### PR TITLE
Remove the line ending support from Lutro.dat

### DIFF
--- a/dat/Lutro.dat
+++ b/dat/Lutro.dat
@@ -13,79 +13,52 @@ game (
 	name "Game of Life"
 	description "Game of Life"
 	rom ( name "main.lua" crc 8b18cc53 )
-	rom ( name "main-LF.lua" crc 8b18cc53 )
-	rom ( name "main-CR.lua" crc abdbe2f0 )
-	rom ( name "main-CRLF.lua" crc 84ae2ff6 )
 )
 
 game (
 	name "IYFCT"
 	description "IYFCT"
 	rom ( name "main.lua" crc d5e77e87 )
-	rom ( name "main-LF.lua" crc d5e77e87 )
-	rom ( name "main-CR.lua" crc 2e72d83e )
-	rom ( name "main-CRLF.lua" crc 571024f8 )
 )
 
 game (
 	name "Platformer"
 	description "Platformer"
 	rom ( name "main.lua" crc fe4781fb )
-	rom ( name "main-LF.lua" crc fe4781fb )
-	rom ( name "main-CR.lua" crc 4bf6d235 )
-	rom ( name "main-CRLF.lua" crc e891005 )
 )
 
 game (
 	name "Pong"
 	description "Pong"
 	rom ( name "main.lua" crc bebbbaf0 )
-	rom ( name "main-LF.lua" crc bebbbaf0 )
-	rom ( name "main-CR.lua" crc 92ef6787 )
-	rom ( name "main-CRLF.lua" crc 9737b3c5 )
 )
 
 game (
 	name "Sienna"
 	description "Sienna"
 	rom ( name "main.lua" crc 432264d )
-	rom ( name "main-LF.lua" crc 432264d )
-	rom ( name "main-CR.lua" crc 34702ed1 )
-	rom ( name "main-CRLF.lua" crc a0438a67 )
 )
 
 game (
 	name "Snake"
 	description "Snake"
 	rom ( name "main.lua" crc 6e3d72c8 )
-	rom ( name "main-LF.lua" crc 6e3d72c8 )
-	rom ( name "main-CR.lua" crc c4730794 )
-	rom ( name "main-CRLF.lua" crc 3763afa9 )
 )
 
 game (
 	name "Spaceship"
 	description "Spaceship"
 	rom ( name "main.lua" crc 283908 )
-	rom ( name "main-LF.lua" crc 283908 )
-	rom ( name "main-CR.lua" crc bdc7372b )
-	rom ( name "main-CRLF.lua" crc 862c3efd )
 )
 
 game (
 	name "Tetris"
 	description "Tetris"
 	rom ( name "main.lua" crc c89c89ec )
-	rom ( name "main-LF.lua" crc c89c89ec )
-	rom ( name "main-CR.lua" crc 991f0031 )
-	rom ( name "main-CRLF.lua" crc 4a0c39a4 )
 )
 
 game (
 	name "Lutris"
 	description "Lutris"
 	rom ( name "main.lua" crc 6e9204f0 )
-	rom ( name "main-LF.lua" crc 6e9204f0 )
-	rom ( name "main-CR.lua" crc b8b6372f )
-	rom ( name "main-CRLF.lua" crc bd812579 )
 )


### PR DESCRIPTION
It appears that having multiple `rom` definitions in the game set forces the database to read only the last `rom` definition. Due to this, we'll only use the first one, without any line ending manipulation.