### PR TITLE
Add new line support to the .scummvm files

### DIFF
--- a/dat/ScummVM.dat
+++ b/dat/ScummVM.dat
@@ -13,904 +13,1206 @@ game (
 	name "Access"
 	description "Access"
 	rom ( name "Access.scummvm" size 6 crc 1c52e62 )
+	rom ( name "Access Windows.scummvm" size 8 crc 9fbf8083 )
+	rom ( name "Access Unix.scummvm" size 7 crc 916ac3c9 )
 )
 
 game (
 	name "Backyard Baseball 2003"
 	description "Backyard Baseball 2003"
 	rom ( name "Backyard Baseball 2003.scummvm" size 12 crc bf796b2d )
+	rom ( name "Backyard Baseball 2003 Windows.scummvm" size 14 crc eee8d8ea )
+	rom ( name "Backyard Baseball 2003 Unix.scummvm" size 13 crc 77b7238d )
 )
 
 game (
 	name "Blue's 123 Time Activities"
 	description "Blue's 123 Time Activities"
 	rom ( name "Blue's 123 Time Activities.scummvm" size 12 crc 96cdd5ca )
+	rom ( name "Blue's 123 Time Activities Windows.scummvm" size 14 crc d30e0afe )
+	rom ( name "Blue's 123 Time Activities Unix.scummvm" size 13 crc 49f0e0e8 )
 )
 
 game (
 	name "Blue's ABC Time Activities"
 	description "Blue's ABC Time Activities"
 	rom ( name "Blue's ABC Time Activities.scummvm" size 12 crc 8855e8ef )
+	rom ( name "Blue's ABC Time Activities Windows.scummvm" size 14 crc 63958890 )
+	rom ( name "Blue's ABC Time Activities Unix.scummvm" size 13 crc 2eaac92 )
 )
 
 game (
 	name "Blue's Birthday Adventure"
 	description "Blue's Birthday Adventure"
 	rom ( name "Blue's Birthday Adventure.scummvm" size 13 crc 55358473 )
+	rom ( name "Blue's Birthday Adventure Windows.scummvm" size 15 crc fa65bd95 )
+	rom ( name "Blue's Birthday Adventure Unix.scummvm" size 14 crc fb8e1391 )
 )
 
 game (
 	name "Blue's Treasure Hunt"
 	description "Blue's Treasure Hunt"
 	rom ( name "Blue's Treasure Hunt.scummvm" size 17 crc 2ab30b17 )
+	rom ( name "Blue's Treasure Hunt Windows.scummvm" size 19 crc 86f3f201 )
+	rom ( name "Blue's Treasure Hunt Unix.scummvm" size 18 crc b12e305f )
 )
 
 game (
 	name "Freddi Fish's One-Stop Fun Shop"
 	description "Freddi Fish's One-Stop Fun Shop"
 	rom ( name "Freddi Fish's One-Stop Fun Shop.scummvm" size 14 crc 9faddef6 )
+	rom ( name "Freddi Fish's One-Stop Fun Shop Windows.scummvm" size 16 crc 372fa3e9 )
+	rom ( name "Freddi Fish's One-Stop Fun Shop Unix.scummvm" size 15 crc 6696fc64 )
 )
 
 game (
 	name "MADS"
 	description "MADS"
 	rom ( name "MADS.scummvm" size 4 crc 5f153244 )
+	rom ( name "MADS Windows.scummvm" size 6 crc 48600138 )
+	rom ( name "MADS Unix.scummvm" size 5 crc 43399628 )
 )
 
 game (
 	name "Putt-Putt's One-Stop Fun Shop"
 	description "Putt-Putt's One-Stop Fun Shop"
 	rom ( name "Putt-Putt's One-Stop Fun Shop.scummvm" size 12 crc cfc36a07 )
+	rom ( name "Putt-Putt's One-Stop Fun Shop Windows.scummvm" size 14 crc f68454ee )
+	rom ( name "Putt-Putt's One-Stop Fun Shop Unix.scummvm" size 13 crc ac7c505a )
 )
 
 game (
 	name "Pajama Sam's One-Stop Fun Shop"
 	description "Pajama Sam's One-Stop Fun Shop"
 	rom ( name "Pajama Sam's One-Stop Fun Shop.scummvm" size 11 crc 4c27bc9a )
+	rom ( name "Pajama Sam's One-Stop Fun Shop Windows.scummvm" size 13 crc 5ddb54bc )
+	rom ( name "Pajama Sam's One-Stop Fun Shop Unix.scummvm" size 12 crc 22415b75 )
 )
 
 game (
 	name "Backyard Soccer 2004"
 	description "Backyard Soccer 2004"
 	rom ( name "Backyard Soccer 2004.scummvm" size 10 crc 8dd9d0d2 )
+	rom ( name "Backyard Soccer 2004 Windows.scummvm" size 12 crc 217f7d3c )
+	rom ( name "Backyard Soccer 2004 Unix.scummvm" size 11 crc 5a876cbb )
 )
 
 game (
 	name "Backyard Soccer MLS Edition"
 	description "Backyard Soccer MLS Edition"
 	rom ( name "Backyard Soccer MLS Edition.scummvm" size 9 crc d62b7e78 )
+	rom ( name "Backyard Soccer MLS Edition Windows.scummvm" size 11 crc 44f9fc42 )
+	rom ( name "Backyard Soccer MLS Edition Unix.scummvm" size 10 crc 6cdfd4e3 )
 )
 
 game (
 	name "Putt-Putt & Fatty Bear's Activity Pack"
 	description "Putt-Putt & Fatty Bear's Activity Pack"
 	rom ( name "Putt-Putt & Fatty Bear's Activity Pack.scummvm" size 8 crc ac74095a )
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack Windows.scummvm" size 10 crc 2d2a24a2 )
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack Unix.scummvm" size 9 crc b9c5ca70 )
 )
 
 game (
 	name "Sierra AGI game"
 	description "Sierra AGI game"
 	rom ( name "Sierra AGI game.scummvm" size 3 crc a8865c99 )
+	rom ( name "Sierra AGI game Windows.scummvm" size 5 crc d6fc01a6 )
+	rom ( name "Sierra AGI game Unix.scummvm" size 4 crc bbacab2f )
 )
 
 game (
 	name "Let's Explore the Airport with Buzzy"
 	description "Let's Explore the Airport with Buzzy"
 	rom ( name "Let's Explore the Airport with Buzzy.scummvm" size 7 crc 7e91f7c2 )
+	rom ( name "Let's Explore the Airport with Buzzy Windows.scummvm" size 9 crc ceb7294e )
+	rom ( name "Let's Explore the Airport with Buzzy Unix.scummvm" size 8 crc 47c334f8 )
 )
 
 game (
 	name "Amazon Guardians of Eden"
 	description "Amazon Guardians of Eden"
 	rom ( name "Amazon Guardians of Eden.scummvm" size 6 crc 815b8877 )
+	rom ( name "Amazon Guardians of Eden Windows.scummvm" size 8 crc 97bfe0d4 )
+	rom ( name "Amazon Guardians of Eden Unix.scummvm" size 7 crc fc37b984 )
 )
 
 game (
 	name "Blue's Art Time Activities"
 	description "Blue's Art Time Activities"
 	rom ( name "Blue's Art Time Activities.scummvm" size 7 crc b4c535b3 )
+	rom ( name "Blue's Art Time Activities Windows.scummvm" size 9 crc 8df90831 )
+	rom ( name "Blue's Art Time Activities Unix.scummvm" size 8 crc 600b2190 )
 )
 
 game (
 	name "Indiana Jones and the Fate of Atlantis"
 	description "Indiana Jones and the Fate of Atlantis"
 	rom ( name "Indiana Jones and the Fate of Atlantis.scummvm" size 8 crc 4f12aa7c )
+	rom ( name "Indiana Jones and the Fate of Atlantis Windows.scummvm" size 10 crc a12bb6b2 )
+	rom ( name "Indiana Jones and the Fate of Atlantis Unix.scummvm" size 9 crc 6b2b292e )
 )
 
 game (
 	name "Putt-Putt and Pep's Balloon-O-Rama"
 	description "Putt-Putt and Pep's Balloon-O-Rama"
 	rom ( name "Putt-Putt and Pep's Balloon-O-Rama.scummvm" size 7 crc 643b3b90 )
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama Windows.scummvm" size 9 crc d4e882a9 )
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama Unix.scummvm" size 8 crc c2bcaeec )
 )
 
 game (
 	name "Backyard Baseball"
 	description "Backyard Baseball"
 	rom ( name "Backyard Baseball.scummvm" size 8 crc 533f2feb )
+	rom ( name "Backyard Baseball Windows.scummvm" size 10 crc 2f9c1ed )
+	rom ( name "Backyard Baseball Unix.scummvm" size 9 crc 55c024c )
 )
 
 game (
 	name "Backyard Baseball 2001"
 	description "Backyard Baseball 2001"
 	rom ( name "Backyard Baseball 2001.scummvm" size 12 crc 4946d1f9 )
+	rom ( name "Backyard Baseball 2001 Windows.scummvm" size 14 crc 2008745c )
+	rom ( name "Backyard Baseball 2001 Unix.scummvm" size 13 crc f6ff0afa )
 )
 
 game (
 	name "Backyard Basketball"
 	description "Backyard Basketball"
 	rom ( name "Backyard Basketball.scummvm" size 10 crc d7f3e811 )
+	rom ( name "Backyard Basketball Windows.scummvm" size 12 crc e9aa1b05 )
+	rom ( name "Backyard Basketball Unix.scummvm" size 11 crc 58b0d589 )
 )
 
 game (
 	name "Beavis and Butt-head in Virtual Stupidity"
 	description "Beavis and Butt-head in Virtual Stupidity"
 	rom ( name "Beavis and Butt-head in Virtual Stupidity.scummvm" size 4 crc 4b51012c )
+	rom ( name "Beavis and Butt-head in Virtual Stupidity Windows.scummvm" size 6 crc 5a9495c5 )
+	rom ( name "Beavis and Butt-head in Virtual Stupidity Unix.scummvm" size 5 crc 443b71 )
 )
 
 game (
 	name "The Big Red Adventure"
 	description "The Big Red Adventure"
 	rom ( name "The Big Red Adventure.scummvm" size 3 crc 93ae8ce6 )
+	rom ( name "The Big Red Adventure Windows.scummvm" size 5 crc f8888d63 )
+	rom ( name "The Big Red Adventure Unix.scummvm" size 4 crc 7b2def52 )
 )
 
 game (
 	name "Bear Stormin'"
 	description "Bear Stormin'"
 	rom ( name "Bear Stormin'.scummvm" size 7 crc f0010920 )
+	rom ( name "Bear Stormin' Windows.scummvm" size 9 crc f8fae9ab )
+	rom ( name "Bear Stormin' Unix.scummvm" size 8 crc 9492752 )
 )
 
 game (
 	name "Humongous Interactive Catalog"
 	description "Humongous Interactive Catalog"
 	rom ( name "Humongous Interactive Catalog.scummvm" size 7 crc 1b2c3247 )
+	rom ( name "Humongous Interactive Catalog Windows.scummvm" size 9 crc 634d16c2 )
+	rom ( name "Humongous Interactive Catalog Unix.scummvm" size 8 crc da74fe92 )
 )
 
 game (
 	name "SPY Fox in Cheese Chase"
 	description "SPY Fox in Cheese Chase"
 	rom ( name "SPY Fox in Cheese Chase.scummvm" size 5 crc 96fd3b99 )
+	rom ( name "SPY Fox in Cheese Chase Windows.scummvm" size 7 crc 52acb26 )
+	rom ( name "SPY Fox in Cheese Chase Unix.scummvm" size 6 crc bb92d048 )
 )
 
 game (
 	name "Cinematique evo.1 engine game"
 	description "Cinematique evo.1 engine game"
 	rom ( name "Cinematique evo.1 engine game.scummvm" size 4 crc 8977a4a0 )
+	rom ( name "Cinematique evo.1 engine game Windows.scummvm" size 6 crc 6b1ed7c3 )
+	rom ( name "Cinematique evo.1 engine game Unix.scummvm" size 5 crc e488d2df )
 )
 
 game (
 	name "The Curse of Monkey Island"
 	description "The Curse of Monkey Island"
 	rom ( name "The Curse of Monkey Island.scummvm" size 4 crc af61c7fa )
+	rom ( name "The Curse of Monkey Island Windows.scummvm" size 6 crc fff174e9 )
+	rom ( name "The Curse of Monkey Island Unix.scummvm" size 5 crc 6f107c56 )
 )
 
 game (
 	name "Composer Game"
 	description "Composer Game"
 	rom ( name "Composer Game.scummvm" size 8 crc 987306d8 )
+	rom ( name "Composer Game Windows.scummvm" size 10 crc b420f7fd )
+	rom ( name "Composer Game Unix.scummvm" size 9 crc ba472f73 )
 )
 
 game (
 	name "Cinematique evo.2 engine game"
 	description "Cinematique evo.2 engine game"
 	rom ( name "Cinematique evo.2 engine game.scummvm" size 6 crc 9e9d701b )
+	rom ( name "Cinematique evo.2 engine game Windows.scummvm" size 8 crc ed91a197 )
+	rom ( name "Cinematique evo.2 engine game Unix.scummvm" size 7 crc b82c520f )
 )
 
 game (
 	name "The Dig"
 	description "The Dig"
 	rom ( name "The Dig.scummvm" size 3 crc d7769efb )
+	rom ( name "The Dig Windows.scummvm" size 5 crc f45dd4ef )
+	rom ( name "The Dig Unix.scummvm" size 4 crc 186f5b99 )
 )
 
 game (
 	name "Demon in my Pocket"
 	description "Demon in my Pocket"
 	rom ( name "Demon in my Pocket.scummvm" size 4 crc 52502b31 )
+	rom ( name "Demon in my Pocket Windows.scummvm" size 6 crc 7e43290e )
+	rom ( name "Demon in my Pocket Unix.scummvm" size 5 crc 635b5682 )
 )
 
 game (
 	name "Putt-Putt and Pep's Dog on a Stick"
 	description "Putt-Putt and Pep's Dog on a Stick"
 	rom ( name "Putt-Putt and Pep's Dog on a Stick.scummvm" size 3 crc 812c397d )
+	rom ( name "Putt-Putt and Pep's Dog on a Stick Windows.scummvm" size 5 crc d1368b33 )
+	rom ( name "Putt-Putt and Pep's Dog on a Stick Unix.scummvm" size 4 crc 1ce2272b )
 )
 
 game (
 	name "Draci Historie"
 	description "Draci Historie"
 	rom ( name "Draci Historie.scummvm" size 5 crc 580d0e08 )
+	rom ( name "Draci Historie Windows.scummvm" size 7 crc 3bc37aae )
+	rom ( name "Draci Historie Unix.scummvm" size 6 crc 3c5483af )
 )
 
 game (
 	name "Dragonsphere"
 	description "Dragonsphere"
 	rom ( name "Dragonsphere.scummvm" size 12 crc c691bb82 )
+	rom ( name "Dragonsphere Windows.scummvm" size 14 crc 41a4d3f0 )
+	rom ( name "Dragonsphere Unix.scummvm" size 13 crc 31a77524 )
 )
 
 game (
 	name "Drascula The Vampire Strikes Back"
 	description "Drascula The Vampire Strikes Back"
 	rom ( name "Drascula The Vampire Strikes Back.scummvm" size 8 crc bffa71f9 )
+	rom ( name "Drascula The Vampire Strikes Back Windows.scummvm" size 10 crc f6de2108 )
+	rom ( name "Drascula The Vampire Strikes Back Unix.scummvm" size 9 crc f609b65a )
 )
 
 game (
 	name "DreamWeb"
 	description "DreamWeb"
 	rom ( name "DreamWeb.scummvm" size 8 crc 95dbbea3 )
+	rom ( name "DreamWeb Windows.scummvm" size 10 crc bd5161d6 )
+	rom ( name "DreamWeb Unix.scummvm" size 9 crc 7d9d2f7f )
 )
 
 game (
 	name "Elvira - Mistress of the Dark"
 	description "Elvira - Mistress of the Dark"
 	rom ( name "Elvira - Mistress of the Dark.scummvm" size 7 crc 71253819 )
+	rom ( name "Elvira - Mistress of the Dark Windows.scummvm" size 9 crc a7a0e50f )
+	rom ( name "Elvira - Mistress of the Dark Unix.scummvm" size 8 crc 56cd8b6b )
 )
 
 game (
 	name "Elvira II - The Jaws of Cerberus"
 	description "Elvira II - The Jaws of Cerberus"
 	rom ( name "Elvira II - The Jaws of Cerberus.scummvm" size 7 crc e82c69a3 )
+	rom ( name "Elvira II - The Jaws of Cerberus Windows.scummvm" size 9 crc a5e65b56 )
+	rom ( name "Elvira II - The Jaws of Cerberus Unix.scummvm" size 8 crc 7de0d8a8 )
 )
 
 game (
 	name "Eye of the Beholder"
 	description "Eye of the Beholder"
 	rom ( name "Eye of the Beholder.scummvm" size 3 crc f084a7c5 )
+	rom ( name "Eye of the Beholder Windows.scummvm" size 5 crc ea9d6068 )
+	rom ( name "Eye of the Beholder Unix.scummvm" size 4 crc d929b40b )
 )
 
 game (
 	name "Eye of the Beholder II The Legend of Darkmoon"
 	description "Eye of the Beholder II The Legend of Darkmoon"
 	rom ( name "Eye of the Beholder II The Legend of Darkmoon.scummvm" size 4 crc f12b0c95 )
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon Windows.scummvm" size 6 crc 112246f3 )
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon Unix.scummvm" size 5 crc b2434a54 )
 )
 
 game (
 	name "Let's Explore the Farm with Buzzy"
 	description "Let's Explore the Farm with Buzzy"
 	rom ( name "Let's Explore the Farm with Buzzy.scummvm" size 4 crc 5816d045 )
+	rom ( name "Let's Explore the Farm with Buzzy Windows.scummvm" size 6 crc 1f7fb42e )
+	rom ( name "Let's Explore the Farm with Buzzy Unix.scummvm" size 5 crc 3439a55c )
 )
 
 game (
 	name "Fatty Bear's Birthday Surprise"
 	description "Fatty Bear's Birthday Surprise"
 	rom ( name "Fatty Bear's Birthday Surprise.scummvm" size 5 crc cd8e0945 )
+	rom ( name "Fatty Bear's Birthday Surprise Windows.scummvm" size 7 crc e0704bc6 )
+	rom ( name "Fatty Bear's Birthday Surprise Unix.scummvm" size 6 crc 34ac3d85 )
 )
 
 game (
 	name "Fatty Bear's Fun Pack"
 	description "Fatty Bear's Fun Pack"
 	rom ( name "Fatty Bear's Fun Pack.scummvm" size 6 crc 3a07e8f6 )
+	rom ( name "Fatty Bear's Fun Pack Windows.scummvm" size 8 crc f89593da )
+	rom ( name "Fatty Bear's Fun Pack Unix.scummvm" size 7 crc 66335652 )
 )
 
 game (
 	name "The Feeble Files"
 	description "The Feeble Files"
 	rom ( name "The Feeble Files.scummvm" size 6 crc 8d861cda )
+	rom ( name "The Feeble Files Windows.scummvm" size 8 crc 7b7479f0 )
+	rom ( name "The Feeble Files Unix.scummvm" size 7 crc 545cbb45 )
 )
 
 game (
 	name "Backyard Football"
 	description "Backyard Football"
 	rom ( name "Backyard Football.scummvm" size 8 crc aede269e )
+	rom ( name "Backyard Football Windows.scummvm" size 10 crc 296d091b )
+	rom ( name "Backyard Football Unix.scummvm" size 9 crc 25ce66f6 )
 )
 
 game (
 	name "Backyard Football 2002"
 	description "Backyard Football 2002"
 	rom ( name "Backyard Football 2002.scummvm" size 12 crc 716a76e )
+	rom ( name "Backyard Football 2002 Windows.scummvm" size 14 crc a76ef2d8 )
+	rom ( name "Backyard Football 2002 Unix.scummvm" size 13 crc 98da5c6b )
 )
 
 game (
 	name "Freddi Fish 1 The Case of the Missing Kelp Seeds"
 	description "Freddi Fish 1 The Case of the Missing Kelp Seeds"
 	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds.scummvm" size 6 crc 9aa4edd9 )
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds Windows.scummvm" size 8 crc 9ae3ff9b )
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds Unix.scummvm" size 7 crc cd42c80e )
 )
 
 game (
 	name "Freddi Fish 2 The Case of the Haunted Schoolhouse"
 	description "Freddi Fish 2 The Case of the Haunted Schoolhouse"
 	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse.scummvm" size 7 crc e5407090 )
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse Windows.scummvm" size 9 crc 35e69bca )
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse Unix.scummvm" size 8 crc c23dd5a7 )
 )
 
 game (
 	name "Freddi Fish 3 The Case of the Stolen Conch Shell"
 	description "Freddi Fish 3 The Case of the Stolen Conch Shell"
 	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell.scummvm" size 7 crc 92474006 )
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell Windows.scummvm" size 9 crc 3424f1fd )
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell Unix.scummvm" size 8 crc db26e4e6 )
 )
 
 game (
 	name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
 	description "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
 	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch.scummvm" size 7 crc c23d5a5 )
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch Windows.scummvm" size 9 crc 316be778 )
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch Unix.scummvm" size 8 crc 94677221 )
 )
 
 game (
 	name "Freddi Fish 5 The Case of the Creature of Coral Cove"
 	description "Freddi Fish 5 The Case of the Creature of Coral Cove"
 	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove.scummvm" size 10 crc 2f36f61c )
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove Windows.scummvm" size 12 crc a60ba0ee )
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove Unix.scummvm" size 11 crc 26f96c2a )
 )
 
 game (
 	name "Full Throttle"
 	description "Full Throttle"
 	rom ( name "Full Throttle.scummvm" size 2 crc 25166bfb )
+	rom ( name "Full Throttle Windows.scummvm" size 4 crc 398a201c )
+	rom ( name "Full Throttle Unix.scummvm" size 3 crc 189d3b6c )
 )
 
 game (
 	name "Putt-Putt's Fun Pack"
 	description "Putt-Putt's Fun Pack"
 	rom ( name "Putt-Putt's Fun Pack.scummvm" size 7 crc be7d72c0 )
+	rom ( name "Putt-Putt's Fun Pack Windows.scummvm" size 9 crc 6153fc8f )
+	rom ( name "Putt-Putt's Fun Pack Unix.scummvm" size 8 crc a90db951 )
 )
 
 game (
 	name "Gob engine game"
 	description "Gob engine game"
 	rom ( name "Gob engine game.scummvm" size 3 crc f30073ab )
+	rom ( name "Gob engine game Windows.scummvm" size 5 crc 905d3308 )
+	rom ( name "Gob engine game Unix.scummvm" size 4 crc 73207c80 )
 )
 
 game (
 	name "Groovie engine game"
 	description "Groovie engine game"
 	rom ( name "Groovie engine game.scummvm" size 7 crc 342b57cd )
+	rom ( name "Groovie engine game Windows.scummvm" size 9 crc 9ff9dcd3 )
+	rom ( name "Groovie engine game Unix.scummvm" size 8 crc d73693c9 )
 )
 
 game (
 	name "Hopkins FBI"
 	description "Hopkins FBI"
 	rom ( name "Hopkins FBI.scummvm" size 7 crc bc1666be )
+	rom ( name "Hopkins FBI Windows.scummvm" size 9 crc ca357ee1 )
+	rom ( name "Hopkins FBI Unix.scummvm" size 8 crc 1eb28e7e )
 )
 
 game (
 	name "Hugo 1 Hugo's House of Horrors"
 	description "Hugo 1 Hugo's House of Horrors"
 	rom ( name "Hugo 1 Hugo's House of Horrors.scummvm" size 5 crc cda231c8 )
+	rom ( name "Hugo 1 Hugo's House of Horrors Windows.scummvm" size 7 crc 465f1572 )
+	rom ( name "Hugo 1 Hugo's House of Horrors Unix.scummvm" size 6 crc a7a5ee20 )
 )
 
 game (
 	name "Hugo 2 Whodunit"
 	description "Hugo 2 Whodunit"
 	rom ( name "Hugo 2 Whodunit.scummvm" size 5 crc 54ab6072 )
+	rom ( name "Hugo 2 Whodunit Windows.scummvm" size 7 crc 4419ab2b )
+	rom ( name "Hugo 2 Whodunit Unix.scummvm" size 6 crc 8c88bde3 )
 )
 
 game (
 	name "Hugo 3 Jungle of Doom"
 	description "Hugo 3 Jungle of Doom"
 	rom ( name "Hugo 3 Jungle of Doom.scummvm" size 5 crc 23ac50e4 )
+	rom ( name "Hugo 3 Jungle of Doom Windows.scummvm" size 7 crc 45dbc11c )
+	rom ( name "Hugo 3 Jungle of Doom Unix.scummvm" size 6 crc 95938ca2 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade"
 	description "Indiana Jones and the Last Crusade"
 	rom ( name "Indiana Jones and the Last Crusade.scummvm" size 5 crc 870aa244 )
+	rom ( name "Indiana Jones and the Last Crusade Windows.scummvm" size 7 crc b86f4a63 )
+	rom ( name "Indiana Jones and the Last Crusade Unix.scummvm" size 6 crc 43e189b8 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade & Loom"
 	description "Indiana Jones and the Last Crusade & Loom"
 	rom ( name "Indiana Jones and the Last Crusade & Loom.scummvm" size 8 crc f5b53298 )
+	rom ( name "Indiana Jones and the Last Crusade & Loom Windows.scummvm" size 10 crc 65ed218b )
+	rom ( name "Indiana Jones and the Last Crusade & Loom Unix.scummvm" size 9 crc ccf6a8d7 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade & Zak McKracken"
 	description "Indiana Jones and the Last Crusade & Zak McKracken"
 	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken.scummvm" size 7 crc 34d98949 )
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken Windows.scummvm" size 9 crc a17d7ebd )
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken Unix.scummvm" size 8 crc 3de3262e )
 )
 
 game (
 	name "Jumble"
 	description "Jumble"
 	rom ( name "Jumble.scummvm" size 6 crc 5f1063cc )
+	rom ( name "Jumble Windows.scummvm" size 8 crc a756721c )
+	rom ( name "Jumble Unix.scummvm" size 7 crc a05a986b )
 )
 
 game (
 	name "Let's Explore the Jungle with Buzzy"
 	description "Let's Explore the Jungle with Buzzy"
 	rom ( name "Let's Explore the Jungle with Buzzy.scummvm" size 6 crc 4b6e0ec9 )
+	rom ( name "Let's Explore the Jungle with Buzzy Windows.scummvm" size 8 crc e9228fc2 )
+	rom ( name "Let's Explore the Jungle with Buzzy Unix.scummvm" size 7 crc d0241289 )
 )
 
 game (
 	name "The Legend of Kyrandia"
 	description "The Legend of Kyrandia"
 	rom ( name "The Legend of Kyrandia.scummvm" size 5 crc 44bab8b5 )
+	rom ( name "The Legend of Kyrandia Windows.scummvm" size 7 crc 48aaa055 )
+	rom ( name "The Legend of Kyrandia Unix.scummvm" size 6 crc 8998fb28 )
 )
 
 game (
 	name "The Legend of Kyrandia The Hand of Fate"
 	description "The Legend of Kyrandia The Hand of Fate"
 	rom ( name "The Legend of Kyrandia The Hand of Fate.scummvm" size 5 crc ddb3e90f )
+	rom ( name "The Legend of Kyrandia The Hand of Fate Windows.scummvm" size 7 crc 4aec1e0c )
+	rom ( name "The Legend of Kyrandia The Hand of Fate Unix.scummvm" size 6 crc a2b5a8eb )
 )
 
 game (
 	name "The Legend of Kyrandia Malcolm's Revenge"
 	description "The Legend of Kyrandia Malcolm's Revenge"
 	rom ( name "The Legend of Kyrandia Malcolm's Revenge.scummvm" size 5 crc aab4d999 )
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge Windows.scummvm" size 7 crc 4b2e743b )
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge Unix.scummvm" size 6 crc bbae99aa )
 )
 
 game (
 	name "Labyrinth of Time"
 	description "Labyrinth of Time"
 	rom ( name "Labyrinth of Time.scummvm" size 3 crc 61d6b1c4 )
+	rom ( name "Labyrinth of Time Windows.scummvm" size 5 crc 752752a )
+	rom ( name "Labyrinth of Time Unix.scummvm" size 4 crc aebfd68b )
 )
 
 game (
 	name "Lands of Lore The Throne of Chaos"
 	description "Lands of Lore The Throne of Chaos"
 	rom ( name "Lands of Lore The Throne of Chaos.scummvm" size 3 crc 18edb14d )
+	rom ( name "Lands of Lore The Throne of Chaos Windows.scummvm" size 5 crc ed132f13 )
+	rom ( name "Lands of Lore The Throne of Chaos Unix.scummvm" size 4 crc 3aa2d60f )
 )
 
 game (
 	name "Loom"
 	description "Loom"
 	rom ( name "Loom.scummvm" size 4 crc c2597137 )
+	rom ( name "Loom Windows.scummvm" size 6 crc a3a7a66b )
+	rom ( name "Loom Unix.scummvm" size 5 crc 8aa8faed )
 )
 
 game (
 	name "Pajama Sam's Lost & Found"
 	description "Pajama Sam's Lost & Found"
 	rom ( name "Pajama Sam's Lost & Found.scummvm" size 4 crc 404584aa )
+	rom ( name "Pajama Sam's Lost & Found Windows.scummvm" size 6 crc aa9fd6b3 )
+	rom ( name "Pajama Sam's Lost & Found Unix.scummvm" size 5 crc 49409e1 )
 )
 
 game (
 	name "Lure of the Temptress"
 	description "Lure of the Temptress"
 	rom ( name "Lure of the Temptress.scummvm" size 4 crc 225fb3bf )
+	rom ( name "Lure of the Temptress Windows.scummvm" size 6 crc 2597f7b2 )
+	rom ( name "Lure of the Temptress Unix.scummvm" size 5 crc 692bf73d )
 )
 
 game (
 	name "MADE engine game"
 	description "MADE engine game"
 	rom ( name "MADE engine game.scummvm" size 4 crc 9d546aa1 )
+	rom ( name "MADE engine game Windows.scummvm" size 6 crc ed91d16 )
+	rom ( name "MADE engine game Unix.scummvm" size 5 crc 939bc187 )
 )
 
 game (
 	name "Maniac Mansion"
 	description "Maniac Mansion"
 	rom ( name "Maniac Mansion.scummvm" size 6 crc 9558f941 )
+	rom ( name "Maniac Mansion Windows.scummvm" size 8 crc 39a12408 )
+	rom ( name "Maniac Mansion Unix.scummvm" size 7 crc 33992f6c )
 )
 
 game (
 	name "Martian Memorandum"
 	description "Martian Memorandum"
 	rom ( name "Martian Memorandum.scummvm" size 7 crc 42004cd6 )
+	rom ( name "Martian Memorandum Windows.scummvm" size 9 crc bcaaa88e )
+	rom ( name "Martian Memorandum Unix.scummvm" size 8 crc 5d25713e )
 )
 
 game (
 	name "Freddi Fish and Luther's Maze Madness"
 	description "Freddi Fish and Luther's Maze Madness"
 	rom ( name "Freddi Fish and Luther's Maze Madness.scummvm" size 4 crc 4915557e )
+	rom ( name "Freddi Fish and Luther's Maze Madness Windows.scummvm" size 6 crc be1f3dba )
+	rom ( name "Freddi Fish and Luther's Maze Madness Unix.scummvm" size 5 crc 85234ffd )
 )
 
 game (
 	name "Mohawk Game"
 	description "Mohawk Game"
 	rom ( name "Mohawk Game.scummvm" size 6 crc 135374a1 )
+	rom ( name "Mohawk Game Windows.scummvm" size 8 crc f4d6ae72 )
+	rom ( name "Mohawk Game Unix.scummvm" size 7 crc 9315c699 )
 )
 
 game (
 	name "The Secret of Monkey Island"
 	description "The Secret of Monkey Island"
 	rom ( name "The Secret of Monkey Island.scummvm" size 6 crc b0e2af30 )
+	rom ( name "The Secret of Monkey Island Windows.scummvm" size 8 crc 8d8dbdc4 )
+	rom ( name "The Secret of Monkey Island Unix.scummvm" size 7 crc 14bed490 )
 )
 
 game (
 	name "Monkey Island 2 LeChuck's Revenge"
 	description "Monkey Island 2 LeChuck's Revenge"
 	rom ( name "Monkey Island 2 LeChuck's Revenge.scummvm" size 7 crc 3cbc6c0e )
+	rom ( name "Monkey Island 2 LeChuck's Revenge Windows.scummvm" size 9 crc ce25b9ed )
+	rom ( name "Monkey Island 2 LeChuck's Revenge Unix.scummvm" size 8 crc d55397f8 )
 )
 
 game (
 	name "Moonbase Commander"
 	description "Moonbase Commander"
 	rom ( name "Moonbase Commander.scummvm" size 8 crc 6d6203d1 )
+	rom ( name "Moonbase Commander Windows.scummvm" size 10 crc 15884d2a )
+	rom ( name "Moonbase Commander Unix.scummvm" size 9 crc c36e86d2 )
 )
 
 game (
 	name "Mortville Manor"
 	description "Mortville Manor"
 	rom ( name "Mortville Manor.scummvm" size 11 crc f165dbc )
+	rom ( name "Mortville Manor Windows.scummvm" size 13 crc 49084647 )
+	rom ( name "Mortville Manor Unix.scummvm" size 12 crc f00fef69 )
 )
 
 game (
 	name "SPY Fox in Hold the Mustard"
 	description "SPY Fox in Hold the Mustard"
 	rom ( name "SPY Fox in Hold the Mustard.scummvm" size 7 crc 680edcdf )
+	rom ( name "SPY Fox in Hold the Mustard Windows.scummvm" size 9 crc 9d67aa8d )
+	rom ( name "SPY Fox in Hold the Mustard Unix.scummvm" size 8 crc 24d3c70a )
 )
 
 game (
 	name "Rex Nebular and the Cosmic Gender Bender"
 	description "Rex Nebular and the Cosmic Gender Bender"
 	rom ( name "Rex Nebular and the Cosmic Gender Bender.scummvm" size 7 crc 22ef7a1e )
+	rom ( name "Rex Nebular and the Cosmic Gender Bender Windows.scummvm" size 9 crc 703300be )
+	rom ( name "Rex Nebular and the Cosmic Gender Bender Unix.scummvm" size 8 crc c8fad48a )
 )
 
 game (
 	name "The Neverhood Chronicles"
 	description "The Neverhood Chronicles"
 	rom ( name "The Neverhood Chronicles.scummvm" size 9 crc ab93a9c8 )
+	rom ( name "The Neverhood Chronicles Windows.scummvm" size 11 crc b88b6835 )
+	rom ( name "The Neverhood Chronicles Unix.scummvm" size 10 crc a7c3dfb8 )
 )
 
 game (
 	name "Nippon Safes Inc."
 	description "Nippon Safes Inc."
 	rom ( name "Nippon Safes Inc..scummvm" size 6 crc 60bf294e )
+	rom ( name "Nippon Safes Inc. Windows.scummvm" size 8 crc 38ea1ff4 )
+	rom ( name "Nippon Safes Inc. Unix.scummvm" size 7 crc a3d3d52d )
 )
 
 game (
 	name "Pajama Sam 1 No Need to Hide When It's Dark Outside"
 	description "Pajama Sam 1 No Need to Hide When It's Dark Outside"
 	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside.scummvm" size 6 crc e9da00cb )
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside Windows.scummvm" size 8 crc 3cac62f3 )
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside Unix.scummvm" size 7 crc 3e88c7ab )
 )
 
 game (
 	name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
 	description "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
 	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening.scummvm" size 7 crc 168a7f35 )
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening Windows.scummvm" size 9 crc 76293d3d )
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening Unix.scummvm" size 8 crc 647248cf )
 )
 
 game (
 	name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
 	description "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
 	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet.scummvm" size 7 crc 618d4fa3 )
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet Windows.scummvm" size 9 crc 77eb570a )
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet Unix.scummvm" size 8 crc 7d69798e )
 )
 
 game (
 	name "Parallaction engine game"
 	description "Parallaction engine game"
 	rom ( name "Parallaction engine game.scummvm" size 12 crc 4a3d7075 )
+	rom ( name "Parallaction engine game Windows.scummvm" size 14 crc 16ef331e )
+	rom ( name "Parallaction engine game Unix.scummvm" size 13 crc 12f2be50 )
 )
 
 game (
 	name "Passport to Adventure"
 	description "Passport to Adventure"
 	rom ( name "Passport to Adventure.scummvm" size 4 crc ce70d424 )
+	rom ( name "Passport to Adventure Windows.scummvm" size 6 crc 64f4bcb7 )
+	rom ( name "Passport to Adventure Unix.scummvm" size 5 crc e1a9296 )
 )
 
 game (
 	name "The Journeyman Project Pegasus Prime"
 	description "The Journeyman Project Pegasus Prime"
 	rom ( name "The Journeyman Project Pegasus Prime.scummvm" size 7 crc 4c46d1bb )
+	rom ( name "The Journeyman Project Pegasus Prime Windows.scummvm" size 9 crc e2475cdb )
+	rom ( name "The Journeyman Project Pegasus Prime Unix.scummvm" size 8 crc 6e282a46 )
 )
 
 game (
 	name "Return of the Phantom"
 	description "Return of the Phantom"
 	rom ( name "Return of the Phantom.scummvm" size 7 crc 6896f6ae )
+	rom ( name "Return of the Phantom Windows.scummvm" size 9 crc 70f82b74 )
+	rom ( name "Return of the Phantom Unix.scummvm" size 8 crc 3d11e8a )
 )
 
 game (
 	name "Pajama Sam Games to Play on Any Day"
 	description "Pajama Sam Games to Play on Any Day"
 	rom ( name "Pajama Sam Games to Play on Any Day.scummvm" size 7 crc e16aff45 )
+	rom ( name "Pajama Sam Games to Play on Any Day Windows.scummvm" size 9 crc b4ae300b )
+	rom ( name "Pajama Sam Games to Play on Any Day Unix.scummvm" size 8 crc 3480d973 )
 )
 
 game (
 	name "Personal Nightmare"
 	description "Personal Nightmare"
 	rom ( name "Personal Nightmare.scummvm" size 2 crc c4ec2756 )
+	rom ( name "Personal Nightmare Windows.scummvm" size 4 crc 5d490ef9 )
+	rom ( name "Personal Nightmare Unix.scummvm" size 3 crc b01b1e75 )
 )
 
 game (
 	name "Putt-Putt Joins the Circus"
 	description "Putt-Putt Joins the Circus"
 	rom ( name "Putt-Putt Joins the Circus.scummvm" size 10 crc 956bd8b5 )
+	rom ( name "Putt-Putt Joins the Circus Windows.scummvm" size 12 crc 51810dc )
+	rom ( name "Putt-Putt Joins the Circus Unix.scummvm" size 11 crc 89492a48 )
 )
 
 game (
 	name "Putt-Putt Goes to the Moon"
 	description "Putt-Putt Goes to the Moon"
 	rom ( name "Putt-Putt Goes to the Moon.scummvm" size 8 crc 296b2059 )
+	rom ( name "Putt-Putt Goes to the Moon Windows.scummvm" size 10 crc 44b56a12 )
+	rom ( name "Putt-Putt Goes to the Moon Unix.scummvm" size 9 crc 204984e3 )
 )
 
 game (
 	name "Putt-Putt Joins the Parade"
 	description "Putt-Putt Joins the Parade"
 	rom ( name "Putt-Putt Joins the Parade.scummvm" size 8 crc cefdbb5d )
+	rom ( name "Putt-Putt Joins the Parade Windows.scummvm" size 10 crc 4704024c )
+	rom ( name "Putt-Putt Joins the Parade Unix.scummvm" size 9 crc 27c3d661 )
 )
 
 game (
 	name "Putt-Putt Enters the Race"
 	description "Putt-Putt Enters the Race"
 	rom ( name "Putt-Putt Enters the Race.scummvm" size 8 crc 10e8dc1e )
+	rom ( name "Putt-Putt Enters the Race Windows.scummvm" size 10 crc 4f863464 )
+	rom ( name "Putt-Putt Enters the Race Unix.scummvm" size 9 crc c8c8d32c )
 )
 
 game (
 	name "Putt-Putt Travels Through Time"
 	description "Putt-Putt Travels Through Time"
 	rom ( name "Putt-Putt Travels Through Time.scummvm" size 8 crc a513fff4 )
+	rom ( name "Putt-Putt Travels Through Time Windows.scummvm" size 10 crc 4970eb8b )
+	rom ( name "Putt-Putt Travels Through Time Unix.scummvm" size 9 crc 88a22369 )
 )
 
 game (
 	name "Putt-Putt Saves the Zoo"
 	description "Putt-Putt Saves the Zoo"
 	rom ( name "Putt-Putt Saves the Zoo.scummvm" size 7 crc a4ea04c4 )
+	rom ( name "Putt-Putt Saves the Zoo Windows.scummvm" size 9 crc bc59f715 )
+	rom ( name "Putt-Putt Saves the Zoo Unix.scummvm" size 8 crc ae7aea3e )
 )
 
 game (
 	name "NoPatience"
 	description "NoPatience"
 	rom ( name "NoPatience.scummvm" size 6 crc 22a6dfdf )
+	rom ( name "NoPatience Windows.scummvm" size 8 crc 46eb19f )
+	rom ( name "NoPatience Unix.scummvm" size 7 crc 24996f09 )
 )
 
 game (
 	name "Flight of the Amazon Queen"
 	description "Flight of the Amazon Queen"
 	rom ( name "Flight of the Amazon Queen.scummvm" size 5 crc a2edb4ba )
+	rom ( name "Flight of the Amazon Queen Windows.scummvm" size 7 crc c68416e6 )
+	rom ( name "Flight of the Amazon Queen Unix.scummvm" size 6 crc 19c1b1b5 )
 )
 
 game (
 	name "Blue's Reading Time Activities"
 	description "Blue's Reading Time Activities"
 	rom ( name "Blue's Reading Time Activities.scummvm" size 8 crc b31360ed )
+	rom ( name "Blue's Reading Time Activities Windows.scummvm" size 10 crc b2c0da46 )
+	rom ( name "Blue's Reading Time Activities Unix.scummvm" size 9 crc ecdf8b36 )
 )
 
 game (
 	name "The Case of the Rose Tattoo"
 	description "The Case of the Rose Tattoo"
 	rom ( name "The Case of the Rose Tattoo.scummvm" size 10 crc d5916b5b )
+	rom ( name "The Case of the Rose Tattoo Windows.scummvm" size 12 crc 978d6c72 )
+	rom ( name "The Case of the Rose Tattoo Unix.scummvm" size 11 crc cebb1f84 )
 )
 
 game (
 	name "SAGA Engine game"
 	description "SAGA Engine game"
 	rom ( name "SAGA Engine game.scummvm" size 4 crc 1d2ddd7 )
+	rom ( name "SAGA Engine game Windows.scummvm" size 6 crc 22b979cf )
+	rom ( name "SAGA Engine game Unix.scummvm" size 5 crc 2a619339 )
 )
 
 game (
 	name "Sam & Max Hit the Road"
 	description "Sam & Max Hit the Road"
 	rom ( name "Sam & Max Hit the Road.scummvm" size 7 crc 5b280160 )
+	rom ( name "Sam & Max Hit the Road Windows.scummvm" size 9 crc 65885b5 )
+	rom ( name "Sam & Max Hit the Road Unix.scummvm" size 8 crc 7f3e4fca )
 )
 
 game (
 	name "The Case of the Serrated Scalpel"
 	description "The Case of the Serrated Scalpel"
 	rom ( name "The Case of the Serrated Scalpel.scummvm" size 7 crc 1351a4bb )
+	rom ( name "The Case of the Serrated Scalpel Windows.scummvm" size 9 crc c228867f )
+	rom ( name "The Case of the Serrated Scalpel Unix.scummvm" size 8 crc 6e773d33 )
 )
 
 game (
 	name "Sierra SCI Game"
 	description "Sierra SCI Game"
 	rom ( name "Sierra SCI Game.scummvm" size 3 crc d348ee83 )
+	rom ( name "Sierra SCI Game Windows.scummvm" size 5 crc 43be5213 )
+	rom ( name "Sierra SCI Game Unix.scummvm" size 4 crc 46b59ce7 )
 )
 
 game (
 	name "Sfinx"
 	description "Sfinx"
 	rom ( name "Sfinx.scummvm" size 5 crc 84bb8a55 )
+	rom ( name "Sfinx Windows.scummvm" size 7 crc de03c238 )
+	rom ( name "Sfinx Unix.scummvm" size 6 crc 29521862 )
 )
 
 game (
 	name "Simon the Sorcerer 1"
 	description "Simon the Sorcerer 1"
 	rom ( name "Simon the Sorcerer 1.scummvm" size 6 crc 88312e20 )
+	rom ( name "Simon the Sorcerer 1 Windows.scummvm" size 8 crc 5df024f0 )
+	rom ( name "Simon the Sorcerer 1 Unix.scummvm" size 7 crc 9311775 )
 )
 
 game (
 	name "Simon the Sorcerer 2"
 	description "Simon the Sorcerer 2"
 	rom ( name "Simon the Sorcerer 2.scummvm" size 6 crc 11387f9a )
+	rom ( name "Simon the Sorcerer 2 Windows.scummvm" size 8 crc 5fb69aa9 )
+	rom ( name "Simon the Sorcerer 2 Unix.scummvm" size 7 crc 221c44b6 )
 )
 
 game (
 	name "Beneath a Steel Sky"
 	description "Beneath a Steel Sky"
 	rom ( name "Beneath a Steel Sky.scummvm" size 3 crc 62674ef )
+	rom ( name "Beneath a Steel Sky Windows.scummvm" size 5 crc 9a2cd98c )
+	rom ( name "Beneath a Steel Sky Unix.scummvm" size 4 crc 264df0e )
 )
 
 game (
 	name "Backyard Soccer"
 	description "Backyard Soccer"
 	rom ( name "Backyard Soccer.scummvm" size 6 crc e2959c36 )
+	rom ( name "Backyard Soccer Windows.scummvm" size 8 crc 64072923 )
+	rom ( name "Backyard Soccer Unix.scummvm" size 7 crc fd8f0696 )
 )
 
 game (
 	name "Pajama Sam's Sock Works"
 	description "Pajama Sam's Sock Works"
 	rom ( name "Pajama Sam's Sock Works.scummvm" size 5 crc 1e816dc4 )
+	rom ( name "Pajama Sam's Sock Works Windows.scummvm" size 7 crc 88379482 )
+	rom ( name "Pajama Sam's Sock Works Unix.scummvm" size 6 crc aec08157 )
 )
 
 game (
 	name "Soltys"
 	description "Soltys"
 	rom ( name "Soltys.scummvm" size 6 crc 32ef545e )
+	rom ( name "Soltys Windows.scummvm" size 8 crc 5c9c5274 )
+	rom ( name "Soltys Unix.scummvm" size 7 crc be369534 )
 )
 
 game (
 	name "SPY Fox 1 Dry Cereal"
 	description "SPY Fox 1 Dry Cereal"
 	rom ( name "SPY Fox 1 Dry Cereal.scummvm" size 6 crc 2370e8e1 )
+	rom ( name "SPY Fox 1 Dry Cereal Windows.scummvm" size 8 crc fd160e3b )
+	rom ( name "SPY Fox 1 Dry Cereal Unix.scummvm" size 7 crc e5f9a495 )
 )
 
 game (
 	name "SPY Fox 2 Some Assembly Required"
 	description "SPY Fox 2 Some Assembly Required"
 	rom ( name "SPY Fox 2 Some Assembly Required.scummvm" size 7 crc cdfb1c0b )
+	rom ( name "SPY Fox 2 Some Assembly Required Windows.scummvm" size 9 crc e357cdd3 )
+	rom ( name "SPY Fox 2 Some Assembly Required Unix.scummvm" size 8 crc a5c82407 )
 )
 
 game (
 	name "SPY Fox 3 Operation Ozone"
 	description "SPY Fox 3 Operation Ozone"
 	rom ( name "SPY Fox 3 Operation Ozone.scummvm" size 7 crc cd40ab53 )
+	rom ( name "SPY Fox 3 Operation Ozone Windows.scummvm" size 9 crc c4303c1b )
+	rom ( name "SPY Fox 3 Operation Ozone Unix.scummvm" size 8 crc c0784676 )
 )
 
 game (
 	name "Swampy Adventures"
 	description "Swampy Adventures"
 	rom ( name "Swampy Adventures.scummvm" size 6 crc b2f59a68 )
+	rom ( name "Swampy Adventures Windows.scummvm" size 8 crc a95cacac )
+	rom ( name "Swampy Adventures Unix.scummvm" size 7 crc 710c1a63 )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars"
 	description "Broken Sword The Shadow of the Templars"
 	rom ( name "Broken Sword The Shadow of the Templars.scummvm" size 6 crc 13f917e1 )
+	rom ( name "Broken Sword The Shadow of the Templars Windows.scummvm" size 8 crc d014d13f )
+	rom ( name "Broken Sword The Shadow of the Templars Unix.scummvm" size 7 crc e5c92d6a )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars (Demo)"
 	description "Broken Sword The Shadow of the Templars (Demo)"
 	rom ( name "Broken Sword The Shadow of the Templars (Demo).scummvm" size 10 crc e0285722 )
+	rom ( name "Broken Sword The Shadow of the Templars (Demo) Windows.scummvm" size 12 crc 461fe7f3 )
+	rom ( name "Broken Sword The Shadow of the Templars (Demo) Unix.scummvm" size 11 crc e7576f20 )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars (Mac)"
 	description "Broken Sword The Shadow of the Templars (Mac)"
 	rom ( name "Broken Sword The Shadow of the Templars (Mac).scummvm" size 9 crc 7ed19fcf )
+	rom ( name "Broken Sword The Shadow of the Templars (Mac) Windows.scummvm" size 11 crc 3870be29 )
+	rom ( name "Broken Sword The Shadow of the Templars (Mac) Unix.scummvm" size 10 crc 3972082d )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars (Mac demo)"
 	description "Broken Sword The Shadow of the Templars (Mac demo)"
 	rom ( name "Broken Sword The Shadow of the Templars (Mac demo).scummvm" size 13 crc 21bd7658 )
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo) Windows.scummvm" size 15 crc dfa6a744 )
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo) Unix.scummvm" size 14 crc 57466223 )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars (PlayStation)"
 	description "Broken Sword The Shadow of the Templars (PlayStation)"
 	rom ( name "Broken Sword The Shadow of the Templars (PlayStation).scummvm" size 9 crc 98be16d3 )
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation) Windows.scummvm" size 11 crc 4a633e9f )
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation) Unix.scummvm" size 10 crc 2d953beb )
 )
 
 game (
 	name "Broken Sword The Shadow of the Templars (PlayStation demo)"
 	description "Broken Sword The Shadow of the Templars (PlayStation demo)"
 	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo).scummvm" size 13 crc 7e9a8e55 )
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo) Windows.scummvm" size 15 crc d96efc00 )
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo) Unix.scummvm" size 14 crc 29a83966 )
 )
 
 game (
 	name "Broken Sword II The Smoking Mirror"
 	description "Broken Sword II The Smoking Mirror"
 	rom ( name "Broken Sword II The Smoking Mirror.scummvm" size 6 crc 8af0465b )
+	rom ( name "Broken Sword II The Smoking Mirror Windows.scummvm" size 8 crc d2526f66 )
+	rom ( name "Broken Sword II The Smoking Mirror Unix.scummvm" size 7 crc cee47ea9 )
 )
 
 game (
 	name "Broken Sword 2.5"
 	description "Broken Sword 2.5"
 	rom ( name "Broken Sword 2.5.scummvm" size 7 crc 78825394 )
+	rom ( name "Broken Sword 2.5 Windows.scummvm" size 9 crc f3edb27e )
+	rom ( name "Broken Sword 2.5 Unix.scummvm" size 8 crc c5cdd39d )
 )
 
 game (
 	name "Broken Sword II The Smoking Mirror (alt)"
 	description "Broken Sword II The Smoking Mirror (alt)"
 	rom ( name "Broken Sword II The Smoking Mirror (alt).scummvm" size 9 crc 530332cf )
+	rom ( name "Broken Sword II The Smoking Mirror (alt) Windows.scummvm" size 11 crc 90174cae )
+	rom ( name "Broken Sword II The Smoking Mirror (alt) Unix.scummvm" size 10 crc 395fda80 )
 )
 
 game (
 	name "Broken Sword II The Smoking Mirror (Demo)"
 	description "Broken Sword II The Smoking Mirror (Demo)"
 	rom ( name "Broken Sword II The Smoking Mirror (Demo).scummvm" size 10 crc a7882df2 )
+	rom ( name "Broken Sword II The Smoking Mirror (Demo) Windows.scummvm" size 12 crc 77f7fd6e )
+	rom ( name "Broken Sword II The Smoking Mirror (Demo) Unix.scummvm" size 11 crc 61c31d8e )
 )
 
 game (
 	name "Broken Sword II The Smoking Mirror (PlayStation)"
 	description "Broken Sword II The Smoking Mirror (PlayStation)"
 	rom ( name "Broken Sword II The Smoking Mirror (PlayStation).scummvm" size 9 crc 8a0bb93d )
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation) Windows.scummvm" size 11 crc ccf74c31 )
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation) Unix.scummvm" size 10 crc 6a35413b )
 )
 
 game (
 	name "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
 	description "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
 	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo).scummvm" size 13 crc f01589b6 )
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo) Windows.scummvm" size 15 crc 32594703 )
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo) Unix.scummvm" size 14 crc 102505a3 )
 )
 
 game (
 	name "Teen Agent"
 	description "Teen Agent"
 	rom ( name "Teen Agent.scummvm" size 9 crc d8944e40 )
+	rom ( name "Teen Agent Windows.scummvm" size 11 crc 75bf7eaa )
+	rom ( name "Teen Agent Unix.scummvm" size 10 crc 44d3d34d )
 )
 
 game (
 	name "Day of the Tentacle"
 	description "Day of the Tentacle"
 	rom ( name "Day of the Tentacle.scummvm" size 8 crc 97815f07 )
+	rom ( name "Day of the Tentacle Windows.scummvm" size 10 crc a037c88f )
+	rom ( name "Day of the Tentacle Unix.scummvm" size 9 crc ac24126f )
 )
 
 game (
 	name "Big Thinkers First Grade"
 	description "Big Thinkers First Grade"
 	rom ( name "Big Thinkers First Grade.scummvm" size 8 crc 1274b7b8 )
+	rom ( name "Big Thinkers First Grade Windows.scummvm" size 10 crc 6dbb9547 )
+	rom ( name "Big Thinkers First Grade Unix.scummvm" size 9 crc f77f499a )
 )
 
 game (
 	name "Big Thinkers Kindergarten"
 	description "Big Thinkers Kindergarten"
 	rom ( name "Big Thinkers Kindergarten.scummvm" size 8 crc 99ca0f52 )
+	rom ( name "Big Thinkers Kindergarten Windows.scummvm" size 10 crc c903e21 )
+	rom ( name "Big Thinkers Kindergarten Unix.scummvm" size 9 crc b72bfc44 )
 )
 
 game (
 	name "Tinsel engine game"
 	description "Tinsel engine game"
 	rom ( name "Tinsel engine game.scummvm" size 6 crc 64931fe0 )
+	rom ( name "Tinsel engine game Windows.scummvm" size 8 crc c7d41f26 )
+	rom ( name "Tinsel engine game Unix.scummvm" size 7 crc 92b977f4 )
 )
 
 game (
 	name "3 Skulls of the Toltecs"
 	description "3 Skulls of the Toltecs"
 	rom ( name "3 Skulls of the Toltecs.scummvm" size 7 crc db62a67 )
+	rom ( name "3 Skulls of the Toltecs Windows.scummvm" size 9 crc e5a5bcac )
+	rom ( name "3 Skulls of the Toltecs Unix.scummvm" size 8 crc e10c4442 )
 )
 
 game (
 	name "Tony Tough and the Night of Roasted Moths"
 	description "Tony Tough and the Night of Roasted Moths"
 	rom ( name "Tony Tough and the Night of Roasted Moths.scummvm" size 4 crc 5435eb7b )
+	rom ( name "Tony Tough and the Night of Roasted Moths Windows.scummvm" size 6 crc efb14a54 )
+	rom ( name "Tony Tough and the Night of Roasted Moths Unix.scummvm" size 5 crc f5549bcc )
 )
 
 game (
 	name "Toonstruck"
 	description "Toonstruck"
 	rom ( name "Toonstruck.scummvm" size 4 crc cefd5ffd )
+	rom ( name "Toonstruck Windows.scummvm" size 6 crc 4e6498c4 )
+	rom ( name "Toonstruck Unix.scummvm" size 5 crc f115756d )
 )
 
 game (
 	name "Touche The Adventures of the Fifth Musketeer"
 	description "Touche The Adventures of the Fifth Musketeer"
 	rom ( name "Touche The Adventures of the Fifth Musketeer.scummvm" size 6 crc bc9f5f47 )
+	rom ( name "Touche The Adventures of the Fifth Musketeer Windows.scummvm" size 8 crc 504eac94 )
+	rom ( name "Touche The Adventures of the Fifth Musketeer Unix.scummvm" size 7 crc dad34dff )
 )
 
 game (
 	name "Tsunami TsAGE-based Game"
 	description "Tsunami TsAGE-based Game"
 	rom ( name "Tsunami TsAGE-based Game.scummvm" size 5 crc ed8b77c0 )
+	rom ( name "Tsunami TsAGE-based Game Windows.scummvm" size 7 crc 11395bf6 )
+	rom ( name "Tsunami TsAGE-based Game Unix.scummvm" size 6 crc a95e4f54 )
 )
 
 game (
 	name "Bud Tucker in Double Trouble"
 	description "Bud Tucker in Double Trouble"
 	rom ( name "Bud Tucker in Double Trouble.scummvm" size 6 crc dbd37215 )
+	rom ( name "Bud Tucker in Double Trouble Windows.scummvm" size 8 crc 9d1ca87b )
+	rom ( name "Bud Tucker in Double Trouble Unix.scummvm" size 7 crc 5fd1310a )
 )
 
 game (
 	name "Voyeur"
 	description "Voyeur"
 	rom ( name "Voyeur.scummvm" size 6 crc c3b3d49d )
+	rom ( name "Voyeur Windows.scummvm" size 8 crc 51f3a485 )
+	rom ( name "Voyeur Unix.scummvm" size 7 crc bcaa5abe )
 )
 
 game (
 	name "Freddi Fish and Luther's Water Worries"
 	description "Freddi Fish and Luther's Water Worries"
 	rom ( name "Freddi Fish and Luther's Water Worries.scummvm" size 5 crc fb3314da )
+	rom ( name "Freddi Fish and Luther's Water Worries Windows.scummvm" size 7 crc 75af8777 )
+	rom ( name "Freddi Fish and Luther's Water Worries Unix.scummvm" size 6 crc 542a0e4d )
 )
 
 game (
 	name "Waxworks"
 	description "Waxworks"
 	rom ( name "Waxworks.scummvm" size 8 crc 39c07a43 )
+	rom ( name "Waxworks Windows.scummvm" size 10 crc 7f263888 )
+	rom ( name "Waxworks Unix.scummvm" size 9 crc dd3bd6c3 )
 )
 
 game (
 	name "Wintermute engine game"
 	description "Wintermute engine game"
 	rom ( name "Wintermute engine game.scummvm" size 10 crc ec4f06df )
+	rom ( name "Wintermute engine game Windows.scummvm" size 12 crc fb611506 )
+	rom ( name "Wintermute engine game Unix.scummvm" size 11 crc 245786d0 )
 )
 
 game (
 	name "Zak McKracken and the Alien Mindbenders"
 	description "Zak McKracken and the Alien Mindbenders"
 	rom ( name "Zak McKracken and the Alien Mindbenders.scummvm" size 3 crc a1d6a2 )
+	rom ( name "Zak McKracken and the Alien Mindbenders Windows.scummvm" size 5 crc e7232c87 )
+	rom ( name "Zak McKracken and the Alien Mindbenders Unix.scummvm" size 4 crc a0f6581 )
 )
 
 game (
 	name "Zak McKracken & Loom"
 	description "Zak McKracken & Loom"
 	rom ( name "Zak McKracken & Loom.scummvm" size 7 crc 1b236493 )
+	rom ( name "Zak McKracken & Loom Windows.scummvm" size 9 crc 411e217 )
+	rom ( name "Zak McKracken & Loom Unix.scummvm" size 8 crc 5bcae709 )
 )
 
 game (
 	name "Z-Vision Game"
 	description "Z-Vision Game"
 	rom ( name "Z-Vision Game.scummvm" size 7 crc eace6f11 )
+	rom ( name "Z-Vision Game Windows.scummvm" size 9 crc 9a7630bb )
+	rom ( name "Z-Vision Game Unix.scummvm" size 8 crc 588de80e )
 )


### PR DESCRIPTION
The user's operating system can sometimes add new line terminators to the end of the created `.scummvm` files. This PR adds the new line support directly in the DAT file so that it works whether or not the OS added the newline.