### PR TITLE
Update Nintendo - Nintendo 64.dat

### DIFF
--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -1416,7 +1416,7 @@ game (
 	name "Eikou no Saint Andrews (Japan)"
 	description "Eikou no Saint Andrews (Japan)"
 	rom ( name "Eikou no Saint Andrews (Japan).n64" size 8388608 crc CE55BB19 md5 619D71F98B53696347C497FA5AC0C7B1 sha1 1A313D3B4B11A16B8280B0139A15E47791C8080A flags verified )
-	( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
+	rom ( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
 )
 
 game (
@@ -1430,7 +1430,7 @@ game (
 	name "Elmo's Number Journey (USA)"
 	description "Elmo's Number Journey (USA)"
 	rom ( name "Elmo's Number Journey (USA).n64" size 8388608 crc B7AD0F05 md5 76E81D17D5C88EE40A1C32ED20E17B92 sha1 72419FD0A80CBDEEA635F094D6B0D086EBBB2750 )
-	Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
+	rom ( name "Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
 )
 
 game (
@@ -4180,7 +4180,6 @@ game (
 	description "Pokemon Stadium (Japan)"
 	rom ( name "Pokemon Stadium (Japan).n64" size 16777216 crc 3B2A3F7A md5 7159F1B35AF48EC43236DDFCC2C73B5C sha1 D1796076F855BD2354FFC5019EAEB2C9D7676716 flags verified )
 	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189C md5 C46E087D966A35095DF96799B0B4FFAE sha1 8BC8D2FF7DF25B26BD0C353D2ADFE83E4E3A7A87 )
-	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
@@ -5942,7 +5941,7 @@ game (
 	name "Twisted Edge - Extreme Snowboarding (Europe)"
 	description "Twisted Edge - Extreme Snowboarding (Europe)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (Europe).n64" size 12582912 crc 394BDD25 md5 935894C48C7CEB500299CBEB6ACFA805 sha1 E5BAE263E692121A080308E6FDB2E42D20B1B347 flags verified )
-		rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
 )
 
 game (

--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -2743,7 +2743,7 @@ game (
 game (
 	name "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
 	description "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
-	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo)" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo).n64" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
 	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc DCC110A0 md5 8F281800FBA5DDCB1D2B377731FC0215 sha1 2F0744F2422B0421697A74B305CB1EF27041AB11 )
 )
 


### PR DESCRIPTION
Fixed formatting issues from last pull request:
- Line 1419: Added missing "rom" before ( name... )
- Line 1433: Added missing "rom" before ( name... )
- Line 4183: Removed invalid entry for Pokemon Stadium (France)
- Line 5944: Removed extra indent.