### PR TITLE
Fix the metadat DOOM.dat titles

### DIFF
--- a/metadat/developer/DOOM.dat
+++ b/metadat/developer/DOOM.dat
@@ -4,91 +4,91 @@ clrmamepro (
 )
 
 game (
-	name "Doom (v1.0, shareware)"
+	name "Doom (v1.0) (Demo)"
 	developer "id Software"
 	rom ( crc eedae672 )
 )
 
 game (
-	name "Doom (v1.1, registered)"
+	name "Doom (v1.1)"
 	developer "id Software"
 	rom ( crc 66457ab9 )
 )
 
 game (
-	name "Doom (v1.1, shareware)"
+	name "Doom (v1.1 (Demo)"
 	developer "id Software"
 	rom ( crc 981dcebb )
 )
 
 game (
-	name "Doom (v1.2, registered)"
+	name "Doom (v1.2)"
 	developer "id Software"
 	rom ( crc a5da8930 )
 )
 
 game (
-	name "Doom (v1.2, shareware)"
+	name "Doom (v1.2) (Demo)"
 	developer "id Software"
 	rom ( crc bc842626 )
 )
 
 game (
-	name "Doom (v1.25, shareware, Sybex)"
+	name "Doom (v1.25) (Demo)"
 	developer "id Software"
 	rom ( crc 225d7fb1 )
 )
 
 game (
-	name "Doom (v1.4, shareware, beta)"
+	name "Doom (v1.4 Beta) (Demo)"
 	developer "id Software"
 	rom ( crc f5c2708d )
 )
 
 game (
-	name "Doom (v1.5, shareware, beta)"
+	name "Doom (v1.5 Beta) (Demo)"
 	developer "id Software"
 	rom ( crc 8653b0eb )
 )
 
 game (
-	name "Doom (v1.6, shareware, beta)"
+	name "Doom (v1.6 Beta) (Demo)"
 	developer "id Software"
 	rom ( crc f26dcad8 )
 )
 
 game (
-	name "Doom (v1.666, registered)"
+	name "Doom (v1.666)"
 	developer "id Software"
 	rom ( crc f756aab5 )
 )
 
 game (
-	name "Doom (v1.666, shareware)"
+	name "Doom (v1.666) (Demo)"
 	developer "id Software"
 	rom ( crc 505fb740 )
 )
 
 game (
-	name "Doom (v1.8, registered)"
+	name "Doom (v1.8)"
 	developer "id Software"
 	rom ( crc 8d242df9 )
 )
 
 game (
-	name "Doom (v1.8, shareware)"
+	name "Doom (v1.8) (Demo)"
 	developer "id Software"
 	rom ( crc 331ebf07 )
 )
 
 game (
-	name "Doom (v1.9, registered)"
+	name "Doom (v1.9)"
 	developer "id Software"
 	rom ( crc 723e60f9 )
 )
 
 game (
-	name "Doom (v1.9, shareware)"
+	name "Doom (v1.9) (Demo)"
 	developer "id Software"
 	rom ( crc 162b696a )
 )


### PR DESCRIPTION
They are named well in [DOOM.dat](https://github.com/libretro/libretro-database/blob/master/dat/DOOM.dat), but then metadat was changing the schema. This fixes the Doom titles to match the original DOOM.dat.

Another solution would be to remove the name fields entirely.