### PR TITLE
Fix NEC - PC Engine SuperGrafx name

### DIFF
--- a/dat/NEC - PC Engine SuperGrafx.dat
+++ b/dat/NEC - PC Engine SuperGrafx.dat
@@ -1,6 +1,6 @@
 clrmamepro (
-	name "NEC - Super Grafx"
-	description "NEC - Super Grafx"
+	name "NEC - PC Engine SuperGrafx"
+	description "NEC - PC Engine SuperGrafx"
 	version 20110307-113453
 	comment "no-intro | www.no-intro.org"
 )


### PR DESCRIPTION
DAT file names must match their info names.