### PR TITLE
Fix ROM order for DOOM

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -327,21 +327,21 @@ game (
 game (
 	name "Hell to Pay"
 	description "Hell to Pay"
-	rom ( name HTP-RAW.WAD size 11852644 crc c8db7b44 md5 ba4d2564c72f7ec963be2f02c3c3e5f5 sha1 3a261acd34c09585d0a7fe61e16913e96f7eb8b0 )
 	rom ( name HTPDMO16.WAD size 23744 crc 02b90bc3 md5 60ae056fa7c22311c27f7051a411ff48 sha1 ada65a77dad8a312d66a3a491a8829ba8dde4144 )
 	rom ( name HTPDMO17.WAD size 23744 crc 00b4e769 md5 3f8bef448db2fddc8dca2ad9327caf8d sha1 9dabed333aa0a2bb7600aac6498ae752b544bac8 )
 	rom ( name HTPDMO18.WAD size 23744 crc 0e95603f md5 8ede0e4a7f84785d06c59081023f214a sha1 ac4648967da7d38f5d1e4f21bbb15d0b91808167 )
 	rom ( name HTPDMO19.WAD size 23744 crc 0c988c95 md5 979c06bd61752f0029cb7c224fa7a0e2 sha1 6084484f255ce8e79f4a21d705087ba4f44e3e51 )
+	rom ( name HTP-RAW.WAD size 11852644 crc c8db7b44 md5 ba4d2564c72f7ec963be2f02c3c3e5f5 sha1 3a261acd34c09585d0a7fe61e16913e96f7eb8b0 )
 )
 
 game (
 	name "Hell to Pay (Demo)"
 	description "Hell to Pay (Demo)"
-	rom ( name HTP-LTD.WAD size 6732780 crc 6f8c8d6e md5 b739291c2cb37dd1722b2eeffebe3353 sha1 0256779b1267de84e05b40caf8f2f082f32d9a63 )
 	rom ( name HTPDMO16.WAD size 24676 crc 22cd9946 md5 0f10b8635b1999fb29b8f4245ed941bd sha1 77b6ce7470efd392ccdb8efa9ff6a2e04aa6f9ed )
 	rom ( name HTPDMO17.WAD size 24676 crc bbf8e9ed md5 c57ec77fb91f50981946b5b74ca9b5b9 sha1 8efefe76740879cc578dda1ea15444a173c42ab2 )
 	rom ( name HTPDMO18.WAD size 24676 crc c290b63e md5 5c06c391eaffcf83ea748decf34e0ae1 sha1 13a52d911274589bcc7041b5091e374baf80c7a8 )
 	rom ( name HTPDMO19.WAD size 24676 crc 5ba5c695 md5 848c60715be0636abddc76b0a93ca3f6 sha1 d4ed8c5a9a7e67dd641f6911020290bb60d627bd )
+	rom ( name HTP-LTD.WAD size 6732780 crc 6f8c8d6e md5 b739291c2cb37dd1722b2eeffebe3353 sha1 0256779b1267de84e05b40caf8f2f082f32d9a63 )
 )
 
 game (
@@ -469,29 +469,29 @@ game (
 	name "Perdition's Gate"
 	description "Perdition's Gate"
 	rom ( name PG-RAW-X.WAD size 7012512 crc eaeb3ec0 md5 2e179a5aa598f02e9ef132c9cfed7a1a sha1 38635b065258ac562ac9dd75a40901be68f2ef4e )
-	rom ( name PG-RAW.WAD size 7008400 crc afa09215 md5 22bde2b7714c4e059a557c009666265f sha1 a06af291e447389094f62a2a2734c521a9c17f95 )
 	rom ( name PGDEMO16.WAD size 29776 crc f84e30b4 md5 a1bf1cb53930441663231701d5dce766 sha1 ecae7b1d851853dbe02ecca62650344ac1652b7d )
 	rom ( name PGDEMO17.WAD size 29776 crc 40492caa md5 38718a9618f38b78ba30c7f8892dec31 sha1 8553435b8a95da72f77eb65befbf49210108cd2a )
 	rom ( name PGDEMO18.WAD size 29776 crc debe7472 md5 43fe4c4fef6ececfe8eecb4a618eab07 sha1 7c2507f9349f7f5a02a2c310c35127bfc4231b1d )
 	rom ( name PGDEMO19.WAD size 29776 crc 66b9686c md5 0219f6c19d35c7c99168bb16cc653950 sha1 b263a10ce17d65ca953c7ac32923f45c3e41d7fb )
+	rom ( name PG-RAW.WAD size 7008400 crc afa09215 md5 22bde2b7714c4e059a557c009666265f sha1 a06af291e447389094f62a2a2734c521a9c17f95 )
 )
 
 game (
 	name "Perdition's Gate (Demo)"
 	description "Perdition's Gate (Demo)"
 	rom ( name PG-LTD-X.WAD size 2811816 crc 40d781d5 md5 6f87b2efe8820f257c29e821e96ad5a9 sha1 791afa256fead52f7f8db7b2f9ac1250fa8177d3 )
-	rom ( name PG-LTD.WAD size 2807704 crc bf223dd2 md5 7d1f8cba50cfc0f9334ad5950604c80c sha1 56d98c7046d26955dfea6110eef7394b6677f989 )
 	rom ( name PGDEMO16.WAD size 55228 crc dfbbfbc8 md5 7ae425d1bf1d0655040382739f741e7d sha1 9a070d11a5e54d6eb484803248d551b3b250698b )
 	rom ( name PGDEMO17.WAD size 55228 crc 1d2c4343 md5 a786beb8614e77cd0a16c3390ef1db2a sha1 02609f16fe12dfed70ec800535936a658763dc12 )
 	rom ( name PGDEMO18.WAD size 55228 crc 3d596231 md5 5f5314d9927d72c8a3ce18e873b3c1c6 sha1 29e0e20c0365527961595447072364de7821ba45 )
 	rom ( name PGDEMO19.WAD size 55228 crc ffcedaba md5 781035cf5b8300fd93cdcb639bdeb0f9 sha1 2ba85090eaa133499fbfedb13310d6bac6390a4e )
+	rom ( name PG-LTD.WAD size 2807704 crc bf223dd2 md5 7d1f8cba50cfc0f9334ad5950604c80c sha1 56d98c7046d26955dfea6110eef7394b6677f989 )
 )
 
 game (
 	name "Strife (v1.0)"
 	description "Strife (v1.0)"
-	rom ( name STRIFE1.WAD size 28372168 crc b7581abd md5 8f2d3a6a289f5d2f2f9c1eec02b47299 sha1 eb0f3e157b35c34d5a598701f775e789ec85b4ae )
 	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
+	rom ( name STRIFE1.WAD size 28372168 crc b7581abd md5 8f2d3a6a289f5d2f2f9c1eec02b47299 sha1 eb0f3e157b35c34d5a598701f775e789ec85b4ae )
 )
 
 game (
@@ -509,8 +509,8 @@ game (
 game (
 	name "Strife (v1.2)"
 	description "Strife (v1.2)"
-	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
 	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
+	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
 )
 
 game (


### PR DESCRIPTION

When the Database is loaded, the last rom in the set is saved as the rom to load from the database. This PR re-orders the DOOM roms so that the WAD we want to load in prboom is the one that's indexed in the database.

Having a look through the Database Manager shows us for Strife, the CRC loads VOICES.WAD, while STRIFE1.WAD is the actual rom we want to load:

![strife](https://cloud.githubusercontent.com/assets/25086/16332678/3d9d929c-39c5-11e6-9528-5eda4652cd61.png)

This PR flips the rom order so that STRIFE1.WAD is the rom we will load.