### PR TITLE
Add Cave Story.dat

### DIFF
--- a/dat/Cave Story.dat
+++ b/dat/Cave Story.dat
@@ -1,0 +1,18 @@
+clrmamepro (
+	name "Cave Story"
+	description "Cave Story"
+	version 20160108
+	comment "libretro | www.libretro.com"
+)
+
+game (
+	name "Cave Story (English) (1.0.0.6)"
+	description "Cave Story (English) (1.0.0.6)"
+	rom ( name "Doukutsu.exe" size 1478656 crc c5a2a3f6 md5 38695d3d69d7a0ada8178072dad4c58b sha1 bb2d0441e073da9c584f23c2ad8c7ab8aac293bf )
+)
+
+game (
+	name "Cave Story (Japanese) (1.0.0.6)"
+	description "Cave Story (Japanese) (1.0.0.6)"
+	rom ( name "Doukutsu.exe" size 1478656 crc 439ad666 md5 ce3942dbc04635f4b018006f523cd6f4 sha1 4c26357af89971dd1dec9b06e278dfd6722921ed )
+)


### PR DESCRIPTION
This is the beginnings of indexing the executables from Cave Story that are playable through the libretro NXEngine core.

These two were obtained from http://www.cavestory.org/download/cave-story.php . Running the files through `wine Doukutsu.exe` shows that they're both version 1.0.0.6, while libretro looks to use nxengine 1.0.0.4. Would appreciate adding [more translations if needed](http://www.cavestory.org/download/cave-story.php)!