### PR TITLE
Add the Myst CRCs and fix ScummVM.rdb compilation

### DIFF
--- a/metadat/developer/ScummVM.dat
+++ b/metadat/developer/ScummVM.dat
@@ -5,14 +5,13 @@ clrmamepro (
 
 game (
 	name "Myst"
-   developer "Cyan"
-	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 )
-	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d )
-	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571  )
-	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 )
-	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 )
-	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 )
+	developer "Cyan"
+	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 crc 4052e5ed )
+	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed crc eaff82e3 )
+	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 crc 8c8b4c90 )
+	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d crc 46b15d90 )
+	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571 crc acfc465a )
+	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 crc 97c9fec3 )
+	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 crc 770599b5 )
+	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 crc 5a435367 )
 )

--- a/metadat/franchise/ScummVM.dat
+++ b/metadat/franchise/ScummVM.dat
@@ -5,14 +5,13 @@ clrmamepro (
 
 game (
 	name "Myst"
-   franchise "Myst"
-	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 )
-	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d )
-	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571  )
-	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 )
-	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 )
-	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 )
+	franchise "Myst"
+	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 crc 4052e5ed )
+	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed crc eaff82e3 )
+	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 crc 8c8b4c90 )
+	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d crc 46b15d90 )
+	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571 crc acfc465a )
+	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 crc 97c9fec3 )
+	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 crc 770599b5 )
+	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 crc 5a435367 )
 )

--- a/metadat/magazine/edge/ScummVM.dat
+++ b/metadat/magazine/edge/ScummVM.dat
@@ -5,15 +5,14 @@ clrmamepro (
 
 game (
 	name "Myst"
-   edge_rating 6
-   edge_issue 4
-	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 )
-	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d )
-	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571  )
-	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 )
-	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 )
-	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 )
+	edge_rating 6
+	edge_issue 4
+	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 crc 4052e5ed )
+	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed crc eaff82e3 )
+	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 crc 8c8b4c90 )
+	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d crc 46b15d90 )
+	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571 crc acfc465a )
+	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 crc 97c9fec3 )
+	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 crc 770599b5 )
+	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 crc 5a435367 )
 )

--- a/metadat/maxusers/ScummVM.dat
+++ b/metadat/maxusers/ScummVM.dat
@@ -5,14 +5,13 @@ clrmamepro (
 
 game (
 	name "Myst"
-   users 1
-	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 )
-	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d )
-	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571  )
-	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 )
-	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 )
-	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 )
+	users 1
+	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 crc 4052e5ed )
+	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed crc eaff82e3 )
+	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 crc 8c8b4c90 )
+	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d crc 46b15d90 )
+	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571 crc acfc465a )
+	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 crc 97c9fec3 )
+	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 crc 770599b5 )
+	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 crc 5a435367 )
 )

--- a/metadat/origin/ScummVM.dat
+++ b/metadat/origin/ScummVM.dat
@@ -5,14 +5,13 @@ clrmamepro (
 
 game (
 	name "Myst"
-   origin "US"
-	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed )
-	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 )
-	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d )
-	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571  )
-	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 )
-	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 )
-	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 )
+	origin "US"
+	rom ( name "CHANNEL.DAT" sha1 c57ef60c4163d04f653630e2edf6f052090a1ad4 crc 4052e5ed )
+	rom ( name "CREDITS.DAT" sha1 1c3e35867ef1d59043fa294ce6da0b7ae03da6ed crc eaff82e3 )
+	rom ( name "DUNNY.DAT" sha1  f9b75fe06056426f035677e60afc8498d2d7e172 crc 8c8b4c90 )
+	rom ( name "INTRO.DAT"  sha1 face1ccd587869945b25cc595f97c51a3ae9e84d crc 46b15d90 )
+	rom ( name "MECHAN.DAT" sha1 7805f3b312e06016da4e926290752addc3e9e571 crc acfc465a )
+	rom ( name "MYST.DAT" sha1 cbc1d970d3ecc32a9c873f2eb11a0c18e449aba7 crc 97c9fec3 )
+	rom ( name "SELEN.DAT" sha1 95f68fd246cc3cb928058b3266a9416e9b3bc073 crc 770599b5 )
+	rom ( name "STONE.DAT" sha1 3886da65910d7ed291f3b3581023075659425de6 crc 5a435367 )
 )


### PR DESCRIPTION
Myst was missing the CRCs, breaking the build process. This adds them in so that `libretro-build-database.sh` can work again.