### PR TITLE
Add Sega - Saturn support

### DIFF
--- a/dat/Sega - Saturn.dat
+++ b/dat/Sega - Saturn.dat
@@ -1,0 +1,9331 @@
+clrmamepro (
+	name "Sega - Saturn"
+	description "Sega - Saturn"
+	version "20160705 01-00-24"
+	comment "libretro-database's Sega - Saturn.dat, built from Redump.org"
+	homepage "https://github.com/RobLoach/libretro-database-sega-saturn"
+)
+
+game (
+	name "Lunar 2 - Eternal Blue (Japan) (Disc 1)"
+	description "Lunar 2 - Eternal Blue (Japan) (Disc 1)"
+	rom ( name "Lunar 2 - Eternal Blue (Japan) (Disc 1) (Track 1).bin" size 653957136 crc 49d70180 md5 07136c4431147a54f12a15291102a3ef sha1 135c69c600dac940cd542a3436cb26a72a0929ec )
+)
+
+game (
+	name "Lunar 2 - Eternal Blue (Japan) (Disc 2)"
+	description "Lunar 2 - Eternal Blue (Japan) (Disc 2)"
+	rom ( name "Lunar 2 - Eternal Blue (Japan) (Disc 2) (Track 1).bin" size 659202096 crc d6cc59ad md5 a8c24a241e1707b0cb0ae69aa65e7990 sha1 07dfb50073f5899f48ba57d42cac03cea507b89a )
+)
+
+game (
+	name "Devil Summoner - Soul Hackers & Ronde - Otameshi you (Japan) (Sample)"
+	description "Devil Summoner - Soul Hackers & Ronde - Otameshi you (Japan) (Sample)"
+	rom ( name "Devil Summoner - Soul Hackers & Ronde - Otameshi you (Japan) (Sample) (Track 1).bin" size 576357600 crc 0198e73d md5 ecffddcff5623913105faa20a80001b3 sha1 4d28689d460bd9a764624d9a6590b928248b4d2a )
+)
+
+game (
+	name "World Cup France '98 - Road to Win (Japan)"
+	description "World Cup France '98 - Road to Win (Japan)"
+	rom ( name "World Cup France '98 - Road to Win (Japan) (Track 1).bin" size 442851024 crc 65f7ea85 md5 d62571632b3d26be1ba6ec28589d66ed sha1 5c7ed1d24a9b2fef526cd1c372703f2938c2acfb )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (3M)"
+	description "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (3M)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (3M) (Track 1).bin" size 476717472 crc 675444b3 md5 2360f1ce1a62fd1ca6e7f923b589340e sha1 499471933b0ae793e27c4d7ced1e68537c1c42c8 )
+)
+
+game (
+	name "DX Jinsei Game (Japan) (Rev B)"
+	description "DX Jinsei Game (Japan) (Rev B)"
+	rom ( name "DX Jinsei Game (Japan) (Rev B) (Track 1).bin" size 93301488 crc 55890eb4 md5 f80bb45fba42a8e56fde6c0bb49f03c9 sha1 ef367003f34022fd51a98d66f91262289615d59d )
+)
+
+game (
+	name "America Oudan Ultra Quiz (Japan)"
+	description "America Oudan Ultra Quiz (Japan)"
+	rom ( name "America Oudan Ultra Quiz (Japan) (Track 1).bin" size 421085616 crc 96114d50 md5 61982ea9d2d4e083dbf41e9a354cbbbc sha1 7fab9c3fdecd9b81bb9aa7b799310ef49d234741 )
+)
+
+game (
+	name "Jungle Park - Saturn Shima (Japan) (Rev A)"
+	description "Jungle Park - Saturn Shima (Japan) (Rev A)"
+	rom ( name "Jungle Park - Saturn Shima (Japan) (Rev A) (Track 1).bin" size 246205008 crc 1b4c2994 md5 2cc9da4818bcd7d740fa8b1febf12e96 sha1 b4436b521bbaea046ef24ff89d80ed7621573b69 )
+)
+
+game (
+	name "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan) (Rev A)"
+	description "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan) (Rev A)"
+	rom ( name "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan) (Rev A) (Track 1).bin" size 651376992 crc c3e7ebea md5 e8cf063078b0ecc9040d70c1351b3a96 sha1 cf26c815926178afd28e6fc4123de9c350168caf )
+)
+
+game (
+	name "m [emu] - Kimi o Tsutaete (Japan) (2M)"
+	description "m [emu] - Kimi o Tsutaete (Japan) (2M)"
+	rom ( name "m [emu] - Kimi o Tsutaete (Japan) (2M) (Track 1).bin" size 230627712 crc 1cf5012f md5 74a3431325defcc07e752531f74c0816 sha1 7e1b833ab0ba5522385e0792ad6a36e75cfd654f )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (2M)"
+	description "Enemy Zero (Japan) (Disc 0) (Opening Disc) (2M)"
+	rom ( name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (2M) (Track 1).bin" size 311461248 crc f3ded9fb md5 560e2109c42292adae0f1bdad22341d7 sha1 1c159b1eb911ff8c6b5f1b260c09a72251ccaf79 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 1) (Game Disc) (2M)"
+	description "Enemy Zero (Japan) (Disc 1) (Game Disc) (2M)"
+	rom ( name "Enemy Zero (Japan) (Disc 1) (Game Disc) (2M) (Track 1).bin" size 579892656 crc 24b4a293 md5 f5e33317836aff0d67905a044c2f5420 sha1 5c24e7c696a462ad0f62f2b6352aa176dcea8daa )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 2) (Game Disc) (2M)"
+	description "Enemy Zero (Japan) (Disc 2) (Game Disc) (2M)"
+	rom ( name "Enemy Zero (Japan) (Disc 2) (Game Disc) (2M) (Track 1).bin" size 653105712 crc ca8af6c3 md5 227b78034f7143d844e1ff3ad8c09f8b sha1 8b6f1e7844724a828392d9fd4893b6b6adc88746 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 3) (Game Disc) (3M)"
+	description "Enemy Zero (Japan) (Disc 3) (Game Disc) (3M)"
+	rom ( name "Enemy Zero (Japan) (Disc 3) (Game Disc) (3M) (Track 1).bin" size 470703408 crc f6e72036 md5 9a28f668bb6f9c53f0c7744414604b23 sha1 f3ed12d3d433c28d34d52b0744fcfd79eeaeab8f )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 1) (7M, 9M)"
+	description "Sakura Taisen (Japan) (Disc 1) (7M, 9M)"
+	rom ( name "Sakura Taisen (Japan) (Disc 1) (7M, 9M) (Track 1).bin" size 635917296 crc edda732e md5 69b12554031b7e3b22ae37aaf03d3c3d sha1 76f3b13c6dc7429b1df475c68edfd9dc37feca27 )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 2) (9M)"
+	description "Sakura Taisen (Japan) (Disc 2) (9M)"
+	rom ( name "Sakura Taisen (Japan) (Disc 2) (9M) (Track 1).bin" size 617896272 crc 5eb578e5 md5 2c68b0b4444dbcc53a29ccea484b63f1 sha1 3577ad4f1a02b024bb34d8e823a96b7da0b3b6fe )
+)
+
+game (
+	name "Vampire Hunter - Darkstalkers' Revenge (Japan) (3M)"
+	description "Vampire Hunter - Darkstalkers' Revenge (Japan) (3M)"
+	rom ( name "Vampire Hunter - Darkstalkers' Revenge (Japan) (3M) (Track 1).bin" size 493741248 crc 94c313ab md5 beef086bf1235c752ef9d2b693a5642c sha1 77390da7878762e3963bb54d8a7c3ba3f86800ed )
+)
+
+game (
+	name "Street Fighter Zero 2 (Japan)"
+	description "Street Fighter Zero 2 (Japan)"
+	rom ( name "Street Fighter Zero 2 (Japan) (Track 1).bin" size 467723424 crc 5dd6ad25 md5 fa703e7ed0bcf721e4d8b1208d4f9537 sha1 d2f39e5277bc98bd302508de8c1ef2a4d3f6c043 )
+)
+
+game (
+	name "Virtua Fighter 2 (Japan) (Rev B) (39B)"
+	description "Virtua Fighter 2 (Japan) (Rev B) (39B)"
+	rom ( name "Virtua Fighter 2 (Japan) (Rev B) (39B) (Track 01).bin" size 61316640 crc 65c7fc1e md5 14992450395f67b251023821a4d20480 sha1 2475bfb03eeaabdfcce93bc010d7c395efdf8dce )
+)
+
+game (
+	name "Grandia - Digital Museum (Japan) (Rev A) (10M)"
+	description "Grandia - Digital Museum (Japan) (Rev A) (10M)"
+	rom ( name "Grandia - Digital Museum (Japan) (Rev A) (10M) (Track 1).bin" size 455394240 crc 76f96c61 md5 59b19105615ca37886e1e0542ff2967e sha1 e886bd5be85a7106b60b59a03b5918a9af31be65 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (3M, 4M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (3M, 4M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (3M, 4M) (Track 1).bin" size 655554144 crc d7b04497 md5 6a2775388e661c2384ec3c911298a15a sha1 9abde77a4d14c62e2dcba2d58b627ed4cb0d770d )
+)
+
+game (
+	name "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev A)"
+	description "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev A)"
+	rom ( name "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev A) (Track 1).bin" size 137281536 crc 6e368e94 md5 75159a6d1cd92368fee8ee1091a36a4e sha1 6f1b1f6eab5faff81bed135c414adf92dac0bc15 )
+)
+
+game (
+	name "Stakes Winner - GI Kanzen Seiha e no Michi (Japan)"
+	description "Stakes Winner - GI Kanzen Seiha e no Michi (Japan)"
+	rom ( name "Stakes Winner - GI Kanzen Seiha e no Michi (Japan) (Track 01).bin" size 10315872 crc 19f0bc0a md5 0a9a946d1b1ce56826394bb67819989e sha1 aa133cea2b0d3ca847e325c70f05357987c6d23f )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (1M, 2M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (1M, 2M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (1M, 2M) (Track 1).bin" size 652296624 crc 92b0049f md5 36eac93a576c1c536863af7e66210787 sha1 d81ca4e8711d2bda775a040e9242a6c3285153f0 )
+)
+
+game (
+	name "AI Shougi (Japan)"
+	description "AI Shougi (Japan)"
+	rom ( name "AI Shougi (Japan) (Track 1).bin" size 5908224 crc 97f31af5 md5 63462853cbc9bdd35b4d0ef991e5ad6f sha1 8e0bd0618991521bf72335a7eaadc700de29eaf5 )
+)
+
+game (
+	name "Tomb Raiders (Japan)"
+	description "Tomb Raiders (Japan)"
+	rom ( name "Tomb Raiders (Japan) (Track 01).bin" size 222635616 crc eb8b53e2 md5 78ffcb905fb0fad07dbdd81c76b2d4b0 sha1 e9aad4508a6b395357bfd4124c86faa31604373b )
+)
+
+game (
+	name "Dennou Senki - Virtual On - Cyber Troopers (Japan)"
+	description "Dennou Senki - Virtual On - Cyber Troopers (Japan)"
+	rom ( name "Dennou Senki - Virtual On - Cyber Troopers (Japan) (Track 01).bin" size 67380096 crc 378963c9 md5 5f1b332332c36ed6dd1aa02e46a91475 sha1 d10698afb018c3067379fec0c793376d263ce37a )
+)
+
+game (
+	name "Nonomura Byouin no Hitobito (Japan)"
+	description "Nonomura Byouin no Hitobito (Japan)"
+	rom ( name "Nonomura Byouin no Hitobito (Japan) (Track 1).bin" size 546828240 crc 68fd13cd md5 5150730167bb5ff974f834ae08f130c6 sha1 67edd8842fa807b5759c1f3e21821768f71fb0f7 )
+)
+
+game (
+	name "Battle Garegga (Japan)"
+	description "Battle Garegga (Japan)"
+	rom ( name "Battle Garegga (Japan) (Track 01).bin" size 17322480 crc 0d28ab46 md5 b0c6d96fe425ac8468f9ea0eff44143d sha1 d7ee834b01770945bec7d240b7f19d1c721e4b29 )
+)
+
+game (
+	name "Winning Post 2 - Program '96 (Japan)"
+	description "Winning Post 2 - Program '96 (Japan)"
+	rom ( name "Winning Post 2 - Program '96 (Japan) (Track 1).bin" size 137062800 crc 9503c37c md5 474d62197e86b574e572db4b9204e7ac sha1 855cf41bf3da4d8366399af560f754bb8dffd6c8 )
+)
+
+game (
+	name "Logic Puzzle - Rainbow Town (Japan)"
+	description "Logic Puzzle - Rainbow Town (Japan)"
+	rom ( name "Logic Puzzle - Rainbow Town (Japan) (Track 01).bin" size 25646208 crc 699cb280 md5 006d6613b9b4a62e4d300b814df52c03 sha1 f55e400b7cc8438cfb8e8b2cf2796eb57112b67d )
+)
+
+game (
+	name "Manx TT SuperBike (Japan)"
+	description "Manx TT SuperBike (Japan)"
+	rom ( name "Manx TT SuperBike (Japan) (Track 01).bin" size 91944384 crc 359dacfe md5 ec89b66615f7022cad4364b85156ab90 sha1 08215f6e89e3d8b6693a3cc5e662dc57d1b5cd60 )
+)
+
+game (
+	name "Metal Slug - Super Vehicle-001 (Japan) (Rev A)"
+	description "Metal Slug - Super Vehicle-001 (Japan) (Rev A)"
+	rom ( name "Metal Slug - Super Vehicle-001 (Japan) (Rev A) (Track 01).bin" size 69031200 crc 105dacb0 md5 35aae15f0a552b751d68753e3ab2e2db sha1 ba3d6e466ce076b85bc2f9c1f1ee7dbc508e28e0 )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '97 - Make Miracle (Japan)"
+	description "Pro Yakyuu Greatest Nine '97 - Make Miracle (Japan)"
+	rom ( name "Pro Yakyuu Greatest Nine '97 - Make Miracle (Japan) (Track 1).bin" size 420528192 crc b70f0e3f md5 8cb1ecb05787392a03a462d487024226 sha1 807938e073055ebefbb6da2e277f59a3c1b4b6fb )
+)
+
+game (
+	name "Tournament Leader (Japan)"
+	description "Tournament Leader (Japan)"
+	rom ( name "Tournament Leader (Japan) (Track 01).bin" size 28976640 crc 378ba632 md5 994d71c6a24a65fb804f5b28cf614ee4 sha1 c88aa5036ff1ba45b8bf4f328686e5fd81e08d59 )
+)
+
+game (
+	name "DoDonPachi (Japan)"
+	description "DoDonPachi (Japan)"
+	rom ( name "DoDonPachi (Japan) (Track 01).bin" size 27254976 crc 5763b66c md5 52a1db1f0a2f60b8dc19e96a0ef39203 sha1 3dbfc75ba3cac58b06d1185bf9d804ec17c9cad7 )
+)
+
+game (
+	name "X-Men vs. Street Fighter (Japan) (1M)"
+	description "X-Men vs. Street Fighter (Japan) (1M)"
+	rom ( name "X-Men vs. Street Fighter (Japan) (1M) (Track 01).bin" size 169127616 crc 6f45e815 md5 0c9a8b0b0e062943b458c7f2bf381119 sha1 5e68e74be9393f1bf3fac6e9c7c00b9eb277286b )
+)
+
+game (
+	name "Real Bout Garou Densetsu Special (Japan)"
+	description "Real Bout Garou Densetsu Special (Japan)"
+	rom ( name "Real Bout Garou Densetsu Special (Japan) (Track 01).bin" size 71385552 crc 59fafa48 md5 84a36c1d4c6c23e90a01118cfea232d7 sha1 ecb607ebc467ee8f709c9a46ebccfecea0961d43 )
+)
+
+game (
+	name "Rockman 8 - Metal Heroes (Japan)"
+	description "Rockman 8 - Metal Heroes (Japan)"
+	rom ( name "Rockman 8 - Metal Heroes (Japan) (Track 1).bin" size 295959216 crc 64e64a69 md5 afa3fc604ddbcb5783f778d2634c5064 sha1 ae9f82f96eafcd324b8eca1b2c30974524ebe248 )
+)
+
+game (
+	name "Clockwork Knight - Pepperouchau's Adventure (Europe)"
+	description "Clockwork Knight - Pepperouchau's Adventure (Europe)"
+	rom ( name "Clockwork Knight - Pepperouchau's Adventure (Europe) (Track 1).bin" size 216419280 crc 02ac5602 md5 4150845d960385a6cdaf81f4ead55549 sha1 189deddc4ad88e4672942a3f4d0c079449f70c90 )
+)
+
+game (
+	name "World Cup Golf - In Hyatt Dorado Beach (Japan) (En,Ja)"
+	description "World Cup Golf - In Hyatt Dorado Beach (Japan) (En,Ja)"
+	rom ( name "World Cup Golf - In Hyatt Dorado Beach (Japan) (En,Ja) (Track 1).bin" size 570811584 crc 49f8099e md5 19ead8da51db2168ab4813d900c0bb2f sha1 30a0163907e32103ed4931fc97329cfaee18ea67 )
+)
+
+game (
+	name "Preview Sega Saturn Vol. 1 (Europe)"
+	description "Preview Sega Saturn Vol. 1 (Europe)"
+	rom ( name "Preview Sega Saturn Vol. 1 (Europe) (Track 01).bin" size 157948560 crc c2a4016d md5 f988cf56287990812ad2df88543bbf93 sha1 05506e6b122cb28eb023a01a244ec5070810f89d )
+)
+
+game (
+	name "Terra Phantastica (Japan)"
+	description "Terra Phantastica (Japan)"
+	rom ( name "Terra Phantastica (Japan) (Track 1).bin" size 446604816 crc 7447a215 md5 96f907b4ae9944a70713f2097660389a sha1 e6068d7e942a3c62a762a0a9dabf76b3794b9d56 )
+)
+
+game (
+	name "Devil Summoner - Soul Hackers (Japan) (Disc 1)"
+	description "Devil Summoner - Soul Hackers (Japan) (Disc 1)"
+	rom ( name "Devil Summoner - Soul Hackers (Japan) (Disc 1) (Track 1).bin" size 593110896 crc f32796b1 md5 3d18516108c408d936ae729b7a4047ca sha1 81926fd820465f1588247377e7fadaa477913e9b )
+)
+
+game (
+	name "Devil Summoner - Soul Hackers (Japan) (Disc 2)"
+	description "Devil Summoner - Soul Hackers (Japan) (Disc 2)"
+	rom ( name "Devil Summoner - Soul Hackers (Japan) (Disc 2) (Track 1).bin" size 618771216 crc ad5d3006 md5 0628ba7614f97e0bfda1fc7a2238b2c7 sha1 ecce5aa8aa06d03ceed28ee72a636b13184cf6ba )
+)
+
+game (
+	name "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 1)"
+	description "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 1)"
+	rom ( name "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 1) (Track 1).bin" size 220946880 crc 015d6f92 md5 07752c15b9327da040d6382c2d27a61d sha1 637fd1421077aaf315b854f2e3d4fbcf8abc57e3 )
+)
+
+game (
+	name "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 2)"
+	description "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 2)"
+	rom ( name "Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan) (Disc 2) (Track 1).bin" size 410193504 crc 0e2055ce md5 012f83cdc08ae9f5c3cb5bfae1bd815c sha1 9cc64764f85f7ae6b25871c5d8b8910e3209d0ee )
+)
+
+game (
+	name "Alien Trilogy (Europe) (En,Fr,Es,It)"
+	description "Alien Trilogy (Europe) (En,Fr,Es,It)"
+	rom ( name "Alien Trilogy (Europe) (En,Fr,Es,It) (Track 01).bin" size 205837632 crc 0bdc6db1 md5 4f8a5a6e8ce46579c543d1b2ba0fd4c6 sha1 2a6aaba7ea51d471202ca27928f5e1a9888cf4cb )
+)
+
+game (
+	name "King of Fighters '95, The (Japan) (2M)"
+	description "King of Fighters '95, The (Japan) (2M)"
+	rom ( name "King of Fighters '95, The (Japan) (2M) (Track 01).bin" size 30517200 crc d82522b6 md5 fc1cb22527384e20dcfd08d60b5aee00 sha1 ab82ae6b720811e2306cee6ce597081ac17e6a62 )
+)
+
+game (
+	name "Sega Ages - Galaxy Force II (Japan)"
+	description "Sega Ages - Galaxy Force II (Japan)"
+	rom ( name "Sega Ages - Galaxy Force II (Japan) (Track 1).bin" size 10957968 crc ad725db6 md5 d0c3d2288b82bce3e950312e04cc63ba sha1 545e5c3fa44356e51796473f8fba148aa2ce829c )
+)
+
+game (
+	name "Duke Nukem 3D (Europe)"
+	description "Duke Nukem 3D (Europe)"
+	rom ( name "Duke Nukem 3D (Europe) (Track 01).bin" size 60629856 crc 7107dfd6 md5 08d1de8a90f5651d52425d58106ec5dc sha1 b3e658d851426555a84852231938f91c503bb93e )
+)
+
+game (
+	name "Shanghai - Banri no Choujou - The Great Wall (Japan) (Rev A) (15M)"
+	description "Shanghai - Banri no Choujou - The Great Wall (Japan) (Rev A) (15M)"
+	rom ( name "Shanghai - Banri no Choujou - The Great Wall (Japan) (Rev A) (15M) (Track 1).bin" size 7420560 crc 6df2ea9e md5 083c395a4939cfbfbccff733f6ff8501 sha1 52234f2f3e0b97f5b5b92ca840e44ce996928c0e )
+)
+
+game (
+	name "Panic-chan (Japan) (Rev A) (11M)"
+	description "Panic-chan (Japan) (Rev A) (11M)"
+	rom ( name "Panic-chan (Japan) (Rev A) (11M) (Track 1).bin" size 504442848 crc e5198c20 md5 c398a16ab37960a89d3ef1dccfb7c4bc sha1 efbd63c9091ae90474ac5aca001c120ae090edb6 )
+)
+
+game (
+	name "Die Hard Trilogy (Japan)"
+	description "Die Hard Trilogy (Japan)"
+	rom ( name "Die Hard Trilogy (Japan) (Track 01).bin" size 96648384 crc 51e18ce1 md5 a46a6911355a60170765fff5c65dc394 sha1 38bf66d3a2752d6c97a754ef06aabb2f41ae3a2c )
+)
+
+game (
+	name "Virtua Cop 2 (Japan) (2M)"
+	description "Virtua Cop 2 (Japan) (2M)"
+	rom ( name "Virtua Cop 2 (Japan) (2M) (Track 01).bin" size 37702560 crc a95e48e9 md5 41e990adbd1d3255217e407d3869d7c8 sha1 dbc979c79cab0b428ea253ffbdaf622e0c476fa7 )
+)
+
+game (
+	name "Sega Touring Car Championship (Japan)"
+	description "Sega Touring Car Championship (Japan)"
+	rom ( name "Sega Touring Car Championship (Japan) (Track 01).bin" size 34183968 crc 8799333b md5 833a167d4ce84ddb344e4a8fd844d59a sha1 21cc97a868faa713c155b319f8406bf2dd8e26a0 )
+)
+
+game (
+	name "Fuusui Sensei - Feng-Shui Master (Japan)"
+	description "Fuusui Sensei - Feng-Shui Master (Japan)"
+	rom ( name "Fuusui Sensei - Feng-Shui Master (Japan) (Track 1).bin" size 219495696 crc 55b1cbc1 md5 6f20d13d25093a1db95aa6fcbc31b287 sha1 1cec56fad7b040edf6bdd194f78fe63750896d04 )
+)
+
+game (
+	name "International Victory Goal (Europe)"
+	description "International Victory Goal (Europe)"
+	rom ( name "International Victory Goal (Europe) (Track 01).bin" size 149354352 crc 7fb84616 md5 8cb76a2695610eddc4d52a9c0edf5ef5 sha1 72c8bed1101fc38d01ca95d0a3f56ab9c40ae3ec )
+)
+
+game (
+	name "Shin Megami Tensei - Devil Summoner (Japan) (Rev A)"
+	description "Shin Megami Tensei - Devil Summoner (Japan) (Rev A)"
+	rom ( name "Shin Megami Tensei - Devil Summoner (Japan) (Rev A) (Track 1).bin" size 430470096 crc 2145d7e1 md5 ba6703bf4f789d03c2502bf997239283 sha1 046bab81be23acf48845ec566c8d42063b279698 )
+)
+
+game (
+	name "Shin Megami Tensei - Devil Summoner - Akuma Zensho (Japan)"
+	description "Shin Megami Tensei - Devil Summoner - Akuma Zensho (Japan)"
+	rom ( name "Shin Megami Tensei - Devil Summoner - Akuma Zensho (Japan) (Track 1).bin" size 209753712 crc 130b7c42 md5 fb7ecfe7ae82ae83ee06c6d935589461 sha1 8d08b821c739addad039f6401c7f1fdf237e4cd2 )
+)
+
+game (
+	name "Mortal Kombat II (Europe)"
+	description "Mortal Kombat II (Europe)"
+	rom ( name "Mortal Kombat II (Europe) (Track 1).bin" size 30782976 crc 7bdc26fb md5 1abaa22c4fa542356218866d2ef9e9ca sha1 ffbea9f1230a1592e023b680858b5e7eb464ed96 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 0) (Opening Disc)"
+	description "Enemy Zero (Japan) (Disc 0) (Opening Disc)"
+	rom ( name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (Track 1).bin" size 311461248 crc f3ded9fb md5 560e2109c42292adae0f1bdad22341d7 sha1 1c159b1eb911ff8c6b5f1b260c09a72251ccaf79 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 1) (Game Disc)"
+	description "Enemy Zero (Japan) (Disc 1) (Game Disc)"
+	rom ( name "Enemy Zero (Japan) (Disc 1) (Game Disc) (Track 1).bin" size 579892656 crc 24b4a293 md5 f5e33317836aff0d67905a044c2f5420 sha1 5c24e7c696a462ad0f62f2b6352aa176dcea8daa )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 2) (Game Disc)"
+	description "Enemy Zero (Japan) (Disc 2) (Game Disc)"
+	rom ( name "Enemy Zero (Japan) (Disc 2) (Game Disc) (Track 1).bin" size 653105712 crc ca8af6c3 md5 227b78034f7143d844e1ff3ad8c09f8b sha1 8b6f1e7844724a828392d9fd4893b6b6adc88746 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 3) (Game Disc)"
+	description "Enemy Zero (Japan) (Disc 3) (Game Disc)"
+	rom ( name "Enemy Zero (Japan) (Disc 3) (Game Disc) (Track 1).bin" size 470703408 crc f6e72036 md5 9a28f668bb6f9c53f0c7744414604b23 sha1 f3ed12d3d433c28d34d52b0744fcfd79eeaeab8f )
+)
+
+game (
+	name "Jissen Pachi-Slot Hisshouhou! 3 (Japan)"
+	description "Jissen Pachi-Slot Hisshouhou! 3 (Japan)"
+	rom ( name "Jissen Pachi-Slot Hisshouhou! 3 (Japan) (Track 1).bin" size 162382080 crc 2d1a81bb md5 2544d388c039c946dedc26e9a5e80c71 sha1 898a3e58c969f54d29b8bbfcf3257220d67ace87 )
+)
+
+game (
+	name "Conveni, The - Ano Machi o Dokusen seyo (Japan)"
+	description "Conveni, The - Ano Machi o Dokusen seyo (Japan)"
+	rom ( name "Conveni, The - Ano Machi o Dokusen seyo (Japan) (Track 1).bin" size 19476912 crc 83a2457c md5 2b91f3bf7319eeef22c489c832e9764e sha1 6d845d89003d3940ccf9ce7e9e7f20e71c27ed40 )
+)
+
+game (
+	name "Sega Worldwide Soccer '98 (Japan)"
+	description "Sega Worldwide Soccer '98 (Japan)"
+	rom ( name "Sega Worldwide Soccer '98 (Japan) (Track 1).bin" size 266102928 crc 88ce1740 md5 263d0a334783501de0d6606b1a42658d sha1 340698a10db452147514f89235687ddaa286cb10 )
+)
+
+game (
+	name "Tower, The (Japan)"
+	description "Tower, The (Japan)"
+	rom ( name "Tower, The (Japan) (Track 1).bin" size 491107008 crc a38c520c md5 2fc20196314a2d7c34cabd5df61f36d1 sha1 df69921edff93630f8b050f77f73d7db95af229c )
+)
+
+game (
+	name "Bakuretsu Hunter R (Japan)"
+	description "Bakuretsu Hunter R (Japan)"
+	rom ( name "Bakuretsu Hunter R (Japan) (Track 1).bin" size 330644160 crc c0fdcfce md5 7def9083ca6c8f6079b4fff48932059f sha1 fda4bbe40fbb24039f4db1080067e1acdd300796 )
+)
+
+game (
+	name "Bakuretsu Hunter (Japan) (Disc 2) (Omake CD)"
+	description "Bakuretsu Hunter (Japan) (Disc 2) (Omake CD)"
+	rom ( name "Bakuretsu Hunter (Japan) (Disc 2) (Omake CD) (Track 1).bin" size 289444176 crc 8c5ea0a1 md5 48531cd6625946778adc1f3905d01520 sha1 49e102328b5de6cc0811407b3f21c1370db45b2e )
+)
+
+game (
+	name "Mahjong Doukyuusei Special (Japan) (Disc 1) (Genteiban)"
+	description "Mahjong Doukyuusei Special (Japan) (Disc 1) (Genteiban)"
+	rom ( name "Mahjong Doukyuusei Special (Japan) (Disc 1) (Genteiban) (Track 01).bin" size 74055072 crc 13363434 md5 a0ca0f4a6a996069648f7ed821d60948 sha1 241a1244bf625bf9e6551938cb1117c3486d85d5 )
+)
+
+game (
+	name "Virtual Volleyball (Japan)"
+	description "Virtual Volleyball (Japan)"
+	rom ( name "Virtual Volleyball (Japan) (Track 01).bin" size 29298864 crc ebcfd4df md5 c8b3ab80f6ac01aa834bab232e2b8e74 sha1 3ab54b4010f41a1f1a00ffe736049b52d673234b )
+)
+
+game (
+	name "Street Fighter Zero 3 (Japan)"
+	description "Street Fighter Zero 3 (Japan)"
+	rom ( name "Street Fighter Zero 3 (Japan) (Track 1).bin" size 621937008 crc e10dc642 md5 e9088a83e44b0ed2500597328a1eb391 sha1 b1cc45650b526ed88a82efcd315ee73e89a658d1 )
+)
+
+game (
+	name "Bio Hazard (Japan)"
+	description "Bio Hazard (Japan)"
+	rom ( name "Bio Hazard (Japan) (Track 1).bin" size 592179504 crc f86350c7 md5 2be37eec06826af04e74cd16aafb646e sha1 0e6910ce695e263cdd7e7354690bfe67afc18315 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (4M, 5M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (4M, 5M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (4M, 5M) (Track 1).bin" size 654709776 crc 23c25c87 md5 770ebda210ecf6299b97d5f4b9731617 sha1 2b3d50b0da785e9a4bca7175de99dd69d3511c50 )
+)
+
+game (
+	name "Dead or Alive (Japan) (2M)"
+	description "Dead or Alive (Japan) (2M)"
+	rom ( name "Dead or Alive (Japan) (2M) (Track 01).bin" size 111527136 crc b876ae12 md5 70652f7f3eb790a01f23929d63343c9e sha1 e59e46aca45cf56bcdc35ef031121860d8c861a5 )
+)
+
+game (
+	name "Marvel Super Heroes vs. Street Fighter (Japan)"
+	description "Marvel Super Heroes vs. Street Fighter (Japan)"
+	rom ( name "Marvel Super Heroes vs. Street Fighter (Japan) (Track 01).bin" size 452397792 crc d43ccea7 md5 c3a959c587efa936c6f7d3e8fb77d1c5 sha1 e23c88b1c181ac66dc05f65527b8bc6e3ecce39e )
+)
+
+game (
+	name "Virtua Fighter (Japan)"
+	description "Virtua Fighter (Japan)"
+	rom ( name "Virtua Fighter (Japan) (Track 01).bin" size 9633792 crc 2898a607 md5 20b291f129763c789d7afec3e6c910fa sha1 c6d3151e4958c0162c84f8f493bcf9f03134b285 )
+)
+
+game (
+	name "Vampire Savior (Japan)"
+	description "Vampire Savior (Japan)"
+	rom ( name "Vampire Savior (Japan) (Track 01).bin" size 234393264 crc 5b3be220 md5 3fe84905f90abe7c079f0376b6dab73e sha1 02cab915f4036051a5575db178f194d5dfb7b509 )
+)
+
+game (
+	name "Panzer Dragoon (Japan) (5A)"
+	description "Panzer Dragoon (Japan) (5A)"
+	rom ( name "Panzer Dragoon (Japan) (5A) (Track 01).bin" size 256278624 crc bdc4cff8 md5 b4b35400bb956837fa3301cd4faf68dc sha1 62704a420aad185e27df23c8df924cdde7b17f14 )
+)
+
+game (
+	name "Panzer Dragoon II Zwei (Japan)"
+	description "Panzer Dragoon II Zwei (Japan)"
+	rom ( name "Panzer Dragoon II Zwei (Japan) (Track 1).bin" size 428906016 crc 4e901617 md5 ce06c819d8f3575b315ae041838c8a03 sha1 efe2ca536ca63a3877ffaa0b909aace282ec0a9c )
+)
+
+game (
+	name "Airs Adventure (Japan)"
+	description "Airs Adventure (Japan)"
+	rom ( name "Airs Adventure (Japan) (Track 1).bin" size 531636672 crc 1791e04f md5 11ce71a979c4901448b87279d814e26b sha1 1f7550167576646fb14230365bc5b22215200d9d )
+)
+
+game (
+	name "Amok (USA)"
+	description "Amok (USA)"
+	rom ( name "Amok (USA) (Track 1).bin" size 37227456 crc ec3bfc10 md5 4c2b33726a51287dfbca1931f3f95010 sha1 bfc53f49c4cdc671a08e0c343310763dd4be25b0 )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! (Japan)"
+	description "J. League Pro Soccer Club o Tsukurou! (Japan)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! (Japan) (Track 1).bin" size 380038512 crc 5723d999 md5 65b6d049744546e92826e5d24d232784 sha1 107f2d1ae86c8717699df06c0c02180ca29d1f67 )
+)
+
+game (
+	name "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 1)"
+	description "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 1)"
+	rom ( name "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 1) (Track 1).bin" size 652809360 crc 5e1c5e85 md5 585a154f9d2025f16d4690a587b9be8c sha1 e104b54642a487b4c56e0d3807027f4b00f4c242 )
+)
+
+game (
+	name "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 2)"
+	description "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 2)"
+	rom ( name "Tengai Makyou - Daiyon no Mokushiroku - The Apocalypse IV (Japan) (Disc 2) (Track 1).bin" size 661876320 crc 5fa831aa md5 f96da06e0d47ccf71a967fd5384779ac sha1 d57bb8dcc0f5799849973dd83920caac622de914 )
+)
+
+game (
+	name "Alone in the Dark - One-Eyed Jack's Revenge (USA)"
+	description "Alone in the Dark - One-Eyed Jack's Revenge (USA)"
+	rom ( name "Alone in the Dark - One-Eyed Jack's Revenge (USA) (Track 1).bin" size 173156592 crc 3673b863 md5 f88fab5f12b9447aff8e4aad4371139d sha1 71facfbf4cb7a639ab0f058c925bf3ae4049a54f )
+)
+
+game (
+	name "Virtua Fighter 2 (Europe) (Rev A) (Made in EU)"
+	description "Virtua Fighter 2 (Europe) (Rev A) (Made in EU)"
+	rom ( name "Virtua Fighter 2 (Europe) (Rev A) (Made in EU) (Track 01).bin" size 61321344 crc 4287ef99 md5 d3b932e85a84438410417d990e7d895d sha1 9be7b1d5edc9b765345bbd7c5cf0cb2b60f60da4 )
+)
+
+game (
+	name "Dragon Force (Japan) (4M)"
+	description "Dragon Force (Japan) (4M)"
+	rom ( name "Dragon Force (Japan) (4M) (Track 1).bin" size 565164432 crc b3a7fc63 md5 750cddb0426ae85f192544d924f343cc sha1 5696a5981bde34b8465854a30fa049890b5a28ad )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu '95 - Kaimakuban (Japan) (2M)"
+	description "Jikkyou Powerful Pro Yakyuu '95 - Kaimakuban (Japan) (2M)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu '95 - Kaimakuban (Japan) (2M) (Track 1).bin" size 132241200 crc 042bb32f md5 52f9c4ed6233a14632fe325b9a1855eb sha1 aafabdc693808cc20b43a79c711c2e10e2c6d018 )
+)
+
+game (
+	name "Virtua Cop 2 (Europe)"
+	description "Virtua Cop 2 (Europe)"
+	rom ( name "Virtua Cop 2 (Europe) (Track 01).bin" size 37693152 crc 837e11d3 md5 385bda47fabfb318fe4a3292bd4eb894 sha1 8c42452328d4351b107b4c29472c155abe931b34 )
+)
+
+game (
+	name "Rayman (Europe) (En,Fr,De) (6S)"
+	description "Rayman (Europe) (En,Fr,De) (6S)"
+	rom ( name "Rayman (Europe) (En,Fr,De) (6S) (Track 01).bin" size 152482512 crc 07997b9c md5 88bb0bfd24405d149c621fc8def64775 sha1 c92d74d4b41565804c22fcbb2b4dd8a654e82b9f )
+)
+
+game (
+	name "Bust-A-Move 3 (Europe)"
+	description "Bust-A-Move 3 (Europe)"
+	rom ( name "Bust-A-Move 3 (Europe) (Track 01).bin" size 30975840 crc 7916710d md5 ab2b12a16026adbafb2cec1b2a8615f8 sha1 5c7303aeaeacbf30e87f26f3f28c63a3e89713fb )
+)
+
+game (
+	name "Soviet Strike (Europe)"
+	description "Soviet Strike (Europe)"
+	rom ( name "Soviet Strike (Europe) (Track 1).bin" size 661563504 crc eacdbc12 md5 01675a6c0d838358301289ffdca4873d sha1 456e3d73f4c95ed774bd0b4da8083d03f4ef8ea8 )
+)
+
+game (
+	name "Pocket Fighter (Japan)"
+	description "Pocket Fighter (Japan)"
+	rom ( name "Pocket Fighter (Japan) (Track 01).bin" size 77674800 crc 2a33f282 md5 5af6a375398fbc76eb88c24e929f0ea3 sha1 92ed2f6d205f4fdfe6b3da2935d1a3b5cf7b5ce2 )
+)
+
+game (
+	name "Dragon Ball Z - Shinbutouden (Japan)"
+	description "Dragon Ball Z - Shinbutouden (Japan)"
+	rom ( name "Dragon Ball Z - Shinbutouden (Japan) (Track 01).bin" size 103563264 crc 7e17f841 md5 7a284435b203bb69eb2caa78487ebc64 sha1 b1ea2876623ee1dc2e9d02ca3e19780534bb179e )
+)
+
+game (
+	name "Scorcher (Europe)"
+	description "Scorcher (Europe)"
+	rom ( name "Scorcher (Europe) (Track 1).bin" size 20100192 crc 21a2bb43 md5 86f409dbe96846e0f50ed4002f3b3a4c sha1 b859cf46c975feacfe2649ddb9e3dd960141c103 )
+)
+
+game (
+	name "Sega Rally Championship (Europe) (Made in EU)"
+	description "Sega Rally Championship (Europe) (Made in EU)"
+	rom ( name "Sega Rally Championship (Europe) (Made in EU) (Track 01).bin" size 29712816 crc 667e14f4 md5 51e34ce14cff940f2c0f370733a8b4e8 sha1 b60f19c3f691f7b03f7e7364b946085ca010954d )
+)
+
+game (
+	name "Story of Thor 2, The (Europe)"
+	description "Story of Thor 2, The (Europe)"
+	rom ( name "Story of Thor 2, The (Europe) (Track 1).bin" size 81995424 crc fa572cf3 md5 4d23bbc603d24bd865d7f94265e3fa33 sha1 1f8d1169799f88ba64d112a2ac303c788c3bc13f )
+)
+
+game (
+	name "Sonic R (Europe)"
+	description "Sonic R (Europe)"
+	rom ( name "Sonic R (Europe) (Track 01).bin" size 16188816 crc b4cda5e0 md5 32848ccebe2dadd3f63467bcc7939cc5 sha1 7c5a015623ea11b63a19323a20ec2f61a462a328 )
+)
+
+game (
+	name "Riglordsaga (Japan) (Made in USA) (4S)"
+	description "Riglordsaga (Japan) (Made in USA) (4S)"
+	rom ( name "Riglordsaga (Japan) (Made in USA) (4S) (Track 1).bin" size 177406656 crc 9a5e51fb md5 4270c76f0492f0fc1cfec2254724f597 sha1 17e65814e5a8d8843b58c8a1191fea9109df1731 )
+)
+
+game (
+	name "Touge King the Spirits (Japan)"
+	description "Touge King the Spirits (Japan)"
+	rom ( name "Touge King the Spirits (Japan) (Track 1).bin" size 26109552 crc f12223bc md5 f536b29fe574ad2e07b8169063d8d22b sha1 03e5e9356c0ee9d5ae1bab8c57a1e1bfc0c63938 )
+)
+
+game (
+	name "Guardian Heroes (Europe)"
+	description "Guardian Heroes (Europe)"
+	rom ( name "Guardian Heroes (Europe) (Track 01).bin" size 77463120 crc e9a209c5 md5 7274e460e773877a78e68dfbdbd6853f sha1 5a31ca3c495f117af6b614e73438f8a70fc52ee6 )
+)
+
+game (
+	name "Dark Savior (Europe)"
+	description "Dark Savior (Europe)"
+	rom ( name "Dark Savior (Europe) (Track 1).bin" size 113646288 crc ba43f47e md5 d69798707ae11506617deff847493207 sha1 f620789ddec4023d24cf6f4f63072d847ab1e87b )
+)
+
+game (
+	name "Resident Evil (Europe)"
+	description "Resident Evil (Europe)"
+	rom ( name "Resident Evil (Europe) (Track 1).bin" size 585274032 crc 195dba98 md5 2bd6c275274f596e3c8a0ff650e11b8c sha1 886c0c470359e8070a92493db1c85ba0b36b3a24 )
+)
+
+game (
+	name "Shining the Holy Ark (Europe)"
+	description "Shining the Holy Ark (Europe)"
+	rom ( name "Shining the Holy Ark (Europe) (Track 1).bin" size 257659248 crc b0ab7156 md5 72b0faea7711d579c43a69af0b67455a sha1 852233b6f94f428ec2dcc215f9c01511c37121bc )
+)
+
+game (
+	name "Ronde (Japan) (Disc 1)"
+	description "Ronde (Japan) (Disc 1)"
+	rom ( name "Ronde (Japan) (Disc 1) (Track 1).bin" size 605823456 crc 2b59990f md5 543ddea9e418f823fcf24b3fbfd1632f sha1 ad2ba8ff938cba9c3e28cd238b9f1d6edc17acdf )
+)
+
+game (
+	name "Ronde (Japan) (Disc 2)"
+	description "Ronde (Japan) (Disc 2)"
+	rom ( name "Ronde (Japan) (Disc 2) (Track 1).bin" size 586139568 crc 7a2bee9d md5 060ac04fb57a2807f12a9b0c7c9debd9 sha1 3a374c96a810b30f748aa25b927cdb02b807aaf2 )
+)
+
+game (
+	name "Alien Trilogy (USA)"
+	description "Alien Trilogy (USA)"
+	rom ( name "Alien Trilogy (USA) (Track 01).bin" size 126772800 crc 7a7f7037 md5 48e6ddbdf81f63d1591ab033f62525c7 sha1 afd0d1c7e122b8d4d90732dde580507d3d65c750 )
+)
+
+game (
+	name "Virtua Cop (Europe) (4S)"
+	description "Virtua Cop (Europe) (4S)"
+	rom ( name "Virtua Cop (Europe) (4S) (Track 01).bin" size 50655024 crc e88845db md5 78b0ab0e1687e3618340546af1b0336c sha1 0c3d977136dd3fb33ccca4fb38d275b8fa8a3597 )
+)
+
+game (
+	name "Whizz (Europe)"
+	description "Whizz (Europe)"
+	rom ( name "Whizz (Europe) (Track 1).bin" size 67961040 crc 03d89363 md5 6662d1f05887dbc63d883586e8186c4a sha1 e97e34c2da2a95573b7b2ce4edbb1d87e9a4ee2e )
+)
+
+game (
+	name "Manx TT SuperBike (Europe)"
+	description "Manx TT SuperBike (Europe)"
+	rom ( name "Manx TT SuperBike (Europe) (Track 01).bin" size 91944384 crc cf68669a md5 9650375b94f6edfbb2d6664478374c41 sha1 543644d3932ff238a261b90272e04f96ae74930d )
+)
+
+game (
+	name "Krazy Ivan (Germany)"
+	description "Krazy Ivan (Germany)"
+	rom ( name "Krazy Ivan (Germany) (Track 01).bin" size 330865248 crc 0b164d76 md5 69032b111ae82857e257e36c913b70bc sha1 22fc3ae78edd717d25b5b4501d15791a503a010f )
+)
+
+game (
+	name "Myst (Europe) (En,Fr,De,Es)"
+	description "Myst (Europe) (En,Fr,De,Es)"
+	rom ( name "Myst (Europe) (En,Fr,De,Es) (Track 1).bin" size 631775424 crc 0e967e64 md5 98b2f7332cdfb18c4d2232b9c78dd127 sha1 970db0ca8c67186dc19d22052e5c37ca43380449 )
+)
+
+game (
+	name "WipEout (Europe)"
+	description "WipEout (Europe)"
+	rom ( name "WipEout (Europe) (Track 01).bin" size 54881568 crc 75855e55 md5 866b41246a47ae0430bfc3004c795761 sha1 18b4268eac8766bfef48104f98f1c480ff87fd84 )
+)
+
+game (
+	name "Mystaria - The Realms of Lore (Europe)"
+	description "Mystaria - The Realms of Lore (Europe)"
+	rom ( name "Mystaria - The Realms of Lore (Europe) (Track 1).bin" size 177606576 crc 692fc1c4 md5 04b3c4a3acd64bcaf6be4d5ba43c8a74 sha1 e76e3a63a43d3b379a5c51999f6704f715c9ec65 )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev A)"
+	description "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev A)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev A) (Track 1).bin" size 380040864 crc 6e04011e md5 588b17f695a2170fe213fd5422eab8f8 sha1 cd38ede50c9984c8cf9252b133f77b0217089160 )
+)
+
+game (
+	name "Metal Slug - Super Vehicle-001 (Japan)"
+	description "Metal Slug - Super Vehicle-001 (Japan)"
+	rom ( name "Metal Slug - Super Vehicle-001 (Japan) (Track 01).bin" size 69026496 crc 7ede503d md5 c824837621e6a67a5cbed778dff7cf3d sha1 f9a228fee1b94aa8073dc6fe19cb48a1e63e7389 )
+)
+
+game (
+	name "Virtua Racing (USA) (12S)"
+	description "Virtua Racing (USA) (12S)"
+	rom ( name "Virtua Racing (USA) (12S) (Track 01).bin" size 148258320 crc 90547920 md5 3879222252c6cd12c5311ef9e05ec9e3 sha1 c7dc2f7faede1ffd3c2270652c8d12229281b05d )
+)
+
+game (
+	name "Daytona USA (Japan)"
+	description "Daytona USA (Japan)"
+	rom ( name "Daytona USA (Japan) (Track 01).bin" size 10061856 crc 363ab933 md5 e3a1e5bfc17a3b06f1a23fec5150664b sha1 9f4bb81ee580c7e3fdf4bdb5b4ca9fa36b302bc5 )
+)
+
+game (
+	name "Virtua Cop (Japan) (2M)"
+	description "Virtua Cop (Japan) (2M)"
+	rom ( name "Virtua Cop (Japan) (2M) (Track 01).bin" size 50819664 crc 8d4fbd4f md5 c9aaf15873d7773ddb5102f284725029 sha1 7c0be204392480a54ededcd86908b434c29d25ab )
+)
+
+game (
+	name "Sega Rally Championship (Japan)"
+	description "Sega Rally Championship (Japan)"
+	rom ( name "Sega Rally Championship (Japan) (Track 01).bin" size 29731632 crc 8adde82a md5 6d3907259dca7074222ba7f632287cd2 sha1 26ccc214dbfc8612532861a5078c4038443e3e33 )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 1) (8M)"
+	description "Sakura Taisen (Japan) (Disc 1) (8M)"
+	rom ( name "Sakura Taisen (Japan) (Disc 1) (8M) (Track 1).bin" size 635917296 crc edda732e md5 69b12554031b7e3b22ae37aaf03d3c3d sha1 76f3b13c6dc7429b1df475c68edfd9dc37feca27 )
+)
+
+game (
+	name "Dragon Force (Japan) (2M, 3M)"
+	description "Dragon Force (Japan) (2M, 3M)"
+	rom ( name "Dragon Force (Japan) (2M, 3M) (Track 1).bin" size 565164432 crc b3a7fc63 md5 750cddb0426ae85f192544d924f343cc sha1 5696a5981bde34b8465854a30fa049890b5a28ad )
+)
+
+game (
+	name "Thor - Seireioukiden (Japan)"
+	description "Thor - Seireioukiden (Japan)"
+	rom ( name "Thor - Seireioukiden (Japan) (Track 1).bin" size 96982368 crc d3c19d1b md5 57621a6ca529c79f2d1edcadd9b858e0 sha1 f2a1ce57158c0040270614f7917e6d2a3281f873 )
+)
+
+game (
+	name "Shining Wisdom (Japan) (Rev A)"
+	description "Shining Wisdom (Japan) (Rev A)"
+	rom ( name "Shining Wisdom (Japan) (Rev A) (Track 1).bin" size 93303840 crc e34360bd md5 76879bc7defb88b54a7b7dc252d58947 sha1 3a38723fd2ece5e6a782f20f8e0520cef60bf84e )
+)
+
+game (
+	name "Shin Shinobi Den (Japan)"
+	description "Shin Shinobi Den (Japan)"
+	rom ( name "Shin Shinobi Den (Japan) (Track 1).bin" size 442145424 crc c94adfb1 md5 ebfe0e3d04fba72b67e4e03282c9439e sha1 0e12fc0ce1cc3b4a40409d4e9d7404db5f488237 )
+)
+
+game (
+	name "Baku Baku Animal - Sekai Shiiku Gakari Senshuken (Japan) (Rev A)"
+	description "Baku Baku Animal - Sekai Shiiku Gakari Senshuken (Japan) (Rev A)"
+	rom ( name "Baku Baku Animal - Sekai Shiiku Gakari Senshuken (Japan) (Rev A) (Track 01).bin" size 177733584 crc c07a00bd md5 907f8d194d240623265c8e20492045ce sha1 069621578aad86b45f17ad74790ba3ae2a223549 )
+)
+
+game (
+	name "Linkle Liver Story (Japan)"
+	description "Linkle Liver Story (Japan)"
+	rom ( name "Linkle Liver Story (Japan) (Track 1).bin" size 90709584 crc 4bd10720 md5 f396d1aa11425c04f4df1e01233dbce9 sha1 027d53152475029182e182ca7c1df3b97ac7c0e2 )
+)
+
+game (
+	name "Golden Axe - The Duel (Japan) (2M)"
+	description "Golden Axe - The Duel (Japan) (2M)"
+	rom ( name "Golden Axe - The Duel (Japan) (2M) (Track 01).bin" size 22800288 crc d134b41a md5 34ced0ccfc8a6a8f14d2847c80f32f52 sha1 fa186678a4c3036f198392a6840e9dfe575773fe )
+)
+
+game (
+	name "Magic Knight Rayearth (Japan) (Genteiban) (1M)"
+	description "Magic Knight Rayearth (Japan) (Genteiban) (1M)"
+	rom ( name "Magic Knight Rayearth (Japan) (Genteiban) (1M) (Track 1).bin" size 579483408 crc dfe67900 md5 ef37213ca996f3d13c89276f8b61273f sha1 4942c306ac5ab8278c42dd587e34a1b66faccca1 )
+)
+
+game (
+	name "Panzer Dragoon (Japan) (3A, 3B)"
+	description "Panzer Dragoon (Japan) (3A, 3B)"
+	rom ( name "Panzer Dragoon (Japan) (3A, 3B) (Track 01).bin" size 256278624 crc bdc4cff8 md5 b4b35400bb956837fa3301cd4faf68dc sha1 62704a420aad185e27df23c8df924cdde7b17f14 )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (1M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (1M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (1M) (Track 1).bin" size 645414672 crc 708828ee md5 5d27593babac69e7ca03bd87c909db4f sha1 24cd238de0fb417680eee7855f83d04663309740 )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 2) (2M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 2) (2M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 2) (2M) (Track 1).bin" size 559267968 crc da1f95ac md5 e9d9f69fe1aed234b1d042f059866022 sha1 e442c82158484460660f99f5ef5776402163fd08 )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (1M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (1M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (1M) (Track 1).bin" size 632161152 crc 353c3a39 md5 f1e5658315ddd11c7d11783443aea918 sha1 538555faa5c358af8d588eae41eb37bb20f965c6 )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 4) (2M, 3M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 4) (2M, 3M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 4) (2M, 3M) (Track 1).bin" size 582493968 crc ae25113e md5 955fff0b1b00a24e8c7e2713e8aab90e sha1 d039b53491dceac55a7133baf1deea2f6a3f3e37 )
+)
+
+game (
+	name "DecAthlete (Japan) (2M)"
+	description "DecAthlete (Japan) (2M)"
+	rom ( name "DecAthlete (Japan) (2M) (Track 01).bin" size 33628896 crc 422cfec1 md5 07b25ac43b9584c4d63a35b9fa9c4770 sha1 36be9c20a017d1415b3d0ebeeda71cd95a8412cb )
+)
+
+game (
+	name "Guardian Heroes (Japan) (3M)"
+	description "Guardian Heroes (Japan) (3M)"
+	rom ( name "Guardian Heroes (Japan) (3M) (Track 01).bin" size 77488992 crc b39d9b9d md5 6036cb1cd4e057ece807bb0490d1fb7c sha1 8e1b86f9793c13e9460e6a66f3928b8f63becedf )
+)
+
+game (
+	name "Kisuishou Densetsu Astal (Japan) (4M)"
+	description "Kisuishou Densetsu Astal (Japan) (4M)"
+	rom ( name "Kisuishou Densetsu Astal (Japan) (4M) (Track 1).bin" size 605957520 crc 5888089a md5 9d4a3d16ff7e4ee7d6344eb5229f782a sha1 23fbf6a661481fdaa6d20bb002bfc671fb365324 )
+)
+
+game (
+	name "Slayers Royal 2 (Japan) (1M, 2M)"
+	description "Slayers Royal 2 (Japan) (1M, 2M)"
+	rom ( name "Slayers Royal 2 (Japan) (1M, 2M) (Track 1).bin" size 289248960 crc 9c892eeb md5 9c11b07136bbe75518f70f9904407f93 sha1 ede48c3e553ee96719bf89eb0b1c6ba7b714f2a8 )
+)
+
+game (
+	name "Super Robot Taisen F Kanketsuhen (Japan) (Rev A) (10M)"
+	description "Super Robot Taisen F Kanketsuhen (Japan) (Rev A) (10M)"
+	rom ( name "Super Robot Taisen F Kanketsuhen (Japan) (Rev A) (10M) (Track 1).bin" size 180607728 crc fce88b19 md5 566ca38a913dce482535465a43e0d292 sha1 d2c4d5f02745d2bf94a3409820747d69d07cf2df )
+)
+
+game (
+	name "Virtua Fighter CG Portrait Series Vol. 4 - Pai Chan (Japan) (2M)"
+	description "Virtua Fighter CG Portrait Series Vol. 4 - Pai Chan (Japan) (2M)"
+	rom ( name "Virtua Fighter CG Portrait Series Vol. 4 - Pai Chan (Japan) (2M) (Track 1).bin" size 1843968 crc c6214334 md5 9af70d1668576f9026ddcd6dbc31d17d sha1 352cf5a19fb325f7d9f9efb11223a5d756da6e0d )
+)
+
+game (
+	name "Super Robot Taisen F (Japan) (Rev A) (10M, 11M, 12M, 13M)"
+	description "Super Robot Taisen F (Japan) (Rev A) (10M, 11M, 12M, 13M)"
+	rom ( name "Super Robot Taisen F (Japan) (Rev A) (10M, 11M, 12M, 13M) (Track 1).bin" size 237756624 crc 3c74bb5b md5 4121dd2449d0abaa5c0540a2d9fc7a86 sha1 ee4b8a15c0c890678e56ea1eee33abd8853a0f15 )
+)
+
+game (
+	name "King of Boxing, The (Japan)"
+	description "King of Boxing, The (Japan)"
+	rom ( name "King of Boxing, The (Japan) (Track 1).bin" size 22572144 crc 99ad53da md5 30a90033fcba05d0a284a0f2fe6076d2 sha1 e55346c7d77cf74b33b1b2d50f5f693d35a51bd2 )
+)
+
+game (
+	name "Ou-chan no Oekaki Logic (Japan)"
+	description "Ou-chan no Oekaki Logic (Japan)"
+	rom ( name "Ou-chan no Oekaki Logic (Japan) (Track 01).bin" size 4870992 crc 4647c1bd md5 97cc34e55891dfd6d2949115d4128529 sha1 7a17dc4607ee1ab2a2f3a607ba28601a0058a46c )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '97 (Japan) (Rev A)"
+	description "Pro Yakyuu Greatest Nine '97 (Japan) (Rev A)"
+	rom ( name "Pro Yakyuu Greatest Nine '97 (Japan) (Rev A) (Track 1).bin" size 351369984 crc 1e9e2d4e md5 5cb3d7720d6159796aa29e13698f3c0a sha1 5eebe2ee52701a77a8016836472f0856c975ddb1 )
+)
+
+game (
+	name "Digital Dance Mix Vol. 1 - Namie Amuro (Japan) (Rev A) (11M)"
+	description "Digital Dance Mix Vol. 1 - Namie Amuro (Japan) (Rev A) (11M)"
+	rom ( name "Digital Dance Mix Vol. 1 - Namie Amuro (Japan) (Rev A) (11M) (Track 1).bin" size 64618848 crc 3ee761e6 md5 80623a3431ba4353ee2774a251877ae5 sha1 0197ff938a5682b9687c2a9063aee18eabc28a38 )
+)
+
+game (
+	name "Sakura Taisen - Hanagumi Tsuushin (Japan) (2M)"
+	description "Sakura Taisen - Hanagumi Tsuushin (Japan) (2M)"
+	rom ( name "Sakura Taisen - Hanagumi Tsuushin (Japan) (2M) (Track 1).bin" size 163762704 crc a88ca457 md5 37ca482d65f46fa560a26a8d3a6b1380 sha1 c205cd8b74cbf4d608620b1dbc58718b8bfbf6f0 )
+)
+
+game (
+	name "Game-Ware Vol. 3 (Japan)"
+	description "Game-Ware Vol. 3 (Japan)"
+	rom ( name "Game-Ware Vol. 3 (Japan) (Track 1).bin" size 509504352 crc 99fd3710 md5 81ee9fd563a55a4609933fb6a01c08c1 sha1 48de5c5e453f009ca6455ffab57590ecf81ad96c )
+)
+
+game (
+	name "Gungriffon - The Eurasian Conflict (Japan)"
+	description "Gungriffon - The Eurasian Conflict (Japan)"
+	rom ( name "Gungriffon - The Eurasian Conflict (Japan) (Track 01).bin" size 82044816 crc 3821351c md5 d6174a8086f9477d3bb717a69d89389a sha1 e7e9fc5963d5a8f73374b85c849f99941d23942a )
+)
+
+game (
+	name "Tokimeki Memorial Selection - Fujisaki Shiori (Japan)"
+	description "Tokimeki Memorial Selection - Fujisaki Shiori (Japan)"
+	rom ( name "Tokimeki Memorial Selection - Fujisaki Shiori (Japan) (Track 1).bin" size 113319360 crc afa3f3f9 md5 564cf18eb9f218169ff75855916fc74a sha1 a4454640e51f3862f022da970bd253970c63d75e )
+)
+
+game (
+	name "Slayers Royal (Japan)"
+	description "Slayers Royal (Japan)"
+	rom ( name "Slayers Royal (Japan) (Track 1).bin" size 445501728 crc 527b45a8 md5 ceb17e5177ae845edbceb9e01c692085 sha1 accee0e0b8b82562fcc61ce881e79ff6e5ede1e2 )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (1M)"
+	description "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (1M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (1M) (Track 1).bin" size 151454688 crc 68ac9a0d md5 9947140b8b6385df81aacb7f010085ec sha1 c929b7f32b35996f38ef24b4a38c10fff9fbe454 )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (4M)"
+	description "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (4M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (4M) (Track 1).bin" size 508271904 crc b3004699 md5 a744abc5f85a0087e876feeb547e933b sha1 6ae4e9a85fd7a5d174d13d9b2dd0a2c336434b4f )
+)
+
+game (
+	name "Shin Seiki Evangelion (Japan)"
+	description "Shin Seiki Evangelion (Japan)"
+	rom ( name "Shin Seiki Evangelion (Japan) (Track 1).bin" size 11117904 crc 5eb58f85 md5 23e76aa2a3df5c90c504196bbacc0346 sha1 1c641695d07afc09cf13041f6af0ad1769a3cc05 )
+)
+
+game (
+	name "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in Japan)"
+	description "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in Japan)"
+	rom ( name "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in Japan) (Track 1).bin" size 81052272 crc 6f800b25 md5 0fe3ac1bc9f62ff8501376f6e8ece82f sha1 0ab577e80805f69525ab423a1840e662a2605cf5 )
+)
+
+game (
+	name "Casper (Europe) (En,Fr,De)"
+	description "Casper (Europe) (En,Fr,De)"
+	rom ( name "Casper (Europe) (En,Fr,De) (Track 1).bin" size 421429008 crc 65392b18 md5 c59ee39f463b5a4ebbb2d89b5dea4b5c sha1 ac16c237a99a925d970416e4c4f57d61ba043c8d )
+)
+
+game (
+	name "Choro Q Park (Japan)"
+	description "Choro Q Park (Japan)"
+	rom ( name "Choro Q Park (Japan) (Track 01).bin" size 51214800 crc a765a5b8 md5 f6f48c1ba8391fca7aee23897e2b2a3d sha1 e373ba44c979d868426452ff613ad31aa9d9700b )
+)
+
+game (
+	name "Kouryuu Sangoku Engi (Japan)"
+	description "Kouryuu Sangoku Engi (Japan)"
+	rom ( name "Kouryuu Sangoku Engi (Japan) (Track 1).bin" size 58369584 crc 1d8a7046 md5 b4836e477c43c3c85b5c4ef84cef7e50 sha1 2f733595ea910873102ed68b50070b77fadd8833 )
+)
+
+game (
+	name "Sotsugyou Crossworld (Japan)"
+	description "Sotsugyou Crossworld (Japan)"
+	rom ( name "Sotsugyou Crossworld (Japan) (Track 1).bin" size 531888336 crc 78e6c259 md5 7b7444f84b42ae1ddb8e70d7249d9b9a sha1 6e221cedade7497f1818293746c60b18d8a3b0bb )
+)
+
+game (
+	name "Shining Force III (Europe)"
+	description "Shining Force III (Europe)"
+	rom ( name "Shining Force III (Europe) (Track 1).bin" size 245017248 crc dfdb35cb md5 1b5aafeb44c7840571b89fb1bdff5f2c sha1 9d8f601c9938acb39c7a2a5181dbc77e70117a6f )
+)
+
+game (
+	name "Wachenroeder (Japan)"
+	description "Wachenroeder (Japan)"
+	rom ( name "Wachenroeder (Japan) (Track 1).bin" size 445320624 crc f6bb733f md5 8c18fe058a7701a0438aeb52f292f65c sha1 6c900fb5a98e8926a3da7cec171f6bff691ce717 )
+)
+
+game (
+	name "Sega Ages - Space Harrier (Japan) (1M)"
+	description "Sega Ages - Space Harrier (Japan) (1M)"
+	rom ( name "Sega Ages - Space Harrier (Japan) (1M) (Track 01).bin" size 45969840 crc 1c5c2421 md5 b1d5c16318c72e218ca518b29a7fc579 sha1 910d3e63f65bf3cce43ba9f68cb6ccf27556c848 )
+)
+
+game (
+	name "Sonic R (Japan) (1M)"
+	description "Sonic R (Japan) (1M)"
+	rom ( name "Sonic R (Japan) (1M) (Track 01).bin" size 16238208 crc 03310902 md5 71663113415b8c2aa38e36c0c463b6c6 sha1 792b2a8225b2dc5b36e2da0b4164bc798d315f83 )
+)
+
+game (
+	name "Sonic Jam (Japan)"
+	description "Sonic Jam (Japan)"
+	rom ( name "Sonic Jam (Japan) (Track 1).bin" size 631297968 crc 62255ec2 md5 7f1ac13eb6d6d50423efa2a0899cb034 sha1 de51baeacc559d4a0a559d4a7c5a444af1d1fc0a )
+)
+
+game (
+	name "Shining Force III - Scenario 3 - Hyouheki no Jashinguu (Japan)"
+	description "Shining Force III - Scenario 3 - Hyouheki no Jashinguu (Japan)"
+	rom ( name "Shining Force III - Scenario 3 - Hyouheki no Jashinguu (Japan) (Track 1).bin" size 508594128 crc e6f03eab md5 455c90108d57b4570cca42adb221bfbd sha1 6a2646030ff74a98b666726b78003e6505d24285 )
+)
+
+game (
+	name "Shining Force III - Scenario 2 - Nerawareta Miko (Japan) (Rev A)"
+	description "Shining Force III - Scenario 2 - Nerawareta Miko (Japan) (Rev A)"
+	rom ( name "Shining Force III - Scenario 2 - Nerawareta Miko (Japan) (Rev A) (Track 1).bin" size 307093584 crc 4fa9ac0c md5 ecc6a3010c15c05743f707bf028a20d6 sha1 e21f7ad51af3ef57af9f9f7db58afb2dd642e3ad )
+)
+
+game (
+	name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Rev A)"
+	description "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Rev A)"
+	rom ( name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Rev A) (Track 1).bin" size 247717344 crc 72c4aa7e md5 e69383cb9871efbb13b3a6cf988acf55 sha1 4169bfb491046eac26688054c314233656d08c6b )
+)
+
+game (
+	name "Sega Rally Championship Plus (Japan)"
+	description "Sega Rally Championship Plus (Japan)"
+	rom ( name "Sega Rally Championship Plus (Japan) (Track 01).bin" size 32634000 crc efbadf18 md5 bd65bfee16f749ff7ff17f1cafaec42a sha1 cbf8a9cf375d30afda4b0d4133d6ed6fff74973b )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (Rev A) (12M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (Rev A) (12M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (Rev A) (12M) (Track 1).bin" size 654707424 crc 96bc2dbd md5 cb0564da201d351166bb43860c791c55 sha1 a24944a1a4301cfa5465d9447f404eb8e6d72f73 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (Rev A) (10M, 11M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (Rev A) (10M, 11M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (Rev A) (10M, 11M) (Track 1).bin" size 652296624 crc 47363867 md5 1e31f66260e998a6fab085eb1ede1dda sha1 ef79583c48bce0ef9572d962462f9533b62a1f7d )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (Rev A) (10M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (Rev A) (10M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (Rev A) (10M) (Track 1).bin" size 655554144 crc d45c6b0c md5 d874961c379b0b73a3219a16b72ec82b sha1 221bfb1aba070ca52f9f6c8db5a3ce6c0000cd77 )
+)
+
+game (
+	name "Sega Ages - Power Drift (Japan)"
+	description "Sega Ages - Power Drift (Japan)"
+	rom ( name "Sega Ages - Power Drift (Japan) (Track 01).bin" size 10795680 crc acb3a30d md5 8181e48d0fada82c29e68211c715ad7d sha1 873d96d95a1fb144bfa950a3ed7a55aeefdf4660 )
+)
+
+game (
+	name "Sega Ages - Phantasy Star Collection (Japan)"
+	description "Sega Ages - Phantasy Star Collection (Japan)"
+	rom ( name "Sega Ages - Phantasy Star Collection (Japan) (Track 1).bin" size 439522944 crc b20dbb2d md5 b56f80f1a3b543529de6b76a59d31991 sha1 2aa51c772013aa1896b7570e738a832fdd87786f )
+)
+
+game (
+	name "Sega Ages - OutRun (Japan)"
+	description "Sega Ages - OutRun (Japan)"
+	rom ( name "Sega Ages - OutRun (Japan) (Track 1).bin" size 3177552 crc 9666fd27 md5 831d8b811af96eef2efbb62fefa04bab sha1 18616731897d0aff943417c40e2752e7cc7c769b )
+)
+
+game (
+	name "Sega Ages - Memorial Selection Vol. 2 (Japan)"
+	description "Sega Ages - Memorial Selection Vol. 2 (Japan)"
+	rom ( name "Sega Ages - Memorial Selection Vol. 2 (Japan) (Track 1).bin" size 8255520 crc 86899c7a md5 23c08a41850f9591e685db34c0f3fc5e sha1 6751865284967563e5267921cb5399c20f24b8a7 )
+)
+
+game (
+	name "Magical Drop 2 (Japan)"
+	description "Magical Drop 2 (Japan)"
+	rom ( name "Magical Drop 2 (Japan) (Track 01).bin" size 39685296 crc 6c34cae7 md5 3c22621a3a387dc0baa91a0829eb108f sha1 e4b85b5e1bab8e3ffca5d1dd3da8464ec95c2487 )
+)
+
+game (
+	name "Sega Ages - I Love Mickey Mouse - Fushigi no Oshiro Daibouken & I Love Donald Duck - Georgia Ou no Hihou (Japan)"
+	description "Sega Ages - I Love Mickey Mouse - Fushigi no Oshiro Daibouken & I Love Donald Duck - Georgia Ou no Hihou (Japan)"
+	rom ( name "Sega Ages - I Love Mickey Mouse - Fushigi no Oshiro Daibouken & I Love Donald Duck - Georgia Ou no Hihou (Japan) (Track 1).bin" size 128075808 crc ca5ba49e md5 c21093120a607b200d25026f7710763a sha1 2e841158a1d8c5645698571a6a71b76af4ad6ae5 )
+)
+
+game (
+	name "Sakura Taisen - Hanagumi Taisen Columns (Japan)"
+	description "Sakura Taisen - Hanagumi Taisen Columns (Japan)"
+	rom ( name "Sakura Taisen - Hanagumi Taisen Columns (Japan) (Track 1).bin" size 275821392 crc d90fe1a6 md5 c13aed4c6e9e5e26b0d424dc4a19f480 sha1 7182180a8acfd0b5306cde838a1c52d06ee9d278 )
+)
+
+game (
+	name "Sega Ages - Fantasy Zone (Japan)"
+	description "Sega Ages - Fantasy Zone (Japan)"
+	rom ( name "Sega Ages - Fantasy Zone (Japan) (Track 01).bin" size 99327312 crc 3080eca2 md5 03cc3c5c70e745189fe23ca523a1bdc6 sha1 1dfe450bc63edc2938aa7d116cc83491d3480d31 )
+)
+
+game (
+	name "Dynamite Deka (Japan)"
+	description "Dynamite Deka (Japan)"
+	rom ( name "Dynamite Deka (Japan) (Track 01).bin" size 62716080 crc e601766a md5 c591777a008eadfbf4e8fa351f394be0 sha1 2573b625ddc6fc60a1f41a3026ed2f1661388708 )
+)
+
+game (
+	name "Dragon Force II - Kami Sarishi Daichi ni (Japan)"
+	description "Dragon Force II - Kami Sarishi Daichi ni (Japan)"
+	rom ( name "Dragon Force II - Kami Sarishi Daichi ni (Japan) (Track 1).bin" size 607349904 crc 94cebdba md5 3e762d55926b47fff25e97341f44043f sha1 af3d2c364b24e064450147cb0ee31259b94a08f9 )
+)
+
+game (
+	name "Deep Fear (Japan) (Disc 2)"
+	description "Deep Fear (Japan) (Disc 2)"
+	rom ( name "Deep Fear (Japan) (Disc 2) (Track 1).bin" size 613387488 crc abaf1f24 md5 3e75b96d471278051cd818c735fa8d2d sha1 34433b113105c072a23c93f7486a2696d9eb2c43 )
+)
+
+game (
+	name "Deep Fear (Japan) (Disc 1)"
+	description "Deep Fear (Japan) (Disc 1)"
+	rom ( name "Deep Fear (Japan) (Disc 1) (Track 1).bin" size 642850992 crc af4fb155 md5 866f0d5324f7df34a89112d1e1b6c9c2 sha1 2d8a25879b76d2eb4cd0ee2835d761a1283e2d18 )
+)
+
+game (
+	name "Sega Ages - Columns Arcade Collection (Japan)"
+	description "Sega Ages - Columns Arcade Collection (Japan)"
+	rom ( name "Sega Ages - Columns Arcade Collection (Japan) (Track 01).bin" size 21353808 crc 91d47bc0 md5 8333b60315e74f0d88f3263debc3a6fa sha1 889e3afbb9c8a795bde56032c27d23e9ce163d19 )
+)
+
+game (
+	name "Burning Rangers (Japan)"
+	description "Burning Rangers (Japan)"
+	rom ( name "Burning Rangers (Japan) (Track 1).bin" size 386207808 crc 3830e4e1 md5 d19a6646a5430a60fd84d5cedbc2e5ca sha1 18bde4455b8fa6d29704191217d0e288c20e30d5 )
+)
+
+game (
+	name "Doom (Europe)"
+	description "Doom (Europe)"
+	rom ( name "Doom (Europe) (Track 01).bin" size 70317744 crc 3115f4f5 md5 e74e9747f89b8e7d9549eb1babece50b sha1 2718aab1ccbc68f5638b4d92b29a465d9238f80e )
+)
+
+game (
+	name "Puzzle Bobble 2X (Japan) (2M1, 2MB1)"
+	description "Puzzle Bobble 2X (Japan) (2M1, 2MB1)"
+	rom ( name "Puzzle Bobble 2X (Japan) (2M1, 2MB1) (Track 01).bin" size 14309568 crc 3275b83c md5 ed0f20585c7d3a96a36d1410e5888498 sha1 c58ceebc042ebd552c585b05a4bc88d69c6c995e )
+)
+
+game (
+	name "Darius Gaiden (Japan) (3M)"
+	description "Darius Gaiden (Japan) (3M)"
+	rom ( name "Darius Gaiden (Japan) (3M) (Track 01).bin" size 23362416 crc 9df46871 md5 8ed009c1eac1d9b53441af6adc2513fd sha1 22910f1b417c5616fe9b9c489c36317754d18147 )
+)
+
+game (
+	name "Cleopatra Fortune (Japan)"
+	description "Cleopatra Fortune (Japan)"
+	rom ( name "Cleopatra Fortune (Japan) (Track 01).bin" size 18672528 crc 989627c9 md5 5333f1025a13e68a752af7ce1264faef sha1 c1a52053643a491cb85680bbde8ef1fdb5795a39 )
+)
+
+game (
+	name "Layer Section (Japan) (3M)"
+	description "Layer Section (Japan) (3M)"
+	rom ( name "Layer Section (Japan) (3M) (Track 01).bin" size 16779168 crc 07e9d8da md5 4cb2552702a5767be5b791efad43762d sha1 d90ef75e7a8d0ff60fceb58d4e534308b85391ea )
+)
+
+game (
+	name "WarCraft II - The Dark Saga (Europe) (En,Fr,De,Es,It)"
+	description "WarCraft II - The Dark Saga (Europe) (En,Fr,De,Es,It)"
+	rom ( name "WarCraft II - The Dark Saga (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 617084832 crc b16e6ace md5 2bbd6d89d8a486e0500621f5be1ae26c sha1 a2be36b6ba964d3746f63a2a8aaef406f81b979d )
+)
+
+game (
+	name "Tilt! (Europe) (En,Fr,De)"
+	description "Tilt! (Europe) (En,Fr,De)"
+	rom ( name "Tilt! (Europe) (En,Fr,De) (Track 1).bin" size 76367088 crc 699d5615 md5 f0261958b7dbf90d92edc1f5d2b5b66e sha1 cf699613f28f14c24ce112b0a2a00c8c59dd36e9 )
+)
+
+game (
+	name "Robotica - Cybernation Revolt (Europe)"
+	description "Robotica - Cybernation Revolt (Europe)"
+	rom ( name "Robotica - Cybernation Revolt (Europe) (Track 1).bin" size 140837760 crc 7839e62a md5 dd72f25cc51f404f0af2a36d53231588 sha1 8f20015752348165259cc6e2df55cee18160b485 )
+)
+
+game (
+	name "Pandemonium! (Europe)"
+	description "Pandemonium! (Europe)"
+	rom ( name "Pandemonium! (Europe) (Track 1).bin" size 84495600 crc 2906f6de md5 abdbda8d2e57e2e15204dcba129d9f38 sha1 e48c761d1fe51588a4225b821d57ed747dbfd51b )
+)
+
+game (
+	name "Capcom Generation - Dai-1-shuu Gekitsuiou no Jidai (Japan)"
+	description "Capcom Generation - Dai-1-shuu Gekitsuiou no Jidai (Japan)"
+	rom ( name "Capcom Generation - Dai-1-shuu Gekitsuiou no Jidai (Japan) (Track 1).bin" size 538266960 crc a764100e md5 464a8b529a037c59feddd71554875015 sha1 a79b54b3cc9c9245aa86ecfbc248d82c1234c835 )
+)
+
+game (
+	name "Capcom Generation - Dai-2-shuu Makai to Kishi (Japan)"
+	description "Capcom Generation - Dai-2-shuu Makai to Kishi (Japan)"
+	rom ( name "Capcom Generation - Dai-2-shuu Makai to Kishi (Japan) (Track 1).bin" size 400886640 crc 10c8c92f md5 a06fd8c86a9d8f4ee668f17fd6f688d4 sha1 0c004e79175c29109cc613bc33ad0665cd82cf84 )
+)
+
+game (
+	name "Capcom Generation - Dai-3-shuu Koko ni Rekishi Hajimaru (Japan)"
+	description "Capcom Generation - Dai-3-shuu Koko ni Rekishi Hajimaru (Japan)"
+	rom ( name "Capcom Generation - Dai-3-shuu Koko ni Rekishi Hajimaru (Japan) (Track 01).bin" size 38831520 crc f44dd311 md5 405028fa5484d70051fd208e4c210ef0 sha1 fa08f4654512bd498baea440b31f3667335fbcb1 )
+)
+
+game (
+	name "Capcom Generation - Dai-4-shuu Kokou no Eiyuu (Japan)"
+	description "Capcom Generation - Dai-4-shuu Kokou no Eiyuu (Japan)"
+	rom ( name "Capcom Generation - Dai-4-shuu Kokou no Eiyuu (Japan) (Track 01).bin" size 44582160 crc c6e0717a md5 f64a85d928f00e87cb6c6d716b4b1ba2 sha1 140dae85a2b26155004c755dae6bdcd0d3a49fe3 )
+)
+
+game (
+	name "Capcom Generation - Dai-5-shuu Kakutouka-tachi (Japan)"
+	description "Capcom Generation - Dai-5-shuu Kakutouka-tachi (Japan)"
+	rom ( name "Capcom Generation - Dai-5-shuu Kakutouka-tachi (Japan) (Track 1).bin" size 536112528 crc f4c9b8ff md5 0f94159ab402ae26b3560e5bdbde19f3 sha1 e6c2e44ff2f6f01c69b72460f803c32807abef0f )
+)
+
+game (
+	name "Marvel Super Heroes (Japan)"
+	description "Marvel Super Heroes (Japan)"
+	rom ( name "Marvel Super Heroes (Japan) (Track 01).bin" size 39457152 crc 82b5c0de md5 bcc34faaa82b53fbc8df3390e7b786a8 sha1 6c0fbfb13268828cd38c1fb270a7a6a759e5d90b )
+)
+
+game (
+	name "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan)"
+	description "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan)"
+	rom ( name "Quiz Nanairo Dreams - Nijiirochou no Kiseki (Japan) (Track 1).bin" size 651376992 crc 9c510d9d md5 3afaf4b37145c82193d06d811dfe947f sha1 a9a68581fde92db2a8572fc8010a9f8eaf388a0a )
+)
+
+game (
+	name "Rockman X3 (Japan) (2M)"
+	description "Rockman X3 (Japan) (2M)"
+	rom ( name "Rockman X3 (Japan) (2M) (Track 01).bin" size 205106160 crc 8030be91 md5 47ec4d19ce8826ba541d29b4d031bebd sha1 1ef3da9f377899ec9b5edab51c6150ddbe3909b0 )
+)
+
+game (
+	name "Rockman X4 (Japan) (3M)"
+	description "Rockman X4 (Japan) (3M)"
+	rom ( name "Rockman X4 (Japan) (3M) (Track 1).bin" size 536931024 crc e37470f1 md5 8395c4404bf215ed6ffbe1f39bc96547 sha1 c2cf36457262e9b62579c9fab2ffb31f03d86599 )
+)
+
+game (
+	name "Street Fighter Collection (Japan) (Disc 1)"
+	description "Street Fighter Collection (Japan) (Disc 1)"
+	rom ( name "Street Fighter Collection (Japan) (Disc 1) (Track 01).bin" size 45043152 crc 14204b39 md5 04f31941c17f06681ad5a9aec926abbe sha1 91d3839031d4082a005bdb7c3fd0b05deede9740 )
+)
+
+game (
+	name "Street Fighter Collection (Japan) (Disc 2)"
+	description "Street Fighter Collection (Japan) (Disc 2)"
+	rom ( name "Street Fighter Collection (Japan) (Disc 2) (Track 1).bin" size 474668880 crc dd17ee68 md5 823ff944fd3f4046f56f569b1bae62c8 sha1 1973e90df13af0997140df9b92079a6f0b2ada45 )
+)
+
+game (
+	name "Street Fighter Zero (Japan) (2M)"
+	description "Street Fighter Zero (Japan) (2M)"
+	rom ( name "Street Fighter Zero (Japan) (2M) (Track 01).bin" size 26563488 crc df20a652 md5 b76e752b97e63eb0a61b4b3636668b78 sha1 1e20bf94efd71ae50e7a2a0d83325dea2348a5be )
+)
+
+game (
+	name "Super Adventure Rockman (Japan) (Disc 1)"
+	description "Super Adventure Rockman (Japan) (Disc 1)"
+	rom ( name "Super Adventure Rockman (Japan) (Disc 1) (Track 1).bin" size 524651232 crc a6c7fb37 md5 61bcd9fcf7420e65655689af3d4bd827 sha1 46370e0c54d784de71cbcfe52ec665bd20ce7217 )
+)
+
+game (
+	name "Super Adventure Rockman (Japan) (Disc 2)"
+	description "Super Adventure Rockman (Japan) (Disc 2)"
+	rom ( name "Super Adventure Rockman (Japan) (Disc 2) (Track 1).bin" size 581404992 crc 2dfc78e9 md5 220c3c7d4d465058c53324c70da4098a sha1 4e284357bce04e4a3aaab8672b3d5130bb9a6c31 )
+)
+
+game (
+	name "Super Adventure Rockman (Japan) (Disc 3)"
+	description "Super Adventure Rockman (Japan) (Disc 3)"
+	rom ( name "Super Adventure Rockman (Japan) (Disc 3) (Track 1).bin" size 576505776 crc de0404a5 md5 eca47d58aa145a402fb4bff760b4b086 sha1 5dfaf12d139efa9968dc04d37e3fbf216d2a79b7 )
+)
+
+game (
+	name "Super Puzzle Fighter II X (Japan)"
+	description "Super Puzzle Fighter II X (Japan)"
+	rom ( name "Super Puzzle Fighter II X (Japan) (Track 1).bin" size 406376208 crc 66cb5f50 md5 83c28a9fc7a947a9d4d8ec893b47f0ad sha1 dad1a06f3356e11553725d81329a8b679287aafd )
+)
+
+game (
+	name "Tenchi o Kurau II - Sekiheki no Tatakai (Japan) (2M)"
+	description "Tenchi o Kurau II - Sekiheki no Tatakai (Japan) (2M)"
+	rom ( name "Tenchi o Kurau II - Sekiheki no Tatakai (Japan) (2M) (Track 01).bin" size 12573792 crc 171e22f6 md5 a515902432900b9cbf6a90a3d6b2bdc5 sha1 f13307f8c5ccf48bb2098e240c90e7823adf4267 )
+)
+
+game (
+	name "X-Men - Children of the Atom (Japan)"
+	description "X-Men - Children of the Atom (Japan)"
+	rom ( name "X-Men - Children of the Atom (Japan) (Track 01).bin" size 43079232 crc d7f1c067 md5 21994b69f1af4d8ac7c62ed5ee0ad02e sha1 79e6be96b1541fe0ba4a419fd8d4aba0f3a48ed0 )
+)
+
+game (
+	name "Cyberbots - Fullmetal Madness (Japan) (1M)"
+	description "Cyberbots - Fullmetal Madness (Japan) (1M)"
+	rom ( name "Cyberbots - Fullmetal Madness (Japan) (1M) (Track 01).bin" size 103001136 crc 86c3a4b3 md5 161db5cf79a46eed7c6aeb57acedcd8d sha1 699b6be716ba29773b7503f4b815fc9b97cfa848 )
+)
+
+game (
+	name "Dungeons & Dragons Collection (Japan) (Disc 1) (Tower of Doom)"
+	description "Dungeons & Dragons Collection (Japan) (Disc 1) (Tower of Doom)"
+	rom ( name "Dungeons & Dragons Collection (Japan) (Disc 1) (Tower of Doom) (Track 01).bin" size 33445440 crc 710d92d8 md5 3017fbd6c246328f15383badb80645dd sha1 1dc24ad4f442ca14c33edb520089c31c5c7f3640 )
+)
+
+game (
+	name "Dungeons & Dragons Collection (Japan) (Disc 2) (Shadow over Mystara)"
+	description "Dungeons & Dragons Collection (Japan) (Disc 2) (Shadow over Mystara)"
+	rom ( name "Dungeons & Dragons Collection (Japan) (Disc 2) (Shadow over Mystara) (Track 01).bin" size 60135936 crc 00bff107 md5 3ba5b992fc6c061a7d0f9e025e2ee944 sha1 6989ed54bfe0611d1d66d355ab0933e96dafebe9 )
+)
+
+game (
+	name "Virtua Fighter Remix (Japan) (6M)"
+	description "Virtua Fighter Remix (Japan) (6M)"
+	rom ( name "Virtua Fighter Remix (Japan) (6M) (Track 01).bin" size 13533408 crc 874d91ab md5 37c0d347cecff874931962d4fb4c7eff sha1 3d16f1e887d908e75737319467e42d694376f5a7 )
+)
+
+game (
+	name "Vampire Hunter - Darkstalkers' Revenge (Japan) (1M)"
+	description "Vampire Hunter - Darkstalkers' Revenge (Japan) (1M)"
+	rom ( name "Vampire Hunter - Darkstalkers' Revenge (Japan) (1M) (Track 1).bin" size 493741248 crc 94c313ab md5 beef086bf1235c752ef9d2b693a5642c sha1 77390da7878762e3963bb54d8a7c3ba3f86800ed )
+)
+
+game (
+	name "Vampire Hunter - Darkstalkers' Revenge (Japan) (2M)"
+	description "Vampire Hunter - Darkstalkers' Revenge (Japan) (2M)"
+	rom ( name "Vampire Hunter - Darkstalkers' Revenge (Japan) (2M) (Track 1).bin" size 493741248 crc 94c313ab md5 beef086bf1235c752ef9d2b693a5642c sha1 77390da7878762e3963bb54d8a7c3ba3f86800ed )
+)
+
+game (
+	name "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 1) (GDI)"
+	description "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 1) (GDI)"
+	rom ( name "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 1) (GDI) (Track 01).bin" size 384869520 crc ac606970 md5 c1e358beca0b3e9f1f9f3b4deffee23a sha1 4642bec8c02a1375b3e6c4fec60574c0569c1879 )
+)
+
+game (
+	name "Assault Suit Leynos 2 (Japan)"
+	description "Assault Suit Leynos 2 (Japan)"
+	rom ( name "Assault Suit Leynos 2 (Japan) (Track 01).bin" size 109462080 crc fc698d08 md5 6e2806a357258761c6ddbfbab0028dad sha1 8fea17dcf623be8839accebadfe321f277eac08f )
+)
+
+game (
+	name "Thunder Force V (Japan)"
+	description "Thunder Force V (Japan)"
+	rom ( name "Thunder Force V (Japan) (Track 01).bin" size 29555232 crc 11315d0b md5 c3e78dae9fba38be227364b508836a8a sha1 c4ab205bb830816bcdce4de98456f3a35834495d )
+)
+
+game (
+	name "Magical Drop III - Toretate Zoukangou! (Japan) (2M)"
+	description "Magical Drop III - Toretate Zoukangou! (Japan) (2M)"
+	rom ( name "Magical Drop III - Toretate Zoukangou! (Japan) (2M) (Track 01).bin" size 12032832 crc 97d3b2b2 md5 09877a93cce59efc2dc3b70a70ad9097 sha1 e7c297323dcec228ccd5d5accab611f2accc4f09 )
+)
+
+game (
+	name "Samurai Spirits - Amakusa Kourin (Japan) (En,Ja,Es,Pt)"
+	description "Samurai Spirits - Amakusa Kourin (Japan) (En,Ja,Es,Pt)"
+	rom ( name "Samurai Spirits - Amakusa Kourin (Japan) (En,Ja,Es,Pt) (Track 01).bin" size 52190880 crc 4f2f8f3b md5 e4b4ab8cb49d57640b2c33bc663b778c sha1 9f92ce13382aac28cdecd250b4e90f201a820f0d )
+)
+
+game (
+	name "Popoitto Hebereke (Japan)"
+	description "Popoitto Hebereke (Japan)"
+	rom ( name "Popoitto Hebereke (Japan) (Track 01).bin" size 7712208 crc 54c48873 md5 db7729957e68e51495598d515ab69ba2 sha1 f59683027e88105efd3ac9228b08b1bec1efb53c )
+)
+
+game (
+	name "Lupin Sansei - Pyramid no Kenja (Japan)"
+	description "Lupin Sansei - Pyramid no Kenja (Japan)"
+	rom ( name "Lupin Sansei - Pyramid no Kenja (Japan) (Track 1).bin" size 114707040 crc 4bf958ff md5 752bc5920449bf58a5efe4883df18a7a sha1 74922fc02f2c857a1e1847f27004120e5c9d602a )
+)
+
+game (
+	name "Hyper Duel (Japan)"
+	description "Hyper Duel (Japan)"
+	rom ( name "Hyper Duel (Japan) (Track 01).bin" size 18183312 crc 905dc1ba md5 5847a8374c393c24393084364e87e2a7 sha1 ee1377dabf6473aadd32a69d660fa71cef876c5c )
+)
+
+game (
+	name "Shinsetsu Samurai Spirits - Bushidou Retsuden (Japan)"
+	description "Shinsetsu Samurai Spirits - Bushidou Retsuden (Japan)"
+	rom ( name "Shinsetsu Samurai Spirits - Bushidou Retsuden (Japan) (Track 1).bin" size 214135488 crc e05756ef md5 0fa884818a70b7451d13ce7311f92a78 sha1 7c4c82f6e69c73ceaeb7971e7a5823a19b773b2c )
+)
+
+game (
+	name "Game Basic for SegaSaturn (Japan)"
+	description "Game Basic for SegaSaturn (Japan)"
+	rom ( name "Game Basic for SegaSaturn (Japan) (Track 1).bin" size 26471760 crc 08b7e1d2 md5 31c65a0e56f50f812e63395652046107 sha1 b2e666cb0c8befd95e861aed14a5bd1b009a586f )
+)
+
+game (
+	name "Astra Superstars (Japan)"
+	description "Astra Superstars (Japan)"
+	rom ( name "Astra Superstars (Japan) (Track 1).bin" size 602921088 crc e6a86ffd md5 a8ca967f4cae449e8f1e32a65fb2d020 sha1 929b608b3f8a9cf29e31c2e4590f386f1669f247 )
+)
+
+game (
+	name "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 2) (NOD)"
+	description "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 2) (NOD)"
+	rom ( name "Command & Conquer - Teil 1 - Der Tiberiumkonflikt (Germany) (Disc 2) (NOD) (Track 01).bin" size 314808144 crc abeac454 md5 08e42994949042de057ad48f75ecce15 sha1 a4304247db920750a6a3726c8330051e645b0368 )
+)
+
+game (
+	name "Grandia - Digital Museum (Japan)"
+	description "Grandia - Digital Museum (Japan)"
+	rom ( name "Grandia - Digital Museum (Japan) (Track 1).bin" size 455391888 crc c6239c41 md5 0981b16cbd4865c8d64f04ea80fc8a18 sha1 2deb34145dc2af3f01f8db6a53bf5acf0bd3a4a9 )
+)
+
+game (
+	name "Game Tengoku - The Game Paradise! (Japan)"
+	description "Game Tengoku - The Game Paradise! (Japan)"
+	rom ( name "Game Tengoku - The Game Paradise! (Japan) (Track 01).bin" size 167888112 crc d1ea68aa md5 a1de86c70a74da0feaa459f89236281f sha1 f2dd95ad8ea69cc50409e003abcee8142dedac26 )
+)
+
+game (
+	name "Blue Breaker - Ken Yori mo Hohoemi o (Japan)"
+	description "Blue Breaker - Ken Yori mo Hohoemi o (Japan)"
+	rom ( name "Blue Breaker - Ken Yori mo Hohoemi o (Japan) (Track 1).bin" size 663141696 crc aac9a9d0 md5 1928f685d77600c1b54b1a75729ce883 sha1 bf8bb4927921b54f8e887c66d1f2ad5810938f3f )
+)
+
+game (
+	name "Grandia (Japan) (Disc 1) (2M)"
+	description "Grandia (Japan) (Disc 1) (2M)"
+	rom ( name "Grandia (Japan) (Disc 1) (2M) (Track 1).bin" size 618496032 crc 8ff62b58 md5 57e71f8aa1b38824c512a431f6b40de0 sha1 6ac02a31c36eaca966b1dc01657b097e078009d3 )
+)
+
+game (
+	name "Grandia (Japan) (Disc 2) (3M)"
+	description "Grandia (Japan) (Disc 2) (3M)"
+	rom ( name "Grandia (Japan) (Disc 2) (3M) (Track 1).bin" size 585104688 crc af818605 md5 b719951858337593af00b35c835a77c3 sha1 023f0894b5ba9ae1224aeb2e241a5c7b275fde0c )
+)
+
+game (
+	name "Keiou Yuugekitai - Katsugeki-hen (Japan)"
+	description "Keiou Yuugekitai - Katsugeki-hen (Japan)"
+	rom ( name "Keiou Yuugekitai - Katsugeki-hen (Japan) (Track 01).bin" size 165272688 crc 3d724c19 md5 8bdb862c5f741a223f275298c888f72b sha1 7a5210ac18db6d9511a3d5a099502b632cc9d9ad )
+)
+
+game (
+	name "Noon (Japan) (Rev A)"
+	description "Noon (Japan) (Rev A)"
+	rom ( name "Noon (Japan) (Rev A) (Track 01).bin" size 15422064 crc 55b29f3a md5 7cf6c2ee28c4947eac94480c095936da sha1 bc455f659e8b076f2e6811f6f3455bd6978d1fea )
+)
+
+game (
+	name "Deroon Dero Dero (Japan) (1M)"
+	description "Deroon Dero Dero (Japan) (1M)"
+	rom ( name "Deroon Dero Dero (Japan) (1M) (Track 01).bin" size 18959472 crc 45e405f9 md5 d7e718e4bd71544f01d6cba06eb22930 sha1 64e47a3140c5b223a7ac6682d67d74e15f60c485 )
+)
+
+game (
+	name "Madou Monogatari (Japan)"
+	description "Madou Monogatari (Japan)"
+	rom ( name "Madou Monogatari (Japan) (Track 1).bin" size 134459136 crc b570613d md5 2c4b542fea2d1e830153a3411e1eb0f3 sha1 a53f9154dc8263f451b73532992ce9dc04e99848 )
+)
+
+game (
+	name "Ochigee Designer Tsukutte Pon! (Japan)"
+	description "Ochigee Designer Tsukutte Pon! (Japan)"
+	rom ( name "Ochigee Designer Tsukutte Pon! (Japan) (Track 01).bin" size 15410304 crc d407dd3e md5 94dd77d65b02e108842c8e700cd3bad8 sha1 c3efc140a2f12a9c2a6c0dd15f800db635ef4a0b )
+)
+
+game (
+	name "Puyo Puyo Tsuu (Japan) (3M)"
+	description "Puyo Puyo Tsuu (Japan) (3M)"
+	rom ( name "Puyo Puyo Tsuu (Japan) (3M) (Track 1).bin" size 606498480 crc 3f966f9d md5 ffc09ff9b8be1e96b8440ce7fcefea89 sha1 7dcbc65efc9d356e8216061c2cda5a71b40e291f )
+)
+
+game (
+	name "Shinrei Jusatsushi Taroumaru (Japan)"
+	description "Shinrei Jusatsushi Taroumaru (Japan)"
+	rom ( name "Shinrei Jusatsushi Taroumaru (Japan) (Track 01).bin" size 9375072 crc efe9589b md5 0117a9985542cf5afeea10327c6af89b sha1 7d6ccc28b0c9074175110023967def08ae42638b )
+)
+
+game (
+	name "Tetris Plus (Japan)"
+	description "Tetris Plus (Japan)"
+	rom ( name "Tetris Plus (Japan) (Track 01).bin" size 6799632 crc 10650940 md5 844b9ce0c2c72885526960d7c4dadb99 sha1 3cb3739c9d793fec4eed8e53741d24097d020bc8 )
+)
+
+game (
+	name "Waku Waku Puyo Puyo Dungeon (Japan) (4M)"
+	description "Waku Waku Puyo Puyo Dungeon (Japan) (4M)"
+	rom ( name "Waku Waku Puyo Puyo Dungeon (Japan) (4M) (Track 1).bin" size 89848752 crc b8d1e870 md5 567e6dfc4776c7cf3e417d5c98f34dbf sha1 e0af339ab1985b33560937fa69f01a1d19c61242 )
+)
+
+game (
+	name "Puyo Puyo Sun (Japan) (3M)"
+	description "Puyo Puyo Sun (Japan) (3M)"
+	rom ( name "Puyo Puyo Sun (Japan) (3M) (Track 1).bin" size 464670528 crc 7ad79d38 md5 2cfd26ffd2b82f9e5d7e7102af78e9e0 sha1 4b0291bed2dbee1dccaad7e0352af557e1c4ee43 )
+)
+
+game (
+	name "House of the Dead, The (Japan)"
+	description "House of the Dead, The (Japan)"
+	rom ( name "House of the Dead, The (Japan) (Track 01).bin" size 75854352 crc cbc54214 md5 978aed97313f610d7f9c2628652dd462 sha1 599fa039a87035017348bf9969ee274865b10b35 )
+)
+
+game (
+	name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (3M)"
+	description "Albert Odyssey Gaiden - Legend of Eldean (Japan) (3M)"
+	rom ( name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (3M) (Track 01).bin" size 247254000 crc 4bdcb4ca md5 0097592e49699ef198187d0da798ef1c sha1 7bd618af44e7dbe210d5d41bcda68a071b65aefc )
+)
+
+game (
+	name "Galaxy Fight - Universal Warriors (Japan)"
+	description "Galaxy Fight - Universal Warriors (Japan)"
+	rom ( name "Galaxy Fight - Universal Warriors (Japan) (Track 01).bin" size 31286304 crc 0e3a7e4c md5 139e8a7722bd50062ed62d5ccece112f sha1 547786763c39805c7594ab37236ae7219e730d56 )
+)
+
+game (
+	name "Cyber Doll (Japan)"
+	description "Cyber Doll (Japan)"
+	rom ( name "Cyber Doll (Japan) (Track 01).bin" size 136366608 crc cb2eaaea md5 4b4b2d7cad5c22e36e43d0eb2cb8314e sha1 b16da2f96e185a2f1fb45821e32d261d36f00064 )
+)
+
+game (
+	name "NHL All-Star Hockey (Europe)"
+	description "NHL All-Star Hockey (Europe)"
+	rom ( name "NHL All-Star Hockey (Europe) (Track 01).bin" size 437662512 crc 84a9b046 md5 a20353f3eb13bc3f8767c776f59123df sha1 57b675bbe764bc42c06cb33b16d28c7b5389e5fd )
+)
+
+game (
+	name "Daisuki (Japan) (Disc 1)"
+	description "Daisuki (Japan) (Disc 1)"
+	rom ( name "Daisuki (Japan) (Disc 1) (Track 1).bin" size 658651728 crc 57b70a26 md5 f005becbf53356da2279ea7265dd6c42 sha1 0efaae4467269aa13ddb27a9a0f8c5b214a73134 )
+)
+
+game (
+	name "Daisuki (Japan) (Disc 2)"
+	description "Daisuki (Japan) (Disc 2)"
+	rom ( name "Daisuki (Japan) (Disc 2) (Track 1).bin" size 50655024 crc fa9ec253 md5 a4b8389f97c269abab8db923f5dc3c88 sha1 3b2bf6b68fb6c7745dc80b4c4e2408d5b439236a )
+)
+
+game (
+	name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (2M)"
+	description "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (2M)"
+	rom ( name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (2M) (Track 1).bin" size 481720176 crc f1b74601 md5 32f037579707e192320db6e8f24ef571 sha1 ebf3209692dcc4df8d4448bbcada9ab9266549d0 )
+)
+
+game (
+	name "Chibi Maruko-chan no Taisen Puzzledama (Japan)"
+	description "Chibi Maruko-chan no Taisen Puzzledama (Japan)"
+	rom ( name "Chibi Maruko-chan no Taisen Puzzledama (Japan) (Track 01).bin" size 10581648 crc 4f240b2f md5 ab08a6c8a79280706c1ffc7c1e30e120 sha1 8bf152c9856b6b2a822332dd8581523534d9258e )
+)
+
+game (
+	name "Detana Twinbee Yahoo! Deluxe Pack (Japan) (3M)"
+	description "Detana Twinbee Yahoo! Deluxe Pack (Japan) (3M)"
+	rom ( name "Detana Twinbee Yahoo! Deluxe Pack (Japan) (3M) (Track 1).bin" size 617999760 crc 43611045 md5 854eecf8196792a5a1e5421fc025bc27 sha1 3e99d5e8bfdcd2ce6ab849662e51a4e682b8d6bf )
+)
+
+game (
+	name "Gokujou Parodius Da! Deluxe Pack (Japan) (Rev A)"
+	description "Gokujou Parodius Da! Deluxe Pack (Japan) (Rev A)"
+	rom ( name "Gokujou Parodius Da! Deluxe Pack (Japan) (Rev A) (Track 1).bin" size 517357680 crc 183ff5fa md5 90cc6fdd6f4db380dbea123a96258ac4 sha1 163c546aa1b43eee8ec9e9bd13bade9ffa86ec75 )
+)
+
+game (
+	name "Gradius Deluxe Pack (Japan)"
+	description "Gradius Deluxe Pack (Japan)"
+	rom ( name "Gradius Deluxe Pack (Japan) (Track 1).bin" size 309737232 crc 1ca9165e md5 9b6c78a37a178f0f2be6cf3b5baf3113 sha1 545604929715f5d68b13648690b1045aa43fd71a )
+)
+
+game (
+	name "J. League Jikkyou Honoo no Striker (Japan) (1M)"
+	description "J. League Jikkyou Honoo no Striker (Japan) (1M)"
+	rom ( name "J. League Jikkyou Honoo no Striker (Japan) (1M) (Track 1).bin" size 193273248 crc caf86dcb md5 0136657406352a1a671d12ff506059ea sha1 c82d8f1798a2a9f1d476f6cb87f0db17d7a5576d )
+)
+
+game (
+	name "Jikkyou Oshaberi Parodius - Forever with Me (Japan)"
+	description "Jikkyou Oshaberi Parodius - Forever with Me (Japan)"
+	rom ( name "Jikkyou Oshaberi Parodius - Forever with Me (Japan) (Track 1).bin" size 144184656 crc 8ee0a811 md5 beadea1467eef8bf4c553c8f6bbdf9b8 sha1 32cec306f73952da14147b9ae40fb8177b5d6e60 )
+)
+
+game (
+	name "Konami Antiques - MSX Collection Ultra Pack (Japan) (2M)"
+	description "Konami Antiques - MSX Collection Ultra Pack (Japan) (2M)"
+	rom ( name "Konami Antiques - MSX Collection Ultra Pack (Japan) (2M) (Track 1).bin" size 6145776 crc 7acf682f md5 42be8f056fffae73d2dab577bdae6d2f sha1 6d92d0d2dcc6b08348a2355b1f76bac75aa38b7f )
+)
+
+game (
+	name "Policenauts (Japan) (Disc 1)"
+	description "Policenauts (Japan) (Disc 1)"
+	rom ( name "Policenauts (Japan) (Disc 1) (Track 1).bin" size 524338416 crc 40559040 md5 d78318eff2d44189f14dfcb3b4859333 sha1 526bcd0ff248866f5d8c829c6c186f6c1a9c2405 )
+)
+
+game (
+	name "Policenauts (Japan) (Disc 2)"
+	description "Policenauts (Japan) (Disc 2)"
+	rom ( name "Policenauts (Japan) (Disc 2) (Track 1).bin" size 560211120 crc 5ae082f4 md5 657ecc922d2b0912476a387bd039ea2c sha1 20edac717f607b1e0a10443f3480c96acd725450 )
+)
+
+game (
+	name "Policenauts (Japan) (Disc 3)"
+	description "Policenauts (Japan) (Disc 3)"
+	rom ( name "Policenauts (Japan) (Disc 3) (Track 1).bin" size 513533328 crc dd3689b8 md5 90c6a9161d47c1c0244adfee57f89323 sha1 7c837f0a3a1c12ba430c0bf4feefabf518629220 )
+)
+
+game (
+	name "Salamander Deluxe Pack Plus (Japan)"
+	description "Salamander Deluxe Pack Plus (Japan)"
+	rom ( name "Salamander Deluxe Pack Plus (Japan) (Track 1).bin" size 504085344 crc 7315b0c4 md5 169d675542c5515e1a04241419cf4d73 sha1 121871f6ebd47c87cee56f8069ee58e28368fb7e )
+)
+
+game (
+	name "Sexy Parodius (Japan)"
+	description "Sexy Parodius (Japan)"
+	rom ( name "Sexy Parodius (Japan) (Track 1).bin" size 325159296 crc 6d2d4415 md5 84dca55d9d6d3ce5a0e9855aa2d4fc96 sha1 6e7a69aa3f9880afa10a8c9158e065215f6e455a )
+)
+
+game (
+	name "Snatcher (Japan)"
+	description "Snatcher (Japan)"
+	rom ( name "Snatcher (Japan) (Track 1).bin" size 479149440 crc 61c1c029 md5 fd6c0438987fcbc8f520efeed54b37a5 sha1 a3ebab5b07a2b9a17aa68554072585be8839aba3 )
+)
+
+game (
+	name "Tokimeki Memorial - Forever with You (Japan) (Special Ban) (2M)"
+	description "Tokimeki Memorial - Forever with You (Japan) (Special Ban) (2M)"
+	rom ( name "Tokimeki Memorial - Forever with You (Japan) (Special Ban) (2M) (Track 1).bin" size 239685264 crc 22e2ae16 md5 2f6943d792d80e780ab37273ec1a96ae sha1 1cd7310334d324b14a64757f29f6e06c23501a60 )
+)
+
+game (
+	name "Tokimeki Memorial Taisen Puzzledama (Japan) (2M)"
+	description "Tokimeki Memorial Taisen Puzzledama (Japan) (2M)"
+	rom ( name "Tokimeki Memorial Taisen Puzzledama (Japan) (2M) (Track 01).bin" size 480033792 crc aaa097e3 md5 6a1af439c7ff5d42dc3cf7325ddf8c40 sha1 4f7f6afe3baa340e0d853acf92838ea593b7c421 )
+)
+
+game (
+	name "Tokimeki Memorial Taisen Tokkaedama (Japan)"
+	description "Tokimeki Memorial Taisen Tokkaedama (Japan)"
+	rom ( name "Tokimeki Memorial Taisen Tokkaedama (Japan) (Track 01).bin" size 154825104 crc fd563251 md5 234c4de7170fec319ce27be37b8902a8 sha1 2c52e1485e92def35df66edabea34b705e1b9264 )
+)
+
+game (
+	name "Vandal Hearts - Ushinawareta Kodai Bunmei (Japan)"
+	description "Vandal Hearts - Ushinawareta Kodai Bunmei (Japan)"
+	rom ( name "Vandal Hearts - Ushinawareta Kodai Bunmei (Japan) (Track 1).bin" size 594319824 crc 8fa97541 md5 398f6065e2225181cf396d779f74cba6 sha1 bedc213792d5050af482a36f4a61d7a19ce75c2f )
+)
+
+game (
+	name "Guardian Force (Japan)"
+	description "Guardian Force (Japan)"
+	rom ( name "Guardian Force (Japan) (Track 1).bin" size 21076272 crc b224c50c md5 bcfc800d2697f324f4092d0f3c0b1286 sha1 95dae668cf65bc2a4951106da31435015e1eed51 )
+)
+
+game (
+	name "Magical Night Dreams - Cotton 2 (Japan)"
+	description "Magical Night Dreams - Cotton 2 (Japan)"
+	rom ( name "Magical Night Dreams - Cotton 2 (Japan) (Track 1).bin" size 37951872 crc f110ab6b md5 e3d6c7826c57ced4565ef3ef88bfd0b1 sha1 25366440f350ec6620e4f78ce61774238766caeb )
+)
+
+game (
+	name "Steamgear Mash (Japan)"
+	description "Steamgear Mash (Japan)"
+	rom ( name "Steamgear Mash (Japan) (Track 01).bin" size 100929024 crc 6e9ed792 md5 3aeab40165d54c839683d3725d4db7a9 sha1 00510b2a68e4e29646722f4ac72a9ea910224d74 )
+)
+
+game (
+	name "Magical Night Dreams - Cotton Boomerang (Japan)"
+	description "Magical Night Dreams - Cotton Boomerang (Japan)"
+	rom ( name "Magical Night Dreams - Cotton Boomerang (Japan) (Track 1).bin" size 34948368 crc abc1dedc md5 b84b0a35d3e4dec786862cb12e7a36bd sha1 67a1b71253d02a099c745a398ecf5bbfff3af77e )
+)
+
+game (
+	name "Soukyuu Gurentai (Japan) (Rev A)"
+	description "Soukyuu Gurentai (Japan) (Rev A)"
+	rom ( name "Soukyuu Gurentai (Japan) (Rev A) (Track 01).bin" size 30761808 crc ca8fbb57 md5 d1487a99b38c1f471eda64192d1b8d37 sha1 6fa14e1aa2dbf3df861754184be6240e0d68dfbd )
+)
+
+game (
+	name "Bubble Bobble also featuring Rainbow Islands (Europe)"
+	description "Bubble Bobble also featuring Rainbow Islands (Europe)"
+	rom ( name "Bubble Bobble also featuring Rainbow Islands (Europe) (Track 1).bin" size 42281904 crc 0397ed86 md5 4ba1b42a9c9f64780de51930b9ec14de sha1 1be0759b3d17eeb08bd43e7cc9bcce357f146a6f )
+)
+
+game (
+	name "Street Fighter Alpha - Warriors' Dreams (Europe)"
+	description "Street Fighter Alpha - Warriors' Dreams (Europe)"
+	rom ( name "Street Fighter Alpha - Warriors' Dreams (Europe) (Track 01).bin" size 26556432 crc f28632b8 md5 36894ac7991b41f1c2429ff97ca12d18 sha1 d4462d7db01ec4337940e94fb99e5f2cc4dc3f33 )
+)
+
+game (
+	name "Street Fighter Alpha 2 (Europe)"
+	description "Street Fighter Alpha 2 (Europe)"
+	rom ( name "Street Fighter Alpha 2 (Europe) (Track 1).bin" size 465681888 crc 4b404eb9 md5 de3fae977e251ff7dc5b4853038a0b5f sha1 18ab6a47a2c21b3d27b74b373efc641f29989751 )
+)
+
+game (
+	name "Street Fighter - Real Battle on Film (Japan) (4M)"
+	description "Street Fighter - Real Battle on Film (Japan) (4M)"
+	rom ( name "Street Fighter - Real Battle on Film (Japan) (4M) (Track 01).bin" size 326410560 crc ec9fc9db md5 66142caba82bff83087c5ba66d03df7c sha1 6b48aba9f7343be7baa3a6a11ed9f123e28f89e3 )
+)
+
+game (
+	name "Grandia (Japan) (Disc 1) (1M)"
+	description "Grandia (Japan) (Disc 1) (1M)"
+	rom ( name "Grandia (Japan) (Disc 1) (1M) (Track 1).bin" size 618496032 crc 8ff62b58 md5 57e71f8aa1b38824c512a431f6b40de0 sha1 6ac02a31c36eaca966b1dc01657b097e078009d3 )
+)
+
+game (
+	name "Grandia (Japan) (Disc 2) (4M)"
+	description "Grandia (Japan) (Disc 2) (4M)"
+	rom ( name "Grandia (Japan) (Disc 2) (4M) (Track 1).bin" size 585104688 crc af818605 md5 b719951858337593af00b35c835a77c3 sha1 023f0894b5ba9ae1224aeb2e241a5c7b275fde0c )
+)
+
+game (
+	name "Command & Conquer (Europe) (En,Fr,De) (Disc 2) (NOD)"
+	description "Command & Conquer (Europe) (En,Fr,De) (Disc 2) (NOD)"
+	rom ( name "Command & Conquer (Europe) (En,Fr,De) (Disc 2) (NOD) (Track 01).bin" size 322320432 crc adeb24c9 md5 6662def1d608428c5ba4182aff2f4a1b sha1 17fef755c485e367d3ecad8519ddb8cda47e0660 )
+)
+
+game (
+	name "Command & Conquer (Europe) (En,Fr,De) (Disc 1) (GDI)"
+	description "Command & Conquer (Europe) (En,Fr,De) (Disc 1) (GDI)"
+	rom ( name "Command & Conquer (Europe) (En,Fr,De) (Disc 1) (GDI) (Track 01).bin" size 390747168 crc 5b49d23a md5 fba281d030dbaf24f33353a13411655e sha1 2aa12b2efe5665cdad6ad171845efd667659cb7a )
+)
+
+game (
+	name "Magical Drop (Japan)"
+	description "Magical Drop (Japan)"
+	rom ( name "Magical Drop (Japan) (Track 01).bin" size 88581024 crc e1291aac md5 11cc12d7544aec89266da024c6d63a4e sha1 f66e13b0c5b0a4507ba07037104a6ac51b813835 )
+)
+
+game (
+	name "Command & Conquer (Japan) (Disc 1) (GDI Disc)"
+	description "Command & Conquer (Japan) (Disc 1) (GDI Disc)"
+	rom ( name "Command & Conquer (Japan) (Disc 1) (GDI Disc) (Track 01).bin" size 390961200 crc 683c0208 md5 8459b6a776ec75872be9b0c51f74fe36 sha1 ee0c5628486427efafdb8410ebb3a79e1627e181 )
+)
+
+game (
+	name "Command & Conquer (Japan) (Disc 2) (NOD Disc)"
+	description "Command & Conquer (Japan) (Disc 2) (NOD Disc)"
+	rom ( name "Command & Conquer (Japan) (Disc 2) (NOD Disc) (Track 01).bin" size 322353360 crc 6f413538 md5 8650e0055f63390b937af5e2a945107b sha1 1771eaeaace8d2c16afdf6aa60ae34be9ed9a5ba )
+)
+
+game (
+	name "Road Rash (Europe)"
+	description "Road Rash (Europe)"
+	rom ( name "Road Rash (Europe) (Track 1).bin" size 575228640 crc 5906947e md5 469c7db0b3b8a8e4e36576cc5861990d sha1 701ff71cda0d6de7f1527e451038493543e63e42 )
+)
+
+game (
+	name "Kaitei Daisensou (Japan)"
+	description "Kaitei Daisensou (Japan)"
+	rom ( name "Kaitei Daisensou (Japan) (Track 01).bin" size 35757456 crc 42e65f6e md5 827f5399b6164ca3244b40aa6a3ba9eb sha1 fe1a957a99d2072d3dbef30307a03db731e196c6 )
+)
+
+game (
+	name "Virtua Fighter Remix (Japan) (5M)"
+	description "Virtua Fighter Remix (Japan) (5M)"
+	rom ( name "Virtua Fighter Remix (Japan) (5M) (Track 01).bin" size 13533408 crc 874d91ab md5 37c0d347cecff874931962d4fb4c7eff sha1 3d16f1e887d908e75737319467e42d694376f5a7 )
+)
+
+game (
+	name "Ultimate Mortal Kombat 3 (Europe)"
+	description "Ultimate Mortal Kombat 3 (Europe)"
+	rom ( name "Ultimate Mortal Kombat 3 (Europe) (Track 01).bin" size 49293216 crc cf14b81e md5 036008c36c77136ec124f3addf904a28 sha1 42acd662a3c18641f7f54d887fa6544827a0f0af )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev B)"
+	description "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev B)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! (Japan) (Rev B) (Track 1).bin" size 380024400 crc 54274582 md5 ff64c34258ba87e9fe2b23537a28b52c sha1 200c8e75f8db9e87a570f7f05aa9bcf83343f932 )
+)
+
+game (
+	name "Find Love 2 - The Prologue (Japan)"
+	description "Find Love 2 - The Prologue (Japan)"
+	rom ( name "Find Love 2 - The Prologue (Japan) (Track 1).bin" size 485725632 crc 78f5ab60 md5 b64dbddfcbfa2c679f812d529d30a891 sha1 c6c80a92c4c5ebac7957d2f8c8106292d691364d )
+)
+
+game (
+	name "Winning Post 2 - Final '97 (Japan)"
+	description "Winning Post 2 - Final '97 (Japan)"
+	rom ( name "Winning Post 2 - Final '97 (Japan) (Track 1).bin" size 132241200 crc 98027001 md5 384031aebddc76b946fa429da06bec19 sha1 a109b9412bf401ace1f12fd88fe03fccf526b616 )
+)
+
+game (
+	name "Exhumed (Europe) (En,Fr,De,Es)"
+	description "Exhumed (Europe) (En,Fr,De,Es)"
+	rom ( name "Exhumed (Europe) (En,Fr,De,Es) (Track 01).bin" size 193597824 crc 8e802794 md5 4ff1ae639b1db8b14decaa035cf24ad4 sha1 a62bcb979eebee7df1979cbac0f5f5e849cb2c10 )
+)
+
+game (
+	name "Night Warriors - Darkstalkers' Revenge (Europe)"
+	description "Night Warriors - Darkstalkers' Revenge (Europe)"
+	rom ( name "Night Warriors - Darkstalkers' Revenge (Europe) (Track 1).bin" size 493757712 crc d6a752fb md5 275b7b32feae5be22d6642a0c10298b6 sha1 4312b831414b49221a9e290308a38d4a9ce54f3f )
+)
+
+game (
+	name "Virtual Hydlide (Europe)"
+	description "Virtual Hydlide (Europe)"
+	rom ( name "Virtual Hydlide (Europe) (Track 01).bin" size 122346336 crc 9bcf0430 md5 ac758cd1ef01d2b782a92e42c8867b9a sha1 2b69a6bdc993501ccf49d5ca5d0c35233417d306 )
+)
+
+game (
+	name "Croc - Legend of the Gobbos (Europe)"
+	description "Croc - Legend of the Gobbos (Europe)"
+	rom ( name "Croc - Legend of the Gobbos (Europe) (Track 01).bin" size 224082096 crc f6de9f21 md5 348dfefb189e66002b1795d9c16a9dcb sha1 34e034e58ca0ca0fddc395e22ca4e553ad9e5255 )
+)
+
+game (
+	name "Sonic Jam (Europe)"
+	description "Sonic Jam (Europe)"
+	rom ( name "Sonic Jam (Europe) (Track 1).bin" size 631295616 crc 9a1f8fbc md5 bbb90b4ff64e6d9a52a3c5b1efd4ba30 sha1 b82fbd64bb007265ccd59fc0a08e0af99c33128b )
+)
+
+game (
+	name "Gun Griffon (Europe)"
+	description "Gun Griffon (Europe)"
+	rom ( name "Gun Griffon (Europe) (Track 01).bin" size 78559152 crc beff3126 md5 db2df99c0a61af573233d756238bad3c sha1 f41e835f6f0d0a1ee2e3fd56ad6cded72413bea3 )
+)
+
+game (
+	name "SimCity 2000 (Japan) (Rev A)"
+	description "SimCity 2000 (Japan) (Rev A)"
+	rom ( name "SimCity 2000 (Japan) (Rev A) (Track 1).bin" size 195197184 crc ab228fbc md5 37bb013de435f0670cf530d62b9e5bfa sha1 50ad810c4c39dc54e634735e44fe7dc5b17a0060 )
+)
+
+game (
+	name "Virtua Fighter CG Portrait Collection (Europe)"
+	description "Virtua Fighter CG Portrait Collection (Europe)"
+	rom ( name "Virtua Fighter CG Portrait Collection (Europe) (Track 1).bin" size 22746192 crc 573f6de1 md5 d8308a7136c9afd4fb9a3bba224753dc sha1 a9a9f8beff4458c5a934f8657c3442b4e4a9bb09 )
+)
+
+game (
+	name "Virtua Fighter Remix (Europe)"
+	description "Virtua Fighter Remix (Europe)"
+	rom ( name "Virtua Fighter Remix (Europe) (Track 01).bin" size 13251168 crc d67b237c md5 5ab311f80242cd85f02319f69c122a08 sha1 b508a994c77a0704e62bedbf123a49578af4b539 )
+)
+
+game (
+	name "Road & Track Presents - The Need for Speed (Europe) (En,De)"
+	description "Road & Track Presents - The Need for Speed (Europe) (En,De)"
+	rom ( name "Road & Track Presents - The Need for Speed (Europe) (En,De) (Track 01).bin" size 337829520 crc 0051678a md5 a18b22031af2c7a5ece33a31a2d731af sha1 3bace4d02f1143e34725017bf21407f55d4128d9 )
+)
+
+game (
+	name "Fighter's History Dynamite (Japan)"
+	description "Fighter's History Dynamite (Japan)"
+	rom ( name "Fighter's History Dynamite (Japan) (Track 01).bin" size 258788208 crc e8997b3d md5 f5a9a877f3f4cb45aa2f0bb4b2fd4bf8 sha1 5300e29ba76de5194a0a9e71884a56407780f465 )
+)
+
+game (
+	name "Zero Divide - The Final Conflict (Japan)"
+	description "Zero Divide - The Final Conflict (Japan)"
+	rom ( name "Zero Divide - The Final Conflict (Japan) (Track 01).bin" size 37744896 crc 5000b5a1 md5 96fb4eddca1b83a2d38b27aede274bd8 sha1 40e102f948df8d11698127806b528a89cf1c4535 )
+)
+
+game (
+	name "Mystery Mansion - Das Haus der verlorenen Seelen (Germany)"
+	description "Mystery Mansion - Das Haus der verlorenen Seelen (Germany)"
+	rom ( name "Mystery Mansion - Das Haus der verlorenen Seelen (Germany) (Track 1).bin" size 445939200 crc a22ccb19 md5 da06b292c4765d00fd1c5dfa5cd4d391 sha1 3092afe0280cf6fee8e12e8d96c16d5342b299c7 )
+)
+
+game (
+	name "Sega Rally Championship (USA)"
+	description "Sega Rally Championship (USA)"
+	rom ( name "Sega Rally Championship (USA) (Track 01).bin" size 31347456 crc e7a06577 md5 ff5fb7590ce8fb30da9bc0bdd7037303 sha1 a7305950c44839ad4008b29b1db442df2ffddd7c )
+)
+
+game (
+	name "Street Racer Extra (Japan)"
+	description "Street Racer Extra (Japan)"
+	rom ( name "Street Racer Extra (Japan) (Track 01).bin" size 29592864 crc 61d86b6b md5 c443dbeb05cee26a07dc177e89ff86ef sha1 d9bdd5ba42c9f601dc53adb9360f89d7bab3aaa2 )
+)
+
+game (
+	name "Strikers 1945 (Japan)"
+	description "Strikers 1945 (Japan)"
+	rom ( name "Strikers 1945 (Japan) (Track 1).bin" size 230420736 crc f0a11887 md5 7367c3b58368cf6923c7a27f2327fb84 sha1 d2c625faab0fe316559c82ac64f10387ea36bc62 )
+)
+
+game (
+	name "Waku Waku Monster (Japan)"
+	description "Waku Waku Monster (Japan)"
+	rom ( name "Waku Waku Monster (Japan) (Track 1).bin" size 22894368 crc c1c694e6 md5 18e4017546f785feab02aadb0eea074c sha1 c57080d17ffeb2b1a361a455a45127fe1710760b )
+)
+
+game (
+	name "Touge King the Spirits 2 (Japan)"
+	description "Touge King the Spirits 2 (Japan)"
+	rom ( name "Touge King the Spirits 2 (Japan) (Track 01).bin" size 105696528 crc 63d57511 md5 5585437a82272842cc452a2160e0fd80 sha1 048402e20d0553280cda5cde6e974dca8d96688a )
+)
+
+game (
+	name "Princess Crown (Japan) (1M)"
+	description "Princess Crown (Japan) (1M)"
+	rom ( name "Princess Crown (Japan) (1M) (Track 01).bin" size 87339168 crc 005affaf md5 372041b64f903fb8e2049ed6561f91a9 sha1 1c7b9c750b20b6d2d177b429568a05e8a94d0806 )
+)
+
+game (
+	name "Sol Divide (Japan)"
+	description "Sol Divide (Japan)"
+	rom ( name "Sol Divide (Japan) (Track 1).bin" size 919632 crc 7f387c27 md5 9489bb1d3c7572db844cf7522ea054bb sha1 78f2bbf85a5fcf12794d25091df7032d924fc57a )
+)
+
+game (
+	name "Mobile Suit Gundam (Japan)"
+	description "Mobile Suit Gundam (Japan)"
+	rom ( name "Mobile Suit Gundam (Japan) (Track 1).bin" size 524178480 crc 0ae2513c md5 ebfffc49aa5aaf2db1657c11d4119643 sha1 d3c41d44f2fe8ae9a384ad0afcad817cabeb24c5 )
+)
+
+game (
+	name "Rayman (Japan)"
+	description "Rayman (Japan)"
+	rom ( name "Rayman (Japan) (Track 01).bin" size 86548896 crc 07abd059 md5 9bea82be94a5a03843336ce1db79e009 sha1 d00a5c97d32666deaaf11989073b0d2ab3d27568 )
+)
+
+game (
+	name "Willy Wombat (Japan)"
+	description "Willy Wombat (Japan)"
+	rom ( name "Willy Wombat (Japan) (Track 01).bin" size 171018624 crc a62e1002 md5 447cdadfe4bc8a5ff3f80445a6754e8d sha1 7648c8e65df732415365e9bc5a0fdc450aabc852 )
+)
+
+game (
+	name "Kidou Senshi Z Gundam - Kouhen Uchuu o Kakeru (Japan)"
+	description "Kidou Senshi Z Gundam - Kouhen Uchuu o Kakeru (Japan)"
+	rom ( name "Kidou Senshi Z Gundam - Kouhen Uchuu o Kakeru (Japan) (Track 1).bin" size 607904976 crc 5dae766e md5 dd7bacfa0c69f6601cee6bb5f75b8971 sha1 46ceea74a178ff4b41149c834f346c294c66886a )
+)
+
+game (
+	name "Magical Hoppers (Japan)"
+	description "Magical Hoppers (Japan)"
+	rom ( name "Magical Hoppers (Japan) (Track 1).bin" size 126638736 crc 59265746 md5 cde88f31a8b0f7c599d1cba50c82a0b7 sha1 2bec5b93ae02d14e4b9a529491a751bc79e44723 )
+)
+
+game (
+	name "Saturn Bomberman (Japan)"
+	description "Saturn Bomberman (Japan)"
+	rom ( name "Saturn Bomberman (Japan) (Track 01).bin" size 131592048 crc e92e2f1e md5 d72332214aa5c22bd002e4841a9d4937 sha1 7c21abd29124e347d133744395152dd42727c1f7 )
+)
+
+game (
+	name "Saturn Bomberman Fight!! (Japan)"
+	description "Saturn Bomberman Fight!! (Japan)"
+	rom ( name "Saturn Bomberman Fight!! (Japan) (Track 01).bin" size 400893696 crc fed7b242 md5 a04389c705767f9e56e48d168c618a36 sha1 4dcd839956274f1316a311f487a22ad51e371f18 )
+)
+
+game (
+	name "Joshikousei no Houkago... - Pukunpa (Japan)"
+	description "Joshikousei no Houkago... - Pukunpa (Japan)"
+	rom ( name "Joshikousei no Houkago... - Pukunpa (Japan) (Track 01).bin" size 18216240 crc 3e09490a md5 aff3afb9d9bf089f69e6c97a70c78527 sha1 c20e6135c33b7f4aede6cef11fa290929ece22b9 )
+)
+
+game (
+	name "Kidou Senshi Z Gundam - Zenpen Zeta no Kodou (Japan)"
+	description "Kidou Senshi Z Gundam - Zenpen Zeta no Kodou (Japan)"
+	rom ( name "Kidou Senshi Z Gundam - Zenpen Zeta no Kodou (Japan) (Track 1).bin" size 334303872 crc 09167b7e md5 87199e6748da40a50b34699d20071365 sha1 8a519885387188e7e7939285744f2b4978239491 )
+)
+
+game (
+	name "PD Ultraman Link (Japan)"
+	description "PD Ultraman Link (Japan)"
+	rom ( name "PD Ultraman Link (Japan) (Track 01).bin" size 26041344 crc 408d11d2 md5 1578d6d686ef631c20c4e9830b4e3b91 sha1 517c9b2dacb1a7f5f1f6172d9ea4a39c62854d45 )
+)
+
+game (
+	name "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 1)"
+	description "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 1)"
+	rom ( name "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 1) (Track 1).bin" size 334245072 crc 260f0a9d md5 bb23e52c0215cb2a7a6f0fc302cbcd8a sha1 17de3ba500a6c62cf3755a58dbccf466e3d4479e )
+)
+
+game (
+	name "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 2)"
+	description "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 2)"
+	rom ( name "Shiroki Majo - Mou Hitotsu no Eiyuu Densetsu (Japan) (Disc 2) (Track 1).bin" size 472293360 crc 5c7b1e71 md5 ff022073d236272d8a8adc84361e4843 sha1 dc71a89a89028cd15c9f7d12fe48d17a0656f974 )
+)
+
+game (
+	name "Drift King Shutokou Battle '97 - Tsuchiya Keiichi & Bandou Masaaki (Japan)"
+	description "Drift King Shutokou Battle '97 - Tsuchiya Keiichi & Bandou Masaaki (Japan)"
+	rom ( name "Drift King Shutokou Battle '97 - Tsuchiya Keiichi & Bandou Masaaki (Japan) (Track 1).bin" size 203944272 crc 0538a65d md5 166eb5676677e80017c6e92b1a276899 sha1 0dce30d79657441d8d477d6c91886adc7da54f18 )
+)
+
+game (
+	name "Prikura - Princess Clara Daisakusen (Japan)"
+	description "Prikura - Princess Clara Daisakusen (Japan)"
+	rom ( name "Prikura - Princess Clara Daisakusen (Japan) (Track 01).bin" size 167438880 crc e920ddab md5 164953686107802dad64586a2a6b147f sha1 8a29ab166880ed427e124aa7086f98a81159e7a3 )
+)
+
+game (
+	name "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 2) (Sengoku Kawaraban)"
+	description "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 2) (Sengoku Kawaraban)"
+	rom ( name "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 2) (Sengoku Kawaraban) (Track 1).bin" size 497043456 crc 78b98279 md5 7d3f8fca32267d989fb885e6bfeeb894 sha1 25a26dee9d8973bc4428010549e647cc7f8fd541 )
+)
+
+game (
+	name "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 1)"
+	description "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 1)"
+	rom ( name "Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 1) (Track 01).bin" size 446564832 crc c4028f9c md5 e9f7074030f7146b873697b60d1566f2 sha1 55a612e7058f0b6c9f7fe405bc08833d3567d67f )
+)
+
+game (
+	name "DonPachi (Japan)"
+	description "DonPachi (Japan)"
+	rom ( name "DonPachi (Japan) (Track 01).bin" size 28682640 crc efba6df9 md5 0427c96240067972e9afff284f5ced81 sha1 5160302f285749db9207e1e255a9b52d60729665 )
+)
+
+game (
+	name "Kyuukyoku Tiger II Plus (Japan)"
+	description "Kyuukyoku Tiger II Plus (Japan)"
+	rom ( name "Kyuukyoku Tiger II Plus (Japan) (Track 01).bin" size 75692064 crc f336c295 md5 ca6a5757900eb1c87c6eac1255ec75e4 sha1 36fac337e04742130477d6ea00846e38703ce964 )
+)
+
+game (
+	name "Shippuu Mahou Daisakusen - Kingdom Grandprix (Japan)"
+	description "Shippuu Mahou Daisakusen - Kingdom Grandprix (Japan)"
+	rom ( name "Shippuu Mahou Daisakusen - Kingdom Grandprix (Japan) (Track 01).bin" size 20979840 crc c13cd74d md5 3942fe56e1e97bf01677c5df1ee5fbd1 sha1 54f34928821758d37314b8fb286bdf6943518e00 )
+)
+
+game (
+	name "Black Matrix (Japan) (Reprint)"
+	description "Black Matrix (Japan) (Reprint)"
+	rom ( name "Black Matrix (Japan) (Reprint) (Track 1).bin" size 349801200 crc e05fcd06 md5 0101b9fc68a11d2d87fbf63df7e8f36e sha1 374ad4e0b0e2f889b2c8198fbf27d468a9989eb2 )
+)
+
+game (
+	name "Bubble Symphony (Japan)"
+	description "Bubble Symphony (Japan)"
+	rom ( name "Bubble Symphony (Japan) (Track 1).bin" size 522101664 crc c904b5fb md5 fe7cafe04c6f362b82f90119dc555816 sha1 07a0c76a54bae69188b7848b22c7c6d32d1f9f8f )
+)
+
+game (
+	name "Digital Pinball - Last Gladiators (Japan)"
+	description "Digital Pinball - Last Gladiators (Japan)"
+	rom ( name "Digital Pinball - Last Gladiators (Japan) (Track 01).bin" size 75141696 crc fab05cb2 md5 48336ab34762178f213ba5bd2c591f1e sha1 5df80658641e251fb6a9edb4472a7a39c486c668 )
+)
+
+game (
+	name "Digital Pinball - Necronomicon (Japan)"
+	description "Digital Pinball - Necronomicon (Japan)"
+	rom ( name "Digital Pinball - Necronomicon (Japan) (Track 01).bin" size 79165968 crc 9894a2bd md5 4ba1aa2dba5b23b98ffb4d55e6364e0f sha1 998cd91c7666feae3bd279e9d6b744cb468e1357 )
+)
+
+game (
+	name "Doraemon - Nobita to Fukkatsu no Hoshi (Japan)"
+	description "Doraemon - Nobita to Fukkatsu no Hoshi (Japan)"
+	rom ( name "Doraemon - Nobita to Fukkatsu no Hoshi (Japan) (Track 01).bin" size 92567664 crc e9b78af0 md5 bf6c906318c68c9c8b65475715447f13 sha1 803e466e3dedf567141995105e231f3879d72ee3 )
+)
+
+game (
+	name "Hansha de Spark! (Japan)"
+	description "Hansha de Spark! (Japan)"
+	rom ( name "Hansha de Spark! (Japan) (Track 01).bin" size 113810928 crc c9026161 md5 207411f414b50c9926c2db67728c4e57 sha1 da9b5d33f5c7c8c41c27e4aa7526b64b14728fcc )
+)
+
+game (
+	name "Mizubaku Daibouken (Japan)"
+	description "Mizubaku Daibouken (Japan)"
+	rom ( name "Mizubaku Daibouken (Japan) (Track 01).bin" size 3598560 crc 105672e2 md5 881a2f97cf0f44bf224f99ccd1c07366 sha1 32aebaaf3a06a87c1666efe951f015e2ade34cca )
+)
+
+game (
+	name "Strikers 1945 II (Japan)"
+	description "Strikers 1945 II (Japan)"
+	rom ( name "Strikers 1945 II (Japan) (Track 1).bin" size 179441136 crc 032111a2 md5 a559b998a46ea0f2b87aebcd305b68a5 sha1 bf3af4fb3a958eee942bd1ee550792bab0af28a8 )
+)
+
+game (
+	name "Chaos Control (Europe) (En,Fr,De)"
+	description "Chaos Control (Europe) (En,Fr,De)"
+	rom ( name "Chaos Control (Europe) (En,Fr,De) (Track 1).bin" size 537337920 crc ca108dbd md5 c8a9f814e63812aba56b93e3fbe9b9b3 sha1 f17214b380f40a434f99086967e1375af753eb88 )
+)
+
+game (
+	name "Sega Worldwide Soccer 97 (Europe) (Alt)"
+	description "Sega Worldwide Soccer 97 (Europe) (Alt)"
+	rom ( name "Sega Worldwide Soccer 97 (Europe) (Alt) (Track 01).bin" size 152360208 crc 11aa6d93 md5 d7e4088df4e0a250e885f56148013e74 sha1 14cf2bff6dd80179ce9a595b8787e89e65444752 )
+)
+
+game (
+	name "World Cup Golf - Professional Edition (Germany) (Rev A)"
+	description "World Cup Golf - Professional Edition (Germany) (Rev A)"
+	rom ( name "World Cup Golf - Professional Edition (Germany) (Rev A) (Track 1).bin" size 561130752 crc 4425e779 md5 60b25f342eaf495238689b6ee0aab7a1 sha1 b14f915a44fb1428d088862673dbd3d9dd3db14c )
+)
+
+game (
+	name "World Series Baseball (Europe)"
+	description "World Series Baseball (Europe)"
+	rom ( name "World Series Baseball (Europe) (Track 1).bin" size 97111728 crc 320ea1de md5 c54d983bfad906bc276b0473ae74da9a sha1 69bae9aad4336917879c5894c905259aa90467db )
+)
+
+game (
+	name "Batsugun (Japan)"
+	description "Batsugun (Japan)"
+	rom ( name "Batsugun (Japan) (Track 01).bin" size 12166896 crc 4fff8459 md5 f926cebcc89bc05f85133987c2dde2da sha1 ae690da0edd82927fb2100bf9664656f0e492dd7 )
+)
+
+game (
+	name "Time Bokan Series - Bokan to Ippatsu! Doronboo Kanpekiban (Japan)"
+	description "Time Bokan Series - Bokan to Ippatsu! Doronboo Kanpekiban (Japan)"
+	rom ( name "Time Bokan Series - Bokan to Ippatsu! Doronboo Kanpekiban (Japan) (Track 01).bin" size 132401136 crc d3ac159c md5 e8eb0cc25062efb4730e645739d9b600 sha1 baf834b29d75af4f06a14748f88b6ee0b7338e9f )
+)
+
+game (
+	name "Dark Savior (Japan)"
+	description "Dark Savior (Japan)"
+	rom ( name "Dark Savior (Japan) (Track 1).bin" size 117882240 crc de78209d md5 f2d871c8afa6defb4456e83807f4de07 sha1 4e459190bc6e19691a38f5fa3708acae806b2aaa )
+)
+
+game (
+	name "Gals Panic SS (Japan)"
+	description "Gals Panic SS (Japan)"
+	rom ( name "Gals Panic SS (Japan) (Track 01).bin" size 33403104 crc e55a37bc md5 b4617ad4f4a0e1b164133946ed5d11fd sha1 ee4497b230fb758c0fadb6049228409bd545867c )
+)
+
+game (
+	name "Gussun Oyoyo S (Japan)"
+	description "Gussun Oyoyo S (Japan)"
+	rom ( name "Gussun Oyoyo S (Japan) (Track 01).bin" size 24274992 crc 415810a3 md5 46438b48a1c087bc56edd65066d304f5 sha1 1afbd36dd50efda9daebc20aae21f401dd60e99e )
+)
+
+game (
+	name "Arcade Gears Vol. 4 - ImageFight & XMultiply (Japan)"
+	description "Arcade Gears Vol. 4 - ImageFight & XMultiply (Japan)"
+	rom ( name "Arcade Gears Vol. 4 - ImageFight & XMultiply (Japan) (Track 01).bin" size 36427776 crc eda820e1 md5 683d51b02e51201560f69a0526d7eddc sha1 7d8f100b081c25b2432cd4683dd38d1a379184db )
+)
+
+game (
+	name "Kururin Pa! (Japan)"
+	description "Kururin Pa! (Japan)"
+	rom ( name "Kururin Pa! (Japan) (Track 01).bin" size 6990144 crc db035e5c md5 d7d03dc3d91328f3d4b265e239d57109 sha1 3ad492284074f43cb20f66fa7e0d47ba6b1c4bb9 )
+)
+
+game (
+	name "Layer Section II (Japan)"
+	description "Layer Section II (Japan)"
+	rom ( name "Layer Section II (Japan) (Track 01).bin" size 96671904 crc 9429a3a8 md5 c806a73912ed6107e076e836f1874123 sha1 cd7bec3d9003bd07427c857b05382c0ca150771d )
+)
+
+game (
+	name "Lunar - Silver Star Story (Japan)"
+	description "Lunar - Silver Star Story (Japan)"
+	rom ( name "Lunar - Silver Star Story (Japan) (Track 1).bin" size 620977392 crc a2842e57 md5 2680fe52010346471b4ab3d9b065b803 sha1 6cdaf84cb005605d2961a85bd17e469b1758afbd )
+)
+
+game (
+	name "Monster Slider (Japan)"
+	description "Monster Slider (Japan)"
+	rom ( name "Monster Slider (Japan) (Track 01).bin" size 27160896 crc dbec3c4c md5 3fa6f4c5ecea6e8bc0da6ee536c7ac1c sha1 9db7ed47ac9519ec4f03a33f0ce5c0bc0f603b22 )
+)
+
+game (
+	name "Arcade Gears Vol. 1 - Pu Li Ru La (Japan)"
+	description "Arcade Gears Vol. 1 - Pu Li Ru La (Japan)"
+	rom ( name "Arcade Gears Vol. 1 - Pu Li Ru La (Japan) (Track 01).bin" size 9899568 crc 7e9236f7 md5 ff6c57f7d4cf8bf1eadc07991ec02ea6 sha1 c42e57603a5c6a55d8c0362153566d10b79f8709 )
+)
+
+game (
+	name "Shienryuu (Japan)"
+	description "Shienryuu (Japan)"
+	rom ( name "Shienryuu (Japan) (Track 1).bin" size 41613936 crc bc073c3f md5 e14b7b246c5a2bb917922d531e4b9512 sha1 d89a1c821fb0ae7ad603c71aea420fd2ed544341 )
+)
+
+game (
+	name "Tryrush Deppy (Japan)"
+	description "Tryrush Deppy (Japan)"
+	rom ( name "Tryrush Deppy (Japan) (Track 01).bin" size 36171408 crc 977f6bfa md5 912204647b2d7cc6dffec919d0cd831d sha1 299aee6e53e233fdb27a8bf64f249491cf4462af )
+)
+
+game (
+	name "Arcade Gears Vol. 3 - Wonder 3 (Japan)"
+	description "Arcade Gears Vol. 3 - Wonder 3 (Japan)"
+	rom ( name "Arcade Gears Vol. 3 - Wonder 3 (Japan) (Track 01).bin" size 19646256 crc d9c31ed8 md5 5a918121ae4ed83144a9fef3bc5bc19a sha1 236f3f11faba59d6784500b3c3bb298c93878af2 )
+)
+
+game (
+	name "Zoku Gussun Oyoyo (Japan) (2M)"
+	description "Zoku Gussun Oyoyo (Japan) (2M)"
+	rom ( name "Zoku Gussun Oyoyo (Japan) (2M) (Track 01).bin" size 215229168 crc 420d2693 md5 72b98b89a35d6174d367513d9322d79e sha1 aed0ed78411cb6ee818fa347bfba7c41081a2f9b )
+)
+
+game (
+	name "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev B)"
+	description "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev B)"
+	rom ( name "Kanzen Chuukei Pro Yakyuu Greatest Nine (Japan) (Rev B) (Track 1).bin" size 137281536 crc ab898a0b md5 8a7079d6d2246e37ba8351d55600d3d2 sha1 638faa830415b8dddbafb65d04c0f3d52a8acf15 )
+)
+
+game (
+	name "Greatest Nine '96 (Japan) (2M)"
+	description "Greatest Nine '96 (Japan) (2M)"
+	rom ( name "Greatest Nine '96 (Japan) (2M) (Track 1).bin" size 155201424 crc 6b3897c2 md5 a542cb2be9e93f65ff64782f34c464af sha1 c6c8ee610dacc1d2035f8e7d6061e45624e9027f )
+)
+
+game (
+	name "Fighting Vipers (Japan) (Rev A)"
+	description "Fighting Vipers (Japan) (Rev A)"
+	rom ( name "Fighting Vipers (Japan) (Rev A) (Track 01).bin" size 82893888 crc 3cdd749c md5 5e5b1e609ad1e2ade7c5cc9a8310d615 sha1 7fde6819aaabb35294cfe64f90bdaf695a7f31ce )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '98 - Summer Action (Japan)"
+	description "Pro Yakyuu Greatest Nine '98 - Summer Action (Japan)"
+	rom ( name "Pro Yakyuu Greatest Nine '98 - Summer Action (Japan) (Track 1).bin" size 439941600 crc 0a0b5700 md5 2fce5ee2e3704a5cc1ebe5ee4432274a sha1 4a15563ca09e2d5f858c522d03ddad1835ab977e )
+)
+
+game (
+	name "Zen Nihon Pro Wres featuring Virtua (Japan) (Rev A)"
+	description "Zen Nihon Pro Wres featuring Virtua (Japan) (Rev A)"
+	rom ( name "Zen Nihon Pro Wres featuring Virtua (Japan) (Rev A) (Track 1).bin" size 563369856 crc f4b6f0ad md5 cbbf47b8a8f333df35dea8c61d647300 sha1 5a6244305a228d3cbde1fa30cbf888c4fef543ed )
+)
+
+game (
+	name "Kakinoki Shougi (Japan)"
+	description "Kakinoki Shougi (Japan)"
+	rom ( name "Kakinoki Shougi (Japan) (Track 1).bin" size 2914128 crc 34af47a4 md5 5d6097a3845f2eba932994312bd6a23b sha1 3f80081a65ab93d55e73dd2f29f32eb96d11cf82 )
+)
+
+game (
+	name "Fire Prowrestling S - 6Men Scramble (Japan) (2M)"
+	description "Fire Prowrestling S - 6Men Scramble (Japan) (2M)"
+	rom ( name "Fire Prowrestling S - 6Men Scramble (Japan) (2M) (Track 1).bin" size 488802048 crc 18b025ae md5 737e83c03bb52f42a2d1e734cda1117b sha1 cd78bd2d77c2de30f640d38663e2111fbf576c2a )
+)
+
+game (
+	name "Sotsugyou II - Neo Generation (Japan) (2M)"
+	description "Sotsugyou II - Neo Generation (Japan) (2M)"
+	rom ( name "Sotsugyou II - Neo Generation (Japan) (2M) (Track 1).bin" size 665343168 crc af56676b md5 bc1c9ea0cc1e1160fa4433c589b80fa1 sha1 d2da6d74fc77b5fb87861fe7399bee96132c0bef )
+)
+
+game (
+	name "Sangokushi Eiketsuden (Japan)"
+	description "Sangokushi Eiketsuden (Japan)"
+	rom ( name "Sangokushi Eiketsuden (Japan) (Track 1).bin" size 284168640 crc 3abe0342 md5 bbd1493d47e0451b2af4e2de81228224 sha1 b681438ba39ff729c3e2a1e7586b6be0a38c8085 )
+)
+
+game (
+	name "Daikoukai Jidai II (Japan)"
+	description "Daikoukai Jidai II (Japan)"
+	rom ( name "Daikoukai Jidai II (Japan) (Track 1).bin" size 91426944 crc ef7cb29d md5 684a8d8bd0509d118154f4cf63c0f8ae sha1 8281b5cd6563c2674381f70a2e73565a0c289403 )
+)
+
+game (
+	name "Sangokushi Koumeiden (Japan)"
+	description "Sangokushi Koumeiden (Japan)"
+	rom ( name "Sangokushi Koumeiden (Japan) (Track 1).bin" size 502601232 crc 9bc756fd md5 86a09786917df6f728f3e3016eda729d sha1 cf8ee5fd7de755ded272c3a9427ce34c13cb8c81 )
+)
+
+game (
+	name "Nobunaga no Yabou Sengoku Gunyuuden (Japan)"
+	description "Nobunaga no Yabou Sengoku Gunyuuden (Japan)"
+	rom ( name "Nobunaga no Yabou Sengoku Gunyuuden (Japan) (Track 1).bin" size 45762864 crc f63c14b7 md5 5b7e7c1558850e559e885a7b7e09a0b1 sha1 7800547f0d8b2ee34324281db6ed01c39c7d9efb )
+)
+
+game (
+	name "Taikou Risshiden II (Japan) (Rev A) (10M)"
+	description "Taikou Risshiden II (Japan) (Rev A) (10M)"
+	rom ( name "Taikou Risshiden II (Japan) (Rev A) (10M) (Track 1).bin" size 157426416 crc a8955263 md5 3e79050b2d4d2589442b71ac5b7318aa sha1 1faae5e3e20440972c4914bbd8ab77c5795953b7 )
+)
+
+game (
+	name "Alone in the Dark 2 (Japan)"
+	description "Alone in the Dark 2 (Japan)"
+	rom ( name "Alone in the Dark 2 (Japan) (Track 1).bin" size 184218048 crc ec89e81f md5 71a3b9ee984df4fefcbb12d6d004e5f7 sha1 ac5372ff0b47cb6545b8fc1790ea51c9b9907e69 )
+)
+
+game (
+	name "Moon Cradle (Japan) (Disc 1)"
+	description "Moon Cradle (Japan) (Disc 1)"
+	rom ( name "Moon Cradle (Japan) (Disc 1) (Track 01).bin" size 287186256 crc 2cf95557 md5 96982d9bbf85a5213e05b19334de91ed sha1 3cf9aa9e43e9d709077fa5193910184ee9725431 )
+)
+
+game (
+	name "Moon Cradle (Japan) (Disc 2)"
+	description "Moon Cradle (Japan) (Disc 2)"
+	rom ( name "Moon Cradle (Japan) (Disc 2) (Track 1).bin" size 288185856 crc c96baab6 md5 c85836c82668ee97bdd71c34f750f429 sha1 626772064e1def9a9feb6675d85d0d2bf1053fea )
+)
+
+game (
+	name "Moon Cradle (Japan) (Disc 3)"
+	description "Moon Cradle (Japan) (Disc 3)"
+	rom ( name "Moon Cradle (Japan) (Disc 3) (Track 1).bin" size 305672976 crc 7b87ad8e md5 a744a252d970cee920f440902e12b1dd sha1 7baa5550126ebd63f8532fb65a3e6f9fe5763788 )
+)
+
+game (
+	name "Kidou Senshi Gundam - Gihren no Yabou (Japan)"
+	description "Kidou Senshi Gundam - Gihren no Yabou (Japan)"
+	rom ( name "Kidou Senshi Gundam - Gihren no Yabou (Japan) (Track 1).bin" size 615675984 crc 481741eb md5 fc48c74b24dfa90a6880b4e98d63df2c sha1 55e4a390c1a7fb1cb9ca6e4715d9a5b4a5697b19 )
+)
+
+game (
+	name "Kindaichi Shounen no Jikenbo - Hoshimitou Kanashimi no Fukushuuki (Japan)"
+	description "Kindaichi Shounen no Jikenbo - Hoshimitou Kanashimi no Fukushuuki (Japan)"
+	rom ( name "Kindaichi Shounen no Jikenbo - Hoshimitou Kanashimi no Fukushuuki (Japan) (Track 1).bin" size 366498048 crc bcad538b md5 ae6ae8061f50bebf0094b92828aa5947 sha1 f56f070b1009f6482d0455fc4abf61407a67fd88 )
+)
+
+game (
+	name "ClockWerx (Japan)"
+	description "ClockWerx (Japan)"
+	rom ( name "ClockWerx (Japan) (Track 01).bin" size 177651264 crc 60acccec md5 1787bdc0d3338afdcd091cdef145a697 sha1 a46062f5cf36e5608ecb63c64b5e328f88125f17 )
+)
+
+game (
+	name "Battle Monsters (Japan)"
+	description "Battle Monsters (Japan)"
+	rom ( name "Battle Monsters (Japan) (Track 1).bin" size 35898576 crc f156bc5b md5 c656d8dbc639d39ac2f84729780dfdf9 sha1 8178479ac0d37c39e398eee1574ff48fb5461ca6 )
+)
+
+game (
+	name "Falcom Classics (Japan) (Disc 1) (Game Disc)"
+	description "Falcom Classics (Japan) (Disc 1) (Game Disc)"
+	rom ( name "Falcom Classics (Japan) (Disc 1) (Game Disc) (Track 01).bin" size 24263232 crc 2d079f77 md5 287adc660e0d65e5ae3600157db6c9d5 sha1 f400588a0be305a36583846a814cc0631ede0fa6 )
+)
+
+game (
+	name "Falcom Classics II (Japan) (Genteiban)"
+	description "Falcom Classics II (Japan) (Genteiban)"
+	rom ( name "Falcom Classics II (Japan) (Genteiban) (Track 1).bin" size 560606256 crc 32b5934f md5 34f883ad1a324ee28262160ce6a734db sha1 9497f22c044c8ffeb32b81df8470dcfe113ba8f6 )
+)
+
+game (
+	name "Pastel Muses (Japan)"
+	description "Pastel Muses (Japan)"
+	rom ( name "Pastel Muses (Japan) (Track 01).bin" size 35926800 crc 8a9fbb9a md5 f7f8c987dca5d9ae5ae92f88065849c9 sha1 47a5eea8cbd4d192dcfaed127f22e3b0f48f3c57 )
+)
+
+game (
+	name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev A) (10M)"
+	description "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev A) (10M)"
+	rom ( name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev A) (10M) (Track 1).bin" size 157878000 crc 82817470 md5 5c18b68c89035177b0bb12fbe2c4e479 sha1 1d841eda7989f3ec14f7810d2584e762ae231ece )
+)
+
+game (
+	name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 2) (Omake CD)"
+	description "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 2) (Omake CD)"
+	rom ( name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 2) (Omake CD) (Track 01).bin" size 234318000 crc 6a1222b6 md5 d7df7203cc7e06bba70588e7c27c0b24 sha1 556ccf3b409e682a876695294811148f59532452 )
+)
+
+game (
+	name "Sakura Taisen - Teigeki Graph (Japan) (Disc 1)"
+	description "Sakura Taisen - Teigeki Graph (Japan) (Disc 1)"
+	rom ( name "Sakura Taisen - Teigeki Graph (Japan) (Disc 1) (Track 1).bin" size 260396976 crc 9ef44de4 md5 75f785b0cf657720cee527e8159a2a69 sha1 58e59e1cca23eee0a037d5db616069c308f47572 )
+)
+
+game (
+	name "Sakura Taisen - Teigeki Graph (Japan) (Disc 2)"
+	description "Sakura Taisen - Teigeki Graph (Japan) (Disc 2)"
+	rom ( name "Sakura Taisen - Teigeki Graph (Japan) (Disc 2) (Track 1).bin" size 426871536 crc 4c7cc578 md5 2d11f258bad6339a6d1b5d375de1f30b sha1 93733c6fddd8faa3b6295aabbbbe0d6ff047c659 )
+)
+
+game (
+	name "Cat the Ripper - 13Ninme no Tanteishi (Japan)"
+	description "Cat the Ripper - 13Ninme no Tanteishi (Japan)"
+	rom ( name "Cat the Ripper - 13Ninme no Tanteishi (Japan) (Track 1).bin" size 527591232 crc c81f5843 md5 b1e0d4a0edda9f12a46ab8fb46f96548 sha1 243fb7111542ee41ed174dbb231fa4664165d27c )
+)
+
+game (
+	name "Fishing Koushien (Japan)"
+	description "Fishing Koushien (Japan)"
+	rom ( name "Fishing Koushien (Japan) (Track 1).bin" size 119135856 crc 3fd9c732 md5 5b7e8b062d397a2ac14be4bfe0eb04d8 sha1 97ce49f5a7835cb4a3cb2a7449717bb9bb4d6e6f )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 1) (2M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 1) (2M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 1) (2M) (Track 1).bin" size 384921264 crc 56511de6 md5 95dac98915d6e9548ac2f70f860445e3 sha1 11a1bc79ba1d3f007458b09422176da731ac9161 )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 2) (1M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 2) (1M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 2) (1M) (Track 1).bin" size 566418048 crc a79798c3 md5 5b46603c810fda84992d963a45cb0ba9 sha1 acfaa732f84eb18f7eec4f070aa3bfa62621af82 )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 3) (2M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 3) (2M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 3) (2M) (Track 1).bin" size 298087776 crc d327b058 md5 e153f0f03eeec7d95a998930a227b07c sha1 09464089d35c06b3275407d60778110fd4ac1156 )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 4) (3M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 4) (3M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 4) (3M) (Track 1).bin" size 660648576 crc f82dacaf md5 133a4f3e8435b06f66fd57ef749cbd25 sha1 fd781e8cd9bc9d2159386e491df295a3fc010bd8 )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 2) (7M)"
+	description "Sakura Taisen (Japan) (Disc 2) (7M)"
+	rom ( name "Sakura Taisen (Japan) (Disc 2) (7M) (Track 1).bin" size 617896272 crc 5eb578e5 md5 2c68b0b4444dbcc53a29ccea484b63f1 sha1 3577ad4f1a02b024bb34d8e823a96b7da0b3b6fe )
+)
+
+game (
+	name "Baroque (Japan)"
+	description "Baroque (Japan)"
+	rom ( name "Baroque (Japan) (Track 1).bin" size 410981424 crc c2310647 md5 1f22cf4b439775bbc31c65ebe6ccd6ac sha1 a0851d3f94e338f2710e4f5978ec07a69ea9ab81 )
+)
+
+game (
+	name "Mahoutsukai ni Naru Houhou (Japan)"
+	description "Mahoutsukai ni Naru Houhou (Japan)"
+	rom ( name "Mahoutsukai ni Naru Houhou (Japan) (Track 01).bin" size 68151552 crc f1c81c74 md5 53818eb7da8b78505e2c5afbf00c1c20 sha1 aa6cb9eb81fe4cff9fa1404ae698afc88aa48da1 )
+)
+
+game (
+	name "Radiant Silvergun (Japan)"
+	description "Radiant Silvergun (Japan)"
+	rom ( name "Radiant Silvergun (Japan) (Track 01).bin" size 192158400 crc fafea6ac md5 86a11ab20e5f78ee4244cadda558cc25 sha1 bc6557f7e7721114745ad37043037a6230c797a0 )
+)
+
+game (
+	name "Silhouette Mirage (Japan)"
+	description "Silhouette Mirage (Japan)"
+	rom ( name "Silhouette Mirage (Japan) (Track 01).bin" size 144600960 crc d760174c md5 bccbe33330bb2728e3fc5fd94b4dbebc sha1 dc46ccfbee8cd8f85ad35f1838a65c11e7ebad36 )
+)
+
+game (
+	name "Steam-Heart's (Japan)"
+	description "Steam-Heart's (Japan)"
+	rom ( name "Steam-Heart's (Japan) (Track 01).bin" size 228162816 crc 2ad4feac md5 a543bcd4a4f7e7a7450fa37cbc3eb6fc sha1 71cc4fc3e0613cc76c99392a2fa66cfa18fb05ef )
+)
+
+game (
+	name "Touryuu Densetsu Elan Doree (Japan)"
+	description "Touryuu Densetsu Elan Doree (Japan)"
+	rom ( name "Touryuu Densetsu Elan Doree (Japan) (Track 01).bin" size 39158448 crc cc76d32c md5 16bdf6cb551a89e13655ee46a9530cd0 sha1 d1e076f48ac9d45baa9f7ff7caf88f2c0d7313aa )
+)
+
+game (
+	name "Twinkle Star Sprites (Japan) (Disc 1)"
+	description "Twinkle Star Sprites (Japan) (Disc 1)"
+	rom ( name "Twinkle Star Sprites (Japan) (Disc 1) (Track 01).bin" size 225222816 crc 1950ed15 md5 6c64f539e1e40994fcc9ce7906f423e7 sha1 99ed2270f48fa12f45c9bb85687c6847f465e436 )
+)
+
+game (
+	name "Twinkle Star Sprites (Japan) (Disc 2) (Omake CD)"
+	description "Twinkle Star Sprites (Japan) (Disc 2) (Omake CD)"
+	rom ( name "Twinkle Star Sprites (Japan) (Disc 2) (Omake CD) (Track 01).bin" size 165310320 crc 530e2cd7 md5 7f9e457686fae5869985cf1f1db71ede sha1 782442c5a3b244376ef2d8845451f8b2e4451814 )
+)
+
+game (
+	name "Whizz (Japan)"
+	description "Whizz (Japan)"
+	rom ( name "Whizz (Japan) (Track 1).bin" size 70734048 crc 6c26dc63 md5 cbe9f9bfd21244b99d0bafb88cd8586e sha1 0ad11e6721414420b0f9b8c14b862544ce4637fd )
+)
+
+game (
+	name "J. League Victory Goal '96 (Japan) (1M, 3M)"
+	description "J. League Victory Goal '96 (Japan) (1M, 3M)"
+	rom ( name "J. League Victory Goal '96 (Japan) (1M, 3M) (Track 01).bin" size 399277872 crc 7dfc1e0c md5 304cd5e15fb36e1c21a13f6210982e58 sha1 532cc6b1fe8f823ed4654440762a4a565a8a8610 )
+)
+
+game (
+	name "Thunderhawk 2 - Firestorm (Germany)"
+	description "Thunderhawk 2 - Firestorm (Germany)"
+	rom ( name "Thunderhawk 2 - Firestorm (Germany) (Track 01).bin" size 62109264 crc 92de7c13 md5 433e13831715100bc12d296a1b611795 sha1 4cb1491104d9d11ca1ec9b7758912d0f6ffcb849 )
+)
+
+game (
+	name "Shellshock (Germany)"
+	description "Shellshock (Germany)"
+	rom ( name "Shellshock (Germany) (Track 01).bin" size 235479888 crc b075e6cb md5 4d170816552b7098ed576e4d09e06429 sha1 c06047e11b7fbcf631ae24ab356453bce3453f30 )
+)
+
+game (
+	name "Cyber Speedway (Europe)"
+	description "Cyber Speedway (Europe)"
+	rom ( name "Cyber Speedway (Europe) (Track 01).bin" size 61410720 crc 981500f7 md5 26d7c40fbb68f3cb2909a07e7f7d9012 sha1 491d0a781cdfc91aca3d901cb511227dc7955d8c )
+)
+
+game (
+	name "F1 Challenge (Europe)"
+	description "F1 Challenge (Europe)"
+	rom ( name "F1 Challenge (Europe) (Track 01).bin" size 38645712 crc 9b5960ce md5 e890fe194073f32b5508ccad6fa0ecbb sha1 dcd2ceec9a173bc69346ec76e243da6279043e0f )
+)
+
+game (
+	name "Pebble Beach Golf Links (Europe) (4S)"
+	description "Pebble Beach Golf Links (Europe) (4S)"
+	rom ( name "Pebble Beach Golf Links (Europe) (4S) (Track 1).bin" size 422534448 crc b446142d md5 dbc4060484ab3c5bc5f7556bd2061f1b sha1 1937a17b2e157607e31e21376fcaaa35dc44adf4 )
+)
+
+game (
+	name "King of Fighters '96, The (Japan) (4M, 5M)"
+	description "King of Fighters '96, The (Japan) (4M, 5M)"
+	rom ( name "King of Fighters '96, The (Japan) (4M, 5M) (Track 01).bin" size 42206640 crc efc8f28c md5 7899e19b113b3facde7e02df203dccb1 sha1 0ffd729b437b38ceed7f4f08d069a2c8311a559a )
+)
+
+game (
+	name "Hi-Octane (Japan)"
+	description "Hi-Octane (Japan)"
+	rom ( name "Hi-Octane (Japan) (Track 01).bin" size 27360816 crc 45c8c03f md5 ec2efadece5f0e4fb5f35cf617de041b sha1 77ced7f968fa2f383e9e0eccdd32ae07f42416f2 )
+)
+
+game (
+	name "6 Inch My Darling (Japan)"
+	description "6 Inch My Darling (Japan)"
+	rom ( name "6 Inch My Darling (Japan) (Track 1).bin" size 416475696 crc 5af1919a md5 5dc7c19cc5fed1ea9646dd062893f787 sha1 ce6c6040c17e65441cfeddf8ab32ceab47a1073d )
+)
+
+game (
+	name "Aquazone - Desktop Life (Japan)"
+	description "Aquazone - Desktop Life (Japan)"
+	rom ( name "Aquazone - Desktop Life (Japan) (Track 01).bin" size 743232 crc 166b7b11 md5 22160173e71766ad3176e9bc41e9369e sha1 6c809b09251a289c296761267a3dca45e748057d )
+)
+
+game (
+	name "Girl Doll Toy - Tamashii o Kudasai (Japan)"
+	description "Girl Doll Toy - Tamashii o Kudasai (Japan)"
+	rom ( name "Girl Doll Toy - Tamashii o Kudasai (Japan) (Track 1).bin" size 70068432 crc 91e85fa3 md5 00f81e88ab13b0f895280b6d9c1fedd9 sha1 abdd6109bddc0db60727702f2e77b4bbcecfca91 )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (Rev C) (32M)"
+	description "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (Rev C) (32M)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (Rev C) (32M) (Track 1).bin" size 476733936 crc d8b6212b md5 7dbf69829a24cd077cc0edc3b8fccb7a sha1 5e0f1eaaa571ea43b23892e66254f2b79a436a2c )
+)
+
+game (
+	name "King of Fighters '96, The (Japan) (1M)"
+	description "King of Fighters '96, The (Japan) (1M)"
+	rom ( name "King of Fighters '96, The (Japan) (1M) (Track 01).bin" size 42206640 crc efc8f28c md5 7899e19b113b3facde7e02df203dccb1 sha1 0ffd729b437b38ceed7f4f08d069a2c8311a559a )
+)
+
+game (
+	name "Nightruth - Explanation of the Paranormal - The Making of Nightruth (Japan) (2M)"
+	description "Nightruth - Explanation of the Paranormal - The Making of Nightruth (Japan) (2M)"
+	rom ( name "Nightruth - Explanation of the Paranormal - The Making of Nightruth (Japan) (2M) (Track 1).bin" size 458621184 crc 9da271b1 md5 b0736932405c4367387f6b62ec65e793 sha1 45c735f72e1b5de4064db9329d77dcae85c2437d )
+)
+
+game (
+	name "She'sn (Japan)"
+	description "She'sn (Japan)"
+	rom ( name "She'sn (Japan) (Track 1).bin" size 366218160 crc a3f9f907 md5 47a72238ba57ee90b7cb558d26e7e7bc sha1 892a95f3a4287a8bb6f8aa501539aba57a981683 )
+)
+
+game (
+	name "Sotsugyou Album (Japan)"
+	description "Sotsugyou Album (Japan)"
+	rom ( name "Sotsugyou Album (Japan) (Track 1).bin" size 482058864 crc 4731ee3b md5 c4d7ba7f9ed178e4e38b7dd35c74ab41 sha1 8e38af24aa64811975ed683f4eabf4ec6ec8a3b0 )
+)
+
+game (
+	name "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan)"
+	description "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan)"
+	rom ( name "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan) (Track 1).bin" size 431902464 crc df0eaa5d md5 d0b23eb35d8183db43437783ba1ad027 sha1 cf1793aa15edce3a60c4f6d2f2e0e347cd931ce3 )
+)
+
+game (
+	name "World Advanced Daisenryaku - Sakusen File (Japan) (1M)"
+	description "World Advanced Daisenryaku - Sakusen File (Japan) (1M)"
+	rom ( name "World Advanced Daisenryaku - Sakusen File (Japan) (1M) (Track 1).bin" size 255027360 crc fa54bc16 md5 9c5b2a7c4bbb0a37e782efef8f91d94a sha1 9c31ee6fb23e93434864f8b75daffd3ada2a2c3b )
+)
+
+game (
+	name "Street Fighter Zero (Japan) (1M)"
+	description "Street Fighter Zero (Japan) (1M)"
+	rom ( name "Street Fighter Zero (Japan) (1M) (Track 01).bin" size 26563488 crc df20a652 md5 b76e752b97e63eb0a61b4b3636668b78 sha1 1e20bf94efd71ae50e7a2a0d83325dea2348a5be )
+)
+
+game (
+	name "Rampo (Japan) (Disc 1)"
+	description "Rampo (Japan) (Disc 1)"
+	rom ( name "Rampo (Japan) (Disc 1) (Track 1).bin" size 512246784 crc 095102d7 md5 159ebfcdf7724cea00cbda424a710435 sha1 78aed079155d03c9ed2c2dfa2df240decab0faad )
+)
+
+game (
+	name "Rampo (Japan) (Disc 2)"
+	description "Rampo (Japan) (Disc 2)"
+	rom ( name "Rampo (Japan) (Disc 2) (Track 1).bin" size 648326448 crc 6a8e633e md5 97c30fbd5ca2b946ad4c8a02186cb756 sha1 9d76d625128ae722fd8e3ce477eaa9f292bf2ef9 )
+)
+
+game (
+	name "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in USA)"
+	description "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in USA)"
+	rom ( name "Shin Seiki Evangelion - 2nd Impression (Japan) (Made in USA) (Track 1).bin" size 81052272 crc 6f800b25 md5 0fe3ac1bc9f62ff8501376f6e8ece82f sha1 0ab577e80805f69525ab423a1840e662a2605cf5 )
+)
+
+game (
+	name "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 1)"
+	description "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 1)"
+	rom ( name "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 1) (Track 1).bin" size 574767648 crc 2c624797 md5 54153617287afa34719bebccb795ee69 sha1 5d6c4ad8afde3a5529e03c9399af0766bdf11542 )
+)
+
+game (
+	name "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 2)"
+	description "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 2)"
+	rom ( name "Neon Genesis - Evangelion - Koutetsu no Girlfriend (Japan) (Disc 2) (Track 1).bin" size 507756816 crc f86f3c5f md5 952f90152b16a40d393525667e869e99 sha1 208e54a76e556da6250ee9097ae0203c8fc1cef9 )
+)
+
+game (
+	name "Nanatsu no Hikan (Japan) (Disc 1) (2M)"
+	description "Nanatsu no Hikan (Japan) (Disc 1) (2M)"
+	rom ( name "Nanatsu no Hikan (Japan) (Disc 1) (2M) (Track 01).bin" size 387696624 crc 8ca57435 md5 ba82663290f38b179e56ebabd48b837c sha1 10c8589e6a3ef1c9bdecedbc91107c53d79a50d7 )
+)
+
+game (
+	name "Nanatsu no Hikan (Japan) (Disc 2) (2M)"
+	description "Nanatsu no Hikan (Japan) (Disc 2) (2M)"
+	rom ( name "Nanatsu no Hikan (Japan) (Disc 2) (2M) (Track 01).bin" size 379768032 crc 929d7c88 md5 088deccfbca394f145cc75cd10bede9e sha1 b37dcbfe46a6aebd6db5be8ae0636a3e1a1cfac9 )
+)
+
+game (
+	name "Nanatsu no Hikan (Japan) (Disc 3) (1M, 2M)"
+	description "Nanatsu no Hikan (Japan) (Disc 3) (1M, 2M)"
+	rom ( name "Nanatsu no Hikan (Japan) (Disc 3) (1M, 2M) (Track 1).bin" size 461831664 crc f02a2540 md5 338bf874c7b1126eefb9ef52481ae0d3 sha1 b9097428c833dd6c4889b3b6b46dd7c5093d1001 )
+)
+
+game (
+	name "Tomb Raider (Europe)"
+	description "Tomb Raider (Europe)"
+	rom ( name "Tomb Raider (Europe) (Track 01).bin" size 207714528 crc 7d16473a md5 7d515185961e3411eb268e01ddbbffa2 sha1 147585e31fa6a2a819711ee936fd149a86ef653c )
+)
+
+game (
+	name "WipEout 2097 (Europe)"
+	description "WipEout 2097 (Europe)"
+	rom ( name "WipEout 2097 (Europe) (Track 01).bin" size 91650384 crc f82822c4 md5 7b4c15fa4ae5ded773dea2e2482a0e16 sha1 bf062506dc31a2d103d6f5028d21560749fe7c13 )
+)
+
+game (
+	name "Street Fighter Alpha 2 (USA)"
+	description "Street Fighter Alpha 2 (USA)"
+	rom ( name "Street Fighter Alpha 2 (USA) (Track 1).bin" size 465691296 crc 8c808cbf md5 b9be89474d0256a0df15d7d1c2256f1a sha1 7e7cbef32b51d7d0a5132fe7e492c6726a7d3cb6 )
+)
+
+game (
+	name "Mortal Kombat II (USA)"
+	description "Mortal Kombat II (USA)"
+	rom ( name "Mortal Kombat II (USA) (Track 1).bin" size 30782976 crc 2d4cd516 md5 136a3ce07b4622d2b5a9065fcc9fea61 sha1 240986fe2b6ecd8c9e4fae08bbb53d8546bd3c8f )
+)
+
+game (
+	name "Iron Storm (USA)"
+	description "Iron Storm (USA)"
+	rom ( name "Iron Storm (USA) (Track 1).bin" size 353580864 crc ae08f550 md5 b96caaf11dd85fdbd3715389e8d39cc0 sha1 ed8c503d60701f44cffb55fe08ea35c8c1b2a81f )
+)
+
+game (
+	name "Night Warriors - Darkstalkers' Revenge (USA)"
+	description "Night Warriors - Darkstalkers' Revenge (USA)"
+	rom ( name "Night Warriors - Darkstalkers' Revenge (USA) (Track 1).bin" size 493741248 crc 91921ea9 md5 d284efa04e4bccd1a0f859feae7830e5 sha1 c1c01169d0e4d0acd7e4bfe768eae67c6b90fb1d )
+)
+
+game (
+	name "NHL 97 (USA)"
+	description "NHL 97 (USA)"
+	rom ( name "NHL 97 (USA) (Track 1).bin" size 396707136 crc e1d773ed md5 d81522d9c25c183395e52bf36bca1c54 sha1 b3cba348da79061fd88ada5fe7aaf443d27ab883 )
+)
+
+game (
+	name "All-Star Baseball '97 featuring Frank Thomas (USA)"
+	description "All-Star Baseball '97 featuring Frank Thomas (USA)"
+	rom ( name "All-Star Baseball '97 featuring Frank Thomas (USA) (Track 1).bin" size 484763664 crc 5eb3c4ba md5 cc1c3402114b2da0f611af448ec41280 sha1 64619c1539a23a7fe8124fa410a2e65916ca53e2 )
+)
+
+game (
+	name "Horde, The (Japan)"
+	description "Horde, The (Japan)"
+	rom ( name "Horde, The (Japan) (Track 1).bin" size 604774464 crc 0f51b487 md5 f89e2400143010dd87393a493c13becb sha1 6ed6c100c31de15b1c95171c0e9cf5cd5b79ec65 )
+)
+
+game (
+	name "Langrisser III (Japan) (1M)"
+	description "Langrisser III (Japan) (1M)"
+	rom ( name "Langrisser III (Japan) (1M) (Track 01).bin" size 77098560 crc 1e0de6c6 md5 5e5f8ff50ea0dc93b17a79909dfca4df sha1 57d2ac385e8e7a54e51806cadccde673d33a9e2a )
+)
+
+game (
+	name "Winter Heat (Japan)"
+	description "Winter Heat (Japan)"
+	rom ( name "Winter Heat (Japan) (Track 01).bin" size 57442896 crc f975eed9 md5 1274a9f798d4e32f8936555dcdc24ffa sha1 68611585c50698e0ca0c051ef840e0b1e58b26d7 )
+)
+
+game (
+	name "J.B. Harold - Blue Chicago Blues (Japan) (Disc 1)"
+	description "J.B. Harold - Blue Chicago Blues (Japan) (Disc 1)"
+	rom ( name "J.B. Harold - Blue Chicago Blues (Japan) (Disc 1) (Track 1).bin" size 606947712 crc 20bae4ee md5 beb1365bdd4e869b5599fdf9e8f6ccf4 sha1 27e064f348673c2922a3c3d1bde318f575395c2d )
+)
+
+game (
+	name "J.B. Harold - Blue Chicago Blues (Japan) (Disc 2)"
+	description "J.B. Harold - Blue Chicago Blues (Japan) (Disc 2)"
+	rom ( name "J.B. Harold - Blue Chicago Blues (Japan) (Disc 2) (Track 1).bin" size 595328832 crc 2f9db25a md5 fe82ff158a42b5cdb8f58abe879afe0b sha1 473910cbed557b83a435f6ff55b0122435e78366 )
+)
+
+game (
+	name "NBA Jam Extreme (USA)"
+	description "NBA Jam Extreme (USA)"
+	rom ( name "NBA Jam Extreme (USA) (Track 1).bin" size 58423680 crc 4449d597 md5 b56282e6821f7d7ec2ec70674d98d5c9 sha1 a25b1cc4b4b36a3339d6c3f1d6bc5b120e7c048c )
+)
+
+game (
+	name "Virtual Open Tennis (USA)"
+	description "Virtual Open Tennis (USA)"
+	rom ( name "Virtual Open Tennis (USA) (Track 01).bin" size 111722352 crc ef886771 md5 cd7f1c46b7568c7e72b3693775b7f9f6 sha1 b79c67f8c727d823e72bfd5d07dbf1bfb8897880 )
+)
+
+game (
+	name "Gunbird (Japan)"
+	description "Gunbird (Japan)"
+	rom ( name "Gunbird (Japan) (Track 01).bin" size 319512144 crc 5829132c md5 d44ef14fa105dff39635cc9f3c9e19f6 sha1 16faca39361ea0383264f3b844af0c38cf359cfb )
+)
+
+game (
+	name "Gale Racer (Japan) (En,Ja) (1A)"
+	description "Gale Racer (Japan) (En,Ja) (1A)"
+	rom ( name "Gale Racer (Japan) (En,Ja) (1A) (Track 01).bin" size 195860448 crc 0a9f8160 md5 0c8c342334ff47646a78631134693aad sha1 d2d63a984bceb5bcb9614f9accd3131ce382c815 )
+)
+
+game (
+	name "Christmas NiGHTS into Dreams... (Europe)"
+	description "Christmas NiGHTS into Dreams... (Europe)"
+	rom ( name "Christmas NiGHTS into Dreams... (Europe) (Track 01).bin" size 31900176 crc cf52516f md5 b6ed84ea4c93914df72ebacb21f24ea5 sha1 4d24926a336b282bef39228c4fa1d9a1c531bdab )
+)
+
+game (
+	name "NiGHTS into Dreams... (Europe)"
+	description "NiGHTS into Dreams... (Europe)"
+	rom ( name "NiGHTS into Dreams... (Europe) (Track 01).bin" size 46421424 crc f5d06dbb md5 f8a267b41d36111fde9a47c61e786a20 sha1 b79a4ece9dea7af2fff693af9befdf165755109c )
+)
+
+game (
+	name "NiGHTS into Dreams... (USA) (RE)"
+	description "NiGHTS into Dreams... (USA) (RE)"
+	rom ( name "NiGHTS into Dreams... (USA) (RE) (Track 01).bin" size 46005120 crc fdc86ea5 md5 fed63f3007dfb6c1777a5e52dcb1fc4a sha1 06c9913005cf5c7c1b5335f6317f26546c19f800 )
+)
+
+game (
+	name "Sonic 3D Blast (USA)"
+	description "Sonic 3D Blast (USA)"
+	rom ( name "Sonic 3D Blast (USA) (Track 01).bin" size 66199392 crc d91fbfa5 md5 35e92b07e298a7cd15bd0ec4ab738027 sha1 1e1948953106fc62616f81b4ed1c6025622418f5 )
+)
+
+game (
+	name "Virtua Fighter 2 (USA) (RE)"
+	description "Virtua Fighter 2 (USA) (RE)"
+	rom ( name "Virtua Fighter 2 (USA) (RE) (Track 01).bin" size 60267648 crc 99f5881e md5 59931fdb3d121315268ca2a6348ad8d6 sha1 a456f667a0cc323ed16a21b858caf21b47a44cf3 )
+)
+
+game (
+	name "WipEout 2097 (Europe) (Demo)"
+	description "WipEout 2097 (Europe) (Demo)"
+	rom ( name "WipEout 2097 (Europe) (Demo) (Track 1).bin" size 27953520 crc 793a05e6 md5 e5a93fe781d8fb3556680e2ab1724a05 sha1 6a2ffc41a953fef79d3b77ce42c5530478216412 )
+)
+
+game (
+	name "Pinball Graffiti (Europe) (Demo)"
+	description "Pinball Graffiti (Europe) (Demo)"
+	rom ( name "Pinball Graffiti (Europe) (Demo) (Track 01).bin" size 10167696 crc e4f53e5c md5 742beb9aca6f1cbf14559ca0741610ea sha1 3df8e40995d18dcea44068e9601b16e75aa8c9ba )
+)
+
+game (
+	name "Gremlin Demo Disc (Europe)"
+	description "Gremlin Demo Disc (Europe)"
+	rom ( name "Gremlin Demo Disc (Europe) (Track 1).bin" size 87063984 crc 89d3fc2c md5 ec1b3ea3d503dccdbcbd4c2901f19e98 sha1 abfd8837e39e086516eb38a3d1e6bd68b089a36d )
+)
+
+game (
+	name "Winter Heat (Europe) (Demo)"
+	description "Winter Heat (Europe) (Demo)"
+	rom ( name "Winter Heat (Europe) (Demo) (Track 01).bin" size 54660480 crc b3253886 md5 961c18f2fb03510732d491590ee7b937 sha1 8e7573116b2e7c4307397f8c9400810bb33e45ad )
+)
+
+game (
+	name "Core Demo Disc (Europe)"
+	description "Core Demo Disc (Europe)"
+	rom ( name "Core Demo Disc (Europe) (Track 1).bin" size 147616224 crc f6336f96 md5 0689125490b6b9b9df5b4e3031d3e802 sha1 b3b0848b37398333ea203ba3948da802c5ee840e )
+)
+
+game (
+	name "WWF WrestleMania - The Arcade Game (Europe) (Demo)"
+	description "WWF WrestleMania - The Arcade Game (Europe) (Demo)"
+	rom ( name "WWF WrestleMania - The Arcade Game (Europe) (Demo) (Track 1).bin" size 16852080 crc b0aa0570 md5 d3585cd695e16de407e051b2fc0908b5 sha1 9e28acdc8fab06a2bc80c9364fb0ebe11eac3d70 )
+)
+
+game (
+	name "Sega Flash Vol. 1 (Europe)"
+	description "Sega Flash Vol. 1 (Europe)"
+	rom ( name "Sega Flash Vol. 1 (Europe) (Track 01).bin" size 151649904 crc 5d7facfd md5 204e8c2dde2da3334c09479d693ff519 sha1 11c8443867e9da488ba66e85f531dda862cb151b )
+)
+
+game (
+	name "Sega Flash Vol. 2 (Europe)"
+	description "Sega Flash Vol. 2 (Europe)"
+	rom ( name "Sega Flash Vol. 2 (Europe) (Track 01).bin" size 259467936 crc 06b821c4 md5 6270284af9958828414e121876393eff sha1 bf58fa7cba78dcfddc9b7b3aa525441fd75a3119 )
+)
+
+game (
+	name "Sega Flash Vol. 3 (Europe) (Rev A)"
+	description "Sega Flash Vol. 3 (Europe) (Rev A)"
+	rom ( name "Sega Flash Vol. 3 (Europe) (Rev A) (Track 01).bin" size 414142512 crc 3014ad30 md5 73ffb40b4dc4b458cc76fb331584891a sha1 2ac1b05038e1b3f58a3df93aa43f29c7ea6ba125 )
+)
+
+game (
+	name "Sega Flash Vol. 4 (Europe)"
+	description "Sega Flash Vol. 4 (Europe)"
+	rom ( name "Sega Flash Vol. 4 (Europe) (Track 01).bin" size 451743936 crc 0b0bed86 md5 78573fd965d83ca2e8645dd2d5c5f8c6 sha1 9de9c72efbcca1104954d40c196ba12b5fc8a46c )
+)
+
+game (
+	name "Sega Flash Vol. 6 (Europe)"
+	description "Sega Flash Vol. 6 (Europe)"
+	rom ( name "Sega Flash Vol. 6 (Europe) (Track 01).bin" size 498026592 crc 696965e3 md5 77bb480bb8faf8c43cbdb3e5a990493f sha1 394e55b92d7d337f40373a336f44517a248c4f3f )
+)
+
+game (
+	name "Sega Flash Vol. 7 (Europe)"
+	description "Sega Flash Vol. 7 (Europe)"
+	rom ( name "Sega Flash Vol. 7 (Europe) (Track 1).bin" size 566338080 crc 0767d4b5 md5 f4b742bc07834aa797eee8737930047f sha1 eefb5d238f9d504beecfcfdadf13b7346965bcd2 )
+)
+
+game (
+	name "Panzer Dragoon (Europe) (Demo) (6S)"
+	description "Panzer Dragoon (Europe) (Demo) (6S)"
+	rom ( name "Panzer Dragoon (Europe) (Demo) (6S) (Track 1).bin" size 34005216 crc 81a5d47e md5 71352eaad887cf1d1b483b69c7414f27 sha1 0eea3ffc71148adc9a6f6e1faf1da90548324bbf )
+)
+
+game (
+	name "Sega Flash Vol. 3 (Europe)"
+	description "Sega Flash Vol. 3 (Europe)"
+	rom ( name "Sega Flash Vol. 3 (Europe) (Track 01).bin" size 414116640 crc 44a8f531 md5 1a6e15a5e2e5f55f88aa71926e0d33b2 sha1 2161c2dce6d9723b71ae734086727a141deabea6 )
+)
+
+game (
+	name "Sega Flash Vol. 5 (Europe)"
+	description "Sega Flash Vol. 5 (Europe)"
+	rom ( name "Sega Flash Vol. 5 (Europe) (Track 01).bin" size 454295856 crc 055ef31e md5 3e4341ba2bd4e80f1ae27ea01d8f76b4 sha1 f6a9eff6eda0f891d1ae46690db1867b75c16d8f )
+)
+
+game (
+	name "Parodius (Europe)"
+	description "Parodius (Europe)"
+	rom ( name "Parodius (Europe) (Track 1).bin" size 517369440 crc 4a7c0b43 md5 7356e471d39029a1176d2ee90426dbd0 sha1 57f48ca8e24606b45166b55c520f9b5ef7bc94a3 )
+)
+
+game (
+	name "Mechanical Violator Hakaider - Last Judgement (Japan)"
+	description "Mechanical Violator Hakaider - Last Judgement (Japan)"
+	rom ( name "Mechanical Violator Hakaider - Last Judgement (Japan) (Track 1).bin" size 568516032 crc 3609f605 md5 36b7033fd382e1643d20d2cfa9ef2c12 sha1 5a8709957aa4ec7d83ded9537a86e663c113364d )
+)
+
+game (
+	name "Street Fighter II Movie (Japan) (Disc 1)"
+	description "Street Fighter II Movie (Japan) (Disc 1)"
+	rom ( name "Street Fighter II Movie (Japan) (Disc 1) (Track 1).bin" size 521396064 crc 9ea94413 md5 a8088765f14f0432522135c3c85bf0ee sha1 3ab69e5ba98b9f6af5f19408b3c0f517006a3f52 )
+)
+
+game (
+	name "Street Fighter II Movie (Japan) (Disc 2)"
+	description "Street Fighter II Movie (Japan) (Disc 2)"
+	rom ( name "Street Fighter II Movie (Japan) (Disc 2) (Track 1).bin" size 429399936 crc 196ca53f md5 ed7a4feb0645a4b7d06bc70fe41ee1dd sha1 06efbb7055c59d9d70d861543e6f34fb7430cfbd )
+)
+
+game (
+	name "Panzer Dragoon Zwei (Europe)"
+	description "Panzer Dragoon Zwei (Europe)"
+	rom ( name "Panzer Dragoon Zwei (Europe) (Track 1).bin" size 448074816 crc 41febd44 md5 dd1236c9bd477323a7970a97821ec77e sha1 c2b1dea66c7ee2a7d2664b0bb58896a9ac29bb54 )
+)
+
+game (
+	name "Wing Arms (Europe)"
+	description "Wing Arms (Europe)"
+	rom ( name "Wing Arms (Europe) (Track 01).bin" size 138481056 crc 624894e0 md5 ad21d62f409e5cf9b6552f5ce36a0805 sha1 8c54ffdc918fb06450ad5e086e45a36529bf1fd6 )
+)
+
+game (
+	name "Battle Arena Toshinden Remix (Europe)"
+	description "Battle Arena Toshinden Remix (Europe)"
+	rom ( name "Battle Arena Toshinden Remix (Europe) (Track 01).bin" size 144709152 crc 601953f1 md5 70276601780daec90623f0a6296df2bb sha1 42f63d6743d66b8b9dedd5f1baeed98d28e5f226 )
+)
+
+game (
+	name "FIFA Soccer 96 (Europe) (En,Fr,De,Es,It,Sv)"
+	description "FIFA Soccer 96 (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "FIFA Soccer 96 (Europe) (En,Fr,De,Es,It,Sv) (Track 01).bin" size 240614304 crc c026a0e9 md5 0d00974a0ebdf317411be10cbe45f996 sha1 4ed9d72f8cdc642f0eca155655ce8a787204df3e )
+)
+
+game (
+	name "FIFA 97 (Germany) (En,Fr,De,Es,It,Sv)"
+	description "FIFA 97 (Germany) (En,Fr,De,Es,It,Sv)"
+	rom ( name "FIFA 97 (Germany) (En,Fr,De,Es,It,Sv) (Track 1).bin" size 456979488 crc 00b395c4 md5 790a3f3b5207eaba5aa82882d20c579f sha1 5faebf0d2e4ff63e6bf8794c343cda07681465ba )
+)
+
+game (
+	name "FIFA 97 (Europe) (En,Fr,De,Es,It,Sv)"
+	description "FIFA 97 (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "FIFA 97 (Europe) (En,Fr,De,Es,It,Sv) (Track 1).bin" size 642799248 crc 886dcf96 md5 cef8337bb3101cee3b034ea81843640b sha1 b8767c75f0d7187a1bc1faecded0dd182de76c4b )
+)
+
+game (
+	name "Burning Rangers (Europe)"
+	description "Burning Rangers (Europe)"
+	rom ( name "Burning Rangers (Europe) (Track 1).bin" size 372436848 crc 4f129161 md5 6db07866473cf77f8c0d3afa7e22652e sha1 cd82eea106c54a85ffe1db94d03a36fec6a92a63 )
+)
+
+game (
+	name "Panzer Dragoon Saga (Europe) (Disc 1)"
+	description "Panzer Dragoon Saga (Europe) (Disc 1)"
+	rom ( name "Panzer Dragoon Saga (Europe) (Disc 1) (Track 1).bin" size 645506400 crc bc5aff1f md5 907b5351e9ebbad0b458af42518a3230 sha1 54abf937fe17851423f3cd1ad09cac5c2166cc00 )
+)
+
+game (
+	name "Panzer Dragoon Saga (Europe) (Disc 2)"
+	description "Panzer Dragoon Saga (Europe) (Disc 2)"
+	rom ( name "Panzer Dragoon Saga (Europe) (Disc 2) (Track 1).bin" size 559359696 crc ca501f15 md5 96cf5ab15fdb60bd980cee26579b55b3 sha1 bbf0be526029eb2a635d6dac325e21822b5b13cc )
+)
+
+game (
+	name "Panzer Dragoon Saga (Europe) (Disc 3)"
+	description "Panzer Dragoon Saga (Europe) (Disc 3)"
+	rom ( name "Panzer Dragoon Saga (Europe) (Disc 3) (Track 1).bin" size 632252880 crc 039b0719 md5 81f45f95f960f005d7939b10f7f00e9f sha1 486bec9f3d966f1be2e1deecac849394bf5cd9dc )
+)
+
+game (
+	name "Panzer Dragoon Saga (Europe) (Disc 4)"
+	description "Panzer Dragoon Saga (Europe) (Disc 4)"
+	rom ( name "Panzer Dragoon Saga (Europe) (Disc 4) (Track 1).bin" size 582665664 crc 5b991d30 md5 1500b6db73337075f8e9861f23d52b24 sha1 cabf3b3cb7f83a4d57f2af2157e3a413be5f30bb )
+)
+
+game (
+	name "Dragon Ball Z - La Grande Legende des Boules de Cristal (France, Spain)"
+	description "Dragon Ball Z - La Grande Legende des Boules de Cristal (France, Spain)"
+	rom ( name "Dragon Ball Z - La Grande Legende des Boules de Cristal (France, Spain) (Track 01).bin" size 434680176 crc 089a679c md5 7ec9e46f60f66b0fd20fd52e752641c0 sha1 37f8addec925f595debb93e2b68b4c0a2253d0bc )
+)
+
+game (
+	name "Virtual On - Cyber Troopers (Europe)"
+	description "Virtual On - Cyber Troopers (Europe)"
+	rom ( name "Virtual On - Cyber Troopers (Europe) (Track 01).bin" size 63892080 crc 47b88e4b md5 c1dd8cebbf98bfd1209b38ffb50b0d1d sha1 efbdf4c7e1f0eba3771300023d6e72026df5e227 )
+)
+
+game (
+	name "Earthworm Jim 2 (Europe)"
+	description "Earthworm Jim 2 (Europe)"
+	rom ( name "Earthworm Jim 2 (Europe) (Track 01).bin" size 29882160 crc 37c284b0 md5 357222c0326c81f6bc18cf5512353403 sha1 deea3289048f1731999b8eab420e34ae7ca5d62c )
+)
+
+game (
+	name "Winter Heat (Europe)"
+	description "Winter Heat (Europe)"
+	rom ( name "Winter Heat (Europe) (Track 01).bin" size 57421728 crc 523ac3ef md5 885f26f2e71f330f90432f4131603af2 sha1 30e255599f920d09af27bf5d40ffddbfba693fa7 )
+)
+
+game (
+	name "Die Hard Arcade (Europe)"
+	description "Die Hard Arcade (Europe)"
+	rom ( name "Die Hard Arcade (Europe) (Track 01).bin" size 62464416 crc 8e36d6c5 md5 0e8cbf1e22ff1256810f2fe68705050d sha1 393a940f0a3cbe82fd91cf42044685ea5d79285a )
+)
+
+game (
+	name "Mighty Hits (Europe)"
+	description "Mighty Hits (Europe)"
+	rom ( name "Mighty Hits (Europe) (Track 01).bin" size 105195552 crc be32f663 md5 3f3658d5891a6eccc208cfc95eb6ab25 sha1 2f823910640cd6f051c5ff739b16321f850b7fdd )
+)
+
+game (
+	name "Golden Axe - The Duel (Europe)"
+	description "Golden Axe - The Duel (Europe)"
+	rom ( name "Golden Axe - The Duel (Europe) (Track 01).bin" size 22807344 crc 39b62b93 md5 bb538e32f01a132194137f3f5cab5ee1 sha1 919b902a85504f410571adb38c3b3397efadbbe7 )
+)
+
+game (
+	name "Deep Fear (Europe) (Disc 1)"
+	description "Deep Fear (Europe) (Disc 1)"
+	rom ( name "Deep Fear (Europe) (Disc 1) (Track 1).bin" size 641642064 crc 7f1334dd md5 a9ab3e4174e4b1c9c6946d2bf74d8e40 sha1 13d10b96b34ca69d6dc150abbc43fb2920c0dee3 )
+)
+
+game (
+	name "Deep Fear (Europe) (Disc 2)"
+	description "Deep Fear (Europe) (Disc 2)"
+	rom ( name "Deep Fear (Europe) (Disc 2) (Track 1).bin" size 611381232 crc dfc9aa2d md5 4cb8b829edbde14c24e9ac27872db53e sha1 b6e64c18bbc6fc4cccca5241d411dfc6c98031e8 )
+)
+
+game (
+	name "Torico (Europe) (Disc 1)"
+	description "Torico (Europe) (Disc 1)"
+	rom ( name "Torico (Europe) (Disc 1) (Track 1).bin" size 656182128 crc 23cd2672 md5 65e9c5453c3b4cb2c7971ec96de471ee sha1 412143d88d7c3b1b9d02bbc5869c9982566c2947 )
+)
+
+game (
+	name "Torico (Europe) (Disc 2)"
+	description "Torico (Europe) (Disc 2)"
+	rom ( name "Torico (Europe) (Disc 2) (Track 1).bin" size 664529376 crc b92fac43 md5 4e706aaa1093237833285d9e25e6e94c sha1 89eef1765a95e0b5928a66dab0236b56f2d8ba7e )
+)
+
+game (
+	name "Enemy Zero (Europe) (Disc 0) (Opening Disc)"
+	description "Enemy Zero (Europe) (Disc 0) (Opening Disc)"
+	rom ( name "Enemy Zero (Europe) (Disc 0) (Opening Disc) (Track 1).bin" size 329082432 crc dc8861ac md5 8ad17cd01553fe85c31544a695160e6a sha1 c5d720651ea36a092ac15a04690648b5551ab12d )
+)
+
+game (
+	name "Enemy Zero (Europe) (Disc 1) (Game Disc)"
+	description "Enemy Zero (Europe) (Disc 1) (Game Disc)"
+	rom ( name "Enemy Zero (Europe) (Disc 1) (Game Disc) (Track 1).bin" size 572220432 crc 9f4741b9 md5 9f97e89dc4d1ff5e71436127bbf0b0e9 sha1 6460aab3dd194bdb668b9836a279482887268393 )
+)
+
+game (
+	name "Enemy Zero (Europe) (Disc 2) (Game Disc)"
+	description "Enemy Zero (Europe) (Disc 2) (Game Disc)"
+	rom ( name "Enemy Zero (Europe) (Disc 2) (Game Disc) (Track 1).bin" size 654039456 crc 4fd68eaa md5 55a645032d469854c3d11f8ce4f8384d sha1 eceee8e958c50b1e964f83fbf9cbf60f43447a9d )
+)
+
+game (
+	name "Enemy Zero (Europe) (Disc 3) (Game Disc)"
+	description "Enemy Zero (Europe) (Disc 3) (Game Disc)"
+	rom ( name "Enemy Zero (Europe) (Disc 3) (Game Disc) (Track 1).bin" size 484316784 crc 06fb7085 md5 19b102915ac391243c3f8b9bb32a12c2 sha1 2f4b06ead35c0ac9a488cc867aee6e96e6fee9f2 )
+)
+
+game (
+	name "Fighters Megamix (Europe)"
+	description "Fighters Megamix (Europe)"
+	rom ( name "Fighters Megamix (Europe) (Track 01).bin" size 60455808 crc fc498bd4 md5 cdade929b6413e3e522143ee6a95906c sha1 77b2963d6a6d333b7a5edb376361d3715832c0c7 )
+)
+
+game (
+	name "Keio Flying Squadron 2 (Europe)"
+	description "Keio Flying Squadron 2 (Europe)"
+	rom ( name "Keio Flying Squadron 2 (Europe) (Track 01).bin" size 163979088 crc c5eedccf md5 c0c8128c8a34da73e6847936d181ae9c sha1 e58ec445ad744075354e61b4ca629e5551361eb5 )
+)
+
+game (
+	name "Sega Ages Volume 1 (Europe)"
+	description "Sega Ages Volume 1 (Europe)"
+	rom ( name "Sega Ages Volume 1 (Europe) (Track 01).bin" size 52023888 crc 0e74a918 md5 e0cf86dbf8025bd06c0e73078b2767ef sha1 d6aad98a8bc7fc7cca24774d83d50e04d4757370 )
+)
+
+game (
+	name "Saturn Bomberman (Europe)"
+	description "Saturn Bomberman (Europe)"
+	rom ( name "Saturn Bomberman (Europe) (Track 01).bin" size 129813936 crc abc53768 md5 db8fe117be4ba5b4646be69d410f318f sha1 36d1cb71d4eb330dcaddd78d38477de074ed2143 )
+)
+
+game (
+	name "Virtua Fighter Kids (Europe)"
+	description "Virtua Fighter Kids (Europe)"
+	rom ( name "Virtua Fighter Kids (Europe) (Track 01).bin" size 184295664 crc 2c1e595b md5 de7b9e6c7f77a840090cdeed456a11d1 sha1 da7b4d815c9235ce65b0715adfba810ba5c46046 )
+)
+
+game (
+	name "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 1) (Thunder Storm)"
+	description "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 1) (Thunder Storm)"
+	rom ( name "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 1) (Thunder Storm) (Track 1).bin" size 427920528 crc 7794a4f3 md5 92d016af17fa3c8081cd8c65b9655907 sha1 948366a8b43f1ac055e40f4482c1c99d0ef90f91 )
+)
+
+game (
+	name "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 2) (Road Blaster)"
+	description "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 2) (Road Blaster)"
+	rom ( name "Interactive Movie Action - Thunder Storm & Road Blaster (Japan) (Disc 2) (Road Blaster) (Track 1).bin" size 422245152 crc 5b8d5be8 md5 e4bd6c202d52de4be15999094361ca70 sha1 eeed348168e4c1726232cb02805d7fdd24ce0302 )
+)
+
+game (
+	name "Gensou Suikoden (Japan)"
+	description "Gensou Suikoden (Japan)"
+	rom ( name "Gensou Suikoden (Japan) (Track 1).bin" size 278448576 crc 1309c0e2 md5 daa7fa4d491533d1c77e68191a6ef78a sha1 b9c598f9dec783364ddde01af1a6aea5363bae27 )
+)
+
+game (
+	name "Marie no Atelier Ver. 1.3 - Salburg no Renkinjutsushi (Japan)"
+	description "Marie no Atelier Ver. 1.3 - Salburg no Renkinjutsushi (Japan)"
+	rom ( name "Marie no Atelier Ver. 1.3 - Salburg no Renkinjutsushi (Japan) (Track 1).bin" size 18164496 crc 79c67824 md5 30772d5075339ebe57e9886ecd45432b sha1 e1ed46a6e57179df81c2b3445f05ba5ecfb8623a )
+)
+
+game (
+	name "Wizard's Harmony (Japan)"
+	description "Wizard's Harmony (Japan)"
+	rom ( name "Wizard's Harmony (Japan) (Track 01).bin" size 311141376 crc dd8a3ba8 md5 25f168b265029ed09c82f5dc2e72d1d8 sha1 12b27d25f65c0153e7bb6c555f9619ba6ba3b6f8 )
+)
+
+game (
+	name "Princess Quest (Japan)"
+	description "Princess Quest (Japan)"
+	rom ( name "Princess Quest (Japan) (Track 1).bin" size 528971856 crc 2cae805c md5 7ceb4267c1c567061c31cbd1bbe58fe7 sha1 c89045b8d6582777800e65483c6d315c85fc4103 )
+)
+
+game (
+	name "Zen Nihon Pro Wres featuring Virtua (Japan)"
+	description "Zen Nihon Pro Wres featuring Virtua (Japan)"
+	rom ( name "Zen Nihon Pro Wres featuring Virtua (Japan) (Track 1).bin" size 563369856 crc a159ee88 md5 7c547cbec4f38c8a90b45be70acde66b sha1 4e1af63e5ea71591c8e080bd70cba74275ae4e33 )
+)
+
+game (
+	name "Taklamakan - Tonkou Denki (Japan)"
+	description "Taklamakan - Tonkou Denki (Japan)"
+	rom ( name "Taklamakan - Tonkou Denki (Japan) (Track 01).bin" size 203631456 crc 7f6d47fa md5 a2fbdb1a8043b8c0e8ecf19c9b2800d5 sha1 7fcde40a905b09009ed0d4d44030b0a307889d89 )
+)
+
+game (
+	name "Gakkou no Kaidan (Japan)"
+	description "Gakkou no Kaidan (Japan)"
+	rom ( name "Gakkou no Kaidan (Japan) (Track 1).bin" size 504337008 crc 052f66e1 md5 efc943831c9c85c5029bd87d1b51fc38 sha1 e14a80005bc534a53194f844eb00259d750c2dd4 )
+)
+
+game (
+	name "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 1)"
+	description "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 1)"
+	rom ( name "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 1) (Track 1).bin" size 433995744 crc f3e14668 md5 a73be9a8de0fe6e4c995c215202b43c9 sha1 5ecaca3ada8b367a3d7ce34292d6cb5534a2a71c )
+)
+
+game (
+	name "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 2)"
+	description "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 2)"
+	rom ( name "Suchie-Pai Adventure - Doki Doki Nightmare (Japan) (Disc 2) (Track 1).bin" size 494943120 crc 60bc99ec md5 3b94471dd73efabeede9db6024d9f515 sha1 bd5485441ac5689da05b333d0f0110f1cb3b1fc9 )
+)
+
+game (
+	name "Mujintou Monogatari R - Futari no Love Love Island (Japan)"
+	description "Mujintou Monogatari R - Futari no Love Love Island (Japan)"
+	rom ( name "Mujintou Monogatari R - Futari no Love Love Island (Japan) (Track 1).bin" size 141035328 crc 6ef10359 md5 44f289c6e96ae48c4e3b379963e3a7c5 sha1 6b3da543fc9eb51191e2ca81f34794d55275eb2a )
+)
+
+game (
+	name "Pia Carrot e Youkoso!! We've Been Waiting for You (Japan)"
+	description "Pia Carrot e Youkoso!! We've Been Waiting for You (Japan)"
+	rom ( name "Pia Carrot e Youkoso!! We've Been Waiting for You (Japan) (Track 1).bin" size 499482480 crc f3410721 md5 44641f10879e2b91d3acd05032122648 sha1 4c316542d99547356d19c717452f4a5b3456caaa )
+)
+
+game (
+	name "Tenchi Muyou! Ryououki Gokuraku CD-ROM for Sega Saturn (Japan) (1M)"
+	description "Tenchi Muyou! Ryououki Gokuraku CD-ROM for Sega Saturn (Japan) (1M)"
+	rom ( name "Tenchi Muyou! Ryououki Gokuraku CD-ROM for Sega Saturn (Japan) (1M) (Track 1).bin" size 652028496 crc 42fc324d md5 51e01e517646076e851b22fdc25be4ed sha1 a2aee1289f9b55206b9db67ef3fbb728c11ad9ff )
+)
+
+game (
+	name "Doukyuusei - if (Japan) (1M, 2M)"
+	description "Doukyuusei - if (Japan) (1M, 2M)"
+	rom ( name "Doukyuusei - if (Japan) (1M, 2M) (Track 1).bin" size 362198592 crc 3050a2f7 md5 5890c90de3a6c720e80750d397722b1c sha1 70f990855fde7789fbd8d2da548c226766dbcbde )
+)
+
+game (
+	name "Yakyuuken Special, The - Kon'ya wa 12-kaisen!! (Japan) (1M)"
+	description "Yakyuuken Special, The - Kon'ya wa 12-kaisen!! (Japan) (1M)"
+	rom ( name "Yakyuuken Special, The - Kon'ya wa 12-kaisen!! (Japan) (1M) (Track 1).bin" size 633257184 crc fd5967c8 md5 1ca85649505fa8bcb5cfc1102b89ca5a sha1 b94f91310ca9002d19d503694f393eb494462a3a )
+)
+
+game (
+	name "Sotsugyou III - Wedding Bell (Japan)"
+	description "Sotsugyou III - Wedding Bell (Japan)"
+	rom ( name "Sotsugyou III - Wedding Bell (Japan) (Track 1).bin" size 131159280 crc 7b373db6 md5 5b4635e3f5261c8b24203ef8376d955e sha1 dabcb7cdb6c6194e1cd1b8bff91bf93cffb38a68 )
+)
+
+game (
+	name "Dezaemon 2 (Japan)"
+	description "Dezaemon 2 (Japan)"
+	rom ( name "Dezaemon 2 (Japan) (Track 1).bin" size 7646352 crc b8e8f0b9 md5 275573ae8e2efb011dd6147fe4a3f19d sha1 1d5999d77610b00ac778e7346eebf60aca0fb2fb )
+)
+
+game (
+	name "Sotsugyou II - Neo Generation (Japan) (1M)"
+	description "Sotsugyou II - Neo Generation (Japan) (1M)"
+	rom ( name "Sotsugyou II - Neo Generation (Japan) (1M) (Track 1).bin" size 665343168 crc af56676b md5 bc1c9ea0cc1e1160fa4433c589b80fa1 sha1 d2da6d74fc77b5fb87861fe7399bee96132c0bef )
+)
+
+game (
+	name "Mr. Bones (Japan) (Disc 1)"
+	description "Mr. Bones (Japan) (Disc 1)"
+	rom ( name "Mr. Bones (Japan) (Disc 1) (Track 01).bin" size 311541216 crc 295703ad md5 66cbbfa8e19bee154dff545e9d43208d sha1 889f15774fb04de26e4faed218a6ac7347b97bc7 )
+)
+
+game (
+	name "Mass Destruction (Europe) (En,Fr,De,Es)"
+	description "Mass Destruction (Europe) (En,Fr,De,Es)"
+	rom ( name "Mass Destruction (Europe) (En,Fr,De,Es) (Track 01).bin" size 86767632 crc 48f73dc9 md5 477553d2eb699b2cbcecabbeed521728 sha1 59693953967d3921a197feb0f1d6843fea98c382 )
+)
+
+game (
+	name "House of the Dead, The (Europe)"
+	description "House of the Dead, The (Europe)"
+	rom ( name "House of the Dead, The (Europe) (Track 01).bin" size 81235728 crc 2247bdae md5 11d0f427c8849b83cd610e063f70835f sha1 6fdca1e2f72b22593fef710d64ce6ebed93b5301 )
+)
+
+game (
+	name "Sakura Tsuushin (Japan)"
+	description "Sakura Tsuushin (Japan)"
+	rom ( name "Sakura Tsuushin (Japan) (Track 1).bin" size 453512640 crc 8369ec49 md5 37b49314f1b65aa19f5dbda40ae3106f sha1 65d99fd854930340da3e8fca731a6430e9001bd5 )
+)
+
+game (
+	name "Sword & Sorcery (Japan) (2M)"
+	description "Sword & Sorcery (Japan) (2M)"
+	rom ( name "Sword & Sorcery (Japan) (2M) (Track 1).bin" size 463082928 crc 2281dbbd md5 38bc350b6471ea6f721a9570e5de08d7 sha1 5d09e1d9dbab1768a919cb85d1ee27b3d5070961 )
+)
+
+game (
+	name "Mega Man X3 (Europe)"
+	description "Mega Man X3 (Europe)"
+	rom ( name "Mega Man X3 (Europe) (Track 01).bin" size 199668336 crc b4d040be md5 444abf55adbac1474a1021b249441154 sha1 f99ebe09d5ae5968823e13ac8bfb8a09397b2a28 )
+)
+
+game (
+	name "King of Fighters '95, The (Europe)"
+	description "King of Fighters '95, The (Europe)"
+	rom ( name "King of Fighters '95, The (Europe) (Track 01).bin" size 25876704 crc 90b548a4 md5 e9d7e302b6746d47e1e06e732207bb47 sha1 2518d7615fe62299583a980ac69c98085d99c7d6 )
+)
+
+game (
+	name "Athlete Kings (Europe)"
+	description "Athlete Kings (Europe)"
+	rom ( name "Athlete Kings (Europe) (Track 01).bin" size 34292160 crc ee36b6a1 md5 1bda03893b434b75a8c7a1f76cf7b384 sha1 da4ff7b9b4d35f5879b53e22a78ea1fffbbe39b2 )
+)
+
+game (
+	name "Daytona USA - Championship Circuit Edition (Europe) (Rev A)"
+	description "Daytona USA - Championship Circuit Edition (Europe) (Rev A)"
+	rom ( name "Daytona USA - Championship Circuit Edition (Europe) (Rev A) (Track 01).bin" size 24155040 crc 8e7ccb4d md5 2f91bed777fdbc624de6c4a18b990670 sha1 d5b98dee62e334ac0de754b72af36066616786ba )
+)
+
+game (
+	name "Tetris Plus (Europe)"
+	description "Tetris Plus (Europe)"
+	rom ( name "Tetris Plus (Europe) (Track 01).bin" size 6722016 crc 85a13ec2 md5 f4e5f6a840b58bdbe6f06c9f1307c0b6 sha1 fef8c0c104a1a3e0a826b9af0a1d9aa578166d7f )
+)
+
+game (
+	name "Fighting Vipers (Europe)"
+	description "Fighting Vipers (Europe)"
+	rom ( name "Fighting Vipers (Europe) (Track 01).bin" size 80652432 crc 62c3b096 md5 e547c0ae9f4c011cf8dd49bb9e6d4694 sha1 af9cff92de7ca88756c36914a215738cf3d691c6 )
+)
+
+game (
+	name "Darius Gaiden (Europe)"
+	description "Darius Gaiden (Europe)"
+	rom ( name "Darius Gaiden (Europe) (Track 01).bin" size 23371824 crc db020af4 md5 8bfee2b912523c0f2bd3454006407735 sha1 b3e647749c13c6bad2ae6f49878cbd10b6ee2e63 )
+)
+
+game (
+	name "Sonic 3D - Flickies' Island (Europe)"
+	description "Sonic 3D - Flickies' Island (Europe)"
+	rom ( name "Sonic 3D - Flickies' Island (Europe) (Track 01).bin" size 67704672 crc 3641d6fd md5 295497a053a7060fa2b8d0d6633f9727 sha1 3b5e0d0cf3131bd951ee8f5d406a2d7aaf12bba8 )
+)
+
+game (
+	name "Sega Touring Car Championship (Europe)"
+	description "Sega Touring Car Championship (Europe)"
+	rom ( name "Sega Touring Car Championship (Europe) (Track 01).bin" size 26826912 crc bf5bbd45 md5 9ea8e7ebcf9229ffbd48d59efa7eb695 sha1 fc2b9ee4f2bb67f9fdd44293c2afe4cb0fb59e68 )
+)
+
+game (
+	name "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (2A)"
+	description "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (2A)"
+	rom ( name "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (2A) (Track 1).bin" size 466051152 crc 15865aef md5 7f595f4e63beded0e88fd8d691cba56e sha1 e45b70cbd9dffc90cfa4dcf35cf1b032ca60aa9f )
+)
+
+game (
+	name "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan)"
+	description "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan)"
+	rom ( name "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan) (Track 01).bin" size 124119744 crc 340585ce md5 e32048a2aeff073db25a93c80e2791a5 sha1 f4712ce9d5c40c2bdcdcaa8a4939e878760e1f43 )
+)
+
+game (
+	name "Shouryuu Sangoku Engi (Japan)"
+	description "Shouryuu Sangoku Engi (Japan)"
+	rom ( name "Shouryuu Sangoku Engi (Japan) (Track 1).bin" size 86795856 crc 03295571 md5 296121633e113956521b67dfb9f4cdca sha1 3d5a81eac9fa056c069e6c5fb29d3c0c97aaa1c3 )
+)
+
+game (
+	name "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc A)"
+	description "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc A)"
+	rom ( name "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc A) (Track 1).bin" size 472657920 crc 31298439 md5 aaec2a26f36fe27b00fa2808d2171932 sha1 ad2e78450cc7f8dc583574e34b2f23296a9bc5af )
+)
+
+game (
+	name "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc B)"
+	description "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc B)"
+	rom ( name "Jikuu Tantei DD (Dracula Detective) - Maboroshi no Lorelei (Japan) (Disc B) (Track 1).bin" size 546929376 crc 0c478dd6 md5 809815680c4bc935a3669ddb15de772f sha1 d002e8497caeae9c569750ac19e18fde2efc1b06 )
+)
+
+game (
+	name "Shanghai - Banri no Choujou - The Great Wall (Japan) (1M)"
+	description "Shanghai - Banri no Choujou - The Great Wall (Japan) (1M)"
+	rom ( name "Shanghai - Banri no Choujou - The Great Wall (Japan) (1M) (Track 1).bin" size 7420560 crc de3c5c68 md5 b8fbd896cecc68518fa6de277c83b3c7 sha1 ce5e79ca773c93864f45b5d2f4aec46aae40d412 )
+)
+
+game (
+	name "Virtua Cop 2 (Japan) (Rev B) (23M)"
+	description "Virtua Cop 2 (Japan) (Rev B) (23M)"
+	rom ( name "Virtua Cop 2 (Japan) (Rev B) (23M) (Track 01).bin" size 37702560 crc 24d6cf15 md5 ad2f4f5117bbd94aced0ccfee80046ac sha1 76c897da9b06a2296fd8ba6535cb0df67938a2b8 )
+)
+
+game (
+	name "Virtua Fighter Remix (Japan) (4M)"
+	description "Virtua Fighter Remix (Japan) (4M)"
+	rom ( name "Virtua Fighter Remix (Japan) (4M) (Track 01).bin" size 13533408 crc 874d91ab md5 37c0d347cecff874931962d4fb4c7eff sha1 3d16f1e887d908e75737319467e42d694376f5a7 )
+)
+
+game (
+	name "DecAthlete (Japan) (1M)"
+	description "DecAthlete (Japan) (1M)"
+	rom ( name "DecAthlete (Japan) (1M) (Track 01).bin" size 33628896 crc 422cfec1 md5 07b25ac43b9584c4d63a35b9fa9c4770 sha1 36be9c20a017d1415b3d0ebeeda71cd95a8412cb )
+)
+
+game (
+	name "Riglordsaga 2 (Japan) (2M)"
+	description "Riglordsaga 2 (Japan) (2M)"
+	rom ( name "Riglordsaga 2 (Japan) (2M) (Track 1).bin" size 607333440 crc cf722fcf md5 0168bcf9e845aede99243d2e0743a2fb sha1 3e78011513b27fe13798ed9b152c35b63dbed751 )
+)
+
+game (
+	name "Tokimeki Memorial Drama Series Vol. 1 - Nijiiro no Seishun (Japan)"
+	description "Tokimeki Memorial Drama Series Vol. 1 - Nijiiro no Seishun (Japan)"
+	rom ( name "Tokimeki Memorial Drama Series Vol. 1 - Nijiiro no Seishun (Japan) (Track 1).bin" size 662384352 crc 41e3850d md5 3972d2df8377f99ecddcfb5f9c4f994a sha1 a707f835efd7e06913edb5aeca60ce12f0b55369 )
+)
+
+game (
+	name "Nightruth - Explanation of the Paranormal - Making of Nightruth II - Voice Selection (Japan)"
+	description "Nightruth - Explanation of the Paranormal - Making of Nightruth II - Voice Selection (Japan)"
+	rom ( name "Nightruth - Explanation of the Paranormal - Making of Nightruth II - Voice Selection (Japan) (Track 1).bin" size 46670736 crc 212b14d7 md5 dc9ee9c21323706b150decbbd497e1d4 sha1 1eab88191aa1c122d12b6d3d507c9cdbf0831cf3 )
+)
+
+game (
+	name "Pyon Pyon Kyaruru no Mahjong Hiyori (Japan) (2M)"
+	description "Pyon Pyon Kyaruru no Mahjong Hiyori (Japan) (2M)"
+	rom ( name "Pyon Pyon Kyaruru no Mahjong Hiyori (Japan) (2M) (Track 01).bin" size 201865104 crc fe239a84 md5 007965b0f5f56c878fb2cf35cce17677 sha1 750d59125636a977bcf0c81b83c7400dde2bf8ea )
+)
+
+game (
+	name "QuoVadis (Japan)"
+	description "QuoVadis (Japan)"
+	rom ( name "QuoVadis (Japan) (Track 1).bin" size 538829088 crc afce694e md5 30be178e4173cc85988f92dac6daf465 sha1 7d3fdf1fee51cf70f915bf31e58178e6e08a8523 )
+)
+
+game (
+	name "Winning Post 2 (Japan) (2M)"
+	description "Winning Post 2 (Japan) (2M)"
+	rom ( name "Winning Post 2 (Japan) (2M) (Track 1).bin" size 152496624 crc 3e16519c md5 9eb8724c9026997a20579a6e0eacca7e sha1 c39db7bb5455d7f507bd8945146a8eee1b83b18a )
+)
+
+game (
+	name "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 1) (Aquasphere) (4M)"
+	description "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 1) (Aquasphere) (4M)"
+	rom ( name "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 1) (Aquasphere) (4M) (Track 1).bin" size 428489712 crc 23b3deb6 md5 c844ce224257ac20c704d2d6e07b8604 sha1 e07dd216c45dd6b6bae0b06f69762cecc0a6d04c )
+)
+
+game (
+	name "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 2) (Landsphere) (3M)"
+	description "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 2) (Landsphere) (3M)"
+	rom ( name "Lifescape - Seimei 40 Okunen Haruka na Tabi (Japan) (Disc 2) (Landsphere) (3M) (Track 1).bin" size 453166896 crc 0d98108a md5 fa5673e26ac92f89a160bf08389ca0e4 sha1 0d4be6f29d52d20f24c9cb10f917af4fe99dde20 )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 1) (Kyoko Disc) (1M)"
+	description "Eve - The Lost One (Japan) (Disc 1) (Kyoko Disc) (1M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 1) (Kyoko Disc) (1M) (Track 1).bin" size 420586992 crc f7f49392 md5 94a8e1f1c19b6d21c260ab52d9101e64 sha1 5b161a0c1e07e79613de7a92ad248e590bb3144e )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 2) (Snake Disc) (2M)"
+	description "Eve - The Lost One (Japan) (Disc 2) (Snake Disc) (2M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 2) (Snake Disc) (2M) (Track 1).bin" size 446270832 crc 4dc4e40e md5 271b05eae5c2e58d12d0489ae12ba0f7 sha1 24fd499653106954e30bf1eb5cee68b4f09ce410 )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (1M)"
+	description "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (1M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (1M) (Track 1).bin" size 144269328 crc 9a008946 md5 5bbac24b07ee11c7c48d4c44b8503022 sha1 fa8ef8d8773fb9e641c8d5bcdbe4775e70459c56 )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (2M)"
+	description "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (2M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (2M) (Track 1).bin" size 160578096 crc a8d81cd8 md5 42ad053f87c5ada68c2919ba762cd71a sha1 c66a2110726c88ef202fc47e932f276a37ed5b4d )
+)
+
+game (
+	name "Eve - Burst Error (Japan) (Disc 1) (Kojiroh Disc)"
+	description "Eve - Burst Error (Japan) (Disc 1) (Kojiroh Disc)"
+	rom ( name "Eve - Burst Error (Japan) (Disc 1) (Kojiroh Disc) (Track 1).bin" size 310209984 crc e2c4dc85 md5 eb244c152f24e3741a1a1fa4d2f31fa8 sha1 e16ff6f141b0958918a6c5ead9663b570f877d89 )
+)
+
+game (
+	name "Eve - Burst Error (Japan) (Disc 2) (Marina Disc)"
+	description "Eve - Burst Error (Japan) (Disc 2) (Marina Disc)"
+	rom ( name "Eve - Burst Error (Japan) (Disc 2) (Marina Disc) (Track 1).bin" size 292400640 crc 448107ef md5 a28ba5957484639389b82888d8615fdf sha1 9cfdd708be03c99afc641e154efabaee9bab006b )
+)
+
+game (
+	name "Eve - Burst Error (Japan) (Disc 3) (Terror Disc)"
+	description "Eve - Burst Error (Japan) (Disc 3) (Terror Disc)"
+	rom ( name "Eve - Burst Error (Japan) (Disc 3) (Terror Disc) (Track 1).bin" size 665712432 crc 5b6fc649 md5 2a0e5c6400c0499970cd7c8dfbca0af7 sha1 a1830d35c81718ed2d7179347d6b41c810807fed )
+)
+
+game (
+	name "Eve - Burst Error (Japan) (Disc 4) (Making Disc)"
+	description "Eve - Burst Error (Japan) (Disc 4) (Making Disc)"
+	rom ( name "Eve - Burst Error (Japan) (Disc 4) (Making Disc) (Track 1).bin" size 470517600 crc ca58fcbf md5 9b9fbc8bf3bdfa5a7ed3d220c89a0aba sha1 1683e34b0a07162b729f81189b5e26f5248aefe1 )
+)
+
+game (
+	name "Baku Baku Animal - World Zookeeper Contest (Europe)"
+	description "Baku Baku Animal - World Zookeeper Contest (Europe)"
+	rom ( name "Baku Baku Animal - World Zookeeper Contest (Europe) (Track 01).bin" size 124792416 crc 5488b64a md5 9cd7b4f9db9974110e2a4854a8c3379a sha1 7e3d5c432d09c88801abf30fa17adbc3beb8d387 )
+)
+
+game (
+	name "Neon Genesis Evangelion - Digital Card Library (Japan)"
+	description "Neon Genesis Evangelion - Digital Card Library (Japan)"
+	rom ( name "Neon Genesis Evangelion - Digital Card Library (Japan) (Track 1).bin" size 623997360 crc 2312189f md5 be6ba5a8047c148ae7cd13ec8d977930 sha1 3e74cdb1b5b4c3fc5904f64b06e3a6bec0a47929 )
+)
+
+game (
+	name "RMJ - The Mystery Hospital (Japan)"
+	description "RMJ - The Mystery Hospital (Japan)"
+	rom ( name "RMJ - The Mystery Hospital (Japan) (Track 1).bin" size 595462896 crc 9ae40919 md5 58c68035118cb3d625b9a3a297a0106a sha1 cd913d09b04f38610723d4f6b447e4278134870c )
+)
+
+game (
+	name "Densetsu no Ogre Battle (Japan)"
+	description "Densetsu no Ogre Battle (Japan)"
+	rom ( name "Densetsu no Ogre Battle (Japan) (Track 01).bin" size 208906992 crc eda8e278 md5 e35664fb34da0c2af1ab44066bc16539 sha1 d18f6cebf971cd8486e8f4c79bc2c7b7f21e83b5 )
+)
+
+game (
+	name "From TV Animation Slam Dunk - I Love Basketball (Japan)"
+	description "From TV Animation Slam Dunk - I Love Basketball (Japan)"
+	rom ( name "From TV Animation Slam Dunk - I Love Basketball (Japan) (Track 1).bin" size 439816944 crc f678c87d md5 5d59d536260596dd2cb6501f255c474a sha1 b3bb3e7cfaf86c5661713ce8ac76ec317463c009 )
+)
+
+game (
+	name "Virus (Japan) (Disc 1)"
+	description "Virus (Japan) (Disc 1)"
+	rom ( name "Virus (Japan) (Disc 1) (Track 1).bin" size 523021296 crc db47fe51 md5 dcd87e1c635d247d30317e82bcdc2df7 sha1 34a18af59648d07fbab4443fc578cbf429310525 )
+)
+
+game (
+	name "Virus (Japan) (Disc 2)"
+	description "Virus (Japan) (Disc 2)"
+	rom ( name "Virus (Japan) (Disc 2) (Track 1).bin" size 478258032 crc 79294bad md5 a89378e4944bafc61df10b6913b3c968 sha1 556c319cd80821dfa78603708b67d90100c2ce40 )
+)
+
+game (
+	name "Virus (Japan) (Disc 3)"
+	description "Virus (Japan) (Disc 3)"
+	rom ( name "Virus (Japan) (Disc 3) (Track 1).bin" size 575247456 crc eedc405c md5 a2246a5ab0d98046eeb606cd9f5995cb sha1 d895ac27a46bc1b597b3e8504baed3aab8c617aa )
+)
+
+game (
+	name "Nihon Daihyou Team no Kantoku ni Naruu! Sekaihatsu Soccer RPG - Become the Coach for the National Team! (Japan)"
+	description "Nihon Daihyou Team no Kantoku ni Naruu! Sekaihatsu Soccer RPG - Become the Coach for the National Team! (Japan)"
+	rom ( name "Nihon Daihyou Team no Kantoku ni Naruu! Sekaihatsu Soccer RPG - Become the Coach for the National Team! (Japan) (Track 1).bin" size 418695984 crc 5aa58332 md5 56a29c2d0d8569e38229c87011ce8fde sha1 d6323b6d6d338df295c53c6bc3b3e9b36d6a922e )
+)
+
+game (
+	name "Clockwork Knight 2 - Pepperouchau's Adventure (Europe)"
+	description "Clockwork Knight 2 - Pepperouchau's Adventure (Europe)"
+	rom ( name "Clockwork Knight 2 - Pepperouchau's Adventure (Europe) (Track 1).bin" size 288531600 crc 632cca92 md5 db892a1825aaa7caabf2a3d6fcc23b06 sha1 4de94dff2b5e6a64b9744e68f401ddac2f202958 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1) (Track 1).bin" size 655554144 crc d7b04497 md5 6a2775388e661c2384ec3c911298a15a sha1 9abde77a4d14c62e2dcba2d58b627ed4cb0d770d )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2) (Track 1).bin" size 652296624 crc 92b0049f md5 36eac93a576c1c536863af7e66210787 sha1 d81ca4e8711d2bda775a040e9242a6c3285153f0 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (Track 1).bin" size 654709776 crc 23c25c87 md5 770ebda210ecf6299b97d5f4b9731617 sha1 2b3d50b0da785e9a4bca7175de99dd69d3511c50 )
+)
+
+game (
+	name "Virtua Fighter 2 (Japan) (Rev B)"
+	description "Virtua Fighter 2 (Japan) (Rev B)"
+	rom ( name "Virtua Fighter 2 (Japan) (Rev B) (Track 01).bin" size 61316640 crc 65c7fc1e md5 14992450395f67b251023821a4d20480 sha1 2475bfb03eeaabdfcce93bc010d7c395efdf8dce )
+)
+
+game (
+	name "Fighters Megamix (Japan)"
+	description "Fighters Megamix (Japan)"
+	rom ( name "Fighters Megamix (Japan) (Track 01).bin" size 61812912 crc 348a2dc1 md5 0232b6517e3cba3e4de7b4dfc028b7dd sha1 0945308ea66caa9b47ee5947d68f834426767455 )
+)
+
+game (
+	name "Godzilla - Rettou Shinkan (Japan)"
+	description "Godzilla - Rettou Shinkan (Japan)"
+	rom ( name "Godzilla - Rettou Shinkan (Japan) (Track 01).bin" size 179208288 crc 8dca7bc4 md5 ae5406af45a23532f7f61c1b099ea3a2 sha1 8f315f28535a6d97f422c0a1c37c0a79b2e92b0c )
+)
+
+game (
+	name "Ryuuteki Gosennen - Dragons Of China (Japan)"
+	description "Ryuuteki Gosennen - Dragons Of China (Japan)"
+	rom ( name "Ryuuteki Gosennen - Dragons Of China (Japan) (Track 1).bin" size 60975600 crc 48bfc614 md5 14fda6447d3e8c096045c25b84c654f8 sha1 d457d2cf8e8352ff9840ef079ec018f66955b3fd )
+)
+
+game (
+	name "Side Pocket 2 - Densetsu no Hustler (Japan)"
+	description "Side Pocket 2 - Densetsu no Hustler (Japan)"
+	rom ( name "Side Pocket 2 - Densetsu no Hustler (Japan) (Track 01).bin" size 429621024 crc a3ce6e2b md5 2891ed2a61f9e5fab9efd999b2d162b1 sha1 76628c239ae59167efb5e827901bca1e257150d5 )
+)
+
+game (
+	name "Mahjong Gokuu Tenjiku (Japan)"
+	description "Mahjong Gokuu Tenjiku (Japan)"
+	rom ( name "Mahjong Gokuu Tenjiku (Japan) (Track 01).bin" size 11496576 crc af52a1cd md5 b5d606214e23fe18c751098093c0e112 sha1 f61426f0f589fed3e7800e83fd4014e464cf6f88 )
+)
+
+game (
+	name "J. League Victory Goal '97 (Japan)"
+	description "J. League Victory Goal '97 (Japan)"
+	rom ( name "J. League Victory Goal '97 (Japan) (Track 1).bin" size 610988448 crc 5b97c829 md5 84f133d1569123709659f96bd97e5e75 sha1 4c740700673ab9d734a19e3654d5af8f9ac5ced3 )
+)
+
+game (
+	name "Riglordsaga (Japan) (Made in USA) (1S)"
+	description "Riglordsaga (Japan) (Made in USA) (1S)"
+	rom ( name "Riglordsaga (Japan) (Made in USA) (1S) (Track 1).bin" size 177406656 crc 9a5e51fb md5 4270c76f0492f0fc1cfec2254724f597 sha1 17e65814e5a8d8843b58c8a1191fea9109df1731 )
+)
+
+game (
+	name "Madden NFL 97 (USA)"
+	description "Madden NFL 97 (USA)"
+	rom ( name "Madden NFL 97 (USA) (Track 1).bin" size 529357584 crc fc031b1a md5 a76f984fed286b266c45284f3be1f226 sha1 445e331522bb713eef615e7476462e97cd9f98d9 )
+)
+
+game (
+	name "NHL 98 (USA)"
+	description "NHL 98 (USA)"
+	rom ( name "NHL 98 (USA) (Track 1).bin" size 535009440 crc 60d99c42 md5 a523aefdeb1b8dedd111ca08d86975e4 sha1 682b51f790cbd45c282b62169b9de1481d7ff3bd )
+)
+
+game (
+	name "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (USA)"
+	description "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (USA)"
+	rom ( name "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (USA) (Track 01).bin" size 217936320 crc d5aec3aa md5 128ce8c1c5496937547343427cd11589 sha1 434f60af487b1c5bb41efcad89482874a933088d )
+)
+
+game (
+	name "Ghen War (USA)"
+	description "Ghen War (USA)"
+	rom ( name "Ghen War (USA) (Track 01).bin" size 224928816 crc 962a1eb2 md5 94026a31dac866a03d21e08ce93c366a sha1 67cf7a1699af27d62d4a3c10fef2fbda743482ec )
+)
+
+game (
+	name "Independence Day (USA)"
+	description "Independence Day (USA)"
+	rom ( name "Independence Day (USA) (Track 1).bin" size 261450672 crc e5fa9911 md5 3e31451f87e3716604fe1b0803628134 sha1 9ad15af762021d75c00b28a0a6069e6a224fd2f8 )
+)
+
+game (
+	name "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 1)"
+	description "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 1)"
+	rom ( name "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 1) (Track 1).bin" size 165498480 crc 8c8d2039 md5 0a76a9ff4ef9ea74682092b6e39394d2 sha1 75784d7e1a93ec452a09b95155767ab3e7ec1dd0 )
+)
+
+game (
+	name "Angel Graffiti S - Anata e no Profile (Japan)"
+	description "Angel Graffiti S - Anata e no Profile (Japan)"
+	rom ( name "Angel Graffiti S - Anata e no Profile (Japan) (Track 1).bin" size 327130272 crc 422c8841 md5 76b9cb6e6c36f27cd78dfedb90dfb81f sha1 8807bad6bbc63d7a102540d59f3cde047dd1976a )
+)
+
+game (
+	name "Worldwide Soccer - Sega International Victory Goal Edition (USA) (RE)"
+	description "Worldwide Soccer - Sega International Victory Goal Edition (USA) (RE)"
+	rom ( name "Worldwide Soccer - Sega International Victory Goal Edition (USA) (RE) (Track 01).bin" size 149340240 crc 40c99930 md5 bce791b393a3561bb225daecacfe830d sha1 cd1635a5a3eddba5232d7e7150c202ddaeb1eda2 )
+)
+
+game (
+	name "Mahjong Hyper Reaction R (Japan)"
+	description "Mahjong Hyper Reaction R (Japan)"
+	rom ( name "Mahjong Hyper Reaction R (Japan) (Track 01).bin" size 165460848 crc b48b6f7a md5 abdde205263b4c3b87359d1bf9a710bd sha1 5dbb2fcb93e0246d465eea75516cf41e5612dd04 )
+)
+
+game (
+	name "Mahjong Kaigan Monogatari - Mahjong-kyou Jidai Sexy Idol-hen (Japan) (2M)"
+	description "Mahjong Kaigan Monogatari - Mahjong-kyou Jidai Sexy Idol-hen (Japan) (2M)"
+	rom ( name "Mahjong Kaigan Monogatari - Mahjong-kyou Jidai Sexy Idol-hen (Japan) (2M) (Track 01).bin" size 229301184 crc bdd4723f md5 864de5bb74d286c0b6dc4db66000bfd5 sha1 eac9a13b48e6353d4b4789cccf631b0336a13dac )
+)
+
+game (
+	name "Beach de Riichi! (Japan)"
+	description "Beach de Riichi! (Japan)"
+	rom ( name "Beach de Riichi! (Japan) (Track 1).bin" size 283176096 crc 7c7731df md5 f4ed3a354a06dc9c3c442c5ea1e341ad sha1 770b80a57c3b3a90ea7ba297339b880e887d0117 )
+)
+
+game (
+	name "Gal Jan (Japan)"
+	description "Gal Jan (Japan)"
+	rom ( name "Gal Jan (Japan) (Track 1).bin" size 25081728 crc d24b46ef md5 a44d1d52721a871b014d3a02aa02c60a sha1 ccb31adb62e990e1848ca0a873b77b9b9ca48770 )
+)
+
+game (
+	name "Lovely Pop 2 in 1 - Jan Jan Koi Shimasho (Japan)"
+	description "Lovely Pop 2 in 1 - Jan Jan Koi Shimasho (Japan)"
+	rom ( name "Lovely Pop 2 in 1 - Jan Jan Koi Shimasho (Japan) (Track 1).bin" size 342853392 crc 0f884c78 md5 31cbddfa3fca20ae1f16e3bf70d8c280 sha1 80ba43de1441661b3859f429c064058b3603b8ae )
+)
+
+game (
+	name "Idol Mahjong Final Romance R (Japan)"
+	description "Idol Mahjong Final Romance R (Japan)"
+	rom ( name "Idol Mahjong Final Romance R (Japan) (Track 01).bin" size 149535456 crc 55e160f5 md5 8ece1f56939dce9ba5679015ea8cace9 sha1 2d12e26747034b4385e0b61164c2e715cc403cd1 )
+)
+
+game (
+	name "Gyuwambler Jiko Chuushinha - Tokyo Mahjongland (Japan)"
+	description "Gyuwambler Jiko Chuushinha - Tokyo Mahjongland (Japan)"
+	rom ( name "Gyuwambler Jiko Chuushinha - Tokyo Mahjongland (Japan) (Track 01).bin" size 227464272 crc becbcfdf md5 06dced593e265352006c28d9815ee375 sha1 0e4a32148044b71aeb8a148102e7544c0f859340 )
+)
+
+game (
+	name "Idol Mahjong Final Romance 2 (Japan)"
+	description "Idol Mahjong Final Romance 2 (Japan)"
+	rom ( name "Idol Mahjong Final Romance 2 (Japan) (Track 01).bin" size 13921488 crc eddb6ddb md5 fd8f45cb540490179d317c298c93035d sha1 d53a5ca99617494678c42df815e3df4c5ac7451f )
+)
+
+game (
+	name "Jantei Battle Cos-Player (Japan) (Disc 1)"
+	description "Jantei Battle Cos-Player (Japan) (Disc 1)"
+	rom ( name "Jantei Battle Cos-Player (Japan) (Disc 1) (Track 1).bin" size 545106576 crc e56419af md5 6de77832f7ebb58528e9224cceb54fad sha1 37b6131ade15a379a58adb7e049427207efc1d87 )
+)
+
+game (
+	name "Daytona USA (Europe) (2S)"
+	description "Daytona USA (Europe) (2S)"
+	rom ( name "Daytona USA (Europe) (2S) (Track 01).bin" size 9553824 crc 2f262beb md5 d29c54c6e01cb9e5c2c470fe653398cc sha1 a326849e3d86c554afa1d3fe100a3c817721d707 )
+)
+
+game (
+	name "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)"
+	description "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)"
+	rom ( name "Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan) (Track 01).bin" size 430310160 crc 6f60e4fb md5 182581d20df20fb88586f3304a0243bb sha1 1a127c27b17fe9d4c067fb3b1e0197dad772a9bf )
+)
+
+game (
+	name "Fighters Megamix (Japan) (1M)"
+	description "Fighters Megamix (Japan) (1M)"
+	rom ( name "Fighters Megamix (Japan) (1M) (Track 01).bin" size 61812912 crc 348a2dc1 md5 0232b6517e3cba3e4de7b4dfc028b7dd sha1 0945308ea66caa9b47ee5947d68f834426767455 )
+)
+
+game (
+	name "Last Bronx (Japan) (Disc 1) (Arcade Disc)"
+	description "Last Bronx (Japan) (Disc 1) (Arcade Disc)"
+	rom ( name "Last Bronx (Japan) (Disc 1) (Arcade Disc) (Track 01).bin" size 1053696 crc fb1a3516 md5 04e18ea40b07b10a115bc9a4c734d4b7 sha1 685ece7c8d9b5dd9e87fd50fb33bd938054db2bf )
+)
+
+game (
+	name "Last Bronx (Japan) (Disc 2) (Special Disc)"
+	description "Last Bronx (Japan) (Disc 2) (Special Disc)"
+	rom ( name "Last Bronx (Japan) (Disc 2) (Special Disc) (Track 01).bin" size 999600 crc 97c95b96 md5 f793cca5d01111186927024f6cde289a sha1 88fb0aecba795f482a28fa8a92b745b9dfaf2d4d )
+)
+
+game (
+	name "Virtua Fighter Kids (Japan)"
+	description "Virtua Fighter Kids (Japan)"
+	rom ( name "Virtua Fighter Kids (Japan) (Track 01).bin" size 184290960 crc 7b5caa4c md5 60dc010de2cd684a4a07aa8c52616d1b sha1 4493150657714862cbba91786378d4cb2cbbefbd )
+)
+
+game (
+	name "Virtua Fighter 2 (Japan) (Rev B) (32B, 37M)"
+	description "Virtua Fighter 2 (Japan) (Rev B) (32B, 37M)"
+	rom ( name "Virtua Fighter 2 (Japan) (Rev B) (32B, 37M) (Track 01).bin" size 61316640 crc 65c7fc1e md5 14992450395f67b251023821a4d20480 sha1 2475bfb03eeaabdfcce93bc010d7c395efdf8dce )
+)
+
+game (
+	name "Funky Head Boxers (Japan)"
+	description "Funky Head Boxers (Japan)"
+	rom ( name "Funky Head Boxers (Japan) (Track 1).bin" size 200192832 crc 4debf7e3 md5 3e50a3bb73e5d2dd18f2c47c9c5719d3 sha1 2c882b7b3621f76558bac61d8eaacbae67f008db )
+)
+
+game (
+	name "King of Fighters '97, The (Japan)"
+	description "King of Fighters '97, The (Japan)"
+	rom ( name "King of Fighters '97, The (Japan) (Track 01).bin" size 57485232 crc 04ed57a2 md5 dfbaef68dae4b9b8085581dab6b3bf3a sha1 2723b0540455c59c3e7e948544906185bf66df35 )
+)
+
+game (
+	name "Toh Shin Den S (Japan)"
+	description "Toh Shin Den S (Japan)"
+	rom ( name "Toh Shin Den S (Japan) (Track 01).bin" size 161525952 crc 34c1a752 md5 a8ef7d7a87e3d88e7ce45325ac899a64 sha1 ef464b9187539cbde895558339092ac2deda39ad )
+)
+
+game (
+	name "Toh Shin Den URA (Japan)"
+	description "Toh Shin Den URA (Japan)"
+	rom ( name "Toh Shin Den URA (Japan) (Track 01).bin" size 82371744 crc dcde1979 md5 80e6dfb12f2ff77d15385b4e787a3d30 sha1 1bcd7e85b362ed83db28058ea6b654df5e147508 )
+)
+
+game (
+	name "Legend of K-1 - Grand Prix '96 (Japan)"
+	description "Legend of K-1 - Grand Prix '96 (Japan)"
+	rom ( name "Legend of K-1 - Grand Prix '96 (Japan) (Track 1).bin" size 606625488 crc 17ff9df3 md5 90cf520c19a1471bcd1146197aa30406 sha1 8bdc4b38ddde7724cd4a6ba86c889521353f44f7 )
+)
+
+game (
+	name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 1)"
+	description "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 1)"
+	rom ( name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 1) (Track 1).bin" size 395912160 crc 5ece48e8 md5 61e7d5af61605bcd80bc24dc37848b74 sha1 0f79104dcd548a468b23faab5c15a7392eb5ef52 )
+)
+
+game (
+	name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 2)"
+	description "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 2)"
+	rom ( name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 2) (Track 1).bin" size 340078032 crc 6e97c6ee md5 b40fa77a6c1c84079aaaf79714aadf29 sha1 9f1eeb46446bd623b13b141b29f06c4200cc6aa4 )
+)
+
+game (
+	name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 3) (Special CD-ROM)"
+	description "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 3) (Special CD-ROM)"
+	rom ( name "3x3 Eyes - Kyuusei Koushu S (Japan) (Disc 3) (Special CD-ROM) (Track 1).bin" size 465044496 crc aab28a81 md5 fa3b167daac0a3d2e6c8fe05145205ba sha1 9ae07dbd30affa883682683d445218756063b4d6 )
+)
+
+game (
+	name "Three Dirty Dwarves (USA) (RE)"
+	description "Three Dirty Dwarves (USA) (RE)"
+	rom ( name "Three Dirty Dwarves (USA) (RE) (Track 1).bin" size 190095696 crc a68779b5 md5 14aad12cee42a5d1119cf3c8560e7d3a sha1 a70266eb11ecf395764835b2f560ba1247b7a359 )
+)
+
+game (
+	name "Resident Evil (USA)"
+	description "Resident Evil (USA)"
+	rom ( name "Resident Evil (USA) (Track 1).bin" size 585274032 crc f712365e md5 ffe9b7018da54b90dc6ab9f948b12ed8 sha1 c7af9583f864feaf353ca447bad0092e5982d6b5 )
+)
+
+game (
+	name "Alien Trilogy (Japan)"
+	description "Alien Trilogy (Japan)"
+	rom ( name "Alien Trilogy (Japan) (Track 01).bin" size 134372112 crc 50f93271 md5 2be98a3adcb7e3a0cbac915e6b931fff sha1 66245859f7b4c101637fff6563ea6234dd8d139a )
+)
+
+game (
+	name "Virtua Fighter 2 (Japan) (Rev B) (35C)"
+	description "Virtua Fighter 2 (Japan) (Rev B) (35C)"
+	rom ( name "Virtua Fighter 2 (Japan) (Rev B) (35C) (Track 01).bin" size 61316640 crc 65c7fc1e md5 14992450395f67b251023821a4d20480 sha1 2475bfb03eeaabdfcce93bc010d7c395efdf8dce )
+)
+
+game (
+	name "Myst (Korea)"
+	description "Myst (Korea)"
+	rom ( name "Myst (Korea) (Track 1).bin" size 594296304 crc c5da4021 md5 04254cf8d630f2257815c36aa182ff8f sha1 cbe30fbb8c39ce5b875b47965529bc0b22718948 )
+)
+
+game (
+	name "Mr. Bones (USA) (Disc 1)"
+	description "Mr. Bones (USA) (Disc 1)"
+	rom ( name "Mr. Bones (USA) (Disc 1) (Track 01).bin" size 342317136 crc 9e540fd2 md5 3a96d13c14b329946c1eaf5efbe03eab sha1 b179ecd17ce133925f598c0734fccdf2b9e02db5 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (USA)"
+	description "Mortal Kombat Trilogy (USA)"
+	rom ( name "Mortal Kombat Trilogy (USA) (Track 01).bin" size 56010528 crc e876c99e md5 8c1c7fab8c5894a1838c2fc5b9448d1a sha1 75e57bc7536efacb1c90f34baf2eded0a2bfab1a )
+)
+
+game (
+	name "Mr. Bones (USA) (Disc 2)"
+	description "Mr. Bones (USA) (Disc 2)"
+	rom ( name "Mr. Bones (USA) (Disc 2) (Track 01).bin" size 300442128 crc dee00923 md5 b1aebb2ed25fbc028195a0406c51fb9a sha1 3e03182fab54418f3e5616df4144531ca447320d )
+)
+
+game (
+	name "Fighting Vipers (Korea)"
+	description "Fighting Vipers (Korea)"
+	rom ( name "Fighting Vipers (Korea) (Track 01).bin" size 80652432 crc d9217229 md5 aa0a032104645ed70a538451b68bc079 sha1 167bec4833dac3ff23c1efb9e3bc22ebeb146f7d )
+)
+
+game (
+	name "Worldwide Soccer '98 (USA) (En,Fr,Es)"
+	description "Worldwide Soccer '98 (USA) (En,Fr,Es)"
+	rom ( name "Worldwide Soccer '98 (USA) (En,Fr,Es) (Track 1).bin" size 262756032 crc 938b3061 md5 e4394f243d6520d1d201c29cbbe4a3e9 sha1 9df512653f9e53523325ce0b48b27d931706d480 )
+)
+
+game (
+	name "Worldwide Soccer - Sega International Victory Goal Edition (Korea)"
+	description "Worldwide Soccer - Sega International Victory Goal Edition (Korea)"
+	rom ( name "Worldwide Soccer - Sega International Victory Goal Edition (Korea) (Track 01).bin" size 149340240 crc 40c99930 md5 bce791b393a3561bb225daecacfe830d sha1 cd1635a5a3eddba5232d7e7150c202ddaeb1eda2 )
+)
+
+game (
+	name "Quake (Europe)"
+	description "Quake (Europe)"
+	rom ( name "Quake (Europe) (Track 01).bin" size 66222912 crc 8576c9e3 md5 806564c22b4c9af8597deb44fd2184a9 sha1 06675ba0c372f0236dc276e44f298708ba8ab533 )
+)
+
+game (
+	name "Riven - A Sequencia de Myst (Brazil) (Disc 1)"
+	description "Riven - A Sequencia de Myst (Brazil) (Disc 1)"
+	rom ( name "Riven - A Sequencia de Myst (Brazil) (Disc 1) (Track 1).bin" size 480297216 crc 74730dbd md5 f89f176e02d86063c6185e6c66ba34f7 sha1 7d033a09bfb43ed49a4b5211b670dd488d2ce9bb )
+)
+
+game (
+	name "Riven - A Sequencia de Myst (Brazil) (Disc 2)"
+	description "Riven - A Sequencia de Myst (Brazil) (Disc 2)"
+	rom ( name "Riven - A Sequencia de Myst (Brazil) (Disc 2) (Track 1).bin" size 483728784 crc 92f4bf49 md5 9c47c350a829469567a45643d5571c79 sha1 64709467b021a667a9cecb1167c24bcd5ea764bc )
+)
+
+game (
+	name "Riven - A Sequencia de Myst (Brazil) (Disc 3)"
+	description "Riven - A Sequencia de Myst (Brazil) (Disc 3)"
+	rom ( name "Riven - A Sequencia de Myst (Brazil) (Disc 3) (Track 1).bin" size 457875600 crc 8455a14f md5 e5625e05c4e386ddf906bb3c8644188d sha1 daa5e2515d1cf33e5b10a4d789361b704e1007b5 )
+)
+
+game (
+	name "Riven - A Sequencia de Myst (Brazil) (Disc 4)"
+	description "Riven - A Sequencia de Myst (Brazil) (Disc 4)"
+	rom ( name "Riven - A Sequencia de Myst (Brazil) (Disc 4) (Track 1).bin" size 392541744 crc 317ff550 md5 6a41c4f0af1437e7887bcbafbb7bba61 sha1 714b8a00e2d11806d1385d6878baa3dc486d5e87 )
+)
+
+game (
+	name "Gex (USA)"
+	description "Gex (USA)"
+	rom ( name "Gex (USA) (Track 1).bin" size 271465488 crc 60208339 md5 4b7ebf6d85a42a3476d7f30799fc8718 sha1 6709b72210b54de74c4184757b4459a43e733612 )
+)
+
+game (
+	name "Panzer Dragoon (USA)"
+	description "Panzer Dragoon (USA)"
+	rom ( name "Panzer Dragoon (USA) (Track 01).bin" size 254982672 crc 8480ce97 md5 d66e9a49ac6260d51d705b09d76b4311 sha1 432be537ac5f0454d21e83ab33497d70c4f2a77a )
+)
+
+game (
+	name "X-Men - Children of the Atom (USA)"
+	description "X-Men - Children of the Atom (USA)"
+	rom ( name "X-Men - Children of the Atom (USA) (Track 01).bin" size 59472672 crc 7c9ff6a9 md5 0a5ddb769d1e941a590d118d10a79382 sha1 eed819c2d2fc267fb0c95714b8d4f79262b64dfa )
+)
+
+game (
+	name "Ultimate Mortal Kombat 3 (USA)"
+	description "Ultimate Mortal Kombat 3 (USA)"
+	rom ( name "Ultimate Mortal Kombat 3 (USA) (Track 01).bin" size 49274400 crc 108223dc md5 7c57f31db0b4b2e732799df10c7c5fca sha1 514f41d5d9376b97be164e637b6acf7c70bc87d0 )
+)
+
+game (
+	name "Bootleg Sampler (USA)"
+	description "Bootleg Sampler (USA)"
+	rom ( name "Bootleg Sampler (USA) (Track 1).bin" size 328343904 crc 8491571e md5 f210849659298ec9900567c9da3ddf8b sha1 f76d3df80bac3b5507d35df4a94357577bc02140 )
+)
+
+game (
+	name "Sega Screams Volume 1 (USA)"
+	description "Sega Screams Volume 1 (USA)"
+	rom ( name "Sega Screams Volume 1 (USA) (Track 01).bin" size 396394320 crc 9a44e240 md5 90d808a99b2ece485b8920c4ff7f8e50 sha1 55d5e05d4b657b59b7b0f19d2b27de9fb29edb0a )
+)
+
+game (
+	name "Daytona USA (USA)"
+	description "Daytona USA (USA)"
+	rom ( name "Daytona USA (USA) (Track 01).bin" size 9551472 crc 302a51b7 md5 9138d2f1c105422cfc9162224d924246 sha1 6078e96e563273980e01740b4717dcfbd45cf19c )
+)
+
+game (
+	name "Panzer Dragoon (USA) (Playable Preview) (4S)"
+	description "Panzer Dragoon (USA) (Playable Preview) (4S)"
+	rom ( name "Panzer Dragoon (USA) (Playable Preview) (4S) (Track 1).bin" size 33998160 crc 32cb1172 md5 cd17efc5f8c5a85c3d3aa05932a5e1e9 sha1 fdf7e265308be930accec259c5afe5bc2e83acef )
+)
+
+game (
+	name "Rayman (USA) (Playable Game Preview)"
+	description "Rayman (USA) (Playable Game Preview)"
+	rom ( name "Rayman (USA) (Playable Game Preview) (Track 01).bin" size 67208400 crc b92b6872 md5 6ff4b3ab8c3d66059eefcd6fb893e016 sha1 e50691cea06e3fcf54cb0d474a565b53c5ec10e7 )
+)
+
+game (
+	name "Ultimate Mortal Kombat 3 (Europe) (Rev A)"
+	description "Ultimate Mortal Kombat 3 (Europe) (Rev A)"
+	rom ( name "Ultimate Mortal Kombat 3 (Europe) (Rev A) (Track 01).bin" size 49304976 crc 3e8dcbff md5 a350cb272a0badd5adb419dd35eb8580 sha1 efdf5fd7e3962cd8fe179a8201a8ca4aeb59a725 )
+)
+
+game (
+	name "Dragon Force (Europe)"
+	description "Dragon Force (Europe)"
+	rom ( name "Dragon Force (Europe) (Track 1).bin" size 661253040 crc 50c3f72a md5 766de5b8e2ed65951bdb530d97a6ed39 sha1 d50ade025f1f6c10ae555529838bfe84f397755c )
+)
+
+game (
+	name "Street Fighter - The Movie (Europe) (4S)"
+	description "Street Fighter - The Movie (Europe) (4S)"
+	rom ( name "Street Fighter - The Movie (Europe) (4S) (Track 01).bin" size 318672480 crc 0685d1d8 md5 ad77ddbbe86b7ae769d6089c1d262114 sha1 d14c44b7d024ee1a6b53a16f69cc66ed84edbbd4 )
+)
+
+game (
+	name "SimCity 2000 (Europe)"
+	description "SimCity 2000 (Europe)"
+	rom ( name "SimCity 2000 (Europe) (Track 1).bin" size 192506496 crc ad04b253 md5 ec908556942e35a00c8bcc05bdc2f4b7 sha1 5ab387bb9bcc9f640188250f5af342e0d9e08faf )
+)
+
+game (
+	name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es)"
+	description "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es)"
+	rom ( name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Track 1).bin" size 263369904 crc bbcb8e1e md5 821385409f86a766a0cd7a384821f5df sha1 3c3852e13fadf42778b6d27dd6e14e49a1d7fa07 )
+)
+
+game (
+	name "Bootleg Sampler (Europe) (Made in EU)"
+	description "Bootleg Sampler (Europe) (Made in EU)"
+	rom ( name "Bootleg Sampler (Europe) (Made in EU) (Track 01).bin" size 365524320 crc f2455e56 md5 0cfae7291cd1c9ceac54173eb4704df1 sha1 0f32465dbbe7585beb14d4e6ec77ef6b1aae5cf9 )
+)
+
+game (
+	name "Shining Wisdom (Japan)"
+	description "Shining Wisdom (Japan)"
+	rom ( name "Shining Wisdom (Japan) (Track 1).bin" size 93303840 crc c65f1794 md5 00837f5a7226d3b94eb4e77a9450a129 sha1 985c7f63be8f6181011d3effa7e3a45b9f87eefc )
+)
+
+game (
+	name "Destruction Derby (Europe)"
+	description "Destruction Derby (Europe)"
+	rom ( name "Destruction Derby (Europe) (Track 01).bin" size 15579648 crc 9e1636d4 md5 8505588d8fabac95457a0a230322d5c9 sha1 d2c21b3af539529ae76830898e235966a414f0ed )
+)
+
+game (
+	name "Tetris Plus (USA)"
+	description "Tetris Plus (USA)"
+	rom ( name "Tetris Plus (USA) (Track 01).bin" size 6743184 crc d771bc8e md5 74abb19a44258714a50c01eaeb6c318e sha1 85b03f952938dfdd154efe009404dd29a4887dc8 )
+)
+
+game (
+	name "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 1)"
+	description "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 1)"
+	rom ( name "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 1) (Track 1).bin" size 642839232 crc 4f60c120 md5 720fdd48962341e4c74edbea23fc4b7b sha1 5a6fa32bb2b5db20f246f7e919acf60bc76ad1a7 )
+)
+
+game (
+	name "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 2)"
+	description "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 2)"
+	rom ( name "Backguiner - Yomigaeru Yuusha-tachi - Hishou-hen - Uragiri no Senjou (Japan) (Disc 2) (Track 1).bin" size 628456752 crc ebe072c6 md5 c002e226a990d3060fc5c1f224ff8f11 sha1 abb62925fe0c66e821b2b8ca2c6774db03516d13 )
+)
+
+game (
+	name "Tomb Raider (USA)"
+	description "Tomb Raider (USA)"
+	rom ( name "Tomb Raider (USA) (Track 01).bin" size 207171216 crc 97c37b06 md5 00302d2af6663db595387b018141c23a sha1 4ecca92d2c381edbe72acc32ac7dce2ffe6bac1d )
+)
+
+game (
+	name "Pinball Graffiti (Europe)"
+	description "Pinball Graffiti (Europe)"
+	rom ( name "Pinball Graffiti (Europe) (Track 01).bin" size 10167696 crc c0c37524 md5 c1481d70d35735651deb0e6a4e183a08 sha1 9f35d48e01c89b1b5d00640dc9a21264534eb8c3 )
+)
+
+game (
+	name "NBA Live 98 (USA)"
+	description "NBA Live 98 (USA)"
+	rom ( name "NBA Live 98 (USA) (Track 1).bin" size 509713680 crc 91f39d80 md5 a897cba583d83f616664ca97d45110f1 sha1 7aecc534ede098e961d40d616e9cbe7984fed4d4 )
+)
+
+game (
+	name "Terry Pratchett's Discworld (Europe) (En,Fr,De,Es,It)"
+	description "Terry Pratchett's Discworld (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Terry Pratchett's Discworld (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 506644320 crc 67d5f2a4 md5 c80b034910b888d22e15f1ed9928209e sha1 949156dbb86d0167af8152cd5e4a1525e0ab1f98 )
+)
+
+game (
+	name "Discworld II - Missing Presumed...! (Europe) (En,Fr,De,Es,It)"
+	description "Discworld II - Missing Presumed...! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Discworld II - Missing Presumed...! (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 558472992 crc 625b133d md5 c5f990db6a4851b722dfb5051fc02dbd sha1 0c783b33dd84b9019270c32f7b93c25454ac22c7 )
+)
+
+game (
+	name "Digital Pinball (Europe)"
+	description "Digital Pinball (Europe)"
+	rom ( name "Digital Pinball (Europe) (Track 01).bin" size 77738304 crc a3174164 md5 251b1203f0fbe1c78465634a787427bb sha1 c39abd1d739d9c4bd4e6a3e2e7e00f7e22c5e8dd )
+)
+
+game (
+	name "Darius II (Europe)"
+	description "Darius II (Europe)"
+	rom ( name "Darius II (Europe) (Track 01).bin" size 9191616 crc b0d98231 md5 4c1bd6cf6d8668c3c1a9f1286d388b61 sha1 6a0e850648803e5fd0d8b1112f4729cd515e4317 )
+)
+
+game (
+	name "Area 51 (Europe) (En,Fr,De,Es)"
+	description "Area 51 (Europe) (En,Fr,De,Es)"
+	rom ( name "Area 51 (Europe) (En,Fr,De,Es) (Track 1).bin" size 382689216 crc e2c05575 md5 8b734a8699534fe45182cee35f6a3d58 sha1 1b0bcf5e144059b88f68db8d2508e86d46f0d953 )
+)
+
+game (
+	name "Andretti Racing (Germany)"
+	description "Andretti Racing (Germany)"
+	rom ( name "Andretti Racing (Germany) (Track 1).bin" size 591770256 crc 90ea47fd md5 3b8c8f5386ef92043384f9303aff442f sha1 650c95e35d258d6886e9cdb8048195a6916b4d6a )
+)
+
+game (
+	name "NHL 97 (Germany)"
+	description "NHL 97 (Germany)"
+	rom ( name "NHL 97 (Germany) (Track 1).bin" size 396763584 crc 34b7fb79 md5 b17535f8b29a8c8fbdc27a6037379ccf sha1 6527984dc97e9b49f14e5707e215858b903a17d1 )
+)
+
+game (
+	name "NHL 98 (Europe)"
+	description "NHL 98 (Europe)"
+	rom ( name "NHL 98 (Europe) (Track 1).bin" size 535009440 crc 87f46702 md5 3c9e9fccbaeeec902117a38526de49f8 sha1 5df78916fa9c4abdc9226e53ab322202da2b41d9 )
+)
+
+game (
+	name "NBA Live 97 (Europe)"
+	description "NBA Live 97 (Europe)"
+	rom ( name "NBA Live 97 (Europe) (Track 1).bin" size 356807808 crc 10564d96 md5 dd0a9ce27d7a2f46c1e8fe4fe347db3e sha1 c0115cde428eb92fe6a5af14fe3294edffcb839d )
+)
+
+game (
+	name "World Series Baseball (USA)"
+	description "World Series Baseball (USA)"
+	rom ( name "World Series Baseball (USA) (Track 1).bin" size 97109376 crc aa19fed8 md5 e6b71219329b731523b64b253a2fbe78 sha1 0bf67bb689e03aaedb76d73a73d2d0af40fccaf6 )
+)
+
+game (
+	name "World Series Baseball II (USA) (1S)"
+	description "World Series Baseball II (USA) (1S)"
+	rom ( name "World Series Baseball II (USA) (1S) (Track 1).bin" size 298372368 crc 0cf1e4e9 md5 600298f488423201b4577d286d0e8446 sha1 6769b64fadb8d4b058afc36284c3544a43897707 )
+)
+
+game (
+	name "NHL All-Star Hockey 98 (USA)"
+	description "NHL All-Star Hockey 98 (USA)"
+	rom ( name "NHL All-Star Hockey 98 (USA) (Track 1).bin" size 273589344 crc 08873e66 md5 838da7a37c450f547b61042c62912943 sha1 4933713a39653752fe8f801f7f1cdf62b2f516f5 )
+)
+
+game (
+	name "NBA Action 98 (USA)"
+	description "NBA Action 98 (USA)"
+	rom ( name "NBA Action 98 (USA) (Track 1).bin" size 138810336 crc 872ce29c md5 63e311ed561ae603e6500b6bd2b70281 sha1 04966d1fdfeb46ec921eaf11a79b3c00a5f62aff )
+)
+
+game (
+	name "World Series Baseball 98 (USA)"
+	description "World Series Baseball 98 (USA)"
+	rom ( name "World Series Baseball 98 (USA) (Track 1).bin" size 389531184 crc 1fba73cb md5 2c1995df3e9a163590b3651204d2c06c sha1 fc55ec35a9f24233abcf7b537b5447b680f90f78 )
+)
+
+game (
+	name "PGA Tour 97 (USA)"
+	description "PGA Tour 97 (USA)"
+	rom ( name "PGA Tour 97 (USA) (Track 1).bin" size 276364704 crc a942d512 md5 2dcec89ec171dc45c6b07e84138f8ff0 sha1 274269eaea4017807e394804e0f27d608c4f1e93 )
+)
+
+game (
+	name "NBA Live 97 (USA)"
+	description "NBA Live 97 (USA)"
+	rom ( name "NBA Live 97 (USA) (Track 1).bin" size 356807808 crc ddd7d9bc md5 7fb0cef0eb645a3e43440d507bd2e75d sha1 44ae04b2f78924602e17da4cbda6ad1a3c8c749a )
+)
+
+game (
+	name "Incredible Hulk, The - The Pantheon Saga (Europe) (En,Fr,De,Es,It)"
+	description "Incredible Hulk, The - The Pantheon Saga (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Incredible Hulk, The - The Pantheon Saga (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 86407776 crc ac0110dd md5 267e15db59c67e0d516d93c6ecaf185f sha1 1b5418b61f55f431ab2506fc57b1778ebfb2f9ee )
+)
+
+game (
+	name "Virtua Cop (USA) (8S, 12S)"
+	description "Virtua Cop (USA) (8S, 12S)"
+	rom ( name "Virtua Cop (USA) (8S, 12S) (Track 01).bin" size 50652672 crc 340c6dd2 md5 7955f0a8773d9fff7922e72e06d6cb06 sha1 68e5614e161475407bd68de5eff6702df9f3785f )
+)
+
+game (
+	name "FIFA Soccer 97 (USA)"
+	description "FIFA Soccer 97 (USA)"
+	rom ( name "FIFA Soccer 97 (USA) (Track 1).bin" size 642799248 crc 12a71f52 md5 532687fcbc9768d8917866e25130c6a8 sha1 51e33fc2e793a2a3b17cc2466aa4e90d03a7d0f9 )
+)
+
+game (
+	name "Black Fire (USA)"
+	description "Black Fire (USA)"
+	rom ( name "Black Fire (USA) (Track 1).bin" size 358705872 crc 4b372388 md5 6342c7c4c40c709862cbea25821b2eb1 sha1 452ebf5130e88893d906b7424a2f5d3be15bc621 )
+)
+
+game (
+	name "Bases Loaded '96 - Double Header (USA)"
+	description "Bases Loaded '96 - Double Header (USA)"
+	rom ( name "Bases Loaded '96 - Double Header (USA) (Track 1).bin" size 84013440 crc 4755cf18 md5 5d26c5adebbe6500babe74cb3f267141 sha1 3b13c3d8daf38aa9c38af17cc02962fcb232011a )
+)
+
+game (
+	name "Last Bronx (Europe)"
+	description "Last Bronx (Europe)"
+	rom ( name "Last Bronx (Europe) (Track 01).bin" size 2283792 crc 98b3c93a md5 4ac09ea7ade738e5047f9d147ea3dc9a sha1 93c4556a49d00006507d344b69aae438f2c63eaa )
+)
+
+game (
+	name "Andretti Racing (USA)"
+	description "Andretti Racing (USA)"
+	rom ( name "Andretti Racing (USA) (Track 1).bin" size 598496976 crc 26ae8b30 md5 e12f38d3549282a9324dc2dfde88348d sha1 618a1ef108fb9f235be11ebc7d20bea576c71e8f )
+)
+
+game (
+	name "NBA Action (USA)"
+	description "NBA Action (USA)"
+	rom ( name "NBA Action (USA) (Track 01).bin" size 196678944 crc 195e2507 md5 f52866d6f6bda9acd305bac749b4efe8 sha1 bf48677838184fad9a5c609f9eb6f74f266a3bcc )
+)
+
+game (
+	name "Actua Soccer - Club Edition (Europe)"
+	description "Actua Soccer - Club Edition (Europe)"
+	rom ( name "Actua Soccer - Club Edition (Europe) (Track 1).bin" size 167365968 crc 9aca8e86 md5 84a5429e4640c3b57052e08f5d1fe486 sha1 e811622b21b1b37cc0e0c50c5bc7154d99b58ac7 )
+)
+
+game (
+	name "Magic Carpet (Europe) (En,Fr,De,Es,Sv)"
+	description "Magic Carpet (Europe) (En,Fr,De,Es,Sv)"
+	rom ( name "Magic Carpet (Europe) (En,Fr,De,Es,Sv) (Track 1).bin" size 81713184 crc 4005e840 md5 5c52ea8d1614fc7f846360aa50d09a7d sha1 8e689320ceeebe77cfa5ffb4ec7c6f2fd6c8efe1 )
+)
+
+game (
+	name "Virtua Fighter 2 (USA)"
+	description "Virtua Fighter 2 (USA)"
+	rom ( name "Virtua Fighter 2 (USA) (Track 01).bin" size 60267648 crc 2cea1d09 md5 faffd0c8b1832b376aab5e98fe466043 sha1 28e0b690ffb61ee737c7f2ccc9280185265a1096 )
+)
+
+game (
+	name "Rise 2 - Resurrection (USA) (En,Fr,De,Es,It)"
+	description "Rise 2 - Resurrection (USA) (En,Fr,De,Es,It)"
+	rom ( name "Rise 2 - Resurrection (USA) (En,Fr,De,Es,It) (Track 01).bin" size 143928288 crc f01653d6 md5 5bf5afca49997fdfc4eb5eabf83c7e96 sha1 e09f680322346d0d2164cd0eb2f65716893f6001 )
+)
+
+game (
+	name "Command & Conquer (USA) (Disc 1) (GDI Disc)"
+	description "Command & Conquer (USA) (Disc 1) (GDI Disc)"
+	rom ( name "Command & Conquer (USA) (Disc 1) (GDI Disc) (Track 01).bin" size 390747168 crc 3bdfff19 md5 cc0200f85f46679e7fe1445b56a2a196 sha1 dd073bd7e20ec8233718fdff2947bf1ca5c36ed3 )
+)
+
+game (
+	name "Command & Conquer (USA) (Disc 2) (NOD Disc)"
+	description "Command & Conquer (USA) (Disc 2) (NOD Disc)"
+	rom ( name "Command & Conquer (USA) (Disc 2) (NOD Disc) (Track 01).bin" size 322320432 crc 7b441190 md5 092d28dd20cedaa04d69a9be19b7de4b sha1 1005081671bcaf2db906eea0f5d9174a767e09f1 )
+)
+
+game (
+	name "Doom (USA)"
+	description "Doom (USA)"
+	rom ( name "Doom (USA) (Track 01).bin" size 70320096 crc 5a84e39a md5 3be9f210f812dfcd6db4dff31ecb4664 sha1 693f8adc6006bcf3e552cd67dace01f451319952 )
+)
+
+game (
+	name "Alone in the Dark - Jack Is Back (Europe) (En,Fr,De,Es,It)"
+	description "Alone in the Dark - Jack Is Back (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Alone in the Dark - Jack Is Back (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 223188336 crc a1e98c27 md5 29e3d09e423cc6167fa9a7cc7b6cc260 sha1 d3a6be7c3496555ec439da37feefbf4d18304a61 )
+)
+
+game (
+	name "Alien Trilogy (Germany)"
+	description "Alien Trilogy (Germany)"
+	rom ( name "Alien Trilogy (Germany) (Track 01).bin" size 130705344 crc 70825cd8 md5 14e4b7e5a8b1bf9467cf7c3e28246283 sha1 95efeb806a50321ed293d43ea8414a839344e4cd )
+)
+
+game (
+	name "Virtua Fighter (Europe) (P2)"
+	description "Virtua Fighter (Europe) (P2)"
+	rom ( name "Virtua Fighter (Europe) (P2) (Track 01).bin" size 9318624 crc 53deaf48 md5 7d4ec77d2ebd5e16f1d50438ea4a4623 sha1 356c5aac13511bc0ac28ae9a271574996f045ecf )
+)
+
+game (
+	name "Virtual Golf (Europe)"
+	description "Virtual Golf (Europe)"
+	rom ( name "Virtual Golf (Europe) (Track 01).bin" size 26662272 crc 2a56560c md5 162b88d429b2f83e86e7e6840b8eeb30 sha1 2259181babfa6e21c6bb70b38e5b08e94ef543d4 )
+)
+
+game (
+	name "Virtual Open Tennis (Europe)"
+	description "Virtual Open Tennis (Europe)"
+	rom ( name "Virtual Open Tennis (Europe) (Track 01).bin" size 111722352 crc 6619f72c md5 cb0254dd9fd21f2a4e0d828d3e843d53 sha1 2a07290f3163d664fc000fdd26f37f8fdd399ace )
+)
+
+game (
+	name "Victory Boxing (Europe)"
+	description "Victory Boxing (Europe)"
+	rom ( name "Victory Boxing (Europe) (Track 1).bin" size 22579200 crc 73057ec6 md5 d9cb039252dcf6af44af7113140a43d7 sha1 8acb579a99dcd1250a7bb476b214e4f8334f69c9 )
+)
+
+game (
+	name "Blast Chamber (Europe) (En,Fr,De,Es,It)"
+	description "Blast Chamber (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Blast Chamber (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 90923616 crc 2a56e422 md5 b9b654990975d7c5a43462e7711c9c7d sha1 18d15521186119d3be60af0156285e528566f9ad )
+)
+
+game (
+	name "Theme Park (Europe) (En,Fr,De,Es,Sv)"
+	description "Theme Park (Europe) (En,Fr,De,Es,Sv)"
+	rom ( name "Theme Park (Europe) (En,Fr,De,Es,Sv) (Track 01).bin" size 156838416 crc 2b2bbdf3 md5 a2cd6acc680e317f1758785c1d57a938 sha1 65d0c46b23d9139caa943e9da02da1c070b21f39 )
+)
+
+game (
+	name "Battle Arena Toshinden URA - Ultimate Revenge Attack (Europe)"
+	description "Battle Arena Toshinden URA - Ultimate Revenge Attack (Europe)"
+	rom ( name "Battle Arena Toshinden URA - Ultimate Revenge Attack (Europe) (Track 01).bin" size 82526976 crc d1152b03 md5 8349c03e7d57238e27a8defcb684dc24 sha1 cdc2d014068e9c0fdf3d75b9520b3a5ebbc0e9be )
+)
+
+game (
+	name "Krazy Ivan (Europe)"
+	description "Krazy Ivan (Europe)"
+	rom ( name "Krazy Ivan (Europe) (Track 01).bin" size 330862896 crc ee8391b7 md5 f964bd0c41ea1618e12deb14340b0e6a sha1 12f95c551df2876c6f64c5602040691d6247cbe9 )
+)
+
+game (
+	name "Darklight Conflict (Europe) (En,Fr,De,Es,It,Sv)"
+	description "Darklight Conflict (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "Darklight Conflict (Europe) (En,Fr,De,Es,It,Sv) (Track 1).bin" size 114864624 crc dc5bc0b1 md5 978a5985b5fe40a176a0e218e8ca2117 sha1 834bf15ccba9ef9c44b06379cc7995cf2299109c )
+)
+
+game (
+	name "Shockwave Assault (Europe)"
+	description "Shockwave Assault (Europe)"
+	rom ( name "Shockwave Assault (Europe) (Track 1).bin" size 664821024 crc b77a1b6e md5 62d02b716d23120c60dc35e4f7bcdc39 sha1 e10effd8cb94fa2ca9fe1b276d66280e58987509 )
+)
+
+game (
+	name "Madden NFL 97 (Europe)"
+	description "Madden NFL 97 (Europe)"
+	rom ( name "Madden NFL 97 (Europe) (Track 1).bin" size 529362288 crc 19de7611 md5 ab53b8b2ca7b76e6ba2859c4cb13b8ab sha1 ef3d926929a4428d906731d127e38761bdd9f659 )
+)
+
+game (
+	name "Space Hulk - Vengeance of the Blood Angels (Europe)"
+	description "Space Hulk - Vengeance of the Blood Angels (Europe)"
+	rom ( name "Space Hulk - Vengeance of the Blood Angels (Europe) (Track 1).bin" size 449692992 crc 01d98d3c md5 a1b62cffec62705b56346cac76e909bd sha1 f918cc71ddbd4983407299578451627604af81ed )
+)
+
+game (
+	name "Crusader - No Remorse (France)"
+	description "Crusader - No Remorse (France)"
+	rom ( name "Crusader - No Remorse (France) (Track 1).bin" size 613255776 crc 9fcca30c md5 158c7cdf948693b88497ca03f11bfc81 sha1 52e5b971d5fa16b7d9abed8bb81c0cffc656a603 )
+)
+
+game (
+	name "World Series Baseball II (Europe)"
+	description "World Series Baseball II (Europe)"
+	rom ( name "World Series Baseball II (Europe) (Track 1).bin" size 238281120 crc 31dc312c md5 7797d1695d5553aaa0aed51f98baa8c7 sha1 61ba664c76d9c0538dc1f068713d4e72fb5cd318 )
+)
+
+game (
+	name "Daytona USA - Circuit Edition (Japan)"
+	description "Daytona USA - Circuit Edition (Japan)"
+	rom ( name "Daytona USA - Circuit Edition (Japan) (Track 01).bin" size 29385888 crc 401bdb48 md5 77465eb1be6cdd2981cfbf8bd3b859da sha1 f450f510f621d1d9a4c65e8c786faf65ba6d7c46 )
+)
+
+game (
+	name "D no Shokutaku (Japan) (Disc 1)"
+	description "D no Shokutaku (Japan) (Disc 1)"
+	rom ( name "D no Shokutaku (Japan) (Disc 1) (Track 1).bin" size 563064096 crc dd6522fa md5 8ebabf2b1cd866eec3b9538b5b748df5 sha1 ac553a14fb16ab6ad173f946c9b92752c751b56e )
+)
+
+game (
+	name "D no Shokutaku (Japan) (Disc 2)"
+	description "D no Shokutaku (Japan) (Disc 2)"
+	rom ( name "D no Shokutaku (Japan) (Disc 2) (Track 1).bin" size 534200352 crc 27f308e0 md5 cb8a7087dbb9b765f4772d6b02ee9994 sha1 79e928d28038a56785757187a2161e4f48ba270e )
+)
+
+game (
+	name "Rayman (Europe) (En,Fr,De) (1S)"
+	description "Rayman (Europe) (En,Fr,De) (1S)"
+	rom ( name "Rayman (Europe) (En,Fr,De) (1S) (Track 01).bin" size 152482512 crc 07997b9c md5 88bb0bfd24405d149c621fc8def64775 sha1 c92d74d4b41565804c22fcbb2b4dd8a654e82b9f )
+)
+
+game (
+	name "Layer Section (Japan) (6M)"
+	description "Layer Section (Japan) (6M)"
+	rom ( name "Layer Section (Japan) (6M) (Track 01).bin" size 16779168 crc 07e9d8da md5 4cb2552702a5767be5b791efad43762d sha1 d90ef75e7a8d0ff60fceb58d4e534308b85391ea )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (4M)"
+	description "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (4M)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (4M) (Track 1).bin" size 476717472 crc 675444b3 md5 2360f1ce1a62fd1ca6e7f923b589340e sha1 499471933b0ae793e27c4d7ced1e68537c1c42c8 )
+)
+
+game (
+	name "Fighting Vipers (Japan) (Rev C)"
+	description "Fighting Vipers (Japan) (Rev C)"
+	rom ( name "Fighting Vipers (Japan) (Rev C) (Track 01).bin" size 82893888 crc d2052063 md5 25fbac218daf59dd46f95aae437a05cf sha1 60c6cda378a9dab3b5077286d9988c407d850dbc )
+)
+
+game (
+	name "Digital Ange - Dennou Tenshi SS (Japan)"
+	description "Digital Ange - Dennou Tenshi SS (Japan)"
+	rom ( name "Digital Ange - Dennou Tenshi SS (Japan) (Track 1).bin" size 82599888 crc 464c94d8 md5 5b22f54be722a40a29ef769bc547359d sha1 23c7c14eadf9b2af6a63d0d3ea57d4e1199f7c3a )
+)
+
+game (
+	name "Dino Island (Japan) (Yokoku-hen)"
+	description "Dino Island (Japan) (Yokoku-hen)"
+	rom ( name "Dino Island (Japan) (Yokoku-hen) (Track 1).bin" size 49431984 crc 779ef372 md5 8562680a0e41be752bf3f7570fdb75b3 sha1 a32fa94f79d6124ec37e32b6aae6ff5b711d7519 )
+)
+
+game (
+	name "Meltylancer - Ginga Shoujo Keisatsu 2086 (Japan)"
+	description "Meltylancer - Ginga Shoujo Keisatsu 2086 (Japan)"
+	rom ( name "Meltylancer - Ginga Shoujo Keisatsu 2086 (Japan) (Track 1).bin" size 75616800 crc 71610423 md5 d2d4bb95a951fe1827f469a470ca2f0b sha1 739f6bffdf4376d36ff3b8ea652b667ad8fe3dd5 )
+)
+
+game (
+	name "Doukyuusei 2 (Japan) (Disc A)"
+	description "Doukyuusei 2 (Japan) (Disc A)"
+	rom ( name "Doukyuusei 2 (Japan) (Disc A) (Track 1).bin" size 581550816 crc 71471707 md5 3b9df542b5ae986946d9fa8d534d32a4 sha1 e9d88718813cc7259333b93209bf8786f0533dc7 )
+)
+
+game (
+	name "Doukyuusei 2 (Japan) (Disc B)"
+	description "Doukyuusei 2 (Japan) (Disc B)"
+	rom ( name "Doukyuusei 2 (Japan) (Disc B) (Track 1).bin" size 616376880 crc 216dc73f md5 0a7967abe4ddc209d939990bb810a77e sha1 e362a8feddaead32651f15e13dc928a780d06a76 )
+)
+
+game (
+	name "Free Talk Studio - Mari no Kimamana Oshaberi (Japan)"
+	description "Free Talk Studio - Mari no Kimamana Oshaberi (Japan)"
+	rom ( name "Free Talk Studio - Mari no Kimamana Oshaberi (Japan) (Track 1).bin" size 452868192 crc e6cc195c md5 319b9302cd77f83edab70ddc386c7c7f sha1 f5167318c84bc476f8963c12af56d940f416405d )
+)
+
+game (
+	name "DX Nihon Tokkyuu Ryokou Game - Let's Travel in Japan (Japan)"
+	description "DX Nihon Tokkyuu Ryokou Game - Let's Travel in Japan (Japan)"
+	rom ( name "DX Nihon Tokkyuu Ryokou Game - Let's Travel in Japan (Japan) (Track 1).bin" size 23275392 crc 76fbf7d0 md5 31ac21c593e60dacf2b6f5d6ca746f92 sha1 44a6c66c89deea9b921077084171b217d8d4733b )
+)
+
+game (
+	name "Gaia Breeder (Japan)"
+	description "Gaia Breeder (Japan)"
+	rom ( name "Gaia Breeder (Japan) (Track 1).bin" size 15579648 crc 2b7b75bf md5 c6c8124db2cc24e023ba8be42c0db6f1 sha1 d9f3bf0338bf490500e4eac05ad65b5f2e1b947d )
+)
+
+game (
+	name "Pebble Beach Golf Links (Europe) (3S)"
+	description "Pebble Beach Golf Links (Europe) (3S)"
+	rom ( name "Pebble Beach Golf Links (Europe) (3S) (Track 1).bin" size 422534448 crc b446142d md5 dbc4060484ab3c5bc5f7556bd2061f1b sha1 1937a17b2e157607e31e21376fcaaa35dc44adf4 )
+)
+
+game (
+	name "UEFA Euro 96 - England (Europe) (En,Fr,De,Es,It,Pt)"
+	description "UEFA Euro 96 - England (Europe) (En,Fr,De,Es,It,Pt)"
+	rom ( name "UEFA Euro 96 - England (Europe) (En,Fr,De,Es,It,Pt) (Track 1).bin" size 315676032 crc 0d5b420b md5 abcf280069ab7cbfc8d3bff318efb55a sha1 099b1936e0f5977e41d0cf389c045b93e2c5baa5 )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna - Akitaka Mika IllustWorks (Japan)"
+	description "Ginga Ojousama Densetsu Yuna - Akitaka Mika IllustWorks (Japan)"
+	rom ( name "Ginga Ojousama Densetsu Yuna - Akitaka Mika IllustWorks (Japan) (Track 1).bin" size 35327040 crc b5d81787 md5 fd8e97ac075a29967ebeb133b6f3cf92 sha1 00ed0e3b82d3765d815fe5b669083cf312aee052 )
+)
+
+game (
+	name "Last Gladiators - Digital Pinball (USA) (3S)"
+	description "Last Gladiators - Digital Pinball (USA) (3S)"
+	rom ( name "Last Gladiators - Digital Pinball (USA) (3S) (Track 01).bin" size 76508208 crc e3ecaf51 md5 ffb41618528b42b9931ea73fb147d75f sha1 fa67a8134c34b1416277dc36ecb4f76fd3b035b8 )
+)
+
+game (
+	name "Deka Yonku - Tough The Truck (Japan)"
+	description "Deka Yonku - Tough The Truck (Japan)"
+	rom ( name "Deka Yonku - Tough The Truck (Japan) (Track 1).bin" size 44205840 crc 0094f30b md5 7807d1ea0c622656eb2632f732e13b54 sha1 ce2ed046cfc0ac3547dd0cc17e756f1735f1e780 )
+)
+
+game (
+	name "Revolution X - Music Is the Weapon (Germany) (5S)"
+	description "Revolution X - Music Is the Weapon (Germany) (5S)"
+	rom ( name "Revolution X - Music Is the Weapon (Germany) (5S) (Track 01).bin" size 12477360 crc 4d289cf4 md5 95f786cb1fbeaf019f86de0df00be0e0 sha1 811e9d672269d4273d00bd1303f16a7c73ab8eec )
+)
+
+game (
+	name "Horde, The (Germany)"
+	description "Horde, The (Germany)"
+	rom ( name "Horde, The (Germany) (Track 1).bin" size 601545168 crc c73375e5 md5 45c3c8bb09d1808010b4294849f6dc3f sha1 4e11ef4ff7954deee519698243658c73730ea124 )
+)
+
+game (
+	name "Olympic Soccer (Germany)"
+	description "Olympic Soccer (Germany)"
+	rom ( name "Olympic Soccer (Germany) (Track 01).bin" size 48293616 crc 48f87fd5 md5 ac353916cedaecd31448e7b2430a9807 sha1 9cf34197b60020c6f2d973e1150eca3031c49a97 )
+)
+
+game (
+	name "Sky Target (Europe)"
+	description "Sky Target (Europe)"
+	rom ( name "Sky Target (Europe) (Track 01).bin" size 94919664 crc 29856f3f md5 ddd63e1f72d4e24da03d8cd44e133d1f sha1 a250ff2ecdbf1242fb5664ebd0b6034a7c0bb98c )
+)
+
+game (
+	name "NHL Powerplay '96 (Europe)"
+	description "NHL Powerplay '96 (Europe)"
+	rom ( name "NHL Powerplay '96 (Europe) (Track 1).bin" size 333083184 crc 2558c4a5 md5 aabec9171a4c1be7f69655e6ab570e49 sha1 94804b40ab56993f9a98ef1154a57a2a8765c7b1 )
+)
+
+game (
+	name "Formula Karts - Special Edition (Europe) (En,Fr,De,Es)"
+	description "Formula Karts - Special Edition (Europe) (En,Fr,De,Es)"
+	rom ( name "Formula Karts - Special Edition (Europe) (En,Fr,De,Es) (Track 01).bin" size 24472560 crc fe28220b md5 21ccc8c53a939efc4522dd37421214e8 sha1 7fcc394c643c54c56b4567384dc25278b8e9de66 )
+)
+
+game (
+	name "Sea Bass Fishing (Europe) (En,Fr,De)"
+	description "Sea Bass Fishing (Europe) (En,Fr,De)"
+	rom ( name "Sea Bass Fishing (Europe) (En,Fr,De) (Track 1).bin" size 177917040 crc 5a8b7c7f md5 e16071e68f21bfa30e58b52482757a59 sha1 9e3174cf99aa6c9d4fc86ebe049869f8245d4e52 )
+)
+
+game (
+	name "Striker 96 (Europe) (En,Fr,De,Es,It)"
+	description "Striker 96 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Striker 96 (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 50017632 crc 9447d248 md5 f50e5efb2214edab83e8604686eeb1da sha1 88b352cac465e16bd81182ea8d84d2ca0e602570 )
+)
+
+game (
+	name "Sky Target (Japan)"
+	description "Sky Target (Japan)"
+	rom ( name "Sky Target (Japan) (Track 01).bin" size 94830288 crc 5a08305b md5 413c031eea9167c6859c7b7d3977860e sha1 6876b090c142a794eb21e7179f2ac52da6c82d7f )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (1M)"
+	description "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (1M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 4) (Extra Disc) (1M) (Track 1).bin" size 160578096 crc a8d81cd8 md5 42ad053f87c5ada68c2919ba762cd71a sha1 c66a2110726c88ef202fc47e932f276a37ed5b4d )
+)
+
+game (
+	name "WipEout (Japan) (2M)"
+	description "WipEout (Japan) (2M)"
+	rom ( name "WipEout (Japan) (2M) (Track 01).bin" size 55956432 crc e17e75b1 md5 df859e467efd889a099bf61f5c0cabe4 sha1 5accf8bba6bfbdf1a52e0087f4a80370ef4ca2b0 )
+)
+
+game (
+	name "Last Gladiators - Digital Pinball (USA) (4S)"
+	description "Last Gladiators - Digital Pinball (USA) (4S)"
+	rom ( name "Last Gladiators - Digital Pinball (USA) (4S) (Track 01).bin" size 76508208 crc e3ecaf51 md5 ffb41618528b42b9931ea73fb147d75f sha1 fa67a8134c34b1416277dc36ecb4f76fd3b035b8 )
+)
+
+game (
+	name "Brain Battle Q (Japan)"
+	description "Brain Battle Q (Japan)"
+	rom ( name "Brain Battle Q (Japan) (Track 01).bin" size 15445584 crc ba2ef26a md5 c72dd15dce221d0d31e85dc861a05860 sha1 2e2566a4299774690b9554267ae7518fa44d5fdb )
+)
+
+game (
+	name "2do Aru Koto wa Sando R (Japan)"
+	description "2do Aru Koto wa Sando R (Japan)"
+	rom ( name "2do Aru Koto wa Sando R (Japan) (Track 1).bin" size 43606080 crc 6642e237 md5 e7f2e9369788293f761b7d02b83eec7b sha1 a094e7cb1d7c2d7ee6844ca2f8a698e7e21e67b9 )
+)
+
+game (
+	name "Pro Yakyuu Team mo Tsukurou! (Japan)"
+	description "Pro Yakyuu Team mo Tsukurou! (Japan)"
+	rom ( name "Pro Yakyuu Team mo Tsukurou! (Japan) (Track 1).bin" size 556720752 crc 8df52b89 md5 ec1255ef5a2a9e0ca9f227fe159d3360 sha1 e62bea70b6812aa1dc08c59c18bae16da2136972 )
+)
+
+game (
+	name "Momotarou Douchuuki (Japan) (2M)"
+	description "Momotarou Douchuuki (Japan) (2M)"
+	rom ( name "Momotarou Douchuuki (Japan) (2M) (Track 1).bin" size 209161008 crc 69a9fb1a md5 a7025d80f66597b8c1c2c6c3a4a2c789 sha1 b213b7f7b761fbcc0b29515a1a1061c4bfaa699f )
+)
+
+game (
+	name "Earthworm Jim 2 (USA)"
+	description "Earthworm Jim 2 (USA)"
+	rom ( name "Earthworm Jim 2 (USA) (Track 01).bin" size 29816304 crc 5fdaa32a md5 db132b4513ab55877f29af796b4161b1 sha1 82827d1c11855b931ccaf20f856e11dee49fcfdb )
+)
+
+game (
+	name "Sento Monogatari Sono I (Japan)"
+	description "Sento Monogatari Sono I (Japan)"
+	rom ( name "Sento Monogatari Sono I (Japan) (Track 1).bin" size 505941072 crc ca5fab46 md5 bc37d11cdf8e2a023087d982f3292c61 sha1 55582aa3608633447de20d75c5e18f841e18eeec )
+)
+
+game (
+	name "Actua Golf (Japan)"
+	description "Actua Golf (Japan)"
+	rom ( name "Actua Golf (Japan) (Track 1).bin" size 242380656 crc f6e86ae4 md5 3594acca1b7b2e3b6349d6bb3fe7bc7f sha1 8f8d652a4d76ad86273ecf6f4402c6b291afee20 )
+)
+
+game (
+	name "Tokuso Kidoutai J-SWAT (Japan)"
+	description "Tokuso Kidoutai J-SWAT (Japan)"
+	rom ( name "Tokuso Kidoutai J-SWAT (Japan) (Track 01).bin" size 743232 crc 773a0ee9 md5 ebc135cdb215feff498891617f119083 sha1 894e75217efee64184af6a027699640867839e88 )
+)
+
+game (
+	name "Gran Chaser (Japan) (3M)"
+	description "Gran Chaser (Japan) (3M)"
+	rom ( name "Gran Chaser (Japan) (3M) (Track 01).bin" size 45624096 crc 155508b1 md5 85d92f6b205444bcb5c4637e82b2eb25 sha1 88dbd7f9e150eb975acee455ede2bbe5e4fe3f0c )
+)
+
+game (
+	name "Race Drivin' (Japan) (2M)"
+	description "Race Drivin' (Japan) (2M)"
+	rom ( name "Race Drivin' (Japan) (2M) (Track 01).bin" size 4823952 crc 3c8caed7 md5 db4865eb2fe3fdcedb7001f6ebb0113b sha1 3c9e3ecf193950ee6470520209a9ddd87ca8289c )
+)
+
+game (
+	name "Creature Shock (Japan) (Disc 1)"
+	description "Creature Shock (Japan) (Disc 1)"
+	rom ( name "Creature Shock (Japan) (Disc 1) (Track 1).bin" size 661109568 crc 90bc63db md5 52054cb4abf481fd9f8d9f9eaea28419 sha1 9c5412f8804229291d5a6b96afb8990bcc1c9622 )
+)
+
+game (
+	name "Creature Shock (Japan) (Disc 2)"
+	description "Creature Shock (Japan) (Disc 2)"
+	rom ( name "Creature Shock (Japan) (Disc 2) (Track 1).bin" size 649396608 crc a65cb3dc md5 d99b95031342d14f712715c8fef25836 sha1 85f77686e733dfb2a820dab9ef2c8a2c62452142 )
+)
+
+game (
+	name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (1M)"
+	description "Albert Odyssey Gaiden - Legend of Eldean (Japan) (1M)"
+	rom ( name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (1M) (Track 01).bin" size 247254000 crc 4bdcb4ca md5 0097592e49699ef198187d0da798ef1c sha1 7bd618af44e7dbe210d5d41bcda68a071b65aefc )
+)
+
+game (
+	name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (2M)"
+	description "Albert Odyssey Gaiden - Legend of Eldean (Japan) (2M)"
+	rom ( name "Albert Odyssey Gaiden - Legend of Eldean (Japan) (2M) (Track 01).bin" size 247254000 crc 4bdcb4ca md5 0097592e49699ef198187d0da798ef1c sha1 7bd618af44e7dbe210d5d41bcda68a071b65aefc )
+)
+
+game (
+	name "Mansion of Hidden Souls, The (USA)"
+	description "Mansion of Hidden Souls, The (USA)"
+	rom ( name "Mansion of Hidden Souls, The (USA) (Track 1).bin" size 442517040 crc 61a3b618 md5 19e187d32fd94ef825a440647b7c1f10 sha1 747bc47cd974f0688815b40a45bda6be9df98051 )
+)
+
+game (
+	name "Angelique Special (Japan)"
+	description "Angelique Special (Japan)"
+	rom ( name "Angelique Special (Japan) (Track 01).bin" size 294174048 crc 2bb01333 md5 73473b8c8e475d0d0455105b015e6f5d sha1 4fa905149c4c2fab418e1237b35ac12125d32e15 )
+)
+
+game (
+	name "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (Europe)"
+	description "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (Europe)"
+	rom ( name "MechWarrior 2 - 31st Century Combat - Arcade Combat Edition (Europe) (Track 01).bin" size 217959840 crc 8a9ab7f8 md5 a715743d994a3791c0ef3906aab01d6a sha1 958960ba8a8acb6bc152e8903c31682ab66836fb )
+)
+
+game (
+	name "Street Racer (Europe)"
+	description "Street Racer (Europe)"
+	rom ( name "Street Racer (Europe) (Track 01).bin" size 28296912 crc 47145896 md5 c91f7c58379a9e4f560d01729adb6a2e sha1 61fa96a84c756b627f275151873dbe582b47ab4c )
+)
+
+game (
+	name "Space Jam (Europe)"
+	description "Space Jam (Europe)"
+	rom ( name "Space Jam (Europe) (Track 01).bin" size 59689056 crc aaabf08f md5 0d003b93a3343aea79aa96184c3945e1 sha1 bb763e1b8db01a2c28c9fb805e9efc50fded9aad )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (1M)"
+	description "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (1M)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! 2 (Japan) (1M) (Track 1).bin" size 476717472 crc 675444b3 md5 2360f1ce1a62fd1ca6e7f923b589340e sha1 499471933b0ae793e27c4d7ced1e68537c1c42c8 )
+)
+
+game (
+	name "Die Hard Trilogy (Europe) (En,Fr,De,Es,It,Sv)"
+	description "Die Hard Trilogy (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "Die Hard Trilogy (Europe) (En,Fr,De,Es,It,Sv) (Track 01).bin" size 96304992 crc cda251e2 md5 6ab3a8ae3e433a3e7271c4574f4ed043 sha1 622f94670610291d3095b97a6bffb2d899594d03 )
+)
+
+game (
+	name "Angelique Duet (Japan)"
+	description "Angelique Duet (Japan)"
+	rom ( name "Angelique Duet (Japan) (Track 1).bin" size 630754656 crc 51b476f2 md5 67551ff1c7279e42963d78b6f73361b8 sha1 59320f834f912b06bed7214a8e36e409f4f5dea6 )
+)
+
+game (
+	name "Bug! (Europe)"
+	description "Bug! (Europe)"
+	rom ( name "Bug! (Europe) (Track 01).bin" size 133635936 crc cff02f88 md5 2974340e9f6048c80943ef74e250acaa sha1 ca35427b05a64df668b2c1d577428d1dd522f9d6 )
+)
+
+game (
+	name "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 1)"
+	description "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 1)"
+	rom ( name "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 1) (Track 1).bin" size 300818448 crc 9f9a0cdd md5 2a0f03bebb11645e9bc73f3cc4a725f8 sha1 09f80353128bab1bdc77bc2887dcf06d3db9daeb )
+)
+
+game (
+	name "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 2) (Omake Disk)"
+	description "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 2) (Omake Disk)"
+	rom ( name "Mahjong-kyou Jidai Cebu Island '96 (Japan) (Disc 2) (Omake Disk) (Track 1).bin" size 306780768 crc ed99f676 md5 459cad1c21ec66a71457214ca375d9fa sha1 58ef6b04e35f95008a553e0d05161ed0409fdad4 )
+)
+
+game (
+	name "Mighty Hits (Japan)"
+	description "Mighty Hits (Japan)"
+	rom ( name "Mighty Hits (Japan) (Track 01).bin" size 105416640 crc d05d61ba md5 00ac880b8f8315cd19cf6be5b8e1d0b6 sha1 d18047a93c84c41785b894ed49fec7200b6571ef )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 2) (2M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 2) (2M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 2) (2M) (Track 1).bin" size 566418048 crc a79798c3 md5 5b46603c810fda84992d963a45cb0ba9 sha1 acfaa732f84eb18f7eec4f070aa3bfa62621af82 )
+)
+
+game (
+	name "Olympic Soccer (Japan)"
+	description "Olympic Soccer (Japan)"
+	rom ( name "Olympic Soccer (Japan) (Track 01).bin" size 49798896 crc b596a98b md5 4c26ccbb9a9ce83700e150ba9fff413f sha1 04d9f5884101fff4482b4e0bfe8bcb04a72438d9 )
+)
+
+game (
+	name "Dino Island (Japan)"
+	description "Dino Island (Japan)"
+	rom ( name "Dino Island (Japan) (Track 1).bin" size 613686192 crc 58e84eaa md5 80c2e8de32c19842c163930b5fc01496 sha1 50c4cbd9d19bf0ad6b3924a9516dd6b9b66ba85d )
+)
+
+game (
+	name "Space Invaders (Japan)"
+	description "Space Invaders (Japan)"
+	rom ( name "Space Invaders (Japan) (Track 1).bin" size 2253216 crc 333eb4f7 md5 4f010010660339bbee29b921284cc2dd sha1 3e96c341c0df1860262a82782b02d5926d0f2e2d )
+)
+
+game (
+	name "NiGHTS into Dreams... (Japan)"
+	description "NiGHTS into Dreams... (Japan)"
+	rom ( name "NiGHTS into Dreams... (Japan) (Track 01).bin" size 46005120 crc e19a8bb3 md5 6266cfb8127cbed4251e60494897abb0 sha1 cb9c1f3a1a1fc1b58d32e058ded9f04f7fe44bdd )
+)
+
+game (
+	name "Christmas NiGHTS into Dreams... (Japan) (Rev A)"
+	description "Christmas NiGHTS into Dreams... (Japan) (Rev A)"
+	rom ( name "Christmas NiGHTS into Dreams... (Japan) (Rev A) (Track 01).bin" size 31441536 crc 3a72b51c md5 62ccfdf908dd14002c5e4362e914f274 sha1 57d038778a2fcdea3604108e488f476503c41c94 )
+)
+
+game (
+	name "Nobunaga no Yabou Tenshouki (Japan)"
+	description "Nobunaga no Yabou Tenshouki (Japan)"
+	rom ( name "Nobunaga no Yabou Tenshouki (Japan) (Track 1).bin" size 534706032 crc acef2fd6 md5 681c26af312901b1920af06e1ec7fbe6 sha1 523562be604e59f4b56a5fcc4e3144d81bd92ee9 )
+)
+
+game (
+	name "Nobunaga no Yabou Returns (Japan)"
+	description "Nobunaga no Yabou Returns (Japan)"
+	rom ( name "Nobunaga no Yabou Returns (Japan) (Track 1).bin" size 49972944 crc f798368c md5 fc6ccd0e391bf652ee3714ad2d22f93d sha1 2b160782c1df8545a1607b0f3056d5b07c74dd26 )
+)
+
+game (
+	name "Clockwork Knight - Pepperouchau no Daibouken Joukan (Japan)"
+	description "Clockwork Knight - Pepperouchau no Daibouken Joukan (Japan)"
+	rom ( name "Clockwork Knight - Pepperouchau no Daibouken Joukan (Japan) (Track 1).bin" size 216553344 crc 3766c5e1 md5 0a83b24407f8640cec8a497dc9952c85 sha1 14d36313b95762614c9513e89464f6b9d2c54b98 )
+)
+
+game (
+	name "Panzer Dragoon II Zwei (USA)"
+	description "Panzer Dragoon II Zwei (USA)"
+	rom ( name "Panzer Dragoon II Zwei (USA) (Track 1).bin" size 447409200 crc 158cd426 md5 d84611ed5d0c021f2e4af94978cb8c9c sha1 65e46985139ef10e21439f63529e157dee1dbc42 )
+)
+
+game (
+	name "Shining the Holy Ark (Japan) (1M)"
+	description "Shining the Holy Ark (Japan) (1M)"
+	rom ( name "Shining the Holy Ark (Japan) (1M) (Track 1).bin" size 258578880 crc aa8aca9c md5 d9849fd195dd1bfc417856f44774c12d sha1 88ac52abb7faab33f260569870861592b3126bfc )
+)
+
+game (
+	name "Clockwork Knight - Pepperouchau no Daibouken Gekan (Japan) (2M)"
+	description "Clockwork Knight - Pepperouchau no Daibouken Gekan (Japan) (2M)"
+	rom ( name "Clockwork Knight - Pepperouchau no Daibouken Gekan (Japan) (2M) (Track 1).bin" size 288708000 crc d7bad9a0 md5 7bfd1d0cc2b91a56c3ee9b16c7554322 sha1 c74e873ab8b07d77039288b78e1bbbac416bcf4a )
+)
+
+game (
+	name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan)"
+	description "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan)"
+	rom ( name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Track 1).bin" size 247987824 crc dfaee920 md5 b991cc1a933fa785ed3f92c131a5a891 sha1 6ae4c9cc601ee02a432f871373e25cad3a65b8b8 )
+)
+
+game (
+	name "Gotha - Ismailia SenEki (Japan)"
+	description "Gotha - Ismailia SenEki (Japan)"
+	rom ( name "Gotha - Ismailia SenEki (Japan) (Track 01).bin" size 249772992 crc bc2d90c5 md5 331cfea60d1e76119dfd7fb79812c7ca sha1 7a4ed87d5f9d43572be71fa4d53f16811c0f1979 )
+)
+
+game (
+	name "Gotha II - Tenkuu no Kishi (Japan)"
+	description "Gotha II - Tenkuu no Kishi (Japan)"
+	rom ( name "Gotha II - Tenkuu no Kishi (Japan) (Track 01).bin" size 412790112 crc 59f42b01 md5 2c2a93dc146f9e8da166a006e1595bd2 sha1 6106f681969ac887a727b98e69dd47c1b9eda7be )
+)
+
+game (
+	name "Soukuu no Tsubasa - Gotha World (Japan) (Disc 1)"
+	description "Soukuu no Tsubasa - Gotha World (Japan) (Disc 1)"
+	rom ( name "Soukuu no Tsubasa - Gotha World (Japan) (Disc 1) (Track 01).bin" size 140764848 crc e1bfd47d md5 a6a6689cf25c32d17fbb0caeef774eea sha1 d5e59d3d06f8f304e1bb061a27c282a28fa2b758 )
+)
+
+game (
+	name "Soukuu no Tsubasa - Gotha World (Japan) (Disc 2)"
+	description "Soukuu no Tsubasa - Gotha World (Japan) (Disc 2)"
+	rom ( name "Soukuu no Tsubasa - Gotha World (Japan) (Disc 2) (Track 01).bin" size 283312512 crc d2671971 md5 af47b6c5b586a5b190249709412fd1ba sha1 d07a55c5a1bef54c39b484f94d9a214c8cca3ef4 )
+)
+
+game (
+	name "Thunderstrike 2 (USA)"
+	description "Thunderstrike 2 (USA)"
+	rom ( name "Thunderstrike 2 (USA) (Track 01).bin" size 62118672 crc a6a9a005 md5 27bd5d24ed7d33398e61da46f5528338 sha1 fb13f63496d97197779cef38ec8f9eb0e256692d )
+)
+
+game (
+	name "3D Baseball - The Majors (Japan)"
+	description "3D Baseball - The Majors (Japan)"
+	rom ( name "3D Baseball - The Majors (Japan) (Track 1).bin" size 345158352 crc aea21ef0 md5 dd19bfb327d061ac7ed539c6cec17bdf sha1 185077e00bbd5c8fe0675dd7b7ea26826aac033f )
+)
+
+game (
+	name "2Tax Gold (Japan)"
+	description "2Tax Gold (Japan)"
+	rom ( name "2Tax Gold (Japan) (Track 01).bin" size 38088288 crc 02954d99 md5 db79faefd5a15dae8cb227126120789f sha1 e8dbaa30e847b15123a1f11e7db245af15fd7d0b )
+)
+
+game (
+	name "Johnny Bazookatone (Europe)"
+	description "Johnny Bazookatone (Europe)"
+	rom ( name "Johnny Bazookatone (Europe) (Track 01).bin" size 192233664 crc 264940ec md5 88e5914de5827f0f46b32c149174a9c9 sha1 681a655b68bb236ffb5d983d14feb34c1e7244be )
+)
+
+game (
+	name "3D Lemmings (Japan)"
+	description "3D Lemmings (Japan)"
+	rom ( name "3D Lemmings (Japan) (Track 01).bin" size 155575392 crc ee89b7ce md5 5f13f5d16f2e41ad9eb300774f2d0b8b sha1 e20186e493e6ebdd704152d59940be45bc116813 )
+)
+
+game (
+	name "Myst (Japan)"
+	description "Myst (Japan)"
+	rom ( name "Myst (Japan) (Track 1).bin" size 582653904 crc 8b58de3f md5 305f2012cee46fc4969c5b35dd638612 sha1 0daa2da75f419251b04d0582f2ef7de5d05bc9c7 )
+)
+
+game (
+	name "Mortal Kombat II Kanzenban (Japan) (4S)"
+	description "Mortal Kombat II Kanzenban (Japan) (4S)"
+	rom ( name "Mortal Kombat II Kanzenban (Japan) (4S) (Track 1).bin" size 30820608 crc e448fc79 md5 bc3e67486092df80537452e7cd39dbd1 sha1 bf4835c64435e235696488175d006173f01c57a7 )
+)
+
+game (
+	name "Wizard's Harmony 2 (Japan) (2M)"
+	description "Wizard's Harmony 2 (Japan) (2M)"
+	rom ( name "Wizard's Harmony 2 (Japan) (2M) (Track 1).bin" size 48959232 crc 94957406 md5 e43a552a967d133b704de8fc65445a0c sha1 e052e38d1f8d4842906d757b0a35f7cae6d8d870 )
+)
+
+game (
+	name "Heiwa Pachinko Soushingeki (Japan) (1M)"
+	description "Heiwa Pachinko Soushingeki (Japan) (1M)"
+	rom ( name "Heiwa Pachinko Soushingeki (Japan) (1M) (Track 1).bin" size 16428720 crc a85c34d7 md5 67fca580967cd0f2a7abd23feb49be7f sha1 f959e091ff5d433c2fecf06fc5898980b01c882a )
+)
+
+game (
+	name "Steep Slope Sliders (Japan)"
+	description "Steep Slope Sliders (Japan)"
+	rom ( name "Steep Slope Sliders (Japan) (Track 01).bin" size 21160944 crc 52aa53c3 md5 ba1c6b616dbd4dd9066ecffdf2a58fe9 sha1 a6a0ff7063e681d920b2ac5035cbf510277b01d7 )
+)
+
+game (
+	name "Top Anglers - Super Fishing Big Fight 2 (Japan)"
+	description "Top Anglers - Super Fishing Big Fight 2 (Japan)"
+	rom ( name "Top Anglers - Super Fishing Big Fight 2 (Japan) (Track 01).bin" size 45238368 crc ff4ed4c8 md5 f83393d21c37cda2f8fea69be9e5941c sha1 cc2effaddb998466a80d901ffc91ae5a4c5f7f5a )
+)
+
+game (
+	name "3D Mission Shooting - Finalist (Japan)"
+	description "3D Mission Shooting - Finalist (Japan)"
+	rom ( name "3D Mission Shooting - Finalist (Japan) (Track 01).bin" size 129689280 crc 2bc848df md5 83ad4b4087707333968fcc1e3be7e7ba sha1 f213143a9aa563b17b74d9a3f95284f5aed9b4d9 )
+)
+
+game (
+	name "Andretti Racing (Europe)"
+	description "Andretti Racing (Europe)"
+	rom ( name "Andretti Racing (Europe) (Track 1).bin" size 598499328 crc 2dd3c824 md5 65df87898bd478b30d6231abef505dc5 sha1 47006b28c26f8ef824dd5a473e30dde03642ba35 )
+)
+
+game (
+	name "NASCAR 98 (Europe)"
+	description "NASCAR 98 (Europe)"
+	rom ( name "NASCAR 98 (Europe) (Track 1).bin" size 218533728 crc 294ffa3b md5 ee78a6513d59bde3e273858abd50a184 sha1 b9ea3edc098578c4511ef1a117efd9017a83ed5f )
+)
+
+game (
+	name "Shining Wisdom (Europe)"
+	description "Shining Wisdom (Europe)"
+	rom ( name "Shining Wisdom (Europe) (Track 1).bin" size 96928272 crc 2422fdfb md5 c71c6c93eec542f2ab5c03d7ff145f63 sha1 9740c24aeb9d5554f3575567bc954858ae21713e )
+)
+
+game (
+	name "Tunnel B1 (Europe) (En,Fr,De,Es,It)"
+	description "Tunnel B1 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tunnel B1 (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 129541104 crc c7a9e2ef md5 c4043d620dd9874f7e2577cb42a8f92a sha1 676699da746a1dd01065c3267bd43e252de4d860 )
+)
+
+game (
+	name "Game-Ware Vol. 1 (Japan)"
+	description "Game-Ware Vol. 1 (Japan)"
+	rom ( name "Game-Ware Vol. 1 (Japan) (Track 1).bin" size 590027424 crc 76ca025f md5 d95f321be875020315fe1a806bbf72f2 sha1 aca1c787110bf5f15a1c8ae4e71ca557d89c9bbd )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 1) (Game Disc) (1M)"
+	description "Enemy Zero (Japan) (Disc 1) (Game Disc) (1M)"
+	rom ( name "Enemy Zero (Japan) (Disc 1) (Game Disc) (1M) (Track 1).bin" size 579892656 crc 24b4a293 md5 f5e33317836aff0d67905a044c2f5420 sha1 5c24e7c696a462ad0f62f2b6352aa176dcea8daa )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 2) (Game Disc) (1M)"
+	description "Enemy Zero (Japan) (Disc 2) (Game Disc) (1M)"
+	rom ( name "Enemy Zero (Japan) (Disc 2) (Game Disc) (1M) (Track 1).bin" size 653105712 crc ca8af6c3 md5 227b78034f7143d844e1ff3ad8c09f8b sha1 8b6f1e7844724a828392d9fd4893b6b6adc88746 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 3) (Game Disc) (4M)"
+	description "Enemy Zero (Japan) (Disc 3) (Game Disc) (4M)"
+	rom ( name "Enemy Zero (Japan) (Disc 3) (Game Disc) (4M) (Track 1).bin" size 470703408 crc f6e72036 md5 9a28f668bb6f9c53f0c7744414604b23 sha1 f3ed12d3d433c28d34d52b0744fcfd79eeaeab8f )
+)
+
+game (
+	name "DX Jinsei Game (Japan) (Rev A)"
+	description "DX Jinsei Game (Japan) (Rev A)"
+	rom ( name "DX Jinsei Game (Japan) (Rev A) (Track 1).bin" size 93306192 crc d951df10 md5 e9a8ccdf0fdecad81d3094570f9c4caf sha1 90f6ffe1ca2e21820320e20c6a0500962977794a )
+)
+
+game (
+	name "Virtua Cop (USA) (6S)"
+	description "Virtua Cop (USA) (6S)"
+	rom ( name "Virtua Cop (USA) (6S) (Track 01).bin" size 50655024 crc 1f08de95 md5 117e40c1c1f308764df5f72d0df98723 sha1 f545c290b4aff92567d9dd9be704611afc389333 )
+)
+
+game (
+	name "Sega Worldwide Soccer '97 (USA)"
+	description "Sega Worldwide Soccer '97 (USA)"
+	rom ( name "Sega Worldwide Soccer '97 (USA) (Track 01).bin" size 152183808 crc a1aa69c5 md5 6bd404d049f3916830e71bf8d28bbcb8 sha1 fce8e4aa5172f770bfc6198e399ddde756accde3 )
+)
+
+game (
+	name "Cyberia (USA) (En,Fr,De)"
+	description "Cyberia (USA) (En,Fr,De)"
+	rom ( name "Cyberia (USA) (En,Fr,De) (Track 1).bin" size 504402864 crc d413124a md5 7e49b3aad6c48cc489f5863ec7fdb646 sha1 d00cacd6c8151a1805927ae8231848b784a03198 )
+)
+
+game (
+	name "World Series Baseball II (USA) (2S)"
+	description "World Series Baseball II (USA) (2S)"
+	rom ( name "World Series Baseball II (USA) (2S) (Track 1).bin" size 298372368 crc 0cf1e4e9 md5 600298f488423201b4577d286d0e8446 sha1 6769b64fadb8d4b058afc36284c3544a43897707 )
+)
+
+game (
+	name "3D Lemmings (Europe)"
+	description "3D Lemmings (Europe)"
+	rom ( name "3D Lemmings (Europe) (Track 01).bin" size 155478960 crc 48746da9 md5 4560f28f77f016c5454d0bcb46d5481a sha1 caa35befa897b24e92adb26d84868568a554f564 )
+)
+
+game (
+	name "Lost World, The - Jurassic Park (Europe)"
+	description "Lost World, The - Jurassic Park (Europe)"
+	rom ( name "Lost World, The - Jurassic Park (Europe) (Track 01).bin" size 156045792 crc 62b9574f md5 dfbaf0d1b6fb74f8bb26055f243064a8 sha1 f386b26e9f0fd579a54b1a6773fb52bb06c44056 )
+)
+
+game (
+	name "Firestorm - Thunderhawk 2 (Europe) (En,Fr)"
+	description "Firestorm - Thunderhawk 2 (Europe) (En,Fr)"
+	rom ( name "Firestorm - Thunderhawk 2 (Europe) (En,Fr) (Track 01).bin" size 62113968 crc 8a8caad3 md5 31d9cb76eb3547077271f4396aaa77c8 sha1 0749d8dfb3d9f0a4d60ea9b500bfbdf16fc9f4d5 )
+)
+
+game (
+	name "Marvel Super Heroes (Europe)"
+	description "Marvel Super Heroes (Europe)"
+	rom ( name "Marvel Super Heroes (Europe) (Track 01).bin" size 44727984 crc e41a34d6 md5 14cc637b09af1edf206b2561fe1cbf74 sha1 0783c35e365a3f2304a562b45f73de58104dc0a9 )
+)
+
+game (
+	name "Moujiya (Japan)"
+	description "Moujiya (Japan)"
+	rom ( name "Moujiya (Japan) (Track 01).bin" size 11040288 crc 7300a7a1 md5 77b79f47ba87b4a287c0c8203c49d1c1 sha1 ea0af152686e9d5b04f4e216ab37a9a39b623dcd )
+)
+
+game (
+	name "High Velocity - Mountain Racing Challenge (USA)"
+	description "High Velocity - Mountain Racing Challenge (USA)"
+	rom ( name "High Velocity - Mountain Racing Challenge (USA) (Track 1).bin" size 26088384 crc 713bfa2e md5 c255f879873503f79eeb97a0b24160b4 sha1 2b72a5d362500bdad5c75625e5de014191074670 )
+)
+
+game (
+	name "NHL All-Star Hockey (USA) (2S)"
+	description "NHL All-Star Hockey (USA) (2S)"
+	rom ( name "NHL All-Star Hockey (USA) (2S) (Track 01).bin" size 437664864 crc 17fc83b3 md5 1a3b5fd9d67356fe60d38e4f323b254e sha1 8eda60225749d8de9de8f0b01e1cd1ba69ffc73a )
+)
+
+game (
+	name "Clockwork Knight - Pepperouchau's Adventure (USA)"
+	description "Clockwork Knight - Pepperouchau's Adventure (USA)"
+	rom ( name "Clockwork Knight - Pepperouchau's Adventure (USA) (Track 1).bin" size 216423984 crc 0981f06b md5 c23f8858ccab53baa1c4678ef988e940 sha1 19ccb658be4c541a2ebad8255040ecb504d090da )
+)
+
+game (
+	name "VR Soccer (USA)"
+	description "VR Soccer (USA)"
+	rom ( name "VR Soccer (USA) (Track 1).bin" size 73871616 crc 24b4e423 md5 11d398688395a3fa1671471cff6dea45 sha1 9feea9fc8f7998364f12d8f531b16369ac247d5c )
+)
+
+game (
+	name "Madden NFL 98 (USA)"
+	description "Madden NFL 98 (USA)"
+	rom ( name "Madden NFL 98 (USA) (Track 1).bin" size 649210800 crc ea17a423 md5 39ce2e4cb40b0875eeb6b6e74ded227a sha1 0351355772becf2ce4045aec08298f2195f9a645 )
+)
+
+game (
+	name "Panzer Dragoon (Europe) (En,Fr,De,Es,It)"
+	description "Panzer Dragoon (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Panzer Dragoon (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 255192000 crc 8d3492be md5 0378ea630f67badf5c719c6ac475978b sha1 3a8d714be75f8ad7bf56c1bb1ac25cb610193891 )
+)
+
+game (
+	name "Defcon 5 (Europe)"
+	description "Defcon 5 (Europe)"
+	rom ( name "Defcon 5 (Europe) (Track 1).bin" size 228654384 crc 0f0743c0 md5 6798480b0bf7849854c82724aeb1e17d sha1 29f3e6fda18f9ceef1dcf49b32320e0885baa291 )
+)
+
+game (
+	name "NBA Jam Extreme (Europe)"
+	description "NBA Jam Extreme (Europe)"
+	rom ( name "NBA Jam Extreme (Europe) (Track 1).bin" size 58381344 crc 4db90b4e md5 960062d09a59cf1cbfab3eec9d61a2ae sha1 4acb54c4d0f817cc77430797664545a9e93ce01a )
+)
+
+game (
+	name "NFL Quarterback Club 96 (Europe)"
+	description "NFL Quarterback Club 96 (Europe)"
+	rom ( name "NFL Quarterback Club 96 (Europe) (Track 1).bin" size 157245312 crc 7453314f md5 6a25feafefccfe8b0052c62252e73b2a sha1 d7a5a0fa748c0e02ca55d2e490c6795cb660d1b5 )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku (Japan)"
+	description "Yuukyuu Gensoukyoku (Japan)"
+	rom ( name "Yuukyuu Gensoukyoku (Japan) (Track 1).bin" size 86367792 crc a767d327 md5 bc1e85d9ace920a43bee48321847762b sha1 b21fa2a100f6f4133ea34adc043d6a5367d5ef66 )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku 2nd Album (Japan)"
+	description "Yuukyuu Gensoukyoku 2nd Album (Japan)"
+	rom ( name "Yuukyuu Gensoukyoku 2nd Album (Japan) (Track 1).bin" size 97577424 crc 1c9cd961 md5 51d34328ad03077ea5f5b0e68c43a404 sha1 11311c1b6c12d0385deb55e75d7b3322498cdc0b )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku Ensemble (Japan)"
+	description "Yuukyuu Gensoukyoku Ensemble (Japan)"
+	rom ( name "Yuukyuu Gensoukyoku Ensemble (Japan) (Track 1).bin" size 133120848 crc f4d69bc0 md5 cd618417444961c68c1c51ce8f71e9a1 sha1 a52ed3f42a2bae2ed5087fa5506917d8c8d611b8 )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku Ensemble 2 (Japan)"
+	description "Yuukyuu Gensoukyoku Ensemble 2 (Japan)"
+	rom ( name "Yuukyuu Gensoukyoku Ensemble 2 (Japan) (Track 1).bin" size 141129408 crc 826c0e63 md5 bcad72a45501ef6adef75cc2e1d46300 sha1 f4785abf9edfb17e2c290beac2b1aa29f749c6ba )
+)
+
+game (
+	name "Yuukyuu no Kobako Official Collection (Japan)"
+	description "Yuukyuu no Kobako Official Collection (Japan)"
+	rom ( name "Yuukyuu no Kobako Official Collection (Japan) (Track 1).bin" size 178669680 crc bfee5462 md5 d07703197a35ec9a680eff1dc4c7c8cb sha1 068b60f636433e0163b7e4ca4b050125cc9eabd9 )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku (Japan) (Alt)"
+	description "Yuukyuu Gensoukyoku (Japan) (Alt)"
+	rom ( name "Yuukyuu Gensoukyoku (Japan) (Alt) (Track 1).bin" size 86014992 crc c6083d23 md5 e6a3e161fe7bab4a5d2ee4ccf54f3733 sha1 7b702c92937121376636814857aac148dbfea8f6 )
+)
+
+game (
+	name "Yuukyuu Gensoukyoku 2nd Album (Japan) (2M)"
+	description "Yuukyuu Gensoukyoku 2nd Album (Japan) (2M)"
+	rom ( name "Yuukyuu Gensoukyoku 2nd Album (Japan) (2M) (Track 1).bin" size 97401024 crc 17350e68 md5 5f14f668de03e44ea1da42c969c5a020 sha1 7931de4f2bba9529837ee2ca0585977f1bbf441e )
+)
+
+game (
+	name "Virtua Fighter 2 (Europe) (Made in USA)"
+	description "Virtua Fighter 2 (Europe) (Made in USA)"
+	rom ( name "Virtua Fighter 2 (Europe) (Made in USA) (Track 01).bin" size 61321344 crc 46ee74f3 md5 d5f3255b5f7373e75cda2e468767cc01 sha1 168c6380fcf034446b05a502485833afce4751a7 )
+)
+
+game (
+	name "True Pinball (Europe)"
+	description "True Pinball (Europe)"
+	rom ( name "True Pinball (Europe) (Track 01).bin" size 20784624 crc 140e5272 md5 0410fbbd46d041e1f1e1de9f11a4accb sha1 1e3761269ab91942d98fb27ca4790fd63dc719a5 )
+)
+
+game (
+	name "Battle Stations (Europe) (En,Fr,De)"
+	description "Battle Stations (Europe) (En,Fr,De)"
+	rom ( name "Battle Stations (Europe) (En,Fr,De) (Track 01).bin" size 160926192 crc c21867f3 md5 04faa57f016134170ff31f38b37db32a sha1 086859259e3e167d66556f6967ed3b93b651697c )
+)
+
+game (
+	name "Independence Day - The Game (Europe) (En,Fr,De,Es,It,Sv)"
+	description "Independence Day - The Game (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "Independence Day - The Game (Europe) (En,Fr,De,Es,It,Sv) (Track 1).bin" size 261107280 crc 24be88cd md5 9d65a109188d35f2e83aaad941161238 sha1 963925a104c258f7a67603a2f711d9fe988b2bbe )
+)
+
+game (
+	name "Machi (Japan) (Sample)"
+	description "Machi (Japan) (Sample)"
+	rom ( name "Machi (Japan) (Sample) (Track 1).bin" size 367182480 crc 442e93ba md5 25a6d3f8a196d6e5ed3f7d933e46c1a5 sha1 72ac89ea3704a8b9ce7ec34fff7eb343d826b443 )
+)
+
+game (
+	name "House of the Dead, The (Japan) (Sample)"
+	description "House of the Dead, The (Japan) (Sample)"
+	rom ( name "House of the Dead, The (Japan) (Sample) (Track 1).bin" size 20241312 crc 47ac68ec md5 6ef9de0fd721308d2c45bca3799d0c2f sha1 87225369d84e16d170319a92fc28ad33544c2b87 )
+)
+
+game (
+	name "Grandia - Prelude (Japan) (2M)"
+	description "Grandia - Prelude (Japan) (2M)"
+	rom ( name "Grandia - Prelude (Japan) (2M) (Track 1).bin" size 248187744 crc b0258240 md5 f0e512088659f51cfdaa18dbf60a0d4c sha1 85dc928fbaf98fa3e5f56110a835f9c51e9b5693 )
+)
+
+game (
+	name "Hardcore 4x4 (Europe) (En,Fr,De)"
+	description "Hardcore 4x4 (Europe) (En,Fr,De)"
+	rom ( name "Hardcore 4x4 (Europe) (En,Fr,De) (Track 1).bin" size 36514800 crc b26cdf91 md5 46cd1c363d6b49db2dd07f737d39efe1 sha1 37c0604f91bcf9450c283129ece58d2a9a119251 )
+)
+
+game (
+	name "Andretti Racing (France)"
+	description "Andretti Racing (France)"
+	rom ( name "Andretti Racing (France) (Track 1).bin" size 592254768 crc 223b97c8 md5 7afefc022d44fac1a8c1d146649cd5b8 sha1 94a48d2427777c67c8a8f01fcd576f7fb7d1ed53 )
+)
+
+game (
+	name "FIFA 97 (France) (En,Fr,De,Es,It,Sv)"
+	description "FIFA 97 (France) (En,Fr,De,Es,It,Sv)"
+	rom ( name "FIFA 97 (France) (En,Fr,De,Es,It,Sv) (Track 1).bin" size 542726352 crc dd7e113f md5 d7927c3e8e9e84090202b9d6a2b47ca1 sha1 86bb35c46ccfb5d3632fd10a4800d8dea9ab67d0 )
+)
+
+game (
+	name "Virtua Fighter (USA)"
+	description "Virtua Fighter (USA)"
+	rom ( name "Virtua Fighter (USA) (Track 01).bin" size 9598512 crc 76286d69 md5 71e64f38d9ca5dc9593d845fc09f1f7f sha1 8d132022b2c13acb1b0757b0dc7ca5d61b4509e9 )
+)
+
+game (
+	name "Shanghai - Triple-Threat (USA)"
+	description "Shanghai - Triple-Threat (USA)"
+	rom ( name "Shanghai - Triple-Threat (USA) (Track 1).bin" size 7455840 crc b9f7fcfc md5 64ce223509d9f32de51e4f549757c173 sha1 37f249e407a8fe2d53c1e43a709f83df58ccb098 )
+)
+
+game (
+	name "Center Ring Boxing (USA)"
+	description "Center Ring Boxing (USA)"
+	rom ( name "Center Ring Boxing (USA) (Track 1).bin" size 22588608 crc 59d36920 md5 7dd4f5ba3c6e8a293c49a6483e18972b sha1 b0617c38dd45c4e0b4b7032a5d65bcaf8866d17b )
+)
+
+game (
+	name "Theme Park (USA)"
+	description "Theme Park (USA)"
+	rom ( name "Theme Park (USA) (Track 01).bin" size 156720816 crc 735e1172 md5 ce7197756854b73d22f5728ec8da3bfc sha1 bd94ba50ad6e14c80b978b698ac38dc5909f64d6 )
+)
+
+game (
+	name "Daytona USA - Championship Circuit Edition (USA)"
+	description "Daytona USA - Championship Circuit Edition (USA)"
+	rom ( name "Daytona USA - Championship Circuit Edition (USA) (Track 01).bin" size 24394944 crc 9145e630 md5 4b5a31120562d5ef8087ffe86603fadc sha1 fbe7b0a88e2651f50533063772c5841e68b95bfb )
+)
+
+game (
+	name "Hang-On GP (USA)"
+	description "Hang-On GP (USA)"
+	rom ( name "Hang-On GP (USA) (Track 1).bin" size 16134720 crc 3bc42503 md5 56c6739ec912e2ef920d699b21e72c99 sha1 7e6d2d94239a0f94694edc09b9171fd9fbd0c35c )
+)
+
+game (
+	name "Yuukyuu no Kobako Official Collection (Japan) (1M)"
+	description "Yuukyuu no Kobako Official Collection (Japan) (1M)"
+	rom ( name "Yuukyuu no Kobako Official Collection (Japan) (1M) (Track 1).bin" size 178493280 crc 3994391c md5 03d6e75edc4985f2a06eaa8625e69a66 sha1 23b5f64a862ae014d7afbf9a30f009d10b8e8567 )
+)
+
+game (
+	name "Spot Goes to Hollywood (USA)"
+	description "Spot Goes to Hollywood (USA)"
+	rom ( name "Spot Goes to Hollywood (USA) (Track 01).bin" size 188799744 crc df43deae md5 44aae63443dbce03ae788f62a64c20fc sha1 ec5c8a85afbe2b5fc0971d69ec94e132b3cf834c )
+)
+
+game (
+	name "Virtua Fighter Remix (Japan) (SegaNet)"
+	description "Virtua Fighter Remix (Japan) (SegaNet)"
+	rom ( name "Virtua Fighter Remix (Japan) (SegaNet) (Track 01).bin" size 16087680 crc b13536c4 md5 2f477a8f8d5b156c14bf2278ffa69370 sha1 f5f7a9ee01aa252dd3055d5df3d74c3a6ca2db13 )
+)
+
+game (
+	name "NiGHTS into Dreams... (USA, Brazil)"
+	description "NiGHTS into Dreams... (USA, Brazil)"
+	rom ( name "NiGHTS into Dreams... (USA, Brazil) (Track 01).bin" size 46005120 crc fdc86ea5 md5 fed63f3007dfb6c1777a5e52dcb1fc4a sha1 06c9913005cf5c7c1b5335f6317f26546c19f800 )
+)
+
+game (
+	name "Sonic R (USA, Brazil)"
+	description "Sonic R (USA, Brazil)"
+	rom ( name "Sonic R (USA, Brazil) (Track 01).bin" size 16217040 crc a46e3723 md5 8874c43a33afb9e6799b531a387c02f2 sha1 5baecb073eeaf7e8234c4b51a67e7ea85866f2ee )
+)
+
+game (
+	name "Albert Odyssey - Legend of Eldean (USA)"
+	description "Albert Odyssey - Legend of Eldean (USA)"
+	rom ( name "Albert Odyssey - Legend of Eldean (USA) (Track 01).bin" size 253752576 crc d4a3aff5 md5 f517b2586e1c4e58cc2f3191d3953b3d sha1 a42123dfe1d82ded68268f35f167729d272c93fe )
+)
+
+game (
+	name "Albert Odyssey - Legend of Eldean (USA) (RE)"
+	description "Albert Odyssey - Legend of Eldean (USA) (RE)"
+	rom ( name "Albert Odyssey - Legend of Eldean (USA) (RE) (Track 01).bin" size 253752576 crc 6d12d82a md5 3b172a954f233e85841df19b2818a61e sha1 d2b22003925b5d2de086a518f9d0dc14abbf6625 )
+)
+
+game (
+	name "Blazing Heroes (USA)"
+	description "Blazing Heroes (USA)"
+	rom ( name "Blazing Heroes (USA) (Track 1).bin" size 179645760 crc a9026495 md5 1b672dc4ec5ac44ec7fea6dfb0344311 sha1 6ece3db5c631de0c8cdf627f4e9078b3871f2fd2 )
+)
+
+game (
+	name "Shining the Holy Ark (USA)"
+	description "Shining the Holy Ark (USA)"
+	rom ( name "Shining the Holy Ark (USA) (Track 1).bin" size 257661600 crc f995d006 md5 06fea2ffc7f67b4547606889db515504 sha1 f55fd6cbea76dbf62a4d973200fa62fc49105936 )
+)
+
+game (
+	name "Legend of Oasis, The (USA)"
+	description "Legend of Oasis, The (USA)"
+	rom ( name "Legend of Oasis, The (USA) (Track 1).bin" size 81986016 crc e3a15511 md5 eb0ba70a984d74fceec62f35b26e999d sha1 9d31c016ce4df2f10a1724d0368bba45feb96158 )
+)
+
+game (
+	name "Romance of the Three Kingdoms IV - Wall of Fire (USA)"
+	description "Romance of the Three Kingdoms IV - Wall of Fire (USA)"
+	rom ( name "Romance of the Three Kingdoms IV - Wall of Fire (USA) (Track 1).bin" size 502500096 crc 6bcb8424 md5 5aabe05308c9a63c7f128512ab02e682 sha1 a1d1907fa18a56e873d4b6f05a64c4dad42b6cbc )
+)
+
+game (
+	name "Mystaria - The Realms of Lore (USA)"
+	description "Mystaria - The Realms of Lore (USA)"
+	rom ( name "Mystaria - The Realms of Lore (USA) (Track 1).bin" size 177606576 crc cfc53fb6 md5 fd981b8f1271856c4b9473483033eac8 sha1 94c77b4e196a7a18fb3175290171575febde7880 )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (USA)"
+	description "Bust-A-Move 2 - Arcade Edition (USA)"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (USA) (Track 01).bin" size 14323680 crc 7f68b76d md5 917f0752246b1113f340f1423b30d613 sha1 8980b4ff48f62af7c759326084c31886ebe3c6c9 )
+)
+
+game (
+	name "Soviet Strike (USA)"
+	description "Soviet Strike (USA)"
+	rom ( name "Soviet Strike (USA) (Track 1).bin" size 661563504 crc 2ec4fae9 md5 f1b1c64bcbaffa9eac9706533dacb434 sha1 309a20b6042b978c9e8f8b017415d4c9227f5328 )
+)
+
+game (
+	name "FIFA Soccer 96 (USA)"
+	description "FIFA Soccer 96 (USA)"
+	rom ( name "FIFA Soccer 96 (USA) (Track 01).bin" size 240614304 crc 3a71eedf md5 2592cf324431884819b8c4d44a294ff7 sha1 b7056356657d8ad7330ca49c5ac3f9dadf098492 )
+)
+
+game (
+	name "Mortal Kombat Trilogy (Europe)"
+	description "Mortal Kombat Trilogy (Europe)"
+	rom ( name "Mortal Kombat Trilogy (Europe) (Track 01).bin" size 56036400 crc d7f1496f md5 d194f36a3fd61c39cfa71e45b5f428ad sha1 0665b6671a761fe36dcffe471160676fbe26cded )
+)
+
+game (
+	name "Tanjou S - Debut (Japan) (1M)"
+	description "Tanjou S - Debut (Japan) (1M)"
+	rom ( name "Tanjou S - Debut (Japan) (1M) (Track 1).bin" size 556965360 crc 42fe26c3 md5 76767413863dd33ba16e3100da114e5d sha1 14a7ac866a31c4e149e2f9d8daa4ad4c6e551b4c )
+)
+
+game (
+	name "Victory Goal (Japan) (2B)"
+	description "Victory Goal (Japan) (2B)"
+	rom ( name "Victory Goal (Japan) (2B) (Track 01).bin" size 169826160 crc 0562bf1e md5 9f348d2553199f2fec45ef1de46e6df0 sha1 1689ca91b615e0065a4d49a17cd2af43b99582f0 )
+)
+
+game (
+	name "Victory Goal (Japan) (3A)"
+	description "Victory Goal (Japan) (3A)"
+	rom ( name "Victory Goal (Japan) (3A) (Track 01).bin" size 169826160 crc 0562bf1e md5 9f348d2553199f2fec45ef1de46e6df0 sha1 1689ca91b615e0065a4d49a17cd2af43b99582f0 )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '98 (Japan) (Rev A)"
+	description "Pro Yakyuu Greatest Nine '98 (Japan) (Rev A)"
+	rom ( name "Pro Yakyuu Greatest Nine '98 (Japan) (Rev A) (Track 1).bin" size 438784416 crc f553ada2 md5 b3a3df2c2503d8ad45a070b12dc5eee4 sha1 3df3c86fc06897232506ff238ce542d3a83f6a7c )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '98 (Japan) (Rev B)"
+	description "Pro Yakyuu Greatest Nine '98 (Japan) (Rev B)"
+	rom ( name "Pro Yakyuu Greatest Nine '98 (Japan) (Rev B) (Track 1).bin" size 438784416 crc 8160cca9 md5 14773a55397d8483649b9df720888578 sha1 fc13806cac393f59197a35bbc3de2e7235530cf0 )
+)
+
+game (
+	name "Pro Yakyuu Team mo Tsukurou! (Japan) (Rev B)"
+	description "Pro Yakyuu Team mo Tsukurou! (Japan) (Rev B)"
+	rom ( name "Pro Yakyuu Team mo Tsukurou! (Japan) (Rev B) (Track 1).bin" size 556718400 crc 9ee37737 md5 f41a772b6f135d9617b1797f72453794 sha1 77729761d8045946df90030f750e9fed3183e9a7 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (2M)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (2M)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3) (2M) (Track 1).bin" size 654709776 crc 23c25c87 md5 770ebda210ecf6299b97d5f4b9731617 sha1 2b3d50b0da785e9a4bca7175de99dd69d3511c50 )
+)
+
+game (
+	name "Conveni 2, The - Zenkoku Chain Tenkai da! (Japan)"
+	description "Conveni 2, The - Zenkoku Chain Tenkai da! (Japan)"
+	rom ( name "Conveni 2, The - Zenkoku Chain Tenkai da! (Japan) (Track 1).bin" size 38706864 crc 19b1119c md5 77209d53dcf138532a09042f5b8f756b sha1 266cf2be2728d60b4eb5a96929250da39960679f )
+)
+
+game (
+	name "Wangan Dead Heat (Japan)"
+	description "Wangan Dead Heat (Japan)"
+	rom ( name "Wangan Dead Heat (Japan) (Track 01).bin" size 274711248 crc 404329ed md5 c027b37f8f56d06dba4bb0a93828d0f9 sha1 c102aea332cfb1d53e49386d2b5045b6ba750428 )
+)
+
+game (
+	name "Wangan Dead Heat + Real Arrange (Japan) (Disc 1)"
+	description "Wangan Dead Heat + Real Arrange (Japan) (Disc 1)"
+	rom ( name "Wangan Dead Heat + Real Arrange (Japan) (Disc 1) (Track 1).bin" size 216506304 crc 88acbfce md5 71991ceef8253fe7d5e352afce3af02c sha1 1cdecd147a29d3a8db3cddc5624fc03eb51ec91a )
+)
+
+game (
+	name "Wangan Dead Heat + Real Arrange (Japan) (Disc 2) (Addition)"
+	description "Wangan Dead Heat + Real Arrange (Japan) (Disc 2) (Addition)"
+	rom ( name "Wangan Dead Heat + Real Arrange (Japan) (Disc 2) (Addition) (Track 1).bin" size 315443184 crc f977b7ff md5 bf9d02e5baac0859c1e7acba159cf861 sha1 8ec39a47c13f24a7c48ec309672ad54a774d47dd )
+)
+
+game (
+	name "Sega Rally Championship (Korea)"
+	description "Sega Rally Championship (Korea)"
+	rom ( name "Sega Rally Championship (Korea) (Track 01).bin" size 29654016 crc aa1229d4 md5 d9e444d35bb19927cb7f257dd89af755 sha1 9b76a7958a24750d5291c05256d48a7c6b78aabb )
+)
+
+game (
+	name "Koi no Summer Fantasy - in Miyazaki Seagaia (Japan)"
+	description "Koi no Summer Fantasy - in Miyazaki Seagaia (Japan)"
+	rom ( name "Koi no Summer Fantasy - in Miyazaki Seagaia (Japan) (Track 1).bin" size 597812544 crc 1f79999f md5 aef970b63d5a8e83e10f632e7532f67b sha1 4d7c0ec46ef23137aa0adde246b1e7c13b18f2b5 )
+)
+
+game (
+	name "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 1)"
+	description "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 1)"
+	rom ( name "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 1) (Track 1).bin" size 647435040 crc 9a2b063e md5 807c2705a490424bff9ae353826a75bd sha1 5b715d35fc3f5654e4b52cbdc54c3fd6fc56e9f6 )
+)
+
+game (
+	name "Tokimeki Mahjong Paradise - Koi no Tenpai Beat (Japan)"
+	description "Tokimeki Mahjong Paradise - Koi no Tenpai Beat (Japan)"
+	rom ( name "Tokimeki Mahjong Paradise - Koi no Tenpai Beat (Japan) (Track 01).bin" size 282169440 crc e3733a54 md5 fa5564be0b9fcacb324f39cc5847d085 sha1 eda809182077d2a5cb9cfc9032c6db92d59988f9 )
+)
+
+game (
+	name "Virtua Fighter 2 (Europe) (Rev A) (Made in USA)"
+	description "Virtua Fighter 2 (Europe) (Rev A) (Made in USA)"
+	rom ( name "Virtua Fighter 2 (Europe) (Rev A) (Made in USA) (Track 01).bin" size 61321344 crc 4287ef99 md5 d3b932e85a84438410417d990e7d895d sha1 9be7b1d5edc9b765345bbd7c5cf0cb2b60f60da4 )
+)
+
+game (
+	name "Puyo Puyo Sun for SegaNet (Japan)"
+	description "Puyo Puyo Sun for SegaNet (Japan)"
+	rom ( name "Puyo Puyo Sun for SegaNet (Japan) (Track 1).bin" size 467605824 crc c303595a md5 09074d619ccc5d7a115f7d3d4f1127f4 sha1 b6e0114280bd31d864f128da7336cae48c6f056b )
+)
+
+game (
+	name "Momotarou Douchuuki (Japan) (1M)"
+	description "Momotarou Douchuuki (Japan) (1M)"
+	rom ( name "Momotarou Douchuuki (Japan) (1M) (Track 1).bin" size 209161008 crc 69a9fb1a md5 a7025d80f66597b8c1c2c6c3a4a2c789 sha1 b213b7f7b761fbcc0b29515a1a1061c4bfaa699f )
+)
+
+game (
+	name "GeGeGe no Kitarou - Gentou Kaikitan (Japan)"
+	description "GeGeGe no Kitarou - Gentou Kaikitan (Japan)"
+	rom ( name "GeGeGe no Kitarou - Gentou Kaikitan (Japan) (Track 01).bin" size 27725376 crc e5ef9f63 md5 27c69476f68eceef39685c2e975a4c3f sha1 d29ac836b13d857d6761423bd3a61c10ed453bf3 )
+)
+
+game (
+	name "Tantei Jinguuji Saburou - Mikan no Report (Japan)"
+	description "Tantei Jinguuji Saburou - Mikan no Report (Japan)"
+	rom ( name "Tantei Jinguuji Saburou - Mikan no Report (Japan) (Track 01).bin" size 259093968 crc 8a7e4223 md5 d7b83efa738805a3b88e89630468e525 sha1 4db721115c4cf3e538ff19a72ef39bfc90be9260 )
+)
+
+game (
+	name "Tantei Jinguuji Saburou - Yume no Owari ni (Japan) (3M)"
+	description "Tantei Jinguuji Saburou - Yume no Owari ni (Japan) (3M)"
+	rom ( name "Tantei Jinguuji Saburou - Yume no Owari ni (Japan) (3M) (Track 1).bin" size 661838688 crc 08d910e6 md5 88da706eb4e00354dee0c08a2bdfa1fa sha1 04046aa1af0ea50ebe9a48d1cebd607307434d24 )
+)
+
+game (
+	name "Sound Novel Machi (Japan) (Disc 1) (10.11-10.13 Incl.)"
+	description "Sound Novel Machi (Japan) (Disc 1) (10.11-10.13 Incl.)"
+	rom ( name "Sound Novel Machi (Japan) (Disc 1) (10.11-10.13 Incl.) (Track 1).bin" size 613309872 crc 02e13493 md5 9b1a7e02cbb77188b51449f5201212e8 sha1 0bb47aba55fd37127d547da9811d85c3c0a57d4c )
+)
+
+game (
+	name "Sound Novel Machi (Japan) (Disc 2) (10.13-10.15 Incl.)"
+	description "Sound Novel Machi (Japan) (Disc 2) (10.13-10.15 Incl.)"
+	rom ( name "Sound Novel Machi (Japan) (Disc 2) (10.13-10.15 Incl.) (Track 1).bin" size 630293664 crc 8672b34d md5 fd4d98e66e83ed121e247b26b753b64b sha1 417f4435505b9174535906d637943293eae8d618 )
+)
+
+game (
+	name "Houma Hunter Lime Perfect Collection (Japan) (Disc 1)"
+	description "Houma Hunter Lime Perfect Collection (Japan) (Disc 1)"
+	rom ( name "Houma Hunter Lime Perfect Collection (Japan) (Disc 1) (Track 1).bin" size 305007360 crc da9c6c3d md5 96159faa72eb7760ff51c2465631b225 sha1 a1431ebf9d9f38c3672482d6493a61809ff2e564 )
+)
+
+game (
+	name "Houma Hunter Lime Perfect Collection (Japan) (Disc 2)"
+	description "Houma Hunter Lime Perfect Collection (Japan) (Disc 2)"
+	rom ( name "Houma Hunter Lime Perfect Collection (Japan) (Disc 2) (Track 1).bin" size 405903456 crc 669b23fb md5 2fa8770d2cfbc2944e48b4e0a2b827ae sha1 c2b1769d342ae5658203f4ce31c299b9b16c490b )
+)
+
+game (
+	name "Horror Tour (Japan) (1M)"
+	description "Horror Tour (Japan) (1M)"
+	rom ( name "Horror Tour (Japan) (1M) (Track 1).bin" size 373093056 crc 661ef4d1 md5 bee9a3c0d87ec5687b4f2a4d6d6a22b8 sha1 5a1eb9923eed8de7cfde709f109107e3df5fc674 )
+)
+
+game (
+	name "Shadows of the Tusk (Japan)"
+	description "Shadows of the Tusk (Japan)"
+	rom ( name "Shadows of the Tusk (Japan) (Track 1).bin" size 66552192 crc 5a63852e md5 16b7f7e39f8fabbbeadbf714b2d72945 sha1 29040d015314f76c71a1a790e0edf99c7468586a )
+)
+
+game (
+	name "DJ Wars (Japan) (Rev A) (10M)"
+	description "DJ Wars (Japan) (Rev A) (10M)"
+	rom ( name "DJ Wars (Japan) (Rev A) (10M) (Track 1).bin" size 230296080 crc b1eb8c28 md5 8b57791ce08e99bbd698741763628b9f sha1 b7bf28da8e2be0c885cad4931d4fcad57bd72d1e )
+)
+
+game (
+	name "Photo Genic (Japan)"
+	description "Photo Genic (Japan)"
+	rom ( name "Photo Genic (Japan) (Track 1).bin" size 244763232 crc 62d4679e md5 7c350d925c911c85ef127313b54f0696 sha1 2090e7f9683081c00c6b6bafb20e2476697a1e14 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (1M)"
+	description "Enemy Zero (Japan) (Disc 0) (Opening Disc) (1M)"
+	rom ( name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (1M) (Track 1).bin" size 311461248 crc f3ded9fb md5 560e2109c42292adae0f1bdad22341d7 sha1 1c159b1eb911ff8c6b5f1b260c09a72251ccaf79 )
+)
+
+game (
+	name "Segakore Sega Bible Mogitate SegaSaturn. Soukangou 1997.11 (Japan)"
+	description "Segakore Sega Bible Mogitate SegaSaturn. Soukangou 1997.11 (Japan)"
+	rom ( name "Segakore Sega Bible Mogitate SegaSaturn. Soukangou 1997.11 (Japan) (Track 01).bin" size 117284832 crc 0d05a953 md5 0c6b3853660bb695b5a7c8515dea0853 sha1 23d88f63547014881c8420935fceb95eb868715d )
+)
+
+game (
+	name "Vampire Hunter - Darkstalker's Revenge (Japan) (En,Ja) (Sample)"
+	description "Vampire Hunter - Darkstalker's Revenge (Japan) (En,Ja) (Sample)"
+	rom ( name "Vampire Hunter - Darkstalker's Revenge (Japan) (En,Ja) (Sample) (Track 1).bin" size 484867152 crc 90b7af0c md5 a10c909ba76389502cb8a7c9e5dbff8d sha1 be5fa9b7879f989cf248d39cab488721bf7e3c4a )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Sample)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Sample)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Sample) (Track 1).bin" size 53348064 crc ea342a1e md5 d939026e8dfd2d16a06c8116684ed07b sha1 588ee5753e2c8a9c590e6a28dec1bd8b5bc7550d )
+)
+
+game (
+	name "Shining Force III - Scenario 2 - Nerawareta Miko (Japan)"
+	description "Shining Force III - Scenario 2 - Nerawareta Miko (Japan)"
+	rom ( name "Shining Force III - Scenario 2 - Nerawareta Miko (Japan) (Track 1).bin" size 307023024 crc d88476ee md5 ef890d2f6ed900ec8cc96e83a7b1c41d sha1 82c157dbad2f50bd8d1fd9b417233221ab9fd8c8 )
+)
+
+game (
+	name "Puyo Puyo Sun (Japan) (Rev A) (10M)"
+	description "Puyo Puyo Sun (Japan) (Rev A) (10M)"
+	rom ( name "Puyo Puyo Sun (Japan) (Rev A) (10M) (Track 1).bin" size 464670528 crc e1afff40 md5 bdc7629b8cb65436994737a79328f4fb sha1 8d67a56e70a606f5ddf2516e903a038a09dd027b )
+)
+
+game (
+	name "Puyo Puyo Sun (Japan) (2M)"
+	description "Puyo Puyo Sun (Japan) (2M)"
+	rom ( name "Puyo Puyo Sun (Japan) (2M) (Track 1).bin" size 464670528 crc 7ad79d38 md5 2cfd26ffd2b82f9e5d7e7102af78e9e0 sha1 4b0291bed2dbee1dccaad7e0352af557e1c4ee43 )
+)
+
+game (
+	name "NHL Powerplay '96 (USA)"
+	description "NHL Powerplay '96 (USA)"
+	rom ( name "NHL Powerplay '96 (USA) (Track 1).bin" size 333132576 crc 68bd37d5 md5 81bd8e4004137e224b1643aab081883a sha1 2eb7f8a1a487064dfc0904a94b2d0e28a9f29359 )
+)
+
+game (
+	name "Wing Arms (USA)"
+	description "Wing Arms (USA)"
+	rom ( name "Wing Arms (USA) (Track 01).bin" size 138481056 crc cdf27c99 md5 744715ea99411e6e8b0aa03c99b3728a sha1 831c6ba0f9e48b02288a68cddcdfb9d96ab9901a )
+)
+
+game (
+	name "Street Fighter - The Movie (USA) (8S)"
+	description "Street Fighter - The Movie (USA) (8S)"
+	rom ( name "Street Fighter - The Movie (USA) (8S) (Track 01).bin" size 318672480 crc 9917575a md5 dfecf6090d5aa3e94904d7ed1bd4b427 sha1 3e4db96b12dba9b4e684ff34f69c60bf62f53c34 )
+)
+
+game (
+	name "Cyber Speedway (USA)"
+	description "Cyber Speedway (USA)"
+	rom ( name "Cyber Speedway (USA) (Track 01).bin" size 62631408 crc c685dc11 md5 2b575e395f406a3803993c14813813d8 sha1 08b9fa852be3e60802e705a00e7101ed41a4ad66 )
+)
+
+game (
+	name "NASCAR 98 (USA)"
+	description "NASCAR 98 (USA)"
+	rom ( name "NASCAR 98 (USA) (Track 1).bin" size 217458864 crc 172bc479 md5 c4e62267af9b9eb1ea05595019d02897 sha1 c75a297ab7bd89f5cc53023a80c071bccebb2954 )
+)
+
+game (
+	name "Road Rash (USA)"
+	description "Road Rash (USA)"
+	rom ( name "Road Rash (USA) (Track 1).bin" size 575223936 crc 89b196e3 md5 2a5d89f827782643ba657cbf03ddbd3b sha1 5d3404a85c054012d37a7e7bfddbdc39da0bb224 )
+)
+
+game (
+	name "Road & Track Presents - The Need for Speed (USA)"
+	description "Road & Track Presents - The Need for Speed (USA)"
+	rom ( name "Road & Track Presents - The Need for Speed (USA) (Track 01).bin" size 337829520 crc b5be9c83 md5 73f216d3ec05c07a9170d3dcbfd78198 sha1 fa2ed18e91279271e4bdea651c18e7bdb1b661a4 )
+)
+
+game (
+	name "Nissan Presents - Over Drivin' GT-R (Japan)"
+	description "Nissan Presents - Over Drivin' GT-R (Japan)"
+	rom ( name "Nissan Presents - Over Drivin' GT-R (Japan) (Track 01).bin" size 272538000 crc f987ceb1 md5 4003944f48b7a2f6254eec2dc7818bde sha1 a9876a6a897205583a910ff4662016dd654edf5a )
+)
+
+game (
+	name "Nissan Presents - Over Drivin' GT-R (Japan) (Rev A)"
+	description "Nissan Presents - Over Drivin' GT-R (Japan) (Rev A)"
+	rom ( name "Nissan Presents - Over Drivin' GT-R (Japan) (Rev A) (Track 01).bin" size 272538000 crc ff1f4f1b md5 81227f505eff6a12ac37bee3548820a2 sha1 d42a3537bbbc59a520d209e028ac967e3bf9a490 )
+)
+
+game (
+	name "Virtua Cop 2 (USA)"
+	description "Virtua Cop 2 (USA)"
+	rom ( name "Virtua Cop 2 (USA) (Track 01).bin" size 37693152 crc e27ad52c md5 05a3aa6a4e5bee396ac18bc367ad38af sha1 1995dab2517c37798d38de1190dc094b8c82af9b )
+)
+
+game (
+	name "Shining Force III (USA)"
+	description "Shining Force III (USA)"
+	rom ( name "Shining Force III (USA) (Track 1).bin" size 245934528 crc f5dc8703 md5 51cc5502a3d6192cde39e9f4001ec701 sha1 9b1033304091b3dea7c2fd6d88914a1c7d0c6727 )
+)
+
+game (
+	name "Guardian Heroes (USA)"
+	description "Guardian Heroes (USA)"
+	rom ( name "Guardian Heroes (USA) (Track 01).bin" size 77460768 crc 7c3b0698 md5 bfd0671f56d4580627f3a607cf1044a8 sha1 f954e930cfffe67861a76eff154e625f1effaacf )
+)
+
+game (
+	name "Shining Wisdom (USA)"
+	description "Shining Wisdom (USA)"
+	rom ( name "Shining Wisdom (USA) (Track 1).bin" size 98993328 crc e8501a85 md5 1c41e4f63008f078abf53eef7cd5e011 sha1 4e02d81118b85f403058d1fa8a43184e07bdb44f )
+)
+
+game (
+	name "Super Puzzle Fighter II Turbo (USA)"
+	description "Super Puzzle Fighter II Turbo (USA)"
+	rom ( name "Super Puzzle Fighter II Turbo (USA) (Track 1).bin" size 406427952 crc 31307ec4 md5 b1e230ce20706615af0f1edaf2291345 sha1 21d92723345b82b1229120eb8e49ad423438996a )
+)
+
+game (
+	name "Saturn Bomberman (USA)"
+	description "Saturn Bomberman (USA)"
+	rom ( name "Saturn Bomberman (USA) (Track 01).bin" size 143399088 crc 5019cbb1 md5 b0911243c1b96bdab6ecb5a641e81b4b sha1 b95102652aac11a2ffd0460edd7972dc69df6643 )
+)
+
+game (
+	name "Mega Man 8 (USA)"
+	description "Mega Man 8 (USA)"
+	rom ( name "Mega Man 8 (USA) (Track 1).bin" size 296361408 crc 4eea7ae5 md5 a4d575cd681b7d7c88b45d639ed7ffb7 sha1 047182c8f4f5ace8b4a87d6f55d24a4a44460630 )
+)
+
+game (
+	name "Mega Man X4 (USA)"
+	description "Mega Man X4 (USA)"
+	rom ( name "Mega Man X4 (USA) (Track 1).bin" size 528550848 crc 4936b3b9 md5 751aa87f920a21c77f0fcbbfd24b5319 sha1 064d5ee316034a0e6968ced1932af7d36e0cffc1 )
+)
+
+game (
+	name "Duke Nukem 3D (USA)"
+	description "Duke Nukem 3D (USA)"
+	rom ( name "Duke Nukem 3D (USA) (Track 01).bin" size 70153104 crc 30735df6 md5 653f4d65c053e2f5b44ab1bd09ceb69a sha1 060e08b4ebf474defac585bc143a114f79e8a06c )
+)
+
+game (
+	name "Burning Rangers (USA)"
+	description "Burning Rangers (USA)"
+	rom ( name "Burning Rangers (USA) (Track 1).bin" size 373121280 crc 221d4e21 md5 5342ca09437538bcbabf224df5a856d4 sha1 47890d8237c0c0f02f8944b0e4cc1fc055b9c3db )
+)
+
+game (
+	name "Sonic Jam (USA)"
+	description "Sonic Jam (USA)"
+	rom ( name "Sonic Jam (USA) (Track 1).bin" size 631297968 crc ef4d69ef md5 4c3b955ad54ad6e3a307dd846f196783 sha1 c4ff434556ff1fc744f94fc361b4308377587693 )
+)
+
+game (
+	name "Hexen (USA)"
+	description "Hexen (USA)"
+	rom ( name "Hexen (USA) (Track 01).bin" size 142479456 crc 5cc5e188 md5 1d87f7c497f1633c89df8e5cfa03eeff sha1 28ae46aec5e0418e79a0a7ebc6f99a6c704d43c5 )
+)
+
+game (
+	name "Bug! (USA)"
+	description "Bug! (USA)"
+	rom ( name "Bug! (USA) (Track 01).bin" size 133635936 crc 06330e16 md5 fef6ca05595fbdd715f45d0f17313347 sha1 ebff7b2adc5373f3a4b507362b2b3cd9e5c408dc )
+)
+
+game (
+	name "Bug Too! (USA)"
+	description "Bug Too! (USA)"
+	rom ( name "Bug Too! (USA) (Track 01).bin" size 293442576 crc 91a26f55 md5 c06f6b8f44a438f9bed7f8b57036bb11 sha1 ef35cbc949153b1308a9833c7db93789dbb0ba03 )
+)
+
+game (
+	name "Machine Head (USA)"
+	description "Machine Head (USA)"
+	rom ( name "Machine Head (USA) (Track 01).bin" size 131338032 crc 2f6f909c md5 86da7ca1ce407ab7f01ad3ac03418264 sha1 9399a20a39cb0401f651547d14c26bd213286b40 )
+)
+
+game (
+	name "Panzer Dragoon Saga (USA) (Disc 2)"
+	description "Panzer Dragoon Saga (USA) (Disc 2)"
+	rom ( name "Panzer Dragoon Saga (USA) (Disc 2) (Track 1).bin" size 559354992 crc 4b175909 md5 8d3ca4799ed3fba24623af15b86f582d sha1 50a7cb8c5ec1bc7c586e6385cd8ac0694cd970eb )
+)
+
+game (
+	name "Panzer Dragoon Saga (USA) (Disc 4)"
+	description "Panzer Dragoon Saga (USA) (Disc 4)"
+	rom ( name "Panzer Dragoon Saga (USA) (Disc 4) (Track 1).bin" size 582660960 crc 266bf5ae md5 665e16ab6958f3b045dfc010c7f2146b sha1 11a8f4e8786cd85f1adc1aa042b54b3599be1308 )
+)
+
+game (
+	name "Panzer Dragoon Saga (USA) (Disc 1)"
+	description "Panzer Dragoon Saga (USA) (Disc 1)"
+	rom ( name "Panzer Dragoon Saga (USA) (Disc 1) (Track 1).bin" size 645501696 crc 37481032 md5 0ec7992f3c06916b1260c465beec60d5 sha1 bddd53e1877e733b0117a79ba811a4701ac2e41d )
+)
+
+game (
+	name "Panzer Dragoon Saga (USA) (Disc 3)"
+	description "Panzer Dragoon Saga (USA) (Disc 3)"
+	rom ( name "Panzer Dragoon Saga (USA) (Disc 3) (Track 1).bin" size 632248176 crc 3d113c52 md5 eaade108e99cdefc93d391e7e00b04bd sha1 a9f73785a671d9b3857711de27635f0c9e77b195 )
+)
+
+game (
+	name "Dragon Force (USA)"
+	description "Dragon Force (USA)"
+	rom ( name "Dragon Force (USA) (Track 1).bin" size 661775184 crc 1bc556b4 md5 1877bdabcea56d68b4b298dd1a830d0a sha1 b8e37ca5cbeb331718cf385119fa9357d96a5d71 )
+)
+
+game (
+	name "Battle Monsters (USA)"
+	description "Battle Monsters (USA)"
+	rom ( name "Battle Monsters (USA) (Track 1).bin" size 36432480 crc cf043c57 md5 c3140c21276cb1a3fa80eebc4c0d6f71 sha1 f260608abdd53306dac67056dc901af25cd42f75 )
+)
+
+game (
+	name "Magic Knight Rayearth (USA)"
+	description "Magic Knight Rayearth (USA)"
+	rom ( name "Magic Knight Rayearth (USA) (Track 1).bin" size 626354064 crc 37e7ef4d md5 8756dc0b21bd5cc606f5049c2fabb56d sha1 d5bc960ca5846342e07d0168b776e2aa3743b44c )
+)
+
+game (
+	name "Street Fighter Collection (USA) (Disc 1)"
+	description "Street Fighter Collection (USA) (Disc 1)"
+	rom ( name "Street Fighter Collection (USA) (Disc 1) (Track 01).bin" size 45828720 crc d32a83b3 md5 fabddec03d24ab4da1d0d7af5d57fa37 sha1 648ff024e0688e8cbee9ed1a6131e298f8f48195 )
+)
+
+game (
+	name "Street Fighter Collection (USA) (Disc 2)"
+	description "Street Fighter Collection (USA) (Disc 2)"
+	rom ( name "Street Fighter Collection (USA) (Disc 2) (Track 1).bin" size 472573248 crc dc428994 md5 50bcc46952ab8227b4047881a262bcb6 sha1 47ccb411464bd53bf5c180e91ede3656cba68114 )
+)
+
+game (
+	name "Virtual On - Cyber Troopers (USA)"
+	description "Virtual On - Cyber Troopers (USA)"
+	rom ( name "Virtual On - Cyber Troopers (USA) (Track 01).bin" size 67403616 crc c7876844 md5 55df3764d592bee566b4bdcbc06b41f6 sha1 4da61e0e32e2e60e4aca4f5f34f07ebecb0d6303 )
+)
+
+game (
+	name "Myst (USA)"
+	description "Myst (USA)"
+	rom ( name "Myst (USA) (Track 1).bin" size 585318720 crc 86363afb md5 a18a7586d7d703ab0891bd88681cc1eb sha1 f26ae2f02565e3c81fba7cceed7a70a281e70e7e )
+)
+
+game (
+	name "Fighters Megamix (USA) (RE)"
+	description "Fighters Megamix (USA) (RE)"
+	rom ( name "Fighters Megamix (USA) (RE) (Track 01).bin" size 59397408 crc 09721d6b md5 ce4bfcd83a6efdba045d0ced146b9fa4 sha1 905ed226001c4bf965ec80e12ab019854da6e12f )
+)
+
+game (
+	name "Dark Savior (USA)"
+	description "Dark Savior (USA)"
+	rom ( name "Dark Savior (USA) (Track 1).bin" size 117952800 crc 58aa1325 md5 9ceb6c099a1747e0ac22ad45913fe3fc sha1 d386d2a925c66111910c13cf3a06cde1274988d7 )
+)
+
+game (
+	name "Robotica (USA)"
+	description "Robotica (USA)"
+	rom ( name "Robotica (USA) (Track 1).bin" size 140840112 crc c9870c47 md5 8f62909b1923cdd78ecdfbf044023136 sha1 36b1c751106dcd6d1ae19cf173cae5780659b7ee )
+)
+
+game (
+	name "Croc - Legend of the Gobbos (USA)"
+	description "Croc - Legend of the Gobbos (USA)"
+	rom ( name "Croc - Legend of the Gobbos (USA) (Track 01).bin" size 231415632 crc 9a1bdb3c md5 1600bd8c93d82bafd3d9f78e1e34a264 sha1 cba62c218a6715a4517cd3b014260f9f43e25e2f )
+)
+
+game (
+	name "Astal (USA)"
+	description "Astal (USA)"
+	rom ( name "Astal (USA) (Track 1).bin" size 615464304 crc bdbd50f7 md5 b89c9cc616ea75adb44314bdd74e2121 sha1 7c287746fc175e9cca51a4150084f877357443b7 )
+)
+
+game (
+	name "Primal Rage (Europe) (En,Fr,De,Es,It,Pt)"
+	description "Primal Rage (Europe) (En,Fr,De,Es,It,Pt)"
+	rom ( name "Primal Rage (Europe) (En,Fr,De,Es,It,Pt) (Track 01).bin" size 129950352 crc c126ff17 md5 afe0a33fc0db6adbfa7d28c3ebd035ed sha1 b1deaed7e205e8c8d28534b11e5d4862281f0b72 )
+)
+
+game (
+	name "Olympic Soccer (Europe) (En,Fr,De,Es,It)"
+	description "Olympic Soccer (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Olympic Soccer (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 48693456 crc 0f9af7e5 md5 d5fb1adc36b6df194d9e1f487c292d5e sha1 445588e3168cafe435d622011824a38c7d55bcde )
+)
+
+game (
+	name "Black Dawn (USA)"
+	description "Black Dawn (USA)"
+	rom ( name "Black Dawn (USA) (Track 01).bin" size 17296608 crc 9d7d0e37 md5 000d33a5b48048f2b57210b6ed37dafb sha1 504d50c2f4ba8d24821e0b33e928b24deba5b321 )
+)
+
+game (
+	name "Battle Arena Toshinden Remix (USA)"
+	description "Battle Arena Toshinden Remix (USA)"
+	rom ( name "Battle Arena Toshinden Remix (USA) (Track 01).bin" size 144709152 crc 753a6b26 md5 01673312b60332503ab7a0a56ec1a9fb sha1 e8e47e294bd0fdf44ff48e586faebff12ba44fa6 )
+)
+
+game (
+	name "WipEout (USA)"
+	description "WipEout (USA)"
+	rom ( name "WipEout (USA) (Track 01).bin" size 55956432 crc 7f1f144d md5 f07cee2efd3731a5cfe6fc2403349055 sha1 4dd1465c33dbf8fd6cce369fce9296f06e84365a )
+)
+
+game (
+	name "Panzer Dragoon (Europe) (Demo) (5S)"
+	description "Panzer Dragoon (Europe) (Demo) (5S)"
+	rom ( name "Panzer Dragoon (Europe) (Demo) (5S) (Track 1).bin" size 34005216 crc 81a5d47e md5 71352eaad887cf1d1b483b69c7414f27 sha1 0eea3ffc71148adc9a6f6e1faf1da90548324bbf )
+)
+
+game (
+	name "Daytona USA (Europe) (1S)"
+	description "Daytona USA (Europe) (1S)"
+	rom ( name "Daytona USA (Europe) (1S) (Track 01).bin" size 9553824 crc 2f262beb md5 d29c54c6e01cb9e5c2c470fe653398cc sha1 a326849e3d86c554afa1d3fe100a3c817721d707 )
+)
+
+game (
+	name "Desire (Japan) (Disc 1)"
+	description "Desire (Japan) (Disc 1)"
+	rom ( name "Desire (Japan) (Disc 1) (Track 1).bin" size 603577296 crc 5a66d74f md5 5b7a90e8931a61733e970b578ad51e6d sha1 99f1a27ac1c2929d6b60b7c317e3f796b36eef98 )
+)
+
+game (
+	name "Desire (Japan) (Disc 2) (1M)"
+	description "Desire (Japan) (Disc 2) (1M)"
+	rom ( name "Desire (Japan) (Disc 2) (1M) (Track 1).bin" size 247653840 crc d4b1c0da md5 061b3d54d7e326f17230ca7d9ebc2df3 sha1 bf0e94902239702106a79656a98073b13e6a3a61 )
+)
+
+game (
+	name "Waku Waku Puyo Puyo Dungeon (Japan) (Sample)"
+	description "Waku Waku Puyo Puyo Dungeon (Japan) (Sample)"
+	rom ( name "Waku Waku Puyo Puyo Dungeon (Japan) (Sample) (Track 1).bin" size 39318384 crc a9b10d53 md5 57224e751c6f9d604eada51d18056146 sha1 fd670ae1ab1c6dfe8dc92c1237c211fb0ac40275 )
+)
+
+game (
+	name "Virtua Fighter Kids (Korea)"
+	description "Virtua Fighter Kids (Korea)"
+	rom ( name "Virtua Fighter Kids (Korea) (Track 01).bin" size 184293312 crc 17cc59c9 md5 7e928f58b754ef8a74361d6f944a3550 sha1 0be17beef007c489305b228a0b503959ae7bd6d1 )
+)
+
+game (
+	name "NiGHTS into Dreams... (Korea)"
+	description "NiGHTS into Dreams... (Korea)"
+	rom ( name "NiGHTS into Dreams... (Korea) (Track 01).bin" size 46005120 crc fdc86ea5 md5 fed63f3007dfb6c1777a5e52dcb1fc4a sha1 06c9913005cf5c7c1b5335f6317f26546c19f800 )
+)
+
+game (
+	name "Advanced V.G. (Japan)"
+	description "Advanced V.G. (Japan)"
+	rom ( name "Advanced V.G. (Japan) (Track 01).bin" size 92969856 crc 9fb04fec md5 ae41b533471b53601dc47cb6498eefaf sha1 242726a82702065d44fbe48fc0223220587b3c84 )
+)
+
+game (
+	name "Night Striker S (Japan)"
+	description "Night Striker S (Japan)"
+	rom ( name "Night Striker S (Japan) (Track 01).bin" size 49356720 crc adeef67c md5 0f79d1a55ce28042431983a3f9574162 sha1 d3e1f7b394cdfe9b8cb1d95c2e25245523a02049 )
+)
+
+game (
+	name "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (1M, 4M)"
+	description "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (1M, 4M)"
+	rom ( name "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (1M, 4M) (Track 1).bin" size 357748608 crc 268b4623 md5 1e34cc12e3aed064c3cce9781a31d1d5 sha1 80ff55e726563c0e51d25c76ad16a4a0a85c16f4 )
+)
+
+game (
+	name "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (2M)"
+	description "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (2M)"
+	rom ( name "World Advanced Daisenryaku - Koutetsu no Senpuu (Japan) (2M) (Track 1).bin" size 357748608 crc 268b4623 md5 1e34cc12e3aed064c3cce9781a31d1d5 sha1 80ff55e726563c0e51d25c76ad16a4a0a85c16f4 )
+)
+
+game (
+	name "World Advanced Daisenryaku - Sakusen File (Japan) (2M)"
+	description "World Advanced Daisenryaku - Sakusen File (Japan) (2M)"
+	rom ( name "World Advanced Daisenryaku - Sakusen File (Japan) (2M) (Track 1).bin" size 255027360 crc fa54bc16 md5 9c5b2a7c4bbb0a37e782efef8f91d94a sha1 9c31ee6fb23e93434864f8b75daffd3ada2a2c3b )
+)
+
+game (
+	name "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (2M)"
+	description "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (2M)"
+	rom ( name "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (2M) (Track 01).bin" size 610200528 crc 3c5065d3 md5 8e3a2b42352f5de2b6788db29902f247 sha1 72fad25960ef1e1a874cae3b739fa7bee5dc3e06 )
+)
+
+game (
+	name "House of the Dead, The (Japan) (Rev A)"
+	description "House of the Dead, The (Japan) (Rev A)"
+	rom ( name "House of the Dead, The (Japan) (Rev A) (Track 01).bin" size 75852000 crc a0e35d40 md5 7ffc2270a3997e05fd4c0cbd42ae0a70 sha1 aab5644e5ec5aa6d319a3fcb0a011577ca792aad )
+)
+
+game (
+	name "Full Cowled Mini Yonku - Super Factory (Japan) (Rev A)"
+	description "Full Cowled Mini Yonku - Super Factory (Japan) (Rev A)"
+	rom ( name "Full Cowled Mini Yonku - Super Factory (Japan) (Rev A) (Track 1).bin" size 363247584 crc 97cf099a md5 1f4969661eb2ed82310325428818eb5b sha1 3e6d51cd31c25c948fc2f38afb2ee3949977dd11 )
+)
+
+game (
+	name "Sega Saturn de Hakken!! Tamagotchi Park (Japan)"
+	description "Sega Saturn de Hakken!! Tamagotchi Park (Japan)"
+	rom ( name "Sega Saturn de Hakken!! Tamagotchi Park (Japan) (Track 1).bin" size 7815696 crc 3feb672e md5 2917c4e1bef7ce849d396b43c8783a8f sha1 0d9244f0a62fb4c7b51f6cfc06fec7f8841aad05 )
+)
+
+game (
+	name "Doom (Japan)"
+	description "Doom (Japan)"
+	rom ( name "Doom (Japan) (Track 01).bin" size 70320096 crc d4db17c2 md5 7346c43e3e936c093623b6ee9d067a20 sha1 52e910f216d85a99e9a7eb30a4a216073e982be0 )
+)
+
+game (
+	name "Universal Nuts (Japan)"
+	description "Universal Nuts (Japan)"
+	rom ( name "Universal Nuts (Japan) (Track 1).bin" size 528802512 crc cd4d4215 md5 6e3c4234864827a18ad95846b22144fd sha1 35ff72fd43bf0636a30d0643c89f9d4d1e511bc9 )
+)
+
+game (
+	name "Master of Monsters - Neo Generations (Japan)"
+	description "Master of Monsters - Neo Generations (Japan)"
+	rom ( name "Master of Monsters - Neo Generations (Japan) (Track 01).bin" size 63346416 crc 897ba4ee md5 dbd3ddfef42ecd5dc3eef74ef6536a94 sha1 dc6d25f9d025082ba72a932d89069d1d66a449f9 )
+)
+
+game (
+	name "Sega Ages - Memorial Selection Vol. 1 (Japan)"
+	description "Sega Ages - Memorial Selection Vol. 1 (Japan)"
+	rom ( name "Sega Ages - Memorial Selection Vol. 1 (Japan) (Track 01).bin" size 5371968 crc a8f92c31 md5 292251f3ade756bf3ca3ac6165650ce6 sha1 b99458da1c52bccda25d1e3aa0e534136e20db1e )
+)
+
+game (
+	name "Sega Ages - After Burner II (Japan)"
+	description "Sega Ages - After Burner II (Japan)"
+	rom ( name "Sega Ages - After Burner II (Japan) (Track 01).bin" size 3596208 crc 81004aea md5 abac2ac38a59df8ec961ca140f8ad50a sha1 6bfbe4a90370aa643f5c8aa1596f28ea1d1c7e19 )
+)
+
+game (
+	name "Sega Ages - Rouka ni Ichidanto R (Japan)"
+	description "Sega Ages - Rouka ni Ichidanto R (Japan)"
+	rom ( name "Sega Ages - Rouka ni Ichidanto R (Japan) (Track 1).bin" size 17988096 crc dc26b4aa md5 28cac1b5efd2e5d0f63a3f2506eddd88 sha1 b9455467480c35f1c3c6f159313c3e94ab90595b )
+)
+
+game (
+	name "Sega Ages - Shukudai ga Tanto R (Japan)"
+	description "Sega Ages - Shukudai ga Tanto R (Japan)"
+	rom ( name "Sega Ages - Shukudai ga Tanto R (Japan) (Track 1).bin" size 12416208 crc 08f63ed1 md5 7073a03aea180ca571983da63ce24636 sha1 2008e1cae4bf129b11dcd7963dfba085afc723de )
+)
+
+game (
+	name "Irem Arcade Classics (Japan)"
+	description "Irem Arcade Classics (Japan)"
+	rom ( name "Irem Arcade Classics (Japan) (Track 1).bin" size 86052624 crc c3c12f09 md5 f55faf852f46b7527e1b7d9d894edc19 sha1 be86999b90afa694d67c3ba5f408e3af97676fe1 )
+)
+
+game (
+	name "Sakura Taisen - Hanagumi Tsuushin (Japan) (1M)"
+	description "Sakura Taisen - Hanagumi Tsuushin (Japan) (1M)"
+	rom ( name "Sakura Taisen - Hanagumi Tsuushin (Japan) (1M) (Track 1).bin" size 163762704 crc a88ca457 md5 37ca482d65f46fa560a26a8d3a6b1380 sha1 c205cd8b74cbf4d608620b1dbc58718b8bfbf6f0 )
+)
+
+game (
+	name "Tokimeki Memorial Taisen Puzzledama (Japan) (1M)"
+	description "Tokimeki Memorial Taisen Puzzledama (Japan) (1M)"
+	rom ( name "Tokimeki Memorial Taisen Puzzledama (Japan) (1M) (Track 01).bin" size 480033792 crc aaa097e3 md5 6a1af439c7ff5d42dc3cf7325ddf8c40 sha1 4f7f6afe3baa340e0d853acf92838ea593b7c421 )
+)
+
+game (
+	name "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (5M)"
+	description "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (5M)"
+	rom ( name "Shinsetsu Yumemi Yakata - Tobira no Oku ni Darekaga... (Japan) (Rev A) (5M) (Track 1).bin" size 466048800 crc 0089a213 md5 9f495af6dc872fa0e6b5299a58d9b80a sha1 778d052ce4421784917054d22f0a6828d2efe67d )
+)
+
+game (
+	name "Nanatsu no Hikan (Japan) (Disc 1) (1M)"
+	description "Nanatsu no Hikan (Japan) (Disc 1) (1M)"
+	rom ( name "Nanatsu no Hikan (Japan) (Disc 1) (1M) (Track 01).bin" size 387696624 crc 8ca57435 md5 ba82663290f38b179e56ebabd48b837c sha1 10c8589e6a3ef1c9bdecedbc91107c53d79a50d7 )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (2M)"
+	description "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (2M)"
+	rom ( name "Eve - The Lost One (Japan) (Disc 3) (Lost One Disc) (2M) (Track 1).bin" size 144269328 crc 9a008946 md5 5bbac24b07ee11c7c48d4c44b8503022 sha1 fa8ef8d8773fb9e641c8d5bcdbe4775e70459c56 )
+)
+
+game (
+	name "Wara Wara Wars - Gekitou! Daigundan Battle (Japan)"
+	description "Wara Wara Wars - Gekitou! Daigundan Battle (Japan)"
+	rom ( name "Wara Wara Wars - Gekitou! Daigundan Battle (Japan) (Track 1).bin" size 11134368 crc a93c3a32 md5 8423ef95b4d7889e1795d27c9e1d4026 sha1 e735993e59366edcd64099861795fa9f6f225344 )
+)
+
+game (
+	name "BreakThru! (Japan)"
+	description "BreakThru! (Japan)"
+	rom ( name "BreakThru! (Japan) (Track 1).bin" size 16351104 crc 7785e0e0 md5 78b197787dcb6ea95332c39a88505b56 sha1 c3dc1df5f2220a831301d19c849fa2ef79a05a62 )
+)
+
+game (
+	name "Taito Chase H.Q. + S.C.I. (Japan)"
+	description "Taito Chase H.Q. + S.C.I. (Japan)"
+	rom ( name "Taito Chase H.Q. + S.C.I. (Japan) (Track 1).bin" size 14406000 crc ac393542 md5 fc28cbb320f4af4c7ff13ff06c027889 sha1 c50c3790b46bbf4ae43688b16db3cef9bda13773 )
+)
+
+game (
+	name "Actua Soccer (Japan)"
+	description "Actua Soccer (Japan)"
+	rom ( name "Actua Soccer (Japan) (Track 1).bin" size 121050384 crc 7132a98a md5 6aafbf96938bb9127e7989bffe3b07c6 sha1 3f9cced55c4abf560c0b9e375c68b2a6e7c31157 )
+)
+
+game (
+	name "TNN Motor Sports HardCore 4X4 (USA)"
+	description "TNN Motor Sports HardCore 4X4 (USA)"
+	rom ( name "TNN Motor Sports HardCore 4X4 (USA) (Track 1).bin" size 40880112 crc e4c4c47c md5 17260c8510de3615c297acef06e02412 sha1 ab9e55b861761f5f562df0216b538dee1c9c7a83 )
+)
+
+game (
+	name "VR Golf '97 (USA)"
+	description "VR Golf '97 (USA)"
+	rom ( name "VR Golf '97 (USA) (Track 1).bin" size 428306256 crc 096b40a4 md5 fd7bc769d3209c36d4aeab422e3e3aba sha1 ca79d2af0d48eb83c3e8511d7f983d60fdbb6d87 )
+)
+
+game (
+	name "Quake (USA)"
+	description "Quake (USA)"
+	rom ( name "Quake (USA) (Track 01).bin" size 66326400 crc 85ecb329 md5 604d3652c003dee0fc4a621979a2d4c7 sha1 ada3aa0b95f1af966c982739e17b5b1e18a3d66e )
+)
+
+game (
+	name "Fighting Vipers (USA) (5S)"
+	description "Fighting Vipers (USA) (5S)"
+	rom ( name "Fighting Vipers (USA) (5S) (Track 01).bin" size 74857104 crc 0c14fd6c md5 34aa336b0a11b0b29c54ef4e9573c814 sha1 122c167eab08bff7da34052b32ae24db14006e37 )
+)
+
+game (
+	name "NFL '97 (USA)"
+	description "NFL '97 (USA)"
+	rom ( name "NFL '97 (USA) (Track 01).bin" size 84439152 crc f5b7e452 md5 ad43debe5c19428de21bc0233979cd8f sha1 03a671bb12cad160beec29c760954f80d98c480f )
+)
+
+game (
+	name "NFL '97 (USA) (Rev A)"
+	description "NFL '97 (USA) (Rev A)"
+	rom ( name "NFL '97 (USA) (Rev A) (Track 01).bin" size 84448560 crc 0cf26141 md5 e11bd940a20966f1ee789a8e78367765 sha1 d892cc066b87801213b313cf535abaa724515a59 )
+)
+
+game (
+	name "Robo Pit (Europe)"
+	description "Robo Pit (Europe)"
+	rom ( name "Robo Pit (Europe) (Track 01).bin" size 30488976 crc 5fbb5eee md5 b24b7bf0d4e393398e6c146f7f2db112 sha1 fcff690fd8e46444bdc4bc507134367af8e17883 )
+)
+
+game (
+	name "Robo Pit (USA)"
+	description "Robo Pit (USA)"
+	rom ( name "Robo Pit (USA) (Track 01).bin" size 30456048 crc 3aff8e8f md5 01c8dd236add4bd15620dc4fb5148d82 sha1 07e8b37426aec2701376e0fcc3e34ed27896d2b8 )
+)
+
+game (
+	name "SimCity 2000 (USA)"
+	description "SimCity 2000 (USA)"
+	rom ( name "SimCity 2000 (USA) (Track 1).bin" size 191384592 crc eebbc25d md5 e85d975f2bd37f455a6d23b7e309947e sha1 3cb334c1c366eca9f4121101bc4d64d88a0ee467 )
+)
+
+game (
+	name "NFL Quarterback Club 97 (USA)"
+	description "NFL Quarterback Club 97 (USA)"
+	rom ( name "NFL Quarterback Club 97 (USA) (Track 1).bin" size 106738464 crc f43ba828 md5 aa790ed947ac240ec1aa33e332601ee3 sha1 5b7e5ef7227aa86434ac3c806127d85c39c7c915 )
+)
+
+game (
+	name "Panzer Dragoon (USA) (Playable Preview) (3S)"
+	description "Panzer Dragoon (USA) (Playable Preview) (3S)"
+	rom ( name "Panzer Dragoon (USA) (Playable Preview) (3S) (Track 1).bin" size 33995808 crc be593f0d md5 d49dda4f1b5f352e50e45cacd9b637a2 sha1 57eb4a8928e94d9e9327b2fa55dc492013af0108 )
+)
+
+game (
+	name "Impact Racing (USA)"
+	description "Impact Racing (USA)"
+	rom ( name "Impact Racing (USA) (Track 01).bin" size 47588016 crc d731035d md5 15d6885a93f0e16fd7cdc76744918277 sha1 f779b93b1512ed6976d27ec93b62d18a2ad9a43d )
+)
+
+game (
+	name "Arcade's Greatest Hits (USA)"
+	description "Arcade's Greatest Hits (USA)"
+	rom ( name "Arcade's Greatest Hits (USA) (Track 1).bin" size 468972336 crc 3aa72a8a md5 1abee358b25605cc5522a4b308c3459d sha1 d08f408addd228433ef68e22a04a1e5194bc4dd6 )
+)
+
+game (
+	name "Arcade's Greatest Hits - The Atari Collection 1 (USA)"
+	description "Arcade's Greatest Hits - The Atari Collection 1 (USA)"
+	rom ( name "Arcade's Greatest Hits - The Atari Collection 1 (USA) (Track 1).bin" size 350760816 crc f89e9732 md5 5b0f2f77f48a98398b0e566cce54872f sha1 a62ea0d96648e106c649777637c0011f02ee78ba )
+)
+
+game (
+	name "NHL All-Star Hockey (USA) (1S)"
+	description "NHL All-Star Hockey (USA) (1S)"
+	rom ( name "NHL All-Star Hockey (USA) (1S) (Track 01).bin" size 437664864 crc 17fc83b3 md5 1a3b5fd9d67356fe60d38e4f323b254e sha1 8eda60225749d8de9de8f0b01e1cd1ba69ffc73a )
+)
+
+game (
+	name "Frank Thomas Big Hurt Baseball (USA)"
+	description "Frank Thomas Big Hurt Baseball (USA)"
+	rom ( name "Frank Thomas Big Hurt Baseball (USA) (Track 1).bin" size 352839984 crc 282adcc4 md5 a2633db2f5f0683ee38e701c70a651c2 sha1 4cdd84fddd94c1a656ba043e24c7f66205933ed0 )
+)
+
+game (
+	name "Greatest Nine '96 (Japan) (3M)"
+	description "Greatest Nine '96 (Japan) (3M)"
+	rom ( name "Greatest Nine '96 (Japan) (3M) (Track 1).bin" size 155201424 crc 6b3897c2 md5 a542cb2be9e93f65ff64782f34c464af sha1 c6c8ee610dacc1d2035f8e7d6061e45624e9027f )
+)
+
+game (
+	name "Greatest Nine '96 (Japan) (Rev A) (10M)"
+	description "Greatest Nine '96 (Japan) (Rev A) (10M)"
+	rom ( name "Greatest Nine '96 (Japan) (Rev A) (10M) (Track 1).bin" size 155201424 crc 764065e6 md5 30a0cc3f59fb9cd6ede7d9d116539b6a sha1 2247850d441fdba489e036e7439824a030a56a8a )
+)
+
+game (
+	name "Pebble Beach Golf Links - Stadler ni Chousen (Japan)"
+	description "Pebble Beach Golf Links - Stadler ni Chousen (Japan)"
+	rom ( name "Pebble Beach Golf Links - Stadler ni Chousen (Japan) (Track 1).bin" size 427203168 crc 0b5e9f4f md5 965f2cfa1402ff81fd6b36e831b5f604 sha1 65f0d2bde5a8a64ee9e66d5e76ba082bf6a1c8d3 )
+)
+
+game (
+	name "HatTrick Hero S (Japan)"
+	description "HatTrick Hero S (Japan)"
+	rom ( name "HatTrick Hero S (Japan) (Track 01).bin" size 7413504 crc 5fdc0f44 md5 df896e93d1b0bf1131a31a7ef4d5cfaa sha1 421b54b3a8f52f359edc7bd83c1447bddea0d64b )
+)
+
+game (
+	name "Victory Goal Worldwide Edition (Japan)"
+	description "Victory Goal Worldwide Edition (Japan)"
+	rom ( name "Victory Goal Worldwide Edition (Japan) (Track 01).bin" size 166053552 crc 97a66790 md5 ef18d4e9c2ca0f933f247ae51e7e7adf sha1 9ce899e574e3b8f347dad7b9bfa3b203d38d2b40 )
+)
+
+game (
+	name "Sega International Victory Goal (Japan) (5M)"
+	description "Sega International Victory Goal (Japan) (5M)"
+	rom ( name "Sega International Victory Goal (Japan) (5M) (Track 01).bin" size 170602320 crc 61d6dd6c md5 c672aa3298e6bfec3233b82aa09343bd sha1 d7259cce415bdee2027a186b50d731efcbb4b655 )
+)
+
+game (
+	name "J. League Victory Goal '96 (Japan) (2M)"
+	description "J. League Victory Goal '96 (Japan) (2M)"
+	rom ( name "J. League Victory Goal '96 (Japan) (2M) (Track 01).bin" size 399277872 crc 7dfc1e0c md5 304cd5e15fb36e1c21a13f6210982e58 sha1 532cc6b1fe8f823ed4654440762a4a565a8a8610 )
+)
+
+game (
+	name "Puyo Puyo Tsuu (Japan) (1M)"
+	description "Puyo Puyo Tsuu (Japan) (1M)"
+	rom ( name "Puyo Puyo Tsuu (Japan) (1M) (Track 1).bin" size 606498480 crc 3f966f9d md5 ffc09ff9b8be1e96b8440ce7fcefea89 sha1 7dcbc65efc9d356e8216061c2cda5a71b40e291f )
+)
+
+game (
+	name "Devil Summoner - Soul Hackers - Akuma Zensho Dai-ni-shuu (Japan)"
+	description "Devil Summoner - Soul Hackers - Akuma Zensho Dai-ni-shuu (Japan)"
+	rom ( name "Devil Summoner - Soul Hackers - Akuma Zensho Dai-ni-shuu (Japan) (Track 1).bin" size 494762016 crc daded1a2 md5 ba6c8ea0baeebdfc306c1637f6744d50 sha1 4a8853aa4f140c24d453946fb525829d0186f57a )
+)
+
+game (
+	name "Shin Megami Tensei - Devil Summoner (Japan) (Rev B)"
+	description "Shin Megami Tensei - Devil Summoner (Japan) (Rev B)"
+	rom ( name "Shin Megami Tensei - Devil Summoner (Japan) (Rev B) (Track 1).bin" size 430467744 crc e70c6b92 md5 eff0ff17ada30e96dfb5b8e006267474 sha1 f2bac79dd9b5885fe435d3d24293d4308dd26b4c )
+)
+
+game (
+	name "Batman Forever - The Arcade Game (Europe)"
+	description "Batman Forever - The Arcade Game (Europe)"
+	rom ( name "Batman Forever - The Arcade Game (Europe) (Track 1).bin" size 28461552 crc 8a8ac3a0 md5 aca9744d6c8a611fc78850c6e9341a7f sha1 0b2e47f5d47e3001edb1ae1df0a8cdd3fca35a69 )
+)
+
+game (
+	name "Shin Seiki Evangelion - Eva to Yukaina Nakama-tachi (Japan)"
+	description "Shin Seiki Evangelion - Eva to Yukaina Nakama-tachi (Japan)"
+	rom ( name "Shin Seiki Evangelion - Eva to Yukaina Nakama-tachi (Japan) (Track 1).bin" size 205804704 crc 3d9abc7f md5 273b800247c5647fc615af63ecc1a2f2 sha1 53c826d92609f0c8201f38ba07ddce22057185cf )
+)
+
+game (
+	name "Elf o Karu Monotachi - Hanafuda-hen (Japan)"
+	description "Elf o Karu Monotachi - Hanafuda-hen (Japan)"
+	rom ( name "Elf o Karu Monotachi - Hanafuda-hen (Japan) (Track 1).bin" size 27386688 crc f3fed36f md5 2f5b80539f708b0f8dc51dffa0537b84 sha1 0dfcd71b3693d17a1e4687fd56fc77e82b6eb40b )
+)
+
+game (
+	name "Elf o Karu Monotachi II (Japan) (Disc 1)"
+	description "Elf o Karu Monotachi II (Japan) (Disc 1)"
+	rom ( name "Elf o Karu Monotachi II (Japan) (Disc 1) (Track 1).bin" size 554479296 crc 902671a5 md5 d3ee34d4a83c86328835531b1912b5af sha1 f4ac5a14b8036f6b7a4d396e9005de036049c36e )
+)
+
+game (
+	name "Elf o Karu Monotachi II (Japan) (Disc 2) (Omake Disc)"
+	description "Elf o Karu Monotachi II (Japan) (Disc 2) (Omake Disc)"
+	rom ( name "Elf o Karu Monotachi II (Japan) (Disc 2) (Omake Disc) (Track 01).bin" size 7171248 crc 80a7c9cf md5 01bf53191345a9cfd0ecb8a7fc50fecf sha1 6b69c29750e21a77042a4cc5cd034fcd9ef55a0b )
+)
+
+game (
+	name "Elf o Karu Monotachi (Japan) (Disc 1)"
+	description "Elf o Karu Monotachi (Japan) (Disc 1)"
+	rom ( name "Elf o Karu Monotachi (Japan) (Disc 1) (Track 1).bin" size 375355680 crc 0bcbe41c md5 e50662411efa57dde366a77aa4fb9b6d sha1 4a9aa94d71cc2f4c8afb659f88043f354cc6f5b7 )
+)
+
+game (
+	name "Elf o Karu Monotachi (Japan) (Disc 2) (Omake Disc)"
+	description "Elf o Karu Monotachi (Japan) (Disc 2) (Omake Disc)"
+	rom ( name "Elf o Karu Monotachi (Japan) (Disc 2) (Omake Disc) (Track 01).bin" size 101263008 crc fc1c9214 md5 d59195a1d26ddaca47ec2129891ee66f sha1 9d8b674dcf80e7ec96b9c8fbb792f56a76a71dd7 )
+)
+
+game (
+	name "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 1)"
+	description "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 1)"
+	rom ( name "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 1) (Track 1).bin" size 455191968 crc d09bb820 md5 4bafc62317927b6f4fd928ed91c0fe1e sha1 02e80bf640c50da94633cd46a71ed856cd58468f )
+)
+
+game (
+	name "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 2)"
+	description "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 2)"
+	rom ( name "Shoujo Kakumei Utena - Itsuka Kakumei Sareru Monogatari (Japan) (Disc 2) (Track 1).bin" size 568266720 crc ea84b5c1 md5 e1868e827dca16686d781334a2f5b702 sha1 7dee85e47594bd621f7dcdf284afc582476c0e5c )
+)
+
+game (
+	name "Angelique Special 2 (Japan)"
+	description "Angelique Special 2 (Japan)"
+	rom ( name "Angelique Special 2 (Japan) (Track 1).bin" size 459540816 crc d1332560 md5 84d12f6fd47a4a31e256aa459e8e5edb sha1 4a3db38d2c4efc14fd4f92ef7436e73d870c3b97 )
+)
+
+game (
+	name "Actua Golf (Europe) (En,Fr,De)"
+	description "Actua Golf (Europe) (En,Fr,De)"
+	rom ( name "Actua Golf (Europe) (En,Fr,De) (Track 1).bin" size 506070432 crc a3b14acd md5 183a23a7f10b498026ad837cd7cf2ae1 sha1 bb1ce881faaa05bd591accc0f35b59111c17bf7b )
+)
+
+game (
+	name "Elevator Action^2 - Returns (Japan)"
+	description "Elevator Action^2 - Returns (Japan)"
+	rom ( name "Elevator Action^2 - Returns (Japan) (Track 01).bin" size 12211584 crc 52a20f10 md5 b3ef66f9cbc8b007560c4a5d11c69aed sha1 a386344ac4167479dd82068b04200dec4a9e275a )
+)
+
+game (
+	name "Ninja Jajamaru-kun - Onigiri Ninpouchou Gold (Japan)"
+	description "Ninja Jajamaru-kun - Onigiri Ninpouchou Gold (Japan)"
+	rom ( name "Ninja Jajamaru-kun - Onigiri Ninpouchou Gold (Japan) (Track 1).bin" size 314492976 crc 130e8e2d md5 a0258bbde002a9276179f5cbfb9b2de9 sha1 22015504652ba999f7553f6de913757b697e68f9 )
+)
+
+game (
+	name "Black Fire (Japan)"
+	description "Black Fire (Japan)"
+	rom ( name "Black Fire (Japan) (Track 1).bin" size 358296624 crc 0ebcce73 md5 d917f1f61f7856d7de0cbb4dfb42a74d sha1 73fb7f2dd471559f86b97dace15d5fb404963d9d )
+)
+
+game (
+	name "Black Dawn (Japan)"
+	description "Black Dawn (Japan)"
+	rom ( name "Black Dawn (Japan) (Track 01).bin" size 17324832 crc 33e5f80c md5 5d49ff70123e14c3fab8c360f7f51b29 sha1 8ad39a7f6f955315077f67fe8b4c17ef04fec0ce )
+)
+
+game (
+	name "Thunderhawk II (Japan)"
+	description "Thunderhawk II (Japan)"
+	rom ( name "Thunderhawk II (Japan) (Track 01).bin" size 62153952 crc ebeb6246 md5 e5a2bf0bfe7aa5d020a86f9673f6c31e sha1 3c13cdb96c93396bac9fb54db7f4272ed8c7d60b )
+)
+
+game (
+	name "Soviet Strike (Japan)"
+	description "Soviet Strike (Japan)"
+	rom ( name "Soviet Strike (Japan) (Track 1).bin" size 659710128 crc 82514da1 md5 4436886711e34f3f4a8678300d9a01ed sha1 824c5d02a3606dd49b9bea5b855470554f4799f0 )
+)
+
+game (
+	name "Battle Monsters (Europe)"
+	description "Battle Monsters (Europe)"
+	rom ( name "Battle Monsters (Europe) (Track 1).bin" size 36432480 crc f24b95c2 md5 74c19430e80cd500aacede7006dc0d98 sha1 d58241cc0377996ec72300eb5bdc4011f353e120 )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (2M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (2M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 3) (2M) (Track 1).bin" size 632161152 crc 353c3a39 md5 f1e5658315ddd11c7d11783443aea918 sha1 538555faa5c358af8d588eae41eb37bb20f965c6 )
+)
+
+game (
+	name "Black Dawn (Europe)"
+	description "Black Dawn (Europe)"
+	rom ( name "Black Dawn (Europe) (Track 01).bin" size 17251920 crc 35981a33 md5 3bcb90e0755c964268696d8f9e2aedfc sha1 3bb936d2840ed237dd75799df8f1ba74ad637efc )
+)
+
+game (
+	name "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (2M)"
+	description "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (2M)"
+	rom ( name "Azel - Panzer Dragoon RPG (Japan) (Disc 1) (2M) (Track 1).bin" size 645414672 crc 708828ee md5 5d27593babac69e7ca03bd87c909db4f sha1 24cd238de0fb417680eee7855f83d04663309740 )
+)
+
+game (
+	name "Amok (Japan)"
+	description "Amok (Japan)"
+	rom ( name "Amok (Japan) (Track 1).bin" size 23741088 crc 098989a5 md5 ce071aa36331d195c8d20130ca5b50e0 sha1 ac11e1d8a41d7ebda05e122bb9c4e20d9f3cfcda )
+)
+
+game (
+	name "Blazing Dragons (Germany)"
+	description "Blazing Dragons (Germany)"
+	rom ( name "Blazing Dragons (Germany) (Track 1).bin" size 365860656 crc 97a55389 md5 ac06e224b666050b7a5a5df851eaa02f sha1 575d203ef937308ab5c513568bfa6746c526b061 )
+)
+
+game (
+	name "Krazy Ivan (Japan)"
+	description "Krazy Ivan (Japan)"
+	rom ( name "Krazy Ivan (Japan) (Track 01).bin" size 329251776 crc 7a506a8d md5 351e596684956322240a799dd4900378 sha1 717e0c83c65aa7a344bae8e2a6f36c7ed045eb89 )
+)
+
+game (
+	name "Gungriffon II (Japan)"
+	description "Gungriffon II (Japan)"
+	rom ( name "Gungriffon II (Japan) (Track 01).bin" size 84255696 crc deb1d5d9 md5 7a99d7ec075940a750a792ff8aaf541a sha1 4a9b2612d5a1642a7adce0228b3b1b9e88d73b82 )
+)
+
+game (
+	name "MechWarrior 2 (Japan)"
+	description "MechWarrior 2 (Japan)"
+	rom ( name "MechWarrior 2 (Japan) (Track 01).bin" size 213472224 crc a999c197 md5 5811f09ff48502860a6faf384a54f408 sha1 3c59c7e40bceec98b390669b9865734bf3baceb0 )
+)
+
+game (
+	name "Gungriffon (USA)"
+	description "Gungriffon (USA)"
+	rom ( name "Gungriffon (USA) (Track 01).bin" size 78559152 crc 01114dff md5 682ede711e918423e3bef00d64c446cd sha1 f42834f3762214f30ad96be92201fcd5cace8b8a )
+)
+
+game (
+	name "Brain Dead 13 (USA)"
+	description "Brain Dead 13 (USA)"
+	rom ( name "Brain Dead 13 (USA) (Track 1).bin" size 621593616 crc ef590f97 md5 e28dc3eb718f2d147b32624258f1842b sha1 ce8061a08997f3044803eab43aca7296c44c67ce )
+)
+
+game (
+	name "Pebble Beach Golf Links (USA)"
+	description "Pebble Beach Golf Links (USA)"
+	rom ( name "Pebble Beach Golf Links (USA) (Track 1).bin" size 422454480 crc 91e1defa md5 99703d591fcea714da07cd6ac45d598f sha1 d6581f0e5037c348baaa25be6b22de5af1114ba8 )
+)
+
+game (
+	name "Puzzle Bobble 3 (Japan) (1M)"
+	description "Puzzle Bobble 3 (Japan) (1M)"
+	rom ( name "Puzzle Bobble 3 (Japan) (1M) (Track 01).bin" size 24552528 crc 25431be9 md5 4a401bb9b41ea9dfd4f30220aec7945b sha1 a6119f6f262f75c25dfa9cf927e87e9b563ab99e )
+)
+
+game (
+	name "Sega Saturn Choice Cuts (USA) (RE)"
+	description "Sega Saturn Choice Cuts (USA) (RE)"
+	rom ( name "Sega Saturn Choice Cuts (USA) (RE) (Track 1).bin" size 204607536 crc 875a8456 md5 55c19d41119ea99c2458dedc7784cc41 sha1 b93dcca4f08402629b8260cf4e009963e63ae633 )
+)
+
+game (
+	name "Virtua Racing (USA) (15S)"
+	description "Virtua Racing (USA) (15S)"
+	rom ( name "Virtua Racing (USA) (15S) (Track 01).bin" size 148258320 crc 90547920 md5 3879222252c6cd12c5311ef9e05ec9e3 sha1 c7dc2f7faede1ffd3c2270652c8d12229281b05d )
+)
+
+game (
+	name "Kidou Senshi Gundam - Gihren no Yabou - Kouryaku Shireisho (Japan)"
+	description "Kidou Senshi Gundam - Gihren no Yabou - Kouryaku Shireisho (Japan)"
+	rom ( name "Kidou Senshi Gundam - Gihren no Yabou - Kouryaku Shireisho (Japan) (Track 1).bin" size 424646544 crc 2c0cfb0b md5 038f4904d1deb706aac151283ff1eb7a sha1 0e921b1878673d7b8a3fd69bddf9c9fe4373e337 )
+)
+
+game (
+	name "GunBlaze-S (Japan)"
+	description "GunBlaze-S (Japan)"
+	rom ( name "GunBlaze-S (Japan) (Track 1).bin" size 440858880 crc 8d8a74f8 md5 4546ff5145f6699e5959effb993821ab sha1 742c3c58821c17cd921ec8591c3307ed62a515eb )
+)
+
+game (
+	name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 1)"
+	description "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 1)"
+	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 1) (Track 1).bin" size 503577312 crc acc9af24 md5 d3c9e40cc1f6cc296aa5f943fea895c1 sha1 f38275a197d69325fca05f7584a66d063b9e3b43 )
+)
+
+game (
+	name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 2)"
+	description "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 2)"
+	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Disc 2) (Track 1).bin" size 395446464 crc c4f17b2c md5 3f40b4be81ae36c92b51de3f1c751eb9 sha1 7e161c2569967c06634daba84e18085345565fea )
+)
+
+game (
+	name "Real Bout Garou Densetsu (Japan) (2M)"
+	description "Real Bout Garou Densetsu (Japan) (2M)"
+	rom ( name "Real Bout Garou Densetsu (Japan) (2M) (Track 01).bin" size 30815904 crc 0e64f3c8 md5 33872a15bf967f5a252b51d839c38608 sha1 80bab0f2e985b54ade495148173aea0ea219d93f )
+)
+
+game (
+	name "Real Bout Garou Densetsu Special (Japan) (Rev A)"
+	description "Real Bout Garou Densetsu Special (Japan) (Rev A)"
+	rom ( name "Real Bout Garou Densetsu Special (Japan) (Rev A) (Track 01).bin" size 71385552 crc a3101144 md5 1a230a134615aac555d5ac229b08c6b5 sha1 766813a7280d1f53e5191c07411626b90c513939 )
+)
+
+game (
+	name "Marica - Shinjitsu no Sekai (Japan)"
+	description "Marica - Shinjitsu no Sekai (Japan)"
+	rom ( name "Marica - Shinjitsu no Sekai (Japan) (Track 1).bin" size 642999168 crc 02c129fe md5 a7f2aed45cc7ddb017fa60258560b119 sha1 cfcbb000a24a56f7da087f9d0d6bade470e596bf )
+)
+
+game (
+	name "Linda^3 Kanzenban (Japan)"
+	description "Linda^3 Kanzenban (Japan)"
+	rom ( name "Linda^3 Kanzenban (Japan) (Track 1).bin" size 385683312 crc 7e6330ca md5 837ce34e8227f306b599eabfd78fbe27 sha1 b6526c36bc60bdea7c69cfa26077ea7496766ac8 )
+)
+
+game (
+	name "Soukyuu Gurentai Otokuyou (Japan)"
+	description "Soukyuu Gurentai Otokuyou (Japan)"
+	rom ( name "Soukyuu Gurentai Otokuyou (Japan) (Track 01).bin" size 43302672 crc aca6e12b md5 c7ce4ed25a7ca66bc8040696ddc60d0c sha1 24a844501d930495d3ee7ae34772ac0023e63eb4 )
+)
+
+game (
+	name "Sonic Jam (Japan) (Rev A)"
+	description "Sonic Jam (Japan) (Rev A)"
+	rom ( name "Sonic Jam (Japan) (Rev A) (Track 1).bin" size 631297968 crc 20735b89 md5 64c20d23b003edb1f94d7997b8455f6f sha1 3f312f597649f3311614d2de6070336c104daae5 )
+)
+
+game (
+	name "Three Dirty Dwarves (Japan) (2M)"
+	description "Three Dirty Dwarves (Japan) (2M)"
+	rom ( name "Three Dirty Dwarves (Japan) (2M) (Track 1).bin" size 197937264 crc fc06c6b3 md5 651e95cc0dc246f0a79c609d092e3789 sha1 4847e559769e06ebaf53153862bdd6a3773583c8 )
+)
+
+game (
+	name "Ninpen Manmaru (Japan)"
+	description "Ninpen Manmaru (Japan)"
+	rom ( name "Ninpen Manmaru (Japan) (Track 1).bin" size 57214752 crc 0ed1ef28 md5 fd39c220406a70b48f55462340864b61 sha1 d70b79bd293faf38aa80b11adfc83be076560b9c )
+)
+
+game (
+	name "Batman Forever - The Arcade Game (Japan)"
+	description "Batman Forever - The Arcade Game (Japan)"
+	rom ( name "Batman Forever - The Arcade Game (Japan) (Track 1).bin" size 28461552 crc a1ae93db md5 0782362c11ca394a2a8d2da69b9c7e44 sha1 5a5de1bdccb75231731ca952a5e143fdcd231fd7 )
+)
+
+game (
+	name "Falcom Classics II (Japan)"
+	description "Falcom Classics II (Japan)"
+	rom ( name "Falcom Classics II (Japan) (Track 1).bin" size 561859872 crc d1462e35 md5 f318ceab24508302e15df193f3969373 sha1 339030bd0fe482f8553ef46211a31e40fc4f5957 )
+)
+
+game (
+	name "Iron Man & X-O Manowar in Heavy Metal (Japan)"
+	description "Iron Man & X-O Manowar in Heavy Metal (Japan)"
+	rom ( name "Iron Man & X-O Manowar in Heavy Metal (Japan) (Track 01).bin" size 178128720 crc 7a1a1404 md5 98f72116940421e2f5dfa3e6bddcbe7f sha1 e97bbfef856bfb2910afc2aeb100318c3e6cf455 )
+)
+
+game (
+	name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev A)"
+	description "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev A)"
+	rom ( name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev A) (Track 1).bin" size 263369904 crc b7713a0b md5 8adeba8af559ac797d58138f90f105d5 sha1 813c7bb290a1b4c8a49509ca1f4c58141d9dedfd )
+)
+
+game (
+	name "Hexen (Europe) (En,Fr,De,Es,It)"
+	description "Hexen (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Hexen (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 142479456 crc d97b9471 md5 ba431e654d02fd07eeaca43c6e4a65f6 sha1 7337dbd48e6540ef108aff3f88ea1c4e20477d0a )
+)
+
+game (
+	name "Panzer Dragoon (Japan) (4B)"
+	description "Panzer Dragoon (Japan) (4B)"
+	rom ( name "Panzer Dragoon (Japan) (4B) (Track 01).bin" size 256278624 crc bdc4cff8 md5 b4b35400bb956837fa3301cd4faf68dc sha1 62704a420aad185e27df23c8df924cdde7b17f14 )
+)
+
+game (
+	name "G Vector (Japan)"
+	description "G Vector (Japan)"
+	rom ( name "G Vector (Japan) (Track 01).bin" size 41030640 crc 1c3db424 md5 993f5113d8336b393572e77db29097ed sha1 7d914d5ba9fad1be8ab10642e368d4a3e78db828 )
+)
+
+game (
+	name "Baldy Land (Japan)"
+	description "Baldy Land (Japan)"
+	rom ( name "Baldy Land (Japan) (Track 01).bin" size 19389888 crc ec4de84d md5 ce0b4ce84bd4e79590f970c108821908 sha1 c177a396a5463802089e0802dfa44403601b47ff )
+)
+
+game (
+	name "Waku Waku 7 (Japan)"
+	description "Waku Waku 7 (Japan)"
+	rom ( name "Waku Waku 7 (Japan) (Track 01).bin" size 35797440 crc 0ed785c6 md5 09c7d5b496ce0317e69858a08392078d sha1 2882fde607f85fb659c9a5c53b750f6bb6f1c87b )
+)
+
+game (
+	name "Garou Densetsu 3 - Road to the Final Victory (Japan)"
+	description "Garou Densetsu 3 - Road to the Final Victory (Japan)"
+	rom ( name "Garou Densetsu 3 - Road to the Final Victory (Japan) (Track 01).bin" size 38523408 crc 5ad172b4 md5 7d1af316f841e446b66777785becd5f6 sha1 be8cf5a902265c0e9f9925f53b7882c43a9fecc2 )
+)
+
+game (
+	name "Street Fighter Zero 2' (Japan)"
+	description "Street Fighter Zero 2' (Japan)"
+	rom ( name "Street Fighter Zero 2' (Japan) (Track 1).bin" size 474607728 crc 3cf8d1fd md5 d07d86d4bf79fa0b5670751d68506e14 sha1 95ac5204714893457b1addb6506a13e751b74ae8 )
+)
+
+game (
+	name "Shinouken (Japan)"
+	description "Shinouken (Japan)"
+	rom ( name "Shinouken (Japan) (Track 01).bin" size 39318384 crc 0ad164e4 md5 e477a1060024792900ade0b26b8dd3d0 sha1 c785f441f88915e27816800b442a9647ce316291 )
+)
+
+game (
+	name "World Heroes Perfect (Japan)"
+	description "World Heroes Perfect (Japan)"
+	rom ( name "World Heroes Perfect (Japan) (Track 01).bin" size 36432480 crc 2f836b09 md5 2e548131abf36a769de1eafb1e63b7d0 sha1 acea87211e4c7071c82977ea71a71ebb42048cf9 )
+)
+
+game (
+	name "Suiko Enbu (Japan)"
+	description "Suiko Enbu (Japan)"
+	rom ( name "Suiko Enbu (Japan) (Track 01).bin" size 26779872 crc ca3f7d78 md5 f0ae15b2fb9e52923184e60a375db1bf sha1 2952351d86e8799d220a8fab6d4bb74c5f06c96a )
+)
+
+game (
+	name "Suiko Enbu - Fuuun Saiki (Japan)"
+	description "Suiko Enbu - Fuuun Saiki (Japan)"
+	rom ( name "Suiko Enbu - Fuuun Saiki (Japan) (Track 01).bin" size 21541968 crc c9c27d01 md5 90f91b19e195ffc880824b19f20a4f8a sha1 d260569c806d77eecede98c4d527095e32201b78 )
+)
+
+game (
+	name "Fire Prowrestling S - 6Men Scramble (Japan) (1M)"
+	description "Fire Prowrestling S - 6Men Scramble (Japan) (1M)"
+	rom ( name "Fire Prowrestling S - 6Men Scramble (Japan) (1M) (Track 1).bin" size 488802048 crc 18b025ae md5 737e83c03bb52f42a2d1e734cda1117b sha1 cd78bd2d77c2de30f640d38663e2111fbf576c2a )
+)
+
+game (
+	name "Fire Pro Gaiden Blazing Tornado (Japan)"
+	description "Fire Pro Gaiden Blazing Tornado (Japan)"
+	rom ( name "Fire Pro Gaiden Blazing Tornado (Japan) (Track 01).bin" size 107770992 crc 5f6d8ad3 md5 10a32fad73f90a67ca04e3a47c494f55 sha1 863004410ac94e3e835e06990d6ae9d9fb917284 )
+)
+
+game (
+	name "K-1 Grand Prix - Fighting Illusion Shou (Japan)"
+	description "K-1 Grand Prix - Fighting Illusion Shou (Japan)"
+	rom ( name "K-1 Grand Prix - Fighting Illusion Shou (Japan) (Track 01).bin" size 113531040 crc d9042a6b md5 940c1378fc6572fd4b559b075de50534 sha1 bb4b7a436d3b0fbfc47cf8ee3c58513dac2d996a )
+)
+
+game (
+	name "Legend of K-1 - The Best Collection (Japan)"
+	description "Legend of K-1 - The Best Collection (Japan)"
+	rom ( name "Legend of K-1 - The Best Collection (Japan) (Track 1).bin" size 654648624 crc d136d0d3 md5 f180f6e077949b8f2d39df5a284138c4 sha1 f1101b0e9b8bc4ba3aa30ed3f8b50a32c495faba )
+)
+
+game (
+	name "Ultraman - Hikari no Kyojin Densetsu (Japan)"
+	description "Ultraman - Hikari no Kyojin Densetsu (Japan)"
+	rom ( name "Ultraman - Hikari no Kyojin Densetsu (Japan) (Track 01).bin" size 216802656 crc 6585fb25 md5 77ce070cb58daf1550fdc2d577083747 sha1 dddb9816f3dbcedfd314a76a25c835ec9c566f5f )
+)
+
+game (
+	name "Wizard's Harmony 2 (Japan) (1M)"
+	description "Wizard's Harmony 2 (Japan) (1M)"
+	rom ( name "Wizard's Harmony 2 (Japan) (1M) (Track 1).bin" size 48959232 crc 94957406 md5 e43a552a967d133b704de8fc65445a0c sha1 e052e38d1f8d4842906d757b0a35f7cae6d8d870 )
+)
+
+game (
+	name "Mr. Bones (Japan) (Disc 2)"
+	description "Mr. Bones (Japan) (Disc 2)"
+	rom ( name "Mr. Bones (Japan) (Disc 2) (Track 01).bin" size 270882192 crc 51e96595 md5 44358bf34041b5565d13fc3140ffbb51 sha1 f81dec3af18e0fec29d6330230bba5802bc82091 )
+)
+
+game (
+	name "Lost World, The - Jurassic Park (Japan)"
+	description "Lost World, The - Jurassic Park (Japan)"
+	rom ( name "Lost World, The - Jurassic Park (Japan) (Track 01).bin" size 161791728 crc c77ed3f4 md5 114059889dcac6e56491cc889c254724 sha1 8384d75926d5608d116efedf0d2b3751e50ec453 )
+)
+
+game (
+	name "Tanjou S - Debut (Japan) (5M)"
+	description "Tanjou S - Debut (Japan) (5M)"
+	rom ( name "Tanjou S - Debut (Japan) (5M) (Track 1).bin" size 556965360 crc 42fe26c3 md5 76767413863dd33ba16e3100da114e5d sha1 14a7ac866a31c4e149e2f9d8daa4ad4c6e551b4c )
+)
+
+game (
+	name "Lode Runner - The Legend Returns (Japan)"
+	description "Lode Runner - The Legend Returns (Japan)"
+	rom ( name "Lode Runner - The Legend Returns (Japan) (Track 01).bin" size 11672976 crc 8b6d4938 md5 87d7456c6f460dcd0c1b8355417853f9 sha1 68cbcd997c2406f043119fd4bfc077e254e770e6 )
+)
+
+game (
+	name "Lode Runner Extra (Japan)"
+	description "Lode Runner Extra (Japan)"
+	rom ( name "Lode Runner Extra (Japan) (Track 01).bin" size 12308016 crc 4a24e48d md5 1ee6345238b067250acc4fdef78e7c2c sha1 bf6a89fd6a03e6ae7e0679f092e6f2b747566a68 )
+)
+
+game (
+	name "Fighting Vipers (USA) (6S)"
+	description "Fighting Vipers (USA) (6S)"
+	rom ( name "Fighting Vipers (USA) (6S) (Track 01).bin" size 74857104 crc 0c14fd6c md5 34aa336b0a11b0b29c54ef4e9573c814 sha1 122c167eab08bff7da34052b32ae24db14006e37 )
+)
+
+game (
+	name "Next King - Koi no Sennen Oukoku (Japan)"
+	description "Next King - Koi no Sennen Oukoku (Japan)"
+	rom ( name "Next King - Koi no Sennen Oukoku (Japan) (Track 1).bin" size 189578256 crc a285e554 md5 463427045f17d592759b6911cba80df5 sha1 df6741c2e7919b7e43e48b2c932bb8ba1b067a28 )
+)
+
+game (
+	name "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (USA)"
+	description "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (USA)"
+	rom ( name "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (USA) (Track 1).bin" size 122922576 crc ac85b5c4 md5 69ceacd52ab5a3c981682215dca5522f sha1 dc29aa6093ab99b87b8f1bda46542412ee717bea )
+)
+
+game (
+	name "Slam 'n Jam '96 featuring Magic & Kareem (Japan)"
+	description "Slam 'n Jam '96 featuring Magic & Kareem (Japan)"
+	rom ( name "Slam 'n Jam '96 featuring Magic & Kareem (Japan) (Track 1).bin" size 122948448 crc 9abd5020 md5 d6ee65d8118cd70090f84e70a5f27d68 sha1 952357c55f83e945dffe2ebdfe1758360bef84b8 )
+)
+
+game (
+	name "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 1) (2M)"
+	description "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 1) (2M)"
+	rom ( name "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 1) (2M) (Track 01).bin" size 919632 crc 6f55f3cb md5 1daabe996d0a70a66166cc687c615ca1 sha1 18582073cab76b85ebff4c9a2d6dffe88c3648ce )
+)
+
+game (
+	name "Virtua Cop 2 (Japan) (3M)"
+	description "Virtua Cop 2 (Japan) (3M)"
+	rom ( name "Virtua Cop 2 (Japan) (3M) (Track 01).bin" size 37702560 crc a95e48e9 md5 41e990adbd1d3255217e407d3869d7c8 sha1 dbc979c79cab0b428ea253ffbdaf622e0c476fa7 )
+)
+
+game (
+	name "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 2)"
+	description "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 2)"
+	rom ( name "Voice Idol Maniacs - Pool Bar Story (Japan) (Disc 2) (Track 1).bin" size 919632 crc 975acf5b md5 15ab43a84496a05af4e022ba1997c2f7 sha1 0f226c5eca572988bdff4b5a8dff74bced40c529 )
+)
+
+game (
+	name "Uno DX (Japan)"
+	description "Uno DX (Japan)"
+	rom ( name "Uno DX (Japan) (Track 1).bin" size 60860352 crc 4cf77321 md5 bb6303ed3a4775ed0173c664b9b46f30 sha1 d7ceb82b83f80a8fd9327409b0147e9a38356f9b )
+)
+
+game (
+	name "Revolution X - Music Is the Weapon (Japan) (10S)"
+	description "Revolution X - Music Is the Weapon (Japan) (10S)"
+	rom ( name "Revolution X - Music Is the Weapon (Japan) (10S) (Track 01).bin" size 12503232 crc 31c22082 md5 fdd67164932c86d1a7b1dd12c161d571 sha1 657d3421650b8480c62b3a18277f5f0b42441c43 )
+)
+
+game (
+	name "Tactics Ogre - Let Us Cling Together (Japan)"
+	description "Tactics Ogre - Let Us Cling Together (Japan)"
+	rom ( name "Tactics Ogre - Let Us Cling Together (Japan) (Track 01).bin" size 295430016 crc 6791dad8 md5 5835038936b1eef19063b1627c7f2e46 sha1 24ce1a059c7172065204f0b22b0c82fc7cce53e3 )
+)
+
+game (
+	name "Sega Saturn - SGL Tool Kit - Sega 3D Game Library (Japan)"
+	description "Sega Saturn - SGL Tool Kit - Sega 3D Game Library (Japan)"
+	rom ( name "Sega Saturn - SGL Tool Kit - Sega 3D Game Library (Japan) (Track 1).bin" size 84902496 crc 63c12369 md5 0a8fd8e047578ed2c88474d24e11b678 sha1 1e3590758b3d7260b36f648aef31b687531e3e53 )
+)
+
+game (
+	name "Virtua Photo Studio - Cameraman Simulation (Japan) (1M, 2M)"
+	description "Virtua Photo Studio - Cameraman Simulation (Japan) (1M, 2M)"
+	rom ( name "Virtua Photo Studio - Cameraman Simulation (Japan) (1M, 2M) (Track 1).bin" size 650725488 crc af0931f0 md5 89216e37443f986c7478bc316a0a7432 sha1 87591768f47662c106f099cc6a1040a78e4578a3 )
+)
+
+game (
+	name "Bust-A-Move 2 - Arcade Edition (Europe)"
+	description "Bust-A-Move 2 - Arcade Edition (Europe)"
+	rom ( name "Bust-A-Move 2 - Arcade Edition (Europe) (Track 01).bin" size 14321328 crc 5ab7c34d md5 ef71713d4cb3e08914148829b1bffe23 sha1 37fb0db994cf91f3ef34059fed47974c862d77ba )
+)
+
+game (
+	name "Grandia (Japan) (Disc 2) (1M, 2M)"
+	description "Grandia (Japan) (Disc 2) (1M, 2M)"
+	rom ( name "Grandia (Japan) (Disc 2) (1M, 2M) (Track 1).bin" size 585104688 crc af818605 md5 b719951858337593af00b35c835a77c3 sha1 023f0894b5ba9ae1224aeb2e241a5c7b275fde0c )
+)
+
+game (
+	name "Langrisser - Dramatic Edition (Japan) (1M)"
+	description "Langrisser - Dramatic Edition (Japan) (1M)"
+	rom ( name "Langrisser - Dramatic Edition (Japan) (1M) (Track 1).bin" size 392784000 crc 3da1e7c9 md5 3f7bf0e1e3d70356828d962eebdc085e sha1 771515a4e9dee1225d73a206dd0d7ce154b113d0 )
+)
+
+game (
+	name "Langrisser IV (Japan) (1M, 3M)"
+	description "Langrisser IV (Japan) (1M, 3M)"
+	rom ( name "Langrisser IV (Japan) (1M, 3M) (Track 1).bin" size 96817728 crc 74cd685c md5 399c41e0a05cc80255cbde4d780f1632 sha1 31b3f3efe7d37d9172da5034019dfcacb9a01193 )
+)
+
+game (
+	name "Techno Motor (Japan)"
+	description "Techno Motor (Japan)"
+	rom ( name "Techno Motor (Japan) (Track 1).bin" size 235181184 crc 9188126a md5 ed16060be7bddf2230725d0ed14fc9d6 sha1 b9c923c542110ef332815357c2728c082d59b86a )
+)
+
+game (
+	name "Lunar - Silver Star Story (Japan) (MPEG-ban)"
+	description "Lunar - Silver Star Story (Japan) (MPEG-ban)"
+	rom ( name "Lunar - Silver Star Story (Japan) (MPEG-ban) (Track 1).bin" size 83710032 crc be2032b4 md5 8bdc880445c5d883c833cbe850fc5e0c sha1 b6d71e1c96211af46d83278eccf7d6827a57d004 )
+)
+
+game (
+	name "Mahou Gakuen Lunar! (Japan) (2M)"
+	description "Mahou Gakuen Lunar! (Japan) (2M)"
+	rom ( name "Mahou Gakuen Lunar! (Japan) (2M) (Track 01).bin" size 454643952 crc 3cc5331f md5 7235eb0892ce34a4a996fc95aff9687f sha1 fcdcc837b7bd233e06acb687dbb264307234037d )
+)
+
+game (
+	name "My Best Friends - St. Andrew Jogakuin-hen (Japan)"
+	description "My Best Friends - St. Andrew Jogakuin-hen (Japan)"
+	rom ( name "My Best Friends - St. Andrew Jogakuin-hen (Japan) (Track 01).bin" size 398955648 crc e2063661 md5 89bcad17dd4fc5768fd4b9cfcb282cd6 sha1 ff1c319d8ed69394ccabf78f0f154e7f98d3e8f2 )
+)
+
+game (
+	name "Angel Paradise Vol. 1 - Sakaki Yuko - Koi no Yokan in Hollywood (Japan)"
+	description "Angel Paradise Vol. 1 - Sakaki Yuko - Koi no Yokan in Hollywood (Japan)"
+	rom ( name "Angel Paradise Vol. 1 - Sakaki Yuko - Koi no Yokan in Hollywood (Japan) (Track 1).bin" size 465966480 crc 2f3bcbe2 md5 0849681d8eab50634678f28613fa4d51 sha1 6b0599dd5b0f85197c368334a3b74ba636f7c568 )
+)
+
+game (
+	name "Angel Paradise Vol. 2 - Yoshino Kimika - Isshoni I-ta-i in Hawaii (Japan)"
+	description "Angel Paradise Vol. 2 - Yoshino Kimika - Isshoni I-ta-i in Hawaii (Japan)"
+	rom ( name "Angel Paradise Vol. 2 - Yoshino Kimika - Isshoni I-ta-i in Hawaii (Japan) (Track 1).bin" size 565267920 crc cbf53ee3 md5 9f321f91b7f8d3538f2fa3d86512ac0d sha1 cdeb144c333e0305a28738329bdfb365b1c7002a )
+)
+
+game (
+	name "Girls in Motion Puzzle Vol. 1 - Hiyake no Omoide + Himekuri (Japan)"
+	description "Girls in Motion Puzzle Vol. 1 - Hiyake no Omoide + Himekuri (Japan)"
+	rom ( name "Girls in Motion Puzzle Vol. 1 - Hiyake no Omoide + Himekuri (Japan) (Track 1).bin" size 321290256 crc b736b6e5 md5 76fbd92cdf4fd6699b0f87e72a067249 sha1 2d919d5f1f2085c40412b0a6544a6fdbe6505381 )
+)
+
+game (
+	name "Girls in Motion Puzzle Vol. 2 - Body Special 264 (Japan)"
+	description "Girls in Motion Puzzle Vol. 2 - Body Special 264 (Japan)"
+	rom ( name "Girls in Motion Puzzle Vol. 2 - Body Special 264 (Japan) (Track 1).bin" size 624023232 crc e24eb3bc md5 bbd5ce52f26c892ebe21baeee07c2fb7 sha1 5aca3dafb47b2277100a47e9f23bf2073b56daac )
+)
+
+game (
+	name "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 1)"
+	description "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 1)"
+	rom ( name "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 1) (Track 1).bin" size 536124288 crc e2ac2ccc md5 9cacc94ad22ece9227116ff7641d9c71 sha1 c060ebc7498374cf3f5add15f98fc227057ec090 )
+)
+
+game (
+	name "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 2)"
+	description "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 2)"
+	rom ( name "Cross Tantei Monogatari - Motsureta Nanatsu no Labyrinth (Japan) (Disc 2) (Track 1).bin" size 522706128 crc ce9735cd md5 8b43f8eeb9f21dc2f339cb3320d22eba sha1 860a811e606a97aff192c4c06b02720775677c6a )
+)
+
+game (
+	name "WWF WrestleMania - The Arcade Game (Japan)"
+	description "WWF WrestleMania - The Arcade Game (Japan)"
+	rom ( name "WWF WrestleMania - The Arcade Game (Japan) (Track 01).bin" size 29301216 crc 0fd541f4 md5 168895f2a18be27edd8b24f94323a4e2 sha1 97a4c503b284b63ae50278fc16c49c64a2b69ac1 )
+)
+
+game (
+	name "No-appointment Gals Olympos (Japan)"
+	description "No-appointment Gals Olympos (Japan)"
+	rom ( name "No-appointment Gals Olympos (Japan) (Track 1).bin" size 553961856 crc 45fce898 md5 c206b875d5be3fdb82a150564971455d sha1 d0c969c5d483d311630d31494af34e29b3256be1 )
+)
+
+game (
+	name "Command & Conquer (France) (Disc 1) (GDI Disc)"
+	description "Command & Conquer (France) (Disc 1) (GDI Disc)"
+	rom ( name "Command & Conquer (France) (Disc 1) (GDI Disc) (Track 01).bin" size 390944736 crc d0121565 md5 942644a6d3e1f0c4bba14ad62265f86d sha1 73b5db33173935562fd15e6376dd390faecffa1e )
+)
+
+game (
+	name "Aquazone - Desktop Life Option Disc Series 2 - Black Molly (Japan) (Rev A)"
+	description "Aquazone - Desktop Life Option Disc Series 2 - Black Molly (Japan) (Rev A)"
+	rom ( name "Aquazone - Desktop Life Option Disc Series 2 - Black Molly (Japan) (Rev A) (Track 01).bin" size 743232 crc badf658c md5 0627b7194a3806efc9428e8f1e78fde3 sha1 15c9524f9f6fc6e397a456fc5e201c585596da23 )
+)
+
+game (
+	name "Command & Conquer (France) (Disc 2) (NOD Disc)"
+	description "Command & Conquer (France) (Disc 2) (NOD Disc)"
+	rom ( name "Command & Conquer (France) (Disc 2) (NOD Disc) (Track 01).bin" size 322426272 crc 743af7de md5 132bb2552a19233520ee5303d57f5222 sha1 a442a068be0fcb5991001fa90189d9c1bcbe8104 )
+)
+
+game (
+	name "Earthworm Jim 2 (Japan) (2M)"
+	description "Earthworm Jim 2 (Japan) (2M)"
+	rom ( name "Earthworm Jim 2 (Japan) (2M) (Track 01).bin" size 29835120 crc 727ad733 md5 afae4d6c6e1390e5b678975754b48ba0 sha1 fd23450d179dbd6fda8981eda949909320694c4f )
+)
+
+game (
+	name "Gex (Japan)"
+	description "Gex (Japan)"
+	rom ( name "Gex (Japan) (Track 1).bin" size 205282560 crc 2c29e2e1 md5 0db3260ad79951d90cf569df77b5aa64 sha1 b3acaab1ada4b29ba14f2cf13294eb794bed973f )
+)
+
+game (
+	name "Johnny Bazooka (Japan)"
+	description "Johnny Bazooka (Japan)"
+	rom ( name "Johnny Bazooka (Japan) (Track 01).bin" size 192417120 crc e7d8cd67 md5 27fbcb7771aa5150df86e9ac857fc0ab sha1 3711f41021f7e40162f3a83f2760e7c272fb84f4 )
+)
+
+game (
+	name "Spot Goes to Hollywood (Japan)"
+	description "Spot Goes to Hollywood (Japan)"
+	rom ( name "Spot Goes to Hollywood (Japan) (Track 01).bin" size 188872656 crc 4ed9f08d md5 59096b8bcc7e0565ed3ba5351b159074 sha1 46eec324706b00cd58de3ac737908b26bd5b6b89 )
+)
+
+game (
+	name "Defcon 5 (Japan)"
+	description "Defcon 5 (Japan)"
+	rom ( name "Defcon 5 (Japan) (Track 1).bin" size 228880176 crc ce8cbbec md5 ab5c6e7402c070b7eb0670bc7c666d3c sha1 db52080f8c51781d17e56efee77daaddf6106794 )
+)
+
+game (
+	name "Deadalus (Japan) (2A)"
+	description "Deadalus (Japan) (2A)"
+	rom ( name "Deadalus (Japan) (2A) (Track 1).bin" size 141414000 crc 578d3a96 md5 f0a68872839a442cfbf9b2b329a35964 sha1 01c0a63285e023dd95284383795fe75fcf252b9c )
+)
+
+game (
+	name "Soeldnerschild (Japan)"
+	description "Soeldnerschild (Japan)"
+	rom ( name "Soeldnerschild (Japan) (Track 1).bin" size 153738480 crc 55d6817a md5 957bc8ad98d247d8281b9a9f2651b698 sha1 d8d261f08bbb2f3ab1aceee36709471a3888dad7 )
+)
+
+game (
+	name "Yellow Brick Road (Japan) (3M)"
+	description "Yellow Brick Road (Japan) (3M)"
+	rom ( name "Yellow Brick Road (Japan) (3M) (Track 1).bin" size 513846144 crc 08396284 md5 b56387a719ddd8bc95f38e2fe3ee254c sha1 ed756f468e4134fbbd9143e62c92fe1c9e955ab6 )
+)
+
+game (
+	name "Tilk - Aoi Umi kara Kita Shoujo (Japan)"
+	description "Tilk - Aoi Umi kara Kita Shoujo (Japan)"
+	rom ( name "Tilk - Aoi Umi kara Kita Shoujo (Japan) (Track 1).bin" size 498659280 crc 7bdb0297 md5 0d709f4d2093d8839b0594eafede5d8f sha1 00ba63b2b6021700252f447a4a4d02053a6f2367 )
+)
+
+game (
+	name "Fantastep (Japan)"
+	description "Fantastep (Japan)"
+	rom ( name "Fantastep (Japan) (Track 01).bin" size 306724320 crc 8753fc8a md5 006041aa8ea497961b8429ed903c303a sha1 0fabc5b95c164057c36616e4deb51315d4307b3e )
+)
+
+game (
+	name "Dungeon Master Nexus (Japan)"
+	description "Dungeon Master Nexus (Japan)"
+	rom ( name "Dungeon Master Nexus (Japan) (Track 1).bin" size 139278384 crc 6852311b md5 d83623212c7fd61623377cc9074bf3ea sha1 2218799e3d832651baed624563c6027e99856297 )
+)
+
+game (
+	name "Bouken Katsugeki Monomono (Japan)"
+	description "Bouken Katsugeki Monomono (Japan)"
+	rom ( name "Bouken Katsugeki Monomono (Japan) (Track 1).bin" size 189677040 crc 63bedea7 md5 34aea42b83d4e5d28aa519131847978f sha1 1b973e64ce7a6f598eed5db33bf7f2d02efa855d )
+)
+
+game (
+	name "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 1)"
+	description "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 1)"
+	rom ( name "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 1) (Track 01).bin" size 460815600 crc 8bd4a0ae md5 1cd73842c34e81fef9c1f11dcccf7d14 sha1 708ca605619b2fa90e90bd19348d241d9c134f59 )
+)
+
+game (
+	name "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 2) (Premium CD)"
+	description "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 2) (Premium CD)"
+	rom ( name "Nanatsu Kaze no Shima Monogatari (Japan) (Disc 2) (Premium CD) (Track 1).bin" size 139551216 crc ad76e75e md5 5aa1d40b0cf50bf19960f75360213241 sha1 23116bdf79bcd3a93c5f8ce92e8b55461f87ff34 )
+)
+
+game (
+	name "Tactical Fighter (Japan)"
+	description "Tactical Fighter (Japan)"
+	rom ( name "Tactical Fighter (Japan) (Track 1).bin" size 238161168 crc 099ed357 md5 fefb4a97123051ea56977014282565f9 sha1 44a409a09f0217c9825fcd5519d29a32082eca54 )
+)
+
+game (
+	name "Wangan Trial Love (Japan)"
+	description "Wangan Trial Love (Japan)"
+	rom ( name "Wangan Trial Love (Japan) (Track 01).bin" size 186348960 crc c3b4901e md5 239deb20ca65480c04f6e3cc102887db sha1 58fcbab969d2db6926d436162fd42dc5392ab0b6 )
+)
+
+game (
+	name "Simulation RPG Tkool (Japan)"
+	description "Simulation RPG Tkool (Japan)"
+	rom ( name "Simulation RPG Tkool (Japan) (Track 1).bin" size 48194832 crc d431a644 md5 ee84bf7e1685ea21d8783e46aebbc400 sha1 cc2b64d9b740ef5851a5526f99ba7203004cb81c )
+)
+
+game (
+	name "Sound Novel Tkool 2 (Japan)"
+	description "Sound Novel Tkool 2 (Japan)"
+	rom ( name "Sound Novel Tkool 2 (Japan) (Track 1).bin" size 240630768 crc 57cc0cc3 md5 f1da3ad6ac7357a5ee940ba754cdaa30 sha1 a96effccebe50ec902f38b888690ecc9960ba752 )
+)
+
+game (
+	name "Emit Vol. 1 - Toki no Maigo (Japan)"
+	description "Emit Vol. 1 - Toki no Maigo (Japan)"
+	rom ( name "Emit Vol. 1 - Toki no Maigo (Japan) (Track 01).bin" size 15335040 crc c5a6d372 md5 351ee0a8a41c4de072eeabd91076a7e1 sha1 36ba57407a0e00d32c5630d6829d84b327e3d4c4 )
+)
+
+game (
+	name "Emit Vol. 2 - Inochigake no Tabi (Japan) (Rev A)"
+	description "Emit Vol. 2 - Inochigake no Tabi (Japan) (Rev A)"
+	rom ( name "Emit Vol. 2 - Inochigake no Tabi (Japan) (Rev A) (Track 01).bin" size 16442832 crc 469d4230 md5 8455a4dc709a63a9c72d760ada1483f0 sha1 38a1299aef07db6dde5a2dfd446fbc34a6539c69 )
+)
+
+game (
+	name "Emit Vol. 3 - Watashi ni Sayonara o (Japan) (Rev A)"
+	description "Emit Vol. 3 - Watashi ni Sayonara o (Japan) (Rev A)"
+	rom ( name "Emit Vol. 3 - Watashi ni Sayonara o (Japan) (Rev A) (Track 01).bin" size 15812496 crc 9db8cc97 md5 06b2222c4292131f5f38d14d5d484edf sha1 fca4a40595ac3a3e7def0b03296b64ae97128d08 )
+)
+
+game (
+	name "Mobile Suit Gundam Side Story II - Ao o Uketsugu Mono (Japan)"
+	description "Mobile Suit Gundam Side Story II - Ao o Uketsugu Mono (Japan)"
+	rom ( name "Mobile Suit Gundam Side Story II - Ao o Uketsugu Mono (Japan) (Track 01).bin" size 156984240 crc 61198854 md5 9b44a46aa34f4d66f9a9f1cbbaa1a69d sha1 ab6ba25fa5c26f4ecca71eaae69a1d639c86bc6f )
+)
+
+game (
+	name "Mobile Suit Gundam Side Story III - Sabakareshi Mono (Japan)"
+	description "Mobile Suit Gundam Side Story III - Sabakareshi Mono (Japan)"
+	rom ( name "Mobile Suit Gundam Side Story III - Sabakareshi Mono (Japan) (Track 01).bin" size 246428448 crc 38990887 md5 acb0108f768845b9ee1875a45a0c0620 sha1 e744142ac22f2bf23ca80b1e922dceb6cae93ee1 )
+)
+
+game (
+	name "Mobile Suit Gundam Side Story - Optional Guide (Japan)"
+	description "Mobile Suit Gundam Side Story - Optional Guide (Japan)"
+	rom ( name "Mobile Suit Gundam Side Story - Optional Guide (Japan) (Track 1).bin" size 536926320 crc c8293ea7 md5 233c818e3127c087062678db37e9a7a9 sha1 52c87a65c8cc0bfc8e999d33330f5f3785a5d4cc )
+)
+
+game (
+	name "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan) (Sample)"
+	description "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan) (Sample)"
+	rom ( name "Mobile Suit Gundam Side Story I - Senritsu no Blue (Japan) (Sample) (Track 01).bin" size 100084656 crc d88c4380 md5 970e0c8f2cdec06f8a4ce24504f4e7cc sha1 e67fc3360d1cf5958bc3db9840a85eda5ca519d0 )
+)
+
+game (
+	name "SD Gundam - GCentury S (Japan)"
+	description "SD Gundam - GCentury S (Japan)"
+	rom ( name "SD Gundam - GCentury S (Japan) (Track 01).bin" size 194588016 crc f289c5b8 md5 d71008c770156c5d2da7740919d99b0c sha1 fecbf8ca5a41c6e3fb1717e6a8db8182cd15fbdf )
+)
+
+game (
+	name "Lupin the 3rd Chronicles (Japan) (Disc 1)"
+	description "Lupin the 3rd Chronicles (Japan) (Disc 1)"
+	rom ( name "Lupin the 3rd Chronicles (Japan) (Disc 1) (Track 1).bin" size 600096336 crc bb393bb7 md5 66c5ebbe8c61c412d785ee050bf31976 sha1 319a9457a791b3e325b5ef50fbcfe104d525fe5f )
+)
+
+game (
+	name "Lupin the 3rd Chronicles (Japan) (Disc 2)"
+	description "Lupin the 3rd Chronicles (Japan) (Disc 2)"
+	rom ( name "Lupin the 3rd Chronicles (Japan) (Disc 2) (Track 1).bin" size 483084336 crc 41f3e650 md5 c5df4f3f188cb9fbefdbc9119ad00d2d sha1 09734b7c884d986fe74954e2dc82efc67791c886 )
+)
+
+game (
+	name "Street Fighter Zero (Japan) (Rev A) (10M)"
+	description "Street Fighter Zero (Japan) (Rev A) (10M)"
+	rom ( name "Street Fighter Zero (Japan) (Rev A) (10M) (Track 01).bin" size 26563488 crc d86461bc md5 9e97c08a45f5339be1122643c64fca30 sha1 1c253d4e1dfeb0565e8067fcafa7e5fe4480b869 )
+)
+
+game (
+	name "Dead or Alive (Japan) (Rev A) (10M)"
+	description "Dead or Alive (Japan) (Rev A) (10M)"
+	rom ( name "Dead or Alive (Japan) (Rev A) (10M) (Track 01).bin" size 111527136 crc 57f1deae md5 9f7acede4dde6d4571150c7419c5bc06 sha1 af8b446918082dabce616234f12ee0c907b96213 )
+)
+
+game (
+	name "Virtua Fighter Kids (Japan) (Java Tea Original)"
+	description "Virtua Fighter Kids (Japan) (Java Tea Original)"
+	rom ( name "Virtua Fighter Kids (Japan) (Java Tea Original) (Track 01).bin" size 64513008 crc ffe49c81 md5 0a0541cda354f7f20c9eea687bce12b5 sha1 6adfa8f0104855e374ec00433883a78537aef878 )
+)
+
+game (
+	name "Gokujou Parodius Da! Deluxe Pack (Japan)"
+	description "Gokujou Parodius Da! Deluxe Pack (Japan)"
+	rom ( name "Gokujou Parodius Da! Deluxe Pack (Japan) (Track 1).bin" size 517357680 crc 6c447203 md5 63d73109dddf95625dd8ecdb0ff85dbe sha1 40d60fd06190494de21731abb896ffe6b1e74c24 )
+)
+
+game (
+	name "Winning Post EX (Japan) (2M)"
+	description "Winning Post EX (Japan) (2M)"
+	rom ( name "Winning Post EX (Japan) (2M) (Track 1).bin" size 341209344 crc e448ab0d md5 5b854c1ece4f6551c63664b8f24c36b3 sha1 89f073c505f5c0b43f5c0da049ed2b1df8d1c766 )
+)
+
+game (
+	name "Dragon Force (Japan) (Rev A) (10M)"
+	description "Dragon Force (Japan) (Rev A) (10M)"
+	rom ( name "Dragon Force (Japan) (Rev A) (10M) (Track 1).bin" size 565176192 crc d4b6b6f1 md5 02e9a9ff0d6f4a316e18071b27683ba7 sha1 a0cd10d17d1df3642442bade5e8398aacee0f611 )
+)
+
+game (
+	name "Bulk Slash (Japan)"
+	description "Bulk Slash (Japan)"
+	rom ( name "Bulk Slash (Japan) (Track 1).bin" size 158496576 crc 372052c7 md5 f392d1f214401d8ba7377fbf9866a87b sha1 4a86915c45a914e54e7b610ba9bfa98d3a73c26f )
+)
+
+game (
+	name "Cyberia (Europe)"
+	description "Cyberia (Europe)"
+	rom ( name "Cyberia (Europe) (Track 1).bin" size 504405216 crc 69914a8f md5 c500260db683e2614de062caa97e5cfa sha1 2c074ae01c1e0a3c0868904b94b98cac206efbd8 )
+)
+
+game (
+	name "D (France) (Disc 1)"
+	description "D (France) (Disc 1)"
+	rom ( name "D (France) (Disc 1) (Track 1).bin" size 571404288 crc fe3bf0d0 md5 dd6924d73ac5ac28144601742dfcfdde sha1 c8cb4959da29b2445f3c9722a243eace2f9f31a7 )
+)
+
+game (
+	name "D (France) (Disc 2)"
+	description "D (France) (Disc 2)"
+	rom ( name "D (France) (Disc 2) (Track 1).bin" size 534531984 crc 4bfe3cc9 md5 c97d3a73789854babe51e9d16275f538 sha1 facb4df9fb927443778d8aa3bb6f239173163c6d )
+)
+
+game (
+	name "Break Point (Europe) (En,Fr)"
+	description "Break Point (Europe) (En,Fr)"
+	rom ( name "Break Point (Europe) (En,Fr) (Track 1).bin" size 7780416 crc ba15f273 md5 0fd62ae0b711c7557820ab9a4f703d04 sha1 0b82b1fbb7c59cccbd34b8fd2f85ab2adf9dfd16 )
+)
+
+game (
+	name "FIFA - Die WM-Qualifikation 98 (Germany)"
+	description "FIFA - Die WM-Qualifikation 98 (Germany)"
+	rom ( name "FIFA - Die WM-Qualifikation 98 (Germany) (Track 1).bin" size 482331696 crc 1cced1e5 md5 a221eba7a5301d06b102174fb4b16b8f sha1 a9b08d7ed5a906d85f2bc272888689d5fa958eda )
+)
+
+game (
+	name "FIFA - En Route pour la Coupe du Monde 98 (France)"
+	description "FIFA - En Route pour la Coupe du Monde 98 (France)"
+	rom ( name "FIFA - En Route pour la Coupe du Monde 98 (France) (Track 1).bin" size 444384528 crc 06718679 md5 5fe633af0eba44cd84a2e4fee24458e4 sha1 2798e0c5dd834039bd65b089a59b96b9810dc68e )
+)
+
+game (
+	name "Galactic Attack (Europe)"
+	description "Galactic Attack (Europe)"
+	rom ( name "Galactic Attack (Europe) (Track 01).bin" size 16781520 crc 84617195 md5 d680e323286db4c0899de6638fecaa81 sha1 160d5222990e4afceb7c82c799e85f1aa27bea92 )
+)
+
+game (
+	name "Hang On GP '96 (Europe)"
+	description "Hang On GP '96 (Europe)"
+	rom ( name "Hang On GP '96 (Europe) (Track 1).bin" size 16139424 crc 6e3b5316 md5 b0528c46bfd7538c4433a79d5191675e sha1 b9735d55baaeb229d07a8463d16101bd609d167e )
+)
+
+game (
+	name "Hi-Octane (Europe) (En,Fr,De,Es)"
+	description "Hi-Octane (Europe) (En,Fr,De,Es)"
+	rom ( name "Hi-Octane (Europe) (En,Fr,De,Es) (Track 1).bin" size 15064560 crc e1b4220a md5 135bc4efdacd2e11f6b8b9bbd8e86d33 sha1 8e8e23844581ebd00d793ab4a830fdf73a5bcdfc )
+)
+
+game (
+	name "Jonah Lomu Rugby (Europe)"
+	description "Jonah Lomu Rugby (Europe)"
+	rom ( name "Jonah Lomu Rugby (Europe) (Track 1).bin" size 102848256 crc 5e150052 md5 d5b860c4b449380359e7177d5618ff44 sha1 aaec095c16c2c4381e20751479c90fc1dfd9a7e2 )
+)
+
+game (
+	name "Jonah Lomu Rugby (France)"
+	description "Jonah Lomu Rugby (France)"
+	rom ( name "Jonah Lomu Rugby (France) (Track 1).bin" size 101401776 crc 78028858 md5 664c446589ac34a1b26d9690fe30a5da sha1 77b2ba85a95aeb46df2826ad3ddf055c84e1249b )
+)
+
+game (
+	name "Darkseed (Japan)"
+	description "Darkseed (Japan)"
+	rom ( name "Darkseed (Japan) (Track 1).bin" size 38558688 crc 3c09c445 md5 b156a55a47fb186ae70f917174138eab sha1 ea9a70da90c749c7962b31e77d4ee6b19a5d2c2e )
+)
+
+game (
+	name "Magic Knight Rayearth (Japan) (Genteiban) (3M)"
+	description "Magic Knight Rayearth (Japan) (Genteiban) (3M)"
+	rom ( name "Magic Knight Rayearth (Japan) (Genteiban) (3M) (Track 1).bin" size 579483408 crc dfe67900 md5 ef37213ca996f3d13c89276f8b61273f sha1 4942c306ac5ab8278c42dd587e34a1b66faccca1 )
+)
+
+game (
+	name "Magic Knight Rayearth (Japan) (4M)"
+	description "Magic Knight Rayearth (Japan) (4M)"
+	rom ( name "Magic Knight Rayearth (Japan) (4M) (Track 1).bin" size 579483408 crc d00f0f64 md5 e0af3a86aca622d7c435d71810f40e0a sha1 03d2ae84b63e7402b8457da5c05acfe647b886fd )
+)
+
+game (
+	name "Clockwork Knight - Pepperouchau no Fukubukuro (Japan)"
+	description "Clockwork Knight - Pepperouchau no Fukubukuro (Japan)"
+	rom ( name "Clockwork Knight - Pepperouchau no Fukubukuro (Japan) (Track 1).bin" size 415565472 crc 2bf0bd4f md5 932b157d0854673822d71262627521c2 sha1 e6c7752e13580ae775a86568ed08c68e5a9c507f )
+)
+
+game (
+	name "Bug! Jump Shite, Funzukechatte, Petchanko (Japan)"
+	description "Bug! Jump Shite, Funzukechatte, Petchanko (Japan)"
+	rom ( name "Bug! Jump Shite, Funzukechatte, Petchanko (Japan) (Track 01).bin" size 133741776 crc 54a27641 md5 36b86383ebae9ce9c4ed46d414104404 sha1 29bf4a1d9d7d4dd6bacd745d017b102910349b29 )
+)
+
+game (
+	name "Bug Too! Motto Motto Jump Shite, Funzukechatte, Petchanko (Japan)"
+	description "Bug Too! Motto Motto Jump Shite, Funzukechatte, Petchanko (Japan)"
+	rom ( name "Bug Too! Motto Motto Jump Shite, Funzukechatte, Petchanko (Japan) (Track 01).bin" size 293849472 crc a604f079 md5 20635ed460ecefee0933a7ed7f543e86 sha1 02abbac3891beedbbb7a68bbf269f0825b75c332 )
+)
+
+game (
+	name "Bomberman Wars (Japan)"
+	description "Bomberman Wars (Japan)"
+	rom ( name "Bomberman Wars (Japan) (Track 1).bin" size 150384528 crc 03376fac md5 baba1d00a3987c9bb3b64912de78b621 sha1 7d34dd58919cab01ab4b859f052e00ca9d3ca4dd )
+)
+
+game (
+	name "Hyper Reverthion (Japan) (2M)"
+	description "Hyper Reverthion (Japan) (2M)"
+	rom ( name "Hyper Reverthion (Japan) (2M) (Track 01).bin" size 47860848 crc 6497e7c2 md5 36980f2178f571ba546447b9ace3c4fc sha1 227d04dcbb42bdf7a7787949b439a51b46360f88 )
+)
+
+game (
+	name "Kisuishou Densetsu Astal (Japan) (3A)"
+	description "Kisuishou Densetsu Astal (Japan) (3A)"
+	rom ( name "Kisuishou Densetsu Astal (Japan) (3A) (Track 1).bin" size 605957520 crc 5888089a md5 9d4a3d16ff7e4ee7d6344eb5229f782a sha1 23fbf6a661481fdaa6d20bb002bfc671fb365324 )
+)
+
+game (
+	name "Crimewave (Japan)"
+	description "Crimewave (Japan)"
+	rom ( name "Crimewave (Japan) (Track 1).bin" size 58296672 crc 8f9253de md5 c4e3f4c5129c3f773e38e428daada8a0 sha1 9a9030c84d72c1d0c9458361830cd0f362d4b815 )
+)
+
+game (
+	name "Hang On GP '95 (Japan) (2M)"
+	description "Hang On GP '95 (Japan) (2M)"
+	rom ( name "Hang On GP '95 (Japan) (2M) (Track 1).bin" size 15445584 crc d774da3a md5 60c36b8c8f309bac57ab8dec497d82a0 sha1 9583eb6e78b8fe9e99ca5e303e07711a96108246 )
+)
+
+game (
+	name "Road Rash (Japan)"
+	description "Road Rash (Japan)"
+	rom ( name "Road Rash (Japan) (Track 1).bin" size 581651952 crc e2af05bf md5 fd7dfab30aa070bdac74172f471ab390 sha1 2459b4920d91c892fe36a479bbe5b80557b164f0 )
+)
+
+game (
+	name "Destruction Derby (Japan)"
+	description "Destruction Derby (Japan)"
+	rom ( name "Destruction Derby (Japan) (Track 01).bin" size 15577296 crc 52be2ad3 md5 39f89dfbaa5054a3b8aedb29bc81e7ae sha1 beb2ca92add08a9b2f45dc75d7210321e07f667a )
+)
+
+game (
+	name "F-1 Live Information (Japan)"
+	description "F-1 Live Information (Japan)"
+	rom ( name "F-1 Live Information (Japan) (Track 01).bin" size 224086800 crc a4c71558 md5 e10db9ae35b38c215915227988816cfa sha1 8bcb0607eb50761af310a05f7fefccf9227a6a3d )
+)
+
+game (
+	name "Virtua Racing (Japan)"
+	description "Virtua Racing (Japan)"
+	rom ( name "Virtua Racing (Japan) (Track 01).bin" size 148260672 crc cb0e77cd md5 cd66258ec5045f1fb2fe1dc5e66471f8 sha1 d92d09e2283dd0b053398620860fbb41b3fe14e1 )
+)
+
+game (
+	name "Vatlva (Japan) (Rev A)"
+	description "Vatlva (Japan) (Rev A)"
+	rom ( name "Vatlva (Japan) (Rev A) (Track 01).bin" size 12731376 crc ef06e0f0 md5 e2be1cfecc7e4780f2dcaff07abeca76 sha1 c30b0d25b140e23281750652c92870c83d15a3e3 )
+)
+
+game (
+	name "Tactics Formula (Japan)"
+	description "Tactics Formula (Japan)"
+	rom ( name "Tactics Formula (Japan) (Track 1).bin" size 506124528 crc f274c9b9 md5 c30ae080036368e061e14b95b6e94546 sha1 cd2efd713236bf867fc6c276b5ceb38b3278e1c5 )
+)
+
+game (
+	name "Casper (USA)"
+	description "Casper (USA)"
+	rom ( name "Casper (USA) (Track 1).bin" size 131036976 crc 68df3f36 md5 65995a1acc58e63cedb44cac9f4f50e0 sha1 6c7f62a7303a6e9f9e2db44f0aac8894d1bb5268 )
+)
+
+game (
+	name "Zero4 Champ DooZy-J Type-R (Japan)"
+	description "Zero4 Champ DooZy-J Type-R (Japan)"
+	rom ( name "Zero4 Champ DooZy-J Type-R (Japan) (Track 01).bin" size 178991904 crc 9305e5bb md5 9730c1b76705ee8d9df526c698415bd9 sha1 fb95d8f929eb98f3989fb213aff0ed501b773598 )
+)
+
+game (
+	name "Sound Qube (Japan)"
+	description "Sound Qube (Japan)"
+	rom ( name "Sound Qube (Japan) (Track 1).bin" size 9574992 crc 32e2bd96 md5 e137ea8ed72b4680e5f11fd7b64b2d0c sha1 872d1563f81a79dc5fad1192319d2ba5060082b8 )
+)
+
+game (
+	name "Cube Battler - Story of Shou (Japan)"
+	description "Cube Battler - Story of Shou (Japan)"
+	rom ( name "Cube Battler - Story of Shou (Japan) (Track 1).bin" size 630907536 crc 8519ff66 md5 78c70aac16ea112074832f3c69b59bb6 sha1 38701ed98ac84ffcc3ebf19c50103c5aa14f60d7 )
+)
+
+game (
+	name "Cube Battler - Story of Anna (Japan)"
+	description "Cube Battler - Story of Anna (Japan)"
+	rom ( name "Cube Battler - Story of Anna (Japan) (Track 1).bin" size 619509744 crc 56d0b84b md5 9b95fc43537c79b3ce77b3083d88e197 sha1 657a563fabb7e7272045046b7ee1af38db94a37d )
+)
+
+game (
+	name "Sky Target (USA)"
+	description "Sky Target (USA)"
+	rom ( name "Sky Target (USA) (Track 01).bin" size 94924368 crc 49dea48e md5 d907ed47e47ec902fdaa40646051209f sha1 66fbfa685330d983d9c9d1e91b21ce174520ad51 )
+)
+
+game (
+	name "Henry Explorers (Japan)"
+	description "Henry Explorers (Japan)"
+	rom ( name "Henry Explorers (Japan) (Track 1).bin" size 426229440 crc 1432f410 md5 77d606a509d98e71dee0b39691941864 sha1 7f0e59634487722bb37a501b850a2addca534089 )
+)
+
+game (
+	name "Death Crimson (Japan)"
+	description "Death Crimson (Japan)"
+	rom ( name "Death Crimson (Japan) (Track 1).bin" size 63532224 crc 8dc2d5dd md5 6d354f0a40297afb04f4107db1fb8f1e sha1 94ac323c44a9cf8137c857036c592899c403625c )
+)
+
+game (
+	name "Bust-A-Move 3 (USA)"
+	description "Bust-A-Move 3 (USA)"
+	rom ( name "Bust-A-Move 3 (USA) (Track 01).bin" size 24486672 crc 68ff7c4d md5 0fd1a22f478eacee5d2c356e5e026c31 sha1 a27168e8526c7e3c94d089659e728c0fb2dcb479 )
+)
+
+game (
+	name "Virtua Fighter Remix (USA)"
+	description "Virtua Fighter Remix (USA)"
+	rom ( name "Virtua Fighter Remix (USA) (Track 01).bin" size 13538112 crc b8b2ddd0 md5 cf3f4e41d4e2d8afe7c0255864c18832 sha1 9157a88cdd6c6b1da3782c4e4b647112e995eb83 )
+)
+
+game (
+	name "Himitsu Sentai Metamor V (Japan)"
+	description "Himitsu Sentai Metamor V (Japan)"
+	rom ( name "Himitsu Sentai Metamor V (Japan) (Track 1).bin" size 640444896 crc e6947e98 md5 2f349e46af78c6f9446a450a4ddd51b1 sha1 101a4a500a631d38faa3719c33cda28db63d02a5 )
+)
+
+game (
+	name "Battle Athletess Daiundoukai (Japan)"
+	description "Battle Athletess Daiundoukai (Japan)"
+	rom ( name "Battle Athletess Daiundoukai (Japan) (Track 1).bin" size 471202032 crc 6a0c9f64 md5 9a2df41054e59370f7207cdd713a43d2 sha1 e1b7bd9941dae89a4cd4699f2c06cc53d467a641 )
+)
+
+game (
+	name "Metal Fighter Miku (Japan)"
+	description "Metal Fighter Miku (Japan)"
+	rom ( name "Metal Fighter Miku (Japan) (Track 1).bin" size 424787664 crc 5d414258 md5 76ede7ccc27d416657bbc24c81c1a027 sha1 974c2c77c7a941a0d4857e5f43d2f6ad0d8fa7f3 )
+)
+
+game (
+	name "Simulation Zoo (Japan)"
+	description "Simulation Zoo (Japan)"
+	rom ( name "Simulation Zoo (Japan) (Track 01).bin" size 16990848 crc 26157d56 md5 423c9d6183ec4292c63df1b8cd18a549 sha1 6b1ab4f1ef510f926eb0b763dc2b327548697a52 )
+)
+
+game (
+	name "Jung Rhythm (Japan)"
+	description "Jung Rhythm (Japan)"
+	rom ( name "Jung Rhythm (Japan) (Track 01).bin" size 290086272 crc c51daf75 md5 2a8828a0e29cf17ed045bdaf29a6e761 sha1 1b99b615e6a2c2b6fea6f74a298892db859dafc6 )
+)
+
+game (
+	name "Funky Fantasy (Japan)"
+	description "Funky Fantasy (Japan)"
+	rom ( name "Funky Fantasy (Japan) (Track 1).bin" size 211110816 crc 9e253e6b md5 67fd867017f048ca7ca5c119afd07df4 sha1 77b48138add40228e6ef8808a2e756b68214c012 )
+)
+
+game (
+	name "Eiyuu Shigan - Gal Act Heroism (Japan)"
+	description "Eiyuu Shigan - Gal Act Heroism (Japan)"
+	rom ( name "Eiyuu Shigan - Gal Act Heroism (Japan) (Track 1).bin" size 493228512 crc 9e86acb8 md5 97205b914dfa20f793ab773dba0896b5 sha1 b5002d3248f0acb1d7bbf31ab0d26f03c3d9b4b9 )
+)
+
+game (
+	name "Farland Saga (Japan)"
+	description "Farland Saga (Japan)"
+	rom ( name "Farland Saga (Japan) (Track 1).bin" size 301232400 crc 89195b94 md5 946b18cd25ca78468dedf577ff92b88c sha1 907fe0fca3d0a8ff58813b2ffb88309b5e903bf9 )
+)
+
+game (
+	name "Device Reign (Japan)"
+	description "Device Reign (Japan)"
+	rom ( name "Device Reign (Japan) (Track 1).bin" size 589519392 crc 19ffe4a3 md5 cad2c5fc05202d272124322f125aa7b1 sha1 2bcf8a72ce7f900cb31c8a04fa692ca4b061b7e8 )
+)
+
+game (
+	name "Legend of Heroes I & II, The - Eiyuu Densetsu (Japan)"
+	description "Legend of Heroes I & II, The - Eiyuu Densetsu (Japan)"
+	rom ( name "Legend of Heroes I & II, The - Eiyuu Densetsu (Japan) (Track 01).bin" size 36354864 crc a44da1da md5 70bc32608786b277d7af5100910c7924 sha1 7351b690113bb7c6a4a379c0af13d925f2c007ec )
+)
+
+game (
+	name "3D Baseball (USA)"
+	description "3D Baseball (USA)"
+	rom ( name "3D Baseball (USA) (Track 1).bin" size 345158352 crc e03a593a md5 5f33157efd8a73de6612a852cf1ba147 sha1 b79890f234721dac70ffaec83ec8715f0f183c14 )
+)
+
+game (
+	name "Area 51 (USA)"
+	description "Area 51 (USA)"
+	rom ( name "Area 51 (USA) (Track 1).bin" size 384528480 crc bfff8e55 md5 128d26c8f03fcdb85b7b40137fcec988 sha1 ad0abed6c4f303218f87d879633af69b2f80925b )
+)
+
+game (
+	name "Baku Baku Animal - World Zookeeper Contest (USA)"
+	description "Baku Baku Animal - World Zookeeper Contest (USA)"
+	rom ( name "Baku Baku Animal - World Zookeeper Contest (USA) (Track 01).bin" size 177218496 crc 551394d1 md5 0602917c30e6efb017faf6575939aeb3 sha1 1db5382fff2891290b59ec238e7f7f37eaafa29d )
+)
+
+game (
+	name "Batman Forever - The Arcade Game (USA)"
+	description "Batman Forever - The Arcade Game (USA)"
+	rom ( name "Batman Forever - The Arcade Game (USA) (Track 1).bin" size 28461552 crc bdb8ea8d md5 f1bc2587d6cc781cc3a5cd63707959c6 sha1 652b9046379a73d7752d249a08025c1004d03534 )
+)
+
+game (
+	name "BattleSport (USA)"
+	description "BattleSport (USA)"
+	rom ( name "BattleSport (USA) (Track 01).bin" size 83888784 crc b6c0115f md5 08bb4b22029f0075897cdd5fe41f4e4b sha1 681c340073d5ce2bafe04529cce91d05d204d631 )
+)
+
+game (
+	name "Bubble Bobble also featuring Rainbow Islands (USA)"
+	description "Bubble Bobble also featuring Rainbow Islands (USA)"
+	rom ( name "Bubble Bobble also featuring Rainbow Islands (USA) (Track 1).bin" size 42288960 crc 5c3f03d8 md5 dab079a02a6ef9745c8e0d5bbd4b7f72 sha1 2aa49bc08f5daed97e17f636964e75c0935d8524 )
+)
+
+game (
+	name "Battle Arena Toshinden URA - Ultimate Revenge Attack (USA)"
+	description "Battle Arena Toshinden URA - Ultimate Revenge Attack (USA)"
+	rom ( name "Battle Arena Toshinden URA - Ultimate Revenge Attack (USA) (Track 01).bin" size 82524624 crc ae035caa md5 7abf903981c004ba266eea3cad788a94 sha1 731b6e3c949384642687ab44b9994aa73544e0ad )
+)
+
+game (
+	name "Battle Stations (USA)"
+	description "Battle Stations (USA)"
+	rom ( name "Battle Stations (USA) (Track 01).bin" size 160926192 crc 694d3d26 md5 71b5ffe832e36055bc3d3725b91b2351 sha1 8730eca6ea8c24c0c01df1cbabd7ae7d89a64ab9 )
+)
+
+game (
+	name "Blast Chamber (USA)"
+	description "Blast Chamber (USA)"
+	rom ( name "Blast Chamber (USA) (Track 01).bin" size 90923616 crc 177e7651 md5 7491d990e6160c58d076c9c248aa9214 sha1 013f15a2d98e15e1b128b4937ce86df09fcc62f2 )
+)
+
+game (
+	name "Break Point Tennis (USA)"
+	description "Break Point Tennis (USA)"
+	rom ( name "Break Point Tennis (USA) (Track 1).bin" size 8274336 crc c29844c2 md5 e18e59e93c6660682b78f9cae5d0aa2f sha1 0e13c1a9dfbc38575143dae6afde36100e91fe6b )
+)
+
+game (
+	name "Crusader - No Remorse (USA)"
+	description "Crusader - No Remorse (USA)"
+	rom ( name "Crusader - No Remorse (USA) (Track 1).bin" size 614826912 crc 6974930b md5 90fb57192ab9d80abbcadddd5a56b382 sha1 6a6d7c61fe19798a9fa7a880d07251e4ae784525 )
+)
+
+game (
+	name "Die Hard Trilogy (USA)"
+	description "Die Hard Trilogy (USA)"
+	rom ( name "Die Hard Trilogy (USA) (Track 01).bin" size 96982368 crc dfd1ab7b md5 2e58751354718db7a25d18c934bcbfc5 sha1 002088c218f169da0f8faf1f9a2f019d75730cae )
+)
+
+game (
+	name "Hi-Octane - The Track Fights Back! (USA)"
+	description "Hi-Octane - The Track Fights Back! (USA)"
+	rom ( name "Hi-Octane - The Track Fights Back! (USA) (Track 1).bin" size 15064560 crc 6ed1437e md5 2519351609dd46f973cb71eaa2dd538b sha1 d7520a2731e195529e3f8656721ee7a3bcbb4470 )
+)
+
+game (
+	name "Johnny Bazookatone (USA)"
+	description "Johnny Bazookatone (USA)"
+	rom ( name "Johnny Bazookatone (USA) (Track 01).bin" size 192410064 crc c9df3f2e md5 9b3440bbe6ecb448c116d280a1948eb0 sha1 1c702edd1a69fde92e2a86663946cd3e2f5f9b28 )
+)
+
+game (
+	name "WWF In Your House (USA)"
+	description "WWF In Your House (USA)"
+	rom ( name "WWF In Your House (USA) (Track 01).bin" size 100609152 crc 9fa0bf5f md5 d73923ad6cc559ed5ed58420c59f8788 sha1 ce4d10db55ea117ca3b79f21f9d75ce7222fd1b6 )
+)
+
+game (
+	name "WWF WrestleMania - The Arcade Game (USA)"
+	description "WWF WrestleMania - The Arcade Game (USA)"
+	rom ( name "WWF WrestleMania - The Arcade Game (USA) (Track 01).bin" size 29291808 crc 116b6dd2 md5 d01239c495fbcbe3fcee731d4b4cda98 sha1 191071c83b74ba53fca2e04a09f0f0e5d845264c )
+)
+
+game (
+	name "Denpa Shounenteki Game (Japan) (Reprint)"
+	description "Denpa Shounenteki Game (Japan) (Reprint)"
+	rom ( name "Denpa Shounenteki Game (Japan) (Reprint) (Track 1).bin" size 38116512 crc 06e2d843 md5 b91d4000f4eeb8f6b9222d3b4920d166 sha1 6e5a0244bbc8d080e58fa6d8f14b22106a320548 )
+)
+
+game (
+	name "Father Christmas (Japan)"
+	description "Father Christmas (Japan)"
+	rom ( name "Father Christmas (Japan) (Track 1).bin" size 448312368 crc 8a2afdaa md5 0d60de45c5a8367b9de3198b45ae59db sha1 58628f380da23248c32ee1c73efde0bbfae9a162 )
+)
+
+game (
+	name "Culdcept (Japan) (Rev B) (20M)"
+	description "Culdcept (Japan) (Rev B) (20M)"
+	rom ( name "Culdcept (Japan) (Rev B) (20M) (Track 1).bin" size 273264768 crc 37698dcf md5 2f88dd7320f65b9192be8d4fc97558b3 sha1 b392abfd1d5db1782b7238d00a45551f5c2f656b )
+)
+
+game (
+	name "Game-Ware Vol. 4 (Japan) (Disc A)"
+	description "Game-Ware Vol. 4 (Japan) (Disc A)"
+	rom ( name "Game-Ware Vol. 4 (Japan) (Disc A) (Track 1).bin" size 232676304 crc 2a4a3309 md5 8b6a45f74ffe68ed2e5e2c46c9894c18 sha1 57b219ba180a49f3b6e6be1499aad63998e8dc27 )
+)
+
+game (
+	name "Game-Ware Vol. 4 (Japan) (Disc B)"
+	description "Game-Ware Vol. 4 (Japan) (Disc B)"
+	rom ( name "Game-Ware Vol. 4 (Japan) (Disc B) (Track 1).bin" size 634743648 crc 71972844 md5 70a68760b6f7090eb60a9d9f42c3ccbc sha1 50fd2591fa19d962e434b5f9d5010c78bb66fb37 )
+)
+
+game (
+	name "SeaBass Fishing 2 (Japan)"
+	description "SeaBass Fishing 2 (Japan)"
+	rom ( name "SeaBass Fishing 2 (Japan) (Track 1).bin" size 346974096 crc e8753040 md5 6afc88d279dc28ece4fb34a2baf27eab sha1 f7d9db51b5bf01ebe01e01bbc59d08d7a3bcd3fc )
+)
+
+game (
+	name "SeaBass Fishing (Japan)"
+	description "SeaBass Fishing (Japan)"
+	rom ( name "SeaBass Fishing (Japan) (Track 01).bin" size 177757104 crc a863c236 md5 646a0b530dd83638690376d18b44608b sha1 71b1bd25bf0adf860e0cf493e8796e4974480b5f )
+)
+
+game (
+	name "Murakoshi Seikai no Bakuchou Nihon Rettou (Japan)"
+	description "Murakoshi Seikai no Bakuchou Nihon Rettou (Japan)"
+	rom ( name "Murakoshi Seikai no Bakuchou Nihon Rettou (Japan) (Track 1).bin" size 436406544 crc 3918fe42 md5 7c5ccb4bbe69137b6a07c9ceeef14109 sha1 72b561de078b61dba279dfffdd594c73470c463d )
+)
+
+game (
+	name "Farland Saga - Toki no Michishirube (Japan)"
+	description "Farland Saga - Toki no Michishirube (Japan)"
+	rom ( name "Farland Saga - Toki no Michishirube (Japan) (Track 1).bin" size 516419232 crc 98ebc3ff md5 5c5bb788648e0b2cc3bc575c80683f19 sha1 58ed09b28c56afb510f68ee4e90509727eb66ac2 )
+)
+
+game (
+	name "World Series Baseball II (Japan)"
+	description "World Series Baseball II (Japan)"
+	rom ( name "World Series Baseball II (Japan) (Track 1).bin" size 238252896 crc 6c5927d4 md5 239836ba9a42b00f00d7e11fb7c8ad2d sha1 00f51fbc3a2bf649541b7226dfd07fce491c7d68 )
+)
+
+game (
+	name "Oracle no Houseki - Jewels of the Oracle (Japan) (En,Ja,Fr,De)"
+	description "Oracle no Houseki - Jewels of the Oracle (Japan) (En,Ja,Fr,De)"
+	rom ( name "Oracle no Houseki - Jewels of the Oracle (Japan) (En,Ja,Fr,De) (Track 1).bin" size 451226496 crc 91811235 md5 0276da5923dafb066841e93bbb5c05d4 sha1 5f129cf246124b66cfdfc73160016a2d6f75476b )
+)
+
+game (
+	name "Ultraman Zukan (Japan)"
+	description "Ultraman Zukan (Japan)"
+	rom ( name "Ultraman Zukan (Japan) (Track 01).bin" size 1096032 crc 21f4a1ff md5 8914e55d4c78ac4dd1b276a43d08b406 sha1 d86a7c14165c0f05c94aedfec73f5ce1ef915c5f )
+)
+
+game (
+	name "Langrisser V - The End of Legend (Japan) (1M)"
+	description "Langrisser V - The End of Legend (Japan) (1M)"
+	rom ( name "Langrisser V - The End of Legend (Japan) (1M) (Track 1).bin" size 145591152 crc ef034bde md5 37685a3ac74ac252abb2d01ea6987c73 sha1 b90529e379efde5787693ffda6fff53fddd7c2ee )
+)
+
+game (
+	name "Album Club (Mune Kyun) - Saint Paulia Jogakuin (Japan)"
+	description "Album Club (Mune Kyun) - Saint Paulia Jogakuin (Japan)"
+	rom ( name "Album Club (Mune Kyun) - Saint Paulia Jogakuin (Japan) (Track 1).bin" size 652896384 crc f57b3fb6 md5 c3a61429806e0f79c1b380aba1b0f5ef sha1 c61fb715130a2a5e6dd8f4b2ce220b9eaccfc7be )
+)
+
+game (
+	name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev B) (21M)"
+	description "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev B) (21M)"
+	rom ( name "Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev B) (21M) (Track 1).bin" size 157880352 crc d8298541 md5 b9b3f25f82877771ded23fe0dae8a9bc sha1 ec9362205154dd6819e27154c44bf009ce4fb1df )
+)
+
+game (
+	name "Ai Iijima Interactive Video Clip - Good Island Cafe (Japan)"
+	description "Ai Iijima Interactive Video Clip - Good Island Cafe (Japan)"
+	rom ( name "Ai Iijima Interactive Video Clip - Good Island Cafe (Japan) (Track 1).bin" size 523992672 crc aea610f1 md5 e7af10e08123f750206e9e95de08db53 sha1 83a1d5d027e50c994faf0e8e11af6ea6d98b6f09 )
+)
+
+game (
+	name "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (1M)"
+	description "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (1M)"
+	rom ( name "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (1M) (Track 1).bin" size 662751264 crc 84e9f8a2 md5 4b3992a709efa11166cf21beb70a803c sha1 e16f4d05d013788146b9385dfcb55bee08c46756 )
+)
+
+game (
+	name "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (2M)"
+	description "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (2M)"
+	rom ( name "Gekka Mugentan Torico (Japan) (Disc A) (Kyouchou-hen) (2M) (Track 1).bin" size 662751264 crc 84e9f8a2 md5 4b3992a709efa11166cf21beb70a803c sha1 e16f4d05d013788146b9385dfcb55bee08c46756 )
+)
+
+game (
+	name "Gekka Mugentan Torico (Japan) (Disc B) (Houkai-hen)"
+	description "Gekka Mugentan Torico (Japan) (Disc B) (Houkai-hen)"
+	rom ( name "Gekka Mugentan Torico (Japan) (Disc B) (Houkai-hen) (Track 1).bin" size 665194992 crc 5f87215e md5 cb70bd0499a876cca2d2de849d100103 sha1 27e4393e0016409259443b79a5deac0c0a84274a )
+)
+
+game (
+	name "Desire (Japan) (Disc 2) (2M)"
+	description "Desire (Japan) (Disc 2) (2M)"
+	rom ( name "Desire (Japan) (Disc 2) (2M) (Track 1).bin" size 247653840 crc d4b1c0da md5 061b3d54d7e326f17230ca7d9ebc2df3 sha1 bf0e94902239702106a79656a98073b13e6a3a61 )
+)
+
+game (
+	name "Eve - The Lost One (Japan) (Sample)"
+	description "Eve - The Lost One (Japan) (Sample)"
+	rom ( name "Eve - The Lost One (Japan) (Sample) (Track 1).bin" size 97972560 crc 288219c3 md5 23ad128763448886d5e7ec402d0c9119 sha1 cbd03586201daedd50cf43eb52548830e48bb50b )
+)
+
+game (
+	name "Criticom (USA)"
+	description "Criticom (USA)"
+	rom ( name "Criticom (USA) (Track 01).bin" size 242279520 crc c1e87cdd md5 bf8d2b9733212d4a010fc478e6d87bb9 sha1 80a53ffe354c8a85c9f5e252b27b42e6e2cc5353 )
+)
+
+game (
+	name "Off-World Interceptor Extreme (USA)"
+	description "Off-World Interceptor Extreme (USA)"
+	rom ( name "Off-World Interceptor Extreme (USA) (Track 1).bin" size 402716496 crc ac578214 md5 4af0aadd55562ca366803fc0bf500e9f sha1 6319af0457620ebb7bbc576ff3f912a8f826210f )
+)
+
+game (
+	name "WarCraft II - The Dark Saga (USA)"
+	description "WarCraft II - The Dark Saga (USA)"
+	rom ( name "WarCraft II - The Dark Saga (USA) (Track 1).bin" size 617084832 crc 6c5f7fa0 md5 634edb3622c00b75f55bbcf8d377420e sha1 7401eed90fa01795266ef68beb306cc31c9747af )
+)
+
+game (
+	name "Asuka 120% Limited - Burning Fest. Limited (Japan)"
+	description "Asuka 120% Limited - Burning Fest. Limited (Japan)"
+	rom ( name "Asuka 120% Limited - Burning Fest. Limited (Japan) (Track 01).bin" size 62337408 crc 1db11c62 md5 9f943972333e83a4d2c15cf0bb9f3434 sha1 1c21759864381dbc946a143e3527848fb35976d8 )
+)
+
+game (
+	name "Sokkou Seitokai - Sonic Council (Japan)"
+	description "Sokkou Seitokai - Sonic Council (Japan)"
+	rom ( name "Sokkou Seitokai - Sonic Council (Japan) (Track 01).bin" size 99738912 crc 65fe8940 md5 c0620298f876401c76ade23df94604e0 sha1 d123894e60e044db8afbe977f993a14a1f6fa5e3 )
+)
+
+game (
+	name "Sonic 3D - Flickies' Island (Japan)"
+	description "Sonic 3D - Flickies' Island (Japan)"
+	rom ( name "Sonic 3D - Flickies' Island (Japan) (Track 01).bin" size 71870064 crc 498141a3 md5 1323195c75bc744a252439addc798770 sha1 117314d88bd2e74cafd5d1211e04b2369b215dcd )
+)
+
+game (
+	name "Langrisser - Dramatic Edition (Japan) (2M)"
+	description "Langrisser - Dramatic Edition (Japan) (2M)"
+	rom ( name "Langrisser - Dramatic Edition (Japan) (2M) (Track 1).bin" size 392784000 crc 3da1e7c9 md5 3f7bf0e1e3d70356828d962eebdc085e sha1 771515a4e9dee1225d73a206dd0d7ce154b113d0 )
+)
+
+game (
+	name "Langrisser III (Japan) (Rev A) (7M)"
+	description "Langrisser III (Japan) (Rev A) (7M)"
+	rom ( name "Langrisser III (Japan) (Rev A) (7M) (Track 01).bin" size 77098560 crc 2acd6725 md5 527c0cd9cca6b147cb50bf8b79940f57 sha1 5de9c016a03ec97fa23684f87fef8aad756f7303 )
+)
+
+game (
+	name "Langrisser V - The End of Legend (Japan) (3M)"
+	description "Langrisser V - The End of Legend (Japan) (3M)"
+	rom ( name "Langrisser V - The End of Legend (Japan) (3M) (Track 1).bin" size 145591152 crc ef034bde md5 37685a3ac74ac252abb2d01ea6987c73 sha1 b90529e379efde5787693ffda6fff53fddd7c2ee )
+)
+
+game (
+	name "Shining Force III Premium Disc (Japan)"
+	description "Shining Force III Premium Disc (Japan)"
+	rom ( name "Shining Force III Premium Disc (Japan) (Track 1).bin" size 555869328 crc 4064bc3e md5 0cde397b0f369631e4051e1f76ccfc25 sha1 1b5de342984618965d25494f329cb317452b7a6e )
+)
+
+game (
+	name "Keriotosse! (Japan)"
+	description "Keriotosse! (Japan)"
+	rom ( name "Keriotosse! (Japan) (Track 01).bin" size 86360736 crc e18a109a md5 dbad4a2f0025e096b9b1033c0fe44d8e sha1 84c8b491e5e8f40431a8abe82357c2532bff13fb )
+)
+
+game (
+	name "Planet Joker (Japan)"
+	description "Planet Joker (Japan)"
+	rom ( name "Planet Joker (Japan) (Track 01).bin" size 204036000 crc e7f2a1a0 md5 4f0fc2726445c7f1afe48ff7ceda4314 sha1 3d53709ced8b73f2420439e4864ae4df3828ce7f )
+)
+
+game (
+	name "Assault Rigs (Japan)"
+	description "Assault Rigs (Japan)"
+	rom ( name "Assault Rigs (Japan) (Track 01).bin" size 132490512 crc 694a7878 md5 1c7e004a330839624afc118c54d357c2 sha1 5c697196e840feb99e9c43c43672e4b1fe4ac6aa )
+)
+
+game (
+	name "Area 51 (Japan)"
+	description "Area 51 (Japan)"
+	rom ( name "Area 51 (Japan) (Track 1).bin" size 382689216 crc 1fd47481 md5 5c504cb13d9ae1f0cb3e9911fe30155e sha1 fe88614a6da50de2c883e9e27f8f46a75feb7981 )
+)
+
+game (
+	name "Hexen - Beyond Heretic (Japan)"
+	description "Hexen - Beyond Heretic (Japan)"
+	rom ( name "Hexen - Beyond Heretic (Japan) (Track 01).bin" size 142479456 crc e6e9a05d md5 c1bc0c4fc531be468a304deb1ed71048 sha1 bb1cf50b0b1b75810da841ee5e9cf2d4a95c4523 )
+)
+
+game (
+	name "Impact Racing (Japan)"
+	description "Impact Racing (Japan)"
+	rom ( name "Impact Racing (Japan) (Track 01).bin" size 45927504 crc 813d50f4 md5 bd252ab0703d22e0c99c1c761519f907 sha1 0830658450c78aa19856031133e16317e902f7a3 )
+)
+
+game (
+	name "Sonic Wings Special (Japan)"
+	description "Sonic Wings Special (Japan)"
+	rom ( name "Sonic Wings Special (Japan) (Track 1).bin" size 79782192 crc ab242da6 md5 6aa17fe32a13f6ff31e66b5ea01d854f sha1 a517bb41a5487c25f4430f68a7aac46009d1df41 )
+)
+
+game (
+	name "Steeldom (Japan) (2M)"
+	description "Steeldom (Japan) (2M)"
+	rom ( name "Steeldom (Japan) (2M) (Track 01).bin" size 169104096 crc cc1c56fe md5 af268987e5e992fefe96c25a2a29d8fe sha1 a2ec83faeba9cd021f60739ccad119faf87f572d )
+)
+
+game (
+	name "Rise 2 - Resurrection (Japan) (En,Fr,De,Es,It)"
+	description "Rise 2 - Resurrection (Japan) (En,Fr,De,Es,It)"
+	rom ( name "Rise 2 - Resurrection (Japan) (En,Fr,De,Es,It) (Track 01).bin" size 143928288 crc eae62b34 md5 e79936500a0422309939b3f39643c185 sha1 f6827b98cc8a3db8f9be88ba5c02a96dc2cec41a )
+)
+
+game (
+	name "Pappara Paoon (Japan) (2M)"
+	description "Pappara Paoon (Japan) (2M)"
+	rom ( name "Pappara Paoon (Japan) (2M) (Track 01).bin" size 23976288 crc 71153ab2 md5 cbe6a1f1a9d40dec9bbf7cd6945ea530 sha1 aa5e8b45ad9a24d14f6bfd50ac45f3317c78904e )
+)
+
+game (
+	name "Croc! Pau-Pau Island (Japan)"
+	description "Croc! Pau-Pau Island (Japan)"
+	rom ( name "Croc! Pau-Pau Island (Japan) (Track 01).bin" size 232469328 crc ca45fc24 md5 ebcd4158aab331c759a6c2d4bfa3a4f0 sha1 f07a371de19f5de508789445061f624af9676e14 )
+)
+
+game (
+	name "Senken Kigyouden (Japan)"
+	description "Senken Kigyouden (Japan)"
+	rom ( name "Senken Kigyouden (Japan) (Track 01).bin" size 311757600 crc 3a311fe8 md5 09dbb6c7d42e9e515c1fcdf588aa107c sha1 44277ddcc47cd843af34399e7b472c7e52c263bd )
+)
+
+game (
+	name "StarFighter 3000 (Europe) (En,Fr,De,Es,It)"
+	description "StarFighter 3000 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "StarFighter 3000 (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 191010624 crc 7816c814 md5 7dd100eae5369af5ec5a950c6aa05692 sha1 c98328778c6193bb48b9171d064d71c1a09e176d )
+)
+
+game (
+	name "StarFighter 3000 (Japan)"
+	description "StarFighter 3000 (Japan)"
+	rom ( name "StarFighter 3000 (Japan) (Track 1).bin" size 156175152 crc 1f13dbb1 md5 4fe90350f7a10505d375d62703307213 sha1 832da18c28770c87762990a415282519a6a646f1 )
+)
+
+game (
+	name "Frank Thomas Big Hurt Baseball (Europe)"
+	description "Frank Thomas Big Hurt Baseball (Europe)"
+	rom ( name "Frank Thomas Big Hurt Baseball (Europe) (Track 1).bin" size 352837632 crc c5146b61 md5 58de281e704047b0ae7557c804c34306 sha1 6724bb24d47daabfdf6246465a57fc1184668285 )
+)
+
+game (
+	name "Shellshock - Jus' Keepin' da Peace (Japan)"
+	description "Shellshock - Jus' Keepin' da Peace (Japan)"
+	rom ( name "Shellshock - Jus' Keepin' da Peace (Japan) (Track 1).bin" size 439555872 crc 6da7157b md5 5144fe83bc21cc9c07fc80f0ec8f2350 sha1 51267efa6a3f402a2eb4ad4595d90a8f6cd58fd5 )
+)
+
+game (
+	name "Off-World Interceptor Extreme (Japan)"
+	description "Off-World Interceptor Extreme (Japan)"
+	rom ( name "Off-World Interceptor Extreme (Japan) (Track 1).bin" size 452136720 crc 4363ae8c md5 266b77f8666201a0ce8ccdfa8ea7ef51 sha1 99e30b276d499ea2e7847da62e693f4c5742c130 )
+)
+
+game (
+	name "Ghen War (Japan)"
+	description "Ghen War (Japan)"
+	rom ( name "Ghen War (Japan) (Track 01).bin" size 225262800 crc 2af8fce3 md5 195cf2c584b3b00c25b7b8b3f8a1af33 sha1 324b64039fc016cc6630074abd4ee5b0b849904c )
+)
+
+game (
+	name "Dark Hunter Ge - Youma no Mori (Japan)"
+	description "Dark Hunter Ge - Youma no Mori (Japan)"
+	rom ( name "Dark Hunter Ge - Youma no Mori (Japan) (Track 1).bin" size 167885760 crc c34b7ff0 md5 c5564f337132e393380f37e985fba5a5 sha1 630e6c47719a71ceeb4374ddf24f3eab76c63dc2 )
+)
+
+game (
+	name "Dark Hunter Jou - Ijigen Gakuen (Japan)"
+	description "Dark Hunter Jou - Ijigen Gakuen (Japan)"
+	rom ( name "Dark Hunter Jou - Ijigen Gakuen (Japan) (Track 1).bin" size 196857696 crc 9d67a8ee md5 654eee0023739bd9d70383b5b7c0e10a sha1 9d94ab262c564f7837a12ee246328dc22cf30469 )
+)
+
+game (
+	name "Wipeout XL (Japan)"
+	description "Wipeout XL (Japan)"
+	rom ( name "Wipeout XL (Japan) (Track 01).bin" size 91659792 crc 8a1533f3 md5 72489581a7f518f1a98ffa2f6cb5b328 sha1 f81eef996057dee1cb06619e00d2f17fe5dc9420 )
+)
+
+game (
+	name "Primal Rage (Japan)"
+	description "Primal Rage (Japan)"
+	rom ( name "Primal Rage (Japan) (Track 01).bin" size 126711648 crc 313652d4 md5 be6e8c481585d294a8ad582ce831ffbb sha1 e82d38f01546227ab4f1c10df41dad950e607ac5 )
+)
+
+game (
+	name "Mass Destruction - Otousan ni mo Dekiru Soft (Japan)"
+	description "Mass Destruction - Otousan ni mo Dekiru Soft (Japan)"
+	rom ( name "Mass Destruction - Otousan ni mo Dekiru Soft (Japan) (Track 01).bin" size 106383312 crc 2162ed38 md5 4b18aea7a48f2a1304b2548cc4013536 sha1 0338a1c007c1f086e68111cbf28ebf3c3ecea6d5 )
+)
+
+game (
+	name "Death Throttle - Kakuzetsu Toshi kara no Dasshutsu (Japan)"
+	description "Death Throttle - Kakuzetsu Toshi kara no Dasshutsu (Japan)"
+	rom ( name "Death Throttle - Kakuzetsu Toshi kara no Dasshutsu (Japan) (Track 01).bin" size 74273808 crc 0efdf35b md5 7eeb582240bfd00269829185dce4a9cd sha1 7271575928b376e5c06eb4d7f3e07e6fea6e69a6 )
+)
+
+game (
+	name "Kumitate Battle Kuttu Ketto (Japan)"
+	description "Kumitate Battle Kuttu Ketto (Japan)"
+	rom ( name "Kumitate Battle Kuttu Ketto (Japan) (Track 01).bin" size 119909664 crc e35feaea md5 4147636fd0618fb55e48e4f61f132230 sha1 18f0398a591fff7a5554ab51d7284a2592326bad )
+)
+
+game (
+	name "X Japan - Virtual Shock 001 (Japan) (4M)"
+	description "X Japan - Virtual Shock 001 (Japan) (4M)"
+	rom ( name "X Japan - Virtual Shock 001 (Japan) (4M) (Track 1).bin" size 929040 crc 60399408 md5 02e12dea036f45c106896f7c05f42056 sha1 834a96c73229e1befc2fd36d78f0d53ea873aace )
+)
+
+game (
+	name "Space Jam (Japan)"
+	description "Space Jam (Japan)"
+	rom ( name "Space Jam (Japan) (Track 01).bin" size 59689056 crc 566e1986 md5 c7439660f0208701754084ff6cebcf78 sha1 2263bce17b73fa6f6c1b8e4f8ef990e9a7c34722 )
+)
+
+game (
+	name "Magic Carpet (Japan)"
+	description "Magic Carpet (Japan)"
+	rom ( name "Magic Carpet (Japan) (Track 1).bin" size 101552304 crc 088564a9 md5 7e606b8a252256d0dc40217fd4b0a47a sha1 96d4995862cf68bd1959419e14047e57cd94b7b2 )
+)
+
+game (
+	name "Time Commando (Japan)"
+	description "Time Commando (Japan)"
+	rom ( name "Time Commando (Japan) (Track 1).bin" size 460371072 crc 407d62a8 md5 7fc9c8958d3a41948ed5ea1c34a70406 sha1 464c8e52de53d9751b7d071e0712d61a7e2b6263 )
+)
+
+game (
+	name "Aquazone - Desktop Life Option Disc Series 1 - Angel Fish (Japan) (Rev A)"
+	description "Aquazone - Desktop Life Option Disc Series 1 - Angel Fish (Japan) (Rev A)"
+	rom ( name "Aquazone - Desktop Life Option Disc Series 1 - Angel Fish (Japan) (Rev A) (Track 01).bin" size 743232 crc a08b0a99 md5 c00b1f4a5f9506a692aded125d1d8a81 sha1 2cdf09e7cc92e58362dc4ec2c88b3bda6c4b1c05 )
+)
+
+game (
+	name "Aquazone - Desktop Life Option Disc Series 3 - Blue Emperor (Japan) (Rev A)"
+	description "Aquazone - Desktop Life Option Disc Series 3 - Blue Emperor (Japan) (Rev A)"
+	rom ( name "Aquazone - Desktop Life Option Disc Series 3 - Blue Emperor (Japan) (Rev A) (Track 01).bin" size 743232 crc bc407728 md5 b50f7a724216a76fc5d763f6eb3167ea sha1 882eb6b3ad1cd9bc8572af8a0b2d04f007750edf )
+)
+
+game (
+	name "Aquazone - Desktop Life Option Disc Series 4 - Clown Loach (Japan) (Rev A)"
+	description "Aquazone - Desktop Life Option Disc Series 4 - Clown Loach (Japan) (Rev A)"
+	rom ( name "Aquazone - Desktop Life Option Disc Series 4 - Clown Loach (Japan) (Rev A) (Track 01).bin" size 743232 crc 8e04e80f md5 38e5b162766ab50e848f1fa76966abcc sha1 a966824b994858757948df22d730ac7cbce2372b )
+)
+
+game (
+	name "Aquazone - Desktop Life Option Disc Series 5 - False Rummy-Nose (Japan) (Rev A)"
+	description "Aquazone - Desktop Life Option Disc Series 5 - False Rummy-Nose (Japan) (Rev A)"
+	rom ( name "Aquazone - Desktop Life Option Disc Series 5 - False Rummy-Nose (Japan) (Rev A) (Track 01).bin" size 743232 crc 88310da7 md5 4172e0ad703289b1a219600c2158a2f3 sha1 6d87868f6ae9796bb2a8892d1ccb90cb0e5187bf )
+)
+
+game (
+	name "Gouketsuji Ichizoku 3 - Groove on Fight (Japan)"
+	description "Gouketsuji Ichizoku 3 - Groove on Fight (Japan)"
+	rom ( name "Gouketsuji Ichizoku 3 - Groove on Fight (Japan) (Track 01).bin" size 120864576 crc 78f93471 md5 200f24cb50e1f6d340b900649f424b11 sha1 59744e8d94f6285f0eedc20357ab06d65c48b211 )
+)
+
+game (
+	name "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 1)"
+	description "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 1)"
+	rom ( name "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 1) (Track 1).bin" size 179770416 crc 310d0af7 md5 07cc7eb53c43d4d2abce7c14c7a6928a sha1 1fc582fe4210238028425bde652baae9a46a3a6b )
+)
+
+game (
+	name "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 2)"
+	description "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 2)"
+	rom ( name "Tutankhamen no Nazo - A.N.K.H (Japan) (Disc 2) (Track 1).bin" size 643090896 crc 48dfc74c md5 9726a6d9c0f2a9f7b53a3a3fc20a67d3 sha1 531b23747bd6b7a3c5473fe9ca1013f487396833 )
+)
+
+game (
+	name "GT24 (Japan)"
+	description "GT24 (Japan)"
+	rom ( name "GT24 (Japan) (Track 01).bin" size 5390784 crc 6ff416de md5 8d2a1b0efa4dcacb79144f9c5dec3e42 sha1 bb049dc42dc7e0b1530eca60f9429c9e3d4d12e8 )
+)
+
+game (
+	name "Samurai Spirits - Zankurou Musouken (Japan)"
+	description "Samurai Spirits - Zankurou Musouken (Japan)"
+	rom ( name "Samurai Spirits - Zankurou Musouken (Japan) (Track 01).bin" size 57504048 crc 5ddfd8b3 md5 10ef62790e424328f00d37bfe36d0ce7 sha1 8b19487e66d3999709578a526d9f200154ab5583 )
+)
+
+game (
+	name "Tsuukai!! Slot Shooting (Japan)"
+	description "Tsuukai!! Slot Shooting (Japan)"
+	rom ( name "Tsuukai!! Slot Shooting (Japan) (Track 01).bin" size 7996800 crc 7f4b07bd md5 b95dddd51925c008479e8c307a430e79 sha1 aa0d00ea1e204c65869c4ed4861ef423772ba9f2 )
+)
+
+game (
+	name "Sakamoto Ryouma - Ishin Kaikoku (Japan)"
+	description "Sakamoto Ryouma - Ishin Kaikoku (Japan)"
+	rom ( name "Sakamoto Ryouma - Ishin Kaikoku (Japan) (Track 1).bin" size 69158208 crc 9d6121e9 md5 d6ffafb11e73d2d59c093e01e37ee467 sha1 e2d4d0a7471d334153828537d02996ad65edb766 )
+)
+
+game (
+	name "Honkaku Hanafuda (Japan)"
+	description "Honkaku Hanafuda (Japan)"
+	rom ( name "Honkaku Hanafuda (Japan) (Track 1).bin" size 16574544 crc 848a997f md5 e057c430363f5918c9533a589a1fcd15 sha1 e483efbb2f78b5f1351bdb382f6413cf3d419be6 )
+)
+
+game (
+	name "Minami no Shima ni Buta ga Ita - Lucas no Daibouken (Japan) (2M)"
+	description "Minami no Shima ni Buta ga Ita - Lucas no Daibouken (Japan) (2M)"
+	rom ( name "Minami no Shima ni Buta ga Ita - Lucas no Daibouken (Japan) (2M) (Track 1).bin" size 425316864 crc 9c1f5972 md5 45d6717e40c16ef8e18f5ad86a1f9bbc sha1 d160b9c8ef1d5483bde53f187215c62e88410a57 )
+)
+
+game (
+	name "Segata Sanshirou - Shinken Yuugi (Japan)"
+	description "Segata Sanshirou - Shinken Yuugi (Japan)"
+	rom ( name "Segata Sanshirou - Shinken Yuugi (Japan) (Track 1).bin" size 311785824 crc 08ef7f55 md5 3da904c5fef3a39ddbfe74856f5bc5dc sha1 e714c363930db1c33225aa044735e65d3a80999b )
+)
+
+game (
+	name "Junclassic C.C. & Rope Club (Japan) (2M)"
+	description "Junclassic C.C. & Rope Club (Japan) (2M)"
+	rom ( name "Junclassic C.C. & Rope Club (Japan) (2M) (Track 1).bin" size 297911376 crc 851f615a md5 5744a38808cdd9a93c36a011481d6810 sha1 946d15200965ea02521df16b9f8e5b5c8709cb58 )
+)
+
+game (
+	name "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 2) (Premium CD-ROM)"
+	description "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 2) (Premium CD-ROM)"
+	rom ( name "Voice Fantasia S - Ushinawareta Voice Power (Japan) (Disc 2) (Premium CD-ROM) (Track 1).bin" size 409073952 crc 7d506e2c md5 46469481f04385c481677d64d7214efa sha1 4d6010878154255ad7ea0ea8df0cf3c4c0beb2dd )
+)
+
+game (
+	name "Virtuacall S (Japan) (Disc 1) (Game Honpen)"
+	description "Virtuacall S (Japan) (Disc 1) (Game Honpen)"
+	rom ( name "Virtuacall S (Japan) (Disc 1) (Game Honpen) (Track 1).bin" size 498461712 crc 0a8770ec md5 269fffd0ce24a6c35c9f843342acec94 sha1 4330fc66d25f1ab1b602d909b322cce6fa55ee1f )
+)
+
+game (
+	name "Virtuacall S (Japan) (Disc 2) (Shokai Gentei Yobikake-kun)"
+	description "Virtuacall S (Japan) (Disc 2) (Shokai Gentei Yobikake-kun)"
+	rom ( name "Virtuacall S (Japan) (Disc 2) (Shokai Gentei Yobikake-kun) (Track 1).bin" size 289893408 crc b494c909 md5 3c512cb5f200c5a140981271b780c096 sha1 05c7a228209743d4a0d0cd7f14b82057e9fe99b9 )
+)
+
+game (
+	name "Bakuretsu Hunter (Japan) (Disc 1)"
+	description "Bakuretsu Hunter (Japan) (Disc 1)"
+	rom ( name "Bakuretsu Hunter (Japan) (Disc 1) (Track 1).bin" size 386640576 crc 083f4a02 md5 2ae2063dc74a2c4451d555820f940c60 sha1 770e7981bd541ce76b785552bcf3e001fe8bc8b0 )
+)
+
+game (
+	name "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 2)"
+	description "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 2)"
+	rom ( name "Ayakashi Ninden Kunoichiban Plus (Japan) (Disc 2) (Track 1).bin" size 165498480 crc d61a803f md5 d4d06aad9a04d86bbeebd3a3cd6148d3 sha1 648bd824ff2835a65e3f4c68d0fec763e52ccf43 )
+)
+
+game (
+	name "Ousama Game (Japan) (Disc 1) (Ichigo Disc)"
+	description "Ousama Game (Japan) (Disc 1) (Ichigo Disc)"
+	rom ( name "Ousama Game (Japan) (Disc 1) (Ichigo Disc) (Track 1).bin" size 649768224 crc 69d2b1b3 md5 194ca03bb54be1643c67bf17d6cc4230 sha1 57bbc3518b4eeca8fc43b7ae6543e2f69f259680 )
+)
+
+game (
+	name "Ousama Game (Japan) (Disc 2) (Momo Disc)"
+	description "Ousama Game (Japan) (Disc 2) (Momo Disc)"
+	rom ( name "Ousama Game (Japan) (Disc 2) (Momo Disc) (Track 1).bin" size 640437840 crc 00278769 md5 bb46b7de877771b3beac2010895be304 sha1 7de67a5f1242d803fcc49b77759f7ba125f4b46b )
+)
+
+game (
+	name "Haunted Casino (Japan) (Disc A)"
+	description "Haunted Casino (Japan) (Disc A)"
+	rom ( name "Haunted Casino (Japan) (Disc A) (Track 1).bin" size 663064080 crc a2ae4068 md5 0c993dd231673ec66fcfbbac612c53d7 sha1 51204a361a53248a52cb69ae6baa44768e03785a )
+)
+
+game (
+	name "Haunted Casino (Japan) (Disc B)"
+	description "Haunted Casino (Japan) (Disc B)"
+	rom ( name "Haunted Casino (Japan) (Disc B) (Track 1).bin" size 616807296 crc 2b952d0c md5 4724a306ec460dd079814de159630595 sha1 67095813b11450299410972ec78511786ebb19b8 )
+)
+
+game (
+	name "Haunted Casino (Japan) (Disc C)"
+	description "Haunted Casino (Japan) (Disc C)"
+	rom ( name "Haunted Casino (Japan) (Disc C) (Track 1).bin" size 641355120 crc d4be20d1 md5 8639cbd61d0e6e6adf88f0a5c65d6287 sha1 c48cd1c1682551f15def9805d2499bd91b13e236 )
+)
+
+game (
+	name "Ojousama Tokkyuu (Japan) (Disc 1)"
+	description "Ojousama Tokkyuu (Japan) (Disc 1)"
+	rom ( name "Ojousama Tokkyuu (Japan) (Disc 1) (Track 1).bin" size 132984432 crc 82c54956 md5 72d50231fcc2febcb6be08a0a9d2643a sha1 2b6ae29f5e93c23c7551048d5227e36390ce74f5 )
+)
+
+game (
+	name "Ojousama Tokkyuu (Japan) (Disc 2)"
+	description "Ojousama Tokkyuu (Japan) (Disc 2)"
+	rom ( name "Ojousama Tokkyuu (Japan) (Disc 2) (Track 1).bin" size 132984432 crc 208f7d31 md5 597d39388ea8c230adcbbce1d345f457 sha1 df61d131789fd0cb89e30db3792293dd232f4786 )
+)
+
+game (
+	name "Ojousama o Nerae!! (Japan) (Rev A)"
+	description "Ojousama o Nerae!! (Japan) (Rev A)"
+	rom ( name "Ojousama o Nerae!! (Japan) (Rev A) (Track 1).bin" size 33388992 crc 957ebc30 md5 b2f6a14b9de0e45251ee81f74e3c2dcd sha1 0444f60dbadd3c7e026d8771b09ee0479650d0da )
+)
+
+game (
+	name "Theme Park (Japan)"
+	description "Theme Park (Japan)"
+	rom ( name "Theme Park (Japan) (Track 01).bin" size 162725472 crc 18c21ad0 md5 956fd80a9cc67e59fafd9b9a316627ad sha1 3125b7f4a2cd3734e9387b5b1b177776a6f7c37e )
+)
+
+game (
+	name "Shin Theme Park (Japan)"
+	description "Shin Theme Park (Japan)"
+	rom ( name "Shin Theme Park (Japan) (Track 01).bin" size 188270544 crc 1b780253 md5 87854ded77c53e84f9abaad2a1b0d86e sha1 d4c0c3a75483fce18456b7cb7c01b00bbbf891d0 )
+)
+
+game (
+	name "Sekai no Shasou kara - I Swiss-hen - Alps Tozantetsudou no Tabi (Japan)"
+	description "Sekai no Shasou kara - I Swiss-hen - Alps Tozantetsudou no Tabi (Japan)"
+	rom ( name "Sekai no Shasou kara - I Swiss-hen - Alps Tozantetsudou no Tabi (Japan) (Track 1).bin" size 570830400 crc bd55b2e1 md5 13dfd40ce3448fd206cc9a579028686a sha1 072937822455d2b6d456db83c4c29dd612d24d92 )
+)
+
+game (
+	name "LuLu - Un Conte Interactif de Romain Victor-Pujebet (Japan)"
+	description "LuLu - Un Conte Interactif de Romain Victor-Pujebet (Japan)"
+	rom ( name "LuLu - Un Conte Interactif de Romain Victor-Pujebet (Japan) (Track 1).bin" size 181564992 crc 2ac8a0da md5 66099c27149a601bcca73f07d34c7021 sha1 538d1778a1643bb7889ddbc7cba585366010f8d1 )
+)
+
+game (
+	name "Super Robot Taisen F Kanketsuhen (Japan) (5M)"
+	description "Super Robot Taisen F Kanketsuhen (Japan) (5M)"
+	rom ( name "Super Robot Taisen F Kanketsuhen (Japan) (5M) (Track 1).bin" size 180603024 crc a9f3ee19 md5 4da1cc3ff193cfaad4bb2a1a5a514e1b sha1 98b6138dbde6462b611bd9aa3923d707ab81faca )
+)
+
+game (
+	name "Super Robot Taisen F Kanketsuhen (Japan) (2M, 3M)"
+	description "Super Robot Taisen F Kanketsuhen (Japan) (2M, 3M)"
+	rom ( name "Super Robot Taisen F Kanketsuhen (Japan) (2M, 3M) (Track 1).bin" size 180603024 crc a9f3ee19 md5 4da1cc3ff193cfaad4bb2a1a5a514e1b sha1 98b6138dbde6462b611bd9aa3923d707ab81faca )
+)
+
+game (
+	name "Super Robot Taisen F (Japan) (Rev B) (21M)"
+	description "Super Robot Taisen F (Japan) (Rev B) (21M)"
+	rom ( name "Super Robot Taisen F (Japan) (Rev B) (21M) (Track 1).bin" size 238711536 crc d5f6ddeb md5 82dba88e548c3af97c1a172eeef6125e sha1 c4d816ef2f43b0e9ed0c58a773965409b8467e42 )
+)
+
+game (
+	name "King of Fighters '95, The (Japan) (1M)"
+	description "King of Fighters '95, The (Japan) (1M)"
+	rom ( name "King of Fighters '95, The (Japan) (1M) (Track 01).bin" size 30517200 crc d82522b6 md5 fc1cb22527384e20dcfd08d60b5aee00 sha1 ab82ae6b720811e2306cee6ce597081ac17e6a62 )
+)
+
+game (
+	name "King of Fighters '95, The (Japan) (3M)"
+	description "King of Fighters '95, The (Japan) (3M)"
+	rom ( name "King of Fighters '95, The (Japan) (3M) (Track 01).bin" size 30517200 crc d82522b6 md5 fc1cb22527384e20dcfd08d60b5aee00 sha1 ab82ae6b720811e2306cee6ce597081ac17e6a62 )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 3) (1M)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 3) (1M)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 3) (1M) (Track 1).bin" size 298087776 crc d327b058 md5 e153f0f03eeec7d95a998930a227b07c sha1 09464089d35c06b3275407d60778110fd4ac1156 )
+)
+
+game (
+	name "Virtua Fighter 2 (Japan) (Rev B) (36C)"
+	description "Virtua Fighter 2 (Japan) (Rev B) (36C)"
+	rom ( name "Virtua Fighter 2 (Japan) (Rev B) (36C) (Track 01).bin" size 61316640 crc 65c7fc1e md5 14992450395f67b251023821a4d20480 sha1 2475bfb03eeaabdfcce93bc010d7c395efdf8dce )
+)
+
+game (
+	name "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 1)"
+	description "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 1)"
+	rom ( name "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 1) (Track 1).bin" size 600721968 crc a8f80d87 md5 913fc7d76b0763dd48616509b3203314 sha1 337961430a3bfd81d91c2b5a7a422d2874744d22 )
+)
+
+game (
+	name "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 2)"
+	description "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 2)"
+	rom ( name "QuoVadis 2 - Wakusei Kyoushuu Ovan Rei (Japan) (Disc 2) (Track 1).bin" size 537361440 crc b2a3a100 md5 bd284547a5d07c7ed7971df222ac8e5c sha1 4875e6b49e3ae94aecc910de5e6659368b3437ce )
+)
+
+game (
+	name "Mizuki Shigeru no Youkai Zukan Soushuuhen (Japan)"
+	description "Mizuki Shigeru no Youkai Zukan Soushuuhen (Japan)"
+	rom ( name "Mizuki Shigeru no Youkai Zukan Soushuuhen (Japan) (Track 1).bin" size 411635280 crc 06c26e28 md5 ed9c1a44c3dabbb3a62e496f785282b9 sha1 55e7c53aa43681a20a6c13034b5ff66f89ac186a )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (5M)"
+	description "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (5M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (5M) (Track 1).bin" size 151454688 crc 68ac9a0d md5 9947140b8b6385df81aacb7f010085ec sha1 c929b7f32b35996f38ef24b4a38c10fff9fbe454 )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (4M)"
+	description "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (4M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (4M) (Track 1).bin" size 151454688 crc 68ac9a0d md5 9947140b8b6385df81aacb7f010085ec sha1 c929b7f32b35996f38ef24b4a38c10fff9fbe454 )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (5M)"
+	description "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (5M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (5M) (Track 1).bin" size 508271904 crc b3004699 md5 a744abc5f85a0087e876feeb547e933b sha1 6ae4e9a85fd7a5d174d13d9b2dd0a2c336434b4f )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (1M, 2M)"
+	description "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (1M, 2M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 2) (Second Window) (1M, 2M) (Track 1).bin" size 508271904 crc b3004699 md5 a744abc5f85a0087e876feeb547e933b sha1 6ae4e9a85fd7a5d174d13d9b2dd0a2c336434b4f )
+)
+
+game (
+	name "Sonic R (Japan) (2M)"
+	description "Sonic R (Japan) (2M)"
+	rom ( name "Sonic R (Japan) (2M) (Track 01).bin" size 16238208 crc 03310902 md5 71663113415b8c2aa38e36c0c463b6c6 sha1 792b2a8225b2dc5b36e2da0b4164bc798d315f83 )
+)
+
+game (
+	name "Arthur to Astaroth no Nazomakaimura - Incredible Toons (Japan)"
+	description "Arthur to Astaroth no Nazomakaimura - Incredible Toons (Japan)"
+	rom ( name "Arthur to Astaroth no Nazomakaimura - Incredible Toons (Japan) (Track 01).bin" size 15031632 crc 19b6e5e6 md5 b948aab1f3f65ec5be4e9f11218e8344 sha1 3d969d5d6cd747bd2dfa2a6ed36d605ab5529c04 )
+)
+
+game (
+	name "Sega Worldwide Soccer 97 (Europe)"
+	description "Sega Worldwide Soccer 97 (Europe)"
+	rom ( name "Sega Worldwide Soccer 97 (Europe) (Track 01).bin" size 152360208 crc 11aa6d93 md5 d7e4088df4e0a250e885f56148013e74 sha1 14cf2bff6dd80179ce9a595b8787e89e65444752 )
+)
+
+game (
+	name "Skeleton Warriors (Europe) (En,Fr,De,Es,It)"
+	description "Skeleton Warriors (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Skeleton Warriors (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 122621520 crc 0a443a36 md5 1e6851ab2a344fd7240bd0366ca0d7cf sha1 d088c6cbb1bb5806f39eeb50ebb19676a152e097 )
+)
+
+game (
+	name "Kekkon - Marriage (Japan)"
+	description "Kekkon - Marriage (Japan)"
+	rom ( name "Kekkon - Marriage (Japan) (Track 1).bin" size 199854144 crc a9980342 md5 4e0e0757a2b2d9b046e65242c2aa91d4 sha1 33d9e7476612b591c3af4d3bec6ab3732898437f )
+)
+
+game (
+	name "Riven - The Sequel to Myst (Japan) (Disc 1)"
+	description "Riven - The Sequel to Myst (Japan) (Disc 1)"
+	rom ( name "Riven - The Sequel to Myst (Japan) (Disc 1) (Track 1).bin" size 522520320 crc f4c5b0d2 md5 d9416fc59058dd85271c04a915832704 sha1 44de1fc7f287f9fb2d8b1d83ccc3f22eeca62a63 )
+)
+
+game (
+	name "Riven - The Sequel to Myst (Japan) (Disc 2)"
+	description "Riven - The Sequel to Myst (Japan) (Disc 2)"
+	rom ( name "Riven - The Sequel to Myst (Japan) (Disc 2) (Track 1).bin" size 488910240 crc d4223c9c md5 90dfe7db9352a10c09c36f8a455e058e sha1 25cf4900ccf2ad711b241556342bfe98fa79da9e )
+)
+
+game (
+	name "Riven - The Sequel to Myst (Japan) (Disc 3)"
+	description "Riven - The Sequel to Myst (Japan) (Disc 3)"
+	rom ( name "Riven - The Sequel to Myst (Japan) (Disc 3) (Track 1).bin" size 462687792 crc 5d5831c3 md5 73c174766d3030a96ca3dd15b496a0d6 sha1 e86064cd4a96990417be022da007e0ddda934bb0 )
+)
+
+game (
+	name "Riven - The Sequel to Myst (Japan) (Disc 4)"
+	description "Riven - The Sequel to Myst (Japan) (Disc 4)"
+	rom ( name "Riven - The Sequel to Myst (Japan) (Disc 4) (Track 1).bin" size 404162976 crc 57ce3c1c md5 3ba3562839b8a6a79ae4010ed98c7a0c sha1 50ffdbadaf5d1e1922f64c19d09f720d1d6ef4e0 )
+)
+
+game (
+	name "DragonHeart - Fire & Steel (Europe) (En,Fr,De)"
+	description "DragonHeart - Fire & Steel (Europe) (En,Fr,De)"
+	rom ( name "DragonHeart - Fire & Steel (Europe) (En,Fr,De) (Track 01).bin" size 95811072 crc 301c5971 md5 5c1ec3875288dbda851b8808a407627b sha1 c5752377f38c1529f4d4f24bdbc6d63601685f79 )
+)
+
+game (
+	name "Spot Goes to Hollywood (Europe)"
+	description "Spot Goes to Hollywood (Europe)"
+	rom ( name "Spot Goes to Hollywood (Europe) (Track 01).bin" size 188799744 crc 8ecc561f md5 80edf5d5b9234760b51f96662f63f2b4 sha1 bcd1cffa551437bc9fc9bb29dedf9a0c5088c57b )
+)
+
+game (
+	name "Bug Too! (Europe)"
+	description "Bug Too! (Europe)"
+	rom ( name "Bug Too! (Europe) (Track 01).bin" size 293849472 crc 3f42a9f9 md5 6cbff393c15bdd1f9f49e30663fb39f6 sha1 3e093f4da18aaa98b8a437c7f634303a178058fd )
+)
+
+game (
+	name "Lost World, The - Jurassic Park (USA)"
+	description "Lost World, The - Jurassic Park (USA)"
+	rom ( name "Lost World, The - Jurassic Park (USA) (Track 01).bin" size 156158688 crc 33818e32 md5 ab9226f03b513bc562914b4c81d8bfa3 sha1 02948c44fac4df55e2398c04902ffb7f7d82636d )
+)
+
+game (
+	name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (2M)"
+	description "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (2M)"
+	rom ( name "Sentimental Graffiti (Japan) (Disc 1) (Game Disc) (2M) (Track 1).bin" size 151454688 crc 68ac9a0d md5 9947140b8b6385df81aacb7f010085ec sha1 c929b7f32b35996f38ef24b4a38c10fff9fbe454 )
+)
+
+game (
+	name "Side Pocket 3 - 3D Polygon Billiard Game (Japan)"
+	description "Side Pocket 3 - 3D Polygon Billiard Game (Japan)"
+	rom ( name "Side Pocket 3 - 3D Polygon Billiard Game (Japan) (Track 01).bin" size 150880800 crc 09ef0d33 md5 028fb628ef258e402f5132dd9179e987 sha1 247a7c42bd6590ed3f67ad9dc4a2e17c1825af97 )
+)
+
+game (
+	name "Crimewave (Europe) (En,Fr,De,Es,It)"
+	description "Crimewave (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Crimewave (Europe) (En,Fr,De,Es,It) (Track 1).bin" size 58567152 crc 0af5d507 md5 fb7656bcf6eae3e6e87912f1e92f291c sha1 18fb96fe5758f4cdebda3986cc508aa071318433 )
+)
+
+game (
+	name "In the Hunt (Europe)"
+	description "In the Hunt (Europe)"
+	rom ( name "In the Hunt (Europe) (Track 01).bin" size 38589264 crc e0070648 md5 c0aa43cede9f52f336fc17cefdcc9446 sha1 fb04d052452124587f75b6996f2db701a727a354 )
+)
+
+game (
+	name "Rise 2 - Resurrection (Europe) (En,Fr,De,Es,It)"
+	description "Rise 2 - Resurrection (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rise 2 - Resurrection (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 143928288 crc 93d7d178 md5 0c6c42ab9a716516bb2fb5e330c9f77e sha1 233e1c7f4df02a619fc3b21ef726fcbdc5a86dc6 )
+)
+
+game (
+	name "Shinobi-X - Shin Shinobi Den (Europe)"
+	description "Shinobi-X - Shin Shinobi Den (Europe)"
+	rom ( name "Shinobi-X - Shin Shinobi Den (Europe) (Track 1).bin" size 450304512 crc 64ac9850 md5 10c43f665a6eaf7a9790313eb47624b6 sha1 19d2d04d8f3c6ca106168409d3049e2ffeda82a6 )
+)
+
+game (
+	name "Soviet Strike (Germany)"
+	description "Soviet Strike (Germany)"
+	rom ( name "Soviet Strike (Germany) (Track 1).bin" size 660949632 crc c9ee0a9a md5 679c617921ce950b2ad0cfdf24f4be22 sha1 db439bea450c9fc20dc3a5511bf22ed76700263d )
+)
+
+game (
+	name "Daytona USA C.C.E. Net Link Edition (USA)"
+	description "Daytona USA C.C.E. Net Link Edition (USA)"
+	rom ( name "Daytona USA C.C.E. Net Link Edition (USA) (Track 01).bin" size 35322336 crc 4d813fc3 md5 7c17cd2cbdfbd5dbe6caff6387cdd73f sha1 01e1b73a5fd59255a52f4464c0f38211faeaf1f4 )
+)
+
+game (
+	name "Playboy - Karaoke Collection Volume 2 (Japan) (2M)"
+	description "Playboy - Karaoke Collection Volume 2 (Japan) (2M)"
+	rom ( name "Playboy - Karaoke Collection Volume 2 (Japan) (2M) (Track 1).bin" size 444130512 crc 23bdfae9 md5 6ae604834c02f590ea7865f03cdac1ff sha1 fce674408630ceba990d082777a798be4d86ed7e )
+)
+
+game (
+	name "X-Men - Children of the Atom (Europe)"
+	description "X-Men - Children of the Atom (Europe)"
+	rom ( name "X-Men - Children of the Atom (Europe) (Track 01).bin" size 59811360 crc 16ff738d md5 bf980b9d96b457d4fcf0ef7bf12470cc sha1 b23fe5cc60d5591913761501ada37c91dfedd8c8 )
+)
+
+game (
+	name "Crusader - No Remorse (Germany)"
+	description "Crusader - No Remorse (Germany)"
+	rom ( name "Crusader - No Remorse (Germany) (Track 1).bin" size 614208336 crc fb899ab0 md5 5616cb3a944395bfcbbab334d1e3e28a sha1 8c95de34029632d5caf9649c7696ea2ba72a7096 )
+)
+
+game (
+	name "NBA Action (Europe)"
+	description "NBA Action (Europe)"
+	rom ( name "NBA Action (Europe) (Track 01).bin" size 196500192 crc 5ce01095 md5 733506f7258513807bb70382fde536e9 sha1 bc43d98d523ae0d8d2cb10c221ea338f145d2545 )
+)
+
+game (
+	name "Hebereke's Popoitto (Europe)"
+	description "Hebereke's Popoitto (Europe)"
+	rom ( name "Hebereke's Popoitto (Europe) (Track 01).bin" size 7712208 crc 26e44e9d md5 be36ccb0a236a2681cd6cdffc2a17e97 sha1 657838261fce14b65b15e656f0b4533e5ac9577f )
+)
+
+game (
+	name "Rockman X4 (Japan) (1M)"
+	description "Rockman X4 (Japan) (1M)"
+	rom ( name "Rockman X4 (Japan) (1M) (Track 1).bin" size 536931024 crc e37470f1 md5 8395c4404bf215ed6ffbe1f39bc96547 sha1 c2cf36457262e9b62579c9fab2ffb31f03d86599 )
+)
+
+game (
+	name "Jewels of the Oracle (Europe) (En,Ja,Fr,De)"
+	description "Jewels of the Oracle (Europe) (En,Ja,Fr,De)"
+	rom ( name "Jewels of the Oracle (Europe) (En,Ja,Fr,De) (Track 1).bin" size 451287648 crc a1db5cfa md5 e375f42a45a538815ad3f48fbc94a558 sha1 12d446f1abbb712e4003067a8b9af76fecbb4688 )
+)
+
+game (
+	name "Z (Europe)"
+	description "Z (Europe)"
+	rom ( name "Z (Europe) (Track 1).bin" size 344067024 crc cf1ce816 md5 65accd69ec5340c390c2088d2d51c08b sha1 4afa369bbfc8f36a6c4f00b2cefbb2098028b4d7 )
+)
+
+game (
+	name "Worms (Europe)"
+	description "Worms (Europe)"
+	rom ( name "Worms (Europe) (Track 1).bin" size 100190496 crc a01f101e md5 e17a2028153daf526f50575eb3bb7770 sha1 ac8c5eb2aaa28abea170edd163007c4b3b7ce015 )
+)
+
+game (
+	name "Ghen War (Europe)"
+	description "Ghen War (Europe)"
+	rom ( name "Ghen War (Europe) (Track 01).bin" size 225335712 crc 5ac540ca md5 a7c95ca3a94ead407809ebdc08149570 sha1 374bd5baa3f3e44b90e326e8822b236b2d116bb8 )
+)
+
+game (
+	name "Off-World Interceptor Extreme (Europe)"
+	description "Off-World Interceptor Extreme (Europe)"
+	rom ( name "Off-World Interceptor Extreme (Europe) (Track 1).bin" size 402714144 crc 25a394f7 md5 6d353c7a17bd063439a5ff1605a0b89b sha1 637779e95bac2482681456243c25ebe9c681ab40 )
+)
+
+game (
+	name "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 1)"
+	description "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 1)"
+	rom ( name "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 1) (Track 1).bin" size 655062576 crc c590b7b7 md5 38f86b442350cc83f8cce8d35a3062eb sha1 3127b0dad45a5d2c2f14cd6813c4d54b96b0517c )
+)
+
+game (
+	name "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 2)"
+	description "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 2)"
+	rom ( name "Atlantis - The Lost Tales (Europe) (En,De,Es) (Disc 2) (Track 1).bin" size 487216800 crc 3fb70028 md5 a7c14e9772021511f86b6311f1dcff7e sha1 e4154748a93fd3577ba2180025d4263f56aeaf5c )
+)
+
+game (
+	name "Atlantis - The Lost Tales (France) (Disc 1)"
+	description "Atlantis - The Lost Tales (France) (Disc 1)"
+	rom ( name "Atlantis - The Lost Tales (France) (Disc 1) (Track 1).bin" size 655615296 crc eaf16480 md5 3eee7727e2dc2dae12913b905559e886 sha1 afc434251a9a1b1c974db56fcf115bf4c152893d )
+)
+
+game (
+	name "Atlantis - The Lost Tales (France) (Disc 2)"
+	description "Atlantis - The Lost Tales (France) (Disc 2)"
+	rom ( name "Atlantis - The Lost Tales (France) (Disc 2) (Track 1).bin" size 486219552 crc d7fdf1d0 md5 039b34ae0503365648399ba96535c1d0 sha1 284c9ee91e8f12ff58a5e497a9595f3569952e28 )
+)
+
+game (
+	name "Photo CD Operating System (Europe) (En,Ja,Fr,De,Es,It) (2S)"
+	description "Photo CD Operating System (Europe) (En,Ja,Fr,De,Es,It) (2S)"
+	rom ( name "Photo CD Operating System (Europe) (En,Ja,Fr,De,Es,It) (2S) (Track 1).bin" size 4882752 crc 33a1c13b md5 b8b327625d7649a075dcf6dc70b6eb4e sha1 09297b3e6b32434868e00f1b32bb4a4fc08efc3a )
+)
+
+game (
+	name "Valora Valley Golf (Europe)"
+	description "Valora Valley Golf (Europe)"
+	rom ( name "Valora Valley Golf (Europe) (Track 1).bin" size 343650720 crc dca5a2fd md5 5b1ac0d60b8f91e80ab535a160e5987d sha1 ad65e106c30c953089257fb68248d154a443c741 )
+)
+
+game (
+	name "NBA Live 98 (Europe)"
+	description "NBA Live 98 (Europe)"
+	rom ( name "NBA Live 98 (Europe) (Track 1).bin" size 509770128 crc ef15a03a md5 fccfe8ed3c30947f1613304ad4f7b65a sha1 58157d761a4ee3a369c6b9d3af06e354570e3efa )
+)
+
+game (
+	name "NBA Jam - Tournament Edition (Europe)"
+	description "NBA Jam - Tournament Edition (Europe)"
+	rom ( name "NBA Jam - Tournament Edition (Europe) (Track 1).bin" size 117738768 crc 1a47070c md5 90f52d850f347d0658fbbffbf97d6027 sha1 078e9dbb0b76dd2dccf91dd9029fb011c7fc822c )
+)
+
+game (
+	name "Blam! Machinehead (Germany)"
+	description "Blam! Machinehead (Germany)"
+	rom ( name "Blam! Machinehead (Germany) (Track 01).bin" size 131269824 crc 493a4a23 md5 dc215fc39e5f6423241220afce5e8ae3 sha1 18f8c8feedb96e5ecaf369a5b87bcbd8eebcd235 )
+)
+
+game (
+	name "Grid Run (Europe)"
+	description "Grid Run (Europe)"
+	rom ( name "Grid Run (Europe) (Track 01).bin" size 95742864 crc 824d7a89 md5 80c0c2c38884f26c1d430c06b21b85b0 sha1 25923bfa5fc1a15b872f5959a75978b9de713005 )
+)
+
+game (
+	name "NASCAR 98 (Germany)"
+	description "NASCAR 98 (Germany)"
+	rom ( name "NASCAR 98 (Germany) (Track 1).bin" size 219371040 crc 3f3d09dc md5 8e1ac90bfd8f21942ec3f37d03014fcf sha1 8e51c864bfe7bcb5d00284e9fc8b6a26a8e4dfd6 )
+)
+
+game (
+	name "Super Puzzle Fighter II Turbo (Europe)"
+	description "Super Puzzle Fighter II Turbo (Europe)"
+	rom ( name "Super Puzzle Fighter II Turbo (Europe) (Track 1).bin" size 406446768 crc 07b4a466 md5 16babcacd280ff5dcf719b907d8a36f0 sha1 6da67170f674662dcf9c56a6853630428679f306 )
+)
+
+game (
+	name "Virtua Racing (Europe)"
+	description "Virtua Racing (Europe)"
+	rom ( name "Virtua Racing (Europe) (Track 01).bin" size 148260672 crc cb0e77cd md5 cd66258ec5045f1fb2fe1dc5e66471f8 sha1 d92d09e2283dd0b053398620860fbb41b3fe14e1 )
+)
+
+game (
+	name "WWF In Your House (Europe)"
+	description "WWF In Your House (Europe)"
+	rom ( name "WWF In Your House (Europe) (Track 01).bin" size 99903552 crc d96e3ab4 md5 87117cd36d560c2a9978f55bd2a0de0b sha1 f24009c4376c454eab9127bafaae1e5fdf52fbf2 )
+)
+
+game (
+	name "Lost Vikings 2 - Norse by Norsewest (Europe) (En,Fr,De)"
+	description "Lost Vikings 2 - Norse by Norsewest (Europe) (En,Fr,De)"
+	rom ( name "Lost Vikings 2 - Norse by Norsewest (Europe) (En,Fr,De) (Track 1).bin" size 232299984 crc b5955133 md5 e09a64408e39075161e4b829ad76977d sha1 d31949cbab367a7cb7eb2ee9a0d939b8d4727daa )
+)
+
+game (
+	name "Virtua Cop (Europe) (2S)"
+	description "Virtua Cop (Europe) (2S)"
+	rom ( name "Virtua Cop (Europe) (2S) (Track 01).bin" size 50655024 crc e88845db md5 78b0ab0e1687e3618340546af1b0336c sha1 0c3d977136dd3fb33ccca4fb38d275b8fa8a3597 )
+)
+
+game (
+	name "Blast Wind (Japan)"
+	description "Blast Wind (Japan)"
+	rom ( name "Blast Wind (Japan) (Track 01).bin" size 4774560 crc 6c91fa72 md5 d9f438b8e4eb6b561da8bb24941106cc sha1 d5ac10bcf50d4d8d23bfc129ba8f7f0dd41616b2 )
+)
+
+game (
+	name "Darius Gaiden (USA)"
+	description "Darius Gaiden (USA)"
+	rom ( name "Darius Gaiden (USA) (Track 01).bin" size 23371824 crc 004fe32b md5 9f93f48a03e0509168cd7bb4131a196b sha1 9b550b6daabad0dd63068fdfd1ae35306b61846f )
+)
+
+game (
+	name "Galactic Attack (USA)"
+	description "Galactic Attack (USA)"
+	rom ( name "Galactic Attack (USA) (Track 01).bin" size 16781520 crc 69fc11ea md5 5758da94abf13c16d21528c192f7c624 sha1 ac745a5e8ec979fd61dbce14939e68d0f532e8e0 )
+)
+
+game (
+	name "Manx TT SuperBike (USA)"
+	description "Manx TT SuperBike (USA)"
+	rom ( name "Manx TT SuperBike (USA) (Track 01).bin" size 90020448 crc 2894bd11 md5 9cd6757b4d14a8009e7f60cb7b7749ea sha1 779a441c5ce7cf3456681eb279c0278203fe7aa9 )
+)
+
+game (
+	name "Custom Web Browser (Version 2) (USA)"
+	description "Custom Web Browser (Version 2) (USA)"
+	rom ( name "Custom Web Browser (Version 2) (USA) (Track 1).bin" size 21450240 crc 99e4dab7 md5 8333feaa3f83bede565018cf63af06f7 sha1 459006f3d9f0004ebf1eee68eeeb9eb2630902c7 )
+)
+
+game (
+	name "Sega Rally Championship (Europe) (Made in USA)"
+	description "Sega Rally Championship (Europe) (Made in USA)"
+	rom ( name "Sega Rally Championship (Europe) (Made in USA) (Track 01).bin" size 29712816 crc 667e14f4 md5 51e34ce14cff940f2c0f370733a8b4e8 sha1 b60f19c3f691f7b03f7e7364b946085ca010954d )
+)
+
+game (
+	name "Three Dirty Dwarves (Europe)"
+	description "Three Dirty Dwarves (Europe)"
+	rom ( name "Three Dirty Dwarves (Europe) (Track 1).bin" size 197920800 crc 76fe8aca md5 d7b6bfee6bf443e21d7d96472923ee65 sha1 84c859e4c468bf8a1019e040e342833d13178543 )
+)
+
+game (
+	name "Gex (Europe)"
+	description "Gex (Europe)"
+	rom ( name "Gex (Europe) (Track 1).bin" size 271465488 crc 67a8b1a8 md5 04f2765295878ca785164371e0482ac0 sha1 dbe035c273e39abd0002b9b16ea1f81fc274382c )
+)
+
+game (
+	name "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (Europe)"
+	description "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (Europe)"
+	rom ( name "Slam 'n Jam '96 featuring Magic & Kareem - Signature Edition (Europe) (Track 1).bin" size 122922576 crc e04a4e7a md5 c2c99a07ef92c2cb3be0b9c65f359e23 sha1 00adbdfe5beb260c2a7408731af52cf926f572ac )
+)
+
+game (
+	name "Christmas NiGHTS into Dreams... (USA)"
+	description "Christmas NiGHTS into Dreams... (USA)"
+	rom ( name "Christmas NiGHTS into Dreams... (USA) (Track 01).bin" size 31102848 crc b79f922c md5 0042cd59d3b055251c015bcc924e9d41 sha1 415c9c2e025a199c5d7b618f64a4f5ee16e3c806 )
+)
+
+game (
+	name "Gekiretsu Pachinkers (Japan)"
+	description "Gekiretsu Pachinkers (Japan)"
+	rom ( name "Gekiretsu Pachinkers (Japan) (Track 01).bin" size 19980240 crc 12998d60 md5 5d286f90f0bfea25339dbf6b51d242b7 sha1 d948dd5a8cec9fd4e56fbc9f6ed4742d42ce3222 )
+)
+
+game (
+	name "Pro Yakyuu Greatest Nine '97 (Japan) (Rev B)"
+	description "Pro Yakyuu Greatest Nine '97 (Japan) (Rev B)"
+	rom ( name "Pro Yakyuu Greatest Nine '97 (Japan) (Rev B) (Track 1).bin" size 351369984 crc 01eeb339 md5 4d4449a7728fa1da90f395e819dd4d32 sha1 0d87207e6072d64e7a5592babc58c53024e86f22 )
+)
+
+game (
+	name "Myst (Japan) (Rev A)"
+	description "Myst (Japan) (Rev A)"
+	rom ( name "Myst (Japan) (Rev A) (Track 1).bin" size 582653904 crc 1e66f3df md5 70c14bc55fb31223ca8152d467b0223b sha1 2bc6f225374943a39dcb181ea2c966005a838960 )
+)
+
+game (
+	name "Silhouette Mirage (Japan) (Sample)"
+	description "Silhouette Mirage (Japan) (Sample)"
+	rom ( name "Silhouette Mirage (Japan) (Sample) (Track 01).bin" size 144318720 crc 05f82fef md5 2df109411598e6cac156a091001e1721 sha1 421fc1bfaab2a3795df05485da9d9fb27931dc9e )
+)
+
+game (
+	name "NBA Jam - Tournament Edition (USA)"
+	description "NBA Jam - Tournament Edition (USA)"
+	rom ( name "NBA Jam - Tournament Edition (USA) (Track 1).bin" size 117738768 crc ce53c150 md5 0b0d85c3ede75eb4409619d3af26368f sha1 d8f1d7994e179a3e2090413f4a5ed88b891b5b00 )
+)
+
+game (
+	name "Funky Head Boxers Plus (Japan)"
+	description "Funky Head Boxers Plus (Japan)"
+	rom ( name "Funky Head Boxers Plus (Japan) (Track 1).bin" size 198471168 crc 53ce01c1 md5 145d00d02f7cf87ef1076c07c0946935 sha1 7e298d1c505541500d399d83a7ddda424b32b921 )
+)
+
+game (
+	name "Code R (Japan)"
+	description "Code R (Japan)"
+	rom ( name "Code R (Japan) (Track 1).bin" size 533017296 crc c7a8a6bb md5 c3a9397caeb7a44e4fab03d572f2dcab sha1 0968fd705726c3ef511b4c0daf1f6d069bfb3baf )
+)
+
+game (
+	name "Sotsugyou S - Graduation S (Japan)"
+	description "Sotsugyou S - Graduation S (Japan)"
+	rom ( name "Sotsugyou S - Graduation S (Japan) (Track 1).bin" size 436768752 crc b05897e4 md5 4fd862dbe028741bdaac23f18c74dc6e sha1 64ec6d6e2db4a3143fa05527f8bfbba1c99c6df5 )
+)
+
+game (
+	name "Private Idol Disc Vol. 7 - Asou Kaori (Japan)"
+	description "Private Idol Disc Vol. 7 - Asou Kaori (Japan)"
+	rom ( name "Private Idol Disc Vol. 7 - Asou Kaori (Japan) (Track 1).bin" size 648524016 crc 312e2f22 md5 715b3dbdb17f2f71e1994209778913ab sha1 0339cc8b20f0125cf063fa80d4d1343e53d8b5d7 )
+)
+
+game (
+	name "EGWord (Japan) (Rev A) (10M)"
+	description "EGWord (Japan) (Rev A) (10M)"
+	rom ( name "EGWord (Japan) (Rev A) (10M) (Track 1).bin" size 45109008 crc d0c1c7a0 md5 c285bf1b5ae351fc577d8b3645bc317d sha1 e85d329975215a4bf27810e2dddac2cef02fec09 )
+)
+
+game (
+	name "EGWord Ver 2.00 (Japan)"
+	description "EGWord Ver 2.00 (Japan)"
+	rom ( name "EGWord Ver 2.00 (Japan) (Track 1).bin" size 51990960 crc 51226423 md5 1c208f95d1d659f4f402ae0311c40387 sha1 33f254b90696aabdbc39ef0010a36a06c6318a36 )
+)
+
+game (
+	name "Terra Cresta 3D (Japan) (2M)"
+	description "Terra Cresta 3D (Japan) (2M)"
+	rom ( name "Terra Cresta 3D (Japan) (2M) (Track 01).bin" size 8368416 crc 4882a53c md5 19ef74065b54d588e2b46e7b26b77743 sha1 7d4b2fad70638c49bcdae6d95426fd069a918970 )
+)
+
+game (
+	name "Hissatsu! (Japan)"
+	description "Hissatsu! (Japan)"
+	rom ( name "Hissatsu! (Japan) (Track 01).bin" size 21974736 crc 168ef310 md5 9c5d9ed945c73326345c576fcfab6617 sha1 d5f0417067a759b177c5a9a03eb98a3f31e8085b )
+)
+
+game (
+	name "Sonic R (Japan) (Sample)"
+	description "Sonic R (Japan) (Sample)"
+	rom ( name "Sonic R (Japan) (Sample) (Track 1).bin" size 5376672 crc 2c67828f md5 04715c85d78368eb9ec788c5099fc14c sha1 c94b41706419f19d29437bc4b0800d067403b664 )
+)
+
+game (
+	name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Sample)"
+	description "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Sample)"
+	rom ( name "Shining Force III - Scenario 1 - Outo no Kyoshin (Japan) (Sample) (Track 1).bin" size 61683552 crc 85e32509 md5 f612baa034019bac3cccfb14d0c83e9a sha1 a407d296d4cbcaa193c639f8fafff1adfed1eb23 )
+)
+
+game (
+	name "Courier Crisis - The Saga of the Modern Fatalist (Japan)"
+	description "Courier Crisis - The Saga of the Modern Fatalist (Japan)"
+	rom ( name "Courier Crisis - The Saga of the Modern Fatalist (Japan) (Track 1).bin" size 322332192 crc 579dd31a md5 f780bad9f5ff5f73ca5468a5c9c13899 sha1 24e1dabd463d31dabcafdeb0d1ef112053a8637e )
+)
+
+game (
+	name "Saturn Music School (Japan)"
+	description "Saturn Music School (Japan)"
+	rom ( name "Saturn Music School (Japan) (Track 1).bin" size 25060560 crc d4d9386b md5 dfa894b245a6cfd168ba0f0a336a4bed sha1 b8b1f38577df365163a19585cc957bce64b559fe )
+)
+
+game (
+	name "Saturn Music School 2 (Japan) (Rev A)"
+	description "Saturn Music School 2 (Japan) (Rev A)"
+	rom ( name "Saturn Music School 2 (Japan) (Rev A) (Track 1).bin" size 29524656 crc 353b1076 md5 0a7d2046dfa733c1124e9a3dd1254208 sha1 8041c0206100d34d4054fc07cbfb1bafdd0530d0 )
+)
+
+game (
+	name "Trash It (Europe) (En,Fr,De,Es,It)"
+	description "Trash It (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Trash It (Europe) (En,Fr,De,Es,It) (Track 01).bin" size 306677280 crc dbcd8355 md5 ac6f1b2989e4ee5cd50f1b7f6e3a8cdd sha1 094ef51c625d07fbc61b3ccd8e07d0606f35f1a9 )
+)
+
+game (
+	name "Defcon 5 (France)"
+	description "Defcon 5 (France)"
+	rom ( name "Defcon 5 (France) (Track 1).bin" size 228960144 crc 06fce61e md5 0fe1353adf1b615650e73c7749ffbce9 sha1 af9043729d3b96f44ba0057dcb7d8801868f32b6 )
+)
+
+game (
+	name "Core Demo Disc (Europe) (Alt)"
+	description "Core Demo Disc (Europe) (Alt)"
+	rom ( name "Core Demo Disc (Europe) (Alt) (Track 1).bin" size 147616224 crc f6336f96 md5 0689125490b6b9b9df5b4e3031d3e802 sha1 b3b0848b37398333ea203ba3948da802c5ee840e )
+)
+
+game (
+	name "Gremlin Demo Disk (Europe)"
+	description "Gremlin Demo Disk (Europe)"
+	rom ( name "Gremlin Demo Disk (Europe) (Track 1).bin" size 191255232 crc e9492bfb md5 f91a4b8c2a5b20a432dcacfc0f4d9c60 sha1 dfe891cfb80a579ad806c86deeedb1ba4638be94 )
+)
+
+game (
+	name "Impact Racing (Europe) (Demo)"
+	description "Impact Racing (Europe) (Demo)"
+	rom ( name "Impact Racing (Europe) (Demo) (Track 01).bin" size 47787936 crc 9155e8d9 md5 111fcdf46536ccbb69ec97ae5dcc4c25 sha1 56e9bde3f84f8114f8faf4e6b74fab237ae94a73 )
+)
+
+game (
+	name "Crimewave (Europe) (Demo)"
+	description "Crimewave (Europe) (Demo)"
+	rom ( name "Crimewave (Europe) (Demo) (Track 1).bin" size 58517760 crc 2077e54c md5 789d3b79d758965c508d8bcaea44d514 sha1 2049509261dfd6f7faf18a8f14649f27d68c43e9 )
+)
+
+game (
+	name "Street Fighter - The Movie (Europe) (2S)"
+	description "Street Fighter - The Movie (Europe) (2S)"
+	rom ( name "Street Fighter - The Movie (Europe) (2S) (Track 01).bin" size 318672480 crc 0685d1d8 md5 ad77ddbbe86b7ae769d6089c1d262114 sha1 d14c44b7d024ee1a6b53a16f69cc66ed84edbbd4 )
+)
+
+game (
+	name "Daytona USA (Europe)"
+	description "Daytona USA (Europe)"
+	rom ( name "Daytona USA (Europe) (Track 01).bin" size 9551472 crc 720c6052 md5 bfcd996f363ce64f530df6d99ed5cade sha1 d4e3afdb7268cb456356d09728f95842c22b62d8 )
+)
+
+game (
+	name "Momotarou Douchuuki (Japan) (Rev A) (11M)"
+	description "Momotarou Douchuuki (Japan) (Rev A) (11M)"
+	rom ( name "Momotarou Douchuuki (Japan) (Rev A) (11M) (Track 1).bin" size 209161008 crc 84eefd43 md5 c2d89c5815de979c0feabfd1355528df sha1 e0259a61ffff1f7de34309e8a615f946ceb0be84 )
+)
+
+game (
+	name "Princess Crown (Japan) (Rev A) (11M)"
+	description "Princess Crown (Japan) (Rev A) (11M)"
+	rom ( name "Princess Crown (Japan) (Rev A) (11M) (Track 01).bin" size 87339168 crc e7305871 md5 1b070c4c2e108a791e17e0109df168eb sha1 aef5549e5578c410383cbab178ac04b3c4b046e6 )
+)
+
+game (
+	name "Silhouette Mirage (Japan) (Rev A)"
+	description "Silhouette Mirage (Japan) (Rev A)"
+	rom ( name "Silhouette Mirage (Japan) (Rev A) (Track 01).bin" size 144600960 crc fa6f376a md5 7a731c8fb1d551faaada1e1cc03b0ece sha1 02dc51bc271f08c120b13a0285b9bc686e396fd0 )
+)
+
+game (
+	name "Winning Post 2 (Japan) (Rev A) (10M)"
+	description "Winning Post 2 (Japan) (Rev A) (10M)"
+	rom ( name "Winning Post 2 (Japan) (Rev A) (10M) (Track 1).bin" size 152494272 crc 32468376 md5 e5c8b144f1ca456b706f8beaab3b769d sha1 c4779365eb0170b1fb9d9dc5155bed8a02c67dd0 )
+)
+
+game (
+	name "DecAthlete (Japan) (Rev B) (20M)"
+	description "DecAthlete (Japan) (Rev B) (20M)"
+	rom ( name "DecAthlete (Japan) (Rev B) (20M) (Track 01).bin" size 34294512 crc 85db2f61 md5 17a18e75e8c9105a4e29548f0f80b823 sha1 d74b280066f42dcc664611e234425de2e6057127 )
+)
+
+game (
+	name "Digital Pinball - Last Gladiators Ver.9.7 (Japan)"
+	description "Digital Pinball - Last Gladiators Ver.9.7 (Japan)"
+	rom ( name "Digital Pinball - Last Gladiators Ver.9.7 (Japan) (Track 01).bin" size 98880432 crc 2bf31146 md5 76d2f01352b90b7f63d64f67aa0a6036 sha1 7c391e77e470a386f7167f6913faf477446a0050 )
+)
+
+game (
+	name "Layer Section (Japan) (Rev A) (11M)"
+	description "Layer Section (Japan) (Rev A) (11M)"
+	rom ( name "Layer Section (Japan) (Rev A) (11M) (Track 01).bin" size 16776816 crc c93873c3 md5 5ded6df721cdc81372a856c7fb3b5e5a sha1 4a4c321d615b4cd033796433582a2ee4380e9bb8 )
+)
+
+game (
+	name "Teitoku no Ketsudan II (Japan)"
+	description "Teitoku no Ketsudan II (Japan)"
+	rom ( name "Teitoku no Ketsudan II (Japan) (Track 1).bin" size 354985008 crc 1497437b md5 d767cd2ff3ab46ddec1a1e60c1e73e89 sha1 63e24d727232ddd16559c99e17649ce4bba2b502 )
+)
+
+game (
+	name "Teitoku no Ketsudan III (Japan)"
+	description "Teitoku no Ketsudan III (Japan)"
+	rom ( name "Teitoku no Ketsudan III (Japan) (Track 1).bin" size 264322464 crc c15238e8 md5 fd84e47ded0427fee8d8a5db60678927 sha1 a1d1f24bb39614396722ee6a2a8801e831901e6a )
+)
+
+game (
+	name "Taikou Risshiden II (Japan) (2M)"
+	description "Taikou Risshiden II (Japan) (2M)"
+	rom ( name "Taikou Risshiden II (Japan) (2M) (Track 1).bin" size 157393488 crc 96b274ed md5 a18776c08e77f84bf3e140071ff996a4 sha1 8ebac2171c0574fde5d2338fe12b6a0dd0581579 )
+)
+
+game (
+	name "Sangokushi IV (Japan)"
+	description "Sangokushi IV (Japan)"
+	rom ( name "Sangokushi IV (Japan) (Track 1).bin" size 513072336 crc f374d0fe md5 c7cf10343a98dfd3afa2da602ed51cc8 sha1 fa386eeacbfacc7a45bf8d6327ffccebf6709c36 )
+)
+
+game (
+	name "Sangokushi IV with Power-Up Kit (Japan)"
+	description "Sangokushi IV with Power-Up Kit (Japan)"
+	rom ( name "Sangokushi IV with Power-Up Kit (Japan) (Track 1).bin" size 519643824 crc 72fef28e md5 a8793474034b4a04196d42367c053e0c sha1 e3e8620ca624d112b1209f1c01ac0937613c7676 )
+)
+
+game (
+	name "Sangokushi Returns (Japan)"
+	description "Sangokushi Returns (Japan)"
+	rom ( name "Sangokushi Returns (Japan) (Track 1).bin" size 117472992 crc 5a9a5af6 md5 261ce620b2c9394efbe4e36c3bf404ed sha1 4d769aa3e116315cb391008912ce376e665a116e )
+)
+
+game (
+	name "Sangokushi V (Japan)"
+	description "Sangokushi V (Japan)"
+	rom ( name "Sangokushi V (Japan) (Track 1).bin" size 309464400 crc 7ba1de3e md5 8ee08424e056085a77eacda19b7bb142 sha1 039a00f346c5207c9fb5f6f4feeb388fa4e9dc3d )
+)
+
+game (
+	name "Sangokushi V (Japan) (Rev A)"
+	description "Sangokushi V (Japan) (Rev A)"
+	rom ( name "Sangokushi V (Japan) (Rev A) (Track 1).bin" size 309464400 crc 64e357ac md5 2b1337a5f1fc9f88b7386e59f98053ab sha1 40a4d71baf0697bc62aea96c527ad1a3de2ece0e )
+)
+
+game (
+	name "Game Nihonshi - Kakumeiji Oda Nobunaga (Japan)"
+	description "Game Nihonshi - Kakumeiji Oda Nobunaga (Japan)"
+	rom ( name "Game Nihonshi - Kakumeiji Oda Nobunaga (Japan) (Track 1).bin" size 614027232 crc 4bb31cca md5 061f23bfb1701b14fd5aa1ac77879a2c sha1 d3954243e18a28afd127c07615ca26d13f28f2d5 )
+)
+
+game (
+	name "Nobunaga no Yabou Tenshouki with Power-Up Kit (Japan)"
+	description "Nobunaga no Yabou Tenshouki with Power-Up Kit (Japan)"
+	rom ( name "Nobunaga no Yabou Tenshouki with Power-Up Kit (Japan) (Track 1).bin" size 537892992 crc a00c0445 md5 30466fa210479f6ab6af6c626c82530b sha1 75037740b4a8323c8c87483abced5cab2430cb83 )
+)
+
+game (
+	name "Nobunaga no Yabou - Shouseiroku (Japan) (2M)"
+	description "Nobunaga no Yabou - Shouseiroku (Japan) (2M)"
+	rom ( name "Nobunaga no Yabou - Shouseiroku (Japan) (2M) (Track 1).bin" size 488472768 crc fb966dcb md5 a9970ce5342c3e647ce9daf6a7f1c5cc sha1 4a94a57504da4cce292ffb9f7e3f85b5c8ec87e6 )
+)
+
+game (
+	name "Rabbit (Japan)"
+	description "Rabbit (Japan)"
+	rom ( name "Rabbit (Japan) (Track 01).bin" size 88446960 crc c245287e md5 a158d910b0e9a4c3296dcf43a4abfb66 sha1 5bcf07467f103e82df977f43f4db77a70a2e22fa )
+)
+
+game (
+	name "Soukyuu Gurentai (Japan)"
+	description "Soukyuu Gurentai (Japan)"
+	rom ( name "Soukyuu Gurentai (Japan) (Track 01).bin" size 30761808 crc dd90b794 md5 2154b929bf3156735a082d0d550322a0 sha1 9f9513cd4fe0e42c8766fbc26b49453454fe3e22 )
+)
+
+game (
+	name "Darius II (Japan) (2M)"
+	description "Darius II (Japan) (2M)"
+	rom ( name "Darius II (Japan) (2M) (Track 01).bin" size 9161040 crc a3ec1bb6 md5 560e36d43aefecaa17a65db99c0bd051 sha1 1b0f63f33735b82265ba4955a64df7e6afc7c157 )
+)
+
+game (
+	name "Final Fight Revenge (Japan)"
+	description "Final Fight Revenge (Japan)"
+	rom ( name "Final Fight Revenge (Japan) (Track 01).bin" size 27412560 crc 67cfd79a md5 1456b8fe3792b0cf19197a97899bb137 sha1 9abf2c478957d027bae69d3a8e6384aeb1d30d08 )
+)
+
+game (
+	name "Skull Fang - Kuuga Gaiden (Japan)"
+	description "Skull Fang - Kuuga Gaiden (Japan)"
+	rom ( name "Skull Fang - Kuuga Gaiden (Japan) (Track 01).bin" size 67144896 crc 6a77c4e9 md5 e503c1bec63560b7abe2e366d82f7002 sha1 77646c48e71cd8c3c3b7d8d5a2ed05d655a59873 )
+)
+
+game (
+	name "Thunder Force Gold Pack 1 (Japan)"
+	description "Thunder Force Gold Pack 1 (Japan)"
+	rom ( name "Thunder Force Gold Pack 1 (Japan) (Track 01).bin" size 35207088 crc 86d42dde md5 63a56abcff166617772cde6e1b9d7514 sha1 8f38894cfc979afa94312e0563f70211abc08930 )
+)
+
+game (
+	name "Metal Black (Japan) (1M)"
+	description "Metal Black (Japan) (1M)"
+	rom ( name "Metal Black (Japan) (1M) (Track 01).bin" size 5623632 crc 65069511 md5 50aa092277c6d05830d0bb9e8f644f27 sha1 0cd3c65b44cb511257230c30ea08c010b36585b6 )
+)
+
+game (
+	name "Arcade Gears Vol. 2 - Gun Frontier (Japan)"
+	description "Arcade Gears Vol. 2 - Gun Frontier (Japan)"
+	rom ( name "Arcade Gears Vol. 2 - Gun Frontier (Japan) (Track 01).bin" size 20182512 crc efedc666 md5 d458fffa0f0c16a4cf7d7c41d1998305 sha1 d34aeb22a361efc16bbfcd1777d13359110532bd )
+)
+
+game (
+	name "Stellar Assault SS (Japan)"
+	description "Stellar Assault SS (Japan)"
+	rom ( name "Stellar Assault SS (Japan) (Track 1).bin" size 508532976 crc dfa1c1b2 md5 5d454bf6eaf647bc7e7b835d264b4b32 sha1 5fe7d4d6ed067af5bafc20cdf3ed497ae38626e7 )
+)
+
+game (
+	name "Nekketsu Oyako (Japan)"
+	description "Nekketsu Oyako (Japan)"
+	rom ( name "Nekketsu Oyako (Japan) (Track 01).bin" size 10680432 crc 2e66de45 md5 4693d25ab35c6a4de8d6029b6c756ea6 sha1 b2be85500261f27222f67511241925e7092a90d8 )
+)
+
+game (
+	name "AI Shougi 2 (Japan)"
+	description "AI Shougi 2 (Japan)"
+	rom ( name "AI Shougi 2 (Japan) (Track 1).bin" size 13048896 crc cb47de6f md5 e381ac2f75d574c8dedd9b365fd9531c sha1 b5aed5030e2555d8fd5e296f1a4261d815a2d387 )
+)
+
+game (
+	name "FIFA Soccer 96 (Japan)"
+	description "FIFA Soccer 96 (Japan)"
+	rom ( name "FIFA Soccer 96 (Japan) (Track 01).bin" size 240560208 crc 84b9a3be md5 2da2c6ee91d253e0bff7fe5f419c8d37 sha1 75695133d9ac74eba7b101a7c19526e09e5463c1 )
+)
+
+game (
+	name "PGA Tour 97 (Japan)"
+	description "PGA Tour 97 (Japan)"
+	rom ( name "PGA Tour 97 (Japan) (Track 1).bin" size 275670864 crc d992509c md5 b056e82ce07c307dee03544a87a89baf sha1 8c9272c9b710268dbbcae8c6a2cb5d917128eb2c )
+)
+
+game (
+	name "NHL 97 (Japan)"
+	description "NHL 97 (Japan)"
+	rom ( name "NHL 97 (Japan) (Track 1).bin" size 396683616 crc 06bb5593 md5 d7a5090bee0dc05b6bc29c7ab9855c4e sha1 c9d9059018076ebebe005184a93c5eb4b6d0fc76 )
+)
+
+game (
+	name "WarCraft II - The Dark Saga (Japan)"
+	description "WarCraft II - The Dark Saga (Japan)"
+	rom ( name "WarCraft II - The Dark Saga (Japan) (Track 1).bin" size 488435136 crc dda5240c md5 b24ce0569f6986a9cb9fdc62f3c4e29c sha1 924deb40306e6c406625727d9027637306c4bf16 )
+)
+
+game (
+	name "Sid Meier's Civilization - Shin Sekai Shichidai Bunmei (Japan)"
+	description "Sid Meier's Civilization - Shin Sekai Shichidai Bunmei (Japan)"
+	rom ( name "Sid Meier's Civilization - Shin Sekai Shichidai Bunmei (Japan) (Track 1).bin" size 83660640 crc b9b9ac2b md5 f32b708025d936d4b72f3c68d561af60 sha1 995541c041b811fc89d2e9112309d0bbbba1ae0e )
+)
+
+game (
+	name "Transport Tycoon (Japan)"
+	description "Transport Tycoon (Japan)"
+	rom ( name "Transport Tycoon (Japan) (Track 01).bin" size 13984992 crc e4f50868 md5 635eaa046280dfe8f10f9d4436ede55b sha1 9371fb695bcd50265b3375b053a840f64bc369c4 )
+)
+
+game (
+	name "Virtual Kyoutei 2 (Japan) (2M)"
+	description "Virtual Kyoutei 2 (Japan) (2M)"
+	rom ( name "Virtual Kyoutei 2 (Japan) (2M) (Track 01).bin" size 16186464 crc 232a1a4d md5 49da447d8544b6719839c1fd07f1377e sha1 899efba8ffccc2eb7dbf6fa56a81ab17ff1f7a40 )
+)
+
+game (
+	name "Break Point (Japan)"
+	description "Break Point (Japan)"
+	rom ( name "Break Point (Japan) (Track 1).bin" size 4076016 crc 0f7e5cd8 md5 c73a154f3f015e54b474448d68adec6d sha1 ae676ed0ca0b23976d281e3a16fb75132b8d92b7 )
+)
+
+game (
+	name "Eisei Meijin (Japan) (2M)"
+	description "Eisei Meijin (Japan) (2M)"
+	rom ( name "Eisei Meijin (Japan) (2M) (Track 1).bin" size 4692240 crc bd2f8155 md5 4b862448ac7008c0b962d2df0228200f sha1 967fd6f3caaa7594498d8eae30bec72b8f3672bc )
+)
+
+game (
+	name "Eisei Meijin II (Japan)"
+	description "Eisei Meijin II (Japan)"
+	rom ( name "Eisei Meijin II (Japan) (Track 1).bin" size 4981536 crc c33c522a md5 940282c8246e29cc264983dd37ee189c sha1 e72a1503a669600ea5dd9e72571036be0f7c333f )
+)
+
+game (
+	name "Yoshimura Shougi (Japan)"
+	description "Yoshimura Shougi (Japan)"
+	rom ( name "Yoshimura Shougi (Japan) (Track 1).bin" size 4137168 crc 323c5c2b md5 629e90d36ce272d805d908be9f647a3c sha1 79ffd777aa102c9723bef10b35c3470ffef3f0de )
+)
+
+game (
+	name "Etude Prologue - Yureugoku Kokoro no Katachi (Japan)"
+	description "Etude Prologue - Yureugoku Kokoro no Katachi (Japan)"
+	rom ( name "Etude Prologue - Yureugoku Kokoro no Katachi (Japan) (Track 1).bin" size 83933472 crc a8eb9144 md5 3aea076719988bb648dc24f7f4d69845 sha1 54b31fd3783cd6096ac81f49b894613f755137d4 )
+)
+
+game (
+	name "Ojousama o Nerae!! (Japan)"
+	description "Ojousama o Nerae!! (Japan)"
+	rom ( name "Ojousama o Nerae!! (Japan) (Track 1).bin" size 33388992 crc d26db1af md5 0f3eb1be957001e56d4ff52d98182118 sha1 f1c7f9ee7212d85bfef7fc86677b6e669cd9f0ba )
+)
+
+game (
+	name "My Dream - On Air ga Matenakute (Japan) (Disc 1)"
+	description "My Dream - On Air ga Matenakute (Japan) (Disc 1)"
+	rom ( name "My Dream - On Air ga Matenakute (Japan) (Disc 1) (Track 1).bin" size 475421520 crc 00af10ae md5 bdaa66a968b8675a909ff483711c0ced sha1 061ef9232a9fdaf49b8c7766983acffa32fdabdf )
+)
+
+game (
+	name "My Dream - On Air ga Matenakute (Japan) (Disc 2)"
+	description "My Dream - On Air ga Matenakute (Japan) (Disc 2)"
+	rom ( name "My Dream - On Air ga Matenakute (Japan) (Disc 2) (Track 1).bin" size 549725904 crc d9c18e2d md5 c66956d086dcb5fb829f772355484917 sha1 fd592ac96376321efd54e25719f99cae2ea19664 )
+)
+
+game (
+	name "Game de Seishun (Japan) (Rev A)"
+	description "Game de Seishun (Japan) (Rev A)"
+	rom ( name "Game de Seishun (Japan) (Rev A) (Track 1).bin" size 377319600 crc 60c64af5 md5 8c92b7feabe9bc4d372fdcba379e40ff sha1 96a3e19944644f4fb7952b7c52a4d88258354796 )
+)
+
+game (
+	name "Ryouri no Tetsujin - Kitchen Stadium Tour (Japan)"
+	description "Ryouri no Tetsujin - Kitchen Stadium Tour (Japan)"
+	rom ( name "Ryouri no Tetsujin - Kitchen Stadium Tour (Japan) (Track 1).bin" size 578269776 crc edf8c76f md5 5ff60eb53b31d7db7808d0ac6f08e086 sha1 2b80b2293b7904ce7d8dcad1614072ff2ec5c562 )
+)
+
+game (
+	name "Sankyo Fever Jikki Simulation S (Japan)"
+	description "Sankyo Fever Jikki Simulation S (Japan)"
+	rom ( name "Sankyo Fever Jikki Simulation S (Japan) (Track 1).bin" size 240764832 crc f57ccea2 md5 4c068d541077c9f95767f64bf7fb5d86 sha1 5cd1e37725363c9036e080701824dcc79ba8b465 )
+)
+
+game (
+	name "Jissen Pachinko Hisshouhou! Twin (Japan)"
+	description "Jissen Pachinko Hisshouhou! Twin (Japan)"
+	rom ( name "Jissen Pachinko Hisshouhou! Twin (Japan) (Track 01).bin" size 7846272 crc a861bbe1 md5 e5dc70343d6da2ec92f85ae8b765d0b9 sha1 d02b1790751d60403442de4081b7d6c1bd8432ca )
+)
+
+game (
+	name "Taikyoku Shougi - Kiwame II (Japan)"
+	description "Taikyoku Shougi - Kiwame II (Japan)"
+	rom ( name "Taikyoku Shougi - Kiwame II (Japan) (Track 1).bin" size 7302960 crc 505b968d md5 e75c167d25fed20aa17d14607ad41897 sha1 c157faf6adfa2538183064cffe9e91fa89b7e0bc )
+)
+
+game (
+	name "Virtual Casino (Japan)"
+	description "Virtual Casino (Japan)"
+	rom ( name "Virtual Casino (Japan) (Track 01).bin" size 96667200 crc 3e7b56fe md5 7a243ec6da05b2566d849bb56acd1c05 sha1 b5403b84095efca69343b344250f57e4a42640ed )
+)
+
+game (
+	name "Umanari 1 Furlong Gekijou (Japan)"
+	description "Umanari 1 Furlong Gekijou (Japan)"
+	rom ( name "Umanari 1 Furlong Gekijou (Japan) (Track 1).bin" size 137436768 crc 206f73dc md5 551c070b0e2532b010503d602df07670 sha1 6caf9520ce1bb09c6b3e317f3b0e3fa493efe413 )
+)
+
+game (
+	name "Minton Keibu no Sousa File - Doukeshi Satsujin Jiken (Japan)"
+	description "Minton Keibu no Sousa File - Doukeshi Satsujin Jiken (Japan)"
+	rom ( name "Minton Keibu no Sousa File - Doukeshi Satsujin Jiken (Japan) (Track 1).bin" size 395013696 crc 68880f05 md5 73f5c3e38a2556978241d83d26d883b1 sha1 e85e1857a29c7e5d013bf7f91fbab13e436dcb06 )
+)
+
+game (
+	name "Unsolved, The (Japan) (Disc 1)"
+	description "Unsolved, The (Japan) (Disc 1)"
+	rom ( name "Unsolved, The (Japan) (Disc 1) (Track 1).bin" size 586400640 crc b13a1074 md5 ac52a56298c95c978fbd9c3d8ddc366b sha1 31b4c507bfa58441b16d87dca8acb226fe7f3c6a )
+)
+
+game (
+	name "Unsolved, The (Japan) (Disc 2)"
+	description "Unsolved, The (Japan) (Disc 2)"
+	rom ( name "Unsolved, The (Japan) (Disc 2) (Track 1).bin" size 419015856 crc ce35a35a md5 b6d7bdf56155d01773f2c93019654bdc sha1 2d0bc8a712a9367a6c867e17acb0270ba27975b6 )
+)
+
+game (
+	name "Unsolved, The (Japan) (Disc 3)"
+	description "Unsolved, The (Japan) (Disc 3)"
+	rom ( name "Unsolved, The (Japan) (Disc 3) (Track 1).bin" size 489505296 crc 6e31e167 md5 622b4c8e7acce9ff6f34102c5474c586 sha1 f1b7166a6a4353cb7268bf58e6264ef33d8cfa0e )
+)
+
+game (
+	name "Private Idol Disc Vol. 1 - Kinoshita Yuu (Japan)"
+	description "Private Idol Disc Vol. 1 - Kinoshita Yuu (Japan)"
+	rom ( name "Private Idol Disc Vol. 1 - Kinoshita Yuu (Japan) (Track 1).bin" size 223087200 crc e2a9cc1e md5 43ad803e5c4e9d34e48692a80c8e0805 sha1 3cb64e53ff2eee07d2204aa8aacea8e71249cd12 )
+)
+
+game (
+	name "Private Idol Disc Vol. 2 - Uchiyama Miki (Japan)"
+	description "Private Idol Disc Vol. 2 - Uchiyama Miki (Japan)"
+	rom ( name "Private Idol Disc Vol. 2 - Uchiyama Miki (Japan) (Track 1).bin" size 143366160 crc 6c49ecf4 md5 4483540ff473fe307bf472a117a8c11f sha1 98cf4afcc89cb7824db1843f701e24d32a4e6cbe )
+)
+
+game (
+	name "Private Idol Disc Vol. 3 - Ooshima Akemi (Japan) (2M)"
+	description "Private Idol Disc Vol. 3 - Ooshima Akemi (Japan) (2M)"
+	rom ( name "Private Idol Disc Vol. 3 - Ooshima Akemi (Japan) (2M) (Track 1).bin" size 149664816 crc 81275259 md5 6db121dd0e3568de6473e076a615821e sha1 13f0fa6776960d9f3de64fb8a9760be63ee5c461 )
+)
+
+game (
+	name "Private Idol Disc - Tokubetsu-hen - Cosplayers (Japan) (2M)"
+	description "Private Idol Disc - Tokubetsu-hen - Cosplayers (Japan) (2M)"
+	rom ( name "Private Idol Disc - Tokubetsu-hen - Cosplayers (Japan) (2M) (Track 1).bin" size 381964800 crc bb85b51d md5 24b87be5c04cd2dfa196715008a60d9a sha1 3eb932ab3f395fb7805a99294aa34eb2c7c6706b )
+)
+
+game (
+	name "Private Idol Disc - Tokubetsu-hen - Kogal Daihyakka 100 (Japan)"
+	description "Private Idol Disc - Tokubetsu-hen - Kogal Daihyakka 100 (Japan)"
+	rom ( name "Private Idol Disc - Tokubetsu-hen - Kogal Daihyakka 100 (Japan) (Track 1).bin" size 426845664 crc 285b7ce1 md5 d54eceffe6888a47283d9c4b9e17ae71 sha1 7fc979b115d7c82e896ec20ee3e1570b7fe4d026 )
+)
+
+game (
+	name "Private Idol Disc Vol. 4 - Kuroda Mirei (Japan)"
+	description "Private Idol Disc Vol. 4 - Kuroda Mirei (Japan)"
+	rom ( name "Private Idol Disc Vol. 4 - Kuroda Mirei (Japan) (Track 1).bin" size 185459904 crc 5bacc551 md5 0eb2890bb41f62d20c170ecfc828a02f sha1 2cc80eafa52c163c9dfe28d704e430e6be6254e6 )
+)
+
+game (
+	name "Photograph of a Crime, The - Hankou Shashin - Shibarareta Shoujo-tachi no Mita Mono wa (Japan)"
+	description "Photograph of a Crime, The - Hankou Shashin - Shibarareta Shoujo-tachi no Mita Mono wa (Japan)"
+	rom ( name "Photograph of a Crime, The - Hankou Shashin - Shibarareta Shoujo-tachi no Mita Mono wa (Japan) (Track 1).bin" size 256083408 crc b94f3958 md5 8f0a2f94971b044db5b5086f90dbbaac sha1 2950f92eac28b39acec668a4699eeddc42c8032a )
+)
+
+game (
+	name "Habitat II (Japan)"
+	description "Habitat II (Japan)"
+	rom ( name "Habitat II (Japan) (Track 1).bin" size 32130672 crc 2f1b54fb md5 adc3feb0ed90eb2d87fd3bef32fe43b3 sha1 386346fff100389a9d9a8f5fa273f028aed47d8e )
+)
+
+game (
+	name "Kekkon - Marriage - Zen'ya (Japan)"
+	description "Kekkon - Marriage - Zen'ya (Japan)"
+	rom ( name "Kekkon - Marriage - Zen'ya (Japan) (Track 1).bin" size 151200672 crc 9d2decb4 md5 36a85508e9c297d16b9f3cef4d56158b sha1 666643daf5d6bb7376b68df962f2562c27b3c2fc )
+)
+
+game (
+	name "Game no Tetsujin - The Shanghai (Japan)"
+	description "Game no Tetsujin - The Shanghai (Japan)"
+	rom ( name "Game no Tetsujin - The Shanghai (Japan) (Track 01).bin" size 9052848 crc c3b7a1ca md5 66e7873d22bb7e9d3f055f340c229b97 sha1 bde79a4d32565a1217dcf5373caf5ceac51cce62 )
+)
+
+game (
+	name "Shanghai - Great Moments (Japan) (2M)"
+	description "Shanghai - Great Moments (Japan) (2M)"
+	rom ( name "Shanghai - Great Moments (Japan) (2M) (Track 01).bin" size 365644272 crc e3709080 md5 1e251810eef8193937a6a82e7c3f0f1e sha1 39af7ba02fe73d31c6fda34b05f78397d8bca1a5 )
+)
+
+game (
+	name "MediaROMancer - DA - Daisuke Asakura (Japan)"
+	description "MediaROMancer - DA - Daisuke Asakura (Japan)"
+	rom ( name "MediaROMancer - DA - Daisuke Asakura (Japan) (Track 1).bin" size 409880688 crc 801d3d40 md5 198cb8700301fedb7bd26ca321944b3d sha1 65b02e6a29a9c5b50539027fc564f6e6d0c6802f )
+)
+
+game (
+	name "Maboroshi no Black Bass (Japan)"
+	description "Maboroshi no Black Bass (Japan)"
+	rom ( name "Maboroshi no Black Bass (Japan) (Track 01).bin" size 188924400 crc 6e49f3b8 md5 b218fcc2d9d2233aaad4bbe127fd3869 sha1 83f919d5266be6a04ebfa0d292b1a9e8ed391857 )
+)
+
+game (
+	name "Super Casino Special (Japan)"
+	description "Super Casino Special (Japan)"
+	rom ( name "Super Casino Special (Japan) (Track 01).bin" size 95145456 crc 7fea16ce md5 4d2a2e3b9efc9dc0dbee1a995b8b53bd sha1 ffe5280797223c05881a45c59171c91ffe6218a6 )
+)
+
+game (
+	name "Frank Thomas Big Hurt Baseball (Japan)"
+	description "Frank Thomas Big Hurt Baseball (Japan)"
+	rom ( name "Frank Thomas Big Hurt Baseball (Japan) (Track 1).bin" size 352821168 crc 832f4652 md5 fe943cb9f322dd0130a8d26077dc1c23 sha1 f9a4ffeaed88ecfc082821c573617770110e468b )
+)
+
+game (
+	name "WWF In Your House (Japan)"
+	description "WWF In Your House (Japan)"
+	rom ( name "WWF In Your House (Japan) (Track 01).bin" size 99903552 crc a6763b8b md5 d281d0b1a8bb1c7d8056e58420d96203 sha1 f0b9074d4143304d62627f3ccf2e0bbcbb265679 )
+)
+
+game (
+	name "Game-Ware Vol. 2 (Japan)"
+	description "Game-Ware Vol. 2 (Japan)"
+	rom ( name "Game-Ware Vol. 2 (Japan) (Track 1).bin" size 488223456 crc f7d51d12 md5 308ddce586ab641e64b67309bf586f77 sha1 d68a722b4fd094e6a9bdd605f881ea698ed54b4c )
+)
+
+game (
+	name "NFL Quarterback Club '97 (Japan)"
+	description "NFL Quarterback Club '97 (Japan)"
+	rom ( name "NFL Quarterback Club '97 (Japan) (Track 1).bin" size 106738464 crc 092002a4 md5 424302383f7b17810af779acc99b9aa1 sha1 540a65f2d9cc9680e8864d4b486924f077cd2689 )
+)
+
+game (
+	name "Zap! Snowboarding Trix (Japan)"
+	description "Zap! Snowboarding Trix (Japan)"
+	rom ( name "Zap! Snowboarding Trix (Japan) (Track 01).bin" size 12235104 crc fa140a99 md5 a5cbf68093f1de94b80cfc2490592439 sha1 58c80985d214c7fff67bcb59a47d94cd8ab06b5b )
+)
+
+game (
+	name "Zap! Snowboarding Trix '98 (Japan)"
+	description "Zap! Snowboarding Trix '98 (Japan)"
+	rom ( name "Zap! Snowboarding Trix '98 (Japan) (Track 01).bin" size 27556032 crc f4f3f0d3 md5 1057d0c0b3c999c814d61dc533d35d43 sha1 5804b65956257d191f2fcbb0ed409549d0c392bc )
+)
+
+game (
+	name "Game-Ware Vol. 5 (Japan) (Disc A)"
+	description "Game-Ware Vol. 5 (Japan) (Disc A)"
+	rom ( name "Game-Ware Vol. 5 (Japan) (Disc A) (Track 1).bin" size 628035744 crc a58d5288 md5 7f0192549a8bd0535ecf34a3c12fbc8d sha1 b19598d1be2d0044a82dfdb43c69a4247ff00025 )
+)
+
+game (
+	name "Game-Ware Vol. 5 (Japan) (Disc B)"
+	description "Game-Ware Vol. 5 (Japan) (Disc B)"
+	rom ( name "Game-Ware Vol. 5 (Japan) (Disc B) (Track 1).bin" size 643728288 crc bc3b1393 md5 8ec0905bb87900b32dac76c3c74be54e sha1 301e99e6d10148ca39fe236354758ab998c420fc )
+)
+
+game (
+	name "Mahjong Ganryuujima (Japan) (4M)"
+	description "Mahjong Ganryuujima (Japan) (4M)"
+	rom ( name "Mahjong Ganryuujima (Japan) (4M) (Track 1).bin" size 3151680 crc 37355748 md5 4d4b4b56a72b52ed5b9939e9176fd3df sha1 2db285feb57e36ce7d5f5c5f18310ee232faf4a8 )
+)
+
+game (
+	name "Honkaku 4-nin Uchi Geinoujin Taikyoku Mahjong - The Wareme de Pon (Japan)"
+	description "Honkaku 4-nin Uchi Geinoujin Taikyoku Mahjong - The Wareme de Pon (Japan)"
+	rom ( name "Honkaku 4-nin Uchi Geinoujin Taikyoku Mahjong - The Wareme de Pon (Japan) (Track 01).bin" size 84761376 crc ebf6b5cb md5 b475793437cf4a43a8117bf512d1592e sha1 b1c77f405ff5500e1f1e1175217a2e0b7950e6e7 )
+)
+
+game (
+	name "Kuro no Danshou - The Literary Fragment (Japan) (2M)"
+	description "Kuro no Danshou - The Literary Fragment (Japan) (2M)"
+	rom ( name "Kuro no Danshou - The Literary Fragment (Japan) (2M) (Track 1).bin" size 621541872 crc 2a914b75 md5 8296cee8575ebf4be973b34f3a2f4c2c sha1 49c7c04e99ccce31b7d7b725714071d6a5cfe826 )
+)
+
+game (
+	name "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 1) (Joukan)"
+	description "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 1) (Joukan)"
+	rom ( name "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 1) (Joukan) (Track 01).bin" size 501481680 crc 5644060a md5 35714a5549e4439a727b7fa7a9f56ded sha1 e53eae86ae632f288a03438d9d22e02044d148b9 )
+)
+
+game (
+	name "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 2) (Gekan)"
+	description "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 2) (Gekan)"
+	rom ( name "Koden Koureijutsu - Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan) (Disc 2) (Gekan) (Track 01).bin" size 505999872 crc 9f58aee4 md5 197d5ab47021ad7a401b6a5bebab199a sha1 84a7b5f2eb02cff889506ee0ceb1e2eef63aab90 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (Satakore)"
+	description "Enemy Zero (Japan) (Disc 0) (Opening Disc) (Satakore)"
+	rom ( name "Enemy Zero (Japan) (Disc 0) (Opening Disc) (Satakore) (Track 1).bin" size 328452096 crc a274c88f md5 c94d31dc9bbc9dd1d1d3ceb23895e255 sha1 476a69f66818a6ead3d100dfd64bf0f92df165cf )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 1) (Game Disc) (Satakore)"
+	description "Enemy Zero (Japan) (Disc 1) (Game Disc) (Satakore)"
+	rom ( name "Enemy Zero (Japan) (Disc 1) (Game Disc) (Satakore) (Track 1).bin" size 579902064 crc ab4b731a md5 e9c85b456f22c1b988d0738d6ef2f964 sha1 eaab3760257a5d262be139980c9cfe74d1e428bb )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 2) (Game Disc) (Satakore)"
+	description "Enemy Zero (Japan) (Disc 2) (Game Disc) (Satakore)"
+	rom ( name "Enemy Zero (Japan) (Disc 2) (Game Disc) (Satakore) (Track 1).bin" size 652597680 crc b7718b1f md5 420644755be4932d94b73f654065ba66 sha1 ec94f477a8f914fc4648b6b314204b9711312c71 )
+)
+
+game (
+	name "Enemy Zero (Japan) (Disc 3) (Game Disc) (Satakore)"
+	description "Enemy Zero (Japan) (Disc 3) (Game Disc) (Satakore)"
+	rom ( name "Enemy Zero (Japan) (Disc 3) (Game Disc) (Satakore) (Track 1).bin" size 470712816 crc c6c86370 md5 c2af595c321ca2e99fdacf5789dcc490 sha1 5fe62ae169de220a95c848a522df96b20627ad7b )
+)
+
+game (
+	name "Hyper 3D Pinball (Japan)"
+	description "Hyper 3D Pinball (Japan)"
+	rom ( name "Hyper 3D Pinball (Japan) (Track 1).bin" size 74238528 crc c850ed62 md5 a2980fe20b748a1a0d33b5a5958a8ecb sha1 a68557cf43eea4ac5e398ebaeb2ec4c79fbc592b )
+)
+
+game (
+	name "Ginga Eiyuu Densetsu (Japan)"
+	description "Ginga Eiyuu Densetsu (Japan)"
+	rom ( name "Ginga Eiyuu Densetsu (Japan) (Track 1).bin" size 527019696 crc 1bf23702 md5 106443832b60d80fa28025600bdee120 sha1 ebb2de0d156c04c990a3882a6b614485a44a1ad5 )
+)
+
+game (
+	name "Ginga Eiyuu Densetsu Plus (Japan)"
+	description "Ginga Eiyuu Densetsu Plus (Japan)"
+	rom ( name "Ginga Eiyuu Densetsu Plus (Japan) (Track 1).bin" size 470491728 crc 4559842f md5 42012420f42fe38b127156c9c61e7759 sha1 6f694a50a1b1366b4ef3ebaed29d295607745cc4 )
+)
+
+game (
+	name "Courier Crisis - The Saga of the Modern Fatalist (USA)"
+	description "Courier Crisis - The Saga of the Modern Fatalist (USA)"
+	rom ( name "Courier Crisis - The Saga of the Modern Fatalist (USA) (Track 1).bin" size 321577200 crc 8b514f55 md5 e663a2777f6f42c9922fd043a1de09f6 sha1 e900e227fd6c00b0880191dc868d0122378e2008 )
+)
+
+game (
+	name "D-Xhird (Japan) (1M)"
+	description "D-Xhird (Japan) (1M)"
+	rom ( name "D-Xhird (Japan) (1M) (Track 01).bin" size 87179232 crc 8e93f1a9 md5 4ff16a7ac3dbb940ef7565967c45baeb sha1 0df54c603e17a9c3eecd52b0f1a67dff1ecea159 )
+)
+
+game (
+	name "D-Xhird (Japan) (2M)"
+	description "D-Xhird (Japan) (2M)"
+	rom ( name "D-Xhird (Japan) (2M) (Track 01).bin" size 87179232 crc 8e93f1a9 md5 4ff16a7ac3dbb940ef7565967c45baeb sha1 0df54c603e17a9c3eecd52b0f1a67dff1ecea159 )
+)
+
+game (
+	name "Criticom - The Critical Combat (Japan)"
+	description "Criticom - The Critical Combat (Japan)"
+	rom ( name "Criticom - The Critical Combat (Japan) (Track 01).bin" size 240687216 crc fd12e55d md5 1f5f42a7cd94de49df6e05a3a0c68cf4 sha1 db4064e3a94946118f3a2d91ebe6771d096c7849 )
+)
+
+game (
+	name "Grid Runner (Japan)"
+	description "Grid Runner (Japan)"
+	rom ( name "Grid Runner (Japan) (Track 01).bin" size 95759328 crc 654ba4df md5 86f3518de33a2ce736feeef4c670ed2b sha1 0bc963aa5e435eddeee1b7502917cfc90d84e062 )
+)
+
+game (
+	name "Tetris S (Japan)"
+	description "Tetris S (Japan)"
+	rom ( name "Tetris S (Japan) (Track 01).bin" size 52134432 crc 5eb2dcf2 md5 4fcd65af51e68410bb91d8968f033f6d sha1 9968553843d46b7efccf84d8a43242baadb59d11 )
+)
+
+game (
+	name "Tetris S (Japan) (Rev A)"
+	description "Tetris S (Japan) (Rev A)"
+	rom ( name "Tetris S (Japan) (Rev A) (Track 01).bin" size 52520160 crc 56324a0f md5 46b72c9d030e48f236ae61003f7cc1ce sha1 2b8f7f9f444b405b0102b49eaaf2e2de8027d926 )
+)
+
+game (
+	name "Brain Dead 13 (Japan)"
+	description "Brain Dead 13 (Japan)"
+	rom ( name "Brain Dead 13 (Japan) (Track 1).bin" size 628922448 crc 5a292d35 md5 636748b61204e2e990709235343e2c12 sha1 772d4af62f92dace97fb9913a429a2a2deba5233 )
+)
+
+game (
+	name "Worms (Japan)"
+	description "Worms (Japan)"
+	rom ( name "Worms (Japan) (Track 1).bin" size 102810624 crc 16410dd3 md5 eb8f43ae4af1419c894df22b7aa4f57e sha1 1c48b1ac2a65e9c06b0090d423afe2fe75b12580 )
+)
+
+game (
+	name "Chaos Control (Japan)"
+	description "Chaos Control (Japan)"
+	rom ( name "Chaos Control (Japan) (Track 1).bin" size 494940768 crc c570b18f md5 7f3ddfcc1c5143469d64c18f82372441 sha1 3bfd72a8ccd5ab4ee1fabd154497ca58796f6320 )
+)
+
+game (
+	name "Chaos Control Remix (Japan)"
+	description "Chaos Control Remix (Japan)"
+	rom ( name "Chaos Control Remix (Japan) (Track 1).bin" size 398367648 crc 765495dd md5 6ef51e2cf8bc1958d0900ff3bfd4998c sha1 f346a73865df2182648f400f7274a06df7d5c5c0 )
+)
+
+game (
+	name "Strahl - Himerareshi Nanatsu no Hikari (Japan)"
+	description "Strahl - Himerareshi Nanatsu no Hikari (Japan)"
+	rom ( name "Strahl - Himerareshi Nanatsu no Hikari (Japan) (Track 1).bin" size 495625200 crc 19584f0d md5 eabd8d57cd11262bdb165a6aa39529a5 sha1 53fe1eeb3524cd812454352ca08392b8c592927a )
+)
+
+game (
+	name "RoX - 6 = Six (Japan)"
+	description "RoX - 6 = Six (Japan)"
+	rom ( name "RoX - 6 = Six (Japan) (Track 1).bin" size 17595312 crc 84a44a68 md5 7454c2c3a2dd569bf869fa013d8fc8b8 sha1 ccd6e1afaa8db1cef01f6745464f2e12445b7a7d )
+)
+
+game (
+	name "Puzzle Bobble 2X (Japan) (2M2)"
+	description "Puzzle Bobble 2X (Japan) (2M2)"
+	rom ( name "Puzzle Bobble 2X (Japan) (2M2) (Track 01).bin" size 14309568 crc 3275b83c md5 ed0f20585c7d3a96a36d1410e5888498 sha1 c58ceebc042ebd552c585b05a4bc88d69c6c995e )
+)
+
+game (
+	name "Star Bowling, The (Japan) (Disc 1)"
+	description "Star Bowling, The (Japan) (Disc 1)"
+	rom ( name "Star Bowling, The (Japan) (Disc 1) (Track 1).bin" size 343194432 crc 2dff0442 md5 c966b5aa5fdbbfe69e64e7bb50014088 sha1 b28c5bdf60512c84a9d1ffe2fe88feeea723e4c7 )
+)
+
+game (
+	name "Star Bowling, The (Japan) (Disc 2)"
+	description "Star Bowling, The (Japan) (Disc 2)"
+	rom ( name "Star Bowling, The (Japan) (Disc 2) (Track 1).bin" size 143015712 crc 168590c5 md5 e5a4c63d26e11ed56e6e281e1468aa61 sha1 71626b990af1dd0194261d78f1426cf283f80757 )
+)
+
+game (
+	name "Star Bowling Vol. 2, The (Japan) (Disc 1)"
+	description "Star Bowling Vol. 2, The (Japan) (Disc 1)"
+	rom ( name "Star Bowling Vol. 2, The (Japan) (Disc 1) (Track 1).bin" size 386151360 crc 1b671847 md5 78a50020b28d1953d1e0972a5c955f18 sha1 2b2ee85b0f1ff3da2973c398ee6264042e2b268b )
+)
+
+game (
+	name "Star Bowling Vol. 2, The (Japan) (Disc 2)"
+	description "Star Bowling Vol. 2, The (Japan) (Disc 2)"
+	rom ( name "Star Bowling Vol. 2, The (Japan) (Disc 2) (Track 1).bin" size 141505728 crc 1e631a00 md5 4e209a9a24d2b3afa5dc8a6b5f0460f7 sha1 0db98734e19424e59dd6e13c91526de0470305c3 )
+)
+
+game (
+	name "Falcom Classics (Japan) (Disc 2) (Special CD)"
+	description "Falcom Classics (Japan) (Disc 2) (Special CD)"
+	rom ( name "Falcom Classics (Japan) (Disc 2) (Special CD) (Track 1).bin" size 2932944 crc bffcc6a2 md5 bd9f8c3eb573b0af97d273f0ff82dfd5 sha1 2683858f64ccaabe189e281008d3fd08441599b5 )
+)
+
+game (
+	name "Blood Factory (Japan)"
+	description "Blood Factory (Japan)"
+	rom ( name "Blood Factory (Japan) (Track 01).bin" size 41080032 crc 510495c2 md5 08ea8988eefef852cb6d1ab2e6bb1833 sha1 e2f2cee2ba3e7eaf8e963181f2bff28d0c17dfdc )
+)
+
+game (
+	name "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 1)"
+	description "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 1)"
+	rom ( name "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 1) (Track 1).bin" size 360422832 crc 7a119367 md5 d0ff5f13c188a58037c425803b8a9f58 sha1 a9def7b5076926fd8d985c0017f561a1c1fc3a3b )
+)
+
+game (
+	name "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 2)"
+	description "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 2)"
+	rom ( name "Houkago Ren'ai Club - Koi no Etude (Japan) (Disc 2) (Track 1).bin" size 438064704 crc 0667298f md5 a3bc3189321e0896b8adc7b50051f65b sha1 6bd379dfd861ea242fa96866100451f4cbf2816a )
+)
+
+game (
+	name "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 1) (2M)"
+	description "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 1) (2M)"
+	rom ( name "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 1) (2M) (Track 1).bin" size 627252528 crc efd6700f md5 6ba8d460054e4805c0026dcdcdf125a4 sha1 54aeccbb895efd032bafcadb9333ff0012a7b07a )
+)
+
+game (
+	name "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 2) (2M)"
+	description "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 2) (2M)"
+	rom ( name "Tokimeki Memorial Drama Series Vol. 2 - Irodori no Love Song (Japan) (Disc 2) (2M) (Track 1).bin" size 661403568 crc 10ffbbc3 md5 1999d2a3718f0fdb2943f902daa2f100 sha1 9d1e37431732096f9f6d10329dacef86cde7ce2e )
+)
+
+game (
+	name "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 1)"
+	description "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 1)"
+	rom ( name "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 1) (Track 1).bin" size 656132736 crc 08a28811 md5 12e3df6bbec3bde22714e14a20d0bb02 sha1 5cfad446802a926cc8cccb74c422128c43d62dee )
+)
+
+game (
+	name "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 2)"
+	description "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 2)"
+	rom ( name "Tokimeki Memorial Drama Series Vol. 3 - Tabidachi no Uta (Japan) (Disc 2) (Track 1).bin" size 655838736 crc de2e790a md5 688afb6901b1960fe85aa18151592e1b sha1 c9d78e8f80ca45708098f6b552794c4986720d10 )
+)
+
+game (
+	name "Minakata Hakudou Toujou (Japan) (Disc 1) (2M)"
+	description "Minakata Hakudou Toujou (Japan) (Disc 1) (2M)"
+	rom ( name "Minakata Hakudou Toujou (Japan) (Disc 1) (2M) (Track 1).bin" size 437467296 crc 74402367 md5 163ee14008a2a1066d3776fcf545c5a6 sha1 72229e201d161047f017c4a3a9ec3fab2e0aa934 )
+)
+
+game (
+	name "Minakata Hakudou Toujou (Japan) (Disc 2)"
+	description "Minakata Hakudou Toujou (Japan) (Disc 2)"
+	rom ( name "Minakata Hakudou Toujou (Japan) (Disc 2) (Track 1).bin" size 332436384 crc 2d6aa833 md5 b86fb7b195039eae4a70374b957deb0a sha1 6205882279530bd3cb76de25fe056b5ebc79b998 )
+)
+
+game (
+	name "Zork I - The Great Underground Empire (Japan)"
+	description "Zork I - The Great Underground Empire (Japan)"
+	rom ( name "Zork I - The Great Underground Empire (Japan) (Track 01).bin" size 56161056 crc 25c6e4af md5 435e8000ac287463bf0b228365eae957 sha1 215b4f1b674c3609f77e6179f28becd00a21028a )
+)
+
+game (
+	name "Return to Zork (Japan) (1M)"
+	description "Return to Zork (Japan) (1M)"
+	rom ( name "Return to Zork (Japan) (1M) (Track 1).bin" size 616964880 crc 2afa4616 md5 3d645ae95c045773682ef10607901d57 sha1 ffaa4c7c17e7d519b44725ec1150425ff1a62ab6 )
+)
+
+game (
+	name "Return to Zork (Japan) (Rev A) (10M)"
+	description "Return to Zork (Japan) (Rev A) (10M)"
+	rom ( name "Return to Zork (Japan) (Rev A) (10M) (Track 1).bin" size 616971936 crc 7708040e md5 76d6110f0eb431dbdc98c8a78fb04ffb sha1 8027ffcba4039a1602d6219ccbd512fd4e1f23e0 )
+)
+
+game (
+	name "Taiheiyou no Arashi 2 - Shippuu no Moudou (Japan)"
+	description "Taiheiyou no Arashi 2 - Shippuu no Moudou (Japan)"
+	rom ( name "Taiheiyou no Arashi 2 - Shippuu no Moudou (Japan) (Track 1).bin" size 531342672 crc a944ac6e md5 dd96effe10ab662d4b5eb1587cc8c907 sha1 a9d10c56e39d1f11a98d2b757666709081ab6e52 )
+)
+
+game (
+	name "Taiheiyou no Arashi 2 - 3D Heiki Data-shuu (Japan)"
+	description "Taiheiyou no Arashi 2 - 3D Heiki Data-shuu (Japan)"
+	rom ( name "Taiheiyou no Arashi 2 - 3D Heiki Data-shuu (Japan) (Track 01).bin" size 129818640 crc dac41fc5 md5 29ad116f201cf3ae24735ea231749adc sha1 0deec6126828b587a2ddfe3f46cedae8ff96577d )
+)
+
+game (
+	name "Tokimeki Memorial - Forever with You (Japan) (2M)"
+	description "Tokimeki Memorial - Forever with You (Japan) (2M)"
+	rom ( name "Tokimeki Memorial - Forever with You (Japan) (2M) (Track 1).bin" size 239685264 crc 22e2ae16 md5 2f6943d792d80e780ab37273ec1a96ae sha1 1cd7310334d324b14a64757f29f6e06c23501a60 )
+)
+
+game (
+	name "Panic-chan (Japan) (Rev A) (10M)"
+	description "Panic-chan (Japan) (Rev A) (10M)"
+	rom ( name "Panic-chan (Japan) (Rev A) (10M) (Track 1).bin" size 504442848 crc e5198c20 md5 c398a16ab37960a89d3ef1dccfb7c4bc sha1 efbd63c9091ae90474ac5aca001c120ae090edb6 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 1)"
+	description "PhantasM (Japan) (Disc 1)"
+	rom ( name "PhantasM (Japan) (Disc 1) (Track 1).bin" size 366928464 crc 593eb67f md5 8cbe9a84bcdb7197a0652bb1b530395e sha1 87a71ec68b953a5bd98b922faa251e8bf991e1f5 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 2)"
+	description "PhantasM (Japan) (Disc 2)"
+	rom ( name "PhantasM (Japan) (Disc 2) (Track 1).bin" size 406872480 crc 3b854f19 md5 2fb0437c01830e43f01d40cbbbdb2871 sha1 1bd8c21614c63b6af9d9b3a394041642deb0f59a )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 3) (2M)"
+	description "PhantasM (Japan) (Disc 3) (2M)"
+	rom ( name "PhantasM (Japan) (Disc 3) (2M) (Track 1).bin" size 492720480 crc eea22c90 md5 e6e5b394890c06477101c71dd6a9b98a sha1 83ca32e9baf9a80658b0f20905ad23bd5fc2edd3 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 4)"
+	description "PhantasM (Japan) (Disc 4)"
+	rom ( name "PhantasM (Japan) (Disc 4) (Track 1).bin" size 460321680 crc baf59dd2 md5 c35d39b914ba4f4c247bdf102bfc8314 sha1 5df838c50bc8febcdbe651e5653be441a1e7e31c )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 5)"
+	description "PhantasM (Japan) (Disc 5)"
+	rom ( name "PhantasM (Japan) (Disc 5) (Track 1).bin" size 395540544 crc 1361635d md5 b032c9ad3573c34ce0aee0edfb981b60 sha1 529651c1822401ce01b838af73cc49c7437d9976 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 6) (4M)"
+	description "PhantasM (Japan) (Disc 6) (4M)"
+	rom ( name "PhantasM (Japan) (Disc 6) (4M) (Track 1).bin" size 545624016 crc 8c2363fd md5 acc2350da5e0b6004276996048bfa819 sha1 f8a4e21f4f911745567098bed8be386519857058 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 6) (5M)"
+	description "PhantasM (Japan) (Disc 6) (5M)"
+	rom ( name "PhantasM (Japan) (Disc 6) (5M) (Track 1).bin" size 545624016 crc 8c2363fd md5 acc2350da5e0b6004276996048bfa819 sha1 f8a4e21f4f911745567098bed8be386519857058 )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 7)"
+	description "PhantasM (Japan) (Disc 7)"
+	rom ( name "PhantasM (Japan) (Disc 7) (Track 1).bin" size 371072688 crc 65832ff3 md5 e6f5989eed5d051fa7250da231e36dd3 sha1 0507e507f85217422945793ff5b6e8476a1bfdbb )
+)
+
+game (
+	name "PhantasM (Japan) (Disc 8)"
+	description "PhantasM (Japan) (Disc 8)"
+	rom ( name "PhantasM (Japan) (Disc 8) (Track 1).bin" size 493136784 crc 8d048c75 md5 0747f319c0e50229e5f3dc707d611c35 sha1 964388c0f3349b917958746cccf487a1528ced7e )
+)
+
+game (
+	name "Pad Nifty (Japan)"
+	description "Pad Nifty (Japan)"
+	rom ( name "Pad Nifty (Japan) (Track 1).bin" size 7460544 crc d9f5c53b md5 b5608f32cf99f3dea515019f96d7a4fd sha1 58732a22df46e6fcd3dd76d6dfcc387de74220aa )
+)
+
+game (
+	name "SegaSaturn Internet Vol. 1 (Japan)"
+	description "SegaSaturn Internet Vol. 1 (Japan)"
+	rom ( name "SegaSaturn Internet Vol. 1 (Japan) (Track 1).bin" size 22562736 crc 010d5320 md5 83d8365e8864c456dd3d84a492d3198c sha1 0a2d17432b21fd1d22171ba5cf5f162ecc73f484 )
+)
+
+game (
+	name "Saturn Bomberman (Japan) (SegaNet)"
+	description "Saturn Bomberman (Japan) (SegaNet)"
+	rom ( name "Saturn Bomberman (Japan) (SegaNet) (Track 01).bin" size 134179248 crc dfe0943c md5 c0b0757ca7b071fd07d95c8b0e066e85 sha1 cec813af9b08e473de3caeb0bf55d400508d6fd0 )
+)
+
+game (
+	name "Puzzle Bobble 3 for SegaNet (Japan)"
+	description "Puzzle Bobble 3 for SegaNet (Japan)"
+	rom ( name "Puzzle Bobble 3 for SegaNet (Japan) (Track 01).bin" size 27377280 crc 728dd8bf md5 249f9e028652bf784570cfd5ed4f3edb sha1 6e4028b48e44634569b46971458f4f4acace8807 )
+)
+
+game (
+	name "Dennou Senki - Virtual On - Cyber Troopers for SegaNet (Japan)"
+	description "Dennou Senki - Virtual On - Cyber Troopers for SegaNet (Japan)"
+	rom ( name "Dennou Senki - Virtual On - Cyber Troopers for SegaNet (Japan) (Track 01).bin" size 41336400 crc f6eab32b md5 eec262a7b8ff437533a80da8f25040d5 sha1 6b7d48e71a7507f026d0614dedb7880d35724f3d )
+)
+
+game (
+	name "Can Can Bunny Premiere (Japan) (1M)"
+	description "Can Can Bunny Premiere (Japan) (1M)"
+	rom ( name "Can Can Bunny Premiere (Japan) (1M) (Track 01).bin" size 158219040 crc 2d17460a md5 3e815c1a7ac505c07af95fce622981c5 sha1 374b507cd390d4fcdd72a16bf2ab7e637f8e16e9 )
+)
+
+game (
+	name "Can Can Bunny Premiere 2 (Japan) (Disc 1)"
+	description "Can Can Bunny Premiere 2 (Japan) (Disc 1)"
+	rom ( name "Can Can Bunny Premiere 2 (Japan) (Disc 1) (Track 1).bin" size 629402256 crc f102767f md5 2606139c208fb9124a61946e71d6f281 sha1 efe014382a218c0e9e4aa230c754032121a1e820 )
+)
+
+game (
+	name "Can Can Bunny Premiere 2 (Japan) (Disc 2) (Can Bani Himekuri Calendar)"
+	description "Can Can Bunny Premiere 2 (Japan) (Disc 2) (Can Bani Himekuri Calendar)"
+	rom ( name "Can Can Bunny Premiere 2 (Japan) (Disc 2) (Can Bani Himekuri Calendar) (Track 1).bin" size 331410912 crc 67704e9b md5 81d06f10d46f93926413740dc42aa3b9 sha1 dfa0d280bd6705e386540f681b8b7e6ff6ec5381 )
+)
+
+game (
+	name "Can Can Bunny Extra (Japan)"
+	description "Can Can Bunny Extra (Japan)"
+	rom ( name "Can Can Bunny Extra (Japan) (Track 1).bin" size 531636672 crc 568a9a59 md5 0560a0a70970fd6d493d52a795114c15 sha1 28dc444c104d3ff7fe8a23a1c163a974775122fa )
+)
+
+game (
+	name "Mahjong Gakuensai (Japan)"
+	description "Mahjong Gakuensai (Japan)"
+	rom ( name "Mahjong Gakuensai (Japan) (Track 1).bin" size 448159488 crc e2c5b362 md5 08f2837ed74ce49d226123718c0886d9 sha1 2ff6c618a668c5922f8ae5c5d5c4105d8d90d3ea )
+)
+
+game (
+	name "Mahjong Gakuensai (Japan) (Disc 1) (Genteiban)"
+	description "Mahjong Gakuensai (Japan) (Disc 1) (Genteiban)"
+	rom ( name "Mahjong Gakuensai (Japan) (Disc 1) (Genteiban) (Track 1).bin" size 448159488 crc 0afa926c md5 15034f8e5cffa772ef1fa9bd38d45295 sha1 79e9e688f1765f00cb120b3c8dfcab8c176c449e )
+)
+
+game (
+	name "Mahjong Gakuensai (Japan) (Disc 2) (Seiyuu Interview Hi CD) (Genteiban)"
+	description "Mahjong Gakuensai (Japan) (Disc 2) (Seiyuu Interview Hi CD) (Genteiban)"
+	rom ( name "Mahjong Gakuensai (Japan) (Disc 2) (Seiyuu Interview Hi CD) (Genteiban) (Track 01).bin" size 65237424 crc 08cdf950 md5 e3e3402caf0f1fc5088861ea06a6f653 sha1 ac9f0652f574efb71b9a600766f98ab7dc514fee )
+)
+
+game (
+	name "Mahjong Gakuensai DX - Zenjitsu ni Matsuwaru Funsenki (Japan)"
+	description "Mahjong Gakuensai DX - Zenjitsu ni Matsuwaru Funsenki (Japan)"
+	rom ( name "Mahjong Gakuensai DX - Zenjitsu ni Matsuwaru Funsenki (Japan) (Track 1).bin" size 255707088 crc 35488b7f md5 73df5fd9eb3187926e77f9ba4101c428 sha1 cfccfdcc09f5edc79ed30486072e7eebd3a13064 )
+)
+
+game (
+	name "Super Real Mahjong PV (Japan) (P's Club Special Edition) (2M)"
+	description "Super Real Mahjong PV (Japan) (P's Club Special Edition) (2M)"
+	rom ( name "Super Real Mahjong PV (Japan) (P's Club Special Edition) (2M) (Track 1).bin" size 129510528 crc be11ba6e md5 4c223a84696c9f4d1a889ab4550ca031 sha1 04cb17302c4eb501fa093970b19844983b8886b5 )
+)
+
+game (
+	name "Super Real Mahjong PVI (Japan) (P's Club Special Edition)"
+	description "Super Real Mahjong PVI (Japan) (P's Club Special Edition)"
+	rom ( name "Super Real Mahjong PVI (Japan) (P's Club Special Edition) (Track 01).bin" size 154208880 crc 93c6883e md5 cdb4e1763fa303f897872a1c22bf31aa sha1 e05fa2622a6d9b674306bb5ce4c80d16ada89dde )
+)
+
+game (
+	name "Super Real Mahjong P7 (Japan) (P's Club Special Edition)"
+	description "Super Real Mahjong P7 (Japan) (P's Club Special Edition)"
+	rom ( name "Super Real Mahjong P7 (Japan) (P's Club Special Edition) (Track 01).bin" size 305701200 crc 7604c77a md5 57dac7c469476cd0e8962b75a615f68a sha1 e8b4f484fda03616a7df4ccfc32f2c76f65309f0 )
+)
+
+game (
+	name "Super Real Mahjong Graffiti (Japan) (P's Club Special Edition) (2M)"
+	description "Super Real Mahjong Graffiti (Japan) (P's Club Special Edition) (2M)"
+	rom ( name "Super Real Mahjong Graffiti (Japan) (P's Club Special Edition) (2M) (Track 01).bin" size 21539616 crc c505c25a md5 c3d72b895a9986e3e72c729bee849fb0 sha1 5a404e575452f8603e241e0398439ef100c0ad20 )
+)
+
+game (
+	name "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan) (P's Club Genteiban)"
+	description "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan) (P's Club Genteiban)"
+	rom ( name "Real Mahjong Adventure 'Umi e' - Summer Waltz (Japan) (P's Club Genteiban) (Track 1).bin" size 431911872 crc 68eb7316 md5 019a3a5f6d7c7123cbe8f12a7db79dc1 sha1 e9ddbfde2209f0e5f66cd88aff9547d117bb2c70 )
+)
+
+game (
+	name "Burning Rangers (Japan) (Sample)"
+	description "Burning Rangers (Japan) (Sample)"
+	rom ( name "Burning Rangers (Japan) (Sample) (Track 1).bin" size 279220032 crc 2e5af2a8 md5 3e8ec79b6d0882f7f6b9f44042ea7bf7 sha1 acdb237c6c6fa34f6f6bdab767e88f15a6670d6b )
+)
+
+game (
+	name "Solo Crisis (Japan) (Sample)"
+	description "Solo Crisis (Japan) (Sample)"
+	rom ( name "Solo Crisis (Japan) (Sample) (Track 1).bin" size 51052512 crc 7d17e082 md5 3347551de2152be4bb8589226888cebc sha1 6d7d179855d5a89b1fdff9115ee73a9c3d6da4ba )
+)
+
+game (
+	name "Mr. Bones (Japan) (Trial Edition)"
+	description "Mr. Bones (Japan) (Trial Edition)"
+	rom ( name "Mr. Bones (Japan) (Trial Edition) (Track 01).bin" size 82926816 crc f1118e05 md5 eef611c7401abca876916a1cacd97e3b sha1 59051622bb6a9ead529ca6a4929caa04da7067bd )
+)
+
+game (
+	name "Roommate - Inoue Ryouko (Japan)"
+	description "Roommate - Inoue Ryouko (Japan)"
+	rom ( name "Roommate - Inoue Ryouko (Japan) (Track 1).bin" size 491408064 crc daeea821 md5 fdc3a59384171475f98ad4388eba774b sha1 8e62a2aced32c3537a4997a1d350531804537a10 )
+)
+
+game (
+	name "Roommate 3 - Ryouko Kaze no Kagayaku Asa ni (Japan)"
+	description "Roommate 3 - Ryouko Kaze no Kagayaku Asa ni (Japan)"
+	rom ( name "Roommate 3 - Ryouko Kaze no Kagayaku Asa ni (Japan) (Track 1).bin" size 307738032 crc 2a8b3673 md5 f38bd9745bdd8cc2447bee87c7493211 sha1 42875389ac9c43b05d8dd9f1a1931e0a89944f0d )
+)
+
+game (
+	name "Roommate W - Futari (Japan) (Disc 1)"
+	description "Roommate W - Futari (Japan) (Disc 1)"
+	rom ( name "Roommate W - Futari (Japan) (Disc 1) (Track 1).bin" size 394966656 crc 603c9b6f md5 a38227378cddd39611944d110b317a78 sha1 0656bb8edddb559ab923f5c21aded3b46b721f10 )
+)
+
+game (
+	name "Roommate W - Futari (Japan) (Disc 2)"
+	description "Roommate W - Futari (Japan) (Disc 2)"
+	rom ( name "Roommate W - Futari (Japan) (Disc 2) (Track 1).bin" size 463583904 crc 896c14af md5 f9a0595c26b6787ed25a7fec482812e2 sha1 5beb8e115b2bb460f72bc6b7c18bdfad3cb47744 )
+)
+
+game (
+	name "Ryouko no Oshaberi Room (Japan)"
+	description "Ryouko no Oshaberi Room (Japan)"
+	rom ( name "Ryouko no Oshaberi Room (Japan) (Track 1).bin" size 331857792 crc 326d12b5 md5 8512a5c8d142d0910b07873871ee20dd sha1 1620fca1504d17fb7ebc6beb65dd2e098071a367 )
+)
+
+game (
+	name "Casper (Japan)"
+	description "Casper (Japan)"
+	rom ( name "Casper (Japan) (Track 1).bin" size 129338832 crc aeea1689 md5 caa878aa133cd2dc4847007117876297 sha1 1900bcfd3b8b31a6718bf8c8a2bc04d57f1ae5d5 )
+)
+
+game (
+	name "Shougi Matsuri (Japan)"
+	description "Shougi Matsuri (Japan)"
+	rom ( name "Shougi Matsuri (Japan) (Track 01).bin" size 19081776 crc 647c3495 md5 e21ddadb11e08d11cad781c6f79381e6 sha1 23d622c3238759b80ea062f14fccbd7ad9d5cb69 )
+)
+
+game (
+	name "Fushigi no Kuni no Angelique (Japan)"
+	description "Fushigi no Kuni no Angelique (Japan)"
+	rom ( name "Fushigi no Kuni no Angelique (Japan) (Track 01).bin" size 192673488 crc b079e921 md5 603ddb39365f092601e58cce423fecf8 sha1 b1ba264d7dbdd5df8c784555ccb4260abe72c789 )
+)
+
+game (
+	name "Psychotron, The (Japan)"
+	description "Psychotron, The (Japan)"
+	rom ( name "Psychotron, The (Japan) (Track 1).bin" size 545753376 crc 4927225c md5 483498a0e34096386599a88fe9b75bb8 sha1 d03bfa745a62fa25555cab1124275c3cce43f060 )
+)
+
+game (
+	name "Magic Carpet (USA)"
+	description "Magic Carpet (USA)"
+	rom ( name "Magic Carpet (USA) (Track 1).bin" size 81713184 crc b6cd0306 md5 bad3e88c179ef6a2117788551d2ae22a sha1 19f852bd345f5392ab304e674278288ef12347f2 )
+)
+
+game (
+	name "Ooedo Renaissance (Japan)"
+	description "Ooedo Renaissance (Japan)"
+	rom ( name "Ooedo Renaissance (Japan) (Track 01).bin" size 12129264 crc 6dfbec2a md5 a2164e6ab78022d391b3efedd3f5df44 sha1 6551f0d00eecbeb6960a93f545cf481029afc62e )
+)
+
+game (
+	name "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (Rev B)"
+	description "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (Rev B)"
+	rom ( name "Advanced World War - Sennen Teikoku no Koubou - Last of the Millennium (Japan) (Rev B) (Track 01).bin" size 610200528 crc f464829d md5 38b165abba4444cc4d8b0e922350ac33 sha1 ed85413bd508cd0b1710f36582be6e4830769945 )
+)
+
+game (
+	name "Go III Professional - Taikyoku Igo (Japan)"
+	description "Go III Professional - Taikyoku Igo (Japan)"
+	rom ( name "Go III Professional - Taikyoku Igo (Japan) (Track 1).bin" size 4238304 crc 8184d468 md5 49faa55dae3d6e91694d10cd9f38e4c6 sha1 a45c3dadaa1e06579d0955bb205004e46a36399c )
+)
+
+game (
+	name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev B)"
+	description "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev B)"
+	rom ( name "Sega Worldwide Soccer '98 - Club Edition (Europe) (En,Fr,Es) (Rev B) (Track 1).bin" size 263369904 crc 8d3e2526 md5 7777a206bdf46a1d01cd9bae84612bb0 sha1 b35f57a2a7173fc547998471a1c82483037842f1 )
+)
+
+game (
+	name "Tempest 2000 (Europe)"
+	description "Tempest 2000 (Europe)"
+	rom ( name "Tempest 2000 (Europe) (Track 01).bin" size 2580144 crc eeffc4e6 md5 fcfbf0db8f3432752de011cc37cc06ec sha1 99828009a32add1a4de9069d927f9db8915dd2e5 )
+)
+
+game (
+	name "Dragon's Dream (Japan)"
+	description "Dragon's Dream (Japan)"
+	rom ( name "Dragon's Dream (Japan) (Track 1).bin" size 22765008 crc 05f7e157 md5 ff19a295567bf7f827789c21ad5a2ded sha1 fbc952729a0e39db9d695d385bc9cb84b7064369 )
+)


### PR DESCRIPTION
This DAT will allow RetroArch to browse and play Sega Saturn games. It is built from the Sega Saturn DAT from [redump.org](http://redump.org), using the [libretro-database-sega-saturn](https://github.com/RobLoach/libretro-database-sega-saturn) script.

## Caveat

[Yabause currently doesn't  support loading multiple tracks](http://libretro.com/forums/showthread.php?t=4791), so this DAT only writes the first track. It still works with a large majority of games in Yabause, however. If another DAT comes along (or a core that supports multiple tracks), then we could roll with that. But for now, this is the best we have. Just make Yabause load the first track.