### PR TITLE
[N64] Restore No-Intro N64 DAT and add GoodTools metadat

### DIFF
--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -3,21 +3,18 @@ clrmamepro (
 	description "Nintendo - Nintendo 64"
 	version 20151122-045954
 	comment "no-intro | www.no-intro.org"
-	comment "Merged with GoodN64v3.14 for .z64 support."
 )
 
 game (
 	name "007 - GoldenEye (Europe)"
 	description "007 - GoldenEye (Europe)"
 	rom ( name "007 - GoldenEye (Europe).n64" size 12582912 crc 7425AE2D md5 B477CFB12BB946E522B496AF87ADB220 sha1 63627DBA22BE2B357C0E370E68DC5AF56EEB0A24 flags verified )
-	rom ( name "GoldenEye 007 (E) [!].z64" size 12582912 crc 9EC14AEB md5 CFF69B70A8AD674A0EFE5558765855C9 sha1 167C3C433DEC1F1EB921736F7D53FAC8CB45EE31 )
 )
 
 game (
 	name "007 - GoldenEye (Japan)"
 	description "007 - GoldenEye (Japan)"
 	rom ( name "007 - GoldenEye (Japan).n64" size 12582912 crc C26FED78 md5 369BF90B44B050EF74B4759E29D85EE7 sha1 451B41B63D75677BD42DB89A56679208808FCFD0 flags verified )
-	rom ( name "GoldenEye 007 (J) [!].z64" size 12582912 crc A6BE19DD md5 1880DA358F875C0740D4A6731E110109 sha1 2A5DADE32F7FAD6C73C659D2026994632C1B3174 )
 )
 
 game (
@@ -31,7 +28,6 @@ game (
 	name "007 - The World Is Not Enough (Europe) (En,Fr,De)"
 	description "007 - The World Is Not Enough (Europe) (En,Fr,De)"
 	rom ( name "007 - The World Is Not Enough (Europe) (En,Fr,De).n64" size 33554432 crc 7F030D3A md5 7FDC9151F2BD8F6B6F3CBA3BB93A06A2 sha1 441BDF924566E6475AA49BAB7A199DC06D32A6D5 flags verified )
-	rom ( name "007 - The World is Not Enough (E) (M3) [!].z64" size 33554432 crc 002C3B2A md5 34AB1DEA3111A233A8B5C5679DE22E83 sha1 7FDE668850A7E1A8402AB94BB09538A537A7E38B )
 )
 
 game (
@@ -45,14 +41,12 @@ game (
 	name "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De)"
 	description "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De)"
 	rom ( name "1080 TenEighty Snowboarding (Europe) (En,Ja,Fr,De).n64" size 16777216 crc B0256101 md5 F58B3055A2C642FB2F563F11B6B597EA sha1 DA7BCB78CF78333D7515B77F676FD45473B5B506 flags verified )
-	rom ( name "1080 Snowboarding (E) (M4) [!].z64" size 16777216 crc 75A21679 md5 632C98CF281CDA776E66685B278A4FA6 sha1 637D92B08DBFE7C2F9D5E338835B1FCE5F4A87D0 )
 )
 
 game (
 	name "1080 TenEighty Snowboarding (Japan, USA) (En,Ja)"
 	description "1080 TenEighty Snowboarding (Japan, USA) (En,Ja)"
 	rom ( name "1080 TenEighty Snowboarding (Japan, USA) (En,Ja).n64" size 16777216 crc D1744951 md5 18381C8F37E2B29F5940EEA9B5F96814 sha1 5F837C13A2FB3C8CDFD6FB720BD4A963AB515632 flags verified )
-	rom ( name "1080 Snowboarding (JU) (M2) [!].z64" size 16777216 crc 08FE81C7 md5 FA27089C425DBAB99F19245C5C997613 sha1 79CD1166C365E5809DEC9B62E6D40D6032D5DB3A )
 )
 
 game (
@@ -65,112 +59,96 @@ game (
 	name "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)"
 	description "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)"
 	rom ( name "64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).n64" size 12582912 crc C6400938 md5 6463D5006439CD1BBFB2FBDBD062CCEA sha1 538AE3F3354C3FB96926D759E81CF64B827F2782 flags verified )
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!].z64" size 12582912 crc 67A789E5 md5 EA6A92DE5A221A00814F7448BF6F1B31 sha1 35F7E37C62AE36EB29AAD0D9DA0AE83D57F6D8BD )
 )
 
 game (
 	name "64 Hanafuda - Tenshi no Yakusoku (Japan)"
 	description "64 Hanafuda - Tenshi no Yakusoku (Japan)"
 	rom ( name "64 Hanafuda - Tenshi no Yakusoku (Japan).n64" size 8388608 crc 2B43006C md5 F86BE386603A97B805510C4D5C779E02 sha1 17D93494401AEADAD114D8DB66B85E75B714473C flags verified )
-	rom ( name "64 Hanafuda - Tenshi no Yakusoku (J) [!].z64" size 8388608 crc 60A680E7 md5 66335F4DC6AB27034398BC26F263B897 sha1 36D1B4EF15CDA8139FACE7E118CB34727C30BF29 )
 )
 
 game (
 	name "64 Oozumou (Japan)"
 	description "64 Oozumou (Japan)"
 	rom ( name "64 Oozumou (Japan).n64" size 16777216 crc A6DBF8AE md5 73A97768B685B13E4F8449AB1D3B01CE sha1 DA4C60C6054C374A251A7E5E718F199A37946423 flags verified )
-	rom ( name "64 Oozumou (J) [!].z64" size 16777216 crc 742E31FB md5 2CF9EDB51ADA9DE2AE7AD9FD5ACC5580 sha1 E77FE9F2C32870EB7ACBCF6A13D26DD022BAFE5D )
 )
 
 game (
 	name "64 Oozumou 2 (Japan)"
 	description "64 Oozumou 2 (Japan)"
 	rom ( name "64 Oozumou 2 (Japan).n64" size 16777216 crc 3CD5E271 md5 3573F819B8A97453EBB64ABDD67BCD88 sha1 1DAA89EC3F5E63E131973BAB03166E4F7FB60EE9 flags verified )
-	rom ( name "64 Oozumou 2 (J) [!].z64" size 16777216 crc C1BC6FD8 md5 F7C796371E77E0A6FBD02EB866341952 sha1 6D524E0D0DD610DFB0C3BCCAA88EF1E7AECEAB98 )
 )
 
 game (
 	name "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
 	description "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
 	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (Japan).n64" size 12582912 crc 34BBB95D md5 7F197499F8D11D2A1941F77ED3A427A2 sha1 769CB7028262871611ACB8CD5788D477E7F6C12F flags verified )
-	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!].z64" size 12582912 crc DCA7F4EB md5 6B947F654775CF5DACD1E5D53D577DA7 sha1 B5CF2C98D60AD8E6FAD450681F9CEFD63F4E5939 )
 )
 
 game (
 	name "Action Replay Pro 64 (Europe) (v3.0) (Unl)"
 	description "Action Replay Pro 64 (Europe) (v3.0) (Unl)"
 	rom ( name "Action Replay Pro 64 (Europe) (v3.0) (Unl).n64" size 262144 crc C992DFB4 md5 35BA407EA9E4EF7C0ACE8B4F58BEEC41 sha1 D5E4E8C875D6BDA0AFAFB1B2513B16B1CB88DFC1 )
-	rom ( name "Action Replay Pro 64 V3.0 (Unl).z64" size 262144 crc C992DFB4 md5 35BA407EA9E4EF7C0ACE8B4F58BEEC41 sha1 D5E4E8C875D6BDA0AFAFB1B2513B16B1CB88DFC1 )
 )
 
 game (
 	name "Action Replay Pro 64 (Europe) (v3.3) (Unl)"
 	description "Action Replay Pro 64 (Europe) (v3.3) (Unl)"
 	rom ( name "Action Replay Pro 64 (Europe) (v3.3) (Unl).n64" size 262144 crc 9FBABFDA md5 67AFA5DF80A5CFC91FCE1DC918EA0A4F sha1 C3426114F5DA1FB7ABDE15A766D362698AD07166 )
-	rom ( name "Action Replay Pro 64 V3.3 (Unl).z64" size 262144 crc 9FBABFDA md5 67AFA5DF80A5CFC91FCE1DC918EA0A4F sha1 C3426114F5DA1FB7ABDE15A766D362698AD07166 )
 )
 
 game (
 	name "AeroFighters Assault (Europe) (En,Fr,De)"
 	description "AeroFighters Assault (Europe) (En,Fr,De)"
 	rom ( name "AeroFighters Assault (Europe) (En,Fr,De).n64" size 12582912 crc E493E46C md5 35C77035BFF9E20C3EE805CE5583E6B5 sha1 7849993E61D690DECE9C5524CE2831D7B2340F34 flags verified )
-	rom ( name "AeroFighters Assault (E) (M3) [!].z64" size 12582912 crc 6A2B08DA md5 7558E3DA7225712936D3BA3DCE210C36 sha1 F1057A278A06DCFBC7EB8B6B7679AB879255F977 )
 )
 
 game (
 	name "AeroFighters Assault (USA)"
 	description "AeroFighters Assault (USA)"
 	rom ( name "AeroFighters Assault (USA).n64" size 8388608 crc B08EF0B9 md5 ADEE8C02A192470A3FE09418D7EA7AEF sha1 DE542F002E4F08CFDAC19DEC57F5BBAEA6EDEAFE )
-	rom ( name "AeroFighters Assault (U) [!].z64" size 8388608 crc 4370D7E3 md5 79FB6E2452AF077C5EF1DDE5FC810F04 sha1 6742F67D7D2639072E186D240237BE1C662CB25A )
 )
 
 game (
 	name "AeroGauge (Europe) (En,Fr,De)"
 	description "AeroGauge (Europe) (En,Fr,De)"
 	rom ( name "AeroGauge (Europe) (En,Fr,De).n64" size 8388608 crc D8CA6C8E md5 45AA24B9C09F007590CEF795EBB67A94 sha1 1645CCF3C77D41B70BA7F3A6C7155EC819728CF0 flags verified )
-	rom ( name "AeroGauge (E) (M3) [!].z64" size 8388608 crc 040B0046 md5 05056045447BF1FBA8F9878A7F6009F3 sha1 38AADD684AD7662B02BBC29EDDDADE9C9E16A3C0 )
 )
 
 game (
 	name "AeroGauge (Japan) (Demo) (Kiosk)"
 	description "AeroGauge (Japan) (Demo) (Kiosk)"
 	rom ( name "AeroGauge (Japan) (Demo) (Kiosk).n64" size 8388608 crc 4BA2A495 md5 A9E3A990BE71328800426FF716067E7D sha1 E6BB91D367911FDC7E858A7614560FFCE1758AEC flags verified )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [!].z64" size 8388608 crc 6EE3B932 md5 E970AF3DE25BB5AE1154010E26AF776F sha1 0253C33355986DDDA18A7A72B81B91DDC1BED978 )
 )
 
 game (
 	name "AeroGauge (Japan) (Rev A)"
 	description "AeroGauge (Japan) (Rev A)"
 	rom ( name "AeroGauge (Japan) (Rev A).n64" size 8388608 crc 1A5F6C19 md5 D92E3E7B6DD2DAF31D112A12315CB801 sha1 DFB171CAA0091BD36526641D252839C0E72B616C flags verified )
-	rom ( name "AeroGauge (J) (V1.1) [!].z64" size 8388608 crc F322B641 md5 0620C2D134A0430F4AFA208FFEDA67B8 sha1 F7C2D4B0E77CC02DEAFE2E5FD95152B7E8BF86CF )
 )
 
 game (
 	name "AeroGauge (USA)"
 	description "AeroGauge (USA)"
 	rom ( name "AeroGauge (USA).n64" size 8388608 crc 04038CB8 md5 4766856942945EAA9CF521937BE5FEE3 sha1 204DF59CBD065E39CADCCC23A68E08AE212546D0 )
-	rom ( name "AeroGauge (U) [!].z64" size 8388608 crc 198B9E0E md5 72C7FFCEA6C1430616867616F5E9D51A sha1 77626171C35FB1A4DFEBB0927280897F362225ED )
 )
 
 game (
 	name "AI Shougi 3 (Japan)"
 	description "AI Shougi 3 (Japan)"
 	rom ( name "AI Shougi 3 (Japan).n64" size 8388608 crc 43022243 md5 9B469746EB02588F9A2273A6BDEC33C9 sha1 0ACF1F83BA14DBE2EDBAE454EEA04CAF2CC0030A flags verified )
-	rom ( name "AI Shougi 3 (J) [!].z64" size 8388608 crc 86DF90E6 md5 4A5C509A20DB7A429DC1DD4E219AD4A2 sha1 8D87D888E8916C4C148DAD32EE0519DD297D1FA6 )
 )
 
 game (
 	name "Aidyn Chronicles - The First Mage (Europe)"
 	description "Aidyn Chronicles - The First Mage (Europe)"
 	rom ( name "Aidyn Chronicles - The First Mage (Europe).n64" size 33554432 crc 9DC07FC0 md5 13B3B8AC219F8A57783BC1779DF02901 sha1 DD8867A3B33C897FA9E7E1742C4BC0DF1207CFA8 flags verified )
-	rom ( name "Aidyn Chronicles - The First Mage (E) [!].z64" size 33554432 crc BE7E230D md5 54D0A39123C15F74AABB1ECC24D4D6A0 sha1 E3A1E26F4C10A6767612D1A8462689E86D09DC0B )
 )
 
 game (
 	name "Aidyn Chronicles - The First Mage (USA)"
 	description "Aidyn Chronicles - The First Mage (USA)"
 	rom ( name "Aidyn Chronicles - The First Mage (USA).n64" size 33554432 crc 8DA62304 md5 08D66E903C0DC4EB9736B0DD853FAB51 sha1 32EF42E143B74CB957A88DDB9249AF13B15B45E7 )
-	rom ( name "Aidyn Chronicles - The First Mage (U) [!].z64" size 33554432 crc B1F18186 md5 AF149336B3DDB899598E7BE8740D7DC6 sha1 47AE795A2B12783A13E2B8D03439CE9A39FC826C )
 )
 
 game (
@@ -183,204 +161,174 @@ game (
 	name "Air Boarder 64 (Europe)"
 	description "Air Boarder 64 (Europe)"
 	rom ( name "Air Boarder 64 (Europe).n64" size 8388608 crc 92659837 md5 2B257F7989946666032DF995273746FE sha1 E0A148AE2193E533947F52BA4AB029C2CD8B34D3 flags verified )
-	rom ( name "Airboarder 64 (E) [!].z64" size 8388608 crc C14D45AC md5 E8891F8F498A615A6CBAF75B7DDC9FA6 sha1 2171FE2C0A9253CBA56828F24A5E6153726C1516 )
 )
 
 game (
 	name "Air Boarder 64 (Japan)"
 	description "Air Boarder 64 (Japan)"
 	rom ( name "Air Boarder 64 (Japan).n64" size 8388608 crc 79F2DF14 md5 EAD11D91FA8975AE8C3D2EFEB227297A sha1 0CE4D812125F7C153795BBE3835CDA6C29105724 flags verified )
-	rom ( name "Airboarder 64 (J) [!].z64" size 8388608 crc 58FCB771 md5 CCEE2FCF38DC2200128D75D15DB53283 sha1 4A70C9CA027ECC8D05337993204E1EF76F5F0AC9 )
 )
 
 game (
 	name "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)"
 	description "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)"
 	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).n64" size 12582912 crc CA79D5A0 md5 20971504B49F98AD0CC15C666EE1E30F sha1 78629A527B6EC02825487E3C800AA81178768039 flags verified )
-	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!].z64" size 12582912 crc E349CFEC md5 256A1CB23F9E1A2762A7A171417B5D68 sha1 AA70348968589E6BA6E7091CA115FB505099CD97 )
 )
 
 game (
 	name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)"
 	description "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)"
 	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).n64" size 16777216 crc 420CE37B md5 7CB2782769F9B834B5948D316EF83CD6 sha1 10B15A7CEB6D56720DDD7755DAC6102832407110 flags verified )
-	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!].z64" size 16777216 crc FF009C21 md5 47EA239717C4D225C9D0E9FD37B9FCB3 sha1 50439ACB5784BEA3A4BBBA5188C2AEAA1442099D )
 )
 
 game (
 	name "All Star Tennis '99 (Europe) (En,Fr,De,Es,It)"
 	description "All Star Tennis '99 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "All Star Tennis '99 (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc E718347D md5 E302824280FA6AF35FCC9BA079ABFBCD sha1 85D2B8DED8D2A6D9BBF1CF80C9A0422FB338FD63 flags verified )
-	rom ( name "All Star Tennis '99 (E) (M5) [!].z64" size 8388608 crc 996E845F md5 E3F4C868917A12BD5E84D94D1C260C7D sha1 09DDBD45F4962735DEF65399B5792E3BB5BD7D3C )
 )
 
 game (
 	name "All Star Tennis 99 (USA)"
 	description "All Star Tennis 99 (USA)"
 	rom ( name "All Star Tennis 99 (USA).n64" size 8388608 crc 7326E6C9 md5 1714F404F1AD75EC85D237E8D4D2362C sha1 2655AF06374C3CA9F8A40A76F7F9FC6E1044B576 )
-	rom ( name "All Star Tennis '99 (U) [!].z64" size 8388608 crc A7DCF638 md5 AFC3DC9BB737D81903F6CE4875B63AE9 sha1 3A6446409D63DCAC0D5C860A3E2888A378474887 )
 )
 
 game (
 	name "All-Star Baseball 2000 (Europe)"
 	description "All-Star Baseball 2000 (Europe)"
 	rom ( name "All-Star Baseball 2000 (Europe).n64" size 16777216 crc 15F18CAE md5 CBD9E7E9BA8204029B52B972836668AC sha1 EFF8CE1B3EFD9C0ADA98838715C10633F0E6F4F9 flags verified )
-	rom ( name "All-Star Baseball 2000 (E) [!].z64" size 16777216 crc D3C29AA4 md5 90448C4175EE9D0247674474DCABDFED sha1 C8F41A27B9509DA422B7ECF32F64DF3E213194EA )
 )
 
 game (
 	name "All-Star Baseball 2000 (USA)"
 	description "All-Star Baseball 2000 (USA)"
 	rom ( name "All-Star Baseball 2000 (USA).n64" size 16777216 crc 15063EAC md5 984528194CA782D74A92CB8C0EA42358 sha1 C0D574AF5C3523A4A804182B4D6465212FD9EE29 )
-	rom ( name "All-Star Baseball 2000 (U) [!].z64" size 16777216 crc 69E88471 md5 AADA358CE97F06C4DF5BF55987268844 sha1 4256A23902E22E6E8291F1931F8DE4B2716FE480 )
 )
 
 game (
 	name "All-Star Baseball 2001 (USA)"
 	description "All-Star Baseball 2001 (USA)"
 	rom ( name "All-Star Baseball 2001 (USA).n64" size 16777216 crc 3E8BE0E0 md5 D00D67475255A3043394C23B7CF978A3 sha1 353AD679666287988A0E645851EE01EFF2048449 )
-	rom ( name "All-Star Baseball 2001 (U) [!].z64" size 16777216 crc 4D659E85 md5 6E01B8D425AE74EF5A0F875C700A3B18 sha1 4F1B8635322190BB3D0C6FC7D3BA844941F05574 )
 )
 
 game (
 	name "All-Star Baseball 99 (Europe)"
 	description "All-Star Baseball 99 (Europe)"
 	rom ( name "All-Star Baseball 99 (Europe).n64" size 12582912 crc CECD29A6 md5 D6A5D897FEC2605E3366615CAEF19EB2 sha1 47272C40A13E42E6400C6E1221173F6BD07205BD flags verified )
-	rom ( name "All-Star Baseball '99 (E) [!].z64" size 12582912 crc D0DE3584 md5 ED5F1E12DA36DBEC8A0A24ED98D4AED5 sha1 3AC0D13F2260797DABF99CFEDABF7E3676C5B2E2 )
 )
 
 game (
 	name "All-Star Baseball 99 (USA)"
 	description "All-Star Baseball 99 (USA)"
 	rom ( name "All-Star Baseball 99 (USA).n64" size 12582912 crc 82B7E47D md5 9B9631FD0CD2B7C434057902B78E5A03 sha1 6D01A4986311A4486B4B0BE029658E8DF63F4EE4 )
-	rom ( name "All-Star Baseball '99 (U) [!].z64" size 12582912 crc 6D25B36F md5 78551D23F230B58B9F449CDB4A285761 sha1 AA576624F2A66034CB0D6E621BA16A0D3BEACA3A )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (Europe)"
 	description "Armorines - Project S.W.A.R.M. (Europe)"
 	rom ( name "Armorines - Project S.W.A.R.M. (Europe).n64" size 16777216 crc 33332C57 md5 3F2A78A8E70C6392B73DD2491DB2B6E4 sha1 38E0CAFCBECDDD2F2CF46F1CDBB0BE6F8582402F flags verified )
-	rom ( name "Armorines - Project S.W.A.R.M. (E) [!].z64" size 16777216 crc 600BC49E md5 0C2CBAFEC6F184AD39EF29B2B5E0F44A sha1 66F2B431D2275B2563692BFD053D4C0118E0E0C2 )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (Germany)"
 	description "Armorines - Project S.W.A.R.M. (Germany)"
 	rom ( name "Armorines - Project S.W.A.R.M. (Germany).n64" size 16777216 crc 43A6829D md5 E159DA0F67964F136E793872B79956D3 sha1 3479266909BCBFA928F67E967BDAE789C20895E1 )
-	rom ( name "Armorines - Project S.W.A.R.M. (G) [!].z64" size 16777216 crc 5BAB9100 md5 2BC48B3E6F61896B9BC7BEF5205CC49C sha1 68F9DDA2863F7625A36F115419956DD9F249AFE6 )
 )
 
 game (
 	name "Armorines - Project S.W.A.R.M. (USA)"
 	description "Armorines - Project S.W.A.R.M. (USA)"
 	rom ( name "Armorines - Project S.W.A.R.M. (USA).n64" size 16777216 crc 950985F6 md5 1655F81B5987234481EA96BB9E964D38 sha1 A9C1319C582668B9AFC7807DCD59F68D09B5317E )
-	rom ( name "Armorines - Project S.W.A.R.M. (U) [!].z64" size 16777216 crc 630A19E2 md5 6E6E7A703C131ADADDF4175E9037A2EB sha1 D9F55ACF77A54EEB7F62577AA5711769EBEADDE3 )
-	
 )
 
 game (
 	name "Army Men - Air Combat (USA)"
 	description "Army Men - Air Combat (USA)"
 	rom ( name "Army Men - Air Combat (USA).n64" size 8388608 crc 2355E4F3 md5 7E57B116C3D0740B7B8F873BD007F4DC sha1 52F4722CBF3DED8E55A62471FBC5A6CF07F4FD5D )
-	rom ( name "Army Men - Air Combat (U) [!].z64" size 8388608 crc 1952CC87 md5 755DF7F57EDF87706D4C80FF15883312 sha1 EB9BACB12EB6665BE9936A3E1DFD6D57B2EAABDB )
 )
 
 game (
 	name "Army Men - Sarge's Heroes (Europe) (En,Fr,De)"
 	description "Army Men - Sarge's Heroes (Europe) (En,Fr,De)"
 	rom ( name "Army Men - Sarge's Heroes (Europe) (En,Fr,De).n64" size 8388608 crc B2B54CC1 md5 06B9E71B0ACC83F8C75BEFD2EC602B52 sha1 C6470921EA8B5D3565383D94E98B6FF8B39F7C14 flags verified )
-	rom ( name "Army Men - Sarge's Heroes (E) (M3) [!].z64" size 8388608 crc E79048E2 md5 53E2872612760133AB7B2CC2E22B847C sha1 00E594FA64DA61C2AD3138A31A22B9854BB3FAFA )
 )
 
 game (
 	name "Army Men - Sarge's Heroes (USA)"
 	description "Army Men - Sarge's Heroes (USA)"
 	rom ( name "Army Men - Sarge's Heroes (USA).n64" size 8388608 crc 97BF6DB2 md5 7C4EA4747805499059AAD17C209A6E77 sha1 82F8D41D16C9161FF21776A8B2531CB11857F410 )
-	rom ( name "Army Men - Sarge's Heroes (U) [!].z64" size 8388608 crc 2FE786F6 md5 B8085C2EDB1C6D23E52ED8C06D92B4F8 sha1 1824380911579424E50042D45AEF4851F7AB25A7 )
 )
 
 game (
 	name "Army Men - Sarge's Heroes 2 (USA)"
 	description "Army Men - Sarge's Heroes 2 (USA)"
 	rom ( name "Army Men - Sarge's Heroes 2 (USA).n64" size 8388608 crc 3E9D1C51 md5 F85EC17F51F076D9D0F315EDAE6C192B sha1 FF1A799C6C0AEC45EFA7E0F8D107D91E1BBA5EEA )
-	rom ( name "Army Men - Sarge's Heroes 2 (U) [!].z64" size 8388608 crc 79A71608 md5 6EEA5C4A6256092ED8F9BA8861C689C6 sha1 F32B6DE2F87928378F26CA17B68B27D87FDEFCE1 )
 )
 
 game (
 	name "Asteroids Hyper 64 (USA)"
 	description "Asteroids Hyper 64 (USA)"
 	rom ( name "Asteroids Hyper 64 (USA).n64" size 4194304 crc FB982B44 md5 257601175E6C41604BD5B9AB93A3EC75 sha1 6E1C4AF8F765DEE69B5308EC5A0B20BC7FB8D862 )
-	rom ( name "Asteroids Hyper 64 (U) [!].z64" size 4194304 crc F5CE3D91 md5 874C7B7B365D2C20AAA1A0C90C93F9B8 sha1 329F4D560B0BA7DA622EDD9B84523E86E265FFFE )
 )
 
 game (
 	name "Automobili Lamborghini (Europe)"
 	description "Automobili Lamborghini (Europe)"
 	rom ( name "Automobili Lamborghini (Europe).n64" size 4194304 crc 210F594E md5 874C42768C21E33A2E83305AD70120F1 sha1 3B03236C455C2FBFE76E13F0F44EFB502B30ACEA flags verified )
-	rom ( name "Automobili Lamborghini (E) [!].z64" size 4194304 crc 3BAF58D5 md5 7853F02DC66A35BC8C2BC33D03B8F0CA sha1 513C9511539BF2361FF20EE1F19DC03F618B5214 )
 )
 
 game (
 	name "Automobili Lamborghini (USA)"
 	description "Automobili Lamborghini (USA)"
 	rom ( name "Automobili Lamborghini (USA).n64" size 4194304 crc 17932C62 md5 77C7E53A78C68EB1C254D17383DD7293 sha1 022CDE34610AF501687BAF6B33B76F9B6841044B )
-	rom ( name "Automobili Lamborghini (U) [!].z64" size 4194304 crc A4374EAC md5 EC39579F066A9714FF030D07DEC3C9D3 sha1 78B36B48040426478011CAEF5E11884AF2E80375 )
 )
 
 game (
 	name "Baku Bomber Man (Japan)"
 	description "Baku Bomber Man (Japan)"
 	rom ( name "Baku Bomber Man (Japan).n64" size 8388608 crc B9FAA3E4 md5 59174C50BC837A9C2C4BABC05193FC28 sha1 57B5B49E61AFB44A368820997706C752545C677F flags verified )
-	rom ( name "Baku Bomberman (J) [!].z64" size 8388608 crc 22F54A52 md5 8183688A4B7D0A390496B5655BCD252E sha1 4813B147D552F72FDB0B306469BF9AA0F820FD5B )
 )
 
 game (
 	name "Baku Bomber Man 2 (Japan)"
 	description "Baku Bomber Man 2 (Japan)"
 	rom ( name "Baku Bomber Man 2 (Japan).n64" size 16777216 crc 850675CC md5 89C5450B3286CE62A6D93FEA74633848 sha1 C6188F3217E28CF820040B6FB1F57DB655995B38 flags verified )
-	rom ( name "Baku Bomberman 2 (J) [!].z64" size 16777216 crc 86BBC278 md5 CA956015B6820DCFF1C814F3532E18B1 sha1 179CAB7426755F14BD3F4999F3789EB6D7AF64C4 )
 )
 
 game (
 	name "Bakuretsu Muteki Bangaioh (Japan)"
 	description "Bakuretsu Muteki Bangaioh (Japan)"
 	rom ( name "Bakuretsu Muteki Bangaioh (Japan).n64" size 12582912 crc 2A8CE2E1 md5 EAED8A95D38B6D962C0440EDCD46A849 sha1 38C6653A0C4E45F25F33C97CCD2A7F5AF0B57784 flags verified )
-	rom ( name "Bakuretsu Muteki Bangai-O (J) [!].z64" size 12582912 crc 6AB7FEC6 md5 8107825AC2A522057422463ED81E276B sha1 2DBFE78F97B8D6E1A33B73D244BE831D18B0491E )
 )
 
 game (
 	name "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)"
 	description "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)"
 	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).n64" size 12582912 crc 5FD42464 md5 925FD223A6284F0CDFDE458E88BFC603 sha1 353B62279F67634030CC66F43C4B82E516A6AF28 flags verified )
-	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!].z64" size 12582912 crc EF8C2F34 md5 09FD63AFA1156405E618752FC583DF93 sha1 28E6D11F6F48C86A9B7C112C672109E1C2D7E5D0 )
 )
 
 game (
 	name "Banjo to Kazooie no Daibouken (Japan)"
 	description "Banjo to Kazooie no Daibouken (Japan)"
 	rom ( name "Banjo to Kazooie no Daibouken (Japan).n64" size 16777216 crc 11AD432C md5 6846FD87C7CE9063A4F25CD6A253C309 sha1 9379962839A6638F8DDCFB7D917216EC40A83EDB flags verified )
-	rom ( name "Banjo to Kazooie no Daibouken (J) [!].z64" size 16777216 crc 8F7C9324 md5 3D3855A86FD5A1B4D30BEB0F5A4A85AF sha1 90726D7E7CD5BF6CDFD38F45C9ACBF4D45BD9FD8 )
 )
 
 game (
 	name "Banjo to Kazooie no Daibouken 2 (Japan)"
 	description "Banjo to Kazooie no Daibouken 2 (Japan)"
 	rom ( name "Banjo to Kazooie no Daibouken 2 (Japan).n64" size 33554432 crc 8A3D8792 md5 085405CFDF2CBA66BAF21AD07C73CDD6 sha1 A6C8D06AA6462C1479639786EDA455CD60FF6AA3 flags verified )
-	rom ( name "Banjo to Kazooie no Daibouken 2 (J) [!].z64" size 33554432 crc 258C58D0 md5 715A8816F30FA24B8D174DC5CB6F25A9 sha1 5A5172383037D171F121790959962703BE1F373C )
 )
 
 game (
 	name "Banjo-Kazooie (Europe) (En,Fr,De)"
 	description "Banjo-Kazooie (Europe) (En,Fr,De)"
 	rom ( name "Banjo-Kazooie (Europe) (En,Fr,De).n64" size 16777216 crc 4AF7C16B md5 CEECE9F299B2870C9A0D545018F1C43F sha1 908469A0B4F4B7473E85D3C981520F32CF3E3C70 flags verified )
-	rom ( name "Banjo-Kazooie (E) (M3) [!].z64" size 16777216 crc 525899C9 md5 06A43BACF5C0687F596DF9B018CA6D7F sha1 BB359A75941DF74BF7290212C89FBC6E2C5601FE )
 )
 
 game (
 	name "Banjo-Kazooie (USA)"
 	description "Banjo-Kazooie (USA)"
 	rom ( name "Banjo-Kazooie (USA).n64" size 16777216 crc 4FD43199 md5 81E326E2ABBD65EC4C4C20F4364F7E48 sha1 0CA5E28494B7D99E22ED27DFC914EC5B391CDB6B flags verified )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [!].z64" size 16777216 crc AD429961 md5 B29599651A13F681C9923D69354BF4A3 sha1 1FE1632098865F639E22C11B9A81EE8F29C75D7A )
 )
 
 game (
@@ -394,14 +342,12 @@ game (
 	name "Banjo-Tooie (Australia)"
 	description "Banjo-Tooie (Australia)"
 	rom ( name "Banjo-Tooie (Australia).n64" size 33554432 crc 38EC4A6E md5 B943623A53F427B53C48316E722ED2E1 sha1 F3C391F7D04F9CBCDDAC1CF03B7B6C78D844F7B0 flags verified )
-	rom ( name "Banjo-Tooie (A) [!].z64" size 33554432 crc 2736266A md5 61B5C5C3E5E1A81E5D37072C01B39B76 sha1 4CA2D332F6E6B018777AFC6A8B7880B38B6DFB79 )
 )
 
 game (
 	name "Banjo-Tooie (Europe) (En,Fr,De,Es)"
 	description "Banjo-Tooie (Europe) (En,Fr,De,Es)"
 	rom ( name "Banjo-Tooie (Europe) (En,Fr,De,Es).n64" size 33554432 crc 5EE620FB md5 3A585EF93B327D47CB0095EEA98D766A sha1 1E2CA48F786983C487A8D0E17C496FCCF5411DFE flags verified )
-	rom ( name "Banjo-Tooie (E) (M4) [!].z64" size 33554432 crc 1EC12F5A md5 8B2E56F18421A67BCA861427453A1E19 sha1 93BF2FAC1387320AD07251CB4B64FD36BAC1D7A6 )
 )
 
 game (
@@ -415,14 +361,12 @@ game (
 	name "Bass Rush - ECOGEAR PowerWorm Championship (Japan)"
 	description "Bass Rush - ECOGEAR PowerWorm Championship (Japan)"
 	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (Japan).n64" size 33554432 crc 0E388FAE md5 B7939B2EA15C92EDB33971FDBE236D6C sha1 06D9DA5DFD1E16ED56FC2BD028FA3642B4905820 flags verified )
-	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!].z64" size 33554432 crc 383B86EF md5 2C618F6C69C3B4803F08762A03835139 sha1 1718C9048CB7849A59D48138A058B20BF191EBF6 )
 )
 
 game (
 	name "Bassmasters 2000 (USA)"
 	description "Bassmasters 2000 (USA)"
 	rom ( name "Bassmasters 2000 (USA).n64" size 12582912 crc 8B7BD07E md5 F4AC3AF45A448B9F0D5D38AF14A285B9 sha1 747B3B6C49F27E3381D91E9DF59D01DBEE769A58 )
-	rom ( name "Bassmasters 2000 (U) [!].z64" size 12582912 crc 6B09092E md5 930C7F6E5863471DDE1816D28A10EB88 sha1 946B3E08A1A4DE4F917AD547BB24F533B737F712 )
 )
 
 game (
@@ -436,7 +380,6 @@ game (
 	name "Batman of the Future - Return of the Joker (Europe) (En,Fr,De)"
 	description "Batman of the Future - Return of the Joker (Europe) (En,Fr,De)"
 	rom ( name "Batman of the Future - Return of the Joker (Europe) (En,Fr,De).n64" size 4194304 crc 86AA921C md5 7AD96BE5F289276B6A9D7163B19D2BC4 sha1 16977E84FDA45BBDE7882A73A9685426FD4B458C flags verified )
-	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [!].z64" size 4194304 crc 82A4BB8A md5 A5EE8A6C34863E3D0EB8C06AE8668B30 sha1 3954131395F98E605072BEA11CC85842DA58F754 )
 )
 
 game (
@@ -450,7 +393,6 @@ game (
 	name "BattleTanx - Global Assault (Europe) (En,Fr,De)"
 	description "BattleTanx - Global Assault (Europe) (En,Fr,De)"
 	rom ( name "BattleTanx - Global Assault (Europe) (En,Fr,De).n64" size 8388608 crc EC02C5AD md5 2589AE458EBFC86100DC039CD0854CFA sha1 EC346910B30E5C5C91CF4394633D226EA604BB57 flags verified )
-	rom ( name "BattleTanx - Global Assault (E) (M3) [!].z64" size 8388608 crc C99C6030 md5 D6E667FE10AFE8F7116888EFDE98AE0E sha1 AEFADE7A37A4716DDC82A6B67BA085CBF7C27259 )
 )
 
 game (
@@ -464,70 +406,60 @@ game (
 	name "Battlezone - Rise of the Black Dogs (USA)"
 	description "Battlezone - Rise of the Black Dogs (USA)"
 	rom ( name "Battlezone - Rise of the Black Dogs (USA).n64" size 16777216 crc 18CCCCFD md5 69CC951520CCEE8C99F28E086BA6BAAA sha1 CDD1D1DEC9763CE6B7B1A70668EFFCEAD0A185A0 )
-	rom ( name "Battlezone - Rise of the Black Dogs (U) [!].z64" size 16777216 crc 736F9D5C md5 266C0989ED0929DF499389954779EA97 sha1 85B4FEBBE6FBD1ECFC883905E43E68E7188C44F9 )
 )
 
 game (
 	name "Beetle Adventure Racing! (Europe) (En,Fr,De)"
 	description "Beetle Adventure Racing! (Europe) (En,Fr,De)"
 	rom ( name "Beetle Adventure Racing! (Europe) (En,Fr,De).n64" size 16777216 crc E6F43F48 md5 939BDAF220EDDCEFC8BE78A5B3B98744 sha1 B185ED71668F9BD4F6AEEF5EDB31E03C1A119AE0 flags verified )
-	rom ( name "Beetle Adventure Racing! (E) (M3) [!].z64" size 16777216 crc 5B6C6E4C md5 A94135D163E6091C960ADC918C1FB8A7 sha1 85B3B95D587D2646F781B04CF5239804D105685A )
 )
 
 game (
 	name "Beetle Adventure Racing! (Japan)"
 	description "Beetle Adventure Racing! (Japan)"
 	rom ( name "Beetle Adventure Racing! (Japan).n64" size 16777216 crc 4246ACD8 md5 B0C2A92CB944332571EC482F2010D470 sha1 196B70D4FD0BD361BAABAEE9719A5A3AA5A7F48F flags verified )
-	rom ( name "Beetle Adventure Racing! (J) [!].z64" size 16777216 crc 49E75825 md5 5FFD43089B7334072B2B74421618D973 sha1 D6E943A8733D3C09795F4BE24B75C7FB0C30A27D )
 )
 
 game (
 	name "Beetle Adventure Racing! (USA) (En,Fr,De)"
 	description "Beetle Adventure Racing! (USA) (En,Fr,De)"
 	rom ( name "Beetle Adventure Racing! (USA) (En,Fr,De).n64" size 16777216 crc E3517FD8 md5 5559A7AAE79E960851CE754F873280CB sha1 52171429B655825A02864A94499816187D4014DC )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [!].z64" size 16777216 crc F4A97C73 md5 CF97C336479DDBF1217E4DDE89D9D2D3 sha1 E5AB4D226C08D22F68A2EDCC48870203E67454B8 )
 )
 
 game (
 	name "Big Mountain 2000 (USA)"
 	description "Big Mountain 2000 (USA)"
 	rom ( name "Big Mountain 2000 (USA).n64" size 12582912 crc FF44020C md5 E0B3354C7205DB2D67C1FA23462F6326 sha1 CDC88D4FFA5883D34FFC426C552DF200C4C65023 )
-	rom ( name "Big Mountain 2000 (U) [!].z64" size 12582912 crc 3AC924BC md5 BF6780E2982C16D4A4FDB553BE8F9226 sha1 E28F3EBFB7BC706CCE639FC1874243E1D4995D1D )
 )
 
 game (
 	name "Bio F.R.E.A.K.S. (Europe)"
 	description "Bio F.R.E.A.K.S. (Europe)"
 	rom ( name "Bio F.R.E.A.K.S. (Europe).n64" size 16777216 crc 3EC67AD8 md5 58C15C1E507950273AE926F350C9292C sha1 EF5546F288B39CA628907C05F8CBAADA9E895026 flags verified )
-	rom ( name "Bio F.R.E.A.K.S. (E) [!].z64" size 16777216 crc 2C4EB906 md5 42672BA5E98CD21D7F3E3745E69038DD sha1 8A85EC7D68954A36569F28F6A26981D6F283FD6D )
 )
 
 game (
 	name "Bio F.R.E.A.K.S. (USA)"
 	description "Bio F.R.E.A.K.S. (USA)"
 	rom ( name "Bio F.R.E.A.K.S. (USA).n64" size 16777216 crc 52283865 md5 8B112F230A6E1E185F10F9574D676EF8 sha1 7D0A70C4437FE985AAF4FAF82CA1DC011B8ED4E1 )
-	rom ( name "Bio F.R.E.A.K.S. (U) [!].z64" size 16777216 crc DFBF448C md5 B90AB8F7605D971CC7A6D9BA5E67D1AF sha1 E20E9124480B559AA7148412C8993804501E180D )
 )
 
 game (
 	name "Biohazard 2 (Japan)"
 	description "Biohazard 2 (Japan)"
 	rom ( name "Biohazard 2 (Japan).n64" size 67108864 crc 31A3B913 md5 13B6F12B9F8CB0CB8C708C3132F7A372 sha1 8651451A9363DA0B6783DEE6BB99EB077B318BD5 flags verified )
-	rom ( name "Biohazard 2 (J) [!].z64" size 67108864 crc 4F9D569F md5 F77D70959222276491222F31EBFF3BF1 sha1 7492139F237C547EF32955C7CC6B9A5E6DCAA55D )
 )
 
 game (
 	name "Blast Corps (Europe) (En,De)"
 	description "Blast Corps (Europe) (En,De)"
 	rom ( name "Blast Corps (Europe) (En,De).n64" size 8388608 crc 2FF810CF md5 BD819802309E8E65CCC9F8EAB8361223 sha1 9D42BE8A947E64D4862D8A7C1FAE57E10C2257EE flags verified )
-	rom ( name "Blast Corps (E) (M2) [!].z64" size 8388608 crc 4C820695 MD5 889D4D337AD11CE94357511C725EAB6A SHA1 460212600F8B9F0DA95219C4C7330F2E626D9A7E )
 )
 
 game (
 	name "Blast Corps (USA)"
 	description "Blast Corps (USA)"
 	rom ( name "Blast Corps (USA).n64" size 8388608 crc 22CA221D md5 E579AA236D12725597DD4ED8C3E9350B sha1 A6AD7FFF57B10B782CEDE51D4558E19AD134F019 )
-	rom ( name "Blast Corps (U) (V1.0) [!].z64" size 8388608 crc 767A95E7 md5 A8DFDFF49144627492DA9B0B65B91845 sha1 185A6EF7BA1ADB243278062C81A7D4E119BDA58C )
 )
 
 game (
@@ -541,28 +473,24 @@ game (
 	name "Blastdozer (Japan)"
 	description "Blastdozer (Japan)"
 	rom ( name "Blastdozer (Japan).n64" size 8388608 crc 4605759E md5 1691A0124A175F45954CC70C7DD98297 sha1 68C6D95AF29C647B64D5DAD90C02980B772D5FAF flags verified )
-	rom ( name "Blast Dozer (J) [!].z64" size 8388608 crc 081A3641 md5 16B82D53D7F038A8FE67A78027720516 sha1 B147FDBEB661C89107C440B00DC4810508F58636 )
 )
 
 game (
 	name "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 56507793 md5 37D5409EBB172E00CEFAA8B1F14C39B2 sha1 A3E21EC8BF3DE87D257F254AB68879981EAED4A9 flags verified )
-	rom ( name "Blues Brothers 2000 (E) (M6) [!].z64" size 16777216 crc 8FB41658 md5 31B4A8ED52B48E756B344C9F22736E50 sha1 D641AFCA71A7D83587F9D7105D5E6DFFDEAA8016 )
 )
 
 game (
 	name "Blues Brothers 2000 (USA)"
 	description "Blues Brothers 2000 (USA)"
 	rom ( name "Blues Brothers 2000 (USA).n64" size 16777216 crc 109907B5 md5 D7F17E918AB32F64A67409DC86D89C5C sha1 62655484F77091F31FB6A8142AF90AE58489E0E2 )
-	rom ( name "Blues Brothers 2000 (U) [!].z64" size 16777216 crc C6F49764 md5 997FD8F79CD6F3CD1C1C1FD21E358717 sha1 ED0FE7C9A2E8015BDF8262D35065F53C6FCEA60F )
 )
 
 game (
 	name "Body Harvest (Europe) (En,Fr,De)"
 	description "Body Harvest (Europe) (En,Fr,De)"
 	rom ( name "Body Harvest (Europe) (En,Fr,De).n64" size 12582912 crc 2761BDAE md5 1F065DB3BAA31487DE47DEFE56DCD374 sha1 C366CEC6DFE3B724648486F0940D9A2C091C5E14 flags verified )
-	rom ( name "Body Harvest (E) (M3) [!].z64" size 12582912 crc 6A04CDAE md5 B27FA5E9AD0CB47BB3A74FFAC7BC8EDF sha1 67750E2E7AB46FEDF65A271AB7F4C7AAD92AE355 )
 )
 
 game (
@@ -576,7 +504,6 @@ game (
 	name "Bokujou Monogatari 2 (Japan)"
 	description "Bokujou Monogatari 2 (Japan)"
 	rom ( name "Bokujou Monogatari 2 (Japan).n64" size 16777216 crc 0837B349 md5 A6E56E36E311994103A362CA5E5478B9 sha1 E12E5F2FCE0F27C52BE2C7454B21D9B538EA2EE5 flags verified )
-	rom ( name "Bokujou Monogatari 2 (J) [!].z64" size 16777216 crc F97237C7 md5 1CF31E7F6E0DEB2C18C39DDD4EED9E51 sha1 E41D15C394B5FEFD4016ADD3883A794C48E7E232 )
 )
 
 game (
@@ -595,21 +522,18 @@ game (
 	name "Bomber Man 64 (Japan)"
 	description "Bomber Man 64 (Japan)"
 	rom ( name "Bomber Man 64 (Japan).n64" size 12582912 crc 7C532342 md5 F3B1BDE174B0203857DB24416ED112BE sha1 161639FD706DD2637FED2A14CCEE73138E82FB2D flags verified )
-	rom ( name "Bomberman 64 - Arcade Edition (J).z64" size 12582912 crc 7E74EEDC md5 08E491F87445C6E5C168D982FC665D5F sha1 1F2E0598730A2F7EA1987603E505AF45879E194A )
 )
 
 game (
 	name "Bomber Man Hero - Mirian Oujo o Sukue! (Japan)"
 	description "Bomber Man Hero - Mirian Oujo o Sukue! (Japan)"
 	rom ( name "Bomber Man Hero - Mirian Oujo o Sukue! (Japan).n64" size 12582912 crc F3A50116 md5 E44F4D5DADD25568C906CC51BFD4D5BF sha1 C143FCA315277496E0558C93701494A225BA4A37 flags verified )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!].z64" size 12582912 crc 69CEABCC md5 EE273763C7391458865FF26C7EA0C3F1 sha1 AE3F4F7C31DDBD14843D9BEB932FC5AA21746211 )
 )
 
 game (
 	name "Bomberman 64 (Europe)"
 	description "Bomberman 64 (Europe)"
 	rom ( name "Bomberman 64 (Europe).n64" size 8388608 crc D3657C19 md5 8BA9C0C53A390C55C10B76B61ECFA696 sha1 2338FB84AA8C0A4A67E98C52DA2FC7059C570509 flags verified )
-	rom ( name "Bomberman 64 (E) [!].z64" size 8388608 crc 525339C5 md5 B68F49AA8F6F7499184AC6B7B8570F2B sha1 01E50F41733994BF229BEE3B3D8AA9FD46441175 )
 )
 
 game (
@@ -630,7 +554,6 @@ game (
 	name "Bomberman Hero (Europe)"
 	description "Bomberman Hero (Europe)"
 	rom ( name "Bomberman Hero (Europe).n64" size 12582912 crc 28DAD01B md5 EFEFAF4D6DF695651FDA796C9AE8A440 sha1 68CEFA50957D6B6F2E7126851C6A3BDEC8E3AD83 flags verified )
-	rom ( name "Bomberman Hero (E) [!].z64" size 12582912 crc 59E39947 md5 F79EF0813157880FFBAD6199E07579BE sha1 BA1E6A4CC323A83D7C14573C9128AB9F9B60E5F2 )
 )
 
 game (
@@ -644,63 +567,54 @@ game (
 	name "Bottom of the 9th (USA)"
 	description "Bottom of the 9th (USA)"
 	rom ( name "Bottom of the 9th (USA).n64" size 16777216 crc 0F016E17 md5 9746E155104F336FACB6BA7789F0A3D0 sha1 A4D2E5AFC511631D1CC5D8AF6C4C705F17EA8ED6 )
-	rom ( name "Bottom of the 9th (U) [!].z64" size 16777216 crc 1844C8CA md5 FB19AFD5E8C49978E6E6AE3622E0498A sha1 4EE0E3768B9F23112E4E5EF0C81A2B29AE22EAB2 )
 )
 
 game (
 	name "Brunswick Circuit Pro Bowling (USA)"
 	description "Brunswick Circuit Pro Bowling (USA)"
 	rom ( name "Brunswick Circuit Pro Bowling (USA).n64" size 8388608 crc 3AC1BBAE md5 DB929D47127EA55BB919F8C7623E0256 sha1 578BEF71585B2CC956A6847C682B123599BE830A )
-	rom ( name "Brunswick Circuit Pro Bowling (U) [!].z64" size 8388608 crc 80D70173 md5 62E92102D6FD1701A6E904DA6AB58AE8 sha1 91F6F7843A7413126A7B4026104526615F979134 )
 )
 
 game (
 	name "Buck Bumble (Europe) (En,Fr,De,Es,It)"
 	description "Buck Bumble (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Buck Bumble (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 08433E0D md5 80A2C272C13B2F1A5654E98CBEB64AAF sha1 60305A61143BAE5557672E2BDBB9D81EC2DA5C20 flags verified )
-	rom ( name "Buck Bumble (E) (M5) [!].z64" size 12582912 crc E26192AB md5 A2E4BE02876CB0F0D1E925FF95090C96 sha1 1123BFAC4EC3730A54900CA83E196065CBB4B6E2 )
 )
 
 game (
 	name "Buck Bumble (Japan)"
 	description "Buck Bumble (Japan)"
 	rom ( name "Buck Bumble (Japan).n64" size 12582912 crc 24D1A591 md5 5B2D83E1474A34190F748287982407BE sha1 60AFBCC6AFDE1F22AA8031F98F9AD84B1529F848 flags verified )
-	rom ( name "Buck Bumble (J) [!].z64" size 12582912 crc 2ED81A65 md5 AEE981977D8F069003574CD10A268D47 sha1 38007F846A454AD09D2090F0EF86E9762A46CCF7 )
 )
 
 game (
 	name "Buck Bumble (USA)"
 	description "Buck Bumble (USA)"
 	rom ( name "Buck Bumble (USA).n64" size 12582912 crc DA2ACD5E md5 2BD134F866AF753AB46767FAC3144E2E sha1 9CF046E320E5437159A41C49694DC66D4D8E79BD )
-	rom ( name "Buck Bumble (U) [!].z64" size 12582912 crc 8EC937DB md5 41417FCE2B37EAAE787C5A845A0015C4 sha1 01D9497EA0E1F68AE285B8C7A57439B42B7D9A56 )
 )
 
 game (
 	name "Bug's Life, A (Europe)"
 	description "Bug's Life, A (Europe)"
 	rom ( name "Bug's Life, A (Europe).n64" size 12582912 crc 0D101756 md5 FDBAC5A07EF105E31428E14FC7AFE887 sha1 EE0175CDF971BCE250E174D5BC56CDB53104058E flags verified )
-	rom ( name "Bug's Life, A (E) [!].z64" size 12582912 crc 791881D4 md5 ED3E962653A1CD56AAB175DEEE6EE52A sha1 2922C2281FAA4106295830C617289292DF4C377A )
 )
 
 game (
 	name "Bug's Life, A (France)"
 	description "Bug's Life, A (France)"
 	rom ( name "Bug's Life, A (France).n64" size 12582912 crc 2420C6FD md5 AF129B15546FEB93C26E60A13D26E51B sha1 EE71DBBB82CEA124AB2D8A59AA7C24AC20E5979A )
-	rom ( name "Bug's Life, A (F) [!].z64" size 12582912 crc E5429094 md5 D2860D4FBD0EC4B2711A6EF8D78F9866 sha1 4970ECC65E8DE25990A241B0D2FFBE274CB1619A )
 )
 
 game (
 	name "Bug's Life, A (Germany)"
 	description "Bug's Life, A (Germany)"
 	rom ( name "Bug's Life, A (Germany).n64" size 12582912 crc DE6CE3EF md5 DC4896F284956BFE8A105F7C93E0472E sha1 9BDC6D273262F6D1362565215566F6166AEC6A07 )
-	rom ( name "Bug's Life, A (G) [!].z64" size 12582912 crc 15A32836 md5 CBEF54768670F4B5602CCBC90150007A sha1 DAA7114A8D16C3E636B2808D4F256E07954F05DD )
 )
 
 game (
 	name "Bug's Life, A (Italy)"
 	description "Bug's Life, A (Italy)"
 	rom ( name "Bug's Life, A (Italy).n64" size 12582912 crc 04244AAC md5 C7FFEE53B085C5C8C184FC1AA0B374F7 sha1 59564546478AE885A39B4ED77F8FB3A6E7E9BC40 )
-	rom ( name "Bug's Life, A (I) [!].z64" size 12582912 crc 2D118764 md5 E3609FD12369C464E832C6D2A4D20790 sha1 46F9C5D7EB822B19BE6910B992949DEF27E46887 )
 )
 
 game (
@@ -714,35 +628,30 @@ game (
 	name "Bust-A-Move '99 (USA)"
 	description "Bust-A-Move '99 (USA)"
 	rom ( name "Bust-A-Move '99 (USA).n64" size 8388608 crc 2A95290F md5 F81F1FA671A2C861C484500150643360 sha1 3561149DDFF17A60210EC5752781C512B6F4E126 )
-	rom ( name "Bust-A-Move '99 (U) [!].z64" size 8388608 crc C285FC69 md5 8567382D3CD5BC0406B7B4C780F621DC sha1 8D874677CFBFA88C5E52BC13327D518BE3B756BA )
 )
 
 game (
 	name "Bust-A-Move 2 - Arcade Edition (Europe)"
 	description "Bust-A-Move 2 - Arcade Edition (Europe)"
 	rom ( name "Bust-A-Move 2 - Arcade Edition (Europe).n64" size 8388608 crc 14F2CBE9 md5 066D3B1727225962DB938D60642CD6BC sha1 275A39083567C0E4ECF334B666EE6543962FB899 flags verified )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [!].z64" size 8388608 crc 04731BAB md5 094F639A9BA63B2136D2887C8D72BCA0 sha1 F92A1B19C522BA6CF20A9D7883321E6E283DA32F )
 )
 
 game (
 	name "Bust-A-Move 2 - Arcade Edition (USA)"
 	description "Bust-A-Move 2 - Arcade Edition (USA)"
 	rom ( name "Bust-A-Move 2 - Arcade Edition (USA).n64" size 8388608 crc 47511877 md5 8B2F1700CD02E34A99752213BDD150CF sha1 9F7DCB8EE0A918EB9B257AC9F210F0D30F9F6430 )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [!].z64" size 8388608 crc 9F54CD2D md5 8897A39E34AEE4D3F807AF255C6617D6 sha1 8F1AAD51E733958D1A9A7A0CB7516FC7A293CA7B )
 )
 
 game (
 	name "Bust-A-Move 3 DX (Europe)"
 	description "Bust-A-Move 3 DX (Europe)"
 	rom ( name "Bust-A-Move 3 DX (Europe).n64" size 8388608 crc 9F3F484B md5 C7D54104CC455D90D31EDD761BEB7205 sha1 20B2704B12298987BB6151FF432D616866DC00C1 flags verified )
-	rom ( name "Bust-A-Move 3 DX (E) [!].z64" size 8388608 crc 95595889 md5 3EA21256DDC4157C3231AE5CC9C4652A sha1 2BD376C3DB3080D0A2328EF4052E59C3DF71797E )
 )
 
 game (
 	name "California Speed (USA)"
 	description "California Speed (USA)"
 	rom ( name "California Speed (USA).n64" size 16777216 crc 387B0C4C md5 50726D8E0714F80F5514BEC192796BA2 sha1 AFE86AED561560BFCF1BC7130C8341252142269B )
-	rom ( name "California Speed (U) [!].z64" size 16777216 crc 6F6262CB md5 965AD2FA317F0644E49A89A3219719CB sha1 BD4C070A71EF58499587CB811FB7490B88DD7C0B )
 )
 
 game (
@@ -755,14 +664,12 @@ game (
 	name "Carmageddon 64 (Europe) (En,Fr,De,Es)"
 	description "Carmageddon 64 (Europe) (En,Fr,De,Es)"
 	rom ( name "Carmageddon 64 (Europe) (En,Fr,De,Es).n64" size 16777216 crc D8D87DCA md5 74DCF49871606036CD70B42AE2B19B1C sha1 B8AA32D7D78E3119B05C19CD45AAD102465AD254 )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!].z64" size 16777216 crc 8569F1A0 md5 CA21467BDE6B355E7A15B8F1ADA7B24D sha1 2AB7EA2A9BC05ECF3CAC026E2AFF7ACC9D3202E5 )
 )
 
 game (
 	name "Carmageddon 64 (Europe) (En,Fr,Es,It)"
 	description "Carmageddon 64 (Europe) (En,Fr,Es,It)"
 	rom ( name "Carmageddon 64 (Europe) (En,Fr,Es,It).n64" size 16777216 crc 17B07602 md5 3405BB5266CCD60A3B4A4DE7408251F2 sha1 2E64E34DC8F3B6349CB71412F1BF2CA6A2FD5C2B flags verified )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!].z64" size 16777216 crc 8036F999 md5 59EB5646FA079BCBD7A340D7A10196DD sha1 A26831C07ECC57DBF5846DB847A30D9F735297C2 )
 )
 
 game (
@@ -776,14 +683,12 @@ game (
 	name "Castlevania (Europe) (En,Fr,De)"
 	description "Castlevania (Europe) (En,Fr,De)"
 	rom ( name "Castlevania (Europe) (En,Fr,De).n64" size 12582912 crc D1D4D306 md5 0BFEBEDF99C1E715ADA7103664BFCC97 sha1 72FEC07CDB52645E48126A154C9F72E32C2B1931 flags verified )
-	rom ( name "Castlevania (E) (M3) [!].z64" size 12582912 crc D9D76235 md5 57146B6CD8EE7D96B01A811F98A1AC61 sha1 E0DA571CDDCB8D069B36C2DF254334F7C532133E )
 )
 
 game (
 	name "Castlevania (USA)"
 	description "Castlevania (USA)"
 	rom ( name "Castlevania (USA).n64" size 12582912 crc 84E815F3 md5 0BBAA6DE2B9CBB822F8B4D85C1D5497B sha1 B9E2DD5CA9E38E3BEB4C4C374E7DD9377E88D943 )
-	rom ( name "Castlevania (U) (V1.0) [!].z64" size 12582912 crc 8B0D3C00 md5 1CC5CF3B4D29D8C3ADE957648B529DC1 sha1 989A28782ED6B0BC489A1BBBD7BEC355D8F2707E )
 )
 
 game (
@@ -803,7 +708,6 @@ game (
 	name "Castlevania - Legacy of Darkness (Europe) (En,Fr,De)"
 	description "Castlevania - Legacy of Darkness (Europe) (En,Fr,De)"
 	rom ( name "Castlevania - Legacy of Darkness (Europe) (En,Fr,De).n64" size 16777216 crc A12BF3DE md5 BC0CBC7CE863579675116A14F660BF54 sha1 57EF17BD7450EB1E3C486E5C628ADED23E884236 flags verified )
-	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [!].z64" size 16777216 crc 12AB9B45 md5 78D5F8A98A5ED21D0817856BCD2AD750 sha1 0C6817082DD322477C63F3C91A99C1F34AF0065C )
 )
 
 game (
@@ -817,28 +721,24 @@ game (
 	name "Centre Court Tennis (Europe)"
 	description "Centre Court Tennis (Europe)"
 	rom ( name "Centre Court Tennis (Europe).n64" size 12582912 crc 2573171A md5 FFF4BF92143C5A043E25461C2BAADEC8 sha1 18CC04521D0C7E9EBA015B45CF7F3AB9930AF28E flags verified )
-	rom ( name "Centre Court Tennis (E) [!].z64" size 12582912 crc B1D26F39 md5 31FB88048076ACE4BD4205C5F40414AB sha1 C6F1251B4B7841220F670D8A0AF844B34C5CFADA )
 )
 
 game (
 	name "Chameleon Twist (Europe)"
 	description "Chameleon Twist (Europe)"
 	rom ( name "Chameleon Twist (Europe).n64" size 12582912 crc 2AF50883 md5 EC5604A1573D0A2C08F6EF36BE842154 sha1 1C936C558066DA54210DEEF28EBA58520D264011 flags verified )
-	rom ( name "Chameleon Twist (E) [!].z64" size 12582912 crc 587DD983 md5 1CD90B13B7FD6AFDCB838F801D807826 sha1 197556F41756C82EDB6BA7767F0D181290C1B2C2 )
 )
 
 game (
 	name "Chameleon Twist (Japan)"
 	description "Chameleon Twist (Japan)"
 	rom ( name "Chameleon Twist (Japan).n64" size 12582912 crc A2DCF689 md5 59227D760A41DBCC644070CF0E993BFA sha1 E6A1D9B94E83D1784ECAF0DEC6F6A9E42FEAA74D flags verified )
-	rom ( name "Chameleon Twist (J) [!].z64" size 12582912 crc 6395C475 md5 C0EB519122D63A944A122437EC1B98EE sha1 A1FAF5C4CA961AB2C029C84ECFA556755E7F70C8 )
 )
 
 game (
 	name "Chameleon Twist (USA)"
 	description "Chameleon Twist (USA)"
 	rom ( name "Chameleon Twist (USA).n64" size 12582912 crc 4246EE14 md5 74520D4064C37C72C2BDEE4AF2520E59 sha1 2CABB61506BF5F74437BC813429C22325045393A )
-	rom ( name "Chameleon Twist (U) [!].z64" size 12582912 crc 7FE024C9 md5 397BE52D4FB7DF1E26C6275E05425571 sha1 173875D2A98161228EFB56841484E12446A43156 )
 )
 
 game (
@@ -851,42 +751,36 @@ game (
 	name "Chameleon Twist 2 (Europe)"
 	description "Chameleon Twist 2 (Europe)"
 	rom ( name "Chameleon Twist 2 (Europe).n64" size 8388608 crc 35958F55 md5 7A20B97C0B509AAA38E36068ACD217C3 sha1 6EF1F9C84E73C9307B52A52635E4FE5E23D795D8 flags verified )
-	rom ( name "Chameleon Twist 2 (E) [!].z64" size 8388608 crc 3B53519F md5 45D1D039AB7926ADC748DE640AFD986A sha1 BBCA485EE38E07DA78F44E5DE653311B8EDC18F2 )
 )
 
 game (
 	name "Chameleon Twist 2 (Japan)"
 	description "Chameleon Twist 2 (Japan)"
 	rom ( name "Chameleon Twist 2 (Japan).n64" size 12582912 crc F42BB75F md5 CB4FC518CB6F3A1D70B3179C23FD54D3 sha1 E659CD6059FD464BA1883A5BAE8B839C14BA72F4 flags verified )
-	rom ( name "Chameleon Twist 2 (J) [!].z64" size 8388608 crc 5677EAEF md5 A55AF433E65E3690E2DC2B16018E9A0F sha1 0F14F7C1E2A72008B83CBEA6A79BA38B8971561E )
 )
 
 game (
 	name "Chameleon Twist 2 (USA)"
 	description "Chameleon Twist 2 (USA)"
 	rom ( name "Chameleon Twist 2 (USA).n64" size 8388608 crc 356736C7 md5 BE134500DA3342CD5DC7922B5E2697B7 sha1 185141B800BF109367905F1A6B0EF6823F224CE8 )
-	rom ( name "Chameleon Twist 2 (U) [!].z64" size 8388608 crc CDF26D67 md5 00327E0B5DF6DCE6DECC31353F33A3D3 sha1 9FA379D66B218228DA3CBF386C91D857C677F489 )
 )
 
 game (
 	name "Charlie Blast's Territory (Europe)"
 	description "Charlie Blast's Territory (Europe)"
 	rom ( name "Charlie Blast's Territory (Europe).n64" size 4194304 crc 831C5A55 md5 9F591BF3C78E6F00E8B83AA797441A4C sha1 43B30901BEFBC629E50F76EDC7D96B393DCC5F0B flags verified )
-	rom ( name "Charlie Blast's Territory (E) [!].z64" size 4194304 crc 82C1D9E1 md5 DD53E1F83E8789D23DF6AF942FFEF236 sha1 9A0EB87BA72C1EF4DCB8B80029F29CDEEA91FE49 )
 )
 
 game (
 	name "Charlie Blast's Territory (USA)"
 	description "Charlie Blast's Territory (USA)"
 	rom ( name "Charlie Blast's Territory (USA).n64" size 4194304 crc 928A2968 md5 402809447FFB03C0921219ADAB45E714 sha1 CA22FA616D00D6199513A52C7851CBEE5CC52354 )
-	rom ( name "Charlie Blast's Territory (U) [!].z64" size 4194304 crc BA4E65A8 md5 59FA8C6D533D36C0FFC2AAFAB7166E6F sha1 E11619C7A8E1C2A280EA3AC069CF11153D4951A6 )
 )
 
 game (
 	name "Chopper Attack (Europe)"
 	description "Chopper Attack (Europe)"
 	rom ( name "Chopper Attack (Europe).n64" size 8388608 crc 30CA7DBE md5 F1CAC35BC510733862A55B32642FFF74 sha1 9D0840380C468A8458A838C0EE06C4858DCD1C9A flags verified )
-	rom ( name "Chopper Attack (E) [!].z64" size 8388608 crc C1DCD7AB md5 8F6BED633BE214CF039DBDAC356231CE sha1 9688C388384EDEA0141FC66B20D6D0E5FE2D668F )
 )
 
 game (
@@ -899,42 +793,36 @@ game (
 	name "Choro Q 64 (Japan)"
 	description "Choro Q 64 (Japan)"
 	rom ( name "Choro Q 64 (Japan).n64" size 8388608 crc C5722B49 md5 1E1C1407FB9DCDDFA2A140A9C7597398 sha1 C399149B3166CE310028184610AAF312AF9BA75A flags verified )
-	rom ( name "Choro Q 64 (J) [!].z64" size 8388608 crc 231F9284 md5 8287A908E36E79B2D3AF0BD22C43ECD9 sha1 288CDBABE30349B70DDD68931E697AF03E0D2EE8 )
 )
 
 game (
 	name "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan)"
 	description "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan)"
 	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (Japan).n64" size 12582912 crc 42AE9174 md5 4AC91D55887E73BB58650FB351E0A30E sha1 EDD177A68DD0C20DD6F939CDB7A74264132DD326 flags verified )
-	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!].z64" size 12582912 crc 5C565AD6 md5 9081370141079031EBBDBCA56FC8C7D8 sha1 4532621D98B25D07E2F19AA106FF4DB547104160 )
 )
 
 game (
 	name "Chou Kuukan Nighter Pro Yakyuu King (Japan)"
 	description "Chou Kuukan Nighter Pro Yakyuu King (Japan)"
 	rom ( name "Chou Kuukan Nighter Pro Yakyuu King (Japan).n64" size 8388608 crc C73E336C md5 70A0306209E6141293349648E22B9705 sha1 EA7E403A37EE386F6422F4B96D4450FCD5D816F0 flags verified )
-	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [!].z64" size 8388608 crc 5F75634E md5 78838C202C4FF5A460586451EE9182AA sha1 A08DD769F3B885DC27F4CD14022613D1BAA52B84 )
 )
 
 game (
 	name "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)"
 	description "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)"
 	rom ( name "Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).n64" size 16777216 crc C0FC82C0 md5 11031676E9BECC877BC513D4AAD3449E sha1 391E91DDBFF9B42A0F5563187DC66F4D2842F598 flags verified )
-	rom ( name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!].z64" size 16777216 crc 479643E2 md5 97EAB4DC83DA0AD2890DE2AAAA5D109A sha1 B8C62BEFE0A2BD7BCD6EFB5F78B34B923B325AAC )
 )
 
 game (
 	name "Chou Snobo Kids (Japan)"
 	description "Chou Snobo Kids (Japan)"
 	rom ( name "Chou Snobo Kids (Japan).n64" size 16777216 crc AB53586B md5 B8867AF93066C46884FD4CE2EDC55937 sha1 36DF553351DEF16BF92DE8CADA7350E0A287FD0D )
-	rom ( name "Chou Snobow Kids (J) [!].z64" size 16777216 crc 8FEDF4C6 md5 9466618F4497DA6C9091E05CC9666786 sha1 A116C12CA0056D952128D57F7569674F457F0F74 )
 )
 
 game (
 	name "City-Tour GP - Zen-Nihon GT Senshuken (Japan)"
 	description "City-Tour GP - Zen-Nihon GT Senshuken (Japan)"
 	rom ( name "City-Tour GP - Zen-Nihon GT Senshuken (Japan).n64" size 16777216 crc 7A59354B md5 E55BE3D631AD7B76ACF8AD4832A1CB8B sha1 FCAD11BCDD2AD20E1C49CEA89F1ED4697DDEBD91 flags verified )
-	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [!].z64" size 16777216 crc E272BDF6 md5 2A0BF5A9A136D57AF01D199B16899634 sha1 2B543707F5BDBA52A49D71755615D6CF38E23E76 )
 )
 
 game (
@@ -948,7 +836,6 @@ game (
 	name "Clay Fighter 63 1-3 (Europe)"
 	description "Clay Fighter 63 1-3 (Europe)"
 	rom ( name "Clay Fighter 63 1-3 (Europe).n64" size 12582912 crc DCCCB22F md5 53B9F00C65FD7E8D594149533A2A4982 sha1 1CDA578CAD71ABCCECD3643197C76A3284CAAC3E flags verified )
-	rom ( name "Clay Fighter 63 1-3 (E) [!].z64" size 12582912 crc 82263E5D md5 41965B533F3DD95663361D9DF68B0C1F sha1 FEC40EF7D8B973C5937ADE10423D0CF1B5A18E3C )
 )
 
 game (
@@ -962,21 +849,18 @@ game (
 	name "Clay Fighter 63 1-3 (USA) (Beta)"
 	description "Clay Fighter 63 1-3 (USA) (Beta)"
 	rom ( name "Clay Fighter 63 1-3 (USA) (Beta).n64" size 12582912 crc 23139027 md5 DDC463091050484309037576A201D439 sha1 9C2009462315508119B991BA22D4B23BB50D0779 )
-	rom ( name "Clay Fighter 63 1-3 (Beta) [!].z64" size 12582912 crc 18F4166A md5 CBBEAFF5A9074D1A5507CF46CD683D36 sha1 3307F73B8BD0795D3C7036D77FC4A78EFEBC4EF0 )
 )
 
 game (
 	name "Command & Conquer (Europe) (En,Fr)"
 	description "Command & Conquer (Europe) (En,Fr)"
 	rom ( name "Command & Conquer (Europe) (En,Fr).n64" size 33554432 crc CE383B3E md5 2B7E4E14D744B40FD393C487E0768C24 sha1 5EA73072575EDED3954ABE4A9D44623B7847C820 flags verified )
-	rom ( name "Command & Conquer (E) (M2) [!].z64" size 33554432 crc F3DA8A26 md5 42DA4C7D040F9E7CD046A42EC3E68027 sha1 0D5211E211E7FC063C63C3E8235B62BC288CE305 )
 )
 
 game (
 	name "Command & Conquer (Germany)"
 	description "Command & Conquer (Germany)"
 	rom ( name "Command & Conquer (Germany).n64" size 33554432 crc B312E838 md5 FBC337325B9CEAE41F237F3E54D72AB3 sha1 662D03F3DF3E1817330DB94CE330F7915BD9A00C flags verified )
-	rom ( name "Command & Conquer (G) [!].z64" size 33554432 crc 6CD0FC99 md5 1A9195662C89DCBEA88BCFA99B096CDE sha1 725083ECE68D5DEB9724D3FA3F2A65F0291B2D5D )
 )
 
 game (
@@ -990,7 +874,6 @@ game (
 	name "Conker's Bad Fur Day (Europe)"
 	description "Conker's Bad Fur Day (Europe)"
 	rom ( name "Conker's Bad Fur Day (Europe).n64" size 67108864 crc 96DBA949 md5 E31DED9C7887EBC07A343B8865A2BF55 sha1 175A058E739762D49AFF01B4EAC8784DB415C711 flags verified )
-	rom ( name "Conker's Bad Fur Day (E) [!].z64" size 67108864 crc 4667CFE9 md5 05194D49C14E52055DF72A54D40791E1 sha1 EE7BC6656FD1E1D9FFB3D19ADD759F28B88DF710 )
 )
 
 game (
@@ -1004,98 +887,84 @@ game (
 	name "Cruis'n Exotica (USA)"
 	description "Cruis'n Exotica (USA)"
 	rom ( name "Cruis'n Exotica (USA).n64" size 16777216 crc 20E7DBD7 md5 AC67B606AEA6A01F3CFCCCBC30061A10 sha1 130FED584A6EB820B69E90E8AC8EC9301D69C3C5 )
-	rom ( name "Cruis'n Exotica (U) [!].z64" size 16777216 crc 867A2CED md5 DB7A03B77D44DB81B8A3FCDFC4B72D8C sha1 428F53A060103FD88EBFBDCC032A99CAEA901E17 )
 )
 
 game (
 	name "Cruis'n USA (Europe)"
 	description "Cruis'n USA (Europe)"
 	rom ( name "Cruis'n USA (Europe).n64" size 8388608 crc 6767ECA4 md5 07BBF2E52F243852B01B25CE874FDE17 sha1 6CC846AEDCC31597842645BBB6030272CD9A82F0 flags verified )
-	rom ( name "Cruis'n USA (E) [!].z64" size 8388608 crc 8935A8D9 md5 69CD5BA6BC9310B9E37CCB1BC6BD16AD sha1 404AB549CD148EA07F40D66C0B896A343741BBF6 )
 )
 
 game (
 	name "Cruis'n USA (USA)"
 	description "Cruis'n USA (USA)"
 	rom ( name "Cruis'n USA (USA).n64" size 8388608 crc EE925406 md5 D2D8CBC47EE941A30AEC1AF3AC471519 sha1 AA8768945FF398B13B7EE9722A268E49424B6F26 )
-	rom ( name "Cruis'n USA (U) (V1.0) [!].z64" size 8388608 crc 5238B727 md5 00A3E885F8D899646228A21D946B2102 sha1 AEFE77A5518FE74519908B6CBC97CB81B8570897 )
 )
 
 game (
 	name "Cruis'n USA (USA) (Rev A)"
 	description "Cruis'n USA (USA) (Rev A)"
 	rom ( name "Cruis'n USA (USA) (Rev A).n64" size 8388608 crc 615AC9BC md5 78BAA0F08D53842B84F25700B750CA8C sha1 DA43A6443C22A608B76B6B73602C30B0C6038379 )
-	rom ( name "Cruis'n USA (U) (V1.1) [!].z64" size 8388608 crc 4655BA2D md5 45FC88E2BA6711F25F0DE988E719DF29 sha1 71BB3D8850B6A4A294AECA2ABAD1F936E4F85F0F )
 )
 
 game (
 	name "Cruis'n USA (USA) (Rev B)"
 	description "Cruis'n USA (USA) (Rev B)"
 	rom ( name "Cruis'n USA (USA) (Rev B).n64" size 8388608 crc E466C124 md5 4379EE6C5CB0B521C2D0866A3BA71973 sha1 4E0AF2979C573AAAB84A60F42266EC0C3FA60B84 flags verified )
-	rom ( name "Cruis'n USA (U) (V1.2) [!].z64" size 8388608 crc C3B52701 md5 2838A9018AD2BCB8B7F6161C746A1B71 sha1 54A875EE0B482036FA401A6BC2B242699F0259F7 )
 )
 
 game (
 	name "Cruis'n World (Europe)"
 	description "Cruis'n World (Europe)"
 	rom ( name "Cruis'n World (Europe).n64" size 12582912 crc 2A8B3094 md5 47D90F8A5B8BBF90049A161469625FE2 sha1 E0EFBB03B343CC9ACE4E98306250436604054B6E flags verified )
-	rom ( name "Cruis'n World (E) [!].z64" size 12582912 crc E46CE079 md5 AF950A1B6C460D7FC3E78375D35047EF sha1 EE508F14C936265D101C9699B5AE1A722B3E7D9E )
 )
 
 game (
 	name "Cruis'n World (USA)"
 	description "Cruis'n World (USA)"
 	rom ( name "Cruis'n World (USA).n64" size 12582912 crc 41877D7D md5 FCF34799BB1F3CA47B46371BD23B4424 sha1 A584735385485EE0B158E3206CE9B2E47FECA830 )
-	rom ( name "Cruis'n World (U) [!].z64" size 12582912 crc A123769F md5 AADA4CBD938E58A447B399A1D46F03E6 sha1 6DA1A6A2BDA687D50E798D80C342948AD1738202 )
 )
 
 game (
 	name "Custom Robo (Japan)"
 	description "Custom Robo (Japan)"
 	rom ( name "Custom Robo (Japan).n64" size 16777216 crc 30C84F36 md5 41FFF04711D1B5524785A5CE05F6E611 sha1 9D462983D2F6C4417C328D97D430E0D62C5DAC94 flags verified )
-	rom ( name "Custom Robo (J) [!].z64" size 16777216 crc F2FAE693 md5 A06D2E83CF2628915E8847F609474661 sha1 49DE08F08400A477485C4798D6CD81D95842C806 )
 )
 
 game (
 	name "Custom Robo V2 (Japan)"
 	description "Custom Robo V2 (Japan)"
 	rom ( name "Custom Robo V2 (Japan).n64" size 16777216 crc 7BEF9ECC md5 64E09AB54443CFFBB31FEE73936EE489 sha1 67FF98E6230470F0C3C209EDB72869C715DB2800 flags verified )
-	rom ( name "Custom Robo V2 (J) [!].z64" size 16777216 crc C8201454 md5 115118DD5E0F02D82BA1BF070A7B78F1 sha1 F9515C2482AF8DF791339536F60260509C424F6A )
 )
 
 game (
 	name "CyberTiger (Europe)"
 	description "CyberTiger (Europe)"
 	rom ( name "CyberTiger (Europe).n64" size 16777216 crc BCF1071F md5 AEE5BD2F3288182038C028531C0AD092 sha1 E68970895CC01B69B8A5A05EAF4D07B632544330 flags verified )
-	rom ( name "CyberTiger (E) [!].z64" size 16777216 crc 7319D9AF md5 8C4A4CD472D610CDA5459B3A92F21D30 sha1 AE220AC1CD6D892098937DC639C925F9EF158759 )
 )
 
 game (
 	name "CyberTiger (USA)"
 	description "CyberTiger (USA)"
 	rom ( name "CyberTiger (USA).n64" size 16777216 crc F0F89BB9 md5 4F1540CA7E7DEDBB2B3EE4BF6509975D sha1 AFB3E9290730FD19106ECA24CB305C1B55F2E864 )
-	rom ( name "CyberTiger (U) [!].z64" size 16777216 crc 10CC5F15 md5 88072F30D4F9CF384B2B3A0300649218 sha1 14E0635CCC2A80C77FD0A888A2E7977C55C6E129 )
 )
 
 game (
 	name "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 6CB4B600 md5 1979C1A7D449107F478EBA716CD30266 sha1 456706F0E7A55B40715585F4A66A250A5654C02C flags verified )
-	rom ( name "Looney Tunes - Duck Dodgers (E) (M6) [!].z64" size 16777216 crc C61F6BB9 md5 1408FCF68B60D845F090107EF355A7E5 sha1 5499B5284C04CEE98186E68198D6BFE73FEE0CDB )
 )
 
 game (
 	name "Dance Dance Revolution - Disney Dancing Museum (Japan)"
 	description "Dance Dance Revolution - Disney Dancing Museum (Japan)"
 	rom ( name "Dance Dance Revolution - Disney Dancing Museum (Japan).n64" size 33554432 crc E085AFA0 md5 B3F1D0ABC1A8E1713124EF64A4B9BE51 sha1 B0931ECABC6D7C05A14C792F45BC6FAAC8722AB1 flags verified )
-	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [!].z64" size 25165824 crc 3C13FBCF md5 3A1488C2A8A8F2AB9368D7C056EB02A2 sha1 DB0AE6323F9EF4F7ED62071B2901B48E87E919C6 )
 )
 
 game (
 	name "Dark Rift (Europe)"
 	description "Dark Rift (Europe)"
 	rom ( name "Dark Rift (Europe).n64" size 8388608 crc 375D8FFE md5 B05AB4D2CEB5B9132AFDB138E14B9A4C sha1 9C6701DD396A35649B0045C5BE3DC0642C334C8C flags verified )
-	rom ( name "Dark Rift (E) [!].z64" size 8388608 crc D2A19C71 md5 4242FDE5B74F22AAF5746459E126121F sha1 18B02FC18411ACD770BF3F25B2707669DAC2EC5D )
 )
 
 game (
@@ -1116,35 +985,30 @@ game (
 	name "Defi au Tetris Magique (France)"
 	description "Defi au Tetris Magique (France)"
 	rom ( name "Defi au Tetris Magique (France).n64" size 16777216 crc EB304709 md5 29BB26E9C200A947C57361AB5A57812F sha1 0F90CE8124A023F207C59CCBDA17D10D13532D62 )
-	rom ( name "Defi au Tetris Magique (F) [!].z64" size 16777216 crc E7EF60E8 md5 C644E318B33C4EBD94695C0C3E1E80FF sha1 E5C79CF80AE1C19D2CB7136600EC8BD2CCEAE934 )
 )
 
 game (
 	name "Densha de Go! 64 (Japan)"
 	description "Densha de Go! 64 (Japan)"
 	rom ( name "Densha de Go! 64 (Japan).n64" size 33554432 crc 8F63474F md5 E990868A77DBAA62E1F32C2EA1C9BDEF sha1 AD5B14C3C571DB911B2896D6C80E200B12CAFDCD flags verified )
-	rom ( name "Densha de Go! 64 (J) [!].z64" size 33554432 crc 7BFC71E0 md5 772FA166E5DB51EFFC77FB8D832AC4D2 sha1 5B99D3AF55DFD04A5ACC11B9D25A3330C1E45708 )
 )
 
 game (
 	name "Derby Stallion 64 (Japan)"
 	description "Derby Stallion 64 (Japan)"
 	rom ( name "Derby Stallion 64 (Japan).n64" size 33554432 crc 922506AD md5 CB80BE23EEDC36D6FACB03D4C877E28B sha1 B404E2A26DA5CF0EE2EECFD691FFB0385D08642A flags verified )
-	rom ( name "Derby Stallion 64 (J) [!].z64" size 33554432 crc A9417994 md5 7F57463856540104B21A5289312B626F sha1 9A2B7DFA38FBF9CD07FF676C0E484D7B97DB606B )
 )
 
 game (
 	name "Derby Stallion 64 (Japan) (Beta)"
 	description "Derby Stallion 64 (Japan) (Beta)"
 	rom ( name "Derby Stallion 64 (Japan) (Beta).n64" size 33554432 crc 418FA479 md5 836D85A3668E5FC577DE63E411B0B8EA sha1 BCA2DB2B280261CD0E62B304BA3754A6C56351B5 )
-	rom ( name "Derby Stallion 64 (J) (Beta).z64" size 33554432 crc 8EC950A9 md5 1051E1402EE110F3C5E372C9E1C5B338 sha1 BD03F18C456D5DB90475DCF1AAE2237C82D7446A )
 )
 
 game (
 	name "Destruction Derby 64 (Europe) (En,Fr,De)"
 	description "Destruction Derby 64 (Europe) (En,Fr,De)"
 	rom ( name "Destruction Derby 64 (Europe) (En,Fr,De).n64" size 16777216 crc 212A8000 md5 DFFD909E47B4ABC8FB25669C83EEF8AA sha1 E68747F46AB2EB21D56BD39F65232BDAAD86BCF9 flags verified )
-	rom ( name "Destruction Derby 64 (E) (M3) [!].z64" size 16777216 crc 7AD9E429 md5 BDA717ECC8434F12F313342485828B58 sha1 EED379520C7FC7D08EBE5A076683BD56F3A0A04F )
 )
 
 game (
@@ -1158,35 +1022,30 @@ game (
 	name "Dezaemon 3D (Japan)"
 	description "Dezaemon 3D (Japan)"
 	rom ( name "Dezaemon 3D (Japan).n64" size 16777216 crc 8CE25C68 md5 6C21310E6F906057BA261BBD9903BCBB sha1 7CA61515B13D927E905B59390DD300945B68D218 flags verified )
-	rom ( name "Dezaemon 3D (J) [!].z64" size 16777216 crc 9E978488 md5 54BE265E7B2C28AB92BF1A4130ACB5A2 sha1 1C10A85A2B6A782E6302B19C2387E2D58983A8D4 )
 )
 
 game (
 	name "Diddy Kong Racing (Europe) (En,Fr,De)"
 	description "Diddy Kong Racing (Europe) (En,Fr,De)"
 	rom ( name "Diddy Kong Racing (Europe) (En,Fr,De).n64" size 12582912 crc 883DF1EA md5 56CAA8F0D1B95FD3AF3472841A04C5FB sha1 944EF38C40630573C16D7534109EB7D3C822EEEC flags verified )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [!].z64" size 12582912 crc 4A13323C md5 0F0B7B78B345FBF2581D834CB4A81245 sha1 DD5D64DD140CB7AA28404FA35ABDCABA33C29260 )
 )
 
 game (
 	name "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A)"
 	description "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Diddy Kong Racing (Europe) (En,Fr,De) (Rev A).n64" size 12582912 crc F05D414F md5 75874D5233240E9790755DA009B8B6BB sha1 FD57DA7FE1D4DD471CAACA419176A4C097EE7B90 flags verified )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [!].z64" size 12582912 crc B1E87639 md5 6B2BAFE540E0AF052A78E85B992BE999 sha1 B7F628073237B3D211D40406AA0884FF8FDD70D5 )
 )
 
 game (
 	name "Diddy Kong Racing (Japan)"
 	description "Diddy Kong Racing (Japan)"
 	rom ( name "Diddy Kong Racing (Japan).n64" size 12582912 crc 95931356 md5 7021A85C953549E73B151A1B328A8FB1 sha1 A33962564640CD80E57F7CAC895CA831F123AFD5 flags verified )
-	rom ( name "Diddy Kong Racing (J).z64" size 12582912 crc B566FB94 md5 10747662A55241B9234CD114C940504F sha1 23BA3D302025153D111416E751027CEF11213A19 )
 )
 
 game (
 	name "Diddy Kong Racing (USA) (En,Fr)"
 	description "Diddy Kong Racing (USA) (En,Fr)"
 	rom ( name "Diddy Kong Racing (USA) (En,Fr).n64" size 12582912 crc 9D2935A1 md5 E00C0E6BFB0CE740E3E1C50BA82BC01A sha1 812807D8DC23229E736D543C3BAFC7EF28519EF5 flags verified )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [!].z64" size 12582912 crc EB759206 md5 4F0E07F0EEAC7E5D7CE3A75461888D03 sha1 0CB115D8716DBBC2922FDA38E533B9FE63BB9670 )
 )
 
 game (
@@ -1200,28 +1059,24 @@ game (
 	name "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)"
 	description "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)"
 	rom ( name "Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).n64" size 20971520 crc 6D48B64E md5 F2B2D71DE20BC16FF9F036D965A2E499 sha1 2700F7534D477C7B673DCDEE0FE19B93DC95CA89 )
-	rom ( name "Disney's Donald Duck - Goin' Quackers (U) [!].z64" size 20971520 crc 7FDEC270 md5 0E0E920AB13EF13508F5A98CC4CD2FF8 sha1 E31A7567D408C890065029BA537F830765B17D94 )
 )
 
 game (
 	name "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
 	description "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).n64" size 20971520 crc 5F67A191 md5 E8127681104E997954F2B238B3A75BAE sha1 6C761E0668247A5B264E2DEB502F1DE992F83346 flags verified )
-	rom ( name "Donald Duck - Quack Attack (E) (M5) [!].z64" size 20971520 crc C4B0D9EA md5 E8B403A0F0E212FA5C1220AF10D9C379 sha1 C42FAFB06BE6EB7DE08370D07F19571B7661074B )
 )
 
 game (
 	name "Donkey Kong 64 (Europe) (En,Fr,De,Es)"
 	description "Donkey Kong 64 (Europe) (En,Fr,De,Es)"
 	rom ( name "Donkey Kong 64 (Europe) (En,Fr,De,Es).n64" size 33554432 crc FC37B06A md5 D31BB4EDFFDB35E5EC293A1154B2E844 sha1 29FA421E7732AB990178033BC8C979AEB8FE78D5 flags verified )
-	rom ( name "Donkey Kong 64 (E) [!].z64" size 33554432 crc A28C71C6 md5 118E9CE360B97A6F8DAB2C9F30660BF5 sha1 F96AF883845308106600D84E0618C1A066DC6676 )
 )
 
 game (
 	name "Donkey Kong 64 (Japan)"
 	description "Donkey Kong 64 (Japan)"
 	rom ( name "Donkey Kong 64 (Japan).n64" size 33554432 crc FBD001B9 md5 0E7EA5BAFF2F6A7FBE17164E97231619 sha1 429E7ACE2A68832345BFBB3BC3AADF3A7A505D7B flags verified )
-	rom ( name "Donkey Kong 64 (J) [!].z64" size 33554432 crc 919F7E74 md5 5B677F4BF93D6578252FCAD2C8CEB637 sha1 F0AD2B2BBF04D574ED7AFBB1BB6A4F0511DCD87D )
 )
 
 game (
@@ -1235,28 +1090,24 @@ game (
 	name "Donkey Kong 64 (USA) (Demo) (Kiosk)"
 	description "Donkey Kong 64 (USA) (Demo) (Kiosk)"
 	rom ( name "Donkey Kong 64 (USA) (Demo) (Kiosk).n64" size 33554432 crc 54BB87F6 md5 669A211FEA4EF38438947C1561124DF1 sha1 69127A8B8A0848CEECCD3712F3752EAB3F9143CD )
-	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [!].z64" size 33554432 crc C83DFA15 md5 98A5836E3A5DA7BD0B5819E7498ACEA2 sha1 B4717E602F07CA9BE0D4822813C658CD8B99F993 )
 )
 
 game (
 	name "Doom 64 (Europe)"
 	description "Doom 64 (Europe)"
 	rom ( name "Doom 64 (Europe).n64" size 8388608 crc 0227DB4B md5 B3850615885124F41E3011FE191AF3C0 sha1 1C863F00650FA5C4111F3CF0B972105EDFC970AB flags verified )
-	rom ( name "Doom 64 (E) [!].z64" size 8388608 crc D985C356 md5 190CCCA6526DC4A1F611E3B40F5131C0 sha1 B63060F69BB4E1547DA1D762E740D19393977055 )
 )
 
 game (
 	name "Doom 64 (Japan)"
 	description "Doom 64 (Japan)"
 	rom ( name "Doom 64 (Japan).n64" size 8388608 crc 95526F13 md5 042E4EBF2DB26B10EC8A22A3915C726A sha1 D7D8E5636839255FD1C324B9A27511917E3C454F flags verified )
-	rom ( name "Doom 64 (J) [!].z64" size 8388608 crc C8F3AF5B md5 06F15EF2228C1B1147C41DCCAA07D9DE sha1 6B0D65E62626A92AA59EE4BFF3F02715F6247692 )
 )
 
 game (
 	name "Doom 64 (USA)"
 	description "Doom 64 (USA)"
 	rom ( name "Doom 64 (USA).n64" size 8388608 crc 4DFB7CB6 md5 5A8684BC098428DD2A401F4CDAEE78DF sha1 B30F2B1B1CF70DC4B398BFF26F75EEDFF858540D flags verified )
-	rom ( name "Doom 64 (U) (V1.0) [!].z64" size 8388608 crc 5CC1ADE6 md5 B67748B64A2CC7EFD2F3AD4504561E0E sha1 799A588D73DA3FCCE8031026A8187DA92B91C817 )
 )
 
 game (
@@ -1270,28 +1121,24 @@ game (
 	name "Doraemon - Nobita to 3tsu no Seireiseki (Japan)"
 	description "Doraemon - Nobita to 3tsu no Seireiseki (Japan)"
 	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (Japan).n64" size 8388608 crc CAD0A2C2 md5 14A4BE756F6BD3BC3FF4B590D325DF58 sha1 A35B06DC974429DBD6CBF0712A4C170FD099748A flags verified )
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!].z64" size 8388608 crc 154E8B33 md5 C2166455E94E89E9E3AB612B4377C443 sha1 BBEB7B7A92A68B17CA72DCB9D7FB16F7B771C4F6 )
 )
 
 game (
 	name "Doraemon 2 - Nobita to Hikari no Shinden (Japan)"
 	description "Doraemon 2 - Nobita to Hikari no Shinden (Japan)"
 	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (Japan).n64" size 12582912 crc 2DE1A873 md5 AB09E0921B229AD6C673D512D1C279DE sha1 00A02647DE6760FA2CF1A2FFCAADA43703A8A98D flags verified )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!].z64" size 12582912 crc 0C1A0C38 md5 0580D96A71671C9E6972FDCF5897CC26 sha1 4B187360E1999556662C28B65DD179432EC61F9A )
 )
 
 game (
 	name "Doraemon 3 - Nobita no Machi SOS! (Japan)"
 	description "Doraemon 3 - Nobita no Machi SOS! (Japan)"
 	rom ( name "Doraemon 3 - Nobita no Machi SOS! (Japan).n64" size 16777216 crc 0B3AD913 md5 988E5C05E1976F0A50E670DCB6BB672C sha1 A567AA96860525963F9DAFA256036C0DF5F66909 flags verified )
-	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [!].z64" size 16777216 crc D3B68BE4 md5 A4A1D490BA67831775FC381B846E2168 sha1 DD9BA0F6CFC10C3B78401CC55D06AD534F39D5B1 )
 )
 
 game (
 	name "Doubutsu no Mori (Japan)"
 	description "Doubutsu no Mori (Japan)"
 	rom ( name "Doubutsu no Mori (Japan).n64" size 16777216 crc B9FCD0A6 md5 A6EF34BD225F22BBF737D61B839AE1B0 sha1 648B978895BC20256D48F763A72A8686F5CF549D flags verified )
-	rom ( name "Doubutsu no Mori (J) [!].z64" size 16777216 crc 9503E3F1 md5 A4F7C57C180297B2E7BA5A5FEB44FE0B sha1 E106DFF7146F72415337C96DEB14F630E1580EFB )
 )
 
 game (
@@ -1311,21 +1158,18 @@ game (
 	name "Dual Heroes (Europe)"
 	description "Dual Heroes (Europe)"
 	rom ( name "Dual Heroes (Europe).n64" size 12582912 crc 04064347 md5 8D9C55CD89894E24EA49FCAA6ADE1A22 sha1 7703976C4BEF912FEEB5B553FF913E8EF0DB8A60 flags verified )
-	rom ( name "Dual Heroes (E) [!].z64" size 12582912 crc 5A7E226B md5 F120FADB52B414EB4FB7D13092AC3CDB sha1 061B7956C3AADDDC6FDC11AAB885F95A71B7F463 )
 )
 
 game (
 	name "Dual Heroes (Japan)"
 	description "Dual Heroes (Japan)"
 	rom ( name "Dual Heroes (Japan).n64" size 12582912 crc A3565FFC md5 8DC1F2991FB430F2D18BD37F0242ED90 sha1 B36E4D8A19A50711B0423469DD43B954084FE36A flags verified )
-	rom ( name "Dual Heroes (J) [!].z64" size 12582912 crc 20F23DDE md5 E7652ED5CECEB5B1BC14495C58546D1C sha1 CFD5992BCC3E0D90966D8A6FC6E0813E75473B14 )
 )
 
 game (
 	name "Dual Heroes (USA)"
 	description "Dual Heroes (USA)"
 	rom ( name "Dual Heroes (USA).n64" size 12582912 crc 8968D989 md5 4F154F3490D35C0A6D38CB94FD842D0B sha1 AC48D0A10A26DE691976618D1D0CAEBF402F9123 )
-	rom ( name "Dual Heroes (U) [!].z64" size 12582912 crc D09F4DA8 md5 923D65E69F51858C697E0E5759CD038B sha1 8FD879CE53E211D33A689015A78CFF3FDD39DB09 )
 )
 
 game (
@@ -1339,21 +1183,18 @@ game (
 	name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta)"
 	description "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta)"
 	rom ( name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta).n64" size 20971520 crc 0829B87A md5 94C9052BF01F4A860C23C8D289841783 sha1 10CD84CEADD50DD7C5A06652BB1C203677644FB0 )
-	rom ( name "Lt. Duck Dodgers (Prototype).z64" size 20971520 crc 7291BA5B md5 4CCFF861AD2CFD65CC660F496C1D1664 sha1 D850517994081AB90AF79629DF86FD5BAEE616C5 )
 )
 
 game (
 	name "Duke Nukem - Zero Hour (Europe)"
 	description "Duke Nukem - Zero Hour (Europe)"
 	rom ( name "Duke Nukem - Zero Hour (Europe).n64" size 33554432 crc C2B3DF4D md5 006A02315DD24BF4418C070BA29052CB sha1 D90325D6AC785C94ED0A66469319F2164474A8A3 flags verified )
-	rom ( name "Duke Nukem - ZER0 H0UR (E) [!].z64" size 33554432 crc EA82F037 md5 86E98AACA0D90BF744DA090539BA4AD8 sha1 C18AD90FB889F95773FEF48C204CE06CFF9E6BE3 )
 )
 
 game (
 	name "Duke Nukem - Zero Hour (France)"
 	description "Duke Nukem - Zero Hour (France)"
 	rom ( name "Duke Nukem - Zero Hour (France).n64" size 33554432 crc 8FBF7447 md5 6F7B49C80B5C4A071F6A696C1DED3E60 sha1 1777E76DD3FF153373AE458E35A29188ED901082 )
-	rom ( name "Duke Nukem - ZER0 H0UR (F) [!].z64" size 33554432 crc 7ECDFB28 md5 E2B73FEB0843874EA831A2E0076FCB72 sha1 E69A4DDA8CCA88D4C149F2B00640DA0FF04FA9C8 )
 )
 
 game (
@@ -1367,14 +1208,12 @@ game (
 	name "Duke Nukem 64 (Europe)"
 	description "Duke Nukem 64 (Europe)"
 	rom ( name "Duke Nukem 64 (Europe).n64" size 8388608 crc 9817B026 md5 217D446A4A703533181878920BF95E76 sha1 3DA4E470DC928C62FD7E0C010B9EA413321C7824 flags verified )
-	rom ( name "Duke Nukem 64 (E) [!].z64" size 8388608 crc 3275ADB0 md5 8657CBA95C409B74C1F5632CBC36643F sha1 6CC06F6097F90228BD7D7784FA7D20BA17E82EEF )
 )
 
 game (
 	name "Duke Nukem 64 (France)"
 	description "Duke Nukem 64 (France)"
 	rom ( name "Duke Nukem 64 (France).n64" size 8388608 crc CBE8C78A md5 521C4E8444786C1FF6CF9BBC6D6FACB6 sha1 BF05F8EC1A1BB936F8CC4D32F0DEADA7355B16B1 )
-	rom ( name "Duke Nukem 64 (F).z64" size 8388608 crc B9C9F07A md5 E2E79C7167BDB26E176D220904739C91 sha1 2C48706C4280A51E52691331543606E4170A19A9 )
 )
 
 game (
@@ -1388,7 +1227,6 @@ game (
 	name "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)"
 	description "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 20C3ADAB md5 404B4CEDC5DCFF08D1580E9E98B7E5C7 sha1 C613B72369292BB8A16B395073F70C586E0FA65E flags verified )
-	rom ( name "Earthworm Jim 3D (E) (M6) [!].z64" size 16777216 crc 61A56330 md5 BF2DF4B86FAA2181A7ACFE2643FA2293 sha1 F02C1AFD18C1CBE309472CBE5B3B3F04B22DB7EE )
 )
 
 game (
@@ -1402,56 +1240,48 @@ game (
 	name "ECW Hardcore Revolution (Europe)"
 	description "ECW Hardcore Revolution (Europe)"
 	rom ( name "ECW Hardcore Revolution (Europe).n64" size 33554432 crc 2FAC2C41 md5 0B8F0BBC92DD58EF7B66B4862DE3CE70 sha1 8718A6E6C75BA0DB8D2266F5A2FB0361807AC988 flags verified )
-	rom ( name "ECW Hardcore Revolution (E) [!].z64" size 33554432 crc BE8FEEAD md5 1830EDE2557E8685E6F76D05CC65076A sha1 226CAD0C48E9E0D1DC928298518CA8B2D6EAE5ED )
 )
 
 game (
 	name "ECW Hardcore Revolution (USA)"
 	description "ECW Hardcore Revolution (USA)"
 	rom ( name "ECW Hardcore Revolution (USA).n64" size 33554432 crc 4BA40079 md5 2321D612F4B48262F4A65CBA8E631A07 sha1 8BC52EC9D4A66F4C7A8DD2349C5DA90AA2DD3684 )
-	rom ( name "ECW Hardcore Revolution (U) [!].z64" size 33554432 crc 36D368EF md5 8EEBB16B7A4D39AE8BC8CCCBC41F0A01 sha1 D460DC1EB24EF3E1E27C6B125C8C8D8324A64125 )
 )
 
 game (
 	name "Eikou no Saint Andrews (Japan)"
 	description "Eikou no Saint Andrews (Japan)"
 	rom ( name "Eikou no Saint Andrews (Japan).n64" size 8388608 crc CE55BB19 md5 619D71F98B53696347C497FA5AC0C7B1 sha1 1A313D3B4B11A16B8280B0139A15E47791C8080A flags verified )
-	( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
 )
 
 game (
 	name "Elmo's Letter Adventure (USA)"
 	description "Elmo's Letter Adventure (USA)"
 	rom ( name "Elmo's Letter Adventure (USA).n64" size 8388608 crc 710011FB md5 1FA1170F9D0C037DE32D27D9D9F7AFD7 sha1 4C8E68CC1C5AF546BC9AC26DE423458141346E2C )
-	rom ( name "Elmo's Letter Adventure (U) [!].z64" size 8388608 crc 92C3BA6F md5 15DF97A59B2354B130DEC3FB86BBA513 sha1 97777CA06F4E8AFF8F1E95033CC8D3833BE40F76 )
 )
 
 game (
 	name "Elmo's Number Journey (USA)"
 	description "Elmo's Number Journey (USA)"
 	rom ( name "Elmo's Number Journey (USA).n64" size 8388608 crc B7AD0F05 md5 76E81D17D5C88EE40A1C32ED20E17B92 sha1 72419FD0A80CBDEEA635F094D6B0D086EBBB2750 )
-	Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
 )
 
 game (
 	name "Eltale Monsters (Japan)"
 	description "Eltale Monsters (Japan)"
 	rom ( name "Eltale Monsters (Japan).n64" size 16777216 crc 3541C4BB md5 1FBA4E16A562610C98F823667E29DD6F sha1 36FC37E9EEC7157961E8ACCD9E40DA4134055669 )
-	rom ( name "Eltale Monsters (J) [!].z64" size 16777216 crc A4FE7652 md5 D42CC78A2BF0D34518B8E0D0439E432E sha1 50EA6C3D4DE4B68B3C9B77524D8177066B9F36E7 )
 )
 
 game (
 	name "Excitebike 64 (Europe)"
 	description "Excitebike 64 (Europe)"
 	rom ( name "Excitebike 64 (Europe).n64" size 16777216 crc 8FEEDE6F md5 84D3DEF8AC326830573C7703A4F1D321 sha1 2579188D81BFBD26557AD7034A2931CCEA72F84F flags verified )
-	rom ( name "Excitebike 64 (E) [!].z64" size 16777216 crc 0B881E60 md5 8FA253FD69B73DF9A831EF2F731491F2 sha1 5ABFB6024F935EF5FE0067F39FD594C50697C749 )
 )
 
 game (
 	name "Excitebike 64 (Japan)"
 	description "Excitebike 64 (Japan)"
 	rom ( name "Excitebike 64 (Japan).n64" size 16777216 crc 9DFEB099 md5 6B764C5DE8ABEA1483FE52F6E1468274 sha1 AD840FE563076BD600AD0AB3AD4433B3F1A72A4C flags verified )
-	rom ( name "Excitebike 64 (J) [!].z64" size 16777216 crc 03BFD065 md5 BF15A61AFF71C93BF5E05243F57BCA1D sha1 E2C8D01FC66C0A575E79CB338678F1FD065226D6 )
 )
 
 game (
@@ -1465,7 +1295,6 @@ game (
 	name "Excitebike 64 (USA) (Demo) (Kiosk)"
 	description "Excitebike 64 (USA) (Demo) (Kiosk)"
 	rom ( name "Excitebike 64 (USA) (Demo) (Kiosk).n64" size 16777216 crc 13157DF7 md5 2E53DB0E290F91430E6D87DD4123D402 sha1 7130FB444673842807A4C38D6F2E9505C8616A39 )
-	rom ( name "Excitebike 64 (U) (Kiosk Demo) [!].z64" size 16777216 crc BE6298B0 md5 E0018C33346714B63A55C0E040F23DEA sha1 DAAF564815E9EEF3FC163B9546B5880EE256274B )
 )
 
 game (
@@ -1478,77 +1307,66 @@ game (
 	name "Extreme-G (Europe) (En,Fr,De,Es,It)"
 	description "Extreme-G (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Extreme-G (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc 1BE8E42B md5 133FEFA13974BFB77236952D2421EE18 sha1 CC28FD3B6EB8DEFF86CCCA081EF78F93B63011F4 flags verified )
-	rom ( name "Extreme-G (E) (M5) [!].z64" size 8388608 crc 0B71B1EA md5 3B2CA0DA0810C95B31DF8C1FB8811BE2 sha1 E7120856ECC9A7F29C21F45130ECA0ECA8A7BFEC )
 )
 
 game (
 	name "Extreme-G (Japan)"
 	description "Extreme-G (Japan)"
 	rom ( name "Extreme-G (Japan).n64" size 8388608 crc 856227BB md5 7F6270B7D776B117F1607C6B6F618FED sha1 AFB26291E828E049E6913F88FC11F28D097057BF flags verified )
-	rom ( name "Extreme-G (J) [!].z64" size 8388608 crc 750DC9A7 md5 A7CD65E5A4A8838D1CD452BA66E74DF6 sha1 D9D6F7CC456B530FD3233EF2D8D6B9F845CEE043 )
 )
 
 game (
 	name "Extreme-G (USA)"
 	description "Extreme-G (USA)"
 	rom ( name "Extreme-G (USA).n64" size 8388608 crc A43A0B17 md5 3F55D4E4E4A851D03BDD1667FB3EAB3A sha1 3544A3779AF1B7BCA0C03E2298AAD0ACBB3C0B2A )
-	rom ( name "Extreme-G (U) [!].z64" size 8388608 crc 04CB74EC md5 3E660D3F991C0529E90BFEC0244DB31A sha1 EB9B273431970A6124319A8FD125F0B2CACD8966 )
 )
 
 game (
 	name "Extreme-G XG2 (Europe) (En,Fr,De,Es,It)"
 	description "Extreme-G XG2 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Extreme-G XG2 (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 32FC980C md5 FD1FEB895801C0076EEE07C4DD07A1B5 sha1 3076CD1E025AEBC6168C0F33FCB215106F519DD3 flags verified )
-	rom ( name "Extreme-G XG2 (E) (M5) [!].z64" size 12582912 crc 1A57F416 md5 BB7F98E657FB4B5FCC7DC04BD72E2D2B sha1 CA6DB450D29A6CC0D4A6FBB3468A1ED725CEF51E )
 )
 
 game (
 	name "Extreme-G XG2 (Japan)"
 	description "Extreme-G XG2 (Japan)"
 	rom ( name "Extreme-G XG2 (Japan).n64" size 12582912 crc 62202D15 md5 717BE4FE42147C468F0E3F4E1820EF74 sha1 769E78EFAE2164CE03441DCDF5B2A2849F15F281 flags verified )
-	rom ( name "Extreme-G XG2 (J) [!].z64" size 12582912 crc 7C8A36DA md5 F17884A2C16FB6FD11A74D65B1388B4A sha1 94EFB5D7247A075A9CC782D39B5E8AF56D5F434F )
 )
 
 game (
 	name "Extreme-G XG2 (USA)"
 	description "Extreme-G XG2 (USA)"
 	rom ( name "Extreme-G XG2 (USA).n64" size 12582912 crc 849C18CE md5 335CE3973AE33C062C92825D8DF083D7 sha1 E27268A708B6D6A707B6E01AF94D062EA9CBC26D )
-	rom ( name "Extreme-G XG2 (U) [!].z64" size 12582912 crc 81A4C28B md5 44FE06BA3686C02A7988F27600A533DA sha1 ED0A50086EF9A89F5B445C20AB6F365165959630 )
 )
 
 game (
 	name "F-1 World Grand Prix (Europe)"
 	description "F-1 World Grand Prix (Europe)"
 	rom ( name "F-1 World Grand Prix (Europe).n64" size 12582912 crc 8C08A7A8 md5 151BC850C8078A6DC78001D2E690D32A sha1 359E4B83246BCA7F377ECFC97291F297012FEBCC )
-	rom ( name "F-1 World Grand Prix (E) [!].z64" size 12582912 crc BEBBC6C8 md5 9FBE3363DA6C146EF2E29605BCA834FF sha1 63BD69C382ECA5E569EDDF7456F6435A7DCE484F )
 )
 
 game (
 	name "F-1 World Grand Prix (France)"
 	description "F-1 World Grand Prix (France)"
 	rom ( name "F-1 World Grand Prix (France).n64" size 12582912 crc 02E9695D md5 93C9511ACFC2804CFC786CE9D849B51E sha1 40CA54DB3858AD04B328F741A79CAEF2BBD02873 )
-	rom ( name "F-1 World Grand Prix (F) [!].z64" size 12582912 crc 57CD299D md5 35F6C42D5A9284688284C24250F4D6BE sha1 DD68B3624F2F8A0F821A391B690ECC5BB4FEF2FD )
 )
 
 game (
 	name "F-1 World Grand Prix (Germany)"
 	description "F-1 World Grand Prix (Germany)"
 	rom ( name "F-1 World Grand Prix (Germany).n64" size 12582912 crc 7D8DDEFB md5 2511E6CEAB2E827E2E892BCA05BDB04F sha1 BA7A94D3CECE240276C294C2FF29AC93C59BD939 flags verified )
-	rom ( name "F-1 World Grand Prix (G) [!].z64" size 12582912 crc 0F1984DC md5 A8C78454C70BD73375AAF69C4078D5DA sha1 2AE85DB9D6E9F3B85E4478577D5EB049EC4040C9 )
 )
 
 game (
 	name "F-1 World Grand Prix (Japan)"
 	description "F-1 World Grand Prix (Japan)"
 	rom ( name "F-1 World Grand Prix (Japan).n64" size 12582912 crc 386E127D md5 8E4D9125B040019478DE77CF36729ED0 sha1 932CA3DDD3A6B4E4C1F7A1A1F9A77E14A009A6C0 flags verified )
-	rom ( name "F-1 World Grand Prix (J) [!].z64" size 12582912 crc F7BACBC3 md5 F248F0AAE609111BA9DFF9FD7AFBC485 sha1 595BFA62EC34F7884FF46137C92771CDE4D8D6FE )
 )
 
 game (
 	name "F-1 World Grand Prix (USA)"
 	description "F-1 World Grand Prix (USA)"
 	rom ( name "F-1 World Grand Prix (USA).n64" size 12582912 crc 4D203242 md5 82DCD2B311352AD9B571089AFF6B6171 sha1 CA05633242B31E3EC808945E9AFEAFC2FE4DE652 )
-	rom ( name "F-1 World Grand Prix (U) [!].z64" size 12582912 crc 7DC9EF2C md5 A81B1DE864DF3F4BB0903760BE673F21 sha1 DD17545ADC8FE2AF2A713AB48C5F71801222EDAF )
 )
 
 game (
@@ -1561,21 +1379,18 @@ game (
 	name "F-1 World Grand Prix II (Europe) (En,Fr,De,Es)"
 	description "F-1 World Grand Prix II (Europe) (En,Fr,De,Es)"
 	rom ( name "F-1 World Grand Prix II (Europe) (En,Fr,De,Es).n64" size 12582912 crc 484C801D md5 664CC372586A1AD7D1B15C1008E41470 sha1 E8E598CCD19011539E815C01131539649C3EA8DA flags verified )
-	rom ( name "F-1 World Grand Prix II (E) (M4) [!].z64" size 12582912 crc 803D33DF md5 BC0FD2468AC7769A37C3C58CD5699585 sha1 53ED343A757B8A14814732393D02B3D780BCCAB5
 )
 
 game (
 	name "F-Zero X (Europe)"
 	description "F-Zero X (Europe)"
 	rom ( name "F-Zero X (Europe).n64" size 16777216 crc 3D95DF80 md5 7B2D9E24E6535BE213BA036EFE618E31 sha1 6108DD6D6D65E1440535AAD43CAFF99C2E886340 flags verified )
-	rom ( name "F-ZERO X (E) [!].z64" size 16777216 crc 2D6F7E8B md5 EE79A8FE287B5DCAEA584439363342FC sha1 AF9038BCB543A2B4FAAAB876DBDAB4663859E092 )
 )
 
 game (
 	name "F-Zero X (Japan)"
 	description "F-Zero X (Japan)"
 	rom ( name "F-Zero X (Japan).n64" size 16777216 crc 927387B6 md5 60297B40A16AC569DEE8659062B08B7F sha1 AAD380CE474A19D3823AEAAAD3594AB0EDD47F97 flags verified )
-	rom ( name "F-ZERO X (J) [!].z64" size 16777216 crc 6B1CEF83 md5 58D200D43620007314304F4E6C9E6528 sha1 A418B0151521B76691FA03F8658C8B567C69498B )
 )
 
 game (
@@ -1589,21 +1404,18 @@ game (
 	name "F1 Pole Position 64 (Europe) (En,Fr,De)"
 	description "F1 Pole Position 64 (Europe) (En,Fr,De)"
 	rom ( name "F1 Pole Position 64 (Europe) (En,Fr,De).n64" size 8388608 crc EC8B6DB6 md5 809E19E2AB5606D9F3AD23D55F610F0D sha1 DFA0FAC4E42E6426A8213101807EC445D752934F flags verified )
-	rom ( name "F-1 Pole Position 64 (E) (M3) [!].z64" size 8388608 crc ED750623 md5 A6BD93EA576CDF8569F68171452F7E8A sha1 685FEB2E8615D5D50944093EB0552858D3E12583 )
 )
 
 game (
 	name "F1 Pole Position 64 (USA) (En,Fr,De)"
 	description "F1 Pole Position 64 (USA) (En,Fr,De)"
 	rom ( name "F1 Pole Position 64 (USA) (En,Fr,De).n64" size 8388608 crc 873BC45A md5 EA2A94D17B1513D08C0A69E277275523 sha1 BBC6CA8FE4C5BDB77D9963696BA8BF8E46FB39A6 )
-	rom ( name "F-1 Pole Position 64 (U) (M3) [!].z64" size 8388608 crc 30A24D89 md5 049DB657F4223D949F56E9DC5B6A9180 sha1 6E6BDAEFC9980F066CD2ABC5FA7F29F2353CA8B1 )
 )
 
 game (
 	name "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
 	description "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
 	rom ( name "F1 Racing Championship (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 0605E5AC md5 00898329C43A045521C609858CC590A9 sha1 9C13ED6322A45772EA881BE821C22F5157AA895A flags verified )
-	rom ( name "F1 Racing Championship (E) (M5) [!].z64" size 16777216 crc 2DA744F5 md5 9581FC6CEAC86DC8A2AEE4053043E422 sha1 3BCE20F58EF9F377299858B7F2DABD0A02D2E9B9 )
 )
 
 game (
@@ -1616,56 +1428,48 @@ game (
 	name "Famista 64 (Japan)"
 	description "Famista 64 (Japan)"
 	rom ( name "Famista 64 (Japan).n64" size 12582912 crc 51E0B88A md5 B07C622062E20E3878B8CE48EDC003AB sha1 C14270956393834DA8F670668155C41AF34AF7A9 flags verified )
-	rom ( name "Famista 64 (J) [!].z64" size 12582912 crc 9FB0E6C9 md5 D99B1A3F6D72DEFD76F3620959B94944 sha1 F4ACB365C8A0DFFDF2E93A726FD5E805AB857C56 )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)"
 	description "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)"
 	rom ( name "FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).n64" size 12582912 crc 2D49F99A md5 2A9C172F12CD6ACB941911C22FEF75C8 sha1 12A12C3B5ABA1307D947EA7F72246497755B5482 flags verified )
-	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [!].z64" size 12582912 crc 137CB3CC md5 26B18D35984528AE2F90ADBB2F2642F7 sha1 676B4D14AD74CCC92EE4B19AA9130DDCE42E0E9C )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)"
 	description "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)"
 	rom ( name "FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).n64" size 12582912 crc 9504B3DF md5 73AEDBD8AB7FE0AE842F3BD70F77ADC2 sha1 7DEB782823B8D14496CE9843384281D07CC814FC flags verified )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [!].z64" size 12582912 crc 28B1221C md5 2C6D146A8473511CFCFBBE8518F49D71 sha1 148D6424D2135AFEFECDE74092701C491027C23E )
 )
 
 game (
 	name "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)"
 	description "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)"
 	rom ( name "FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).n64" size 12582912 crc 6AE6B8ED md5 848C6DF3382206C6FC385362E6524139 sha1 83A86CE813E7DBB5C7D80B567F35FCA7E742F8BA flags verified )
-	rom ( name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!].z64" size 12582912 crc AE346DF6 md5 3611779F29997267622CBC80E2D087CC sha1 D8A0C9EF8FF258D061A639E7572D0D9E3038A895 )
 )
 
 game (
 	name "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	description "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	rom ( name "FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" size 16777216 crc CE258860 md5 ED490E6C55C665207562BD6DEFCF8973 sha1 EAB12CC33BD12923C022D2336C3B8A1001132137 flags verified )
-	rom ( name "FIFA 99 (E) (M8) [!].z64" size 16777216 crc 6EAE1E6E md5 6432C622C05EA9CD3217E280AC2CE37C sha1 07400C53AEF501887F73EF6A45CE04FE2F170FB0 )
 )
 
 game (
 	name "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	description "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)"
 	rom ( name "FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" size 16777216 crc D69DD3D1 md5 E7A508B8E27CFEF334E96DE549E385D3 sha1 5A085F6D871FB697A672F56B4023CF3B822E4CF9 )
-	rom ( name "FIFA 99 (U) [!].z64" size 16777216 crc 6B2473A9 md5 148DE3073727B9FD156F10AFADD46864 sha1 735062E593715F128D3AAD435DE0E7A899AED127 )
 )
 
 game (
 	name "FIFA Soccer 64 (Europe) (En,Fr,De)"
 	description "FIFA Soccer 64 (Europe) (En,Fr,De)"
 	rom ( name "FIFA Soccer 64 (Europe) (En,Fr,De).n64" size 8388608 crc 26F52456 md5 746AD640A23A9A4B2A8D84D05B962799 sha1 6D2F25B4D87E8DDCD8AF34831CD5952552B11F3C flags verified )
-	rom ( name "FIFA Soccer 64 (E) (M3) [!].z64" size 8388608 crc AE2583FB md5 9A7006212947EE7648EE1D13162E55E0 sha1 EACDF23E27EC1E0639042BF03804222851E4F151 )
 )
 
 game (
 	name "FIFA Soccer 64 (USA) (En,Fr,De)"
 	description "FIFA Soccer 64 (USA) (En,Fr,De)"
 	rom ( name "FIFA Soccer 64 (USA) (En,Fr,De).n64" size 8388608 crc 3B22F9F2 md5 1F7BA149359B4C402E41C40FD68EC174 sha1 A27A2BA02BB02EAAC999E60E3CEDD67FB937B580 )
-	rom ( name "FIFA Soccer 64 (U) (M3) [!].z64" size 8388608 crc 57DE7CAB md5 CC7C58A032AABA19E72CCBFA6B3EEFF6 sha1 603C5BF64497DCA86C4EB802F97F1C32E75A68A8 )
 )
 
 game (
@@ -1679,21 +1483,18 @@ game (
 	name "Fighters Destiny (Europe)"
 	description "Fighters Destiny (Europe)"
 	rom ( name "Fighters Destiny (Europe).n64" size 12582912 crc 83F9299E md5 1031918EB48CE51D0EE0F457AF9A4D41 sha1 AD18A0144137ED61012363F7E810548E7CEAA934 flags verified )
-	rom ( name "Fighter's Destiny (E) [!].z64" size 12582912 crc C9225511 md5 EF5CB24CE3FE4E0F850901205437B574 sha1 2763731085A9D86D357D8FEF775C2D21D3C9F2B4 )
 )
 
 game (
 	name "Fighters Destiny (France)"
 	description "Fighters Destiny (France)"
 	rom ( name "Fighters Destiny (France).n64" size 12582912 crc 80D968B1 md5 D0BF413496BD4D48EE0A944ECC8D6930 sha1 3EF0546BFFC49807C4C00AC7C06CA72F5A787C29 )
-	rom ( name "Fighter's Destiny (F) [!].z64" size 12582912 crc 0CC22034 md5 44B0BE1C4B48F6119D3AC9424903D0EB sha1 28C6486F4036295284A022B6D70D3BC2F64B20E8 )
 )
 
 game (
 	name "Fighters Destiny (Germany)"
 	description "Fighters Destiny (Germany)"
 	rom ( name "Fighters Destiny (Germany).n64" size 12582912 crc 0A89CA02 md5 96C8D4DD7EC9EADB01964FCABB98490B sha1 4317A5CB4ADA2D73D752FDC6C962ADE147953CF6 flags verified )
-	rom ( name "Fighter's Destiny (G) [!].z64" size 12582912 crc 5052168C md5 1CF379ACA2397222AF9F3DC5D8E3C444 sha1 AEF7792324C262C956E91EE01F57BED0C36BD825 )
 )
 
 game (
@@ -1707,14 +1508,12 @@ game (
 	name "Fighting Cup (Japan)"
 	description "Fighting Cup (Japan)"
 	rom ( name "Fighting Cup (Japan).n64" size 12582912 crc A9740235 md5 9BBF2CEB75411BFDF139D8DFBF99CA96 sha1 55F3E6E3C9FDCF0278FA494A798316600D9DB4D4 flags verified )
-	rom ( name "Fighting Cup (J) [!].z64" size 12582912 crc 8A1C261E md5 722C3A74A90305D6079A37994CEBF5B2 sha1 011BDBAA1BC6D6A5540A749CF1A90BF6A35FD94B )
 )
 
 game (
 	name "Fighting Force 64 (Europe)"
 	description "Fighting Force 64 (Europe)"
 	rom ( name "Fighting Force 64 (Europe).n64" size 16777216 crc 8D0CB2FF md5 A3BEC94D91F24DBEA7290FF0DAF92F5C sha1 0E55DB7874B9259622F54AA9B36247DB87373E58 flags verified )
-	rom ( name "Fighting Force 64 (E) [!].z64" size 16777216 crc 4052C176 md5 0035E8205336982E362402AAEA37D147 sha1 705D2B553FAB526C908E46C048BE3A3338AE2A86 )
 )
 
 game (
@@ -1728,7 +1527,6 @@ game (
 	name "Flying Dragon (Europe)"
 	description "Flying Dragon (Europe)"
 	rom ( name "Flying Dragon (Europe).n64" size 12582912 crc 00FFF973 md5 73C88384B597B0CC667F353DFAE12B79 sha1 FA71BADA5055FCDA27899D8F165224B737DC8449 flags verified )
-	rom ( name "Flying Dragon (E) [!].z64" size 12582912 crc C3066E59 md5 ADD115AAD0AB7D33BFD243936D809178 sha1 3F4462D85D5B5DDC6EDAEEF45B682EEFF7F4B144 )
 )
 
 game (
@@ -1742,14 +1540,12 @@ game (
 	name "Forsaken 64 (Europe) (En,Fr,Es,It)"
 	description "Forsaken 64 (Europe) (En,Fr,Es,It)"
 	rom ( name "Forsaken 64 (Europe) (En,Fr,Es,It).n64" size 8388608 crc 6C65EF7A md5 58A15FB343C7A2A4BB091D9585A1A99F sha1 5B6A661F75F9E3560238ACF6DFCD4287E75586C0 flags verified )
-	rom ( name "Forsaken 64 (E) (M4) [!].z64" size 8388608 crc 5ED736D9 md5 8286DED701DFA22436D311BD5B93BD29 sha1 AC24C6E48FCD03C32AEF484188BA842B619FF613 )
 )
 
 game (
 	name "Forsaken 64 (Germany)"
 	description "Forsaken 64 (Germany)"
 	rom ( name "Forsaken 64 (Germany).n64" size 8388608 crc C3FA1B8E md5 E39D59320CFE31F04AC575ABFDF21840 sha1 46E2A07B805F06E04FB4DC6934EAA0EBCCC81F76 )
-	rom ( name "Forsaken 64 (G) [!].z64" size 8388608 crc 9793ABC2 md5 74650F7154E0B2DD7C364F511B0D6A77 sha1 F1BE08780D117C44FC10A0DBA792D6C5BE7D4093 )
 )
 
 game (
@@ -1763,7 +1559,6 @@ game (
 	name "Fox Sports College Hoops '99 (USA)"
 	description "Fox Sports College Hoops '99 (USA)"
 	rom ( name "Fox Sports College Hoops '99 (USA).n64" size 12582912 crc FEDE3EF8 md5 D468CAF0AAB6D1C9607B69AD1BAD1824 sha1 86D16B039ABE70BC5B8B16805DD48483477FBDF6 )
-	rom ( name "Fox Sports College Hoops '99 (U) [!].z64" size 12582912 crc 67EAF0F3 md5 360DC6BE6D06DCA12E53C077AC0D2571 sha1 A8CE01A7D6D01BE19FFB87CB54CC069494EFB596 )
 )
 
 game (
@@ -1782,85 +1577,72 @@ game (
 	name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)"
 	description "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)"
 	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).n64" size 33554432 crc AF0A22EF md5 E520452C07479FA6A059346919340764 sha1 A50EF01EC653ED48A2B857FE2834D815CBD8E972 flags verified )
-	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!].z64" size 33554432 crc 2AA6D2A1 md5 BBCDE4966BEE5602A80D9B8C1011DFA6 sha1 F97B070A1FA6AB3D190B36D6B68A2EF182D35233 )
 )
 
 game (
 	name "G.A.S.P!! Fighters' NEXTream (Europe)"
 	description "G.A.S.P!! Fighters' NEXTream (Europe)"
 	rom ( name "G.A.S.P!! Fighters' NEXTream (Europe).n64" size 12582912 crc B0D256B8 md5 139A72A1EBFD224924F72747695C2945 sha1 FF187A9A1F357796528CA98E0B15EC227DF8A659 flags verified )
-	rom ( name "G.A.S.P!! Fighter's NEXTream (E) [!].z64" size 12582912 crc 5AA63B04 md5 316C59DAE45C20250A0419A937E7D65B sha1 B069F2C0B6AB4FBD486861C4D3AAF8A149AB4529 )
 )
 
 game (
 	name "G.A.S.P!! Fighters' NEXTream (Japan)"
 	description "G.A.S.P!! Fighters' NEXTream (Japan)"
 	rom ( name "G.A.S.P!! Fighters' NEXTream (Japan).n64" size 12582912 crc 0E05EA3A md5 A34A1FD0BFD7E2E18696370AFC642273 sha1 743673180188DFEE89F36C76602C1A75DF51716E flags verified )
-	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [!].z64" size 12582912 crc 6EAD2D89 md5 6C73558DE5A1EEE6597D7264F9A11B0C sha1 86693E6C1623708438EBF23AB0E78DD6EA8C8FA7 )
 )
 
 game (
 	name "GameBooster 64 (Europe) (v1.1) (Unl)"
 	description "GameBooster 64 (Europe) (v1.1) (Unl)"
 	rom ( name "GameBooster 64 (Europe) (v1.1) (Unl).n64" size 262144 crc 35B99BD9 md5 1A56FE2B2FE339C7DD4FF8D37EC8654B sha1 D79EE0482443C046B9E865A78F3D4507B7478AF4 )
-	rom ( name "GameBooster 64 V1.1 (PAL) (Unl).z64" size 262144 crc 35B99BD9 md5 1A56FE2B2FE339C7DD4FF8D37EC8654B sha1 D79EE0482443C046B9E865A78F3D4507B7478AF4 )
 )
 
 game (
 	name "GameBooster 64 (USA) (v1.1) (Unl)"
 	description "GameBooster 64 (USA) (v1.1) (Unl)"
 	rom ( name "GameBooster 64 (USA) (v1.1) (Unl).n64" size 262144 crc E0B8EDAE md5 60D0264B38E22EF0D6B9549E4C81C29F sha1 5D0F244584D6CC0B0CED714409412F61DE181E57 )
-	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl).z64" size 262144 crc E0B8EDAE md5 60D0264B38E22EF0D6B9549E4C81C29F sha1 5D0F244584D6CC0B0CED714409412F61DE181E57 )	
 )
 
 game (
 	name "GameShark Pro (USA) (v2.0) (Unl)"
 	description "GameShark Pro (USA) (v2.0) (Unl)"
 	rom ( name "GameShark Pro (USA) (v2.0) (Unl).n64" size 262144 crc EF9EDF87 md5 437EFD7FD7F84F4C0F802D3BF1F8464E sha1 19148A009EF8E1013AB35C8141781184B141699F )
-	rom ( name "GameShark Pro V2.0 (Unl).z64" size 262144 crc EF9EDF87 md5 437EFD7FD7F84F4C0F802D3BF1F8464E sha1 19148A009EF8E1013AB35C8141781184B141699F )
 )
 
 game (
 	name "GameShark Pro (USA) (v3.3) (Unl)"
 	description "GameShark Pro (USA) (v3.3) (Unl)"
 	rom ( name "GameShark Pro (USA) (v3.3) (Unl).n64" size 262144 crc 7CC07BBC md5 9F556D184D945369DDD11B5F815814A8 sha1 3B5046AE8129FD226EB7B02BC2C26CC7548FE6F2 )
-	rom ( name "GameShark Pro V3.3 (Mar 2000) (Unl) [!].z64" size 262144 crc 7CC07BBC md5 9F556D184D945369DDD11B5F815814A8 sha1 3B5046AE8129FD226EB7B02BC2C26CC7548FE6F2 )
-	rom ( name "GameShark Pro V3.3 (Apr 2000) (Unl) [!].z64" size 262144 crc F1851EBD md5 F275A4216744D8F04B4A0CD74DE53111 sha1 5D1E4CA8DD158AD72A6E7FCFB651F854F087FFDE )
 )
 
 game (
 	name "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)"
 	description "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)"
 	rom ( name "Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).n64" size 16777216 crc 163C3C51 md5 624742B506DF9FF5C2D86D649EB8F3FB sha1 D8EE4E745BAE3625826FF267DA5404B42F36C3C2 flags verified )
-	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!].z64" size 16777216 crc 08C41E0E md5 96CA36D474E82C270A129D775C63167A sha1 2AB71B71665A688D40832E16D897548ECE9F0DD4 )
 )
 
 game (
 	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)"
 	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)"
 	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).n64" size 16777216 crc 69964858 md5 9704B99F5F86879C0482D7223257DCEF sha1 B6386455C0B8F573E315976BBB47548CBAFCEDB3 flags verified )
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J).z64" size 16777216 crc 2E91EFC9 md5 9B929E0BF8D63E62820F2FA6257CC5CF sha1 9843EE979B5F6C80F5EDA85DF0BAED9AE7C4E73B )
 )
 
 game (
 	name "Ganbare! Nippon! Olympics 2000 (Japan)"
 	description "Ganbare! Nippon! Olympics 2000 (Japan)"
 	rom ( name "Ganbare! Nippon! Olympics 2000 (Japan).n64" size 12582912 crc 1C7E5D6E md5 2954FCA21D60748834893EFF5BF8F961 sha1 FF7721BEA55F0447E5EB84F5583BBB67DE1348D3 flags verified )
-	rom ( name "Ganbare Nippon! Olympics 2000 (J) [!].z64" size 12582912 crc 73133CD2 md5 8D8F3A8393F3F5489B3B144369565594 sha1 F683446894A704DF016B90CC3409ECDB70CBA0AA )
 )
 
 game (
 	name "Gauntlet Legends (Europe)"
 	description "Gauntlet Legends (Europe)"
 	rom ( name "Gauntlet Legends (Europe).n64" size 16777216 crc D9F765AD md5 FDBB62DE0864236733FADE8BF18F2AB8 sha1 E659120EBDE6FE00DA6815D0E10360D7A0652557 flags verified )
-	rom ( name "Gauntlet Legends (E) [!].z64" size 16777216 crc B7B3A489 md5 28C2108A375F7731E719333A09439D2F sha1 29f19e0405dca66c7383fb94104a22758a9d06dd )
 )
 
 game (
 	name "Gauntlet Legends (Japan)"
 	description "Gauntlet Legends (Japan)"
 	rom ( name "Gauntlet Legends (Japan).n64" size 16777216 crc 1F3A1912 md5 0B185F16670731A63EAC6CF7BFFE64AA sha1 C7938E334F9FA10004355F7163D5A7F3B80D981D flags verified )
-	rom ( name "Gauntlet Legends (U) [!].z64" size 16777216 crc 64765E82 md5 9CB963E8B71F18568F78EC1AF120362E sha1 0489DCCE749C6A5102681D288ED0616A4B94E99D )
 )
 
 game (
@@ -1874,21 +1656,18 @@ game (
 	name "Getter Love!! Cho Renai Party Game (Japan)"
 	description "Getter Love!! Cho Renai Party Game (Japan)"
 	rom ( name "Getter Love!! Cho Renai Party Game (Japan).n64" size 12582912 crc BBD2AE37 md5 22F83FF238790D2455CB0A155D2A4F61 sha1 17507AFA02AEC34FE3AF3077EF60A4A990626160 flags verified )
-	rom ( name "Getter Love!! (J) [!].z64" size 12582912 crc 724ECAE7 md5 5270D98F9E67DC7EF354ECE109C2A18F sha1 942D161ABF00B612486388EEE98A2C51FC990147 )
 )
 
 game (
 	name "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)"
 	description "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)"
 	rom ( name "Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).n64" size 33554432 crc 1110CC22 md5 EC10D3D8A602BBB4D7DB942B4B53CD10 sha1 1071D9CDE1DEDD1F44AEC60CAB40703643094D33 flags verified )
-	rom ( name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!].z64" size 33554432 crc 6BC4A056 md5 9F0492A34D7A2D7C4E9F29DC1848A04A sha1 54653BA26A12521CCD886212FFFDF2F6427C2FEA )
 )
 
 game (
 	name "Gex 3 - Deep Cover Gecko (Europe) (Fr,De)"
 	description "Gex 3 - Deep Cover Gecko (Europe) (Fr,De)"
 	rom ( name "Gex 3 - Deep Cover Gecko (Europe) (Fr,De).n64" size 33554432 crc D169E9F8 md5 19B3E60F53AE174321A9C410C076CBB2 sha1 EE133817A0AC2D0BE0F0EF8AA343F83E70704ACC flags verified )
-	rom ( name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!].z64" size 33554432 crc A43CB8E4 md5 43B9A7A5CCB6EA3F4860F9F80D73669D sha1 4BCD958526D9145ACF4E3EE7EE484E62DC1BB4BA )	
 )
 
 game (
@@ -1902,7 +1681,6 @@ game (
 	name "Gex 64 - Enter the Gecko (Europe)"
 	description "Gex 64 - Enter the Gecko (Europe)"
 	rom ( name "Gex 64 - Enter the Gecko (Europe).n64" size 16777216 crc 3E20EAFD md5 3429FE82DF66192EDDB2844C81BA49B1 sha1 B802DFC2015BD7F944A9633AC06C96F68001C0A8 flags verified )
-	rom ( name "Gex 64 - Enter the Gecko (E) [!].z64" size 16777216 crc A7C92BEA md5 5BBA457E286D250101CE274E0E58080D sha1 C5318E2660FED61782BB170E780B89305AA8C3DC )
 )
 
 game (
@@ -1916,7 +1694,6 @@ game (
 	name "Glover (Europe) (En,Fr,De)"
 	description "Glover (Europe) (En,Fr,De)"
 	rom ( name "Glover (Europe) (En,Fr,De).n64" size 8388608 crc 93DAE2A0 md5 6DBB99C1A623D31F7C7954873D63EFD3 sha1 D61D03147A0F88136DD3FEF4E934FA8C8BD96BC1 flags verified )
-	rom ( name "Glover (E) (M3) [!].z64" size 8388608 crc 90ECEB4A md5 2F2163C53DB135792331DF00398B3F87 sha1 A5209925761C4EF08E5D446A55BC957505308A31 )
 )
 
 game (
@@ -1948,7 +1725,6 @@ game (
 	name "Goemon - Mononoke Sugoroku (Japan)"
 	description "Goemon - Mononoke Sugoroku (Japan)"
 	rom ( name "Goemon - Mononoke Sugoroku (Japan).n64" size 16777216 crc F6BACBAC md5 6444C04AA9A4E176120FBBEE2B2DFBFD sha1 FBB8C3D20023AB13DC8EB95A23F10D8E1063D86B flags verified )
-	rom ( name "Ganbare Goemon - Mononoke Sugoroku (J) [!].z64" size 16777216 crc 965C4575 md5 2BDE49F2855030DE342976C9A95B81B3 sha1 ACCC27A72E9BD8BCAC011009A08DF7F7AAE3B2FE )
 )
 
 game (
@@ -1962,35 +1738,30 @@ game (
 	name "Golden Nugget 64 (USA)"
 	description "Golden Nugget 64 (USA)"
 	rom ( name "Golden Nugget 64 (USA).n64" size 8388608 crc 9670A4B7 md5 D6949657C4A42A35684F4C447A9FF294 sha1 543310E808DEC437A0E499410A9C39694430A7C7 )
-	rom ( name "Golden Nugget 64 (U) [!].z64" size 8388608 crc 641885DF md5 E048C2FE226634F039882C35A2A4EEA9 sha1 D64494A450B8569C4AA42390D2EAD651B407019D )
 )
 
 game (
 	name "GT64 - Championship Edition (Europe) (En,Fr,De)"
 	description "GT64 - Championship Edition (Europe) (En,Fr,De)"
 	rom ( name "GT64 - Championship Edition (Europe) (En,Fr,De).n64" size 12582912 crc B06D0D85 md5 15166FA77D606D98E6AB6A238DCECD12 sha1 A2016364DDE65EC5746BAB9710BD4FA72DA25485 flags verified )
-	rom ( name "GT 64 - Championship Edition (E) (M3) [!].z64" size 12582912 crc 6DFB4747 md5 628AA3CD492559B705488F634797E045 sha1 A4D0D694F521CEF69F64ACAEE3EB420A64F28E4D )
 )
 
 game (
 	name "GT64 - Championship Edition (USA)"
 	description "GT64 - Championship Edition (USA)"
 	rom ( name "GT64 - Championship Edition (USA).n64" size 12582912 crc B6DC4CFD md5 15AE9E64114F87DE8ADABD5A24CA8A2F sha1 BBF4039865FDCF30E403A45478DC6C8450944512 )
-	rom ( name "GT 64 - Championship Edition (U) [!].z64" size 12582912 crc BC627DA7 md5 FE81AA381719FADA693D803BAE7D5EB9 sha1 B941246AF78748F4E081F496DAC0A9E2056D3D8D )
 )
 
 game (
 	name "Hamster Monogatari 64 (Japan)"
 	description "Hamster Monogatari 64 (Japan)"
 	rom ( name "Hamster Monogatari 64 (Japan).n64" size 12582912 crc 689191C6 md5 B9B21D064BB9572F25EFBDD03DE7DFAF sha1 0460DE6B25D40CA4F8D7C4AF671C736F029812F6 flags verified )
-	rom ( name "Hamster Monogatari 64 (J) [!].z64" size 12582912 crc C1D98B78 md5 3D4C7B11076BAFA4620BCC154C0EEEF3 sha1 436627174830FB9941BD4F25EFA6FA1024498A97 )
 )
 
 game (
 	name "Harukanaru Augusta - Masters '98 (Japan)"
 	description "Harukanaru Augusta - Masters '98 (Japan)"
 	rom ( name "Harukanaru Augusta - Masters '98 (Japan).n64" size 16777216 crc AD4720E2 md5 810F6A925AA08746ABF7DFB5655D8CF4 sha1 CA7BCAE17E76880D3853C96E842DB4EE0538630D flags verified )
-	rom ( name "Harukanaru Augusta Masters 98 (J) [!].z64" size 16777216 crc 51228F0C md5 A02A4FB4B93E9847348440652CEF8D4D sha1 08AF498BCA98C79E3FA18C9C860091D5EB952E6E )
 )
 
 game (
@@ -2004,56 +1775,48 @@ game (
 	name "Heiwa Pachinko World 64 (Japan)"
 	description "Heiwa Pachinko World 64 (Japan)"
 	rom ( name "Heiwa Pachinko World 64 (Japan).n64" size 8388608 crc 3ACB817E md5 D4669DEA04E321FF393429EC344BCB53 sha1 0143E37535187F5FF40EED1C0B7A41A195C0E724 flags verified )
-	rom ( name "Heiwa Pachinko World 64 (J) [!].z64" size 8388608 crc 99A427FA md5 5E8539E037EEA88C5A2746F60E431C8D sha1 D48A484FEBAAC3BD146130434921861890503B29 )
 )
 
 game (
 	name "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).n64" size 16777216 crc 65517307 md5 FF64D07E5A429E7A434BC9A377F27360 sha1 9FC6C63EB8641D957342AA5F31D35075BC5B9E8C flags verified )
-	rom ( name "Hercules - The Legendary Journeys (E) (M6) [!].z64" size 16777216 crc B1954B08 md5 1546877FD85C00A83515005727E5FDA5 sha1 D2E26F4AECF488F87E1AB36395280385B060D229 )
 )
 
 game (
 	name "Hercules - The Legendary Journeys (USA)"
 	description "Hercules - The Legendary Journeys (USA)"
 	rom ( name "Hercules - The Legendary Journeys (USA).n64" size 16777216 crc CF90BC4A md5 0A121700A0FC84557841EEF7282316B2 sha1 09E56E035981831A2BB0B932774E4EBE34EA175F )
-	rom ( name "Hercules - The Legendary Journeys (U) [!].z64" size 16777216 crc 4948892B md5 6BBD8C42F6EF8F5B9541D6F4DB657DD7 sha1 5C3C4345BE505763FC51A9E3713F5787E4044646 )
 )
 
 game (
 	name "Hexen (Europe)"
 	description "Hexen (Europe)"
 	rom ( name "Hexen (Europe).n64" size 8388608 crc ED939F94 md5 C1D1CDC1D9DD2DCD5643468F91CE0CA6 sha1 3970A749E5B88E8130418CB06A28AF84C54BE40D flags verified )
-	rom ( name "Hexen (E) [!].z64" size 8388608 crc 5369EFB4 md5 2080262A251D270F9CE819887F2104A7 sha1 1A929AE2A7930CF4B762FA28A9D20338C5FED847 )
 )
 
 game (
 	name "Hexen (France)"
 	description "Hexen (France)"
 	rom ( name "Hexen (France).n64" size 8388608 crc 4B3DC7FE md5 B8B66454F3019BA433946A914B7AE4F1 sha1 84DA065C47E1D29155B9869970B9156428A1AE00 )
-	rom ( name "Hexen (F) [!].z64" size 8388608 crc E373FA31 md5 A5921C00111200257284CE0ABA0904CA sha1 476D3B340BA2A1B1ACC1D0CC97AC6E25A5136CA2 )
 )
 
 game (
 	name "Hexen (Germany)"
 	description "Hexen (Germany)"
 	rom ( name "Hexen (Germany).n64" size 8388608 crc 176C6242 md5 31D96B7439843350216A12906EFFC8D5 sha1 4C70006B724FC43A3283B8E2AAE9941BE6F67DEA flags verified )
-	rom ( name "Hexen (G) [!].z64" size 8388608 crc E4821C4B md5 08CBB141DEC604E4DAD2787F237D57A2 sha1 8D10CA2860D72C3C1ADB409485936C4BA3F18396 )
 )
 
 game (
 	name "Hexen (Japan)"
 	description "Hexen (Japan)"
 	rom ( name "Hexen (Japan).n64" size 8388608 crc 3D157140 md5 7648296BED096CCE8AA707ADE991EDA9 sha1 70ADC890606315107D97ADEDC02D210AB7AE8A57 flags verified )
-	rom ( name "Hexen (J) [!].z64" size 8388608 crc 571DA09A md5 672152CF4DCB5D0A19662C11EFF71452 sha1 3E3E2B012BBB873338B0573F6E11426E38F8B5CD )
 )
 
 game (
 	name "Hexen (USA)"
 	description "Hexen (USA)"
 	rom ( name "Hexen (USA).n64" size 8388608 crc D2B22343 md5 A8531BFD6FFBAD2059EF4F34AABC6282 sha1 5B58CC647FB10178C89D4DACC97CD25F5FBFF2D0 )
-	rom ( name "Hexen (U) [!].z64" size 8388608 crc 1D35E110 md5 EB98F1B8C6898AF7417F6882946DA9B3 sha1 A602839132F6CCA71F175FB72039897705BA4661 )
 )
 
 game (
@@ -2067,98 +1830,84 @@ game (
 	name "Hiryuu no Ken Twin (Japan)"
 	description "Hiryuu no Ken Twin (Japan)"
 	rom ( name "Hiryuu no Ken Twin (Japan).n64" size 12582912 crc 4A07511C md5 82DAA5FC7115D43A72DBF7566C95B106 sha1 BF68B9514A78040EDD62863DFE15B75AED397CDB flags verified )
-	rom ( name "Hiryuu no Ken Twin (J) [!].z64" size 12582912 crc BA6A687E md5 73084495F3209C54900525436BBBC531 sha1 C7A76B061C383600378E52A39DADA8D2BE58325B )
 )
 
 game (
 	name "Holy Magic Century (Europe)"
 	description "Holy Magic Century (Europe)"
 	rom ( name "Holy Magic Century (Europe).n64" size 16777216 crc 2F886030 md5 F457779A4CF5CA5AACC21589F3A8C6B4 sha1 4A5FAD6564FFB69B874B1054B702E64AED197387 flags verified )
-	rom ( name "Holy Magic Century (E) [!].z64" size 16777216 crc BF6F67BF md5 FA6A2E00BBFF236DAC91F08544AFFA40 sha1 11ACE24C670E72B1D227681B974DFBBFE81D9A38 )
 )
 
 game (
 	name "Holy Magic Century (France)"
 	description "Holy Magic Century (France)"
 	rom ( name "Holy Magic Century (France).n64" size 16777216 crc CEFC98AA md5 3110D0DC89CAA7C04F993520723842B8 sha1 31F28C9A0C6B0CA00A6015496B377936E196D498 )
-	rom ( name "Holy Magic Century (F).z64" size 16777216 crc 284170ED md5 988F5ABD96259196343659E913666820 sha1 610BF1F4A5CBEB2D6DC3AE1DAFC5B3B818F69C26 )
 )
 
 game (
 	name "Holy Magic Century (Germany)"
 	description "Holy Magic Century (Germany)"
 	rom ( name "Holy Magic Century (Germany).n64" size 16777216 crc 40796997 md5 794846ABAE030C9CD51E96B45E1718AE sha1 92DCCC50EC31676ED983AA0BD5E4056137919AB2 )
-	rom ( name "Holy Magic Century (G) [!].z64" size 16777216 crc D1934CF6 md5 AB676C3E9D26A77450DDB4AACD1A3861 sha1 AC5457FFF3FCC8D6ACFFB60FA9A99846D36FACF8 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan)"
 	description "Hoshi no Kirby 64 (Japan)"
 	rom ( name "Hoshi no Kirby 64 (Japan).n64" size 33554432 crc FCACBE90 md5 FB33B9FA1386DEE54E84CEFA7B7496F8 sha1 8861AACDF6C36B40AE2031A85798173D8D180C91 flags verified )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [!].z64" size 33554432 crc AE7CB69D md5 B1A67AEBC2BE89A800E5EB60C0DFA968 sha1 B9882992907A102BD33373585ACC90B9C7EB1BA4 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev A)"
 	description "Hoshi no Kirby 64 (Japan) (Rev A)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev A).n64" size 33554432 crc E2FAB230 md5 3B7A47D93A77E036C238917DD90E4727 sha1 E2FB9469E99CA6ED48FBE19B1F57F5FD653981A3 flags verified )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.1) [!].z64" size 33554432 crc A263C1B9 md5 FFDB4456F799722BCFE430632C3986AE sha1 2502CEB1AFBA83C90F3E7F98B283F667B85D4150 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev B)"
 	description "Hoshi no Kirby 64 (Japan) (Rev B)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev B).n64" size 33554432 crc 32D2D11E md5 2A710B570DE57061B5AFC05F7FF51069 sha1 84E2597BC65A67E8C74E47B38614C89D42E3316F flags verified )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.2) [!].z64" size 33554432 crc F4589AA8 md5 3EC0471E2CBEE17471DDBF80C56606D5 sha1 C177F4E37EFF98EF2D18FB1E94CD253FD366A218 )
 )
 
 game (
 	name "Hoshi no Kirby 64 (Japan) (Rev C)"
 	description "Hoshi no Kirby 64 (Japan) (Rev C)"
 	rom ( name "Hoshi no Kirby 64 (Japan) (Rev C).n64" size 33554432 crc 3DEC34A5 md5 CB8E9EEE8A11D6B1ABB74D7F9D647B3E sha1 95E28E31109A42E80A6A4AFEBB3157B8ACC6B4EC flags verified )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.3) [!].z64" size 33554432 crc 6D5E1332 md5 35E039F8E79843917D02BE06D00C457B sha1 03257C820B7705400C32BDE1BCC3161C55814605 )
 )
 
 game (
 	name "Hot Wheels - Turbo Racing (Europe) (En,Fr,De)"
 	description "Hot Wheels - Turbo Racing (Europe) (En,Fr,De)"
 	rom ( name "Hot Wheels - Turbo Racing (Europe) (En,Fr,De).n64" size 16777216 crc EF63C780 md5 A42DF6D45B181731707DE3A01F5B9E4F sha1 1BF92987C5531AE213ED1D721980C61F580436FA flags verified )
-	rom ( name "Hot Wheels Turbo Racing (E) (M3) [!].z64" size 16777216 crc 850633A7 md5 EF34DA35EF8A0734843CB182C19FEB26 sha1 FBCFD6D466931E5CB71FE880C52EA692C3F84D75 )
 )
 
 game (
 	name "Hot Wheels - Turbo Racing (USA)"
 	description "Hot Wheels - Turbo Racing (USA)"
 	rom ( name "Hot Wheels - Turbo Racing (USA).n64" size 12582912 crc 525E8F8F md5 3BD7F78AF738FC3D68D855C2CD525C26 sha1 477818165666648BFBE8452F2F89F42277ADD932 )
-	rom ( name "Hot Wheels Turbo Racing (U) [!].z64" size 12582912 crc A5C92148 md5 4311A1AEF1898678331F7E3486055307 sha1 94913A07E49005FFD43DFDFA16FF5862BDB93748 )
 )
 
 game (
 	name "HSV Adventure Racing! (Australia)"
 	description "HSV Adventure Racing! (Australia)"
 	rom ( name "HSV Adventure Racing! (Australia).n64" size 16777216 crc FB1294C3 md5 1D8F8CA47FE02D1950E7A9725822414E sha1 066B18E04A5AE248DB3B7041F73FE3E8E883DE93 flags verified )
-	rom ( name "HSV Adventure Racing (A).z64" size 16777216 crc C0BA9440 md5 26F7D8F4640EBDFA823F84E5F89D62BF sha1 8A9CDC2A7D98C354BA4B31CEA644DBD5153880AE )
 )
 
 game (
 	name "Human Grand Prix - The New Generation (Japan)"
 	description "Human Grand Prix - The New Generation (Japan)"
 	rom ( name "Human Grand Prix - The New Generation (Japan).n64" size 8388608 crc A3FC9AEA md5 B38D88B3F4C9AB2278306CF4C094C75D sha1 D7BC56C4ED710091BEC56C3E1485ADF1C533D1C5 flags verified )
-	rom ( name "Human Grand Prix - New Generation (J) [!].z64" size 8388608 crc 31E102E3 md5 97E706ED9CC6F30708FFDC187C85D59F sha1 B8DFE78C7ABF1E33EDAD0B5ECEC1C9F1F3C8B576 )
 )
 
 game (
 	name "Hybrid Heaven (Europe) (En,Fr,De)"
 	description "Hybrid Heaven (Europe) (En,Fr,De)"
 	rom ( name "Hybrid Heaven (Europe) (En,Fr,De).n64" size 16777216 crc 8696B2A2 md5 9C696496F4F5B9A0B6B0F13F93D8E658 sha1 3ED6D3B4127DC26FAE32E88E1FD78BF95E1118E2 flags verified )
-	rom ( name "Hybrid Heaven (E) (M3) [!].z64" size 16777216 crc E76627FF md5 DA861C4D9202F661575466450A27C412 sha1 D2210D492BAD952B055A4269E45FD89631C32D25 )
 )
 
 game (
 	name "Hybrid Heaven (Japan)"
 	description "Hybrid Heaven (Japan)"
 	rom ( name "Hybrid Heaven (Japan).n64" size 16777216 crc 42E44701 md5 2A5C6DFB0965C6C6DB2CC8E6E27832DB sha1 6B755FC59F35F0F25C46F062471699533AB99DA4 flags verified )
-	rom ( name "Hybrid Heaven (J) [!].z64" size 16777216 crc E769DE96 md5 9946EFF915FC947A226407AC1F7B35C4 sha1 09F4D3200B0BD4B984A80248AF07DE3C40B5CC26 )
 )
 
 game (
@@ -2172,42 +1921,36 @@ game (
 	name "Hydro Thunder (Europe)"
 	description "Hydro Thunder (Europe)"
 	rom ( name "Hydro Thunder (Europe).n64" size 33554432 crc B75696AE md5 18B80F3996956C282D7462B2D0CDB901 sha1 6377AFC193B7C8FA8AD3F8B3A41279D05702E43A flags verified )
-	rom ( name "Hydro Thunder (E) [!].z64" size 33554432 crc 863AB8F3 md5 434BB8DE49011573AC38E893224C5623 sha1 0661B1B0E47BC02D9B0D87D1688FD466793C074B )
 )
 
 game (
 	name "Hydro Thunder (France)"
 	description "Hydro Thunder (France)"
 	rom ( name "Hydro Thunder (France).n64" size 33554432 crc C8CD9B5D md5 B9759A54B3D69D410E9ABF9D8541D2B6 sha1 164C60C5966E4716F3A5AEF6BF6EB023E4875D32 )
-	rom ( name "Hydro Thunder (F) [!].z64" size 33554432 crc 010F6242 md5 4B4C85D9DD2D460ADAFABAE8DB48B4FA sha1 03FA91AEC0819654F1AD0D12BB81CE3F5D7D08AE )
 )
 
 game (
 	name "Hydro Thunder (USA)"
 	description "Hydro Thunder (USA)"
 	rom ( name "Hydro Thunder (USA).n64" size 33554432 crc 6B78C2C8 md5 801E1B409166F76228C3DD8DC9D286AA sha1 665E3D9773B0A6802814CD3E7B930CAB62FC583D )
-	rom ( name "Hydro Thunder (U) [!].z64" size 33554432 crc E744456F md5 54F43E6B68782E98CAABEA5E7976B2BE sha1 F5D5054F97DA0D68857F9824130147EC38EE7A76 )
 )
 
 game (
 	name "Hyper Olympics in Nagano 64 (Japan)"
 	description "Hyper Olympics in Nagano 64 (Japan)"
 	rom ( name "Hyper Olympics in Nagano 64 (Japan).n64" size 12582912 crc F7C2BB67 md5 2148B042F40957F75C7BF8C8BFD1BB87 sha1 51EA8AF6B29FC99A9C61DD2242C3732B6CDF43DC flags verified )
-	rom ( name "Hyper Olympics Nagano 64 (J) [!].z64" size 12582912 crc C1EA5D33 md5 D2F7B3ACE75A2CE7A06BEAC929711D94 sha1 3D0F36371F99C8ABC8E835DAE4E0913757EE4827 )
 )
 
 game (
 	name "Ide Yosuke no Mahjong Juku (Japan)"
 	description "Ide Yosuke no Mahjong Juku (Japan)"
 	rom ( name "Ide Yosuke no Mahjong Juku (Japan).n64" size 12582912 crc 32003C85 md5 20364F316726FAF88490CE3FE1FB42F2 sha1 278E45431689B52CE28955957B444AE4F8539199 flags verified )
-	rom ( name "Ide Yosuke no Mahjong Juku (J) [!].z64" size 12582912 crc A4A24517 md5 DC577D70E9308F94E5F3CE03F3508539 sha1 A38F22CFA8FE1588C85CEFB0602F5A910136932A )
 )
 
 game (
 	name "Iggy's Reckin' Balls (Europe)"
 	description "Iggy's Reckin' Balls (Europe)"
 	rom ( name "Iggy's Reckin' Balls (Europe).n64" size 4194304 crc 76530405 md5 08DEEF2DBCADDC2BCB08B5ECCCFD7E48 sha1 67C05C4056FE7E38D34FEA26E4A87EDF570910AF flags verified )
-	rom ( name "Iggy's Reckin' Balls (E) [!].z64" size 4194304 crc 9BF26065 md5 25B297143E9E5CCBB4B80A7FB6AF399B sha1 DA3C5BA5849E104383EA4C3DF1FBDB8253F184C9 )
 )
 
 game (
@@ -2221,21 +1964,18 @@ game (
 	name "Iggy-kun no Bura Bura Poyon (Japan)"
 	description "Iggy-kun no Bura Bura Poyon (Japan)"
 	rom ( name "Iggy-kun no Bura Bura Poyon (Japan).n64" size 4194304 crc E133064B md5 611FEC9AF7DD0D6A4064963042C538EC sha1 02542CFDC3734350403E4FB7CC139953436584D8 flags verified )
-	rom ( name "Iggy-kun no Bura Bura Poyon (J) [!].z64" size 4194304 crc 26CC1266 md5 C70B0B680807F2B8C2C3D5DC495FA8C2 sha1 EBB8C0C99D000A366D2DBA0D8D184EC18AA82D43 )
 )
 
 game (
 	name "In-Fisherman - Bass Hunter 64 (Europe)"
 	description "In-Fisherman - Bass Hunter 64 (Europe)"
 	rom ( name "In-Fisherman - Bass Hunter 64 (Europe).n64" size 8388608 crc 930E6F44 md5 7249524A0519489E8173B29246E6DD70 sha1 3D09C3384069A4BCF959BFB05CF7A9F398C6CEB6 flags verified )
-	rom ( name "Bass Hunter 64 (E) [!].z64" size 8388608 crc 00DA3704 md5 BF3E84CDD01CAC05987FD8DA5191534B sha1 D36374BE227E972B1C0B6F2CFBB8FDD724AA1074 )
 )
 
 game (
 	name "In-Fisherman - Bass Hunter 64 (USA)"
 	description "In-Fisherman - Bass Hunter 64 (USA)"
 	rom ( name "In-Fisherman - Bass Hunter 64 (USA).n64" size 8388608 crc 88279F19 md5 3451C623E119C62E8A0AC6C3E57BFF6F sha1 39FDE60D5447006CF864624860F3889C8B20EF27 )
-	rom ( name "In-Fisherman Bass Hunter 64 (U) [!].z64" size 8388608 crc D8EB5E6E md5 C605F40BF669E00A5E51BAF0D00621EA sha1 4AA373E23876C89A549C98036F456B564D779217 )
 )
 
 game (
@@ -2255,182 +1995,156 @@ game (
 	name "Indy Racing 2000 (USA)"
 	description "Indy Racing 2000 (USA)"
 	rom ( name "Indy Racing 2000 (USA).n64" size 16777216 crc 1C622354 md5 7E6DFA14B1550EC31D33B33695E67AEF sha1 B8983FA34D9614AF433FEE6DFD331BF8793A4DD1 )
-	rom ( name "Indy Racing 2000 (U) [!].z64" size 16777216 crc A5163F29 md5 A7781D441AF55C4FF8AFC68AB3A59313 sha1 015BF0E0BC700A80A2606D3578E4A9B7645E99EC )
 )
 
 game (
 	name "International Superstar Soccer '98 (Europe)"
 	description "International Superstar Soccer '98 (Europe)"
 	rom ( name "International Superstar Soccer '98 (Europe).n64" size 12582912 crc 463FE8B7 md5 7AB4ED7CDABB83C9D507C7F50E7E4D12 sha1 4FC51FBE034F8572B4727756778DE7A27B43C81A flags verified )
-	rom ( name "International Superstar Soccer '98 (E) [!].z64" size 12582912 crc BF23945D md5 34489365B550F32C97337D86D52D8C84 sha1 CCAFFEE3A793A0C3A5E7C48FBC4A4759EF29153F )
 )
 
 game (
 	name "International Superstar Soccer '98 (USA)"
 	description "International Superstar Soccer '98 (USA)"
 	rom ( name "International Superstar Soccer '98 (USA).n64" size 12582912 crc D685F2EC md5 673AE2592FC748112B78D2A21C95A43D sha1 1EE4DD4D774FED61248513E0D2F5285918B98D73 )
-	rom ( name "International Superstar Soccer '98 (U) [!].z64" size 12582912 crc B85FA721 md5 7DCC05B98E2FA690B478808EBBAD5D1A sha1 053735184D414E0A1BBD888F3C931252EA1B92FD )
 )
 
 game (
 	name "International Superstar Soccer 2000 (Europe) (En,De)"
 	description "International Superstar Soccer 2000 (Europe) (En,De)"
 	rom ( name "International Superstar Soccer 2000 (Europe) (En,De).n64" size 16777216 crc 61799242 md5 DF6E682CA10BE8F1995FDCF4186482AE sha1 E6D2B8E25D3FCD9F38439EF07D71E9F8A48A4F99 flags verified )
-	rom ( name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!].z64" size 16777216 crc 69572558 md5 9F101B6F6BEF4F267DEB5C6C37A24B97 sha1 E7078E5F1E899382B1CC145DF43EE8CFAA924297 )
 )
 
 game (
 	name "International Superstar Soccer 2000 (Europe) (Fr,It)"
 	description "International Superstar Soccer 2000 (Europe) (Fr,It)"
 	rom ( name "International Superstar Soccer 2000 (Europe) (Fr,It).n64" size 16777216 crc 7D7DCD46 md5 65B79B1226B0D29068024EE3D3E8CEF4 sha1 640EC4BF4C838814B003ADD093B0F9642058FE04 )
-	rom ( name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!].z64" size 16777216 crc 8A16A6A9 md5 CC2BE97A16744860FAE8A94611479C4C sha1 B0505E13BA0F029EA735378C50B224FD618BE302 )
 )
 
 game (
 	name "International Superstar Soccer 2000 (USA) (En,Es)"
 	description "International Superstar Soccer 2000 (USA) (En,Es)"
 	rom ( name "International Superstar Soccer 2000 (USA) (En,Es).n64" size 16777216 crc BB1824B8 md5 3513028962D61ED2396C43F67CB9ED7D sha1 D86386EEEE1B5B32CE43BC9A4149314A23A6320B )
-	rom ( name "International Superstar Soccer 2000 (U) (M2) [!].z64" size 16777216 crc DCD0538F md5 23A4ED8D79882594206173B1D476F0E9 sha1 E7BD36C410CE881D8B8DC853CB4B7B7961BF6A62 )
 )
 
 game (
 	name "International Superstar Soccer 64 (Europe)"
 	description "International Superstar Soccer 64 (Europe)"
 	rom ( name "International Superstar Soccer 64 (Europe).n64" size 8388608 crc 662DA098 md5 8C255FD7A678E8E948A205C9AC37A04C sha1 C19B5DD94ED7EC6799DA5F41A14EC67F2493F119 flags verified )
-	rom ( name "International Superstar Soccer 64 (E) [!].z64" size 8388608 crc 8C839268 md5 376803F28CA8B2133671783419933CA2 sha1 3B53FD76BB37B923B0FE61E50057AE773A25170A )
 )
 
 game (
 	name "International Superstar Soccer 64 (USA)"
 	description "International Superstar Soccer 64 (USA)"
 	rom ( name "International Superstar Soccer 64 (USA).n64" size 8388608 crc 91CB6803 md5 DA2174464A3BD5DF10F8D891D8896E9D sha1 94D4969597596C9E990754AEFDD506D3C75177BA )
-	rom ( name "International Superstar Soccer 64 (U) [!].z64" size 8388608 crc 0EA249B9 md5 6A345402AE1DB5CE1041365E36126BCE sha1 D2C258EE3844BE77049E4AF5208F8F2BB073A86E )
 )
 
 game (
 	name "International Track & Field - Summer Games (Europe) (En,Fr,De)"
 	description "International Track & Field - Summer Games (Europe) (En,Fr,De)"
 	rom ( name "International Track & Field - Summer Games (Europe) (En,Fr,De).n64" size 12582912 crc 73073EC2 md5 A944268E3E840B3F1017BD4F0098390C sha1 E08B8E0EB424CB9044B53D5D903AB89CC82F0FB8 flags verified )
-	rom ( name "International Track & Field Summer Games (E) (M3) [!].z64" size 12582912 crc B3181EE0 md5 970488FB7D9C5C25BD924E6F898B84A0 sha1 B3D5A2128813BD077DD3E161978E3C1717E278E0 )
 )
 
 game (
 	name "International Track & Field 2000 (USA)"
 	description "International Track & Field 2000 (USA)"
 	rom ( name "International Track & Field 2000 (USA).n64" size 12582912 crc F93868A3 md5 CE7249FFFFB3D600010435F34574A527 sha1 D5B614B9A95086B2366C5470659FA5B89FACEC68 )
-	rom ( name "International Track & Field 2000 (U) [!].z64" size 12582912 crc DA443F0B md5 35662CFD07FD6AF4BAB90CA23F7C98E6 sha1 61D7958E61B50FD933FAF5D3AE70807FA53818FB )
 )
 
 game (
 	name "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)"
 	description "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)"
 	rom ( name "Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).n64" size 16777216 crc 5E9C3E4B md5 E75D722A11840424C21FF77A847A49C8 sha1 E9581337DF0F93638DDAF328F84BFE92E5764474 flags verified )
-	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!].z64" size 16777216 crc 576915D4 md5 13893DB9E919C4E7CF0C0B0064CCB554 sha1 C722BA7FD7C44FEE474233DB3FD251177A83A9AB )
 )
 
 game (
 	name "J.League Dynamite Soccer 64 (Japan)"
 	description "J.League Dynamite Soccer 64 (Japan)"
 	rom ( name "J.League Dynamite Soccer 64 (Japan).n64" size 8388608 crc 67EC5F38 md5 E9CBA40742F4DDE165AD54A9377929F4 sha1 FBD0A8B7D405A06E3A955E6F897C667EAC3F03A7 flags verified )
-	rom ( name "J.League Dynamite Soccer 64 (J) [!].z64" size 8388608 crc DC0B2C8F md5 1247B093E0FD6CCFD50D15DE59301076 sha1 B5618FFDE759BCEF12A19B336CF940DF24F52209 )
 )
 
 game (
 	name "J.League Eleven Beat 1997 (Japan)"
 	description "J.League Eleven Beat 1997 (Japan)"
 	rom ( name "J.League Eleven Beat 1997 (Japan).n64" size 8388608 crc B2D77747 md5 AC6CBD30B676412C9E52330C82048ED0 sha1 C5D159BDDC89DA2224E1D32C695248998C4560BD flags verified )
-	rom ( name "J.League Eleven Beat 1997 (J).z64" size 8388608 crc 7D0EED6A md5 30E23D3DE446E37E5E7FBEF6794A6FC9 sha1 0403902145CED0C42252981BC6C8FEF2F76CCC08 )
 )
 
 game (
 	name "J.League Live 64 (Japan)"
 	description "J.League Live 64 (Japan)"
 	rom ( name "J.League Live 64 (Japan).n64" size 8388608 crc 8A48DE94 md5 3372BCC3042D76130075C20F9F86030C sha1 563C4F5D0B7CBE2EC675153D52EEFB2901E5B624 flags verified )
-	rom ( name "J.League Live 64 (J) [!].z64" size 8388608 crc 4C536DD7 md5 209DB8333EEB526AE9A91209175348CE sha1 447E573EB019BF4ACD48B926C89701E09198EE36 )
 )
 
 game (
 	name "J.League Tactics Soccer (Japan)"
 	description "J.League Tactics Soccer (Japan)"
 	rom ( name "J.League Tactics Soccer (Japan).n64" size 12582912 crc 0B6C70EA md5 A6FD45ACAE3F889AC559A72F982643A1 sha1 058E9CCD131199394E0D6E6F6EA04AEEB2946D59 flags verified )
-	rom ( name "J.League Tactics Soccer (J) (V1.0) [!].z64" size 12582912 crc 976A2D12 md5 800ACC7D609ECDB3E09E68CBD05F5FA0 sha1 853CECC41C00F1BBC9972DFFB94B78BDB0DFA274 )
 )
 
 game (
 	name "J.League Tactics Soccer (Japan) (Rev A)"
 	description "J.League Tactics Soccer (Japan) (Rev A)"
 	rom ( name "J.League Tactics Soccer (Japan) (Rev A).n64" size 12582912 crc 71FA1D4D md5 4C2E19F6EF05A390356D6C9A4D13D15E sha1 BC3A2585E96E64E1F0D8CB7C2F7F38F0A6163319 flags verified )
-	rom ( name "J.League Tactics Soccer (J) (V1.1) [!].z64" size 12582912 crc 156E705E md5 793DBF504E20C92F6B73B4E8A25A220C sha1 9A47293D82C161F1CB146673AC6AD96C1730C624 )
 )
 
 game (
 	name "Jangou Simulation Mahjong Dou 64 (Japan)"
 	description "Jangou Simulation Mahjong Dou 64 (Japan)"
 	rom ( name "Jangou Simulation Mahjong Dou 64 (Japan).n64" size 8388608 crc 27E9853C md5 21755B140310E9E062ADDDFA51AB4475 sha1 D969105F2EC0D1116E35B66410ACAC4B207AAF3D flags verified )
-	rom ( name "Jangou Simulation Mahjong Do 64 (J) [!].z64" size 8388608 crc D1C1681E md5 8EE01DE7DA2E9AD08D7ED913A5EE8632 sha1 F2F96B00709AC81BA8228BB38A8396824C29CE51 )
 )
 
 game (
 	name "Jeopardy! (USA)"
 	description "Jeopardy! (USA)"
 	rom ( name "Jeopardy! (USA).n64" size 4194304 crc 82B2AB69 md5 BD65646119CF596491406E59EE60FED8 sha1 6F22227EA9A64F16F4B8A5A8B84A30FAC55FD84C )
-	rom ( name "Jeopardy! (U) [!].z64" size 4194304 crc E739947C md5 A45F7200537C0D928A88CBBA2DFEB680 sha1 C5BCF3EFF6BCDD9E7846CE5FD5DB3095DB9C58ED )
 )
 
 game (
 	name "Jeremy McGrath Supercross 2000 (Europe)"
 	description "Jeremy McGrath Supercross 2000 (Europe)"
 	rom ( name "Jeremy McGrath Supercross 2000 (Europe).n64" size 16777216 crc EFE0B465 md5 D4C85F5DACECF2787EDD4A387BE0AB01 sha1 3E61CE15A20BE752240C889C37BE82270BDD423E flags verified )
-	rom ( name "Jeremy McGrath Supercross 2000 (E) [!].z64" size 16777216 crc 5BF42EC4 md5 4C5BE1BFC1CCCFF501EBA2A685226962 sha1 7804A688C9F7ED39D9C1A33C0339F4317D3918DC )
 )
 
 game (
 	name "Jeremy McGrath Supercross 2000 (USA)"
 	description "Jeremy McGrath Supercross 2000 (USA)"
 	rom ( name "Jeremy McGrath Supercross 2000 (USA).n64" size 16777216 crc 67BF293B md5 BED43C3E682F5450CD35C346CB230532 sha1 1C0352BAD4F56F1CF5D892E85F2D04D956EDB49E )
-	rom ( name "Jeremy McGrath Supercross 2000 (U) [!].z64" size 16777216 crc 2A5C9A06 md5 8046A4B8ABD4353B2AB9696106CCF8D2 sha1 278AD55333B7B75970812ECB9E691111CA3CFC46 )
 )
 
 game (
 	name "Jet Force Gemini (Europe) (En,Fr,De,Es)"
 	description "Jet Force Gemini (Europe) (En,Fr,De,Es)"
 	rom ( name "Jet Force Gemini (Europe) (En,Fr,De,Es).n64" size 33554432 crc FEC297EF md5 761A047404C6460A077FF858E0244A8F sha1 3085A20258F3A554839D0007CB231BC9B96875BC flags verified )
-	rom ( name "Jet Force Gemini (E) (M4) [!].z64" size 33554432 crc CFBED88C md5 BAAF237E71AA7526C9B2F01C08B68A53 sha1 50651C4E0C46332F7F0B45870263F0A8B9A49602 )
 )
 
 game (
 	name "Jet Force Gemini (USA)"
 	description "Jet Force Gemini (USA)"
 	rom ( name "Jet Force Gemini (USA).n64" size 33554432 crc B5932174 md5 0EF01AFDE32E40228C03904E3D884ADD sha1 AA7EDC75952104F0B52BF1300DF427835A128B01 )
-	rom ( name "Jet Force Gemini (U) [!].z64" size 33554432 crc 6753D5A3 md5 772CC6EAB2620D2D3CDC17BBC26C4F68 sha1 493CED9008DBE932D6E91179B68E8630CF23A023 )
 )
 
 game (
 	name "Jet Force Gemini (USA) (Demo) (Kiosk)"
 	description "Jet Force Gemini (USA) (Demo) (Kiosk)"
 	rom ( name "Jet Force Gemini (USA) (Demo) (Kiosk).n64" size 33554432 crc 6E75735B md5 D9DB99C392E85A82C551CF7808D742ED sha1 4C1EEDFAC94EA2041A765E60CAAC00ABF77A678D )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [!].z64" size 33554432 crc FA061B96 md5 5BBE9ADE7171F2E1DAAA7C48FAD38728 sha1 F00F7C7FB085D0DF57DCB649793ACED5BE4E8562 )
 )
 
 game (
 	name "Jikkyou G1 Stable (Japan)"
 	description "Jikkyou G1 Stable (Japan)"
 	rom ( name "Jikkyou G1 Stable (Japan).n64" size 16777216 crc 97669431 md5 3CFEDA8E61349753835B37EF56514627 sha1 076D1EF9AF18A6456048A1699AAD377AEAB8772F flags verified )
-	rom ( name "Jikkyou G1 Stable (J) [!].z64" size 16777216 crc 0A796C3E md5 878D8A26FD02FDB08200464CB6F566EF sha1 EB7B24BAC29DF362CAB562662AE9A5DE7D5FB0C3 )
 )
 
 game (
 	name "Jikkyou G1 Stable (Japan) (Rev A)"
 	description "Jikkyou G1 Stable (Japan) (Rev A)"
 	rom ( name "Jikkyou G1 Stable (Japan) (Rev A).n64" size 16777216 crc 142072BF md5 614489CEED70C2D44CDCBF147E8F3D34 sha1 6DA9B4181B3AEC624D9B9CE507251C319313411F )
-	rom ( name "Jikkyou J.League Perfect Striker (J) [!].z64" size 8388608 crc 8ED60DEA md5 58153AC5C4030D1BFD3C15CF57FB02E7 sha1 E1185922648A6B9DEC1C820F43A292E480E396CC )
 )
 
 game (
 	name "Jikkyou J.League 1999 - Perfect Striker 2 (Japan)"
 	description "Jikkyou J.League 1999 - Perfect Striker 2 (Japan)"
 	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (Japan).n64" size 16777216 crc 8E2F8322 md5 73F742C7199D7A6FBF18DF68E8957A0E sha1 25033E8EBAA71316D108DE450971180B544DE315 )
-	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!].z64" size 16777216 crc 153AEB15 md5 3D2CCA1B2E3BDE267769812219EDB864 sha1 B713D43DE585C06C6757070EF0274CF434424261 )
 )
 
 game (
@@ -2449,35 +2163,30 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu 2000 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 2000 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (Japan).n64" size 16777216 crc 45E04C78 md5 7D09F9F9B087ED758A0337CB9AEF25C6 sha1 5705CBEE7664F8EB184FD451E219F5954060B5A8 flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!].z64" size 16777216 crc 351CDE48 md5 23409668A6E6C4ECE7B5FB0B7D0E8F2C sha1 365D6EFA2665B816A5E0E2233C890DDCD524C05D )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A)"
 	description "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev A).n64" size 16777216 crc 4E6FAA43 md5 EEDDACC180DF4702B4D367D2973EBF7D sha1 6F32972FE2FDCE0AC051787B8253950AA36487D1 flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!].z64" size 16777216 crc 753706EF md5 B653C963ED8D3A749676810F07CFE4E5 sha1 2B9425BE9C6F76EB6594D414299C24E19CF12992 )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 4 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 4 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (Japan).n64" size 12582912 crc 8D2540F1 md5 BC1762B17751DB7BB7B2C55B8A9D6E70 sha1 73016B7C15BAE869B0D868E62B433400503EF540 flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!].z64" size 12582912 crc 480B953E md5 FDA57F65EB159278223EB9D03267C27F sha1 7E27A27BAD4F98500D7A68EC43AB7BFFE5DE03E1 )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A)"
 	description "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev A).n64" size 12582912 crc 435126AE md5 12BC7271B915B0A8C7FE8DD5EA7BDCCA sha1 44287562745C42662B61224EBFD9B483867EAFEE flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!].z64" size 12582912 crc 40E3AC61 md5 B454490EB44F0978F009FA41DE8C478E sha1 D11B2860925C3784CBD4AD163111414537C5378A )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 5 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 5 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (Japan).n64" size 16777216 crc 94FA55FF md5 078319B0411390250349D4BE269B9F1C sha1 7822E0015E716AE540E95F50C32558EAA7865174 flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [!].z64" size 16777216 crc FEEC34F6 md5 E9F989E09E3F1519AEFE619889A4F710 sha1 F1BC8D2A6B03FFAB7355C4E7B5FA1C393421E9F9 )
 )
 
 game (
@@ -2496,7 +2205,6 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu 6 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu 6 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (Japan).n64" size 16777216 crc A54E4397 md5 86E100B32C6AD951831DB09D3A58CD97 sha1 AE89AA2CD42AA841984C3E9EE2E3AADA1148BF2D flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [!].z64" size 16777216 crc D9329895 md5 E6129460E23170FFD4EC4B09D5E0CC56 sha1 938C8D82E470D4E407AAD90F14B250803BCAB0B4 )
 )
 
 game (
@@ -2515,7 +2223,6 @@ game (
 	name "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan)"
 	description "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan)"
 	rom ( name "Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan).n64" size 16777216 crc 4E102917 md5 2A9636FED3DF9F4093CA3D370AF0CD99 sha1 0F34CC6C6448CF4956DCCDABEAC0FBBD1F36DCA1 flags verified )
-	rom ( name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!].z64" size 16777216 crc 6A9E24D7 md5 7FC933A64884A382AA07605EA7204FF5 sha1 B24170ED95734DD12084CA3C82B678FABCBD4279 )
 )
 
 game (
@@ -2528,98 +2235,84 @@ game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan).n64" size 16777216 crc 970A3C24 md5 12C04BC4A8C7BB05453C7992086549C6 sha1 5FFD475D721C334ED82CA7BC99ED0E17C025D1E4 flags verified )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!].z64" size 16777216 crc 5C721850 md5 A05E7DB2409DEECCA36E48E9D931CACB sha1 BB1C7A8634BA6078843532264A8676F80D5B79FC )
 )
 
 game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev A).n64" size 16777216 crc 7576897D md5 05F8642B057570C23E30441E7A2955C4 sha1 CFBDEB8A9218B147B2CFF8D087B3D3FB07E9CD37 flags verified )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!].z64" size 16777216 crc 68DBCC04 md5 538B54C2AAEA73FAA3A021D42A3225BE sha1 E9ED8A0ED5B7B20B80F0E140CC4B7261A89143BB )
 )
 
 game (
 	name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B)"
 	description "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B)"
 	rom ( name "Jikkyou World Soccer - World Cup France '98 (Japan) (Rev B).n64" size 16777216 crc 55551947 md5 4876E203993FF609A34E60EA8204ACBB sha1 B86CB29227A7173338B6A2245E760BE5344379B6 flags verified )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!].z64" size 16777216 crc F63F9A5E md5 2E5FD9303138E8F558BF67BB9E799960 sha1 8EA26072DD7DA07C567EBCA7C25071739EC563FB )
 )
 
 game (
 	name "Jikkyou World Soccer 3 (Japan)"
 	description "Jikkyou World Soccer 3 (Japan)"
 	rom ( name "Jikkyou World Soccer 3 (Japan).n64" size 8388608 crc 8755DE1F md5 0A060338879D75C8603F931E6D8362E2 sha1 E1C73256A92E98BCB79D2D4C56EFCE77F0FF158B flags verified )
-	rom ( name "Jikkyou World Soccer 3 (J) [!].z64" size 8388608 crc 3BA9E644 md5 EF0F425689586850A6F5796124B0C85B sha1 A06528CE7A1C007F3E8DFAE199B6E65B3DBC034D )
 )
 
 game (
 	name "Jikuu Senshi Turok (Japan)"
 	description "Jikuu Senshi Turok (Japan)"
 	rom ( name "Jikuu Senshi Turok (Japan).n64" size 8388608 crc C3230021 md5 C88376BDEF9580777FDB2EEDD5B6E3EC sha1 182394E9772985DDD45E4459A58916FBA9F386AD flags verified )
-	rom ( name "Tokisora Senshi Turok (J) [!].z64" size 8388608 crc E6BD65D5 md5 7B261247150C431DE55AB371E8B46EA8 sha1 726BAEFD703EB2CA72EC22B4AAB8844662F32845 )
 )
 
 game (
 	name "Jinsei Game 64 (Japan)"
 	description "Jinsei Game 64 (Japan)"
 	rom ( name "Jinsei Game 64 (Japan).n64" size 16777216 crc 888B4265 md5 56FB8AC309038EF2F68A8B3B0456C915 sha1 CE9931571E9D60CC3C92458F89FBDBED214ED833 flags verified )
-	rom ( name "Jinsei Game 64 (J) [!].z64" size 16777216 crc 67A1A22C md5 68230D510015FF6817EF898C0B8B636C sha1 8759A3FC272C3F6259BBE2433EB34411705D8634 )
 )
 
 game (
 	name "John Romero's Daikatana (Europe) (En,Fr,De)"
 	description "John Romero's Daikatana (Europe) (En,Fr,De)"
 	rom ( name "John Romero's Daikatana (Europe) (En,Fr,De).n64" size 16777216 crc 48F3E888 md5 AF13198DB692DA423806E88114BFFC77 sha1 0A9400897CB7984A0E927A47F912405664AB70BA flags verified )
-	rom ( name "John Romero's Daikatana (E) (M3) [!].z64" size 16777216 crc F88AC3CE md5 7AB29C6AD2D8F4007D8213EB3411E0BD sha1 0278C3F9B2780890C4C2A3EE8A10C550A1EDA346 )
 )
 
 game (
 	name "John Romero's Daikatana (Japan)"
 	description "John Romero's Daikatana (Japan)"
 	rom ( name "John Romero's Daikatana (Japan).n64" size 16777216 crc BEFB1434 md5 45711F060D945982CE4DFFB9F5E31306 sha1 8BDA39F1E1C39020FF259B1D4D1CCB2C87D1EE38 flags verified )
-	rom ( name "John Romero's Daikatana (J) [!].z64" size 16777216 crc 44B80FD7 md5 57D31EA7121DD5A05B547225EFA5CFD7 sha1 4ED2EC28997865E301C5693639C2EC717C79A5BC )
 )
 
 game (
 	name "John Romero's Daikatana (USA)"
 	description "John Romero's Daikatana (USA)"
 	rom ( name "John Romero's Daikatana (USA).n64" size 16777216 crc CB126EA9 md5 FEE7F48F3DA74AEA78994FFC862A3641 sha1 C9F3D07AF09ADEF1CC977BF263B899E005A5AAB6 )
-	rom ( name "John Romero's Daikatana (U) [!].z64" size 16777216 crc 494950C6 md5 5B4C268422469F50B94779E655F2B798 sha1 08709013D512F3A2BED65B98AB451EC8B839D3B4 )
 )
 
 game (
 	name "Kakutou Denshou - F-Cup Maniax (Japan)"
 	description "Kakutou Denshou - F-Cup Maniax (Japan)"
 	rom ( name "Kakutou Denshou - F-Cup Maniax (Japan).n64" size 16777216 crc 1E967AC0 md5 327A06936FB2B4944B3A3328BC0D7F6A sha1 6E7116DB2A7AABD5F8D6149F34B6E187BCAAEC3C flags verified )
-	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [!].z64" size 16777216 crc DB40A155 md5 DFF0EFE2B35FCDE506D21B0C0BD373A5 sha1 F88F541D5913C99A9EAC5CA4162E65B8A3828725 )
 )
 
 game (
 	name "Ken Griffey Jr.'s Slugfest (USA)"
 	description "Ken Griffey Jr.'s Slugfest (USA)"
 	rom ( name "Ken Griffey Jr.'s Slugfest (USA).n64" size 16777216 crc 42D1ED42 md5 E6993C8FCEB6E4841639AF2701454830 sha1 EC8497EE9EBE1333032472B39206F9899C9213B3 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [!].z64" size 16777216 crc 12D8F3E9 md5 EEC0FAB75AF59E9C23E6DE2132DE89FF sha1 EC33CD4D44BBA163F89E435C2AEFBF7313D8CECE )
 )
 
 game (
 	name "Killer Instinct Gold (Europe)"
 	description "Killer Instinct Gold (Europe)"
 	rom ( name "Killer Instinct Gold (Europe).n64" size 12582912 crc 19421CA7 md5 AC5067339580E952D8BBFCC967756949 sha1 A7A6428EE27E62B9E2D91280C71B29963E5F3B22 flags verified )
-	rom ( name "Killer Instinct Gold (E) [!].z64" size 12582912 crc 5D0EE5D2 md5 C93D92F10A1A97D2BA87386BE7D178FD sha1 E0ED97C7310B012A5CF81C6F6678A75B8601B47E )
 )
 
 game (
 	name "Killer Instinct Gold (USA)"
 	description "Killer Instinct Gold (USA)"
 	rom ( name "Killer Instinct Gold (USA).n64" size 12582912 crc B279E4B2 md5 7AC487BA50FC8FB8993DACC60DED57BD sha1 75E148B5F290B08F7E0A661EE485FB5A79F4A54A )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [!].z64" size 12582912 crc 31C76BE7 md5 8E33AD20C31FEB61D7230FAD28846C5C sha1 BA52E91B44450C548467044B26951353DC491E04 )
 )
 
 game (
 	name "Killer Instinct Gold (USA) (Rev A)"
 	description "Killer Instinct Gold (USA) (Rev A)"
 	rom ( name "Killer Instinct Gold (USA) (Rev A).n64" size 12582912 crc 24AC459C md5 BEC96E5480969151888482631BD26626 sha1 90B7D7E5A7372CA3ABF059C0D24D499FAD2E909D )
-	rom ( name "Killer Instinct Gold (U) (V1.1) [!].z64" size 12582912 crc 49EF8F2B md5 4C9B419DC583C0DF4AB908ADF83BFC65 sha1 BCC599ED0F0B8B75A8068269958A2230EC7CB34C )
 )
 
 game (
@@ -2633,21 +2326,18 @@ game (
 	name "King Hill 64 - Extreme Snowboarding (Japan)"
 	description "King Hill 64 - Extreme Snowboarding (Japan)"
 	rom ( name "King Hill 64 - Extreme Snowboarding (Japan).n64" size 12582912 crc BC5F8666 md5 AB3BB51E491CC39FDC2F4BB95F4F1E52 sha1 35DF68D6C1BE28EF72ED54AD7F19BF1504C43C2A flags verified )
-	rom ( name "King Hill 64 - Extreme Snowboarding (J) [!].z64" size 12582912 crc F120CC52 md5 CCA4E87EC206B5B65AEAB9531C0F275B sha1 10924AB3C8909B18DAE64FEDE304AF2A08D7FFE1 )
 )
 
 game (
 	name "Kiratto Kaiketsu! 64 Tanteidan (Japan)"
 	description "Kiratto Kaiketsu! 64 Tanteidan (Japan)"
 	rom ( name "Kiratto Kaiketsu! 64 Tanteidan (Japan).n64" size 12582912 crc 9FC8A30C md5 57814D8E06DEE516B9873509C04AEA1E sha1 C6B8349A834853501397225E29D2A7DECEDD07F1 flags verified )
-	rom ( name "Kira to Kaiketsu! 64 Tanteidan (J) [!].z64" size 12582912 crc 7FDC3784 md5 32257BFFFD9B2D680F582E148E9B0611 sha1 5340930EE4A26D8897C8734EE812E769C162BE0F )
 )
 
 game (
 	name "Kirby 64 - The Crystal Shards (Europe)"
 	description "Kirby 64 - The Crystal Shards (Europe)"
 	rom ( name "Kirby 64 - The Crystal Shards (Europe).n64" size 33554432 crc F1EB0F93 md5 1AF046C0638F8E401270976841D1AB58 sha1 47CD5958A26E9A118CF7D15B65D613DB894FA8B7 flags verified )
-	rom ( name "Kirby 64 - The Crystal Shards (E) [!].z64" size 33554432 crc 5B8B89EF md5 A44B7A612964A6D6139D0426E569D9C9 sha1 52E8382252EC9B629662153EAE6F87AE3675B700 )
 )
 
 game (
@@ -2661,76 +2351,60 @@ game (
 	name "Knife Edge - Nose Gunner (Europe)"
 	description "Knife Edge - Nose Gunner (Europe)"
 	rom ( name "Knife Edge - Nose Gunner (Europe).n64" size 8388608 crc 35B61293 md5 7F5681A7C28870C568A92D3639EBE0E3 sha1 FEAF0B775E71DD35D5A1FEF72E3CF4CE6E06D230 flags verified )
-	rom ( name "Knife Edge - Nose Gunner (E) [!].z64" size 8388608 crc B77783BE md5 D31A94A5685A21A932CC886D64CC9B21 sha1 5359C747E91C9119FDE3A7920333A9D0C04D251D )
 )
 
 game (
 	name "Knife Edge - Nose Gunner (Japan)"
 	description "Knife Edge - Nose Gunner (Japan)"
 	rom ( name "Knife Edge - Nose Gunner (Japan).n64" size 8388608 crc 2FF68ED9 md5 1152129CAC86E01ADF68D1ED052BC679 sha1 5E1ECEDDB5FD98A08DD5F08CE85FF6F9DFF34417 flags verified )
-	rom ( name "Knife Edge - Nose Gunner (J) [!].z64" size 8388608 crc 3BC93017 md5 436BA873E9466AAB237D9429348A5F70 sha1 B3242226237A401436D9D7A8D533296333E64240 )
 )
 
 game (
 	name "Knife Edge - Nose Gunner (USA)"
 	description "Knife Edge - Nose Gunner (USA)"
 	rom ( name "Knife Edge - Nose Gunner (USA).n64" size 8388608 crc CF204405 md5 2CCBEA019D3D1AAA1E8E6198DD677573 sha1 B6B92B53285D22967E2250B6D020350EAFB72643 )
-	rom ( name "Knife Edge - Nose Gunner (U) [!].z64" size 8388608 crc 255EE1DD md5 8043D829FCD4F8F72DD81E5C6DDE916F sha1 B247167E37E7F62924BE6B0D2362A091FD2352AC )
 )
 
 game (
 	name "Knockout Kings 2000 (Europe)"
 	description "Knockout Kings 2000 (Europe)"
 	rom ( name "Knockout Kings 2000 (Europe).n64" size 16777216 crc 3C38BA4A md5 9E560C7EB237EC3B23CCF95F1BD6A535 sha1 F21EB0318863175C3DDC73757636383D824B7202 flags verified )
-	rom ( name "Knockout Kings 2000 (E) [!].z64" size 16777216 crc 58CE7D80 md5 E95D73FF55FBB63E79AA9EAB14608584 sha1 181D220EFAA3E06AC5A7BAAC4B6A351B762EC384 )
 )
 
 game (
 	name "Knockout Kings 2000 (USA)"
 	description "Knockout Kings 2000 (USA)"
 	rom ( name "Knockout Kings 2000 (USA).n64" size 16777216 crc A26533FC md5 E10DE38BC510ED100318BF313F666D1C sha1 2C8A091CB5EE9BE6AAAF390D25642E12409330F8 )
-	rom ( name "Knockout Kings 2000 (U) [!].z64" size 16777216 crc 074690D6 md5 008B473841CE4D9AC050D55F99B4B5D4 sha1 AE7229676DA9ACB39BECB03246969693585B7728 )
 )
 
 game (
 	name "Kobe Bryant in NBA Courtside (Europe)"
 	description "Kobe Bryant in NBA Courtside (Europe)"
 	rom ( name "Kobe Bryant in NBA Courtside (Europe).n64" size 12582912 crc 5ADEF1C7 md5 F388EDBB69B82BC116B7EFC020B7ACAD sha1 CAB29E7B3D9C1993801E415B5823567B8FE2F682 flags verified )
-	rom ( name "Kobe Bryant in NBA Courtside (E) [!].z64" size 12582912 crc 1355A826 md5 C6B01C020FDFD2E5C037C5A330B161AD sha1 6390DC1CD4600CA57069D92F39F108A4CC1B62F1 )
 )
 
 game (
 	name "Kobe Bryant's NBA Courtside (USA)"
 	description "Kobe Bryant's NBA Courtside (USA)"
 	rom ( name "Kobe Bryant's NBA Courtside (USA).n64" size 12582912 crc 0FF8C439 md5 D34D9DDA767D0AF4D2E6803FC5CF81C6 sha1 C17D414B741338FD2C079B1AC6238D4ED87B0675 )
-	rom ( name "Kobe Bryant's NBA Courtside (U) [!].z64" size 12582912 crc 86360BFB md5 D37C79E4E4EABCB5DC6A07BD76688223 sha1 49346B3124750C14DDDF56B9BB2FE38B618F28F2 )
 )
 
 game (
 	name "Last Legion UX (Japan)"
 	description "Last Legion UX (Japan)"
 	rom ( name "Last Legion UX (Japan).n64" size 12582912 crc C3DAF1AA md5 8FF522EBFEA649A45B8A8247AFE2875E sha1 3D434DF177270A319B83D99DF74F0C2D59C8C370 flags verified )
-	rom ( name "Last Legion UX (J) [!].z64" size 12582912 crc 9DB99881 md5 EB11FC0797AE1107201C4601FEE5471A sha1 DFDF852D0939466AD1F1627F4DE29B7288A77589 )
 )
 
 game (
 	name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)"
 	description "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)"
 	rom ( name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).n64" size 33554432 crc 9267F4BA md5 53990A4AE36382AE17D15E26EDF89C92 sha1 8BF74834C614F6CCB7C659B82DFDC68BA61301A4 flags verified )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!].z64" size 33554432 crc 9EAD1608 md5 13FAB67E603B002CEAF0EEA84130E973 sha1 C04599CDAFEE1C84A7AF9A71DF68F139179ADA84 )
 )
 
 game (
 	name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A)"
 	description "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A)"
 	rom ( name "Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev A).n64" size 33554432 crc 1D4D50B7 md5 59BFB6DE226C9CFD6825EA59EA5D8663 sha1 B02A477871BBB90E75F09E714BF30991FD2B8CAF )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1).z64" size 33554432 crc E2E6823D md5 BECCFDED43A2F159D03555027462A950 sha1 BB4E4757D10727C7584C59C1F2E5F44196E9C293 )
-)
-
-game (
-	name "Legend of Zelda, The - Majora's Mask (USA) (GC)"
-	description "Legend of Zelda, The - Majora's Mask (USA) (GC)"
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) (GC).z64" size 33554432 crc B008458F md5 AC0751DBC23AB2EC0C3144203ACA0003 sha1 9743AA026E9269B339EB0E3044CD5830A440C1FD )
 )
 
 game (
@@ -2743,8 +2417,7 @@ game (
 game (
 	name "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
 	description "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
-	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo)" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
-	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc DCC110A0 md5 8F281800FBA5DDCB1D2B377731FC0215 sha1 2F0744F2422B0421697A74B305CB1EF27041AB11 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo).n64" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
 )
 
 game (
@@ -2754,35 +2427,15 @@ game (
 )
 
 game (
-	name "Legend of Zelda, The - Majora's Mask - Collector's Edition (Europe) (M4) (GC)"
-	description "Legend of Zelda, The - Majora's Mask - Collector's Edition (Europe) (M4) (GC)"
-	rom ( name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!].z64" size 33554432 crc 12836E19 md5 DBE9AF0DB46256E42B5C67902B696549 sha1 A849A65E56D57D4DD98B550524150F898DF90A9F )
-)
-
-game (
-	name "Legend of Zelda, The - Ocarina of Time (Europe) (GC)"
-	description "Legend of Zelda, The - Ocarina of Time (Europe) (GC)"
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!].z64" size 33554432 crc 3FBD519F md5 2C27B4E000E85FD78DBCA551F1B1C965 sha1 0227D7C0074F2D0AC935631990DA8EC5914597B4 )
-)
-
-game (
 	name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)"
 	description "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).n64" size 33554432 crc 9852A62F md5 9526B263B60577D8ED22FB7A33C2FACD sha1 D0BDC2EB320668B4BA6893B9AEFE4040A73123FF flags verified )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!].z64" size 33554432 crc 946FD0F7 md5 E040DE91A74B61E3201DB0E2323F768A sha1 328A1F1BEBA30CE5E178F031662019EB32C5F3B5 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A)"
 	description "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A).n64" size 33554432 crc AB0FFBAE md5 AE0D5CE5C27D4ECCBB6D206B854A7159 sha1 663C34F1B2C05A09E5BEFFE4D0DCD440F7D49DC7 flags verified )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!].z64" size 33554432 crc A108F6E3 md5 D714580DD74C2C033F5E1B6DC0AEAC77 sha1 CFBB98D392E4A9D39DA8285D10CBEF3974C2F012 )
-)
-
-game (
-	name "Legend of Zelda, The - Ocarina of Time (USA) (GC)"
-	description "Legend of Zelda, The - Ocarina of Time (USA) (GC)"
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!].z64" size 33554432 crc 346DE3AE md5 CD09029EDCFB7C097AC01986A0F83D3F sha1 B82710BA2BD3B4C6EE8AA1A7E9ACF787DFC72E9B )
 )
 
 game (
@@ -2796,34 +2449,24 @@ game (
 	name "Legend of Zelda, The - Ocarina of Time (USA) (Rev A)"
 	description "Legend of Zelda, The - Ocarina of Time (USA) (Rev A)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (Rev A).n64" size 33554432 crc AA07C8BA md5 A9A86A09677B0394F15C62CA60906FBD sha1 18CD0EB65914A21D8FA08DFE71C29D865E9D728A flags verified )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!].z64" size 33554432 crc 3FD2151E md5 721FDCC6F5F34BE55C43A807F2A16AF4 sha1 D3ECB253776CD847A5AA63D859D8C89A2F37B364 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time (USA) (Rev B)"
 	description "Legend of Zelda, The - Ocarina of Time (USA) (Rev B)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (Rev B).n64" size 33554432 crc 3C7DBF5B md5 1F26107A97CD9D923DF493EBFBFD234D sha1 3AC86253E0C0D55486D212E647350C1527B9C92D )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!].z64" size 33554432 crc 32120C23 md5 57A9719AD547C516342E1A15D5C28C3D sha1 41B3BDC48D98C48529219919015A1AF22F5057C2 )
 )
 
 game (
 	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version)"
 	description "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Version).n64" size 67108864 crc 2EE3E247 md5 DDE376D47187B931820D5B2957CDED14 sha1 973BC6FE56010A8D646166A1182A81B4F13B8CF9 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version).z64" size 67108864 crc 62F92704 md5 8CA71E87DE4CE5E9F6EC916202A623E9 sha1 50BEBEDAD9E0F10746A52B07239E47FA6C284D03 )
-)
-
-game (
-	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GC)"
-	description "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GC)"
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!].z64" size 33554432 crc C744C4DB md5 DA35577FE54579F6A266931CC75F512D sha1 8B5D13AAC69BFBF989861CFDC50B1D840945FC1D )
 )
 
 game (
 	name "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	description "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	rom ( name "LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" size 16777216 crc 3D4679E5 md5 0224FEB5786ED25BB0B21BF6FE180BAD sha1 C221ABC794BB1C67DA5499ACEA8C80222B200A90 flags verified )
-	rom ( name "LEGO Racers (E) (M10) [!].z64" size 16777216 crc C7D9B21C md5 6310C7173385ED2B06020F3B90158E9E sha1 6E9C4B097628F0147E9E79393DBA6D7B4E59986F )
 )
 
 game (
@@ -2837,154 +2480,132 @@ game (
 	name "Let's Smash (Japan)"
 	description "Let's Smash (Japan)"
 	rom ( name "Let's Smash (Japan).n64" size 12582912 crc 33543946 md5 160FAE47DE863D4A772CB01A95CEF2E1 sha1 7DD60D27CC1CABF70A380FA2A567621EF8E69DCD flags verified )
-	rom ( name "Let's Smash Tennis (J) [!].z64" size 12582912 crc 455A1770 md5 AEE5016E6D60D12AD768E9F6D10ADDE8 sha1 6FDA28A79CEC30B6C52C3DBC96B513DA16BFA4D0 )
 )
 
 game (
 	name "Lode Runner 3-D (Europe) (En,Fr,De,Es,It)"
 	description "Lode Runner 3-D (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Lode Runner 3-D (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc 78707CEA md5 879D630EF468FF1873FDE9CC860B3D8D sha1 80C368DA49A956756D14D4E5B313E3D64A772F36 flags verified )
-	rom ( name "Lode Runner 3-D (E) (M5) [!].z64" size 8388608 crc 7148251D md5 E62F4FDCC82C244BA9709E40756D9B62 sha1 3B198C0117DA808B25FBC4E543D282228BB4780A )
 )
 
 game (
 	name "Lode Runner 3-D (Japan)"
 	description "Lode Runner 3-D (Japan)"
 	rom ( name "Lode Runner 3-D (Japan).n64" size 8388608 crc 8A1AE6A7 md5 EF70842D44DA034ED89CDCB2520109C7 sha1 62C0D2599BB3EBBAB3602F5E1CB5CFC2626506D4 flags verified )
-	rom ( name "Lode Runner 3-D (J) [!].z64" size 8388608 crc 1D4FB466 md5 D2BD8DD8C3BE1E8F0B8AE49206DBD7E5 sha1 A115C19E1DEA438861437A326124C0E7A482DE3B )
 )
 
 game (
 	name "Lode Runner 3-D (USA)"
 	description "Lode Runner 3-D (USA)"
 	rom ( name "Lode Runner 3-D (USA).n64" size 8388608 crc 5AF38589 md5 A884DFD24237F838FC902C2CA0D5A3F4 sha1 361CA0A284CE8DE1B8E54716ED3952A179E0A148 )
-	rom ( name "Lode Runner 3-D (U) [!].z64" size 8388608 crc 4EA07453 md5 D038813541589F0B3F1F900F4FD22C9B sha1 D3A13C0CFDFF835FDF87D5DC7C5149FBA564877F )
 )
 
 game (
 	name "Lylat Wars (Australia) (En,Fr,De)"
 	description "Lylat Wars (Australia) (En,Fr,De)"
 	rom ( name "Lylat Wars (Australia) (En,Fr,De).n64" size 12582912 crc ED1249A5 md5 A51F94CA0CE8BFE1BAD0192957F0DCE0 sha1 9CBF5087D5684D3B5329630932EB2BFB29AF8511 )
-	rom ( name "Lylat Wars (A) (M3) [!].z64" size 12582912 crc 9A3425DA md5 7A99628EDF0A6602D0C408F31B701435 sha1 47A8CCC11450F9044CA2292B9FC3C58949B9CAAC )
 )
 
 game (
 	name "Lylat Wars (Europe) (En,Fr,De)"
 	description "Lylat Wars (Europe) (En,Fr,De)"
 	rom ( name "Lylat Wars (Europe) (En,Fr,De).n64" size 12582912 crc 94A1A16A md5 204A14C2AC815AFEE74B58EF9394708D sha1 8DE2942E59E31FEA235AD672F6096294D8E7D12E flags verified )
-	rom ( name "Lylat Wars (E) (M3) [!].z64" size 12582912 crc 50A9C0B1 md5 884CCCA35CBEEDB8ED288326F9662100 sha1 05B307B8804F992AF1A1E2FBAFBD588501FDF799 )
 )
 
 game (
 	name "Mace - The Dark Age (Europe)"
 	description "Mace - The Dark Age (Europe)"
 	rom ( name "Mace - The Dark Age (Europe).n64" size 12582912 crc 4BDF2D6C md5 C325018C2DD647A4761B29DBB87DC03C sha1 904AE518FD489EF94E0F379A4020D96A1771C2C0 flags verified )
-	rom ( name "Mace - The Dark Age (E) [!].z64" size 12582912 crc 57DDEDE1 md5 523883A766C662E8377CD256755B27B4 sha1 19FC1FE13A3C50A5D03D44D2E93440967C7F3618 )
 )
 
 game (
 	name "Mace - The Dark Age (USA)"
 	description "Mace - The Dark Age (USA)"
 	rom ( name "Mace - The Dark Age (USA).n64" size 12582912 crc E49D603A md5 F56E658854300DB6CEDF9B3C41983CED sha1 55D187B8AE20D2271F96FA9A8FB76FC11301A2EB )
-	rom ( name "Mace - The Dark Age (U) [!].z64" size 12582912 crc D2A363A6 md5 39A2BCA1C17CD4CF1A9F3AE2B725B5C6 sha1 05D82A2C73AC536180B68137DBB9972A9E8E883E )
 )
 
 game (
 	name "Madden Football 64 (Europe)"
 	description "Madden Football 64 (Europe)"
 	rom ( name "Madden Football 64 (Europe).n64" size 12582912 crc C39F863D md5 46721FF8604B3F18E3FC2B0C28C5CEBD sha1 711C709393CDC4D76CA9E3CC669504144F554BC5 flags verified )
-	rom ( name "Madden Football 64 (E) [!].z64" size 12582912 crc FAB3E50D md5 67C96076459EB5F71733F39D7FCC76A3 sha1 ACF22B715B11609F42DF24ABAC143BC0221D12F4 )
 )
 
 game (
 	name "Madden Football 64 (USA)"
 	description "Madden Football 64 (USA)"
 	rom ( name "Madden Football 64 (USA).n64" size 12582912 crc 43B28179 md5 14F3988408E222F8B1A0FC9D8E2C6DF6 sha1 65FDC159374E6161A0CE0BA8ED520A669512094F )
-	rom ( name "Madden Football 64 (U) [!].z64" size 12582912 crc 42E5FAFA md5 903B912CE88626900221731224E9DBE8 sha1 B0DE34B759F18AD86D39A4C68C9840D35CE25809 )
 )
 
 game (
 	name "Madden NFL 2000 (USA)"
 	description "Madden NFL 2000 (USA)"
 	rom ( name "Madden NFL 2000 (USA).n64" size 12582912 crc F41B2332 md5 50E191F2CDC12AAEDBD6694C6D6BB431 sha1 A2A09DFDE793BD42F5B3C11429628E48794091B1 )
-	rom ( name "Madden NFL 2000 (U) [!].z64" size 12582912 crc EF5F997B md5 955D19E26B4BA7CC941F86A54A0FC13D sha1 EC01DE96960EA23A9EE997F4456C5C8EE7BAF7E4 )
 )
 
 game (
 	name "Madden NFL 2001 (USA)"
 	description "Madden NFL 2001 (USA)"
 	rom ( name "Madden NFL 2001 (USA).n64" size 12582912 crc 3B49EC33 md5 6B386503E10CA7494C20B6BE4FC1EADF sha1 FBA3C676A8ACD733F16DDF7EF9BF95811974F9F1 )
-	rom ( name "Madden NFL 2001 (U) [!].z64" size 12582912 crc 245EAEE8 md5 441FA65FAA5C12339F89A0BB7DB43C8F sha1 93F5BA646098E1AA45ECEC6312604A0932EDD24B )
 )
 
 game (
 	name "Madden NFL 2002 (USA)"
 	description "Madden NFL 2002 (USA)"
 	rom ( name "Madden NFL 2002 (USA).n64" size 12582912 crc 0C711DFE md5 6D90DAA85DF1667C3B7CD431AF703A3F sha1 DF3F696131141B4E5BC9E71A72A9815FB24C9112 )
-	rom ( name "Madden NFL 2002 (U) [!].z64" size 12582912 crc F573F107 md5 AD0F2EC565D7575FB37512BC8DF8A092 sha1 DE51147A238158ADC059D0CC75FD39BBB08DCFC6 )
 )
 
 game (
 	name "Madden NFL 99 (Europe)"
 	description "Madden NFL 99 (Europe)"
 	rom ( name "Madden NFL 99 (Europe).n64" size 12582912 crc 5DCAD836 md5 62BA00F622C9AFA26E5C4D4E9F8B3D28 sha1 C6D88BBF811E3973EF6B9FB8A565424ABF2C15B6 flags verified )
-	rom ( name "Madden NFL 99 (E) [!].z64" size 12582912 crc D0929942 md5 E7BF80861A0AB2A788959463D953B5D5 sha1 7C55BA6741DCF96208432507B8191B3C15F666DF )
 )
 
 game (
 	name "Madden NFL 99 (USA)"
 	description "Madden NFL 99 (USA)"
 	rom ( name "Madden NFL 99 (USA).n64" size 12582912 crc AC21A5BF md5 CE6D203535E27FB7A98FD6F2C10490A8 sha1 FD5DA6FEF67461FB5D6767D933663DCFA6E0F054 )
-	rom ( name "Madden NFL 99 (U) [!].z64" size 12582912 crc 2EB64FC2 md5 507CEAB72EF2A1BF145BF190F5CE1C80 sha1 2E8595C6EA0267A0344C0E203B4B08F00A42B13A )
 )
 
 game (
 	name "Magical Tetris Challenge (Europe)"
 	description "Magical Tetris Challenge (Europe)"
 	rom ( name "Magical Tetris Challenge (Europe).n64" size 16777216 crc BF53BF3D md5 5B0931119D80F5EDFFCDBD0B9F612228 sha1 4885E3951584032FB0254CBBDBA9961C45C3D10F flags verified )
-	rom ( name "Magical Tetris Challenge (E) [!].z64" size 16777216 crc AF3B099E md5 20E51B27E8098A9D101B44689014C281 sha1 ECC73F8A0A530EE42A56B46611DA6F74B728FE7D )
 )
 
 game (
 	name "Magical Tetris Challenge (Germany)"
 	description "Magical Tetris Challenge (Germany)"
 	rom ( name "Magical Tetris Challenge (Germany).n64" size 16777216 crc 16995CF8 md5 6DBE632A26B64EFE3E6372A14A8304F5 sha1 DF058519CCE4B5517B10C633F2A2DBD882018F47 )
-	rom ( name "Magical Tetris Challenge (G) [!].z64" size 16777216 crc 377F18E9 md5 E0992A90191BE4F1B2BA02258599334E sha1 ACE81319209D50D074418934554CBFB261D27288 )
 )
 
 game (
 	name "Magical Tetris Challenge (USA)"
 	description "Magical Tetris Challenge (USA)"
 	rom ( name "Magical Tetris Challenge (USA).n64" size 16777216 crc 167C60E6 md5 25F5F55C6938175F06140099A1FF46A9 sha1 D0CBBE4E61AF75B6BC41AE76881F81B499F1AE3E )
-	rom ( name "Magical Tetris Challenge (U) [!].z64" size 16777216 crc 22FE979C md5 79FCC98002D1F4C79DEAF55784222DF8 sha1 CA3FBD17406031A88E04BB79959D851550B641D0 )
 )
 
 game (
 	name "Magical Tetris Challenge featuring Mickey (Japan)"
 	description "Magical Tetris Challenge featuring Mickey (Japan)"
 	rom ( name "Magical Tetris Challenge featuring Mickey (Japan).n64" size 16777216 crc 6D3EBA8B md5 980CE31C0DC220C1DA8D73322B70CA88 sha1 43848D4A70A0D33B4C94B340895F0A09561B6BBC flags verified )
-	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [!].z64" size 16777216 crc 7EFB2F1E md5 F1FF1F364C459701F42BEB8989675D44 sha1 FE7C8FA25EA09280F94D08623BB8838D88EEC2E3 )
 )
 
 game (
 	name "Mahjong 64 (Japan)"
 	description "Mahjong 64 (Japan)"
 	rom ( name "Mahjong 64 (Japan).n64" size 8388608 crc 0FB9138C md5 AEC0D0CFD27C0771FF41870ACFA83DC6 sha1 3C9D98DFC27E9B5A8F085A2F189F42E2A77A970E flags verified )
-	rom ( name "Mahjong 64 (J) [!].z64" size 8388608 crc DBE7D51A md5 8AE2E8F0C356FEE638C8D908DCBB3381 sha1 41C73C372FF316322593B791D09934B37C461F9F )
 )
 
 game (
 	name "Mahjong Hourouki Classic (Japan)"
 	description "Mahjong Hourouki Classic (Japan)"
 	rom ( name "Mahjong Hourouki Classic (Japan).n64" size 12582912 crc FD9EA0D5 md5 4FC66A872680B5EBE1A4402B85B33E21 sha1 DBB8E86F53953ABC97FA015F50523264689D3331 flags verified )
-	rom ( name "Mahjong Hourouki Classic (J) [!].z64" size 12582912 crc 990A8E54 md5 E942A3EEB1EB572BADD6F705EB12A22C sha1 405E6BCB6AD4A1452FE50AAC1278A3F411C378C0 )
 )
 
 game (
 	name "Mahjong Master (Japan)"
 	description "Mahjong Master (Japan)"
 	rom ( name "Mahjong Master (Japan).n64" size 8388608 crc DB0B662A md5 BCD1E29BB785D81B6DDE356E5E270B4E sha1 734F5865D4E293A3FC28E167A0AAF79DDEFE8837 flags verified )
-	rom ( name "Mahjong Master (J) [!].z64" size 8388608 crc B68D596F md5 CF0D228E8EFDF823A227979BB352DD5B sha1 556DD6DBBEC02680E47362552D2BABD4F8720050 )
 )
 
 game (
@@ -2994,23 +2615,15 @@ game (
 )
 
 game (
-	name "Major League Baseball Featuring Ken Griffey Jr. (Europe)"
-	description "Major League Baseball Featuring Ken Griffey Jr. (Europe)"
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [!].z64" size 16777216 crc E08F7578 md5 152B9939A5F50734D5401980028856B4 sha1 E300E8ACB110D72BC5BFEE4FC4981E09B881300E )
-)
-
-game (
 	name "Major League Baseball featuring Ken Griffey Jr. (USA)"
 	description "Major League Baseball featuring Ken Griffey Jr. (USA)"
 	rom ( name "Major League Baseball featuring Ken Griffey Jr. (USA).n64" size 16777216 crc 7542D45D md5 3A99F4F24ADEE8C6E53BCC410FBD35FE sha1 EE0AB1E8AF669712AFBAF4B9BBCEE62E8EB13A4A )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [!].z64" size 16777216 crc 2EF1EA20 md5 764F22AD3D0F59667A7F083D2F789B31 sha1 54B8C97523089D92754C2582A7B7A43246947122 )
 )
 
 game (
 	name "Mario Golf (Europe)"
 	description "Mario Golf (Europe)"
 	rom ( name "Mario Golf (Europe).n64" size 33554432 crc 1CA3E8B6 md5 D5033F389476733D5730B112F61C2D47 sha1 B77C8A9F163FEB9AE2F2253B6D9EC82D77B7088C flags verified )
-	rom ( name "Mario Golf (E) [!].z64" size 25165824 crc E5D723C7 md5 4D010AE1AF4B04D6B70B799C56F05993 sha1 3AEC0837A5C2AACF172A83D7F60BD5B004B5DE72 )
 )
 
 game (
@@ -3024,7 +2637,6 @@ game (
 	name "Mario Golf 64 (Japan)"
 	description "Mario Golf 64 (Japan)"
 	rom ( name "Mario Golf 64 (Japan).n64" size 33554432 crc 889091FD md5 D8196C554ABD7A8C71F8BA225DB3B1AF sha1 137B9591194489CFC33D29FA0B054D9954DB4E1E flags verified )
-	rom ( name "Mario Golf 64 (J) [!].z64" size 25165824 crc 911F179A md5 E5A041B1B7C8E3B4C2E8178E5A138E2D sha1 0B57E0859BC984105C669DEEFDC866231DEB1BD9 )
 )
 
 game (
@@ -3037,28 +2649,24 @@ game (
 	name "Mario Kart 64 (Europe)"
 	description "Mario Kart 64 (Europe)"
 	rom ( name "Mario Kart 64 (Europe).n64" size 12582912 crc 6787E212 md5 02B214F4C1A288DD74E2870723C6FED3 sha1 F1324F0A316ED895A92097B949E3AA74AEFEDDA5 flags verified )
-	rom ( name "Mario Kart 64 (E) (V1.0) [!].z64" size 12582912 crc FAA6B083 md5 8FAD1E4FA7BAF1443B7F21AD1947B429 sha1 A729039453210B84F17019DDA3F248D5888F7690 )
 )
 
 game (
 	name "Mario Kart 64 (Europe) (Rev A)"
 	description "Mario Kart 64 (Europe) (Rev A)"
 	rom ( name "Mario Kart 64 (Europe) (Rev A).n64" size 12582912 crc 032625B0 md5 4172E73D0F2939683214D631F9E4F51E sha1 F18317BFD7FBCAEA6CFBFCB9C4AE3C7C7D1D66C7 flags verified )
-	rom ( name "Mario Kart 64 (E) (V1.1) [!].z64" size 12582912 crc 0248F6C3 md5 2BB149A583FDEFEA96805F628FE42FD9 sha1 F6B5F519DD57EA59E9F013CC64816E9D273B2329 )
 )
 
 game (
 	name "Mario Kart 64 (Japan)"
 	description "Mario Kart 64 (Japan)"
 	rom ( name "Mario Kart 64 (Japan).n64" size 12582912 crc 4711A9DC md5 F5037802F4485B9CAE6158AC5F9EF0B7 sha1 991D4F714730CDEF771AB1E32DA5A324388619B7 flags verified )
-	rom ( name "Mario Kart 64 (J) (V1.0) [!].z64" size 12582912 crc 5D9696DF md5 BF964CECA78A13A82055EBDA80B95CCA sha1 AFEEEC65B9A03F0CB8EC92F9BA7A9F0122E8BD0E )
 )
 
 game (
 	name "Mario Kart 64 (Japan) (Rev A)"
 	description "Mario Kart 64 (Japan) (Rev A)"
 	rom ( name "Mario Kart 64 (Japan) (Rev A).n64" size 12582912 crc 26450AAB md5 7C5002BF20B22CAA2226A0C382974D62 sha1 42769BC9467DF9A517A88E28F9CE2B6956A7A15F )
-	rom ( name "Mario Kart 64 (J) (V1.1) [!].z64" size 12582912 crc 6CED6472 md5 60535265BAE43DDFCBDB0D71594B1693 sha1 9F439457585146A4E1DA7E1DD9104F7F94381688 )
 )
 
 game (
@@ -3072,21 +2680,18 @@ game (
 	name "Mario no Photopie (Japan)"
 	description "Mario no Photopie (Japan)"
 	rom ( name "Mario no Photopie (Japan).n64" size 16777216 crc 49E24AE2 md5 E3AD4BF0504D18FFE35B6D9C7A736CD3 sha1 F8BBA2635AADE03FB700C1614F36AA5A605AF85E flags verified )
-	rom ( name "Mario no Photopie (J) [!].z64" size 16777216 crc 1D69CA55 md5 6BAB5F2A62A4BABAF456D5DA2976871D sha1 8C3C75C484CB7636490331162BB5C41E2FBE8A8B )
 )
 
 game (
 	name "Mario Party (Europe) (En,Fr,De)"
 	description "Mario Party (Europe) (En,Fr,De)"
 	rom ( name "Mario Party (Europe) (En,Fr,De).n64" size 33554432 crc 6973373F md5 9AAE6D37096F2D543160710ECB691AC5 sha1 2F8B0BF9861D10B4C1C5B9C0F0C47333C96DBE30 flags verified )
-	rom ( name "Mario Party (E) (M3) [!].z64" size 33554432 crc DA98A5D3 md5 9773150709BD804B8E57E35F1D6B0EED sha1 D7BA071C220A71F5E4503E55C98C91FF8F027848 )
 )
 
 game (
 	name "Mario Party (Japan)"
 	description "Mario Party (Japan)"
 	rom ( name "Mario Party (Japan).n64" size 33554432 crc 7D387E37 md5 ACBD5528540A2EE9DE209C2CF92D1B4C sha1 82D03C229F37B7E8AF72F4EE867022E4FA0F1F99 flags verified )
-	rom ( name "Mario Party (J) [!].z64" size 33554432 crc 4F1ADC7B md5 3F556CC3B3A996CD2F471FA0D992D529 sha1 37FD6D27F55C468DC36EFB92A255F7AB04FFC0A8 )
 )
 
 game (
@@ -3100,14 +2705,12 @@ game (
 	name "Mario Party 2 (Europe) (En,Fr,De,Es,It)"
 	description "Mario Party 2 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Mario Party 2 (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc 8C0C8BEC md5 A838E03022502B3A0B945286C0496AD1 sha1 130BDC56FBE29FC27645E21959B27322C342728C flags verified )
-	rom ( name "Mario Party 2 (E) (M5) [!].z64" size 33554432 crc DC00357A md5 F70112B652B0EE4856AF83F4E8005C31 sha1 FA5D1426488B298A1C5C383360A78F1A3DE18DC7 )
 )
 
 game (
 	name "Mario Party 2 (Japan)"
 	description "Mario Party 2 (Japan)"
 	rom ( name "Mario Party 2 (Japan).n64" size 33554432 crc E19BF21C md5 5AF4CAD99D4E3AABE119A705F5CC75C0 sha1 FD523DFF2F552A766993EBB5F056F15FCF52E17F flags verified )
-	rom ( name "Mario Party 2 (J) [!].z64" size 33554432 crc 7457B081 md5 F23E4CD437465F3E725262253CF3EA59 sha1 26F4637167AAAA0E420BB4FDB26A965FD34F8D19 )
 )
 
 game (
@@ -3121,14 +2724,12 @@ game (
 	name "Mario Party 3 (Europe) (En,Fr,De,Es)"
 	description "Mario Party 3 (Europe) (En,Fr,De,Es)"
 	rom ( name "Mario Party 3 (Europe) (En,Fr,De,Es).n64" size 33554432 crc A5D78A36 md5 5B8C0C27F64DEB890FDE54E83B313E26 sha1 E8BA773A4FD1251A78EEFCF1F3CBE1F0054A8A38 flags verified )
-	rom ( name "Mario Party 3 (E) (M4) [!].z64" size 33554432 crc 813B13F2 md5 8E62EC6FBE3CC9FF6284191C9C88E68F sha1 9E1DDFE872C6D43AE51010A9E8A6FE2D2E634B50 )
 )
 
 game (
 	name "Mario Party 3 (Japan)"
 	description "Mario Party 3 (Japan)"
 	rom ( name "Mario Party 3 (Japan).n64" size 33554432 crc 703586D1 md5 EADBAFE27F4982A80AEF897019BD7A78 sha1 89B91548C6C5943E95EEBFB8A4DF84FB98D3D905 flags verified )
-	rom ( name "Mario Party 3 (J) [!].z64" size 33554432 crc 3FC04053 md5 ED99F330CE7A2638AB13351012EEB86B sha1 43CF5EB8BD68EF57BA1C9B4CAE7BD18F1826E543 )
 )
 
 game (
@@ -3142,14 +2743,12 @@ game (
 	name "Mario Story (Japan)"
 	description "Mario Story (Japan)"
 	rom ( name "Mario Story (Japan).n64" size 41943040 crc 1FB7E59A md5 B235F3A025AD5B62F330CF2D7C9F007F sha1 01C32F527383B4EC69ECC7805C485B7FB9A76CE0 flags verified )
-	rom ( name "Mario Story (J) [!].z64" size 41943040 crc BD60CA66 md5 DF54F17FB84FB5B5BCF6AA9AF65B0942 sha1 B9CCA3FF260B9FF427D981626B82F96DE73586D3 )
 )
 
 game (
 	name "Mario Tennis (Europe)"
 	description "Mario Tennis (Europe)"
 	rom ( name "Mario Tennis (Europe).n64" size 16777216 crc 0F03CA6E md5 C4A2DFC5C9D5041B2D6575DB191BF3F3 sha1 F7C4535CE92CA794C4B26E09E74072125AE97DAB flags verified )
-	rom ( name "Mario Tennis (E) [!].z64" size 16777216 crc 29AA5DF4 md5 FFF9B3E22ABB9B60215DAFB13AD5A4DE sha1 B5E4AA1ABF8FC8022FC47F30CD6D4AC6A6B21684 )
 )
 
 game (
@@ -3163,7 +2762,6 @@ game (
 	name "Mario Tennis 64 (Japan)"
 	description "Mario Tennis 64 (Japan)"
 	rom ( name "Mario Tennis 64 (Japan).n64" size 16777216 crc 17C5515B md5 6B7D1DB6AFFBDD27D08C7329C3CE28E2 sha1 FB7F917AA3F40DBDE33107F1C949301AF8470C2E flags verified )
-	rom ( name "Mario Tennis 64 (J) [!].z64" size 16777216 crc C665301D md5 8EB1C2443D0B2E6EDA52A4EEA66D6C35 sha1 8AA424795BBE87C659F777D0843E236340B12E16 )
 )
 
 game (
@@ -3177,77 +2775,66 @@ game (
 	name "Mia Hamm Soccer 64 (USA) (En,Es)"
 	description "Mia Hamm Soccer 64 (USA) (En,Es)"
 	rom ( name "Mia Hamm Soccer 64 (USA) (En,Es).n64" size 16777216 crc 3AA4BFF5 md5 537D7CFED7A0F3287D711F187E70B2FC sha1 656DAA19BC199929EF2ED52F841487E3FFAC7692 )
-	rom ( name "Mia Hamm Soccer 64 (U) (M2) [!].z64" size 16777216 crc 2DB3D3D6 md5 A4039368E0472C68E3072C02C7A80F94 sha1 62CE9D1C1F4CF7BEAA1EF7C456C155F63F13F057 )
 )
 
 game (
 	name "Michael Owen's World League Soccer 2000 (Europe)"
 	description "Michael Owen's World League Soccer 2000 (Europe)"
 	rom ( name "Michael Owen's World League Soccer 2000 (Europe).n64" size 16777216 crc FAFFEF70 md5 AA451044641D7AEB94A33E891D0AD592 sha1 B2C6442F2E04FEC284AC4C4F7439059FA2315700 flags verified )
-	rom ( name "Michael Owens WLS 2000 (E) [!].z64" size 16777216 crc BB680CBE md5 892222CC4BAF9958405D20BC492175BF sha1 F629A56ED36FB3889841A047D7C4CD2B9731EB43 )
 )
 
 game (
 	name "Mickey no Racing Challenge USA (Japan)"
 	description "Mickey no Racing Challenge USA (Japan)"
 	rom ( name "Mickey no Racing Challenge USA (Japan).n64" size 33554432 crc 915A43EE md5 FB28BF7DDE6DB9846072D8F5F34D665F sha1 74B76CB5075663E568EEBF9AC977E08CDBA17BA9 flags verified )
-	rom ( name "Mickey no Racing Challenge USA (J) [!].z64" size 33554432 crc 1AECFC56 md5 288A514E98972BF9D329167AA29E66B6 sha1 5B4F7BAD6591DE2199C095352A811A2EB7FC6F53 )
 )
 
 game (
 	name "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)"
 	description "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc DDF28F6B md5 658641D0532BCD0059C333B00EC3B595 sha1 BF43FA4A34CEFB537271DD71DB8DB47F5B4A29FD flags verified )
-	rom ( name "Mickey's Speedway USA (E) (M5) [!].z64" size 33554432 crc 0AE51EA5 md5 5BA3DC37860C08A209F24286B8DFEC8C sha1 C583ED998A6B422A22FFD3F8376C3CEF0C3710D9 )
 )
 
 game (
 	name "Mickey's Speedway USA (USA)"
 	description "Mickey's Speedway USA (USA)"
 	rom ( name "Mickey's Speedway USA (USA).n64" size 33554432 crc 6E589C47 md5 99D8FE5ED2F827FB1C43A3EA2B7CA9FD sha1 1156459D3DA0CD1AC8DA73F75AECDC23D093AFFF )
-	rom ( name "Mickey's Speedway USA (U) [!].z64" size 33554432 crc 2D4F8F1B md5 0BF64427CF68E49C70E9EC2C9D815209 sha1 507341C0A40CA3E9A7CEE969B396EE53FACFB548 )
 )
 
 game (
 	name "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)"
 	description "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).n64" size 12582912 crc 14030FF5 md5 FE6C48F7C14C518FCFC3301A135183AF sha1 B8961F88210027EE0525623242F7CED6C139DEDF flags verified )
-	rom ( name "Micro Machines 64 Turbo (E) (M5) [!].z64" size 12582912 crc 10B9FF1F md5 9A8465E302263D635557A14AA197FE3C sha1 E5E2D6169AF2663E5519795B28BEC018934E86EE )
 )
 
 game (
 	name "Micro Machines 64 Turbo (USA)"
 	description "Micro Machines 64 Turbo (USA)"
 	rom ( name "Micro Machines 64 Turbo (USA).n64" size 12582912 crc 02790693 md5 514FAA23F81391EA58A25564EB62478F sha1 B62D18DCECAD57852B21107D5B9C026237CBEE6E )
-	rom ( name "Micro Machines 64 Turbo (U) [!].z64" size 12582912 crc A62A2763 md5 74EB415E16C333B252847A8E09432FD9 sha1 9672FA010A06ADF01074C9720EE46031F5D9E101 )
 )
 
 game (
 	name "Midway's Greatest Arcade Hits - Volume 1 (USA)"
 	description "Midway's Greatest Arcade Hits - Volume 1 (USA)"
 	rom ( name "Midway's Greatest Arcade Hits - Volume 1 (USA).n64" size 4194304 crc 202A2718 md5 68CF12426B11E75DF95D64DC6B94D41D sha1 DB7CAE68D2A73018ADA2E9587E997EC8557F8A8A )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [!].z64" size 4194304 crc E5C1FEDC md5 2B86775EA4D848202E4F4A39C33571CA sha1 E24C61AAA5CF15112258052EC78D24AD047BA5AE )
 )
 
 game (
 	name "Mike Piazza's StrikeZone (USA)"
 	description "Mike Piazza's StrikeZone (USA)"
 	rom ( name "Mike Piazza's StrikeZone (USA).n64" size 12582912 crc 9042CB8E md5 0900C5E52C6B2196E38DE6F5B8DDAD9A sha1 D333E7C755451F244F24AC56352A0C6294406016 )
-	rom ( name "Mike Piazza's Strike Zone (U) [!].z64" size 12582912 crc CC253CAB md5 EB1908E51C8D10AF8B9CAF77797BFE00 sha1 09C90701261E345C0023C55B61B37E6AAF809E57 )
 )
 
 game (
 	name "Milo's Astro Lanes (Europe)"
 	description "Milo's Astro Lanes (Europe)"
 	rom ( name "Milo's Astro Lanes (Europe).n64" size 4194304 crc 165D7BC2 md5 E9092B278DFAAEFD34716DC062CD9304 sha1 5D5AB3E386B8970C3FD61E84187315C1E8297443 flags verified )
-	rom ( name "Milo's Astro Lanes (E) [!].z64" size 4194304 crc C08CE624 md5 43B02AF2789990A14F77CE020E6F135C sha1 77DA41C16CD8989291A82159A15CE98D155916A6 )
 )
 
 game (
 	name "Milo's Astro Lanes (USA)"
 	description "Milo's Astro Lanes (USA)"
 	rom ( name "Milo's Astro Lanes (USA).n64" size 4194304 crc DFF1BA7E md5 ED92851C90F5BC542A41AC86F1DAFC30 sha1 FC5C26B0089B50624F330E9F769078D333754A5E )
-	rom ( name "Milo's Astro Lanes (U) [!].z64" size 4194304 crc 172FCA97 md5 4F256146BAC4A3DDE5AD0D5F9C909251 sha1 7A0246E367FF84B46C0BEC9A6B760D3B67B13041 )
 )
 
 game (
@@ -3260,7 +2847,6 @@ game (
 	name "Mischief Makers (Europe)"
 	description "Mischief Makers (Europe)"
 	rom ( name "Mischief Makers (Europe).n64" size 8388608 crc 12529953 md5 C895949D378443FCFC5B98515FDEB9C6 sha1 A2805E1C825157A491850B0D25C84759CA76BBB6 flags verified )
-	rom ( name "Mischief Makers (E) [!].z64" size 8388608 crc 68A4F072 md5 EB3B078A74D4DC827E1E79791004DFBB sha1 E5405AAD683959EDAB641B5DA05B8159CAC93E63 )
 )
 
 game (
@@ -3280,91 +2866,78 @@ game (
 	name "Mission Impossible (Europe)"
 	description "Mission Impossible (Europe)"
 	rom ( name "Mission Impossible (Europe).n64" size 12582912 crc C41A1EBE md5 FF2364267347871E6D62F44CA8160A03 sha1 3AA5B3B1A063DDB1F2D883AD95D04365D2C0A42A flags verified )
-	rom ( name "Mission Impossible (E) [!].z64" size 12582912 crc 2C7131D6 md5 599B5D40B51F53C2C9A909E0139702FC sha1 1A406D19F527D1E394FA140290FDE04D81D3E639 )
 )
 
 game (
 	name "Mission Impossible (France)"
 	description "Mission Impossible (France)"
 	rom ( name "Mission Impossible (France).n64" size 12582912 crc 67895343 md5 5BA6DE6E1877AF2169BCACC4FBD900AA sha1 FC28EDCAE49CA1BD298258BB693C92CF39ED39B6 )
-	rom ( name "Mission Impossible (F) [!].z64" size 12582912 crc 282A350D md5 FD0C0E8C523437F9B6B630E369FDFC69 sha1 EA934F931124DB891F12E92726FAAE5EDDE39C45 )
 )
 
 game (
 	name "Mission Impossible (Germany)"
 	description "Mission Impossible (Germany)"
 	rom ( name "Mission Impossible (Germany).n64" size 12582912 crc 20067768 md5 DF09EA446F6854A6BE030B0C74841C54 sha1 A891AEE53F10BD4E25973CE47A2E70B5CF4C90DA flags verified )
-	rom ( name "Mission Impossible (G) [!].z64" size 12582912 crc 67C30A2D md5 4111482C92EE806484AAA2C210893A52 sha1 906FFAB2F8E8EECE17E0846FFBD9EA32370206DA )
 )
 
 game (
 	name "Mission Impossible (Italy)"
 	description "Mission Impossible (Italy)"
 	rom ( name "Mission Impossible (Italy).n64" size 12582912 crc AC5C1408 md5 9BED21A83454E5D8B10F7AFA34B5786B sha1 25B1FF3432465450B4B17BB26CE9F9289EBFE65C )
-	rom ( name "Mission Impossible (I) [!].z64" size 12582912 crc 2D789D98 md5 66C7EB8148E0714B5A71F5717DFF8642 sha1 9EE0E754B7AFAF751DF281B9411EC1D8F30A894D )
 )
 
 game (
 	name "Mission Impossible (Spain)"
 	description "Mission Impossible (Spain)"
 	rom ( name "Mission Impossible (Spain).n64" size 12582912 crc E33B52F0 md5 0405DA489B59895412E60659411FBC49 sha1 244711046F77E8059E677731C2D26D0C45996DDA )
-	rom ( name "Mission Impossible (S) [!].z64" size 12582912 crc EBB060DC md5 D1BA3B1899576A4B67908ABB6544D75A sha1 D79C313B8581B558DBECA29F797D91A8B3122841 )
 )
 
 game (
 	name "Mission Impossible (USA)"
 	description "Mission Impossible (USA)"
 	rom ( name "Mission Impossible (USA).n64" size 12582912 crc 2DBD815D md5 85E09C5B9C3A6C6E7B8FCE029D5CD50D sha1 C17C89F1A8485CFD481426800870F860C2CEAE24 flags verified )
-	rom ( name "Mission Impossible (U) [!].z64" size 12582912 crc 3677A8B8 md5 EEBDFBD7CB57202D70CFFFCAAF55E93E sha1 7546D5DF1FC93FED8205A066F1333FD7DD50C1E1 )
 )
 
 game (
 	name "Monaco Grand Prix (USA)"
 	description "Monaco Grand Prix (USA)"
 	rom ( name "Monaco Grand Prix (USA).n64" size 16777216 crc 30079403 md5 1FB6AC64BE78637A9E79C1AB1D17060D sha1 75F401C150CD9210432A96CF6DB411F6F46E0047 )
-	rom ( name "Monaco Grand Prix (U) [!].z64" size 16777216 crc E2BBEAC1 md5 4FF9589A3224AAA46E9877D6B25E68E3 sha1 477F945DC38F930336E0D05CFDCBA2C4C30F6A31 )
 )
 
 game (
 	name "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)"
 	description "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)"
 	rom ( name "Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).n64" size 16777216 crc 0A54FDF0 md5 257E81AC747A455A709A013A5F8CBC1F sha1 BD25283C98FC1915C07F4EE9CE58820C1D4A44B2 flags verified )
-	rom ( name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!].z64" size 16777216 crc 3F5E5830 md5 C93A17D130B96FBA27A0E959CAB2A450 sha1 39A7F5515DD822A32C0FC8D9E01A72F0C8B2A1F7 )
 )
 
 game (
 	name "Monopoly (USA)"
 	description "Monopoly (USA)"
 	rom ( name "Monopoly (USA).n64" size 8388608 crc 416B1F8F md5 B0F1BC097C75F6AC50751A1F81E209D2 sha1 99D176B45784CED5F469C64E065F6EA3E1176188 )
-	rom ( name "Monopoly (U) [!].z64" size 8388608 crc C8CAD8F6 md5 D51506EDB0A941A00EB45850703B32CB sha1 FD724BDC323AA81D4873768ACF789529CC1C08E5 )
 )
 
 game (
 	name "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)"
 	description "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).n64" size 8388608 crc CE6779FB md5 5BAEE822A8A2EB40F4EF11F59824B83F sha1 42F1702360E5381B0C94912AE3B5BB092C04297C flags verified )
-	rom ( name "Monster Truck Madness 64 (E) (M5) [!].z64" size 8388608 crc 4731DF5C md5 E3B408997D7DB91F8219F168C6D57D26 sha1 A702B0616030BFC5FEB78FEAF365EAB74F1A8B6E )
 )
 
 game (
 	name "Monster Truck Madness 64 (USA)"
 	description "Monster Truck Madness 64 (USA)"
 	rom ( name "Monster Truck Madness 64 (USA).n64" size 8388608 crc B8D03FFB md5 268465AB3095C1D2FFF2AA025C49E610 sha1 F7E66B1EB2905DF6C6DFADF1593064FC6D592C17 )
-	rom ( name "Monster Truck Madness 64 (U) [!].z64" size 8388608 crc 3FD0604D md5 514D61D3B3D5E6326869783EB2E84A00 sha1 F8C7AE14DF7341881346B1CEAF838D2219291279 )
 )
 
 game (
 	name "Morita Shougi 64 (Japan)"
 	description "Morita Shougi 64 (Japan)"
 	rom ( name "Morita Shougi 64 (Japan).n64" size 8388608 crc 377B7580 md5 CEADD46EAAF7DA339A395401633192EB sha1 41B66663B6428C040579CEBEDA70DB2FCD063B3E flags verified )
-	rom ( name "Morita Shougi 64 (J) [!].z64" size 8388608 crc 88C83511 md5 462B9C4F38758C2E558312AC60DF2B91 sha1 D079AE0F578032347541B7EAE8935907C8AB79E3 )
 )
 
 game (
 	name "Mortal Kombat 4 (Europe)"
 	description "Mortal Kombat 4 (Europe)"
 	rom ( name "Mortal Kombat 4 (Europe).n64" size 16777216 crc 70B72A07 md5 12FFBF0BB1E493AFF82F0384DFECE543 sha1 C992254964774AAAEA5FBDE5BF4031C5096FB554 flags verified )
-	rom ( name "Mortal Kombat 4 (E) [!].z64" size 16777216 crc 635ADECA md5 264B82F0FC2431D6EEFDE9C9F3ED7596 sha1 34A25CC52F0D2B5FF3A65552F9D43D8714A8E10C )
 )
 
 game (
@@ -3378,7 +2951,6 @@ game (
 	name "Mortal Kombat Mythologies - Sub-Zero (Europe)"
 	description "Mortal Kombat Mythologies - Sub-Zero (Europe)"
 	rom ( name "Mortal Kombat Mythologies - Sub-Zero (Europe).n64" size 16777216 crc 1063DA05 md5 1152B6BEE522DAE82081EF35FD07F51C sha1 3FDE66EC7640F79A10471CD159E6B5C6101742EE flags verified )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [!].z64" size 16777216 crc EA21015A md5 38A82A56AE61A4D354C6A26E64D25E1C sha1 E674E0F08D7218136F31CA99A9C5323F0D2BB4D4 )
 )
 
 game (
@@ -3392,14 +2964,12 @@ game (
 	name "Mortal Kombat Trilogy (Europe)"
 	description "Mortal Kombat Trilogy (Europe)"
 	rom ( name "Mortal Kombat Trilogy (Europe).n64" size 12582912 crc 6A805380 md5 287BBC37468C5E434289C649499B0394 sha1 75298D06ADAF9814430C9DFDE87DCA3A9C59DAB1 flags verified )
-	rom ( name "Mortal Kombat Trilogy (E) [!].z64" size 12582912 crc BC04C62F md5 7A558BBAD8CE8828414A9CF3B044A87D sha1 5796AAF21BFA0E8532EF225BA4BE3B39EEF1BE63 )
 )
 
 game (
 	name "Mortal Kombat Trilogy (USA)"
 	description "Mortal Kombat Trilogy (USA)"
 	rom ( name "Mortal Kombat Trilogy (USA).n64" size 12582912 crc 58E57C08 md5 11819262F59DBD61F9E6621483CC0245 sha1 FC82A5BBB306C3F855974DE18CF1B1BFFAC268FF )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [!].z64" size 12582912 crc 50A99D60 md5 9B7F29AAB911D6753F2011C48DA752BF sha1 39B3CB20417C503F1C047D5037DF814D1CCF90DD )
 )
 
 game (
@@ -3419,42 +2989,36 @@ game (
 	name "MRC - Multi Racing Championship (Europe) (En,Fr,De)"
 	description "MRC - Multi Racing Championship (Europe) (En,Fr,De)"
 	rom ( name "MRC - Multi Racing Championship (Europe) (En,Fr,De).n64" size 12582912 crc 9C7D29EC md5 53D95CEAB72663184895663AC0C88C18 sha1 6C00683512F99DA0DB25E22833B8369270A3A044 flags verified )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [!].z64" size 12582912 crc BC966B10 md5 0054B7FC0C2ACBED650EFE727CDBA472 sha1 6D8600A1326C39B4B80BB1D4A6500C3F0C6202A1 )
 )
 
 game (
 	name "MRC - Multi Racing Championship (Japan)"
 	description "MRC - Multi Racing Championship (Japan)"
 	rom ( name "MRC - Multi Racing Championship (Japan).n64" size 12582912 crc 4CA898E3 md5 1B54B620B1997A21587EDA8F2FF1A45E sha1 96B6966A12C0D3DEB78A26E7273ECB5AED17D5E9 flags verified )
-	rom ( name "MRC - Multi Racing Championship (J) [!].z64" size 12582912 crc BEA43300 md5 8E18064A2C4B3EC15A20C3D676644B3A sha1 B0992A8029622DF74D3165814AA40DF19A14B4A4 )
 )
 
 game (
 	name "MRC - Multi Racing Championship (USA)"
 	description "MRC - Multi Racing Championship (USA)"
 	rom ( name "MRC - Multi Racing Championship (USA).n64" size 12582912 crc 2F30B7FE md5 F7E833F423BBE33AF47DF45A998E9FB5 sha1 72009EBA46CD9362CB7979D457EB1C7581B552DA flags verified )
-	rom ( name "MRC - Multi Racing Championship (U) [!].z64" size 12582912 crc 1DC1C812 md5 FC61D60F2C6FE4610F70CE4949A7A062 sha1 8BEA68833D63B2F17DAAD4477A572C274A9468BE )
 )
 
 game (
 	name "Ms. Pac-Man - Maze Madness (USA)"
 	description "Ms. Pac-Man - Maze Madness (USA)"
 	rom ( name "Ms. Pac-Man - Maze Madness (USA).n64" size 12582912 crc D5017D76 md5 7CAF992661AE9008D556E880D72F1A2A sha1 B3924A297A03A0B10FF246A7C90F424C90E7AB64 )
-	rom ( name "Ms. Pac-Man - Maze Madness (U) [!].z64" size 12582912 crc E34C7060 md5 08BEA3310E778A6584EB64CD3F15F86E sha1 99028C738B5AC5FF99D73698B50D14F5E58DDEA7 )
 )
 
 game (
 	name "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)"
 	description "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)"
 	rom ( name "Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).n64" size 16777216 crc 6DF2BDA6 md5 89F1CE5BCE09D4B882F190407B08E2D4 sha1 45BBFD1436D86055A82DBA19869CB9D2038BFA18 flags verified )
-	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [!].z64" size 16777216 crc 3502DBBE md5 E6B5C17B7BBBB7C432B3506C085D16C4 sha1 AADD1D7E943CBFA5496A370158B5F8FE17B06415 )
 )
 
 game (
 	name "Mystical Ninja Starring Goemon (Europe)"
 	description "Mystical Ninja Starring Goemon (Europe)"
 	rom ( name "Mystical Ninja Starring Goemon (Europe).n64" size 16777216 crc 7DFE2E7A md5 D9CF1C0538367A4149390C0845363A03 sha1 3EB67F551791AA84EC2524C7A00B53DFD24B11EE flags verified )
-	rom ( name "Mystical Ninja Starring Goemon (E) [!].z64" size 16777216 crc 3BD9059A md5 698930C7CCD844673D77FFECCB3DD66E sha1 F7304934BA4E8D98A71500C249BACB168BCA5AF0 )
 )
 
 game (
@@ -3468,224 +3032,192 @@ game (
 	name "Nagano Winter Olympics '98 (Europe)"
 	description "Nagano Winter Olympics '98 (Europe)"
 	rom ( name "Nagano Winter Olympics '98 (Europe).n64" size 12582912 crc 36D43F29 md5 54E3AA4FCC7C0EEC8F66FEB0481B9C48 sha1 CB3EE16B5E45FEF723AF43BCF3E6F5AE07BC570A flags verified )
-	rom ( name "Nagano Winter Olympics '98 (E) [!].z64" size 12582912 crc C44DE11C md5 B935B87F3DCCA8AEEB6A9365124846DC sha1 8FACA645020857B87ED3842BD26CCCBDF31BEC39 )
 )
 
 game (
 	name "Nagano Winter Olympics '98 (USA)"
 	description "Nagano Winter Olympics '98 (USA)"
 	rom ( name "Nagano Winter Olympics '98 (USA).n64" size 12582912 crc 1F8D21FB md5 89DBB22886A2973838B2D682A150295C sha1 090D652498885CCFA841C1465E4B721D090D7B39 )
-	rom ( name "Nagano Winter Olympics '98 (U) [!].z64" size 12582912 crc EE8288D4 md5 C17F78A103D99B21533F0C1566378EF6 sha1 EAF543E195731031A84F4136B506449209E3A8F5 )
 )
 
 game (
 	name "Namco Museum 64 (USA)"
 	description "Namco Museum 64 (USA)"
 	rom ( name "Namco Museum 64 (USA).n64" size 4194304 crc 03776764 md5 D2675B639421FC6EBCE92F0511F5BC5D sha1 8FF73B91E62ABE925AD475B166EA65B1A698DAE7 )
-	rom ( name "Namco Museum 64 (U) [!].z64" size 4194304 crc CE361F92 md5 E61251D2819E3BF3A9C0B95329F60F70 sha1 A934E08F80778111D1BC03CAF0A170A2D8C4E6A7 )
 )
 
 game (
 	name "NASCAR 2000 (USA)"
 	description "NASCAR 2000 (USA)"
 	rom ( name "NASCAR 2000 (USA).n64" size 12582912 crc D07AD471 md5 FB698DD422FAB3CE770224B2385173D5 sha1 D889B2F0E632CDC9D1EC6261A6841F7822A5D130 )
-	rom ( name "NASCAR 2000 (U) [!].z64" size 12582912 crc 02BF7C2D md5 45FEB0FBBEC6CB48FF21DEAE176E9B6B sha1 36CD848BE9196C9E04EB3A9B0371A04AFC8BAEA3 )
 )
 
 game (
 	name "NASCAR 99 (Europe) (En,Fr,De)"
 	description "NASCAR 99 (Europe) (En,Fr,De)"
 	rom ( name "NASCAR 99 (Europe) (En,Fr,De).n64" size 12582912 crc 5351ACB5 md5 96A36A9871B34839D6A2AF57C5C4EF96 sha1 84C515AB4ECF3CAC306D1355B639D7E535845F42 flags verified )
-	rom ( name "NASCAR 99 (E) (M3) [!].z64" size 12582912 crc 76E79CEA md5 15A87A6D01DBA1A7C4375FFBC1214BB8 sha1 CB43EE3D86A7B85BEFEC8D068D72192FA8174EB0 )
 )
 
 game (
 	name "NASCAR 99 (USA)"
 	description "NASCAR 99 (USA)"
 	rom ( name "NASCAR 99 (USA).n64" size 12582912 crc 2D234FB7 md5 2EAB72BF6EE786DD521A360D94A868DD sha1 C65CA3084221CCBD63A21CAB179A50184A7FA798 )
-	rom ( name "NASCAR 99 (U) [!].z64" size 12582912 crc 3D8EB950 md5 DC5F1A814C8423B4B43F71C229D65A84 sha1 0FBBAEB4C286D45D27C977D5722E38415EFD1A74 )
 )
 
 game (
 	name "NBA Courtside 2 featuring Kobe Bryant (USA)"
 	description "NBA Courtside 2 featuring Kobe Bryant (USA)"
 	rom ( name "NBA Courtside 2 featuring Kobe Bryant (USA).n64" size 16777216 crc 7A8FD7D3 md5 FF29DB046C31ADCE1B5280558DBC3DF8 sha1 63711BE92268098BC69BEC3168C09D0088DB8CE6 )
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!].z64" size 16777216 crc A7CC4CE2 md5 73BB54FFD3C0FC71F941D9A8CC57E2A1 sha1 8C27333189FC19570BC494BC3ED9E3879D6E54BE )
 )
 
 game (
 	name "NBA Hangtime (Europe)"
 	description "NBA Hangtime (Europe)"
 	rom ( name "NBA Hangtime (Europe).n64" size 12582912 crc BF05FE53 md5 662386EE4FDF23F3423A4300F1DAD651 sha1 004AFE25EE5B70B915797AE799BFBF1D92C969A5 flags verified )
-	rom ( name "NBA Hangtime (E) [!].z64" size 12582912 crc 7E6D00AE md5 62365463743857CFC823978E0E590D84 sha1 2BCBDD92CCB4C72757739D32557098F4EEC36312 )
 )
 
 game (
 	name "NBA Hangtime (USA)"
 	description "NBA Hangtime (USA)"
 	rom ( name "NBA Hangtime (USA).n64" size 12582912 crc 72E2ACA9 md5 458170659E9F493099BC1D6FE50AA937 sha1 2A1EF108F5345E6CA80D7F73F4CA4557E7843594 )
-	rom ( name "NBA Hangtime (U) [!].z64" size 12582912 crc 714CF532 md5 DC15FCBEAE0F1FEF7BEE141D77BB25A0 sha1 3C96741DB636938F140E9592AD34E93AC25C7762 )
 )
 
 game (
 	name "NBA in the Zone '98 (Japan)"
 	description "NBA in the Zone '98 (Japan)"
 	rom ( name "NBA in the Zone '98 (Japan).n64" size 12582912 crc 58B2150D md5 12373D4569A3498D13F9274B2395D9BC sha1 4FC0A8392ECE34F8A8C524640DCE2A1255C66BFC flags verified )
-	rom ( name "NBA In the Zone '98 (J) [!].z64" size 12582912 crc AED2700A md5 4C7A2F4881EACA75DC2FC36673AE2A20 sha1 C4DC9049094100D48A010D39F2901E1AB164A8FA )
 )
 
 game (
 	name "NBA in the Zone '98 (USA)"
 	description "NBA in the Zone '98 (USA)"
 	rom ( name "NBA in the Zone '98 (USA).n64" size 12582912 crc 2BB83C0E md5 73334F6ADAB3F19C314C9F9CB2006E97 sha1 B0E5D3A7FC83EC86027F9E7EFDD876B7639E727C )
-	rom ( name "NBA In the Zone '98 (U) [!].z64" size 12582912 crc A245D737 md5 BBB48BE198089A26050C84FE5B7B8BD5 sha1 A306D80F483F8BB5891A543919C53FAC61D9348F )
 )
 
 game (
 	name "NBA in the Zone '99 (USA)"
 	description "NBA in the Zone '99 (USA)"
 	rom ( name "NBA in the Zone '99 (USA).n64" size 12582912 crc C15AFC69 md5 D56AB19B2D4550D8CD082C96904DAB0B sha1 BE6B8FAD67ECE51E3DC09182CA7497652D92B241 )
-	rom ( name "NBA In the Zone '99 (U) [!].z64" size 12582912 crc EAB083B8 md5 6CBF4014C053E16852A3DB80AEB4C853 sha1 6964BAEC49592E64C34782B55E234C7BD32C8A99 )
 )
 
 game (
 	name "NBA in the Zone 2 (Japan)"
 	description "NBA in the Zone 2 (Japan)"
 	rom ( name "NBA in the Zone 2 (Japan).n64" size 12582912 crc F736D01A md5 127671F54E44C68039DD29EC702AED21 sha1 C81BCE72A48686B3966815915A579F2F5DE733EC flags verified )
-	rom ( name "NBA In the Zone 2 (J) [!].z64" size 12582912 crc 41093B73 md5 F8F87AEB2C537C9CB2E9913050BFC928 sha1 A7685C8833256ECD1033862EA077E75147F9C49A )
 )
 
 game (
 	name "NBA in the Zone 2000 (Europe)"
 	description "NBA in the Zone 2000 (Europe)"
 	rom ( name "NBA in the Zone 2000 (Europe).n64" size 16777216 crc AD6CD2AE md5 1E53474D393C2A16A25480843DF965AB sha1 29ECBF3DADB77C56051370897344839EBBD63130 flags verified )
-	rom ( name "NBA In the Zone 2000 (E) [!].z64" size 16777216 crc A4973197 md5 4244CC48674C26BD848718C05688F821 sha1 255AADF60E9DE652247BB1F7C63B50415D6C4354 )
 )
 
 game (
 	name "NBA in the Zone 2000 (USA)"
 	description "NBA in the Zone 2000 (USA)"
 	rom ( name "NBA in the Zone 2000 (USA).n64" size 16777216 crc D850CFA3 md5 3E9F73902FD5C9AF3DECB26F0E045128 sha1 681D09E327E4FAAA3EA53977047BE5434ABA1468 )
-	rom ( name "NBA In the Zone 2000 (U) [!].z64" size 16777216 crc CBB4B730 md5 1942833AC1A71BE8BAE74BBDFD6DE278 sha1 7E838C203F29336CBDABA77051EBE48D9EAE798D )
 )
 
 game (
 	name "NBA Jam 2000 (Europe)"
 	description "NBA Jam 2000 (Europe)"
 	rom ( name "NBA Jam 2000 (Europe).n64" size 16777216 crc 84DEB3BD md5 568BE0ACEE43DEDD85BFEAADCE3060B8 sha1 4FC4D73EEB7669D9D54F8AE26908124CD8F9F618 flags verified )
-	rom ( name "NBA Jam 2000 (E) [!].z64" size 16777216 crc 9F95485E md5 604FEB17258044A3E6C3AA9D2C5B62F9 sha1 A91C52AC8AF8DE6172411C5BF8E57F5795BE7F78 )
 )
 
 game (
 	name "NBA Jam 2000 (USA)"
 	description "NBA Jam 2000 (USA)"
 	rom ( name "NBA Jam 2000 (USA).n64" size 16777216 crc 65A3BD1C md5 2BC421E0B95150299CAD0D9EA37E289F sha1 58FACEC83666D3EBA51986DF97024229A087C78D )
-	rom ( name "NBA Jam 2000 (U) [!].z64" size 16777216 crc 163DADF9 md5 AFECC9A2DF7B1A66A6B7AB3AA8B4BD2E sha1 94139439D6C234A560FC5D0E5D9C0AA4508FC7B6 )
 )
 
 game (
 	name "NBA Jam 99 (Europe)"
 	description "NBA Jam 99 (Europe)"
 	rom ( name "NBA Jam 99 (Europe).n64" size 12582912 crc 8CCE0AE4 md5 3797FA95D1B8F635C1E68A6153159143 sha1 07EA5C1767C0EDE88D0CF231352F7389ABCB2F2F flags verified )
-	rom ( name "NBA Jam 99 (E) [!].z64" size 12582912 crc 90E4275B md5 BE72BE370BC0A76D403FF2B9ED2A9173 sha1 CF6C46785B75F9BC1D5B1FD08DAFB72DD595F68A )
 )
 
 game (
 	name "NBA Jam 99 (USA)"
 	description "NBA Jam 99 (USA)"
 	rom ( name "NBA Jam 99 (USA).n64" size 12582912 crc F40C871A md5 6B1912A7269E4A2FEEA518653277B7B6 sha1 5303A21D20BEF75E6F77FBAEDD120391CB4131D5 )
-	rom ( name "NBA Jam 99 (U) [!].z64" size 12582912 crc 559CD6B1 md5 ADBE5CA10F659AF2BE712038E8522704 sha1 2E306D2123AD4220E672D8A07874CA7B515D57E0 )
 )
 
 game (
 	name "NBA Live 2000 (Europe) (En,Fr,De,Es)"
 	description "NBA Live 2000 (Europe) (En,Fr,De,Es)"
 	rom ( name "NBA Live 2000 (Europe) (En,Fr,De,Es).n64" size 16777216 crc 4C7282D6 md5 591D563BABCD634DF5A6F1BE6D86D352 sha1 E2B90369CC88D6488D8CA307B7AB915CFF8ED5D6 flags verified )
-	rom ( name "NBA Live 2000 (E) (M4) [!].z64" size 16777216 crc 0E4B944C md5 7FEC099D1A989D5222D3F9E1A7770404 sha1 D4CB60EB3645AE803A1EFC234CEFFD8F424DC8F7 )
 )
 
 game (
 	name "NBA Live 2000 (USA) (En,Fr,De,Es)"
 	description "NBA Live 2000 (USA) (En,Fr,De,Es)"
 	rom ( name "NBA Live 2000 (USA) (En,Fr,De,Es).n64" size 16777216 crc 94FC12D3 md5 C3071968BC7891FAC1A1DEE216FDB5C0 sha1 61E5052589BFE9B7736B9E758125A8AF11A11CB3 )
-	rom ( name "NBA Live 2000 (U) (M4) [!].z64" size 16777216 crc 7C3BC95E md5 FC47F85CC501C8C5BD9D0CA4DB48258F sha1 4BA671A132125BCAA6552542B7FC2C7F6DC56A0E )
 )
 
 game (
 	name "NBA Live 99 (Europe) (En,Fr,De,Es,It)"
 	description "NBA Live 99 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "NBA Live 99 (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 086E322E md5 DB69F8396056D6D89E143DA38CF6DC7B sha1 EEA6E4FF34BEB7D0EB5692D79F4C5A1FF757853E flags verified )
-	rom ( name "NBA Live 99 (E) (M5) [!].z64" size 16777216 crc A316DF37 md5 226C19C8759314AC740420DDC3A34EB4 sha1 530EF95C12F0CA73BC4E178A397CE677A57AD858 )
 )
 
 game (
 	name "NBA Live 99 (USA) (En,Fr,De,Es,It)"
 	description "NBA Live 99 (USA) (En,Fr,De,Es,It)"
 	rom ( name "NBA Live 99 (USA) (En,Fr,De,Es,It).n64" size 16777216 crc 74BC96BE md5 32D4469E1B2B600E36708ED6D903628F sha1 C040AABD6A985052A6D2E9AB7B8D458233D0793F )
-	rom ( name "NBA Live 99 (U) (M5) [!].z64" size 16777216 crc 9BE0A7AC md5 DBE79AE6531B491B8F8EE8B2B814D665 sha1 89E47FFAC3EAE25B37E1A20CE66CA24E343912DD )
 )
 
 game (
 	name "NBA Pro 98 (Europe)"
 	description "NBA Pro 98 (Europe)"
 	rom ( name "NBA Pro 98 (Europe).n64" size 12582912 crc 7FABF1EA md5 378F71037E3994A605B0060262C3AF6B sha1 FD5131330C501858E6AD3128EE3D252C998A2EB5 flags verified )
-	rom ( name "NBA Pro 98 (E) [!].z64" size 12582912 crc 04B75CCC md5 A4111A6CDDBDE0A45489106F0DF0CA2B sha1 94416270D83A87E360BAC5059CC5F7365CA120AC )
 )
 
 game (
 	name "NBA Pro 99 (Europe)"
 	description "NBA Pro 99 (Europe)"
 	rom ( name "NBA Pro 99 (Europe).n64" size 12582912 crc 6EA32E08 md5 408DD9E2EE93F8A8283A6E0C05EEC781 sha1 FB369E088766095BC6466AD09B8C94CAAF9A1DF5 flags verified )
-	rom ( name "NBA Pro 99 (E) [!].z64" size 12582912 crc 588E60E8 md5 C5EBBDD41EAEA8BD02CF520640CCCCDF sha1 5DECF930D859E8B834A5F897955880556CA6AADF )
 )
 
 game (
 	name "NBA Showtime - NBA on NBC (USA)"
 	description "NBA Showtime - NBA on NBC (USA)"
 	rom ( name "NBA Showtime - NBA on NBC (USA).n64" size 16777216 crc A9302DEE md5 9F62363594B50F8A2695C113E52D9485 sha1 4857B02997B65AA86D2ADA8E7364E62B5FF10356 )
-	rom ( name "NBA Showtime - NBA on NBC (U) [!].z64" size 16777216 crc A4E378F4 md5 881E98B47F32093C330A8B0DAD6BB65D sha1 702D6D55FC23C56B8A57D7348D159098FFF98650 )
 )
 
 game (
 	name "Neon Genesis Evangelion (Japan)"
 	description "Neon Genesis Evangelion (Japan)"
 	rom ( name "Neon Genesis Evangelion (Japan).n64" size 33554432 crc 4B8B23DC md5 5E0CF74116F195913D543CAED446D990 sha1 BF10F76812ADA36C304EB45AD5DA794F02C560FE flags verified )
-	rom ( name "Neon Genesis Evangelion (J) [!].z64" size 33554432 crc A10A86AF md5 5E1940CA1236A76E8F2D15DE0414AE55 sha1 A9BA0A4AFEED48080F54AA237850F3676B3D9980 )
 )
 
 game (
 	name "New Tetris, The (Europe)"
 	description "New Tetris, The (Europe)"
 	rom ( name "New Tetris, The (Europe).n64" size 12582912 crc 88B774C4 md5 847724BA74D3610D9CDA1D9163F34047 sha1 99C7FF49CFD04569FB29514149BE62F073A19BDA flags verified )
-	rom ( name "New Tetris, The (E) [!].z64" size 12582912 crc 983263D7 md5 C4ECFEC66ECEEA23F39632AB6753300F sha1 2392F403B0993F838912CEFA83AEFD35D34A05A0 )
 )
 
 game (
 	name "New Tetris, The (USA)"
 	description "New Tetris, The (USA)"
 	rom ( name "New Tetris, The (USA).n64" size 12582912 crc 82A76DC9 md5 FD417F24466BEE4443CF0A7740E34C1A sha1 CC88BFED8B77885CDA6123C08E5D3B11451C6074 )
-	rom ( name "New Tetris, The (U) [!].z64" size 12582912 crc 528A07FA md5 7A28179B00734C9AA0F0609FAFAAFD5F sha1 83FFF25E82181A6993F28C91B9EEB8430396838B )
 )
 
 game (
 	name "NFL Blitz (USA)"
 	description "NFL Blitz (USA)"
 	rom ( name "NFL Blitz (USA).n64" size 16777216 crc 5FA3455D md5 4FE0DF8523E907DE4C7C85E836BFB637 sha1 FA193A704B83F00CF3874D2F49275930168F0416 )
-	rom ( name "NFL Blitz (U) [!].z64" size 16777216 crc 9BCD670F md5 7F6C5E71711DEC81E77CCF71060F67CA sha1 2853AFD9E38D63D913C8484F546804708C8AD712 )
 )
 
 game (
 	name "NFL Blitz - Special Edition (USA)"
 	description "NFL Blitz - Special Edition (USA)"
 	rom ( name "NFL Blitz - Special Edition (USA).n64" size 16777216 crc 3DD3EB64 md5 7B5036A93B1F01F1D90D3DF554DACB51 sha1 2F64076B423A72F873A04910A40D3A3F5DDDBB25 )
-	rom ( name "NFL Blitz - Special Edition (U) [!].z64" size 16777216 crc 5D1907F7 md5 7E856FA8F743900FEBA5A4E28C234AF7 sha1 A109F44BBB3270205205755BA9A889BAFC6FF5AB )
 )
 
 game (
 	name "NFL Blitz 2000 (USA)"
 	description "NFL Blitz 2000 (USA)"
 	rom ( name "NFL Blitz 2000 (USA).n64" size 16777216 crc E4B42E6A md5 B4015F331830C550EDD438F254BE318A sha1 0DC7A0B174C53D95CB8046538A1A4C4475D7209D )
-	rom ( name "NFL Blitz 2000 (U) [!].z64" size 16777216 crc 7F471773 md5 BA49514441023722F02D41C62612F6C3 sha1 36E124746A842A2E1F72480F122DFE9188FC5575 )
 )
 
 game (
@@ -3698,161 +3230,138 @@ game (
 	name "NFL Blitz 2001 (USA)"
 	description "NFL Blitz 2001 (USA)"
 	rom ( name "NFL Blitz 2001 (USA).n64" size 16777216 crc E18211E5 md5 86B10A10D32821F6972E14752EF0A56B sha1 1305EA64FA5EB62B36E029C5646299C080DAEDE9 )
-	rom ( name "NFL Blitz 2001 (U) [!].z64" size 16777216 crc 18EEB41B md5 E4EDD73CB036C6B143CEE9AEEED60341 sha1 279BC9ED596663610265A618A1656DBB8EA4237A )
 )
 
 game (
 	name "NFL QB Club 2001 (USA)"
 	description "NFL QB Club 2001 (USA)"
 	rom ( name "NFL QB Club 2001 (USA).n64" size 12582912 crc 2C0D748B md5 0272B74693620913F7C5170D747A546E sha1 1B31A55A7C744F5DE52F6198820C17BF25785EBF )
-	rom ( name "NFL Quarterback Club 2001 (U) [!].z64" size 12582912 crc 6D849E17 md5 FD2CBDEA0992452B52E2803224232D12 sha1 C81421BB204270EF5DDD8F60DDA51CDF73482FE2 )
 )
 
 game (
 	name "NFL Quarterback Club 2000 (Europe)"
 	description "NFL Quarterback Club 2000 (Europe)"
 	rom ( name "NFL Quarterback Club 2000 (Europe).n64" size 12582912 crc 11225980 md5 B1D3B429CCA7650681882B40B6CD1A0D sha1 9029E7B3EA19277E323337E5B41BB6BA83EE57AE flags verified )
-	rom ( name "NFL Quarterback Club 2000 (E) [!].z64" size 12582912 crc CEEF5C29 md5 75C0121D84915BF5C1FBD389CF9F9C17 sha1 CD97AECE871F0AE5D29AF9F92142A470A34273B9 )
 )
 
 game (
 	name "NFL Quarterback Club 2000 (USA)"
 	description "NFL Quarterback Club 2000 (USA)"
 	rom ( name "NFL Quarterback Club 2000 (USA).n64" size 12582912 crc B61D114A md5 574D2F51E9D4B05057925B49CF45526B sha1 63B52F8C4D8EFAAABC87237938FD65975EC19BAD )
-	rom ( name "NFL Quarterback Club 2000 (U) [!].z64" size 12582912 crc 8F54F999 md5 EC18E3131040842E32EBAB66C7496EBD sha1 390FEA44C8DF84F601B20A3E506FDD611AB34A8B )
 )
 
 game (
 	name "NFL Quarterback Club 98 (Europe)"
 	description "NFL Quarterback Club 98 (Europe)"
 	rom ( name "NFL Quarterback Club 98 (Europe).n64" size 8388608 crc 129928ED md5 EB1A0007ED08AA3BE9EF465447C69CAF sha1 E73F59F51EFF338DA0FEEDFE018C6FB46C3638F3 flags verified )
-	rom ( name "NFL Quarterback Club 98 (E) [!].z64" size 8388608 crc 34A21417 md5 A18CA5DBC85668667AA467ADD6A62B39 sha1 1F00635179FB741FBBCF31FFAFF399469DA16ECF )
 )
 
 game (
 	name "NFL Quarterback Club 98 (USA)"
 	description "NFL Quarterback Club 98 (USA)"
 	rom ( name "NFL Quarterback Club 98 (USA).n64" size 8388608 crc 94368DB1 md5 593678BCD8C2C98E0B72CB8B22771584 sha1 AFA0FA7B55931325426C46C3A04A1A5BEC81F711 )
-	rom ( name "NFL Quarterback Club 98 (U) [!].z64" size 8388608 crc ABF0E8F2 md5 709F966C30CE6DF1833E95740A5A2AB2 sha1 8E53DE9EB6DCECB3B0BB3E707EF01690DE7EFAB2 )
 )
 
 game (
 	name "NFL Quarterback Club 99 (Europe)"
 	description "NFL Quarterback Club 99 (Europe)"
 	rom ( name "NFL Quarterback Club 99 (Europe).n64" size 12582912 crc 8D95305F md5 F3696DD7D1F47F99E6F4962E5C1C69D7 sha1 32E5B34284B4CA3CF52FAB86DC4A155624B4B64D flags verified )
-	rom ( name "NFL Quarterback Club 99 (E) [!].z64" size 12582912 crc F688BDF3 md5 7EC0484C2BA6AA9F0A45D7AC1F4117DA sha1 1EE4EBAF6B0C189164397EA257F17B45EEDF0767 )
 )
 
 game (
 	name "NFL Quarterback Club 99 (USA)"
 	description "NFL Quarterback Club 99 (USA)"
 	rom ( name "NFL Quarterback Club 99 (USA).n64" size 12582912 crc CE525BC5 md5 86FD9DDE3D248E1FA2FA0C31045AE3E2 sha1 BB054FA24A084018995B68164560020DE44C6C92 )
-	rom ( name "NFL Quarterback Club 99 (U) [!].z64" size 12582912 crc 44496B26 md5 928869D1CE001B813BA908DFE18D7F94 sha1 8DBA75859D21219B3638E337991851DB31B4D70E )
 )
 
 game (
 	name "NHL 99 (Europe) (En,De,Sv,Fi)"
 	description "NHL 99 (Europe) (En,De,Sv,Fi)"
 	rom ( name "NHL 99 (Europe) (En,De,Sv,Fi).n64" size 12582912 crc 5CAABE5A md5 40359DD3081568FFB007F7BD6E9FE372 sha1 D6142F571BB72E4BC6AC9C665E666FCD927302A4 flags verified )
-	rom ( name "NHL 99 (E) [!].z64" size 12582912 crc F3B2AA4D md5 B7E41D34D209B6CFA92E3D622F911C4E sha1 87CD5ECFF93D5B34C246CB96A6249B78B5B90126 )
 )
 
 game (
 	name "NHL 99 (USA)"
 	description "NHL 99 (USA)"
 	rom ( name "NHL 99 (USA).n64" size 12582912 crc 50F81F73 md5 E6C12AC9C562D772B8EB4F3FA439A84D sha1 94B9957551BC31E5BFB49C72310155E376887757 )
-	rom ( name "NHL 99 (U) [!].z64" size 12582912 crc E5DF2AFE md5 A62FA044BCB5507D358424ABDA6419DB sha1 D730540D8C447420DE4AA81F6A2776C2E310D12A )
 )
 
 game (
 	name "NHL Blades of Steel '99 (USA)"
 	description "NHL Blades of Steel '99 (USA)"
 	rom ( name "NHL Blades of Steel '99 (USA).n64" size 12582912 crc 5EF28CFB md5 C6DC3887063705863C70CD516C036867 sha1 176BDE5F17295AECCEA06C09C761ADD271A6931F )
-	rom ( name "NHL Blades of Steel '99 (U) [!].z64" size 12582912 crc 1EE678FE md5 349F61F9747F2D2098F305924C97A1BF sha1 C55E9771B1548CFE4297646ADCFCAFE85712DA5E )
 )
 
 game (
 	name "NHL Breakaway 98 (Europe)"
 	description "NHL Breakaway 98 (Europe)"
 	rom ( name "NHL Breakaway 98 (Europe).n64" size 12582912 crc 30B28491 md5 B32084ADF71213662B255E6678F134DC sha1 7F3F234BB01B1128D954C3D98F2DEBAD6EAA018F flags verified )
-	rom ( name "NHL Breakaway 98 (E) [!].z64" size 12582912 crc 8C0C9669 md5 46476A5626CD99B3749AC1EE1E234FAC sha1 6D6631FE93B7C70AE28960F4141AC7656B333AA4 )
 )
 
 game (
 	name "NHL Breakaway 98 (USA)"
 	description "NHL Breakaway 98 (USA)"
 	rom ( name "NHL Breakaway 98 (USA).n64" size 12582912 crc F59B082F md5 08FAD70EF737B685AD030604F237C674 sha1 4CE6FA90BC8A92A73EAFEBB677EA6DDB90E93ECC )
-	rom ( name "NHL Breakaway 98 (U) [!].z64" size 12582912 crc 49D86C00 md5 B62076FA1421B8E7FDEC2B4F8A910EA3 sha1 2658334BF4091D0D3ED2DE3327592D04FC0B6849 )
 )
 
 game (
 	name "NHL Breakaway 99 (Europe)"
 	description "NHL Breakaway 99 (Europe)"
 	rom ( name "NHL Breakaway 99 (Europe).n64" size 12582912 crc B7E1618A md5 51660FECECC432FE2A6D5D3CBC8AD386 sha1 59A291A5F9887F8D569670A868E44C53CFB84475 flags verified )
-	rom ( name "NHL Breakaway 99 (E) [!].z64" size 12582912 crc 572060E0 md5 4BA95AA97ECFEE36051EBE0A9024EEE8 sha1 46147DB00BD9D80F0D22E8EB1B00603106DE2692 )
 )
 
 game (
 	name "NHL Breakaway 99 (USA)"
 	description "NHL Breakaway 99 (USA)"
 	rom ( name "NHL Breakaway 99 (USA).n64" size 12582912 crc 9F774781 md5 67FB118A37B3C742F5DD8B1F452F43D8 sha1 B026FB43057815B7D383F82170617AB5D59120F9 )
-	rom ( name "NHL Breakaway 99 (U) [!].z64" size 12582912 crc 75F75B9D md5 AF1D07679014760B88923A4827658CAF sha1 65C0F8BF81D8DEC3E5D719B167A61A73B2436E84 )
 )
 
 game (
 	name "NHL Pro 99 (Europe)"
 	description "NHL Pro 99 (Europe)"
 	rom ( name "NHL Pro 99 (Europe).n64" size 12582912 crc 36696571 md5 B47E8A21CA2AFBD3B43D5B781041A613 sha1 C8B0D2C2FA2B221EFE1FEE05220581A68A6C3F9E flags verified )
-	rom ( name "NHL Pro 99 (E) [!].z64" size 12582912 crc E272867E md5 A61854CF27E536C8513174FAEF08DFCB sha1 4FF557CCD19982699B3AA82D4C44F436D1D87F93 )
 )
 
 game (
 	name "Nightmare Creatures (USA)"
 	description "Nightmare Creatures (USA)"
 	rom ( name "Nightmare Creatures (USA).n64" size 16777216 crc 134C09DA md5 EEBB2936CD8514C47E973A98FC37296A sha1 1D01BE47A805679D17BEDC4F5294DB20BBB2875D )
-	rom ( name "Nightmare Creatures (U) [!].z64" size 16777216 crc 6A1EB795 md5 4116CF435DB315A2481AF8D1E9352FEB sha1 BEA6C21B3EF5950BDF8CDB255955DA6C4746EEA8 )
 )
 
 game (
 	name "Nintama Rantarou 64 Game Gallery (Japan)"
 	description "Nintama Rantarou 64 Game Gallery (Japan)"
 	rom ( name "Nintama Rantarou 64 Game Gallery (Japan).n64" size 8388608 crc 2D96C091 md5 6672AA7772BF2280077B6B57A200AAC0 sha1 0C2EE2266C67B5AFA507F5B8ECE88AB565FED63A flags verified )
-	rom ( name "Nintama Rantarou 64 Game Gallery (J) [!].z64" size 8388608 crc 8C7C2DCA md5 B04957D052EF850C5EDECE69DB7377B3 sha1 1BF5217924C5FB00F8E8829E9EBF3FBCEB89B9CD )
 )
 
 game (
 	name "Nintendo All-Star! Dairantou Smash Brothers (Japan)"
 	description "Nintendo All-Star! Dairantou Smash Brothers (Japan)"
 	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (Japan).n64" size 16777216 crc A2D1D0D1 md5 69A4BBDABDF6806AA37044508D0775B4 sha1 42E5BAB5D8C3B3CA3582E142094B50ECC7FEA5E6 flags verified )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [!].z64" size 16777216 crc 04C9D3B1 md5 66DB457B130D31A286A23D6E4DD9726E sha1 4B71F0E01878696733EEFA9C80D11C147ECB4984 )
 )
 
 game (
 	name "Nuclear Strike 64 (Europe) (En,Fr)"
 	description "Nuclear Strike 64 (Europe) (En,Fr)"
 	rom ( name "Nuclear Strike 64 (Europe) (En,Fr).n64" size 33554432 crc 575FBFE5 md5 6AE796D1D0BEFA2321A5FF055A48DD13 sha1 C170B3A4032CFDF885068F6F3AF9EB6CBF28484C flags verified )
-	rom ( name "Nuclear Strike 64 (E) (M2) [!].z64" size 33554432 crc 9AFBFCAF md5 710BA49EBD5C9A2B26653FAE93BD667A sha1 34A23CFA247DE4E8ECDB8D72431AF93D35C69753 )
 )
 
 game (
 	name "Nuclear Strike 64 (Germany)"
 	description "Nuclear Strike 64 (Germany)"
 	rom ( name "Nuclear Strike 64 (Germany).n64" size 33554432 crc 2F575E61 md5 AF0378047DEB8B6E01380FD7C562E16B sha1 7DF3153F6FD24BA33255909225B481C3444A6FA7 )
-	rom ( name "Nuclear Strike 64 (G) [!].z64" size 33554432 crc 0916AB13 md5 D43C2E1938534363E56A22413B91D051 sha1 B3E7F7C3306B7DE2F29FE115FF74DE7FC95149C7 )
 )
 
 game (
 	name "Nuclear Strike 64 (USA)"
 	description "Nuclear Strike 64 (USA)"
 	rom ( name "Nuclear Strike 64 (USA).n64" size 33554432 crc 1A70D11A md5 3B7330D7055AD8D514E4F516F2A80101 sha1 EA1371D29CBDEDE166A69C77B2C4A77D6EDAB77D )
-	rom ( name "Nuclear Strike 64 (U) [!].z64" size 33554432 crc D7467294 md5 FFC584040D0D052FBAB4CB6C19245449 sha1 6A8B0B450E87FBFBADEEE3854ADA0731DEB6E8B5 )
 )
 
 game (
 	name "Nushi Zuri 64 (Japan)"
 	description "Nushi Zuri 64 (Japan)"
 	rom ( name "Nushi Zuri 64 (Japan).n64" size 16777216 crc 02FF4DF5 md5 F9CDE2DC7B498309879CB7CE3C10A2EA sha1 0C6561DB721D440C1E29FABB79A53B0422AC1903 flags verified )
-	rom ( name "Nushi Tsuri 64 (J) [!].z64" size 16777216 crc A6800EC0 md5 50C10082D0C077FDB5658EF5A6E3F54F sha1 5F20D41669458E1C981292F17CD8B29032406287 )
 )
 
 game (
@@ -3865,42 +3374,36 @@ game (
 	name "Nushi Zuri 64 - Shiokaze ni Notte (Japan)"
 	description "Nushi Zuri 64 - Shiokaze ni Notte (Japan)"
 	rom ( name "Nushi Zuri 64 - Shiokaze ni Notte (Japan).n64" size 33554432 crc 6A81744D md5 EA55037AD7BFA5E1EC5605A39D35CA04 sha1 5306827FFBF9BD51F52723D87083D68DB240C890 flags verified )
-	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!].z64" size 33554432 crc F0BCD1CE md5 EEB69597E42E2F5D2914070ACF161B4F sha1 85D8B412E3045C7A06062D3E155FEF9EA918E800 )
 )
 
 game (
 	name "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)"
 	description "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)"
 	rom ( name "O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).n64" size 16777216 crc 6E79473E md5 88A46921227F3FA23F52AED725C040D1 sha1 93DC2ADB08C209FDC0BF2F007824FDE79F79A638 )
-	rom ( name "O.D.T. (E) (M5) [!].z64" size 16777216 crc 7B870026 md5 E2FB4F16A039A0E302D28ACA94D5D928 sha1 092FB7C560B40CC3A2A0E6B48A6AFC10948C4166 )
 )
 
 game (
 	name "O.D.T. (USA) (En,Fr,Es) (Proto)"
 	description "O.D.T. (USA) (En,Fr,Es) (Proto)"
 	rom ( name "O.D.T. (USA) (En,Fr,Es) (Proto).n64" size 16777216 crc AE7E3A9E md5 AE29DE9B6BD8DEA8CF27783B2F720B10 sha1 9D1E073F9AAD18F4A7A52CB185A50F5045BFD656 )
-	rom ( name "O.D.T. (U) (M3) [!].z64" size 16777216 crc 1D4A8659 md5 4116E492168AAFFF1BD3100C7B0AA28F sha1 453A7A636B05C8B9DAD6AA6FB5E265BAAE568074 )
 )
 
 game (
 	name "Off Road Challenge (Europe)"
 	description "Off Road Challenge (Europe)"
 	rom ( name "Off Road Challenge (Europe).n64" size 16777216 crc E1938232 md5 4F6390A166F11F9D2920F15780DF937C sha1 C15EBCDBE0532556E215CDB7EE35C4F25FE66884 flags verified )
-	rom ( name "Off Road Challenge (E) [!].z64" size 16777216 crc D9FE9EE7 md5 E96FECBA52905DB14ADDAD7CFD61091F sha1 3476E0EB4048C76107BD2B404D19A136BFC15AD9 )
 )
 
 game (
 	name "Off Road Challenge (USA)"
 	description "Off Road Challenge (USA)"
 	rom ( name "Off Road Challenge (USA).n64" size 16777216 crc 129BADCC md5 4CA359921B3A49DCD5BBD725656A255D sha1 914239AA8172C91C44280A09E34B6E7CE046CA1B )
-	rom ( name "Off Road Challenge (U) [!].z64" size 16777216 crc 1A45C5AB md5 AF7083FC0ABCFD5A2C6A5E971453D831 sha1 9E754CA37D69424E9F82A421D5E69D4AD73046C1 )
 )
 
 game (
 	name "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A)"
 	description "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A)"
 	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev A).n64" size 41943040 crc D52F01FD md5 4777C460D5BFE53978A33D825413C4BF sha1 771BB04C814FDB741351B37BC4CA2DB00F3D2A43 flags verified )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!].z64" size 41943040 crc 845B8711 md5 A45C39767D33AC21956A3D4E6C03CFA1 sha1 244A92DF46863964EC507C78B72C226F48754967 )
 )
 
 game (
@@ -3920,49 +3423,42 @@ game (
 	name "Olympic Hockey 98 (Europe) (En,Fr,De,Es)"
 	description "Olympic Hockey 98 (Europe) (En,Fr,De,Es)"
 	rom ( name "Olympic Hockey 98 (Europe) (En,Fr,De,Es).n64" size 8388608 crc 1C7B9ED5 md5 435EB59F36BDEA6BFC2E25D763C9EE46 sha1 D72F932B0D12F19B9423A112664D0CCFC1526767 flags verified )
-	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [!].z64" size 8388608 crc 5A805C2E md5 465DFD27DDAB4F5488F4DADC09B7F938 sha1 E01404FAC7E9AFC02D48BF889ABA51F843165B7C )
 )
 
 game (
 	name "Olympic Hockey 98 (Japan)"
 	description "Olympic Hockey 98 (Japan)"
 	rom ( name "Olympic Hockey 98 (Japan).n64" size 8388608 crc 436CC625 md5 9C58F2842D71B3145650133C2F1E7824 sha1 DF9D4743019FBA3DD0725588F0D17D97CBB2C223 flags verified )
-	rom ( name "Olympic Hockey Nagano '98 (J) [!].z64" size 8388608 crc 9E98FCE8 md5 8A964671C5A4F4FC62787F1F25EDD70D sha1 A5359E35839B40C414EAE498CA633B28176629AA )
 )
 
 game (
 	name "Olympic Hockey 98 (USA)"
 	description "Olympic Hockey 98 (USA)"
 	rom ( name "Olympic Hockey 98 (USA).n64" size 8388608 crc C57C7643 md5 C80F8E7D193A9582A0662C923B128F7F sha1 7E200F4F4D2A7EB0DDC2011BD55628B5A50788BF )
-	rom ( name "Olympic Hockey Nagano '98 (U) [!].z64" size 8388608 crc 2D777652 md5 9C99C6D9EA98A960056C531CB78EB35B sha1 02310067DEFD4C7EAC235DFF5E71EF0566CE916C )
 )
 
 game (
 	name "Onegai Monsters (Japan)"
 	description "Onegai Monsters (Japan)"
 	rom ( name "Onegai Monsters (Japan).n64" size 16777216 crc FF03EC8A md5 94F9782A2D365C7A697119D728909257 sha1 A352A6F95B414F7563503FA39E92C604F965A11E flags verified )
-	rom ( name "Onegai Monsters (J) [!].z64" size 16777216 crc AC72A1C7 md5 3796829F54958CE103DCF5E3E8EB80B4 sha1 7592F4C16B8E040539B5DCC201FAB2965A5E8C8D )
 )
 
 game (
 	name "Operation WinBack (Europe) (En,Fr,De,Es,It)"
 	description "Operation WinBack (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Operation WinBack (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 15F1C325 md5 D92A9A5BB620700F6CF59EED83DE9105 sha1 6AB5A9771F4BED7F96726C943A24215300C107E5 flags verified )
-	rom ( name "Operation WinBack (E) (M5) [!].z64" size 16777216 crc FB96F166 md5 91CF1982F309BD73822165087DAD4371 sha1 133F17162B2734286F9E94F64ACB1538B11506B2 )
 )
 
 game (
 	name "Pachinko 365 Nichi (Japan)"
 	description "Pachinko 365 Nichi (Japan)"
 	rom ( name "Pachinko 365 Nichi (Japan).n64" size 12582912 crc 41363874 md5 31D86C32389108E5780E23380BE13974 sha1 A14F8B56F1F40D982E3636B328911CCC96B58BD5 flags verified )
-	rom ( name "Pachinko 365 Nichi (J) [!].z64" size 12582912 crc 42D06E32 md5 D60046C23400BFEBD5B051F89E7F2F07 sha1 B8F29E8EFCF51EE9A6A16E2A1E60442B4F304950 )
 )
 
 game (
 	name "Paper Mario (Europe) (En,Fr,De,Es)"
 	description "Paper Mario (Europe) (En,Fr,De,Es)"
 	rom ( name "Paper Mario (Europe) (En,Fr,De,Es).n64" size 67108864 crc 7CAB0055 md5 24EDF142D2974627C218D2D507190C3B sha1 7F29B70C9CB686AE678BEB40B59EE5583B095FF7 flags verified )
-	rom ( name "Paper Mario (E) (M4) [!].z64" size 67108864 crc 85B3AB37 md5 A9BE6A493A680642D840F859A65816CA sha1 2111D39265A317414D359E35A7D971C4DFA5F9E1 )
 )
 
 game (
@@ -3976,7 +3472,6 @@ game (
 	name "Paperboy (Europe)"
 	description "Paperboy (Europe)"
 	rom ( name "Paperboy (Europe).n64" size 12582912 crc D98C3F8B md5 7D4366BBED26ABD0C161501DE1BBAEBB sha1 DA7DA76570C4C5303475C30C18791CA83F8455C4 flags verified )
-	rom ( name "Paperboy (E) [!].z64" size 12582912 crc F00C5053 md5 B7F2EB7989C9C00096655D087D72EC51 sha1 7DB4808042B9651B47592E814AC4C125B51D4D2F )
 )
 
 game (
@@ -3990,49 +3485,42 @@ game (
 	name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)"
 	description "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)"
 	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).n64" size 12582912 crc 66420991 md5 C9FB55F7B8CFD59DB0CFE346F13B2694 sha1 2E1F15CBB6E4744D6B1C8EFDC708349AB6C8982A flags verified )
-	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!].z64" size 12582912 crc A33146E0 md5 D78E10C6B3E98F3B32FE0F23ED72DB42 sha1 9887A0E4BFE3C5E85E31638853574069F6C41CD3 )
 )
 
 game (
 	name "PD Ultraman Battle Collection 64 (Japan)"
 	description "PD Ultraman Battle Collection 64 (Japan)"
 	rom ( name "PD Ultraman Battle Collection 64 (Japan).n64" size 33554432 crc AB901B83 md5 5DB16368F53664CE98024AC721B12E84 sha1 15A646C8E612F50A767055C352A1BEF59AEF49E5 flags verified )
-	rom ( name "PD Ultraman Battle Collection 64 (J) [!].z64" size 33554432 crc 86CC80B5 md5 52F4F3320607F3E8DD1A16A2F1BFBDB0 sha1 16783D9DE1FF772E215F47441612D6805AA98C67 )
 )
 
 game (
 	name "Penny Racers (Europe)"
 	description "Penny Racers (Europe)"
 	rom ( name "Penny Racers (Europe).n64" size 8388608 crc DECD5D16 md5 62AC66021E02EAEBCEA8A153A7366E63 sha1 D44053CAED77DE2C91DE6527E1D4CD4441B231D8 flags verified )
-	rom ( name "Penny Racers (E) [!].z64" size 8388608 crc A1D6EB5B md5 20DA62ECE553EDE84D02283174BECC8F sha1 9848CC288B388D23E0AE026EF58DA8FC936D7605 )
 )
 
 game (
 	name "Penny Racers (USA)"
 	description "Penny Racers (USA)"
 	rom ( name "Penny Racers (USA).n64" size 8388608 crc 06BEEA3F md5 A9E6E459908009B979C4CB649609A208 sha1 F8CA8A70653DBE488749FD3EA3E428FB9B1F72C8 )
-	rom ( name "Penny Racers (U) [!].z64" size 8388608 crc C1E57337 md5 518B14054A667A3B9E0B72D3BF784E41 sha1 1D4FCE8AD6B1F0072D89AEB4C3187BC853B750A0 )
 )
 
 game (
 	name "Perfect Dark (Europe) (En,Fr,De,Es,It)"
 	description "Perfect Dark (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Perfect Dark (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc C4639ED6 md5 6F86452863716270C51C4F433AF47534 sha1 EB38780B7F7A0EA4C24369D03644B42FFE739E63 flags verified )
-	rom ( name "Perfect Dark (E) (M5) [!].z64" size 33554432 crc 7718A714 md5 D9B5CD305D228424891CE38E71BC9213 sha1 A663D3F4EEE0B198471132DB92E9639A9EDD1985 )
 )
 
 game (
 	name "Perfect Dark (Japan)"
 	description "Perfect Dark (Japan)"
 	rom ( name "Perfect Dark (Japan).n64" size 33554432 crc D76471DB md5 041B6A5025585E70AC658975F6DCBCD7 sha1 E001AF5A3069B374E0A08D1598B0833FE3128D82 flags verified )
-	rom ( name "Perfect Dark (J) [!].z64" size 33554432 crc 639C0DA9 md5 538D2B75945EAE069B29C46193E74790 sha1 99BCAAA4841B09C845E1094006DF8F637862F02E )
 )
 
 game (
 	name "Perfect Dark (USA)"
 	description "Perfect Dark (USA)"
 	rom ( name "Perfect Dark (USA).n64" size 33554432 crc F0FE18F0 md5 EAEDD63AE7609C8C795DB93AA2437C4C sha1 EA43D1F09B47107AE0D1B7472BCA58D785E8573A )
-	rom ( name "Perfect Dark (U) (V1.0) [!].z64" size 33554432 crc 68446AD4 md5 7F4171B0C8D17815BE37913F535E4E93 sha1 60DFE17923C03875B499B3CD3200F05CB538B7AD )
 )
 
 game (
@@ -4046,35 +3534,30 @@ game (
 	name "PGA European Tour (USA)"
 	description "PGA European Tour (USA)"
 	rom ( name "PGA European Tour (USA).n64" size 16777216 crc 2B07F591 md5 1ACCD330228ECEC87DAC81CCB999486D sha1 6417F608E7DD002DC1193641D8C846328C3FAAB2 )
-	rom ( name "PGA European Tour (U) [!].z64" size 16777216 crc 7CDFCDAA md5 617CECA1D2BEFFCE943EF832326898BF sha1 6E8DFCCFE93318A597E99C9186D5E8CDCA3BE987 )
 )
 
 game (
 	name "PGA European Tour Golf (Europe) (En,Fr,De,Es,It)"
 	description "PGA European Tour Golf (Europe) (En,Fr,De,Es,It)"
 	rom ( name "PGA European Tour Golf (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 07B0271E md5 71689E7713FC30F32E39D3B2EF8F7B65 sha1 20C442CF25951E2B09EB7B19E3E900B885231FFA flags verified )
-	rom ( name "PGA European Tour (E) (M5) [!].z64" size 16777216 crc 6B5FF959 md5 0112FFAADA116D172ABCE136E9043A93 sha1 F9E838CF5CFD0FA493D5E5F7A7D450A80787C814 )	
 )
 
 game (
 	name "Pikachuu Genki de Chuu (Japan)"
 	description "Pikachuu Genki de Chuu (Japan)"
 	rom ( name "Pikachuu Genki de Chuu (Japan).n64" size 16777216 crc 2AE884CD md5 9433601ED8326F9C60A5F78050EADA2E sha1 533BA7078E631BDCBF97776A151DBCAB206FA991 flags verified )
-	rom ( name "Pikachu Genki Dechu (J) [!].z64" size 16777216 crc 3F6245AE md5 E0BCB2758EDF0AC6AB7DB36D98E1E57C sha1 A28C689E58F58B4A2A672D3D010436661D247476 )
 )
 
 game (
 	name "Pilotwings 64 (Europe) (En,Fr,De)"
 	description "Pilotwings 64 (Europe) (En,Fr,De)"
 	rom ( name "Pilotwings 64 (Europe) (En,Fr,De).n64" size 8388608 crc 334E88BF md5 9E90E82CDA1F83B2BD43B9B19F68E404 sha1 7014B6AC0A6AF8AB729E441AE9B5DE08EF7B68DD flags verified )
-	rom ( name "Pilotwings 64 (E) (M3) [!].z64" size 8388608 crc C902E57C md5 3FCD4969F9A080BD2BCB913EC5D7A3BD sha1 FA4E0A1941EEA83E09CA00197569E2464D70ECB0 )
 )
 
 game (
 	name "Pilotwings 64 (Japan)"
 	description "Pilotwings 64 (Japan)"
 	rom ( name "Pilotwings 64 (Japan).n64" size 8388608 crc 001EE45B md5 C7BD4AB71093D71D1313905F85292EAF sha1 E6E8A48E433DC7A4949756E70AB18D0165A1BC6F flags verified )
-	rom ( name "Pilotwings 64 (J) [!].z64" size 8388608 crc 3D3A84A9 md5 E8E6EC0692009009F5DCA6827B21F59A sha1 892A5472D9A6811B881D093020DE81F72BAEEEC9 )
 )
 
 game (
@@ -4088,21 +3571,18 @@ game (
 	name "Pokemon Puzzle League (Europe)"
 	description "Pokemon Puzzle League (Europe)"
 	rom ( name "Pokemon Puzzle League (Europe).n64" size 33554432 crc 443B309A md5 CCCDA8BDB4C64DE28FA086DE3F8C0BD1 sha1 06EB1D4C92A7BAB8267B6FA15BE89F253DEAD96C flags verified )
-	rom ( name "Pokemon Puzzle League (E) [!].z64" size 33554432 crc 75839254 md5 2EF9FA16DE2A09EA15B6289447F40490 sha1 184F0CAC8FDFAD47590C515FC637076D2DED58D7 )
 )
 
 game (
 	name "Pokemon Puzzle League (France)"
 	description "Pokemon Puzzle League (France)"
 	rom ( name "Pokemon Puzzle League (France).n64" size 33554432 crc EE080CCD md5 FCC53191CE4825E5B858DEAAE9EC6D8A sha1 838F4CDC5033A672AFC8662700ECD8DF1EF6B776 flags verified )
-	rom ( name "Pokemon Puzzle League (F) [!].z64" size 33554432 crc C3AA0074 md5 A3BA044DFC00BB766B4B2BFB9D4B5BE9 sha1 72760A2D87ED3E70756A4AA689B9B26786669A52 )
 )
 
 game (
 	name "Pokemon Puzzle League (Germany)"
 	description "Pokemon Puzzle League (Germany)"
 	rom ( name "Pokemon Puzzle League (Germany).n64" size 33554432 crc 7D4C9859 md5 77A22697BA18EC59018F0C8B5F16C656 sha1 656C86A50E4954E11C202ADA31D2E2FD516B8F07 )
-	rom ( name "Pokemon Puzzle League (G) [!].z64" size 33554432 crc AC543150 md5 000364BAC80E41D9060A31A5923874B7 sha1 DBC9D0DE131F3604A9115B58368E9050F1A6303F )
 )
 
 game (
@@ -4116,49 +3596,42 @@ game (
 	name "Pokemon Snap (Japan)"
 	description "Pokemon Snap (Japan)"
 	rom ( name "Pokemon Snap (Japan).n64" size 16777216 crc 100AACC0 md5 37B2C5F48A58C22C62D7F5A3A77BB50A sha1 76EA033F8D76C3ADD4F76D7DC718834AA1D30615 flags verified )
-	rom ( name "Pocket Monsters Snap (J) [!].z64" size 16777216 crc A091BD56 md5 FBDD74ED68E6A0CD734562D56CCB752D sha1 5D7B3B8D4BB64DA5B7AE5E1F132B26A282C33909 )
 )
 
 game (
 	name "Pokemon Snap (Australia)"
 	description "Pokemon Snap (Australia)"
 	rom ( name "Pokemon Snap (Australia).n64" size 16777216 crc 8A8F6D5F md5 FC945109F7F097061E85E98D1FEDB745 sha1 D6BDD376A1BAEB863A14925BC96E2D1A73645E71 )
-	rom ( name "Pokemon Snap (A) [!].z64" size 16777216 crc CDEA6D4C md5 E5A0CA3DC54B38EA7FCD927E3CFFAD3B sha1 EB388731BB7530F60E3AD4A1652F79296B5063EC )
 )
 
 game (
 	name "Pokemon Snap (Europe)"
 	description "Pokemon Snap (Europe)"
 	rom ( name "Pokemon Snap (Europe).n64" size 16777216 crc E9100906 md5 D1858ECF414716FB86861862256D85EA sha1 85EC6F75567D5676EE7317B4F20C8EC6CACA03BB flags verified )
-	rom ( name "Pokemon Snap (E) [!].z64" size 16777216 crc F824A057 md5 F2A8106403D2BF9350BFEAB08689D54A sha1 D575B393812A0A59FBB52F3CE55CE4D7BC5F3225 )
 )
 
 game (
 	name "Pokemon Snap (France)"
 	description "Pokemon Snap (France)"
 	rom ( name "Pokemon Snap (France).n64" size 16777216 crc 116B2CAC md5 CA5BC0BE9FBCD288F60A21D10056B972 sha1 5C1D6E2020EED2E012B722A98846DB16FA7B1C9B )
-	rom ( name "Pokemon Snap (F) [!].z64" size 16777216 crc EC843586 md5 E9028F9CCC307806695DD81742D05D5D sha1 9EE1ED91AD6E00CC50E1A1513A256CCCEB9A41DF )
 )
 
 game (
 	name "Pokemon Snap (Germany)"
 	description "Pokemon Snap (Germany)"
 	rom ( name "Pokemon Snap (Germany).n64" size 16777216 crc 482A6D8D md5 182EEA9719F8C5EE6A29622B192CAA2C sha1 D12D3AD66DA97985F057D42DD7FBB9B9C1A0074E flags verified )
-	rom ( name "Pokemon Snap (G) [!].z64" size 16777216 crc 10C27B3C md5 144B8906DC40534CFBEF6D7B994A982B sha1 F1FE20E26C3803C0E4EA33711BE5E0EDF8E9C4BE )
 )
 
 game (
 	name "Pokemon Snap (Italy)"
 	description "Pokemon Snap (Italy)"
 	rom ( name "Pokemon Snap (Italy).n64" size 16777216 crc D3AE1D04 md5 AAAE244517FE402FE86BFBF8A2FC9D4F sha1 AB649B902B48271F628B614B43453C651592AF4F )
-	rom ( name "Pokemon Snap (I) [!].z64" size 16777216 crc 63F6058A md5 D0453459095F69BE36D675D8F743069B sha1 F69BFBF1F5590B2F25A79400ABCDAFB884F5E3A0 )
 )
 
 game (
 	name "Pokemon Snap (Spain)"
 	description "Pokemon Snap (Spain)"
 	rom ( name "Pokemon Snap (Spain).n64" size 16777216 crc 426A1919 md5 E845272B8A282AE4051676574405EC13 sha1 E2276ABF1CC2FE7BB5A8D05241214481B02580E1 )
-	rom ( name "Pokemon Snap (S) [!].z64" size 16777216 crc 371B787F md5 A45D7115BE5A06FD1567F9F913C3BDF8 sha1 24DA787140662D1FB40D8E17199CE6412D72DEDC )
 )
 
 game (
@@ -4179,50 +3652,42 @@ game (
 	name "Pokemon Stadium (Japan)"
 	description "Pokemon Stadium (Japan)"
 	rom ( name "Pokemon Stadium (Japan).n64" size 16777216 crc 3B2A3F7A md5 7159F1B35AF48EC43236DDFCC2C73B5C sha1 D1796076F855BD2354FFC5019EAEB2C9D7676716 flags verified )
-	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189C md5 C46E087D966A35095DF96799B0B4FFAE sha1 8BC8D2FF7DF25B26BD0C353D2ADFE83E4E3A7A87 )
-	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
 	name "Pokemon Stadium (Europe)"
 	description "Pokemon Stadium (Europe)"
 	rom ( name "Pokemon Stadium (Europe).n64" size 33554432 crc 7A8BF040 md5 3D01C1B902876B4F72C10B66ED99B693 sha1 DF6D958FDF04D598194AB5821DD77655DA9D0C5D )
-	rom ( name "Pokemon Stadium (E) (V1.0) [!].z64" size 33554432 crc DC57508D md5 2859090D78581E0925A3AF8045E81E4B sha1 6F26E3C8B35C3232058375E30D19665FACB23123 )
 )
 
 game (
 	name "Pokemon Stadium (Europe) (Rev A)"
 	description "Pokemon Stadium (Europe) (Rev A)"
 	rom ( name "Pokemon Stadium (Europe) (Rev A).n64" size 33554432 crc 60F6BE65 md5 B70451292A9F5C57F1526520ADC7F340 sha1 B34B5DB300E0A7B9D283839B92A3A7040924130A flags verified )
-	rom ( name "Pokemon Stadium (E) (V1.1) [!].z64" size 33554432 crc DA889668 md5 31EE2DE8E65E30F5934C450DBAA924F0 sha1 9470F899AD0107677B7DFD24E1DD567723A5F84F )
 )
 
 game (
 	name "Pokemon Stadium (France)"
 	description "Pokemon Stadium (France)"
 	rom ( name "Pokemon Stadium (France).n64" size 33554432 crc 476848F6 md5 2C8804EDFE7BB61C4FC3AABE27D13EEE sha1 3F246D6357AB981DB1E2C588C92B29B7DBE4051C )
-	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
 	name "Pokemon Stadium (Germany)"
 	description "Pokemon Stadium (Germany)"
 	rom ( name "Pokemon Stadium (Germany).n64" size 33554432 crc 3243A2A7 md5 738A02D2C1DE1D60ADE9E45654466019 sha1 20943B1E25AF11AE2305D9680049DFA777B96EF0 flags verified )
-	rom ( name "Pokemon Stadium (G) [!].z64" size 33554432 crc 9F22A945 md5 24BE2CCB0DEA0755908C02BF67E22FE5 sha1 6A25903E733F071E7D6EA54529B7FD60B760CDA3 )
 )
 
 game (
 	name "Pokemon Stadium (Italy)"
 	description "Pokemon Stadium (Italy)"
 	rom ( name "Pokemon Stadium (Italy).n64" size 33554432 crc 77A59419 md5 CDD4546D1C9CFA4FA835A519C8696982 sha1 C205D6CEF57D1FEC51F13627F1D2957138814322 )
-	rom ( name "Pokemon Stadium (I) [!].z64" size 33554432 crc F155C465 md5 A81321759AF38BEB30A40FDACA2EA22A sha1 DB5F2797C377FA8957B97465FC5738D6999FF240 )
 )
 
 game (
 	name "Pokemon Stadium (Spain)"
 	description "Pokemon Stadium (Spain)"
 	rom ( name "Pokemon Stadium (Spain).n64" size 33554432 crc 7ADFB7E0 md5 13B70060607A6F86E29427D784B984CE sha1 D8BCE5FDD89654C37C74E64A39589466C6ED8C3D )
-	rom ( name "Pokemon Stadium (S) [!].z64" size 33554432 crc F02CD5EB md5 D14A499BC4E324974EAE3E42DEC58625 sha1 F39911AD0BEDCCC3E44D4338507C73BFA97856BF )
 )
 
 game (
@@ -4236,7 +3701,6 @@ game (
 	name "Pokemon Stadium (USA) (Rev A)"
 	description "Pokemon Stadium (USA) (Rev A)"
 	rom ( name "Pokemon Stadium (USA) (Rev A).n64" size 33554432 crc 7BB7489F md5 A029CF9B7D15E30FB88E472D965B2865 sha1 D5B479461CD45DB31E896143519C85B7136CFE2E flags verified )
-	rom ( name "Pokemon Stadium (U) (V1.1) [!].z64" size 33554432 crc 72B552E3 md5 A7087A96A709E4C662A459B4B4159094 sha1 E8F84246EEBDC63C31CEBFD0475C72A3520A67A3 )
 )
 
 game (
@@ -4249,42 +3713,36 @@ game (
 	name "Pokemon Stadium 2 (Japan)"
 	description "Pokemon Stadium 2 (Japan)"
 	rom ( name "Pokemon Stadium 2 (Japan).n64" size 33554432 crc C876BE9C md5 A682DF3D958AF64B48AA5B8EB809EDF1 sha1 17A3552F251DAEB475B359AAC687BCEE473C13F7 flags verified )
-	rom ( name "Pocket Monsters Stadium 2 (J) [!].z64" size 33554432 crc 40AA4874 md5 2449BB712A64E3363A6CBD56F5ADEDA5 sha1 074582744C71D7F0569CE960964A7BBE947EFD3C )
 )
 
 game (
 	name "Pokemon Stadium 2 (Europe)"
 	description "Pokemon Stadium 2 (Europe)"
 	rom ( name "Pokemon Stadium 2 (Europe).n64" size 67108864 crc 85F53D6C md5 31209E91A896F0E7A70971ADAB11F4CA sha1 F090D5F2C20BCD2290A7544AF5304E81C0F63D84 flags verified )
-	rom ( name "Pokemon Stadium 2 (E) [!].z64" size 67108864 crc 6B3096C4 md5 B1271DB50D6EF8F6B53CC640C3743E4F sha1 F6A7E8146433A48BF101722E30BF86311A641F7B )
 )
 
 game (
 	name "Pokemon Stadium 2 (France)"
 	description "Pokemon Stadium 2 (France)"
 	rom ( name "Pokemon Stadium 2 (France).n64" size 67108864 crc A72C55AF md5 E75AB876AD8CD202D0D97F0661088157 sha1 8B7D84BFCE6E1CCE565E3DA13D1B70AC49972B4B )
-	rom ( name "Pokemon Stadium 2 (F) [!].z64" size 67108864 crc E2A78066 md5 4748D96916AE2BCC5FC1630515EE2561 sha1 D7E13535B671024A92822DB01507E87BD42F68EC )
 )
 
 game (
 	name "Pokemon Stadium 2 (Germany)"
 	description "Pokemon Stadium 2 (Germany)"
 	rom ( name "Pokemon Stadium 2 (Germany).n64" size 67108864 crc B0A291FC md5 2D84449AA09E7BE0210D88EB95F44334 sha1 BDB0DB2AB6E2661BD32FF3CD1DED3BD5AD6073EF flags verified )
-	rom ( name "Pokemon Stadium 2 (G) [!].z64" size 67108864 crc 1146A43A md5 484F3E696C94980ACF3D7068F9ACC98F sha1 6DE05180D77E73DCF32D57AF7C8C1529C7ACDA59 )
 )
 
 game (
 	name "Pokemon Stadium 2 (Italy)"
 	description "Pokemon Stadium 2 (Italy)"
 	rom ( name "Pokemon Stadium 2 (Italy).n64" size 67108864 crc C849C481 md5 98E85F8307B004E0A44321D271B96343 sha1 55E9C0186A5C846B84315B1780587D31E8A9EB44 )
-	rom ( name "Pokemon Stadium 2 (I) [!].z64" size 67108864 crc 9FA5C095 md5 5A04D7F1AB9C6B080176567AA7168D3A sha1 4926DB649C76521F61AE51C13E452A2C8001354C )
 )
 
 game (
 	name "Pokemon Stadium 2 (Spain)"
 	description "Pokemon Stadium 2 (Spain)"
 	rom ( name "Pokemon Stadium 2 (Spain).n64" size 67108864 crc 391119B5 md5 B20177F0D7693991428837737151FB79 sha1 EF07A49536DDB18B98897B78EB66A44C13467351 )
-	rom ( name "Pokemon Stadium 2 (S) [!].z64" size 67108864 crc 283E7641 md5 B26AAFD452C9816E1B7AA0954E75825F sha1 AB1CDF753BED70487923EA3129278E45D6325773 )
 )
 
 game (
@@ -4298,7 +3756,6 @@ game (
 	name "Pokemon Stadium Kin Gin (Japan)"
 	description "Pokemon Stadium Kin Gin (Japan)"
 	rom ( name "Pokemon Stadium Kin Gin (Japan).n64" size 67108864 crc 16701567 md5 586F807965D79E117F74D9353186249E sha1 4D40523A8FC1C212F30312BB7DCB665588BC6F1B flags verified )
-	rom ( name "Pocket Monsters Stadium Kin Gin (J) [!].z64" size 67108864 crc CBC3B935 md5 A17AADCC962393D476EDC321E59C504B sha1 05682E60B13479CA1C54656E5A5B1EE6D099C1A4 )
 )
 
 game (
@@ -4311,14 +3768,12 @@ game (
 	name "Power League 64 (Japan)"
 	description "Power League 64 (Japan)"
 	rom ( name "Power League 64 (Japan).n64" size 8388608 crc BC7E2494 md5 FAEB21232DC50BCC9CA01E93A5DBD2AF sha1 97E55B2C39F4E0390EC280A6F6D6D2777669EB43 flags verified )
-	rom ( name "Power League Baseball 64 (J) [!].z64" size 8388608 crc AEC21C28 md5 8CC73C373016070647030DDE492FDC8C sha1 1E0D939C8E278DE21C42FA33495E446ED03C027E )
 )
 
 game (
 	name "Power Rangers - Lightspeed Rescue (Europe)"
 	description "Power Rangers - Lightspeed Rescue (Europe)"
 	rom ( name "Power Rangers - Lightspeed Rescue (Europe).n64" size 12582912 crc 88250AB1 md5 6E2F4DBD273BCB6F881C359E7422D022 sha1 C49AC782BC970A7CE1F76D7B60F7E741E915FBE2 )
-	rom ( name "Power Rangers - Lightspeed Rescue (E) [!].z64" size 12582912 crc 83590247 md5 AE3BDF729214964620417CC3163F0BB6 sha1 C0C283528CB892195F6D22B8A5C610239FA8C206 )
 )
 
 game (
@@ -4339,14 +3794,12 @@ game (
 	name "Premier Manager 64 (Europe)"
 	description "Premier Manager 64 (Europe)"
 	rom ( name "Premier Manager 64 (Europe).n64" size 16777216 crc 74A0C415 md5 427F58630B25DE66A1C87C7B3BD30E3E sha1 C379521C2BAE36F37D93DDCD2781ABC255AE4E14 flags verified )
-	rom ( name "Premier Manager 64 (E) [!].z64" size 16777216 crc 81CDA888 md5 25BAFC84BA4D87854DC44DF3EF8764EA sha1 6AFFB5B00B1862E233E4D909DC6E4201F9945579 )
 )
 
 game (
 	name "Pro Mahjong Kiwame 64 (Japan)"
 	description "Pro Mahjong Kiwame 64 (Japan)"
 	rom ( name "Pro Mahjong Kiwame 64 (Japan).n64" size 8388608 crc 01E83335 md5 B65C64ECCCAC8B4802754437AB4AFFF8 sha1 D58D1BD7184A69AB06F0104A0A94A1179EE7B208 flags verified )
-	rom ( name "Pro Mahjong Kiwame 64 (J) [!].z64" size 8388608 crc 1F5907F9 md5 7995D76F4CE236B0F0289F47AE523D32 sha1 B5BE6C3B49AD37C0DD1D6E7DACBCBE03653859D9 )
 )
 
 game (
@@ -4359,35 +3812,30 @@ game (
 	name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)"
 	description "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)"
 	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).n64" size 8388608 crc 388DA567 md5 7B150366EC773FE9174D78D62C834B01 sha1 7C5565519BB9041EBD25A78CA174143FAF872809 flags verified )
-	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!].z64" size 8388608 crc 35461699 md5 F1A2E4DD22ADF4F90DA4BDDCA37D5F18 sha1 25BC862BFABDC972459E8EC2F4173BD5D638EFF3 )
 )
 
 game (
 	name "Puyo Puyo 4 - Puyo Puyon Party (Japan)"
 	description "Puyo Puyo 4 - Puyo Puyon Party (Japan)"
 	rom ( name "Puyo Puyo 4 - Puyo Puyon Party (Japan).n64" size 12582912 crc 9C32ADEB md5 53272289F493D802B7C562DAAB64219F sha1 E02D3A92256A43C8AEAA6DABD2F53CD3769EF1F6 flags verified )
-	rom ( name "Puyo Puyo 4 - Puyo Puyo Party (J) [!].z64" size 12582912 crc D59D2794 md5 22B86AB3F320A607899A0516C90A24D0 sha1 D5553182ECDA2EBA6076E7B04B900EF78B700FC5 )
 )
 
 game (
 	name "Puyo Puyo Sun 64 (Japan)"
 	description "Puyo Puyo Sun 64 (Japan)"
 	rom ( name "Puyo Puyo Sun 64 (Japan).n64" size 8388608 crc C256544C md5 D8445CC05C4073CAE562FD80849DB467 sha1 6BA3441890502ED5CDC27F29752F231490E49BF5 flags verified )
-	rom ( name "Puyo Puyo Sun 64 (J) [!].z64" size 8388608 crc 355FF9DE md5 FAAA2094B04DCA4C287AF9334D22529D sha1 CF79EC32E7E78B2CAD15B5B7DD763F578648B6C6 )
 )
 
 game (
 	name "Puzzle Bobble 64 (Japan)"
 	description "Puzzle Bobble 64 (Japan)"
 	rom ( name "Puzzle Bobble 64 (Japan).n64" size 8388608 crc 30238199 md5 3C411421611E82C81CA228E9EC2B81DB sha1 4E8B0BFB5A885919E63CB09618A0A3D938422301 flags verified )
-	rom ( name "Puzzle Bobble 64 (J) [!].z64" size 8388608 crc EA837423 md5 B478D4AF60D43C38BA81DE9FAEA6E057 sha1 9A4CDDE04E6C42CF7957BF578A0B15CA90203280 )
 )
 
 game (
 	name "Quake 64 (Europe)"
 	description "Quake 64 (Europe)"
 	rom ( name "Quake 64 (Europe).n64" size 12582912 crc 6F79B0EB md5 D42EF7ADF20697AEE783DBC33EAFA107 sha1 8B9FF00FFF48EF847794164111EC9415E5DCCB31 flags verified )
-	rom ( name "Quake 64 (E) [!].z64" size 12582912 crc 28C10844 md5 592CE7718EFDD1FF2F077C9B2B5275FB sha1 C1B4FC22A1699BE0BC8CEA170AC4F8B6BF8F41D1 )
 )
 
 game (
@@ -4401,7 +3849,6 @@ game (
 	name "Quake II (Europe)"
 	description "Quake II (Europe)"
 	rom ( name "Quake II (Europe).n64" size 12582912 crc 7098DF97 md5 BB759EC808C3AD387B9D7C02B99DECCE sha1 03F9A512C37E1351CB701A4EE5504BA6EA7D47AB flags verified )
-	rom ( name "Quake II (E) [!].z64" size 12582912 crc 82BECA21 md5 673D4BA4F41A0FE23650F06AF53EEC50 sha1 F99CC966965E8FA0BEB9FD768C646E6686E19916 )
 )
 
 game (
@@ -4415,91 +3862,78 @@ game (
 	name "Quest 64 (USA)"
 	description "Quest 64 (USA)"
 	rom ( name "Quest 64 (USA).n64" size 16777216 crc E90856E8 md5 949A7017E27D2ED402D2AD709498FD65 sha1 738F11572A72BEA06CC5C6D9C0A341A288F29457 )
-	rom ( name "Quest 64 (U) [!].z64" size 16777216 crc D75B45C6 md5 EA552E33973468233A0712C251ABDB6B sha1 91B96E938C6D91699057FAD91D726EE5A23CE33A )
 )
 
 game (
 	name "Racing Simulation 2 (Germany)"
 	description "Racing Simulation 2 (Germany)"
 	rom ( name "Racing Simulation 2 (Germany).n64" size 16777216 crc D660A56F md5 34ADC5B0190B07AFEF58795727A26D0B sha1 2CD2004B2E349773F3457DC8AE2F174F0E6FA0C0 )
-	rom ( name "Racing Simulation 2 (G) [!].z64" size 16777216 crc BA73A7E4 md5 AA57D69867F53456F351A289EBA08C3D sha1 08BC64CB8C64DB9B048FC1522FD5E808FF63CE1A )
 )
 
 game (
 	name "Rakuga Kids (Europe)"
 	description "Rakuga Kids (Europe)"
 	rom ( name "Rakuga Kids (Europe).n64" size 12582912 crc 2146409A md5 F59D1D9CEDBBEBDEF9B028A3FF102566 sha1 F6E08506BA7F53312767C0033D1EF8D393C0457D flags verified )
-	rom ( name "Rakuga Kids (E) [!].z64" size 12582912 crc 483129AA md5 167A3502F06CF0EEF56758533F3D0E52 sha1 A2846CB316DC980DD0040CA95C20ABFC8CCCE212 )
 )
 
 game (
 	name "Rakuga Kids (Japan)"
 	description "Rakuga Kids (Japan)"
 	rom ( name "Rakuga Kids (Japan).n64" size 12582912 crc 4C07C266 md5 9E7D59CE213B14865FE079422CBB50B2 sha1 9CB434635987E947F25D0EBD0E1A0F500E63ADC6 flags verified )
-	rom ( name "Rakuga Kids (J) [!].z64" size 12582912 crc B9E53B06 md5 813AD5C00BAD7C4D41F8558CECEDAE51 sha1 43596236CC1A4A4B671D0586FB42518A009427A5 )
 )
 
 game (
 	name "Rally '99 (Japan)"
 	description "Rally '99 (Japan)"
 	rom ( name "Rally '99 (Japan).n64" size 8388608 crc A1C36245 md5 C9EB885EBD88E2A669757036E6E47023 sha1 920113A96DFB15E3E8ED991C42E28734EFA26599 flags verified )
-	rom ( name "Rally '99 (J) [!].z64" size 8388608 crc FFA625FE md5 0630226F63561A05916EDCFBC8D96C04 sha1 8D3659925433B9D4C37D06ABD2E1C4662AA80E1F )
 )
 
 game (
 	name "Rally Challenge 2000 (USA)"
 	description "Rally Challenge 2000 (USA)"
 	rom ( name "Rally Challenge 2000 (USA).n64" size 12582912 crc FAF5C3B6 md5 723FBC251A8D59987D77980496949125 sha1 ECD309FC0826467F7B0E197743ABF1C51C48910D )
-	rom ( name "Rally Challenge 2000 (U) [!].z64" size 12582912 crc 3EDEC7B0 md5 0458BC47CD771D8BC66B0CEAE6895724 sha1 D42FD8DE45755CD70A4D4C252CC1873410DB9F3E )
 )
 
 game (
 	name "Rampage - World Tour (Europe)"
 	description "Rampage - World Tour (Europe)"
 	rom ( name "Rampage - World Tour (Europe).n64" size 12582912 crc DFBA19D6 md5 F805ECE6A8B5AE2A0B24291DBE58D332 sha1 742B440371E2B27BFF9267041CEBBD1358B105ED flags verified )
-	rom ( name "Rampage - World Tour (E) [!].z64" size 12582912 crc CDC458EC md5 08E02F52E0547686A9BFAC7CBB03C129 sha1 C8DB2A3669B08050F42AF47BAE9FD5146B8C87BB )
 )
 
 game (
 	name "Rampage - World Tour (USA)"
 	description "Rampage - World Tour (USA)"
 	rom ( name "Rampage - World Tour (USA).n64" size 12582912 crc 6FE4DA23 md5 407698ABB21EFA78E7C91E1753C967A9 sha1 5DD821436DB22CE9B4168088189EE5788270D044 )
-	rom ( name "Rampage - World Tour (U) [!].z64" size 12582912 crc 211119DD md5 4645672A0CF00ADA9B5E37CFDE8B024E sha1 7A6C8758E67FD3DA99E3420983C0D6DF83E41C6B )
 )
 
 game (
 	name "Rampage 2 - Universal Tour (Europe)"
 	description "Rampage 2 - Universal Tour (Europe)"
 	rom ( name "Rampage 2 - Universal Tour (Europe).n64" size 12582912 crc 0D4654A8 md5 820990A9B6194339B30C4B6D3EA75309 sha1 52583EE2CEB4606F86C01FE8A3498971A104D987 flags verified )
-	rom ( name "Rampage 2 - Universal Tour (E) [!].z64" size 12582912 crc FA6E097B md5 1492806F12D33C3EA0EDB6848D43B1CC sha1 0C18A10807A5F910CE7337812770B4FE18994A60 )
 )
 
 game (
 	name "Rampage 2 - Universal Tour (USA)"
 	description "Rampage 2 - Universal Tour (USA)"
 	rom ( name "Rampage 2 - Universal Tour (USA).n64" size 12582912 crc 75E8C2AD md5 4A118869C2089FDAAD900DC34DF0788B sha1 BB3AF2FC085E58BEFA528051B7A91A54F9F38E8F )
-	rom ( name "Rampage 2 - Universal Tour (U) [!].z64" size 12582912 crc 7614EE0D md5 8113D0EA2008402D4631F241F625D16B sha1 36D1B741F6EA896B05AB7CEEAC8B78684CBDAC6B )
 )
 
 game (
 	name "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rat Attack! (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc C3909721 md5 1CB8A6D49AC03FACF06E0E24048777DF sha1 8115F19AADE05147DB633266A4DD7BEC82CDD735 flags verified )
-	rom ( name "Rat Attack (E) (M6) [!].z64" size 8388608 crc DD4FA798 md5 BC66239C12AE8696926E50C2B6ED9C49 sha1 B27E328F7600B7A2E175E4A36D8C85073EAF4D0E )
 )
 
 game (
 	name "Rat Attack! (USA) (En,Fr,De,Es,It,Nl)"
 	description "Rat Attack! (USA) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rat Attack! (USA) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 78F6FFA2 md5 9EF477AA075ABFEB026DEFDE6E57B048 sha1 6814EE444C67F1289F11A9F7DECACB75176BF634 )
-	rom ( name "Rat Attack (U) (M6) [!].z64" size 8388608 crc 2315FEA7 md5 F661889FDF65DDCD212E9FB53B2C8F50 sha1 0682B6745832984F43652C0589E4ECF37F937790 )
 )
 
 game (
 	name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
 	description "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).n64" size 33554432 crc B7E10177 md5 8D0B9783B56E4D62D0462A80CB61947C sha1 A422B3BE224814C7F01512D778BECFA0BDFFAFC8 flags verified )
-	rom ( name "Rayman 2 - The Great Escape (E) (M5) [!].z64" size 33554432 crc 169A5037 md5 5DBBFD5ACE8222FA8FE51BE113453C13 sha1 619AB27EA1645399439AD324566361D3E7FF020E )
 )
 
 game (
@@ -4513,35 +3947,30 @@ game (
 	name "Razmoket, Les - La Chasse aux Tresors (France)"
 	description "Razmoket, Les - La Chasse aux Tresors (France)"
 	rom ( name "Razmoket, Les - La Chasse aux Tresors (France).n64" size 16777216 crc D6C8D961 md5 5418B849D3BF95C84946742AF8DEB05D sha1 1F697BBE34DCCE3A74605F13D50D0CBBE4510085 )
-	rom ( name "Les Razmoket - La Chasse Aux Tresors (F) [!].z64" size 16777216 crc 66766469 md5 55685D6324EFDE5BC9D26C98706B0B8A sha1 69C06B2D31BC6BC66CD028705D81024F21A7654C )
 )
 
 game (
 	name "Razor Freestyle Scooter (USA)"
 	description "Razor Freestyle Scooter (USA)"
 	rom ( name "Razor Freestyle Scooter (USA).n64" size 8388608 crc 208350C5 md5 C5A6C5F3A8B1A59AC2064C83744310C3 sha1 8AF56990D73F7EAE9212C44CD9F417B27ED78649 )
-	rom ( name "Razor Freestyle Scooter (U) [!].z64" size 8388608 crc 927CE621 md5 406B08987AB92D73D72B597EC6B11BD9 sha1 D107E8D28A262A60BA50DE4C227343EBC3587784 )
 )
 
 game (
 	name "Re-Volt (Europe) (En,Fr,De,Es)"
 	description "Re-Volt (Europe) (En,Fr,De,Es)"
 	rom ( name "Re-Volt (Europe) (En,Fr,De,Es).n64" size 12582912 crc 194BB8A1 md5 ABD10FCD29119EF5E7F9915429042449 sha1 31D1B888BDA70D2D5B1C7ECD95F8F2D83AC35D36 flags verified )
-	rom ( name "Re-Volt (E) (M4) [!].z64" size 12582912 crc 81D13A11 md5 FAA64ABB0D222FCC0C6E2515D3805D9F sha1 5ED3CD3888FEC080D44FFE345DD50D75E471FF8F )
 )
 
 game (
 	name "Re-Volt (USA)"
 	description "Re-Volt (USA)"
 	rom ( name "Re-Volt (USA).n64" size 12582912 crc 9366C53C md5 B23B9E8CEC8B00507D20464905A0C5C5 sha1 BFFC68E662338CDF03B619B3A62EF880F1DB025D )
-	rom ( name "Re-Volt (U) [!].z64" size 12582912 crc FC0C86D0 md5 3FC4D3187435443455F8355B2D3F8934 sha1 667FDC39112599BD904F5E7D8D692973E554BD88 )
 )
 
 game (
 	name "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
 	description "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
 	rom ( name "Ready 2 Rumble Boxing (Europe) (En,Fr,De).n64" size 33554432 crc F2FE85AD md5 F8A3D817DB07D19F3C06207D2835803A sha1 8A2BD9CEB91BC753CBEEBD4CB0D47819361E4BEA flags verified )
-	rom ( name "Ready 2 Rumble Boxing (E) (M3) [!].z64" size 33554432 crc A69DF7B3 md5 ADC95AE01855FA305B13F8B22427E597 sha1 E18477D858C623A834F24DC2717D0EF340E63364 )
 )
 
 game (
@@ -4562,7 +3991,6 @@ game (
 	name "Resident Evil 2 (Europe) (En,Fr)"
 	description "Resident Evil 2 (Europe) (En,Fr)"
 	rom ( name "Resident Evil 2 (Europe) (En,Fr).n64" size 67108864 crc A9936CEC md5 7F3B88A0968FE05034F967F646EBD114 sha1 C82E3C253E438C0F742882F26E8006FDF9C99346 flags verified )
-	rom ( name "Resident Evil 2 (E) (M2) [!].z64" size 67108864 crc 7C8EE011 md5 B04F298721223A22E1150CEBC712EE6A sha1 D54561791BC41F1B743F8ABE769A6E8CBF435326 )
 )
 
 game (
@@ -4582,84 +4010,72 @@ game (
 	name "Road Rash 64 (Europe)"
 	description "Road Rash 64 (Europe)"
 	rom ( name "Road Rash 64 (Europe).n64" size 33554432 crc E3BC7725 md5 C881E7CEC084640AFBBDDC37F6EFD179 sha1 273C72F8C9F9D194B98375E3076972BFD7FDF64D flags verified )
-	rom ( name "Road Rash 64 (E) [!].z64" size 33554432 crc 3C664A7B md5 AD922DAE446A301E1AAFE1DFBAD75A2E sha1 816824CB5DC62EE54DC52C0EBB9B2564ECB88133 )
 )
 
 game (
 	name "Road Rash 64 (USA)"
 	description "Road Rash 64 (USA)"
 	rom ( name "Road Rash 64 (USA).n64" size 33554432 crc 2DA44585 md5 CDF72CB4647C70FE36247091F5025148 sha1 4990B922E946AA0EE45FD8355E447DEDC92EC352 )
-	rom ( name "Road Rash 64 (U) [!].z64" size 33554432 crc 600B3988 md5 28C2373F6D831EEC81F6146A809E701B sha1 87727A298F583EC8325F5655088FF21E37B335B2 )
 )
 
 game (
 	name "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Roadsters (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc C2D2F16B md5 BB95A96AA50732504EC987337A635663 sha1 BDE57B268B6BFFE2E60CCA0E3D9500A35506A81C flags verified )
-	rom ( name "Roadsters Trophy (E) (M6) [!].z64" size 12582912 crc 997ED5AF md5 41F67B5C8BB8DAEFFD989123846FC063 sha1 2AD3BCCD29DC879A873C926AF03002E36582525A )
 )
 
 game (
 	name "Roadsters (USA) (En,Fr,Es)"
 	description "Roadsters (USA) (En,Fr,Es)"
 	rom ( name "Roadsters (USA) (En,Fr,Es).n64" size 12582912 crc F68D139E md5 49D0C8BC8AD23306B87456FB3055C5DB sha1 E2827C55874A4883C5D969EB34944324D639AF06 )
-	rom ( name "Roadsters Trophy (U) (M3) [!].z64" size 12582912 crc E4337B92 md5 D3644B398C090528E0ED9EB3C140366E sha1 D896FFCBA44696BDB7E2048841F287EA5951AD2A )
 )
 
 game (
 	name "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)"
 	description "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)"
 	rom ( name "Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).n64" size 33554432 crc 49BB7DDE md5 C36C2FAF41E34EA2D10E178702101DA3 sha1 27BFAFF7A8D2A3CEF081AF67A5E89290C6B59550 flags verified )
-	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!].z64" size 33554432 crc 3B0F8061 md5 444F70A655AC89CA900F6FAFAF926B16 sha1 9BC6130916D8A1D8BCEC5F38FBBFF066444838CD )
 )
 
 game (
 	name "Robotech - Crystal Dreams (USA) (Proto)"
 	description "Robotech - Crystal Dreams (USA) (Proto)"
 	rom ( name "Robotech - Crystal Dreams (USA) (Proto).n64" size 12582912 crc 3A711F12 md5 8B1574BE8AFB8A7559CA6867FB15B665 sha1 5EA71103D323530C73E1668CC47A1C287D07E99B )
-	rom ( name "Robotech - Crystal Dreams (Beta).z64" size 16777216 crc F9A7904E md5 B39592C6C9A3121258BDB62485956880 sha1 8051C03135447A92B21AFACE5B00111C3B4AF773 )
 )
 
 game (
 	name "Robotron 64 (Europe)"
 	description "Robotron 64 (Europe)"
 	rom ( name "Robotron 64 (Europe).n64" size 8388608 crc 862ACD20 md5 1B170EFF5E2D9EA85B494DCA5AD53970 sha1 A12C93AC2C4E70A3B19BCB07A62B7B6B9CE83DB9 flags verified )
-	rom ( name "Robotron 64 (E) [!].z64" size 8388608 crc 23BF4956 md5 2ABCD1AD41B3356FBC1018ECB121283E sha1 D86A7ED2F203BA9DF0CE5B18D9E4E2E2D9B62A3F )
 )
 
 game (
 	name "Robotron 64 (USA)"
 	description "Robotron 64 (USA)"
 	rom ( name "Robotron 64 (USA).n64" size 8388608 crc 123D44CC md5 FB1C4E85F13E95B5154C550A06408808 sha1 9DACD6239F2256E8EFAC6D1C6ACF8E5EA53040BB )
-	rom ( name "Robotron 64 (U) [!].z64" size 8388608 crc B2CBAE58 md5 5698757883A6F46FE5B4C9B6E780B480 sha1 44D158BC2AEEFB111A620B61E043B2703E6C5808 )
 )
 
 game (
 	name "Rocket - Robot on Wheels (Europe) (En,Fr,De)"
 	description "Rocket - Robot on Wheels (Europe) (En,Fr,De)"
 	rom ( name "Rocket - Robot on Wheels (Europe) (En,Fr,De).n64" size 12582912 crc 2960FF8B md5 CFC34E10E7BD3DA3420D4C768C82DE10 sha1 FCE3A9B4CC94E44D0C2F58B7669140447F9BF0EC flags verified )
-	rom ( name "Rocket - Robot on Wheels (E) (M3) [!].z64" size 12582912 crc 7DE5D20D md5 427C5457D4A29A222811F0CAA9CCA7B9 sha1 A1AA086F0826BEE4BE71C16BC67468B8D8A49065 )
 )
 
 game (
 	name "Rocket - Robot on Wheels (USA)"
 	description "Rocket - Robot on Wheels (USA)"
 	rom ( name "Rocket - Robot on Wheels (USA).n64" size 12582912 crc B0F36D79 md5 53BD4994CB0DFCA0DB955389E96145FA sha1 5DFCD4CDB0A2EA1412FA5D92236D0A066231D9AC )
-	rom ( name "Rocket - Robot on Wheels (U) [!].z64" size 12582912 crc E0399F23 md5 C2907EB2F9A350793317ECE878A3B8E3 sha1 622D71A44DA0B81EA68092CAC9198C66154A4F4A )
 )
 
 game (
 	name "Rockman Dash - Hagane no Boukenshin (Japan)"
 	description "Rockman Dash - Hagane no Boukenshin (Japan)"
 	rom ( name "Rockman Dash - Hagane no Boukenshin (Japan).n64" size 33554432 crc E1919C66 md5 530311472663F4885C387C90C8BB2FCF sha1 CD8C73A181A137DC8A4AC24E9F26CCC2518DC35F flags verified )
-	rom ( name "Rockman Dash (J) [!].z64" size 33554432 crc 61EAEE83 md5 0C74B44680276FFE808CFA6045329819 sha1 E807ED78DB0B3440F76B445BF989A943BC05E0AD )
 )
 
 game (
 	name "RR64 - Ridge Racer 64 (Europe)"
 	description "RR64 - Ridge Racer 64 (Europe)"
 	rom ( name "RR64 - Ridge Racer 64 (Europe).n64" size 33554432 crc 170F63B2 md5 9E2D9D2B2A83EDD05AB1FAB8130C9570 sha1 7543E17585EF4AF0B3B1DE8004B6CD4D92EC214D flags verified )
-	rom ( name "RR64 - Ridge Racer 64 (E) [!].z64" size 33554432 crc DD9AE3A8 md5 4561840840760FFA7B59F03A5F416A5C sha1 FAA21C8E0282D21EAC2D1B35B020F40381E18FC4 )
 )
 
 game (
@@ -4673,14 +4089,12 @@ game (
 	name "RTL World League Soccer 2000 (Germany)"
 	description "RTL World League Soccer 2000 (Germany)"
 	rom ( name "RTL World League Soccer 2000 (Germany).n64" size 16777216 crc 4E3C9433 md5 BF0AD2FC5E13F2E1DF15878BA82DD040 sha1 EF2E9DBB16C798DF3315A925231314E1660A2F03 flags verified )
-	rom ( name "RTL World League Soccer 2000 (G) [!].z64" size 16777216 crc 0A17DA7B md5 A1082A6676455C040843FD75E92DE1A3 sha1 A68294E47C82639C9BCDAE1B7306AC2A2E2F47B5 )
 )
 
 game (
 	name "Rugrats - Die grosse Schatzsuche (Germany)"
 	description "Rugrats - Die grosse Schatzsuche (Germany)"
 	rom ( name "Rugrats - Die grosse Schatzsuche (Germany).n64" size 16777216 crc E1D7919F md5 C17DEEEFBBA8A96DEE4C6756CB5BBB3B sha1 7840BDFE801FA2D8E34E120F66AF59A140D3C1C3 )
-	rom ( name "Rugrats - Die grosse Schatzsuche (G) [!].z64" size 16777216 crc 23AED3A2 md5 DEC4598A39728C28CD0CEBA45A173CE1 sha1 32CABA1042CABBF366852D629D3FEE1A5186BCE3 )
 )
 
 game (
@@ -4694,14 +4108,12 @@ game (
 	name "Rugrats - Treasure Hunt (Europe)"
 	description "Rugrats - Treasure Hunt (Europe)"
 	rom ( name "Rugrats - Treasure Hunt (Europe).n64" size 16777216 crc 65EDE901 md5 40950ECADEFA371666DC6A2CB8305752 sha1 A86B2FAED29727496DD3F0B0367293E16B324568 flags verified )
-	rom ( name "Rugrats - Treasure Hunt (E) [!].z64" size 16777216 crc 3338B7C8 md5 55185016031CDC73C0FD471527C35706 sha1 5FF0B82077559DD4C206A7A7D13EABEABC82E9C4 )
 )
 
 game (
 	name "Rugrats in Paris - The Movie (Europe)"
 	description "Rugrats in Paris - The Movie (Europe)"
 	rom ( name "Rugrats in Paris - The Movie (Europe).n64" size 16777216 crc 17BD7518 md5 D71441A6906526C79E4DA220942850E8 sha1 0212C18E1FE5C637C5B88124F053CF08F048EFC4 flags verified )
-	rom ( name "Rugrats in Paris - The Movie (E) [!].z64" size 16777216 crc CD74B07E md5 229089089661F517C863242D6BB77746 sha1 FDDA27E7C418728391A5EC53F62FDB5E1B21A0DF )
 )
 
 game (
@@ -4715,21 +4127,18 @@ game (
 	name "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 9B364DF7 md5 21731BC459610D60C2B604B4D3737C75 sha1 FC590418F82BD5E360FF4530100D72CEA2A97D99 flags verified )
-	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [!].z64" size 12582912 crc 30F21F89 md5 681DF5A32E857E77194106B35304D6B5 sha1 090A027612140E90FFBBD7C48DEC77005F7B0A69 )
 )
 
 game (
 	name "Rush 2 - Extreme Racing USA (USA)"
 	description "Rush 2 - Extreme Racing USA (USA)"
 	rom ( name "Rush 2 - Extreme Racing USA (USA).n64" size 12582912 crc 5412916B md5 68C4766E0FD28E3BAFE220D52BB5C841 sha1 94685E4A27114175946CDF2084079C9BF2E69EF3 )
-	rom ( name "Rush 2 - Extreme Racing USA (U) [!].z64" size 12582912 crc 9EB14EA8 md5 6A925AB624EE3B343231D799733BA898 sha1 01B0A31B1ACCC18061E8C85F6C5EDF0DBD79F097 )
 )
 
 game (
 	name "S.C.A.R.S. (Europe) (En,Fr,De)"
 	description "S.C.A.R.S. (Europe) (En,Fr,De)"
 	rom ( name "S.C.A.R.S. (Europe) (En,Fr,De).n64" size 8388608 crc DA47D3C9 md5 46DD8A0AE504E32A2338F32A9B3A9CFE sha1 EF5834F25A44931CC9339DD22B6E8F9955736076 flags verified )
-	rom ( name "S.C.A.R.S. (E) (M3) [!].z64" size 8388608 crc 4E37B6F2 md5 7ED3F10BC32CF76F172D8C31D15A2799 sha1 8B4EBAD8B7F50381BA2E16D0C475332837BB5780 )
 )
 
 game (
@@ -4743,21 +4152,18 @@ game (
 	name "Saikyou Habu Shougi (Japan)"
 	description "Saikyou Habu Shougi (Japan)"
 	rom ( name "Saikyou Habu Shougi (Japan).n64" size 8388608 crc E8D0810B md5 213192EB4FF4F7FAA7DF653D0FEFF142 sha1 8A06E7A7D15E5586FF5CE5FED235E0357096C827 flags verified )
-	rom ( name "Saikyou Habu Shougi (J) [!].z64" size 8388608 crc 01794D62 md5 C4E47228706BC724D7FBD811231D20C9 sha1 B7C977FCD8224595E84714C3FA84221374E1838E )
 )
 
 game (
 	name "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)"
 	description "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)"
 	rom ( name "San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).n64" size 8388608 crc 78CD03C9 md5 E35E6F54850BB6ECDBFE6E4971B419FA sha1 9339CCE34D9EAC2626BA14FA55F558BD7C827CC9 flags verified )
-	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [!].z64" size 8388608 crc E064962A md5 81B1122EE15F7B50A341AE62E9C5716B sha1 BC8D37E3A3B9EDB4C8465ED7E477C6434C31B47D )
 )
 
 game (
 	name "San Francisco Rush - Extreme Racing (USA) (En,Fr,De)"
 	description "San Francisco Rush - Extreme Racing (USA) (En,Fr,De)"
 	rom ( name "San Francisco Rush - Extreme Racing (USA) (En,Fr,De).n64" size 8388608 crc 32E250BA md5 67C74AB836A9D54FAA4D41B491E3794A sha1 8980D1E967D63CB13F794EE5DE15BEF299B93935 )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [!].z64" size 8388608 crc 3E20070B md5 F015FC28E1D62A36B4EBF4C79CA8F285 sha1 CC62539CB30B180C3C7E0AA927786ED061D8D9AB )
 )
 
 game (
@@ -4770,28 +4176,24 @@ game (
 	name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc DF85FDC3 md5 45BB91607C06103C3F545C648F0994A4 sha1 C722FDC039489E1C0E604EED8B81E29DA75CB0BE flags verified )
-	rom ( name "San Francisco Rush 2049 (E) (M6) [!].z64" size 12582912 crc E63B86C5 md5 02B16AC23998F78F09AF6513F4ACB664 sha1 61373D4758ECA3FA831BEAC27B4D4C250845F80C )
 )
 
 game (
 	name "San Francisco Rush 2049 (USA)"
 	description "San Francisco Rush 2049 (USA)"
 	rom ( name "San Francisco Rush 2049 (USA).n64" size 12582912 crc 1A03B9DE md5 2120248576E6398F2F90791E2EBD2EDA sha1 F79223F8060A530D0DC8683A923C3C60615AA0A0 )
-	rom ( name "San Francisco Rush 2049 (U) [!].z64" size 12582912 crc 10941439 md5 AF5BE0ADFF51A8E9C6D771282C295810 sha1 3F99351D7BB61656614BDB2AA1A90CFE55D1922C )
 )
 
 game (
 	name "Scooby-Doo! - Classic Creep Capers (Europe)"
 	description "Scooby-Doo! - Classic Creep Capers (Europe)"
 	rom ( name "Scooby-Doo! - Classic Creep Capers (Europe).n64" size 16777216 crc 81CDD595 md5 A773D245148DDC739375E3AE0D2B3852 sha1 AD7148B91845113A10A297DA25F7110EDDEB8758 flags verified )
-	rom ( name "Scooby-Doo! - Classic Creep Capers (E) [!].z64" size 16777216 crc 0D737E6F md5 3B6DD7B60437234895500BEFF28DF6D6 sha1 FA2D39392750E160F2C41733777C64D8DF1127AF )
 )
 
 game (
 	name "Scooby-Doo! - Classic Creep Capers (USA)"
 	description "Scooby-Doo! - Classic Creep Capers (USA)"
 	rom ( name "Scooby-Doo! - Classic Creep Capers (USA).n64" size 16777216 crc E3A2F1E7 md5 E0F4AA58C66F35169AEC717AA58D5A71 sha1 41C8454775E0E555B354537F3EFD916FD5F058D6 )
-	rom ( name "Scooby-Doo! - Classic Creep Capers (U) [!].z64" size 16777216 crc 39068228 md5 16CC6DB10A56331B56F374B4FB254D5E sha1 FA22BD1216094124C84987414DDE1B50AF90D928 )
 )
 
 game (
@@ -4804,35 +4206,30 @@ game (
 	name "SD Hiryuu no Ken Densetsu (Japan)"
 	description "SD Hiryuu no Ken Densetsu (Japan)"
 	rom ( name "SD Hiryuu no Ken Densetsu (Japan).n64" size 12582912 crc ADF81B90 md5 9543942C65C3DCDB86498E985B712AB9 sha1 DA0D9331C5A9688B674E6C72D4206FB05F1C2EE0 flags verified )
-	rom ( name "SD Hiryuu no Ken Densetsu (J) [!].z64" size 12582912 crc CC083E34 md5 637A7EA2A39F20C5B20834187230D89D sha1 79CFB5A29B2CBD4F35966F209385B389233CF8CF )
 )
 
 game (
 	name "Shadow Man (Europe) (En,Es,It)"
 	description "Shadow Man (Europe) (En,Es,It)"
 	rom ( name "Shadow Man (Europe) (En,Es,It).n64" size 33554432 crc 0CD66C1F md5 01EABFA5224182258DE02D20E277F0A2 sha1 7BCD7D9A05363B20F338B092081C2FAE4D8C1F64 flags verified )
-	rom ( name "Shadow Man (E) (M3) [!].z64" size 33554432 crc 8D230306 md5 A485A6E9E30B7D55D23D8DD043770C64 sha1 39ECE3F37C1F54AF4274A9733419EB693EAC1740 )
 )
 
 game (
 	name "Shadow Man (France)"
 	description "Shadow Man (France)"
 	rom ( name "Shadow Man (France).n64" size 33554432 crc CB221562 md5 B536D55DE81FFFC8E4052399B1D99021 sha1 9FD09639DBF2A9B11F7D1C2CCCB40529FEBEDB2A )
-	rom ( name "Shadow Man (F) [!].z64" size 33554432 crc 6812D3A7 md5 235511BBDB21AF5A767BDB7502A80F06 sha1 1F0B03C80C6449DE78EE8403CFA84FE8CF759341 )
 )
 
 game (
 	name "Shadow Man (Germany)"
 	description "Shadow Man (Germany)"
 	rom ( name "Shadow Man (Germany).n64" size 33554432 crc 1F171A3F md5 12B26C386F02451E2D8E600020CB2567 sha1 01D453D23E8E089C071F41A2BDCB78A3C695A72A flags verified )
-	rom ( name "Shadow Man (G) [!].z64" size 33554432 crc EAF6ADD1 md5 AF40EF12CE923FF1C26E76CC9D9B9ED9 sha1 8768F0EC0B7A0B4F5FF0DA6F4D790EDEF5E3FE9C )
 )
 
 game (
 	name "Shadow Man (USA)"
 	description "Shadow Man (USA)"
 	rom ( name "Shadow Man (USA).n64" size 33554432 crc 47E05128 md5 09D23066364C5F212731B19DD9B9C87C sha1 F3791231DC17AF77056E5320C59081D3E8459A7F )
-	rom ( name "Shadow Man (U) [!].z64" size 33554432 crc 5E20CC63 md5 B457298B87B85BBF950F24867DAA9475 sha1 CFB99DD949FDB2B2A0002EF595AB1813FE865B2C )
 )
 
 game (
@@ -4845,14 +4242,12 @@ game (
 	name "Shadowgate 64 - Trials of the Four Towers (Europe)"
 	description "Shadowgate 64 - Trials of the Four Towers (Europe)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Europe).n64" size 16777216 crc ABB08BC3 md5 FC4DB34EA0C88F5AB72046AA7DBB30D4 sha1 E879093C0243EBBC0C9E392DE4141CD65FC9B85D flags verified )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [!].z64" size 16777216 crc FF7D7DF0 md5 E8955C3B743FDDFE403E52E769E9853F sha1 F2844B3421779A997C96231D25275DA4E2D1018B )
 )
 
 game (
 	name "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)"
 	description "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).n64" size 16777216 crc D49B5065 md5 D616CF79F9B2E213FA2B6383893E4064 sha1 EC3ED3D0A854C726C2355BCD8AB23799FC1630CA )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!].z64" size 16777216 crc 87F00472 md5 A06E757CF1930B29FA4C0B5C9F31335F sha1 9F1A413F686032DDA73BE3312F452991A4E29EC9 )
 )
 
 game (
@@ -4865,7 +4260,6 @@ game (
 	name "Shadowgate 64 - Trials of the Four Towers (Japan)"
 	description "Shadowgate 64 - Trials of the Four Towers (Japan)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (Japan).n64" size 16777216 crc F2665AFD md5 4BE1E1A9C5BC5202108BA0CBACA648DB sha1 94295AC2B5E44AD299DED088A8D43EF7A168C59D flags verified )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J).z64" size 16777216 crc 9F74A58C md5 1960A3879FADF2C5EFF5BEB47E0E1441 sha1 706524AFF9BD84972D4E095AFD0317D5BACC525F )
 )
 
 game (
@@ -4879,49 +4273,42 @@ game (
 	name "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)"
 	description "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)"
 	rom ( name "Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).n64" size 12582912 crc 62C99DE2 md5 802A4C0EB26D41D837366DFEA85E5AC4 sha1 4DA682946B4A6F586F4D525F0649D7A1E36357D9 flags verified )
-	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!].z64" size 12582912 crc E892ED43 md5 13D9514A4D208DC6C7B0C833F68114D2 sha1 8E87DD6BAF0D8D27E60C3257B145EF439B17B7A0 )
 )
 
 game (
 	name "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)"
 	description "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)"
 	rom ( name "Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).n64" size 33554432 crc BE0FC7E8 md5 D013CD14D46001289D2E7BB58DA94C26 sha1 15B9C28584A26B60E5A2A231E5BA2897E831E8F8 flags verified )
-	rom ( name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!].z64" size 33554432 crc DEAC787F md5 113044B16B75F98792BF9C20C6B6282B sha1 BDFA3C47264196BD91D0487D3C9B3531BDACE8EA )
 )
 
 game (
 	name "SimCity 2000 (Japan)"
 	description "SimCity 2000 (Japan)"
 	rom ( name "SimCity 2000 (Japan).n64" size 12582912 crc F7A96B81 md5 A6AE966D625069D8DC5CC2967B5D22C8 sha1 2A5B25809A5470B85DB9CC0A1E6C5C44F225747B flags verified )
-	rom ( name "Sim City 2000 (J) [!].z64" size 12582912 crc 57767E45 md5 244BEA64EA209990E9C69A830B507135 sha1 F728BD9990B9674533A04CD2FE275236B5CAB32F )
 )
 
 game (
 	name "Snobo Kids (Japan)"
 	description "Snobo Kids (Japan)"
 	rom ( name "Snobo Kids (Japan).n64" size 8388608 crc 9B691DF4 md5 8FD0896369A6C9A01427BC878202BAC4 sha1 739AB70A45CCA33E8BF884C35BE338FF4CE66F11 flags verified )
-	rom ( name "Snobow Kids (J) [!].z64" size 8388608 crc 213BF381 md5 B8D4B92E66A312708626B3216DE07A3A sha1 96480C8FA7285D9E850F6BA002E56BCB7ADA9796 )
 )
 
 game (
 	name "Snow Speeder (Japan)"
 	description "Snow Speeder (Japan)"
 	rom ( name "Snow Speeder (Japan).n64" size 12582912 crc 5C98F900 md5 AF71E732AB17533638132B01BB19EC2F sha1 2EF8591E9750066E248075DC940EC4FC080EF905 flags verified )
-	rom ( name "Snow Speeder (J) [!].z64" size 12582912 crc 30EA3FD7 md5 F7E66DA23C8BB8E59F641A636A9CAE82 sha1 0E7DF6A6F053F37A168EC33AF8CE5240CB18F0EE )
 )
 
 game (
 	name "Snowboard Kids (Europe)"
 	description "Snowboard Kids (Europe)"
 	rom ( name "Snowboard Kids (Europe).n64" size 8388608 crc 4F2415F3 md5 127AB20EE41ADB54C83DFB5BF5794D27 sha1 FD4CA5DC092DA70996AF699C8A4591FAEF58EC0C flags verified )
-	rom ( name "Snowboard Kids (E) [!].z64" size 8388608 crc 5619A70D md5 AB4382E583AE139EEDBAFCE5FA87E4C8 sha1 B26802748F4CC15F44492BCC6941A487E75BBCA6 )
 )
 
 game (
 	name "Snowboard Kids (USA)"
 	description "Snowboard Kids (USA)"
 	rom ( name "Snowboard Kids (USA).n64" size 8388608 crc 540C190B md5 14B72B59AA3EFABF368779E6EBECDCAB sha1 584277AA4190D23F7DB8A6E225735D934022E58C )
-	rom ( name "Snowboard Kids (U) [!].z64" size 8388608 crc 020FB906 md5 EB31F4F9C1FE26A3A663F74E9790516E sha1 1583BACC9046A360DF8EA4D536942155247E154C )
 )
 
 game (
@@ -4931,44 +4318,33 @@ game (
 )
 
 game (
-	name "Snowboard Kids 2 (Europe)"
-	description "Snowboard Kids 2 (Europe)"
-	rom ( name "Snowboard Kids 2 (E) [!].z64" size 16777216 crc 3A0B6214 md5 47B5E3955D54F969941533F26691AB38 sha1 E807F0FA1D6FDE619A83F0926B2294123F34501C )
-)
-
-game (
 	name "Snowboard Kids 2 (USA)"
 	description "Snowboard Kids 2 (USA)"
 	rom ( name "Snowboard Kids 2 (USA).n64" size 16777216 crc CA84AACE md5 DED8648106F16417C01B4CC68986E97B sha1 7A195B4D0D03CE1C7C4FD0D13B1BE2E97D20000C )
-	rom ( name "Snowboard Kids 2 (U) [!].z64" size 16777216 crc D0DC8A8E md5 08E1152E9D9742E9BBF6C224B6958F2D sha1 5CE896FD64276948BC2B8CCCD8CD51C25A9F32AA )
 )
 
 game (
 	name "Sonic Wings Assault (Japan)"
 	description "Sonic Wings Assault (Japan)"
 	rom ( name "Sonic Wings Assault (Japan).n64" size 8388608 crc 1D8F9D5E md5 B8A13663741EBC6A38249C31462F7A8D sha1 FB3E2BE4927CF3FB39CCE031004FF3420023EEC5 flags verified )
-	rom ( name "Sonic Wings Assault (J) [!].z64" size 8388608 crc FC73FB79 md5 7D47911B5C3D91A303EF19E764F3C02B sha1 978936613096D1EBE49FEC3EF50E3C870CE165B6 )
 )
 
 game (
 	name "South Park (Europe) (En,Fr,Es)"
 	description "South Park (Europe) (En,Fr,Es)"
 	rom ( name "South Park (Europe) (En,Fr,Es).n64" size 16777216 crc ACD74F7F md5 251B291DCCE55F9C1B4E8AD4F785C326 sha1 B1905FA89677F770A8B57876488D96BFF4C4B278 flags verified )
-	rom ( name "South Park (E) (M3) [!].z64" size 16777216 crc B2C3E123 md5 40CC2085A5C12456BEF830B047068326 sha1 C70C9FD6EBF1AE9F79155F9384AB1C4B29DC6882 )
 )
 
 game (
 	name "South Park (Germany)"
 	description "South Park (Germany)"
 	rom ( name "South Park (Germany).n64" size 16777216 crc 3445C078 md5 AE3C592B2136BB445D50EC6FE3A07B3C sha1 C9F78F00F1749EC36D06D43693552EE33647D54B )
-	rom ( name "South Park (G) [!].z64" size 16777216 crc 5711E197 md5 2C94A246E701D667BA807DAB6C9771E2 sha1 3260DB8FBC90370603FC07AB2E48E02C029573FB )
 )
 
 game (
 	name "South Park (USA)"
 	description "South Park (USA)"
 	rom ( name "South Park (USA).n64" size 16777216 crc FAAE9AA3 md5 C26EFF29CEE9D8F65D5D3321413400FE sha1 5133B87061172B467424170672C3321DE6C78494 )
-	rom ( name "South Park (U) [!].z64" size 16777216 crc 7D666B9E md5 1730119B0455EF89C4E495DEC8E950A5 sha1 42D7350D1F9040C5546F481C4D650B99A23AADBC )
 )
 
 game (
@@ -4981,63 +4357,54 @@ game (
 	name "South Park - Chef's Luv Shack (Europe)"
 	description "South Park - Chef's Luv Shack (Europe)"
 	rom ( name "South Park - Chef's Luv Shack (Europe).n64" size 16777216 crc ED36FA49 md5 06DA3C068C3FC5D39684AAAA6C778BAC sha1 1FCDC805DB0B026DB04730FB385B30721CE74A21 flags verified )
-	rom ( name "South Park - Chef's Luv Shack (E) [!].z64" size 16777216 crc AC1628EB md5 F1AE48B778C8431A50C37EB1ED96B120 sha1 5AEEC40C04AE9F7BC286F38E5250712C5FEAD191 )
 )
 
 game (
 	name "South Park - Chef's Luv Shack (USA)"
 	description "South Park - Chef's Luv Shack (USA)"
 	rom ( name "South Park - Chef's Luv Shack (USA).n64" size 16777216 crc 67D38382 md5 D9699E89A4E4CD0AC04B628D6007DF0E sha1 54FB22142F3A02C9C15E412D7E900A963698BBDA )
-	rom ( name "South Park - Chef's Luv Shack (U) [!].z64" size 16777216 crc 6B6B1D09 md5 6AF573EB055648A8542AA82D9524FB2F sha1 0344B569E8410A860CD54165BC33130E80760896 )
 )
 
 game (
 	name "South Park Rally (Europe)"
 	description "South Park Rally (Europe)"
 	rom ( name "South Park Rally (Europe).n64" size 16777216 crc DE023E0A md5 8D040504B81AA2E37C0A4AA795C9D12E sha1 63F95579B1F2A5E41E78343B59105EF08A290BF3 flags verified )
-	rom ( name "South Park Rally (E) [!].z64" size 16777216 crc 296E3525 md5 C33FA02791077A71B0AFE1CFED47C180 sha1 E16B5B16E41C66FEFB3BC82BD6A82F9EF4D709FD )
 )
 
 game (
 	name "South Park Rally (USA)"
 	description "South Park Rally (USA)"
 	rom ( name "South Park Rally (USA).n64" size 16777216 crc 2C1F0859 md5 39D0960F29634E5BB6AA21F00C1044E7 sha1 0309DF340D098F014C6673EC7CAD60EACE1BF166 )
-	rom ( name "South Park Rally (U) [!].z64" size 16777216 crc CCDD322A md5 1C494719032FF99382B167C43FB11762 sha1 E0B9E2358B09D430A100A14A6CB19E30B55FAEA2 )
 )
 
 game (
 	name "Space Dynamites (Japan)"
 	description "Space Dynamites (Japan)"
 	rom ( name "Space Dynamites (Japan).n64" size 8388608 crc 803F78AC md5 2D4B1CDB5AC82E521F0AA39059B9233E sha1 9B0776E967CBC97F832799CA8B16535EFABC1CDF flags verified )
-	rom ( name "Space Dynamites (J) [!].z64" size 8388608 crc 8CB4B948 md5 7F9CDBBB1AAAAF0983C64988EF9C58BE sha1 DEF172A1B2D17A6EBBBC0551172DE4AE46B88E48 )
 )
 
 game (
 	name "Space Invaders (USA)"
 	description "Space Invaders (USA)"
 	rom ( name "Space Invaders (USA).n64" size 8388608 crc 62E6DEFF md5 FE0E7B9873FDDB70BB5D1271903D9438 sha1 1ED83DD9637D5B6E7323480E74BF151542665A1B )
-	rom ( name "Space Invaders (U) [!].z64" size 8388608 crc 60F7FF8E md5 C72417E0F8F043F9F11851633C4B1A57 sha1 6850205EACE572AE1AA31100320AD8DF1B8DB37E )
 )
 
 game (
 	name "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)"
 	description "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)"
 	rom ( name "SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).n64" size 8388608 crc 6148B598 md5 33908C5D01C0DDB1A07FFB307A81C2DA sha1 065085D8E956E75980BAED473754FE539EE843D9 flags verified )
-	rom ( name "Space Station Silicon Valley (E) (M7) [!].z64" size 8388608 crc 63042E36 md5 FCA7AFCADCF5E5545A62919BA94DAD18 sha1 23710541BB3394072740B0F0236A7CB1A7D41531 )
 )
 
 game (
 	name "SpaceStation Silicon Valley (Japan) (Proto)"
 	description "SpaceStation Silicon Valley (Japan) (Proto)"
 	rom ( name "SpaceStation Silicon Valley (Japan) (Proto).n64" size 8388608 crc 7ABF7F2C md5 CC635E0AB1038E0CB8ACB3F09C83D6D4 sha1 F9B2A71ADA850509E27225A41E6FE8E271051A99 )
-	rom ( name "Space Station Silicon Valley (J) [!].z64" size 8388608 crc DCEC9F8A md5 E66ED1CC4AB95D0872BB2EBC49B206C4 sha1 7320F08474C011FC7781093BF1A6818C37CE51E2 )
 )
 
 game (
 	name "SpaceStation Silicon Valley (USA)"
 	description "SpaceStation Silicon Valley (USA)"
 	rom ( name "SpaceStation Silicon Valley (USA).n64" size 8388608 crc 76DB1DA1 md5 2745AAEA6429880E19E605D4DCE1DE61 sha1 8AE14D65342F5A1FF8D0F09251EF46E24C29FF2B )
-	rom ( name "Space Station Silicon Valley (U) [!].z64" size 8388608 crc A606E8AE md5 868B37D1B66D1D994E2BAD4E218BF129 sha1 E5E09205AA743A9E5043A42DF72ADC379C746B0B )
 )
 
 game (
@@ -5051,14 +4418,12 @@ game (
 	name "Star Fox 64 (Japan)"
 	description "Star Fox 64 (Japan)"
 	rom ( name "Star Fox 64 (Japan).n64" size 12582912 crc 879EDB89 md5 384EF29B9A1F638EAE21A871C2F1CEA9 sha1 86629DEF8EDBCFD1C6A3DE1C5172B14D1BF2F020 flags verified )
-	rom ( name "Star Fox 64 (J) [!].z64" size 12582912 crc 411142A7 md5 446D5215C4D34EB8AB0F355F324B8D0E sha1 9BD71AFBECF4D0A43146E4E7A893395E19BF3220 )
 )
 
 game (
 	name "Star Fox 64 (USA)"
 	description "Star Fox 64 (USA)"
 	rom ( name "Star Fox 64 (USA).n64" size 12582912 crc 363E7EE8 md5 FECDCBBCD1A178A2F4B29B43FACF9F39 sha1 CFF7FB46E79D35F727E4E20CC4C13492ECD2A2D7 flags verified )
-	rom ( name "Star Fox 64 (U) (V1.0) [!].z64" size 12582912 crc B1FCAA9C md5 CAF9A78DB13EE00002FF63A3C0C5EABB sha1 D8B1088520F7C5F81433292A9258C1184AFA1457 )
 )
 
 game (
@@ -5072,35 +4437,30 @@ game (
 	name "Star Soldier - Vanishing Earth (Japan)"
 	description "Star Soldier - Vanishing Earth (Japan)"
 	rom ( name "Star Soldier - Vanishing Earth (Japan).n64" size 12582912 crc F51D4C7C md5 8A51A0FF79F26A06F70083B2D079DAC1 sha1 F075EEB6890065CE827A900DF99E95F02F19098C flags verified )
-	rom ( name "Star Soldier - Vanishing Earth (J) [!].z64" size 12582912 crc 7EE5F51D md5 14A21928BE46C18BA04161305E89F5DE sha1 0B34BDDD00C49530E0EF47330A05DC70EBE5F8B7 )
 )
 
 game (
 	name "Star Soldier - Vanishing Earth (USA)"
 	description "Star Soldier - Vanishing Earth (USA)"
 	rom ( name "Star Soldier - Vanishing Earth (USA).n64" size 12582912 crc 052945E7 md5 EF7D98FEE80B68E3B3C1144508EAE1F5 sha1 A1A7EE7F86485C854F81DEC66462CA83ABC8EDD2 flags verified )
-	rom ( name "Star Soldier - Vanishing Earth (U) [!].z64" size 12582912 crc EA650DEF md5 EE045A2E9F924CD8FD00018B50E46650 sha1 14DFD0172567B47C819B3E61D1CE13281E0FFED6 )
 )
 
 game (
 	name "Star Twins (Japan)"
 	description "Star Twins (Japan)"
 	rom ( name "Star Twins (Japan).n64" size 33554432 crc C7BFB542 md5 28BD618B8E7CB56789626B758745467D sha1 8F1A670D89C1252326D0979126DEFF532452F333 flags verified )
-	rom ( name "Star Twins (J) [!].z64" size 33554432 crc 964506CE md5 CA28A3645FC7AD969EBD75C5D6506E7A sha1 15099233760B36E7AFAD7DA36B9464DA1512C4B1 )
 )
 
 game (
 	name "Star Wars - Rogue Squadron (Europe) (En,Fr,De)"
 	description "Star Wars - Rogue Squadron (Europe) (En,Fr,De)"
 	rom ( name "Star Wars - Rogue Squadron (Europe) (En,Fr,De).n64" size 16777216 crc 13CC4CA4 md5 1488007DB476D3EADB42DBABEAD088B5 sha1 E09FF328184B25F6A9170901FAC2D0A7158CE7B9 flags verified )
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!].z64" size 16777216 crc 6289645F md5 7F919D2E35CBE561E139AE8FE93ACA86 sha1 DA91A86F1F566DC66A2AE1292AA581BFC4F9CDFD )
 )
 
 game (
 	name "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A)"
 	description "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A)"
 	rom ( name "Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev A).n64" size 16777216 crc A6E336CE md5 FC21AA1CBF31E5DEA71E804878C3B5F0 sha1 D8B0AAFC759F6BEE328CC5D447250E3BC1D0905F )
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!].z64" size 16777216 crc C88E5638 md5 A9DD498E6A28F55311CE4EF057E164B8 sha1 66A70566D267532272B15ABC0BE20E2A1074AE45 )
 )
 
 game (
@@ -5120,21 +4480,18 @@ game (
 	name "Star Wars - Shadows of the Empire (Europe)"
 	description "Star Wars - Shadows of the Empire (Europe)"
 	rom ( name "Star Wars - Shadows of the Empire (Europe).n64" size 12582912 crc 675D15B2 md5 5E440149B6BEB286AAD3A0B1F10ADE9E sha1 C0F55DEA0BB07D0A8CB25F633DB3F86630B4C639 flags verified )
-	rom ( name "Star Wars - Shadows of the Empire (E) [!].z64" size 12582912 crc F0A191BF md5 591CF8E672C9CC0FE9C871CC56DCC854 sha1 E014F60BEA29BBC7FBD7F3BA4FCC6BDD228C8FE5 )
 )
 
 game (
 	name "Star Wars - Shadows of the Empire (USA)"
 	description "Star Wars - Shadows of the Empire (USA)"
 	rom ( name "Star Wars - Shadows of the Empire (USA).n64" size 12582912 crc 02FAE534 md5 CB1E1F8D818AB3CADEA2CBE24994C9FE sha1 4BF31D88277583D458FA73E4B69CBAE068A227B5 flags verified )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [!].z64" size 12582912 crc 3C0837B3 md5 5CCE8AD5F86E8A373A7525DC4C7E6705 sha1 271C285F6E5069133AB27A2A8324D4651591E35D )
 )
 
 game (
 	name "Star Wars - Shadows of the Empire (USA) (Rev A)"
 	description "Star Wars - Shadows of the Empire (USA) (Rev A)"
 	rom ( name "Star Wars - Shadows of the Empire (USA) (Rev A).n64" size 12582912 crc B0DBB100 md5 547321DF653203AD7BCBC178D9C37BF6 sha1 9AC4A13F7D73398E6B75FEB3238F0AE84680F532 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [!].z64" size 12582912 crc B0540688 md5 FA635E837275D28FD5A24D5675BA42C8 sha1 DED8F972D1E1D662614B1EC79822D649A8CE5430 )
 )
 
 game (
@@ -5154,21 +4511,18 @@ game (
 	name "Star Wars - Shutsugeki! Rogue Chuutai (Japan)"
 	description "Star Wars - Shutsugeki! Rogue Chuutai (Japan)"
 	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (Japan).n64" size 16777216 crc DE90ADE4 md5 02AAE1BCB61E071C3F87E0600FF6317F sha1 184A06D1967921E5BC9451D1337A529754B55C50 flags verified )
-	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!].z64" size 16777216 crc EE7643B6 md5 8603B180E70B2A72EF77D46C2BEC2234 sha1 D8BDDB9727264C14BF3BC20B2FE983FB86EADA32 )
 )
 
 game (
 	name "Star Wars - Teikoku no Kage (Japan)"
 	description "Star Wars - Teikoku no Kage (Japan)"
 	rom ( name "Star Wars - Teikoku no Kage (Japan).n64" size 12582912 crc 54F66BB9 md5 FE07ADDEFF06F9956F72643E7ACEC778 sha1 5AE92ACB3035DE0B62164787940F3D8272BB2708 flags verified )
-	rom ( name "Star Wars - Teikoku no Kage (J) [!].z64" size 12582912 crc 7CE71426 md5 5B6B6B0C8C9A40286DCF61706B6A05CB sha1 93ED6F1497EDE2239F9D75B4A39204B6C9DD9FFD )
 )
 
 game (
 	name "Star Wars Episode I - Battle for Naboo (Europe)"
 	description "Star Wars Episode I - Battle for Naboo (Europe)"
 	rom ( name "Star Wars Episode I - Battle for Naboo (Europe).n64" size 33554432 crc F6B20484 md5 415A266C6DFF65350FD577A127A2D601 sha1 7A22D9BDCE8067A9DC800017E5A01823D1514293 flags verified )
-	rom ( name "Star Wars Episode I - Battle for Naboo (E) [!].z64" size 33554432 crc 029104FD md5 0BD1F7BB9F4B02520E4E9285C809F099 sha1 C949856A6CB0B59A2D171C8AD2E8D913CCA23022 )
 )
 
 game (
@@ -5182,14 +4536,12 @@ game (
 	name "Star Wars Episode I - Racer (Europe) (En,Fr,De)"
 	description "Star Wars Episode I - Racer (Europe) (En,Fr,De)"
 	rom ( name "Star Wars Episode I - Racer (Europe) (En,Fr,De).n64" size 33554432 crc EDE47E8A md5 DE98F1BCEB2C317BB0A9743282CE2C2E sha1 D4968CE06B93705ED40FF4433279F587F62E3C26 flags verified )
-	rom ( name "Star Wars Episode I - Racer (E) (M3) [!].z64" size 33554432 crc E0F46629 md5 6EF9FED309F28BD59B605F128869AA00 sha1 899A8245DA017289C88E97327FDCD6694B770A25 )
 )
 
 game (
 	name "Star Wars Episode I - Racer (Japan)"
 	description "Star Wars Episode I - Racer (Japan)"
 	rom ( name "Star Wars Episode I - Racer (Japan).n64" size 33554432 crc 794412BF md5 4A44748DD673BA6F3F4C0EBE9637B9FB sha1 4760072BB254BB7ABFBF19D7664238B2CF5A6BD3 flags verified )
-	rom ( name "Star Wars Episode I - Racer (J) [!].z64" size 33554432 crc 97C155C5 md5 7579AB0E79B1011479B88F2BF39D48E0 sha1 9577CCD2D069D0E7E306CF21DDB0E4765A308072 )
 )
 
 game (
@@ -5206,12 +4558,6 @@ game (
 )
 
 game (
-	name "StarCraft 64 (Europe)"
-	description "StarCraft 64 (Europe)"
-	rom ( name "StarCraft 64 (E) [!].z64" size 33554432 crc 2639DAE2 md5 72B60FAC5EE257FA387B43C57632D50C sha1 BD8AB8994BE02368C844234006E5C11509CE2894 )
-)
-
-game (
 	name "StarCraft 64 (USA)"
 	description "StarCraft 64 (USA)"
 	rom ( name "StarCraft 64 (USA).n64" size 33554432 crc 14C77369 md5 FCB1EDE6D4F63DFF012CE8C2E62E95CF sha1 3466CE39800B160AB8157BA1505ADA238ED10D4A )
@@ -5222,7 +4568,6 @@ game (
 	name "StarCraft 64 (USA) (Beta)"
 	description "StarCraft 64 (USA) (Beta)"
 	rom ( name "StarCraft 64 (USA) (Beta).n64" size 33554432 crc 0DAB69E2 md5 A955E7F0C08DC43E98BEF99C005BAE1C sha1 1C58EBC31A5A7D750C980D8730EA4B2A98B6E1D0 )
-	rom ( name "StarCraft 64 (Beta).z64" size 33554432 crc B0E1654F md5 3EB732A8D004263AD8EB0DA59A29582A sha1 472573D057E42653B7413861319B9F7342F2467D )
 )
 
 game (
@@ -5235,63 +4580,54 @@ game (
 	name "Starshot - Space Circus Fever (Europe) (En,Fr,De)"
 	description "Starshot - Space Circus Fever (Europe) (En,Fr,De)"
 	rom ( name "Starshot - Space Circus Fever (Europe) (En,Fr,De).n64" size 12582912 crc 171B80E1 md5 DEDB299035EA5C330ED3590599B73241 sha1 4CCCF890424728BA500DB1046984EDCBAE280BEB flags verified )
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [!].z64" size 12582912 crc 056D2218 md5 A9C393AA232B32798ADF378F4318F99F sha1 B92818C5FF6BE02BEC77EDCBE278D06785D00C78 )
 )
 
 game (
 	name "Starshot - Space Circus Fever (USA) (En,Fr,Es)"
 	description "Starshot - Space Circus Fever (USA) (En,Fr,Es)"
 	rom ( name "Starshot - Space Circus Fever (USA) (En,Fr,Es).n64" size 12582912 crc 64370749 md5 5255C9F757D88188ED3D90FAEAFF462E sha1 1A4B81C3BD09D24DBBFED6AAE66CB6761429817B )
-	rom ( name "Starshot - Space Circus Fever (U) (M3) [!].z64" size 12582912 crc 7720E5F3 md5 42AF1992978229BBB5F560571708E25E sha1 7DEF46651F55745D5BBD633C9002BDBFFC53A5E0 )
 )
 
 game (
 	name "Stunt Racer 64 (USA)"
 	description "Stunt Racer 64 (USA)"
 	rom ( name "Stunt Racer 64 (USA).n64" size 12582912 crc F60613DE md5 B84F3C943E89F3743BEFB4092DEED5CC sha1 69D2CCB020F710886E76F28288FEA2846E341527 )
-	rom ( name "Stunt Racer 64 (U) [!].z64" size 12582912 crc 3438B1AF md5 E8B666A429FEDB2A1A1228CD450CD4FC sha1 8570FA1F3E4CF7E62DC49DA181353E4F301503B7 )
 )
 
 game (
 	name "Super B-Daman - Battle Phoenix 64 (Japan)"
 	description "Super B-Daman - Battle Phoenix 64 (Japan)"
 	rom ( name "Super B-Daman - Battle Phoenix 64 (Japan).n64" size 12582912 crc 0BE4F736 md5 FE9DE38985FCDD721A7858D684339021 sha1 E5F4934BD4B4DC553A9A42C37A09DC24156941C4 flags verified )
-	rom ( name "Super B-Daman - Battle Phoenix 64 (J) [!].z64" size 12582912 crc 5006DC88 md5 B3C1D4B9EC7DCD2922E681DBBC393915 sha1 D443FB2E2E3980FCB90E5BBA4138922477EA9037 )
 )
 
 game (
 	name "Super Bowling (Japan)"
 	description "Super Bowling (Japan)"
 	rom ( name "Super Bowling (Japan).n64" size 8388608 crc BE01964B md5 0A764357EC273A485BF2326A653AC15D sha1 8C9A5A424F3FD5C3165835BC240102F1A8BB67AD flags verified )
-	rom ( name "Super Bowling (J) [!].z64" size 8388608 crc BA2D8B2E md5 09C5B4D19364EFE48BB818087734978E sha1 FAA5FFDFFEC1FA56125130BECB6E150032C6923E )
 )
 
 game (
 	name "Super Bowling (USA)"
 	description "Super Bowling (USA)"
 	rom ( name "Super Bowling (USA).n64" size 8388608 crc E651CBAA md5 61587D9A36D7E745BF53EB7A5C86DD65 sha1 876973C2E83D4F915F65D7231CBF9051A2CF03AA )
-	rom ( name "Super Bowling 64 (U) [!].z64" size 8388608 crc F6CCD04A md5 FA3A043997A3ACDF17337385B126BC04 sha1 56937A9E9536AF55EBED06480413265848C4A04A )
 )
 
 game (
 	name "Super Mario 64 (Europe) (En,Fr,De)"
 	description "Super Mario 64 (Europe) (En,Fr,De)"
 	rom ( name "Super Mario 64 (Europe) (En,Fr,De).n64" size 8388608 crc 11FB579B md5 C9E143571EEF343B7BA731D15308A39D sha1 D80EE9EEB6454D53A96CEB6ED0ACA3FFDE045091 flags verified )
-	rom ( name "Super Mario 64 (E) (M3) [!].z64" size 8388608 crc 03048DE6 md5 45676429EF6B90E65B517129B700308E sha1 4AC5721683D0E0B6BBB561B58A71740845DCEEA9 )
 )
 
 game (
 	name "Super Mario 64 (Japan)"
 	description "Super Mario 64 (Japan)"
 	rom ( name "Super Mario 64 (Japan).n64" size 8388608 crc 5CF7952A md5 73C72657B1320FAF2A6AEA0E0A3DE45A sha1 1D2579DD5FB1D8263A4BCC063A651A64ACC88921 flags verified )
-	rom ( name "Super Mario 64 (J) [!].z64" size 8388608 crc DD801954 md5 85D61F5525AF708C9F1E84DCE6DC10E9 sha1 8A20A5C83D6CEB0F0506CFC9FA20D8F438CAFE51 )
 )
 
 game (
 	name "Super Mario 64 (Japan) (Rev A) (Shindou Edition)"
 	description "Super Mario 64 (Japan) (Rev A) (Shindou Edition)"
 	rom ( name "Super Mario 64 (Japan) (Rev A) (Shindou Edition).n64" size 8388608 crc BC9FF5F2 md5 F3A6E533DE52FB84D4E2DFAE6167C8B1 sha1 2A2B85E94581545CA3C05B8F864B488B141A8A1F flags verified )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [!].z64" size 8388608 crc A1E15117 md5 2D727C3278AA232D94F2FB45AEC4D303 sha1 3F319AE697533A255A1003D09202379D78D5A2E0 )
 )
 
 game (
@@ -5305,28 +4641,24 @@ game (
 	name "Super Robot Spirits (Japan)"
 	description "Super Robot Spirits (Japan)"
 	rom ( name "Super Robot Spirits (Japan).n64" size 16777216 crc DAB52B89 md5 AB017A5868FBDBF542E281689BFE10AA sha1 F7B7E507B7210E637CCFD2F788A95EF5C7970EC0 flags verified )
-	rom ( name "Super Robot Spirits (J) [!].z64" size 16777216 crc 8C9216C1 md5 3EC3F83EAB22702E146C467EB1DB45FA sha1 3BF62A1A48716708A5831CE47FB8C1A41DC365E6 )
 )
 
 game (
 	name "Super Robot Taisen 64 (Japan)"
 	description "Super Robot Taisen 64 (Japan)"
 	rom ( name "Super Robot Taisen 64 (Japan).n64" size 33554432 crc 70FBC3B8 md5 5EEA2F2CF76D8A4B397D5A01BB11C198 sha1 5BA9E915C1494FA6D9E8B0D4D32F312469963777 flags verified )
-	rom ( name "Super Robot Taisen 64 (J) [!].z64" size 33554432 crc 85DF2771 md5 3F4B73963ABC91CEE59C416063EFD4AE sha1 9883AEF6E20A46E110560C505999F3E21A1897DE )
 )
 
 game (
 	name "Super Smash Bros. (Australia)"
 	description "Super Smash Bros. (Australia)"
 	rom ( name "Super Smash Bros. (Australia).n64" size 16777216 crc B2F04090 md5 8F6203BD3B76A171C8290B819488AA51 sha1 E6F5167EEE80C2C92358A195FB88C6207AB0F9F6 flags verified )
-	rom ( name "Super Smash Bros. (A) [!].z64" size 16777216 crc E96779FA md5 694DEA68DBF1C3F06FF0476ACF2169E6 sha1 A9BF83FE73361E8D042C33ED48B3851D7D46712C )
 )
 
 game (
 	name "Super Smash Bros. (Europe) (En,Fr,De)"
 	description "Super Smash Bros. (Europe) (En,Fr,De)"
 	rom ( name "Super Smash Bros. (Europe) (En,Fr,De).n64" size 33554432 crc 7976248C md5 1E201F4C469927828BCF3335F2F3C4A3 sha1 A582522C0A09816BF904109E014A970625C06D3C flags verified )
-	rom ( name "Super Smash Bros. (E) (M3) [!].z64" size 33554432 crc 45A91CB1 md5 5E54C6C563B09C107F86FB33E914EF81 sha1 6EE8A41FEF66280CE3E3F0984D00B96079442FB9 )
 )
 
 game (
@@ -5340,28 +4672,24 @@ game (
 	name "Super Speed Race 64 (Japan)"
 	description "Super Speed Race 64 (Japan)"
 	rom ( name "Super Speed Race 64 (Japan).n64" size 4194304 crc D96B76C3 md5 FF6DD7E8B64AEE8C80548F2FDB6F1F1A sha1 E2E885786198A0F44AE740BA8C5DD59EAC14B207 flags verified )
-	rom ( name "Super Speed Race 64 (J) [!].z64" size 4194304 crc 0F879A70 md5 6B5D93B3566E96147009D1AC4FB15C97 sha1 E0A49FF953B882F9F135B583EF9E09A664D24288 )
 )
 
 game (
 	name "Supercross 2000 (Europe) (En,Fr,De)"
 	description "Supercross 2000 (Europe) (En,Fr,De)"
 	rom ( name "Supercross 2000 (Europe) (En,Fr,De).n64" size 16777216 crc 0A6377EE md5 EAA08CE91CAFF8A81CD88D4A265CA162 sha1 EE0802389002A907410A0E3F826FDCEFA572E6C1 flags verified )
-	rom ( name "Supercross 2000 (E) (M3) [!].z64" size 16777216 crc CB5482EC md5 6D58A01EF7A7A7C779D2A66315992C5F sha1 3FA3F859048A65E1E810ED7BE98ADA0A0B4E49AD )
 )
 
 game (
 	name "Supercross 2000 (USA)"
 	description "Supercross 2000 (USA)"
 	rom ( name "Supercross 2000 (USA).n64" size 16777216 crc 5A8A721D md5 B3922E74A81DC6F71A8FE3AF472C17F4 sha1 03CBBFB4F57E2813CBE9050401D6144724B84D6F )
-	rom ( name "Supercross 2000 (U) [!].z64" size 16777216 crc 094E2A48 md5 60347200A1A7CABC0D849EE69EC51DF7 sha1 8D726C2EF6BC74B0D516067FFD92DA00EFA07993 )
 )
 
 game (
 	name "Superman (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Superman (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Superman (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 9CEF1753 md5 32D596185AE37074134CEB34CFB476FC sha1 660CBD7F4808D928F8C3DADA9851267B6058FA80 flags verified )
-	rom ( name "Superman (E) (M6) [!].z64" size 8388608 crc BCA4FF8C md5 5AB39F2D7A144E1BA243DF059560E878 sha1 326378F4C05CA48B69D29CA1C72AB8E19B6EE10D )
 )
 
 game (
@@ -5381,7 +4709,6 @@ game (
 	name "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)"
 	description "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)"
 	rom ( name "Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).n64" size 8388608 crc DC83BCD3 md5 12CB5AB99EB3AEC0BAB422FC5C42906E sha1 ABD8ECDBFC3676488C4CB961439F13EF8DC7C0C7 flags verified )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!].z64" size 8388608 crc 4CD21372 md5 26F4CA20F7B9C88199AC046C57E282B4 sha1 FB905AC5887DE6C3670F73F9C92EFBACD55B6816 )
 )
 
 game (
@@ -5406,35 +4733,30 @@ game (
 	name "Tarzan (Europe)"
 	description "Tarzan (Europe)"
 	rom ( name "Tarzan (Europe).n64" size 16777216 crc 5FA14035 md5 735DC0F52D801D820CCDA651058E43DE sha1 A489E4E47DE9B59083F7BEBAFD260C8DCBB56F5F flags verified )
-	rom ( name "Disney's Tarzan (E) [!].z64" size 16777216 crc 7737ED9E md5 BD1DE2FC1CF31096423563A40ECBF933 sha1 7623ACEECD244F4352A7D9346A607AC183B32CD6 )
 )
 
 game (
 	name "Tarzan (France)"
 	description "Tarzan (France)"
 	rom ( name "Tarzan (France).n64" size 16777216 crc C1176831 md5 491CB5649BF3957591EDF9B1E5D765D4 sha1 F3193B0EB2A2DDD2735D51C1ADC4170BF2ED0252 )
-	rom ( name "Disney's Tarzan (F) [!].z64" size 16777216 crc 99C7649D md5 5D82E903F65341487DDC11AF80AD607A sha1 1CF1F0F8217BA4E1691427F97EF62B15DC02A1C3 )
 )
 
 game (
 	name "Tarzan (Germany)"
 	description "Tarzan (Germany)"
 	rom ( name "Tarzan (Germany).n64" size 16777216 crc 67DBEC0B md5 799EED5EE57EF4F21CF8C50201E1482B sha1 04E6C0A8C6B19B78E1B124D8D758813559716809 )
-	rom ( name "Disney's Tarzan (G) [!].z64" size 16777216 crc 0B0954C5 md5 DF3CDD959E8C63B45F557FC197CE0E63 sha1 4FC7DED9601A78DB964ED5B1A585BB716F6D636C )
 )
 
 game (
 	name "Tarzan (USA)"
 	description "Tarzan (USA)"
 	rom ( name "Tarzan (USA).n64" size 16777216 crc 2B59490B md5 FB7D7D58E4E3CBD434DB579AA4EF3F5E sha1 64C186549F71134872FE1279A0440A95A2A60866 )
-	rom ( name "Disney's Tarzan (U) [!].z64" size 16777216 crc C38CA641 md5 EAE7E0EE5328ED9F13B9CF9990189928 sha1 44C63A89E1E8F9EEEE0AA4B45442822FEB3CC579 )
 )
 
 game (
 	name "Taz Express (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Taz Express (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Taz Express (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 85382541 md5 A9F437615049E404C7D70481B6AF25E2 sha1 FA61BD39F2A02BDF65FBE0B5730FF7C01F239B18 flags verified )
-	rom ( name "Taz Express (E) (M6) [!].z64" size 12582912 crc 0712C306 md5 192B715E8BC5972A4986DF21DC8BF357 sha1 E1D8121986652ED180505AF21456C180C8B29FAB )
 )
 
 game (
@@ -5447,84 +4769,72 @@ game (
 	name "Telefoot Soccer 2000 (France)"
 	description "Telefoot Soccer 2000 (France)"
 	rom ( name "Telefoot Soccer 2000 (France).n64" size 16777216 crc FAD893EA md5 B3AC7EFA85C5E3BBD3667741F84660C7 sha1 D8F7D0557319B7B24DE2F9EF864A1A46F84F1DD8 )
-	rom ( name "Telefoot Soccer 2000 (F) [!].z64" size 16777216 crc 7BD20931 md5 7F244AFF8D729417E32B6A5B299AFDA5 sha1 FFC1F3271929B0E7D6467FDCBED9E0CCF2EBA0A5 )
 )
 
 game (
 	name "Tetris 64 (Japan) (En)"
 	description "Tetris 64 (Japan) (En)"
 	rom ( name "Tetris 64 (Japan) (En).n64" size 8388608 crc 08B4CA1B md5 3692F5A2457004BF8D08D43FD24257C4 sha1 95D42D3B33569FC2F47AC30C7DE277470CB79462 flags verified )
-	rom ( name "Tetris 64 (J) [!].z64" size 8388608 crc F128CD17 md5 7C8EFCF4FBA28F9F5B5EA10A71283BF3 sha1 EA9A3BA1384E15E0AF996B43FE3E56DB889002DE )
 )
 
 game (
 	name "Tetrisphere (Europe)"
 	description "Tetrisphere (Europe)"
 	rom ( name "Tetrisphere (Europe).n64" size 8388608 crc 2E953131 md5 6924D91E4A544E973136D7BF65F86BC0 sha1 4486F5BDB049F170F7525E72D14BCF61F159B0BB flags verified )
-	rom ( name "Tetrisphere (E) [!].z64" size 8388608 crc 7CB31B0F md5 765A330D5CE2DBE7120C6C8E18A1487D sha1 A730D8DD3B00C22F8FA4C6E74299E5CC2BBB8207 )
 )
 
 game (
 	name "Tetrisphere (USA)"
 	description "Tetrisphere (USA)"
 	rom ( name "Tetrisphere (USA).n64" size 8388608 crc 5DB18578 md5 AFEDBBA2EC96F65582229564B025BF4F sha1 81FFBB3912AAE46BF358FE03A96A090A9997DDB0 )
-	rom ( name "Tetrisphere (U) [!].z64" size 8388608 crc 70A3A5CE md5 3F88078E2D9DBF6C9372F6373CF9AE09 sha1 32ADAA274CEED246AEEE9F53592D642A121F3BDB )
 )
 
 game (
 	name "TG Rally 2 (Europe)"
 	description "TG Rally 2 (Europe)"
 	rom ( name "TG Rally 2 (Europe).n64" size 12582912 crc B5E8A1DF md5 A2C3EC262B1DB91463369CBDCAA1C4AB sha1 77BAF3DD7B20C2C7FAAE4944D1F9D30476A25AAC flags verified )
-	rom ( name "TG Rally 2 (E) [!].z64" size 12582912 crc 135C8EB0 md5 ACD0118AC4709DB3943B3D35112C2001 sha1 46907A7BD1CEB65F48C39D9D60B56DBC75A7A2C3 )
 )
 
 game (
 	name "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)"
 	description "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)"
 	rom ( name "Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).n64" size 16777216 crc CF7AA5EF md5 AC60411BBFB28C3B43DC7E5E030DBC73 sha1 92362BF5C1CF95B726FB9B05735BBEB00C0751E0 flags verified )
-	rom ( name "Tigger's Honey Hunt (E) (M7) [!].z64" size 16777216 crc D82D5736 md5 A09663B596F348D28AF846A51375EB81 sha1 53944F6C63B2E971ABF756EFECCAB24FA0B96E78 )
 )
 
 game (
 	name "Tigger's Honey Hunt (USA)"
 	description "Tigger's Honey Hunt (USA)"
 	rom ( name "Tigger's Honey Hunt (USA).n64" size 16777216 crc 79F8BF3B md5 800E231DECCD724D8B1F1F6820B8BE90 sha1 5B48828607CFCECAAF3450EE369E5D0CABBAFD7C )
-	rom ( name "Tigger's Honey Hunt (U) [!].z64" size 16777216 crc 68C2AC8F md5 F8636514B5B0EDEBF376C3111D24417A sha1 98DB3A0F9025893107E9FB1BB8D0B6BC0EF3E280 )
 )
 
 game (
 	name "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc B030A574 md5 B49212CBC6E122D8DB2747B03BA0CD24 sha1 C4FF73733C284CC927F06BE23551E73B14844984 flags verified )
-	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [!].z64" size 12582912 crc 9EA8A3B8 md5 46BE5D00682FCC1F7FC0FBA507E8E5C1 sha1 96C874C4556B4872269E41339A1CBAC53CC5B052 )
 )
 
 game (
 	name "Tom and Jerry in Fists of Furry (USA)"
 	description "Tom and Jerry in Fists of Furry (USA)"
 	rom ( name "Tom and Jerry in Fists of Furry (USA).n64" size 12582912 crc F0BFC6AB md5 9DCDFAB5FA65EFE5E18652E59A116E64 sha1 66C59EEF4370EDD573B3AEAD79E1C805CA768E1F )
-	rom ( name "Tom and Jerry in Fists of Furry (U) [!].z64" size 12582912 crc 6D685B83 md5 A63A9AF85BE8BB47C1741B8A37115354 sha1 D8980A34ECE4A8933D439D0378E0CFF8F03994A7 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (Europe)"
 	description "Tom Clancy's Rainbow Six (Europe)"
 	rom ( name "Tom Clancy's Rainbow Six (Europe).n64" size 16777216 crc B430BA47 md5 5FEE34130BAE944EDED29C7992DA1177 sha1 CE2CB1BDD42E0E7450B82DF3C238A3C0B58667B2 flags verified )
-	rom ( name "Tom Clancy's Rainbow Six (E) [!].z64" size 16777216 crc 4B71E083 md5 1B991CF41C70FF2C92FFBEFACABE8D03 sha1 64105F5C17BA7E2E0350F20E18ADDCC0A4766BD8 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (France)"
 	description "Tom Clancy's Rainbow Six (France)"
 	rom ( name "Tom Clancy's Rainbow Six (France).n64" size 16777216 crc 31BC7B49 md5 EDFDDAE2F418715999E5E418CBDE5640 sha1 ED7356FB54FB6F24EAF76BEC971C5DAD72252E74 )
-	rom ( name "Tom Clancy's Rainbow Six (F) [!].z64" size 16777216 crc BBF7B6A8 md5 15E4C1B4F3F459D4CAA7F7E2CF0C95DA sha1 EC38196491AEEE7AD2FB4A0A7F139C0839E864C6 )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six (Germany)"
 	description "Tom Clancy's Rainbow Six (Germany)"
 	rom ( name "Tom Clancy's Rainbow Six (Germany).n64" size 16777216 crc 1F872C4A md5 A2CAB7B96AF0A27C40802C165878F457 sha1 0E79AD6F283903A9E408C6DD3C80541B920CB3FC )
-	rom ( name "Tom Clancy's Rainbow Six (G) [!].z64" size 16777216 crc 5D73E788 md5 FDC76A53B1056D3E50EA6A3E295FE4D1 sha1 E41C7B71284976EA5D51B42593973A1D3CE58508 )
 )
 
 game (
@@ -5544,56 +4854,48 @@ game (
 	name "Tonic Trouble (Europe) (En,Fr,De,Es,It)"
 	description "Tonic Trouble (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Tonic Trouble (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc A10B0009 md5 00CB176BE188D983890451488755C25C sha1 84E6C54C9DD3F18EBA2C741E5F1CFD1BE04855CC flags verified )
-	rom ( name "Tonic Trouble (E) (M5) [!].z64" size 16777216 crc B4322403 md5 3D3573A855835A98DE29D598C35590E0 sha1 81909104362BAEB7AE3793C08C3D138E96105BBF )
 )
 
 game (
 	name "Tonic Trouble (USA) (Rev A)"
 	description "Tonic Trouble (USA) (Rev A)"
 	rom ( name "Tonic Trouble (USA) (Rev A).n64" size 16777216 crc 0ECD289A md5 B0488CD676773D283FE4FDEC55418F32 sha1 88F9ACE09F949A43253D37896E75472BC9AE6D12 )
-	rom ( name "Tonic Trouble (U) (V1.1) [!].z64" size 16777216 crc 1C04BA12 md5 7D3E935156844DE0002DB875E1076A5C sha1 38F9837159D6AA69CA656D8005ECCF099C129537 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater (USA)"
 	description "Tony Hawk's Pro Skater (USA)"
 	rom ( name "Tony Hawk's Pro Skater (USA).n64" size 12582912 crc EE2C9008 md5 7332315B5D57CE551E6D7069B5656932 sha1 7523D5E43EE18FC1298E8CE6656EFFCDB7B0C1B7 )
-	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [!].z64" size 12582912 crc F5C1B64F md5 5ED7E392198A5FA56EE37EA9E93A8D50 sha1 FC1B4DEC85E6874FA7321EDC24F5A1E78600D9D0 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater (USA) (Rev A)"
 	description "Tony Hawk's Pro Skater (USA) (Rev A)"
 	rom ( name "Tony Hawk's Pro Skater (USA) (Rev A).n64" size 12582912 crc 1BE278C1 md5 A5E0125B0FD742E744505F3895165AFC sha1 8F6B113675CF437FA0686E35683EBDC8AAF11D39 )
-	rom ( name "Tony Hawk's Pro Skater (U) (V1.1) [!].z64" size 12582912 crc 6182A092 md5 AFF424A1883DC7BB92C7B2EBE9342F85 sha1 4900B6C92FB8DF1765E91E891DCCC525BB102FE1 )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 2 (Europe)"
 	description "Tony Hawk's Pro Skater 2 (Europe)"
 	rom ( name "Tony Hawk's Pro Skater 2 (Europe).n64" size 16777216 crc DC703B1E md5 6792FBF31A3E6BA1FAB3CDC595BC949C sha1 28B9C785BDC0A54F1675D6180A092C300F514633 flags verified )
-	rom ( name "Tony Hawk's Pro Skater 2 (E) [!].z64" size 16777216 crc A1207132 md5 6BE030475C4DB52F273EF8A02B4DAFA8 sha1 803672C1FFA7860536D8B35DCA8B59F637F4165E )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 2 (USA)"
 	description "Tony Hawk's Pro Skater 2 (USA)"
 	rom ( name "Tony Hawk's Pro Skater 2 (USA).n64" size 16777216 crc 6DF2D58E md5 BC77A627AD496C0668FD14558F0E9AC2 sha1 6C2D313AEA3724F5638738923A58C0E765BDDCFA )
-	rom ( name "Tony Hawk's Pro Skater 2 (U) [!].z64" size 16777216 crc 80AA83F3 md5 29974692808C112B306FBD259273DC96 sha1 458AC754CD8E08C46F4C5C9204192ECDE84A179D )
 )
 
 game (
 	name "Tony Hawk's Pro Skater 3 (USA)"
 	description "Tony Hawk's Pro Skater 3 (USA)"
 	rom ( name "Tony Hawk's Pro Skater 3 (USA).n64" size 16777216 crc ED73272E md5 A1AA4FCE55D79E6F2E76BC04393008F7 sha1 63ECBB3D07B8AC20ED096AF0735704EF715BD398 )
-	rom ( name "Tony Hawk's Pro Skater 3 (U).z64" size 16777216 crc 62A8CE7D md5 9D4891BF26881C4541171B0235015FD4 sha1 7B9438120C67214AFAEA09F4B106C54EF8F366C5 )
 )
 
 game (
 	name "Tony Hawk's Skateboarding (Europe)"
 	description "Tony Hawk's Skateboarding (Europe)"
 	rom ( name "Tony Hawk's Skateboarding (Europe).n64" size 12582912 crc 93A26129 md5 03A0EA296D5BE79EDD8ECC9B41B42704 sha1 9DC473F35CEA9BA531590DE833EBF32E25A6A9D1 flags verified )
-	rom ( name "Tony Hawk's Pro Skater (E) [!].z64" size 12582912 crc 39E4F766 md5 C9E9C4A18B1540C6B4111331D7C663B8 sha1 C321CD05EEC58765467878AC8015784535280E3C )
 )
 
 game (
@@ -5603,113 +4905,87 @@ game (
 )
 
 game (
-	name "Top Gear Hyper Bike (Beta)"
-	description "Top Gear Hyper Bike (Beta)"
-	rom ( name "Top Gear Hyper Bike (Beta).z64" size 33554432 crc 00C0278A md5 B60D26C2C2242BFF61F76469FC272D2A sha1 D3AE07E2C4360EC4EB06A70C6E48D848EEC532DD )
-)
-
-game (
 	name "Top Gear Hyper-Bike (Europe)"
 	description "Top Gear Hyper-Bike (Europe)"
 	rom ( name "Top Gear Hyper-Bike (Europe).n64" size 16777216 crc DC687AD1 md5 25C594ED6E76C20BB731890E2319F9EA sha1 29573E3A4016ADCDFD2EE318D7700AD423EB369F flags verified )
-	rom ( name "Top Gear Hyper Bike (E) [!].z64" size 16777216 crc BAE57EA7 md5 0072538EF925645DB310F8E23A480B89 sha1 FF4EB866C48700FA978A5E663CDA1499C8EAC0B4 )
 )
 
 game (
 	name "Top Gear Hyper-Bike (Japan)"
 	description "Top Gear Hyper-Bike (Japan)"
 	rom ( name "Top Gear Hyper-Bike (Japan).n64" size 16777216 crc D9AF869C md5 C11BEBD92FAF132907769AD8B66CF965 sha1 0B97DBEE843094ED6320D4B795B64F7FAC908DAE flags verified )
-	rom ( name "Top Gear Hyper Bike (J) [!].z64" size 16777216 crc 09B2CDA1 md5 4347174BB415CA970F2D50DF2973F656 sha1 7DB7337260AF8F153B6291B13E655F192B59EC01 )
 )
 
 game (
 	name "Top Gear Hyper-Bike (USA)"
 	description "Top Gear Hyper-Bike (USA)"
 	rom ( name "Top Gear Hyper-Bike (USA).n64" size 16777216 crc 3E9CE2AF md5 35154380516AB853060A9B60EF6C30B5 sha1 4A146C7A53FB979BCEEDD79CC1719BD6130698A3 )
-	rom ( name "Top Gear Hyper Bike (U) [!].z64" size 16777216 crc 6EEBC26A md5 7258F4AB367B025C95A4F476C461E717 sha1 C7593B3D0D793CF03616DF02501735221624AC04 )
 )
 
 game (
 	name "Top Gear Overdrive (Europe)"
 	description "Top Gear Overdrive (Europe)"
 	rom ( name "Top Gear Overdrive (Europe).n64" size 12582912 crc 52D39097 md5 63E66FC7686B3007A5FF87D4CF881E96 sha1 37013DFFC9E8A61F3B40EB100133CD40F2AE523D flags verified )
-	rom ( name "Top Gear Overdrive (E) [!].z64" size 12582912 crc 0CC70580 md5 6C65A252F227AEF18DF2DD3CE04CC821 sha1 BAD781B7A3FE73A0127223CD807FAFBC4007DCCF )
 )
 
 game (
 	name "Top Gear Overdrive (Japan)"
 	description "Top Gear Overdrive (Japan)"
 	rom ( name "Top Gear Overdrive (Japan).n64" size 12582912 crc E680B138 md5 9AC8633925EFCB6EBD559A6A9B0CBD9B sha1 7A92260252F5E823F1B3B4ADEDC85908A0CADBB5 flags verified )
-	rom ( name "Top Gear Overdrive (J) [!].z64" size 12582912 crc 81AAFC2B md5 B5691794A851D8B603F0C741D44AA244 sha1 BE62D75C7AC1067111CD213365A9583550F897F3 )
 )
 
 game (
 	name "Top Gear Overdrive (USA)"
 	description "Top Gear Overdrive (USA)"
 	rom ( name "Top Gear Overdrive (USA).n64" size 12582912 crc B5B23053 md5 CB5E6AE88AD069B6E69A1D2FEB793C42 sha1 2B79D74949BC631E74379720265E8633806290AF )
-	rom ( name "Top Gear Overdrive (U) [!].z64" size 12582912 crc F3E0FF21 md5 7818696426C0A429FBFCCC4EFE8D5570 sha1 75EBBE451906CE68B0DD43EEF9EE44416452A4F1 )
 )
 
 game (
 	name "Top Gear Rally (Europe)"
 	description "Top Gear Rally (Europe)"
 	rom ( name "Top Gear Rally (Europe).n64" size 8388608 crc 83B04584 md5 B50A5815E2FB20E90B834A571F8FD8C9 sha1 42F8C45ACE108ADE7FFDCDF5D8475C2E1702954C flags verified )
-	rom ( name "Top Gear Rally (E) [!].z64" size 8388608 crc 40B3BB21 md5 1698508F521280D0A80E078EC981D4AC sha1 9FAE5D98FE3464F00D59034690DF90118646EB95 )
 )
 
 game (
 	name "Top Gear Rally (Japan)"
 	description "Top Gear Rally (Japan)"
 	rom ( name "Top Gear Rally (Japan).n64" size 8388608 crc D8E793F5 md5 1B20AD52E630FEA15304688D66E0FA89 sha1 3C29783DD963B8594D2FD41E296B2C7D9DC318F2 flags verified )
-	rom ( name "Top Gear Rally (J) [!].z64" size 8388608 crc C6707CD6 md5 6E0AF13DCEFEE6A11C4D7262206D6D2D sha1 E0415B87C5A5B69AC581E79137406BDAA79B354A )
 )
 
 game (
 	name "Top Gear Rally (USA)"
 	description "Top Gear Rally (USA)"
 	rom ( name "Top Gear Rally (USA).n64" size 8388608 crc A04F1CC0 md5 105D3FB95998914A3EB7AC9E7631C6D1 sha1 0DDE80BAE97B82FA56496360FC6B1BBFEACA6999 )
-	rom ( name "Top Gear Rally (U) [!].z64" size 8388608 crc 137287F5 md5 6F7030284B6BC84A49E07DA864526B52 sha1 BFC51F086EBDB78904DC24AD0C3A2D946E26D022 )
-)
-
-game (
-	name "Top Gear Rally 2 (Beta)"
-	description "Top Gear Rally 2 (Beta)"
-	rom ( name "Top Gear Rally 2 (Beta).z64" size 16777216 crc 3C77C5D6 md5 C33CD926E1E71F39F7238AF7B9E0DC5C sha1 168DD383EDD88A921D25CF7EAEB18B2DA29C744A )
 )
 
 game (
 	name "Top Gear Rally 2 (Europe)"
 	description "Top Gear Rally 2 (Europe)"
 	rom ( name "Top Gear Rally 2 (Europe).n64" size 12582912 crc 88C8A6EA md5 E440BA3B06ABC2749D765D196323EED4 sha1 CDEBA42C305995A7FB66B26C8DAF4E135152ABEC flags verified )
-	rom ( name "Top Gear Rally 2 (E) [!].z64" size 12582912 crc CB294D39 md5 44C4566572DC0662D4299AB5B19043AE sha1 CC140D2A8BAB74109D34FDA97F4DA21F8C3CD083 )
 )
 
 game (
 	name "Top Gear Rally 2 (Japan)"
 	description "Top Gear Rally 2 (Japan)"
 	rom ( name "Top Gear Rally 2 (Japan).n64" size 12582912 crc CCD50A05 md5 D7B62F7B669A0285B4681BEF150C4CF7 sha1 6C342E8E47BAA3B9EE8A0A35721EC3A123B94243 flags verified )
-	rom ( name "Top Gear Rally 2 (J) [!].z64" size 12582912 crc AA136E07 md5 B10D781EC625CA45713FD34E5096C24A sha1 D78DF79985BFDC7C77F7ED0338E86E852BB3F45A )
 )
 
 game (
 	name "Top Gear Rally 2 (USA)"
 	description "Top Gear Rally 2 (USA)"
 	rom ( name "Top Gear Rally 2 (USA).n64" size 12582912 crc 7E4E181C md5 75C415A43440B19BED2672EE3884A707 sha1 2C51EF2CA9B738DAA5F70B8199A64CD765A44243 )
-	rom ( name "Top Gear Rally 2 (U) [!].z64" size 12582912 crc 914CF9C4 md5 1FA409FCAC007DDECCC4CF439A0D8DAE sha1 FED36B2202B28FC7FF6446ECBA541413660D0630 )
 )
 
 game (
 	name "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
 	description "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
 	rom ( name "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).n64" size 12582912 crc 2AF45190 md5 06B460CAACB8F29261ACC5EFAF058617 sha1 4F08A4D02FC14E99BD13789895F7A447381E0C8C )
-	rom ( name "Toy Story 2 (F) [!].z64" size 12582912 crc FB4BEA9A md5 FA0F12C15B3655F9F56888C3249B1CED sha1 A9F97E22391313095D2C2FBAF81FB33BFA2BA7C6 )
 )
 
 game (
 	name "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
 	description "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
 	rom ( name "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).n64" size 12582912 crc C1C5B460 md5 0B766E5D0B28D3062A30C26F33FBEF1C sha1 E201405104E9C4275EDC2671E1BD99D13CCC40A8 flags verified )
-	rom ( name "Toy Story 2 (E) [!].z64" size 12582912 crc 59574CB9 md5 5F2C9E5E39AB09311D96E6C751184B6B sha1 92015E5254CBBAD1BC668ECB13A4B568E5F55052 )
 )
 
 game (
@@ -5729,7 +5005,6 @@ game (
 	name "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
 	description "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
 	rom ( name "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).n64" size 12582912 crc 33FD1561 md5 85F6378FCAC99ED25F807842B1729517 sha1 24CB3C7F89640A9AB542AABC55BC32561FD9218A )
-	rom ( name "Toy Story 2 (G) [!].z64" size 12582912 crc C5E4C89F md5 3F40F37B0464DD065067523FB21016DD sha1 F8FBB100227015BE8629243F53D70F29A2A14315 )
 )
 
 game (
@@ -5743,7 +5018,6 @@ game (
 	name "Transformers - Beast Wars Metals 64 (Japan)"
 	description "Transformers - Beast Wars Metals 64 (Japan)"
 	rom ( name "Transformers - Beast Wars Metals 64 (Japan).n64" size 12582912 crc 5E972B7D md5 5A136A29C0948ED3C131728CA3BCD296 sha1 DA8E453DBBD57AC3B207B44B4621EA8897141BB6 flags verified )
-	rom ( name "Transformers - Beast Wars Metals 64 (J) [!].z64" size 12582912 crc 338F1D45 md5 3D22D5BD7997293612ECDD3046BEBA13 sha1 A292C7AAB0092F39F1292434F3059782715863DB )
 )
 
 game (
@@ -5757,56 +5031,48 @@ game (
 	name "Triple Play 2000 (USA)"
 	description "Triple Play 2000 (USA)"
 	rom ( name "Triple Play 2000 (USA).n64" size 16777216 crc BFB124FC md5 E13208CE9412C9DB3FB62FFF93CD2B0D sha1 E604AA2D812DFC73D20E3FC8C81CBB73439DB88A )
-	rom ( name "Triple Play 2000 (U) [!].z64" size 16777216 crc 785DD0F8 md5 6F2C37A20E6ECCB657FBFC4BA36A34BB sha1 03619F14149D5A2716DFFBE02E21C2A0F5EE24F5 )
 )
 
 game (
 	name "Tsumi to Batsu - Hoshi no Keishousha (Japan)"
 	description "Tsumi to Batsu - Hoshi no Keishousha (Japan)"
 	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (Japan).n64" size 33554432 crc C0891399 md5 3B8638452B46DEBA9EDFFBCD6CDB6966 sha1 4C9AE28811F8688A9016D293C5F67681DA53CAD9 flags verified )
-	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (J) [!].z64" size 33554432 crc CA2E5E49 md5 A0657BC99E169153FD46AECCFDE748F3 sha1 581297B9D5C3A4C33169AE0AAE218C742CD9CBCF )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe)"
 	description "Turok - Dinosaur Hunter (Europe)"
 	rom ( name "Turok - Dinosaur Hunter (Europe).n64" size 8388608 crc 019A0C30 md5 1E09EEEBDAD6527BDE34A9E863AA6809 sha1 0CCDBFA032AE5F48C47489468B5DA23CF98F6D84 flags verified )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [!].z64" size 8388608 crc E8525687 md5 13FAA58604597E4EDC608070F8E0AE24 sha1 88916D5D2E2470F395AD8F4245D34138EF2D156A )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe) (Rev A)"
 	description "Turok - Dinosaur Hunter (Europe) (Rev A)"
 	rom ( name "Turok - Dinosaur Hunter (Europe) (Rev A).n64" size 8388608 crc 5ED8AB71 md5 EF2E88DA46D427DCAB90C5820D84B13F sha1 81A389040F3A284766BD31A7B65529B939241689 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.1) [!].z64" size 8388608 crc C2353283 md5 992BA72F4A1E9C51934FF345CDD0D90C sha1 90809F3D30BF085F5EACBD12136672216AA7B88B )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Europe) (Rev B)"
 	description "Turok - Dinosaur Hunter (Europe) (Rev B)"
 	rom ( name "Turok - Dinosaur Hunter (Europe) (Rev B).n64" size 8388608 crc 03D8CA48 md5 1428572BF7A06CCCB90411BEA697929A sha1 BFCF4FB8C268EB07EB4921712E0C8FB9EF0702CE flags verified )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.2) [!].z64" size 8388608 crc 312AF877 md5 548FC0E6035B65BC2108255039859934 sha1 0B3CD4FCB03C704E1F8EB3BBD109C82F4BE50075 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (Germany)"
 	description "Turok - Dinosaur Hunter (Germany)"
 	rom ( name "Turok - Dinosaur Hunter (Germany).n64" size 8388608 crc 70398790 md5 0ADBD2C70517AC80ED2430D61D3363AA sha1 D82536E69FF05CE4829588CEC79B96DC51E2BEB6 )
-	rom ( name "Turok - Dinosaur Hunter (G) [!].z64" size 8388608 crc 64631FF9 md5 0C0BFD1038EDA4F5C958DC362CDFF2D6 sha1 698760178EDFBB8293A536D4960AA9566F1A1871 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (USA)"
 	description "Turok - Dinosaur Hunter (USA)"
 	rom ( name "Turok - Dinosaur Hunter (USA).n64" size 8388608 crc 777D75E6 md5 E030EFB29598B151EBAAF6B101803D57 sha1 8A5D29E062F6893AF4E817B90AFD5F941968DF6D flags verified )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [!].z64" size 8388608 crc 26C4F597 md5 AE5107EFDD3C210E1EDD4ACD9B3CAC31 sha1 40FB0250C095740031278FB1F82B9937A3895E01 )
 )
 
 game (
 	name "Turok - Dinosaur Hunter (USA) (Rev A)"
 	description "Turok - Dinosaur Hunter (USA) (Rev A)"
 	rom ( name "Turok - Dinosaur Hunter (USA) (Rev A).n64" size 8388608 crc F26EC081 md5 331C149B6E1B6673B5369DECC9A0E931 sha1 9A2E1DB319AEC3EADA430053FB79D150BADE79AD )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.1) [!].z64" size 8388608 crc 7F2476F4 md5 37260287D59FE4EC6049C1D22B5614E6 sha1 6E67DCB49F700F01B18B7B4FD9AEB6BD911F1850 )
 )
 
 game (
@@ -5832,21 +5098,18 @@ game (
 	name "Turok - Legenden des Verlorenen Landes (Germany)"
 	description "Turok - Legenden des Verlorenen Landes (Germany)"
 	rom ( name "Turok - Legenden des Verlorenen Landes (Germany).n64" size 8388608 crc A2754CA4 md5 C8E5BA393A985E771BFEB8DF0182B011 sha1 51792351F4FD61C11F4B3B755A5EB8B9EA725B72 flags verified )
-	rom ( name "Turok - Legenden des Verlorenen Landes (G) [!].z64" size 8388608 crc B937874F md5 72A6AA28608EE93A1CB6FEB0A5F4C28C sha1 A6DAACBD0E7F77C73208CF494AEFC24703060B17 )
 )
 
 game (
 	name "Turok - Rage Wars (Europe)"
 	description "Turok - Rage Wars (Europe)"
 	rom ( name "Turok - Rage Wars (Europe).n64" size 8388608 crc 6C391585 md5 A7AE3121961623AF5668E5D2671D814D sha1 1DCD7B6A18E395872392E8F718D8EB8ED6F5D29D flags verified )
-	rom ( name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita).z64" size 8388608 crc F4A2862B md5 241CF94BED487FFF62FFB7B846DA46AB sha1 0B54615930A55675955EEF8D8A22F1DFC34D2B44 )
 )
 
 game (
 	name "Turok - Rage Wars (Europe) (En,Fr,It)"
 	description "Turok - Rage Wars (Europe) (En,Fr,It)"
 	rom ( name "Turok - Rage Wars (Europe) (En,Fr,It).n64" size 8388608 crc 6331B573 md5 72E5F21944E030D4782FAD476CFF2744 sha1 A0173D69A2DFD793B8A23092D7EDC79FA5A61C0C )
-	rom ( name "Turok - Rage Wars (E) [!].z64" size 8388608 crc 82B1E116 md5 DBA166A42710F40DC78DC52EB37B0BE6 sha1 46B474FAC79A4B21535BB6C78CE3039A2C202359 )
 )
 
 game (
@@ -5866,42 +5129,36 @@ game (
 	name "Turok 2 - Seeds of Evil (Europe)"
 	description "Turok 2 - Seeds of Evil (Europe)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe).n64" size 33554432 crc 9791B9CF md5 E00F7F87E87A504FD3D6862B5E8FEAB2 sha1 54FD5142F25A5FA058BDD2EB9F47EE1DFDD93B10 flags verified )
-	rom ( name "Turok 2 - Seeds of Evil (E) [!].z64" size 33554432 crc E2D34BFE md5 E5A39521FA954EB97B96AC2154A5FD7A sha1 1A0B36D9FD95DB483C846D0D604D2549D6CE4CC3 )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)"
 	description "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).n64" size 33554432 crc A309D9D3 md5 783F3ED408A5CEEA962F5B4202F9E4D7 sha1 B7D0DD6908ACBC7BC7A2588EEDBDCDFAB8C210BE flags verified )
-	rom ( name "Turok 2 - Seeds of Evil (E) (M4) [!].z64" size 33554432 crc 1FEBDE32 md5 144B10A484A22367FD2679529DBD2FED sha1 FB20F8E540C01D321BF805922B05E7A448521E1E )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)"
 	description "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)"
 	rom ( name "Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).n64" size 12582912 crc 38B017D5 md5 AA50B21A2F57E282E07CC43A691DC78B sha1 4D47EABE2740D6327207539CD229D7C9A27B51F0 flags verified )
-	rom ( name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!].z64" size 12582912 crc 4E29B234 md5 CE72237707F481CFE97FDE330C2AFCD6 sha1 BFC04B6C5C300D39BBABE0B42227AEF45CC41D3F )	
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (Germany)"
 	description "Turok 2 - Seeds of Evil (Germany)"
 	rom ( name "Turok 2 - Seeds of Evil (Germany).n64" size 33554432 crc FBE927CC md5 F00CBE882F8D2FAC3A4FECC0D83FAB9D sha1 1A46B9CA32625BD20C7C8E02AD62AE3273B8790A flags verified )
-	rom ( name "Turok 2 - Seeds of Evil (G) [!].z64" size 33554432 crc C07877B6 md5 B932116C967795076B5C112841AB4427 sha1 D09353C551F5309F29B6FF964B583A54E3D63C5F )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (USA)"
 	description "Turok 2 - Seeds of Evil (USA)"
 	rom ( name "Turok 2 - Seeds of Evil (USA).n64" size 33554432 crc FE3527AE md5 76557AB6A4D86107EF31603B4822DAE2 sha1 2CA5D6BA9529A57D822661EF770001276E7BEB92 flags verified )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [!].z64" size 33554432 crc FF5E7636 md5 FAD4DA8E17CE12F68CDF29180CDD4A90 sha1 FB0400F21E3F043939AB56500C7B12A3231006F1 )
 )
 
 game (
 	name "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)"
 	description "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)"
 	rom ( name "Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).n64" size 12582912 crc 46175228 md5 92AE515C8AE54299BFC5F2A760F1EA65 sha1 E9C274DD10C65FC4E0B07C1896EB884EEF78C41C )
-	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!].z64" size 12582912 crc 8D5B9BD0 md5 3BD42F6AEC477C056E1AFEBB3515495C sha1 68D1C5B79CC243804FCE3C993D9C93A10A58CAB8 )
 )
 
 game (
@@ -5915,7 +5172,6 @@ game (
 	name "Turok 3 - Shadow of Oblivion (Europe)"
 	description "Turok 3 - Shadow of Oblivion (Europe)"
 	rom ( name "Turok 3 - Shadow of Oblivion (Europe).n64" size 33554432 crc 3113283E md5 0C92616A1E18DBF389378EF2A2C2E957 sha1 10DF040EF5D6B2E9E72A1BFA2BDE5C0D74F68A7F flags verified )
-	rom ( name "Turok 3 - Shadow of Oblivion (E) [!].z64" size 33554432 crc 98D3114C md5 279EC83BD60A3CCE69A1DB22B0A5C318 sha1 F3FDC0B58D0AE8111F033C5F61C364E6A9425F91 )
 )
 
 game (
@@ -5935,70 +5191,60 @@ game (
 	name "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta)"
 	description "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta)"
 	rom ( name "Turok 3 - Shadow of Oblivion (USA) (2000-05-31) (Beta).n64" size 33554432 crc 505E9066 md5 0488A90E2380F6183A2382DFC7A1209D sha1 12A22310E653B2389110E7708831634E3F9F18DB )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta).z64" size 33554432 crc 97B7C3FF md5 0A3A4C761960F7D648AFA60B1E565C7C sha1 B3B232F098C8AC934682B0185159CDB3A3A570CE )
 )
 
 game (
 	name "Twisted Edge - Extreme Snowboarding (Europe)"
 	description "Twisted Edge - Extreme Snowboarding (Europe)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (Europe).n64" size 12582912 crc 394BDD25 md5 935894C48C7CEB500299CBEB6ACFA805 sha1 E5BAE263E692121A080308E6FDB2E42D20B1B347 flags verified )
-		rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
 )
 
 game (
 	name "Twisted Edge - Extreme Snowboarding (USA)"
 	description "Twisted Edge - Extreme Snowboarding (USA)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (USA).n64" size 12582912 crc 3A572B23 md5 8E18804153D55B4CF614E2176F7C1FAB sha1 0B737F0E48B4BFC80A78FE18E7E0530050F70FC0 )
-	rom ( name "Twisted Edge Extreme Snowboarding (U) [!].z64" size 12582912 crc BFBCC038 md5 9DF6C2C97FA34A978EF3CB77631536FE sha1 8888228AD423DF143C2C820130FB0658DF64C930 )
 )
 
 game (
 	name "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)"
 	description "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)"
 	rom ( name "Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).n64" size 8388608 crc CB8C642B md5 B10D16F9EED103635B8722441E8A3CF4 sha1 9099C31FA07C8BFDD5DC94EFEBB9054144A1E34C flags verified )
-	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!].z64" size 8388608 crc 50CBE8A6 md5 FFEB5C1A85BABBBE60F2FEBA2B35C893 sha1 557D2DADEBEA77FBC7342A881311FCA5C5B35B39 )
 )
 
 game (
 	name "V-Rally Edition 99 (Europe) (En,Fr,De)"
 	description "V-Rally Edition 99 (Europe) (En,Fr,De)"
 	rom ( name "V-Rally Edition 99 (Europe) (En,Fr,De).n64" size 12582912 crc D200F779 md5 2DC8FBC3F591C0E4C54710AB2B66DF58 sha1 D55B29CEE570D6BD7E8B5A4F817D987A8C08B32E flags verified )
-	rom ( name "V-Rally Edition 99 (E) (M3) [!].z64" size 12582912 crc 0735D7A2 md5 DCAC12EB5832D4A489188330EB9EC387 sha1 DA3F262DFB86CFF1376C9A1AA081212E5A7AAD64 )
 )
 
 game (
 	name "V-Rally Edition 99 (Japan)"
 	description "V-Rally Edition 99 (Japan)"
 	rom ( name "V-Rally Edition 99 (Japan).n64" size 8388608 crc 7AAB7E2A md5 2017C8E61F2DB918270B6B5458D02846 sha1 04BAC1690879D0178F646E04C935DAC7AE72E16D flags verified )
-	rom ( name "V-Rally Edition 99 (J) [!].z64" size 8388608 crc 02475A01 md5 8541D7A8737BE09C52D4EC1274DE2A91 sha1 B23ADB839AC7BB51CC080FF531E42AB0BC86DD13 )
 )
 
 game (
 	name "V-Rally Edition 99 (USA)"
 	description "V-Rally Edition 99 (USA)"
 	rom ( name "V-Rally Edition 99 (USA).n64" size 8388608 crc BFEF13E9 md5 5E82395C7F9C3ADE651551682F9A9869 sha1 7FC14B6683A5CBF1597211EB2375E5AD0E16C756 )
-	rom ( name "V-Rally Edition 99 (U) [!].z64" size 8388608 crc 4803075E md5 0C3448A9D85300ACB9C5556F27A84B23 sha1 891C64C871993C043BF47745FCCE16CD7E6AA76F )
 )
 
 game (
 	name "Vigilante 8 (Europe)"
 	description "Vigilante 8 (Europe)"
 	rom ( name "Vigilante 8 (Europe).n64" size 8388608 crc 959ECCE7 md5 56FE17C8AEBB21A2E625D74F66B7CBE3 sha1 49F44E03DCC432784ED4251D4A52490F734A30A8 flags verified )
-	rom ( name "Vigilante 8 (E) [!].z64" size 8388608 crc 0E9BB6D6 md5 DF011E19F41B1B19C21F1E77E13780B7 sha1 37603E7AFBA0D0EBEBE64782EFD135B096D4CADC )
 )
 
 game (
 	name "Vigilante 8 (France)"
 	description "Vigilante 8 (France)"
 	rom ( name "Vigilante 8 (France).n64" size 8388608 crc C178EA87 md5 ACF053FBCDA123346A446D5133628092 sha1 53446583AEE4C693C9A9B5ED50A4D9BAE1D284B2 )
-	rom ( name "Vigilante 8 (F) [!].z64" size 8388608 crc 11D23AB3 md5 FF9F85C50982DBDBA9853A8915321D31 sha1 16688EAC55153332D49A62696294F38D6C1AFEFA )
 )
 
 game (
 	name "Vigilante 8 (Germany)"
 	description "Vigilante 8 (Germany)"
 	rom ( name "Vigilante 8 (Germany).n64" size 8388608 crc 179EEC29 md5 5649539D6734F4BC0369FF3AB8C2CA9D sha1 7E6E6630F419C25EFC18ADC9AF884AB25EEF42B6 )
-	rom ( name "Vigilante 8 (G) [!].z64" size 8388608 crc 17F63C3F md5 37B430EE16167831C6C6292994F93277 sha1 39E4FC6D553D370EFC0710DE2E99D8BC8A020A7C )
 )
 
 game (
@@ -6012,7 +5258,6 @@ game (
 	name "Vigilante 8 - 2nd Offense (Europe)"
 	description "Vigilante 8 - 2nd Offense (Europe)"
 	rom ( name "Vigilante 8 - 2nd Offense (Europe).n64" size 12582912 crc 763D501E md5 417701C8EE152E3E9003001623EBAE5B sha1 AD3F8CC2E2EAD6E713621E25F5F6F02534A81AD5 flags verified )
-	rom ( name "Vigilante 8 - 2nd Offence (E) [!].z64" size 12582912 crc 691AA971 md5 47661EF1964524B6319B759913F08B62 sha1 A2841A8B4C29481D05B52227442C0E419C574E2D )
 )
 
 game (
@@ -6026,119 +5271,102 @@ game (
 	name "Violence Killer - Turok New Generation (Japan)"
 	description "Violence Killer - Turok New Generation (Japan)"
 	rom ( name "Violence Killer - Turok New Generation (Japan).n64" size 33554432 crc 65785622 md5 8B8FD4AC3F3379747644EF183088D49B sha1 873B8520FC44DB2B3910DD5F11B9AEC63F17645C flags verified )
-	rom ( name "Violence Killer - Turok New Generation (J) [!].z64" size 33554432 crc 097F139F md5 C3005D76AF42E929E5C67421A19F8235 sha1 2DD9771030500A4E4512E76209267E358A4A0AE6 )
 )
 
 game (
 	name "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).n64" size 4194304 crc D20F855C md5 E78D046A3E65769966BEBFD9280938DD sha1 47B211D0F2CB0C5F53BFBB52649CAF6A616CF24C flags verified )
-	rom ( name "Virtual Chess 64 (E) (M6) [!].z64" size 4194304 crc AAE15243 md5 E790BE1A5B883BEBA44BC0D2666C65F5 sha1 0899017B0A5231ECBB084ABFF2303D9C25342828 )
 )
 
 game (
 	name "Virtual Chess 64 (USA) (En,Fr,Es)"
 	description "Virtual Chess 64 (USA) (En,Fr,Es)"
 	rom ( name "Virtual Chess 64 (USA) (En,Fr,Es).n64" size 4194304 crc 3CD894C4 md5 EEC508E77327324B9CD88957C173079B sha1 9F57EC795E3C62D88EA823A5866A7B1012B731DB )
-	rom ( name "Virtual Chess 64 (U) (M3) [!].z64" size 4194304 crc 620DE0B7 md5 F8A35270279B277586D7210FD15134FF sha1 B3F84937813EB76F94DFCF1DBEA69B11BDBF7E4F )
 )
 
 game (
 	name "Virtual Pool 64 (Europe)"
 	description "Virtual Pool 64 (Europe)"
 	rom ( name "Virtual Pool 64 (Europe).n64" size 4194304 crc F8498BD2 md5 383518F562B819AC7D1BCCB2987E035E sha1 92994B5289C95951A566B745E2D9A80D62C711EE flags verified )
-	rom ( name "Virtual Pool 64 (E) [!].z64" size 4194304 crc 9A6FB0BC md5 AB68FB43F012C1A45AF1DBCC8E8C109C sha1 70BD9ECE445D6B66EF65AFC19B5EA9DF5A75DBA4 )
 )
 
 game (
 	name "Virtual Pool 64 (USA)"
 	description "Virtual Pool 64 (USA)"
 	rom ( name "Virtual Pool 64 (USA).n64" size 4194304 crc 584B2A5F md5 379A1B5091AC14011BBF13905F7358E3 sha1 5AA70FE4E2BF875BA089AFD53D1FEF27A59BB3F9 )
-	rom ( name "Virtual Pool 64 (U) [!].z64" size 4194304 crc AD628DED md5 6D3DB67319DA339DF4B68AD0084904D5 sha1 4FED63F7EE35F4D3941F0D61175057481D91D2E0 )
 )
 
 game (
 	name "Virtual Pro Wrestling 2 - Oudou Keishou (Japan)"
 	description "Virtual Pro Wrestling 2 - Oudou Keishou (Japan)"
 	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (Japan).n64" size 33554432 crc 8E33C3AF md5 F615D6D16FDE2D86E67D8418C5F7FDF3 sha1 D6E4980EE08519A0AF60BED5C40A71E284B1E178 flags verified )
-	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!].z64" size 33554432 crc F620835D md5 90002501777E3237739F5ED9B0E349E2 sha1 82DD25A044689EAB57AB362FE10C0DA6388C217A )
 )
 
 game (
 	name "Virtual Pro Wrestling 64 (Japan)"
 	description "Virtual Pro Wrestling 64 (Japan)"
 	rom ( name "Virtual Pro Wrestling 64 (Japan).n64" size 16777216 crc 2B4B9BEF md5 BAC5D6CA43BAB3A963DE9DE88E02D5D7 sha1 A98DF45B6FDEB368FB906A2A1FB257658739CEFE flags verified )
-	rom ( name "Virtual Pro Wrestling 64 (J) [!].z64" size 16777216 crc E6651803 md5 5E6202200AF40A8F026780EDFE1E15D0 sha1 F9E9FA2ED819C3A39DB5CB6AFECA186F021DB5ED )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (Europe)"
 	description "Waialae Country Club - True Golf Classics (Europe)"
 	rom ( name "Waialae Country Club - True Golf Classics (Europe).n64" size 16777216 crc 8E6F987B md5 A3F14021F514509F6A001073F0F7ED19 sha1 B7542C7FC1566D4A9D72B85E3C6D57642614EE29 flags verified )
-	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!].z64" size 16777216 crc 6858759A md5 5F1906DF4EB30537C2AC2FCBD005907D sha1 A06F905F4466637012ADB5EB56CCDCBEE2E7AC72 )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (Europe) (Rev A)"
 	description "Waialae Country Club - True Golf Classics (Europe) (Rev A)"
 	rom ( name "Waialae Country Club - True Golf Classics (Europe) (Rev A).n64" size 16777216 crc 53A68628 md5 7EA7F5676D06D1C6387E7B8C01905BC3 sha1 57CBFA043A2D86C11B35B49855115641184097D7 )
-	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!].z64" size 16777216 crc 6CB097B3 md5 F7C1B1EE1CE37CE09AA48C7E0A115EFA sha1 074D13DA1AC91167654A8047EB72D732FBCB5121 )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (USA)"
 	description "Waialae Country Club - True Golf Classics (USA)"
 	rom ( name "Waialae Country Club - True Golf Classics (USA).n64" size 16777216 crc CB760261 md5 AC8E0BA90CF88F77382AC450E3975343 sha1 F0A57D923159F5940528EAD63C1F34D129DCA866 )
-	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.0) [!].z64" size 16777216 crc CCAB08D7 md5 DD8154D507C88694AFD69C7AF16A8CD6 sha1 F8609F518D60C87CB6A4E257633E8A1BE957311C )
 )
 
 game (
 	name "Waialae Country Club - True Golf Classics (USA) (Rev A)"
 	description "Waialae Country Club - True Golf Classics (USA) (Rev A)"
 	rom ( name "Waialae Country Club - True Golf Classics (USA) (Rev A).n64" size 16777216 crc 76EBDB18 md5 8F0FD604B64DFDF18E3922258EDE4DD1 sha1 305E4A9FA345CF74000F7F05AEC2483F4C7BDF3E )
-	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.1) [!].z64" size 16777216 crc C65EE122 md5 67F75C4DD30922A001C8C32AEB9333AC sha1 45C9E0CA0D41B47BB59D36CEBB1D2A9DB7C8278B )
 )
 
 game (
 	name "War Gods (Europe)"
 	description "War Gods (Europe)"
 	rom ( name "War Gods (Europe).n64" size 12582912 crc FD10AAA6 md5 94A2651B517464D197DEDBC5B13B87D3 sha1 FC77E3D872220DAFC41147BA79188A04E21F3805 flags verified )
-	rom ( name "War Gods (E) [!].z64" size 12582912 crc C73010C8 md5 D25DD15903BDCB7724A2E8A02561987F sha1 C9BDD7E5AF853135FC4CBD72E461FC227F7498E3 )
 )
 
 game (
 	name "War Gods (USA)"
 	description "War Gods (USA)"
 	rom ( name "War Gods (USA).n64" size 12582912 crc 10635B27 md5 804E38E2FF638EF8B2E02E231AD2F8A2 sha1 3FF5C88420221F95EB27A65519C6FE558618BFC7 )
-	rom ( name "War Gods (U) [!].z64" size 12582912 crc FFACF993 md5 9FF2BA3C8408DE9F0EDB6D764A97C197 sha1 829C4F0F1CAA72A2FBABAEE5651E2ACC695D3921 )
 )
 
 game (
 	name "Wave Race 64 (Europe) (En,De)"
 	description "Wave Race 64 (Europe) (En,De)"
 	rom ( name "Wave Race 64 (Europe) (En,De).n64" size 8388608 crc D74117B0 md5 BAFF32EE50896E62DC713E23D1A589DA sha1 7FFDD44890B1A00E0C13868A18B482FBF8C752F7 flags verified )
-	rom ( name "Wave Race 64 (E) (M2) [!].z64" size 8388608 crc FB289893 md5 310659115E9939F219A783ABDD456CE9 sha1 C20AA97DC25AEC7A9B9C6889286BBD216FC7CAA4 )
 )
 
 game (
 	name "Wave Race 64 (Japan)"
 	description "Wave Race 64 (Japan)"
 	rom ( name "Wave Race 64 (Japan).n64" size 8388608 crc 0580EEE7 md5 488DCC35AF1074C2A5A7483417C0EE3F sha1 B1B4435B15627830F7C932EB40DF862EEA2B38E4 flags verified )
-	rom ( name "Wave Race 64 (J) [!].z64" size 8388608 crc 6C93FF83 md5 B32E555BC1A375256E8A4021A25339BE sha1 05D40E57C9CB29A8992595AFDDE6653936E16729 )
 )
 
 game (
 	name "Wave Race 64 (Japan) (Rev B) (Shindou Edition)"
 	description "Wave Race 64 (Japan) (Rev B) (Shindou Edition)"
 	rom ( name "Wave Race 64 (Japan) (Rev B) (Shindou Edition).n64" size 8388608 crc D3610A02 md5 F385D82E0E9372A812CBF98BC0D0EE48 sha1 443E3C3476568DE9C36582184104F2DD09B59407 flags verified )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [!].z64" size 8388608 crc 90044C4B md5 FF67DF97476C210D158779AE6142F239 sha1 445ECB4904CC0AB6B81FB415A35072E99F18B545 )
 )
 
 game (
 	name "Wave Race 64 (USA)"
 	description "Wave Race 64 (USA)"
 	rom ( name "Wave Race 64 (USA).n64" size 8388608 crc 9EF814CD md5 89C5C1208E2BBA07CB9C46786571B159 sha1 8BACCF6A8A298609BFF1FE489845F2136FD03CF1 )
-	rom ( name "Wave Race 64 (U) (V1.0) [!].z64" size 8388608 crc 74A7B725 md5 AE480013F39D4AEC86EEA1B4995600D1 sha1 887AB588C2ECC64C52FB2065F06B0A1EE4AF13DC )
 )
 
 game (
@@ -6158,70 +5386,60 @@ game (
 	name "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)"
 	description "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)"
 	rom ( name "Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).n64" size 8388608 crc 0EFF3F94 md5 1CFC82269D38199171E2FCD48FB93BC4 sha1 BFA32477EA99C93C156E51FDF14107A6BEEB31AA flags verified )
-	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [!].z64" size 8388608 crc 442A4F5F md5 319816AAA30E512827BE7B7F81F80D86 sha1 D9A6BA9A6E75A198E995AF3C4C81F4CFB3830C64 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (Japan)"
 	description "Wayne Gretzky's 3D Hockey (Japan)"
 	rom ( name "Wayne Gretzky's 3D Hockey (Japan).n64" size 8388608 crc 694B3B0B md5 197EE91817839DD7E8FAE10051EC6992 sha1 0A7890D52130CFA7F6076545735C510586C230BA flags verified )
-	rom ( name "Wayne Gretzky's 3D Hockey (J) [!].z64" size 8388608 crc 485275ED md5 61E637B542D5DF178040454075C28E19 sha1 D8EDC3B462BF80B48C98FB36032B8ACA95164055 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (USA)"
 	description "Wayne Gretzky's 3D Hockey (USA)"
 	rom ( name "Wayne Gretzky's 3D Hockey (USA).n64" size 8388608 crc 2462389E md5 402AF7C6B9A5D77ABCDEB140164C4641 sha1 2CB103FECADA5DA8DE2A6384F13E004098F4E724 )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!].z64" size 8388608 crc 9781F88D md5 6DF0D6259261D0096C90BBC6AA037D8E sha1 400AA84811F1F2F6C62C756B43B54D534D5A5EC8 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey (USA) (Rev A)"
 	description "Wayne Gretzky's 3D Hockey (USA) (Rev A)"
 	rom ( name "Wayne Gretzky's 3D Hockey (USA) (Rev A).n64" size 8388608 crc 6E5A30ED md5 5A54B97A4049E3987BC057535F95FB2B sha1 073B4E9CD8D93A58145625FFEF9B1FC642EB31A8 )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!].z64" size 8388608 crc C2678971 md5 04E650B7742A69DAE98F125D1B492D78 sha1 91F33097C5DA2C3480E0A9F04F7463CEA16B176B )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)"
 	description "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)"
 	rom ( name "Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).n64" size 8388608 crc 53751331 md5 69F21F9AD371EB5564F0E3E817A7035D sha1 2F1462118B4AFF3DED4AE5AFD3952F2189B43A27 flags verified )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!].z64" size 8388608 crc 6F6DC53D md5 24A0D8C8CABC22116E469476FF6C691D sha1 3EB1A78C0480AF0CC6F2180F87260790C37367D0 )
 )
 
 game (
 	name "Wayne Gretzky's 3D Hockey '98 (USA)"
 	description "Wayne Gretzky's 3D Hockey '98 (USA)"
 	rom ( name "Wayne Gretzky's 3D Hockey '98 (USA).n64" size 8388608 crc 5C593E2E md5 4F055251F47CE44D618E0EE4B3962C98 sha1 D561EBA53BED8B399635298233A073FFFAF0EEDE )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [!].z64" size 8388608 crc 355FB089 md5 810F8BC2C8C66BDA3B206C7DD4B6D42F sha1 1AF0BE9568F8ACE865D5CF76FD241DA741154B0F )
 )
 
 game (
 	name "WCW Backstage Assault (USA)"
 	description "WCW Backstage Assault (USA)"
 	rom ( name "WCW Backstage Assault (USA).n64" size 33554432 crc D3A9F234 md5 A08B158B8EEBB9FE2CBF5C5BEC86266E sha1 F31E03752C7502E99A201BF86FFB453AC260D426 )
-	rom ( name "WCW Backstage Assault (U) [!].z64" size 33554432 crc 5DCC2E4E md5 02AED169EB579494ACE75D22E10D789B sha1 34F793D55770D5EB112CFF0E28CB0A35E0EC7385 )
 )
 
 game (
 	name "WCW Mayhem (Europe)"
 	description "WCW Mayhem (Europe)"
 	rom ( name "WCW Mayhem (Europe).n64" size 16777216 crc E56874EE md5 EBE4D489C2D6EA05986F6FDB54747AA0 sha1 E52D1E83BC9283A7BA7B99372A83D4D6ECF57347 flags verified )
-	rom ( name "WCW Mayhem (E) [!].z64" size 16777216 crc 864E066E md5 9E943752BCF4FBA9CA3028E596F4EB4A sha1 594B273EE9D6E174CFD9B33D4FD6AA86CD3E2442 )
 )
 
 game (
 	name "WCW Mayhem (USA)"
 	description "WCW Mayhem (USA)"
 	rom ( name "WCW Mayhem (USA).n64" size 16777216 crc A1911368 md5 953870B29EC86FDB782136F334BCB05C sha1 0B848A7747C97286D42764F9237D9EF05B39BECD )
-	rom ( name "WCW Mayhem (U) [!].z64" size 16777216 crc F1F9B6EB md5 87BF3784709CD09693CD7BCC08460C63 sha1 83382EE31DB3DCCD598D8AF55607E70DB1BCBBB6 )
 )
 
 game (
 	name "WCW Nitro (USA)"
 	description "WCW Nitro (USA)"
 	rom ( name "WCW Nitro (USA).n64" size 12582912 crc AC1909A9 md5 C8C8B278A90951C9EEE9097CEEE92194 sha1 F4C03AE1CCC3EAC5B0F8B37B0293DB44DAA6397C )
-	rom ( name "WCW Nitro (U) [!].z64" size 12582912 crc 455B0830 md5 1E9FEAD701FE5AAAA248D4713891775D sha1 1F3B1A9E348506AE3D2A79216B0BC6E69D04A4F9 )
 )
 
 game (
@@ -6234,70 +5452,60 @@ game (
 	name "WCW vs. nWo - World Tour (Europe)"
 	description "WCW vs. nWo - World Tour (Europe)"
 	rom ( name "WCW vs. nWo - World Tour (Europe).n64" size 12582912 crc B3A472A3 md5 D8F27EB71A348B6E5EBD902E619845BC sha1 DD07A3434EE38AC03F5D3E45BFB0B3F956EBDAB5 flags verified )
-	rom ( name "WCW vs. nWo - World Tour (E) [!].z64" size 12582912 crc 37F358EB md5 553D8D5347969C66E5D91C3FE35208B9 sha1 840B8B6303ACACEB49619EB1533CB4221CDEC474 )
 )
 
 game (
 	name "WCW vs. nWo - World Tour (USA)"
 	description "WCW vs. nWo - World Tour (USA)"
 	rom ( name "WCW vs. nWo - World Tour (USA).n64" size 12582912 crc AD6FE55F md5 B352F1CD684BB04530A454E8618E6582 sha1 050A85A8FB5146D0A5DD0A67D1004695F83CEA36 )
-	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [!].z64" size 12582912 crc DFBFC61F md5 203C3BBFDD10C5A0B7C5D0CDB085D853 sha1 5AD2D8359058C8BB71F08E3D3433B7A50D3BB645 )
 )
 
 game (
 	name "WCW vs. nWo - World Tour (USA) (Rev A)"
 	description "WCW vs. nWo - World Tour (USA) (Rev A)"
 	rom ( name "WCW vs. nWo - World Tour (USA) (Rev A).n64" size 12582912 crc 85E0C097 md5 D87E95C5B6BC2E1D484C2F8CC3986D63 sha1 6ECEDD03908627B4A76C3E1CC46D3567E755591D )
-	rom ( name "WCW vs. nWo - World Tour (U) (V1.1) [!].z64" size 12582912 crc A74DA07A md5 B7A220B59303D47F3BEAE233CA868CFD sha1 60814FB3AD2DD206BADBEEE47C07636357DD0D7E )
 )
 
 game (
 	name "WCW-nWo Revenge (Europe)"
 	description "WCW-nWo Revenge (Europe)"
 	rom ( name "WCW-nWo Revenge (Europe).n64" size 16777216 crc 0ABBE702 md5 9FB2B096FEECDADA1DBF02021C4FEF50 sha1 12C5CCBBB9744226517E6EECFBA0FF103E83B905 flags verified )
-	rom ( name "WCW-nWo Revenge (E) [!].z64" size 16777216 crc 8AF0F964 md5 30C6676EC1D62122F4E7607EF3ABBD41 sha1 C59315A3E7A6E8124495477656A77E4619DAC104 )
 )
 
 game (
 	name "WCW-nWo Revenge (USA)"
 	description "WCW-nWo Revenge (USA)"
 	rom ( name "WCW-nWo Revenge (USA).n64" size 16777216 crc 2257FD02 md5 E3635E2F657ECCA2B00714034F5A6330 sha1 EF6CD4DF563C3DBBF8E7AFD890A6C4A3E0704FF6 flags verified )
-	rom ( name "WCW-nWo Revenge (U) [!].z64" size 16777216 crc 54CBAAA8 md5 C1384F3637D7A381B29341FED3EF3CEB sha1 E1711A2511394B9357B5F1AC8CA5CC17BD674836 )
 )
 
 game (
 	name "Wetrix (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Wetrix (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Wetrix (Europe) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc E26CFF31 md5 185812A68E64C7FED30842C7082A9ADB sha1 8967CD465FBCC1151F8794F0C58181DA1040C2EC flags verified )
-	rom ( name "Wetrix (E) (M6) [!].z64" size 8388608 crc EDDC5B06 md5 A99E2CB6ACEF7A004961DE5F6DFEEFF0 sha1 4CC1B6E3AA150CD79093F21E3FBE91A72FB86AD6 )
 )
 
 game (
 	name "Wetrix (Japan)"
 	description "Wetrix (Japan)"
 	rom ( name "Wetrix (Japan).n64" size 4194304 crc AEBAFD6D md5 18A3AAC38AAE52CFE1A38F75FCFF6963 sha1 A8D2970EB0313BDF925BE994F04508373715F771 flags verified )
-	rom ( name "Wetrix (J) [!].z64" size 4194304 crc BAD08218 md5 E8997BF5662540B184FBF8277D260984 sha1 1B1635546CB973EBAA0A4A0940A363EC2C074053 )
 )
 
 game (
 	name "Wetrix (USA) (En,Fr,De,Es,It,Nl)"
 	description "Wetrix (USA) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Wetrix (USA) (En,Fr,De,Es,It,Nl).n64" size 8388608 crc 4EDA94C1 md5 B0DF900CD2B612F23CE81E1AB28DABA2 sha1 80CC6C54CC9517A33E90CCF0CC9F2C03D1F050AD )
-	rom ( name "Wetrix (U) (M6) [!].z64" size 8388608 crc 50CD1F71 md5 6E81D3056E409208E4AF2D39A2FF0F03 sha1 6E40312CF88A9182E93B396B9D82457B1ABA7CD6 )
 )
 
 game (
 	name "Wheel of Fortune (USA)"
 	description "Wheel of Fortune (USA)"
 	rom ( name "Wheel of Fortune (USA).n64" size 4194304 crc C2571693 md5 6F3C444A52BBEB79664518DF389D5BD7 sha1 A40D8DAE6BFE2C0ABDF1FD6B1EB219F4DA988BD2 )
-	rom ( name "Wheel of Fortune (U) [!].z64" size 4194304 crc 8D3EFA8D md5 2ABE36754E866B9B6C4BDCFFC1D11ABF sha1 B51B28660699BF029F862F51C319A5962FE9DE9B )
 )
 
 game (
 	name "Wild Choppers (Japan)"
 	description "Wild Choppers (Japan)"
 	rom ( name "Wild Choppers (Japan).n64" size 8388608 crc FED21F49 md5 5BA61B7BC73E515F579A6A42DF21C8E2 sha1 E9794038F75DDADD6F57B0981B4E077766DCCA3E flags verified )
-	rom ( name "Wild Choppers (J) [!].z64" size 8388608 crc D6136DC5 md5 F85F2A2B6CA64898F0ADD2A78CCDCCF3 sha1 9ED151FCE580F875F09CB250D2BB9C18C8D549C0 )
 )
 
 game (
@@ -6310,7 +5518,6 @@ game (
 	name "WinBack (Japan)"
 	description "WinBack (Japan)"
 	rom ( name "WinBack (Japan).n64" size 16777216 crc A5364D80 md5 6AB34E12639A776D5060B934AFFF2BBD sha1 E66E96813BB9A7D4E9C6B4FF39695ADCC10B7ED5 flags verified )
-	rom ( name "WinBack (J) [!].z64" size 16777216 crc D35360B0 md5 EE3D3550ACC463CA57408BF14E541F68 sha1 D6DB9E2509B760403F5DB330142055AF842FB52C )
 )
 
 game (
@@ -6323,14 +5530,12 @@ game (
 	name "WinBack - Covert Operations (USA)"
 	description "WinBack - Covert Operations (USA)"
 	rom ( name "WinBack - Covert Operations (USA).n64" size 16777216 crc 1A6334D0 md5 3CDDD6598405CE272E14BACE45F082B5 sha1 B0FAFA4570B27F42428DFFA3BAC2BA582B99FE21 )
-	rom ( name "WinBack - Covert Operations (U) [!].z64" size 16777216 crc 64C817C5 md5 48DA6CDCAB838153CAA2ECC3DD592A65 sha1 FA04477B321A95E1F7A2EDCAC5C09BFA6EF72041 )
 )
 
 game (
 	name "Wipeout 64 (Europe)"
 	description "Wipeout 64 (Europe)"
 	rom ( name "Wipeout 64 (Europe).n64" size 8388608 crc 0C3497E4 md5 58263168B3363AE6AD715EEE2E2DA4F0 sha1 CCAB769B06290671ADBC81B09440049B487ADBAB flags verified )
-	rom ( name "Wipeout 64 (E) [!].z64" size 8388608 crc 38111048 md5 5783373634B11F81C86908C3D81CA988 sha1 3EEF8EC7D0009EE67D604AACA2BB61B7397BA862 )
 )
 
 game (
@@ -6344,42 +5549,36 @@ game (
 	name "Wonder Project J2 - Koruro no Mori no Jozet (Japan)"
 	description "Wonder Project J2 - Koruro no Mori no Jozet (Japan)"
 	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).n64" size 8388608 crc 8AAF74A3 md5 A91C568F04CDA76B70DF6EEDF051F82E sha1 585B62B5CA10A5E296A7DD0065DCCB91BB620ED2 flags verified )
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!].z64" size 8388608 crc 5E8FC436 md5 0FF1F8628D8FE69582DB54572D2BEA79 sha1 3A311EC0D77D4E0FC425A99CB6B9416F072E268E )
 )
 
 game (
 	name "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	description "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	rom ( name "World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).n64" size 12582912 crc 163481D0 md5 C10FABD6404A7AEF3516DBEEE1DD57E3 sha1 5E115692C924CCD0CA6AFA4C4777077F97A7D9C2 flags verified )
-	rom ( name "World Cup 98 (E) (M8) [!].z64" size 12582912 crc 79F483F7 md5 3AA263ACA66F3A07BB081B575D66DEEB sha1 CD92B2CBB253411FC66544649567D9B1C44BB210 )
 )
 
 game (
 	name "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	description "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
 	rom ( name "World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).n64" size 12582912 crc B875CD94 md5 197399A234FF807C2B0A69061D719C47 sha1 8ECA8B866A0F746E9BD7A6FC1B8DFF6BD7B2F210 )
-	rom ( name "World Cup 98 (U) (M8) [!].z64" size 12582912 crc 13930C26 md5 4BEF5E9AA9E71205DAC1A7060E778235 sha1 B496EDEE84E5E84EAD8DA6F57A765936B2AF2F9F )
 )
 
 game (
 	name "World Driver Championship (Europe) (En,Fr,De,Es,It)"
 	description "World Driver Championship (Europe) (En,Fr,De,Es,It)"
 	rom ( name "World Driver Championship (Europe) (En,Fr,De,Es,It).n64" size 16777216 crc 74FAD5AA md5 EA7663CC3BBF0FFBA3671F8357515163 sha1 DBE027955669E25E6CECAFA6E07BED9890C8995C flags verified )
-	rom ( name "World Driver Championship (E) (M5) [!].z64" size 16777216 crc 76151DF6 md5 431DE8F6611A8131B536F0EDE1F330D9 sha1 7B054D1580CC263429EB6961AD6ED6E0140E1DF0 )
 )
 
 game (
 	name "World Driver Championship (USA)"
 	description "World Driver Championship (USA)"
 	rom ( name "World Driver Championship (USA).n64" size 16777216 crc DCD9D2D2 md5 19831C89B9033F7BCFD0C7106E3C3EC6 sha1 B5A329E477FEBC75A0B73A7466C48BBFD1320BFF )
-	rom ( name "World Driver Championship (U) [!].z64" size 16777216 crc 5E4ACBFA md5 7C567A5BB1AD4CBE414FB6BBFF66E336 sha1 93227776F59B42E9FB1C942EBA9D5B465EEB3979 )
 )
 
 game (
 	name "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).n64" size 12582912 crc 4862EBBD md5 4CED4F06943551F53EECB3D71324EB24 sha1 EC23BB5489C76933EFF1A2BA17658C7EBD116328 flags verified )
-	rom ( name "Worms - Armageddon (E) (M6) [!].z64" size 12582912 crc 6BFFF27B md5 44FC2A7F028F0B6F71B255F672C8B495 sha1 34042046E3CFA44723C32F6D366052483EDB80D7 )
 )
 
 game (
@@ -6393,98 +5592,84 @@ game (
 	name "WWF Attitude (Europe)"
 	description "WWF Attitude (Europe)"
 	rom ( name "WWF Attitude (Europe).n64" size 33554432 crc 69CF2FE6 md5 16479D2A012C09B64255F303ED5119AC sha1 4135D3346BE4EB657C6779CE7B2CA89D5D94A0DB flags verified )
-	rom ( name "WWF Attitude (E) [!].z64" size 33554432 crc 804FE494 md5 3FDB2E5F9982FDA2C2344A883B8AB6EF sha1 880D3AACAE0B3792235404DECD294AFDAD51A0A6 )
 )
 
 game (
 	name "WWF Attitude (Germany)"
 	description "WWF Attitude (Germany)"
 	rom ( name "WWF Attitude (Germany).n64" size 33554432 crc F1F22E20 md5 B1BFBECAC6B92145DCFA98ADF34B4BDC sha1 53FC14DFC7CCBB4498AECB2D0DBCB3BB1A569B0A )
-	rom ( name "WWF Attitude (G) [!].z64" size 33554432 crc EA5D8359 md5 B86EC8D19D7D1A50EA900EA10355A735 sha1 40C2C6309589755C4CFDBF3E4E39B3788820B199 )
 )
 
 game (
 	name "WWF Attitude (USA)"
 	description "WWF Attitude (USA)"
 	rom ( name "WWF Attitude (USA).n64" size 33554432 crc F694DB1E md5 71EE30C9BC45E33089226B02B23EEE7A sha1 9519C9A7E9F370E565545FA5F5A21077F585310B )
-	rom ( name "WWF Attitude (U) [!].z64" size 33554432 crc 7A4B3686 md5 9FAF514CB3DBB742C129DEB395DCA342 sha1 259973EB0BA1D01F1A5FBF3039ED511E6B705F26 )
 )
 
 game (
 	name "WWF No Mercy (Europe)"
 	description "WWF No Mercy (Europe)"
 	rom ( name "WWF No Mercy (Europe).n64" size 33554432 crc EEB166B4 md5 F58F64A8AD952459B2EE37F07004272B sha1 CADBCD5361DFFAF2AA17F0CB4C4CC799BDC8350A )
-	rom ( name "WWF No Mercy (E) (V1.0) [!].z64" size 33554432 crc B79BDDD8 md5 C9A6446918DA5D65612C521D432B7DA1 sha1 3AF3190DE8E687D2899EE5EA7CDD58A3B6F34953 )
 )
 
 game (
 	name "WWF No Mercy (Europe) (Rev A)"
 	description "WWF No Mercy (Europe) (Rev A)"
 	rom ( name "WWF No Mercy (Europe) (Rev A).n64" size 33554432 crc 1A6F82E4 md5 685BA168AF8B7D4A9D31B17A1B432405 sha1 F49217CB9039212D2D779ACB00222FB73C454F56 flags verified )
-	rom ( name "WWF No Mercy (E) (V1.1) [!].z64" size 33554432 crc 43BA9E7E md5 400A14F132D993F5544F8B008EC136FA sha1 CC8B9863C0E96D1B6A611D6AC2238E38B247EA5D )
 )
 
 game (
 	name "WWF No Mercy (USA)"
 	description "WWF No Mercy (USA)"
 	rom ( name "WWF No Mercy (USA).n64" size 33554432 crc EE8C16C1 md5 6B698F27E29366B68DC518976BA844A6 sha1 3A902129BD2221C4411D05C642EF7F79AEFB1720 )
-	rom ( name "WWF No Mercy (U) (V1.0) [!].z64" size 33554432 crc B33F44F0 md5 04C492BE7F89FC6F425238BD67629544 sha1 3566D9B5723291937582453AD0453CE517CFC358 )
 )
 
 game (
 	name "WWF No Mercy (USA) (Rev A)"
 	description "WWF No Mercy (USA) (Rev A)"
 	rom ( name "WWF No Mercy (USA) (Rev A).n64" size 33554432 crc AFBC514E md5 761D5C8FB24CAF5F44613ACD5C9AD4B2 sha1 159ECD53E5FD9B0F607CB39042057F55F07D18A6 )
-	rom ( name "WWF No Mercy (U) (V1.1) [!].z64" size 33554432 crc BACEEA13 md5 66B8EC24557A50514A814F15429BD559 sha1 91CEE3D096F4A76644D8B35B9AEAD6448909ABD1 )
 )
 
 game (
 	name "WWF War Zone (Europe)"
 	description "WWF War Zone (Europe)"
 	rom ( name "WWF War Zone (Europe).n64" size 12582912 crc 58062C02 md5 2A89A8ED317F092687E4481D8A982185 sha1 4685430FBC7BB719EA2A277C4EB8616011925546 flags verified )
-	rom ( name "WWF - War Zone (E) [!].z64" size 12582912 crc 90A0B609 md5 EBC0CF55FC58845C6EE86CF8B2D87303 sha1 808A8997AA8D717AAC2A9A0C476B901338AC626E )
 )
 
 game (
 	name "WWF War Zone (USA)"
 	description "WWF War Zone (USA)"
 	rom ( name "WWF War Zone (USA).n64" size 12582912 crc 6CFE13A8 md5 0A8F9866320695A5032B946E6E4E6DA9 sha1 852A6D39FC61C82BF13E852978924F8C7DB8D039 )
-	rom ( name "WWF - War Zone (U) [!].z64" size 12582912 crc 2FBB5507 md5 2322DA2B9E7DC74678CD683B7A246B49 sha1 8700F89CD7CFA873452117F6B2A648D32796111C )
 )
 
 game (
 	name "WWF WrestleMania 2000 (Europe)"
 	description "WWF WrestleMania 2000 (Europe)"
 	rom ( name "WWF WrestleMania 2000 (Europe).n64" size 33554432 crc ACB7BA1B md5 02BCB985BF7E169DF502E2667BD64CAB sha1 A5923994A65FFD425ED094FB9FF8CCAFD5ABC10A flags verified )
-	rom ( name "WWF WrestleMania 2000 (E) [!].z64" size 33554432 crc 09D710C7 md5 B75149F87CC5F3A508643AC377F2FCC9 sha1 D37C4100D967CB8B71852993B947619467FFCAF7 )
 )
 
 game (
 	name "WWF WrestleMania 2000 (Japan)"
 	description "WWF WrestleMania 2000 (Japan)"
 	rom ( name "WWF WrestleMania 2000 (Japan).n64" size 33554432 crc E4E3B9A3 md5 F751FE0E25CF396CE883B61149E03C87 sha1 4128E150BC7E1291A3D388A210A50BD423E5D3E2 flags verified )
-	rom ( name "WWF WrestleMania 2000 (J) [!].z64" size 33554432 crc C2034D24 md5 11EEE2F34BF8DA05A1B8F4FB9FE9F74C sha1 E020C26DEDE0C349181CF08A3541816DC47F63A8 )
 )
 
 game (
 	name "WWF WrestleMania 2000 (USA)"
 	description "WWF WrestleMania 2000 (USA)"
 	rom ( name "WWF WrestleMania 2000 (USA).n64" size 33554432 crc D514E83C md5 20AB9371EAA3BAB3E3ED169A7F9A59D1 sha1 D8CF547EB81C72C748BE87B6CE6B2F66C2699BD0 )
-	rom ( name "WWF WrestleMania 2000 (U) [!].z64" size 33554432 crc 0B50B4C6 md5 D9030CA30E4D1AF805ACCE1BFED988CC sha1 442D417A52ED672CA1A47E7261A5414DEBB1E27A )
 )
 
 game (
 	name "Xena - Warrior Princess - The Talisman of Fate (Europe)"
 	description "Xena - Warrior Princess - The Talisman of Fate (Europe)"
 	rom ( name "Xena - Warrior Princess - The Talisman of Fate (Europe).n64" size 12582912 crc 2BB18EB6 md5 262276343CA48F34007E2FA0701A4FAD sha1 B900A33736F7AB68648D274B76BBD4A8F6E4AF33 flags verified )
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (E) [!].z64" size 12582912 crc D3932F88 md5 EC2BCB1B7FC7D068BE1F39E79E49A842 sha1 2FA884F36BD370D844ED1E57C4357510584FE3E2 )
 )
 
 game (
 	name "Xena - Warrior Princess - The Talisman of Fate (USA)"
 	description "Xena - Warrior Princess - The Talisman of Fate (USA)"
 	rom ( name "Xena - Warrior Princess - The Talisman of Fate (USA).n64" size 12582912 crc 7CB26725 md5 2C503835FD4CF83BDBCDEF0564D995D7 sha1 91A1E7C709D7CD8065C38CD23910D19C5BF991E1 )
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [!].z64" size 12582912 crc 7DA93999 md5 1AC234649D28F09E82C0D11ABB17F03B sha1 E3316269B8466FE1FB968AC9338E6ACDC0379970 )
 )
 
 game (
@@ -6497,21 +5682,18 @@ game (
 	name "Yakouchuu II - Satsujin Kouro (Japan)"
 	description "Yakouchuu II - Satsujin Kouro (Japan)"
 	rom ( name "Yakouchuu II - Satsujin Kouro (Japan).n64" size 33554432 crc 5C97C412 md5 8EBB08A30E9E1800ABEA767E20C9A505 sha1 E4035072F682FE16E189E57BF6A9A35706D3028A flags verified )
-	rom ( name "Yakouchuu II - Satsujin Kouru (J) [!].z64" size 33554432 crc 4538C41A md5 E24942948F7140EE4260268DB763D0FD sha1 09929CA361D47FB9FC0EB4077CF1FB77CB843CEF )
 )
 
 game (
 	name "Yoshi Story (Japan)"
 	description "Yoshi Story (Japan)"
 	rom ( name "Yoshi Story (Japan).n64" size 16777216 crc FEAC925C md5 C14F873AB510F8FB47B7021FAAAB2CFE sha1 325A1487C4BE295837728DBE7809A31823AD2554 flags verified )
-	rom ( name "Yoshi Story (J) [!].z64" size 16777216 crc 4F44A9EF md5 DD8A0E5472F13EA87B176F0155FA0C66 sha1 FF320B4122894C773F465A8996E82A00F3116E83 )
 )
 
 game (
 	name "Yoshi's Story (Europe) (En,Fr,De)"
 	description "Yoshi's Story (Europe) (En,Fr,De)"
 	rom ( name "Yoshi's Story (Europe) (En,Fr,De).n64" size 16777216 crc 21A5F264 md5 6BF066BFAC815FCA8179280ABA469554 sha1 0A480425BAECC4D4FD236275384D9EE67285E8FD flags verified )
-	rom ( name "Yoshi's Story (E) (M3) [!].z64" size 16777216 crc F9FFC760 md5 2524E5FB8ED4BB8C831C5AC057E8F344 sha1 5B56EC1DA78456F968129BADDC1F233E1FB4F4F3 )
 )
 
 game (
@@ -6525,71 +5707,40 @@ game (
 	name "Yuke Yuke!! Trouble Makers (Japan)"
 	description "Yuke Yuke!! Trouble Makers (Japan)"
 	rom ( name "Yuke Yuke!! Trouble Makers (Japan).n64" size 8388608 crc F8BB860C md5 B94FD249C7AA4336DBD92483E43FBA9A sha1 6807EBE5F95C30BAEE18F5DA6C170396D6B8764E flags verified )
-	rom ( name "Yuke Yuke!! Trouble Makers (J) [!].z64" size 8388608 crc B69D3068 md5 2AE35BDF163613024D876A09F25063F3 sha1 039A75636C34D219D489D0A84A671D00DC23E7C4 )
 )
 
 game (
 	name "Zelda no Densetsu - Mujura no Kamen (Japan)"
 	description "Zelda no Densetsu - Mujura no Kamen (Japan)"
 	rom ( name "Zelda no Densetsu - Mujura no Kamen (Japan).n64" size 33554432 crc 3361B649 md5 44DBDE0232B67654B3A4251D599CC713 sha1 9AFDA65B3AE7D3714066DBCCF820158C3286F423 flags verified )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!].z64" size 33554432 crc 0D33E1DB md5 15D1A2217CAD61C39CFECBFFA0703E25 sha1 5FB2301AACBF85278AF30DCA3E4194AD48599E36 )
 )
 
 game (
 	name "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A)"
 	description "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A)"
 	rom ( name "Zelda no Densetsu - Mujura no Kamen (Japan) (Rev A).n64" size 33554432 crc 2DE56C55 md5 130A7217F9BAAECD2F7CEB4BACC018E4 sha1 666FAD106735135C1A3471EF1B967C396F949AD9 flags verified )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!].z64" size 33554432 crc 356C2E19 md5 C38A7F6F6B61862EA383A75CDF888279 sha1 41FDB879AB422EC158B4EAFEA69087F255EA8589 )
-)
-
-game (
-	name "Zelda no Densetsu - Mujura no Kamen (Japan) (GC)"
-	description "Zelda no Densetsu - Mujura no Kamen (Japan) (GC)"
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!].z64" size 33554432 crc B9BF76DF md5 D3929AADF7640F8C5B4CE8321AD4393A sha1 1438FD501E3E5B25461770AF88C02AB1E41D3A7E )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan).n64" size 33554432 crc B58E98BB md5 7D44B555E0AF3EEC36319B5E76E31B0C sha1 F9E2B6840B9103E9707EA390089A7B6943592A98 flags verified )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!].z64" size 33554432 crc D423E8B0 md5 9F04C8E68534B870F707C247FA4B50FC sha1 C892BBDA3993E66BD0D56A10ECD30B1EE612210F )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev A).n64" size 33554432 crc F31C202C md5 DAF387C5BC73D4EAAE2DC781AE1B5ADA sha1 1181034D5F9533F53EBE8E1C781BADBEE115F5AA flags verified )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!].z64" size 33554432 crc 26E73887 md5 1BF5F42B98C3E97948F01155F12E2D88 sha1 DBFC81F655187DC6FEFD93FA6798FACE770D579D )
 )
 
 game (
 	name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B)"
 	description "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B)"
 	rom ( name "Zelda no Densetsu - Toki no Ocarina (Japan) (Rev B).n64" size 33554432 crc 656657CD md5 CD8B202E87C28060D29A1A52234C87FD sha1 2D8FB7140A9C5D11CE614561E5A36FFEF0C17540 flags verified )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!].z64" size 33554432 crc 2B2721BA md5 2258052847BDD056C8406A9EF6427F13 sha1 FA5F5942B27480D60243C2D52C0E93E26B9E6B86 )
-)
-
-game (
-	name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (Japan) (GC)"
-	description "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (Japan) (GC)"
-	rom ( name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!].z64" size 33554432 crc 8C5B90C1 md5 0C13E0449A28EA5B925CDB8AF8D29768 sha1 2CE2D1A9F0534C9CD9FA04EA5317B80DA21E5E73 )
-)
-
-game (
-	name "Zelda no Densetsu - Toki no Ocarina GC (Japan) (GC)"
-	description "Zelda no Densetsu - Toki no Ocarina GC (Japan) (GC)"
-	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!].z64" size 33554432 crc 1C6CE8CB md5 33FB7852C180B18EA0B9620B630F413F sha1 0769C84615422D60F16925CD859593CDFA597F84 )
-)
-
-game (
-	name "Zelda no Densetsu - Toki no Ocarina GC URA (Japan) (GC)"
-	description "Zelda no Densetsu - Toki no Ocarina GC URA (Japan) (GC)"
-	rom ( name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!].z64" size 33554432 crc 122FF261 md5 69895C5C78442260F6EAFB2506DC482A sha1 DD14E143C4275861FE93EA79D0C02E36AE8C6C2F )
 )
 
 game (
 	name "Zool - Majuu Tsukai Densetsu (Japan)"
 	description "Zool - Majuu Tsukai Densetsu (Japan)"
 	rom ( name "Zool - Majuu Tsukai Densetsu (Japan).n64" size 12582912 crc 84428431 md5 9795074EF3192F49ADE9ABC9F0BF71D0 sha1 DEF9F1D097CEF5857449827AE2B1291BA346C2A8 flags verified )
-	rom ( name "Zool - Majou Tsukai Densetsu (J) [!].z64" size 12582912 crc 756BA26D md5 692A33B0D7456FC733A81AB83C20382B sha1 2D6EFDB155F6726478AD255E76220A95B559BE40 )
 )

--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -2743,7 +2743,7 @@ game (
 game (
 	name "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
 	description "Legend of Zelda, The - Majora's Mask (USA) (Demo)"
-	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo).n64" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (Demo)" size 33554432 crc F97C02CE md5 A412A010E0FCE74EFBA8FE90716B4DA2 sha1 99D8B0E3000DCEAF494EA18941D7C31E796BFC78 )
 	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc DCC110A0 md5 8F281800FBA5DDCB1D2B377731FC0215 sha1 2F0744F2422B0421697A74B305CB1EF27041AB11 )
 )
 

--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -21,7 +21,6 @@ game (
 	name "007 - GoldenEye (USA)"
 	description "007 - GoldenEye (USA)"
 	rom ( name "007 - GoldenEye (USA).n64" size 12582912 crc 8B70CB5B md5 2A56A06A05A9DBF9E693325B503AB5B1 sha1 7DD376E996D77D108316AC7CED087125C5674FA4 )
-	rom ( name "GoldenEye 007 (U) [!].z64" size 12582912 crc B6330846 md5 70C525880240C1E838B8B1BE35666C3B sha1 ABE01E4AEB033B6C0836819F549C791B26CFDE83 )
 )
 
 game (
@@ -34,7 +33,6 @@ game (
 	name "007 - The World Is Not Enough (USA)"
 	description "007 - The World Is Not Enough (USA)"
 	rom ( name "007 - The World Is Not Enough (USA).n64" size 33554432 crc 34F0EE5B md5 2B1594E9B9F1EC0105C5ADABE3C024CE sha1 E93005466AC84BC1D19B40673D0C50B604A8753C )
-	rom ( name "007 - The World is Not Enough (U) [!].z64" size 33554432 crc 26360987 md5 9D58996A8AA91263B5CD45C385F45FE4 sha1 D347159808F0374A93CF44CFB6135D8F56279F7B )
 )
 
 game (
@@ -335,7 +333,6 @@ game (
 	name "Banjo-Kazooie (USA) (Rev A)"
 	description "Banjo-Kazooie (USA) (Rev A)"
 	rom ( name "Banjo-Kazooie (USA) (Rev A).n64" size 16777216 crc 90B38651 md5 767D015DB4CE450D5F0C55276EAB1CA4 sha1 93C5CFAC5CCA89E54C0F1D076625E2A4570994FD )
-	rom ( name "Banjo-Kazooie (U) (V1.1) [!].z64" size 16777216 crc FB7FFB10 md5 B11F476D4BC8E039355241E871DC08CF sha1 DED6EE166E740AD1BC810FD678A84B48E245AB80 )
 )
 
 game (
@@ -354,7 +351,6 @@ game (
 	name "Banjo-Tooie (USA)"
 	description "Banjo-Tooie (USA)"
 	rom ( name "Banjo-Tooie (USA).n64" size 33554432 crc 0E0DC5A5 md5 CA0DF738AE6A16BFB4B46D3860C159D9 sha1 139051AB7312FD5E1314BA6BAF7D424EA5987EAC )
-	rom ( name "Banjo-Tooie (U) [!].z64" size 33554432 crc BAB803EF md5 40E98FAA24AC3EBE1D25CB5E5DDF49E4 sha1 AF1A89E12B638B8D82CC4C085C8E01D4CBA03FB3 )
 )
 
 game (
@@ -373,7 +369,6 @@ game (
 	name "Batman Beyond - Return of the Joker (USA)"
 	description "Batman Beyond - Return of the Joker (USA)"
 	rom ( name "Batman Beyond - Return of the Joker (USA).n64" size 4194304 crc D64E0A7B md5 AD242C47475D1B14EC2A29201B52A9F1 sha1 A67CEF8A1F06CE201E0486AD2B9507314398799F )
-	rom ( name "Batman Beyond - Return of the Joker (U) [!].z64" size 4194304 crc 35299F9C md5 A08676124B326B1035B202C83A97468F sha1 F7382358250965E9757BA9A89FE42D033DBE7FE8 )
 )
 
 game (
@@ -386,7 +381,6 @@ game (
 	name "BattleTanx (USA)"
 	description "BattleTanx (USA)"
 	rom ( name "BattleTanx (USA).n64" size 8388608 crc 66123C8B md5 E4F24EF9B43259BAD0A1BF235745D81E sha1 1DACED29439E8F2605349E9F453E90155FEA46F4 )
-	rom ( name "BattleTanx (U) [!].z64" size 8388608 crc 6C230765 md5 3406A505C22BAC2F40D9BFC6FF08CF86 sha1 535860D941738AC1210C20A9B80114FEA0E0FF17 )
 )
 
 game (
@@ -399,7 +393,6 @@ game (
 	name "BattleTanx - Global Assault (USA)"
 	description "BattleTanx - Global Assault (USA)"
 	rom ( name "BattleTanx - Global Assault (USA).n64" size 8388608 crc 5819D423 md5 88DA33CA04EF2D936F0C1B73248B71AA sha1 08A9037488C47D1E26CE6F709955639E9F0F0BB8 )
-	rom ( name "BattleTanx - Global Assault (U) [!].z64" size 8388608 crc 31BEB053 md5 654557C316F901A2CA6F7F4B43343147 sha1 805248FB0A0EE694CAD8D7DC927B631D860DD8CF )
 )
 
 game (
@@ -466,7 +459,6 @@ game (
 	name "Blast Corps (USA) (Rev A)"
 	description "Blast Corps (USA) (Rev A)"
 	rom ( name "Blast Corps (USA) (Rev A).n64" size 8388608 crc 23D415F8 md5 FD169651B23B5424C2D4CB5D9AF81FC3 sha1 80E5365BD5EE8388E38A04B23BF3DB9B5E4BF06B )
-	rom ( name "Blast Corps (U) (V1.1) [!].z64" size 8388608 crc 9CBBCCF1 md5 5875FC73069077C93E214233B60F0BDC sha1 483F7161AEA39DE8B45C9FBC70A2C3883C4DEA8C )
 )
 
 game (
@@ -497,7 +489,6 @@ game (
 	name "Body Harvest (USA)"
 	description "Body Harvest (USA)"
 	rom ( name "Body Harvest (USA).n64" size 12582912 crc 7B878C56 md5 20113A1AC62660F507B00E541A3AC584 sha1 F61C30BC6FEAAC9700578A865D552AE42079B0E5 )
-	rom ( name "Body Harvest (U) [!].z64" size 12582912 crc FABBDF02 md5 3B8585ED03E8DDB89D7DE456317545E7 sha1 BBB6666F5014A473747EE4145F036D9FB25D7348 )
 )
 
 game (
@@ -540,14 +531,12 @@ game (
 	name "Bomberman 64 (USA)"
 	description "Bomberman 64 (USA)"
 	rom ( name "Bomberman 64 (USA).n64" size 8388608 crc 50A98BDF md5 E52CE4AB747FF37663E93E5C322BE9D2 sha1 DF52CAEA78CC786F896CB14E532088EC9CA6BEA6 )
-	rom ( name "Bomberman 64 (U) [!].z64" size 8388608 crc 3ED0E0DC md5 093058ECE14C8CC1A887B2087EB5CFE9 sha1 8A7648D8105AC4FC1AD942291B2EF89AECA921C9 )
 )
 
 game (
 	name "Bomberman 64 - The Second Attack! (USA)"
 	description "Bomberman 64 - The Second Attack! (USA)"
 	rom ( name "Bomberman 64 - The Second Attack! (USA).n64" size 16777216 crc 302B3135 md5 CB7F9FAD147F0ADB63A79EDC57237219 sha1 5C2C59506AA4DFD83CE80E9E5E377F64F4F18C58 )
-	rom ( name "Bomberman 64 - The Second Attack! (U) [!].z64" size 16777216 crc 57550007 md5 AEC1FDB0F1CAAD86C9F457989A4CE482 sha1 66B1FD763793ECC6E03AA6C5D023DF8DE5351B9E )
 )
 
 game (
@@ -560,7 +549,6 @@ game (
 	name "Bomberman Hero (USA)"
 	description "Bomberman Hero (USA)"
 	rom ( name "Bomberman Hero (USA).n64" size 12582912 crc 3E73AF1A md5 F59261E74B9466AC9F8A2A709CFAE8B7 sha1 F4377BD43DE34CC61E59CA5167109D4D6123272A )
-	rom ( name "Bomberman Hero (U) [!].z64" size 12582912 crc 2CC2E634 md5 EF2453BFF7AD0C4BFA9AB0BD6324EBF3 sha1 A36364B7E59351F7551AB351CB3B41EBC4BE285B )
 )
 
 game (
@@ -621,7 +609,6 @@ game (
 	name "Bug's Life, A (USA)"
 	description "Bug's Life, A (USA)"
 	rom ( name "Bug's Life, A (USA).n64" size 12582912 crc 7C2F610D md5 F4EB001D85F6D3229069CB82B8D3495F sha1 E30E1B6BDCFD985B000757A8E611A419D1F38233 )
-	rom ( name "Bug's Life, A (U) [!].z64" size 12582912 crc CF2EA0B6 md5 7FD6BFFB80F920E01EF869829D485EA3 sha1 697C1E895FC840826FCB6A6F37411A2AF6D6F47C )
 )
 
 game (
@@ -676,7 +663,6 @@ game (
 	name "Carmageddon 64 (USA)"
 	description "Carmageddon 64 (USA)"
 	rom ( name "Carmageddon 64 (USA).n64" size 16777216 crc E78DEBB6 md5 0B3C3A0940B9034ECF84A8DB19B25200 sha1 AB3A1A52754FED3DEA98E587FB9CC4CD64973403 )
-	rom ( name "Carmageddon 64 (U) [!].z64" size 16777216 crc 10C6A0A1 md5 31BB57C1FAD0D47DC2353C1950B11886 sha1 DC7495093FB9A668B0C851B87C037A4CDF2DDC65 )
 )
 
 game (
@@ -695,7 +681,6 @@ game (
 	name "Castlevania (USA) (Rev B)"
 	description "Castlevania (USA) (Rev B)"
 	rom ( name "Castlevania (USA) (Rev B).n64" size 12582912 crc 7F50E637 md5 609B7B72221EE6DC3E25E419752AEDCE sha1 C99A25022CC019CA8D3DD6B58552049B0EE0718C )
-	rom ( name "Castlevania (U) (V1.2) [!].z64" size 12582912 crc 83032D97 md5 06B58673F7D31C56F8FE8186E86F6BD6 sha1 BA23D0FB480B9885F0D847F7F3D67B249177C8C4 )
 )
 
 game (
@@ -714,7 +699,6 @@ game (
 	name "Castlevania - Legacy of Darkness (USA)"
 	description "Castlevania - Legacy of Darkness (USA)"
 	rom ( name "Castlevania - Legacy of Darkness (USA).n64" size 16777216 crc 1F147376 md5 8A1729B7EF9BF63375194109C07BC41F sha1 AB24FEAE782703886EE61069B930A2713B398C6D )
-	rom ( name "Castlevania - Legacy of Darkness (U) [!].z64" size 16777216 crc AB13028C md5 25258460F98F567497B24844ABE3A05B sha1 879EAD98F197FD05EDDA867655DA5B1CE25AA5B8 )
 )
 
 game (
@@ -829,7 +813,6 @@ game (
 	name "Clay Fighter - Sculptor's Cut (USA)"
 	description "Clay Fighter - Sculptor's Cut (USA)"
 	rom ( name "Clay Fighter - Sculptor's Cut (USA).n64" size 16777216 crc F59FD73E md5 B0D4356AD7C988B8D6F257BF039FAF50 sha1 99CC2FE3C4F7E8DF185FECA570281364BAB987C6 )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [!].z64" size 16777216 crc 434DE656 md5 30E7E083B978408D5B7760D0CE4DC61D sha1 28697FBA130DED056BF7C497DEAA3E154CCE8022 )
 )
 
 game (
@@ -842,7 +825,6 @@ game (
 	name "Clay Fighter 63 1-3 (USA)"
 	description "Clay Fighter 63 1-3 (USA)"
 	rom ( name "Clay Fighter 63 1-3 (USA).n64" size 12582912 crc E7C70F25 md5 8FF24347D96B0F1BDC755E864E8DBA91 sha1 475E41F3E2AC43892657146170FD223D5D6557A9 flags verified )
-	rom ( name "Clay Fighter 63 1-3 (U) [!].z64" size 12582912 crc 3FA647DD md5 3207BF22E305C488109B09A03706F36F sha1 036873AB0D3107B2D9B3225A180F67DAF0899365 )
 )
 
 game (
@@ -867,7 +849,6 @@ game (
 	name "Command & Conquer (USA)"
 	description "Command & Conquer (USA)"
 	rom ( name "Command & Conquer (USA).n64" size 33554432 crc 8D23BA95 md5 D822DDE8CAFAD279C3EA27C22BEAEFEC sha1 63BAFA4615EB7488AEC3C631021720E05376AA1C )
-	rom ( name "Command & Conquer (U) [!].z64" size 33554432 crc 3E9069EF md5 B436F4717AC585B0D847756468FD6393 sha1 B559E86D98DE598B1D25583CA082FAA4B7C62641 )
 )
 
 game (
@@ -880,7 +861,6 @@ game (
 	name "Conker's Bad Fur Day (USA)"
 	description "Conker's Bad Fur Day (USA)"
 	rom ( name "Conker's Bad Fur Day (USA).n64" size 67108864 crc 6ACDB3FC md5 220543F489A9828021EA82A69E6305A3 sha1 27D3123DD4A3D84CB1A7ECF2CED3BC44389F4607 )
-	rom ( name "Conker's Bad Fur Day (U) [!].z64" size 67108864 crc CE8CC172 md5 00E2920665F2329B95797A7EAABC2390 sha1 4CBADD3C4E0729DEC46AF64AD018050EADA4F47A )
 )
 
 game (
@@ -971,14 +951,12 @@ game (
 	name "Dark Rift (USA)"
 	description "Dark Rift (USA)"
 	rom ( name "Dark Rift (USA).n64" size 8388608 crc 2AFAB93C md5 A524D85ECD2C9C239F10439A95A79467 sha1 8E7EC39E0F4B0A1351CF15F12AD5E5AFA337F5F4 )
-	rom ( name "Dark Rift (U) [!].z64" size 8388608 crc 83FD222F md5 ECB170EBBFDA0E932C07524040BCC36C sha1 3254442626CA2F2AC74400DC1C6A306F5D1B6CEB )
 )
 
 game (
 	name "Deadly Arts (USA)"
 	description "Deadly Arts (USA)"
 	rom ( name "Deadly Arts (USA).n64" size 12582912 crc B4AFBF51 md5 72CC6BC6A40705E4D49BBACABC84E347 sha1 F4C7B5F79CEE09D263B8A75B683FFBDB453D88F4 )
-	rom ( name "Deadly Arts (U) [!].z64" size 12582912 crc 3DB8130E md5 A2A4A0318DAB366A595336B6F80FF3AB sha1 AA8566669575E3FEA05DAF5688D4FE05DF735CD9 )
 )
 
 game (
@@ -1015,7 +993,6 @@ game (
 	name "Destruction Derby 64 (USA)"
 	description "Destruction Derby 64 (USA)"
 	rom ( name "Destruction Derby 64 (USA).n64" size 16777216 crc EF680F71 md5 5B9D74019FFCC91B8737CE09C0AF5030 sha1 31981B9B32814BBC3FE0C2A71C888858566352F9 )
-	rom ( name "Destruction Derby 64 (U) [!].z64" size 16777216 crc 38F1B5D9 md5 7FCCB47498EEC06E96AE9372247D1E90 sha1 A2C0799E13566D1B723299592CFCAC9387F25FA7 )
 )
 
 game (
@@ -1052,7 +1029,6 @@ game (
 	name "Diddy Kong Racing (USA) (En,Fr) (Rev A)"
 	description "Diddy Kong Racing (USA) (En,Fr) (Rev A)"
 	rom ( name "Diddy Kong Racing (USA) (En,Fr) (Rev A).n64" size 12582912 crc 96C32BB6 md5 34FCEBA45079808A1A4F735B27344EF6 sha1 03F04DFE0C34E8BAD370AA4B68F4BB8ED3429FDE )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.1) [!].z64" size 12582912 crc 5ACCA298 md5 B31F8CCA50F31ACC9B999ED5B779D6ED sha1 6D96743D46F8C0CD0EDB0EC5600B003C89B93755 )
 )
 
 game (
@@ -1083,7 +1059,6 @@ game (
 	name "Donkey Kong 64 (USA)"
 	description "Donkey Kong 64 (USA)"
 	rom ( name "Donkey Kong 64 (USA).n64" size 33554432 crc 96972D67 md5 B71A88BA73E141FA2D355A6A72F46F6C sha1 3EAD7798284C0593D8C91E09923CDE03E87C6B09 flags verified )
-	rom ( name "Donkey Kong 64 (U) [!].z64" size 33554432 crc D44B4FC6 md5 9EC41ABF2519FC386CADD0731F6E868C sha1 CF806FF2603640A748FCA5026DED28802F1F4A50 )
 )
 
 game (
@@ -1114,7 +1089,6 @@ game (
 	name "Doom 64 (USA) (Rev A)"
 	description "Doom 64 (USA) (Rev A)"
 	rom ( name "Doom 64 (USA) (Rev A).n64" size 8388608 crc 0F080D06 md5 300CE844F090807053377D43C6706E33 sha1 07A7DAC8084F1BE8B102312FCD3EE65BE095109C )
-	rom ( name "Doom 64 (U) (V1.1) [!].z64" size 8388608 crc 1D3A17B5 md5 1B1378BB9EE819F740550F566745AF73 sha1 6FB0CE9C75BBE54B6E1EDE337652B0221E5F2AAD )
 )
 
 game (
@@ -1145,7 +1119,6 @@ game (
 	name "Dr. Mario 64 (USA)"
 	description "Dr. Mario 64 (USA)"
 	rom ( name "Dr. Mario 64 (USA).n64" size 4194304 crc F7C44B5B md5 30EC4F3E1C435ED8B1D1FD3788B6A407 sha1 188ABDF9E879DD8C92E78A2E978284879A00A8BF )
-	rom ( name "Dr. Mario 64 (U) [!].z64" size 4194304 crc A4701927 md5 1A7936367413E5D6874ABDA6D623AD32 sha1 A130D3622CE40E0158DB2DA4247101F6E92206FC )
 )
 
 game (
@@ -1176,7 +1149,6 @@ game (
 	name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)"
 	description "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)"
 	rom ( name "Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).n64" size 16777216 crc B67BBC15 md5 FA00DC1372A4C347BBD7B102CE17A835 sha1 40CE11880A5E0603A42AE46B0518B95AE174556C )
-	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [!].z64" size 16777216 crc 3177A905 md5 02192B4B3797983BBE5E452336584208 sha1 2C840E2991D6A2AF63C4EFE830240FC49D93FC9A )
 )
 
 game (
@@ -1201,7 +1173,6 @@ game (
 	name "Duke Nukem - Zero Hour (USA)"
 	description "Duke Nukem - Zero Hour (USA)"
 	rom ( name "Duke Nukem - Zero Hour (USA).n64" size 33554432 crc 912F576F md5 C6CB6E8CEDA52641313F49BDBF1FBBFE sha1 18FC2F1D69B34B31588A0617E81ABB794A9205EF )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [!].z64" size 33554432 crc 9A3258D7 md5 026789D47DB5FE202A76F89797B33AC7 sha1 DE4DB292CC6CF5DD1DD1D3C9700CF8E5C3078410 )
 )
 
 game (
@@ -1220,7 +1191,6 @@ game (
 	name "Duke Nukem 64 (USA)"
 	description "Duke Nukem 64 (USA)"
 	rom ( name "Duke Nukem 64 (USA).n64" size 8388608 crc 1BF948C3 md5 A18868C5D7BCF919A65999D91653B268 sha1 72FCF260632323C2538A6D2FEEA7030B8DA5BAC8 flags verified )
-	rom ( name "Duke Nukem 64 (U) [!].z64" size 8388608 crc DBFD5A53 md5 C7F1A43764A26DA2E43F2A36A5F76E4C sha1 98D6778004BECC672EBA0A5E887F6E3F3D1B5C15 )
 )
 
 game (
@@ -1233,7 +1203,6 @@ game (
 	name "Earthworm Jim 3D (USA)"
 	description "Earthworm Jim 3D (USA)"
 	rom ( name "Earthworm Jim 3D (USA).n64" size 16777216 crc 1017BE14 md5 9F793770D32E576F62DBD57F35EA441D sha1 1B0AA4D94194EDC885D9A9C2A4F37000C963756A )
-	rom ( name "Earthworm Jim 3D (U) [!].z64" size 16777216 crc 9E6579C5 md5 980DFB38AD9A883119DE135F45B7DB36 sha1 EAB14F23640CD6148D4888902CDCC00DD6111BF9 )
 )
 
 game (
@@ -1288,7 +1257,6 @@ game (
 	name "Excitebike 64 (USA)"
 	description "Excitebike 64 (USA)"
 	rom ( name "Excitebike 64 (USA).n64" size 16777216 crc EF78ED7E md5 4A5ECA1D547CB1A36F832F56328F1FD5 sha1 3F65D89577FF12A47502A970A0C81B8E5BDB39E0 )
-	rom ( name "Excitebike 64 (U) [!].z64" size 16777216 crc FC459192 md5 7200D1C1CF489FAFFF767729F215E6E6 sha1 A847DD011E98204AD198CADEB6C80DDA10D9A40E )
 )
 
 game (
@@ -1397,7 +1365,6 @@ game (
 	name "F-Zero X (USA)"
 	description "F-Zero X (USA)"
 	rom ( name "F-Zero X (USA).n64" size 16777216 crc 9408C2C1 md5 DEE6EF2CBAAC89846A59983E19A55348 sha1 C322C80A676604CDA4B605558B5BD8AA6F1A2060 flags verified )
-	rom ( name "F-ZERO X (U) [!].z64" size 16777216 crc 0B561FBA md5 753437D0D8ADA1D12F3F9CF0F0A5171F sha1 5F658E88FFA9DE23CBA6986A8FD3D3A90D7B4340 )
 )
 
 game (
@@ -1476,7 +1443,6 @@ game (
 	name "Fighter Destiny 2 (USA)"
 	description "Fighter Destiny 2 (USA)"
 	rom ( name "Fighter Destiny 2 (USA).n64" size 16777216 crc 7FC19103 md5 EC8B2DBD67221C8DCBC7F28F2FB8E56D sha1 55AF6BFB78D58700D0B97A5EF390693817195051 )
-	rom ( name "Fighter Destiny 2 (U) [!].z64" size 16777216 crc BB2563C6 md5 04DD2A319F4F5C22569B612CFDF9F00C sha1 1DC12CFD908F56DEBCAD6CF582BFDFC23A3AD725 )
 )
 
 game (
@@ -1501,7 +1467,6 @@ game (
 	name "Fighters Destiny (USA)"
 	description "Fighters Destiny (USA)"
 	rom ( name "Fighters Destiny (USA).n64" size 12582912 crc A625973F md5 C34077E5027FC18EF5A502E7364B5F68 sha1 2FBA94EC3A6EAC33E2680E1DB661178C3E320BC4 )
-	rom ( name "Fighter's Destiny (U) [!].z64" size 12582912 crc F45EA789 md5 D61D97A7658C419A25A9BAC96B0A3DF8 sha1 F87E1677602E38BAC962424042E289EC58EC37B2 )
 )
 
 game (
@@ -1520,7 +1485,6 @@ game (
 	name "Fighting Force 64 (USA)"
 	description "Fighting Force 64 (USA)"
 	rom ( name "Fighting Force 64 (USA).n64" size 16777216 crc ADE7DCA4 md5 A47AF0821704B001C3565C0C1D5AFEF1 sha1 3CE2DDAFAA5101D3B2F49210AB6E6976994E5FBE )
-	rom ( name "Fighting Force 64 (U) [!].z64" size 16777216 crc 8456841E md5 E7008D17FD71D9C2BDA1362C885388B2 sha1 6B4E78201AD5C5D0BD932652F233D9732316CDC2 )
 )
 
 game (
@@ -1533,7 +1497,6 @@ game (
 	name "Flying Dragon (USA)"
 	description "Flying Dragon (USA)"
 	rom ( name "Flying Dragon (USA).n64" size 12582912 crc 87E4E352 md5 A7A2BD96167EEA31EDEE3E05F4D3DD04 sha1 25FD5CC411092D917D18C6D6BA3D7749B2F27F1A )
-	rom ( name "Flying Dragon (U) [!].z64" size 12582912 crc 91BC9AEB md5 272B359D8F8AC48ACBF053C262F422E4 sha1 5472FE1DCAAACAECBA8D1BED8EAB4A2146E58665 )
 )
 
 game (
@@ -1552,7 +1515,6 @@ game (
 	name "Forsaken 64 (USA)"
 	description "Forsaken 64 (USA)"
 	rom ( name "Forsaken 64 (USA).n64" size 8388608 crc F970E4A4 md5 A35A36CCEDBE741236EED34B26CB7473 sha1 7741FA3CC164E7B51D79079E14C46EDD5BE205BF )
-	rom ( name "Forsaken 64 (U) [!].z64" size 8388608 crc 76C4333D md5 5CDEE5503A57D14533C66B35A5848899 sha1 7C670B224ACFA960DF902C866FEBB679806CB3FB )
 )
 
 game (
@@ -1565,12 +1527,6 @@ game (
 	name "Frogger 2 (USA) (Rev A) (Proto)"
 	description "Frogger 2 (USA) (Rev A) (Proto)"
 	rom ( name "Frogger 2 (USA) (Rev A) (Proto).n64" size 33554432 crc DC59ECE7 md5 FC7D68D9DA36F898B75E422A08E0AE76 sha1 F16B3D87C243F0E25C1F71EB8C388178757DCDF9 )
-)
-
-game (
-	name "Frogger 2 (USA) (Alpha)"
-	description "Frogger 2 (USA) (Alpha)"
-	rom ( name "Frogger 2 (U) (Alpha) [!].z64" size 4194304 crc B0C62957 md5 CB2C9C6104C3EF69A1CF979525F2F73D sha1 1AFF1DF3270AD8014BC36499803B71BF92737D01 )
 )
 
 game (
@@ -1649,7 +1605,6 @@ game (
 	name "Gauntlet Legends (USA)"
 	description "Gauntlet Legends (USA)"
 	rom ( name "Gauntlet Legends (USA).n64" size 16777216 crc 7E90C0A8 md5 A45B7398E01414CCFE2F66D8F02968D4 sha1 5DEBF6CC5DC00B962B29079CAF505CDF50914E1D )
-	rom ( name "Gauntlet Legends (U) [!].z64" size 16777216 crc 64765E82 md5 9CB963E8B71F18568F78EC1AF120362E sha1 0489DCCE749C6A5102681D288ED0616A4B94E99D )
 )
 
 game (
@@ -1674,7 +1629,6 @@ game (
 	name "Gex 3 - Deep Cover Gecko (USA)"
 	description "Gex 3 - Deep Cover Gecko (USA)"
 	rom ( name "Gex 3 - Deep Cover Gecko (USA).n64" size 33554432 crc 3571F3BD md5 6E47938FFEB8B202198877C7CB0EFA1D sha1 4D26566BA00F6F633FB41384A01A4464A7371000 )
-	rom ( name "Gex 3 - Deep Cover Gecko (U) [!].z64" size 33554432 crc 87A7D099 md5 6770DDEC84EB21A5E0D0F55DFD52A01A sha1 467BC88942E02D542E1A4705DCAB98AB7281819F )
 )
 
 game (
@@ -1687,7 +1641,6 @@ game (
 	name "Gex 64 - Enter the Gecko (USA)"
 	description "Gex 64 - Enter the Gecko (USA)"
 	rom ( name "Gex 64 - Enter the Gecko (USA).n64" size 16777216 crc 3F90E7C2 md5 A949166A1EB9592C8F46471E7AAC290F sha1 8C10971D9052EF796973F4CE137858109A63A598 )
-	rom ( name "Gex 64 - Enter the Gecko (U) [!].z64" size 16777216 crc C545CE80 md5 47F9D900C97ECE154BB40A9C6DCCD3FD sha1 16042CD0DFA5439CA436F1BF05EBFB7E9F730CDA )
 )
 
 game (
@@ -1700,7 +1653,6 @@ game (
 	name "Glover (USA)"
 	description "Glover (USA)"
 	rom ( name "Glover (USA).n64" size 8388608 crc D024893A md5 A43F68079C8FFF2920137585B39FC73E sha1 ED756CAE1582A4940DDB854B5376A0013F7F5634 )
-	rom ( name "Glover (U) [!].z64" size 8388608 crc F874571C md5 87AA5740DFF79291EE97832DA1F86205 sha1 270BE17B3C8DA9B88A7B99C2A545B0BCE16837F4 )
 )
 
 game (
@@ -1731,7 +1683,6 @@ game (
 	name "Goemon's Great Adventure (USA)"
 	description "Goemon's Great Adventure (USA)"
 	rom ( name "Goemon's Great Adventure (USA).n64" size 16777216 crc E3C7A184 md5 B31DEBB9007459B0B20D7E73C189CFFB sha1 FB5F82D315EC99E5CD1ED5EDDA0D2F289231851E flags verified )
-	rom ( name "Goemon's Great Adventure (U) [!].z64" size 16777216 crc 52D418E1 md5 29BC5C1A24D3979D376AD421000AC9CB sha1 9F9E860816F9E2A68BB5F4F56086E0C7450C64D7 )
 )
 
 game (
@@ -1768,7 +1719,6 @@ game (
 	name "Harvest Moon 64 (USA)"
 	description "Harvest Moon 64 (USA)"
 	rom ( name "Harvest Moon 64 (USA).n64" size 16777216 crc D2EE315F md5 0A5D1E13B410D209835B43F2A985EF64 sha1 7FCAB48A10A9B3B7BA5834347FF180C74D7B932C )
-	rom ( name "Harvest Moon 64 (U) [!].z64" size 16777216 crc DECDC0AD md5 6DA848A70D83ECE130D274124760928E sha1 90631460F1876A14849DF0541D534012B410A34C )
 )
 
 game (
@@ -1823,7 +1773,6 @@ game (
 	name "Hey You, Pikachu! (USA)"
 	description "Hey You, Pikachu! (USA)"
 	rom ( name "Hey You, Pikachu! (USA).n64" size 16777216 crc 0149E9F6 md5 3FF2ABE65504C4A9C0602090AA6D2B27 sha1 615835390E80921F37CB9C081D27FEA42920FCCE )
-	rom ( name "Hey You, Pikachu! (U) [!].z64" size 16777216 crc B18B2734 md5 1280C78F286FC1C437A4905EE42C47F1 sha1 DA1A1E47A86720F9D54FB2D2D247480041BDA824 )
 )
 
 game (
@@ -1914,7 +1863,6 @@ game (
 	name "Hybrid Heaven (USA)"
 	description "Hybrid Heaven (USA)"
 	rom ( name "Hybrid Heaven (USA).n64" size 16777216 crc 7CE3EA39 md5 EC6E73ECA53E902E305168F773F67B11 sha1 A0F6777DCECF8B956F12FF69EC5051A9BE4C234F )
-	rom ( name "Hybrid Heaven (U) [!].z64" size 16777216 crc 15B57EF8 md5 C47E95BB32AB132C41D67BD243F9E02A sha1 16DBC21620B52DEAB5C5ABF8A309AC60ADFBEE85 )
 )
 
 game (
@@ -1957,7 +1905,6 @@ game (
 	name "Iggy's Reckin' Balls (USA)"
 	description "Iggy's Reckin' Balls (USA)"
 	rom ( name "Iggy's Reckin' Balls (USA).n64" size 4194304 crc 5953567E md5 07E0D07122336DC0FC83EF1E0BCBEEA0 sha1 289A26F3A0D656FF522252CAABC0E005C760FACA )
-	rom ( name "Iggy's Reckin' Balls (U) [!].z64" size 4194304 crc 6A6FBD5D md5 464211ABB602EE1005974D2D835A3BCF sha1 1A32230E0EF147B3C8C07ECE5AEC96458286B4AF )
 )
 
 game (
@@ -1982,7 +1929,6 @@ game (
 	name "Indiana Jones and the Infernal Machine (USA)"
 	description "Indiana Jones and the Infernal Machine (USA)"
 	rom ( name "Indiana Jones and the Infernal Machine (USA).n64" size 33554432 crc A8F86EB6 md5 2E32BE40F6AEAA549579B026989A017F sha1 9D326652E881D80742E49C51D60FA3FFEA21207C )
-	rom ( name "Indiana Jones and the Infernal Machine (U) [!].z64" size 33554432 crc 4978EB57 md5 70DE1EAB508596B6BBEFD168B5D07194 sha1 93300D63412D6C7432109B5AD2E4A8B9348E9538 )
 )
 
 game (
@@ -2319,7 +2265,6 @@ game (
 	name "Killer Instinct Gold (USA) (Rev B)"
 	description "Killer Instinct Gold (USA) (Rev B)"
 	rom ( name "Killer Instinct Gold (USA) (Rev B).n64" size 12582912 crc 8E1DB3C2 md5 B8C98E55712842E6DC07C1A5E9EBC612 sha1 291F62378DC3D378D443D649689CFCBF43382174 )
-	rom ( name "Killer Instinct Gold (U) (V1.2) [!].z64" size 12582912 crc 0B5B5DF8 md5 DD0A82FCC10397AFB37F12BB7F94E67A sha1 AAEB492B1E538AF65A3544A97240675EF438A04F )
 )
 
 game (
@@ -2344,7 +2289,6 @@ game (
 	name "Kirby 64 - The Crystal Shards (USA)"
 	description "Kirby 64 - The Crystal Shards (USA)"
 	rom ( name "Kirby 64 - The Crystal Shards (USA).n64" size 33554432 crc 8EB3565B md5 968A49EA33D35C94A393A770A8117AA3 sha1 56D8A1C461A3EE38C5C1977D497686058B90DF8A flags verified )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [!].z64" size 33554432 crc 20A1C120 md5 D33E4254336383A17FF4728360562ADA sha1 6CEA2D46B929A3BB347B060A77FCCC83526FB855 )
 )
 
 game (
@@ -2411,7 +2355,6 @@ game (
 	name "Legend of Zelda, The - Majora's Mask (USA)"
 	description "Legend of Zelda, The - Majora's Mask (USA)"
 	rom ( name "Legend of Zelda, The - Majora's Mask (USA).n64" size 33554432 crc 3EE3F2D1 md5 B0CC37A45BC1B6C76CD7F0B71FE2BB1F sha1 22F8BFA1AB6C763013A3C2A568BB014395B12499 flags verified )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [!].z64" size 33554432 crc B428D8A7 md5 2A0A8ACB61538235BC1094D297FB6556 sha1 D6133ACE5AFAA0882CF214CF88DABA39E266C078 )
 )
 
 game (
@@ -2442,7 +2385,6 @@ game (
 	name "Legend of Zelda, The - Ocarina of Time (USA)"
 	description "Legend of Zelda, The - Ocarina of Time (USA)"
 	rom ( name "Legend of Zelda, The - Ocarina of Time (USA).n64" size 33554432 crc EC95702D md5 6697768A7A7DF2DD27A692A2638EA90B sha1 79A4F053D34018E59279E6D4B83C7DACCD985C87 flags verified )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!].z64" size 33554432 crc CD16C529 md5 5BD1FE107BF8106B2AB6650ABECD54D6 sha1 AD69C91157F6705E8AB06C79FE08AAD47BB57BA7 )
 )
 
 game (
@@ -2473,7 +2415,6 @@ game (
 	name "LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	description "LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
 	rom ( name "LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" size 16777216 crc 3339E557 md5 30A227E03D4D07A4676D24D1DA971470 sha1 9C5B574680A18FC87C74E7C1FEEA19AAE87CC059 )
-	rom ( name "LEGO Racers (U) (M10) [!].z64" size 16777216 crc 39407C9F md5 97C4CAE584F427EC44266E9B98FBF7B6 sha1 965190474172A15C53EB04F89F25D388AB49DB1A )
 )
 
 game (
@@ -2630,7 +2571,6 @@ game (
 	name "Mario Golf (USA)"
 	description "Mario Golf (USA)"
 	rom ( name "Mario Golf (USA).n64" size 33554432 crc CEB5B977 md5 846984C666C35407961C7C069066FC42 sha1 03DB12B8A018EB10A31D3EDCF693D92AB8676F1B )
-	rom ( name "Mario Golf (U) [!].z64" size 33554432 crc 2D40ABB0 md5 7A5D0D77A462B5A7C372FB19EFDE1A5F sha1 C7B9E24F214386C40BF97E924F88055FE6EF8404 )
 )
 
 game (
@@ -2673,7 +2613,6 @@ game (
 	name "Mario Kart 64 (USA)"
 	description "Mario Kart 64 (USA)"
 	rom ( name "Mario Kart 64 (USA).n64" size 12582912 crc 2BCEE11C md5 E19398A0FD1CC12DF64FCA7FBCAA82CC sha1 E72FDCBB4EDEC32535A62B672C4559B04B07A081 flags verified )
-	rom ( name "Mario Kart 64 (U) [!].z64" size 12582912 crc 434389C1 md5 3A67D9986F54EB282924FCA4CD5F6DFF sha1 579C48E211AE952530FFC8738709F078D5DD215E )
 )
 
 game (
@@ -2698,7 +2637,6 @@ game (
 	name "Mario Party (USA)"
 	description "Mario Party (USA)"
 	rom ( name "Mario Party (USA).n64" size 33554432 crc 4717CD1B md5 22D2815355F2BE326AA4AB08976EA091 sha1 08390DB915DD689191906A13F4F736D419E2AFF9 )
-	rom ( name "Mario Party (U) [!].z64" size 33554432 crc 4D60ABE5 md5 8BC2712139FBF0C56C8EA835802C52DC sha1 1159BD56730094BFC71BE30113E1CFC8BACF34F3 )
 )
 
 game (
@@ -2717,7 +2655,6 @@ game (
 	name "Mario Party 2 (USA)"
 	description "Mario Party 2 (USA)"
 	rom ( name "Mario Party 2 (USA).n64" size 33554432 crc 3BA5471B md5 F107F70EE02DCED2617A5DEDFF72869B sha1 528ECD9E10233EA7CE372559A16196A8E9438763 )
-	rom ( name "Mario Party 2 (U) [!].z64" size 33554432 crc E58A1955 md5 04840612A35ECE222AFDB2DFBF926409 sha1 166EDA1C05670D337E2C3F15A5DB528AE1E5D6E3 )
 )
 
 game (
@@ -2736,7 +2673,6 @@ game (
 	name "Mario Party 3 (USA)"
 	description "Mario Party 3 (USA)"
 	rom ( name "Mario Party 3 (USA).n64" size 33554432 crc A1BEE3F8 md5 AC422FB77258336895EE5355F1B2B36D sha1 58BD552B48BCEC6AA39174DE9796A7C093D64B67 )
-	rom ( name "Mario Party 3 (U) [!].z64" size 33554432 crc B7445DDC md5 76A8BBC81BC2060EC99C9645867237CC sha1 6BEB80FF822B96BCF85DCDB512E8B2B7969D8259 )
 )
 
 game (
@@ -2755,7 +2691,6 @@ game (
 	name "Mario Tennis (USA)"
 	description "Mario Tennis (USA)"
 	rom ( name "Mario Tennis (USA).n64" size 16777216 crc 995C9F24 md5 8DFB2FAC888368660B54E390FE9042F4 sha1 9BB2D4E8D1CC4E31BD75A588BD94EB085FF7D73E )
-	rom ( name "Mario Tennis (U) [!].z64" size 16777216 crc 4E9560F6 md5 759358FAD1ED5AE31DCB2001A07F2FE5 sha1 999047F07CEC931FFBDCC7B33B8502EF602807EE )
 )
 
 game (
@@ -2768,7 +2703,6 @@ game (
 	name "Mega Man 64 (USA)"
 	description "Mega Man 64 (USA)"
 	rom ( name "Mega Man 64 (USA).n64" size 33554432 crc B57DD0E4 md5 19E60FD08033B4AFC86AA0F2ED39181D sha1 C24B210F2FC297897940AF1ADD23C1C19C191699 )
-	rom ( name "Mega Man 64 (U) [!].z64" size 33554432 crc 1BFC71F0 md5 3620674ACB51E436D5150738AC1C0969 sha1 F24FE0AFF01AEC018E2DD558EC4F076CF328129F )
 )
 
 game (
@@ -2853,7 +2787,6 @@ game (
 	name "Mischief Makers (USA)"
 	description "Mischief Makers (USA)"
 	rom ( name "Mischief Makers (USA).n64" size 8388608 crc AF7B3820 md5 0F4AF851005304993C21D414C8165296 sha1 FA7B20E6C4082D9068A59EDA3713525F1B7D794E )
-	rom ( name "Mischief Makers (U) [!].z64" size 8388608 crc 7D222D3F md5 495A9BFFD6620BE43225DB7133373FC5 sha1 5EB5A9D6F413A379FE297FE1542D21F728393A27 )
 )
 
 game (
@@ -2944,7 +2877,6 @@ game (
 	name "Mortal Kombat 4 (USA)"
 	description "Mortal Kombat 4 (USA)"
 	rom ( name "Mortal Kombat 4 (USA).n64" size 16777216 crc AA865B66 md5 27445BFDEDD5233AC56012F3331C4A41 sha1 5FB558A40F06365A1F759B4DF718623F1F3AC3DF flags verified )
-	rom ( name "Mortal Kombat 4 (U) [!].z64" size 16777216 crc B7F46516 md5 C70B91430866300CE38B49098019EF9D sha1 F47D05BBD1BCADDDFF2EC7A21BC2E795CBEF9F9B )
 )
 
 game (
@@ -2957,7 +2889,6 @@ game (
 	name "Mortal Kombat Mythologies - Sub-Zero (USA)"
 	description "Mortal Kombat Mythologies - Sub-Zero (USA)"
 	rom ( name "Mortal Kombat Mythologies - Sub-Zero (USA).n64" size 16777216 crc F0F7D9E3 md5 74FBF4979DF136E2EDFB71948ECDCFA7 sha1 04B8029337AFDDF618D9B0F0998BD0692782048F )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [!].z64" size 16777216 crc 51A07FD9 md5 DEEC4FAEC416F4E02D934C2E42C0CAAD sha1 EF3DF4E1496260D44C44AB7DD145751141F11C60 )
 )
 
 game (
@@ -2976,7 +2907,6 @@ game (
 	name "Mortal Kombat Trilogy (USA) (Rev B)"
 	description "Mortal Kombat Trilogy (USA) (Rev B)"
 	rom ( name "Mortal Kombat Trilogy (USA) (Rev B).n64" size 12582912 crc E58597D7 md5 116D3FFC3C906620F99B0A5F0B6B1600 sha1 4092A66080AFC03D7BF9779AAD047AFF1A56ECB6 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [!].z64" size 12582912 crc 0F323D00 md5 3DCB15043063BD656A0223C519218CFB sha1 11F2488B21F9F7185C25905DD02C2955C35AD5C1 )
 )
 
 game (
@@ -3025,7 +2955,6 @@ game (
 	name "Mystical Ninja Starring Goemon (USA)"
 	description "Mystical Ninja Starring Goemon (USA)"
 	rom ( name "Mystical Ninja Starring Goemon (USA).n64" size 16777216 crc 81C10AD9 md5 F2162BE647E4AA59254EC5ED7DB1E94A sha1 7A7CC41A47F0EDBC96EFA29D3F0F0E1C0D1E65AF flags verified )
-	rom ( name "Mystical Ninja Starring Goemon (U) [!].z64" size 16777216 crc 4180C296 md5 643CCE1AB06F97E9590241D27E5C2363 sha1 DF8083A54296B8C151917C5333E1C85F014A2A66 )
 )
 
 game (
@@ -3410,7 +3339,6 @@ game (
 	name "Ogre Battle 64 - Person of Lordly Caliber (USA)"
 	description "Ogre Battle 64 - Person of Lordly Caliber (USA)"
 	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (USA).n64" size 41943040 crc C650BE3C md5 2B9C065A0BE087C1CEBA99EE246C9C54 sha1 A9FAADFDADCC0FD02AADCBECC28BFCC3D691A31C flags verified )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (U) [!].z64" size 41943040 crc A05AEA85 md5 F666E020218392E52662FDDFA1EA4F21 sha1 9CD0CFB50B883EDB068E0C30D213193B9CF89895 )
 )
 
 game (
@@ -3465,7 +3393,6 @@ game (
 	name "Paper Mario (USA)"
 	description "Paper Mario (USA)"
 	rom ( name "Paper Mario (USA).n64" size 41943040 crc D56D1C89 md5 7DE64234EE20788B9D74D2FDB3462AED sha1 77693A00418A9D8971B7A005F2001D997E359BFF flags verified )
-	rom ( name "Paper Mario (U) [!].z64" size 41943040 crc A7F5CD7E md5 A722F8161FF489943191330BF8416496 sha1 3837F44CDA784B466C9A2D99DF70D77C322B97A0 )
 )
 
 game (
@@ -3478,7 +3405,6 @@ game (
 	name "Paperboy (USA)"
 	description "Paperboy (USA)"
 	rom ( name "Paperboy (USA).n64" size 12582912 crc 2FCEEFF6 md5 3CD24A79755D55D4C5BFC71236C73CC3 sha1 0DCCD178F9AF55A2FCBC5B963B60E7A897E237FF )
-	rom ( name "Paperboy (U) [!].z64" size 12582912 crc F27114E6 md5 C4CBCB54B010A5A71FE5CAA391E5C25F sha1 B043C47B9758FA6BB289CA7DBA2068BDA6CAFA3A )
 )
 
 game (
@@ -3527,7 +3453,6 @@ game (
 	name "Perfect Dark (USA) (Rev A)"
 	description "Perfect Dark (USA) (Rev A)"
 	rom ( name "Perfect Dark (USA) (Rev A).n64" size 33554432 crc F85A16F1 md5 F267577A1FAECA4C07F1BB188452CA80 sha1 07E74D1B42AAADC6D95B171F6BD5F16E7C641284 )
-	rom ( name "Perfect Dark (U) (V1.1) [!].z64" size 33554432 crc 4C1677F7 md5 E03B088B6AC9E0080440EFED07C1E40F sha1 AF8788AC4D1A57260EAE9C53FFE851FCF2A3319B )
 )
 
 game (
@@ -3564,7 +3489,6 @@ game (
 	name "Pilotwings 64 (USA)"
 	description "Pilotwings 64 (USA)"
 	rom ( name "Pilotwings 64 (USA).n64" size 8388608 crc C445F7E3 md5 C5569227242E04138AAC8457B7F83E6C sha1 0576080DD468FF528D90CF2DE6C4A7790E4923F3 )
-	rom ( name "Pilotwings 64 (U) [!].z64" size 8388608 crc 728807E7 md5 8B346182730CEAFFE5E2CCF6D223C5EF sha1 EC771AEDF54EE1B214C25404FB4EC51CFD43191A )
 )
 
 game (
@@ -3589,7 +3513,6 @@ game (
 	name "Pokemon Puzzle League (USA)"
 	description "Pokemon Puzzle League (USA)"
 	rom ( name "Pokemon Puzzle League (USA).n64" size 33554432 crc 281AFB0D md5 AFE4CC6F067852B96FEC84CB739B4C99 sha1 E52AF5A60EA9BD2DAE34E4252D71BEDAF496CDB3 )
-	rom ( name "Pokemon Puzzle League (U) [!].z64" size 33554432 crc 8B9C598F md5 E722576A15182CFED6782379CE4BC8BE sha1 8173866FC8C7652ABD44C48EFCAB85441C6806A1 )
 )
 
 game (
@@ -3638,14 +3561,12 @@ game (
 	name "Pokemon Snap (USA)"
 	description "Pokemon Snap (USA)"
 	rom ( name "Pokemon Snap (USA).n64" size 16777216 crc DF387848 md5 9B10B9D70DAC67AE40953148FBE9CB96 sha1 CFA6C20848651B686761F3BD72D5D97C3B83CCA9 )
-	rom ( name "Pokemon Snap (U) [!].z64" size 16777216 crc 86A69756 md5 FC3C9329B7CDD67CF7650ABF63B9A580 sha1 EDC7C49CC568C045FE48BE0D18011C30F393CBAF )
 )
 
 game (
 	name "Pokemon Snap Station (USA) (Promo)"
 	description "Pokemon Snap Station (USA) (Promo)"
 	rom ( name "Pokemon Snap Station (USA) (Promo).n64" size 16777216 crc 9BEF1033 md5 5BEE2ABA2576A2D8554427751FFC2643 sha1 7DFBE7F3E764A740D92D4C7195F1C638A0912452 )
-	rom ( name "Pokemon Snap Station (U) [!].z64" size 16777216 crc E22A00D0 md5 A9C272687DABD59C5144774B53BCC35A sha1 1E16C19FF303F9283D7B53545C4D575C6DF43158 )
 )
 
 game (
@@ -3694,7 +3615,6 @@ game (
 	name "Pokemon Stadium (USA)"
 	description "Pokemon Stadium (USA)"
 	rom ( name "Pokemon Stadium (USA).n64" size 33554432 crc 3003E90C md5 3A7324CE816D5891DEA074055690750A sha1 59E8993202E6B8219A80855A400822417132CC81 )
-	rom ( name "Pokemon Stadium (U) (V1.0) [!].z64" size 33554432 crc 72F66F05 md5 ED1378BC12115F71209A77844965BA50 sha1 ED7BEF5A306F88C0A6E96B15E71FEE2EF32058F3 )
 )
 
 game (
@@ -3749,7 +3669,6 @@ game (
 	name "Pokemon Stadium 2 (USA)"
 	description "Pokemon Stadium 2 (USA)"
 	rom ( name "Pokemon Stadium 2 (USA).n64" size 67108864 crc FBFF058A md5 FE05FB7A1E76ADCF8942B24A97748939 sha1 D6337714E46B39D43E570813CC51C64F7C62D981 )
-	rom ( name "Pokemon Stadium 2 (U) [!].z64" size 67108864 crc A9998E09 md5 1561C75D11CEDF356A8DDB1A4A5F9D5D sha1 D8343E69A7DC63B869CF6361D87CDE64444281D3 )
 )
 
 game (
@@ -3780,14 +3699,12 @@ game (
 	name "Power Rangers - Lightspeed Rescue (USA)"
 	description "Power Rangers - Lightspeed Rescue (USA)"
 	rom ( name "Power Rangers - Lightspeed Rescue (USA).n64" size 12582912 crc EB8CE95B md5 23E1F0F7B63DE817DDCCE91A8CA0EC9F sha1 A7523544E7E293F58207ECEA9CA44F713E9DEEE2 )
-	rom ( name "Power Rangers - Lightspeed Rescue (U) [!].z64" size 12582912 crc A5033311 md5 91D74621DDEF6D37FB845B3BC7059A38 sha1 9C0B970DFA344A8CDEA9B775D7F95ACEC2CCF79F )
 )
 
 game (
 	name "Powerpuff Girls, The - Chemical X-Traction (USA)"
 	description "Powerpuff Girls, The - Chemical X-Traction (USA)"
 	rom ( name "Powerpuff Girls, The - Chemical X-Traction (USA).n64" size 8388608 crc 4EE7CD7E md5 BA39CF3E29E026030B9D2BD23908F721 sha1 8F982BAB4F1857D6562113D120BCE82BD316F78D )
-	rom ( name "Powerpuff Girls, The - Chemical X-Traction (U) [!].z64" size 8388608 crc 9514DA0A md5 2991BB68ECA54813D6B834ADBBBACC4C sha1 88E2032997CB884AF31A7380FABAC0D0A5360892 )
 )
 
 game (
@@ -3842,7 +3759,6 @@ game (
 	name "Quake 64 (USA)"
 	description "Quake 64 (USA)"
 	rom ( name "Quake 64 (USA).n64" size 12582912 crc 06D5CDBB md5 056E41DD8205E701F630B8E19AE4F523 sha1 4DF581EBF44EB0E6060C331995FEBD39A04CCEDD )
-	rom ( name "Quake 64 (U) [!].z64" size 12582912 crc 761F39D1 md5 097605021951024C3ECB2D502C0C2A9F sha1 25A7FE0342490D3C23328040BB34F8748995537A )
 )
 
 game (
@@ -3855,7 +3771,6 @@ game (
 	name "Quake II (USA)"
 	description "Quake II (USA)"
 	rom ( name "Quake II (USA).n64" size 12582912 crc 5D880E55 md5 CA711AFDD1E85147D309F0C8C56241AD sha1 24B792FEF01FCA18FAF73A1B980E9C738822298F )
-	rom ( name "Quake II (U) [!].z64" size 12582912 crc E6B34387 md5 CC93C30C633FF461C29B54CEABEFD701 sha1 2EDB00E602E7C2813A5D6A04DFEC80487627237A )
 )
 
 game (
@@ -3940,7 +3855,6 @@ game (
 	name "Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)"
 	description "Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)"
 	rom ( name "Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).n64" size 33554432 crc 72EE54B2 md5 55ED44F3ADBE04C3FC405CCEDC261578 sha1 4D7A58F7A87928E592416B75B364E3563BBEED2F )
-	rom ( name "Rayman 2 - The Great Escape (U) (M5) [!].z64" size 33554432 crc 02BB4409 md5 03AA4D09FDE77EED9B95BE68E603D233 sha1 50558356B059AD3FBAF5FE95380512B9DCEAAF52 )
 )
 
 game (
@@ -3977,14 +3891,12 @@ game (
 	name "Ready 2 Rumble Boxing (USA)"
 	description "Ready 2 Rumble Boxing (USA)"
 	rom ( name "Ready 2 Rumble Boxing (USA).n64" size 33554432 crc E8D926F3 md5 5802E9C1F9D486E873D413011BFF3336 sha1 667083F0DBBD428216475DDCAD1883AD04207CFD )
-	rom ( name "Ready 2 Rumble Boxing (U) [!].z64" size 33554432 crc 2A554048 md5 A42F6F14F7EA10ABEB3B55FFD42EB572 sha1 E60FEDD535A72FDA5C424B846421BBDAD17C6CAA )
 )
 
 game (
 	name "Ready 2 Rumble Boxing - Round 2 (USA)"
 	description "Ready 2 Rumble Boxing - Round 2 (USA)"
 	rom ( name "Ready 2 Rumble Boxing - Round 2 (USA).n64" size 33554432 crc A64FDF28 md5 FEB4D736B38B3C6695370E445B7051A5 sha1 3E6B280A6B8925C0528C63ADD72F0861156D07D6 )
-	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [!].z64" size 33554432 crc 052A0E04 md5 DF4446A2B55C4D8D67E9C0C19E0FD9FB sha1 42AD558C20DDA72E9383323960CD1FD591122052 )
 )
 
 game (
@@ -3997,7 +3909,6 @@ game (
 	name "Resident Evil 2 (USA) (Rev A)"
 	description "Resident Evil 2 (USA) (Rev A)"
 	rom ( name "Resident Evil 2 (USA) (Rev A).n64" size 67108864 crc 6A0D64BB md5 2C1C2949B4A5F16AE7C6D9B5DB4C034A sha1 6F5FBEDB304D66098732D4A7C69271BAEEE3ECB4 )
-	rom ( name "Resident Evil 2 (U) (V1.1) [!].z64" size 67108864 crc 848FBC0D md5 1ADD2C0217662B307CDFD876B35FBF7A sha1 62EC19BEAD748C12D38F6C5A7AB0831EDBD3D44B )
 )
 
 game (
@@ -4082,7 +3993,6 @@ game (
 	name "RR64 - Ridge Racer 64 (USA)"
 	description "RR64 - Ridge Racer 64 (USA)"
 	rom ( name "RR64 - Ridge Racer 64 (USA).n64" size 33554432 crc 7CCB9749 md5 87B8428DAC1D275B0E32E42DD5CFDE22 sha1 79DB18AC171142F287A45271EF3A7CF6341A17F8 )
-	rom ( name "RR64 - Ridge Racer 64 (U) [!].z64" size 33554432 crc 3C2C2D1C md5 990F97D56456FC23E52BD263E709E21E sha1 5F079CD9827B24D12AF4961482A0FCC679E53042 )
 )
 
 game (
@@ -4101,7 +4011,6 @@ game (
 	name "Rugrats - Scavenger Hunt (USA)"
 	description "Rugrats - Scavenger Hunt (USA)"
 	rom ( name "Rugrats - Scavenger Hunt (USA).n64" size 16777216 crc EA79AD0A md5 61DBD8183B1CD88CE41591537851F48A sha1 F69A4A88BC2374FEA96DFB06A42DBB5B9A5EB6B1 )
-	rom ( name "Rugrats - Scavenger Hunt (U) [!].z64" size 16777216 crc A87FAF82 md5 8C432235A57D34BC4A9B8B290E21E01E sha1 FB2A62F1625630D6F0BEB5FD00A32E12155D50E8 )
 )
 
 game (
@@ -4120,7 +4029,6 @@ game (
 	name "Rugrats in Paris - The Movie (USA)"
 	description "Rugrats in Paris - The Movie (USA)"
 	rom ( name "Rugrats in Paris - The Movie (USA).n64" size 16777216 crc 8F09AF37 md5 BB517073518EFCD38134F1C6D3236C2B sha1 42FBA753590296B288537162437357741B7F5596 )
-	rom ( name "Rugrats in Paris - The Movie (U) [!].z64" size 16777216 crc A9CC2419 md5 207EFE58C7C221DBDFFF285AB80126C1 sha1 7A80199973C42B08490DA1F6255B5F17569BA15E )
 )
 
 game (
@@ -4145,7 +4053,6 @@ game (
 	name "S.C.A.R.S. (USA)"
 	description "S.C.A.R.S. (USA)"
 	rom ( name "S.C.A.R.S. (USA).n64" size 8388608 crc 6594B593 md5 EFBD7401712765D36CE6A1B6685B6CE6 sha1 8FEF439B4649FE6C52F722F6158C67CADE7841CD )
-	rom ( name "S.C.A.R.S. (U) [!].z64" size 8388608 crc 22916735 md5 D0AA9D20A4B85FE514D2A3150D0133EA sha1 1E87E7BC5B7BC877ABC790EBFF122ED6E2BE828E )
 )
 
 game (
@@ -4266,7 +4173,6 @@ game (
 	name "Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)"
 	description "Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)"
 	rom ( name "Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).n64" size 16777216 crc 1E9986E5 md5 BCDC05DD4B0F22F640BE713916F4A4FD sha1 5C22F49BDA1332D1C060A576C3E8CEBEEEE6E7A0 )
-	rom ( name "Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).n64" size 16777216 crc 69983CC3 md5 407A1A18BD7DBE0485329296C3F84EB8 sha1 4397729F8143EA9A39F319E1F31F2E0B84335A24 )
 )
 
 game (
@@ -4411,7 +4317,6 @@ game (
 	name "Spider-Man (USA)"
 	description "Spider-Man (USA)"
 	rom ( name "Spider-Man (USA).n64" size 33554432 crc A2866A6E md5 EA9DD6280A01AB95984CAA1CB82C621E sha1 2AE97B0581BEC355C4A7A2DC7A12DF46CF4C91AB )
-	rom ( name "Spider-Man (U) [!].z64" size 33554432 crc 696CC2A4 md5 7F1991B8861E7E532EC21ECF2AF82191 sha1 382C9C5D4E416444C4F6F9F4F6A5914D679FEDF1 )
 )
 
 game (
@@ -4430,7 +4335,6 @@ game (
 	name "Star Fox 64 (USA) (Rev A)"
 	description "Star Fox 64 (USA) (Rev A)"
 	rom ( name "Star Fox 64 (USA) (Rev A).n64" size 12582912 crc D71902B0 md5 EF9A76901153F66123DAFCCB0C13CD94 sha1 7D6B2D10DECD487A172FC4C49E44C4F71AB0D703 )
-	rom ( name "Star Fox 64 (U) (V1.1) [!].z64" size 12582912 crc B1B5FC46 md5 741A94EEE093C4C8684E66B89F8685E8 sha1 09F0D105F476B00EFA5303A3EBC42E60A7753B7A )
 )
 
 game (
@@ -4467,7 +4371,6 @@ game (
 	name "Star Wars - Rogue Squadron (USA)"
 	description "Star Wars - Rogue Squadron (USA)"
 	rom ( name "Star Wars - Rogue Squadron (USA).n64" size 16777216 crc 2D6FA165 md5 459C6591D816660A2F714D2A9D0DFF1E sha1 FFE16DE53B845C7687808EA78BB664498738F8CE )
-	rom ( name "Star Wars - Rogue Squadron (U) (M3) [!].z64" size 16777216 crc 83C225CC md5 47CAC4E2A6309458342F21A9018FFBF0 sha1 ED42EED1EE2DB646FF7EF94BA8C5421D164A4F0D )
 )
 
 game (
@@ -4498,7 +4401,6 @@ game (
 	name "Star Wars - Shadows of the Empire (USA) (Rev B)"
 	description "Star Wars - Shadows of the Empire (USA) (Rev B)"
 	rom ( name "Star Wars - Shadows of the Empire (USA) (Rev B).n64" size 12582912 crc F4E546D1 md5 99B150A2E655D771EE1695CC1DF65B65 sha1 F3AB96424B567417722D95790F4EFE30333B23F6 flags verified )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [!].z64" size 12582912 crc E8727549 md5 C7B40352AAD8D863D88D51672F9A0087 sha1 9AB85626C27372EE614B7C5301C2C4EB187FD9F6 )
 )
 
 game (
@@ -4529,7 +4431,6 @@ game (
 	name "Star Wars Episode I - Battle for Naboo (USA)"
 	description "Star Wars Episode I - Battle for Naboo (USA)"
 	rom ( name "Star Wars Episode I - Battle for Naboo (USA).n64" size 33554432 crc 97EBBEA8 md5 ABC8665FC1A2C76FF61394AEA0DAD6C3 sha1 9F2782C314F7A8F481E6515FCD19C5431C6D5347 )
-	rom ( name "Star Wars Episode I - Battle for Naboo (U) [!].z64" size 33554432 crc 99DEE3C0 md5 3CB88B934572E7520F35E5458798775B sha1 E4441A6EEB67861408C2E009BAAE8AAD4DF34021 )
 )
 
 game (
@@ -4548,7 +4449,6 @@ game (
 	name "Star Wars Episode I - Racer (USA)"
 	description "Star Wars Episode I - Racer (USA)"
 	rom ( name "Star Wars Episode I - Racer (USA).n64" size 33554432 crc 494C667A md5 DBBF693E7B9E264312B88B7310D18280 sha1 F7F84332057E3FDE3168C34D781B8C2B8C312E57 )
-	rom ( name "Star Wars Episode I - Racer (U) [!].z64" size 33554432 crc C53C1035 md5 1EE8800A4003E7F9688C5A35F929D01B sha1 3542D5597C8A56EA8F5C63BCEAE97A24C4C08D58 )
 )
 
 game (
@@ -4561,7 +4461,6 @@ game (
 	name "StarCraft 64 (USA)"
 	description "StarCraft 64 (USA)"
 	rom ( name "StarCraft 64 (USA).n64" size 33554432 crc 14C77369 md5 FCB1EDE6D4F63DFF012CE8C2E62E95CF sha1 3466CE39800B160AB8157BA1505ADA238ED10D4A )
-	rom ( name "StarCraft 64 (U) [!].z64" size 33554432 crc 4E4C7EC9 md5 559F71B861F639B6376D891E3023414B sha1 A36D91B5AAC7BB95DF0D7DE5F9814F5270E25C2B )
 )
 
 game (
@@ -4634,7 +4533,6 @@ game (
 	name "Super Mario 64 (USA)"
 	description "Super Mario 64 (USA)"
 	rom ( name "Super Mario 64 (USA).n64" size 8388608 crc 42C43204 md5 165A9558B7539507E73E7AFECFFB200C sha1 1002DD7B56AA0A59A9103F1FB3D57D6B161F8DA7 flags verified )
-	rom ( name "Super Mario 64 (U) [!].z64" size 8388608 crc 3CE60709 md5 20B854B239203BAF6C961B850A4A51A2 sha1 9BEF1128717F958171A4AFAC3ED78EE2BB4E86CE )
 )
 
 game (
@@ -4665,7 +4563,6 @@ game (
 	name "Super Smash Bros. (USA)"
 	description "Super Smash Bros. (USA)"
 	rom ( name "Super Smash Bros. (USA).n64" size 16777216 crc DD2DF6D9 md5 3C4E65D9B7BF55338496108F04DA7F41 sha1 0FD35AE9976B4FE68ECE1C6F2D9156D913CCF076 flags verified )
-	rom ( name "Super Smash Bros. (U) [!].z64" size 16777216 crc EB97929E md5 F7C52568A31AADF26E14DC2B6416B2ED sha1 E2929E10FCCC0AA84E5776227E798ABC07CEDABF )
 )
 
 game (
@@ -4702,7 +4599,6 @@ game (
 	name "Superman - The New Superman Aventures (USA) (En,Fr,Es)"
 	description "Superman - The New Superman Aventures (USA) (En,Fr,Es)"
 	rom ( name "Superman - The New Superman Aventures (USA) (En,Fr,Es).n64" size 8388608 crc F10D66F0 md5 6574373D96FB836E5E0B79DB0F7D10EC sha1 25FDC20FF0C55F6223C12058F7EAB2DF893CE9E4 )
-	rom ( name "Superman (U) (M3) [!].z64" size 8388608 crc 437E3677 md5 3F64B4F72E61225EF3AE93976C9BFC7C sha1 C271DB752610C9581E1BA1E9125EA8ECDB56F74F )
 )
 
 game (
@@ -4841,7 +4737,6 @@ game (
 	name "Tom Clancy's Rainbow Six (USA)"
 	description "Tom Clancy's Rainbow Six (USA)"
 	rom ( name "Tom Clancy's Rainbow Six (USA).n64" size 16777216 crc 67F3D120 md5 445193C8C48C4DDDA38412135FC59C09 sha1 1EFFA41AEAF6EBF626EA8E26093E0609015E1007 )
-	rom ( name "Tom Clancy's Rainbow Six (U) [!].z64" size 16777216 crc 53B0CC13 md5 80F3B1ABD9FB9AE73997489DB185A74D sha1 F785674C670C01E31C77B3034525D43FD6703B9A )
 )
 
 game (
@@ -4992,7 +4887,6 @@ game (
 	name "Toy Story 2 - Buzz Lightyear to the Rescue! (USA)"
 	description "Toy Story 2 - Buzz Lightyear to the Rescue! (USA)"
 	rom ( name "Toy Story 2 - Buzz Lightyear to the Rescue! (USA).n64" size 12582912 crc F7A72276 md5 EEECA2B0130B8C9A11A1FC95110990B0 sha1 2196B226F1A75A917BFD1DCF22F02CD96FF39007 )
-	rom ( name "Toy Story 2 (U) [!].z64" size 12582912 crc B9570841 md5 B44E9C2D9D2F2DE3AF4793B824CCF936 sha1 982AD2E1E44C6662C88A77367BC5DF91C51531BF )
 )
 
 game (
@@ -5024,7 +4918,6 @@ game (
 	name "Transformers - Beast Wars Transmetals (USA)"
 	description "Transformers - Beast Wars Transmetals (USA)"
 	rom ( name "Transformers - Beast Wars Transmetals (USA).n64" size 16777216 crc 14C6B5E3 md5 F256B211E61AE0B75063A23A678F2D40 sha1 423E5388F643BBFDA1F893382F1F91849BE4DD99 )
-	rom ( name "Transformers - Beast Wars Transmetal (U) [!].z64" size 16777216 crc 85138B5A md5 6D38909FAA2840FC409AFA221489DE49 sha1 8D074A0E74E69A45A57A48470383BD5268521CDE )
 )
 
 game (
@@ -5079,7 +4972,6 @@ game (
 	name "Turok - Dinosaur Hunter (USA) (Rev B)"
 	description "Turok - Dinosaur Hunter (USA) (Rev B)"
 	rom ( name "Turok - Dinosaur Hunter (USA) (Rev B).n64" size 8388608 crc AF6EA1B8 md5 3D1B3CF1FDE3D730F92FCB4EAEE32311 sha1 E5F7580F2909B79C623B93491AF2BCA5A64127C8 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.2) [!].z64" size 8388608 crc 8C3BBC00 md5 039875B92C0E4FEF9797EC1744877B17 sha1 C7ED00DEE20F4235823BCF50D32FA5D6862D6FCE )
 )
 
 game (
@@ -5116,7 +5008,6 @@ game (
 	name "Turok - Rage Wars (USA)"
 	description "Turok - Rage Wars (USA)"
 	rom ( name "Turok - Rage Wars (USA).n64" size 8388608 crc 416474D8 md5 3A02804A9FF56AFDED03B688305780A9 sha1 11C2DD51FFCECC5D8134CEC96FFCF9C44B15DB48 )
-	rom ( name "Turok - Rage Wars (U) [!].z64" size 8388608 crc 422872A2 md5 CF5B28578FD62FA1FF8690079F5D68F5 sha1 9F8CB190831945F6F707AA8C2B20E04FA4276795 )
 )
 
 game (
@@ -5165,7 +5056,6 @@ game (
 	name "Turok 2 - Seeds of Evil (USA) (Rev A)"
 	description "Turok 2 - Seeds of Evil (USA) (Rev A)"
 	rom ( name "Turok 2 - Seeds of Evil (USA) (Rev A).n64" size 33554432 crc ADEC745F md5 15877E23F64EEF6F66A616DA7B24D6E2 sha1 BF56FE227F6E1936E7AE54390EE09EC2F9500160 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.1).z64" size 33554432 crc 57F1FBF5 md5 166221365DB70D446C4206083D422DD1 sha1 A86AF6C2AC9F6D837181F07C0A27F7EE59E7DF68 )
 )
 
 game (
@@ -5178,7 +5068,6 @@ game (
 	name "Turok 3 - Shadow of Oblivion (USA)"
 	description "Turok 3 - Shadow of Oblivion (USA)"
 	rom ( name "Turok 3 - Shadow of Oblivion (USA).n64" size 33554432 crc E0D0D902 md5 0D522595B31AABBD5DCF914C7975770A sha1 0176E990FA8145DBBA9B1781B44A121EA014CDA4 )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) [!].z64" size 33554432 crc CB297224 md5 1211C556D77B169D81A666A9661E1777 sha1 A2E0A28DC0D3A48C7C02CB9E4C4B38FE04B2D436 )
 )
 
 game (
@@ -5251,7 +5140,6 @@ game (
 	name "Vigilante 8 (USA)"
 	description "Vigilante 8 (USA)"
 	rom ( name "Vigilante 8 (USA).n64" size 8388608 crc B445EDCD md5 AFCE4FF54D26B29BA7BE5BE1B180FEE9 sha1 588807AFB3ACDA05955B6362C21CA24A5F2E70A2 )
-	rom ( name "Vigilante 8 (U) [!].z64" size 8388608 crc 330B73E6 md5 D616ADF6441ACBBD0E6BEF023A8F6031 sha1 22B7D7B4F1722EFD52D3C8BEBA8CF5D07340569B )
 )
 
 game (
@@ -5264,7 +5152,6 @@ game (
 	name "Vigilante 8 - 2nd Offense (USA)"
 	description "Vigilante 8 - 2nd Offense (USA)"
 	rom ( name "Vigilante 8 - 2nd Offense (USA).n64" size 12582912 crc 764ABDB3 md5 F2C52F565BD370E6827AE8C6438E5A51 sha1 2DA6A5A3FA61077949582154597A4717BCF51E3A )
-	rom ( name "Vigilante 8 - 2nd Offense (U) [!].z64" size 12582912 crc 0293203F md5 60CDF7445FAD2ABA05C958F46691501B sha1 9634247CA456C82A65BB33F552DB036BA6F33F79 )
 )
 
 game (
@@ -5373,7 +5260,6 @@ game (
 	name "Wave Race 64 (USA) (Rev A)"
 	description "Wave Race 64 (USA) (Rev A)"
 	rom ( name "Wave Race 64 (USA) (Rev A).n64" size 8388608 crc DD2BB7B6 md5 D28DBE3D633FC8F955814F9367E61ABE sha1 D37F82B15669502487B3E5790E76E3ED33EF9831 flags verified )
-	rom ( name "Wave Race 64 (U) (V1.1) [!].z64" size 8388608 crc 394948C4 md5 2048A640C12D1CF2052BA1629937D2FF sha1 508DFC2D4CAA42B6F6DE5263D0AED5E44AC7966A )
 )
 
 game (
@@ -5542,7 +5428,6 @@ game (
 	name "Wipeout 64 (USA)"
 	description "Wipeout 64 (USA)"
 	rom ( name "Wipeout 64 (USA).n64" size 8388608 crc 3E8CCE96 md5 CB63C8CD01A19341B725C9CBC8F28776 sha1 4B9D19E3010756D3106F8B20B2B90DADDB80BC1C )
-	rom ( name "Wipeout 64 (U) [!].z64" size 8388608 crc 4888D0FE md5 73C6D87DBE50F73F3B44E0F237A546D7 sha1 54E4795ABA4FC326F79D0703FFDB51A212DD4B5C )
 )
 
 game (
@@ -5585,7 +5470,6 @@ game (
 	name "Worms Armageddon (USA) (En,Fr,Es)"
 	description "Worms Armageddon (USA) (En,Fr,Es)"
 	rom ( name "Worms Armageddon (USA) (En,Fr,Es).n64" size 12582912 crc 556268B7 md5 05765F60B64F167AB0CDA48183A72384 sha1 04D60D848A5CB9923EB95B016EEBB6AF829296F2 )
-	rom ( name "Worms - Armageddon (U) (M3) [!].z64" size 12582912 crc 5471AE3B md5 491D4DB6718302489BF05FB962C73651 sha1 3B17B36BA91737B86AA56ECB1B48A89444B53572 )
 )
 
 game (
@@ -5700,7 +5584,6 @@ game (
 	name "Yoshi's Story (USA) (En,Ja)"
 	description "Yoshi's Story (USA) (En,Ja)"
 	rom ( name "Yoshi's Story (USA) (En,Ja).n64" size 16777216 crc 01A4B1E9 md5 D3436319D51DF291BA71A2E512DDB7B5 sha1 2263C34FF25CCE79A51693EBBA109C76F6246D01 )
-	rom ( name "Yoshi's Story (U) (M2) [!].z64" size 16777216 crc A1453E0D md5 586A092E22604840973B82DFACEAC77A sha1 B13072FEF6C6DF48C07D8822C01E5BC59036F6DA )
 )
 
 game (

--- a/dat/Nintendo - Nintendo 64.dat
+++ b/dat/Nintendo - Nintendo 64.dat
@@ -1416,7 +1416,7 @@ game (
 	name "Eikou no Saint Andrews (Japan)"
 	description "Eikou no Saint Andrews (Japan)"
 	rom ( name "Eikou no Saint Andrews (Japan).n64" size 8388608 crc CE55BB19 md5 619D71F98B53696347C497FA5AC0C7B1 sha1 1A313D3B4B11A16B8280B0139A15E47791C8080A flags verified )
-	rom ( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
+	( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699D2D6 md5 935DD85AD198BBDE92161CDCE47CBFB3 sha1 5686B49AC9A60EBFC1D1ABF6214F7BC06849ABF4 )
 )
 
 game (
@@ -1430,7 +1430,7 @@ game (
 	name "Elmo's Number Journey (USA)"
 	description "Elmo's Number Journey (USA)"
 	rom ( name "Elmo's Number Journey (USA).n64" size 8388608 crc B7AD0F05 md5 76E81D17D5C88EE40A1C32ED20E17B92 sha1 72419FD0A80CBDEEA635F094D6B0D086EBBB2750 )
-	rom ( name "Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
+	Elmo's Number Journey (U) [!].z64" size 8388608 crc EA3B92D8 md5 F733453ED26AFA0ACA8D3EB3B5B6D8EA sha1 7195EA96D9FE5DE065AF61F70D55C92C8EE905E6 )
 )
 
 game (
@@ -4180,6 +4180,7 @@ game (
 	description "Pokemon Stadium (Japan)"
 	rom ( name "Pokemon Stadium (Japan).n64" size 16777216 crc 3B2A3F7A md5 7159F1B35AF48EC43236DDFCC2C73B5C sha1 D1796076F855BD2354FFC5019EAEB2C9D7676716 flags verified )
 	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189C md5 C46E087D966A35095DF96799B0B4FFAE sha1 8BC8D2FF7DF25B26BD0C353D2ADFE83E4E3A7A87 )
+	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5DD92D4C md5 0E85A098D0F0E8A7EB572A69612A6873 sha1 4F7267CCABA4A8A9B0AE2CB89E191BC69B153DDC )
 )
 
 game (
@@ -5941,7 +5942,7 @@ game (
 	name "Twisted Edge - Extreme Snowboarding (Europe)"
 	description "Twisted Edge - Extreme Snowboarding (Europe)"
 	rom ( name "Twisted Edge - Extreme Snowboarding (Europe).n64" size 12582912 crc 394BDD25 md5 935894C48C7CEB500299CBEB6ACFA805 sha1 E5BAE263E692121A080308E6FDB2E42D20B1B347 flags verified )
-	rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
+		rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc BF0C1291 md5 420C9FDBAE15767C5E584070209FF253 sha1 DE12629F2538F80E25901DECAFC7CCC18C7D481C )
 )
 
 game (

--- a/metadat/goodtools/Nintendo - Nintendo 64.dat
+++ b/metadat/goodtools/Nintendo - Nintendo 64.dat
@@ -8,5071 +8,18133 @@ clrmamepro (
 )
 
 game (
-	name "007 - The World is Not Enough"
-	description "007 - The World is Not Enough"
-	rom ( name "007 - The World is Not Enough (E) (M3) [!].z64" size 33554432 crc 002c3b2a )
-	rom ( name "007 - The World is Not Enough (U) [!].z64" size 33554432 crc 26360987 )
-	rom ( name "007 - The World is Not Enough (U) [t1].z64" size 33554432 crc c3b67335 )
-	rom ( name "007 - The World is Not Enough (U) [t1][f1] (PAL-NTSC).z64" size 33554432 crc 98fdd6a2 )
+	name "1080 Snowboarding (E) (M4) [!]"
+	description "1080 Snowboarding (E) (M4) [!]"
+	rom ( name "1080 Snowboarding (E) (M4) [!].z64" crc 75A21679 )
 )
 
 game (
-	name "1080 Snowboarding"
-	description "1080 Snowboarding"
-	rom ( name "1080 Snowboarding (E) (M4) [!].z64" size 16777216 crc 75a21679 )
-	rom ( name "1080 Snowboarding (E) (M4) [b1].z64" size 16777216 crc 9204cc62 )
-	rom ( name "1080 Snowboarding (E) (M4) [b1][f2] (NTSC).z64" size 16777216 crc 933a9d1b )
-	rom ( name "1080 Snowboarding (E) (M4) [f1].z64" size 16777216 crc f6a6e391 )
-	rom ( name "1080 Snowboarding (E) (M4) [f2] (NTSC).z64" size 16777216 crc 7e360eb6 )
-	rom ( name "1080 Snowboarding (JU) (M2) [!].z64" size 16777216 crc 08fe81c7 )
-	rom ( name "1080 Snowboarding (JU) (M2) [b1].z64" size 16777216 crc 1a5cdba6 )
-	rom ( name "1080 Snowboarding (JU) (M2) [b2].z64" size 16777216 crc a1dff82c )
-	rom ( name "1080 Snowboarding (JU) (M2) [b3].z64" size 16777216 crc e9fdcb54 )
-	rom ( name "1080 Snowboarding (JU) (M2) [b4].z64" size 16777216 crc 5ffac155 )
-	rom ( name "1080 Snowboarding (JU) (M2) [b5].z64" size 16777216 crc c3eba74a )
-	rom ( name "1080 Snowboarding (JU) (M2) [b6].z64" size 16777216 crc c71f2e9e )
-	rom ( name "1080 Snowboarding (JU) (M2) [b7].z64" size 16777216 crc 8c39ceab )
-	rom ( name "1080 Snowboarding (JU) (M2) [b8].z64" size 16777216 crc a59a9ca3 )
-	rom ( name "1080 Snowboarding (JU) (M2) [b9].z64" size 16777216 crc 06615926 )
-	rom ( name "1080 Snowboarding (JU) (M2) [ba].z64" size 16777216 crc 2efff977 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f1] (DS-1).z64" size 16777216 crc 3ed1c741 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f2] (PAL).z64" size 16777216 crc b1fc6b9d )
-	rom ( name "1080 Snowboarding (JU) (M2) [f2][b1].z64" size 16777216 crc 2d25e8d8 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f3][t1].z64" size 16777216 crc 33e0ab89 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f3][t2] (All Levels).z64" size 16777216 crc 8009aa55 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f4] (PAL-Z64).z64" size 16777216 crc e3969a61 )
-	rom ( name "1080 Snowboarding (JU) (M2) [f5] (SRAM).z64" size 16777216 crc c980f67f )
-	rom ( name "1080 Snowboarding (JU) (M2) [h1C].z64" size 16777216 crc 15bfdee8 )
-	rom ( name "1080 Snowboarding (JU) (M2) [h2C].z64" size 16777216 crc 407adfd5 )
-)
-
-game (
-	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World"
-	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World"
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!].z64" size 12582912 crc 67a789e5 )
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [b1].z64" size 12582912 crc 281185fb )
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h1C].z64" size 16777216 crc 97389efc )
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h2C].z64" size 12582912 crc b6fa1328 )
-	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [o1].z64" size 16777216 crc 63cd7973 )
-)
-
-game (
-	name "64 Hanafuda - Tenshi no Yakusoku"
-	description "64 Hanafuda - Tenshi no Yakusoku"
-	rom ( name "64 Hanafuda - Tenshi no Yakusoku (J) [!].z64" size 8388608 crc 60a680e7 )
-)
-
-game (
-	name "64 Oozumou"
-	description "64 Oozumou"
-	rom ( name "64 Oozumou (J) [!].z64" size 16777216 crc 742e31fb )
-	rom ( name "64 Oozumou (J) [b1].z64" size 16777216 crc 638ca205 )
-	rom ( name "64 Oozumou (J) [b2].z64" size 16777216 crc 71b80a1a )
-	rom ( name "64 Oozumou (J) [b3].z64" size 16515072 crc 820505f2 )
-)
-
-game (
-	name "64 Oozumou 2"
-	description "64 Oozumou 2"
-	rom ( name "64 Oozumou 2 (J) [!].z64" size 16777216 crc c1bc6fd8 )
-)
-
-game (
-	name "64 Trump Collection - Alice no Wakuwaku Trump World"
-	description "64 Trump Collection - Alice no Wakuwaku Trump World"
-	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!].z64" size 12582912 crc dca7f4eb )
-	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [h1C].z64" size 12582912 crc d4eaef9b )
-)
-
-game (
-	name "Action Replay Pro 64"
-	description "Action Replay Pro 64"
-	rom ( name "Action Replay Pro 64 V3.0 (Unl) [b1].z64" size 262144 crc 57225419 )
-	rom ( name "Action Replay Pro 64 V3.0 (Unl) [f1].z64" size 262144 crc b87db58a )
-	rom ( name "Action Replay Pro 64 V3.0 (Unl).z64" size 262144 crc c992dfb4 )
-	rom ( name "Action Replay Pro 64 V3.3 (Unl).z64" size 262144 crc 9fbabfda )
-)
-
-game (
-	name "AeroFighters Assault"
-	description "AeroFighters Assault"
-	rom ( name "AeroFighters Assault (E) (M3) [!].z64" size 12582912 crc 6a2b08da )
-	rom ( name "AeroFighters Assault (E) (M3) [f1] (NTSC).z64" size 16777216 crc 72e78322 )
-	rom ( name "AeroFighters Assault (E) (M3) [o1].z64" size 16777216 crc 5a8060eb )
-	rom ( name "AeroFighters Assault (U) [!].z64" size 8388608 crc 4370d7e3 )
-	rom ( name "AeroFighters Assault (U) [b1].z64" size 8388608 crc 6d5a0d7a )
-	rom ( name "AeroFighters Assault (U) [b2].z64" size 8388608 crc df81ebb3 )
-	rom ( name "AeroFighters Assault (U) [b3].z64" size 6815744 crc bac88428 )
-	rom ( name "AeroFighters Assault (U) [f1] (PAL).z64" size 8388608 crc 0e8c21d4 )
-	rom ( name "AeroFighters Assault (U) [h1C].z64" size 8388608 crc d1c34769 )
-	rom ( name "AeroFighters Assault (U) [h2C].z64" size 8388608 crc 1fc10b93 )
-	rom ( name "AeroFighters Assault (U) [h3C].z64" size 8388608 crc 126f23eb )
-	rom ( name "Sonic Wings Assault (J) [!].z64" size 8388608 crc fc73fb79 )
-)
+	name "1080 Snowboarding (E) (M4) [b1]"
+	description "1080 Snowboarding (E) (M4) [b1]"
+	rom ( name "1080 Snowboarding (E) (M4) [b1].z64" crc 9204CC62 )
+)
+
+game (
+	name "1080 Snowboarding (E) (M4) [b1][f2] (NTSC)"
+	description "1080 Snowboarding (E) (M4) [b1][f2] (NTSC)"
+	rom ( name "1080 Snowboarding (E) (M4) [b1][f2] (NTSC).z64" crc 933A9D1B )
+)
+
+game (
+	name "1080 Snowboarding (E) (M4) [f1]"
+	description "1080 Snowboarding (E) (M4) [f1]"
+	rom ( name "1080 Snowboarding (E) (M4) [f1].z64" crc F6A6E391 )
+)
+
+game (
+	name "1080 Snowboarding (E) (M4) [f2] (NTSC)"
+	description "1080 Snowboarding (E) (M4) [f2] (NTSC)"
+	rom ( name "1080 Snowboarding (E) (M4) [f2] (NTSC).z64" crc 7E360EB6 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [!]"
+	description "1080 Snowboarding (JU) (M2) [!]"
+	rom ( name "1080 Snowboarding (JU) (M2) [!].z64" crc 08FE81C7 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b1]"
+	description "1080 Snowboarding (JU) (M2) [b1]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b1].z64" crc 1A5CDBA6 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b2]"
+	description "1080 Snowboarding (JU) (M2) [b2]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b2].z64" crc A1DFF82C )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b3]"
+	description "1080 Snowboarding (JU) (M2) [b3]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b3].z64" crc E9FDCB54 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b4]"
+	description "1080 Snowboarding (JU) (M2) [b4]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b4].z64" crc 5FFAC155 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b5]"
+	description "1080 Snowboarding (JU) (M2) [b5]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b5].z64" crc C3EBA74A )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b6]"
+	description "1080 Snowboarding (JU) (M2) [b6]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b6].z64" crc C71F2E9E )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b7]"
+	description "1080 Snowboarding (JU) (M2) [b7]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b7].z64" crc 8C39CEAB )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b8]"
+	description "1080 Snowboarding (JU) (M2) [b8]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b8].z64" crc A59A9CA3 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [b9]"
+	description "1080 Snowboarding (JU) (M2) [b9]"
+	rom ( name "1080 Snowboarding (JU) (M2) [b9].z64" crc 06615926 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [ba]"
+	description "1080 Snowboarding (JU) (M2) [ba]"
+	rom ( name "1080 Snowboarding (JU) (M2) [ba].z64" crc 2EFFF977 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f1] (DS-1)"
+	description "1080 Snowboarding (JU) (M2) [f1] (DS-1)"
+	rom ( name "1080 Snowboarding (JU) (M2) [f1] (DS-1).z64" crc 3ED1C741 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f2] (PAL)"
+	description "1080 Snowboarding (JU) (M2) [f2] (PAL)"
+	rom ( name "1080 Snowboarding (JU) (M2) [f2] (PAL).z64" crc B1FC6B9D )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f2][b1]"
+	description "1080 Snowboarding (JU) (M2) [f2][b1]"
+	rom ( name "1080 Snowboarding (JU) (M2) [f2][b1].z64" crc 2D25E8D8 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f3][t1]"
+	description "1080 Snowboarding (JU) (M2) [f3][t1]"
+	rom ( name "1080 Snowboarding (JU) (M2) [f3][t1].z64" crc 33E0AB89 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f3][t2] (All Levels)"
+	description "1080 Snowboarding (JU) (M2) [f3][t2] (All Levels)"
+	rom ( name "1080 Snowboarding (JU) (M2) [f3][t2] (All Levels).z64" crc 8009AA55 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f4] (PAL-Z64)"
+	description "1080 Snowboarding (JU) (M2) [f4] (PAL-Z64)"
+	rom ( name "1080 Snowboarding (JU) (M2) [f4] (PAL-Z64).z64" crc E3969A61 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [f5] (SRAM)"
+	description "1080 Snowboarding (JU) (M2) [f5] (SRAM)"
+	rom ( name "1080 Snowboarding (JU) (M2) [f5] (SRAM).z64" crc C980F67F )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [h1C]"
+	description "1080 Snowboarding (JU) (M2) [h1C]"
+	rom ( name "1080 Snowboarding (JU) (M2) [h1C].z64" crc 15BFDEE8 )
+)
+
+game (
+	name "1080 Snowboarding (JU) (M2) [h2C]"
+	description "1080 Snowboarding (JU) (M2) [h2C]"
+	rom ( name "1080 Snowboarding (JU) (M2) [h2C].z64" crc 407ADFD5 )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!]"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!]"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!].z64" crc 67A789E5 )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [b1]"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [b1]"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [b1].z64" crc 281185FB )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h1C]"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h1C]"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h1C].z64" crc 97389EFC )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h2C]"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h2C]"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h2C].z64" crc B6FA1328 )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [o1]"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [o1]"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [o1].z64" crc 63CD7973 )
+)
+
+game (
+	name "64 Hanafuda - Tenshi no Yakusoku (J) [!]"
+	description "64 Hanafuda - Tenshi no Yakusoku (J) [!]"
+	rom ( name "64 Hanafuda - Tenshi no Yakusoku (J) [!].z64" crc 60A680E7 )
+)
+
+game (
+	name "64 Oozumou (J) [!]"
+	description "64 Oozumou (J) [!]"
+	rom ( name "64 Oozumou (J) [!].z64" crc 742E31FB )
+)
+
+game (
+	name "64 Oozumou (J) [b1]"
+	description "64 Oozumou (J) [b1]"
+	rom ( name "64 Oozumou (J) [b1].z64" crc 638CA205 )
+)
+
+game (
+	name "64 Oozumou (J) [b2]"
+	description "64 Oozumou (J) [b2]"
+	rom ( name "64 Oozumou (J) [b2].z64" crc 71B80A1A )
+)
+
+game (
+	name "64 Oozumou (J) [b3]"
+	description "64 Oozumou (J) [b3]"
+	rom ( name "64 Oozumou (J) [b3].z64" crc 820505F2 )
+)
+
+game (
+	name "64 Oozumou 2 (J) [!]"
+	description "64 Oozumou 2 (J) [!]"
+	rom ( name "64 Oozumou 2 (J) [!].z64" crc C1BC6FD8 )
+)
+
+game (
+	name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!]"
+	description "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!]"
+	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!].z64" crc DCA7F4EB )
+)
+
+game (
+	name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [h1C]"
+	description "64 Trump Collection - Alice no Wakuwaku Trump World (J) [h1C]"
+	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [h1C].z64" crc D4EAEF9B )
+)
+
+game (
+	name "Action Replay Pro 64 V3.0 (Unl) [b1]"
+	description "Action Replay Pro 64 V3.0 (Unl) [b1]"
+	rom ( name "Action Replay Pro 64 V3.0 (Unl) [b1].z64" crc 57225419 )
+)
+
+game (
+	name "Action Replay Pro 64 V3.0 (Unl) [f1]"
+	description "Action Replay Pro 64 V3.0 (Unl) [f1]"
+	rom ( name "Action Replay Pro 64 V3.0 (Unl) [f1].z64" crc B87DB58A )
+)
+
+game (
+	name "Action Replay Pro 64 V3.0 (Unl)"
+	description "Action Replay Pro 64 V3.0 (Unl)"
+	rom ( name "Action Replay Pro 64 V3.0 (Unl).z64" crc C992DFB4 )
+)
+
+game (
+	name "Action Replay Pro 64 V3.3 (Unl)"
+	description "Action Replay Pro 64 V3.3 (Unl)"
+	rom ( name "Action Replay Pro 64 V3.3 (Unl).z64" crc 9FBABFDA )
+)
+
+game (
+	name "AeroFighters Assault (E) (M3) [!]"
+	description "AeroFighters Assault (E) (M3) [!]"
+	rom ( name "AeroFighters Assault (E) (M3) [!].z64" crc 6A2B08DA )
+)
+
+game (
+	name "AeroFighters Assault (E) (M3) [f1] (NTSC)"
+	description "AeroFighters Assault (E) (M3) [f1] (NTSC)"
+	rom ( name "AeroFighters Assault (E) (M3) [f1] (NTSC).z64" crc 72E78322 )
+)
+
+game (
+	name "AeroFighters Assault (E) (M3) [o1]"
+	description "AeroFighters Assault (E) (M3) [o1]"
+	rom ( name "AeroFighters Assault (E) (M3) [o1].z64" crc 5A8060EB )
+)
+
+game (
+	name "AeroFighters Assault (U) [!]"
+	description "AeroFighters Assault (U) [!]"
+	rom ( name "AeroFighters Assault (U) [!].z64" crc 4370D7E3 )
+)
+
+game (
+	name "AeroFighters Assault (U) [b1]"
+	description "AeroFighters Assault (U) [b1]"
+	rom ( name "AeroFighters Assault (U) [b1].z64" crc 6D5A0D7A )
+)
+
+game (
+	name "AeroFighters Assault (U) [b2]"
+	description "AeroFighters Assault (U) [b2]"
+	rom ( name "AeroFighters Assault (U) [b2].z64" crc DF81EBB3 )
+)
+
+game (
+	name "AeroFighters Assault (U) [b3]"
+	description "AeroFighters Assault (U) [b3]"
+	rom ( name "AeroFighters Assault (U) [b3].z64" crc BAC88428 )
+)
+
+game (
+	name "AeroFighters Assault (U) [f1] (PAL)"
+	description "AeroFighters Assault (U) [f1] (PAL)"
+	rom ( name "AeroFighters Assault (U) [f1] (PAL).z64" crc 0E8C21D4 )
+)
+
+game (
+	name "AeroFighters Assault (U) [h1C]"
+	description "AeroFighters Assault (U) [h1C]"
+	rom ( name "AeroFighters Assault (U) [h1C].z64" crc D1C34769 )
+)
+
+game (
+	name "AeroFighters Assault (U) [h2C]"
+	description "AeroFighters Assault (U) [h2C]"
+	rom ( name "AeroFighters Assault (U) [h2C].z64" crc 1FC10B93 )
+)
+
+game (
+	name "AeroFighters Assault (U) [h3C]"
+	description "AeroFighters Assault (U) [h3C]"
+	rom ( name "AeroFighters Assault (U) [h3C].z64" crc 126F23EB )
+)
+
+game (
+	name "Sonic Wings Assault (J) [!]"
+	description "Sonic Wings Assault (J) [!]"
+	rom ( name "Sonic Wings Assault (J) [!].z64" crc FC73FB79 )
+)
+
+game (
+	name "AeroGauge (E) (M3) [!]"
+	description "AeroGauge (E) (M3) [!]"
+	rom ( name "AeroGauge (E) (M3) [!].z64" crc 040B0046 )
+)
+
+game (
+	name "AeroGauge (E) (M3) [f1] (NTSC)"
+	description "AeroGauge (E) (M3) [f1] (NTSC)"
+	rom ( name "AeroGauge (E) (M3) [f1] (NTSC).z64" crc 521865A1 )
+)
+
+game (
+	name "AeroGauge (E) (M3) [h1C]"
+	description "AeroGauge (E) (M3) [h1C]"
+	rom ( name "AeroGauge (E) (M3) [h1C].z64" crc 821D25CE )
+)
+
+game (
+	name "AeroGauge (E) (M3) [h2C]"
+	description "AeroGauge (E) (M3) [h2C]"
+	rom ( name "AeroGauge (E) (M3) [h2C].z64" crc A36E5628 )
+)
+
+game (
+	name "AeroGauge (J) (V1.0) (Kiosk Demo) [!]"
+	description "AeroGauge (J) (V1.0) (Kiosk Demo) [!]"
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [!].z64" crc 6EE3B932 )
+)
+
+game (
+	name "AeroGauge (J) (V1.0) (Kiosk Demo) [b1]"
+	description "AeroGauge (J) (V1.0) (Kiosk Demo) [b1]"
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b1].z64" crc 2F50E5AC )
+)
+
+game (
+	name "AeroGauge (J) (V1.0) (Kiosk Demo) [b2]"
+	description "AeroGauge (J) (V1.0) (Kiosk Demo) [b2]"
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b2].z64" crc AC1C4DEA )
+)
+
+game (
+	name "AeroGauge (J) (V1.0) (Kiosk Demo) [b3]"
+	description "AeroGauge (J) (V1.0) (Kiosk Demo) [b3]"
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b3].z64" crc D77CB849 )
+)
+
+game (
+	name "AeroGauge (J) (V1.0) (Kiosk Demo) [b4]"
+	description "AeroGauge (J) (V1.0) (Kiosk Demo) [b4]"
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b4].z64" crc 20BC4BE0 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [!]"
+	description "AeroGauge (J) (V1.1) [!]"
+	rom ( name "AeroGauge (J) (V1.1) [!].z64" crc F322B641 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b1]"
+	description "AeroGauge (J) (V1.1) [b1]"
+	rom ( name "AeroGauge (J) (V1.1) [b1].z64" crc 083CEA9C )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b2]"
+	description "AeroGauge (J) (V1.1) [b2]"
+	rom ( name "AeroGauge (J) (V1.1) [b2].z64" crc 90C976B3 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b3]"
+	description "AeroGauge (J) (V1.1) [b3]"
+	rom ( name "AeroGauge (J) (V1.1) [b3].z64" crc B32F01E9 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b4]"
+	description "AeroGauge (J) (V1.1) [b4]"
+	rom ( name "AeroGauge (J) (V1.1) [b4].z64" crc E75DE0A8 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b5]"
+	description "AeroGauge (J) (V1.1) [b5]"
+	rom ( name "AeroGauge (J) (V1.1) [b5].z64" crc 5447E02F )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b6]"
+	description "AeroGauge (J) (V1.1) [b6]"
+	rom ( name "AeroGauge (J) (V1.1) [b6].z64" crc 3386D6CF )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [b7]"
+	description "AeroGauge (J) (V1.1) [b7]"
+	rom ( name "AeroGauge (J) (V1.1) [b7].z64" crc D00C9205 )
+)
+
+game (
+	name "AeroGauge (J) (V1.1) [f1] (PAL)"
+	description "AeroGauge (J) (V1.1) [f1] (PAL)"
+	rom ( name "AeroGauge (J) (V1.1) [f1] (PAL).z64" crc 6462DB5A )
+)
+
+game (
+	name "AeroGauge (U) [!]"
+	description "AeroGauge (U) [!]"
+	rom ( name "AeroGauge (U) [!].z64" crc 198B9E0E )
+)
+
+game (
+	name "AeroGauge (U) [b1]"
+	description "AeroGauge (U) [b1]"
+	rom ( name "AeroGauge (U) [b1].z64" crc 042EFDF7 )
+)
+
+game (
+	name "AeroGauge (U) [f1] (PAL)"
+	description "AeroGauge (U) [f1] (PAL)"
+	rom ( name "AeroGauge (U) [f1] (PAL).z64" crc 5FC8383F )
+)
+
+game (
+	name "AeroGauge (U) [h1C]"
+	description "AeroGauge (U) [h1C]"
+	rom ( name "AeroGauge (U) [h1C].z64" crc 9F9DBB86 )
+)
+
+game (
+	name "AeroGauge (U) [h2C]"
+	description "AeroGauge (U) [h2C]"
+	rom ( name "AeroGauge (U) [h2C].z64" crc BEEEC860 )
+)
+
+game (
+	name "AeroGauge (U) [T+Ita0.01_Cattivik66]"
+	description "AeroGauge (U) [T+Ita0.01_Cattivik66]"
+	rom ( name "AeroGauge (U) [T+Ita0.01_Cattivik66].z64" crc 6A505B99 )
+)
+
+game (
+	name "AI Shougi 3 (J) [!]"
+	description "AI Shougi 3 (J) [!]"
+	rom ( name "AI Shougi 3 (J) [!].z64" crc 86DF90E6 )
+)
+
+game (
+	name "Aidyn Chronicles - The First Mage (E) [!]"
+	description "Aidyn Chronicles - The First Mage (E) [!]"
+	rom ( name "Aidyn Chronicles - The First Mage (E) [!].z64" crc BE7E230D )
+)
+
+game (
+	name "Aidyn Chronicles - The First Mage (U) [!]"
+	description "Aidyn Chronicles - The First Mage (U) [!]"
+	rom ( name "Aidyn Chronicles - The First Mage (U) [!].z64" crc B1F18186 )
+)
+
+game (
+	name "Aidyn Chronicles - The First Mage (U) [o1]"
+	description "Aidyn Chronicles - The First Mage (U) [o1]"
+	rom ( name "Aidyn Chronicles - The First Mage (U) [o1].z64" crc B4E83C35 )
+)
+
+game (
+	name "Airboarder 64 (E) [!]"
+	description "Airboarder 64 (E) [!]"
+	rom ( name "Airboarder 64 (E) [!].z64" crc C14D45AC )
+)
+
+game (
+	name "Airboarder 64 (E) [f1] (NTSC)"
+	description "Airboarder 64 (E) [f1] (NTSC)"
+	rom ( name "Airboarder 64 (E) [f1] (NTSC).z64" crc 5A820AEB )
+)
+
+game (
+	name "Airboarder 64 (E) [h1C]"
+	description "Airboarder 64 (E) [h1C]"
+	rom ( name "Airboarder 64 (E) [h1C].z64" crc 33D91397 )
+)
+
+game (
+	name "Airboarder 64 (J) [!]"
+	description "Airboarder 64 (J) [!]"
+	rom ( name "Airboarder 64 (J) [!].z64" crc 58FCB771 )
+)
+
+game (
+	name "Airboarder 64 (J) [b1]"
+	description "Airboarder 64 (J) [b1]"
+	rom ( name "Airboarder 64 (J) [b1].z64" crc 74210E87 )
+)
+
+game (
+	name "Airboarder 64 (J) [b1][t1]"
+	description "Airboarder 64 (J) [b1][t1]"
+	rom ( name "Airboarder 64 (J) [b1][t1].z64" crc 3ECD5B63 )
+)
+
+game (
+	name "Airboarder 64 (J) [b2]"
+	description "Airboarder 64 (J) [b2]"
+	rom ( name "Airboarder 64 (J) [b2].z64" crc F91056A0 )
+)
+
+game (
+	name "Airboarder 64 (J) [b3]"
+	description "Airboarder 64 (J) [b3]"
+	rom ( name "Airboarder 64 (J) [b3].z64" crc 2D4F7C45 )
+)
+
+game (
+	name "Airboarder 64 (J) [f1] (PAL)"
+	description "Airboarder 64 (J) [f1] (PAL)"
+	rom ( name "Airboarder 64 (J) [f1] (PAL).z64" crc DEE11797 )
+)
+
+game (
+	name "Airboarder 64 (J) [h1C]"
+	description "Airboarder 64 (J) [h1C]"
+	rom ( name "Airboarder 64 (J) [h1C].z64" crc 50598308 )
+)
+
+game (
+	name "Airboarder 64 (J) [h2C]"
+	description "Airboarder 64 (J) [h2C]"
+	rom ( name "Airboarder 64 (J) [h2C].z64" crc 1C5EED6E )
+)
+
+game (
+	name "Airboarder 64 (J) [h3C]"
+	description "Airboarder 64 (J) [h3C]"
+	rom ( name "Airboarder 64 (J) [h3C].z64" crc 43D2EE8A )
+)
+
+game (
+	name "Airboarder 64 (J) [h4C]"
+	description "Airboarder 64 (J) [h4C]"
+	rom ( name "Airboarder 64 (J) [h4C].z64" crc B146B8B1 )
+)
+
+game (
+	name "Airboarder 64 (J) [h5C]"
+	description "Airboarder 64 (J) [h5C]"
+	rom ( name "Airboarder 64 (J) [h5C].z64" crc 7346313D )
+)
+
+game (
+	name "Airboarder 64 (J) [h6C]"
+	description "Airboarder 64 (J) [h6C]"
+	rom ( name "Airboarder 64 (J) [h6C].z64" crc E5E93FF3 )
+)
+
+game (
+	name "Airboarder 64 (J) [t1]"
+	description "Airboarder 64 (J) [t1]"
+	rom ( name "Airboarder 64 (J) [t1].z64" crc DB44D4C2 )
+)
+
+game (
+	name "All Star Tennis '99 (E) (M5) [!]"
+	description "All Star Tennis '99 (E) (M5) [!]"
+	rom ( name "All Star Tennis '99 (E) (M5) [!].z64" crc 996E845F )
+)
+
+game (
+	name "All Star Tennis '99 (E) (M5) [f1] (NTSC)"
+	description "All Star Tennis '99 (E) (M5) [f1] (NTSC)"
+	rom ( name "All Star Tennis '99 (E) (M5) [f1] (NTSC).z64" crc F9BB05A1 )
+)
+
+game (
+	name "All Star Tennis '99 (E) (M5) [f2] (NTSC)"
+	description "All Star Tennis '99 (E) (M5) [f2] (NTSC)"
+	rom ( name "All Star Tennis '99 (E) (M5) [f2] (NTSC).z64" crc 0A0B0FFC )
+)
+
+game (
+	name "All Star Tennis '99 (E) (M5) [f3] (NTSC)"
+	description "All Star Tennis '99 (E) (M5) [f3] (NTSC)"
+	rom ( name "All Star Tennis '99 (E) (M5) [f3] (NTSC).z64" crc CD951F26 )
+)
+
+game (
+	name "All Star Tennis '99 (E) (M5) [f4] (NTSC)"
+	description "All Star Tennis '99 (E) (M5) [f4] (NTSC)"
+	rom ( name "All Star Tennis '99 (E) (M5) [f4] (NTSC).z64" crc EDD65146 )
+)
+
+game (
+	name "All Star Tennis '99 (U) [!]"
+	description "All Star Tennis '99 (U) [!]"
+	rom ( name "All Star Tennis '99 (U) [!].z64" crc A7DCF638 )
+)
+
+game (
+	name "All Star Tennis '99 (U) [f1] (PAL)"
+	description "All Star Tennis '99 (U) [f1] (PAL)"
+	rom ( name "All Star Tennis '99 (U) [f1] (PAL).z64" crc 78B03963 )
+)
+
+game (
+	name "All Star Tennis '99 (U) [f2] (PAL)"
+	description "All Star Tennis '99 (U) [f2] (PAL)"
+	rom ( name "All Star Tennis '99 (U) [f2] (PAL).z64" crc 6238BB48 )
+)
+
+game (
+	name "All Star Tennis '99 (U) [h1C]"
+	description "All Star Tennis '99 (U) [h1C]"
+	rom ( name "All Star Tennis '99 (U) [h1C].z64" crc ADD1E941 )
+)
+
+game (
+	name "All Star Tennis '99 (U) [T+Bra1.0_Guto]"
+	description "All Star Tennis '99 (U) [T+Bra1.0_Guto]"
+	rom ( name "All Star Tennis '99 (U) [T+Bra1.0_Guto].z64" crc A7196CA9 )
+)
+
+game (
+	name "All-Star Baseball '99 (E) [!]"
+	description "All-Star Baseball '99 (E) [!]"
+	rom ( name "All-Star Baseball '99 (E) [!].z64" crc D0DE3584 )
+)
+
+game (
+	name "All-Star Baseball '99 (U) [!]"
+	description "All-Star Baseball '99 (U) [!]"
+	rom ( name "All-Star Baseball '99 (U) [!].z64" crc 6D25B36F )
+)
+
+game (
+	name "All-Star Baseball '99 (U) [f1] (PAL)"
+	description "All-Star Baseball '99 (U) [f1] (PAL)"
+	rom ( name "All-Star Baseball '99 (U) [f1] (PAL).z64" crc 8749CFC1 )
+)
+
+game (
+	name "All-Star Baseball '99 (U) [o1]"
+	description "All-Star Baseball '99 (U) [o1]"
+	rom ( name "All-Star Baseball '99 (U) [o1].z64" crc 43421A65 )
+)
+
+game (
+	name "All-Star Baseball 2000 (E) [!]"
+	description "All-Star Baseball 2000 (E) [!]"
+	rom ( name "All-Star Baseball 2000 (E) [!].z64" crc D3C29AA4 )
+)
+
+game (
+	name "All-Star Baseball 2000 (E) [f1] (NTSC)"
+	description "All-Star Baseball 2000 (E) [f1] (NTSC)"
+	rom ( name "All-Star Baseball 2000 (E) [f1] (NTSC).z64" crc 3FC70C72 )
+)
+
+game (
+	name "All-Star Baseball 2000 (U) [!]"
+	description "All-Star Baseball 2000 (U) [!]"
+	rom ( name "All-Star Baseball 2000 (U) [!].z64" crc 69E88471 )
+)
+
+game (
+	name "All-Star Baseball 2000 (U) [f1] (PAL)"
+	description "All-Star Baseball 2000 (U) [f1] (PAL)"
+	rom ( name "All-Star Baseball 2000 (U) [f1] (PAL).z64" crc DE5D7096 )
+)
+
+game (
+	name "All-Star Baseball 2000 (U) [h1C]"
+	description "All-Star Baseball 2000 (U) [h1C]"
+	rom ( name "All-Star Baseball 2000 (U) [h1C].z64" crc 936ABE15 )
+)
+
+game (
+	name "All-Star Baseball 2000 (U) [h2C]"
+	description "All-Star Baseball 2000 (U) [h2C]"
+	rom ( name "All-Star Baseball 2000 (U) [h2C].z64" crc 8327D5D7 )
+)
+
+game (
+	name "All-Star Baseball 2001 (U) [!]"
+	description "All-Star Baseball 2001 (U) [!]"
+	rom ( name "All-Star Baseball 2001 (U) [!].z64" crc 4D659E85 )
+)
+
+game (
+	name "All-Star Baseball 2001 (U) [f1] (PAL)"
+	description "All-Star Baseball 2001 (U) [f1] (PAL)"
+	rom ( name "All-Star Baseball 2001 (U) [f1] (PAL).z64" crc 50F2289D )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (E) [!]"
+	description "Armorines - Project S.W.A.R.M. (E) [!]"
+	rom ( name "Armorines - Project S.W.A.R.M. (E) [!].z64" crc 600BC49E )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (E) [f1] (NTSC)"
+	description "Armorines - Project S.W.A.R.M. (E) [f1] (NTSC)"
+	rom ( name "Armorines - Project S.W.A.R.M. (E) [f1] (NTSC).z64" crc ABF06B85 )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (G) [!]"
+	description "Armorines - Project S.W.A.R.M. (G) [!]"
+	rom ( name "Armorines - Project S.W.A.R.M. (G) [!].z64" crc 5BAB9100 )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (G) [f1] (NTSC)"
+	description "Armorines - Project S.W.A.R.M. (G) [f1] (NTSC)"
+	rom ( name "Armorines - Project S.W.A.R.M. (G) [f1] (NTSC).z64" crc D7EEB023 )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (U) [!]"
+	description "Armorines - Project S.W.A.R.M. (U) [!]"
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [!].z64" crc 630A19E2 )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (U) [f1] (PAL)"
+	description "Armorines - Project S.W.A.R.M. (U) [f1] (PAL)"
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [f1] (PAL).z64" crc DEDA354C )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M. (U) [t1]"
+	description "Armorines - Project S.W.A.R.M. (U) [t1]"
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [t1].z64" crc 0A51D29C )
+)
+
+game (
+	name "Army Men - Air Combat (U) [!]"
+	description "Army Men - Air Combat (U) [!]"
+	rom ( name "Army Men - Air Combat (U) [!].z64" crc 1952CC87 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (E) (M3) [!]"
+	description "Army Men - Sarge's Heroes (E) (M3) [!]"
+	rom ( name "Army Men - Sarge's Heroes (E) (M3) [!].z64" crc E79048E2 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [!]"
+	description "Army Men - Sarge's Heroes (U) [!]"
+	rom ( name "Army Men - Sarge's Heroes (U) [!].z64" crc 2FE786F6 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [b1]"
+	description "Army Men - Sarge's Heroes (U) [b1]"
+	rom ( name "Army Men - Sarge's Heroes (U) [b1].z64" crc 1F6724F7 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [f1] (PAL)"
+	description "Army Men - Sarge's Heroes (U) [f1] (PAL)"
+	rom ( name "Army Men - Sarge's Heroes (U) [f1] (PAL).z64" crc 5E67A745 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [t1]"
+	description "Army Men - Sarge's Heroes (U) [t1]"
+	rom ( name "Army Men - Sarge's Heroes (U) [t1].z64" crc 675938D9 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [t2]"
+	description "Army Men - Sarge's Heroes (U) [t2]"
+	rom ( name "Army Men - Sarge's Heroes (U) [t2].z64" crc 58F10814 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (U) [t3]"
+	description "Army Men - Sarge's Heroes (U) [t3]"
+	rom ( name "Army Men - Sarge's Heroes (U) [t3].z64" crc A14C9EFC )
+)
+
+game (
+	name "Army Men - Sarge's Heroes 2 (U) [!]"
+	description "Army Men - Sarge's Heroes 2 (U) [!]"
+	rom ( name "Army Men - Sarge's Heroes 2 (U) [!].z64" crc 79A71608 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes 2 (U) [t1]"
+	description "Army Men - Sarge's Heroes 2 (U) [t1]"
+	rom ( name "Army Men - Sarge's Heroes 2 (U) [t1].z64" crc 7FDC2D7D )
+)
+
+game (
+	name "Asteroids Hyper 64 (U) [!]"
+	description "Asteroids Hyper 64 (U) [!]"
+	rom ( name "Asteroids Hyper 64 (U) [!].z64" crc F5CE3D91 )
+)
+
+game (
+	name "Asteroids Hyper 64 (U) [o1]"
+	description "Asteroids Hyper 64 (U) [o1]"
+	rom ( name "Asteroids Hyper 64 (U) [o1].z64" crc 91AA6689 )
+)
+
+game (
+	name "Asteroids Hyper 64 (U) [o1][f1] (PAL)"
+	description "Asteroids Hyper 64 (U) [o1][f1] (PAL)"
+	rom ( name "Asteroids Hyper 64 (U) [o1][f1] (PAL).z64" crc FD3D371B )
+)
+
+game (
+	name "Asteroids Hyper 64 (U) [o1][t1]"
+	description "Asteroids Hyper 64 (U) [o1][t1]"
+	rom ( name "Asteroids Hyper 64 (U) [o1][t1].z64" crc D65F7B9A )
+)
+
+game (
+	name "Automobili Lamborghini (E) [!]"
+	description "Automobili Lamborghini (E) [!]"
+	rom ( name "Automobili Lamborghini (E) [!].z64" crc 3BAF58D5 )
+)
+
+game (
+	name "Automobili Lamborghini (E) [o1]"
+	description "Automobili Lamborghini (E) [o1]"
+	rom ( name "Automobili Lamborghini (E) [o1].z64" crc 95107C80 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [!]"
+	description "Automobili Lamborghini (U) [!]"
+	rom ( name "Automobili Lamborghini (U) [!].z64" crc A4374EAC )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b1]"
+	description "Automobili Lamborghini (U) [b1]"
+	rom ( name "Automobili Lamborghini (U) [b1].z64" crc 5D371E34 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b2]"
+	description "Automobili Lamborghini (U) [b2]"
+	rom ( name "Automobili Lamborghini (U) [b2].z64" crc 2DDCD6C5 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b3]"
+	description "Automobili Lamborghini (U) [b3]"
+	rom ( name "Automobili Lamborghini (U) [b3].z64" crc 94766BDA )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b4]"
+	description "Automobili Lamborghini (U) [b4]"
+	rom ( name "Automobili Lamborghini (U) [b4].z64" crc E62BED9D )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b5]"
+	description "Automobili Lamborghini (U) [b5]"
+	rom ( name "Automobili Lamborghini (U) [b5].z64" crc B5BB916B )
+)
+
+game (
+	name "Automobili Lamborghini (U) [b6]"
+	description "Automobili Lamborghini (U) [b6]"
+	rom ( name "Automobili Lamborghini (U) [b6].z64" crc 8D796095 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [f1]"
+	description "Automobili Lamborghini (U) [f1]"
+	rom ( name "Automobili Lamborghini (U) [f1].z64" crc F922947E )
+)
+
+game (
+	name "Automobili Lamborghini (U) [h1C]"
+	description "Automobili Lamborghini (U) [h1C]"
+	rom ( name "Automobili Lamborghini (U) [h1C].z64" crc 7D8A5BB2 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [h2C]"
+	description "Automobili Lamborghini (U) [h2C]"
+	rom ( name "Automobili Lamborghini (U) [h2C].z64" crc 68D2AA64 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o1]"
+	description "Automobili Lamborghini (U) [o1]"
+	rom ( name "Automobili Lamborghini (U) [o1].z64" crc 190288D7 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o1][T+Ita_cattivik66]"
+	description "Automobili Lamborghini (U) [o1][T+Ita_cattivik66]"
+	rom ( name "Automobili Lamborghini (U) [o1][T+Ita_cattivik66].z64" crc 1F38D9C4 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o2]"
+	description "Automobili Lamborghini (U) [o2]"
+	rom ( name "Automobili Lamborghini (U) [o2].z64" crc 006C9B00 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o3]"
+	description "Automobili Lamborghini (U) [o3]"
+	rom ( name "Automobili Lamborghini (U) [o3].z64" crc 5BF77066 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o4]"
+	description "Automobili Lamborghini (U) [o4]"
+	rom ( name "Automobili Lamborghini (U) [o4].z64" crc 231DEFAE )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o5]"
+	description "Automobili Lamborghini (U) [o5]"
+	rom ( name "Automobili Lamborghini (U) [o5].z64" crc CD100474 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o6]"
+	description "Automobili Lamborghini (U) [o6]"
+	rom ( name "Automobili Lamborghini (U) [o6].z64" crc 1D23F90B )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o7]"
+	description "Automobili Lamborghini (U) [o7]"
+	rom ( name "Automobili Lamborghini (U) [o7].z64" crc 3A760D0B )
+)
+
+game (
+	name "Automobili Lamborghini (U) [o7][T+Ita_cattivik66]"
+	description "Automobili Lamborghini (U) [o7][T+Ita_cattivik66]"
+	rom ( name "Automobili Lamborghini (U) [o7][T+Ita_cattivik66].z64" crc 405C647D )
+)
+
+game (
+	name "Automobili Lamborghini (U) [T+Ita_cattivik66][b3]"
+	description "Automobili Lamborghini (U) [T+Ita_cattivik66][b3]"
+	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b3].z64" crc 4A0325BE )
+)
+
+game (
+	name "Automobili Lamborghini (U) [T+Ita_cattivik66][b4]"
+	description "Automobili Lamborghini (U) [T+Ita_cattivik66][b4]"
+	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b4].z64" crc 1C0D6E98 )
+)
+
+game (
+	name "Automobili Lamborghini (U) [t1]"
+	description "Automobili Lamborghini (U) [t1]"
+	rom ( name "Automobili Lamborghini (U) [t1].z64" crc 5BE718FA )
+)
+
+game (
+	name "Super Speed Race 64 (J) [!]"
+	description "Super Speed Race 64 (J) [!]"
+	rom ( name "Super Speed Race 64 (J) [!].z64" crc 0F879A70 )
+)
+
+game (
+	name "Super Speed Race 64 (J) [o1]"
+	description "Super Speed Race 64 (J) [o1]"
+	rom ( name "Super Speed Race 64 (J) [o1].z64" crc D94FD663 )
+)
+
+game (
+	name "Bakuretsu Muteki Bangai-O (J) [!]"
+	description "Bakuretsu Muteki Bangai-O (J) [!]"
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [!].z64" crc 6AB7FEC6 )
+)
+
+game (
+	name "Bakuretsu Muteki Bangai-O (J) [f1] (PAL)"
+	description "Bakuretsu Muteki Bangai-O (J) [f1] (PAL)"
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [f1] (PAL).z64" crc 2582FDA5 )
+)
+
+game (
+	name "Bakuretsu Muteki Bangai-O (J) [h1C]"
+	description "Bakuretsu Muteki Bangai-O (J) [h1C]"
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [h1C].z64" crc C76F1D4C )
+)
+
+game (
+	name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!]"
+	description "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!]"
+	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!].z64" crc EF8C2F34 )
+)
+
+game (
+	name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C]"
+	description "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C]"
+	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C].z64" crc 47DB2246 )
+)
+
+game (
+	name "Banjo to Kazooie no Daibouken 2 (J) [!]"
+	description "Banjo to Kazooie no Daibouken 2 (J) [!]"
+	rom ( name "Banjo to Kazooie no Daibouken 2 (J) [!].z64" crc 258C58D0 )
+)
+
+game (
+	name "Banjo-Tooie (A) [!]"
+	description "Banjo-Tooie (A) [!]"
+	rom ( name "Banjo-Tooie (A) [!].z64" crc 2736266A )
+)
+
+game (
+	name "Banjo-Tooie (E) (M4) [!]"
+	description "Banjo-Tooie (E) (M4) [!]"
+	rom ( name "Banjo-Tooie (E) (M4) [!].z64" crc 1EC12F5A )
+)
+
+game (
+	name "Banjo-Tooie (U) [!]"
+	description "Banjo-Tooie (U) [!]"
+	rom ( name "Banjo-Tooie (U) [!].z64" crc BAB803EF )
+)
+
+game (
+	name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!]"
+	description "Bass Rush - ECOGEAR PowerWorm Championship (J) [!]"
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!].z64" crc 383B86EF )
+)
+
+game (
+	name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b1]"
+	description "Bass Rush - ECOGEAR PowerWorm Championship (J) [b1]"
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b1].z64" crc 2AC04018 )
+)
+
+game (
+	name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b2]"
+	description "Bass Rush - ECOGEAR PowerWorm Championship (J) [b2]"
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b2].z64" crc 2C3A7B2B )
+)
+
+game (
+	name "Bassmasters 2000 (U) [!]"
+	description "Bassmasters 2000 (U) [!]"
+	rom ( name "Bassmasters 2000 (U) [!].z64" crc 6B09092E )
+)
+
+game (
+	name "Bassmasters 2000 (U) [b1]"
+	description "Bassmasters 2000 (U) [b1]"
+	rom ( name "Bassmasters 2000 (U) [b1].z64" crc FF7FF0EC )
+)
+
+game (
+	name "Bassmasters 2000 (U) [f1] (PAL)"
+	description "Bassmasters 2000 (U) [f1] (PAL)"
+	rom ( name "Bassmasters 2000 (U) [f1] (PAL).z64" crc 38B00D48 )
+)
+
+game (
+	name "Batman Beyond - Return of the Joker (U) [!]"
+	description "Batman Beyond - Return of the Joker (U) [!]"
+	rom ( name "Batman Beyond - Return of the Joker (U) [!].z64" crc 35299F9C )
+)
+
+game (
+	name "Batman Beyond - Return of the Joker (U) [o1]"
+	description "Batman Beyond - Return of the Joker (U) [o1]"
+	rom ( name "Batman Beyond - Return of the Joker (U) [o1].z64" crc 6C5AB61E )
+)
+
+game (
+	name "Batman Beyond - Return of the Joker (U) [o1][t1]"
+	description "Batman Beyond - Return of the Joker (U) [o1][t1]"
+	rom ( name "Batman Beyond - Return of the Joker (U) [o1][t1].z64" crc 0184342F )
+)
+
+game (
+	name "Batman of the Future - Return of the Joker (E) (M3) [!]"
+	description "Batman of the Future - Return of the Joker (E) (M3) [!]"
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [!].z64" crc 82A4BB8A )
+)
+
+game (
+	name "Batman of the Future - Return of the Joker (E) (M3) [b1]"
+	description "Batman of the Future - Return of the Joker (E) (M3) [b1]"
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [b1].z64" crc 353DD094 )
+)
+
+game (
+	name "Batman of the Future - Return of the Joker (E) (M3) [o1]"
+	description "Batman of the Future - Return of the Joker (E) (M3) [o1]"
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [o1].z64" crc 564125B9 )
+)
+
+game (
+	name "BattleTanx (U) [!]"
+	description "BattleTanx (U) [!]"
+	rom ( name "BattleTanx (U) [!].z64" crc 6C230765 )
+)
+
+game (
+	name "BattleTanx (U) [b1]"
+	description "BattleTanx (U) [b1]"
+	rom ( name "BattleTanx (U) [b1].z64" crc 716239A4 )
+)
+
+game (
+	name "BattleTanx (U) [b1][t1]"
+	description "BattleTanx (U) [b1][t1]"
+	rom ( name "BattleTanx (U) [b1][t1].z64" crc B6697B5C )
+)
+
+game (
+	name "BattleTanx (U) [f1] (PAL)"
+	description "BattleTanx (U) [f1] (PAL)"
+	rom ( name "BattleTanx (U) [f1] (PAL).z64" crc 0E897622 )
+)
+
+game (
+	name "BattleTanx (U) [t1]"
+	description "BattleTanx (U) [t1]"
+	rom ( name "BattleTanx (U) [t1].z64" crc 245A516B )
+)
+
+game (
+	name "BattleTanx - Global Assault (E) (M3) [!]"
+	description "BattleTanx - Global Assault (E) (M3) [!]"
+	rom ( name "BattleTanx - Global Assault (E) (M3) [!].z64" crc C99C6030 )
+)
+
+game (
+	name "BattleTanx - Global Assault (U) [!]"
+	description "BattleTanx - Global Assault (U) [!]"
+	rom ( name "BattleTanx - Global Assault (U) [!].z64" crc 31BEB053 )
+)
+
+game (
+	name "BattleTanx - Global Assault (U) [f1] (Country Check)"
+	description "BattleTanx - Global Assault (U) [f1] (Country Check)"
+	rom ( name "BattleTanx - Global Assault (U) [f1] (Country Check).z64" crc D375DEBC )
+)
+
+game (
+	name "BattleTanx - Global Assault (U) [f2] (PAL)"
+	description "BattleTanx - Global Assault (U) [f2] (PAL)"
+	rom ( name "BattleTanx - Global Assault (U) [f2] (PAL).z64" crc E448B23F )
+)
+
+game (
+	name "Battlezone - Rise of the Black Dogs (U) [!]"
+	description "Battlezone - Rise of the Black Dogs (U) [!]"
+	rom ( name "Battlezone - Rise of the Black Dogs (U) [!].z64" crc 736F9D5C )
+)
+
+game (
+	name "Beetle Adventure Racing! (E) (M3) [!]"
+	description "Beetle Adventure Racing! (E) (M3) [!]"
+	rom ( name "Beetle Adventure Racing! (E) (M3) [!].z64" crc 5B6C6E4C )
+)
+
+game (
+	name "Beetle Adventure Racing! (E) (M3) [h1C]"
+	description "Beetle Adventure Racing! (E) (M3) [h1C]"
+	rom ( name "Beetle Adventure Racing! (E) (M3) [h1C].z64" crc B0986539 )
+)
+
+game (
+	name "Beetle Adventure Racing! (E) (M3) [t1]"
+	description "Beetle Adventure Racing! (E) (M3) [t1]"
+	rom ( name "Beetle Adventure Racing! (E) (M3) [t1].z64" crc 0605AE3C )
+)
+
+game (
+	name "Beetle Adventure Racing! (J) [!]"
+	description "Beetle Adventure Racing! (J) [!]"
+	rom ( name "Beetle Adventure Racing! (J) [!].z64" crc 49E75825 )
+)
+
+game (
+	name "Beetle Adventure Racing! (J) [b1]"
+	description "Beetle Adventure Racing! (J) [b1]"
+	rom ( name "Beetle Adventure Racing! (J) [b1].z64" crc 54085E2E )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [!]"
+	description "Beetle Adventure Racing! (U) (M3) [!]"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [!].z64" crc F4A97C73 )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [b1]"
+	description "Beetle Adventure Racing! (U) (M3) [b1]"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [b1].z64" crc 94C6C38E )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [b2]"
+	description "Beetle Adventure Racing! (U) (M3) [b2]"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [b2].z64" crc CFA90A9C )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [f1] (PAL)"
+	description "Beetle Adventure Racing! (U) (M3) [f1] (PAL)"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [f1] (PAL).z64" crc 9E372E72 )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [t1]"
+	description "Beetle Adventure Racing! (U) (M3) [t1]"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [t1].z64" crc 67389D41 )
+)
+
+game (
+	name "Beetle Adventure Racing! (U) (M3) [t2]"
+	description "Beetle Adventure Racing! (U) (M3) [t2]"
+	rom ( name "Beetle Adventure Racing! (U) (M3) [t2].z64" crc E5164EB0 )
+)
+
+game (
+	name "HSV Adventure Racing (A) [b1]"
+	description "HSV Adventure Racing (A) [b1]"
+	rom ( name "HSV Adventure Racing (A) [b1].z64" crc 513B0745 )
+)
+
+game (
+	name "HSV Adventure Racing (A) [f1] (NTSC)"
+	description "HSV Adventure Racing (A) [f1] (NTSC)"
+	rom ( name "HSV Adventure Racing (A) [f1] (NTSC).z64" crc CE50FDB3 )
+)
+
+game (
+	name "HSV Adventure Racing (A)"
+	description "HSV Adventure Racing (A)"
+	rom ( name "HSV Adventure Racing (A).z64" crc C0BA9440 )
+)
+
+game (
+	name "Big Mountain 2000 (U) [!]"
+	description "Big Mountain 2000 (U) [!]"
+	rom ( name "Big Mountain 2000 (U) [!].z64" crc 3AC924BC )
+)
+
+game (
+	name "Big Mountain 2000 (U) [t1]"
+	description "Big Mountain 2000 (U) [t1]"
+	rom ( name "Big Mountain 2000 (U) [t1].z64" crc 5B7C40DC )
+)
+
+game (
+	name "Snow Speeder (J) [!]"
+	description "Snow Speeder (J) [!]"
+	rom ( name "Snow Speeder (J) [!].z64" crc 30EA3FD7 )
+)
+
+game (
+	name "Snow Speeder (J) [b1]"
+	description "Snow Speeder (J) [b1]"
+	rom ( name "Snow Speeder (J) [b1].z64" crc 0D85C419 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (E) [!]"
+	description "Bio F.R.E.A.K.S. (E) [!]"
+	rom ( name "Bio F.R.E.A.K.S. (E) [!].z64" crc 2C4EB906 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (E) [b1]"
+	description "Bio F.R.E.A.K.S. (E) [b1]"
+	rom ( name "Bio F.R.E.A.K.S. (E) [b1].z64" crc 786C72E2 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [!]"
+	description "Bio F.R.E.A.K.S. (U) [!]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [!].z64" crc DFBF448C )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [b1]"
+	description "Bio F.R.E.A.K.S. (U) [b1]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [b1].z64" crc 06134DAE )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [b2]"
+	description "Bio F.R.E.A.K.S. (U) [b2]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [b2].z64" crc C1BA30A0 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [b3]"
+	description "Bio F.R.E.A.K.S. (U) [b3]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [b3].z64" crc 68269493 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [h1C]"
+	description "Bio F.R.E.A.K.S. (U) [h1C]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [h1C].z64" crc 5BF5ACEE )
+)
+
+game (
+	name "Bio F.R.E.A.K.S. (U) [t1]"
+	description "Bio F.R.E.A.K.S. (U) [t1]"
+	rom ( name "Bio F.R.E.A.K.S. (U) [t1].z64" crc D239559B )
+)
+
+game (
+	name "Blast Corps (E) (M2) [!]"
+	description "Blast Corps (E) (M2) [!]"
+	rom ( name "Blast Corps (E) (M2) [!].z64" crc 4C820695 )
+)
+
+game (
+	name "Blast Corps (E) (M2) [b1]"
+	description "Blast Corps (E) (M2) [b1]"
+	rom ( name "Blast Corps (E) (M2) [b1].z64" crc 529072B8 )
+)
+
+game (
+	name "Blast Corps (E) (M2) [b2]"
+	description "Blast Corps (E) (M2) [b2]"
+	rom ( name "Blast Corps (E) (M2) [b2].z64" crc AE6DF20F )
+)
+
+game (
+	name "Blast Corps (U) (V1.0) [!]"
+	description "Blast Corps (U) (V1.0) [!]"
+	rom ( name "Blast Corps (U) (V1.0) [!].z64" crc 767A95E7 )
+)
+
+game (
+	name "Blast Corps (U) (V1.0) [b1]"
+	description "Blast Corps (U) (V1.0) [b1]"
+	rom ( name "Blast Corps (U) (V1.0) [b1].z64" crc 43484DA5 )
+)
+
+game (
+	name "Blast Corps (U) (V1.0) [b2]"
+	description "Blast Corps (U) (V1.0) [b2]"
+	rom ( name "Blast Corps (U) (V1.0) [b2].z64" crc E7FD8279 )
+)
+
+game (
+	name "Blast Corps (U) (V1.1) [!]"
+	description "Blast Corps (U) (V1.1) [!]"
+	rom ( name "Blast Corps (U) (V1.1) [!].z64" crc 9CBBCCF1 )
+)
+
+game (
+	name "Blast Dozer (J) [!]"
+	description "Blast Dozer (J) [!]"
+	rom ( name "Blast Dozer (J) [!].z64" crc 081A3641 )
+)
+
+game (
+	name "Blast Dozer (J) [b1]"
+	description "Blast Dozer (J) [b1]"
+	rom ( name "Blast Dozer (J) [b1].z64" crc 5C01AB00 )
+)
+
+game (
+	name "Blues Brothers 2000 (E) (M6) [!]"
+	description "Blues Brothers 2000 (E) (M6) [!]"
+	rom ( name "Blues Brothers 2000 (E) (M6) [!].z64" crc 8FB41658 )
+)
+
+game (
+	name "Blues Brothers 2000 (U) [!]"
+	description "Blues Brothers 2000 (U) [!]"
+	rom ( name "Blues Brothers 2000 (U) [!].z64" crc C6F49764 )
+)
+
+game (
+	name "Blues Brothers 2000 (U) [f1] (PAL-NTSC)"
+	description "Blues Brothers 2000 (U) [f1] (PAL-NTSC)"
+	rom ( name "Blues Brothers 2000 (U) [f1] (PAL-NTSC).z64" crc C978C9B2 )
+)
+
+game (
+	name "Blues Brothers 2000 (U) [t1]"
+	description "Blues Brothers 2000 (U) [t1]"
+	rom ( name "Blues Brothers 2000 (U) [t1].z64" crc 3AE17959 )
+)
+
+game (
+	name "Blues Brothers 2000 (U) [t1][f1] (PAL-NTSC)"
+	description "Blues Brothers 2000 (U) [t1][f1] (PAL-NTSC)"
+	rom ( name "Blues Brothers 2000 (U) [t1][f1] (PAL-NTSC).z64" crc F0EF67EF )
+)
+
+game (
+	name "Body Harvest (E) (M3) [!]"
+	description "Body Harvest (E) (M3) [!]"
+	rom ( name "Body Harvest (E) (M3) [!].z64" crc 6A04CDAE )
+)
+
+game (
+	name "Body Harvest (E) (M3) [f1] (NTSC)"
+	description "Body Harvest (E) (M3) [f1] (NTSC)"
+	rom ( name "Body Harvest (E) (M3) [f1] (NTSC).z64" crc 561081C2 )
+)
+
+game (
+	name "Body Harvest (U) [!]"
+	description "Body Harvest (U) [!]"
+	rom ( name "Body Harvest (U) [!].z64" crc FABBDF02 )
+)
+
+game (
+	name "Body Harvest (U) [b1]"
+	description "Body Harvest (U) [b1]"
+	rom ( name "Body Harvest (U) [b1].z64" crc 47057360 )
+)
+
+game (
+	name "Body Harvest (U) [b1][t1]"
+	description "Body Harvest (U) [b1][t1]"
+	rom ( name "Body Harvest (U) [b1][t1].z64" crc 822CCE53 )
+)
+
+game (
+	name "Body Harvest (U) [b2]"
+	description "Body Harvest (U) [b2]"
+	rom ( name "Body Harvest (U) [b2].z64" crc A8C980A0 )
+)
+
+game (
+	name "Body Harvest (U) [t1]"
+	description "Body Harvest (U) [t1]"
+	rom ( name "Body Harvest (U) [t1].z64" crc 418DA29B )
+)
+
+game (
+	name "Baku Bomberman (J) [!]"
+	description "Baku Bomberman (J) [!]"
+	rom ( name "Baku Bomberman (J) [!].z64" crc 22F54A52 )
+)
+
+game (
+	name "Baku Bomberman (J) [b1]"
+	description "Baku Bomberman (J) [b1]"
+	rom ( name "Baku Bomberman (J) [b1].z64" crc F8D8623F )
+)
+
+game (
+	name "Baku Bomberman (J) [h1C]"
+	description "Baku Bomberman (J) [h1C]"
+	rom ( name "Baku Bomberman (J) [h1C].z64" crc 1F6BA05D )
+)
+
+game (
+	name "Baku Bomberman (J) [t1]"
+	description "Baku Bomberman (J) [t1]"
+	rom ( name "Baku Bomberman (J) [t1].z64" crc 6733C63C )
+)
+
+game (
+	name "Bomberman 64 (E) [!]"
+	description "Bomberman 64 (E) [!]"
+	rom ( name "Bomberman 64 (E) [!].z64" crc 525339C5 )
+)
+
+game (
+	name "Bomberman 64 (E) [b1]"
+	description "Bomberman 64 (E) [b1]"
+	rom ( name "Bomberman 64 (E) [b1].z64" crc C7D3898D )
+)
+
+game (
+	name "Bomberman 64 (E) [b2]"
+	description "Bomberman 64 (E) [b2]"
+	rom ( name "Bomberman 64 (E) [b2].z64" crc F6FC15D0 )
+)
+
+game (
+	name "Bomberman 64 (E) [h1C]"
+	description "Bomberman 64 (E) [h1C]"
+	rom ( name "Bomberman 64 (E) [h1C].z64" crc 70EA3058 )
+)
+
+game (
+	name "Bomberman 64 (E) [t1]"
+	description "Bomberman 64 (E) [t1]"
+	rom ( name "Bomberman 64 (E) [t1].z64" crc 7DECD8F8 )
+)
+
+game (
+	name "Bomberman 64 (U) [!]"
+	description "Bomberman 64 (U) [!]"
+	rom ( name "Bomberman 64 (U) [!].z64" crc 3ED0E0DC )
+)
+
+game (
+	name "Bomberman 64 (U) [b1]"
+	description "Bomberman 64 (U) [b1]"
+	rom ( name "Bomberman 64 (U) [b1].z64" crc 2F1488D8 )
+)
+
+game (
+	name "Bomberman 64 (U) [o1]"
+	description "Bomberman 64 (U) [o1]"
+	rom ( name "Bomberman 64 (U) [o1].z64" crc E4C0A3A4 )
+)
+
+game (
+	name "Bomberman 64 - Arcade Edition (J) [f1] (PAL)"
+	description "Bomberman 64 - Arcade Edition (J) [f1] (PAL)"
+	rom ( name "Bomberman 64 - Arcade Edition (J) [f1] (PAL).z64" crc 7B3F423E )
+)
+
+game (
+	name "Bomberman 64 - Arcade Edition (J) [f2] (PAL-CRC)"
+	description "Bomberman 64 - Arcade Edition (J) [f2] (PAL-CRC)"
+	rom ( name "Bomberman 64 - Arcade Edition (J) [f2] (PAL-CRC).z64" crc CA005639 )
+)
+
+game (
+	name "Bomberman 64 - Arcade Edition (J)"
+	description "Bomberman 64 - Arcade Edition (J)"
+	rom ( name "Bomberman 64 - Arcade Edition (J).z64" crc 7E74EEDC )
+)
+
+game (
+	name "Baku Bomberman 2 (J) [!]"
+	description "Baku Bomberman 2 (J) [!]"
+	rom ( name "Baku Bomberman 2 (J) [!].z64" crc 86BBC278 )
+)
+
+game (
+	name "Bomberman 64 - The Second Attack! (U) [!]"
+	description "Bomberman 64 - The Second Attack! (U) [!]"
+	rom ( name "Bomberman 64 - The Second Attack! (U) [!].z64" crc 57550007 )
+)
+
+game (
+	name "Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC)"
+	description "Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC)"
+	rom ( name "Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC).z64" crc F2DDB246 )
+)
+
+game (
+	name "Bomberman Hero (E) [!]"
+	description "Bomberman Hero (E) [!]"
+	rom ( name "Bomberman Hero (E) [!].z64" crc 59E39947 )
+)
+
+game (
+	name "Bomberman Hero (E) [b1]"
+	description "Bomberman Hero (E) [b1]"
+	rom ( name "Bomberman Hero (E) [b1].z64" crc FAAD0E58 )
+)
+
+game (
+	name "Bomberman Hero (E) [b2]"
+	description "Bomberman Hero (E) [b2]"
+	rom ( name "Bomberman Hero (E) [b2].z64" crc 332391A6 )
+)
+
+game (
+	name "Bomberman Hero (E) [b3]"
+	description "Bomberman Hero (E) [b3]"
+	rom ( name "Bomberman Hero (E) [b3].z64" crc 18957212 )
+)
+
+game (
+	name "Bomberman Hero (E) [f1] (NTSC)"
+	description "Bomberman Hero (E) [f1] (NTSC)"
+	rom ( name "Bomberman Hero (E) [f1] (NTSC).z64" crc 371AB763 )
+)
+
+game (
+	name "Bomberman Hero (U) [!]"
+	description "Bomberman Hero (U) [!]"
+	rom ( name "Bomberman Hero (U) [!].z64" crc 2CC2E634 )
+)
+
+game (
+	name "Bomberman Hero (U) [b1]"
+	description "Bomberman Hero (U) [b1]"
+	rom ( name "Bomberman Hero (U) [b1].z64" crc D9204816 )
+)
+
+game (
+	name "Bomberman Hero (U) [b2]"
+	description "Bomberman Hero (U) [b2]"
+	rom ( name "Bomberman Hero (U) [b2].z64" crc 2E329C9C )
+)
+
+game (
+	name "Bomberman Hero (U) [b3]"
+	description "Bomberman Hero (U) [b3]"
+	rom ( name "Bomberman Hero (U) [b3].z64" crc E3EA697C )
+)
+
+game (
+	name "Bomberman Hero (U) [t1]"
+	description "Bomberman Hero (U) [t1]"
+	rom ( name "Bomberman Hero (U) [t1].z64" crc B7EA3FE0 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!].z64" crc 69CEABCC )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1].z64" crc FBE5D5F7 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b2]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b2]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b2].z64" crc C9822C46 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b3]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b3]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b3].z64" crc E3E4703F )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b4]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b4]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b4].z64" crc 70700853 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b5]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b5]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b5].z64" crc 7A3E9BF6 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b6]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b6]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b6].z64" crc 7409B5D6 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b7]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b7]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b7].z64" crc 002A9FDE )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b8]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b8]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b8].z64" crc 737334C7 )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [o1]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [o1]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [o1].z64" crc 2573DFEF )
+)
+
+game (
+	name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [t1]"
+	description "Bomberman Hero - Mirian Oujo wo Sukue! (J) [t1]"
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [t1].z64" crc 6ACD9758 )
+)
+
+game (
+	name "Bottom of the 9th (U) [!]"
+	description "Bottom of the 9th (U) [!]"
+	rom ( name "Bottom of the 9th (U) [!].z64" crc 1844C8CA )
+)
+
+game (
+	name "Bottom of the 9th (U) [b1]"
+	description "Bottom of the 9th (U) [b1]"
+	rom ( name "Bottom of the 9th (U) [b1].z64" crc 352F0D77 )
+)
+
+game (
+	name "Brunswick Circuit Pro Bowling (U) [!]"
+	description "Brunswick Circuit Pro Bowling (U) [!]"
+	rom ( name "Brunswick Circuit Pro Bowling (U) [!].z64" crc 80D70173 )
+)
+
+game (
+	name "Brunswick Circuit Pro Bowling (U) [b1]"
+	description "Brunswick Circuit Pro Bowling (U) [b1]"
+	rom ( name "Brunswick Circuit Pro Bowling (U) [b1].z64" crc 48D6FBB5 )
+)
+
+game (
+	name "Brunswick Circuit Pro Bowling (U) [o1]"
+	description "Brunswick Circuit Pro Bowling (U) [o1]"
+	rom ( name "Brunswick Circuit Pro Bowling (U) [o1].z64" crc CA69AA8B )
+)
+
+game (
+	name "Brunswick Circuit Pro Bowling (U) [o1][f1] (PAL)"
+	description "Brunswick Circuit Pro Bowling (U) [o1][f1] (PAL)"
+	rom ( name "Brunswick Circuit Pro Bowling (U) [o1][f1] (PAL).z64" crc 84E3B242 )
+)
+
+game (
+	name "Buck Bumble (E) (M5) [!]"
+	description "Buck Bumble (E) (M5) [!]"
+	rom ( name "Buck Bumble (E) (M5) [!].z64" crc E26192AB )
+)
+
+game (
+	name "Buck Bumble (J) [!]"
+	description "Buck Bumble (J) [!]"
+	rom ( name "Buck Bumble (J) [!].z64" crc 2ED81A65 )
+)
+
+game (
+	name "Buck Bumble (U) [!]"
+	description "Buck Bumble (U) [!]"
+	rom ( name "Buck Bumble (U) [!].z64" crc 8EC937DB )
+)
+
+game (
+	name "Buck Bumble (U) [b1][t1]"
+	description "Buck Bumble (U) [b1][t1]"
+	rom ( name "Buck Bumble (U) [b1][t1].z64" crc 35682724 )
+)
+
+game (
+	name "Buck Bumble (U) [b2]"
+	description "Buck Bumble (U) [b2]"
+	rom ( name "Buck Bumble (U) [b2].z64" crc 462EA83E )
+)
+
+game (
+	name "Buck Bumble (U) [f1] (PAL)"
+	description "Buck Bumble (U) [f1] (PAL)"
+	rom ( name "Buck Bumble (U) [f1] (PAL).z64" crc 96E40527 )
+)
+
+game (
+	name "Buck Bumble (U) [t1]"
+	description "Buck Bumble (U) [t1]"
+	rom ( name "Buck Bumble (U) [t1].z64" crc AB751417 )
+)
+
+game (
+	name "Bug's Life, A (E) [!]"
+	description "Bug's Life, A (E) [!]"
+	rom ( name "Bug's Life, A (E) [!].z64" crc 791881D4 )
+)
+
+game (
+	name "Bug's Life, A (E) [f1] (NTSC)"
+	description "Bug's Life, A (E) [f1] (NTSC)"
+	rom ( name "Bug's Life, A (E) [f1] (NTSC).z64" crc C9CFE718 )
+)
+
+game (
+	name "Bug's Life, A (F) [!]"
+	description "Bug's Life, A (F) [!]"
+	rom ( name "Bug's Life, A (F) [!].z64" crc E5429094 )
+)
+
+game (
+	name "Bug's Life, A (F) [f1] (NTSC)"
+	description "Bug's Life, A (F) [f1] (NTSC)"
+	rom ( name "Bug's Life, A (F) [f1] (NTSC).z64" crc 32A7F761 )
+)
+
+game (
+	name "Bug's Life, A (G) [!]"
+	description "Bug's Life, A (G) [!]"
+	rom ( name "Bug's Life, A (G) [!].z64" crc 15A32836 )
+)
+
+game (
+	name "Bug's Life, A (G) [f1] (NTSC)"
+	description "Bug's Life, A (G) [f1] (NTSC)"
+	rom ( name "Bug's Life, A (G) [f1] (NTSC).z64" crc ACB166FF )
+)
+
+game (
+	name "Bug's Life, A (I) [!]"
+	description "Bug's Life, A (I) [!]"
+	rom ( name "Bug's Life, A (I) [!].z64" crc 2D118764 )
+)
+
+game (
+	name "Bug's Life, A (U) [!]"
+	description "Bug's Life, A (U) [!]"
+	rom ( name "Bug's Life, A (U) [!].z64" crc CF2EA0B6 )
+)
+
+game (
+	name "Bug's Life, A (U) [b1]"
+	description "Bug's Life, A (U) [b1]"
+	rom ( name "Bug's Life, A (U) [b1].z64" crc DF844E51 )
+)
+
+game (
+	name "Bug's Life, A (U) [b1][f1] (PAL)"
+	description "Bug's Life, A (U) [b1][f1] (PAL)"
+	rom ( name "Bug's Life, A (U) [b1][f1] (PAL).z64" crc 478CE66F )
+)
+
+game (
+	name "Bug's Life, A (U) [f1] (PAL)"
+	description "Bug's Life, A (U) [f1] (PAL)"
+	rom ( name "Bug's Life, A (U) [f1] (PAL).z64" crc 57260888 )
+)
+
+game (
+	name "Bug's Life, A (U) [t1]"
+	description "Bug's Life, A (U) [t1]"
+	rom ( name "Bug's Life, A (U) [t1].z64" crc 4EA0808A )
+)
+
+game (
+	name "Bug's Life, A (U) [t2]"
+	description "Bug's Life, A (U) [t2]"
+	rom ( name "Bug's Life, A (U) [t2].z64" crc 5E0A6E6D )
+)
+
+game (
+	name "Bust-A-Move '99 (U) [!]"
+	description "Bust-A-Move '99 (U) [!]"
+	rom ( name "Bust-A-Move '99 (U) [!].z64" crc C285FC69 )
+)
+
+game (
+	name "Bust-A-Move '99 (U) [b1]"
+	description "Bust-A-Move '99 (U) [b1]"
+	rom ( name "Bust-A-Move '99 (U) [b1].z64" crc F7CED91E )
+)
+
+game (
+	name "Bust-A-Move '99 (U) [f1] (PAL)"
+	description "Bust-A-Move '99 (U) [f1] (PAL)"
+	rom ( name "Bust-A-Move '99 (U) [f1] (PAL).z64" crc 3CD99896 )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [!]"
+	description "Bust-A-Move 3 DX (E) [!]"
+	rom ( name "Bust-A-Move 3 DX (E) [!].z64" crc 95595889 )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [b1]"
+	description "Bust-A-Move 3 DX (E) [b1]"
+	rom ( name "Bust-A-Move 3 DX (E) [b1].z64" crc 414F160F )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [b2]"
+	description "Bust-A-Move 3 DX (E) [b2]"
+	rom ( name "Bust-A-Move 3 DX (E) [b2].z64" crc 935DDA42 )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [b3]"
+	description "Bust-A-Move 3 DX (E) [b3]"
+	rom ( name "Bust-A-Move 3 DX (E) [b3].z64" crc 0F94B85D )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [f1] (NTSC100%)"
+	description "Bust-A-Move 3 DX (E) [f1] (NTSC100%)"
+	rom ( name "Bust-A-Move 3 DX (E) [f1] (NTSC100%).z64" crc DB82F6DB )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [f2] (NTSC-Z64)"
+	description "Bust-A-Move 3 DX (E) [f2] (NTSC-Z64)"
+	rom ( name "Bust-A-Move 3 DX (E) [f2] (NTSC-Z64).z64" crc 2837DD00 )
+)
+
+game (
+	name "Bust-A-Move 3 DX (E) [f3] (NTSC)"
+	description "Bust-A-Move 3 DX (E) [f3] (NTSC)"
+	rom ( name "Bust-A-Move 3 DX (E) [f3] (NTSC).z64" crc 58533B87 )
+)
+
+game (
+	name "Puzzle Bobble 64 (J) [!]"
+	description "Puzzle Bobble 64 (J) [!]"
+	rom ( name "Puzzle Bobble 64 (J) [!].z64" crc EA837423 )
+)
+
+game (
+	name "Puzzle Bobble 64 (J) [f1] (PAL)"
+	description "Puzzle Bobble 64 (J) [f1] (PAL)"
+	rom ( name "Puzzle Bobble 64 (J) [f1] (PAL).z64" crc E120EB0C )
+)
+
+game (
+	name "Puzzle Bobble 64 (J) [f2] (PAL)"
+	description "Puzzle Bobble 64 (J) [f2] (PAL)"
+	rom ( name "Puzzle Bobble 64 (J) [f2] (PAL).z64" crc D1F3984A )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (E) [!]"
+	description "Bust-A-Move 2 - Arcade Edition (E) [!]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [!].z64" crc 04731BAB )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (E) [b1]"
+	description "Bust-A-Move 2 - Arcade Edition (E) [b1]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [b1].z64" crc C352DF3F )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (U) [!]"
+	description "Bust-A-Move 2 - Arcade Edition (U) [!]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [!].z64" crc 9F54CD2D )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (U) [b1]"
+	description "Bust-A-Move 2 - Arcade Edition (U) [b1]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b1].z64" crc E79F0ACB )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (U) [b2]"
+	description "Bust-A-Move 2 - Arcade Edition (U) [b2]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b2].z64" crc 948A1CFB )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (U) [b3]"
+	description "Bust-A-Move 2 - Arcade Edition (U) [b3]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b3].z64" crc 96325FC3 )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (U) [b4]"
+	description "Bust-A-Move 2 - Arcade Edition (U) [b4]"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b4].z64" crc 4DFB7A1D )
+)
+
+game (
+	name "California Speed (U) [!]"
+	description "California Speed (U) [!]"
+	rom ( name "California Speed (U) [!].z64" crc 6F6262CB )
+)
+
+game (
+	name "California Speed (U) [f1] (Country Check)"
+	description "California Speed (U) [f1] (Country Check)"
+	rom ( name "California Speed (U) [f1] (Country Check).z64" crc F9D470E2 )
+)
+
+game (
+	name "California Speed (U) [f2] (PAL)"
+	description "California Speed (U) [f2] (PAL)"
+	rom ( name "California Speed (U) [f2] (PAL).z64" crc 1C41238A )
+)
+
+game (
+	name "California Speed (U) [t1]"
+	description "California Speed (U) [t1]"
+	rom ( name "California Speed (U) [t1].z64" crc C8250C69 )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!]"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!]"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!].z64" crc 8569F1A0 )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [f1] (NTSC)"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [f1] (NTSC)"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [f1] (NTSC).z64" crc 9F85CC8C )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!]"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!]"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!].z64" crc 8036F999 )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [b1]"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [b1]"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [b1].z64" crc 5E71223E )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f1] (NTSC)"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f1] (NTSC)"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f1] (NTSC).z64" crc 3221B1D4 )
+)
+
+game (
+	name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f2] (NTSC)"
+	description "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f2] (NTSC)"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f2] (NTSC).z64" crc E1EE0473 )
+)
+
+game (
+	name "Carmageddon 64 (U) [!]"
+	description "Carmageddon 64 (U) [!]"
+	rom ( name "Carmageddon 64 (U) [!].z64" crc 10C6A0A1 )
+)
+
+game (
+	name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!]"
+	description "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!]"
+	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!].z64" crc E349CFEC )
+)
+
+game (
+	name "Castlevania (E) (M3) [!]"
+	description "Castlevania (E) (M3) [!]"
+	rom ( name "Castlevania (E) (M3) [!].z64" crc D9D76235 )
+)
+
+game (
+	name "Castlevania (E) (M3) [b1]"
+	description "Castlevania (E) (M3) [b1]"
+	rom ( name "Castlevania (E) (M3) [b1].z64" crc 8E6E53A0 )
+)
+
+game (
+	name "Castlevania (E) (M3) [t1]"
+	description "Castlevania (E) (M3) [t1]"
+	rom ( name "Castlevania (E) (M3) [t1].z64" crc 3C9D1ED5 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [!]"
+	description "Castlevania (U) (V1.0) [!]"
+	rom ( name "Castlevania (U) (V1.0) [!].z64" crc 8B0D3C00 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [b1]"
+	description "Castlevania (U) (V1.0) [b1]"
+	rom ( name "Castlevania (U) (V1.0) [b1].z64" crc 724A540E )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [b2]"
+	description "Castlevania (U) (V1.0) [b2]"
+	rom ( name "Castlevania (U) (V1.0) [b2].z64" crc 16DB3687 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [b3]"
+	description "Castlevania (U) (V1.0) [b3]"
+	rom ( name "Castlevania (U) (V1.0) [b3].z64" crc 567E1271 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [b4]"
+	description "Castlevania (U) (V1.0) [b4]"
+	rom ( name "Castlevania (U) (V1.0) [b4].z64" crc E6036665 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [t1]"
+	description "Castlevania (U) (V1.0) [t1]"
+	rom ( name "Castlevania (U) (V1.0) [t1].z64" crc 5263B185 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [t2]"
+	description "Castlevania (U) (V1.0) [t2]"
+	rom ( name "Castlevania (U) (V1.0) [t2].z64" crc FE5D8B7A )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [t3]"
+	description "Castlevania (U) (V1.0) [t3]"
+	rom ( name "Castlevania (U) (V1.0) [t3].z64" crc E1D6CB91 )
+)
+
+game (
+	name "Castlevania (U) (V1.0) [t4]"
+	description "Castlevania (U) (V1.0) [t4]"
+	rom ( name "Castlevania (U) (V1.0) [t4].z64" crc 1F95EF27 )
+)
+
+game (
+	name "Castlevania (U) (V1.2) [!]"
+	description "Castlevania (U) (V1.2) [!]"
+	rom ( name "Castlevania (U) (V1.2) [!].z64" crc 83032D97 )
+)
+
+game (
+	name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!]"
+	description "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!]"
+	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!].z64" crc FF009C21 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (E) (M3) [!]"
+	description "Castlevania - Legacy of Darkness (E) (M3) [!]"
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [!].z64" crc 12AB9B45 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (E) (M3) [h1C]"
+	description "Castlevania - Legacy of Darkness (E) (M3) [h1C]"
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [h1C].z64" crc 12548AA1 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (E) (M3) [o1]"
+	description "Castlevania - Legacy of Darkness (E) (M3) [o1]"
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [o1].z64" crc 7C1A0085 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (U) [!]"
+	description "Castlevania - Legacy of Darkness (U) [!]"
+	rom ( name "Castlevania - Legacy of Darkness (U) [!].z64" crc AB13028C )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (U) [b1]"
+	description "Castlevania - Legacy of Darkness (U) [b1]"
+	rom ( name "Castlevania - Legacy of Darkness (U) [b1].z64" crc EAC65CA0 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (U) [f1] (PAL)"
+	description "Castlevania - Legacy of Darkness (U) [f1] (PAL)"
+	rom ( name "Castlevania - Legacy of Darkness (U) [f1] (PAL).z64" crc 72FB900A )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (U) [f2] (PAL)"
+	description "Castlevania - Legacy of Darkness (U) [f2] (PAL)"
+	rom ( name "Castlevania - Legacy of Darkness (U) [f2] (PAL).z64" crc 0C6CDF58 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness (U) [t1]"
+	description "Castlevania - Legacy of Darkness (U) [t1]"
+	rom ( name "Castlevania - Legacy of Darkness (U) [t1].z64" crc E49F3C4D )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.08"
+	description "CD64 BIOS Direct-Upgrade V1.08"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.08.bin" crc 5C4FD81F )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.09"
+	description "CD64 BIOS Direct-Upgrade V1.09"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.09.bin" crc B271FF1B )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.10"
+	description "CD64 BIOS Direct-Upgrade V1.10"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.10.bin" crc 7BF28F41 )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.11"
+	description "CD64 BIOS Direct-Upgrade V1.11"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.11.bin" crc 711774C5 )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.13"
+	description "CD64 BIOS Direct-Upgrade V1.13"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.13.bin" crc FDEFF9E8 )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.20"
+	description "CD64 BIOS Direct-Upgrade V1.20"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.20.bin" crc 26D1D2C7 )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.21"
+	description "CD64 BIOS Direct-Upgrade V1.21"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.21.bin" crc F0E0B2A2 )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.23"
+	description "CD64 BIOS Direct-Upgrade V1.23"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.23.bin" crc 52EE53CA )
+)
+
+game (
+	name "CD64 BIOS Direct-Upgrade V1.30"
+	description "CD64 BIOS Direct-Upgrade V1.30"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.30.bin" crc 65A164E1 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.08 [a1]"
+	description "CD64 BIOS EEPROM-Burner V1.08 [a1]"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.08 [a1].bin" crc C3E77B21 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.08"
+	description "CD64 BIOS EEPROM-Burner V1.08"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.08.bin" crc 4C84AFAA )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.09"
+	description "CD64 BIOS EEPROM-Burner V1.09"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.09.bin" crc 6B96B2B4 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.10"
+	description "CD64 BIOS EEPROM-Burner V1.10"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.10.bin" crc 283780F1 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.11 (Even Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.11 (Even Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Even Bytes).bin" crc E6598DBD )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.11 (Odd Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.11 (Odd Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Odd Bytes).bin" crc 4443F4A3 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.11"
+	description "CD64 BIOS EEPROM-Burner V1.11"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11.bin" crc EC7A03EC )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.21 (Even Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.21 (Even Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Even Bytes).bin" crc 73CF6202 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.21 (Odd Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.21 (Odd Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Odd Bytes).bin" crc 12F79A82 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.21"
+	description "CD64 BIOS EEPROM-Burner V1.21"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21.bin" crc E993D4B3 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.23 (Even Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.23 (Even Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Even Bytes).bin" crc B29DBB3F )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.23 (Odd Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.23 (Odd Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Odd Bytes).bin" crc 09D3EB60 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.23"
+	description "CD64 BIOS EEPROM-Burner V1.23"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23.bin" crc C3A5A1FB )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.30 (Even Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.30 (Even Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Even Bytes).bin" crc 41CE5465 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.30 (Odd Bytes)"
+	description "CD64 BIOS EEPROM-Burner V1.30 (Odd Bytes)"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Odd Bytes).bin" crc ABEE5982 )
+)
+
+game (
+	name "CD64 BIOS EEPROM-Burner V1.30"
+	description "CD64 BIOS EEPROM-Burner V1.30"
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30.bin" crc 011CF143 )
+)
+
+game (
+	name "Centre Court Tennis (E) [!]"
+	description "Centre Court Tennis (E) [!]"
+	rom ( name "Centre Court Tennis (E) [!].z64" crc B1D26F39 )
+)
+
+game (
+	name "Centre Court Tennis (E) [f1] (NTSC)"
+	description "Centre Court Tennis (E) [f1] (NTSC)"
+	rom ( name "Centre Court Tennis (E) [f1] (NTSC).z64" crc D70F7B00 )
+)
+
+game (
+	name "Centre Court Tennis (E) [h1C]"
+	description "Centre Court Tennis (E) [h1C]"
+	rom ( name "Centre Court Tennis (E) [h1C].z64" crc F928608B )
+)
+
+game (
+	name "Let's Smash Tennis (J) [!]"
+	description "Let's Smash Tennis (J) [!]"
+	rom ( name "Let's Smash Tennis (J) [!].z64" crc 455A1770 )
+)
+
+game (
+	name "Chameleon Twist (E) [!]"
+	description "Chameleon Twist (E) [!]"
+	rom ( name "Chameleon Twist (E) [!].z64" crc 587DD983 )
+)
+
+game (
+	name "Chameleon Twist (E) [b1]"
+	description "Chameleon Twist (E) [b1]"
+	rom ( name "Chameleon Twist (E) [b1].z64" crc 68CEAD3E )
+)
+
+game (
+	name "Chameleon Twist (E) [b2]"
+	description "Chameleon Twist (E) [b2]"
+	rom ( name "Chameleon Twist (E) [b2].z64" crc F3772611 )
+)
+
+game (
+	name "Chameleon Twist (E) [b3]"
+	description "Chameleon Twist (E) [b3]"
+	rom ( name "Chameleon Twist (E) [b3].z64" crc 7618134D )
+)
+
+game (
+	name "Chameleon Twist (E) [f1] (NTSC)"
+	description "Chameleon Twist (E) [f1] (NTSC)"
+	rom ( name "Chameleon Twist (E) [f1] (NTSC).z64" crc 1B8DF49A )
+)
+
+game (
+	name "Chameleon Twist (E) [o1]"
+	description "Chameleon Twist (E) [o1]"
+	rom ( name "Chameleon Twist (E) [o1].z64" crc E060AD47 )
+)
+
+game (
+	name "Chameleon Twist (E) [o2]"
+	description "Chameleon Twist (E) [o2]"
+	rom ( name "Chameleon Twist (E) [o2].z64" crc 7D6A36E8 )
+)
+
+game (
+	name "Chameleon Twist (J) [!]"
+	description "Chameleon Twist (J) [!]"
+	rom ( name "Chameleon Twist (J) [!].z64" crc 6395C475 )
+)
+
+game (
+	name "Chameleon Twist (U) [!]"
+	description "Chameleon Twist (U) [!]"
+	rom ( name "Chameleon Twist (U) [!].z64" crc 7FE024C9 )
+)
+
+game (
+	name "Chameleon Twist (U) [b1]"
+	description "Chameleon Twist (U) [b1]"
+	rom ( name "Chameleon Twist (U) [b1].z64" crc 566543CE )
+)
+
+game (
+	name "Chameleon Twist (U) [b2]"
+	description "Chameleon Twist (U) [b2]"
+	rom ( name "Chameleon Twist (U) [b2].z64" crc 5D928B73 )
+)
+
+game (
+	name "Chameleon Twist (U) [b3]"
+	description "Chameleon Twist (U) [b3]"
+	rom ( name "Chameleon Twist (U) [b3].z64" crc F654ADCB )
+)
+
+game (
+	name "Chameleon Twist (U) [t1]"
+	description "Chameleon Twist (U) [t1]"
+	rom ( name "Chameleon Twist (U) [t1].z64" crc F6537276 )
+)
+
+game (
+	name "Chameleon Twist 2 (E) [!]"
+	description "Chameleon Twist 2 (E) [!]"
+	rom ( name "Chameleon Twist 2 (E) [!].z64" crc 3B53519F )
+)
+
+game (
+	name "Chameleon Twist 2 (E) [b1]"
+	description "Chameleon Twist 2 (E) [b1]"
+	rom ( name "Chameleon Twist 2 (E) [b1].z64" crc 9DA3FD63 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [!]"
+	description "Chameleon Twist 2 (J) [!]"
+	rom ( name "Chameleon Twist 2 (J) [!].z64" crc 5677EAEF )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [b1]"
+	description "Chameleon Twist 2 (J) [b1]"
+	rom ( name "Chameleon Twist 2 (J) [b1].z64" crc 23857073 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [b2]"
+	description "Chameleon Twist 2 (J) [b2]"
+	rom ( name "Chameleon Twist 2 (J) [b2].z64" crc 84CBD297 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [b3]"
+	description "Chameleon Twist 2 (J) [b3]"
+	rom ( name "Chameleon Twist 2 (J) [b3].z64" crc F6839D99 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [b4]"
+	description "Chameleon Twist 2 (J) [b4]"
+	rom ( name "Chameleon Twist 2 (J) [b4].z64" crc 8FF29073 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [o1]"
+	description "Chameleon Twist 2 (J) [o1]"
+	rom ( name "Chameleon Twist 2 (J) [o1].z64" crc 08287CC8 )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [o2]"
+	description "Chameleon Twist 2 (J) [o2]"
+	rom ( name "Chameleon Twist 2 (J) [o2].z64" crc 8DFE135A )
+)
+
+game (
+	name "Chameleon Twist 2 (J) [t1]"
+	description "Chameleon Twist 2 (J) [t1]"
+	rom ( name "Chameleon Twist 2 (J) [t1].z64" crc 10A24D0C )
+)
+
+game (
+	name "Chameleon Twist 2 (U) [!]"
+	description "Chameleon Twist 2 (U) [!]"
+	rom ( name "Chameleon Twist 2 (U) [!].z64" crc CDF26D67 )
+)
+
+game (
+	name "Chameleon Twist 2 (U) [t1]"
+	description "Chameleon Twist 2 (U) [t1]"
+	rom ( name "Chameleon Twist 2 (U) [t1].z64" crc AC3D5715 )
+)
+
+game (
+	name "Charlie Blast's Territory (E) [!]"
+	description "Charlie Blast's Territory (E) [!]"
+	rom ( name "Charlie Blast's Territory (E) [!].z64" crc 82C1D9E1 )
+)
+
+game (
+	name "Charlie Blast's Territory (E) [o1]"
+	description "Charlie Blast's Territory (E) [o1]"
+	rom ( name "Charlie Blast's Territory (E) [o1].z64" crc 2562FC53 )
+)
+
+game (
+	name "Charlie Blast's Territory (U) [!]"
+	description "Charlie Blast's Territory (U) [!]"
+	rom ( name "Charlie Blast's Territory (U) [!].z64" crc BA4E65A8 )
+)
+
+game (
+	name "Charlie Blast's Territory (U) [hI]"
+	description "Charlie Blast's Territory (U) [hI]"
+	rom ( name "Charlie Blast's Territory (U) [hI].z64" crc 87935EAF )
+)
+
+game (
+	name "Charlie Blast's Territory (U) [hIR]"
+	description "Charlie Blast's Territory (U) [hIR]"
+	rom ( name "Charlie Blast's Territory (U) [hIR].z64" crc 5C1EA306 )
+)
+
+game (
+	name "Chopper Attack (E) [!]"
+	description "Chopper Attack (E) [!]"
+	rom ( name "Chopper Attack (E) [!].z64" crc C1DCD7AB )
+)
+
+game (
+	name "Chopper Attack (E) [b1]"
+	description "Chopper Attack (E) [b1]"
+	rom ( name "Chopper Attack (E) [b1].z64" crc 2FD90225 )
+)
+
+game (
+	name "Chopper Attack (E) [t1]"
+	description "Chopper Attack (E) [t1]"
+	rom ( name "Chopper Attack (E) [t1].z64" crc 83A7D582 )
+)
+
+game (
+	name "Chopper Attack (U) [!]"
+	description "Chopper Attack (U) [!]"
+	rom ( name "Chopper Attack (U) [!].z64" crc AA5D76A9 )
+)
+
+game (
+	name "Chopper Attack (U) [b1]"
+	description "Chopper Attack (U) [b1]"
+	rom ( name "Chopper Attack (U) [b1].z64" crc 10296792 )
+)
+
+game (
+	name "Chopper Attack (U) [b2]"
+	description "Chopper Attack (U) [b2]"
+	rom ( name "Chopper Attack (U) [b2].z64" crc 12E48F07 )
+)
+
+game (
+	name "Chopper Attack (U) [b3]"
+	description "Chopper Attack (U) [b3]"
+	rom ( name "Chopper Attack (U) [b3].z64" crc AD84B711 )
+)
+
+game (
+	name "Chopper Attack (U) [b4]"
+	description "Chopper Attack (U) [b4]"
+	rom ( name "Chopper Attack (U) [b4].z64" crc 6ABD62C4 )
+)
+
+game (
+	name "Chopper Attack (U) [b5]"
+	description "Chopper Attack (U) [b5]"
+	rom ( name "Chopper Attack (U) [b5].z64" crc FBF44189 )
+)
+
+game (
+	name "Chopper Attack (U) [b6]"
+	description "Chopper Attack (U) [b6]"
+	rom ( name "Chopper Attack (U) [b6].z64" crc 0182EF2E )
+)
+
+game (
+	name "Chopper Attack (U) [t1]"
+	description "Chopper Attack (U) [t1]"
+	rom ( name "Chopper Attack (U) [t1].z64" crc 521F2BB5 )
+)
+
+game (
+	name "Wild Choppers (J) [!]"
+	description "Wild Choppers (J) [!]"
+	rom ( name "Wild Choppers (J) [!].z64" crc D6136DC5 )
+)
+
+game (
+	name "Wild Choppers (J) [b1]"
+	description "Wild Choppers (J) [b1]"
+	rom ( name "Wild Choppers (J) [b1].z64" crc 6F07A665 )
+)
+
+game (
+	name "Wild Choppers (J) [b2]"
+	description "Wild Choppers (J) [b2]"
+	rom ( name "Wild Choppers (J) [b2].z64" crc 12EC9B86 )
+)
+
+game (
+	name "Wild Choppers (J) [b3]"
+	description "Wild Choppers (J) [b3]"
+	rom ( name "Wild Choppers (J) [b3].z64" crc 71726557 )
+)
+
+game (
+	name "Wild Choppers (J) [o1]"
+	description "Wild Choppers (J) [o1]"
+	rom ( name "Wild Choppers (J) [o1].z64" crc E866D832 )
+)
+
+game (
+	name "Wild Choppers (J) [t1]"
+	description "Wild Choppers (J) [t1]"
+	rom ( name "Wild Choppers (J) [t1].z64" crc 3CA3E096 )
+)
+
+game (
+	name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!]"
+	description "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!]"
+	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!].z64" crc 5C565AD6 )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King (J) [!]"
+	description "Chou Kuukan Night Pro Yakyuu King (J) [!]"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [!].z64" crc 5F75634E )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King (J) [b1]"
+	description "Chou Kuukan Night Pro Yakyuu King (J) [b1]"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [b1].z64" crc 61A9756B )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King (J) [h1C]"
+	description "Chou Kuukan Night Pro Yakyuu King (J) [h1C]"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [h1C].z64" crc 64E730DC )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!]"
+	description "Chou Kuukan Night Pro Yakyuu King 2 (J) [!]"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!].z64" crc 479643E2 )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [!]"
+	description "Clay Fighter - Sculptor's Cut (U) [!]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [!].z64" crc 434DE656 )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [b1]"
+	description "Clay Fighter - Sculptor's Cut (U) [b1]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [b1].z64" crc 25FADF5E )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [b2]"
+	description "Clay Fighter - Sculptor's Cut (U) [b2]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [b2].z64" crc 11487231 )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [h1C]"
+	description "Clay Fighter - Sculptor's Cut (U) [h1C]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [h1C].z64" crc 567BFEC1 )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [h2C]"
+	description "Clay Fighter - Sculptor's Cut (U) [h2C]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [h2C].z64" crc 432E391A )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut (U) [t1]"
+	description "Clay Fighter - Sculptor's Cut (U) [t1]"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [t1].z64" crc F8AFA913 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (Beta) [!]"
+	description "Clay Fighter 63 1-3 (Beta) [!]"
+	rom ( name "Clay Fighter 63 1-3 (Beta) [!].z64" crc 18F4166A )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (Beta) [b1]"
+	description "Clay Fighter 63 1-3 (Beta) [b1]"
+	rom ( name "Clay Fighter 63 1-3 (Beta) [b1].z64" crc 0BA68B38 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (E) [!]"
+	description "Clay Fighter 63 1-3 (E) [!]"
+	rom ( name "Clay Fighter 63 1-3 (E) [!].z64" crc 82263E5D )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (E) [b1][h1C]"
+	description "Clay Fighter 63 1-3 (E) [b1][h1C]"
+	rom ( name "Clay Fighter 63 1-3 (E) [b1][h1C].z64" crc 5E0DD087 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (E) [h1C]"
+	description "Clay Fighter 63 1-3 (E) [h1C]"
+	rom ( name "Clay Fighter 63 1-3 (E) [h1C].z64" crc 41F36719 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (U) [!]"
+	description "Clay Fighter 63 1-3 (U) [!]"
+	rom ( name "Clay Fighter 63 1-3 (U) [!].z64" crc 3FA647DD )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (U) [b1]"
+	description "Clay Fighter 63 1-3 (U) [b1]"
+	rom ( name "Clay Fighter 63 1-3 (U) [b1].z64" crc 3C7BC60D )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (U) [b2]"
+	description "Clay Fighter 63 1-3 (U) [b2]"
+	rom ( name "Clay Fighter 63 1-3 (U) [b2].z64" crc 81428075 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (U) [o1]"
+	description "Clay Fighter 63 1-3 (U) [o1]"
+	rom ( name "Clay Fighter 63 1-3 (U) [o1].z64" crc 9C481C79 )
+)
+
+game (
+	name "Clay Fighter 63 1-3 (U) [o2]"
+	description "Clay Fighter 63 1-3 (U) [o2]"
+	rom ( name "Clay Fighter 63 1-3 (U) [o2].z64" crc 2EA4420A )
+)
+
+game (
+	name "Command & Conquer (E) (M2) [!]"
+	description "Command & Conquer (E) (M2) [!]"
+	rom ( name "Command & Conquer (E) (M2) [!].z64" crc F3DA8A26 )
+)
+
+game (
+	name "Command & Conquer (E) (M2) [b1]"
+	description "Command & Conquer (E) (M2) [b1]"
+	rom ( name "Command & Conquer (E) (M2) [b1].z64" crc 8AE902F9 )
+)
+
+game (
+	name "Command & Conquer (E) (M2) [b2]"
+	description "Command & Conquer (E) (M2) [b2]"
+	rom ( name "Command & Conquer (E) (M2) [b2].z64" crc E155637C )
+)
+
+game (
+	name "Command & Conquer (E) (M2) [b3]"
+	description "Command & Conquer (E) (M2) [b3]"
+	rom ( name "Command & Conquer (E) (M2) [b3].z64" crc E465FA53 )
+)
+
+game (
+	name "Command & Conquer (E) (M2) [f1] (Z64)"
+	description "Command & Conquer (E) (M2) [f1] (Z64)"
+	rom ( name "Command & Conquer (E) (M2) [f1] (Z64).z64" crc 8817F44C )
+)
+
+game (
+	name "Command & Conquer (G) [!]"
+	description "Command & Conquer (G) [!]"
+	rom ( name "Command & Conquer (G) [!].z64" crc 6CD0FC99 )
+)
+
+game (
+	name "Command & Conquer (G) [f1] (Z64)"
+	description "Command & Conquer (G) [f1] (Z64)"
+	rom ( name "Command & Conquer (G) [f1] (Z64).z64" crc 88A500D7 )
+)
+
+game (
+	name "Command & Conquer (U) [!]"
+	description "Command & Conquer (U) [!]"
+	rom ( name "Command & Conquer (U) [!].z64" crc 3E9069EF )
+)
+
+game (
+	name "Command & Conquer (U) [b1]"
+	description "Command & Conquer (U) [b1]"
+	rom ( name "Command & Conquer (U) [b1].z64" crc 528347BF )
+)
+
+game (
+	name "Command & Conquer (U) [f1] (Z64)"
+	description "Command & Conquer (U) [f1] (Z64)"
+	rom ( name "Command & Conquer (U) [f1] (Z64).z64" crc E745C5D8 )
+)
+
+game (
+	name "Conker's Bad Fur Day (E) [!]"
+	description "Conker's Bad Fur Day (E) [!]"
+	rom ( name "Conker's Bad Fur Day (E) [!].z64" crc 4667CFE9 )
+)
+
+game (
+	name "Conker's Bad Fur Day (U) [!]"
+	description "Conker's Bad Fur Day (U) [!]"
+	rom ( name "Conker's Bad Fur Day (U) [!].z64" crc CE8CC172 )
+)
+
+game (
+	name "Cruis'n Exotica (U) [!]"
+	description "Cruis'n Exotica (U) [!]"
+	rom ( name "Cruis'n Exotica (U) [!].z64" crc 867A2CED )
+)
+
+game (
+	name "Cruis'n Exotica (U) [t1]"
+	description "Cruis'n Exotica (U) [t1]"
+	rom ( name "Cruis'n Exotica (U) [t1].z64" crc 3DEA85D6 )
+)
+
+game (
+	name "Cruis'n USA (E) [!]"
+	description "Cruis'n USA (E) [!]"
+	rom ( name "Cruis'n USA (E) [!].z64" crc 8935A8D9 )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [!]"
+	description "Cruis'n USA (U) (V1.0) [!]"
+	rom ( name "Cruis'n USA (U) (V1.0) [!].z64" crc 5238B727 )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [b1]"
+	description "Cruis'n USA (U) (V1.0) [b1]"
+	rom ( name "Cruis'n USA (U) (V1.0) [b1].z64" crc 92F6809F )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [b2]"
+	description "Cruis'n USA (U) (V1.0) [b2]"
+	rom ( name "Cruis'n USA (U) (V1.0) [b2].z64" crc 97899ECC )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [b3]"
+	description "Cruis'n USA (U) (V1.0) [b3]"
+	rom ( name "Cruis'n USA (U) (V1.0) [b3].z64" crc D1E1FFB4 )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [b4]"
+	description "Cruis'n USA (U) (V1.0) [b4]"
+	rom ( name "Cruis'n USA (U) (V1.0) [b4].z64" crc B93D9CE6 )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [b5]"
+	description "Cruis'n USA (U) (V1.0) [b5]"
+	rom ( name "Cruis'n USA (U) (V1.0) [b5].z64" crc 05D10DB5 )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.0) [T+Ita0.40]"
+	description "Cruis'n USA (U) (V1.0) [T+Ita0.40]"
+	rom ( name "Cruis'n USA (U) (V1.0) [T+Ita0.40].z64" crc 4512760E )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.1) [!]"
+	description "Cruis'n USA (U) (V1.1) [!]"
+	rom ( name "Cruis'n USA (U) (V1.1) [!].z64" crc 4655BA2D )
+)
+
+game (
+	name "Cruis'n USA (U) (V1.2) [!]"
+	description "Cruis'n USA (U) (V1.2) [!]"
+	rom ( name "Cruis'n USA (U) (V1.2) [!].z64" crc C3B52701 )
+)
+
+game (
+	name "Cruis'n World (E) [!]"
+	description "Cruis'n World (E) [!]"
+	rom ( name "Cruis'n World (E) [!].z64" crc E46CE079 )
+)
+
+game (
+	name "Cruis'n World (E) [b1]"
+	description "Cruis'n World (E) [b1]"
+	rom ( name "Cruis'n World (E) [b1].z64" crc C16D2D71 )
+)
+
+game (
+	name "Cruis'n World (E) [b2]"
+	description "Cruis'n World (E) [b2]"
+	rom ( name "Cruis'n World (E) [b2].z64" crc 3B713E52 )
+)
+
+game (
+	name "Cruis'n World (E) [f1]"
+	description "Cruis'n World (E) [f1]"
+	rom ( name "Cruis'n World (E) [f1].z64" crc 8DF63936 )
+)
+
+game (
+	name "Cruis'n World (E) [f2]"
+	description "Cruis'n World (E) [f2]"
+	rom ( name "Cruis'n World (E) [f2].z64" crc 82F27646 )
+)
+
+game (
+	name "Cruis'n World (E) [f3] (NTSC)"
+	description "Cruis'n World (E) [f3] (NTSC)"
+	rom ( name "Cruis'n World (E) [f3] (NTSC).z64" crc 248F00C9 )
+)
+
+game (
+	name "Cruis'n World (U) [!]"
+	description "Cruis'n World (U) [!]"
+	rom ( name "Cruis'n World (U) [!].z64" crc A123769F )
+)
+
+game (
+	name "Cruis'n World (U) [b1]"
+	description "Cruis'n World (U) [b1]"
+	rom ( name "Cruis'n World (U) [b1].z64" crc 0274CBFC )
+)
+
+game (
+	name "Cruis'n World (U) [b2]"
+	description "Cruis'n World (U) [b2]"
+	rom ( name "Cruis'n World (U) [b2].z64" crc 10109820 )
+)
+
+game (
+	name "Cruis'n World (U) [b3]"
+	description "Cruis'n World (U) [b3]"
+	rom ( name "Cruis'n World (U) [b3].z64" crc C30ED9F6 )
+)
+
+game (
+	name "Cruis'n World (U) [f1]"
+	description "Cruis'n World (U) [f1]"
+	rom ( name "Cruis'n World (U) [f1].z64" crc 048791C6 )
+)
+
+game (
+	name "Cruis'n World (U) [o1]"
+	description "Cruis'n World (U) [o1]"
+	rom ( name "Cruis'n World (U) [o1].z64" crc 35FBEAFE )
+)
+
+game (
+	name "Custom Robo (J) [!]"
+	description "Custom Robo (J) [!]"
+	rom ( name "Custom Robo (J) [!].z64" crc F2FAE693 )
+)
+
+game (
+	name "Custom Robo V2 (J) [!]"
+	description "Custom Robo V2 (J) [!]"
+	rom ( name "Custom Robo V2 (J) [!].z64" crc C8201454 )
+)
+
+game (
+	name "CyberTiger (E) [!]"
+	description "CyberTiger (E) [!]"
+	rom ( name "CyberTiger (E) [!].z64" crc 7319D9AF )
+)
+
+game (
+	name "CyberTiger (U) [!]"
+	description "CyberTiger (U) [!]"
+	rom ( name "CyberTiger (U) [!].z64" crc 10CC5F15 )
+)
+
+game (
+	name "Dance Dance Revolution - Disney Dancing Museum (J) [!]"
+	description "Dance Dance Revolution - Disney Dancing Museum (J) [!]"
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [!].z64" crc 3C13FBCF )
+)
+
+game (
+	name "Dance Dance Revolution - Disney Dancing Museum (J) [o1]"
+	description "Dance Dance Revolution - Disney Dancing Museum (J) [o1]"
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o1].z64" crc 43EE0117 )
+)
+
+game (
+	name "Dance Dance Revolution - Disney Dancing Museum (J) [o2]"
+	description "Dance Dance Revolution - Disney Dancing Museum (J) [o2]"
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o2].z64" crc 0FEED8B3 )
+)
+
+game (
+	name "Dark Rift (E) [!]"
+	description "Dark Rift (E) [!]"
+	rom ( name "Dark Rift (E) [!].z64" crc D2A19C71 )
+)
+
+game (
+	name "Dark Rift (E) [b1]"
+	description "Dark Rift (E) [b1]"
+	rom ( name "Dark Rift (E) [b1].z64" crc 632E1937 )
+)
+
+game (
+	name "Dark Rift (U) [!]"
+	description "Dark Rift (U) [!]"
+	rom ( name "Dark Rift (U) [!].z64" crc 83FD222F )
+)
+
+game (
+	name "Dark Rift (U) [t1]"
+	description "Dark Rift (U) [t1]"
+	rom ( name "Dark Rift (U) [t1].z64" crc 1329D6BD )
+)
+
+game (
+	name "Space Dynamites (J) [!]"
+	description "Space Dynamites (J) [!]"
+	rom ( name "Space Dynamites (J) [!].z64" crc 8CB4B948 )
+)
+
+game (
+	name "Space Dynamites (J) [b1]"
+	description "Space Dynamites (J) [b1]"
+	rom ( name "Space Dynamites (J) [b1].z64" crc 537D2E2F )
+)
+
+game (
+	name "Deadly Arts (U) [!]"
+	description "Deadly Arts (U) [!]"
+	rom ( name "Deadly Arts (U) [!].z64" crc 3DB8130E )
+)
+
+game (
+	name "Deadly Arts (U) [b1]"
+	description "Deadly Arts (U) [b1]"
+	rom ( name "Deadly Arts (U) [b1].z64" crc CDECB164 )
+)
+
+game (
+	name "G.A.S.P!! Fighter's NEXTream (E) [!]"
+	description "G.A.S.P!! Fighter's NEXTream (E) [!]"
+	rom ( name "G.A.S.P!! Fighter's NEXTream (E) [!].z64" crc 5AA63B04 )
+)
+
+game (
+	name "G.A.S.P!! Fighter's NEXTream (J) [!]"
+	description "G.A.S.P!! Fighter's NEXTream (J) [!]"
+	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [!].z64" crc 6EAD2D89 )
+)
+
+game (
+	name "G.A.S.P!! Fighter's NEXTream (J) [o1]"
+	description "G.A.S.P!! Fighter's NEXTream (J) [o1]"
+	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [o1].z64" crc F0532EAF )
+)
+
+game (
+	name "Densha de Go! 64 (J) [!]"
+	description "Densha de Go! 64 (J) [!]"
+	rom ( name "Densha de Go! 64 (J) [!].z64" crc 7BFC71E0 )
+)
+
+game (
+	name "Densha de Go! 64 (J) [f1] (PAL)"
+	description "Densha de Go! 64 (J) [f1] (PAL)"
+	rom ( name "Densha de Go! 64 (J) [f1] (PAL).z64" crc FFC76F35 )
+)
+
+game (
+	name "Derby Stallion 64 (J) (Beta)"
+	description "Derby Stallion 64 (J) (Beta)"
+	rom ( name "Derby Stallion 64 (J) (Beta).z64" crc 8EC950A9 )
+)
+
+game (
+	name "Derby Stallion 64 (J) [!]"
+	description "Derby Stallion 64 (J) [!]"
+	rom ( name "Derby Stallion 64 (J) [!].z64" crc A9417994 )
+)
+
+game (
+	name "Destruction Derby 64 (E) (M3) [!]"
+	description "Destruction Derby 64 (E) (M3) [!]"
+	rom ( name "Destruction Derby 64 (E) (M3) [!].z64" crc 7AD9E429 )
+)
+
+game (
+	name "Destruction Derby 64 (U) [!]"
+	description "Destruction Derby 64 (U) [!]"
+	rom ( name "Destruction Derby 64 (U) [!].z64" crc 38F1B5D9 )
+)
+
+game (
+	name "Destruction Derby 64 (U) [f1] (PAL)"
+	description "Destruction Derby 64 (U) [f1] (PAL)"
+	rom ( name "Destruction Derby 64 (U) [f1] (PAL).z64" crc ED1AC18C )
+)
+
+game (
+	name "Destruction Derby 64 (U) [t1]"
+	description "Destruction Derby 64 (U) [t1]"
+	rom ( name "Destruction Derby 64 (U) [t1].z64" crc 60485DFB )
+)
+
+game (
+	name "Dezaemon 3D (J) [!]"
+	description "Dezaemon 3D (J) [!]"
+	rom ( name "Dezaemon 3D (J) [!].z64" crc 9E978488 )
+)
+
+game (
+	name "Dezaemon 3D (J) [b1]"
+	description "Dezaemon 3D (J) [b1]"
+	rom ( name "Dezaemon 3D (J) [b1].z64" crc 9DE8A036 )
+)
+
+game (
+	name "Dezaemon 3D (J) [b1][t1]"
+	description "Dezaemon 3D (J) [b1][t1]"
+	rom ( name "Dezaemon 3D (J) [b1][t1].z64" crc 9BBAD86E )
+)
+
+game (
+	name "Dezaemon 3D (J) [b2]"
+	description "Dezaemon 3D (J) [b2]"
+	rom ( name "Dezaemon 3D (J) [b2].z64" crc 573B12D2 )
+)
+
+game (
+	name "Dezaemon 3D (J) [t1]"
+	description "Dezaemon 3D (J) [t1]"
+	rom ( name "Dezaemon 3D (J) [t1].z64" crc 7A615C39 )
+)
+
+game (
+	name "Diddy Kong Racing (E) (M3) (V1.0) [!]"
+	description "Diddy Kong Racing (E) (M3) (V1.0) [!]"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [!].z64" crc 4A13323C )
+)
+
+game (
+	name "Diddy Kong Racing (E) (M3) (V1.0) [f1]"
+	description "Diddy Kong Racing (E) (M3) (V1.0) [f1]"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [f1].z64" crc A95A5572 )
+)
+
+game (
+	name "Diddy Kong Racing (E) (M3) (V1.0) [o1]"
+	description "Diddy Kong Racing (E) (M3) (V1.0) [o1]"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [o1].z64" crc 417C71D7 )
+)
+
+game (
+	name "Diddy Kong Racing (E) (M3) (V1.1) [!]"
+	description "Diddy Kong Racing (E) (M3) (V1.1) [!]"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [!].z64" crc B1E87639 )
+)
+
+game (
+	name "Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64)"
+	description "Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64)"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64).z64" crc 7DB6C3E2 )
+)
+
+game (
+	name "Diddy Kong Racing (J) [f1] (Z64)"
+	description "Diddy Kong Racing (J) [f1] (Z64)"
+	rom ( name "Diddy Kong Racing (J) [f1] (Z64).z64" crc 60BD0E39 )
+)
+
+game (
+	name "Diddy Kong Racing (J)"
+	description "Diddy Kong Racing (J)"
+	rom ( name "Diddy Kong Racing (J).z64" crc B566FB94 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [!]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [!]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [!].z64" crc EB759206 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b1]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b1]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b1].z64" crc C9EF2818 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b2]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b2]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b2].z64" crc E7F77779 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b3]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b3]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b3].z64" crc 97E53BD6 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b4]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b4]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b4].z64" crc 18138847 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b5]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b5]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b5].z64" crc 5E7AA4BC )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b6]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b6]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b6].z64" crc F26051DD )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [b7]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [b7]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b7].z64" crc FF62C5E1 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [f1]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [f1]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1].z64" crc 52B44E7A )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [f1][h1C]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [f1][h1C]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1][h1C].z64" crc 173BD1B9 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [f2]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [f2]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f2].z64" crc 3BF35F08 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [f3]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [f3]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f3].z64" crc 692FE6C3 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [f4]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [f4]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f4].z64" crc F09727F4 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [o1]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [o1]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1].z64" crc 36C92D99 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [o1][f1]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [o1][f1]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1][f1].z64" crc FD3DC0D2 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [o2]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [o2]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o2].z64" crc 17EF30CA )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil]"
+	description "Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil].z64" crc 7DAB6850 )
+)
+
+game (
+	name "Diddy Kong Racing (U) (M2) (V1.1) [!]"
+	description "Diddy Kong Racing (U) (M2) (V1.1) [!]"
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.1) [!].z64" crc 5ACCA298 )
+)
+
+game (
+	name "Disney's Donald Duck - Goin' Quackers (U) [!]"
+	description "Disney's Donald Duck - Goin' Quackers (U) [!]"
+	rom ( name "Disney's Donald Duck - Goin' Quackers (U) [!].z64" crc 7FDEC270 )
+)
+
+game (
+	name "Donald Duck - Quack Attack (E) (M5) [!]"
+	description "Donald Duck - Quack Attack (E) (M5) [!]"
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [!].z64" crc C4B0D9EA )
+)
+
+game (
+	name "Donald Duck - Quack Attack (E) (M5) [b1]"
+	description "Donald Duck - Quack Attack (E) (M5) [b1]"
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [b1].z64" crc 0097D5CF )
+)
+
+game (
+	name "Donald Duck - Quack Attack (E) (M5) [f1] (NTSC)"
+	description "Donald Duck - Quack Attack (E) (M5) [f1] (NTSC)"
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [f1] (NTSC).z64" crc 18BB3891 )
+)
+
+game (
+	name "Disney's Tarzan (E) [!]"
+	description "Disney's Tarzan (E) [!]"
+	rom ( name "Disney's Tarzan (E) [!].z64" crc 7737ED9E )
+)
+
+game (
+	name "Disney's Tarzan (E) [h1C]"
+	description "Disney's Tarzan (E) [h1C]"
+	rom ( name "Disney's Tarzan (E) [h1C].z64" crc B9C1B4DA )
+)
+
+game (
+	name "Disney's Tarzan (F) [!]"
+	description "Disney's Tarzan (F) [!]"
+	rom ( name "Disney's Tarzan (F) [!].z64" crc 99C7649D )
+)
+
+game (
+	name "Disney's Tarzan (G) [!]"
+	description "Disney's Tarzan (G) [!]"
+	rom ( name "Disney's Tarzan (G) [!].z64" crc 0B0954C5 )
+)
+
+game (
+	name "Disney's Tarzan (G) [h1C]"
+	description "Disney's Tarzan (G) [h1C]"
+	rom ( name "Disney's Tarzan (G) [h1C].z64" crc C5FF0D81 )
+)
+
+game (
+	name "Disney's Tarzan (U) [!]"
+	description "Disney's Tarzan (U) [!]"
+	rom ( name "Disney's Tarzan (U) [!].z64" crc C38CA641 )
+)
+
+game (
+	name "Disney's Tarzan (U) [f1] (PAL)"
+	description "Disney's Tarzan (U) [f1] (PAL)"
+	rom ( name "Disney's Tarzan (U) [f1] (PAL).z64" crc 1F710DBF )
+)
+
+game (
+	name "Disney's Tarzan (U) [f2] (PAL)"
+	description "Disney's Tarzan (U) [f2] (PAL)"
+	rom ( name "Disney's Tarzan (U) [f2] (PAL).z64" crc 19F56474 )
+)
+
+game (
+	name "Disney's Tarzan (U) [t1]"
+	description "Disney's Tarzan (U) [t1]"
+	rom ( name "Disney's Tarzan (U) [t1].z64" crc 15F5F6B9 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.01"
+	description "Doctor V64 BIOS V1.01"
+	rom ( name "Doctor V64 BIOS V1.01.bin" crc A189032E )
+)
+
+game (
+	name "Doctor V64 BIOS V1.02"
+	description "Doctor V64 BIOS V1.02"
+	rom ( name "Doctor V64 BIOS V1.02.bin" crc 4D8C07BE )
+)
+
+game (
+	name "Doctor V64 BIOS V1.03"
+	description "Doctor V64 BIOS V1.03"
+	rom ( name "Doctor V64 BIOS V1.03.bin" crc C701737C )
+)
+
+game (
+	name "Doctor V64 BIOS V1.04"
+	description "Doctor V64 BIOS V1.04"
+	rom ( name "Doctor V64 BIOS V1.04.bin" crc 02367435 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.05"
+	description "Doctor V64 BIOS V1.05"
+	rom ( name "Doctor V64 BIOS V1.05.bin" crc 532080B9 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.08"
+	description "Doctor V64 BIOS V1.08"
+	rom ( name "Doctor V64 BIOS V1.08.bin" crc 2994D961 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.09"
+	description "Doctor V64 BIOS V1.09"
+	rom ( name "Doctor V64 BIOS V1.09.bin" crc 7924F6CE )
+)
+
+game (
+	name "Doctor V64 BIOS V1.10"
+	description "Doctor V64 BIOS V1.10"
+	rom ( name "Doctor V64 BIOS V1.10.bin" crc DE489E90 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.10r (RBubba Hack)"
+	description "Doctor V64 BIOS V1.10r (RBubba Hack)"
+	rom ( name "Doctor V64 BIOS V1.10r (RBubba Hack).bin" crc 2B8919F0 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.11"
+	description "Doctor V64 BIOS V1.11"
+	rom ( name "Doctor V64 BIOS V1.11.bin" crc 61A2D42C )
+)
+
+game (
+	name "Doctor V64 BIOS V1.21"
+	description "Doctor V64 BIOS V1.21"
+	rom ( name "Doctor V64 BIOS V1.21.bin" crc F5200388 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.22"
+	description "Doctor V64 BIOS V1.22"
+	rom ( name "Doctor V64 BIOS V1.22.bin" crc 8E5050D0 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.30"
+	description "Doctor V64 BIOS V1.30"
+	rom ( name "Doctor V64 BIOS V1.30.bin" crc 520238C4 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.31 (Blue)"
+	description "Doctor V64 BIOS V1.31 (Blue)"
+	rom ( name "Doctor V64 BIOS V1.31 (Blue).bin" crc 21EC5148 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.31"
+	description "Doctor V64 BIOS V1.31"
+	rom ( name "Doctor V64 BIOS V1.31.bin" crc 0C500D9B )
+)
+
+game (
+	name "Doctor V64 BIOS V1.32"
+	description "Doctor V64 BIOS V1.32"
+	rom ( name "Doctor V64 BIOS V1.32.bin" crc DAD115EF )
+)
+
+game (
+	name "Doctor V64 BIOS V1.33"
+	description "Doctor V64 BIOS V1.33"
+	rom ( name "Doctor V64 BIOS V1.33.bin" crc 083A7CCD )
+)
+
+game (
+	name "Doctor V64 BIOS V1.33b"
+	description "Doctor V64 BIOS V1.33b"
+	rom ( name "Doctor V64 BIOS V1.33b.bin" crc 6F4F23DF )
+)
+
+game (
+	name "Doctor V64 BIOS V1.40"
+	description "Doctor V64 BIOS V1.40"
+	rom ( name "Doctor V64 BIOS V1.40.bin" crc 05A09EE2 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.40b"
+	description "Doctor V64 BIOS V1.40b"
+	rom ( name "Doctor V64 BIOS V1.40b.bin" crc 62D5C1F0 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.41"
+	description "Doctor V64 BIOS V1.41"
+	rom ( name "Doctor V64 BIOS V1.41.bin" crc 370E1675 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.41b"
+	description "Doctor V64 BIOS V1.41b"
+	rom ( name "Doctor V64 BIOS V1.41b.bin" crc 507B4967 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.50"
+	description "Doctor V64 BIOS V1.50"
+	rom ( name "Doctor V64 BIOS V1.50.bin" crc BC7E2E16 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.51"
+	description "Doctor V64 BIOS V1.51"
+	rom ( name "Doctor V64 BIOS V1.51.bin" crc C9CCEE6F )
+)
+
+game (
+	name "Doctor V64 BIOS V1.52 (CH2 Hack)"
+	description "Doctor V64 BIOS V1.52 (CH2 Hack)"
+	rom ( name "Doctor V64 BIOS V1.52 (CH2 Hack).bin" crc A2AA3469 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.52"
+	description "Doctor V64 BIOS V1.52"
+	rom ( name "Doctor V64 BIOS V1.52.bin" crc 40217611 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.53"
+	description "Doctor V64 BIOS V1.53"
+	rom ( name "Doctor V64 BIOS V1.53.bin" crc 7BC1107E )
+)
+
+game (
+	name "Doctor V64 BIOS V1.60"
+	description "Doctor V64 BIOS V1.60"
+	rom ( name "Doctor V64 BIOS V1.60.bin" crc AC51F894 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.61"
+	description "Doctor V64 BIOS V1.61"
+	rom ( name "Doctor V64 BIOS V1.61.bin" crc A0AB9232 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.70"
+	description "Doctor V64 BIOS V1.70"
+	rom ( name "Doctor V64 BIOS V1.70.bin" crc ADDCEBEC )
+)
+
+game (
+	name "Doctor V64 BIOS V1.71"
+	description "Doctor V64 BIOS V1.71"
+	rom ( name "Doctor V64 BIOS V1.71.bin" crc 4781B044 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.72"
+	description "Doctor V64 BIOS V1.72"
+	rom ( name "Doctor V64 BIOS V1.72.bin" crc 624F8950 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.73"
+	description "Doctor V64 BIOS V1.73"
+	rom ( name "Doctor V64 BIOS V1.73.bin" crc BDE9C452 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.74 (Revive Version)"
+	description "Doctor V64 BIOS V1.74 (Revive Version)"
+	rom ( name "Doctor V64 BIOS V1.74 (Revive Version).bin" crc 3699334A )
+)
+
+game (
+	name "Doctor V64 BIOS V1.74"
+	description "Doctor V64 BIOS V1.74"
+	rom ( name "Doctor V64 BIOS V1.74.bin" crc 5055B5BA )
+)
+
+game (
+	name "Doctor V64 BIOS V1.75"
+	description "Doctor V64 BIOS V1.75"
+	rom ( name "Doctor V64 BIOS V1.75.bin" crc 48BAF170 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.76"
+	description "Doctor V64 BIOS V1.76"
+	rom ( name "Doctor V64 BIOS V1.76.bin" crc 6CE67878 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.80"
+	description "Doctor V64 BIOS V1.80"
+	rom ( name "Doctor V64 BIOS V1.80.bin" crc D3C94E60 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.81"
+	description "Doctor V64 BIOS V1.81"
+	rom ( name "Doctor V64 BIOS V1.81.bin" crc A463F12F )
+)
+
+game (
+	name "Doctor V64 BIOS V1.82"
+	description "Doctor V64 BIOS V1.82"
+	rom ( name "Doctor V64 BIOS V1.82.bin" crc 1E115FD4 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.83"
+	description "Doctor V64 BIOS V1.83"
+	rom ( name "Doctor V64 BIOS V1.83.bin" crc D6A8D690 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.90"
+	description "Doctor V64 BIOS V1.90"
+	rom ( name "Doctor V64 BIOS V1.90.bin" crc 25D2DD26 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.91"
+	description "Doctor V64 BIOS V1.91"
+	rom ( name "Doctor V64 BIOS V1.91.bin" crc 979F7092 )
+)
+
+game (
+	name "Doctor V64 BIOS V1.92"
+	description "Doctor V64 BIOS V1.92"
+	rom ( name "Doctor V64 BIOS V1.92.bin" crc FBB5F11C )
+)
+
+game (
+	name "Doctor V64 BIOS V1.93"
+	description "Doctor V64 BIOS V1.93"
+	rom ( name "Doctor V64 BIOS V1.93.bin" crc 5133779B )
+)
+
+game (
+	name "Doctor V64 BIOS V1.94"
+	description "Doctor V64 BIOS V1.94"
+	rom ( name "Doctor V64 BIOS V1.94.bin" crc D223CE48 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.00"
+	description "Doctor V64 BIOS V2.00"
+	rom ( name "Doctor V64 BIOS V2.00.bin" crc 76831784 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.00b"
+	description "Doctor V64 BIOS V2.00b"
+	rom ( name "Doctor V64 BIOS V2.00b.bin" crc 201B503F )
+)
+
+game (
+	name "Doctor V64 BIOS V2.01 (Red)"
+	description "Doctor V64 BIOS V2.01 (Red)"
+	rom ( name "Doctor V64 BIOS V2.01 (Red).bin" crc 59D5F118 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.01"
+	description "Doctor V64 BIOS V2.01"
+	rom ( name "Doctor V64 BIOS V2.01.bin" crc C7D5D511 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.01b"
+	description "Doctor V64 BIOS V2.01b"
+	rom ( name "Doctor V64 BIOS V2.01b.bin" crc 0276DA37 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.02"
+	description "Doctor V64 BIOS V2.02"
+	rom ( name "Doctor V64 BIOS V2.02.bin" crc 16A08FDC )
+)
+
+game (
+	name "Doctor V64 BIOS V2.02b"
+	description "Doctor V64 BIOS V2.02b"
+	rom ( name "Doctor V64 BIOS V2.02b.bin" crc CC0CAF09 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03 (Black)"
+	description "Doctor V64 BIOS V2.03 (Black)"
+	rom ( name "Doctor V64 BIOS V2.03 (Black).bin" crc 9E19FF85 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03 (Blue)"
+	description "Doctor V64 BIOS V2.03 (Blue)"
+	rom ( name "Doctor V64 BIOS V2.03 (Blue).bin" crc 07CA4D44 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03 (Green)"
+	description "Doctor V64 BIOS V2.03 (Green)"
+	rom ( name "Doctor V64 BIOS V2.03 (Green).bin" crc 8901DF22 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03 (Purple)"
+	description "Doctor V64 BIOS V2.03 (Purple)"
+	rom ( name "Doctor V64 BIOS V2.03 (Purple).bin" crc 0DD22DC0 )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03 (Red)"
+	description "Doctor V64 BIOS V2.03 (Red)"
+	rom ( name "Doctor V64 BIOS V2.03 (Red).bin" crc 4282F00D )
+)
+
+game (
+	name "Doctor V64 BIOS V2.03"
+	description "Doctor V64 BIOS V2.03"
+	rom ( name "Doctor V64 BIOS V2.03.bin" crc A37D13AF )
+)
+
+game (
+	name "Donkey Kong 64 (E) [!]"
+	description "Donkey Kong 64 (E) [!]"
+	rom ( name "Donkey Kong 64 (E) [!].z64" crc A28C71C6 )
+)
+
+game (
+	name "Donkey Kong 64 (E) [b1]"
+	description "Donkey Kong 64 (E) [b1]"
+	rom ( name "Donkey Kong 64 (E) [b1].z64" crc F33061A5 )
+)
+
+game (
+	name "Donkey Kong 64 (E) [f1] (Boot&Save)"
+	description "Donkey Kong 64 (E) [f1] (Boot&Save)"
+	rom ( name "Donkey Kong 64 (E) [f1] (Boot&Save).z64" crc BB882FC7 )
+)
+
+game (
+	name "Donkey Kong 64 (E) [f1] (Save)"
+	description "Donkey Kong 64 (E) [f1] (Save)"
+	rom ( name "Donkey Kong 64 (E) [f1] (Save).z64" crc 9BB8700A )
+)
+
+game (
+	name "Donkey Kong 64 (J) [!]"
+	description "Donkey Kong 64 (J) [!]"
+	rom ( name "Donkey Kong 64 (J) [!].z64" crc 919F7E74 )
+)
+
+game (
+	name "Donkey Kong 64 (U) (Kiosk Demo) [!]"
+	description "Donkey Kong 64 (U) (Kiosk Demo) [!]"
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [!].z64" crc C83DFA15 )
+)
+
+game (
+	name "Donkey Kong 64 (U) (Kiosk Demo) [b1]"
+	description "Donkey Kong 64 (U) (Kiosk Demo) [b1]"
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b1].z64" crc AC26933F )
+)
+
+game (
+	name "Donkey Kong 64 (U) (Kiosk Demo) [b2]"
+	description "Donkey Kong 64 (U) (Kiosk Demo) [b2]"
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b2].z64" crc 0DD55E97 )
+)
+
+game (
+	name "Donkey Kong 64 (U) (Kiosk Demo) [f1] (PAL)"
+	description "Donkey Kong 64 (U) (Kiosk Demo) [f1] (PAL)"
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [f1] (PAL).z64" crc 4229DBD9 )
+)
+
+game (
+	name "Donkey Kong 64 (U) [!]"
+	description "Donkey Kong 64 (U) [!]"
+	rom ( name "Donkey Kong 64 (U) [!].z64" crc D44B4FC6 )
+)
+
+game (
+	name "Donkey Kong 64 (U) [b1]"
+	description "Donkey Kong 64 (U) [b1]"
+	rom ( name "Donkey Kong 64 (U) [b1].z64" crc 261B74E9 )
+)
+
+game (
+	name "Donkey Kong 64 (U) [f1] (Save)"
+	description "Donkey Kong 64 (U) [f1] (Save)"
+	rom ( name "Donkey Kong 64 (U) [f1] (Save).z64" crc 15656CBA )
+)
+
+game (
+	name "Donkey Kong 64 (U) [f2]"
+	description "Donkey Kong 64 (U) [f2]"
+	rom ( name "Donkey Kong 64 (U) [f2].z64" crc B62F126F )
+)
+
+game (
+	name "Donkey Kong 64 (U) [f3]"
+	description "Donkey Kong 64 (U) [f3]"
+	rom ( name "Donkey Kong 64 (U) [f3].z64" crc 35BEDE73 )
+)
+
+game (
+	name "Doom 64 (E) [!]"
+	description "Doom 64 (E) [!]"
+	rom ( name "Doom 64 (E) [!].z64" crc D985C356 )
+)
+
+game (
+	name "Doom 64 (E) [b1]"
+	description "Doom 64 (E) [b1]"
+	rom ( name "Doom 64 (E) [b1].z64" crc 010B5830 )
+)
+
+game (
+	name "Doom 64 (J) [!]"
+	description "Doom 64 (J) [!]"
+	rom ( name "Doom 64 (J) [!].z64" crc C8F3AF5B )
+)
+
+game (
+	name "Doom 64 (J) [b1]"
+	description "Doom 64 (J) [b1]"
+	rom ( name "Doom 64 (J) [b1].z64" crc C1DD12A2 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [!]"
+	description "Doom 64 (U) (V1.0) [!]"
+	rom ( name "Doom 64 (U) (V1.0) [!].z64" crc 5CC1ADE6 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [b1]"
+	description "Doom 64 (U) (V1.0) [b1]"
+	rom ( name "Doom 64 (U) (V1.0) [b1].z64" crc 0D54C0F6 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [b2]"
+	description "Doom 64 (U) (V1.0) [b2]"
+	rom ( name "Doom 64 (U) (V1.0) [b2].z64" crc 0B3D7F30 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [o1]"
+	description "Doom 64 (U) (V1.0) [o1]"
+	rom ( name "Doom 64 (U) (V1.0) [o1].z64" crc DE3B18BE )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR]"
+	description "Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR]"
+	rom ( name "Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR].z64" crc 19347E61 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [t1]"
+	description "Doom 64 (U) (V1.0) [t1]"
+	rom ( name "Doom 64 (U) (V1.0) [t1].z64" crc C1909D70 )
+)
+
+game (
+	name "Doom 64 (U) (V1.0) [t2]"
+	description "Doom 64 (U) (V1.0) [t2]"
+	rom ( name "Doom 64 (U) (V1.0) [t2].z64" crc E0D16283 )
+)
+
+game (
+	name "Doom 64 (U) (V1.1) [!]"
+	description "Doom 64 (U) (V1.1) [!]"
+	rom ( name "Doom 64 (U) (V1.1) [!].z64" crc 1D3A17B5 )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!]"
+	description "Doraemon - Nobita to 3tsu no Seireiseki (J) [!]"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!].z64" crc 154E8B33 )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b1]"
+	description "Doraemon - Nobita to 3tsu no Seireiseki (J) [b1]"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b1].z64" crc D5E8B08D )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b2]"
+	description "Doraemon - Nobita to 3tsu no Seireiseki (J) [b2]"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b2].z64" crc AFE97CA4 )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b3]"
+	description "Doraemon - Nobita to 3tsu no Seireiseki (J) [b3]"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b3].z64" crc EAF14AE6 )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki (J) [t1]"
+	description "Doraemon - Nobita to 3tsu no Seireiseki (J) [t1]"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [t1].z64" crc E31DADBD )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!]"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [!]"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!].z64" crc 0C1A0C38 )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b1]"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [b1]"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b1].z64" crc 3A0BF1D5 )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b2]"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [b2]"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b2].z64" crc 50D15DC8 )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f1] (PAL)"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [f1] (PAL)"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f1] (PAL).z64" crc F3FC6987 )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f2]"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [f2]"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f2].z64" crc FD5154ED )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden (J) [t1]"
+	description "Doraemon 2 - Nobita to Hikari no Shinden (J) [t1]"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [t1].z64" crc 5204AF6D )
+)
+
+game (
+	name "Doraemon 3 - Nobita no Machi SOS! (J) [!]"
+	description "Doraemon 3 - Nobita no Machi SOS! (J) [!]"
+	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [!].z64" crc D3B68BE4 )
+)
+
+game (
+	name "Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC)"
+	description "Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC)"
+	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC).z64" crc 92DFE338 )
+)
+
+game (
+	name "Doubutsu no Mori (J) [!]"
+	description "Doubutsu no Mori (J) [!]"
+	rom ( name "Doubutsu no Mori (J) [!].z64" crc 9503E3F1 )
+)
+
+game (
+	name "Doubutsu no Mori (J) [T+Eng2007-03-22_Brandon Dixon]"
+	description "Doubutsu no Mori (J) [T+Eng2007-03-22_Brandon Dixon]"
+	rom ( name "Doubutsu no Mori (J) [T+Eng2007-03-22_Brandon Dixon].z64" crc 85B86420 )
+)
+
+game (
+	name "Doubutsu no Mori (J) [T-Eng2007-02-08_Brandon Dixon]"
+	description "Doubutsu no Mori (J) [T-Eng2007-02-08_Brandon Dixon]"
+	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-08_Brandon Dixon].z64" crc 09DAA322 )
+)
+
+game (
+	name "Doubutsu no Mori (J) [T-Eng2007-02-09_Brandon Dixon]"
+	description "Doubutsu no Mori (J) [T-Eng2007-02-09_Brandon Dixon]"
+	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-09_Brandon Dixon].z64" crc FBA629D1 )
+)
+
+game (
+	name "Dr. Mario 64 (U) [!]"
+	description "Dr. Mario 64 (U) [!]"
+	rom ( name "Dr. Mario 64 (U) [!].z64" crc A4701927 )
+)
+
+game (
+	name "Dual Heroes (E) [!]"
+	description "Dual Heroes (E) [!]"
+	rom ( name "Dual Heroes (E) [!].z64" crc 5A7E226B )
+)
+
+game (
+	name "Dual Heroes (E) [b1]"
+	description "Dual Heroes (E) [b1]"
+	rom ( name "Dual Heroes (E) [b1].z64" crc 67D23CE6 )
+)
+
+game (
+	name "Dual Heroes (E) [b2]"
+	description "Dual Heroes (E) [b2]"
+	rom ( name "Dual Heroes (E) [b2].z64" crc EF7A7E0B )
+)
+
+game (
+	name "Dual Heroes (E) [f1] (NTSC)"
+	description "Dual Heroes (E) [f1] (NTSC)"
+	rom ( name "Dual Heroes (E) [f1] (NTSC).z64" crc 307AFA61 )
+)
+
+game (
+	name "Dual Heroes (J) [!]"
+	description "Dual Heroes (J) [!]"
+	rom ( name "Dual Heroes (J) [!].z64" crc 20F23DDE )
+)
+
+game (
+	name "Dual Heroes (J) [o1]"
+	description "Dual Heroes (J) [o1]"
+	rom ( name "Dual Heroes (J) [o1].z64" crc 28B291E9 )
+)
+
+game (
+	name "Dual Heroes (J) [o2]"
+	description "Dual Heroes (J) [o2]"
+	rom ( name "Dual Heroes (J) [o2].z64" crc 5CB6F46C )
+)
+
+game (
+	name "Dual Heroes (U) [!]"
+	description "Dual Heroes (U) [!]"
+	rom ( name "Dual Heroes (U) [!].z64" crc D09F4DA8 )
+)
+
+game (
+	name "Dual Heroes (U) [b1]"
+	description "Dual Heroes (U) [b1]"
+	rom ( name "Dual Heroes (U) [b1].z64" crc 211C0CDE )
+)
+
+game (
+	name "Duck Dodgers Starring Daffy Duck (U) (M3) [!]"
+	description "Duck Dodgers Starring Daffy Duck (U) (M3) [!]"
+	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [!].z64" crc 3177A905 )
+)
+
+game (
+	name "Duck Dodgers Starring Daffy Duck (U) (M3) [t1]"
+	description "Duck Dodgers Starring Daffy Duck (U) (M3) [t1]"
+	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [t1].z64" crc 40F0C9D8 )
+)
+
+game (
+	name "Looney Tunes - Duck Dodgers (E) (M6) [!]"
+	description "Looney Tunes - Duck Dodgers (E) (M6) [!]"
+	rom ( name "Looney Tunes - Duck Dodgers (E) (M6) [!].z64" crc C61F6BB9 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (E) [!]"
+	description "Duke Nukem - ZER0 H0UR (E) [!]"
+	rom ( name "Duke Nukem - ZER0 H0UR (E) [!].z64" crc EA82F037 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (E) [f1] (NTSC)"
+	description "Duke Nukem - ZER0 H0UR (E) [f1] (NTSC)"
+	rom ( name "Duke Nukem - ZER0 H0UR (E) [f1] (NTSC).z64" crc 99EFD6CD )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (F) [!]"
+	description "Duke Nukem - ZER0 H0UR (F) [!]"
+	rom ( name "Duke Nukem - ZER0 H0UR (F) [!].z64" crc 7ECDFB28 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [!]"
+	description "Duke Nukem - ZER0 H0UR (U) [!]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [!].z64" crc 9A3258D7 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [b1]"
+	description "Duke Nukem - ZER0 H0UR (U) [b1]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b1].z64" crc 5BC8B0D4 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [b2]"
+	description "Duke Nukem - ZER0 H0UR (U) [b2]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b2].z64" crc 197B34D9 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [b3]"
+	description "Duke Nukem - ZER0 H0UR (U) [b3]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b3].z64" crc BFF139C6 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [b4]"
+	description "Duke Nukem - ZER0 H0UR (U) [b4]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b4].z64" crc 06329ECD )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR (U) [t1]"
+	description "Duke Nukem - ZER0 H0UR (U) [t1]"
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [t1].z64" crc 50AC825E )
+)
+
+game (
+	name "Duke Nukem 64 (E) [!]"
+	description "Duke Nukem 64 (E) [!]"
+	rom ( name "Duke Nukem 64 (E) [!].z64" crc 3275ADB0 )
+)
+
+game (
+	name "Duke Nukem 64 (E) [b1]"
+	description "Duke Nukem 64 (E) [b1]"
+	rom ( name "Duke Nukem 64 (E) [b1].z64" crc CC79FC6F )
+)
+
+game (
+	name "Duke Nukem 64 (E) [o1]"
+	description "Duke Nukem 64 (E) [o1]"
+	rom ( name "Duke Nukem 64 (E) [o1].z64" crc 31A5C4BE )
+)
+
+game (
+	name "Duke Nukem 64 (F)"
+	description "Duke Nukem 64 (F)"
+	rom ( name "Duke Nukem 64 (F).z64" crc B9C9F07A )
+)
+
+game (
+	name "Duke Nukem 64 (U) [!]"
+	description "Duke Nukem 64 (U) [!]"
+	rom ( name "Duke Nukem 64 (U) [!].z64" crc DBFD5A53 )
+)
+
+game (
+	name "Duke Nukem 64 (U) [b1]"
+	description "Duke Nukem 64 (U) [b1]"
+	rom ( name "Duke Nukem 64 (U) [b1].z64" crc 9DCE8136 )
+)
+
+game (
+	name "Duke Nukem 64 (U) [b2]"
+	description "Duke Nukem 64 (U) [b2]"
+	rom ( name "Duke Nukem 64 (U) [b2].z64" crc 6CED6C75 )
+)
+
+game (
+	name "Duke Nukem 64 (U) [b3]"
+	description "Duke Nukem 64 (U) [b3]"
+	rom ( name "Duke Nukem 64 (U) [b3].z64" crc 1F18823F )
+)
+
+game (
+	name "Duke Nukem 64 (U) [h1C]"
+	description "Duke Nukem 64 (U) [h1C]"
+	rom ( name "Duke Nukem 64 (U) [h1C].z64" crc BF009E6E )
+)
+
+game (
+	name "Duke Nukem 64 (U) [o1]"
+	description "Duke Nukem 64 (U) [o1]"
+	rom ( name "Duke Nukem 64 (U) [o1].z64" crc 20489410 )
+)
+
+game (
+	name "Duke Nukem 64 (U) [t1]"
+	description "Duke Nukem 64 (U) [t1]"
+	rom ( name "Duke Nukem 64 (U) [t1].z64" crc 6A42D55D )
+)
+
+game (
+	name "Duke Nukem 64 (U) [t2]"
+	description "Duke Nukem 64 (U) [t2]"
+	rom ( name "Duke Nukem 64 (U) [t2].z64" crc 5FDB41A9 )
+)
+
+game (
+	name "Duke Nukem 64 (U) [t3]"
+	description "Duke Nukem 64 (U) [t3]"
+	rom ( name "Duke Nukem 64 (U) [t3].z64" crc 55FD0D4F )
+)
+
+game (
+	name "Earthworm Jim 3D (E) (M6) [!]"
+	description "Earthworm Jim 3D (E) (M6) [!]"
+	rom ( name "Earthworm Jim 3D (E) (M6) [!].z64" crc 61A56330 )
+)
+
+game (
+	name "Earthworm Jim 3D (E) (M6) [b1]"
+	description "Earthworm Jim 3D (E) (M6) [b1]"
+	rom ( name "Earthworm Jim 3D (E) (M6) [b1].z64" crc E57B20DD )
+)
+
+game (
+	name "Earthworm Jim 3D (U) [!]"
+	description "Earthworm Jim 3D (U) [!]"
+	rom ( name "Earthworm Jim 3D (U) [!].z64" crc 9E6579C5 )
+)
+
+game (
+	name "Earthworm Jim 3D (U) [f1] (PAL)"
+	description "Earthworm Jim 3D (U) [f1] (PAL)"
+	rom ( name "Earthworm Jim 3D (U) [f1] (PAL).z64" crc 25285541 )
+)
+
+game (
+	name "Earthworm Jim 3D (U) [hI]"
+	description "Earthworm Jim 3D (U) [hI]"
+	rom ( name "Earthworm Jim 3D (U) [hI].z64" crc 92E70880 )
+)
+
+game (
+	name "Earthworm Jim 3D (U) [T+Rus]"
+	description "Earthworm Jim 3D (U) [T+Rus]"
+	rom ( name "Earthworm Jim 3D (U) [T+Rus].z64" crc C548F974 )
+)
+
+game (
+	name "Earthworm Jim 3D (U) [t1]"
+	description "Earthworm Jim 3D (U) [t1]"
+	rom ( name "Earthworm Jim 3D (U) [t1].z64" crc 7D1F1297 )
+)
+
+game (
+	name "ECW Hardcore Revolution (E) [!]"
+	description "ECW Hardcore Revolution (E) [!]"
+	rom ( name "ECW Hardcore Revolution (E) [!].z64" crc BE8FEEAD )
+)
+
+game (
+	name "ECW Hardcore Revolution (E) [b1]"
+	description "ECW Hardcore Revolution (E) [b1]"
+	rom ( name "ECW Hardcore Revolution (E) [b1].z64" crc 7340D982 )
+)
+
+game (
+	name "ECW Hardcore Revolution (U) [!]"
+	description "ECW Hardcore Revolution (U) [!]"
+	rom ( name "ECW Hardcore Revolution (U) [!].z64" crc 36D368EF )
+)
+
+game (
+	name "Eikou no Saint Andrews (J) [!]"
+	description "Eikou no Saint Andrews (J) [!]"
+	rom ( name "Eikou no Saint Andrews (J) [!].z64" crc 1699D2D6 )
+)
+
+game (
+	name "Eikou no Saint Andrews (J) [b1]"
+	description "Eikou no Saint Andrews (J) [b1]"
+	rom ( name "Eikou no Saint Andrews (J) [b1].z64" crc 2196A2DB )
+)
+
+game (
+	name "Eikou no Saint Andrews (J) [b2]"
+	description "Eikou no Saint Andrews (J) [b2]"
+	rom ( name "Eikou no Saint Andrews (J) [b2].z64" crc C348F53C )
+)
+
+game (
+	name "Eikou no Saint Andrews (J) [h1C]"
+	description "Eikou no Saint Andrews (J) [h1C]"
+	rom ( name "Eikou no Saint Andrews (J) [h1C].z64" crc 6ACAE1F4 )
+)
+
+game (
+	name "Eikou no Saint Andrews (J) [h2C]"
+	description "Eikou no Saint Andrews (J) [h2C]"
+	rom ( name "Eikou no Saint Andrews (J) [h2C].z64" crc A281B31F )
+)
+
+game (
+	name "Elmo's Letter Adventure (U) [!]"
+	description "Elmo's Letter Adventure (U) [!]"
+	rom ( name "Elmo's Letter Adventure (U) [!].z64" crc 92C3BA6F )
+)
+
+game (
+	name "Elmo's Number Journey (U) [!]"
+	description "Elmo's Number Journey (U) [!]"
+	rom ( name "Elmo's Number Journey (U) [!].z64" crc EA3B92D8 )
+)
+
+game (
+	name "Excitebike 64 (E) [!]"
+	description "Excitebike 64 (E) [!]"
+	rom ( name "Excitebike 64 (E) [!].z64" crc 0B881E60 )
+)
+
+game (
+	name "Excitebike 64 (J) [!]"
+	description "Excitebike 64 (J) [!]"
+	rom ( name "Excitebike 64 (J) [!].z64" crc 03BFD065 )
+)
+
+game (
+	name "Excitebike 64 (U) (Kiosk Demo) [!]"
+	description "Excitebike 64 (U) (Kiosk Demo) [!]"
+	rom ( name "Excitebike 64 (U) (Kiosk Demo) [!].z64" crc BE6298B0 )
+)
+
+game (
+	name "Excitebike 64 (U) [!]"
+	description "Excitebike 64 (U) [!]"
+	rom ( name "Excitebike 64 (U) [!].z64" crc FC459192 )
+)
+
+game (
+	name "Excitebike 64 (U) [b1]"
+	description "Excitebike 64 (U) [b1]"
+	rom ( name "Excitebike 64 (U) [b1].z64" crc 60424B3C )
+)
+
+game (
+	name "Excitebike 64 (U) [f1]"
+	description "Excitebike 64 (U) [f1]"
+	rom ( name "Excitebike 64 (U) [f1].z64" crc FBCAE6F4 )
+)
+
+game (
+	name "Excitebike 64 (U) [f2] (Save)"
+	description "Excitebike 64 (U) [f2] (Save)"
+	rom ( name "Excitebike 64 (U) [f2] (Save).z64" crc 53873696 )
+)
+
+game (
+	name "Extreme-G (E) (M5) [!]"
+	description "Extreme-G (E) (M5) [!]"
+	rom ( name "Extreme-G (E) (M5) [!].z64" crc 0B71B1EA )
+)
+
+game (
+	name "Extreme-G (E) (M5) [b1]"
+	description "Extreme-G (E) (M5) [b1]"
+	rom ( name "Extreme-G (E) (M5) [b1].z64" crc 58D2D3F1 )
+)
+
+game (
+	name "Extreme-G (E) (M5) [b2]"
+	description "Extreme-G (E) (M5) [b2]"
+	rom ( name "Extreme-G (E) (M5) [b2].z64" crc 43744FB5 )
+)
+
+game (
+	name "Extreme-G (E) (M5) [b3]"
+	description "Extreme-G (E) (M5) [b3]"
+	rom ( name "Extreme-G (E) (M5) [b3].z64" crc 78ABCCB1 )
+)
+
+game (
+	name "Extreme-G (E) (M5) [b4]"
+	description "Extreme-G (E) (M5) [b4]"
+	rom ( name "Extreme-G (E) (M5) [b4].z64" crc 8C017609 )
+)
+
+game (
+	name "Extreme-G (E) (M5) [h1C]"
+	description "Extreme-G (E) (M5) [h1C]"
+	rom ( name "Extreme-G (E) (M5) [h1C].z64" crc 6E828955 )
+)
+
+game (
+	name "Extreme-G (J) [!]"
+	description "Extreme-G (J) [!]"
+	rom ( name "Extreme-G (J) [!].z64" crc 750DC9A7 )
+)
+
+game (
+	name "Extreme-G (U) [!]"
+	description "Extreme-G (U) [!]"
+	rom ( name "Extreme-G (U) [!].z64" crc 04CB74EC )
+)
+
+game (
+	name "Extreme-G (U) [h1C]"
+	description "Extreme-G (U) [h1C]"
+	rom ( name "Extreme-G (U) [h1C].z64" crc 27969273 )
+)
+
+game (
+	name "Extreme-G (U) [o1]"
+	description "Extreme-G (U) [o1]"
+	rom ( name "Extreme-G (U) [o1].z64" crc 4EF0CE44 )
+)
+
+game (
+	name "Extreme-G (U) [t1]"
+	description "Extreme-G (U) [t1]"
+	rom ( name "Extreme-G (U) [t1].z64" crc 86CC5964 )
+)
+
+game (
+	name "Extreme-G XG2 (E) (M5) [!]"
+	description "Extreme-G XG2 (E) (M5) [!]"
+	rom ( name "Extreme-G XG2 (E) (M5) [!].z64" crc 1A57F416 )
+)
+
+game (
+	name "Extreme-G XG2 (J) [!]"
+	description "Extreme-G XG2 (J) [!]"
+	rom ( name "Extreme-G XG2 (J) [!].z64" crc 7C8A36DA )
+)
+
+game (
+	name "Extreme-G XG2 (U) [!]"
+	description "Extreme-G XG2 (U) [!]"
+	rom ( name "Extreme-G XG2 (U) [!].z64" crc 81A4C28B )
+)
+
+game (
+	name "Extreme-G XG2 (U) [t1]"
+	description "Extreme-G XG2 (U) [t1]"
+	rom ( name "Extreme-G XG2 (U) [t1].z64" crc FD7F3393 )
+)
+
+game (
+	name "F-1 Pole Position 64 (E) (M3) [!]"
+	description "F-1 Pole Position 64 (E) (M3) [!]"
+	rom ( name "F-1 Pole Position 64 (E) (M3) [!].z64" crc ED750623 )
+)
+
+game (
+	name "F-1 Pole Position 64 (E) (M3) [b1]"
+	description "F-1 Pole Position 64 (E) (M3) [b1]"
+	rom ( name "F-1 Pole Position 64 (E) (M3) [b1].z64" crc DEA54AF5 )
+)
+
+game (
+	name "F-1 Pole Position 64 (U) (M3) [!]"
+	description "F-1 Pole Position 64 (U) (M3) [!]"
+	rom ( name "F-1 Pole Position 64 (U) (M3) [!].z64" crc 30A24D89 )
+)
+
+game (
+	name "F-1 Pole Position 64 (U) (M3) [b1]"
+	description "F-1 Pole Position 64 (U) (M3) [b1]"
+	rom ( name "F-1 Pole Position 64 (U) (M3) [b1].z64" crc AF1AECC1 )
+)
+
+game (
+	name "F-1 Pole Position 64 (U) (M3) [b2]"
+	description "F-1 Pole Position 64 (U) (M3) [b2]"
+	rom ( name "F-1 Pole Position 64 (U) (M3) [b2].z64" crc C18699EA )
+)
+
+game (
+	name "F-1 Pole Position 64 (U) (M3) [h1C]"
+	description "F-1 Pole Position 64 (U) (M3) [h1C]"
+	rom ( name "F-1 Pole Position 64 (U) (M3) [h1C].z64" crc 50B4BC6C )
+)
+
+game (
+	name "Human Grand Prix - New Generation (J) [!]"
+	description "Human Grand Prix - New Generation (J) [!]"
+	rom ( name "Human Grand Prix - New Generation (J) [!].z64" crc 31E102E3 )
+)
+
+game (
+	name "Human Grand Prix - New Generation (J) [b1]"
+	description "Human Grand Prix - New Generation (J) [b1]"
+	rom ( name "Human Grand Prix - New Generation (J) [b1].z64" crc ECB4CCCD )
+)
+
+game (
+	name "Human Grand Prix - New Generation (J) [o1]"
+	description "Human Grand Prix - New Generation (J) [o1]"
+	rom ( name "Human Grand Prix - New Generation (J) [o1].z64" crc 23E323FC )
+)
+
+game (
+	name "F-1 World Grand Prix (E) [!]"
+	description "F-1 World Grand Prix (E) [!]"
+	rom ( name "F-1 World Grand Prix (E) [!].z64" crc BEBBC6C8 )
+)
+
+game (
+	name "F-1 World Grand Prix (E) [h1C]"
+	description "F-1 World Grand Prix (E) [h1C]"
+	rom ( name "F-1 World Grand Prix (E) [h1C].z64" crc 9D2B0E08 )
+)
+
+game (
+	name "F-1 World Grand Prix (F) [!]"
+	description "F-1 World Grand Prix (F) [!]"
+	rom ( name "F-1 World Grand Prix (F) [!].z64" crc 57CD299D )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [!]"
+	description "F-1 World Grand Prix (G) [!]"
+	rom ( name "F-1 World Grand Prix (G) [!].z64" crc 0F1984DC )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [b1]"
+	description "F-1 World Grand Prix (G) [b1]"
+	rom ( name "F-1 World Grand Prix (G) [b1].z64" crc 973F566E )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [b1][o1]"
+	description "F-1 World Grand Prix (G) [b1][o1]"
+	rom ( name "F-1 World Grand Prix (G) [b1][o1].z64" crc F2A26788 )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [h1C]"
+	description "F-1 World Grand Prix (G) [h1C]"
+	rom ( name "F-1 World Grand Prix (G) [h1C].z64" crc 2C894C1C )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [o1]"
+	description "F-1 World Grand Prix (G) [o1]"
+	rom ( name "F-1 World Grand Prix (G) [o1].z64" crc 7E49CFA2 )
+)
+
+game (
+	name "F-1 World Grand Prix (G) [o1][h1C]"
+	description "F-1 World Grand Prix (G) [o1][h1C]"
+	rom ( name "F-1 World Grand Prix (G) [o1][h1C].z64" crc 1D800E13 )
+)
+
+game (
+	name "F-1 World Grand Prix (J) [!]"
+	description "F-1 World Grand Prix (J) [!]"
+	rom ( name "F-1 World Grand Prix (J) [!].z64" crc F7BACBC3 )
+)
+
+game (
+	name "F-1 World Grand Prix (J) [h1C]"
+	description "F-1 World Grand Prix (J) [h1C]"
+	rom ( name "F-1 World Grand Prix (J) [h1C].z64" crc D42A0303 )
+)
+
+game (
+	name "F-1 World Grand Prix (U) [!]"
+	description "F-1 World Grand Prix (U) [!]"
+	rom ( name "F-1 World Grand Prix (U) [!].z64" crc 7DC9EF2C )
+)
+
+game (
+	name "F-1 World Grand Prix (U) [h1C]"
+	description "F-1 World Grand Prix (U) [h1C]"
+	rom ( name "F-1 World Grand Prix (U) [h1C].z64" crc C3477307 )
+)
+
+game (
+	name "F-1 World Grand Prix (U) [h2C]"
+	description "F-1 World Grand Prix (U) [h2C]"
+	rom ( name "F-1 World Grand Prix (U) [h2C].z64" crc 5E5927EC )
+)
+
+game (
+	name "F-1 World Grand Prix II (E) (M4) [!]"
+	description "F-1 World Grand Prix II (E) (M4) [!]"
+	rom ( name "F-1 World Grand Prix II (E) (M4) [!].z64" crc 803D33DF )
+)
+
+game (
+	name "F-1 World Grand Prix II (E) (M4) [f1] (NTSC)"
+	description "F-1 World Grand Prix II (E) (M4) [f1] (NTSC)"
+	rom ( name "F-1 World Grand Prix II (E) (M4) [f1] (NTSC).z64" crc BE78C19A )
+)
+
+game (
+	name "F-1 World Grand Prix II (E) (M4) [h1C]"
+	description "F-1 World Grand Prix II (E) (M4) [h1C]"
+	rom ( name "F-1 World Grand Prix II (E) (M4) [h1C].z64" crc A3ADFB1F )
+)
+
+game (
+	name "F-ZERO Expansion Kit (N64DD)"
+	description "F-ZERO Expansion Kit (N64DD)"
+	rom ( name "F-ZERO Expansion Kit (N64DD).ndd" crc A4A24AB0 )
+)
+
+game (
+	name "F-ZERO X (E) [!]"
+	description "F-ZERO X (E) [!]"
+	rom ( name "F-ZERO X (E) [!].z64" crc 2D6F7E8B )
+)
+
+game (
+	name "F-ZERO X (E) [b1]"
+	description "F-ZERO X (E) [b1]"
+	rom ( name "F-ZERO X (E) [b1].z64" crc AEF90BC1 )
+)
+
+game (
+	name "F-ZERO X (E) [b2]"
+	description "F-ZERO X (E) [b2]"
+	rom ( name "F-ZERO X (E) [b2].z64" crc 3203F697 )
+)
+
+game (
+	name "F-ZERO X (E) [b3]"
+	description "F-ZERO X (E) [b3]"
+	rom ( name "F-ZERO X (E) [b3].z64" crc 8C0E80E2 )
+)
+
+game (
+	name "F-ZERO X (E) [b4]"
+	description "F-ZERO X (E) [b4]"
+	rom ( name "F-ZERO X (E) [b4].z64" crc C0EBC4D9 )
+)
+
+game (
+	name "F-ZERO X (E) [f1]"
+	description "F-ZERO X (E) [f1]"
+	rom ( name "F-ZERO X (E) [f1].z64" crc D925EAC7 )
+)
+
+game (
+	name "F-ZERO X (E) [h1C]"
+	description "F-ZERO X (E) [h1C]"
+	rom ( name "F-ZERO X (E) [h1C].z64" crc 7A571A1A )
+)
+
+game (
+	name "F-ZERO X (J) [!]"
+	description "F-ZERO X (J) [!]"
+	rom ( name "F-ZERO X (J) [!].z64" crc 6B1CEF83 )
+)
+
+game (
+	name "F-ZERO X (J) [b1]"
+	description "F-ZERO X (J) [b1]"
+	rom ( name "F-ZERO X (J) [b1].z64" crc 190EB759 )
+)
+
+game (
+	name "F-ZERO X (J) [b2]"
+	description "F-ZERO X (J) [b2]"
+	rom ( name "F-ZERO X (J) [b2].z64" crc 8561C494 )
+)
+
+game (
+	name "F-ZERO X (J) [b3]"
+	description "F-ZERO X (J) [b3]"
+	rom ( name "F-ZERO X (J) [b3].z64" crc 032A013A )
+)
+
+game (
+	name "F-ZERO X (J) [t1]"
+	description "F-ZERO X (J) [t1]"
+	rom ( name "F-ZERO X (J) [t1].z64" crc 3F7EEC93 )
+)
+
+game (
+	name "F-ZERO X (U) (DXP Track Pack Hack)"
+	description "F-ZERO X (U) (DXP Track Pack Hack)"
+	rom ( name "F-ZERO X (U) (DXP Track Pack Hack).z64" crc B25212C7 )
+)
+
+game (
+	name "F-ZERO X (U) [!]"
+	description "F-ZERO X (U) [!]"
+	rom ( name "F-ZERO X (U) [!].z64" crc 0B561FBA )
+)
+
+game (
+	name "F-ZERO X (U) [f1] (Sex V1.0 Hack)"
+	description "F-ZERO X (U) [f1] (Sex V1.0 Hack)"
+	rom ( name "F-ZERO X (U) [f1] (Sex V1.0 Hack).z64" crc 570B39F7 )
+)
+
+game (
+	name "F-ZERO X (U) [f1] (Sex V1.1 Hack)"
+	description "F-ZERO X (U) [f1] (Sex V1.1 Hack)"
+	rom ( name "F-ZERO X (U) [f1] (Sex V1.1 Hack).z64" crc 6BA4DF43 )
+)
+
+game (
+	name "F-ZERO X (U) [f1]"
+	description "F-ZERO X (U) [f1]"
+	rom ( name "F-ZERO X (U) [f1].z64" crc CB9CED6C )
+)
+
+game (
+	name "F-ZERO X (U) [f2] (GameShark)"
+	description "F-ZERO X (U) [f2] (GameShark)"
+	rom ( name "F-ZERO X (U) [f2] (GameShark).z64" crc C82964A8 )
+)
+
+game (
+	name "F1 Racing Championship (E) (M5) [!]"
+	description "F1 Racing Championship (E) (M5) [!]"
+	rom ( name "F1 Racing Championship (E) (M5) [!].z64" crc 2DA744F5 )
+)
+
+game (
+	name "F1 Racing Championship (E) (M5) [f1] (NTSC)"
+	description "F1 Racing Championship (E) (M5) [f1] (NTSC)"
+	rom ( name "F1 Racing Championship (E) (M5) [f1] (NTSC).z64" crc 9DF5D7A1 )
+)
+
+game (
+	name "Famista 64 (J) [!]"
+	description "Famista 64 (J) [!]"
+	rom ( name "Famista 64 (J) [!].z64" crc 9FB0E6C9 )
+)
+
+game (
+	name "Famista 64 (J) [b1]"
+	description "Famista 64 (J) [b1]"
+	rom ( name "Famista 64 (J) [b1].z64" crc 1B41CE74 )
+)
+
+game (
+	name "Famista 64 (J) [b2]"
+	description "Famista 64 (J) [b2]"
+	rom ( name "Famista 64 (J) [b2].z64" crc 3D41E4A3 )
+)
+
+game (
+	name "Famista 64 (J) [b3]"
+	description "Famista 64 (J) [b3]"
+	rom ( name "Famista 64 (J) [b3].z64" crc BB94897B )
+)
+
+game (
+	name "Famista 64 (J) [b4]"
+	description "Famista 64 (J) [b4]"
+	rom ( name "Famista 64 (J) [b4].z64" crc 22341B95 )
+)
+
+game (
+	name "Famista 64 (J) [b5]"
+	description "Famista 64 (J) [b5]"
+	rom ( name "Famista 64 (J) [b5].z64" crc AD201004 )
+)
+
+game (
+	name "Famista 64 (J) [b6]"
+	description "Famista 64 (J) [b6]"
+	rom ( name "Famista 64 (J) [b6].z64" crc 6F2515AF )
+)
+
+game (
+	name "Famista 64 (J) [b7]"
+	description "Famista 64 (J) [b7]"
+	rom ( name "Famista 64 (J) [b7].z64" crc FE593E79 )
+)
+
+game (
+	name "Famista 64 (J) [o1]"
+	description "Famista 64 (J) [o1]"
+	rom ( name "Famista 64 (J) [o1].z64" crc B05B9D06 )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (E) (M7) [!]"
+	description "FIFA - Road to World Cup 98 (E) (M7) [!]"
+	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [!].z64" crc 137CB3CC )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (E) (M7) [o1]"
+	description "FIFA - Road to World Cup 98 (E) (M7) [o1]"
+	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [o1].z64" crc C61307D6 )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [!]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [!]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [!].z64" crc 28B1221C )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [b1]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [b1]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b1].z64" crc 01D31B3C )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [b2]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [b2]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b2].z64" crc E3E2A97E )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [b3]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [b3]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b3].z64" crc 2B1F7E3F )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [b4]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [b4]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b4].z64" crc 4620B4BB )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 (U) (M7) [o1]"
+	description "FIFA - Road to World Cup 98 (U) (M7) [o1]"
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [o1].z64" crc 24B60D8F )
+)
+
+game (
+	name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!]"
+	description "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!]"
+	rom ( name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!].z64" crc AE346DF6 )
+)
+
+game (
+	name "FIFA 99 (E) (M8) [!]"
+	description "FIFA 99 (E) (M8) [!]"
+	rom ( name "FIFA 99 (E) (M8) [!].z64" crc 6EAE1E6E )
+)
+
+game (
+	name "FIFA 99 (E) (M8) [hI]"
+	description "FIFA 99 (E) (M8) [hI]"
+	rom ( name "FIFA 99 (E) (M8) [hI].z64" crc 7155E600 )
+)
+
+game (
+	name "FIFA 99 (U) [!]"
+	description "FIFA 99 (U) [!]"
+	rom ( name "FIFA 99 (U) [!].z64" crc 6B2473A9 )
+)
+
+game (
+	name "FIFA 99 (U) [b1]"
+	description "FIFA 99 (U) [b1]"
+	rom ( name "FIFA 99 (U) [b1].z64" crc FFE33A71 )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [!]"
+	description "FIFA Soccer 64 (E) (M3) [!]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [!].z64" crc AE2583FB )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [b1]"
+	description "FIFA Soccer 64 (E) (M3) [b1]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [b1].z64" crc 6A991D12 )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [o1]"
+	description "FIFA Soccer 64 (E) (M3) [o1]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [o1].z64" crc 5079FDC3 )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [o2]"
+	description "FIFA Soccer 64 (E) (M3) [o2]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [o2].z64" crc E97B5D6B )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [o3]"
+	description "FIFA Soccer 64 (E) (M3) [o3]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [o3].z64" crc 86FE6E3B )
+)
+
+game (
+	name "FIFA Soccer 64 (E) (M3) [o4]"
+	description "FIFA Soccer 64 (E) (M3) [o4]"
+	rom ( name "FIFA Soccer 64 (E) (M3) [o4].z64" crc 042E31B2 )
+)
+
+game (
+	name "FIFA Soccer 64 (U) (M3) [!]"
+	description "FIFA Soccer 64 (U) (M3) [!]"
+	rom ( name "FIFA Soccer 64 (U) (M3) [!].z64" crc 57DE7CAB )
+)
+
+game (
+	name "FIFA Soccer 64 (U) (M3) [b1]"
+	description "FIFA Soccer 64 (U) (M3) [b1]"
+	rom ( name "FIFA Soccer 64 (U) (M3) [b1].z64" crc 27ABEC34 )
+)
+
+game (
+	name "FIFA Soccer 64 (U) (M3) [o1]"
+	description "FIFA Soccer 64 (U) (M3) [o1]"
+	rom ( name "FIFA Soccer 64 (U) (M3) [o1].z64" crc 95EC83D3 )
+)
+
+game (
+	name "Fighter Destiny 2 (U) [!]"
+	description "Fighter Destiny 2 (U) [!]"
+	rom ( name "Fighter Destiny 2 (U) [!].z64" crc BB2563C6 )
+)
+
+game (
+	name "Fighter Destiny 2 (U) [f1] (PAL-NTSC)"
+	description "Fighter Destiny 2 (U) [f1] (PAL-NTSC)"
+	rom ( name "Fighter Destiny 2 (U) [f1] (PAL-NTSC).z64" crc AD232E1B )
+)
+
+game (
+	name "Kakutou Denshou - F-Cup Maniax (J) [!]"
+	description "Kakutou Denshou - F-Cup Maniax (J) [!]"
+	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [!].z64" crc DB40A155 )
+)
+
+game (
+	name "Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL)"
+	description "Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL)"
+	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL).z64" crc F88089F1 )
+)
+
+game (
+	name "Fighter's Destiny (E) [!]"
+	description "Fighter's Destiny (E) [!]"
+	rom ( name "Fighter's Destiny (E) [!].z64" crc C9225511 )
+)
+
+game (
+	name "Fighter's Destiny (F) [!]"
+	description "Fighter's Destiny (F) [!]"
+	rom ( name "Fighter's Destiny (F) [!].z64" crc 0CC22034 )
+)
+
+game (
+	name "Fighter's Destiny (G) [!]"
+	description "Fighter's Destiny (G) [!]"
+	rom ( name "Fighter's Destiny (G) [!].z64" crc 5052168C )
+)
+
+game (
+	name "Fighter's Destiny (U) [!]"
+	description "Fighter's Destiny (U) [!]"
+	rom ( name "Fighter's Destiny (U) [!].z64" crc F45EA789 )
+)
+
+game (
+	name "Fighter's Destiny (U) [b1]"
+	description "Fighter's Destiny (U) [b1]"
+	rom ( name "Fighter's Destiny (U) [b1].z64" crc B60BD3AF )
+)
+
+game (
+	name "Fighter's Destiny (U) [o1]"
+	description "Fighter's Destiny (U) [o1]"
+	rom ( name "Fighter's Destiny (U) [o1].z64" crc 845E5A29 )
+)
+
+game (
+	name "Fighting Cup (J) [!]"
+	description "Fighting Cup (J) [!]"
+	rom ( name "Fighting Cup (J) [!].z64" crc 8A1C261E )
+)
+
+game (
+	name "Fighting Force 64 (E) [!]"
+	description "Fighting Force 64 (E) [!]"
+	rom ( name "Fighting Force 64 (E) [!].z64" crc 4052C176 )
+)
+
+game (
+	name "Fighting Force 64 (U) [!]"
+	description "Fighting Force 64 (U) [!]"
+	rom ( name "Fighting Force 64 (U) [!].z64" crc 8456841E )
+)
+
+game (
+	name "Fighting Force 64 (U) [T+Ita_Cattivik66]"
+	description "Fighting Force 64 (U) [T+Ita_Cattivik66]"
+	rom ( name "Fighting Force 64 (U) [T+Ita_Cattivik66].z64" crc 83B13EE4 )
+)
+
+game (
+	name "Fighting Force 64 (U) [t1]"
+	description "Fighting Force 64 (U) [t1]"
+	rom ( name "Fighting Force 64 (U) [t1].z64" crc BD748727 )
+)
+
+game (
+	name "Fighting Force 64 (U) [t1][f1] (PAL)"
+	description "Fighting Force 64 (U) [t1][f1] (PAL)"
+	rom ( name "Fighting Force 64 (U) [t1][f1] (PAL).z64" crc B91DE407 )
+)
+
+game (
+	name "Flying Dragon (E) [!]"
+	description "Flying Dragon (E) [!]"
+	rom ( name "Flying Dragon (E) [!].z64" crc C3066E59 )
+)
+
+game (
+	name "Flying Dragon (U) [!]"
+	description "Flying Dragon (U) [!]"
+	rom ( name "Flying Dragon (U) [!].z64" crc 91BC9AEB )
+)
+
+game (
+	name "Flying Dragon (U) [b1]"
+	description "Flying Dragon (U) [b1]"
+	rom ( name "Flying Dragon (U) [b1].z64" crc 28ADBEF4 )
+)
+
+game (
+	name "Flying Dragon (U) [b2]"
+	description "Flying Dragon (U) [b2]"
+	rom ( name "Flying Dragon (U) [b2].z64" crc A52E28E6 )
+)
+
+game (
+	name "Hiryuu no Ken Twin (J) [!]"
+	description "Hiryuu no Ken Twin (J) [!]"
+	rom ( name "Hiryuu no Ken Twin (J) [!].z64" crc BA6A687E )
+)
+
+game (
+	name "Hiryuu no Ken Twin (J) [h1C]"
+	description "Hiryuu no Ken Twin (J) [h1C]"
+	rom ( name "Hiryuu no Ken Twin (J) [h1C].z64" crc BA40793D )
+)
+
+game (
+	name "Hiryuu no Ken Twin (J) [h2C]"
+	description "Hiryuu no Ken Twin (J) [h2C]"
+	rom ( name "Hiryuu no Ken Twin (J) [h2C].z64" crc 09F183C5 )
+)
+
+game (
+	name "Hiryuu no Ken Twin (J) [h3C]"
+	description "Hiryuu no Ken Twin (J) [h3C]"
+	rom ( name "Hiryuu no Ken Twin (J) [h3C].z64" crc FAA2D612 )
+)
+
+game (
+	name "Forsaken 64 (E) (M4) [!]"
+	description "Forsaken 64 (E) (M4) [!]"
+	rom ( name "Forsaken 64 (E) (M4) [!].z64" crc 5ED736D9 )
+)
+
+game (
+	name "Forsaken 64 (G) [!]"
+	description "Forsaken 64 (G) [!]"
+	rom ( name "Forsaken 64 (G) [!].z64" crc 9793ABC2 )
+)
+
+game (
+	name "Forsaken 64 (G) [h1C]"
+	description "Forsaken 64 (G) [h1C]"
+	rom ( name "Forsaken 64 (G) [h1C].z64" crc 7C27CB56 )
+)
+
+game (
+	name "Forsaken 64 (G) [o1]"
+	description "Forsaken 64 (G) [o1]"
+	rom ( name "Forsaken 64 (G) [o1].z64" crc FEC081C8 )
+)
+
+game (
+	name "Forsaken 64 (U) [!]"
+	description "Forsaken 64 (U) [!]"
+	rom ( name "Forsaken 64 (U) [!].z64" crc 76C4333D )
+)
+
+game (
+	name "Forsaken 64 (U) [b1]"
+	description "Forsaken 64 (U) [b1]"
+	rom ( name "Forsaken 64 (U) [b1].z64" crc CD83B6D6 )
+)
+
+game (
+	name "Forsaken 64 (U) [t1]"
+	description "Forsaken 64 (U) [t1]"
+	rom ( name "Forsaken 64 (U) [t1].z64" crc A7A563D8 )
+)
+
+game (
+	name "Forsaken 64 (U) [t2]"
+	description "Forsaken 64 (U) [t2]"
+	rom ( name "Forsaken 64 (U) [t2].z64" crc F26D2D5D )
+)
+
+game (
+	name "Forsaken 64 (U) [t3]"
+	description "Forsaken 64 (U) [t3]"
+	rom ( name "Forsaken 64 (U) [t3].z64" crc 4DC1CBE3 )
+)
+
+game (
+	name "Fox Sports College Hoops '99 (U) [!]"
+	description "Fox Sports College Hoops '99 (U) [!]"
+	rom ( name "Fox Sports College Hoops '99 (U) [!].z64" crc 67EAF0F3 )
+)
+
+game (
+	name "Fox Sports College Hoops '99 (U) [f1] (PAL)"
+	description "Fox Sports College Hoops '99 (U) [f1] (PAL)"
+	rom ( name "Fox Sports College Hoops '99 (U) [f1] (PAL).z64" crc 43AD9C56 )
+)
+
+game (
+	name "Frogger 2 (U) (Alpha) [!]"
+	description "Frogger 2 (U) (Alpha) [!]"
+	rom ( name "Frogger 2 (U) (Alpha) [!].z64" crc B0C62957 )
+)
+
+game (
+	name "Frogger 2 (U) (Alpha) [o1]"
+	description "Frogger 2 (U) (Alpha) [o1]"
+	rom ( name "Frogger 2 (U) (Alpha) [o1].z64" crc A8F81F39 )
+)
+
+game (
+	name "Frogger 2 (U) (Alpha) [o2]"
+	description "Frogger 2 (U) (Alpha) [o2]"
+	rom ( name "Frogger 2 (U) (Alpha) [o2].z64" crc DED56725 )
+)
+
+game (
+	name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!]"
+	description "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!]"
+	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!].z64" crc 2AA6D2A1 )
+)
+
+game (
+	name "GameBooster 64 V1.1 (NTSC) (Unl) [b1]"
+	description "GameBooster 64 V1.1 (NTSC) (Unl) [b1]"
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [b1].z64" crc EC7CFD07 )
+)
+
+game (
+	name "GameBooster 64 V1.1 (NTSC) (Unl) [f1]"
+	description "GameBooster 64 V1.1 (NTSC) (Unl) [f1]"
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [f1].z64" crc 3543FAE8 )
+)
+
+game (
+	name "GameBooster 64 V1.1 (NTSC) (Unl)"
+	description "GameBooster 64 V1.1 (NTSC) (Unl)"
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl).z64" crc E0B8EDAE )
+)
+
+game (
+	name "GameBooster 64 V1.1 (PAL) (Unl) [b1]"
+	description "GameBooster 64 V1.1 (PAL) (Unl) [b1]"
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [b1].z64" crc 0F7C70D3 )
+)
+
+game (
+	name "GameBooster 64 V1.1 (PAL) (Unl) [f1] (Sound)"
+	description "GameBooster 64 V1.1 (PAL) (Unl) [f1] (Sound)"
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [f1] (Sound).z64" crc 8A4275FF )
+)
+
+game (
+	name "GameBooster 64 V1.1 (PAL) (Unl)"
+	description "GameBooster 64 V1.1 (PAL) (Unl)"
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl).z64" crc 35B99BD9 )
+)
+
+game (
+	name "GameShark Pro V2.0 (Unl)"
+	description "GameShark Pro V2.0 (Unl)"
+	rom ( name "GameShark Pro V2.0 (Unl).z64" crc EF9EDF87 )
+)
+
+game (
+	name "GameShark Pro V3.3 (Apr 2000) (Unl) [!]"
+	description "GameShark Pro V3.3 (Apr 2000) (Unl) [!]"
+	rom ( name "GameShark Pro V3.3 (Apr 2000) (Unl) [!].z64" crc F1851EBD )
+)
+
+game (
+	name "GameShark Pro V3.3 (Mar 2000) (Unl) [!]"
+	description "GameShark Pro V3.3 (Mar 2000) (Unl) [!]"
+	rom ( name "GameShark Pro V3.3 (Mar 2000) (Unl) [!].z64" crc 7CC07BBC )
+)
+
+game (
+	name "Ganbare Goemon - Mononoke Sugoroku (J) [!]"
+	description "Ganbare Goemon - Mononoke Sugoroku (J) [!]"
+	rom ( name "Ganbare Goemon - Mononoke Sugoroku (J) [!].z64" crc 965C4575 )
+)
+
+game (
+	name "Gauntlet Legends (E) [!]"
+	description "Gauntlet Legends (E) [!]"
+	rom ( name "Gauntlet Legends (E) [!].z64" crc B7B3A489 )
+)
+
+game (
+	name "Gauntlet Legends (E) [b1]"
+	description "Gauntlet Legends (E) [b1]"
+	rom ( name "Gauntlet Legends (E) [b1].z64" crc 5AE31C93 )
+)
+
+game (
+	name "Gauntlet Legends (J) [!]"
+	description "Gauntlet Legends (J) [!]"
+	rom ( name "Gauntlet Legends (J) [!].z64" crc 8D133DB0 )
+)
+
+game (
+	name "Gauntlet Legends (U) [!]"
+	description "Gauntlet Legends (U) [!]"
+	rom ( name "Gauntlet Legends (U) [!].z64" crc 64765E82 )
+)
+
+game (
+	name "Gauntlet Legends (U) [f1] (PAL)"
+	description "Gauntlet Legends (U) [f1] (PAL)"
+	rom ( name "Gauntlet Legends (U) [f1] (PAL).z64" crc 510CB972 )
+)
+
+game (
+	name "Getter Love!! (J) [!]"
+	description "Getter Love!! (J) [!]"
+	rom ( name "Getter Love!! (J) [!].z64" crc 724ECAE7 )
+)
+
+game (
+	name "Getter Love!! (J) [b1]"
+	description "Getter Love!! (J) [b1]"
+	rom ( name "Getter Love!! (J) [b1].z64" crc 8BD98062 )
+)
+
+game (
+	name "Getter Love!! (J) [b2]"
+	description "Getter Love!! (J) [b2]"
+	rom ( name "Getter Love!! (J) [b2].z64" crc 88DA17F6 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!]"
+	description "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!]"
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!].z64" crc A43CB8E4 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!]"
+	description "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!]"
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!].z64" crc 6BC4A056 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko (U) [!]"
+	description "Gex 3 - Deep Cover Gecko (U) [!]"
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [!].z64" crc 87A7D099 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko (U) [f1] (PAL)"
+	description "Gex 3 - Deep Cover Gecko (U) [f1] (PAL)"
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [f1] (PAL).z64" crc 26C35612 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko (U) [t1]"
+	description "Gex 3 - Deep Cover Gecko (U) [t1]"
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [t1].z64" crc 3AEE8310 )
+)
+
+game (
+	name "Gex 64 - Enter the Gecko (E) [!]"
+	description "Gex 64 - Enter the Gecko (E) [!]"
+	rom ( name "Gex 64 - Enter the Gecko (E) [!].z64" crc A7C92BEA )
+)
+
+game (
+	name "Gex 64 - Enter the Gecko (U) [!]"
+	description "Gex 64 - Enter the Gecko (U) [!]"
+	rom ( name "Gex 64 - Enter the Gecko (U) [!].z64" crc C545CE80 )
+)
+
+game (
+	name "Gex 64 - Enter the Gecko (U) [f1] (PAL)"
+	description "Gex 64 - Enter the Gecko (U) [f1] (PAL)"
+	rom ( name "Gex 64 - Enter the Gecko (U) [f1] (PAL).z64" crc 5802D207 )
+)
+
+game (
+	name "Gex 64 - Enter the Gecko (U) [t1]"
+	description "Gex 64 - Enter the Gecko (U) [t1]"
+	rom ( name "Gex 64 - Enter the Gecko (U) [t1].z64" crc DD37073A )
+)
+
+game (
+	name "Glover (E) (M3) [!]"
+	description "Glover (E) (M3) [!]"
+	rom ( name "Glover (E) (M3) [!].z64" crc 90ECEB4A )
+)
+
+game (
+	name "Glover (E) (M3) [f1] (NTSC)"
+	description "Glover (E) (M3) [f1] (NTSC)"
+	rom ( name "Glover (E) (M3) [f1] (NTSC).z64" crc 2EC58E29 )
+)
+
+game (
+	name "Glover (U) [!]"
+	description "Glover (U) [!]"
+	rom ( name "Glover (U) [!].z64" crc F874571C )
+)
+
+game (
+	name "Glover (U) [b1]"
+	description "Glover (U) [b1]"
+	rom ( name "Glover (U) [b1].z64" crc 98DB770D )
+)
+
+game (
+	name "Glover (U) [b2]"
+	description "Glover (U) [b2]"
+	rom ( name "Glover (U) [b2].z64" crc 537290A5 )
+)
+
+game (
+	name "Glover (U) [t1]"
+	description "Glover (U) [t1]"
+	rom ( name "Glover (U) [t1].z64" crc 0DFFCF4B )
+)
+
+game (
+	name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!]"
+	description "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!]"
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!].z64" crc 08C41E0E )
+)
+
+game (
+	name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t1]"
+	description "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t1]"
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t1].z64" crc 2FB2D3B1 )
+)
+
+game (
+	name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t2]"
+	description "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t2]"
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t2].z64" crc A5563B90 )
+)
+
+game (
+	name "Goemon's Great Adventure (U) [!]"
+	description "Goemon's Great Adventure (U) [!]"
+	rom ( name "Goemon's Great Adventure (U) [!].z64" crc 52D418E1 )
+)
+
+game (
+	name "Mystical Ninja 2 Starring Goemon (E) (M3) [!]"
+	description "Mystical Ninja 2 Starring Goemon (E) (M3) [!]"
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [!].z64" crc 3502DBBE )
+)
+
+game (
+	name "Mystical Ninja 2 Starring Goemon (E) (M3) [hI]"
+	description "Mystical Ninja 2 Starring Goemon (E) (M3) [hI]"
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [hI].z64" crc B153BA15 )
+)
+
+game (
+	name "Mystical Ninja 2 Starring Goemon (E) (M3) [t1]"
+	description "Mystical Ninja 2 Starring Goemon (E) (M3) [t1]"
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [t1].z64" crc 29965288 )
+)
+
+game (
+	name "Golden Nugget 64 (U) [!]"
+	description "Golden Nugget 64 (U) [!]"
+	rom ( name "Golden Nugget 64 (U) [!].z64" crc 641885DF )
+)
+
+game (
+	name "Golden Nugget 64 (U) [b1]"
+	description "Golden Nugget 64 (U) [b1]"
+	rom ( name "Golden Nugget 64 (U) [b1].z64" crc E0B4C1EE )
+)
+
+game (
+	name "Golden Nugget 64 (U) [b2]"
+	description "Golden Nugget 64 (U) [b2]"
+	rom ( name "Golden Nugget 64 (U) [b2].z64" crc 4B5FD87A )
+)
+
+game (
+	name "Golden Nugget 64 (U) [f1] (PAL)"
+	description "Golden Nugget 64 (U) [f1] (PAL)"
+	rom ( name "Golden Nugget 64 (U) [f1] (PAL).z64" crc B5E49D46 )
+)
+
+game (
+	name "Golden Nugget 64 (U) [h1C]"
+	description "Golden Nugget 64 (U) [h1C]"
+	rom ( name "Golden Nugget 64 (U) [h1C].z64" crc 40E74294 )
+)
+
+game (
+	name "GoldenEye 007 (E) (Citadel Hack)"
+	description "GoldenEye 007 (E) (Citadel Hack)"
+	rom ( name "GoldenEye 007 (E) (Citadel Hack).bin" crc 27DAD263 )
+)
+
+game (
+	name "GoldenEye 007 (E) [!]"
+	description "GoldenEye 007 (E) [!]"
+	rom ( name "GoldenEye 007 (E) [!].z64" crc 9EC14AEB )
+)
+
+game (
+	name "GoldenEye 007 (E) [b1]"
+	description "GoldenEye 007 (E) [b1]"
+	rom ( name "GoldenEye 007 (E) [b1].z64" crc 6833E958 )
+)
+
+game (
+	name "GoldenEye 007 (E) [h1C]"
+	description "GoldenEye 007 (E) [h1C]"
+	rom ( name "GoldenEye 007 (E) [h1C].z64" crc E88D9DA4 )
+)
+
+game (
+	name "GoldenEye 007 (E) [t1] (Rapid Fire)"
+	description "GoldenEye 007 (E) [t1] (Rapid Fire)"
+	rom ( name "GoldenEye 007 (E) [t1] (Rapid Fire).z64" crc E0833DF2 )
+)
+
+game (
+	name "GoldenEye 007 (J) [!]"
+	description "GoldenEye 007 (J) [!]"
+	rom ( name "GoldenEye 007 (J) [!].z64" crc A6BE19DD )
+)
+
+game (
+	name "GoldenEye 007 (J) [t1] (Rapid Fire)"
+	description "GoldenEye 007 (J) [t1] (Rapid Fire)"
+	rom ( name "GoldenEye 007 (J) [t1] (Rapid Fire).z64" crc 7FBCC907 )
+)
+
+game (
+	name "GoldenEye 007 (U) (Citadel Hack)"
+	description "GoldenEye 007 (U) (Citadel Hack)"
+	rom ( name "GoldenEye 007 (U) (Citadel Hack).bin" crc 6374D7CC )
+)
+
+game (
+	name "GoldenEye 007 (U) (Frozen Enemies Hack)"
+	description "GoldenEye 007 (U) (Frozen Enemies Hack)"
+	rom ( name "GoldenEye 007 (U) (Frozen Enemies Hack).z64" crc 1EB6869D )
+)
+
+game (
+	name "GoldenEye 007 (U) (G5 Multi (for backups) Hack)"
+	description "GoldenEye 007 (U) (G5 Multi (for backups) Hack)"
+	rom ( name "GoldenEye 007 (U) (G5 Multi (for backups) Hack).bin" crc 285E8D41 )
+)
+
+game (
+	name "GoldenEye 007 (U) (G5 Multi Hack)"
+	description "GoldenEye 007 (U) (G5 Multi Hack)"
+	rom ( name "GoldenEye 007 (U) (G5 Multi Hack).bin" crc 724ECD4B )
+)
+
+game (
+	name "GoldenEye 007 (U) (God Mode Hack)"
+	description "GoldenEye 007 (U) (God Mode Hack)"
+	rom ( name "GoldenEye 007 (U) (God Mode Hack).z64" crc F177AA35 )
+)
+
+game (
+	name "GoldenEye 007 (U) (No Music Hack)"
+	description "GoldenEye 007 (U) (No Music Hack)"
+	rom ( name "GoldenEye 007 (U) (No Music Hack).z64" crc A42184FA )
+)
+
+game (
+	name "GoldenEye 007 (U) (No Power Bar Hack)"
+	description "GoldenEye 007 (U) (No Power Bar Hack)"
+	rom ( name "GoldenEye 007 (U) (No Power Bar Hack).z64" crc 59B84D17 )
+)
+
+game (
+	name "GoldenEye 007 (U) (Tetris Hack)"
+	description "GoldenEye 007 (U) (Tetris Hack)"
+	rom ( name "GoldenEye 007 (U) (Tetris Hack).bin" crc 89B3EB2B )
+)
+
+game (
+	name "GoldenEye 007 (U) [!]"
+	description "GoldenEye 007 (U) [!]"
+	rom ( name "GoldenEye 007 (U) [!].z64" crc B6330846 )
+)
+
+game (
+	name "GoldenEye 007 (U) [b1]"
+	description "GoldenEye 007 (U) [b1]"
+	rom ( name "GoldenEye 007 (U) [b1].z64" crc EA2B1826 )
+)
+
+game (
+	name "GoldenEye 007 (U) [h1C]"
+	description "GoldenEye 007 (U) [h1C]"
+	rom ( name "GoldenEye 007 (U) [h1C].z64" crc 54858FEE )
+)
+
+game (
+	name "GoldenEye 007 (U) [o1]"
+	description "GoldenEye 007 (U) [o1]"
+	rom ( name "GoldenEye 007 (U) [o1].z64" crc EE36B9BA )
+)
+
+game (
+	name "GoldenEye 007 (U) [o2]"
+	description "GoldenEye 007 (U) [o2]"
+	rom ( name "GoldenEye 007 (U) [o2].z64" crc D32C4CB3 )
+)
+
+game (
+	name "GoldenEye 007 (U) [t1] (Rapid Fire)"
+	description "GoldenEye 007 (U) [t1] (Rapid Fire)"
+	rom ( name "GoldenEye 007 (U) [t1] (Rapid Fire).z64" crc FEF59913 )
+)
+
+game (
+	name "GoldenEye 007 (U) [t2]"
+	description "GoldenEye 007 (U) [t2]"
+	rom ( name "GoldenEye 007 (U) [t2].z64" crc 1D5409D0 )
+)
+
+game (
+	name "GoldenEye 007 (U) [t3] (All Guns Zoom Mode)"
+	description "GoldenEye 007 (U) [t3] (All Guns Zoom Mode)"
+	rom ( name "GoldenEye 007 (U) [t3] (All Guns Zoom Mode).z64" crc 490F003C )
+)
+
+game (
+	name "City-Tour GP - Zennihon GT Senshuken (J) [!]"
+	description "City-Tour GP - Zennihon GT Senshuken (J) [!]"
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [!].z64" crc E272BDF6 )
+)
+
+game (
+	name "City-Tour GP - Zennihon GT Senshuken (J) [b1]"
+	description "City-Tour GP - Zennihon GT Senshuken (J) [b1]"
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b1].z64" crc DB1991CD )
+)
+
+game (
+	name "City-Tour GP - Zennihon GT Senshuken (J) [b2]"
+	description "City-Tour GP - Zennihon GT Senshuken (J) [b2]"
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b2].z64" crc 8AD78B91 )
+)
+
+game (
+	name "City-Tour GP - Zennihon GT Senshuken (J) [b3]"
+	description "City-Tour GP - Zennihon GT Senshuken (J) [b3]"
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b3].z64" crc 946C079D )
+)
+
+game (
+	name "GT 64 - Championship Edition (E) (M3) [!]"
+	description "GT 64 - Championship Edition (E) (M3) [!]"
+	rom ( name "GT 64 - Championship Edition (E) (M3) [!].z64" crc 6DFB4747 )
+)
+
+game (
+	name "GT 64 - Championship Edition (E) (M3) [b1]"
+	description "GT 64 - Championship Edition (E) (M3) [b1]"
+	rom ( name "GT 64 - Championship Edition (E) (M3) [b1].z64" crc B1E2C1D2 )
+)
+
+game (
+	name "GT 64 - Championship Edition (E) (M3) [f1] (NTSC)"
+	description "GT 64 - Championship Edition (E) (M3) [f1] (NTSC)"
+	rom ( name "GT 64 - Championship Edition (E) (M3) [f1] (NTSC).z64" crc DC890E2E )
+)
+
+game (
+	name "GT 64 - Championship Edition (E) (M3) [f2] (NTSC)"
+	description "GT 64 - Championship Edition (E) (M3) [f2] (NTSC)"
+	rom ( name "GT 64 - Championship Edition (E) (M3) [f2] (NTSC).z64" crc D507B9AB )
+)
+
+game (
+	name "GT 64 - Championship Edition (U) [!]"
+	description "GT 64 - Championship Edition (U) [!]"
+	rom ( name "GT 64 - Championship Edition (U) [!].z64" crc BC627DA7 )
+)
+
+game (
+	name "GT 64 - Championship Edition (U) [b1]"
+	description "GT 64 - Championship Edition (U) [b1]"
+	rom ( name "GT 64 - Championship Edition (U) [b1].z64" crc 1BD55EFF )
+)
+
+game (
+	name "Hamster Monogatari 64 (J) [!]"
+	description "Hamster Monogatari 64 (J) [!]"
+	rom ( name "Hamster Monogatari 64 (J) [!].z64" crc C1D98B78 )
+)
+
+game (
+	name "Bokujou Monogatari 2 (J) [!]"
+	description "Bokujou Monogatari 2 (J) [!]"
+	rom ( name "Bokujou Monogatari 2 (J) [!].z64" crc F97237C7 )
+)
+
+game (
+	name "Bokujou Monogatari 2 (J) [b1]"
+	description "Bokujou Monogatari 2 (J) [b1]"
+	rom ( name "Bokujou Monogatari 2 (J) [b1].z64" crc E9E0C465 )
+)
+
+game (
+	name "Harvest Moon 64 (U) [!]"
+	description "Harvest Moon 64 (U) [!]"
+	rom ( name "Harvest Moon 64 (U) [!].z64" crc DECDC0AD )
+)
+
+game (
+	name "Harvest Moon 64 (U) [b1]"
+	description "Harvest Moon 64 (U) [b1]"
+	rom ( name "Harvest Moon 64 (U) [b1].z64" crc A4026E3F )
+)
+
+game (
+	name "Harvest Moon 64 (U) [f1] (PAL)"
+	description "Harvest Moon 64 (U) [f1] (PAL)"
+	rom ( name "Harvest Moon 64 (U) [f1] (PAL).z64" crc 769E12A2 )
+)
+
+game (
+	name "Harvest Moon 64 (U) [T+Pol001]"
+	description "Harvest Moon 64 (U) [T+Pol001]"
+	rom ( name "Harvest Moon 64 (U) [T+Pol001].z64" crc 06252291 )
+)
+
+game (
+	name "Harvest Moon 64 (U) [t1]"
+	description "Harvest Moon 64 (U) [t1]"
+	rom ( name "Harvest Moon 64 (U) [t1].z64" crc E391F319 )
+)
+
+game (
+	name "Harvest Moon 64 (U) [t1][f1] (PAL-NTSC)"
+	description "Harvest Moon 64 (U) [t1][f1] (PAL-NTSC)"
+	rom ( name "Harvest Moon 64 (U) [t1][f1] (PAL-NTSC).z64" crc C2648DF7 )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [!]"
+	description "Heiwa Pachinko World 64 (J) [!]"
+	rom ( name "Heiwa Pachinko World 64 (J) [!].z64" crc 99A427FA )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [b1]"
+	description "Heiwa Pachinko World 64 (J) [b1]"
+	rom ( name "Heiwa Pachinko World 64 (J) [b1].z64" crc C9474ABF )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [b2]"
+	description "Heiwa Pachinko World 64 (J) [b2]"
+	rom ( name "Heiwa Pachinko World 64 (J) [b2].z64" crc 90CF7169 )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [b3]"
+	description "Heiwa Pachinko World 64 (J) [b3]"
+	rom ( name "Heiwa Pachinko World 64 (J) [b3].z64" crc 5D34235A )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [h1C]"
+	description "Heiwa Pachinko World 64 (J) [h1C]"
+	rom ( name "Heiwa Pachinko World 64 (J) [h1C].z64" crc DEA145AE )
+)
+
+game (
+	name "Heiwa Pachinko World 64 (J) [o1]"
+	description "Heiwa Pachinko World 64 (J) [o1]"
+	rom ( name "Heiwa Pachinko World 64 (J) [o1].z64" crc ED3B55D8 )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (E) (M6) [!]"
+	description "Hercules - The Legendary Journeys (E) (M6) [!]"
+	rom ( name "Hercules - The Legendary Journeys (E) (M6) [!].z64" crc B1954B08 )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (U) [!]"
+	description "Hercules - The Legendary Journeys (U) [!]"
+	rom ( name "Hercules - The Legendary Journeys (U) [!].z64" crc 4948892B )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (U) [o1]"
+	description "Hercules - The Legendary Journeys (U) [o1]"
+	rom ( name "Hercules - The Legendary Journeys (U) [o1].z64" crc 1C0C079F )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (U) [t1][f1] (PAL-NTSC)"
+	description "Hercules - The Legendary Journeys (U) [t1][f1] (PAL-NTSC)"
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1] (PAL-NTSC).z64" crc 4A8C19B2 )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (U) [t1][f1][b1]"
+	description "Hercules - The Legendary Journeys (U) [t1][f1][b1]"
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1][b1].z64" crc 5DAB18EC )
+)
+
+game (
+	name "Hercules - The Legendary Journeys (U) [t1][f2] (PAL-NTSC)"
+	description "Hercules - The Legendary Journeys (U) [t1][f2] (PAL-NTSC)"
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f2] (PAL-NTSC).z64" crc 6D30E1D2 )
+)
+
+game (
+	name "Hexen (E) [!]"
+	description "Hexen (E) [!]"
+	rom ( name "Hexen (E) [!].z64" crc 5369EFB4 )
+)
+
+game (
+	name "Hexen (E) [h1C]"
+	description "Hexen (E) [h1C]"
+	rom ( name "Hexen (E) [h1C].z64" crc F0899C71 )
+)
+
+game (
+	name "Hexen (F) [!]"
+	description "Hexen (F) [!]"
+	rom ( name "Hexen (F) [!].z64" crc E373FA31 )
+)
+
+game (
+	name "Hexen (G) [!]"
+	description "Hexen (G) [!]"
+	rom ( name "Hexen (G) [!].z64" crc E4821C4B )
+)
+
+game (
+	name "Hexen (G) [h1C]"
+	description "Hexen (G) [h1C]"
+	rom ( name "Hexen (G) [h1C].z64" crc B1A8C486 )
+)
+
+game (
+	name "Hexen (J) [!]"
+	description "Hexen (J) [!]"
+	rom ( name "Hexen (J) [!].z64" crc 571DA09A )
+)
+
+game (
+	name "Hexen (U) [!]"
+	description "Hexen (U) [!]"
+	rom ( name "Hexen (U) [!].z64" crc 1D35E110 )
+)
+
+game (
+	name "Hexen (U) [b1]"
+	description "Hexen (U) [b1]"
+	rom ( name "Hexen (U) [b1].z64" crc 1C66BDFE )
+)
+
+game (
+	name "Hexen (U) [h1C]"
+	description "Hexen (U) [h1C]"
+	rom ( name "Hexen (U) [h1C].z64" crc FF80D2FB )
+)
+
+game (
+	name "Hexen (U) [t1]"
+	description "Hexen (U) [t1]"
+	rom ( name "Hexen (U) [t1].z64" crc EB25FD56 )
+)
+
+game (
+	name "Hexen (U) [t2]"
+	description "Hexen (U) [t2]"
+	rom ( name "Hexen (U) [t2].z64" crc BBE1C15E )
+)
+
+game (
+	name "Hey You, Pikachu! (U) [!]"
+	description "Hey You, Pikachu! (U) [!]"
+	rom ( name "Hey You, Pikachu! (U) [!].z64" crc B18B2734 )
+)
+
+game (
+	name "Pikachu Genki Dechu (J) [!]"
+	description "Pikachu Genki Dechu (J) [!]"
+	rom ( name "Pikachu Genki Dechu (J) [!].z64" crc 3F6245AE )
+)
+
+game (
+	name "Pikachu Genki Dechu (J) [b1]"
+	description "Pikachu Genki Dechu (J) [b1]"
+	rom ( name "Pikachu Genki Dechu (J) [b1].z64" crc EE4886FA )
+)
+
+game (
+	name "Hot Wheels Turbo Racing (E) (M3) [!]"
+	description "Hot Wheels Turbo Racing (E) (M3) [!]"
+	rom ( name "Hot Wheels Turbo Racing (E) (M3) [!].z64" crc 850633A7 )
+)
+
+game (
+	name "Hot Wheels Turbo Racing (E) (M3) [b1]"
+	description "Hot Wheels Turbo Racing (E) (M3) [b1]"
+	rom ( name "Hot Wheels Turbo Racing (E) (M3) [b1].z64" crc E2EB5D7A )
+)
+
+game (
+	name "Hot Wheels Turbo Racing (U) [!]"
+	description "Hot Wheels Turbo Racing (U) [!]"
+	rom ( name "Hot Wheels Turbo Racing (U) [!].z64" crc A5C92148 )
+)
+
+game (
+	name "Hot Wheels Turbo Racing (U) [f1] (PAL)"
+	description "Hot Wheels Turbo Racing (U) [f1] (PAL)"
+	rom ( name "Hot Wheels Turbo Racing (U) [f1] (PAL).z64" crc E0FD8F22 )
+)
+
+game (
+	name "Hot Wheels Turbo Racing (U) [t1]"
+	description "Hot Wheels Turbo Racing (U) [t1]"
+	rom ( name "Hot Wheels Turbo Racing (U) [t1].z64" crc FFF6A4BA )
+)
+
+game (
+	name "Hybrid Heaven (E) (M3) [!]"
+	description "Hybrid Heaven (E) (M3) [!]"
+	rom ( name "Hybrid Heaven (E) (M3) [!].z64" crc E76627FF )
+)
+
+game (
+	name "Hybrid Heaven (E) (M3) [b1]"
+	description "Hybrid Heaven (E) (M3) [b1]"
+	rom ( name "Hybrid Heaven (E) (M3) [b1].z64" crc F5FA7401 )
+)
+
+game (
+	name "Hybrid Heaven (E) (M3) [f1] (NTSC)"
+	description "Hybrid Heaven (E) (M3) [f1] (NTSC)"
+	rom ( name "Hybrid Heaven (E) (M3) [f1] (NTSC).z64" crc E8322D68 )
+)
+
+game (
+	name "Hybrid Heaven (J) [!]"
+	description "Hybrid Heaven (J) [!]"
+	rom ( name "Hybrid Heaven (J) [!].z64" crc E769DE96 )
+)
+
+game (
+	name "Hybrid Heaven (J) [b1]"
+	description "Hybrid Heaven (J) [b1]"
+	rom ( name "Hybrid Heaven (J) [b1].z64" crc 47F2DD70 )
+)
+
+game (
+	name "Hybrid Heaven (J) [f1] (PAL)"
+	description "Hybrid Heaven (J) [f1] (PAL)"
+	rom ( name "Hybrid Heaven (J) [f1] (PAL).z64" crc 1D8781DC )
+)
+
+game (
+	name "Hybrid Heaven (U) [!]"
+	description "Hybrid Heaven (U) [!]"
+	rom ( name "Hybrid Heaven (U) [!].z64" crc 15B57EF8 )
+)
+
+game (
+	name "Hybrid Heaven (U) [f1] (PAL)"
+	description "Hybrid Heaven (U) [f1] (PAL)"
+	rom ( name "Hybrid Heaven (U) [f1] (PAL).z64" crc 0D4CBD39 )
+)
+
+game (
+	name "Hybrid Heaven (U) [t1]"
+	description "Hybrid Heaven (U) [t1]"
+	rom ( name "Hybrid Heaven (U) [t1].z64" crc 478C2604 )
+)
+
+game (
+	name "Hydro Thunder (E) [!]"
+	description "Hydro Thunder (E) [!]"
+	rom ( name "Hydro Thunder (E) [!].z64" crc 863AB8F3 )
+)
+
+game (
+	name "Hydro Thunder (E) [f1] (NTSC)"
+	description "Hydro Thunder (E) [f1] (NTSC)"
+	rom ( name "Hydro Thunder (E) [f1] (NTSC).z64" crc 4DA8BD88 )
+)
+
+game (
+	name "Hydro Thunder (F) [!]"
+	description "Hydro Thunder (F) [!]"
+	rom ( name "Hydro Thunder (F) [!].z64" crc 010F6242 )
+)
+
+game (
+	name "Hydro Thunder (U) [!]"
+	description "Hydro Thunder (U) [!]"
+	rom ( name "Hydro Thunder (U) [!].z64" crc E744456F )
+)
+
+game (
+	name "Hydro Thunder (U) [b1]"
+	description "Hydro Thunder (U) [b1]"
+	rom ( name "Hydro Thunder (U) [b1].z64" crc DF1693A6 )
+)
+
+game (
+	name "Hydro Thunder (U) [b1][f1] (PAL)"
+	description "Hydro Thunder (U) [b1][f1] (PAL)"
+	rom ( name "Hydro Thunder (U) [b1][f1] (PAL).z64" crc 2856FBFB )
+)
+
+game (
+	name "Hydro Thunder (U) [b1][t1]"
+	description "Hydro Thunder (U) [b1][t1]"
+	rom ( name "Hydro Thunder (U) [b1][t1].z64" crc C0B7026F )
+)
+
+game (
+	name "Hydro Thunder (U) [b2]"
+	description "Hydro Thunder (U) [b2]"
+	rom ( name "Hydro Thunder (U) [b2].z64" crc 8F621ADB )
+)
+
+game (
+	name "Hydro Thunder (U) [b3]"
+	description "Hydro Thunder (U) [b3]"
+	rom ( name "Hydro Thunder (U) [b3].z64" crc 87F7EC0D )
+)
+
+game (
+	name "Ide Yosuke no Mahjong Juku (J) [!]"
+	description "Ide Yosuke no Mahjong Juku (J) [!]"
+	rom ( name "Ide Yosuke no Mahjong Juku (J) [!].z64" crc A4A24517 )
+)
+
+game (
+	name "Ide Yosuke no Mahjong Juku (J) [b1]"
+	description "Ide Yosuke no Mahjong Juku (J) [b1]"
+	rom ( name "Ide Yosuke no Mahjong Juku (J) [b1].z64" crc DBD96DEB )
+)
+
+game (
+	name "Iggy's Reckin' Balls (E) [!]"
+	description "Iggy's Reckin' Balls (E) [!]"
+	rom ( name "Iggy's Reckin' Balls (E) [!].z64" crc 9BF26065 )
+)
+
+game (
+	name "Iggy's Reckin' Balls (E) [o1]"
+	description "Iggy's Reckin' Balls (E) [o1]"
+	rom ( name "Iggy's Reckin' Balls (E) [o1].z64" crc 4F15CE42 )
+)
+
+game (
+	name "Iggy's Reckin' Balls (U) [!]"
+	description "Iggy's Reckin' Balls (U) [!]"
+	rom ( name "Iggy's Reckin' Balls (U) [!].z64" crc 6A6FBD5D )
+)
+
+game (
+	name "Iggy's Reckin' Balls (U) [o1]"
+	description "Iggy's Reckin' Balls (U) [o1]"
+	rom ( name "Iggy's Reckin' Balls (U) [o1].z64" crc 9EC813FB )
+)
+
+game (
+	name "Iggy-kun no Bura Bura Poyon (J) [!]"
+	description "Iggy-kun no Bura Bura Poyon (J) [!]"
+	rom ( name "Iggy-kun no Bura Bura Poyon (J) [!].z64" crc 26CC1266 )
+)
+
+game (
+	name "Iggy-kun no Bura Bura Poyon (J) [o1]"
+	description "Iggy-kun no Bura Bura Poyon (J) [o1]"
+	rom ( name "Iggy-kun no Bura Bura Poyon (J) [o1].z64" crc 5A67E489 )
+)
+
+game (
+	name "Bass Hunter 64 (E) [!]"
+	description "Bass Hunter 64 (E) [!]"
+	rom ( name "Bass Hunter 64 (E) [!].z64" crc 00DA3704 )
+)
+
+game (
+	name "In-Fisherman Bass Hunter 64 (U) [!]"
+	description "In-Fisherman Bass Hunter 64 (U) [!]"
+	rom ( name "In-Fisherman Bass Hunter 64 (U) [!].z64" crc D8EB5E6E )
+)
+
+game (
+	name "In-Fisherman Bass Hunter 64 (U) [f1] (PAL)"
+	description "In-Fisherman Bass Hunter 64 (U) [f1] (PAL)"
+	rom ( name "In-Fisherman Bass Hunter 64 (U) [f1] (PAL).z64" crc 3D30E44B )
+)
+
+game (
+	name "Indiana Jones and the Infernal Machine (U) [!]"
+	description "Indiana Jones and the Infernal Machine (U) [!]"
+	rom ( name "Indiana Jones and the Infernal Machine (U) [!].z64" crc 4978EB57 )
+)
+
+game (
+	name "Indy Racing 2000 (U) [!]"
+	description "Indy Racing 2000 (U) [!]"
+	rom ( name "Indy Racing 2000 (U) [!].z64" crc A5163F29 )
+)
+
+game (
+	name "International Superstar Soccer '98 (E) [!]"
+	description "International Superstar Soccer '98 (E) [!]"
+	rom ( name "International Superstar Soccer '98 (E) [!].z64" crc BF23945D )
+)
+
+game (
+	name "International Superstar Soccer '98 (U) [!]"
+	description "International Superstar Soccer '98 (U) [!]"
+	rom ( name "International Superstar Soccer '98 (U) [!].z64" crc B85FA721 )
+)
+
+game (
+	name "International Superstar Soccer '98 (U) [o1]"
+	description "International Superstar Soccer '98 (U) [o1]"
+	rom ( name "International Superstar Soccer '98 (U) [o1].z64" crc FFF24A88 )
+)
+
+game (
+	name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!]"
+	description "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!]"
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!].z64" crc 5C721850 )
+)
+
+game (
+	name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!]"
+	description "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!]"
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!].z64" crc 68DBCC04 )
+)
+
+game (
+	name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!]"
+	description "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!]"
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!].z64" crc F63F9A5E )
+)
+
+game (
+	name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!]"
+	description "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!]"
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!].z64" crc 69572558 )
+)
+
+game (
+	name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!]"
+	description "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!]"
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!].z64" crc 8A16A6A9 )
+)
+
+game (
+	name "International Superstar Soccer 2000 (U) (M2) [!]"
+	description "International Superstar Soccer 2000 (U) (M2) [!]"
+	rom ( name "International Superstar Soccer 2000 (U) (M2) [!].z64" crc DCD0538F )
+)
+
+game (
+	name "International Superstar Soccer 2000 (U) (M2) [f1] (PAL)"
+	description "International Superstar Soccer 2000 (U) (M2) [f1] (PAL)"
+	rom ( name "International Superstar Soccer 2000 (U) (M2) [f1] (PAL).z64" crc 2141DD95 )
+)
+
+game (
+	name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!]"
+	description "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!]"
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!].z64" crc 153AEB15 )
+)
+
+game (
+	name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [b1]"
+	description "Jikkyou J.League 1999 - Perfect Striker 2 (J) [b1]"
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [b1].z64" crc 25FA617F )
+)
+
+game (
+	name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f1] (PAL)"
+	description "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f1] (PAL)"
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f1] (PAL).z64" crc FFF14BE7 )
+)
+
+game (
+	name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f2] (PAL)"
+	description "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f2] (PAL)"
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f2] (PAL).z64" crc 71D98830 )
+)
+
+game (
+	name "International Superstar Soccer 64 (E) [!]"
+	description "International Superstar Soccer 64 (E) [!]"
+	rom ( name "International Superstar Soccer 64 (E) [!].z64" crc 8C839268 )
+)
+
+game (
+	name "International Superstar Soccer 64 (E) [b1]"
+	description "International Superstar Soccer 64 (E) [b1]"
+	rom ( name "International Superstar Soccer 64 (E) [b1].z64" crc AB19D163 )
+)
+
+game (
+	name "International Superstar Soccer 64 (E) [b2]"
+	description "International Superstar Soccer 64 (E) [b2]"
+	rom ( name "International Superstar Soccer 64 (E) [b2].z64" crc 4A3BFBBD )
+)
+
+game (
+	name "International Superstar Soccer 64 (E) [h1C]"
+	description "International Superstar Soccer 64 (E) [h1C]"
+	rom ( name "International Superstar Soccer 64 (E) [h1C].z64" crc 3A827AFC )
+)
+
+game (
+	name "International Superstar Soccer 64 (E) [h2C]"
+	description "International Superstar Soccer 64 (E) [h2C]"
+	rom ( name "International Superstar Soccer 64 (E) [h2C].z64" crc 3FF384EF )
+)
+
+game (
+	name "International Superstar Soccer 64 (U) [!]"
+	description "International Superstar Soccer 64 (U) [!]"
+	rom ( name "International Superstar Soccer 64 (U) [!].z64" crc 0EA249B9 )
+)
+
+game (
+	name "International Superstar Soccer 64 (U) [b1]"
+	description "International Superstar Soccer 64 (U) [b1]"
+	rom ( name "International Superstar Soccer 64 (U) [b1].z64" crc F73E92C6 )
+)
+
+game (
+	name "International Superstar Soccer 64 (U) [h1C]"
+	description "International Superstar Soccer 64 (U) [h1C]"
+	rom ( name "International Superstar Soccer 64 (U) [h1C].z64" crc 53FD493E )
+)
+
+game (
+	name "International Superstar Soccer 64 (U) [h2C]"
+	description "International Superstar Soccer 64 (U) [h2C]"
+	rom ( name "International Superstar Soccer 64 (U) [h2C].z64" crc 3DB7C140 )
+)
+
+game (
+	name "Jikkyou World Soccer 3 (J) [!]"
+	description "Jikkyou World Soccer 3 (J) [!]"
+	rom ( name "Jikkyou World Soccer 3 (J) [!].z64" crc 3BA9E644 )
+)
+
+game (
+	name "Ganbare Nippon! Olympics 2000 (J) [!]"
+	description "Ganbare Nippon! Olympics 2000 (J) [!]"
+	rom ( name "Ganbare Nippon! Olympics 2000 (J) [!].z64" crc 73133CD2 )
+)
+
+game (
+	name "International Track & Field 2000 (U) [!]"
+	description "International Track & Field 2000 (U) [!]"
+	rom ( name "International Track & Field 2000 (U) [!].z64" crc DA443F0B )
+)
+
+game (
+	name "International Track & Field Summer Games (E) (M3) [!]"
+	description "International Track & Field Summer Games (E) (M3) [!]"
+	rom ( name "International Track & Field Summer Games (E) (M3) [!].z64" crc B3181EE0 )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [!]"
+	description "J.League Dynamite Soccer 64 (J) [!]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [!].z64" crc DC0B2C8F )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [b1]"
+	description "J.League Dynamite Soccer 64 (J) [b1]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [b1].z64" crc 6CFFFEF0 )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [b2]"
+	description "J.League Dynamite Soccer 64 (J) [b2]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [b2].z64" crc 3A53CBA9 )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [b3]"
+	description "J.League Dynamite Soccer 64 (J) [b3]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [b3].z64" crc 03F8518B )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [b4]"
+	description "J.League Dynamite Soccer 64 (J) [b4]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [b4].z64" crc 3A78F83E )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [h1C]"
+	description "J.League Dynamite Soccer 64 (J) [h1C]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [h1C].z64" crc EEB3FA9E )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [h2C]"
+	description "J.League Dynamite Soccer 64 (J) [h2C]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [h2C].z64" crc A7372112 )
+)
+
+game (
+	name "J.League Dynamite Soccer 64 (J) [h3C]"
+	description "J.League Dynamite Soccer 64 (J) [h3C]"
+	rom ( name "J.League Dynamite Soccer 64 (J) [h3C].z64" crc 0C7DF059 )
+)
+
+game (
+	name "J.League Eleven Beat 1997 (J) [b1][h1C]"
+	description "J.League Eleven Beat 1997 (J) [b1][h1C]"
+	rom ( name "J.League Eleven Beat 1997 (J) [b1][h1C].z64" crc C6279F61 )
+)
+
+game (
+	name "J.League Eleven Beat 1997 (J) [b2][h1C]"
+	description "J.League Eleven Beat 1997 (J) [b2][h1C]"
+	rom ( name "J.League Eleven Beat 1997 (J) [b2][h1C].z64" crc 30D40134 )
+)
+
+game (
+	name "J.League Eleven Beat 1997 (J) [h1C]"
+	description "J.League Eleven Beat 1997 (J) [h1C]"
+	rom ( name "J.League Eleven Beat 1997 (J) [h1C].z64" crc 1347819A )
+)
+
+game (
+	name "J.League Eleven Beat 1997 (J)"
+	description "J.League Eleven Beat 1997 (J)"
+	rom ( name "J.League Eleven Beat 1997 (J).z64" crc 7D0EED6A )
+)
+
+game (
+	name "J.League Live 64 (J) [!]"
+	description "J.League Live 64 (J) [!]"
+	rom ( name "J.League Live 64 (J) [!].z64" crc 4C536DD7 )
+)
+
+game (
+	name "J.League Live 64 (J) [b1]"
+	description "J.League Live 64 (J) [b1]"
+	rom ( name "J.League Live 64 (J) [b1].z64" crc 741721F4 )
+)
+
+game (
+	name "J.League Tactics Soccer (J) (V1.0) [!]"
+	description "J.League Tactics Soccer (J) (V1.0) [!]"
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [!].z64" crc 976A2D12 )
+)
+
+game (
+	name "J.League Tactics Soccer (J) (V1.0) [b1]"
+	description "J.League Tactics Soccer (J) (V1.0) [b1]"
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [b1].z64" crc 8E05A52D )
+)
+
+game (
+	name "J.League Tactics Soccer (J) (V1.0) [f1] (PAL)"
+	description "J.League Tactics Soccer (J) (V1.0) [f1] (PAL)"
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [f1] (PAL).z64" crc 15809231 )
+)
+
+game (
+	name "J.League Tactics Soccer (J) (V1.1) [!]"
+	description "J.League Tactics Soccer (J) (V1.1) [!]"
+	rom ( name "J.League Tactics Soccer (J) (V1.1) [!].z64" crc 156E705E )
+)
+
+game (
+	name "Jangou Simulation Mahjong Do 64 (J) [!]"
+	description "Jangou Simulation Mahjong Do 64 (J) [!]"
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [!].z64" crc D1C1681E )
+)
+
+game (
+	name "Jangou Simulation Mahjong Do 64 (J) [b1]"
+	description "Jangou Simulation Mahjong Do 64 (J) [b1]"
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b1].z64" crc CF0DC4F6 )
+)
+
+game (
+	name "Jangou Simulation Mahjong Do 64 (J) [b2]"
+	description "Jangou Simulation Mahjong Do 64 (J) [b2]"
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b2].z64" crc E4E6F7AB )
+)
+
+game (
+	name "Jangou Simulation Mahjong Do 64 (J) [b3]"
+	description "Jangou Simulation Mahjong Do 64 (J) [b3]"
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b3].z64" crc E0511A0E )
+)
+
+game (
+	name "Jeopardy! (U) [!]"
+	description "Jeopardy! (U) [!]"
+	rom ( name "Jeopardy! (U) [!].z64" crc E739947C )
+)
+
+game (
+	name "Jeopardy! (U) [h1C]"
+	description "Jeopardy! (U) [h1C]"
+	rom ( name "Jeopardy! (U) [h1C].z64" crc 9F14481B )
+)
+
+game (
+	name "Jeopardy! (U) [o1]"
+	description "Jeopardy! (U) [o1]"
+	rom ( name "Jeopardy! (U) [o1].z64" crc 8A6A5A0A )
+)
+
+game (
+	name "Jeopardy! (U) [o1][h1C]"
+	description "Jeopardy! (U) [o1][h1C]"
+	rom ( name "Jeopardy! (U) [o1][h1C].z64" crc FD0D1DB5 )
+)
+
+game (
+	name "Jeremy McGrath Supercross 2000 (E) [!]"
+	description "Jeremy McGrath Supercross 2000 (E) [!]"
+	rom ( name "Jeremy McGrath Supercross 2000 (E) [!].z64" crc 5BF42EC4 )
+)
+
+game (
+	name "Jeremy McGrath Supercross 2000 (U) [!]"
+	description "Jeremy McGrath Supercross 2000 (U) [!]"
+	rom ( name "Jeremy McGrath Supercross 2000 (U) [!].z64" crc 2A5C9A06 )
+)
+
+game (
+	name "Jeremy McGrath Supercross 2000 (U) [f1]"
+	description "Jeremy McGrath Supercross 2000 (U) [f1]"
+	rom ( name "Jeremy McGrath Supercross 2000 (U) [f1].z64" crc 5E7AFDD5 )
+)
+
+game (
+	name "Jet Force Gemini (E) (M4) [!]"
+	description "Jet Force Gemini (E) (M4) [!]"
+	rom ( name "Jet Force Gemini (E) (M4) [!].z64" crc CFBED88C )
+)
+
+game (
+	name "Jet Force Gemini (E) (M4) [f1]"
+	description "Jet Force Gemini (E) (M4) [f1]"
+	rom ( name "Jet Force Gemini (E) (M4) [f1].z64" crc 4909C764 )
+)
+
+game (
+	name "Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless]"
+	description "Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless]"
+	rom ( name "Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless].z64" crc D81484C8 )
+)
+
+game (
+	name "Jet Force Gemini (U) (Kiosk Demo) [!]"
+	description "Jet Force Gemini (U) (Kiosk Demo) [!]"
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [!].z64" crc FA061B96 )
+)
+
+game (
+	name "Jet Force Gemini (U) (Kiosk Demo) [b1]"
+	description "Jet Force Gemini (U) (Kiosk Demo) [b1]"
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1].z64" crc 15F91F65 )
+)
+
+game (
+	name "Jet Force Gemini (U) (Kiosk Demo) [b1][f1] (Save)"
+	description "Jet Force Gemini (U) (Kiosk Demo) [b1][f1] (Save)"
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f1] (Save).z64" crc DCF40812 )
+)
+
+game (
+	name "Jet Force Gemini (U) (Kiosk Demo) [b1][f2]"
+	description "Jet Force Gemini (U) (Kiosk Demo) [b1][f2]"
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f2].z64" crc 3E65056C )
+)
+
+game (
+	name "Jet Force Gemini (U) (Kiosk Demo) [b2]"
+	description "Jet Force Gemini (U) (Kiosk Demo) [b2]"
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b2].z64" crc DF2567CB )
+)
+
+game (
+	name "Jet Force Gemini (U) [!]"
+	description "Jet Force Gemini (U) [!]"
+	rom ( name "Jet Force Gemini (U) [!].z64" crc 6753D5A3 )
+)
+
+game (
+	name "Jet Force Gemini (U) [b1]"
+	description "Jet Force Gemini (U) [b1]"
+	rom ( name "Jet Force Gemini (U) [b1].z64" crc DAACC564 )
+)
+
+game (
+	name "Jet Force Gemini (U) [b2]"
+	description "Jet Force Gemini (U) [b2]"
+	rom ( name "Jet Force Gemini (U) [b2].z64" crc 83F0CD60 )
+)
+
+game (
+	name "Star Twins (J) [!]"
+	description "Star Twins (J) [!]"
+	rom ( name "Star Twins (J) [!].z64" crc 964506CE )
+)
+
+game (
+	name "Jikkyou G1 Stable (J) [!]"
+	description "Jikkyou G1 Stable (J) [!]"
+	rom ( name "Jikkyou G1 Stable (J) [!].z64" crc 0A796C3E )
+)
+
+game (
+	name "Jikkyou G1 Stable (J) [b1]"
+	description "Jikkyou G1 Stable (J) [b1]"
+	rom ( name "Jikkyou G1 Stable (J) [b1].z64" crc 6A5DBF42 )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker (J) [!]"
+	description "Jikkyou J.League Perfect Striker (J) [!]"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [!].z64" crc 8ED60DEA )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker (J) [b1]"
+	description "Jikkyou J.League Perfect Striker (J) [b1]"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b1].z64" crc BF55925B )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker (J) [b2]"
+	description "Jikkyou J.League Perfect Striker (J) [b2]"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b2].z64" crc CEC983C4 )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker (J) [b3]"
+	description "Jikkyou J.League Perfect Striker (J) [b3]"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b3].z64" crc 99D33459 )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker (J) [f1] (PAL)"
+	description "Jikkyou J.League Perfect Striker (J) [f1] (PAL)"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [f1] (PAL).z64" crc 70B86019 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!]"
+	description "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!].z64" crc 6A9E24D7 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!].z64" crc 351CDE48 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!].z64" crc 753706EF )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!].z64" crc 480B953E )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1].z64" crc A9CBF551 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b2]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b2]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b2].z64" crc 7B6C6447 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b3]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b3]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b3].z64" crc BD96513E )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b4]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b4]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b4].z64" crc B0B19ACD )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b5]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b5]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b5].z64" crc BC6A43D1 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [o1]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [o1]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [o1].z64" crc 3E95D085 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!].z64" crc 40E3AC61 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 5 (J) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 5 (J) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [!].z64" crc FEEC34F6 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 5 (J) [b1]"
+	description "Jikkyou Powerful Pro Yakyuu 5 (J) [b1]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [b1].z64" crc 46882289 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 5 (J) [f1]"
+	description "Jikkyou Powerful Pro Yakyuu 5 (J) [f1]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f1].z64" crc ECBC4C5A )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 5 (J) [f2] (PAL)"
+	description "Jikkyou Powerful Pro Yakyuu 5 (J) [f2] (PAL)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f2] (PAL).z64" crc 3B182DDA )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 6 (J) [!]"
+	description "Jikkyou Powerful Pro Yakyuu 6 (J) [!]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [!].z64" crc D9329895 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 6 (J) [b1]"
+	description "Jikkyou Powerful Pro Yakyuu 6 (J) [b1]"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [b1].z64" crc 1E53A7BA )
+)
+
+game (
+	name "Jinsei Game 64 (J) [!]"
+	description "Jinsei Game 64 (J) [!]"
+	rom ( name "Jinsei Game 64 (J) [!].z64" crc 67A1A22C )
+)
+
+game (
+	name "Jinsei Game 64 (J) [f1] (PAL)"
+	description "Jinsei Game 64 (J) [f1] (PAL)"
+	rom ( name "Jinsei Game 64 (J) [f1] (PAL).z64" crc D8087B7F )
+)
+
+game (
+	name "John Romero's Daikatana (E) (M3) [!]"
+	description "John Romero's Daikatana (E) (M3) [!]"
+	rom ( name "John Romero's Daikatana (E) (M3) [!].z64" crc F88AC3CE )
+)
+
+game (
+	name "John Romero's Daikatana (E) (M3) [f1] (NTSC)"
+	description "John Romero's Daikatana (E) (M3) [f1] (NTSC)"
+	rom ( name "John Romero's Daikatana (E) (M3) [f1] (NTSC).z64" crc 09DD5D1D )
+)
+
+game (
+	name "John Romero's Daikatana (E) (M3) [h1C]"
+	description "John Romero's Daikatana (E) (M3) [h1C]"
+	rom ( name "John Romero's Daikatana (E) (M3) [h1C].z64" crc 429502C6 )
+)
+
+game (
+	name "John Romero's Daikatana (J) [!]"
+	description "John Romero's Daikatana (J) [!]"
+	rom ( name "John Romero's Daikatana (J) [!].z64" crc 44B80FD7 )
+)
+
+game (
+	name "John Romero's Daikatana (U) [!]"
+	description "John Romero's Daikatana (U) [!]"
+	rom ( name "John Romero's Daikatana (U) [!].z64" crc 494950C6 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [!]"
+	description "Ken Griffey Jr.'s Slugfest (U) [!]"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [!].z64" crc 12D8F3E9 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [b1]"
+	description "Ken Griffey Jr.'s Slugfest (U) [b1]"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b1].z64" crc 7F4BF06C )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [b2]"
+	description "Ken Griffey Jr.'s Slugfest (U) [b2]"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b2].z64" crc 6A76D40C )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [f1]"
+	description "Ken Griffey Jr.'s Slugfest (U) [f1]"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f1].z64" crc 07E5D789 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [f2] (PAL)"
+	description "Ken Griffey Jr.'s Slugfest (U) [f2] (PAL)"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f2] (PAL).z64" crc 00E8DD96 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [f3] (Nosave)"
+	description "Ken Griffey Jr.'s Slugfest (U) [f3] (Nosave)"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f3] (Nosave).z64" crc 28C9FF55 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [f4] (Nosave-Z64)"
+	description "Ken Griffey Jr.'s Slugfest (U) [f4] (Nosave-Z64)"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f4] (Nosave-Z64).z64" crc DDDBEB27 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest (U) [f5]"
+	description "Ken Griffey Jr.'s Slugfest (U) [f5]"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f5].z64" crc 7846FA73 )
+)
+
+game (
+	name "Killer Instinct Gold (E) [!]"
+	description "Killer Instinct Gold (E) [!]"
+	rom ( name "Killer Instinct Gold (E) [!].z64" crc 5D0EE5D2 )
+)
+
+game (
+	name "Killer Instinct Gold (E) [o1]"
+	description "Killer Instinct Gold (E) [o1]"
+	rom ( name "Killer Instinct Gold (E) [o1].z64" crc 896D0B78 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [!]"
+	description "Killer Instinct Gold (U) (V1.0) [!]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [!].z64" crc 31C76BE7 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b1]"
+	description "Killer Instinct Gold (U) (V1.0) [b1]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b1].z64" crc 3C1D7A7B )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b1][t1]"
+	description "Killer Instinct Gold (U) (V1.0) [b1][t1]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b1][t1].z64" crc 5057DD86 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b2]"
+	description "Killer Instinct Gold (U) (V1.0) [b2]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b2].z64" crc 5E0D463C )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b3]"
+	description "Killer Instinct Gold (U) (V1.0) [b3]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b3].z64" crc 3E4BDC51 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b4]"
+	description "Killer Instinct Gold (U) (V1.0) [b4]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b4].z64" crc CB383067 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [b5]"
+	description "Killer Instinct Gold (U) (V1.0) [b5]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b5].z64" crc 00974048 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [o1]"
+	description "Killer Instinct Gold (U) (V1.0) [o1]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [o1].z64" crc F2D8CA68 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [o2]"
+	description "Killer Instinct Gold (U) (V1.0) [o2]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [o2].z64" crc 2C32D6D5 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [t1]"
+	description "Killer Instinct Gold (U) (V1.0) [t1]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [t1].z64" crc AC327AD0 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.0) [t2]"
+	description "Killer Instinct Gold (U) (V1.0) [t2]"
+	rom ( name "Killer Instinct Gold (U) (V1.0) [t2].z64" crc A52431B0 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.1) [!]"
+	description "Killer Instinct Gold (U) (V1.1) [!]"
+	rom ( name "Killer Instinct Gold (U) (V1.1) [!].z64" crc 49EF8F2B )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.1) [o1]"
+	description "Killer Instinct Gold (U) (V1.1) [o1]"
+	rom ( name "Killer Instinct Gold (U) (V1.1) [o1].z64" crc 79AEE5E0 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.2) [!]"
+	description "Killer Instinct Gold (U) (V1.2) [!]"
+	rom ( name "Killer Instinct Gold (U) (V1.2) [!].z64" crc 0B5B5DF8 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.2) [b1]"
+	description "Killer Instinct Gold (U) (V1.2) [b1]"
+	rom ( name "Killer Instinct Gold (U) (V1.2) [b1].z64" crc 12B74C51 )
+)
+
+game (
+	name "Killer Instinct Gold (U) (V1.2) [o1]"
+	description "Killer Instinct Gold (U) (V1.2) [o1]"
+	rom ( name "Killer Instinct Gold (U) (V1.2) [o1].z64" crc C9E80752 )
+)
+
+game (
+	name "Kira to Kaiketsu! 64 Tanteidan (J) [!]"
+	description "Kira to Kaiketsu! 64 Tanteidan (J) [!]"
+	rom ( name "Kira to Kaiketsu! 64 Tanteidan (J) [!].z64" crc 7FDC3784 )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.0) [!]"
+	description "Hoshi no Kirby 64 (J) (V1.0) [!]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [!].z64" crc AE7CB69D )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.0) [f1]"
+	description "Hoshi no Kirby 64 (J) (V1.0) [f1]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f1].z64" crc 81652A1A )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.0) [f2]"
+	description "Hoshi no Kirby 64 (J) (V1.0) [f2]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f2].z64" crc AE41BA5F )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.1) [!]"
+	description "Hoshi no Kirby 64 (J) (V1.1) [!]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.1) [!].z64" crc A263C1B9 )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.2) [!]"
+	description "Hoshi no Kirby 64 (J) (V1.2) [!]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.2) [!].z64" crc F4589AA8 )
+)
+
+game (
+	name "Hoshi no Kirby 64 (J) (V1.3) [!]"
+	description "Hoshi no Kirby 64 (J) (V1.3) [!]"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.3) [!].z64" crc 6D5E1332 )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (E) [!]"
+	description "Kirby 64 - The Crystal Shards (E) [!]"
+	rom ( name "Kirby 64 - The Crystal Shards (E) [!].z64" crc 5B8B89EF )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (E) [b1]"
+	description "Kirby 64 - The Crystal Shards (E) [b1]"
+	rom ( name "Kirby 64 - The Crystal Shards (E) [b1].z64" crc 5CD16874 )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (E) [f1]"
+	description "Kirby 64 - The Crystal Shards (E) [f1]"
+	rom ( name "Kirby 64 - The Crystal Shards (E) [f1].z64" crc 4FE0DADF )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (U) [!]"
+	description "Kirby 64 - The Crystal Shards (U) [!]"
+	rom ( name "Kirby 64 - The Crystal Shards (U) [!].z64" crc 20A1C120 )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (U) [b1]"
+	description "Kirby 64 - The Crystal Shards (U) [b1]"
+	rom ( name "Kirby 64 - The Crystal Shards (U) [b1].z64" crc 1916876E )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (U) [b2]"
+	description "Kirby 64 - The Crystal Shards (U) [b2]"
+	rom ( name "Kirby 64 - The Crystal Shards (U) [b2].z64" crc 2033759A )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (U) [f1]"
+	description "Kirby 64 - The Crystal Shards (U) [f1]"
+	rom ( name "Kirby 64 - The Crystal Shards (U) [f1].z64" crc 5945FE08 )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards (U) [t1]"
+	description "Kirby 64 - The Crystal Shards (U) [t1]"
+	rom ( name "Kirby 64 - The Crystal Shards (U) [t1].z64" crc 910ECF72 )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (E) [!]"
+	description "Knife Edge - Nose Gunner (E) [!]"
+	rom ( name "Knife Edge - Nose Gunner (E) [!].z64" crc B77783BE )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (J) [!]"
+	description "Knife Edge - Nose Gunner (J) [!]"
+	rom ( name "Knife Edge - Nose Gunner (J) [!].z64" crc 3BC93017 )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (U) [!]"
+	description "Knife Edge - Nose Gunner (U) [!]"
+	rom ( name "Knife Edge - Nose Gunner (U) [!].z64" crc 255EE1DD )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (U) [b1][t1]"
+	description "Knife Edge - Nose Gunner (U) [b1][t1]"
+	rom ( name "Knife Edge - Nose Gunner (U) [b1][t1].z64" crc C7BEF4E1 )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (U) [hI]"
+	description "Knife Edge - Nose Gunner (U) [hI]"
+	rom ( name "Knife Edge - Nose Gunner (U) [hI].z64" crc 0B2C0D2F )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (U) [hI][t1]"
+	description "Knife Edge - Nose Gunner (U) [hI][t1]"
+	rom ( name "Knife Edge - Nose Gunner (U) [hI][t1].z64" crc 34E8D3CF )
+)
+
+game (
+	name "Knife Edge - Nose Gunner (U) [t1]"
+	description "Knife Edge - Nose Gunner (U) [t1]"
+	rom ( name "Knife Edge - Nose Gunner (U) [t1].z64" crc 1DC1E85D )
+)
+
+game (
+	name "Knockout Kings 2000 (E) [!]"
+	description "Knockout Kings 2000 (E) [!]"
+	rom ( name "Knockout Kings 2000 (E) [!].z64" crc 58CE7D80 )
+)
+
+game (
+	name "Knockout Kings 2000 (U) [!]"
+	description "Knockout Kings 2000 (U) [!]"
+	rom ( name "Knockout Kings 2000 (U) [!].z64" crc 074690D6 )
+)
+
+game (
+	name "Knockout Kings 2000 (U) [f1] (PAL)"
+	description "Knockout Kings 2000 (U) [f1] (PAL)"
+	rom ( name "Knockout Kings 2000 (U) [f1] (PAL).z64" crc 2A42B10F )
+)
+
+game (
+	name "Kobe Bryant in NBA Courtside (E) [!]"
+	description "Kobe Bryant in NBA Courtside (E) [!]"
+	rom ( name "Kobe Bryant in NBA Courtside (E) [!].z64" crc 1355A826 )
+)
+
+game (
+	name "Kobe Bryant in NBA Courtside (E) [f1]"
+	description "Kobe Bryant in NBA Courtside (E) [f1]"
+	rom ( name "Kobe Bryant in NBA Courtside (E) [f1].z64" crc DC2DCD0B )
+)
+
+game (
+	name "Kobe Bryant's NBA Courtside (U) [!]"
+	description "Kobe Bryant's NBA Courtside (U) [!]"
+	rom ( name "Kobe Bryant's NBA Courtside (U) [!].z64" crc 86360BFB )
+)
+
+game (
+	name "Kobe Bryant's NBA Courtside (U) [f1]"
+	description "Kobe Bryant's NBA Courtside (U) [f1]"
+	rom ( name "Kobe Bryant's NBA Courtside (U) [f1].z64" crc E1FE4B7D )
+)
+
+game (
+	name "Kobe Bryant's NBA Courtside (U) [h1C]"
+	description "Kobe Bryant's NBA Courtside (U) [h1C]"
+	rom ( name "Kobe Bryant's NBA Courtside (U) [h1C].z64" crc 13181CF8 )
+)
+
+game (
+	name "Last Legion UX (J) [!]"
+	description "Last Legion UX (J) [!]"
+	rom ( name "Last Legion UX (J) [!].z64" crc 9DB99881 )
+)
+
+game (
+	name "Last Legion UX (J) [a1]"
+	description "Last Legion UX (J) [a1]"
+	rom ( name "Last Legion UX (J) [a1].z64" crc C155E137 )
+)
+
+game (
+	name "Last Legion UX (J) [b1]"
+	description "Last Legion UX (J) [b1]"
+	rom ( name "Last Legion UX (J) [b1].z64" crc A320E0F0 )
+)
+
+game (
+	name "Last Legion UX (J) [b2]"
+	description "Last Legion UX (J) [b2]"
+	rom ( name "Last Legion UX (J) [b2].z64" crc 11260FAA )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!].z64" crc 9EAD1608 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [f1]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [f1]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [f1].z64" crc E6104497 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire].z64" crc 323C8CA3 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9e_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9e_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9e_Vampire].z64" crc 0F5EB553 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9f_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9f_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9f_Vampire].z64" crc 4CBC60DC )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9M_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9M_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9M_Vampire].z64" crc 9EF15B1E )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9P1+G_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9P1+G_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9P1+G_Vampire].z64" crc 8176EB83 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9Z3_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9Z3_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9Z3_Vampire].z64" crc FF12F3F4 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire]"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire].z64" crc 8EBF7691 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1)"
+	description "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1)"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1).z64" crc E2E6823D )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) (GC)"
+	description "Legend of Zelda, The - Majora's Mask (U) (GC)"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) (GC).z64" crc B008458F )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [!]"
+	description "Legend of Zelda, The - Majora's Mask (U) [!]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [!].z64" crc B428D8A7 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [f1]"
+	description "Legend of Zelda, The - Majora's Mask (U) [f1]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [f1].z64" crc 5663BA96 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0].z64" crc 1FDF0CEB )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T+Rus0.85_Alex]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T+Rus0.85_Alex]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Rus0.85_Alex].z64" crc BE6FEBF1 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T+RusPreAlpha_Alex&gottax]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T+RusPreAlpha_Alex&gottax]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+RusPreAlpha_Alex&gottax].z64" crc 0131DD2C )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.1_Alex]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.1_Alex]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.1_Alex].z64" crc 25CC969C )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.2_Alex]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.2_Alex]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.2_Alex].z64" crc 5DED3201 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.36Alex]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.36Alex]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.36Alex].z64" crc 74747E29 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.50_Alex]"
+	description "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.50_Alex]"
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.50_Alex].z64" crc 3F53645E )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!]"
+	description "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!]"
+	rom ( name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!].z64" crc 12836E19 )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!]"
+	description "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!]"
+	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" crc DCC110A0 )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!].z64" crc B9BF76DF )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!].z64" crc 0D33E1DB )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1].z64" crc A60DE571 )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1][o1]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1][o1]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1][o1].z64" crc 749EAB8F )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [f1]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [f1]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [f1].z64" crc 3BE52CCF )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [o1]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [o1]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [o1].z64" crc D3AC5F99 )
+)
+
+game (
+	name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!]"
+	description "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!]"
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!].z64" crc 356C2E19 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (E) (GC) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!].z64" crc 3FBD519F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (GC) [f1]"
+	description "Legend of Zelda, The - Ocarina of Time (E) (GC) [f1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [f1].z64" crc 9569957F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!].z64" crc 946FD0F7 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1]"
+	description "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1].z64" crc 658905C6 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f1] (zpfc)"
+	description "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f1] (zpfc)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f1] (zpfc).z64" crc 1CCAF639 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f2] (zpc1)"
+	description "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f2] (zpc1)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f2] (zpc1).z64" crc 4FD78FC5 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!].z64" crc A108F6E3 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (GC) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!].z64" crc 346DE3AE )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack)"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack).z64" crc 7D951B34 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!].z64" crc CD16C529 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [b1]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [b1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [b1].z64" crc 8F50BF38 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f1]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f1].z64" crc D77A70E8 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f2]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f2].z64" crc 1587879B )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f3]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f3]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f3].z64" crc 92A0CBFD )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Dut]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Dut]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Dut].z64" crc 5307F70B )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Ita100]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Ita100]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Ita100].z64" crc B5D1B588 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Pol1.3]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Pol1.3]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Pol1.3].z64" crc 0F6AFB03 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.0]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.0]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.0].z64" crc 3E00D978 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.5BetaFinal]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.5BetaFinal]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.5BetaFinal].z64" crc 32D72425 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus1.0beta2_Sergey Anton]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus1.0beta2_Sergey Anton]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus1.0beta2_Sergey Anton].z64" crc 2174DBFA )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus101b2]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus101b2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus101b2].z64" crc D2B87BDD )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa01b_toruzz]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa01b_toruzz]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa01b_toruzz].z64" crc A07BEB6F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa097b2]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa097b2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa097b2].z64" crc DA6171CD )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa1.0]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa1.0]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa1.0].z64" crc 3E355253 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa2.0_eduardo_a2j]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa2.0_eduardo_a2j]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa2.0_eduardo_a2j].z64" crc AFD60B23 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Pol1.2]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Pol1.2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Pol1.2].z64" crc 92A5B35D )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.09]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.09]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.09].z64" crc F2CBB79E )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.14]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.14]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.14].z64" crc 995532C5 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.22]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.22]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.22].z64" crc 2FE15996 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.26]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.26]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.26].z64" crc BB45B0BF )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.28]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.28]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.28].z64" crc 0B86B28E )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.30]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.30]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.30].z64" crc D9FA73A7 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.33]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.33]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.33].z64" crc B68EA623 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.35]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.35]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.35].z64" crc EBDADA62 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.37]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.37]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.37].z64" crc 11031B9F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.42]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.42]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.42].z64" crc 7A7BA9B5 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.01]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.01]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.01].z64" crc 03E96F36 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.06]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.06]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.06].z64" crc 01231A9F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.82]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.82]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.82].z64" crc 6B4D5FE7 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099bfix]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099bfix]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099bfix].z64" crc 88E7A5B6 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099wip]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099wip]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099wip].z64" crc 3C67188A )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Spa1.0_eduardo]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Spa1.0_eduardo]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Spa1.0_eduardo].z64" crc 38056E6D )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!].z64" crc 3FD2151E )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b1]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b1].z64" crc 91649D1B )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b2]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b2].z64" crc 63C8D30F )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100].z64" crc 39070E84 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por1.0]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por1.0]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por1.0].z64" crc 6553C572 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por100%]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por100%]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por100%].z64" crc AE32F542 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Spa01b_toruzz]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Spa01b_toruzz]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Spa01b_toruzz].z64" crc A924A530 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo].z64" crc AE802C75 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo][b1]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo][b1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo][b1].z64" crc F04BB305 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!]"
+	description "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!].z64" crc 32120C23 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [!]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [!].z64" crc 832D6449 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [f1] (NTSC)"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [f1] (NTSC)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [f1] (NTSC).z64" crc 33ED5939 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [h1C]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [h1C]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [h1C].z64" crc 091D9D5C )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Ita70%_Rulesless]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Ita70%_Rulesless]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Ita70%_Rulesless].z64" crc B63DCB25 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Pol1.0]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Pol1.0]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Pol1.0].z64" crc EBB2EC57 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f1]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f1]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f1].z64" crc 9DAA2516 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f2]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f2]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f2].bin" crc 20AB8205 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version)"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version).z64" crc 62F92704 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!]"
+	description "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!]"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!].z64" crc C744C4DB )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!].z64" crc D423E8B0 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1].z64" crc 0CB2AA02 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell].z64" crc 5C8E5553 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi].z64" crc 52662E13 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!].z64" crc 26E73887 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!].z64" crc 2B2721BA )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!].z64" crc 8C5B90C1 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!].z64" crc 1C6CE8CB )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!]"
+	description "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!]"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!].z64" crc 122FF261 )
+)
+
+game (
+	name "LEGO Racers (E) (M10) [!]"
+	description "LEGO Racers (E) (M10) [!]"
+	rom ( name "LEGO Racers (E) (M10) [!].z64" crc C7D9B21C )
+)
+
+game (
+	name "LEGO Racers (U) (M10) [!]"
+	description "LEGO Racers (U) (M10) [!]"
+	rom ( name "LEGO Racers (U) (M10) [!].z64" crc 39407C9F )
+)
+
+game (
+	name "LEGO Racers (U) (M10) [b1]"
+	description "LEGO Racers (U) (M10) [b1]"
+	rom ( name "LEGO Racers (U) (M10) [b1].z64" crc 4D1E1897 )
+)
+
+game (
+	name "LEGO Racers (U) (M10) [b1][f1] (PAL)"
+	description "LEGO Racers (U) (M10) [b1][f1] (PAL)"
+	rom ( name "LEGO Racers (U) (M10) [b1][f1] (PAL).z64" crc 194358EF )
+)
+
+game (
+	name "LEGO Racers (U) (M10) [b1][t1]"
+	description "LEGO Racers (U) (M10) [b1][t1]"
+	rom ( name "LEGO Racers (U) (M10) [b1][t1].z64" crc 21599DE8 )
+)
+
+game (
+	name "Lode Runner 3-D (E) (M5) [!]"
+	description "Lode Runner 3-D (E) (M5) [!]"
+	rom ( name "Lode Runner 3-D (E) (M5) [!].z64" crc 7148251D )
+)
+
+game (
+	name "Lode Runner 3-D (E) (M5) [b1]"
+	description "Lode Runner 3-D (E) (M5) [b1]"
+	rom ( name "Lode Runner 3-D (E) (M5) [b1].z64" crc C50C0CCB )
+)
+
+game (
+	name "Lode Runner 3-D (J) [!]"
+	description "Lode Runner 3-D (J) [!]"
+	rom ( name "Lode Runner 3-D (J) [!].z64" crc 1D4FB466 )
+)
+
+game (
+	name "Lode Runner 3-D (U) [!]"
+	description "Lode Runner 3-D (U) [!]"
+	rom ( name "Lode Runner 3-D (U) [!].z64" crc 4EA07453 )
+)
+
+game (
+	name "Lode Runner 3-D (U) [b1][f1] (PAL)"
+	description "Lode Runner 3-D (U) [b1][f1] (PAL)"
+	rom ( name "Lode Runner 3-D (U) [b1][f1] (PAL).z64" crc E799D4BE )
+)
+
+game (
+	name "Lode Runner 3-D (U) [f1] (PAL)"
+	description "Lode Runner 3-D (U) [f1] (PAL)"
+	rom ( name "Lode Runner 3-D (U) [f1] (PAL).z64" crc 0DC54B5B )
+)
+
+game (
+	name "Lode Runner 3-D (U) [t1]"
+	description "Lode Runner 3-D (U) [t1]"
+	rom ( name "Lode Runner 3-D (U) [t1].z64" crc 54FFCD02 )
+)
+
+game (
+	name "Lt. Duck Dodgers (Prototype)"
+	description "Lt. Duck Dodgers (Prototype)"
+	rom ( name "Lt. Duck Dodgers (Prototype).z64" crc 7291BA5B )
+)
+
+game (
+	name "Mace - The Dark Age (E) [!]"
+	description "Mace - The Dark Age (E) [!]"
+	rom ( name "Mace - The Dark Age (E) [!].z64" crc 57DDEDE1 )
+)
+
+game (
+	name "Mace - The Dark Age (E) [b1]"
+	description "Mace - The Dark Age (E) [b1]"
+	rom ( name "Mace - The Dark Age (E) [b1].z64" crc D5A1C38C )
+)
+
+game (
+	name "Mace - The Dark Age (E) [b2]"
+	description "Mace - The Dark Age (E) [b2]"
+	rom ( name "Mace - The Dark Age (E) [b2].z64" crc 5639E41A )
+)
+
+game (
+	name "Mace - The Dark Age (E) [o1]"
+	description "Mace - The Dark Age (E) [o1]"
+	rom ( name "Mace - The Dark Age (E) [o1].z64" crc D09BDA9C )
+)
+
+game (
+	name "Mace - The Dark Age (E) [o2]"
+	description "Mace - The Dark Age (E) [o2]"
+	rom ( name "Mace - The Dark Age (E) [o2].z64" crc F89B3C8B )
+)
+
+game (
+	name "Mace - The Dark Age (U) [!]"
+	description "Mace - The Dark Age (U) [!]"
+	rom ( name "Mace - The Dark Age (U) [!].z64" crc D2A363A6 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b1]"
+	description "Mace - The Dark Age (U) [b1]"
+	rom ( name "Mace - The Dark Age (U) [b1].z64" crc C80DDBDC )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b2]"
+	description "Mace - The Dark Age (U) [b2]"
+	rom ( name "Mace - The Dark Age (U) [b2].z64" crc E5D6A780 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b3]"
+	description "Mace - The Dark Age (U) [b3]"
+	rom ( name "Mace - The Dark Age (U) [b3].z64" crc DA979923 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b4]"
+	description "Mace - The Dark Age (U) [b4]"
+	rom ( name "Mace - The Dark Age (U) [b4].z64" crc 24B74E65 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b5]"
+	description "Mace - The Dark Age (U) [b5]"
+	rom ( name "Mace - The Dark Age (U) [b5].z64" crc C993764F )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b6]"
+	description "Mace - The Dark Age (U) [b6]"
+	rom ( name "Mace - The Dark Age (U) [b6].z64" crc C5B79F9A )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b7]"
+	description "Mace - The Dark Age (U) [b7]"
+	rom ( name "Mace - The Dark Age (U) [b7].z64" crc 9BEB0740 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b8]"
+	description "Mace - The Dark Age (U) [b8]"
+	rom ( name "Mace - The Dark Age (U) [b8].z64" crc 5F6A8B72 )
+)
+
+game (
+	name "Mace - The Dark Age (U) [b9]"
+	description "Mace - The Dark Age (U) [b9]"
+	rom ( name "Mace - The Dark Age (U) [b9].z64" crc 799B3FFB )
+)
+
+game (
+	name "Mace - The Dark Age (U) [o1]"
+	description "Mace - The Dark Age (U) [o1]"
+	rom ( name "Mace - The Dark Age (U) [o1].z64" crc 12E470A7 )
+)
+
+game (
+	name "Madden Football 64 (E) [!]"
+	description "Madden Football 64 (E) [!]"
+	rom ( name "Madden Football 64 (E) [!].z64" crc FAB3E50D )
+)
+
+game (
+	name "Madden Football 64 (E) [b1]"
+	description "Madden Football 64 (E) [b1]"
+	rom ( name "Madden Football 64 (E) [b1].z64" crc D2100F88 )
+)
+
+game (
+	name "Madden Football 64 (U) [!]"
+	description "Madden Football 64 (U) [!]"
+	rom ( name "Madden Football 64 (U) [!].z64" crc 42E5FAFA )
+)
+
+game (
+	name "Madden Football 64 (U) [b1]"
+	description "Madden Football 64 (U) [b1]"
+	rom ( name "Madden Football 64 (U) [b1].z64" crc D9ADDFFC )
+)
+
+game (
+	name "Madden Football 64 (U) [b2]"
+	description "Madden Football 64 (U) [b2]"
+	rom ( name "Madden Football 64 (U) [b2].z64" crc 89F3009B )
+)
+
+game (
+	name "Madden Football 64 (U) [h1C]"
+	description "Madden Football 64 (U) [h1C]"
+	rom ( name "Madden Football 64 (U) [h1C].z64" crc 6A46107F )
+)
+
+game (
+	name "Madden Football 64 (U) [o1]"
+	description "Madden Football 64 (U) [o1]"
+	rom ( name "Madden Football 64 (U) [o1].z64" crc 47226E0C )
+)
+
+game (
+	name "Madden Football 64 (U) [o1][h1C]"
+	description "Madden Football 64 (U) [o1][h1C]"
+	rom ( name "Madden Football 64 (U) [o1][h1C].z64" crc 7CCCB7C5 )
+)
+
+game (
+	name "Madden Football 64 (U) [o2]"
+	description "Madden Football 64 (U) [o2]"
+	rom ( name "Madden Football 64 (U) [o2].z64" crc 563B4710 )
+)
+
+game (
+	name "Madden Football 64 (U) [o3]"
+	description "Madden Football 64 (U) [o3]"
+	rom ( name "Madden Football 64 (U) [o3].z64" crc 225E1692 )
+)
+
+game (
+	name "Madden NFL 2000 (U) [!]"
+	description "Madden NFL 2000 (U) [!]"
+	rom ( name "Madden NFL 2000 (U) [!].z64" crc EF5F997B )
+)
+
+game (
+	name "Madden NFL 2001 (U) [!]"
+	description "Madden NFL 2001 (U) [!]"
+	rom ( name "Madden NFL 2001 (U) [!].z64" crc 245EAEE8 )
+)
+
+game (
+	name "Madden NFL 2002 (U) [!]"
+	description "Madden NFL 2002 (U) [!]"
+	rom ( name "Madden NFL 2002 (U) [!].z64" crc F573F107 )
+)
+
+game (
+	name "Madden NFL 99 (E) [!]"
+	description "Madden NFL 99 (E) [!]"
+	rom ( name "Madden NFL 99 (E) [!].z64" crc D0929942 )
+)
+
+game (
+	name "Madden NFL 99 (E) [h1C]"
+	description "Madden NFL 99 (E) [h1C]"
+	rom ( name "Madden NFL 99 (E) [h1C].z64" crc F83173C7 )
+)
+
+game (
+	name "Madden NFL 99 (U) [!]"
+	description "Madden NFL 99 (U) [!]"
+	rom ( name "Madden NFL 99 (U) [!].z64" crc 2EB64FC2 )
+)
+
+game (
+	name "Madden NFL 99 (U) [o1]"
+	description "Madden NFL 99 (U) [o1]"
+	rom ( name "Madden NFL 99 (U) [o1].z64" crc 06C06C02 )
+)
+
+game (
+	name "Defi au Tetris Magique (F) [!]"
+	description "Defi au Tetris Magique (F) [!]"
+	rom ( name "Defi au Tetris Magique (F) [!].z64" crc E7EF60E8 )
+)
+
+game (
+	name "Magical Tetris Challenge (E) [!]"
+	description "Magical Tetris Challenge (E) [!]"
+	rom ( name "Magical Tetris Challenge (E) [!].z64" crc AF3B099E )
+)
+
+game (
+	name "Magical Tetris Challenge (E) [b1]"
+	description "Magical Tetris Challenge (E) [b1]"
+	rom ( name "Magical Tetris Challenge (E) [b1].z64" crc 32C5F787 )
+)
+
+game (
+	name "Magical Tetris Challenge (E) [f1] (NTSC)"
+	description "Magical Tetris Challenge (E) [f1] (NTSC)"
+	rom ( name "Magical Tetris Challenge (E) [f1] (NTSC).z64" crc B7D8D550 )
+)
+
+game (
+	name "Magical Tetris Challenge (G) [!]"
+	description "Magical Tetris Challenge (G) [!]"
+	rom ( name "Magical Tetris Challenge (G) [!].z64" crc 377F18E9 )
+)
+
+game (
+	name "Magical Tetris Challenge (U) [!]"
+	description "Magical Tetris Challenge (U) [!]"
+	rom ( name "Magical Tetris Challenge (U) [!].z64" crc 22FE979C )
+)
+
+game (
+	name "Magical Tetris Challenge (U) [b1][hI]"
+	description "Magical Tetris Challenge (U) [b1][hI]"
+	rom ( name "Magical Tetris Challenge (U) [b1][hI].z64" crc 93ACD064 )
+)
+
+game (
+	name "Magical Tetris Challenge (U) [hI]"
+	description "Magical Tetris Challenge (U) [hI]"
+	rom ( name "Magical Tetris Challenge (U) [hI].z64" crc B078E78D )
+)
+
+game (
+	name "Magical Tetris Challenge Featuring Mickey (J) [!]"
+	description "Magical Tetris Challenge Featuring Mickey (J) [!]"
+	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [!].z64" crc 7EFB2F1E )
+)
+
+game (
+	name "Magical Tetris Challenge Featuring Mickey (J) [b1]"
+	description "Magical Tetris Challenge Featuring Mickey (J) [b1]"
+	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [b1].z64" crc 4D42ABF7 )
+)
+
+game (
+	name "Mahjong 64 (J) [!]"
+	description "Mahjong 64 (J) [!]"
+	rom ( name "Mahjong 64 (J) [!].z64" crc DBE7D51A )
+)
+
+game (
+	name "Mahjong 64 (J) [o1]"
+	description "Mahjong 64 (J) [o1]"
+	rom ( name "Mahjong 64 (J) [o1].z64" crc A3AAC620 )
+)
+
+game (
+	name "Mahjong 64 (J) [o2]"
+	description "Mahjong 64 (J) [o2]"
+	rom ( name "Mahjong 64 (J) [o2].z64" crc AA562908 )
+)
+
+game (
+	name "Mahjong Hourouki Classic (J) [!]"
+	description "Mahjong Hourouki Classic (J) [!]"
+	rom ( name "Mahjong Hourouki Classic (J) [!].z64" crc 990A8E54 )
+)
+
+game (
+	name "Mahjong Hourouki Classic (J) [b1]"
+	description "Mahjong Hourouki Classic (J) [b1]"
+	rom ( name "Mahjong Hourouki Classic (J) [b1].z64" crc 9BD30B4B )
+)
+
+game (
+	name "Mahjong Hourouki Classic (J) [b2]"
+	description "Mahjong Hourouki Classic (J) [b2]"
+	rom ( name "Mahjong Hourouki Classic (J) [b2].z64" crc FF6AFBFE )
+)
+
+game (
+	name "Mahjong Hourouki Classic (J) [b3]"
+	description "Mahjong Hourouki Classic (J) [b3]"
+	rom ( name "Mahjong Hourouki Classic (J) [b3].z64" crc DE57CA3C )
+)
+
+game (
+	name "Mahjong Master (J) [!]"
+	description "Mahjong Master (J) [!]"
+	rom ( name "Mahjong Master (J) [!].z64" crc B68D596F )
+)
+
+game (
+	name "Mahjong Master (J) [b1]"
+	description "Mahjong Master (J) [b1]"
+	rom ( name "Mahjong Master (J) [b1].z64" crc C993C7E5 )
+)
+
+game (
+	name "Mahjong Master (J) [b2]"
+	description "Mahjong Master (J) [b2]"
+	rom ( name "Mahjong Master (J) [b2].z64" crc 9BF6FA03 )
+)
+
+game (
+	name "Mahjong Master (J) [o1]"
+	description "Mahjong Master (J) [o1]"
+	rom ( name "Mahjong Master (J) [o1].z64" crc E4EFE0E0 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (E) [!]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (E) [!]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [!].z64" crc E08F7578 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (E) [b1]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (E) [b1]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [b1].z64" crc EC77AC54 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (E) [f1]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (E) [f1]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [f1].z64" crc A12EFECC )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (U) [!]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (U) [!]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [!].z64" crc 2EF1EA20 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (U) [b1]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (U) [b1]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b1].z64" crc 7AD4BBC9 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (U) [b2]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (U) [b2]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b2].z64" crc 3769A87D )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (U) [b3]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (U) [b3]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b3].z64" crc 7B200444 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr. (U) [f1]"
+	description "Major League Baseball Featuring Ken Griffey Jr. (U) [f1]"
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [f1].z64" crc 8AC7208C )
+)
+
+game (
+	name "Mario Golf (E) [!]"
+	description "Mario Golf (E) [!]"
+	rom ( name "Mario Golf (E) [!].z64" crc E5D723C7 )
+)
+
+game (
+	name "Mario Golf (E) [f1] (Z64-Save)"
+	description "Mario Golf (E) [f1] (Z64-Save)"
+	rom ( name "Mario Golf (E) [f1] (Z64-Save).z64" crc 804CF5C2 )
+)
+
+game (
+	name "Mario Golf (E) [f2] (Z64-Save)"
+	description "Mario Golf (E) [f2] (Z64-Save)"
+	rom ( name "Mario Golf (E) [f2] (Z64-Save).z64" crc 5451672F )
+)
+
+game (
+	name "Mario Golf (E) [h1C]"
+	description "Mario Golf (E) [h1C]"
+	rom ( name "Mario Golf (E) [h1C].z64" crc 2E71189B )
+)
+
+game (
+	name "Mario Golf (E) [o1]"
+	description "Mario Golf (E) [o1]"
+	rom ( name "Mario Golf (E) [o1].z64" crc A5071A77 )
+)
+
+game (
+	name "Mario Golf (E) [o1][h1C]"
+	description "Mario Golf (E) [o1][h1C]"
+	rom ( name "Mario Golf (E) [o1][h1C].z64" crc 1183B2CB )
+)
+
+game (
+	name "Mario Golf (U) [!]"
+	description "Mario Golf (U) [!]"
+	rom ( name "Mario Golf (U) [!].z64" crc 2D40ABB0 )
+)
+
+game (
+	name "Mario Golf (U) [b1]"
+	description "Mario Golf (U) [b1]"
+	rom ( name "Mario Golf (U) [b1].z64" crc 619F2D0E )
+)
+
+game (
+	name "Mario Golf (U) [b1][f1] (PAL)"
+	description "Mario Golf (U) [b1][f1] (PAL)"
+	rom ( name "Mario Golf (U) [b1][f1] (PAL).z64" crc BF7C03E5 )
+)
+
+game (
+	name "Mario Golf (U) [b2]"
+	description "Mario Golf (U) [b2]"
+	rom ( name "Mario Golf (U) [b2].z64" crc 353C3EE3 )
+)
+
+game (
+	name "Mario Golf (U) [f1] (PAL)"
+	description "Mario Golf (U) [f1] (PAL)"
+	rom ( name "Mario Golf (U) [f1] (PAL).z64" crc 6AC0859F )
+)
+
+game (
+	name "Mario Golf (U) [f2] (Z64-Save)"
+	description "Mario Golf (U) [f2] (Z64-Save)"
+	rom ( name "Mario Golf (U) [f2] (Z64-Save).z64" crc C705A039 )
+)
+
+game (
+	name "Mario Golf (U) [o2][h1C]"
+	description "Mario Golf (U) [o2][h1C]"
+	rom ( name "Mario Golf (U) [o2][h1C].z64" crc 2FC4C216 )
+)
+
+game (
+	name "Mario Golf (U) [t1]"
+	description "Mario Golf (U) [t1]"
+	rom ( name "Mario Golf (U) [t1].z64" crc 941E1852 )
+)
+
+game (
+	name "Mario Golf 64 (J) [!]"
+	description "Mario Golf 64 (J) [!]"
+	rom ( name "Mario Golf 64 (J) [!].z64" crc 911F179A )
+)
+
+game (
+	name "Mario Golf 64 (J) [b1]"
+	description "Mario Golf 64 (J) [b1]"
+	rom ( name "Mario Golf 64 (J) [b1].z64" crc 7C33129A )
+)
+
+game (
+	name "Mario Golf 64 (J) [b1][f1] (PAL)"
+	description "Mario Golf 64 (J) [b1][f1] (PAL)"
+	rom ( name "Mario Golf 64 (J) [b1][f1] (PAL).z64" crc 15632A1A )
+)
+
+game (
+	name "Mario Golf 64 (J) [b2]"
+	description "Mario Golf 64 (J) [b2]"
+	rom ( name "Mario Golf 64 (J) [b2].z64" crc C5995246 )
+)
+
+game (
+	name "Mario Golf 64 (J) [f1] (PAL)"
+	description "Mario Golf 64 (J) [f1] (PAL)"
+	rom ( name "Mario Golf 64 (J) [f1] (PAL).z64" crc BF6ECC62 )
+)
+
+game (
+	name "Mario Golf 64 (J) [o1]"
+	description "Mario Golf 64 (J) [o1]"
+	rom ( name "Mario Golf 64 (J) [o1].z64" crc BB03A1A6 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.0) (Super W00ting Hack)"
+	description "Mario Kart 64 (E) (V1.0) (Super W00ting Hack)"
+	rom ( name "Mario Kart 64 (E) (V1.0) (Super W00ting Hack).z64" crc 27546369 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.0) [!]"
+	description "Mario Kart 64 (E) (V1.0) [!]"
+	rom ( name "Mario Kart 64 (E) (V1.0) [!].z64" crc FAA6B083 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.0) [b1]"
+	description "Mario Kart 64 (E) (V1.0) [b1]"
+	rom ( name "Mario Kart 64 (E) (V1.0) [b1].z64" crc B0577C8A )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.0) [b2]"
+	description "Mario Kart 64 (E) (V1.0) [b2]"
+	rom ( name "Mario Kart 64 (E) (V1.0) [b2].z64" crc FF0EEE69 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.0) [T+Ita_Cattivik66]"
+	description "Mario Kart 64 (E) (V1.0) [T+Ita_Cattivik66]"
+	rom ( name "Mario Kart 64 (E) (V1.0) [T+Ita_Cattivik66].z64" crc D3811840 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.1) [!]"
+	description "Mario Kart 64 (E) (V1.1) [!]"
+	rom ( name "Mario Kart 64 (E) (V1.1) [!].z64" crc 0248F6C3 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.1) [o1]"
+	description "Mario Kart 64 (E) (V1.1) [o1]"
+	rom ( name "Mario Kart 64 (E) (V1.1) [o1].z64" crc B27A4098 )
+)
+
+game (
+	name "Mario Kart 64 (E) (V1.1) [T+Ita_Cattivik66][b1]"
+	description "Mario Kart 64 (E) (V1.1) [T+Ita_Cattivik66][b1]"
+	rom ( name "Mario Kart 64 (E) (V1.1) [T+Ita_Cattivik66][b1].z64" crc 89FAB579 )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.0) [!]"
+	description "Mario Kart 64 (J) (V1.0) [!]"
+	rom ( name "Mario Kart 64 (J) (V1.0) [!].z64" crc 5D9696DF )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.0) [b1]"
+	description "Mario Kart 64 (J) (V1.0) [b1]"
+	rom ( name "Mario Kart 64 (J) (V1.0) [b1].z64" crc 0653AF29 )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.0) [b2]"
+	description "Mario Kart 64 (J) (V1.0) [b2]"
+	rom ( name "Mario Kart 64 (J) (V1.0) [b2].z64" crc 97B054BA )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.0) [o1]"
+	description "Mario Kart 64 (J) (V1.0) [o1]"
+	rom ( name "Mario Kart 64 (J) (V1.0) [o1].z64" crc 2D84117A )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.0) [T+Ita_Cattivik66][b1]"
+	description "Mario Kart 64 (J) (V1.0) [T+Ita_Cattivik66][b1]"
+	rom ( name "Mario Kart 64 (J) (V1.0) [T+Ita_Cattivik66][b1].z64" crc 85631D8C )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.1) [!]"
+	description "Mario Kart 64 (J) (V1.1) [!]"
+	rom ( name "Mario Kart 64 (J) (V1.1) [!].z64" crc 6CED6472 )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.1) [b1]"
+	description "Mario Kart 64 (J) (V1.1) [b1]"
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1].z64" crc B3F6F8CC )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.1) [b1][f1] (PAL)"
+	description "Mario Kart 64 (J) (V1.1) [b1][f1] (PAL)"
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1][f1] (PAL).z64" crc 23CCD780 )
+)
+
+game (
+	name "Mario Kart 64 (J) (V1.1) [b1][T+Ita_Cattivik66]"
+	description "Mario Kart 64 (J) (V1.1) [b1][T+Ita_Cattivik66]"
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1][T+Ita_Cattivik66].z64" crc 9BDC5ACE )
+)
+
+game (
+	name "Mario Kart 64 (U) (Super W00ting Hack)"
+	description "Mario Kart 64 (U) (Super W00ting Hack)"
+	rom ( name "Mario Kart 64 (U) (Super W00ting Hack).z64" crc 87B17D90 )
+)
+
+game (
+	name "Mario Kart 64 (U) [!]"
+	description "Mario Kart 64 (U) [!]"
+	rom ( name "Mario Kart 64 (U) [!].z64" crc 434389C1 )
+)
+
+game (
+	name "Mario Kart 64 (U) [b1]"
+	description "Mario Kart 64 (U) [b1]"
+	rom ( name "Mario Kart 64 (U) [b1].z64" crc 9DED0AC7 )
+)
+
+game (
+	name "Mario Kart 64 (U) [b2]"
+	description "Mario Kart 64 (U) [b2]"
+	rom ( name "Mario Kart 64 (U) [b2].z64" crc C98E9D4A )
+)
+
+game (
+	name "Mario Kart 64 (U) [b3]"
+	description "Mario Kart 64 (U) [b3]"
+	rom ( name "Mario Kart 64 (U) [b3].z64" crc 08E55176 )
+)
+
+game (
+	name "Mario Kart 64 (U) [b4]"
+	description "Mario Kart 64 (U) [b4]"
+	rom ( name "Mario Kart 64 (U) [b4].z64" crc 8A325AF1 )
+)
+
+game (
+	name "Mario Kart 64 (U) [h1C]"
+	description "Mario Kart 64 (U) [h1C]"
+	rom ( name "Mario Kart 64 (U) [h1C].z64" crc 89654BA4 )
+)
+
+game (
+	name "Mario Kart 64 (U) [o1]"
+	description "Mario Kart 64 (U) [o1]"
+	rom ( name "Mario Kart 64 (U) [o1].z64" crc 166D8AF1 )
+)
+
+game (
+	name "Mario Kart 64 (U) [o2]"
+	description "Mario Kart 64 (U) [o2]"
+	rom ( name "Mario Kart 64 (U) [o2].z64" crc 98BD4147 )
+)
+
+game (
+	name "Mario Kart 64 (U) [T+Ita0.01_Cattivik66]"
+	description "Mario Kart 64 (U) [T+Ita0.01_Cattivik66]"
+	rom ( name "Mario Kart 64 (U) [T+Ita0.01_Cattivik66].z64" crc F638D5E2 )
+)
+
+game (
+	name "Mario Kart 64 (U) [T+Por1.0_Dr_X]"
+	description "Mario Kart 64 (U) [T+Por1.0_Dr_X]"
+	rom ( name "Mario Kart 64 (U) [T+Por1.0_Dr_X].z64" crc 32C5EC1E )
+)
+
+game (
+	name "Mario Kart 64 (U) [t1]"
+	description "Mario Kart 64 (U) [t1]"
+	rom ( name "Mario Kart 64 (U) [t1].z64" crc D6161D88 )
+)
+
+game (
+	name "Mario Kart 64 (U) [t2] (Course Cheat)"
+	description "Mario Kart 64 (U) [t2] (Course Cheat)"
+	rom ( name "Mario Kart 64 (U) [t2] (Course Cheat).z64" crc 5F053063 )
+)
+
+game (
+	name "Mario Kart 64 (U) [t3] (Star Cheat)"
+	description "Mario Kart 64 (U) [t3] (Star Cheat)"
+	rom ( name "Mario Kart 64 (U) [t3] (Star Cheat).z64" crc 799A7466 )
+)
+
+game (
+	name "Mario Kart 64 (U) [t4]"
+	description "Mario Kart 64 (U) [t4]"
+	rom ( name "Mario Kart 64 (U) [t4].z64" crc AA5F37A1 )
+)
+
+game (
+	name "Mario no Photopie (J) [!]"
+	description "Mario no Photopie (J) [!]"
+	rom ( name "Mario no Photopie (J) [!].z64" crc 1D69CA55 )
+)
+
+game (
+	name "Mario no Photopie (J) [a1]"
+	description "Mario no Photopie (J) [a1]"
+	rom ( name "Mario no Photopie (J) [a1].z64" crc 176B3683 )
+)
+
+game (
+	name "Mario Party (E) (M3) [!]"
+	description "Mario Party (E) (M3) [!]"
+	rom ( name "Mario Party (E) (M3) [!].z64" crc DA98A5D3 )
+)
+
+game (
+	name "Mario Party (E) (M3) [b1]"
+	description "Mario Party (E) (M3) [b1]"
+	rom ( name "Mario Party (E) (M3) [b1].z64" crc 41ACA890 )
+)
+
+game (
+	name "Mario Party (E) (M3) [h1C]"
+	description "Mario Party (E) (M3) [h1C]"
+	rom ( name "Mario Party (E) (M3) [h1C].z64" crc 7B899FAE )
+)
+
+game (
+	name "Mario Party (J) [!]"
+	description "Mario Party (J) [!]"
+	rom ( name "Mario Party (J) [!].z64" crc 4F1ADC7B )
+)
+
+game (
+	name "Mario Party (U) [!]"
+	description "Mario Party (U) [!]"
+	rom ( name "Mario Party (U) [!].z64" crc 4D60ABE5 )
+)
+
+game (
+	name "Mario Party (U) [f1] (PAL)"
+	description "Mario Party (U) [f1] (PAL)"
+	rom ( name "Mario Party (U) [f1] (PAL).z64" crc C154D3B3 )
+)
+
+game (
+	name "Mario Party 2 (E) (M5) [!]"
+	description "Mario Party 2 (E) (M5) [!]"
+	rom ( name "Mario Party 2 (E) (M5) [!].z64" crc DC00357A )
+)
+
+game (
+	name "Mario Party 2 (J) [!]"
+	description "Mario Party 2 (J) [!]"
+	rom ( name "Mario Party 2 (J) [!].z64" crc 7457B081 )
+)
+
+game (
+	name "Mario Party 2 (U) [!]"
+	description "Mario Party 2 (U) [!]"
+	rom ( name "Mario Party 2 (U) [!].z64" crc E58A1955 )
+)
+
+game (
+	name "Mario Party 2 (U) [f1] (PAL)"
+	description "Mario Party 2 (U) [f1] (PAL)"
+	rom ( name "Mario Party 2 (U) [f1] (PAL).z64" crc 08FFB2B3 )
+)
+
+game (
+	name "Mario Party 2 (U) [f2] (PAL)"
+	description "Mario Party 2 (U) [f2] (PAL)"
+	rom ( name "Mario Party 2 (U) [f2] (PAL).z64" crc 3677F1BC )
+)
+
+game (
+	name "Mario Party 3 (E) (M4) [!]"
+	description "Mario Party 3 (E) (M4) [!]"
+	rom ( name "Mario Party 3 (E) (M4) [!].z64" crc 813B13F2 )
+)
+
+game (
+	name "Mario Party 3 (J) [!]"
+	description "Mario Party 3 (J) [!]"
+	rom ( name "Mario Party 3 (J) [!].z64" crc 3FC04053 )
+)
+
+game (
+	name "Mario Party 3 (U) [!]"
+	description "Mario Party 3 (U) [!]"
+	rom ( name "Mario Party 3 (U) [!].z64" crc B7445DDC )
+)
+
+game (
+	name "Mario Party 3 (U) [f1]"
+	description "Mario Party 3 (U) [f1]"
+	rom ( name "Mario Party 3 (U) [f1].z64" crc E9A8DA8C )
+)
+
+game (
+	name "Mario Party 3 (U) [f2] (PAL)"
+	description "Mario Party 3 (U) [f2] (PAL)"
+	rom ( name "Mario Party 3 (U) [f2] (PAL).z64" crc 1E5A8F53 )
+)
+
+game (
+	name "Mario Party 3 (U) [f3]"
+	description "Mario Party 3 (U) [f3]"
+	rom ( name "Mario Party 3 (U) [f3].z64" crc 2CB2B136 )
+)
+
+game (
+	name "Mario Tennis (E) [!]"
+	description "Mario Tennis (E) [!]"
+	rom ( name "Mario Tennis (E) [!].z64" crc 29AA5DF4 )
+)
+
+game (
+	name "Mario Tennis (U) [!]"
+	description "Mario Tennis (U) [!]"
+	rom ( name "Mario Tennis (U) [!].z64" crc 4E9560F6 )
+)
+
+game (
+	name "Mario Tennis (U) [f1] (Save)"
+	description "Mario Tennis (U) [f1] (Save)"
+	rom ( name "Mario Tennis (U) [f1] (Save).z64" crc DA72F0D6 )
+)
+
+game (
+	name "Mario Tennis 64 (J) [!]"
+	description "Mario Tennis 64 (J) [!]"
+	rom ( name "Mario Tennis 64 (J) [!].z64" crc C665301D )
+)
+
+game (
+	name "Mario Tennis 64 (J) [f1] (Country Check)"
+	description "Mario Tennis 64 (J) [f1] (Country Check)"
+	rom ( name "Mario Tennis 64 (J) [f1] (Country Check).z64" crc 3653DB6A )
+)
+
+game (
+	name "Mega Man 64 (U) [!]"
+	description "Mega Man 64 (U) [!]"
+	rom ( name "Mega Man 64 (U) [!].z64" crc 1BFC71F0 )
+)
+
+game (
+	name "Mega Man 64 (U) [t1][f1] (PAL-NTSC)"
+	description "Mega Man 64 (U) [t1][f1] (PAL-NTSC)"
+	rom ( name "Mega Man 64 (U) [t1][f1] (PAL-NTSC).z64" crc F09701AE )
+)
+
+game (
+	name "Rockman Dash (J) [!]"
+	description "Rockman Dash (J) [!]"
+	rom ( name "Rockman Dash (J) [!].z64" crc 61EAEE83 )
+)
+
+game (
+	name "Mia Hamm Soccer 64 (U) (M2) [!]"
+	description "Mia Hamm Soccer 64 (U) (M2) [!]"
+	rom ( name "Mia Hamm Soccer 64 (U) (M2) [!].z64" crc 2DB3D3D6 )
+)
+
+game (
+	name "Michael Owens WLS 2000 (E) [!]"
+	description "Michael Owens WLS 2000 (E) [!]"
+	rom ( name "Michael Owens WLS 2000 (E) [!].z64" crc BB680CBE )
+)
+
+game (
+	name "Michael Owens WLS 2000 (E) [b1]"
+	description "Michael Owens WLS 2000 (E) [b1]"
+	rom ( name "Michael Owens WLS 2000 (E) [b1].z64" crc 71684224 )
+)
+
+game (
+	name "Michael Owens WLS 2000 (E) [b2]"
+	description "Michael Owens WLS 2000 (E) [b2]"
+	rom ( name "Michael Owens WLS 2000 (E) [b2].z64" crc 1DBC7C2D )
+)
+
+game (
+	name "Michael Owens WLS 2000 (E) [f1] (NTSC)"
+	description "Michael Owens WLS 2000 (E) [f1] (NTSC)"
+	rom ( name "Michael Owens WLS 2000 (E) [f1] (NTSC).z64" crc 6B919894 )
+)
+
+game (
+	name "RTL World League Soccer 2000 (G) [!]"
+	description "RTL World League Soccer 2000 (G) [!]"
+	rom ( name "RTL World League Soccer 2000 (G) [!].z64" crc 0A17DA7B )
+)
+
+game (
+	name "RTL World League Soccer 2000 (G) [f1] (NTSC)"
+	description "RTL World League Soccer 2000 (G) [f1] (NTSC)"
+	rom ( name "RTL World League Soccer 2000 (G) [f1] (NTSC).z64" crc A05D2F1F )
+)
+
+game (
+	name "RTL World League Soccer 2000 (G) [f1][o1]"
+	description "RTL World League Soccer 2000 (G) [f1][o1]"
+	rom ( name "RTL World League Soccer 2000 (G) [f1][o1].z64" crc 7ABE5F0A )
+)
+
+game (
+	name "Telefoot Soccer 2000 (F) [!]"
+	description "Telefoot Soccer 2000 (F) [!]"
+	rom ( name "Telefoot Soccer 2000 (F) [!].z64" crc 7BD20931 )
+)
+
+game (
+	name "Telefoot Soccer 2000 (F) [b1]"
+	description "Telefoot Soccer 2000 (F) [b1]"
+	rom ( name "Telefoot Soccer 2000 (F) [b1].z64" crc 86D4084B )
+)
+
+game (
+	name "Telefoot Soccer 2000 (F) [f1] (NTSC)"
+	description "Telefoot Soccer 2000 (F) [f1] (NTSC)"
+	rom ( name "Telefoot Soccer 2000 (F) [f1] (NTSC).z64" crc 9E830833 )
+)
+
+game (
+	name "Mickey no Racing Challenge USA (J) [!]"
+	description "Mickey no Racing Challenge USA (J) [!]"
+	rom ( name "Mickey no Racing Challenge USA (J) [!].z64" crc 1AECFC56 )
+)
+
+game (
+	name "Mickey's Speedway USA (E) (M5) [!]"
+	description "Mickey's Speedway USA (E) (M5) [!]"
+	rom ( name "Mickey's Speedway USA (E) (M5) [!].z64" crc 0AE51EA5 )
+)
+
+game (
+	name "Mickey's Speedway USA (U) [!]"
+	description "Mickey's Speedway USA (U) [!]"
+	rom ( name "Mickey's Speedway USA (U) [!].z64" crc 2D4F8F1B )
+)
+
+game (
+	name "Mickey's Speedway USA (U) [t1]"
+	description "Mickey's Speedway USA (U) [t1]"
+	rom ( name "Mickey's Speedway USA (U) [t1].z64" crc 24858A92 )
+)
+
+game (
+	name "Micro Machines 64 Turbo (E) (M5) [!]"
+	description "Micro Machines 64 Turbo (E) (M5) [!]"
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [!].z64" crc 10B9FF1F )
+)
+
+game (
+	name "Micro Machines 64 Turbo (E) (M5) [b1]"
+	description "Micro Machines 64 Turbo (E) (M5) [b1]"
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1].z64" crc 5DFE09A6 )
+)
+
+game (
+	name "Micro Machines 64 Turbo (E) (M5) [b1][f1] (NTSC)"
+	description "Micro Machines 64 Turbo (E) (M5) [b1][f1] (NTSC)"
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1][f1] (NTSC).z64" crc 33B1CD80 )
+)
+
+game (
+	name "Micro Machines 64 Turbo (E) (M5) [t1]"
+	description "Micro Machines 64 Turbo (E) (M5) [t1]"
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [t1].z64" crc 314EFF98 )
+)
+
+game (
+	name "Micro Machines 64 Turbo (U) [!]"
+	description "Micro Machines 64 Turbo (U) [!]"
+	rom ( name "Micro Machines 64 Turbo (U) [!].z64" crc A62A2763 )
+)
+
+game (
+	name "Micro Machines 64 Turbo (U) [a1][!]"
+	description "Micro Machines 64 Turbo (U) [a1][!]"
+	rom ( name "Micro Machines 64 Turbo (U) [a1][!].z64" crc 9AD74CEF )
+)
+
+game (
+	name "Micro Machines 64 Turbo (U) [b1]"
+	description "Micro Machines 64 Turbo (U) [b1]"
+	rom ( name "Micro Machines 64 Turbo (U) [b1].z64" crc AADF1A8B )
+)
+
+game (
+	name "Micro Machines 64 Turbo (U) [t1]"
+	description "Micro Machines 64 Turbo (U) [t1]"
+	rom ( name "Micro Machines 64 Turbo (U) [t1].z64" crc B598C181 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [!]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [!]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [!].z64" crc E5C1FEDC )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [b1]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [b1]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b1].z64" crc 79F93575 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [b2]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [b2]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b2].z64" crc DC4E9F77 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [o1]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [o1]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1].z64" crc 3ADB627E )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [o1][t1]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [o1][t1]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1][t1].z64" crc 6BBD79F0 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [t1]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [t1]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t1].z64" crc 9F3BC746 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [t2]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [t2]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2].z64" crc A3612C92 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1 (U) [t2][b1]"
+	description "Midway's Greatest Arcade Hits Volume 1 (U) [t2][b1]"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2][b1].z64" crc 29C63281 )
+)
+
+game (
+	name "Mike Piazza's Strike Zone (U) [!]"
+	description "Mike Piazza's Strike Zone (U) [!]"
+	rom ( name "Mike Piazza's Strike Zone (U) [!].z64" crc CC253CAB )
+)
+
+game (
+	name "Mike Piazza's Strike Zone (U) [h1C]"
+	description "Mike Piazza's Strike Zone (U) [h1C]"
+	rom ( name "Mike Piazza's Strike Zone (U) [h1C].z64" crc 759DF18E )
+)
+
+game (
+	name "Mike Piazza's Strike Zone (U) [h2C]"
+	description "Mike Piazza's Strike Zone (U) [h2C]"
+	rom ( name "Mike Piazza's Strike Zone (U) [h2C].z64" crc FA1A59CE )
+)
+
+game (
+	name "Mike Piazza's Strike Zone (U) [h3C]"
+	description "Mike Piazza's Strike Zone (U) [h3C]"
+	rom ( name "Mike Piazza's Strike Zone (U) [h3C].z64" crc 8374C598 )
+)
+
+game (
+	name "Milo's Astro Lanes (E) [!]"
+	description "Milo's Astro Lanes (E) [!]"
+	rom ( name "Milo's Astro Lanes (E) [!].z64" crc C08CE624 )
+)
+
+game (
+	name "Milo's Astro Lanes (E) [o1]"
+	description "Milo's Astro Lanes (E) [o1]"
+	rom ( name "Milo's Astro Lanes (E) [o1].z64" crc 8172B1BD )
+)
+
+game (
+	name "Milo's Astro Lanes (E) [o2]"
+	description "Milo's Astro Lanes (E) [o2]"
+	rom ( name "Milo's Astro Lanes (E) [o2].z64" crc 360FD523 )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [!]"
+	description "Milo's Astro Lanes (U) [!]"
+	rom ( name "Milo's Astro Lanes (U) [!].z64" crc 172FCA97 )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [b1]"
+	description "Milo's Astro Lanes (U) [b1]"
+	rom ( name "Milo's Astro Lanes (U) [b1].z64" crc 3E898BB3 )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [h1C]"
+	description "Milo's Astro Lanes (U) [h1C]"
+	rom ( name "Milo's Astro Lanes (U) [h1C].z64" crc 81A075A0 )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [h2C]"
+	description "Milo's Astro Lanes (U) [h2C]"
+	rom ( name "Milo's Astro Lanes (U) [h2C].z64" crc 0FEDF73A )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [o1]"
+	description "Milo's Astro Lanes (U) [o1]"
+	rom ( name "Milo's Astro Lanes (U) [o1].z64" crc DABCC4EE )
+)
+
+game (
+	name "Milo's Astro Lanes (U) [o1][b1]"
+	description "Milo's Astro Lanes (U) [o1][b1]"
+	rom ( name "Milo's Astro Lanes (U) [o1][b1].z64" crc F31A85CA )
+)
+
+game (
+	name "Mischief Makers (E) [!]"
+	description "Mischief Makers (E) [!]"
+	rom ( name "Mischief Makers (E) [!].z64" crc 68A4F072 )
+)
+
+game (
+	name "Mischief Makers (E) [b1]"
+	description "Mischief Makers (E) [b1]"
+	rom ( name "Mischief Makers (E) [b1].z64" crc 3C6D6432 )
+)
+
+game (
+	name "Mischief Makers (U) [!]"
+	description "Mischief Makers (U) [!]"
+	rom ( name "Mischief Makers (U) [!].z64" crc 7D222D3F )
+)
+
+game (
+	name "Mischief Makers (U) [b1]"
+	description "Mischief Makers (U) [b1]"
+	rom ( name "Mischief Makers (U) [b1].z64" crc 8A8E05F2 )
+)
+
+game (
+	name "Mischief Makers (U) [o1]"
+	description "Mischief Makers (U) [o1]"
+	rom ( name "Mischief Makers (U) [o1].z64" crc 908A11D3 )
+)
+
+game (
+	name "Yuke Yuke!! Trouble Makers (J) [!]"
+	description "Yuke Yuke!! Trouble Makers (J) [!]"
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [!].z64" crc B69D3068 )
+)
+
+game (
+	name "Yuke Yuke!! Trouble Makers (J) [a1]"
+	description "Yuke Yuke!! Trouble Makers (J) [a1]"
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [a1].z64" crc E4117EB5 )
+)
+
+game (
+	name "Yuke Yuke!! Trouble Makers (J) [b1]"
+	description "Yuke Yuke!! Trouble Makers (J) [b1]"
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [b1].z64" crc A408B93B )
+)
+
+game (
+	name "Yuke Yuke!! Trouble Makers (J) [o1]"
+	description "Yuke Yuke!! Trouble Makers (J) [o1]"
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [o1].z64" crc 758B4189 )
+)
+
+game (
+	name "Mission Impossible (E) [!]"
+	description "Mission Impossible (E) [!]"
+	rom ( name "Mission Impossible (E) [!].z64" crc 2C7131D6 )
+)
+
+game (
+	name "Mission Impossible (E) [b1]"
+	description "Mission Impossible (E) [b1]"
+	rom ( name "Mission Impossible (E) [b1].z64" crc 6B082B2C )
+)
+
+game (
+	name "Mission Impossible (F) [!]"
+	description "Mission Impossible (F) [!]"
+	rom ( name "Mission Impossible (F) [!].z64" crc 282A350D )
+)
+
+game (
+	name "Mission Impossible (F) [b1]"
+	description "Mission Impossible (F) [b1]"
+	rom ( name "Mission Impossible (F) [b1].z64" crc 94C43451 )
+)
+
+game (
+	name "Mission Impossible (F) [b2]"
+	description "Mission Impossible (F) [b2]"
+	rom ( name "Mission Impossible (F) [b2].z64" crc 748EBD5B )
+)
+
+game (
+	name "Mission Impossible (G) [!]"
+	description "Mission Impossible (G) [!]"
+	rom ( name "Mission Impossible (G) [!].z64" crc 67C30A2D )
+)
+
+game (
+	name "Mission Impossible (I) [!]"
+	description "Mission Impossible (I) [!]"
+	rom ( name "Mission Impossible (I) [!].z64" crc 2D789D98 )
+)
+
+game (
+	name "Mission Impossible (I) [f1] (NTSC)"
+	description "Mission Impossible (I) [f1] (NTSC)"
+	rom ( name "Mission Impossible (I) [f1] (NTSC).z64" crc B8DA029F )
+)
+
+game (
+	name "Mission Impossible (S) [!]"
+	description "Mission Impossible (S) [!]"
+	rom ( name "Mission Impossible (S) [!].z64" crc EBB060DC )
+)
+
+game (
+	name "Mission Impossible (S) [f1] (NTSC)"
+	description "Mission Impossible (S) [f1] (NTSC)"
+	rom ( name "Mission Impossible (S) [f1] (NTSC).z64" crc E7141756 )
+)
+
+game (
+	name "Mission Impossible (U) [!]"
+	description "Mission Impossible (U) [!]"
+	rom ( name "Mission Impossible (U) [!].z64" crc 3677A8B8 )
+)
+
+game (
+	name "Mission Impossible (U) [b1]"
+	description "Mission Impossible (U) [b1]"
+	rom ( name "Mission Impossible (U) [b1].z64" crc F9B45A0E )
+)
+
+game (
+	name "Mission Impossible (U) [b2]"
+	description "Mission Impossible (U) [b2]"
+	rom ( name "Mission Impossible (U) [b2].z64" crc 20530AFE )
+)
+
+game (
+	name "Mission Impossible (U) [f1] (PAL)"
+	description "Mission Impossible (U) [f1] (PAL)"
+	rom ( name "Mission Impossible (U) [f1] (PAL).z64" crc 8E9CBB30 )
+)
+
+game (
+	name "Mission Impossible (U) [t1]"
+	description "Mission Impossible (U) [t1]"
+	rom ( name "Mission Impossible (U) [t1].z64" crc 37D8EBF1 )
+)
+
+game (
+	name "Monaco Grand Prix (U) [!]"
+	description "Monaco Grand Prix (U) [!]"
+	rom ( name "Monaco Grand Prix (U) [!].z64" crc E2BBEAC1 )
+)
+
+game (
+	name "Monaco Grand Prix (U) [f1] (PAL)"
+	description "Monaco Grand Prix (U) [f1] (PAL)"
+	rom ( name "Monaco Grand Prix (U) [f1] (PAL).z64" crc E84AC777 )
+)
+
+game (
+	name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!]"
+	description "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!]"
+	rom ( name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!].z64" crc 3F5E5830 )
+)
+
+game (
+	name "Racing Simulation 2 (G) [!]"
+	description "Racing Simulation 2 (G) [!]"
+	rom ( name "Racing Simulation 2 (G) [!].z64" crc BA73A7E4 )
+)
+
+game (
+	name "Racing Simulation 2 (G) [h1C]"
+	description "Racing Simulation 2 (G) [h1C]"
+	rom ( name "Racing Simulation 2 (G) [h1C].z64" crc 3C85A70B )
+)
+
+game (
+	name "Monopoly (U) [!]"
+	description "Monopoly (U) [!]"
+	rom ( name "Monopoly (U) [!].z64" crc C8CAD8F6 )
+)
+
+game (
+	name "Monopoly (U) [f1] (PAL)"
+	description "Monopoly (U) [f1] (PAL)"
+	rom ( name "Monopoly (U) [f1] (PAL).z64" crc 35FD44BD )
+)
+
+game (
+	name "Monster Truck Madness 64 (E) (M5) [!]"
+	description "Monster Truck Madness 64 (E) (M5) [!]"
+	rom ( name "Monster Truck Madness 64 (E) (M5) [!].z64" crc 4731DF5C )
+)
+
+game (
+	name "Monster Truck Madness 64 (E) (M5) [f1] (NTSC)"
+	description "Monster Truck Madness 64 (E) (M5) [f1] (NTSC)"
+	rom ( name "Monster Truck Madness 64 (E) (M5) [f1] (NTSC).z64" crc 1F63FCF2 )
+)
+
+game (
+	name "Monster Truck Madness 64 (U) [!]"
+	description "Monster Truck Madness 64 (U) [!]"
+	rom ( name "Monster Truck Madness 64 (U) [!].z64" crc 3FD0604D )
+)
+
+game (
+	name "Monster Truck Madness 64 (U) [t1]"
+	description "Monster Truck Madness 64 (U) [t1]"
+	rom ( name "Monster Truck Madness 64 (U) [t1].z64" crc 30502368 )
+)
+
+game (
+	name "Morita Shougi 64 (J) [!]"
+	description "Morita Shougi 64 (J) [!]"
+	rom ( name "Morita Shougi 64 (J) [!].z64" crc 88C83511 )
+)
+
+game (
+	name "Mortal Kombat 4 (E) [!]"
+	description "Mortal Kombat 4 (E) [!]"
+	rom ( name "Mortal Kombat 4 (E) [!].z64" crc 635ADECA )
+)
+
+game (
+	name "Mortal Kombat 4 (E) [h1C]"
+	description "Mortal Kombat 4 (E) [h1C]"
+	rom ( name "Mortal Kombat 4 (E) [h1C].z64" crc B1F79756 )
+)
+
+game (
+	name "Mortal Kombat 4 (E) [t1] (Hit Anywhere)"
+	description "Mortal Kombat 4 (E) [t1] (Hit Anywhere)"
+	rom ( name "Mortal Kombat 4 (E) [t1] (Hit Anywhere).z64" crc 7EA0D2F1 )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [!]"
+	description "Mortal Kombat 4 (U) [!]"
+	rom ( name "Mortal Kombat 4 (U) [!].z64" crc B7F46516 )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [b1]"
+	description "Mortal Kombat 4 (U) [b1]"
+	rom ( name "Mortal Kombat 4 (U) [b1].z64" crc 1F5466B1 )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [b2]"
+	description "Mortal Kombat 4 (U) [b2]"
+	rom ( name "Mortal Kombat 4 (U) [b2].z64" crc E44B4A50 )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [b3]"
+	description "Mortal Kombat 4 (U) [b3]"
+	rom ( name "Mortal Kombat 4 (U) [b3].z64" crc 5629D9DC )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [h1C]"
+	description "Mortal Kombat 4 (U) [h1C]"
+	rom ( name "Mortal Kombat 4 (U) [h1C].z64" crc 65592C8A )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [t1]"
+	description "Mortal Kombat 4 (U) [t1]"
+	rom ( name "Mortal Kombat 4 (U) [t1].z64" crc F0411EE7 )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [t1][f1] (PAL)"
+	description "Mortal Kombat 4 (U) [t1][f1] (PAL)"
+	rom ( name "Mortal Kombat 4 (U) [t1][f1] (PAL).z64" crc EB90E97C )
+)
+
+game (
+	name "Mortal Kombat 4 (U) [t2] (Hit Anywhere)"
+	description "Mortal Kombat 4 (U) [t2] (Hit Anywhere)"
+	rom ( name "Mortal Kombat 4 (U) [t2] (Hit Anywhere).z64" crc BA5F7ABA )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (E) [!]"
+	description "Mortal Kombat Mythologies - Sub-Zero (E) [!]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [!].z64" crc EA21015A )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (E) [h1C]"
+	description "Mortal Kombat Mythologies - Sub-Zero (E) [h1C]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [h1C].z64" crc D974B2D5 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (E) [t1] (Endless Ice)"
+	description "Mortal Kombat Mythologies - Sub-Zero (E) [t1] (Endless Ice)"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [t1] (Endless Ice).z64" crc 9ECFFDED )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [!]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [!]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [!].z64" crc 51A07FD9 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [b1]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [b1]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b1].z64" crc 07A1666D )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [b2]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [b2]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b2].z64" crc 03E5E2E8 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [b3]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [b3]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b3].z64" crc AB1092FB )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [f1]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [f1]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f1].z64" crc E74E2821 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [f3] (PAL)"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [f3] (PAL)"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f3] (PAL).z64" crc D47F76DD )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [h1C]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [h1C]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h1C].z64" crc 796DE304 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [h2C]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [h2C]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h2C].z64" crc 7F31E315 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [o1]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [o1]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [o1].z64" crc 56397C81 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [t1]"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [t1]"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t1].z64" crc 751A2B19 )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero (U) [t2] (Endless Ice)"
+	description "Mortal Kombat Mythologies - Sub-Zero (U) [t2] (Endless Ice)"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t2] (Endless Ice).z64" crc 85E4462B )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [!]"
+	description "Mortal Kombat Trilogy (E) [!]"
+	rom ( name "Mortal Kombat Trilogy (E) [!].z64" crc BC04C62F )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [b1]"
+	description "Mortal Kombat Trilogy (E) [b1]"
+	rom ( name "Mortal Kombat Trilogy (E) [b1].z64" crc 05C20375 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [h1C]"
+	description "Mortal Kombat Trilogy (E) [h1C]"
+	rom ( name "Mortal Kombat Trilogy (E) [h1C].z64" crc 110585FB )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [o1]"
+	description "Mortal Kombat Trilogy (E) [o1]"
+	rom ( name "Mortal Kombat Trilogy (E) [o1].z64" crc F28ED18E )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t1] (Hit Anywhere)"
+	description "Mortal Kombat Trilogy (E) [t1] (Hit Anywhere)"
+	rom ( name "Mortal Kombat Trilogy (E) [t1] (Hit Anywhere).z64" crc 942BE6CA )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t2] (All Attacks Hurt P1)"
+	description "Mortal Kombat Trilogy (E) [t2] (All Attacks Hurt P1)"
+	rom ( name "Mortal Kombat Trilogy (E) [t2] (All Attacks Hurt P1).z64" crc CA1756B0 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t3] (All Attacks Hurt P2)"
+	description "Mortal Kombat Trilogy (E) [t3] (All Attacks Hurt P2)"
+	rom ( name "Mortal Kombat Trilogy (E) [t3] (All Attacks Hurt P2).z64" crc 2A0538C8 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t4] (Hyper Mode)"
+	description "Mortal Kombat Trilogy (E) [t4] (Hyper Mode)"
+	rom ( name "Mortal Kombat Trilogy (E) [t4] (Hyper Mode).z64" crc BF347C36 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t5] (2x Aggressor)"
+	description "Mortal Kombat Trilogy (E) [t5] (2x Aggressor)"
+	rom ( name "Mortal Kombat Trilogy (E) [t5] (2x Aggressor).z64" crc 865FDED9 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (E) [t6] (P1 Invincible)"
+	description "Mortal Kombat Trilogy (E) [t6] (P1 Invincible)"
+	rom ( name "Mortal Kombat Trilogy (E) [t6] (P1 Invincible).z64" crc 7FA1C269 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [!]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [!]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [!].z64" crc 50A99D60 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [b1]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [b1]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b1].z64" crc A2D599E0 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [b2]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [b2]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b2].z64" crc 04B7A1C2 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [b3]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [b3]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b3].z64" crc 1CD3F9AA )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [b4]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [b4]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b4].z64" crc 0CC21088 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [b5]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [b5]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b5].z64" crc F66D6FC0 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [h1C]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [h1C]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h1C].z64" crc 8A9FB090 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [h2C]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [h2C]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h2C].z64" crc 241EBD3A )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [o1]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [o1]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1].z64" crc 8848CCD8 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [o1][h1C]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [o1][h1C]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h1C].z64" crc 80ACF17B )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [o1][h2C]"
+	description "Mortal Kombat Trilogy (U) (V1.0) [o1][h2C]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h2C].z64" crc 5E190B89 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t1] (Hit Anywhere)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t1] (Hit Anywhere)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t1] (Hit Anywhere).z64" crc E89A5E5D )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t2] (All Attacks Hurt P1)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t2] (All Attacks Hurt P1)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t2] (All Attacks Hurt P1).z64" crc 9D5A1F62 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t3] (All Attacks Hurt P2)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t3] (All Attacks Hurt P2)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t3] (All Attacks Hurt P2).z64" crc 214E58D3 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t4] (Hyper Mode)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t4] (Hyper Mode)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t4] (Hyper Mode).z64" crc 776A74C3 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t5] (2x Aggressor)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t5] (2x Aggressor)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t5] (2x Aggressor).z64" crc F760EC0C )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.0) [t6] (P1 Invincible)"
+	description "Mortal Kombat Trilogy (U) (V1.0) [t6] (P1 Invincible)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t6] (P1 Invincible).z64" crc 6AB8D104 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [!]"
+	description "Mortal Kombat Trilogy (U) (V1.2) [!]"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [!].z64" crc 0F323D00 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere).z64" crc 2DF614F4 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t2] (All Attacks Hurt P1)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t2] (All Attacks Hurt P1)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t2] (All Attacks Hurt P1).z64" crc F73189DB )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t3] (All Attacks Hurt P2)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t3] (All Attacks Hurt P2)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t3] (All Attacks Hurt P2).z64" crc 4A75DBEF )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t4] (Hyper Mode)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t4] (Hyper Mode)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t4] (Hyper Mode).z64" crc C39464A6 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t5] (2x Aggressor)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t5] (2x Aggressor)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t5] (2x Aggressor).z64" crc 846A9593 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (U) (V1.2) [t6] (P1 Invincible)"
+	description "Mortal Kombat Trilogy (U) (V1.2) [t6] (P1 Invincible)"
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t6] (P1 Invincible).z64" crc 58CA16A1 )
+)
+
+game (
+	name "Rape Kombat Trilogy Beta1 (Mortal Kombat Hack)"
+	description "Rape Kombat Trilogy Beta1 (Mortal Kombat Hack)"
+	rom ( name "Rape Kombat Trilogy Beta1 (Mortal Kombat Hack).z64" crc 9E6BB93D )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [!]"
+	description "MRC - Multi Racing Championship (E) (M3) [!]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [!].z64" crc BC966B10 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [b1]"
+	description "MRC - Multi Racing Championship (E) (M3) [b1]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b1].z64" crc 2A7F6B3A )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [b2]"
+	description "MRC - Multi Racing Championship (E) (M3) [b2]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b2].z64" crc 32DF39A3 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [b3]"
+	description "MRC - Multi Racing Championship (E) (M3) [b3]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b3].z64" crc 2E030F26 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [h1C]"
+	description "MRC - Multi Racing Championship (E) (M3) [h1C]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [h1C].z64" crc 4FACA987 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (E) (M3) [o1]"
+	description "MRC - Multi Racing Championship (E) (M3) [o1]"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [o1].z64" crc 89D3AB70 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [!]"
+	description "MRC - Multi Racing Championship (J) [!]"
+	rom ( name "MRC - Multi Racing Championship (J) [!].z64" crc BEA43300 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [b1]"
+	description "MRC - Multi Racing Championship (J) [b1]"
+	rom ( name "MRC - Multi Racing Championship (J) [b1].z64" crc CC67323B )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [b2]"
+	description "MRC - Multi Racing Championship (J) [b2]"
+	rom ( name "MRC - Multi Racing Championship (J) [b2].z64" crc 772F3E51 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [b3]"
+	description "MRC - Multi Racing Championship (J) [b3]"
+	rom ( name "MRC - Multi Racing Championship (J) [b3].z64" crc E75E186D )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [b4]"
+	description "MRC - Multi Racing Championship (J) [b4]"
+	rom ( name "MRC - Multi Racing Championship (J) [b4].z64" crc A0CB84F1 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (J) [b5]"
+	description "MRC - Multi Racing Championship (J) [b5]"
+	rom ( name "MRC - Multi Racing Championship (J) [b5].z64" crc 5D3113EB )
+)
+
+game (
+	name "MRC - Multi Racing Championship (U) [!]"
+	description "MRC - Multi Racing Championship (U) [!]"
+	rom ( name "MRC - Multi Racing Championship (U) [!].z64" crc 1DC1C812 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (U) [b1]"
+	description "MRC - Multi Racing Championship (U) [b1]"
+	rom ( name "MRC - Multi Racing Championship (U) [b1].z64" crc F5A9068F )
+)
+
+game (
+	name "MRC - Multi Racing Championship (U) [b2]"
+	description "MRC - Multi Racing Championship (U) [b2]"
+	rom ( name "MRC - Multi Racing Championship (U) [b2].z64" crc 0D186242 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (U) [b3]"
+	description "MRC - Multi Racing Championship (U) [b3]"
+	rom ( name "MRC - Multi Racing Championship (U) [b3].z64" crc 1F56A884 )
+)
+
+game (
+	name "MRC - Multi Racing Championship (U) [o1]"
+	description "MRC - Multi Racing Championship (U) [o1]"
+	rom ( name "MRC - Multi Racing Championship (U) [o1].z64" crc E406A452 )
+)
+
+game (
+	name "Ms. Pac-Man - Maze Madness (U) [!]"
+	description "Ms. Pac-Man - Maze Madness (U) [!]"
+	rom ( name "Ms. Pac-Man - Maze Madness (U) [!].z64" crc E34C7060 )
+)
+
+game (
+	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b1]"
+	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b1]"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b1].z64" crc 4C40EB14 )
+)
+
+game (
+	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b2]"
+	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b2]"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b2].z64" crc 911B3CE5 )
+)
+
+game (
+	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C]"
+	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C]"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C].z64" crc 95C9DA86 )
+)
+
+game (
+	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C][t1]"
+	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C][t1]"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C][t1].z64" crc C059BEF1 )
+)
+
+game (
+	name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J)"
+	description "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J)"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J).z64" crc 2E91EFC9 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (E) [!]"
+	description "Mystical Ninja Starring Goemon (E) [!]"
+	rom ( name "Mystical Ninja Starring Goemon (E) [!].z64" crc 3BD9059A )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (E) [b1]"
+	description "Mystical Ninja Starring Goemon (E) [b1]"
+	rom ( name "Mystical Ninja Starring Goemon (E) [b1].z64" crc 266B1F56 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (E) [h1C]"
+	description "Mystical Ninja Starring Goemon (E) [h1C]"
+	rom ( name "Mystical Ninja Starring Goemon (E) [h1C].z64" crc FC486459 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (E) [t1]"
+	description "Mystical Ninja Starring Goemon (E) [t1]"
+	rom ( name "Mystical Ninja Starring Goemon (E) [t1].z64" crc 7A0C2406 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (U) [!]"
+	description "Mystical Ninja Starring Goemon (U) [!]"
+	rom ( name "Mystical Ninja Starring Goemon (U) [!].z64" crc 4180C296 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (U) [h1C]"
+	description "Mystical Ninja Starring Goemon (U) [h1C]"
+	rom ( name "Mystical Ninja Starring Goemon (U) [h1C].z64" crc 8611A355 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (U) [t1]"
+	description "Mystical Ninja Starring Goemon (U) [t1]"
+	rom ( name "Mystical Ninja Starring Goemon (U) [t1].z64" crc FFDA5261 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (U) [t1][h2C]"
+	description "Mystical Ninja Starring Goemon (U) [t1][h2C]"
+	rom ( name "Mystical Ninja Starring Goemon (U) [t1][h2C].z64" crc D5280782 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon (U) [t2]"
+	description "Mystical Ninja Starring Goemon (U) [t2]"
+	rom ( name "Mystical Ninja Starring Goemon (U) [t2].z64" crc 48A584DE )
+)
+
+game (
+	name "N64DD IPLROM (J)"
+	description "N64DD IPLROM (J)"
+	rom ( name "N64DD IPLROM (J).n64" crc 7F933CE2 )
+)
+
+game (
+	name "Hyper Olympics Nagano 64 (J) [!]"
+	description "Hyper Olympics Nagano 64 (J) [!]"
+	rom ( name "Hyper Olympics Nagano 64 (J) [!].z64" crc C1EA5D33 )
+)
+
+game (
+	name "Hyper Olympics Nagano 64 (J) [b1]"
+	description "Hyper Olympics Nagano 64 (J) [b1]"
+	rom ( name "Hyper Olympics Nagano 64 (J) [b1].z64" crc B6BB1BF7 )
+)
+
+game (
+	name "Hyper Olympics Nagano 64 (J) [b2]"
+	description "Hyper Olympics Nagano 64 (J) [b2]"
+	rom ( name "Hyper Olympics Nagano 64 (J) [b2].z64" crc F1865C1B )
+)
+
+game (
+	name "Hyper Olympics Nagano 64 (J) [b3]"
+	description "Hyper Olympics Nagano 64 (J) [b3]"
+	rom ( name "Hyper Olympics Nagano 64 (J) [b3].z64" crc 8D9CA6E8 )
+)
+
+game (
+	name "Hyper Olympics Nagano 64 (J) [o1]"
+	description "Hyper Olympics Nagano 64 (J) [o1]"
+	rom ( name "Hyper Olympics Nagano 64 (J) [o1].z64" crc E50EDE25 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (E) [!]"
+	description "Nagano Winter Olympics '98 (E) [!]"
+	rom ( name "Nagano Winter Olympics '98 (E) [!].z64" crc C44DE11C )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (E) [h1C]"
+	description "Nagano Winter Olympics '98 (E) [h1C]"
+	rom ( name "Nagano Winter Olympics '98 (E) [h1C].z64" crc 9BFBA6C3 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (E) [o1]"
+	description "Nagano Winter Olympics '98 (E) [o1]"
+	rom ( name "Nagano Winter Olympics '98 (E) [o1].z64" crc 13FB3B46 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [!]"
+	description "Nagano Winter Olympics '98 (U) [!]"
+	rom ( name "Nagano Winter Olympics '98 (U) [!].z64" crc EE8288D4 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [b1]"
+	description "Nagano Winter Olympics '98 (U) [b1]"
+	rom ( name "Nagano Winter Olympics '98 (U) [b1].z64" crc 2034B668 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [b2]"
+	description "Nagano Winter Olympics '98 (U) [b2]"
+	rom ( name "Nagano Winter Olympics '98 (U) [b2].z64" crc CFE4F4AD )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [h1C]"
+	description "Nagano Winter Olympics '98 (U) [h1C]"
+	rom ( name "Nagano Winter Olympics '98 (U) [h1C].z64" crc B70FA5B8 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [o1]"
+	description "Nagano Winter Olympics '98 (U) [o1]"
+	rom ( name "Nagano Winter Olympics '98 (U) [o1].z64" crc BC27F178 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [o2]"
+	description "Nagano Winter Olympics '98 (U) [o2]"
+	rom ( name "Nagano Winter Olympics '98 (U) [o2].z64" crc 026DB3C7 )
+)
+
+game (
+	name "Nagano Winter Olympics '98 (U) [T+Ita_HRG]"
+	description "Nagano Winter Olympics '98 (U) [T+Ita_HRG]"
+	rom ( name "Nagano Winter Olympics '98 (U) [T+Ita_HRG].z64" crc 24838711 )
+)
+
+game (
+	name "Namco Museum 64 (U) [!]"
+	description "Namco Museum 64 (U) [!]"
+	rom ( name "Namco Museum 64 (U) [!].z64" crc CE361F92 )
+)
+
+game (
+	name "Namco Museum 64 (U) [f1] (PAL)"
+	description "Namco Museum 64 (U) [f1] (PAL)"
+	rom ( name "Namco Museum 64 (U) [f1] (PAL).z64" crc A4EC448B )
+)
+
+game (
+	name "Namco Museum 64 (U) [o1]"
+	description "Namco Museum 64 (U) [o1]"
+	rom ( name "Namco Museum 64 (U) [o1].z64" crc 843D5802 )
+)
+
+game (
+	name "Namco Museum 64 (U) [o1][f1] (PAL)"
+	description "Namco Museum 64 (U) [o1][f1] (PAL)"
+	rom ( name "Namco Museum 64 (U) [o1][f1] (PAL).z64" crc D76C2FBF )
+)
+
+game (
+	name "Namco Museum 64 (U) [t1]"
+	description "Namco Museum 64 (U) [t1]"
+	rom ( name "Namco Museum 64 (U) [t1].z64" crc E3CC9EA8 )
+)
+
+game (
+	name "NASCAR 2000 (U) [!]"
+	description "NASCAR 2000 (U) [!]"
+	rom ( name "NASCAR 2000 (U) [!].z64" crc 02BF7C2D )
+)
+
+game (
+	name "NASCAR 2000 (U) [f1] (PAL)"
+	description "NASCAR 2000 (U) [f1] (PAL)"
+	rom ( name "NASCAR 2000 (U) [f1] (PAL).z64" crc 83BDD48A )
+)
+
+game (
+	name "NASCAR 99 (E) (M3) [!]"
+	description "NASCAR 99 (E) (M3) [!]"
+	rom ( name "NASCAR 99 (E) (M3) [!].z64" crc 76E79CEA )
+)
+
+game (
+	name "NASCAR 99 (E) (M3) [h1C]"
+	description "NASCAR 99 (E) (M3) [h1C]"
+	rom ( name "NASCAR 99 (E) (M3) [h1C].z64" crc 5E44766F )
+)
+
+game (
+	name "NASCAR 99 (U) [!]"
+	description "NASCAR 99 (U) [!]"
+	rom ( name "NASCAR 99 (U) [!].z64" crc 3D8EB950 )
+)
+
+game (
+	name "NASCAR 99 (U) [b1]"
+	description "NASCAR 99 (U) [b1]"
+	rom ( name "NASCAR 99 (U) [b1].z64" crc 982B5CCD )
+)
+
+game (
+	name "NASCAR 99 (U) [b2]"
+	description "NASCAR 99 (U) [b2]"
+	rom ( name "NASCAR 99 (U) [b2].z64" crc 28DF02B4 )
+)
+
+game (
+	name "NASCAR 99 (U) [b3]"
+	description "NASCAR 99 (U) [b3]"
+	rom ( name "NASCAR 99 (U) [b3].z64" crc 1F3774E6 )
+)
+
+game (
+	name "NASCAR 99 (U) [f1] (PAL)"
+	description "NASCAR 99 (U) [f1] (PAL)"
+	rom ( name "NASCAR 99 (U) [f1] (PAL).z64" crc B1183FE4 )
+)
+
+game (
+	name "NASCAR 99 (U) [o1]"
+	description "NASCAR 99 (U) [o1]"
+	rom ( name "NASCAR 99 (U) [o1].z64" crc A948F28C )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!]"
+	description "NBA Courtside 2 - Featuring Kobe Bryant (U) [!]"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!].z64" crc A7CC4CE2 )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL)"
+	description "NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL)"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL).z64" crc 39154EB0 )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f2]"
+	description "NBA Courtside 2 - Featuring Kobe Bryant (U) [f2]"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f2].z64" crc 81F2B85B )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI]"
+	description "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI]"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI].z64" crc 4F3E62DC )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI][f1] (PAL)"
+	description "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI][f1] (PAL)"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI][f1] (PAL).z64" crc 13BC6D87 )
+)
+
+game (
+	name "NBA Hangtime (E) [!]"
+	description "NBA Hangtime (E) [!]"
+	rom ( name "NBA Hangtime (E) [!].z64" crc 7E6D00AE )
+)
+
+game (
+	name "NBA Hangtime (E) [h1C]"
+	description "NBA Hangtime (E) [h1C]"
+	rom ( name "NBA Hangtime (E) [h1C].z64" crc 69328DF0 )
+)
+
+game (
+	name "NBA Hangtime (U) [!]"
+	description "NBA Hangtime (U) [!]"
+	rom ( name "NBA Hangtime (U) [!].z64" crc 714CF532 )
+)
+
+game (
+	name "NBA Hangtime (U) [b1]"
+	description "NBA Hangtime (U) [b1]"
+	rom ( name "NBA Hangtime (U) [b1].z64" crc 0F2126A5 )
+)
+
+game (
+	name "NBA Hangtime (U) [b2]"
+	description "NBA Hangtime (U) [b2]"
+	rom ( name "NBA Hangtime (U) [b2].z64" crc 0027D41F )
+)
+
+game (
+	name "NBA Hangtime (U) [b3]"
+	description "NBA Hangtime (U) [b3]"
+	rom ( name "NBA Hangtime (U) [b3].z64" crc 975DD6CB )
+)
+
+game (
+	name "NBA Hangtime (U) [f1] (PAL)"
+	description "NBA Hangtime (U) [f1] (PAL)"
+	rom ( name "NBA Hangtime (U) [f1] (PAL).z64" crc E7E8EF6C )
+)
+
+game (
+	name "NBA Hangtime (U) [o1]"
+	description "NBA Hangtime (U) [o1]"
+	rom ( name "NBA Hangtime (U) [o1].z64" crc 2590C84E )
+)
+
+game (
+	name "NBA Hangtime (U) [o1][f1]"
+	description "NBA Hangtime (U) [o1][f1]"
+	rom ( name "NBA Hangtime (U) [o1][f1].z64" crc 0EB4EBA0 )
+)
+
+game (
+	name "NBA In the Zone '98 (J) [!]"
+	description "NBA In the Zone '98 (J) [!]"
+	rom ( name "NBA In the Zone '98 (J) [!].z64" crc AED2700A )
+)
+
+game (
+	name "NBA In the Zone '98 (J) [o1]"
+	description "NBA In the Zone '98 (J) [o1]"
+	rom ( name "NBA In the Zone '98 (J) [o1].z64" crc 6E35773E )
+)
+
+game (
+	name "NBA In the Zone '98 (J) [o2]"
+	description "NBA In the Zone '98 (J) [o2]"
+	rom ( name "NBA In the Zone '98 (J) [o2].z64" crc 093EC0FB )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [!]"
+	description "NBA In the Zone '98 (U) [!]"
+	rom ( name "NBA In the Zone '98 (U) [!].z64" crc A245D737 )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [b1]"
+	description "NBA In the Zone '98 (U) [b1]"
+	rom ( name "NBA In the Zone '98 (U) [b1].z64" crc 8B5DC438 )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [b2]"
+	description "NBA In the Zone '98 (U) [b2]"
+	rom ( name "NBA In the Zone '98 (U) [b2].z64" crc DBE6ECCD )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [b3]"
+	description "NBA In the Zone '98 (U) [b3]"
+	rom ( name "NBA In the Zone '98 (U) [b3].z64" crc FEF7E360 )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [h1C]"
+	description "NBA In the Zone '98 (U) [h1C]"
+	rom ( name "NBA In the Zone '98 (U) [h1C].z64" crc 6F4D6051 )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [h2C]"
+	description "NBA In the Zone '98 (U) [h2C]"
+	rom ( name "NBA In the Zone '98 (U) [h2C].z64" crc 878878EA )
+)
+
+game (
+	name "NBA In the Zone '98 (U) [o1]"
+	description "NBA In the Zone '98 (U) [o1]"
+	rom ( name "NBA In the Zone '98 (U) [o1].z64" crc D30DE54F )
+)
+
+game (
+	name "NBA Pro 98 (E) [!]"
+	description "NBA Pro 98 (E) [!]"
+	rom ( name "NBA Pro 98 (E) [!].z64" crc 04B75CCC )
+)
+
+game (
+	name "NBA In the Zone '99 (U) [!]"
+	description "NBA In the Zone '99 (U) [!]"
+	rom ( name "NBA In the Zone '99 (U) [!].z64" crc EAB083B8 )
+)
+
+game (
+	name "NBA In the Zone 2 (J) [!]"
+	description "NBA In the Zone 2 (J) [!]"
+	rom ( name "NBA In the Zone 2 (J) [!].z64" crc 41093B73 )
+)
+
+game (
+	name "NBA Pro 99 (E) [!]"
+	description "NBA Pro 99 (E) [!]"
+	rom ( name "NBA Pro 99 (E) [!].z64" crc 588E60E8 )
+)
+
+game (
+	name "NBA Pro 99 (E) [f1] (NTSC)"
+	description "NBA Pro 99 (E) [f1] (NTSC)"
+	rom ( name "NBA Pro 99 (E) [f1] (NTSC).z64" crc DFD7B539 )
+)
+
+game (
+	name "NBA In the Zone 2000 (E) [!]"
+	description "NBA In the Zone 2000 (E) [!]"
+	rom ( name "NBA In the Zone 2000 (E) [!].z64" crc A4973197 )
+)
+
+game (
+	name "NBA In the Zone 2000 (E) [h1C]"
+	description "NBA In the Zone 2000 (E) [h1C]"
+	rom ( name "NBA In the Zone 2000 (E) [h1C].z64" crc 9E6568A5 )
+)
+
+game (
+	name "NBA In the Zone 2000 (U) [!]"
+	description "NBA In the Zone 2000 (U) [!]"
+	rom ( name "NBA In the Zone 2000 (U) [!].z64" crc CBB4B730 )
+)
+
+game (
+	name "NBA In the Zone 2000 (U) [f1] (PAL)"
+	description "NBA In the Zone 2000 (U) [f1] (PAL)"
+	rom ( name "NBA In the Zone 2000 (U) [f1] (PAL).z64" crc E5956E4C )
+)
+
+game (
+	name "NBA Jam 2000 (E) [!]"
+	description "NBA Jam 2000 (E) [!]"
+	rom ( name "NBA Jam 2000 (E) [!].z64" crc 9F95485E )
+)
+
+game (
+	name "NBA Jam 2000 (U) [!]"
+	description "NBA Jam 2000 (U) [!]"
+	rom ( name "NBA Jam 2000 (U) [!].z64" crc 163DADF9 )
+)
+
+game (
+	name "NBA Jam 2000 (U) [f1] (PAL)"
+	description "NBA Jam 2000 (U) [f1] (PAL)"
+	rom ( name "NBA Jam 2000 (U) [f1] (PAL).z64" crc 18914B4F )
+)
+
+game (
+	name "NBA Jam 99 (E) [!]"
+	description "NBA Jam 99 (E) [!]"
+	rom ( name "NBA Jam 99 (E) [!].z64" crc 90E4275B )
+)
+
+game (
+	name "NBA Jam 99 (E) [h1C]"
+	description "NBA Jam 99 (E) [h1C]"
+	rom ( name "NBA Jam 99 (E) [h1C].z64" crc F76D0149 )
+)
+
+game (
+	name "NBA Jam 99 (U) [!]"
+	description "NBA Jam 99 (U) [!]"
+	rom ( name "NBA Jam 99 (U) [!].z64" crc 559CD6B1 )
+)
+
+game (
+	name "NBA Jam 99 (U) [b1]"
+	description "NBA Jam 99 (U) [b1]"
+	rom ( name "NBA Jam 99 (U) [b1].z64" crc AF017390 )
+)
+
+game (
+	name "NBA Jam 99 (U) [f1] (PAL)"
+	description "NBA Jam 99 (U) [f1] (PAL)"
+	rom ( name "NBA Jam 99 (U) [f1] (PAL).z64" crc BABDB2B6 )
+)
+
+game (
+	name "NBA Live 2000 (E) (M4) [!]"
+	description "NBA Live 2000 (E) (M4) [!]"
+	rom ( name "NBA Live 2000 (E) (M4) [!].z64" crc 0E4B944C )
+)
+
+game (
+	name "NBA Live 2000 (U) (M4) [!]"
+	description "NBA Live 2000 (U) (M4) [!]"
+	rom ( name "NBA Live 2000 (U) (M4) [!].z64" crc 7C3BC95E )
+)
+
+game (
+	name "NBA Live 99 (E) (M5) [!]"
+	description "NBA Live 99 (E) (M5) [!]"
+	rom ( name "NBA Live 99 (E) (M5) [!].z64" crc A316DF37 )
+)
+
+game (
+	name "NBA Live 99 (U) (M5) [!]"
+	description "NBA Live 99 (U) (M5) [!]"
+	rom ( name "NBA Live 99 (U) (M5) [!].z64" crc 9BE0A7AC )
+)
+
+game (
+	name "NBA Live 99 (U) (M5) [b1]"
+	description "NBA Live 99 (U) (M5) [b1]"
+	rom ( name "NBA Live 99 (U) (M5) [b1].z64" crc F5CA13C9 )
+)
+
+game (
+	name "NBA Live 99 (U) (M5) [b2]"
+	description "NBA Live 99 (U) (M5) [b2]"
+	rom ( name "NBA Live 99 (U) (M5) [b2].z64" crc EEA737E2 )
+)
+
+game (
+	name "NBA Live 99 (U) (M5) [b3]"
+	description "NBA Live 99 (U) (M5) [b3]"
+	rom ( name "NBA Live 99 (U) (M5) [b3].z64" crc 2544B74B )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC (U) [!]"
+	description "NBA Showtime - NBA on NBC (U) [!]"
+	rom ( name "NBA Showtime - NBA on NBC (U) [!].z64" crc A4E378F4 )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC (U) [f1] (Country Check)"
+	description "NBA Showtime - NBA on NBC (U) [f1] (Country Check)"
+	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (Country Check).z64" crc A8EF96B3 )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC (U) [f1] (PAL)"
+	description "NBA Showtime - NBA on NBC (U) [f1] (PAL)"
+	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (PAL).z64" crc 2D2A5374 )
+)
+
+game (
+	name "Neon Genesis Evangelion (J) [!]"
+	description "Neon Genesis Evangelion (J) [!]"
+	rom ( name "Neon Genesis Evangelion (J) [!].z64" crc A10A86AF )
+)
+
+game (
+	name "Neon Genesis Evangelion (J) [b1]"
+	description "Neon Genesis Evangelion (J) [b1]"
+	rom ( name "Neon Genesis Evangelion (J) [b1].z64" crc 50C86364 )
+)
+
+game (
+	name "Neon Genesis Evangelion (J) [b2]"
+	description "Neon Genesis Evangelion (J) [b2]"
+	rom ( name "Neon Genesis Evangelion (J) [b2].z64" crc 960855F8 )
+)
+
+game (
+	name "Neon Genesis Evangelion (J) [b3]"
+	description "Neon Genesis Evangelion (J) [b3]"
+	rom ( name "Neon Genesis Evangelion (J) [b3].z64" crc 283BA9BA )
+)
+
+game (
+	name "Neon Genesis Evangelion (J) [f1] (PAL)"
+	description "Neon Genesis Evangelion (J) [f1] (PAL)"
+	rom ( name "Neon Genesis Evangelion (J) [f1] (PAL).z64" crc E718D433 )
+)
+
+game (
+	name "New Tetris, The (E) [!]"
+	description "New Tetris, The (E) [!]"
+	rom ( name "New Tetris, The (E) [!].z64" crc 983263D7 )
+)
+
+game (
+	name "New Tetris, The (U) [!]"
+	description "New Tetris, The (U) [!]"
+	rom ( name "New Tetris, The (U) [!].z64" crc 528A07FA )
+)
+
+game (
+	name "New Tetris, The (U) [f1] (PAL)"
+	description "New Tetris, The (U) [f1] (PAL)"
+	rom ( name "New Tetris, The (U) [f1] (PAL).z64" crc 335530E4 )
+)
+
+game (
+	name "New Tetris, The (U) [f2] (PAL)"
+	description "New Tetris, The (U) [f2] (PAL)"
+	rom ( name "New Tetris, The (U) [f2] (PAL).z64" crc D9242D9F )
+)
+
+game (
+	name "New Tetris, The (U) [f3] (PAL)"
+	description "New Tetris, The (U) [f3] (PAL)"
+	rom ( name "New Tetris, The (U) [f3] (PAL).z64" crc 2B5CAE1E )
+)
+
+game (
+	name "Tetris 64 (J) [!]"
+	description "Tetris 64 (J) [!]"
+	rom ( name "Tetris 64 (J) [!].z64" crc F128CD17 )
+)
+
+game (
+	name "Tetris 64 (J) [b1]"
+	description "Tetris 64 (J) [b1]"
+	rom ( name "Tetris 64 (J) [b1].z64" crc 4D282F22 )
+)
+
+game (
+	name "Tetris 64 (J) [b2]"
+	description "Tetris 64 (J) [b2]"
+	rom ( name "Tetris 64 (J) [b2].z64" crc 17050B7D )
+)
+
+game (
+	name "Tetris 64 (J) [T+Ita]"
+	description "Tetris 64 (J) [T+Ita]"
+	rom ( name "Tetris 64 (J) [T+Ita].z64" crc AD0D86D9 )
+)
+
+game (
+	name "NFL Blitz (U) [!]"
+	description "NFL Blitz (U) [!]"
+	rom ( name "NFL Blitz (U) [!].z64" crc 9BCD670F )
+)
+
+game (
+	name "NFL Blitz (U) [f1] (PAL)"
+	description "NFL Blitz (U) [f1] (PAL)"
+	rom ( name "NFL Blitz (U) [f1] (PAL).z64" crc ADFDB71E )
+)
+
+game (
+	name "NFL Blitz - Special Edition (U) [!]"
+	description "NFL Blitz - Special Edition (U) [!]"
+	rom ( name "NFL Blitz - Special Edition (U) [!].z64" crc 5D1907F7 )
+)
+
+game (
+	name "NFL Blitz 2000 (U) [!]"
+	description "NFL Blitz 2000 (U) [!]"
+	rom ( name "NFL Blitz 2000 (U) [!].z64" crc 7F471773 )
+)
+
+game (
+	name "NFL Blitz 2000 (U) [f1] (PAL)"
+	description "NFL Blitz 2000 (U) [f1] (PAL)"
+	rom ( name "NFL Blitz 2000 (U) [f1] (PAL).z64" crc CFA472F3 )
+)
+
+game (
+	name "NFL Blitz 2001 (U) [!]"
+	description "NFL Blitz 2001 (U) [!]"
+	rom ( name "NFL Blitz 2001 (U) [!].z64" crc 18EEB41B )
+)
+
+game (
+	name "NFL Blitz 2001 (U) [f1] (PAL-NTSC)"
+	description "NFL Blitz 2001 (U) [f1] (PAL-NTSC)"
+	rom ( name "NFL Blitz 2001 (U) [f1] (PAL-NTSC).z64" crc 02012098 )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (E) [!]"
+	description "NFL Quarterback Club 2000 (E) [!]"
+	rom ( name "NFL Quarterback Club 2000 (E) [!].z64" crc CEEF5C29 )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (U) [!]"
+	description "NFL Quarterback Club 2000 (U) [!]"
+	rom ( name "NFL Quarterback Club 2000 (U) [!].z64" crc 8F54F999 )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (U) [b1]"
+	description "NFL Quarterback Club 2000 (U) [b1]"
+	rom ( name "NFL Quarterback Club 2000 (U) [b1].z64" crc 1A7B61BF )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (U) [b2]"
+	description "NFL Quarterback Club 2000 (U) [b2]"
+	rom ( name "NFL Quarterback Club 2000 (U) [b2].z64" crc FFF3B2DF )
+)
+
+game (
+	name "NFL Quarterback Club 2001 (U) [!]"
+	description "NFL Quarterback Club 2001 (U) [!]"
+	rom ( name "NFL Quarterback Club 2001 (U) [!].z64" crc 6D849E17 )
+)
+
+game (
+	name "NFL Quarterback Club 98 (E) [!]"
+	description "NFL Quarterback Club 98 (E) [!]"
+	rom ( name "NFL Quarterback Club 98 (E) [!].z64" crc 34A21417 )
+)
+
+game (
+	name "NFL Quarterback Club 98 (E) [o1]"
+	description "NFL Quarterback Club 98 (E) [o1]"
+	rom ( name "NFL Quarterback Club 98 (E) [o1].z64" crc 4DA5B881 )
+)
+
+game (
+	name "NFL Quarterback Club 98 (U) [!]"
+	description "NFL Quarterback Club 98 (U) [!]"
+	rom ( name "NFL Quarterback Club 98 (U) [!].z64" crc ABF0E8F2 )
+)
+
+game (
+	name "NFL Quarterback Club 98 (U) [b1]"
+	description "NFL Quarterback Club 98 (U) [b1]"
+	rom ( name "NFL Quarterback Club 98 (U) [b1].z64" crc A34D7669 )
+)
+
+game (
+	name "NFL Quarterback Club 98 (U) [o1]"
+	description "NFL Quarterback Club 98 (U) [o1]"
+	rom ( name "NFL Quarterback Club 98 (U) [o1].z64" crc 8244762B )
+)
+
+game (
+	name "NFL Quarterback Club 99 (E) [!]"
+	description "NFL Quarterback Club 99 (E) [!]"
+	rom ( name "NFL Quarterback Club 99 (E) [!].z64" crc F688BDF3 )
+)
+
+game (
+	name "NFL Quarterback Club 99 (E) [b1]"
+	description "NFL Quarterback Club 99 (E) [b1]"
+	rom ( name "NFL Quarterback Club 99 (E) [b1].z64" crc 579B3A20 )
+)
+
+game (
+	name "NFL Quarterback Club 99 (U) [!]"
+	description "NFL Quarterback Club 99 (U) [!]"
+	rom ( name "NFL Quarterback Club 99 (U) [!].z64" crc 44496B26 )
+)
+
+game (
+	name "NHL 99 (E) [!]"
+	description "NHL 99 (E) [!]"
+	rom ( name "NHL 99 (E) [!].z64" crc F3B2AA4D )
+)
+
+game (
+	name "NHL 99 (U) [!]"
+	description "NHL 99 (U) [!]"
+	rom ( name "NHL 99 (U) [!].z64" crc E5DF2AFE )
+)
+
+game (
+	name "NHL Blades of Steel '99 (U) [!]"
+	description "NHL Blades of Steel '99 (U) [!]"
+	rom ( name "NHL Blades of Steel '99 (U) [!].z64" crc 1EE678FE )
+)
+
+game (
+	name "NHL Blades of Steel '99 (U) [f1] (PAL)"
+	description "NHL Blades of Steel '99 (U) [f1] (PAL)"
+	rom ( name "NHL Blades of Steel '99 (U) [f1] (PAL).z64" crc E8BC286A )
+)
+
+game (
+	name "NHL Pro 99 (E) [!]"
+	description "NHL Pro 99 (E) [!]"
+	rom ( name "NHL Pro 99 (E) [!].z64" crc E272867E )
+)
+
+game (
+	name "NHL Pro 99 (E) [o1]"
+	description "NHL Pro 99 (E) [o1]"
+	rom ( name "NHL Pro 99 (E) [o1].z64" crc AF94245E )
+)
+
+game (
+	name "NHL Breakaway 98 (E) [!]"
+	description "NHL Breakaway 98 (E) [!]"
+	rom ( name "NHL Breakaway 98 (E) [!].z64" crc 8C0C9669 )
+)
+
+game (
+	name "NHL Breakaway 98 (E) [f1] (NTSC)"
+	description "NHL Breakaway 98 (E) [f1] (NTSC)"
+	rom ( name "NHL Breakaway 98 (E) [f1] (NTSC).z64" crc 3618BBA7 )
+)
+
+game (
+	name "NHL Breakaway 98 (E) [h1C]"
+	description "NHL Breakaway 98 (E) [h1C]"
+	rom ( name "NHL Breakaway 98 (E) [h1C].z64" crc ED786754 )
+)
+
+game (
+	name "NHL Breakaway 98 (E) [o1]"
+	description "NHL Breakaway 98 (E) [o1]"
+	rom ( name "NHL Breakaway 98 (E) [o1].z64" crc 02FADDCA )
+)
+
+game (
+	name "NHL Breakaway 98 (E) [o1][h1C]"
+	description "NHL Breakaway 98 (E) [o1][h1C]"
+	rom ( name "NHL Breakaway 98 (E) [o1][h1C].z64" crc E9E248FE )
+)
+
+game (
+	name "NHL Breakaway 98 (U) [!]"
+	description "NHL Breakaway 98 (U) [!]"
+	rom ( name "NHL Breakaway 98 (U) [!].z64" crc 49D86C00 )
+)
+
+game (
+	name "NHL Breakaway 98 (U) [h1C]"
+	description "NHL Breakaway 98 (U) [h1C]"
+	rom ( name "NHL Breakaway 98 (U) [h1C].z64" crc B3DCBBB8 )
+)
+
+game (
+	name "NHL Breakaway 98 (U) [o1]"
+	description "NHL Breakaway 98 (U) [o1]"
+	rom ( name "NHL Breakaway 98 (U) [o1].z64" crc 4C866C4D )
+)
+
+game (
+	name "NHL Breakaway 98 (U) [o1][h1C]"
+	description "NHL Breakaway 98 (U) [o1][h1C]"
+	rom ( name "NHL Breakaway 98 (U) [o1][h1C].z64" crc F21257C9 )
+)
+
+game (
+	name "NHL Breakaway 99 (E) [!]"
+	description "NHL Breakaway 99 (E) [!]"
+	rom ( name "NHL Breakaway 99 (E) [!].z64" crc 572060E0 )
+)
+
+game (
+	name "NHL Breakaway 99 (E) [b1]"
+	description "NHL Breakaway 99 (E) [b1]"
+	rom ( name "NHL Breakaway 99 (E) [b1].z64" crc 8612C050 )
+)
+
+game (
+	name "NHL Breakaway 99 (U) [!]"
+	description "NHL Breakaway 99 (U) [!]"
+	rom ( name "NHL Breakaway 99 (U) [!].z64" crc 75F75B9D )
+)
+
+game (
+	name "NHL Breakaway 99 (U) [b1]"
+	description "NHL Breakaway 99 (U) [b1]"
+	rom ( name "NHL Breakaway 99 (U) [b1].z64" crc 1F962087 )
+)
+
+game (
+	name "NHL Breakaway 99 (U) [b2]"
+	description "NHL Breakaway 99 (U) [b2]"
+	rom ( name "NHL Breakaway 99 (U) [b2].z64" crc 8287F822 )
+)
+
+game (
+	name "Nightmare Creatures (U) [!]"
+	description "Nightmare Creatures (U) [!]"
+	rom ( name "Nightmare Creatures (U) [!].z64" crc 6A1EB795 )
+)
+
+game (
+	name "Nightmare Creatures (U) [b1]"
+	description "Nightmare Creatures (U) [b1]"
+	rom ( name "Nightmare Creatures (U) [b1].z64" crc D10DB6B6 )
+)
+
+game (
+	name "Nightmare Creatures (U) [b2]"
+	description "Nightmare Creatures (U) [b2]"
+	rom ( name "Nightmare Creatures (U) [b2].z64" crc ABE329E1 )
+)
+
+game (
+	name "Nightmare Creatures (U) [t1]"
+	description "Nightmare Creatures (U) [t1]"
+	rom ( name "Nightmare Creatures (U) [t1].z64" crc 82CE76B5 )
+)
+
+game (
+	name "Nightmare Creatures (U) [t2]"
+	description "Nightmare Creatures (U) [t2]"
+	rom ( name "Nightmare Creatures (U) [t2].z64" crc EC39285D )
+)
+
+game (
+	name "Nintama Rantarou 64 Game Gallery (J) [!]"
+	description "Nintama Rantarou 64 Game Gallery (J) [!]"
+	rom ( name "Nintama Rantarou 64 Game Gallery (J) [!].z64" crc 8C7C2DCA )
+)
+
+game (
+	name "Nuclear Strike 64 (E) (M2) [!]"
+	description "Nuclear Strike 64 (E) (M2) [!]"
+	rom ( name "Nuclear Strike 64 (E) (M2) [!].z64" crc 9AFBFCAF )
+)
+
+game (
+	name "Nuclear Strike 64 (E) (M2) [h1C]"
+	description "Nuclear Strike 64 (E) (M2) [h1C]"
+	rom ( name "Nuclear Strike 64 (E) (M2) [h1C].z64" crc 7B1479A9 )
+)
+
+game (
+	name "Nuclear Strike 64 (G) [!]"
+	description "Nuclear Strike 64 (G) [!]"
+	rom ( name "Nuclear Strike 64 (G) [!].z64" crc 0916AB13 )
+)
+
+game (
+	name "Nuclear Strike 64 (U) [!]"
+	description "Nuclear Strike 64 (U) [!]"
+	rom ( name "Nuclear Strike 64 (U) [!].z64" crc D7467294 )
+)
+
+game (
+	name "Nuclear Strike 64 (U) [b1]"
+	description "Nuclear Strike 64 (U) [b1]"
+	rom ( name "Nuclear Strike 64 (U) [b1].z64" crc CE1F9EC3 )
+)
+
+game (
+	name "Nuclear Strike 64 (U) [f1] (PAL)"
+	description "Nuclear Strike 64 (U) [f1] (PAL)"
+	rom ( name "Nuclear Strike 64 (U) [f1] (PAL).z64" crc 484F91ED )
+)
+
+game (
+	name "Nuclear Strike 64 (U) [t1]"
+	description "Nuclear Strike 64 (U) [t1]"
+	rom ( name "Nuclear Strike 64 (U) [t1].z64" crc A9206EB3 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [!]"
+	description "Nushi Tsuri 64 (J) [!]"
+	rom ( name "Nushi Tsuri 64 (J) [!].z64" crc A6800EC0 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [b1]"
+	description "Nushi Tsuri 64 (J) [b1]"
+	rom ( name "Nushi Tsuri 64 (J) [b1].z64" crc 01FE5AE4 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [b2]"
+	description "Nushi Tsuri 64 (J) [b2]"
+	rom ( name "Nushi Tsuri 64 (J) [b2].z64" crc 22DBDD94 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [b3]"
+	description "Nushi Tsuri 64 (J) [b3]"
+	rom ( name "Nushi Tsuri 64 (J) [b3].z64" crc D5F95BA3 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [b4]"
+	description "Nushi Tsuri 64 (J) [b4]"
+	rom ( name "Nushi Tsuri 64 (J) [b4].z64" crc 979068B4 )
+)
+
+game (
+	name "Nushi Tsuri 64 (J) [b5]"
+	description "Nushi Tsuri 64 (J) [b5]"
+	rom ( name "Nushi Tsuri 64 (J) [b5].z64" crc 7220EFE0 )
+)
+
+game (
+	name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!]"
+	description "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!]"
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!].z64" crc F0BCD1CE )
+)
+
+game (
+	name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b1]"
+	description "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b1]"
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b1].z64" crc C6C43A7B )
+)
+
+game (
+	name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b2]"
+	description "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b2]"
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b2].z64" crc EE4263AE )
+)
+
+game (
+	name "O.D.T. (E) (M5) [!]"
+	description "O.D.T. (E) (M5) [!]"
+	rom ( name "O.D.T. (E) (M5) [!].z64" crc 7B870026 )
+)
+
+game (
+	name "O.D.T. (U) (M3) [!]"
+	description "O.D.T. (U) (M3) [!]"
+	rom ( name "O.D.T. (U) (M3) [!].z64" crc 1D4A8659 )
+)
+
+game (
+	name "Off Road Challenge (E) [!]"
+	description "Off Road Challenge (E) [!]"
+	rom ( name "Off Road Challenge (E) [!].z64" crc D9FE9EE7 )
+)
+
+game (
+	name "Off Road Challenge (E) [b1]"
+	description "Off Road Challenge (E) [b1]"
+	rom ( name "Off Road Challenge (E) [b1].z64" crc D91A7ED5 )
+)
+
+game (
+	name "Off Road Challenge (E) [b2]"
+	description "Off Road Challenge (E) [b2]"
+	rom ( name "Off Road Challenge (E) [b2].z64" crc 2F9D6B8E )
+)
+
+game (
+	name "Off Road Challenge (U) [!]"
+	description "Off Road Challenge (U) [!]"
+	rom ( name "Off Road Challenge (U) [!].z64" crc 1A45C5AB )
+)
+
+game (
+	name "Off Road Challenge (U) [b1]"
+	description "Off Road Challenge (U) [b1]"
+	rom ( name "Off Road Challenge (U) [b1].z64" crc DD2DC258 )
+)
+
+game (
+	name "Off Road Challenge (U) [b2]"
+	description "Off Road Challenge (U) [b2]"
+	rom ( name "Off Road Challenge (U) [b2].z64" crc A7B1EC20 )
+)
+
+game (
+	name "Off Road Challenge (U) [t1]"
+	description "Off Road Challenge (U) [t1]"
+	rom ( name "Off Road Challenge (U) [t1].z64" crc C5119E5A )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!]"
+	description "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!]"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!].z64" crc 845B8711 )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1]"
+	description "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1]"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1].z64" crc BE2AE208 )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1][o1]"
+	description "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1][o1]"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1][o1].z64" crc 27EA3320 )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b2]"
+	description "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b2]"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b2].z64" crc 330A2C9F )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber (U) [!]"
+	description "Ogre Battle 64 - Person of Lordly Caliber (U) [!]"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (U) [!].z64" crc A05AEA85 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (E) (M4) [!]"
+	description "Olympic Hockey Nagano '98 (E) (M4) [!]"
+	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [!].z64" crc 5A805C2E )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (E) (M4) [h1C]"
+	description "Olympic Hockey Nagano '98 (E) (M4) [h1C]"
+	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [h1C].z64" crc 0BF6AD1F )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (J) [!]"
+	description "Olympic Hockey Nagano '98 (J) [!]"
+	rom ( name "Olympic Hockey Nagano '98 (J) [!].z64" crc 9E98FCE8 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [!]"
+	description "Olympic Hockey Nagano '98 (U) [!]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [!].z64" crc 2D777652 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [b1]"
+	description "Olympic Hockey Nagano '98 (U) [b1]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [b1].z64" crc BF7EAE06 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [b2]"
+	description "Olympic Hockey Nagano '98 (U) [b2]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [b2].z64" crc 5A86EB33 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [b3]"
+	description "Olympic Hockey Nagano '98 (U) [b3]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [b3].z64" crc 2270F56B )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [h1C]"
+	description "Olympic Hockey Nagano '98 (U) [h1C]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [h1C].z64" crc 5A5315EC )
+)
+
+game (
+	name "Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66]"
+	description "Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66]"
+	rom ( name "Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66].z64" crc C9F7B017 )
+)
+
+game (
+	name "Onegai Monsters (J) [!]"
+	description "Onegai Monsters (J) [!]"
+	rom ( name "Onegai Monsters (J) [!].z64" crc AC72A1C7 )
+)
+
+game (
+	name "Onegai Monsters (J) [b1]"
+	description "Onegai Monsters (J) [b1]"
+	rom ( name "Onegai Monsters (J) [b1].z64" crc A632B622 )
+)
+
+game (
+	name "Pachinko 365 Nichi (J) [!]"
+	description "Pachinko 365 Nichi (J) [!]"
+	rom ( name "Pachinko 365 Nichi (J) [!].z64" crc 42D06E32 )
+)
+
+game (
+	name "Pachinko 365 Nichi (J) [b1]"
+	description "Pachinko 365 Nichi (J) [b1]"
+	rom ( name "Pachinko 365 Nichi (J) [b1].z64" crc 75CE6E9B )
+)
+
+game (
+	name "Pachinko 365 Nichi (J) [b2]"
+	description "Pachinko 365 Nichi (J) [b2]"
+	rom ( name "Pachinko 365 Nichi (J) [b2].z64" crc F2202871 )
+)
+
+game (
+	name "Mario Story (J) [!]"
+	description "Mario Story (J) [!]"
+	rom ( name "Mario Story (J) [!].z64" crc BD60CA66 )
+)
+
+game (
+	name "Paper Mario (E) (M4) [!]"
+	description "Paper Mario (E) (M4) [!]"
+	rom ( name "Paper Mario (E) (M4) [!].z64" crc 85B3AB37 )
+)
+
+game (
+	name "Paper Mario (U) [!]"
+	description "Paper Mario (U) [!]"
+	rom ( name "Paper Mario (U) [!].z64" crc A7F5CD7E )
+)
+
+game (
+	name "Paper Mario (U) [T+Chi]"
+	description "Paper Mario (U) [T+Chi]"
+	rom ( name "Paper Mario (U) [T+Chi].z64" crc EC10421A )
+)
+
+game (
+	name "Paperboy (E) [!]"
+	description "Paperboy (E) [!]"
+	rom ( name "Paperboy (E) [!].z64" crc F00C5053 )
+)
+
+game (
+	name "Paperboy (U) [!]"
+	description "Paperboy (U) [!]"
+	rom ( name "Paperboy (U) [!].z64" crc F27114E6 )
+)
+
+game (
+	name "Paperboy (U) [f1] (PAL)"
+	description "Paperboy (U) [f1] (PAL)"
+	rom ( name "Paperboy (U) [f1] (PAL).z64" crc 7CFE1430 )
+)
+
+game (
+	name "Paperboy (U) [hI]"
+	description "Paperboy (U) [hI]"
+	rom ( name "Paperboy (U) [hI].z64" crc 943FED7B )
+)
+
+game (
+	name "Paperboy (U) [hI][f1] (PAL)"
+	description "Paperboy (U) [hI][f1] (PAL)"
+	rom ( name "Paperboy (U) [hI][f1] (PAL).z64" crc 0FEFA6B4 )
+)
+
+game (
+	name "Paperboy (U) [hI][t1]"
+	description "Paperboy (U) [hI][t1]"
+	rom ( name "Paperboy (U) [hI][t1].z64" crc A5A5DA90 )
+)
+
+game (
+	name "Paperboy (U) [t1]"
+	description "Paperboy (U) [t1]"
+	rom ( name "Paperboy (U) [t1].z64" crc EA4F823A )
+)
+
+game (
+	name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!]"
+	description "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!]"
+	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!].z64" crc A33146E0 )
+)
+
+game (
+	name "PD Ultraman Battle Collection 64 (J) [!]"
+	description "PD Ultraman Battle Collection 64 (J) [!]"
+	rom ( name "PD Ultraman Battle Collection 64 (J) [!].z64" crc 86CC80B5 )
+)
+
+game (
+	name "PD Ultraman Battle Collection 64 (J) [b1]"
+	description "PD Ultraman Battle Collection 64 (J) [b1]"
+	rom ( name "PD Ultraman Battle Collection 64 (J) [b1].z64" crc 34AF8235 )
+)
+
+game (
+	name "PD Ultraman Battle Collection 64 (J) [f1] (PAL)"
+	description "PD Ultraman Battle Collection 64 (J) [f1] (PAL)"
+	rom ( name "PD Ultraman Battle Collection 64 (J) [f1] (PAL).z64" crc 4D2DAB64 )
+)
+
+game (
+	name "PD Ultraman Battle Collection 64 (J) [f2] (PAL)"
+	description "PD Ultraman Battle Collection 64 (J) [f2] (PAL)"
+	rom ( name "PD Ultraman Battle Collection 64 (J) [f2] (PAL).z64" crc E48D1481 )
+)
+
+game (
+	name "Choro Q 64 (J) [!]"
+	description "Choro Q 64 (J) [!]"
+	rom ( name "Choro Q 64 (J) [!].z64" crc 231F9284 )
+)
+
+game (
+	name "Choro Q 64 (J) [b1]"
+	description "Choro Q 64 (J) [b1]"
+	rom ( name "Choro Q 64 (J) [b1].z64" crc B19825F1 )
+)
+
+game (
+	name "Choro Q 64 (J) [b2]"
+	description "Choro Q 64 (J) [b2]"
+	rom ( name "Choro Q 64 (J) [b2].z64" crc EDBBCB0E )
+)
+
+game (
+	name "Choro Q 64 (J) [b3]"
+	description "Choro Q 64 (J) [b3]"
+	rom ( name "Choro Q 64 (J) [b3].z64" crc B94CA728 )
+)
+
+game (
+	name "Choro Q 64 (J) [b4]"
+	description "Choro Q 64 (J) [b4]"
+	rom ( name "Choro Q 64 (J) [b4].z64" crc CE6F7754 )
+)
+
+game (
+	name "Choro Q 64 (J) [h1C]"
+	description "Choro Q 64 (J) [h1C]"
+	rom ( name "Choro Q 64 (J) [h1C].z64" crc C35391EC )
+)
+
+game (
+	name "Penny Racers (E) [!]"
+	description "Penny Racers (E) [!]"
+	rom ( name "Penny Racers (E) [!].z64" crc A1D6EB5B )
+)
+
+game (
+	name "Penny Racers (E) [h1C]"
+	description "Penny Racers (E) [h1C]"
+	rom ( name "Penny Racers (E) [h1C].z64" crc 88D6B0FC )
+)
+
+game (
+	name "Penny Racers (E) [h2C]"
+	description "Penny Racers (E) [h2C]"
+	rom ( name "Penny Racers (E) [h2C].z64" crc 48ADF127 )
+)
+
+game (
+	name "Penny Racers (U) [!]"
+	description "Penny Racers (U) [!]"
+	rom ( name "Penny Racers (U) [!].z64" crc C1E57337 )
+)
+
+game (
+	name "Penny Racers (U) [hI]"
+	description "Penny Racers (U) [hI]"
+	rom ( name "Penny Racers (U) [hI].z64" crc 47BB87AB )
+)
+
+game (
+	name "Perfect Dark (E) (M5) [!]"
+	description "Perfect Dark (E) (M5) [!]"
+	rom ( name "Perfect Dark (E) (M5) [!].z64" crc 7718A714 )
+)
+
+game (
+	name "Perfect Dark (E) (M5) [b1]"
+	description "Perfect Dark (E) (M5) [b1]"
+	rom ( name "Perfect Dark (E) (M5) [b1].z64" crc 0EAE06B7 )
+)
+
+game (
+	name "Perfect Dark (J) [!]"
+	description "Perfect Dark (J) [!]"
+	rom ( name "Perfect Dark (J) [!].z64" crc 639C0DA9 )
+)
+
+game (
+	name "Perfect Dark (U) (V1.0) [!]"
+	description "Perfect Dark (U) (V1.0) [!]"
+	rom ( name "Perfect Dark (U) (V1.0) [!].z64" crc 68446AD4 )
+)
+
+game (
+	name "Perfect Dark (U) (V1.0) [f1] (PAL)"
+	description "Perfect Dark (U) (V1.0) [f1] (PAL)"
+	rom ( name "Perfect Dark (U) (V1.0) [f1] (PAL).z64" crc 8D4F0485 )
+)
+
+game (
+	name "Perfect Dark (U) (V1.1) [!]"
+	description "Perfect Dark (U) (V1.1) [!]"
+	rom ( name "Perfect Dark (U) (V1.1) [!].z64" crc 4C1677F7 )
+)
+
+game (
+	name "PGA European Tour (E) (M5) [!]"
+	description "PGA European Tour (E) (M5) [!]"
+	rom ( name "PGA European Tour (E) (M5) [!].z64" crc 6B5FF959 )
+)
+
+game (
+	name "PGA European Tour (E) (M5) [f1] (NTSC)"
+	description "PGA European Tour (E) (M5) [f1] (NTSC)"
+	rom ( name "PGA European Tour (E) (M5) [f1] (NTSC).z64" crc B7E9B0CA )
+)
+
+game (
+	name "PGA European Tour (E) (M5) [f2] (NTSC)"
+	description "PGA European Tour (E) (M5) [f2] (NTSC)"
+	rom ( name "PGA European Tour (E) (M5) [f2] (NTSC).z64" crc 7BF9235E )
+)
+
+game (
+	name "PGA European Tour (U) [!]"
+	description "PGA European Tour (U) [!]"
+	rom ( name "PGA European Tour (U) [!].z64" crc 7CDFCDAA )
+)
+
+game (
+	name "Pilotwings 64 (E) (M3) [!]"
+	description "Pilotwings 64 (E) (M3) [!]"
+	rom ( name "Pilotwings 64 (E) (M3) [!].z64" crc C902E57C )
+)
+
+game (
+	name "Pilotwings 64 (E) (M3) [b1]"
+	description "Pilotwings 64 (E) (M3) [b1]"
+	rom ( name "Pilotwings 64 (E) (M3) [b1].z64" crc 69CEE7BB )
+)
+
+game (
+	name "Pilotwings 64 (E) (M3) [b2]"
+	description "Pilotwings 64 (E) (M3) [b2]"
+	rom ( name "Pilotwings 64 (E) (M3) [b2].z64" crc A3F6B922 )
+)
+
+game (
+	name "Pilotwings 64 (E) (M3) [h1C]"
+	description "Pilotwings 64 (E) (M3) [h1C]"
+	rom ( name "Pilotwings 64 (E) (M3) [h1C].z64" crc 3F2C45D1 )
+)
+
+game (
+	name "Pilotwings 64 (J) [!]"
+	description "Pilotwings 64 (J) [!]"
+	rom ( name "Pilotwings 64 (J) [!].z64" crc 3D3A84A9 )
+)
+
+game (
+	name "Pilotwings 64 (J) [b1]"
+	description "Pilotwings 64 (J) [b1]"
+	rom ( name "Pilotwings 64 (J) [b1].z64" crc 48D4865D )
+)
+
+game (
+	name "Pilotwings 64 (U) [!]"
+	description "Pilotwings 64 (U) [!]"
+	rom ( name "Pilotwings 64 (U) [!].z64" crc 728807E7 )
+)
+
+game (
+	name "Pilotwings 64 (U) [h1C]"
+	description "Pilotwings 64 (U) [h1C]"
+	rom ( name "Pilotwings 64 (U) [h1C].z64" crc 80193EC3 )
+)
+
+game (
+	name "Pilotwings 64 (U) [t1]"
+	description "Pilotwings 64 (U) [t1]"
+	rom ( name "Pilotwings 64 (U) [t1].z64" crc E1B8CDD3 )
+)
+
+game (
+	name "Pocket Monsters Stadium (J) [!]"
+	description "Pocket Monsters Stadium (J) [!]"
+	rom ( name "Pocket Monsters Stadium (J) [!].z64" crc 3139189C )
+)
+
+game (
+	name "Pocket Monsters Stadium (J) [b1]"
+	description "Pocket Monsters Stadium (J) [b1]"
+	rom ( name "Pocket Monsters Stadium (J) [b1].z64" crc 6F856803 )
+)
+
+game (
+	name "Pocket Monsters Stadium (J) [b2]"
+	description "Pocket Monsters Stadium (J) [b2]"
+	rom ( name "Pocket Monsters Stadium (J) [b2].z64" crc B4F73DBA )
+)
+
+game (
+	name "Pocket Monsters Stadium (J) [f1] (Boot-PAL)"
+	description "Pocket Monsters Stadium (J) [f1] (Boot-PAL)"
+	rom ( name "Pocket Monsters Stadium (J) [f1] (Boot-PAL).z64" crc 54D42FD3 )
+)
+
+game (
+	name "Pocket Monsters Stadium (J) [f2] (Boot)"
+	description "Pocket Monsters Stadium (J) [f2] (Boot)"
+	rom ( name "Pocket Monsters Stadium (J) [f2] (Boot).z64" crc 32B4C38D )
+)
+
+game (
+	name "Pokemon Puzzle League (E) [!]"
+	description "Pokemon Puzzle League (E) [!]"
+	rom ( name "Pokemon Puzzle League (E) [!].z64" crc 75839254 )
+)
+
+game (
+	name "Pokemon Puzzle League (F) [!]"
+	description "Pokemon Puzzle League (F) [!]"
+	rom ( name "Pokemon Puzzle League (F) [!].z64" crc C3AA0074 )
+)
+
+game (
+	name "Pokemon Puzzle League (G) [!]"
+	description "Pokemon Puzzle League (G) [!]"
+	rom ( name "Pokemon Puzzle League (G) [!].z64" crc AC543150 )
+)
+
+game (
+	name "Pokemon Puzzle League (U) [!]"
+	description "Pokemon Puzzle League (U) [!]"
+	rom ( name "Pokemon Puzzle League (U) [!].z64" crc 8B9C598F )
+)
+
+game (
+	name "Pokemon Puzzle League (U) [t1]"
+	description "Pokemon Puzzle League (U) [t1]"
+	rom ( name "Pokemon Puzzle League (U) [t1].z64" crc 47EDE839 )
+)
+
+game (
+	name "Pokemon Puzzle League (U) [t2]"
+	description "Pokemon Puzzle League (U) [t2]"
+	rom ( name "Pokemon Puzzle League (U) [t2].z64" crc E74D7734 )
+)
+
+game (
+	name "Pocket Monsters Snap (J) [!]"
+	description "Pocket Monsters Snap (J) [!]"
+	rom ( name "Pocket Monsters Snap (J) [!].z64" crc A091BD56 )
+)
+
+game (
+	name "Pocket Monsters Snap (J) [b1]"
+	description "Pocket Monsters Snap (J) [b1]"
+	rom ( name "Pocket Monsters Snap (J) [b1].z64" crc 28F6F98D )
+)
+
+game (
+	name "Pocket Monsters Snap (J) [f1]"
+	description "Pocket Monsters Snap (J) [f1]"
+	rom ( name "Pocket Monsters Snap (J) [f1].z64" crc 676A945B )
+)
+
+game (
+	name "Pocket Monsters Snap (J) [f2] (GameShark)"
+	description "Pocket Monsters Snap (J) [f2] (GameShark)"
+	rom ( name "Pocket Monsters Snap (J) [f2] (GameShark).z64" crc 7822E4DC )
+)
+
+game (
+	name "Pokemon Snap (A) [!]"
+	description "Pokemon Snap (A) [!]"
+	rom ( name "Pokemon Snap (A) [!].z64" crc CDEA6D4C )
+)
+
+game (
+	name "Pokemon Snap (A) [f1] (GameShark)"
+	description "Pokemon Snap (A) [f1] (GameShark)"
+	rom ( name "Pokemon Snap (A) [f1] (GameShark).z64" crc 144F7260 )
+)
+
+game (
+	name "Pokemon Snap (E) [!]"
+	description "Pokemon Snap (E) [!]"
+	rom ( name "Pokemon Snap (E) [!].z64" crc F824A057 )
+)
+
+game (
+	name "Pokemon Snap (F) [!]"
+	description "Pokemon Snap (F) [!]"
+	rom ( name "Pokemon Snap (F) [!].z64" crc EC843586 )
+)
+
+game (
+	name "Pokemon Snap (F) [b1]"
+	description "Pokemon Snap (F) [b1]"
+	rom ( name "Pokemon Snap (F) [b1].z64" crc 396961B4 )
+)
+
+game (
+	name "Pokemon Snap (G) [!]"
+	description "Pokemon Snap (G) [!]"
+	rom ( name "Pokemon Snap (G) [!].z64" crc 10C27B3C )
+)
+
+game (
+	name "Pokemon Snap (I) [!]"
+	description "Pokemon Snap (I) [!]"
+	rom ( name "Pokemon Snap (I) [!].z64" crc 63F6058A )
+)
+
+game (
+	name "Pokemon Snap (S) [!]"
+	description "Pokemon Snap (S) [!]"
+	rom ( name "Pokemon Snap (S) [!].z64" crc 371B787F )
+)
+
+game (
+	name "Pokemon Snap (U) [!]"
+	description "Pokemon Snap (U) [!]"
+	rom ( name "Pokemon Snap (U) [!].z64" crc 86A69756 )
+)
+
+game (
+	name "Pokemon Snap (U) [f1] (Save)"
+	description "Pokemon Snap (U) [f1] (Save)"
+	rom ( name "Pokemon Snap (U) [f1] (Save).z64" crc 4E0C3AB0 )
+)
+
+game (
+	name "Pokemon Snap (U) [f2] (Save-PAL)"
+	description "Pokemon Snap (U) [f2] (Save-PAL)"
+	rom ( name "Pokemon Snap (U) [f2] (Save-PAL).z64" crc A6EF9AE7 )
+)
+
+game (
+	name "Pokemon Snap (U) [f3] (GameShark)"
+	description "Pokemon Snap (U) [f3] (GameShark)"
+	rom ( name "Pokemon Snap (U) [f3] (GameShark).z64" crc 6A7D374C )
+)
+
+game (
+	name "Pokemon Snap (U) [f3]"
+	description "Pokemon Snap (U) [f3]"
+	rom ( name "Pokemon Snap (U) [f3].z64" crc 9F5B2741 )
+)
+
+game (
+	name "Pokemon Snap (U) [T+Spa]"
+	description "Pokemon Snap (U) [T+Spa]"
+	rom ( name "Pokemon Snap (U) [T+Spa].z64" crc EA713736 )
+)
+
+game (
+	name "Pokemon Snap Station (U) [!]"
+	description "Pokemon Snap Station (U) [!]"
+	rom ( name "Pokemon Snap Station (U) [!].z64" crc E22A00D0 )
+)
+
+game (
+	name "Pokemon Snap Station (U) [f1]"
+	description "Pokemon Snap Station (U) [f1]"
+	rom ( name "Pokemon Snap Station (U) [f1].z64" crc DCE70F89 )
+)
+
+game (
+	name "Pocket Monsters Stadium 2 (J) [!]"
+	description "Pocket Monsters Stadium 2 (J) [!]"
+	rom ( name "Pocket Monsters Stadium 2 (J) [!].z64" crc 40AA4874 )
+)
+
+game (
+	name "Pocket Monsters Stadium 2 (J) [f1]"
+	description "Pocket Monsters Stadium 2 (J) [f1]"
+	rom ( name "Pocket Monsters Stadium 2 (J) [f1].z64" crc DF47ADF2 )
+)
+
+game (
+	name "Pocket Monsters Stadium 2 (J) [f2]"
+	description "Pocket Monsters Stadium 2 (J) [f2]"
+	rom ( name "Pocket Monsters Stadium 2 (J) [f2].z64" crc E3269942 )
+)
+
+game (
+	name "Pocket Monsters Stadium 2 (J) [f3]"
+	description "Pocket Monsters Stadium 2 (J) [f3]"
+	rom ( name "Pocket Monsters Stadium 2 (J) [f3].z64" crc B9365D21 )
+)
+
+game (
+	name "Pocket Monsters Stadium 2 (J) [f4]"
+	description "Pocket Monsters Stadium 2 (J) [f4]"
+	rom ( name "Pocket Monsters Stadium 2 (J) [f4].z64" crc 3DB3C49B )
+)
+
+game (
+	name "Pokemon Stadium (E) (V1.0) [!]"
+	description "Pokemon Stadium (E) (V1.0) [!]"
+	rom ( name "Pokemon Stadium (E) (V1.0) [!].z64" crc DC57508D )
+)
+
+game (
+	name "Pokemon Stadium (E) (V1.0) [f1]"
+	description "Pokemon Stadium (E) (V1.0) [f1]"
+	rom ( name "Pokemon Stadium (E) (V1.0) [f1].z64" crc C0055DD4 )
+)
+
+game (
+	name "Pokemon Stadium (E) (V1.1) [!]"
+	description "Pokemon Stadium (E) (V1.1) [!]"
+	rom ( name "Pokemon Stadium (E) (V1.1) [!].z64" crc DA889668 )
+)
+
+game (
+	name "Pokemon Stadium (F) [!]"
+	description "Pokemon Stadium (F) [!]"
+	rom ( name "Pokemon Stadium (F) [!].z64" crc 5DD92D4C )
+)
+
+game (
+	name "Pokemon Stadium (F) [f1]"
+	description "Pokemon Stadium (F) [f1]"
+	rom ( name "Pokemon Stadium (F) [f1].z64" crc 56BB95DB )
+)
+
+game (
+	name "Pokemon Stadium (G) [!]"
+	description "Pokemon Stadium (G) [!]"
+	rom ( name "Pokemon Stadium (G) [!].z64" crc 9F22A945 )
+)
+
+game (
+	name "Pokemon Stadium (G) [f1]"
+	description "Pokemon Stadium (G) [f1]"
+	rom ( name "Pokemon Stadium (G) [f1].z64" crc F4152673 )
+)
+
+game (
+	name "Pokemon Stadium (I) [!]"
+	description "Pokemon Stadium (I) [!]"
+	rom ( name "Pokemon Stadium (I) [!].z64" crc F155C465 )
+)
+
+game (
+	name "Pokemon Stadium (S) [!]"
+	description "Pokemon Stadium (S) [!]"
+	rom ( name "Pokemon Stadium (S) [!].z64" crc F02CD5EB )
+)
+
+game (
+	name "Pokemon Stadium (S) [f1]"
+	description "Pokemon Stadium (S) [f1]"
+	rom ( name "Pokemon Stadium (S) [f1].z64" crc 55A3CD84 )
+)
+
+game (
+	name "Pokemon Stadium (U) (V1.0) [!]"
+	description "Pokemon Stadium (U) (V1.0) [!]"
+	rom ( name "Pokemon Stadium (U) (V1.0) [!].z64" crc 72F66F05 )
+)
+
+game (
+	name "Pokemon Stadium (U) (V1.0) [f1]"
+	description "Pokemon Stadium (U) (V1.0) [f1]"
+	rom ( name "Pokemon Stadium (U) (V1.0) [f1].z64" crc 932B7A31 )
+)
+
+game (
+	name "Pokemon Stadium (U) (V1.1) [!]"
+	description "Pokemon Stadium (U) (V1.1) [!]"
+	rom ( name "Pokemon Stadium (U) (V1.1) [!].z64" crc 72B552E3 )
+)
+
+game (
+	name "Pokemon Stadium (U) (V1.1) [f1]"
+	description "Pokemon Stadium (U) (V1.1) [f1]"
+	rom ( name "Pokemon Stadium (U) (V1.1) [f1].z64" crc 32233FDC )
+)
+
+game (
+	name "Pocket Monsters Stadium Kin Gin (J) [!]"
+	description "Pocket Monsters Stadium Kin Gin (J) [!]"
+	rom ( name "Pocket Monsters Stadium Kin Gin (J) [!].z64" crc CBC3B935 )
+)
+
+game (
+	name "Pokemon Stadium 2 (E) [!]"
+	description "Pokemon Stadium 2 (E) [!]"
+	rom ( name "Pokemon Stadium 2 (E) [!].z64" crc 6B3096C4 )
+)
+
+game (
+	name "Pokemon Stadium 2 (E) [T+Ita0.05]"
+	description "Pokemon Stadium 2 (E) [T+Ita0.05]"
+	rom ( name "Pokemon Stadium 2 (E) [T+Ita0.05].z64" crc 89E7DA00 )
+)
+
+game (
+	name "Pokemon Stadium 2 (F) [!]"
+	description "Pokemon Stadium 2 (F) [!]"
+	rom ( name "Pokemon Stadium 2 (F) [!].z64" crc E2A78066 )
+)
+
+game (
+	name "Pokemon Stadium 2 (G) [!]"
+	description "Pokemon Stadium 2 (G) [!]"
+	rom ( name "Pokemon Stadium 2 (G) [!].z64" crc 1146A43A )
+)
+
+game (
+	name "Pokemon Stadium 2 (I) [!]"
+	description "Pokemon Stadium 2 (I) [!]"
+	rom ( name "Pokemon Stadium 2 (I) [!].z64" crc 9FA5C095 )
+)
+
+game (
+	name "Pokemon Stadium 2 (S) [!]"
+	description "Pokemon Stadium 2 (S) [!]"
+	rom ( name "Pokemon Stadium 2 (S) [!].z64" crc 283E7641 )
+)
+
+game (
+	name "Pokemon Stadium 2 (U) [!]"
+	description "Pokemon Stadium 2 (U) [!]"
+	rom ( name "Pokemon Stadium 2 (U) [!].z64" crc A9998E09 )
+)
+
+game (
+	name "Polaris SnoCross (U) [!]"
+	description "Polaris SnoCross (U) [!]"
+	rom ( name "Polaris SnoCross (U) [!].z64" crc 8DD735EF )
+)
+
+game (
+	name "Polaris SnoCross (U) [o1][t1]"
+	description "Polaris SnoCross (U) [o1][t1]"
+	rom ( name "Polaris SnoCross (U) [o1][t1].z64" crc 00CE1EBB )
+)
+
+game (
+	name "Polaris SnoCross (U) [t1]"
+	description "Polaris SnoCross (U) [t1]"
+	rom ( name "Polaris SnoCross (U) [t1].z64" crc 9356FE6C )
+)
+
+game (
+	name "Power League Baseball 64 (J) [!]"
+	description "Power League Baseball 64 (J) [!]"
+	rom ( name "Power League Baseball 64 (J) [!].z64" crc AEC21C28 )
+)
+
+game (
+	name "Power League Baseball 64 (J) [o1]"
+	description "Power League Baseball 64 (J) [o1]"
+	rom ( name "Power League Baseball 64 (J) [o1].z64" crc 1B77039D )
+)
+
+game (
+	name "Power Rangers - Lightspeed Rescue (E) [!]"
+	description "Power Rangers - Lightspeed Rescue (E) [!]"
+	rom ( name "Power Rangers - Lightspeed Rescue (E) [!].z64" crc 83590247 )
+)
+
+game (
+	name "Power Rangers - Lightspeed Rescue (E) [f1] (NTSC)"
+	description "Power Rangers - Lightspeed Rescue (E) [f1] (NTSC)"
+	rom ( name "Power Rangers - Lightspeed Rescue (E) [f1] (NTSC).z64" crc 388EAB69 )
+)
+
+game (
+	name "Power Rangers - Lightspeed Rescue (U) [!]"
+	description "Power Rangers - Lightspeed Rescue (U) [!]"
+	rom ( name "Power Rangers - Lightspeed Rescue (U) [!].z64" crc A5033311 )
+)
+
+game (
+	name "Powerpuff Girls, The - Chemical X-Traction (U) [!]"
+	description "Powerpuff Girls, The - Chemical X-Traction (U) [!]"
+	rom ( name "Powerpuff Girls, The - Chemical X-Traction (U) [!].z64" crc 9514DA0A )
+)
+
+game (
+	name "Premier Manager 64 (E) [!]"
+	description "Premier Manager 64 (E) [!]"
+	rom ( name "Premier Manager 64 (E) [!].z64" crc 81CDA888 )
+)
+
+game (
+	name "Premier Manager 64 (E) [f1] (NTSC)"
+	description "Premier Manager 64 (E) [f1] (NTSC)"
+	rom ( name "Premier Manager 64 (E) [f1] (NTSC).z64" crc 18A89111 )
+)
+
+game (
+	name "Premier Manager 64 (E) [f2] (NTSC100%)"
+	description "Premier Manager 64 (E) [f2] (NTSC100%)"
+	rom ( name "Premier Manager 64 (E) [f2] (NTSC100%).z64" crc 9E43EC66 )
+)
+
+game (
+	name "Pro Mahjong Kiwame 64 (J) [!]"
+	description "Pro Mahjong Kiwame 64 (J) [!]"
+	rom ( name "Pro Mahjong Kiwame 64 (J) [!].z64" crc 1F5907F9 )
+)
+
+game (
+	name "Pro Mahjong Kiwame 64 (J) [b1]"
+	description "Pro Mahjong Kiwame 64 (J) [b1]"
+	rom ( name "Pro Mahjong Kiwame 64 (J) [b1].z64" crc 21AE1D70 )
+)
+
+game (
+	name "Pro Mahjong Kiwame 64 (J) [o1]"
+	description "Pro Mahjong Kiwame 64 (J) [o1]"
+	rom ( name "Pro Mahjong Kiwame 64 (J) [o1].z64" crc 7B914A49 )
+)
+
+game (
+	name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!]"
+	description "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!]"
+	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!].z64" crc 35461699 )
+)
+
+game (
+	name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD) [f1]"
+	description "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD) [f1]"
+	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD) [f1].z64" crc CA8CCA0B )
+)
+
+game (
+	name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD)"
+	description "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD)"
+	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD).z64" crc 48BE02A9 )
+)
+
+game (
+	name "3DS Model Conversion by Snake (PD) [h1C]"
+	description "3DS Model Conversion by Snake (PD) [h1C]"
+	rom ( name "3DS Model Conversion by Snake (PD) [h1C].z64" crc FDB0D5AD )
+)
+
+game (
+	name "3DS Model Conversion by Snake (PD)"
+	description "3DS Model Conversion by Snake (PD)"
+	rom ( name "3DS Model Conversion by Snake (PD).z64" crc 685F71CD )
+)
+
+game (
+	name "77a by Count0 (POM '98) (PD) [b1]"
+	description "77a by Count0 (POM '98) (PD) [b1]"
+	rom ( name "77a by Count0 (POM '98) (PD) [b1].z64" crc 0FCB5E9E )
+)
+
+game (
+	name "77a by Count0 (POM '98) (PD)"
+	description "77a by Count0 (POM '98) (PD)"
+	rom ( name "77a by Count0 (POM '98) (PD).z64" crc EF6D1CA6 )
+)
+
+game (
+	name "77a Special Edition by Count0 (PD) [b1]"
+	description "77a Special Edition by Count0 (PD) [b1]"
+	rom ( name "77a Special Edition by Count0 (PD) [b1].z64" crc A2AE127C )
+)
+
+game (
+	name "77a Special Edition by Count0 (PD)"
+	description "77a Special Edition by Count0 (PD)"
+	rom ( name "77a Special Edition by Count0 (PD).z64" crc 0C84AF76 )
+)
+
+game (
+	name "Absolute Crap #2 by Lem (PD) [b1]"
+	description "Absolute Crap #2 by Lem (PD) [b1]"
+	rom ( name "Absolute Crap #2 by Lem (PD) [b1].z64" crc CAEADAB4 )
+)
+
+game (
+	name "Absolute Crap #2 by Lem (PD) [b2]"
+	description "Absolute Crap #2 by Lem (PD) [b2]"
+	rom ( name "Absolute Crap #2 by Lem (PD) [b2].z64" crc 4026B0CB )
+)
+
+game (
+	name "Absolute Crap #2 by Lem (PD)"
+	description "Absolute Crap #2 by Lem (PD)"
+	rom ( name "Absolute Crap #2 by Lem (PD).z64" crc 9B9FDB8E )
+)
+
+game (
+	name "Alleycat 64 by Dosin (POM '99) (PD) [b1]"
+	description "Alleycat 64 by Dosin (POM '99) (PD) [b1]"
+	rom ( name "Alleycat 64 by Dosin (POM '99) (PD) [b1].z64" crc FE3B7986 )
+)
+
+game (
+	name "Alleycat 64 by Dosin (POM '99) (PD)"
+	description "Alleycat 64 by Dosin (POM '99) (PD)"
+	rom ( name "Alleycat 64 by Dosin (POM '99) (PD).z64" crc 938ECA3E )
+)
+
+game (
+	name "Attax64 by Pookae (POM '99) (PD) [b1]"
+	description "Attax64 by Pookae (POM '99) (PD) [b1]"
+	rom ( name "Attax64 by Pookae (POM '99) (PD) [b1].z64" crc 21B5E4E7 )
+)
+
+game (
+	name "Attax64 by Pookae (POM '99) (PD)"
+	description "Attax64 by Pookae (POM '99) (PD)"
+	rom ( name "Attax64 by Pookae (POM '99) (PD).z64" crc 53976AC5 )
+)
+
+game (
+	name "Berney Must Die! by Nop_ (POM '99) (PD) [t1]"
+	description "Berney Must Die! by Nop_ (POM '99) (PD) [t1]"
+	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD) [t1].z64" crc C5DAC064 )
+)
+
+game (
+	name "Berney Must Die! by Nop_ (POM '99) (PD)"
+	description "Berney Must Die! by Nop_ (POM '99) (PD)"
+	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD).z64" crc 661E5FF5 )
+)
+
+game (
+	name "Bike Race '98 V1.0 by NAN (PD) [b1]"
+	description "Bike Race '98 V1.0 by NAN (PD) [b1]"
+	rom ( name "Bike Race '98 V1.0 by NAN (PD) [b1].z64" crc CD797C66 )
+)
+
+game (
+	name "Bike Race '98 V1.0 by NAN (PD)"
+	description "Bike Race '98 V1.0 by NAN (PD)"
+	rom ( name "Bike Race '98 V1.0 by NAN (PD).z64" crc 601C8801 )
+)
+
+game (
+	name "Bike Race '98 V1.2 by NAN (PD) [b1]"
+	description "Bike Race '98 V1.2 by NAN (PD) [b1]"
+	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b1].z64" crc 19F78649 )
+)
+
+game (
+	name "Bike Race '98 V1.2 by NAN (PD) [b2]"
+	description "Bike Race '98 V1.2 by NAN (PD) [b2]"
+	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b2].z64" crc 109B847A )
+)
+
+game (
+	name "Bike Race '98 V1.2 by NAN (PD)"
+	description "Bike Race '98 V1.2 by NAN (PD)"
+	rom ( name "Bike Race '98 V1.2 by NAN (PD).z64" crc C2CC79C2 )
+)
+
+game (
+	name "BMP View by Count0 (PD)"
+	description "BMP View by Count0 (PD)"
+	rom ( name "BMP View by Count0 (PD).z64" crc 9BA53380 )
+)
+
+game (
+	name "CZN Module Player (PD)"
+	description "CZN Module Player (PD)"
+	rom ( name "CZN Module Player (PD).z64" crc F93A2B1F )
+)
+
+game (
+	name "Dexanoid R1 by Protest Design (PD) [b1]"
+	description "Dexanoid R1 by Protest Design (PD) [b1]"
+	rom ( name "Dexanoid R1 by Protest Design (PD) [b1].z64" crc 1B9A2D13 )
+)
+
+game (
+	name "Dexanoid R1 by Protest Design (PD) [f1] (PAL)"
+	description "Dexanoid R1 by Protest Design (PD) [f1] (PAL)"
+	rom ( name "Dexanoid R1 by Protest Design (PD) [f1] (PAL).z64" crc 7A4BBB34 )
+)
+
+game (
+	name "Dexanoid R1 by Protest Design (PD) [f2] (PAL)"
+	description "Dexanoid R1 by Protest Design (PD) [f2] (PAL)"
+	rom ( name "Dexanoid R1 by Protest Design (PD) [f2] (PAL).z64" crc 7E2B8065 )
+)
+
+game (
+	name "Dexanoid R1 by Protest Design (PD) [t1]"
+	description "Dexanoid R1 by Protest Design (PD) [t1]"
+	rom ( name "Dexanoid R1 by Protest Design (PD) [t1].z64" crc 3CF0961F )
+)
+
+game (
+	name "Dexanoid R1 by Protest Design (PD)"
+	description "Dexanoid R1 by Protest Design (PD)"
+	rom ( name "Dexanoid R1 by Protest Design (PD).z64" crc 244E6D59 )
+)
+
+game (
+	name "Dragon King by CrowTRobo (PD) [b1]"
+	description "Dragon King by CrowTRobo (PD) [b1]"
+	rom ( name "Dragon King by CrowTRobo (PD) [b1].z64" crc 1FC33D83 )
+)
+
+game (
+	name "Dragon King by CrowTRobo (PD)"
+	description "Dragon King by CrowTRobo (PD)"
+	rom ( name "Dragon King by CrowTRobo (PD).z64" crc EA5C7922 )
+)
+
+game (
+	name "Dynamix Readme by Widget and Immortal (PD)"
+	description "Dynamix Readme by Widget and Immortal (PD)"
+	rom ( name "Dynamix Readme by Widget and Immortal (PD).z64" crc 82531023 )
+)
+
+game (
+	name "Game Boy 64 (POM '98) (PD) (Illegal Mode Enabled)"
+	description "Game Boy 64 (POM '98) (PD) (Illegal Mode Enabled)"
+	rom ( name "Game Boy 64 (POM '98) (PD) (Illegal Mode Enabled).z64" crc E299D6C1 )
+)
+
+game (
+	name "Game Boy 64 (POM '98) (PD)"
+	description "Game Boy 64 (POM '98) (PD)"
+	rom ( name "Game Boy 64 (POM '98) (PD).z64" crc 3C22F622 )
+)
+
+game (
+	name "Game Boy 64 + Super Mario 3 (PD)"
+	description "Game Boy 64 + Super Mario 3 (PD)"
+	rom ( name "Game Boy 64 + Super Mario 3 (PD).z64" crc 8145D2E8 )
+)
+
+game (
+	name "HIPTHRUST by MooglyGuy (PD)"
+	description "HIPTHRUST by MooglyGuy (PD)"
+	rom ( name "HIPTHRUST by MooglyGuy (PD).z64" crc B1A4D196 )
+)
+
+game (
+	name "JPEG Slideshow Viewer by Garth Elgar (PD)"
+	description "JPEG Slideshow Viewer by Garth Elgar (PD)"
+	rom ( name "JPEG Slideshow Viewer by Garth Elgar (PD).z64" crc B5AA682D )
+)
+
+game (
+	name "LaC's MOD Player - The Temple Gates (PD)"
+	description "LaC's MOD Player - The Temple Gates (PD)"
+	rom ( name "LaC's MOD Player - The Temple Gates (PD).z64" crc 4C4477D6 )
+)
+
+game (
+	name "Liner V1.00 by Colin Phillipps of Memir (PD) [b1]"
+	description "Liner V1.00 by Colin Phillipps of Memir (PD) [b1]"
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b1].z64" crc 0388EE97 )
+)
+
+game (
+	name "Liner V1.00 by Colin Phillipps of Memir (PD) [b2]"
+	description "Liner V1.00 by Colin Phillipps of Memir (PD) [b2]"
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b2].z64" crc 4155E1C9 )
+)
+
+game (
+	name "Liner V1.00 by Colin Phillipps of Memir (PD)"
+	description "Liner V1.00 by Colin Phillipps of Memir (PD)"
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD).z64" crc A9397703 )
+)
+
+game (
+	name "Liner V1.02 by Colin Phillipps of Memir (PD)"
+	description "Liner V1.02 by Colin Phillipps of Memir (PD)"
+	rom ( name "Liner V1.02 by Colin Phillipps of Memir (PD).z64" crc D3D11218 )
+)
+
+game (
+	name "MAME 64 Beta 3 (PD)"
+	description "MAME 64 Beta 3 (PD)"
+	rom ( name "MAME 64 Beta 3 (PD).z64" crc 2103E950 )
+)
+
+game (
+	name "MAME 64 V1.0 (PD) [b1]"
+	description "MAME 64 V1.0 (PD) [b1]"
+	rom ( name "MAME 64 V1.0 (PD) [b1].z64" crc 7F0DD250 )
+)
+
+game (
+	name "MAME 64 V1.0 (PD)"
+	description "MAME 64 V1.0 (PD)"
+	rom ( name "MAME 64 V1.0 (PD).z64" crc 6612CEBA )
+)
+
+game (
+	name "Mandelbrot Zoomer by RedBox (PD)"
+	description "Mandelbrot Zoomer by RedBox (PD)"
+	rom ( name "Mandelbrot Zoomer by RedBox (PD).z64" crc 611513AD )
+)
+
+game (
+	name "Manic Miner - Hidden Levels by RedboX (PD)"
+	description "Manic Miner - Hidden Levels by RedboX (PD)"
+	rom ( name "Manic Miner - Hidden Levels by RedboX (PD).z64" crc F496A0FA )
+)
+
+game (
+	name "Manic Miner by RedboX (PD)"
+	description "Manic Miner by RedboX (PD)"
+	rom ( name "Manic Miner by RedboX (PD).z64" crc 02AACC20 )
+)
+
+game (
+	name "Memory Manager V1.0b by R. Bubba Magillicutty (PD)"
+	description "Memory Manager V1.0b by R. Bubba Magillicutty (PD)"
+	rom ( name "Memory Manager V1.0b by R. Bubba Magillicutty (PD).z64" crc 3B3F140A )
+)
+
+game (
+	name "MMR by Count0 (PD) [b1]"
+	description "MMR by Count0 (PD) [b1]"
+	rom ( name "MMR by Count0 (PD) [b1].z64" crc 47BD7E97 )
+)
+
+game (
+	name "MMR by Count0 (PD)"
+	description "MMR by Count0 (PD)"
+	rom ( name "MMR by Count0 (PD).z64" crc F4803DCB )
+)
+
+game (
+	name "N64 Scene Gallery by CALi (PD)"
+	description "N64 Scene Gallery by CALi (PD)"
+	rom ( name "N64 Scene Gallery by CALi (PD).z64" crc DFBB8DFE )
+)
+
+game (
+	name "N64probe (Button Test) by MooglyGuy (PD)"
+	description "N64probe (Button Test) by MooglyGuy (PD)"
+	rom ( name "N64probe (Button Test) by MooglyGuy (PD).z64" crc 18D7C629 )
+)
+
+game (
+	name "N64probe by MooglyGuy (PD)"
+	description "N64probe by MooglyGuy (PD)"
+	rom ( name "N64probe by MooglyGuy (PD).v64" crc 361F713F )
+)
+
+game (
+	name "Namp64 - N64 MP3-Player by Obsidian (PD)"
+	description "Namp64 - N64 MP3-Player by Obsidian (PD)"
+	rom ( name "Namp64 - N64 MP3-Player by Obsidian (PD).z64" crc 6A9BE044 )
+)
+
+game (
+	name "NBC-LFC Kings of Porn Vol 01 (PD) [a1]"
+	description "NBC-LFC Kings of Porn Vol 01 (PD) [a1]"
+	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD) [a1].z64" crc 82CA0F47 )
+)
+
+game (
+	name "NBC-LFC Kings of Porn Vol 01 (PD)"
+	description "NBC-LFC Kings of Porn Vol 01 (PD)"
+	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD).z64" crc B20CD983 )
+)
+
+game (
+	name "NBCG Special Edition (PD)"
+	description "NBCG Special Edition (PD)"
+	rom ( name "NBCG Special Edition (PD).z64" crc 57AF612B )
+)
+
+game (
+	name "NBCG's Tag Gallery 01 by CALi (PD)"
+	description "NBCG's Tag Gallery 01 by CALi (PD)"
+	rom ( name "NBCG's Tag Gallery 01 by CALi (PD).z64" crc 60394429 )
+)
+
+game (
+	name "Nintendo Family by CALi (PD)"
+	description "Nintendo Family by CALi (PD)"
+	rom ( name "Nintendo Family by CALi (PD).z64" crc F9D7BF11 )
+)
+
+game (
+	name "Nintendo WideBoy 64 by SonCrap (PD)"
+	description "Nintendo WideBoy 64 by SonCrap (PD)"
+	rom ( name "Nintendo WideBoy 64 by SonCrap (PD).z64" crc 1EFCC1B2 )
+)
+
+game (
+	name "ObjectVIEWER V1.1 by Kid Stardust (PD)"
+	description "ObjectVIEWER V1.1 by Kid Stardust (PD)"
+	rom ( name "ObjectVIEWER V1.1 by Kid Stardust (PD).v64" crc 1DEDA87C )
+)
+
+game (
+	name "PC-Engine 64 (POM '99) (PD) [t1]"
+	description "PC-Engine 64 (POM '99) (PD) [t1]"
+	rom ( name "PC-Engine 64 (POM '99) (PD) [t1].z64" crc 63C024C6 )
+)
+
+game (
+	name "PC-Engine 64 (POM '99) (PD)"
+	description "PC-Engine 64 (POM '99) (PD)"
+	rom ( name "PC-Engine 64 (POM '99) (PD).z64" crc E69B416B )
+)
+
+game (
+	name "Pip's Pong by Mr. Pips (PD) [b1]"
+	description "Pip's Pong by Mr. Pips (PD) [b1]"
+	rom ( name "Pip's Pong by Mr. Pips (PD) [b1].z64" crc 426F0F6E )
+)
+
+game (
+	name "Pip's Pong by Mr. Pips (PD)"
+	description "Pip's Pong by Mr. Pips (PD)"
+	rom ( name "Pip's Pong by Mr. Pips (PD).z64" crc 756871E3 )
+)
+
+game (
+	name "Pip's Porn Pack 1 by Mr. Pips (PD)"
+	description "Pip's Porn Pack 1 by Mr. Pips (PD)"
+	rom ( name "Pip's Porn Pack 1 by Mr. Pips (PD).z64" crc 4843B97C )
+)
+
+game (
+	name "Pip's Porn Pack 2 by Mr. Pips (POM '99) (PD)"
+	description "Pip's Porn Pack 2 by Mr. Pips (POM '99) (PD)"
+	rom ( name "Pip's Porn Pack 2 by Mr. Pips (POM '99) (PD).z64" crc 48C2E078 )
+)
+
+game (
+	name "Pip's Porn Pack 3 by Mr. Pips (PD)"
+	description "Pip's Porn Pack 3 by Mr. Pips (PD)"
+	rom ( name "Pip's Porn Pack 3 by Mr. Pips (PD).z64" crc 22EF2B51 )
+)
+
+game (
+	name "Pip's RPGs Beta 12 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 12 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 12 by Mr. Pips (PD).z64" crc 8B84F446 )
+)
+
+game (
+	name "Pip's RPGs Beta 14 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 14 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 14 by Mr. Pips (PD).z64" crc 97288804 )
+)
+
+game (
+	name "Pip's RPGs Beta 15 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 15 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 15 by Mr. Pips (PD).z64" crc 195A1C24 )
+)
+
+game (
+	name "Pip's RPGs Beta 2 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 2 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 2 by Mr. Pips (PD).z64" crc C27DD46E )
+)
+
+game (
+	name "Pip's RPGs Beta 3 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 3 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 3 by Mr. Pips (PD).z64" crc 30CA3FD9 )
+)
+
+game (
+	name "Pip's RPGs Beta 6 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 6 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 6 by Mr. Pips (PD).z64" crc 9930D6BD )
+)
+
+game (
+	name "Pip's RPGs Beta 7 by Mr. Pips (PD)"
+	description "Pip's RPGs Beta 7 by Mr. Pips (PD)"
+	rom ( name "Pip's RPGs Beta 7 by Mr. Pips (PD).z64" crc 0F30D531 )
+)
+
+game (
+	name "Pip's RPGs Beta x (PD) [a1]"
+	description "Pip's RPGs Beta x (PD) [a1]"
+	rom ( name "Pip's RPGs Beta x (PD) [a1].z64" crc E392CF51 )
+)
+
+game (
+	name "Pip's RPGs Beta x (PD)"
+	description "Pip's RPGs Beta x (PD)"
+	rom ( name "Pip's RPGs Beta x (PD).z64" crc 4CEB0273 )
+)
+
+game (
+	name "Pip's Tic Tak Toe by Mark Pips (PD)"
+	description "Pip's Tic Tak Toe by Mark Pips (PD)"
+	rom ( name "Pip's Tic Tak Toe by Mark Pips (PD).z64" crc 08950965 )
+)
+
+game (
+	name "Pip's World Game 1 by Mr. Pips (PD) [b1]"
+	description "Pip's World Game 1 by Mr. Pips (PD) [b1]"
+	rom ( name "Pip's World Game 1 by Mr. Pips (PD) [b1].z64" crc 5F3ACBD9 )
+)
+
+game (
+	name "Pip's World Game 1 by Mr. Pips (PD)"
+	description "Pip's World Game 1 by Mr. Pips (PD)"
+	rom ( name "Pip's World Game 1 by Mr. Pips (PD).z64" crc 36D3FBD2 )
+)
+
+game (
+	name "Pip's World Game 2 by Mr. Pips (PD) [b1]"
+	description "Pip's World Game 2 by Mr. Pips (PD) [b1]"
+	rom ( name "Pip's World Game 2 by Mr. Pips (PD) [b1].z64" crc 8E2B9445 )
+)
+
+game (
+	name "Pip's World Game 2 by Mr. Pips (PD)"
+	description "Pip's World Game 2 by Mr. Pips (PD)"
+	rom ( name "Pip's World Game 2 by Mr. Pips (PD).z64" crc 03EE5C91 )
+)
+
+game (
+	name "Pipendo by Mr. Pips (PD)"
+	description "Pipendo by Mr. Pips (PD)"
+	rom ( name "Pipendo by Mr. Pips (PD).z64" crc F7AAAB1C )
+)
+
+game (
+	name "Pong by Oman (PD) [a1]"
+	description "Pong by Oman (PD) [a1]"
+	rom ( name "Pong by Oman (PD) [a1].z64" crc 49238810 )
+)
+
+game (
+	name "Pong by Oman (PD) [h1C][o1]"
+	description "Pong by Oman (PD) [h1C][o1]"
+	rom ( name "Pong by Oman (PD) [h1C][o1].z64" crc C7D62967 )
+)
+
+game (
+	name "Pong by Oman (PD) [t1]"
+	description "Pong by Oman (PD) [t1]"
+	rom ( name "Pong by Oman (PD) [t1].z64" crc BE397968 )
+)
+
+game (
+	name "Pong by Oman (PD)"
+	description "Pong by Oman (PD)"
+	rom ( name "Pong by Oman (PD).z64" crc DFF8F71A )
+)
+
+game (
+	name "Pong V0.01 by Omsk (PD)"
+	description "Pong V0.01 by Omsk (PD)"
+	rom ( name "Pong V0.01 by Omsk (PD).z64" crc 6F5C095E )
+)
+
+game (
+	name "Puzzle Master 64 by Michael Searl (PD)"
+	description "Puzzle Master 64 by Michael Searl (PD)"
+	rom ( name "Puzzle Master 64 by Michael Searl (PD).z64" crc 8CEF5822 )
+)
+
+game (
+	name "Shuffle Puck 64 (PD)"
+	description "Shuffle Puck 64 (PD)"
+	rom ( name "Shuffle Puck 64 (PD).z64" crc DDDDA2C6 )
+)
+
+game (
+	name "Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD)"
+	description "Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD)"
+	rom ( name "Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD).z64" crc 5EAB0F34 )
+)
+
+game (
+	name "Sinus (PD)"
+	description "Sinus (PD)"
+	rom ( name "Sinus (PD).z64" crc D7679079 )
+)
+
+game (
+	name "SLiDeS (PD)"
+	description "SLiDeS (PD)"
+	rom ( name "SLiDeS (PD).z64" crc 76B35C44 )
+)
+
+game (
+	name "Spacer by Memir (POM '99) (PD) [t1]"
+	description "Spacer by Memir (POM '99) (PD) [t1]"
+	rom ( name "Spacer by Memir (POM '99) (PD) [t1].z64" crc 01C93AFE )
+)
+
+game (
+	name "Spacer by Memir (POM '99) (PD) [t2]"
+	description "Spacer by Memir (POM '99) (PD) [t2]"
+	rom ( name "Spacer by Memir (POM '99) (PD) [t2].z64" crc 6791F671 )
+)
+
+game (
+	name "Spacer by Memir (POM '99) (PD) [t2][b1]"
+	description "Spacer by Memir (POM '99) (PD) [t2][b1]"
+	rom ( name "Spacer by Memir (POM '99) (PD) [t2][b1].z64" crc E62AE0EB )
+)
+
+game (
+	name "Spacer by Memir (POM '99) (PD)"
+	description "Spacer by Memir (POM '99) (PD)"
+	rom ( name "Spacer by Memir (POM '99) (PD).z64" crc DC0D3F8A )
+)
+
+game (
+	name "SPLiT's Nacho64 by SPLiT (PD) [f1] (PAL)"
+	description "SPLiT's Nacho64 by SPLiT (PD) [f1] (PAL)"
+	rom ( name "SPLiT's Nacho64 by SPLiT (PD) [f1] (PAL).z64" crc AD7990A9 )
+)
+
+game (
+	name "SPLiT's Nacho64 by SPLiT (PD)"
+	description "SPLiT's Nacho64 by SPLiT (PD)"
+	rom ( name "SPLiT's Nacho64 by SPLiT (PD).z64" crc 4C3DA466 )
+)
+
+game (
+	name "Sporting Clays by Charles Doty (PD) [a1]"
+	description "Sporting Clays by Charles Doty (PD) [a1]"
+	rom ( name "Sporting Clays by Charles Doty (PD) [a1].z64" crc 2EC84B48 )
+)
+
+game (
+	name "Sporting Clays by Charles Doty (PD) [b1]"
+	description "Sporting Clays by Charles Doty (PD) [b1]"
+	rom ( name "Sporting Clays by Charles Doty (PD) [b1].z64" crc 8FB5ADBC )
+)
+
+game (
+	name "Sporting Clays by Charles Doty (PD)"
+	description "Sporting Clays by Charles Doty (PD)"
+	rom ( name "Sporting Clays by Charles Doty (PD).z64" crc 2471C621 )
+)
+
+game (
+	name "Super Bomberman 2 by Rider (POM '99) (PD)"
+	description "Super Bomberman 2 by Rider (POM '99) (PD)"
+	rom ( name "Super Bomberman 2 by Rider (POM '99) (PD).z64" crc FCB72EC3 )
+)
+
+game (
+	name "Twintris by Twinsen (POM '98) (PD)"
+	description "Twintris by Twinsen (POM '98) (PD)"
+	rom ( name "Twintris by Twinsen (POM '98) (PD).z64" crc 7FDFF7E7 )
+)
+
+game (
+	name "Ultrafox 64 by Megahawks (PD)"
+	description "Ultrafox 64 by Megahawks (PD)"
+	rom ( name "Ultrafox 64 by Megahawks (PD).z64" crc 12F0D7B4 )
+)
+
+game (
+	name "Wet Dreams Readme by Immortal (POM '99) (PD)"
+	description "Wet Dreams Readme by Immortal (POM '99) (PD)"
+	rom ( name "Wet Dreams Readme by Immortal (POM '99) (PD).z64" crc 80FA548D )
+)
+
+game (
+	name "1964 Demo by Steb (PD)"
+	description "1964 Demo by Steb (PD)"
+	rom ( name "1964 Demo by Steb (PD).z64" crc 2336871B )
+)
+
+game (
+	name "Birthday Demo for Steve by Nep (PD) [b1]"
+	description "Birthday Demo for Steve by Nep (PD) [b1]"
+	rom ( name "Birthday Demo for Steve by Nep (PD) [b1].z64" crc 5AF2EFE0 )
+)
+
+game (
+	name "Birthday Demo for Steve by Nep (PD)"
+	description "Birthday Demo for Steve by Nep (PD)"
+	rom ( name "Birthday Demo for Steve by Nep (PD).z64" crc 50B40D33 )
+)
+
+game (
+	name "Chaos 89 Demo (PD)"
+	description "Chaos 89 Demo (PD)"
+	rom ( name "Chaos 89 Demo (PD).z64" crc 0EC05E31 )
+)
+
+game (
+	name "Christmas Flame Demo by Halley's Comet Software (PD)"
+	description "Christmas Flame Demo by Halley's Comet Software (PD)"
+	rom ( name "Christmas Flame Demo by Halley's Comet Software (PD).z64" crc B16E26C5 )
+)
+
+game (
+	name "Congratulations Demo for SPLiT by Widget and Immortal (PD) [b1]"
+	description "Congratulations Demo for SPLiT by Widget and Immortal (PD) [b1]"
+	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD) [b1].z64" crc 3901A5B5 )
+)
+
+game (
+	name "Congratulations Demo for SPLiT by Widget and Immortal (PD)"
+	description "Congratulations Demo for SPLiT by Widget and Immortal (PD)"
+	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD).z64" crc F3A9B5AC )
+)
+
+game (
+	name "Cube Demo (PD) [b1]"
+	description "Cube Demo (PD) [b1]"
+	rom ( name "Cube Demo (PD) [b1].z64" crc 663CCA5B )
+)
+
+game (
+	name "Cube Demo (PD) [b2]"
+	description "Cube Demo (PD) [b2]"
+	rom ( name "Cube Demo (PD) [b2].z64" crc FBEAD436 )
+)
+
+game (
+	name "Cube Demo (PD)"
+	description "Cube Demo (PD)"
+	rom ( name "Cube Demo (PD).z64" crc C8ABE90C )
+)
+
+game (
+	name "Cube Demo by Msftug (PD)"
+	description "Cube Demo by Msftug (PD)"
+	rom ( name "Cube Demo by Msftug (PD).z64" crc A63621FF )
+)
+
+game (
+	name "Display List Ate My Mind Demo by Kid Stardust (PD)"
+	description "Display List Ate My Mind Demo by Kid Stardust (PD)"
+	rom ( name "Display List Ate My Mind Demo by Kid Stardust (PD).z64" crc 01D47287 )
+)
+
+game (
+	name "DKONG Demo (PD)"
+	description "DKONG Demo (PD)"
+	rom ( name "DKONG Demo (PD).z64" crc 40A32FC4 )
+)
+
+game (
+	name "Explode Demo by NaN (PD)"
+	description "Explode Demo by NaN (PD)"
+	rom ( name "Explode Demo by NaN (PD).z64" crc 4ADE6D08 )
+)
+
+game (
+	name "Fire Demo by Lac (PD)"
+	description "Fire Demo by Lac (PD)"
+	rom ( name "Fire Demo by Lac (PD).z64" crc A827A178 )
+)
+
+game (
+	name "Fireworks Demo by CrowTRobo (PD)"
+	description "Fireworks Demo by CrowTRobo (PD)"
+	rom ( name "Fireworks Demo by CrowTRobo (PD).z64" crc C49262F7 )
+)
+
+game (
+	name "Fish Demo by NaN (PD)"
+	description "Fish Demo by NaN (PD)"
+	rom ( name "Fish Demo by NaN (PD).z64" crc 5A7D1331 )
+)
+
+game (
+	name "Fogworld USA Demo by Horizon64 (PD) [h1C][o1]"
+	description "Fogworld USA Demo by Horizon64 (PD) [h1C][o1]"
+	rom ( name "Fogworld USA Demo by Horizon64 (PD) [h1C][o1].z64" crc CBE4B416 )
+)
+
+game (
+	name "Fogworld USA Demo by Horizon64 (PD)"
+	description "Fogworld USA Demo by Horizon64 (PD)"
+	rom ( name "Fogworld USA Demo by Horizon64 (PD).z64" crc A0B6250D )
+)
+
+game (
+	name "Fractal Zoomer Demo by RedboX (PD)"
+	description "Fractal Zoomer Demo by RedboX (PD)"
+	rom ( name "Fractal Zoomer Demo by RedboX (PD).z64" crc D10EA06A )
+)
+
+game (
+	name "Friendship Demo by Renderman (PD) [b1]"
+	description "Friendship Demo by Renderman (PD) [b1]"
+	rom ( name "Friendship Demo by Renderman (PD) [b1].z64" crc 4FAE1EDF )
+)
+
+game (
+	name "Friendship Demo by Renderman (PD)"
+	description "Friendship Demo by Renderman (PD)"
+	rom ( name "Friendship Demo by Renderman (PD).z64" crc B38A50E8 )
+)
+
+game (
+	name "GT Demo (PD) [a1]"
+	description "GT Demo (PD) [a1]"
+	rom ( name "GT Demo (PD) [a1].z64" crc FB2C9648 )
+)
+
+game (
+	name "GT Demo (PD)"
+	description "GT Demo (PD)"
+	rom ( name "GT Demo (PD).z64" crc 51A3A682 )
+)
+
+game (
+	name "Hard Coded Demo by Silo and Fractal (PD) [a1]"
+	description "Hard Coded Demo by Silo and Fractal (PD) [a1]"
+	rom ( name "Hard Coded Demo by Silo and Fractal (PD) [a1].z64" crc 713D8AF3 )
+)
+
+game (
+	name "Hard Coded Demo by Silo and Fractal (PD)"
+	description "Hard Coded Demo by Silo and Fractal (PD)"
+	rom ( name "Hard Coded Demo by Silo and Fractal (PD).z64" crc 44E52674 )
+)
+
+game (
+	name "Hard Pom '99 Demo by TS_Garp (POM '99) (PD)"
+	description "Hard Pom '99 Demo by TS_Garp (POM '99) (PD)"
+	rom ( name "Hard Pom '99 Demo by TS_Garp (POM '99) (PD).z64" crc 227992C1 )
+)
+
+game (
+	name "Heavy 64 Demo by Destop (PD)"
+	description "Heavy 64 Demo by Destop (PD)"
+	rom ( name "Heavy 64 Demo by Destop (PD).z64" crc F94F368F )
+)
+
+game (
+	name "HiRes CFB Demo (PD)"
+	description "HiRes CFB Demo (PD)"
+	rom ( name "HiRes CFB Demo (PD).z64" crc 2925B3F3 )
+)
+
+game (
+	name "LCARS Demo by WT Riker (PD) [b1]"
+	description "LCARS Demo by WT Riker (PD) [b1]"
+	rom ( name "LCARS Demo by WT Riker (PD) [b1].z64" crc 8E8AED5E )
+)
+
+game (
+	name "LCARS Demo by WT Riker (PD)"
+	description "LCARS Demo by WT Riker (PD)"
+	rom ( name "LCARS Demo by WT Riker (PD).z64" crc B5BBDD7F )
+)
+
+game (
+	name "Light Force First N64 Demo by Fractal (PD)"
+	description "Light Force First N64 Demo by Fractal (PD)"
+	rom ( name "Light Force First N64 Demo by Fractal (PD).z64" crc 4652C058 )
+)
+
+game (
+	name "MAME 64 Demo (PD) [b1]"
+	description "MAME 64 Demo (PD) [b1]"
+	rom ( name "MAME 64 Demo (PD) [b1].z64" crc A033C664 )
+)
+
+game (
+	name "MAME 64 Demo (PD) [b2]"
+	description "MAME 64 Demo (PD) [b2]"
+	rom ( name "MAME 64 Demo (PD) [b2].z64" crc 6D7663ED )
+)
+
+game (
+	name "MAME 64 Demo (PD)"
+	description "MAME 64 Demo (PD)"
+	rom ( name "MAME 64 Demo (PD).z64" crc B8FD2E8B )
+)
+
+game (
+	name "MeeTING Demo by Renderman (PD) [b1]"
+	description "MeeTING Demo by Renderman (PD) [b1]"
+	rom ( name "MeeTING Demo by Renderman (PD) [b1].z64" crc 8D6E473F )
+)
+
+game (
+	name "MeeTING Demo by Renderman (PD)"
+	description "MeeTING Demo by Renderman (PD)"
+	rom ( name "MeeTING Demo by Renderman (PD).z64" crc 63EC31A1 )
+)
+
+game (
+	name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD) [b1]"
+	description "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD) [b1]"
+	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD) [b1].z64" crc 7B38E6C7 )
+)
+
+game (
+	name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD)"
+	description "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD)"
+	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD).z64" crc 390EF548 )
+)
+
+game (
+	name "Mind Present Demo Readme by Widget and Immortal (POM '98) (PD)"
+	description "Mind Present Demo Readme by Widget and Immortal (POM '98) (PD)"
+	rom ( name "Mind Present Demo Readme by Widget and Immortal (POM '98) (PD).z64" crc D348C33F )
+)
+
+game (
+	name "Money Creates Taste Demo by Count0 (POM '99) (PD) [f1]"
+	description "Money Creates Taste Demo by Count0 (POM '99) (PD) [f1]"
+	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD) [f1].z64" crc 8A909B08 )
+)
+
+game (
+	name "Money Creates Taste Demo by Count0 (POM '99) (PD)"
+	description "Money Creates Taste Demo by Count0 (POM '99) (PD)"
+	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD).z64" crc B154E087 )
+)
+
+game (
+	name "My Angel Demo (PD)"
+	description "My Angel Demo (PD)"
+	rom ( name "My Angel Demo (PD).z64" crc D55D55EF )
+)
+
+game (
+	name "N64 Seminar Demo - CPU by ZoRAXE (PD)"
+	description "N64 Seminar Demo - CPU by ZoRAXE (PD)"
+	rom ( name "N64 Seminar Demo - CPU by ZoRAXE (PD).z64" crc 6093FAE0 )
+)
+
+game (
+	name "N64 Seminar Demo - RSP by ZoRAXE (PD)"
+	description "N64 Seminar Demo - RSP by ZoRAXE (PD)"
+	rom ( name "N64 Seminar Demo - RSP by ZoRAXE (PD).z64" crc 6E476896 )
+)
+
+game (
+	name "N64 Stars Demo (PD) [b1]"
+	description "N64 Stars Demo (PD) [b1]"
+	rom ( name "N64 Stars Demo (PD) [b1].z64" crc A56117AF )
+)
+
+game (
+	name "N64 Stars Demo (PD)"
+	description "N64 Stars Demo (PD)"
+	rom ( name "N64 Stars Demo (PD).z64" crc 3210B3F2 )
+)
+
+game (
+	name "NBCG's Kings of Porn Demo (PD)"
+	description "NBCG's Kings of Porn Demo (PD)"
+	rom ( name "NBCG's Kings of Porn Demo (PD).z64" crc 30C0D79A )
+)
+
+game (
+	name "NBCrew 2 Demo (PD)"
+	description "NBCrew 2 Demo (PD)"
+	rom ( name "NBCrew 2 Demo (PD).z64" crc A57D3BDA )
+)
+
+game (
+	name "NEO Myth N64 Menu Demo V0.1 (PD)"
+	description "NEO Myth N64 Menu Demo V0.1 (PD)"
+	rom ( name "NEO Myth N64 Menu Demo V0.1 (PD).z64" crc FC989FD7 )
+)
+
+game (
+	name "Nintendo On My Mind Demo by Kid Stardust (PD)"
+	description "Nintendo On My Mind Demo by Kid Stardust (PD)"
+	rom ( name "Nintendo On My Mind Demo by Kid Stardust (PD).z64" crc 23E051F4 )
+)
+
+game (
+	name "Nintro64 Demo by Lem (POM '98) (PD) [b1]"
+	description "Nintro64 Demo by Lem (POM '98) (PD) [b1]"
+	rom ( name "Nintro64 Demo by Lem (POM '98) (PD) [b1].z64" crc C581EE0D )
+)
+
+game (
+	name "Nintro64 Demo by Lem (POM '98) (PD)"
+	description "Nintro64 Demo by Lem (POM '98) (PD)"
+	rom ( name "Nintro64 Demo by Lem (POM '98) (PD).z64" crc D79DA002 )
+)
+
+game (
+	name "NuFan Demo by Kid Stardust (PD) [b1]"
+	description "NuFan Demo by Kid Stardust (PD) [b1]"
+	rom ( name "NuFan Demo by Kid Stardust (PD) [b1].z64" crc C2B3B43C )
+)
+
+game (
+	name "NuFan Demo by Kid Stardust (PD)"
+	description "NuFan Demo by Kid Stardust (PD)"
+	rom ( name "NuFan Demo by Kid Stardust (PD).z64" crc 3C637D2B )
+)
+
+game (
+	name "Pamela Demo (PD)"
+	description "Pamela Demo (PD)"
+	rom ( name "Pamela Demo (PD).z64" crc 74F01EC6 )
+)
+
+game (
+	name "Pamela Demo - Resized (PD)"
+	description "Pamela Demo - Resized (PD)"
+	rom ( name "Pamela Demo - Resized (PD).z64" crc 1607EEBD )
+)
+
+game (
+	name "Pause Demo by RedboX (PD)"
+	description "Pause Demo by RedboX (PD)"
+	rom ( name "Pause Demo by RedboX (PD).z64" crc AAC99313 )
+)
+
+game (
+	name "Plasma Demo (PD) [a1]"
+	description "Plasma Demo (PD) [a1]"
+	rom ( name "Plasma Demo (PD) [a1].z64" crc 92984BE1 )
+)
+
+game (
+	name "Plasma Demo (PD)"
+	description "Plasma Demo (PD)"
+	rom ( name "Plasma Demo (PD).z64" crc 57FE4E68 )
+)
+
+game (
+	name "Pom Part 1 Demo (PD)"
+	description "Pom Part 1 Demo (PD)"
+	rom ( name "Pom Part 1 Demo (PD).z64" crc DC92EAF6 )
+)
+
+game (
+	name "Pom Part 2 Demo (PD)"
+	description "Pom Part 2 Demo (PD)"
+	rom ( name "Pom Part 2 Demo (PD).z64" crc A88FDEAC )
+)
+
+game (
+	name "Pom Part 3 Demo (PD)"
+	description "Pom Part 3 Demo (PD)"
+	rom ( name "Pom Part 3 Demo (PD).z64" crc 23D33929 )
+)
+
+game (
+	name "Pom Part 4 Demo (PD)"
+	description "Pom Part 4 Demo (PD)"
+	rom ( name "Pom Part 4 Demo (PD).z64" crc B8FDC6DC )
+)
+
+game (
+	name "Pom Part 5 Demo (PD)"
+	description "Pom Part 5 Demo (PD)"
+	rom ( name "Pom Part 5 Demo (PD).z64" crc 13C05DDA )
+)
+
+game (
+	name "POMbaer Demo by Kid Stardust (POM '99) (PD)"
+	description "POMbaer Demo by Kid Stardust (POM '99) (PD)"
+	rom ( name "POMbaer Demo by Kid Stardust (POM '99) (PD).z64" crc 9E6FD36C )
+)
+
+game (
+	name "POMolizer Demo by Renderman (POM '99) (PD)"
+	description "POMolizer Demo by Renderman (POM '99) (PD)"
+	rom ( name "POMolizer Demo by Renderman (POM '99) (PD).z64" crc 0F34D619 )
+)
+
+game (
+	name "Psychodelic Demo by Ste (POM '98) (PD) [b1]"
+	description "Psychodelic Demo by Ste (POM '98) (PD) [b1]"
+	rom ( name "Psychodelic Demo by Ste (POM '98) (PD) [b1].z64" crc 331A7257 )
+)
+
+game (
+	name "Psychodelic Demo by Ste (POM '98) (PD)"
+	description "Psychodelic Demo by Ste (POM '98) (PD)"
+	rom ( name "Psychodelic Demo by Ste (POM '98) (PD).z64" crc 4F03510F )
+)
+
+game (
+	name "R.I.P. Jay Demo by Ste (PD) [b1]"
+	description "R.I.P. Jay Demo by Ste (PD) [b1]"
+	rom ( name "R.I.P. Jay Demo by Ste (PD) [b1].z64" crc FEE6EE6D )
+)
+
+game (
+	name "R.I.P. Jay Demo by Ste (PD)"
+	description "R.I.P. Jay Demo by Ste (PD)"
+	rom ( name "R.I.P. Jay Demo by Ste (PD).z64" crc A916DFF5 )
+)
+
+game (
+	name "Rotating Demo USA by Rene (PD) [a1]"
+	description "Rotating Demo USA by Rene (PD) [a1]"
+	rom ( name "Rotating Demo USA by Rene (PD) [a1].z64" crc 9C2A266B )
+)
+
+game (
+	name "Rotating Demo USA by Rene (PD)"
+	description "Rotating Demo USA by Rene (PD)"
+	rom ( name "Rotating Demo USA by Rene (PD).z64" crc 95E9D320 )
+)
+
+game (
+	name "Sample Demo by Florian (PD) [b1]"
+	description "Sample Demo by Florian (PD) [b1]"
+	rom ( name "Sample Demo by Florian (PD) [b1].z64" crc 39153954 )
+)
+
+game (
+	name "Sample Demo by Florian (PD)"
+	description "Sample Demo by Florian (PD)"
+	rom ( name "Sample Demo by Florian (PD).z64" crc 096430D1 )
+)
+
+game (
+	name "Shag'a'Delic Demo by Steve and NEP (PD)"
+	description "Shag'a'Delic Demo by Steve and NEP (PD)"
+	rom ( name "Shag'a'Delic Demo by Steve and NEP (PD).z64" crc 29FCF3CB )
+)
+
+game (
+	name "Sitero Demo by Renderman (PD)"
+	description "Sitero Demo by Renderman (PD)"
+	rom ( name "Sitero Demo by Renderman (PD).z64" crc 223B828E )
+)
+
+game (
+	name "Spice Girls Rotator Demo by RedboX (PD) [a1]"
+	description "Spice Girls Rotator Demo by RedboX (PD) [a1]"
+	rom ( name "Spice Girls Rotator Demo by RedboX (PD) [a1].z64" crc F36AD81B )
+)
+
+game (
+	name "Spice Girls Rotator Demo by RedboX (PD)"
+	description "Spice Girls Rotator Demo by RedboX (PD)"
+	rom ( name "Spice Girls Rotator Demo by RedboX (PD).z64" crc 40402197 )
+)
+
+game (
+	name "Split! 3D Demo by Lem (PD)"
+	description "Split! 3D Demo by Lem (PD)"
+	rom ( name "Split! 3D Demo by Lem (PD).z64" crc FBE321BA )
+)
+
+game (
+	name "Summer64 Demo by Lem (PD) [b1]"
+	description "Summer64 Demo by Lem (PD) [b1]"
+	rom ( name "Summer64 Demo by Lem (PD) [b1].z64" crc 5D33DCAF )
+)
+
+game (
+	name "Summer64 Demo by Lem (PD)"
+	description "Summer64 Demo by Lem (PD)"
+	rom ( name "Summer64 Demo by Lem (PD).z64" crc 0D13E643 )
+)
+
+game (
+	name "Super Fighter Demo Halley's Comet Software (PD)"
+	description "Super Fighter Demo Halley's Comet Software (PD)"
+	rom ( name "Super Fighter Demo Halley's Comet Software (PD).z64" crc D0DC2237 )
+)
+
+game (
+	name "T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1]"
+	description "T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1]"
+	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1].z64" crc E0B60B7E )
+)
+
+game (
+	name "T-Shirt Demo by Neptune and Steve (POM '98) (PD)"
+	description "T-Shirt Demo by Neptune and Steve (POM '98) (PD)"
+	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD).z64" crc 0CB63DF2 )
+)
+
+game (
+	name "Tetris Beta Demo by FusionMan (POM '98) (PD) [b1]"
+	description "Tetris Beta Demo by FusionMan (POM '98) (PD) [b1]"
+	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD) [b1].z64" crc 17C191C8 )
+)
+
+game (
+	name "Tetris Beta Demo by FusionMan (POM '98) (PD)"
+	description "Tetris Beta Demo by FusionMan (POM '98) (PD)"
+	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD).z64" crc F96778D2 )
+)
+
+game (
+	name "Textlight Demo by Horizon64 (PD) [b1]"
+	description "Textlight Demo by Horizon64 (PD) [b1]"
+	rom ( name "Textlight Demo by Horizon64 (PD) [b1].z64" crc 0FEB3819 )
+)
+
+game (
+	name "Textlight Demo by Horizon64 (PD)"
+	description "Textlight Demo by Horizon64 (PD)"
+	rom ( name "Textlight Demo by Horizon64 (PD).z64" crc D0931871 )
+)
+
+game (
+	name "The Corporation XMAS Demo '99 by TS_Garp (PD) [b1]"
+	description "The Corporation XMAS Demo '99 by TS_Garp (PD) [b1]"
+	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD) [b1].z64" crc 19CFC4A4 )
+)
+
+game (
+	name "The Corporation XMAS Demo '99 by TS_Garp (PD)"
+	description "The Corporation XMAS Demo '99 by TS_Garp (PD)"
+	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD).z64" crc 933AE249 )
+)
+
+game (
+	name "TheMuscularDemo by megahawks (PD)"
+	description "TheMuscularDemo by megahawks (PD)"
+	rom ( name "TheMuscularDemo by megahawks (PD).v64" crc 2CB9F365 )
+)
+
+game (
+	name "Tom Demo (PD)"
+	description "Tom Demo (PD)"
+	rom ( name "Tom Demo (PD).z64" crc 94F1E1E9 )
+)
+
+game (
+	name "TopGun Demo by Horizon64 (PD)"
+	description "TopGun Demo by Horizon64 (PD)"
+	rom ( name "TopGun Demo by Horizon64 (PD).z64" crc BAC738E4 )
+)
+
+game (
+	name "TR64 Demo by FIres and Icepir8 (PD)"
+	description "TR64 Demo by FIres and Icepir8 (PD)"
+	rom ( name "TR64 Demo by FIres and Icepir8 (PD).z64" crc BDE293C7 )
+)
+
+game (
+	name "TRON Demo (PD) [a1]"
+	description "TRON Demo (PD) [a1]"
+	rom ( name "TRON Demo (PD) [a1].z64" crc 40ACE055 )
+)
+
+game (
+	name "TRON Demo (PD)"
+	description "TRON Demo (PD)"
+	rom ( name "TRON Demo (PD).z64" crc 4158E22A )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (older) (PD) [b1]"
+	description "U64 (Chrome) Demo by Horizon64 (older) (PD) [b1]"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD) [b1].z64" crc FC014665 )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (older) (PD)"
+	description "U64 (Chrome) Demo by Horizon64 (older) (PD)"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD).z64" crc 58423A11 )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (PD) [a1]"
+	description "U64 (Chrome) Demo by Horizon64 (PD) [a1]"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1].z64" crc 429526BE )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (PD) [a1][b1]"
+	description "U64 (Chrome) Demo by Horizon64 (PD) [a1][b1]"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1][b1].z64" crc 1846D8E6 )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (PD) [b1]"
+	description "U64 (Chrome) Demo by Horizon64 (PD) [b1]"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [b1].z64" crc A586FCD8 )
+)
+
+game (
+	name "U64 (Chrome) Demo by Horizon64 (PD)"
+	description "U64 (Chrome) Demo by Horizon64 (PD)"
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD).z64" crc C0C70544 )
+)
+
+game (
+	name "Ultra Demo Bootcode by Locke^ (PD) [h1C]"
+	description "Ultra Demo Bootcode by Locke^ (PD) [h1C]"
+	rom ( name "Ultra Demo Bootcode by Locke^ (PD) [h1C].z64" crc 7E0E4BAE )
+)
+
+game (
+	name "Ultra Demo Bootcode by Locke^ (PD)"
+	description "Ultra Demo Bootcode by Locke^ (PD)"
+	rom ( name "Ultra Demo Bootcode by Locke^ (PD).z64" crc 121ACA7D )
+)
+
+game (
+	name "Ultra Demo by Locke^ (PD) [a1]"
+	description "Ultra Demo by Locke^ (PD) [a1]"
+	rom ( name "Ultra Demo by Locke^ (PD) [a1].z64" crc 6A372C49 )
+)
+
+game (
+	name "Ultra Demo by Locke^ (PD)"
+	description "Ultra Demo by Locke^ (PD)"
+	rom ( name "Ultra Demo by Locke^ (PD).z64" crc 7642CA11 )
+)
+
+game (
+	name "Vector Demo by Destop (POM '99) (PD)"
+	description "Vector Demo by Destop (POM '99) (PD)"
+	rom ( name "Vector Demo by Destop (POM '99) (PD).z64" crc A23FFA73 )
+)
+
+game (
+	name "Wet Dreams Can Beta Demo by Immortal (POM '99) (PD)"
+	description "Wet Dreams Can Beta Demo by Immortal (POM '99) (PD)"
+	rom ( name "Wet Dreams Can Beta Demo by Immortal (POM '99) (PD).z64" crc 690D2946 )
+)
+
+game (
+	name "Wet Dreams Madeiragames Demo by Immortal (POM '99) (PD)"
+	description "Wet Dreams Madeiragames Demo by Immortal (POM '99) (PD)"
+	rom ( name "Wet Dreams Madeiragames Demo by Immortal (POM '99) (PD).z64" crc 38CECB99 )
+)
+
+game (
+	name "Wet Dreams Main Demo by Immortal (POM '99) (PD)"
+	description "Wet Dreams Main Demo by Immortal (POM '99) (PD)"
+	rom ( name "Wet Dreams Main Demo by Immortal (POM '99) (PD).z64" crc 965C7727 )
+)
+
+game (
+	name "XtraLife Dextrose Demo by RedboX (PD) [h1C]"
+	description "XtraLife Dextrose Demo by RedboX (PD) [h1C]"
+	rom ( name "XtraLife Dextrose Demo by RedboX (PD) [h1C].z64" crc FCC9D3EA )
+)
+
+game (
+	name "XtraLife Dextrose Demo by RedboX (PD)"
+	description "XtraLife Dextrose Demo by RedboX (PD)"
+	rom ( name "XtraLife Dextrose Demo by RedboX (PD).z64" crc 1A4654A4 )
+)
+
+game (
+	name "Y2K Demo by WT_Riker (PD) [b1]"
+	description "Y2K Demo by WT_Riker (PD) [b1]"
+	rom ( name "Y2K Demo by WT_Riker (PD) [b1].z64" crc B40A130D )
+)
+
+game (
+	name "Y2K Demo by WT_Riker (PD)"
+	description "Y2K Demo by WT_Riker (PD)"
+	rom ( name "Y2K Demo by WT_Riker (PD).z64" crc CC2762C7 )
+)
+
+game (
+	name "GBlator for CD64 (PD) [f1] (V64-PAL)"
+	description "GBlator for CD64 (PD) [f1] (V64-PAL)"
+	rom ( name "GBlator for CD64 (PD) [f1] (V64-PAL).z64" crc E2E97639 )
+)
+
+game (
+	name "GBlator for CD64 (PD)"
+	description "GBlator for CD64 (PD)"
+	rom ( name "GBlator for CD64 (PD).z64" crc 9C8F0F5F )
+)
+
+game (
+	name "GBlator for NTSC Dr V64 (PD)"
+	description "GBlator for NTSC Dr V64 (PD)"
+	rom ( name "GBlator for NTSC Dr V64 (PD).z64" crc F7BB3DCD )
+)
+
+game (
+	name "GBlator for PAL Dr V64 (PD)"
+	description "GBlator for PAL Dr V64 (PD)"
+	rom ( name "GBlator for PAL Dr V64 (PD).z64" crc D1040F61 )
+)
+
+game (
+	name "Neon64 First Public Beta Release by Halley's Comet Software (PD)"
+	description "Neon64 First Public Beta Release by Halley's Comet Software (PD)"
+	rom ( name "Neon64 First Public Beta Release by Halley's Comet Software (PD).z64" crc 27778CE1 )
+)
+
+game (
+	name "Neon64 First Public Beta Release V2 by Halley's Comet Software (PD)"
+	description "Neon64 First Public Beta Release V2 by Halley's Comet Software (PD)"
+	rom ( name "Neon64 First Public Beta Release V2 by Halley's Comet Software (PD).z64" crc 23674549 )
+)
+
+game (
+	name "Neon64 First Public Beta Release V3 by Halley's Comet Software (PD)"
+	description "Neon64 First Public Beta Release V3 by Halley's Comet Software (PD)"
+	rom ( name "Neon64 First Public Beta Release V3 by Halley's Comet Software (PD).z64" crc 2FB21AF0 )
+)
+
+game (
+	name "Neon64 GS V1.05 (Gameshark Version) (PD)"
+	description "Neon64 GS V1.05 (Gameshark Version) (PD)"
+	rom ( name "Neon64 GS V1.05 (Gameshark Version) (PD).bin" crc 9574F823 )
+)
+
+game (
+	name "Neon64 GS V1.1 (Gameshark Version) (PD)"
+	description "Neon64 GS V1.1 (Gameshark Version) (PD)"
+	rom ( name "Neon64 GS V1.1 (Gameshark Version) (PD).bin" crc 42CC8F66 )
+)
+
+game (
+	name "Neon64 GS V1.2 (Gameshark Version) (PD)"
+	description "Neon64 GS V1.2 (Gameshark Version) (PD)"
+	rom ( name "Neon64 GS V1.2 (Gameshark Version) (PD).bin" crc 03FFAB8E )
+)
+
+game (
+	name "Neon64 GS V1.2 (Pro Action Replay Version) (PD)"
+	description "Neon64 GS V1.2 (Pro Action Replay Version) (PD)"
+	rom ( name "Neon64 GS V1.2 (Pro Action Replay Version) (PD).bin" crc 96179E7A )
+)
+
+game (
+	name "Neon64 GS V1.2a (Gameshark Version) (PD)"
+	description "Neon64 GS V1.2a (Gameshark Version) (PD)"
+	rom ( name "Neon64 GS V1.2a (Gameshark Version) (PD).bin" crc 2F6E5A23 )
+)
+
+game (
+	name "Neon64 GS V1.2a (Pro Action Replay Version) (PD)"
+	description "Neon64 GS V1.2a (Pro Action Replay Version) (PD)"
+	rom ( name "Neon64 GS V1.2a (Pro Action Replay Version) (PD).bin" crc 740355D6 )
+)
+
+game (
+	name "Neon64 V1.0 by Halley's Comet Software (PD)"
+	description "Neon64 V1.0 by Halley's Comet Software (PD)"
+	rom ( name "Neon64 V1.0 by Halley's Comet Software (PD).z64" crc 3CA8BC6E )
+)
+
+game (
+	name "Neon64 V1.1 by Halley's Comet Software (PD) [o2]"
+	description "Neon64 V1.1 by Halley's Comet Software (PD) [o2]"
+	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD) [o2].z64" crc AAB95EE1 )
+)
+
+game (
+	name "Neon64 V1.1 by Halley's Comet Software (PD)"
+	description "Neon64 V1.1 by Halley's Comet Software (PD)"
+	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD).z64" crc 213D6889 )
+)
+
+game (
+	name "Neon64 V1.2 by Halley's Comet Software (PD) [o1]"
+	description "Neon64 V1.2 by Halley's Comet Software (PD) [o1]"
+	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD) [o1].z64" crc BAEC90EC )
+)
+
+game (
+	name "Neon64 V1.2 by Halley's Comet Software (PD)"
+	description "Neon64 V1.2 by Halley's Comet Software (PD)"
+	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD).z64" crc 36C5AB96 )
+)
+
+game (
+	name "Neon64 V1.2a by Halley's Comet Software (PD) [b1]"
+	description "Neon64 V1.2a by Halley's Comet Software (PD) [b1]"
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [b1].z64" crc 10DEA381 )
+)
+
+game (
+	name "Neon64 V1.2a by Halley's Comet Software (PD) [o1]"
+	description "Neon64 V1.2a by Halley's Comet Software (PD) [o1]"
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [o1].z64" crc BAEB6D04 )
+)
+
+game (
+	name "Neon64 V1.2a by Halley's Comet Software (PD)"
+	description "Neon64 V1.2a by Halley's Comet Software (PD)"
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD).z64" crc 93BEA654 )
+)
+
+game (
+	name "SNES 9X Alpha by Loom-Crazy Nation (PD) [f1] (V64BIOS1.91)"
+	description "SNES 9X Alpha by Loom-Crazy Nation (PD) [f1] (V64BIOS1.91)"
+	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD) [f1] (V64BIOS1.91).z64" crc 6A2F8756 )
+)
+
+game (
+	name "SNES 9X Alpha by Loom-Crazy Nation (PD)"
+	description "SNES 9X Alpha by Loom-Crazy Nation (PD)"
+	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD).z64" crc 5DCE278B )
+)
+
+game (
+	name "UltraMSX2 V1.0 by Jos Kwanten (PD) [f1] (V64)"
+	description "UltraMSX2 V1.0 by Jos Kwanten (PD) [f1] (V64)"
+	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD) [f1] (V64).z64" crc 7DCC97A4 )
+)
+
+game (
+	name "UltraMSX2 V1.0 by Jos Kwanten (PD)"
+	description "UltraMSX2 V1.0 by Jos Kwanten (PD)"
+	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD).z64" crc 4D2CC1C6 )
+)
+
+game (
+	name "UltraMSX2 V1.0 w-F1 Spirit by Jos Kwanten (PD)"
+	description "UltraMSX2 V1.0 w-F1 Spirit by Jos Kwanten (PD)"
+	rom ( name "UltraMSX2 V1.0 w-F1 Spirit by Jos Kwanten (PD).z64" crc 0255875D )
+)
+
+game (
+	name "UltraMSX2 V1.0 w-Salamander by Jos Kwanten (PD)"
+	description "UltraMSX2 V1.0 w-Salamander by Jos Kwanten (PD)"
+	rom ( name "UltraMSX2 V1.0 w-Salamander by Jos Kwanten (PD).z64" crc 264EAE81 )
+)
+
+game (
+	name "UltraSMS V1.0 by Jos Kwanten (PD) [f1] (V64)"
+	description "UltraSMS V1.0 by Jos Kwanten (PD) [f1] (V64)"
+	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD) [f1] (V64).z64" crc 03795EE4 )
+)
+
+game (
+	name "UltraSMS V1.0 by Jos Kwanten (PD)"
+	description "UltraSMS V1.0 by Jos Kwanten (PD)"
+	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD).z64" crc 6AEBCD00 )
+)
+
+game (
+	name "VNES64 + Galaga (PD)"
+	description "VNES64 + Galaga (PD)"
+	rom ( name "VNES64 + Galaga (PD).z64" crc 927B17A4 )
+)
+
+game (
+	name "VNES64 + Mario (PD)"
+	description "VNES64 + Mario (PD)"
+	rom ( name "VNES64 + Mario (PD).z64" crc 16A708B2 )
+)
+
+game (
+	name "VNES64 + Test Cart (PD)"
+	description "VNES64 + Test Cart (PD)"
+	rom ( name "VNES64 + Test Cart (PD).z64" crc A9E37BA5 )
+)
+
+game (
+	name "VNES64 V0.1 by Jean-Luc Picard (POM '98) (PD)"
+	description "VNES64 V0.1 by Jean-Luc Picard (POM '98) (PD)"
+	rom ( name "VNES64 V0.1 by Jean-Luc Picard (POM '98) (PD).z64" crc E7898D4E )
+)
+
+game (
+	name "VNES64 V0.12 by Jean-Luc Picard (PD)"
+	description "VNES64 V0.12 by Jean-Luc Picard (PD)"
+	rom ( name "VNES64 V0.12 by Jean-Luc Picard (PD).z64" crc B90D5F96 )
+)
+
+game (
+	name "Absolute Crap Intro #1 by Kid Stardust (PD) [b1]"
+	description "Absolute Crap Intro #1 by Kid Stardust (PD) [b1]"
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [b1].z64" crc 06A8EDED )
+)
+
+game (
+	name "Absolute Crap Intro #1 by Kid Stardust (PD) [h1C]"
+	description "Absolute Crap Intro #1 by Kid Stardust (PD) [h1C]"
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [h1C].z64" crc B7FBCFBF )
+)
+
+game (
+	name "Absolute Crap Intro #1 by Kid Stardust (PD)"
+	description "Absolute Crap Intro #1 by Kid Stardust (PD)"
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD).z64" crc 886E5C25 )
+)
+
+game (
+	name "Alienstyle Intro by Renderman (PD) [a1]"
+	description "Alienstyle Intro by Renderman (PD) [a1]"
+	rom ( name "Alienstyle Intro by Renderman (PD) [a1].z64" crc AFC60BF3 )
+)
+
+game (
+	name "Alienstyle Intro by Renderman (PD)"
+	description "Alienstyle Intro by Renderman (PD)"
+	rom ( name "Alienstyle Intro by Renderman (PD).z64" crc F6F9B635 )
+)
+
+game (
+	name "Cliffi's Little Intro by Cliffi (POM '99) (PD) [b1]"
+	description "Cliffi's Little Intro by Cliffi (POM '99) (PD) [b1]"
+	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD) [b1].z64" crc F3C6F1B3 )
+)
+
+game (
+	name "Cliffi's Little Intro by Cliffi (POM '99) (PD)"
+	description "Cliffi's Little Intro by Cliffi (POM '99) (PD)"
+	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD).z64" crc BB82270A )
+)
+
+game (
+	name "Dynamix Intro (Hidden Song) by Widget and Immortal (PD)"
+	description "Dynamix Intro (Hidden Song) by Widget and Immortal (PD)"
+	rom ( name "Dynamix Intro (Hidden Song) by Widget and Immortal (PD).z64" crc 7AA49C93 )
+)
+
+game (
+	name "Dynamix Intro by Widget and Immortal (PD) [h1C]"
+	description "Dynamix Intro by Widget and Immortal (PD) [h1C]"
+	rom ( name "Dynamix Intro by Widget and Immortal (PD) [h1C].z64" crc 1C24BE4D )
+)
+
+game (
+	name "Dynamix Intro by Widget and Immortal (PD)"
+	description "Dynamix Intro by Widget and Immortal (PD)"
+	rom ( name "Dynamix Intro by Widget and Immortal (PD).z64" crc E188962A )
+)
+
+game (
+	name "Eurasia First N64 Intro by Sispeo (PD)"
+	description "Eurasia First N64 Intro by Sispeo (PD)"
+	rom ( name "Eurasia First N64 Intro by Sispeo (PD).z64" crc 3E198A3C )
+)
+
+game (
+	name "Eurasia Intro by Ste (PD) [b1]"
+	description "Eurasia Intro by Ste (PD) [b1]"
+	rom ( name "Eurasia Intro by Ste (PD) [b1].z64" crc E0832EB4 )
+)
+
+game (
+	name "Eurasia Intro by Ste (PD)"
+	description "Eurasia Intro by Ste (PD)"
+	rom ( name "Eurasia Intro by Ste (PD).z64" crc AAB92D03 )
+)
+
+game (
+	name "Freekworld BBS Intro by Rene (PD) [a1]"
+	description "Freekworld BBS Intro by Rene (PD) [a1]"
+	rom ( name "Freekworld BBS Intro by Rene (PD) [a1].z64" crc E8B47508 )
+)
+
+game (
+	name "Freekworld BBS Intro by Rene (PD)"
+	description "Freekworld BBS Intro by Rene (PD)"
+	rom ( name "Freekworld BBS Intro by Rene (PD).z64" crc F909A0E2 )
+)
+
+game (
+	name "Freekworld New Intro by Ste (PD)"
+	description "Freekworld New Intro by Ste (PD)"
+	rom ( name "Freekworld New Intro by Ste (PD).z64" crc 9E092010 )
+)
+
+game (
+	name "GoldenEye 007 Intro by SonCrap (PD)"
+	description "GoldenEye 007 Intro by SonCrap (PD)"
+	rom ( name "GoldenEye 007 Intro by SonCrap (PD).z64" crc 1C95EA7D )
+)
+
+game (
+	name "HSD Quick Intro (PD)"
+	description "HSD Quick Intro (PD)"
+	rom ( name "HSD Quick Intro (PD).z64" crc D8F98B8F )
+)
+
+game (
+	name "Kid Stardust Intro with Sound by Kid Stardust (PD) [a1]"
+	description "Kid Stardust Intro with Sound by Kid Stardust (PD) [a1]"
+	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD) [a1].z64" crc A04EADEC )
+)
+
+game (
+	name "Kid Stardust Intro with Sound by Kid Stardust (PD)"
+	description "Kid Stardust Intro with Sound by Kid Stardust (PD)"
+	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD).z64" crc 4FEDB618 )
+)
+
+game (
+	name "MSFTUG Intro #1 by LaC (PD)"
+	description "MSFTUG Intro #1 by LaC (PD)"
+	rom ( name "MSFTUG Intro #1 by LaC (PD).z64" crc 5EBD8482 )
+)
+
+game (
+	name "NBC First Intro by CALi (PD)"
+	description "NBC First Intro by CALi (PD)"
+	rom ( name "NBC First Intro by CALi (PD).z64" crc DB19D4F2 )
+)
+
+game (
+	name "Oerjan Intro by Oerjan (POM '99) (PD)"
+	description "Oerjan Intro by Oerjan (POM '99) (PD)"
+	rom ( name "Oerjan Intro by Oerjan (POM '99) (PD).z64" crc 899BAE4D )
+)
+
+game (
+	name "Planet Console Intro (PD)"
+	description "Planet Console Intro (PD)"
+	rom ( name "Planet Console Intro (PD).z64" crc 266B8AF5 )
+)
+
+game (
+	name "Quake 64 Intro (PD)"
+	description "Quake 64 Intro (PD)"
+	rom ( name "Quake 64 Intro (PD).z64" crc C4DCCEBC )
+)
+
+game (
+	name "RADWAR 2K Party Inv. Intro by Ayatolloh (PD)"
+	description "RADWAR 2K Party Inv. Intro by Ayatolloh (PD)"
+	rom ( name "RADWAR 2K Party Inv. Intro by Ayatolloh (PD).z64" crc 68CA8FA8 )
+)
+
+game (
+	name "RPA Site Intro by Lem (PD)"
+	description "RPA Site Intro by Lem (PD)"
+	rom ( name "RPA Site Intro by Lem (PD).z64" crc A7EF1EE3 )
+)
+
+game (
+	name "Soncrap Intro by RedboX (PD)"
+	description "Soncrap Intro by RedboX (PD)"
+	rom ( name "Soncrap Intro by RedboX (PD).z64" crc 433F92FA )
+)
+
+game (
+	name "The Corporation 1st Intro by i_savant (PD) [b1]"
+	description "The Corporation 1st Intro by i_savant (PD) [b1]"
+	rom ( name "The Corporation 1st Intro by i_savant (PD) [b1].z64" crc C11A41E1 )
+)
+
+game (
+	name "The Corporation 1st Intro by i_savant (PD)"
+	description "The Corporation 1st Intro by i_savant (PD)"
+	rom ( name "The Corporation 1st Intro by i_savant (PD).z64" crc 78AFCB51 )
+)
+
+game (
+	name "The Corporation 2nd Intro by TS_Garp (PD) [a1]"
+	description "The Corporation 2nd Intro by TS_Garp (PD) [a1]"
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [a1].z64" crc DBB84084 )
+)
+
+game (
+	name "The Corporation 2nd Intro by TS_Garp (PD) [b1]"
+	description "The Corporation 2nd Intro by TS_Garp (PD) [b1]"
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [b1].z64" crc A8007491 )
+)
+
+game (
+	name "The Corporation 2nd Intro by TS_Garp (PD)"
+	description "The Corporation 2nd Intro by TS_Garp (PD)"
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD).z64" crc 6F91442F )
+)
+
+game (
+	name "Tristar and Lightforce Quake Intro by Ayatollah & Mike (PD)"
+	description "Tristar and Lightforce Quake Intro by Ayatollah & Mike (PD)"
+	rom ( name "Tristar and Lightforce Quake Intro by Ayatollah & Mike (PD).z64" crc C2733E40 )
+)
+
+game (
+	name "TRSI Intro by Ayatollah (POM '99) (PD)"
+	description "TRSI Intro by Ayatollah (POM '99) (PD)"
+	rom ( name "TRSI Intro by Ayatollah (POM '99) (PD).z64" crc E998917A )
+)
+
+game (
+	name "Virtual Springfield Site Intro by Presten (PD)"
+	description "Virtual Springfield Site Intro by Presten (PD)"
+	rom ( name "Virtual Springfield Site Intro by Presten (PD).z64" crc F1F3E11E )
+)
+
+game (
+	name "Analogue Test Utility by WT_Riker (POM '99) (PD) [b1]"
+	description "Analogue Test Utility by WT_Riker (POM '99) (PD) [b1]"
+	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD) [b1].z64" crc 8E095ECC )
+)
+
+game (
+	name "Analogue Test Utility by WT_Riker (POM '99) (PD)"
+	description "Analogue Test Utility by WT_Riker (POM '99) (PD)"
+	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD).z64" crc 36913E7D )
+)
+
+game (
+	name "BB SRAM Manager (PD)"
+	description "BB SRAM Manager (PD)"
+	rom ( name "BB SRAM Manager (PD).z64" crc F1C0331E )
+)
+
+game (
+	name "Boot Emu by Jovis (PD)"
+	description "Boot Emu by Jovis (PD)"
+	rom ( name "Boot Emu by Jovis (PD).z64" crc 8CE8DED7 )
+)
+
+game (
+	name "CD64 Memory Test (PD)"
+	description "CD64 Memory Test (PD)"
+	rom ( name "CD64 Memory Test (PD).z64" crc DFAB7498 )
+)
+
+game (
+	name "Diddy Kong Racing SRAM by Group5 (PD)"
+	description "Diddy Kong Racing SRAM by Group5 (PD)"
+	rom ( name "Diddy Kong Racing SRAM by Group5 (PD).z64" crc 96CCA1F2 )
+)
+
+game (
+	name "DS1 Manager V1.0 by R. Bubba Magillicutty (PD)"
+	description "DS1 Manager V1.0 by R. Bubba Magillicutty (PD)"
+	rom ( name "DS1 Manager V1.0 by R. Bubba Magillicutty (PD).z64" crc F7DB1BA0 )
+)
+
+game (
+	name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD) [T+Ita]"
+	description "DS1 Manager V1.1 by R. Bubba Magillicutty (PD) [T+Ita]"
+	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD) [T+Ita].rom" crc 91F9ED69 )
+)
+
+game (
+	name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD)"
+	description "DS1 Manager V1.1 by R. Bubba Magillicutty (PD)"
+	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD).z64" crc 66AFC5C3 )
+)
+
+game (
+	name "DS1 SRAM Manager V1.1 by _Sage_ (PD)"
+	description "DS1 SRAM Manager V1.1 by _Sage_ (PD)"
+	rom ( name "DS1 SRAM Manager V1.1 by _Sage_ (PD).z64" crc 6AEE017F )
+)
+
+game (
+	name "Evek - V64jr Save Manager by WT_Riker (PD)"
+	description "Evek - V64jr Save Manager by WT_Riker (PD)"
+	rom ( name "Evek - V64jr Save Manager by WT_Riker (PD).z64" crc B4745243 )
+)
+
+game (
+	name "Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD)"
+	description "Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD)"
+	rom ( name "Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD).z64" crc 6545DB14 )
+)
+
+game (
+	name "Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD)"
+	description "Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD)"
+	rom ( name "Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD).z64" crc D8306DF8 )
+)
+
+game (
+	name "LaC's Universal Bootemu V1.0 (PD)"
+	description "LaC's Universal Bootemu V1.0 (PD)"
+	rom ( name "LaC's Universal Bootemu V1.0 (PD).z64" crc F2DEF854 )
+)
+
+game (
+	name "LaC's Universal Bootemu V1.1 (PD)"
+	description "LaC's Universal Bootemu V1.1 (PD)"
+	rom ( name "LaC's Universal Bootemu V1.1 (PD).z64" crc ABBB9CF8 )
+)
+
+game (
+	name "LaC's Universal Bootemu V1.2 (PD)"
+	description "LaC's Universal Bootemu V1.2 (PD)"
+	rom ( name "LaC's Universal Bootemu V1.2 (PD).z64" crc 5DAD5CE6 )
+)
+
+game (
+	name "Mempack Manager for Jr 0.9 by deas (PD)"
+	description "Mempack Manager for Jr 0.9 by deas (PD)"
+	rom ( name "Mempack Manager for Jr 0.9 by deas (PD).z64" crc F0EFB434 )
+)
+
+game (
+	name "Mempack Manager for Jr 0.9b by deas (PD)"
+	description "Mempack Manager for Jr 0.9b by deas (PD)"
+	rom ( name "Mempack Manager for Jr 0.9b by deas (PD).z64" crc 07B656CD )
+)
+
+game (
+	name "Mempack Manager for Jr 0.9c by deas (PD)"
+	description "Mempack Manager for Jr 0.9c by deas (PD)"
+	rom ( name "Mempack Manager for Jr 0.9c by deas (PD).z64" crc 8FF05062 )
+)
+
+game (
+	name "Mempack to N64 Uploader by Destop V1.0 (PD)"
+	description "Mempack to N64 Uploader by Destop V1.0 (PD)"
+	rom ( name "Mempack to N64 Uploader by Destop V1.0 (PD).z64" crc 7E787B48 )
+)
+
+game (
+	name "Mortal Kombat SRAM Loader (PD)"
+	description "Mortal Kombat SRAM Loader (PD)"
+	rom ( name "Mortal Kombat SRAM Loader (PD).z64" crc 62E14497 )
+)
+
+game (
+	name "NUTS - Nintendo Ultra64 Test Suite by MooglyGuy (PD)"
+	description "NUTS - Nintendo Ultra64 Test Suite by MooglyGuy (PD)"
+	rom ( name "NUTS - Nintendo Ultra64 Test Suite by MooglyGuy (PD).z64" crc AB88303D )
+)
+
+game (
+	name "SRAM Manager V1.0 Beta (32Mbit) (PD) [a1]"
+	description "SRAM Manager V1.0 Beta (32Mbit) (PD) [a1]"
+	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD) [a1].z64" crc 7EF6FB76 )
+)
+
+game (
+	name "SRAM Manager V1.0 Beta (32Mbit) (PD)"
+	description "SRAM Manager V1.0 Beta (32Mbit) (PD)"
+	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD).z64" crc 2DFC78D5 )
+)
+
+game (
+	name "SRAM Manager V1.0 Beta (PD)"
+	description "SRAM Manager V1.0 Beta (PD)"
+	rom ( name "SRAM Manager V1.0 Beta (PD).z64" crc 476DBAB1 )
+)
+
+game (
+	name "SRAM Manager V1.0 PAL Beta (PD)"
+	description "SRAM Manager V1.0 PAL Beta (PD)"
+	rom ( name "SRAM Manager V1.0 PAL Beta (PD).z64" crc 9EC21295 )
+)
+
+game (
+	name "SRAM Manager V2.0 (PD) [a1]"
+	description "SRAM Manager V2.0 (PD) [a1]"
+	rom ( name "SRAM Manager V2.0 (PD) [a1].z64" crc 87F2400C )
+)
+
+game (
+	name "SRAM Manager V2.0 (PD) [h1C]"
+	description "SRAM Manager V2.0 (PD) [h1C]"
+	rom ( name "SRAM Manager V2.0 (PD) [h1C].z64" crc BF6C8A15 )
+)
+
+game (
+	name "SRAM Manager V2.0 (PD) [h2C]"
+	description "SRAM Manager V2.0 (PD) [h2C]"
+	rom ( name "SRAM Manager V2.0 (PD) [h2C].z64" crc BA6F9DE6 )
+)
+
+game (
+	name "SRAM Manager V2.0 (PD)"
+	description "SRAM Manager V2.0 (PD)"
+	rom ( name "SRAM Manager V2.0 (PD).z64" crc 1BDDF05F )
+)
+
+game (
+	name "SRAM to DS1 Tool by WT_Riker (PD)"
+	description "SRAM to DS1 Tool by WT_Riker (PD)"
+	rom ( name "SRAM to DS1 Tool by WT_Riker (PD).z64" crc 2C1671E7 )
+)
+
+game (
+	name "SRAM Upload Tool (PD)"
+	description "SRAM Upload Tool (PD)"
+	rom ( name "SRAM Upload Tool (PD).z64" crc 8280AB7A )
+)
+
+game (
+	name "SRAM Upload Tool + Star Fox 64 SRAM (PD)"
+	description "SRAM Upload Tool + Star Fox 64 SRAM (PD)"
+	rom ( name "SRAM Upload Tool + Star Fox 64 SRAM (PD).z64" crc 44C44C92 )
+)
+
+game (
+	name "SRAM Upload Tool V1 by LaC (PD)"
+	description "SRAM Upload Tool V1 by LaC (PD)"
+	rom ( name "SRAM Upload Tool V1 by LaC (PD).z64" crc D50828D1 )
+)
+
+game (
+	name "SRAM Upload Tool V1.1 by Lac (PD) [b1]"
+	description "SRAM Upload Tool V1.1 by Lac (PD) [b1]"
+	rom ( name "SRAM Upload Tool V1.1 by Lac (PD) [b1].z64" crc 1EB5431C )
+)
+
+game (
+	name "SRAM Upload Tool V1.1 by Lac (PD)"
+	description "SRAM Upload Tool V1.1 by Lac (PD)"
+	rom ( name "SRAM Upload Tool V1.1 by Lac (PD).z64" crc 0E4ABA32 )
+)
+
+game (
+	name "SRAM Uploader-Editor by BlackBag (PD)"
+	description "SRAM Uploader-Editor by BlackBag (PD)"
+	rom ( name "SRAM Uploader-Editor by BlackBag (PD).z64" crc 429277EE )
+)
+
+game (
+	name "Unix SRAM-Upload Utility 1.0 by Madman (PD)"
+	description "Unix SRAM-Upload Utility 1.0 by Madman (PD)"
+	rom ( name "Unix SRAM-Upload Utility 1.0 by Madman (PD).z64" crc 46325595 )
+)
+
+game (
+	name "V64Jr 512M Backup Program by HKPhooey (PD)"
+	description "V64Jr 512M Backup Program by HKPhooey (PD)"
+	rom ( name "V64Jr 512M Backup Program by HKPhooey (PD).z64" crc 33704AFF )
+)
+
+game (
+	name "V64Jr Backup Tool by WT_Riker (PD)"
+	description "V64Jr Backup Tool by WT_Riker (PD)"
+	rom ( name "V64Jr Backup Tool by WT_Riker (PD).z64" crc BDA5FB4B )
+)
+
+game (
+	name "V64Jr Backup Tool V0.2b_Beta by RedboX (PD)"
+	description "V64Jr Backup Tool V0.2b_Beta by RedboX (PD)"
+	rom ( name "V64Jr Backup Tool V0.2b_Beta by RedboX (PD).z64" crc 9536FE2B )
+)
+
+game (
+	name "V64Jr Flash Save Util by CrowTRobo (PD)"
+	description "V64Jr Flash Save Util by CrowTRobo (PD)"
+	rom ( name "V64Jr Flash Save Util by CrowTRobo (PD).z64" crc 18F47B60 )
+)
+
+game (
+	name "View N64 Test Program (PD) [b1]"
+	description "View N64 Test Program (PD) [b1]"
+	rom ( name "View N64 Test Program (PD) [b1].z64" crc FB65B4F8 )
+)
+
+game (
+	name "View N64 Test Program (PD)"
+	description "View N64 Test Program (PD)"
+	rom ( name "View N64 Test Program (PD).z64" crc A41556BE )
+)
+
+game (
+	name "Yoshi's Story BootEmu (PD)"
+	description "Yoshi's Story BootEmu (PD)"
+	rom ( name "Yoshi's Story BootEmu (PD).z64" crc 4AD8E4F7 )
+)
+
+game (
+	name "Zelda 64 Boot Emu V1 by Crazy Nation (PD) [a1]"
+	description "Zelda 64 Boot Emu V1 by Crazy Nation (PD) [a1]"
+	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD) [a1].z64" crc DD5BA742 )
+)
+
+game (
+	name "Zelda 64 Boot Emu V1 by Crazy Nation (PD)"
+	description "Zelda 64 Boot Emu V1 by Crazy Nation (PD)"
+	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD).z64" crc 3EE1B78B )
+)
+
+game (
+	name "Zelda 64 Boot Emu V2 by Crazy Nation (PD) [a1]"
+	description "Zelda 64 Boot Emu V2 by Crazy Nation (PD) [a1]"
+	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD) [a1].z64" crc E4E29DC9 )
+)
+
+game (
+	name "Zelda 64 Boot Emu V2 by Crazy Nation (PD)"
+	description "Zelda 64 Boot Emu V2 by Crazy Nation (PD)"
+	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD).z64" crc 07588D00 )
+)
+
+game (
+	name "Puyo Puyo 4 - Puyo Puyo Party (J) [!]"
+	description "Puyo Puyo 4 - Puyo Puyo Party (J) [!]"
+	rom ( name "Puyo Puyo 4 - Puyo Puyo Party (J) [!].z64" crc D59D2794 )
+)
+
+game (
+	name "Puyo Puyo Sun 64 (J) [!]"
+	description "Puyo Puyo Sun 64 (J) [!]"
+	rom ( name "Puyo Puyo Sun 64 (J) [!].z64" crc 355FF9DE )
+)
+
+game (
+	name "Puyo Puyo Sun 64 (J) [b1]"
+	description "Puyo Puyo Sun 64 (J) [b1]"
+	rom ( name "Puyo Puyo Sun 64 (J) [b1].z64" crc 3B88CE97 )
+)
+
+game (
+	name "Quake 64 (E) [!]"
+	description "Quake 64 (E) [!]"
+	rom ( name "Quake 64 (E) [!].z64" crc 28C10844 )
+)
+
+game (
+	name "Quake 64 (E) [o1]"
+	description "Quake 64 (E) [o1]"
+	rom ( name "Quake 64 (E) [o1].z64" crc DCDECA54 )
+)
+
+game (
+	name "Quake 64 (E) [t1]"
+	description "Quake 64 (E) [t1]"
+	rom ( name "Quake 64 (E) [t1].z64" crc 2618F474 )
+)
+
+game (
+	name "Quake 64 (U) [!]"
+	description "Quake 64 (U) [!]"
+	rom ( name "Quake 64 (U) [!].z64" crc 761F39D1 )
+)
+
+game (
+	name "Quake 64 (U) [b1]"
+	description "Quake 64 (U) [b1]"
+	rom ( name "Quake 64 (U) [b1].z64" crc 2E004334 )
+)
+
+game (
+	name "Quake 64 (U) [h1C]"
+	description "Quake 64 (U) [h1C]"
+	rom ( name "Quake 64 (U) [h1C].z64" crc F7797D6C )
+)
+
+game (
+	name "Quake 64 (U) [o1]"
+	description "Quake 64 (U) [o1]"
+	rom ( name "Quake 64 (U) [o1].z64" crc 92DCB206 )
+)
+
+game (
+	name "Quake 64 (U) [o1][t1]"
+	description "Quake 64 (U) [o1][t1]"
+	rom ( name "Quake 64 (U) [o1][t1].z64" crc 2235B036 )
+)
+
+game (
+	name "Quake 64 (U) [o2]"
+	description "Quake 64 (U) [o2]"
+	rom ( name "Quake 64 (U) [o2].z64" crc BA81D418 )
+)
+
+game (
+	name "Quake 64 (U) [o2][t1]"
+	description "Quake 64 (U) [o2][t1]"
+	rom ( name "Quake 64 (U) [o2][t1].z64" crc 87F05C4D )
+)
+
+game (
+	name "Quake 64 (U) [t1]"
+	description "Quake 64 (U) [t1]"
+	rom ( name "Quake 64 (U) [t1].z64" crc 61D7E238 )
+)
+
+game (
+	name "Quake II (E) [!]"
+	description "Quake II (E) [!]"
+	rom ( name "Quake II (E) [!].z64" crc 82BECA21 )
+)
+
+game (
+	name "Quake II (E) [h1C]"
+	description "Quake II (E) [h1C]"
+	rom ( name "Quake II (E) [h1C].z64" crc D7002A39 )
+)
+
+game (
+	name "Quake II (U) [!]"
+	description "Quake II (U) [!]"
+	rom ( name "Quake II (U) [!].z64" crc E6B34387 )
+)
+
+game (
+	name "Quake II (U) [f1] (PAL)"
+	description "Quake II (U) [f1] (PAL)"
+	rom ( name "Quake II (U) [f1] (PAL).z64" crc 2CD53CF2 )
+)
+
+game (
+	name "Eltale Monsters (J) [!]"
+	description "Eltale Monsters (J) [!]"
+	rom ( name "Eltale Monsters (J) [!].z64" crc A4FE7652 )
+)
+
+game (
+	name "Eltale Monsters (J) [b1]"
+	description "Eltale Monsters (J) [b1]"
+	rom ( name "Eltale Monsters (J) [b1].z64" crc 75FFFB14 )
+)
+
+game (
+	name "Holy Magic Century (E) [!]"
+	description "Holy Magic Century (E) [!]"
+	rom ( name "Holy Magic Century (E) [!].z64" crc BF6F67BF )
+)
+
+game (
+	name "Holy Magic Century (E) [b1]"
+	description "Holy Magic Century (E) [b1]"
+	rom ( name "Holy Magic Century (E) [b1].z64" crc 84FF9890 )
+)
+
+game (
+	name "Holy Magic Century (F) [h1C]"
+	description "Holy Magic Century (F) [h1C]"
+	rom ( name "Holy Magic Century (F) [h1C].z64" crc BAF6C66A )
+)
+
+game (
+	name "Holy Magic Century (F) [o1]"
+	description "Holy Magic Century (F) [o1]"
+	rom ( name "Holy Magic Century (F) [o1].z64" crc 53CCD8F4 )
+)
+
+game (
+	name "Holy Magic Century (F)"
+	description "Holy Magic Century (F)"
+	rom ( name "Holy Magic Century (F).z64" crc 284170ED )
+)
+
+game (
+	name "Holy Magic Century (G) [!]"
+	description "Holy Magic Century (G) [!]"
+	rom ( name "Holy Magic Century (G) [!].z64" crc D1934CF6 )
+)
+
+game (
+	name "Holy Magic Century (G) [b1]"
+	description "Holy Magic Century (G) [b1]"
+	rom ( name "Holy Magic Century (G) [b1].z64" crc 2F87F160 )
+)
+
+game (
+	name "Holy Magic Century (G) [b2]"
+	description "Holy Magic Century (G) [b2]"
+	rom ( name "Holy Magic Century (G) [b2].z64" crc AA28C3C1 )
+)
+
+game (
+	name "Holy Magic Century (G) [b3]"
+	description "Holy Magic Century (G) [b3]"
+	rom ( name "Holy Magic Century (G) [b3].z64" crc 8BC3D869 )
+)
+
+game (
+	name "Quest 64 (U) [!]"
+	description "Quest 64 (U) [!]"
+	rom ( name "Quest 64 (U) [!].z64" crc D75B45C6 )
+)
+
+game (
+	name "Quest 64 (U) [b1]"
+	description "Quest 64 (U) [b1]"
+	rom ( name "Quest 64 (U) [b1].z64" crc 166B46BF )
+)
+
+game (
+	name "Quest 64 (U) [b2]"
+	description "Quest 64 (U) [b2]"
+	rom ( name "Quest 64 (U) [b2].z64" crc B23C4425 )
+)
+
+game (
+	name "Quest 64 (U) [b3]"
+	description "Quest 64 (U) [b3]"
+	rom ( name "Quest 64 (U) [b3].z64" crc C4134703 )
+)
+
+game (
+	name "Quest 64 (U) [b4]"
+	description "Quest 64 (U) [b4]"
+	rom ( name "Quest 64 (U) [b4].z64" crc 4A3A1548 )
+)
+
+game (
+	name "Quest 64 (U) [b5]"
+	description "Quest 64 (U) [b5]"
+	rom ( name "Quest 64 (U) [b5].z64" crc D3C10D18 )
+)
+
+game (
+	name "Quest 64 (U) [t1]"
+	description "Quest 64 (U) [t1]"
+	rom ( name "Quest 64 (U) [t1].z64" crc ADDB964B )
+)
+
+game (
+	name "Rakuga Kids (E) [!]"
+	description "Rakuga Kids (E) [!]"
+	rom ( name "Rakuga Kids (E) [!].z64" crc 483129AA )
+)
+
+game (
+	name "Rakuga Kids (E) [b1]"
+	description "Rakuga Kids (E) [b1]"
+	rom ( name "Rakuga Kids (E) [b1].z64" crc F2F11A4F )
+)
+
+game (
+	name "Rakuga Kids (E) [f1] (NTSC)"
+	description "Rakuga Kids (E) [f1] (NTSC)"
+	rom ( name "Rakuga Kids (E) [f1] (NTSC).z64" crc B62029DD )
+)
+
+game (
+	name "Rakuga Kids (E) [h1C]"
+	description "Rakuga Kids (E) [h1C]"
+	rom ( name "Rakuga Kids (E) [h1C].z64" crc B9165694 )
+)
+
+game (
+	name "Rakuga Kids (J) [!]"
+	description "Rakuga Kids (J) [!]"
+	rom ( name "Rakuga Kids (J) [!].z64" crc B9E53B06 )
+)
+
+game (
+	name "Rakuga Kids (J) [b1]"
+	description "Rakuga Kids (J) [b1]"
+	rom ( name "Rakuga Kids (J) [b1].z64" crc 4D897EF9 )
+)
+
+game (
+	name "Rakuga Kids (J) [h1C]"
+	description "Rakuga Kids (J) [h1C]"
+	rom ( name "Rakuga Kids (J) [h1C].z64" crc 48C24438 )
+)
+
+game (
+	name "Rally '99 (J) [!]"
+	description "Rally '99 (J) [!]"
+	rom ( name "Rally '99 (J) [!].z64" crc FFA625FE )
+)
+
+game (
+	name "Rally '99 (J) [f1] (PAL)"
+	description "Rally '99 (J) [f1] (PAL)"
+	rom ( name "Rally '99 (J) [f1] (PAL).z64" crc D12EE95F )
+)
+
+game (
+	name "Rally Challenge 2000 (U) [!]"
+	description "Rally Challenge 2000 (U) [!]"
+	rom ( name "Rally Challenge 2000 (U) [!].z64" crc 3EDEC7B0 )
+)
+
+game (
+	name "Rampage - World Tour (E) [!]"
+	description "Rampage - World Tour (E) [!]"
+	rom ( name "Rampage - World Tour (E) [!].z64" crc CDC458EC )
+)
+
+game (
+	name "Rampage - World Tour (E) [h1C]"
+	description "Rampage - World Tour (E) [h1C]"
+	rom ( name "Rampage - World Tour (E) [h1C].z64" crc 4D1C58CC )
+)
+
+game (
+	name "Rampage - World Tour (U) [!]"
+	description "Rampage - World Tour (U) [!]"
+	rom ( name "Rampage - World Tour (U) [!].z64" crc 211119DD )
+)
+
+game (
+	name "Rampage - World Tour (U) [b1]"
+	description "Rampage - World Tour (U) [b1]"
+	rom ( name "Rampage - World Tour (U) [b1].z64" crc C86193CB )
+)
+
+game (
+	name "Rampage - World Tour (U) [b2]"
+	description "Rampage - World Tour (U) [b2]"
+	rom ( name "Rampage - World Tour (U) [b2].z64" crc 57788722 )
+)
+
+game (
+	name "Rampage - World Tour (U) [b3]"
+	description "Rampage - World Tour (U) [b3]"
+	rom ( name "Rampage - World Tour (U) [b3].z64" crc 3E734158 )
+)
+
+game (
+	name "Rampage - World Tour (U) [b4]"
+	description "Rampage - World Tour (U) [b4]"
+	rom ( name "Rampage - World Tour (U) [b4].z64" crc 68E3E953 )
+)
+
+game (
+	name "Rampage - World Tour (U) [h1C]"
+	description "Rampage - World Tour (U) [h1C]"
+	rom ( name "Rampage - World Tour (U) [h1C].z64" crc DC157FFB )
+)
+
+game (
+	name "Rampage - World Tour (U) [t1]"
+	description "Rampage - World Tour (U) [t1]"
+	rom ( name "Rampage - World Tour (U) [t1].z64" crc 81DD0EC0 )
+)
+
+game (
+	name "Rampage - World Tour (U) [t2]"
+	description "Rampage - World Tour (U) [t2]"
+	rom ( name "Rampage - World Tour (U) [t2].z64" crc 7A16A164 )
+)
+
+game (
+	name "Rampage 2 - Universal Tour (E) [!]"
+	description "Rampage 2 - Universal Tour (E) [!]"
+	rom ( name "Rampage 2 - Universal Tour (E) [!].z64" crc FA6E097B )
+)
+
+game (
+	name "Rampage 2 - Universal Tour (U) [!]"
+	description "Rampage 2 - Universal Tour (U) [!]"
+	rom ( name "Rampage 2 - Universal Tour (U) [!].z64" crc 7614EE0D )
+)
+
+game (
+	name "Rampage 2 - Universal Tour (U) [t1]"
+	description "Rampage 2 - Universal Tour (U) [t1]"
+	rom ( name "Rampage 2 - Universal Tour (U) [t1].z64" crc B1F3163B )
+)
+
+game (
+	name "Rampage 2 - Universal Tour (U) [t2]"
+	description "Rampage 2 - Universal Tour (U) [t2]"
+	rom ( name "Rampage 2 - Universal Tour (U) [t2].z64" crc 259DC074 )
+)
+
+game (
+	name "Rat Attack (E) (M6) [!]"
+	description "Rat Attack (E) (M6) [!]"
+	rom ( name "Rat Attack (E) (M6) [!].z64" crc DD4FA798 )
+)
+
+game (
+	name "Rat Attack (E) (M6) [f1] (NTSC)"
+	description "Rat Attack (E) (M6) [f1] (NTSC)"
+	rom ( name "Rat Attack (E) (M6) [f1] (NTSC).z64" crc E9CBBE51 )
+)
+
+game (
+	name "Rat Attack (E) (M6) [h1C]"
+	description "Rat Attack (E) (M6) [h1C]"
+	rom ( name "Rat Attack (E) (M6) [h1C].z64" crc E4215FEF )
+)
+
+game (
+	name "Rat Attack (U) (M6) [!]"
+	description "Rat Attack (U) (M6) [!]"
+	rom ( name "Rat Attack (U) (M6) [!].z64" crc 2315FEA7 )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (E) (M5) [!]"
+	description "Rayman 2 - The Great Escape (E) (M5) [!]"
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [!].z64" crc 169A5037 )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC)"
+	description "Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC)"
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC).z64" crc 9D33F2E1 )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (E) (M5) [f2] (NTSC)"
+	description "Rayman 2 - The Great Escape (E) (M5) [f2] (NTSC)"
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f2] (NTSC).z64" crc 98AE479B )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (U) (M5) [!]"
+	description "Rayman 2 - The Great Escape (U) (M5) [!]"
+	rom ( name "Rayman 2 - The Great Escape (U) (M5) [!].z64" crc 02BB4409 )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (U) (M5) [t1]"
+	description "Rayman 2 - The Great Escape (U) (M5) [t1]"
+	rom ( name "Rayman 2 - The Great Escape (U) (M5) [t1].z64" crc 415A2BBC )
+)
+
+game (
+	name "Razor Freestyle Scooter (U) [!]"
+	description "Razor Freestyle Scooter (U) [!]"
+	rom ( name "Razor Freestyle Scooter (U) [!].z64" crc 927CE621 )
+)
+
+game (
+	name "Re-Volt (E) (M4) [!]"
+	description "Re-Volt (E) (M4) [!]"
+	rom ( name "Re-Volt (E) (M4) [!].z64" crc 81D13A11 )
+)
+
+game (
+	name "Re-Volt (U) [!]"
+	description "Re-Volt (U) [!]"
+	rom ( name "Re-Volt (U) [!].z64" crc FC0C86D0 )
+)
+
+game (
+	name "Re-Volt (U) [f1] (Country Check)"
+	description "Re-Volt (U) [f1] (Country Check)"
+	rom ( name "Re-Volt (U) [f1] (Country Check).z64" crc EC4C68D4 )
+)
+
+game (
+	name "Re-Volt (U) [f2] (PAL)"
+	description "Re-Volt (U) [f2] (PAL)"
+	rom ( name "Re-Volt (U) [f2] (PAL).z64" crc F3EFC7CB )
+)
+
+game (
+	name "Re-Volt (U) [t1]"
+	description "Re-Volt (U) [t1]"
+	rom ( name "Re-Volt (U) [t1].z64" crc 604400CF )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (E) (M3) [!]"
+	description "Ready 2 Rumble Boxing (E) (M3) [!]"
+	rom ( name "Ready 2 Rumble Boxing (E) (M3) [!].z64" crc A69DF7B3 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable)"
+	description "Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable)"
+	rom ( name "Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable).z64" crc B0591A28 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (U) [!]"
+	description "Ready 2 Rumble Boxing (U) [!]"
+	rom ( name "Ready 2 Rumble Boxing (U) [!].z64" crc 2A554048 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (U) [f1] (PAL)"
+	description "Ready 2 Rumble Boxing (U) [f1] (PAL)"
+	rom ( name "Ready 2 Rumble Boxing (U) [f1] (PAL).z64" crc C981AFB7 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (U) [t1] (P1 Untouchable)"
+	description "Ready 2 Rumble Boxing (U) [t1] (P1 Untouchable)"
+	rom ( name "Ready 2 Rumble Boxing (U) [t1] (P1 Untouchable).z64" crc FF48B206 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing - Round 2 (U) [!]"
+	description "Ready 2 Rumble Boxing - Round 2 (U) [!]"
+	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [!].z64" crc 052A0E04 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing - Round 2 (U) [t1]"
+	description "Ready 2 Rumble Boxing - Round 2 (U) [t1]"
+	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [t1].z64" crc B5E23CC7 )
+)
+
+game (
+	name "Biohazard 2 (J) [!]"
+	description "Biohazard 2 (J) [!]"
+	rom ( name "Biohazard 2 (J) [!].z64" crc 4F9D569F )
+)
+
+game (
+	name "Resident Evil 2 (E) (M2) [!]"
+	description "Resident Evil 2 (E) (M2) [!]"
+	rom ( name "Resident Evil 2 (E) (M2) [!].z64" crc 7C8EE011 )
+)
+
+game (
+	name "Resident Evil 2 (U) (V1.1) [!]"
+	description "Resident Evil 2 (U) (V1.1) [!]"
+	rom ( name "Resident Evil 2 (U) (V1.1) [!].z64" crc 848FBC0D )
+)
+
+game (
+	name "Road Rash 64 (E) [!]"
+	description "Road Rash 64 (E) [!]"
+	rom ( name "Road Rash 64 (E) [!].z64" crc 3C664A7B )
+)
+
+game (
+	name "Road Rash 64 (E) [h1C]"
+	description "Road Rash 64 (E) [h1C]"
+	rom ( name "Road Rash 64 (E) [h1C].z64" crc 39BB993F )
+)
+
+game (
+	name "Road Rash 64 (U) [!]"
+	description "Road Rash 64 (U) [!]"
+	rom ( name "Road Rash 64 (U) [!].z64" crc 600B3988 )
+)
+
+game (
+	name "Road Rash 64 (U) [f1] (PAL)"
+	description "Road Rash 64 (U) [f1] (PAL)"
+	rom ( name "Road Rash 64 (U) [f1] (PAL).z64" crc 321AFCC1 )
+)
+
+game (
+	name "Road Rash 64 (U) [t1]"
+	description "Road Rash 64 (U) [t1]"
+	rom ( name "Road Rash 64 (U) [t1].z64" crc D10F77A1 )
+)
+
+game (
+	name "Roadsters Trophy (E) (M6) [!]"
+	description "Roadsters Trophy (E) (M6) [!]"
+	rom ( name "Roadsters Trophy (E) (M6) [!].z64" crc 997ED5AF )
+)
+
+game (
+	name "Roadsters Trophy (U) (M3) [!]"
+	description "Roadsters Trophy (U) (M3) [!]"
+	rom ( name "Roadsters Trophy (U) (M3) [!].z64" crc E4337B92 )
+)
+
+game (
+	name "Roadsters Trophy (U) (M3) [f1] (PAL)"
+	description "Roadsters Trophy (U) (M3) [f1] (PAL)"
+	rom ( name "Roadsters Trophy (U) (M3) [f1] (PAL).z64" crc 55980F72 )
+)
+
+game (
+	name "Roadsters Trophy (U) (M3) [t1]"
+	description "Roadsters Trophy (U) (M3) [t1]"
+	rom ( name "Roadsters Trophy (U) (M3) [t1].z64" crc A51B51D1 )
+)
+
+game (
+	name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!]"
+	description "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!]"
+	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!].z64" crc 3B0F8061 )
+)
+
+game (
+	name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL)"
+	description "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL)"
+	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL).z64" crc B4F3E4E6 )
+)
+
+game (
+	name "Robotech - Crystal Dreams (Beta) [a1]"
+	description "Robotech - Crystal Dreams (Beta) [a1]"
+	rom ( name "Robotech - Crystal Dreams (Beta) [a1].z64" crc 8F5BC48F )
+)
+
+game (
+	name "Robotech - Crystal Dreams (Beta)"
+	description "Robotech - Crystal Dreams (Beta)"
+	rom ( name "Robotech - Crystal Dreams (Beta).z64" crc F9A7904E )
+)
+
+game (
+	name "Robotron 64 (E) [!]"
+	description "Robotron 64 (E) [!]"
+	rom ( name "Robotron 64 (E) [!].z64" crc 23BF4956 )
+)
+
+game (
+	name "Robotron 64 (E) [h1C]"
+	description "Robotron 64 (E) [h1C]"
+	rom ( name "Robotron 64 (E) [h1C].z64" crc 90088356 )
+)
+
+game (
+	name "Robotron 64 (U) [!]"
+	description "Robotron 64 (U) [!]"
+	rom ( name "Robotron 64 (U) [!].z64" crc B2CBAE58 )
+)
+
+game (
+	name "Robotron 64 (U) [b1]"
+	description "Robotron 64 (U) [b1]"
+	rom ( name "Robotron 64 (U) [b1].z64" crc 3C95E84C )
+)
+
+game (
+	name "Robotron 64 (U) [b2]"
+	description "Robotron 64 (U) [b2]"
+	rom ( name "Robotron 64 (U) [b2].z64" crc 6093B12B )
+)
+
+game (
+	name "Robotron 64 (U) [b3]"
+	description "Robotron 64 (U) [b3]"
+	rom ( name "Robotron 64 (U) [b3].z64" crc D3247B2B )
+)
+
+game (
+	name "Robotron 64 (U) [b4]"
+	description "Robotron 64 (U) [b4]"
+	rom ( name "Robotron 64 (U) [b4].z64" crc 8FB685A9 )
+)
+
+game (
+	name "Robotron 64 (U) [f1] (PAL)"
+	description "Robotron 64 (U) [f1] (PAL)"
+	rom ( name "Robotron 64 (U) [f1] (PAL).z64" crc 8BA428CD )
+)
+
+game (
+	name "Robotron 64 (U) [o1]"
+	description "Robotron 64 (U) [o1]"
+	rom ( name "Robotron 64 (U) [o1].z64" crc 1D89EB63 )
+)
+
+game (
+	name "Robotron 64 (U) [t1]"
+	description "Robotron 64 (U) [t1]"
+	rom ( name "Robotron 64 (U) [t1].z64" crc 9D5938AC )
+)
+
+game (
+	name "Rocket - Robot on Wheels (E) (M3) [!]"
+	description "Rocket - Robot on Wheels (E) (M3) [!]"
+	rom ( name "Rocket - Robot on Wheels (E) (M3) [!].z64" crc 7DE5D20D )
+)
+
+game (
+	name "Rocket - Robot on Wheels (U) [!]"
+	description "Rocket - Robot on Wheels (U) [!]"
+	rom ( name "Rocket - Robot on Wheels (U) [!].z64" crc E0399F23 )
+)
+
+game (
+	name "Rocket - Robot on Wheels (U) [b1]"
+	description "Rocket - Robot on Wheels (U) [b1]"
+	rom ( name "Rocket - Robot on Wheels (U) [b1].z64" crc FB415F76 )
+)
+
+game (
+	name "Rocket - Robot on Wheels (U) [f1] (PAL)"
+	description "Rocket - Robot on Wheels (U) [f1] (PAL)"
+	rom ( name "Rocket - Robot on Wheels (U) [f1] (PAL).z64" crc 72D33867 )
+)
+
+game (
+	name "Rocket - Robot on Wheels (U) [t1]"
+	description "Rocket - Robot on Wheels (U) [t1]"
+	rom ( name "Rocket - Robot on Wheels (U) [t1].z64" crc A449F11C )
+)
+
+game (
+	name "RR64 - Ridge Racer 64 (E) [!]"
+	description "RR64 - Ridge Racer 64 (E) [!]"
+	rom ( name "RR64 - Ridge Racer 64 (E) [!].z64" crc DD9AE3A8 )
+)
+
+game (
+	name "RR64 - Ridge Racer 64 (U) [!]"
+	description "RR64 - Ridge Racer 64 (U) [!]"
+	rom ( name "RR64 - Ridge Racer 64 (U) [!].z64" crc 3C2C2D1C )
+)
+
+game (
+	name "RR64 - Ridge Racer 64 (U) [f1] (PAL)"
+	description "RR64 - Ridge Racer 64 (U) [f1] (PAL)"
+	rom ( name "RR64 - Ridge Racer 64 (U) [f1] (PAL).z64" crc BFE2077B )
+)
+
+game (
+	name "RR64 - Ridge Racer 64 (U) [t1]"
+	description "RR64 - Ridge Racer 64 (U) [t1]"
+	rom ( name "RR64 - Ridge Racer 64 (U) [t1].z64" crc 7ADF6A89 )
+)
+
+game (
+	name "Les Razmoket - La Chasse Aux Tresors (F) [!]"
+	description "Les Razmoket - La Chasse Aux Tresors (F) [!]"
+	rom ( name "Les Razmoket - La Chasse Aux Tresors (F) [!].z64" crc 66766469 )
+)
+
+game (
+	name "Rugrats - Die grosse Schatzsuche (G) [!]"
+	description "Rugrats - Die grosse Schatzsuche (G) [!]"
+	rom ( name "Rugrats - Die grosse Schatzsuche (G) [!].z64" crc 23AED3A2 )
+)
+
+game (
+	name "Rugrats - Scavenger Hunt (U) [!]"
+	description "Rugrats - Scavenger Hunt (U) [!]"
+	rom ( name "Rugrats - Scavenger Hunt (U) [!].z64" crc A87FAF82 )
+)
+
+game (
+	name "Rugrats - Scavenger Hunt (U) [f1] (PAL)"
+	description "Rugrats - Scavenger Hunt (U) [f1] (PAL)"
+	rom ( name "Rugrats - Scavenger Hunt (U) [f1] (PAL).z64" crc E24FCD04 )
+)
+
+game (
+	name "Rugrats - Treasure Hunt (E) [!]"
+	description "Rugrats - Treasure Hunt (E) [!]"
+	rom ( name "Rugrats - Treasure Hunt (E) [!].z64" crc 3338B7C8 )
+)
+
+game (
+	name "Rugrats - Treasure Hunt (E) [h1C]"
+	description "Rugrats - Treasure Hunt (E) [h1C]"
+	rom ( name "Rugrats - Treasure Hunt (E) [h1C].z64" crc A1938B36 )
+)
+
+game (
+	name "Rugrats in Paris - The Movie (E) [!]"
+	description "Rugrats in Paris - The Movie (E) [!]"
+	rom ( name "Rugrats in Paris - The Movie (E) [!].z64" crc CD74B07E )
+)
+
+game (
+	name "Rugrats in Paris - The Movie (U) [!]"
+	description "Rugrats in Paris - The Movie (U) [!]"
+	rom ( name "Rugrats in Paris - The Movie (U) [!].z64" crc A9CC2419 )
+)
+
+game (
+	name "Rugrats in Paris - The Movie (U) [T+Spa0.10]"
+	description "Rugrats in Paris - The Movie (U) [T+Spa0.10]"
+	rom ( name "Rugrats in Paris - The Movie (U) [T+Spa0.10].z64" crc BDA8A807 )
+)
+
+game (
+	name "Rush 2 - Extreme Racing USA (E) (M6) [!]"
+	description "Rush 2 - Extreme Racing USA (E) (M6) [!]"
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [!].z64" crc 30F21F89 )
+)
+
+game (
+	name "Rush 2 - Extreme Racing USA (E) (M6) [h1I]"
+	description "Rush 2 - Extreme Racing USA (E) (M6) [h1I]"
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h1I].z64" crc 3940F7DD )
+)
+
+game (
+	name "Rush 2 - Extreme Racing USA (E) (M6) [h2I]"
+	description "Rush 2 - Extreme Racing USA (E) (M6) [h2I]"
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h2I].z64" crc E23DE536 )
+)
+
+game (
+	name "Rush 2 - Extreme Racing USA (U) [!]"
+	description "Rush 2 - Extreme Racing USA (U) [!]"
+	rom ( name "Rush 2 - Extreme Racing USA (U) [!].z64" crc 9EB14EA8 )
+)
+
+game (
+	name "S.C.A.R.S. (E) (M3) [!]"
+	description "S.C.A.R.S. (E) (M3) [!]"
+	rom ( name "S.C.A.R.S. (E) (M3) [!].z64" crc 4E37B6F2 )
+)
+
+game (
+	name "S.C.A.R.S. (E) (M3) [h1C]"
+	description "S.C.A.R.S. (E) (M3) [h1C]"
+	rom ( name "S.C.A.R.S. (E) (M3) [h1C].z64" crc C3747A8D )
+)
+
+game (
+	name "S.C.A.R.S. (U) [!]"
+	description "S.C.A.R.S. (U) [!]"
+	rom ( name "S.C.A.R.S. (U) [!].z64" crc 22916735 )
+)
+
+game (
+	name "S.C.A.R.S. (U) [f1] (PAL)"
+	description "S.C.A.R.S. (U) [f1] (PAL)"
+	rom ( name "S.C.A.R.S. (U) [f1] (PAL).z64" crc 848B3DAB )
+)
+
+game (
+	name "S.C.A.R.S. (U) [t1]"
+	description "S.C.A.R.S. (U) [t1]"
+	rom ( name "S.C.A.R.S. (U) [t1].z64" crc 42A8EE01 )
+)
+
+game (
+	name "Saikyou Habu Shougi (J) [!]"
+	description "Saikyou Habu Shougi (J) [!]"
+	rom ( name "Saikyou Habu Shougi (J) [!].z64" crc 01794D62 )
+)
+
+game (
+	name "Saikyou Habu Shougi (J) [h1C]"
+	description "Saikyou Habu Shougi (J) [h1C]"
+	rom ( name "Saikyou Habu Shougi (J) [h1C].z64" crc C1F2B7A4 )
+)
+
+game (
+	name "Saikyou Habu Shougi (J) [h2C]"
+	description "Saikyou Habu Shougi (J) [h2C]"
+	rom ( name "Saikyou Habu Shougi (J) [h2C].z64" crc A5D2585D )
+)
+
+game (
+	name "Saikyou Habu Shougi (J) [h3C]"
+	description "Saikyou Habu Shougi (J) [h3C]"
+	rom ( name "Saikyou Habu Shougi (J) [h3C].z64" crc CB3FD380 )
+)
+
+game (
+	name "Saikyou Habu Shougi (J) [h4C]"
+	description "Saikyou Habu Shougi (J) [h4C]"
+	rom ( name "Saikyou Habu Shougi (J) [h4C].z64" crc A1211799 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (E) (M3) [!]"
+	description "San Francisco Rush - Extreme Racing (E) (M3) [!]"
+	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [!].z64" crc E064962A )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (E) (M3) [h1C]"
+	description "San Francisco Rush - Extreme Racing (E) (M3) [h1C]"
+	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [h1C].z64" crc 34A7F68E )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [!]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [!]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [!].z64" crc 3E20070B )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [b1]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [b1]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b1].z64" crc CF1E89E3 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [b2]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [b2]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b2].z64" crc C5C8CE3B )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [b3]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [b3]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b3].z64" crc F0772E31 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [o1]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [o1]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o1].z64" crc E9ADB7C1 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [o2]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [o2]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o2].z64" crc D0A9EB38 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing (U) (M3) [o3]"
+	description "San Francisco Rush - Extreme Racing (U) (M3) [o3]"
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o3].z64" crc B6B9F6BE )
+)
+
+game (
+	name "San Francisco Rush 2049 (E) (M6) [!]"
+	description "San Francisco Rush 2049 (E) (M6) [!]"
+	rom ( name "San Francisco Rush 2049 (E) (M6) [!].z64" crc E63B86C5 )
+)
+
+game (
+	name "San Francisco Rush 2049 (U) [!]"
+	description "San Francisco Rush 2049 (U) [!]"
+	rom ( name "San Francisco Rush 2049 (U) [!].z64" crc 10941439 )
+)
+
+game (
+	name "San Francisco Rush 2049 (U) [t1]"
+	description "San Francisco Rush 2049 (U) [t1]"
+	rom ( name "San Francisco Rush 2049 (U) [t1].z64" crc 540A6DE1 )
+)
+
+game (
+	name "Scooby-Doo! - Classic Creep Capers (E) [!]"
+	description "Scooby-Doo! - Classic Creep Capers (E) [!]"
+	rom ( name "Scooby-Doo! - Classic Creep Capers (E) [!].z64" crc 0D737E6F )
+)
+
+game (
+	name "Scooby-Doo! - Classic Creep Capers (U) [!]"
+	description "Scooby-Doo! - Classic Creep Capers (U) [!]"
+	rom ( name "Scooby-Doo! - Classic Creep Capers (U) [!].z64" crc 39068228 )
+)
+
+game (
+	name "SD Hiryuu no Ken Densetsu (J) [!]"
+	description "SD Hiryuu no Ken Densetsu (J) [!]"
+	rom ( name "SD Hiryuu no Ken Densetsu (J) [!].z64" crc CC083E34 )
+)
+
+game (
+	name "SD Hiryuu no Ken Densetsu (J) [f1] (PAL)"
+	description "SD Hiryuu no Ken Densetsu (J) [f1] (PAL)"
+	rom ( name "SD Hiryuu no Ken Densetsu (J) [f1] (PAL).z64" crc E0921D7E )
+)
+
+game (
+	name "Shadow Man (E) (M3) [!]"
+	description "Shadow Man (E) (M3) [!]"
+	rom ( name "Shadow Man (E) (M3) [!].z64" crc 8D230306 )
+)
+
+game (
+	name "Shadow Man (F) [!]"
+	description "Shadow Man (F) [!]"
+	rom ( name "Shadow Man (F) [!].z64" crc 6812D3A7 )
+)
+
+game (
+	name "Shadow Man (G) [!]"
+	description "Shadow Man (G) [!]"
+	rom ( name "Shadow Man (G) [!].z64" crc EAF6ADD1 )
+)
+
+game (
+	name "Shadow Man (G) [b1]"
+	description "Shadow Man (G) [b1]"
+	rom ( name "Shadow Man (G) [b1].z64" crc F71CC55B )
+)
+
+game (
+	name "Shadow Man (G) [b2]"
+	description "Shadow Man (G) [b2]"
+	rom ( name "Shadow Man (G) [b2].z64" crc E020C909 )
+)
+
+game (
+	name "Shadow Man (G) [f1] (NTSC)"
+	description "Shadow Man (G) [f1] (NTSC)"
+	rom ( name "Shadow Man (G) [f1] (NTSC).z64" crc C580323E )
+)
+
+game (
+	name "Shadow Man (U) [!]"
+	description "Shadow Man (U) [!]"
+	rom ( name "Shadow Man (U) [!].z64" crc 5E20CC63 )
+)
+
+game (
+	name "Shadow Man (U) [b1]"
+	description "Shadow Man (U) [b1]"
+	rom ( name "Shadow Man (U) [b1].z64" crc 622D1F6C )
+)
+
+game (
+	name "Shadow Man (U) [b2]"
+	description "Shadow Man (U) [b2]"
+	rom ( name "Shadow Man (U) [b2].z64" crc 65AF5218 )
+)
+
+game (
+	name "Shadow Man (U) [b3]"
+	description "Shadow Man (U) [b3]"
+	rom ( name "Shadow Man (U) [b3].z64" crc 80B0BEFD )
+)
+
+game (
+	name "Shadow Man (U) [t1]"
+	description "Shadow Man (U) [t1]"
+	rom ( name "Shadow Man (U) [t1].z64" crc 181F5096 )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!]"
+	description "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!].z64" crc 87F00472 )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!]"
+	description "Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!].z64" crc EEDC0BEA )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (E) [!]"
+	description "Shadowgate 64 - Trials Of The Four Towers (E) [!]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [!].z64" crc FF7D7DF0 )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC)"
+	description "Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC)"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC).z64" crc 31FC728A )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (J) [b1]"
+	description "Shadowgate 64 - Trials Of The Four Towers (J) [b1]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b1].z64" crc 2BD3203A )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (J) [b2]"
+	description "Shadowgate 64 - Trials Of The Four Towers (J) [b2]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b2].z64" crc CBEB984B )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (J)"
+	description "Shadowgate 64 - Trials Of The Four Towers (J)"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J).z64" crc 9F74A58C )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!]"
+	description "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!]"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!].z64" crc 69983CC3 )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL)"
+	description "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL)"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL).z64" crc 627F113A )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f2] (PAL)"
+	description "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f2] (PAL)"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f2] (PAL).z64" crc 1B731693 )
+)
+
+game (
+	name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!]"
+	description "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!]"
+	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!].z64" crc 576915D4 )
+)
+
+game (
+	name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [b1]"
+	description "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [b1]"
+	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [b1].z64" crc B8925ED3 )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!]"
+	description "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!]"
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!].z64" crc E892ED43 )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1]"
+	description "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1]"
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1].z64" crc 66790E64 )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!]"
+	description "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!]"
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!].z64" crc DEAC787F )
+)
+
+game (
+	name "Sim City 2000 (J) [!]"
+	description "Sim City 2000 (J) [!]"
+	rom ( name "Sim City 2000 (J) [!].z64" crc 57767E45 )
+)
+
+game (
+	name "Sim City 2000 (J) [b1]"
+	description "Sim City 2000 (J) [b1]"
+	rom ( name "Sim City 2000 (J) [b1].z64" crc AE23045E )
+)
+
+game (
+	name "Sim City 2000 (J) [b1][o1]"
+	description "Sim City 2000 (J) [b1][o1]"
+	rom ( name "Sim City 2000 (J) [b1][o1].z64" crc C2FD3D62 )
+)
+
+game (
+	name "Sim City 2000 (J) [b2]"
+	description "Sim City 2000 (J) [b2]"
+	rom ( name "Sim City 2000 (J) [b2].z64" crc E435B297 )
+)
+
+game (
+	name "Sim City 2000 (J) [h1C]"
+	description "Sim City 2000 (J) [h1C]"
+	rom ( name "Sim City 2000 (J) [h1C].z64" crc 8140D8FC )
+)
+
+game (
+	name "Sim City 2000 (J) [o1]"
+	description "Sim City 2000 (J) [o1]"
+	rom ( name "Sim City 2000 (J) [o1].z64" crc 73C9AB24 )
+)
+
+game (
+	name "Sim City 2000 (J) [o1][h1C]"
+	description "Sim City 2000 (J) [o1][h1C]"
+	rom ( name "Sim City 2000 (J) [o1][h1C].z64" crc DBEF385D )
+)
+
+game (
+	name "Snobow Kids (J) [!]"
+	description "Snobow Kids (J) [!]"
+	rom ( name "Snobow Kids (J) [!].z64" crc 213BF381 )
+)
+
+game (
+	name "Snobow Kids (J) [h1C]"
+	description "Snobow Kids (J) [h1C]"
+	rom ( name "Snobow Kids (J) [h1C].z64" crc CE6D35F1 )
+)
+
+game (
+	name "Snobow Kids (J) [h2C]"
+	description "Snobow Kids (J) [h2C]"
+	rom ( name "Snobow Kids (J) [h2C].z64" crc 299830E2 )
+)
+
+game (
+	name "Snowboard Kids (E) [!]"
+	description "Snowboard Kids (E) [!]"
+	rom ( name "Snowboard Kids (E) [!].z64" crc 5619A70D )
+)
+
+game (
+	name "Snowboard Kids (E) [h1C]"
+	description "Snowboard Kids (E) [h1C]"
+	rom ( name "Snowboard Kids (E) [h1C].z64" crc ECA826FC )
+)
+
+game (
+	name "Snowboard Kids (U) [!]"
+	description "Snowboard Kids (U) [!]"
+	rom ( name "Snowboard Kids (U) [!].z64" crc 020FB906 )
+)
+
+game (
+	name "Snowboard Kids (U) [b1]"
+	description "Snowboard Kids (U) [b1]"
+	rom ( name "Snowboard Kids (U) [b1].z64" crc 798D185F )
+)
+
+game (
+	name "Snowboard Kids (U) [b2]"
+	description "Snowboard Kids (U) [b2]"
+	rom ( name "Snowboard Kids (U) [b2].z64" crc CC3A899D )
+)
+
+game (
+	name "Snowboard Kids (U) [b3]"
+	description "Snowboard Kids (U) [b3]"
+	rom ( name "Snowboard Kids (U) [b3].z64" crc 8EB60A3D )
+)
+
+game (
+	name "Snowboard Kids (U) [h1C]"
+	description "Snowboard Kids (U) [h1C]"
+	rom ( name "Snowboard Kids (U) [h1C].z64" crc B8BE38F7 )
+)
+
+game (
+	name "Snowboard Kids (U) [t1]"
+	description "Snowboard Kids (U) [t1]"
+	rom ( name "Snowboard Kids (U) [t1].z64" crc 72219675 )
+)
+
+game (
+	name "Chou Snobow Kids (J) [!]"
+	description "Chou Snobow Kids (J) [!]"
+	rom ( name "Chou Snobow Kids (J) [!].z64" crc 8FEDF4C6 )
+)
+
+game (
+	name "Chou Snobow Kids (J) [f1] (PAL)"
+	description "Chou Snobow Kids (J) [f1] (PAL)"
+	rom ( name "Chou Snobow Kids (J) [f1] (PAL).z64" crc F999B89C )
+)
+
+game (
+	name "Snowboard Kids 2 (E) [!]"
+	description "Snowboard Kids 2 (E) [!]"
+	rom ( name "Snowboard Kids 2 (E) [!].z64" crc 3A0B6214 )
+)
+
+game (
+	name "Snowboard Kids 2 (U) [!]"
+	description "Snowboard Kids 2 (U) [!]"
+	rom ( name "Snowboard Kids 2 (U) [!].z64" crc D0DC8A8E )
+)
+
+game (
+	name "Snowboard Kids 2 (U) [f1] (PAL)"
+	description "Snowboard Kids 2 (U) [f1] (PAL)"
+	rom ( name "Snowboard Kids 2 (U) [f1] (PAL).z64" crc AC4B9DA6 )
+)
+
+game (
+	name "Snowboard Kids 2 (U) [f2] (PAL)"
+	description "Snowboard Kids 2 (U) [f2] (PAL)"
+	rom ( name "Snowboard Kids 2 (U) [f2] (PAL).z64" crc 8232CCAF )
+)
+
+game (
+	name "South Park (E) (M3) [!]"
+	description "South Park (E) (M3) [!]"
+	rom ( name "South Park (E) (M3) [!].z64" crc B2C3E123 )
+)
+
+game (
+	name "South Park (E) (M3) [b1]"
+	description "South Park (E) (M3) [b1]"
+	rom ( name "South Park (E) (M3) [b1].z64" crc 56C96784 )
+)
+
+game (
+	name "South Park (E) (M3) [h1C]"
+	description "South Park (E) (M3) [h1C]"
+	rom ( name "South Park (E) (M3) [h1C].z64" crc 4710B1CD )
+)
+
+game (
+	name "South Park (G) [!]"
+	description "South Park (G) [!]"
+	rom ( name "South Park (G) [!].z64" crc 5711E197 )
+)
+
+game (
+	name "South Park (U) [!]"
+	description "South Park (U) [!]"
+	rom ( name "South Park (U) [!].z64" crc 7D666B9E )
+)
+
+game (
+	name "South Park (U) [b1]"
+	description "South Park (U) [b1]"
+	rom ( name "South Park (U) [b1].z64" crc 858F3DF8 )
+)
+
+game (
+	name "South Park (U) [f1] (PAL)"
+	description "South Park (U) [f1] (PAL)"
+	rom ( name "South Park (U) [f1] (PAL).z64" crc 73C0BCF5 )
+)
+
+game (
+	name "South Park (U) [t1]"
+	description "South Park (U) [t1]"
+	rom ( name "South Park (U) [t1].z64" crc 4EFE2139 )
+)
+
+game (
+	name "South Park - Chef's Luv Shack (E) [!]"
+	description "South Park - Chef's Luv Shack (E) [!]"
+	rom ( name "South Park - Chef's Luv Shack (E) [!].z64" crc AC1628EB )
+)
+
+game (
+	name "South Park - Chef's Luv Shack (U) [!]"
+	description "South Park - Chef's Luv Shack (U) [!]"
+	rom ( name "South Park - Chef's Luv Shack (U) [!].z64" crc 6B6B1D09 )
+)
+
+game (
+	name "South Park - Chef's Luv Shack (U) [f1] (Country Check)"
+	description "South Park - Chef's Luv Shack (U) [f1] (Country Check)"
+	rom ( name "South Park - Chef's Luv Shack (U) [f1] (Country Check).z64" crc 605DE6C5 )
+)
+
+game (
+	name "South Park Rally (E) [!]"
+	description "South Park Rally (E) [!]"
+	rom ( name "South Park Rally (E) [!].z64" crc 296E3525 )
+)
+
+game (
+	name "South Park Rally (U) [!]"
+	description "South Park Rally (U) [!]"
+	rom ( name "South Park Rally (U) [!].z64" crc CCDD322A )
+)
+
+game (
+	name "South Park Rally (U) [f1] (PAL)"
+	description "South Park Rally (U) [f1] (PAL)"
+	rom ( name "South Park Rally (U) [f1] (PAL).z64" crc 5B9B3F35 )
+)
+
+game (
+	name "South Park Rally (U) [t1]"
+	description "South Park Rally (U) [t1]"
+	rom ( name "South Park Rally (U) [t1].z64" crc AC087102 )
+)
+
+game (
+	name "South Park Rally (U) [t2]"
+	description "South Park Rally (U) [t2]"
+	rom ( name "South Park Rally (U) [t2].z64" crc DC38C0BE )
+)
+
+game (
+	name "Space Invaders (U) [!]"
+	description "Space Invaders (U) [!]"
+	rom ( name "Space Invaders (U) [!].z64" crc 60F7FF8E )
+)
+
+game (
+	name "Space Invaders (U) [f1] (PAL)"
+	description "Space Invaders (U) [f1] (PAL)"
+	rom ( name "Space Invaders (U) [f1] (PAL).z64" crc 2CE1EBB0 )
+)
+
+game (
+	name "Space Invaders (U) [t1]"
+	description "Space Invaders (U) [t1]"
+	rom ( name "Space Invaders (U) [t1].z64" crc 47469C2D )
+)
+
+game (
+	name "Space Invaders (U) [t2]"
+	description "Space Invaders (U) [t2]"
+	rom ( name "Space Invaders (U) [t2].z64" crc BAB1C482 )
+)
+
+game (
+	name "Space Station Silicon Valley (E) (M7) [!]"
+	description "Space Station Silicon Valley (E) (M7) [!]"
+	rom ( name "Space Station Silicon Valley (E) (M7) [!].z64" crc 63042E36 )
+)
+
+game (
+	name "Space Station Silicon Valley (E) (M7) [b1]"
+	description "Space Station Silicon Valley (E) (M7) [b1]"
+	rom ( name "Space Station Silicon Valley (E) (M7) [b1].z64" crc A7507158 )
+)
+
+game (
+	name "Space Station Silicon Valley (J) [!]"
+	description "Space Station Silicon Valley (J) [!]"
+	rom ( name "Space Station Silicon Valley (J) [!].z64" crc DCEC9F8A )
+)
+
+game (
+	name "Space Station Silicon Valley (U) [!]"
+	description "Space Station Silicon Valley (U) [!]"
+	rom ( name "Space Station Silicon Valley (U) [!].z64" crc A606E8AE )
+)
+
+game (
+	name "Space Station Silicon Valley (U) [f1] (PAL)"
+	description "Space Station Silicon Valley (U) [f1] (PAL)"
+	rom ( name "Space Station Silicon Valley (U) [f1] (PAL).z64" crc 0EF42062 )
+)
+
+game (
+	name "Space Station Silicon Valley (U) [f2] (PAL)"
+	description "Space Station Silicon Valley (U) [f2] (PAL)"
+	rom ( name "Space Station Silicon Valley (U) [f2] (PAL).z64" crc 1B17ACD9 )
+)
+
+game (
+	name "Spider-Man (U) [!]"
+	description "Spider-Man (U) [!]"
+	rom ( name "Spider-Man (U) [!].z64" crc 696CC2A4 )
+)
+
+game (
+	name "Spider-Man (U) [t1]"
+	description "Spider-Man (U) [t1]"
+	rom ( name "Spider-Man (U) [t1].z64" crc 071196F8 )
+)
+
+game (
+	name "Lylat Wars (A) (M3) [!]"
+	description "Lylat Wars (A) (M3) [!]"
+	rom ( name "Lylat Wars (A) (M3) [!].z64" crc 9A3425DA )
+)
+
+game (
+	name "Lylat Wars (A) (M3) [f1]"
+	description "Lylat Wars (A) (M3) [f1]"
+	rom ( name "Lylat Wars (A) (M3) [f1].z64" crc 6C252BEB )
+)
+
+game (
+	name "Lylat Wars (A) (M3) [t1] (Boost)"
+	description "Lylat Wars (A) (M3) [t1] (Boost)"
+	rom ( name "Lylat Wars (A) (M3) [t1] (Boost).z64" crc 45139835 )
+)
+
+game (
+	name "Lylat Wars (A) (M3) [t2] (No Damage-Unbreakable Wings)"
+	description "Lylat Wars (A) (M3) [t2] (No Damage-Unbreakable Wings)"
+	rom ( name "Lylat Wars (A) (M3) [t2] (No Damage-Unbreakable Wings).z64" crc 9F5255DA )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [!]"
+	description "Lylat Wars (E) (M3) [!]"
+	rom ( name "Lylat Wars (E) (M3) [!].z64" crc 50A9C0B1 )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [f1]"
+	description "Lylat Wars (E) (M3) [f1]"
+	rom ( name "Lylat Wars (E) (M3) [f1].z64" crc A6B8CE80 )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [f1][h1C]"
+	description "Lylat Wars (E) (M3) [f1][h1C]"
+	rom ( name "Lylat Wars (E) (M3) [f1][h1C].z64" crc 82E3FF42 )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [f2] (NTSC)"
+	description "Lylat Wars (E) (M3) [f2] (NTSC)"
+	rom ( name "Lylat Wars (E) (M3) [f2] (NTSC).z64" crc 927CF25E )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [t1] (Boost)"
+	description "Lylat Wars (E) (M3) [t1] (Boost)"
+	rom ( name "Lylat Wars (E) (M3) [t1] (Boost).z64" crc 321ECE7E )
+)
+
+game (
+	name "Lylat Wars (E) (M3) [t2] (No Damage-Unbreakable Wings)"
+	description "Lylat Wars (E) (M3) [t2] (No Damage-Unbreakable Wings)"
+	rom ( name "Lylat Wars (E) (M3) [t2] (No Damage-Unbreakable Wings).z64" crc 13576CDD )
+)
+
+game (
+	name "Star Fox 64 (J) [!]"
+	description "Star Fox 64 (J) [!]"
+	rom ( name "Star Fox 64 (J) [!].z64" crc 411142A7 )
+)
+
+game (
+	name "Star Fox 64 (J) [f1]"
+	description "Star Fox 64 (J) [f1]"
+	rom ( name "Star Fox 64 (J) [f1].z64" crc DAC2F94E )
+)
+
+game (
+	name "Star Fox 64 (J) [o1]"
+	description "Star Fox 64 (J) [o1]"
+	rom ( name "Star Fox 64 (J) [o1].z64" crc 94E2BF8B )
+)
+
+game (
+	name "Star Fox 64 (J) [o1][f1]"
+	description "Star Fox 64 (J) [o1][f1]"
+	rom ( name "Star Fox 64 (J) [o1][f1].z64" crc 4DC374C0 )
+)
+
+game (
+	name "Star Fox 64 (J) [o2][f1]"
+	description "Star Fox 64 (J) [o2][f1]"
+	rom ( name "Star Fox 64 (J) [o2][f1].z64" crc 5D842B4D )
+)
+
+game (
+	name "Star Fox 64 (J) [o3][f1]"
+	description "Star Fox 64 (J) [o3][f1]"
+	rom ( name "Star Fox 64 (J) [o3][f1].z64" crc 5439C8ED )
+)
+
+game (
+	name "Star Fox 64 (J) [t1] (Boost)"
+	description "Star Fox 64 (J) [t1] (Boost)"
+	rom ( name "Star Fox 64 (J) [t1] (Boost).z64" crc 21278E57 )
+)
+
+game (
+	name "Star Fox 64 (J) [t2] (No Damage-Unbreakable Wings)"
+	description "Star Fox 64 (J) [t2] (No Damage-Unbreakable Wings)"
+	rom ( name "Star Fox 64 (J) [t2] (No Damage-Unbreakable Wings).z64" crc 0963550F )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [!]"
+	description "Star Fox 64 (U) (V1.0) [!]"
+	rom ( name "Star Fox 64 (U) (V1.0) [!].z64" crc B1FCAA9C )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [f1]"
+	description "Star Fox 64 (U) (V1.0) [f1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [f1].z64" crc 2A2F1175 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [f1][h1C]"
+	description "Star Fox 64 (U) (V1.0) [f1][h1C]"
+	rom ( name "Star Fox 64 (U) (V1.0) [f1][h1C].z64" crc 2E096BC0 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [f1][o1]"
+	description "Star Fox 64 (U) (V1.0) [f1][o1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [f1][o1].z64" crc 6A831A95 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [f2] (PAL)"
+	description "Star Fox 64 (U) (V1.0) [f2] (PAL)"
+	rom ( name "Star Fox 64 (U) (V1.0) [f2] (PAL).z64" crc 878B74E8 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [h1C]"
+	description "Star Fox 64 (U) (V1.0) [h1C]"
+	rom ( name "Star Fox 64 (U) (V1.0) [h1C].z64" crc DB9324C2 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [o1][f1]"
+	description "Star Fox 64 (U) (V1.0) [o1][f1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [o1][f1].z64" crc B6007A08 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [o2][f1]"
+	description "Star Fox 64 (U) (V1.0) [o2][f1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [o2][f1].z64" crc 792ED884 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [o3][f1]"
+	description "Star Fox 64 (U) (V1.0) [o3][f1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [o3][f1].z64" crc E86AF5A6 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [t1]"
+	description "Star Fox 64 (U) (V1.0) [t1]"
+	rom ( name "Star Fox 64 (U) (V1.0) [t1].z64" crc AF40CB76 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [t2] (Boost)"
+	description "Star Fox 64 (U) (V1.0) [t2] (Boost)"
+	rom ( name "Star Fox 64 (U) (V1.0) [t2] (Boost).z64" crc 65935FE9 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.0) [t3] (No Damage-Unbreakable Wings)"
+	description "Star Fox 64 (U) (V1.0) [t3] (No Damage-Unbreakable Wings)"
+	rom ( name "Star Fox 64 (U) (V1.0) [t3] (No Damage-Unbreakable Wings).z64" crc D9215C45 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.1) [!]"
+	description "Star Fox 64 (U) (V1.1) [!]"
+	rom ( name "Star Fox 64 (U) (V1.1) [!].z64" crc B1B5FC46 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.1) [t1] (Energy)"
+	description "Star Fox 64 (U) (V1.1) [t1] (Energy)"
+	rom ( name "Star Fox 64 (U) (V1.1) [t1] (Energy).z64" crc F066CC83 )
+)
+
+game (
+	name "Star Fox 64 (U) (V1.1) [t2] (Boost)"
+	description "Star Fox 64 (U) (V1.1) [t2] (Boost)"
+	rom ( name "Star Fox 64 (U) (V1.1) [t2] (Boost).z64" crc 5083B27C )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (J) [!]"
+	description "Star Soldier - Vanishing Earth (J) [!]"
+	rom ( name "Star Soldier - Vanishing Earth (J) [!].z64" crc 7EE5F51D )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (J) [b1]"
+	description "Star Soldier - Vanishing Earth (J) [b1]"
+	rom ( name "Star Soldier - Vanishing Earth (J) [b1].z64" crc 532379C3 )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (J) [h1C]"
+	description "Star Soldier - Vanishing Earth (J) [h1C]"
+	rom ( name "Star Soldier - Vanishing Earth (J) [h1C].z64" crc CFDA6035 )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (J) [o1]"
+	description "Star Soldier - Vanishing Earth (J) [o1]"
+	rom ( name "Star Soldier - Vanishing Earth (J) [o1].z64" crc 720344D8 )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (J) [t1]"
+	description "Star Soldier - Vanishing Earth (J) [t1]"
+	rom ( name "Star Soldier - Vanishing Earth (J) [t1].z64" crc 445278B4 )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (U) [!]"
+	description "Star Soldier - Vanishing Earth (U) [!]"
+	rom ( name "Star Soldier - Vanishing Earth (U) [!].z64" crc EA650DEF )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth (U) [t1]"
+	description "Star Soldier - Vanishing Earth (U) [t1]"
+	rom ( name "Star Soldier - Vanishing Earth (U) [t1].z64" crc BE7AA424 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack)"
+	description "Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack)"
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack).z64" crc ACAA878B )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!]"
+	description "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!]"
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!].z64" crc 6289645F )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [t1]"
+	description "Star Wars - Rogue Squadron (E) (M3) (V1.0) [t1]"
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [t1].z64" crc 8AAFF501 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!]"
+	description "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!]"
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!].z64" crc C88E5638 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (U) (M3) (Language Select Hack)"
+	description "Star Wars - Rogue Squadron (U) (M3) (Language Select Hack)"
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) (Language Select Hack).z64" crc D85EE95E )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (U) (M3) [!]"
+	description "Star Wars - Rogue Squadron (U) (M3) [!]"
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [!].z64" crc 83C225CC )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (U) (M3) [b1]"
+	description "Star Wars - Rogue Squadron (U) (M3) [b1]"
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [b1].z64" crc 207DF305 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron (U) (M3) [t1]"
+	description "Star Wars - Rogue Squadron (U) (M3) [t1]"
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [t1].z64" crc 11ADCE88 )
+)
+
+game (
+	name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!]"
+	description "Star Wars - Shutsugeki! Rogue Chuutai (J) [!]"
+	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!].z64" crc EE7643B6 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [!]"
+	description "Star Wars - Shadows of the Empire (E) [!]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [!].z64" crc F0A191BF )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [b1]"
+	description "Star Wars - Shadows of the Empire (E) [b1]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [b1].z64" crc 2CB8BC8D )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [b2]"
+	description "Star Wars - Shadows of the Empire (E) [b2]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [b2].z64" crc EEB97B44 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [b3]"
+	description "Star Wars - Shadows of the Empire (E) [b3]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [b3].z64" crc E1D48724 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [b4]"
+	description "Star Wars - Shadows of the Empire (E) [b4]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [b4].z64" crc 0387F26C )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (E) [o1]"
+	description "Star Wars - Shadows of the Empire (E) [o1]"
+	rom ( name "Star Wars - Shadows of the Empire (E) [o1].z64" crc 34C7981C )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [!]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [!]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [!].z64" crc 3C0837B3 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [b1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [b1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b1].z64" crc F4E231A3 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [b2]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [b2]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b2].z64" crc E9810930 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [o1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [o1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [o1].z64" crc 1EC5F1DC )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [t1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [t1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t1].z64" crc E09DB876 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.0) [t2]"
+	description "Star Wars - Shadows of the Empire (U) (V1.0) [t2]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t2].z64" crc 1012BEDD )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.1) [!]"
+	description "Star Wars - Shadows of the Empire (U) (V1.1) [!]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [!].z64" crc B0540688 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.1) [b1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.1) [b1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [b1].z64" crc DB8C7E81 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.1) [o1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.1) [o1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [o1].z64" crc 86767AF9 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.1) [t1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.1) [t1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [t1].z64" crc 1CC97B41 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.2) [!]"
+	description "Star Wars - Shadows of the Empire (U) (V1.2) [!]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [!].z64" crc E8727549 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.2) [b1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.2) [b1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b1].z64" crc EFEBC833 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.2) [b2]"
+	description "Star Wars - Shadows of the Empire (U) (V1.2) [b2]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b2].z64" crc 26408EA6 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire (U) (V1.2) [o1]"
+	description "Star Wars - Shadows of the Empire (U) (V1.2) [o1]"
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [o1].z64" crc 222D4A2B )
+)
+
+game (
+	name "Star Wars - Teikoku no Kage (J) [!]"
+	description "Star Wars - Teikoku no Kage (J) [!]"
+	rom ( name "Star Wars - Teikoku no Kage (J) [!].z64" crc 7CE71426 )
+)
+
+game (
+	name "Star Wars - Teikoku no Kage (J) [o1]"
+	description "Star Wars - Teikoku no Kage (J) [o1]"
+	rom ( name "Star Wars - Teikoku no Kage (J) [o1].z64" crc 6B430661 )
+)
+
+game (
+	name "Star Wars - Teikoku no Kage (J) [o2]"
+	description "Star Wars - Teikoku no Kage (J) [o2]"
+	rom ( name "Star Wars - Teikoku no Kage (J) [o2].z64" crc 506AFDDA )
+)
+
+game (
+	name "Star Wars Episode I - Battle for Naboo (E) [!]"
+	description "Star Wars Episode I - Battle for Naboo (E) [!]"
+	rom ( name "Star Wars Episode I - Battle for Naboo (E) [!].z64" crc 029104FD )
+)
+
+game (
+	name "Star Wars Episode I - Battle for Naboo (U) [!]"
+	description "Star Wars Episode I - Battle for Naboo (U) [!]"
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [!].z64" crc 99DEE3C0 )
+)
+
+game (
+	name "Star Wars Episode I - Battle for Naboo (U) [b1]"
+	description "Star Wars Episode I - Battle for Naboo (U) [b1]"
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [b1].z64" crc F02CD015 )
+)
+
+game (
+	name "Star Wars Episode I - Battle for Naboo (U) [t1]"
+	description "Star Wars Episode I - Battle for Naboo (U) [t1]"
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [t1].z64" crc 377CE7C7 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (E) (M3) [!]"
+	description "Star Wars Episode I - Racer (E) (M3) [!]"
+	rom ( name "Star Wars Episode I - Racer (E) (M3) [!].z64" crc E0F46629 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (E) (M3) [f1] (Save)"
+	description "Star Wars Episode I - Racer (E) (M3) [f1] (Save)"
+	rom ( name "Star Wars Episode I - Racer (E) (M3) [f1] (Save).z64" crc DF6DA1CF )
+)
+
+game (
+	name "Star Wars Episode I - Racer (J) [!]"
+	description "Star Wars Episode I - Racer (J) [!]"
+	rom ( name "Star Wars Episode I - Racer (J) [!].z64" crc 97C155C5 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (J) [b1]"
+	description "Star Wars Episode I - Racer (J) [b1]"
+	rom ( name "Star Wars Episode I - Racer (J) [b1].z64" crc 5CC91891 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [!]"
+	description "Star Wars Episode I - Racer (U) [!]"
+	rom ( name "Star Wars Episode I - Racer (U) [!].z64" crc C53C1035 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [f1] (Save)"
+	description "Star Wars Episode I - Racer (U) [f1] (Save)"
+	rom ( name "Star Wars Episode I - Racer (U) [f1] (Save).z64" crc 950E170D )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [t1]"
+	description "Star Wars Episode I - Racer (U) [t1]"
+	rom ( name "Star Wars Episode I - Racer (U) [t1].z64" crc 5AD165B7 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [t2]"
+	description "Star Wars Episode I - Racer (U) [t2]"
+	rom ( name "Star Wars Episode I - Racer (U) [t2].z64" crc F7841689 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [t3]"
+	description "Star Wars Episode I - Racer (U) [t3]"
+	rom ( name "Star Wars Episode I - Racer (U) [t3].z64" crc B4CEAFF5 )
+)
+
+game (
+	name "Star Wars Episode I - Racer (U) [t4]"
+	description "Star Wars Episode I - Racer (U) [t4]"
+	rom ( name "Star Wars Episode I - Racer (U) [t4].z64" crc C59DE7A3 )
+)
+
+game (
+	name "StarCraft 64 (Beta) [f1]"
+	description "StarCraft 64 (Beta) [f1]"
+	rom ( name "StarCraft 64 (Beta) [f1].z64" crc D0D566A2 )
+)
+
+game (
+	name "StarCraft 64 (Beta) [f2] (PAL)"
+	description "StarCraft 64 (Beta) [f2] (PAL)"
+	rom ( name "StarCraft 64 (Beta) [f2] (PAL).z64" crc 79D4832C )
+)
+
+game (
+	name "StarCraft 64 (Beta) [f3] (Country Code)"
+	description "StarCraft 64 (Beta) [f3] (Country Code)"
+	rom ( name "StarCraft 64 (Beta) [f3] (Country Code).z64" crc 5F114823 )
+)
+
+game (
+	name "StarCraft 64 (Beta)"
+	description "StarCraft 64 (Beta)"
+	rom ( name "StarCraft 64 (Beta).z64" crc B0E1654F )
+)
+
+game (
+	name "StarCraft 64 (E) [!]"
+	description "StarCraft 64 (E) [!]"
+	rom ( name "StarCraft 64 (E) [!].z64" crc 2639DAE2 )
+)
+
+game (
+	name "StarCraft 64 (E) [b1]"
+	description "StarCraft 64 (E) [b1]"
+	rom ( name "StarCraft 64 (E) [b1].z64" crc 888F52E7 )
+)
+
+game (
+	name "StarCraft 64 (E) [f1] (NTSC)"
+	description "StarCraft 64 (E) [f1] (NTSC)"
+	rom ( name "StarCraft 64 (E) [f1] (NTSC).z64" crc 84A6CE9C )
+)
+
+game (
+	name "StarCraft 64 (U) [!]"
+	description "StarCraft 64 (U) [!]"
+	rom ( name "StarCraft 64 (U) [!].z64" crc 4E4C7EC9 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (E) (M3) [!]"
+	description "Starshot - Space Circus Fever (E) (M3) [!]"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [!].z64" crc 056D2218 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%)"
+	description "Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%)"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%).z64" crc 01AE0CFC )
+)
+
+game (
+	name "Starshot - Space Circus Fever (E) (M3) [f2] (NTSC)"
+	description "Starshot - Space Circus Fever (E) (M3) [f2] (NTSC)"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f2] (NTSC).z64" crc B3054021 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (E) (M3) [f3] (NTSC)"
+	description "Starshot - Space Circus Fever (E) (M3) [f3] (NTSC)"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f3] (NTSC).z64" crc 4AA2EC88 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (E) (M3) [t1]"
+	description "Starshot - Space Circus Fever (E) (M3) [t1]"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [t1].z64" crc 85BFE092 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (U) (M3) [!]"
+	description "Starshot - Space Circus Fever (U) (M3) [!]"
+	rom ( name "Starshot - Space Circus Fever (U) (M3) [!].z64" crc 7720E5F3 )
+)
+
+game (
+	name "Starshot - Space Circus Fever (U) (M3) [b1]"
+	description "Starshot - Space Circus Fever (U) (M3) [b1]"
+	rom ( name "Starshot - Space Circus Fever (U) (M3) [b1].z64" crc 8F0A4446 )
+)
+
+game (
+	name "Stunt Racer 64 (U) [!]"
+	description "Stunt Racer 64 (U) [!]"
+	rom ( name "Stunt Racer 64 (U) [!].z64" crc 3438B1AF )
+)
+
+game (
+	name "Super B-Daman - Battle Phoenix 64 (J) [!]"
+	description "Super B-Daman - Battle Phoenix 64 (J) [!]"
+	rom ( name "Super B-Daman - Battle Phoenix 64 (J) [!].z64" crc 5006DC88 )
+)
+
+game (
+	name "Super Bowling (J) [!]"
+	description "Super Bowling (J) [!]"
+	rom ( name "Super Bowling (J) [!].z64" crc BA2D8B2E )
+)
+
+game (
+	name "Super Bowling 64 (U) [!]"
+	description "Super Bowling 64 (U) [!]"
+	rom ( name "Super Bowling 64 (U) [!].z64" crc F6CCD04A )
+)
+
+game (
+	name "Super Irishley Drunk Giant WaLuigi 64 (Super Mario 64 Hack)"
+	description "Super Irishley Drunk Giant WaLuigi 64 (Super Mario 64 Hack)"
+	rom ( name "Super Irishley Drunk Giant WaLuigi 64 (Super Mario 64 Hack).z64" crc 70AB0041 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [!]"
+	description "Super Mario 64 (E) (M3) [!]"
+	rom ( name "Super Mario 64 (E) (M3) [!].z64" crc 03048DE6 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [b1]"
+	description "Super Mario 64 (E) (M3) [b1]"
+	rom ( name "Super Mario 64 (E) (M3) [b1].z64" crc 613E80DE )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [b2]"
+	description "Super Mario 64 (E) (M3) [b2]"
+	rom ( name "Super Mario 64 (E) (M3) [b2].z64" crc FDF3C491 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [h1C]"
+	description "Super Mario 64 (E) (M3) [h1C]"
+	rom ( name "Super Mario 64 (E) (M3) [h1C].z64" crc 7162572A )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [o1]"
+	description "Super Mario 64 (E) (M3) [o1]"
+	rom ( name "Super Mario 64 (E) (M3) [o1].z64" crc 1863FD76 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [o2]"
+	description "Super Mario 64 (E) (M3) [o2]"
+	rom ( name "Super Mario 64 (E) (M3) [o2].z64" crc 2A023F50 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [t1]"
+	description "Super Mario 64 (E) (M3) [t1]"
+	rom ( name "Super Mario 64 (E) (M3) [t1].z64" crc 5FEEBB05 )
+)
+
+game (
+	name "Super Mario 64 (E) (M3) [t2]"
+	description "Super Mario 64 (E) (M3) [t2]"
+	rom ( name "Super Mario 64 (E) (M3) [t2].z64" crc 680AD655 )
+)
+
+game (
+	name "Super Mario 64 (J) [!]"
+	description "Super Mario 64 (J) [!]"
+	rom ( name "Super Mario 64 (J) [!].z64" crc DD801954 )
+)
+
+game (
+	name "Super Mario 64 (J) [h1C]"
+	description "Super Mario 64 (J) [h1C]"
+	rom ( name "Super Mario 64 (J) [h1C].z64" crc 7E0BDF78 )
+)
+
+game (
+	name "Super Mario 64 (U) (Enable Hidden Scroller Hack)"
+	description "Super Mario 64 (U) (Enable Hidden Scroller Hack)"
+	rom ( name "Super Mario 64 (U) (Enable Hidden Scroller Hack).z64" crc A42B60BF )
+)
+
+game (
+	name "Super Mario 64 (U) (No Cap Hack)"
+	description "Super Mario 64 (U) (No Cap Hack)"
+	rom ( name "Super Mario 64 (U) (No Cap Hack).z64" crc 64F3D9F2 )
+)
+
+game (
+	name "Super Mario 64 (U) (Silver Mario Hack)"
+	description "Super Mario 64 (U) (Silver Mario Hack)"
+	rom ( name "Super Mario 64 (U) (Silver Mario Hack).z64" crc E41D2F03 )
+)
+
+game (
+	name "Super Mario 64 (U) [!]"
+	description "Super Mario 64 (U) [!]"
+	rom ( name "Super Mario 64 (U) [!].z64" crc 3CE60709 )
+)
+
+game (
+	name "Super Mario 64 (U) [b1]"
+	description "Super Mario 64 (U) [b1]"
+	rom ( name "Super Mario 64 (U) [b1].z64" crc 4501F084 )
+)
+
+game (
+	name "Super Mario 64 (U) [b2]"
+	description "Super Mario 64 (U) [b2]"
+	rom ( name "Super Mario 64 (U) [b2].z64" crc 9AAEE776 )
+)
+
+game (
+	name "Super Mario 64 (U) [h1C]"
+	description "Super Mario 64 (U) [h1C]"
+	rom ( name "Super Mario 64 (U) [h1C].z64" crc D8EC20DC )
+)
+
+game (
+	name "Super Mario 64 (U) [h2C]"
+	description "Super Mario 64 (U) [h2C]"
+	rom ( name "Super Mario 64 (U) [h2C].z64" crc 4E80DDC5 )
+)
+
+game (
+	name "Super Mario 64 (U) [o1]"
+	description "Super Mario 64 (U) [o1]"
+	rom ( name "Super Mario 64 (U) [o1].z64" crc 5870C898 )
+)
+
+game (
+	name "Super Mario 64 (U) [T+Ita2.0final_beta2_Rulesless]"
+	description "Super Mario 64 (U) [T+Ita2.0final_beta2_Rulesless]"
+	rom ( name "Super Mario 64 (U) [T+Ita2.0final_beta2_Rulesless].bin" crc 5F5401F6 )
+)
+
+game (
+	name "Super Mario 64 (U) [T+Rus]"
+	description "Super Mario 64 (U) [T+Rus]"
+	rom ( name "Super Mario 64 (U) [T+Rus].z64" crc 474BFC87 )
+)
+
+game (
+	name "Super Mario 64 (U) [T+SpaFinal_Mistergame]"
+	description "Super Mario 64 (U) [T+SpaFinal_Mistergame]"
+	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame].z64" crc CF9F8B39 )
+)
+
+game (
+	name "Super Mario 64 (U) [T+SpaFinal_Mistergame][a1]"
+	description "Super Mario 64 (U) [T+SpaFinal_Mistergame][a1]"
+	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame][a1].z64" crc 720726BF )
+)
+
+game (
+	name "Super Mario 64 (U) [T-Ita1.0final_beta1_Rulesless]"
+	description "Super Mario 64 (U) [T-Ita1.0final_beta1_Rulesless]"
+	rom ( name "Super Mario 64 (U) [T-Ita1.0final_beta1_Rulesless].z64" crc 9A4825FB )
+)
+
+game (
+	name "Super Mario 64 (U) [t1] (Invincible)"
+	description "Super Mario 64 (U) [t1] (Invincible)"
+	rom ( name "Super Mario 64 (U) [t1] (Invincible).z64" crc 48EA9C39 )
+)
+
+game (
+	name "Super Mario 64 (U) [t2] (Speed)"
+	description "Super Mario 64 (U) [t2] (Speed)"
+	rom ( name "Super Mario 64 (U) [t2] (Speed).z64" crc 44EFDD34 )
+)
+
+game (
+	name "Super Mario 64 (U) [t3]"
+	description "Super Mario 64 (U) [t3]"
+	rom ( name "Super Mario 64 (U) [t3].z64" crc 9F154B8C )
+)
+
+game (
+	name "Super Mario 64 - Shindou Edition (J) [!]"
+	description "Super Mario 64 - Shindou Edition (J) [!]"
+	rom ( name "Super Mario 64 - Shindou Edition (J) [!].z64" crc A1E15117 )
+)
+
+game (
+	name "Super Mario 64 - Shindou Edition (J) [b1]"
+	description "Super Mario 64 - Shindou Edition (J) [b1]"
+	rom ( name "Super Mario 64 - Shindou Edition (J) [b1].z64" crc EF29D54D )
+)
+
+game (
+	name "Super Mario 64 - Shindou Edition (J) [b2]"
+	description "Super Mario 64 - Shindou Edition (J) [b2]"
+	rom ( name "Super Mario 64 - Shindou Edition (J) [b2].z64" crc 857D972A )
+)
+
+game (
+	name "Super Mario 64 - Shindou Edition (J) [h1C]"
+	description "Super Mario 64 - Shindou Edition (J) [h1C]"
+	rom ( name "Super Mario 64 - Shindou Edition (J) [h1C].z64" crc B6C0EB94 )
+)
+
+game (
+	name "Super Mario 64 - Shindou Edition (J) [h2C]"
+	description "Super Mario 64 - Shindou Edition (J) [h2C]"
+	rom ( name "Super Mario 64 - Shindou Edition (J) [h2C].z64" crc 0EBBCF0D )
+)
+
+game (
+	name "Super Mario Magic Plant Adventure 64 (Super Mario 64 Hack)"
+	description "Super Mario Magic Plant Adventure 64 (Super Mario 64 Hack)"
+	rom ( name "Super Mario Magic Plant Adventure 64 (Super Mario 64 Hack).z64" crc 97934027 )
+)
+
+game (
+	name "Super WaLuigi 64 (Super Mario 64 Hack)"
+	description "Super WaLuigi 64 (Super Mario 64 Hack)"
+	rom ( name "Super WaLuigi 64 (Super Mario 64 Hack).z64" crc 7ABC992D )
+)
+
+game (
+	name "Super Wario 64 (Super Mario 64 Hack)"
+	description "Super Wario 64 (Super Mario 64 Hack)"
+	rom ( name "Super Wario 64 (Super Mario 64 Hack).z64" crc 5615DBC0 )
+)
+
+game (
+	name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack) [T+Ita]"
+	description "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack) [T+Ita]"
+	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack) [T+Ita].z64" crc 1BBDDA7E )
+)
+
+game (
+	name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack)"
+	description "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack)"
+	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack).z64" crc DB6BED15 )
+)
+
+game (
+	name "Super Robot Spirits (J) [!]"
+	description "Super Robot Spirits (J) [!]"
+	rom ( name "Super Robot Spirits (J) [!].z64" crc 8C9216C1 )
+)
+
+game (
+	name "Super Robot Spirits (J) [b1]"
+	description "Super Robot Spirits (J) [b1]"
+	rom ( name "Super Robot Spirits (J) [b1].z64" crc DB33CE3B )
+)
+
+game (
+	name "Super Robot Taisen 64 (J) [!]"
+	description "Super Robot Taisen 64 (J) [!]"
+	rom ( name "Super Robot Taisen 64 (J) [!].z64" crc 85DF2771 )
+)
+
+game (
+	name "Super Robot Taisen 64 (J) [b1]"
+	description "Super Robot Taisen 64 (J) [b1]"
+	rom ( name "Super Robot Taisen 64 (J) [b1].z64" crc DE81F6C3 )
+)
+
+game (
+	name "Super Robot Taisen 64 (J) [b2]"
+	description "Super Robot Taisen 64 (J) [b2]"
+	rom ( name "Super Robot Taisen 64 (J) [b2].z64" crc 4482C180 )
+)
+
+game (
+	name "Super Robot Taisen 64 (J) [f1] (PAL)"
+	description "Super Robot Taisen 64 (J) [f1] (PAL)"
+	rom ( name "Super Robot Taisen 64 (J) [f1] (PAL).z64" crc 09D5E6DB )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [!]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [!]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [!].z64" crc 04C9D3B1 )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [b1]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [b1]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b1].z64" crc EF0EA76F )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [b2]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [b2]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b2].z64" crc DABE5627 )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [b3]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [b3]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b3].z64" crc 3F9A4310 )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [f1]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [f1]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f1].z64" crc 13CCB98D )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [f2]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [f2]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f2].z64" crc 433BD4A5 )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [f3]"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [f3]"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f3].z64" crc 03DB0407 )
+)
+
+game (
+	name "Nintendo All-Star! Dairantou Smash Brothers (J) [f4] (PAL)"
+	description "Nintendo All-Star! Dairantou Smash Brothers (J) [f4] (PAL)"
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f4] (PAL).z64" crc 64051AD3 )
+)
+
+game (
+	name "Super Smash Bros. (A) [!]"
+	description "Super Smash Bros. (A) [!]"
+	rom ( name "Super Smash Bros. (A) [!].z64" crc E96779FA )
+)
+
+game (
+	name "Super Smash Bros. (A) [f1]"
+	description "Super Smash Bros. (A) [f1]"
+	rom ( name "Super Smash Bros. (A) [f1].z64" crc 2B4391AD )
+)
+
+game (
+	name "Super Smash Bros. (E) (M3) [!]"
+	description "Super Smash Bros. (E) (M3) [!]"
+	rom ( name "Super Smash Bros. (E) (M3) [!].z64" crc 45A91CB1 )
+)
+
+game (
+	name "Super Smash Bros. (E) (M3) [b1]"
+	description "Super Smash Bros. (E) (M3) [b1]"
+	rom ( name "Super Smash Bros. (E) (M3) [b1].z64" crc 01FDB7F2 )
+)
+
+game (
+	name "Super Smash Bros. (E) (M3) [f1]"
+	description "Super Smash Bros. (E) (M3) [f1]"
+	rom ( name "Super Smash Bros. (E) (M3) [f1].z64" crc FD8A4EF0 )
+)
+
+game (
+	name "Super Smash Bros. (U) [!]"
+	description "Super Smash Bros. (U) [!]"
+	rom ( name "Super Smash Bros. (U) [!].z64" crc EB97929E )
+)
+
+game (
+	name "Super Smash Bros. (U) [b1]"
+	description "Super Smash Bros. (U) [b1]"
+	rom ( name "Super Smash Bros. (U) [b1].z64" crc 4E7626B9 )
+)
+
+game (
+	name "Super Smash Bros. (U) [b2]"
+	description "Super Smash Bros. (U) [b2]"
+	rom ( name "Super Smash Bros. (U) [b2].z64" crc 8F6D6B7E )
+)
+
+game (
+	name "Super Smash Bros. (U) [f1]"
+	description "Super Smash Bros. (U) [f1]"
+	rom ( name "Super Smash Bros. (U) [f1].z64" crc E789A66D )
+)
+
+game (
+	name "Super Smash Bros. (U) [f2] (PAL)"
+	description "Super Smash Bros. (U) [f2] (PAL)"
+	rom ( name "Super Smash Bros. (U) [f2] (PAL).z64" crc E91BE8FA )
+)
+
+game (
+	name "Super Smash Bros. (U) [f3]"
+	description "Super Smash Bros. (U) [f3]"
+	rom ( name "Super Smash Bros. (U) [f3].z64" crc 34017708 )
+)
+
+game (
+	name "Super Smash Bros. (U) [f4] (GameShark)"
+	description "Super Smash Bros. (U) [f4] (GameShark)"
+	rom ( name "Super Smash Bros. (U) [f4] (GameShark).z64" crc 0B382B42 )
+)
+
+game (
+	name "Super Smash Bros. (U) [hI]"
+	description "Super Smash Bros. (U) [hI]"
+	rom ( name "Super Smash Bros. (U) [hI].z64" crc 381F43FB )
+)
+
+game (
+	name "Supercross 2000 (E) (M3) [!]"
+	description "Supercross 2000 (E) (M3) [!]"
+	rom ( name "Supercross 2000 (E) (M3) [!].z64" crc CB5482EC )
+)
+
+game (
+	name "Supercross 2000 (U) [!]"
+	description "Supercross 2000 (U) [!]"
+	rom ( name "Supercross 2000 (U) [!].z64" crc 094E2A48 )
+)
+
+game (
+	name "Supercross 2000 (U) [b1]"
+	description "Supercross 2000 (U) [b1]"
+	rom ( name "Supercross 2000 (U) [b1].z64" crc BE3BC325 )
+)
+
+game (
+	name "Supercross 2000 (U) [f1] (PAL)"
+	description "Supercross 2000 (U) [f1] (PAL)"
+	rom ( name "Supercross 2000 (U) [f1] (PAL).z64" crc 103EA361 )
+)
+
+game (
+	name "Superman (E) (M6) [!]"
+	description "Superman (E) (M6) [!]"
+	rom ( name "Superman (E) (M6) [!].z64" crc BCA4FF8C )
+)
+
+game (
+	name "Superman (U) (M3) [!]"
+	description "Superman (U) (M3) [!]"
+	rom ( name "Superman (U) (M3) [!].z64" crc 437E3677 )
+)
+
+game (
+	name "Superman (U) (M3) [b1]"
+	description "Superman (U) (M3) [b1]"
+	rom ( name "Superman (U) (M3) [b1].z64" crc C90865B7 )
+)
+
+game (
+	name "Superman (U) (M3) [b2]"
+	description "Superman (U) (M3) [b2]"
+	rom ( name "Superman (U) (M3) [b2].z64" crc 96787121 )
+)
+
+game (
+	name "Superman (U) (M3) [f1] (PAL)"
+	description "Superman (U) (M3) [f1] (PAL)"
+	rom ( name "Superman (U) (M3) [f1] (PAL).z64" crc 935CA58D )
+)
+
+game (
+	name "Superman (U) (M3) [f2] (PAL)"
+	description "Superman (U) (M3) [f2] (PAL)"
+	rom ( name "Superman (U) (M3) [f2] (PAL).z64" crc 806B05F3 )
+)
+
+game (
+	name "Superman (U) (M3) [T+Ita100_Cattivik66]"
+	description "Superman (U) (M3) [T+Ita100_Cattivik66]"
+	rom ( name "Superman (U) (M3) [T+Ita100_Cattivik66].z64" crc 3506DB6F )
+)
+
+game (
+	name "Superman (U) (M3) [t1]"
+	description "Superman (U) (M3) [t1]"
+	rom ( name "Superman (U) (M3) [t1].z64" crc A6E40855 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!].z64" crc 4CD21372 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1].z64" crc 6B805829 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b2]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b2]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b2].z64" crc 9EA0EE5C )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b3]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b3]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b3].z64" crc 52CD30E0 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h1C]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h1C]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h1C].z64" crc 2C02621F )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h2C]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h2C]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h2C].z64" crc 06BD781B )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o1]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o1]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o1].z64" crc C2A1CFF5 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2].z64" crc 5A7F4C1E )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2][b1]"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2][b1]"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2][b1].z64" crc E30023E8 )
+)
+
+game (
+	name "Taz Express (E) (M6) [!]"
+	description "Taz Express (E) (M6) [!]"
+	rom ( name "Taz Express (E) (M6) [!].z64" crc 0712C306 )
+)
+
+game (
+	name "Taz Express (E) (M6) [f1] (NTSC)"
+	description "Taz Express (E) (M6) [f1] (NTSC)"
+	rom ( name "Taz Express (E) (M6) [f1] (NTSC).z64" crc 860EADE0 )
+)
+
+game (
+	name "Taz Express (E) (M6) [f2] (NTSC)"
+	description "Taz Express (E) (M6) [f2] (NTSC)"
+	rom ( name "Taz Express (E) (M6) [f2] (NTSC).z64" crc 6DF9355E )
+)
+
+game (
+	name "Tetrisphere (E) [!]"
+	description "Tetrisphere (E) [!]"
+	rom ( name "Tetrisphere (E) [!].z64" crc 7CB31B0F )
+)
+
+game (
+	name "Tetrisphere (E) [b1]"
+	description "Tetrisphere (E) [b1]"
+	rom ( name "Tetrisphere (E) [b1].z64" crc 22628530 )
+)
+
+game (
+	name "Tetrisphere (E) [b2]"
+	description "Tetrisphere (E) [b2]"
+	rom ( name "Tetrisphere (E) [b2].z64" crc 7B6DEA75 )
+)
+
+game (
+	name "Tetrisphere (U) [!]"
+	description "Tetrisphere (U) [!]"
+	rom ( name "Tetrisphere (U) [!].z64" crc 70A3A5CE )
+)
+
+game (
+	name "Tetrisphere (U) [b1]"
+	description "Tetrisphere (U) [b1]"
+	rom ( name "Tetrisphere (U) [b1].z64" crc BAE26B43 )
+)
+
+game (
+	name "Tetrisphere (U) [t1]"
+	description "Tetrisphere (U) [t1]"
+	rom ( name "Tetrisphere (U) [t1].z64" crc 1A23E825 )
+)
+
+game (
+	name "Tigger's Honey Hunt (E) (M7) [!]"
+	description "Tigger's Honey Hunt (E) (M7) [!]"
+	rom ( name "Tigger's Honey Hunt (E) (M7) [!].z64" crc D82D5736 )
+)
+
+game (
+	name "Tigger's Honey Hunt (U) [!]"
+	description "Tigger's Honey Hunt (U) [!]"
+	rom ( name "Tigger's Honey Hunt (U) [!].z64" crc 68C2AC8F )
+)
+
+game (
+	name "Tigger's Honey Hunt (U) [t1]"
+	description "Tigger's Honey Hunt (U) [t1]"
+	rom ( name "Tigger's Honey Hunt (U) [t1].z64" crc E9DD1176 )
+)
+
+game (
+	name "Tom and Jerry in Fists of Furry (E) (M6) [!]"
+	description "Tom and Jerry in Fists of Furry (E) (M6) [!]"
+	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [!].z64" crc 9EA8A3B8 )
+)
+
+game (
+	name "Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC)"
+	description "Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC)"
+	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC).z64" crc C0A9CC13 )
+)
+
+game (
+	name "Tom and Jerry in Fists of Furry (U) [!]"
+	description "Tom and Jerry in Fists of Furry (U) [!]"
+	rom ( name "Tom and Jerry in Fists of Furry (U) [!].z64" crc 6D685B83 )
+)
+
+game (
+	name "Tom and Jerry in Fists of Furry (U) [t1]"
+	description "Tom and Jerry in Fists of Furry (U) [t1]"
+	rom ( name "Tom and Jerry in Fists of Furry (U) [t1].z64" crc CD44FC8D )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (E) [!]"
+	description "Tom Clancy's Rainbow Six (E) [!]"
+	rom ( name "Tom Clancy's Rainbow Six (E) [!].z64" crc 4B71E083 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (E) [b1]"
+	description "Tom Clancy's Rainbow Six (E) [b1]"
+	rom ( name "Tom Clancy's Rainbow Six (E) [b1].z64" crc 4B61B50F )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (E) [h1C]"
+	description "Tom Clancy's Rainbow Six (E) [h1C]"
+	rom ( name "Tom Clancy's Rainbow Six (E) [h1C].z64" crc C1417FAF )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (E) [o1]"
+	description "Tom Clancy's Rainbow Six (E) [o1]"
+	rom ( name "Tom Clancy's Rainbow Six (E) [o1].z64" crc 7EDBE625 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (F) [!]"
+	description "Tom Clancy's Rainbow Six (F) [!]"
+	rom ( name "Tom Clancy's Rainbow Six (F) [!].z64" crc BBF7B6A8 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (G) [!]"
+	description "Tom Clancy's Rainbow Six (G) [!]"
+	rom ( name "Tom Clancy's Rainbow Six (G) [!].z64" crc 5D73E788 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (U) [!]"
+	description "Tom Clancy's Rainbow Six (U) [!]"
+	rom ( name "Tom Clancy's Rainbow Six (U) [!].z64" crc 53B0CC13 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (U) [f1] (PAL)"
+	description "Tom Clancy's Rainbow Six (U) [f1] (PAL)"
+	rom ( name "Tom Clancy's Rainbow Six (U) [f1] (PAL).z64" crc 09745879 )
+)
+
+game (
+	name "Tonic Trouble (E) (M5) [!]"
+	description "Tonic Trouble (E) (M5) [!]"
+	rom ( name "Tonic Trouble (E) (M5) [!].z64" crc B4322403 )
+)
+
+game (
+	name "Tonic Trouble (U) (V1.1) [!]"
+	description "Tonic Trouble (U) (V1.1) [!]"
+	rom ( name "Tonic Trouble (U) (V1.1) [!].z64" crc 1C04BA12 )
+)
+
+game (
+	name "Tonic Trouble (U) (V1.1) [b1]"
+	description "Tonic Trouble (U) (V1.1) [b1]"
+	rom ( name "Tonic Trouble (U) (V1.1) [b1].z64" crc F13448D0 )
+)
+
+game (
+	name "Tonic Trouble (U) (V1.1) [f1] (PAL)"
+	description "Tonic Trouble (U) (V1.1) [f1] (PAL)"
+	rom ( name "Tonic Trouble (U) (V1.1) [f1] (PAL).z64" crc A297E4FF )
+)
+
+game (
+	name "Tonic Trouble (U) (V1.1) [t1]"
+	description "Tonic Trouble (U) (V1.1) [t1]"
+	rom ( name "Tonic Trouble (U) (V1.1) [t1].z64" crc 3866227F )
+)
+
+game (
+	name "Tony Hawk's Pro Skater (E) [!]"
+	description "Tony Hawk's Pro Skater (E) [!]"
+	rom ( name "Tony Hawk's Pro Skater (E) [!].z64" crc 39E4F766 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater (U) (V1.0) [!]"
+	description "Tony Hawk's Pro Skater (U) (V1.0) [!]"
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [!].z64" crc F5C1B64F )
+)
+
+game (
+	name "Tony Hawk's Pro Skater (U) (V1.0) [t1]"
+	description "Tony Hawk's Pro Skater (U) (V1.0) [t1]"
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [t1].z64" crc CCC5A733 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater (U) (V1.1) [!]"
+	description "Tony Hawk's Pro Skater (U) (V1.1) [!]"
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.1) [!].z64" crc 6182A092 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2 (E) [!]"
+	description "Tony Hawk's Pro Skater 2 (E) [!]"
+	rom ( name "Tony Hawk's Pro Skater 2 (E) [!].z64" crc A1207132 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2 (U) [!]"
+	description "Tony Hawk's Pro Skater 2 (U) [!]"
+	rom ( name "Tony Hawk's Pro Skater 2 (U) [!].z64" crc 80AA83F3 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (U)"
+	description "Tony Hawk's Pro Skater 3 (U)"
+	rom ( name "Tony Hawk's Pro Skater 3 (U).z64" crc 62A8CE7D )
+)
+
+game (
+	name "Top Gear Hyper Bike (Beta)"
+	description "Top Gear Hyper Bike (Beta)"
+	rom ( name "Top Gear Hyper Bike (Beta).z64" crc 00C0278A )
+)
+
+game (
+	name "Top Gear Hyper Bike (E) [!]"
+	description "Top Gear Hyper Bike (E) [!]"
+	rom ( name "Top Gear Hyper Bike (E) [!].z64" crc BAE57EA7 )
+)
+
+game (
+	name "Top Gear Hyper Bike (E) [b1]"
+	description "Top Gear Hyper Bike (E) [b1]"
+	rom ( name "Top Gear Hyper Bike (E) [b1].z64" crc 6183EA77 )
+)
+
+game (
+	name "Top Gear Hyper Bike (J) [!]"
+	description "Top Gear Hyper Bike (J) [!]"
+	rom ( name "Top Gear Hyper Bike (J) [!].z64" crc 09B2CDA1 )
+)
+
+game (
+	name "Top Gear Hyper Bike (U) [!]"
+	description "Top Gear Hyper Bike (U) [!]"
+	rom ( name "Top Gear Hyper Bike (U) [!].z64" crc 6EEBC26A )
+)
+
+game (
+	name "Top Gear Overdrive (E) [!]"
+	description "Top Gear Overdrive (E) [!]"
+	rom ( name "Top Gear Overdrive (E) [!].z64" crc 0CC70580 )
+)
+
+game (
+	name "Top Gear Overdrive (E) [h1C]"
+	description "Top Gear Overdrive (E) [h1C]"
+	rom ( name "Top Gear Overdrive (E) [h1C].z64" crc 9B1D439F )
+)
+
+game (
+	name "Top Gear Overdrive (J) [!]"
+	description "Top Gear Overdrive (J) [!]"
+	rom ( name "Top Gear Overdrive (J) [!].z64" crc 81AAFC2B )
+)
+
+game (
+	name "Top Gear Overdrive (J) [b1]"
+	description "Top Gear Overdrive (J) [b1]"
+	rom ( name "Top Gear Overdrive (J) [b1].z64" crc 9113D45E )
+)
+
+game (
+	name "Top Gear Overdrive (U) [!]"
+	description "Top Gear Overdrive (U) [!]"
+	rom ( name "Top Gear Overdrive (U) [!].z64" crc F3E0FF21 )
+)
+
+game (
+	name "Top Gear Overdrive (U) [o1]"
+	description "Top Gear Overdrive (U) [o1]"
+	rom ( name "Top Gear Overdrive (U) [o1].z64" crc 0BB0DB0E )
+)
+
+game (
+	name "Top Gear Overdrive (U) [t1]"
+	description "Top Gear Overdrive (U) [t1]"
+	rom ( name "Top Gear Overdrive (U) [t1].z64" crc 6CE5DD98 )
+)
+
+game (
+	name "Top Gear Rally (E) [!]"
+	description "Top Gear Rally (E) [!]"
+	rom ( name "Top Gear Rally (E) [!].z64" crc 40B3BB21 )
+)
+
+game (
+	name "Top Gear Rally (E) [b1]"
+	description "Top Gear Rally (E) [b1]"
+	rom ( name "Top Gear Rally (E) [b1].z64" crc 14238E76 )
+)
+
+game (
+	name "Top Gear Rally (E) [h1C]"
+	description "Top Gear Rally (E) [h1C]"
+	rom ( name "Top Gear Rally (E) [h1C].z64" crc 9C83FB6A )
+)
+
+game (
+	name "Top Gear Rally (J) [!]"
+	description "Top Gear Rally (J) [!]"
+	rom ( name "Top Gear Rally (J) [!].z64" crc C6707CD6 )
+)
+
+game (
+	name "Top Gear Rally (U) [!]"
+	description "Top Gear Rally (U) [!]"
+	rom ( name "Top Gear Rally (U) [!].z64" crc 137287F5 )
+)
+
+game (
+	name "Top Gear Rally (U) [b1]"
+	description "Top Gear Rally (U) [b1]"
+	rom ( name "Top Gear Rally (U) [b1].z64" crc 36809F7D )
+)
+
+game (
+	name "Top Gear Rally (U) [b2]"
+	description "Top Gear Rally (U) [b2]"
+	rom ( name "Top Gear Rally (U) [b2].z64" crc CF42C7BE )
+)
+
+game (
+	name "Top Gear Rally (U) [b3]"
+	description "Top Gear Rally (U) [b3]"
+	rom ( name "Top Gear Rally (U) [b3].z64" crc 7354E999 )
+)
+
+game (
+	name "Top Gear Rally (U) [o1]"
+	description "Top Gear Rally (U) [o1]"
+	rom ( name "Top Gear Rally (U) [o1].z64" crc 53A95ACB )
+)
+
+game (
+	name "TG Rally 2 (E) [!]"
+	description "TG Rally 2 (E) [!]"
+	rom ( name "TG Rally 2 (E) [!].z64" crc 135C8EB0 )
+)
+
+game (
+	name "Top Gear Rally 2 (Beta)"
+	description "Top Gear Rally 2 (Beta)"
+	rom ( name "Top Gear Rally 2 (Beta).z64" crc 3C77C5D6 )
+)
+
+game (
+	name "Top Gear Rally 2 (E) [!]"
+	description "Top Gear Rally 2 (E) [!]"
+	rom ( name "Top Gear Rally 2 (E) [!].z64" crc CB294D39 )
+)
+
+game (
+	name "Top Gear Rally 2 (J) [!]"
+	description "Top Gear Rally 2 (J) [!]"
+	rom ( name "Top Gear Rally 2 (J) [!].z64" crc AA136E07 )
+)
+
+game (
+	name "Top Gear Rally 2 (U) [!]"
+	description "Top Gear Rally 2 (U) [!]"
+	rom ( name "Top Gear Rally 2 (U) [!].z64" crc 914CF9C4 )
+)
+
+game (
+	name "Top Gear Rally 2 (U) [f1] (PAL)"
+	description "Top Gear Rally 2 (U) [f1] (PAL)"
+	rom ( name "Top Gear Rally 2 (U) [f1] (PAL).z64" crc 9FE61044 )
+)
+
+game (
+	name "Toy Story 2 (E) [!]"
+	description "Toy Story 2 (E) [!]"
+	rom ( name "Toy Story 2 (E) [!].z64" crc 59574CB9 )
+)
+
+game (
+	name "Toy Story 2 (F) [!]"
+	description "Toy Story 2 (F) [!]"
+	rom ( name "Toy Story 2 (F) [!].z64" crc FB4BEA9A )
+)
+
+game (
+	name "Toy Story 2 (G) [!]"
+	description "Toy Story 2 (G) [!]"
+	rom ( name "Toy Story 2 (G) [!].z64" crc C5E4C89F )
+)
+
+game (
+	name "Toy Story 2 (U) [!]"
+	description "Toy Story 2 (U) [!]"
+	rom ( name "Toy Story 2 (U) [!].z64" crc B9570841 )
+)
+
+game (
+	name "Toy Story 2 (U) [f1] (PAL)"
+	description "Toy Story 2 (U) [f1] (PAL)"
+	rom ( name "Toy Story 2 (U) [f1] (PAL).z64" crc CA080E9F )
+)
+
+game (
+	name "Toy Story 2 (U) [t1]"
+	description "Toy Story 2 (U) [t1]"
+	rom ( name "Toy Story 2 (U) [t1].z64" crc 170C01D5 )
+)
+
+game (
+	name "Transformers - Beast Wars Metals 64 (J) [!]"
+	description "Transformers - Beast Wars Metals 64 (J) [!]"
+	rom ( name "Transformers - Beast Wars Metals 64 (J) [!].z64" crc 338F1D45 )
+)
+
+game (
+	name "Transformers - Beast Wars Transmetal (U) [!]"
+	description "Transformers - Beast Wars Transmetal (U) [!]"
+	rom ( name "Transformers - Beast Wars Transmetal (U) [!].z64" crc 85138B5A )
+)
+
+game (
+	name "Triple Play 2000 (U) [!]"
+	description "Triple Play 2000 (U) [!]"
+	rom ( name "Triple Play 2000 (U) [!].z64" crc 785DD0F8 )
+)
+
+game (
+	name "Tsumi to Batsu - Hoshi no Keishousha (J) [!]"
+	description "Tsumi to Batsu - Hoshi no Keishousha (J) [!]"
+	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (J) [!].z64" crc CA2E5E49 )
+)
+
+game (
+	name "Tokisora Senshi Turok (J) [!]"
+	description "Tokisora Senshi Turok (J) [!]"
+	rom ( name "Tokisora Senshi Turok (J) [!].z64" crc E6BD65D5 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (E) (V1.0) [!]"
+	description "Turok - Dinosaur Hunter (E) (V1.0) [!]"
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [!].z64" crc E8525687 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (E) (V1.0) [b1]"
+	description "Turok - Dinosaur Hunter (E) (V1.0) [b1]"
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [b1].z64" crc D7236669 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (E) (V1.0) [h1C]"
+	description "Turok - Dinosaur Hunter (E) (V1.0) [h1C]"
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [h1C].z64" crc 1C5432A2 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (E) (V1.1) [!]"
+	description "Turok - Dinosaur Hunter (E) (V1.1) [!]"
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.1) [!].z64" crc C2353283 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (E) (V1.2) [!]"
+	description "Turok - Dinosaur Hunter (E) (V1.2) [!]"
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.2) [!].z64" crc 312AF877 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (G) [!]"
+	description "Turok - Dinosaur Hunter (G) [!]"
+	rom ( name "Turok - Dinosaur Hunter (G) [!].z64" crc 64631FF9 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [!]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [!]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [!].z64" crc 26C4F597 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [b1]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [b1]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [b1].z64" crc FA434F4B )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [h1C]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [h1C]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [h1C].z64" crc D2C291B2 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [o1]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [o1]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [o1].z64" crc 71DF1460 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [t1]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [t1]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t1].z64" crc 09D4B965 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.0) [t2]"
+	description "Turok - Dinosaur Hunter (U) (V1.0) [t2]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t2].z64" crc CEEC672D )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.1) [!]"
+	description "Turok - Dinosaur Hunter (U) (V1.1) [!]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.1) [!].z64" crc 7F2476F4 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter (U) (V1.2) [!]"
+	description "Turok - Dinosaur Hunter (U) (V1.2) [!]"
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.2) [!].z64" crc 8C3BBC00 )
+)
+
+game (
+	name "Turok - Legenden des Verlorenen Landes (G) [!]"
+	description "Turok - Legenden des Verlorenen Landes (G) [!]"
+	rom ( name "Turok - Legenden des Verlorenen Landes (G) [!].z64" crc B937874F )
+)
+
+game (
+	name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita)"
+	description "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita)"
+	rom ( name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita).z64" crc F4A2862B )
+)
+
+game (
+	name "Turok - Rage Wars (E) [!]"
+	description "Turok - Rage Wars (E) [!]"
+	rom ( name "Turok - Rage Wars (E) [!].z64" crc 82B1E116 )
+)
+
+game (
+	name "Turok - Rage Wars (U) [!]"
+	description "Turok - Rage Wars (U) [!]"
+	rom ( name "Turok - Rage Wars (U) [!].z64" crc 422872A2 )
+)
+
+game (
+	name "Turok - Rage Wars (U) [f1] (PAL)"
+	description "Turok - Rage Wars (U) [f1] (PAL)"
+	rom ( name "Turok - Rage Wars (U) [f1] (PAL).z64" crc 43CC10F3 )
+)
+
+game (
+	name "Turok - Rage Wars (U) [f2] (PAL)"
+	description "Turok - Rage Wars (U) [f2] (PAL)"
+	rom ( name "Turok - Rage Wars (U) [f2] (PAL).z64" crc 5B21D17D )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!]"
+	description "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!].z64" crc 4E29B234 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (E) (M4) [!]"
+	description "Turok 2 - Seeds of Evil (E) (M4) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (E) (M4) [!].z64" crc 1FEBDE32 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (E) [!]"
+	description "Turok 2 - Seeds of Evil (E) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (E) [!].z64" crc E2D34BFE )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (E) [b1]"
+	description "Turok 2 - Seeds of Evil (E) [b1]"
+	rom ( name "Turok 2 - Seeds of Evil (E) [b1].z64" crc BDAB5526 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (G) [!]"
+	description "Turok 2 - Seeds of Evil (G) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (G) [!].z64" crc C07877B6 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack)"
+	description "Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack)"
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack).z64" crc 4B1C2A9D )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!]"
+	description "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!].z64" crc 8D5B9BD0 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [h1C]"
+	description "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [h1C]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [h1C].z64" crc 2E733502 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (V1.0) [!]"
+	description "Turok 2 - Seeds of Evil (U) (V1.0) [!]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [!].z64" crc FF5E7636 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (V1.0) [t1]"
+	description "Turok 2 - Seeds of Evil (U) (V1.0) [t1]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t1].z64" crc 020945C6 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (V1.0) [t2]"
+	description "Turok 2 - Seeds of Evil (U) (V1.0) [t2]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t2].z64" crc 006395AB )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (V1.0) [t3]"
+	description "Turok 2 - Seeds of Evil (U) (V1.0) [t3]"
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t3].z64" crc E563D747 )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil (U) (V1.1)"
+	description "Turok 2 - Seeds of Evil (U) (V1.1)"
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.1).z64" crc 57F1FBF5 )
+)
+
+game (
+	name "Violence Killer - Turok New Generation (J) [!]"
+	description "Violence Killer - Turok New Generation (J) [!]"
+	rom ( name "Violence Killer - Turok New Generation (J) [!].z64" crc 097F139F )
+)
+
+game (
+	name "Violence Killer - Turok New Generation (J) [b1]"
+	description "Violence Killer - Turok New Generation (J) [b1]"
+	rom ( name "Violence Killer - Turok New Generation (J) [b1].z64" crc 0A474DDB )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (E) [!]"
+	description "Turok 3 - Shadow of Oblivion (E) [!]"
+	rom ( name "Turok 3 - Shadow of Oblivion (E) [!].z64" crc 98D3114C )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (U) (Beta) [h1C]"
+	description "Turok 3 - Shadow of Oblivion (U) (Beta) [h1C]"
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta) [h1C].z64" crc 7946B05A )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (U) (Beta)"
+	description "Turok 3 - Shadow of Oblivion (U) (Beta)"
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta).z64" crc 97B7C3FF )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (U) (Beta-WIP)"
+	description "Turok 3 - Shadow of Oblivion (U) (Beta-WIP)"
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta-WIP).z64" crc 3CD1F9AF )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (U) [!]"
+	description "Turok 3 - Shadow of Oblivion (U) [!]"
+	rom ( name "Turok 3 - Shadow of Oblivion (U) [!].z64" crc CB297224 )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion (U) [t1]"
+	description "Turok 3 - Shadow of Oblivion (U) [t1]"
+	rom ( name "Turok 3 - Shadow of Oblivion (U) [t1].z64" crc 411D8468 )
+)
+
+game (
+	name "King Hill 64 - Extreme Snowboarding (J) [!]"
+	description "King Hill 64 - Extreme Snowboarding (J) [!]"
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [!].z64" crc F120CC52 )
+)
+
+game (
+	name "King Hill 64 - Extreme Snowboarding (J) [b1]"
+	description "King Hill 64 - Extreme Snowboarding (J) [b1]"
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b1].z64" crc 2E846375 )
+)
+
+game (
+	name "King Hill 64 - Extreme Snowboarding (J) [b2]"
+	description "King Hill 64 - Extreme Snowboarding (J) [b2]"
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b2].z64" crc E31698A4 )
+)
+
+game (
+	name "Twisted Edge Extreme Snowboarding (E) [!]"
+	description "Twisted Edge Extreme Snowboarding (E) [!]"
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" crc BF0C1291 )
+)
+
+game (
+	name "Twisted Edge Extreme Snowboarding (E) [b1]"
+	description "Twisted Edge Extreme Snowboarding (E) [b1]"
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [b1].z64" crc 1F26259E )
+)
+
+game (
+	name "Twisted Edge Extreme Snowboarding (E) [h1C]"
+	description "Twisted Edge Extreme Snowboarding (E) [h1C]"
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [h1C].z64" crc 4F64CD21 )
+)
+
+game (
+	name "Twisted Edge Extreme Snowboarding (U) [!]"
+	description "Twisted Edge Extreme Snowboarding (U) [!]"
+	rom ( name "Twisted Edge Extreme Snowboarding (U) [!].z64" crc BFBCC038 )
+)
+
+game (
+	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!]"
+	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!]"
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!].z64" crc 50CBE8A6 )
+)
+
+game (
+	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h1C]"
+	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h1C]"
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h1C].z64" crc B6F8ADC2 )
+)
+
+game (
+	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h2C]"
+	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h2C]"
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h2C].z64" crc 31F32B8D )
+)
+
+game (
+	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [o1]"
+	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [o1]"
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [o1].z64" crc 5D92C2DF )
+)
+
+game (
+	name "V-Rally Edition 99 (E) (M3) [!]"
+	description "V-Rally Edition 99 (E) (M3) [!]"
+	rom ( name "V-Rally Edition 99 (E) (M3) [!].z64" crc 0735D7A2 )
+)
+
+game (
+	name "V-Rally Edition 99 (E) (M3) [f1] (NTSC)"
+	description "V-Rally Edition 99 (E) (M3) [f1] (NTSC)"
+	rom ( name "V-Rally Edition 99 (E) (M3) [f1] (NTSC).z64" crc 02A8267B )
+)
+
+game (
+	name "V-Rally Edition 99 (J) [!]"
+	description "V-Rally Edition 99 (J) [!]"
+	rom ( name "V-Rally Edition 99 (J) [!].z64" crc 02475A01 )
+)
+
+game (
+	name "V-Rally Edition 99 (U) [!]"
+	description "V-Rally Edition 99 (U) [!]"
+	rom ( name "V-Rally Edition 99 (U) [!].z64" crc 4803075E )
+)
+
+game (
+	name "V-Rally Edition 99 (U) [f1] (PAL)"
+	description "V-Rally Edition 99 (U) [f1] (PAL)"
+	rom ( name "V-Rally Edition 99 (U) [f1] (PAL).z64" crc 2C399B1C )
+)
+
+game (
+	name "Vigilante 8 (E) [!]"
+	description "Vigilante 8 (E) [!]"
+	rom ( name "Vigilante 8 (E) [!].z64" crc 0E9BB6D6 )
+)
+
+game (
+	name "Vigilante 8 (E) [h1C]"
+	description "Vigilante 8 (E) [h1C]"
+	rom ( name "Vigilante 8 (E) [h1C].z64" crc 888D935E )
+)
+
+game (
+	name "Vigilante 8 (F) [!]"
+	description "Vigilante 8 (F) [!]"
+	rom ( name "Vigilante 8 (F) [!].z64" crc 11D23AB3 )
+)
+
+game (
+	name "Vigilante 8 (F) [b1]"
+	description "Vigilante 8 (F) [b1]"
+	rom ( name "Vigilante 8 (F) [b1].z64" crc D36573E5 )
+)
+
+game (
+	name "Vigilante 8 (G) [!]"
+	description "Vigilante 8 (G) [!]"
+	rom ( name "Vigilante 8 (G) [!].z64" crc 17F63C3F )
+)
+
+game (
+	name "Vigilante 8 (U) [!]"
+	description "Vigilante 8 (U) [!]"
+	rom ( name "Vigilante 8 (U) [!].z64" crc 330B73E6 )
+)
+
+game (
+	name "Vigilante 8 (U) [b1]"
+	description "Vigilante 8 (U) [b1]"
+	rom ( name "Vigilante 8 (U) [b1].z64" crc 56695C4B )
+)
+
+game (
+	name "Vigilante 8 (U) [b2]"
+	description "Vigilante 8 (U) [b2]"
+	rom ( name "Vigilante 8 (U) [b2].z64" crc 47854808 )
+)
+
+game (
+	name "Vigilante 8 (U) [f1] (PAL)"
+	description "Vigilante 8 (U) [f1] (PAL)"
+	rom ( name "Vigilante 8 (U) [f1] (PAL).z64" crc F5DA5754 )
+)
+
+game (
+	name "Vigilante 8 (U) [f2] (PAL)"
+	description "Vigilante 8 (U) [f2] (PAL)"
+	rom ( name "Vigilante 8 (U) [f2] (PAL).z64" crc 654352B9 )
+)
+
+game (
+	name "Vigilante 8 (U) [t1]"
+	description "Vigilante 8 (U) [t1]"
+	rom ( name "Vigilante 8 (U) [t1].z64" crc 5D56E5AE )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offence (E) [!]"
+	description "Vigilante 8 - 2nd Offence (E) [!]"
+	rom ( name "Vigilante 8 - 2nd Offence (E) [!].z64" crc 691AA971 )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offense (U) [!]"
+	description "Vigilante 8 - 2nd Offense (U) [!]"
+	rom ( name "Vigilante 8 - 2nd Offense (U) [!].z64" crc 0293203F )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offense (U) [f1] (PAL)"
+	description "Vigilante 8 - 2nd Offense (U) [f1] (PAL)"
+	rom ( name "Vigilante 8 - 2nd Offense (U) [f1] (PAL).z64" crc A06F594E )
+)
+
+game (
+	name "Virtual Chess 64 (E) (M6) [!]"
+	description "Virtual Chess 64 (E) (M6) [!]"
+	rom ( name "Virtual Chess 64 (E) (M6) [!].z64" crc AAE15243 )
+)
+
+game (
+	name "Virtual Chess 64 (E) (M6) [b1]"
+	description "Virtual Chess 64 (E) (M6) [b1]"
+	rom ( name "Virtual Chess 64 (E) (M6) [b1].z64" crc FC843DB9 )
+)
+
+game (
+	name "Virtual Chess 64 (E) (M6) [b2]"
+	description "Virtual Chess 64 (E) (M6) [b2]"
+	rom ( name "Virtual Chess 64 (E) (M6) [b2].z64" crc 9D037B23 )
+)
+
+game (
+	name "Virtual Chess 64 (E) (M6) [o1]"
+	description "Virtual Chess 64 (E) (M6) [o1]"
+	rom ( name "Virtual Chess 64 (E) (M6) [o1].z64" crc 79167DCE )
+)
+
+game (
+	name "Virtual Chess 64 (E) (M6) [o1][h1C]"
+	description "Virtual Chess 64 (E) (M6) [o1][h1C]"
+	rom ( name "Virtual Chess 64 (E) (M6) [o1][h1C].z64" crc AB0EF811 )
+)
+
+game (
+	name "Virtual Chess 64 (U) (M3) [!]"
+	description "Virtual Chess 64 (U) (M3) [!]"
+	rom ( name "Virtual Chess 64 (U) (M3) [!].z64" crc 620DE0B7 )
+)
+
+game (
+	name "Virtual Chess 64 (U) (M3) [b1]"
+	description "Virtual Chess 64 (U) (M3) [b1]"
+	rom ( name "Virtual Chess 64 (U) (M3) [b1].z64" crc 722C9FEB )
+)
+
+game (
+	name "Virtual Chess 64 (U) (M3) [b1][o1]"
+	description "Virtual Chess 64 (U) (M3) [b1][o1]"
+	rom ( name "Virtual Chess 64 (U) (M3) [b1][o1].z64" crc 93774CAB )
+)
+
+game (
+	name "Virtual Chess 64 (U) (M3) [f1] (PAL)"
+	description "Virtual Chess 64 (U) (M3) [f1] (PAL)"
+	rom ( name "Virtual Chess 64 (U) (M3) [f1] (PAL).z64" crc 63A9E373 )
+)
+
+game (
+	name "Virtual Chess 64 (U) (M3) [f1][o1]"
+	description "Virtual Chess 64 (U) (M3) [f1][o1]"
+	rom ( name "Virtual Chess 64 (U) (M3) [f1][o1].z64" crc 7FA359F4 )
+)
+
+game (
+	name "Virtual Chess 64 (U) [o1]"
+	description "Virtual Chess 64 (U) [o1]"
+	rom ( name "Virtual Chess 64 (U) [o1].z64" crc AC2D5385 )
+)
+
+game (
+	name "Virtual Pool 64 (E) [!]"
+	description "Virtual Pool 64 (E) [!]"
+	rom ( name "Virtual Pool 64 (E) [!].z64" crc 9A6FB0BC )
+)
+
+game (
+	name "Virtual Pool 64 (E) [o1]"
+	description "Virtual Pool 64 (E) [o1]"
+	rom ( name "Virtual Pool 64 (E) [o1].z64" crc FAD2F55F )
+)
+
+game (
+	name "Virtual Pool 64 (U) [!]"
+	description "Virtual Pool 64 (U) [!]"
+	rom ( name "Virtual Pool 64 (U) [!].z64" crc AD628DED )
+)
+
+game (
+	name "Virtual Pool 64 (U) [o1]"
+	description "Virtual Pool 64 (U) [o1]"
+	rom ( name "Virtual Pool 64 (U) [o1].z64" crc 43B5083A )
+)
+
+game (
+	name "Virtual Pro Wrestling 64 (J) [!]"
+	description "Virtual Pro Wrestling 64 (J) [!]"
+	rom ( name "Virtual Pro Wrestling 64 (J) [!].z64" crc E6651803 )
+)
+
+game (
+	name "Virtual Pro Wrestling 64 (J) [b1]"
+	description "Virtual Pro Wrestling 64 (J) [b1]"
+	rom ( name "Virtual Pro Wrestling 64 (J) [b1].z64" crc 26366A4A )
+)
+
+game (
+	name "Virtual Pro Wrestling 64 (J) [f1]"
+	description "Virtual Pro Wrestling 64 (J) [f1]"
+	rom ( name "Virtual Pro Wrestling 64 (J) [f1].z64" crc 9328A297 )
+)
+
+game (
+	name "Virtual Pro Wrestling 64 (J) [f2]"
+	description "Virtual Pro Wrestling 64 (J) [f2]"
+	rom ( name "Virtual Pro Wrestling 64 (J) [f2].z64" crc F0958025 )
+)
+
+game (
+	name "Virtual Pro Wrestling 64 (J) [h1C]"
+	description "Virtual Pro Wrestling 64 (J) [h1C]"
+	rom ( name "Virtual Pro Wrestling 64 (J) [h1C].z64" crc 0093FF39 )
+)
+
+game (
+	name "Harukanaru Augusta Masters 98 (J) [!]"
+	description "Harukanaru Augusta Masters 98 (J) [!]"
+	rom ( name "Harukanaru Augusta Masters 98 (J) [!].z64" crc 51228F0C )
+)
+
+game (
+	name "Harukanaru Augusta Masters 98 (J) [b1]"
+	description "Harukanaru Augusta Masters 98 (J) [b1]"
+	rom ( name "Harukanaru Augusta Masters 98 (J) [b1].z64" crc 6D82E5A2 )
+)
+
+game (
+	name "Harukanaru Augusta Masters 98 (J) [b2]"
+	description "Harukanaru Augusta Masters 98 (J) [b2]"
+	rom ( name "Harukanaru Augusta Masters 98 (J) [b2].z64" crc 720F6D47 )
+)
+
+game (
+	name "Harukanaru Augusta Masters 98 (J) [h1C]"
+	description "Harukanaru Augusta Masters 98 (J) [h1C]"
+	rom ( name "Harukanaru Augusta Masters 98 (J) [h1C].z64" crc 5CB9B985 )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!]"
+	description "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!]"
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!].z64" crc 6858759A )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1]"
+	description "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1]"
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1].z64" crc A46A7B14 )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!]"
+	description "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!]"
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!].z64" crc 6CB097B3 )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics (U) (V1.0) [!]"
+	description "Waialae Country Club - True Golf Classics (U) (V1.0) [!]"
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.0) [!].z64" crc CCAB08D7 )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics (U) (V1.1) [!]"
+	description "Waialae Country Club - True Golf Classics (U) (V1.1) [!]"
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.1) [!].z64" crc C65EE122 )
+)
+
+game (
+	name "War Gods (E) [!]"
+	description "War Gods (E) [!]"
+	rom ( name "War Gods (E) [!].z64" crc C73010C8 )
+)
+
+game (
+	name "War Gods (U) (Power Bar Hack)"
+	description "War Gods (U) (Power Bar Hack)"
+	rom ( name "War Gods (U) (Power Bar Hack).z64" crc DC773BBA )
+)
+
+game (
+	name "War Gods (U) [!]"
+	description "War Gods (U) [!]"
+	rom ( name "War Gods (U) [!].z64" crc FFACF993 )
+)
+
+game (
+	name "War Gods (U) [o1]"
+	description "War Gods (U) [o1]"
+	rom ( name "War Gods (U) [o1].z64" crc 5CFC294C )
+)
+
+game (
+	name "War Gods (U) [o1][h1C]"
+	description "War Gods (U) [o1][h1C]"
+	rom ( name "War Gods (U) [o1][h1C].z64" crc F4DABA35 )
+)
+
+game (
+	name "War Gods (U) [o2]"
+	description "War Gods (U) [o2]"
+	rom ( name "War Gods (U) [o2].z64" crc 689B570B )
+)
+
+game (
+	name "War Gods (U) [o3]"
+	description "War Gods (U) [o3]"
+	rom ( name "War Gods (U) [o3].z64" crc CC10D8A9 )
+)
+
+game (
+	name "War Gods (U) [t1] (God Mode)"
+	description "War Gods (U) [t1] (God Mode)"
+	rom ( name "War Gods (U) [t1] (God Mode).z64" crc 93D4C6FD )
+)
+
+game (
+	name "Wave Race 64 (E) (M2) [!]"
+	description "Wave Race 64 (E) (M2) [!]"
+	rom ( name "Wave Race 64 (E) (M2) [!].z64" crc FB289893 )
+)
+
+game (
+	name "Wave Race 64 (E) (M2) [h1C]"
+	description "Wave Race 64 (E) (M2) [h1C]"
+	rom ( name "Wave Race 64 (E) (M2) [h1C].z64" crc 1E78FA64 )
+)
+
+game (
+	name "Wave Race 64 (E) (M2) [o1]"
+	description "Wave Race 64 (E) (M2) [o1]"
+	rom ( name "Wave Race 64 (E) (M2) [o1].z64" crc D559933C )
+)
+
+game (
+	name "Wave Race 64 (J) [!]"
+	description "Wave Race 64 (J) [!]"
+	rom ( name "Wave Race 64 (J) [!].z64" crc 6C93FF83 )
+)
+
+game (
+	name "Wave Race 64 (U) (V1.0) [!]"
+	description "Wave Race 64 (U) (V1.0) [!]"
+	rom ( name "Wave Race 64 (U) (V1.0) [!].z64" crc 74A7B725 )
+)
+
+game (
+	name "Wave Race 64 (U) (V1.0) [t1]"
+	description "Wave Race 64 (U) (V1.0) [t1]"
+	rom ( name "Wave Race 64 (U) (V1.0) [t1].z64" crc 60717F86 )
+)
+
+game (
+	name "Wave Race 64 (U) (V1.1) [!]"
+	description "Wave Race 64 (U) (V1.1) [!]"
+	rom ( name "Wave Race 64 (U) (V1.1) [!].z64" crc 394948C4 )
+)
+
+game (
+	name "Wave Race 64 - Shindou Edition (J) (V1.2) [!]"
+	description "Wave Race 64 - Shindou Edition (J) (V1.2) [!]"
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [!].z64" crc 90044C4B )
+)
+
+game (
+	name "Wave Race 64 - Shindou Edition (J) (V1.2) [b1]"
+	description "Wave Race 64 - Shindou Edition (J) (V1.2) [b1]"
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b1].z64" crc 33B45441 )
+)
+
+game (
+	name "Wave Race 64 - Shindou Edition (J) (V1.2) [b2]"
+	description "Wave Race 64 - Shindou Edition (J) (V1.2) [b2]"
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b2].z64" crc 66DD6AC7 )
+)
+
+game (
+	name "Wave Race 64 - Shindou Edition (J) (V1.2) [h1C]"
+	description "Wave Race 64 - Shindou Edition (J) (V1.2) [h1C]"
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [h1C].z64" crc 5DCFBA0B )
+)
+
+game (
+	name "Wave Race 64 - Shindou Edition (J) (V1.2) [o1]"
+	description "Wave Race 64 - Shindou Edition (J) (V1.2) [o1]"
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [o1].z64" crc AFA7C48B )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (E) (M4) [!]"
+	description "Wayne Gretzky's 3D Hockey (E) (M4) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [!].z64" crc 442A4F5F )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (E) (M4) [b1]"
+	description "Wayne Gretzky's 3D Hockey (E) (M4) [b1]"
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [b1].z64" crc 13343F88 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (E) (M4) [h1C]"
+	description "Wayne Gretzky's 3D Hockey (E) (M4) [h1C]"
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [h1C].z64" crc 50D4462A )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (J) [!]"
+	description "Wayne Gretzky's 3D Hockey (J) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [!].z64" crc 485275ED )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (J) [b1]"
+	description "Wayne Gretzky's 3D Hockey (J) [b1]"
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [b1].z64" crc 8535F510 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (J) [o1]"
+	description "Wayne Gretzky's 3D Hockey (J) [o1]"
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [o1].z64" crc 562F5060 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (J) [o2]"
+	description "Wayne Gretzky's 3D Hockey (J) [o2]"
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [o2].z64" crc 039D4651 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!]"
+	description "Wayne Gretzky's 3D Hockey (U) (V1.0) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!].z64" crc 9781F88D )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (U) (V1.0) [b1]"
+	description "Wayne Gretzky's 3D Hockey (U) (V1.0) [b1]"
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [b1].z64" crc 4DF6CAF7 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey (U) (V1.0) [o1]"
+	description "Wayne Gretzky's 3D Hockey (U) (V1.0) [o1]"
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [o1].z64" crc B8BD42E5 )
+)
 
 game (
-	name AeroGauge
-	description "AeroGauge"
-	rom ( name "AeroGauge (E) (M3) [!].z64" size 8388608 crc 040b0046 )
-	rom ( name "AeroGauge (E) (M3) [f1] (NTSC).z64" size 8388608 crc 521865a1 )
-	rom ( name "AeroGauge (E) (M3) [h1C].z64" size 8388608 crc 821d25ce )
-	rom ( name "AeroGauge (E) (M3) [h2C].z64" size 8388608 crc a36e5628 )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [!].z64" size 8388608 crc 6ee3b932 )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b1].z64" size 16777216 crc 2f50e5ac )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b2].z64" size 16777216 crc ac1c4dea )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b3].z64" size 8388608 crc d77cb849 )
-	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b4].z64" size 8388608 crc 20bc4be0 )
-	rom ( name "AeroGauge (J) (V1.1) [!].z64" size 8388608 crc f322b641 )
-	rom ( name "AeroGauge (J) (V1.1) [b1].z64" size 8388608 crc 083cea9c )
-	rom ( name "AeroGauge (J) (V1.1) [b2].z64" size 8388608 crc 90c976b3 )
-	rom ( name "AeroGauge (J) (V1.1) [b3].z64" size 8388608 crc b32f01e9 )
-	rom ( name "AeroGauge (J) (V1.1) [b4].z64" size 8425571 crc e75de0a8 )
-	rom ( name "AeroGauge (J) (V1.1) [b5].z64" size 8388608 crc 5447e02f )
-	rom ( name "AeroGauge (J) (V1.1) [b6].z64" size 6553600 crc 3386d6cf )
-	rom ( name "AeroGauge (J) (V1.1) [b7].z64" size 8388608 crc d00c9205 )
-	rom ( name "AeroGauge (J) (V1.1) [f1] (PAL).z64" size 8388608 crc 6462db5a )
-	rom ( name "AeroGauge (U) [!].z64" size 8388608 crc 198b9e0e )
-	rom ( name "AeroGauge (U) [b1].z64" size 6815744 crc 042efdf7 )
-	rom ( name "AeroGauge (U) [f1] (PAL).z64" size 8388608 crc 5fc8383f )
-	rom ( name "AeroGauge (U) [h1C].z64" size 8388608 crc 9f9dbb86 )
-	rom ( name "AeroGauge (U) [h2C].z64" size 8388608 crc beeec860 )
-	rom ( name "AeroGauge (U) [T+Ita0.01_Cattivik66].z64" size 8388608 crc 6a505b99 )
+	name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!]"
+	description "Wayne Gretzky's 3D Hockey (U) (V1.1) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!].z64" crc C2678971 )
 )
 
 game (
-	name "AI Shougi 3"
-	description "AI Shougi 3"
-	rom ( name "AI Shougi 3 (J) [!].z64" size 8388608 crc 86df90e6 )
-)
-
-game (
-	name "Aidyn Chronicles - The First Mage"
-	description "Aidyn Chronicles - The First Mage"
-	rom ( name "Aidyn Chronicles - The First Mage (E) [!].z64" size 33554432 crc be7e230d )
-	rom ( name "Aidyn Chronicles - The First Mage (U) [!].z64" size 33554432 crc b1f18186 )
-	rom ( name "Aidyn Chronicles - The First Mage (U) [o1].z64" size 67108864 crc b4e83c35 )
+	name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!]"
+	description "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!].z64" crc 6F6DC53D )
 )
 
 game (
-	name "Airboarder 64"
-	description "Airboarder 64"
-	rom ( name "Airboarder 64 (E) [!].z64" size 8388608 crc c14d45ac )
-	rom ( name "Airboarder 64 (E) [f1] (NTSC).z64" size 8388608 crc 5a820aeb )
-	rom ( name "Airboarder 64 (E) [h1C].z64" size 8388608 crc 33d91397 )
-	rom ( name "Airboarder 64 (J) [!].z64" size 8388608 crc 58fcb771 )
-	rom ( name "Airboarder 64 (J) [b1].z64" size 8388608 crc 74210e87 )
-	rom ( name "Airboarder 64 (J) [b1][t1].z64" size 8388608 crc 3ecd5b63 )
-	rom ( name "Airboarder 64 (J) [b2].z64" size 7864320 crc f91056a0 )
-	rom ( name "Airboarder 64 (J) [b3].z64" size 7864320 crc 2d4f7c45 )
-	rom ( name "Airboarder 64 (J) [f1] (PAL).z64" size 8388608 crc dee11797 )
-	rom ( name "Airboarder 64 (J) [h1C].z64" size 8388608 crc 50598308 )
-	rom ( name "Airboarder 64 (J) [h2C].z64" size 8388608 crc 1c5eed6e )
-	rom ( name "Airboarder 64 (J) [h3C].z64" size 8388608 crc 43d2ee8a )
-	rom ( name "Airboarder 64 (J) [h4C].z64" size 8388608 crc b146b8b1 )
-	rom ( name "Airboarder 64 (J) [h5C].z64" size 8388608 crc 7346313d )
-	rom ( name "Airboarder 64 (J) [h6C].z64" size 8388608 crc e5e93ff3 )
-	rom ( name "Airboarder 64 (J) [t1].z64" size 8388608 crc db44d4c2 )
+	name "Wayne Gretzky's 3D Hockey '98 (U) [!]"
+	description "Wayne Gretzky's 3D Hockey '98 (U) [!]"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [!].z64" crc 355FB089 )
 )
 
 game (
-	name "All Star Tennis '99"
-	description "All Star Tennis '99"
-	rom ( name "All Star Tennis '99 (E) (M5) [!].z64" size 8388608 crc 996e845f )
-	rom ( name "All Star Tennis '99 (E) (M5) [f1] (NTSC).z64" size 8388608 crc f9bb05a1 )
-	rom ( name "All Star Tennis '99 (E) (M5) [f2] (NTSC).z64" size 8388608 crc 0a0b0ffc )
-	rom ( name "All Star Tennis '99 (E) (M5) [f3] (NTSC).z64" size 8388608 crc cd951f26 )
-	rom ( name "All Star Tennis '99 (E) (M5) [f4] (NTSC).z64" size 8388608 crc edd65146 )
-	rom ( name "All Star Tennis '99 (U) [!].z64" size 8388608 crc a7dcf638 )
-	rom ( name "All Star Tennis '99 (U) [f1] (PAL).z64" size 8388608 crc 78b03963 )
-	rom ( name "All Star Tennis '99 (U) [f2] (PAL).z64" size 8388608 crc 6238bb48 )
-	rom ( name "All Star Tennis '99 (U) [h1C].z64" size 8388608 crc add1e941 )
-	rom ( name "All Star Tennis '99 (U) [T+Bra1.0_Guto].z64" size 8388608 crc a7196ca9 )
-)
-
-game (
-	name "All-Star Baseball '99"
-	description "All-Star Baseball '99"
-	rom ( name "All-Star Baseball '99 (E) [!].z64" size 12582912 crc d0de3584 )
-	rom ( name "All-Star Baseball '99 (U) [!].z64" size 12582912 crc 6d25b36f )
-	rom ( name "All-Star Baseball '99 (U) [f1] (PAL).z64" size 12582912 crc 8749cfc1 )
-	rom ( name "All-Star Baseball '99 (U) [o1].z64" size 16777216 crc 43421a65 )
-)
-
-game (
-	name "All-Star Baseball 2000"
-	description "All-Star Baseball 2000"
-	rom ( name "All-Star Baseball 2000 (E) [!].z64" size 16777216 crc d3c29aa4 )
-	rom ( name "All-Star Baseball 2000 (E) [f1] (NTSC).z64" size 16777216 crc 3fc70c72 )
-	rom ( name "All-Star Baseball 2000 (U) [!].z64" size 16777216 crc 69e88471 )
-	rom ( name "All-Star Baseball 2000 (U) [f1] (PAL).z64" size 16777216 crc de5d7096 )
-	rom ( name "All-Star Baseball 2000 (U) [h1C].z64" size 16777216 crc 936abe15 )
-	rom ( name "All-Star Baseball 2000 (U) [h2C].z64" size 16777216 crc 8327d5d7 )
-)
+	name "Wayne Gretzky's 3D Hockey '98 (U) [h1C]"
+	description "Wayne Gretzky's 3D Hockey '98 (U) [h1C]"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h1C].z64" crc A80C229A )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey '98 (U) [h2C]"
+	description "Wayne Gretzky's 3D Hockey '98 (U) [h2C]"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h2C].z64" crc 0C729578 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66]"
+	description "Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66]"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66].z64" crc 5C920E10 )
+)
+
+game (
+	name "WCW Backstage Assault (U) [!]"
+	description "WCW Backstage Assault (U) [!]"
+	rom ( name "WCW Backstage Assault (U) [!].z64" crc 5DCC2E4E )
+)
+
+game (
+	name "WCW Mayhem (E) [!]"
+	description "WCW Mayhem (E) [!]"
+	rom ( name "WCW Mayhem (E) [!].z64" crc 864E066E )
+)
+
+game (
+	name "WCW Mayhem (E) [h1C]"
+	description "WCW Mayhem (E) [h1C]"
+	rom ( name "WCW Mayhem (E) [h1C].z64" crc B3AFF8D7 )
+)
+
+game (
+	name "WCW Mayhem (U) [!]"
+	description "WCW Mayhem (U) [!]"
+	rom ( name "WCW Mayhem (U) [!].z64" crc F1F9B6EB )
+)
+
+game (
+	name "WCW Mayhem (U) [f1] (PAL)"
+	description "WCW Mayhem (U) [f1] (PAL)"
+	rom ( name "WCW Mayhem (U) [f1] (PAL).z64" crc 0EC50495 )
+)
+
+game (
+	name "WCW Nitro (U) [!]"
+	description "WCW Nitro (U) [!]"
+	rom ( name "WCW Nitro (U) [!].z64" crc 455B0830 )
+)
+
+game (
+	name "WCW Nitro (U) [b1]"
+	description "WCW Nitro (U) [b1]"
+	rom ( name "WCW Nitro (U) [b1].z64" crc 22D8DEF9 )
+)
+
+game (
+	name "WCW Nitro (U) [b2]"
+	description "WCW Nitro (U) [b2]"
+	rom ( name "WCW Nitro (U) [b2].z64" crc BD721ABC )
+)
+
+game (
+	name "WCW Nitro (U) [b3]"
+	description "WCW Nitro (U) [b3]"
+	rom ( name "WCW Nitro (U) [b3].z64" crc A4BB0A17 )
+)
+
+game (
+	name "WCW Nitro (U) [f1] (PAL)"
+	description "WCW Nitro (U) [f1] (PAL)"
+	rom ( name "WCW Nitro (U) [f1] (PAL).z64" crc 6988159F )
+)
+
+game (
+	name "WCW Nitro (U) [f2] (PAL)"
+	description "WCW Nitro (U) [f2] (PAL)"
+	rom ( name "WCW Nitro (U) [f2] (PAL).z64" crc 120F8C2A )
+)
+
+game (
+	name "WCW vs. nWo - World Tour (E) [!]"
+	description "WCW vs. nWo - World Tour (E) [!]"
+	rom ( name "WCW vs. nWo - World Tour (E) [!].z64" crc 37F358EB )
+)
+
+game (
+	name "WCW vs. nWo - World Tour (U) (V1.0) [!]"
+	description "WCW vs. nWo - World Tour (U) (V1.0) [!]"
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [!].z64" crc DFBFC61F )
+)
+
+game (
+	name "WCW vs. nWo - World Tour (U) (V1.0) [b1]"
+	description "WCW vs. nWo - World Tour (U) (V1.0) [b1]"
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [b1].z64" crc F224AEE7 )
+)
+
+game (
+	name "WCW vs. nWo - World Tour (U) (V1.1) [!]"
+	description "WCW vs. nWo - World Tour (U) (V1.1) [!]"
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.1) [!].z64" crc A74DA07A )
+)
+
+game (
+	name "WCW-nWo Revenge (E) [!]"
+	description "WCW-nWo Revenge (E) [!]"
+	rom ( name "WCW-nWo Revenge (E) [!].z64" crc 8AF0F964 )
+)
+
+game (
+	name "WCW-nWo Revenge (E) [h1C]"
+	description "WCW-nWo Revenge (E) [h1C]"
+	rom ( name "WCW-nWo Revenge (E) [h1C].z64" crc 771FD04E )
+)
+
+game (
+	name "WCW-nWo Revenge (U) [!]"
+	description "WCW-nWo Revenge (U) [!]"
+	rom ( name "WCW-nWo Revenge (U) [!].z64" crc 54CBAAA8 )
+)
+
+game (
+	name "WCW-nWo Revenge (U) [b1]"
+	description "WCW-nWo Revenge (U) [b1]"
+	rom ( name "WCW-nWo Revenge (U) [b1].z64" crc 31EB978F )
+)
+
+game (
+	name "WCW-nWo Revenge (U) [b2]"
+	description "WCW-nWo Revenge (U) [b2]"
+	rom ( name "WCW-nWo Revenge (U) [b2].z64" crc 9D1B3557 )
+)
+
+game (
+	name "WCW-nWo Revenge (U) [f1] (PAL)"
+	description "WCW-nWo Revenge (U) [f1] (PAL)"
+	rom ( name "WCW-nWo Revenge (U) [f1] (PAL).z64" crc 7EA064D5 )
+)
+
+game (
+	name "WCW-nWo Revenge (U) [f2] (PAL)"
+	description "WCW-nWo Revenge (U) [f2] (PAL)"
+	rom ( name "WCW-nWo Revenge (U) [f2] (PAL).z64" crc B770FB2A )
+)
+
+game (
+	name "Wetrix (E) (M6) [!]"
+	description "Wetrix (E) (M6) [!]"
+	rom ( name "Wetrix (E) (M6) [!].z64" crc EDDC5B06 )
+)
+
+game (
+	name "Wetrix (E) (M6) [f1] (NTSC)"
+	description "Wetrix (E) (M6) [f1] (NTSC)"
+	rom ( name "Wetrix (E) (M6) [f1] (NTSC).z64" crc 46F031A8 )
+)
+
+game (
+	name "Wetrix (E) (M6) [t1]"
+	description "Wetrix (E) (M6) [t1]"
+	rom ( name "Wetrix (E) (M6) [t1].z64" crc C4924BE2 )
+)
+
+game (
+	name "Wetrix (J) [!]"
+	description "Wetrix (J) [!]"
+	rom ( name "Wetrix (J) [!].z64" crc BAD08218 )
+)
+
+game (
+	name "Wetrix (J) [o1]"
+	description "Wetrix (J) [o1]"
+	rom ( name "Wetrix (J) [o1].z64" crc 8DB9C41B )
+)
+
+game (
+	name "Wetrix (U) (M6) [!]"
+	description "Wetrix (U) (M6) [!]"
+	rom ( name "Wetrix (U) (M6) [!].z64" crc 50CD1F71 )
+)
+
+game (
+	name "Wheel of Fortune (U) [!]"
+	description "Wheel of Fortune (U) [!]"
+	rom ( name "Wheel of Fortune (U) [!].z64" crc 8D3EFA8D )
+)
+
+game (
+	name "Wheel of Fortune (U) [b1]"
+	description "Wheel of Fortune (U) [b1]"
+	rom ( name "Wheel of Fortune (U) [b1].z64" crc D6C7BDBA )
+)
+
+game (
+	name "Wheel of Fortune (U) [o1]"
+	description "Wheel of Fortune (U) [o1]"
+	rom ( name "Wheel of Fortune (U) [o1].z64" crc 58878DAF )
+)
+
+game (
+	name "Wheel of Fortune (U) [o1][b1]"
+	description "Wheel of Fortune (U) [o1][b1]"
+	rom ( name "Wheel of Fortune (U) [o1][b1].z64" crc 037ECA98 )
+)
+
+game (
+	name "WideBoy BIOS V980910"
+	description "WideBoy BIOS V980910"
+	rom ( name "WideBoy BIOS V980910.bin" crc 3FE8291E )
+)
+
+game (
+	name "WideBoy BIOS V980914"
+	description "WideBoy BIOS V980914"
+	rom ( name "WideBoy BIOS V980914.bin" crc C9FF4C4B )
+)
+
+game (
+	name "Operation WinBack (E) (M5) [!]"
+	description "Operation WinBack (E) (M5) [!]"
+	rom ( name "Operation WinBack (E) (M5) [!].z64" crc FB96F166 )
+)
+
+game (
+	name "WinBack (J) [!]"
+	description "WinBack (J) [!]"
+	rom ( name "WinBack (J) [!].z64" crc D35360B0 )
+)
+
+game (
+	name "WinBack (J) [b1]"
+	description "WinBack (J) [b1]"
+	rom ( name "WinBack (J) [b1].z64" crc 18256C96 )
+)
+
+game (
+	name "WinBack - Covert Operations (U) [!]"
+	description "WinBack - Covert Operations (U) [!]"
+	rom ( name "WinBack - Covert Operations (U) [!].z64" crc 64C817C5 )
+)
+
+game (
+	name "WinBack - Covert Operations (U) [b1]"
+	description "WinBack - Covert Operations (U) [b1]"
+	rom ( name "WinBack - Covert Operations (U) [b1].z64" crc 5C319F14 )
+)
+
+game (
+	name "WinBack - Covert Operations (U) [f1] (PAL)"
+	description "WinBack - Covert Operations (U) [f1] (PAL)"
+	rom ( name "WinBack - Covert Operations (U) [f1] (PAL).z64" crc E13EDE7D )
+)
+
+game (
+	name "WinBack - Covert Operations (U) [t1]"
+	description "WinBack - Covert Operations (U) [t1]"
+	rom ( name "WinBack - Covert Operations (U) [t1].z64" crc EDC5F66E )
+)
+
+game (
+	name "Wipeout 64 (E) [!]"
+	description "Wipeout 64 (E) [!]"
+	rom ( name "Wipeout 64 (E) [!].z64" crc 38111048 )
+)
+
+game (
+	name "Wipeout 64 (U) [!]"
+	description "Wipeout 64 (U) [!]"
+	rom ( name "Wipeout 64 (U) [!].z64" crc 4888D0FE )
+)
+
+game (
+	name "Wipeout 64 (U) [o1]"
+	description "Wipeout 64 (U) [o1]"
+	rom ( name "Wipeout 64 (U) [o1].z64" crc FF733418 )
+)
+
+game (
+	name "Wipeout 64 (U) [t1]"
+	description "Wipeout 64 (U) [t1]"
+	rom ( name "Wipeout 64 (U) [t1].z64" crc 6FBC4937 )
+)
+
+game (
+	name "Wipeout 64 (U) [t2]"
+	description "Wipeout 64 (U) [t2]"
+	rom ( name "Wipeout 64 (U) [t2].z64" crc 3367383C )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!]"
+	description "Wonder Project J2 - Koruro no Mori no Jozet (J) [!]"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!].z64" crc 5E8FC436 )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet (J) [b1]"
+	description "Wonder Project J2 - Koruro no Mori no Jozet (J) [b1]"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [b1].z64" crc C3516904 )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet (J) [h1C]"
+	description "Wonder Project J2 - Koruro no Mori no Jozet (J) [h1C]"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [h1C].z64" crc A4C86774 )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T+Eng0.1_Ryu]"
+	description "Wonder Project J2 - Koruro no Mori no Jozet (J) [T+Eng0.1_Ryu]"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T+Eng0.1_Ryu].z64" crc C6458D2B )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T-Eng0.05]"
+	description "Wonder Project J2 - Koruro no Mori no Jozet (J) [T-Eng0.05]"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T-Eng0.05].v64" crc 2163807B )
+)
+
+game (
+	name "World Cup 98 (E) (M8) [!]"
+	description "World Cup 98 (E) (M8) [!]"
+	rom ( name "World Cup 98 (E) (M8) [!].z64" crc 79F483F7 )
+)
+
+game (
+	name "World Cup 98 (E) (M8) [f1] (NTSC)"
+	description "World Cup 98 (E) (M8) [f1] (NTSC)"
+	rom ( name "World Cup 98 (E) (M8) [f1] (NTSC).z64" crc 58E87217 )
+)
+
+game (
+	name "World Cup 98 (U) (M8) [!]"
+	description "World Cup 98 (U) (M8) [!]"
+	rom ( name "World Cup 98 (U) (M8) [!].z64" crc 13930C26 )
+)
+
+game (
+	name "World Driver Championship (E) (M5) [!]"
+	description "World Driver Championship (E) (M5) [!]"
+	rom ( name "World Driver Championship (E) (M5) [!].z64" crc 76151DF6 )
+)
+
+game (
+	name "World Driver Championship (E) (M5) [h1C]"
+	description "World Driver Championship (E) (M5) [h1C]"
+	rom ( name "World Driver Championship (E) (M5) [h1C].z64" crc 30C31843 )
+)
+
+game (
+	name "World Driver Championship (U) [!]"
+	description "World Driver Championship (U) [!]"
+	rom ( name "World Driver Championship (U) [!].z64" crc 5E4ACBFA )
+)
+
+game (
+	name "World Driver Championship (U) [b1]"
+	description "World Driver Championship (U) [b1]"
+	rom ( name "World Driver Championship (U) [b1].z64" crc 8811AF43 )
+)
+
+game (
+	name "World Driver Championship (U) [f1] (PAL)"
+	description "World Driver Championship (U) [f1] (PAL)"
+	rom ( name "World Driver Championship (U) [f1] (PAL).z64" crc 02D1F824 )
+)
+
+game (
+	name "World Driver Championship (U) [f2] (PAL)"
+	description "World Driver Championship (U) [f2] (PAL)"
+	rom ( name "World Driver Championship (U) [f2] (PAL).z64" crc DF25EBE8 )
+)
+
+game (
+	name "World Driver Championship (U) [t1]"
+	description "World Driver Championship (U) [t1]"
+	rom ( name "World Driver Championship (U) [t1].z64" crc 813FCBED )
+)
+
+game (
+	name "Worms - Armageddon (E) (M6) [!]"
+	description "Worms - Armageddon (E) (M6) [!]"
+	rom ( name "Worms - Armageddon (E) (M6) [!].z64" crc 6BFFF27B )
+)
+
+game (
+	name "Worms - Armageddon (E) (M6) [f1] (NTSC)"
+	description "Worms - Armageddon (E) (M6) [f1] (NTSC)"
+	rom ( name "Worms - Armageddon (E) (M6) [f1] (NTSC).z64" crc 9CDFEE58 )
+)
+
+game (
+	name "Worms - Armageddon (U) (M3) [!]"
+	description "Worms - Armageddon (U) (M3) [!]"
+	rom ( name "Worms - Armageddon (U) (M3) [!].z64" crc 5471AE3B )
+)
+
+game (
+	name "WWF - War Zone (E) [!]"
+	description "WWF - War Zone (E) [!]"
+	rom ( name "WWF - War Zone (E) [!].z64" crc 90A0B609 )
+)
+
+game (
+	name "WWF - War Zone (U) [!]"
+	description "WWF - War Zone (U) [!]"
+	rom ( name "WWF - War Zone (U) [!].z64" crc 2FBB5507 )
+)
+
+game (
+	name "WWF Attitude (E) [!]"
+	description "WWF Attitude (E) [!]"
+	rom ( name "WWF Attitude (E) [!].z64" crc 804FE494 )
+)
+
+game (
+	name "WWF Attitude (G) [!]"
+	description "WWF Attitude (G) [!]"
+	rom ( name "WWF Attitude (G) [!].z64" crc EA5D8359 )
+)
+
+game (
+	name "WWF Attitude (G) [b1]"
+	description "WWF Attitude (G) [b1]"
+	rom ( name "WWF Attitude (G) [b1].z64" crc 45C4C497 )
+)
+
+game (
+	name "WWF Attitude (U) [!]"
+	description "WWF Attitude (U) [!]"
+	rom ( name "WWF Attitude (U) [!].z64" crc 7A4B3686 )
+)
+
+game (
+	name "WWF Attitude (U) [b1]"
+	description "WWF Attitude (U) [b1]"
+	rom ( name "WWF Attitude (U) [b1].z64" crc 80634009 )
+)
+
+game (
+	name "WWF Attitude (U) [b2]"
+	description "WWF Attitude (U) [b2]"
+	rom ( name "WWF Attitude (U) [b2].z64" crc 8E21A880 )
+)
+
+game (
+	name "WWF Attitude (U) [f1] (PAL)"
+	description "WWF Attitude (U) [f1] (PAL)"
+	rom ( name "WWF Attitude (U) [f1] (PAL).z64" crc BABB135A )
+)
+
+game (
+	name "WWF No Mercy (E) (V1.0) [!]"
+	description "WWF No Mercy (E) (V1.0) [!]"
+	rom ( name "WWF No Mercy (E) (V1.0) [!].z64" crc B79BDDD8 )
+)
+
+game (
+	name "WWF No Mercy (E) (V1.0) [b1]"
+	description "WWF No Mercy (E) (V1.0) [b1]"
+	rom ( name "WWF No Mercy (E) (V1.0) [b1].z64" crc D6F1C981 )
+)
+
+game (
+	name "WWF No Mercy (E) (V1.1) [!]"
+	description "WWF No Mercy (E) (V1.1) [!]"
+	rom ( name "WWF No Mercy (E) (V1.1) [!].z64" crc 43BA9E7E )
+)
+
+game (
+	name "WWF No Mercy (U) (V1.0) [!]"
+	description "WWF No Mercy (U) (V1.0) [!]"
+	rom ( name "WWF No Mercy (U) (V1.0) [!].z64" crc B33F44F0 )
+)
+
+game (
+	name "WWF No Mercy (U) (V1.0) [t1]"
+	description "WWF No Mercy (U) (V1.0) [t1]"
+	rom ( name "WWF No Mercy (U) (V1.0) [t1].z64" crc FEE04A00 )
+)
+
+game (
+	name "WWF No Mercy (U) (V1.1) [!]"
+	description "WWF No Mercy (U) (V1.1) [!]"
+	rom ( name "WWF No Mercy (U) (V1.1) [!].z64" crc BACEEA13 )
+)
 
 game (
-	name "All-Star Baseball 2001"
-	description "All-Star Baseball 2001"
-	rom ( name "All-Star Baseball 2001 (U) [!].z64" size 16777216 crc 4d659e85 )
-	rom ( name "All-Star Baseball 2001 (U) [f1] (PAL).z64" size 16777216 crc 50f2289d )
-)
-
-game (
-	name "Armorines - Project S.W.A.R.M."
-	description "Armorines - Project S.W.A.R.M."
-	rom ( name "Armorines - Project S.W.A.R.M. (E) [!].z64" size 16777216 crc 600bc49e )
-	rom ( name "Armorines - Project S.W.A.R.M. (E) [f1] (NTSC).z64" size 16777216 crc abf06b85 )
-	rom ( name "Armorines - Project S.W.A.R.M. (G) [!].z64" size 16777216 crc 5bab9100 )
-	rom ( name "Armorines - Project S.W.A.R.M. (G) [f1] (NTSC).z64" size 16777216 crc d7eeb023 )
-	rom ( name "Armorines - Project S.W.A.R.M. (U) [!].z64" size 16777216 crc 630a19e2 )
-	rom ( name "Armorines - Project S.W.A.R.M. (U) [f1] (PAL).z64" size 16777216 crc deda354c )
-	rom ( name "Armorines - Project S.W.A.R.M. (U) [t1].z64" size 16777216 crc 0a51d29c )
-)
-
-game (
-	name "Army Men - Air Combat"
-	description "Army Men - Air Combat"
-	rom ( name "Army Men - Air Combat (U) [!].z64" size 8388608 crc 1952cc87 )
-)
-
-game (
-	name "Army Men - Sarge's Heroes"
-	description "Army Men - Sarge's Heroes"
-	rom ( name "Army Men - Sarge's Heroes (E) (M3) [!].z64" size 8388608 crc e79048e2 )
-	rom ( name "Army Men - Sarge's Heroes (U) [!].z64" size 8388608 crc 2fe786f6 )
-	rom ( name "Army Men - Sarge's Heroes (U) [b1].z64" size 12530901 crc 1f6724f7 )
-	rom ( name "Army Men - Sarge's Heroes (U) [f1] (PAL).z64" size 8388608 crc 5e67a745 )
-	rom ( name "Army Men - Sarge's Heroes (U) [t1].z64" size 8388608 crc 675938d9 )
-	rom ( name "Army Men - Sarge's Heroes (U) [t2].z64" size 8388608 crc 58f10814 )
-	rom ( name "Army Men - Sarge's Heroes (U) [t3].z64" size 8388608 crc a14c9efc )
-)
-
-game (
-	name "Army Men - Sarge's Heroes 2"
-	description "Army Men - Sarge's Heroes 2"
-	rom ( name "Army Men - Sarge's Heroes 2 (U) [!].z64" size 8388608 crc 79a71608 )
-	rom ( name "Army Men - Sarge's Heroes 2 (U) [t1].z64" size 8388608 crc 7fdc2d7d )
-)
-
-game (
-	name "Asteroids Hyper 64"
-	description "Asteroids Hyper 64"
-	rom ( name "Asteroids Hyper 64 (U) [!].z64" size 4194304 crc f5ce3d91 )
-	rom ( name "Asteroids Hyper 64 (U) [o1].z64" size 8388608 crc 91aa6689 )
-	rom ( name "Asteroids Hyper 64 (U) [o1][f1] (PAL).z64" size 8388608 crc fd3d371b )
-	rom ( name "Asteroids Hyper 64 (U) [o1][t1].z64" size 8650752 crc d65f7b9a )
+	name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!]"
+	description "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!]"
+	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!].z64" crc F620835D )
 )
-
-game (
-	name "Automobili Lamborghini"
-	description "Automobili Lamborghini"
-	rom ( name "Automobili Lamborghini (E) [!].z64" size 4194304 crc 3baf58d5 )
-	rom ( name "Automobili Lamborghini (E) [o1].z64" size 8388608 crc 95107c80 )
-	rom ( name "Automobili Lamborghini (U) [!].z64" size 4194304 crc a4374eac )
-	rom ( name "Automobili Lamborghini (U) [b1].z64" size 16777216 crc 5d371e34 )
-	rom ( name "Automobili Lamborghini (U) [b2].z64" size 8388608 crc 2ddcd6c5 )
-	rom ( name "Automobili Lamborghini (U) [b3].z64" size 8388608 crc 94766bda )
-	rom ( name "Automobili Lamborghini (U) [b4].z64" size 4194304 crc e62bed9d )
-	rom ( name "Automobili Lamborghini (U) [b5].z64" size 4194304 crc b5bb916b )
-	rom ( name "Automobili Lamborghini (U) [b6].z64" size 4194304 crc 8d796095 )
-	rom ( name "Automobili Lamborghini (U) [f1].z64" size 4194304 crc f922947e )
-	rom ( name "Automobili Lamborghini (U) [h1C].z64" size 4194304 crc 7d8a5bb2 )
-	rom ( name "Automobili Lamborghini (U) [h2C].z64" size 4194304 crc 68d2aa64 )
-	rom ( name "Automobili Lamborghini (U) [o1].z64" size 8388608 crc 190288d7 )
-	rom ( name "Automobili Lamborghini (U) [o1][T+Ita_cattivik66].z64" size 8388608 crc 1f38d9c4 )
-	rom ( name "Automobili Lamborghini (U) [o2].z64" size 16777216 crc 006c9b00 )
-	rom ( name "Automobili Lamborghini (U) [o3].z64" size 16777207 crc 5bf77066 )
-	rom ( name "Automobili Lamborghini (U) [o4].z64" size 16777648 crc 231defae )
-	rom ( name "Automobili Lamborghini (U) [o5].z64" size 16777216 crc cd100474 )
-	rom ( name "Automobili Lamborghini (U) [o6].z64" size 16777216 crc 1d23f90b )
-	rom ( name "Automobili Lamborghini (U) [o7].z64" size 12582912 crc 3a760d0b )
-	rom ( name "Automobili Lamborghini (U) [o7][T+Ita_cattivik66].z64" size 12582912 crc 405c647d )
-	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b3].z64" size 4194304 crc 4a0325be )
-	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b4].z64" size 4194304 crc 1c0d6e98 )
-	rom ( name "Automobili Lamborghini (U) [t1].z64" size 8369260 crc 5be718fa )
-	rom ( name "Super Speed Race 64 (J) [!].z64" size 4194304 crc 0f879a70 )
-	rom ( name "Super Speed Race 64 (J) [o1].z64" size 8388608 crc d94fd663 )
+
+game (
+	name "WWF WrestleMania 2000 (E) [!]"
+	description "WWF WrestleMania 2000 (E) [!]"
+	rom ( name "WWF WrestleMania 2000 (E) [!].z64" crc 09D710C7 )
+)
+
+game (
+	name "WWF WrestleMania 2000 (E) [h1C]"
+	description "WWF WrestleMania 2000 (E) [h1C]"
+	rom ( name "WWF WrestleMania 2000 (E) [h1C].z64" crc 596C6ED1 )
 )
 
 game (
-	name "Bakuretsu Muteki Bangai-O"
-	description "Bakuretsu Muteki Bangai-O"
-	rom ( name "Bakuretsu Muteki Bangai-O (J) [!].z64" size 12582912 crc 6ab7fec6 )
-	rom ( name "Bakuretsu Muteki Bangai-O (J) [f1] (PAL).z64" size 12582912 crc 2582fda5 )
-	rom ( name "Bakuretsu Muteki Bangai-O (J) [h1C].z64" size 12582912 crc c76f1d4c )
+	name "WWF WrestleMania 2000 (J) [!]"
+	description "WWF WrestleMania 2000 (J) [!]"
+	rom ( name "WWF WrestleMania 2000 (J) [!].z64" crc C2034D24 )
 )
 
 game (
-	name "Bakushou Jinsei 64 - Mezase! Resort Ou"
-	description "Bakushou Jinsei 64 - Mezase! Resort Ou"
-	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!].z64" size 12582912 crc ef8c2f34 )
-	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C].z64" size 12582912 crc 47db2246 )
+	name "WWF WrestleMania 2000 (J) [b1]"
+	description "WWF WrestleMania 2000 (J) [b1]"
+	rom ( name "WWF WrestleMania 2000 (J) [b1].z64" crc 9AFB5300 )
 )
 
 game (
-	name Banjo-Kazooie
-	description "Banjo-Kazooie"
-	rom ( name "Banjo to Kazooie no Daibouken (J) [!].z64" size 16777216 crc 8f7c9324 )
-	rom ( name "Banjo to Kazooie no Daibouken (J) [f1].z64" size 16824592 crc 73576c8b )
-	rom ( name "Banjo to Kazooie no Daibouken (J) [f2].z64" size 17039360 crc 56944ade )
-	rom ( name "Banjo to Kazooie no Daibouken (J) [f3].z64" size 16824592 crc fc4be10d )
-	rom ( name "Banjo-Kazooie (E) (M3) [!].z64" size 16777216 crc 525899c9 )
-	rom ( name "Banjo-Kazooie (E) (M3) [f1].z64" size 17039360 crc 310fc34b )
-	rom ( name "Banjo-Kazooie (E) (M3) [f2].z64" size 16777216 crc 8fa1a9b1 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [!].z64" size 16777216 crc ad429961 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b1].z64" size 16829405 crc f000e01e )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b2].z64" size 16777216 crc 409090e5 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b3].z64" size 16777216 crc e1bc390f )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b4].z64" size 16777216 crc e5e5b566 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b5].z64" size 16645536 crc 10259bd1 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b6].z64" size 16777216 crc 617c02cc )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [b7].z64" size 16777216 crc 93e70f75 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [f1].z64" size 16777216 crc 5b581d38 )
-	rom ( name "Banjo-Kazooie (U) (V1.0) [t1].z64" size 16777216 crc 2600ae00 )
-	rom ( name "Banjo-Kazooie (U) (V1.1) [!].z64" size 16777216 crc fb7ffb10 )
+	name "WWF WrestleMania 2000 (U) [!]"
+	description "WWF WrestleMania 2000 (U) [!]"
+	rom ( name "WWF WrestleMania 2000 (U) [!].z64" crc 0B50B4C6 )
 )
 
 game (
-	name Banjo-Tooie
-	description "Banjo-Tooie"
-	rom ( name "Banjo to Kazooie no Daibouken 2 (J) [!].z64" size 33554432 crc 258c58d0 )
-	rom ( name "Banjo-Tooie (A) [!].z64" size 33554432 crc 2736266a )
-	rom ( name "Banjo-Tooie (E) (M4) [!].z64" size 33554432 crc 1ec12f5a )
-	rom ( name "Banjo-Tooie (U) [!].z64" size 33554432 crc bab803ef )
+	name "WWF WrestleMania 2000 (U) [b1]"
+	description "WWF WrestleMania 2000 (U) [b1]"
+	rom ( name "WWF WrestleMania 2000 (U) [b1].z64" crc 963F19A3 )
 )
 
 game (
-	name "Bass Rush - ECOGEAR PowerWorm Championship"
-	description "Bass Rush - ECOGEAR PowerWorm Championship"
-	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!].z64" size 33554432 crc 383b86ef )
-	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b1].z64" size 29360129 crc 2ac04018 )
-	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b2].z64" size 29360128 crc 2c3a7b2b )
+	name "WWF WrestleMania 2000 (U) [t1] (Never Drop Weapons)"
+	description "WWF WrestleMania 2000 (U) [t1] (Never Drop Weapons)"
+	rom ( name "WWF WrestleMania 2000 (U) [t1] (Never Drop Weapons).bin" crc 59D05C03 )
 )
 
 game (
-	name "Bassmasters 2000"
-	description "Bassmasters 2000"
-	rom ( name "Bassmasters 2000 (U) [!].z64" size 12582912 crc 6b09092e )
-	rom ( name "Bassmasters 2000 (U) [b1].z64" size 12582912 crc ff7ff0ec )
-	rom ( name "Bassmasters 2000 (U) [f1] (PAL).z64" size 12582912 crc 38b00d48 )
+	name "Xena Warrior Princess - The Talisman of Fate (E) [!]"
+	description "Xena Warrior Princess - The Talisman of Fate (E) [!]"
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (E) [!].z64" crc D3932F88 )
 )
 
 game (
-	name "Batman Beyond - Return of the Joker"
-	description "Batman Beyond - Return of the Joker"
-	rom ( name "Batman Beyond - Return of the Joker (U) [!].z64" size 4194304 crc 35299f9c )
-	rom ( name "Batman Beyond - Return of the Joker (U) [o1].z64" size 8388608 crc 6c5ab61e )
-	rom ( name "Batman Beyond - Return of the Joker (U) [o1][t1].z64" size 8388608 crc 0184342f )
-	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [!].z64" size 4194304 crc 82a4bb8a )
-	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [b1].z64" size 4194304 crc 353dd094 )
-	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [o1].z64" size 8388608 crc 564125b9 )
+	name "Xena Warrior Princess - The Talisman of Fate (U) [!]"
+	description "Xena Warrior Princess - The Talisman of Fate (U) [!]"
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [!].z64" crc 7DA93999 )
 )
 
 game (
-	name BattleTanx
-	description "BattleTanx"
-	rom ( name "BattleTanx (U) [!].z64" size 8388608 crc 6c230765 )
-	rom ( name "BattleTanx (U) [b1].z64" size 8388608 crc 716239a4 )
-	rom ( name "BattleTanx (U) [b1][t1].z64" size 8388608 crc b6697b5c )
-	rom ( name "BattleTanx (U) [f1] (PAL).z64" size 8388608 crc 0e897622 )
-	rom ( name "BattleTanx (U) [t1].z64" size 8388608 crc 245a516b )
+	name "Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL)"
+	description "Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL)"
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL).z64" crc 476A756D )
 )
 
 game (
-	name "BattleTanx - Global Assault"
-	description "BattleTanx - Global Assault"
-	rom ( name "BattleTanx - Global Assault (E) (M3) [!].z64" size 8388608 crc c99c6030 )
-	rom ( name "BattleTanx - Global Assault (U) [!].z64" size 8388608 crc 31beb053 )
-	rom ( name "BattleTanx - Global Assault (U) [f1] (Country Check).z64" size 8388608 crc d375debc )
-	rom ( name "BattleTanx - Global Assault (U) [f2] (PAL).z64" size 8388608 crc e448b23f )
-)
-
+	name "Xena Warrior Princess - The Talisman of Fate (U) [t1]"
+	description "Xena Warrior Princess - The Talisman of Fate (U) [t1]"
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [t1].z64" crc D2532F61 )
+)
+
 game (
-	name "Battlezone - Rise of the Black Dogs"
-	description "Battlezone - Rise of the Black Dogs"
-	rom ( name "Battlezone - Rise of the Black Dogs (U) [!].z64" size 16777216 crc 736f9d5c )
+	name "Xplorer64 BIOS V1.067 (G)"
+	description "Xplorer64 BIOS V1.067 (G)"
+	rom ( name "Xplorer64 BIOS V1.067 (G).bin" crc 656ACDF5 )
 )
 
 game (
-	name "Beetle Adventure Racing!"
-	description "Beetle Adventure Racing!"
-	rom ( name "Beetle Adventure Racing! (E) (M3) [!].z64" size 16777216 crc 5b6c6e4c )
-	rom ( name "Beetle Adventure Racing! (E) (M3) [h1C].z64" size 16777216 crc b0986539 )
-	rom ( name "Beetle Adventure Racing! (E) (M3) [t1].z64" size 16777216 crc 0605ae3c )
-	rom ( name "Beetle Adventure Racing! (J) [!].z64" size 16777216 crc 49e75825 )
-	rom ( name "Beetle Adventure Racing! (J) [b1].z64" size 16777216 crc 54085e2e )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [!].z64" size 16777216 crc f4a97c73 )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [b1].z64" size 16777216 crc 94c6c38e )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [b2].z64" size 16777216 crc cfa90a9c )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [f1] (PAL).z64" size 15990784 crc 9e372e72 )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [t1].z64" size 16777216 crc 67389d41 )
-	rom ( name "Beetle Adventure Racing! (U) (M3) [t2].z64" size 16777216 crc e5164eb0 )
-	rom ( name "HSV Adventure Racing (A) [b1].z64" size 16777216 crc 513b0745 )
-	rom ( name "HSV Adventure Racing (A) [f1] (NTSC).z64" size 16777216 crc ce50fdb3 )
-	rom ( name "HSV Adventure Racing (A).z64" size 16777216 crc c0ba9440 )
+	name "Yakouchuu II - Satsujin Kouru (J) [!]"
+	description "Yakouchuu II - Satsujin Kouru (J) [!]"
+	rom ( name "Yakouchuu II - Satsujin Kouru (J) [!].z64" crc 4538C41A )
 )
 
 game (
-	name "Big Mountain 2000"
-	description "Big Mountain 2000"
-	rom ( name "Big Mountain 2000 (U) [!].z64" size 12582912 crc 3ac924bc )
-	rom ( name "Big Mountain 2000 (U) [t1].z64" size 12582912 crc 5b7c40dc )
-	rom ( name "Snow Speeder (J) [!].z64" size 12582912 crc 30ea3fd7 )
-	rom ( name "Snow Speeder (J) [b1].z64" size 12582912 crc 0d85c419 )
-)
-
-game (
-	name "Bio F.R.E.A.K.S."
-	description "Bio F.R.E.A.K.S."
-	rom ( name "Bio F.R.E.A.K.S. (E) [!].z64" size 16777216 crc 2c4eb906 )
-	rom ( name "Bio F.R.E.A.K.S. (E) [b1].z64" size 12582912 crc 786c72e2 )
-	rom ( name "Bio F.R.E.A.K.S. (U) [!].z64" size 16777216 crc dfbf448c )
-	rom ( name "Bio F.R.E.A.K.S. (U) [b1].z64" size 16777216 crc 06134dae )
-	rom ( name "Bio F.R.E.A.K.S. (U) [b2].z64" size 16777216 crc c1ba30a0 )
-	rom ( name "Bio F.R.E.A.K.S. (U) [b3].z64" size 16777216 crc 68269493 )
-	rom ( name "Bio F.R.E.A.K.S. (U) [h1C].z64" size 16777216 crc 5bf5acee )
-	rom ( name "Bio F.R.E.A.K.S. (U) [t1].z64" size 16777216 crc d239559b )
-)
-
-game (
-	name "Blast Corps"
-	description "Blast Corps"
-	rom ( name "Blast Corps (E) (M2) [!].z64" size 8388608 crc 4c820695 )
-	rom ( name "Blast Corps (E) (M2) [b1].z64" size 8388608 crc 529072b8 )
-	rom ( name "Blast Corps (E) (M2) [b2].z64" size 8388608 crc ae6df20f )
-	rom ( name "Blast Corps (U) (V1.0) [!].z64" size 8388608 crc 767a95e7 )
-	rom ( name "Blast Corps (U) (V1.0) [b1].z64" size 8388608 crc 43484da5 )
-	rom ( name "Blast Corps (U) (V1.0) [b2].z64" size 8388608 crc e7fd8279 )
-	rom ( name "Blast Corps (U) (V1.1) [!].z64" size 8388608 crc 9cbbccf1 )
-	rom ( name "Blast Dozer (J) [!].z64" size 8388608 crc 081a3641 )
-	rom ( name "Blast Dozer (J) [b1].z64" size 8388608 crc 5c01ab00 )
+	name "Yoshi Story (J) [!]"
+	description "Yoshi Story (J) [!]"
+	rom ( name "Yoshi Story (J) [!].z64" crc 4F44A9EF )
 )
 
 game (
-	name "Blues Brothers 2000"
-	description "Blues Brothers 2000"
-	rom ( name "Blues Brothers 2000 (E) (M6) [!].z64" size 16777216 crc 8fb41658 )
-	rom ( name "Blues Brothers 2000 (U) [!].z64" size 16777216 crc c6f49764 )
-	rom ( name "Blues Brothers 2000 (U) [f1] (PAL-NTSC).z64" size 16777216 crc c978c9b2 )
-	rom ( name "Blues Brothers 2000 (U) [t1].z64" size 16777216 crc 3ae17959 )
-	rom ( name "Blues Brothers 2000 (U) [t1][f1] (PAL-NTSC).z64" size 16777216 crc f0ef67ef )
+	name "Yoshi Story (J) [b1]"
+	description "Yoshi Story (J) [b1]"
+	rom ( name "Yoshi Story (J) [b1].z64" crc 6E01A7AE )
 )
 
 game (
-	name "Body Harvest"
-	description "Body Harvest"
-	rom ( name "Body Harvest (E) (M3) [!].z64" size 12582912 crc 6a04cdae )
-	rom ( name "Body Harvest (E) (M3) [f1] (NTSC).z64" size 12582912 crc 561081c2 )
-	rom ( name "Body Harvest (U) [!].z64" size 12582912 crc fabbdf02 )
-	rom ( name "Body Harvest (U) [b1].z64" size 12582912 crc 47057360 )
-	rom ( name "Body Harvest (U) [b1][t1].z64" size 12582912 crc 822cce53 )
-	rom ( name "Body Harvest (U) [b2].z64" size 12582912 crc a8c980a0 )
-	rom ( name "Body Harvest (U) [t1].z64" size 12582912 crc 418da29b )
-)
-
-game (
-	name "Bomberman 64"
-	description "Bomberman 64"
-	rom ( name "Baku Bomberman (J) [!].z64" size 8388608 crc 22f54a52 )
-	rom ( name "Baku Bomberman (J) [b1].z64" size 8388608 crc f8d8623f )
-	rom ( name "Baku Bomberman (J) [h1C].z64" size 8388608 crc 1f6ba05d )
-	rom ( name "Baku Bomberman (J) [t1].z64" size 8388608 crc 6733c63c )
-	rom ( name "Bomberman 64 (E) [!].z64" size 8388608 crc 525339c5 )
-	rom ( name "Bomberman 64 (E) [b1].z64" size 8388608 crc c7d3898d )
-	rom ( name "Bomberman 64 (E) [b2].z64" size 8388608 crc f6fc15d0 )
-	rom ( name "Bomberman 64 (E) [h1C].z64" size 8388608 crc 70ea3058 )
-	rom ( name "Bomberman 64 (E) [t1].z64" size 8388608 crc 7decd8f8 )
-	rom ( name "Bomberman 64 (U) [!].z64" size 8388608 crc 3ed0e0dc )
-	rom ( name "Bomberman 64 (U) [b1].z64" size 8126464 crc 2f1488d8 )
-	rom ( name "Bomberman 64 (U) [o1].z64" size 8388808 crc e4c0a3a4 )
-)
-
-game (
-	name "Bomberman 64 - Arcade Edition"
-	description "Bomberman 64 - Arcade Edition"
-	rom ( name "Bomberman 64 - Arcade Edition (J) [f1] (PAL).z64" size 12582912 crc 7b3f423e )
-	rom ( name "Bomberman 64 - Arcade Edition (J) [f2] (PAL-CRC).z64" size 12582912 crc ca005639 )
-	rom ( name "Bomberman 64 - Arcade Edition (J).z64" size 12582912 crc 7e74eedc )
-)
-
-game (
-	name "Bomberman 64 - The Second Attack!"
-	description "Bomberman 64 - The Second Attack!"
-	rom ( name "Baku Bomberman 2 (J) [!].z64" size 16777216 crc 86bbc278 )
-	rom ( name "Bomberman 64 - The Second Attack! (U) [!].z64" size 16777216 crc 57550007 )
-	rom ( name "Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC).z64" size 16777216 crc f2ddb246 )
-)
-
-game (
-	name "Bomberman Hero"
-	description "Bomberman Hero"
-	rom ( name "Bomberman Hero (E) [!].z64" size 12582912 crc 59e39947 )
-	rom ( name "Bomberman Hero (E) [b1].z64" size 12582912 crc faad0e58 )
-	rom ( name "Bomberman Hero (E) [b2].z64" size 33554432 crc 332391a6 )
-	rom ( name "Bomberman Hero (E) [b3].z64" size 12582912 crc 18957212 )
-	rom ( name "Bomberman Hero (E) [f1] (NTSC).z64" size 12582912 crc 371ab763 )
-	rom ( name "Bomberman Hero (U) [!].z64" size 12582912 crc 2cc2e634 )
-	rom ( name "Bomberman Hero (U) [b1].z64" size 5967872 crc d9204816 )
-	rom ( name "Bomberman Hero (U) [b2].z64" size 12581464 crc 2e329c9c )
-	rom ( name "Bomberman Hero (U) [b3].z64" size 12582912 crc e3ea697c )
-	rom ( name "Bomberman Hero (U) [t1].z64" size 12582912 crc b7ea3fe0 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!].z64" size 12582912 crc 69ceabcc )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1].z64" size 16777216 crc fbe5d5f7 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b2].z64" size 16777216 crc c9822c46 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b3].z64" size 16777216 crc e3e4703f )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b4].z64" size 12582912 crc 70700853 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b5].z64" size 16777216 crc 7a3e9bf6 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b6].z64" size 12582912 crc 7409b5d6 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b7].z64" size 12582912 crc 002a9fde )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b8].z64" size 12582912 crc 737334c7 )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [o1].z64" size 16777216 crc 2573dfef )
-	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [t1].z64" size 12582912 crc 6acd9758 )
-)
-
-game (
-	name "Bottom of the 9th"
-	description "Bottom of the 9th"
-	rom ( name "Bottom of the 9th (U) [!].z64" size 16777216 crc 1844c8ca )
-	rom ( name "Bottom of the 9th (U) [b1].z64" size 16777216 crc 352f0d77 )
-)
-
-game (
-	name "Brunswick Circuit Pro Bowling"
-	description "Brunswick Circuit Pro Bowling"
-	rom ( name "Brunswick Circuit Pro Bowling (U) [!].z64" size 8388608 crc 80d70173 )
-	rom ( name "Brunswick Circuit Pro Bowling (U) [b1].z64" size 8388608 crc 48d6fbb5 )
-	rom ( name "Brunswick Circuit Pro Bowling (U) [o1].z64" size 12582912 crc ca69aa8b )
-	rom ( name "Brunswick Circuit Pro Bowling (U) [o1][f1] (PAL).z64" size 12582912 crc 84e3b242 )
-)
-
-game (
-	name "Buck Bumble"
-	description "Buck Bumble"
-	rom ( name "Buck Bumble (E) (M5) [!].z64" size 12582912 crc e26192ab )
-	rom ( name "Buck Bumble (J) [!].z64" size 12582912 crc 2ed81a65 )
-	rom ( name "Buck Bumble (U) [!].z64" size 12582912 crc 8ec937db )
-	rom ( name "Buck Bumble (U) [b1][t1].z64" size 12582912 crc 35682724 )
-	rom ( name "Buck Bumble (U) [b2].z64" size 12582912 crc 462ea83e )
-	rom ( name "Buck Bumble (U) [f1] (PAL).z64" size 12582912 crc 96e40527 )
-	rom ( name "Buck Bumble (U) [t1].z64" size 12582912 crc ab751417 )
-)
-
-game (
-	name "Bug's Life, A"
-	description "Bug's Life, A"
-	rom ( name "Bug's Life, A (E) [!].z64" size 12582912 crc 791881d4 )
-	rom ( name "Bug's Life, A (E) [f1] (NTSC).z64" size 12582912 crc c9cfe718 )
-	rom ( name "Bug's Life, A (F) [!].z64" size 12582912 crc e5429094 )
-	rom ( name "Bug's Life, A (F) [f1] (NTSC).z64" size 12582912 crc 32a7f761 )
-	rom ( name "Bug's Life, A (G) [!].z64" size 12582912 crc 15a32836 )
-	rom ( name "Bug's Life, A (G) [f1] (NTSC).z64" size 12582912 crc acb166ff )
-	rom ( name "Bug's Life, A (I) [!].z64" size 12582912 crc 2d118764 )
-	rom ( name "Bug's Life, A (U) [!].z64" size 12582912 crc cf2ea0b6 )
-	rom ( name "Bug's Life, A (U) [b1].z64" size 12582912 crc df844e51 )
-	rom ( name "Bug's Life, A (U) [b1][f1] (PAL).z64" size 12582912 crc 478ce66f )
-	rom ( name "Bug's Life, A (U) [f1] (PAL).z64" size 12582912 crc 57260888 )
-	rom ( name "Bug's Life, A (U) [t1].z64" size 12582912 crc 4ea0808a )
-	rom ( name "Bug's Life, A (U) [t2].z64" size 12582912 crc 5e0a6e6d )
-)
-
-game (
-	name "Bust-A-Move '99"
-	description "Bust-A-Move '99"
-	rom ( name "Bust-A-Move '99 (U) [!].z64" size 8388608 crc c285fc69 )
-	rom ( name "Bust-A-Move '99 (U) [b1].z64" size 8388608 crc f7ced91e )
-	rom ( name "Bust-A-Move '99 (U) [f1] (PAL).z64" size 8388608 crc 3cd99896 )
-	rom ( name "Bust-A-Move 3 DX (E) [!].z64" size 8388608 crc 95595889 )
-	rom ( name "Bust-A-Move 3 DX (E) [b1].z64" size 8388608 crc 414f160f )
-	rom ( name "Bust-A-Move 3 DX (E) [b2].z64" size 8388608 crc 935dda42 )
-	rom ( name "Bust-A-Move 3 DX (E) [b3].z64" size 8388608 crc 0f94b85d )
-	rom ( name "Bust-A-Move 3 DX (E) [f1] (NTSC100%).z64" size 8388608 crc db82f6db )
-	rom ( name "Bust-A-Move 3 DX (E) [f2] (NTSC-Z64).z64" size 8388608 crc 2837dd00 )
-	rom ( name "Bust-A-Move 3 DX (E) [f3] (NTSC).z64" size 8388608 crc 58533b87 )
-	rom ( name "Puzzle Bobble 64 (J) [!].z64" size 8388608 crc ea837423 )
-	rom ( name "Puzzle Bobble 64 (J) [f1] (PAL).z64" size 8388608 crc e120eb0c )
-	rom ( name "Puzzle Bobble 64 (J) [f2] (PAL).z64" size 8388608 crc d1f3984a )
-)
-
-game (
-	name "Bust-A-Move 2 - Arcade Edition"
-	description "Bust-A-Move 2 - Arcade Edition"
-	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [!].z64" size 8388608 crc 04731bab )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [b1].z64" size 8388608 crc c352df3f )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [!].z64" size 8388608 crc 9f54cd2d )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b1].z64" size 8388608 crc e79f0acb )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b2].z64" size 8388608 crc 948a1cfb )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b3].z64" size 8388608 crc 96325fc3 )
-	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b4].z64" size 7864320 crc 4dfb7a1d )
-)
-
-game (
-	name "California Speed"
-	description "California Speed"
-	rom ( name "California Speed (U) [!].z64" size 16777216 crc 6f6262cb )
-	rom ( name "California Speed (U) [f1] (Country Check).z64" size 16777216 crc f9d470e2 )
-	rom ( name "California Speed (U) [f2] (PAL).z64" size 16777216 crc 1c41238a )
-	rom ( name "California Speed (U) [t1].z64" size 16777216 crc c8250c69 )
-)
-
-game (
-	name "Carmageddon 64"
-	description "Carmageddon 64"
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!].z64" size 16777216 crc 8569f1a0 )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [f1] (NTSC).z64" size 16777216 crc 9f85cc8c )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!].z64" size 16777216 crc 8036f999 )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [b1].z64" size 16777216 crc 5e71223e )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f1] (NTSC).z64" size 16777216 crc 3221b1d4 )
-	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f2] (NTSC).z64" size 16777216 crc e1ee0473 )
-	rom ( name "Carmageddon 64 (U) [!].z64" size 16777216 crc 10c6a0a1 )
-)
-
-game (
-	name Castlevania
-	description "Castlevania"
-	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!].z64" size 12582912 crc e349cfec )
-	rom ( name "Castlevania (E) (M3) [!].z64" size 12582912 crc d9d76235 )
-	rom ( name "Castlevania (E) (M3) [b1].z64" size 12582912 crc 8e6e53a0 )
-	rom ( name "Castlevania (E) (M3) [t1].z64" size 12582912 crc 3c9d1ed5 )
-	rom ( name "Castlevania (U) (V1.0) [!].z64" size 12582912 crc 8b0d3c00 )
-	rom ( name "Castlevania (U) (V1.0) [b1].z64" size 12350745 crc 724a540e )
-	rom ( name "Castlevania (U) (V1.0) [b2].z64" size 12582912 crc 16db3687 )
-	rom ( name "Castlevania (U) (V1.0) [b3].z64" size 12582912 crc 567e1271 )
-	rom ( name "Castlevania (U) (V1.0) [b4].z64" size 12582912 crc e6036665 )
-	rom ( name "Castlevania (U) (V1.0) [t1].z64" size 12582912 crc 5263b185 )
-	rom ( name "Castlevania (U) (V1.0) [t2].z64" size 12582912 crc fe5d8b7a )
-	rom ( name "Castlevania (U) (V1.0) [t3].z64" size 12582912 crc e1d6cb91 )
-	rom ( name "Castlevania (U) (V1.0) [t4].z64" size 12582912 crc 1f95ef27 )
-	rom ( name "Castlevania (U) (V1.2) [!].z64" size 12582912 crc 83032d97 )
-)
-
-game (
-	name "Castlevania - Legacy of Darkness"
-	description "Castlevania - Legacy of Darkness"
-	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!].z64" size 16777216 crc ff009c21 )
-	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [!].z64" size 16777216 crc 12ab9b45 )
-	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [h1C].z64" size 16777216 crc 12548aa1 )
-	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [o1].z64" size 16777220 crc 7c1a0085 )
-	rom ( name "Castlevania - Legacy of Darkness (U) [!].z64" size 16777216 crc ab13028c )
-	rom ( name "Castlevania - Legacy of Darkness (U) [b1].z64" size 16777216 crc eac65ca0 )
-	rom ( name "Castlevania - Legacy of Darkness (U) [f1] (PAL).z64" size 16777216 crc 72fb900a )
-	rom ( name "Castlevania - Legacy of Darkness (U) [f2] (PAL).z64" size 16777216 crc 0c6cdf58 )
-	rom ( name "Castlevania - Legacy of Darkness (U) [t1].z64" size 16777216 crc e49f3c4d )
-)
-
-game (
-	name "CD64 BIOS"
-	description "CD64 BIOS"
-	rom ( name "CD64 BIOS Direct-Upgrade V1.08.bin" size 8388608 crc 5c4fd81f )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.09.bin" size 8388608 crc b271ff1b )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.10.bin" size 8388608 crc 7bf28f41 )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.11.bin" size 8388608 crc 711774c5 )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.13.bin" size 8388608 crc fdeff9e8 )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.20.bin" size 8388608 crc 26d1d2c7 )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.21.bin" size 8388608 crc f0e0b2a2 )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.23.bin" size 8388608 crc 52ee53ca )
-	rom ( name "CD64 BIOS Direct-Upgrade V1.30.bin" size 8388608 crc 65a164e1 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.08 [a1].bin" size 262144 crc c3e77b21 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.08.bin" size 262144 crc 4c84afaa )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.09.bin" size 262144 crc 6b96b2b4 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.10.bin" size 262144 crc 283780f1 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Even Bytes).bin" size 131072 crc e6598dbd )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Odd Bytes).bin" size 131072 crc 4443f4a3 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.11.bin" size 262144 crc ec7a03ec )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Even Bytes).bin" size 131072 crc 73cf6202 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Odd Bytes).bin" size 131072 crc 12f79a82 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.21.bin" size 262144 crc e993d4b3 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Even Bytes).bin" size 131072 crc b29dbb3f )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Odd Bytes).bin" size 131072 crc 09d3eb60 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.23.bin" size 262144 crc c3a5a1fb )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Even Bytes).bin" size 131072 crc 41ce5465 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Odd Bytes).bin" size 131072 crc abee5982 )
-	rom ( name "CD64 BIOS EEPROM-Burner V1.30.bin" size 262144 crc 011cf143 )
-)
-
-game (
-	name "Centre Court Tennis"
-	description "Centre Court Tennis"
-	rom ( name "Centre Court Tennis (E) [!].z64" size 12582912 crc b1d26f39 )
-	rom ( name "Centre Court Tennis (E) [f1] (NTSC).z64" size 12582912 crc d70f7b00 )
-	rom ( name "Centre Court Tennis (E) [h1C].z64" size 12582912 crc f928608b )
-	rom ( name "Let's Smash Tennis (J) [!].z64" size 12582912 crc 455a1770 )
-)
-
-game (
-	name "Chameleon Twist"
-	description "Chameleon Twist"
-	rom ( name "Chameleon Twist (E) [!].z64" size 12582912 crc 587dd983 )
-	rom ( name "Chameleon Twist (E) [b1].z64" size 16777216 crc 68cead3e )
-	rom ( name "Chameleon Twist (E) [b2].z64" size 11534336 crc f3772611 )
-	rom ( name "Chameleon Twist (E) [b3].z64" size 12582912 crc 7618134d )
-	rom ( name "Chameleon Twist (E) [f1] (NTSC).z64" size 12582912 crc 1b8df49a )
-	rom ( name "Chameleon Twist (E) [o1].z64" size 16777216 crc e060ad47 )
-	rom ( name "Chameleon Twist (E) [o2].z64" size 12582916 crc 7d6a36e8 )
-	rom ( name "Chameleon Twist (J) [!].z64" size 12582912 crc 6395c475 )
-	rom ( name "Chameleon Twist (U) [!].z64" size 12582912 crc 7fe024c9 )
-	rom ( name "Chameleon Twist (U) [b1].z64" size 12582912 crc 566543ce )
-	rom ( name "Chameleon Twist (U) [b2].z64" size 12582912 crc 5d928b73 )
-	rom ( name "Chameleon Twist (U) [b3].z64" size 12582912 crc f654adcb )
-	rom ( name "Chameleon Twist (U) [t1].z64" size 12582912 crc f6537276 )
-)
-
-game (
-	name "Chameleon Twist 2"
-	description "Chameleon Twist 2"
-	rom ( name "Chameleon Twist 2 (E) [!].z64" size 8388608 crc 3b53519f )
-	rom ( name "Chameleon Twist 2 (E) [b1].z64" size 8388608 crc 9da3fd63 )
-	rom ( name "Chameleon Twist 2 (J) [!].z64" size 8388608 crc 5677eaef )
-	rom ( name "Chameleon Twist 2 (J) [b1].z64" size 12582912 crc 23857073 )
-	rom ( name "Chameleon Twist 2 (J) [b2].z64" size 8388608 crc 84cbd297 )
-	rom ( name "Chameleon Twist 2 (J) [b3].z64" size 8388608 crc f6839d99 )
-	rom ( name "Chameleon Twist 2 (J) [b4].z64" size 8388608 crc 8ff29073 )
-	rom ( name "Chameleon Twist 2 (J) [o1].z64" size 12582912 crc 08287cc8 )
-	rom ( name "Chameleon Twist 2 (J) [o2].z64" size 12582912 crc 8dfe135a )
-	rom ( name "Chameleon Twist 2 (J) [t1].z64" size 12582912 crc 10a24d0c )
-	rom ( name "Chameleon Twist 2 (U) [!].z64" size 8388608 crc cdf26d67 )
-	rom ( name "Chameleon Twist 2 (U) [t1].z64" size 8388608 crc ac3d5715 )
-)
-
-game (
-	name "Charlie Blast's Territory"
-	description "Charlie Blast's Territory"
-	rom ( name "Charlie Blast's Territory (E) [!].z64" size 4194304 crc 82c1d9e1 )
-	rom ( name "Charlie Blast's Territory (E) [o1].z64" size 8388608 crc 2562fc53 )
-	rom ( name "Charlie Blast's Territory (U) [!].z64" size 4194304 crc ba4e65a8 )
-	rom ( name "Charlie Blast's Territory (U) [hI].z64" size 8388608 crc 87935eaf )
-	rom ( name "Charlie Blast's Territory (U) [hIR].z64" size 8388608 crc 5c1ea306 )
-)
-
-game (
-	name "Chopper Attack"
-	description "Chopper Attack"
-	rom ( name "Chopper Attack (E) [!].z64" size 8388608 crc c1dcd7ab )
-	rom ( name "Chopper Attack (E) [b1].z64" size 8388608 crc 2fd90225 )
-	rom ( name "Chopper Attack (E) [t1].z64" size 8388608 crc 83a7d582 )
-	rom ( name "Chopper Attack (U) [!].z64" size 8388608 crc aa5d76a9 )
-	rom ( name "Chopper Attack (U) [b1].z64" size 8388608 crc 10296792 )
-	rom ( name "Chopper Attack (U) [b2].z64" size 8388608 crc 12e48f07 )
-	rom ( name "Chopper Attack (U) [b3].z64" size 8388608 crc ad84b711 )
-	rom ( name "Chopper Attack (U) [b4].z64" size 8388608 crc 6abd62c4 )
-	rom ( name "Chopper Attack (U) [b5].z64" size 8388608 crc fbf44189 )
-	rom ( name "Chopper Attack (U) [b6].z64" size 8388608 crc 0182ef2e )
-	rom ( name "Chopper Attack (U) [t1].z64" size 8388608 crc 521f2bb5 )
-	rom ( name "Wild Choppers (J) [!].z64" size 8388608 crc d6136dc5 )
-	rom ( name "Wild Choppers (J) [b1].z64" size 8388608 crc 6f07a665 )
-	rom ( name "Wild Choppers (J) [b2].z64" size 8388608 crc 12ec9b86 )
-	rom ( name "Wild Choppers (J) [b3].z64" size 8126464 crc 71726557 )
-	rom ( name "Wild Choppers (J) [o1].z64" size 8388808 crc e866d832 )
-	rom ( name "Wild Choppers (J) [t1].z64" size 8388608 crc 3ca3e096 )
-)
-
-game (
-	name "Choro Q 64 II - Hacha Mecha Grand Prix Race"
-	description "Choro Q 64 II - Hacha Mecha Grand Prix Race"
-	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!].z64" size 12582912 crc 5c565ad6 )
-)
-
-game (
-	name "Chou Kuukan Night Pro Yakyuu King"
-	description "Chou Kuukan Night Pro Yakyuu King"
-	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [!].z64" size 8388608 crc 5f75634e )
-	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [b1].z64" size 8388608 crc 61a9756b )
-	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [h1C].z64" size 8388608 crc 64e730dc )
-)
-
-game (
-	name "Chou Kuukan Night Pro Yakyuu King 2"
-	description "Chou Kuukan Night Pro Yakyuu King 2"
-	rom ( name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!].z64" size 16777216 crc 479643e2 )
-)
-
-game (
-	name "Clay Fighter - Sculptor's Cut"
-	description "Clay Fighter - Sculptor's Cut"
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [!].z64" size 16777216 crc 434de656 )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [b1].z64" size 16777216 crc 25fadf5e )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [b2].z64" size 16777216 crc 11487231 )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [h1C].z64" size 16777216 crc 567bfec1 )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [h2C].z64" size 16777216 crc 432e391a )
-	rom ( name "Clay Fighter - Sculptor's Cut (U) [t1].z64" size 16777216 crc f8afa913 )
-)
-
-game (
-	name "Clay Fighter 63 1-3"
-	description "Clay Fighter 63 1-3"
-	rom ( name "Clay Fighter 63 1-3 (Beta) [!].z64" size 12582912 crc 18f4166a )
-	rom ( name "Clay Fighter 63 1-3 (Beta) [b1].z64" size 12582912 crc 0ba68b38 )
-	rom ( name "Clay Fighter 63 1-3 (E) [!].z64" size 12582912 crc 82263e5d )
-	rom ( name "Clay Fighter 63 1-3 (E) [b1][h1C].z64" size 12582912 crc 5e0dd087 )
-	rom ( name "Clay Fighter 63 1-3 (E) [h1C].z64" size 12582912 crc 41f36719 )
-	rom ( name "Clay Fighter 63 1-3 (U) [!].z64" size 12582912 crc 3fa647dd )
-	rom ( name "Clay Fighter 63 1-3 (U) [b1].z64" size 4465600 crc 3c7bc60d )
-	rom ( name "Clay Fighter 63 1-3 (U) [b2].z64" size 12582912 crc 81428075 )
-	rom ( name "Clay Fighter 63 1-3 (U) [o1].z64" size 16777216 crc 9c481c79 )
-	rom ( name "Clay Fighter 63 1-3 (U) [o2].z64" size 16777216 crc 2ea4420a )
-)
-
-game (
-	name "Command & Conquer"
-	description "Command & Conquer"
-	rom ( name "Command & Conquer (E) (M2) [!].z64" size 33554432 crc f3da8a26 )
-	rom ( name "Command & Conquer (E) (M2) [b1].z64" size 16994304 crc 8ae902f9 )
-	rom ( name "Command & Conquer (E) (M2) [b2].z64" size 33554432 crc e155637c )
-	rom ( name "Command & Conquer (E) (M2) [b3].z64" size 33554436 crc e465fa53 )
-	rom ( name "Command & Conquer (E) (M2) [f1] (Z64).z64" size 33554432 crc 8817f44c )
-	rom ( name "Command & Conquer (G) [!].z64" size 33554432 crc 6cd0fc99 )
-	rom ( name "Command & Conquer (G) [f1] (Z64).z64" size 33554432 crc 88a500d7 )
-	rom ( name "Command & Conquer (U) [!].z64" size 33554432 crc 3e9069ef )
-	rom ( name "Command & Conquer (U) [b1].z64" size 33554432 crc 528347bf )
-	rom ( name "Command & Conquer (U) [f1] (Z64).z64" size 33554432 crc e745c5d8 )
-)
-
-game (
-	name "Conker's Bad Fur Day"
-	description "Conker's Bad Fur Day"
-	rom ( name "Conker's Bad Fur Day (E) [!].z64" size 67108864 crc 4667cfe9 )
-	rom ( name "Conker's Bad Fur Day (U) [!].z64" size 67108864 crc ce8cc172 )
-)
-
-game (
-	name "Cruis'n Exotica"
-	description "Cruis'n Exotica"
-	rom ( name "Cruis'n Exotica (U) [!].z64" size 16777216 crc 867a2ced )
-	rom ( name "Cruis'n Exotica (U) [t1].z64" size 16777216 crc 3dea85d6 )
-)
-
-game (
-	name "Cruis'n USA"
-	description "Cruis'n USA"
-	rom ( name "Cruis'n USA (E) [!].z64" size 8388608 crc 8935a8d9 )
-	rom ( name "Cruis'n USA (U) (V1.0) [!].z64" size 8388608 crc 5238b727 )
-	rom ( name "Cruis'n USA (U) (V1.0) [b1].z64" size 8388608 crc 92f6809f )
-	rom ( name "Cruis'n USA (U) (V1.0) [b2].z64" size 8388608 crc 97899ecc )
-	rom ( name "Cruis'n USA (U) (V1.0) [b3].z64" size 8388608 crc d1e1ffb4 )
-	rom ( name "Cruis'n USA (U) (V1.0) [b4].z64" size 8388608 crc b93d9ce6 )
-	rom ( name "Cruis'n USA (U) (V1.0) [b5].z64" size 8388608 crc 05d10db5 )
-	rom ( name "Cruis'n USA (U) (V1.0) [T+Ita0.40].z64" size 8388608 crc 4512760e )
-	rom ( name "Cruis'n USA (U) (V1.1) [!].z64" size 8388608 crc 4655ba2d )
-	rom ( name "Cruis'n USA (U) (V1.2) [!].z64" size 8388608 crc c3b52701 )
+	name "Yoshi Story (J) [f1]"
+	description "Yoshi Story (J) [f1]"
+	rom ( name "Yoshi Story (J) [f1].z64" crc 8A89904C )
 )
 
 game (
-	name "Cruis'n World"
-	description "Cruis'n World"
-	rom ( name "Cruis'n World (E) [!].z64" size 12582912 crc e46ce079 )
-	rom ( name "Cruis'n World (E) [b1].z64" size 12582912 crc c16d2d71 )
-	rom ( name "Cruis'n World (E) [b2].z64" size 12582912 crc 3b713e52 )
-	rom ( name "Cruis'n World (E) [f1].z64" size 12582912 crc 8df63936 )
-	rom ( name "Cruis'n World (E) [f2].z64" size 12582912 crc 82f27646 )
-	rom ( name "Cruis'n World (E) [f3] (NTSC).z64" size 12582912 crc 248f00c9 )
-	rom ( name "Cruis'n World (U) [!].z64" size 12582912 crc a123769f )
-	rom ( name "Cruis'n World (U) [b1].z64" size 12582912 crc 0274cbfc )
-	rom ( name "Cruis'n World (U) [b2].z64" size 4100096 crc 10109820 )
-	rom ( name "Cruis'n World (U) [b3].z64" size 12582916 crc c30ed9f6 )
-	rom ( name "Cruis'n World (U) [f1].z64" size 12582912 crc 048791c6 )
-	rom ( name "Cruis'n World (U) [o1].z64" size 12582916 crc 35fbeafe )
-)
-
-game (
-	name "Custom Robo"
-	description "Custom Robo"
-	rom ( name "Custom Robo (J) [!].z64" size 16777216 crc f2fae693 )
-)
-
-game (
-	name "Custom Robo V2"
-	description "Custom Robo V2"
-	rom ( name "Custom Robo V2 (J) [!].z64" size 16777216 crc c8201454 )
-)
-
-game (
-	name CyberTiger
-	description "CyberTiger"
-	rom ( name "CyberTiger (E) [!].z64" size 16777216 crc 7319d9af )
-	rom ( name "CyberTiger (U) [!].z64" size 16777216 crc 10cc5f15 )
-)
-
-game (
-	name "Dance Dance Revolution - Disney Dancing Museum"
-	description "Dance Dance Revolution - Disney Dancing Museum"
-	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [!].z64" size 25165824 crc 3c13fbcf )
-	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o1].z64" size 33554432 crc 43ee0117 )
-	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o2].z64" size 25690112 crc 0feed8b3 )
-)
-
-game (
-	name "Dark Rift"
-	description "Dark Rift"
-	rom ( name "Dark Rift (E) [!].z64" size 8388608 crc d2a19c71 )
-	rom ( name "Dark Rift (E) [b1].z64" size 8429660 crc 632e1937 )
-	rom ( name "Dark Rift (U) [!].z64" size 8388608 crc 83fd222f )
-	rom ( name "Dark Rift (U) [t1].z64" size 8388608 crc 1329d6bd )
-	rom ( name "Space Dynamites (J) [!].z64" size 8388608 crc 8cb4b948 )
-	rom ( name "Space Dynamites (J) [b1].z64" size 8388608 crc 537d2e2f )
-)
-
-game (
-	name "Deadly Arts"
-	description "Deadly Arts"
-	rom ( name "Deadly Arts (U) [!].z64" size 12582912 crc 3db8130e )
-	rom ( name "Deadly Arts (U) [b1].z64" size 12582912 crc cdecb164 )
-	rom ( name "G.A.S.P!! Fighter's NEXTream (E) [!].z64" size 12582912 crc 5aa63b04 )
-	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [!].z64" size 12582912 crc 6ead2d89 )
-	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [o1].z64" size 16777216 crc f0532eaf )
-)
-
-game (
-	name "Densha de Go! 64"
-	description "Densha de Go! 64"
-	rom ( name "Densha de Go! 64 (J) [!].z64" size 33554432 crc 7bfc71e0 )
-	rom ( name "Densha de Go! 64 (J) [f1] (PAL).z64" size 33554432 crc ffc76f35 )
-)
-
-game (
-	name "Derby Stallion 64"
-	description "Derby Stallion 64"
-	rom ( name "Derby Stallion 64 (J) (Beta).z64" size 33554432 crc 8ec950a9 )
-	rom ( name "Derby Stallion 64 (J) [!].z64" size 33554432 crc a9417994 )
-)
-
-game (
-	name "Destruction Derby 64"
-	description "Destruction Derby 64"
-	rom ( name "Destruction Derby 64 (E) (M3) [!].z64" size 16777216 crc 7ad9e429 )
-	rom ( name "Destruction Derby 64 (U) [!].z64" size 16777216 crc 38f1b5d9 )
-	rom ( name "Destruction Derby 64 (U) [f1] (PAL).z64" size 16777216 crc ed1ac18c )
-	rom ( name "Destruction Derby 64 (U) [t1].z64" size 16777216 crc 60485dfb )
-)
-
-game (
-	name "Dezaemon 3D"
-	description "Dezaemon 3D"
-	rom ( name "Dezaemon 3D (J) [!].z64" size 16777216 crc 9e978488 )
-	rom ( name "Dezaemon 3D (J) [b1].z64" size 12582912 crc 9de8a036 )
-	rom ( name "Dezaemon 3D (J) [b1][t1].z64" size 16777216 crc 9bbad86e )
-	rom ( name "Dezaemon 3D (J) [b2].z64" size 16777216 crc 573b12d2 )
-	rom ( name "Dezaemon 3D (J) [t1].z64" size 16777216 crc 7a615c39 )
-)
-
-game (
-	name "Diddy Kong Racing"
-	description "Diddy Kong Racing"
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [!].z64" size 12582912 crc 4a13323c )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [f1].z64" size 12582912 crc a95a5572 )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [o1].z64" size 16777216 crc 417c71d7 )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [!].z64" size 12582912 crc b1e87639 )
-	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64).z64" size 12582912 crc 7db6c3e2 )
-	rom ( name "Diddy Kong Racing (J) [f1] (Z64).z64" size 12582912 crc 60bd0e39 )
-	rom ( name "Diddy Kong Racing (J).z64" size 12582912 crc b566fb94 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [!].z64" size 12582912 crc eb759206 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b1].z64" size 16777216 crc c9ef2818 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b2].z64" size 11534336 crc e7f77779 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b3].z64" size 3440640 crc 97e53bd6 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b4].z64" size 11534336 crc 18138847 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b5].z64" size 16777216 crc 5e7aa4bc )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b6].z64" size 12582912 crc f26051dd )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b7].z64" size 16777216 crc ff62c5e1 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1].z64" size 12582912 crc 52b44e7a )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1][h1C].z64" size 12582912 crc 173bd1b9 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f2].z64" size 16777216 crc 3bf35f08 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f3].z64" size 12582912 crc 692fe6c3 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f4].z64" size 12582912 crc f09727f4 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1].z64" size 16777216 crc 36c92d99 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1][f1].z64" size 16777216 crc fd3dc0d2 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o2].z64" size 16777216 crc 17ef30ca )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil].z64" size 12582912 crc 7dab6850 )
-	rom ( name "Diddy Kong Racing (U) (M2) (V1.1) [!].z64" size 12582912 crc 5acca298 )
-)
-
-game (
-	name "Disney's Donald Duck - Goin' Quackers"
-	description "Disney's Donald Duck - Goin' Quackers"
-	rom ( name "Disney's Donald Duck - Goin' Quackers (U) [!].z64" size 20971520 crc 7fdec270 )
-	rom ( name "Donald Duck - Quack Attack (E) (M5) [!].z64" size 20971520 crc c4b0d9ea )
-	rom ( name "Donald Duck - Quack Attack (E) (M5) [b1].z64" size 20971520 crc 0097d5cf )
-	rom ( name "Donald Duck - Quack Attack (E) (M5) [f1] (NTSC).z64" size 20971520 crc 18bb3891 )
-)
-
-game (
-	name "Disney's Tarzan"
-	description "Disney's Tarzan"
-	rom ( name "Disney's Tarzan (E) [!].z64" size 16777216 crc 7737ed9e )
-	rom ( name "Disney's Tarzan (E) [h1C].z64" size 16777216 crc b9c1b4da )
-	rom ( name "Disney's Tarzan (F) [!].z64" size 16777216 crc 99c7649d )
-	rom ( name "Disney's Tarzan (G) [!].z64" size 16777216 crc 0b0954c5 )
-	rom ( name "Disney's Tarzan (G) [h1C].z64" size 16777216 crc c5ff0d81 )
-	rom ( name "Disney's Tarzan (U) [!].z64" size 16777216 crc c38ca641 )
-	rom ( name "Disney's Tarzan (U) [f1] (PAL).z64" size 16777216 crc 1f710dbf )
-	rom ( name "Disney's Tarzan (U) [f2] (PAL).z64" size 16777216 crc 19f56474 )
-	rom ( name "Disney's Tarzan (U) [t1].z64" size 16777216 crc 15f5f6b9 )
-)
-
-game (
-	name "Doctor V64 BIOS"
-	description "Doctor V64 BIOS"
-	rom ( name "Doctor V64 BIOS V1.01.bin" size 262144 crc a189032e )
-	rom ( name "Doctor V64 BIOS V1.02.bin" size 262144 crc 4d8c07be )
-	rom ( name "Doctor V64 BIOS V1.03.bin" size 262144 crc c701737c )
-	rom ( name "Doctor V64 BIOS V1.04.bin" size 262144 crc 02367435 )
-	rom ( name "Doctor V64 BIOS V1.05.bin" size 262144 crc 532080b9 )
-	rom ( name "Doctor V64 BIOS V1.08.bin" size 262144 crc 2994d961 )
-	rom ( name "Doctor V64 BIOS V1.09.bin" size 262144 crc 7924f6ce )
-	rom ( name "Doctor V64 BIOS V1.10.bin" size 262144 crc de489e90 )
-	rom ( name "Doctor V64 BIOS V1.10r (RBubba Hack).bin" size 262144 crc 2b8919f0 )
-	rom ( name "Doctor V64 BIOS V1.11.bin" size 262144 crc 61a2d42c )
-	rom ( name "Doctor V64 BIOS V1.21.bin" size 262144 crc f5200388 )
-	rom ( name "Doctor V64 BIOS V1.22.bin" size 262144 crc 8e5050d0 )
-	rom ( name "Doctor V64 BIOS V1.30.bin" size 262144 crc 520238c4 )
-	rom ( name "Doctor V64 BIOS V1.31 (Blue).bin" size 262144 crc 21ec5148 )
-	rom ( name "Doctor V64 BIOS V1.31.bin" size 262144 crc 0c500d9b )
-	rom ( name "Doctor V64 BIOS V1.32.bin" size 262144 crc dad115ef )
-	rom ( name "Doctor V64 BIOS V1.33.bin" size 262144 crc 083a7ccd )
-	rom ( name "Doctor V64 BIOS V1.33b.bin" size 262144 crc 6f4f23df )
-	rom ( name "Doctor V64 BIOS V1.40.bin" size 262144 crc 05a09ee2 )
-	rom ( name "Doctor V64 BIOS V1.40b.bin" size 262144 crc 62d5c1f0 )
-	rom ( name "Doctor V64 BIOS V1.41.bin" size 262144 crc 370e1675 )
-	rom ( name "Doctor V64 BIOS V1.41b.bin" size 262144 crc 507b4967 )
-	rom ( name "Doctor V64 BIOS V1.50.bin" size 262144 crc bc7e2e16 )
-	rom ( name "Doctor V64 BIOS V1.51.bin" size 262144 crc c9ccee6f )
-	rom ( name "Doctor V64 BIOS V1.52 (CH2 Hack).bin" size 262144 crc a2aa3469 )
-	rom ( name "Doctor V64 BIOS V1.52.bin" size 262144 crc 40217611 )
-	rom ( name "Doctor V64 BIOS V1.53.bin" size 262144 crc 7bc1107e )
-	rom ( name "Doctor V64 BIOS V1.60.bin" size 262144 crc ac51f894 )
-	rom ( name "Doctor V64 BIOS V1.61.bin" size 262144 crc a0ab9232 )
-	rom ( name "Doctor V64 BIOS V1.70.bin" size 262144 crc addcebec )
-	rom ( name "Doctor V64 BIOS V1.71.bin" size 262144 crc 4781b044 )
-	rom ( name "Doctor V64 BIOS V1.72.bin" size 262144 crc 624f8950 )
-	rom ( name "Doctor V64 BIOS V1.73.bin" size 262144 crc bde9c452 )
-	rom ( name "Doctor V64 BIOS V1.74 (Revive Version).bin" size 262144 crc 3699334a )
-	rom ( name "Doctor V64 BIOS V1.74.bin" size 262144 crc 5055b5ba )
-	rom ( name "Doctor V64 BIOS V1.75.bin" size 262144 crc 48baf170 )
-	rom ( name "Doctor V64 BIOS V1.76.bin" size 262144 crc 6ce67878 )
-	rom ( name "Doctor V64 BIOS V1.80.bin" size 262144 crc d3c94e60 )
-	rom ( name "Doctor V64 BIOS V1.81.bin" size 262144 crc a463f12f )
-	rom ( name "Doctor V64 BIOS V1.82.bin" size 262144 crc 1e115fd4 )
-	rom ( name "Doctor V64 BIOS V1.83.bin" size 262144 crc d6a8d690 )
-	rom ( name "Doctor V64 BIOS V1.90.bin" size 262144 crc 25d2dd26 )
-	rom ( name "Doctor V64 BIOS V1.91.bin" size 262144 crc 979f7092 )
-	rom ( name "Doctor V64 BIOS V1.92.bin" size 262144 crc fbb5f11c )
-	rom ( name "Doctor V64 BIOS V1.93.bin" size 262144 crc 5133779b )
-	rom ( name "Doctor V64 BIOS V1.94.bin" size 262144 crc d223ce48 )
-	rom ( name "Doctor V64 BIOS V2.00.bin" size 262144 crc 76831784 )
-	rom ( name "Doctor V64 BIOS V2.00b.bin" size 262144 crc 201b503f )
-	rom ( name "Doctor V64 BIOS V2.01 (Red).bin" size 262144 crc 59d5f118 )
-	rom ( name "Doctor V64 BIOS V2.01.bin" size 262144 crc c7d5d511 )
-	rom ( name "Doctor V64 BIOS V2.01b.bin" size 262144 crc 0276da37 )
-	rom ( name "Doctor V64 BIOS V2.02.bin" size 262144 crc 16a08fdc )
-	rom ( name "Doctor V64 BIOS V2.02b.bin" size 262144 crc cc0caf09 )
-	rom ( name "Doctor V64 BIOS V2.03 (Black).bin" size 262144 crc 9e19ff85 )
-	rom ( name "Doctor V64 BIOS V2.03 (Blue).bin" size 262144 crc 07ca4d44 )
-	rom ( name "Doctor V64 BIOS V2.03 (Green).bin" size 262144 crc 8901df22 )
-	rom ( name "Doctor V64 BIOS V2.03 (Purple).bin" size 262144 crc 0dd22dc0 )
-	rom ( name "Doctor V64 BIOS V2.03 (Red).bin" size 262144 crc 4282f00d )
-	rom ( name "Doctor V64 BIOS V2.03.bin" size 262144 crc a37d13af )
-)
-
-game (
-	name "Donkey Kong 64"
-	description "Donkey Kong 64"
-	rom ( name "Donkey Kong 64 (E) [!].z64" size 33554432 crc a28c71c6 )
-	rom ( name "Donkey Kong 64 (E) [b1].z64" size 33554432 crc f33061a5 )
-	rom ( name "Donkey Kong 64 (E) [f1] (Boot&Save).z64" size 33554432 crc bb882fc7 )
-	rom ( name "Donkey Kong 64 (E) [f1] (Save).z64" size 33554432 crc 9bb8700a )
-	rom ( name "Donkey Kong 64 (J) [!].z64" size 33554432 crc 919f7e74 )
-	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [!].z64" size 33554432 crc c83dfa15 )
-	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b1].z64" size 33554432 crc ac26933f )
-	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b2].z64" size 25165824 crc 0dd55e97 )
-	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [f1] (PAL).z64" size 33554432 crc 4229dbd9 )
-	rom ( name "Donkey Kong 64 (U) [!].z64" size 33554432 crc d44b4fc6 )
-	rom ( name "Donkey Kong 64 (U) [b1].z64" size 33554432 crc 261b74e9 )
-	rom ( name "Donkey Kong 64 (U) [f1] (Save).z64" size 33554432 crc 15656cba )
-	rom ( name "Donkey Kong 64 (U) [f2].z64" size 33554432 crc b62f126f )
-	rom ( name "Donkey Kong 64 (U) [f3].z64" size 33554432 crc 35bede73 )
-)
-
-game (
-	name "Doom 64"
-	description "Doom 64"
-	rom ( name "Doom 64 (E) [!].z64" size 8388608 crc d985c356 )
-	rom ( name "Doom 64 (E) [b1].z64" size 8388608 crc 010b5830 )
-	rom ( name "Doom 64 (J) [!].z64" size 8388608 crc c8f3af5b )
-	rom ( name "Doom 64 (J) [b1].z64" size 8388608 crc c1dd12a2 )
-	rom ( name "Doom 64 (U) (V1.0) [!].z64" size 8388608 crc 5cc1ade6 )
-	rom ( name "Doom 64 (U) (V1.0) [b1].z64" size 8388612 crc 0d54c0f6 )
-	rom ( name "Doom 64 (U) (V1.0) [b2].z64" size 8388608 crc 0b3d7f30 )
-	rom ( name "Doom 64 (U) (V1.0) [o1].z64" size 16777216 crc de3b18be )
-	rom ( name "Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR].z64" size 10485760 crc 19347e61 )
-	rom ( name "Doom 64 (U) (V1.0) [t1].z64" size 8388608 crc c1909d70 )
-	rom ( name "Doom 64 (U) (V1.0) [t2].z64" size 8388608 crc e0d16283 )
-	rom ( name "Doom 64 (U) (V1.1) [!].z64" size 8388608 crc 1d3a17b5 )
-)
-
-game (
-	name "Doraemon - Nobita to 3tsu no Seireiseki"
-	description "Doraemon - Nobita to 3tsu no Seireiseki"
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!].z64" size 8388608 crc 154e8b33 )
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b1].z64" size 8388608 crc d5e8b08d )
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b2].z64" size 8388608 crc afe97ca4 )
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b3].z64" size 8388608 crc eaf14ae6 )
-	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [t1].z64" size 8388608 crc e31dadbd )
-)
-
-game (
-	name "Doraemon 2 - Nobita to Hikari no Shinden"
-	description "Doraemon 2 - Nobita to Hikari no Shinden"
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!].z64" size 12582912 crc 0c1a0c38 )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b1].z64" size 12582912 crc 3a0bf1d5 )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b2].z64" size 12582912 crc 50d15dc8 )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f1] (PAL).z64" size 12582912 crc f3fc6987 )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f2].z64" size 12582912 crc fd5154ed )
-	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [t1].z64" size 12582912 crc 5204af6d )
-)
-
-game (
-	name "Doraemon 3 - Nobita no Machi SOS!"
-	description "Doraemon 3 - Nobita no Machi SOS!"
-	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [!].z64" size 16777216 crc d3b68be4 )
-	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC).z64" size 16777216 crc 92dfe338 )
-)
-
-game (
-	name "Doubutsu no Mori"
-	description "Doubutsu no Mori"
-	rom ( name "Doubutsu no Mori (J) [!].z64" size 16777216 crc 9503e3f1 )
-	rom ( name "Doubutsu no Mori (J) [T+Eng2007-03-22_Brandon Dixon].z64" size 16777216 crc 85b86420 )
-	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-08_Brandon Dixon].z64" size 16777216 crc 09daa322 )
-	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-09_Brandon Dixon].z64" size 16777216 crc fba629d1 )
-)
-
-game (
-	name "Dr. Mario 64"
-	description "Dr. Mario 64"
-	rom ( name "Dr. Mario 64 (U) [!].z64" size 4194304 crc a4701927 )
-)
-
-game (
-	name "Dual Heroes"
-	description "Dual Heroes"
-	rom ( name "Dual Heroes (E) [!].z64" size 12582912 crc 5a7e226b )
-	rom ( name "Dual Heroes (E) [b1].z64" size 12582912 crc 67d23ce6 )
-	rom ( name "Dual Heroes (E) [b2].z64" size 12582912 crc ef7a7e0b )
-	rom ( name "Dual Heroes (E) [f1] (NTSC).z64" size 12582912 crc 307afa61 )
-	rom ( name "Dual Heroes (J) [!].z64" size 12582912 crc 20f23dde )
-	rom ( name "Dual Heroes (J) [o1].z64" size 16777216 crc 28b291e9 )
-	rom ( name "Dual Heroes (J) [o2].z64" size 16777216 crc 5cb6f46c )
-	rom ( name "Dual Heroes (U) [!].z64" size 12582912 crc d09f4da8 )
-	rom ( name "Dual Heroes (U) [b1].z64" size 12582912 crc 211c0cde )
-)
-
-game (
-	name "Duck Dodgers Starring Daffy Duck"
-	description "Duck Dodgers Starring Daffy Duck"
-	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [!].z64" size 16777216 crc 3177a905 )
-	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [t1].z64" size 16777216 crc 40f0c9d8 )
-	rom ( name "Looney Tunes - Duck Dodgers (E) (M6) [!].z64" size 16777216 crc c61f6bb9 )
-)
-
-game (
-	name "Duke Nukem - ZER0 H0UR"
-	description "Duke Nukem - ZER0 H0UR"
-	rom ( name "Duke Nukem - ZER0 H0UR (E) [!].z64" size 33554432 crc ea82f037 )
-	rom ( name "Duke Nukem - ZER0 H0UR (E) [f1] (NTSC).z64" size 33554432 crc 99efd6cd )
-	rom ( name "Duke Nukem - ZER0 H0UR (F) [!].z64" size 33554432 crc 7ecdfb28 )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [!].z64" size 33554432 crc 9a3258d7 )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [b1].z64" size 33555621 crc 5bc8b0d4 )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [b2].z64" size 33554454 crc 197b34d9 )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [b3].z64" size 33554432 crc bff139c6 )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [b4].z64" size 33554432 crc 06329ecd )
-	rom ( name "Duke Nukem - ZER0 H0UR (U) [t1].z64" size 33554432 crc 50ac825e )
-)
-
-game (
-	name "Duke Nukem 64"
-	description "Duke Nukem 64"
-	rom ( name "Duke Nukem 64 (E) [!].z64" size 8388608 crc 3275adb0 )
-	rom ( name "Duke Nukem 64 (E) [b1].z64" size 8388608 crc cc79fc6f )
-	rom ( name "Duke Nukem 64 (E) [o1].z64" size 33554432 crc 31a5c4be )
-	rom ( name "Duke Nukem 64 (F).z64" size 8388608 crc b9c9f07a )
-	rom ( name "Duke Nukem 64 (U) [!].z64" size 8388608 crc dbfd5a53 )
-	rom ( name "Duke Nukem 64 (U) [b1].z64" size 8650752 crc 9dce8136 )
-	rom ( name "Duke Nukem 64 (U) [b2].z64" size 8650752 crc 6ced6c75 )
-	rom ( name "Duke Nukem 64 (U) [b3].z64" size 33554432 crc 1f18823f )
-	rom ( name "Duke Nukem 64 (U) [h1C].z64" size 8388608 crc bf009e6e )
-	rom ( name "Duke Nukem 64 (U) [o1].z64" size 16777216 crc 20489410 )
-	rom ( name "Duke Nukem 64 (U) [t1].z64" size 8650752 crc 6a42d55d )
-	rom ( name "Duke Nukem 64 (U) [t2].z64" size 8650752 crc 5fdb41a9 )
-	rom ( name "Duke Nukem 64 (U) [t3].z64" size 8650752 crc 55fd0d4f )
-)
-
-game (
-	name "Earthworm Jim 3D"
-	description "Earthworm Jim 3D"
-	rom ( name "Earthworm Jim 3D (E) (M6) [!].z64" size 16777216 crc 61a56330 )
-	rom ( name "Earthworm Jim 3D (E) (M6) [b1].z64" size 16777216 crc e57b20dd )
-	rom ( name "Earthworm Jim 3D (U) [!].z64" size 16777216 crc 9e6579c5 )
-	rom ( name "Earthworm Jim 3D (U) [f1] (PAL).z64" size 16777216 crc 25285541 )
-	rom ( name "Earthworm Jim 3D (U) [hI].z64" size 16777216 crc 92e70880 )
-	rom ( name "Earthworm Jim 3D (U) [T+Rus].z64" size 16777216 crc c548f974 )
-	rom ( name "Earthworm Jim 3D (U) [t1].z64" size 16777216 crc 7d1f1297 )
-)
-
-game (
-	name "ECW Hardcore Revolution"
-	description "ECW Hardcore Revolution"
-	rom ( name "ECW Hardcore Revolution (E) [!].z64" size 33554432 crc be8feead )
-	rom ( name "ECW Hardcore Revolution (E) [b1].z64" size 33554436 crc 7340d982 )
-	rom ( name "ECW Hardcore Revolution (U) [!].z64" size 33554432 crc 36d368ef )
-)
-
-game (
-	name "Eikou no Saint Andrews"
-	description "Eikou no Saint Andrews"
-	rom ( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699d2d6 )
-	rom ( name "Eikou no Saint Andrews (J) [b1].z64" size 8388608 crc 2196a2db )
-	rom ( name "Eikou no Saint Andrews (J) [b2].z64" size 8388608 crc c348f53c )
-	rom ( name "Eikou no Saint Andrews (J) [h1C].z64" size 8388608 crc 6acae1f4 )
-	rom ( name "Eikou no Saint Andrews (J) [h2C].z64" size 8388608 crc a281b31f )
-)
-
-game (
-	name "Elmo's Letter Adventure"
-	description "Elmo's Letter Adventure"
-	rom ( name "Elmo's Letter Adventure (U) [!].z64" size 8388608 crc 92c3ba6f )
-)
-
-game (
-	name "Elmo's Number Journey"
-	description "Elmo's Number Journey"
-	rom ( name "Elmo's Number Journey (U) [!].z64" size 8388608 crc ea3b92d8 )
-)
-
-game (
-	name "Excitebike 64"
-	description "Excitebike 64"
-	rom ( name "Excitebike 64 (E) [!].z64" size 16777216 crc 0b881e60 )
-	rom ( name "Excitebike 64 (J) [!].z64" size 16777216 crc 03bfd065 )
-	rom ( name "Excitebike 64 (U) (Kiosk Demo) [!].z64" size 16777216 crc be6298b0 )
-	rom ( name "Excitebike 64 (U) [!].z64" size 16777216 crc fc459192 )
-	rom ( name "Excitebike 64 (U) [b1].z64" size 16777216 crc 60424b3c )
-	rom ( name "Excitebike 64 (U) [f1].z64" size 16777216 crc fbcae6f4 )
-	rom ( name "Excitebike 64 (U) [f2] (Save).z64" size 16777216 crc 53873696 )
-)
-
-game (
-	name Extreme-G
-	description "Extreme-G"
-	rom ( name "Extreme-G (E) (M5) [!].z64" size 8388608 crc 0b71b1ea )
-	rom ( name "Extreme-G (E) (M5) [b1].z64" size 8388608 crc 58d2d3f1 )
-	rom ( name "Extreme-G (E) (M5) [b2].z64" size 8388612 crc 43744fb5 )
-	rom ( name "Extreme-G (E) (M5) [b3].z64" size 8388608 crc 78abccb1 )
-	rom ( name "Extreme-G (E) (M5) [b4].z64" size 8388612 crc 8c017609 )
-	rom ( name "Extreme-G (E) (M5) [h1C].z64" size 8388608 crc 6e828955 )
-	rom ( name "Extreme-G (J) [!].z64" size 8388608 crc 750dc9a7 )
-	rom ( name "Extreme-G (U) [!].z64" size 8388608 crc 04cb74ec )
-	rom ( name "Extreme-G (U) [h1C].z64" size 8388608 crc 27969273 )
-	rom ( name "Extreme-G (U) [o1].z64" size 16777216 crc 4ef0ce44 )
-	rom ( name "Extreme-G (U) [t1].z64" size 8388608 crc 86cc5964 )
-)
-
-game (
-	name "Extreme-G XG2"
-	description "Extreme-G XG2"
-	rom ( name "Extreme-G XG2 (E) (M5) [!].z64" size 12582912 crc 1a57f416 )
-	rom ( name "Extreme-G XG2 (J) [!].z64" size 12582912 crc 7c8a36da )
-	rom ( name "Extreme-G XG2 (U) [!].z64" size 12582912 crc 81a4c28b )
-	rom ( name "Extreme-G XG2 (U) [t1].z64" size 12845056 crc fd7f3393 )
-)
-
-game (
-	name "F-1 Pole Position 64"
-	description "F-1 Pole Position 64"
-	rom ( name "F-1 Pole Position 64 (E) (M3) [!].z64" size 8388608 crc ed750623 )
-	rom ( name "F-1 Pole Position 64 (E) (M3) [b1].z64" size 8388608 crc dea54af5 )
-	rom ( name "F-1 Pole Position 64 (U) (M3) [!].z64" size 8388608 crc 30a24d89 )
-	rom ( name "F-1 Pole Position 64 (U) (M3) [b1].z64" size 8388608 crc af1aecc1 )
-	rom ( name "F-1 Pole Position 64 (U) (M3) [b2].z64" size 8388608 crc c18699ea )
-	rom ( name "F-1 Pole Position 64 (U) (M3) [h1C].z64" size 8388608 crc 50b4bc6c )
-	rom ( name "Human Grand Prix - New Generation (J) [!].z64" size 8388608 crc 31e102e3 )
-	rom ( name "Human Grand Prix - New Generation (J) [b1].z64" size 7602176 crc ecb4cccd )
-	rom ( name "Human Grand Prix - New Generation (J) [o1].z64" size 16777216 crc 23e323fc )
-)
-
-game (
-	name "F-1 World Grand Prix"
-	description "F-1 World Grand Prix"
-	rom ( name "F-1 World Grand Prix (E) [!].z64" size 12582912 crc bebbc6c8 )
-	rom ( name "F-1 World Grand Prix (E) [h1C].z64" size 12582912 crc 9d2b0e08 )
-	rom ( name "F-1 World Grand Prix (F) [!].z64" size 12582912 crc 57cd299d )
-	rom ( name "F-1 World Grand Prix (G) [!].z64" size 12582912 crc 0f1984dc )
-	rom ( name "F-1 World Grand Prix (G) [b1].z64" size 12582912 crc 973f566e )
-	rom ( name "F-1 World Grand Prix (G) [b1][o1].z64" size 16777216 crc f2a26788 )
-	rom ( name "F-1 World Grand Prix (G) [h1C].z64" size 12582912 crc 2c894c1c )
-	rom ( name "F-1 World Grand Prix (G) [o1].z64" size 16777216 crc 7e49cfa2 )
-	rom ( name "F-1 World Grand Prix (G) [o1][h1C].z64" size 16777216 crc 1d800e13 )
-	rom ( name "F-1 World Grand Prix (J) [!].z64" size 12582912 crc f7bacbc3 )
-	rom ( name "F-1 World Grand Prix (J) [h1C].z64" size 12582912 crc d42a0303 )
-	rom ( name "F-1 World Grand Prix (U) [!].z64" size 12582912 crc 7dc9ef2c )
-	rom ( name "F-1 World Grand Prix (U) [h1C].z64" size 12582912 crc c3477307 )
-	rom ( name "F-1 World Grand Prix (U) [h2C].z64" size 12582912 crc 5e5927ec )
-)
-
-game (
-	name "F-1 World Grand Prix II"
-	description "F-1 World Grand Prix II"
-	rom ( name "F-1 World Grand Prix II (E) (M4) [!].z64" size 12582912 crc 803d33df )
-	rom ( name "F-1 World Grand Prix II (E) (M4) [f1] (NTSC).z64" size 12582912 crc be78c19a )
-	rom ( name "F-1 World Grand Prix II (E) (M4) [h1C].z64" size 12582912 crc a3adfb1f )
-)
-
-game (
-	name "F-ZERO Expansion Kit"
-	description "F-ZERO Expansion Kit"
-	rom ( name "F-ZERO Expansion Kit (N64DD).ndd" size 67108864 crc a4a24ab0 )
-)
-
-game (
-	name "F-ZERO X"
-	description "F-ZERO X"
-	rom ( name "F-ZERO X (E) [!].z64" size 16777216 crc 2d6f7e8b )
-	rom ( name "F-ZERO X (E) [b1].z64" size 16777216 crc aef90bc1 )
-	rom ( name "F-ZERO X (E) [b2].z64" size 16777216 crc 3203f697 )
-	rom ( name "F-ZERO X (E) [b3].z64" size 16777216 crc 8c0e80e2 )
-	rom ( name "F-ZERO X (E) [b4].z64" size 16777216 crc c0ebc4d9 )
-	rom ( name "F-ZERO X (E) [f1].z64" size 16777216 crc d925eac7 )
-	rom ( name "F-ZERO X (E) [h1C].z64" size 16777216 crc 7a571a1a )
-	rom ( name "F-ZERO X (J) [!].z64" size 16777216 crc 6b1cef83 )
-	rom ( name "F-ZERO X (J) [b1].z64" size 16777216 crc 190eb759 )
-	rom ( name "F-ZERO X (J) [b2].z64" size 16777216 crc 8561c494 )
-	rom ( name "F-ZERO X (J) [b3].z64" size 16777216 crc 032a013a )
-	rom ( name "F-ZERO X (J) [t1].z64" size 16777216 crc 3f7eec93 )
-	rom ( name "F-ZERO X (U) (DXP Track Pack Hack).z64" size 16777216 crc b25212c7 )
-	rom ( name "F-ZERO X (U) [!].z64" size 16777216 crc 0b561fba )
-	rom ( name "F-ZERO X (U) [f1] (Sex V1.0 Hack).z64" size 16777216 crc 570b39f7 )
-	rom ( name "F-ZERO X (U) [f1] (Sex V1.1 Hack).z64" size 16777216 crc 6ba4df43 )
-	rom ( name "F-ZERO X (U) [f1].z64" size 16777216 crc cb9ced6c )
-	rom ( name "F-ZERO X (U) [f2] (GameShark).z64" size 16777216 crc c82964a8 )
-)
-
-game (
-	name "F1 Racing Championship"
-	description "F1 Racing Championship"
-	rom ( name "F1 Racing Championship (E) (M5) [!].z64" size 16777216 crc 2da744f5 )
-	rom ( name "F1 Racing Championship (E) (M5) [f1] (NTSC).z64" size 16777216 crc 9df5d7a1 )
-)
-
-game (
-	name "Famista 64"
-	description "Famista 64"
-	rom ( name "Famista 64 (J) [!].z64" size 12582912 crc 9fb0e6c9 )
-	rom ( name "Famista 64 (J) [b1].z64" size 12058624 crc 1b41ce74 )
-	rom ( name "Famista 64 (J) [b2].z64" size 16777216 crc 3d41e4a3 )
-	rom ( name "Famista 64 (J) [b3].z64" size 12582912 crc bb94897b )
-	rom ( name "Famista 64 (J) [b4].z64" size 16777216 crc 22341b95 )
-	rom ( name "Famista 64 (J) [b5].z64" size 12058624 crc ad201004 )
-	rom ( name "Famista 64 (J) [b6].z64" size 12582912 crc 6f2515af )
-	rom ( name "Famista 64 (J) [b7].z64" size 12582912 crc fe593e79 )
-	rom ( name "Famista 64 (J) [o1].z64" size 16777216 crc b05b9d06 )
-)
-
-game (
-	name "FIFA - Road to World Cup 98"
-	description "FIFA - Road to World Cup 98"
-	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [!].z64" size 12582912 crc 137cb3cc )
-	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [o1].z64" size 12582912 crc c61307d6 )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [!].z64" size 12582912 crc 28b1221c )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b1].z64" size 12582912 crc 01d31b3c )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b2].z64" size 16777216 crc e3e2a97e )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b3].z64" size 11534336 crc 2b1f7e3f )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b4].z64" size 12582912 crc 4620b4bb )
-	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [o1].z64" size 16777216 crc 24b60d8f )
-	rom ( name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!].z64" size 12582912 crc ae346df6 )
-)
-
-game (
-	name "FIFA 99"
-	description "FIFA 99"
-	rom ( name "FIFA 99 (E) (M8) [!].z64" size 16777216 crc 6eae1e6e )
-	rom ( name "FIFA 99 (E) (M8) [hI].z64" size 16777216 crc 7155e600 )
-	rom ( name "FIFA 99 (U) [!].z64" size 16777216 crc 6b2473a9 )
-	rom ( name "FIFA 99 (U) [b1].z64" size 16777216 crc ffe33a71 )
-)
-
-game (
-	name "FIFA Soccer 64"
-	description "FIFA Soccer 64"
-	rom ( name "FIFA Soccer 64 (E) (M3) [!].z64" size 8388608 crc ae2583fb )
-	rom ( name "FIFA Soccer 64 (E) (M3) [b1].z64" size 8388608 crc 6a991d12 )
-	rom ( name "FIFA Soccer 64 (E) (M3) [o1].z64" size 16777216 crc 5079fdc3 )
-	rom ( name "FIFA Soccer 64 (E) (M3) [o2].z64" size 12582912 crc e97b5d6b )
-	rom ( name "FIFA Soccer 64 (E) (M3) [o3].z64" size 12582912 crc 86fe6e3b )
-	rom ( name "FIFA Soccer 64 (E) (M3) [o4].z64" size 16777216 crc 042e31b2 )
-	rom ( name "FIFA Soccer 64 (U) (M3) [!].z64" size 8388608 crc 57de7cab )
-	rom ( name "FIFA Soccer 64 (U) (M3) [b1].z64" size 7340032 crc 27abec34 )
-	rom ( name "FIFA Soccer 64 (U) (M3) [o1].z64" size 16777216 crc 95ec83d3 )
-)
-
-game (
-	name "Fighter Destiny 2"
-	description "Fighter Destiny 2"
-	rom ( name "Fighter Destiny 2 (U) [!].z64" size 16777216 crc bb2563c6 )
-	rom ( name "Fighter Destiny 2 (U) [f1] (PAL-NTSC).z64" size 16777216 crc ad232e1b )
-	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [!].z64" size 16777216 crc db40a155 )
-	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL).z64" size 16777216 crc f88089f1 )
-)
-
-game (
-	name "Fighter's Destiny"
-	description "Fighter's Destiny"
-	rom ( name "Fighter's Destiny (E) [!].z64" size 12582912 crc c9225511 )
-	rom ( name "Fighter's Destiny (F) [!].z64" size 12582912 crc 0cc22034 )
-	rom ( name "Fighter's Destiny (G) [!].z64" size 12582912 crc 5052168c )
-	rom ( name "Fighter's Destiny (U) [!].z64" size 12582912 crc f45ea789 )
-	rom ( name "Fighter's Destiny (U) [b1].z64" size 12582912 crc b60bd3af )
-	rom ( name "Fighter's Destiny (U) [o1].z64" size 16777216 crc 845e5a29 )
-	rom ( name "Fighting Cup (J) [!].z64" size 12582912 crc 8a1c261e )
-)
-
-game (
-	name "Fighting Force 64"
-	description "Fighting Force 64"
-	rom ( name "Fighting Force 64 (E) [!].z64" size 16777216 crc 4052c176 )
-	rom ( name "Fighting Force 64 (U) [!].z64" size 16777216 crc 8456841e )
-	rom ( name "Fighting Force 64 (U) [T+Ita_Cattivik66].z64" size 16777216 crc 83b13ee4 )
-	rom ( name "Fighting Force 64 (U) [t1].z64" size 16777216 crc bd748727 )
-	rom ( name "Fighting Force 64 (U) [t1][f1] (PAL).z64" size 16777216 crc b91de407 )
-)
-
-game (
-	name "Flying Dragon"
-	description "Flying Dragon"
-	rom ( name "Flying Dragon (E) [!].z64" size 12582912 crc c3066e59 )
-	rom ( name "Flying Dragon (U) [!].z64" size 12582912 crc 91bc9aeb )
-	rom ( name "Flying Dragon (U) [b1].z64" size 12582912 crc 28adbef4 )
-	rom ( name "Flying Dragon (U) [b2].z64" size 12582912 crc a52e28e6 )
-	rom ( name "Hiryuu no Ken Twin (J) [!].z64" size 12582912 crc ba6a687e )
-	rom ( name "Hiryuu no Ken Twin (J) [h1C].z64" size 12582912 crc ba40793d )
-	rom ( name "Hiryuu no Ken Twin (J) [h2C].z64" size 12582912 crc 09f183c5 )
-	rom ( name "Hiryuu no Ken Twin (J) [h3C].z64" size 12582912 crc faa2d612 )
-)
-
-game (
-	name "Forsaken 64"
-	description "Forsaken 64"
-	rom ( name "Forsaken 64 (E) (M4) [!].z64" size 8388608 crc 5ed736d9 )
-	rom ( name "Forsaken 64 (G) [!].z64" size 8388608 crc 9793abc2 )
-	rom ( name "Forsaken 64 (G) [h1C].z64" size 8388608 crc 7c27cb56 )
-	rom ( name "Forsaken 64 (G) [o1].z64" size 33554432 crc fec081c8 )
-	rom ( name "Forsaken 64 (U) [!].z64" size 8388608 crc 76c4333d )
-	rom ( name "Forsaken 64 (U) [b1].z64" size 7602176 crc cd83b6d6 )
-	rom ( name "Forsaken 64 (U) [t1].z64" size 8388608 crc a7a563d8 )
-	rom ( name "Forsaken 64 (U) [t2].z64" size 8388608 crc f26d2d5d )
-	rom ( name "Forsaken 64 (U) [t3].z64" size 8388608 crc 4dc1cbe3 )
-)
-
-game (
-	name "Fox Sports College Hoops '99"
-	description "Fox Sports College Hoops '99"
-	rom ( name "Fox Sports College Hoops '99 (U) [!].z64" size 12582912 crc 67eaf0f3 )
-	rom ( name "Fox Sports College Hoops '99 (U) [f1] (PAL).z64" size 12582912 crc 43ad9c56 )
-)
-
-game (
-	name "Frogger 2"
-	description "Frogger 2"
-	rom ( name "Frogger 2 (U) (Alpha) [!].z64" size 4194304 crc b0c62957 )
-	rom ( name "Frogger 2 (U) (Alpha) [o1].z64" size 33554432 crc a8f81f39 )
-	rom ( name "Frogger 2 (U) (Alpha) [o2].z64" size 8388608 crc ded56725 )
-)
-
-game (
-	name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou!"
-	description "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou!"
-	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!].z64" size 33554432 crc 2aa6d2a1 )
-)
-
-game (
-	name "GameBooster 64"
-	description "GameBooster 64"
-	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [b1].z64" size 2097152 crc ec7cfd07 )
-	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [f1].z64" size 2097152 crc 3543fae8 )
-	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl).z64" size 262144 crc e0b8edae )
-	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [b1].z64" size 1310720 crc 0f7c70d3 )
-	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [f1] (Sound).z64" size 2097152 crc 8a4275ff )
-	rom ( name "GameBooster 64 V1.1 (PAL) (Unl).z64" size 262144 crc 35b99bd9 )
-)
-
-game (
-	name "GameShark Pro"
-	description "GameShark Pro"
-	rom ( name "GameShark Pro V2.0 (Unl).z64" size 262144 crc ef9edf87 )
-	rom ( name "GameShark Pro V3.3 (Apr 2000) (Unl) [!].z64" size 262144 crc f1851ebd )
-	rom ( name "GameShark Pro V3.3 (Mar 2000) (Unl) [!].z64" size 262144 crc 7cc07bbc )
-)
-
-game (
-	name "Ganbare Goemon - Mononoke Sugoroku"
-	description "Ganbare Goemon - Mononoke Sugoroku"
-	rom ( name "Ganbare Goemon - Mononoke Sugoroku (J) [!].z64" size 16777216 crc 965c4575 )
-)
-
-game (
-	name "Gauntlet Legends"
-	description "Gauntlet Legends"
-	rom ( name "Gauntlet Legends (E) [!].z64" size 16777216 crc b7b3a489 )
-	rom ( name "Gauntlet Legends (E) [b1].z64" size 16777216 crc 5ae31c93 )
-	rom ( name "Gauntlet Legends (J) [!].z64" size 16777216 crc 8d133db0 )
-	rom ( name "Gauntlet Legends (U) [!].z64" size 16777216 crc 64765e82 )
-	rom ( name "Gauntlet Legends (U) [f1] (PAL).z64" size 16777216 crc 510cb972 )
-)
-
-game (
-	name "Getter Love!!"
-	description "Getter Love!!"
-	rom ( name "Getter Love!! (J) [!].z64" size 12582912 crc 724ecae7 )
-	rom ( name "Getter Love!! (J) [b1].z64" size 12582912 crc 8bd98062 )
-	rom ( name "Getter Love!! (J) [b2].z64" size 12582912 crc 88da17f6 )
-)
-
-game (
-	name "Gex 3 - Deep Cover Gecko"
-	description "Gex 3 - Deep Cover Gecko"
-	rom ( name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!].z64" size 33554432 crc a43cb8e4 )
-	rom ( name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!].z64" size 33554432 crc 6bc4a056 )
-	rom ( name "Gex 3 - Deep Cover Gecko (U) [!].z64" size 33554432 crc 87a7d099 )
-	rom ( name "Gex 3 - Deep Cover Gecko (U) [f1] (PAL).z64" size 33554432 crc 26c35612 )
-	rom ( name "Gex 3 - Deep Cover Gecko (U) [t1].z64" size 33554432 crc 3aee8310 )
-)
-
-game (
-	name "Gex 64 - Enter the Gecko"
-	description "Gex 64 - Enter the Gecko"
-	rom ( name "Gex 64 - Enter the Gecko (E) [!].z64" size 16777216 crc a7c92bea )
-	rom ( name "Gex 64 - Enter the Gecko (U) [!].z64" size 16777216 crc c545ce80 )
-	rom ( name "Gex 64 - Enter the Gecko (U) [f1] (PAL).z64" size 16777216 crc 5802d207 )
-	rom ( name "Gex 64 - Enter the Gecko (U) [t1].z64" size 16777216 crc dd37073a )
-)
-
-game (
-	name Glover
-	description "Glover"
-	rom ( name "Glover (E) (M3) [!].z64" size 8388608 crc 90eceb4a )
-	rom ( name "Glover (E) (M3) [f1] (NTSC).z64" size 8388608 crc 2ec58e29 )
-	rom ( name "Glover (U) [!].z64" size 8388608 crc f874571c )
-	rom ( name "Glover (U) [b1].z64" size 8388608 crc 98db770d )
-	rom ( name "Glover (U) [b2].z64" size 8388608 crc 537290a5 )
-	rom ( name "Glover (U) [t1].z64" size 8388608 crc 0dffcf4b )
-)
-
-game (
-	name "Goemon's Great Adventure"
-	description "Goemon's Great Adventure"
-	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!].z64" size 16777216 crc 08c41e0e )
-	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t1].z64" size 16777216 crc 2fb2d3b1 )
-	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t2].z64" size 16777216 crc a5563b90 )
-	rom ( name "Goemon's Great Adventure (U) [!].z64" size 16777216 crc 52d418e1 )
-	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [!].z64" size 16777216 crc 3502dbbe )
-	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [hI].z64" size 16777216 crc b153ba15 )
-	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [t1].z64" size 16777216 crc 29965288 )
-)
-
-game (
-	name "Golden Nugget 64"
-	description "Golden Nugget 64"
-	rom ( name "Golden Nugget 64 (U) [!].z64" size 8388608 crc 641885df )
-	rom ( name "Golden Nugget 64 (U) [b1].z64" size 8388608 crc e0b4c1ee )
-	rom ( name "Golden Nugget 64 (U) [b2].z64" size 5996544 crc 4b5fd87a )
-	rom ( name "Golden Nugget 64 (U) [f1] (PAL).z64" size 8388608 crc b5e49d46 )
-	rom ( name "Golden Nugget 64 (U) [h1C].z64" size 8388608 crc 40e74294 )
-)
-
-game (
-	name "GoldenEye 007"
-	description "GoldenEye 007"
-	rom ( name "GoldenEye 007 (E) (Citadel Hack).bin" size 12582912 crc 27dad263 )
-	rom ( name "GoldenEye 007 (E) [!].z64" size 12582912 crc 9ec14aeb )
-	rom ( name "GoldenEye 007 (E) [b1].z64" size 12582912 crc 6833e958 )
-	rom ( name "GoldenEye 007 (E) [h1C].z64" size 12582912 crc e88d9da4 )
-	rom ( name "GoldenEye 007 (E) [t1] (Rapid Fire).z64" size 12582912 crc e0833df2 )
-	rom ( name "GoldenEye 007 (J) [!].z64" size 12582912 crc a6be19dd )
-	rom ( name "GoldenEye 007 (J) [t1] (Rapid Fire).z64" size 12582912 crc 7fbcc907 )
-	rom ( name "GoldenEye 007 (U) (Citadel Hack).bin" size 12582912 crc 6374d7cc )
-	rom ( name "GoldenEye 007 (U) (Frozen Enemies Hack).z64" size 12582912 crc 1eb6869d )
-	rom ( name "GoldenEye 007 (U) (G5 Multi (for backups) Hack).bin" size 12582912 crc 285e8d41 )
-	rom ( name "GoldenEye 007 (U) (G5 Multi Hack).bin" size 12582912 crc 724ecd4b )
-	rom ( name "GoldenEye 007 (U) (God Mode Hack).z64" size 12582912 crc f177aa35 )
-	rom ( name "GoldenEye 007 (U) (No Music Hack).z64" size 12582912 crc a42184fa )
-	rom ( name "GoldenEye 007 (U) (No Power Bar Hack).z64" size 12582912 crc 59b84d17 )
-	rom ( name "GoldenEye 007 (U) (Tetris Hack).bin" size 12582912 crc 89b3eb2b )
-	rom ( name "GoldenEye 007 (U) [!].z64" size 12582912 crc b6330846 )
-	rom ( name "GoldenEye 007 (U) [b1].z64" size 12582912 crc ea2b1826 )
-	rom ( name "GoldenEye 007 (U) [h1C].z64" size 12582912 crc 54858fee )
-	rom ( name "GoldenEye 007 (U) [o1].z64" size 16777216 crc ee36b9ba )
-	rom ( name "GoldenEye 007 (U) [o2].z64" size 16777216 crc d32c4cb3 )
-	rom ( name "GoldenEye 007 (U) [t1] (Rapid Fire).z64" size 12582912 crc fef59913 )
-	rom ( name "GoldenEye 007 (U) [t2].z64" size 12582912 crc 1d5409d0 )
-	rom ( name "GoldenEye 007 (U) [t3] (All Guns Zoom Mode).z64" size 12582912 crc 490f003c )
-)
-
-game (
-	name "GT 64 - Championship Edition"
-	description "GT 64 - Championship Edition"
-	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [!].z64" size 16777216 crc e272bdf6 )
-	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b1].z64" size 16777216 crc db1991cd )
-	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b2].z64" size 16777216 crc 8ad78b91 )
-	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b3].z64" size 1540096 crc 946c079d )
-	rom ( name "GT 64 - Championship Edition (E) (M3) [!].z64" size 12582912 crc 6dfb4747 )
-	rom ( name "GT 64 - Championship Edition (E) (M3) [b1].z64" size 12582912 crc b1e2c1d2 )
-	rom ( name "GT 64 - Championship Edition (E) (M3) [f1] (NTSC).z64" size 12582912 crc dc890e2e )
-	rom ( name "GT 64 - Championship Edition (E) (M3) [f2] (NTSC).z64" size 12582912 crc d507b9ab )
-	rom ( name "GT 64 - Championship Edition (U) [!].z64" size 12582912 crc bc627da7 )
-	rom ( name "GT 64 - Championship Edition (U) [b1].z64" size 12582912 crc 1bd55eff )
-)
-
-game (
-	name "Hamster Monogatari 64"
-	description "Hamster Monogatari 64"
-	rom ( name "Hamster Monogatari 64 (J) [!].z64" size 12582912 crc c1d98b78 )
-)
-
-game (
-	name "Harvest Moon 64"
-	description "Harvest Moon 64"
-	rom ( name "Bokujou Monogatari 2 (J) [!].z64" size 16777216 crc f97237c7 )
-	rom ( name "Bokujou Monogatari 2 (J) [b1].z64" size 16777216 crc e9e0c465 )
-	rom ( name "Harvest Moon 64 (U) [!].z64" size 16777216 crc decdc0ad )
-	rom ( name "Harvest Moon 64 (U) [b1].z64" size 16777216 crc a4026e3f )
-	rom ( name "Harvest Moon 64 (U) [f1] (PAL).z64" size 16777216 crc 769e12a2 )
-	rom ( name "Harvest Moon 64 (U) [T+Pol001].z64" size 16777216 crc 06252291 )
-	rom ( name "Harvest Moon 64 (U) [t1].z64" size 17039360 crc e391f319 )
-	rom ( name "Harvest Moon 64 (U) [t1][f1] (PAL-NTSC).z64" size 16811339 crc c2648df7 )
-)
-
-game (
-	name "Heiwa Pachinko World 64"
-	description "Heiwa Pachinko World 64"
-	rom ( name "Heiwa Pachinko World 64 (J) [!].z64" size 8388608 crc 99a427fa )
-	rom ( name "Heiwa Pachinko World 64 (J) [b1].z64" size 8388608 crc c9474abf )
-	rom ( name "Heiwa Pachinko World 64 (J) [b2].z64" size 8388608 crc 90cf7169 )
-	rom ( name "Heiwa Pachinko World 64 (J) [b3].z64" size 16777216 crc 5d34235a )
-	rom ( name "Heiwa Pachinko World 64 (J) [h1C].z64" size 16777216 crc dea145ae )
-	rom ( name "Heiwa Pachinko World 64 (J) [o1].z64" size 16777216 crc ed3b55d8 )
-)
-
-game (
-	name "Hercules - The Legendary Journeys"
-	description "Hercules - The Legendary Journeys"
-	rom ( name "Hercules - The Legendary Journeys (E) (M6) [!].z64" size 16777216 crc b1954b08 )
-	rom ( name "Hercules - The Legendary Journeys (U) [!].z64" size 16777216 crc 4948892b )
-	rom ( name "Hercules - The Legendary Journeys (U) [o1].z64" size 33554432 crc 1c0c079f )
-	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1] (PAL-NTSC).z64" size 16883918 crc 4a8c19b2 )
-	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1][b1].z64" size 16883918 crc 5dab18ec )
-	rom ( name "Hercules - The Legendary Journeys (U) [t1][f2] (PAL-NTSC).z64" size 17039360 crc 6d30e1d2 )
-)
-
-game (
-	name Hexen
-	description "Hexen"
-	rom ( name "Hexen (E) [!].z64" size 8388608 crc 5369efb4 )
-	rom ( name "Hexen (E) [h1C].z64" size 8388608 crc f0899c71 )
-	rom ( name "Hexen (F) [!].z64" size 8388608 crc e373fa31 )
-	rom ( name "Hexen (G) [!].z64" size 8388608 crc e4821c4b )
-	rom ( name "Hexen (G) [h1C].z64" size 8388608 crc b1a8c486 )
-	rom ( name "Hexen (J) [!].z64" size 8388608 crc 571da09a )
-	rom ( name "Hexen (U) [!].z64" size 8388608 crc 1d35e110 )
-	rom ( name "Hexen (U) [b1].z64" size 8388608 crc 1c66bdfe )
-	rom ( name "Hexen (U) [h1C].z64" size 8388608 crc ff80d2fb )
-	rom ( name "Hexen (U) [t1].z64" size 8388608 crc eb25fd56 )
-	rom ( name "Hexen (U) [t2].z64" size 8388608 crc bbe1c15e )
-)
-
-game (
-	name "Hey You, Pikachu!"
-	description "Hey You, Pikachu!"
-	rom ( name "Hey You, Pikachu! (U) [!].z64" size 16777216 crc b18b2734 )
-	rom ( name "Pikachu Genki Dechu (J) [!].z64" size 16777216 crc 3f6245ae )
-	rom ( name "Pikachu Genki Dechu (J) [b1].z64" size 5668864 crc ee4886fa )
-)
-
-game (
-	name "Hot Wheels Turbo Racing"
-	description "Hot Wheels Turbo Racing"
-	rom ( name "Hot Wheels Turbo Racing (E) (M3) [!].z64" size 16777216 crc 850633a7 )
-	rom ( name "Hot Wheels Turbo Racing (E) (M3) [b1].z64" size 16777216 crc e2eb5d7a )
-	rom ( name "Hot Wheels Turbo Racing (U) [!].z64" size 12582912 crc a5c92148 )
-	rom ( name "Hot Wheels Turbo Racing (U) [f1] (PAL).z64" size 12582912 crc e0fd8f22 )
-	rom ( name "Hot Wheels Turbo Racing (U) [t1].z64" size 12582912 crc fff6a4ba )
-)
-
-game (
-	name "Hybrid Heaven"
-	description "Hybrid Heaven"
-	rom ( name "Hybrid Heaven (E) (M3) [!].z64" size 16777216 crc e76627ff )
-	rom ( name "Hybrid Heaven (E) (M3) [b1].z64" size 16777216 crc f5fa7401 )
-	rom ( name "Hybrid Heaven (E) (M3) [f1] (NTSC).z64" size 16777216 crc e8322d68 )
-	rom ( name "Hybrid Heaven (J) [!].z64" size 16777216 crc e769de96 )
-	rom ( name "Hybrid Heaven (J) [b1].z64" size 16777230 crc 47f2dd70 )
-	rom ( name "Hybrid Heaven (J) [f1] (PAL).z64" size 16777216 crc 1d8781dc )
-	rom ( name "Hybrid Heaven (U) [!].z64" size 16777216 crc 15b57ef8 )
-	rom ( name "Hybrid Heaven (U) [f1] (PAL).z64" size 16777216 crc 0d4cbd39 )
-	rom ( name "Hybrid Heaven (U) [t1].z64" size 16777216 crc 478c2604 )
-)
-
-game (
-	name "Hydro Thunder"
-	description "Hydro Thunder"
-	rom ( name "Hydro Thunder (E) [!].z64" size 33554432 crc 863ab8f3 )
-	rom ( name "Hydro Thunder (E) [f1] (NTSC).z64" size 33554432 crc 4da8bd88 )
-	rom ( name "Hydro Thunder (F) [!].z64" size 33554432 crc 010f6242 )
-	rom ( name "Hydro Thunder (U) [!].z64" size 33554432 crc e744456f )
-	rom ( name "Hydro Thunder (U) [b1].z64" size 29360128 crc df1693a6 )
-	rom ( name "Hydro Thunder (U) [b1][f1] (PAL).z64" size 29360128 crc 2856fbfb )
-	rom ( name "Hydro Thunder (U) [b1][t1].z64" size 29360128 crc c0b7026f )
-	rom ( name "Hydro Thunder (U) [b2].z64" size 33554432 crc 8f621adb )
-	rom ( name "Hydro Thunder (U) [b3].z64" size 29360128 crc 87f7ec0d )
-)
-
-game (
-	name "Ide Yosuke no Mahjong Juku"
-	description "Ide Yosuke no Mahjong Juku"
-	rom ( name "Ide Yosuke no Mahjong Juku (J) [!].z64" size 12582912 crc a4a24517 )
-	rom ( name "Ide Yosuke no Mahjong Juku (J) [b1].z64" size 12582912 crc dbd96deb )
-)
-
-game (
-	name "Iggy's Reckin' Balls"
-	description "Iggy's Reckin' Balls"
-	rom ( name "Iggy's Reckin' Balls (E) [!].z64" size 4194304 crc 9bf26065 )
-	rom ( name "Iggy's Reckin' Balls (E) [o1].z64" size 8388608 crc 4f15ce42 )
-	rom ( name "Iggy's Reckin' Balls (U) [!].z64" size 4194304 crc 6a6fbd5d )
-	rom ( name "Iggy's Reckin' Balls (U) [o1].z64" size 8388608 crc 9ec813fb )
-	rom ( name "Iggy-kun no Bura Bura Poyon (J) [!].z64" size 4194304 crc 26cc1266 )
-	rom ( name "Iggy-kun no Bura Bura Poyon (J) [o1].z64" size 8388608 crc 5a67e489 )
+	name "Yoshi Story (J) [f2]"
+	description "Yoshi Story (J) [f2]"
+	rom ( name "Yoshi Story (J) [f2].z64" crc 8D18A944 )
 )
 
 game (
-	name "In-Fisherman Bass Hunter 64"
-	description "In-Fisherman Bass Hunter 64"
-	rom ( name "Bass Hunter 64 (E) [!].z64" size 8388608 crc 00da3704 )
-	rom ( name "In-Fisherman Bass Hunter 64 (U) [!].z64" size 8388608 crc d8eb5e6e )
-	rom ( name "In-Fisherman Bass Hunter 64 (U) [f1] (PAL).z64" size 8388608 crc 3d30e44b )
+	name "Yoshi Story (J) [f3]"
+	description "Yoshi Story (J) [f3]"
+	rom ( name "Yoshi Story (J) [f3].z64" crc 967949F0 )
 )
 
 game (
-	name "Indiana Jones and the Infernal Machine"
-	description "Indiana Jones and the Infernal Machine"
-	rom ( name "Indiana Jones and the Infernal Machine (U) [!].z64" size 33554432 crc 4978eb57 )
+	name "Yoshi Story (J) [f4]"
+	description "Yoshi Story (J) [f4]"
+	rom ( name "Yoshi Story (J) [f4].z64" crc 0AFE15CA )
 )
 
 game (
-	name "Indy Racing 2000"
-	description "Indy Racing 2000"
-	rom ( name "Indy Racing 2000 (U) [!].z64" size 16777216 crc a5163f29 )
+	name "Yoshi Story (J) [t1]"
+	description "Yoshi Story (J) [t1]"
+	rom ( name "Yoshi Story (J) [t1].z64" crc 7DD9A4ED )
 )
 
 game (
-	name "International Superstar Soccer '98"
-	description "International Superstar Soccer '98"
-	rom ( name "International Superstar Soccer '98 (E) [!].z64" size 12582912 crc bf23945d )
-	rom ( name "International Superstar Soccer '98 (U) [!].z64" size 12582912 crc b85fa721 )
-	rom ( name "International Superstar Soccer '98 (U) [o1].z64" size 33554432 crc fff24a88 )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!].z64" size 16777216 crc 5c721850 )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!].z64" size 16777216 crc 68dbcc04 )
-	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!].z64" size 16777216 crc f63f9a5e )
+	name "Yoshi Story (J) [t2] (Health and Eggs)"
+	description "Yoshi Story (J) [t2] (Health and Eggs)"
+	rom ( name "Yoshi Story (J) [t2] (Health and Eggs).z64" crc 308915C3 )
 )
 
 game (
-	name "International Superstar Soccer 2000"
-	description "International Superstar Soccer 2000"
-	rom ( name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!].z64" size 16777216 crc 69572558 )
-	rom ( name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!].z64" size 16777216 crc 8a16a6a9 )
-	rom ( name "International Superstar Soccer 2000 (U) (M2) [!].z64" size 16777216 crc dcd0538f )
-	rom ( name "International Superstar Soccer 2000 (U) (M2) [f1] (PAL).z64" size 16777216 crc 2141dd95 )
-	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!].z64" size 16777216 crc 153aeb15 )
-	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [b1].z64" size 16777216 crc 25fa617f )
-	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f1] (PAL).z64" size 16777216 crc fff14be7 )
-	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f2] (PAL).z64" size 16777216 crc 71d98830 )
+	name "Yoshi's Story (E) (M3) [!]"
+	description "Yoshi's Story (E) (M3) [!]"
+	rom ( name "Yoshi's Story (E) (M3) [!].z64" crc F9FFC760 )
 )
 
 game (
-	name "International Superstar Soccer 64"
-	description "International Superstar Soccer 64"
-	rom ( name "International Superstar Soccer 64 (E) [!].z64" size 8388608 crc 8c839268 )
-	rom ( name "International Superstar Soccer 64 (E) [b1].z64" size 8388608 crc ab19d163 )
-	rom ( name "International Superstar Soccer 64 (E) [b2].z64" size 8388608 crc 4a3bfbbd )
-	rom ( name "International Superstar Soccer 64 (E) [h1C].z64" size 8388608 crc 3a827afc )
-	rom ( name "International Superstar Soccer 64 (E) [h2C].z64" size 8388608 crc 3ff384ef )
-	rom ( name "International Superstar Soccer 64 (U) [!].z64" size 8388608 crc 0ea249b9 )
-	rom ( name "International Superstar Soccer 64 (U) [b1].z64" size 8388608 crc f73e92c6 )
-	rom ( name "International Superstar Soccer 64 (U) [h1C].z64" size 8388608 crc 53fd493e )
-	rom ( name "International Superstar Soccer 64 (U) [h2C].z64" size 8388608 crc 3db7c140 )
-	rom ( name "Jikkyou World Soccer 3 (J) [!].z64" size 8388608 crc 3ba9e644 )
+	name "Yoshi's Story (E) (M3) [b1]"
+	description "Yoshi's Story (E) (M3) [b1]"
+	rom ( name "Yoshi's Story (E) (M3) [b1].z64" crc 9E6C336A )
 )
 
 game (
-	name "International Track & Field 2000"
-	description "International Track & Field 2000"
-	rom ( name "Ganbare Nippon! Olympics 2000 (J) [!].z64" size 12582912 crc 73133cd2 )
-	rom ( name "International Track & Field 2000 (U) [!].z64" size 12582912 crc da443f0b )
-	rom ( name "International Track & Field Summer Games (E) (M3) [!].z64" size 12582912 crc b3181ee0 )
+	name "Yoshi's Story (E) (M3) [b2]"
+	description "Yoshi's Story (E) (M3) [b2]"
+	rom ( name "Yoshi's Story (E) (M3) [b2].z64" crc CDA63103 )
 )
 
 game (
-	name "J.League Dynamite Soccer 64"
-	description "J.League Dynamite Soccer 64"
-	rom ( name "J.League Dynamite Soccer 64 (J) [!].z64" size 8388608 crc dc0b2c8f )
-	rom ( name "J.League Dynamite Soccer 64 (J) [b1].z64" size 8388608 crc 6cfffef0 )
-	rom ( name "J.League Dynamite Soccer 64 (J) [b2].z64" size 8388608 crc 3a53cba9 )
-	rom ( name "J.League Dynamite Soccer 64 (J) [b3].z64" size 7864320 crc 03f8518b )
-	rom ( name "J.League Dynamite Soccer 64 (J) [b4].z64" size 8388608 crc 3a78f83e )
-	rom ( name "J.League Dynamite Soccer 64 (J) [h1C].z64" size 8388608 crc eeb3fa9e )
-	rom ( name "J.League Dynamite Soccer 64 (J) [h2C].z64" size 8388608 crc a7372112 )
-	rom ( name "J.League Dynamite Soccer 64 (J) [h3C].z64" size 8388608 crc 0c7df059 )
+	name "Yoshi's Story (E) (M3) [b2][f1]"
+	description "Yoshi's Story (E) (M3) [b2][f1]"
+	rom ( name "Yoshi's Story (E) (M3) [b2][f1].z64" crc E5FAA601 )
 )
 
 game (
-	name "J.League Eleven Beat 1997"
-	description "J.League Eleven Beat 1997"
-	rom ( name "J.League Eleven Beat 1997 (J) [b1][h1C].z64" size 8425780 crc c6279f61 )
-	rom ( name "J.League Eleven Beat 1997 (J) [b2][h1C].z64" size 8388608 crc 30d40134 )
-	rom ( name "J.League Eleven Beat 1997 (J) [h1C].z64" size 8388608 crc 1347819a )
-	rom ( name "J.League Eleven Beat 1997 (J).z64" size 8388608 crc 7d0eed6a )
+	name "Yoshi's Story (E) (M3) [b3]"
+	description "Yoshi's Story (E) (M3) [b3]"
+	rom ( name "Yoshi's Story (E) (M3) [b3].z64" crc 476F7CF5 )
 )
 
 game (
-	name "J.League Live 64"
-	description "J.League Live 64"
-	rom ( name "J.League Live 64 (J) [!].z64" size 8388608 crc 4c536dd7 )
-	rom ( name "J.League Live 64 (J) [b1].z64" size 8388608 crc 741721f4 )
+	name "Yoshi's Story (E) (M3) [t1] (Health and Eggs)"
+	description "Yoshi's Story (E) (M3) [t1] (Health and Eggs)"
+	rom ( name "Yoshi's Story (E) (M3) [t1] (Health and Eggs).z64" crc BA05B7CF )
 )
 
 game (
-	name "J.League Tactics Soccer"
-	description "J.League Tactics Soccer"
-	rom ( name "J.League Tactics Soccer (J) (V1.0) [!].z64" size 12582912 crc 976a2d12 )
-	rom ( name "J.League Tactics Soccer (J) (V1.0) [b1].z64" size 12582912 crc 8e05a52d )
-	rom ( name "J.League Tactics Soccer (J) (V1.0) [f1] (PAL).z64" size 12582912 crc 15809231 )
-	rom ( name "J.League Tactics Soccer (J) (V1.1) [!].z64" size 12582912 crc 156e705e )
+	name "Yoshi's Story (U) (M2) [!]"
+	description "Yoshi's Story (U) (M2) [!]"
+	rom ( name "Yoshi's Story (U) (M2) [!].z64" crc A1453E0D )
 )
 
 game (
-	name "Jangou Simulation Mahjong Do 64"
-	description "Jangou Simulation Mahjong Do 64"
-	rom ( name "Jangou Simulation Mahjong Do 64 (J) [!].z64" size 8388608 crc d1c1681e )
-	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b1].z64" size 8388608 crc cf0dc4f6 )
-	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b2].z64" size 8388608 crc e4e6f7ab )
-	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b3].z64" size 8388608 crc e0511a0e )
+	name "Yoshi's Story (U) (M2) [b1]"
+	description "Yoshi's Story (U) (M2) [b1]"
+	rom ( name "Yoshi's Story (U) (M2) [b1].z64" crc D1A35062 )
 )
 
 game (
-	name Jeopardy!
-	description "Jeopardy!"
-	rom ( name "Jeopardy! (U) [!].z64" size 4194304 crc e739947c )
-	rom ( name "Jeopardy! (U) [h1C].z64" size 4194304 crc 9f14481b )
-	rom ( name "Jeopardy! (U) [o1].z64" size 8388608 crc 8a6a5a0a )
-	rom ( name "Jeopardy! (U) [o1][h1C].z64" size 8388608 crc fd0d1db5 )
+	name "Yoshi's Story (U) (M2) [b2]"
+	description "Yoshi's Story (U) (M2) [b2]"
+	rom ( name "Yoshi's Story (U) (M2) [b2].z64" crc 724BAA87 )
 )
 
 game (
-	name "Jeremy McGrath Supercross 2000"
-	description "Jeremy McGrath Supercross 2000"
-	rom ( name "Jeremy McGrath Supercross 2000 (E) [!].z64" size 16777216 crc 5bf42ec4 )
-	rom ( name "Jeremy McGrath Supercross 2000 (U) [!].z64" size 16777216 crc 2a5c9a06 )
-	rom ( name "Jeremy McGrath Supercross 2000 (U) [f1].z64" size 16777216 crc 5e7afdd5 )
+	name "Yoshi's Story (U) (M2) [b3]"
+	description "Yoshi's Story (U) (M2) [b3]"
+	rom ( name "Yoshi's Story (U) (M2) [b3].z64" crc CC2ADC22 )
 )
 
 game (
-	name "Jet Force Gemini"
-	description "Jet Force Gemini"
-	rom ( name "Jet Force Gemini (E) (M4) [!].z64" size 33554432 crc cfbed88c )
-	rom ( name "Jet Force Gemini (E) (M4) [f1].z64" size 33554432 crc 4909c764 )
-	rom ( name "Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless].z64" size 33554432 crc d81484c8 )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [!].z64" size 33554432 crc fa061b96 )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1].z64" size 29360128 crc 15f91f65 )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f1] (Save).z64" size 29360128 crc dcf40812 )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f2].z64" size 29360128 crc 3e65056c )
-	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b2].z64" size 29360128 crc df2567cb )
-	rom ( name "Jet Force Gemini (U) [!].z64" size 33554432 crc 6753d5a3 )
-	rom ( name "Jet Force Gemini (U) [b1].z64" size 33672023 crc daacc564 )
-	rom ( name "Jet Force Gemini (U) [b2].z64" size 33554432 crc 83f0cd60 )
-	rom ( name "Star Twins (J) [!].z64" size 33554432 crc 964506ce )
+	name "Yoshi's Story (U) (M2) [b4]"
+	description "Yoshi's Story (U) (M2) [b4]"
+	rom ( name "Yoshi's Story (U) (M2) [b4].z64" crc 47D2B1F2 )
 )
 
 game (
-	name "Jikkyou G1 Stable"
-	description "Jikkyou G1 Stable"
-	rom ( name "Jikkyou G1 Stable (J) [!].z64" size 16777216 crc 0a796c3e )
-	rom ( name "Jikkyou G1 Stable (J) [b1].z64" size 16777216 crc 6a5dbf42 )
+	name "Yoshi's Story (U) (M2) [b5]"
+	description "Yoshi's Story (U) (M2) [b5]"
+	rom ( name "Yoshi's Story (U) (M2) [b5].z64" crc 2230A687 )
 )
 
 game (
-	name "Jikkyou J.League Perfect Striker"
-	description "Jikkyou J.League Perfect Striker"
-	rom ( name "Jikkyou J.League Perfect Striker (J) [!].z64" size 8388608 crc 8ed60dea )
-	rom ( name "Jikkyou J.League Perfect Striker (J) [b1].z64" size 8436170 crc bf55925b )
-	rom ( name "Jikkyou J.League Perfect Striker (J) [b2].z64" size 3670016 crc cec983c4 )
-	rom ( name "Jikkyou J.League Perfect Striker (J) [b3].z64" size 8388608 crc 99d33459 )
-	rom ( name "Jikkyou J.League Perfect Striker (J) [f1] (PAL).z64" size 8388608 crc 70b86019 )
+	name "Yoshi's Story (U) (M2) [f1]"
+	description "Yoshi's Story (U) (M2) [f1]"
+	rom ( name "Yoshi's Story (U) (M2) [f1].z64" crc 65DAD012 )
 )
 
 game (
-	name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001"
-	description "Jikkyou Powerful Pro Yakyuu - Basic Han 2001"
-	rom ( name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!].z64" size 16777216 crc 6a9e24d7 )
+	name "Yoshi's Story (U) (M2) [t1]"
+	description "Yoshi's Story (U) (M2) [t1]"
+	rom ( name "Yoshi's Story (U) (M2) [t1].z64" crc 40D0E350 )
 )
 
 game (
-	name "Jikkyou Powerful Pro Yakyuu 2000"
-	description "Jikkyou Powerful Pro Yakyuu 2000"
-	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!].z64" size 16777216 crc 351cde48 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!].z64" size 16777216 crc 753706ef )
+	name "Yoshi's Story (U) (M2) [t2] (Health and Eggs)"
+	description "Yoshi's Story (U) (M2) [t2] (Health and Eggs)"
+	rom ( name "Yoshi's Story (U) (M2) [t2] (Health and Eggs).z64" crc FAFD0923 )
 )
 
 game (
-	name "Jikkyou Powerful Pro Yakyuu 4"
-	description "Jikkyou Powerful Pro Yakyuu 4"
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!].z64" size 12582912 crc 480b953e )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1].z64" size 16777216 crc a9cbf551 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b2].z64" size 12582912 crc 7b6c6447 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b3].z64" size 16777216 crc bd96513e )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b4].z64" size 12582912 crc b0b19acd )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b5].z64" size 12582912 crc bc6a43d1 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [o1].z64" size 16777216 crc 3e95d085 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!].z64" size 12582912 crc 40e3ac61 )
+	name "Z64 BIOS V1.05"
+	description "Z64 BIOS V1.05"
+	rom ( name "Z64 BIOS V1.05.bin" crc D31F5D1D )
 )
 
 game (
-	name "Jikkyou Powerful Pro Yakyuu 5"
-	description "Jikkyou Powerful Pro Yakyuu 5"
-	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [!].z64" size 16777216 crc feec34f6 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [b1].z64" size 16777216 crc 46882289 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f1].z64" size 16777216 crc ecbc4c5a )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f2] (PAL).z64" size 16777216 crc 3b182dda )
+	name "Z64 BIOS V1.07"
+	description "Z64 BIOS V1.07"
+	rom ( name "Z64 BIOS V1.07.bin" crc C41DCFFC )
 )
 
 game (
-	name "Jikkyou Powerful Pro Yakyuu 6"
-	description "Jikkyou Powerful Pro Yakyuu 6"
-	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [!].z64" size 16777216 crc d9329895 )
-	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [b1].z64" size 16777216 crc 1e53a7ba )
+	name "Z64 BIOS V1.08 (Ravemax Hack V1.00b)"
+	description "Z64 BIOS V1.08 (Ravemax Hack V1.00b)"
+	rom ( name "Z64 BIOS V1.08 (Ravemax Hack V1.00b).bin" crc CF0138EE )
 )
 
 game (
-	name "Jinsei Game 64"
-	description "Jinsei Game 64"
-	rom ( name "Jinsei Game 64 (J) [!].z64" size 16777216 crc 67a1a22c )
-	rom ( name "Jinsei Game 64 (J) [f1] (PAL).z64" size 16777216 crc d8087b7f )
+	name "Z64 BIOS V1.08"
+	description "Z64 BIOS V1.08"
+	rom ( name "Z64 BIOS V1.08.bin" crc FA1FECC4 )
 )
 
 game (
-	name "John Romero's Daikatana"
-	description "John Romero's Daikatana"
-	rom ( name "John Romero's Daikatana (E) (M3) [!].z64" size 16777216 crc f88ac3ce )
-	rom ( name "John Romero's Daikatana (E) (M3) [f1] (NTSC).z64" size 16777216 crc 09dd5d1d )
-	rom ( name "John Romero's Daikatana (E) (M3) [h1C].z64" size 16777216 crc 429502c6 )
-	rom ( name "John Romero's Daikatana (J) [!].z64" size 16777216 crc 44b80fd7 )
-	rom ( name "John Romero's Daikatana (U) [!].z64" size 16777216 crc 494950c6 )
+	name "Z64 BIOS V1.09"
+	description "Z64 BIOS V1.09"
+	rom ( name "Z64 BIOS V1.09.bin" crc EA68D5ED )
 )
 
 game (
-	name "Ken Griffey Jr.'s Slugfest"
-	description "Ken Griffey Jr.'s Slugfest"
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [!].z64" size 16777216 crc 12d8f3e9 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b1].z64" size 16777216 crc 7f4bf06c )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b2].z64" size 16777216 crc 6a76d40c )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f1].z64" size 16777216 crc 07e5d789 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f2] (PAL).z64" size 16777216 crc 00e8dd96 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f3] (Nosave).z64" size 16777216 crc 28c9ff55 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f4] (Nosave-Z64).z64" size 16777216 crc dddbeb27 )
-	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f5].z64" size 16777216 crc 7846fa73 )
+	name "Z64 BIOS V1.10b"
+	description "Z64 BIOS V1.10b"
+	rom ( name "Z64 BIOS V1.10b.bin" crc 5912AF9D )
 )
 
 game (
-	name "Killer Instinct Gold"
-	description "Killer Instinct Gold"
-	rom ( name "Killer Instinct Gold (E) [!].z64" size 12582912 crc 5d0ee5d2 )
-	rom ( name "Killer Instinct Gold (E) [o1].z64" size 16777216 crc 896d0b78 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [!].z64" size 12582912 crc 31c76be7 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b1].z64" size 16777216 crc 3c1d7a7b )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b1][t1].z64" size 16778838 crc 5057dd86 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b2].z64" size 17039360 crc 5e0d463c )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b3].z64" size 16778838 crc 3e4bdc51 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b4].z64" size 16778838 crc cb383067 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [b5].z64" size 12582912 crc 00974048 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [o1].z64" size 16777216 crc f2d8ca68 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [o2].z64" size 16777216 crc 2c32d6d5 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [t1].z64" size 17039360 crc ac327ad0 )
-	rom ( name "Killer Instinct Gold (U) (V1.0) [t2].z64" size 16778838 crc a52431b0 )
-	rom ( name "Killer Instinct Gold (U) (V1.1) [!].z64" size 12582912 crc 49ef8f2b )
-	rom ( name "Killer Instinct Gold (U) (V1.1) [o1].z64" size 16777216 crc 79aee5e0 )
-	rom ( name "Killer Instinct Gold (U) (V1.2) [!].z64" size 12582912 crc 0b5b5df8 )
-	rom ( name "Killer Instinct Gold (U) (V1.2) [b1].z64" size 17039360 crc 12b74c51 )
-	rom ( name "Killer Instinct Gold (U) (V1.2) [o1].z64" size 16777216 crc c9e80752 )
+	name "Z64 BIOS V1.11"
+	description "Z64 BIOS V1.11"
+	rom ( name "Z64 BIOS V1.11.bin" crc A7BA30FC )
 )
 
 game (
-	name "Kira to Kaiketsu! 64 Tanteidan"
-	description "Kira to Kaiketsu! 64 Tanteidan"
-	rom ( name "Kira to Kaiketsu! 64 Tanteidan (J) [!].z64" size 12582912 crc 7fdc3784 )
+	name "Z64 BIOS V1.12"
+	description "Z64 BIOS V1.12"
+	rom ( name "Z64 BIOS V1.12.bin" crc B5BBBCBE )
 )
 
 game (
-	name "Kirby 64 - The Crystal Shards"
-	description "Kirby 64 - The Crystal Shards"
-	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [!].z64" size 33554432 crc ae7cb69d )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f1].z64" size 33554432 crc 81652a1a )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f2].z64" size 33554432 crc ae41ba5f )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.1) [!].z64" size 33554432 crc a263c1b9 )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.2) [!].z64" size 33554432 crc f4589aa8 )
-	rom ( name "Hoshi no Kirby 64 (J) (V1.3) [!].z64" size 33554432 crc 6d5e1332 )
-	rom ( name "Kirby 64 - The Crystal Shards (E) [!].z64" size 33554432 crc 5b8b89ef )
-	rom ( name "Kirby 64 - The Crystal Shards (E) [b1].z64" size 33554432 crc 5cd16874 )
-	rom ( name "Kirby 64 - The Crystal Shards (E) [f1].z64" size 33554432 crc 4fe0dadf )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [!].z64" size 33554432 crc 20a1c120 )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [b1].z64" size 33554432 crc 1916876e )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [b2].z64" size 33554432 crc 2033759a )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [f1].z64" size 33554432 crc 5945fe08 )
-	rom ( name "Kirby 64 - The Crystal Shards (U) [t1].z64" size 33554432 crc 910ecf72 )
-)
-
-game (
-	name "Knife Edge - Nose Gunner"
-	description "Knife Edge - Nose Gunner"
-	rom ( name "Knife Edge - Nose Gunner (E) [!].z64" size 8388608 crc b77783be )
-	rom ( name "Knife Edge - Nose Gunner (J) [!].z64" size 8388608 crc 3bc93017 )
-	rom ( name "Knife Edge - Nose Gunner (U) [!].z64" size 8388608 crc 255ee1dd )
-	rom ( name "Knife Edge - Nose Gunner (U) [b1][t1].z64" size 8388608 crc c7bef4e1 )
-	rom ( name "Knife Edge - Nose Gunner (U) [hI].z64" size 8388608 crc 0b2c0d2f )
-	rom ( name "Knife Edge - Nose Gunner (U) [hI][t1].z64" size 8388608 crc 34e8d3cf )
-	rom ( name "Knife Edge - Nose Gunner (U) [t1].z64" size 8388608 crc 1dc1e85d )
-)
-
-game (
-	name "Knockout Kings 2000"
-	description "Knockout Kings 2000"
-	rom ( name "Knockout Kings 2000 (E) [!].z64" size 16777216 crc 58ce7d80 )
-	rom ( name "Knockout Kings 2000 (U) [!].z64" size 16777216 crc 074690d6 )
-	rom ( name "Knockout Kings 2000 (U) [f1] (PAL).z64" size 16777216 crc 2a42b10f )
-)
-
-game (
-	name "Kobe Bryant's NBA Courtside"
-	description "Kobe Bryant's NBA Courtside"
-	rom ( name "Kobe Bryant in NBA Courtside (E) [!].z64" size 12582912 crc 1355a826 )
-	rom ( name "Kobe Bryant in NBA Courtside (E) [f1].z64" size 12582912 crc dc2dcd0b )
-	rom ( name "Kobe Bryant's NBA Courtside (U) [!].z64" size 12582912 crc 86360bfb )
-	rom ( name "Kobe Bryant's NBA Courtside (U) [f1].z64" size 12582912 crc e1fe4b7d )
-	rom ( name "Kobe Bryant's NBA Courtside (U) [h1C].z64" size 12582912 crc 13181cf8 )
-)
-
-game (
-	name "Last Legion UX"
-	description "Last Legion UX"
-	rom ( name "Last Legion UX (J) [!].z64" size 12582912 crc 9db99881 )
-	rom ( name "Last Legion UX (J) [a1].z64" size 12582912 crc c155e137 )
-	rom ( name "Last Legion UX (J) [b1].z64" size 9434802 crc a320e0f0 )
-	rom ( name "Last Legion UX (J) [b2].z64" size 12582912 crc 11260faa )
-)
-
-game (
-	name "Legend of Zelda, The - Majora's Mask"
-	description "Legend of Zelda, The - Majora's Mask"
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!].z64" size 33554432 crc 9ead1608 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [f1].z64" size 33554432 crc e6104497 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire].z64" size 33554432 crc 323c8ca3 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9e_Vampire].z64" size 33554432 crc 0f5eb553 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9f_Vampire].z64" size 33554432 crc 4cbc60dc )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9M_Vampire].z64" size 33554432 crc 9ef15b1e )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9P1+G_Vampire].z64" size 33554432 crc 8176eb83 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9Z3_Vampire].z64" size 33554432 crc ff12f3f4 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire].z64" size 33554432 crc 8ebf7691 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1).z64" size 33554432 crc e2e6823d )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) (GC).z64" size 33554432 crc b008458f )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [!].z64" size 33554432 crc b428d8a7 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [f1].z64" size 33554432 crc 5663ba96 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0].z64" size 33554432 crc 1fdf0ceb )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Rus0.85_Alex].z64" size 33554432 crc be6febf1 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+RusPreAlpha_Alex&gottax].z64" size 33554432 crc 0131dd2c )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.1_Alex].z64" size 33554432 crc 25cc969c )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.2_Alex].z64" size 33554432 crc 5ded3201 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.36Alex].z64" size 33554432 crc 74747e29 )
-	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.50_Alex].z64" size 33554432 crc 3f53645e )
-	rom ( name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!].z64" size 33554432 crc 12836e19 )
-	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc dcc110a0 )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!].z64" size 33554432 crc b9bf76df )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!].z64" size 33554432 crc 0d33e1db )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1].z64" size 33554432 crc a60de571 )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1][o1].z64" size 67108864 crc 749eab8f )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [f1].z64" size 33554432 crc 3be52ccf )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [o1].z64" size 67108864 crc d3ac5f99 )
-	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!].z64" size 33554432 crc 356c2e19 )
-)
-
-game (
-	name "Legend of Zelda, The - Ocarina of Time"
-	description "Legend of Zelda, The - Ocarina of Time"
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!].z64" size 33554432 crc 3fbd519f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [f1].z64" size 33554432 crc 9569957f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!].z64" size 33554432 crc 946fd0f7 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1].z64" size 33554432 crc 658905c6 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f1] (zpfc).z64" size 33554432 crc 1ccaf639 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f2] (zpc1).z64" size 33554432 crc 4fd78fc5 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!].z64" size 33554432 crc a108f6e3 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!].z64" size 33554432 crc 346de3ae )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack).z64" size 33554432 crc 7d951b34 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!].z64" size 33554432 crc cd16c529 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [b1].z64" size 33554432 crc 8f50bf38 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f1].z64" size 33554432 crc d77a70e8 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f2].z64" size 33554432 crc 1587879b )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f3].z64" size 33554432 crc 92a0cbfd )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Dut].z64" size 33554432 crc 5307f70b )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Ita100].z64" size 33554432 crc b5d1b588 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Pol1.3].z64" size 33554432 crc 0f6afb03 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.0].z64" size 33554432 crc 3e00d978 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.5BetaFinal].z64" size 33554432 crc 32d72425 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus1.0beta2_Sergey Anton].z64" size 33554432 crc 2174dbfa )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus101b2].z64" size 33554432 crc d2b87bdd )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa01b_toruzz].z64" size 33554432 crc a07beb6f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa097b2].z64" size 33554432 crc da6171cd )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa1.0].z64" size 33554432 crc 3e355253 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa2.0_eduardo_a2j].z64" size 33554432 crc afd60b23 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Pol1.2].z64" size 33554432 crc 92a5b35d )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.09].z64" size 33554432 crc f2cbb79e )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.14].z64" size 33554432 crc 995532c5 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.22].z64" size 33554432 crc 2fe15996 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.26].z64" size 33554432 crc bb45b0bf )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.28].z64" size 33554432 crc 0b86b28e )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.30].z64" size 33554432 crc d9fa73a7 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.33].z64" size 33554432 crc b68ea623 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.35].z64" size 33554432 crc ebdada62 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.37].z64" size 33554432 crc 11031b9f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.42].z64" size 33554432 crc 7a7ba9b5 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.01].z64" size 33554432 crc 03e96f36 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.06].z64" size 33554432 crc 01231a9f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.82].z64" size 33554432 crc 6b4d5fe7 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099bfix].z64" size 33554432 crc 88e7a5b6 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099wip].z64" size 33554432 crc 3c67188a )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Spa1.0_eduardo].z64" size 33554432 crc 38056e6d )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!].z64" size 33554432 crc 3fd2151e )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b1].z64" size 33554432 crc 91649d1b )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b2].z64" size 33554432 crc 63c8d30f )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100].z64" size 33554432 crc 39070e84 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por1.0].z64" size 33554432 crc 6553c572 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por100%].z64" size 33554432 crc ae32f542 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Spa01b_toruzz].z64" size 33554432 crc a924a530 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo].z64" size 33554432 crc ae802c75 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo][b1].z64" size 33554432 crc f04bb305 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!].z64" size 33554432 crc 32120c23 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [!].z64" size 33554432 crc 832d6449 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [f1] (NTSC).z64" size 33554432 crc 33ed5939 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [h1C].z64" size 33554432 crc 091d9d5c )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Ita70%_Rulesless].z64" size 33554432 crc b63dcb25 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Pol1.0].z64" size 33554432 crc ebb2ec57 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f1].z64" size 67108864 crc 9daa2516 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f2].bin" size 67108864 crc 20ab8205 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version).z64" size 67108864 crc 62f92704 )
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!].z64" size 33554432 crc c744c4db )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!].z64" size 33554432 crc d423e8b0 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1].z64" size 33554432 crc 0cb2aa02 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell].z64" size 33554432 crc 5c8e5553 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi].z64" size 33554432 crc 52662e13 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!].z64" size 33554432 crc 26e73887 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!].z64" size 33554432 crc 2b2721ba )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!].z64" size 33554432 crc 8c5b90c1 )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!].z64" size 33554432 crc 1c6ce8cb )
-	rom ( name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!].z64" size 33554432 crc 122ff261 )
-)
-
-game (
-	name "LEGO Racers"
-	description "LEGO Racers"
-	rom ( name "LEGO Racers (E) (M10) [!].z64" size 16777216 crc c7d9b21c )
-	rom ( name "LEGO Racers (U) (M10) [!].z64" size 16777216 crc 39407c9f )
-	rom ( name "LEGO Racers (U) (M10) [b1].z64" size 16777216 crc 4d1e1897 )
-	rom ( name "LEGO Racers (U) (M10) [b1][f1] (PAL).z64" size 16777216 crc 194358ef )
-	rom ( name "LEGO Racers (U) (M10) [b1][t1].z64" size 16777216 crc 21599de8 )
-)
-
-game (
-	name "Lode Runner 3-D"
-	description "Lode Runner 3-D"
-	rom ( name "Lode Runner 3-D (E) (M5) [!].z64" size 8388608 crc 7148251d )
-	rom ( name "Lode Runner 3-D (E) (M5) [b1].z64" size 8388608 crc c50c0ccb )
-	rom ( name "Lode Runner 3-D (J) [!].z64" size 8388608 crc 1d4fb466 )
-	rom ( name "Lode Runner 3-D (U) [!].z64" size 8388608 crc 4ea07453 )
-	rom ( name "Lode Runner 3-D (U) [b1][f1] (PAL).z64" size 7864320 crc e799d4be )
-	rom ( name "Lode Runner 3-D (U) [f1] (PAL).z64" size 8388608 crc 0dc54b5b )
-	rom ( name "Lode Runner 3-D (U) [t1].z64" size 8388608 crc 54ffcd02 )
-)
-
-game (
-	name "Lt. Duck Dodgers"
-	description "Lt. Duck Dodgers"
-	rom ( name "Lt. Duck Dodgers (Prototype).z64" size 20971520 crc 7291ba5b )
-)
-
-game (
-	name "Mace - The Dark Age"
-	description "Mace - The Dark Age"
-	rom ( name "Mace - The Dark Age (E) [!].z64" size 12582912 crc 57ddede1 )
-	rom ( name "Mace - The Dark Age (E) [b1].z64" size 12582912 crc d5a1c38c )
-	rom ( name "Mace - The Dark Age (E) [b2].z64" size 12582912 crc 5639e41a )
-	rom ( name "Mace - The Dark Age (E) [o1].z64" size 16777216 crc d09bda9c )
-	rom ( name "Mace - The Dark Age (E) [o2].z64" size 33554432 crc f89b3c8b )
-	rom ( name "Mace - The Dark Age (U) [!].z64" size 12582912 crc d2a363a6 )
-	rom ( name "Mace - The Dark Age (U) [b1].z64" size 12628669 crc c80ddbdc )
-	rom ( name "Mace - The Dark Age (U) [b2].z64" size 12582912 crc e5d6a780 )
-	rom ( name "Mace - The Dark Age (U) [b3].z64" size 16777216 crc da979923 )
-	rom ( name "Mace - The Dark Age (U) [b4].z64" size 12582912 crc 24b74e65 )
-	rom ( name "Mace - The Dark Age (U) [b5].z64" size 12582916 crc c993764f )
-	rom ( name "Mace - The Dark Age (U) [b6].z64" size 12058624 crc c5b79f9a )
-	rom ( name "Mace - The Dark Age (U) [b7].z64" size 16777216 crc 9beb0740 )
-	rom ( name "Mace - The Dark Age (U) [b8].z64" size 12582912 crc 5f6a8b72 )
-	rom ( name "Mace - The Dark Age (U) [b9].z64" size 12582912 crc 799b3ffb )
-	rom ( name "Mace - The Dark Age (U) [o1].z64" size 16777216 crc 12e470a7 )
-)
-
-game (
-	name "Madden Football 64"
-	description "Madden Football 64"
-	rom ( name "Madden Football 64 (E) [!].z64" size 12582912 crc fab3e50d )
-	rom ( name "Madden Football 64 (E) [b1].z64" size 12582912 crc d2100f88 )
-	rom ( name "Madden Football 64 (U) [!].z64" size 12582912 crc 42e5fafa )
-	rom ( name "Madden Football 64 (U) [b1].z64" size 16777216 crc d9addffc )
-	rom ( name "Madden Football 64 (U) [b2].z64" size 12582912 crc 89f3009b )
-	rom ( name "Madden Football 64 (U) [h1C].z64" size 12582912 crc 6a46107f )
-	rom ( name "Madden Football 64 (U) [o1].z64" size 16777216 crc 47226e0c )
-	rom ( name "Madden Football 64 (U) [o1][h1C].z64" size 16777216 crc 7cccb7c5 )
-	rom ( name "Madden Football 64 (U) [o2].z64" size 16777216 crc 563b4710 )
-	rom ( name "Madden Football 64 (U) [o3].z64" size 16777216 crc 225e1692 )
-)
-
-game (
-	name "Madden NFL 2000"
-	description "Madden NFL 2000"
-	rom ( name "Madden NFL 2000 (U) [!].z64" size 12582912 crc ef5f997b )
-)
-
-game (
-	name "Madden NFL 2001"
-	description "Madden NFL 2001"
-	rom ( name "Madden NFL 2001 (U) [!].z64" size 12582912 crc 245eaee8 )
-)
-
-game (
-	name "Madden NFL 2002"
-	description "Madden NFL 2002"
-	rom ( name "Madden NFL 2002 (U) [!].z64" size 12582912 crc f573f107 )
-)
-
-game (
-	name "Madden NFL 99"
-	description "Madden NFL 99"
-	rom ( name "Madden NFL 99 (E) [!].z64" size 12582912 crc d0929942 )
-	rom ( name "Madden NFL 99 (E) [h1C].z64" size 12582912 crc f83173c7 )
-	rom ( name "Madden NFL 99 (U) [!].z64" size 12582912 crc 2eb64fc2 )
-	rom ( name "Madden NFL 99 (U) [o1].z64" size 16777216 crc 06c06c02 )
-)
-
-game (
-	name "Magical Tetris Challenge"
-	description "Magical Tetris Challenge"
-	rom ( name "Defi au Tetris Magique (F) [!].z64" size 16777216 crc e7ef60e8 )
-	rom ( name "Magical Tetris Challenge (E) [!].z64" size 16777216 crc af3b099e )
-	rom ( name "Magical Tetris Challenge (E) [b1].z64" size 16777216 crc 32c5f787 )
-	rom ( name "Magical Tetris Challenge (E) [f1] (NTSC).z64" size 16777216 crc b7d8d550 )
-	rom ( name "Magical Tetris Challenge (G) [!].z64" size 16777216 crc 377f18e9 )
-	rom ( name "Magical Tetris Challenge (U) [!].z64" size 16777216 crc 22fe979c )
-	rom ( name "Magical Tetris Challenge (U) [b1][hI].z64" size 16777216 crc 93acd064 )
-	rom ( name "Magical Tetris Challenge (U) [hI].z64" size 16777216 crc b078e78d )
-	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [!].z64" size 16777216 crc 7efb2f1e )
-	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [b1].z64" size 16777216 crc 4d42abf7 )
-)
-
-game (
-	name "Mahjong 64"
-	description "Mahjong 64"
-	rom ( name "Mahjong 64 (J) [!].z64" size 8388608 crc dbe7d51a )
-	rom ( name "Mahjong 64 (J) [o1].z64" size 16777216 crc a3aac620 )
-	rom ( name "Mahjong 64 (J) [o2].z64" size 16777216 crc aa562908 )
-)
-
-game (
-	name "Mahjong Hourouki Classic"
-	description "Mahjong Hourouki Classic"
-	rom ( name "Mahjong Hourouki Classic (J) [!].z64" size 12582912 crc 990a8e54 )
-	rom ( name "Mahjong Hourouki Classic (J) [b1].z64" size 12582912 crc 9bd30b4b )
-	rom ( name "Mahjong Hourouki Classic (J) [b2].z64" size 8388608 crc ff6afbfe )
-	rom ( name "Mahjong Hourouki Classic (J) [b3].z64" size 12582912 crc de57ca3c )
-)
-
-game (
-	name "Mahjong Master"
-	description "Mahjong Master"
-	rom ( name "Mahjong Master (J) [!].z64" size 8388608 crc b68d596f )
-	rom ( name "Mahjong Master (J) [b1].z64" size 8388608 crc c993c7e5 )
-	rom ( name "Mahjong Master (J) [b2].z64" size 8126464 crc 9bf6fa03 )
-	rom ( name "Mahjong Master (J) [o1].z64" size 8388808 crc e4efe0e0 )
-)
-
-game (
-	name "Major League Baseball Featuring Ken Griffey Jr."
-	description "Major League Baseball Featuring Ken Griffey Jr."
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [!].z64" size 16777216 crc e08f7578 )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [b1].z64" size 16777216 crc ec77ac54 )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [f1].z64" size 16777216 crc a12efecc )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [!].z64" size 16777216 crc 2ef1ea20 )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b1].z64" size 16777216 crc 7ad4bbc9 )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b2].z64" size 16777216 crc 3769a87d )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b3].z64" size 16777216 crc 7b200444 )
-	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [f1].z64" size 16777216 crc 8ac7208c )
-)
-
-game (
-	name "Mario Golf"
-	description "Mario Golf"
-	rom ( name "Mario Golf (E) [!].z64" size 25165824 crc e5d723c7 )
-	rom ( name "Mario Golf (E) [f1] (Z64-Save).z64" size 33554432 crc 804cf5c2 )
-	rom ( name "Mario Golf (E) [f2] (Z64-Save).z64" size 25165824 crc 5451672f )
-	rom ( name "Mario Golf (E) [h1C].z64" size 25165824 crc 2e71189b )
-	rom ( name "Mario Golf (E) [o1].z64" size 33554432 crc a5071a77 )
-	rom ( name "Mario Golf (E) [o1][h1C].z64" size 33554432 crc 1183b2cb )
-	rom ( name "Mario Golf (U) [!].z64" size 25165824 crc 2d40abb0 )
-	rom ( name "Mario Golf (U) [b1].z64" size 25165824 crc 619f2d0e )
-	rom ( name "Mario Golf (U) [b1][f1] (PAL).z64" size 25165824 crc bf7c03e5 )
-	rom ( name "Mario Golf (U) [b2].z64" size 25165824 crc 353c3ee3 )
-	rom ( name "Mario Golf (U) [f1] (PAL).z64" size 33554432 crc 6ac0859f )
-	rom ( name "Mario Golf (U) [f2] (Z64-Save).z64" size 25165824 crc c705a039 )
-	rom ( name "Mario Golf (U) [o2][h1C].z64" size 33554432 crc 2fc4c216 )
-	rom ( name "Mario Golf (U) [t1].z64" size 25165824 crc 941e1852 )
-	rom ( name "Mario Golf 64 (J) [!].z64" size 25165824 crc 911f179a )
-	rom ( name "Mario Golf 64 (J) [b1].z64" size 33554432 crc 7c33129a )
-	rom ( name "Mario Golf 64 (J) [b1][f1] (PAL).z64" size 25165824 crc 15632a1a )
-	rom ( name "Mario Golf 64 (J) [b2].z64" size 25165824 crc c5995246 )
-	rom ( name "Mario Golf 64 (J) [f1] (PAL).z64" size 33554432 crc bf6ecc62 )
-	rom ( name "Mario Golf 64 (J) [o1].z64" size 33554432 crc bb03a1a6 )
-)
-
-game (
-	name "Mario Kart 64"
-	description "Mario Kart 64"
-	rom ( name "Mario Kart 64 (E) (V1.0) (Super W00ting Hack).z64" size 12582912 crc 27546369 )
-	rom ( name "Mario Kart 64 (E) (V1.0) [!].z64" size 12582912 crc faa6b083 )
-	rom ( name "Mario Kart 64 (E) (V1.0) [b1].z64" size 12582912 crc b0577c8a )
-	rom ( name "Mario Kart 64 (E) (V1.0) [b2].z64" size 12582912 crc ff0eee69 )
-	rom ( name "Mario Kart 64 (E) (V1.0) [T+Ita_Cattivik66].z64" size 12582912 crc d3811840 )
-	rom ( name "Mario Kart 64 (E) (V1.1) [!].z64" size 12582912 crc 0248f6c3 )
-	rom ( name "Mario Kart 64 (E) (V1.1) [o1].z64" size 33554432 crc b27a4098 )
-	rom ( name "Mario Kart 64 (E) (V1.1) [T+Ita_Cattivik66][b1].z64" size 12582912 crc 89fab579 )
-	rom ( name "Mario Kart 64 (J) (V1.0) [!].z64" size 12582912 crc 5d9696df )
-	rom ( name "Mario Kart 64 (J) (V1.0) [b1].z64" size 12582912 crc 0653af29 )
-	rom ( name "Mario Kart 64 (J) (V1.0) [b2].z64" size 12582912 crc 97b054ba )
-	rom ( name "Mario Kart 64 (J) (V1.0) [o1].z64" size 16777216 crc 2d84117a )
-	rom ( name "Mario Kart 64 (J) (V1.0) [T+Ita_Cattivik66][b1].z64" size 12582912 crc 85631d8c )
-	rom ( name "Mario Kart 64 (J) (V1.1) [!].z64" size 12582912 crc 6ced6472 )
-	rom ( name "Mario Kart 64 (J) (V1.1) [b1].z64" size 12582912 crc b3f6f8cc )
-	rom ( name "Mario Kart 64 (J) (V1.1) [b1][f1] (PAL).z64" size 12582912 crc 23ccd780 )
-	rom ( name "Mario Kart 64 (J) (V1.1) [b1][T+Ita_Cattivik66].z64" size 12582912 crc 9bdc5ace )
-	rom ( name "Mario Kart 64 (U) (Super W00ting Hack).z64" size 12582912 crc 87b17d90 )
-	rom ( name "Mario Kart 64 (U) [!].z64" size 12582912 crc 434389c1 )
-	rom ( name "Mario Kart 64 (U) [b1].z64" size 16777216 crc 9ded0ac7 )
-	rom ( name "Mario Kart 64 (U) [b2].z64" size 16777216 crc c98e9d4a )
-	rom ( name "Mario Kart 64 (U) [b3].z64" size 12582912 crc 08e55176 )
-	rom ( name "Mario Kart 64 (U) [b4].z64" size 12582912 crc 8a325af1 )
-	rom ( name "Mario Kart 64 (U) [h1C].z64" size 12582912 crc 89654ba4 )
-	rom ( name "Mario Kart 64 (U) [o1].z64" size 16777216 crc 166d8af1 )
-	rom ( name "Mario Kart 64 (U) [o2].z64" size 13893632 crc 98bd4147 )
-	rom ( name "Mario Kart 64 (U) [T+Ita0.01_Cattivik66].z64" size 12582912 crc f638d5e2 )
-	rom ( name "Mario Kart 64 (U) [T+Por1.0_Dr_X].z64" size 12582912 crc 32c5ec1e )
-	rom ( name "Mario Kart 64 (U) [t1].z64" size 12582912 crc d6161d88 )
-	rom ( name "Mario Kart 64 (U) [t2] (Course Cheat).z64" size 12582912 crc 5f053063 )
-	rom ( name "Mario Kart 64 (U) [t3] (Star Cheat).z64" size 14575980 crc 799a7466 )
-	rom ( name "Mario Kart 64 (U) [t4].z64" size 12582912 crc aa5f37a1 )
-)
-
-game (
-	name "Mario no Photopie"
-	description "Mario no Photopie"
-	rom ( name "Mario no Photopie (J) [!].z64" size 16777216 crc 1d69ca55 )
-	rom ( name "Mario no Photopie (J) [a1].z64" size 16777216 crc 176b3683 )
-)
-
-game (
-	name "Mario Party"
-	description "Mario Party"
-	rom ( name "Mario Party (E) (M3) [!].z64" size 33554432 crc da98a5d3 )
-	rom ( name "Mario Party (E) (M3) [b1].z64" size 33554432 crc 41aca890 )
-	rom ( name "Mario Party (E) (M3) [h1C].z64" size 33554432 crc 7b899fae )
-	rom ( name "Mario Party (J) [!].z64" size 33554432 crc 4f1adc7b )
-	rom ( name "Mario Party (U) [!].z64" size 33554432 crc 4d60abe5 )
-	rom ( name "Mario Party (U) [f1] (PAL).z64" size 33554432 crc c154d3b3 )
-)
-
-game (
-	name "Mario Party 2"
-	description "Mario Party 2"
-	rom ( name "Mario Party 2 (E) (M5) [!].z64" size 33554432 crc dc00357a )
-	rom ( name "Mario Party 2 (J) [!].z64" size 33554432 crc 7457b081 )
-	rom ( name "Mario Party 2 (U) [!].z64" size 33554432 crc e58a1955 )
-	rom ( name "Mario Party 2 (U) [f1] (PAL).z64" size 33554432 crc 08ffb2b3 )
-	rom ( name "Mario Party 2 (U) [f2] (PAL).z64" size 33554432 crc 3677f1bc )
-)
-
-game (
-	name "Mario Party 3"
-	description "Mario Party 3"
-	rom ( name "Mario Party 3 (E) (M4) [!].z64" size 33554432 crc 813b13f2 )
-	rom ( name "Mario Party 3 (J) [!].z64" size 33554432 crc 3fc04053 )
-	rom ( name "Mario Party 3 (U) [!].z64" size 33554432 crc b7445ddc )
-	rom ( name "Mario Party 3 (U) [f1].z64" size 33554432 crc e9a8da8c )
-	rom ( name "Mario Party 3 (U) [f2] (PAL).z64" size 33554432 crc 1e5a8f53 )
-	rom ( name "Mario Party 3 (U) [f3].z64" size 33554432 crc 2cb2b136 )
-)
-
-game (
-	name "Mario Tennis"
-	description "Mario Tennis"
-	rom ( name "Mario Tennis (E) [!].z64" size 16777216 crc 29aa5df4 )
-	rom ( name "Mario Tennis (U) [!].z64" size 16777216 crc 4e9560f6 )
-	rom ( name "Mario Tennis (U) [f1] (Save).z64" size 16777216 crc da72f0d6 )
-	rom ( name "Mario Tennis 64 (J) [!].z64" size 16777216 crc c665301d )
-	rom ( name "Mario Tennis 64 (J) [f1] (Country Check).z64" size 16777216 crc 3653db6a )
-)
-
-game (
-	name "Mega Man 64"
-	description "Mega Man 64"
-	rom ( name "Mega Man 64 (U) [!].z64" size 33554432 crc 1bfc71f0 )
-	rom ( name "Mega Man 64 (U) [t1][f1] (PAL-NTSC).z64" size 33554432 crc f09701ae )
-	rom ( name "Rockman Dash (J) [!].z64" size 33554432 crc 61eaee83 )
-)
-
-game (
-	name "Mia Hamm Soccer 64"
-	description "Mia Hamm Soccer 64"
-	rom ( name "Mia Hamm Soccer 64 (U) (M2) [!].z64" size 16777216 crc 2db3d3d6 )
-)
-
-game (
-	name "Michael Owens WLS 2000"
-	description "Michael Owens WLS 2000"
-	rom ( name "Michael Owens WLS 2000 (E) [!].z64" size 16777216 crc bb680cbe )
-	rom ( name "Michael Owens WLS 2000 (E) [b1].z64" size 16777216 crc 71684224 )
-	rom ( name "Michael Owens WLS 2000 (E) [b2].z64" size 16777216 crc 1dbc7c2d )
-	rom ( name "Michael Owens WLS 2000 (E) [f1] (NTSC).z64" size 17039360 crc 6b919894 )
-	rom ( name "RTL World League Soccer 2000 (G) [!].z64" size 16777216 crc 0a17da7b )
-	rom ( name "RTL World League Soccer 2000 (G) [f1] (NTSC).z64" size 17039360 crc a05d2f1f )
-	rom ( name "RTL World League Soccer 2000 (G) [f1][o1].z64" size 16777216 crc 7abe5f0a )
-	rom ( name "Telefoot Soccer 2000 (F) [!].z64" size 16777216 crc 7bd20931 )
-	rom ( name "Telefoot Soccer 2000 (F) [b1].z64" size 16777216 crc 86d4084b )
-	rom ( name "Telefoot Soccer 2000 (F) [f1] (NTSC).z64" size 17039360 crc 9e830833 )
-)
-
-game (
-	name "Mickey's Speedway USA"
-	description "Mickey's Speedway USA"
-	rom ( name "Mickey no Racing Challenge USA (J) [!].z64" size 33554432 crc 1aecfc56 )
-	rom ( name "Mickey's Speedway USA (E) (M5) [!].z64" size 33554432 crc 0ae51ea5 )
-	rom ( name "Mickey's Speedway USA (U) [!].z64" size 33554432 crc 2d4f8f1b )
-	rom ( name "Mickey's Speedway USA (U) [t1].z64" size 33554432 crc 24858a92 )
-)
-
-game (
-	name "Micro Machines 64 Turbo"
-	description "Micro Machines 64 Turbo"
-	rom ( name "Micro Machines 64 Turbo (E) (M5) [!].z64" size 12582912 crc 10b9ff1f )
-	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1].z64" size 12582912 crc 5dfe09a6 )
-	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1][f1] (NTSC).z64" size 12582912 crc 33b1cd80 )
-	rom ( name "Micro Machines 64 Turbo (E) (M5) [t1].z64" size 12582912 crc 314eff98 )
-	rom ( name "Micro Machines 64 Turbo (U) [!].z64" size 12582912 crc a62a2763 )
-	rom ( name "Micro Machines 64 Turbo (U) [a1][!].z64" size 12582912 crc 9ad74cef )
-	rom ( name "Micro Machines 64 Turbo (U) [b1].z64" size 12582912 crc aadf1a8b )
-	rom ( name "Micro Machines 64 Turbo (U) [t1].z64" size 12582912 crc b598c181 )
-)
-
-game (
-	name "Midway's Greatest Arcade Hits Volume 1"
-	description "Midway's Greatest Arcade Hits Volume 1"
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [!].z64" size 4194304 crc e5c1fedc )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b1].z64" size 4194304 crc 79f93575 )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b2].z64" size 4194304 crc dc4e9f77 )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1].z64" size 8388608 crc 3adb627e )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1][t1].z64" size 8388608 crc 6bbd79f0 )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t1].z64" size 8388608 crc 9f3bc746 )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2].z64" size 8012002 crc a3612c92 )
-	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2][b1].z64" size 8012002 crc 29c63281 )
-)
-
-game (
-	name "Mike Piazza's Strike Zone"
-	description "Mike Piazza's Strike Zone"
-	rom ( name "Mike Piazza's Strike Zone (U) [!].z64" size 12582912 crc cc253cab )
-	rom ( name "Mike Piazza's Strike Zone (U) [h1C].z64" size 12582912 crc 759df18e )
-	rom ( name "Mike Piazza's Strike Zone (U) [h2C].z64" size 12582912 crc fa1a59ce )
-	rom ( name "Mike Piazza's Strike Zone (U) [h3C].z64" size 12582912 crc 8374c598 )
-)
-
-game (
-	name "Milo's Astro Lanes"
-	description "Milo's Astro Lanes"
-	rom ( name "Milo's Astro Lanes (E) [!].z64" size 4194304 crc c08ce624 )
-	rom ( name "Milo's Astro Lanes (E) [o1].z64" size 8388608 crc 8172b1bd )
-	rom ( name "Milo's Astro Lanes (E) [o2].z64" size 33554432 crc 360fd523 )
-	rom ( name "Milo's Astro Lanes (U) [!].z64" size 4194304 crc 172fca97 )
-	rom ( name "Milo's Astro Lanes (U) [b1].z64" size 4194304 crc 3e898bb3 )
-	rom ( name "Milo's Astro Lanes (U) [h1C].z64" size 8388608 crc 81a075a0 )
-	rom ( name "Milo's Astro Lanes (U) [h2C].z64" size 4194304 crc 0fedf73a )
-	rom ( name "Milo's Astro Lanes (U) [o1].z64" size 8388608 crc dabcc4ee )
-	rom ( name "Milo's Astro Lanes (U) [o1][b1].z64" size 8388608 crc f31a85ca )
-)
-
-game (
-	name "Mischief Makers"
-	description "Mischief Makers"
-	rom ( name "Mischief Makers (E) [!].z64" size 8388608 crc 68a4f072 )
-	rom ( name "Mischief Makers (E) [b1].z64" size 8388608 crc 3c6d6432 )
-	rom ( name "Mischief Makers (U) [!].z64" size 8388608 crc 7d222d3f )
-	rom ( name "Mischief Makers (U) [b1].z64" size 8388608 crc 8a8e05f2 )
-	rom ( name "Mischief Makers (U) [o1].z64" size 16777216 crc 908a11d3 )
-	rom ( name "Yuke Yuke!! Trouble Makers (J) [!].z64" size 8388608 crc b69d3068 )
-	rom ( name "Yuke Yuke!! Trouble Makers (J) [a1].z64" size 8388608 crc e4117eb5 )
-	rom ( name "Yuke Yuke!! Trouble Makers (J) [b1].z64" size 8388608 crc a408b93b )
-	rom ( name "Yuke Yuke!! Trouble Makers (J) [o1].z64" size 16777216 crc 758b4189 )
-)
-
-game (
-	name "Mission Impossible"
-	description "Mission Impossible"
-	rom ( name "Mission Impossible (E) [!].z64" size 12582912 crc 2c7131d6 )
-	rom ( name "Mission Impossible (E) [b1].z64" size 12582912 crc 6b082b2c )
-	rom ( name "Mission Impossible (F) [!].z64" size 12582912 crc 282a350d )
-	rom ( name "Mission Impossible (F) [b1].z64" size 16777216 crc 94c43451 )
-	rom ( name "Mission Impossible (F) [b2].z64" size 12582912 crc 748ebd5b )
-	rom ( name "Mission Impossible (G) [!].z64" size 12582912 crc 67c30a2d )
-	rom ( name "Mission Impossible (I) [!].z64" size 12582912 crc 2d789d98 )
-	rom ( name "Mission Impossible (I) [f1] (NTSC).z64" size 12582912 crc b8da029f )
-	rom ( name "Mission Impossible (S) [!].z64" size 12582912 crc ebb060dc )
-	rom ( name "Mission Impossible (S) [f1] (NTSC).z64" size 12582912 crc e7141756 )
-	rom ( name "Mission Impossible (U) [!].z64" size 12582912 crc 3677a8b8 )
-	rom ( name "Mission Impossible (U) [b1].z64" size 12582912 crc f9b45a0e )
-	rom ( name "Mission Impossible (U) [b2].z64" size 12582912 crc 20530afe )
-	rom ( name "Mission Impossible (U) [f1] (PAL).z64" size 12582912 crc 8e9cbb30 )
-	rom ( name "Mission Impossible (U) [t1].z64" size 12582912 crc 37d8ebf1 )
-)
-
-game (
-	name "Monaco Grand Prix"
-	description "Monaco Grand Prix"
-	rom ( name "Monaco Grand Prix (U) [!].z64" size 16777216 crc e2bbeac1 )
-	rom ( name "Monaco Grand Prix (U) [f1] (PAL).z64" size 16777216 crc e84ac777 )
-	rom ( name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!].z64" size 16777216 crc 3f5e5830 )
-	rom ( name "Racing Simulation 2 (G) [!].z64" size 16777216 crc ba73a7e4 )
-	rom ( name "Racing Simulation 2 (G) [h1C].z64" size 16777216 crc 3c85a70b )
-)
-
-game (
-	name Monopoly
-	description "Monopoly"
-	rom ( name "Monopoly (U) [!].z64" size 8388608 crc c8cad8f6 )
-	rom ( name "Monopoly (U) [f1] (PAL).z64" size 8388608 crc 35fd44bd )
-)
-
-game (
-	name "Monster Truck Madness 64"
-	description "Monster Truck Madness 64"
-	rom ( name "Monster Truck Madness 64 (E) (M5) [!].z64" size 8388608 crc 4731df5c )
-	rom ( name "Monster Truck Madness 64 (E) (M5) [f1] (NTSC).z64" size 8388608 crc 1f63fcf2 )
-	rom ( name "Monster Truck Madness 64 (U) [!].z64" size 8388608 crc 3fd0604d )
-	rom ( name "Monster Truck Madness 64 (U) [t1].z64" size 8388608 crc 30502368 )
-)
-
-game (
-	name "Morita Shougi 64"
-	description "Morita Shougi 64"
-	rom ( name "Morita Shougi 64 (J) [!].z64" size 8388608 crc 88c83511 )
-)
-
-game (
-	name "Mortal Kombat 4"
-	description "Mortal Kombat 4"
-	rom ( name "Mortal Kombat 4 (E) [!].z64" size 16777216 crc 635adeca )
-	rom ( name "Mortal Kombat 4 (E) [h1C].z64" size 16777216 crc b1f79756 )
-	rom ( name "Mortal Kombat 4 (E) [t1] (Hit Anywhere).z64" size 16777216 crc 7ea0d2f1 )
-	rom ( name "Mortal Kombat 4 (U) [!].z64" size 16777216 crc b7f46516 )
-	rom ( name "Mortal Kombat 4 (U) [b1].z64" size 16777216 crc 1f5466b1 )
-	rom ( name "Mortal Kombat 4 (U) [b2].z64" size 16777216 crc e44b4a50 )
-	rom ( name "Mortal Kombat 4 (U) [b3].z64" size 15466496 crc 5629d9dc )
-	rom ( name "Mortal Kombat 4 (U) [h1C].z64" size 16777216 crc 65592c8a )
-	rom ( name "Mortal Kombat 4 (U) [t1].z64" size 16777216 crc f0411ee7 )
-	rom ( name "Mortal Kombat 4 (U) [t1][f1] (PAL).z64" size 16777216 crc eb90e97c )
-	rom ( name "Mortal Kombat 4 (U) [t2] (Hit Anywhere).z64" size 16777216 crc ba5f7aba )
-)
-
-game (
-	name "Mortal Kombat Mythologies - Sub-Zero"
-	description "Mortal Kombat Mythologies - Sub-Zero"
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [!].z64" size 16777216 crc ea21015a )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [h1C].z64" size 16777216 crc d974b2d5 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [t1] (Endless Ice).z64" size 16777216 crc 9ecffded )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [!].z64" size 16777216 crc 51a07fd9 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b1].z64" size 16777216 crc 07a1666d )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b2].z64" size 2613248 crc 03e5e2e8 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b3].z64" size 15728640 crc ab1092fb )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f1].z64" size 16777216 crc e74e2821 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f3] (PAL).z64" size 16777216 crc d47f76dd )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h1C].z64" size 16777216 crc 796de304 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h2C].z64" size 16777216 crc 7f31e315 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [o1].z64" size 16769024 crc 56397c81 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t1].z64" size 16777216 crc 751a2b19 )
-	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t2] (Endless Ice).z64" size 16777216 crc 85e4462b )
-)
-
-game (
-	name "Mortal Kombat Trilogy"
-	description "Mortal Kombat Trilogy"
-	rom ( name "Mortal Kombat Trilogy (E) [!].z64" size 12582912 crc bc04c62f )
-	rom ( name "Mortal Kombat Trilogy (E) [b1].z64" size 16777216 crc 05c20375 )
-	rom ( name "Mortal Kombat Trilogy (E) [h1C].z64" size 12582912 crc 110585fb )
-	rom ( name "Mortal Kombat Trilogy (E) [o1].z64" size 16777216 crc f28ed18e )
-	rom ( name "Mortal Kombat Trilogy (E) [t1] (Hit Anywhere).z64" size 12582912 crc 942be6ca )
-	rom ( name "Mortal Kombat Trilogy (E) [t2] (All Attacks Hurt P1).z64" size 12582912 crc ca1756b0 )
-	rom ( name "Mortal Kombat Trilogy (E) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 2a0538c8 )
-	rom ( name "Mortal Kombat Trilogy (E) [t4] (Hyper Mode).z64" size 12582912 crc bf347c36 )
-	rom ( name "Mortal Kombat Trilogy (E) [t5] (2x Aggressor).z64" size 12582912 crc 865fded9 )
-	rom ( name "Mortal Kombat Trilogy (E) [t6] (P1 Invincible).z64" size 12582912 crc 7fa1c269 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [!].z64" size 12582912 crc 50a99d60 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b1].z64" size 8388608 crc a2d599e0 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b2].z64" size 16873070 crc 04b7a1c2 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b3].z64" size 16777216 crc 1cd3f9aa )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b4].z64" size 12582912 crc 0cc21088 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b5].z64" size 12582912 crc f66d6fc0 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h1C].z64" size 12582912 crc 8a9fb090 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h2C].z64" size 12582912 crc 241ebd3a )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1].z64" size 16777216 crc 8848ccd8 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h1C].z64" size 16777216 crc 80acf17b )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h2C].z64" size 16777216 crc 5e190b89 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t1] (Hit Anywhere).z64" size 12582912 crc e89a5e5d )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t2] (All Attacks Hurt P1).z64" size 12582912 crc 9d5a1f62 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 214e58d3 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t4] (Hyper Mode).z64" size 12582912 crc 776a74c3 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t5] (2x Aggressor).z64" size 12582912 crc f760ec0c )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t6] (P1 Invincible).z64" size 12582912 crc 6ab8d104 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [!].z64" size 12582912 crc 0f323d00 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere).z64" size 12582912 crc 2df614f4 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t2] (All Attacks Hurt P1).z64" size 12582912 crc f73189db )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 4a75dbef )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t4] (Hyper Mode).z64" size 12582912 crc c39464a6 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t5] (2x Aggressor).z64" size 12582912 crc 846a9593 )
-	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t6] (P1 Invincible).z64" size 12582912 crc 58ca16a1 )
-	rom ( name "Rape Kombat Trilogy Beta1 (Mortal Kombat Hack).z64" size 12582912 crc 9e6bb93d )
-)
-
-game (
-	name "MRC - Multi Racing Championship"
-	description "MRC - Multi Racing Championship"
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [!].z64" size 12582912 crc bc966b10 )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [b1].z64" size 16777216 crc 2a7f6b3a )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [b2].z64" size 16777216 crc 32df39a3 )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [b3].z64" size 12582912 crc 2e030f26 )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [h1C].z64" size 12582912 crc 4faca987 )
-	rom ( name "MRC - Multi Racing Championship (E) (M3) [o1].z64" size 16777216 crc 89d3ab70 )
-	rom ( name "MRC - Multi Racing Championship (J) [!].z64" size 12582912 crc bea43300 )
-	rom ( name "MRC - Multi Racing Championship (J) [b1].z64" size 16777216 crc cc67323b )
-	rom ( name "MRC - Multi Racing Championship (J) [b2].z64" size 12582912 crc 772f3e51 )
-	rom ( name "MRC - Multi Racing Championship (J) [b3].z64" size 16777216 crc e75e186d )
-	rom ( name "MRC - Multi Racing Championship (J) [b4].z64" size 12582912 crc a0cb84f1 )
-	rom ( name "MRC - Multi Racing Championship (J) [b5].z64" size 12582912 crc 5d3113eb )
-	rom ( name "MRC - Multi Racing Championship (U) [!].z64" size 12582912 crc 1dc1c812 )
-	rom ( name "MRC - Multi Racing Championship (U) [b1].z64" size 8107444 crc f5a9068f )
-	rom ( name "MRC - Multi Racing Championship (U) [b2].z64" size 12574720 crc 0d186242 )
-	rom ( name "MRC - Multi Racing Championship (U) [b3].z64" size 12582912 crc 1f56a884 )
-	rom ( name "MRC - Multi Racing Championship (U) [o1].z64" size 16777216 crc e406a452 )
-)
-
-game (
-	name "Ms. Pac-Man - Maze Madness"
-	description "Ms. Pac-Man - Maze Madness"
-	rom ( name "Ms. Pac-Man - Maze Madness (U) [!].z64" size 12582912 crc e34c7060 )
-)
-
-game (
-	name "Mystical Ninja Starring Goemon"
-	description "Mystical Ninja Starring Goemon"
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b1].z64" size 16777216 crc 4c40eb14 )
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b2].z64" size 16777216 crc 911b3ce5 )
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C].z64" size 16777216 crc 95c9da86 )
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C][t1].z64" size 16777216 crc c059bef1 )
-	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J).z64" size 16777216 crc 2e91efc9 )
-	rom ( name "Mystical Ninja Starring Goemon (E) [!].z64" size 16777216 crc 3bd9059a )
-	rom ( name "Mystical Ninja Starring Goemon (E) [b1].z64" size 16777216 crc 266b1f56 )
-	rom ( name "Mystical Ninja Starring Goemon (E) [h1C].z64" size 16777216 crc fc486459 )
-	rom ( name "Mystical Ninja Starring Goemon (E) [t1].z64" size 16777216 crc 7a0c2406 )
-	rom ( name "Mystical Ninja Starring Goemon (U) [!].z64" size 16777216 crc 4180c296 )
-	rom ( name "Mystical Ninja Starring Goemon (U) [h1C].z64" size 16777216 crc 8611a355 )
-	rom ( name "Mystical Ninja Starring Goemon (U) [t1].z64" size 16777216 crc ffda5261 )
-	rom ( name "Mystical Ninja Starring Goemon (U) [t1][h2C].z64" size 16777216 crc d5280782 )
-	rom ( name "Mystical Ninja Starring Goemon (U) [t2].z64" size 16777216 crc 48a584de )
-)
-
-game (
-	name "N64DD IPLROM"
-	description "N64DD IPLROM"
-	rom ( name "N64DD IPLROM (J).n64" size 4194304 crc 7f933ce2 )
-)
-
-game (
-	name "Nagano Winter Olympics '98"
-	description "Nagano Winter Olympics '98"
-	rom ( name "Hyper Olympics Nagano 64 (J) [!].z64" size 12582912 crc c1ea5d33 )
-	rom ( name "Hyper Olympics Nagano 64 (J) [b1].z64" size 16777216 crc b6bb1bf7 )
-	rom ( name "Hyper Olympics Nagano 64 (J) [b2].z64" size 12320768 crc f1865c1b )
-	rom ( name "Hyper Olympics Nagano 64 (J) [b3].z64" size 12582912 crc 8d9ca6e8 )
-	rom ( name "Hyper Olympics Nagano 64 (J) [o1].z64" size 16777216 crc e50ede25 )
-	rom ( name "Nagano Winter Olympics '98 (E) [!].z64" size 12582912 crc c44de11c )
-	rom ( name "Nagano Winter Olympics '98 (E) [h1C].z64" size 12582912 crc 9bfba6c3 )
-	rom ( name "Nagano Winter Olympics '98 (E) [o1].z64" size 16777216 crc 13fb3b46 )
-	rom ( name "Nagano Winter Olympics '98 (U) [!].z64" size 12582912 crc ee8288d4 )
-	rom ( name "Nagano Winter Olympics '98 (U) [b1].z64" size 12582912 crc 2034b668 )
-	rom ( name "Nagano Winter Olympics '98 (U) [b2].z64" size 12320768 crc cfe4f4ad )
-	rom ( name "Nagano Winter Olympics '98 (U) [h1C].z64" size 12582912 crc b70fa5b8 )
-	rom ( name "Nagano Winter Olympics '98 (U) [o1].z64" size 16777216 crc bc27f178 )
-	rom ( name "Nagano Winter Olympics '98 (U) [o2].z64" size 16777216 crc 026db3c7 )
-	rom ( name "Nagano Winter Olympics '98 (U) [T+Ita_HRG].z64" size 12582912 crc 24838711 )
-)
-
-game (
-	name "Namco Museum 64"
-	description "Namco Museum 64"
-	rom ( name "Namco Museum 64 (U) [!].z64" size 4194304 crc ce361f92 )
-	rom ( name "Namco Museum 64 (U) [f1] (PAL).z64" size 8388608 crc a4ec448b )
-	rom ( name "Namco Museum 64 (U) [o1].z64" size 8388608 crc 843d5802 )
-	rom ( name "Namco Museum 64 (U) [o1][f1] (PAL).z64" size 8388608 crc d76c2fbf )
-	rom ( name "Namco Museum 64 (U) [t1].z64" size 4194304 crc e3cc9ea8 )
-)
-
-game (
-	name "NASCAR 2000"
-	description "NASCAR 2000"
-	rom ( name "NASCAR 2000 (U) [!].z64" size 12582912 crc 02bf7c2d )
-	rom ( name "NASCAR 2000 (U) [f1] (PAL).z64" size 12582912 crc 83bdd48a )
-)
-
-game (
-	name "NASCAR 99"
-	description "NASCAR 99"
-	rom ( name "NASCAR 99 (E) (M3) [!].z64" size 12582912 crc 76e79cea )
-	rom ( name "NASCAR 99 (E) (M3) [h1C].z64" size 12582912 crc 5e44766f )
-	rom ( name "NASCAR 99 (U) [!].z64" size 12582912 crc 3d8eb950 )
-	rom ( name "NASCAR 99 (U) [b1].z64" size 12582912 crc 982b5ccd )
-	rom ( name "NASCAR 99 (U) [b2].z64" size 12582912 crc 28df02b4 )
-	rom ( name "NASCAR 99 (U) [b3].z64" size 12582912 crc 1f3774e6 )
-	rom ( name "NASCAR 99 (U) [f1] (PAL).z64" size 12582912 crc b1183fe4 )
-	rom ( name "NASCAR 99 (U) [o1].z64" size 16777216 crc a948f28c )
-)
-
-game (
-	name "NBA Courtside 2 - Featuring Kobe Bryant"
-	description "NBA Courtside 2 - Featuring Kobe Bryant"
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!].z64" size 16777216 crc a7cc4ce2 )
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL).z64" size 16777216 crc 39154eb0 )
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f2].z64" size 16777216 crc 81f2b85b )
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI].z64" size 16777216 crc 4f3e62dc )
-	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI][f1] (PAL).z64" size 16777216 crc 13bc6d87 )
-)
-
-game (
-	name "NBA Hangtime"
-	description "NBA Hangtime"
-	rom ( name "NBA Hangtime (E) [!].z64" size 12582912 crc 7e6d00ae )
-	rom ( name "NBA Hangtime (E) [h1C].z64" size 12582912 crc 69328df0 )
-	rom ( name "NBA Hangtime (U) [!].z64" size 12582912 crc 714cf532 )
-	rom ( name "NBA Hangtime (U) [b1].z64" size 12582912 crc 0f2126a5 )
-	rom ( name "NBA Hangtime (U) [b2].z64" size 16777216 crc 0027d41f )
-	rom ( name "NBA Hangtime (U) [b3].z64" size 12582912 crc 975dd6cb )
-	rom ( name "NBA Hangtime (U) [f1] (PAL).z64" size 16777216 crc e7e8ef6c )
-	rom ( name "NBA Hangtime (U) [o1].z64" size 16777216 crc 2590c84e )
-	rom ( name "NBA Hangtime (U) [o1][f1].z64" size 12582912 crc 0eb4eba0 )
-)
-
-game (
-	name "NBA In the Zone '98"
-	description "NBA In the Zone '98"
-	rom ( name "NBA In the Zone '98 (J) [!].z64" size 12582912 crc aed2700a )
-	rom ( name "NBA In the Zone '98 (J) [o1].z64" size 16777216 crc 6e35773e )
-	rom ( name "NBA In the Zone '98 (J) [o2].z64" size 16777216 crc 093ec0fb )
-	rom ( name "NBA In the Zone '98 (U) [!].z64" size 12582912 crc a245d737 )
-	rom ( name "NBA In the Zone '98 (U) [b1].z64" size 16777216 crc 8b5dc438 )
-	rom ( name "NBA In the Zone '98 (U) [b2].z64" size 6946816 crc dbe6eccd )
-	rom ( name "NBA In the Zone '98 (U) [b3].z64" size 16752472 crc fef7e360 )
-	rom ( name "NBA In the Zone '98 (U) [h1C].z64" size 16777216 crc 6f4d6051 )
-	rom ( name "NBA In the Zone '98 (U) [h2C].z64" size 12582912 crc 878878ea )
-	rom ( name "NBA In the Zone '98 (U) [o1].z64" size 16777216 crc d30de54f )
-	rom ( name "NBA Pro 98 (E) [!].z64" size 12582912 crc 04b75ccc )
-)
-
-game (
-	name "NBA In the Zone '99"
-	description "NBA In the Zone '99"
-	rom ( name "NBA In the Zone '99 (U) [!].z64" size 12582912 crc eab083b8 )
-	rom ( name "NBA In the Zone 2 (J) [!].z64" size 12582912 crc 41093b73 )
-	rom ( name "NBA Pro 99 (E) [!].z64" size 12582912 crc 588e60e8 )
-	rom ( name "NBA Pro 99 (E) [f1] (NTSC).z64" size 12582912 crc dfd7b539 )
-)
-
-game (
-	name "NBA In the Zone 2000"
-	description "NBA In the Zone 2000"
-	rom ( name "NBA In the Zone 2000 (E) [!].z64" size 16777216 crc a4973197 )
-	rom ( name "NBA In the Zone 2000 (E) [h1C].z64" size 16777216 crc 9e6568a5 )
-	rom ( name "NBA In the Zone 2000 (U) [!].z64" size 16777216 crc cbb4b730 )
-	rom ( name "NBA In the Zone 2000 (U) [f1] (PAL).z64" size 16777216 crc e5956e4c )
-)
-
-game (
-	name "NBA Jam 2000"
-	description "NBA Jam 2000"
-	rom ( name "NBA Jam 2000 (E) [!].z64" size 16777216 crc 9f95485e )
-	rom ( name "NBA Jam 2000 (U) [!].z64" size 16777216 crc 163dadf9 )
-	rom ( name "NBA Jam 2000 (U) [f1] (PAL).z64" size 16777216 crc 18914b4f )
-)
-
-game (
-	name "NBA Jam 99"
-	description "NBA Jam 99"
-	rom ( name "NBA Jam 99 (E) [!].z64" size 12582912 crc 90e4275b )
-	rom ( name "NBA Jam 99 (E) [h1C].z64" size 12582912 crc f76d0149 )
-	rom ( name "NBA Jam 99 (U) [!].z64" size 12582912 crc 559cd6b1 )
-	rom ( name "NBA Jam 99 (U) [b1].z64" size 12582912 crc af017390 )
-	rom ( name "NBA Jam 99 (U) [f1] (PAL).z64" size 12582912 crc babdb2b6 )
-)
-
-game (
-	name "NBA Live 2000"
-	description "NBA Live 2000"
-	rom ( name "NBA Live 2000 (E) (M4) [!].z64" size 16777216 crc 0e4b944c )
-	rom ( name "NBA Live 2000 (U) (M4) [!].z64" size 16777216 crc 7c3bc95e )
-)
-
-game (
-	name "NBA Live 99"
-	description "NBA Live 99"
-	rom ( name "NBA Live 99 (E) (M5) [!].z64" size 16777216 crc a316df37 )
-	rom ( name "NBA Live 99 (U) (M5) [!].z64" size 16777216 crc 9be0a7ac )
-	rom ( name "NBA Live 99 (U) (M5) [b1].z64" size 16777216 crc f5ca13c9 )
-	rom ( name "NBA Live 99 (U) (M5) [b2].z64" size 16777216 crc eea737e2 )
-	rom ( name "NBA Live 99 (U) (M5) [b3].z64" size 16777216 crc 2544b74b )
-)
-
-game (
-	name "NBA Showtime - NBA on NBC"
-	description "NBA Showtime - NBA on NBC"
-	rom ( name "NBA Showtime - NBA on NBC (U) [!].z64" size 16777216 crc a4e378f4 )
-	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (Country Check).z64" size 16777216 crc a8ef96b3 )
-	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (PAL).z64" size 16777216 crc 2d2a5374 )
-)
-
-game (
-	name "Neon Genesis Evangelion"
-	description "Neon Genesis Evangelion"
-	rom ( name "Neon Genesis Evangelion (J) [!].z64" size 33554432 crc a10a86af )
-	rom ( name "Neon Genesis Evangelion (J) [b1].z64" size 33554432 crc 50c86364 )
-	rom ( name "Neon Genesis Evangelion (J) [b2].z64" size 31317000 crc 960855f8 )
-	rom ( name "Neon Genesis Evangelion (J) [b3].z64" size 33554432 crc 283ba9ba )
-	rom ( name "Neon Genesis Evangelion (J) [f1] (PAL).z64" size 33554432 crc e718d433 )
-)
-
-game (
-	name "New Tetris, The"
-	description "New Tetris, The"
-	rom ( name "New Tetris, The (E) [!].z64" size 12582912 crc 983263d7 )
-	rom ( name "New Tetris, The (U) [!].z64" size 12582912 crc 528a07fa )
-	rom ( name "New Tetris, The (U) [f1] (PAL).z64" size 12582912 crc 335530e4 )
-	rom ( name "New Tetris, The (U) [f2] (PAL).z64" size 12582912 crc d9242d9f )
-	rom ( name "New Tetris, The (U) [f3] (PAL).z64" size 12582912 crc 2b5cae1e )
-	rom ( name "Tetris 64 (J) [!].z64" size 8388608 crc f128cd17 )
-	rom ( name "Tetris 64 (J) [b1].z64" size 8388608 crc 4d282f22 )
-	rom ( name "Tetris 64 (J) [b2].z64" size 8388608 crc 17050b7d )
-	rom ( name "Tetris 64 (J) [T+Ita].z64" size 8388608 crc ad0d86d9 )
-)
-
-game (
-	name "NFL Blitz"
-	description "NFL Blitz"
-	rom ( name "NFL Blitz (U) [!].z64" size 16777216 crc 9bcd670f )
-	rom ( name "NFL Blitz (U) [f1] (PAL).z64" size 16777216 crc adfdb71e )
-)
-
-game (
-	name "NFL Blitz - Special Edition"
-	description "NFL Blitz - Special Edition"
-	rom ( name "NFL Blitz - Special Edition (U) [!].z64" size 16777216 crc 5d1907f7 )
-)
-
-game (
-	name "NFL Blitz 2000"
-	description "NFL Blitz 2000"
-	rom ( name "NFL Blitz 2000 (U) [!].z64" size 16777216 crc 7f471773 )
-	rom ( name "NFL Blitz 2000 (U) [f1] (PAL).z64" size 16777216 crc cfa472f3 )
-)
-
-game (
-	name "NFL Blitz 2001"
-	description "NFL Blitz 2001"
-	rom ( name "NFL Blitz 2001 (U) [!].z64" size 16777216 crc 18eeb41b )
-	rom ( name "NFL Blitz 2001 (U) [f1] (PAL-NTSC).z64" size 16777216 crc 02012098 )
-)
-
-game (
-	name "NFL Quarterback Club 2000"
-	description "NFL Quarterback Club 2000"
-	rom ( name "NFL Quarterback Club 2000 (E) [!].z64" size 12582912 crc ceef5c29 )
-	rom ( name "NFL Quarterback Club 2000 (U) [!].z64" size 12582912 crc 8f54f999 )
-	rom ( name "NFL Quarterback Club 2000 (U) [b1].z64" size 12581403 crc 1a7b61bf )
-	rom ( name "NFL Quarterback Club 2000 (U) [b2].z64" size 12582912 crc fff3b2df )
-)
-
-game (
-	name "NFL Quarterback Club 2001"
-	description "NFL Quarterback Club 2001"
-	rom ( name "NFL Quarterback Club 2001 (U) [!].z64" size 12582912 crc 6d849e17 )
-)
-
-game (
-	name "NFL Quarterback Club 98"
-	description "NFL Quarterback Club 98"
-	rom ( name "NFL Quarterback Club 98 (E) [!].z64" size 8388608 crc 34a21417 )
-	rom ( name "NFL Quarterback Club 98 (E) [o1].z64" size 16777216 crc 4da5b881 )
-	rom ( name "NFL Quarterback Club 98 (U) [!].z64" size 8388608 crc abf0e8f2 )
-	rom ( name "NFL Quarterback Club 98 (U) [b1].z64" size 8388608 crc a34d7669 )
-	rom ( name "NFL Quarterback Club 98 (U) [o1].z64" size 16777216 crc 8244762b )
-)
-
-game (
-	name "NFL Quarterback Club 99"
-	description "NFL Quarterback Club 99"
-	rom ( name "NFL Quarterback Club 99 (E) [!].z64" size 12582912 crc f688bdf3 )
-	rom ( name "NFL Quarterback Club 99 (E) [b1].z64" size 12582912 crc 579b3a20 )
-	rom ( name "NFL Quarterback Club 99 (U) [!].z64" size 12582912 crc 44496b26 )
-)
-
-game (
-	name "NHL 99"
-	description "NHL 99"
-	rom ( name "NHL 99 (E) [!].z64" size 12582912 crc f3b2aa4d )
-	rom ( name "NHL 99 (U) [!].z64" size 12582912 crc e5df2afe )
-)
-
+	name "Z64 BIOS V2.00 (Barebones)"
+	description "Z64 BIOS V2.00 (Barebones)"
+	rom ( name "Z64 BIOS V2.00 (Barebones).bin" crc B00306A3 )
+)
+
 game (
-	name "NHL Blades of Steel '99"
-	description "NHL Blades of Steel '99"
-	rom ( name "NHL Blades of Steel '99 (U) [!].z64" size 12582912 crc 1ee678fe )
-	rom ( name "NHL Blades of Steel '99 (U) [f1] (PAL).z64" size 12582912 crc e8bc286a )
-	rom ( name "NHL Pro 99 (E) [!].z64" size 12582912 crc e272867e )
-	rom ( name "NHL Pro 99 (E) [o1].z64" size 33554432 crc af94245e )
-)
-
+	name "Z64 BIOS V2.00"
+	description "Z64 BIOS V2.00"
+	rom ( name "Z64 BIOS V2.00.bin" crc 21BA9967 )
+)
+
 game (
-	name "NHL Breakaway 98"
-	description "NHL Breakaway 98"
-	rom ( name "NHL Breakaway 98 (E) [!].z64" size 12582912 crc 8c0c9669 )
-	rom ( name "NHL Breakaway 98 (E) [f1] (NTSC).z64" size 12582912 crc 3618bba7 )
-	rom ( name "NHL Breakaway 98 (E) [h1C].z64" size 12582912 crc ed786754 )
-	rom ( name "NHL Breakaway 98 (E) [o1].z64" size 16777216 crc 02faddca )
-	rom ( name "NHL Breakaway 98 (E) [o1][h1C].z64" size 16777216 crc e9e248fe )
-	rom ( name "NHL Breakaway 98 (U) [!].z64" size 12582912 crc 49d86c00 )
-	rom ( name "NHL Breakaway 98 (U) [h1C].z64" size 12582912 crc b3dcbbb8 )
-	rom ( name "NHL Breakaway 98 (U) [o1].z64" size 16777216 crc 4c866c4d )
-	rom ( name "NHL Breakaway 98 (U) [o1][h1C].z64" size 16777216 crc f21257c9 )
-)
-
-game (
-	name "NHL Breakaway 99"
-	description "NHL Breakaway 99"
-	rom ( name "NHL Breakaway 99 (E) [!].z64" size 12582912 crc 572060e0 )
-	rom ( name "NHL Breakaway 99 (E) [b1].z64" size 12582912 crc 8612c050 )
-	rom ( name "NHL Breakaway 99 (U) [!].z64" size 12582912 crc 75f75b9d )
-	rom ( name "NHL Breakaway 99 (U) [b1].z64" size 12582912 crc 1f962087 )
-	rom ( name "NHL Breakaway 99 (U) [b2].z64" size 12582912 crc 8287f822 )
+	name "Z64 BIOS V2.00b (Ravemax Hack)"
+	description "Z64 BIOS V2.00b (Ravemax Hack)"
+	rom ( name "Z64 BIOS V2.00b (Ravemax Hack).bin" crc 5B9BE146 )
 )
 
 game (
-	name "Nightmare Creatures"
-	description "Nightmare Creatures"
-	rom ( name "Nightmare Creatures (U) [!].z64" size 16777216 crc 6a1eb795 )
-	rom ( name "Nightmare Creatures (U) [b1].z64" size 16838806 crc d10db6b6 )
-	rom ( name "Nightmare Creatures (U) [b2].z64" size 16777216 crc abe329e1 )
-	rom ( name "Nightmare Creatures (U) [t1].z64" size 16777216 crc 82ce76b5 )
-	rom ( name "Nightmare Creatures (U) [t2].z64" size 16777216 crc ec39285d )
+	name "Z64 BIOS V2.10NTSC"
+	description "Z64 BIOS V2.10NTSC"
+	rom ( name "Z64 BIOS V2.10NTSC.bin" crc 7A94038D )
 )
 
 game (
-	name "Nintama Rantarou 64 Game Gallery"
-	description "Nintama Rantarou 64 Game Gallery"
-	rom ( name "Nintama Rantarou 64 Game Gallery (J) [!].z64" size 8388608 crc 8c7c2dca )
+	name "Z64 BIOS V2.10PAL"
+	description "Z64 BIOS V2.10PAL"
+	rom ( name "Z64 BIOS V2.10PAL.bin" crc B9D3DE21 )
 )
 
 game (
-	name "Nuclear Strike 64"
-	description "Nuclear Strike 64"
-	rom ( name "Nuclear Strike 64 (E) (M2) [!].z64" size 33554432 crc 9afbfcaf )
-	rom ( name "Nuclear Strike 64 (E) (M2) [h1C].z64" size 33554432 crc 7b1479a9 )
-	rom ( name "Nuclear Strike 64 (G) [!].z64" size 33554432 crc 0916ab13 )
-	rom ( name "Nuclear Strike 64 (U) [!].z64" size 33554432 crc d7467294 )
-	rom ( name "Nuclear Strike 64 (U) [b1].z64" size 33554432 crc ce1f9ec3 )
-	rom ( name "Nuclear Strike 64 (U) [f1] (PAL).z64" size 33554432 crc 484f91ed )
-	rom ( name "Nuclear Strike 64 (U) [t1].z64" size 33554432 crc a9206eb3 )
+	name "Z64 BIOS V2.11NTSC"
+	description "Z64 BIOS V2.11NTSC"
+	rom ( name "Z64 BIOS V2.11NTSC.bin" crc 19D51222 )
 )
 
 game (
-	name "Nushi Tsuri 64"
-	description "Nushi Tsuri 64"
-	rom ( name "Nushi Tsuri 64 (J) [!].z64" size 16777216 crc a6800ec0 )
-	rom ( name "Nushi Tsuri 64 (J) [b1].z64" size 16777216 crc 01fe5ae4 )
-	rom ( name "Nushi Tsuri 64 (J) [b2].z64" size 16777216 crc 22dbdd94 )
-	rom ( name "Nushi Tsuri 64 (J) [b3].z64" size 16777216 crc d5f95ba3 )
-	rom ( name "Nushi Tsuri 64 (J) [b4].z64" size 16777216 crc 979068b4 )
-	rom ( name "Nushi Tsuri 64 (J) [b5].z64" size 16777193 crc 7220efe0 )
+	name "Z64 BIOS V2.11PAL"
+	description "Z64 BIOS V2.11PAL"
+	rom ( name "Z64 BIOS V2.11PAL.bin" crc 719CB3D4 )
 )
 
 game (
-	name "Nushi Tsuri 64 - Shiokaze ni Notte"
-	description "Nushi Tsuri 64 - Shiokaze ni Notte"
-	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!].z64" size 33554432 crc f0bcd1ce )
-	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b1].z64" size 33554432 crc c6c43a7b )
-	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b2].z64" size 29360128 crc ee4263ae )
+	name "Z64 BIOS V2.12b (Nintendo Backup Crew Hack)"
+	description "Z64 BIOS V2.12b (Nintendo Backup Crew Hack)"
+	rom ( name "Z64 BIOS V2.12b (Nintendo Backup Crew Hack).bin" crc 9A7968DD )
 )
 
 game (
-	name O.D.T.
-	description "O.D.T."
-	rom ( name "O.D.T. (E) (M5) [!].z64" size 16777216 crc 7b870026 )
-	rom ( name "O.D.T. (U) (M3) [!].z64" size 16777216 crc 1d4a8659 )
+	name "Z64 BIOS V2.12b3"
+	description "Z64 BIOS V2.12b3"
+	rom ( name "Z64 BIOS V2.12b3.bin" crc 99ADB980 )
 )
 
 game (
-	name "Off Road Challenge"
-	description "Off Road Challenge"
-	rom ( name "Off Road Challenge (E) [!].z64" size 16777216 crc d9fe9ee7 )
-	rom ( name "Off Road Challenge (E) [b1].z64" size 16777216 crc d91a7ed5 )
-	rom ( name "Off Road Challenge (E) [b2].z64" size 16777216 crc 2f9d6b8e )
-	rom ( name "Off Road Challenge (U) [!].z64" size 16777216 crc 1a45c5ab )
-	rom ( name "Off Road Challenge (U) [b1].z64" size 16777216 crc dd2dc258 )
-	rom ( name "Off Road Challenge (U) [b2].z64" size 15990784 crc a7b1ec20 )
-	rom ( name "Off Road Challenge (U) [t1].z64" size 16777216 crc c5119e5a )
+	name "Z64 BIOS V2.12b4"
+	description "Z64 BIOS V2.12b4"
+	rom ( name "Z64 BIOS V2.12b4.bin" crc 1D0A771A )
 )
 
 game (
-	name "Ogre Battle 64 - Person of Lordly Caliber"
-	description "Ogre Battle 64 - Person of Lordly Caliber"
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!].z64" size 41943040 crc 845b8711 )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1].z64" size 41943040 crc be2ae208 )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1][o1].z64" size 50331648 crc 27ea3320 )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b2].z64" size 41943040 crc 330a2c9f )
-	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (U) [!].z64" size 41943040 crc a05aea85 )
+	name "Z64 BIOS V2.12NTSC"
+	description "Z64 BIOS V2.12NTSC"
+	rom ( name "Z64 BIOS V2.12NTSC.bin" crc CE7D86E7 )
 )
 
 game (
-	name "Olympic Hockey Nagano '98"
-	description "Olympic Hockey Nagano '98"
-	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [!].z64" size 8388608 crc 5a805c2e )
-	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [h1C].z64" size 8388608 crc 0bf6ad1f )
-	rom ( name "Olympic Hockey Nagano '98 (J) [!].z64" size 8388608 crc 9e98fce8 )
-	rom ( name "Olympic Hockey Nagano '98 (U) [!].z64" size 8388608 crc 2d777652 )
-	rom ( name "Olympic Hockey Nagano '98 (U) [b1].z64" size 8388608 crc bf7eae06 )
-	rom ( name "Olympic Hockey Nagano '98 (U) [b2].z64" size 7077888 crc 5a86eb33 )
-	rom ( name "Olympic Hockey Nagano '98 (U) [b3].z64" size 8388608 crc 2270f56b )
-	rom ( name "Olympic Hockey Nagano '98 (U) [h1C].z64" size 8388608 crc 5a5315ec )
-	rom ( name "Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66].z64" size 8388608 crc c9f7b017 )
+	name "Z64 BIOS V2.12PAL"
+	description "Z64 BIOS V2.12PAL"
+	rom ( name "Z64 BIOS V2.12PAL.bin" crc D5DD6E66 )
 )
 
 game (
-	name "Onegai Monsters"
-	description "Onegai Monsters"
-	rom ( name "Onegai Monsters (J) [!].z64" size 16777216 crc ac72a1c7 )
-	rom ( name "Onegai Monsters (J) [b1].z64" size 16777216 crc a632b622 )
+	name "Z64 BIOS V2.13"
+	description "Z64 BIOS V2.13"
+	rom ( name "Z64 BIOS V2.13.bin" crc D95E339B )
 )
 
 game (
-	name "Pachinko 365 Nichi"
-	description "Pachinko 365 Nichi"
-	rom ( name "Pachinko 365 Nichi (J) [!].z64" size 12582912 crc 42d06e32 )
-	rom ( name "Pachinko 365 Nichi (J) [b1].z64" size 1376256 crc 75ce6e9b )
-	rom ( name "Pachinko 365 Nichi (J) [b2].z64" size 12582912 crc f2202871 )
+	name "Z64 BIOS V2.15"
+	description "Z64 BIOS V2.15"
+	rom ( name "Z64 BIOS V2.15.bin" crc FE278859 )
 )
 
 game (
-	name "Paper Mario"
-	description "Paper Mario"
-	rom ( name "Mario Story (J) [!].z64" size 41943040 crc bd60ca66 )
-	rom ( name "Paper Mario (E) (M4) [!].z64" size 67108864 crc 85b3ab37 )
-	rom ( name "Paper Mario (U) [!].z64" size 41943040 crc a7f5cd7e )
-	rom ( name "Paper Mario (U) [T+Chi].z64" size 44040192 crc ec10421a )
+	name "Z64 BIOS V2.16"
+	description "Z64 BIOS V2.16"
+	rom ( name "Z64 BIOS V2.16.bin" crc 46BD8AF5 )
 )
 
 game (
-	name Paperboy
-	description "Paperboy"
-	rom ( name "Paperboy (E) [!].z64" size 12582912 crc f00c5053 )
-	rom ( name "Paperboy (U) [!].z64" size 12582912 crc f27114e6 )
-	rom ( name "Paperboy (U) [f1] (PAL).z64" size 12582912 crc 7cfe1430 )
-	rom ( name "Paperboy (U) [hI].z64" size 12582912 crc 943fed7b )
-	rom ( name "Paperboy (U) [hI][f1] (PAL).z64" size 12582912 crc 0fefa6b4 )
-	rom ( name "Paperboy (U) [hI][t1].z64" size 12582912 crc a5a5da90 )
-	rom ( name "Paperboy (U) [t1].z64" size 12582912 crc ea4f823a )
+	name "Z64 BIOS V2.16b"
+	description "Z64 BIOS V2.16b"
+	rom ( name "Z64 BIOS V2.16b.bin" crc 3265AE3D )
 )
 
 game (
-	name "Parlor! Pro 64 - Pachinko Jikki Simulation Game"
-	description "Parlor! Pro 64 - Pachinko Jikki Simulation Game"
-	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!].z64" size 12582912 crc a33146e0 )
+	name "Z64 BIOS V2.17 [h1]"
+	description "Z64 BIOS V2.17 [h1]"
+	rom ( name "Z64 BIOS V2.17 [h1].bin" crc 926CD3BD )
 )
 
 game (
-	name "PD Ultraman Battle Collection 64"
-	description "PD Ultraman Battle Collection 64"
-	rom ( name "PD Ultraman Battle Collection 64 (J) [!].z64" size 33554432 crc 86cc80b5 )
-	rom ( name "PD Ultraman Battle Collection 64 (J) [b1].z64" size 33554432 crc 34af8235 )
-	rom ( name "PD Ultraman Battle Collection 64 (J) [f1] (PAL).z64" size 33554432 crc 4d2dab64 )
-	rom ( name "PD Ultraman Battle Collection 64 (J) [f2] (PAL).z64" size 33554432 crc e48d1481 )
+	name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 2.18zd Hack)"
+	description "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 2.18zd Hack)"
+	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 2.18zd Hack).bin" crc 31F08661 )
 )
 
 game (
-	name "Penny Racers"
-	description "Penny Racers"
-	rom ( name "Choro Q 64 (J) [!].z64" size 8388608 crc 231f9284 )
-	rom ( name "Choro Q 64 (J) [b1].z64" size 8388608 crc b19825f1 )
-	rom ( name "Choro Q 64 (J) [b2].z64" size 8388608 crc edbbcb0e )
-	rom ( name "Choro Q 64 (J) [b3].z64" size 8388608 crc b94ca728 )
-	rom ( name "Choro Q 64 (J) [b4].z64" size 6029312 crc ce6f7754 )
-	rom ( name "Choro Q 64 (J) [h1C].z64" size 8388608 crc c35391ec )
-	rom ( name "Penny Racers (E) [!].z64" size 8388608 crc a1d6eb5b )
-	rom ( name "Penny Racers (E) [h1C].z64" size 8388608 crc 88d6b0fc )
-	rom ( name "Penny Racers (E) [h2C].z64" size 8388608 crc 48adf127 )
-	rom ( name "Penny Racers (U) [!].z64" size 8388608 crc c1e57337 )
-	rom ( name "Penny Racers (U) [hI].z64" size 8388608 crc 47bb87ab )
-)
-
-game (
-	name "Perfect Dark"
-	description "Perfect Dark"
-	rom ( name "Perfect Dark (E) (M5) [!].z64" size 33554432 crc 7718a714 )
-	rom ( name "Perfect Dark (E) (M5) [b1].z64" size 33488896 crc 0eae06b7 )
-	rom ( name "Perfect Dark (J) [!].z64" size 33554432 crc 639c0da9 )
-	rom ( name "Perfect Dark (U) (V1.0) [!].z64" size 33554432 crc 68446ad4 )
-	rom ( name "Perfect Dark (U) (V1.0) [f1] (PAL).z64" size 33554432 crc 8d4f0485 )
-	rom ( name "Perfect Dark (U) (V1.1) [!].z64" size 33554432 crc 4c1677f7 )
-)
-
-game (
-	name "PGA European Tour"
-	description "PGA European Tour"
-	rom ( name "PGA European Tour (E) (M5) [!].z64" size 16777216 crc 6b5ff959 )
-	rom ( name "PGA European Tour (E) (M5) [f1] (NTSC).z64" size 16777216 crc b7e9b0ca )
-	rom ( name "PGA European Tour (E) (M5) [f2] (NTSC).z64" size 16777216 crc 7bf9235e )
-	rom ( name "PGA European Tour (U) [!].z64" size 16777216 crc 7cdfcdaa )
-)
-
-game (
-	name "Pilotwings 64"
-	description "Pilotwings 64"
-	rom ( name "Pilotwings 64 (E) (M3) [!].z64" size 8388608 crc c902e57c )
-	rom ( name "Pilotwings 64 (E) (M3) [b1].z64" size 8388608 crc 69cee7bb )
-	rom ( name "Pilotwings 64 (E) (M3) [b2].z64" size 8126464 crc a3f6b922 )
-	rom ( name "Pilotwings 64 (E) (M3) [h1C].z64" size 8388608 crc 3f2c45d1 )
-	rom ( name "Pilotwings 64 (J) [!].z64" size 8388608 crc 3d3a84a9 )
-	rom ( name "Pilotwings 64 (J) [b1].z64" size 7340032 crc 48d4865d )
-	rom ( name "Pilotwings 64 (U) [!].z64" size 8388608 crc 728807e7 )
-	rom ( name "Pilotwings 64 (U) [h1C].z64" size 8388608 crc 80193ec3 )
-	rom ( name "Pilotwings 64 (U) [t1].z64" size 8388608 crc e1b8cdd3 )
+	name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 Hack)"
+	description "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 Hack)"
+	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 Hack).bin" crc C8FB4890 )
 )
 
 game (
-	name "Pocket Monsters Stadium"
-	description "Pocket Monsters Stadium"
-	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189c )
-	rom ( name "Pocket Monsters Stadium (J) [b1].z64" size 16777216 crc 6f856803 )
-	rom ( name "Pocket Monsters Stadium (J) [b2].z64" size 16777216 crc b4f73dba )
-	rom ( name "Pocket Monsters Stadium (J) [f1] (Boot-PAL).z64" size 16777216 crc 54d42fd3 )
-	rom ( name "Pocket Monsters Stadium (J) [f2] (Boot).z64" size 16777216 crc 32b4c38d )
+	name "Z64 BIOS V2.17"
+	description "Z64 BIOS V2.17"
+	rom ( name "Z64 BIOS V2.17.bin" crc 7A73DBAA )
 )
 
 game (
-	name "Pokemon Puzzle League"
-	description "Pokemon Puzzle League"
-	rom ( name "Pokemon Puzzle League (E) [!].z64" size 33554432 crc 75839254 )
-	rom ( name "Pokemon Puzzle League (F) [!].z64" size 33554432 crc c3aa0074 )
-	rom ( name "Pokemon Puzzle League (G) [!].z64" size 33554432 crc ac543150 )
-	rom ( name "Pokemon Puzzle League (U) [!].z64" size 33554432 crc 8b9c598f )
-	rom ( name "Pokemon Puzzle League (U) [t1].z64" size 33554432 crc 47ede839 )
-	rom ( name "Pokemon Puzzle League (U) [t2].z64" size 33554432 crc e74d7734 )
+	name "Z64 BIOS V2.18"
+	description "Z64 BIOS V2.18"
+	rom ( name "Z64 BIOS V2.18.bin" crc ABB513C4 )
 )
 
 game (
-	name "Pokemon Snap"
-	description "Pokemon Snap"
-	rom ( name "Pocket Monsters Snap (J) [!].z64" size 16777216 crc a091bd56 )
-	rom ( name "Pocket Monsters Snap (J) [b1].z64" size 16777216 crc 28f6f98d )
-	rom ( name "Pocket Monsters Snap (J) [f1].z64" size 16777216 crc 676a945b )
-	rom ( name "Pocket Monsters Snap (J) [f2] (GameShark).z64" size 16777216 crc 7822e4dc )
-	rom ( name "Pokemon Snap (A) [!].z64" size 16777216 crc cdea6d4c )
-	rom ( name "Pokemon Snap (A) [f1] (GameShark).z64" size 16777216 crc 144f7260 )
-	rom ( name "Pokemon Snap (E) [!].z64" size 16777216 crc f824a057 )
-	rom ( name "Pokemon Snap (F) [!].z64" size 16777216 crc ec843586 )
-	rom ( name "Pokemon Snap (F) [b1].z64" size 16777216 crc 396961b4 )
-	rom ( name "Pokemon Snap (G) [!].z64" size 16777216 crc 10c27b3c )
-	rom ( name "Pokemon Snap (I) [!].z64" size 16777216 crc 63f6058a )
-	rom ( name "Pokemon Snap (S) [!].z64" size 16777216 crc 371b787f )
-	rom ( name "Pokemon Snap (U) [!].z64" size 16777216 crc 86a69756 )
-	rom ( name "Pokemon Snap (U) [f1] (Save).z64" size 16777216 crc 4e0c3ab0 )
-	rom ( name "Pokemon Snap (U) [f2] (Save-PAL).z64" size 16777216 crc a6ef9ae7 )
-	rom ( name "Pokemon Snap (U) [f3] (GameShark).z64" size 16777216 crc 6a7d374c )
-	rom ( name "Pokemon Snap (U) [f3].z64" size 16777216 crc 9f5b2741 )
-	rom ( name "Pokemon Snap (U) [T+Spa].z64" size 16777216 crc ea713736 )
-	rom ( name "Pokemon Snap Station (U) [!].z64" size 16777216 crc e22a00d0 )
-	rom ( name "Pokemon Snap Station (U) [f1].z64" size 16777216 crc dce70f89 )
+	name "Z64 BIOS V2.20cf"
+	description "Z64 BIOS V2.20cf"
+	rom ( name "Z64 BIOS V2.20cf.rom" crc 5A4DB022 )
 )
 
 game (
-	name "Pokemon Stadium"
-	description "Pokemon Stadium"
-	rom ( name "Pocket Monsters Stadium 2 (J) [!].z64" size 33554432 crc 40aa4874 )
-	rom ( name "Pocket Monsters Stadium 2 (J) [f1].z64" size 33554432 crc df47adf2 )
-	rom ( name "Pocket Monsters Stadium 2 (J) [f2].z64" size 33554432 crc e3269942 )
-	rom ( name "Pocket Monsters Stadium 2 (J) [f3].z64" size 33554432 crc b9365d21 )
-	rom ( name "Pocket Monsters Stadium 2 (J) [f4].z64" size 33554432 crc 3db3c49b )
-	rom ( name "Pokemon Stadium (E) (V1.0) [!].z64" size 33554432 crc dc57508d )
-	rom ( name "Pokemon Stadium (E) (V1.0) [f1].z64" size 33554432 crc c0055dd4 )
-	rom ( name "Pokemon Stadium (E) (V1.1) [!].z64" size 33554432 crc da889668 )
-	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5dd92d4c )
-	rom ( name "Pokemon Stadium (F) [f1].z64" size 33554432 crc 56bb95db )
-	rom ( name "Pokemon Stadium (G) [!].z64" size 33554432 crc 9f22a945 )
-	rom ( name "Pokemon Stadium (G) [f1].z64" size 33554432 crc f4152673 )
-	rom ( name "Pokemon Stadium (I) [!].z64" size 33554432 crc f155c465 )
-	rom ( name "Pokemon Stadium (S) [!].z64" size 33554432 crc f02cd5eb )
-	rom ( name "Pokemon Stadium (S) [f1].z64" size 33554432 crc 55a3cd84 )
-	rom ( name "Pokemon Stadium (U) (V1.0) [!].z64" size 33554432 crc 72f66f05 )
-	rom ( name "Pokemon Stadium (U) (V1.0) [f1].z64" size 33554432 crc 932b7a31 )
-	rom ( name "Pokemon Stadium (U) (V1.1) [!].z64" size 33554432 crc 72b552e3 )
-	rom ( name "Pokemon Stadium (U) (V1.1) [f1].z64" size 33554432 crc 32233fdc )
-)
-
-game (
-	name "Pokemon Stadium 2"
-	description "Pokemon Stadium 2"
-	rom ( name "Pocket Monsters Stadium Kin Gin (J) [!].z64" size 67108864 crc cbc3b935 )
-	rom ( name "Pokemon Stadium 2 (E) [!].z64" size 67108864 crc 6b3096c4 )
-	rom ( name "Pokemon Stadium 2 (E) [T+Ita0.05].z64" size 67108864 crc 89e7da00 )
-	rom ( name "Pokemon Stadium 2 (F) [!].z64" size 67108864 crc e2a78066 )
-	rom ( name "Pokemon Stadium 2 (G) [!].z64" size 67108864 crc 1146a43a )
-	rom ( name "Pokemon Stadium 2 (I) [!].z64" size 67108864 crc 9fa5c095 )
-	rom ( name "Pokemon Stadium 2 (S) [!].z64" size 67108864 crc 283e7641 )
-	rom ( name "Pokemon Stadium 2 (U) [!].z64" size 67108864 crc a9998e09 )
-)
-
-game (
-	name "Polaris SnoCross"
-	description "Polaris SnoCross"
-	rom ( name "Polaris SnoCross (U) [!].z64" size 12582912 crc 8dd735ef )
-	rom ( name "Polaris SnoCross (U) [o1][t1].z64" size 12582912 crc 00ce1ebb )
-	rom ( name "Polaris SnoCross (U) [t1].z64" size 12582912 crc 9356fe6c )
-)
-
-game (
-	name "Power League Baseball 64"
-	description "Power League Baseball 64"
-	rom ( name "Power League Baseball 64 (J) [!].z64" size 8388608 crc aec21c28 )
-	rom ( name "Power League Baseball 64 (J) [o1].z64" size 16777216 crc 1b77039d )
-)
-
-game (
-	name "Power Rangers - Lightspeed Rescue"
-	description "Power Rangers - Lightspeed Rescue"
-	rom ( name "Power Rangers - Lightspeed Rescue (E) [!].z64" size 12582912 crc 83590247 )
-	rom ( name "Power Rangers - Lightspeed Rescue (E) [f1] (NTSC).z64" size 12582912 crc 388eab69 )
-	rom ( name "Power Rangers - Lightspeed Rescue (U) [!].z64" size 12582912 crc a5033311 )
-)
-
-game (
-	name "Powerpuff Girls, The - Chemical X-Traction"
-	description "Powerpuff Girls, The - Chemical X-Traction"
-	rom ( name "Powerpuff Girls, The - Chemical X-Traction (U) [!].z64" size 8388608 crc 9514da0a )
-)
-
-game (
-	name "Premier Manager 64"
-	description "Premier Manager 64"
-	rom ( name "Premier Manager 64 (E) [!].z64" size 16777216 crc 81cda888 )
-	rom ( name "Premier Manager 64 (E) [f1] (NTSC).z64" size 16777216 crc 18a89111 )
-	rom ( name "Premier Manager 64 (E) [f2] (NTSC100%).z64" size 16777216 crc 9e43ec66 )
-)
-
-game (
-	name "Pro Mahjong Kiwame 64"
-	description "Pro Mahjong Kiwame 64"
-	rom ( name "Pro Mahjong Kiwame 64 (J) [!].z64" size 8388608 crc 1f5907f9 )
-	rom ( name "Pro Mahjong Kiwame 64 (J) [b1].z64" size 8126464 crc 21ae1d70 )
-	rom ( name "Pro Mahjong Kiwame 64 (J) [o1].z64" size 16777216 crc 7b914a49 )
-)
-
-game (
-	name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen"
-	description "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen"
-	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!].z64" size 8388608 crc 35461699 )
-)
-
-game (
-	name "Public Domain"
-	description "Public Domain"
-	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD) [f1].z64" size 1310720 crc ca8cca0b )
-	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD).z64" size 1310720 crc 48be02a9 )
-	rom ( name "3DS Model Conversion by Snake (PD) [h1C].z64" size 1572864 crc fdb0d5ad )
-	rom ( name "3DS Model Conversion by Snake (PD).z64" size 1572864 crc 685f71cd )
-	rom ( name "77a by Count0 (POM '98) (PD) [b1].z64" size 1310720 crc 0fcb5e9e )
-	rom ( name "77a by Count0 (POM '98) (PD).z64" size 1310720 crc ef6d1ca6 )
-	rom ( name "77a Special Edition by Count0 (PD) [b1].z64" size 2883584 crc a2ae127c )
-	rom ( name "77a Special Edition by Count0 (PD).z64" size 2883584 crc 0c84af76 )
-	rom ( name "Absolute Crap #2 by Lem (PD) [b1].z64" size 1310720 crc caeadab4 )
-	rom ( name "Absolute Crap #2 by Lem (PD) [b2].z64" size 1310720 crc 4026b0cb )
-	rom ( name "Absolute Crap #2 by Lem (PD).z64" size 1310720 crc 9b9fdb8e )
-	rom ( name "Alleycat 64 by Dosin (POM '99) (PD) [b1].z64" size 1310720 crc fe3b7986 )
-	rom ( name "Alleycat 64 by Dosin (POM '99) (PD).z64" size 1310720 crc 938eca3e )
-	rom ( name "Attax64 by Pookae (POM '99) (PD) [b1].z64" size 1572864 crc 21b5e4e7 )
-	rom ( name "Attax64 by Pookae (POM '99) (PD).z64" size 1572864 crc 53976ac5 )
-	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD) [t1].z64" size 1572864 crc c5dac064 )
-	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD).z64" size 1572864 crc 661e5ff5 )
-	rom ( name "Bike Race '98 V1.0 by NAN (PD) [b1].z64" size 3145728 crc cd797c66 )
-	rom ( name "Bike Race '98 V1.0 by NAN (PD).z64" size 3145728 crc 601c8801 )
-	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b1].z64" size 1048576 crc 19f78649 )
-	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b2].z64" size 840768 crc 109b847a )
-	rom ( name "Bike Race '98 V1.2 by NAN (PD).z64" size 840768 crc c2cc79c2 )
-	rom ( name "BMP View by Count0 (PD).z64" size 262144 crc 9ba53380 )
-	rom ( name "CZN Module Player (PD).z64" size 1048576 crc f93a2b1f )
-	rom ( name "Dexanoid R1 by Protest Design (PD) [b1].z64" size 2097152 crc 1b9a2d13 )
-	rom ( name "Dexanoid R1 by Protest Design (PD) [f1] (PAL).z64" size 16777216 crc 7a4bbb34 )
-	rom ( name "Dexanoid R1 by Protest Design (PD) [f2] (PAL).z64" size 16777216 crc 7e2b8065 )
-	rom ( name "Dexanoid R1 by Protest Design (PD) [t1].z64" size 16777216 crc 3cf0961f )
-	rom ( name "Dexanoid R1 by Protest Design (PD).z64" size 16777216 crc 244e6d59 )
-	rom ( name "Dragon King by CrowTRobo (PD) [b1].z64" size 3407872 crc 1fc33d83 )
-	rom ( name "Dragon King by CrowTRobo (PD).z64" size 3407872 crc ea5c7922 )
-	rom ( name "Dynamix Readme by Widget and Immortal (PD).z64" size 1310720 crc 82531023 )
-	rom ( name "Game Boy 64 (POM '98) (PD) (Illegal Mode Enabled).z64" size 3145728 crc e299d6c1 )
-	rom ( name "Game Boy 64 (POM '98) (PD).z64" size 3145728 crc 3c22f622 )
-	rom ( name "Game Boy 64 + Super Mario 3 (PD).z64" size 1835008 crc 8145d2e8 )
-	rom ( name "HIPTHRUST by MooglyGuy (PD).z64" size 2097152 crc b1a4d196 )
-	rom ( name "JPEG Slideshow Viewer by Garth Elgar (PD).z64" size 334112 crc b5aa682d )
-	rom ( name "LaC's MOD Player - The Temple Gates (PD).z64" size 2807878 crc 4c4477d6 )
-	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b1].z64" size 1310720 crc 0388ee97 )
-	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b2].z64" size 1310720 crc 4155e1c9 )
-	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD).z64" size 1310720 crc a9397703 )
-	rom ( name "Liner V1.02 by Colin Phillipps of Memir (PD).z64" size 1310720 crc d3d11218 )
-	rom ( name "MAME 64 Beta 3 (PD).z64" size 8388608 crc 2103e950 )
-	rom ( name "MAME 64 V1.0 (PD) [b1].z64" size 8388608 crc 7f0dd250 )
-	rom ( name "MAME 64 V1.0 (PD).z64" size 8388608 crc 6612ceba )
-	rom ( name "Mandelbrot Zoomer by RedBox (PD).z64" size 524288 crc 611513ad )
-	rom ( name "Manic Miner - Hidden Levels by RedboX (PD).z64" size 2097152 crc f496a0fa )
-	rom ( name "Manic Miner by RedboX (PD).z64" size 2097152 crc 02aacc20 )
-	rom ( name "Memory Manager V1.0b by R. Bubba Magillicutty (PD).z64" size 2097152 crc 3b3f140a )
-	rom ( name "MMR by Count0 (PD) [b1].z64" size 1572864 crc 47bd7e97 )
-	rom ( name "MMR by Count0 (PD).z64" size 1572864 crc f4803dcb )
-	rom ( name "N64 Scene Gallery by CALi (PD).z64" size 4456448 crc dfbb8dfe )
-	rom ( name "N64probe (Button Test) by MooglyGuy (PD).z64" size 2097152 crc 18d7c629 )
-	rom ( name "N64probe by MooglyGuy (PD).v64" size 2097152 crc 361f713f )
-	rom ( name "Namp64 - N64 MP3-Player by Obsidian (PD).z64" size 262144 crc 6a9be044 )
-	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD) [a1].z64" size 6029312 crc 82ca0f47 )
-	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD).z64" size 6029312 crc b20cd983 )
-	rom ( name "NBCG Special Edition (PD).z64" size 2621440 crc 57af612b )
-	rom ( name "NBCG's Tag Gallery 01 by CALi (PD).z64" size 2359296 crc 60394429 )
-	rom ( name "Nintendo Family by CALi (PD).z64" size 3145728 crc f9d7bf11 )
-	rom ( name "Nintendo WideBoy 64 by SonCrap (PD).z64" size 2097152 crc 1efcc1b2 )
-	rom ( name "ObjectVIEWER V1.1 by Kid Stardust (PD).v64" size 1310720 crc 1deda87c )
-	rom ( name "PC-Engine 64 (POM '99) (PD) [t1].z64" size 2097152 crc 63c024c6 )
-	rom ( name "PC-Engine 64 (POM '99) (PD).z64" size 2097152 crc e69b416b )
-	rom ( name "Pip's Pong by Mr. Pips (PD) [b1].z64" size 1310720 crc 426f0f6e )
-	rom ( name "Pip's Pong by Mr. Pips (PD).z64" size 1310720 crc 756871e3 )
-	rom ( name "Pip's Porn Pack 1 by Mr. Pips (PD).z64" size 1310720 crc 4843b97c )
-	rom ( name "Pip's Porn Pack 2 by Mr. Pips (POM '99) (PD).z64" size 1572864 crc 48c2e078 )
-	rom ( name "Pip's Porn Pack 3 by Mr. Pips (PD).z64" size 1572864 crc 22ef2b51 )
-	rom ( name "Pip's RPGs Beta 12 by Mr. Pips (PD).z64" size 1572864 crc 8b84f446 )
-	rom ( name "Pip's RPGs Beta 14 by Mr. Pips (PD).z64" size 1572864 crc 97288804 )
-	rom ( name "Pip's RPGs Beta 15 by Mr. Pips (PD).z64" size 1835008 crc 195a1c24 )
-	rom ( name "Pip's RPGs Beta 2 by Mr. Pips (PD).z64" size 1310720 crc c27dd46e )
-	rom ( name "Pip's RPGs Beta 3 by Mr. Pips (PD).z64" size 1310720 crc 30ca3fd9 )
-	rom ( name "Pip's RPGs Beta 6 by Mr. Pips (PD).z64" size 1310720 crc 9930d6bd )
-	rom ( name "Pip's RPGs Beta 7 by Mr. Pips (PD).z64" size 1310720 crc 0f30d531 )
-	rom ( name "Pip's RPGs Beta x (PD) [a1].z64" size 1572864 crc e392cf51 )
-	rom ( name "Pip's RPGs Beta x (PD).z64" size 1572864 crc 4ceb0273 )
-	rom ( name "Pip's Tic Tak Toe by Mark Pips (PD).z64" size 1310720 crc 08950965 )
-	rom ( name "Pip's World Game 1 by Mr. Pips (PD) [b1].z64" size 1310720 crc 5f3acbd9 )
-	rom ( name "Pip's World Game 1 by Mr. Pips (PD).z64" size 1310720 crc 36d3fbd2 )
-	rom ( name "Pip's World Game 2 by Mr. Pips (PD) [b1].z64" size 1310720 crc 8e2b9445 )
-	rom ( name "Pip's World Game 2 by Mr. Pips (PD).z64" size 1310720 crc 03ee5c91 )
-	rom ( name "Pipendo by Mr. Pips (PD).z64" size 1310720 crc f7aaab1c )
-	rom ( name "Pong by Oman (PD) [a1].z64" size 8388608 crc 49238810 )
-	rom ( name "Pong by Oman (PD) [h1C][o1].z64" size 8388608 crc c7d62967 )
-	rom ( name "Pong by Oman (PD) [t1].z64" size 8388608 crc be397968 )
-	rom ( name "Pong by Oman (PD).z64" size 262144 crc dff8f71a )
-	rom ( name "Pong V0.01 by Omsk (PD).z64" size 1572864 crc 6f5c095e )
-	rom ( name "Puzzle Master 64 by Michael Searl (PD).z64" size 10485760 crc 8cef5822 )
-	rom ( name "Shuffle Puck 64 (PD).z64" size 3932160 crc dddda2c6 )
-	rom ( name "Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD).z64" size 1310720 crc 5eab0f34 )
-	rom ( name "Sinus (PD).z64" size 1310720 crc d7679079 )
-	rom ( name "SLiDeS (PD).z64" size 1572864 crc 76b35c44 )
-	rom ( name "Spacer by Memir (POM '99) (PD) [t1].z64" size 3145728 crc 01c93afe )
-	rom ( name "Spacer by Memir (POM '99) (PD) [t2].z64" size 3102038 crc 6791f671 )
-	rom ( name "Spacer by Memir (POM '99) (PD) [t2][b1].z64" size 3102038 crc e62ae0eb )
-	rom ( name "Spacer by Memir (POM '99) (PD).z64" size 2683944 crc dc0d3f8a )
-	rom ( name "SPLiT's Nacho64 by SPLiT (PD) [f1] (PAL).z64" size 2097152 crc ad7990a9 )
-	rom ( name "SPLiT's Nacho64 by SPLiT (PD).z64" size 2097152 crc 4c3da466 )
-	rom ( name "Sporting Clays by Charles Doty (PD) [a1].z64" size 1310720 crc 2ec84b48 )
-	rom ( name "Sporting Clays by Charles Doty (PD) [b1].z64" size 1310720 crc 8fb5adbc )
-	rom ( name "Sporting Clays by Charles Doty (PD).z64" size 1310720 crc 2471c621 )
-	rom ( name "Super Bomberman 2 by Rider (POM '99) (PD).z64" size 1310720 crc fcb72ec3 )
-	rom ( name "Twintris by Twinsen (POM '98) (PD).z64" size 3145728 crc 7fdff7e7 )
-	rom ( name "Ultrafox 64 by Megahawks (PD).z64" size 1877136 crc 12f0d7b4 )
-	rom ( name "Wet Dreams Readme by Immortal (POM '99) (PD).z64" size 2097152 crc 80fa548d )
-)
-
-game (
-	name "Public Domain (Demos)"
-	description "Public Domain (Demos)"
-	rom ( name "1964 Demo by Steb (PD).z64" size 1310720 crc 2336871b )
-	rom ( name "Birthday Demo for Steve by Nep (PD) [b1].z64" size 1310720 crc 5af2efe0 )
-	rom ( name "Birthday Demo for Steve by Nep (PD).z64" size 1310720 crc 50b40d33 )
-	rom ( name "Chaos 89 Demo (PD).z64" size 1310720 crc 0ec05e31 )
-	rom ( name "Christmas Flame Demo by Halley's Comet Software (PD).z64" size 237440 crc b16e26c5 )
-	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD) [b1].z64" size 1310720 crc 3901a5b5 )
-	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD).z64" size 1310720 crc f3a9b5ac )
-	rom ( name "Cube Demo (PD) [b1].z64" size 524288 crc 663cca5b )
-	rom ( name "Cube Demo (PD) [b2].z64" size 9437184 crc fbead436 )
-	rom ( name "Cube Demo (PD).z64" size 9437184 crc c8abe90c )
-	rom ( name "Cube Demo by Msftug (PD).z64" size 8388608 crc a63621ff )
-	rom ( name "Display List Ate My Mind Demo by Kid Stardust (PD).z64" size 1310720 crc 01d47287 )
-	rom ( name "DKONG Demo (PD).z64" size 2097152 crc 40a32fc4 )
-	rom ( name "Explode Demo by NaN (PD).z64" size 195688 crc 4ade6d08 )
-	rom ( name "Fire Demo by Lac (PD).z64" size 2097152 crc a827a178 )
-	rom ( name "Fireworks Demo by CrowTRobo (PD).z64" size 1310720 crc c49262f7 )
-	rom ( name "Fish Demo by NaN (PD).z64" size 1310720 crc 5a7d1331 )
-	rom ( name "Fogworld USA Demo by Horizon64 (PD) [h1C][o1].z64" size 1310720 crc cbe4b416 )
-	rom ( name "Fogworld USA Demo by Horizon64 (PD).z64" size 1179648 crc a0b6250d )
-	rom ( name "Fractal Zoomer Demo by RedboX (PD).z64" size 2097152 crc d10ea06a )
-	rom ( name "Friendship Demo by Renderman (PD) [b1].z64" size 1310720 crc 4fae1edf )
-	rom ( name "Friendship Demo by Renderman (PD).z64" size 1310720 crc b38a50e8 )
-	rom ( name "GT Demo (PD) [a1].z64" size 1048576 crc fb2c9648 )
-	rom ( name "GT Demo (PD).z64" size 1310720 crc 51a3a682 )
-	rom ( name "Hard Coded Demo by Silo and Fractal (PD) [a1].z64" size 786432 crc 713d8af3 )
-	rom ( name "Hard Coded Demo by Silo and Fractal (PD).z64" size 1310720 crc 44e52674 )
-	rom ( name "Hard Pom '99 Demo by TS_Garp (POM '99) (PD).z64" size 1835008 crc 227992c1 )
-	rom ( name "Heavy 64 Demo by Destop (PD).z64" size 3932160 crc f94f368f )
-	rom ( name "HiRes CFB Demo (PD).z64" size 1310720 crc 2925b3f3 )
-	rom ( name "LCARS Demo by WT Riker (PD) [b1].z64" size 2097152 crc 8e8aed5e )
-	rom ( name "LCARS Demo by WT Riker (PD).z64" size 2097152 crc b5bbdd7f )
-	rom ( name "Light Force First N64 Demo by Fractal (PD).z64" size 1310720 crc 4652c058 )
-	rom ( name "MAME 64 Demo (PD) [b1].z64" size 8388608 crc a033c664 )
-	rom ( name "MAME 64 Demo (PD) [b2].z64" size 8388608 crc 6d7663ed )
-	rom ( name "MAME 64 Demo (PD).z64" size 8388608 crc b8fd2e8b )
-	rom ( name "MeeTING Demo by Renderman (PD) [b1].z64" size 1310720 crc 8d6e473f )
-	rom ( name "MeeTING Demo by Renderman (PD).z64" size 1310720 crc 63ec31a1 )
-	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD) [b1].z64" size 2097152 crc 7b38e6c7 )
-	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD).z64" size 2097152 crc 390ef548 )
-	rom ( name "Mind Present Demo Readme by Widget and Immortal (POM '98) (PD).z64" size 1310720 crc d348c33f )
-	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD) [f1].z64" size 3670016 crc 8a909b08 )
-	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD).z64" size 3670016 crc b154e087 )
-	rom ( name "My Angel Demo (PD).z64" size 1048576 crc d55d55ef )
-	rom ( name "N64 Seminar Demo - CPU by ZoRAXE (PD).z64" size 2097152 crc 6093fae0 )
-	rom ( name "N64 Seminar Demo - RSP by ZoRAXE (PD).z64" size 2097152 crc 6e476896 )
-	rom ( name "N64 Stars Demo (PD) [b1].z64" size 2097152 crc a56117af )
-	rom ( name "N64 Stars Demo (PD).z64" size 2097152 crc 3210b3f2 )
-	rom ( name "NBCG's Kings of Porn Demo (PD).z64" size 4718592 crc 30c0d79a )
-	rom ( name "NBCrew 2 Demo (PD).z64" size 262144 crc a57d3bda )
-	rom ( name "NEO Myth N64 Menu Demo V0.1 (PD).z64" size 2097152 crc fc989fd7 )
-	rom ( name "Nintendo On My Mind Demo by Kid Stardust (PD).z64" size 1310720 crc 23e051f4 )
-	rom ( name "Nintro64 Demo by Lem (POM '98) (PD) [b1].z64" size 3145728 crc c581ee0d )
-	rom ( name "Nintro64 Demo by Lem (POM '98) (PD).z64" size 3145728 crc d79da002 )
-	rom ( name "NuFan Demo by Kid Stardust (PD) [b1].z64" size 1310720 crc c2b3b43c )
-	rom ( name "NuFan Demo by Kid Stardust (PD).z64" size 1310720 crc 3c637d2b )
-	rom ( name "Pamela Demo (PD).z64" size 1310720 crc 74f01ec6 )
-	rom ( name "Pamela Demo - Resized (PD).z64" size 1048576 crc 1607eebd )
-	rom ( name "Pause Demo by RedboX (PD).z64" size 2097152 crc aac99313 )
-	rom ( name "Plasma Demo (PD) [a1].z64" size 524288 crc 92984be1 )
-	rom ( name "Plasma Demo (PD).z64" size 1310720 crc 57fe4e68 )
-	rom ( name "Pom Part 1 Demo (PD).z64" size 1310720 crc dc92eaf6 )
-	rom ( name "Pom Part 2 Demo (PD).z64" size 1310720 crc a88fdeac )
-	rom ( name "Pom Part 3 Demo (PD).z64" size 1310720 crc 23d33929 )
-	rom ( name "Pom Part 4 Demo (PD).z64" size 1310720 crc b8fdc6dc )
-	rom ( name "Pom Part 5 Demo (PD).z64" size 1310720 crc 13c05dda )
-	rom ( name "POMbaer Demo by Kid Stardust (POM '99) (PD).z64" size 1310720 crc 9e6fd36c )
-	rom ( name "POMolizer Demo by Renderman (POM '99) (PD).z64" size 1310720 crc 0f34d619 )
-	rom ( name "Psychodelic Demo by Ste (POM '98) (PD) [b1].z64" size 3145728 crc 331a7257 )
-	rom ( name "Psychodelic Demo by Ste (POM '98) (PD).z64" size 3145728 crc 4f03510f )
-	rom ( name "R.I.P. Jay Demo by Ste (PD) [b1].z64" size 8388608 crc fee6ee6d )
-	rom ( name "R.I.P. Jay Demo by Ste (PD).z64" size 8388608 crc a916dff5 )
-	rom ( name "Rotating Demo USA by Rene (PD) [a1].z64" size 1310720 crc 9c2a266b )
-	rom ( name "Rotating Demo USA by Rene (PD).z64" size 1310720 crc 95e9d320 )
-	rom ( name "Sample Demo by Florian (PD) [b1].z64" size 1310720 crc 39153954 )
-	rom ( name "Sample Demo by Florian (PD).z64" size 1310720 crc 096430d1 )
-	rom ( name "Shag'a'Delic Demo by Steve and NEP (PD).z64" size 1835008 crc 29fcf3cb )
-	rom ( name "Sitero Demo by Renderman (PD).z64" size 1310720 crc 223b828e )
-	rom ( name "Spice Girls Rotator Demo by RedboX (PD) [a1].z64" size 524288 crc f36ad81b )
-	rom ( name "Spice Girls Rotator Demo by RedboX (PD).z64" size 2097152 crc 40402197 )
-	rom ( name "Split! 3D Demo by Lem (PD).z64" size 262144 crc fbe321ba )
-	rom ( name "Summer64 Demo by Lem (PD) [b1].z64" size 2359296 crc 5d33dcaf )
-	rom ( name "Summer64 Demo by Lem (PD).z64" size 2359296 crc 0d13e643 )
-	rom ( name "Super Fighter Demo Halley's Comet Software (PD).z64" size 2264820 crc d0dc2237 )
-	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1].z64" size 1310720 crc e0b60b7e )
-	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD).z64" size 1310720 crc 0cb63df2 )
-	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD) [b1].z64" size 1310720 crc 17c191c8 )
-	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD).z64" size 1310720 crc f96778d2 )
-	rom ( name "Textlight Demo by Horizon64 (PD) [b1].z64" size 1310720 crc 0feb3819 )
-	rom ( name "Textlight Demo by Horizon64 (PD).z64" size 1310720 crc d0931871 )
-	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD) [b1].z64" size 1310720 crc 19cfc4a4 )
-	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD).z64" size 1310720 crc 933ae249 )
-	rom ( name "TheMuscularDemo by megahawks (PD).v64" size 3981552 crc 2cb9f365 )
-	rom ( name "Tom Demo (PD).z64" size 2621440 crc 94f1e1e9 )
-	rom ( name "TopGun Demo by Horizon64 (PD).z64" size 1310720 crc bac738e4 )
-	rom ( name "TR64 Demo by FIres and Icepir8 (PD).z64" size 1310720 crc bde293c7 )
-	rom ( name "TRON Demo (PD) [a1].z64" size 524288 crc 40ace055 )
-	rom ( name "TRON Demo (PD).z64" size 2097152 crc 4158e22a )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD) [b1].z64" size 2097152 crc fc014665 )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD).z64" size 2097152 crc 58423a11 )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1].z64" size 2097152 crc 429526be )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1][b1].z64" size 2097152 crc 1846d8e6 )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [b1].z64" size 1310720 crc a586fcd8 )
-	rom ( name "U64 (Chrome) Demo by Horizon64 (PD).z64" size 2097152 crc c0c70544 )
-	rom ( name "Ultra Demo Bootcode by Locke^ (PD) [h1C].z64" size 4096 crc 7e0e4bae )
-	rom ( name "Ultra Demo Bootcode by Locke^ (PD).z64" size 4096 crc 121aca7d )
-	rom ( name "Ultra Demo by Locke^ (PD) [a1].z64" size 1048576 crc 6a372c49 )
-	rom ( name "Ultra Demo by Locke^ (PD).z64" size 1310720 crc 7642ca11 )
-	rom ( name "Vector Demo by Destop (POM '99) (PD).z64" size 1310720 crc a23ffa73 )
-	rom ( name "Wet Dreams Can Beta Demo by Immortal (POM '99) (PD).z64" size 1310720 crc 690d2946 )
-	rom ( name "Wet Dreams Madeiragames Demo by Immortal (POM '99) (PD).z64" size 4194304 crc 38cecb99 )
-	rom ( name "Wet Dreams Main Demo by Immortal (POM '99) (PD).z64" size 8388608 crc 965c7727 )
-	rom ( name "XtraLife Dextrose Demo by RedboX (PD) [h1C].z64" size 786432 crc fcc9d3ea )
-	rom ( name "XtraLife Dextrose Demo by RedboX (PD).z64" size 2097152 crc 1a4654a4 )
-	rom ( name "Y2K Demo by WT_Riker (PD) [b1].z64" size 1310720 crc b40a130d )
-	rom ( name "Y2K Demo by WT_Riker (PD).z64" size 1310720 crc cc2762c7 )
-)
-
-game (
-	name "Public Domain (Emulation)"
-	description "Public Domain (Emulation)"
-	rom ( name "GBlator for CD64 (PD) [f1] (V64-PAL).z64" size 8388608 crc e2e97639 )
-	rom ( name "GBlator for CD64 (PD).z64" size 8388608 crc 9c8f0f5f )
-	rom ( name "GBlator for NTSC Dr V64 (PD).z64" size 524288 crc f7bb3dcd )
-	rom ( name "GBlator for PAL Dr V64 (PD).z64" size 524288 crc d1040f61 )
-	rom ( name "Neon64 First Public Beta Release by Halley's Comet Software (PD).z64" size 425168 crc 27778ce1 )
-	rom ( name "Neon64 First Public Beta Release V2 by Halley's Comet Software (PD).z64" size 2097152 crc 23674549 )
-	rom ( name "Neon64 First Public Beta Release V3 by Halley's Comet Software (PD).z64" size 516752 crc 2fb21af0 )
-	rom ( name "Neon64 GS V1.05 (Gameshark Version) (PD).bin" size 67763 crc 9574f823 )
-	rom ( name "Neon64 GS V1.1 (Gameshark Version) (PD).bin" size 20088 crc 42cc8f66 )
-	rom ( name "Neon64 GS V1.2 (Gameshark Version) (PD).bin" size 20888 crc 03ffab8e )
-	rom ( name "Neon64 GS V1.2 (Pro Action Replay Version) (PD).bin" size 20888 crc 96179e7a )
-	rom ( name "Neon64 GS V1.2a (Gameshark Version) (PD).bin" size 20912 crc 2f6e5a23 )
-	rom ( name "Neon64 GS V1.2a (Pro Action Replay Version) (PD).bin" size 20912 crc 740355d6 )
-	rom ( name "Neon64 V1.0 by Halley's Comet Software (PD).z64" size 2097152 crc 3ca8bc6e )
-	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD) [o2].z64" size 2097152 crc aab95ee1 )
-	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD).z64" size 24272 crc 213d6889 )
-	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD) [o1].z64" size 2097152 crc baec90ec )
-	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD).z64" size 80760 crc 36c5ab96 )
-	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [b1].z64" size 2097152 crc 10dea381 )
-	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [o1].z64" size 1052672 crc baeb6d04 )
-	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD).z64" size 80904 crc 93bea654 )
-	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD) [f1] (V64BIOS1.91).z64" size 2097152 crc 6a2f8756 )
-	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD).z64" size 8388608 crc 5dce278b )
-	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD) [f1] (V64).z64" size 2097152 crc 7dcc97a4 )
-	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD).z64" size 524288 crc 4d2cc1c6 )
-	rom ( name "UltraMSX2 V1.0 w-F1 Spirit by Jos Kwanten (PD).z64" size 524288 crc 0255875d )
-	rom ( name "UltraMSX2 V1.0 w-Salamander by Jos Kwanten (PD).z64" size 524288 crc 264eae81 )
-	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD) [f1] (V64).z64" size 2097152 crc 03795ee4 )
-	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD).z64" size 1048576 crc 6aebcd00 )
-	rom ( name "VNES64 + Galaga (PD).z64" size 1310720 crc 927b17a4 )
-	rom ( name "VNES64 + Mario (PD).z64" size 1310720 crc 16a708b2 )
-	rom ( name "VNES64 + Test Cart (PD).z64" size 1310720 crc a9e37ba5 )
-	rom ( name "VNES64 V0.1 by Jean-Luc Picard (POM '98) (PD).z64" size 1060878 crc e7898d4e )
-	rom ( name "VNES64 V0.12 by Jean-Luc Picard (PD).z64" size 2097152 crc b90d5f96 )
-)
-
-game (
-	name "Public Domain (Intros)"
-	description "Public Domain (Intros)"
-	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [b1].z64" size 1310720 crc 06a8eded )
-	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [h1C].z64" size 1310720 crc b7fbcfbf )
-	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD).z64" size 1310720 crc 886e5c25 )
-	rom ( name "Alienstyle Intro by Renderman (PD) [a1].z64" size 1310720 crc afc60bf3 )
-	rom ( name "Alienstyle Intro by Renderman (PD).z64" size 1310720 crc f6f9b635 )
-	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD) [b1].z64" size 262144 crc f3c6f1b3 )
-	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD).z64" size 1310720 crc bb82270a )
-	rom ( name "Dynamix Intro (Hidden Song) by Widget and Immortal (PD).z64" size 1310720 crc 7aa49c93 )
-	rom ( name "Dynamix Intro by Widget and Immortal (PD) [h1C].z64" size 1310720 crc 1c24be4d )
-	rom ( name "Dynamix Intro by Widget and Immortal (PD).z64" size 1310720 crc e188962a )
-	rom ( name "Eurasia First N64 Intro by Sispeo (PD).z64" size 1572864 crc 3e198a3c )
-	rom ( name "Eurasia Intro by Ste (PD) [b1].z64" size 1572864 crc e0832eb4 )
-	rom ( name "Eurasia Intro by Ste (PD).z64" size 2359296 crc aab92d03 )
-	rom ( name "Freekworld BBS Intro by Rene (PD) [a1].z64" size 786432 crc e8b47508 )
-	rom ( name "Freekworld BBS Intro by Rene (PD).z64" size 1048576 crc f909a0e2 )
-	rom ( name "Freekworld New Intro by Ste (PD).z64" size 1835008 crc 9e092010 )
-	rom ( name "GoldenEye 007 Intro by SonCrap (PD).z64" size 2097152 crc 1c95ea7d )
-	rom ( name "HSD Quick Intro (PD).z64" size 1310720 crc d8f98b8f )
-	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD) [a1].z64" size 1572864 crc a04eadec )
-	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD).z64" size 1572864 crc 4fedb618 )
-	rom ( name "MSFTUG Intro #1 by LaC (PD).z64" size 1310720 crc 5ebd8482 )
-	rom ( name "NBC First Intro by CALi (PD).z64" size 262144 crc db19d4f2 )
-	rom ( name "Oerjan Intro by Oerjan (POM '99) (PD).z64" size 1310720 crc 899bae4d )
-	rom ( name "Planet Console Intro (PD).z64" size 262144 crc 266b8af5 )
-	rom ( name "Quake 64 Intro (PD).z64" size 1310720 crc c4dccebc )
-	rom ( name "RADWAR 2K Party Inv. Intro by Ayatolloh (PD).z64" size 2097152 crc 68ca8fa8 )
-	rom ( name "RPA Site Intro by Lem (PD).z64" size 1310720 crc a7ef1ee3 )
-	rom ( name "Soncrap Intro by RedboX (PD).z64" size 2097152 crc 433f92fa )
-	rom ( name "The Corporation 1st Intro by i_savant (PD) [b1].z64" size 1179648 crc c11a41e1 )
-	rom ( name "The Corporation 1st Intro by i_savant (PD).z64" size 1179648 crc 78afcb51 )
-	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [a1].z64" size 1310720 crc dbb84084 )
-	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [b1].z64" size 1310720 crc a8007491 )
-	rom ( name "The Corporation 2nd Intro by TS_Garp (PD).z64" size 1310720 crc 6f91442f )
-	rom ( name "Tristar and Lightforce Quake Intro by Ayatollah & Mike (PD).z64" size 1310720 crc c2733e40 )
-	rom ( name "TRSI Intro by Ayatollah (POM '99) (PD).z64" size 2621440 crc e998917a )
-	rom ( name "Virtual Springfield Site Intro by Presten (PD).z64" size 2359296 crc f1f3e11e )
-)
-
-game (
-	name "Public Domain (Tools)"
-	description "Public Domain (Tools)"
-	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD) [b1].z64" size 2097152 crc 8e095ecc )
-	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD).z64" size 2097152 crc 36913e7d )
-	rom ( name "BB SRAM Manager (PD).z64" size 1310720 crc f1c0331e )
-	rom ( name "Boot Emu by Jovis (PD).z64" size 1310720 crc 8ce8ded7 )
-	rom ( name "CD64 Memory Test (PD).z64" size 1310720 crc dfab7498 )
-	rom ( name "Diddy Kong Racing SRAM by Group5 (PD).z64" size 1310720 crc 96cca1f2 )
-	rom ( name "DS1 Manager V1.0 by R. Bubba Magillicutty (PD).z64" size 262144 crc f7db1ba0 )
-	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD) [T+Ita].rom" size 262144 crc 91f9ed69 )
-	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD).z64" size 262144 crc 66afc5c3 )
-	rom ( name "DS1 SRAM Manager V1.1 by _Sage_ (PD).z64" size 1310720 crc 6aee017f )
-	rom ( name "Evek - V64jr Save Manager by WT_Riker (PD).z64" size 262144 crc b4745243 )
-	rom ( name "Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD).z64" size 1310720 crc 6545db14 )
-	rom ( name "Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD).z64" size 1310720 crc d8306df8 )
-	rom ( name "LaC's Universal Bootemu V1.0 (PD).z64" size 262144 crc f2def854 )
-	rom ( name "LaC's Universal Bootemu V1.1 (PD).z64" size 262144 crc abbb9cf8 )
-	rom ( name "LaC's Universal Bootemu V1.2 (PD).z64" size 1310720 crc 5dad5ce6 )
-	rom ( name "Mempack Manager for Jr 0.9 by deas (PD).z64" size 1310720 crc f0efb434 )
-	rom ( name "Mempack Manager for Jr 0.9b by deas (PD).z64" size 1310720 crc 07b656cd )
-	rom ( name "Mempack Manager for Jr 0.9c by deas (PD).z64" size 1310720 crc 8ff05062 )
-	rom ( name "Mempack to N64 Uploader by Destop V1.0 (PD).z64" size 427704 crc 7e787b48 )
-	rom ( name "Mortal Kombat SRAM Loader (PD).z64" size 1310720 crc 62e14497 )
-	rom ( name "NUTS - Nintendo Ultra64 Test Suite by MooglyGuy (PD).z64" size 2097152 crc ab88303d )
-	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD) [a1].z64" size 8388608 crc 7ef6fb76 )
-	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD).z64" size 8388608 crc 2dfc78d5 )
-	rom ( name "SRAM Manager V1.0 Beta (PD).z64" size 2097152 crc 476dbab1 )
-	rom ( name "SRAM Manager V1.0 PAL Beta (PD).z64" size 1310720 crc 9ec21295 )
-	rom ( name "SRAM Manager V2.0 (PD) [a1].z64" size 786432 crc 87f2400c )
-	rom ( name "SRAM Manager V2.0 (PD) [h1C].z64" size 1310720 crc bf6c8a15 )
-	rom ( name "SRAM Manager V2.0 (PD) [h2C].z64" size 1310720 crc ba6f9de6 )
-	rom ( name "SRAM Manager V2.0 (PD).z64" size 1310720 crc 1bddf05f )
-	rom ( name "SRAM to DS1 Tool by WT_Riker (PD).z64" size 2097152 crc 2c1671e7 )
-	rom ( name "SRAM Upload Tool (PD).z64" size 1310720 crc 8280ab7a )
-	rom ( name "SRAM Upload Tool + Star Fox 64 SRAM (PD).z64" size 1310720 crc 44c44c92 )
-	rom ( name "SRAM Upload Tool V1 by LaC (PD).z64" size 8388608 crc d50828d1 )
-	rom ( name "SRAM Upload Tool V1.1 by Lac (PD) [b1].z64" size 1310720 crc 1eb5431c )
-	rom ( name "SRAM Upload Tool V1.1 by Lac (PD).z64" size 1310720 crc 0e4aba32 )
-	rom ( name "SRAM Uploader-Editor by BlackBag (PD).z64" size 1310720 crc 429277ee )
-	rom ( name "Unix SRAM-Upload Utility 1.0 by Madman (PD).z64" size 1310720 crc 46325595 )
-	rom ( name "V64Jr 512M Backup Program by HKPhooey (PD).z64" size 1310720 crc 33704aff )
-	rom ( name "V64Jr Backup Tool by WT_Riker (PD).z64" size 2097152 crc bda5fb4b )
-	rom ( name "V64Jr Backup Tool V0.2b_Beta by RedboX (PD).z64" size 2097152 crc 9536fe2b )
-	rom ( name "V64Jr Flash Save Util by CrowTRobo (PD).z64" size 1310720 crc 18f47b60 )
-	rom ( name "View N64 Test Program (PD) [b1].z64" size 2097152 crc fb65b4f8 )
-	rom ( name "View N64 Test Program (PD).z64" size 524288 crc a41556be )
-	rom ( name "Yoshi's Story BootEmu (PD).z64" size 1310720 crc 4ad8e4f7 )
-	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD) [a1].z64" size 262144 crc dd5ba742 )
-	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD).z64" size 262144 crc 3ee1b78b )
-	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD) [a1].z64" size 262144 crc e4e29dc9 )
-	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD).z64" size 262144 crc 07588d00 )
-)
-
-game (
-	name "Puyo Puyo 4 - Puyo Puyo Party"
-	description "Puyo Puyo 4 - Puyo Puyo Party"
-	rom ( name "Puyo Puyo 4 - Puyo Puyo Party (J) [!].z64" size 12582912 crc d59d2794 )
-)
-
-game (
-	name "Puyo Puyo Sun 64"
-	description "Puyo Puyo Sun 64"
-	rom ( name "Puyo Puyo Sun 64 (J) [!].z64" size 8388608 crc 355ff9de )
-	rom ( name "Puyo Puyo Sun 64 (J) [b1].z64" size 8388608 crc 3b88ce97 )
-)
-
-game (
-	name "Quake 64"
-	description "Quake 64"
-	rom ( name "Quake 64 (E) [!].z64" size 12582912 crc 28c10844 )
-	rom ( name "Quake 64 (E) [o1].z64" size 16777216 crc dcdeca54 )
-	rom ( name "Quake 64 (E) [t1].z64" size 12582912 crc 2618f474 )
-	rom ( name "Quake 64 (U) [!].z64" size 12582912 crc 761f39d1 )
-	rom ( name "Quake 64 (U) [b1].z64" size 12582912 crc 2e004334 )
-	rom ( name "Quake 64 (U) [h1C].z64" size 16777216 crc f7797d6c )
-	rom ( name "Quake 64 (U) [o1].z64" size 16777216 crc 92dcb206 )
-	rom ( name "Quake 64 (U) [o1][t1].z64" size 16777216 crc 2235b036 )
-	rom ( name "Quake 64 (U) [o2].z64" size 16777216 crc ba81d418 )
-	rom ( name "Quake 64 (U) [o2][t1].z64" size 16777216 crc 87f05c4d )
-	rom ( name "Quake 64 (U) [t1].z64" size 12582912 crc 61d7e238 )
-)
-
-game (
-	name "Quake II"
-	description "Quake II"
-	rom ( name "Quake II (E) [!].z64" size 12582912 crc 82beca21 )
-	rom ( name "Quake II (E) [h1C].z64" size 12582912 crc d7002a39 )
-	rom ( name "Quake II (U) [!].z64" size 12582912 crc e6b34387 )
-	rom ( name "Quake II (U) [f1] (PAL).z64" size 12582912 crc 2cd53cf2 )
-)
-
-game (
-	name "Quest 64"
-	description "Quest 64"
-	rom ( name "Eltale Monsters (J) [!].z64" size 16777216 crc a4fe7652 )
-	rom ( name "Eltale Monsters (J) [b1].z64" size 16777181 crc 75fffb14 )
-	rom ( name "Holy Magic Century (E) [!].z64" size 16777216 crc bf6f67bf )
-	rom ( name "Holy Magic Century (E) [b1].z64" size 16777216 crc 84ff9890 )
-	rom ( name "Holy Magic Century (F) [h1C].z64" size 16777216 crc baf6c66a )
-	rom ( name "Holy Magic Century (F) [o1].z64" size 16777220 crc 53ccd8f4 )
-	rom ( name "Holy Magic Century (F).z64" size 16777216 crc 284170ed )
-	rom ( name "Holy Magic Century (G) [!].z64" size 16777216 crc d1934cf6 )
-	rom ( name "Holy Magic Century (G) [b1].z64" size 16777216 crc 2f87f160 )
-	rom ( name "Holy Magic Century (G) [b2].z64" size 16777216 crc aa28c3c1 )
-	rom ( name "Holy Magic Century (G) [b3].z64" size 16777216 crc 8bc3d869 )
-	rom ( name "Quest 64 (U) [!].z64" size 16777216 crc d75b45c6 )
-	rom ( name "Quest 64 (U) [b1].z64" size 16777216 crc 166b46bf )
-	rom ( name "Quest 64 (U) [b2].z64" size 8519680 crc b23c4425 )
-	rom ( name "Quest 64 (U) [b3].z64" size 16777216 crc c4134703 )
-	rom ( name "Quest 64 (U) [b4].z64" size 16515072 crc 4a3a1548 )
-	rom ( name "Quest 64 (U) [b5].z64" size 16777216 crc d3c10d18 )
-	rom ( name "Quest 64 (U) [t1].z64" size 16777216 crc addb964b )
-)
-
-game (
-	name "Rakuga Kids"
-	description "Rakuga Kids"
-	rom ( name "Rakuga Kids (E) [!].z64" size 12582912 crc 483129aa )
-	rom ( name "Rakuga Kids (E) [b1].z64" size 12582912 crc f2f11a4f )
-	rom ( name "Rakuga Kids (E) [f1] (NTSC).z64" size 12582912 crc b62029dd )
-	rom ( name "Rakuga Kids (E) [h1C].z64" size 12582912 crc b9165694 )
-	rom ( name "Rakuga Kids (J) [!].z64" size 12582912 crc b9e53b06 )
-	rom ( name "Rakuga Kids (J) [b1].z64" size 12582912 crc 4d897ef9 )
-	rom ( name "Rakuga Kids (J) [h1C].z64" size 12582912 crc 48c24438 )
-)
-
-game (
-	name "Rally Challenge 2000"
-	description "Rally Challenge 2000"
-	rom ( name "Rally '99 (J) [!].z64" size 8388608 crc ffa625fe )
-	rom ( name "Rally '99 (J) [f1] (PAL).z64" size 8388608 crc d12ee95f )
-	rom ( name "Rally Challenge 2000 (U) [!].z64" size 12582912 crc 3edec7b0 )
-)
-
-game (
-	name "Rampage - World Tour"
-	description "Rampage - World Tour"
-	rom ( name "Rampage - World Tour (E) [!].z64" size 12582912 crc cdc458ec )
-	rom ( name "Rampage - World Tour (E) [h1C].z64" size 12582912 crc 4d1c58cc )
-	rom ( name "Rampage - World Tour (U) [!].z64" size 12582912 crc 211119dd )
-	rom ( name "Rampage - World Tour (U) [b1].z64" size 12648804 crc c86193cb )
-	rom ( name "Rampage - World Tour (U) [b2].z64" size 12582912 crc 57788722 )
-	rom ( name "Rampage - World Tour (U) [b3].z64" size 12582910 crc 3e734158 )
-	rom ( name "Rampage - World Tour (U) [b4].z64" size 12582912 crc 68e3e953 )
-	rom ( name "Rampage - World Tour (U) [h1C].z64" size 12582912 crc dc157ffb )
-	rom ( name "Rampage - World Tour (U) [t1].z64" size 12582912 crc 81dd0ec0 )
-	rom ( name "Rampage - World Tour (U) [t2].z64" size 12582912 crc 7a16a164 )
-)
-
-game (
-	name "Rampage 2 - Universal Tour"
-	description "Rampage 2 - Universal Tour"
-	rom ( name "Rampage 2 - Universal Tour (E) [!].z64" size 12582912 crc fa6e097b )
-	rom ( name "Rampage 2 - Universal Tour (U) [!].z64" size 12582912 crc 7614ee0d )
-	rom ( name "Rampage 2 - Universal Tour (U) [t1].z64" size 12845056 crc b1f3163b )
-	rom ( name "Rampage 2 - Universal Tour (U) [t2].z64" size 12845056 crc 259dc074 )
-)
-
-game (
-	name "Rat Attack"
-	description "Rat Attack"
-	rom ( name "Rat Attack (E) (M6) [!].z64" size 8388608 crc dd4fa798 )
-	rom ( name "Rat Attack (E) (M6) [f1] (NTSC).z64" size 8388608 crc e9cbbe51 )
-	rom ( name "Rat Attack (E) (M6) [h1C].z64" size 8388608 crc e4215fef )
-	rom ( name "Rat Attack (U) (M6) [!].z64" size 8388608 crc 2315fea7 )
-)
-
-game (
-	name "Rayman 2 - The Great Escape"
-	description "Rayman 2 - The Great Escape"
-	rom ( name "Rayman 2 - The Great Escape (E) (M5) [!].z64" size 33554432 crc 169a5037 )
-	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC).z64" size 33554432 crc 9d33f2e1 )
-	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f2] (NTSC).z64" size 33554432 crc 98ae479b )
-	rom ( name "Rayman 2 - The Great Escape (U) (M5) [!].z64" size 33554432 crc 02bb4409 )
-	rom ( name "Rayman 2 - The Great Escape (U) (M5) [t1].z64" size 33554432 crc 415a2bbc )
-)
-
-game (
-	name "Razor Freestyle Scooter"
-	description "Razor Freestyle Scooter"
-	rom ( name "Razor Freestyle Scooter (U) [!].z64" size 8388608 crc 927ce621 )
-)
-
-game (
-	name Re-Volt
-	description "Re-Volt"
-	rom ( name "Re-Volt (E) (M4) [!].z64" size 12582912 crc 81d13a11 )
-	rom ( name "Re-Volt (U) [!].z64" size 12582912 crc fc0c86d0 )
-	rom ( name "Re-Volt (U) [f1] (Country Check).z64" size 12582912 crc ec4c68d4 )
-	rom ( name "Re-Volt (U) [f2] (PAL).z64" size 12582912 crc f3efc7cb )
-	rom ( name "Re-Volt (U) [t1].z64" size 12582912 crc 604400cf )
-)
-
-game (
-	name "Ready 2 Rumble Boxing"
-	description "Ready 2 Rumble Boxing"
-	rom ( name "Ready 2 Rumble Boxing (E) (M3) [!].z64" size 33554432 crc a69df7b3 )
-	rom ( name "Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable).z64" size 33554432 crc b0591a28 )
-	rom ( name "Ready 2 Rumble Boxing (U) [!].z64" size 33554432 crc 2a554048 )
-	rom ( name "Ready 2 Rumble Boxing (U) [f1] (PAL).z64" size 33554432 crc c981afb7 )
-	rom ( name "Ready 2 Rumble Boxing (U) [t1] (P1 Untouchable).z64" size 33554432 crc ff48b206 )
-)
-
-game (
-	name "Ready 2 Rumble Boxing - Round 2"
-	description "Ready 2 Rumble Boxing - Round 2"
-	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [!].z64" size 33554432 crc 052a0e04 )
-	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [t1].z64" size 33554432 crc b5e23cc7 )
-)
-
-game (
-	name "Resident Evil 2"
-	description "Resident Evil 2"
-	rom ( name "Biohazard 2 (J) [!].z64" size 67108864 crc 4f9d569f )
-	rom ( name "Resident Evil 2 (E) (M2) [!].z64" size 67108864 crc 7c8ee011 )
-	rom ( name "Resident Evil 2 (U) (V1.1) [!].z64" size 67108864 crc 848fbc0d )
-)
-
-game (
-	name "Road Rash 64"
-	description "Road Rash 64"
-	rom ( name "Road Rash 64 (E) [!].z64" size 33554432 crc 3c664a7b )
-	rom ( name "Road Rash 64 (E) [h1C].z64" size 33554432 crc 39bb993f )
-	rom ( name "Road Rash 64 (U) [!].z64" size 33554432 crc 600b3988 )
-	rom ( name "Road Rash 64 (U) [f1] (PAL).z64" size 33554432 crc 321afcc1 )
-	rom ( name "Road Rash 64 (U) [t1].z64" size 33554432 crc d10f77a1 )
-)
-
-game (
-	name "Roadsters Trophy"
-	description "Roadsters Trophy"
-	rom ( name "Roadsters Trophy (E) (M6) [!].z64" size 12582912 crc 997ed5af )
-	rom ( name "Roadsters Trophy (U) (M3) [!].z64" size 12582912 crc e4337b92 )
-	rom ( name "Roadsters Trophy (U) (M3) [f1] (PAL).z64" size 12582912 crc 55980f72 )
-	rom ( name "Roadsters Trophy (U) (M3) [t1].z64" size 12582912 crc a51b51d1 )
-)
-
-game (
-	name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel"
-	description "Robot Ponkotsu 64 - 7tsu no Umi no Caramel"
-	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!].z64" size 33554432 crc 3b0f8061 )
-	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL).z64" size 33554432 crc b4f3e4e6 )
-)
-
-game (
-	name "Robotech - Crystal Dreams"
-	description "Robotech - Crystal Dreams"
-	rom ( name "Robotech - Crystal Dreams (Beta) [a1].z64" size 12582912 crc 8f5bc48f )
-	rom ( name "Robotech - Crystal Dreams (Beta).z64" size 16777216 crc f9a7904e )
-)
-
-game (
-	name "Robotron 64"
-	description "Robotron 64"
-	rom ( name "Robotron 64 (E) [!].z64" size 8388608 crc 23bf4956 )
-	rom ( name "Robotron 64 (E) [h1C].z64" size 8388608 crc 90088356 )
-	rom ( name "Robotron 64 (U) [!].z64" size 8388608 crc b2cbae58 )
-	rom ( name "Robotron 64 (U) [b1].z64" size 8388608 crc 3c95e84c )
-	rom ( name "Robotron 64 (U) [b2].z64" size 8388608 crc 6093b12b )
-	rom ( name "Robotron 64 (U) [b3].z64" size 8388608 crc d3247b2b )
-	rom ( name "Robotron 64 (U) [b4].z64" size 8388608 crc 8fb685a9 )
-	rom ( name "Robotron 64 (U) [f1] (PAL).z64" size 8388608 crc 8ba428cd )
-	rom ( name "Robotron 64 (U) [o1].z64" size 8126464 crc 1d89eb63 )
-	rom ( name "Robotron 64 (U) [t1].z64" size 8388608 crc 9d5938ac )
-)
-
-game (
-	name "Rocket - Robot on Wheels"
-	description "Rocket - Robot on Wheels"
-	rom ( name "Rocket - Robot on Wheels (E) (M3) [!].z64" size 12582912 crc 7de5d20d )
-	rom ( name "Rocket - Robot on Wheels (U) [!].z64" size 12582912 crc e0399f23 )
-	rom ( name "Rocket - Robot on Wheels (U) [b1].z64" size 12582912 crc fb415f76 )
-	rom ( name "Rocket - Robot on Wheels (U) [f1] (PAL).z64" size 12582912 crc 72d33867 )
-	rom ( name "Rocket - Robot on Wheels (U) [t1].z64" size 12582912 crc a449f11c )
-)
-
-game (
-	name "RR64 - Ridge Racer 64"
-	description "RR64 - Ridge Racer 64"
-	rom ( name "RR64 - Ridge Racer 64 (E) [!].z64" size 33554432 crc dd9ae3a8 )
-	rom ( name "RR64 - Ridge Racer 64 (U) [!].z64" size 33554432 crc 3c2c2d1c )
-	rom ( name "RR64 - Ridge Racer 64 (U) [f1] (PAL).z64" size 33554432 crc bfe2077b )
-	rom ( name "RR64 - Ridge Racer 64 (U) [t1].z64" size 33554432 crc 7adf6a89 )
-)
-
-game (
-	name "Rugrats - Scavenger Hunt"
-	description "Rugrats - Scavenger Hunt"
-	rom ( name "Les Razmoket - La Chasse Aux Tresors (F) [!].z64" size 16777216 crc 66766469 )
-	rom ( name "Rugrats - Die grosse Schatzsuche (G) [!].z64" size 16777216 crc 23aed3a2 )
-	rom ( name "Rugrats - Scavenger Hunt (U) [!].z64" size 16777216 crc a87faf82 )
-	rom ( name "Rugrats - Scavenger Hunt (U) [f1] (PAL).z64" size 16777216 crc e24fcd04 )
-	rom ( name "Rugrats - Treasure Hunt (E) [!].z64" size 16777216 crc 3338b7c8 )
-	rom ( name "Rugrats - Treasure Hunt (E) [h1C].z64" size 16777216 crc a1938b36 )
-)
-
-game (
-	name "Rugrats in Paris - The Movie"
-	description "Rugrats in Paris - The Movie"
-	rom ( name "Rugrats in Paris - The Movie (E) [!].z64" size 16777216 crc cd74b07e )
-	rom ( name "Rugrats in Paris - The Movie (U) [!].z64" size 16777216 crc a9cc2419 )
-	rom ( name "Rugrats in Paris - The Movie (U) [T+Spa0.10].z64" size 16777216 crc bda8a807 )
-)
-
-game (
-	name "Rush 2 - Extreme Racing USA"
-	description "Rush 2 - Extreme Racing USA"
-	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [!].z64" size 12582912 crc 30f21f89 )
-	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h1I].z64" size 12582912 crc 3940f7dd )
-	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h2I].z64" size 12582912 crc e23de536 )
-	rom ( name "Rush 2 - Extreme Racing USA (U) [!].z64" size 12582912 crc 9eb14ea8 )
-)
-
-game (
-	name S.C.A.R.S.
-	description "S.C.A.R.S."
-	rom ( name "S.C.A.R.S. (E) (M3) [!].z64" size 8388608 crc 4e37b6f2 )
-	rom ( name "S.C.A.R.S. (E) (M3) [h1C].z64" size 8388608 crc c3747a8d )
-	rom ( name "S.C.A.R.S. (U) [!].z64" size 8388608 crc 22916735 )
-	rom ( name "S.C.A.R.S. (U) [f1] (PAL).z64" size 8388608 crc 848b3dab )
-	rom ( name "S.C.A.R.S. (U) [t1].z64" size 8388608 crc 42a8ee01 )
-)
-
-game (
-	name "Saikyou Habu Shougi"
-	description "Saikyou Habu Shougi"
-	rom ( name "Saikyou Habu Shougi (J) [!].z64" size 8388608 crc 01794d62 )
-	rom ( name "Saikyou Habu Shougi (J) [h1C].z64" size 8388608 crc c1f2b7a4 )
-	rom ( name "Saikyou Habu Shougi (J) [h2C].z64" size 8388608 crc a5d2585d )
-	rom ( name "Saikyou Habu Shougi (J) [h3C].z64" size 8388608 crc cb3fd380 )
-	rom ( name "Saikyou Habu Shougi (J) [h4C].z64" size 8388608 crc a1211799 )
-)
-
-game (
-	name "San Francisco Rush - Extreme Racing"
-	description "San Francisco Rush - Extreme Racing"
-	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [!].z64" size 8388608 crc e064962a )
-	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [h1C].z64" size 8388608 crc 34a7f68e )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [!].z64" size 8388608 crc 3e20070b )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b1].z64" size 16777216 crc cf1e89e3 )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b2].z64" size 16777216 crc c5c8ce3b )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b3].z64" size 8388608 crc f0772e31 )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o1].z64" size 12582912 crc e9adb7c1 )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o2].z64" size 16777216 crc d0a9eb38 )
-	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o3].z64" size 16777216 crc b6b9f6be )
-)
-
-game (
-	name "San Francisco Rush 2049"
-	description "San Francisco Rush 2049"
-	rom ( name "San Francisco Rush 2049 (E) (M6) [!].z64" size 12582912 crc e63b86c5 )
-	rom ( name "San Francisco Rush 2049 (U) [!].z64" size 12582912 crc 10941439 )
-	rom ( name "San Francisco Rush 2049 (U) [t1].z64" size 12582912 crc 540a6de1 )
-)
-
-game (
-	name "Scooby-Doo! - Classic Creep Capers"
-	description "Scooby-Doo! - Classic Creep Capers"
-	rom ( name "Scooby-Doo! - Classic Creep Capers (E) [!].z64" size 16777216 crc 0d737e6f )
-	rom ( name "Scooby-Doo! - Classic Creep Capers (U) [!].z64" size 16777216 crc 39068228 )
-)
-
-game (
-	name "SD Hiryuu no Ken Densetsu"
-	description "SD Hiryuu no Ken Densetsu"
-	rom ( name "SD Hiryuu no Ken Densetsu (J) [!].z64" size 12582912 crc cc083e34 )
-	rom ( name "SD Hiryuu no Ken Densetsu (J) [f1] (PAL).z64" size 12582912 crc e0921d7e )
-)
-
-game (
-	name "Shadow Man"
-	description "Shadow Man"
-	rom ( name "Shadow Man (E) (M3) [!].z64" size 33554432 crc 8d230306 )
-	rom ( name "Shadow Man (F) [!].z64" size 33554432 crc 6812d3a7 )
-	rom ( name "Shadow Man (G) [!].z64" size 33554432 crc eaf6add1 )
-	rom ( name "Shadow Man (G) [b1].z64" size 33554432 crc f71cc55b )
-	rom ( name "Shadow Man (G) [b2].z64" size 33554432 crc e020c909 )
-	rom ( name "Shadow Man (G) [f1] (NTSC).z64" size 33554432 crc c580323e )
-	rom ( name "Shadow Man (U) [!].z64" size 33554432 crc 5e20cc63 )
-	rom ( name "Shadow Man (U) [b1].z64" size 33554432 crc 622d1f6c )
-	rom ( name "Shadow Man (U) [b2].z64" size 33554980 crc 65af5218 )
-	rom ( name "Shadow Man (U) [b3].z64" size 33554431 crc 80b0befd )
-	rom ( name "Shadow Man (U) [t1].z64" size 33554432 crc 181f5096 )
-)
-
-game (
-	name "Shadowgate 64 - Trials Of The Four Towers"
-	description "Shadowgate 64 - Trials Of The Four Towers"
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!].z64" size 16777216 crc 87f00472 )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!].z64" size 16777216 crc eedc0bea )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [!].z64" size 16777216 crc ff7d7df0 )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC).z64" size 16777216 crc 31fc728a )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b1].z64" size 16777216 crc 2bd3203a )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b2].z64" size 16777216 crc cbeb984b )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J).z64" size 16777216 crc 9f74a58c )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!].z64" size 16777216 crc 69983cc3 )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL).z64" size 16777216 crc 627f113a )
-	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f2] (PAL).z64" size 16777216 crc 1b731693 )
-)
-
-game (
-	name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition"
-	description "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition"
-	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!].z64" size 16777216 crc 576915d4 )
-	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [b1].z64" size 16777216 crc b8925ed3 )
-)
-
-game (
-	name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits"
-	description "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits"
-	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!].z64" size 12582912 crc e892ed43 )
-	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1].z64" size 11796480 crc 66790e64 )
-)
-
-game (
-	name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation"
-	description "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation"
-	rom ( name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!].z64" size 33554432 crc deac787f )
-)
-
-game (
-	name "Sim City 2000"
-	description "Sim City 2000"
-	rom ( name "Sim City 2000 (J) [!].z64" size 12582912 crc 57767e45 )
-	rom ( name "Sim City 2000 (J) [b1].z64" size 12582912 crc ae23045e )
-	rom ( name "Sim City 2000 (J) [b1][o1].z64" size 11010048 crc c2fd3d62 )
-	rom ( name "Sim City 2000 (J) [b2].z64" size 16777216 crc e435b297 )
-	rom ( name "Sim City 2000 (J) [h1C].z64" size 12582912 crc 8140d8fc )
-	rom ( name "Sim City 2000 (J) [o1].z64" size 16777216 crc 73c9ab24 )
-	rom ( name "Sim City 2000 (J) [o1][h1C].z64" size 16777216 crc dbef385d )
-)
-
-game (
-	name "Snowboard Kids"
-	description "Snowboard Kids"
-	rom ( name "Snobow Kids (J) [!].z64" size 8388608 crc 213bf381 )
-	rom ( name "Snobow Kids (J) [h1C].z64" size 8388608 crc ce6d35f1 )
-	rom ( name "Snobow Kids (J) [h2C].z64" size 8388608 crc 299830e2 )
-	rom ( name "Snowboard Kids (E) [!].z64" size 8388608 crc 5619a70d )
-	rom ( name "Snowboard Kids (E) [h1C].z64" size 8388608 crc eca826fc )
-	rom ( name "Snowboard Kids (U) [!].z64" size 8388608 crc 020fb906 )
-	rom ( name "Snowboard Kids (U) [b1].z64" size 8388612 crc 798d185f )
-	rom ( name "Snowboard Kids (U) [b2].z64" size 8388608 crc cc3a899d )
-	rom ( name "Snowboard Kids (U) [b3].z64" size 8388608 crc 8eb60a3d )
-	rom ( name "Snowboard Kids (U) [h1C].z64" size 8388608 crc b8be38f7 )
-	rom ( name "Snowboard Kids (U) [t1].z64" size 8388608 crc 72219675 )
-)
-
-game (
-	name "Snowboard Kids 2"
-	description "Snowboard Kids 2"
-	rom ( name "Chou Snobow Kids (J) [!].z64" size 16777216 crc 8fedf4c6 )
-	rom ( name "Chou Snobow Kids (J) [f1] (PAL).z64" size 16777216 crc f999b89c )
-	rom ( name "Snowboard Kids 2 (E) [!].z64" size 16777216 crc 3a0b6214 )
-	rom ( name "Snowboard Kids 2 (U) [!].z64" size 16777216 crc d0dc8a8e )
-	rom ( name "Snowboard Kids 2 (U) [f1] (PAL).z64" size 16777216 crc ac4b9da6 )
-	rom ( name "Snowboard Kids 2 (U) [f2] (PAL).z64" size 16777216 crc 8232ccaf )
-)
-
-game (
-	name "South Park"
-	description "South Park"
-	rom ( name "South Park (E) (M3) [!].z64" size 16777216 crc b2c3e123 )
-	rom ( name "South Park (E) (M3) [b1].z64" size 16777216 crc 56c96784 )
-	rom ( name "South Park (E) (M3) [h1C].z64" size 16777216 crc 4710b1cd )
-	rom ( name "South Park (G) [!].z64" size 16777216 crc 5711e197 )
-	rom ( name "South Park (U) [!].z64" size 16777216 crc 7d666b9e )
-	rom ( name "South Park (U) [b1].z64" size 16777216 crc 858f3df8 )
-	rom ( name "South Park (U) [f1] (PAL).z64" size 16777216 crc 73c0bcf5 )
-	rom ( name "South Park (U) [t1].z64" size 16777216 crc 4efe2139 )
-)
-
-game (
-	name "South Park - Chef's Luv Shack"
-	description "South Park - Chef's Luv Shack"
-	rom ( name "South Park - Chef's Luv Shack (E) [!].z64" size 16777216 crc ac1628eb )
-	rom ( name "South Park - Chef's Luv Shack (U) [!].z64" size 16777216 crc 6b6b1d09 )
-	rom ( name "South Park - Chef's Luv Shack (U) [f1] (Country Check).z64" size 16777216 crc 605de6c5 )
-)
-
-game (
-	name "South Park Rally"
-	description "South Park Rally"
-	rom ( name "South Park Rally (E) [!].z64" size 16777216 crc 296e3525 )
-	rom ( name "South Park Rally (U) [!].z64" size 16777216 crc ccdd322a )
-	rom ( name "South Park Rally (U) [f1] (PAL).z64" size 16777216 crc 5b9b3f35 )
-	rom ( name "South Park Rally (U) [t1].z64" size 17039360 crc ac087102 )
-	rom ( name "South Park Rally (U) [t2].z64" size 16810384 crc dc38c0be )
-)
-
-game (
-	name "Space Invaders"
-	description "Space Invaders"
-	rom ( name "Space Invaders (U) [!].z64" size 8388608 crc 60f7ff8e )
-	rom ( name "Space Invaders (U) [f1] (PAL).z64" size 8388608 crc 2ce1ebb0 )
-	rom ( name "Space Invaders (U) [t1].z64" size 8388608 crc 47469c2d )
-	rom ( name "Space Invaders (U) [t2].z64" size 8388608 crc bab1c482 )
-)
-
-game (
-	name "Space Station Silicon Valley"
-	description "Space Station Silicon Valley"
-	rom ( name "Space Station Silicon Valley (E) (M7) [!].z64" size 8388608 crc 63042e36 )
-	rom ( name "Space Station Silicon Valley (E) (M7) [b1].z64" size 8388608 crc a7507158 )
-	rom ( name "Space Station Silicon Valley (J) [!].z64" size 8388608 crc dcec9f8a )
-	rom ( name "Space Station Silicon Valley (U) [!].z64" size 8388608 crc a606e8ae )
-	rom ( name "Space Station Silicon Valley (U) [f1] (PAL).z64" size 8388608 crc 0ef42062 )
-	rom ( name "Space Station Silicon Valley (U) [f2] (PAL).z64" size 8388608 crc 1b17acd9 )
-)
-
-game (
-	name Spider-Man
-	description "Spider-Man"
-	rom ( name "Spider-Man (U) [!].z64" size 33554432 crc 696cc2a4 )
-	rom ( name "Spider-Man (U) [t1].z64" size 33554432 crc 071196f8 )
-)
-
-game (
-	name "Star Fox 64"
-	description "Star Fox 64"
-	rom ( name "Lylat Wars (A) (M3) [!].z64" size 12582912 crc 9a3425da )
-	rom ( name "Lylat Wars (A) (M3) [f1].z64" size 12582912 crc 6c252beb )
-	rom ( name "Lylat Wars (A) (M3) [t1] (Boost).z64" size 12582912 crc 45139835 )
-	rom ( name "Lylat Wars (A) (M3) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 9f5255da )
-	rom ( name "Lylat Wars (E) (M3) [!].z64" size 12582912 crc 50a9c0b1 )
-	rom ( name "Lylat Wars (E) (M3) [f1].z64" size 12582912 crc a6b8ce80 )
-	rom ( name "Lylat Wars (E) (M3) [f1][h1C].z64" size 12582912 crc 82e3ff42 )
-	rom ( name "Lylat Wars (E) (M3) [f2] (NTSC).z64" size 12582912 crc 927cf25e )
-	rom ( name "Lylat Wars (E) (M3) [t1] (Boost).z64" size 12582912 crc 321ece7e )
-	rom ( name "Lylat Wars (E) (M3) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 13576cdd )
-	rom ( name "Star Fox 64 (J) [!].z64" size 12582912 crc 411142a7 )
-	rom ( name "Star Fox 64 (J) [f1].z64" size 12582912 crc dac2f94e )
-	rom ( name "Star Fox 64 (J) [o1].z64" size 16777216 crc 94e2bf8b )
-	rom ( name "Star Fox 64 (J) [o1][f1].z64" size 16777216 crc 4dc374c0 )
-	rom ( name "Star Fox 64 (J) [o2][f1].z64" size 16777216 crc 5d842b4d )
-	rom ( name "Star Fox 64 (J) [o3][f1].z64" size 16777216 crc 5439c8ed )
-	rom ( name "Star Fox 64 (J) [t1] (Boost).z64" size 12582912 crc 21278e57 )
-	rom ( name "Star Fox 64 (J) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 0963550f )
-	rom ( name "Star Fox 64 (U) (V1.0) [!].z64" size 12582912 crc b1fcaa9c )
-	rom ( name "Star Fox 64 (U) (V1.0) [f1].z64" size 12582912 crc 2a2f1175 )
-	rom ( name "Star Fox 64 (U) (V1.0) [f1][h1C].z64" size 12582912 crc 2e096bc0 )
-	rom ( name "Star Fox 64 (U) (V1.0) [f1][o1].z64" size 16777216 crc 6a831a95 )
-	rom ( name "Star Fox 64 (U) (V1.0) [f2] (PAL).z64" size 12582912 crc 878b74e8 )
-	rom ( name "Star Fox 64 (U) (V1.0) [h1C].z64" size 12582912 crc db9324c2 )
-	rom ( name "Star Fox 64 (U) (V1.0) [o1][f1].z64" size 16777216 crc b6007a08 )
-	rom ( name "Star Fox 64 (U) (V1.0) [o2][f1].z64" size 12845056 crc 792ed884 )
-	rom ( name "Star Fox 64 (U) (V1.0) [o3][f1].z64" size 33554432 crc e86af5a6 )
-	rom ( name "Star Fox 64 (U) (V1.0) [t1].z64" size 12845056 crc af40cb76 )
-	rom ( name "Star Fox 64 (U) (V1.0) [t2] (Boost).z64" size 12582912 crc 65935fe9 )
-	rom ( name "Star Fox 64 (U) (V1.0) [t3] (No Damage-Unbreakable Wings).z64" size 12582912 crc d9215c45 )
-	rom ( name "Star Fox 64 (U) (V1.1) [!].z64" size 12582912 crc b1b5fc46 )
-	rom ( name "Star Fox 64 (U) (V1.1) [t1] (Energy).z64" size 12582912 crc f066cc83 )
-	rom ( name "Star Fox 64 (U) (V1.1) [t2] (Boost).z64" size 12582912 crc 5083b27c )
-)
-
-game (
-	name "Star Soldier - Vanishing Earth"
-	description "Star Soldier - Vanishing Earth"
-	rom ( name "Star Soldier - Vanishing Earth (J) [!].z64" size 12582912 crc 7ee5f51d )
-	rom ( name "Star Soldier - Vanishing Earth (J) [b1].z64" size 12582912 crc 532379c3 )
-	rom ( name "Star Soldier - Vanishing Earth (J) [h1C].z64" size 12582912 crc cfda6035 )
-	rom ( name "Star Soldier - Vanishing Earth (J) [o1].z64" size 33554432 crc 720344d8 )
-	rom ( name "Star Soldier - Vanishing Earth (J) [t1].z64" size 12582912 crc 445278b4 )
-	rom ( name "Star Soldier - Vanishing Earth (U) [!].z64" size 12582912 crc ea650def )
-	rom ( name "Star Soldier - Vanishing Earth (U) [t1].z64" size 12582912 crc be7aa424 )
-)
-
-game (
-	name "Star Wars - Rogue Squadron"
-	description "Star Wars - Rogue Squadron"
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack).z64" size 16777216 crc acaa878b )
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!].z64" size 16777216 crc 6289645f )
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [t1].z64" size 16777216 crc 8aaff501 )
-	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!].z64" size 16777216 crc c88e5638 )
-	rom ( name "Star Wars - Rogue Squadron (U) (M3) (Language Select Hack).z64" size 16777216 crc d85ee95e )
-	rom ( name "Star Wars - Rogue Squadron (U) (M3) [!].z64" size 16777216 crc 83c225cc )
-	rom ( name "Star Wars - Rogue Squadron (U) (M3) [b1].z64" size 16777216 crc 207df305 )
-	rom ( name "Star Wars - Rogue Squadron (U) (M3) [t1].z64" size 16777216 crc 11adce88 )
-	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!].z64" size 16777216 crc ee7643b6 )
-)
-
-game (
-	name "Star Wars - Shadows of the Empire"
-	description "Star Wars - Shadows of the Empire"
-	rom ( name "Star Wars - Shadows of the Empire (E) [!].z64" size 12582912 crc f0a191bf )
-	rom ( name "Star Wars - Shadows of the Empire (E) [b1].z64" size 10440704 crc 2cb8bc8d )
-	rom ( name "Star Wars - Shadows of the Empire (E) [b2].z64" size 8388608 crc eeb97b44 )
-	rom ( name "Star Wars - Shadows of the Empire (E) [b3].z64" size 12582912 crc e1d48724 )
-	rom ( name "Star Wars - Shadows of the Empire (E) [b4].z64" size 16777216 crc 0387f26c )
-	rom ( name "Star Wars - Shadows of the Empire (E) [o1].z64" size 16777216 crc 34c7981c )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [!].z64" size 12582912 crc 3c0837b3 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b1].z64" size 12582912 crc f4e231a3 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b2].z64" size 12582912 crc e9810930 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [o1].z64" size 16777216 crc 1ec5f1dc )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t1].z64" size 12845056 crc e09db876 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t2].z64" size 12845056 crc 1012bedd )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [!].z64" size 12582912 crc b0540688 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [b1].z64" size 12582912 crc db8c7e81 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [o1].z64" size 16777216 crc 86767af9 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [t1].z64" size 12845056 crc 1cc97b41 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [!].z64" size 12582912 crc e8727549 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b1].z64" size 12845056 crc efebc833 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b2].z64" size 12582912 crc 26408ea6 )
-	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [o1].z64" size 16777216 crc 222d4a2b )
-	rom ( name "Star Wars - Teikoku no Kage (J) [!].z64" size 12582912 crc 7ce71426 )
-	rom ( name "Star Wars - Teikoku no Kage (J) [o1].z64" size 16777216 crc 6b430661 )
-	rom ( name "Star Wars - Teikoku no Kage (J) [o2].z64" size 16777216 crc 506afdda )
-)
-
-game (
-	name "Star Wars Episode I - Battle for Naboo"
-	description "Star Wars Episode I - Battle for Naboo"
-	rom ( name "Star Wars Episode I - Battle for Naboo (E) [!].z64" size 33554432 crc 029104fd )
-	rom ( name "Star Wars Episode I - Battle for Naboo (U) [!].z64" size 33554432 crc 99dee3c0 )
-	rom ( name "Star Wars Episode I - Battle for Naboo (U) [b1].z64" size 33329432 crc f02cd015 )
-	rom ( name "Star Wars Episode I - Battle for Naboo (U) [t1].z64" size 33554432 crc 377ce7c7 )
-)
-
-game (
-	name "Star Wars Episode I - Racer"
-	description "Star Wars Episode I - Racer"
-	rom ( name "Star Wars Episode I - Racer (E) (M3) [!].z64" size 33554432 crc e0f46629 )
-	rom ( name "Star Wars Episode I - Racer (E) (M3) [f1] (Save).z64" size 33554432 crc df6da1cf )
-	rom ( name "Star Wars Episode I - Racer (J) [!].z64" size 33554432 crc 97c155c5 )
-	rom ( name "Star Wars Episode I - Racer (J) [b1].z64" size 33554432 crc 5cc91891 )
-	rom ( name "Star Wars Episode I - Racer (U) [!].z64" size 33554432 crc c53c1035 )
-	rom ( name "Star Wars Episode I - Racer (U) [f1] (Save).z64" size 33554432 crc 950e170d )
-	rom ( name "Star Wars Episode I - Racer (U) [t1].z64" size 33554432 crc 5ad165b7 )
-	rom ( name "Star Wars Episode I - Racer (U) [t2].z64" size 33554432 crc f7841689 )
-	rom ( name "Star Wars Episode I - Racer (U) [t3].z64" size 33554432 crc b4ceaff5 )
-	rom ( name "Star Wars Episode I - Racer (U) [t4].z64" size 33554432 crc c59de7a3 )
-)
-
-game (
-	name "StarCraft 64"
-	description "StarCraft 64"
-	rom ( name "StarCraft 64 (Beta) [f1].z64" size 33554432 crc d0d566a2 )
-	rom ( name "StarCraft 64 (Beta) [f2] (PAL).z64" size 33554432 crc 79d4832c )
-	rom ( name "StarCraft 64 (Beta) [f3] (Country Code).z64" size 33554432 crc 5f114823 )
-	rom ( name "StarCraft 64 (Beta).z64" size 33554432 crc b0e1654f )
-	rom ( name "StarCraft 64 (E) [!].z64" size 33554432 crc 2639dae2 )
-	rom ( name "StarCraft 64 (E) [b1].z64" size 33554432 crc 888f52e7 )
-	rom ( name "StarCraft 64 (E) [f1] (NTSC).z64" size 33554432 crc 84a6ce9c )
-	rom ( name "StarCraft 64 (U) [!].z64" size 33554432 crc 4e4c7ec9 )
-)
-
-game (
-	name "Starshot - Space Circus Fever"
-	description "Starshot - Space Circus Fever"
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [!].z64" size 12582912 crc 056d2218 )
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%).z64" size 12582912 crc 01ae0cfc )
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [f2] (NTSC).z64" size 12582912 crc b3054021 )
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [f3] (NTSC).z64" size 12582912 crc 4aa2ec88 )
-	rom ( name "Starshot - Space Circus Fever (E) (M3) [t1].z64" size 12582912 crc 85bfe092 )
-	rom ( name "Starshot - Space Circus Fever (U) (M3) [!].z64" size 12582912 crc 7720e5f3 )
-	rom ( name "Starshot - Space Circus Fever (U) (M3) [b1].z64" size 12582912 crc 8f0a4446 )
-)
-
-game (
-	name "Stunt Racer 64"
-	description "Stunt Racer 64"
-	rom ( name "Stunt Racer 64 (U) [!].z64" size 12582912 crc 3438b1af )
-)
-
-game (
-	name "Super B-Daman - Battle Phoenix 64"
-	description "Super B-Daman - Battle Phoenix 64"
-	rom ( name "Super B-Daman - Battle Phoenix 64 (J) [!].z64" size 12582912 crc 5006dc88 )
-)
-
-game (
-	name "Super Bowling 64"
-	description "Super Bowling 64"
-	rom ( name "Super Bowling (J) [!].z64" size 8388608 crc ba2d8b2e )
-	rom ( name "Super Bowling 64 (U) [!].z64" size 8388608 crc f6ccd04a )
-)
-
-game (
-	name "Super Mario 64"
-	description "Super Mario 64"
-	rom ( name "Super Irishley Drunk Giant WaLuigi 64 (Super Mario 64 Hack).z64" size 25165824 crc 70ab0041 )
-	rom ( name "Super Mario 64 (E) (M3) [!].z64" size 8388608 crc 03048de6 )
-	rom ( name "Super Mario 64 (E) (M3) [b1].z64" size 8388608 crc 613e80de )
-	rom ( name "Super Mario 64 (E) (M3) [b2].z64" size 8388608 crc fdf3c491 )
-	rom ( name "Super Mario 64 (E) (M3) [h1C].z64" size 8388608 crc 7162572a )
-	rom ( name "Super Mario 64 (E) (M3) [o1].z64" size 8388612 crc 1863fd76 )
-	rom ( name "Super Mario 64 (E) (M3) [o2].z64" size 33554432 crc 2a023f50 )
-	rom ( name "Super Mario 64 (E) (M3) [t1].z64" size 8388608 crc 5feebb05 )
-	rom ( name "Super Mario 64 (E) (M3) [t2].z64" size 8388608 crc 680ad655 )
-	rom ( name "Super Mario 64 (J) [!].z64" size 8388608 crc dd801954 )
-	rom ( name "Super Mario 64 (J) [h1C].z64" size 8388608 crc 7e0bdf78 )
-	rom ( name "Super Mario 64 (U) (Enable Hidden Scroller Hack).z64" size 8388608 crc a42b60bf )
-	rom ( name "Super Mario 64 (U) (No Cap Hack).z64" size 8388608 crc 64f3d9f2 )
-	rom ( name "Super Mario 64 (U) (Silver Mario Hack).z64" size 8388608 crc e41d2f03 )
-	rom ( name "Super Mario 64 (U) [!].z64" size 8388608 crc 3ce60709 )
-	rom ( name "Super Mario 64 (U) [b1].z64" size 8388608 crc 4501f084 )
-	rom ( name "Super Mario 64 (U) [b2].z64" size 8388608 crc 9aaee776 )
-	rom ( name "Super Mario 64 (U) [h1C].z64" size 8388608 crc d8ec20dc )
-	rom ( name "Super Mario 64 (U) [h2C].z64" size 8388608 crc 4e80ddc5 )
-	rom ( name "Super Mario 64 (U) [o1].z64" size 33554432 crc 5870c898 )
-	rom ( name "Super Mario 64 (U) [T+Ita2.0final_beta2_Rulesless].bin" size 25165824 crc 5f5401f6 )
-	rom ( name "Super Mario 64 (U) [T+Rus].z64" size 8388608 crc 474bfc87 )
-	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame].z64" size 25165824 crc cf9f8b39 )
-	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame][a1].z64" size 25165824 crc 720726bf )
-	rom ( name "Super Mario 64 (U) [T-Ita1.0final_beta1_Rulesless].z64" size 25165824 crc 9a4825fb )
-	rom ( name "Super Mario 64 (U) [t1] (Invincible).z64" size 8388608 crc 48ea9c39 )
-	rom ( name "Super Mario 64 (U) [t2] (Speed).z64" size 8388608 crc 44efdd34 )
-	rom ( name "Super Mario 64 (U) [t3].z64" size 8388608 crc 9f154b8c )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [!].z64" size 8388608 crc a1e15117 )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [b1].z64" size 8388608 crc ef29d54d )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [b2].z64" size 8126464 crc 857d972a )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [h1C].z64" size 8126464 crc b6c0eb94 )
-	rom ( name "Super Mario 64 - Shindou Edition (J) [h2C].z64" size 8388608 crc 0ebbcf0d )
-	rom ( name "Super Mario Magic Plant Adventure 64 (Super Mario 64 Hack).z64" size 25165824 crc 97934027 )
-	rom ( name "Super WaLuigi 64 (Super Mario 64 Hack).z64" size 25165824 crc 7abc992d )
-	rom ( name "Super Wario 64 (Super Mario 64 Hack).z64" size 25165824 crc 5615dbc0 )
-	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack) [T+Ita].z64" size 25165824 crc 1bbdda7e )
-	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack).z64" size 25165824 crc db6bed15 )
-)
-
-game (
-	name "Super Robot Spirits"
-	description "Super Robot Spirits"
-	rom ( name "Super Robot Spirits (J) [!].z64" size 16777216 crc 8c9216c1 )
-	rom ( name "Super Robot Spirits (J) [b1].z64" size 15204352 crc db33ce3b )
-)
-
-game (
-	name "Super Robot Taisen 64"
-	description "Super Robot Taisen 64"
-	rom ( name "Super Robot Taisen 64 (J) [!].z64" size 33554432 crc 85df2771 )
-	rom ( name "Super Robot Taisen 64 (J) [b1].z64" size 33554432 crc de81f6c3 )
-	rom ( name "Super Robot Taisen 64 (J) [b2].z64" size 33554432 crc 4482c180 )
-	rom ( name "Super Robot Taisen 64 (J) [f1] (PAL).z64" size 33554432 crc 09d5e6db )
-)
-
-game (
-	name "Super Smash Bros."
-	description "Super Smash Bros."
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [!].z64" size 16777216 crc 04c9d3b1 )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b1].z64" size 16777216 crc ef0ea76f )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b2].z64" size 16777216 crc dabe5627 )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b3].z64" size 11468800 crc 3f9a4310 )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f1].z64" size 16777216 crc 13ccb98d )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f2].z64" size 16777216 crc 433bd4a5 )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f3].z64" size 16777216 crc 03db0407 )
-	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f4] (PAL).z64" size 16777216 crc 64051ad3 )
-	rom ( name "Super Smash Bros. (A) [!].z64" size 16777216 crc e96779fa )
-	rom ( name "Super Smash Bros. (A) [f1].z64" size 16777216 crc 2b4391ad )
-	rom ( name "Super Smash Bros. (E) (M3) [!].z64" size 33554432 crc 45a91cb1 )
-	rom ( name "Super Smash Bros. (E) (M3) [b1].z64" size 33554436 crc 01fdb7f2 )
-	rom ( name "Super Smash Bros. (E) (M3) [f1].z64" size 33554432 crc fd8a4ef0 )
-	rom ( name "Super Smash Bros. (U) [!].z64" size 16777216 crc eb97929e )
-	rom ( name "Super Smash Bros. (U) [b1].z64" size 16777216 crc 4e7626b9 )
-	rom ( name "Super Smash Bros. (U) [b2].z64" size 16777216 crc 8f6d6b7e )
-	rom ( name "Super Smash Bros. (U) [f1].z64" size 16777216 crc e789a66d )
-	rom ( name "Super Smash Bros. (U) [f2] (PAL).z64" size 16777216 crc e91be8fa )
-	rom ( name "Super Smash Bros. (U) [f3].z64" size 16777216 crc 34017708 )
-	rom ( name "Super Smash Bros. (U) [f4] (GameShark).z64" size 16777216 crc 0b382b42 )
-	rom ( name "Super Smash Bros. (U) [hI].z64" size 16777216 crc 381f43fb )
-)
-
-game (
-	name "Supercross 2000"
-	description "Supercross 2000"
-	rom ( name "Supercross 2000 (E) (M3) [!].z64" size 16777216 crc cb5482ec )
-	rom ( name "Supercross 2000 (U) [!].z64" size 16777216 crc 094e2a48 )
-	rom ( name "Supercross 2000 (U) [b1].z64" size 8388608 crc be3bc325 )
-	rom ( name "Supercross 2000 (U) [f1] (PAL).z64" size 16777216 crc 103ea361 )
-)
-
-game (
-	name Superman
-	description "Superman"
-	rom ( name "Superman (E) (M6) [!].z64" size 8388608 crc bca4ff8c )
-	rom ( name "Superman (U) (M3) [!].z64" size 8388608 crc 437e3677 )
-	rom ( name "Superman (U) (M3) [b1].z64" size 8388608 crc c90865b7 )
-	rom ( name "Superman (U) (M3) [b2].z64" size 8388608 crc 96787121 )
-	rom ( name "Superman (U) (M3) [f1] (PAL).z64" size 8388608 crc 935ca58d )
-	rom ( name "Superman (U) (M3) [f2] (PAL).z64" size 8388608 crc 806b05f3 )
-	rom ( name "Superman (U) (M3) [T+Ita100_Cattivik66].z64" size 8388608 crc 3506db6f )
-	rom ( name "Superman (U) (M3) [t1].z64" size 8388608 crc a6e40855 )
-)
-
-game (
-	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou"
-	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou"
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!].z64" size 8388608 crc 4cd21372 )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1].z64" size 16777216 crc 6b805829 )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b2].z64" size 8126464 crc 9ea0ee5c )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b3].z64" size 8388608 crc 52cd30e0 )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h1C].z64" size 8388608 crc 2c02621f )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h2C].z64" size 8388608 crc 06bd781b )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o1].z64" size 16777216 crc c2a1cff5 )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2].z64" size 8388808 crc 5a7f4c1e )
-	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2][b1].z64" size 16777216 crc e30023e8 )
-)
-
-game (
-	name "Taz Express"
-	description "Taz Express"
-	rom ( name "Taz Express (E) (M6) [!].z64" size 12582912 crc 0712c306 )
-	rom ( name "Taz Express (E) (M6) [f1] (NTSC).z64" size 12582912 crc 860eade0 )
-	rom ( name "Taz Express (E) (M6) [f2] (NTSC).z64" size 12582912 crc 6df9355e )
-)
-
-game (
-	name Tetrisphere
-	description "Tetrisphere"
-	rom ( name "Tetrisphere (E) [!].z64" size 8388608 crc 7cb31b0f )
-	rom ( name "Tetrisphere (E) [b1].z64" size 8388608 crc 22628530 )
-	rom ( name "Tetrisphere (E) [b2].z64" size 8388608 crc 7b6dea75 )
-	rom ( name "Tetrisphere (U) [!].z64" size 8388608 crc 70a3a5ce )
-	rom ( name "Tetrisphere (U) [b1].z64" size 7815168 crc bae26b43 )
-	rom ( name "Tetrisphere (U) [t1].z64" size 8388608 crc 1a23e825 )
-)
-
-game (
-	name "Tigger's Honey Hunt"
-	description "Tigger's Honey Hunt"
-	rom ( name "Tigger's Honey Hunt (E) (M7) [!].z64" size 16777216 crc d82d5736 )
-	rom ( name "Tigger's Honey Hunt (U) [!].z64" size 16777216 crc 68c2ac8f )
-	rom ( name "Tigger's Honey Hunt (U) [t1].z64" size 16777216 crc e9dd1176 )
-)
-
-game (
-	name "Tom and Jerry in Fists of Furry"
-	description "Tom and Jerry in Fists of Furry"
-	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [!].z64" size 12582912 crc 9ea8a3b8 )
-	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC).z64" size 12582912 crc c0a9cc13 )
-	rom ( name "Tom and Jerry in Fists of Furry (U) [!].z64" size 12582912 crc 6d685b83 )
-	rom ( name "Tom and Jerry in Fists of Furry (U) [t1].z64" size 12582912 crc cd44fc8d )
-)
-
-game (
-	name "Tom Clancy's Rainbow Six"
-	description "Tom Clancy's Rainbow Six"
-	rom ( name "Tom Clancy's Rainbow Six (E) [!].z64" size 16777216 crc 4b71e083 )
-	rom ( name "Tom Clancy's Rainbow Six (E) [b1].z64" size 16777216 crc 4b61b50f )
-	rom ( name "Tom Clancy's Rainbow Six (E) [h1C].z64" size 16777216 crc c1417faf )
-	rom ( name "Tom Clancy's Rainbow Six (E) [o1].z64" size 16777220 crc 7edbe625 )
-	rom ( name "Tom Clancy's Rainbow Six (F) [!].z64" size 16777216 crc bbf7b6a8 )
-	rom ( name "Tom Clancy's Rainbow Six (G) [!].z64" size 16777216 crc 5d73e788 )
-	rom ( name "Tom Clancy's Rainbow Six (U) [!].z64" size 16777216 crc 53b0cc13 )
-	rom ( name "Tom Clancy's Rainbow Six (U) [f1] (PAL).z64" size 16777216 crc 09745879 )
-)
-
-game (
-	name "Tonic Trouble"
-	description "Tonic Trouble"
-	rom ( name "Tonic Trouble (E) (M5) [!].z64" size 16777216 crc b4322403 )
-	rom ( name "Tonic Trouble (U) (V1.1) [!].z64" size 16777216 crc 1c04ba12 )
-	rom ( name "Tonic Trouble (U) (V1.1) [b1].z64" size 16777216 crc f13448d0 )
-	rom ( name "Tonic Trouble (U) (V1.1) [f1] (PAL).z64" size 16777216 crc a297e4ff )
-	rom ( name "Tonic Trouble (U) (V1.1) [t1].z64" size 16777216 crc 3866227f )
-)
-
-game (
-	name "Tony Hawk's Pro Skater"
-	description "Tony Hawk's Pro Skater"
-	rom ( name "Tony Hawk's Pro Skater (E) [!].z64" size 12582912 crc 39e4f766 )
-	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [!].z64" size 12582912 crc f5c1b64f )
-	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [t1].z64" size 12582912 crc ccc5a733 )
-	rom ( name "Tony Hawk's Pro Skater (U) (V1.1) [!].z64" size 12582912 crc 6182a092 )
-)
-
-game (
-	name "Tony Hawk's Pro Skater 2"
-	description "Tony Hawk's Pro Skater 2"
-	rom ( name "Tony Hawk's Pro Skater 2 (E) [!].z64" size 16777216 crc a1207132 )
-	rom ( name "Tony Hawk's Pro Skater 2 (U) [!].z64" size 16777216 crc 80aa83f3 )
-)
-
-game (
-	name "Tony Hawk's Pro Skater 3"
-	description "Tony Hawk's Pro Skater 3"
-	rom ( name "Tony Hawk's Pro Skater 3 (U).z64" size 16777216 crc 62a8ce7d )
-)
-
-game (
-	name "Top Gear Hyper Bike"
-	description "Top Gear Hyper Bike"
-	rom ( name "Top Gear Hyper Bike (Beta).z64" size 33554432 crc 00c0278a )
-	rom ( name "Top Gear Hyper Bike (E) [!].z64" size 16777216 crc bae57ea7 )
-	rom ( name "Top Gear Hyper Bike (E) [b1].z64" size 16777216 crc 6183ea77 )
-	rom ( name "Top Gear Hyper Bike (J) [!].z64" size 16777216 crc 09b2cda1 )
-	rom ( name "Top Gear Hyper Bike (U) [!].z64" size 16777216 crc 6eebc26a )
-)
-
-game (
-	name "Top Gear Overdrive"
-	description "Top Gear Overdrive"
-	rom ( name "Top Gear Overdrive (E) [!].z64" size 12582912 crc 0cc70580 )
-	rom ( name "Top Gear Overdrive (E) [h1C].z64" size 12582912 crc 9b1d439f )
-	rom ( name "Top Gear Overdrive (J) [!].z64" size 12582912 crc 81aafc2b )
-	rom ( name "Top Gear Overdrive (J) [b1].z64" size 12582912 crc 9113d45e )
-	rom ( name "Top Gear Overdrive (U) [!].z64" size 12582912 crc f3e0ff21 )
-	rom ( name "Top Gear Overdrive (U) [o1].z64" size 16777216 crc 0bb0db0e )
-	rom ( name "Top Gear Overdrive (U) [t1].z64" size 12582912 crc 6ce5dd98 )
-)
-
-game (
-	name "Top Gear Rally"
-	description "Top Gear Rally"
-	rom ( name "Top Gear Rally (E) [!].z64" size 8388608 crc 40b3bb21 )
-	rom ( name "Top Gear Rally (E) [b1].z64" size 8388608 crc 14238e76 )
-	rom ( name "Top Gear Rally (E) [h1C].z64" size 8388608 crc 9c83fb6a )
-	rom ( name "Top Gear Rally (J) [!].z64" size 8388608 crc c6707cd6 )
-	rom ( name "Top Gear Rally (U) [!].z64" size 8388608 crc 137287f5 )
-	rom ( name "Top Gear Rally (U) [b1].z64" size 8388608 crc 36809f7d )
-	rom ( name "Top Gear Rally (U) [b2].z64" size 8388608 crc cf42c7be )
-	rom ( name "Top Gear Rally (U) [b3].z64" size 8388608 crc 7354e999 )
-	rom ( name "Top Gear Rally (U) [o1].z64" size 8388612 crc 53a95acb )
-)
-
-game (
-	name "Top Gear Rally 2"
-	description "Top Gear Rally 2"
-	rom ( name "TG Rally 2 (E) [!].z64" size 12582912 crc 135c8eb0 )
-	rom ( name "Top Gear Rally 2 (Beta).z64" size 16777216 crc 3c77c5d6 )
-	rom ( name "Top Gear Rally 2 (E) [!].z64" size 12582912 crc cb294d39 )
-	rom ( name "Top Gear Rally 2 (J) [!].z64" size 12582912 crc aa136e07 )
-	rom ( name "Top Gear Rally 2 (U) [!].z64" size 12582912 crc 914cf9c4 )
-	rom ( name "Top Gear Rally 2 (U) [f1] (PAL).z64" size 12582912 crc 9fe61044 )
-)
-
-game (
-	name "Toy Story 2"
-	description "Toy Story 2"
-	rom ( name "Toy Story 2 (E) [!].z64" size 12582912 crc 59574cb9 )
-	rom ( name "Toy Story 2 (F) [!].z64" size 12582912 crc fb4bea9a )
-	rom ( name "Toy Story 2 (G) [!].z64" size 12582912 crc c5e4c89f )
-	rom ( name "Toy Story 2 (U) [!].z64" size 12582912 crc b9570841 )
-	rom ( name "Toy Story 2 (U) [f1] (PAL).z64" size 12582912 crc ca080e9f )
-	rom ( name "Toy Story 2 (U) [t1].z64" size 12582912 crc 170c01d5 )
-)
-
-game (
-	name "Transformers - Beast Wars Transmetal"
-	description "Transformers - Beast Wars Transmetal"
-	rom ( name "Transformers - Beast Wars Metals 64 (J) [!].z64" size 12582912 crc 338f1d45 )
-	rom ( name "Transformers - Beast Wars Transmetal (U) [!].z64" size 16777216 crc 85138b5a )
-)
-
-game (
-	name "Triple Play 2000"
-	description "Triple Play 2000"
-	rom ( name "Triple Play 2000 (U) [!].z64" size 16777216 crc 785dd0f8 )
-)
-
-game (
-	name "Tsumi to Batsu - Hoshi no Keishousha"
-	description "Tsumi to Batsu - Hoshi no Keishousha"
-	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (J) [!].z64" size 33554432 crc ca2e5e49 )
-)
-
-game (
-	name "Turok - Dinosaur Hunter"
-	description "Turok - Dinosaur Hunter"
-	rom ( name "Tokisora Senshi Turok (J) [!].z64" size 8388608 crc e6bd65d5 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [!].z64" size 8388608 crc e8525687 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [b1].z64" size 8388608 crc d7236669 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [h1C].z64" size 8388608 crc 1c5432a2 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.1) [!].z64" size 8388608 crc c2353283 )
-	rom ( name "Turok - Dinosaur Hunter (E) (V1.2) [!].z64" size 8388608 crc 312af877 )
-	rom ( name "Turok - Dinosaur Hunter (G) [!].z64" size 8388608 crc 64631ff9 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [!].z64" size 8388608 crc 26c4f597 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [b1].z64" size 8388608 crc fa434f4b )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [h1C].z64" size 8388608 crc d2c291b2 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [o1].z64" size 8388612 crc 71df1460 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t1].z64" size 8388608 crc 09d4b965 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t2].z64" size 8388608 crc ceec672d )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.1) [!].z64" size 8388608 crc 7f2476f4 )
-	rom ( name "Turok - Dinosaur Hunter (U) (V1.2) [!].z64" size 8388608 crc 8c3bbc00 )
-)
-
-game (
-	name "Turok - Rage Wars"
-	description "Turok - Rage Wars"
-	rom ( name "Turok - Legenden des Verlorenen Landes (G) [!].z64" size 8388608 crc b937874f )
-	rom ( name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita).z64" size 8388608 crc f4a2862b )
-	rom ( name "Turok - Rage Wars (E) [!].z64" size 8388608 crc 82b1e116 )
-	rom ( name "Turok - Rage Wars (U) [!].z64" size 8388608 crc 422872a2 )
-	rom ( name "Turok - Rage Wars (U) [f1] (PAL).z64" size 8388608 crc 43cc10f3 )
-	rom ( name "Turok - Rage Wars (U) [f2] (PAL).z64" size 8388608 crc 5b21d17d )
-)
-
-game (
-	name "Turok 2 - Seeds of Evil"
-	description "Turok 2 - Seeds of Evil"
-	rom ( name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!].z64" size 12582912 crc 4e29b234 )
-	rom ( name "Turok 2 - Seeds of Evil (E) (M4) [!].z64" size 33554432 crc 1febde32 )
-	rom ( name "Turok 2 - Seeds of Evil (E) [!].z64" size 33554432 crc e2d34bfe )
-	rom ( name "Turok 2 - Seeds of Evil (E) [b1].z64" size 33554432 crc bdab5526 )
-	rom ( name "Turok 2 - Seeds of Evil (G) [!].z64" size 33554432 crc c07877b6 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack).z64" size 12582912 crc 4b1c2a9d )
-	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!].z64" size 12582912 crc 8d5b9bd0 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [h1C].z64" size 12582912 crc 2e733502 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [!].z64" size 33554432 crc ff5e7636 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t1].z64" size 33554432 crc 020945c6 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t2].z64" size 33554432 crc 006395ab )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t3].z64" size 33554432 crc e563d747 )
-	rom ( name "Turok 2 - Seeds of Evil (U) (V1.1).z64" size 33554432 crc 57f1fbf5 )
-	rom ( name "Violence Killer - Turok New Generation (J) [!].z64" size 33554432 crc 097f139f )
-	rom ( name "Violence Killer - Turok New Generation (J) [b1].z64" size 33554432 crc 0a474ddb )
-)
-
-game (
-	name "Turok 3 - Shadow of Oblivion"
-	description "Turok 3 - Shadow of Oblivion"
-	rom ( name "Turok 3 - Shadow of Oblivion (E) [!].z64" size 33554432 crc 98d3114c )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta) [h1C].z64" size 33554432 crc 7946b05a )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta).z64" size 33554432 crc 97b7c3ff )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta-WIP).z64" size 33554432 crc 3cd1f9af )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) [!].z64" size 33554432 crc cb297224 )
-	rom ( name "Turok 3 - Shadow of Oblivion (U) [t1].z64" size 33554432 crc 411d8468 )
-)
-
-game (
-	name "Twisted Edge Extreme Snowboarding"
-	description "Twisted Edge Extreme Snowboarding"
-	rom ( name "King Hill 64 - Extreme Snowboarding (J) [!].z64" size 12582912 crc f120cc52 )
-	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b1].z64" size 9392128 crc 2e846375 )
-	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b2].z64" size 12582912 crc e31698a4 )
-	rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc bf0c1291 )
-	rom ( name "Twisted Edge Extreme Snowboarding (E) [b1].z64" size 12582912 crc 1f26259e )
-	rom ( name "Twisted Edge Extreme Snowboarding (E) [h1C].z64" size 12582912 crc 4f64cd21 )
-	rom ( name "Twisted Edge Extreme Snowboarding (U) [!].z64" size 12582912 crc bfbcc038 )
-)
-
-game (
-	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou"
-	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou"
-	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!].z64" size 8388608 crc 50cbe8a6 )
-	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h1C].z64" size 8388608 crc b6f8adc2 )
-	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h2C].z64" size 8388608 crc 31f32b8d )
-	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [o1].z64" size 12582912 crc 5d92c2df )
-)
-
-game (
-	name "V-Rally Edition 99"
-	description "V-Rally Edition 99"
-	rom ( name "V-Rally Edition 99 (E) (M3) [!].z64" size 12582912 crc 0735d7a2 )
-	rom ( name "V-Rally Edition 99 (E) (M3) [f1] (NTSC).z64" size 12582912 crc 02a8267b )
-	rom ( name "V-Rally Edition 99 (J) [!].z64" size 8388608 crc 02475a01 )
-	rom ( name "V-Rally Edition 99 (U) [!].z64" size 8388608 crc 4803075e )
-	rom ( name "V-Rally Edition 99 (U) [f1] (PAL).z64" size 8388608 crc 2c399b1c )
-)
-
-game (
-	name "Vigilante 8"
-	description "Vigilante 8"
-	rom ( name "Vigilante 8 (E) [!].z64" size 8388608 crc 0e9bb6d6 )
-	rom ( name "Vigilante 8 (E) [h1C].z64" size 8388608 crc 888d935e )
-	rom ( name "Vigilante 8 (F) [!].z64" size 8388608 crc 11d23ab3 )
-	rom ( name "Vigilante 8 (F) [b1].z64" size 8388608 crc d36573e5 )
-	rom ( name "Vigilante 8 (G) [!].z64" size 8388608 crc 17f63c3f )
-	rom ( name "Vigilante 8 (U) [!].z64" size 8388608 crc 330b73e6 )
-	rom ( name "Vigilante 8 (U) [b1].z64" size 8388608 crc 56695c4b )
-	rom ( name "Vigilante 8 (U) [b2].z64" size 8388608 crc 47854808 )
-	rom ( name "Vigilante 8 (U) [f1] (PAL).z64" size 8388608 crc f5da5754 )
-	rom ( name "Vigilante 8 (U) [f2] (PAL).z64" size 8388608 crc 654352b9 )
-	rom ( name "Vigilante 8 (U) [t1].z64" size 8388608 crc 5d56e5ae )
-)
-
-game (
-	name "Vigilante 8 - 2nd Offense"
-	description "Vigilante 8 - 2nd Offense"
-	rom ( name "Vigilante 8 - 2nd Offence (E) [!].z64" size 12582912 crc 691aa971 )
-	rom ( name "Vigilante 8 - 2nd Offense (U) [!].z64" size 12582912 crc 0293203f )
-	rom ( name "Vigilante 8 - 2nd Offense (U) [f1] (PAL).z64" size 12582912 crc a06f594e )
-)
-
-game (
-	name "Virtual Chess 64"
-	description "Virtual Chess 64"
-	rom ( name "Virtual Chess 64 (E) (M6) [!].z64" size 4194304 crc aae15243 )
-	rom ( name "Virtual Chess 64 (E) (M6) [b1].z64" size 8388608 crc fc843db9 )
-	rom ( name "Virtual Chess 64 (E) (M6) [b2].z64" size 4194304 crc 9d037b23 )
-	rom ( name "Virtual Chess 64 (E) (M6) [o1].z64" size 8388608 crc 79167dce )
-	rom ( name "Virtual Chess 64 (E) (M6) [o1][h1C].z64" size 8388608 crc ab0ef811 )
-	rom ( name "Virtual Chess 64 (U) (M3) [!].z64" size 4194304 crc 620de0b7 )
-	rom ( name "Virtual Chess 64 (U) (M3) [b1].z64" size 4194304 crc 722c9feb )
-	rom ( name "Virtual Chess 64 (U) (M3) [b1][o1].z64" size 8388608 crc 93774cab )
-	rom ( name "Virtual Chess 64 (U) (M3) [f1] (PAL).z64" size 4194304 crc 63a9e373 )
-	rom ( name "Virtual Chess 64 (U) (M3) [f1][o1].z64" size 8388608 crc 7fa359f4 )
-	rom ( name "Virtual Chess 64 (U) [o1].z64" size 8388608 crc ac2d5385 )
-)
-
-game (
-	name "Virtual Pool 64"
-	description "Virtual Pool 64"
-	rom ( name "Virtual Pool 64 (E) [!].z64" size 4194304 crc 9a6fb0bc )
-	rom ( name "Virtual Pool 64 (E) [o1].z64" size 8388608 crc fad2f55f )
-	rom ( name "Virtual Pool 64 (U) [!].z64" size 4194304 crc ad628ded )
-	rom ( name "Virtual Pool 64 (U) [o1].z64" size 8388608 crc 43b5083a )
-)
-
-game (
-	name "Virtual Pro Wrestling 64"
-	description "Virtual Pro Wrestling 64"
-	rom ( name "Virtual Pro Wrestling 64 (J) [!].z64" size 16777216 crc e6651803 )
-	rom ( name "Virtual Pro Wrestling 64 (J) [b1].z64" size 16777216 crc 26366a4a )
-	rom ( name "Virtual Pro Wrestling 64 (J) [f1].z64" size 16777216 crc 9328a297 )
-	rom ( name "Virtual Pro Wrestling 64 (J) [f2].z64" size 16777216 crc f0958025 )
-	rom ( name "Virtual Pro Wrestling 64 (J) [h1C].z64" size 16777216 crc 0093ff39 )
-)
-
-game (
-	name "Waialae Country Club - True Golf Classics"
-	description "Waialae Country Club - True Golf Classics"
-	rom ( name "Harukanaru Augusta Masters 98 (J) [!].z64" size 16777216 crc 51228f0c )
-	rom ( name "Harukanaru Augusta Masters 98 (J) [b1].z64" size 16777216 crc 6d82e5a2 )
-	rom ( name "Harukanaru Augusta Masters 98 (J) [b2].z64" size 16777216 crc 720f6d47 )
-	rom ( name "Harukanaru Augusta Masters 98 (J) [h1C].z64" size 16777216 crc 5cb9b985 )
-	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!].z64" size 16777216 crc 6858759a )
-	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1].z64" size 16777216 crc a46a7b14 )
-	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!].z64" size 16777216 crc 6cb097b3 )
-	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.0) [!].z64" size 16777216 crc ccab08d7 )
-	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.1) [!].z64" size 16777216 crc c65ee122 )
-)
-
-game (
-	name "War Gods"
-	description "War Gods"
-	rom ( name "War Gods (E) [!].z64" size 12582912 crc c73010c8 )
-	rom ( name "War Gods (U) (Power Bar Hack).z64" size 12582912 crc dc773bba )
-	rom ( name "War Gods (U) [!].z64" size 12582912 crc ffacf993 )
-	rom ( name "War Gods (U) [o1].z64" size 16777216 crc 5cfc294c )
-	rom ( name "War Gods (U) [o1][h1C].z64" size 16777216 crc f4daba35 )
-	rom ( name "War Gods (U) [o2].z64" size 16777216 crc 689b570b )
-	rom ( name "War Gods (U) [o3].z64" size 16777216 crc cc10d8a9 )
-	rom ( name "War Gods (U) [t1] (God Mode).z64" size 12582912 crc 93d4c6fd )
-)
-
-game (
-	name "Wave Race 64"
-	description "Wave Race 64"
-	rom ( name "Wave Race 64 (E) (M2) [!].z64" size 8388608 crc fb289893 )
-	rom ( name "Wave Race 64 (E) (M2) [h1C].z64" size 8388608 crc 1e78fa64 )
-	rom ( name "Wave Race 64 (E) (M2) [o1].z64" size 33554432 crc d559933c )
-	rom ( name "Wave Race 64 (J) [!].z64" size 8388608 crc 6c93ff83 )
-	rom ( name "Wave Race 64 (U) (V1.0) [!].z64" size 8388608 crc 74a7b725 )
-	rom ( name "Wave Race 64 (U) (V1.0) [t1].z64" size 8388608 crc 60717f86 )
-	rom ( name "Wave Race 64 (U) (V1.1) [!].z64" size 8388608 crc 394948c4 )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [!].z64" size 8388608 crc 90044c4b )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b1].z64" size 8388608 crc 33b45441 )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b2].z64" size 8388608 crc 66dd6ac7 )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [h1C].z64" size 8388608 crc 5dcfba0b )
-	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [o1].z64" size 12582912 crc afa7c48b )
-)
-
-game (
-	name "Wayne Gretzky's 3D Hockey"
-	description "Wayne Gretzky's 3D Hockey"
-	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [!].z64" size 8388608 crc 442a4f5f )
-	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [b1].z64" size 8388608 crc 13343f88 )
-	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [h1C].z64" size 8388608 crc 50d4462a )
-	rom ( name "Wayne Gretzky's 3D Hockey (J) [!].z64" size 8388608 crc 485275ed )
-	rom ( name "Wayne Gretzky's 3D Hockey (J) [b1].z64" size 8388608 crc 8535f510 )
-	rom ( name "Wayne Gretzky's 3D Hockey (J) [o1].z64" size 16777216 crc 562f5060 )
-	rom ( name "Wayne Gretzky's 3D Hockey (J) [o2].z64" size 16777216 crc 039d4651 )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!].z64" size 8388608 crc 9781f88d )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [b1].z64" size 8388608 crc 4df6caf7 )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [o1].z64" size 8126464 crc b8bd42e5 )
-	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!].z64" size 8388608 crc c2678971 )
-)
-
-game (
-	name "Wayne Gretzky's 3D Hockey '98"
-	description "Wayne Gretzky's 3D Hockey '98"
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!].z64" size 8388608 crc 6f6dc53d )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [!].z64" size 8388608 crc 355fb089 )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h1C].z64" size 8388608 crc a80c229a )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h2C].z64" size 8388608 crc 0c729578 )
-	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66].z64" size 8388608 crc 5c920e10 )
-)
-
-game (
-	name "WCW Backstage Assault"
-	description "WCW Backstage Assault"
-	rom ( name "WCW Backstage Assault (U) [!].z64" size 33554432 crc 5dcc2e4e )
-)
-
-game (
-	name "WCW Mayhem"
-	description "WCW Mayhem"
-	rom ( name "WCW Mayhem (E) [!].z64" size 16777216 crc 864e066e )
-	rom ( name "WCW Mayhem (E) [h1C].z64" size 16777216 crc b3aff8d7 )
-	rom ( name "WCW Mayhem (U) [!].z64" size 16777216 crc f1f9b6eb )
-	rom ( name "WCW Mayhem (U) [f1] (PAL).z64" size 16777216 crc 0ec50495 )
-)
-
-game (
-	name "WCW Nitro"
-	description "WCW Nitro"
-	rom ( name "WCW Nitro (U) [!].z64" size 12582912 crc 455b0830 )
-	rom ( name "WCW Nitro (U) [b1].z64" size 12582912 crc 22d8def9 )
-	rom ( name "WCW Nitro (U) [b2].z64" size 12582912 crc bd721abc )
-	rom ( name "WCW Nitro (U) [b3].z64" size 12582912 crc a4bb0a17 )
-	rom ( name "WCW Nitro (U) [f1] (PAL).z64" size 12582912 crc 6988159f )
-	rom ( name "WCW Nitro (U) [f2] (PAL).z64" size 12582912 crc 120f8c2a )
-)
-
-game (
-	name "WCW vs. nWo - World Tour"
-	description "WCW vs. nWo - World Tour"
-	rom ( name "WCW vs. nWo - World Tour (E) [!].z64" size 12582912 crc 37f358eb )
-	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [!].z64" size 12582912 crc dfbfc61f )
-	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [b1].z64" size 11534336 crc f224aee7 )
-	rom ( name "WCW vs. nWo - World Tour (U) (V1.1) [!].z64" size 12582912 crc a74da07a )
-)
-
-game (
-	name "WCW-nWo Revenge"
-	description "WCW-nWo Revenge"
-	rom ( name "WCW-nWo Revenge (E) [!].z64" size 16777216 crc 8af0f964 )
-	rom ( name "WCW-nWo Revenge (E) [h1C].z64" size 16777216 crc 771fd04e )
-	rom ( name "WCW-nWo Revenge (U) [!].z64" size 16777216 crc 54cbaaa8 )
-	rom ( name "WCW-nWo Revenge (U) [b1].z64" size 16777216 crc 31eb978f )
-	rom ( name "WCW-nWo Revenge (U) [b2].z64" size 16777216 crc 9d1b3557 )
-	rom ( name "WCW-nWo Revenge (U) [f1] (PAL).z64" size 16777216 crc 7ea064d5 )
-	rom ( name "WCW-nWo Revenge (U) [f2] (PAL).z64" size 16777216 crc b770fb2a )
-)
-
-game (
-	name Wetrix
-	description "Wetrix"
-	rom ( name "Wetrix (E) (M6) [!].z64" size 8388608 crc eddc5b06 )
-	rom ( name "Wetrix (E) (M6) [f1] (NTSC).z64" size 8388608 crc 46f031a8 )
-	rom ( name "Wetrix (E) (M6) [t1].z64" size 8388608 crc c4924be2 )
-	rom ( name "Wetrix (J) [!].z64" size 4194304 crc bad08218 )
-	rom ( name "Wetrix (J) [o1].z64" size 8388608 crc 8db9c41b )
-	rom ( name "Wetrix (U) (M6) [!].z64" size 8388608 crc 50cd1f71 )
-)
-
-game (
-	name "Wheel of Fortune"
-	description "Wheel of Fortune"
-	rom ( name "Wheel of Fortune (U) [!].z64" size 4194304 crc 8d3efa8d )
-	rom ( name "Wheel of Fortune (U) [b1].z64" size 4194304 crc d6c7bdba )
-	rom ( name "Wheel of Fortune (U) [o1].z64" size 8388608 crc 58878daf )
-	rom ( name "Wheel of Fortune (U) [o1][b1].z64" size 8388608 crc 037eca98 )
-)
-
-game (
-	name "WideBoy BIOS"
-	description "WideBoy BIOS"
-	rom ( name "WideBoy BIOS V980910.bin" size 1048576 crc 3fe8291e )
-	rom ( name "WideBoy BIOS V980914.bin" size 1048576 crc c9ff4c4b )
-)
-
-game (
-	name "WinBack - Covert Operations"
-	description "WinBack - Covert Operations"
-	rom ( name "Operation WinBack (E) (M5) [!].z64" size 16777216 crc fb96f166 )
-	rom ( name "WinBack (J) [!].z64" size 16777216 crc d35360b0 )
-	rom ( name "WinBack (J) [b1].z64" size 16777216 crc 18256c96 )
-	rom ( name "WinBack - Covert Operations (U) [!].z64" size 16777216 crc 64c817c5 )
-	rom ( name "WinBack - Covert Operations (U) [b1].z64" size 16777216 crc 5c319f14 )
-	rom ( name "WinBack - Covert Operations (U) [f1] (PAL).z64" size 16777216 crc e13ede7d )
-	rom ( name "WinBack - Covert Operations (U) [t1].z64" size 16777216 crc edc5f66e )
-)
-
-game (
-	name "Wipeout 64"
-	description "Wipeout 64"
-	rom ( name "Wipeout 64 (E) [!].z64" size 8388608 crc 38111048 )
-	rom ( name "Wipeout 64 (U) [!].z64" size 8388608 crc 4888d0fe )
-	rom ( name "Wipeout 64 (U) [o1].z64" size 16777216 crc ff733418 )
-	rom ( name "Wipeout 64 (U) [t1].z64" size 8388608 crc 6fbc4937 )
-	rom ( name "Wipeout 64 (U) [t2].z64" size 8388608 crc 3367383c )
-)
-
-game (
-	name "Wonder Project J2 - Koruro no Mori no Jozet"
-	description "Wonder Project J2 - Koruro no Mori no Jozet"
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!].z64" size 8388608 crc 5e8fc436 )
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [b1].z64" size 8388608 crc c3516904 )
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [h1C].z64" size 8388608 crc a4c86774 )
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T+Eng0.1_Ryu].z64" size 8912896 crc c6458d2b )
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T-Eng0.05].v64" size 8912896 crc 2163807b )
-)
-
-game (
-	name "World Cup 98"
-	description "World Cup 98"
-	rom ( name "World Cup 98 (E) (M8) [!].z64" size 12582912 crc 79f483f7 )
-	rom ( name "World Cup 98 (E) (M8) [f1] (NTSC).z64" size 12582912 crc 58e87217 )
-	rom ( name "World Cup 98 (U) (M8) [!].z64" size 12582912 crc 13930c26 )
-)
-
-game (
-	name "World Driver Championship"
-	description "World Driver Championship"
-	rom ( name "World Driver Championship (E) (M5) [!].z64" size 16777216 crc 76151df6 )
-	rom ( name "World Driver Championship (E) (M5) [h1C].z64" size 16777216 crc 30c31843 )
-	rom ( name "World Driver Championship (U) [!].z64" size 16777216 crc 5e4acbfa )
-	rom ( name "World Driver Championship (U) [b1].z64" size 16777216 crc 8811af43 )
-	rom ( name "World Driver Championship (U) [f1] (PAL).z64" size 16777216 crc 02d1f824 )
-	rom ( name "World Driver Championship (U) [f2] (PAL).z64" size 16777216 crc df25ebe8 )
-	rom ( name "World Driver Championship (U) [t1].z64" size 16777216 crc 813fcbed )
-)
-
-game (
-	name "Worms - Armageddon"
-	description "Worms - Armageddon"
-	rom ( name "Worms - Armageddon (E) (M6) [!].z64" size 12582912 crc 6bfff27b )
-	rom ( name "Worms - Armageddon (E) (M6) [f1] (NTSC).z64" size 12582912 crc 9cdfee58 )
-	rom ( name "Worms - Armageddon (U) (M3) [!].z64" size 12582912 crc 5471ae3b )
-)
-
-game (
-	name "WWF - War Zone"
-	description "WWF - War Zone"
-	rom ( name "WWF - War Zone (E) [!].z64" size 12582912 crc 90a0b609 )
-	rom ( name "WWF - War Zone (U) [!].z64" size 12582912 crc 2fbb5507 )
-)
-
-game (
-	name "WWF Attitude"
-	description "WWF Attitude"
-	rom ( name "WWF Attitude (E) [!].z64" size 33554432 crc 804fe494 )
-	rom ( name "WWF Attitude (G) [!].z64" size 33554432 crc ea5d8359 )
-	rom ( name "WWF Attitude (G) [b1].z64" size 33465250 crc 45c4c497 )
-	rom ( name "WWF Attitude (U) [!].z64" size 33554432 crc 7a4b3686 )
-	rom ( name "WWF Attitude (U) [b1].z64" size 5736981 crc 80634009 )
-	rom ( name "WWF Attitude (U) [b2].z64" size 33554432 crc 8e21a880 )
-	rom ( name "WWF Attitude (U) [f1] (PAL).z64" size 33554432 crc babb135a )
-)
-
-game (
-	name "WWF No Mercy"
-	description "WWF No Mercy"
-	rom ( name "WWF No Mercy (E) (V1.0) [!].z64" size 33554432 crc b79bddd8 )
-	rom ( name "WWF No Mercy (E) (V1.0) [b1].z64" size 12279808 crc d6f1c981 )
-	rom ( name "WWF No Mercy (E) (V1.1) [!].z64" size 33554432 crc 43ba9e7e )
-	rom ( name "WWF No Mercy (U) (V1.0) [!].z64" size 33554432 crc b33f44f0 )
-	rom ( name "WWF No Mercy (U) (V1.0) [t1].z64" size 33554432 crc fee04a00 )
-	rom ( name "WWF No Mercy (U) (V1.1) [!].z64" size 33554432 crc baceea13 )
-)
-
-game (
-	name "WWF WrestleMania 2000"
-	description "WWF WrestleMania 2000"
-	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!].z64" size 33554432 crc f620835d )
-	rom ( name "WWF WrestleMania 2000 (E) [!].z64" size 33554432 crc 09d710c7 )
-	rom ( name "WWF WrestleMania 2000 (E) [h1C].z64" size 33554432 crc 596c6ed1 )
-	rom ( name "WWF WrestleMania 2000 (J) [!].z64" size 33554432 crc c2034d24 )
-	rom ( name "WWF WrestleMania 2000 (J) [b1].z64" size 29360128 crc 9afb5300 )
-	rom ( name "WWF WrestleMania 2000 (U) [!].z64" size 33554432 crc 0b50b4c6 )
-	rom ( name "WWF WrestleMania 2000 (U) [b1].z64" size 29360128 crc 963f19a3 )
-	rom ( name "WWF WrestleMania 2000 (U) [t1] (Never Drop Weapons).bin" size 33554432 crc 59d05c03 )
-)
-
-game (
-	name "Xena Warrior Princess - The Talisman of Fate"
-	description "Xena Warrior Princess - The Talisman of Fate"
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (E) [!].z64" size 12582912 crc d3932f88 )
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [!].z64" size 12582912 crc 7da93999 )
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL).z64" size 12582912 crc 476a756d )
-	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [t1].z64" size 12582912 crc d2532f61 )
-)
-
-game (
-	name "Xplorer64 BIOS"
-	description "Xplorer64 BIOS"
-	rom ( name "Xplorer64 BIOS V1.067 (G).bin" size 262144 crc 656acdf5 )
-)
-
-game (
-	name "Yakouchuu II - Satsujin Kouru"
-	description "Yakouchuu II - Satsujin Kouru"
-	rom ( name "Yakouchuu II - Satsujin Kouru (J) [!].z64" size 33554432 crc 4538c41a )
-)
-
-game (
-	name "Yoshi's Story"
-	description "Yoshi's Story"
-	rom ( name "Yoshi Story (J) [!].z64" size 16777216 crc 4f44a9ef )
-	rom ( name "Yoshi Story (J) [b1].z64" size 15728640 crc 6e01a7ae )
-	rom ( name "Yoshi Story (J) [f1].z64" size 16777216 crc 8a89904c )
-	rom ( name "Yoshi Story (J) [f2].z64" size 16777216 crc 8d18a944 )
-	rom ( name "Yoshi Story (J) [f3].z64" size 16777216 crc 967949f0 )
-	rom ( name "Yoshi Story (J) [f4].z64" size 16777216 crc 0afe15ca )
-	rom ( name "Yoshi Story (J) [t1].z64" size 16777216 crc 7dd9a4ed )
-	rom ( name "Yoshi Story (J) [t2] (Health and Eggs).z64" size 16777216 crc 308915c3 )
-	rom ( name "Yoshi's Story (E) (M3) [!].z64" size 16777216 crc f9ffc760 )
-	rom ( name "Yoshi's Story (E) (M3) [b1].z64" size 16777216 crc 9e6c336a )
-	rom ( name "Yoshi's Story (E) (M3) [b2].z64" size 16777216 crc cda63103 )
-	rom ( name "Yoshi's Story (E) (M3) [b2][f1].z64" size 16777216 crc e5faa601 )
-	rom ( name "Yoshi's Story (E) (M3) [b3].z64" size 13434880 crc 476f7cf5 )
-	rom ( name "Yoshi's Story (E) (M3) [t1] (Health and Eggs).z64" size 16777216 crc ba05b7cf )
-	rom ( name "Yoshi's Story (U) (M2) [!].z64" size 16777216 crc a1453e0d )
-	rom ( name "Yoshi's Story (U) (M2) [b1].z64" size 16777216 crc d1a35062 )
-	rom ( name "Yoshi's Story (U) (M2) [b2].z64" size 16777216 crc 724baa87 )
-	rom ( name "Yoshi's Story (U) (M2) [b3].z64" size 16777216 crc cc2adc22 )
-	rom ( name "Yoshi's Story (U) (M2) [b4].z64" size 16777216 crc 47d2b1f2 )
-	rom ( name "Yoshi's Story (U) (M2) [b5].z64" size 16777216 crc 2230a687 )
-	rom ( name "Yoshi's Story (U) (M2) [f1].z64" size 16777216 crc 65dad012 )
-	rom ( name "Yoshi's Story (U) (M2) [t1].z64" size 16777216 crc 40d0e350 )
-	rom ( name "Yoshi's Story (U) (M2) [t2] (Health and Eggs).z64" size 16777216 crc fafd0923 )
-)
-
-game (
-	name "Z64 BIOS"
-	description "Z64 BIOS"
-	rom ( name "Z64 BIOS V1.05.bin" size 524288 crc d31f5d1d )
-	rom ( name "Z64 BIOS V1.07.bin" size 524288 crc c41dcffc )
-	rom ( name "Z64 BIOS V1.08 (Ravemax Hack V1.00b).bin" size 524288 crc cf0138ee )
-	rom ( name "Z64 BIOS V1.08.bin" size 524288 crc fa1fecc4 )
-	rom ( name "Z64 BIOS V1.09.bin" size 524288 crc ea68d5ed )
-	rom ( name "Z64 BIOS V1.10b.bin" size 524288 crc 5912af9d )
-	rom ( name "Z64 BIOS V1.11.bin" size 524288 crc a7ba30fc )
-	rom ( name "Z64 BIOS V1.12.bin" size 524288 crc b5bbbcbe )
-	rom ( name "Z64 BIOS V2.00 (Barebones).bin" size 65536 crc b00306a3 )
-	rom ( name "Z64 BIOS V2.00.bin" size 524288 crc 21ba9967 )
-	rom ( name "Z64 BIOS V2.00b (Ravemax Hack).bin" size 524288 crc 5b9be146 )
-	rom ( name "Z64 BIOS V2.10NTSC.bin" size 524288 crc 7a94038d )
-	rom ( name "Z64 BIOS V2.10PAL.bin" size 524288 crc b9d3de21 )
-	rom ( name "Z64 BIOS V2.11NTSC.bin" size 524288 crc 19d51222 )
-	rom ( name "Z64 BIOS V2.11PAL.bin" size 524288 crc 719cb3d4 )
-	rom ( name "Z64 BIOS V2.12b (Nintendo Backup Crew Hack).bin" size 524288 crc 9a7968dd )
-	rom ( name "Z64 BIOS V2.12b3.bin" size 524288 crc 99adb980 )
-	rom ( name "Z64 BIOS V2.12b4.bin" size 524288 crc 1d0a771a )
-	rom ( name "Z64 BIOS V2.12NTSC.bin" size 524288 crc ce7d86e7 )
-	rom ( name "Z64 BIOS V2.12PAL.bin" size 524288 crc d5dd6e66 )
-	rom ( name "Z64 BIOS V2.13.bin" size 524288 crc d95e339b )
-	rom ( name "Z64 BIOS V2.15.bin" size 524288 crc fe278859 )
-	rom ( name "Z64 BIOS V2.16.bin" size 524288 crc 46bd8af5 )
-	rom ( name "Z64 BIOS V2.16b.bin" size 524288 crc 3265ae3d )
-	rom ( name "Z64 BIOS V2.17 [h1].bin" size 524288 crc 926cd3bd )
-	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 2.18zd Hack).bin" size 524288 crc 31f08661 )
-	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 Hack).bin" size 524288 crc c8fb4890 )
-	rom ( name "Z64 BIOS V2.17.bin" size 524288 crc 7a73dbaa )
-	rom ( name "Z64 BIOS V2.18.bin" size 524288 crc abb513c4 )
-	rom ( name "Z64 BIOS V2.20cf.rom" size 524288 crc 5a4db022 )
-)
-
-game (
-	name "Zool - Majou Tsukai Densetsu"
-	description "Zool - Majou Tsukai Densetsu"
-	rom ( name "Zool - Majou Tsukai Densetsu (J) [!].z64" size 12582912 crc 756ba26d )
-	rom ( name "Zool - Majou Tsukai Densetsu (J) [f1] (PAL).z64" size 12582912 crc 7a6f93b2 )
+	name "Zool - Majou Tsukai Densetsu (J) [!]"
+	description "Zool - Majou Tsukai Densetsu (J) [!]"
+	rom ( name "Zool - Majou Tsukai Densetsu (J) [!].z64" crc 756BA26D )
 )
 
+game (
+	name "Zool - Majou Tsukai Densetsu (J) [f1] (PAL)"
+	description "Zool - Majou Tsukai Densetsu (J) [f1] (PAL)"
+	rom ( name "Zool - Majou Tsukai Densetsu (J) [f1] (PAL).z64" crc 7A6F93B2 )
+)

--- a/metadat/goodtools/Nintendo - Nintendo 64.dat
+++ b/metadat/goodtools/Nintendo - Nintendo 64.dat
@@ -1,0 +1,5078 @@
+clrmamepro (
+	name "Nintendo - Nintendo 64"
+	description "GoodN64 DAT"
+	version "3.14"
+	date "2007-11-24"
+	author "GoodTools"
+	homepage "https://en.wikipedia.org/wiki/GoodTools"
+)
+
+game (
+	name "007 - The World is Not Enough"
+	description "007 - The World is Not Enough"
+	rom ( name "007 - The World is Not Enough (E) (M3) [!].z64" size 33554432 crc 002c3b2a )
+	rom ( name "007 - The World is Not Enough (U) [!].z64" size 33554432 crc 26360987 )
+	rom ( name "007 - The World is Not Enough (U) [t1].z64" size 33554432 crc c3b67335 )
+	rom ( name "007 - The World is Not Enough (U) [t1][f1] (PAL-NTSC).z64" size 33554432 crc 98fdd6a2 )
+)
+
+game (
+	name "1080 Snowboarding"
+	description "1080 Snowboarding"
+	rom ( name "1080 Snowboarding (E) (M4) [!].z64" size 16777216 crc 75a21679 )
+	rom ( name "1080 Snowboarding (E) (M4) [b1].z64" size 16777216 crc 9204cc62 )
+	rom ( name "1080 Snowboarding (E) (M4) [b1][f2] (NTSC).z64" size 16777216 crc 933a9d1b )
+	rom ( name "1080 Snowboarding (E) (M4) [f1].z64" size 16777216 crc f6a6e391 )
+	rom ( name "1080 Snowboarding (E) (M4) [f2] (NTSC).z64" size 16777216 crc 7e360eb6 )
+	rom ( name "1080 Snowboarding (JU) (M2) [!].z64" size 16777216 crc 08fe81c7 )
+	rom ( name "1080 Snowboarding (JU) (M2) [b1].z64" size 16777216 crc 1a5cdba6 )
+	rom ( name "1080 Snowboarding (JU) (M2) [b2].z64" size 16777216 crc a1dff82c )
+	rom ( name "1080 Snowboarding (JU) (M2) [b3].z64" size 16777216 crc e9fdcb54 )
+	rom ( name "1080 Snowboarding (JU) (M2) [b4].z64" size 16777216 crc 5ffac155 )
+	rom ( name "1080 Snowboarding (JU) (M2) [b5].z64" size 16777216 crc c3eba74a )
+	rom ( name "1080 Snowboarding (JU) (M2) [b6].z64" size 16777216 crc c71f2e9e )
+	rom ( name "1080 Snowboarding (JU) (M2) [b7].z64" size 16777216 crc 8c39ceab )
+	rom ( name "1080 Snowboarding (JU) (M2) [b8].z64" size 16777216 crc a59a9ca3 )
+	rom ( name "1080 Snowboarding (JU) (M2) [b9].z64" size 16777216 crc 06615926 )
+	rom ( name "1080 Snowboarding (JU) (M2) [ba].z64" size 16777216 crc 2efff977 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f1] (DS-1).z64" size 16777216 crc 3ed1c741 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f2] (PAL).z64" size 16777216 crc b1fc6b9d )
+	rom ( name "1080 Snowboarding (JU) (M2) [f2][b1].z64" size 16777216 crc 2d25e8d8 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f3][t1].z64" size 16777216 crc 33e0ab89 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f3][t2] (All Levels).z64" size 16777216 crc 8009aa55 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f4] (PAL-Z64).z64" size 16777216 crc e3969a61 )
+	rom ( name "1080 Snowboarding (JU) (M2) [f5] (SRAM).z64" size 16777216 crc c980f67f )
+	rom ( name "1080 Snowboarding (JU) (M2) [h1C].z64" size 16777216 crc 15bfdee8 )
+	rom ( name "1080 Snowboarding (JU) (M2) [h2C].z64" size 16777216 crc 407adfd5 )
+)
+
+game (
+	name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World"
+	description "64 de Hakken!! Tamagotchi Minna de Tamagotchi World"
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [!].z64" size 12582912 crc 67a789e5 )
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [b1].z64" size 12582912 crc 281185fb )
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h1C].z64" size 16777216 crc 97389efc )
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [h2C].z64" size 12582912 crc b6fa1328 )
+	rom ( name "64 de Hakken!! Tamagotchi Minna de Tamagotchi World (J) [o1].z64" size 16777216 crc 63cd7973 )
+)
+
+game (
+	name "64 Hanafuda - Tenshi no Yakusoku"
+	description "64 Hanafuda - Tenshi no Yakusoku"
+	rom ( name "64 Hanafuda - Tenshi no Yakusoku (J) [!].z64" size 8388608 crc 60a680e7 )
+)
+
+game (
+	name "64 Oozumou"
+	description "64 Oozumou"
+	rom ( name "64 Oozumou (J) [!].z64" size 16777216 crc 742e31fb )
+	rom ( name "64 Oozumou (J) [b1].z64" size 16777216 crc 638ca205 )
+	rom ( name "64 Oozumou (J) [b2].z64" size 16777216 crc 71b80a1a )
+	rom ( name "64 Oozumou (J) [b3].z64" size 16515072 crc 820505f2 )
+)
+
+game (
+	name "64 Oozumou 2"
+	description "64 Oozumou 2"
+	rom ( name "64 Oozumou 2 (J) [!].z64" size 16777216 crc c1bc6fd8 )
+)
+
+game (
+	name "64 Trump Collection - Alice no Wakuwaku Trump World"
+	description "64 Trump Collection - Alice no Wakuwaku Trump World"
+	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [!].z64" size 12582912 crc dca7f4eb )
+	rom ( name "64 Trump Collection - Alice no Wakuwaku Trump World (J) [h1C].z64" size 12582912 crc d4eaef9b )
+)
+
+game (
+	name "Action Replay Pro 64"
+	description "Action Replay Pro 64"
+	rom ( name "Action Replay Pro 64 V3.0 (Unl) [b1].z64" size 262144 crc 57225419 )
+	rom ( name "Action Replay Pro 64 V3.0 (Unl) [f1].z64" size 262144 crc b87db58a )
+	rom ( name "Action Replay Pro 64 V3.0 (Unl).z64" size 262144 crc c992dfb4 )
+	rom ( name "Action Replay Pro 64 V3.3 (Unl).z64" size 262144 crc 9fbabfda )
+)
+
+game (
+	name "AeroFighters Assault"
+	description "AeroFighters Assault"
+	rom ( name "AeroFighters Assault (E) (M3) [!].z64" size 12582912 crc 6a2b08da )
+	rom ( name "AeroFighters Assault (E) (M3) [f1] (NTSC).z64" size 16777216 crc 72e78322 )
+	rom ( name "AeroFighters Assault (E) (M3) [o1].z64" size 16777216 crc 5a8060eb )
+	rom ( name "AeroFighters Assault (U) [!].z64" size 8388608 crc 4370d7e3 )
+	rom ( name "AeroFighters Assault (U) [b1].z64" size 8388608 crc 6d5a0d7a )
+	rom ( name "AeroFighters Assault (U) [b2].z64" size 8388608 crc df81ebb3 )
+	rom ( name "AeroFighters Assault (U) [b3].z64" size 6815744 crc bac88428 )
+	rom ( name "AeroFighters Assault (U) [f1] (PAL).z64" size 8388608 crc 0e8c21d4 )
+	rom ( name "AeroFighters Assault (U) [h1C].z64" size 8388608 crc d1c34769 )
+	rom ( name "AeroFighters Assault (U) [h2C].z64" size 8388608 crc 1fc10b93 )
+	rom ( name "AeroFighters Assault (U) [h3C].z64" size 8388608 crc 126f23eb )
+	rom ( name "Sonic Wings Assault (J) [!].z64" size 8388608 crc fc73fb79 )
+)
+
+game (
+	name AeroGauge
+	description "AeroGauge"
+	rom ( name "AeroGauge (E) (M3) [!].z64" size 8388608 crc 040b0046 )
+	rom ( name "AeroGauge (E) (M3) [f1] (NTSC).z64" size 8388608 crc 521865a1 )
+	rom ( name "AeroGauge (E) (M3) [h1C].z64" size 8388608 crc 821d25ce )
+	rom ( name "AeroGauge (E) (M3) [h2C].z64" size 8388608 crc a36e5628 )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [!].z64" size 8388608 crc 6ee3b932 )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b1].z64" size 16777216 crc 2f50e5ac )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b2].z64" size 16777216 crc ac1c4dea )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b3].z64" size 8388608 crc d77cb849 )
+	rom ( name "AeroGauge (J) (V1.0) (Kiosk Demo) [b4].z64" size 8388608 crc 20bc4be0 )
+	rom ( name "AeroGauge (J) (V1.1) [!].z64" size 8388608 crc f322b641 )
+	rom ( name "AeroGauge (J) (V1.1) [b1].z64" size 8388608 crc 083cea9c )
+	rom ( name "AeroGauge (J) (V1.1) [b2].z64" size 8388608 crc 90c976b3 )
+	rom ( name "AeroGauge (J) (V1.1) [b3].z64" size 8388608 crc b32f01e9 )
+	rom ( name "AeroGauge (J) (V1.1) [b4].z64" size 8425571 crc e75de0a8 )
+	rom ( name "AeroGauge (J) (V1.1) [b5].z64" size 8388608 crc 5447e02f )
+	rom ( name "AeroGauge (J) (V1.1) [b6].z64" size 6553600 crc 3386d6cf )
+	rom ( name "AeroGauge (J) (V1.1) [b7].z64" size 8388608 crc d00c9205 )
+	rom ( name "AeroGauge (J) (V1.1) [f1] (PAL).z64" size 8388608 crc 6462db5a )
+	rom ( name "AeroGauge (U) [!].z64" size 8388608 crc 198b9e0e )
+	rom ( name "AeroGauge (U) [b1].z64" size 6815744 crc 042efdf7 )
+	rom ( name "AeroGauge (U) [f1] (PAL).z64" size 8388608 crc 5fc8383f )
+	rom ( name "AeroGauge (U) [h1C].z64" size 8388608 crc 9f9dbb86 )
+	rom ( name "AeroGauge (U) [h2C].z64" size 8388608 crc beeec860 )
+	rom ( name "AeroGauge (U) [T+Ita0.01_Cattivik66].z64" size 8388608 crc 6a505b99 )
+)
+
+game (
+	name "AI Shougi 3"
+	description "AI Shougi 3"
+	rom ( name "AI Shougi 3 (J) [!].z64" size 8388608 crc 86df90e6 )
+)
+
+game (
+	name "Aidyn Chronicles - The First Mage"
+	description "Aidyn Chronicles - The First Mage"
+	rom ( name "Aidyn Chronicles - The First Mage (E) [!].z64" size 33554432 crc be7e230d )
+	rom ( name "Aidyn Chronicles - The First Mage (U) [!].z64" size 33554432 crc b1f18186 )
+	rom ( name "Aidyn Chronicles - The First Mage (U) [o1].z64" size 67108864 crc b4e83c35 )
+)
+
+game (
+	name "Airboarder 64"
+	description "Airboarder 64"
+	rom ( name "Airboarder 64 (E) [!].z64" size 8388608 crc c14d45ac )
+	rom ( name "Airboarder 64 (E) [f1] (NTSC).z64" size 8388608 crc 5a820aeb )
+	rom ( name "Airboarder 64 (E) [h1C].z64" size 8388608 crc 33d91397 )
+	rom ( name "Airboarder 64 (J) [!].z64" size 8388608 crc 58fcb771 )
+	rom ( name "Airboarder 64 (J) [b1].z64" size 8388608 crc 74210e87 )
+	rom ( name "Airboarder 64 (J) [b1][t1].z64" size 8388608 crc 3ecd5b63 )
+	rom ( name "Airboarder 64 (J) [b2].z64" size 7864320 crc f91056a0 )
+	rom ( name "Airboarder 64 (J) [b3].z64" size 7864320 crc 2d4f7c45 )
+	rom ( name "Airboarder 64 (J) [f1] (PAL).z64" size 8388608 crc dee11797 )
+	rom ( name "Airboarder 64 (J) [h1C].z64" size 8388608 crc 50598308 )
+	rom ( name "Airboarder 64 (J) [h2C].z64" size 8388608 crc 1c5eed6e )
+	rom ( name "Airboarder 64 (J) [h3C].z64" size 8388608 crc 43d2ee8a )
+	rom ( name "Airboarder 64 (J) [h4C].z64" size 8388608 crc b146b8b1 )
+	rom ( name "Airboarder 64 (J) [h5C].z64" size 8388608 crc 7346313d )
+	rom ( name "Airboarder 64 (J) [h6C].z64" size 8388608 crc e5e93ff3 )
+	rom ( name "Airboarder 64 (J) [t1].z64" size 8388608 crc db44d4c2 )
+)
+
+game (
+	name "All Star Tennis '99"
+	description "All Star Tennis '99"
+	rom ( name "All Star Tennis '99 (E) (M5) [!].z64" size 8388608 crc 996e845f )
+	rom ( name "All Star Tennis '99 (E) (M5) [f1] (NTSC).z64" size 8388608 crc f9bb05a1 )
+	rom ( name "All Star Tennis '99 (E) (M5) [f2] (NTSC).z64" size 8388608 crc 0a0b0ffc )
+	rom ( name "All Star Tennis '99 (E) (M5) [f3] (NTSC).z64" size 8388608 crc cd951f26 )
+	rom ( name "All Star Tennis '99 (E) (M5) [f4] (NTSC).z64" size 8388608 crc edd65146 )
+	rom ( name "All Star Tennis '99 (U) [!].z64" size 8388608 crc a7dcf638 )
+	rom ( name "All Star Tennis '99 (U) [f1] (PAL).z64" size 8388608 crc 78b03963 )
+	rom ( name "All Star Tennis '99 (U) [f2] (PAL).z64" size 8388608 crc 6238bb48 )
+	rom ( name "All Star Tennis '99 (U) [h1C].z64" size 8388608 crc add1e941 )
+	rom ( name "All Star Tennis '99 (U) [T+Bra1.0_Guto].z64" size 8388608 crc a7196ca9 )
+)
+
+game (
+	name "All-Star Baseball '99"
+	description "All-Star Baseball '99"
+	rom ( name "All-Star Baseball '99 (E) [!].z64" size 12582912 crc d0de3584 )
+	rom ( name "All-Star Baseball '99 (U) [!].z64" size 12582912 crc 6d25b36f )
+	rom ( name "All-Star Baseball '99 (U) [f1] (PAL).z64" size 12582912 crc 8749cfc1 )
+	rom ( name "All-Star Baseball '99 (U) [o1].z64" size 16777216 crc 43421a65 )
+)
+
+game (
+	name "All-Star Baseball 2000"
+	description "All-Star Baseball 2000"
+	rom ( name "All-Star Baseball 2000 (E) [!].z64" size 16777216 crc d3c29aa4 )
+	rom ( name "All-Star Baseball 2000 (E) [f1] (NTSC).z64" size 16777216 crc 3fc70c72 )
+	rom ( name "All-Star Baseball 2000 (U) [!].z64" size 16777216 crc 69e88471 )
+	rom ( name "All-Star Baseball 2000 (U) [f1] (PAL).z64" size 16777216 crc de5d7096 )
+	rom ( name "All-Star Baseball 2000 (U) [h1C].z64" size 16777216 crc 936abe15 )
+	rom ( name "All-Star Baseball 2000 (U) [h2C].z64" size 16777216 crc 8327d5d7 )
+)
+
+game (
+	name "All-Star Baseball 2001"
+	description "All-Star Baseball 2001"
+	rom ( name "All-Star Baseball 2001 (U) [!].z64" size 16777216 crc 4d659e85 )
+	rom ( name "All-Star Baseball 2001 (U) [f1] (PAL).z64" size 16777216 crc 50f2289d )
+)
+
+game (
+	name "Armorines - Project S.W.A.R.M."
+	description "Armorines - Project S.W.A.R.M."
+	rom ( name "Armorines - Project S.W.A.R.M. (E) [!].z64" size 16777216 crc 600bc49e )
+	rom ( name "Armorines - Project S.W.A.R.M. (E) [f1] (NTSC).z64" size 16777216 crc abf06b85 )
+	rom ( name "Armorines - Project S.W.A.R.M. (G) [!].z64" size 16777216 crc 5bab9100 )
+	rom ( name "Armorines - Project S.W.A.R.M. (G) [f1] (NTSC).z64" size 16777216 crc d7eeb023 )
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [!].z64" size 16777216 crc 630a19e2 )
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [f1] (PAL).z64" size 16777216 crc deda354c )
+	rom ( name "Armorines - Project S.W.A.R.M. (U) [t1].z64" size 16777216 crc 0a51d29c )
+)
+
+game (
+	name "Army Men - Air Combat"
+	description "Army Men - Air Combat"
+	rom ( name "Army Men - Air Combat (U) [!].z64" size 8388608 crc 1952cc87 )
+)
+
+game (
+	name "Army Men - Sarge's Heroes"
+	description "Army Men - Sarge's Heroes"
+	rom ( name "Army Men - Sarge's Heroes (E) (M3) [!].z64" size 8388608 crc e79048e2 )
+	rom ( name "Army Men - Sarge's Heroes (U) [!].z64" size 8388608 crc 2fe786f6 )
+	rom ( name "Army Men - Sarge's Heroes (U) [b1].z64" size 12530901 crc 1f6724f7 )
+	rom ( name "Army Men - Sarge's Heroes (U) [f1] (PAL).z64" size 8388608 crc 5e67a745 )
+	rom ( name "Army Men - Sarge's Heroes (U) [t1].z64" size 8388608 crc 675938d9 )
+	rom ( name "Army Men - Sarge's Heroes (U) [t2].z64" size 8388608 crc 58f10814 )
+	rom ( name "Army Men - Sarge's Heroes (U) [t3].z64" size 8388608 crc a14c9efc )
+)
+
+game (
+	name "Army Men - Sarge's Heroes 2"
+	description "Army Men - Sarge's Heroes 2"
+	rom ( name "Army Men - Sarge's Heroes 2 (U) [!].z64" size 8388608 crc 79a71608 )
+	rom ( name "Army Men - Sarge's Heroes 2 (U) [t1].z64" size 8388608 crc 7fdc2d7d )
+)
+
+game (
+	name "Asteroids Hyper 64"
+	description "Asteroids Hyper 64"
+	rom ( name "Asteroids Hyper 64 (U) [!].z64" size 4194304 crc f5ce3d91 )
+	rom ( name "Asteroids Hyper 64 (U) [o1].z64" size 8388608 crc 91aa6689 )
+	rom ( name "Asteroids Hyper 64 (U) [o1][f1] (PAL).z64" size 8388608 crc fd3d371b )
+	rom ( name "Asteroids Hyper 64 (U) [o1][t1].z64" size 8650752 crc d65f7b9a )
+)
+
+game (
+	name "Automobili Lamborghini"
+	description "Automobili Lamborghini"
+	rom ( name "Automobili Lamborghini (E) [!].z64" size 4194304 crc 3baf58d5 )
+	rom ( name "Automobili Lamborghini (E) [o1].z64" size 8388608 crc 95107c80 )
+	rom ( name "Automobili Lamborghini (U) [!].z64" size 4194304 crc a4374eac )
+	rom ( name "Automobili Lamborghini (U) [b1].z64" size 16777216 crc 5d371e34 )
+	rom ( name "Automobili Lamborghini (U) [b2].z64" size 8388608 crc 2ddcd6c5 )
+	rom ( name "Automobili Lamborghini (U) [b3].z64" size 8388608 crc 94766bda )
+	rom ( name "Automobili Lamborghini (U) [b4].z64" size 4194304 crc e62bed9d )
+	rom ( name "Automobili Lamborghini (U) [b5].z64" size 4194304 crc b5bb916b )
+	rom ( name "Automobili Lamborghini (U) [b6].z64" size 4194304 crc 8d796095 )
+	rom ( name "Automobili Lamborghini (U) [f1].z64" size 4194304 crc f922947e )
+	rom ( name "Automobili Lamborghini (U) [h1C].z64" size 4194304 crc 7d8a5bb2 )
+	rom ( name "Automobili Lamborghini (U) [h2C].z64" size 4194304 crc 68d2aa64 )
+	rom ( name "Automobili Lamborghini (U) [o1].z64" size 8388608 crc 190288d7 )
+	rom ( name "Automobili Lamborghini (U) [o1][T+Ita_cattivik66].z64" size 8388608 crc 1f38d9c4 )
+	rom ( name "Automobili Lamborghini (U) [o2].z64" size 16777216 crc 006c9b00 )
+	rom ( name "Automobili Lamborghini (U) [o3].z64" size 16777207 crc 5bf77066 )
+	rom ( name "Automobili Lamborghini (U) [o4].z64" size 16777648 crc 231defae )
+	rom ( name "Automobili Lamborghini (U) [o5].z64" size 16777216 crc cd100474 )
+	rom ( name "Automobili Lamborghini (U) [o6].z64" size 16777216 crc 1d23f90b )
+	rom ( name "Automobili Lamborghini (U) [o7].z64" size 12582912 crc 3a760d0b )
+	rom ( name "Automobili Lamborghini (U) [o7][T+Ita_cattivik66].z64" size 12582912 crc 405c647d )
+	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b3].z64" size 4194304 crc 4a0325be )
+	rom ( name "Automobili Lamborghini (U) [T+Ita_cattivik66][b4].z64" size 4194304 crc 1c0d6e98 )
+	rom ( name "Automobili Lamborghini (U) [t1].z64" size 8369260 crc 5be718fa )
+	rom ( name "Super Speed Race 64 (J) [!].z64" size 4194304 crc 0f879a70 )
+	rom ( name "Super Speed Race 64 (J) [o1].z64" size 8388608 crc d94fd663 )
+)
+
+game (
+	name "Bakuretsu Muteki Bangai-O"
+	description "Bakuretsu Muteki Bangai-O"
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [!].z64" size 12582912 crc 6ab7fec6 )
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [f1] (PAL).z64" size 12582912 crc 2582fda5 )
+	rom ( name "Bakuretsu Muteki Bangai-O (J) [h1C].z64" size 12582912 crc c76f1d4c )
+)
+
+game (
+	name "Bakushou Jinsei 64 - Mezase! Resort Ou"
+	description "Bakushou Jinsei 64 - Mezase! Resort Ou"
+	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!].z64" size 12582912 crc ef8c2f34 )
+	rom ( name "Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C].z64" size 12582912 crc 47db2246 )
+)
+
+game (
+	name Banjo-Kazooie
+	description "Banjo-Kazooie"
+	rom ( name "Banjo to Kazooie no Daibouken (J) [!].z64" size 16777216 crc 8f7c9324 )
+	rom ( name "Banjo to Kazooie no Daibouken (J) [f1].z64" size 16824592 crc 73576c8b )
+	rom ( name "Banjo to Kazooie no Daibouken (J) [f2].z64" size 17039360 crc 56944ade )
+	rom ( name "Banjo to Kazooie no Daibouken (J) [f3].z64" size 16824592 crc fc4be10d )
+	rom ( name "Banjo-Kazooie (E) (M3) [!].z64" size 16777216 crc 525899c9 )
+	rom ( name "Banjo-Kazooie (E) (M3) [f1].z64" size 17039360 crc 310fc34b )
+	rom ( name "Banjo-Kazooie (E) (M3) [f2].z64" size 16777216 crc 8fa1a9b1 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [!].z64" size 16777216 crc ad429961 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b1].z64" size 16829405 crc f000e01e )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b2].z64" size 16777216 crc 409090e5 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b3].z64" size 16777216 crc e1bc390f )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b4].z64" size 16777216 crc e5e5b566 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b5].z64" size 16645536 crc 10259bd1 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b6].z64" size 16777216 crc 617c02cc )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [b7].z64" size 16777216 crc 93e70f75 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [f1].z64" size 16777216 crc 5b581d38 )
+	rom ( name "Banjo-Kazooie (U) (V1.0) [t1].z64" size 16777216 crc 2600ae00 )
+	rom ( name "Banjo-Kazooie (U) (V1.1) [!].z64" size 16777216 crc fb7ffb10 )
+)
+
+game (
+	name Banjo-Tooie
+	description "Banjo-Tooie"
+	rom ( name "Banjo to Kazooie no Daibouken 2 (J) [!].z64" size 33554432 crc 258c58d0 )
+	rom ( name "Banjo-Tooie (A) [!].z64" size 33554432 crc 2736266a )
+	rom ( name "Banjo-Tooie (E) (M4) [!].z64" size 33554432 crc 1ec12f5a )
+	rom ( name "Banjo-Tooie (U) [!].z64" size 33554432 crc bab803ef )
+)
+
+game (
+	name "Bass Rush - ECOGEAR PowerWorm Championship"
+	description "Bass Rush - ECOGEAR PowerWorm Championship"
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [!].z64" size 33554432 crc 383b86ef )
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b1].z64" size 29360129 crc 2ac04018 )
+	rom ( name "Bass Rush - ECOGEAR PowerWorm Championship (J) [b2].z64" size 29360128 crc 2c3a7b2b )
+)
+
+game (
+	name "Bassmasters 2000"
+	description "Bassmasters 2000"
+	rom ( name "Bassmasters 2000 (U) [!].z64" size 12582912 crc 6b09092e )
+	rom ( name "Bassmasters 2000 (U) [b1].z64" size 12582912 crc ff7ff0ec )
+	rom ( name "Bassmasters 2000 (U) [f1] (PAL).z64" size 12582912 crc 38b00d48 )
+)
+
+game (
+	name "Batman Beyond - Return of the Joker"
+	description "Batman Beyond - Return of the Joker"
+	rom ( name "Batman Beyond - Return of the Joker (U) [!].z64" size 4194304 crc 35299f9c )
+	rom ( name "Batman Beyond - Return of the Joker (U) [o1].z64" size 8388608 crc 6c5ab61e )
+	rom ( name "Batman Beyond - Return of the Joker (U) [o1][t1].z64" size 8388608 crc 0184342f )
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [!].z64" size 4194304 crc 82a4bb8a )
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [b1].z64" size 4194304 crc 353dd094 )
+	rom ( name "Batman of the Future - Return of the Joker (E) (M3) [o1].z64" size 8388608 crc 564125b9 )
+)
+
+game (
+	name BattleTanx
+	description "BattleTanx"
+	rom ( name "BattleTanx (U) [!].z64" size 8388608 crc 6c230765 )
+	rom ( name "BattleTanx (U) [b1].z64" size 8388608 crc 716239a4 )
+	rom ( name "BattleTanx (U) [b1][t1].z64" size 8388608 crc b6697b5c )
+	rom ( name "BattleTanx (U) [f1] (PAL).z64" size 8388608 crc 0e897622 )
+	rom ( name "BattleTanx (U) [t1].z64" size 8388608 crc 245a516b )
+)
+
+game (
+	name "BattleTanx - Global Assault"
+	description "BattleTanx - Global Assault"
+	rom ( name "BattleTanx - Global Assault (E) (M3) [!].z64" size 8388608 crc c99c6030 )
+	rom ( name "BattleTanx - Global Assault (U) [!].z64" size 8388608 crc 31beb053 )
+	rom ( name "BattleTanx - Global Assault (U) [f1] (Country Check).z64" size 8388608 crc d375debc )
+	rom ( name "BattleTanx - Global Assault (U) [f2] (PAL).z64" size 8388608 crc e448b23f )
+)
+
+game (
+	name "Battlezone - Rise of the Black Dogs"
+	description "Battlezone - Rise of the Black Dogs"
+	rom ( name "Battlezone - Rise of the Black Dogs (U) [!].z64" size 16777216 crc 736f9d5c )
+)
+
+game (
+	name "Beetle Adventure Racing!"
+	description "Beetle Adventure Racing!"
+	rom ( name "Beetle Adventure Racing! (E) (M3) [!].z64" size 16777216 crc 5b6c6e4c )
+	rom ( name "Beetle Adventure Racing! (E) (M3) [h1C].z64" size 16777216 crc b0986539 )
+	rom ( name "Beetle Adventure Racing! (E) (M3) [t1].z64" size 16777216 crc 0605ae3c )
+	rom ( name "Beetle Adventure Racing! (J) [!].z64" size 16777216 crc 49e75825 )
+	rom ( name "Beetle Adventure Racing! (J) [b1].z64" size 16777216 crc 54085e2e )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [!].z64" size 16777216 crc f4a97c73 )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [b1].z64" size 16777216 crc 94c6c38e )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [b2].z64" size 16777216 crc cfa90a9c )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [f1] (PAL).z64" size 15990784 crc 9e372e72 )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [t1].z64" size 16777216 crc 67389d41 )
+	rom ( name "Beetle Adventure Racing! (U) (M3) [t2].z64" size 16777216 crc e5164eb0 )
+	rom ( name "HSV Adventure Racing (A) [b1].z64" size 16777216 crc 513b0745 )
+	rom ( name "HSV Adventure Racing (A) [f1] (NTSC).z64" size 16777216 crc ce50fdb3 )
+	rom ( name "HSV Adventure Racing (A).z64" size 16777216 crc c0ba9440 )
+)
+
+game (
+	name "Big Mountain 2000"
+	description "Big Mountain 2000"
+	rom ( name "Big Mountain 2000 (U) [!].z64" size 12582912 crc 3ac924bc )
+	rom ( name "Big Mountain 2000 (U) [t1].z64" size 12582912 crc 5b7c40dc )
+	rom ( name "Snow Speeder (J) [!].z64" size 12582912 crc 30ea3fd7 )
+	rom ( name "Snow Speeder (J) [b1].z64" size 12582912 crc 0d85c419 )
+)
+
+game (
+	name "Bio F.R.E.A.K.S."
+	description "Bio F.R.E.A.K.S."
+	rom ( name "Bio F.R.E.A.K.S. (E) [!].z64" size 16777216 crc 2c4eb906 )
+	rom ( name "Bio F.R.E.A.K.S. (E) [b1].z64" size 12582912 crc 786c72e2 )
+	rom ( name "Bio F.R.E.A.K.S. (U) [!].z64" size 16777216 crc dfbf448c )
+	rom ( name "Bio F.R.E.A.K.S. (U) [b1].z64" size 16777216 crc 06134dae )
+	rom ( name "Bio F.R.E.A.K.S. (U) [b2].z64" size 16777216 crc c1ba30a0 )
+	rom ( name "Bio F.R.E.A.K.S. (U) [b3].z64" size 16777216 crc 68269493 )
+	rom ( name "Bio F.R.E.A.K.S. (U) [h1C].z64" size 16777216 crc 5bf5acee )
+	rom ( name "Bio F.R.E.A.K.S. (U) [t1].z64" size 16777216 crc d239559b )
+)
+
+game (
+	name "Blast Corps"
+	description "Blast Corps"
+	rom ( name "Blast Corps (E) (M2) [!].z64" size 8388608 crc 4c820695 )
+	rom ( name "Blast Corps (E) (M2) [b1].z64" size 8388608 crc 529072b8 )
+	rom ( name "Blast Corps (E) (M2) [b2].z64" size 8388608 crc ae6df20f )
+	rom ( name "Blast Corps (U) (V1.0) [!].z64" size 8388608 crc 767a95e7 )
+	rom ( name "Blast Corps (U) (V1.0) [b1].z64" size 8388608 crc 43484da5 )
+	rom ( name "Blast Corps (U) (V1.0) [b2].z64" size 8388608 crc e7fd8279 )
+	rom ( name "Blast Corps (U) (V1.1) [!].z64" size 8388608 crc 9cbbccf1 )
+	rom ( name "Blast Dozer (J) [!].z64" size 8388608 crc 081a3641 )
+	rom ( name "Blast Dozer (J) [b1].z64" size 8388608 crc 5c01ab00 )
+)
+
+game (
+	name "Blues Brothers 2000"
+	description "Blues Brothers 2000"
+	rom ( name "Blues Brothers 2000 (E) (M6) [!].z64" size 16777216 crc 8fb41658 )
+	rom ( name "Blues Brothers 2000 (U) [!].z64" size 16777216 crc c6f49764 )
+	rom ( name "Blues Brothers 2000 (U) [f1] (PAL-NTSC).z64" size 16777216 crc c978c9b2 )
+	rom ( name "Blues Brothers 2000 (U) [t1].z64" size 16777216 crc 3ae17959 )
+	rom ( name "Blues Brothers 2000 (U) [t1][f1] (PAL-NTSC).z64" size 16777216 crc f0ef67ef )
+)
+
+game (
+	name "Body Harvest"
+	description "Body Harvest"
+	rom ( name "Body Harvest (E) (M3) [!].z64" size 12582912 crc 6a04cdae )
+	rom ( name "Body Harvest (E) (M3) [f1] (NTSC).z64" size 12582912 crc 561081c2 )
+	rom ( name "Body Harvest (U) [!].z64" size 12582912 crc fabbdf02 )
+	rom ( name "Body Harvest (U) [b1].z64" size 12582912 crc 47057360 )
+	rom ( name "Body Harvest (U) [b1][t1].z64" size 12582912 crc 822cce53 )
+	rom ( name "Body Harvest (U) [b2].z64" size 12582912 crc a8c980a0 )
+	rom ( name "Body Harvest (U) [t1].z64" size 12582912 crc 418da29b )
+)
+
+game (
+	name "Bomberman 64"
+	description "Bomberman 64"
+	rom ( name "Baku Bomberman (J) [!].z64" size 8388608 crc 22f54a52 )
+	rom ( name "Baku Bomberman (J) [b1].z64" size 8388608 crc f8d8623f )
+	rom ( name "Baku Bomberman (J) [h1C].z64" size 8388608 crc 1f6ba05d )
+	rom ( name "Baku Bomberman (J) [t1].z64" size 8388608 crc 6733c63c )
+	rom ( name "Bomberman 64 (E) [!].z64" size 8388608 crc 525339c5 )
+	rom ( name "Bomberman 64 (E) [b1].z64" size 8388608 crc c7d3898d )
+	rom ( name "Bomberman 64 (E) [b2].z64" size 8388608 crc f6fc15d0 )
+	rom ( name "Bomberman 64 (E) [h1C].z64" size 8388608 crc 70ea3058 )
+	rom ( name "Bomberman 64 (E) [t1].z64" size 8388608 crc 7decd8f8 )
+	rom ( name "Bomberman 64 (U) [!].z64" size 8388608 crc 3ed0e0dc )
+	rom ( name "Bomberman 64 (U) [b1].z64" size 8126464 crc 2f1488d8 )
+	rom ( name "Bomberman 64 (U) [o1].z64" size 8388808 crc e4c0a3a4 )
+)
+
+game (
+	name "Bomberman 64 - Arcade Edition"
+	description "Bomberman 64 - Arcade Edition"
+	rom ( name "Bomberman 64 - Arcade Edition (J) [f1] (PAL).z64" size 12582912 crc 7b3f423e )
+	rom ( name "Bomberman 64 - Arcade Edition (J) [f2] (PAL-CRC).z64" size 12582912 crc ca005639 )
+	rom ( name "Bomberman 64 - Arcade Edition (J).z64" size 12582912 crc 7e74eedc )
+)
+
+game (
+	name "Bomberman 64 - The Second Attack!"
+	description "Bomberman 64 - The Second Attack!"
+	rom ( name "Baku Bomberman 2 (J) [!].z64" size 16777216 crc 86bbc278 )
+	rom ( name "Bomberman 64 - The Second Attack! (U) [!].z64" size 16777216 crc 57550007 )
+	rom ( name "Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC).z64" size 16777216 crc f2ddb246 )
+)
+
+game (
+	name "Bomberman Hero"
+	description "Bomberman Hero"
+	rom ( name "Bomberman Hero (E) [!].z64" size 12582912 crc 59e39947 )
+	rom ( name "Bomberman Hero (E) [b1].z64" size 12582912 crc faad0e58 )
+	rom ( name "Bomberman Hero (E) [b2].z64" size 33554432 crc 332391a6 )
+	rom ( name "Bomberman Hero (E) [b3].z64" size 12582912 crc 18957212 )
+	rom ( name "Bomberman Hero (E) [f1] (NTSC).z64" size 12582912 crc 371ab763 )
+	rom ( name "Bomberman Hero (U) [!].z64" size 12582912 crc 2cc2e634 )
+	rom ( name "Bomberman Hero (U) [b1].z64" size 5967872 crc d9204816 )
+	rom ( name "Bomberman Hero (U) [b2].z64" size 12581464 crc 2e329c9c )
+	rom ( name "Bomberman Hero (U) [b3].z64" size 12582912 crc e3ea697c )
+	rom ( name "Bomberman Hero (U) [t1].z64" size 12582912 crc b7ea3fe0 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [!].z64" size 12582912 crc 69ceabcc )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1].z64" size 16777216 crc fbe5d5f7 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b2].z64" size 16777216 crc c9822c46 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b3].z64" size 16777216 crc e3e4703f )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b4].z64" size 12582912 crc 70700853 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b5].z64" size 16777216 crc 7a3e9bf6 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b6].z64" size 12582912 crc 7409b5d6 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b7].z64" size 12582912 crc 002a9fde )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [b8].z64" size 12582912 crc 737334c7 )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [o1].z64" size 16777216 crc 2573dfef )
+	rom ( name "Bomberman Hero - Mirian Oujo wo Sukue! (J) [t1].z64" size 12582912 crc 6acd9758 )
+)
+
+game (
+	name "Bottom of the 9th"
+	description "Bottom of the 9th"
+	rom ( name "Bottom of the 9th (U) [!].z64" size 16777216 crc 1844c8ca )
+	rom ( name "Bottom of the 9th (U) [b1].z64" size 16777216 crc 352f0d77 )
+)
+
+game (
+	name "Brunswick Circuit Pro Bowling"
+	description "Brunswick Circuit Pro Bowling"
+	rom ( name "Brunswick Circuit Pro Bowling (U) [!].z64" size 8388608 crc 80d70173 )
+	rom ( name "Brunswick Circuit Pro Bowling (U) [b1].z64" size 8388608 crc 48d6fbb5 )
+	rom ( name "Brunswick Circuit Pro Bowling (U) [o1].z64" size 12582912 crc ca69aa8b )
+	rom ( name "Brunswick Circuit Pro Bowling (U) [o1][f1] (PAL).z64" size 12582912 crc 84e3b242 )
+)
+
+game (
+	name "Buck Bumble"
+	description "Buck Bumble"
+	rom ( name "Buck Bumble (E) (M5) [!].z64" size 12582912 crc e26192ab )
+	rom ( name "Buck Bumble (J) [!].z64" size 12582912 crc 2ed81a65 )
+	rom ( name "Buck Bumble (U) [!].z64" size 12582912 crc 8ec937db )
+	rom ( name "Buck Bumble (U) [b1][t1].z64" size 12582912 crc 35682724 )
+	rom ( name "Buck Bumble (U) [b2].z64" size 12582912 crc 462ea83e )
+	rom ( name "Buck Bumble (U) [f1] (PAL).z64" size 12582912 crc 96e40527 )
+	rom ( name "Buck Bumble (U) [t1].z64" size 12582912 crc ab751417 )
+)
+
+game (
+	name "Bug's Life, A"
+	description "Bug's Life, A"
+	rom ( name "Bug's Life, A (E) [!].z64" size 12582912 crc 791881d4 )
+	rom ( name "Bug's Life, A (E) [f1] (NTSC).z64" size 12582912 crc c9cfe718 )
+	rom ( name "Bug's Life, A (F) [!].z64" size 12582912 crc e5429094 )
+	rom ( name "Bug's Life, A (F) [f1] (NTSC).z64" size 12582912 crc 32a7f761 )
+	rom ( name "Bug's Life, A (G) [!].z64" size 12582912 crc 15a32836 )
+	rom ( name "Bug's Life, A (G) [f1] (NTSC).z64" size 12582912 crc acb166ff )
+	rom ( name "Bug's Life, A (I) [!].z64" size 12582912 crc 2d118764 )
+	rom ( name "Bug's Life, A (U) [!].z64" size 12582912 crc cf2ea0b6 )
+	rom ( name "Bug's Life, A (U) [b1].z64" size 12582912 crc df844e51 )
+	rom ( name "Bug's Life, A (U) [b1][f1] (PAL).z64" size 12582912 crc 478ce66f )
+	rom ( name "Bug's Life, A (U) [f1] (PAL).z64" size 12582912 crc 57260888 )
+	rom ( name "Bug's Life, A (U) [t1].z64" size 12582912 crc 4ea0808a )
+	rom ( name "Bug's Life, A (U) [t2].z64" size 12582912 crc 5e0a6e6d )
+)
+
+game (
+	name "Bust-A-Move '99"
+	description "Bust-A-Move '99"
+	rom ( name "Bust-A-Move '99 (U) [!].z64" size 8388608 crc c285fc69 )
+	rom ( name "Bust-A-Move '99 (U) [b1].z64" size 8388608 crc f7ced91e )
+	rom ( name "Bust-A-Move '99 (U) [f1] (PAL).z64" size 8388608 crc 3cd99896 )
+	rom ( name "Bust-A-Move 3 DX (E) [!].z64" size 8388608 crc 95595889 )
+	rom ( name "Bust-A-Move 3 DX (E) [b1].z64" size 8388608 crc 414f160f )
+	rom ( name "Bust-A-Move 3 DX (E) [b2].z64" size 8388608 crc 935dda42 )
+	rom ( name "Bust-A-Move 3 DX (E) [b3].z64" size 8388608 crc 0f94b85d )
+	rom ( name "Bust-A-Move 3 DX (E) [f1] (NTSC100%).z64" size 8388608 crc db82f6db )
+	rom ( name "Bust-A-Move 3 DX (E) [f2] (NTSC-Z64).z64" size 8388608 crc 2837dd00 )
+	rom ( name "Bust-A-Move 3 DX (E) [f3] (NTSC).z64" size 8388608 crc 58533b87 )
+	rom ( name "Puzzle Bobble 64 (J) [!].z64" size 8388608 crc ea837423 )
+	rom ( name "Puzzle Bobble 64 (J) [f1] (PAL).z64" size 8388608 crc e120eb0c )
+	rom ( name "Puzzle Bobble 64 (J) [f2] (PAL).z64" size 8388608 crc d1f3984a )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition"
+	description "Bust-A-Move 2 - Arcade Edition"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [!].z64" size 8388608 crc 04731bab )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (E) [b1].z64" size 8388608 crc c352df3f )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [!].z64" size 8388608 crc 9f54cd2d )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b1].z64" size 8388608 crc e79f0acb )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b2].z64" size 8388608 crc 948a1cfb )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b3].z64" size 8388608 crc 96325fc3 )
+	rom ( name "Bust-A-Move 2 - Arcade Edition (U) [b4].z64" size 7864320 crc 4dfb7a1d )
+)
+
+game (
+	name "California Speed"
+	description "California Speed"
+	rom ( name "California Speed (U) [!].z64" size 16777216 crc 6f6262cb )
+	rom ( name "California Speed (U) [f1] (Country Check).z64" size 16777216 crc f9d470e2 )
+	rom ( name "California Speed (U) [f2] (PAL).z64" size 16777216 crc 1c41238a )
+	rom ( name "California Speed (U) [t1].z64" size 16777216 crc c8250c69 )
+)
+
+game (
+	name "Carmageddon 64"
+	description "Carmageddon 64"
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!].z64" size 16777216 crc 8569f1a0 )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [f1] (NTSC).z64" size 16777216 crc 9f85cc8c )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!].z64" size 16777216 crc 8036f999 )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [b1].z64" size 16777216 crc 5e71223e )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f1] (NTSC).z64" size 16777216 crc 3221b1d4 )
+	rom ( name "Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [f2] (NTSC).z64" size 16777216 crc e1ee0473 )
+	rom ( name "Carmageddon 64 (U) [!].z64" size 16777216 crc 10c6a0a1 )
+)
+
+game (
+	name Castlevania
+	description "Castlevania"
+	rom ( name "Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!].z64" size 12582912 crc e349cfec )
+	rom ( name "Castlevania (E) (M3) [!].z64" size 12582912 crc d9d76235 )
+	rom ( name "Castlevania (E) (M3) [b1].z64" size 12582912 crc 8e6e53a0 )
+	rom ( name "Castlevania (E) (M3) [t1].z64" size 12582912 crc 3c9d1ed5 )
+	rom ( name "Castlevania (U) (V1.0) [!].z64" size 12582912 crc 8b0d3c00 )
+	rom ( name "Castlevania (U) (V1.0) [b1].z64" size 12350745 crc 724a540e )
+	rom ( name "Castlevania (U) (V1.0) [b2].z64" size 12582912 crc 16db3687 )
+	rom ( name "Castlevania (U) (V1.0) [b3].z64" size 12582912 crc 567e1271 )
+	rom ( name "Castlevania (U) (V1.0) [b4].z64" size 12582912 crc e6036665 )
+	rom ( name "Castlevania (U) (V1.0) [t1].z64" size 12582912 crc 5263b185 )
+	rom ( name "Castlevania (U) (V1.0) [t2].z64" size 12582912 crc fe5d8b7a )
+	rom ( name "Castlevania (U) (V1.0) [t3].z64" size 12582912 crc e1d6cb91 )
+	rom ( name "Castlevania (U) (V1.0) [t4].z64" size 12582912 crc 1f95ef27 )
+	rom ( name "Castlevania (U) (V1.2) [!].z64" size 12582912 crc 83032d97 )
+)
+
+game (
+	name "Castlevania - Legacy of Darkness"
+	description "Castlevania - Legacy of Darkness"
+	rom ( name "Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!].z64" size 16777216 crc ff009c21 )
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [!].z64" size 16777216 crc 12ab9b45 )
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [h1C].z64" size 16777216 crc 12548aa1 )
+	rom ( name "Castlevania - Legacy of Darkness (E) (M3) [o1].z64" size 16777220 crc 7c1a0085 )
+	rom ( name "Castlevania - Legacy of Darkness (U) [!].z64" size 16777216 crc ab13028c )
+	rom ( name "Castlevania - Legacy of Darkness (U) [b1].z64" size 16777216 crc eac65ca0 )
+	rom ( name "Castlevania - Legacy of Darkness (U) [f1] (PAL).z64" size 16777216 crc 72fb900a )
+	rom ( name "Castlevania - Legacy of Darkness (U) [f2] (PAL).z64" size 16777216 crc 0c6cdf58 )
+	rom ( name "Castlevania - Legacy of Darkness (U) [t1].z64" size 16777216 crc e49f3c4d )
+)
+
+game (
+	name "CD64 BIOS"
+	description "CD64 BIOS"
+	rom ( name "CD64 BIOS Direct-Upgrade V1.08.bin" size 8388608 crc 5c4fd81f )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.09.bin" size 8388608 crc b271ff1b )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.10.bin" size 8388608 crc 7bf28f41 )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.11.bin" size 8388608 crc 711774c5 )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.13.bin" size 8388608 crc fdeff9e8 )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.20.bin" size 8388608 crc 26d1d2c7 )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.21.bin" size 8388608 crc f0e0b2a2 )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.23.bin" size 8388608 crc 52ee53ca )
+	rom ( name "CD64 BIOS Direct-Upgrade V1.30.bin" size 8388608 crc 65a164e1 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.08 [a1].bin" size 262144 crc c3e77b21 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.08.bin" size 262144 crc 4c84afaa )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.09.bin" size 262144 crc 6b96b2b4 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.10.bin" size 262144 crc 283780f1 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Even Bytes).bin" size 131072 crc e6598dbd )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11 (Odd Bytes).bin" size 131072 crc 4443f4a3 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.11.bin" size 262144 crc ec7a03ec )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Even Bytes).bin" size 131072 crc 73cf6202 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21 (Odd Bytes).bin" size 131072 crc 12f79a82 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.21.bin" size 262144 crc e993d4b3 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Even Bytes).bin" size 131072 crc b29dbb3f )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23 (Odd Bytes).bin" size 131072 crc 09d3eb60 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.23.bin" size 262144 crc c3a5a1fb )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Even Bytes).bin" size 131072 crc 41ce5465 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30 (Odd Bytes).bin" size 131072 crc abee5982 )
+	rom ( name "CD64 BIOS EEPROM-Burner V1.30.bin" size 262144 crc 011cf143 )
+)
+
+game (
+	name "Centre Court Tennis"
+	description "Centre Court Tennis"
+	rom ( name "Centre Court Tennis (E) [!].z64" size 12582912 crc b1d26f39 )
+	rom ( name "Centre Court Tennis (E) [f1] (NTSC).z64" size 12582912 crc d70f7b00 )
+	rom ( name "Centre Court Tennis (E) [h1C].z64" size 12582912 crc f928608b )
+	rom ( name "Let's Smash Tennis (J) [!].z64" size 12582912 crc 455a1770 )
+)
+
+game (
+	name "Chameleon Twist"
+	description "Chameleon Twist"
+	rom ( name "Chameleon Twist (E) [!].z64" size 12582912 crc 587dd983 )
+	rom ( name "Chameleon Twist (E) [b1].z64" size 16777216 crc 68cead3e )
+	rom ( name "Chameleon Twist (E) [b2].z64" size 11534336 crc f3772611 )
+	rom ( name "Chameleon Twist (E) [b3].z64" size 12582912 crc 7618134d )
+	rom ( name "Chameleon Twist (E) [f1] (NTSC).z64" size 12582912 crc 1b8df49a )
+	rom ( name "Chameleon Twist (E) [o1].z64" size 16777216 crc e060ad47 )
+	rom ( name "Chameleon Twist (E) [o2].z64" size 12582916 crc 7d6a36e8 )
+	rom ( name "Chameleon Twist (J) [!].z64" size 12582912 crc 6395c475 )
+	rom ( name "Chameleon Twist (U) [!].z64" size 12582912 crc 7fe024c9 )
+	rom ( name "Chameleon Twist (U) [b1].z64" size 12582912 crc 566543ce )
+	rom ( name "Chameleon Twist (U) [b2].z64" size 12582912 crc 5d928b73 )
+	rom ( name "Chameleon Twist (U) [b3].z64" size 12582912 crc f654adcb )
+	rom ( name "Chameleon Twist (U) [t1].z64" size 12582912 crc f6537276 )
+)
+
+game (
+	name "Chameleon Twist 2"
+	description "Chameleon Twist 2"
+	rom ( name "Chameleon Twist 2 (E) [!].z64" size 8388608 crc 3b53519f )
+	rom ( name "Chameleon Twist 2 (E) [b1].z64" size 8388608 crc 9da3fd63 )
+	rom ( name "Chameleon Twist 2 (J) [!].z64" size 8388608 crc 5677eaef )
+	rom ( name "Chameleon Twist 2 (J) [b1].z64" size 12582912 crc 23857073 )
+	rom ( name "Chameleon Twist 2 (J) [b2].z64" size 8388608 crc 84cbd297 )
+	rom ( name "Chameleon Twist 2 (J) [b3].z64" size 8388608 crc f6839d99 )
+	rom ( name "Chameleon Twist 2 (J) [b4].z64" size 8388608 crc 8ff29073 )
+	rom ( name "Chameleon Twist 2 (J) [o1].z64" size 12582912 crc 08287cc8 )
+	rom ( name "Chameleon Twist 2 (J) [o2].z64" size 12582912 crc 8dfe135a )
+	rom ( name "Chameleon Twist 2 (J) [t1].z64" size 12582912 crc 10a24d0c )
+	rom ( name "Chameleon Twist 2 (U) [!].z64" size 8388608 crc cdf26d67 )
+	rom ( name "Chameleon Twist 2 (U) [t1].z64" size 8388608 crc ac3d5715 )
+)
+
+game (
+	name "Charlie Blast's Territory"
+	description "Charlie Blast's Territory"
+	rom ( name "Charlie Blast's Territory (E) [!].z64" size 4194304 crc 82c1d9e1 )
+	rom ( name "Charlie Blast's Territory (E) [o1].z64" size 8388608 crc 2562fc53 )
+	rom ( name "Charlie Blast's Territory (U) [!].z64" size 4194304 crc ba4e65a8 )
+	rom ( name "Charlie Blast's Territory (U) [hI].z64" size 8388608 crc 87935eaf )
+	rom ( name "Charlie Blast's Territory (U) [hIR].z64" size 8388608 crc 5c1ea306 )
+)
+
+game (
+	name "Chopper Attack"
+	description "Chopper Attack"
+	rom ( name "Chopper Attack (E) [!].z64" size 8388608 crc c1dcd7ab )
+	rom ( name "Chopper Attack (E) [b1].z64" size 8388608 crc 2fd90225 )
+	rom ( name "Chopper Attack (E) [t1].z64" size 8388608 crc 83a7d582 )
+	rom ( name "Chopper Attack (U) [!].z64" size 8388608 crc aa5d76a9 )
+	rom ( name "Chopper Attack (U) [b1].z64" size 8388608 crc 10296792 )
+	rom ( name "Chopper Attack (U) [b2].z64" size 8388608 crc 12e48f07 )
+	rom ( name "Chopper Attack (U) [b3].z64" size 8388608 crc ad84b711 )
+	rom ( name "Chopper Attack (U) [b4].z64" size 8388608 crc 6abd62c4 )
+	rom ( name "Chopper Attack (U) [b5].z64" size 8388608 crc fbf44189 )
+	rom ( name "Chopper Attack (U) [b6].z64" size 8388608 crc 0182ef2e )
+	rom ( name "Chopper Attack (U) [t1].z64" size 8388608 crc 521f2bb5 )
+	rom ( name "Wild Choppers (J) [!].z64" size 8388608 crc d6136dc5 )
+	rom ( name "Wild Choppers (J) [b1].z64" size 8388608 crc 6f07a665 )
+	rom ( name "Wild Choppers (J) [b2].z64" size 8388608 crc 12ec9b86 )
+	rom ( name "Wild Choppers (J) [b3].z64" size 8126464 crc 71726557 )
+	rom ( name "Wild Choppers (J) [o1].z64" size 8388808 crc e866d832 )
+	rom ( name "Wild Choppers (J) [t1].z64" size 8388608 crc 3ca3e096 )
+)
+
+game (
+	name "Choro Q 64 II - Hacha Mecha Grand Prix Race"
+	description "Choro Q 64 II - Hacha Mecha Grand Prix Race"
+	rom ( name "Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!].z64" size 12582912 crc 5c565ad6 )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King"
+	description "Chou Kuukan Night Pro Yakyuu King"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [!].z64" size 8388608 crc 5f75634e )
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [b1].z64" size 8388608 crc 61a9756b )
+	rom ( name "Chou Kuukan Night Pro Yakyuu King (J) [h1C].z64" size 8388608 crc 64e730dc )
+)
+
+game (
+	name "Chou Kuukan Night Pro Yakyuu King 2"
+	description "Chou Kuukan Night Pro Yakyuu King 2"
+	rom ( name "Chou Kuukan Night Pro Yakyuu King 2 (J) [!].z64" size 16777216 crc 479643e2 )
+)
+
+game (
+	name "Clay Fighter - Sculptor's Cut"
+	description "Clay Fighter - Sculptor's Cut"
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [!].z64" size 16777216 crc 434de656 )
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [b1].z64" size 16777216 crc 25fadf5e )
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [b2].z64" size 16777216 crc 11487231 )
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [h1C].z64" size 16777216 crc 567bfec1 )
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [h2C].z64" size 16777216 crc 432e391a )
+	rom ( name "Clay Fighter - Sculptor's Cut (U) [t1].z64" size 16777216 crc f8afa913 )
+)
+
+game (
+	name "Clay Fighter 63 1-3"
+	description "Clay Fighter 63 1-3"
+	rom ( name "Clay Fighter 63 1-3 (Beta) [!].z64" size 12582912 crc 18f4166a )
+	rom ( name "Clay Fighter 63 1-3 (Beta) [b1].z64" size 12582912 crc 0ba68b38 )
+	rom ( name "Clay Fighter 63 1-3 (E) [!].z64" size 12582912 crc 82263e5d )
+	rom ( name "Clay Fighter 63 1-3 (E) [b1][h1C].z64" size 12582912 crc 5e0dd087 )
+	rom ( name "Clay Fighter 63 1-3 (E) [h1C].z64" size 12582912 crc 41f36719 )
+	rom ( name "Clay Fighter 63 1-3 (U) [!].z64" size 12582912 crc 3fa647dd )
+	rom ( name "Clay Fighter 63 1-3 (U) [b1].z64" size 4465600 crc 3c7bc60d )
+	rom ( name "Clay Fighter 63 1-3 (U) [b2].z64" size 12582912 crc 81428075 )
+	rom ( name "Clay Fighter 63 1-3 (U) [o1].z64" size 16777216 crc 9c481c79 )
+	rom ( name "Clay Fighter 63 1-3 (U) [o2].z64" size 16777216 crc 2ea4420a )
+)
+
+game (
+	name "Command & Conquer"
+	description "Command & Conquer"
+	rom ( name "Command & Conquer (E) (M2) [!].z64" size 33554432 crc f3da8a26 )
+	rom ( name "Command & Conquer (E) (M2) [b1].z64" size 16994304 crc 8ae902f9 )
+	rom ( name "Command & Conquer (E) (M2) [b2].z64" size 33554432 crc e155637c )
+	rom ( name "Command & Conquer (E) (M2) [b3].z64" size 33554436 crc e465fa53 )
+	rom ( name "Command & Conquer (E) (M2) [f1] (Z64).z64" size 33554432 crc 8817f44c )
+	rom ( name "Command & Conquer (G) [!].z64" size 33554432 crc 6cd0fc99 )
+	rom ( name "Command & Conquer (G) [f1] (Z64).z64" size 33554432 crc 88a500d7 )
+	rom ( name "Command & Conquer (U) [!].z64" size 33554432 crc 3e9069ef )
+	rom ( name "Command & Conquer (U) [b1].z64" size 33554432 crc 528347bf )
+	rom ( name "Command & Conquer (U) [f1] (Z64).z64" size 33554432 crc e745c5d8 )
+)
+
+game (
+	name "Conker's Bad Fur Day"
+	description "Conker's Bad Fur Day"
+	rom ( name "Conker's Bad Fur Day (E) [!].z64" size 67108864 crc 4667cfe9 )
+	rom ( name "Conker's Bad Fur Day (U) [!].z64" size 67108864 crc ce8cc172 )
+)
+
+game (
+	name "Cruis'n Exotica"
+	description "Cruis'n Exotica"
+	rom ( name "Cruis'n Exotica (U) [!].z64" size 16777216 crc 867a2ced )
+	rom ( name "Cruis'n Exotica (U) [t1].z64" size 16777216 crc 3dea85d6 )
+)
+
+game (
+	name "Cruis'n USA"
+	description "Cruis'n USA"
+	rom ( name "Cruis'n USA (E) [!].z64" size 8388608 crc 8935a8d9 )
+	rom ( name "Cruis'n USA (U) (V1.0) [!].z64" size 8388608 crc 5238b727 )
+	rom ( name "Cruis'n USA (U) (V1.0) [b1].z64" size 8388608 crc 92f6809f )
+	rom ( name "Cruis'n USA (U) (V1.0) [b2].z64" size 8388608 crc 97899ecc )
+	rom ( name "Cruis'n USA (U) (V1.0) [b3].z64" size 8388608 crc d1e1ffb4 )
+	rom ( name "Cruis'n USA (U) (V1.0) [b4].z64" size 8388608 crc b93d9ce6 )
+	rom ( name "Cruis'n USA (U) (V1.0) [b5].z64" size 8388608 crc 05d10db5 )
+	rom ( name "Cruis'n USA (U) (V1.0) [T+Ita0.40].z64" size 8388608 crc 4512760e )
+	rom ( name "Cruis'n USA (U) (V1.1) [!].z64" size 8388608 crc 4655ba2d )
+	rom ( name "Cruis'n USA (U) (V1.2) [!].z64" size 8388608 crc c3b52701 )
+)
+
+game (
+	name "Cruis'n World"
+	description "Cruis'n World"
+	rom ( name "Cruis'n World (E) [!].z64" size 12582912 crc e46ce079 )
+	rom ( name "Cruis'n World (E) [b1].z64" size 12582912 crc c16d2d71 )
+	rom ( name "Cruis'n World (E) [b2].z64" size 12582912 crc 3b713e52 )
+	rom ( name "Cruis'n World (E) [f1].z64" size 12582912 crc 8df63936 )
+	rom ( name "Cruis'n World (E) [f2].z64" size 12582912 crc 82f27646 )
+	rom ( name "Cruis'n World (E) [f3] (NTSC).z64" size 12582912 crc 248f00c9 )
+	rom ( name "Cruis'n World (U) [!].z64" size 12582912 crc a123769f )
+	rom ( name "Cruis'n World (U) [b1].z64" size 12582912 crc 0274cbfc )
+	rom ( name "Cruis'n World (U) [b2].z64" size 4100096 crc 10109820 )
+	rom ( name "Cruis'n World (U) [b3].z64" size 12582916 crc c30ed9f6 )
+	rom ( name "Cruis'n World (U) [f1].z64" size 12582912 crc 048791c6 )
+	rom ( name "Cruis'n World (U) [o1].z64" size 12582916 crc 35fbeafe )
+)
+
+game (
+	name "Custom Robo"
+	description "Custom Robo"
+	rom ( name "Custom Robo (J) [!].z64" size 16777216 crc f2fae693 )
+)
+
+game (
+	name "Custom Robo V2"
+	description "Custom Robo V2"
+	rom ( name "Custom Robo V2 (J) [!].z64" size 16777216 crc c8201454 )
+)
+
+game (
+	name CyberTiger
+	description "CyberTiger"
+	rom ( name "CyberTiger (E) [!].z64" size 16777216 crc 7319d9af )
+	rom ( name "CyberTiger (U) [!].z64" size 16777216 crc 10cc5f15 )
+)
+
+game (
+	name "Dance Dance Revolution - Disney Dancing Museum"
+	description "Dance Dance Revolution - Disney Dancing Museum"
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [!].z64" size 25165824 crc 3c13fbcf )
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o1].z64" size 33554432 crc 43ee0117 )
+	rom ( name "Dance Dance Revolution - Disney Dancing Museum (J) [o2].z64" size 25690112 crc 0feed8b3 )
+)
+
+game (
+	name "Dark Rift"
+	description "Dark Rift"
+	rom ( name "Dark Rift (E) [!].z64" size 8388608 crc d2a19c71 )
+	rom ( name "Dark Rift (E) [b1].z64" size 8429660 crc 632e1937 )
+	rom ( name "Dark Rift (U) [!].z64" size 8388608 crc 83fd222f )
+	rom ( name "Dark Rift (U) [t1].z64" size 8388608 crc 1329d6bd )
+	rom ( name "Space Dynamites (J) [!].z64" size 8388608 crc 8cb4b948 )
+	rom ( name "Space Dynamites (J) [b1].z64" size 8388608 crc 537d2e2f )
+)
+
+game (
+	name "Deadly Arts"
+	description "Deadly Arts"
+	rom ( name "Deadly Arts (U) [!].z64" size 12582912 crc 3db8130e )
+	rom ( name "Deadly Arts (U) [b1].z64" size 12582912 crc cdecb164 )
+	rom ( name "G.A.S.P!! Fighter's NEXTream (E) [!].z64" size 12582912 crc 5aa63b04 )
+	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [!].z64" size 12582912 crc 6ead2d89 )
+	rom ( name "G.A.S.P!! Fighter's NEXTream (J) [o1].z64" size 16777216 crc f0532eaf )
+)
+
+game (
+	name "Densha de Go! 64"
+	description "Densha de Go! 64"
+	rom ( name "Densha de Go! 64 (J) [!].z64" size 33554432 crc 7bfc71e0 )
+	rom ( name "Densha de Go! 64 (J) [f1] (PAL).z64" size 33554432 crc ffc76f35 )
+)
+
+game (
+	name "Derby Stallion 64"
+	description "Derby Stallion 64"
+	rom ( name "Derby Stallion 64 (J) (Beta).z64" size 33554432 crc 8ec950a9 )
+	rom ( name "Derby Stallion 64 (J) [!].z64" size 33554432 crc a9417994 )
+)
+
+game (
+	name "Destruction Derby 64"
+	description "Destruction Derby 64"
+	rom ( name "Destruction Derby 64 (E) (M3) [!].z64" size 16777216 crc 7ad9e429 )
+	rom ( name "Destruction Derby 64 (U) [!].z64" size 16777216 crc 38f1b5d9 )
+	rom ( name "Destruction Derby 64 (U) [f1] (PAL).z64" size 16777216 crc ed1ac18c )
+	rom ( name "Destruction Derby 64 (U) [t1].z64" size 16777216 crc 60485dfb )
+)
+
+game (
+	name "Dezaemon 3D"
+	description "Dezaemon 3D"
+	rom ( name "Dezaemon 3D (J) [!].z64" size 16777216 crc 9e978488 )
+	rom ( name "Dezaemon 3D (J) [b1].z64" size 12582912 crc 9de8a036 )
+	rom ( name "Dezaemon 3D (J) [b1][t1].z64" size 16777216 crc 9bbad86e )
+	rom ( name "Dezaemon 3D (J) [b2].z64" size 16777216 crc 573b12d2 )
+	rom ( name "Dezaemon 3D (J) [t1].z64" size 16777216 crc 7a615c39 )
+)
+
+game (
+	name "Diddy Kong Racing"
+	description "Diddy Kong Racing"
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [!].z64" size 12582912 crc 4a13323c )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [f1].z64" size 12582912 crc a95a5572 )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.0) [o1].z64" size 16777216 crc 417c71d7 )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [!].z64" size 12582912 crc b1e87639 )
+	rom ( name "Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64).z64" size 12582912 crc 7db6c3e2 )
+	rom ( name "Diddy Kong Racing (J) [f1] (Z64).z64" size 12582912 crc 60bd0e39 )
+	rom ( name "Diddy Kong Racing (J).z64" size 12582912 crc b566fb94 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [!].z64" size 12582912 crc eb759206 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b1].z64" size 16777216 crc c9ef2818 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b2].z64" size 11534336 crc e7f77779 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b3].z64" size 3440640 crc 97e53bd6 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b4].z64" size 11534336 crc 18138847 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b5].z64" size 16777216 crc 5e7aa4bc )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b6].z64" size 12582912 crc f26051dd )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [b7].z64" size 16777216 crc ff62c5e1 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1].z64" size 12582912 crc 52b44e7a )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f1][h1C].z64" size 12582912 crc 173bd1b9 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f2].z64" size 16777216 crc 3bf35f08 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f3].z64" size 12582912 crc 692fe6c3 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [f4].z64" size 12582912 crc f09727f4 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1].z64" size 16777216 crc 36c92d99 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o1][f1].z64" size 16777216 crc fd3dc0d2 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [o2].z64" size 16777216 crc 17ef30ca )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil].z64" size 12582912 crc 7dab6850 )
+	rom ( name "Diddy Kong Racing (U) (M2) (V1.1) [!].z64" size 12582912 crc 5acca298 )
+)
+
+game (
+	name "Disney's Donald Duck - Goin' Quackers"
+	description "Disney's Donald Duck - Goin' Quackers"
+	rom ( name "Disney's Donald Duck - Goin' Quackers (U) [!].z64" size 20971520 crc 7fdec270 )
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [!].z64" size 20971520 crc c4b0d9ea )
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [b1].z64" size 20971520 crc 0097d5cf )
+	rom ( name "Donald Duck - Quack Attack (E) (M5) [f1] (NTSC).z64" size 20971520 crc 18bb3891 )
+)
+
+game (
+	name "Disney's Tarzan"
+	description "Disney's Tarzan"
+	rom ( name "Disney's Tarzan (E) [!].z64" size 16777216 crc 7737ed9e )
+	rom ( name "Disney's Tarzan (E) [h1C].z64" size 16777216 crc b9c1b4da )
+	rom ( name "Disney's Tarzan (F) [!].z64" size 16777216 crc 99c7649d )
+	rom ( name "Disney's Tarzan (G) [!].z64" size 16777216 crc 0b0954c5 )
+	rom ( name "Disney's Tarzan (G) [h1C].z64" size 16777216 crc c5ff0d81 )
+	rom ( name "Disney's Tarzan (U) [!].z64" size 16777216 crc c38ca641 )
+	rom ( name "Disney's Tarzan (U) [f1] (PAL).z64" size 16777216 crc 1f710dbf )
+	rom ( name "Disney's Tarzan (U) [f2] (PAL).z64" size 16777216 crc 19f56474 )
+	rom ( name "Disney's Tarzan (U) [t1].z64" size 16777216 crc 15f5f6b9 )
+)
+
+game (
+	name "Doctor V64 BIOS"
+	description "Doctor V64 BIOS"
+	rom ( name "Doctor V64 BIOS V1.01.bin" size 262144 crc a189032e )
+	rom ( name "Doctor V64 BIOS V1.02.bin" size 262144 crc 4d8c07be )
+	rom ( name "Doctor V64 BIOS V1.03.bin" size 262144 crc c701737c )
+	rom ( name "Doctor V64 BIOS V1.04.bin" size 262144 crc 02367435 )
+	rom ( name "Doctor V64 BIOS V1.05.bin" size 262144 crc 532080b9 )
+	rom ( name "Doctor V64 BIOS V1.08.bin" size 262144 crc 2994d961 )
+	rom ( name "Doctor V64 BIOS V1.09.bin" size 262144 crc 7924f6ce )
+	rom ( name "Doctor V64 BIOS V1.10.bin" size 262144 crc de489e90 )
+	rom ( name "Doctor V64 BIOS V1.10r (RBubba Hack).bin" size 262144 crc 2b8919f0 )
+	rom ( name "Doctor V64 BIOS V1.11.bin" size 262144 crc 61a2d42c )
+	rom ( name "Doctor V64 BIOS V1.21.bin" size 262144 crc f5200388 )
+	rom ( name "Doctor V64 BIOS V1.22.bin" size 262144 crc 8e5050d0 )
+	rom ( name "Doctor V64 BIOS V1.30.bin" size 262144 crc 520238c4 )
+	rom ( name "Doctor V64 BIOS V1.31 (Blue).bin" size 262144 crc 21ec5148 )
+	rom ( name "Doctor V64 BIOS V1.31.bin" size 262144 crc 0c500d9b )
+	rom ( name "Doctor V64 BIOS V1.32.bin" size 262144 crc dad115ef )
+	rom ( name "Doctor V64 BIOS V1.33.bin" size 262144 crc 083a7ccd )
+	rom ( name "Doctor V64 BIOS V1.33b.bin" size 262144 crc 6f4f23df )
+	rom ( name "Doctor V64 BIOS V1.40.bin" size 262144 crc 05a09ee2 )
+	rom ( name "Doctor V64 BIOS V1.40b.bin" size 262144 crc 62d5c1f0 )
+	rom ( name "Doctor V64 BIOS V1.41.bin" size 262144 crc 370e1675 )
+	rom ( name "Doctor V64 BIOS V1.41b.bin" size 262144 crc 507b4967 )
+	rom ( name "Doctor V64 BIOS V1.50.bin" size 262144 crc bc7e2e16 )
+	rom ( name "Doctor V64 BIOS V1.51.bin" size 262144 crc c9ccee6f )
+	rom ( name "Doctor V64 BIOS V1.52 (CH2 Hack).bin" size 262144 crc a2aa3469 )
+	rom ( name "Doctor V64 BIOS V1.52.bin" size 262144 crc 40217611 )
+	rom ( name "Doctor V64 BIOS V1.53.bin" size 262144 crc 7bc1107e )
+	rom ( name "Doctor V64 BIOS V1.60.bin" size 262144 crc ac51f894 )
+	rom ( name "Doctor V64 BIOS V1.61.bin" size 262144 crc a0ab9232 )
+	rom ( name "Doctor V64 BIOS V1.70.bin" size 262144 crc addcebec )
+	rom ( name "Doctor V64 BIOS V1.71.bin" size 262144 crc 4781b044 )
+	rom ( name "Doctor V64 BIOS V1.72.bin" size 262144 crc 624f8950 )
+	rom ( name "Doctor V64 BIOS V1.73.bin" size 262144 crc bde9c452 )
+	rom ( name "Doctor V64 BIOS V1.74 (Revive Version).bin" size 262144 crc 3699334a )
+	rom ( name "Doctor V64 BIOS V1.74.bin" size 262144 crc 5055b5ba )
+	rom ( name "Doctor V64 BIOS V1.75.bin" size 262144 crc 48baf170 )
+	rom ( name "Doctor V64 BIOS V1.76.bin" size 262144 crc 6ce67878 )
+	rom ( name "Doctor V64 BIOS V1.80.bin" size 262144 crc d3c94e60 )
+	rom ( name "Doctor V64 BIOS V1.81.bin" size 262144 crc a463f12f )
+	rom ( name "Doctor V64 BIOS V1.82.bin" size 262144 crc 1e115fd4 )
+	rom ( name "Doctor V64 BIOS V1.83.bin" size 262144 crc d6a8d690 )
+	rom ( name "Doctor V64 BIOS V1.90.bin" size 262144 crc 25d2dd26 )
+	rom ( name "Doctor V64 BIOS V1.91.bin" size 262144 crc 979f7092 )
+	rom ( name "Doctor V64 BIOS V1.92.bin" size 262144 crc fbb5f11c )
+	rom ( name "Doctor V64 BIOS V1.93.bin" size 262144 crc 5133779b )
+	rom ( name "Doctor V64 BIOS V1.94.bin" size 262144 crc d223ce48 )
+	rom ( name "Doctor V64 BIOS V2.00.bin" size 262144 crc 76831784 )
+	rom ( name "Doctor V64 BIOS V2.00b.bin" size 262144 crc 201b503f )
+	rom ( name "Doctor V64 BIOS V2.01 (Red).bin" size 262144 crc 59d5f118 )
+	rom ( name "Doctor V64 BIOS V2.01.bin" size 262144 crc c7d5d511 )
+	rom ( name "Doctor V64 BIOS V2.01b.bin" size 262144 crc 0276da37 )
+	rom ( name "Doctor V64 BIOS V2.02.bin" size 262144 crc 16a08fdc )
+	rom ( name "Doctor V64 BIOS V2.02b.bin" size 262144 crc cc0caf09 )
+	rom ( name "Doctor V64 BIOS V2.03 (Black).bin" size 262144 crc 9e19ff85 )
+	rom ( name "Doctor V64 BIOS V2.03 (Blue).bin" size 262144 crc 07ca4d44 )
+	rom ( name "Doctor V64 BIOS V2.03 (Green).bin" size 262144 crc 8901df22 )
+	rom ( name "Doctor V64 BIOS V2.03 (Purple).bin" size 262144 crc 0dd22dc0 )
+	rom ( name "Doctor V64 BIOS V2.03 (Red).bin" size 262144 crc 4282f00d )
+	rom ( name "Doctor V64 BIOS V2.03.bin" size 262144 crc a37d13af )
+)
+
+game (
+	name "Donkey Kong 64"
+	description "Donkey Kong 64"
+	rom ( name "Donkey Kong 64 (E) [!].z64" size 33554432 crc a28c71c6 )
+	rom ( name "Donkey Kong 64 (E) [b1].z64" size 33554432 crc f33061a5 )
+	rom ( name "Donkey Kong 64 (E) [f1] (Boot&Save).z64" size 33554432 crc bb882fc7 )
+	rom ( name "Donkey Kong 64 (E) [f1] (Save).z64" size 33554432 crc 9bb8700a )
+	rom ( name "Donkey Kong 64 (J) [!].z64" size 33554432 crc 919f7e74 )
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [!].z64" size 33554432 crc c83dfa15 )
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b1].z64" size 33554432 crc ac26933f )
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [b2].z64" size 25165824 crc 0dd55e97 )
+	rom ( name "Donkey Kong 64 (U) (Kiosk Demo) [f1] (PAL).z64" size 33554432 crc 4229dbd9 )
+	rom ( name "Donkey Kong 64 (U) [!].z64" size 33554432 crc d44b4fc6 )
+	rom ( name "Donkey Kong 64 (U) [b1].z64" size 33554432 crc 261b74e9 )
+	rom ( name "Donkey Kong 64 (U) [f1] (Save).z64" size 33554432 crc 15656cba )
+	rom ( name "Donkey Kong 64 (U) [f2].z64" size 33554432 crc b62f126f )
+	rom ( name "Donkey Kong 64 (U) [f3].z64" size 33554432 crc 35bede73 )
+)
+
+game (
+	name "Doom 64"
+	description "Doom 64"
+	rom ( name "Doom 64 (E) [!].z64" size 8388608 crc d985c356 )
+	rom ( name "Doom 64 (E) [b1].z64" size 8388608 crc 010b5830 )
+	rom ( name "Doom 64 (J) [!].z64" size 8388608 crc c8f3af5b )
+	rom ( name "Doom 64 (J) [b1].z64" size 8388608 crc c1dd12a2 )
+	rom ( name "Doom 64 (U) (V1.0) [!].z64" size 8388608 crc 5cc1ade6 )
+	rom ( name "Doom 64 (U) (V1.0) [b1].z64" size 8388612 crc 0d54c0f6 )
+	rom ( name "Doom 64 (U) (V1.0) [b2].z64" size 8388608 crc 0b3d7f30 )
+	rom ( name "Doom 64 (U) (V1.0) [o1].z64" size 16777216 crc de3b18be )
+	rom ( name "Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR].z64" size 10485760 crc 19347e61 )
+	rom ( name "Doom 64 (U) (V1.0) [t1].z64" size 8388608 crc c1909d70 )
+	rom ( name "Doom 64 (U) (V1.0) [t2].z64" size 8388608 crc e0d16283 )
+	rom ( name "Doom 64 (U) (V1.1) [!].z64" size 8388608 crc 1d3a17b5 )
+)
+
+game (
+	name "Doraemon - Nobita to 3tsu no Seireiseki"
+	description "Doraemon - Nobita to 3tsu no Seireiseki"
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [!].z64" size 8388608 crc 154e8b33 )
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b1].z64" size 8388608 crc d5e8b08d )
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b2].z64" size 8388608 crc afe97ca4 )
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [b3].z64" size 8388608 crc eaf14ae6 )
+	rom ( name "Doraemon - Nobita to 3tsu no Seireiseki (J) [t1].z64" size 8388608 crc e31dadbd )
+)
+
+game (
+	name "Doraemon 2 - Nobita to Hikari no Shinden"
+	description "Doraemon 2 - Nobita to Hikari no Shinden"
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [!].z64" size 12582912 crc 0c1a0c38 )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b1].z64" size 12582912 crc 3a0bf1d5 )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [b2].z64" size 12582912 crc 50d15dc8 )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f1] (PAL).z64" size 12582912 crc f3fc6987 )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [f2].z64" size 12582912 crc fd5154ed )
+	rom ( name "Doraemon 2 - Nobita to Hikari no Shinden (J) [t1].z64" size 12582912 crc 5204af6d )
+)
+
+game (
+	name "Doraemon 3 - Nobita no Machi SOS!"
+	description "Doraemon 3 - Nobita no Machi SOS!"
+	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [!].z64" size 16777216 crc d3b68be4 )
+	rom ( name "Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC).z64" size 16777216 crc 92dfe338 )
+)
+
+game (
+	name "Doubutsu no Mori"
+	description "Doubutsu no Mori"
+	rom ( name "Doubutsu no Mori (J) [!].z64" size 16777216 crc 9503e3f1 )
+	rom ( name "Doubutsu no Mori (J) [T+Eng2007-03-22_Brandon Dixon].z64" size 16777216 crc 85b86420 )
+	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-08_Brandon Dixon].z64" size 16777216 crc 09daa322 )
+	rom ( name "Doubutsu no Mori (J) [T-Eng2007-02-09_Brandon Dixon].z64" size 16777216 crc fba629d1 )
+)
+
+game (
+	name "Dr. Mario 64"
+	description "Dr. Mario 64"
+	rom ( name "Dr. Mario 64 (U) [!].z64" size 4194304 crc a4701927 )
+)
+
+game (
+	name "Dual Heroes"
+	description "Dual Heroes"
+	rom ( name "Dual Heroes (E) [!].z64" size 12582912 crc 5a7e226b )
+	rom ( name "Dual Heroes (E) [b1].z64" size 12582912 crc 67d23ce6 )
+	rom ( name "Dual Heroes (E) [b2].z64" size 12582912 crc ef7a7e0b )
+	rom ( name "Dual Heroes (E) [f1] (NTSC).z64" size 12582912 crc 307afa61 )
+	rom ( name "Dual Heroes (J) [!].z64" size 12582912 crc 20f23dde )
+	rom ( name "Dual Heroes (J) [o1].z64" size 16777216 crc 28b291e9 )
+	rom ( name "Dual Heroes (J) [o2].z64" size 16777216 crc 5cb6f46c )
+	rom ( name "Dual Heroes (U) [!].z64" size 12582912 crc d09f4da8 )
+	rom ( name "Dual Heroes (U) [b1].z64" size 12582912 crc 211c0cde )
+)
+
+game (
+	name "Duck Dodgers Starring Daffy Duck"
+	description "Duck Dodgers Starring Daffy Duck"
+	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [!].z64" size 16777216 crc 3177a905 )
+	rom ( name "Duck Dodgers Starring Daffy Duck (U) (M3) [t1].z64" size 16777216 crc 40f0c9d8 )
+	rom ( name "Looney Tunes - Duck Dodgers (E) (M6) [!].z64" size 16777216 crc c61f6bb9 )
+)
+
+game (
+	name "Duke Nukem - ZER0 H0UR"
+	description "Duke Nukem - ZER0 H0UR"
+	rom ( name "Duke Nukem - ZER0 H0UR (E) [!].z64" size 33554432 crc ea82f037 )
+	rom ( name "Duke Nukem - ZER0 H0UR (E) [f1] (NTSC).z64" size 33554432 crc 99efd6cd )
+	rom ( name "Duke Nukem - ZER0 H0UR (F) [!].z64" size 33554432 crc 7ecdfb28 )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [!].z64" size 33554432 crc 9a3258d7 )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b1].z64" size 33555621 crc 5bc8b0d4 )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b2].z64" size 33554454 crc 197b34d9 )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b3].z64" size 33554432 crc bff139c6 )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [b4].z64" size 33554432 crc 06329ecd )
+	rom ( name "Duke Nukem - ZER0 H0UR (U) [t1].z64" size 33554432 crc 50ac825e )
+)
+
+game (
+	name "Duke Nukem 64"
+	description "Duke Nukem 64"
+	rom ( name "Duke Nukem 64 (E) [!].z64" size 8388608 crc 3275adb0 )
+	rom ( name "Duke Nukem 64 (E) [b1].z64" size 8388608 crc cc79fc6f )
+	rom ( name "Duke Nukem 64 (E) [o1].z64" size 33554432 crc 31a5c4be )
+	rom ( name "Duke Nukem 64 (F).z64" size 8388608 crc b9c9f07a )
+	rom ( name "Duke Nukem 64 (U) [!].z64" size 8388608 crc dbfd5a53 )
+	rom ( name "Duke Nukem 64 (U) [b1].z64" size 8650752 crc 9dce8136 )
+	rom ( name "Duke Nukem 64 (U) [b2].z64" size 8650752 crc 6ced6c75 )
+	rom ( name "Duke Nukem 64 (U) [b3].z64" size 33554432 crc 1f18823f )
+	rom ( name "Duke Nukem 64 (U) [h1C].z64" size 8388608 crc bf009e6e )
+	rom ( name "Duke Nukem 64 (U) [o1].z64" size 16777216 crc 20489410 )
+	rom ( name "Duke Nukem 64 (U) [t1].z64" size 8650752 crc 6a42d55d )
+	rom ( name "Duke Nukem 64 (U) [t2].z64" size 8650752 crc 5fdb41a9 )
+	rom ( name "Duke Nukem 64 (U) [t3].z64" size 8650752 crc 55fd0d4f )
+)
+
+game (
+	name "Earthworm Jim 3D"
+	description "Earthworm Jim 3D"
+	rom ( name "Earthworm Jim 3D (E) (M6) [!].z64" size 16777216 crc 61a56330 )
+	rom ( name "Earthworm Jim 3D (E) (M6) [b1].z64" size 16777216 crc e57b20dd )
+	rom ( name "Earthworm Jim 3D (U) [!].z64" size 16777216 crc 9e6579c5 )
+	rom ( name "Earthworm Jim 3D (U) [f1] (PAL).z64" size 16777216 crc 25285541 )
+	rom ( name "Earthworm Jim 3D (U) [hI].z64" size 16777216 crc 92e70880 )
+	rom ( name "Earthworm Jim 3D (U) [T+Rus].z64" size 16777216 crc c548f974 )
+	rom ( name "Earthworm Jim 3D (U) [t1].z64" size 16777216 crc 7d1f1297 )
+)
+
+game (
+	name "ECW Hardcore Revolution"
+	description "ECW Hardcore Revolution"
+	rom ( name "ECW Hardcore Revolution (E) [!].z64" size 33554432 crc be8feead )
+	rom ( name "ECW Hardcore Revolution (E) [b1].z64" size 33554436 crc 7340d982 )
+	rom ( name "ECW Hardcore Revolution (U) [!].z64" size 33554432 crc 36d368ef )
+)
+
+game (
+	name "Eikou no Saint Andrews"
+	description "Eikou no Saint Andrews"
+	rom ( name "Eikou no Saint Andrews (J) [!].z64" size 8388608 crc 1699d2d6 )
+	rom ( name "Eikou no Saint Andrews (J) [b1].z64" size 8388608 crc 2196a2db )
+	rom ( name "Eikou no Saint Andrews (J) [b2].z64" size 8388608 crc c348f53c )
+	rom ( name "Eikou no Saint Andrews (J) [h1C].z64" size 8388608 crc 6acae1f4 )
+	rom ( name "Eikou no Saint Andrews (J) [h2C].z64" size 8388608 crc a281b31f )
+)
+
+game (
+	name "Elmo's Letter Adventure"
+	description "Elmo's Letter Adventure"
+	rom ( name "Elmo's Letter Adventure (U) [!].z64" size 8388608 crc 92c3ba6f )
+)
+
+game (
+	name "Elmo's Number Journey"
+	description "Elmo's Number Journey"
+	rom ( name "Elmo's Number Journey (U) [!].z64" size 8388608 crc ea3b92d8 )
+)
+
+game (
+	name "Excitebike 64"
+	description "Excitebike 64"
+	rom ( name "Excitebike 64 (E) [!].z64" size 16777216 crc 0b881e60 )
+	rom ( name "Excitebike 64 (J) [!].z64" size 16777216 crc 03bfd065 )
+	rom ( name "Excitebike 64 (U) (Kiosk Demo) [!].z64" size 16777216 crc be6298b0 )
+	rom ( name "Excitebike 64 (U) [!].z64" size 16777216 crc fc459192 )
+	rom ( name "Excitebike 64 (U) [b1].z64" size 16777216 crc 60424b3c )
+	rom ( name "Excitebike 64 (U) [f1].z64" size 16777216 crc fbcae6f4 )
+	rom ( name "Excitebike 64 (U) [f2] (Save).z64" size 16777216 crc 53873696 )
+)
+
+game (
+	name Extreme-G
+	description "Extreme-G"
+	rom ( name "Extreme-G (E) (M5) [!].z64" size 8388608 crc 0b71b1ea )
+	rom ( name "Extreme-G (E) (M5) [b1].z64" size 8388608 crc 58d2d3f1 )
+	rom ( name "Extreme-G (E) (M5) [b2].z64" size 8388612 crc 43744fb5 )
+	rom ( name "Extreme-G (E) (M5) [b3].z64" size 8388608 crc 78abccb1 )
+	rom ( name "Extreme-G (E) (M5) [b4].z64" size 8388612 crc 8c017609 )
+	rom ( name "Extreme-G (E) (M5) [h1C].z64" size 8388608 crc 6e828955 )
+	rom ( name "Extreme-G (J) [!].z64" size 8388608 crc 750dc9a7 )
+	rom ( name "Extreme-G (U) [!].z64" size 8388608 crc 04cb74ec )
+	rom ( name "Extreme-G (U) [h1C].z64" size 8388608 crc 27969273 )
+	rom ( name "Extreme-G (U) [o1].z64" size 16777216 crc 4ef0ce44 )
+	rom ( name "Extreme-G (U) [t1].z64" size 8388608 crc 86cc5964 )
+)
+
+game (
+	name "Extreme-G XG2"
+	description "Extreme-G XG2"
+	rom ( name "Extreme-G XG2 (E) (M5) [!].z64" size 12582912 crc 1a57f416 )
+	rom ( name "Extreme-G XG2 (J) [!].z64" size 12582912 crc 7c8a36da )
+	rom ( name "Extreme-G XG2 (U) [!].z64" size 12582912 crc 81a4c28b )
+	rom ( name "Extreme-G XG2 (U) [t1].z64" size 12845056 crc fd7f3393 )
+)
+
+game (
+	name "F-1 Pole Position 64"
+	description "F-1 Pole Position 64"
+	rom ( name "F-1 Pole Position 64 (E) (M3) [!].z64" size 8388608 crc ed750623 )
+	rom ( name "F-1 Pole Position 64 (E) (M3) [b1].z64" size 8388608 crc dea54af5 )
+	rom ( name "F-1 Pole Position 64 (U) (M3) [!].z64" size 8388608 crc 30a24d89 )
+	rom ( name "F-1 Pole Position 64 (U) (M3) [b1].z64" size 8388608 crc af1aecc1 )
+	rom ( name "F-1 Pole Position 64 (U) (M3) [b2].z64" size 8388608 crc c18699ea )
+	rom ( name "F-1 Pole Position 64 (U) (M3) [h1C].z64" size 8388608 crc 50b4bc6c )
+	rom ( name "Human Grand Prix - New Generation (J) [!].z64" size 8388608 crc 31e102e3 )
+	rom ( name "Human Grand Prix - New Generation (J) [b1].z64" size 7602176 crc ecb4cccd )
+	rom ( name "Human Grand Prix - New Generation (J) [o1].z64" size 16777216 crc 23e323fc )
+)
+
+game (
+	name "F-1 World Grand Prix"
+	description "F-1 World Grand Prix"
+	rom ( name "F-1 World Grand Prix (E) [!].z64" size 12582912 crc bebbc6c8 )
+	rom ( name "F-1 World Grand Prix (E) [h1C].z64" size 12582912 crc 9d2b0e08 )
+	rom ( name "F-1 World Grand Prix (F) [!].z64" size 12582912 crc 57cd299d )
+	rom ( name "F-1 World Grand Prix (G) [!].z64" size 12582912 crc 0f1984dc )
+	rom ( name "F-1 World Grand Prix (G) [b1].z64" size 12582912 crc 973f566e )
+	rom ( name "F-1 World Grand Prix (G) [b1][o1].z64" size 16777216 crc f2a26788 )
+	rom ( name "F-1 World Grand Prix (G) [h1C].z64" size 12582912 crc 2c894c1c )
+	rom ( name "F-1 World Grand Prix (G) [o1].z64" size 16777216 crc 7e49cfa2 )
+	rom ( name "F-1 World Grand Prix (G) [o1][h1C].z64" size 16777216 crc 1d800e13 )
+	rom ( name "F-1 World Grand Prix (J) [!].z64" size 12582912 crc f7bacbc3 )
+	rom ( name "F-1 World Grand Prix (J) [h1C].z64" size 12582912 crc d42a0303 )
+	rom ( name "F-1 World Grand Prix (U) [!].z64" size 12582912 crc 7dc9ef2c )
+	rom ( name "F-1 World Grand Prix (U) [h1C].z64" size 12582912 crc c3477307 )
+	rom ( name "F-1 World Grand Prix (U) [h2C].z64" size 12582912 crc 5e5927ec )
+)
+
+game (
+	name "F-1 World Grand Prix II"
+	description "F-1 World Grand Prix II"
+	rom ( name "F-1 World Grand Prix II (E) (M4) [!].z64" size 12582912 crc 803d33df )
+	rom ( name "F-1 World Grand Prix II (E) (M4) [f1] (NTSC).z64" size 12582912 crc be78c19a )
+	rom ( name "F-1 World Grand Prix II (E) (M4) [h1C].z64" size 12582912 crc a3adfb1f )
+)
+
+game (
+	name "F-ZERO Expansion Kit"
+	description "F-ZERO Expansion Kit"
+	rom ( name "F-ZERO Expansion Kit (N64DD).ndd" size 67108864 crc a4a24ab0 )
+)
+
+game (
+	name "F-ZERO X"
+	description "F-ZERO X"
+	rom ( name "F-ZERO X (E) [!].z64" size 16777216 crc 2d6f7e8b )
+	rom ( name "F-ZERO X (E) [b1].z64" size 16777216 crc aef90bc1 )
+	rom ( name "F-ZERO X (E) [b2].z64" size 16777216 crc 3203f697 )
+	rom ( name "F-ZERO X (E) [b3].z64" size 16777216 crc 8c0e80e2 )
+	rom ( name "F-ZERO X (E) [b4].z64" size 16777216 crc c0ebc4d9 )
+	rom ( name "F-ZERO X (E) [f1].z64" size 16777216 crc d925eac7 )
+	rom ( name "F-ZERO X (E) [h1C].z64" size 16777216 crc 7a571a1a )
+	rom ( name "F-ZERO X (J) [!].z64" size 16777216 crc 6b1cef83 )
+	rom ( name "F-ZERO X (J) [b1].z64" size 16777216 crc 190eb759 )
+	rom ( name "F-ZERO X (J) [b2].z64" size 16777216 crc 8561c494 )
+	rom ( name "F-ZERO X (J) [b3].z64" size 16777216 crc 032a013a )
+	rom ( name "F-ZERO X (J) [t1].z64" size 16777216 crc 3f7eec93 )
+	rom ( name "F-ZERO X (U) (DXP Track Pack Hack).z64" size 16777216 crc b25212c7 )
+	rom ( name "F-ZERO X (U) [!].z64" size 16777216 crc 0b561fba )
+	rom ( name "F-ZERO X (U) [f1] (Sex V1.0 Hack).z64" size 16777216 crc 570b39f7 )
+	rom ( name "F-ZERO X (U) [f1] (Sex V1.1 Hack).z64" size 16777216 crc 6ba4df43 )
+	rom ( name "F-ZERO X (U) [f1].z64" size 16777216 crc cb9ced6c )
+	rom ( name "F-ZERO X (U) [f2] (GameShark).z64" size 16777216 crc c82964a8 )
+)
+
+game (
+	name "F1 Racing Championship"
+	description "F1 Racing Championship"
+	rom ( name "F1 Racing Championship (E) (M5) [!].z64" size 16777216 crc 2da744f5 )
+	rom ( name "F1 Racing Championship (E) (M5) [f1] (NTSC).z64" size 16777216 crc 9df5d7a1 )
+)
+
+game (
+	name "Famista 64"
+	description "Famista 64"
+	rom ( name "Famista 64 (J) [!].z64" size 12582912 crc 9fb0e6c9 )
+	rom ( name "Famista 64 (J) [b1].z64" size 12058624 crc 1b41ce74 )
+	rom ( name "Famista 64 (J) [b2].z64" size 16777216 crc 3d41e4a3 )
+	rom ( name "Famista 64 (J) [b3].z64" size 12582912 crc bb94897b )
+	rom ( name "Famista 64 (J) [b4].z64" size 16777216 crc 22341b95 )
+	rom ( name "Famista 64 (J) [b5].z64" size 12058624 crc ad201004 )
+	rom ( name "Famista 64 (J) [b6].z64" size 12582912 crc 6f2515af )
+	rom ( name "Famista 64 (J) [b7].z64" size 12582912 crc fe593e79 )
+	rom ( name "Famista 64 (J) [o1].z64" size 16777216 crc b05b9d06 )
+)
+
+game (
+	name "FIFA - Road to World Cup 98"
+	description "FIFA - Road to World Cup 98"
+	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [!].z64" size 12582912 crc 137cb3cc )
+	rom ( name "FIFA - Road to World Cup 98 (E) (M7) [o1].z64" size 12582912 crc c61307d6 )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [!].z64" size 12582912 crc 28b1221c )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b1].z64" size 12582912 crc 01d31b3c )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b2].z64" size 16777216 crc e3e2a97e )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b3].z64" size 11534336 crc 2b1f7e3f )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [b4].z64" size 12582912 crc 4620b4bb )
+	rom ( name "FIFA - Road to World Cup 98 (U) (M7) [o1].z64" size 16777216 crc 24b60d8f )
+	rom ( name "FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!].z64" size 12582912 crc ae346df6 )
+)
+
+game (
+	name "FIFA 99"
+	description "FIFA 99"
+	rom ( name "FIFA 99 (E) (M8) [!].z64" size 16777216 crc 6eae1e6e )
+	rom ( name "FIFA 99 (E) (M8) [hI].z64" size 16777216 crc 7155e600 )
+	rom ( name "FIFA 99 (U) [!].z64" size 16777216 crc 6b2473a9 )
+	rom ( name "FIFA 99 (U) [b1].z64" size 16777216 crc ffe33a71 )
+)
+
+game (
+	name "FIFA Soccer 64"
+	description "FIFA Soccer 64"
+	rom ( name "FIFA Soccer 64 (E) (M3) [!].z64" size 8388608 crc ae2583fb )
+	rom ( name "FIFA Soccer 64 (E) (M3) [b1].z64" size 8388608 crc 6a991d12 )
+	rom ( name "FIFA Soccer 64 (E) (M3) [o1].z64" size 16777216 crc 5079fdc3 )
+	rom ( name "FIFA Soccer 64 (E) (M3) [o2].z64" size 12582912 crc e97b5d6b )
+	rom ( name "FIFA Soccer 64 (E) (M3) [o3].z64" size 12582912 crc 86fe6e3b )
+	rom ( name "FIFA Soccer 64 (E) (M3) [o4].z64" size 16777216 crc 042e31b2 )
+	rom ( name "FIFA Soccer 64 (U) (M3) [!].z64" size 8388608 crc 57de7cab )
+	rom ( name "FIFA Soccer 64 (U) (M3) [b1].z64" size 7340032 crc 27abec34 )
+	rom ( name "FIFA Soccer 64 (U) (M3) [o1].z64" size 16777216 crc 95ec83d3 )
+)
+
+game (
+	name "Fighter Destiny 2"
+	description "Fighter Destiny 2"
+	rom ( name "Fighter Destiny 2 (U) [!].z64" size 16777216 crc bb2563c6 )
+	rom ( name "Fighter Destiny 2 (U) [f1] (PAL-NTSC).z64" size 16777216 crc ad232e1b )
+	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [!].z64" size 16777216 crc db40a155 )
+	rom ( name "Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL).z64" size 16777216 crc f88089f1 )
+)
+
+game (
+	name "Fighter's Destiny"
+	description "Fighter's Destiny"
+	rom ( name "Fighter's Destiny (E) [!].z64" size 12582912 crc c9225511 )
+	rom ( name "Fighter's Destiny (F) [!].z64" size 12582912 crc 0cc22034 )
+	rom ( name "Fighter's Destiny (G) [!].z64" size 12582912 crc 5052168c )
+	rom ( name "Fighter's Destiny (U) [!].z64" size 12582912 crc f45ea789 )
+	rom ( name "Fighter's Destiny (U) [b1].z64" size 12582912 crc b60bd3af )
+	rom ( name "Fighter's Destiny (U) [o1].z64" size 16777216 crc 845e5a29 )
+	rom ( name "Fighting Cup (J) [!].z64" size 12582912 crc 8a1c261e )
+)
+
+game (
+	name "Fighting Force 64"
+	description "Fighting Force 64"
+	rom ( name "Fighting Force 64 (E) [!].z64" size 16777216 crc 4052c176 )
+	rom ( name "Fighting Force 64 (U) [!].z64" size 16777216 crc 8456841e )
+	rom ( name "Fighting Force 64 (U) [T+Ita_Cattivik66].z64" size 16777216 crc 83b13ee4 )
+	rom ( name "Fighting Force 64 (U) [t1].z64" size 16777216 crc bd748727 )
+	rom ( name "Fighting Force 64 (U) [t1][f1] (PAL).z64" size 16777216 crc b91de407 )
+)
+
+game (
+	name "Flying Dragon"
+	description "Flying Dragon"
+	rom ( name "Flying Dragon (E) [!].z64" size 12582912 crc c3066e59 )
+	rom ( name "Flying Dragon (U) [!].z64" size 12582912 crc 91bc9aeb )
+	rom ( name "Flying Dragon (U) [b1].z64" size 12582912 crc 28adbef4 )
+	rom ( name "Flying Dragon (U) [b2].z64" size 12582912 crc a52e28e6 )
+	rom ( name "Hiryuu no Ken Twin (J) [!].z64" size 12582912 crc ba6a687e )
+	rom ( name "Hiryuu no Ken Twin (J) [h1C].z64" size 12582912 crc ba40793d )
+	rom ( name "Hiryuu no Ken Twin (J) [h2C].z64" size 12582912 crc 09f183c5 )
+	rom ( name "Hiryuu no Ken Twin (J) [h3C].z64" size 12582912 crc faa2d612 )
+)
+
+game (
+	name "Forsaken 64"
+	description "Forsaken 64"
+	rom ( name "Forsaken 64 (E) (M4) [!].z64" size 8388608 crc 5ed736d9 )
+	rom ( name "Forsaken 64 (G) [!].z64" size 8388608 crc 9793abc2 )
+	rom ( name "Forsaken 64 (G) [h1C].z64" size 8388608 crc 7c27cb56 )
+	rom ( name "Forsaken 64 (G) [o1].z64" size 33554432 crc fec081c8 )
+	rom ( name "Forsaken 64 (U) [!].z64" size 8388608 crc 76c4333d )
+	rom ( name "Forsaken 64 (U) [b1].z64" size 7602176 crc cd83b6d6 )
+	rom ( name "Forsaken 64 (U) [t1].z64" size 8388608 crc a7a563d8 )
+	rom ( name "Forsaken 64 (U) [t2].z64" size 8388608 crc f26d2d5d )
+	rom ( name "Forsaken 64 (U) [t3].z64" size 8388608 crc 4dc1cbe3 )
+)
+
+game (
+	name "Fox Sports College Hoops '99"
+	description "Fox Sports College Hoops '99"
+	rom ( name "Fox Sports College Hoops '99 (U) [!].z64" size 12582912 crc 67eaf0f3 )
+	rom ( name "Fox Sports College Hoops '99 (U) [f1] (PAL).z64" size 12582912 crc 43ad9c56 )
+)
+
+game (
+	name "Frogger 2"
+	description "Frogger 2"
+	rom ( name "Frogger 2 (U) (Alpha) [!].z64" size 4194304 crc b0c62957 )
+	rom ( name "Frogger 2 (U) (Alpha) [o1].z64" size 33554432 crc a8f81f39 )
+	rom ( name "Frogger 2 (U) (Alpha) [o2].z64" size 8388608 crc ded56725 )
+)
+
+game (
+	name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou!"
+	description "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou!"
+	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) [!].z64" size 33554432 crc 2aa6d2a1 )
+)
+
+game (
+	name "GameBooster 64"
+	description "GameBooster 64"
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [b1].z64" size 2097152 crc ec7cfd07 )
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl) [f1].z64" size 2097152 crc 3543fae8 )
+	rom ( name "GameBooster 64 V1.1 (NTSC) (Unl).z64" size 262144 crc e0b8edae )
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [b1].z64" size 1310720 crc 0f7c70d3 )
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl) [f1] (Sound).z64" size 2097152 crc 8a4275ff )
+	rom ( name "GameBooster 64 V1.1 (PAL) (Unl).z64" size 262144 crc 35b99bd9 )
+)
+
+game (
+	name "GameShark Pro"
+	description "GameShark Pro"
+	rom ( name "GameShark Pro V2.0 (Unl).z64" size 262144 crc ef9edf87 )
+	rom ( name "GameShark Pro V3.3 (Apr 2000) (Unl) [!].z64" size 262144 crc f1851ebd )
+	rom ( name "GameShark Pro V3.3 (Mar 2000) (Unl) [!].z64" size 262144 crc 7cc07bbc )
+)
+
+game (
+	name "Ganbare Goemon - Mononoke Sugoroku"
+	description "Ganbare Goemon - Mononoke Sugoroku"
+	rom ( name "Ganbare Goemon - Mononoke Sugoroku (J) [!].z64" size 16777216 crc 965c4575 )
+)
+
+game (
+	name "Gauntlet Legends"
+	description "Gauntlet Legends"
+	rom ( name "Gauntlet Legends (E) [!].z64" size 16777216 crc b7b3a489 )
+	rom ( name "Gauntlet Legends (E) [b1].z64" size 16777216 crc 5ae31c93 )
+	rom ( name "Gauntlet Legends (J) [!].z64" size 16777216 crc 8d133db0 )
+	rom ( name "Gauntlet Legends (U) [!].z64" size 16777216 crc 64765e82 )
+	rom ( name "Gauntlet Legends (U) [f1] (PAL).z64" size 16777216 crc 510cb972 )
+)
+
+game (
+	name "Getter Love!!"
+	description "Getter Love!!"
+	rom ( name "Getter Love!! (J) [!].z64" size 12582912 crc 724ecae7 )
+	rom ( name "Getter Love!! (J) [b1].z64" size 12582912 crc 8bd98062 )
+	rom ( name "Getter Love!! (J) [b2].z64" size 12582912 crc 88da17f6 )
+)
+
+game (
+	name "Gex 3 - Deep Cover Gecko"
+	description "Gex 3 - Deep Cover Gecko"
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!].z64" size 33554432 crc a43cb8e4 )
+	rom ( name "Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!].z64" size 33554432 crc 6bc4a056 )
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [!].z64" size 33554432 crc 87a7d099 )
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [f1] (PAL).z64" size 33554432 crc 26c35612 )
+	rom ( name "Gex 3 - Deep Cover Gecko (U) [t1].z64" size 33554432 crc 3aee8310 )
+)
+
+game (
+	name "Gex 64 - Enter the Gecko"
+	description "Gex 64 - Enter the Gecko"
+	rom ( name "Gex 64 - Enter the Gecko (E) [!].z64" size 16777216 crc a7c92bea )
+	rom ( name "Gex 64 - Enter the Gecko (U) [!].z64" size 16777216 crc c545ce80 )
+	rom ( name "Gex 64 - Enter the Gecko (U) [f1] (PAL).z64" size 16777216 crc 5802d207 )
+	rom ( name "Gex 64 - Enter the Gecko (U) [t1].z64" size 16777216 crc dd37073a )
+)
+
+game (
+	name Glover
+	description "Glover"
+	rom ( name "Glover (E) (M3) [!].z64" size 8388608 crc 90eceb4a )
+	rom ( name "Glover (E) (M3) [f1] (NTSC).z64" size 8388608 crc 2ec58e29 )
+	rom ( name "Glover (U) [!].z64" size 8388608 crc f874571c )
+	rom ( name "Glover (U) [b1].z64" size 8388608 crc 98db770d )
+	rom ( name "Glover (U) [b2].z64" size 8388608 crc 537290a5 )
+	rom ( name "Glover (U) [t1].z64" size 8388608 crc 0dffcf4b )
+)
+
+game (
+	name "Goemon's Great Adventure"
+	description "Goemon's Great Adventure"
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!].z64" size 16777216 crc 08c41e0e )
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t1].z64" size 16777216 crc 2fb2d3b1 )
+	rom ( name "Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [t2].z64" size 16777216 crc a5563b90 )
+	rom ( name "Goemon's Great Adventure (U) [!].z64" size 16777216 crc 52d418e1 )
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [!].z64" size 16777216 crc 3502dbbe )
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [hI].z64" size 16777216 crc b153ba15 )
+	rom ( name "Mystical Ninja 2 Starring Goemon (E) (M3) [t1].z64" size 16777216 crc 29965288 )
+)
+
+game (
+	name "Golden Nugget 64"
+	description "Golden Nugget 64"
+	rom ( name "Golden Nugget 64 (U) [!].z64" size 8388608 crc 641885df )
+	rom ( name "Golden Nugget 64 (U) [b1].z64" size 8388608 crc e0b4c1ee )
+	rom ( name "Golden Nugget 64 (U) [b2].z64" size 5996544 crc 4b5fd87a )
+	rom ( name "Golden Nugget 64 (U) [f1] (PAL).z64" size 8388608 crc b5e49d46 )
+	rom ( name "Golden Nugget 64 (U) [h1C].z64" size 8388608 crc 40e74294 )
+)
+
+game (
+	name "GoldenEye 007"
+	description "GoldenEye 007"
+	rom ( name "GoldenEye 007 (E) (Citadel Hack).bin" size 12582912 crc 27dad263 )
+	rom ( name "GoldenEye 007 (E) [!].z64" size 12582912 crc 9ec14aeb )
+	rom ( name "GoldenEye 007 (E) [b1].z64" size 12582912 crc 6833e958 )
+	rom ( name "GoldenEye 007 (E) [h1C].z64" size 12582912 crc e88d9da4 )
+	rom ( name "GoldenEye 007 (E) [t1] (Rapid Fire).z64" size 12582912 crc e0833df2 )
+	rom ( name "GoldenEye 007 (J) [!].z64" size 12582912 crc a6be19dd )
+	rom ( name "GoldenEye 007 (J) [t1] (Rapid Fire).z64" size 12582912 crc 7fbcc907 )
+	rom ( name "GoldenEye 007 (U) (Citadel Hack).bin" size 12582912 crc 6374d7cc )
+	rom ( name "GoldenEye 007 (U) (Frozen Enemies Hack).z64" size 12582912 crc 1eb6869d )
+	rom ( name "GoldenEye 007 (U) (G5 Multi (for backups) Hack).bin" size 12582912 crc 285e8d41 )
+	rom ( name "GoldenEye 007 (U) (G5 Multi Hack).bin" size 12582912 crc 724ecd4b )
+	rom ( name "GoldenEye 007 (U) (God Mode Hack).z64" size 12582912 crc f177aa35 )
+	rom ( name "GoldenEye 007 (U) (No Music Hack).z64" size 12582912 crc a42184fa )
+	rom ( name "GoldenEye 007 (U) (No Power Bar Hack).z64" size 12582912 crc 59b84d17 )
+	rom ( name "GoldenEye 007 (U) (Tetris Hack).bin" size 12582912 crc 89b3eb2b )
+	rom ( name "GoldenEye 007 (U) [!].z64" size 12582912 crc b6330846 )
+	rom ( name "GoldenEye 007 (U) [b1].z64" size 12582912 crc ea2b1826 )
+	rom ( name "GoldenEye 007 (U) [h1C].z64" size 12582912 crc 54858fee )
+	rom ( name "GoldenEye 007 (U) [o1].z64" size 16777216 crc ee36b9ba )
+	rom ( name "GoldenEye 007 (U) [o2].z64" size 16777216 crc d32c4cb3 )
+	rom ( name "GoldenEye 007 (U) [t1] (Rapid Fire).z64" size 12582912 crc fef59913 )
+	rom ( name "GoldenEye 007 (U) [t2].z64" size 12582912 crc 1d5409d0 )
+	rom ( name "GoldenEye 007 (U) [t3] (All Guns Zoom Mode).z64" size 12582912 crc 490f003c )
+)
+
+game (
+	name "GT 64 - Championship Edition"
+	description "GT 64 - Championship Edition"
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [!].z64" size 16777216 crc e272bdf6 )
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b1].z64" size 16777216 crc db1991cd )
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b2].z64" size 16777216 crc 8ad78b91 )
+	rom ( name "City-Tour GP - Zennihon GT Senshuken (J) [b3].z64" size 1540096 crc 946c079d )
+	rom ( name "GT 64 - Championship Edition (E) (M3) [!].z64" size 12582912 crc 6dfb4747 )
+	rom ( name "GT 64 - Championship Edition (E) (M3) [b1].z64" size 12582912 crc b1e2c1d2 )
+	rom ( name "GT 64 - Championship Edition (E) (M3) [f1] (NTSC).z64" size 12582912 crc dc890e2e )
+	rom ( name "GT 64 - Championship Edition (E) (M3) [f2] (NTSC).z64" size 12582912 crc d507b9ab )
+	rom ( name "GT 64 - Championship Edition (U) [!].z64" size 12582912 crc bc627da7 )
+	rom ( name "GT 64 - Championship Edition (U) [b1].z64" size 12582912 crc 1bd55eff )
+)
+
+game (
+	name "Hamster Monogatari 64"
+	description "Hamster Monogatari 64"
+	rom ( name "Hamster Monogatari 64 (J) [!].z64" size 12582912 crc c1d98b78 )
+)
+
+game (
+	name "Harvest Moon 64"
+	description "Harvest Moon 64"
+	rom ( name "Bokujou Monogatari 2 (J) [!].z64" size 16777216 crc f97237c7 )
+	rom ( name "Bokujou Monogatari 2 (J) [b1].z64" size 16777216 crc e9e0c465 )
+	rom ( name "Harvest Moon 64 (U) [!].z64" size 16777216 crc decdc0ad )
+	rom ( name "Harvest Moon 64 (U) [b1].z64" size 16777216 crc a4026e3f )
+	rom ( name "Harvest Moon 64 (U) [f1] (PAL).z64" size 16777216 crc 769e12a2 )
+	rom ( name "Harvest Moon 64 (U) [T+Pol001].z64" size 16777216 crc 06252291 )
+	rom ( name "Harvest Moon 64 (U) [t1].z64" size 17039360 crc e391f319 )
+	rom ( name "Harvest Moon 64 (U) [t1][f1] (PAL-NTSC).z64" size 16811339 crc c2648df7 )
+)
+
+game (
+	name "Heiwa Pachinko World 64"
+	description "Heiwa Pachinko World 64"
+	rom ( name "Heiwa Pachinko World 64 (J) [!].z64" size 8388608 crc 99a427fa )
+	rom ( name "Heiwa Pachinko World 64 (J) [b1].z64" size 8388608 crc c9474abf )
+	rom ( name "Heiwa Pachinko World 64 (J) [b2].z64" size 8388608 crc 90cf7169 )
+	rom ( name "Heiwa Pachinko World 64 (J) [b3].z64" size 16777216 crc 5d34235a )
+	rom ( name "Heiwa Pachinko World 64 (J) [h1C].z64" size 16777216 crc dea145ae )
+	rom ( name "Heiwa Pachinko World 64 (J) [o1].z64" size 16777216 crc ed3b55d8 )
+)
+
+game (
+	name "Hercules - The Legendary Journeys"
+	description "Hercules - The Legendary Journeys"
+	rom ( name "Hercules - The Legendary Journeys (E) (M6) [!].z64" size 16777216 crc b1954b08 )
+	rom ( name "Hercules - The Legendary Journeys (U) [!].z64" size 16777216 crc 4948892b )
+	rom ( name "Hercules - The Legendary Journeys (U) [o1].z64" size 33554432 crc 1c0c079f )
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1] (PAL-NTSC).z64" size 16883918 crc 4a8c19b2 )
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f1][b1].z64" size 16883918 crc 5dab18ec )
+	rom ( name "Hercules - The Legendary Journeys (U) [t1][f2] (PAL-NTSC).z64" size 17039360 crc 6d30e1d2 )
+)
+
+game (
+	name Hexen
+	description "Hexen"
+	rom ( name "Hexen (E) [!].z64" size 8388608 crc 5369efb4 )
+	rom ( name "Hexen (E) [h1C].z64" size 8388608 crc f0899c71 )
+	rom ( name "Hexen (F) [!].z64" size 8388608 crc e373fa31 )
+	rom ( name "Hexen (G) [!].z64" size 8388608 crc e4821c4b )
+	rom ( name "Hexen (G) [h1C].z64" size 8388608 crc b1a8c486 )
+	rom ( name "Hexen (J) [!].z64" size 8388608 crc 571da09a )
+	rom ( name "Hexen (U) [!].z64" size 8388608 crc 1d35e110 )
+	rom ( name "Hexen (U) [b1].z64" size 8388608 crc 1c66bdfe )
+	rom ( name "Hexen (U) [h1C].z64" size 8388608 crc ff80d2fb )
+	rom ( name "Hexen (U) [t1].z64" size 8388608 crc eb25fd56 )
+	rom ( name "Hexen (U) [t2].z64" size 8388608 crc bbe1c15e )
+)
+
+game (
+	name "Hey You, Pikachu!"
+	description "Hey You, Pikachu!"
+	rom ( name "Hey You, Pikachu! (U) [!].z64" size 16777216 crc b18b2734 )
+	rom ( name "Pikachu Genki Dechu (J) [!].z64" size 16777216 crc 3f6245ae )
+	rom ( name "Pikachu Genki Dechu (J) [b1].z64" size 5668864 crc ee4886fa )
+)
+
+game (
+	name "Hot Wheels Turbo Racing"
+	description "Hot Wheels Turbo Racing"
+	rom ( name "Hot Wheels Turbo Racing (E) (M3) [!].z64" size 16777216 crc 850633a7 )
+	rom ( name "Hot Wheels Turbo Racing (E) (M3) [b1].z64" size 16777216 crc e2eb5d7a )
+	rom ( name "Hot Wheels Turbo Racing (U) [!].z64" size 12582912 crc a5c92148 )
+	rom ( name "Hot Wheels Turbo Racing (U) [f1] (PAL).z64" size 12582912 crc e0fd8f22 )
+	rom ( name "Hot Wheels Turbo Racing (U) [t1].z64" size 12582912 crc fff6a4ba )
+)
+
+game (
+	name "Hybrid Heaven"
+	description "Hybrid Heaven"
+	rom ( name "Hybrid Heaven (E) (M3) [!].z64" size 16777216 crc e76627ff )
+	rom ( name "Hybrid Heaven (E) (M3) [b1].z64" size 16777216 crc f5fa7401 )
+	rom ( name "Hybrid Heaven (E) (M3) [f1] (NTSC).z64" size 16777216 crc e8322d68 )
+	rom ( name "Hybrid Heaven (J) [!].z64" size 16777216 crc e769de96 )
+	rom ( name "Hybrid Heaven (J) [b1].z64" size 16777230 crc 47f2dd70 )
+	rom ( name "Hybrid Heaven (J) [f1] (PAL).z64" size 16777216 crc 1d8781dc )
+	rom ( name "Hybrid Heaven (U) [!].z64" size 16777216 crc 15b57ef8 )
+	rom ( name "Hybrid Heaven (U) [f1] (PAL).z64" size 16777216 crc 0d4cbd39 )
+	rom ( name "Hybrid Heaven (U) [t1].z64" size 16777216 crc 478c2604 )
+)
+
+game (
+	name "Hydro Thunder"
+	description "Hydro Thunder"
+	rom ( name "Hydro Thunder (E) [!].z64" size 33554432 crc 863ab8f3 )
+	rom ( name "Hydro Thunder (E) [f1] (NTSC).z64" size 33554432 crc 4da8bd88 )
+	rom ( name "Hydro Thunder (F) [!].z64" size 33554432 crc 010f6242 )
+	rom ( name "Hydro Thunder (U) [!].z64" size 33554432 crc e744456f )
+	rom ( name "Hydro Thunder (U) [b1].z64" size 29360128 crc df1693a6 )
+	rom ( name "Hydro Thunder (U) [b1][f1] (PAL).z64" size 29360128 crc 2856fbfb )
+	rom ( name "Hydro Thunder (U) [b1][t1].z64" size 29360128 crc c0b7026f )
+	rom ( name "Hydro Thunder (U) [b2].z64" size 33554432 crc 8f621adb )
+	rom ( name "Hydro Thunder (U) [b3].z64" size 29360128 crc 87f7ec0d )
+)
+
+game (
+	name "Ide Yosuke no Mahjong Juku"
+	description "Ide Yosuke no Mahjong Juku"
+	rom ( name "Ide Yosuke no Mahjong Juku (J) [!].z64" size 12582912 crc a4a24517 )
+	rom ( name "Ide Yosuke no Mahjong Juku (J) [b1].z64" size 12582912 crc dbd96deb )
+)
+
+game (
+	name "Iggy's Reckin' Balls"
+	description "Iggy's Reckin' Balls"
+	rom ( name "Iggy's Reckin' Balls (E) [!].z64" size 4194304 crc 9bf26065 )
+	rom ( name "Iggy's Reckin' Balls (E) [o1].z64" size 8388608 crc 4f15ce42 )
+	rom ( name "Iggy's Reckin' Balls (U) [!].z64" size 4194304 crc 6a6fbd5d )
+	rom ( name "Iggy's Reckin' Balls (U) [o1].z64" size 8388608 crc 9ec813fb )
+	rom ( name "Iggy-kun no Bura Bura Poyon (J) [!].z64" size 4194304 crc 26cc1266 )
+	rom ( name "Iggy-kun no Bura Bura Poyon (J) [o1].z64" size 8388608 crc 5a67e489 )
+)
+
+game (
+	name "In-Fisherman Bass Hunter 64"
+	description "In-Fisherman Bass Hunter 64"
+	rom ( name "Bass Hunter 64 (E) [!].z64" size 8388608 crc 00da3704 )
+	rom ( name "In-Fisherman Bass Hunter 64 (U) [!].z64" size 8388608 crc d8eb5e6e )
+	rom ( name "In-Fisherman Bass Hunter 64 (U) [f1] (PAL).z64" size 8388608 crc 3d30e44b )
+)
+
+game (
+	name "Indiana Jones and the Infernal Machine"
+	description "Indiana Jones and the Infernal Machine"
+	rom ( name "Indiana Jones and the Infernal Machine (U) [!].z64" size 33554432 crc 4978eb57 )
+)
+
+game (
+	name "Indy Racing 2000"
+	description "Indy Racing 2000"
+	rom ( name "Indy Racing 2000 (U) [!].z64" size 16777216 crc a5163f29 )
+)
+
+game (
+	name "International Superstar Soccer '98"
+	description "International Superstar Soccer '98"
+	rom ( name "International Superstar Soccer '98 (E) [!].z64" size 12582912 crc bf23945d )
+	rom ( name "International Superstar Soccer '98 (U) [!].z64" size 12582912 crc b85fa721 )
+	rom ( name "International Superstar Soccer '98 (U) [o1].z64" size 33554432 crc fff24a88 )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.0) [!].z64" size 16777216 crc 5c721850 )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!].z64" size 16777216 crc 68dbcc04 )
+	rom ( name "Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!].z64" size 16777216 crc f63f9a5e )
+)
+
+game (
+	name "International Superstar Soccer 2000"
+	description "International Superstar Soccer 2000"
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!].z64" size 16777216 crc 69572558 )
+	rom ( name "International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!].z64" size 16777216 crc 8a16a6a9 )
+	rom ( name "International Superstar Soccer 2000 (U) (M2) [!].z64" size 16777216 crc dcd0538f )
+	rom ( name "International Superstar Soccer 2000 (U) (M2) [f1] (PAL).z64" size 16777216 crc 2141dd95 )
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [!].z64" size 16777216 crc 153aeb15 )
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [b1].z64" size 16777216 crc 25fa617f )
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f1] (PAL).z64" size 16777216 crc fff14be7 )
+	rom ( name "Jikkyou J.League 1999 - Perfect Striker 2 (J) [f2] (PAL).z64" size 16777216 crc 71d98830 )
+)
+
+game (
+	name "International Superstar Soccer 64"
+	description "International Superstar Soccer 64"
+	rom ( name "International Superstar Soccer 64 (E) [!].z64" size 8388608 crc 8c839268 )
+	rom ( name "International Superstar Soccer 64 (E) [b1].z64" size 8388608 crc ab19d163 )
+	rom ( name "International Superstar Soccer 64 (E) [b2].z64" size 8388608 crc 4a3bfbbd )
+	rom ( name "International Superstar Soccer 64 (E) [h1C].z64" size 8388608 crc 3a827afc )
+	rom ( name "International Superstar Soccer 64 (E) [h2C].z64" size 8388608 crc 3ff384ef )
+	rom ( name "International Superstar Soccer 64 (U) [!].z64" size 8388608 crc 0ea249b9 )
+	rom ( name "International Superstar Soccer 64 (U) [b1].z64" size 8388608 crc f73e92c6 )
+	rom ( name "International Superstar Soccer 64 (U) [h1C].z64" size 8388608 crc 53fd493e )
+	rom ( name "International Superstar Soccer 64 (U) [h2C].z64" size 8388608 crc 3db7c140 )
+	rom ( name "Jikkyou World Soccer 3 (J) [!].z64" size 8388608 crc 3ba9e644 )
+)
+
+game (
+	name "International Track & Field 2000"
+	description "International Track & Field 2000"
+	rom ( name "Ganbare Nippon! Olympics 2000 (J) [!].z64" size 12582912 crc 73133cd2 )
+	rom ( name "International Track & Field 2000 (U) [!].z64" size 12582912 crc da443f0b )
+	rom ( name "International Track & Field Summer Games (E) (M3) [!].z64" size 12582912 crc b3181ee0 )
+)
+
+game (
+	name "J.League Dynamite Soccer 64"
+	description "J.League Dynamite Soccer 64"
+	rom ( name "J.League Dynamite Soccer 64 (J) [!].z64" size 8388608 crc dc0b2c8f )
+	rom ( name "J.League Dynamite Soccer 64 (J) [b1].z64" size 8388608 crc 6cfffef0 )
+	rom ( name "J.League Dynamite Soccer 64 (J) [b2].z64" size 8388608 crc 3a53cba9 )
+	rom ( name "J.League Dynamite Soccer 64 (J) [b3].z64" size 7864320 crc 03f8518b )
+	rom ( name "J.League Dynamite Soccer 64 (J) [b4].z64" size 8388608 crc 3a78f83e )
+	rom ( name "J.League Dynamite Soccer 64 (J) [h1C].z64" size 8388608 crc eeb3fa9e )
+	rom ( name "J.League Dynamite Soccer 64 (J) [h2C].z64" size 8388608 crc a7372112 )
+	rom ( name "J.League Dynamite Soccer 64 (J) [h3C].z64" size 8388608 crc 0c7df059 )
+)
+
+game (
+	name "J.League Eleven Beat 1997"
+	description "J.League Eleven Beat 1997"
+	rom ( name "J.League Eleven Beat 1997 (J) [b1][h1C].z64" size 8425780 crc c6279f61 )
+	rom ( name "J.League Eleven Beat 1997 (J) [b2][h1C].z64" size 8388608 crc 30d40134 )
+	rom ( name "J.League Eleven Beat 1997 (J) [h1C].z64" size 8388608 crc 1347819a )
+	rom ( name "J.League Eleven Beat 1997 (J).z64" size 8388608 crc 7d0eed6a )
+)
+
+game (
+	name "J.League Live 64"
+	description "J.League Live 64"
+	rom ( name "J.League Live 64 (J) [!].z64" size 8388608 crc 4c536dd7 )
+	rom ( name "J.League Live 64 (J) [b1].z64" size 8388608 crc 741721f4 )
+)
+
+game (
+	name "J.League Tactics Soccer"
+	description "J.League Tactics Soccer"
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [!].z64" size 12582912 crc 976a2d12 )
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [b1].z64" size 12582912 crc 8e05a52d )
+	rom ( name "J.League Tactics Soccer (J) (V1.0) [f1] (PAL).z64" size 12582912 crc 15809231 )
+	rom ( name "J.League Tactics Soccer (J) (V1.1) [!].z64" size 12582912 crc 156e705e )
+)
+
+game (
+	name "Jangou Simulation Mahjong Do 64"
+	description "Jangou Simulation Mahjong Do 64"
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [!].z64" size 8388608 crc d1c1681e )
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b1].z64" size 8388608 crc cf0dc4f6 )
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b2].z64" size 8388608 crc e4e6f7ab )
+	rom ( name "Jangou Simulation Mahjong Do 64 (J) [b3].z64" size 8388608 crc e0511a0e )
+)
+
+game (
+	name Jeopardy!
+	description "Jeopardy!"
+	rom ( name "Jeopardy! (U) [!].z64" size 4194304 crc e739947c )
+	rom ( name "Jeopardy! (U) [h1C].z64" size 4194304 crc 9f14481b )
+	rom ( name "Jeopardy! (U) [o1].z64" size 8388608 crc 8a6a5a0a )
+	rom ( name "Jeopardy! (U) [o1][h1C].z64" size 8388608 crc fd0d1db5 )
+)
+
+game (
+	name "Jeremy McGrath Supercross 2000"
+	description "Jeremy McGrath Supercross 2000"
+	rom ( name "Jeremy McGrath Supercross 2000 (E) [!].z64" size 16777216 crc 5bf42ec4 )
+	rom ( name "Jeremy McGrath Supercross 2000 (U) [!].z64" size 16777216 crc 2a5c9a06 )
+	rom ( name "Jeremy McGrath Supercross 2000 (U) [f1].z64" size 16777216 crc 5e7afdd5 )
+)
+
+game (
+	name "Jet Force Gemini"
+	description "Jet Force Gemini"
+	rom ( name "Jet Force Gemini (E) (M4) [!].z64" size 33554432 crc cfbed88c )
+	rom ( name "Jet Force Gemini (E) (M4) [f1].z64" size 33554432 crc 4909c764 )
+	rom ( name "Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless].z64" size 33554432 crc d81484c8 )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [!].z64" size 33554432 crc fa061b96 )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1].z64" size 29360128 crc 15f91f65 )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f1] (Save).z64" size 29360128 crc dcf40812 )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b1][f2].z64" size 29360128 crc 3e65056c )
+	rom ( name "Jet Force Gemini (U) (Kiosk Demo) [b2].z64" size 29360128 crc df2567cb )
+	rom ( name "Jet Force Gemini (U) [!].z64" size 33554432 crc 6753d5a3 )
+	rom ( name "Jet Force Gemini (U) [b1].z64" size 33672023 crc daacc564 )
+	rom ( name "Jet Force Gemini (U) [b2].z64" size 33554432 crc 83f0cd60 )
+	rom ( name "Star Twins (J) [!].z64" size 33554432 crc 964506ce )
+)
+
+game (
+	name "Jikkyou G1 Stable"
+	description "Jikkyou G1 Stable"
+	rom ( name "Jikkyou G1 Stable (J) [!].z64" size 16777216 crc 0a796c3e )
+	rom ( name "Jikkyou G1 Stable (J) [b1].z64" size 16777216 crc 6a5dbf42 )
+)
+
+game (
+	name "Jikkyou J.League Perfect Striker"
+	description "Jikkyou J.League Perfect Striker"
+	rom ( name "Jikkyou J.League Perfect Striker (J) [!].z64" size 8388608 crc 8ed60dea )
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b1].z64" size 8436170 crc bf55925b )
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b2].z64" size 3670016 crc cec983c4 )
+	rom ( name "Jikkyou J.League Perfect Striker (J) [b3].z64" size 8388608 crc 99d33459 )
+	rom ( name "Jikkyou J.League Perfect Striker (J) [f1] (PAL).z64" size 8388608 crc 70b86019 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001"
+	description "Jikkyou Powerful Pro Yakyuu - Basic Han 2001"
+	rom ( name "Jikkyou Powerful Pro Yakyuu - Basic Han 2001 (J) [!].z64" size 16777216 crc 6a9e24d7 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 2000"
+	description "Jikkyou Powerful Pro Yakyuu 2000"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!].z64" size 16777216 crc 351cde48 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!].z64" size 16777216 crc 753706ef )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 4"
+	description "Jikkyou Powerful Pro Yakyuu 4"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!].z64" size 12582912 crc 480b953e )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1].z64" size 16777216 crc a9cbf551 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b2].z64" size 12582912 crc 7b6c6447 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b3].z64" size 16777216 crc bd96513e )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b4].z64" size 12582912 crc b0b19acd )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b5].z64" size 12582912 crc bc6a43d1 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [o1].z64" size 16777216 crc 3e95d085 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!].z64" size 12582912 crc 40e3ac61 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 5"
+	description "Jikkyou Powerful Pro Yakyuu 5"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [!].z64" size 16777216 crc feec34f6 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [b1].z64" size 16777216 crc 46882289 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f1].z64" size 16777216 crc ecbc4c5a )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 5 (J) [f2] (PAL).z64" size 16777216 crc 3b182dda )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 6"
+	description "Jikkyou Powerful Pro Yakyuu 6"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [!].z64" size 16777216 crc d9329895 )
+	rom ( name "Jikkyou Powerful Pro Yakyuu 6 (J) [b1].z64" size 16777216 crc 1e53a7ba )
+)
+
+game (
+	name "Jinsei Game 64"
+	description "Jinsei Game 64"
+	rom ( name "Jinsei Game 64 (J) [!].z64" size 16777216 crc 67a1a22c )
+	rom ( name "Jinsei Game 64 (J) [f1] (PAL).z64" size 16777216 crc d8087b7f )
+)
+
+game (
+	name "John Romero's Daikatana"
+	description "John Romero's Daikatana"
+	rom ( name "John Romero's Daikatana (E) (M3) [!].z64" size 16777216 crc f88ac3ce )
+	rom ( name "John Romero's Daikatana (E) (M3) [f1] (NTSC).z64" size 16777216 crc 09dd5d1d )
+	rom ( name "John Romero's Daikatana (E) (M3) [h1C].z64" size 16777216 crc 429502c6 )
+	rom ( name "John Romero's Daikatana (J) [!].z64" size 16777216 crc 44b80fd7 )
+	rom ( name "John Romero's Daikatana (U) [!].z64" size 16777216 crc 494950c6 )
+)
+
+game (
+	name "Ken Griffey Jr.'s Slugfest"
+	description "Ken Griffey Jr.'s Slugfest"
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [!].z64" size 16777216 crc 12d8f3e9 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b1].z64" size 16777216 crc 7f4bf06c )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [b2].z64" size 16777216 crc 6a76d40c )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f1].z64" size 16777216 crc 07e5d789 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f2] (PAL).z64" size 16777216 crc 00e8dd96 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f3] (Nosave).z64" size 16777216 crc 28c9ff55 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f4] (Nosave-Z64).z64" size 16777216 crc dddbeb27 )
+	rom ( name "Ken Griffey Jr.'s Slugfest (U) [f5].z64" size 16777216 crc 7846fa73 )
+)
+
+game (
+	name "Killer Instinct Gold"
+	description "Killer Instinct Gold"
+	rom ( name "Killer Instinct Gold (E) [!].z64" size 12582912 crc 5d0ee5d2 )
+	rom ( name "Killer Instinct Gold (E) [o1].z64" size 16777216 crc 896d0b78 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [!].z64" size 12582912 crc 31c76be7 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b1].z64" size 16777216 crc 3c1d7a7b )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b1][t1].z64" size 16778838 crc 5057dd86 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b2].z64" size 17039360 crc 5e0d463c )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b3].z64" size 16778838 crc 3e4bdc51 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b4].z64" size 16778838 crc cb383067 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [b5].z64" size 12582912 crc 00974048 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [o1].z64" size 16777216 crc f2d8ca68 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [o2].z64" size 16777216 crc 2c32d6d5 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [t1].z64" size 17039360 crc ac327ad0 )
+	rom ( name "Killer Instinct Gold (U) (V1.0) [t2].z64" size 16778838 crc a52431b0 )
+	rom ( name "Killer Instinct Gold (U) (V1.1) [!].z64" size 12582912 crc 49ef8f2b )
+	rom ( name "Killer Instinct Gold (U) (V1.1) [o1].z64" size 16777216 crc 79aee5e0 )
+	rom ( name "Killer Instinct Gold (U) (V1.2) [!].z64" size 12582912 crc 0b5b5df8 )
+	rom ( name "Killer Instinct Gold (U) (V1.2) [b1].z64" size 17039360 crc 12b74c51 )
+	rom ( name "Killer Instinct Gold (U) (V1.2) [o1].z64" size 16777216 crc c9e80752 )
+)
+
+game (
+	name "Kira to Kaiketsu! 64 Tanteidan"
+	description "Kira to Kaiketsu! 64 Tanteidan"
+	rom ( name "Kira to Kaiketsu! 64 Tanteidan (J) [!].z64" size 12582912 crc 7fdc3784 )
+)
+
+game (
+	name "Kirby 64 - The Crystal Shards"
+	description "Kirby 64 - The Crystal Shards"
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [!].z64" size 33554432 crc ae7cb69d )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f1].z64" size 33554432 crc 81652a1a )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.0) [f2].z64" size 33554432 crc ae41ba5f )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.1) [!].z64" size 33554432 crc a263c1b9 )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.2) [!].z64" size 33554432 crc f4589aa8 )
+	rom ( name "Hoshi no Kirby 64 (J) (V1.3) [!].z64" size 33554432 crc 6d5e1332 )
+	rom ( name "Kirby 64 - The Crystal Shards (E) [!].z64" size 33554432 crc 5b8b89ef )
+	rom ( name "Kirby 64 - The Crystal Shards (E) [b1].z64" size 33554432 crc 5cd16874 )
+	rom ( name "Kirby 64 - The Crystal Shards (E) [f1].z64" size 33554432 crc 4fe0dadf )
+	rom ( name "Kirby 64 - The Crystal Shards (U) [!].z64" size 33554432 crc 20a1c120 )
+	rom ( name "Kirby 64 - The Crystal Shards (U) [b1].z64" size 33554432 crc 1916876e )
+	rom ( name "Kirby 64 - The Crystal Shards (U) [b2].z64" size 33554432 crc 2033759a )
+	rom ( name "Kirby 64 - The Crystal Shards (U) [f1].z64" size 33554432 crc 5945fe08 )
+	rom ( name "Kirby 64 - The Crystal Shards (U) [t1].z64" size 33554432 crc 910ecf72 )
+)
+
+game (
+	name "Knife Edge - Nose Gunner"
+	description "Knife Edge - Nose Gunner"
+	rom ( name "Knife Edge - Nose Gunner (E) [!].z64" size 8388608 crc b77783be )
+	rom ( name "Knife Edge - Nose Gunner (J) [!].z64" size 8388608 crc 3bc93017 )
+	rom ( name "Knife Edge - Nose Gunner (U) [!].z64" size 8388608 crc 255ee1dd )
+	rom ( name "Knife Edge - Nose Gunner (U) [b1][t1].z64" size 8388608 crc c7bef4e1 )
+	rom ( name "Knife Edge - Nose Gunner (U) [hI].z64" size 8388608 crc 0b2c0d2f )
+	rom ( name "Knife Edge - Nose Gunner (U) [hI][t1].z64" size 8388608 crc 34e8d3cf )
+	rom ( name "Knife Edge - Nose Gunner (U) [t1].z64" size 8388608 crc 1dc1e85d )
+)
+
+game (
+	name "Knockout Kings 2000"
+	description "Knockout Kings 2000"
+	rom ( name "Knockout Kings 2000 (E) [!].z64" size 16777216 crc 58ce7d80 )
+	rom ( name "Knockout Kings 2000 (U) [!].z64" size 16777216 crc 074690d6 )
+	rom ( name "Knockout Kings 2000 (U) [f1] (PAL).z64" size 16777216 crc 2a42b10f )
+)
+
+game (
+	name "Kobe Bryant's NBA Courtside"
+	description "Kobe Bryant's NBA Courtside"
+	rom ( name "Kobe Bryant in NBA Courtside (E) [!].z64" size 12582912 crc 1355a826 )
+	rom ( name "Kobe Bryant in NBA Courtside (E) [f1].z64" size 12582912 crc dc2dcd0b )
+	rom ( name "Kobe Bryant's NBA Courtside (U) [!].z64" size 12582912 crc 86360bfb )
+	rom ( name "Kobe Bryant's NBA Courtside (U) [f1].z64" size 12582912 crc e1fe4b7d )
+	rom ( name "Kobe Bryant's NBA Courtside (U) [h1C].z64" size 12582912 crc 13181cf8 )
+)
+
+game (
+	name "Last Legion UX"
+	description "Last Legion UX"
+	rom ( name "Last Legion UX (J) [!].z64" size 12582912 crc 9db99881 )
+	rom ( name "Last Legion UX (J) [a1].z64" size 12582912 crc c155e137 )
+	rom ( name "Last Legion UX (J) [b1].z64" size 9434802 crc a320e0f0 )
+	rom ( name "Last Legion UX (J) [b2].z64" size 12582912 crc 11260faa )
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask"
+	description "Legend of Zelda, The - Majora's Mask"
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!].z64" size 33554432 crc 9ead1608 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [f1].z64" size 33554432 crc e6104497 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire].z64" size 33554432 crc 323c8ca3 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9e_Vampire].z64" size 33554432 crc 0f5eb553 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9f_Vampire].z64" size 33554432 crc 4cbc60dc )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9M_Vampire].z64" size 33554432 crc 9ef15b1e )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9P1+G_Vampire].z64" size 33554432 crc 8176eb83 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T-Ita0.9Z3_Vampire].z64" size 33554432 crc ff12f3f4 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire].z64" size 33554432 crc 8ebf7691 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1).z64" size 33554432 crc e2e6823d )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) (GC).z64" size 33554432 crc b008458f )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [!].z64" size 33554432 crc b428d8a7 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [f1].z64" size 33554432 crc 5663ba96 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0].z64" size 33554432 crc 1fdf0ceb )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+Rus0.85_Alex].z64" size 33554432 crc be6febf1 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T+RusPreAlpha_Alex&gottax].z64" size 33554432 crc 0131dd2c )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.1_Alex].z64" size 33554432 crc 25cc969c )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.2_Alex].z64" size 33554432 crc 5ded3201 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.36Alex].z64" size 33554432 crc 74747e29 )
+	rom ( name "Legend of Zelda, The - Majora's Mask (U) [T-Rus0.50_Alex].z64" size 33554432 crc 3f53645e )
+	rom ( name "Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!].z64" size 33554432 crc 12836e19 )
+	rom ( name "Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!].z64" size 33554432 crc dcc110a0 )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (GC) [!].z64" size 33554432 crc b9bf76df )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!].z64" size 33554432 crc 0d33e1db )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1].z64" size 33554432 crc a60de571 )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1][o1].z64" size 67108864 crc 749eab8f )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [f1].z64" size 33554432 crc 3be52ccf )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [o1].z64" size 67108864 crc d3ac5f99 )
+	rom ( name "Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!].z64" size 33554432 crc 356c2e19 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time"
+	description "Legend of Zelda, The - Ocarina of Time"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [!].z64" size 33554432 crc 3fbd519f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (GC) [f1].z64" size 33554432 crc 9569957f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!].z64" size 33554432 crc 946fd0f7 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1].z64" size 33554432 crc 658905c6 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f1] (zpfc).z64" size 33554432 crc 1ccaf639 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [f2] (zpc1).z64" size 33554432 crc 4fd78fc5 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.1) [!].z64" size 33554432 crc a108f6e3 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (GC) [!].z64" size 33554432 crc 346de3ae )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack).z64" size 33554432 crc 7d951b34 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!].z64" size 33554432 crc cd16c529 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [b1].z64" size 33554432 crc 8f50bf38 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f1].z64" size 33554432 crc d77a70e8 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f2].z64" size 33554432 crc 1587879b )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [f3].z64" size 33554432 crc 92a0cbfd )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Dut].z64" size 33554432 crc 5307f70b )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Ita100].z64" size 33554432 crc b5d1b588 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Pol1.3].z64" size 33554432 crc 0f6afb03 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.0].z64" size 33554432 crc 3e00d978 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Por1.5BetaFinal].z64" size 33554432 crc 32d72425 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus1.0beta2_Sergey Anton].z64" size 33554432 crc 2174dbfa )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Rus101b2].z64" size 33554432 crc d2b87bdd )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa01b_toruzz].z64" size 33554432 crc a07beb6f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa097b2].z64" size 33554432 crc da6171cd )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa1.0].z64" size 33554432 crc 3e355253 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T+Spa2.0_eduardo_a2j].z64" size 33554432 crc afd60b23 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Pol1.2].z64" size 33554432 crc 92a5b35d )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.09].z64" size 33554432 crc f2cbb79e )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.14].z64" size 33554432 crc 995532c5 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.22].z64" size 33554432 crc 2fe15996 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.26].z64" size 33554432 crc bb45b0bf )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.28].z64" size 33554432 crc 0b86b28e )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.30].z64" size 33554432 crc d9fa73a7 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.33].z64" size 33554432 crc b68ea623 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.35].z64" size 33554432 crc ebdada62 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.37].z64" size 33554432 crc 11031b9f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Por.42].z64" size 33554432 crc 7a7ba9b5 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.01].z64" size 33554432 crc 03e96f36 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.06].z64" size 33554432 crc 01231a9f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus.82].z64" size 33554432 crc 6b4d5fe7 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099bfix].z64" size 33554432 crc 88e7a5b6 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Rus099wip].z64" size 33554432 crc 3c67188a )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.0) [T-Spa1.0_eduardo].z64" size 33554432 crc 38056e6d )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!].z64" size 33554432 crc 3fd2151e )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b1].z64" size 33554432 crc 91649d1b )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [b2].z64" size 33554432 crc 63c8d30f )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100].z64" size 33554432 crc 39070e84 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por1.0].z64" size 33554432 crc 6553c572 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Por100%].z64" size 33554432 crc ae32f542 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Spa01b_toruzz].z64" size 33554432 crc a924a530 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo].z64" size 33554432 crc ae802c75 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T-Spa1.0_eduardo][b1].z64" size 33554432 crc f04bb305 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!].z64" size 33554432 crc 32120c23 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [!].z64" size 33554432 crc 832d6449 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [f1] (NTSC).z64" size 33554432 crc 33ed5939 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [h1C].z64" size 33554432 crc 091d9d5c )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Ita70%_Rulesless].z64" size 33554432 crc b63dcb25 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (E) (GC) [T+Pol1.0].z64" size 33554432 crc ebb2ec57 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f1].z64" size 67108864 crc 9daa2516 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [f2].bin" size 67108864 crc 20ab8205 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version).z64" size 67108864 crc 62f92704 )
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (U) (GC) [!].z64" size 33554432 crc c744c4db )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!].z64" size 33554432 crc d423e8b0 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1].z64" size 33554432 crc 0cb2aa02 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell].z64" size 33554432 crc 5c8e5553 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi].z64" size 33554432 crc 52662e13 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!].z64" size 33554432 crc 26e73887 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!].z64" size 33554432 crc 2b2721ba )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!].z64" size 33554432 crc 8c5b90c1 )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!].z64" size 33554432 crc 1c6ce8cb )
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!].z64" size 33554432 crc 122ff261 )
+)
+
+game (
+	name "LEGO Racers"
+	description "LEGO Racers"
+	rom ( name "LEGO Racers (E) (M10) [!].z64" size 16777216 crc c7d9b21c )
+	rom ( name "LEGO Racers (U) (M10) [!].z64" size 16777216 crc 39407c9f )
+	rom ( name "LEGO Racers (U) (M10) [b1].z64" size 16777216 crc 4d1e1897 )
+	rom ( name "LEGO Racers (U) (M10) [b1][f1] (PAL).z64" size 16777216 crc 194358ef )
+	rom ( name "LEGO Racers (U) (M10) [b1][t1].z64" size 16777216 crc 21599de8 )
+)
+
+game (
+	name "Lode Runner 3-D"
+	description "Lode Runner 3-D"
+	rom ( name "Lode Runner 3-D (E) (M5) [!].z64" size 8388608 crc 7148251d )
+	rom ( name "Lode Runner 3-D (E) (M5) [b1].z64" size 8388608 crc c50c0ccb )
+	rom ( name "Lode Runner 3-D (J) [!].z64" size 8388608 crc 1d4fb466 )
+	rom ( name "Lode Runner 3-D (U) [!].z64" size 8388608 crc 4ea07453 )
+	rom ( name "Lode Runner 3-D (U) [b1][f1] (PAL).z64" size 7864320 crc e799d4be )
+	rom ( name "Lode Runner 3-D (U) [f1] (PAL).z64" size 8388608 crc 0dc54b5b )
+	rom ( name "Lode Runner 3-D (U) [t1].z64" size 8388608 crc 54ffcd02 )
+)
+
+game (
+	name "Lt. Duck Dodgers"
+	description "Lt. Duck Dodgers"
+	rom ( name "Lt. Duck Dodgers (Prototype).z64" size 20971520 crc 7291ba5b )
+)
+
+game (
+	name "Mace - The Dark Age"
+	description "Mace - The Dark Age"
+	rom ( name "Mace - The Dark Age (E) [!].z64" size 12582912 crc 57ddede1 )
+	rom ( name "Mace - The Dark Age (E) [b1].z64" size 12582912 crc d5a1c38c )
+	rom ( name "Mace - The Dark Age (E) [b2].z64" size 12582912 crc 5639e41a )
+	rom ( name "Mace - The Dark Age (E) [o1].z64" size 16777216 crc d09bda9c )
+	rom ( name "Mace - The Dark Age (E) [o2].z64" size 33554432 crc f89b3c8b )
+	rom ( name "Mace - The Dark Age (U) [!].z64" size 12582912 crc d2a363a6 )
+	rom ( name "Mace - The Dark Age (U) [b1].z64" size 12628669 crc c80ddbdc )
+	rom ( name "Mace - The Dark Age (U) [b2].z64" size 12582912 crc e5d6a780 )
+	rom ( name "Mace - The Dark Age (U) [b3].z64" size 16777216 crc da979923 )
+	rom ( name "Mace - The Dark Age (U) [b4].z64" size 12582912 crc 24b74e65 )
+	rom ( name "Mace - The Dark Age (U) [b5].z64" size 12582916 crc c993764f )
+	rom ( name "Mace - The Dark Age (U) [b6].z64" size 12058624 crc c5b79f9a )
+	rom ( name "Mace - The Dark Age (U) [b7].z64" size 16777216 crc 9beb0740 )
+	rom ( name "Mace - The Dark Age (U) [b8].z64" size 12582912 crc 5f6a8b72 )
+	rom ( name "Mace - The Dark Age (U) [b9].z64" size 12582912 crc 799b3ffb )
+	rom ( name "Mace - The Dark Age (U) [o1].z64" size 16777216 crc 12e470a7 )
+)
+
+game (
+	name "Madden Football 64"
+	description "Madden Football 64"
+	rom ( name "Madden Football 64 (E) [!].z64" size 12582912 crc fab3e50d )
+	rom ( name "Madden Football 64 (E) [b1].z64" size 12582912 crc d2100f88 )
+	rom ( name "Madden Football 64 (U) [!].z64" size 12582912 crc 42e5fafa )
+	rom ( name "Madden Football 64 (U) [b1].z64" size 16777216 crc d9addffc )
+	rom ( name "Madden Football 64 (U) [b2].z64" size 12582912 crc 89f3009b )
+	rom ( name "Madden Football 64 (U) [h1C].z64" size 12582912 crc 6a46107f )
+	rom ( name "Madden Football 64 (U) [o1].z64" size 16777216 crc 47226e0c )
+	rom ( name "Madden Football 64 (U) [o1][h1C].z64" size 16777216 crc 7cccb7c5 )
+	rom ( name "Madden Football 64 (U) [o2].z64" size 16777216 crc 563b4710 )
+	rom ( name "Madden Football 64 (U) [o3].z64" size 16777216 crc 225e1692 )
+)
+
+game (
+	name "Madden NFL 2000"
+	description "Madden NFL 2000"
+	rom ( name "Madden NFL 2000 (U) [!].z64" size 12582912 crc ef5f997b )
+)
+
+game (
+	name "Madden NFL 2001"
+	description "Madden NFL 2001"
+	rom ( name "Madden NFL 2001 (U) [!].z64" size 12582912 crc 245eaee8 )
+)
+
+game (
+	name "Madden NFL 2002"
+	description "Madden NFL 2002"
+	rom ( name "Madden NFL 2002 (U) [!].z64" size 12582912 crc f573f107 )
+)
+
+game (
+	name "Madden NFL 99"
+	description "Madden NFL 99"
+	rom ( name "Madden NFL 99 (E) [!].z64" size 12582912 crc d0929942 )
+	rom ( name "Madden NFL 99 (E) [h1C].z64" size 12582912 crc f83173c7 )
+	rom ( name "Madden NFL 99 (U) [!].z64" size 12582912 crc 2eb64fc2 )
+	rom ( name "Madden NFL 99 (U) [o1].z64" size 16777216 crc 06c06c02 )
+)
+
+game (
+	name "Magical Tetris Challenge"
+	description "Magical Tetris Challenge"
+	rom ( name "Defi au Tetris Magique (F) [!].z64" size 16777216 crc e7ef60e8 )
+	rom ( name "Magical Tetris Challenge (E) [!].z64" size 16777216 crc af3b099e )
+	rom ( name "Magical Tetris Challenge (E) [b1].z64" size 16777216 crc 32c5f787 )
+	rom ( name "Magical Tetris Challenge (E) [f1] (NTSC).z64" size 16777216 crc b7d8d550 )
+	rom ( name "Magical Tetris Challenge (G) [!].z64" size 16777216 crc 377f18e9 )
+	rom ( name "Magical Tetris Challenge (U) [!].z64" size 16777216 crc 22fe979c )
+	rom ( name "Magical Tetris Challenge (U) [b1][hI].z64" size 16777216 crc 93acd064 )
+	rom ( name "Magical Tetris Challenge (U) [hI].z64" size 16777216 crc b078e78d )
+	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [!].z64" size 16777216 crc 7efb2f1e )
+	rom ( name "Magical Tetris Challenge Featuring Mickey (J) [b1].z64" size 16777216 crc 4d42abf7 )
+)
+
+game (
+	name "Mahjong 64"
+	description "Mahjong 64"
+	rom ( name "Mahjong 64 (J) [!].z64" size 8388608 crc dbe7d51a )
+	rom ( name "Mahjong 64 (J) [o1].z64" size 16777216 crc a3aac620 )
+	rom ( name "Mahjong 64 (J) [o2].z64" size 16777216 crc aa562908 )
+)
+
+game (
+	name "Mahjong Hourouki Classic"
+	description "Mahjong Hourouki Classic"
+	rom ( name "Mahjong Hourouki Classic (J) [!].z64" size 12582912 crc 990a8e54 )
+	rom ( name "Mahjong Hourouki Classic (J) [b1].z64" size 12582912 crc 9bd30b4b )
+	rom ( name "Mahjong Hourouki Classic (J) [b2].z64" size 8388608 crc ff6afbfe )
+	rom ( name "Mahjong Hourouki Classic (J) [b3].z64" size 12582912 crc de57ca3c )
+)
+
+game (
+	name "Mahjong Master"
+	description "Mahjong Master"
+	rom ( name "Mahjong Master (J) [!].z64" size 8388608 crc b68d596f )
+	rom ( name "Mahjong Master (J) [b1].z64" size 8388608 crc c993c7e5 )
+	rom ( name "Mahjong Master (J) [b2].z64" size 8126464 crc 9bf6fa03 )
+	rom ( name "Mahjong Master (J) [o1].z64" size 8388808 crc e4efe0e0 )
+)
+
+game (
+	name "Major League Baseball Featuring Ken Griffey Jr."
+	description "Major League Baseball Featuring Ken Griffey Jr."
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [!].z64" size 16777216 crc e08f7578 )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [b1].z64" size 16777216 crc ec77ac54 )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (E) [f1].z64" size 16777216 crc a12efecc )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [!].z64" size 16777216 crc 2ef1ea20 )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b1].z64" size 16777216 crc 7ad4bbc9 )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b2].z64" size 16777216 crc 3769a87d )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [b3].z64" size 16777216 crc 7b200444 )
+	rom ( name "Major League Baseball Featuring Ken Griffey Jr. (U) [f1].z64" size 16777216 crc 8ac7208c )
+)
+
+game (
+	name "Mario Golf"
+	description "Mario Golf"
+	rom ( name "Mario Golf (E) [!].z64" size 25165824 crc e5d723c7 )
+	rom ( name "Mario Golf (E) [f1] (Z64-Save).z64" size 33554432 crc 804cf5c2 )
+	rom ( name "Mario Golf (E) [f2] (Z64-Save).z64" size 25165824 crc 5451672f )
+	rom ( name "Mario Golf (E) [h1C].z64" size 25165824 crc 2e71189b )
+	rom ( name "Mario Golf (E) [o1].z64" size 33554432 crc a5071a77 )
+	rom ( name "Mario Golf (E) [o1][h1C].z64" size 33554432 crc 1183b2cb )
+	rom ( name "Mario Golf (U) [!].z64" size 25165824 crc 2d40abb0 )
+	rom ( name "Mario Golf (U) [b1].z64" size 25165824 crc 619f2d0e )
+	rom ( name "Mario Golf (U) [b1][f1] (PAL).z64" size 25165824 crc bf7c03e5 )
+	rom ( name "Mario Golf (U) [b2].z64" size 25165824 crc 353c3ee3 )
+	rom ( name "Mario Golf (U) [f1] (PAL).z64" size 33554432 crc 6ac0859f )
+	rom ( name "Mario Golf (U) [f2] (Z64-Save).z64" size 25165824 crc c705a039 )
+	rom ( name "Mario Golf (U) [o2][h1C].z64" size 33554432 crc 2fc4c216 )
+	rom ( name "Mario Golf (U) [t1].z64" size 25165824 crc 941e1852 )
+	rom ( name "Mario Golf 64 (J) [!].z64" size 25165824 crc 911f179a )
+	rom ( name "Mario Golf 64 (J) [b1].z64" size 33554432 crc 7c33129a )
+	rom ( name "Mario Golf 64 (J) [b1][f1] (PAL).z64" size 25165824 crc 15632a1a )
+	rom ( name "Mario Golf 64 (J) [b2].z64" size 25165824 crc c5995246 )
+	rom ( name "Mario Golf 64 (J) [f1] (PAL).z64" size 33554432 crc bf6ecc62 )
+	rom ( name "Mario Golf 64 (J) [o1].z64" size 33554432 crc bb03a1a6 )
+)
+
+game (
+	name "Mario Kart 64"
+	description "Mario Kart 64"
+	rom ( name "Mario Kart 64 (E) (V1.0) (Super W00ting Hack).z64" size 12582912 crc 27546369 )
+	rom ( name "Mario Kart 64 (E) (V1.0) [!].z64" size 12582912 crc faa6b083 )
+	rom ( name "Mario Kart 64 (E) (V1.0) [b1].z64" size 12582912 crc b0577c8a )
+	rom ( name "Mario Kart 64 (E) (V1.0) [b2].z64" size 12582912 crc ff0eee69 )
+	rom ( name "Mario Kart 64 (E) (V1.0) [T+Ita_Cattivik66].z64" size 12582912 crc d3811840 )
+	rom ( name "Mario Kart 64 (E) (V1.1) [!].z64" size 12582912 crc 0248f6c3 )
+	rom ( name "Mario Kart 64 (E) (V1.1) [o1].z64" size 33554432 crc b27a4098 )
+	rom ( name "Mario Kart 64 (E) (V1.1) [T+Ita_Cattivik66][b1].z64" size 12582912 crc 89fab579 )
+	rom ( name "Mario Kart 64 (J) (V1.0) [!].z64" size 12582912 crc 5d9696df )
+	rom ( name "Mario Kart 64 (J) (V1.0) [b1].z64" size 12582912 crc 0653af29 )
+	rom ( name "Mario Kart 64 (J) (V1.0) [b2].z64" size 12582912 crc 97b054ba )
+	rom ( name "Mario Kart 64 (J) (V1.0) [o1].z64" size 16777216 crc 2d84117a )
+	rom ( name "Mario Kart 64 (J) (V1.0) [T+Ita_Cattivik66][b1].z64" size 12582912 crc 85631d8c )
+	rom ( name "Mario Kart 64 (J) (V1.1) [!].z64" size 12582912 crc 6ced6472 )
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1].z64" size 12582912 crc b3f6f8cc )
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1][f1] (PAL).z64" size 12582912 crc 23ccd780 )
+	rom ( name "Mario Kart 64 (J) (V1.1) [b1][T+Ita_Cattivik66].z64" size 12582912 crc 9bdc5ace )
+	rom ( name "Mario Kart 64 (U) (Super W00ting Hack).z64" size 12582912 crc 87b17d90 )
+	rom ( name "Mario Kart 64 (U) [!].z64" size 12582912 crc 434389c1 )
+	rom ( name "Mario Kart 64 (U) [b1].z64" size 16777216 crc 9ded0ac7 )
+	rom ( name "Mario Kart 64 (U) [b2].z64" size 16777216 crc c98e9d4a )
+	rom ( name "Mario Kart 64 (U) [b3].z64" size 12582912 crc 08e55176 )
+	rom ( name "Mario Kart 64 (U) [b4].z64" size 12582912 crc 8a325af1 )
+	rom ( name "Mario Kart 64 (U) [h1C].z64" size 12582912 crc 89654ba4 )
+	rom ( name "Mario Kart 64 (U) [o1].z64" size 16777216 crc 166d8af1 )
+	rom ( name "Mario Kart 64 (U) [o2].z64" size 13893632 crc 98bd4147 )
+	rom ( name "Mario Kart 64 (U) [T+Ita0.01_Cattivik66].z64" size 12582912 crc f638d5e2 )
+	rom ( name "Mario Kart 64 (U) [T+Por1.0_Dr_X].z64" size 12582912 crc 32c5ec1e )
+	rom ( name "Mario Kart 64 (U) [t1].z64" size 12582912 crc d6161d88 )
+	rom ( name "Mario Kart 64 (U) [t2] (Course Cheat).z64" size 12582912 crc 5f053063 )
+	rom ( name "Mario Kart 64 (U) [t3] (Star Cheat).z64" size 14575980 crc 799a7466 )
+	rom ( name "Mario Kart 64 (U) [t4].z64" size 12582912 crc aa5f37a1 )
+)
+
+game (
+	name "Mario no Photopie"
+	description "Mario no Photopie"
+	rom ( name "Mario no Photopie (J) [!].z64" size 16777216 crc 1d69ca55 )
+	rom ( name "Mario no Photopie (J) [a1].z64" size 16777216 crc 176b3683 )
+)
+
+game (
+	name "Mario Party"
+	description "Mario Party"
+	rom ( name "Mario Party (E) (M3) [!].z64" size 33554432 crc da98a5d3 )
+	rom ( name "Mario Party (E) (M3) [b1].z64" size 33554432 crc 41aca890 )
+	rom ( name "Mario Party (E) (M3) [h1C].z64" size 33554432 crc 7b899fae )
+	rom ( name "Mario Party (J) [!].z64" size 33554432 crc 4f1adc7b )
+	rom ( name "Mario Party (U) [!].z64" size 33554432 crc 4d60abe5 )
+	rom ( name "Mario Party (U) [f1] (PAL).z64" size 33554432 crc c154d3b3 )
+)
+
+game (
+	name "Mario Party 2"
+	description "Mario Party 2"
+	rom ( name "Mario Party 2 (E) (M5) [!].z64" size 33554432 crc dc00357a )
+	rom ( name "Mario Party 2 (J) [!].z64" size 33554432 crc 7457b081 )
+	rom ( name "Mario Party 2 (U) [!].z64" size 33554432 crc e58a1955 )
+	rom ( name "Mario Party 2 (U) [f1] (PAL).z64" size 33554432 crc 08ffb2b3 )
+	rom ( name "Mario Party 2 (U) [f2] (PAL).z64" size 33554432 crc 3677f1bc )
+)
+
+game (
+	name "Mario Party 3"
+	description "Mario Party 3"
+	rom ( name "Mario Party 3 (E) (M4) [!].z64" size 33554432 crc 813b13f2 )
+	rom ( name "Mario Party 3 (J) [!].z64" size 33554432 crc 3fc04053 )
+	rom ( name "Mario Party 3 (U) [!].z64" size 33554432 crc b7445ddc )
+	rom ( name "Mario Party 3 (U) [f1].z64" size 33554432 crc e9a8da8c )
+	rom ( name "Mario Party 3 (U) [f2] (PAL).z64" size 33554432 crc 1e5a8f53 )
+	rom ( name "Mario Party 3 (U) [f3].z64" size 33554432 crc 2cb2b136 )
+)
+
+game (
+	name "Mario Tennis"
+	description "Mario Tennis"
+	rom ( name "Mario Tennis (E) [!].z64" size 16777216 crc 29aa5df4 )
+	rom ( name "Mario Tennis (U) [!].z64" size 16777216 crc 4e9560f6 )
+	rom ( name "Mario Tennis (U) [f1] (Save).z64" size 16777216 crc da72f0d6 )
+	rom ( name "Mario Tennis 64 (J) [!].z64" size 16777216 crc c665301d )
+	rom ( name "Mario Tennis 64 (J) [f1] (Country Check).z64" size 16777216 crc 3653db6a )
+)
+
+game (
+	name "Mega Man 64"
+	description "Mega Man 64"
+	rom ( name "Mega Man 64 (U) [!].z64" size 33554432 crc 1bfc71f0 )
+	rom ( name "Mega Man 64 (U) [t1][f1] (PAL-NTSC).z64" size 33554432 crc f09701ae )
+	rom ( name "Rockman Dash (J) [!].z64" size 33554432 crc 61eaee83 )
+)
+
+game (
+	name "Mia Hamm Soccer 64"
+	description "Mia Hamm Soccer 64"
+	rom ( name "Mia Hamm Soccer 64 (U) (M2) [!].z64" size 16777216 crc 2db3d3d6 )
+)
+
+game (
+	name "Michael Owens WLS 2000"
+	description "Michael Owens WLS 2000"
+	rom ( name "Michael Owens WLS 2000 (E) [!].z64" size 16777216 crc bb680cbe )
+	rom ( name "Michael Owens WLS 2000 (E) [b1].z64" size 16777216 crc 71684224 )
+	rom ( name "Michael Owens WLS 2000 (E) [b2].z64" size 16777216 crc 1dbc7c2d )
+	rom ( name "Michael Owens WLS 2000 (E) [f1] (NTSC).z64" size 17039360 crc 6b919894 )
+	rom ( name "RTL World League Soccer 2000 (G) [!].z64" size 16777216 crc 0a17da7b )
+	rom ( name "RTL World League Soccer 2000 (G) [f1] (NTSC).z64" size 17039360 crc a05d2f1f )
+	rom ( name "RTL World League Soccer 2000 (G) [f1][o1].z64" size 16777216 crc 7abe5f0a )
+	rom ( name "Telefoot Soccer 2000 (F) [!].z64" size 16777216 crc 7bd20931 )
+	rom ( name "Telefoot Soccer 2000 (F) [b1].z64" size 16777216 crc 86d4084b )
+	rom ( name "Telefoot Soccer 2000 (F) [f1] (NTSC).z64" size 17039360 crc 9e830833 )
+)
+
+game (
+	name "Mickey's Speedway USA"
+	description "Mickey's Speedway USA"
+	rom ( name "Mickey no Racing Challenge USA (J) [!].z64" size 33554432 crc 1aecfc56 )
+	rom ( name "Mickey's Speedway USA (E) (M5) [!].z64" size 33554432 crc 0ae51ea5 )
+	rom ( name "Mickey's Speedway USA (U) [!].z64" size 33554432 crc 2d4f8f1b )
+	rom ( name "Mickey's Speedway USA (U) [t1].z64" size 33554432 crc 24858a92 )
+)
+
+game (
+	name "Micro Machines 64 Turbo"
+	description "Micro Machines 64 Turbo"
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [!].z64" size 12582912 crc 10b9ff1f )
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1].z64" size 12582912 crc 5dfe09a6 )
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [b1][f1] (NTSC).z64" size 12582912 crc 33b1cd80 )
+	rom ( name "Micro Machines 64 Turbo (E) (M5) [t1].z64" size 12582912 crc 314eff98 )
+	rom ( name "Micro Machines 64 Turbo (U) [!].z64" size 12582912 crc a62a2763 )
+	rom ( name "Micro Machines 64 Turbo (U) [a1][!].z64" size 12582912 crc 9ad74cef )
+	rom ( name "Micro Machines 64 Turbo (U) [b1].z64" size 12582912 crc aadf1a8b )
+	rom ( name "Micro Machines 64 Turbo (U) [t1].z64" size 12582912 crc b598c181 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits Volume 1"
+	description "Midway's Greatest Arcade Hits Volume 1"
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [!].z64" size 4194304 crc e5c1fedc )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b1].z64" size 4194304 crc 79f93575 )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [b2].z64" size 4194304 crc dc4e9f77 )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1].z64" size 8388608 crc 3adb627e )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [o1][t1].z64" size 8388608 crc 6bbd79f0 )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t1].z64" size 8388608 crc 9f3bc746 )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2].z64" size 8012002 crc a3612c92 )
+	rom ( name "Midway's Greatest Arcade Hits Volume 1 (U) [t2][b1].z64" size 8012002 crc 29c63281 )
+)
+
+game (
+	name "Mike Piazza's Strike Zone"
+	description "Mike Piazza's Strike Zone"
+	rom ( name "Mike Piazza's Strike Zone (U) [!].z64" size 12582912 crc cc253cab )
+	rom ( name "Mike Piazza's Strike Zone (U) [h1C].z64" size 12582912 crc 759df18e )
+	rom ( name "Mike Piazza's Strike Zone (U) [h2C].z64" size 12582912 crc fa1a59ce )
+	rom ( name "Mike Piazza's Strike Zone (U) [h3C].z64" size 12582912 crc 8374c598 )
+)
+
+game (
+	name "Milo's Astro Lanes"
+	description "Milo's Astro Lanes"
+	rom ( name "Milo's Astro Lanes (E) [!].z64" size 4194304 crc c08ce624 )
+	rom ( name "Milo's Astro Lanes (E) [o1].z64" size 8388608 crc 8172b1bd )
+	rom ( name "Milo's Astro Lanes (E) [o2].z64" size 33554432 crc 360fd523 )
+	rom ( name "Milo's Astro Lanes (U) [!].z64" size 4194304 crc 172fca97 )
+	rom ( name "Milo's Astro Lanes (U) [b1].z64" size 4194304 crc 3e898bb3 )
+	rom ( name "Milo's Astro Lanes (U) [h1C].z64" size 8388608 crc 81a075a0 )
+	rom ( name "Milo's Astro Lanes (U) [h2C].z64" size 4194304 crc 0fedf73a )
+	rom ( name "Milo's Astro Lanes (U) [o1].z64" size 8388608 crc dabcc4ee )
+	rom ( name "Milo's Astro Lanes (U) [o1][b1].z64" size 8388608 crc f31a85ca )
+)
+
+game (
+	name "Mischief Makers"
+	description "Mischief Makers"
+	rom ( name "Mischief Makers (E) [!].z64" size 8388608 crc 68a4f072 )
+	rom ( name "Mischief Makers (E) [b1].z64" size 8388608 crc 3c6d6432 )
+	rom ( name "Mischief Makers (U) [!].z64" size 8388608 crc 7d222d3f )
+	rom ( name "Mischief Makers (U) [b1].z64" size 8388608 crc 8a8e05f2 )
+	rom ( name "Mischief Makers (U) [o1].z64" size 16777216 crc 908a11d3 )
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [!].z64" size 8388608 crc b69d3068 )
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [a1].z64" size 8388608 crc e4117eb5 )
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [b1].z64" size 8388608 crc a408b93b )
+	rom ( name "Yuke Yuke!! Trouble Makers (J) [o1].z64" size 16777216 crc 758b4189 )
+)
+
+game (
+	name "Mission Impossible"
+	description "Mission Impossible"
+	rom ( name "Mission Impossible (E) [!].z64" size 12582912 crc 2c7131d6 )
+	rom ( name "Mission Impossible (E) [b1].z64" size 12582912 crc 6b082b2c )
+	rom ( name "Mission Impossible (F) [!].z64" size 12582912 crc 282a350d )
+	rom ( name "Mission Impossible (F) [b1].z64" size 16777216 crc 94c43451 )
+	rom ( name "Mission Impossible (F) [b2].z64" size 12582912 crc 748ebd5b )
+	rom ( name "Mission Impossible (G) [!].z64" size 12582912 crc 67c30a2d )
+	rom ( name "Mission Impossible (I) [!].z64" size 12582912 crc 2d789d98 )
+	rom ( name "Mission Impossible (I) [f1] (NTSC).z64" size 12582912 crc b8da029f )
+	rom ( name "Mission Impossible (S) [!].z64" size 12582912 crc ebb060dc )
+	rom ( name "Mission Impossible (S) [f1] (NTSC).z64" size 12582912 crc e7141756 )
+	rom ( name "Mission Impossible (U) [!].z64" size 12582912 crc 3677a8b8 )
+	rom ( name "Mission Impossible (U) [b1].z64" size 12582912 crc f9b45a0e )
+	rom ( name "Mission Impossible (U) [b2].z64" size 12582912 crc 20530afe )
+	rom ( name "Mission Impossible (U) [f1] (PAL).z64" size 12582912 crc 8e9cbb30 )
+	rom ( name "Mission Impossible (U) [t1].z64" size 12582912 crc 37d8ebf1 )
+)
+
+game (
+	name "Monaco Grand Prix"
+	description "Monaco Grand Prix"
+	rom ( name "Monaco Grand Prix (U) [!].z64" size 16777216 crc e2bbeac1 )
+	rom ( name "Monaco Grand Prix (U) [f1] (PAL).z64" size 16777216 crc e84ac777 )
+	rom ( name "Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!].z64" size 16777216 crc 3f5e5830 )
+	rom ( name "Racing Simulation 2 (G) [!].z64" size 16777216 crc ba73a7e4 )
+	rom ( name "Racing Simulation 2 (G) [h1C].z64" size 16777216 crc 3c85a70b )
+)
+
+game (
+	name Monopoly
+	description "Monopoly"
+	rom ( name "Monopoly (U) [!].z64" size 8388608 crc c8cad8f6 )
+	rom ( name "Monopoly (U) [f1] (PAL).z64" size 8388608 crc 35fd44bd )
+)
+
+game (
+	name "Monster Truck Madness 64"
+	description "Monster Truck Madness 64"
+	rom ( name "Monster Truck Madness 64 (E) (M5) [!].z64" size 8388608 crc 4731df5c )
+	rom ( name "Monster Truck Madness 64 (E) (M5) [f1] (NTSC).z64" size 8388608 crc 1f63fcf2 )
+	rom ( name "Monster Truck Madness 64 (U) [!].z64" size 8388608 crc 3fd0604d )
+	rom ( name "Monster Truck Madness 64 (U) [t1].z64" size 8388608 crc 30502368 )
+)
+
+game (
+	name "Morita Shougi 64"
+	description "Morita Shougi 64"
+	rom ( name "Morita Shougi 64 (J) [!].z64" size 8388608 crc 88c83511 )
+)
+
+game (
+	name "Mortal Kombat 4"
+	description "Mortal Kombat 4"
+	rom ( name "Mortal Kombat 4 (E) [!].z64" size 16777216 crc 635adeca )
+	rom ( name "Mortal Kombat 4 (E) [h1C].z64" size 16777216 crc b1f79756 )
+	rom ( name "Mortal Kombat 4 (E) [t1] (Hit Anywhere).z64" size 16777216 crc 7ea0d2f1 )
+	rom ( name "Mortal Kombat 4 (U) [!].z64" size 16777216 crc b7f46516 )
+	rom ( name "Mortal Kombat 4 (U) [b1].z64" size 16777216 crc 1f5466b1 )
+	rom ( name "Mortal Kombat 4 (U) [b2].z64" size 16777216 crc e44b4a50 )
+	rom ( name "Mortal Kombat 4 (U) [b3].z64" size 15466496 crc 5629d9dc )
+	rom ( name "Mortal Kombat 4 (U) [h1C].z64" size 16777216 crc 65592c8a )
+	rom ( name "Mortal Kombat 4 (U) [t1].z64" size 16777216 crc f0411ee7 )
+	rom ( name "Mortal Kombat 4 (U) [t1][f1] (PAL).z64" size 16777216 crc eb90e97c )
+	rom ( name "Mortal Kombat 4 (U) [t2] (Hit Anywhere).z64" size 16777216 crc ba5f7aba )
+)
+
+game (
+	name "Mortal Kombat Mythologies - Sub-Zero"
+	description "Mortal Kombat Mythologies - Sub-Zero"
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [!].z64" size 16777216 crc ea21015a )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [h1C].z64" size 16777216 crc d974b2d5 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (E) [t1] (Endless Ice).z64" size 16777216 crc 9ecffded )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [!].z64" size 16777216 crc 51a07fd9 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b1].z64" size 16777216 crc 07a1666d )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b2].z64" size 2613248 crc 03e5e2e8 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [b3].z64" size 15728640 crc ab1092fb )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f1].z64" size 16777216 crc e74e2821 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [f3] (PAL).z64" size 16777216 crc d47f76dd )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h1C].z64" size 16777216 crc 796de304 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [h2C].z64" size 16777216 crc 7f31e315 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [o1].z64" size 16769024 crc 56397c81 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t1].z64" size 16777216 crc 751a2b19 )
+	rom ( name "Mortal Kombat Mythologies - Sub-Zero (U) [t2] (Endless Ice).z64" size 16777216 crc 85e4462b )
+)
+
+game (
+	name "Mortal Kombat Trilogy"
+	description "Mortal Kombat Trilogy"
+	rom ( name "Mortal Kombat Trilogy (E) [!].z64" size 12582912 crc bc04c62f )
+	rom ( name "Mortal Kombat Trilogy (E) [b1].z64" size 16777216 crc 05c20375 )
+	rom ( name "Mortal Kombat Trilogy (E) [h1C].z64" size 12582912 crc 110585fb )
+	rom ( name "Mortal Kombat Trilogy (E) [o1].z64" size 16777216 crc f28ed18e )
+	rom ( name "Mortal Kombat Trilogy (E) [t1] (Hit Anywhere).z64" size 12582912 crc 942be6ca )
+	rom ( name "Mortal Kombat Trilogy (E) [t2] (All Attacks Hurt P1).z64" size 12582912 crc ca1756b0 )
+	rom ( name "Mortal Kombat Trilogy (E) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 2a0538c8 )
+	rom ( name "Mortal Kombat Trilogy (E) [t4] (Hyper Mode).z64" size 12582912 crc bf347c36 )
+	rom ( name "Mortal Kombat Trilogy (E) [t5] (2x Aggressor).z64" size 12582912 crc 865fded9 )
+	rom ( name "Mortal Kombat Trilogy (E) [t6] (P1 Invincible).z64" size 12582912 crc 7fa1c269 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [!].z64" size 12582912 crc 50a99d60 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b1].z64" size 8388608 crc a2d599e0 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b2].z64" size 16873070 crc 04b7a1c2 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b3].z64" size 16777216 crc 1cd3f9aa )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b4].z64" size 12582912 crc 0cc21088 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [b5].z64" size 12582912 crc f66d6fc0 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h1C].z64" size 12582912 crc 8a9fb090 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [h2C].z64" size 12582912 crc 241ebd3a )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1].z64" size 16777216 crc 8848ccd8 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h1C].z64" size 16777216 crc 80acf17b )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [o1][h2C].z64" size 16777216 crc 5e190b89 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t1] (Hit Anywhere).z64" size 12582912 crc e89a5e5d )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t2] (All Attacks Hurt P1).z64" size 12582912 crc 9d5a1f62 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 214e58d3 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t4] (Hyper Mode).z64" size 12582912 crc 776a74c3 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t5] (2x Aggressor).z64" size 12582912 crc f760ec0c )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.0) [t6] (P1 Invincible).z64" size 12582912 crc 6ab8d104 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [!].z64" size 12582912 crc 0f323d00 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere).z64" size 12582912 crc 2df614f4 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t2] (All Attacks Hurt P1).z64" size 12582912 crc f73189db )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t3] (All Attacks Hurt P2).z64" size 12582912 crc 4a75dbef )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t4] (Hyper Mode).z64" size 12582912 crc c39464a6 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t5] (2x Aggressor).z64" size 12582912 crc 846a9593 )
+	rom ( name "Mortal Kombat Trilogy (U) (V1.2) [t6] (P1 Invincible).z64" size 12582912 crc 58ca16a1 )
+	rom ( name "Rape Kombat Trilogy Beta1 (Mortal Kombat Hack).z64" size 12582912 crc 9e6bb93d )
+)
+
+game (
+	name "MRC - Multi Racing Championship"
+	description "MRC - Multi Racing Championship"
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [!].z64" size 12582912 crc bc966b10 )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b1].z64" size 16777216 crc 2a7f6b3a )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b2].z64" size 16777216 crc 32df39a3 )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [b3].z64" size 12582912 crc 2e030f26 )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [h1C].z64" size 12582912 crc 4faca987 )
+	rom ( name "MRC - Multi Racing Championship (E) (M3) [o1].z64" size 16777216 crc 89d3ab70 )
+	rom ( name "MRC - Multi Racing Championship (J) [!].z64" size 12582912 crc bea43300 )
+	rom ( name "MRC - Multi Racing Championship (J) [b1].z64" size 16777216 crc cc67323b )
+	rom ( name "MRC - Multi Racing Championship (J) [b2].z64" size 12582912 crc 772f3e51 )
+	rom ( name "MRC - Multi Racing Championship (J) [b3].z64" size 16777216 crc e75e186d )
+	rom ( name "MRC - Multi Racing Championship (J) [b4].z64" size 12582912 crc a0cb84f1 )
+	rom ( name "MRC - Multi Racing Championship (J) [b5].z64" size 12582912 crc 5d3113eb )
+	rom ( name "MRC - Multi Racing Championship (U) [!].z64" size 12582912 crc 1dc1c812 )
+	rom ( name "MRC - Multi Racing Championship (U) [b1].z64" size 8107444 crc f5a9068f )
+	rom ( name "MRC - Multi Racing Championship (U) [b2].z64" size 12574720 crc 0d186242 )
+	rom ( name "MRC - Multi Racing Championship (U) [b3].z64" size 12582912 crc 1f56a884 )
+	rom ( name "MRC - Multi Racing Championship (U) [o1].z64" size 16777216 crc e406a452 )
+)
+
+game (
+	name "Ms. Pac-Man - Maze Madness"
+	description "Ms. Pac-Man - Maze Madness"
+	rom ( name "Ms. Pac-Man - Maze Madness (U) [!].z64" size 12582912 crc e34c7060 )
+)
+
+game (
+	name "Mystical Ninja Starring Goemon"
+	description "Mystical Ninja Starring Goemon"
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b1].z64" size 16777216 crc 4c40eb14 )
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [b2].z64" size 16777216 crc 911b3ce5 )
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C].z64" size 16777216 crc 95c9da86 )
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [h1C][t1].z64" size 16777216 crc c059bef1 )
+	rom ( name "Ganbare Goemon - Neo Momoyama Bakufu no Odori (J).z64" size 16777216 crc 2e91efc9 )
+	rom ( name "Mystical Ninja Starring Goemon (E) [!].z64" size 16777216 crc 3bd9059a )
+	rom ( name "Mystical Ninja Starring Goemon (E) [b1].z64" size 16777216 crc 266b1f56 )
+	rom ( name "Mystical Ninja Starring Goemon (E) [h1C].z64" size 16777216 crc fc486459 )
+	rom ( name "Mystical Ninja Starring Goemon (E) [t1].z64" size 16777216 crc 7a0c2406 )
+	rom ( name "Mystical Ninja Starring Goemon (U) [!].z64" size 16777216 crc 4180c296 )
+	rom ( name "Mystical Ninja Starring Goemon (U) [h1C].z64" size 16777216 crc 8611a355 )
+	rom ( name "Mystical Ninja Starring Goemon (U) [t1].z64" size 16777216 crc ffda5261 )
+	rom ( name "Mystical Ninja Starring Goemon (U) [t1][h2C].z64" size 16777216 crc d5280782 )
+	rom ( name "Mystical Ninja Starring Goemon (U) [t2].z64" size 16777216 crc 48a584de )
+)
+
+game (
+	name "N64DD IPLROM"
+	description "N64DD IPLROM"
+	rom ( name "N64DD IPLROM (J).n64" size 4194304 crc 7f933ce2 )
+)
+
+game (
+	name "Nagano Winter Olympics '98"
+	description "Nagano Winter Olympics '98"
+	rom ( name "Hyper Olympics Nagano 64 (J) [!].z64" size 12582912 crc c1ea5d33 )
+	rom ( name "Hyper Olympics Nagano 64 (J) [b1].z64" size 16777216 crc b6bb1bf7 )
+	rom ( name "Hyper Olympics Nagano 64 (J) [b2].z64" size 12320768 crc f1865c1b )
+	rom ( name "Hyper Olympics Nagano 64 (J) [b3].z64" size 12582912 crc 8d9ca6e8 )
+	rom ( name "Hyper Olympics Nagano 64 (J) [o1].z64" size 16777216 crc e50ede25 )
+	rom ( name "Nagano Winter Olympics '98 (E) [!].z64" size 12582912 crc c44de11c )
+	rom ( name "Nagano Winter Olympics '98 (E) [h1C].z64" size 12582912 crc 9bfba6c3 )
+	rom ( name "Nagano Winter Olympics '98 (E) [o1].z64" size 16777216 crc 13fb3b46 )
+	rom ( name "Nagano Winter Olympics '98 (U) [!].z64" size 12582912 crc ee8288d4 )
+	rom ( name "Nagano Winter Olympics '98 (U) [b1].z64" size 12582912 crc 2034b668 )
+	rom ( name "Nagano Winter Olympics '98 (U) [b2].z64" size 12320768 crc cfe4f4ad )
+	rom ( name "Nagano Winter Olympics '98 (U) [h1C].z64" size 12582912 crc b70fa5b8 )
+	rom ( name "Nagano Winter Olympics '98 (U) [o1].z64" size 16777216 crc bc27f178 )
+	rom ( name "Nagano Winter Olympics '98 (U) [o2].z64" size 16777216 crc 026db3c7 )
+	rom ( name "Nagano Winter Olympics '98 (U) [T+Ita_HRG].z64" size 12582912 crc 24838711 )
+)
+
+game (
+	name "Namco Museum 64"
+	description "Namco Museum 64"
+	rom ( name "Namco Museum 64 (U) [!].z64" size 4194304 crc ce361f92 )
+	rom ( name "Namco Museum 64 (U) [f1] (PAL).z64" size 8388608 crc a4ec448b )
+	rom ( name "Namco Museum 64 (U) [o1].z64" size 8388608 crc 843d5802 )
+	rom ( name "Namco Museum 64 (U) [o1][f1] (PAL).z64" size 8388608 crc d76c2fbf )
+	rom ( name "Namco Museum 64 (U) [t1].z64" size 4194304 crc e3cc9ea8 )
+)
+
+game (
+	name "NASCAR 2000"
+	description "NASCAR 2000"
+	rom ( name "NASCAR 2000 (U) [!].z64" size 12582912 crc 02bf7c2d )
+	rom ( name "NASCAR 2000 (U) [f1] (PAL).z64" size 12582912 crc 83bdd48a )
+)
+
+game (
+	name "NASCAR 99"
+	description "NASCAR 99"
+	rom ( name "NASCAR 99 (E) (M3) [!].z64" size 12582912 crc 76e79cea )
+	rom ( name "NASCAR 99 (E) (M3) [h1C].z64" size 12582912 crc 5e44766f )
+	rom ( name "NASCAR 99 (U) [!].z64" size 12582912 crc 3d8eb950 )
+	rom ( name "NASCAR 99 (U) [b1].z64" size 12582912 crc 982b5ccd )
+	rom ( name "NASCAR 99 (U) [b2].z64" size 12582912 crc 28df02b4 )
+	rom ( name "NASCAR 99 (U) [b3].z64" size 12582912 crc 1f3774e6 )
+	rom ( name "NASCAR 99 (U) [f1] (PAL).z64" size 12582912 crc b1183fe4 )
+	rom ( name "NASCAR 99 (U) [o1].z64" size 16777216 crc a948f28c )
+)
+
+game (
+	name "NBA Courtside 2 - Featuring Kobe Bryant"
+	description "NBA Courtside 2 - Featuring Kobe Bryant"
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [!].z64" size 16777216 crc a7cc4ce2 )
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL).z64" size 16777216 crc 39154eb0 )
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [f2].z64" size 16777216 crc 81f2b85b )
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI].z64" size 16777216 crc 4f3e62dc )
+	rom ( name "NBA Courtside 2 - Featuring Kobe Bryant (U) [hI][f1] (PAL).z64" size 16777216 crc 13bc6d87 )
+)
+
+game (
+	name "NBA Hangtime"
+	description "NBA Hangtime"
+	rom ( name "NBA Hangtime (E) [!].z64" size 12582912 crc 7e6d00ae )
+	rom ( name "NBA Hangtime (E) [h1C].z64" size 12582912 crc 69328df0 )
+	rom ( name "NBA Hangtime (U) [!].z64" size 12582912 crc 714cf532 )
+	rom ( name "NBA Hangtime (U) [b1].z64" size 12582912 crc 0f2126a5 )
+	rom ( name "NBA Hangtime (U) [b2].z64" size 16777216 crc 0027d41f )
+	rom ( name "NBA Hangtime (U) [b3].z64" size 12582912 crc 975dd6cb )
+	rom ( name "NBA Hangtime (U) [f1] (PAL).z64" size 16777216 crc e7e8ef6c )
+	rom ( name "NBA Hangtime (U) [o1].z64" size 16777216 crc 2590c84e )
+	rom ( name "NBA Hangtime (U) [o1][f1].z64" size 12582912 crc 0eb4eba0 )
+)
+
+game (
+	name "NBA In the Zone '98"
+	description "NBA In the Zone '98"
+	rom ( name "NBA In the Zone '98 (J) [!].z64" size 12582912 crc aed2700a )
+	rom ( name "NBA In the Zone '98 (J) [o1].z64" size 16777216 crc 6e35773e )
+	rom ( name "NBA In the Zone '98 (J) [o2].z64" size 16777216 crc 093ec0fb )
+	rom ( name "NBA In the Zone '98 (U) [!].z64" size 12582912 crc a245d737 )
+	rom ( name "NBA In the Zone '98 (U) [b1].z64" size 16777216 crc 8b5dc438 )
+	rom ( name "NBA In the Zone '98 (U) [b2].z64" size 6946816 crc dbe6eccd )
+	rom ( name "NBA In the Zone '98 (U) [b3].z64" size 16752472 crc fef7e360 )
+	rom ( name "NBA In the Zone '98 (U) [h1C].z64" size 16777216 crc 6f4d6051 )
+	rom ( name "NBA In the Zone '98 (U) [h2C].z64" size 12582912 crc 878878ea )
+	rom ( name "NBA In the Zone '98 (U) [o1].z64" size 16777216 crc d30de54f )
+	rom ( name "NBA Pro 98 (E) [!].z64" size 12582912 crc 04b75ccc )
+)
+
+game (
+	name "NBA In the Zone '99"
+	description "NBA In the Zone '99"
+	rom ( name "NBA In the Zone '99 (U) [!].z64" size 12582912 crc eab083b8 )
+	rom ( name "NBA In the Zone 2 (J) [!].z64" size 12582912 crc 41093b73 )
+	rom ( name "NBA Pro 99 (E) [!].z64" size 12582912 crc 588e60e8 )
+	rom ( name "NBA Pro 99 (E) [f1] (NTSC).z64" size 12582912 crc dfd7b539 )
+)
+
+game (
+	name "NBA In the Zone 2000"
+	description "NBA In the Zone 2000"
+	rom ( name "NBA In the Zone 2000 (E) [!].z64" size 16777216 crc a4973197 )
+	rom ( name "NBA In the Zone 2000 (E) [h1C].z64" size 16777216 crc 9e6568a5 )
+	rom ( name "NBA In the Zone 2000 (U) [!].z64" size 16777216 crc cbb4b730 )
+	rom ( name "NBA In the Zone 2000 (U) [f1] (PAL).z64" size 16777216 crc e5956e4c )
+)
+
+game (
+	name "NBA Jam 2000"
+	description "NBA Jam 2000"
+	rom ( name "NBA Jam 2000 (E) [!].z64" size 16777216 crc 9f95485e )
+	rom ( name "NBA Jam 2000 (U) [!].z64" size 16777216 crc 163dadf9 )
+	rom ( name "NBA Jam 2000 (U) [f1] (PAL).z64" size 16777216 crc 18914b4f )
+)
+
+game (
+	name "NBA Jam 99"
+	description "NBA Jam 99"
+	rom ( name "NBA Jam 99 (E) [!].z64" size 12582912 crc 90e4275b )
+	rom ( name "NBA Jam 99 (E) [h1C].z64" size 12582912 crc f76d0149 )
+	rom ( name "NBA Jam 99 (U) [!].z64" size 12582912 crc 559cd6b1 )
+	rom ( name "NBA Jam 99 (U) [b1].z64" size 12582912 crc af017390 )
+	rom ( name "NBA Jam 99 (U) [f1] (PAL).z64" size 12582912 crc babdb2b6 )
+)
+
+game (
+	name "NBA Live 2000"
+	description "NBA Live 2000"
+	rom ( name "NBA Live 2000 (E) (M4) [!].z64" size 16777216 crc 0e4b944c )
+	rom ( name "NBA Live 2000 (U) (M4) [!].z64" size 16777216 crc 7c3bc95e )
+)
+
+game (
+	name "NBA Live 99"
+	description "NBA Live 99"
+	rom ( name "NBA Live 99 (E) (M5) [!].z64" size 16777216 crc a316df37 )
+	rom ( name "NBA Live 99 (U) (M5) [!].z64" size 16777216 crc 9be0a7ac )
+	rom ( name "NBA Live 99 (U) (M5) [b1].z64" size 16777216 crc f5ca13c9 )
+	rom ( name "NBA Live 99 (U) (M5) [b2].z64" size 16777216 crc eea737e2 )
+	rom ( name "NBA Live 99 (U) (M5) [b3].z64" size 16777216 crc 2544b74b )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC"
+	description "NBA Showtime - NBA on NBC"
+	rom ( name "NBA Showtime - NBA on NBC (U) [!].z64" size 16777216 crc a4e378f4 )
+	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (Country Check).z64" size 16777216 crc a8ef96b3 )
+	rom ( name "NBA Showtime - NBA on NBC (U) [f1] (PAL).z64" size 16777216 crc 2d2a5374 )
+)
+
+game (
+	name "Neon Genesis Evangelion"
+	description "Neon Genesis Evangelion"
+	rom ( name "Neon Genesis Evangelion (J) [!].z64" size 33554432 crc a10a86af )
+	rom ( name "Neon Genesis Evangelion (J) [b1].z64" size 33554432 crc 50c86364 )
+	rom ( name "Neon Genesis Evangelion (J) [b2].z64" size 31317000 crc 960855f8 )
+	rom ( name "Neon Genesis Evangelion (J) [b3].z64" size 33554432 crc 283ba9ba )
+	rom ( name "Neon Genesis Evangelion (J) [f1] (PAL).z64" size 33554432 crc e718d433 )
+)
+
+game (
+	name "New Tetris, The"
+	description "New Tetris, The"
+	rom ( name "New Tetris, The (E) [!].z64" size 12582912 crc 983263d7 )
+	rom ( name "New Tetris, The (U) [!].z64" size 12582912 crc 528a07fa )
+	rom ( name "New Tetris, The (U) [f1] (PAL).z64" size 12582912 crc 335530e4 )
+	rom ( name "New Tetris, The (U) [f2] (PAL).z64" size 12582912 crc d9242d9f )
+	rom ( name "New Tetris, The (U) [f3] (PAL).z64" size 12582912 crc 2b5cae1e )
+	rom ( name "Tetris 64 (J) [!].z64" size 8388608 crc f128cd17 )
+	rom ( name "Tetris 64 (J) [b1].z64" size 8388608 crc 4d282f22 )
+	rom ( name "Tetris 64 (J) [b2].z64" size 8388608 crc 17050b7d )
+	rom ( name "Tetris 64 (J) [T+Ita].z64" size 8388608 crc ad0d86d9 )
+)
+
+game (
+	name "NFL Blitz"
+	description "NFL Blitz"
+	rom ( name "NFL Blitz (U) [!].z64" size 16777216 crc 9bcd670f )
+	rom ( name "NFL Blitz (U) [f1] (PAL).z64" size 16777216 crc adfdb71e )
+)
+
+game (
+	name "NFL Blitz - Special Edition"
+	description "NFL Blitz - Special Edition"
+	rom ( name "NFL Blitz - Special Edition (U) [!].z64" size 16777216 crc 5d1907f7 )
+)
+
+game (
+	name "NFL Blitz 2000"
+	description "NFL Blitz 2000"
+	rom ( name "NFL Blitz 2000 (U) [!].z64" size 16777216 crc 7f471773 )
+	rom ( name "NFL Blitz 2000 (U) [f1] (PAL).z64" size 16777216 crc cfa472f3 )
+)
+
+game (
+	name "NFL Blitz 2001"
+	description "NFL Blitz 2001"
+	rom ( name "NFL Blitz 2001 (U) [!].z64" size 16777216 crc 18eeb41b )
+	rom ( name "NFL Blitz 2001 (U) [f1] (PAL-NTSC).z64" size 16777216 crc 02012098 )
+)
+
+game (
+	name "NFL Quarterback Club 2000"
+	description "NFL Quarterback Club 2000"
+	rom ( name "NFL Quarterback Club 2000 (E) [!].z64" size 12582912 crc ceef5c29 )
+	rom ( name "NFL Quarterback Club 2000 (U) [!].z64" size 12582912 crc 8f54f999 )
+	rom ( name "NFL Quarterback Club 2000 (U) [b1].z64" size 12581403 crc 1a7b61bf )
+	rom ( name "NFL Quarterback Club 2000 (U) [b2].z64" size 12582912 crc fff3b2df )
+)
+
+game (
+	name "NFL Quarterback Club 2001"
+	description "NFL Quarterback Club 2001"
+	rom ( name "NFL Quarterback Club 2001 (U) [!].z64" size 12582912 crc 6d849e17 )
+)
+
+game (
+	name "NFL Quarterback Club 98"
+	description "NFL Quarterback Club 98"
+	rom ( name "NFL Quarterback Club 98 (E) [!].z64" size 8388608 crc 34a21417 )
+	rom ( name "NFL Quarterback Club 98 (E) [o1].z64" size 16777216 crc 4da5b881 )
+	rom ( name "NFL Quarterback Club 98 (U) [!].z64" size 8388608 crc abf0e8f2 )
+	rom ( name "NFL Quarterback Club 98 (U) [b1].z64" size 8388608 crc a34d7669 )
+	rom ( name "NFL Quarterback Club 98 (U) [o1].z64" size 16777216 crc 8244762b )
+)
+
+game (
+	name "NFL Quarterback Club 99"
+	description "NFL Quarterback Club 99"
+	rom ( name "NFL Quarterback Club 99 (E) [!].z64" size 12582912 crc f688bdf3 )
+	rom ( name "NFL Quarterback Club 99 (E) [b1].z64" size 12582912 crc 579b3a20 )
+	rom ( name "NFL Quarterback Club 99 (U) [!].z64" size 12582912 crc 44496b26 )
+)
+
+game (
+	name "NHL 99"
+	description "NHL 99"
+	rom ( name "NHL 99 (E) [!].z64" size 12582912 crc f3b2aa4d )
+	rom ( name "NHL 99 (U) [!].z64" size 12582912 crc e5df2afe )
+)
+
+game (
+	name "NHL Blades of Steel '99"
+	description "NHL Blades of Steel '99"
+	rom ( name "NHL Blades of Steel '99 (U) [!].z64" size 12582912 crc 1ee678fe )
+	rom ( name "NHL Blades of Steel '99 (U) [f1] (PAL).z64" size 12582912 crc e8bc286a )
+	rom ( name "NHL Pro 99 (E) [!].z64" size 12582912 crc e272867e )
+	rom ( name "NHL Pro 99 (E) [o1].z64" size 33554432 crc af94245e )
+)
+
+game (
+	name "NHL Breakaway 98"
+	description "NHL Breakaway 98"
+	rom ( name "NHL Breakaway 98 (E) [!].z64" size 12582912 crc 8c0c9669 )
+	rom ( name "NHL Breakaway 98 (E) [f1] (NTSC).z64" size 12582912 crc 3618bba7 )
+	rom ( name "NHL Breakaway 98 (E) [h1C].z64" size 12582912 crc ed786754 )
+	rom ( name "NHL Breakaway 98 (E) [o1].z64" size 16777216 crc 02faddca )
+	rom ( name "NHL Breakaway 98 (E) [o1][h1C].z64" size 16777216 crc e9e248fe )
+	rom ( name "NHL Breakaway 98 (U) [!].z64" size 12582912 crc 49d86c00 )
+	rom ( name "NHL Breakaway 98 (U) [h1C].z64" size 12582912 crc b3dcbbb8 )
+	rom ( name "NHL Breakaway 98 (U) [o1].z64" size 16777216 crc 4c866c4d )
+	rom ( name "NHL Breakaway 98 (U) [o1][h1C].z64" size 16777216 crc f21257c9 )
+)
+
+game (
+	name "NHL Breakaway 99"
+	description "NHL Breakaway 99"
+	rom ( name "NHL Breakaway 99 (E) [!].z64" size 12582912 crc 572060e0 )
+	rom ( name "NHL Breakaway 99 (E) [b1].z64" size 12582912 crc 8612c050 )
+	rom ( name "NHL Breakaway 99 (U) [!].z64" size 12582912 crc 75f75b9d )
+	rom ( name "NHL Breakaway 99 (U) [b1].z64" size 12582912 crc 1f962087 )
+	rom ( name "NHL Breakaway 99 (U) [b2].z64" size 12582912 crc 8287f822 )
+)
+
+game (
+	name "Nightmare Creatures"
+	description "Nightmare Creatures"
+	rom ( name "Nightmare Creatures (U) [!].z64" size 16777216 crc 6a1eb795 )
+	rom ( name "Nightmare Creatures (U) [b1].z64" size 16838806 crc d10db6b6 )
+	rom ( name "Nightmare Creatures (U) [b2].z64" size 16777216 crc abe329e1 )
+	rom ( name "Nightmare Creatures (U) [t1].z64" size 16777216 crc 82ce76b5 )
+	rom ( name "Nightmare Creatures (U) [t2].z64" size 16777216 crc ec39285d )
+)
+
+game (
+	name "Nintama Rantarou 64 Game Gallery"
+	description "Nintama Rantarou 64 Game Gallery"
+	rom ( name "Nintama Rantarou 64 Game Gallery (J) [!].z64" size 8388608 crc 8c7c2dca )
+)
+
+game (
+	name "Nuclear Strike 64"
+	description "Nuclear Strike 64"
+	rom ( name "Nuclear Strike 64 (E) (M2) [!].z64" size 33554432 crc 9afbfcaf )
+	rom ( name "Nuclear Strike 64 (E) (M2) [h1C].z64" size 33554432 crc 7b1479a9 )
+	rom ( name "Nuclear Strike 64 (G) [!].z64" size 33554432 crc 0916ab13 )
+	rom ( name "Nuclear Strike 64 (U) [!].z64" size 33554432 crc d7467294 )
+	rom ( name "Nuclear Strike 64 (U) [b1].z64" size 33554432 crc ce1f9ec3 )
+	rom ( name "Nuclear Strike 64 (U) [f1] (PAL).z64" size 33554432 crc 484f91ed )
+	rom ( name "Nuclear Strike 64 (U) [t1].z64" size 33554432 crc a9206eb3 )
+)
+
+game (
+	name "Nushi Tsuri 64"
+	description "Nushi Tsuri 64"
+	rom ( name "Nushi Tsuri 64 (J) [!].z64" size 16777216 crc a6800ec0 )
+	rom ( name "Nushi Tsuri 64 (J) [b1].z64" size 16777216 crc 01fe5ae4 )
+	rom ( name "Nushi Tsuri 64 (J) [b2].z64" size 16777216 crc 22dbdd94 )
+	rom ( name "Nushi Tsuri 64 (J) [b3].z64" size 16777216 crc d5f95ba3 )
+	rom ( name "Nushi Tsuri 64 (J) [b4].z64" size 16777216 crc 979068b4 )
+	rom ( name "Nushi Tsuri 64 (J) [b5].z64" size 16777193 crc 7220efe0 )
+)
+
+game (
+	name "Nushi Tsuri 64 - Shiokaze ni Notte"
+	description "Nushi Tsuri 64 - Shiokaze ni Notte"
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [!].z64" size 33554432 crc f0bcd1ce )
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b1].z64" size 33554432 crc c6c43a7b )
+	rom ( name "Nushi Tsuri 64 - Shiokaze ni Notte (J) [b2].z64" size 29360128 crc ee4263ae )
+)
+
+game (
+	name O.D.T.
+	description "O.D.T."
+	rom ( name "O.D.T. (E) (M5) [!].z64" size 16777216 crc 7b870026 )
+	rom ( name "O.D.T. (U) (M3) [!].z64" size 16777216 crc 1d4a8659 )
+)
+
+game (
+	name "Off Road Challenge"
+	description "Off Road Challenge"
+	rom ( name "Off Road Challenge (E) [!].z64" size 16777216 crc d9fe9ee7 )
+	rom ( name "Off Road Challenge (E) [b1].z64" size 16777216 crc d91a7ed5 )
+	rom ( name "Off Road Challenge (E) [b2].z64" size 16777216 crc 2f9d6b8e )
+	rom ( name "Off Road Challenge (U) [!].z64" size 16777216 crc 1a45c5ab )
+	rom ( name "Off Road Challenge (U) [b1].z64" size 16777216 crc dd2dc258 )
+	rom ( name "Off Road Challenge (U) [b2].z64" size 15990784 crc a7b1ec20 )
+	rom ( name "Off Road Challenge (U) [t1].z64" size 16777216 crc c5119e5a )
+)
+
+game (
+	name "Ogre Battle 64 - Person of Lordly Caliber"
+	description "Ogre Battle 64 - Person of Lordly Caliber"
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!].z64" size 41943040 crc 845b8711 )
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1].z64" size 41943040 crc be2ae208 )
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1][o1].z64" size 50331648 crc 27ea3320 )
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b2].z64" size 41943040 crc 330a2c9f )
+	rom ( name "Ogre Battle 64 - Person of Lordly Caliber (U) [!].z64" size 41943040 crc a05aea85 )
+)
+
+game (
+	name "Olympic Hockey Nagano '98"
+	description "Olympic Hockey Nagano '98"
+	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [!].z64" size 8388608 crc 5a805c2e )
+	rom ( name "Olympic Hockey Nagano '98 (E) (M4) [h1C].z64" size 8388608 crc 0bf6ad1f )
+	rom ( name "Olympic Hockey Nagano '98 (J) [!].z64" size 8388608 crc 9e98fce8 )
+	rom ( name "Olympic Hockey Nagano '98 (U) [!].z64" size 8388608 crc 2d777652 )
+	rom ( name "Olympic Hockey Nagano '98 (U) [b1].z64" size 8388608 crc bf7eae06 )
+	rom ( name "Olympic Hockey Nagano '98 (U) [b2].z64" size 7077888 crc 5a86eb33 )
+	rom ( name "Olympic Hockey Nagano '98 (U) [b3].z64" size 8388608 crc 2270f56b )
+	rom ( name "Olympic Hockey Nagano '98 (U) [h1C].z64" size 8388608 crc 5a5315ec )
+	rom ( name "Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66].z64" size 8388608 crc c9f7b017 )
+)
+
+game (
+	name "Onegai Monsters"
+	description "Onegai Monsters"
+	rom ( name "Onegai Monsters (J) [!].z64" size 16777216 crc ac72a1c7 )
+	rom ( name "Onegai Monsters (J) [b1].z64" size 16777216 crc a632b622 )
+)
+
+game (
+	name "Pachinko 365 Nichi"
+	description "Pachinko 365 Nichi"
+	rom ( name "Pachinko 365 Nichi (J) [!].z64" size 12582912 crc 42d06e32 )
+	rom ( name "Pachinko 365 Nichi (J) [b1].z64" size 1376256 crc 75ce6e9b )
+	rom ( name "Pachinko 365 Nichi (J) [b2].z64" size 12582912 crc f2202871 )
+)
+
+game (
+	name "Paper Mario"
+	description "Paper Mario"
+	rom ( name "Mario Story (J) [!].z64" size 41943040 crc bd60ca66 )
+	rom ( name "Paper Mario (E) (M4) [!].z64" size 67108864 crc 85b3ab37 )
+	rom ( name "Paper Mario (U) [!].z64" size 41943040 crc a7f5cd7e )
+	rom ( name "Paper Mario (U) [T+Chi].z64" size 44040192 crc ec10421a )
+)
+
+game (
+	name Paperboy
+	description "Paperboy"
+	rom ( name "Paperboy (E) [!].z64" size 12582912 crc f00c5053 )
+	rom ( name "Paperboy (U) [!].z64" size 12582912 crc f27114e6 )
+	rom ( name "Paperboy (U) [f1] (PAL).z64" size 12582912 crc 7cfe1430 )
+	rom ( name "Paperboy (U) [hI].z64" size 12582912 crc 943fed7b )
+	rom ( name "Paperboy (U) [hI][f1] (PAL).z64" size 12582912 crc 0fefa6b4 )
+	rom ( name "Paperboy (U) [hI][t1].z64" size 12582912 crc a5a5da90 )
+	rom ( name "Paperboy (U) [t1].z64" size 12582912 crc ea4f823a )
+)
+
+game (
+	name "Parlor! Pro 64 - Pachinko Jikki Simulation Game"
+	description "Parlor! Pro 64 - Pachinko Jikki Simulation Game"
+	rom ( name "Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!].z64" size 12582912 crc a33146e0 )
+)
+
+game (
+	name "PD Ultraman Battle Collection 64"
+	description "PD Ultraman Battle Collection 64"
+	rom ( name "PD Ultraman Battle Collection 64 (J) [!].z64" size 33554432 crc 86cc80b5 )
+	rom ( name "PD Ultraman Battle Collection 64 (J) [b1].z64" size 33554432 crc 34af8235 )
+	rom ( name "PD Ultraman Battle Collection 64 (J) [f1] (PAL).z64" size 33554432 crc 4d2dab64 )
+	rom ( name "PD Ultraman Battle Collection 64 (J) [f2] (PAL).z64" size 33554432 crc e48d1481 )
+)
+
+game (
+	name "Penny Racers"
+	description "Penny Racers"
+	rom ( name "Choro Q 64 (J) [!].z64" size 8388608 crc 231f9284 )
+	rom ( name "Choro Q 64 (J) [b1].z64" size 8388608 crc b19825f1 )
+	rom ( name "Choro Q 64 (J) [b2].z64" size 8388608 crc edbbcb0e )
+	rom ( name "Choro Q 64 (J) [b3].z64" size 8388608 crc b94ca728 )
+	rom ( name "Choro Q 64 (J) [b4].z64" size 6029312 crc ce6f7754 )
+	rom ( name "Choro Q 64 (J) [h1C].z64" size 8388608 crc c35391ec )
+	rom ( name "Penny Racers (E) [!].z64" size 8388608 crc a1d6eb5b )
+	rom ( name "Penny Racers (E) [h1C].z64" size 8388608 crc 88d6b0fc )
+	rom ( name "Penny Racers (E) [h2C].z64" size 8388608 crc 48adf127 )
+	rom ( name "Penny Racers (U) [!].z64" size 8388608 crc c1e57337 )
+	rom ( name "Penny Racers (U) [hI].z64" size 8388608 crc 47bb87ab )
+)
+
+game (
+	name "Perfect Dark"
+	description "Perfect Dark"
+	rom ( name "Perfect Dark (E) (M5) [!].z64" size 33554432 crc 7718a714 )
+	rom ( name "Perfect Dark (E) (M5) [b1].z64" size 33488896 crc 0eae06b7 )
+	rom ( name "Perfect Dark (J) [!].z64" size 33554432 crc 639c0da9 )
+	rom ( name "Perfect Dark (U) (V1.0) [!].z64" size 33554432 crc 68446ad4 )
+	rom ( name "Perfect Dark (U) (V1.0) [f1] (PAL).z64" size 33554432 crc 8d4f0485 )
+	rom ( name "Perfect Dark (U) (V1.1) [!].z64" size 33554432 crc 4c1677f7 )
+)
+
+game (
+	name "PGA European Tour"
+	description "PGA European Tour"
+	rom ( name "PGA European Tour (E) (M5) [!].z64" size 16777216 crc 6b5ff959 )
+	rom ( name "PGA European Tour (E) (M5) [f1] (NTSC).z64" size 16777216 crc b7e9b0ca )
+	rom ( name "PGA European Tour (E) (M5) [f2] (NTSC).z64" size 16777216 crc 7bf9235e )
+	rom ( name "PGA European Tour (U) [!].z64" size 16777216 crc 7cdfcdaa )
+)
+
+game (
+	name "Pilotwings 64"
+	description "Pilotwings 64"
+	rom ( name "Pilotwings 64 (E) (M3) [!].z64" size 8388608 crc c902e57c )
+	rom ( name "Pilotwings 64 (E) (M3) [b1].z64" size 8388608 crc 69cee7bb )
+	rom ( name "Pilotwings 64 (E) (M3) [b2].z64" size 8126464 crc a3f6b922 )
+	rom ( name "Pilotwings 64 (E) (M3) [h1C].z64" size 8388608 crc 3f2c45d1 )
+	rom ( name "Pilotwings 64 (J) [!].z64" size 8388608 crc 3d3a84a9 )
+	rom ( name "Pilotwings 64 (J) [b1].z64" size 7340032 crc 48d4865d )
+	rom ( name "Pilotwings 64 (U) [!].z64" size 8388608 crc 728807e7 )
+	rom ( name "Pilotwings 64 (U) [h1C].z64" size 8388608 crc 80193ec3 )
+	rom ( name "Pilotwings 64 (U) [t1].z64" size 8388608 crc e1b8cdd3 )
+)
+
+game (
+	name "Pocket Monsters Stadium"
+	description "Pocket Monsters Stadium"
+	rom ( name "Pocket Monsters Stadium (J) [!].z64" size 16777216 crc 3139189c )
+	rom ( name "Pocket Monsters Stadium (J) [b1].z64" size 16777216 crc 6f856803 )
+	rom ( name "Pocket Monsters Stadium (J) [b2].z64" size 16777216 crc b4f73dba )
+	rom ( name "Pocket Monsters Stadium (J) [f1] (Boot-PAL).z64" size 16777216 crc 54d42fd3 )
+	rom ( name "Pocket Monsters Stadium (J) [f2] (Boot).z64" size 16777216 crc 32b4c38d )
+)
+
+game (
+	name "Pokemon Puzzle League"
+	description "Pokemon Puzzle League"
+	rom ( name "Pokemon Puzzle League (E) [!].z64" size 33554432 crc 75839254 )
+	rom ( name "Pokemon Puzzle League (F) [!].z64" size 33554432 crc c3aa0074 )
+	rom ( name "Pokemon Puzzle League (G) [!].z64" size 33554432 crc ac543150 )
+	rom ( name "Pokemon Puzzle League (U) [!].z64" size 33554432 crc 8b9c598f )
+	rom ( name "Pokemon Puzzle League (U) [t1].z64" size 33554432 crc 47ede839 )
+	rom ( name "Pokemon Puzzle League (U) [t2].z64" size 33554432 crc e74d7734 )
+)
+
+game (
+	name "Pokemon Snap"
+	description "Pokemon Snap"
+	rom ( name "Pocket Monsters Snap (J) [!].z64" size 16777216 crc a091bd56 )
+	rom ( name "Pocket Monsters Snap (J) [b1].z64" size 16777216 crc 28f6f98d )
+	rom ( name "Pocket Monsters Snap (J) [f1].z64" size 16777216 crc 676a945b )
+	rom ( name "Pocket Monsters Snap (J) [f2] (GameShark).z64" size 16777216 crc 7822e4dc )
+	rom ( name "Pokemon Snap (A) [!].z64" size 16777216 crc cdea6d4c )
+	rom ( name "Pokemon Snap (A) [f1] (GameShark).z64" size 16777216 crc 144f7260 )
+	rom ( name "Pokemon Snap (E) [!].z64" size 16777216 crc f824a057 )
+	rom ( name "Pokemon Snap (F) [!].z64" size 16777216 crc ec843586 )
+	rom ( name "Pokemon Snap (F) [b1].z64" size 16777216 crc 396961b4 )
+	rom ( name "Pokemon Snap (G) [!].z64" size 16777216 crc 10c27b3c )
+	rom ( name "Pokemon Snap (I) [!].z64" size 16777216 crc 63f6058a )
+	rom ( name "Pokemon Snap (S) [!].z64" size 16777216 crc 371b787f )
+	rom ( name "Pokemon Snap (U) [!].z64" size 16777216 crc 86a69756 )
+	rom ( name "Pokemon Snap (U) [f1] (Save).z64" size 16777216 crc 4e0c3ab0 )
+	rom ( name "Pokemon Snap (U) [f2] (Save-PAL).z64" size 16777216 crc a6ef9ae7 )
+	rom ( name "Pokemon Snap (U) [f3] (GameShark).z64" size 16777216 crc 6a7d374c )
+	rom ( name "Pokemon Snap (U) [f3].z64" size 16777216 crc 9f5b2741 )
+	rom ( name "Pokemon Snap (U) [T+Spa].z64" size 16777216 crc ea713736 )
+	rom ( name "Pokemon Snap Station (U) [!].z64" size 16777216 crc e22a00d0 )
+	rom ( name "Pokemon Snap Station (U) [f1].z64" size 16777216 crc dce70f89 )
+)
+
+game (
+	name "Pokemon Stadium"
+	description "Pokemon Stadium"
+	rom ( name "Pocket Monsters Stadium 2 (J) [!].z64" size 33554432 crc 40aa4874 )
+	rom ( name "Pocket Monsters Stadium 2 (J) [f1].z64" size 33554432 crc df47adf2 )
+	rom ( name "Pocket Monsters Stadium 2 (J) [f2].z64" size 33554432 crc e3269942 )
+	rom ( name "Pocket Monsters Stadium 2 (J) [f3].z64" size 33554432 crc b9365d21 )
+	rom ( name "Pocket Monsters Stadium 2 (J) [f4].z64" size 33554432 crc 3db3c49b )
+	rom ( name "Pokemon Stadium (E) (V1.0) [!].z64" size 33554432 crc dc57508d )
+	rom ( name "Pokemon Stadium (E) (V1.0) [f1].z64" size 33554432 crc c0055dd4 )
+	rom ( name "Pokemon Stadium (E) (V1.1) [!].z64" size 33554432 crc da889668 )
+	rom ( name "Pokemon Stadium (F) [!].z64" size 33554432 crc 5dd92d4c )
+	rom ( name "Pokemon Stadium (F) [f1].z64" size 33554432 crc 56bb95db )
+	rom ( name "Pokemon Stadium (G) [!].z64" size 33554432 crc 9f22a945 )
+	rom ( name "Pokemon Stadium (G) [f1].z64" size 33554432 crc f4152673 )
+	rom ( name "Pokemon Stadium (I) [!].z64" size 33554432 crc f155c465 )
+	rom ( name "Pokemon Stadium (S) [!].z64" size 33554432 crc f02cd5eb )
+	rom ( name "Pokemon Stadium (S) [f1].z64" size 33554432 crc 55a3cd84 )
+	rom ( name "Pokemon Stadium (U) (V1.0) [!].z64" size 33554432 crc 72f66f05 )
+	rom ( name "Pokemon Stadium (U) (V1.0) [f1].z64" size 33554432 crc 932b7a31 )
+	rom ( name "Pokemon Stadium (U) (V1.1) [!].z64" size 33554432 crc 72b552e3 )
+	rom ( name "Pokemon Stadium (U) (V1.1) [f1].z64" size 33554432 crc 32233fdc )
+)
+
+game (
+	name "Pokemon Stadium 2"
+	description "Pokemon Stadium 2"
+	rom ( name "Pocket Monsters Stadium Kin Gin (J) [!].z64" size 67108864 crc cbc3b935 )
+	rom ( name "Pokemon Stadium 2 (E) [!].z64" size 67108864 crc 6b3096c4 )
+	rom ( name "Pokemon Stadium 2 (E) [T+Ita0.05].z64" size 67108864 crc 89e7da00 )
+	rom ( name "Pokemon Stadium 2 (F) [!].z64" size 67108864 crc e2a78066 )
+	rom ( name "Pokemon Stadium 2 (G) [!].z64" size 67108864 crc 1146a43a )
+	rom ( name "Pokemon Stadium 2 (I) [!].z64" size 67108864 crc 9fa5c095 )
+	rom ( name "Pokemon Stadium 2 (S) [!].z64" size 67108864 crc 283e7641 )
+	rom ( name "Pokemon Stadium 2 (U) [!].z64" size 67108864 crc a9998e09 )
+)
+
+game (
+	name "Polaris SnoCross"
+	description "Polaris SnoCross"
+	rom ( name "Polaris SnoCross (U) [!].z64" size 12582912 crc 8dd735ef )
+	rom ( name "Polaris SnoCross (U) [o1][t1].z64" size 12582912 crc 00ce1ebb )
+	rom ( name "Polaris SnoCross (U) [t1].z64" size 12582912 crc 9356fe6c )
+)
+
+game (
+	name "Power League Baseball 64"
+	description "Power League Baseball 64"
+	rom ( name "Power League Baseball 64 (J) [!].z64" size 8388608 crc aec21c28 )
+	rom ( name "Power League Baseball 64 (J) [o1].z64" size 16777216 crc 1b77039d )
+)
+
+game (
+	name "Power Rangers - Lightspeed Rescue"
+	description "Power Rangers - Lightspeed Rescue"
+	rom ( name "Power Rangers - Lightspeed Rescue (E) [!].z64" size 12582912 crc 83590247 )
+	rom ( name "Power Rangers - Lightspeed Rescue (E) [f1] (NTSC).z64" size 12582912 crc 388eab69 )
+	rom ( name "Power Rangers - Lightspeed Rescue (U) [!].z64" size 12582912 crc a5033311 )
+)
+
+game (
+	name "Powerpuff Girls, The - Chemical X-Traction"
+	description "Powerpuff Girls, The - Chemical X-Traction"
+	rom ( name "Powerpuff Girls, The - Chemical X-Traction (U) [!].z64" size 8388608 crc 9514da0a )
+)
+
+game (
+	name "Premier Manager 64"
+	description "Premier Manager 64"
+	rom ( name "Premier Manager 64 (E) [!].z64" size 16777216 crc 81cda888 )
+	rom ( name "Premier Manager 64 (E) [f1] (NTSC).z64" size 16777216 crc 18a89111 )
+	rom ( name "Premier Manager 64 (E) [f2] (NTSC100%).z64" size 16777216 crc 9e43ec66 )
+)
+
+game (
+	name "Pro Mahjong Kiwame 64"
+	description "Pro Mahjong Kiwame 64"
+	rom ( name "Pro Mahjong Kiwame 64 (J) [!].z64" size 8388608 crc 1f5907f9 )
+	rom ( name "Pro Mahjong Kiwame 64 (J) [b1].z64" size 8126464 crc 21ae1d70 )
+	rom ( name "Pro Mahjong Kiwame 64 (J) [o1].z64" size 16777216 crc 7b914a49 )
+)
+
+game (
+	name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen"
+	description "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen"
+	rom ( name "Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!].z64" size 8388608 crc 35461699 )
+)
+
+game (
+	name "Public Domain"
+	description "Public Domain"
+	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD) [f1].z64" size 1310720 crc ca8cca0b )
+	rom ( name "2 Blokes & An Armchair - Nintendo 64 Remix Remix by Tesko (PD).z64" size 1310720 crc 48be02a9 )
+	rom ( name "3DS Model Conversion by Snake (PD) [h1C].z64" size 1572864 crc fdb0d5ad )
+	rom ( name "3DS Model Conversion by Snake (PD).z64" size 1572864 crc 685f71cd )
+	rom ( name "77a by Count0 (POM '98) (PD) [b1].z64" size 1310720 crc 0fcb5e9e )
+	rom ( name "77a by Count0 (POM '98) (PD).z64" size 1310720 crc ef6d1ca6 )
+	rom ( name "77a Special Edition by Count0 (PD) [b1].z64" size 2883584 crc a2ae127c )
+	rom ( name "77a Special Edition by Count0 (PD).z64" size 2883584 crc 0c84af76 )
+	rom ( name "Absolute Crap #2 by Lem (PD) [b1].z64" size 1310720 crc caeadab4 )
+	rom ( name "Absolute Crap #2 by Lem (PD) [b2].z64" size 1310720 crc 4026b0cb )
+	rom ( name "Absolute Crap #2 by Lem (PD).z64" size 1310720 crc 9b9fdb8e )
+	rom ( name "Alleycat 64 by Dosin (POM '99) (PD) [b1].z64" size 1310720 crc fe3b7986 )
+	rom ( name "Alleycat 64 by Dosin (POM '99) (PD).z64" size 1310720 crc 938eca3e )
+	rom ( name "Attax64 by Pookae (POM '99) (PD) [b1].z64" size 1572864 crc 21b5e4e7 )
+	rom ( name "Attax64 by Pookae (POM '99) (PD).z64" size 1572864 crc 53976ac5 )
+	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD) [t1].z64" size 1572864 crc c5dac064 )
+	rom ( name "Berney Must Die! by Nop_ (POM '99) (PD).z64" size 1572864 crc 661e5ff5 )
+	rom ( name "Bike Race '98 V1.0 by NAN (PD) [b1].z64" size 3145728 crc cd797c66 )
+	rom ( name "Bike Race '98 V1.0 by NAN (PD).z64" size 3145728 crc 601c8801 )
+	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b1].z64" size 1048576 crc 19f78649 )
+	rom ( name "Bike Race '98 V1.2 by NAN (PD) [b2].z64" size 840768 crc 109b847a )
+	rom ( name "Bike Race '98 V1.2 by NAN (PD).z64" size 840768 crc c2cc79c2 )
+	rom ( name "BMP View by Count0 (PD).z64" size 262144 crc 9ba53380 )
+	rom ( name "CZN Module Player (PD).z64" size 1048576 crc f93a2b1f )
+	rom ( name "Dexanoid R1 by Protest Design (PD) [b1].z64" size 2097152 crc 1b9a2d13 )
+	rom ( name "Dexanoid R1 by Protest Design (PD) [f1] (PAL).z64" size 16777216 crc 7a4bbb34 )
+	rom ( name "Dexanoid R1 by Protest Design (PD) [f2] (PAL).z64" size 16777216 crc 7e2b8065 )
+	rom ( name "Dexanoid R1 by Protest Design (PD) [t1].z64" size 16777216 crc 3cf0961f )
+	rom ( name "Dexanoid R1 by Protest Design (PD).z64" size 16777216 crc 244e6d59 )
+	rom ( name "Dragon King by CrowTRobo (PD) [b1].z64" size 3407872 crc 1fc33d83 )
+	rom ( name "Dragon King by CrowTRobo (PD).z64" size 3407872 crc ea5c7922 )
+	rom ( name "Dynamix Readme by Widget and Immortal (PD).z64" size 1310720 crc 82531023 )
+	rom ( name "Game Boy 64 (POM '98) (PD) (Illegal Mode Enabled).z64" size 3145728 crc e299d6c1 )
+	rom ( name "Game Boy 64 (POM '98) (PD).z64" size 3145728 crc 3c22f622 )
+	rom ( name "Game Boy 64 + Super Mario 3 (PD).z64" size 1835008 crc 8145d2e8 )
+	rom ( name "HIPTHRUST by MooglyGuy (PD).z64" size 2097152 crc b1a4d196 )
+	rom ( name "JPEG Slideshow Viewer by Garth Elgar (PD).z64" size 334112 crc b5aa682d )
+	rom ( name "LaC's MOD Player - The Temple Gates (PD).z64" size 2807878 crc 4c4477d6 )
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b1].z64" size 1310720 crc 0388ee97 )
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD) [b2].z64" size 1310720 crc 4155e1c9 )
+	rom ( name "Liner V1.00 by Colin Phillipps of Memir (PD).z64" size 1310720 crc a9397703 )
+	rom ( name "Liner V1.02 by Colin Phillipps of Memir (PD).z64" size 1310720 crc d3d11218 )
+	rom ( name "MAME 64 Beta 3 (PD).z64" size 8388608 crc 2103e950 )
+	rom ( name "MAME 64 V1.0 (PD) [b1].z64" size 8388608 crc 7f0dd250 )
+	rom ( name "MAME 64 V1.0 (PD).z64" size 8388608 crc 6612ceba )
+	rom ( name "Mandelbrot Zoomer by RedBox (PD).z64" size 524288 crc 611513ad )
+	rom ( name "Manic Miner - Hidden Levels by RedboX (PD).z64" size 2097152 crc f496a0fa )
+	rom ( name "Manic Miner by RedboX (PD).z64" size 2097152 crc 02aacc20 )
+	rom ( name "Memory Manager V1.0b by R. Bubba Magillicutty (PD).z64" size 2097152 crc 3b3f140a )
+	rom ( name "MMR by Count0 (PD) [b1].z64" size 1572864 crc 47bd7e97 )
+	rom ( name "MMR by Count0 (PD).z64" size 1572864 crc f4803dcb )
+	rom ( name "N64 Scene Gallery by CALi (PD).z64" size 4456448 crc dfbb8dfe )
+	rom ( name "N64probe (Button Test) by MooglyGuy (PD).z64" size 2097152 crc 18d7c629 )
+	rom ( name "N64probe by MooglyGuy (PD).v64" size 2097152 crc 361f713f )
+	rom ( name "Namp64 - N64 MP3-Player by Obsidian (PD).z64" size 262144 crc 6a9be044 )
+	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD) [a1].z64" size 6029312 crc 82ca0f47 )
+	rom ( name "NBC-LFC Kings of Porn Vol 01 (PD).z64" size 6029312 crc b20cd983 )
+	rom ( name "NBCG Special Edition (PD).z64" size 2621440 crc 57af612b )
+	rom ( name "NBCG's Tag Gallery 01 by CALi (PD).z64" size 2359296 crc 60394429 )
+	rom ( name "Nintendo Family by CALi (PD).z64" size 3145728 crc f9d7bf11 )
+	rom ( name "Nintendo WideBoy 64 by SonCrap (PD).z64" size 2097152 crc 1efcc1b2 )
+	rom ( name "ObjectVIEWER V1.1 by Kid Stardust (PD).v64" size 1310720 crc 1deda87c )
+	rom ( name "PC-Engine 64 (POM '99) (PD) [t1].z64" size 2097152 crc 63c024c6 )
+	rom ( name "PC-Engine 64 (POM '99) (PD).z64" size 2097152 crc e69b416b )
+	rom ( name "Pip's Pong by Mr. Pips (PD) [b1].z64" size 1310720 crc 426f0f6e )
+	rom ( name "Pip's Pong by Mr. Pips (PD).z64" size 1310720 crc 756871e3 )
+	rom ( name "Pip's Porn Pack 1 by Mr. Pips (PD).z64" size 1310720 crc 4843b97c )
+	rom ( name "Pip's Porn Pack 2 by Mr. Pips (POM '99) (PD).z64" size 1572864 crc 48c2e078 )
+	rom ( name "Pip's Porn Pack 3 by Mr. Pips (PD).z64" size 1572864 crc 22ef2b51 )
+	rom ( name "Pip's RPGs Beta 12 by Mr. Pips (PD).z64" size 1572864 crc 8b84f446 )
+	rom ( name "Pip's RPGs Beta 14 by Mr. Pips (PD).z64" size 1572864 crc 97288804 )
+	rom ( name "Pip's RPGs Beta 15 by Mr. Pips (PD).z64" size 1835008 crc 195a1c24 )
+	rom ( name "Pip's RPGs Beta 2 by Mr. Pips (PD).z64" size 1310720 crc c27dd46e )
+	rom ( name "Pip's RPGs Beta 3 by Mr. Pips (PD).z64" size 1310720 crc 30ca3fd9 )
+	rom ( name "Pip's RPGs Beta 6 by Mr. Pips (PD).z64" size 1310720 crc 9930d6bd )
+	rom ( name "Pip's RPGs Beta 7 by Mr. Pips (PD).z64" size 1310720 crc 0f30d531 )
+	rom ( name "Pip's RPGs Beta x (PD) [a1].z64" size 1572864 crc e392cf51 )
+	rom ( name "Pip's RPGs Beta x (PD).z64" size 1572864 crc 4ceb0273 )
+	rom ( name "Pip's Tic Tak Toe by Mark Pips (PD).z64" size 1310720 crc 08950965 )
+	rom ( name "Pip's World Game 1 by Mr. Pips (PD) [b1].z64" size 1310720 crc 5f3acbd9 )
+	rom ( name "Pip's World Game 1 by Mr. Pips (PD).z64" size 1310720 crc 36d3fbd2 )
+	rom ( name "Pip's World Game 2 by Mr. Pips (PD) [b1].z64" size 1310720 crc 8e2b9445 )
+	rom ( name "Pip's World Game 2 by Mr. Pips (PD).z64" size 1310720 crc 03ee5c91 )
+	rom ( name "Pipendo by Mr. Pips (PD).z64" size 1310720 crc f7aaab1c )
+	rom ( name "Pong by Oman (PD) [a1].z64" size 8388608 crc 49238810 )
+	rom ( name "Pong by Oman (PD) [h1C][o1].z64" size 8388608 crc c7d62967 )
+	rom ( name "Pong by Oman (PD) [t1].z64" size 8388608 crc be397968 )
+	rom ( name "Pong by Oman (PD).z64" size 262144 crc dff8f71a )
+	rom ( name "Pong V0.01 by Omsk (PD).z64" size 1572864 crc 6f5c095e )
+	rom ( name "Puzzle Master 64 by Michael Searl (PD).z64" size 10485760 crc 8cef5822 )
+	rom ( name "Shuffle Puck 64 (PD).z64" size 3932160 crc dddda2c6 )
+	rom ( name "Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD).z64" size 1310720 crc 5eab0f34 )
+	rom ( name "Sinus (PD).z64" size 1310720 crc d7679079 )
+	rom ( name "SLiDeS (PD).z64" size 1572864 crc 76b35c44 )
+	rom ( name "Spacer by Memir (POM '99) (PD) [t1].z64" size 3145728 crc 01c93afe )
+	rom ( name "Spacer by Memir (POM '99) (PD) [t2].z64" size 3102038 crc 6791f671 )
+	rom ( name "Spacer by Memir (POM '99) (PD) [t2][b1].z64" size 3102038 crc e62ae0eb )
+	rom ( name "Spacer by Memir (POM '99) (PD).z64" size 2683944 crc dc0d3f8a )
+	rom ( name "SPLiT's Nacho64 by SPLiT (PD) [f1] (PAL).z64" size 2097152 crc ad7990a9 )
+	rom ( name "SPLiT's Nacho64 by SPLiT (PD).z64" size 2097152 crc 4c3da466 )
+	rom ( name "Sporting Clays by Charles Doty (PD) [a1].z64" size 1310720 crc 2ec84b48 )
+	rom ( name "Sporting Clays by Charles Doty (PD) [b1].z64" size 1310720 crc 8fb5adbc )
+	rom ( name "Sporting Clays by Charles Doty (PD).z64" size 1310720 crc 2471c621 )
+	rom ( name "Super Bomberman 2 by Rider (POM '99) (PD).z64" size 1310720 crc fcb72ec3 )
+	rom ( name "Twintris by Twinsen (POM '98) (PD).z64" size 3145728 crc 7fdff7e7 )
+	rom ( name "Ultrafox 64 by Megahawks (PD).z64" size 1877136 crc 12f0d7b4 )
+	rom ( name "Wet Dreams Readme by Immortal (POM '99) (PD).z64" size 2097152 crc 80fa548d )
+)
+
+game (
+	name "Public Domain (Demos)"
+	description "Public Domain (Demos)"
+	rom ( name "1964 Demo by Steb (PD).z64" size 1310720 crc 2336871b )
+	rom ( name "Birthday Demo for Steve by Nep (PD) [b1].z64" size 1310720 crc 5af2efe0 )
+	rom ( name "Birthday Demo for Steve by Nep (PD).z64" size 1310720 crc 50b40d33 )
+	rom ( name "Chaos 89 Demo (PD).z64" size 1310720 crc 0ec05e31 )
+	rom ( name "Christmas Flame Demo by Halley's Comet Software (PD).z64" size 237440 crc b16e26c5 )
+	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD) [b1].z64" size 1310720 crc 3901a5b5 )
+	rom ( name "Congratulations Demo for SPLiT by Widget and Immortal (PD).z64" size 1310720 crc f3a9b5ac )
+	rom ( name "Cube Demo (PD) [b1].z64" size 524288 crc 663cca5b )
+	rom ( name "Cube Demo (PD) [b2].z64" size 9437184 crc fbead436 )
+	rom ( name "Cube Demo (PD).z64" size 9437184 crc c8abe90c )
+	rom ( name "Cube Demo by Msftug (PD).z64" size 8388608 crc a63621ff )
+	rom ( name "Display List Ate My Mind Demo by Kid Stardust (PD).z64" size 1310720 crc 01d47287 )
+	rom ( name "DKONG Demo (PD).z64" size 2097152 crc 40a32fc4 )
+	rom ( name "Explode Demo by NaN (PD).z64" size 195688 crc 4ade6d08 )
+	rom ( name "Fire Demo by Lac (PD).z64" size 2097152 crc a827a178 )
+	rom ( name "Fireworks Demo by CrowTRobo (PD).z64" size 1310720 crc c49262f7 )
+	rom ( name "Fish Demo by NaN (PD).z64" size 1310720 crc 5a7d1331 )
+	rom ( name "Fogworld USA Demo by Horizon64 (PD) [h1C][o1].z64" size 1310720 crc cbe4b416 )
+	rom ( name "Fogworld USA Demo by Horizon64 (PD).z64" size 1179648 crc a0b6250d )
+	rom ( name "Fractal Zoomer Demo by RedboX (PD).z64" size 2097152 crc d10ea06a )
+	rom ( name "Friendship Demo by Renderman (PD) [b1].z64" size 1310720 crc 4fae1edf )
+	rom ( name "Friendship Demo by Renderman (PD).z64" size 1310720 crc b38a50e8 )
+	rom ( name "GT Demo (PD) [a1].z64" size 1048576 crc fb2c9648 )
+	rom ( name "GT Demo (PD).z64" size 1310720 crc 51a3a682 )
+	rom ( name "Hard Coded Demo by Silo and Fractal (PD) [a1].z64" size 786432 crc 713d8af3 )
+	rom ( name "Hard Coded Demo by Silo and Fractal (PD).z64" size 1310720 crc 44e52674 )
+	rom ( name "Hard Pom '99 Demo by TS_Garp (POM '99) (PD).z64" size 1835008 crc 227992c1 )
+	rom ( name "Heavy 64 Demo by Destop (PD).z64" size 3932160 crc f94f368f )
+	rom ( name "HiRes CFB Demo (PD).z64" size 1310720 crc 2925b3f3 )
+	rom ( name "LCARS Demo by WT Riker (PD) [b1].z64" size 2097152 crc 8e8aed5e )
+	rom ( name "LCARS Demo by WT Riker (PD).z64" size 2097152 crc b5bbdd7f )
+	rom ( name "Light Force First N64 Demo by Fractal (PD).z64" size 1310720 crc 4652c058 )
+	rom ( name "MAME 64 Demo (PD) [b1].z64" size 8388608 crc a033c664 )
+	rom ( name "MAME 64 Demo (PD) [b2].z64" size 8388608 crc 6d7663ed )
+	rom ( name "MAME 64 Demo (PD).z64" size 8388608 crc b8fd2e8b )
+	rom ( name "MeeTING Demo by Renderman (PD) [b1].z64" size 1310720 crc 8d6e473f )
+	rom ( name "MeeTING Demo by Renderman (PD).z64" size 1310720 crc 63ec31a1 )
+	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD) [b1].z64" size 2097152 crc 7b38e6c7 )
+	rom ( name "Mind Present Demo 0 by Widget and Immortal (POM '98) (PD).z64" size 2097152 crc 390ef548 )
+	rom ( name "Mind Present Demo Readme by Widget and Immortal (POM '98) (PD).z64" size 1310720 crc d348c33f )
+	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD) [f1].z64" size 3670016 crc 8a909b08 )
+	rom ( name "Money Creates Taste Demo by Count0 (POM '99) (PD).z64" size 3670016 crc b154e087 )
+	rom ( name "My Angel Demo (PD).z64" size 1048576 crc d55d55ef )
+	rom ( name "N64 Seminar Demo - CPU by ZoRAXE (PD).z64" size 2097152 crc 6093fae0 )
+	rom ( name "N64 Seminar Demo - RSP by ZoRAXE (PD).z64" size 2097152 crc 6e476896 )
+	rom ( name "N64 Stars Demo (PD) [b1].z64" size 2097152 crc a56117af )
+	rom ( name "N64 Stars Demo (PD).z64" size 2097152 crc 3210b3f2 )
+	rom ( name "NBCG's Kings of Porn Demo (PD).z64" size 4718592 crc 30c0d79a )
+	rom ( name "NBCrew 2 Demo (PD).z64" size 262144 crc a57d3bda )
+	rom ( name "NEO Myth N64 Menu Demo V0.1 (PD).z64" size 2097152 crc fc989fd7 )
+	rom ( name "Nintendo On My Mind Demo by Kid Stardust (PD).z64" size 1310720 crc 23e051f4 )
+	rom ( name "Nintro64 Demo by Lem (POM '98) (PD) [b1].z64" size 3145728 crc c581ee0d )
+	rom ( name "Nintro64 Demo by Lem (POM '98) (PD).z64" size 3145728 crc d79da002 )
+	rom ( name "NuFan Demo by Kid Stardust (PD) [b1].z64" size 1310720 crc c2b3b43c )
+	rom ( name "NuFan Demo by Kid Stardust (PD).z64" size 1310720 crc 3c637d2b )
+	rom ( name "Pamela Demo (PD).z64" size 1310720 crc 74f01ec6 )
+	rom ( name "Pamela Demo - Resized (PD).z64" size 1048576 crc 1607eebd )
+	rom ( name "Pause Demo by RedboX (PD).z64" size 2097152 crc aac99313 )
+	rom ( name "Plasma Demo (PD) [a1].z64" size 524288 crc 92984be1 )
+	rom ( name "Plasma Demo (PD).z64" size 1310720 crc 57fe4e68 )
+	rom ( name "Pom Part 1 Demo (PD).z64" size 1310720 crc dc92eaf6 )
+	rom ( name "Pom Part 2 Demo (PD).z64" size 1310720 crc a88fdeac )
+	rom ( name "Pom Part 3 Demo (PD).z64" size 1310720 crc 23d33929 )
+	rom ( name "Pom Part 4 Demo (PD).z64" size 1310720 crc b8fdc6dc )
+	rom ( name "Pom Part 5 Demo (PD).z64" size 1310720 crc 13c05dda )
+	rom ( name "POMbaer Demo by Kid Stardust (POM '99) (PD).z64" size 1310720 crc 9e6fd36c )
+	rom ( name "POMolizer Demo by Renderman (POM '99) (PD).z64" size 1310720 crc 0f34d619 )
+	rom ( name "Psychodelic Demo by Ste (POM '98) (PD) [b1].z64" size 3145728 crc 331a7257 )
+	rom ( name "Psychodelic Demo by Ste (POM '98) (PD).z64" size 3145728 crc 4f03510f )
+	rom ( name "R.I.P. Jay Demo by Ste (PD) [b1].z64" size 8388608 crc fee6ee6d )
+	rom ( name "R.I.P. Jay Demo by Ste (PD).z64" size 8388608 crc a916dff5 )
+	rom ( name "Rotating Demo USA by Rene (PD) [a1].z64" size 1310720 crc 9c2a266b )
+	rom ( name "Rotating Demo USA by Rene (PD).z64" size 1310720 crc 95e9d320 )
+	rom ( name "Sample Demo by Florian (PD) [b1].z64" size 1310720 crc 39153954 )
+	rom ( name "Sample Demo by Florian (PD).z64" size 1310720 crc 096430d1 )
+	rom ( name "Shag'a'Delic Demo by Steve and NEP (PD).z64" size 1835008 crc 29fcf3cb )
+	rom ( name "Sitero Demo by Renderman (PD).z64" size 1310720 crc 223b828e )
+	rom ( name "Spice Girls Rotator Demo by RedboX (PD) [a1].z64" size 524288 crc f36ad81b )
+	rom ( name "Spice Girls Rotator Demo by RedboX (PD).z64" size 2097152 crc 40402197 )
+	rom ( name "Split! 3D Demo by Lem (PD).z64" size 262144 crc fbe321ba )
+	rom ( name "Summer64 Demo by Lem (PD) [b1].z64" size 2359296 crc 5d33dcaf )
+	rom ( name "Summer64 Demo by Lem (PD).z64" size 2359296 crc 0d13e643 )
+	rom ( name "Super Fighter Demo Halley's Comet Software (PD).z64" size 2264820 crc d0dc2237 )
+	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1].z64" size 1310720 crc e0b60b7e )
+	rom ( name "T-Shirt Demo by Neptune and Steve (POM '98) (PD).z64" size 1310720 crc 0cb63df2 )
+	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD) [b1].z64" size 1310720 crc 17c191c8 )
+	rom ( name "Tetris Beta Demo by FusionMan (POM '98) (PD).z64" size 1310720 crc f96778d2 )
+	rom ( name "Textlight Demo by Horizon64 (PD) [b1].z64" size 1310720 crc 0feb3819 )
+	rom ( name "Textlight Demo by Horizon64 (PD).z64" size 1310720 crc d0931871 )
+	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD) [b1].z64" size 1310720 crc 19cfc4a4 )
+	rom ( name "The Corporation XMAS Demo '99 by TS_Garp (PD).z64" size 1310720 crc 933ae249 )
+	rom ( name "TheMuscularDemo by megahawks (PD).v64" size 3981552 crc 2cb9f365 )
+	rom ( name "Tom Demo (PD).z64" size 2621440 crc 94f1e1e9 )
+	rom ( name "TopGun Demo by Horizon64 (PD).z64" size 1310720 crc bac738e4 )
+	rom ( name "TR64 Demo by FIres and Icepir8 (PD).z64" size 1310720 crc bde293c7 )
+	rom ( name "TRON Demo (PD) [a1].z64" size 524288 crc 40ace055 )
+	rom ( name "TRON Demo (PD).z64" size 2097152 crc 4158e22a )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD) [b1].z64" size 2097152 crc fc014665 )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (older) (PD).z64" size 2097152 crc 58423a11 )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1].z64" size 2097152 crc 429526be )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [a1][b1].z64" size 2097152 crc 1846d8e6 )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD) [b1].z64" size 1310720 crc a586fcd8 )
+	rom ( name "U64 (Chrome) Demo by Horizon64 (PD).z64" size 2097152 crc c0c70544 )
+	rom ( name "Ultra Demo Bootcode by Locke^ (PD) [h1C].z64" size 4096 crc 7e0e4bae )
+	rom ( name "Ultra Demo Bootcode by Locke^ (PD).z64" size 4096 crc 121aca7d )
+	rom ( name "Ultra Demo by Locke^ (PD) [a1].z64" size 1048576 crc 6a372c49 )
+	rom ( name "Ultra Demo by Locke^ (PD).z64" size 1310720 crc 7642ca11 )
+	rom ( name "Vector Demo by Destop (POM '99) (PD).z64" size 1310720 crc a23ffa73 )
+	rom ( name "Wet Dreams Can Beta Demo by Immortal (POM '99) (PD).z64" size 1310720 crc 690d2946 )
+	rom ( name "Wet Dreams Madeiragames Demo by Immortal (POM '99) (PD).z64" size 4194304 crc 38cecb99 )
+	rom ( name "Wet Dreams Main Demo by Immortal (POM '99) (PD).z64" size 8388608 crc 965c7727 )
+	rom ( name "XtraLife Dextrose Demo by RedboX (PD) [h1C].z64" size 786432 crc fcc9d3ea )
+	rom ( name "XtraLife Dextrose Demo by RedboX (PD).z64" size 2097152 crc 1a4654a4 )
+	rom ( name "Y2K Demo by WT_Riker (PD) [b1].z64" size 1310720 crc b40a130d )
+	rom ( name "Y2K Demo by WT_Riker (PD).z64" size 1310720 crc cc2762c7 )
+)
+
+game (
+	name "Public Domain (Emulation)"
+	description "Public Domain (Emulation)"
+	rom ( name "GBlator for CD64 (PD) [f1] (V64-PAL).z64" size 8388608 crc e2e97639 )
+	rom ( name "GBlator for CD64 (PD).z64" size 8388608 crc 9c8f0f5f )
+	rom ( name "GBlator for NTSC Dr V64 (PD).z64" size 524288 crc f7bb3dcd )
+	rom ( name "GBlator for PAL Dr V64 (PD).z64" size 524288 crc d1040f61 )
+	rom ( name "Neon64 First Public Beta Release by Halley's Comet Software (PD).z64" size 425168 crc 27778ce1 )
+	rom ( name "Neon64 First Public Beta Release V2 by Halley's Comet Software (PD).z64" size 2097152 crc 23674549 )
+	rom ( name "Neon64 First Public Beta Release V3 by Halley's Comet Software (PD).z64" size 516752 crc 2fb21af0 )
+	rom ( name "Neon64 GS V1.05 (Gameshark Version) (PD).bin" size 67763 crc 9574f823 )
+	rom ( name "Neon64 GS V1.1 (Gameshark Version) (PD).bin" size 20088 crc 42cc8f66 )
+	rom ( name "Neon64 GS V1.2 (Gameshark Version) (PD).bin" size 20888 crc 03ffab8e )
+	rom ( name "Neon64 GS V1.2 (Pro Action Replay Version) (PD).bin" size 20888 crc 96179e7a )
+	rom ( name "Neon64 GS V1.2a (Gameshark Version) (PD).bin" size 20912 crc 2f6e5a23 )
+	rom ( name "Neon64 GS V1.2a (Pro Action Replay Version) (PD).bin" size 20912 crc 740355d6 )
+	rom ( name "Neon64 V1.0 by Halley's Comet Software (PD).z64" size 2097152 crc 3ca8bc6e )
+	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD) [o2].z64" size 2097152 crc aab95ee1 )
+	rom ( name "Neon64 V1.1 by Halley's Comet Software (PD).z64" size 24272 crc 213d6889 )
+	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD) [o1].z64" size 2097152 crc baec90ec )
+	rom ( name "Neon64 V1.2 by Halley's Comet Software (PD).z64" size 80760 crc 36c5ab96 )
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [b1].z64" size 2097152 crc 10dea381 )
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD) [o1].z64" size 1052672 crc baeb6d04 )
+	rom ( name "Neon64 V1.2a by Halley's Comet Software (PD).z64" size 80904 crc 93bea654 )
+	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD) [f1] (V64BIOS1.91).z64" size 2097152 crc 6a2f8756 )
+	rom ( name "SNES 9X Alpha by Loom-Crazy Nation (PD).z64" size 8388608 crc 5dce278b )
+	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD) [f1] (V64).z64" size 2097152 crc 7dcc97a4 )
+	rom ( name "UltraMSX2 V1.0 by Jos Kwanten (PD).z64" size 524288 crc 4d2cc1c6 )
+	rom ( name "UltraMSX2 V1.0 w-F1 Spirit by Jos Kwanten (PD).z64" size 524288 crc 0255875d )
+	rom ( name "UltraMSX2 V1.0 w-Salamander by Jos Kwanten (PD).z64" size 524288 crc 264eae81 )
+	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD) [f1] (V64).z64" size 2097152 crc 03795ee4 )
+	rom ( name "UltraSMS V1.0 by Jos Kwanten (PD).z64" size 1048576 crc 6aebcd00 )
+	rom ( name "VNES64 + Galaga (PD).z64" size 1310720 crc 927b17a4 )
+	rom ( name "VNES64 + Mario (PD).z64" size 1310720 crc 16a708b2 )
+	rom ( name "VNES64 + Test Cart (PD).z64" size 1310720 crc a9e37ba5 )
+	rom ( name "VNES64 V0.1 by Jean-Luc Picard (POM '98) (PD).z64" size 1060878 crc e7898d4e )
+	rom ( name "VNES64 V0.12 by Jean-Luc Picard (PD).z64" size 2097152 crc b90d5f96 )
+)
+
+game (
+	name "Public Domain (Intros)"
+	description "Public Domain (Intros)"
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [b1].z64" size 1310720 crc 06a8eded )
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD) [h1C].z64" size 1310720 crc b7fbcfbf )
+	rom ( name "Absolute Crap Intro #1 by Kid Stardust (PD).z64" size 1310720 crc 886e5c25 )
+	rom ( name "Alienstyle Intro by Renderman (PD) [a1].z64" size 1310720 crc afc60bf3 )
+	rom ( name "Alienstyle Intro by Renderman (PD).z64" size 1310720 crc f6f9b635 )
+	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD) [b1].z64" size 262144 crc f3c6f1b3 )
+	rom ( name "Cliffi's Little Intro by Cliffi (POM '99) (PD).z64" size 1310720 crc bb82270a )
+	rom ( name "Dynamix Intro (Hidden Song) by Widget and Immortal (PD).z64" size 1310720 crc 7aa49c93 )
+	rom ( name "Dynamix Intro by Widget and Immortal (PD) [h1C].z64" size 1310720 crc 1c24be4d )
+	rom ( name "Dynamix Intro by Widget and Immortal (PD).z64" size 1310720 crc e188962a )
+	rom ( name "Eurasia First N64 Intro by Sispeo (PD).z64" size 1572864 crc 3e198a3c )
+	rom ( name "Eurasia Intro by Ste (PD) [b1].z64" size 1572864 crc e0832eb4 )
+	rom ( name "Eurasia Intro by Ste (PD).z64" size 2359296 crc aab92d03 )
+	rom ( name "Freekworld BBS Intro by Rene (PD) [a1].z64" size 786432 crc e8b47508 )
+	rom ( name "Freekworld BBS Intro by Rene (PD).z64" size 1048576 crc f909a0e2 )
+	rom ( name "Freekworld New Intro by Ste (PD).z64" size 1835008 crc 9e092010 )
+	rom ( name "GoldenEye 007 Intro by SonCrap (PD).z64" size 2097152 crc 1c95ea7d )
+	rom ( name "HSD Quick Intro (PD).z64" size 1310720 crc d8f98b8f )
+	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD) [a1].z64" size 1572864 crc a04eadec )
+	rom ( name "Kid Stardust Intro with Sound by Kid Stardust (PD).z64" size 1572864 crc 4fedb618 )
+	rom ( name "MSFTUG Intro #1 by LaC (PD).z64" size 1310720 crc 5ebd8482 )
+	rom ( name "NBC First Intro by CALi (PD).z64" size 262144 crc db19d4f2 )
+	rom ( name "Oerjan Intro by Oerjan (POM '99) (PD).z64" size 1310720 crc 899bae4d )
+	rom ( name "Planet Console Intro (PD).z64" size 262144 crc 266b8af5 )
+	rom ( name "Quake 64 Intro (PD).z64" size 1310720 crc c4dccebc )
+	rom ( name "RADWAR 2K Party Inv. Intro by Ayatolloh (PD).z64" size 2097152 crc 68ca8fa8 )
+	rom ( name "RPA Site Intro by Lem (PD).z64" size 1310720 crc a7ef1ee3 )
+	rom ( name "Soncrap Intro by RedboX (PD).z64" size 2097152 crc 433f92fa )
+	rom ( name "The Corporation 1st Intro by i_savant (PD) [b1].z64" size 1179648 crc c11a41e1 )
+	rom ( name "The Corporation 1st Intro by i_savant (PD).z64" size 1179648 crc 78afcb51 )
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [a1].z64" size 1310720 crc dbb84084 )
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD) [b1].z64" size 1310720 crc a8007491 )
+	rom ( name "The Corporation 2nd Intro by TS_Garp (PD).z64" size 1310720 crc 6f91442f )
+	rom ( name "Tristar and Lightforce Quake Intro by Ayatollah & Mike (PD).z64" size 1310720 crc c2733e40 )
+	rom ( name "TRSI Intro by Ayatollah (POM '99) (PD).z64" size 2621440 crc e998917a )
+	rom ( name "Virtual Springfield Site Intro by Presten (PD).z64" size 2359296 crc f1f3e11e )
+)
+
+game (
+	name "Public Domain (Tools)"
+	description "Public Domain (Tools)"
+	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD) [b1].z64" size 2097152 crc 8e095ecc )
+	rom ( name "Analogue Test Utility by WT_Riker (POM '99) (PD).z64" size 2097152 crc 36913e7d )
+	rom ( name "BB SRAM Manager (PD).z64" size 1310720 crc f1c0331e )
+	rom ( name "Boot Emu by Jovis (PD).z64" size 1310720 crc 8ce8ded7 )
+	rom ( name "CD64 Memory Test (PD).z64" size 1310720 crc dfab7498 )
+	rom ( name "Diddy Kong Racing SRAM by Group5 (PD).z64" size 1310720 crc 96cca1f2 )
+	rom ( name "DS1 Manager V1.0 by R. Bubba Magillicutty (PD).z64" size 262144 crc f7db1ba0 )
+	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD) [T+Ita].rom" size 262144 crc 91f9ed69 )
+	rom ( name "DS1 Manager V1.1 by R. Bubba Magillicutty (PD).z64" size 262144 crc 66afc5c3 )
+	rom ( name "DS1 SRAM Manager V1.1 by _Sage_ (PD).z64" size 1310720 crc 6aee017f )
+	rom ( name "Evek - V64jr Save Manager by WT_Riker (PD).z64" size 262144 crc b4745243 )
+	rom ( name "Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD).z64" size 1310720 crc 6545db14 )
+	rom ( name "Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD).z64" size 1310720 crc d8306df8 )
+	rom ( name "LaC's Universal Bootemu V1.0 (PD).z64" size 262144 crc f2def854 )
+	rom ( name "LaC's Universal Bootemu V1.1 (PD).z64" size 262144 crc abbb9cf8 )
+	rom ( name "LaC's Universal Bootemu V1.2 (PD).z64" size 1310720 crc 5dad5ce6 )
+	rom ( name "Mempack Manager for Jr 0.9 by deas (PD).z64" size 1310720 crc f0efb434 )
+	rom ( name "Mempack Manager for Jr 0.9b by deas (PD).z64" size 1310720 crc 07b656cd )
+	rom ( name "Mempack Manager for Jr 0.9c by deas (PD).z64" size 1310720 crc 8ff05062 )
+	rom ( name "Mempack to N64 Uploader by Destop V1.0 (PD).z64" size 427704 crc 7e787b48 )
+	rom ( name "Mortal Kombat SRAM Loader (PD).z64" size 1310720 crc 62e14497 )
+	rom ( name "NUTS - Nintendo Ultra64 Test Suite by MooglyGuy (PD).z64" size 2097152 crc ab88303d )
+	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD) [a1].z64" size 8388608 crc 7ef6fb76 )
+	rom ( name "SRAM Manager V1.0 Beta (32Mbit) (PD).z64" size 8388608 crc 2dfc78d5 )
+	rom ( name "SRAM Manager V1.0 Beta (PD).z64" size 2097152 crc 476dbab1 )
+	rom ( name "SRAM Manager V1.0 PAL Beta (PD).z64" size 1310720 crc 9ec21295 )
+	rom ( name "SRAM Manager V2.0 (PD) [a1].z64" size 786432 crc 87f2400c )
+	rom ( name "SRAM Manager V2.0 (PD) [h1C].z64" size 1310720 crc bf6c8a15 )
+	rom ( name "SRAM Manager V2.0 (PD) [h2C].z64" size 1310720 crc ba6f9de6 )
+	rom ( name "SRAM Manager V2.0 (PD).z64" size 1310720 crc 1bddf05f )
+	rom ( name "SRAM to DS1 Tool by WT_Riker (PD).z64" size 2097152 crc 2c1671e7 )
+	rom ( name "SRAM Upload Tool (PD).z64" size 1310720 crc 8280ab7a )
+	rom ( name "SRAM Upload Tool + Star Fox 64 SRAM (PD).z64" size 1310720 crc 44c44c92 )
+	rom ( name "SRAM Upload Tool V1 by LaC (PD).z64" size 8388608 crc d50828d1 )
+	rom ( name "SRAM Upload Tool V1.1 by Lac (PD) [b1].z64" size 1310720 crc 1eb5431c )
+	rom ( name "SRAM Upload Tool V1.1 by Lac (PD).z64" size 1310720 crc 0e4aba32 )
+	rom ( name "SRAM Uploader-Editor by BlackBag (PD).z64" size 1310720 crc 429277ee )
+	rom ( name "Unix SRAM-Upload Utility 1.0 by Madman (PD).z64" size 1310720 crc 46325595 )
+	rom ( name "V64Jr 512M Backup Program by HKPhooey (PD).z64" size 1310720 crc 33704aff )
+	rom ( name "V64Jr Backup Tool by WT_Riker (PD).z64" size 2097152 crc bda5fb4b )
+	rom ( name "V64Jr Backup Tool V0.2b_Beta by RedboX (PD).z64" size 2097152 crc 9536fe2b )
+	rom ( name "V64Jr Flash Save Util by CrowTRobo (PD).z64" size 1310720 crc 18f47b60 )
+	rom ( name "View N64 Test Program (PD) [b1].z64" size 2097152 crc fb65b4f8 )
+	rom ( name "View N64 Test Program (PD).z64" size 524288 crc a41556be )
+	rom ( name "Yoshi's Story BootEmu (PD).z64" size 1310720 crc 4ad8e4f7 )
+	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD) [a1].z64" size 262144 crc dd5ba742 )
+	rom ( name "Zelda 64 Boot Emu V1 by Crazy Nation (PD).z64" size 262144 crc 3ee1b78b )
+	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD) [a1].z64" size 262144 crc e4e29dc9 )
+	rom ( name "Zelda 64 Boot Emu V2 by Crazy Nation (PD).z64" size 262144 crc 07588d00 )
+)
+
+game (
+	name "Puyo Puyo 4 - Puyo Puyo Party"
+	description "Puyo Puyo 4 - Puyo Puyo Party"
+	rom ( name "Puyo Puyo 4 - Puyo Puyo Party (J) [!].z64" size 12582912 crc d59d2794 )
+)
+
+game (
+	name "Puyo Puyo Sun 64"
+	description "Puyo Puyo Sun 64"
+	rom ( name "Puyo Puyo Sun 64 (J) [!].z64" size 8388608 crc 355ff9de )
+	rom ( name "Puyo Puyo Sun 64 (J) [b1].z64" size 8388608 crc 3b88ce97 )
+)
+
+game (
+	name "Quake 64"
+	description "Quake 64"
+	rom ( name "Quake 64 (E) [!].z64" size 12582912 crc 28c10844 )
+	rom ( name "Quake 64 (E) [o1].z64" size 16777216 crc dcdeca54 )
+	rom ( name "Quake 64 (E) [t1].z64" size 12582912 crc 2618f474 )
+	rom ( name "Quake 64 (U) [!].z64" size 12582912 crc 761f39d1 )
+	rom ( name "Quake 64 (U) [b1].z64" size 12582912 crc 2e004334 )
+	rom ( name "Quake 64 (U) [h1C].z64" size 16777216 crc f7797d6c )
+	rom ( name "Quake 64 (U) [o1].z64" size 16777216 crc 92dcb206 )
+	rom ( name "Quake 64 (U) [o1][t1].z64" size 16777216 crc 2235b036 )
+	rom ( name "Quake 64 (U) [o2].z64" size 16777216 crc ba81d418 )
+	rom ( name "Quake 64 (U) [o2][t1].z64" size 16777216 crc 87f05c4d )
+	rom ( name "Quake 64 (U) [t1].z64" size 12582912 crc 61d7e238 )
+)
+
+game (
+	name "Quake II"
+	description "Quake II"
+	rom ( name "Quake II (E) [!].z64" size 12582912 crc 82beca21 )
+	rom ( name "Quake II (E) [h1C].z64" size 12582912 crc d7002a39 )
+	rom ( name "Quake II (U) [!].z64" size 12582912 crc e6b34387 )
+	rom ( name "Quake II (U) [f1] (PAL).z64" size 12582912 crc 2cd53cf2 )
+)
+
+game (
+	name "Quest 64"
+	description "Quest 64"
+	rom ( name "Eltale Monsters (J) [!].z64" size 16777216 crc a4fe7652 )
+	rom ( name "Eltale Monsters (J) [b1].z64" size 16777181 crc 75fffb14 )
+	rom ( name "Holy Magic Century (E) [!].z64" size 16777216 crc bf6f67bf )
+	rom ( name "Holy Magic Century (E) [b1].z64" size 16777216 crc 84ff9890 )
+	rom ( name "Holy Magic Century (F) [h1C].z64" size 16777216 crc baf6c66a )
+	rom ( name "Holy Magic Century (F) [o1].z64" size 16777220 crc 53ccd8f4 )
+	rom ( name "Holy Magic Century (F).z64" size 16777216 crc 284170ed )
+	rom ( name "Holy Magic Century (G) [!].z64" size 16777216 crc d1934cf6 )
+	rom ( name "Holy Magic Century (G) [b1].z64" size 16777216 crc 2f87f160 )
+	rom ( name "Holy Magic Century (G) [b2].z64" size 16777216 crc aa28c3c1 )
+	rom ( name "Holy Magic Century (G) [b3].z64" size 16777216 crc 8bc3d869 )
+	rom ( name "Quest 64 (U) [!].z64" size 16777216 crc d75b45c6 )
+	rom ( name "Quest 64 (U) [b1].z64" size 16777216 crc 166b46bf )
+	rom ( name "Quest 64 (U) [b2].z64" size 8519680 crc b23c4425 )
+	rom ( name "Quest 64 (U) [b3].z64" size 16777216 crc c4134703 )
+	rom ( name "Quest 64 (U) [b4].z64" size 16515072 crc 4a3a1548 )
+	rom ( name "Quest 64 (U) [b5].z64" size 16777216 crc d3c10d18 )
+	rom ( name "Quest 64 (U) [t1].z64" size 16777216 crc addb964b )
+)
+
+game (
+	name "Rakuga Kids"
+	description "Rakuga Kids"
+	rom ( name "Rakuga Kids (E) [!].z64" size 12582912 crc 483129aa )
+	rom ( name "Rakuga Kids (E) [b1].z64" size 12582912 crc f2f11a4f )
+	rom ( name "Rakuga Kids (E) [f1] (NTSC).z64" size 12582912 crc b62029dd )
+	rom ( name "Rakuga Kids (E) [h1C].z64" size 12582912 crc b9165694 )
+	rom ( name "Rakuga Kids (J) [!].z64" size 12582912 crc b9e53b06 )
+	rom ( name "Rakuga Kids (J) [b1].z64" size 12582912 crc 4d897ef9 )
+	rom ( name "Rakuga Kids (J) [h1C].z64" size 12582912 crc 48c24438 )
+)
+
+game (
+	name "Rally Challenge 2000"
+	description "Rally Challenge 2000"
+	rom ( name "Rally '99 (J) [!].z64" size 8388608 crc ffa625fe )
+	rom ( name "Rally '99 (J) [f1] (PAL).z64" size 8388608 crc d12ee95f )
+	rom ( name "Rally Challenge 2000 (U) [!].z64" size 12582912 crc 3edec7b0 )
+)
+
+game (
+	name "Rampage - World Tour"
+	description "Rampage - World Tour"
+	rom ( name "Rampage - World Tour (E) [!].z64" size 12582912 crc cdc458ec )
+	rom ( name "Rampage - World Tour (E) [h1C].z64" size 12582912 crc 4d1c58cc )
+	rom ( name "Rampage - World Tour (U) [!].z64" size 12582912 crc 211119dd )
+	rom ( name "Rampage - World Tour (U) [b1].z64" size 12648804 crc c86193cb )
+	rom ( name "Rampage - World Tour (U) [b2].z64" size 12582912 crc 57788722 )
+	rom ( name "Rampage - World Tour (U) [b3].z64" size 12582910 crc 3e734158 )
+	rom ( name "Rampage - World Tour (U) [b4].z64" size 12582912 crc 68e3e953 )
+	rom ( name "Rampage - World Tour (U) [h1C].z64" size 12582912 crc dc157ffb )
+	rom ( name "Rampage - World Tour (U) [t1].z64" size 12582912 crc 81dd0ec0 )
+	rom ( name "Rampage - World Tour (U) [t2].z64" size 12582912 crc 7a16a164 )
+)
+
+game (
+	name "Rampage 2 - Universal Tour"
+	description "Rampage 2 - Universal Tour"
+	rom ( name "Rampage 2 - Universal Tour (E) [!].z64" size 12582912 crc fa6e097b )
+	rom ( name "Rampage 2 - Universal Tour (U) [!].z64" size 12582912 crc 7614ee0d )
+	rom ( name "Rampage 2 - Universal Tour (U) [t1].z64" size 12845056 crc b1f3163b )
+	rom ( name "Rampage 2 - Universal Tour (U) [t2].z64" size 12845056 crc 259dc074 )
+)
+
+game (
+	name "Rat Attack"
+	description "Rat Attack"
+	rom ( name "Rat Attack (E) (M6) [!].z64" size 8388608 crc dd4fa798 )
+	rom ( name "Rat Attack (E) (M6) [f1] (NTSC).z64" size 8388608 crc e9cbbe51 )
+	rom ( name "Rat Attack (E) (M6) [h1C].z64" size 8388608 crc e4215fef )
+	rom ( name "Rat Attack (U) (M6) [!].z64" size 8388608 crc 2315fea7 )
+)
+
+game (
+	name "Rayman 2 - The Great Escape"
+	description "Rayman 2 - The Great Escape"
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [!].z64" size 33554432 crc 169a5037 )
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC).z64" size 33554432 crc 9d33f2e1 )
+	rom ( name "Rayman 2 - The Great Escape (E) (M5) [f2] (NTSC).z64" size 33554432 crc 98ae479b )
+	rom ( name "Rayman 2 - The Great Escape (U) (M5) [!].z64" size 33554432 crc 02bb4409 )
+	rom ( name "Rayman 2 - The Great Escape (U) (M5) [t1].z64" size 33554432 crc 415a2bbc )
+)
+
+game (
+	name "Razor Freestyle Scooter"
+	description "Razor Freestyle Scooter"
+	rom ( name "Razor Freestyle Scooter (U) [!].z64" size 8388608 crc 927ce621 )
+)
+
+game (
+	name Re-Volt
+	description "Re-Volt"
+	rom ( name "Re-Volt (E) (M4) [!].z64" size 12582912 crc 81d13a11 )
+	rom ( name "Re-Volt (U) [!].z64" size 12582912 crc fc0c86d0 )
+	rom ( name "Re-Volt (U) [f1] (Country Check).z64" size 12582912 crc ec4c68d4 )
+	rom ( name "Re-Volt (U) [f2] (PAL).z64" size 12582912 crc f3efc7cb )
+	rom ( name "Re-Volt (U) [t1].z64" size 12582912 crc 604400cf )
+)
+
+game (
+	name "Ready 2 Rumble Boxing"
+	description "Ready 2 Rumble Boxing"
+	rom ( name "Ready 2 Rumble Boxing (E) (M3) [!].z64" size 33554432 crc a69df7b3 )
+	rom ( name "Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable).z64" size 33554432 crc b0591a28 )
+	rom ( name "Ready 2 Rumble Boxing (U) [!].z64" size 33554432 crc 2a554048 )
+	rom ( name "Ready 2 Rumble Boxing (U) [f1] (PAL).z64" size 33554432 crc c981afb7 )
+	rom ( name "Ready 2 Rumble Boxing (U) [t1] (P1 Untouchable).z64" size 33554432 crc ff48b206 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing - Round 2"
+	description "Ready 2 Rumble Boxing - Round 2"
+	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [!].z64" size 33554432 crc 052a0e04 )
+	rom ( name "Ready 2 Rumble Boxing - Round 2 (U) [t1].z64" size 33554432 crc b5e23cc7 )
+)
+
+game (
+	name "Resident Evil 2"
+	description "Resident Evil 2"
+	rom ( name "Biohazard 2 (J) [!].z64" size 67108864 crc 4f9d569f )
+	rom ( name "Resident Evil 2 (E) (M2) [!].z64" size 67108864 crc 7c8ee011 )
+	rom ( name "Resident Evil 2 (U) (V1.1) [!].z64" size 67108864 crc 848fbc0d )
+)
+
+game (
+	name "Road Rash 64"
+	description "Road Rash 64"
+	rom ( name "Road Rash 64 (E) [!].z64" size 33554432 crc 3c664a7b )
+	rom ( name "Road Rash 64 (E) [h1C].z64" size 33554432 crc 39bb993f )
+	rom ( name "Road Rash 64 (U) [!].z64" size 33554432 crc 600b3988 )
+	rom ( name "Road Rash 64 (U) [f1] (PAL).z64" size 33554432 crc 321afcc1 )
+	rom ( name "Road Rash 64 (U) [t1].z64" size 33554432 crc d10f77a1 )
+)
+
+game (
+	name "Roadsters Trophy"
+	description "Roadsters Trophy"
+	rom ( name "Roadsters Trophy (E) (M6) [!].z64" size 12582912 crc 997ed5af )
+	rom ( name "Roadsters Trophy (U) (M3) [!].z64" size 12582912 crc e4337b92 )
+	rom ( name "Roadsters Trophy (U) (M3) [f1] (PAL).z64" size 12582912 crc 55980f72 )
+	rom ( name "Roadsters Trophy (U) (M3) [t1].z64" size 12582912 crc a51b51d1 )
+)
+
+game (
+	name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel"
+	description "Robot Ponkotsu 64 - 7tsu no Umi no Caramel"
+	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [!].z64" size 33554432 crc 3b0f8061 )
+	rom ( name "Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL).z64" size 33554432 crc b4f3e4e6 )
+)
+
+game (
+	name "Robotech - Crystal Dreams"
+	description "Robotech - Crystal Dreams"
+	rom ( name "Robotech - Crystal Dreams (Beta) [a1].z64" size 12582912 crc 8f5bc48f )
+	rom ( name "Robotech - Crystal Dreams (Beta).z64" size 16777216 crc f9a7904e )
+)
+
+game (
+	name "Robotron 64"
+	description "Robotron 64"
+	rom ( name "Robotron 64 (E) [!].z64" size 8388608 crc 23bf4956 )
+	rom ( name "Robotron 64 (E) [h1C].z64" size 8388608 crc 90088356 )
+	rom ( name "Robotron 64 (U) [!].z64" size 8388608 crc b2cbae58 )
+	rom ( name "Robotron 64 (U) [b1].z64" size 8388608 crc 3c95e84c )
+	rom ( name "Robotron 64 (U) [b2].z64" size 8388608 crc 6093b12b )
+	rom ( name "Robotron 64 (U) [b3].z64" size 8388608 crc d3247b2b )
+	rom ( name "Robotron 64 (U) [b4].z64" size 8388608 crc 8fb685a9 )
+	rom ( name "Robotron 64 (U) [f1] (PAL).z64" size 8388608 crc 8ba428cd )
+	rom ( name "Robotron 64 (U) [o1].z64" size 8126464 crc 1d89eb63 )
+	rom ( name "Robotron 64 (U) [t1].z64" size 8388608 crc 9d5938ac )
+)
+
+game (
+	name "Rocket - Robot on Wheels"
+	description "Rocket - Robot on Wheels"
+	rom ( name "Rocket - Robot on Wheels (E) (M3) [!].z64" size 12582912 crc 7de5d20d )
+	rom ( name "Rocket - Robot on Wheels (U) [!].z64" size 12582912 crc e0399f23 )
+	rom ( name "Rocket - Robot on Wheels (U) [b1].z64" size 12582912 crc fb415f76 )
+	rom ( name "Rocket - Robot on Wheels (U) [f1] (PAL).z64" size 12582912 crc 72d33867 )
+	rom ( name "Rocket - Robot on Wheels (U) [t1].z64" size 12582912 crc a449f11c )
+)
+
+game (
+	name "RR64 - Ridge Racer 64"
+	description "RR64 - Ridge Racer 64"
+	rom ( name "RR64 - Ridge Racer 64 (E) [!].z64" size 33554432 crc dd9ae3a8 )
+	rom ( name "RR64 - Ridge Racer 64 (U) [!].z64" size 33554432 crc 3c2c2d1c )
+	rom ( name "RR64 - Ridge Racer 64 (U) [f1] (PAL).z64" size 33554432 crc bfe2077b )
+	rom ( name "RR64 - Ridge Racer 64 (U) [t1].z64" size 33554432 crc 7adf6a89 )
+)
+
+game (
+	name "Rugrats - Scavenger Hunt"
+	description "Rugrats - Scavenger Hunt"
+	rom ( name "Les Razmoket - La Chasse Aux Tresors (F) [!].z64" size 16777216 crc 66766469 )
+	rom ( name "Rugrats - Die grosse Schatzsuche (G) [!].z64" size 16777216 crc 23aed3a2 )
+	rom ( name "Rugrats - Scavenger Hunt (U) [!].z64" size 16777216 crc a87faf82 )
+	rom ( name "Rugrats - Scavenger Hunt (U) [f1] (PAL).z64" size 16777216 crc e24fcd04 )
+	rom ( name "Rugrats - Treasure Hunt (E) [!].z64" size 16777216 crc 3338b7c8 )
+	rom ( name "Rugrats - Treasure Hunt (E) [h1C].z64" size 16777216 crc a1938b36 )
+)
+
+game (
+	name "Rugrats in Paris - The Movie"
+	description "Rugrats in Paris - The Movie"
+	rom ( name "Rugrats in Paris - The Movie (E) [!].z64" size 16777216 crc cd74b07e )
+	rom ( name "Rugrats in Paris - The Movie (U) [!].z64" size 16777216 crc a9cc2419 )
+	rom ( name "Rugrats in Paris - The Movie (U) [T+Spa0.10].z64" size 16777216 crc bda8a807 )
+)
+
+game (
+	name "Rush 2 - Extreme Racing USA"
+	description "Rush 2 - Extreme Racing USA"
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [!].z64" size 12582912 crc 30f21f89 )
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h1I].z64" size 12582912 crc 3940f7dd )
+	rom ( name "Rush 2 - Extreme Racing USA (E) (M6) [h2I].z64" size 12582912 crc e23de536 )
+	rom ( name "Rush 2 - Extreme Racing USA (U) [!].z64" size 12582912 crc 9eb14ea8 )
+)
+
+game (
+	name S.C.A.R.S.
+	description "S.C.A.R.S."
+	rom ( name "S.C.A.R.S. (E) (M3) [!].z64" size 8388608 crc 4e37b6f2 )
+	rom ( name "S.C.A.R.S. (E) (M3) [h1C].z64" size 8388608 crc c3747a8d )
+	rom ( name "S.C.A.R.S. (U) [!].z64" size 8388608 crc 22916735 )
+	rom ( name "S.C.A.R.S. (U) [f1] (PAL).z64" size 8388608 crc 848b3dab )
+	rom ( name "S.C.A.R.S. (U) [t1].z64" size 8388608 crc 42a8ee01 )
+)
+
+game (
+	name "Saikyou Habu Shougi"
+	description "Saikyou Habu Shougi"
+	rom ( name "Saikyou Habu Shougi (J) [!].z64" size 8388608 crc 01794d62 )
+	rom ( name "Saikyou Habu Shougi (J) [h1C].z64" size 8388608 crc c1f2b7a4 )
+	rom ( name "Saikyou Habu Shougi (J) [h2C].z64" size 8388608 crc a5d2585d )
+	rom ( name "Saikyou Habu Shougi (J) [h3C].z64" size 8388608 crc cb3fd380 )
+	rom ( name "Saikyou Habu Shougi (J) [h4C].z64" size 8388608 crc a1211799 )
+)
+
+game (
+	name "San Francisco Rush - Extreme Racing"
+	description "San Francisco Rush - Extreme Racing"
+	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [!].z64" size 8388608 crc e064962a )
+	rom ( name "San Francisco Rush - Extreme Racing (E) (M3) [h1C].z64" size 8388608 crc 34a7f68e )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [!].z64" size 8388608 crc 3e20070b )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b1].z64" size 16777216 crc cf1e89e3 )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b2].z64" size 16777216 crc c5c8ce3b )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [b3].z64" size 8388608 crc f0772e31 )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o1].z64" size 12582912 crc e9adb7c1 )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o2].z64" size 16777216 crc d0a9eb38 )
+	rom ( name "San Francisco Rush - Extreme Racing (U) (M3) [o3].z64" size 16777216 crc b6b9f6be )
+)
+
+game (
+	name "San Francisco Rush 2049"
+	description "San Francisco Rush 2049"
+	rom ( name "San Francisco Rush 2049 (E) (M6) [!].z64" size 12582912 crc e63b86c5 )
+	rom ( name "San Francisco Rush 2049 (U) [!].z64" size 12582912 crc 10941439 )
+	rom ( name "San Francisco Rush 2049 (U) [t1].z64" size 12582912 crc 540a6de1 )
+)
+
+game (
+	name "Scooby-Doo! - Classic Creep Capers"
+	description "Scooby-Doo! - Classic Creep Capers"
+	rom ( name "Scooby-Doo! - Classic Creep Capers (E) [!].z64" size 16777216 crc 0d737e6f )
+	rom ( name "Scooby-Doo! - Classic Creep Capers (U) [!].z64" size 16777216 crc 39068228 )
+)
+
+game (
+	name "SD Hiryuu no Ken Densetsu"
+	description "SD Hiryuu no Ken Densetsu"
+	rom ( name "SD Hiryuu no Ken Densetsu (J) [!].z64" size 12582912 crc cc083e34 )
+	rom ( name "SD Hiryuu no Ken Densetsu (J) [f1] (PAL).z64" size 12582912 crc e0921d7e )
+)
+
+game (
+	name "Shadow Man"
+	description "Shadow Man"
+	rom ( name "Shadow Man (E) (M3) [!].z64" size 33554432 crc 8d230306 )
+	rom ( name "Shadow Man (F) [!].z64" size 33554432 crc 6812d3a7 )
+	rom ( name "Shadow Man (G) [!].z64" size 33554432 crc eaf6add1 )
+	rom ( name "Shadow Man (G) [b1].z64" size 33554432 crc f71cc55b )
+	rom ( name "Shadow Man (G) [b2].z64" size 33554432 crc e020c909 )
+	rom ( name "Shadow Man (G) [f1] (NTSC).z64" size 33554432 crc c580323e )
+	rom ( name "Shadow Man (U) [!].z64" size 33554432 crc 5e20cc63 )
+	rom ( name "Shadow Man (U) [b1].z64" size 33554432 crc 622d1f6c )
+	rom ( name "Shadow Man (U) [b2].z64" size 33554980 crc 65af5218 )
+	rom ( name "Shadow Man (U) [b3].z64" size 33554431 crc 80b0befd )
+	rom ( name "Shadow Man (U) [t1].z64" size 33554432 crc 181f5096 )
+)
+
+game (
+	name "Shadowgate 64 - Trials Of The Four Towers"
+	description "Shadowgate 64 - Trials Of The Four Towers"
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!].z64" size 16777216 crc 87f00472 )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!].z64" size 16777216 crc eedc0bea )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [!].z64" size 16777216 crc ff7d7df0 )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC).z64" size 16777216 crc 31fc728a )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b1].z64" size 16777216 crc 2bd3203a )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J) [b2].z64" size 16777216 crc cbeb984b )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (J).z64" size 16777216 crc 9f74a58c )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!].z64" size 16777216 crc 69983cc3 )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL).z64" size 16777216 crc 627f113a )
+	rom ( name "Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f2] (PAL).z64" size 16777216 crc 1b731693 )
+)
+
+game (
+	name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition"
+	description "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition"
+	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [!].z64" size 16777216 crc 576915d4 )
+	rom ( name "Shigesato Itoi's No. 1 Bass Fishing! Definitive Edition (J) [b1].z64" size 16777216 crc b8925ed3 )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits"
+	description "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits"
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!].z64" size 12582912 crc e892ed43 )
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1].z64" size 11796480 crc 66790e64 )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation"
+	description "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation"
+	rom ( name "Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!].z64" size 33554432 crc deac787f )
+)
+
+game (
+	name "Sim City 2000"
+	description "Sim City 2000"
+	rom ( name "Sim City 2000 (J) [!].z64" size 12582912 crc 57767e45 )
+	rom ( name "Sim City 2000 (J) [b1].z64" size 12582912 crc ae23045e )
+	rom ( name "Sim City 2000 (J) [b1][o1].z64" size 11010048 crc c2fd3d62 )
+	rom ( name "Sim City 2000 (J) [b2].z64" size 16777216 crc e435b297 )
+	rom ( name "Sim City 2000 (J) [h1C].z64" size 12582912 crc 8140d8fc )
+	rom ( name "Sim City 2000 (J) [o1].z64" size 16777216 crc 73c9ab24 )
+	rom ( name "Sim City 2000 (J) [o1][h1C].z64" size 16777216 crc dbef385d )
+)
+
+game (
+	name "Snowboard Kids"
+	description "Snowboard Kids"
+	rom ( name "Snobow Kids (J) [!].z64" size 8388608 crc 213bf381 )
+	rom ( name "Snobow Kids (J) [h1C].z64" size 8388608 crc ce6d35f1 )
+	rom ( name "Snobow Kids (J) [h2C].z64" size 8388608 crc 299830e2 )
+	rom ( name "Snowboard Kids (E) [!].z64" size 8388608 crc 5619a70d )
+	rom ( name "Snowboard Kids (E) [h1C].z64" size 8388608 crc eca826fc )
+	rom ( name "Snowboard Kids (U) [!].z64" size 8388608 crc 020fb906 )
+	rom ( name "Snowboard Kids (U) [b1].z64" size 8388612 crc 798d185f )
+	rom ( name "Snowboard Kids (U) [b2].z64" size 8388608 crc cc3a899d )
+	rom ( name "Snowboard Kids (U) [b3].z64" size 8388608 crc 8eb60a3d )
+	rom ( name "Snowboard Kids (U) [h1C].z64" size 8388608 crc b8be38f7 )
+	rom ( name "Snowboard Kids (U) [t1].z64" size 8388608 crc 72219675 )
+)
+
+game (
+	name "Snowboard Kids 2"
+	description "Snowboard Kids 2"
+	rom ( name "Chou Snobow Kids (J) [!].z64" size 16777216 crc 8fedf4c6 )
+	rom ( name "Chou Snobow Kids (J) [f1] (PAL).z64" size 16777216 crc f999b89c )
+	rom ( name "Snowboard Kids 2 (E) [!].z64" size 16777216 crc 3a0b6214 )
+	rom ( name "Snowboard Kids 2 (U) [!].z64" size 16777216 crc d0dc8a8e )
+	rom ( name "Snowboard Kids 2 (U) [f1] (PAL).z64" size 16777216 crc ac4b9da6 )
+	rom ( name "Snowboard Kids 2 (U) [f2] (PAL).z64" size 16777216 crc 8232ccaf )
+)
+
+game (
+	name "South Park"
+	description "South Park"
+	rom ( name "South Park (E) (M3) [!].z64" size 16777216 crc b2c3e123 )
+	rom ( name "South Park (E) (M3) [b1].z64" size 16777216 crc 56c96784 )
+	rom ( name "South Park (E) (M3) [h1C].z64" size 16777216 crc 4710b1cd )
+	rom ( name "South Park (G) [!].z64" size 16777216 crc 5711e197 )
+	rom ( name "South Park (U) [!].z64" size 16777216 crc 7d666b9e )
+	rom ( name "South Park (U) [b1].z64" size 16777216 crc 858f3df8 )
+	rom ( name "South Park (U) [f1] (PAL).z64" size 16777216 crc 73c0bcf5 )
+	rom ( name "South Park (U) [t1].z64" size 16777216 crc 4efe2139 )
+)
+
+game (
+	name "South Park - Chef's Luv Shack"
+	description "South Park - Chef's Luv Shack"
+	rom ( name "South Park - Chef's Luv Shack (E) [!].z64" size 16777216 crc ac1628eb )
+	rom ( name "South Park - Chef's Luv Shack (U) [!].z64" size 16777216 crc 6b6b1d09 )
+	rom ( name "South Park - Chef's Luv Shack (U) [f1] (Country Check).z64" size 16777216 crc 605de6c5 )
+)
+
+game (
+	name "South Park Rally"
+	description "South Park Rally"
+	rom ( name "South Park Rally (E) [!].z64" size 16777216 crc 296e3525 )
+	rom ( name "South Park Rally (U) [!].z64" size 16777216 crc ccdd322a )
+	rom ( name "South Park Rally (U) [f1] (PAL).z64" size 16777216 crc 5b9b3f35 )
+	rom ( name "South Park Rally (U) [t1].z64" size 17039360 crc ac087102 )
+	rom ( name "South Park Rally (U) [t2].z64" size 16810384 crc dc38c0be )
+)
+
+game (
+	name "Space Invaders"
+	description "Space Invaders"
+	rom ( name "Space Invaders (U) [!].z64" size 8388608 crc 60f7ff8e )
+	rom ( name "Space Invaders (U) [f1] (PAL).z64" size 8388608 crc 2ce1ebb0 )
+	rom ( name "Space Invaders (U) [t1].z64" size 8388608 crc 47469c2d )
+	rom ( name "Space Invaders (U) [t2].z64" size 8388608 crc bab1c482 )
+)
+
+game (
+	name "Space Station Silicon Valley"
+	description "Space Station Silicon Valley"
+	rom ( name "Space Station Silicon Valley (E) (M7) [!].z64" size 8388608 crc 63042e36 )
+	rom ( name "Space Station Silicon Valley (E) (M7) [b1].z64" size 8388608 crc a7507158 )
+	rom ( name "Space Station Silicon Valley (J) [!].z64" size 8388608 crc dcec9f8a )
+	rom ( name "Space Station Silicon Valley (U) [!].z64" size 8388608 crc a606e8ae )
+	rom ( name "Space Station Silicon Valley (U) [f1] (PAL).z64" size 8388608 crc 0ef42062 )
+	rom ( name "Space Station Silicon Valley (U) [f2] (PAL).z64" size 8388608 crc 1b17acd9 )
+)
+
+game (
+	name Spider-Man
+	description "Spider-Man"
+	rom ( name "Spider-Man (U) [!].z64" size 33554432 crc 696cc2a4 )
+	rom ( name "Spider-Man (U) [t1].z64" size 33554432 crc 071196f8 )
+)
+
+game (
+	name "Star Fox 64"
+	description "Star Fox 64"
+	rom ( name "Lylat Wars (A) (M3) [!].z64" size 12582912 crc 9a3425da )
+	rom ( name "Lylat Wars (A) (M3) [f1].z64" size 12582912 crc 6c252beb )
+	rom ( name "Lylat Wars (A) (M3) [t1] (Boost).z64" size 12582912 crc 45139835 )
+	rom ( name "Lylat Wars (A) (M3) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 9f5255da )
+	rom ( name "Lylat Wars (E) (M3) [!].z64" size 12582912 crc 50a9c0b1 )
+	rom ( name "Lylat Wars (E) (M3) [f1].z64" size 12582912 crc a6b8ce80 )
+	rom ( name "Lylat Wars (E) (M3) [f1][h1C].z64" size 12582912 crc 82e3ff42 )
+	rom ( name "Lylat Wars (E) (M3) [f2] (NTSC).z64" size 12582912 crc 927cf25e )
+	rom ( name "Lylat Wars (E) (M3) [t1] (Boost).z64" size 12582912 crc 321ece7e )
+	rom ( name "Lylat Wars (E) (M3) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 13576cdd )
+	rom ( name "Star Fox 64 (J) [!].z64" size 12582912 crc 411142a7 )
+	rom ( name "Star Fox 64 (J) [f1].z64" size 12582912 crc dac2f94e )
+	rom ( name "Star Fox 64 (J) [o1].z64" size 16777216 crc 94e2bf8b )
+	rom ( name "Star Fox 64 (J) [o1][f1].z64" size 16777216 crc 4dc374c0 )
+	rom ( name "Star Fox 64 (J) [o2][f1].z64" size 16777216 crc 5d842b4d )
+	rom ( name "Star Fox 64 (J) [o3][f1].z64" size 16777216 crc 5439c8ed )
+	rom ( name "Star Fox 64 (J) [t1] (Boost).z64" size 12582912 crc 21278e57 )
+	rom ( name "Star Fox 64 (J) [t2] (No Damage-Unbreakable Wings).z64" size 12582912 crc 0963550f )
+	rom ( name "Star Fox 64 (U) (V1.0) [!].z64" size 12582912 crc b1fcaa9c )
+	rom ( name "Star Fox 64 (U) (V1.0) [f1].z64" size 12582912 crc 2a2f1175 )
+	rom ( name "Star Fox 64 (U) (V1.0) [f1][h1C].z64" size 12582912 crc 2e096bc0 )
+	rom ( name "Star Fox 64 (U) (V1.0) [f1][o1].z64" size 16777216 crc 6a831a95 )
+	rom ( name "Star Fox 64 (U) (V1.0) [f2] (PAL).z64" size 12582912 crc 878b74e8 )
+	rom ( name "Star Fox 64 (U) (V1.0) [h1C].z64" size 12582912 crc db9324c2 )
+	rom ( name "Star Fox 64 (U) (V1.0) [o1][f1].z64" size 16777216 crc b6007a08 )
+	rom ( name "Star Fox 64 (U) (V1.0) [o2][f1].z64" size 12845056 crc 792ed884 )
+	rom ( name "Star Fox 64 (U) (V1.0) [o3][f1].z64" size 33554432 crc e86af5a6 )
+	rom ( name "Star Fox 64 (U) (V1.0) [t1].z64" size 12845056 crc af40cb76 )
+	rom ( name "Star Fox 64 (U) (V1.0) [t2] (Boost).z64" size 12582912 crc 65935fe9 )
+	rom ( name "Star Fox 64 (U) (V1.0) [t3] (No Damage-Unbreakable Wings).z64" size 12582912 crc d9215c45 )
+	rom ( name "Star Fox 64 (U) (V1.1) [!].z64" size 12582912 crc b1b5fc46 )
+	rom ( name "Star Fox 64 (U) (V1.1) [t1] (Energy).z64" size 12582912 crc f066cc83 )
+	rom ( name "Star Fox 64 (U) (V1.1) [t2] (Boost).z64" size 12582912 crc 5083b27c )
+)
+
+game (
+	name "Star Soldier - Vanishing Earth"
+	description "Star Soldier - Vanishing Earth"
+	rom ( name "Star Soldier - Vanishing Earth (J) [!].z64" size 12582912 crc 7ee5f51d )
+	rom ( name "Star Soldier - Vanishing Earth (J) [b1].z64" size 12582912 crc 532379c3 )
+	rom ( name "Star Soldier - Vanishing Earth (J) [h1C].z64" size 12582912 crc cfda6035 )
+	rom ( name "Star Soldier - Vanishing Earth (J) [o1].z64" size 33554432 crc 720344d8 )
+	rom ( name "Star Soldier - Vanishing Earth (J) [t1].z64" size 12582912 crc 445278b4 )
+	rom ( name "Star Soldier - Vanishing Earth (U) [!].z64" size 12582912 crc ea650def )
+	rom ( name "Star Soldier - Vanishing Earth (U) [t1].z64" size 12582912 crc be7aa424 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron"
+	description "Star Wars - Rogue Squadron"
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack).z64" size 16777216 crc acaa878b )
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [!].z64" size 16777216 crc 6289645f )
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.0) [t1].z64" size 16777216 crc 8aaff501 )
+	rom ( name "Star Wars - Rogue Squadron (E) (M3) (V1.1) [!].z64" size 16777216 crc c88e5638 )
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) (Language Select Hack).z64" size 16777216 crc d85ee95e )
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [!].z64" size 16777216 crc 83c225cc )
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [b1].z64" size 16777216 crc 207df305 )
+	rom ( name "Star Wars - Rogue Squadron (U) (M3) [t1].z64" size 16777216 crc 11adce88 )
+	rom ( name "Star Wars - Shutsugeki! Rogue Chuutai (J) [!].z64" size 16777216 crc ee7643b6 )
+)
+
+game (
+	name "Star Wars - Shadows of the Empire"
+	description "Star Wars - Shadows of the Empire"
+	rom ( name "Star Wars - Shadows of the Empire (E) [!].z64" size 12582912 crc f0a191bf )
+	rom ( name "Star Wars - Shadows of the Empire (E) [b1].z64" size 10440704 crc 2cb8bc8d )
+	rom ( name "Star Wars - Shadows of the Empire (E) [b2].z64" size 8388608 crc eeb97b44 )
+	rom ( name "Star Wars - Shadows of the Empire (E) [b3].z64" size 12582912 crc e1d48724 )
+	rom ( name "Star Wars - Shadows of the Empire (E) [b4].z64" size 16777216 crc 0387f26c )
+	rom ( name "Star Wars - Shadows of the Empire (E) [o1].z64" size 16777216 crc 34c7981c )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [!].z64" size 12582912 crc 3c0837b3 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b1].z64" size 12582912 crc f4e231a3 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [b2].z64" size 12582912 crc e9810930 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [o1].z64" size 16777216 crc 1ec5f1dc )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t1].z64" size 12845056 crc e09db876 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.0) [t2].z64" size 12845056 crc 1012bedd )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [!].z64" size 12582912 crc b0540688 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [b1].z64" size 12582912 crc db8c7e81 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [o1].z64" size 16777216 crc 86767af9 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.1) [t1].z64" size 12845056 crc 1cc97b41 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [!].z64" size 12582912 crc e8727549 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b1].z64" size 12845056 crc efebc833 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [b2].z64" size 12582912 crc 26408ea6 )
+	rom ( name "Star Wars - Shadows of the Empire (U) (V1.2) [o1].z64" size 16777216 crc 222d4a2b )
+	rom ( name "Star Wars - Teikoku no Kage (J) [!].z64" size 12582912 crc 7ce71426 )
+	rom ( name "Star Wars - Teikoku no Kage (J) [o1].z64" size 16777216 crc 6b430661 )
+	rom ( name "Star Wars - Teikoku no Kage (J) [o2].z64" size 16777216 crc 506afdda )
+)
+
+game (
+	name "Star Wars Episode I - Battle for Naboo"
+	description "Star Wars Episode I - Battle for Naboo"
+	rom ( name "Star Wars Episode I - Battle for Naboo (E) [!].z64" size 33554432 crc 029104fd )
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [!].z64" size 33554432 crc 99dee3c0 )
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [b1].z64" size 33329432 crc f02cd015 )
+	rom ( name "Star Wars Episode I - Battle for Naboo (U) [t1].z64" size 33554432 crc 377ce7c7 )
+)
+
+game (
+	name "Star Wars Episode I - Racer"
+	description "Star Wars Episode I - Racer"
+	rom ( name "Star Wars Episode I - Racer (E) (M3) [!].z64" size 33554432 crc e0f46629 )
+	rom ( name "Star Wars Episode I - Racer (E) (M3) [f1] (Save).z64" size 33554432 crc df6da1cf )
+	rom ( name "Star Wars Episode I - Racer (J) [!].z64" size 33554432 crc 97c155c5 )
+	rom ( name "Star Wars Episode I - Racer (J) [b1].z64" size 33554432 crc 5cc91891 )
+	rom ( name "Star Wars Episode I - Racer (U) [!].z64" size 33554432 crc c53c1035 )
+	rom ( name "Star Wars Episode I - Racer (U) [f1] (Save).z64" size 33554432 crc 950e170d )
+	rom ( name "Star Wars Episode I - Racer (U) [t1].z64" size 33554432 crc 5ad165b7 )
+	rom ( name "Star Wars Episode I - Racer (U) [t2].z64" size 33554432 crc f7841689 )
+	rom ( name "Star Wars Episode I - Racer (U) [t3].z64" size 33554432 crc b4ceaff5 )
+	rom ( name "Star Wars Episode I - Racer (U) [t4].z64" size 33554432 crc c59de7a3 )
+)
+
+game (
+	name "StarCraft 64"
+	description "StarCraft 64"
+	rom ( name "StarCraft 64 (Beta) [f1].z64" size 33554432 crc d0d566a2 )
+	rom ( name "StarCraft 64 (Beta) [f2] (PAL).z64" size 33554432 crc 79d4832c )
+	rom ( name "StarCraft 64 (Beta) [f3] (Country Code).z64" size 33554432 crc 5f114823 )
+	rom ( name "StarCraft 64 (Beta).z64" size 33554432 crc b0e1654f )
+	rom ( name "StarCraft 64 (E) [!].z64" size 33554432 crc 2639dae2 )
+	rom ( name "StarCraft 64 (E) [b1].z64" size 33554432 crc 888f52e7 )
+	rom ( name "StarCraft 64 (E) [f1] (NTSC).z64" size 33554432 crc 84a6ce9c )
+	rom ( name "StarCraft 64 (U) [!].z64" size 33554432 crc 4e4c7ec9 )
+)
+
+game (
+	name "Starshot - Space Circus Fever"
+	description "Starshot - Space Circus Fever"
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [!].z64" size 12582912 crc 056d2218 )
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%).z64" size 12582912 crc 01ae0cfc )
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f2] (NTSC).z64" size 12582912 crc b3054021 )
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [f3] (NTSC).z64" size 12582912 crc 4aa2ec88 )
+	rom ( name "Starshot - Space Circus Fever (E) (M3) [t1].z64" size 12582912 crc 85bfe092 )
+	rom ( name "Starshot - Space Circus Fever (U) (M3) [!].z64" size 12582912 crc 7720e5f3 )
+	rom ( name "Starshot - Space Circus Fever (U) (M3) [b1].z64" size 12582912 crc 8f0a4446 )
+)
+
+game (
+	name "Stunt Racer 64"
+	description "Stunt Racer 64"
+	rom ( name "Stunt Racer 64 (U) [!].z64" size 12582912 crc 3438b1af )
+)
+
+game (
+	name "Super B-Daman - Battle Phoenix 64"
+	description "Super B-Daman - Battle Phoenix 64"
+	rom ( name "Super B-Daman - Battle Phoenix 64 (J) [!].z64" size 12582912 crc 5006dc88 )
+)
+
+game (
+	name "Super Bowling 64"
+	description "Super Bowling 64"
+	rom ( name "Super Bowling (J) [!].z64" size 8388608 crc ba2d8b2e )
+	rom ( name "Super Bowling 64 (U) [!].z64" size 8388608 crc f6ccd04a )
+)
+
+game (
+	name "Super Mario 64"
+	description "Super Mario 64"
+	rom ( name "Super Irishley Drunk Giant WaLuigi 64 (Super Mario 64 Hack).z64" size 25165824 crc 70ab0041 )
+	rom ( name "Super Mario 64 (E) (M3) [!].z64" size 8388608 crc 03048de6 )
+	rom ( name "Super Mario 64 (E) (M3) [b1].z64" size 8388608 crc 613e80de )
+	rom ( name "Super Mario 64 (E) (M3) [b2].z64" size 8388608 crc fdf3c491 )
+	rom ( name "Super Mario 64 (E) (M3) [h1C].z64" size 8388608 crc 7162572a )
+	rom ( name "Super Mario 64 (E) (M3) [o1].z64" size 8388612 crc 1863fd76 )
+	rom ( name "Super Mario 64 (E) (M3) [o2].z64" size 33554432 crc 2a023f50 )
+	rom ( name "Super Mario 64 (E) (M3) [t1].z64" size 8388608 crc 5feebb05 )
+	rom ( name "Super Mario 64 (E) (M3) [t2].z64" size 8388608 crc 680ad655 )
+	rom ( name "Super Mario 64 (J) [!].z64" size 8388608 crc dd801954 )
+	rom ( name "Super Mario 64 (J) [h1C].z64" size 8388608 crc 7e0bdf78 )
+	rom ( name "Super Mario 64 (U) (Enable Hidden Scroller Hack).z64" size 8388608 crc a42b60bf )
+	rom ( name "Super Mario 64 (U) (No Cap Hack).z64" size 8388608 crc 64f3d9f2 )
+	rom ( name "Super Mario 64 (U) (Silver Mario Hack).z64" size 8388608 crc e41d2f03 )
+	rom ( name "Super Mario 64 (U) [!].z64" size 8388608 crc 3ce60709 )
+	rom ( name "Super Mario 64 (U) [b1].z64" size 8388608 crc 4501f084 )
+	rom ( name "Super Mario 64 (U) [b2].z64" size 8388608 crc 9aaee776 )
+	rom ( name "Super Mario 64 (U) [h1C].z64" size 8388608 crc d8ec20dc )
+	rom ( name "Super Mario 64 (U) [h2C].z64" size 8388608 crc 4e80ddc5 )
+	rom ( name "Super Mario 64 (U) [o1].z64" size 33554432 crc 5870c898 )
+	rom ( name "Super Mario 64 (U) [T+Ita2.0final_beta2_Rulesless].bin" size 25165824 crc 5f5401f6 )
+	rom ( name "Super Mario 64 (U) [T+Rus].z64" size 8388608 crc 474bfc87 )
+	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame].z64" size 25165824 crc cf9f8b39 )
+	rom ( name "Super Mario 64 (U) [T+SpaFinal_Mistergame][a1].z64" size 25165824 crc 720726bf )
+	rom ( name "Super Mario 64 (U) [T-Ita1.0final_beta1_Rulesless].z64" size 25165824 crc 9a4825fb )
+	rom ( name "Super Mario 64 (U) [t1] (Invincible).z64" size 8388608 crc 48ea9c39 )
+	rom ( name "Super Mario 64 (U) [t2] (Speed).z64" size 8388608 crc 44efdd34 )
+	rom ( name "Super Mario 64 (U) [t3].z64" size 8388608 crc 9f154b8c )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [!].z64" size 8388608 crc a1e15117 )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [b1].z64" size 8388608 crc ef29d54d )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [b2].z64" size 8126464 crc 857d972a )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [h1C].z64" size 8126464 crc b6c0eb94 )
+	rom ( name "Super Mario 64 - Shindou Edition (J) [h2C].z64" size 8388608 crc 0ebbcf0d )
+	rom ( name "Super Mario Magic Plant Adventure 64 (Super Mario 64 Hack).z64" size 25165824 crc 97934027 )
+	rom ( name "Super WaLuigi 64 (Super Mario 64 Hack).z64" size 25165824 crc 7abc992d )
+	rom ( name "Super Wario 64 (Super Mario 64 Hack).z64" size 25165824 crc 5615dbc0 )
+	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack) [T+Ita].z64" size 25165824 crc 1bbdda7e )
+	rom ( name "Super Wario 64 V1.0 by Rulesless (Super Mario 64 Hack).z64" size 25165824 crc db6bed15 )
+)
+
+game (
+	name "Super Robot Spirits"
+	description "Super Robot Spirits"
+	rom ( name "Super Robot Spirits (J) [!].z64" size 16777216 crc 8c9216c1 )
+	rom ( name "Super Robot Spirits (J) [b1].z64" size 15204352 crc db33ce3b )
+)
+
+game (
+	name "Super Robot Taisen 64"
+	description "Super Robot Taisen 64"
+	rom ( name "Super Robot Taisen 64 (J) [!].z64" size 33554432 crc 85df2771 )
+	rom ( name "Super Robot Taisen 64 (J) [b1].z64" size 33554432 crc de81f6c3 )
+	rom ( name "Super Robot Taisen 64 (J) [b2].z64" size 33554432 crc 4482c180 )
+	rom ( name "Super Robot Taisen 64 (J) [f1] (PAL).z64" size 33554432 crc 09d5e6db )
+)
+
+game (
+	name "Super Smash Bros."
+	description "Super Smash Bros."
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [!].z64" size 16777216 crc 04c9d3b1 )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b1].z64" size 16777216 crc ef0ea76f )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b2].z64" size 16777216 crc dabe5627 )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [b3].z64" size 11468800 crc 3f9a4310 )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f1].z64" size 16777216 crc 13ccb98d )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f2].z64" size 16777216 crc 433bd4a5 )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f3].z64" size 16777216 crc 03db0407 )
+	rom ( name "Nintendo All-Star! Dairantou Smash Brothers (J) [f4] (PAL).z64" size 16777216 crc 64051ad3 )
+	rom ( name "Super Smash Bros. (A) [!].z64" size 16777216 crc e96779fa )
+	rom ( name "Super Smash Bros. (A) [f1].z64" size 16777216 crc 2b4391ad )
+	rom ( name "Super Smash Bros. (E) (M3) [!].z64" size 33554432 crc 45a91cb1 )
+	rom ( name "Super Smash Bros. (E) (M3) [b1].z64" size 33554436 crc 01fdb7f2 )
+	rom ( name "Super Smash Bros. (E) (M3) [f1].z64" size 33554432 crc fd8a4ef0 )
+	rom ( name "Super Smash Bros. (U) [!].z64" size 16777216 crc eb97929e )
+	rom ( name "Super Smash Bros. (U) [b1].z64" size 16777216 crc 4e7626b9 )
+	rom ( name "Super Smash Bros. (U) [b2].z64" size 16777216 crc 8f6d6b7e )
+	rom ( name "Super Smash Bros. (U) [f1].z64" size 16777216 crc e789a66d )
+	rom ( name "Super Smash Bros. (U) [f2] (PAL).z64" size 16777216 crc e91be8fa )
+	rom ( name "Super Smash Bros. (U) [f3].z64" size 16777216 crc 34017708 )
+	rom ( name "Super Smash Bros. (U) [f4] (GameShark).z64" size 16777216 crc 0b382b42 )
+	rom ( name "Super Smash Bros. (U) [hI].z64" size 16777216 crc 381f43fb )
+)
+
+game (
+	name "Supercross 2000"
+	description "Supercross 2000"
+	rom ( name "Supercross 2000 (E) (M3) [!].z64" size 16777216 crc cb5482ec )
+	rom ( name "Supercross 2000 (U) [!].z64" size 16777216 crc 094e2a48 )
+	rom ( name "Supercross 2000 (U) [b1].z64" size 8388608 crc be3bc325 )
+	rom ( name "Supercross 2000 (U) [f1] (PAL).z64" size 16777216 crc 103ea361 )
+)
+
+game (
+	name Superman
+	description "Superman"
+	rom ( name "Superman (E) (M6) [!].z64" size 8388608 crc bca4ff8c )
+	rom ( name "Superman (U) (M3) [!].z64" size 8388608 crc 437e3677 )
+	rom ( name "Superman (U) (M3) [b1].z64" size 8388608 crc c90865b7 )
+	rom ( name "Superman (U) (M3) [b2].z64" size 8388608 crc 96787121 )
+	rom ( name "Superman (U) (M3) [f1] (PAL).z64" size 8388608 crc 935ca58d )
+	rom ( name "Superman (U) (M3) [f2] (PAL).z64" size 8388608 crc 806b05f3 )
+	rom ( name "Superman (U) (M3) [T+Ita100_Cattivik66].z64" size 8388608 crc 3506db6f )
+	rom ( name "Superman (U) (M3) [t1].z64" size 8388608 crc a6e40855 )
+)
+
+game (
+	name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou"
+	description "Susume! Taisen Puzzle Dama Toukon! Marumata Chou"
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!].z64" size 8388608 crc 4cd21372 )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1].z64" size 16777216 crc 6b805829 )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b2].z64" size 8126464 crc 9ea0ee5c )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b3].z64" size 8388608 crc 52cd30e0 )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h1C].z64" size 8388608 crc 2c02621f )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [h2C].z64" size 8388608 crc 06bd781b )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o1].z64" size 16777216 crc c2a1cff5 )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2].z64" size 8388808 crc 5a7f4c1e )
+	rom ( name "Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [o2][b1].z64" size 16777216 crc e30023e8 )
+)
+
+game (
+	name "Taz Express"
+	description "Taz Express"
+	rom ( name "Taz Express (E) (M6) [!].z64" size 12582912 crc 0712c306 )
+	rom ( name "Taz Express (E) (M6) [f1] (NTSC).z64" size 12582912 crc 860eade0 )
+	rom ( name "Taz Express (E) (M6) [f2] (NTSC).z64" size 12582912 crc 6df9355e )
+)
+
+game (
+	name Tetrisphere
+	description "Tetrisphere"
+	rom ( name "Tetrisphere (E) [!].z64" size 8388608 crc 7cb31b0f )
+	rom ( name "Tetrisphere (E) [b1].z64" size 8388608 crc 22628530 )
+	rom ( name "Tetrisphere (E) [b2].z64" size 8388608 crc 7b6dea75 )
+	rom ( name "Tetrisphere (U) [!].z64" size 8388608 crc 70a3a5ce )
+	rom ( name "Tetrisphere (U) [b1].z64" size 7815168 crc bae26b43 )
+	rom ( name "Tetrisphere (U) [t1].z64" size 8388608 crc 1a23e825 )
+)
+
+game (
+	name "Tigger's Honey Hunt"
+	description "Tigger's Honey Hunt"
+	rom ( name "Tigger's Honey Hunt (E) (M7) [!].z64" size 16777216 crc d82d5736 )
+	rom ( name "Tigger's Honey Hunt (U) [!].z64" size 16777216 crc 68c2ac8f )
+	rom ( name "Tigger's Honey Hunt (U) [t1].z64" size 16777216 crc e9dd1176 )
+)
+
+game (
+	name "Tom and Jerry in Fists of Furry"
+	description "Tom and Jerry in Fists of Furry"
+	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [!].z64" size 12582912 crc 9ea8a3b8 )
+	rom ( name "Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC).z64" size 12582912 crc c0a9cc13 )
+	rom ( name "Tom and Jerry in Fists of Furry (U) [!].z64" size 12582912 crc 6d685b83 )
+	rom ( name "Tom and Jerry in Fists of Furry (U) [t1].z64" size 12582912 crc cd44fc8d )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six"
+	description "Tom Clancy's Rainbow Six"
+	rom ( name "Tom Clancy's Rainbow Six (E) [!].z64" size 16777216 crc 4b71e083 )
+	rom ( name "Tom Clancy's Rainbow Six (E) [b1].z64" size 16777216 crc 4b61b50f )
+	rom ( name "Tom Clancy's Rainbow Six (E) [h1C].z64" size 16777216 crc c1417faf )
+	rom ( name "Tom Clancy's Rainbow Six (E) [o1].z64" size 16777220 crc 7edbe625 )
+	rom ( name "Tom Clancy's Rainbow Six (F) [!].z64" size 16777216 crc bbf7b6a8 )
+	rom ( name "Tom Clancy's Rainbow Six (G) [!].z64" size 16777216 crc 5d73e788 )
+	rom ( name "Tom Clancy's Rainbow Six (U) [!].z64" size 16777216 crc 53b0cc13 )
+	rom ( name "Tom Clancy's Rainbow Six (U) [f1] (PAL).z64" size 16777216 crc 09745879 )
+)
+
+game (
+	name "Tonic Trouble"
+	description "Tonic Trouble"
+	rom ( name "Tonic Trouble (E) (M5) [!].z64" size 16777216 crc b4322403 )
+	rom ( name "Tonic Trouble (U) (V1.1) [!].z64" size 16777216 crc 1c04ba12 )
+	rom ( name "Tonic Trouble (U) (V1.1) [b1].z64" size 16777216 crc f13448d0 )
+	rom ( name "Tonic Trouble (U) (V1.1) [f1] (PAL).z64" size 16777216 crc a297e4ff )
+	rom ( name "Tonic Trouble (U) (V1.1) [t1].z64" size 16777216 crc 3866227f )
+)
+
+game (
+	name "Tony Hawk's Pro Skater"
+	description "Tony Hawk's Pro Skater"
+	rom ( name "Tony Hawk's Pro Skater (E) [!].z64" size 12582912 crc 39e4f766 )
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [!].z64" size 12582912 crc f5c1b64f )
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.0) [t1].z64" size 12582912 crc ccc5a733 )
+	rom ( name "Tony Hawk's Pro Skater (U) (V1.1) [!].z64" size 12582912 crc 6182a092 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2"
+	description "Tony Hawk's Pro Skater 2"
+	rom ( name "Tony Hawk's Pro Skater 2 (E) [!].z64" size 16777216 crc a1207132 )
+	rom ( name "Tony Hawk's Pro Skater 2 (U) [!].z64" size 16777216 crc 80aa83f3 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3"
+	description "Tony Hawk's Pro Skater 3"
+	rom ( name "Tony Hawk's Pro Skater 3 (U).z64" size 16777216 crc 62a8ce7d )
+)
+
+game (
+	name "Top Gear Hyper Bike"
+	description "Top Gear Hyper Bike"
+	rom ( name "Top Gear Hyper Bike (Beta).z64" size 33554432 crc 00c0278a )
+	rom ( name "Top Gear Hyper Bike (E) [!].z64" size 16777216 crc bae57ea7 )
+	rom ( name "Top Gear Hyper Bike (E) [b1].z64" size 16777216 crc 6183ea77 )
+	rom ( name "Top Gear Hyper Bike (J) [!].z64" size 16777216 crc 09b2cda1 )
+	rom ( name "Top Gear Hyper Bike (U) [!].z64" size 16777216 crc 6eebc26a )
+)
+
+game (
+	name "Top Gear Overdrive"
+	description "Top Gear Overdrive"
+	rom ( name "Top Gear Overdrive (E) [!].z64" size 12582912 crc 0cc70580 )
+	rom ( name "Top Gear Overdrive (E) [h1C].z64" size 12582912 crc 9b1d439f )
+	rom ( name "Top Gear Overdrive (J) [!].z64" size 12582912 crc 81aafc2b )
+	rom ( name "Top Gear Overdrive (J) [b1].z64" size 12582912 crc 9113d45e )
+	rom ( name "Top Gear Overdrive (U) [!].z64" size 12582912 crc f3e0ff21 )
+	rom ( name "Top Gear Overdrive (U) [o1].z64" size 16777216 crc 0bb0db0e )
+	rom ( name "Top Gear Overdrive (U) [t1].z64" size 12582912 crc 6ce5dd98 )
+)
+
+game (
+	name "Top Gear Rally"
+	description "Top Gear Rally"
+	rom ( name "Top Gear Rally (E) [!].z64" size 8388608 crc 40b3bb21 )
+	rom ( name "Top Gear Rally (E) [b1].z64" size 8388608 crc 14238e76 )
+	rom ( name "Top Gear Rally (E) [h1C].z64" size 8388608 crc 9c83fb6a )
+	rom ( name "Top Gear Rally (J) [!].z64" size 8388608 crc c6707cd6 )
+	rom ( name "Top Gear Rally (U) [!].z64" size 8388608 crc 137287f5 )
+	rom ( name "Top Gear Rally (U) [b1].z64" size 8388608 crc 36809f7d )
+	rom ( name "Top Gear Rally (U) [b2].z64" size 8388608 crc cf42c7be )
+	rom ( name "Top Gear Rally (U) [b3].z64" size 8388608 crc 7354e999 )
+	rom ( name "Top Gear Rally (U) [o1].z64" size 8388612 crc 53a95acb )
+)
+
+game (
+	name "Top Gear Rally 2"
+	description "Top Gear Rally 2"
+	rom ( name "TG Rally 2 (E) [!].z64" size 12582912 crc 135c8eb0 )
+	rom ( name "Top Gear Rally 2 (Beta).z64" size 16777216 crc 3c77c5d6 )
+	rom ( name "Top Gear Rally 2 (E) [!].z64" size 12582912 crc cb294d39 )
+	rom ( name "Top Gear Rally 2 (J) [!].z64" size 12582912 crc aa136e07 )
+	rom ( name "Top Gear Rally 2 (U) [!].z64" size 12582912 crc 914cf9c4 )
+	rom ( name "Top Gear Rally 2 (U) [f1] (PAL).z64" size 12582912 crc 9fe61044 )
+)
+
+game (
+	name "Toy Story 2"
+	description "Toy Story 2"
+	rom ( name "Toy Story 2 (E) [!].z64" size 12582912 crc 59574cb9 )
+	rom ( name "Toy Story 2 (F) [!].z64" size 12582912 crc fb4bea9a )
+	rom ( name "Toy Story 2 (G) [!].z64" size 12582912 crc c5e4c89f )
+	rom ( name "Toy Story 2 (U) [!].z64" size 12582912 crc b9570841 )
+	rom ( name "Toy Story 2 (U) [f1] (PAL).z64" size 12582912 crc ca080e9f )
+	rom ( name "Toy Story 2 (U) [t1].z64" size 12582912 crc 170c01d5 )
+)
+
+game (
+	name "Transformers - Beast Wars Transmetal"
+	description "Transformers - Beast Wars Transmetal"
+	rom ( name "Transformers - Beast Wars Metals 64 (J) [!].z64" size 12582912 crc 338f1d45 )
+	rom ( name "Transformers - Beast Wars Transmetal (U) [!].z64" size 16777216 crc 85138b5a )
+)
+
+game (
+	name "Triple Play 2000"
+	description "Triple Play 2000"
+	rom ( name "Triple Play 2000 (U) [!].z64" size 16777216 crc 785dd0f8 )
+)
+
+game (
+	name "Tsumi to Batsu - Hoshi no Keishousha"
+	description "Tsumi to Batsu - Hoshi no Keishousha"
+	rom ( name "Tsumi to Batsu - Hoshi no Keishousha (J) [!].z64" size 33554432 crc ca2e5e49 )
+)
+
+game (
+	name "Turok - Dinosaur Hunter"
+	description "Turok - Dinosaur Hunter"
+	rom ( name "Tokisora Senshi Turok (J) [!].z64" size 8388608 crc e6bd65d5 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [!].z64" size 8388608 crc e8525687 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [b1].z64" size 8388608 crc d7236669 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.0) [h1C].z64" size 8388608 crc 1c5432a2 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.1) [!].z64" size 8388608 crc c2353283 )
+	rom ( name "Turok - Dinosaur Hunter (E) (V1.2) [!].z64" size 8388608 crc 312af877 )
+	rom ( name "Turok - Dinosaur Hunter (G) [!].z64" size 8388608 crc 64631ff9 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [!].z64" size 8388608 crc 26c4f597 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [b1].z64" size 8388608 crc fa434f4b )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [h1C].z64" size 8388608 crc d2c291b2 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [o1].z64" size 8388612 crc 71df1460 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t1].z64" size 8388608 crc 09d4b965 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.0) [t2].z64" size 8388608 crc ceec672d )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.1) [!].z64" size 8388608 crc 7f2476f4 )
+	rom ( name "Turok - Dinosaur Hunter (U) (V1.2) [!].z64" size 8388608 crc 8c3bbc00 )
+)
+
+game (
+	name "Turok - Rage Wars"
+	description "Turok - Rage Wars"
+	rom ( name "Turok - Legenden des Verlorenen Landes (G) [!].z64" size 8388608 crc b937874f )
+	rom ( name "Turok - Rage Wars (E) (M3) (Eng-Fre-Ita).z64" size 8388608 crc f4a2862b )
+	rom ( name "Turok - Rage Wars (E) [!].z64" size 8388608 crc 82b1e116 )
+	rom ( name "Turok - Rage Wars (U) [!].z64" size 8388608 crc 422872a2 )
+	rom ( name "Turok - Rage Wars (U) [f1] (PAL).z64" size 8388608 crc 43cc10f3 )
+	rom ( name "Turok - Rage Wars (U) [f2] (PAL).z64" size 8388608 crc 5b21d17d )
+)
+
+game (
+	name "Turok 2 - Seeds of Evil"
+	description "Turok 2 - Seeds of Evil"
+	rom ( name "Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!].z64" size 12582912 crc 4e29b234 )
+	rom ( name "Turok 2 - Seeds of Evil (E) (M4) [!].z64" size 33554432 crc 1febde32 )
+	rom ( name "Turok 2 - Seeds of Evil (E) [!].z64" size 33554432 crc e2d34bfe )
+	rom ( name "Turok 2 - Seeds of Evil (E) [b1].z64" size 33554432 crc bdab5526 )
+	rom ( name "Turok 2 - Seeds of Evil (G) [!].z64" size 33554432 crc c07877b6 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack).z64" size 12582912 crc 4b1c2a9d )
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!].z64" size 12582912 crc 8d5b9bd0 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (Kiosk Demo) [h1C].z64" size 12582912 crc 2e733502 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [!].z64" size 33554432 crc ff5e7636 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t1].z64" size 33554432 crc 020945c6 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t2].z64" size 33554432 crc 006395ab )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.0) [t3].z64" size 33554432 crc e563d747 )
+	rom ( name "Turok 2 - Seeds of Evil (U) (V1.1).z64" size 33554432 crc 57f1fbf5 )
+	rom ( name "Violence Killer - Turok New Generation (J) [!].z64" size 33554432 crc 097f139f )
+	rom ( name "Violence Killer - Turok New Generation (J) [b1].z64" size 33554432 crc 0a474ddb )
+)
+
+game (
+	name "Turok 3 - Shadow of Oblivion"
+	description "Turok 3 - Shadow of Oblivion"
+	rom ( name "Turok 3 - Shadow of Oblivion (E) [!].z64" size 33554432 crc 98d3114c )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta) [h1C].z64" size 33554432 crc 7946b05a )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta).z64" size 33554432 crc 97b7c3ff )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) (Beta-WIP).z64" size 33554432 crc 3cd1f9af )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) [!].z64" size 33554432 crc cb297224 )
+	rom ( name "Turok 3 - Shadow of Oblivion (U) [t1].z64" size 33554432 crc 411d8468 )
+)
+
+game (
+	name "Twisted Edge Extreme Snowboarding"
+	description "Twisted Edge Extreme Snowboarding"
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [!].z64" size 12582912 crc f120cc52 )
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b1].z64" size 9392128 crc 2e846375 )
+	rom ( name "King Hill 64 - Extreme Snowboarding (J) [b2].z64" size 12582912 crc e31698a4 )
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [!].z64" size 12582912 crc bf0c1291 )
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [b1].z64" size 12582912 crc 1f26259e )
+	rom ( name "Twisted Edge Extreme Snowboarding (E) [h1C].z64" size 12582912 crc 4f64cd21 )
+	rom ( name "Twisted Edge Extreme Snowboarding (U) [!].z64" size 12582912 crc bfbcc038 )
+)
+
+game (
+	name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou"
+	description "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou"
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!].z64" size 8388608 crc 50cbe8a6 )
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h1C].z64" size 8388608 crc b6f8adc2 )
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [h2C].z64" size 8388608 crc 31f32b8d )
+	rom ( name "Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [o1].z64" size 12582912 crc 5d92c2df )
+)
+
+game (
+	name "V-Rally Edition 99"
+	description "V-Rally Edition 99"
+	rom ( name "V-Rally Edition 99 (E) (M3) [!].z64" size 12582912 crc 0735d7a2 )
+	rom ( name "V-Rally Edition 99 (E) (M3) [f1] (NTSC).z64" size 12582912 crc 02a8267b )
+	rom ( name "V-Rally Edition 99 (J) [!].z64" size 8388608 crc 02475a01 )
+	rom ( name "V-Rally Edition 99 (U) [!].z64" size 8388608 crc 4803075e )
+	rom ( name "V-Rally Edition 99 (U) [f1] (PAL).z64" size 8388608 crc 2c399b1c )
+)
+
+game (
+	name "Vigilante 8"
+	description "Vigilante 8"
+	rom ( name "Vigilante 8 (E) [!].z64" size 8388608 crc 0e9bb6d6 )
+	rom ( name "Vigilante 8 (E) [h1C].z64" size 8388608 crc 888d935e )
+	rom ( name "Vigilante 8 (F) [!].z64" size 8388608 crc 11d23ab3 )
+	rom ( name "Vigilante 8 (F) [b1].z64" size 8388608 crc d36573e5 )
+	rom ( name "Vigilante 8 (G) [!].z64" size 8388608 crc 17f63c3f )
+	rom ( name "Vigilante 8 (U) [!].z64" size 8388608 crc 330b73e6 )
+	rom ( name "Vigilante 8 (U) [b1].z64" size 8388608 crc 56695c4b )
+	rom ( name "Vigilante 8 (U) [b2].z64" size 8388608 crc 47854808 )
+	rom ( name "Vigilante 8 (U) [f1] (PAL).z64" size 8388608 crc f5da5754 )
+	rom ( name "Vigilante 8 (U) [f2] (PAL).z64" size 8388608 crc 654352b9 )
+	rom ( name "Vigilante 8 (U) [t1].z64" size 8388608 crc 5d56e5ae )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offense"
+	description "Vigilante 8 - 2nd Offense"
+	rom ( name "Vigilante 8 - 2nd Offence (E) [!].z64" size 12582912 crc 691aa971 )
+	rom ( name "Vigilante 8 - 2nd Offense (U) [!].z64" size 12582912 crc 0293203f )
+	rom ( name "Vigilante 8 - 2nd Offense (U) [f1] (PAL).z64" size 12582912 crc a06f594e )
+)
+
+game (
+	name "Virtual Chess 64"
+	description "Virtual Chess 64"
+	rom ( name "Virtual Chess 64 (E) (M6) [!].z64" size 4194304 crc aae15243 )
+	rom ( name "Virtual Chess 64 (E) (M6) [b1].z64" size 8388608 crc fc843db9 )
+	rom ( name "Virtual Chess 64 (E) (M6) [b2].z64" size 4194304 crc 9d037b23 )
+	rom ( name "Virtual Chess 64 (E) (M6) [o1].z64" size 8388608 crc 79167dce )
+	rom ( name "Virtual Chess 64 (E) (M6) [o1][h1C].z64" size 8388608 crc ab0ef811 )
+	rom ( name "Virtual Chess 64 (U) (M3) [!].z64" size 4194304 crc 620de0b7 )
+	rom ( name "Virtual Chess 64 (U) (M3) [b1].z64" size 4194304 crc 722c9feb )
+	rom ( name "Virtual Chess 64 (U) (M3) [b1][o1].z64" size 8388608 crc 93774cab )
+	rom ( name "Virtual Chess 64 (U) (M3) [f1] (PAL).z64" size 4194304 crc 63a9e373 )
+	rom ( name "Virtual Chess 64 (U) (M3) [f1][o1].z64" size 8388608 crc 7fa359f4 )
+	rom ( name "Virtual Chess 64 (U) [o1].z64" size 8388608 crc ac2d5385 )
+)
+
+game (
+	name "Virtual Pool 64"
+	description "Virtual Pool 64"
+	rom ( name "Virtual Pool 64 (E) [!].z64" size 4194304 crc 9a6fb0bc )
+	rom ( name "Virtual Pool 64 (E) [o1].z64" size 8388608 crc fad2f55f )
+	rom ( name "Virtual Pool 64 (U) [!].z64" size 4194304 crc ad628ded )
+	rom ( name "Virtual Pool 64 (U) [o1].z64" size 8388608 crc 43b5083a )
+)
+
+game (
+	name "Virtual Pro Wrestling 64"
+	description "Virtual Pro Wrestling 64"
+	rom ( name "Virtual Pro Wrestling 64 (J) [!].z64" size 16777216 crc e6651803 )
+	rom ( name "Virtual Pro Wrestling 64 (J) [b1].z64" size 16777216 crc 26366a4a )
+	rom ( name "Virtual Pro Wrestling 64 (J) [f1].z64" size 16777216 crc 9328a297 )
+	rom ( name "Virtual Pro Wrestling 64 (J) [f2].z64" size 16777216 crc f0958025 )
+	rom ( name "Virtual Pro Wrestling 64 (J) [h1C].z64" size 16777216 crc 0093ff39 )
+)
+
+game (
+	name "Waialae Country Club - True Golf Classics"
+	description "Waialae Country Club - True Golf Classics"
+	rom ( name "Harukanaru Augusta Masters 98 (J) [!].z64" size 16777216 crc 51228f0c )
+	rom ( name "Harukanaru Augusta Masters 98 (J) [b1].z64" size 16777216 crc 6d82e5a2 )
+	rom ( name "Harukanaru Augusta Masters 98 (J) [b2].z64" size 16777216 crc 720f6d47 )
+	rom ( name "Harukanaru Augusta Masters 98 (J) [h1C].z64" size 16777216 crc 5cb9b985 )
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!].z64" size 16777216 crc 6858759a )
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1].z64" size 16777216 crc a46a7b14 )
+	rom ( name "Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!].z64" size 16777216 crc 6cb097b3 )
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.0) [!].z64" size 16777216 crc ccab08d7 )
+	rom ( name "Waialae Country Club - True Golf Classics (U) (V1.1) [!].z64" size 16777216 crc c65ee122 )
+)
+
+game (
+	name "War Gods"
+	description "War Gods"
+	rom ( name "War Gods (E) [!].z64" size 12582912 crc c73010c8 )
+	rom ( name "War Gods (U) (Power Bar Hack).z64" size 12582912 crc dc773bba )
+	rom ( name "War Gods (U) [!].z64" size 12582912 crc ffacf993 )
+	rom ( name "War Gods (U) [o1].z64" size 16777216 crc 5cfc294c )
+	rom ( name "War Gods (U) [o1][h1C].z64" size 16777216 crc f4daba35 )
+	rom ( name "War Gods (U) [o2].z64" size 16777216 crc 689b570b )
+	rom ( name "War Gods (U) [o3].z64" size 16777216 crc cc10d8a9 )
+	rom ( name "War Gods (U) [t1] (God Mode).z64" size 12582912 crc 93d4c6fd )
+)
+
+game (
+	name "Wave Race 64"
+	description "Wave Race 64"
+	rom ( name "Wave Race 64 (E) (M2) [!].z64" size 8388608 crc fb289893 )
+	rom ( name "Wave Race 64 (E) (M2) [h1C].z64" size 8388608 crc 1e78fa64 )
+	rom ( name "Wave Race 64 (E) (M2) [o1].z64" size 33554432 crc d559933c )
+	rom ( name "Wave Race 64 (J) [!].z64" size 8388608 crc 6c93ff83 )
+	rom ( name "Wave Race 64 (U) (V1.0) [!].z64" size 8388608 crc 74a7b725 )
+	rom ( name "Wave Race 64 (U) (V1.0) [t1].z64" size 8388608 crc 60717f86 )
+	rom ( name "Wave Race 64 (U) (V1.1) [!].z64" size 8388608 crc 394948c4 )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [!].z64" size 8388608 crc 90044c4b )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b1].z64" size 8388608 crc 33b45441 )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [b2].z64" size 8388608 crc 66dd6ac7 )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [h1C].z64" size 8388608 crc 5dcfba0b )
+	rom ( name "Wave Race 64 - Shindou Edition (J) (V1.2) [o1].z64" size 12582912 crc afa7c48b )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey"
+	description "Wayne Gretzky's 3D Hockey"
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [!].z64" size 8388608 crc 442a4f5f )
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [b1].z64" size 8388608 crc 13343f88 )
+	rom ( name "Wayne Gretzky's 3D Hockey (E) (M4) [h1C].z64" size 8388608 crc 50d4462a )
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [!].z64" size 8388608 crc 485275ed )
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [b1].z64" size 8388608 crc 8535f510 )
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [o1].z64" size 16777216 crc 562f5060 )
+	rom ( name "Wayne Gretzky's 3D Hockey (J) [o2].z64" size 16777216 crc 039d4651 )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [!].z64" size 8388608 crc 9781f88d )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [b1].z64" size 8388608 crc 4df6caf7 )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.0) [o1].z64" size 8126464 crc b8bd42e5 )
+	rom ( name "Wayne Gretzky's 3D Hockey (U) (V1.1) [!].z64" size 8388608 crc c2678971 )
+)
+
+game (
+	name "Wayne Gretzky's 3D Hockey '98"
+	description "Wayne Gretzky's 3D Hockey '98"
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (E) (M4) [!].z64" size 8388608 crc 6f6dc53d )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [!].z64" size 8388608 crc 355fb089 )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h1C].z64" size 8388608 crc a80c229a )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [h2C].z64" size 8388608 crc 0c729578 )
+	rom ( name "Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66].z64" size 8388608 crc 5c920e10 )
+)
+
+game (
+	name "WCW Backstage Assault"
+	description "WCW Backstage Assault"
+	rom ( name "WCW Backstage Assault (U) [!].z64" size 33554432 crc 5dcc2e4e )
+)
+
+game (
+	name "WCW Mayhem"
+	description "WCW Mayhem"
+	rom ( name "WCW Mayhem (E) [!].z64" size 16777216 crc 864e066e )
+	rom ( name "WCW Mayhem (E) [h1C].z64" size 16777216 crc b3aff8d7 )
+	rom ( name "WCW Mayhem (U) [!].z64" size 16777216 crc f1f9b6eb )
+	rom ( name "WCW Mayhem (U) [f1] (PAL).z64" size 16777216 crc 0ec50495 )
+)
+
+game (
+	name "WCW Nitro"
+	description "WCW Nitro"
+	rom ( name "WCW Nitro (U) [!].z64" size 12582912 crc 455b0830 )
+	rom ( name "WCW Nitro (U) [b1].z64" size 12582912 crc 22d8def9 )
+	rom ( name "WCW Nitro (U) [b2].z64" size 12582912 crc bd721abc )
+	rom ( name "WCW Nitro (U) [b3].z64" size 12582912 crc a4bb0a17 )
+	rom ( name "WCW Nitro (U) [f1] (PAL).z64" size 12582912 crc 6988159f )
+	rom ( name "WCW Nitro (U) [f2] (PAL).z64" size 12582912 crc 120f8c2a )
+)
+
+game (
+	name "WCW vs. nWo - World Tour"
+	description "WCW vs. nWo - World Tour"
+	rom ( name "WCW vs. nWo - World Tour (E) [!].z64" size 12582912 crc 37f358eb )
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [!].z64" size 12582912 crc dfbfc61f )
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.0) [b1].z64" size 11534336 crc f224aee7 )
+	rom ( name "WCW vs. nWo - World Tour (U) (V1.1) [!].z64" size 12582912 crc a74da07a )
+)
+
+game (
+	name "WCW-nWo Revenge"
+	description "WCW-nWo Revenge"
+	rom ( name "WCW-nWo Revenge (E) [!].z64" size 16777216 crc 8af0f964 )
+	rom ( name "WCW-nWo Revenge (E) [h1C].z64" size 16777216 crc 771fd04e )
+	rom ( name "WCW-nWo Revenge (U) [!].z64" size 16777216 crc 54cbaaa8 )
+	rom ( name "WCW-nWo Revenge (U) [b1].z64" size 16777216 crc 31eb978f )
+	rom ( name "WCW-nWo Revenge (U) [b2].z64" size 16777216 crc 9d1b3557 )
+	rom ( name "WCW-nWo Revenge (U) [f1] (PAL).z64" size 16777216 crc 7ea064d5 )
+	rom ( name "WCW-nWo Revenge (U) [f2] (PAL).z64" size 16777216 crc b770fb2a )
+)
+
+game (
+	name Wetrix
+	description "Wetrix"
+	rom ( name "Wetrix (E) (M6) [!].z64" size 8388608 crc eddc5b06 )
+	rom ( name "Wetrix (E) (M6) [f1] (NTSC).z64" size 8388608 crc 46f031a8 )
+	rom ( name "Wetrix (E) (M6) [t1].z64" size 8388608 crc c4924be2 )
+	rom ( name "Wetrix (J) [!].z64" size 4194304 crc bad08218 )
+	rom ( name "Wetrix (J) [o1].z64" size 8388608 crc 8db9c41b )
+	rom ( name "Wetrix (U) (M6) [!].z64" size 8388608 crc 50cd1f71 )
+)
+
+game (
+	name "Wheel of Fortune"
+	description "Wheel of Fortune"
+	rom ( name "Wheel of Fortune (U) [!].z64" size 4194304 crc 8d3efa8d )
+	rom ( name "Wheel of Fortune (U) [b1].z64" size 4194304 crc d6c7bdba )
+	rom ( name "Wheel of Fortune (U) [o1].z64" size 8388608 crc 58878daf )
+	rom ( name "Wheel of Fortune (U) [o1][b1].z64" size 8388608 crc 037eca98 )
+)
+
+game (
+	name "WideBoy BIOS"
+	description "WideBoy BIOS"
+	rom ( name "WideBoy BIOS V980910.bin" size 1048576 crc 3fe8291e )
+	rom ( name "WideBoy BIOS V980914.bin" size 1048576 crc c9ff4c4b )
+)
+
+game (
+	name "WinBack - Covert Operations"
+	description "WinBack - Covert Operations"
+	rom ( name "Operation WinBack (E) (M5) [!].z64" size 16777216 crc fb96f166 )
+	rom ( name "WinBack (J) [!].z64" size 16777216 crc d35360b0 )
+	rom ( name "WinBack (J) [b1].z64" size 16777216 crc 18256c96 )
+	rom ( name "WinBack - Covert Operations (U) [!].z64" size 16777216 crc 64c817c5 )
+	rom ( name "WinBack - Covert Operations (U) [b1].z64" size 16777216 crc 5c319f14 )
+	rom ( name "WinBack - Covert Operations (U) [f1] (PAL).z64" size 16777216 crc e13ede7d )
+	rom ( name "WinBack - Covert Operations (U) [t1].z64" size 16777216 crc edc5f66e )
+)
+
+game (
+	name "Wipeout 64"
+	description "Wipeout 64"
+	rom ( name "Wipeout 64 (E) [!].z64" size 8388608 crc 38111048 )
+	rom ( name "Wipeout 64 (U) [!].z64" size 8388608 crc 4888d0fe )
+	rom ( name "Wipeout 64 (U) [o1].z64" size 16777216 crc ff733418 )
+	rom ( name "Wipeout 64 (U) [t1].z64" size 8388608 crc 6fbc4937 )
+	rom ( name "Wipeout 64 (U) [t2].z64" size 8388608 crc 3367383c )
+)
+
+game (
+	name "Wonder Project J2 - Koruro no Mori no Jozet"
+	description "Wonder Project J2 - Koruro no Mori no Jozet"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [!].z64" size 8388608 crc 5e8fc436 )
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [b1].z64" size 8388608 crc c3516904 )
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [h1C].z64" size 8388608 crc a4c86774 )
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T+Eng0.1_Ryu].z64" size 8912896 crc c6458d2b )
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (J) [T-Eng0.05].v64" size 8912896 crc 2163807b )
+)
+
+game (
+	name "World Cup 98"
+	description "World Cup 98"
+	rom ( name "World Cup 98 (E) (M8) [!].z64" size 12582912 crc 79f483f7 )
+	rom ( name "World Cup 98 (E) (M8) [f1] (NTSC).z64" size 12582912 crc 58e87217 )
+	rom ( name "World Cup 98 (U) (M8) [!].z64" size 12582912 crc 13930c26 )
+)
+
+game (
+	name "World Driver Championship"
+	description "World Driver Championship"
+	rom ( name "World Driver Championship (E) (M5) [!].z64" size 16777216 crc 76151df6 )
+	rom ( name "World Driver Championship (E) (M5) [h1C].z64" size 16777216 crc 30c31843 )
+	rom ( name "World Driver Championship (U) [!].z64" size 16777216 crc 5e4acbfa )
+	rom ( name "World Driver Championship (U) [b1].z64" size 16777216 crc 8811af43 )
+	rom ( name "World Driver Championship (U) [f1] (PAL).z64" size 16777216 crc 02d1f824 )
+	rom ( name "World Driver Championship (U) [f2] (PAL).z64" size 16777216 crc df25ebe8 )
+	rom ( name "World Driver Championship (U) [t1].z64" size 16777216 crc 813fcbed )
+)
+
+game (
+	name "Worms - Armageddon"
+	description "Worms - Armageddon"
+	rom ( name "Worms - Armageddon (E) (M6) [!].z64" size 12582912 crc 6bfff27b )
+	rom ( name "Worms - Armageddon (E) (M6) [f1] (NTSC).z64" size 12582912 crc 9cdfee58 )
+	rom ( name "Worms - Armageddon (U) (M3) [!].z64" size 12582912 crc 5471ae3b )
+)
+
+game (
+	name "WWF - War Zone"
+	description "WWF - War Zone"
+	rom ( name "WWF - War Zone (E) [!].z64" size 12582912 crc 90a0b609 )
+	rom ( name "WWF - War Zone (U) [!].z64" size 12582912 crc 2fbb5507 )
+)
+
+game (
+	name "WWF Attitude"
+	description "WWF Attitude"
+	rom ( name "WWF Attitude (E) [!].z64" size 33554432 crc 804fe494 )
+	rom ( name "WWF Attitude (G) [!].z64" size 33554432 crc ea5d8359 )
+	rom ( name "WWF Attitude (G) [b1].z64" size 33465250 crc 45c4c497 )
+	rom ( name "WWF Attitude (U) [!].z64" size 33554432 crc 7a4b3686 )
+	rom ( name "WWF Attitude (U) [b1].z64" size 5736981 crc 80634009 )
+	rom ( name "WWF Attitude (U) [b2].z64" size 33554432 crc 8e21a880 )
+	rom ( name "WWF Attitude (U) [f1] (PAL).z64" size 33554432 crc babb135a )
+)
+
+game (
+	name "WWF No Mercy"
+	description "WWF No Mercy"
+	rom ( name "WWF No Mercy (E) (V1.0) [!].z64" size 33554432 crc b79bddd8 )
+	rom ( name "WWF No Mercy (E) (V1.0) [b1].z64" size 12279808 crc d6f1c981 )
+	rom ( name "WWF No Mercy (E) (V1.1) [!].z64" size 33554432 crc 43ba9e7e )
+	rom ( name "WWF No Mercy (U) (V1.0) [!].z64" size 33554432 crc b33f44f0 )
+	rom ( name "WWF No Mercy (U) (V1.0) [t1].z64" size 33554432 crc fee04a00 )
+	rom ( name "WWF No Mercy (U) (V1.1) [!].z64" size 33554432 crc baceea13 )
+)
+
+game (
+	name "WWF WrestleMania 2000"
+	description "WWF WrestleMania 2000"
+	rom ( name "Virtual Pro Wrestling 2 - Oudou Keishou (J) [!].z64" size 33554432 crc f620835d )
+	rom ( name "WWF WrestleMania 2000 (E) [!].z64" size 33554432 crc 09d710c7 )
+	rom ( name "WWF WrestleMania 2000 (E) [h1C].z64" size 33554432 crc 596c6ed1 )
+	rom ( name "WWF WrestleMania 2000 (J) [!].z64" size 33554432 crc c2034d24 )
+	rom ( name "WWF WrestleMania 2000 (J) [b1].z64" size 29360128 crc 9afb5300 )
+	rom ( name "WWF WrestleMania 2000 (U) [!].z64" size 33554432 crc 0b50b4c6 )
+	rom ( name "WWF WrestleMania 2000 (U) [b1].z64" size 29360128 crc 963f19a3 )
+	rom ( name "WWF WrestleMania 2000 (U) [t1] (Never Drop Weapons).bin" size 33554432 crc 59d05c03 )
+)
+
+game (
+	name "Xena Warrior Princess - The Talisman of Fate"
+	description "Xena Warrior Princess - The Talisman of Fate"
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (E) [!].z64" size 12582912 crc d3932f88 )
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [!].z64" size 12582912 crc 7da93999 )
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL).z64" size 12582912 crc 476a756d )
+	rom ( name "Xena Warrior Princess - The Talisman of Fate (U) [t1].z64" size 12582912 crc d2532f61 )
+)
+
+game (
+	name "Xplorer64 BIOS"
+	description "Xplorer64 BIOS"
+	rom ( name "Xplorer64 BIOS V1.067 (G).bin" size 262144 crc 656acdf5 )
+)
+
+game (
+	name "Yakouchuu II - Satsujin Kouru"
+	description "Yakouchuu II - Satsujin Kouru"
+	rom ( name "Yakouchuu II - Satsujin Kouru (J) [!].z64" size 33554432 crc 4538c41a )
+)
+
+game (
+	name "Yoshi's Story"
+	description "Yoshi's Story"
+	rom ( name "Yoshi Story (J) [!].z64" size 16777216 crc 4f44a9ef )
+	rom ( name "Yoshi Story (J) [b1].z64" size 15728640 crc 6e01a7ae )
+	rom ( name "Yoshi Story (J) [f1].z64" size 16777216 crc 8a89904c )
+	rom ( name "Yoshi Story (J) [f2].z64" size 16777216 crc 8d18a944 )
+	rom ( name "Yoshi Story (J) [f3].z64" size 16777216 crc 967949f0 )
+	rom ( name "Yoshi Story (J) [f4].z64" size 16777216 crc 0afe15ca )
+	rom ( name "Yoshi Story (J) [t1].z64" size 16777216 crc 7dd9a4ed )
+	rom ( name "Yoshi Story (J) [t2] (Health and Eggs).z64" size 16777216 crc 308915c3 )
+	rom ( name "Yoshi's Story (E) (M3) [!].z64" size 16777216 crc f9ffc760 )
+	rom ( name "Yoshi's Story (E) (M3) [b1].z64" size 16777216 crc 9e6c336a )
+	rom ( name "Yoshi's Story (E) (M3) [b2].z64" size 16777216 crc cda63103 )
+	rom ( name "Yoshi's Story (E) (M3) [b2][f1].z64" size 16777216 crc e5faa601 )
+	rom ( name "Yoshi's Story (E) (M3) [b3].z64" size 13434880 crc 476f7cf5 )
+	rom ( name "Yoshi's Story (E) (M3) [t1] (Health and Eggs).z64" size 16777216 crc ba05b7cf )
+	rom ( name "Yoshi's Story (U) (M2) [!].z64" size 16777216 crc a1453e0d )
+	rom ( name "Yoshi's Story (U) (M2) [b1].z64" size 16777216 crc d1a35062 )
+	rom ( name "Yoshi's Story (U) (M2) [b2].z64" size 16777216 crc 724baa87 )
+	rom ( name "Yoshi's Story (U) (M2) [b3].z64" size 16777216 crc cc2adc22 )
+	rom ( name "Yoshi's Story (U) (M2) [b4].z64" size 16777216 crc 47d2b1f2 )
+	rom ( name "Yoshi's Story (U) (M2) [b5].z64" size 16777216 crc 2230a687 )
+	rom ( name "Yoshi's Story (U) (M2) [f1].z64" size 16777216 crc 65dad012 )
+	rom ( name "Yoshi's Story (U) (M2) [t1].z64" size 16777216 crc 40d0e350 )
+	rom ( name "Yoshi's Story (U) (M2) [t2] (Health and Eggs).z64" size 16777216 crc fafd0923 )
+)
+
+game (
+	name "Z64 BIOS"
+	description "Z64 BIOS"
+	rom ( name "Z64 BIOS V1.05.bin" size 524288 crc d31f5d1d )
+	rom ( name "Z64 BIOS V1.07.bin" size 524288 crc c41dcffc )
+	rom ( name "Z64 BIOS V1.08 (Ravemax Hack V1.00b).bin" size 524288 crc cf0138ee )
+	rom ( name "Z64 BIOS V1.08.bin" size 524288 crc fa1fecc4 )
+	rom ( name "Z64 BIOS V1.09.bin" size 524288 crc ea68d5ed )
+	rom ( name "Z64 BIOS V1.10b.bin" size 524288 crc 5912af9d )
+	rom ( name "Z64 BIOS V1.11.bin" size 524288 crc a7ba30fc )
+	rom ( name "Z64 BIOS V1.12.bin" size 524288 crc b5bbbcbe )
+	rom ( name "Z64 BIOS V2.00 (Barebones).bin" size 65536 crc b00306a3 )
+	rom ( name "Z64 BIOS V2.00.bin" size 524288 crc 21ba9967 )
+	rom ( name "Z64 BIOS V2.00b (Ravemax Hack).bin" size 524288 crc 5b9be146 )
+	rom ( name "Z64 BIOS V2.10NTSC.bin" size 524288 crc 7a94038d )
+	rom ( name "Z64 BIOS V2.10PAL.bin" size 524288 crc b9d3de21 )
+	rom ( name "Z64 BIOS V2.11NTSC.bin" size 524288 crc 19d51222 )
+	rom ( name "Z64 BIOS V2.11PAL.bin" size 524288 crc 719cb3d4 )
+	rom ( name "Z64 BIOS V2.12b (Nintendo Backup Crew Hack).bin" size 524288 crc 9a7968dd )
+	rom ( name "Z64 BIOS V2.12b3.bin" size 524288 crc 99adb980 )
+	rom ( name "Z64 BIOS V2.12b4.bin" size 524288 crc 1d0a771a )
+	rom ( name "Z64 BIOS V2.12NTSC.bin" size 524288 crc ce7d86e7 )
+	rom ( name "Z64 BIOS V2.12PAL.bin" size 524288 crc d5dd6e66 )
+	rom ( name "Z64 BIOS V2.13.bin" size 524288 crc d95e339b )
+	rom ( name "Z64 BIOS V2.15.bin" size 524288 crc fe278859 )
+	rom ( name "Z64 BIOS V2.16.bin" size 524288 crc 46bd8af5 )
+	rom ( name "Z64 BIOS V2.16b.bin" size 524288 crc 3265ae3d )
+	rom ( name "Z64 BIOS V2.17 [h1].bin" size 524288 crc 926cd3bd )
+	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 2.18zd Hack).bin" size 524288 crc 31f08661 )
+	rom ( name "Z64 BIOS V2.17 by zmod.onestop.net (ORB HDisk ZIP250 Hack).bin" size 524288 crc c8fb4890 )
+	rom ( name "Z64 BIOS V2.17.bin" size 524288 crc 7a73dbaa )
+	rom ( name "Z64 BIOS V2.18.bin" size 524288 crc abb513c4 )
+	rom ( name "Z64 BIOS V2.20cf.rom" size 524288 crc 5a4db022 )
+)
+
+game (
+	name "Zool - Majou Tsukai Densetsu"
+	description "Zool - Majou Tsukai Densetsu"
+	rom ( name "Zool - Majou Tsukai Densetsu (J) [!].z64" size 12582912 crc 756ba26d )
+	rom ( name "Zool - Majou Tsukai Densetsu (J) [f1] (PAL).z64" size 12582912 crc 7a6f93b2 )
+)
+


### PR DESCRIPTION
This addresses https://github.com/libretro/libretro-database/issues/137 and restores the No-Intro N64 DAT, and then adds [GoodTools](https://en.wikipedia.org/wiki/GoodTools)' GoodN64 in a metadat folder.

Will need https://github.com/libretro/libretro-super/pull/288 .