### PR TITLE
Update Nintendo - Nintendo 64.dat

### DIFF
--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -3,18 +3,21 @@ clrmamepro (
 	description "Nintendo - Nintendo 64"
 	version 20151122-045954
 	comment "no-intro | www.no-intro.org"
+	comment "Merged with GoodN64v3.14 for .z64 support."
 )
 
 game (
 	name "007 - GoldenEye (Europe)"
 	description "007 - GoldenEye (Europe)"
 	rom ( name "007 - GoldenEye (Europe).n64" size 12582912 crc 7425AE2D md5 B477CFB12BB946E522B496AF87ADB220 sha1 63627DBA22BE2B357C0E370E68DC5AF56EEB0A24 flags verified )
+	rom ( name "GoldenEye 007 (E) [!].z64" size 12582912 crc 9EC14AEB md5 CFF69B70A8AD674A0EFE5558765855C9 sha1 167C3C433DEC1F1EB921736F7D53FAC8CB45EE31 )
 )
 
 game (
 	name "007 - GoldenEye (Japan)"
 	description "007 - GoldenEye (Japan)"
 	rom ( name "007 - GoldenEye (Japan).n64" size 12582912 crc C26FED78 md5 369BF90B44B050EF74B4759E29D85EE7 sha1 451B41B63D75677BD42DB89A56679208808FCFD0 flags verified )
+	rom ( name "GoldenEye 007 (J) [!].z64" size 12582912 crc A6BE19DD md5 1880DA358F875C0740D4A6731E110109 sha1 2A5DADE32F7FAD6C73C659D2026994632C1B3174 )
 )
 
 game (
@@ -28,6 +31,7 @@ game (
 	name "007 - The World Is Not Enough (Europe) (En,Fr,De)"
 	description "007 - The World Is Not Enough (Europe) (En,Fr,De)"
 	rom ( name "007 - The World Is Not Enough (Europe) (En,Fr,De).n64" size 33554432 crc 7F030D3A md5 7FDC9151F2BD8F6B6F3CBA3BB93A06A2 sha1 441BDF924566E6475AA49BAB7A199DC06D32A6D5 flags verified )
+	rom ( name "007 - The World is Not Enough (E) (M3) [!].z64" size 33554432 crc 002C3B2A md5 34AB1DEA3111A233A8B5C5679DE22E83 sha1 7FDE668850A7E1A8402AB94BB09538A537A7E38B )
 )
 
 game (
@@ -41,12 +45,14 @@ game (
 	name "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De)"
 	description "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De)"
 	rom ( name "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De).n64" size 16777216 crc B0256101 md5 F58B3055A2C642FB2F563F11B6B597EA sha1 DA7BCB78CF78333D7515B77F676FD45473B5B506 flags verified )
+	rom ( name "1080 Snowboarding (E) (M4) [!].z64" size 16777216 crc 75A21679 md5 632C98CF281CDA776E66685B278A4FA6 sha1 637D92B08DBFE7C2F9D5E338835B1FCE5F4A87D0 )
 )
 
 game (
 	name "1080 TenEighty Snowboarding (Japan, USA) (En,Ja)"
 	description "1080 TenEighty Snowboarding (Japan, USA) (En,Ja)"
 	rom ( name "1080 TenEighty Snowboarding (Japan, USA) (En,Ja).n64" size 16777216 crc D1744951 md5 18381C8F37E2B29F5940EEA9B5F96814 sha1 5F837C13A2FB3C8CDFD6FB720BD4A963AB515632 flags verified )
+	rom ( name "1080 Snowboarding (JU) (M2) [!].z64" size 16777216 crc 08FE81C7 md5 FA27089C425DBAB99F19245C5C997613 sha1 79CD1166C365E5809DEC9B62E6D40D6032D5DB3A )
 )
 
 game (
@@ -59,96 +65,112 @@ game (
 	name "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)"
 	description "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)"
 	rom ( name "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).n64" size 12582912 crc C6400938 md5 6463D5006439CD1BBFB2FBDBD062CCEA sha1 538AE3F3354C3FB96926D759E81CF64B827F2782 flags verified )
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!].z64" size 12582912 crc 67A789E5 md5 EA6A92DE5A221A00814F7448BF6F1B31 sha1 35F7E37C62AE36EB29AAD0D9DA0AE83D57F6D8BD )
 )
 
 game (
 	name "64 Hanafuda - Tenshi no Yakusoku (Japan)"
 	description "64 Hanafuda - Tenshi no Yakusoku (Japan)"
 	rom ( name "64 Hanafuda - Tenshi no Yakusoku (Japan).n64" size 8388608 crc 2B43006C md5 F86BE386603A97B805510C4D5C779E02 sha1 17D93494401AEADAD114D8DB66B85E75B714473C flags verified )
+	rom ( name "64 Hanafuda - Tenshi no Yakusoku (J) [!].z64" size 8388608 crc 60A680E7 md5 66335F4DC6AB27034398BC26F263B897 sha1 36D1B4EF15CDA8139FACE7E118CB34727C30BF29 )
 )
 
 game (
 	name "64 Oozumou (Japan)"
 	description "64 Oozumou (Japan)"
 	rom ( name "64 Oozumou (Japan).n64" size 16777216 crc A6DBF8AE md5 73A97768B685B13E4F8449AB1D3B01CE sha1 DA4C60C6054C374A251A7E5E718F199A37946423 flags verified )
+	rom ( name "64 Oozumou (J) [!].z64" size 16777216 crc 742E31FB md5 2CF9EDB51ADA9DE2AE7AD9FD5ACC5580 sha1 E77FE9F2C32870EB7ACBCF6A13D26DD022BAFE5D )
 )
 
 game (
 	name "64 Oozumou 2 (Japan)"
 	description "64 Oozumou 2 (Japan)"
 	rom ( name "64 Oozumou 2 (Japan).n64" size 16777216 crc 3CD5E271 md5 3573F819B8A97453EBB64ABDD67BCD88 sha1 1DAA89EC3F5E63E131973BAB03166E4F7FB60EE9 flags verified )
+	rom ( name "64 Oozumou 2 (J) [!].z64" size 16777216 crc C1BC6FD8 md5 F7C796371E77E0A6FBD02EB866341952 sha1 6D524E0D0DD610DFB0C3BCCAA88EF1E7AECEAB98 )
 )
 
 game (
 	name "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
 	description "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
 	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (Japan).n64" size 12582912 crc 34BBB95D md5 7F197499F8D11D2A1941F77ED3A427A2 sha1 769CB7028262871611ACB8CD5788D477E7F6C12F flags verified )
+	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!].z64" size 12582912 crc DCA7F4EB md5 6B947F654775CF5DACD1E5D53D577DA7 sha1 B5CF2C98D60AD8E6FAD450681F9CEFD63F4E5939 )
 )
 
 game (
 	name "Action Replay Pro 64 (Europe) (v3.0) (Unl)"
 	description "Action Replay Pro 64 (Europe) (v3.0) (Unl)"
 	rom ( name "Action Replay Pro 64 (Europe) (v3.0) (Unl).n64" size 262144 crc C992DFB4 md5 35BA407EA9E4EF7C0ACE8B4F58BEEC41 sha1 D5E4E8C875D6BDA0AFAFB1B2513B16B1CB88DFC1 )
+	rom ( name "Action Replay Pro 64 V3.0 (Unl).z64" size 262144 crc C992DFB4 md5 35BA407EA9E4EF7C0ACE8B4F58BEEC41 sha1 D5E4E8C875D6BDA0AFAFB1B2513B16B1CB88DFC1 )
 )
 
 game (
 	name "Action Replay Pro 64 (Europe) (v3.3) (Unl)"
 	description "Action Replay Pro 64 (Europe) (v3.3) (Unl)"
 	rom ( name "Action Replay Pro 64 (Europe) (v3.3) (Unl).n64" size 262144 crc 9FBABFDA md5 67AFA5DF80A5CFC91FCE1DC918EA0A4F sha1 C3426114F5DA1FB7ABDE15A766D362698AD07166 )
+	rom ( name "Action Replay Pro 64 V3.3 (Unl).z64" size 262144 crc 9FBABFDA md5 67AFA5DF80A5CFC91FCE1DC918EA0A4F sha1 C3426114F5DA1FB7ABDE15A766D362698AD07166 )
 )
 
 game (
 	name "AeroFighters Assault (Europe) (En,Fr,De)"
 	description "AeroFighters Assault (Europe) (En,Fr,De)"
 	rom ( name "AeroFighters Assault (Europe) (En,Fr,De).n64" size 12582912 crc E493E46C md5 35C77035BFF9E20C3EE805CE5583E6B5 sha1 7849993E61D690DECE9C5524CE2831D7B2340F34 flags verified )
+	rom ( name "AeroFighters Assault (E) (M3) [!].z64" size 12582912 crc 6A2B08DA md5 7558E3DA7225712936D3BA3DCE210C36 sha1 F1057A278A06DCFBC7EB8B6B7679AB879255F977 )
 )
 
 game (
 	name "AeroFighters Assault (USA)"
 	description "AeroFighters Assault (USA)"
 	rom ( name "AeroFighters Assault (USA).n64" size 8388608 crc B08EF0B9 md5 ADEE8C02A192470A3FE09418D7EA7AEF sha1 DE542F002E4F08CFDAC19DEC57F5BBAEA6EDEAFE )
+	rom ( name "AeroFighters Assault (U) [!].z64" size 8388608 crc 4370D7E3 md5 79FB6E2452AF077C5EF1DDE5FC810F04 sha1 6742F67D7D2639072E186D240237BE1C662CB25A )
 )
 
 game (
 	name "AeroGauge (Europe) (En,Fr,De)"
 	description "AeroGauge (Europe) (En,Fr,De)"
 	rom ( name "AeroGauge (Europe) (En,Fr,De).n64" size 8388608 crc D8CA6C8E md5 45AA24B9C09F007590CEF795EBB67A94 sha1 1645CCF3C77D41B70BA7F3A6C7155EC819728CF0 flags verified )
+	rom ( name "AeroGauge (E) (M3) [!].z64" size 8388608 crc 040B0046 md5 05056045447BF1FBA8F9878A7F6009F3 sha1 38AADD684AD7662B02BBC29EDDDADE9C9E16A3C0 )
 )
 
 game (
 	name "AeroGauge (Japan) (Demo) (Kiosk)"
 	description "AeroGauge (Japan) (Demo) (Kiosk)"
 	rom ( name "AeroGauge (Japan) (Demo) (Kiosk).n64" size 8388608 crc 4BA2A495 md5 A9E3A990BE71328800426FF716067E7D sha1 E6BB91D367911FDC7E858A7614560FFCE1758AEC flags verified )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [!].z64" size 8388608 crc 6EE3B932 md5 E970AF3DE25BB5AE1154010E26AF776F sha1 0253C33355986DDDA18A7A72B81B91DDC1BED978 )
 )
 
 game (
 	name "AeroGauge (Japan) (Rev A)"
 	description "AeroGauge (Japan) (Rev A)"
 	rom ( name "AeroGauge (Japan) (Rev A).n64" size 8388608 crc 1A5F6C19 md5 D92E3E7B6DD2DAF31D112A12315CB801 sha1 DFB171CAA0091BD36526641D252839C0E72B616C flags verified )
+	rom ( name "AeroGauge (J) (V1.1) [!].z64" size 8388608 crc F322B641 md5 0620C2D134A0430F4AFA208FFEDA67B8 sha1 F7C2D4B0E77CC02DEAFE2E5FD95152B7E8BF86CF )
 )
 
 game (
 	name "AeroGauge (USA)"
 	description "AeroGauge (USA)"
 	rom ( name "AeroGauge (USA).n64" size 8388608 crc 04038CB8 md5 4766856942945EAA9CF521937BE5FEE3 sha1 204DF59CBD065E39CADCCC23A68E08AE212546D0 )
+	rom ( name "AeroGauge (U) [!].z64" size 8388608 crc 198B9E0E md5 72C7FFCEA6C1430616867616F5E9D51A sha1 77626171C35FB1A4DFEBB0927280897F362225ED )
 )
 
 game (
 	name "AI Shougi 3 (Japan)"
 	description "AI Shougi 3 (Japan)"
 	rom ( name "AI Shougi 3 (Japan).n64" size 8388608 crc 43022243 md5 9B469746EB02588F9A2273A6BDEC33C9 sha1 0ACF1F83BA14DBE2EDBAE454EEA04CAF2CC0030A flags verified )
+	rom ( name "AI Shougi 3 (J) [!].z64" size 8388608 crc 86DF90E6 md5 4A5C509A20DB7A429DC1DD4E219AD4A2 sha1 8D87D888E8916C4C148DAD32EE0519DD297D1FA6 )
 )
 
 game (
 	name "Aidyn Chronicles - The First Mage (Europe)"
 	description "Aidyn Chronicles - The First Mage (Europe)"
 	rom ( name "Aidyn Chronicles - The First Mage (Europe).n64" size 33554432 crc 9DC07FC0 md5 13B3B8AC219F8A57783BC1779DF02901 sha1 DD8867A3B33C897FA9E7E1742C4BC0DF1207CFA8 flags verified )
+	rom ( name "Aidyn Chronicles - The First Mage (E) [!].z64" size 33554432 crc BE7E230D md5 54D0A39123C15F74AABB1ECC24D4D6A0 sha1 E3A1E26F4C10A6767612D1A8462689E86D09DC0B )
 )
 
 game (
 	name "Aidyn Chronicles - The First Mage (USA)"
 	description "Aidyn Chronicles - The First Mage (USA)"
 	rom ( name "Aidyn Chronicles - The First Mage (USA).n64" size 33554432 crc 8DA62304 md5 08D66E903C0DC4EB9736B0DD853FAB51 sha1 32EF42E143B74CB957A88DDB9249AF13B15B45E7 )
+	rom ( name "Aidyn Chronicles - The First Mage (U) [!].z64" size 33554432 crc B1F18186 md5 AF149336B3DDB899598E7BE8740D7DC6 sha1 47AE795A2B12783A13E2B8D03439CE9A39FC826C )
 )
 
 game (
@@ -161,174 +183,204 @@ game (
 	name "Air Boarder 64 (Europe)"
 	description "Air Boarder 64 (Europe)"
 	rom ( name "Air Boarder 64 (Europe).n64" size 8388608 crc 92659837 md5 2B257F7989946666032DF995273746FE sha1 E0A148AE2193E533947F52BA4AB029C2CD8B34D3 flags verified )
+	rom ( name "Airboarder 64 (E) [!].z64" size 8388608 crc C14D45AC md5 E8891F8F498A615A6CBAF75B7DDC9FA6 sha1 2171FE2C0A9253CBA56828F24A5E6153726C1516 )
 )
 
 game (
 	name "Air Boarder 64 (Japan)"
 	description "Air Boarder 64 (Japan)"
 	rom ( name "Air Boarder 64 (Japan).n64" size 8388608 crc 79F2DF14 md5 EAD11D91FA8975AE8C3D2EFEB227297A sha1 0CE4D812125F7C153795BBE3835CDA6C29105724 flags verified )
+	rom ( name "Airboarder 64 (J) [!].z64" size 8388608 crc 58FCB771 md5 CCEE2FCF38DC2200128D75D15DB53283 sha1 4A70C9CA027ECC8D05337993204E1EF76F5F0AC9 )
 )
 
 game (
 	name "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)"
 	description "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)"
 	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).n64" size 12582912 crc CA79D5A0 md5 20971504B49F98AD0CC15C666EE1E30F sha1 78629A527B6EC02825487E3C800AA81178768039 flags verified )
+	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!].z64" size 12582912 crc E349CFEC md5 256A1CB23F9E1A2762A7A171417B5D68 sha1 AA70348968589E6BA6E7091CA115FB505099CD97 )
 )
 
 game (
 	name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)"
 	description "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)"
 	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).n64" size 16777216 crc 420CE37B md5 7CB2782769F9B834B5948D316EF83CD6 sha1 10B15A7CEB6D56720DDD7755DAC6102832407110 flags verified )
+	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!].z64" size 16777216 crc FF009C21 md5 47EA239717C4D225C9D0E9FD37B9FCB3 sha1 50439ACB5784BEA3A4BBBA5188C2AEAA1442099D )
 )
 
 game (
 	name "All Star Tennis '99 (Europe) (En,Fr,De,Es,It)"
 	description "All Star Tennis '99 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "All Star Tennis '99 (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc E718347D md5 E302824280FA6AF35FCC9BA079ABFBCD sha1 85D2B8DED8D2A6D9BBF1CF80C9A0422FB338FD63 flags verified )
+	rom ( name "All Star Tennis '99 (E) (M5) [!].z64" size 8388608 crc 996E845F md5 E3F4C868917A12BD5E84D94D1C260C7D sha1 09DDBD45F4962735DEF65399B5792E3BB5BD7D3C )
 )
 
 game (
 	name "All Star Tennis 99 (USA)"
 	description "All Star Tennis 99 (USA)"
 	rom ( name "All Star Tennis 99 (USA).n64" size 8388608 crc 7326E6C9 md5 1714F404F1AD75EC85D237E8D4D2362C sha1 2655AF06374C3CA9F8A40A76F7F9FC6E1044B576 )
+	rom ( name "All Star Tennis '99 (U) [!].z64" size 8388608 crc A7DCF638 md5 AFC3DC9BB737D81903F6CE4875B63AE9 sha1 3A6446409D63DCAC0D5C860A3E2888A378474887 )
 )
 
 game (
 	name "All-Star Baseball 2000 (Europe)"
 	description "All-Star Baseball 2000 (Europe)"
 	rom ( name "All-Star Baseball 2000 (Europe).n64" size 16777216 crc 15F18CAE md5 CBD9E7E9BA8204029B52B972836668AC sha1 EFF8CE1B3EFD9C0ADA98838715C10633F0E6F4F9 flags verified )
+	rom ( name "All-Star Baseball 2000 (E) [!].z64" size 16777216 crc D3C29AA4 md5 90448C4175EE9D0247674474DCABDFED sha1 C8F41A27B9509DA422B7ECF32F64DF3E213194EA )
 )
 
 game (
 	name "All-Star Baseball 2000 (USA)"
 	description "All-Star Baseball 2000 (USA)"
 	rom ( name "All-Star Baseball 2000 (USA).n64" size 16777216 crc 15063EAC md5 984528194CA782D74A92CB8C0EA42358 sha1 C0D574AF5C3523A4A804182B4D6465212FD9EE29 )
+	rom ( name "All-Star Baseball 2000 (U) [!].z64" size 16777216 crc 69E88471 md5 AADA358CE97F06C4DF5BF55987268844 sha1 4256A23902E22E6E8291F1931F8DE4B2716FE480 )
 )
 
 game (
 	name "All-Star Baseball 2001 (USA)"
 	description "All-Star Baseball 2001 (USA)"
 	rom ( name "All-Star Baseball 2001 (USA).n64" size 16777216 crc 3E8BE0E0 md5 D00D67475255A3043394C23B7CF978A3 sha1 353AD679666287988A0E645851EE01EFF2048449 )
+	rom ( name "All-Star Baseball 2001 (U) [!].z64" size 16777216 crc 4D659E85 md5 6E01B8D425AE74EF5A0F875C700A3B18 sha1 4F1B8635322190BB3D0C6FC7D3BA844941F05574 )
 )
 
 game (
 	name "All-Star Baseball 99 (Europe)"
 	description "All-Star Baseball 99 (Europe)"
 	rom ( name "All-Star Baseball 99 (Europe).n64" size 12582912 crc CECD29A6 md5 D6A5D897FEC2605E3366615CAEF19EB2 sha1 47272C40A13E42E6400C6E1221173F6BD07205BD flags verified )
+	rom ( name "All-Star Baseball '99 (E) [!].z64" size 12582912 crc D0DE3584 md5 ED5F1E12DA36DBEC8A0A24ED98D4AED5 sha1 3AC0D13F2260797DABF99CFEDABF7E3676C5B2E2 )
 )
 
 game (
 	name "All-Star Baseball 99 (USA)"
 	description "All-Star Baseball 99 (USA)"
 	rom ( name "All-Star Baseball 99 (USA).n64" size 12582912 crc 82B7E47D md5 9B9631FD0CD2B7C434057902B78E5A03 sha1 6D01A4986311A4486B4B0BE029658E8DF63F4EE4 )
+	rom ( name "All-Star Baseball '99 (U) [!].z64" size 12582912 crc 6D25B36F md5 78551D23F230B58B9F449CDB4A285761 sha1 AA576624F2A66034CB0D6E621BA16A0D3BEACA3A )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (Europe)"
 	description "Armorines - Project S.W.A.R.M. (Europe)"
 	rom ( name "Armorines - Project S.W.A.R.M. (Europe).n64" size 16777216 crc 33332C57 md5 3F2A78A8E70C6392B73DD2491DB2B6E4 sha1 38E0CAFCBECDDD2F2CF46F1CDBB0BE6F8582402F flags verified )
+	rom ( name "Armorines - Project S.W.A.R.M. (E) [!].z64" size 16777216 crc 600BC49E md5 0C2CBAFEC6F184AD39EF29B2B5E0F44A sha1 66F2B431D2275B2563692BFD053D4C0118E0E0C2 )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (Germany)"
 	description "Armorines - Project S.W.A.R.M. (Germany)"
 	rom ( name "Armorines - Project S.W.A.R.M. (Germany).n64" size 16777216 crc 43A6829D md5 E159DA0F67964F136E793872B79956D3 sha1 3479266909BCBFA928F67E967BDAE789C20895E1 )
+	rom ( name "Armorines - Project S.W.A.R.M. (G) [!].z64" size 16777216 crc 5BAB9100 md5 2BC48B3E6F61896B9BC7BEF5205CC49C sha1 68F9DDA2863F7625A36F115419956DD9F249AFE6 )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (USA)"
 	description "Armorines - Project S.W.A.R.M. (USA)"
 	rom ( name "Armorines - Project S.W.A.R.M. (USA).n64" size 16777216 crc 950985F6 md5 1655F81B5987234481EA96BB9E964D38 sha1 A9C1319C582668B9AFC7807DCD59F68D09B5317E )
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [!].z64" size 16777216 crc 630A19E2 md5 6E6E7A703C131ADADDF4175E9037A2EB sha1 D9F55ACF77A54EEB7F62577AA5711769EBEADDE3 )
+	
 )
 
 game (
 	name "Army Men - Air Combat (USA)"
 	description "Army Men - Air Combat (USA)"
 	rom ( name "Army Men - Air Combat (USA).n64" size 8388608 crc 2355E4F3 md5 7E57B116C3D0740B7B8F873BD007F4DC sha1 52F4722CBF3DED8E55A62471FBC5A6CF07F4FD5D )
+	rom ( name "Army Men - Air Combat (U) [!].z64" size 8388608 crc 1952CC87 md5 755DF7F57EDF87706D4C80FF15883312 sha1 EB9BACB12EB6665BE9936A3E1DFD6D57B2EAABDB )
 )
 
 game (
 	name "Army Men - Sarge's Heroes (Europe) (En,Fr,De)"
 	description "Army Men - Sarge's Heroes (Europe) (En,Fr,De)"
 	rom ( name "Army Men - Sarge's Heroes (Europe) (En,Fr,De).n64" size 8388608 crc B2B54CC1 md5 06B9E71B0ACC83F8C75BEFD2EC602B52 sha1 C6470921EA8B5D3565383D94E98B6FF8B39F7C14 flags verified )
+	rom ( name "Army Men - Sarge's Heroes (E) (M3) [!].z64" size 8388608 crc E79048E2 md5 53E2872612760133AB7B2CC2E22B847C sha1 00E594FA64DA61C2AD3138A31A22B9854BB3FAFA )
 )
 
 game (
 	name "Army Men - Sarge's Heroes (USA)"
 	description "Army Men - Sarge's Heroes (USA)"
 	rom ( name "Army Men - Sarge's Heroes (USA).n64" size 8388608 crc 97BF6DB2 md5 7C4EA4747805499059AAD17C209A6E77 sha1 82F8D41D16C9161FF21776A8B2531CB11857F410 )
+	rom ( name "Army Men - Sarge's Heroes (U) [!].z64" size 8388608 crc 2FE786F6 md5 B8085C2EDB1C6D23E52ED8C06D92B4F8 sha1 1824380911579424E50042D45AEF4851F7AB25A7 )
 )
 
 game (
 	name "Army Men - Sarge's Heroes 2 (USA)"
 	description "Army Men - Sarge's Heroes 2 (USA)"
 	rom ( name "Army Men - Sarge's Heroes 2 (USA).n64" size 8388608 crc 3E9D1C51 md5 F85EC17F51F076D9D0F315EDAE6C192B sha1 FF1A799C6C0AEC45EFA7E0F8D107D91E1BBA5EEA )
+	rom ( name "Army Men - Sarge's Heroes 2 (U) [!].z64" size 8388608 crc 79A71608 md5 6EEA5C4A6256092ED8F9BA8861C689C6 sha1 F32B6DE2F87928378F26CA17B68B27D87FDEFCE1 )
 )
 
 game (
 	name "Asteroids Hyper 64 (USA)"
 	description "Asteroids Hyper 64 (USA)"
 	rom ( name "Asteroids Hyper 64 (USA).n64" size 4194304 crc FB982B44 md5 257601175E6C41604BD5B9AB93A3EC75 sha1 6E1C4AF8F765DEE69B5308EC5A0B20BC7FB8D862 )
+	rom ( name "Asteroids Hyper 64 (U) [!].z64" size 4194304 crc F5CE3D91 md5 874C7B7B365D2C20AAA1A0C90C93F9B8 sha1 329F4D560B0BA7DA622EDD9B84523E86E265FFFE )
 )
 
 game (
 	name "Automobili Lamborghini (Europe)"
 	description "Automobili Lamborghini (Europe)"
 	rom ( name "Automobili Lamborghini (Europe).n64" size 4194304 crc 210F594E md5 874C42768C21E33A2E83305AD70120F1 sha1 3B03236C455C2FBFE76E13F0F44EFB502B30ACEA flags verified )
+	rom ( name "Automobili Lamborghini (E) [!].z64" size 4194304 crc 3BAF58D5 md5 7853F02DC66A35BC8C2BC33D03B8F0CA sha1 513C9511539BF2361FF20EE1F19DC03F618B5214 )
 )
 
 game (
 	name "Automobili Lamborghini (USA)"
 	description "Automobili Lamborghini (USA)"
 	rom ( name "Automobili Lamborghini (USA).n64" size 4194304 crc 17932C62 md5 77C7E53A78C68EB1C254D17383DD7293 sha1 022CDE34610AF501687BAF6B33B76F9B6841044B )
+	rom ( name "Automobili Lamborghini (U) [!].z64" size 4194304 crc A4374EAC md5 EC39579F066A9714FF030D07DEC3C9D3 sha1 78B36B48040426478011CAEF5E11884AF2E80375 )
 )
 
 game (
 	name "Baku Bomber Man (Japan)"
 	description "Baku Bomber Man (Japan)"
 	rom ( name "Baku Bomber Man (Japan).n64" size 8388608 crc B9FAA3E4 md5 59174C50BC837A9C2C4BABC05193FC28 sha1 57B5B49E61AFB44A368820997706C752545C677F flags verified )
+	rom ( name "Baku Bomberman (J) [!].z64" size 8388608 crc 22F54A52 md5 8183688A4B7D0A390496B5655BCD252E sha1 4813B147D552F72FDB0B306469BF9AA0F820FD5B )
 )
 
 game (
 	name "Baku Bomber Man 2 (Japan)"
 	description "Baku Bomber Man 2 (Japan)"
 	rom ( name "Baku Bomber Man 2 (Japan).n64" size 16777216 crc 850675CC md5 89C5450B3286CE62A6D93FEA74633848 sha1 C6188F3217E28CF820040B6FB1F57DB655995B38 flags verified )
+	rom ( name "Baku Bomberman 2 (J) [!].z64" size 16777216 crc 86BBC278 md5 CA956015B6820DCFF1C814F3532E18B1 sha1 179CAB7426755F14BD3F4999F3789EB6D7AF64C4 )
 )
 
 game (
 	name "Bakuretsu Muteki Bangaioh (Japan)"
 	description "Bakuretsu Muteki Bangaioh (Japan)"
 	rom ( name "Bakuretsu Muteki Bangaioh (Japan).n64" size 12582912 crc 2A8CE2E1 md5 EAED8A95D38B6D962C0440EDCD46A849 sha1 38C6653A0C4E45F25F33C97CCD2A7F5AF0B57784 flags verified )
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [!].z64" size 12582912 crc 6AB7FEC6 md5 8107825AC2A522057422463ED81E276B sha1 2DBFE78F97B8D6E1A33B73D244BE831D18B0491E )
 )
 
 game (
 	name "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)"
 	description "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)"
 	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).n64" size 12582912 crc 5FD42464 md5 925FD223A6284F0CDFDE458E88BFC603 sha1 353B62279F67634030CC66F43C4B82E516A6AF28 flags verified )
+	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!].z64" size 12582912 crc EF8C2F34 md5 09FD63AFA1156405E618752FC583DF93 sha1 28E6D11F6F48C86A9B7C112C672109E1C2D7E5D0 )
 )
 
 game (
 	name "Banjo to Kazooie no Daibouken (Japan)"
 	description "Banjo to Kazooie no Daibouken (Japan)"
 	rom ( name "Banjo to Kazooie no Daibouken (Japan).n64" size 16777216 crc 11AD432C md5 6846FD87C7CE9063A4F25CD6A253C309 sha1 9379962839A6638F8DDCFB7D917216EC40A83EDB flags verified )
+	rom ( name "Banjo to Kazooie no Daibouken (J) [!].z64" size 16777216 crc 8F7C9324 md5 3D3855A86FD5A1B4D30BEB0F5A4A85AF sha1 90726D7E7CD5BF6CDFD38F45C9ACBF4D45BD9FD8 )
 )
 
 game (
 	name "Banjo to Kazooie no Daibouken 2 (Japan)"
 	description "Banjo to Kazooie no Daibouken 2 (Japan)"
 	rom ( name "Banjo to Kazooie no Daibouken 2 (Japan).n64" size 33554432 crc 8A3D8792 md5 085405CFDF2CBA66BAF21AD07C73CDD6 sha1 A6C8D06AA6462C1479639786EDA455CD60FF6AA3 flags verified )
+	rom ( name "Banjo to Kazooie no Daibouken 2 (J) [!].z64" size 33554432 crc 258C58D0 md5 715A8816F30FA24B8D174DC5CB6F25A9 sha1 5A5172383037D171F121790959962703BE1F373C )
 )
 
 game (
 	name "Banjo-Kazooie (Europe) (En,Fr,De)"
 	description "Banjo-Kazooie (Europe) (En,Fr,De)"
 	rom ( name "Banjo-Kazooie (Europe) (En,Fr,De).n64" size 16777216 crc 4AF7C16B md5 CEECE9F299B2870C9A0D545018F1C43F sha1 908469A0B4F4B7473E85D3C981520F32CF3E3C70 flags verified )
+	rom ( name "Banjo-Kazooie (E) (M3) [!].z64" size 16777216 crc 525899C9 md5 06A43BACF5C0687F596DF9B018CA6D7F sha1 BB359A75941DF74BF7290212C89FBC6E2C5601FE )
 )
 
 game (
 	name "Banjo-Kazooie (USA)"
 	description "Banjo-Kazooie (USA)"
 	rom ( name "Banjo-Kazooie (USA).n64" size 16777216 crc 4FD43199 md5 81E326E2ABBD65EC4C4C20F4364F7E48 sha1 0CA5E28494B7D99E22ED27DFC914EC5B391CDB6B flags verified )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [!].z64" size 16777216 crc AD429961 md5 B29599651A13F681C9923D69354BF4A3 sha1 1FE1632098865F639E22C11B9A81EE8F29C75D7A )
 )
 
 game (
@@ -342,12 +394,14 @@ game (
 	name "Banjo-Tooie (Australia)"
 	description "Banjo-Tooie (Australia)"
 	rom ( name "Banjo-Tooie (Australia).n64" size 33554432 crc 38EC4A6E md5 B943623A53F427B53C48316E722ED2E1 sha1 F3C391F7D04F9CBCDDAC1CF03B7B6C78D844F7B0 flags verified )
+	rom ( name "Banjo-Tooie (A) [!].z64" size 33554432 crc 2736266A md5 61B5C5C3E5E1A81E5D37072C01B39B76 sha1 4CA2D332F6E6B018777AFC6A8B7880B38B6DFB79 )
 )
 
 game (
 	name "Banjo-Tooie (Europe) (En,Fr,De,Es)"
 	description "Banjo-Tooie (Europe) (En,Fr,De,Es)"
 	rom ( name "Banjo-Tooie (Europe) (En,Fr,De,Es).n64" size 33554432 crc 5EE620FB md5 3A585EF93B327D47CB0095EEA98D766A sha1 1E2CA48F786983C487A8D0E17C496FCCF5411DFE flags verified )
+	rom ( name "Banjo-Tooie (E) (M4) [!].z64" size 33554432 crc 1EC12F5A md5 8B2E56F18421A67BCA861427453A1E19 sha1 93BF2FAC1387320AD07251CB4B64FD36BAC1D7A6 )
 )
 
 game (
@@ -361,12 +415,14 @@ game (
 	name "Bass Rush - ECOGEAR PowerWorm Championship (Japan)"
 	description "Bass Rush - ECOGEAR PowerWorm Championship (Japan)"
 	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (Japan).n64" size 33554432 crc 0E388FAE md5 B7939B2EA15C92EDB33971FDBE236D6C sha1 06D9DA5DFD1E16ED56FC2BD028FA3642B4905820 flags verified )
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!].z64" size 33554432 crc 383B86EF md5 2C618F6C69C3B4803F08762A03835139 sha1 1718C9048CB7849A59D48138A058B20BF191EBF6 )
 )
 
 game (
 	name "Bassmasters 2000 (USA)"
 	description "Bassmasters 2000 (USA)"
 	rom ( name "Bassmasters 2000 (USA).n64" size 12582912 crc 8B7BD07E md5 F4AC3AF45A448B9F0D5D38AF14A285B9 sha1 747B3B6C49F27E3381D91E9DF59D01DBEE769A58 )
+	rom ( name "Bassmasters 2000 (U) [!].z64" size 12582912 crc 6B09092E md5 930C7F6E5863471DDE1816D28A10EB88 sha1 946B3E08A1A4DE4F917AD547BB24F533B737F712 )
 )
 
 game (
@@ -380,6 +436,7 @@ game (
 	name "Batman of the Future - Return of the Joker (Europe) (En,Fr,De)"
 	description "Batman of the Future - Return of the Joker (Europe) (En,Fr,De)"
 	rom ( name "Batman of the Future - Return of the Joker (Europe) (En,Fr,De).n64" size 4194304 crc 86AA921C md5 7AD96BE5F289276B6A9D7163B19D2BC4 sha1 16977E84FDA45BBDE7882A73A9685426FD4B458C flags verified )
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [!].z64" size 4194304 crc 82A4BB8A md5 A5EE8A6C34863E3D0EB8C06AE8668B30 sha1 3954131395F98E605072BEA11CC85842DA58F754 )
 )
 
 game (
@@ -393,6 +450,7 @@ game (
 	name "BattleTanx - Global Assault (Europe) (En,Fr,De)"
 	description "BattleTanx - Global Assault (Europe) (En,Fr,De)"
 	rom ( name "BattleTanx - Global Assault (Europe) (En,Fr,De).n64" size 8388608 crc EC02C5AD md5 2589AE458EBFC86100DC039CD0854CFA sha1 EC346910B30E5C5C91CF4394633D226EA604BB57 flags verified )
+	rom ( name "BattleTanx - Global Assault (E) (M3) [!].z64" size 8388608 crc C99C6030 md5 D6E667FE10AFE8F7116888EFDE98AE0E sha1 AEFADE7A37A4716DDC82A6B67BA085CBF7C27259 )
 )
 
 game (
@@ -406,60 +464,70 @@ game (
 	name "Battlezone - Rise of the Black Dogs (USA)"
 	description "Battlezone - Rise of the Black Dogs (USA)"
 	rom ( name "Battlezone - Rise of the Black Dogs (USA).n64" size 16777216 crc 18CCCCFD md5 69CC951520CCEE8C99F28E086BA6BAAA sha1 CDD1D1DEC9763CE6B7B1A70668EFFCEAD0A185A0 )
+	rom ( name "Battlezone - Rise of the Black Dogs (U) [!].z64" size 16777216 crc 736F9D5C md5 266C0989ED0929DF499389954779EA97 sha1 85B4FEBBE6FBD1ECFC883905E43E68E7188C44F9 )
 )
 
 game (
 	name "Beetle Adventure Racing! (Europe) (En,Fr,De)"
 	description "Beetle Adventure Racing! (Europe) (En,Fr,De)"
 	rom ( name "Beetle Adventure Racing! (Europe) (En,Fr,De).n64" size 16777216 crc E6F43F48 md5 939BDAF220EDDCEFC8BE78A5B3B98744 sha1 B185ED71668F9BD4F6AEEF5EDB31E03C1A119AE0 flags verified )
+	rom ( name "Beetle Adventure Racing! (E) (M3) [!].z64" size 16777216 crc 5B6C6E4C md5 A94135D163E6091C960ADC918C1FB8A7 sha1 85B3B95D587D2646F781B04CF5239804D105685A )
 )
 
 game (
 	name "Beetle Adventure Racing! (Japan)"
 	description "Beetle Adventure Racing! (Japan)"
 	rom ( name "Beetle Adventure Racing! (Japan).n64" size 16777216 crc 4246ACD8 md5 B0C2A92CB944332571EC482F2010D470 sha1 196B70D4FD0BD361BAABAEE9719A5A3AA5A7F48F flags verified )
+	rom ( name "Beetle Adventure Racing! (J) [!].z64" size 16777216 crc 49E75825 md5 5FFD43089B7334072B2B74421618D973 sha1 D6E943A8733D3C09795F4BE24B75C7FB0C30A27D )
 )
 
 game (
 	name "Beetle Adventure Racing! (USA) (En,Fr,De)"
 	description "Beetle Adventure Racing! (USA) (En,Fr,De)"
 	rom ( name "Beetle Adventure Racing! (USA) (En,Fr,De).n64" size 16777216 crc E3517FD8 md5 5559A7AAE79E960851CE754F873280CB sha1 52171429B655825A02864A94499816187D4014DC )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [!].z64" size 16777216 crc F4A97C73 md5 CF97C336479DDBF1217E4DDE89D9D2D3 sha1 E5AB4D226C08D22F68A2EDCC48870203E67454B8 )
 )
 
 game (
 	name "Big Mountain 2000 (USA)"
 	description "Big Mountain 2000 (USA)"
 	rom ( name "Big Mountain 2000 (USA).n64" size 12582912 crc FF44020C md5 E0B3354C7205DB2D67C1FA23462F6326 sha1 CDC88D4FFA5883D34FFC426C552DF200C4C65023 )
+	rom ( name "Big Mountain 2000 (U) [!].z64" size 12582912 crc 3AC924BC md5 BF6780E2982C16D4A4FDB553BE8F9226 sha1 E28F3EBFB7BC706CCE639FC1874243E1D4995D1D )
 )
 
 game (
 	name "Bio F.R.E.A.K.S. (Europe)"
 	description "Bio F.R.E.A.K.S. (Europe)"
 	rom ( name "Bio F.R.E.A.K.S. (Europe).n64" size 16777216 crc 3EC67AD8 md5 58C15C1E507950273AE926F350C9292C sha1 EF5546F288B39CA628907C05F8CBAADA9E895026 flags verified )
+	rom ( name "Bio F.R.E.A.K.S. (E) [!].z64" size 16777216 crc 2C4EB906 md5 42672BA5E98CD21D7F3E3745E69038DD sha1 8A85EC7D68954A36569F28F6A26981D6F283FD6D )
 )
 
 game (
 	name "Bio F.R.E.A.K.S. (USA)"
 	description "Bio F.R.E.A.K.S. (USA)"
 	rom ( name "Bio F.R.E.A.K.S. (USA).n64" size 16777216 crc 52283865 md5 8B112F230A6E1E185F10F9574D676EF8 sha1 7D0A70C4437FE985AAF4FAF82CA1DC011B8ED4E1 )
+	rom ( name "Bio F.R.E.A.K.S. (U) [!].z64" size 16777216 crc DFBF448C md5 B90AB8F7605D971CC7A6D9BA5E67D1AF sha1 E20E9124480B559AA7148412C8993804501E180D )
 )
 
 game (
 	name "Biohazard 2 (Japan)"
 	description "Biohazard 2 (Japan)"
 	rom ( name "Biohazard 2 (Japan).n64" size 67108864 crc 31A3B913 md5 13B6F12B9F8CB0CB8C708C3132F7A372 sha1 8651451A9363DA0B6783DEE6BB99EB077B318BD5 flags verified )
+	rom ( name "Biohazard 2 (J) [!].z64" size 67108864 crc 4F9D569F md5 F77D70959222276491222F31EBFF3BF1 sha1 7492139F237C547EF32955C7CC6B9A5E6DCAA55D )
 )
 
 game (
 	name "Blast Corps (Europe) (En,De)"
 	description "Blast Corps (Europe) (En,De)"
 	rom ( name "Blast Corps (Europe) (En,De).n64" size 8388608 crc 2FF810CF md5 BD819802309E8E65CCC9F8EAB8361223 sha1 9D42BE8A947E64D4862D8A7C1FAE57E10C2257EE flags verified )
+	rom ( name "Blast Corps (E) (M2) [!].z64" size 8388608 crc 4C820695 MD5 889D4D337AD11CE94357511C725EAB6A SHA1 460212600F8B9F0DA95219C4C7330F2E626D9A7E )
 )
 
 game (
 	name "Blast Corps (USA)"
 	description "Blast Corps (USA)"
 	rom ( name "Blast Corps (USA).n64" size 8388608 crc 22CA221D md5 E579AA236D12725597DD4ED8C3E9350B sha1 A6AD7FFF57B10B782CEDE51D4558E19AD134F019 )
+	rom ( name "Blast Corps (U) (V1.0) [!].z64" size 8388608 crc 767A95E7 md5 A8DFDFF49144627492DA9B0B65B91845 sha1 185A6EF7BA1ADB243278062C81A7D4E119BDA58C )
 )
 
 game (
@@ -473,24 +541,28 @@ game (
 	name "Blastdozer (Japan)"
 	description "Blastdozer (Japan)"
 	rom ( name "Blastdozer (Japan).n64" size 8388608 crc 4605759E md5 1691A0124A175F45954CC70C7DD98297 sha1 68C6D95AF29C647B64D5DAD90C02980B772D5FAF flags verified )
+	rom ( name "Blast Dozer (J) [!].z64" size 8388608 crc 081A3641 md5 16B82D53D7F038A8FE67A78027720516 sha1 B147FDBEB661C89107C440B00DC4810508F58636 )
 )
 
 game (
 	name "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 56507793 md5 37D5409EBB172E00CEFAA8B1F14C39B2 sha1 A3E21EC8BF3DE87D257F254AB68879981EAED4A9 flags verified )
+	rom ( name "Blues Brothers 2000 (E) (M6) [!].z64" size 16777216 crc 8FB41658 md5 31B4A8ED52B48E756B344C9F22736E50 sha1 D641AFCA71A7D83587F9D7105D5E6DFFDEAA8016 )
 )
 
 game (
 	name "Blues Brothers 2000 (USA)"
 	description "Blues Brothers 2000 (USA)"
 	rom ( name "Blues Brothers 2000 (USA).n64" size 16777216 crc 109907B5 md5 D7F17E918AB32F64A67409DC86D89C5C sha1 62655484F77091F31FB6A8142AF90AE58489E0E2 )
+	rom ( name "Blues Brothers 2000 (U) [!].z64" size 16777216 crc C6F49764 md5 997FD8F79CD6F3CD1C1C1FD21E358717 sha1 ED0FE7C9A2E8015BDF8262D35065F53C6FCEA60F )
 )
 
 game (
 	name "Body Harvest (Europe) (En,Fr,De)"
 	description "Body Harvest (Europe) (En,Fr,De)"
 	rom ( name "Body Harvest (Europe) (En,Fr,De).n64" size 12582912 crc 2761BDAE md5 1F065DB3BAA31487DE47DEFE56DCD374 sha1 C366CEC6DFE3B724648486F0940D9A2C091C5E14 flags verified )
+	rom ( name "Body Harvest (E) (M3) [!].z64" size 12582912 crc 6A04CDAE md5 B27FA5E9AD0CB47BB3A74FFAC7BC8EDF sha1 67750E2E7AB46FEDF65A271AB7F4C7AAD92AE355 )
 )
 
 game (
@@ -504,6 +576,7 @@ game (
 	name "Bokujou Monogatari 2 (Japan)"
 	description "Bokujou Monogatari 2 (Japan)"
 	rom ( name "Bokujou Monogatari 2 (Japan).n64" size 16777216 crc 0837B349 md5 A6E56E36E311994103A362CA5E5478B9 sha1 E12E5F2FCE0F27C52BE2C7454B21D9B538EA2EE5 flags verified )
+	rom ( name "Bokujou Monogatari 2 (J) [!].z64" size 16777216 crc F97237C7 md5 1CF31E7F6E0DEB2C18C39DDD4EED9E51 sha1 E41D15C394B5FEFD4016ADD3883A794C48E7E232 )
 )
 
 game (
@@ -522,18 +595,21 @@ game (
 	name "Bomber Man 64 (Japan)"
 	description "Bomber Man 64 (Japan)"
 	rom ( name "Bomber Man 64 (Japan).n64" size 12582912 crc 7C532342 md5 F3B1BDE174B0203857DB24416ED112BE sha1 161639FD706DD2637FED2A14CCEE73138E82FB2D flags verified )
+	rom ( name "Bomberman 64 - Arcade Edition (J).z64" size 12582912 crc 7E74EEDC md5 08E491F87445C6E5C168D982FC665D5F sha1 1F2E0598730A2F7EA1987603E505AF45879E194A )
 )
 
 game (
 	name "Bomber Man Hero - Mirian Oujo o Sukue! (Japan)"
 	description "Bomber Man Hero - Mirian Oujo o Sukue! (Japan)"
 	rom ( name "Bomber Man Hero - Mirian Oujo o Sukue! (Japan).n64" size 12582912 crc F3A50116 md5 E44F4D5DADD25568C906CC51BFD4D5BF sha1 C143FCA315277496E0558C93701494A225BA4A37 flags verified )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!].z64" size 12582912 crc 69CEABCC md5 EE273763C7391458865FF26C7EA0C3F1 sha1 AE3F4F7C31DDBD14843D9BEB932FC5AA21746211 )
 )
 
 game (
 	name "Bomberman 64 (Europe)"
 	description "Bomberman 64 (Europe)"
 	rom ( name "Bomberman 64 (Europe).n64" size 8388608 crc D3657C19 md5 8BA9C0C53A390C55C10B76B61ECFA696 sha1 2338FB84AA8C0A4A67E98C52DA2FC7059C570509 flags verified )
+	rom ( name "Bomberman 64 (E) [!].z64" size 8388608 crc 525339C5 md5 B68F49AA8F6F7499184AC6B7B8570F2B sha1 01E50F41733994BF229BEE3B3D8AA9FD46441175 )
 )
 
 game (
@@ -554,6 +630,7 @@ game (
 	name "Bomberman Hero (Europe)"
 	description "Bomberman Hero (Europe)"
 	rom ( name "Bomberman Hero (Europe).n64" size 12582912 crc 28DAD01B md5 EFEFAF4D6DF695651FDA796C9AE8A440 sha1 68CEFA50957D6B6F2E7126851C6A3BDEC8E3AD83 flags verified )
+	rom ( name "Bomberman Hero (E) [!].z64" size 12582912 crc 59E39947 md5 F79EF0813157880FFBAD6199E07579BE sha1 BA1E6A4CC323A83D7C14573C9128AB9F9B60E5F2 )
 )
 
 game (
@@ -567,54 +644,63 @@ game (
 	name "Bottom of the 9th (USA)"
 	description "Bottom of the 9th (USA)"
 	rom ( name "Bottom of the 9th (USA).n64" size 16777216 crc 0F016E17 md5 9746E155104F336FACB6BA7789F0A3D0 sha1 A4D2E5AFC511631D1CC5D8AF6C4C705F17EA8ED6 )
+	rom ( name "Bottom of the 9th (U) [!].z64" size 16777216 crc 1844C8CA md5 FB19AFD5E8C49978E6E6AE3622E0498A sha1 4EE0E3768B9F23112E4E5EF0C81A2B29AE22EAB2 )
 )
 
 game (
 	name "Brunswick Circuit Pro Bowling (USA)"
 	description "Brunswick Circuit Pro Bowling (USA)"
 	rom ( name "Brunswick Circuit Pro Bowling (USA).n64" size 8388608 crc 3AC1BBAE md5 DB929D47127EA55BB919F8C7623E0256 sha1 578BEF71585B2CC956A6847C682B123599BE830A )
+	rom ( name "Brunswick Circuit Pro Bowling (U) [!].z64" size 8388608 crc 80D70173 md5 62E92102D6FD1701A6E904DA6AB58AE8 sha1 91F6F7843A7413126A7B4026104526615F979134 )
 )
 
 game (
 	name "Buck Bumble (Europe) (En,Fr,De,Es,It)"
 	description "Buck Bumble (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Buck Bumble (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 08433E0D md5 80A2C272C13B2F1A5654E98CBEB64AAF sha1 60305A61143BAE5557672E2BDBB9D81EC2DA5C20 flags verified )
+	rom ( name "Buck Bumble (E) (M5) [!].z64" size 12582912 crc E26192AB md5 A2E4BE02876CB0F0D1E925FF95090C96 sha1 1123BFAC4EC3730A54900CA83E196065CBB4B6E2 )
 )
 
 game (
 	name "Buck Bumble (Japan)"
 	description "Buck Bumble (Japan)"
 	rom ( name "Buck Bumble (Japan).n64" size 12582912 crc 24D1A591 md5 5B2D83E1474A34190F748287982407BE sha1 60AFBCC6AFDE1F22AA8031F98F9AD84B1529F848 flags verified )
+	rom ( name "Buck Bumble (J) [!].z64" size 12582912 crc 2ED81A65 md5 AEE981977D8F069003574CD10A268D47 sha1 38007F846A454AD09D2090F0EF86E9762A46CCF7 )
 )
 
 game (
 	name "Buck Bumble (USA)"
 	description "Buck Bumble (USA)"
 	rom ( name "Buck Bumble (USA).n64" size 12582912 crc DA2ACD5E md5 2BD134F866AF753AB46767FAC3144E2E sha1 9CF046E320E5437159A41C49694DC66D4D8E79BD )
+	rom ( name "Buck Bumble (U) [!].z64" size 12582912 crc 8EC937DB md5 41417FCE2B37EAAE787C5A845A0015C4 sha1 01D9497EA0E1F68AE285B8C7A57439B42B7D9A56 )
 )
 
 game (
 	name "Bug's Life, A (Europe)"
 	description "Bug's Life, A (Europe)"
 	rom ( name "Bug's Life, A (Europe).n64" size 12582912 crc 0D101756 md5 FDBAC5A07EF105E31428E14FC7AFE887 sha1 EE0175CDF971BCE250E174D5BC56CDB53104058E flags verified )
+	rom ( name "Bug's Life, A (E) [!].z64" size 12582912 crc 791881D4 md5 ED3E962653A1CD56AAB175DEEE6EE52A sha1 2922C2281FAA4106295830C617289292DF4C377A )
 )
 
 game (
 	name "Bug's Life, A (France)"
 	description "Bug's Life, A (France)"
 	rom ( name "Bug's Life, A (France).n64" size 12582912 crc 2420C6FD md5 AF129B15546FEB93C26E60A13D26E51B sha1 EE71DBBB82CEA124AB2D8A59AA7C24AC20E5979A )
+	rom ( name "Bug's Life, A (F) [!].z64" size 12582912 crc E5429094 md5 D2860D4FBD0EC4B2711A6EF8D78F9866 sha1 4970ECC65E8DE25990A241B0D2FFBE274CB1619A )
 )
 
 game (
 	name "Bug's Life, A (Germany)"
 	description "Bug's Life, A (Germany)"
 	rom ( name "Bug's Life, A (Germany).n64" size 12582912 crc DE6CE3EF md5 DC4896F284956BFE8A105F7C93E0472E sha1 9BDC6D273262F6D1362565215566F6166AEC6A07 )
+	rom ( name "Bug's Life, A (G) [!].z64" size 12582912 crc 15A32836 md5 CBEF54768670F4B5602CCBC90150007A sha1 DAA7114A8D16C3E636B2808D4F256E07954F05DD )
 )
 
 game (
 	name "Bug's Life, A (Italy)"
 	description "Bug's Life, A (Italy)"
 	rom ( name "Bug's Life, A (Italy).n64" size 12582912 crc 04244AAC md5 C7FFEE53B085C5C8C184FC1AA0B374F7 sha1 59564546478AE885A39B4ED77F8FB3A6E7E9BC40 )
+	rom ( name "Bug's Life, A (I) [!].z64" size 12582912 crc 2D118764 md5 E3609FD12369C464E832C6D2A4D20790 sha1 46F9C5D7EB822B19BE6910B992949DEF27E46887 )
 )
 
 game (
@@ -628,30 +714,35 @@ game (
 	name "Bust-A-Move '99 (USA)"
 	description "Bust-A-Move '99 (USA)"
 	rom ( name "Bust-A-Move '99 (USA).n64" size 8388608 crc 2A95290F md5 F81F1FA671A2C861C484500150643360 sha1 3561149DDFF17A60210EC5752781C512B6F4E126 )
+	rom ( name "Bust-A-Move '99 (U) [!].z64" size 8388608 crc C285FC69 md5 8567382D3CD5BC0406B7B4C780F621DC sha1 8D874677CFBFA88C5E52BC13327D518BE3B756BA )
 )
 
 game (
 	name "Bust-A-Move 2 - Arcade Edition (Europe)"
 	description "Bust-A-Move 2 - Arcade Edition (Europe)"
 	rom ( name "Bust-A-Move 2 - Arcade Edition (Europe).n64" size 8388608 crc 14F2CBE9 md5 066D3B1727225962DB938D60642CD6BC sha1 275A39083567C0E4ECF334B666EE6543962FB899 flags verified )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [!].z64" size 8388608 crc 04731BAB md5 094F639A9BA63B2136D2887C8D72BCA0 sha1 F92A1B19C522BA6CF20A9D7883321E6E283DA32F )
 )
 
 game (
 	name "Bust-A-Move 2 - Arcade Edition (USA)"
 	description "Bust-A-Move 2 - Arcade Edition (USA)"
 	rom ( name "Bust-A-Move 2 - Arcade Edition (USA).n64" size 8388608 crc 47511877 md5 8B2F1700CD02E34A99752213BDD150CF sha1 9F7DCB8EE0A918EB9B257AC9F210F0D30F9F6430 )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [!].z64" size 8388608 crc 9F54CD2D md5 8897A39E34AEE4D3F807AF255C6617D6 sha1 8F1AAD51E733958D1A9A7A0CB7516FC7A293CA7B )
 )
 
 game (
 	name "Bust-A-Move 3 DX (Europe)"
 	description "Bust-A-Move 3 DX (Europe)"
 	rom ( name "Bust-A-Move 3 DX (Europe).n64" size 8388608 crc 9F3F484B md5 C7D54104CC455D90D31EDD761BEB7205 sha1 20B2704B12298987BB6151FF432D616866DC00C1 flags verified )
+	rom ( name "Bust-A-Move 3 DX (E) [!].z64" size 8388608 crc 95595889 md5 3EA21256DDC4157C3231AE5CC9C4652A sha1 2BD376C3DB3080D0A2328EF4052E59C3DF71797E )
 )
 
 game (
 	name "California Speed (USA)"
 	description "California Speed (USA)"
 	rom ( name "California Speed (USA).n64" size 16777216 crc 387B0C4C md5 50726D8E0714F80F5514BEC192796BA2 sha1 AFE86AED561560BFCF1BC7130C8341252142269B )
+	rom ( name "California Speed (U) [!].z64" size 16777216 crc 6F6262CB md5 965AD2FA317F0644E49A89A3219719CB sha1 BD4C070A71EF58499587CB811FB7490B88DD7C0B )
 )
 
 game (
@@ -664,12 +755,14 @@ game (
 	name "Carmageddon 64 (Europe) (En,Fr,De,Es)"
 	description "Carmageddon 64 (Europe) (En,Fr,De,Es)"
 	rom ( name "Carmageddon 64 (Europe) (En,Fr,De,Es).n64" size 16777216 crc D8D87DCA md5 74DCF49871606036CD70B42AE2B19B1C sha1 B8AA32D7D78E3119B05C19CD45AAD102465AD254 )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!].z64" size 16777216 crc 8569F1A0 md5 CA21467BDE6B355E7A15B8F1ADA7B24D sha1 2AB7EA2A9BC05ECF3CAC026E2AFF7ACC9D3202E5 )
 )
 
 game (
 	name "Carmageddon 64 (Europe) (En,Fr,Es,It)"
 	description "Carmageddon 64 (Europe) (En,Fr,Es,It)"
 	rom ( name "Carmageddon 64 (Europe) (En,Fr,Es,It).n64" size 16777216 crc 17B07602 md5 3405BB5266CCD60A3B4A4DE7408251F2 sha1 2E64E34DC8F3B6349CB71412F1BF2CA6A2FD5C2B flags verified )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!].z64" size 16777216 crc 8036F999 md5 59EB5646FA079BCBD7A340D7A10196DD sha1 A26831C07ECC57DBF5846DB847A30D9F735297C2 )
 )
 
 game (
@@ -683,12 +776,14 @@ game (
 	name "Castlevania (Europe) (En,Fr,De)"
 	description "Castlevania (Europe) (En,Fr,De)"
 	rom ( name "Castlevania (Europe) (En,Fr,De).n64" size 12582912 crc D1D4D306 md5 0BFEBEDF99C1E715ADA7103664BFCC97 sha1 72FEC07CDB52645E48126A154C9F72E32C2B1931 flags verified )
+	rom ( name "Castlevania (E) (M3) [!].z64" size 12582912 crc D9D76235 md5 57146B6CD8EE7D96B01A811F98A1AC61 sha1 E0DA571CDDCB8D069B36C2DF254334F7C532133E )
 )
 
 game (
 	name "Castlevania (USA)"
 	description "Castlevania (USA)"
 	rom ( name "Castlevania (USA).n64" size 12582912 crc 84E815F3 md5 0BBAA6DE2B9CBB822F8B4D85C1D5497B sha1 B9E2DD5CA9E38E3BEB4C4C374E7DD9377E88D943 )
+	rom ( name "Castlevania (U) (V1.0) [!].z64" size 12582912 crc 8B0D3C00 md5 1CC5CF3B4D29D8C3ADE957648B529DC1 sha1 989A28782ED6B0BC489A1BBBD7BEC355D8F2707E )
 )
 
 game (
@@ -708,6 +803,7 @@ game (
 	name "Castlevania - Legacy of Darkness (Europe) (En,Fr,De)"
 	description "Castlevania - Legacy of Darkness (Europe) (En,Fr,De)"
 	rom ( name "Castlevania - Legacy of Darkness (Europe) (En,Fr,De).n64" size 16777216 crc A12BF3DE md5 BC0CBC7CE863579675116A14F660BF54 sha1 57EF17BD7450EB1E3C486E5C628ADED23E884236 flags verified )
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [!].z64" size 16777216 crc 12AB9B45 md5 78D5F8A98A5ED21D0817856BCD2AD750 sha1 0C6817082DD322477C63F3C91A99C1F34AF0065C )
 )
 
 game (
@@ -721,24 +817,28 @@ game (
 	name "Centre Court Tennis (Europe)"
 	description "Centre Court Tennis (Europe)"
 	rom ( name "Centre Court Tennis (Europe).n64" size 12582912 crc 2573171A md5 FFF4BF92143C5A043E25461C2BAADEC8 sha1 18CC04521D0C7E9EBA015B45CF7F3AB9930AF28E flags verified )
+	rom ( name "Centre Court Tennis (E) [!].z64" size 12582912 crc B1D26F39 md5 31FB88048076ACE4BD4205C5F40414AB sha1 C6F1251B4B7841220F670D8A0AF844B34C5CFADA )
 )
 
 game (
 	name "Chameleon Twist (Europe)"
 	description "Chameleon Twist (Europe)"
 	rom ( name "Chameleon Twist (Europe).n64" size 12582912 crc 2AF50883 md5 EC5604A1573D0A2C08F6EF36BE842154 sha1 1C936C558066DA54210DEEF28EBA58520D264011 flags verified )
+	rom ( name "Chameleon Twist (E) [!].z64" size 12582912 crc 587DD983 md5 1CD90B13B7FD6AFDCB838F801D807826 sha1 197556F41756C82EDB6BA7767F0D181290C1B2C2 )
 )
 
 game (
 	name "Chameleon Twist (Japan)"
 	description "Chameleon Twist (Japan)"
 	rom ( name "Chameleon Twist (Japan).n64" size 12582912 crc A2DCF689 md5 59227D760A41DBCC644070CF0E993BFA sha1 E6A1D9B94E83D1784ECAF0DEC6F6A9E42FEAA74D flags verified )
+	rom ( name "Chameleon Twist (J) [!].z64" size 12582912 crc 6395C475 md5 C0EB519122D63A944A122437EC1B98EE sha1 A1FAF5C4CA961AB2C029C84ECFA556755E7F70C8 )
 )
 
 game (
 	name "Chameleon Twist (USA)"
 	description "Chameleon Twist (USA)"
 	rom ( name "Chameleon Twist (USA).n64" size 12582912 crc 4246EE14 md5 74520D4064C37C72C2BDEE4AF2520E59 sha1 2CABB61506BF5F74437BC813429C22325045393A )
+	rom ( name "Chameleon Twist (U) [!].z64" size 12582912 crc 7FE024C9 md5 397BE52D4FB7DF1E26C6275E05425571 sha1 173875D2A98161228EFB56841484E12446A43156 )
 )
 
 game (
@@ -751,36 +851,42 @@ game (
 	name "Chameleon Twist 2 (Europe)"
 	description "Chameleon Twist 2 (Europe)"
 	rom ( name "Chameleon Twist 2 (Europe).n64" size 8388608 crc 35958F55 md5 7A20B97C0B509AAA38E36068ACD217C3 sha1 6EF1F9C84E73C9307B52A52635E4FE5E23D795D8 flags verified )
+	rom ( name "Chameleon Twist 2 (E) [!].z64" size 8388608 crc 3B53519F md5 45D1D039AB7926ADC748DE640AFD986A sha1 BBCA485EE38E07DA78F44E5DE653311B8EDC18F2 )
 )
 
 game (
 	name "Chameleon Twist 2 (Japan)"
 	description "Chameleon Twist 2 (Japan)"
 	rom ( name "Chameleon Twist 2 (Japan).n64" size 12582912 crc F42BB75F md5 CB4FC518CB6F3A1D70B3179C23FD54D3 sha1 E659CD6059FD464BA1883A5BAE8B839C14BA72F4 flags verified )
+	rom ( name "Chameleon Twist 2 (J) [!].z64" size 8388608 crc 5677EAEF md5 A55AF433E65E3690E2DC2B16018E9A0F sha1 0F14F7C1E2A72008B83CBEA6A79BA38B8971561E )
 )
 
 game (
 	name "Chameleon Twist 2 (USA)"
 	description "Chameleon Twist 2 (USA)"
 	rom ( name "Chameleon Twist 2 (USA).n64" size 8388608 crc 356736C7 md5 BE134500DA3342CD5DC7922B5E2697B7 sha1 185141B800BF109367905F1A6B0EF6823F224CE8 )
+	rom ( name "Chameleon Twist 2 (U) [!].z64" size 8388608 crc CDF26D67 md5 00327E0B5DF6DCE6DECC31353F33A3D3 sha1 9FA379D66B218228DA3CBF386C91D857C677F489 )
 )
 
 game (
 	name "Charlie Blast's Territory (Europe)"
 	description "Charlie Blast's Territory (Europe)"
 	rom ( name "Charlie Blast's Territory (Europe).n64" size 4194304 crc 831C5A55 md5 9F591BF3C78E6F00E8B83AA797441A4C sha1 43B30901BEFBC629E50F76EDC7D96B393DCC5F0B flags verified )
+	rom ( name "Charlie Blast's Territory (E) [!].z64" size 4194304 crc 82C1D9E1 md5 DD53E1F83E8789D23DF6AF942FFEF236 sha1 9A0EB87BA72C1EF4DCB8B80029F29CDEEA91FE49 )
 )
 
 game (
 	name "Charlie Blast's Territory (USA)"
 	description "Charlie Blast's Territory (USA)"
 	rom ( name "Charlie Blast's Territory (USA).n64" size 4194304 crc 928A2968 md5 402809447FFB03C0921219ADAB45E714 sha1 CA22FA616D00D6199513A52C7851CBEE5CC52354 )
+	rom ( name "Charlie Blast's Territory (U) [!].z64" size 4194304 crc BA4E65A8 md5 59FA8C6D533D36C0FFC2AAFAB7166E6F sha1 E11619C7A8E1C2A280EA3AC069CF11153D4951A6 )
 )
 
 game (
 	name "Chopper Attack (Europe)"
 	description "Chopper Attack (Europe)"
 	rom ( name "Chopper Attack (Europe).n64" size 8388608 crc 30CA7DBE md5 F1CAC35BC510733862A55B32642FFF74 sha1 9D0840380C468A8458A838C0EE06C4858DCD1C9A flags verified )
+	rom ( name "Chopper Attack (E) [!].z64" size 8388608 crc C1DCD7AB md5 8F6BED633BE214CF039DBDAC356231CE sha1 9688C388384EDEA0141FC66B20D6D0E5FE2D668F )
 )
 
 game (
@@ -793,36 +899,42 @@ game (
 	name "Choro Q 64 (Japan)"
 	description "Choro Q 64 (Japan)"
 	rom ( name "Choro Q 64 (Japan).n64" size 8388608 crc C5722B49 md5 1E1C1407FB9DCDDFA2A140A9C7597398 sha1 C399149B3166CE310028184610AAF312AF9BA75A flags verified )
+	rom ( name "Choro Q 64 (J) [!].z64" size 8388608 crc 231F9284 md5 8287A908E36E79B2D3AF0BD22C43ECD9 sha1 288CDBABE30349B70DDD68931E697AF03E0D2EE8 )
 )
 
 game (
 	name "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan)"
 	description "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan)"
 	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan).n64" size 12582912 crc 42AE9174 md5 4AC91D55887E73BB58650FB351E0A30E sha1 EDD177A68DD0C20DD6F939CDB7A74264132DD326 flags verified )
+	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!].z64" size 12582912 crc 5C565AD6 md5 9081370141079031EBBDBCA56FC8C7D8 sha1 4532621D98B25D07E2F19AA106FF4DB547104160 )
 )
 
 game (
 	name "Chou Kuukan Nighter Pro Yakyuu King (Japan)"
 	description "Chou Kuukan Nighter Pro Yakyuu King (Japan)"
 	rom ( name "Chou Kuukan Nighter Pro Yakyuu King (Japan).n64" size 8388608 crc C73E336C md5 70A0306209E6141293349648E22B9705 sha1 EA7E403A37EE386F6422F4B96D4450FCD5D816F0 flags verified )
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [!].z64" size 8388608 crc 5F75634E md5 78838C202C4FF5A460586451EE9182AA sha1 A08DD769F3B885DC27F4CD14022613D1BAA52B84 )
 )
 
 game (
 	name "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)"
 	description "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)"
 	rom ( name "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).n64" size 16777216 crc C0FC82C0 md5 11031676E9BECC877BC513D4AAD3449E sha1 391E91DDBFF9B42A0F5563187DC66F4D2842F598 flags verified )
+	rom ( name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!].z64" size 16777216 crc 479643E2 md5 97EAB4DC83DA0AD2890DE2AAAA5D109A sha1 B8C62BEFE0A2BD7BCD6EFB5F78B34B923B325AAC )
 )
 
 game (
 	name "Chou Snobo Kids (Japan)"
 	description "Chou Snobo Kids (Japan)"
 	rom ( name "Chou Snobo Kids (Japan).n64" size 16777216 crc AB53586B md5 B8867AF93066C46884FD4CE2EDC55937 sha1 36DF553351DEF16BF92DE8CADA7350E0A287FD0D )
+	rom ( name "Chou Snobow Kids (J) [!].z64" size 16777216 crc 8FEDF4C6 md5 9466618F4497DA6C9091E05CC9666786 sha1 A116C12CA0056D952128D57F7569674F457F0F74 )
 )
 
 game (
 	name "City-Tour GP - Zen-Nihon GT Senshuken (Japan)"
 	description "City-Tour GP - Zen-Nihon GT Senshuken (Japan)"
 	rom ( name "City-Tour GP - Zen-Nihon GT Senshuken (Japan).n64" size 16777216 crc 7A59354B md5 E55BE3D631AD7B76ACF8AD4832A1CB8B sha1 FCAD11BCDD2AD20E1C49CEA89F1ED4697DDEBD91 flags verified )
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [!].z64" size 16777216 crc E272BDF6 md5 2A0BF5A9A136D57AF01D199B16899634 sha1 2B543707F5BDBA52A49D71755615D6CF38E23E76 )
 )
 
 game (
@@ -836,6 +948,7 @@ game (
 	name "Clay Fighter 63 1-3 (Europe)"
 	description "Clay Fighter 63 1-3 (Europe)"
 	rom ( name "Clay Fighter 63 1-3 (Europe).n64" size 12582912 crc DCCCB22F md5 53B9F00C65FD7E8D594149533A2A4982 sha1 1CDA578CAD71ABCCECD3643197C76A3284CAAC3E flags verified )
+	rom ( name "Clay Fighter 63 1-3 (E) [!].z64" size 12582912 crc 82263E5D md5 41965B533F3DD95663361D9DF68B0C1F sha1 FEC40EF7D8B973C5937ADE10423D0CF1B5A18E3C )
 )
 
 game (
@@ -849,18 +962,21 @@ game (
 	name "Clay Fighter 63 1-3 (USA) (Beta)"
 	description "Clay Fighter 63 1-3 (USA) (Beta)"
 	rom ( name "Clay Fighter 63 1-3 (USA) (Beta).n64" size 12582912 crc 23139027 md5 DDC463091050484309037576A201D439 sha1 9C2009462315508119B991BA22D4B23BB50D0779 )
+	rom ( name "Clay Fighter 63 1-3 (Beta) [!].z64" size 12582912 crc 18F4166A md5 CBBEAFF5A9074D1A5507CF46CD683D36 sha1 3307F73B8BD0795D3C7036D77FC4A78EFEBC4EF0 )
 )
 
 game (
 	name "Command & Conquer (Europe) (En,Fr)"
 	description "Command & Conquer (Europe) (En,Fr)"
 	rom ( name "Command & Conquer (Europe) (En,Fr).n64" size 33554432 crc CE383B3E md5 2B7E4E14D744B40FD393C487E0768C24 sha1 5EA73072575EDED3954ABE4A9D44623B7847C820 flags verified )
+	rom ( name "Command & Conquer (E) (M2) [!].z64" size 33554432 crc F3DA8A26 md5 42DA4C7D040F9E7CD046A42EC3E68027 sha1 0D5211E211E7FC063C63C3E8235B62BC288CE305 )
 )
 
 game (
 	name "Command & Conquer (Germany)"
 	description "Command & Conquer (Germany)"
 	rom ( name "Command & Conquer (Germany).n64" size 33554432 crc B312E838 md5 FBC337325B9CEAE41F237F3E54D72AB3 sha1 662D03F3DF3E1817330DB94CE330F7915BD9A00C flags verified )
+	rom ( name "Command & Conquer (G) [!].z64" size 33554432 crc 6CD0FC99 md5 1A9195662C89DCBEA88BCFA99B096CDE sha1 725083ECE68D5DEB9724D3FA3F2A65F0291B2D5D )
 )
 
 game (
@@ -874,6 +990,7 @@ game (
 	name "Conker's Bad Fur Day (Europe)"
 	description "Conker's Bad Fur Day (Europe)"
 	rom ( name "Conker's Bad Fur Day (Europe).n64" size 67108864 crc 96DBA949 md5 E31DED9C7887EBC07A343B8865A2BF55 sha1 175A058E739762D49AFF01B4EAC8784DB415C711 flags verified )
+	rom ( name "Conker's Bad Fur Day (E) [!].z64" size 67108864 crc 4667CFE9 md5 05194D49C14E52055DF72A54D40791E1 sha1 EE7BC6656FD1E1D9FFB3D19ADD759F28B88DF710 )
 )
 
 game (
@@ -887,84 +1004,98 @@ game (
 	name "Cruis'n Exotica (USA)"
 	description "Cruis'n Exotica (USA)"
 	rom ( name "Cruis'n Exotica (USA).n64" size 16777216 crc 20E7DBD7 md5 AC67B606AEA6A01F3CFCCCBC30061A10 sha1 130FED584A6EB820B69E90E8AC8EC9301D69C3C5 )
+	rom ( name "Cruis'n Exotica (U) [!].z64" size 16777216 crc 867A2CED md5 DB7A03B77D44DB81B8A3FCDFC4B72D8C sha1 428F53A060103FD88EBFBDCC032A99CAEA901E17 )
 )
 
 game (
 	name "Cruis'n USA (Europe)"
 	description "Cruis'n USA (Europe)"
 	rom ( name "Cruis'n USA (Europe).n64" size 8388608 crc 6767ECA4 md5 07BBF2E52F243852B01B25CE874FDE17 sha1 6CC846AEDCC31597842645BBB6030272CD9A82F0 flags verified )
+	rom ( name "Cruis'n USA (E) [!].z64" size 8388608 crc 8935A8D9 md5 69CD5BA6BC9310B9E37CCB1BC6BD16AD sha1 404AB549CD148EA07F40D66C0B896A343741BBF6 )
 )
 
 game (
 	name "Cruis'n USA (USA)"
 	description "Cruis'n USA (USA)"
 	rom ( name "Cruis'n USA (USA).n64" size 8388608 crc EE925406 md5 D2D8CBC47EE941A30AEC1AF3AC471519 sha1 AA8768945FF398B13B7EE9722A268E49424B6F26 )
+	rom ( name "Cruis'n USA (U) (V1.0) [!].z64" size 8388608 crc 5238B727 md5 00A3E885F8D899646228A21D946B2102 sha1 AEFE77A5518FE74519908B6CBC97CB81B8570897 )
 )
 
 game (
 	name "Cruis'n USA (USA) (Rev A)"
 	description "Cruis'n USA (USA) (Rev A)"
 	rom ( name "Cruis'n USA (USA) (Rev A).n64" size 8388608 crc 615AC9BC md5 78BAA0F08D53842B84F25700B750CA8C sha1 DA43A6443C22A608B76B6B73602C30B0C6038379 )
+	rom ( name "Cruis'n USA (U) (V1.1) [!].z64" size 8388608 crc 4655BA2D md5 45FC88E2BA6711F25F0DE988E719DF29 sha1 71BB3D8850B6A4A294AECA2ABAD1F936E4F85F0F )
 )
 
 game (
 	name "Cruis'n USA (USA) (Rev B)"
 	description "Cruis'n USA (USA) (Rev B)"
 	rom ( name "Cruis'n USA (USA) (Rev B).n64" size 8388608 crc E466C124 md5 4379EE6C5CB0B521C2D0866A3BA71973 sha1 4E0AF2979C573AAAB84A60F42266EC0C3FA60B84 flags verified )
+	rom ( name "Cruis'n USA (U) (V1.2) [!].z64" size 8388608 crc C3B52701 md5 2838A9018AD2BCB8B7F6161C746A1B71 sha1 54A875EE0B482036FA401A6BC2B242699F0259F7 )
 )
 
 game (
 	name "Cruis'n World (Europe)"
 	description "Cruis'n World (Europe)"
 	rom ( name "Cruis'n World (Europe).n64" size 12582912 crc 2A8B3094 md5 47D90F8A5B8BBF90049A161469625FE2 sha1 E0EFBB03B343CC9ACE4E98306250436604054B6E flags verified )
+	rom ( name "Cruis'n World (E) [!].z64" size 12582912 crc E46CE079 md5 AF950A1B6C460D7FC3E78375D35047EF sha1 EE508F14C936265D101C9699B5AE1A722B3E7D9E )
 )
 
 game (
 	name "Cruis'n World (USA)"
 	description "Cruis'n World (USA)"
 	rom ( name "Cruis'n World (USA).n64" size 12582912 crc 41877D7D md5 FCF34799BB1F3CA47B46371BD23B4424 sha1 A584735385485EE0B158E3206CE9B2E47FECA830 )
+	rom ( name "Cruis'n World (U) [!].z64" size 12582912 crc A123769F md5 AADA4CBD938E58A447B399A1D46F03E6 sha1 6DA1A6A2BDA687D50E798D80C342948AD1738202 )
 )
 
 game (
 	name "Custom Robo (Japan)"
 	description "Custom Robo (Japan)"
 	rom ( name "Custom Robo (Japan).n64" size 16777216 crc 30C84F36 md5 41FFF04711D1B5524785A5CE05F6E611 sha1 9D462983D2F6C4417C328D97D430E0D62C5DAC94 flags verified )
+	rom ( name "Custom Robo (J) [!].z64" size 16777216 crc F2FAE693 md5 A06D2E83CF2628915E8847F609474661 sha1 49DE08F08400A477485C4798D6CD81D95842C806 )
 )
 
 game (
 	name "Custom Robo V2 (Japan)"
 	description "Custom Robo V2 (Japan)"
 	rom ( name "Custom Robo V2 (Japan).n64" size 16777216 crc 7BEF9ECC md5 64E09AB54443CFFBB31FEE73936EE489 sha1 67FF98E6230470F0C3C209EDB72869C715DB2800 flags verified )
+	rom ( name "Custom Robo V2 (J) [!].z64" size 16777216 crc C8201454 md5 115118DD5E0F02D82BA1BF070A7B78F1 sha1 F9515C2482AF8DF791339536F60260509C424F6A )
 )
 
 game (
 	name "CyberTiger (Europe)"
 	description "CyberTiger (Europe)"
 	rom ( name "CyberTiger (Europe).n64" size 16777216 crc BCF1071F md5 AEE5BD2F3288182038C028531C0AD092 sha1 E68970895CC01B69B8A5A05EAF4D07B632544330 flags verified )
+	rom ( name "CyberTiger (E) [!].z64" size 16777216 crc 7319D9AF md5 8C4A4CD472D610CDA5459B3A92F21D30 sha1 AE220AC1CD6D892098937DC639C925F9EF158759 )
 )
 
 game (
 	name "CyberTiger (USA)"
 	description "CyberTiger (USA)"
 	rom ( name "CyberTiger (USA).n64" size 16777216 crc F0F89BB9 md5 4F1540CA7E7DEDBB2B3EE4BF6509975D sha1 AFB3E9290730FD19106ECA24CB305C1B55F2E864 )
+	rom ( name "CyberTiger (U) [!].z64" size 16777216 crc 10CC5F15 md5 88072F30D4F9CF384B2B3A0300649218 sha1 14E0635CCC2A80C77FD0A888A2E7977C55C6E129 )
 )
 
 game (
 	name "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 6CB4B600 md5 1979C1A7D449107F478EBA716CD30266 sha1 456706F0E7A55B40715585F4A66A250A5654C02C flags verified )
+	rom ( name "Looney Tunes - Duck Dodgers (E) (M6) [!].z64" size 16777216 crc C61F6BB9 md5 1408FCF68B60D845F090107EF355A7E5 sha1 5499B5284C04CEE98186E68198D6BFE73FEE0CDB )
 )
 
 game (
 	name "Dance Dance Revolution - Disney Dancing Museum (Japan)"
 	description "Dance Dance Revolution - Disney Dancing Museum (Japan)"
 	rom ( name "Dance Dance Revolution - Disney Dancing Museum (Japan).n64" size 33554432 crc E085AFA0 md5 B3F1D0ABC1A8E1713124EF64A4B9BE51 sha1 B0931ECABC6D7C05A14C792F45BC6FAAC8722AB1 flags verified )
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [!].z64" size 25165824 crc 3C13FBCF md5 3A1488C2A8A8F2AB9368D7C056EB02A2 sha1 DB0AE6323F9EF4F7ED62071B2901B48E87E919C6 )
 )
 
 game (
 	name "Dark Rift (Europe)"
 	description "Dark Rift (Europe)"
 	rom ( name "Dark Rift (Europe).n64" size 8388608 crc 375D8FFE md5 B05AB4D2CEB5B9132AFDB138E14B9A4C sha1 9C6701DD396A35649B0045C5BE3DC0642C334C8C flags verified )
+	rom ( name "Dark Rift (E) [!].z64" size 8388608 crc D2A19C71 md5 4242FDE5B74F22AAF5746459E126121F sha1 18B02FC18411ACD770BF3F25B2707669DAC2EC5D )
 )
 
 game (
@@ -985,30 +1116,35 @@ game (
 	name "Defi au Tetris Magique (France)"
 	description "Defi au Tetris Magique (France)"
 	rom ( name "Defi au Tetris Magique (France).n64" size 16777216 crc EB304709 md5 29BB26E9C200A947C57361AB5A57812F sha1 0F90CE8124A023F207C59CCBDA17D10D13532D62 )
+	rom ( name "Defi au Tetris Magique (F) [!].z64" size 16777216 crc E7EF60E8 md5 C644E318B33C4EBD94695C0C3E1E80FF sha1 E5C79CF80AE1C19D2CB7136600EC8BD2CCEAE934 )
 )
 
 game (
 	name "Densha de Go! 64 (Japan)"
 	description "Densha de Go! 64 (Japan)"
 	rom ( name "Densha de Go! 64 (Japan).n64" size 33554432 crc 8F63474F md5 E990868A77DBAA62E1F32C2EA1C9BDEF sha1 AD5B14C3C571DB911B2896D6C80E200B12CAFDCD flags verified )
+	rom ( name "Densha de Go! 64 (J) [!].z64" size 33554432 crc 7BFC71E0 md5 772FA166E5DB51EFFC77FB8D832AC4D2 sha1 5B99D3AF55DFD04A5ACC11B9D25A3330C1E45708 )
 )
 
 game (
 	name "Derby Stallion 64 (Japan)"
 	description "Derby Stallion 64 (Japan)"
 	rom ( name "Derby Stallion 64 (Japan).n64" size 33554432 crc 922506AD md5 CB80BE23EEDC36D6FACB03D4C877E28B sha1 B404E2A26DA5CF0EE2EECFD691FFB0385D08642A flags verified )
+	rom ( name "Derby Stallion 64 (J) [!].z64" size 33554432 crc A9417994 md5 7F57463856540104B21A5289312B626F sha1 9A2B7DFA38FBF9CD07FF676C0E484D7B97DB606B )
 )
 
 game (
 	name "Derby Stallion 64 (Japan) (Beta)"
 	description "Derby Stallion 64 (Japan) (Beta)"
 	rom ( name "Derby Stallion 64 (Japan) (Beta).n64" size 33554432 crc 418FA479 md5 836D85A3668E5FC577DE63E411B0B8EA sha1 BCA2DB2B280261CD0E62B304BA3754A6C56351B5 )
+	rom ( name "Derby Stallion 64 (J) (Beta).z64" size 33554432 crc 8EC950A9 md5 1051E1402EE110F3C5E372C9E1C5B338 sha1 BD03F18C456D5DB90475DCF1AAE2237C82D7446A )
 )
 
 game (
 	name "Destruction Derby 64 (Europe) (En,Fr,De)"
 	description "Destruction Derby 64 (Europe) (En,Fr,De)"
 	rom ( name "Destruction Derby 64 (Europe) (En,Fr,De).n64" size 16777216 crc 212A8000 md5 DFFD909E47B4ABC8FB25669C83EEF8AA sha1 E68747F46AB2EB21D56BD39F65232BDAAD86BCF9 flags verified )
+	rom ( name "Destruction Derby 64 (E) (M3) [!].z64" size 16777216 crc 7AD9E429 md5 BDA717ECC8434F12F313342485828B58 sha1 EED379520C7FC7D08EBE5A076683BD56F3A0A04F )
 )
 
 game (
@@ -1022,30 +1158,35 @@ game (
 	name "Dezaemon 3D (Japan)"
 	description "Dezaemon 3D (Japan)"
 	rom ( name "Dezaemon 3D (Japan).n64" size 16777216 crc 8CE25C68 md5 6C21310E6F906057BA261BBD9903BCBB sha1 7CA61515B13D927E905B59390DD300945B68D218 flags verified )
+	rom ( name "Dezaemon 3D (J) [!].z64" size 16777216 crc 9E978488 md5 54BE265E7B2C28AB92BF1A4130ACB5A2 sha1 1C10A85A2B6A782E6302B19C2387E2D58983A8D4 )
 )
 
 game (
 	name "Diddy Kong Racing (Europe) (En,Fr,De)"
 	description "Diddy Kong Racing (Europe) (En,Fr,De)"
 	rom ( name "Diddy Kong Racing (Europe) (En,Fr,De).n64" size 12582912 crc 883DF1EA md5 56CAA8F0D1B95FD3AF3472841A04C5FB sha1 944EF38C40630573C16D7534109EB7D3C822EEEC flags verified )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [!].z64" size 12582912 crc 4A13323C md5 0F0B7B78B345FBF2581D834CB4A81245 sha1 DD5D64DD140CB7AA28404FA35ABDCABA33C29260 )
 )
 
 game (
 	name "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A)"
 	description "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A).n64" size 12582912 crc F05D414F md5 75874D5233240E9790755DA009B8B6BB sha1 FD57DA7FE1D4DD471CAACA419176A4C097EE7B90 flags verified )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [!].z64" size 12582912 crc B1E87639 md5 6B2BAFE540E0AF052A78E85B992BE999 sha1 B7F628073237B3D211D40406AA0884FF8FDD70D5 )
 )
 
 game (
 	name "Diddy Kong Racing (Japan)"
 	description "Diddy Kong Racing (Japan)"
 	rom ( name "Diddy Kong Racing (Japan).n64" size 12582912 crc 95931356 md5 7021A85C953549E73B151A1B328A8FB1 sha1 A33962564640CD80E57F7CAC895CA831F123AFD5 flags verified )
+	rom ( name "Diddy Kong Racing (J).z64" size 12582912 crc B566FB94 md5 10747662A55241B9234CD114C940504F sha1 23BA3D302025153D111416E751027CEF11213A19 )
 )
 
 game (
 	name "Diddy Kong Racing (USA) (En,Fr)"
 	description "Diddy Kong Racing (USA) (En,Fr)"
 	rom ( name "Diddy Kong Racing (USA) (En,Fr).n64" size 12582912 crc 9D2935A1 md5 E00C0E6BFB0CE740E3E1C50BA82BC01A sha1 812807D8DC23229E736D543C3BAFC7EF28519EF5 flags verified )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [!].z64" size 12582912 crc EB759206 md5 4F0E07F0EEAC7E5D7CE3A75461888D03 sha1 0CB115D8716DBBC2922FDA38E533B9FE63BB9670 )
 )
 
 game (
@@ -1059,24 +1200,28 @@ game (
 	name "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)"
 	description "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)"
 	rom ( name "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).n64" size 20971520 crc 6D48B64E md5 F2B2D71DE20BC16FF9F036D965A2E499 sha1 2700F7534D477C7B673DCDEE0FE19B93DC95CA89 )
+	rom ( name "Disney's Donald Duck - Goin' Quackers (U) [!].z64" size 20971520 crc 7FDEC270 md5 0E0E920AB13EF13508F5A98CC4CD2FF8 sha1 E31A7567D408C890065029BA537F830765B17D94 )
 )
 
 game (
 	name "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
 	description "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).n64" size 20971520 crc 5F67A191 md5 E8127681104E997954F2B238B3A75BAE sha1 6C761E0668247A5B264E2DEB502F1DE992F83346 flags verified )
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [!].z64" size 20971520 crc C4B0D9EA md5 E8B403A0F0E212FA5C1220AF10D9C379 sha1 C42FAFB06BE6EB7DE08370D07F19571B7661074B )
 )
 
 game (
 	name "Donkey Kong 64 (Europe) (En,Fr,De,Es)"
 	description "Donkey Kong 64 (Europe) (En,Fr,De,Es)"
 	rom ( name "Donkey Kong 64 (Europe) (En,Fr,De,Es).n64" size 33554432 crc FC37B06A md5 D31BB4EDFFDB35E5EC293A1154B2E844 sha1 29FA421E7732AB990178033BC8C979AEB8FE78D5 flags verified )
+	rom ( name "Donkey Kong 64 (E) [!].z64" size 33554432 crc A28C71C6 md5 118E9CE360B97A6F8DAB2C9F30660BF5 sha1 F96AF883845308106600D84E0618C1A066DC6676 )
 )
 
 game (
 	name "Donkey Kong 64 (Japan)"
 	description "Donkey Kong 64 (Japan)"
 	rom ( name "Donkey Kong 64 (Japan).n64" size 33554432 crc FBD001B9 md5 0E7EA5BAFF2F6A7FBE17164E97231619 sha1 429E7ACE2A68832345BFBB3BC3AADF3A7A505D7B flags verified )
+	rom ( name "Donkey Kong 64 (J) [!].z64" size 33554432 crc 919F7E74 md5 5B677F4BF93D6578252FCAD2C8CEB637 sha1 F0AD2B2BBF04D574ED7AFBB1BB6A4F0511DCD87D )
 )
 
 game (
@@ -1090,24 +1235,28 @@ game (
 	name "Donkey Kong 64 (USA) (Demo) (Kiosk)"
 	description "Donkey Kong 64 (USA) (Demo) (Kiosk)"
 	rom ( name "Donkey Kong 64 (USA) (Demo) (Kiosk).n64" size 33554432 crc 54BB87F6 md5 669A211FEA4EF38438947C1561124DF1 sha1 69127A8B8A0848CEECCD3712F3752EAB3F9143CD )
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [!].z64" size 33554432 crc C83DFA15 md5 98A5836E3A5DA7BD0B5819E7498ACEA2 sha1 B4717E602F07CA9BE0D4822813C658CD8B99F993 )
 )
 
 game (
 	name "Doom 64 (Europe)"
 	description "Doom 64 (Europe)"
 	rom ( name "Doom 64 (Europe).n64" size 8388608 crc 0227DB4B md5 B3850615885124F41E3011FE191AF3C0 sha1 1C863F00650FA5C4111F3CF0B972105EDFC970AB flags verified )
+	rom ( name "Doom 64 (E) [!].z64" size 8388608 crc D985C356 md5 190CCCA6526DC4A1F611E3B40F5131C0 sha1 B63060F69BB4E1547DA1D762E740D19393977055 )
 )
 
 game (
 	name "Doom 64 (Japan)"
 	description "Doom 64 (Japan)"
 	rom ( name "Doom 64 (Japan).n64" size 8388608 crc 95526F13 md5 042E4EBF2DB26B10EC8A22A3915C726A sha1 D7D8E5636839255FD1C324B9A27511917E3C454F flags verified )
+	rom ( name "Doom 64 (J) [!].z64" size 8388608 crc C8F3AF5B md5 06F15EF2228C1B1147C41DCCAA07D9DE sha1 6B0D65E62626A92AA59EE4BFF3F02715F6247692 )
 )
 
 game (
 	name "Doom 64 (USA)"
 	description "Doom 64 (USA)"
 	rom ( name "Doom 64 (USA).n64" size 8388608 crc 4DFB7CB6 md5 5A8684BC098428DD2A401F4CDAEE78DF sha1 B30F2B1B1CF70DC4B398BFF26F75EEDFF858540D flags verified )
+	rom ( name "Doom 64 (U) (V1.0) [!].z64" size 8388608 crc 5CC1ADE6 md5 B67748B64A2CC7EFD2F3AD4504561E0E sha1 799A588D73DA3FCCE8031026A8187DA92B91C817 )
 )
 
 game (
@@ -1121,24 +1270,28 @@ game (
 	name "Doraemon - Nobita to 3tsu no Seireiseki (Japan)"
 	description "Doraemon - Nobita to 3tsu no Seireiseki (Japan)"
 	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (Japan).n64" size 8388608 crc CAD0A2C2 md5 14A4BE756F6BD3BC3FF4B590D325DF58 sha1 A35B06DC974429DBD6CBF0712A4C170FD099748A flags verified )
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!].z64" size 8388608 crc 154E8B33 md5 C2166455E94E89E9E3AB612B4377C443 sha1 BBEB7B7A92A68B17CA72DCB9D7FB16F7B771C4F6 )
 )
 
 game (
 	name "Doraemon 2 - Nobita to Hikari no Shinden (Japan)"
 	description "Doraemon 2 - Nobita to Hikari no Shinden (Japan)"
 	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (Japan).n64" size 12582912 crc 2DE1A873 md5 AB09E0921B229AD6C673D512D1C279DE sha1 00A02647DE6760FA2CF1A2FFCAADA43703A8A98D flags verified )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!].z64" size 12582912 crc 0C1A0C38 md5 0580D96A71671C9E6972FDCF5897CC26 sha1 4B187360E1999556662C28B65DD179432EC61F9A )
 )
 
 game (
 	name "Doraemon 3 - Nobita no Machi SOS! (Japan)"
 	description "Doraemon 3 - Nobita no Machi SOS! (Japan)"
 	rom ( name "Doraemon 3 - Nobita no Machi SOS! (Japan).n64" size 16777216 crc 0B3AD913 md5 988E5C05E1976F0A50E670DCB6BB672C sha1 A567AA96860525963F9DAFA256036C0DF5F66909 flags verified )
+	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [!].z64" size 16777216 crc D3B68BE4 md5 A4A1D490BA67831775FC381B846E2168 sha1 DD9BA0F6CFC10C3B78401CC55D06AD534F39D5B1 )
 )
 
 game (
 	name "Doubutsu no Mori (Japan)"
 	description "Doubutsu no Mori (Japan)"
 	rom ( name "Doubutsu no Mori (Japan).n64" size 16777216 crc B9FCD0A6 md5 A6EF34BD225F22BBF737D61B839AE1B0 sha1 648B978895BC20256D48F763A72A8686F5CF549D flags verified )
+	rom ( name "Doubutsu no Mori (J) [!].z64" size 16777216 crc 9503E3F1 md5 A4F7C57C180297B2E7BA5A5FEB44FE0B sha1 E106DFF7146F72415337C96DEB14F630E1580EFB )
 )
 
 game (
@@ -1158,18 +1311,21 @@ game (
 	name "Dual Heroes (Europe)"
 	description "Dual Heroes (Europe)"
 	rom ( name "Dual Heroes (Europe).n64" size 12582912 crc 04064347 md5 8D9C55CD89894E24EA49FCAA6ADE1A22 sha1 7703976C4BEF912FEEB5B553FF913E8EF0DB8A60 flags verified )
+	rom ( name "Dual Heroes (E) [!].z64" size 12582912 crc 5A7E226B md5 F120FADB52B414EB4FB7D13092AC3CDB sha1 061B7956C3AADDDC6FDC11AAB885F95A71B7F463 )
 )
 
 game (
 	name "Dual Heroes (Japan)"
 	description "Dual Heroes (Japan)"
 	rom ( name "Dual Heroes (Japan).n64" size 12582912 crc A3565FFC md5 8DC1F2991FB430F2D18BD37F0242ED90 sha1 B36E4D8A19A50711B0423469DD43B954084FE36A flags verified )
+	rom ( name "Dual Heroes (J) [!].z64" size 12582912 crc 20F23DDE md5 E7652ED5CECEB5B1BC14495C58546D1C sha1 CFD5992BCC3E0D90966D8A6FC6E0813E75473B14 )
 )
 
 game (
 	name "Dual Heroes (USA)"
 	description "Dual Heroes (USA)"
 	rom ( name "Dual Heroes (USA).n64" size 12582912 crc 8968D989 md5 4F154F3490D35C0A6D38CB94FD842D0B sha1 AC48D0A10A26DE691976618D1D0CAEBF402F9123 )
+	rom ( name "Dual Heroes (U) [!].z64" size 12582912 crc D09F4DA8 md5 923D65E69F51858C697E0E5759CD038B sha1 8FD879CE53E211D33A689015A78CFF3FDD39DB09 )
 )
 
 game (
@@ -1183,18 +1339,21 @@ game (
 	name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta)"
 	description "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta)"
 	rom ( name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta).n64" size 20971520 crc 0829B87A md5 94C9052BF01F4A860C23C8D289841783 sha1 10CD84CEADD50DD7C5A06652BB1C203677644FB0 )
+	rom ( name "Lt. Duck Dodgers (Prototype).z64" size 20971520 crc 7291BA5B md5 4CCFF861AD2CFD65CC660F496C1D1664 sha1 D850517994081AB90AF79629DF86FD5BAEE616C5 )
 )
 
 game (
 	name "Duke Nukem - Zero Hour (Europe)"
 	description "Duke Nukem - Zero Hour (Europe)"
 	rom ( name "Duke Nukem - Zero Hour (Europe).n64" size 33554432 crc C2B3DF4D md5 006A02315DD24BF4418C070BA29052CB sha1 D90325D6AC785C94ED0A66469319F2164474A8A3 flags verified )
+	rom ( name "Duke Nukem - ZER0 H0UR (E) [!].z64" size 33554432 crc EA82F037 md5 86E98AACA0D90BF744DA090539BA4AD8 sha1 C18AD90FB889F95773FEF48C204CE06CFF9E6BE3 )
 )
 
 game (
 	name "Duke Nukem - Zero Hour (France)"
 	description "Duke Nukem - Zero Hour (France)"
 	rom ( name "Duke Nukem - Zero Hour (France).n64" size 33554432 crc 8FBF7447 md5 6F7B49C80B5C4A071F6A696C1DED3E60 sha1 1777E76DD3FF153373AE458E35A29188ED901082 )
+	rom ( name "Duke Nukem - ZER0 H0UR (F) [!].z64" size 33554432 crc 7ECDFB28 md5 E2B73FEB0843874EA831A2E0076FCB72 sha1 E69A4DDA8CCA88D4C149F2B00640DA0FF04FA9C8 )
 )
 
 game (
@@ -1208,12 +1367,14 @@ game (
 	name "Duke Nukem 64 (Europe)"
 	description "Duke Nukem 64 (Europe)"
 	rom ( name "Duke Nukem 64 (Europe).n64" size 8388608 crc 9817B026 md5 217D446A4A703533181878920BF95E76 sha1 3DA4E470DC928C62FD7E0C010B9EA413321C7824 flags verified )
+	rom ( name "Duke Nukem 64 (E) [!].z64" size 8388608 crc 3275ADB0 md5 8657CBA95C409B74C1F5632CBC36643F sha1 6CC06F6097F90228BD7D7784FA7D20BA17E82EEF )
 )
 
 game (
 	name "Duke Nukem 64 (France)"
 	description "Duke Nukem 64 (France)"
 	rom ( name "Duke Nukem 64 (France).n64" size 8388608 crc CBE8C78A md5 521C4E8444786C1FF6CF9BBC6D6FACB6 sha1 BF05F8EC1A1BB936F8CC4D32F0DEADA7355B16B1 )
+	rom ( name "Duke Nukem 64 (F).z64" size 8388608 crc B9C9F07A md5 E2E79C7167BDB26E176D220904739C91 sha1 2C48706C4280A51E52691331543606E4170A19A9 )
 )
 
 game (
@@ -1227,6 +1388,7 @@ game (
 	name "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)"
 	description "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 20C3ADAB md5 404B4CEDC5DCFF08D1580E9E98B7E5C7 sha1 C613B72369292BB8A16B395073F70C586E0FA65E flags verified )
+	rom ( name "Earthworm Jim 3D (E) (M6) [!].z64" size 16777216 crc 61A56330 md5 BF2DF4B86FAA2181A7ACFE2643FA2293 sha1 F02C1AFD18C1CBE309472CBE5B3B3F04B22DB7EE )
 )
 
 game (
@@ -1240,48 +1402,56 @@ game (
 	name "ECW Hardcore Revolution (Europe)"
 	description "ECW Hardcore Revolution (Europe)"
 	rom ( name "ECW Hardcore Revolution (Europe).n64" size 33554432 crc 2FAC2C41 md5 0B8F0BBC92DD58EF7B66B4862DE3CE70 sha1 8718A6E6C75BA0DB8D2266F5A2FB0361807AC988 flags verified )
+	rom ( name "ECW Hardcore Revolution (E) [!].z64" size 33554432 crc BE8FEEAD md5 1830EDE2557E8685E6F76D05CC65076A sha1 226CAD0C48E9E0D1DC928298518CA8B2D6EAE5ED )
 )
 
 game (
 	name "ECW Hardcore Revolution (USA)"
 	description "ECW Hardcore Revolution (USA)"
 	rom ( name "ECW Hardcore Revolution (USA).n64" size 33554432 crc 4BA40079 md5 2321D612F4B48262F4A65CBA8E631A07 sha1 8BC52EC9D4A66F4C7A8DD2349C5DA90AA2DD3684 )
+	rom ( name "ECW Hardcore Revolution (U) [!].z64" size 33554432 crc 36D368EF md5 8EEBB16B7A4D39AE8BC8CCCBC41F0A01 sha1 D460DC1EB24EF3E1E27C6B125C8C8D8324A64125 )
 )
 
 game (
 	name "Eikou no Saint Andrews (Japan)"
 	description "Eikou no Saint Andrews (Japan)"
 	rom ( name "Eikou no Saint Andrews (Japan).n64" size 8388608 crc CE55BB19 md5 619D71F98B53696347C497FA5AC0C7B1 sha1 1A313D3B4B11A16B8280B0139A15E47791C8080A flags verified )
+	( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
 )
 
 game (
 	name "Elmo's Letter Adventure (USA)"
 	description "Elmo's Letter Adventure (USA)"
 	rom ( name "Elmo's Letter Adventure (USA).n64" size 8388608 crc 710011FB md5 1FA1170F9D0C037DE32D27D9D9F7AFD7 sha1 4C8E68CC1C5AF546BC9AC26DE423458141346E2C )
+	rom ( name "Elmo's Letter Adventure (U) [!].z64" size 8388608 crc 92C3BA6F md5 15DF97A59B2354B130DEC3FB86BBA513 sha1 97777CA06F4E8AFF8F1E95033CC8D3833BE40F76 )
 )
 
 game (
 	name "Elmo's Number Journey (USA)"
 	description "Elmo's Number Journey (USA)"
 	rom ( name "Elmo's Number Journey (USA).n64" size 8388608 crc B7AD0F05 md5 76E81D17D5C88EE40A1C32ED20E17B92 sha1 72419FD0A80CBDEEA635F094D6B0D086EBBB2750 )
+	Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
 )
 
 game (
 	name "Eltale Monsters (Japan)"
 	description "Eltale Monsters (Japan)"
 	rom ( name "Eltale Monsters (Japan).n64" size 16777216 crc 3541C4BB md5 1FBA4E16A562610C98F823667E29DD6F sha1 36FC37E9EEC7157961E8ACCD9E40DA4134055669 )
+	rom ( name "Eltale Monsters (J) [!].z64" size 16777216 crc A4FE7652 md5 D42CC78A2BF0D34518B8E0D0439E432E sha1 50EA6C3D4DE4B68B3C9B77524D8177066B9F36E7 )
 )
 
 game (
 	name "Excitebike 64 (Europe)"
 	description "Excitebike 64 (Europe)"
 	rom ( name "Excitebike 64 (Europe).n64" size 16777216 crc 8FEEDE6F md5 84D3DEF8AC326830573C7703A4F1D321 sha1 2579188D81BFBD26557AD7034A2931CCEA72F84F flags verified )
+	rom ( name "Excitebike 64 (E) [!].z64" size 16777216 crc 0B881E60 md5 8FA253FD69B73DF9A831EF2F731491F2 sha1 5ABFB6024F935EF5FE0067F39FD594C50697C749 )
 )
 
 game (
 	name "Excitebike 64 (Japan)"
 	description "Excitebike 64 (Japan)"
 	rom ( name "Excitebike 64 (Japan).n64" size 16777216 crc 9DFEB099 md5 6B764C5DE8ABEA1483FE52F6E1468274 sha1 AD840FE563076BD600AD0AB3AD4433B3F1A72A4C flags verified )
+	rom ( name "Excitebike 64 (J) [!].z64" size 16777216 crc 03BFD065 md5 BF15A61AFF71C93BF5E05243F57BCA1D sha1 E2C8D01FC66C0A575E79CB338678F1FD065226D6 )
 )
 
 game (
@@ -1295,6 +1465,7 @@ game (
 	name "Excitebike 64 (USA) (Demo) (Kiosk)"
 	description "Excitebike 64 (USA) (Demo) (Kiosk)"
 	rom ( name "Excitebike 64 (USA) (Demo) (Kiosk).n64" size 16777216 crc 13157DF7 md5 2E53DB0E290F91430E6D87DD4123D402 sha1 7130FB444673842807A4C38D6F2E9505C8616A39 )
+	rom ( name "Excitebike 64 (U) (Kiosk Demo) [!].z64" size 16777216 crc BE6298B0 md5 E0018C33346714B63A55C0E040F23DEA sha1 DAAF564815E9EEF3FC163B9546B5880EE256274B )
 )
 
 game (
@@ -1307,66 +1478,77 @@ game (
 	name "Extreme-G (Europe) (En,Fr,De,Es,It)"
 	description "Extreme-G (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Extreme-G (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc 1BE8E42B md5 133FEFA13974BFB77236952D2421EE18 sha1 CC28FD3B6EB8DEFF86CCCA081EF78F93B63011F4 flags verified )
+	rom ( name "Extreme-G (E) (M5) [!].z64" size 8388608 crc 0B71B1EA md5 3B2CA0DA0810C95B31DF8C1FB8811BE2 sha1 E7120856ECC9A7F29C21F45130ECA0ECA8A7BFEC )
 )
 
 game (
 	name "Extreme-G (Japan)"
 	description "Extreme-G (Japan)"
 	rom ( name "Extreme-G (Japan).n64" size 8388608 crc 856227BB md5 7F6270B7D776B117F1607C6B6F618FED sha1 AFB26291E828E049E6913F88FC11F28D097057BF flags verified )
+	rom ( name "Extreme-G (J) [!].z64" size 8388608 crc 750DC9A7 md5 A7CD65E5A4A8838D1CD452BA66E74DF6 sha1 D9D6F7CC456B530FD3233EF2D8D6B9F845CEE043 )
 )
 
 game (
 	name "Extreme-G (USA)"
 	description "Extreme-G (USA)"
 	rom ( name "Extreme-G (USA).n64" size 8388608 crc A43A0B17 md5 3F55D4E4E4A851D03BDD1667FB3EAB3A sha1 3544A3779AF1B7BCA0C03E2298AAD0ACBB3C0B2A )
+	rom ( name "Extreme-G (U) [!].z64" size 8388608 crc 04CB74EC md5 3E660D3F991C0529E90BFEC0244DB31A sha1 EB9B273431970A6124319A8FD125F0B2CACD8966 )
 )
 
 game (
 	name "Extreme-G XG2 (Europe) (En,Fr,De,Es,It)"
 	description "Extreme-G XG2 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Extreme-G XG2 (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 32FC980C md5 FD1FEB895801C0076EEE07C4DD07A1B5 sha1 3076CD1E025AEBC6168C0F33FCB215106F519DD3 flags verified )
+	rom ( name "Extreme-G XG2 (E) (M5) [!].z64" size 12582912 crc 1A57F416 md5 BB7F98E657FB4B5FCC7DC04BD72E2D2B sha1 CA6DB450D29A6CC0D4A6FBB3468A1ED725CEF51E )
 )
 
 game (
 	name "Extreme-G XG2 (Japan)"
 	description "Extreme-G XG2 (Japan)"
 	rom ( name "Extreme-G XG2 (Japan).n64" size 12582912 crc 62202D15 md5 717BE4FE42147C468F0E3F4E1820EF74 sha1 769E78EFAE2164CE03441DCDF5B2A2849F15F281 flags verified )
+	rom ( name "Extreme-G XG2 (J) [!].z64" size 12582912 crc 7C8A36DA md5 F17884A2C16FB6FD11A74D65B1388B4A sha1 94EFB5D7247A075A9CC782D39B5E8AF56D5F434F )
 )
 
 game (
 	name "Extreme-G XG2 (USA)"
 	description "Extreme-G XG2 (USA)"
 	rom ( name "Extreme-G XG2 (USA).n64" size 12582912 crc 849C18CE md5 335CE3973AE33C062C92825D8DF083D7 sha1 E27268A708B6D6A707B6E01AF94D062EA9CBC26D )
+	rom ( name "Extreme-G XG2 (U) [!].z64" size 12582912 crc 81A4C28B md5 44FE06BA3686C02A7988F27600A533DA sha1 ED0A50086EF9A89F5B445C20AB6F365165959630 )
 )
 
 game (
 	name "F-1 World Grand Prix (Europe)"
 	description "F-1 World Grand Prix (Europe)"
 	rom ( name "F-1 World Grand Prix (Europe).n64" size 12582912 crc 8C08A7A8 md5 151BC850C8078A6DC78001D2E690D32A sha1 359E4B83246BCA7F377ECFC97291F297012FEBCC )
+	rom ( name "F-1 World Grand Prix (E) [!].z64" size 12582912 crc BEBBC6C8 md5 9FBE3363DA6C146EF2E29605BCA834FF sha1 63BD69C382ECA5E569EDDF7456F6435A7DCE484F )
 )
 
 game (
 	name "F-1 World Grand Prix (France)"
 	description "F-1 World Grand Prix (France)"
 	rom ( name "F-1 World Grand Prix (France).n64" size 12582912 crc 02E9695D md5 93C9511ACFC2804CFC786CE9D849B51E sha1 40CA54DB3858AD04B328F741A79CAEF2BBD02873 )
+	rom ( name "F-1 World Grand Prix (F) [!].z64" size 12582912 crc 57CD299D md5 35F6C42D5A9284688284C24250F4D6BE sha1 DD68B3624F2F8A0F821A391B690ECC5BB4FEF2FD )
 )
 
 game (
 	name "F-1 World Grand Prix (Germany)"
 	description "F-1 World Grand Prix (Germany)"
 	rom ( name "F-1 World Grand Prix (Germany).n64" size 12582912 crc 7D8DDEFB md5 2511E6CEAB2E827E2E892BCA05BDB04F sha1 BA7A94D3CECE240276C294C2FF29AC93C59BD939 flags verified )
+	rom ( name "F-1 World Grand Prix (G) [!].z64" size 12582912 crc 0F1984DC md5 A8C78454C70BD73375AAF69C4078D5DA sha1 2AE85DB9D6E9F3B85E4478577D5EB049EC4040C9 )
 )
 
 game (
 	name "F-1 World Grand Prix (Japan)"
 	description "F-1 World Grand Prix (Japan)"
 	rom ( name "F-1 World Grand Prix (Japan).n64" size 12582912 crc 386E127D md5 8E4D9125B040019478DE77CF36729ED0 sha1 932CA3DDD3A6B4E4C1F7A1A1F9A77E14A009A6C0 flags verified )
+	rom ( name "F-1 World Grand Prix (J) [!].z64" size 12582912 crc F7BACBC3 md5 F248F0AAE609111BA9DFF9FD7AFBC485 sha1 595BFA62EC34F7884FF46137C92771CDE4D8D6FE )
 )
 
 game (
 	name "F-1 World Grand Prix (USA)"
 	description "F-1 World Grand Prix (USA)"
 	rom ( name "F-1 World Grand Prix (USA).n64" size 12582912 crc 4D203242 md5 82DCD2B311352AD9B571089AFF6B6171 sha1 CA05633242B31E3EC808945E9AFEAFC2FE4DE652 )
+	rom ( name "F-1 World Grand Prix (U) [!].z64" size 12582912 crc 7DC9EF2C md5 A81B1DE864DF3F4BB0903760BE673F21 sha1 DD17545ADC8FE2AF2A713AB48C5F71801222EDAF )
 )
 
 game (
@@ -1379,18 +1561,21 @@ game (
 	name "F-1 World Grand Prix II (Europe) (En,Fr,De,Es)"
 	description "F-1 World Grand Prix II (Europe) (En,Fr,De,Es)"
 	rom ( name "F-1 World Grand Prix II (Europe) (En,Fr,De,Es).n64" size 12582912 crc 484C801D md5 664CC372586A1AD7D1B15C1008E41470 sha1 E8E598CCD19011539E815C01131539649C3EA8DA flags verified )
+	rom ( name "F-1 World Grand Prix II (E) (M4) [!].z64" size 12582912 crc 803D33DF md5 BC0FD2468AC7769A37C3C58CD5699585 sha1 53ED343A757B8A14814732393D02B3D780BCCAB5
 )
 
 game (
 	name "F-Zero X (Europe)"
 	description "F-Zero X (Europe)"
 	rom ( name "F-Zero X (Europe).n64" size 16777216 crc 3D95DF80 md5 7B2D9E24E6535BE213BA036EFE618E31 sha1 6108DD6D6D65E1440535AAD43CAFF99C2E886340 flags verified )
+	rom ( name "F-ZERO X (E) [!].z64" size 16777216 crc 2D6F7E8B md5 EE79A8FE287B5DCAEA584439363342FC sha1 AF9038BCB543A2B4FAAAB876DBDAB4663859E092 )
 )
 
 game (
 	name "F-Zero X (Japan)"
 	description "F-Zero X (Japan)"
 	rom ( name "F-Zero X (Japan).n64" size 16777216 crc 927387B6 md5 60297B40A16AC569DEE8659062B08B7F sha1 AAD380CE474A19D3823AEAAAD3594AB0EDD47F97 flags verified )
+	rom ( name "F-ZERO X (J) [!].z64" size 16777216 crc 6B1CEF83 md5 58D200D43620007314304F4E6C9E6528 sha1 A418B0151521B76691FA03F8658C8B567C69498B )
 )
 
 game (
@@ -1404,18 +1589,21 @@ game (
 	name "F1 Pole Position 64 (Europe) (En,Fr,De)"
 	description "F1 Pole Position 64 (Europe) (En,Fr,De)"
 	rom ( name "F1 Pole Position 64 (Europe) (En,Fr,De).n64" size 8388608 crc EC8B6DB6 md5 809E19E2AB5606D9F3AD23D55F610F0D sha1 DFA0FAC4E42E6426A8213101807EC445D752934F flags verified )
+	rom ( name "F-1 Pole Position 64 (E) (M3) [!].z64" size 8388608 crc ED750623 md5 A6BD93EA576CDF8569F68171452F7E8A sha1 685FEB2E8615D5D50944093EB0552858D3E12583 )
 )
 
 game (
 	name "F1 Pole Position 64 (USA) (En,Fr,De)"
 	description "F1 Pole Position 64 (USA) (En,Fr,De)"
 	rom ( name "F1 Pole Position 64 (USA) (En,Fr,De).n64" size 8388608 crc 873BC45A md5 EA2A94D17B1513D08C0A69E277275523 sha1 BBC6CA8FE4C5BDB77D9963696BA8BF8E46FB39A6 )
+	rom ( name "F-1 Pole Position 64 (U) (M3) [!].z64" size 8388608 crc 30A24D89 md5 049DB657F4223D949F56E9DC5B6A9180 sha1 6E6BDAEFC9980F066CD2ABC5FA7F29F2353CA8B1 )
 )
 
 game (
 	name "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
 	description "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
 	rom ( name "F1 Racing Championship (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 0605E5AC md5 00898329C43A045521C609858CC590A9 sha1 9C13ED6322A45772EA881BE821C22F5157AA895A flags verified )
+	rom ( name "F1 Racing Championship (E) (M5) [!].z64" size 16777216 crc 2DA744F5 md5 9581FC6CEAC86DC8A2AEE4053043E422 sha1 3BCE20F58EF9F377299858B7F2DABD0A02D2E9B9 )
 )
 
 game (
@@ -1428,48 +1616,56 @@ game (
 	name "Famista 64 (Japan)"
 	description "Famista 64 (Japan)"
 	rom ( name "Famista 64 (Japan).n64" size 12582912 crc 51E0B88A md5 B07C622062E20E3878B8CE48EDC003AB sha1 C14270956393834DA8F670668155C41AF34AF7A9 flags verified )
+	rom ( name "Famista 64 (J) [!].z64" size 12582912 crc 9FB0E6C9 md5 D99B1A3F6D72DEFD76F3620959B94944 sha1 F4ACB365C8A0DFFDF2E93A726FD5E805AB857C56 )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)"
 	description "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)"
 	rom ( name "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).n64" size 12582912 crc 2D49F99A md5 2A9C172F12CD6ACB941911C22FEF75C8 sha1 12A12C3B5ABA1307D947EA7F72246497755B5482 flags verified )
+	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [!].z64" size 12582912 crc 137CB3CC md5 26B18D35984528AE2F90ADBB2F2642F7 sha1 676B4D14AD74CCC92EE4B19AA9130DDCE42E0E9C )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)"
 	description "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)"
 	rom ( name "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).n64" size 12582912 crc 9504B3DF md5 73AEDBD8AB7FE0AE842F3BD70F77ADC2 sha1 7DEB782823B8D14496CE9843384281D07CC814FC flags verified )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [!].z64" size 12582912 crc 28B1221C md5 2C6D146A8473511CFCFBBE8518F49D71 sha1 148D6424D2135AFEFECDE74092701C491027C23E )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)"
 	description "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)"
 	rom ( name "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).n64" size 12582912 crc 6AE6B8ED md5 848C6DF3382206C6FC385362E6524139 sha1 83A86CE813E7DBB5C7D80B567F35FCA7E742F8BA flags verified )
+	rom ( name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!].z64" size 12582912 crc AE346DF6 md5 3611779F29997267622CBC80E2D087CC sha1 D8A0C9EF8FF258D061A639E7572D0D9E3038A895 )
 )
 
 game (
 	name "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	description "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	rom ( name "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" size 16777216 crc CE258860 md5 ED490E6C55C665207562BD6DEFCF8973 sha1 EAB12CC33BD12923C022D2336C3B8A1001132137 flags verified )
+	rom ( name "FIFA 99 (E) (M8) [!].z64" size 16777216 crc 6EAE1E6E md5 6432C622C05EA9CD3217E280AC2CE37C sha1 07400C53AEF501887F73EF6A45CE04FE2F170FB0 )
 )
 
 game (
 	name "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	description "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	rom ( name "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" size 16777216 crc D69DD3D1 md5 E7A508B8E27CFEF334E96DE549E385D3 sha1 5A085F6D871FB697A672F56B4023CF3B822E4CF9 )
+	rom ( name "FIFA 99 (U) [!].z64" size 16777216 crc 6B2473A9 md5 148DE3073727B9FD156F10AFADD46864 sha1 735062E593715F128D3AAD435DE0E7A899AED127 )
 )
 
 game (
 	name "FIFA Soccer 64 (Europe) (En,Fr,De)"
 	description "FIFA Soccer 64 (Europe) (En,Fr,De)"
 	rom ( name "FIFA Soccer 64 (Europe) (En,Fr,De).n64" size 8388608 crc 26F52456 md5 746AD640A23A9A4B2A8D84D05B962799 sha1 6D2F25B4D87E8DDCD8AF34831CD5952552B11F3C flags verified )
+	rom ( name "FIFA Soccer 64 (E) (M3) [!].z64" size 8388608 crc AE2583FB md5 9A7006212947EE7648EE1D13162E55E0 sha1 EACDF23E27EC1E0639042BF03804222851E4F151 )
 )
 
 game (
 	name "FIFA Soccer 64 (USA) (En,Fr,De)"
 	description "FIFA Soccer 64 (USA) (En,Fr,De)"
 	rom ( name "FIFA Soccer 64 (USA) (En,Fr,De).n64" size 8388608 crc 3B22F9F2 md5 1F7BA149359B4C402E41C40FD68EC174 sha1 A27A2BA02BB02EAAC999E60E3CEDD67FB937B580 )
+	rom ( name "FIFA Soccer 64 (U) (M3) [!].z64" size 8388608 crc 57DE7CAB md5 CC7C58A032AABA19E72CCBFA6B3EEFF6 sha1 603C5BF64497DCA86C4EB802F97F1C32E75A68A8 )
 )
 
 game (
@@ -1483,18 +1679,21 @@ game (
 	name "Fighters Destiny (Europe)"
 	description "Fighters Destiny (Europe)"
 	rom ( name "Fighters Destiny (Europe).n64" size 12582912 crc 83F9299E md5 1031918EB48CE51D0EE0F457AF9A4D41 sha1 AD18A0144137ED61012363F7E810548E7CEAA934 flags verified )
+	rom ( name "Fighter's Destiny (E) [!].z64" size 12582912 crc C9225511 md5 EF5CB24CE3FE4E0F850901205437B574 sha1 2763731085A9D86D357D8FEF775C2D21D3C9F2B4 )
 )
 
 game (
 	name "Fighters Destiny (France)"
 	description "Fighters Destiny (France)"
 	rom ( name "Fighters Destiny (France).n64" size 12582912 crc 80D968B1 md5 D0BF413496BD4D48EE0A944ECC8D6930 sha1 3EF0546BFFC49807C4C00AC7C06CA72F5A787C29 )
+	rom ( name "Fighter's Destiny (F) [!].z64" size 12582912 crc 0CC22034 md5 44B0BE1C4B48F6119D3AC9424903D0EB sha1 28C6486F4036295284A022B6D70D3BC2F64B20E8 )
 )
 
 game (
 	name "Fighters Destiny (Germany)"
 	description "Fighters Destiny (Germany)"
 	rom ( name "Fighters Destiny (Germany).n64" size 12582912 crc 0A89CA02 md5 96C8D4DD7EC9EADB01964FCABB98490B sha1 4317A5CB4ADA2D73D752FDC6C962ADE147953CF6 flags verified )
+	rom ( name "Fighter's Destiny (G) [!].z64" size 12582912 crc 5052168C md5 1CF379ACA2397222AF9F3DC5D8E3C444 sha1 AEF7792324C262C956E91EE01F57BED0C36BD825 )
 )
 
 game (
@@ -1508,12 +1707,14 @@ game (
 	name "Fighting Cup (Japan)"
 	description "Fighting Cup (Japan)"
 	rom ( name "Fighting Cup (Japan).n64" size 12582912 crc A9740235 md5 9BBF2CEB75411BFDF139D8DFBF99CA96 sha1 55F3E6E3C9FDCF0278FA494A798316600D9DB4D4 flags verified )
+	rom ( name "Fighting Cup (J) [!].z64" size 12582912 crc 8A1C261E md5 722C3A74A90305D6079A37994CEBF5B2 sha1 011BDBAA1BC6D6A5540A749CF1A90BF6A35FD94B )
 )
 
 game (
 	name "Fighting Force 64 (Europe)"
 	description "Fighting Force 64 (Europe)"
 	rom ( name "Fighting Force 64 (Europe).n64" size 16777216 crc 8D0CB2FF md5 A3BEC94D91F24DBEA7290FF0DAF92F5C sha1 0E55DB7874B9259622F54AA9B36247DB87373E58 flags verified )
+	rom ( name "Fighting Force 64 (E) [!].z64" size 16777216 crc 4052C176 md5 0035E8205336982E362402AAEA37D147 sha1 705D2B553FAB526C908E46C048BE3A3338AE2A86 )
 )
 
 game (
@@ -1527,6 +1728,7 @@ game (
 	name "Flying Dragon (Europe)"
 	description "Flying Dragon (Europe)"
 	rom ( name "Flying Dragon (Europe).n64" size 12582912 crc 00FFF973 md5 73C88384B597B0CC667F353DFAE12B79 sha1 FA71BADA5055FCDA27899D8F165224B737DC8449 flags verified )
+	rom ( name "Flying Dragon (E) [!].z64" size 12582912 crc C3066E59 md5 ADD115AAD0AB7D33BFD243936D809178 sha1 3F4462D85D5B5DDC6EDAEEF45B682EEFF7F4B144 )
 )
 
 game (
@@ -1540,12 +1742,14 @@ game (
 	name "Forsaken 64 (Europe) (En,Fr,Es,It)"
 	description "Forsaken 64 (Europe) (En,Fr,Es,It)"
 	rom ( name "Forsaken 64 (Europe) (En,Fr,Es,It).n64" size 8388608 crc 6C65EF7A md5 58A15FB343C7A2A4BB091D9585A1A99F sha1 5B6A661F75F9E3560238ACF6DFCD4287E75586C0 flags verified )
+	rom ( name "Forsaken 64 (E) (M4) [!].z64" size 8388608 crc 5ED736D9 md5 8286DED701DFA22436D311BD5B93BD29 sha1 AC24C6E48FCD03C32AEF484188BA842B619FF613 )
 )
 
 game (
 	name "Forsaken 64 (Germany)"
 	description "Forsaken 64 (Germany)"
 	rom ( name "Forsaken 64 (Germany).n64" size 8388608 crc C3FA1B8E md5 E39D59320CFE31F04AC575ABFDF21840 sha1 46E2A07B805F06E04FB4DC6934EAA0EBCCC81F76 )
+	rom ( name "Forsaken 64 (G) [!].z64" size 8388608 crc 9793ABC2 md5 74650F7154E0B2DD7C364F511B0D6A77 sha1 F1BE08780D117C44FC10A0DBA792D6C5BE7D4093 )
 )
 
 game (
@@ -1559,6 +1763,7 @@ game (
 	name "Fox Sports College Hoops '99 (USA)"
 	description "Fox Sports College Hoops '99 (USA)"
 	rom ( name "Fox Sports College Hoops '99 (USA).n64" size 12582912 crc FEDE3EF8 md5 D468CAF0AAB6D1C9607B69AD1BAD1824 sha1 86D16B039ABE70BC5B8B16805DD48483477FBDF6 )
+	rom ( name "Fox Sports College Hoops '99 (U) [!].z64" size 12582912 crc 67EAF0F3 md5 360DC6BE6D06DCA12E53C077AC0D2571 sha1 A8CE01A7D6D01BE19FFB87CB54CC069494EFB596 )
 )
 
 game (
@@ -1577,72 +1782,85 @@ game (
 	name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)"
 	description "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)"
 	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).n64" size 33554432 crc AF0A22EF md5 E520452C07479FA6A059346919340764 sha1 A50EF01EC653ED48A2B857FE2834D815CBD8E972 flags verified )
+	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!].z64" size 33554432 crc 2AA6D2A1 md5 BBCDE4966BEE5602A80D9B8C1011DFA6 sha1 F97B070A1FA6AB3D190B36D6B68A2EF182D35233 )
 )
 
 game (
 	name "G.A.S.P!! Fighters' NEXTream (Europe)"
 	description "G.A.S.P!! Fighters' NEXTream (Europe)"
 	rom ( name "G.A.S.P!! Fighters' NEXTream (Europe).n64" size 12582912 crc B0D256B8 md5 139A72A1EBFD224924F72747695C2945 sha1 FF187A9A1F357796528CA98E0B15EC227DF8A659 flags verified )
+	rom ( name "G.A.S.P!! Fighter's NEXTream (E) [!].z64" size 12582912 crc 5AA63B04 md5 316C59DAE45C20250A0419A937E7D65B sha1 B069F2C0B6AB4FBD486861C4D3AAF8A149AB4529 )
 )
 
 game (
 	name "G.A.S.P!! Fighters' NEXTream (Japan)"
 	description "G.A.S.P!! Fighters' NEXTream (Japan)"
 	rom ( name "G.A.S.P!! Fighters' NEXTream (Japan).n64" size 12582912 crc 0E05EA3A md5 A34A1FD0BFD7E2E18696370AFC642273 sha1 743673180188DFEE89F36C76602C1A75DF51716E flags verified )
+	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [!].z64" size 12582912 crc 6EAD2D89 md5 6C73558DE5A1EEE6597D7264F9A11B0C sha1 86693E6C1623708438EBF23AB0E78DD6EA8C8FA7 )
 )
 
 game (
 	name "GameBooster 64 (Europe) (v1.1) (Unl)"
 	description "GameBooster 64 (Europe) (v1.1) (Unl)"
 	rom ( name "GameBooster 64 (Europe) (v1.1) (Unl).n64" size 262144 crc 35B99BD9 md5 1A56FE2B2FE339C7DD4FF8D37EC8654B sha1 D79EE0482443C046B9E865A78F3D4507B7478AF4 )
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl).z64" size 262144 crc 35B99BD9 md5 1A56FE2B2FE339C7DD4FF8D37EC8654B sha1 D79EE0482443C046B9E865A78F3D4507B7478AF4 )
 )
 
 game (
 	name "GameBooster 64 (USA) (v1.1) (Unl)"
 	description "GameBooster 64 (USA) (v1.1) (Unl)"
 	rom ( name "GameBooster 64 (USA) (v1.1) (Unl).n64" size 262144 crc E0B8EDAE md5 60D0264B38E22EF0D6B9549E4C81C29F sha1 5D0F244584D6CC0B0CED714409412F61DE181E57 )
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl).z64" size 262144 crc E0B8EDAE md5 60D0264B38E22EF0D6B9549E4C81C29F sha1 5D0F244584D6CC0B0CED714409412F61DE181E57 )	
 )
 
 game (
 	name "GameShark Pro (USA) (v2.0) (Unl)"
 	description "GameShark Pro (USA) (v2.0) (Unl)"
 	rom ( name "GameShark Pro (USA) (v2.0) (Unl).n64" size 262144 crc EF9EDF87 md5 437EFD7FD7F84F4C0F802D3BF1F8464E sha1 19148A009EF8E1013AB35C8141781184B141699F )
+	rom ( name "GameShark Pro V2.0 (Unl).z64" size 262144 crc EF9EDF87 md5 437EFD7FD7F84F4C0F802D3BF1F8464E sha1 19148A009EF8E1013AB35C8141781184B141699F )
 )
 
 game (
 	name "GameShark Pro (USA) (v3.3) (Unl)"
 	description "GameShark Pro (USA) (v3.3) (Unl)"
 	rom ( name "GameShark Pro (USA) (v3.3) (Unl).n64" size 262144 crc 7CC07BBC md5 9F556D184D945369DDD11B5F815814A8 sha1 3B5046AE8129FD226EB7B02BC2C26CC7548FE6F2 )
+	rom ( name "GameShark Pro V3.3 (Mar 2000) (Unl) [!].z64" size 262144 crc 7CC07BBC md5 9F556D184D945369DDD11B5F815814A8 sha1 3B5046AE8129FD226EB7B02BC2C26CC7548FE6F2 )
+	rom ( name "GameShark Pro V3.3 (Apr 2000) (Unl) [!].z64" size 262144 crc F1851EBD md5 F275A4216744D8F04B4A0CD74DE53111 sha1 5D1E4CA8DD158AD72A6E7FCFB651F854F087FFDE )
 )
 
 game (
 	name "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)"
 	description "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)"
 	rom ( name "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).n64" size 16777216 crc 163C3C51 md5 624742B506DF9FF5C2D86D649EB8F3FB sha1 D8EE4E745BAE3625826FF267DA5404B42F36C3C2 flags verified )
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!].z64" size 16777216 crc 08C41E0E md5 96CA36D474E82C270A129D775C63167A sha1 2AB71B71665A688D40832E16D897548ECE9F0DD4 )
 )
 
 game (
 	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)"
 	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)"
 	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).n64" size 16777216 crc 69964858 md5 9704B99F5F86879C0482D7223257DCEF sha1 B6386455C0B8F573E315976BBB47548CBAFCEDB3 flags verified )
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J).z64" size 16777216 crc 2E91EFC9 md5 9B929E0BF8D63E62820F2FA6257CC5CF sha1 9843EE979B5F6C80F5EDA85DF0BAED9AE7C4E73B )
 )
 
 game (
 	name "Ganbare! Nippon! Olympics 2000 (Japan)"
 	description "Ganbare! Nippon! Olympics 2000 (Japan)"
 	rom ( name "Ganbare! Nippon! Olympics 2000 (Japan).n64" size 12582912 crc 1C7E5D6E md5 2954FCA21D60748834893EFF5BF8F961 sha1 FF7721BEA55F0447E5EB84F5583BBB67DE1348D3 flags verified )
+	rom ( name "Ganbare Nippon! Olympics 2000 (J) [!].z64" size 12582912 crc 73133CD2 md5 8D8F3A8393F3F5489B3B144369565594 sha1 F683446894A704DF016B90CC3409ECDB70CBA0AA )
 )
 
 game (
 	name "Gauntlet Legends (Europe)"
 	description "Gauntlet Legends (Europe)"
 	rom ( name "Gauntlet Legends (Europe).n64" size 16777216 crc D9F765AD md5 FDBB62DE0864236733FADE8BF18F2AB8 sha1 E659120EBDE6FE00DA6815D0E10360D7A0652557 flags verified )
+	rom ( name "Gauntlet Legends (E) [!].z64" size 16777216 crc B7B3A489 md5 28C2108A375F7731E719333A09439D2F sha1 29f19e0405dca66c7383fb94104a22758a9d06dd )
 )
 
 game (
 	name "Gauntlet Legends (Japan)"
 	description "Gauntlet Legends (Japan)"
 	rom ( name "Gauntlet Legends (Japan).n64" size 16777216 crc 1F3A1912 md5 0B185F16670731A63EAC6CF7BFFE64AA sha1 C7938E334F9FA10004355F7163D5A7F3B80D981D flags verified )
+	rom ( name "Gauntlet Legends (U) [!].z64" size 16777216 crc 64765E82 md5 9CB963E8B71F18568F78EC1AF120362E sha1 0489DCCE749C6A5102681D288ED0616A4B94E99D )
 )
 
 game (
@@ -1656,18 +1874,21 @@ game (
 	name "Getter Love!! Cho Renai Party Game (Japan)"
 	description "Getter Love!! Cho Renai Party Game (Japan)"
 	rom ( name "Getter Love!! Cho Renai Party Game (Japan).n64" size 12582912 crc BBD2AE37 md5 22F83FF238790D2455CB0A155D2A4F61 sha1 17507AFA02AEC34FE3AF3077EF60A4A990626160 flags verified )
+	rom ( name "Getter Love!! (J) [!].z64" size 12582912 crc 724ECAE7 md5 5270D98F9E67DC7EF354ECE109C2A18F sha1 942D161ABF00B612486388EEE98A2C51FC990147 )
 )
 
 game (
 	name "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)"
 	description "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)"
 	rom ( name "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).n64" size 33554432 crc 1110CC22 md5 EC10D3D8A602BBB4D7DB942B4B53CD10 sha1 1071D9CDE1DEDD1F44AEC60CAB40703643094D33 flags verified )
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!].z64" size 33554432 crc 6BC4A056 md5 9F0492A34D7A2D7C4E9F29DC1848A04A sha1 54653BA26A12521CCD886212FFFDF2F6427C2FEA )
 )
 
 game (
 	name "Gex 3 - Deep Cover Gecko (Europe) (Fr,De)"
 	description "Gex 3 - Deep Cover Gecko (Europe) (Fr,De)"
 	rom ( name "Gex 3 - Deep Cover Gecko (Europe) (Fr,De).n64" size 33554432 crc D169E9F8 md5 19B3E60F53AE174321A9C410C076CBB2 sha1 EE133817A0AC2D0BE0F0EF8AA343F83E70704ACC flags verified )
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!].z64" size 33554432 crc A43CB8E4 md5 43B9A7A5CCB6EA3F4860F9F80D73669D sha1 4BCD958526D9145ACF4E3EE7EE484E62DC1BB4BA )	
 )
 
 game (
@@ -1681,6 +1902,7 @@ game (
 	name "Gex 64 - Enter the Gecko (Europe)"
 	description "Gex 64 - Enter the Gecko (Europe)"
 	rom ( name "Gex 64 - Enter the Gecko (Europe).n64" size 16777216 crc 3E20EAFD md5 3429FE82DF66192EDDB2844C81BA49B1 sha1 B802DFC2015BD7F944A9633AC06C96F68001C0A8 flags verified )
+	rom ( name "Gex 64 - Enter the Gecko (E) [!].z64" size 16777216 crc A7C92BEA md5 5BBA457E286D250101CE274E0E58080D sha1 C5318E2660FED61782BB170E780B89305AA8C3DC )
 )
 
 game (
@@ -1694,6 +1916,7 @@ game (
 	name "Glover (Europe) (En,Fr,De)"
 	description "Glover (Europe) (En,Fr,De)"
 	rom ( name "Glover (Europe) (En,Fr,De).n64" size 8388608 crc 93DAE2A0 md5 6DBB99C1A623D31F7C7954873D63EFD3 sha1 D61D03147A0F88136DD3FEF4E934FA8C8BD96BC1 flags verified )
+	rom ( name "Glover (E) (M3) [!].z64" size 8388608 crc 90ECEB4A md5 2F2163C53DB135792331DF00398B3F87 sha1 A5209925761C4EF08E5D446A55BC957505308A31 )
 )
 
 game (
@@ -1725,6 +1948,7 @@ game (
 	name "Goemon - Mononoke Sugoroku (Japan)"
 	description "Goemon - Mononoke Sugoroku (Japan)"
 	rom ( name "Goemon - Mononoke Sugoroku (Japan).n64" size 16777216 crc F6BACBAC md5 6444C04AA9A4E176120FBBEE2B2DFBFD sha1 FBB8C3D20023AB13DC8EB95A23F10D8E1063D86B flags verified )
+	rom ( name "Ganbare Goemon - Mononoke Sugoroku (J) [!].z64" size 16777216 crc 965C4575 md5 2BDE49F2855030DE342976C9A95B81B3 sha1 ACCC27A72E9BD8BCAC011009A08DF7F7AAE3B2FE )
 )
 
 game (
@@ -1738,30 +1962,35 @@ game (
 	name "Golden Nugget 64 (USA)"
 	description "Golden Nugget 64 (USA)"
 	rom ( name "Golden Nugget 64 (USA).n64" size 8388608 crc 9670A4B7 md5 D6949657C4A42A35684F4C447A9FF294 sha1 543310E808DEC437A0E499410A9C39694430A7C7 )
+	rom ( name "Golden Nugget 64 (U) [!].z64" size 8388608 crc 641885DF md5 E048C2FE226634F039882C35A2A4EEA9 sha1 D64494A450B8569C4AA42390D2EAD651B407019D )
 )
 
 game (
 	name "GT64 - Championship Edition (Europe) (En,Fr,De)"
 	description "GT64 - Championship Edition (Europe) (En,Fr,De)"
 	rom ( name "GT64 - Championship Edition (Europe) (En,Fr,De).n64" size 12582912 crc B06D0D85 md5 15166FA77D606D98E6AB6A238DCECD12 sha1 A2016364DDE65EC5746BAB9710BD4FA72DA25485 flags verified )
+	rom ( name "GT 64 - Championship Edition (E) (M3) [!].z64" size 12582912 crc 6DFB4747 md5 628AA3CD492559B705488F634797E045 sha1 A4D0D694F521CEF69F64ACAEE3EB420A64F28E4D )
 )
 
 game (
 	name "GT64 - Championship Edition (USA)"
 	description "GT64 - Championship Edition (USA)"
 	rom ( name "GT64 - Championship Edition (USA).n64" size 12582912 crc B6DC4CFD md5 15AE9E64114F87DE8ADABD5A24CA8A2F sha1 BBF4039865FDCF30E403A45478DC6C8450944512 )
+	rom ( name "GT 64 - Championship Edition (U) [!].z64" size 12582912 crc BC627DA7 md5 FE81AA381719FADA693D803BAE7D5EB9 sha1 B941246AF78748F4E081F496DAC0A9E2056D3D8D )
 )
 
 game (
 	name "Hamster Monogatari 64 (Japan)"
 	description "Hamster Monogatari 64 (Japan)"
 	rom ( name "Hamster Monogatari 64 (Japan).n64" size 12582912 crc 689191C6 md5 B9B21D064BB9572F25EFBDD03DE7DFAF sha1 0460DE6B25D40CA4F8D7C4AF671C736F029812F6 flags verified )
+	rom ( name "Hamster Monogatari 64 (J) [!].z64" size 12582912 crc C1D98B78 md5 3D4C7B11076BAFA4620BCC154C0EEEF3 sha1 436627174830FB9941BD4F25EFA6FA1024498A97 )
 )
 
 game (
 	name "Harukanaru Augusta - Masters '98 (Japan)"
 	description "Harukanaru Augusta - Masters '98 (Japan)"
 	rom ( name "Harukanaru Augusta - Masters '98 (Japan).n64" size 16777216 crc AD4720E2 md5 810F6A925AA08746ABF7DFB5655D8CF4 sha1 CA7BCAE17E76880D3853C96E842DB4EE0538630D flags verified )
+	rom ( name "Harukanaru Augusta Masters 98 (J) [!].z64" size 16777216 crc 51228F0C md5 A02A4FB4B93E9847348440652CEF8D4D sha1 08AF498BCA98C79E3FA18C9C860091D5EB952E6E )
 )
 
 game (
@@ -1775,48 +2004,56 @@ game (
 	name "Heiwa Pachinko World 64 (Japan)"
 	description "Heiwa Pachinko World 64 (Japan)"
 	rom ( name "Heiwa Pachinko World 64 (Japan).n64" size 8388608 crc 3ACB817E md5 D4669DEA04E321FF393429EC344BCB53 sha1 0143E37535187F5FF40EED1C0B7A41A195C0E724 flags verified )
+	rom ( name "Heiwa Pachinko World 64 (J) [!].z64" size 8388608 crc 99A427FA md5 5E8539E037EEA88C5A2746F60E431C8D sha1 D48A484FEBAAC3BD146130434921861890503B29 )
 )
 
 game (
 	name "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 65517307 md5 FF64D07E5A429E7A434BC9A377F27360 sha1 9FC6C63EB8641D957342AA5F31D35075BC5B9E8C flags verified )
+	rom ( name "Hercules - The Legendary Journeys (E) (M6) [!].z64" size 16777216 crc B1954B08 md5 1546877FD85C00A83515005727E5FDA5 sha1 D2E26F4AECF488F87E1AB36395280385B060D229 )
 )
 
 game (
 	name "Hercules - The Legendary Journeys (USA)"
 	description "Hercules - The Legendary Journeys (USA)"
 	rom ( name "Hercules - The Legendary Journeys (USA).n64" size 16777216 crc CF90BC4A md5 0A121700A0FC84557841EEF7282316B2 sha1 09E56E035981831A2BB0B932774E4EBE34EA175F )
+	rom ( name "Hercules - The Legendary Journeys (U) [!].z64" size 16777216 crc 4948892B md5 6BBD8C42F6EF8F5B9541D6F4DB657DD7 sha1 5C3C4345BE505763FC51A9E3713F5787E4044646 )
 )
 
 game (
 	name "Hexen (Europe)"
 	description "Hexen (Europe)"
 	rom ( name "Hexen (Europe).n64" size 8388608 crc ED939F94 md5 C1D1CDC1D9DD2DCD5643468F91CE0CA6 sha1 3970A749E5B88E8130418CB06A28AF84C54BE40D flags verified )
+	rom ( name "Hexen (E) [!].z64" size 8388608 crc 5369EFB4 md5 2080262A251D270F9CE819887F2104A7 sha1 1A929AE2A7930CF4B762FA28A9D20338C5FED847 )
 )
 
 game (
 	name "Hexen (France)"
 	description "Hexen (France)"
 	rom ( name "Hexen (France).n64" size 8388608 crc 4B3DC7FE md5 B8B66454F3019BA433946A914B7AE4F1 sha1 84DA065C47E1D29155B9869970B9156428A1AE00 )
+	rom ( name "Hexen (F) [!].z64" size 8388608 crc E373FA31 md5 A5921C00111200257284CE0ABA0904CA sha1 476D3B340BA2A1B1ACC1D0CC97AC6E25A5136CA2 )
 )
 
 game (
 	name "Hexen (Germany)"
 	description "Hexen (Germany)"
 	rom ( name "Hexen (Germany).n64" size 8388608 crc 176C6242 md5 31D96B7439843350216A12906EFFC8D5 sha1 4C70006B724FC43A3283B8E2AAE9941BE6F67DEA flags verified )
+	rom ( name "Hexen (G) [!].z64" size 8388608 crc E4821C4B md5 08CBB141DEC604E4DAD2787F237D57A2 sha1 8D10CA2860D72C3C1ADB409485936C4BA3F18396 )
 )
 
 game (
 	name "Hexen (Japan)"
 	description "Hexen (Japan)"
 	rom ( name "Hexen (Japan).n64" size 8388608 crc 3D157140 md5 7648296BED096CCE8AA707ADE991EDA9 sha1 70ADC890606315107D97ADEDC02D210AB7AE8A57 flags verified )
+	rom ( name "Hexen (J) [!].z64" size 8388608 crc 571DA09A md5 672152CF4DCB5D0A19662C11EFF71452 sha1 3E3E2B012BBB873338B0573F6E11426E38F8B5CD )
 )
 
 game (
 	name "Hexen (USA)"
 	description "Hexen (USA)"
 	rom ( name "Hexen (USA).n64" size 8388608 crc D2B22343 md5 A8531BFD6FFBAD2059EF4F34AABC6282 sha1 5B58CC647FB10178C89D4DACC97CD25F5FBFF2D0 )
+	rom ( name "Hexen (U) [!].z64" size 8388608 crc 1D35E110 md5 EB98F1B8C6898AF7417F6882946DA9B3 sha1 A602839132F6CCA71F175FB72039897705BA4661 )
 )
 
 game (
@@ -1830,84 +2067,98 @@ game (
 	name "Hiryuu no Ken Twin (Japan)"
 	description "Hiryuu no Ken Twin (Japan)"
 	rom ( name "Hiryuu no Ken Twin (Japan).n64" size 12582912 crc 4A07511C md5 82DAA5FC7115D43A72DBF7566C95B106 sha1 BF68B9514A78040EDD62863DFE15B75AED397CDB flags verified )
+	rom ( name "Hiryuu no Ken Twin (J) [!].z64" size 12582912 crc BA6A687E md5 73084495F3209C54900525436BBBC531 sha1 C7A76B061C383600378E52A39DADA8D2BE58325B )
 )
 
 game (
 	name "Holy Magic Century (Europe)"
 	description "Holy Magic Century (Europe)"
 	rom ( name "Holy Magic Century (Europe).n64" size 16777216 crc 2F886030 md5 F457779A4CF5CA5AACC21589F3A8C6B4 sha1 4A5FAD6564FFB69B874B1054B702E64AED197387 flags verified )
+	rom ( name "Holy Magic Century (E) [!].z64" size 16777216 crc BF6F67BF md5 FA6A2E00BBFF236DAC91F08544AFFA40 sha1 11ACE24C670E72B1D227681B974DFBBFE81D9A38 )
 )
 
 game (
 	name "Holy Magic Century (France)"
 	description "Holy Magic Century (France)"
 	rom ( name "Holy Magic Century (France).n64" size 16777216 crc CEFC98AA md5 3110D0DC89CAA7C04F993520723842B8 sha1 31F28C9A0C6B0CA00A6015496B377936E196D498 )
+	rom ( name "Holy Magic Century (F).z64" size 16777216 crc 284170ED md5 988F5ABD96259196343659E913666820 sha1 610BF1F4A5CBEB2D6DC3AE1DAFC5B3B818F69C26 )
 )
 
 game (
 	name "Holy Magic Century (Germany)"
 	description "Holy Magic Century (Germany)"
 	rom ( name "Holy Magic Century (Germany).n64" size 16777216 crc 40796997 md5 794846ABAE030C9CD51E96B45E1718AE sha1 92DCCC50EC31676ED983AA0BD5E4056137919AB2 )
+	rom ( name "Holy Magic Century (G) [!].z64" size 16777216 crc D1934CF6 md5 AB676C3E9D26A77450DDB4AACD1A3861 sha1 AC5457FFF3FCC8D6ACFFB60FA9A99846D36FACF8 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan)"
 	description "Hoshi no Kirby 64 (Japan)"
 	rom ( name "Hoshi no Kirby 64 (Japan).n64" size 33554432 crc FCACBE90 md5 FB33B9FA1386DEE54E84CEFA7B7496F8 sha1 8861AACDF6C36B40AE2031A85798173D8D180C91 flags verified )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [!].z64" size 33554432 crc AE7CB69D md5 B1A67AEBC2BE89A800E5EB60C0DFA968 sha1 B9882992907A102BD33373585ACC90B9C7EB1BA4 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev A)"
 	description "Hoshi no Kirby 64 (Japan) (Rev A)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev A).n64" size 33554432 crc E2FAB230 md5 3B7A47D93A77E036C238917DD90E4727 sha1 E2FB9469E99CA6ED48FBE19B1F57F5FD653981A3 flags verified )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.1) [!].z64" size 33554432 crc A263C1B9 md5 FFDB4456F799722BCFE430632C3986AE sha1 2502CEB1AFBA83C90F3E7F98B283F667B85D4150 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev B)"
 	description "Hoshi no Kirby 64 (Japan) (Rev B)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev B).n64" size 33554432 crc 32D2D11E md5 2A710B570DE57061B5AFC05F7FF51069 sha1 84E2597BC65A67E8C74E47B38614C89D42E3316F flags verified )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.2) [!].z64" size 33554432 crc F4589AA8 md5 3EC0471E2CBEE17471DDBF80C56606D5 sha1 C177F4E37EFF98EF2D18FB1E94CD253FD366A218 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev C)"
 	description "Hoshi no Kirby 64 (Japan) (Rev C)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev C).n64" size 33554432 crc 3DEC34A5 md5 CB8E9EEE8A11D6B1ABB74D7F9D647B3E sha1 95E28E31109A42E80A6A4AFEBB3157B8ACC6B4EC flags verified )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.3) [!].z64" size 33554432 crc 6D5E1332 md5 35E039F8E79843917D02BE06D00C457B sha1 03257C820B7705400C32BDE1BCC3161C55814605 )
 )
 
 game (
 	name "Hot Wheels - Turbo Racing (Europe) (En,Fr,De)"
 	description "Hot Wheels - Turbo Racing (Europe) (En,Fr,De)"
 	rom ( name "Hot Wheels - Turbo Racing (Europe) (En,Fr,De).n64" size 16777216 crc EF63C780 md5 A42DF6D45B181731707DE3A01F5B9E4F sha1 1BF92987C5531AE213ED1D721980C61F580436FA flags verified )
+	rom ( name "Hot Wheels Turbo Racing (E) (M3) [!].z64" size 16777216 crc 850633A7 md5 EF34DA35EF8A0734843CB182C19FEB26 sha1 FBCFD6D466931E5CB71FE880C52EA692C3F84D75 )
 )
 
 game (
 	name "Hot Wheels - Turbo Racing (USA)"
 	description "Hot Wheels - Turbo Racing (USA)"
 	rom ( name "Hot Wheels - Turbo Racing (USA).n64" size 12582912 crc 525E8F8F md5 3BD7F78AF738FC3D68D855C2CD525C26 sha1 477818165666648BFBE8452F2F89F42277ADD932 )
+	rom ( name "Hot Wheels Turbo Racing (U) [!].z64" size 12582912 crc A5C92148 md5 4311A1AEF1898678331F7E3486055307 sha1 94913A07E49005FFD43DFDFA16FF5862BDB93748 )
 )
 
 game (
 	name "HSV Adventure Racing! (Australia)"
 	description "HSV Adventure Racing! (Australia)"
 	rom ( name "HSV Adventure Racing! (Australia).n64" size 16777216 crc FB1294C3 md5 1D8F8CA47FE02D1950E7A9725822414E sha1 066B18E04A5AE248DB3B7041F73FE3E8E883DE93 flags verified )
+	rom ( name "HSV Adventure Racing (A).z64" size 16777216 crc C0BA9440 md5 26F7D8F4640EBDFA823F84E5F89D62BF sha1 8A9CDC2A7D98C354BA4B31CEA644DBD5153880AE )
 )
 
 game (
 	name "Human Grand Prix - The New Generation (Japan)"
 	description "Human Grand Prix - The New Generation (Japan)"
 	rom ( name "Human Grand Prix - The New Generation (Japan).n64" size 8388608 crc A3FC9AEA md5 B38D88B3F4C9AB2278306CF4C094C75D sha1 D7BC56C4ED710091BEC56C3E1485ADF1C533D1C5 flags verified )
+	rom ( name "Human Grand Prix - New Generation (J) [!].z64" size 8388608 crc 31E102E3 md5 97E706ED9CC6F30708FFDC187C85D59F sha1 B8DFE78C7ABF1E33EDAD0B5ECEC1C9F1F3C8B576 )
 )
 
 game (
 	name "Hybrid Heaven (Europe) (En,Fr,De)"
 	description "Hybrid Heaven (Europe) (En,Fr,De)"
 	rom ( name "Hybrid Heaven (Europe) (En,Fr,De).n64" size 16777216 crc 8696B2A2 md5 9C696496F4F5B9A0B6B0F13F93D8E658 sha1 3ED6D3B4127DC26FAE32E88E1FD78BF95E1118E2 flags verified )
+	rom ( name "Hybrid Heaven (E) (M3) [!].z64" size 16777216 crc E76627FF md5 DA861C4D9202F661575466450A27C412 sha1 D2210D492BAD952B055A4269E45FD89631C32D25 )
 )
 
 game (
 	name "Hybrid Heaven (Japan)"
 	description "Hybrid Heaven (Japan)"
 	rom ( name "Hybrid Heaven (Japan).n64" size 16777216 crc 42E44701 md5 2A5C6DFB0965C6C6DB2CC8E6E27832DB sha1 6B755FC59F35F0F25C46F062471699533AB99DA4 flags verified )
+	rom ( name "Hybrid Heaven (J) [!].z64" size 16777216 crc E769DE96 md5 9946EFF915FC947A226407AC1F7B35C4 sha1 09F4D3200B0BD4B984A80248AF07DE3C40B5CC26 )
 )
 
 game (
@@ -1921,36 +2172,42 @@ game (
 	name "Hydro Thunder (Europe)"
 	description "Hydro Thunder (Europe)"
 	rom ( name "Hydro Thunder (Europe).n64" size 33554432 crc B75696AE md5 18B80F3996956C282D7462B2D0CDB901 sha1 6377AFC193B7C8FA8AD3F8B3A41279D05702E43A flags verified )
+	rom ( name "Hydro Thunder (E) [!].z64" size 33554432 crc 863AB8F3 md5 434BB8DE49011573AC38E893224C5623 sha1 0661B1B0E47BC02D9B0D87D1688FD466793C074B )
 )
 
 game (
 	name "Hydro Thunder (France)"
 	description "Hydro Thunder (France)"
 	rom ( name "Hydro Thunder (France).n64" size 33554432 crc C8CD9B5D md5 B9759A54B3D69D410E9ABF9D8541D2B6 sha1 164C60C5966E4716F3A5AEF6BF6EB023E4875D32 )
+	rom ( name "Hydro Thunder (F) [!].z64" size 33554432 crc 010F6242 md5 4B4C85D9DD2D460ADAFABAE8DB48B4FA sha1 03FA91AEC0819654F1AD0D12BB81CE3F5D7D08AE )
 )
 
 game (
 	name "Hydro Thunder (USA)"
 	description "Hydro Thunder (USA)"
 	rom ( name "Hydro Thunder (USA).n64" size 33554432 crc 6B78C2C8 md5 801E1B409166F76228C3DD8DC9D286AA sha1 665E3D9773B0A6802814CD3E7B930CAB62FC583D )
+	rom ( name "Hydro Thunder (U) [!].z64" size 33554432 crc E744456F md5 54F43E6B68782E98CAABEA5E7976B2BE sha1 F5D5054F97DA0D68857F9824130147EC38EE7A76 )
 )
 
 game (
 	name "Hyper Olympics in Nagano 64 (Japan)"
 	description "Hyper Olympics in Nagano 64 (Japan)"
 	rom ( name "Hyper Olympics in Nagano 64 (Japan).n64" size 12582912 crc F7C2BB67 md5 2148B042F40957F75C7BF8C8BFD1BB87 sha1 51EA8AF6B29FC99A9C61DD2242C3732B6CDF43DC flags verified )
+	rom ( name "Hyper Olympics Nagano 64 (J) [!].z64" size 12582912 crc C1EA5D33 md5 D2F7B3ACE75A2CE7A06BEAC929711D94 sha1 3D0F36371F99C8ABC8E835DAE4E0913757EE4827 )
 )
 
 game (
 	name "Ide Yosuke no Mahjong Juku (Japan)"
 	description "Ide Yosuke no Mahjong Juku (Japan)"
 	rom ( name "Ide Yosuke no Mahjong Juku (Japan).n64" size 12582912 crc 32003C85 md5 20364F316726FAF88490CE3FE1FB42F2 sha1 278E45431689B52CE28955957B444AE4F8539199 flags verified )
+	rom ( name "Ide Yosuke no Mahjong Juku (J) [!].z64" size 12582912 crc A4A24517 md5 DC577D70E9308F94E5F3CE03F3508539 sha1 A38F22CFA8FE1588C85CEFB0602F5A910136932A )
 )
 
 game (
 	name "Iggy's Reckin' Balls (Europe)"
 	description "Iggy's Reckin' Balls (Europe)"
 	rom ( name "Iggy's Reckin' Balls (Europe).n64" size 4194304 crc 76530405 md5 08DEEF2DBCADDC2BCB08B5ECCCFD7E48 sha1 67C05C4056FE7E38D34FEA26E4A87EDF570910AF flags verified )
+	rom ( name "Iggy's Reckin' Balls (E) [!].z64" size 4194304 crc 9BF26065 md5 25B297143E9E5CCBB4B80A7FB6AF399B sha1 DA3C5BA5849E104383EA4C3DF1FBDB8253F184C9 )
 )
 
 game (
@@ -1964,18 +2221,21 @@ game (
 	name "Iggy-kun no Bura Bura Poyon (Japan)"
 	description "Iggy-kun no Bura Bura Poyon (Japan)"
 	rom ( name "Iggy-kun no Bura Bura Poyon (Japan).n64" size 4194304 crc E133064B md5 611FEC9AF7DD0D6A4064963042C538EC sha1 02542CFDC3734350403E4FB7CC139953436584D8 flags verified )
+	rom ( name "Iggy-kun no Bura Bura Poyon (J) [!].z64" size 4194304 crc 26CC1266 md5 C70B0B680807F2B8C2C3D5DC495FA8C2 sha1 EBB8C0C99D000A366D2DBA0D8D184EC18AA82D43 )
 )
 
 game (
 	name "In-Fisherman - Bass Hunter 64 (Europe)"
 	description "In-Fisherman - Bass Hunter 64 (Europe)"
 	rom ( name "In-Fisherman - Bass Hunter 64 (Europe).n64" size 8388608 crc 930E6F44 md5 7249524A0519489E8173B29246E6DD70 sha1 3D09C3384069A4BCF959BFB05CF7A9F398C6CEB6 flags verified )
+	rom ( name "Bass Hunter 64 (E) [!].z64" size 8388608 crc 00DA3704 md5 BF3E84CDD01CAC05987FD8DA5191534B sha1 D36374BE227E972B1C0B6F2CFBB8FDD724AA1074 )
 )
 
 game (
 	name "In-Fisherman - Bass Hunter 64 (USA)"
 	description "In-Fisherman - Bass Hunter 64 (USA)"
 	rom ( name "In-Fisherman - Bass Hunter 64 (USA).n64" size 8388608 crc 88279F19 md5 3451C623E119C62E8A0AC6C3E57BFF6F sha1 39FDE60D5447006CF864624860F3889C8B20EF27 )
+	rom ( name "In-Fisherman Bass Hunter 64 (U) [!].z64" size 8388608 crc D8EB5E6E md5 C605F40BF669E00A5E51BAF0D00621EA sha1 4AA373E23876C89A549C98036F456B564D779217 )
 )
 
 game (
@@ -1995,156 +2255,182 @@ game (
 	name "Indy Racing 2000 (USA)"
 	description "Indy Racing 2000 (USA)"
 	rom ( name "Indy Racing 2000 (USA).n64" size 16777216 crc 1C622354 md5 7E6DFA14B1550EC31D33B33695E67AEF sha1 B8983FA34D9614AF433FEE6DFD331BF8793A4DD1 )
+	rom ( name "Indy Racing 2000 (U) [!].z64" size 16777216 crc A5163F29 md5 A7781D441AF55C4FF8AFC68AB3A59313 sha1 015BF0E0BC700A80A2606D3578E4A9B7645E99EC )
 )
 
 game (
 	name "International Superstar Soccer '98 (Europe)"
 	description "International Superstar Soccer '98 (Europe)"
 	rom ( name "International Superstar Soccer '98 (Europe).n64" size 12582912 crc 463FE8B7 md5 7AB4ED7CDABB83C9D507C7F50E7E4D12 sha1 4FC51FBE034F8572B4727756778DE7A27B43C81A flags verified )
+	rom ( name "International Superstar Soccer '98 (E) [!].z64" size 12582912 crc BF23945D md5 34489365B550F32C97337D86D52D8C84 sha1 CCAFFEE3A793A0C3A5E7C48FBC4A4759EF29153F )
 )
 
 game (
 	name "International Superstar Soccer '98 (USA)"
 	description "International Superstar Soccer '98 (USA)"
 	rom ( name "International Superstar Soccer '98 (USA).n64" size 12582912 crc D685F2EC md5 673AE2592FC748112B78D2A21C95A43D sha1 1EE4DD4D774FED61248513E0D2F5285918B98D73 )
+	rom ( name "International Superstar Soccer '98 (U) [!].z64" size 12582912 crc B85FA721 md5 7DCC05B98E2FA690B478808EBBAD5D1A sha1 053735184D414E0A1BBD888F3C931252EA1B92FD )
 )
 
 game (
 	name "International Superstar Soccer 2000 (Europe) (En,De)"
 	description "International Superstar Soccer 2000 (Europe) (En,De)"
 	rom ( name "International Superstar Soccer 2000 (Europe) (En,De).n64" size 16777216 crc 61799242 md5 DF6E682CA10BE8F1995FDCF4186482AE sha1 E6D2B8E25D3FCD9F38439EF07D71E9F8A48A4F99 flags verified )
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!].z64" size 16777216 crc 69572558 md5 9F101B6F6BEF4F267DEB5C6C37A24B97 sha1 E7078E5F1E899382B1CC145DF43EE8CFAA924297 )
 )
 
 game (
 	name "International Superstar Soccer 2000 (Europe) (Fr,It)"
 	description "International Superstar Soccer 2000 (Europe) (Fr,It)"
 	rom ( name "International Superstar Soccer 2000 (Europe) (Fr,It).n64" size 16777216 crc 7D7DCD46 md5 65B79B1226B0D29068024EE3D3E8CEF4 sha1 640EC4BF4C838814B003ADD093B0F9642058FE04 )
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!].z64" size 16777216 crc 8A16A6A9 md5 CC2BE97A16744860FAE8A94611479C4C sha1 B0505E13BA0F029EA735378C50B224FD618BE302 )
 )
 
 game (
 	name "International Superstar Soccer 2000 (USA) (En,Es)"
 	description "International Superstar Soccer 2000 (USA) (En,Es)"
 	rom ( name "International Superstar Soccer 2000 (USA) (En,Es).n64" size 16777216 crc BB1824B8 md5 3513028962D61ED2396C43F67CB9ED7D sha1 D86386EEEE1B5B32CE43BC9A4149314A23A6320B )
+	rom ( name "International Superstar Soccer 2000 (U) (M2) [!].z64" size 16777216 crc DCD0538F md5 23A4ED8D79882594206173B1D476F0E9 sha1 E7BD36C410CE881D8B8DC853CB4B7B7961BF6A62 )
 )
 
 game (
 	name "International Superstar Soccer 64 (Europe)"
 	description "International Superstar Soccer 64 (Europe)"
 	rom ( name "International Superstar Soccer 64 (Europe).n64" size 8388608 crc 662DA098 md5 8C255FD7A678E8E948A205C9AC37A04C sha1 C19B5DD94ED7EC6799DA5F41A14EC67F2493F119 flags verified )
+	rom ( name "International Superstar Soccer 64 (E) [!].z64" size 8388608 crc 8C839268 md5 376803F28CA8B2133671783419933CA2 sha1 3B53FD76BB37B923B0FE61E50057AE773A25170A )
 )
 
 game (
 	name "International Superstar Soccer 64 (USA)"
 	description "International Superstar Soccer 64 (USA)"
 	rom ( name "International Superstar Soccer 64 (USA).n64" size 8388608 crc 91CB6803 md5 DA2174464A3BD5DF10F8D891D8896E9D sha1 94D4969597596C9E990754AEFDD506D3C75177BA )
+	rom ( name "International Superstar Soccer 64 (U) [!].z64" size 8388608 crc 0EA249B9 md5 6A345402AE1DB5CE1041365E36126BCE sha1 D2C258EE3844BE77049E4AF5208F8F2BB073A86E )
 )
 
 game (
 	name "International Track & Field - Summer Games (Europe) (En,Fr,De)"
 	description "International Track & Field - Summer Games (Europe) (En,Fr,De)"
 	rom ( name "International Track & Field - Summer Games (Europe) (En,Fr,De).n64" size 12582912 crc 73073EC2 md5 A944268E3E840B3F1017BD4F0098390C sha1 E08B8E0EB424CB9044B53D5D903AB89CC82F0FB8 flags verified )
+	rom ( name "International Track & Field Summer Games (E) (M3) [!].z64" size 12582912 crc B3181EE0 md5 970488FB7D9C5C25BD924E6F898B84A0 sha1 B3D5A2128813BD077DD3E161978E3C1717E278E0 )
 )
 
 game (
 	name "International Track & Field 2000 (USA)"
 	description "International Track & Field 2000 (USA)"
 	rom ( name "International Track & Field 2000 (USA).n64" size 12582912 crc F93868A3 md5 CE7249FFFFB3D600010435F34574A527 sha1 D5B614B9A95086B2366C5470659FA5B89FACEC68 )
+	rom ( name "International Track & Field 2000 (U) [!].z64" size 12582912 crc DA443F0B md5 35662CFD07FD6AF4BAB90CA23F7C98E6 sha1 61D7958E61B50FD933FAF5D3AE70807FA53818FB )
 )
 
 game (
 	name "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)"
 	description "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)"
 	rom ( name "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).n64" size 16777216 crc 5E9C3E4B md5 E75D722A11840424C21FF77A847A49C8 sha1 E9581337DF0F93638DDAF328F84BFE92E5764474 flags verified )
+	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!].z64" size 16777216 crc 576915D4 md5 13893DB9E919C4E7CF0C0B0064CCB554 sha1 C722BA7FD7C44FEE474233DB3FD251177A83A9AB )
 )
 
 game (
 	name "J.League Dynamite Soccer 64 (Japan)"
 	description "J.League Dynamite Soccer 64 (Japan)"
 	rom ( name "J.League Dynamite Soccer 64 (Japan).n64" size 8388608 crc 67EC5F38 md5 E9CBA40742F4DDE165AD54A9377929F4 sha1 FBD0A8B7D405A06E3A955E6F897C667EAC3F03A7 flags verified )
+	rom ( name "J.League Dynamite Soccer 64 (J) [!].z64" size 8388608 crc DC0B2C8F md5 1247B093E0FD6CCFD50D15DE59301076 sha1 B5618FFDE759BCEF12A19B336CF940DF24F52209 )
 )
 
 game (
 	name "J.League Eleven Beat 1997 (Japan)"
 	description "J.League Eleven Beat 1997 (Japan)"
 	rom ( name "J.League Eleven Beat 1997 (Japan).n64" size 8388608 crc B2D77747 md5 AC6CBD30B676412C9E52330C82048ED0 sha1 C5D159BDDC89DA2224E1D32C695248998C4560BD flags verified )
+	rom ( name "J.League Eleven Beat 1997 (J).z64" size 8388608 crc 7D0EED6A md5 30E23D3DE446E37E5E7FBEF6794A6FC9 sha1 0403902145CED0C42252981BC6C8FEF2F76CCC08 )
 )
 
 game (
 	name "J.League Live 64 (Japan)"
 	description "J.League Live 64 (Japan)"
 	rom ( name "J.League Live 64 (Japan).n64" size 8388608 crc 8A48DE94 md5 3372BCC3042D76130075C20F9F86030C sha1 563C4F5D0B7CBE2EC675153D52EEFB2901E5B624 flags verified )
+	rom ( name "J.League Live 64 (J) [!].z64" size 8388608 crc 4C536DD7 md5 209DB8333EEB526AE9A91209175348CE sha1 447E573EB019BF4ACD48B926C89701E09198EE36 )
 )
 
 game (
 	name "J.League Tactics Soccer (Japan)"
 	description "J.League Tactics Soccer (Japan)"
 	rom ( name "J.League Tactics Soccer (Japan).n64" size 12582912 crc 0B6C70EA md5 A6FD45ACAE3F889AC559A72F982643A1 sha1 058E9CCD131199394E0D6E6F6EA04AEEB2946D59 flags verified )
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [!].z64" size 12582912 crc 976A2D12 md5 800ACC7D609ECDB3E09E68CBD05F5FA0 sha1 853CECC41C00F1BBC9972DFFB94B78BDB0DFA274 )
 )
 
 game (
 	name "J.League Tactics Soccer (Japan) (Rev A)"
 	description "J.League Tactics Soccer (Japan) (Rev A)"
 	rom ( name "J.League Tactics Soccer (Japan) (Rev A).n64" size 12582912 crc 71FA1D4D md5 4C2E19F6EF05A390356D6C9A4D13D15E sha1 BC3A2585E96E64E1F0D8CB7C2F7F38F0A6163319 flags verified )
+	rom ( name "J.League Tactics Soccer (J) (V1.1) [!].z64" size 12582912 crc 156E705E md5 793DBF504E20C92F6B73B4E8A25A220C sha1 9A47293D82C161F1CB146673AC6AD96C1730C624 )
 )
 
 game (
 	name "Jangou Simulation Mahjong Dou 64 (Japan)"
 	description "Jangou Simulation Mahjong Dou 64 (Japan)"
 	rom ( name "Jangou Simulation Mahjong Dou 64 (Japan).n64" size 8388608 crc 27E9853C md5 21755B140310E9E062ADDDFA51AB4475 sha1 D969105F2EC0D1116E35B66410ACAC4B207AAF3D flags verified )
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [!].z64" size 8388608 crc D1C1681E md5 8EE01DE7DA2E9AD08D7ED913A5EE8632 sha1 F2F96B00709AC81BA8228BB38A8396824C29CE51 )
 )
 
 game (
 	name "Jeopardy! (USA)"
 	description "Jeopardy! (USA)"
 	rom ( name "Jeopardy! (USA).n64" size 4194304 crc 82B2AB69 md5 BD65646119CF596491406E59EE60FED8 sha1 6F22227EA9A64F16F4B8A5A8B84A30FAC55FD84C )
+	rom ( name "Jeopardy! (U) [!].z64" size 4194304 crc E739947C md5 A45F7200537C0D928A88CBBA2DFEB680 sha1 C5BCF3EFF6BCDD9E7846CE5FD5DB3095DB9C58ED )
 )
 
 game (
 	name "Jeremy McGrath Supercross 2000 (Europe)"
 	description "Jeremy McGrath Supercross 2000 (Europe)"
 	rom ( name "Jeremy McGrath Supercross 2000 (Europe).n64" size 16777216 crc EFE0B465 md5 D4C85F5DACECF2787EDD4A387BE0AB01 sha1 3E61CE15A20BE752240C889C37BE82270BDD423E flags verified )
+	rom ( name "Jeremy McGrath Supercross 2000 (E) [!].z64" size 16777216 crc 5BF42EC4 md5 4C5BE1BFC1CCCFF501EBA2A685226962 sha1 7804A688C9F7ED39D9C1A33C0339F4317D3918DC )
 )
 
 game (
 	name "Jeremy McGrath Supercross 2000 (USA)"
 	description "Jeremy McGrath Supercross 2000 (USA)"
 	rom ( name "Jeremy McGrath Supercross 2000 (USA).n64" size 16777216 crc 67BF293B md5 BED43C3E682F5450CD35C346CB230532 sha1 1C0352BAD4F56F1CF5D892E85F2D04D956EDB49E )
+	rom ( name "Jeremy McGrath Supercross 2000 (U) [!].z64" size 16777216 crc 2A5C9A06 md5 8046A4B8ABD4353B2AB9696106CCF8D2 sha1 278AD55333B7B75970812ECB9E691111CA3CFC46 )
 )
 
 game (
 	name "Jet Force Gemini (Europe) (En,Fr,De,Es)"
 	description "Jet Force Gemini (Europe) (En,Fr,De,Es)"
 	rom ( name "Jet Force Gemini (Europe) (En,Fr,De,Es).n64" size 33554432 crc FEC297EF md5 761A047404C6460A077FF858E0244A8F sha1 3085A20258F3A554839D0007CB231BC9B96875BC flags verified )
+	rom ( name "Jet Force Gemini (E) (M4) [!].z64" size 33554432 crc CFBED88C md5 BAAF237E71AA7526C9B2F01C08B68A53 sha1 50651C4E0C46332F7F0B45870263F0A8B9A49602 )
 )
 
 game (
 	name "Jet Force Gemini (USA)"
 	description "Jet Force Gemini (USA)"
 	rom ( name "Jet Force Gemini (USA).n64" size 33554432 crc B5932174 md5 0EF01AFDE32E40228C03904E3D884ADD sha1 AA7EDC75952104F0B52BF1300DF427835A128B01 )
+	rom ( name "Jet Force Gemini (U) [!].z64" size 33554432 crc 6753D5A3 md5 772CC6EAB2620D2D3CDC17BBC26C4F68 sha1 493CED9008DBE932D6E91179B68E8630CF23A023 )
 )
 
 game (
 	name "Jet Force Gemini (USA) (Demo) (Kiosk)"
 	description "Jet Force Gemini (USA) (Demo) (Kiosk)"
 	rom ( name "Jet Force Gemini (USA) (Demo) (Kiosk).n64" size 33554432 crc 6E75735B md5 D9DB99C392E85A82C551CF7808D742ED sha1 4C1EEDFAC94EA2041A765E60CAAC00ABF77A678D )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [!].z64" size 33554432 crc FA061B96 md5 5BBE9ADE7171F2E1DAAA7C48FAD38728 sha1 F00F7C7FB085D0DF57DCB649793ACED5BE4E8562 )
 )
 
 game (
 	name "Jikkyou G1 Stable (Japan)"
 	description "Jikkyou G1 Stable (Japan)"
 	rom ( name "Jikkyou G1 Stable (Japan).n64" size 16777216 crc 97669431 md5 3CFEDA8E61349753835B37EF56514627 sha1 076D1EF9AF18A6456048A1699AAD377AEAB8772F flags verified )
+	rom ( name "Jikkyou G1 Stable (J) [!].z64" size 16777216 crc 0A796C3E md5 878D8A26FD02FDB08200464CB6F566EF sha1 EB7B24BAC29DF362CAB562662AE9A5DE7D5FB0C3 )
 )
 
 game (
 	name "Jikkyou G1 Stable (Japan) (Rev A)"
 	description "Jikkyou G1 Stable (Japan) (Rev A)"
 	rom ( name "Jikkyou G1 Stable (Japan) (Rev A).n64" size 16777216 crc 142072BF md5 614489CEED70C2D44CDCBF147E8F3D34 sha1 6DA9B4181B3AEC624D9B9CE507251C319313411F )
+	rom ( name "Jikkyou J.League Perfect Striker (J) [!].z64" size 8388608 crc 8ED60DEA md5 58153AC5C4030D1BFD3C15CF57FB02E7 sha1 E1185922648A6B9DEC1C820F43A292E480E396CC )
 )
 
 game (
 	name "Jikkyou J.League 1999 - Perfect Striker 2 (Japan)"
 	description "Jikkyou J.League 1999 - Perfect Striker 2 (Japan)"
 	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (Japan).n64" size 16777216 crc 8E2F8322 md5 73F742C7199D7A6FBF18DF68E8957A0E sha1 25033E8EBAA71316D108DE450971180B544DE315 )
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!].z64" size 16777216 crc 153AEB15 md5 3D2CCA1B2E3BDE267769812219EDB864 sha1 B713D43DE585C06C6757070EF0274CF434424261 )
 )
 
 game (
@@ -2163,30 +2449,35 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu 2000 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 2000 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (Japan).n64" size 16777216 crc 45E04C78 md5 7D09F9F9B087ED758A0337CB9AEF25C6 sha1 5705CBEE7664F8EB184FD451E219F5954060B5A8 flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!].z64" size 16777216 crc 351CDE48 md5 23409668A6E6C4ECE7B5FB0B7D0E8F2C sha1 365D6EFA2665B816A5E0E2233C890DDCD524C05D )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A)"
 	description "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A).n64" size 16777216 crc 4E6FAA43 md5 EEDDACC180DF4702B4D367D2973EBF7D sha1 6F32972FE2FDCE0AC051787B8253950AA36487D1 flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!].z64" size 16777216 crc 753706EF md5 B653C963ED8D3A749676810F07CFE4E5 sha1 2B9425BE9C6F76EB6594D414299C24E19CF12992 )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 4 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 4 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (Japan).n64" size 12582912 crc 8D2540F1 md5 BC1762B17751DB7BB7B2C55B8A9D6E70 sha1 73016B7C15BAE869B0D868E62B433400503EF540 flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!].z64" size 12582912 crc 480B953E md5 FDA57F65EB159278223EB9D03267C27F sha1 7E27A27BAD4F98500D7A68EC43AB7BFFE5DE03E1 )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A)"
 	description "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A).n64" size 12582912 crc 435126AE md5 12BC7271B915B0A8C7FE8DD5EA7BDCCA sha1 44287562745C42662B61224EBFD9B483867EAFEE flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!].z64" size 12582912 crc 40E3AC61 md5 B454490EB44F0978F009FA41DE8C478E sha1 D11B2860925C3784CBD4AD163111414537C5378A )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 5 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 5 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (Japan).n64" size 16777216 crc 94FA55FF md5 078319B0411390250349D4BE269B9F1C sha1 7822E0015E716AE540E95F50C32558EAA7865174 flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [!].z64" size 16777216 crc FEEC34F6 md5 E9F989E09E3F1519AEFE619889A4F710 sha1 F1BC8D2A6B03FFAB7355C4E7B5FA1C393421E9F9 )
 )
 
 game (
@@ -2205,6 +2496,7 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu 6 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 6 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (Japan).n64" size 16777216 crc A54E4397 md5 86E100B32C6AD951831DB09D3A58CD97 sha1 AE89AA2CD42AA841984C3E9EE2E3AADA1148BF2D flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [!].z64" size 16777216 crc D9329895 md5 E6129460E23170FFD4EC4B09D5E0CC56 sha1 938C8D82E470D4E407AAD90F14B250803BCAB0B4 )
 )
 
 game (
@@ -2223,6 +2515,7 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan).n64" size 16777216 crc 4E102917 md5 2A9636FED3DF9F4093CA3D370AF0CD99 sha1 0F34CC6C6448CF4956DCCDABEAC0FBBD1F36DCA1 flags verified )
+	rom ( name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!].z64" size 16777216 crc 6A9E24D7 md5 7FC933A64884A382AA07605EA7204FF5 sha1 B24170ED95734DD12084CA3C82B678FABCBD4279 )
 )
 
 game (
@@ -2235,84 +2528,98 @@ game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan).n64" size 16777216 crc 970A3C24 md5 12C04BC4A8C7BB05453C7992086549C6 sha1 5FFD475D721C334ED82CA7BC99ED0E17C025D1E4 flags verified )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!].z64" size 16777216 crc 5C721850 md5 A05E7DB2409DEECCA36E48E9D931CACB sha1 BB1C7A8634BA6078843532264A8676F80D5B79FC )
 )
 
 game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A).n64" size 16777216 crc 7576897D md5 05F8642B057570C23E30441E7A2955C4 sha1 CFBDEB8A9218B147B2CFF8D087B3D3FB07E9CD37 flags verified )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!].z64" size 16777216 crc 68DBCC04 md5 538B54C2AAEA73FAA3A021D42A3225BE sha1 E9ED8A0ED5B7B20B80F0E140CC4B7261A89143BB )
 )
 
 game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B).n64" size 16777216 crc 55551947 md5 4876E203993FF609A34E60EA8204ACBB sha1 B86CB29227A7173338B6A2245E760BE5344379B6 flags verified )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!].z64" size 16777216 crc F63F9A5E md5 2E5FD9303138E8F558BF67BB9E799960 sha1 8EA26072DD7DA07C567EBCA7C25071739EC563FB )
 )
 
 game (
 	name "Jikkyou World Soccer 3 (Japan)"
 	description "Jikkyou World Soccer 3 (Japan)"
 	rom ( name "Jikkyou World Soccer 3 (Japan).n64" size 8388608 crc 8755DE1F md5 0A060338879D75C8603F931E6D8362E2 sha1 E1C73256A92E98BCB79D2D4C56EFCE77F0FF158B flags verified )
+	rom ( name "Jikkyou World Soccer 3 (J) [!].z64" size 8388608 crc 3BA9E644 md5 EF0F425689586850A6F5796124B0C85B sha1 A06528CE7A1C007F3E8DFAE199B6E65B3DBC034D )
 )
 
 game (
 	name "Jikuu Senshi Turok (Japan)"
 	description "Jikuu Senshi Turok (Japan)"
 	rom ( name "Jikuu Senshi Turok (Japan).n64" size 8388608 crc C3230021 md5 C88376BDEF9580777FDB2EEDD5B6E3EC sha1 182394E9772985DDD45E4459A58916FBA9F386AD flags verified )
+	rom ( name "Tokisora Senshi Turok (J) [!].z64" size 8388608 crc E6BD65D5 md5 7B261247150C431DE55AB371E8B46EA8 sha1 726BAEFD703EB2CA72EC22B4AAB8844662F32845 )
 )
 
 game (
 	name "Jinsei Game 64 (Japan)"
 	description "Jinsei Game 64 (Japan)"
 	rom ( name "Jinsei Game 64 (Japan).n64" size 16777216 crc 888B4265 md5 56FB8AC309038EF2F68A8B3B0456C915 sha1 CE9931571E9D60CC3C92458F89FBDBED214ED833 flags verified )
+	rom ( name "Jinsei Game 64 (J) [!].z64" size 16777216 crc 67A1A22C md5 68230D510015FF6817EF898C0B8B636C sha1 8759A3FC272C3F6259BBE2433EB34411705D8634 )
 )
 
 game (
 	name "John Romero's Daikatana (Europe) (En,Fr,De)"
 	description "John Romero's Daikatana (Europe) (En,Fr,De)"
 	rom ( name "John Romero's Daikatana (Europe) (En,Fr,De).n64" size 16777216 crc 48F3E888 md5 AF13198DB692DA423806E88114BFFC77 sha1 0A9400897CB7984A0E927A47F912405664AB70BA flags verified )
+	rom ( name "John Romero's Daikatana (E) (M3) [!].z64" size 16777216 crc F88AC3CE md5 7AB29C6AD2D8F4007D8213EB3411E0BD sha1 0278C3F9B2780890C4C2A3EE8A10C550A1EDA346 )
 )
 
 game (
 	name "John Romero's Daikatana (Japan)"
 	description "John Romero's Daikatana (Japan)"
 	rom ( name "John Romero's Daikatana (Japan).n64" size 16777216 crc BEFB1434 md5 45711F060D945982CE4DFFB9F5E31306 sha1 8BDA39F1E1C39020FF259B1D4D1CCB2C87D1EE38 flags verified )
+	rom ( name "John Romero's Daikatana (J) [!].z64" size 16777216 crc 44B80FD7 md5 57D31EA7121DD5A05B547225EFA5CFD7 sha1 4ED2EC28997865E301C5693639C2EC717C79A5BC )
 )
 
 game (
 	name "John Romero's Daikatana (USA)"
 	description "John Romero's Daikatana (USA)"
 	rom ( name "John Romero's Daikatana (USA).n64" size 16777216 crc CB126EA9 md5 FEE7F48F3DA74AEA78994FFC862A3641 sha1 C9F3D07AF09ADEF1CC977BF263B899E005A5AAB6 )
+	rom ( name "John Romero's Daikatana (U) [!].z64" size 16777216 crc 494950C6 md5 5B4C268422469F50B94779E655F2B798 sha1 08709013D512F3A2BED65B98AB451EC8B839D3B4 )
 )
 
 game (
 	name "Kakutou Denshou - F-Cup Maniax (Japan)"
 	description "Kakutou Denshou - F-Cup Maniax (Japan)"
 	rom ( name "Kakutou Denshou - F-Cup Maniax (Japan).n64" size 16777216 crc 1E967AC0 md5 327A06936FB2B4944B3A3328BC0D7F6A sha1 6E7116DB2A7AABD5F8D6149F34B6E187BCAAEC3C flags verified )
+	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [!].z64" size 16777216 crc DB40A155 md5 DFF0EFE2B35FCDE506D21B0C0BD373A5 sha1 F88F541D5913C99A9EAC5CA4162E65B8A3828725 )
 )
 
 game (
 	name "Ken Griffey Jr.'s Slugfest (USA)"
 	description "Ken Griffey Jr.'s Slugfest (USA)"
 	rom ( name "Ken Griffey Jr.'s Slugfest (USA).n64" size 16777216 crc 42D1ED42 md5 E6993C8FCEB6E4841639AF2701454830 sha1 EC8497EE9EBE1333032472B39206F9899C9213B3 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [!].z64" size 16777216 crc 12D8F3E9 md5 EEC0FAB75AF59E9C23E6DE2132DE89FF sha1 EC33CD4D44BBA163F89E435C2AEFBF7313D8CECE )
 )
 
 game (
 	name "Killer Instinct Gold (Europe)"
 	description "Killer Instinct Gold (Europe)"
 	rom ( name "Killer Instinct Gold (Europe).n64" size 12582912 crc 19421CA7 md5 AC5067339580E952D8BBFCC967756949 sha1 A7A6428EE27E62B9E2D91280C71B29963E5F3B22 flags verified )
+	rom ( name "Killer Instinct Gold (E) [!].z64" size 12582912 crc 5D0EE5D2 md5 C93D92F10A1A97D2BA87386BE7D178FD sha1 E0ED97C7310B012A5CF81C6F6678A75B8601B47E )
 )
 
 game (
 	name "Killer Instinct Gold (USA)"
 	description "Killer Instinct Gold (USA)"
 	rom ( name "Killer Instinct Gold (USA).n64" size 12582912 crc B279E4B2 md5 7AC487BA50FC8FB8993DACC60DED57BD sha1 75E148B5F290B08F7E0A661EE485FB5A79F4A54A )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [!].z64" size 12582912 crc 31C76BE7 md5 8E33AD20C31FEB61D7230FAD28846C5C sha1 BA52E91B44450C548467044B26951353DC491E04 )
 )
 
 game (
 	name "Killer Instinct Gold (USA) (Rev A)"
 	description "Killer Instinct Gold (USA) (Rev A)"
 	rom ( name "Killer Instinct Gold (USA) (Rev A).n64" size 12582912 crc 24AC459C md5 BEC96E5480969151888482631BD26626 sha1 90B7D7E5A7372CA3ABF059C0D24D499FAD2E909D )
+	rom ( name "Killer Instinct Gold (U) (V1.1) [!].z64" size 12582912 crc 49EF8F2B md5 4C9B419DC583C0DF4AB908ADF83BFC65 sha1 BCC599ED0F0B8B75A8068269958A2230EC7CB34C )
 )
 
 game (
@@ -2326,18 +2633,21 @@ game (
 	name "King Hill 64 - Extreme Snowboarding (Japan)"
 	description "King Hill 64 - Extreme Snowboarding (Japan)"
 	rom ( name "King Hill 64 - Extreme Snowboarding (Japan).n64" size 12582912 crc BC5F8666 md5 AB3BB51E491CC39FDC2F4BB95F4F1E52 sha1 35DF68D6C1BE28EF72ED54AD7F19BF1504C43C2A flags verified )
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [!].z64" size 12582912 crc F120CC52 md5 CCA4E87EC206B5B65AEAB9531C0F275B sha1 10924AB3C8909B18DAE64FEDE304AF2A08D7FFE1 )
 )
 
 game (
 	name "Kiratto Kaiketsu! 64 Tanteidan (Japan)"
 	description "Kiratto Kaiketsu! 64 Tanteidan (Japan)"
 	rom ( name "Kiratto Kaiketsu! 64 Tanteidan (Japan).n64" size 12582912 crc 9FC8A30C md5 57814D8E06DEE516B9873509C04AEA1E sha1 C6B8349A834853501397225E29D2A7DECEDD07F1 flags verified )
+	rom ( name "Kira to Kaiketsu! 64 Tanteidan (J) [!].z64" size 12582912 crc 7FDC3784 md5 32257BFFFD9B2D680F582E148E9B0611 sha1 5340930EE4A26D8897C8734EE812E769C162BE0F )
 )
 
 game (
 	name "Kirby 64 - The Crystal Shards (Europe)"
 	description "Kirby 64 - The Crystal Shards (Europe)"
 	rom ( name "Kirby 64 - The Crystal Shards (Europe).n64" size 33554432 crc F1EB0F93 md5 1AF046C0638F8E401270976841D1AB58 sha1 47CD5958A26E9A118CF7D15B65D613DB894FA8B7 flags verified )
+	rom ( name "Kirby 64 - The Crystal Shards (E) [!].z64" size 33554432 crc 5B8B89EF md5 A44B7A612964A6D6139D0426E569D9C9 sha1 52E8382252EC9B629662153EAE6F87AE3675B700 )
 )
 
 game (
@@ -2351,60 +2661,76 @@ game (
 	name "Knife Edge - Nose Gunner (Europe)"
 	description "Knife Edge - Nose Gunner (Europe)"
 	rom ( name "Knife Edge - Nose Gunner (Europe).n64" size 8388608 crc 35B61293 md5 7F5681A7C28870C568A92D3639EBE0E3 sha1 FEAF0B775E71DD35D5A1FEF72E3CF4CE6E06D230 flags verified )
+	rom ( name "Knife Edge - Nose Gunner (E) [!].z64" size 8388608 crc B77783BE md5 D31A94A5685A21A932CC886D64CC9B21 sha1 5359C747E91C9119FDE3A7920333A9D0C04D251D )
 )
 
 game (
 	name "Knife Edge - Nose Gunner (Japan)"
 	description "Knife Edge - Nose Gunner (Japan)"
 	rom ( name "Knife Edge - Nose Gunner (Japan).n64" size 8388608 crc 2FF68ED9 md5 1152129CAC86E01ADF68D1ED052BC679 sha1 5E1ECEDDB5FD98A08DD5F08CE85FF6F9DFF34417 flags verified )
+	rom ( name "Knife Edge - Nose Gunner (J) [!].z64" size 8388608 crc 3BC93017 md5 436BA873E9466AAB237D9429348A5F70 sha1 B3242226237A401436D9D7A8D533296333E64240 )
 )
 
 game (
 	name "Knife Edge - Nose Gunner (USA)"
 	description "Knife Edge - Nose Gunner (USA)"
 	rom ( name "Knife Edge - Nose Gunner (USA).n64" size 8388608 crc CF204405 md5 2CCBEA019D3D1AAA1E8E6198DD677573 sha1 B6B92B53285D22967E2250B6D020350EAFB72643 )
+	rom ( name "Knife Edge - Nose Gunner (U) [!].z64" size 8388608 crc 255EE1DD md5 8043D829FCD4F8F72DD81E5C6DDE916F sha1 B247167E37E7F62924BE6B0D2362A091FD2352AC )
 )
 
 game (
 	name "Knockout Kings 2000 (Europe)"
 	description "Knockout Kings 2000 (Europe)"
 	rom ( name "Knockout Kings 2000 (Europe).n64" size 16777216 crc 3C38BA4A md5 9E560C7EB237EC3B23CCF95F1BD6A535 sha1 F21EB0318863175C3DDC73757636383D824B7202 flags verified )
+	rom ( name "Knockout Kings 2000 (E) [!].z64" size 16777216 crc 58CE7D80 md5 E95D73FF55FBB63E79AA9EAB14608584 sha1 181D220EFAA3E06AC5A7BAAC4B6A351B762EC384 )
 )
 
 game (
 	name "Knockout Kings 2000 (USA)"
 	description "Knockout Kings 2000 (USA)"
 	rom ( name "Knockout Kings 2000 (USA).n64" size 16777216 crc A26533FC md5 E10DE38BC510ED100318BF313F666D1C sha1 2C8A091CB5EE9BE6AAAF390D25642E12409330F8 )
+	rom ( name "Knockout Kings 2000 (U) [!].z64" size 16777216 crc 074690D6 md5 008B473841CE4D9AC050D55F99B4B5D4 sha1 AE7229676DA9ACB39BECB03246969693585B7728 )
 )
 
 game (
 	name "Kobe Bryant in NBA Courtside (Europe)"
 	description "Kobe Bryant in NBA Courtside (Europe)"
 	rom ( name "Kobe Bryant in NBA Courtside (Europe).n64" size 12582912 crc 5ADEF1C7 md5 F388EDBB69B82BC116B7EFC020B7ACAD sha1 CAB29E7B3D9C1993801E415B5823567B8FE2F682 flags verified )
+	rom ( name "Kobe Bryant in NBA Courtside (E) [!].z64" size 12582912 crc 1355A826 md5 C6B01C020FDFD2E5C037C5A330B161AD sha1 6390DC1CD4600CA57069D92F39F108A4CC1B62F1 )
 )
 
 game (
 	name "Kobe Bryant's NBA Courtside (USA)"
 	description "Kobe Bryant's NBA Courtside (USA)"
 	rom ( name "Kobe Bryant's NBA Courtside (USA).n64" size 12582912 crc 0FF8C439 md5 D34D9DDA767D0AF4D2E6803FC5CF81C6 sha1 C17D414B741338FD2C079B1AC6238D4ED87B0675 )
+	rom ( name "Kobe Bryant's NBA Courtside (U) [!].z64" size 12582912 crc 86360BFB md5 D37C79E4E4EABCB5DC6A07BD76688223 sha1 49346B3124750C14DDDF56B9BB2FE38B618F28F2 )
 )
 
 game (
 	name "Last Legion UX (Japan)"
 	description "Last Legion UX (Japan)"
 	rom ( name "Last Legion UX (Japan).n64" size 12582912 crc C3DAF1AA md5 8FF522EBFEA649A45B8A8247AFE2875E sha1 3D434DF177270A319B83D99DF74F0C2D59C8C370 flags verified )
+	rom ( name "Last Legion UX (J) [!].z64" size 12582912 crc 9DB99881 md5 EB11FC0797AE1107201C4601FEE5471A sha1 DFDF852D0939466AD1F1627F4DE29B7288A77589 )
 )
 
 game (
 	name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)"
 	description "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)"
 	rom ( name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).n64" size 33554432 crc 9267F4BA md5 53990A4AE36382AE17D15E26EDF89C92 sha1 8BF74834C614F6CCB7C659B82DFDC68BA61301A4 flags verified )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!].z64" size 33554432 crc 9EAD1608 md5 13FAB67E603B002CEAF0EEA84130E973 sha1 C04599CDAFEE1C84A7AF9A71DF68F139179ADA84 )
 )
 
 game (
 	name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A)"
 	description "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A)"
 	rom ( name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A).n64" size 33554432 crc 1D4D50B7 md5 59BFB6DE226C9CFD6825EA59EA5D8663 sha1 B02A477871BBB90E75F09E714BF30991FD2B8CAF )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1).z64" size 33554432 crc E2E6823D md5 BECCFDED43A2F159D03555027462A950 sha1 BB4E4757D10727C7584C59C1F2E5F44196E9C293 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (USA) (GC)"
+	description "Legend of Zelda, The - Majora's Mask (USA) (GC)"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) (GC).z64" size 33554432 crc B008458F md5 AC0751DBC23AB2EC0C3144203ACA0003 sha1 9743AA026E9269B339EB0E3044CD5830A440C1FD )
 )
 
 game (
@@ -2417,7 +2743,8 @@ game (
 game (
 	name "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
 	description "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
-	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo).n64" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo)" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
+	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc DCC110A0 md5 8F281800FBA5DDCB1D2B377731FC0215 sha1 2F0744F2422B0421697A74B305CB1EF27041AB11 )
 )
 
 game (
@@ -2427,15 +2754,35 @@ game (
 )
 
 game (
+	name "Legend of Zelda, The - Majora's Mask - Collector's Edition (Europe) (M4) (GC)"
+	description "Legend of Zelda, The - Majora's Mask - Collector's Edition (Europe) (M4) (GC)"
+	rom ( name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!].z64" size 33554432 crc 12836E19 md5 DBE9AF0DB46256E42B5C67902B696549 sha1 A849A65E56D57D4DD98B550524150F898DF90A9F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (Europe) (GC)"
+	description "Legend of Zelda, The - Ocarina of Time (Europe) (GC)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!].z64" size 33554432 crc 3FBD519F md5 2C27B4E000E85FD78DBCA551F1B1C965 sha1 0227D7C0074F2D0AC935631990DA8EC5914597B4 )
+)
+
+game (
 	name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)"
 	description "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).n64" size 33554432 crc 9852A62F md5 9526B263B60577D8ED22FB7A33C2FACD sha1 D0BDC2EB320668B4BA6893B9AEFE4040A73123FF flags verified )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!].z64" size 33554432 crc 946FD0F7 md5 E040DE91A74B61E3201DB0E2323F768A sha1 328A1F1BEBA30CE5E178F031662019EB32C5F3B5 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A)"
 	description "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A).n64" size 33554432 crc AB0FFBAE md5 AE0D5CE5C27D4ECCBB6D206B854A7159 sha1 663C34F1B2C05A09E5BEFFE4D0DCD440F7D49DC7 flags verified )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!].z64" size 33554432 crc A108F6E3 md5 D714580DD74C2C033F5E1B6DC0AEAC77 sha1 CFBB98D392E4A9D39DA8285D10CBEF3974C2F012 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (USA) (GC)"
+	description "Legend of Zelda, The - Ocarina of Time (USA) (GC)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!].z64" size 33554432 crc 346DE3AE md5 CD09029EDCFB7C097AC01986A0F83D3F sha1 B82710BA2BD3B4C6EE8AA1A7E9ACF787DFC72E9B )
 )
 
 game (
@@ -2449,24 +2796,34 @@ game (
 	name "Legend of Zelda, The - Ocarina of Time (USA) (Rev A)"
 	description "Legend of Zelda, The - Ocarina of Time (USA) (Rev A)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (Rev A).n64" size 33554432 crc AA07C8BA md5 A9A86A09677B0394F15C62CA60906FBD sha1 18CD0EB65914A21D8FA08DFE71C29D865E9D728A flags verified )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!].z64" size 33554432 crc 3FD2151E md5 721FDCC6F5F34BE55C43A807F2A16AF4 sha1 D3ECB253776CD847A5AA63D859D8C89A2F37B364 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time (USA) (Rev B)"
 	description "Legend of Zelda, The - Ocarina of Time (USA) (Rev B)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (Rev B).n64" size 33554432 crc 3C7DBF5B md5 1F26107A97CD9D923DF493EBFBFD234D sha1 3AC86253E0C0D55486D212E647350C1527B9C92D )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!].z64" size 33554432 crc 32120C23 md5 57A9719AD547C516342E1A15D5C28C3D sha1 41B3BDC48D98C48529219919015A1AF22F5057C2 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version)"
 	description "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version).n64" size 67108864 crc 2EE3E247 md5 DDE376D47187B931820D5B2957CDED14 sha1 973BC6FE56010A8D646166A1182A81B4F13B8CF9 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version).z64" size 67108864 crc 62F92704 md5 8CA71E87DE4CE5E9F6EC916202A623E9 sha1 50BEBEDAD9E0F10746A52B07239E47FA6C284D03 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GC)"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GC)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!].z64" size 33554432 crc C744C4DB md5 DA35577FE54579F6A266931CC75F512D sha1 8B5D13AAC69BFBF989861CFDC50B1D840945FC1D )
 )
 
 game (
 	name "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	description "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	rom ( name "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" size 16777216 crc 3D4679E5 md5 0224FEB5786ED25BB0B21BF6FE180BAD sha1 C221ABC794BB1C67DA5499ACEA8C80222B200A90 flags verified )
+	rom ( name "LEGO Racers (E) (M10) [!].z64" size 16777216 crc C7D9B21C md5 6310C7173385ED2B06020F3B90158E9E sha1 6E9C4B097628F0147E9E79393DBA6D7B4E59986F )
 )
 
 game (
@@ -2480,132 +2837,154 @@ game (
 	name "Let's Smash (Japan)"
 	description "Let's Smash (Japan)"
 	rom ( name "Let's Smash (Japan).n64" size 12582912 crc 33543946 md5 160FAE47DE863D4A772CB01A95CEF2E1 sha1 7DD60D27CC1CABF70A380FA2A567621EF8E69DCD flags verified )
+	rom ( name "Let's Smash Tennis (J) [!].z64" size 12582912 crc 455A1770 md5 AEE5016E6D60D12AD768E9F6D10ADDE8 sha1 6FDA28A79CEC30B6C52C3DBC96B513DA16BFA4D0 )
 )
 
 game (
 	name "Lode Runner 3-D (Europe) (En,Fr,De,Es,It)"
 	description "Lode Runner 3-D (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Lode Runner 3-D (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc 78707CEA md5 879D630EF468FF1873FDE9CC860B3D8D sha1 80C368DA49A956756D14D4E5B313E3D64A772F36 flags verified )
+	rom ( name "Lode Runner 3-D (E) (M5) [!].z64" size 8388608 crc 7148251D md5 E62F4FDCC82C244BA9709E40756D9B62 sha1 3B198C0117DA808B25FBC4E543D282228BB4780A )
 )
 
 game (
 	name "Lode Runner 3-D (Japan)"
 	description "Lode Runner 3-D (Japan)"
 	rom ( name "Lode Runner 3-D (Japan).n64" size 8388608 crc 8A1AE6A7 md5 EF70842D44DA034ED89CDCB2520109C7 sha1 62C0D2599BB3EBBAB3602F5E1CB5CFC2626506D4 flags verified )
+	rom ( name "Lode Runner 3-D (J) [!].z64" size 8388608 crc 1D4FB466 md5 D2BD8DD8C3BE1E8F0B8AE49206DBD7E5 sha1 A115C19E1DEA438861437A326124C0E7A482DE3B )
 )
 
 game (
 	name "Lode Runner 3-D (USA)"
 	description "Lode Runner 3-D (USA)"
 	rom ( name "Lode Runner 3-D (USA).n64" size 8388608 crc 5AF38589 md5 A884DFD24237F838FC902C2CA0D5A3F4 sha1 361CA0A284CE8DE1B8E54716ED3952A179E0A148 )
+	rom ( name "Lode Runner 3-D (U) [!].z64" size 8388608 crc 4EA07453 md5 D038813541589F0B3F1F900F4FD22C9B sha1 D3A13C0CFDFF835FDF87D5DC7C5149FBA564877F )
 )
 
 game (
 	name "Lylat Wars (Australia) (En,Fr,De)"
 	description "Lylat Wars (Australia) (En,Fr,De)"
 	rom ( name "Lylat Wars (Australia) (En,Fr,De).n64" size 12582912 crc ED1249A5 md5 A51F94CA0CE8BFE1BAD0192957F0DCE0 sha1 9CBF5087D5684D3B5329630932EB2BFB29AF8511 )
+	rom ( name "Lylat Wars (A) (M3) [!].z64" size 12582912 crc 9A3425DA md5 7A99628EDF0A6602D0C408F31B701435 sha1 47A8CCC11450F9044CA2292B9FC3C58949B9CAAC )
 )
 
 game (
 	name "Lylat Wars (Europe) (En,Fr,De)"
 	description "Lylat Wars (Europe) (En,Fr,De)"
 	rom ( name "Lylat Wars (Europe) (En,Fr,De).n64" size 12582912 crc 94A1A16A md5 204A14C2AC815AFEE74B58EF9394708D sha1 8DE2942E59E31FEA235AD672F6096294D8E7D12E flags verified )
+	rom ( name "Lylat Wars (E) (M3) [!].z64" size 12582912 crc 50A9C0B1 md5 884CCCA35CBEEDB8ED288326F9662100 sha1 05B307B8804F992AF1A1E2FBAFBD588501FDF799 )
 )
 
 game (
 	name "Mace - The Dark Age (Europe)"
 	description "Mace - The Dark Age (Europe)"
 	rom ( name "Mace - The Dark Age (Europe).n64" size 12582912 crc 4BDF2D6C md5 C325018C2DD647A4761B29DBB87DC03C sha1 904AE518FD489EF94E0F379A4020D96A1771C2C0 flags verified )
+	rom ( name "Mace - The Dark Age (E) [!].z64" size 12582912 crc 57DDEDE1 md5 523883A766C662E8377CD256755B27B4 sha1 19FC1FE13A3C50A5D03D44D2E93440967C7F3618 )
 )
 
 game (
 	name "Mace - The Dark Age (USA)"
 	description "Mace - The Dark Age (USA)"
 	rom ( name "Mace - The Dark Age (USA).n64" size 12582912 crc E49D603A md5 F56E658854300DB6CEDF9B3C41983CED sha1 55D187B8AE20D2271F96FA9A8FB76FC11301A2EB )
+	rom ( name "Mace - The Dark Age (U) [!].z64" size 12582912 crc D2A363A6 md5 39A2BCA1C17CD4CF1A9F3AE2B725B5C6 sha1 05D82A2C73AC536180B68137DBB9972A9E8E883E )
 )
 
 game (
 	name "Madden Football 64 (Europe)"
 	description "Madden Football 64 (Europe)"
 	rom ( name "Madden Football 64 (Europe).n64" size 12582912 crc C39F863D md5 46721FF8604B3F18E3FC2B0C28C5CEBD sha1 711C709393CDC4D76CA9E3CC669504144F554BC5 flags verified )
+	rom ( name "Madden Football 64 (E) [!].z64" size 12582912 crc FAB3E50D md5 67C96076459EB5F71733F39D7FCC76A3 sha1 ACF22B715B11609F42DF24ABAC143BC0221D12F4 )
 )
 
 game (
 	name "Madden Football 64 (USA)"
 	description "Madden Football 64 (USA)"
 	rom ( name "Madden Football 64 (USA).n64" size 12582912 crc 43B28179 md5 14F3988408E222F8B1A0FC9D8E2C6DF6 sha1 65FDC159374E6161A0CE0BA8ED520A669512094F )
+	rom ( name "Madden Football 64 (U) [!].z64" size 12582912 crc 42E5FAFA md5 903B912CE88626900221731224E9DBE8 sha1 B0DE34B759F18AD86D39A4C68C9840D35CE25809 )
 )
 
 game (
 	name "Madden NFL 2000 (USA)"
 	description "Madden NFL 2000 (USA)"
 	rom ( name "Madden NFL 2000 (USA).n64" size 12582912 crc F41B2332 md5 50E191F2CDC12AAEDBD6694C6D6BB431 sha1 A2A09DFDE793BD42F5B3C11429628E48794091B1 )
+	rom ( name "Madden NFL 2000 (U) [!].z64" size 12582912 crc EF5F997B md5 955D19E26B4BA7CC941F86A54A0FC13D sha1 EC01DE96960EA23A9EE997F4456C5C8EE7BAF7E4 )
 )
 
 game (
 	name "Madden NFL 2001 (USA)"
 	description "Madden NFL 2001 (USA)"
 	rom ( name "Madden NFL 2001 (USA).n64" size 12582912 crc 3B49EC33 md5 6B386503E10CA7494C20B6BE4FC1EADF sha1 FBA3C676A8ACD733F16DDF7EF9BF95811974F9F1 )
+	rom ( name "Madden NFL 2001 (U) [!].z64" size 12582912 crc 245EAEE8 md5 441FA65FAA5C12339F89A0BB7DB43C8F sha1 93F5BA646098E1AA45ECEC6312604A0932EDD24B )
 )
 
 game (
 	name "Madden NFL 2002 (USA)"
 	description "Madden NFL 2002 (USA)"
 	rom ( name "Madden NFL 2002 (USA).n64" size 12582912 crc 0C711DFE md5 6D90DAA85DF1667C3B7CD431AF703A3F sha1 DF3F696131141B4E5BC9E71A72A9815FB24C9112 )
+	rom ( name "Madden NFL 2002 (U) [!].z64" size 12582912 crc F573F107 md5 AD0F2EC565D7575FB37512BC8DF8A092 sha1 DE51147A238158ADC059D0CC75FD39BBB08DCFC6 )
 )
 
 game (
 	name "Madden NFL 99 (Europe)"
 	description "Madden NFL 99 (Europe)"
 	rom ( name "Madden NFL 99 (Europe).n64" size 12582912 crc 5DCAD836 md5 62BA00F622C9AFA26E5C4D4E9F8B3D28 sha1 C6D88BBF811E3973EF6B9FB8A565424ABF2C15B6 flags verified )
+	rom ( name "Madden NFL 99 (E) [!].z64" size 12582912 crc D0929942 md5 E7BF80861A0AB2A788959463D953B5D5 sha1 7C55BA6741DCF96208432507B8191B3C15F666DF )
 )
 
 game (
 	name "Madden NFL 99 (USA)"
 	description "Madden NFL 99 (USA)"
 	rom ( name "Madden NFL 99 (USA).n64" size 12582912 crc AC21A5BF md5 CE6D203535E27FB7A98FD6F2C10490A8 sha1 FD5DA6FEF67461FB5D6767D933663DCFA6E0F054 )
+	rom ( name "Madden NFL 99 (U) [!].z64" size 12582912 crc 2EB64FC2 md5 507CEAB72EF2A1BF145BF190F5CE1C80 sha1 2E8595C6EA0267A0344C0E203B4B08F00A42B13A )
 )
 
 game (
 	name "Magical Tetris Challenge (Europe)"
 	description "Magical Tetris Challenge (Europe)"
 	rom ( name "Magical Tetris Challenge (Europe).n64" size 16777216 crc BF53BF3D md5 5B0931119D80F5EDFFCDBD0B9F612228 sha1 4885E3951584032FB0254CBBDBA9961C45C3D10F flags verified )
+	rom ( name "Magical Tetris Challenge (E) [!].z64" size 16777216 crc AF3B099E md5 20E51B27E8098A9D101B44689014C281 sha1 ECC73F8A0A530EE42A56B46611DA6F74B728FE7D )
 )
 
 game (
 	name "Magical Tetris Challenge (Germany)"
 	description "Magical Tetris Challenge (Germany)"
 	rom ( name "Magical Tetris Challenge (Germany).n64" size 16777216 crc 16995CF8 md5 6DBE632A26B64EFE3E6372A14A8304F5 sha1 DF058519CCE4B5517B10C633F2A2DBD882018F47 )
+	rom ( name "Magical Tetris Challenge (G) [!].z64" size 16777216 crc 377F18E9 md5 E0992A90191BE4F1B2BA02258599334E sha1 ACE81319209D50D074418934554CBFB261D27288 )
 )
 
 game (
 	name "Magical Tetris Challenge (USA)"
 	description "Magical Tetris Challenge (USA)"
 	rom ( name "Magical Tetris Challenge (USA).n64" size 16777216 crc 167C60E6 md5 25F5F55C6938175F06140099A1FF46A9 sha1 D0CBBE4E61AF75B6BC41AE76881F81B499F1AE3E )
+	rom ( name "Magical Tetris Challenge (U) [!].z64" size 16777216 crc 22FE979C md5 79FCC98002D1F4C79DEAF55784222DF8 sha1 CA3FBD17406031A88E04BB79959D851550B641D0 )
 )
 
 game (
 	name "Magical Tetris Challenge featuring Mickey (Japan)"
 	description "Magical Tetris Challenge featuring Mickey (Japan)"
 	rom ( name "Magical Tetris Challenge featuring Mickey (Japan).n64" size 16777216 crc 6D3EBA8B md5 980CE31C0DC220C1DA8D73322B70CA88 sha1 43848D4A70A0D33B4C94B340895F0A09561B6BBC flags verified )
+	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [!].z64" size 16777216 crc 7EFB2F1E md5 F1FF1F364C459701F42BEB8989675D44 sha1 FE7C8FA25EA09280F94D08623BB8838D88EEC2E3 )
 )
 
 game (
 	name "Mahjong 64 (Japan)"
 	description "Mahjong 64 (Japan)"
 	rom ( name "Mahjong 64 (Japan).n64" size 8388608 crc 0FB9138C md5 AEC0D0CFD27C0771FF41870ACFA83DC6 sha1 3C9D98DFC27E9B5A8F085A2F189F42E2A77A970E flags verified )
+	rom ( name "Mahjong 64 (J) [!].z64" size 8388608 crc DBE7D51A md5 8AE2E8F0C356FEE638C8D908DCBB3381 sha1 41C73C372FF316322593B791D09934B37C461F9F )
 )
 
 game (
 	name "Mahjong Hourouki Classic (Japan)"
 	description "Mahjong Hourouki Classic (Japan)"
 	rom ( name "Mahjong Hourouki Classic (Japan).n64" size 12582912 crc FD9EA0D5 md5 4FC66A872680B5EBE1A4402B85B33E21 sha1 DBB8E86F53953ABC97FA015F50523264689D3331 flags verified )
+	rom ( name "Mahjong Hourouki Classic (J) [!].z64" size 12582912 crc 990A8E54 md5 E942A3EEB1EB572BADD6F705EB12A22C sha1 405E6BCB6AD4A1452FE50AAC1278A3F411C378C0 )
 )
 
 game (
 	name "Mahjong Master (Japan)"
 	description "Mahjong Master (Japan)"
 	rom ( name "Mahjong Master (Japan).n64" size 8388608 crc DB0B662A md5 BCD1E29BB785D81B6DDE356E5E270B4E sha1 734F5865D4E293A3FC28E167A0AAF79DDEFE8837 flags verified )
+	rom ( name "Mahjong Master (J) [!].z64" size 8388608 crc B68D596F md5 CF0D228E8EFDF823A227979BB352DD5B sha1 556DD6DBBEC02680E47362552D2BABD4F8720050 )
 )
 
 game (
@@ -2615,15 +2994,23 @@ game (
 )
 
 game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (Europe)"
+	description "Major League Baseball Featuring Ken Griffey Jr. (Europe)"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [!].z64" size 16777216 crc E08F7578 md5 152B9939A5F50734D5401980028856B4 sha1 E300E8ACB110D72BC5BFEE4FC4981E09B881300E )
+)
+
+game (
 	name "Major League Baseball featuring Ken Griffey Jr. (USA)"
 	description "Major League Baseball featuring Ken Griffey Jr. (USA)"
 	rom ( name "Major League Baseball featuring Ken Griffey Jr. (USA).n64" size 16777216 crc 7542D45D md5 3A99F4F24ADEE8C6E53BCC410FBD35FE sha1 EE0AB1E8AF669712AFBAF4B9BBCEE62E8EB13A4A )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [!].z64" size 16777216 crc 2EF1EA20 md5 764F22AD3D0F59667A7F083D2F789B31 sha1 54B8C97523089D92754C2582A7B7A43246947122 )
 )
 
 game (
 	name "Mario Golf (Europe)"
 	description "Mario Golf (Europe)"
 	rom ( name "Mario Golf (Europe).n64" size 33554432 crc 1CA3E8B6 md5 D5033F389476733D5730B112F61C2D47 sha1 B77C8A9F163FEB9AE2F2253B6D9EC82D77B7088C flags verified )
+	rom ( name "Mario Golf (E) [!].z64" size 25165824 crc E5D723C7 md5 4D010AE1AF4B04D6B70B799C56F05993 sha1 3AEC0837A5C2AACF172A83D7F60BD5B004B5DE72 )
 )
 
 game (
@@ -2637,6 +3024,7 @@ game (
 	name "Mario Golf 64 (Japan)"
 	description "Mario Golf 64 (Japan)"
 	rom ( name "Mario Golf 64 (Japan).n64" size 33554432 crc 889091FD md5 D8196C554ABD7A8C71F8BA225DB3B1AF sha1 137B9591194489CFC33D29FA0B054D9954DB4E1E flags verified )
+	rom ( name "Mario Golf 64 (J) [!].z64" size 25165824 crc 911F179A md5 E5A041B1B7C8E3B4C2E8178E5A138E2D sha1 0B57E0859BC984105C669DEEFDC866231DEB1BD9 )
 )
 
 game (
@@ -2649,24 +3037,28 @@ game (
 	name "Mario Kart 64 (Europe)"
 	description "Mario Kart 64 (Europe)"
 	rom ( name "Mario Kart 64 (Europe).n64" size 12582912 crc 6787E212 md5 02B214F4C1A288DD74E2870723C6FED3 sha1 F1324F0A316ED895A92097B949E3AA74AEFEDDA5 flags verified )
+	rom ( name "Mario Kart 64 (E) (V1.0) [!].z64" size 12582912 crc FAA6B083 md5 8FAD1E4FA7BAF1443B7F21AD1947B429 sha1 A729039453210B84F17019DDA3F248D5888F7690 )
 )
 
 game (
 	name "Mario Kart 64 (Europe) (Rev A)"
 	description "Mario Kart 64 (Europe) (Rev A)"
 	rom ( name "Mario Kart 64 (Europe) (Rev A).n64" size 12582912 crc 032625B0 md5 4172E73D0F2939683214D631F9E4F51E sha1 F18317BFD7FBCAEA6CFBFCB9C4AE3C7C7D1D66C7 flags verified )
+	rom ( name "Mario Kart 64 (E) (V1.1) [!].z64" size 12582912 crc 0248F6C3 md5 2BB149A583FDEFEA96805F628FE42FD9 sha1 F6B5F519DD57EA59E9F013CC64816E9D273B2329 )
 )
 
 game (
 	name "Mario Kart 64 (Japan)"
 	description "Mario Kart 64 (Japan)"
 	rom ( name "Mario Kart 64 (Japan).n64" size 12582912 crc 4711A9DC md5 F5037802F4485B9CAE6158AC5F9EF0B7 sha1 991D4F714730CDEF771AB1E32DA5A324388619B7 flags verified )
+	rom ( name "Mario Kart 64 (J) (V1.0) [!].z64" size 12582912 crc 5D9696DF md5 BF964CECA78A13A82055EBDA80B95CCA sha1 AFEEEC65B9A03F0CB8EC92F9BA7A9F0122E8BD0E )
 )
 
 game (
 	name "Mario Kart 64 (Japan) (Rev A)"
 	description "Mario Kart 64 (Japan) (Rev A)"
 	rom ( name "Mario Kart 64 (Japan) (Rev A).n64" size 12582912 crc 26450AAB md5 7C5002BF20B22CAA2226A0C382974D62 sha1 42769BC9467DF9A517A88E28F9CE2B6956A7A15F )
+	rom ( name "Mario Kart 64 (J) (V1.1) [!].z64" size 12582912 crc 6CED6472 md5 60535265BAE43DDFCBDB0D71594B1693 sha1 9F439457585146A4E1DA7E1DD9104F7F94381688 )
 )
 
 game (
@@ -2680,18 +3072,21 @@ game (
 	name "Mario no Photopie (Japan)"
 	description "Mario no Photopie (Japan)"
 	rom ( name "Mario no Photopie (Japan).n64" size 16777216 crc 49E24AE2 md5 E3AD4BF0504D18FFE35B6D9C7A736CD3 sha1 F8BBA2635AADE03FB700C1614F36AA5A605AF85E flags verified )
+	rom ( name "Mario no Photopie (J) [!].z64" size 16777216 crc 1D69CA55 md5 6BAB5F2A62A4BABAF456D5DA2976871D sha1 8C3C75C484CB7636490331162BB5C41E2FBE8A8B )
 )
 
 game (
 	name "Mario Party (Europe) (En,Fr,De)"
 	description "Mario Party (Europe) (En,Fr,De)"
 	rom ( name "Mario Party (Europe) (En,Fr,De).n64" size 33554432 crc 6973373F md5 9AAE6D37096F2D543160710ECB691AC5 sha1 2F8B0BF9861D10B4C1C5B9C0F0C47333C96DBE30 flags verified )
+	rom ( name "Mario Party (E) (M3) [!].z64" size 33554432 crc DA98A5D3 md5 9773150709BD804B8E57E35F1D6B0EED sha1 D7BA071C220A71F5E4503E55C98C91FF8F027848 )
 )
 
 game (
 	name "Mario Party (Japan)"
 	description "Mario Party (Japan)"
 	rom ( name "Mario Party (Japan).n64" size 33554432 crc 7D387E37 md5 ACBD5528540A2EE9DE209C2CF92D1B4C sha1 82D03C229F37B7E8AF72F4EE867022E4FA0F1F99 flags verified )
+	rom ( name "Mario Party (J) [!].z64" size 33554432 crc 4F1ADC7B md5 3F556CC3B3A996CD2F471FA0D992D529 sha1 37FD6D27F55C468DC36EFB92A255F7AB04FFC0A8 )
 )
 
 game (
@@ -2705,12 +3100,14 @@ game (
 	name "Mario Party 2 (Europe) (En,Fr,De,Es,It)"
 	description "Mario Party 2 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Mario Party 2 (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc 8C0C8BEC md5 A838E03022502B3A0B945286C0496AD1 sha1 130BDC56FBE29FC27645E21959B27322C342728C flags verified )
+	rom ( name "Mario Party 2 (E) (M5) [!].z64" size 33554432 crc DC00357A md5 F70112B652B0EE4856AF83F4E8005C31 sha1 FA5D1426488B298A1C5C383360A78F1A3DE18DC7 )
 )
 
 game (
 	name "Mario Party 2 (Japan)"
 	description "Mario Party 2 (Japan)"
 	rom ( name "Mario Party 2 (Japan).n64" size 33554432 crc E19BF21C md5 5AF4CAD99D4E3AABE119A705F5CC75C0 sha1 FD523DFF2F552A766993EBB5F056F15FCF52E17F flags verified )
+	rom ( name "Mario Party 2 (J) [!].z64" size 33554432 crc 7457B081 md5 F23E4CD437465F3E725262253CF3EA59 sha1 26F4637167AAAA0E420BB4FDB26A965FD34F8D19 )
 )
 
 game (
@@ -2724,12 +3121,14 @@ game (
 	name "Mario Party 3 (Europe) (En,Fr,De,Es)"
 	description "Mario Party 3 (Europe) (En,Fr,De,Es)"
 	rom ( name "Mario Party 3 (Europe) (En,Fr,De,Es).n64" size 33554432 crc A5D78A36 md5 5B8C0C27F64DEB890FDE54E83B313E26 sha1 E8BA773A4FD1251A78EEFCF1F3CBE1F0054A8A38 flags verified )
+	rom ( name "Mario Party 3 (E) (M4) [!].z64" size 33554432 crc 813B13F2 md5 8E62EC6FBE3CC9FF6284191C9C88E68F sha1 9E1DDFE872C6D43AE51010A9E8A6FE2D2E634B50 )
 )
 
 game (
 	name "Mario Party 3 (Japan)"
 	description "Mario Party 3 (Japan)"
 	rom ( name "Mario Party 3 (Japan).n64" size 33554432 crc 703586D1 md5 EADBAFE27F4982A80AEF897019BD7A78 sha1 89B91548C6C5943E95EEBFB8A4DF84FB98D3D905 flags verified )
+	rom ( name "Mario Party 3 (J) [!].z64" size 33554432 crc 3FC04053 md5 ED99F330CE7A2638AB13351012EEB86B sha1 43CF5EB8BD68EF57BA1C9B4CAE7BD18F1826E543 )
 )
 
 game (
@@ -2743,12 +3142,14 @@ game (
 	name "Mario Story (Japan)"
 	description "Mario Story (Japan)"
 	rom ( name "Mario Story (Japan).n64" size 41943040 crc 1FB7E59A md5 B235F3A025AD5B62F330CF2D7C9F007F sha1 01C32F527383B4EC69ECC7805C485B7FB9A76CE0 flags verified )
+	rom ( name "Mario Story (J) [!].z64" size 41943040 crc BD60CA66 md5 DF54F17FB84FB5B5BCF6AA9AF65B0942 sha1 B9CCA3FF260B9FF427D981626B82F96DE73586D3 )
 )
 
 game (
 	name "Mario Tennis (Europe)"
 	description "Mario Tennis (Europe)"
 	rom ( name "Mario Tennis (Europe).n64" size 16777216 crc 0F03CA6E md5 C4A2DFC5C9D5041B2D6575DB191BF3F3 sha1 F7C4535CE92CA794C4B26E09E74072125AE97DAB flags verified )
+	rom ( name "Mario Tennis (E) [!].z64" size 16777216 crc 29AA5DF4 md5 FFF9B3E22ABB9B60215DAFB13AD5A4DE sha1 B5E4AA1ABF8FC8022FC47F30CD6D4AC6A6B21684 )
 )
 
 game (
@@ -2762,6 +3163,7 @@ game (
 	name "Mario Tennis 64 (Japan)"
 	description "Mario Tennis 64 (Japan)"
 	rom ( name "Mario Tennis 64 (Japan).n64" size 16777216 crc 17C5515B md5 6B7D1DB6AFFBDD27D08C7329C3CE28E2 sha1 FB7F917AA3F40DBDE33107F1C949301AF8470C2E flags verified )
+	rom ( name "Mario Tennis 64 (J) [!].z64" size 16777216 crc C665301D md5 8EB1C2443D0B2E6EDA52A4EEA66D6C35 sha1 8AA424795BBE87C659F777D0843E236340B12E16 )
 )
 
 game (
@@ -2775,66 +3177,77 @@ game (
 	name "Mia Hamm Soccer 64 (USA) (En,Es)"
 	description "Mia Hamm Soccer 64 (USA) (En,Es)"
 	rom ( name "Mia Hamm Soccer 64 (USA) (En,Es).n64" size 16777216 crc 3AA4BFF5 md5 537D7CFED7A0F3287D711F187E70B2FC sha1 656DAA19BC199929EF2ED52F841487E3FFAC7692 )
+	rom ( name "Mia Hamm Soccer 64 (U) (M2) [!].z64" size 16777216 crc 2DB3D3D6 md5 A4039368E0472C68E3072C02C7A80F94 sha1 62CE9D1C1F4CF7BEAA1EF7C456C155F63F13F057 )
 )
 
 game (
 	name "Michael Owen's World League Soccer 2000 (Europe)"
 	description "Michael Owen's World League Soccer 2000 (Europe)"
 	rom ( name "Michael Owen's World League Soccer 2000 (Europe).n64" size 16777216 crc FAFFEF70 md5 AA451044641D7AEB94A33E891D0AD592 sha1 B2C6442F2E04FEC284AC4C4F7439059FA2315700 flags verified )
+	rom ( name "Michael Owens WLS 2000 (E) [!].z64" size 16777216 crc BB680CBE md5 892222CC4BAF9958405D20BC492175BF sha1 F629A56ED36FB3889841A047D7C4CD2B9731EB43 )
 )
 
 game (
 	name "Mickey no Racing Challenge USA (Japan)"
 	description "Mickey no Racing Challenge USA (Japan)"
 	rom ( name "Mickey no Racing Challenge USA (Japan).n64" size 33554432 crc 915A43EE md5 FB28BF7DDE6DB9846072D8F5F34D665F sha1 74B76CB5075663E568EEBF9AC977E08CDBA17BA9 flags verified )
+	rom ( name "Mickey no Racing Challenge USA (J) [!].z64" size 33554432 crc 1AECFC56 md5 288A514E98972BF9D329167AA29E66B6 sha1 5B4F7BAD6591DE2199C095352A811A2EB7FC6F53 )
 )
 
 game (
 	name "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)"
 	description "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc DDF28F6B md5 658641D0532BCD0059C333B00EC3B595 sha1 BF43FA4A34CEFB537271DD71DB8DB47F5B4A29FD flags verified )
+	rom ( name "Mickey's Speedway USA (E) (M5) [!].z64" size 33554432 crc 0AE51EA5 md5 5BA3DC37860C08A209F24286B8DFEC8C sha1 C583ED998A6B422A22FFD3F8376C3CEF0C3710D9 )
 )
 
 game (
 	name "Mickey's Speedway USA (USA)"
 	description "Mickey's Speedway USA (USA)"
 	rom ( name "Mickey's Speedway USA (USA).n64" size 33554432 crc 6E589C47 md5 99D8FE5ED2F827FB1C43A3EA2B7CA9FD sha1 1156459D3DA0CD1AC8DA73F75AECDC23D093AFFF )
+	rom ( name "Mickey's Speedway USA (U) [!].z64" size 33554432 crc 2D4F8F1B md5 0BF64427CF68E49C70E9EC2C9D815209 sha1 507341C0A40CA3E9A7CEE969B396EE53FACFB548 )
 )
 
 game (
 	name "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)"
 	description "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 14030FF5 md5 FE6C48F7C14C518FCFC3301A135183AF sha1 B8961F88210027EE0525623242F7CED6C139DEDF flags verified )
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [!].z64" size 12582912 crc 10B9FF1F md5 9A8465E302263D635557A14AA197FE3C sha1 E5E2D6169AF2663E5519795B28BEC018934E86EE )
 )
 
 game (
 	name "Micro Machines 64 Turbo (USA)"
 	description "Micro Machines 64 Turbo (USA)"
 	rom ( name "Micro Machines 64 Turbo (USA).n64" size 12582912 crc 02790693 md5 514FAA23F81391EA58A25564EB62478F sha1 B62D18DCECAD57852B21107D5B9C026237CBEE6E )
+	rom ( name "Micro Machines 64 Turbo (U) [!].z64" size 12582912 crc A62A2763 md5 74EB415E16C333B252847A8E09432FD9 sha1 9672FA010A06ADF01074C9720EE46031F5D9E101 )
 )
 
 game (
 	name "Midway's Greatest Arcade Hits - Volume 1 (USA)"
 	description "Midway's Greatest Arcade Hits - Volume 1 (USA)"
 	rom ( name "Midway's Greatest Arcade Hits - Volume 1 (USA).n64" size 4194304 crc 202A2718 md5 68CF12426B11E75DF95D64DC6B94D41D sha1 DB7CAE68D2A73018ADA2E9587E997EC8557F8A8A )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [!].z64" size 4194304 crc E5C1FEDC md5 2B86775EA4D848202E4F4A39C33571CA sha1 E24C61AAA5CF15112258052EC78D24AD047BA5AE )
 )
 
 game (
 	name "Mike Piazza's StrikeZone (USA)"
 	description "Mike Piazza's StrikeZone (USA)"
 	rom ( name "Mike Piazza's StrikeZone (USA).n64" size 12582912 crc 9042CB8E md5 0900C5E52C6B2196E38DE6F5B8DDAD9A sha1 D333E7C755451F244F24AC56352A0C6294406016 )
+	rom ( name "Mike Piazza's Strike Zone (U) [!].z64" size 12582912 crc CC253CAB md5 EB1908E51C8D10AF8B9CAF77797BFE00 sha1 09C90701261E345C0023C55B61B37E6AAF809E57 )
 )
 
 game (
 	name "Milo's Astro Lanes (Europe)"
 	description "Milo's Astro Lanes (Europe)"
 	rom ( name "Milo's Astro Lanes (Europe).n64" size 4194304 crc 165D7BC2 md5 E9092B278DFAAEFD34716DC062CD9304 sha1 5D5AB3E386B8970C3FD61E84187315C1E8297443 flags verified )
+	rom ( name "Milo's Astro Lanes (E) [!].z64" size 4194304 crc C08CE624 md5 43B02AF2789990A14F77CE020E6F135C sha1 77DA41C16CD8989291A82159A15CE98D155916A6 )
 )
 
 game (
 	name "Milo's Astro Lanes (USA)"
 	description "Milo's Astro Lanes (USA)"
 	rom ( name "Milo's Astro Lanes (USA).n64" size 4194304 crc DFF1BA7E md5 ED92851C90F5BC542A41AC86F1DAFC30 sha1 FC5C26B0089B50624F330E9F769078D333754A5E )
+	rom ( name "Milo's Astro Lanes (U) [!].z64" size 4194304 crc 172FCA97 md5 4F256146BAC4A3DDE5AD0D5F9C909251 sha1 7A0246E367FF84B46C0BEC9A6B760D3B67B13041 )
 )
 
 game (
@@ -2847,6 +3260,7 @@ game (
 	name "Mischief Makers (Europe)"
 	description "Mischief Makers (Europe)"
 	rom ( name "Mischief Makers (Europe).n64" size 8388608 crc 12529953 md5 C895949D378443FCFC5B98515FDEB9C6 sha1 A2805E1C825157A491850B0D25C84759CA76BBB6 flags verified )
+	rom ( name "Mischief Makers (E) [!].z64" size 8388608 crc 68A4F072 md5 EB3B078A74D4DC827E1E79791004DFBB sha1 E5405AAD683959EDAB641B5DA05B8159CAC93E63 )
 )
 
 game (
@@ -2866,78 +3280,91 @@ game (
 	name "Mission Impossible (Europe)"
 	description "Mission Impossible (Europe)"
 	rom ( name "Mission Impossible (Europe).n64" size 12582912 crc C41A1EBE md5 FF2364267347871E6D62F44CA8160A03 sha1 3AA5B3B1A063DDB1F2D883AD95D04365D2C0A42A flags verified )
+	rom ( name "Mission Impossible (E) [!].z64" size 12582912 crc 2C7131D6 md5 599B5D40B51F53C2C9A909E0139702FC sha1 1A406D19F527D1E394FA140290FDE04D81D3E639 )
 )
 
 game (
 	name "Mission Impossible (France)"
 	description "Mission Impossible (France)"
 	rom ( name "Mission Impossible (France).n64" size 12582912 crc 67895343 md5 5BA6DE6E1877AF2169BCACC4FBD900AA sha1 FC28EDCAE49CA1BD298258BB693C92CF39ED39B6 )
+	rom ( name "Mission Impossible (F) [!].z64" size 12582912 crc 282A350D md5 FD0C0E8C523437F9B6B630E369FDFC69 sha1 EA934F931124DB891F12E92726FAAE5EDDE39C45 )
 )
 
 game (
 	name "Mission Impossible (Germany)"
 	description "Mission Impossible (Germany)"
 	rom ( name "Mission Impossible (Germany).n64" size 12582912 crc 20067768 md5 DF09EA446F6854A6BE030B0C74841C54 sha1 A891AEE53F10BD4E25973CE47A2E70B5CF4C90DA flags verified )
+	rom ( name "Mission Impossible (G) [!].z64" size 12582912 crc 67C30A2D md5 4111482C92EE806484AAA2C210893A52 sha1 906FFAB2F8E8EECE17E0846FFBD9EA32370206DA )
 )
 
 game (
 	name "Mission Impossible (Italy)"
 	description "Mission Impossible (Italy)"
 	rom ( name "Mission Impossible (Italy).n64" size 12582912 crc AC5C1408 md5 9BED21A83454E5D8B10F7AFA34B5786B sha1 25B1FF3432465450B4B17BB26CE9F9289EBFE65C )
+	rom ( name "Mission Impossible (I) [!].z64" size 12582912 crc 2D789D98 md5 66C7EB8148E0714B5A71F5717DFF8642 sha1 9EE0E754B7AFAF751DF281B9411EC1D8F30A894D )
 )
 
 game (
 	name "Mission Impossible (Spain)"
 	description "Mission Impossible (Spain)"
 	rom ( name "Mission Impossible (Spain).n64" size 12582912 crc E33B52F0 md5 0405DA489B59895412E60659411FBC49 sha1 244711046F77E8059E677731C2D26D0C45996DDA )
+	rom ( name "Mission Impossible (S) [!].z64" size 12582912 crc EBB060DC md5 D1BA3B1899576A4B67908ABB6544D75A sha1 D79C313B8581B558DBECA29F797D91A8B3122841 )
 )
 
 game (
 	name "Mission Impossible (USA)"
 	description "Mission Impossible (USA)"
 	rom ( name "Mission Impossible (USA).n64" size 12582912 crc 2DBD815D md5 85E09C5B9C3A6C6E7B8FCE029D5CD50D sha1 C17C89F1A8485CFD481426800870F860C2CEAE24 flags verified )
+	rom ( name "Mission Impossible (U) [!].z64" size 12582912 crc 3677A8B8 md5 EEBDFBD7CB57202D70CFFFCAAF55E93E sha1 7546D5DF1FC93FED8205A066F1333FD7DD50C1E1 )
 )
 
 game (
 	name "Monaco Grand Prix (USA)"
 	description "Monaco Grand Prix (USA)"
 	rom ( name "Monaco Grand Prix (USA).n64" size 16777216 crc 30079403 md5 1FB6AC64BE78637A9E79C1AB1D17060D sha1 75F401C150CD9210432A96CF6DB411F6F46E0047 )
+	rom ( name "Monaco Grand Prix (U) [!].z64" size 16777216 crc E2BBEAC1 md5 4FF9589A3224AAA46E9877D6B25E68E3 sha1 477F945DC38F930336E0D05CFDCBA2C4C30F6A31 )
 )
 
 game (
 	name "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)"
 	description "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)"
 	rom ( name "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).n64" size 16777216 crc 0A54FDF0 md5 257E81AC747A455A709A013A5F8CBC1F sha1 BD25283C98FC1915C07F4EE9CE58820C1D4A44B2 flags verified )
+	rom ( name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!].z64" size 16777216 crc 3F5E5830 md5 C93A17D130B96FBA27A0E959CAB2A450 sha1 39A7F5515DD822A32C0FC8D9E01A72F0C8B2A1F7 )
 )
 
 game (
 	name "Monopoly (USA)"
 	description "Monopoly (USA)"
 	rom ( name "Monopoly (USA).n64" size 8388608 crc 416B1F8F md5 B0F1BC097C75F6AC50751A1F81E209D2 sha1 99D176B45784CED5F469C64E065F6EA3E1176188 )
+	rom ( name "Monopoly (U) [!].z64" size 8388608 crc C8CAD8F6 md5 D51506EDB0A941A00EB45850703B32CB sha1 FD724BDC323AA81D4873768ACF789529CC1C08E5 )
 )
 
 game (
 	name "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)"
 	description "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc CE6779FB md5 5BAEE822A8A2EB40F4EF11F59824B83F sha1 42F1702360E5381B0C94912AE3B5BB092C04297C flags verified )
+	rom ( name "Monster Truck Madness 64 (E) (M5) [!].z64" size 8388608 crc 4731DF5C md5 E3B408997D7DB91F8219F168C6D57D26 sha1 A702B0616030BFC5FEB78FEAF365EAB74F1A8B6E )
 )
 
 game (
 	name "Monster Truck Madness 64 (USA)"
 	description "Monster Truck Madness 64 (USA)"
 	rom ( name "Monster Truck Madness 64 (USA).n64" size 8388608 crc B8D03FFB md5 268465AB3095C1D2FFF2AA025C49E610 sha1 F7E66B1EB2905DF6C6DFADF1593064FC6D592C17 )
+	rom ( name "Monster Truck Madness 64 (U) [!].z64" size 8388608 crc 3FD0604D md5 514D61D3B3D5E6326869783EB2E84A00 sha1 F8C7AE14DF7341881346B1CEAF838D2219291279 )
 )
 
 game (
 	name "Morita Shougi 64 (Japan)"
 	description "Morita Shougi 64 (Japan)"
 	rom ( name "Morita Shougi 64 (Japan).n64" size 8388608 crc 377B7580 md5 CEADD46EAAF7DA339A395401633192EB sha1 41B66663B6428C040579CEBEDA70DB2FCD063B3E flags verified )
+	rom ( name "Morita Shougi 64 (J) [!].z64" size 8388608 crc 88C83511 md5 462B9C4F38758C2E558312AC60DF2B91 sha1 D079AE0F578032347541B7EAE8935907C8AB79E3 )
 )
 
 game (
 	name "Mortal Kombat 4 (Europe)"
 	description "Mortal Kombat 4 (Europe)"
 	rom ( name "Mortal Kombat 4 (Europe).n64" size 16777216 crc 70B72A07 md5 12FFBF0BB1E493AFF82F0384DFECE543 sha1 C992254964774AAAEA5FBDE5BF4031C5096FB554 flags verified )
+	rom ( name "Mortal Kombat 4 (E) [!].z64" size 16777216 crc 635ADECA md5 264B82F0FC2431D6EEFDE9C9F3ED7596 sha1 34A25CC52F0D2B5FF3A65552F9D43D8714A8E10C )
 )
 
 game (
@@ -2951,6 +3378,7 @@ game (
 	name "Mortal Kombat Mythologies - Sub-Zero (Europe)"
 	description "Mortal Kombat Mythologies - Sub-Zero (Europe)"
 	rom ( name "Mortal Kombat Mythologies - Sub-Zero (Europe).n64" size 16777216 crc 1063DA05 md5 1152B6BEE522DAE82081EF35FD07F51C sha1 3FDE66EC7640F79A10471CD159E6B5C6101742EE flags verified )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [!].z64" size 16777216 crc EA21015A md5 38A82A56AE61A4D354C6A26E64D25E1C sha1 E674E0F08D7218136F31CA99A9C5323F0D2BB4D4 )
 )
 
 game (
@@ -2964,12 +3392,14 @@ game (
 	name "Mortal Kombat Trilogy (Europe)"
 	description "Mortal Kombat Trilogy (Europe)"
 	rom ( name "Mortal Kombat Trilogy (Europe).n64" size 12582912 crc 6A805380 md5 287BBC37468C5E434289C649499B0394 sha1 75298D06ADAF9814430C9DFDE87DCA3A9C59DAB1 flags verified )
+	rom ( name "Mortal Kombat Trilogy (E) [!].z64" size 12582912 crc BC04C62F md5 7A558BBAD8CE8828414A9CF3B044A87D sha1 5796AAF21BFA0E8532EF225BA4BE3B39EEF1BE63 )
 )
 
 game (
 	name "Mortal Kombat Trilogy (USA)"
 	description "Mortal Kombat Trilogy (USA)"
 	rom ( name "Mortal Kombat Trilogy (USA).n64" size 12582912 crc 58E57C08 md5 11819262F59DBD61F9E6621483CC0245 sha1 FC82A5BBB306C3F855974DE18CF1B1BFFAC268FF )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [!].z64" size 12582912 crc 50A99D60 md5 9B7F29AAB911D6753F2011C48DA752BF sha1 39B3CB20417C503F1C047D5037DF814D1CCF90DD )
 )
 
 game (
@@ -2989,36 +3419,42 @@ game (
 	name "MRC - Multi Racing Championship (Europe) (En,Fr,De)"
 	description "MRC - Multi Racing Championship (Europe) (En,Fr,De)"
 	rom ( name "MRC - Multi Racing Championship (Europe) (En,Fr,De).n64" size 12582912 crc 9C7D29EC md5 53D95CEAB72663184895663AC0C88C18 sha1 6C00683512F99DA0DB25E22833B8369270A3A044 flags verified )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [!].z64" size 12582912 crc BC966B10 md5 0054B7FC0C2ACBED650EFE727CDBA472 sha1 6D8600A1326C39B4B80BB1D4A6500C3F0C6202A1 )
 )
 
 game (
 	name "MRC - Multi Racing Championship (Japan)"
 	description "MRC - Multi Racing Championship (Japan)"
 	rom ( name "MRC - Multi Racing Championship (Japan).n64" size 12582912 crc 4CA898E3 md5 1B54B620B1997A21587EDA8F2FF1A45E sha1 96B6966A12C0D3DEB78A26E7273ECB5AED17D5E9 flags verified )
+	rom ( name "MRC - Multi Racing Championship (J) [!].z64" size 12582912 crc BEA43300 md5 8E18064A2C4B3EC15A20C3D676644B3A sha1 B0992A8029622DF74D3165814AA40DF19A14B4A4 )
 )
 
 game (
 	name "MRC - Multi Racing Championship (USA)"
 	description "MRC - Multi Racing Championship (USA)"
 	rom ( name "MRC - Multi Racing Championship (USA).n64" size 12582912 crc 2F30B7FE md5 F7E833F423BBE33AF47DF45A998E9FB5 sha1 72009EBA46CD9362CB7979D457EB1C7581B552DA flags verified )
+	rom ( name "MRC - Multi Racing Championship (U) [!].z64" size 12582912 crc 1DC1C812 md5 FC61D60F2C6FE4610F70CE4949A7A062 sha1 8BEA68833D63B2F17DAAD4477A572C274A9468BE )
 )
 
 game (
 	name "Ms. Pac-Man - Maze Madness (USA)"
 	description "Ms. Pac-Man - Maze Madness (USA)"
 	rom ( name "Ms. Pac-Man - Maze Madness (USA).n64" size 12582912 crc D5017D76 md5 7CAF992661AE9008D556E880D72F1A2A sha1 B3924A297A03A0B10FF246A7C90F424C90E7AB64 )
+	rom ( name "Ms. Pac-Man - Maze Madness (U) [!].z64" size 12582912 crc E34C7060 md5 08BEA3310E778A6584EB64CD3F15F86E sha1 99028C738B5AC5FF99D73698B50D14F5E58DDEA7 )
 )
 
 game (
 	name "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)"
 	description "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)"
 	rom ( name "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).n64" size 16777216 crc 6DF2BDA6 md5 89F1CE5BCE09D4B882F190407B08E2D4 sha1 45BBFD1436D86055A82DBA19869CB9D2038BFA18 flags verified )
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [!].z64" size 16777216 crc 3502DBBE md5 E6B5C17B7BBBB7C432B3506C085D16C4 sha1 AADD1D7E943CBFA5496A370158B5F8FE17B06415 )
 )
 
 game (
 	name "Mystical Ninja Starring Goemon (Europe)"
 	description "Mystical Ninja Starring Goemon (Europe)"
 	rom ( name "Mystical Ninja Starring Goemon (Europe).n64" size 16777216 crc 7DFE2E7A md5 D9CF1C0538367A4149390C0845363A03 sha1 3EB67F551791AA84EC2524C7A00B53DFD24B11EE flags verified )
+	rom ( name "Mystical Ninja Starring Goemon (E) [!].z64" size 16777216 crc 3BD9059A md5 698930C7CCD844673D77FFECCB3DD66E sha1 F7304934BA4E8D98A71500C249BACB168BCA5AF0 )
 )
 
 game (
@@ -3032,192 +3468,224 @@ game (
 	name "Nagano Winter Olympics '98 (Europe)"
 	description "Nagano Winter Olympics '98 (Europe)"
 	rom ( name "Nagano Winter Olympics '98 (Europe).n64" size 12582912 crc 36D43F29 md5 54E3AA4FCC7C0EEC8F66FEB0481B9C48 sha1 CB3EE16B5E45FEF723AF43BCF3E6F5AE07BC570A flags verified )
+	rom ( name "Nagano Winter Olympics '98 (E) [!].z64" size 12582912 crc C44DE11C md5 B935B87F3DCCA8AEEB6A9365124846DC sha1 8FACA645020857B87ED3842BD26CCCBDF31BEC39 )
 )
 
 game (
 	name "Nagano Winter Olympics '98 (USA)"
 	description "Nagano Winter Olympics '98 (USA)"
 	rom ( name "Nagano Winter Olympics '98 (USA).n64" size 12582912 crc 1F8D21FB md5 89DBB22886A2973838B2D682A150295C sha1 090D652498885CCFA841C1465E4B721D090D7B39 )
+	rom ( name "Nagano Winter Olympics '98 (U) [!].z64" size 12582912 crc EE8288D4 md5 C17F78A103D99B21533F0C1566378EF6 sha1 EAF543E195731031A84F4136B506449209E3A8F5 )
 )
 
 game (
 	name "Namco Museum 64 (USA)"
 	description "Namco Museum 64 (USA)"
 	rom ( name "Namco Museum 64 (USA).n64" size 4194304 crc 03776764 md5 D2675B639421FC6EBCE92F0511F5BC5D sha1 8FF73B91E62ABE925AD475B166EA65B1A698DAE7 )
+	rom ( name "Namco Museum 64 (U) [!].z64" size 4194304 crc CE361F92 md5 E61251D2819E3BF3A9C0B95329F60F70 sha1 A934E08F80778111D1BC03CAF0A170A2D8C4E6A7 )
 )
 
 game (
 	name "NASCAR 2000 (USA)"
 	description "NASCAR 2000 (USA)"
 	rom ( name "NASCAR 2000 (USA).n64" size 12582912 crc D07AD471 md5 FB698DD422FAB3CE770224B2385173D5 sha1 D889B2F0E632CDC9D1EC6261A6841F7822A5D130 )
+	rom ( name "NASCAR 2000 (U) [!].z64" size 12582912 crc 02BF7C2D md5 45FEB0FBBEC6CB48FF21DEAE176E9B6B sha1 36CD848BE9196C9E04EB3A9B0371A04AFC8BAEA3 )
 )
 
 game (
 	name "NASCAR 99 (Europe) (En,Fr,De)"
 	description "NASCAR 99 (Europe) (En,Fr,De)"
 	rom ( name "NASCAR 99 (Europe) (En,Fr,De).n64" size 12582912 crc 5351ACB5 md5 96A36A9871B34839D6A2AF57C5C4EF96 sha1 84C515AB4ECF3CAC306D1355B639D7E535845F42 flags verified )
+	rom ( name "NASCAR 99 (E) (M3) [!].z64" size 12582912 crc 76E79CEA md5 15A87A6D01DBA1A7C4375FFBC1214BB8 sha1 CB43EE3D86A7B85BEFEC8D068D72192FA8174EB0 )
 )
 
 game (
 	name "NASCAR 99 (USA)"
 	description "NASCAR 99 (USA)"
 	rom ( name "NASCAR 99 (USA).n64" size 12582912 crc 2D234FB7 md5 2EAB72BF6EE786DD521A360D94A868DD sha1 C65CA3084221CCBD63A21CAB179A50184A7FA798 )
+	rom ( name "NASCAR 99 (U) [!].z64" size 12582912 crc 3D8EB950 md5 DC5F1A814C8423B4B43F71C229D65A84 sha1 0FBBAEB4C286D45D27C977D5722E38415EFD1A74 )
 )
 
 game (
 	name "NBA Courtside 2 featuring Kobe Bryant (USA)"
 	description "NBA Courtside 2 featuring Kobe Bryant (USA)"
 	rom ( name "NBA Courtside 2 featuring Kobe Bryant (USA).n64" size 16777216 crc 7A8FD7D3 md5 FF29DB046C31ADCE1B5280558DBC3DF8 sha1 63711BE92268098BC69BEC3168C09D0088DB8CE6 )
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!].z64" size 16777216 crc A7CC4CE2 md5 73BB54FFD3C0FC71F941D9A8CC57E2A1 sha1 8C27333189FC19570BC494BC3ED9E3879D6E54BE )
 )
 
 game (
 	name "NBA Hangtime (Europe)"
 	description "NBA Hangtime (Europe)"
 	rom ( name "NBA Hangtime (Europe).n64" size 12582912 crc BF05FE53 md5 662386EE4FDF23F3423A4300F1DAD651 sha1 004AFE25EE5B70B915797AE799BFBF1D92C969A5 flags verified )
+	rom ( name "NBA Hangtime (E) [!].z64" size 12582912 crc 7E6D00AE md5 62365463743857CFC823978E0E590D84 sha1 2BCBDD92CCB4C72757739D32557098F4EEC36312 )
 )
 
 game (
 	name "NBA Hangtime (USA)"
 	description "NBA Hangtime (USA)"
 	rom ( name "NBA Hangtime (USA).n64" size 12582912 crc 72E2ACA9 md5 458170659E9F493099BC1D6FE50AA937 sha1 2A1EF108F5345E6CA80D7F73F4CA4557E7843594 )
+	rom ( name "NBA Hangtime (U) [!].z64" size 12582912 crc 714CF532 md5 DC15FCBEAE0F1FEF7BEE141D77BB25A0 sha1 3C96741DB636938F140E9592AD34E93AC25C7762 )
 )
 
 game (
 	name "NBA in the Zone '98 (Japan)"
 	description "NBA in the Zone '98 (Japan)"
 	rom ( name "NBA in the Zone '98 (Japan).n64" size 12582912 crc 58B2150D md5 12373D4569A3498D13F9274B2395D9BC sha1 4FC0A8392ECE34F8A8C524640DCE2A1255C66BFC flags verified )
+	rom ( name "NBA In the Zone '98 (J) [!].z64" size 12582912 crc AED2700A md5 4C7A2F4881EACA75DC2FC36673AE2A20 sha1 C4DC9049094100D48A010D39F2901E1AB164A8FA )
 )
 
 game (
 	name "NBA in the Zone '98 (USA)"
 	description "NBA in the Zone '98 (USA)"
 	rom ( name "NBA in the Zone '98 (USA).n64" size 12582912 crc 2BB83C0E md5 73334F6ADAB3F19C314C9F9CB2006E97 sha1 B0E5D3A7FC83EC86027F9E7EFDD876B7639E727C )
+	rom ( name "NBA In the Zone '98 (U) [!].z64" size 12582912 crc A245D737 md5 BBB48BE198089A26050C84FE5B7B8BD5 sha1 A306D80F483F8BB5891A543919C53FAC61D9348F )
 )
 
 game (
 	name "NBA in the Zone '99 (USA)"
 	description "NBA in the Zone '99 (USA)"
 	rom ( name "NBA in the Zone '99 (USA).n64" size 12582912 crc C15AFC69 md5 D56AB19B2D4550D8CD082C96904DAB0B sha1 BE6B8FAD67ECE51E3DC09182CA7497652D92B241 )
+	rom ( name "NBA In the Zone '99 (U) [!].z64" size 12582912 crc EAB083B8 md5 6CBF4014C053E16852A3DB80AEB4C853 sha1 6964BAEC49592E64C34782B55E234C7BD32C8A99 )
 )
 
 game (
 	name "NBA in the Zone 2 (Japan)"
 	description "NBA in the Zone 2 (Japan)"
 	rom ( name "NBA in the Zone 2 (Japan).n64" size 12582912 crc F736D01A md5 127671F54E44C68039DD29EC702AED21 sha1 C81BCE72A48686B3966815915A579F2F5DE733EC flags verified )
+	rom ( name "NBA In the Zone 2 (J) [!].z64" size 12582912 crc 41093B73 md5 F8F87AEB2C537C9CB2E9913050BFC928 sha1 A7685C8833256ECD1033862EA077E75147F9C49A )
 )
 
 game (
 	name "NBA in the Zone 2000 (Europe)"
 	description "NBA in the Zone 2000 (Europe)"
 	rom ( name "NBA in the Zone 2000 (Europe).n64" size 16777216 crc AD6CD2AE md5 1E53474D393C2A16A25480843DF965AB sha1 29ECBF3DADB77C56051370897344839EBBD63130 flags verified )
+	rom ( name "NBA In the Zone 2000 (E) [!].z64" size 16777216 crc A4973197 md5 4244CC48674C26BD848718C05688F821 sha1 255AADF60E9DE652247BB1F7C63B50415D6C4354 )
 )
 
 game (
 	name "NBA in the Zone 2000 (USA)"
 	description "NBA in the Zone 2000 (USA)"
 	rom ( name "NBA in the Zone 2000 (USA).n64" size 16777216 crc D850CFA3 md5 3E9F73902FD5C9AF3DECB26F0E045128 sha1 681D09E327E4FAAA3EA53977047BE5434ABA1468 )
+	rom ( name "NBA In the Zone 2000 (U) [!].z64" size 16777216 crc CBB4B730 md5 1942833AC1A71BE8BAE74BBDFD6DE278 sha1 7E838C203F29336CBDABA77051EBE48D9EAE798D )
 )
 
 game (
 	name "NBA Jam 2000 (Europe)"
 	description "NBA Jam 2000 (Europe)"
 	rom ( name "NBA Jam 2000 (Europe).n64" size 16777216 crc 84DEB3BD md5 568BE0ACEE43DEDD85BFEAADCE3060B8 sha1 4FC4D73EEB7669D9D54F8AE26908124CD8F9F618 flags verified )
+	rom ( name "NBA Jam 2000 (E) [!].z64" size 16777216 crc 9F95485E md5 604FEB17258044A3E6C3AA9D2C5B62F9 sha1 A91C52AC8AF8DE6172411C5BF8E57F5795BE7F78 )
 )
 
 game (
 	name "NBA Jam 2000 (USA)"
 	description "NBA Jam 2000 (USA)"
 	rom ( name "NBA Jam 2000 (USA).n64" size 16777216 crc 65A3BD1C md5 2BC421E0B95150299CAD0D9EA37E289F sha1 58FACEC83666D3EBA51986DF97024229A087C78D )
+	rom ( name "NBA Jam 2000 (U) [!].z64" size 16777216 crc 163DADF9 md5 AFECC9A2DF7B1A66A6B7AB3AA8B4BD2E sha1 94139439D6C234A560FC5D0E5D9C0AA4508FC7B6 )
 )
 
 game (
 	name "NBA Jam 99 (Europe)"
 	description "NBA Jam 99 (Europe)"
 	rom ( name "NBA Jam 99 (Europe).n64" size 12582912 crc 8CCE0AE4 md5 3797FA95D1B8F635C1E68A6153159143 sha1 07EA5C1767C0EDE88D0CF231352F7389ABCB2F2F flags verified )
+	rom ( name "NBA Jam 99 (E) [!].z64" size 12582912 crc 90E4275B md5 BE72BE370BC0A76D403FF2B9ED2A9173 sha1 CF6C46785B75F9BC1D5B1FD08DAFB72DD595F68A )
 )
 
 game (
 	name "NBA Jam 99 (USA)"
 	description "NBA Jam 99 (USA)"
 	rom ( name "NBA Jam 99 (USA).n64" size 12582912 crc F40C871A md5 6B1912A7269E4A2FEEA518653277B7B6 sha1 5303A21D20BEF75E6F77FBAEDD120391CB4131D5 )
+	rom ( name "NBA Jam 99 (U) [!].z64" size 12582912 crc 559CD6B1 md5 ADBE5CA10F659AF2BE712038E8522704 sha1 2E306D2123AD4220E672D8A07874CA7B515D57E0 )
 )
 
 game (
 	name "NBA Live 2000 (Europe) (En,Fr,De,Es)"
 	description "NBA Live 2000 (Europe) (En,Fr,De,Es)"
 	rom ( name "NBA Live 2000 (Europe) (En,Fr,De,Es).n64" size 16777216 crc 4C7282D6 md5 591D563BABCD634DF5A6F1BE6D86D352 sha1 E2B90369CC88D6488D8CA307B7AB915CFF8ED5D6 flags verified )
+	rom ( name "NBA Live 2000 (E) (M4) [!].z64" size 16777216 crc 0E4B944C md5 7FEC099D1A989D5222D3F9E1A7770404 sha1 D4CB60EB3645AE803A1EFC234CEFFD8F424DC8F7 )
 )
 
 game (
 	name "NBA Live 2000 (USA) (En,Fr,De,Es)"
 	description "NBA Live 2000 (USA) (En,Fr,De,Es)"
 	rom ( name "NBA Live 2000 (USA) (En,Fr,De,Es).n64" size 16777216 crc 94FC12D3 md5 C3071968BC7891FAC1A1DEE216FDB5C0 sha1 61E5052589BFE9B7736B9E758125A8AF11A11CB3 )
+	rom ( name "NBA Live 2000 (U) (M4) [!].z64" size 16777216 crc 7C3BC95E md5 FC47F85CC501C8C5BD9D0CA4DB48258F sha1 4BA671A132125BCAA6552542B7FC2C7F6DC56A0E )
 )
 
 game (
 	name "NBA Live 99 (Europe) (En,Fr,De,Es,It)"
 	description "NBA Live 99 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "NBA Live 99 (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 086E322E md5 DB69F8396056D6D89E143DA38CF6DC7B sha1 EEA6E4FF34BEB7D0EB5692D79F4C5A1FF757853E flags verified )
+	rom ( name "NBA Live 99 (E) (M5) [!].z64" size 16777216 crc A316DF37 md5 226C19C8759314AC740420DDC3A34EB4 sha1 530EF95C12F0CA73BC4E178A397CE677A57AD858 )
 )
 
 game (
 	name "NBA Live 99 (USA) (En,Fr,De,Es,It)"
 	description "NBA Live 99 (USA) (En,Fr,De,Es,It)"
 	rom ( name "NBA Live 99 (USA) (En,Fr,De,Es,It).n64" size 16777216 crc 74BC96BE md5 32D4469E1B2B600E36708ED6D903628F sha1 C040AABD6A985052A6D2E9AB7B8D458233D0793F )
+	rom ( name "NBA Live 99 (U) (M5) [!].z64" size 16777216 crc 9BE0A7AC md5 DBE79AE6531B491B8F8EE8B2B814D665 sha1 89E47FFAC3EAE25B37E1A20CE66CA24E343912DD )
 )
 
 game (
 	name "NBA Pro 98 (Europe)"
 	description "NBA Pro 98 (Europe)"
 	rom ( name "NBA Pro 98 (Europe).n64" size 12582912 crc 7FABF1EA md5 378F71037E3994A605B0060262C3AF6B sha1 FD5131330C501858E6AD3128EE3D252C998A2EB5 flags verified )
+	rom ( name "NBA Pro 98 (E) [!].z64" size 12582912 crc 04B75CCC md5 A4111A6CDDBDE0A45489106F0DF0CA2B sha1 94416270D83A87E360BAC5059CC5F7365CA120AC )
 )
 
 game (
 	name "NBA Pro 99 (Europe)"
 	description "NBA Pro 99 (Europe)"
 	rom ( name "NBA Pro 99 (Europe).n64" size 12582912 crc 6EA32E08 md5 408DD9E2EE93F8A8283A6E0C05EEC781 sha1 FB369E088766095BC6466AD09B8C94CAAF9A1DF5 flags verified )
+	rom ( name "NBA Pro 99 (E) [!].z64" size 12582912 crc 588E60E8 md5 C5EBBDD41EAEA8BD02CF520640CCCCDF sha1 5DECF930D859E8B834A5F897955880556CA6AADF )
 )
 
 game (
 	name "NBA Showtime - NBA on NBC (USA)"
 	description "NBA Showtime - NBA on NBC (USA)"
 	rom ( name "NBA Showtime - NBA on NBC (USA).n64" size 16777216 crc A9302DEE md5 9F62363594B50F8A2695C113E52D9485 sha1 4857B02997B65AA86D2ADA8E7364E62B5FF10356 )
+	rom ( name "NBA Showtime - NBA on NBC (U) [!].z64" size 16777216 crc A4E378F4 md5 881E98B47F32093C330A8B0DAD6BB65D sha1 702D6D55FC23C56B8A57D7348D159098FFF98650 )
 )
 
 game (
 	name "Neon Genesis Evangelion (Japan)"
 	description "Neon Genesis Evangelion (Japan)"
 	rom ( name "Neon Genesis Evangelion (Japan).n64" size 33554432 crc 4B8B23DC md5 5E0CF74116F195913D543CAED446D990 sha1 BF10F76812ADA36C304EB45AD5DA794F02C560FE flags verified )
+	rom ( name "Neon Genesis Evangelion (J) [!].z64" size 33554432 crc A10A86AF md5 5E1940CA1236A76E8F2D15DE0414AE55 sha1 A9BA0A4AFEED48080F54AA237850F3676B3D9980 )
 )
 
 game (
 	name "New Tetris, The (Europe)"
 	description "New Tetris, The (Europe)"
 	rom ( name "New Tetris, The (Europe).n64" size 12582912 crc 88B774C4 md5 847724BA74D3610D9CDA1D9163F34047 sha1 99C7FF49CFD04569FB29514149BE62F073A19BDA flags verified )
+	rom ( name "New Tetris, The (E) [!].z64" size 12582912 crc 983263D7 md5 C4ECFEC66ECEEA23F39632AB6753300F sha1 2392F403B0993F838912CEFA83AEFD35D34A05A0 )
 )
 
 game (
 	name "New Tetris, The (USA)"
 	description "New Tetris, The (USA)"
 	rom ( name "New Tetris, The (USA).n64" size 12582912 crc 82A76DC9 md5 FD417F24466BEE4443CF0A7740E34C1A sha1 CC88BFED8B77885CDA6123C08E5D3B11451C6074 )
+	rom ( name "New Tetris, The (U) [!].z64" size 12582912 crc 528A07FA md5 7A28179B00734C9AA0F0609FAFAAFD5F sha1 83FFF25E82181A6993F28C91B9EEB8430396838B )
 )
 
 game (
 	name "NFL Blitz (USA)"
 	description "NFL Blitz (USA)"
 	rom ( name "NFL Blitz (USA).n64" size 16777216 crc 5FA3455D md5 4FE0DF8523E907DE4C7C85E836BFB637 sha1 FA193A704B83F00CF3874D2F49275930168F0416 )
+	rom ( name "NFL Blitz (U) [!].z64" size 16777216 crc 9BCD670F md5 7F6C5E71711DEC81E77CCF71060F67CA sha1 2853AFD9E38D63D913C8484F546804708C8AD712 )
 )
 
 game (
 	name "NFL Blitz - Special Edition (USA)"
 	description "NFL Blitz - Special Edition (USA)"
 	rom ( name "NFL Blitz - Special Edition (USA).n64" size 16777216 crc 3DD3EB64 md5 7B5036A93B1F01F1D90D3DF554DACB51 sha1 2F64076B423A72F873A04910A40D3A3F5DDDBB25 )
+	rom ( name "NFL Blitz - Special Edition (U) [!].z64" size 16777216 crc 5D1907F7 md5 7E856FA8F743900FEBA5A4E28C234AF7 sha1 A109F44BBB3270205205755BA9A889BAFC6FF5AB )
 )
 
 game (
 	name "NFL Blitz 2000 (USA)"
 	description "NFL Blitz 2000 (USA)"
 	rom ( name "NFL Blitz 2000 (USA).n64" size 16777216 crc E4B42E6A md5 B4015F331830C550EDD438F254BE318A sha1 0DC7A0B174C53D95CB8046538A1A4C4475D7209D )
+	rom ( name "NFL Blitz 2000 (U) [!].z64" size 16777216 crc 7F471773 md5 BA49514441023722F02D41C62612F6C3 sha1 36E124746A842A2E1F72480F122DFE9188FC5575 )
 )
 
 game (
@@ -3230,138 +3698,161 @@ game (
 	name "NFL Blitz 2001 (USA)"
 	description "NFL Blitz 2001 (USA)"
 	rom ( name "NFL Blitz 2001 (USA).n64" size 16777216 crc E18211E5 md5 86B10A10D32821F6972E14752EF0A56B sha1 1305EA64FA5EB62B36E029C5646299C080DAEDE9 )
+	rom ( name "NFL Blitz 2001 (U) [!].z64" size 16777216 crc 18EEB41B md5 E4EDD73CB036C6B143CEE9AEEED60341 sha1 279BC9ED596663610265A618A1656DBB8EA4237A )
 )
 
 game (
 	name "NFL QB Club 2001 (USA)"
 	description "NFL QB Club 2001 (USA)"
 	rom ( name "NFL QB Club 2001 (USA).n64" size 12582912 crc 2C0D748B md5 0272B74693620913F7C5170D747A546E sha1 1B31A55A7C744F5DE52F6198820C17BF25785EBF )
+	rom ( name "NFL Quarterback Club 2001 (U) [!].z64" size 12582912 crc 6D849E17 md5 FD2CBDEA0992452B52E2803224232D12 sha1 C81421BB204270EF5DDD8F60DDA51CDF73482FE2 )
 )
 
 game (
 	name "NFL Quarterback Club 2000 (Europe)"
 	description "NFL Quarterback Club 2000 (Europe)"
 	rom ( name "NFL Quarterback Club 2000 (Europe).n64" size 12582912 crc 11225980 md5 B1D3B429CCA7650681882B40B6CD1A0D sha1 9029E7B3EA19277E323337E5B41BB6BA83EE57AE flags verified )
+	rom ( name "NFL Quarterback Club 2000 (E) [!].z64" size 12582912 crc CEEF5C29 md5 75C0121D84915BF5C1FBD389CF9F9C17 sha1 CD97AECE871F0AE5D29AF9F92142A470A34273B9 )
 )
 
 game (
 	name "NFL Quarterback Club 2000 (USA)"
 	description "NFL Quarterback Club 2000 (USA)"
 	rom ( name "NFL Quarterback Club 2000 (USA).n64" size 12582912 crc B61D114A md5 574D2F51E9D4B05057925B49CF45526B sha1 63B52F8C4D8EFAAABC87237938FD65975EC19BAD )
+	rom ( name "NFL Quarterback Club 2000 (U) [!].z64" size 12582912 crc 8F54F999 md5 EC18E3131040842E32EBAB66C7496EBD sha1 390FEA44C8DF84F601B20A3E506FDD611AB34A8B )
 )
 
 game (
 	name "NFL Quarterback Club 98 (Europe)"
 	description "NFL Quarterback Club 98 (Europe)"
 	rom ( name "NFL Quarterback Club 98 (Europe).n64" size 8388608 crc 129928ED md5 EB1A0007ED08AA3BE9EF465447C69CAF sha1 E73F59F51EFF338DA0FEEDFE018C6FB46C3638F3 flags verified )
+	rom ( name "NFL Quarterback Club 98 (E) [!].z64" size 8388608 crc 34A21417 md5 A18CA5DBC85668667AA467ADD6A62B39 sha1 1F00635179FB741FBBCF31FFAFF399469DA16ECF )
 )
 
 game (
 	name "NFL Quarterback Club 98 (USA)"
 	description "NFL Quarterback Club 98 (USA)"
 	rom ( name "NFL Quarterback Club 98 (USA).n64" size 8388608 crc 94368DB1 md5 593678BCD8C2C98E0B72CB8B22771584 sha1 AFA0FA7B55931325426C46C3A04A1A5BEC81F711 )
+	rom ( name "NFL Quarterback Club 98 (U) [!].z64" size 8388608 crc ABF0E8F2 md5 709F966C30CE6DF1833E95740A5A2AB2 sha1 8E53DE9EB6DCECB3B0BB3E707EF01690DE7EFAB2 )
 )
 
 game (
 	name "NFL Quarterback Club 99 (Europe)"
 	description "NFL Quarterback Club 99 (Europe)"
 	rom ( name "NFL Quarterback Club 99 (Europe).n64" size 12582912 crc 8D95305F md5 F3696DD7D1F47F99E6F4962E5C1C69D7 sha1 32E5B34284B4CA3CF52FAB86DC4A155624B4B64D flags verified )
+	rom ( name "NFL Quarterback Club 99 (E) [!].z64" size 12582912 crc F688BDF3 md5 7EC0484C2BA6AA9F0A45D7AC1F4117DA sha1 1EE4EBAF6B0C189164397EA257F17B45EEDF0767 )
 )
 
 game (
 	name "NFL Quarterback Club 99 (USA)"
 	description "NFL Quarterback Club 99 (USA)"
 	rom ( name "NFL Quarterback Club 99 (USA).n64" size 12582912 crc CE525BC5 md5 86FD9DDE3D248E1FA2FA0C31045AE3E2 sha1 BB054FA24A084018995B68164560020DE44C6C92 )
+	rom ( name "NFL Quarterback Club 99 (U) [!].z64" size 12582912 crc 44496B26 md5 928869D1CE001B813BA908DFE18D7F94 sha1 8DBA75859D21219B3638E337991851DB31B4D70E )
 )
 
 game (
 	name "NHL 99 (Europe) (En,De,Sv,Fi)"
 	description "NHL 99 (Europe) (En,De,Sv,Fi)"
 	rom ( name "NHL 99 (Europe) (En,De,Sv,Fi).n64" size 12582912 crc 5CAABE5A md5 40359DD3081568FFB007F7BD6E9FE372 sha1 D6142F571BB72E4BC6AC9C665E666FCD927302A4 flags verified )
+	rom ( name "NHL 99 (E) [!].z64" size 12582912 crc F3B2AA4D md5 B7E41D34D209B6CFA92E3D622F911C4E sha1 87CD5ECFF93D5B34C246CB96A6249B78B5B90126 )
 )
 
 game (
 	name "NHL 99 (USA)"
 	description "NHL 99 (USA)"
 	rom ( name "NHL 99 (USA).n64" size 12582912 crc 50F81F73 md5 E6C12AC9C562D772B8EB4F3FA439A84D sha1 94B9957551BC31E5BFB49C72310155E376887757 )
+	rom ( name "NHL 99 (U) [!].z64" size 12582912 crc E5DF2AFE md5 A62FA044BCB5507D358424ABDA6419DB sha1 D730540D8C447420DE4AA81F6A2776C2E310D12A )
 )
 
 game (
 	name "NHL Blades of Steel '99 (USA)"
 	description "NHL Blades of Steel '99 (USA)"
 	rom ( name "NHL Blades of Steel '99 (USA).n64" size 12582912 crc 5EF28CFB md5 C6DC3887063705863C70CD516C036867 sha1 176BDE5F17295AECCEA06C09C761ADD271A6931F )
+	rom ( name "NHL Blades of Steel '99 (U) [!].z64" size 12582912 crc 1EE678FE md5 349F61F9747F2D2098F305924C97A1BF sha1 C55E9771B1548CFE4297646ADCFCAFE85712DA5E )
 )
 
 game (
 	name "NHL Breakaway 98 (Europe)"
 	description "NHL Breakaway 98 (Europe)"
 	rom ( name "NHL Breakaway 98 (Europe).n64" size 12582912 crc 30B28491 md5 B32084ADF71213662B255E6678F134DC sha1 7F3F234BB01B1128D954C3D98F2DEBAD6EAA018F flags verified )
+	rom ( name "NHL Breakaway 98 (E) [!].z64" size 12582912 crc 8C0C9669 md5 46476A5626CD99B3749AC1EE1E234FAC sha1 6D6631FE93B7C70AE28960F4141AC7656B333AA4 )
 )
 
 game (
 	name "NHL Breakaway 98 (USA)"
 	description "NHL Breakaway 98 (USA)"
 	rom ( name "NHL Breakaway 98 (USA).n64" size 12582912 crc F59B082F md5 08FAD70EF737B685AD030604F237C674 sha1 4CE6FA90BC8A92A73EAFEBB677EA6DDB90E93ECC )
+	rom ( name "NHL Breakaway 98 (U) [!].z64" size 12582912 crc 49D86C00 md5 B62076FA1421B8E7FDEC2B4F8A910EA3 sha1 2658334BF4091D0D3ED2DE3327592D04FC0B6849 )
 )
 
 game (
 	name "NHL Breakaway 99 (Europe)"
 	description "NHL Breakaway 99 (Europe)"
 	rom ( name "NHL Breakaway 99 (Europe).n64" size 12582912 crc B7E1618A md5 51660FECECC432FE2A6D5D3CBC8AD386 sha1 59A291A5F9887F8D569670A868E44C53CFB84475 flags verified )
+	rom ( name "NHL Breakaway 99 (E) [!].z64" size 12582912 crc 572060E0 md5 4BA95AA97ECFEE36051EBE0A9024EEE8 sha1 46147DB00BD9D80F0D22E8EB1B00603106DE2692 )
 )
 
 game (
 	name "NHL Breakaway 99 (USA)"
 	description "NHL Breakaway 99 (USA)"
 	rom ( name "NHL Breakaway 99 (USA).n64" size 12582912 crc 9F774781 md5 67FB118A37B3C742F5DD8B1F452F43D8 sha1 B026FB43057815B7D383F82170617AB5D59120F9 )
+	rom ( name "NHL Breakaway 99 (U) [!].z64" size 12582912 crc 75F75B9D md5 AF1D07679014760B88923A4827658CAF sha1 65C0F8BF81D8DEC3E5D719B167A61A73B2436E84 )
 )
 
 game (
 	name "NHL Pro 99 (Europe)"
 	description "NHL Pro 99 (Europe)"
 	rom ( name "NHL Pro 99 (Europe).n64" size 12582912 crc 36696571 md5 B47E8A21CA2AFBD3B43D5B781041A613 sha1 C8B0D2C2FA2B221EFE1FEE05220581A68A6C3F9E flags verified )
+	rom ( name "NHL Pro 99 (E) [!].z64" size 12582912 crc E272867E md5 A61854CF27E536C8513174FAEF08DFCB sha1 4FF557CCD19982699B3AA82D4C44F436D1D87F93 )
 )
 
 game (
 	name "Nightmare Creatures (USA)"
 	description "Nightmare Creatures (USA)"
 	rom ( name "Nightmare Creatures (USA).n64" size 16777216 crc 134C09DA md5 EEBB2936CD8514C47E973A98FC37296A sha1 1D01BE47A805679D17BEDC4F5294DB20BBB2875D )
+	rom ( name "Nightmare Creatures (U) [!].z64" size 16777216 crc 6A1EB795 md5 4116CF435DB315A2481AF8D1E9352FEB sha1 BEA6C21B3EF5950BDF8CDB255955DA6C4746EEA8 )
 )
 
 game (
 	name "Nintama Rantarou 64 Game Gallery (Japan)"
 	description "Nintama Rantarou 64 Game Gallery (Japan)"
 	rom ( name "Nintama Rantarou 64 Game Gallery (Japan).n64" size 8388608 crc 2D96C091 md5 6672AA7772BF2280077B6B57A200AAC0 sha1 0C2EE2266C67B5AFA507F5B8ECE88AB565FED63A flags verified )
+	rom ( name "Nintama Rantarou 64 Game Gallery (J) [!].z64" size 8388608 crc 8C7C2DCA md5 B04957D052EF850C5EDECE69DB7377B3 sha1 1BF5217924C5FB00F8E8829E9EBF3FBCEB89B9CD )
 )
 
 game (
 	name "Nintendo All-Star! Dairantou Smash Brothers (Japan)"
 	description "Nintendo All-Star! Dairantou Smash Brothers (Japan)"
 	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (Japan).n64" size 16777216 crc A2D1D0D1 md5 69A4BBDABDF6806AA37044508D0775B4 sha1 42E5BAB5D8C3B3CA3582E142094B50ECC7FEA5E6 flags verified )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [!].z64" size 16777216 crc 04C9D3B1 md5 66DB457B130D31A286A23D6E4DD9726E sha1 4B71F0E01878696733EEFA9C80D11C147ECB4984 )
 )
 
 game (
 	name "Nuclear Strike 64 (Europe) (En,Fr)"
 	description "Nuclear Strike 64 (Europe) (En,Fr)"
 	rom ( name "Nuclear Strike 64 (Europe) (En,Fr).n64" size 33554432 crc 575FBFE5 md5 6AE796D1D0BEFA2321A5FF055A48DD13 sha1 C170B3A4032CFDF885068F6F3AF9EB6CBF28484C flags verified )
+	rom ( name "Nuclear Strike 64 (E) (M2) [!].z64" size 33554432 crc 9AFBFCAF md5 710BA49EBD5C9A2B26653FAE93BD667A sha1 34A23CFA247DE4E8ECDB8D72431AF93D35C69753 )
 )
 
 game (
 	name "Nuclear Strike 64 (Germany)"
 	description "Nuclear Strike 64 (Germany)"
 	rom ( name "Nuclear Strike 64 (Germany).n64" size 33554432 crc 2F575E61 md5 AF0378047DEB8B6E01380FD7C562E16B sha1 7DF3153F6FD24BA33255909225B481C3444A6FA7 )
+	rom ( name "Nuclear Strike 64 (G) [!].z64" size 33554432 crc 0916AB13 md5 D43C2E1938534363E56A22413B91D051 sha1 B3E7F7C3306B7DE2F29FE115FF74DE7FC95149C7 )
 )
 
 game (
 	name "Nuclear Strike 64 (USA)"
 	description "Nuclear Strike 64 (USA)"
 	rom ( name "Nuclear Strike 64 (USA).n64" size 33554432 crc 1A70D11A md5 3B7330D7055AD8D514E4F516F2A80101 sha1 EA1371D29CBDEDE166A69C77B2C4A77D6EDAB77D )
+	rom ( name "Nuclear Strike 64 (U) [!].z64" size 33554432 crc D7467294 md5 FFC584040D0D052FBAB4CB6C19245449 sha1 6A8B0B450E87FBFBADEEE3854ADA0731DEB6E8B5 )
 )
 
 game (
 	name "Nushi Zuri 64 (Japan)"
 	description "Nushi Zuri 64 (Japan)"
 	rom ( name "Nushi Zuri 64 (Japan).n64" size 16777216 crc 02FF4DF5 md5 F9CDE2DC7B498309879CB7CE3C10A2EA sha1 0C6561DB721D440C1E29FABB79A53B0422AC1903 flags verified )
+	rom ( name "Nushi Tsuri 64 (J) [!].z64" size 16777216 crc A6800EC0 md5 50C10082D0C077FDB5658EF5A6E3F54F sha1 5F20D41669458E1C981292F17CD8B29032406287 )
 )
 
 game (
@@ -3374,36 +3865,42 @@ game (
 	name "Nushi Zuri 64 - Shiokaze ni Notte (Japan)"
 	description "Nushi Zuri 64 - Shiokaze ni Notte (Japan)"
 	rom ( name "Nushi Zuri 64 - Shiokaze ni Notte (Japan).n64" size 33554432 crc 6A81744D md5 EA55037AD7BFA5E1EC5605A39D35CA04 sha1 5306827FFBF9BD51F52723D87083D68DB240C890 flags verified )
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!].z64" size 33554432 crc F0BCD1CE md5 EEB69597E42E2F5D2914070ACF161B4F sha1 85D8B412E3045C7A06062D3E155FEF9EA918E800 )
 )
 
 game (
 	name "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)"
 	description "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)"
 	rom ( name "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).n64" size 16777216 crc 6E79473E md5 88A46921227F3FA23F52AED725C040D1 sha1 93DC2ADB08C209FDC0BF2F007824FDE79F79A638 )
+	rom ( name "O.D.T. (E) (M5) [!].z64" size 16777216 crc 7B870026 md5 E2FB4F16A039A0E302D28ACA94D5D928 sha1 092FB7C560B40CC3A2A0E6B48A6AFC10948C4166 )
 )
 
 game (
 	name "O.D.T. (USA) (En,Fr,Es) (Proto)"
 	description "O.D.T. (USA) (En,Fr,Es) (Proto)"
 	rom ( name "O.D.T. (USA) (En,Fr,Es) (Proto).n64" size 16777216 crc AE7E3A9E md5 AE29DE9B6BD8DEA8CF27783B2F720B10 sha1 9D1E073F9AAD18F4A7A52CB185A50F5045BFD656 )
+	rom ( name "O.D.T. (U) (M3) [!].z64" size 16777216 crc 1D4A8659 md5 4116E492168AAFFF1BD3100C7B0AA28F sha1 453A7A636B05C8B9DAD6AA6FB5E265BAAE568074 )
 )
 
 game (
 	name "Off Road Challenge (Europe)"
 	description "Off Road Challenge (Europe)"
 	rom ( name "Off Road Challenge (Europe).n64" size 16777216 crc E1938232 md5 4F6390A166F11F9D2920F15780DF937C sha1 C15EBCDBE0532556E215CDB7EE35C4F25FE66884 flags verified )
+	rom ( name "Off Road Challenge (E) [!].z64" size 16777216 crc D9FE9EE7 md5 E96FECBA52905DB14ADDAD7CFD61091F sha1 3476E0EB4048C76107BD2B404D19A136BFC15AD9 )
 )
 
 game (
 	name "Off Road Challenge (USA)"
 	description "Off Road Challenge (USA)"
 	rom ( name "Off Road Challenge (USA).n64" size 16777216 crc 129BADCC md5 4CA359921B3A49DCD5BBD725656A255D sha1 914239AA8172C91C44280A09E34B6E7CE046CA1B )
+	rom ( name "Off Road Challenge (U) [!].z64" size 16777216 crc 1A45C5AB md5 AF7083FC0ABCFD5A2C6A5E971453D831 sha1 9E754CA37D69424E9F82A421D5E69D4AD73046C1 )
 )
 
 game (
 	name "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A)"
 	description "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A)"
 	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A).n64" size 41943040 crc D52F01FD md5 4777C460D5BFE53978A33D825413C4BF sha1 771BB04C814FDB741351B37BC4CA2DB00F3D2A43 flags verified )
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!].z64" size 41943040 crc 845B8711 md5 A45C39767D33AC21956A3D4E6C03CFA1 sha1 244A92DF46863964EC507C78B72C226F48754967 )
 )
 
 game (
@@ -3423,42 +3920,49 @@ game (
 	name "Olympic Hockey 98 (Europe) (En,Fr,De,Es)"
 	description "Olympic Hockey 98 (Europe) (En,Fr,De,Es)"
 	rom ( name "Olympic Hockey 98 (Europe) (En,Fr,De,Es).n64" size 8388608 crc 1C7B9ED5 md5 435EB59F36BDEA6BFC2E25D763C9EE46 sha1 D72F932B0D12F19B9423A112664D0CCFC1526767 flags verified )
+	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [!].z64" size 8388608 crc 5A805C2E md5 465DFD27DDAB4F5488F4DADC09B7F938 sha1 E01404FAC7E9AFC02D48BF889ABA51F843165B7C )
 )
 
 game (
 	name "Olympic Hockey 98 (Japan)"
 	description "Olympic Hockey 98 (Japan)"
 	rom ( name "Olympic Hockey 98 (Japan).n64" size 8388608 crc 436CC625 md5 9C58F2842D71B3145650133C2F1E7824 sha1 DF9D4743019FBA3DD0725588F0D17D97CBB2C223 flags verified )
+	rom ( name "Olympic Hockey Nagano '98 (J) [!].z64" size 8388608 crc 9E98FCE8 md5 8A964671C5A4F4FC62787F1F25EDD70D sha1 A5359E35839B40C414EAE498CA633B28176629AA )
 )
 
 game (
 	name "Olympic Hockey 98 (USA)"
 	description "Olympic Hockey 98 (USA)"
 	rom ( name "Olympic Hockey 98 (USA).n64" size 8388608 crc C57C7643 md5 C80F8E7D193A9582A0662C923B128F7F sha1 7E200F4F4D2A7EB0DDC2011BD55628B5A50788BF )
+	rom ( name "Olympic Hockey Nagano '98 (U) [!].z64" size 8388608 crc 2D777652 md5 9C99C6D9EA98A960056C531CB78EB35B sha1 02310067DEFD4C7EAC235DFF5E71EF0566CE916C )
 )
 
 game (
 	name "Onegai Monsters (Japan)"
 	description "Onegai Monsters (Japan)"
 	rom ( name "Onegai Monsters (Japan).n64" size 16777216 crc FF03EC8A md5 94F9782A2D365C7A697119D728909257 sha1 A352A6F95B414F7563503FA39E92C604F965A11E flags verified )
+	rom ( name "Onegai Monsters (J) [!].z64" size 16777216 crc AC72A1C7 md5 3796829F54958CE103DCF5E3E8EB80B4 sha1 7592F4C16B8E040539B5DCC201FAB2965A5E8C8D )
 )
 
 game (
 	name "Operation WinBack (Europe) (En,Fr,De,Es,It)"
 	description "Operation WinBack (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Operation WinBack (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 15F1C325 md5 D92A9A5BB620700F6CF59EED83DE9105 sha1 6AB5A9771F4BED7F96726C943A24215300C107E5 flags verified )
+	rom ( name "Operation WinBack (E) (M5) [!].z64" size 16777216 crc FB96F166 md5 91CF1982F309BD73822165087DAD4371 sha1 133F17162B2734286F9E94F64ACB1538B11506B2 )
 )
 
 game (
 	name "Pachinko 365 Nichi (Japan)"
 	description "Pachinko 365 Nichi (Japan)"
 	rom ( name "Pachinko 365 Nichi (Japan).n64" size 12582912 crc 41363874 md5 31D86C32389108E5780E23380BE13974 sha1 A14F8B56F1F40D982E3636B328911CCC96B58BD5 flags verified )
+	rom ( name "Pachinko 365 Nichi (J) [!].z64" size 12582912 crc 42D06E32 md5 D60046C23400BFEBD5B051F89E7F2F07 sha1 B8F29E8EFCF51EE9A6A16E2A1E60442B4F304950 )
 )
 
 game (
 	name "Paper Mario (Europe) (En,Fr,De,Es)"
 	description "Paper Mario (Europe) (En,Fr,De,Es)"
 	rom ( name "Paper Mario (Europe) (En,Fr,De,Es).n64" size 67108864 crc 7CAB0055 md5 24EDF142D2974627C218D2D507190C3B sha1 7F29B70C9CB686AE678BEB40B59EE5583B095FF7 flags verified )
+	rom ( name "Paper Mario (E) (M4) [!].z64" size 67108864 crc 85B3AB37 md5 A9BE6A493A680642D840F859A65816CA sha1 2111D39265A317414D359E35A7D971C4DFA5F9E1 )
 )
 
 game (
@@ -3472,6 +3976,7 @@ game (
 	name "Paperboy (Europe)"
 	description "Paperboy (Europe)"
 	rom ( name "Paperboy (Europe).n64" size 12582912 crc D98C3F8B md5 7D4366BBED26ABD0C161501DE1BBAEBB sha1 DA7DA76570C4C5303475C30C18791CA83F8455C4 flags verified )
+	rom ( name "Paperboy (E) [!].z64" size 12582912 crc F00C5053 md5 B7F2EB7989C9C00096655D087D72EC51 sha1 7DB4808042B9651B47592E814AC4C125B51D4D2F )
 )
 
 game (
@@ -3485,42 +3990,49 @@ game (
 	name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)"
 	description "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)"
 	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).n64" size 12582912 crc 66420991 md5 C9FB55F7B8CFD59DB0CFE346F13B2694 sha1 2E1F15CBB6E4744D6B1C8EFDC708349AB6C8982A flags verified )
+	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!].z64" size 12582912 crc A33146E0 md5 D78E10C6B3E98F3B32FE0F23ED72DB42 sha1 9887A0E4BFE3C5E85E31638853574069F6C41CD3 )
 )
 
 game (
 	name "PD Ultraman Battle Collection 64 (Japan)"
 	description "PD Ultraman Battle Collection 64 (Japan)"
 	rom ( name "PD Ultraman Battle Collection 64 (Japan).n64" size 33554432 crc AB901B83 md5 5DB16368F53664CE98024AC721B12E84 sha1 15A646C8E612F50A767055C352A1BEF59AEF49E5 flags verified )
+	rom ( name "PD Ultraman Battle Collection 64 (J) [!].z64" size 33554432 crc 86CC80B5 md5 52F4F3320607F3E8DD1A16A2F1BFBDB0 sha1 16783D9DE1FF772E215F47441612D6805AA98C67 )
 )
 
 game (
 	name "Penny Racers (Europe)"
 	description "Penny Racers (Europe)"
 	rom ( name "Penny Racers (Europe).n64" size 8388608 crc DECD5D16 md5 62AC66021E02EAEBCEA8A153A7366E63 sha1 D44053CAED77DE2C91DE6527E1D4CD4441B231D8 flags verified )
+	rom ( name "Penny Racers (E) [!].z64" size 8388608 crc A1D6EB5B md5 20DA62ECE553EDE84D02283174BECC8F sha1 9848CC288B388D23E0AE026EF58DA8FC936D7605 )
 )
 
 game (
 	name "Penny Racers (USA)"
 	description "Penny Racers (USA)"
 	rom ( name "Penny Racers (USA).n64" size 8388608 crc 06BEEA3F md5 A9E6E459908009B979C4CB649609A208 sha1 F8CA8A70653DBE488749FD3EA3E428FB9B1F72C8 )
+	rom ( name "Penny Racers (U) [!].z64" size 8388608 crc C1E57337 md5 518B14054A667A3B9E0B72D3BF784E41 sha1 1D4FCE8AD6B1F0072D89AEB4C3187BC853B750A0 )
 )
 
 game (
 	name "Perfect Dark (Europe) (En,Fr,De,Es,It)"
 	description "Perfect Dark (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Perfect Dark (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc C4639ED6 md5 6F86452863716270C51C4F433AF47534 sha1 EB38780B7F7A0EA4C24369D03644B42FFE739E63 flags verified )
+	rom ( name "Perfect Dark (E) (M5) [!].z64" size 33554432 crc 7718A714 md5 D9B5CD305D228424891CE38E71BC9213 sha1 A663D3F4EEE0B198471132DB92E9639A9EDD1985 )
 )
 
 game (
 	name "Perfect Dark (Japan)"
 	description "Perfect Dark (Japan)"
 	rom ( name "Perfect Dark (Japan).n64" size 33554432 crc D76471DB md5 041B6A5025585E70AC658975F6DCBCD7 sha1 E001AF5A3069B374E0A08D1598B0833FE3128D82 flags verified )
+	rom ( name "Perfect Dark (J) [!].z64" size 33554432 crc 639C0DA9 md5 538D2B75945EAE069B29C46193E74790 sha1 99BCAAA4841B09C845E1094006DF8F637862F02E )
 )
 
 game (
 	name "Perfect Dark (USA)"
 	description "Perfect Dark (USA)"
 	rom ( name "Perfect Dark (USA).n64" size 33554432 crc F0FE18F0 md5 EAEDD63AE7609C8C795DB93AA2437C4C sha1 EA43D1F09B47107AE0D1B7472BCA58D785E8573A )
+	rom ( name "Perfect Dark (U) (V1.0) [!].z64" size 33554432 crc 68446AD4 md5 7F4171B0C8D17815BE37913F535E4E93 sha1 60DFE17923C03875B499B3CD3200F05CB538B7AD )
 )
 
 game (
@@ -3534,30 +4046,35 @@ game (
 	name "PGA European Tour (USA)"
 	description "PGA European Tour (USA)"
 	rom ( name "PGA European Tour (USA).n64" size 16777216 crc 2B07F591 md5 1ACCD330228ECEC87DAC81CCB999486D sha1 6417F608E7DD002DC1193641D8C846328C3FAAB2 )
+	rom ( name "PGA European Tour (U) [!].z64" size 16777216 crc 7CDFCDAA md5 617CECA1D2BEFFCE943EF832326898BF sha1 6E8DFCCFE93318A597E99C9186D5E8CDCA3BE987 )
 )
 
 game (
 	name "PGA European Tour Golf (Europe) (En,Fr,De,Es,It)"
 	description "PGA European Tour Golf (Europe) (En,Fr,De,Es,It)"
 	rom ( name "PGA European Tour Golf (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 07B0271E md5 71689E7713FC30F32E39D3B2EF8F7B65 sha1 20C442CF25951E2B09EB7B19E3E900B885231FFA flags verified )
+	rom ( name "PGA European Tour (E) (M5) [!].z64" size 16777216 crc 6B5FF959 md5 0112FFAADA116D172ABCE136E9043A93 sha1 F9E838CF5CFD0FA493D5E5F7A7D450A80787C814 )	
 )
 
 game (
 	name "Pikachuu Genki de Chuu (Japan)"
 	description "Pikachuu Genki de Chuu (Japan)"
 	rom ( name "Pikachuu Genki de Chuu (Japan).n64" size 16777216 crc 2AE884CD md5 9433601ED8326F9C60A5F78050EADA2E sha1 533BA7078E631BDCBF97776A151DBCAB206FA991 flags verified )
+	rom ( name "Pikachu Genki Dechu (J) [!].z64" size 16777216 crc 3F6245AE md5 E0BCB2758EDF0AC6AB7DB36D98E1E57C sha1 A28C689E58F58B4A2A672D3D010436661D247476 )
 )
 
 game (
 	name "Pilotwings 64 (Europe) (En,Fr,De)"
 	description "Pilotwings 64 (Europe) (En,Fr,De)"
 	rom ( name "Pilotwings 64 (Europe) (En,Fr,De).n64" size 8388608 crc 334E88BF md5 9E90E82CDA1F83B2BD43B9B19F68E404 sha1 7014B6AC0A6AF8AB729E441AE9B5DE08EF7B68DD flags verified )
+	rom ( name "Pilotwings 64 (E) (M3) [!].z64" size 8388608 crc C902E57C md5 3FCD4969F9A080BD2BCB913EC5D7A3BD sha1 FA4E0A1941EEA83E09CA00197569E2464D70ECB0 )
 )
 
 game (
 	name "Pilotwings 64 (Japan)"
 	description "Pilotwings 64 (Japan)"
 	rom ( name "Pilotwings 64 (Japan).n64" size 8388608 crc 001EE45B md5 C7BD4AB71093D71D1313905F85292EAF sha1 E6E8A48E433DC7A4949756E70AB18D0165A1BC6F flags verified )
+	rom ( name "Pilotwings 64 (J) [!].z64" size 8388608 crc 3D3A84A9 md5 E8E6EC0692009009F5DCA6827B21F59A sha1 892A5472D9A6811B881D093020DE81F72BAEEEC9 )
 )
 
 game (
@@ -3571,18 +4088,21 @@ game (
 	name "Pokemon Puzzle League (Europe)"
 	description "Pokemon Puzzle League (Europe)"
 	rom ( name "Pokemon Puzzle League (Europe).n64" size 33554432 crc 443B309A md5 CCCDA8BDB4C64DE28FA086DE3F8C0BD1 sha1 06EB1D4C92A7BAB8267B6FA15BE89F253DEAD96C flags verified )
+	rom ( name "Pokemon Puzzle League (E) [!].z64" size 33554432 crc 75839254 md5 2EF9FA16DE2A09EA15B6289447F40490 sha1 184F0CAC8FDFAD47590C515FC637076D2DED58D7 )
 )
 
 game (
 	name "Pokemon Puzzle League (France)"
 	description "Pokemon Puzzle League (France)"
 	rom ( name "Pokemon Puzzle League (France).n64" size 33554432 crc EE080CCD md5 FCC53191CE4825E5B858DEAAE9EC6D8A sha1 838F4CDC5033A672AFC8662700ECD8DF1EF6B776 flags verified )
+	rom ( name "Pokemon Puzzle League (F) [!].z64" size 33554432 crc C3AA0074 md5 A3BA044DFC00BB766B4B2BFB9D4B5BE9 sha1 72760A2D87ED3E70756A4AA689B9B26786669A52 )
 )
 
 game (
 	name "Pokemon Puzzle League (Germany)"
 	description "Pokemon Puzzle League (Germany)"
 	rom ( name "Pokemon Puzzle League (Germany).n64" size 33554432 crc 7D4C9859 md5 77A22697BA18EC59018F0C8B5F16C656 sha1 656C86A50E4954E11C202ADA31D2E2FD516B8F07 )
+	rom ( name "Pokemon Puzzle League (G) [!].z64" size 33554432 crc AC543150 md5 000364BAC80E41D9060A31A5923874B7 sha1 DBC9D0DE131F3604A9115B58368E9050F1A6303F )
 )
 
 game (
@@ -3596,42 +4116,49 @@ game (
 	name "Pokemon Snap (Japan)"
 	description "Pokemon Snap (Japan)"
 	rom ( name "Pokemon Snap (Japan).n64" size 16777216 crc 100AACC0 md5 37B2C5F48A58C22C62D7F5A3A77BB50A sha1 76EA033F8D76C3ADD4F76D7DC718834AA1D30615 flags verified )
+	rom ( name "Pocket Monsters Snap (J) [!].z64" size 16777216 crc A091BD56 md5 FBDD74ED68E6A0CD734562D56CCB752D sha1 5D7B3B8D4BB64DA5B7AE5E1F132B26A282C33909 )
 )
 
 game (
 	name "Pokemon Snap (Australia)"
 	description "Pokemon Snap (Australia)"
 	rom ( name "Pokemon Snap (Australia).n64" size 16777216 crc 8A8F6D5F md5 FC945109F7F097061E85E98D1FEDB745 sha1 D6BDD376A1BAEB863A14925BC96E2D1A73645E71 )
+	rom ( name "Pokemon Snap (A) [!].z64" size 16777216 crc CDEA6D4C md5 E5A0CA3DC54B38EA7FCD927E3CFFAD3B sha1 EB388731BB7530F60E3AD4A1652F79296B5063EC )
 )
 
 game (
 	name "Pokemon Snap (Europe)"
 	description "Pokemon Snap (Europe)"
 	rom ( name "Pokemon Snap (Europe).n64" size 16777216 crc E9100906 md5 D1858ECF414716FB86861862256D85EA sha1 85EC6F75567D5676EE7317B4F20C8EC6CACA03BB flags verified )
+	rom ( name "Pokemon Snap (E) [!].z64" size 16777216 crc F824A057 md5 F2A8106403D2BF9350BFEAB08689D54A sha1 D575B393812A0A59FBB52F3CE55CE4D7BC5F3225 )
 )
 
 game (
 	name "Pokemon Snap (France)"
 	description "Pokemon Snap (France)"
 	rom ( name "Pokemon Snap (France).n64" size 16777216 crc 116B2CAC md5 CA5BC0BE9FBCD288F60A21D10056B972 sha1 5C1D6E2020EED2E012B722A98846DB16FA7B1C9B )
+	rom ( name "Pokemon Snap (F) [!].z64" size 16777216 crc EC843586 md5 E9028F9CCC307806695DD81742D05D5D sha1 9EE1ED91AD6E00CC50E1A1513A256CCCEB9A41DF )
 )
 
 game (
 	name "Pokemon Snap (Germany)"
 	description "Pokemon Snap (Germany)"
 	rom ( name "Pokemon Snap (Germany).n64" size 16777216 crc 482A6D8D md5 182EEA9719F8C5EE6A29622B192CAA2C sha1 D12D3AD66DA97985F057D42DD7FBB9B9C1A0074E flags verified )
+	rom ( name "Pokemon Snap (G) [!].z64" size 16777216 crc 10C27B3C md5 144B8906DC40534CFBEF6D7B994A982B sha1 F1FE20E26C3803C0E4EA33711BE5E0EDF8E9C4BE )
 )
 
 game (
 	name "Pokemon Snap (Italy)"
 	description "Pokemon Snap (Italy)"
 	rom ( name "Pokemon Snap (Italy).n64" size 16777216 crc D3AE1D04 md5 AAAE244517FE402FE86BFBF8A2FC9D4F sha1 AB649B902B48271F628B614B43453C651592AF4F )
+	rom ( name "Pokemon Snap (I) [!].z64" size 16777216 crc 63F6058A md5 D0453459095F69BE36D675D8F743069B sha1 F69BFBF1F5590B2F25A79400ABCDAFB884F5E3A0 )
 )
 
 game (
 	name "Pokemon Snap (Spain)"
 	description "Pokemon Snap (Spain)"
 	rom ( name "Pokemon Snap (Spain).n64" size 16777216 crc 426A1919 md5 E845272B8A282AE4051676574405EC13 sha1 E2276ABF1CC2FE7BB5A8D05241214481B02580E1 )
+	rom ( name "Pokemon Snap (S) [!].z64" size 16777216 crc 371B787F md5 A45D7115BE5A06FD1567F9F913C3BDF8 sha1 24DA787140662D1FB40D8E17199CE6412D72DEDC )
 )
 
 game (
@@ -3652,42 +4179,50 @@ game (
 	name "Pokemon Stadium (Japan)"
 	description "Pokemon Stadium (Japan)"
 	rom ( name "Pokemon Stadium (Japan).n64" size 16777216 crc 3B2A3F7A md5 7159F1B35AF48EC43236DDFCC2C73B5C sha1 D1796076F855BD2354FFC5019EAEB2C9D7676716 flags verified )
+	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189C md5 C46E087D966A35095DF96799B0B4FFAE sha1 8BC8D2FF7DF25B26BD0C353D2ADFE83E4E3A7A87 )
+	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
 	name "Pokemon Stadium (Europe)"
 	description "Pokemon Stadium (Europe)"
 	rom ( name "Pokemon Stadium (Europe).n64" size 33554432 crc 7A8BF040 md5 3D01C1B902876B4F72C10B66ED99B693 sha1 DF6D958FDF04D598194AB5821DD77655DA9D0C5D )
+	rom ( name "Pokemon Stadium (E) (V1.0) [!].z64" size 33554432 crc DC57508D md5 2859090D78581E0925A3AF8045E81E4B sha1 6F26E3C8B35C3232058375E30D19665FACB23123 )
 )
 
 game (
 	name "Pokemon Stadium (Europe) (Rev A)"
 	description "Pokemon Stadium (Europe) (Rev A)"
 	rom ( name "Pokemon Stadium (Europe) (Rev A).n64" size 33554432 crc 60F6BE65 md5 B70451292A9F5C57F1526520ADC7F340 sha1 B34B5DB300E0A7B9D283839B92A3A7040924130A flags verified )
+	rom ( name "Pokemon Stadium (E) (V1.1) [!].z64" size 33554432 crc DA889668 md5 31EE2DE8E65E30F5934C450DBAA924F0 sha1 9470F899AD0107677B7DFD24E1DD567723A5F84F )
 )
 
 game (
 	name "Pokemon Stadium (France)"
 	description "Pokemon Stadium (France)"
 	rom ( name "Pokemon Stadium (France).n64" size 33554432 crc 476848F6 md5 2C8804EDFE7BB61C4FC3AABE27D13EEE sha1 3F246D6357AB981DB1E2C588C92B29B7DBE4051C )
+	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
 	name "Pokemon Stadium (Germany)"
 	description "Pokemon Stadium (Germany)"
 	rom ( name "Pokemon Stadium (Germany).n64" size 33554432 crc 3243A2A7 md5 738A02D2C1DE1D60ADE9E45654466019 sha1 20943B1E25AF11AE2305D9680049DFA777B96EF0 flags verified )
+	rom ( name "Pokemon Stadium (G) [!].z64" size 33554432 crc 9F22A945 md5 24BE2CCB0DEA0755908C02BF67E22FE5 sha1 6A25903E733F071E7D6EA54529B7FD60B760CDA3 )
 )
 
 game (
 	name "Pokemon Stadium (Italy)"
 	description "Pokemon Stadium (Italy)"
 	rom ( name "Pokemon Stadium (Italy).n64" size 33554432 crc 77A59419 md5 CDD4546D1C9CFA4FA835A519C8696982 sha1 C205D6CEF57D1FEC51F13627F1D2957138814322 )
+	rom ( name "Pokemon Stadium (I) [!].z64" size 33554432 crc F155C465 md5 A81321759AF38BEB30A40FDACA2EA22A sha1 DB5F2797C377FA8957B97465FC5738D6999FF240 )
 )
 
 game (
 	name "Pokemon Stadium (Spain)"
 	description "Pokemon Stadium (Spain)"
 	rom ( name "Pokemon Stadium (Spain).n64" size 33554432 crc 7ADFB7E0 md5 13B70060607A6F86E29427D784B984CE sha1 D8BCE5FDD89654C37C74E64A39589466C6ED8C3D )
+	rom ( name "Pokemon Stadium (S) [!].z64" size 33554432 crc F02CD5EB md5 D14A499BC4E324974EAE3E42DEC58625 sha1 F39911AD0BEDCCC3E44D4338507C73BFA97856BF )
 )
 
 game (
@@ -3701,6 +4236,7 @@ game (
 	name "Pokemon Stadium (USA) (Rev A)"
 	description "Pokemon Stadium (USA) (Rev A)"
 	rom ( name "Pokemon Stadium (USA) (Rev A).n64" size 33554432 crc 7BB7489F md5 A029CF9B7D15E30FB88E472D965B2865 sha1 D5B479461CD45DB31E896143519C85B7136CFE2E flags verified )
+	rom ( name "Pokemon Stadium (U) (V1.1) [!].z64" size 33554432 crc 72B552E3 md5 A7087A96A709E4C662A459B4B4159094 sha1 E8F84246EEBDC63C31CEBFD0475C72A3520A67A3 )
 )
 
 game (
@@ -3713,36 +4249,42 @@ game (
 	name "Pokemon Stadium 2 (Japan)"
 	description "Pokemon Stadium 2 (Japan)"
 	rom ( name "Pokemon Stadium 2 (Japan).n64" size 33554432 crc C876BE9C md5 A682DF3D958AF64B48AA5B8EB809EDF1 sha1 17A3552F251DAEB475B359AAC687BCEE473C13F7 flags verified )
+	rom ( name "Pocket Monsters Stadium 2 (J) [!].z64" size 33554432 crc 40AA4874 md5 2449BB712A64E3363A6CBD56F5ADEDA5 sha1 074582744C71D7F0569CE960964A7BBE947EFD3C )
 )
 
 game (
 	name "Pokemon Stadium 2 (Europe)"
 	description "Pokemon Stadium 2 (Europe)"
 	rom ( name "Pokemon Stadium 2 (Europe).n64" size 67108864 crc 85F53D6C md5 31209E91A896F0E7A70971ADAB11F4CA sha1 F090D5F2C20BCD2290A7544AF5304E81C0F63D84 flags verified )
+	rom ( name "Pokemon Stadium 2 (E) [!].z64" size 67108864 crc 6B3096C4 md5 B1271DB50D6EF8F6B53CC640C3743E4F sha1 F6A7E8146433A48BF101722E30BF86311A641F7B )
 )
 
 game (
 	name "Pokemon Stadium 2 (France)"
 	description "Pokemon Stadium 2 (France)"
 	rom ( name "Pokemon Stadium 2 (France).n64" size 67108864 crc A72C55AF md5 E75AB876AD8CD202D0D97F0661088157 sha1 8B7D84BFCE6E1CCE565E3DA13D1B70AC49972B4B )
+	rom ( name "Pokemon Stadium 2 (F) [!].z64" size 67108864 crc E2A78066 md5 4748D96916AE2BCC5FC1630515EE2561 sha1 D7E13535B671024A92822DB01507E87BD42F68EC )
 )
 
 game (
 	name "Pokemon Stadium 2 (Germany)"
 	description "Pokemon Stadium 2 (Germany)"
 	rom ( name "Pokemon Stadium 2 (Germany).n64" size 67108864 crc B0A291FC md5 2D84449AA09E7BE0210D88EB95F44334 sha1 BDB0DB2AB6E2661BD32FF3CD1DED3BD5AD6073EF flags verified )
+	rom ( name "Pokemon Stadium 2 (G) [!].z64" size 67108864 crc 1146A43A md5 484F3E696C94980ACF3D7068F9ACC98F sha1 6DE05180D77E73DCF32D57AF7C8C1529C7ACDA59 )
 )
 
 game (
 	name "Pokemon Stadium 2 (Italy)"
 	description "Pokemon Stadium 2 (Italy)"
 	rom ( name "Pokemon Stadium 2 (Italy).n64" size 67108864 crc C849C481 md5 98E85F8307B004E0A44321D271B96343 sha1 55E9C0186A5C846B84315B1780587D31E8A9EB44 )
+	rom ( name "Pokemon Stadium 2 (I) [!].z64" size 67108864 crc 9FA5C095 md5 5A04D7F1AB9C6B080176567AA7168D3A sha1 4926DB649C76521F61AE51C13E452A2C8001354C )
 )
 
 game (
 	name "Pokemon Stadium 2 (Spain)"
 	description "Pokemon Stadium 2 (Spain)"
 	rom ( name "Pokemon Stadium 2 (Spain).n64" size 67108864 crc 391119B5 md5 B20177F0D7693991428837737151FB79 sha1 EF07A49536DDB18B98897B78EB66A44C13467351 )
+	rom ( name "Pokemon Stadium 2 (S) [!].z64" size 67108864 crc 283E7641 md5 B26AAFD452C9816E1B7AA0954E75825F sha1 AB1CDF753BED70487923EA3129278E45D6325773 )
 )
 
 game (
@@ -3756,6 +4298,7 @@ game (
 	name "Pokemon Stadium Kin Gin (Japan)"
 	description "Pokemon Stadium Kin Gin (Japan)"
 	rom ( name "Pokemon Stadium Kin Gin (Japan).n64" size 67108864 crc 16701567 md5 586F807965D79E117F74D9353186249E sha1 4D40523A8FC1C212F30312BB7DCB665588BC6F1B flags verified )
+	rom ( name "Pocket Monsters Stadium Kin Gin (J) [!].z64" size 67108864 crc CBC3B935 md5 A17AADCC962393D476EDC321E59C504B sha1 05682E60B13479CA1C54656E5A5B1EE6D099C1A4 )
 )
 
 game (
@@ -3768,12 +4311,14 @@ game (
 	name "Power League 64 (Japan)"
 	description "Power League 64 (Japan)"
 	rom ( name "Power League 64 (Japan).n64" size 8388608 crc BC7E2494 md5 FAEB21232DC50BCC9CA01E93A5DBD2AF sha1 97E55B2C39F4E0390EC280A6F6D6D2777669EB43 flags verified )
+	rom ( name "Power League Baseball 64 (J) [!].z64" size 8388608 crc AEC21C28 md5 8CC73C373016070647030DDE492FDC8C sha1 1E0D939C8E278DE21C42FA33495E446ED03C027E )
 )
 
 game (
 	name "Power Rangers - Lightspeed Rescue (Europe)"
 	description "Power Rangers - Lightspeed Rescue (Europe)"
 	rom ( name "Power Rangers - Lightspeed Rescue (Europe).n64" size 12582912 crc 88250AB1 md5 6E2F4DBD273BCB6F881C359E7422D022 sha1 C49AC782BC970A7CE1F76D7B60F7E741E915FBE2 )
+	rom ( name "Power Rangers - Lightspeed Rescue (E) [!].z64" size 12582912 crc 83590247 md5 AE3BDF729214964620417CC3163F0BB6 sha1 C0C283528CB892195F6D22B8A5C610239FA8C206 )
 )
 
 game (
@@ -3794,12 +4339,14 @@ game (
 	name "Premier Manager 64 (Europe)"
 	description "Premier Manager 64 (Europe)"
 	rom ( name "Premier Manager 64 (Europe).n64" size 16777216 crc 74A0C415 md5 427F58630B25DE66A1C87C7B3BD30E3E sha1 C379521C2BAE36F37D93DDCD2781ABC255AE4E14 flags verified )
+	rom ( name "Premier Manager 64 (E) [!].z64" size 16777216 crc 81CDA888 md5 25BAFC84BA4D87854DC44DF3EF8764EA sha1 6AFFB5B00B1862E233E4D909DC6E4201F9945579 )
 )
 
 game (
 	name "Pro Mahjong Kiwame 64 (Japan)"
 	description "Pro Mahjong Kiwame 64 (Japan)"
 	rom ( name "Pro Mahjong Kiwame 64 (Japan).n64" size 8388608 crc 01E83335 md5 B65C64ECCCAC8B4802754437AB4AFFF8 sha1 D58D1BD7184A69AB06F0104A0A94A1179EE7B208 flags verified )
+	rom ( name "Pro Mahjong Kiwame 64 (J) [!].z64" size 8388608 crc 1F5907F9 md5 7995D76F4CE236B0F0289F47AE523D32 sha1 B5BE6C3B49AD37C0DD1D6E7DACBCBE03653859D9 )
 )
 
 game (
@@ -3812,30 +4359,35 @@ game (
 	name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)"
 	description "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)"
 	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).n64" size 8388608 crc 388DA567 md5 7B150366EC773FE9174D78D62C834B01 sha1 7C5565519BB9041EBD25A78CA174143FAF872809 flags verified )
+	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!].z64" size 8388608 crc 35461699 md5 F1A2E4DD22ADF4F90DA4BDDCA37D5F18 sha1 25BC862BFABDC972459E8EC2F4173BD5D638EFF3 )
 )
 
 game (
 	name "Puyo Puyo 4 - Puyo Puyon Party (Japan)"
 	description "Puyo Puyo 4 - Puyo Puyon Party (Japan)"
 	rom ( name "Puyo Puyo 4 - Puyo Puyon Party (Japan).n64" size 12582912 crc 9C32ADEB md5 53272289F493D802B7C562DAAB64219F sha1 E02D3A92256A43C8AEAA6DABD2F53CD3769EF1F6 flags verified )
+	rom ( name "Puyo Puyo 4 - Puyo Puyo Party (J) [!].z64" size 12582912 crc D59D2794 md5 22B86AB3F320A607899A0516C90A24D0 sha1 D5553182ECDA2EBA6076E7B04B900EF78B700FC5 )
 )
 
 game (
 	name "Puyo Puyo Sun 64 (Japan)"
 	description "Puyo Puyo Sun 64 (Japan)"
 	rom ( name "Puyo Puyo Sun 64 (Japan).n64" size 8388608 crc C256544C md5 D8445CC05C4073CAE562FD80849DB467 sha1 6BA3441890502ED5CDC27F29752F231490E49BF5 flags verified )
+	rom ( name "Puyo Puyo Sun 64 (J) [!].z64" size 8388608 crc 355FF9DE md5 FAAA2094B04DCA4C287AF9334D22529D sha1 CF79EC32E7E78B2CAD15B5B7DD763F578648B6C6 )
 )
 
 game (
 	name "Puzzle Bobble 64 (Japan)"
 	description "Puzzle Bobble 64 (Japan)"
 	rom ( name "Puzzle Bobble 64 (Japan).n64" size 8388608 crc 30238199 md5 3C411421611E82C81CA228E9EC2B81DB sha1 4E8B0BFB5A885919E63CB09618A0A3D938422301 flags verified )
+	rom ( name "Puzzle Bobble 64 (J) [!].z64" size 8388608 crc EA837423 md5 B478D4AF60D43C38BA81DE9FAEA6E057 sha1 9A4CDDE04E6C42CF7957BF578A0B15CA90203280 )
 )
 
 game (
 	name "Quake 64 (Europe)"
 	description "Quake 64 (Europe)"
 	rom ( name "Quake 64 (Europe).n64" size 12582912 crc 6F79B0EB md5 D42EF7ADF20697AEE783DBC33EAFA107 sha1 8B9FF00FFF48EF847794164111EC9415E5DCCB31 flags verified )
+	rom ( name "Quake 64 (E) [!].z64" size 12582912 crc 28C10844 md5 592CE7718EFDD1FF2F077C9B2B5275FB sha1 C1B4FC22A1699BE0BC8CEA170AC4F8B6BF8F41D1 )
 )
 
 game (
@@ -3849,6 +4401,7 @@ game (
 	name "Quake II (Europe)"
 	description "Quake II (Europe)"
 	rom ( name "Quake II (Europe).n64" size 12582912 crc 7098DF97 md5 BB759EC808C3AD387B9D7C02B99DECCE sha1 03F9A512C37E1351CB701A4EE5504BA6EA7D47AB flags verified )
+	rom ( name "Quake II (E) [!].z64" size 12582912 crc 82BECA21 md5 673D4BA4F41A0FE23650F06AF53EEC50 sha1 F99CC966965E8FA0BEB9FD768C646E6686E19916 )
 )
 
 game (
@@ -3862,78 +4415,91 @@ game (
 	name "Quest 64 (USA)"
 	description "Quest 64 (USA)"
 	rom ( name "Quest 64 (USA).n64" size 16777216 crc E90856E8 md5 949A7017E27D2ED402D2AD709498FD65 sha1 738F11572A72BEA06CC5C6D9C0A341A288F29457 )
+	rom ( name "Quest 64 (U) [!].z64" size 16777216 crc D75B45C6 md5 EA552E33973468233A0712C251ABDB6B sha1 91B96E938C6D91699057FAD91D726EE5A23CE33A )
 )
 
 game (
 	name "Racing Simulation 2 (Germany)"
 	description "Racing Simulation 2 (Germany)"
 	rom ( name "Racing Simulation 2 (Germany).n64" size 16777216 crc D660A56F md5 34ADC5B0190B07AFEF58795727A26D0B sha1 2CD2004B2E349773F3457DC8AE2F174F0E6FA0C0 )
+	rom ( name "Racing Simulation 2 (G) [!].z64" size 16777216 crc BA73A7E4 md5 AA57D69867F53456F351A289EBA08C3D sha1 08BC64CB8C64DB9B048FC1522FD5E808FF63CE1A )
 )
 
 game (
 	name "Rakuga Kids (Europe)"
 	description "Rakuga Kids (Europe)"
 	rom ( name "Rakuga Kids (Europe).n64" size 12582912 crc 2146409A md5 F59D1D9CEDBBEBDEF9B028A3FF102566 sha1 F6E08506BA7F53312767C0033D1EF8D393C0457D flags verified )
+	rom ( name "Rakuga Kids (E) [!].z64" size 12582912 crc 483129AA md5 167A3502F06CF0EEF56758533F3D0E52 sha1 A2846CB316DC980DD0040CA95C20ABFC8CCCE212 )
 )
 
 game (
 	name "Rakuga Kids (Japan)"
 	description "Rakuga Kids (Japan)"
 	rom ( name "Rakuga Kids (Japan).n64" size 12582912 crc 4C07C266 md5 9E7D59CE213B14865FE079422CBB50B2 sha1 9CB434635987E947F25D0EBD0E1A0F500E63ADC6 flags verified )
+	rom ( name "Rakuga Kids (J) [!].z64" size 12582912 crc B9E53B06 md5 813AD5C00BAD7C4D41F8558CECEDAE51 sha1 43596236CC1A4A4B671D0586FB42518A009427A5 )
 )
 
 game (
 	name "Rally '99 (Japan)"
 	description "Rally '99 (Japan)"
 	rom ( name "Rally '99 (Japan).n64" size 8388608 crc A1C36245 md5 C9EB885EBD88E2A669757036E6E47023 sha1 920113A96DFB15E3E8ED991C42E28734EFA26599 flags verified )
+	rom ( name "Rally '99 (J) [!].z64" size 8388608 crc FFA625FE md5 0630226F63561A05916EDCFBC8D96C04 sha1 8D3659925433B9D4C37D06ABD2E1C4662AA80E1F )
 )
 
 game (
 	name "Rally Challenge 2000 (USA)"
 	description "Rally Challenge 2000 (USA)"
 	rom ( name "Rally Challenge 2000 (USA).n64" size 12582912 crc FAF5C3B6 md5 723FBC251A8D59987D77980496949125 sha1 ECD309FC0826467F7B0E197743ABF1C51C48910D )
+	rom ( name "Rally Challenge 2000 (U) [!].z64" size 12582912 crc 3EDEC7B0 md5 0458BC47CD771D8BC66B0CEAE6895724 sha1 D42FD8DE45755CD70A4D4C252CC1873410DB9F3E )
 )
 
 game (
 	name "Rampage - World Tour (Europe)"
 	description "Rampage - World Tour (Europe)"
 	rom ( name "Rampage - World Tour (Europe).n64" size 12582912 crc DFBA19D6 md5 F805ECE6A8B5AE2A0B24291DBE58D332 sha1 742B440371E2B27BFF9267041CEBBD1358B105ED flags verified )
+	rom ( name "Rampage - World Tour (E) [!].z64" size 12582912 crc CDC458EC md5 08E02F52E0547686A9BFAC7CBB03C129 sha1 C8DB2A3669B08050F42AF47BAE9FD5146B8C87BB )
 )
 
 game (
 	name "Rampage - World Tour (USA)"
 	description "Rampage - World Tour (USA)"
 	rom ( name "Rampage - World Tour (USA).n64" size 12582912 crc 6FE4DA23 md5 407698ABB21EFA78E7C91E1753C967A9 sha1 5DD821436DB22CE9B4168088189EE5788270D044 )
+	rom ( name "Rampage - World Tour (U) [!].z64" size 12582912 crc 211119DD md5 4645672A0CF00ADA9B5E37CFDE8B024E sha1 7A6C8758E67FD3DA99E3420983C0D6DF83E41C6B )
 )
 
 game (
 	name "Rampage 2 - Universal Tour (Europe)"
 	description "Rampage 2 - Universal Tour (Europe)"
 	rom ( name "Rampage 2 - Universal Tour (Europe).n64" size 12582912 crc 0D4654A8 md5 820990A9B6194339B30C4B6D3EA75309 sha1 52583EE2CEB4606F86C01FE8A3498971A104D987 flags verified )
+	rom ( name "Rampage 2 - Universal Tour (E) [!].z64" size 12582912 crc FA6E097B md5 1492806F12D33C3EA0EDB6848D43B1CC sha1 0C18A10807A5F910CE7337812770B4FE18994A60 )
 )
 
 game (
 	name "Rampage 2 - Universal Tour (USA)"
 	description "Rampage 2 - Universal Tour (USA)"
 	rom ( name "Rampage 2 - Universal Tour (USA).n64" size 12582912 crc 75E8C2AD md5 4A118869C2089FDAAD900DC34DF0788B sha1 BB3AF2FC085E58BEFA528051B7A91A54F9F38E8F )
+	rom ( name "Rampage 2 - Universal Tour (U) [!].z64" size 12582912 crc 7614EE0D md5 8113D0EA2008402D4631F241F625D16B sha1 36D1B741F6EA896B05AB7CEEAC8B78684CBDAC6B )
 )
 
 game (
 	name "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc C3909721 md5 1CB8A6D49AC03FACF06E0E24048777DF sha1 8115F19AADE05147DB633266A4DD7BEC82CDD735 flags verified )
+	rom ( name "Rat Attack (E) (M6) [!].z64" size 8388608 crc DD4FA798 md5 BC66239C12AE8696926E50C2B6ED9C49 sha1 B27E328F7600B7A2E175E4A36D8C85073EAF4D0E )
 )
 
 game (
 	name "Rat Attack! (USA) (En,Fr,De,Es,It,Nl)"
 	description "Rat Attack! (USA) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rat Attack! (USA) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 78F6FFA2 md5 9EF477AA075ABFEB026DEFDE6E57B048 sha1 6814EE444C67F1289F11A9F7DECACB75176BF634 )
+	rom ( name "Rat Attack (U) (M6) [!].z64" size 8388608 crc 2315FEA7 md5 F661889FDF65DDCD212E9FB53B2C8F50 sha1 0682B6745832984F43652C0589E4ECF37F937790 )
 )
 
 game (
 	name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
 	description "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc B7E10177 md5 8D0B9783B56E4D62D0462A80CB61947C sha1 A422B3BE224814C7F01512D778BECFA0BDFFAFC8 flags verified )
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [!].z64" size 33554432 crc 169A5037 md5 5DBBFD5ACE8222FA8FE51BE113453C13 sha1 619AB27EA1645399439AD324566361D3E7FF020E )
 )
 
 game (
@@ -3947,30 +4513,35 @@ game (
 	name "Razmoket, Les - La Chasse aux Tresors (France)"
 	description "Razmoket, Les - La Chasse aux Tresors (France)"
 	rom ( name "Razmoket, Les - La Chasse aux Tresors (France).n64" size 16777216 crc D6C8D961 md5 5418B849D3BF95C84946742AF8DEB05D sha1 1F697BBE34DCCE3A74605F13D50D0CBBE4510085 )
+	rom ( name "Les Razmoket - La Chasse Aux Tresors (F) [!].z64" size 16777216 crc 66766469 md5 55685D6324EFDE5BC9D26C98706B0B8A sha1 69C06B2D31BC6BC66CD028705D81024F21A7654C )
 )
 
 game (
 	name "Razor Freestyle Scooter (USA)"
 	description "Razor Freestyle Scooter (USA)"
 	rom ( name "Razor Freestyle Scooter (USA).n64" size 8388608 crc 208350C5 md5 C5A6C5F3A8B1A59AC2064C83744310C3 sha1 8AF56990D73F7EAE9212C44CD9F417B27ED78649 )
+	rom ( name "Razor Freestyle Scooter (U) [!].z64" size 8388608 crc 927CE621 md5 406B08987AB92D73D72B597EC6B11BD9 sha1 D107E8D28A262A60BA50DE4C227343EBC3587784 )
 )
 
 game (
 	name "Re-Volt (Europe) (En,Fr,De,Es)"
 	description "Re-Volt (Europe) (En,Fr,De,Es)"
 	rom ( name "Re-Volt (Europe) (En,Fr,De,Es).n64" size 12582912 crc 194BB8A1 md5 ABD10FCD29119EF5E7F9915429042449 sha1 31D1B888BDA70D2D5B1C7ECD95F8F2D83AC35D36 flags verified )
+	rom ( name "Re-Volt (E) (M4) [!].z64" size 12582912 crc 81D13A11 md5 FAA64ABB0D222FCC0C6E2515D3805D9F sha1 5ED3CD3888FEC080D44FFE345DD50D75E471FF8F )
 )
 
 game (
 	name "Re-Volt (USA)"
 	description "Re-Volt (USA)"
 	rom ( name "Re-Volt (USA).n64" size 12582912 crc 9366C53C md5 B23B9E8CEC8B00507D20464905A0C5C5 sha1 BFFC68E662338CDF03B619B3A62EF880F1DB025D )
+	rom ( name "Re-Volt (U) [!].z64" size 12582912 crc FC0C86D0 md5 3FC4D3187435443455F8355B2D3F8934 sha1 667FDC39112599BD904F5E7D8D692973E554BD88 )
 )
 
 game (
 	name "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
 	description "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
 	rom ( name "Ready 2 Rumble Boxing (Europe) (En,Fr,De).n64" size 33554432 crc F2FE85AD md5 F8A3D817DB07D19F3C06207D2835803A sha1 8A2BD9CEB91BC753CBEEBD4CB0D47819361E4BEA flags verified )
+	rom ( name "Ready 2 Rumble Boxing (E) (M3) [!].z64" size 33554432 crc A69DF7B3 md5 ADC95AE01855FA305B13F8B22427E597 sha1 E18477D858C623A834F24DC2717D0EF340E63364 )
 )
 
 game (
@@ -3991,6 +4562,7 @@ game (
 	name "Resident Evil 2 (Europe) (En,Fr)"
 	description "Resident Evil 2 (Europe) (En,Fr)"
 	rom ( name "Resident Evil 2 (Europe) (En,Fr).n64" size 67108864 crc A9936CEC md5 7F3B88A0968FE05034F967F646EBD114 sha1 C82E3C253E438C0F742882F26E8006FDF9C99346 flags verified )
+	rom ( name "Resident Evil 2 (E) (M2) [!].z64" size 67108864 crc 7C8EE011 md5 B04F298721223A22E1150CEBC712EE6A sha1 D54561791BC41F1B743F8ABE769A6E8CBF435326 )
 )
 
 game (
@@ -4010,72 +4582,84 @@ game (
 	name "Road Rash 64 (Europe)"
 	description "Road Rash 64 (Europe)"
 	rom ( name "Road Rash 64 (Europe).n64" size 33554432 crc E3BC7725 md5 C881E7CEC084640AFBBDDC37F6EFD179 sha1 273C72F8C9F9D194B98375E3076972BFD7FDF64D flags verified )
+	rom ( name "Road Rash 64 (E) [!].z64" size 33554432 crc 3C664A7B md5 AD922DAE446A301E1AAFE1DFBAD75A2E sha1 816824CB5DC62EE54DC52C0EBB9B2564ECB88133 )
 )
 
 game (
 	name "Road Rash 64 (USA)"
 	description "Road Rash 64 (USA)"
 	rom ( name "Road Rash 64 (USA).n64" size 33554432 crc 2DA44585 md5 CDF72CB4647C70FE36247091F5025148 sha1 4990B922E946AA0EE45FD8355E447DEDC92EC352 )
+	rom ( name "Road Rash 64 (U) [!].z64" size 33554432 crc 600B3988 md5 28C2373F6D831EEC81F6146A809E701B sha1 87727A298F583EC8325F5655088FF21E37B335B2 )
 )
 
 game (
 	name "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Roadsters (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc C2D2F16B md5 BB95A96AA50732504EC987337A635663 sha1 BDE57B268B6BFFE2E60CCA0E3D9500A35506A81C flags verified )
+	rom ( name "Roadsters Trophy (E) (M6) [!].z64" size 12582912 crc 997ED5AF md5 41F67B5C8BB8DAEFFD989123846FC063 sha1 2AD3BCCD29DC879A873C926AF03002E36582525A )
 )
 
 game (
 	name "Roadsters (USA) (En,Fr,Es)"
 	description "Roadsters (USA) (En,Fr,Es)"
 	rom ( name "Roadsters (USA) (En,Fr,Es).n64" size 12582912 crc F68D139E md5 49D0C8BC8AD23306B87456FB3055C5DB sha1 E2827C55874A4883C5D969EB34944324D639AF06 )
+	rom ( name "Roadsters Trophy (U) (M3) [!].z64" size 12582912 crc E4337B92 md5 D3644B398C090528E0ED9EB3C140366E sha1 D896FFCBA44696BDB7E2048841F287EA5951AD2A )
 )
 
 game (
 	name "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)"
 	description "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)"
 	rom ( name "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).n64" size 33554432 crc 49BB7DDE md5 C36C2FAF41E34EA2D10E178702101DA3 sha1 27BFAFF7A8D2A3CEF081AF67A5E89290C6B59550 flags verified )
+	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!].z64" size 33554432 crc 3B0F8061 md5 444F70A655AC89CA900F6FAFAF926B16 sha1 9BC6130916D8A1D8BCEC5F38FBBFF066444838CD )
 )
 
 game (
 	name "Robotech - Crystal Dreams (USA) (Proto)"
 	description "Robotech - Crystal Dreams (USA) (Proto)"
 	rom ( name "Robotech - Crystal Dreams (USA) (Proto).n64" size 12582912 crc 3A711F12 md5 8B1574BE8AFB8A7559CA6867FB15B665 sha1 5EA71103D323530C73E1668CC47A1C287D07E99B )
+	rom ( name "Robotech - Crystal Dreams (Beta).z64" size 16777216 crc F9A7904E md5 B39592C6C9A3121258BDB62485956880 sha1 8051C03135447A92B21AFACE5B00111C3B4AF773 )
 )
 
 game (
 	name "Robotron 64 (Europe)"
 	description "Robotron 64 (Europe)"
 	rom ( name "Robotron 64 (Europe).n64" size 8388608 crc 862ACD20 md5 1B170EFF5E2D9EA85B494DCA5AD53970 sha1 A12C93AC2C4E70A3B19BCB07A62B7B6B9CE83DB9 flags verified )
+	rom ( name "Robotron 64 (E) [!].z64" size 8388608 crc 23BF4956 md5 2ABCD1AD41B3356FBC1018ECB121283E sha1 D86A7ED2F203BA9DF0CE5B18D9E4E2E2D9B62A3F )
 )
 
 game (
 	name "Robotron 64 (USA)"
 	description "Robotron 64 (USA)"
 	rom ( name "Robotron 64 (USA).n64" size 8388608 crc 123D44CC md5 FB1C4E85F13E95B5154C550A06408808 sha1 9DACD6239F2256E8EFAC6D1C6ACF8E5EA53040BB )
+	rom ( name "Robotron 64 (U) [!].z64" size 8388608 crc B2CBAE58 md5 5698757883A6F46FE5B4C9B6E780B480 sha1 44D158BC2AEEFB111A620B61E043B2703E6C5808 )
 )
 
 game (
 	name "Rocket - Robot on Wheels (Europe) (En,Fr,De)"
 	description "Rocket - Robot on Wheels (Europe) (En,Fr,De)"
 	rom ( name "Rocket - Robot on Wheels (Europe) (En,Fr,De).n64" size 12582912 crc 2960FF8B md5 CFC34E10E7BD3DA3420D4C768C82DE10 sha1 FCE3A9B4CC94E44D0C2F58B7669140447F9BF0EC flags verified )
+	rom ( name "Rocket - Robot on Wheels (E) (M3) [!].z64" size 12582912 crc 7DE5D20D md5 427C5457D4A29A222811F0CAA9CCA7B9 sha1 A1AA086F0826BEE4BE71C16BC67468B8D8A49065 )
 )
 
 game (
 	name "Rocket - Robot on Wheels (USA)"
 	description "Rocket - Robot on Wheels (USA)"
 	rom ( name "Rocket - Robot on Wheels (USA).n64" size 12582912 crc B0F36D79 md5 53BD4994CB0DFCA0DB955389E96145FA sha1 5DFCD4CDB0A2EA1412FA5D92236D0A066231D9AC )
+	rom ( name "Rocket - Robot on Wheels (U) [!].z64" size 12582912 crc E0399F23 md5 C2907EB2F9A350793317ECE878A3B8E3 sha1 622D71A44DA0B81EA68092CAC9198C66154A4F4A )
 )
 
 game (
 	name "Rockman Dash - Hagane no Boukenshin (Japan)"
 	description "Rockman Dash - Hagane no Boukenshin (Japan)"
 	rom ( name "Rockman Dash - Hagane no Boukenshin (Japan).n64" size 33554432 crc E1919C66 md5 530311472663F4885C387C90C8BB2FCF sha1 CD8C73A181A137DC8A4AC24E9F26CCC2518DC35F flags verified )
+	rom ( name "Rockman Dash (J) [!].z64" size 33554432 crc 61EAEE83 md5 0C74B44680276FFE808CFA6045329819 sha1 E807ED78DB0B3440F76B445BF989A943BC05E0AD )
 )
 
 game (
 	name "RR64 - Ridge Racer 64 (Europe)"
 	description "RR64 - Ridge Racer 64 (Europe)"
 	rom ( name "RR64 - Ridge Racer 64 (Europe).n64" size 33554432 crc 170F63B2 md5 9E2D9D2B2A83EDD05AB1FAB8130C9570 sha1 7543E17585EF4AF0B3B1DE8004B6CD4D92EC214D flags verified )
+	rom ( name "RR64 - Ridge Racer 64 (E) [!].z64" size 33554432 crc DD9AE3A8 md5 4561840840760FFA7B59F03A5F416A5C sha1 FAA21C8E0282D21EAC2D1B35B020F40381E18FC4 )
 )
 
 game (
@@ -4089,12 +4673,14 @@ game (
 	name "RTL World League Soccer 2000 (Germany)"
 	description "RTL World League Soccer 2000 (Germany)"
 	rom ( name "RTL World League Soccer 2000 (Germany).n64" size 16777216 crc 4E3C9433 md5 BF0AD2FC5E13F2E1DF15878BA82DD040 sha1 EF2E9DBB16C798DF3315A925231314E1660A2F03 flags verified )
+	rom ( name "RTL World League Soccer 2000 (G) [!].z64" size 16777216 crc 0A17DA7B md5 A1082A6676455C040843FD75E92DE1A3 sha1 A68294E47C82639C9BCDAE1B7306AC2A2E2F47B5 )
 )
 
 game (
 	name "Rugrats - Die grosse Schatzsuche (Germany)"
 	description "Rugrats - Die grosse Schatzsuche (Germany)"
 	rom ( name "Rugrats - Die grosse Schatzsuche (Germany).n64" size 16777216 crc E1D7919F md5 C17DEEEFBBA8A96DEE4C6756CB5BBB3B sha1 7840BDFE801FA2D8E34E120F66AF59A140D3C1C3 )
+	rom ( name "Rugrats - Die grosse Schatzsuche (G) [!].z64" size 16777216 crc 23AED3A2 md5 DEC4598A39728C28CD0CEBA45A173CE1 sha1 32CABA1042CABBF366852D629D3FEE1A5186BCE3 )
 )
 
 game (
@@ -4108,12 +4694,14 @@ game (
 	name "Rugrats - Treasure Hunt (Europe)"
 	description "Rugrats - Treasure Hunt (Europe)"
 	rom ( name "Rugrats - Treasure Hunt (Europe).n64" size 16777216 crc 65EDE901 md5 40950ECADEFA371666DC6A2CB8305752 sha1 A86B2FAED29727496DD3F0B0367293E16B324568 flags verified )
+	rom ( name "Rugrats - Treasure Hunt (E) [!].z64" size 16777216 crc 3338B7C8 md5 55185016031CDC73C0FD471527C35706 sha1 5FF0B82077559DD4C206A7A7D13EABEABC82E9C4 )
 )
 
 game (
 	name "Rugrats in Paris - The Movie (Europe)"
 	description "Rugrats in Paris - The Movie (Europe)"
 	rom ( name "Rugrats in Paris - The Movie (Europe).n64" size 16777216 crc 17BD7518 md5 D71441A6906526C79E4DA220942850E8 sha1 0212C18E1FE5C637C5B88124F053CF08F048EFC4 flags verified )
+	rom ( name "Rugrats in Paris - The Movie (E) [!].z64" size 16777216 crc CD74B07E md5 229089089661F517C863242D6BB77746 sha1 FDDA27E7C418728391A5EC53F62FDB5E1B21A0DF )
 )
 
 game (
@@ -4127,18 +4715,21 @@ game (
 	name "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 9B364DF7 md5 21731BC459610D60C2B604B4D3737C75 sha1 FC590418F82BD5E360FF4530100D72CEA2A97D99 flags verified )
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [!].z64" size 12582912 crc 30F21F89 md5 681DF5A32E857E77194106B35304D6B5 sha1 090A027612140E90FFBBD7C48DEC77005F7B0A69 )
 )
 
 game (
 	name "Rush 2 - Extreme Racing USA (USA)"
 	description "Rush 2 - Extreme Racing USA (USA)"
 	rom ( name "Rush 2 - Extreme Racing USA (USA).n64" size 12582912 crc 5412916B md5 68C4766E0FD28E3BAFE220D52BB5C841 sha1 94685E4A27114175946CDF2084079C9BF2E69EF3 )
+	rom ( name "Rush 2 - Extreme Racing USA (U) [!].z64" size 12582912 crc 9EB14EA8 md5 6A925AB624EE3B343231D799733BA898 sha1 01B0A31B1ACCC18061E8C85F6C5EDF0DBD79F097 )
 )
 
 game (
 	name "S.C.A.R.S. (Europe) (En,Fr,De)"
 	description "S.C.A.R.S. (Europe) (En,Fr,De)"
 	rom ( name "S.C.A.R.S. (Europe) (En,Fr,De).n64" size 8388608 crc DA47D3C9 md5 46DD8A0AE504E32A2338F32A9B3A9CFE sha1 EF5834F25A44931CC9339DD22B6E8F9955736076 flags verified )
+	rom ( name "S.C.A.R.S. (E) (M3) [!].z64" size 8388608 crc 4E37B6F2 md5 7ED3F10BC32CF76F172D8C31D15A2799 sha1 8B4EBAD8B7F50381BA2E16D0C475332837BB5780 )
 )
 
 game (
@@ -4152,18 +4743,21 @@ game (
 	name "Saikyou Habu Shougi (Japan)"
 	description "Saikyou Habu Shougi (Japan)"
 	rom ( name "Saikyou Habu Shougi (Japan).n64" size 8388608 crc E8D0810B md5 213192EB4FF4F7FAA7DF653D0FEFF142 sha1 8A06E7A7D15E5586FF5CE5FED235E0357096C827 flags verified )
+	rom ( name "Saikyou Habu Shougi (J) [!].z64" size 8388608 crc 01794D62 md5 C4E47228706BC724D7FBD811231D20C9 sha1 B7C977FCD8224595E84714C3FA84221374E1838E )
 )
 
 game (
 	name "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)"
 	description "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)"
 	rom ( name "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).n64" size 8388608 crc 78CD03C9 md5 E35E6F54850BB6ECDBFE6E4971B419FA sha1 9339CCE34D9EAC2626BA14FA55F558BD7C827CC9 flags verified )
+	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [!].z64" size 8388608 crc E064962A md5 81B1122EE15F7B50A341AE62E9C5716B sha1 BC8D37E3A3B9EDB4C8465ED7E477C6434C31B47D )
 )
 
 game (
 	name "San Francisco Rush - Extreme Racing (USA) (En,Fr,De)"
 	description "San Francisco Rush - Extreme Racing (USA) (En,Fr,De)"
 	rom ( name "San Francisco Rush - Extreme Racing (USA) (En,Fr,De).n64" size 8388608 crc 32E250BA md5 67C74AB836A9D54FAA4D41B491E3794A sha1 8980D1E967D63CB13F794EE5DE15BEF299B93935 )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [!].z64" size 8388608 crc 3E20070B md5 F015FC28E1D62A36B4EBF4C79CA8F285 sha1 CC62539CB30B180C3C7E0AA927786ED061D8D9AB )
 )
 
 game (
@@ -4176,24 +4770,28 @@ game (
 	name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc DF85FDC3 md5 45BB91607C06103C3F545C648F0994A4 sha1 C722FDC039489E1C0E604EED8B81E29DA75CB0BE flags verified )
+	rom ( name "San Francisco Rush 2049 (E) (M6) [!].z64" size 12582912 crc E63B86C5 md5 02B16AC23998F78F09AF6513F4ACB664 sha1 61373D4758ECA3FA831BEAC27B4D4C250845F80C )
 )
 
 game (
 	name "San Francisco Rush 2049 (USA)"
 	description "San Francisco Rush 2049 (USA)"
 	rom ( name "San Francisco Rush 2049 (USA).n64" size 12582912 crc 1A03B9DE md5 2120248576E6398F2F90791E2EBD2EDA sha1 F79223F8060A530D0DC8683A923C3C60615AA0A0 )
+	rom ( name "San Francisco Rush 2049 (U) [!].z64" size 12582912 crc 10941439 md5 AF5BE0ADFF51A8E9C6D771282C295810 sha1 3F99351D7BB61656614BDB2AA1A90CFE55D1922C )
 )
 
 game (
 	name "Scooby-Doo! - Classic Creep Capers (Europe)"
 	description "Scooby-Doo! - Classic Creep Capers (Europe)"
 	rom ( name "Scooby-Doo! - Classic Creep Capers (Europe).n64" size 16777216 crc 81CDD595 md5 A773D245148DDC739375E3AE0D2B3852 sha1 AD7148B91845113A10A297DA25F7110EDDEB8758 flags verified )
+	rom ( name "Scooby-Doo! - Classic Creep Capers (E) [!].z64" size 16777216 crc 0D737E6F md5 3B6DD7B60437234895500BEFF28DF6D6 sha1 FA2D39392750E160F2C41733777C64D8DF1127AF )
 )
 
 game (
 	name "Scooby-Doo! - Classic Creep Capers (USA)"
 	description "Scooby-Doo! - Classic Creep Capers (USA)"
 	rom ( name "Scooby-Doo! - Classic Creep Capers (USA).n64" size 16777216 crc E3A2F1E7 md5 E0F4AA58C66F35169AEC717AA58D5A71 sha1 41C8454775E0E555B354537F3EFD916FD5F058D6 )
+	rom ( name "Scooby-Doo! - Classic Creep Capers (U) [!].z64" size 16777216 crc 39068228 md5 16CC6DB10A56331B56F374B4FB254D5E sha1 FA22BD1216094124C84987414DDE1B50AF90D928 )
 )
 
 game (
@@ -4206,30 +4804,35 @@ game (
 	name "SD Hiryuu no Ken Densetsu (Japan)"
 	description "SD Hiryuu no Ken Densetsu (Japan)"
 	rom ( name "SD Hiryuu no Ken Densetsu (Japan).n64" size 12582912 crc ADF81B90 md5 9543942C65C3DCDB86498E985B712AB9 sha1 DA0D9331C5A9688B674E6C72D4206FB05F1C2EE0 flags verified )
+	rom ( name "SD Hiryuu no Ken Densetsu (J) [!].z64" size 12582912 crc CC083E34 md5 637A7EA2A39F20C5B20834187230D89D sha1 79CFB5A29B2CBD4F35966F209385B389233CF8CF )
 )
 
 game (
 	name "Shadow Man (Europe) (En,Es,It)"
 	description "Shadow Man (Europe) (En,Es,It)"
 	rom ( name "Shadow Man (Europe) (En,Es,It).n64" size 33554432 crc 0CD66C1F md5 01EABFA5224182258DE02D20E277F0A2 sha1 7BCD7D9A05363B20F338B092081C2FAE4D8C1F64 flags verified )
+	rom ( name "Shadow Man (E) (M3) [!].z64" size 33554432 crc 8D230306 md5 A485A6E9E30B7D55D23D8DD043770C64 sha1 39ECE3F37C1F54AF4274A9733419EB693EAC1740 )
 )
 
 game (
 	name "Shadow Man (France)"
 	description "Shadow Man (France)"
 	rom ( name "Shadow Man (France).n64" size 33554432 crc CB221562 md5 B536D55DE81FFFC8E4052399B1D99021 sha1 9FD09639DBF2A9B11F7D1C2CCCB40529FEBEDB2A )
+	rom ( name "Shadow Man (F) [!].z64" size 33554432 crc 6812D3A7 md5 235511BBDB21AF5A767BDB7502A80F06 sha1 1F0B03C80C6449DE78EE8403CFA84FE8CF759341 )
 )
 
 game (
 	name "Shadow Man (Germany)"
 	description "Shadow Man (Germany)"
 	rom ( name "Shadow Man (Germany).n64" size 33554432 crc 1F171A3F md5 12B26C386F02451E2D8E600020CB2567 sha1 01D453D23E8E089C071F41A2BDCB78A3C695A72A flags verified )
+	rom ( name "Shadow Man (G) [!].z64" size 33554432 crc EAF6ADD1 md5 AF40EF12CE923FF1C26E76CC9D9B9ED9 sha1 8768F0EC0B7A0B4F5FF0DA6F4D790EDEF5E3FE9C )
 )
 
 game (
 	name "Shadow Man (USA)"
 	description "Shadow Man (USA)"
 	rom ( name "Shadow Man (USA).n64" size 33554432 crc 47E05128 md5 09D23066364C5F212731B19DD9B9C87C sha1 F3791231DC17AF77056E5320C59081D3E8459A7F )
+	rom ( name "Shadow Man (U) [!].z64" size 33554432 crc 5E20CC63 md5 B457298B87B85BBF950F24867DAA9475 sha1 CFB99DD949FDB2B2A0002EF595AB1813FE865B2C )
 )
 
 game (
@@ -4242,12 +4845,14 @@ game (
 	name "Shadowgate 64 - Trials of the Four Towers (Europe)"
 	description "Shadowgate 64 - Trials of the Four Towers (Europe)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Europe).n64" size 16777216 crc ABB08BC3 md5 FC4DB34EA0C88F5AB72046AA7DBB30D4 sha1 E879093C0243EBBC0C9E392DE4141CD65FC9B85D flags verified )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [!].z64" size 16777216 crc FF7D7DF0 md5 E8955C3B743FDDFE403E52E769E9853F sha1 F2844B3421779A997C96231D25275DA4E2D1018B )
 )
 
 game (
 	name "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)"
 	description "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).n64" size 16777216 crc D49B5065 md5 D616CF79F9B2E213FA2B6383893E4064 sha1 EC3ED3D0A854C726C2355BCD8AB23799FC1630CA )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!].z64" size 16777216 crc 87F00472 md5 A06E757CF1930B29FA4C0B5C9F31335F sha1 9F1A413F686032DDA73BE3312F452991A4E29EC9 )
 )
 
 game (
@@ -4260,6 +4865,7 @@ game (
 	name "Shadowgate 64 - Trials of the Four Towers (Japan)"
 	description "Shadowgate 64 - Trials of the Four Towers (Japan)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Japan).n64" size 16777216 crc F2665AFD md5 4BE1E1A9C5BC5202108BA0CBACA648DB sha1 94295AC2B5E44AD299DED088A8D43EF7A168C59D flags verified )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J).z64" size 16777216 crc 9F74A58C md5 1960A3879FADF2C5EFF5BEB47E0E1441 sha1 706524AFF9BD84972D4E095AFD0317D5BACC525F )
 )
 
 game (
@@ -4273,42 +4879,49 @@ game (
 	name "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)"
 	description "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)"
 	rom ( name "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).n64" size 12582912 crc 62C99DE2 md5 802A4C0EB26D41D837366DFEA85E5AC4 sha1 4DA682946B4A6F586F4D525F0649D7A1E36357D9 flags verified )
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!].z64" size 12582912 crc E892ED43 md5 13D9514A4D208DC6C7B0C833F68114D2 sha1 8E87DD6BAF0D8D27E60C3257B145EF439B17B7A0 )
 )
 
 game (
 	name "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)"
 	description "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)"
 	rom ( name "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).n64" size 33554432 crc BE0FC7E8 md5 D013CD14D46001289D2E7BB58DA94C26 sha1 15B9C28584A26B60E5A2A231E5BA2897E831E8F8 flags verified )
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!].z64" size 33554432 crc DEAC787F md5 113044B16B75F98792BF9C20C6B6282B sha1 BDFA3C47264196BD91D0487D3C9B3531BDACE8EA )
 )
 
 game (
 	name "SimCity 2000 (Japan)"
 	description "SimCity 2000 (Japan)"
 	rom ( name "SimCity 2000 (Japan).n64" size 12582912 crc F7A96B81 md5 A6AE966D625069D8DC5CC2967B5D22C8 sha1 2A5B25809A5470B85DB9CC0A1E6C5C44F225747B flags verified )
+	rom ( name "Sim City 2000 (J) [!].z64" size 12582912 crc 57767E45 md5 244BEA64EA209990E9C69A830B507135 sha1 F728BD9990B9674533A04CD2FE275236B5CAB32F )
 )
 
 game (
 	name "Snobo Kids (Japan)"
 	description "Snobo Kids (Japan)"
 	rom ( name "Snobo Kids (Japan).n64" size 8388608 crc 9B691DF4 md5 8FD0896369A6C9A01427BC878202BAC4 sha1 739AB70A45CCA33E8BF884C35BE338FF4CE66F11 flags verified )
+	rom ( name "Snobow Kids (J) [!].z64" size 8388608 crc 213BF381 md5 B8D4B92E66A312708626B3216DE07A3A sha1 96480C8FA7285D9E850F6BA002E56BCB7ADA9796 )
 )
 
 game (
 	name "Snow Speeder (Japan)"
 	description "Snow Speeder (Japan)"
 	rom ( name "Snow Speeder (Japan).n64" size 12582912 crc 5C98F900 md5 AF71E732AB17533638132B01BB19EC2F sha1 2EF8591E9750066E248075DC940EC4FC080EF905 flags verified )
+	rom ( name "Snow Speeder (J) [!].z64" size 12582912 crc 30EA3FD7 md5 F7E66DA23C8BB8E59F641A636A9CAE82 sha1 0E7DF6A6F053F37A168EC33AF8CE5240CB18F0EE )
 )
 
 game (
 	name "Snowboard Kids (Europe)"
 	description "Snowboard Kids (Europe)"
 	rom ( name "Snowboard Kids (Europe).n64" size 8388608 crc 4F2415F3 md5 127AB20EE41ADB54C83DFB5BF5794D27 sha1 FD4CA5DC092DA70996AF699C8A4591FAEF58EC0C flags verified )
+	rom ( name "Snowboard Kids (E) [!].z64" size 8388608 crc 5619A70D md5 AB4382E583AE139EEDBAFCE5FA87E4C8 sha1 B26802748F4CC15F44492BCC6941A487E75BBCA6 )
 )
 
 game (
 	name "Snowboard Kids (USA)"
 	description "Snowboard Kids (USA)"
 	rom ( name "Snowboard Kids (USA).n64" size 8388608 crc 540C190B md5 14B72B59AA3EFABF368779E6EBECDCAB sha1 584277AA4190D23F7DB8A6E225735D934022E58C )
+	rom ( name "Snowboard Kids (U) [!].z64" size 8388608 crc 020FB906 md5 EB31F4F9C1FE26A3A663F74E9790516E sha1 1583BACC9046A360DF8EA4D536942155247E154C )
 )
 
 game (
@@ -4318,33 +4931,44 @@ game (
 )
 
 game (
+	name "Snowboard Kids 2 (Europe)"
+	description "Snowboard Kids 2 (Europe)"
+	rom ( name "Snowboard Kids 2 (E) [!].z64" size 16777216 crc 3A0B6214 md5 47B5E3955D54F969941533F26691AB38 sha1 E807F0FA1D6FDE619A83F0926B2294123F34501C )
+)
+
+game (
 	name "Snowboard Kids 2 (USA)"
 	description "Snowboard Kids 2 (USA)"
 	rom ( name "Snowboard Kids 2 (USA).n64" size 16777216 crc CA84AACE md5 DED8648106F16417C01B4CC68986E97B sha1 7A195B4D0D03CE1C7C4FD0D13B1BE2E97D20000C )
+	rom ( name "Snowboard Kids 2 (U) [!].z64" size 16777216 crc D0DC8A8E md5 08E1152E9D9742E9BBF6C224B6958F2D sha1 5CE896FD64276948BC2B8CCCD8CD51C25A9F32AA )
 )
 
 game (
 	name "Sonic Wings Assault (Japan)"
 	description "Sonic Wings Assault (Japan)"
 	rom ( name "Sonic Wings Assault (Japan).n64" size 8388608 crc 1D8F9D5E md5 B8A13663741EBC6A38249C31462F7A8D sha1 FB3E2BE4927CF3FB39CCE031004FF3420023EEC5 flags verified )
+	rom ( name "Sonic Wings Assault (J) [!].z64" size 8388608 crc FC73FB79 md5 7D47911B5C3D91A303EF19E764F3C02B sha1 978936613096D1EBE49FEC3EF50E3C870CE165B6 )
 )
 
 game (
 	name "South Park (Europe) (En,Fr,Es)"
 	description "South Park (Europe) (En,Fr,Es)"
 	rom ( name "South Park (Europe) (En,Fr,Es).n64" size 16777216 crc ACD74F7F md5 251B291DCCE55F9C1B4E8AD4F785C326 sha1 B1905FA89677F770A8B57876488D96BFF4C4B278 flags verified )
+	rom ( name "South Park (E) (M3) [!].z64" size 16777216 crc B2C3E123 md5 40CC2085A5C12456BEF830B047068326 sha1 C70C9FD6EBF1AE9F79155F9384AB1C4B29DC6882 )
 )
 
 game (
 	name "South Park (Germany)"
 	description "South Park (Germany)"
 	rom ( name "South Park (Germany).n64" size 16777216 crc 3445C078 md5 AE3C592B2136BB445D50EC6FE3A07B3C sha1 C9F78F00F1749EC36D06D43693552EE33647D54B )
+	rom ( name "South Park (G) [!].z64" size 16777216 crc 5711E197 md5 2C94A246E701D667BA807DAB6C9771E2 sha1 3260DB8FBC90370603FC07AB2E48E02C029573FB )
 )
 
 game (
 	name "South Park (USA)"
 	description "South Park (USA)"
 	rom ( name "South Park (USA).n64" size 16777216 crc FAAE9AA3 md5 C26EFF29CEE9D8F65D5D3321413400FE sha1 5133B87061172B467424170672C3321DE6C78494 )
+	rom ( name "South Park (U) [!].z64" size 16777216 crc 7D666B9E md5 1730119B0455EF89C4E495DEC8E950A5 sha1 42D7350D1F9040C5546F481C4D650B99A23AADBC )
 )
 
 game (
@@ -4357,54 +4981,63 @@ game (
 	name "South Park - Chef's Luv Shack (Europe)"
 	description "South Park - Chef's Luv Shack (Europe)"
 	rom ( name "South Park - Chef's Luv Shack (Europe).n64" size 16777216 crc ED36FA49 md5 06DA3C068C3FC5D39684AAAA6C778BAC sha1 1FCDC805DB0B026DB04730FB385B30721CE74A21 flags verified )
+	rom ( name "South Park - Chef's Luv Shack (E) [!].z64" size 16777216 crc AC1628EB md5 F1AE48B778C8431A50C37EB1ED96B120 sha1 5AEEC40C04AE9F7BC286F38E5250712C5FEAD191 )
 )
 
 game (
 	name "South Park - Chef's Luv Shack (USA)"
 	description "South Park - Chef's Luv Shack (USA)"
 	rom ( name "South Park - Chef's Luv Shack (USA).n64" size 16777216 crc 67D38382 md5 D9699E89A4E4CD0AC04B628D6007DF0E sha1 54FB22142F3A02C9C15E412D7E900A963698BBDA )
+	rom ( name "South Park - Chef's Luv Shack (U) [!].z64" size 16777216 crc 6B6B1D09 md5 6AF573EB055648A8542AA82D9524FB2F sha1 0344B569E8410A860CD54165BC33130E80760896 )
 )
 
 game (
 	name "South Park Rally (Europe)"
 	description "South Park Rally (Europe)"
 	rom ( name "South Park Rally (Europe).n64" size 16777216 crc DE023E0A md5 8D040504B81AA2E37C0A4AA795C9D12E sha1 63F95579B1F2A5E41E78343B59105EF08A290BF3 flags verified )
+	rom ( name "South Park Rally (E) [!].z64" size 16777216 crc 296E3525 md5 C33FA02791077A71B0AFE1CFED47C180 sha1 E16B5B16E41C66FEFB3BC82BD6A82F9EF4D709FD )
 )
 
 game (
 	name "South Park Rally (USA)"
 	description "South Park Rally (USA)"
 	rom ( name "South Park Rally (USA).n64" size 16777216 crc 2C1F0859 md5 39D0960F29634E5BB6AA21F00C1044E7 sha1 0309DF340D098F014C6673EC7CAD60EACE1BF166 )
+	rom ( name "South Park Rally (U) [!].z64" size 16777216 crc CCDD322A md5 1C494719032FF99382B167C43FB11762 sha1 E0B9E2358B09D430A100A14A6CB19E30B55FAEA2 )
 )
 
 game (
 	name "Space Dynamites (Japan)"
 	description "Space Dynamites (Japan)"
 	rom ( name "Space Dynamites (Japan).n64" size 8388608 crc 803F78AC md5 2D4B1CDB5AC82E521F0AA39059B9233E sha1 9B0776E967CBC97F832799CA8B16535EFABC1CDF flags verified )
+	rom ( name "Space Dynamites (J) [!].z64" size 8388608 crc 8CB4B948 md5 7F9CDBBB1AAAAF0983C64988EF9C58BE sha1 DEF172A1B2D17A6EBBBC0551172DE4AE46B88E48 )
 )
 
 game (
 	name "Space Invaders (USA)"
 	description "Space Invaders (USA)"
 	rom ( name "Space Invaders (USA).n64" size 8388608 crc 62E6DEFF md5 FE0E7B9873FDDB70BB5D1271903D9438 sha1 1ED83DD9637D5B6E7323480E74BF151542665A1B )
+	rom ( name "Space Invaders (U) [!].z64" size 8388608 crc 60F7FF8E md5 C72417E0F8F043F9F11851633C4B1A57 sha1 6850205EACE572AE1AA31100320AD8DF1B8DB37E )
 )
 
 game (
 	name "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)"
 	description "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)"
 	rom ( name "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).n64" size 8388608 crc 6148B598 md5 33908C5D01C0DDB1A07FFB307A81C2DA sha1 065085D8E956E75980BAED473754FE539EE843D9 flags verified )
+	rom ( name "Space Station Silicon Valley (E) (M7) [!].z64" size 8388608 crc 63042E36 md5 FCA7AFCADCF5E5545A62919BA94DAD18 sha1 23710541BB3394072740B0F0236A7CB1A7D41531 )
 )
 
 game (
 	name "SpaceStation Silicon Valley (Japan) (Proto)"
 	description "SpaceStation Silicon Valley (Japan) (Proto)"
 	rom ( name "SpaceStation Silicon Valley (Japan) (Proto).n64" size 8388608 crc 7ABF7F2C md5 CC635E0AB1038E0CB8ACB3F09C83D6D4 sha1 F9B2A71ADA850509E27225A41E6FE8E271051A99 )
+	rom ( name "Space Station Silicon Valley (J) [!].z64" size 8388608 crc DCEC9F8A md5 E66ED1CC4AB95D0872BB2EBC49B206C4 sha1 7320F08474C011FC7781093BF1A6818C37CE51E2 )
 )
 
 game (
 	name "SpaceStation Silicon Valley (USA)"
 	description "SpaceStation Silicon Valley (USA)"
 	rom ( name "SpaceStation Silicon Valley (USA).n64" size 8388608 crc 76DB1DA1 md5 2745AAEA6429880E19E605D4DCE1DE61 sha1 8AE14D65342F5A1FF8D0F09251EF46E24C29FF2B )
+	rom ( name "Space Station Silicon Valley (U) [!].z64" size 8388608 crc A606E8AE md5 868B37D1B66D1D994E2BAD4E218BF129 sha1 E5E09205AA743A9E5043A42DF72ADC379C746B0B )
 )
 
 game (
@@ -4418,12 +5051,14 @@ game (
 	name "Star Fox 64 (Japan)"
 	description "Star Fox 64 (Japan)"
 	rom ( name "Star Fox 64 (Japan).n64" size 12582912 crc 879EDB89 md5 384EF29B9A1F638EAE21A871C2F1CEA9 sha1 86629DEF8EDBCFD1C6A3DE1C5172B14D1BF2F020 flags verified )
+	rom ( name "Star Fox 64 (J) [!].z64" size 12582912 crc 411142A7 md5 446D5215C4D34EB8AB0F355F324B8D0E sha1 9BD71AFBECF4D0A43146E4E7A893395E19BF3220 )
 )
 
 game (
 	name "Star Fox 64 (USA)"
 	description "Star Fox 64 (USA)"
 	rom ( name "Star Fox 64 (USA).n64" size 12582912 crc 363E7EE8 md5 FECDCBBCD1A178A2F4B29B43FACF9F39 sha1 CFF7FB46E79D35F727E4E20CC4C13492ECD2A2D7 flags verified )
+	rom ( name "Star Fox 64 (U) (V1.0) [!].z64" size 12582912 crc B1FCAA9C md5 CAF9A78DB13EE00002FF63A3C0C5EABB sha1 D8B1088520F7C5F81433292A9258C1184AFA1457 )
 )
 
 game (
@@ -4437,30 +5072,35 @@ game (
 	name "Star Soldier - Vanishing Earth (Japan)"
 	description "Star Soldier - Vanishing Earth (Japan)"
 	rom ( name "Star Soldier - Vanishing Earth (Japan).n64" size 12582912 crc F51D4C7C md5 8A51A0FF79F26A06F70083B2D079DAC1 sha1 F075EEB6890065CE827A900DF99E95F02F19098C flags verified )
+	rom ( name "Star Soldier - Vanishing Earth (J) [!].z64" size 12582912 crc 7EE5F51D md5 14A21928BE46C18BA04161305E89F5DE sha1 0B34BDDD00C49530E0EF47330A05DC70EBE5F8B7 )
 )
 
 game (
 	name "Star Soldier - Vanishing Earth (USA)"
 	description "Star Soldier - Vanishing Earth (USA)"
 	rom ( name "Star Soldier - Vanishing Earth (USA).n64" size 12582912 crc 052945E7 md5 EF7D98FEE80B68E3B3C1144508EAE1F5 sha1 A1A7EE7F86485C854F81DEC66462CA83ABC8EDD2 flags verified )
+	rom ( name "Star Soldier - Vanishing Earth (U) [!].z64" size 12582912 crc EA650DEF md5 EE045A2E9F924CD8FD00018B50E46650 sha1 14DFD0172567B47C819B3E61D1CE13281E0FFED6 )
 )
 
 game (
 	name "Star Twins (Japan)"
 	description "Star Twins (Japan)"
 	rom ( name "Star Twins (Japan).n64" size 33554432 crc C7BFB542 md5 28BD618B8E7CB56789626B758745467D sha1 8F1A670D89C1252326D0979126DEFF532452F333 flags verified )
+	rom ( name "Star Twins (J) [!].z64" size 33554432 crc 964506CE md5 CA28A3645FC7AD969EBD75C5D6506E7A sha1 15099233760B36E7AFAD7DA36B9464DA1512C4B1 )
 )
 
 game (
 	name "Star Wars - Rogue Squadron (Europe) (En,Fr,De)"
 	description "Star Wars - Rogue Squadron (Europe) (En,Fr,De)"
 	rom ( name "Star Wars - Rogue Squadron (Europe) (En,Fr,De).n64" size 16777216 crc 13CC4CA4 md5 1488007DB476D3EADB42DBABEAD088B5 sha1 E09FF328184B25F6A9170901FAC2D0A7158CE7B9 flags verified )
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!].z64" size 16777216 crc 6289645F md5 7F919D2E35CBE561E139AE8FE93ACA86 sha1 DA91A86F1F566DC66A2AE1292AA581BFC4F9CDFD )
 )
 
 game (
 	name "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A)"
 	description "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A).n64" size 16777216 crc A6E336CE md5 FC21AA1CBF31E5DEA71E804878C3B5F0 sha1 D8B0AAFC759F6BEE328CC5D447250E3BC1D0905F )
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!].z64" size 16777216 crc C88E5638 md5 A9DD498E6A28F55311CE4EF057E164B8 sha1 66A70566D267532272B15ABC0BE20E2A1074AE45 )
 )
 
 game (
@@ -4480,18 +5120,21 @@ game (
 	name "Star Wars - Shadows of the Empire (Europe)"
 	description "Star Wars - Shadows of the Empire (Europe)"
 	rom ( name "Star Wars - Shadows of the Empire (Europe).n64" size 12582912 crc 675D15B2 md5 5E440149B6BEB286AAD3A0B1F10ADE9E sha1 C0F55DEA0BB07D0A8CB25F633DB3F86630B4C639 flags verified )
+	rom ( name "Star Wars - Shadows of the Empire (E) [!].z64" size 12582912 crc F0A191BF md5 591CF8E672C9CC0FE9C871CC56DCC854 sha1 E014F60BEA29BBC7FBD7F3BA4FCC6BDD228C8FE5 )
 )
 
 game (
 	name "Star Wars - Shadows of the Empire (USA)"
 	description "Star Wars - Shadows of the Empire (USA)"
 	rom ( name "Star Wars - Shadows of the Empire (USA).n64" size 12582912 crc 02FAE534 md5 CB1E1F8D818AB3CADEA2CBE24994C9FE sha1 4BF31D88277583D458FA73E4B69CBAE068A227B5 flags verified )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [!].z64" size 12582912 crc 3C0837B3 md5 5CCE8AD5F86E8A373A7525DC4C7E6705 sha1 271C285F6E5069133AB27A2A8324D4651591E35D )
 )
 
 game (
 	name "Star Wars - Shadows of the Empire (USA) (Rev A)"
 	description "Star Wars - Shadows of the Empire (USA) (Rev A)"
 	rom ( name "Star Wars - Shadows of the Empire (USA) (Rev A).n64" size 12582912 crc B0DBB100 md5 547321DF653203AD7BCBC178D9C37BF6 sha1 9AC4A13F7D73398E6B75FEB3238F0AE84680F532 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [!].z64" size 12582912 crc B0540688 md5 FA635E837275D28FD5A24D5675BA42C8 sha1 DED8F972D1E1D662614B1EC79822D649A8CE5430 )
 )
 
 game (
@@ -4511,18 +5154,21 @@ game (
 	name "Star Wars - Shutsugeki! Rogue Chuutai (Japan)"
 	description "Star Wars - Shutsugeki! Rogue Chuutai (Japan)"
 	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (Japan).n64" size 16777216 crc DE90ADE4 md5 02AAE1BCB61E071C3F87E0600FF6317F sha1 184A06D1967921E5BC9451D1337A529754B55C50 flags verified )
+	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!].z64" size 16777216 crc EE7643B6 md5 8603B180E70B2A72EF77D46C2BEC2234 sha1 D8BDDB9727264C14BF3BC20B2FE983FB86EADA32 )
 )
 
 game (
 	name "Star Wars - Teikoku no Kage (Japan)"
 	description "Star Wars - Teikoku no Kage (Japan)"
 	rom ( name "Star Wars - Teikoku no Kage (Japan).n64" size 12582912 crc 54F66BB9 md5 FE07ADDEFF06F9956F72643E7ACEC778 sha1 5AE92ACB3035DE0B62164787940F3D8272BB2708 flags verified )
+	rom ( name "Star Wars - Teikoku no Kage (J) [!].z64" size 12582912 crc 7CE71426 md5 5B6B6B0C8C9A40286DCF61706B6A05CB sha1 93ED6F1497EDE2239F9D75B4A39204B6C9DD9FFD )
 )
 
 game (
 	name "Star Wars Episode I - Battle for Naboo (Europe)"
 	description "Star Wars Episode I - Battle for Naboo (Europe)"
 	rom ( name "Star Wars Episode I - Battle for Naboo (Europe).n64" size 33554432 crc F6B20484 md5 415A266C6DFF65350FD577A127A2D601 sha1 7A22D9BDCE8067A9DC800017E5A01823D1514293 flags verified )
+	rom ( name "Star Wars Episode I - Battle for Naboo (E) [!].z64" size 33554432 crc 029104FD md5 0BD1F7BB9F4B02520E4E9285C809F099 sha1 C949856A6CB0B59A2D171C8AD2E8D913CCA23022 )
 )
 
 game (
@@ -4536,12 +5182,14 @@ game (
 	name "Star Wars Episode I - Racer (Europe) (En,Fr,De)"
 	description "Star Wars Episode I - Racer (Europe) (En,Fr,De)"
 	rom ( name "Star Wars Episode I - Racer (Europe) (En,Fr,De).n64" size 33554432 crc EDE47E8A md5 DE98F1BCEB2C317BB0A9743282CE2C2E sha1 D4968CE06B93705ED40FF4433279F587F62E3C26 flags verified )
+	rom ( name "Star Wars Episode I - Racer (E) (M3) [!].z64" size 33554432 crc E0F46629 md5 6EF9FED309F28BD59B605F128869AA00 sha1 899A8245DA017289C88E97327FDCD6694B770A25 )
 )
 
 game (
 	name "Star Wars Episode I - Racer (Japan)"
 	description "Star Wars Episode I - Racer (Japan)"
 	rom ( name "Star Wars Episode I - Racer (Japan).n64" size 33554432 crc 794412BF md5 4A44748DD673BA6F3F4C0EBE9637B9FB sha1 4760072BB254BB7ABFBF19D7664238B2CF5A6BD3 flags verified )
+	rom ( name "Star Wars Episode I - Racer (J) [!].z64" size 33554432 crc 97C155C5 md5 7579AB0E79B1011479B88F2BF39D48E0 sha1 9577CCD2D069D0E7E306CF21DDB0E4765A308072 )
 )
 
 game (
@@ -4558,6 +5206,12 @@ game (
 )
 
 game (
+	name "StarCraft 64 (Europe)"
+	description "StarCraft 64 (Europe)"
+	rom ( name "StarCraft 64 (E) [!].z64" size 33554432 crc 2639DAE2 md5 72B60FAC5EE257FA387B43C57632D50C sha1 BD8AB8994BE02368C844234006E5C11509CE2894 )
+)
+
+game (
 	name "StarCraft 64 (USA)"
 	description "StarCraft 64 (USA)"
 	rom ( name "StarCraft 64 (USA).n64" size 33554432 crc 14C77369 md5 FCB1EDE6D4F63DFF012CE8C2E62E95CF sha1 3466CE39800B160AB8157BA1505ADA238ED10D4A )
@@ -4568,6 +5222,7 @@ game (
 	name "StarCraft 64 (USA) (Beta)"
 	description "StarCraft 64 (USA) (Beta)"
 	rom ( name "StarCraft 64 (USA) (Beta).n64" size 33554432 crc 0DAB69E2 md5 A955E7F0C08DC43E98BEF99C005BAE1C sha1 1C58EBC31A5A7D750C980D8730EA4B2A98B6E1D0 )
+	rom ( name "StarCraft 64 (Beta).z64" size 33554432 crc B0E1654F md5 3EB732A8D004263AD8EB0DA59A29582A sha1 472573D057E42653B7413861319B9F7342F2467D )
 )
 
 game (
@@ -4580,54 +5235,63 @@ game (
 	name "Starshot - Space Circus Fever (Europe) (En,Fr,De)"
 	description "Starshot - Space Circus Fever (Europe) (En,Fr,De)"
 	rom ( name "Starshot - Space Circus Fever (Europe) (En,Fr,De).n64" size 12582912 crc 171B80E1 md5 DEDB299035EA5C330ED3590599B73241 sha1 4CCCF890424728BA500DB1046984EDCBAE280BEB flags verified )
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [!].z64" size 12582912 crc 056D2218 md5 A9C393AA232B32798ADF378F4318F99F sha1 B92818C5FF6BE02BEC77EDCBE278D06785D00C78 )
 )
 
 game (
 	name "Starshot - Space Circus Fever (USA) (En,Fr,Es)"
 	description "Starshot - Space Circus Fever (USA) (En,Fr,Es)"
 	rom ( name "Starshot - Space Circus Fever (USA) (En,Fr,Es).n64" size 12582912 crc 64370749 md5 5255C9F757D88188ED3D90FAEAFF462E sha1 1A4B81C3BD09D24DBBFED6AAE66CB6761429817B )
+	rom ( name "Starshot - Space Circus Fever (U) (M3) [!].z64" size 12582912 crc 7720E5F3 md5 42AF1992978229BBB5F560571708E25E sha1 7DEF46651F55745D5BBD633C9002BDBFFC53A5E0 )
 )
 
 game (
 	name "Stunt Racer 64 (USA)"
 	description "Stunt Racer 64 (USA)"
 	rom ( name "Stunt Racer 64 (USA).n64" size 12582912 crc F60613DE md5 B84F3C943E89F3743BEFB4092DEED5CC sha1 69D2CCB020F710886E76F28288FEA2846E341527 )
+	rom ( name "Stunt Racer 64 (U) [!].z64" size 12582912 crc 3438B1AF md5 E8B666A429FEDB2A1A1228CD450CD4FC sha1 8570FA1F3E4CF7E62DC49DA181353E4F301503B7 )
 )
 
 game (
 	name "Super B-Daman - Battle Phoenix 64 (Japan)"
 	description "Super B-Daman - Battle Phoenix 64 (Japan)"
 	rom ( name "Super B-Daman - Battle Phoenix 64 (Japan).n64" size 12582912 crc 0BE4F736 md5 FE9DE38985FCDD721A7858D684339021 sha1 E5F4934BD4B4DC553A9A42C37A09DC24156941C4 flags verified )
+	rom ( name "Super B-Daman - Battle Phoenix 64 (J) [!].z64" size 12582912 crc 5006DC88 md5 B3C1D4B9EC7DCD2922E681DBBC393915 sha1 D443FB2E2E3980FCB90E5BBA4138922477EA9037 )
 )
 
 game (
 	name "Super Bowling (Japan)"
 	description "Super Bowling (Japan)"
 	rom ( name "Super Bowling (Japan).n64" size 8388608 crc BE01964B md5 0A764357EC273A485BF2326A653AC15D sha1 8C9A5A424F3FD5C3165835BC240102F1A8BB67AD flags verified )
+	rom ( name "Super Bowling (J) [!].z64" size 8388608 crc BA2D8B2E md5 09C5B4D19364EFE48BB818087734978E sha1 FAA5FFDFFEC1FA56125130BECB6E150032C6923E )
 )
 
 game (
 	name "Super Bowling (USA)"
 	description "Super Bowling (USA)"
 	rom ( name "Super Bowling (USA).n64" size 8388608 crc E651CBAA md5 61587D9A36D7E745BF53EB7A5C86DD65 sha1 876973C2E83D4F915F65D7231CBF9051A2CF03AA )
+	rom ( name "Super Bowling 64 (U) [!].z64" size 8388608 crc F6CCD04A md5 FA3A043997A3ACDF17337385B126BC04 sha1 56937A9E9536AF55EBED06480413265848C4A04A )
 )
 
 game (
 	name "Super Mario 64 (Europe) (En,Fr,De)"
 	description "Super Mario 64 (Europe) (En,Fr,De)"
 	rom ( name "Super Mario 64 (Europe) (En,Fr,De).n64" size 8388608 crc 11FB579B md5 C9E143571EEF343B7BA731D15308A39D sha1 D80EE9EEB6454D53A96CEB6ED0ACA3FFDE045091 flags verified )
+	rom ( name "Super Mario 64 (E) (M3) [!].z64" size 8388608 crc 03048DE6 md5 45676429EF6B90E65B517129B700308E sha1 4AC5721683D0E0B6BBB561B58A71740845DCEEA9 )
 )
 
 game (
 	name "Super Mario 64 (Japan)"
 	description "Super Mario 64 (Japan)"
 	rom ( name "Super Mario 64 (Japan).n64" size 8388608 crc 5CF7952A md5 73C72657B1320FAF2A6AEA0E0A3DE45A sha1 1D2579DD5FB1D8263A4BCC063A651A64ACC88921 flags verified )
+	rom ( name "Super Mario 64 (J) [!].z64" size 8388608 crc DD801954 md5 85D61F5525AF708C9F1E84DCE6DC10E9 sha1 8A20A5C83D6CEB0F0506CFC9FA20D8F438CAFE51 )
 )
 
 game (
 	name "Super Mario 64 (Japan) (Rev A) (Shindou Edition)"
 	description "Super Mario 64 (Japan) (Rev A) (Shindou Edition)"
 	rom ( name "Super Mario 64 (Japan) (Rev A) (Shindou Edition).n64" size 8388608 crc BC9FF5F2 md5 F3A6E533DE52FB84D4E2DFAE6167C8B1 sha1 2A2B85E94581545CA3C05B8F864B488B141A8A1F flags verified )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [!].z64" size 8388608 crc A1E15117 md5 2D727C3278AA232D94F2FB45AEC4D303 sha1 3F319AE697533A255A1003D09202379D78D5A2E0 )
 )
 
 game (
@@ -4641,24 +5305,28 @@ game (
 	name "Super Robot Spirits (Japan)"
 	description "Super Robot Spirits (Japan)"
 	rom ( name "Super Robot Spirits (Japan).n64" size 16777216 crc DAB52B89 md5 AB017A5868FBDBF542E281689BFE10AA sha1 F7B7E507B7210E637CCFD2F788A95EF5C7970EC0 flags verified )
+	rom ( name "Super Robot Spirits (J) [!].z64" size 16777216 crc 8C9216C1 md5 3EC3F83EAB22702E146C467EB1DB45FA sha1 3BF62A1A48716708A5831CE47FB8C1A41DC365E6 )
 )
 
 game (
 	name "Super Robot Taisen 64 (Japan)"
 	description "Super Robot Taisen 64 (Japan)"
 	rom ( name "Super Robot Taisen 64 (Japan).n64" size 33554432 crc 70FBC3B8 md5 5EEA2F2CF76D8A4B397D5A01BB11C198 sha1 5BA9E915C1494FA6D9E8B0D4D32F312469963777 flags verified )
+	rom ( name "Super Robot Taisen 64 (J) [!].z64" size 33554432 crc 85DF2771 md5 3F4B73963ABC91CEE59C416063EFD4AE sha1 9883AEF6E20A46E110560C505999F3E21A1897DE )
 )
 
 game (
 	name "Super Smash Bros. (Australia)"
 	description "Super Smash Bros. (Australia)"
 	rom ( name "Super Smash Bros. (Australia).n64" size 16777216 crc B2F04090 md5 8F6203BD3B76A171C8290B819488AA51 sha1 E6F5167EEE80C2C92358A195FB88C6207AB0F9F6 flags verified )
+	rom ( name "Super Smash Bros. (A) [!].z64" size 16777216 crc E96779FA md5 694DEA68DBF1C3F06FF0476ACF2169E6 sha1 A9BF83FE73361E8D042C33ED48B3851D7D46712C )
 )
 
 game (
 	name "Super Smash Bros. (Europe) (En,Fr,De)"
 	description "Super Smash Bros. (Europe) (En,Fr,De)"
 	rom ( name "Super Smash Bros. (Europe) (En,Fr,De).n64" size 33554432 crc 7976248C md5 1E201F4C469927828BCF3335F2F3C4A3 sha1 A582522C0A09816BF904109E014A970625C06D3C flags verified )
+	rom ( name "Super Smash Bros. (E) (M3) [!].z64" size 33554432 crc 45A91CB1 md5 5E54C6C563B09C107F86FB33E914EF81 sha1 6EE8A41FEF66280CE3E3F0984D00B96079442FB9 )
 )
 
 game (
@@ -4672,24 +5340,28 @@ game (
 	name "Super Speed Race 64 (Japan)"
 	description "Super Speed Race 64 (Japan)"
 	rom ( name "Super Speed Race 64 (Japan).n64" size 4194304 crc D96B76C3 md5 FF6DD7E8B64AEE8C80548F2FDB6F1F1A sha1 E2E885786198A0F44AE740BA8C5DD59EAC14B207 flags verified )
+	rom ( name "Super Speed Race 64 (J) [!].z64" size 4194304 crc 0F879A70 md5 6B5D93B3566E96147009D1AC4FB15C97 sha1 E0A49FF953B882F9F135B583EF9E09A664D24288 )
 )
 
 game (
 	name "Supercross 2000 (Europe) (En,Fr,De)"
 	description "Supercross 2000 (Europe) (En,Fr,De)"
 	rom ( name "Supercross 2000 (Europe) (En,Fr,De).n64" size 16777216 crc 0A6377EE md5 EAA08CE91CAFF8A81CD88D4A265CA162 sha1 EE0802389002A907410A0E3F826FDCEFA572E6C1 flags verified )
+	rom ( name "Supercross 2000 (E) (M3) [!].z64" size 16777216 crc CB5482EC md5 6D58A01EF7A7A7C779D2A66315992C5F sha1 3FA3F859048A65E1E810ED7BE98ADA0A0B4E49AD )
 )
 
 game (
 	name "Supercross 2000 (USA)"
 	description "Supercross 2000 (USA)"
 	rom ( name "Supercross 2000 (USA).n64" size 16777216 crc 5A8A721D md5 B3922E74A81DC6F71A8FE3AF472C17F4 sha1 03CBBFB4F57E2813CBE9050401D6144724B84D6F )
+	rom ( name "Supercross 2000 (U) [!].z64" size 16777216 crc 094E2A48 md5 60347200A1A7CABC0D849EE69EC51DF7 sha1 8D726C2EF6BC74B0D516067FFD92DA00EFA07993 )
 )
 
 game (
 	name "Superman (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Superman (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Superman (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 9CEF1753 md5 32D596185AE37074134CEB34CFB476FC sha1 660CBD7F4808D928F8C3DADA9851267B6058FA80 flags verified )
+	rom ( name "Superman (E) (M6) [!].z64" size 8388608 crc BCA4FF8C md5 5AB39F2D7A144E1BA243DF059560E878 sha1 326378F4C05CA48B69D29CA1C72AB8E19B6EE10D )
 )
 
 game (
@@ -4709,6 +5381,7 @@ game (
 	name "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)"
 	description "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)"
 	rom ( name "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).n64" size 8388608 crc DC83BCD3 md5 12CB5AB99EB3AEC0BAB422FC5C42906E sha1 ABD8ECDBFC3676488C4CB961439F13EF8DC7C0C7 flags verified )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!].z64" size 8388608 crc 4CD21372 md5 26F4CA20F7B9C88199AC046C57E282B4 sha1 FB905AC5887DE6C3670F73F9C92EFBACD55B6816 )
 )
 
 game (
@@ -4733,30 +5406,35 @@ game (
 	name "Tarzan (Europe)"
 	description "Tarzan (Europe)"
 	rom ( name "Tarzan (Europe).n64" size 16777216 crc 5FA14035 md5 735DC0F52D801D820CCDA651058E43DE sha1 A489E4E47DE9B59083F7BEBAFD260C8DCBB56F5F flags verified )
+	rom ( name "Disney's Tarzan (E) [!].z64" size 16777216 crc 7737ED9E md5 BD1DE2FC1CF31096423563A40ECBF933 sha1 7623ACEECD244F4352A7D9346A607AC183B32CD6 )
 )
 
 game (
 	name "Tarzan (France)"
 	description "Tarzan (France)"
 	rom ( name "Tarzan (France).n64" size 16777216 crc C1176831 md5 491CB5649BF3957591EDF9B1E5D765D4 sha1 F3193B0EB2A2DDD2735D51C1ADC4170BF2ED0252 )
+	rom ( name "Disney's Tarzan (F) [!].z64" size 16777216 crc 99C7649D md5 5D82E903F65341487DDC11AF80AD607A sha1 1CF1F0F8217BA4E1691427F97EF62B15DC02A1C3 )
 )
 
 game (
 	name "Tarzan (Germany)"
 	description "Tarzan (Germany)"
 	rom ( name "Tarzan (Germany).n64" size 16777216 crc 67DBEC0B md5 799EED5EE57EF4F21CF8C50201E1482B sha1 04E6C0A8C6B19B78E1B124D8D758813559716809 )
+	rom ( name "Disney's Tarzan (G) [!].z64" size 16777216 crc 0B0954C5 md5 DF3CDD959E8C63B45F557FC197CE0E63 sha1 4FC7DED9601A78DB964ED5B1A585BB716F6D636C )
 )
 
 game (
 	name "Tarzan (USA)"
 	description "Tarzan (USA)"
 	rom ( name "Tarzan (USA).n64" size 16777216 crc 2B59490B md5 FB7D7D58E4E3CBD434DB579AA4EF3F5E sha1 64C186549F71134872FE1279A0440A95A2A60866 )
+	rom ( name "Disney's Tarzan (U) [!].z64" size 16777216 crc C38CA641 md5 EAE7E0EE5328ED9F13B9CF9990189928 sha1 44C63A89E1E8F9EEEE0AA4B45442822FEB3CC579 )
 )
 
 game (
 	name "Taz Express (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Taz Express (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Taz Express (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 85382541 md5 A9F437615049E404C7D70481B6AF25E2 sha1 FA61BD39F2A02BDF65FBE0B5730FF7C01F239B18 flags verified )
+	rom ( name "Taz Express (E) (M6) [!].z64" size 12582912 crc 0712C306 md5 192B715E8BC5972A4986DF21DC8BF357 sha1 E1D8121986652ED180505AF21456C180C8B29FAB )
 )
 
 game (
@@ -4769,72 +5447,84 @@ game (
 	name "Telefoot Soccer 2000 (France)"
 	description "Telefoot Soccer 2000 (France)"
 	rom ( name "Telefoot Soccer 2000 (France).n64" size 16777216 crc FAD893EA md5 B3AC7EFA85C5E3BBD3667741F84660C7 sha1 D8F7D0557319B7B24DE2F9EF864A1A46F84F1DD8 )
+	rom ( name "Telefoot Soccer 2000 (F) [!].z64" size 16777216 crc 7BD20931 md5 7F244AFF8D729417E32B6A5B299AFDA5 sha1 FFC1F3271929B0E7D6467FDCBED9E0CCF2EBA0A5 )
 )
 
 game (
 	name "Tetris 64 (Japan) (En)"
 	description "Tetris 64 (Japan) (En)"
 	rom ( name "Tetris 64 (Japan) (En).n64" size 8388608 crc 08B4CA1B md5 3692F5A2457004BF8D08D43FD24257C4 sha1 95D42D3B33569FC2F47AC30C7DE277470CB79462 flags verified )
+	rom ( name "Tetris 64 (J) [!].z64" size 8388608 crc F128CD17 md5 7C8EFCF4FBA28F9F5B5EA10A71283BF3 sha1 EA9A3BA1384E15E0AF996B43FE3E56DB889002DE )
 )
 
 game (
 	name "Tetrisphere (Europe)"
 	description "Tetrisphere (Europe)"
 	rom ( name "Tetrisphere (Europe).n64" size 8388608 crc 2E953131 md5 6924D91E4A544E973136D7BF65F86BC0 sha1 4486F5BDB049F170F7525E72D14BCF61F159B0BB flags verified )
+	rom ( name "Tetrisphere (E) [!].z64" size 8388608 crc 7CB31B0F md5 765A330D5CE2DBE7120C6C8E18A1487D sha1 A730D8DD3B00C22F8FA4C6E74299E5CC2BBB8207 )
 )
 
 game (
 	name "Tetrisphere (USA)"
 	description "Tetrisphere (USA)"
 	rom ( name "Tetrisphere (USA).n64" size 8388608 crc 5DB18578 md5 AFEDBBA2EC96F65582229564B025BF4F sha1 81FFBB3912AAE46BF358FE03A96A090A9997DDB0 )
+	rom ( name "Tetrisphere (U) [!].z64" size 8388608 crc 70A3A5CE md5 3F88078E2D9DBF6C9372F6373CF9AE09 sha1 32ADAA274CEED246AEEE9F53592D642A121F3BDB )
 )
 
 game (
 	name "TG Rally 2 (Europe)"
 	description "TG Rally 2 (Europe)"
 	rom ( name "TG Rally 2 (Europe).n64" size 12582912 crc B5E8A1DF md5 A2C3EC262B1DB91463369CBDCAA1C4AB sha1 77BAF3DD7B20C2C7FAAE4944D1F9D30476A25AAC flags verified )
+	rom ( name "TG Rally 2 (E) [!].z64" size 12582912 crc 135C8EB0 md5 ACD0118AC4709DB3943B3D35112C2001 sha1 46907A7BD1CEB65F48C39D9D60B56DBC75A7A2C3 )
 )
 
 game (
 	name "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)"
 	description "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)"
 	rom ( name "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).n64" size 16777216 crc CF7AA5EF md5 AC60411BBFB28C3B43DC7E5E030DBC73 sha1 92362BF5C1CF95B726FB9B05735BBEB00C0751E0 flags verified )
+	rom ( name "Tigger's Honey Hunt (E) (M7) [!].z64" size 16777216 crc D82D5736 md5 A09663B596F348D28AF846A51375EB81 sha1 53944F6C63B2E971ABF756EFECCAB24FA0B96E78 )
 )
 
 game (
 	name "Tigger's Honey Hunt (USA)"
 	description "Tigger's Honey Hunt (USA)"
 	rom ( name "Tigger's Honey Hunt (USA).n64" size 16777216 crc 79F8BF3B md5 800E231DECCD724D8B1F1F6820B8BE90 sha1 5B48828607CFCECAAF3450EE369E5D0CABBAFD7C )
+	rom ( name "Tigger's Honey Hunt (U) [!].z64" size 16777216 crc 68C2AC8F md5 F8636514B5B0EDEBF376C3111D24417A sha1 98DB3A0F9025893107E9FB1BB8D0B6BC0EF3E280 )
 )
 
 game (
 	name "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc B030A574 md5 B49212CBC6E122D8DB2747B03BA0CD24 sha1 C4FF73733C284CC927F06BE23551E73B14844984 flags verified )
+	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [!].z64" size 12582912 crc 9EA8A3B8 md5 46BE5D00682FCC1F7FC0FBA507E8E5C1 sha1 96C874C4556B4872269E41339A1CBAC53CC5B052 )
 )
 
 game (
 	name "Tom and Jerry in Fists of Furry (USA)"
 	description "Tom and Jerry in Fists of Furry (USA)"
 	rom ( name "Tom and Jerry in Fists of Furry (USA).n64" size 12582912 crc F0BFC6AB md5 9DCDFAB5FA65EFE5E18652E59A116E64 sha1 66C59EEF4370EDD573B3AEAD79E1C805CA768E1F )
+	rom ( name "Tom and Jerry in Fists of Furry (U) [!].z64" size 12582912 crc 6D685B83 md5 A63A9AF85BE8BB47C1741B8A37115354 sha1 D8980A34ECE4A8933D439D0378E0CFF8F03994A7 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (Europe)"
 	description "Tom Clancy's Rainbow Six (Europe)"
 	rom ( name "Tom Clancy's Rainbow Six (Europe).n64" size 16777216 crc B430BA47 md5 5FEE34130BAE944EDED29C7992DA1177 sha1 CE2CB1BDD42E0E7450B82DF3C238A3C0B58667B2 flags verified )
+	rom ( name "Tom Clancy's Rainbow Six (E) [!].z64" size 16777216 crc 4B71E083 md5 1B991CF41C70FF2C92FFBEFACABE8D03 sha1 64105F5C17BA7E2E0350F20E18ADDCC0A4766BD8 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (France)"
 	description "Tom Clancy's Rainbow Six (France)"
 	rom ( name "Tom Clancy's Rainbow Six (France).n64" size 16777216 crc 31BC7B49 md5 EDFDDAE2F418715999E5E418CBDE5640 sha1 ED7356FB54FB6F24EAF76BEC971C5DAD72252E74 )
+	rom ( name "Tom Clancy's Rainbow Six (F) [!].z64" size 16777216 crc BBF7B6A8 md5 15E4C1B4F3F459D4CAA7F7E2CF0C95DA sha1 EC38196491AEEE7AD2FB4A0A7F139C0839E864C6 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (Germany)"
 	description "Tom Clancy's Rainbow Six (Germany)"
 	rom ( name "Tom Clancy's Rainbow Six (Germany).n64" size 16777216 crc 1F872C4A md5 A2CAB7B96AF0A27C40802C165878F457 sha1 0E79AD6F283903A9E408C6DD3C80541B920CB3FC )
+	rom ( name "Tom Clancy's Rainbow Six (G) [!].z64" size 16777216 crc 5D73E788 md5 FDC76A53B1056D3E50EA6A3E295FE4D1 sha1 E41C7B71284976EA5D51B42593973A1D3CE58508 )
 )
 
 game (
@@ -4854,48 +5544,56 @@ game (
 	name "Tonic Trouble (Europe) (En,Fr,De,Es,It)"
 	description "Tonic Trouble (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Tonic Trouble (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc A10B0009 md5 00CB176BE188D983890451488755C25C sha1 84E6C54C9DD3F18EBA2C741E5F1CFD1BE04855CC flags verified )
+	rom ( name "Tonic Trouble (E) (M5) [!].z64" size 16777216 crc B4322403 md5 3D3573A855835A98DE29D598C35590E0 sha1 81909104362BAEB7AE3793C08C3D138E96105BBF )
 )
 
 game (
 	name "Tonic Trouble (USA) (Rev A)"
 	description "Tonic Trouble (USA) (Rev A)"
 	rom ( name "Tonic Trouble (USA) (Rev A).n64" size 16777216 crc 0ECD289A md5 B0488CD676773D283FE4FDEC55418F32 sha1 88F9ACE09F949A43253D37896E75472BC9AE6D12 )
+	rom ( name "Tonic Trouble (U) (V1.1) [!].z64" size 16777216 crc 1C04BA12 md5 7D3E935156844DE0002DB875E1076A5C sha1 38F9837159D6AA69CA656D8005ECCF099C129537 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater (USA)"
 	description "Tony Hawk's Pro Skater (USA)"
 	rom ( name "Tony Hawk's Pro Skater (USA).n64" size 12582912 crc EE2C9008 md5 7332315B5D57CE551E6D7069B5656932 sha1 7523D5E43EE18FC1298E8CE6656EFFCDB7B0C1B7 )
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [!].z64" size 12582912 crc F5C1B64F md5 5ED7E392198A5FA56EE37EA9E93A8D50 sha1 FC1B4DEC85E6874FA7321EDC24F5A1E78600D9D0 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater (USA) (Rev A)"
 	description "Tony Hawk's Pro Skater (USA) (Rev A)"
 	rom ( name "Tony Hawk's Pro Skater (USA) (Rev A).n64" size 12582912 crc 1BE278C1 md5 A5E0125B0FD742E744505F3895165AFC sha1 8F6B113675CF437FA0686E35683EBDC8AAF11D39 )
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.1) [!].z64" size 12582912 crc 6182A092 md5 AFF424A1883DC7BB92C7B2EBE9342F85 sha1 4900B6C92FB8DF1765E91E891DCCC525BB102FE1 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 2 (Europe)"
 	description "Tony Hawk's Pro Skater 2 (Europe)"
 	rom ( name "Tony Hawk's Pro Skater 2 (Europe).n64" size 16777216 crc DC703B1E md5 6792FBF31A3E6BA1FAB3CDC595BC949C sha1 28B9C785BDC0A54F1675D6180A092C300F514633 flags verified )
+	rom ( name "Tony Hawk's Pro Skater 2 (E) [!].z64" size 16777216 crc A1207132 md5 6BE030475C4DB52F273EF8A02B4DAFA8 sha1 803672C1FFA7860536D8B35DCA8B59F637F4165E )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 2 (USA)"
 	description "Tony Hawk's Pro Skater 2 (USA)"
 	rom ( name "Tony Hawk's Pro Skater 2 (USA).n64" size 16777216 crc 6DF2D58E md5 BC77A627AD496C0668FD14558F0E9AC2 sha1 6C2D313AEA3724F5638738923A58C0E765BDDCFA )
+	rom ( name "Tony Hawk's Pro Skater 2 (U) [!].z64" size 16777216 crc 80AA83F3 md5 29974692808C112B306FBD259273DC96 sha1 458AC754CD8E08C46F4C5C9204192ECDE84A179D )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 3 (USA)"
 	description "Tony Hawk's Pro Skater 3 (USA)"
 	rom ( name "Tony Hawk's Pro Skater 3 (USA).n64" size 16777216 crc ED73272E md5 A1AA4FCE55D79E6F2E76BC04393008F7 sha1 63ECBB3D07B8AC20ED096AF0735704EF715BD398 )
+	rom ( name "Tony Hawk's Pro Skater 3 (U).z64" size 16777216 crc 62A8CE7D md5 9D4891BF26881C4541171B0235015FD4 sha1 7B9438120C67214AFAEA09F4B106C54EF8F366C5 )
 )
 
 game (
 	name "Tony Hawk's Skateboarding (Europe)"
 	description "Tony Hawk's Skateboarding (Europe)"
 	rom ( name "Tony Hawk's Skateboarding (Europe).n64" size 12582912 crc 93A26129 md5 03A0EA296D5BE79EDD8ECC9B41B42704 sha1 9DC473F35CEA9BA531590DE833EBF32E25A6A9D1 flags verified )
+	rom ( name "Tony Hawk's Pro Skater (E) [!].z64" size 12582912 crc 39E4F766 md5 C9E9C4A18B1540C6B4111331D7C663B8 sha1 C321CD05EEC58765467878AC8015784535280E3C )
 )
 
 game (
@@ -4905,87 +5603,113 @@ game (
 )
 
 game (
+	name "Top Gear Hyper Bike (Beta)"
+	description "Top Gear Hyper Bike (Beta)"
+	rom ( name "Top Gear Hyper Bike (Beta).z64" size 33554432 crc 00C0278A md5 B60D26C2C2242BFF61F76469FC272D2A sha1 D3AE07E2C4360EC4EB06A70C6E48D848EEC532DD )
+)
+
+game (
 	name "Top Gear Hyper-Bike (Europe)"
 	description "Top Gear Hyper-Bike (Europe)"
 	rom ( name "Top Gear Hyper-Bike (Europe).n64" size 16777216 crc DC687AD1 md5 25C594ED6E76C20BB731890E2319F9EA sha1 29573E3A4016ADCDFD2EE318D7700AD423EB369F flags verified )
+	rom ( name "Top Gear Hyper Bike (E) [!].z64" size 16777216 crc BAE57EA7 md5 0072538EF925645DB310F8E23A480B89 sha1 FF4EB866C48700FA978A5E663CDA1499C8EAC0B4 )
 )
 
 game (
 	name "Top Gear Hyper-Bike (Japan)"
 	description "Top Gear Hyper-Bike (Japan)"
 	rom ( name "Top Gear Hyper-Bike (Japan).n64" size 16777216 crc D9AF869C md5 C11BEBD92FAF132907769AD8B66CF965 sha1 0B97DBEE843094ED6320D4B795B64F7FAC908DAE flags verified )
+	rom ( name "Top Gear Hyper Bike (J) [!].z64" size 16777216 crc 09B2CDA1 md5 4347174BB415CA970F2D50DF2973F656 sha1 7DB7337260AF8F153B6291B13E655F192B59EC01 )
 )
 
 game (
 	name "Top Gear Hyper-Bike (USA)"
 	description "Top Gear Hyper-Bike (USA)"
 	rom ( name "Top Gear Hyper-Bike (USA).n64" size 16777216 crc 3E9CE2AF md5 35154380516AB853060A9B60EF6C30B5 sha1 4A146C7A53FB979BCEEDD79CC1719BD6130698A3 )
+	rom ( name "Top Gear Hyper Bike (U) [!].z64" size 16777216 crc 6EEBC26A md5 7258F4AB367B025C95A4F476C461E717 sha1 C7593B3D0D793CF03616DF02501735221624AC04 )
 )
 
 game (
 	name "Top Gear Overdrive (Europe)"
 	description "Top Gear Overdrive (Europe)"
 	rom ( name "Top Gear Overdrive (Europe).n64" size 12582912 crc 52D39097 md5 63E66FC7686B3007A5FF87D4CF881E96 sha1 37013DFFC9E8A61F3B40EB100133CD40F2AE523D flags verified )
+	rom ( name "Top Gear Overdrive (E) [!].z64" size 12582912 crc 0CC70580 md5 6C65A252F227AEF18DF2DD3CE04CC821 sha1 BAD781B7A3FE73A0127223CD807FAFBC4007DCCF )
 )
 
 game (
 	name "Top Gear Overdrive (Japan)"
 	description "Top Gear Overdrive (Japan)"
 	rom ( name "Top Gear Overdrive (Japan).n64" size 12582912 crc E680B138 md5 9AC8633925EFCB6EBD559A6A9B0CBD9B sha1 7A92260252F5E823F1B3B4ADEDC85908A0CADBB5 flags verified )
+	rom ( name "Top Gear Overdrive (J) [!].z64" size 12582912 crc 81AAFC2B md5 B5691794A851D8B603F0C741D44AA244 sha1 BE62D75C7AC1067111CD213365A9583550F897F3 )
 )
 
 game (
 	name "Top Gear Overdrive (USA)"
 	description "Top Gear Overdrive (USA)"
 	rom ( name "Top Gear Overdrive (USA).n64" size 12582912 crc B5B23053 md5 CB5E6AE88AD069B6E69A1D2FEB793C42 sha1 2B79D74949BC631E74379720265E8633806290AF )
+	rom ( name "Top Gear Overdrive (U) [!].z64" size 12582912 crc F3E0FF21 md5 7818696426C0A429FBFCCC4EFE8D5570 sha1 75EBBE451906CE68B0DD43EEF9EE44416452A4F1 )
 )
 
 game (
 	name "Top Gear Rally (Europe)"
 	description "Top Gear Rally (Europe)"
 	rom ( name "Top Gear Rally (Europe).n64" size 8388608 crc 83B04584 md5 B50A5815E2FB20E90B834A571F8FD8C9 sha1 42F8C45ACE108ADE7FFDCDF5D8475C2E1702954C flags verified )
+	rom ( name "Top Gear Rally (E) [!].z64" size 8388608 crc 40B3BB21 md5 1698508F521280D0A80E078EC981D4AC sha1 9FAE5D98FE3464F00D59034690DF90118646EB95 )
 )
 
 game (
 	name "Top Gear Rally (Japan)"
 	description "Top Gear Rally (Japan)"
 	rom ( name "Top Gear Rally (Japan).n64" size 8388608 crc D8E793F5 md5 1B20AD52E630FEA15304688D66E0FA89 sha1 3C29783DD963B8594D2FD41E296B2C7D9DC318F2 flags verified )
+	rom ( name "Top Gear Rally (J) [!].z64" size 8388608 crc C6707CD6 md5 6E0AF13DCEFEE6A11C4D7262206D6D2D sha1 E0415B87C5A5B69AC581E79137406BDAA79B354A )
 )
 
 game (
 	name "Top Gear Rally (USA)"
 	description "Top Gear Rally (USA)"
 	rom ( name "Top Gear Rally (USA).n64" size 8388608 crc A04F1CC0 md5 105D3FB95998914A3EB7AC9E7631C6D1 sha1 0DDE80BAE97B82FA56496360FC6B1BBFEACA6999 )
+	rom ( name "Top Gear Rally (U) [!].z64" size 8388608 crc 137287F5 md5 6F7030284B6BC84A49E07DA864526B52 sha1 BFC51F086EBDB78904DC24AD0C3A2D946E26D022 )
+)
+
+game (
+	name "Top Gear Rally 2 (Beta)"
+	description "Top Gear Rally 2 (Beta)"
+	rom ( name "Top Gear Rally 2 (Beta).z64" size 16777216 crc 3C77C5D6 md5 C33CD926E1E71F39F7238AF7B9E0DC5C sha1 168DD383EDD88A921D25CF7EAEB18B2DA29C744A )
 )
 
 game (
 	name "Top Gear Rally 2 (Europe)"
 	description "Top Gear Rally 2 (Europe)"
 	rom ( name "Top Gear Rally 2 (Europe).n64" size 12582912 crc 88C8A6EA md5 E440BA3B06ABC2749D765D196323EED4 sha1 CDEBA42C305995A7FB66B26C8DAF4E135152ABEC flags verified )
+	rom ( name "Top Gear Rally 2 (E) [!].z64" size 12582912 crc CB294D39 md5 44C4566572DC0662D4299AB5B19043AE sha1 CC140D2A8BAB74109D34FDA97F4DA21F8C3CD083 )
 )
 
 game (
 	name "Top Gear Rally 2 (Japan)"
 	description "Top Gear Rally 2 (Japan)"
 	rom ( name "Top Gear Rally 2 (Japan).n64" size 12582912 crc CCD50A05 md5 D7B62F7B669A0285B4681BEF150C4CF7 sha1 6C342E8E47BAA3B9EE8A0A35721EC3A123B94243 flags verified )
+	rom ( name "Top Gear Rally 2 (J) [!].z64" size 12582912 crc AA136E07 md5 B10D781EC625CA45713FD34E5096C24A sha1 D78DF79985BFDC7C77F7ED0338E86E852BB3F45A )
 )
 
 game (
 	name "Top Gear Rally 2 (USA)"
 	description "Top Gear Rally 2 (USA)"
 	rom ( name "Top Gear Rally 2 (USA).n64" size 12582912 crc 7E4E181C md5 75C415A43440B19BED2672EE3884A707 sha1 2C51EF2CA9B738DAA5F70B8199A64CD765A44243 )
+	rom ( name "Top Gear Rally 2 (U) [!].z64" size 12582912 crc 914CF9C4 md5 1FA409FCAC007DDECCC4CF439A0D8DAE sha1 FED36B2202B28FC7FF6446ECBA541413660D0630 )
 )
 
 game (
 	name "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
 	description "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
 	rom ( name "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).n64" size 12582912 crc 2AF45190 md5 06B460CAACB8F29261ACC5EFAF058617 sha1 4F08A4D02FC14E99BD13789895F7A447381E0C8C )
+	rom ( name "Toy Story 2 (F) [!].z64" size 12582912 crc FB4BEA9A md5 FA0F12C15B3655F9F56888C3249B1CED sha1 A9F97E22391313095D2C2FBAF81FB33BFA2BA7C6 )
 )
 
 game (
 	name "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
 	description "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
 	rom ( name "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).n64" size 12582912 crc C1C5B460 md5 0B766E5D0B28D3062A30C26F33FBEF1C sha1 E201405104E9C4275EDC2671E1BD99D13CCC40A8 flags verified )
+	rom ( name "Toy Story 2 (E) [!].z64" size 12582912 crc 59574CB9 md5 5F2C9E5E39AB09311D96E6C751184B6B sha1 92015E5254CBBAD1BC668ECB13A4B568E5F55052 )
 )
 
 game (
@@ -5005,6 +5729,7 @@ game (
 	name "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
 	description "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
 	rom ( name "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).n64" size 12582912 crc 33FD1561 md5 85F6378FCAC99ED25F807842B1729517 sha1 24CB3C7F89640A9AB542AABC55BC32561FD9218A )
+	rom ( name "Toy Story 2 (G) [!].z64" size 12582912 crc C5E4C89F md5 3F40F37B0464DD065067523FB21016DD sha1 F8FBB100227015BE8629243F53D70F29A2A14315 )
 )
 
 game (
@@ -5018,6 +5743,7 @@ game (
 	name "Transformers - Beast Wars Metals 64 (Japan)"
 	description "Transformers - Beast Wars Metals 64 (Japan)"
 	rom ( name "Transformers - Beast Wars Metals 64 (Japan).n64" size 12582912 crc 5E972B7D md5 5A136A29C0948ED3C131728CA3BCD296 sha1 DA8E453DBBD57AC3B207B44B4621EA8897141BB6 flags verified )
+	rom ( name "Transformers - Beast Wars Metals 64 (J) [!].z64" size 12582912 crc 338F1D45 md5 3D22D5BD7997293612ECDD3046BEBA13 sha1 A292C7AAB0092F39F1292434F3059782715863DB )
 )
 
 game (
@@ -5031,48 +5757,56 @@ game (
 	name "Triple Play 2000 (USA)"
 	description "Triple Play 2000 (USA)"
 	rom ( name "Triple Play 2000 (USA).n64" size 16777216 crc BFB124FC md5 E13208CE9412C9DB3FB62FFF93CD2B0D sha1 E604AA2D812DFC73D20E3FC8C81CBB73439DB88A )
+	rom ( name "Triple Play 2000 (U) [!].z64" size 16777216 crc 785DD0F8 md5 6F2C37A20E6ECCB657FBFC4BA36A34BB sha1 03619F14149D5A2716DFFBE02E21C2A0F5EE24F5 )
 )
 
 game (
 	name "Tsumi to Batsu - Hoshi no Keishousha (Japan)"
 	description "Tsumi to Batsu - Hoshi no Keishousha (Japan)"
 	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (Japan).n64" size 33554432 crc C0891399 md5 3B8638452B46DEBA9EDFFBCD6CDB6966 sha1 4C9AE28811F8688A9016D293C5F67681DA53CAD9 flags verified )
+	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (J) [!].z64" size 33554432 crc CA2E5E49 md5 A0657BC99E169153FD46AECCFDE748F3 sha1 581297B9D5C3A4C33169AE0AAE218C742CD9CBCF )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe)"
 	description "Turok - Dinosaur Hunter (Europe)"
 	rom ( name "Turok - Dinosaur Hunter (Europe).n64" size 8388608 crc 019A0C30 md5 1E09EEEBDAD6527BDE34A9E863AA6809 sha1 0CCDBFA032AE5F48C47489468B5DA23CF98F6D84 flags verified )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [!].z64" size 8388608 crc E8525687 md5 13FAA58604597E4EDC608070F8E0AE24 sha1 88916D5D2E2470F395AD8F4245D34138EF2D156A )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe) (Rev A)"
 	description "Turok - Dinosaur Hunter (Europe) (Rev A)"
 	rom ( name "Turok - Dinosaur Hunter (Europe) (Rev A).n64" size 8388608 crc 5ED8AB71 md5 EF2E88DA46D427DCAB90C5820D84B13F sha1 81A389040F3A284766BD31A7B65529B939241689 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.1) [!].z64" size 8388608 crc C2353283 md5 992BA72F4A1E9C51934FF345CDD0D90C sha1 90809F3D30BF085F5EACBD12136672216AA7B88B )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe) (Rev B)"
 	description "Turok - Dinosaur Hunter (Europe) (Rev B)"
 	rom ( name "Turok - Dinosaur Hunter (Europe) (Rev B).n64" size 8388608 crc 03D8CA48 md5 1428572BF7A06CCCB90411BEA697929A sha1 BFCF4FB8C268EB07EB4921712E0C8FB9EF0702CE flags verified )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.2) [!].z64" size 8388608 crc 312AF877 md5 548FC0E6035B65BC2108255039859934 sha1 0B3CD4FCB03C704E1F8EB3BBD109C82F4BE50075 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Germany)"
 	description "Turok - Dinosaur Hunter (Germany)"
 	rom ( name "Turok - Dinosaur Hunter (Germany).n64" size 8388608 crc 70398790 md5 0ADBD2C70517AC80ED2430D61D3363AA sha1 D82536E69FF05CE4829588CEC79B96DC51E2BEB6 )
+	rom ( name "Turok - Dinosaur Hunter (G) [!].z64" size 8388608 crc 64631FF9 md5 0C0BFD1038EDA4F5C958DC362CDFF2D6 sha1 698760178EDFBB8293A536D4960AA9566F1A1871 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (USA)"
 	description "Turok - Dinosaur Hunter (USA)"
 	rom ( name "Turok - Dinosaur Hunter (USA).n64" size 8388608 crc 777D75E6 md5 E030EFB29598B151EBAAF6B101803D57 sha1 8A5D29E062F6893AF4E817B90AFD5F941968DF6D flags verified )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [!].z64" size 8388608 crc 26C4F597 md5 AE5107EFDD3C210E1EDD4ACD9B3CAC31 sha1 40FB0250C095740031278FB1F82B9937A3895E01 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (USA) (Rev A)"
 	description "Turok - Dinosaur Hunter (USA) (Rev A)"
 	rom ( name "Turok - Dinosaur Hunter (USA) (Rev A).n64" size 8388608 crc F26EC081 md5 331C149B6E1B6673B5369DECC9A0E931 sha1 9A2E1DB319AEC3EADA430053FB79D150BADE79AD )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.1) [!].z64" size 8388608 crc 7F2476F4 md5 37260287D59FE4EC6049C1D22B5614E6 sha1 6E67DCB49F700F01B18B7B4FD9AEB6BD911F1850 )
 )
 
 game (
@@ -5098,18 +5832,21 @@ game (
 	name "Turok - Legenden des Verlorenen Landes (Germany)"
 	description "Turok - Legenden des Verlorenen Landes (Germany)"
 	rom ( name "Turok - Legenden des Verlorenen Landes (Germany).n64" size 8388608 crc A2754CA4 md5 C8E5BA393A985E771BFEB8DF0182B011 sha1 51792351F4FD61C11F4B3B755A5EB8B9EA725B72 flags verified )
+	rom ( name "Turok - Legenden des Verlorenen Landes (G) [!].z64" size 8388608 crc B937874F md5 72A6AA28608EE93A1CB6FEB0A5F4C28C sha1 A6DAACBD0E7F77C73208CF494AEFC24703060B17 )
 )
 
 game (
 	name "Turok - Rage Wars (Europe)"
 	description "Turok - Rage Wars (Europe)"
 	rom ( name "Turok - Rage Wars (Europe).n64" size 8388608 crc 6C391585 md5 A7AE3121961623AF5668E5D2671D814D sha1 1DCD7B6A18E395872392E8F718D8EB8ED6F5D29D flags verified )
+	rom ( name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita).z64" size 8388608 crc F4A2862B md5 241CF94BED487FFF62FFB7B846DA46AB sha1 0B54615930A55675955EEF8D8A22F1DFC34D2B44 )
 )
 
 game (
 	name "Turok - Rage Wars (Europe) (En,Fr,It)"
 	description "Turok - Rage Wars (Europe) (En,Fr,It)"
 	rom ( name "Turok - Rage Wars (Europe) (En,Fr,It).n64" size 8388608 crc 6331B573 md5 72E5F21944E030D4782FAD476CFF2744 sha1 A0173D69A2DFD793B8A23092D7EDC79FA5A61C0C )
+	rom ( name "Turok - Rage Wars (E) [!].z64" size 8388608 crc 82B1E116 md5 DBA166A42710F40DC78DC52EB37B0BE6 sha1 46B474FAC79A4B21535BB6C78CE3039A2C202359 )
 )
 
 game (
@@ -5129,36 +5866,42 @@ game (
 	name "Turok 2 - Seeds of Evil (Europe)"
 	description "Turok 2 - Seeds of Evil (Europe)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe).n64" size 33554432 crc 9791B9CF md5 E00F7F87E87A504FD3D6862B5E8FEAB2 sha1 54FD5142F25A5FA058BDD2EB9F47EE1DFDD93B10 flags verified )
+	rom ( name "Turok 2 - Seeds of Evil (E) [!].z64" size 33554432 crc E2D34BFE md5 E5A39521FA954EB97B96AC2154A5FD7A sha1 1A0B36D9FD95DB483C846D0D604D2549D6CE4CC3 )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)"
 	description "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).n64" size 33554432 crc A309D9D3 md5 783F3ED408A5CEEA962F5B4202F9E4D7 sha1 B7D0DD6908ACBC7BC7A2588EEDBDCDFAB8C210BE flags verified )
+	rom ( name "Turok 2 - Seeds of Evil (E) (M4) [!].z64" size 33554432 crc 1FEBDE32 md5 144B10A484A22367FD2679529DBD2FED sha1 FB20F8E540C01D321BF805922B05E7A448521E1E )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)"
 	description "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).n64" size 12582912 crc 38B017D5 md5 AA50B21A2F57E282E07CC43A691DC78B sha1 4D47EABE2740D6327207539CD229D7C9A27B51F0 flags verified )
+	rom ( name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!].z64" size 12582912 crc 4E29B234 md5 CE72237707F481CFE97FDE330C2AFCD6 sha1 BFC04B6C5C300D39BBABE0B42227AEF45CC41D3F )	
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Germany)"
 	description "Turok 2 - Seeds of Evil (Germany)"
 	rom ( name "Turok 2 - Seeds of Evil (Germany).n64" size 33554432 crc FBE927CC md5 F00CBE882F8D2FAC3A4FECC0D83FAB9D sha1 1A46B9CA32625BD20C7C8E02AD62AE3273B8790A flags verified )
+	rom ( name "Turok 2 - Seeds of Evil (G) [!].z64" size 33554432 crc C07877B6 md5 B932116C967795076B5C112841AB4427 sha1 D09353C551F5309F29B6FF964B583A54E3D63C5F )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (USA)"
 	description "Turok 2 - Seeds of Evil (USA)"
 	rom ( name "Turok 2 - Seeds of Evil (USA).n64" size 33554432 crc FE3527AE md5 76557AB6A4D86107EF31603B4822DAE2 sha1 2CA5D6BA9529A57D822661EF770001276E7BEB92 flags verified )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [!].z64" size 33554432 crc FF5E7636 md5 FAD4DA8E17CE12F68CDF29180CDD4A90 sha1 FB0400F21E3F043939AB56500C7B12A3231006F1 )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)"
 	description "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)"
 	rom ( name "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).n64" size 12582912 crc 46175228 md5 92AE515C8AE54299BFC5F2A760F1EA65 sha1 E9C274DD10C65FC4E0B07C1896EB884EEF78C41C )
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!].z64" size 12582912 crc 8D5B9BD0 md5 3BD42F6AEC477C056E1AFEBB3515495C sha1 68D1C5B79CC243804FCE3C993D9C93A10A58CAB8 )
 )
 
 game (
@@ -5172,6 +5915,7 @@ game (
 	name "Turok 3 - Shadow of Oblivion (Europe)"
 	description "Turok 3 - Shadow of Oblivion (Europe)"
 	rom ( name "Turok 3 - Shadow of Oblivion (Europe).n64" size 33554432 crc 3113283E md5 0C92616A1E18DBF389378EF2A2C2E957 sha1 10DF040EF5D6B2E9E72A1BFA2BDE5C0D74F68A7F flags verified )
+	rom ( name "Turok 3 - Shadow of Oblivion (E) [!].z64" size 33554432 crc 98D3114C md5 279EC83BD60A3CCE69A1DB22B0A5C318 sha1 F3FDC0B58D0AE8111F033C5F61C364E6A9425F91 )
 )
 
 game (
@@ -5191,60 +5935,70 @@ game (
 	name "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta)"
 	description "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta)"
 	rom ( name "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta).n64" size 33554432 crc 505E9066 md5 0488A90E2380F6183A2382DFC7A1209D sha1 12A22310E653B2389110E7708831634E3F9F18DB )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta).z64" size 33554432 crc 97B7C3FF md5 0A3A4C761960F7D648AFA60B1E565C7C sha1 B3B232F098C8AC934682B0185159CDB3A3A570CE )
 )
 
 game (
 	name "Twisted Edge - Extreme Snowboarding (Europe)"
 	description "Twisted Edge - Extreme Snowboarding (Europe)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (Europe).n64" size 12582912 crc 394BDD25 md5 935894C48C7CEB500299CBEB6ACFA805 sha1 E5BAE263E692121A080308E6FDB2E42D20B1B347 flags verified )
+		rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
 )
 
 game (
 	name "Twisted Edge - Extreme Snowboarding (USA)"
 	description "Twisted Edge - Extreme Snowboarding (USA)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (USA).n64" size 12582912 crc 3A572B23 md5 8E18804153D55B4CF614E2176F7C1FAB sha1 0B737F0E48B4BFC80A78FE18E7E0530050F70FC0 )
+	rom ( name "Twisted Edge Extreme Snowboarding (U) [!].z64" size 12582912 crc BFBCC038 md5 9DF6C2C97FA34A978EF3CB77631536FE sha1 8888228AD423DF143C2C820130FB0658DF64C930 )
 )
 
 game (
 	name "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)"
 	description "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)"
 	rom ( name "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).n64" size 8388608 crc CB8C642B md5 B10D16F9EED103635B8722441E8A3CF4 sha1 9099C31FA07C8BFDD5DC94EFEBB9054144A1E34C flags verified )
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!].z64" size 8388608 crc 50CBE8A6 md5 FFEB5C1A85BABBBE60F2FEBA2B35C893 sha1 557D2DADEBEA77FBC7342A881311FCA5C5B35B39 )
 )
 
 game (
 	name "V-Rally Edition 99 (Europe) (En,Fr,De)"
 	description "V-Rally Edition 99 (Europe) (En,Fr,De)"
 	rom ( name "V-Rally Edition 99 (Europe) (En,Fr,De).n64" size 12582912 crc D200F779 md5 2DC8FBC3F591C0E4C54710AB2B66DF58 sha1 D55B29CEE570D6BD7E8B5A4F817D987A8C08B32E flags verified )
+	rom ( name "V-Rally Edition 99 (E) (M3) [!].z64" size 12582912 crc 0735D7A2 md5 DCAC12EB5832D4A489188330EB9EC387 sha1 DA3F262DFB86CFF1376C9A1AA081212E5A7AAD64 )
 )
 
 game (
 	name "V-Rally Edition 99 (Japan)"
 	description "V-Rally Edition 99 (Japan)"
 	rom ( name "V-Rally Edition 99 (Japan).n64" size 8388608 crc 7AAB7E2A md5 2017C8E61F2DB918270B6B5458D02846 sha1 04BAC1690879D0178F646E04C935DAC7AE72E16D flags verified )
+	rom ( name "V-Rally Edition 99 (J) [!].z64" size 8388608 crc 02475A01 md5 8541D7A8737BE09C52D4EC1274DE2A91 sha1 B23ADB839AC7BB51CC080FF531E42AB0BC86DD13 )
 )
 
 game (
 	name "V-Rally Edition 99 (USA)"
 	description "V-Rally Edition 99 (USA)"
 	rom ( name "V-Rally Edition 99 (USA).n64" size 8388608 crc BFEF13E9 md5 5E82395C7F9C3ADE651551682F9A9869 sha1 7FC14B6683A5CBF1597211EB2375E5AD0E16C756 )
+	rom ( name "V-Rally Edition 99 (U) [!].z64" size 8388608 crc 4803075E md5 0C3448A9D85300ACB9C5556F27A84B23 sha1 891C64C871993C043BF47745FCCE16CD7E6AA76F )
 )
 
 game (
 	name "Vigilante 8 (Europe)"
 	description "Vigilante 8 (Europe)"
 	rom ( name "Vigilante 8 (Europe).n64" size 8388608 crc 959ECCE7 md5 56FE17C8AEBB21A2E625D74F66B7CBE3 sha1 49F44E03DCC432784ED4251D4A52490F734A30A8 flags verified )
+	rom ( name "Vigilante 8 (E) [!].z64" size 8388608 crc 0E9BB6D6 md5 DF011E19F41B1B19C21F1E77E13780B7 sha1 37603E7AFBA0D0EBEBE64782EFD135B096D4CADC )
 )
 
 game (
 	name "Vigilante 8 (France)"
 	description "Vigilante 8 (France)"
 	rom ( name "Vigilante 8 (France).n64" size 8388608 crc C178EA87 md5 ACF053FBCDA123346A446D5133628092 sha1 53446583AEE4C693C9A9B5ED50A4D9BAE1D284B2 )
+	rom ( name "Vigilante 8 (F) [!].z64" size 8388608 crc 11D23AB3 md5 FF9F85C50982DBDBA9853A8915321D31 sha1 16688EAC55153332D49A62696294F38D6C1AFEFA )
 )
 
 game (
 	name "Vigilante 8 (Germany)"
 	description "Vigilante 8 (Germany)"
 	rom ( name "Vigilante 8 (Germany).n64" size 8388608 crc 179EEC29 md5 5649539D6734F4BC0369FF3AB8C2CA9D sha1 7E6E6630F419C25EFC18ADC9AF884AB25EEF42B6 )
+	rom ( name "Vigilante 8 (G) [!].z64" size 8388608 crc 17F63C3F md5 37B430EE16167831C6C6292994F93277 sha1 39E4FC6D553D370EFC0710DE2E99D8BC8A020A7C )
 )
 
 game (
@@ -5258,6 +6012,7 @@ game (
 	name "Vigilante 8 - 2nd Offense (Europe)"
 	description "Vigilante 8 - 2nd Offense (Europe)"
 	rom ( name "Vigilante 8 - 2nd Offense (Europe).n64" size 12582912 crc 763D501E md5 417701C8EE152E3E9003001623EBAE5B sha1 AD3F8CC2E2EAD6E713621E25F5F6F02534A81AD5 flags verified )
+	rom ( name "Vigilante 8 - 2nd Offence (E) [!].z64" size 12582912 crc 691AA971 md5 47661EF1964524B6319B759913F08B62 sha1 A2841A8B4C29481D05B52227442C0E419C574E2D )
 )
 
 game (
@@ -5271,102 +6026,119 @@ game (
 	name "Violence Killer - Turok New Generation (Japan)"
 	description "Violence Killer - Turok New Generation (Japan)"
 	rom ( name "Violence Killer - Turok New Generation (Japan).n64" size 33554432 crc 65785622 md5 8B8FD4AC3F3379747644EF183088D49B sha1 873B8520FC44DB2B3910DD5F11B9AEC63F17645C flags verified )
+	rom ( name "Violence Killer - Turok New Generation (J) [!].z64" size 33554432 crc 097F139F md5 C3005D76AF42E929E5C67421A19F8235 sha1 2DD9771030500A4E4512E76209267E358A4A0AE6 )
 )
 
 game (
 	name "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).n64" size 4194304 crc D20F855C md5 E78D046A3E65769966BEBFD9280938DD sha1 47B211D0F2CB0C5F53BFBB52649CAF6A616CF24C flags verified )
+	rom ( name "Virtual Chess 64 (E) (M6) [!].z64" size 4194304 crc AAE15243 md5 E790BE1A5B883BEBA44BC0D2666C65F5 sha1 0899017B0A5231ECBB084ABFF2303D9C25342828 )
 )
 
 game (
 	name "Virtual Chess 64 (USA) (En,Fr,Es)"
 	description "Virtual Chess 64 (USA) (En,Fr,Es)"
 	rom ( name "Virtual Chess 64 (USA) (En,Fr,Es).n64" size 4194304 crc 3CD894C4 md5 EEC508E77327324B9CD88957C173079B sha1 9F57EC795E3C62D88EA823A5866A7B1012B731DB )
+	rom ( name "Virtual Chess 64 (U) (M3) [!].z64" size 4194304 crc 620DE0B7 md5 F8A35270279B277586D7210FD15134FF sha1 B3F84937813EB76F94DFCF1DBEA69B11BDBF7E4F )
 )
 
 game (
 	name "Virtual Pool 64 (Europe)"
 	description "Virtual Pool 64 (Europe)"
 	rom ( name "Virtual Pool 64 (Europe).n64" size 4194304 crc F8498BD2 md5 383518F562B819AC7D1BCCB2987E035E sha1 92994B5289C95951A566B745E2D9A80D62C711EE flags verified )
+	rom ( name "Virtual Pool 64 (E) [!].z64" size 4194304 crc 9A6FB0BC md5 AB68FB43F012C1A45AF1DBCC8E8C109C sha1 70BD9ECE445D6B66EF65AFC19B5EA9DF5A75DBA4 )
 )
 
 game (
 	name "Virtual Pool 64 (USA)"
 	description "Virtual Pool 64 (USA)"
 	rom ( name "Virtual Pool 64 (USA).n64" size 4194304 crc 584B2A5F md5 379A1B5091AC14011BBF13905F7358E3 sha1 5AA70FE4E2BF875BA089AFD53D1FEF27A59BB3F9 )
+	rom ( name "Virtual Pool 64 (U) [!].z64" size 4194304 crc AD628DED md5 6D3DB67319DA339DF4B68AD0084904D5 sha1 4FED63F7EE35F4D3941F0D61175057481D91D2E0 )
 )
 
 game (
 	name "Virtual Pro Wrestling 2 - Oudou Keishou (Japan)"
 	description "Virtual Pro Wrestling 2 - Oudou Keishou (Japan)"
 	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (Japan).n64" size 33554432 crc 8E33C3AF md5 F615D6D16FDE2D86E67D8418C5F7FDF3 sha1 D6E4980EE08519A0AF60BED5C40A71E284B1E178 flags verified )
+	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!].z64" size 33554432 crc F620835D md5 90002501777E3237739F5ED9B0E349E2 sha1 82DD25A044689EAB57AB362FE10C0DA6388C217A )
 )
 
 game (
 	name "Virtual Pro Wrestling 64 (Japan)"
 	description "Virtual Pro Wrestling 64 (Japan)"
 	rom ( name "Virtual Pro Wrestling 64 (Japan).n64" size 16777216 crc 2B4B9BEF md5 BAC5D6CA43BAB3A963DE9DE88E02D5D7 sha1 A98DF45B6FDEB368FB906A2A1FB257658739CEFE flags verified )
+	rom ( name "Virtual Pro Wrestling 64 (J) [!].z64" size 16777216 crc E6651803 md5 5E6202200AF40A8F026780EDFE1E15D0 sha1 F9E9FA2ED819C3A39DB5CB6AFECA186F021DB5ED )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (Europe)"
 	description "Waialae Country Club - True Golf Classics (Europe)"
 	rom ( name "Waialae Country Club - True Golf Classics (Europe).n64" size 16777216 crc 8E6F987B md5 A3F14021F514509F6A001073F0F7ED19 sha1 B7542C7FC1566D4A9D72B85E3C6D57642614EE29 flags verified )
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!].z64" size 16777216 crc 6858759A md5 5F1906DF4EB30537C2AC2FCBD005907D sha1 A06F905F4466637012ADB5EB56CCDCBEE2E7AC72 )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (Europe) (Rev A)"
 	description "Waialae Country Club - True Golf Classics (Europe) (Rev A)"
 	rom ( name "Waialae Country Club - True Golf Classics (Europe) (Rev A).n64" size 16777216 crc 53A68628 md5 7EA7F5676D06D1C6387E7B8C01905BC3 sha1 57CBFA043A2D86C11B35B49855115641184097D7 )
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!].z64" size 16777216 crc 6CB097B3 md5 F7C1B1EE1CE37CE09AA48C7E0A115EFA sha1 074D13DA1AC91167654A8047EB72D732FBCB5121 )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (USA)"
 	description "Waialae Country Club - True Golf Classics (USA)"
 	rom ( name "Waialae Country Club - True Golf Classics (USA).n64" size 16777216 crc CB760261 md5 AC8E0BA90CF88F77382AC450E3975343 sha1 F0A57D923159F5940528EAD63C1F34D129DCA866 )
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.0) [!].z64" size 16777216 crc CCAB08D7 md5 DD8154D507C88694AFD69C7AF16A8CD6 sha1 F8609F518D60C87CB6A4E257633E8A1BE957311C )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (USA) (Rev A)"
 	description "Waialae Country Club - True Golf Classics (USA) (Rev A)"
 	rom ( name "Waialae Country Club - True Golf Classics (USA) (Rev A).n64" size 16777216 crc 76EBDB18 md5 8F0FD604B64DFDF18E3922258EDE4DD1 sha1 305E4A9FA345CF74000F7F05AEC2483F4C7BDF3E )
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.1) [!].z64" size 16777216 crc C65EE122 md5 67F75C4DD30922A001C8C32AEB9333AC sha1 45C9E0CA0D41B47BB59D36CEBB1D2A9DB7C8278B )
 )
 
 game (
 	name "War Gods (Europe)"
 	description "War Gods (Europe)"
 	rom ( name "War Gods (Europe).n64" size 12582912 crc FD10AAA6 md5 94A2651B517464D197DEDBC5B13B87D3 sha1 FC77E3D872220DAFC41147BA79188A04E21F3805 flags verified )
+	rom ( name "War Gods (E) [!].z64" size 12582912 crc C73010C8 md5 D25DD15903BDCB7724A2E8A02561987F sha1 C9BDD7E5AF853135FC4CBD72E461FC227F7498E3 )
 )
 
 game (
 	name "War Gods (USA)"
 	description "War Gods (USA)"
 	rom ( name "War Gods (USA).n64" size 12582912 crc 10635B27 md5 804E38E2FF638EF8B2E02E231AD2F8A2 sha1 3FF5C88420221F95EB27A65519C6FE558618BFC7 )
+	rom ( name "War Gods (U) [!].z64" size 12582912 crc FFACF993 md5 9FF2BA3C8408DE9F0EDB6D764A97C197 sha1 829C4F0F1CAA72A2FBABAEE5651E2ACC695D3921 )
 )
 
 game (
 	name "Wave Race 64 (Europe) (En,De)"
 	description "Wave Race 64 (Europe) (En,De)"
 	rom ( name "Wave Race 64 (Europe) (En,De).n64" size 8388608 crc D74117B0 md5 BAFF32EE50896E62DC713E23D1A589DA sha1 7FFDD44890B1A00E0C13868A18B482FBF8C752F7 flags verified )
+	rom ( name "Wave Race 64 (E) (M2) [!].z64" size 8388608 crc FB289893 md5 310659115E9939F219A783ABDD456CE9 sha1 C20AA97DC25AEC7A9B9C6889286BBD216FC7CAA4 )
 )
 
 game (
 	name "Wave Race 64 (Japan)"
 	description "Wave Race 64 (Japan)"
 	rom ( name "Wave Race 64 (Japan).n64" size 8388608 crc 0580EEE7 md5 488DCC35AF1074C2A5A7483417C0EE3F sha1 B1B4435B15627830F7C932EB40DF862EEA2B38E4 flags verified )
+	rom ( name "Wave Race 64 (J) [!].z64" size 8388608 crc 6C93FF83 md5 B32E555BC1A375256E8A4021A25339BE sha1 05D40E57C9CB29A8992595AFDDE6653936E16729 )
 )
 
 game (
 	name "Wave Race 64 (Japan) (Rev B) (Shindou Edition)"
 	description "Wave Race 64 (Japan) (Rev B) (Shindou Edition)"
 	rom ( name "Wave Race 64 (Japan) (Rev B) (Shindou Edition).n64" size 8388608 crc D3610A02 md5 F385D82E0E9372A812CBF98BC0D0EE48 sha1 443E3C3476568DE9C36582184104F2DD09B59407 flags verified )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [!].z64" size 8388608 crc 90044C4B md5 FF67DF97476C210D158779AE6142F239 sha1 445ECB4904CC0AB6B81FB415A35072E99F18B545 )
 )
 
 game (
 	name "Wave Race 64 (USA)"
 	description "Wave Race 64 (USA)"
 	rom ( name "Wave Race 64 (USA).n64" size 8388608 crc 9EF814CD md5 89C5C1208E2BBA07CB9C46786571B159 sha1 8BACCF6A8A298609BFF1FE489845F2136FD03CF1 )
+	rom ( name "Wave Race 64 (U) (V1.0) [!].z64" size 8388608 crc 74A7B725 md5 AE480013F39D4AEC86EEA1B4995600D1 sha1 887AB588C2ECC64C52FB2065F06B0A1EE4AF13DC )
 )
 
 game (
@@ -5386,60 +6158,70 @@ game (
 	name "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)"
 	description "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)"
 	rom ( name "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).n64" size 8388608 crc 0EFF3F94 md5 1CFC82269D38199171E2FCD48FB93BC4 sha1 BFA32477EA99C93C156E51FDF14107A6BEEB31AA flags verified )
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [!].z64" size 8388608 crc 442A4F5F md5 319816AAA30E512827BE7B7F81F80D86 sha1 D9A6BA9A6E75A198E995AF3C4C81F4CFB3830C64 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (Japan)"
 	description "Wayne Gretzky's 3D Hockey (Japan)"
 	rom ( name "Wayne Gretzky's 3D Hockey (Japan).n64" size 8388608 crc 694B3B0B md5 197EE91817839DD7E8FAE10051EC6992 sha1 0A7890D52130CFA7F6076545735C510586C230BA flags verified )
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [!].z64" size 8388608 crc 485275ED md5 61E637B542D5DF178040454075C28E19 sha1 D8EDC3B462BF80B48C98FB36032B8ACA95164055 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (USA)"
 	description "Wayne Gretzky's 3D Hockey (USA)"
 	rom ( name "Wayne Gretzky's 3D Hockey (USA).n64" size 8388608 crc 2462389E md5 402AF7C6B9A5D77ABCDEB140164C4641 sha1 2CB103FECADA5DA8DE2A6384F13E004098F4E724 )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!].z64" size 8388608 crc 9781F88D md5 6DF0D6259261D0096C90BBC6AA037D8E sha1 400AA84811F1F2F6C62C756B43B54D534D5A5EC8 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (USA) (Rev A)"
 	description "Wayne Gretzky's 3D Hockey (USA) (Rev A)"
 	rom ( name "Wayne Gretzky's 3D Hockey (USA) (Rev A).n64" size 8388608 crc 6E5A30ED md5 5A54B97A4049E3987BC057535F95FB2B sha1 073B4E9CD8D93A58145625FFEF9B1FC642EB31A8 )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!].z64" size 8388608 crc C2678971 md5 04E650B7742A69DAE98F125D1B492D78 sha1 91F33097C5DA2C3480E0A9F04F7463CEA16B176B )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)"
 	description "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)"
 	rom ( name "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).n64" size 8388608 crc 53751331 md5 69F21F9AD371EB5564F0E3E817A7035D sha1 2F1462118B4AFF3DED4AE5AFD3952F2189B43A27 flags verified )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!].z64" size 8388608 crc 6F6DC53D md5 24A0D8C8CABC22116E469476FF6C691D sha1 3EB1A78C0480AF0CC6F2180F87260790C37367D0 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey '98 (USA)"
 	description "Wayne Gretzky's 3D Hockey '98 (USA)"
 	rom ( name "Wayne Gretzky's 3D Hockey '98 (USA).n64" size 8388608 crc 5C593E2E md5 4F055251F47CE44D618E0EE4B3962C98 sha1 D561EBA53BED8B399635298233A073FFFAF0EEDE )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [!].z64" size 8388608 crc 355FB089 md5 810F8BC2C8C66BDA3B206C7DD4B6D42F sha1 1AF0BE9568F8ACE865D5CF76FD241DA741154B0F )
 )
 
 game (
 	name "WCW Backstage Assault (USA)"
 	description "WCW Backstage Assault (USA)"
 	rom ( name "WCW Backstage Assault (USA).n64" size 33554432 crc D3A9F234 md5 A08B158B8EEBB9FE2CBF5C5BEC86266E sha1 F31E03752C7502E99A201BF86FFB453AC260D426 )
+	rom ( name "WCW Backstage Assault (U) [!].z64" size 33554432 crc 5DCC2E4E md5 02AED169EB579494ACE75D22E10D789B sha1 34F793D55770D5EB112CFF0E28CB0A35E0EC7385 )
 )
 
 game (
 	name "WCW Mayhem (Europe)"
 	description "WCW Mayhem (Europe)"
 	rom ( name "WCW Mayhem (Europe).n64" size 16777216 crc E56874EE md5 EBE4D489C2D6EA05986F6FDB54747AA0 sha1 E52D1E83BC9283A7BA7B99372A83D4D6ECF57347 flags verified )
+	rom ( name "WCW Mayhem (E) [!].z64" size 16777216 crc 864E066E md5 9E943752BCF4FBA9CA3028E596F4EB4A sha1 594B273EE9D6E174CFD9B33D4FD6AA86CD3E2442 )
 )
 
 game (
 	name "WCW Mayhem (USA)"
 	description "WCW Mayhem (USA)"
 	rom ( name "WCW Mayhem (USA).n64" size 16777216 crc A1911368 md5 953870B29EC86FDB782136F334BCB05C sha1 0B848A7747C97286D42764F9237D9EF05B39BECD )
+	rom ( name "WCW Mayhem (U) [!].z64" size 16777216 crc F1F9B6EB md5 87BF3784709CD09693CD7BCC08460C63 sha1 83382EE31DB3DCCD598D8AF55607E70DB1BCBBB6 )
 )
 
 game (
 	name "WCW Nitro (USA)"
 	description "WCW Nitro (USA)"
 	rom ( name "WCW Nitro (USA).n64" size 12582912 crc AC1909A9 md5 C8C8B278A90951C9EEE9097CEEE92194 sha1 F4C03AE1CCC3EAC5B0F8B37B0293DB44DAA6397C )
+	rom ( name "WCW Nitro (U) [!].z64" size 12582912 crc 455B0830 md5 1E9FEAD701FE5AAAA248D4713891775D sha1 1F3B1A9E348506AE3D2A79216B0BC6E69D04A4F9 )
 )
 
 game (
@@ -5452,60 +6234,70 @@ game (
 	name "WCW vs. nWo - World Tour (Europe)"
 	description "WCW vs. nWo - World Tour (Europe)"
 	rom ( name "WCW vs. nWo - World Tour (Europe).n64" size 12582912 crc B3A472A3 md5 D8F27EB71A348B6E5EBD902E619845BC sha1 DD07A3434EE38AC03F5D3E45BFB0B3F956EBDAB5 flags verified )
+	rom ( name "WCW vs. nWo - World Tour (E) [!].z64" size 12582912 crc 37F358EB md5 553D8D5347969C66E5D91C3FE35208B9 sha1 840B8B6303ACACEB49619EB1533CB4221CDEC474 )
 )
 
 game (
 	name "WCW vs. nWo - World Tour (USA)"
 	description "WCW vs. nWo - World Tour (USA)"
 	rom ( name "WCW vs. nWo - World Tour (USA).n64" size 12582912 crc AD6FE55F md5 B352F1CD684BB04530A454E8618E6582 sha1 050A85A8FB5146D0A5DD0A67D1004695F83CEA36 )
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [!].z64" size 12582912 crc DFBFC61F md5 203C3BBFDD10C5A0B7C5D0CDB085D853 sha1 5AD2D8359058C8BB71F08E3D3433B7A50D3BB645 )
 )
 
 game (
 	name "WCW vs. nWo - World Tour (USA) (Rev A)"
 	description "WCW vs. nWo - World Tour (USA) (Rev A)"
 	rom ( name "WCW vs. nWo - World Tour (USA) (Rev A).n64" size 12582912 crc 85E0C097 md5 D87E95C5B6BC2E1D484C2F8CC3986D63 sha1 6ECEDD03908627B4A76C3E1CC46D3567E755591D )
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.1) [!].z64" size 12582912 crc A74DA07A md5 B7A220B59303D47F3BEAE233CA868CFD sha1 60814FB3AD2DD206BADBEEE47C07636357DD0D7E )
 )
 
 game (
 	name "WCW-nWo Revenge (Europe)"
 	description "WCW-nWo Revenge (Europe)"
 	rom ( name "WCW-nWo Revenge (Europe).n64" size 16777216 crc 0ABBE702 md5 9FB2B096FEECDADA1DBF02021C4FEF50 sha1 12C5CCBBB9744226517E6EECFBA0FF103E83B905 flags verified )
+	rom ( name "WCW-nWo Revenge (E) [!].z64" size 16777216 crc 8AF0F964 md5 30C6676EC1D62122F4E7607EF3ABBD41 sha1 C59315A3E7A6E8124495477656A77E4619DAC104 )
 )
 
 game (
 	name "WCW-nWo Revenge (USA)"
 	description "WCW-nWo Revenge (USA)"
 	rom ( name "WCW-nWo Revenge (USA).n64" size 16777216 crc 2257FD02 md5 E3635E2F657ECCA2B00714034F5A6330 sha1 EF6CD4DF563C3DBBF8E7AFD890A6C4A3E0704FF6 flags verified )
+	rom ( name "WCW-nWo Revenge (U) [!].z64" size 16777216 crc 54CBAAA8 md5 C1384F3637D7A381B29341FED3EF3CEB sha1 E1711A2511394B9357B5F1AC8CA5CC17BD674836 )
 )
 
 game (
 	name "Wetrix (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Wetrix (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Wetrix (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc E26CFF31 md5 185812A68E64C7FED30842C7082A9ADB sha1 8967CD465FBCC1151F8794F0C58181DA1040C2EC flags verified )
+	rom ( name "Wetrix (E) (M6) [!].z64" size 8388608 crc EDDC5B06 md5 A99E2CB6ACEF7A004961DE5F6DFEEFF0 sha1 4CC1B6E3AA150CD79093F21E3FBE91A72FB86AD6 )
 )
 
 game (
 	name "Wetrix (Japan)"
 	description "Wetrix (Japan)"
 	rom ( name "Wetrix (Japan).n64" size 4194304 crc AEBAFD6D md5 18A3AAC38AAE52CFE1A38F75FCFF6963 sha1 A8D2970EB0313BDF925BE994F04508373715F771 flags verified )
+	rom ( name "Wetrix (J) [!].z64" size 4194304 crc BAD08218 md5 E8997BF5662540B184FBF8277D260984 sha1 1B1635546CB973EBAA0A4A0940A363EC2C074053 )
 )
 
 game (
 	name "Wetrix (USA) (En,Fr,De,Es,It,Nl)"
 	description "Wetrix (USA) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Wetrix (USA) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 4EDA94C1 md5 B0DF900CD2B612F23CE81E1AB28DABA2 sha1 80CC6C54CC9517A33E90CCF0CC9F2C03D1F050AD )
+	rom ( name "Wetrix (U) (M6) [!].z64" size 8388608 crc 50CD1F71 md5 6E81D3056E409208E4AF2D39A2FF0F03 sha1 6E40312CF88A9182E93B396B9D82457B1ABA7CD6 )
 )
 
 game (
 	name "Wheel of Fortune (USA)"
 	description "Wheel of Fortune (USA)"
 	rom ( name "Wheel of Fortune (USA).n64" size 4194304 crc C2571693 md5 6F3C444A52BBEB79664518DF389D5BD7 sha1 A40D8DAE6BFE2C0ABDF1FD6B1EB219F4DA988BD2 )
+	rom ( name "Wheel of Fortune (U) [!].z64" size 4194304 crc 8D3EFA8D md5 2ABE36754E866B9B6C4BDCFFC1D11ABF sha1 B51B28660699BF029F862F51C319A5962FE9DE9B )
 )
 
 game (
 	name "Wild Choppers (Japan)"
 	description "Wild Choppers (Japan)"
 	rom ( name "Wild Choppers (Japan).n64" size 8388608 crc FED21F49 md5 5BA61B7BC73E515F579A6A42DF21C8E2 sha1 E9794038F75DDADD6F57B0981B4E077766DCCA3E flags verified )
+	rom ( name "Wild Choppers (J) [!].z64" size 8388608 crc D6136DC5 md5 F85F2A2B6CA64898F0ADD2A78CCDCCF3 sha1 9ED151FCE580F875F09CB250D2BB9C18C8D549C0 )
 )
 
 game (
@@ -5518,6 +6310,7 @@ game (
 	name "WinBack (Japan)"
 	description "WinBack (Japan)"
 	rom ( name "WinBack (Japan).n64" size 16777216 crc A5364D80 md5 6AB34E12639A776D5060B934AFFF2BBD sha1 E66E96813BB9A7D4E9C6B4FF39695ADCC10B7ED5 flags verified )
+	rom ( name "WinBack (J) [!].z64" size 16777216 crc D35360B0 md5 EE3D3550ACC463CA57408BF14E541F68 sha1 D6DB9E2509B760403F5DB330142055AF842FB52C )
 )
 
 game (
@@ -5530,12 +6323,14 @@ game (
 	name "WinBack - Covert Operations (USA)"
 	description "WinBack - Covert Operations (USA)"
 	rom ( name "WinBack - Covert Operations (USA).n64" size 16777216 crc 1A6334D0 md5 3CDDD6598405CE272E14BACE45F082B5 sha1 B0FAFA4570B27F42428DFFA3BAC2BA582B99FE21 )
+	rom ( name "WinBack - Covert Operations (U) [!].z64" size 16777216 crc 64C817C5 md5 48DA6CDCAB838153CAA2ECC3DD592A65 sha1 FA04477B321A95E1F7A2EDCAC5C09BFA6EF72041 )
 )
 
 game (
 	name "Wipeout 64 (Europe)"
 	description "Wipeout 64 (Europe)"
 	rom ( name "Wipeout 64 (Europe).n64" size 8388608 crc 0C3497E4 md5 58263168B3363AE6AD715EEE2E2DA4F0 sha1 CCAB769B06290671ADBC81B09440049B487ADBAB flags verified )
+	rom ( name "Wipeout 64 (E) [!].z64" size 8388608 crc 38111048 md5 5783373634B11F81C86908C3D81CA988 sha1 3EEF8EC7D0009EE67D604AACA2BB61B7397BA862 )
 )
 
 game (
@@ -5549,36 +6344,42 @@ game (
 	name "Wonder Project J2 - Koruro no Mori no Jozet (Japan)"
 	description "Wonder Project J2 - Koruro no Mori no Jozet (Japan)"
 	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).n64" size 8388608 crc 8AAF74A3 md5 A91C568F04CDA76B70DF6EEDF051F82E sha1 585B62B5CA10A5E296A7DD0065DCCB91BB620ED2 flags verified )
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!].z64" size 8388608 crc 5E8FC436 md5 0FF1F8628D8FE69582DB54572D2BEA79 sha1 3A311EC0D77D4E0FC425A99CB6B9416F072E268E )
 )
 
 game (
 	name "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	description "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	rom ( name "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).n64" size 12582912 crc 163481D0 md5 C10FABD6404A7AEF3516DBEEE1DD57E3 sha1 5E115692C924CCD0CA6AFA4C4777077F97A7D9C2 flags verified )
+	rom ( name "World Cup 98 (E) (M8) [!].z64" size 12582912 crc 79F483F7 md5 3AA263ACA66F3A07BB081B575D66DEEB sha1 CD92B2CBB253411FC66544649567D9B1C44BB210 )
 )
 
 game (
 	name "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	description "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	rom ( name "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).n64" size 12582912 crc B875CD94 md5 197399A234FF807C2B0A69061D719C47 sha1 8ECA8B866A0F746E9BD7A6FC1B8DFF6BD7B2F210 )
+	rom ( name "World Cup 98 (U) (M8) [!].z64" size 12582912 crc 13930C26 md5 4BEF5E9AA9E71205DAC1A7060E778235 sha1 B496EDEE84E5E84EAD8DA6F57A765936B2AF2F9F )
 )
 
 game (
 	name "World Driver Championship (Europe) (En,Fr,De,Es,It)"
 	description "World Driver Championship (Europe) (En,Fr,De,Es,It)"
 	rom ( name "World Driver Championship (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 74FAD5AA md5 EA7663CC3BBF0FFBA3671F8357515163 sha1 DBE027955669E25E6CECAFA6E07BED9890C8995C flags verified )
+	rom ( name "World Driver Championship (E) (M5) [!].z64" size 16777216 crc 76151DF6 md5 431DE8F6611A8131B536F0EDE1F330D9 sha1 7B054D1580CC263429EB6961AD6ED6E0140E1DF0 )
 )
 
 game (
 	name "World Driver Championship (USA)"
 	description "World Driver Championship (USA)"
 	rom ( name "World Driver Championship (USA).n64" size 16777216 crc DCD9D2D2 md5 19831C89B9033F7BCFD0C7106E3C3EC6 sha1 B5A329E477FEBC75A0B73A7466C48BBFD1320BFF )
+	rom ( name "World Driver Championship (U) [!].z64" size 16777216 crc 5E4ACBFA md5 7C567A5BB1AD4CBE414FB6BBFF66E336 sha1 93227776F59B42E9FB1C942EBA9D5B465EEB3979 )
 )
 
 game (
 	name "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 4862EBBD md5 4CED4F06943551F53EECB3D71324EB24 sha1 EC23BB5489C76933EFF1A2BA17658C7EBD116328 flags verified )
+	rom ( name "Worms - Armageddon (E) (M6) [!].z64" size 12582912 crc 6BFFF27B md5 44FC2A7F028F0B6F71B255F672C8B495 sha1 34042046E3CFA44723C32F6D366052483EDB80D7 )
 )
 
 game (
@@ -5592,84 +6393,98 @@ game (
 	name "WWF Attitude (Europe)"
 	description "WWF Attitude (Europe)"
 	rom ( name "WWF Attitude (Europe).n64" size 33554432 crc 69CF2FE6 md5 16479D2A012C09B64255F303ED5119AC sha1 4135D3346BE4EB657C6779CE7B2CA89D5D94A0DB flags verified )
+	rom ( name "WWF Attitude (E) [!].z64" size 33554432 crc 804FE494 md5 3FDB2E5F9982FDA2C2344A883B8AB6EF sha1 880D3AACAE0B3792235404DECD294AFDAD51A0A6 )
 )
 
 game (
 	name "WWF Attitude (Germany)"
 	description "WWF Attitude (Germany)"
 	rom ( name "WWF Attitude (Germany).n64" size 33554432 crc F1F22E20 md5 B1BFBECAC6B92145DCFA98ADF34B4BDC sha1 53FC14DFC7CCBB4498AECB2D0DBCB3BB1A569B0A )
+	rom ( name "WWF Attitude (G) [!].z64" size 33554432 crc EA5D8359 md5 B86EC8D19D7D1A50EA900EA10355A735 sha1 40C2C6309589755C4CFDBF3E4E39B3788820B199 )
 )
 
 game (
 	name "WWF Attitude (USA)"
 	description "WWF Attitude (USA)"
 	rom ( name "WWF Attitude (USA).n64" size 33554432 crc F694DB1E md5 71EE30C9BC45E33089226B02B23EEE7A sha1 9519C9A7E9F370E565545FA5F5A21077F585310B )
+	rom ( name "WWF Attitude (U) [!].z64" size 33554432 crc 7A4B3686 md5 9FAF514CB3DBB742C129DEB395DCA342 sha1 259973EB0BA1D01F1A5FBF3039ED511E6B705F26 )
 )
 
 game (
 	name "WWF No Mercy (Europe)"
 	description "WWF No Mercy (Europe)"
 	rom ( name "WWF No Mercy (Europe).n64" size 33554432 crc EEB166B4 md5 F58F64A8AD952459B2EE37F07004272B sha1 CADBCD5361DFFAF2AA17F0CB4C4CC799BDC8350A )
+	rom ( name "WWF No Mercy (E) (V1.0) [!].z64" size 33554432 crc B79BDDD8 md5 C9A6446918DA5D65612C521D432B7DA1 sha1 3AF3190DE8E687D2899EE5EA7CDD58A3B6F34953 )
 )
 
 game (
 	name "WWF No Mercy (Europe) (Rev A)"
 	description "WWF No Mercy (Europe) (Rev A)"
 	rom ( name "WWF No Mercy (Europe) (Rev A).n64" size 33554432 crc 1A6F82E4 md5 685BA168AF8B7D4A9D31B17A1B432405 sha1 F49217CB9039212D2D779ACB00222FB73C454F56 flags verified )
+	rom ( name "WWF No Mercy (E) (V1.1) [!].z64" size 33554432 crc 43BA9E7E md5 400A14F132D993F5544F8B008EC136FA sha1 CC8B9863C0E96D1B6A611D6AC2238E38B247EA5D )
 )
 
 game (
 	name "WWF No Mercy (USA)"
 	description "WWF No Mercy (USA)"
 	rom ( name "WWF No Mercy (USA).n64" size 33554432 crc EE8C16C1 md5 6B698F27E29366B68DC518976BA844A6 sha1 3A902129BD2221C4411D05C642EF7F79AEFB1720 )
+	rom ( name "WWF No Mercy (U) (V1.0) [!].z64" size 33554432 crc B33F44F0 md5 04C492BE7F89FC6F425238BD67629544 sha1 3566D9B5723291937582453AD0453CE517CFC358 )
 )
 
 game (
 	name "WWF No Mercy (USA) (Rev A)"
 	description "WWF No Mercy (USA) (Rev A)"
 	rom ( name "WWF No Mercy (USA) (Rev A).n64" size 33554432 crc AFBC514E md5 761D5C8FB24CAF5F44613ACD5C9AD4B2 sha1 159ECD53E5FD9B0F607CB39042057F55F07D18A6 )
+	rom ( name "WWF No Mercy (U) (V1.1) [!].z64" size 33554432 crc BACEEA13 md5 66B8EC24557A50514A814F15429BD559 sha1 91CEE3D096F4A76644D8B35B9AEAD6448909ABD1 )
 )
 
 game (
 	name "WWF War Zone (Europe)"
 	description "WWF War Zone (Europe)"
 	rom ( name "WWF War Zone (Europe).n64" size 12582912 crc 58062C02 md5 2A89A8ED317F092687E4481D8A982185 sha1 4685430FBC7BB719EA2A277C4EB8616011925546 flags verified )
+	rom ( name "WWF - War Zone (E) [!].z64" size 12582912 crc 90A0B609 md5 EBC0CF55FC58845C6EE86CF8B2D87303 sha1 808A8997AA8D717AAC2A9A0C476B901338AC626E )
 )
 
 game (
 	name "WWF War Zone (USA)"
 	description "WWF War Zone (USA)"
 	rom ( name "WWF War Zone (USA).n64" size 12582912 crc 6CFE13A8 md5 0A8F9866320695A5032B946E6E4E6DA9 sha1 852A6D39FC61C82BF13E852978924F8C7DB8D039 )
+	rom ( name "WWF - War Zone (U) [!].z64" size 12582912 crc 2FBB5507 md5 2322DA2B9E7DC74678CD683B7A246B49 sha1 8700F89CD7CFA873452117F6B2A648D32796111C )
 )
 
 game (
 	name "WWF WrestleMania 2000 (Europe)"
 	description "WWF WrestleMania 2000 (Europe)"
 	rom ( name "WWF WrestleMania 2000 (Europe).n64" size 33554432 crc ACB7BA1B md5 02BCB985BF7E169DF502E2667BD64CAB sha1 A5923994A65FFD425ED094FB9FF8CCAFD5ABC10A flags verified )
+	rom ( name "WWF WrestleMania 2000 (E) [!].z64" size 33554432 crc 09D710C7 md5 B75149F87CC5F3A508643AC377F2FCC9 sha1 D37C4100D967CB8B71852993B947619467FFCAF7 )
 )
 
 game (
 	name "WWF WrestleMania 2000 (Japan)"
 	description "WWF WrestleMania 2000 (Japan)"
 	rom ( name "WWF WrestleMania 2000 (Japan).n64" size 33554432 crc E4E3B9A3 md5 F751FE0E25CF396CE883B61149E03C87 sha1 4128E150BC7E1291A3D388A210A50BD423E5D3E2 flags verified )
+	rom ( name "WWF WrestleMania 2000 (J) [!].z64" size 33554432 crc C2034D24 md5 11EEE2F34BF8DA05A1B8F4FB9FE9F74C sha1 E020C26DEDE0C349181CF08A3541816DC47F63A8 )
 )
 
 game (
 	name "WWF WrestleMania 2000 (USA)"
 	description "WWF WrestleMania 2000 (USA)"
 	rom ( name "WWF WrestleMania 2000 (USA).n64" size 33554432 crc D514E83C md5 20AB9371EAA3BAB3E3ED169A7F9A59D1 sha1 D8CF547EB81C72C748BE87B6CE6B2F66C2699BD0 )
+	rom ( name "WWF WrestleMania 2000 (U) [!].z64" size 33554432 crc 0B50B4C6 md5 D9030CA30E4D1AF805ACCE1BFED988CC sha1 442D417A52ED672CA1A47E7261A5414DEBB1E27A )
 )
 
 game (
 	name "Xena - Warrior Princess - The Talisman of Fate (Europe)"
 	description "Xena - Warrior Princess - The Talisman of Fate (Europe)"
 	rom ( name "Xena - Warrior Princess - The Talisman of Fate (Europe).n64" size 12582912 crc 2BB18EB6 md5 262276343CA48F34007E2FA0701A4FAD sha1 B900A33736F7AB68648D274B76BBD4A8F6E4AF33 flags verified )
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (E) [!].z64" size 12582912 crc D3932F88 md5 EC2BCB1B7FC7D068BE1F39E79E49A842 sha1 2FA884F36BD370D844ED1E57C4357510584FE3E2 )
 )
 
 game (
 	name "Xena - Warrior Princess - The Talisman of Fate (USA)"
 	description "Xena - Warrior Princess - The Talisman of Fate (USA)"
 	rom ( name "Xena - Warrior Princess - The Talisman of Fate (USA).n64" size 12582912 crc 7CB26725 md5 2C503835FD4CF83BDBCDEF0564D995D7 sha1 91A1E7C709D7CD8065C38CD23910D19C5BF991E1 )
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [!].z64" size 12582912 crc 7DA93999 md5 1AC234649D28F09E82C0D11ABB17F03B sha1 E3316269B8466FE1FB968AC9338E6ACDC0379970 )
 )
 
 game (
@@ -5682,18 +6497,21 @@ game (
 	name "Yakouchuu II - Satsujin Kouro (Japan)"
 	description "Yakouchuu II - Satsujin Kouro (Japan)"
 	rom ( name "Yakouchuu II - Satsujin Kouro (Japan).n64" size 33554432 crc 5C97C412 md5 8EBB08A30E9E1800ABEA767E20C9A505 sha1 E4035072F682FE16E189E57BF6A9A35706D3028A flags verified )
+	rom ( name "Yakouchuu II - Satsujin Kouru (J) [!].z64" size 33554432 crc 4538C41A md5 E24942948F7140EE4260268DB763D0FD sha1 09929CA361D47FB9FC0EB4077CF1FB77CB843CEF )
 )
 
 game (
 	name "Yoshi Story (Japan)"
 	description "Yoshi Story (Japan)"
 	rom ( name "Yoshi Story (Japan).n64" size 16777216 crc FEAC925C md5 C14F873AB510F8FB47B7021FAAAB2CFE sha1 325A1487C4BE295837728DBE7809A31823AD2554 flags verified )
+	rom ( name "Yoshi Story (J) [!].z64" size 16777216 crc 4F44A9EF md5 DD8A0E5472F13EA87B176F0155FA0C66 sha1 FF320B4122894C773F465A8996E82A00F3116E83 )
 )
 
 game (
 	name "Yoshi's Story (Europe) (En,Fr,De)"
 	description "Yoshi's Story (Europe) (En,Fr,De)"
 	rom ( name "Yoshi's Story (Europe) (En,Fr,De).n64" size 16777216 crc 21A5F264 md5 6BF066BFAC815FCA8179280ABA469554 sha1 0A480425BAECC4D4FD236275384D9EE67285E8FD flags verified )
+	rom ( name "Yoshi's Story (E) (M3) [!].z64" size 16777216 crc F9FFC760 md5 2524E5FB8ED4BB8C831C5AC057E8F344 sha1 5B56EC1DA78456F968129BADDC1F233E1FB4F4F3 )
 )
 
 game (
@@ -5707,40 +6525,71 @@ game (
 	name "Yuke Yuke!! Trouble Makers (Japan)"
 	description "Yuke Yuke!! Trouble Makers (Japan)"
 	rom ( name "Yuke Yuke!! Trouble Makers (Japan).n64" size 8388608 crc F8BB860C md5 B94FD249C7AA4336DBD92483E43FBA9A sha1 6807EBE5F95C30BAEE18F5DA6C170396D6B8764E flags verified )
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [!].z64" size 8388608 crc B69D3068 md5 2AE35BDF163613024D876A09F25063F3 sha1 039A75636C34D219D489D0A84A671D00DC23E7C4 )
 )
 
 game (
 	name "Zelda no Densetsu - Mujura no Kamen (Japan)"
 	description "Zelda no Densetsu - Mujura no Kamen (Japan)"
 	rom ( name "Zelda no Densetsu - Mujura no Kamen (Japan).n64" size 33554432 crc 3361B649 md5 44DBDE0232B67654B3A4251D599CC713 sha1 9AFDA65B3AE7D3714066DBCCF820158C3286F423 flags verified )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!].z64" size 33554432 crc 0D33E1DB md5 15D1A2217CAD61C39CFECBFFA0703E25 sha1 5FB2301AACBF85278AF30DCA3E4194AD48599E36 )
 )
 
 game (
 	name "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A)"
 	description "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A)"
 	rom ( name "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A).n64" size 33554432 crc 2DE56C55 md5 130A7217F9BAAECD2F7CEB4BACC018E4 sha1 666FAD106735135C1A3471EF1B967C396F949AD9 flags verified )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!].z64" size 33554432 crc 356C2E19 md5 C38A7F6F6B61862EA383A75CDF888279 sha1 41FDB879AB422EC158B4EAFEA69087F255EA8589 )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (Japan) (GC)"
+	description "Zelda no Densetsu - Mujura no Kamen (Japan) (GC)"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!].z64" size 33554432 crc B9BF76DF md5 D3929AADF7640F8C5B4CE8321AD4393A sha1 1438FD501E3E5B25461770AF88C02AB1E41D3A7E )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan).n64" size 33554432 crc B58E98BB md5 7D44B555E0AF3EEC36319B5E76E31B0C sha1 F9E2B6840B9103E9707EA390089A7B6943592A98 flags verified )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!].z64" size 33554432 crc D423E8B0 md5 9F04C8E68534B870F707C247FA4B50FC sha1 C892BBDA3993E66BD0D56A10ECD30B1EE612210F )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A).n64" size 33554432 crc F31C202C md5 DAF387C5BC73D4EAAE2DC781AE1B5ADA sha1 1181034D5F9533F53EBE8E1C781BADBEE115F5AA flags verified )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!].z64" size 33554432 crc 26E73887 md5 1BF5F42B98C3E97948F01155F12E2D88 sha1 DBFC81F655187DC6FEFD93FA6798FACE770D579D )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B).n64" size 33554432 crc 656657CD md5 CD8B202E87C28060D29A1A52234C87FD sha1 2D8FB7140A9C5D11CE614561E5A36FFEF0C17540 flags verified )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!].z64" size 33554432 crc 2B2721BA md5 2258052847BDD056C8406A9EF6427F13 sha1 FA5F5942B27480D60243C2D52C0E93E26B9E6B86 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (Japan) (GC)"
+	description "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (Japan) (GC)"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!].z64" size 33554432 crc 8C5B90C1 md5 0C13E0449A28EA5B925CDB8AF8D29768 sha1 2CE2D1A9F0534C9CD9FA04EA5317B80DA21E5E73 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC (Japan) (GC)"
+	description "Zelda no Densetsu - Toki no Ocarina GC (Japan) (GC)"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!].z64" size 33554432 crc 1C6CE8CB md5 33FB7852C180B18EA0B9620B630F413F sha1 0769C84615422D60F16925CD859593CDFA597F84 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC URA (Japan) (GC)"
+	description "Zelda no Densetsu - Toki no Ocarina GC URA (Japan) (GC)"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!].z64" size 33554432 crc 122FF261 md5 69895C5C78442260F6EAFB2506DC482A sha1 DD14E143C4275861FE93EA79D0C02E36AE8C6C2F )
 )
 
 game (
 	name "Zool - Majuu Tsukai Densetsu (Japan)"
 	description "Zool - Majuu Tsukai Densetsu (Japan)"
 	rom ( name "Zool - Majuu Tsukai Densetsu (Japan).n64" size 12582912 crc 84428431 md5 9795074EF3192F49ADE9ABC9F0BF71D0 sha1 DEF9F1D097CEF5857449827AE2B1291BA346C2A8 flags verified )
+	rom ( name "Zool - Majou Tsukai Densetsu (J) [!].z64" size 12582912 crc 756BA26D md5 692A33B0D7456FC733A81AB83C20382B sha1 2D6EFDB155F6726478AD255E76220A95B559BE40 )
 )


### PR DESCRIPTION
- Added entries for all verified .z64 ROMS in GoodN64v3.14.
- Added entries for some non-verified games, not including modified ROMS(hacks, translations, fixes, etc.)
- Added a comment in the header.

- Did not add any entries for Public Domain ROMS, however, it is on my roadmap.

I don't know what the 1 deletion is, because my GitHub Desktop Client is giving me errors; I plan to look into it soon.