### PR TITLE
Add Sega - Mega-CD - Sega CD

### DIFF
--- a/dat/Sega - Mega-CD - Sega CD.dat
+++ b/dat/Sega - Mega-CD - Sega CD.dat
@@ -1,0 +1,1639 @@
+clrmamepro (
+	name "Sega - Mega-CD - Sega CD"
+	description "Sega - Mega-CD - Sega CD"
+	version "0.0.2"
+	comment "libretro-database's DAT file for Sega - Mega-CD - Sega CD"
+	homepage "https://github.com/RobLoach/libretro-database-sega-mega-cd"
+)
+
+game (
+	name "3 Ninjas Kick Back (USA)"
+	description "3 Ninjas Kick Back (USA)"
+	rom ( name "3 Ninjas Kick Back (USA).cue" size 1433 crc 9d4d85ae md5 c2218a5e7ddac5a0606889e4d8251e75 sha1 8f457d2b7cf13110ef6c501cb345ec688d4e4ace )
+)
+
+game (
+	name "A-X-101 (USA) (RE)"
+	description "A-X-101 (USA) (RE)"
+	rom ( name "A-X-101 (USA) (RE).cue" size 229 crc 5dd5c2a1 md5 f63325683f0f7b7275c15ae5c1c243ee sha1 7cb650ee451960270fcd5d975f05bf5f623fda5c )
+)
+
+game (
+	name "Adventures of Batman and Robin, The (USA)"
+	description "Adventures of Batman and Robin, The (USA)"
+	rom ( name "Adventures of Batman and Robin, The (USA).cue" size 927 crc 28438349 md5 d50635185b32f14ca4f9d0089c5eb1c8 sha1 87630d5b52393179a5eeab3c231f4d837b56f2d1 )
+)
+
+game (
+	name "Adventures of Willy Beamish, The (USA)"
+	description "Adventures of Willy Beamish, The (USA)"
+	rom ( name "Adventures of Willy Beamish, The (USA).cue" size 2000 crc 7e070f1f md5 1c01a036318fae087eaca07502699c3e sha1 ad68b3e076259b7f34ae99622472c5dd115857fd )
+)
+
+game (
+	name "After Burner III (Japan)"
+	description "After Burner III (Japan)"
+	rom ( name "After Burner III (Japan).cue" size 1433 crc fd01bb95 md5 e9061f9f67eaff1b284c2747f4a10f6f sha1 8b84b96e7a0048557aca3ff7f71ef2318457d48c )
+)
+
+game (
+	name "After Burner III (USA)"
+	description "After Burner III (USA)"
+	rom ( name "After Burner III (USA).cue" size 1386 crc c5c57986 md5 a8a8015513c4fa64d7cdd0d9535926c5 sha1 e054d58ac8ecfc28eb66134d16b23ca53ff13542 )
+)
+
+game (
+	name "AH3 - Thunderstrike (USA)"
+	description "AH3 - Thunderstrike (USA)"
+	rom ( name "AH3 - Thunderstrike (USA).cue" size 1445 crc b3cbb90d md5 23c0c1ded6f0693064fe702d08203851 sha1 5a2a5ebbc46066de1a45d137376ef16ad5dcef15 )
+)
+
+game (
+	name "Amazing Spider-Man vs. The Kingpin, The (Europe)"
+	description "Amazing Spider-Man vs. The Kingpin, The (Europe)"
+	rom ( name "Amazing Spider-Man vs. The Kingpin, The (Europe).cue" size 1841 crc 0c2c6c1a md5 8d45abbb85b09ffdbfdc66d595dc7d51 sha1 c8b4bb9b88f2f891ba9c3de946326514df5c4786 )
+)
+
+game (
+	name "Amazing Spider-Man vs. The Kingpin, The (USA)"
+	description "Amazing Spider-Man vs. The Kingpin, The (USA)"
+	rom ( name "Amazing Spider-Man vs. The Kingpin, The (USA).cue" size 1825 crc e9bdce95 md5 cda12eceedc7c6acbcf1499ead3eeeb5 sha1 646a13adf0ece1416399e2809d6442fac23b25cd )
+)
+
+game (
+	name "Annett Futatabi (Japan)"
+	description "Annett Futatabi (Japan)"
+	rom ( name "Annett Futatabi (Japan).cue" size 3663 crc eea216b7 md5 43ec8735ef8402e32f58897d9bd21a61 sha1 ff8f69abc9c504c94ab730d18ab3ccb5bebad4e2 )
+)
+
+game (
+	name "AX-101 (Japan)"
+	description "AX-101 (Japan)"
+	rom ( name "AX-101 (Japan).cue" size 198 crc 6c514d73 md5 1b4d05efd8ec782a3630577631130efe sha1 7c84137a2d805a8d764ca868172ecdd3f753db73 )
+)
+
+game (
+	name "Bari-Arm (Japan)"
+	description "Bari-Arm (Japan)"
+	rom ( name "Bari-Arm (Japan).cue" size 2114 crc b2223278 md5 773765b9b28be827a45b5d0bab7354ff sha1 41a83957cfa88b27159c312295689cffc1ef097a )
+)
+
+game (
+	name "Batman Returns (Europe)"
+	description "Batman Returns (Europe)"
+	rom ( name "Batman Returns (Europe).cue" size 2460 crc 422f5580 md5 5c0c31f12a7797e259745b970c45e880 sha1 1a6344bdf8558c136ddc099a537ee5ce1c14ceff )
+)
+
+game (
+	name "Batman Returns (Europe) (Alt)"
+	description "Batman Returns (Europe) (Alt)"
+	rom ( name "Batman Returns (Europe) (Alt).cue" size 2586 crc c6efd142 md5 1f98c7e7e398177c69b578ead5374a47 sha1 0b697e920833f623e8ea8437b48551f019094f14 )
+)
+
+game (
+	name "Batman Returns (USA)"
+	description "Batman Returns (USA)"
+	rom ( name "Batman Returns (USA).cue" size 2420 crc 5c5d239a md5 c2acb5a8054c65a1874f0bb8d64b6627 sha1 03f590d80c03e79ce86a55b786855aebf14fe138 )
+)
+
+game (
+	name "Battlecorps (Europe) (En,Fr,De,Es)"
+	description "Battlecorps (Europe) (En,Fr,De,Es)"
+	rom ( name "Battlecorps (Europe) (En,Fr,De,Es).cue" size 5328 crc 7ab115a4 md5 c1c42383c39d0862cb9eab81f5910915 sha1 9e913dda412e95ecea767b0004bf7ed22edfcaae )
+)
+
+game (
+	name "Battlecorps (USA)"
+	description "Battlecorps (USA)"
+	rom ( name "Battlecorps (USA).cue" size 5605 crc 828bd519 md5 527ad02023731f154628c0b24a1559ef sha1 fef9e6e79fee814c0b8b95373c695963a487ddaf )
+)
+
+game (
+	name "BC Racers (Europe) (En,Fr,De)"
+	description "BC Racers (Europe) (En,Fr,De)"
+	rom ( name "BC Racers (Europe) (En,Fr,De).cue" size 1566 crc 5f1b8ea4 md5 3cc7024d69b18a2d56c74053fd605bf1 sha1 e0020cf35c1b1985326fe3805d423dae6e6e5430 )
+)
+
+game (
+	name "BC Racers (Europe) (Sample)"
+	description "BC Racers (Europe) (Sample)"
+	rom ( name "BC Racers (Europe) (Sample).cue" size 345 crc fa2ddc91 md5 9d1a69ac742889e0f0d660130dbc137d sha1 97be0a4de402793e580117a162a54c32562297fe )
+)
+
+game (
+	name "Bill Walsh College Football (USA)"
+	description "Bill Walsh College Football (USA)"
+	rom ( name "Bill Walsh College Football (USA).cue" size 1708 crc 8999068f md5 588e48bd18dc1f48e8419bb71ed0f541 sha1 82d4df12b117844be8f18ec72294d01749d0a3d9 )
+)
+
+game (
+	name "Black Hole Assault (Japan)"
+	description "Black Hole Assault (Japan)"
+	rom ( name "Black Hole Assault (Japan).cue" size 2788 crc 4b7449f6 md5 04217c063d15e32fa38c9880ab5129b4 sha1 90753c452bc193b2aff3c79943cd6d73204b82a6 )
+)
+
+game (
+	name "Blackhole Assault (Europe)"
+	description "Blackhole Assault (Europe)"
+	rom ( name "Blackhole Assault (Europe).cue" size 2788 crc d53a6c1e md5 055b4871f6ee418207047a603d679893 sha1 37ae293fd4dceb608ebeec22bcedd53a8ebb1bdb )
+)
+
+game (
+	name "Blackhole Assault (USA)"
+	description "Blackhole Assault (USA)"
+	rom ( name "Blackhole Assault (USA).cue" size 2259 crc c3d6a886 md5 e79d9728b736bbd2a0fc0614d1eb9e93 sha1 b5e11b0fddf9d6d98496cb3f0426a1ada72c4f69 )
+)
+
+game (
+	name "Bloodshot ~ Battle Frenzy (Europe) (En,Fr,De,Es)"
+	description "Bloodshot ~ Battle Frenzy (Europe) (En,Fr,De,Es)"
+	rom ( name "Bloodshot ~ Battle Frenzy (Europe) (En,Fr,De,Es).cue" size 2436 crc 71bf0ddb md5 a37a042f7f8f7fc5d26b9b4146fee91f sha1 d117d505045857cfc74852ed592f92fcd68281c5 )
+)
+
+game (
+	name "Bouncers (USA)"
+	description "Bouncers (USA)"
+	rom ( name "Bouncers (USA).cue" size 954 crc bca37abb md5 1cb86ee3ddcc8999d32bb181d0981098 sha1 5292fcb4cfb13cca0111c7c6c95e2a2e5e8affce )
+)
+
+game (
+	name "Bram Stoker's Dracula (USA)"
+	description "Bram Stoker's Dracula (USA)"
+	rom ( name "Bram Stoker's Dracula (USA).cue" size 852 crc 0b9ec991 md5 6032afb88218caf58a6a2d59f7b75aea sha1 9d08d3691b8cb11e16dc6f6699ebfc1d83bfa8a0 )
+)
+
+game (
+	name "Bram Stoker's Dracula (USA) (Alt)"
+	description "Bram Stoker's Dracula (USA) (Alt)"
+	rom ( name "Bram Stoker's Dracula (USA) (Alt).cue" size 894 crc 8e010fee md5 90110e253ad161dbd8dcab3640bcdc5e sha1 d2b0b1dd51681c94d634b05a2e59dc4ac60798e1 )
+)
+
+game (
+	name "Bram Stoker's Dracula (USA) (Rev A)"
+	description "Bram Stoker's Dracula (USA) (Rev A)"
+	rom ( name "Bram Stoker's Dracula (USA) (Rev A).cue" size 975 crc 219c0525 md5 3dae6cc30ccf1d728dba4d5f8bb8d34c sha1 7d1e1e09394c01629a7f0a04da4cef735ed280ed )
+)
+
+game (
+	name "Brutal - Paws of Fury (USA)"
+	description "Brutal - Paws of Fury (USA)"
+	rom ( name "Brutal - Paws of Fury (USA).cue" size 1835 crc 07d8ed47 md5 7a3c9ee997b46ffd5c62894ba13ac538 sha1 0b55007c8de87ce1b141b5f1ba8dea945ad61833 )
+)
+
+game (
+	name "Burai - Yatsudama no Yuushi Densetsu (Japan)"
+	description "Burai - Yatsudama no Yuushi Densetsu (Japan)"
+	rom ( name "Burai - Yatsudama no Yuushi Densetsu (Japan).cue" size 5843 crc 4383d83c md5 a9b77b866ac369b2e7dae176954dfb90 sha1 4c0ed24401086b214b4f8d07efe235e3d23596d7 )
+)
+
+game (
+	name "Captain Tsubasa (Japan)"
+	description "Captain Tsubasa (Japan)"
+	rom ( name "Captain Tsubasa (Japan).cue" size 356 crc 8afb73a6 md5 d7a35dbae76b0c11fe056bc217a7b42d sha1 960e6380da88ac67bc9e82c36f1614700d8bcd32 )
+)
+
+game (
+	name "Chuck Rock (USA)"
+	description "Chuck Rock (USA)"
+	rom ( name "Chuck Rock (USA).cue" size 1226 crc f11658ee md5 6e52c090a24ab08cedb102e245a472e4 sha1 ad0ec7226674c3fd858bcf65565d94a5367faeff )
+)
+
+game (
+	name "Chuck Rock II - Son of Chuck (USA)"
+	description "Chuck Rock II - Son of Chuck (USA)"
+	rom ( name "Chuck Rock II - Son of Chuck (USA).cue" size 1682 crc 40f47b1f md5 1da9d4b222d32a144928a735bb5c5a22 sha1 84bc3e091ea44a14d9cd4c07f3b9fbfed6f355f3 )
+)
+
+game (
+	name "Cliffhanger (USA)"
+	description "Cliffhanger (USA)"
+	rom ( name "Cliffhanger (USA).cue" size 759 crc 9f971071 md5 3cdc57f3b89d47801d2321621d6f6ba1 sha1 10f512c2b69e35e678ec07fa32a2ce04984bc869 )
+)
+
+game (
+	name "Cobra Command (Europe)"
+	description "Cobra Command (Europe)"
+	rom ( name "Cobra Command (Europe).cue" size 237 crc 43712679 md5 3b65f5ec83b3bb1c0a0316bc694d181e sha1 61c379a29aebdff705b4248d651fd575ca655720 )
+)
+
+game (
+	name "Cobra Command (USA)"
+	description "Cobra Command (USA)"
+	rom ( name "Cobra Command (USA).cue" size 231 crc 8ac87a6d md5 c225834c538f4ceb75fa083a12477146 sha1 f08f75b06316eb30cb59ec547ec835789a6c68ce )
+)
+
+game (
+	name "Compton's Interactive Encyclopedia (USA) (2.01R)"
+	description "Compton's Interactive Encyclopedia (USA) (2.01R)"
+	rom ( name "Compton's Interactive Encyclopedia (USA) (2.01R).cue" size 289 crc 6fc690d9 md5 97a41ab3899c5911900d2bb6d1c95bf0 sha1 679e29f743ab4b02181f5adcfc5d9abf0b432e3d )
+)
+
+game (
+	name "Corpse Killer (Europe)"
+	description "Corpse Killer (Europe)"
+	rom ( name "Corpse Killer (Europe).cue" size 237 crc 0b948d85 md5 21bf9d23aa4b9d76a986b5be083ed798 sha1 095e6bd182ce844443d11243823e0e9b661d1fd1 )
+)
+
+game (
+	name "Corpse Killer (USA) (Sega CD 32X)"
+	description "Corpse Killer (USA) (Sega CD 32X)"
+	rom ( name "Corpse Killer (USA) (Sega CD 32X).cue" size 259 crc f61bcb9b md5 9b3e00abeffd030543c7d3861966b373 sha1 576180d6d93d79a58f8f2e283b092ac1cfd4dcd5 )
+)
+
+game (
+	name "Cosmic Fantasy Stories (Japan)"
+	description "Cosmic Fantasy Stories (Japan)"
+	rom ( name "Cosmic Fantasy Stories (Japan).cue" size 7255 crc fa9f14c3 md5 c05b38c165a9cfd6fee4777defed531c sha1 72d8709f8f5e063c4572a8b33031601261fd89f1 )
+)
+
+game (
+	name "Cyborg 009 (Japan)"
+	description "Cyborg 009 (Japan)"
+	rom ( name "Cyborg 009 (Japan).cue" size 3734 crc c34c51de md5 16a8c4e879730b423c274fda7d86b668 sha1 e74501a2c83e2a6f6c65e09521027f49258a8cd2 )
+)
+
+game (
+	name "Dark Wizard - Yomigaeri Shiyami no Madoushi (Japan)"
+	description "Dark Wizard - Yomigaeri Shiyami no Madoushi (Japan)"
+	rom ( name "Dark Wizard - Yomigaeri Shiyami no Madoushi (Japan).cue" size 1757 crc 7ad6de0f md5 05f2ea87afd11e88b7a1304b5b6d6234 sha1 7ea5166613d0fc0bf4595f5649fa898d61e919da )
+)
+
+game (
+	name "Dark Wizard (USA)"
+	description "Dark Wizard (USA)"
+	rom ( name "Dark Wizard (USA).cue" size 1349 crc 72b3aea2 md5 8cbdbdaeb67957c85cd58fa4fbc6c2d9 sha1 1aa0be1b173edab2df386824042764a98e0da048 )
+)
+
+game (
+	name "Dennin Aleste - Nobunaga and His Ninja Force (Japan)"
+	description "Dennin Aleste - Nobunaga and His Ninja Force (Japan)"
+	rom ( name "Dennin Aleste - Nobunaga and His Ninja Force (Japan).cue" size 3680 crc 0acc1179 md5 fa0abc62a682cd2b831e6b79973949c8 sha1 622089a7abb84e7531d2f9fa8d604b2da2104267 )
+)
+
+game (
+	name "Detonator Orgun (Japan)"
+	description "Detonator Orgun (Japan)"
+	rom ( name "Detonator Orgun (Japan).cue" size 1303 crc 2d55f0ec md5 8d795e1ccc720e0ef1bfa68a95cf5f31 sha1 00402b7e970ea948f382f3063d8b78dfaac44028 )
+)
+
+game (
+	name "Devastator (Japan)"
+	description "Devastator (Japan)"
+	rom ( name "Devastator (Japan).cue" size 1248 crc d562c153 md5 7f884c34585d76afd83f7540afbabc90 sha1 8644896b010724bbabf2ce78ea85207e1955f546 )
+)
+
+game (
+	name "Double Switch (USA)"
+	description "Double Switch (USA)"
+	rom ( name "Double Switch (USA).cue" size 208 crc fcbaefb5 md5 291d15ef04ae68aa93e4809d9dcd68e8 sha1 70d7c2a43bb462b7de00d802e85c99117c8ba28c )
+)
+
+game (
+	name "Dracula Unleashed (Europe) (Disc 1)"
+	description "Dracula Unleashed (Europe) (Disc 1)"
+	rom ( name "Dracula Unleashed (Europe) (Disc 1).cue" size 263 crc aea8bc97 md5 eb08289c737b145baa541d46c9418731 sha1 19df1f56e1791859a07cb1e145bf5f0af93eb558 )
+)
+
+game (
+	name "Dracula Unleashed (Europe) (Disc 2)"
+	description "Dracula Unleashed (Europe) (Disc 2)"
+	rom ( name "Dracula Unleashed (Europe) (Disc 2).cue" size 263 crc e829e9ed md5 d8e1ca73dac403ffaf4fcfd8f8657ca7 sha1 c4e0ee0ce95952eed80efd9302ca1424a301b537 )
+)
+
+game (
+	name "Dracula Unleashed (USA) (Disc 1)"
+	description "Dracula Unleashed (USA) (Disc 1)"
+	rom ( name "Dracula Unleashed (USA) (Disc 1).cue" size 257 crc 93ade26e md5 fa725eb12ee7eb683144986261c33bf1 sha1 fdb6ad28c7fc21f99e35684502bcd32dfc1abb1b )
+)
+
+game (
+	name "Dracula Unleashed (USA) (Disc 2)"
+	description "Dracula Unleashed (USA) (Disc 2)"
+	rom ( name "Dracula Unleashed (USA) (Disc 2).cue" size 234 crc c464d858 md5 dc484097b4c2f2f0536f8f22f3a54c2b sha1 b9d2dbf101195dcaacacd3049e3aebe397cdd5be )
+)
+
+game (
+	name "Dragon's Lair (Japan) (En,Ja,Fr,De,It)"
+	description "Dragon's Lair (Japan) (En,Ja,Fr,De,It)"
+	rom ( name "Dragon's Lair (Japan) (En,Ja,Fr,De,It).cue" size 246 crc 1191378b md5 673bed048ecddf2cedb6665e1de54d9b sha1 6af9577d3b3b967eb3dbef9bfbfde75d1af469d7 )
+)
+
+game (
+	name "Dragon's Lair (USA)"
+	description "Dragon's Lair (USA)"
+	rom ( name "Dragon's Lair (USA).cue" size 231 crc 345db17e md5 fc6912bc8cf6467d73954340d0b6a637 sha1 213486ddcac93e45c1dbd8c38d28ffef980215c7 )
+)
+
+game (
+	name "Dune (Europe) (En,Fr,De,Es,It,Ar)"
+	description "Dune (Europe) (En,Fr,De,Es,It,Ar)"
+	rom ( name "Dune (Europe) (En,Fr,De,Es,It,Ar).cue" size 236 crc a71c7827 md5 758c8c70aa621bd121fb8b35773fb943 sha1 cd26bd9c637f3fe7d99ec34446ea88b7c2d144b2 )
+)
+
+game (
+	name "Dungeon Explorer (USA)"
+	description "Dungeon Explorer (USA)"
+	rom ( name "Dungeon Explorer (USA).cue" size 1503 crc 7a681bba md5 93b8fbc288447e4be4b93dcbb2ed1b4a sha1 9cc6e6ee394496295eb111ca3118a5d24e18ba8a )
+)
+
+game (
+	name "Dungeon Master II - Skullkeep (Japan)"
+	description "Dungeon Master II - Skullkeep (Japan)"
+	rom ( name "Dungeon Master II - Skullkeep (Japan).cue" size 922 crc dece9515 md5 165ea3c97ed241032c2f19aad27a2fa3 sha1 16681c06c2eef557ff0a619835f9e331bae11177 )
+)
+
+game (
+	name "Dynamic Country Club (Japan)"
+	description "Dynamic Country Club (Japan)"
+	rom ( name "Dynamic Country Club (Japan).cue" size 1581 crc 82b9b757 md5 5ceb6ace02b1cbe514f6d5a349d0690d sha1 e95e5f5a3b4773f1acafaec80d6cdb586a51b043 )
+)
+
+game (
+	name "Earnest Evans (Japan)"
+	description "Earnest Evans (Japan)"
+	rom ( name "Earnest Evans (Japan).cue" size 2905 crc 6916b850 md5 df52d967a8fea2d1ad802f3c5fca3625 sha1 7df815bfe309c2654afb8a9f893a633a7f5d7366 )
+)
+
+game (
+	name "Earthworm Jim - Special Edition (Europe)"
+	description "Earthworm Jim - Special Edition (Europe)"
+	rom ( name "Earthworm Jim - Special Edition (Europe).cue" size 3164 crc 78f01d05 md5 d5317ec07e0961f62a551abc3915d443 sha1 719036c542ee78ee1641eef3ee16aa1aba773132 )
+)
+
+game (
+	name "Ecco - The Tides of Time (Europe) (En,Fr,De,Es)"
+	description "Ecco - The Tides of Time (Europe) (En,Fr,De,Es)"
+	rom ( name "Ecco - The Tides of Time (Europe) (En,Fr,De,Es).cue" size 2051 crc 6ea9acac md5 32698cf98afa024d09d5bb47fa37348d sha1 c33333fd8df44e792dc6ff1f0ed47136d90861a9 )
+)
+
+game (
+	name "Ecco - The Tides of Time (USA)"
+	description "Ecco - The Tides of Time (USA)"
+	rom ( name "Ecco - The Tides of Time (USA).cue" size 2130 crc 280bf750 md5 a988766b2d4d78e3ee8d80d3c0f9a7fe sha1 d7448766bfe751aa52d39c03237ead1e72696e5d )
+)
+
+game (
+	name "Ecco - The Tides of Time (USA) (Alt)"
+	description "Ecco - The Tides of Time (USA) (Alt)"
+	rom ( name "Ecco - The Tides of Time (USA) (Alt).cue" size 2209 crc 9ffd72b6 md5 be562dc7f326ef941c31e772aa00a825 sha1 4610a679661687ce7aad555c9048a00b66cca41c )
+)
+
+game (
+	name "Ecco the Dolphin (Europe)"
+	description "Ecco the Dolphin (Europe)"
+	rom ( name "Ecco the Dolphin (Europe).cue" size 1580 crc 45008939 md5 8701f9b6e61b310979d11e76551b2b6a sha1 7cda6a1b516be739be20a503e0c8c844ab3bc168 )
+)
+
+game (
+	name "Ecco the Dolphin (USA)"
+	description "Ecco the Dolphin (USA)"
+	rom ( name "Ecco the Dolphin (USA).cue" size 1877 crc 232e5a4f md5 9bd5a5330304531ab0a388d0b1e735fc sha1 a7304e95b50b0713a729213d2473c39e082629a1 )
+)
+
+game (
+	name "Ecco The Dolphin CD (Japan) (Disc 1) (Ecco The Dolphin)"
+	description "Ecco The Dolphin CD (Japan) (Disc 1) (Ecco The Dolphin)"
+	rom ( name "Ecco The Dolphin CD (Japan) (Disc 1) (Ecco The Dolphin).cue" size 2382 crc 63d1de2f md5 c6ec05d5453ee82f1c289c0ceb7c4f8b sha1 05696608d9fc0b5c7b15f2254f0d0834415a129f )
+)
+
+game (
+	name "Ecco The Dolphin CD (Japan) (Disc 2) (Ecco The Dolphin II)"
+	description "Ecco The Dolphin CD (Japan) (Disc 2) (Ecco The Dolphin II)"
+	rom ( name "Ecco The Dolphin CD (Japan) (Disc 2) (Ecco The Dolphin II).cue" size 2583 crc 8a085006 md5 b8d250293ed81cd9eb08dcfcbe563c5c sha1 efa8b3586b74c19aaeab617883510708e441392c )
+)
+
+game (
+	name "Egawa Suguru no Super League CD (Japan)"
+	description "Egawa Suguru no Super League CD (Japan)"
+	rom ( name "Egawa Suguru no Super League CD (Japan).cue" size 4695 crc 11b03e97 md5 8c654f6090846ede158faeb03d1e257d sha1 242576ce496723b7b0909db2d6d529d404c80ecd )
+)
+
+game (
+	name "ESPN Baseball Tonight (Europe)"
+	description "ESPN Baseball Tonight (Europe)"
+	rom ( name "ESPN Baseball Tonight (Europe).cue" size 230 crc cb0a080b md5 55cff58f828ffcdd1affe45e796a6521 sha1 bb6c4ac179f27c8beddb8c5f88485504c1abc8ef )
+)
+
+game (
+	name "ESPN Baseball Tonight (USA)"
+	description "ESPN Baseball Tonight (USA)"
+	rom ( name "ESPN Baseball Tonight (USA).cue" size 224 crc 7897b2c8 md5 bb68bbb8ca066e6f15add65859221557 sha1 89ed9d43b0aa42e3265f77516aec92b089ed0616 )
+)
+
+game (
+	name "ESPN Sunday Night NFL (USA)"
+	description "ESPN Sunday Night NFL (USA)"
+	rom ( name "ESPN Sunday Night NFL (USA).cue" size 224 crc d1fe54ab md5 6115bf958437e3a1e9828878b6532308 sha1 4fe91657c85b8104f430a1469a54bc69280b0949 )
+)
+
+game (
+	name "Eternal Champions - Challenge from the Dark Side (USA)"
+	description "Eternal Champions - Challenge from the Dark Side (USA)"
+	rom ( name "Eternal Champions - Challenge from the Dark Side (USA).cue" size 2813 crc c12d13d7 md5 d8a9fe616536100480acb6db7d6eecdf sha1 1ceaaf13103bec71b5a4d7bd069584b6c0528024 )
+)
+
+game (
+	name "Eternal Champions - Challenge from the Dark Side (USA) (RE)"
+	description "Eternal Champions - Challenge from the Dark Side (USA) (RE)"
+	rom ( name "Eternal Champions - Challenge from the Dark Side (USA) (RE).cue" size 2931 crc c9279545 md5 bad0ff27158810a9b22d5ddeef28b172 sha1 58140771e4544b19bd29e8c979640272593df22f )
+)
+
+game (
+	name "Eye of the Beholder (Japan)"
+	description "Eye of the Beholder (Japan)"
+	rom ( name "Eye of the Beholder (Japan).cue" size 6837 crc 67fa521e md5 18c399e30fd6a554312f32642cd6a7f5 sha1 3762218baf5e5fd3cac2a30d2ef7488517fc4d2e )
+)
+
+game (
+	name "Eye of the Beholder (USA)"
+	description "Eye of the Beholder (USA)"
+	rom ( name "Eye of the Beholder (USA).cue" size 6702 crc 4c545624 md5 f5d15d77b39cdef246063c21eaf9a23f sha1 ed3ae15a3ca73bf4ff996414c92e8e201cb1ba85 )
+)
+
+game (
+	name "F1 Circus CD (Japan)"
+	description "F1 Circus CD (Japan)"
+	rom ( name "F1 Circus CD (Japan).cue" size 3317 crc dc3116ca md5 a7601bd976d474bfa1f2aad32e85fba7 sha1 1629dd8dc76a1c693a2dea6b53023637eb3e06c8 )
+)
+
+game (
+	name "Fahrenheit (Europe)"
+	description "Fahrenheit (Europe)"
+	rom ( name "Fahrenheit (Europe).cue" size 208 crc 35111e19 md5 ea5f2e3bbf31eae80d72ea6b2fb9d07a sha1 c8cea1ee37f027be4655967de846234748eab580 )
+)
+
+game (
+	name "Fahrenheit (USA) (Disc 1) (Key Disc) (Sega CD)"
+	description "Fahrenheit (USA) (Disc 1) (Key Disc) (Sega CD)"
+	rom ( name "Fahrenheit (USA) (Disc 1) (Key Disc) (Sega CD).cue" size 262 crc 8982108b md5 0b0a464fd029c7df830ad19ed1bfe099 sha1 825a83edb4966e0d9beaafc2d94233a2a0bc30f0 )
+)
+
+game (
+	name "Fahrenheit (USA) (Disc 2) (Insert Key Disc 1 First) (32X CD)"
+	description "Fahrenheit (USA) (Disc 2) (Insert Key Disc 1 First) (32X CD)"
+	rom ( name "Fahrenheit (USA) (Disc 2) (Insert Key Disc 1 First) (32X CD).cue" size 290 crc 544debe8 md5 eee26c821c392a079d188951ef6a2ca5 sha1 76e2e5d3b1e78ba4c2e9d663655ff4a1455e5bd2 )
+)
+
+game (
+	name "FIFA International Soccer (USA)"
+	description "FIFA International Soccer (USA)"
+	rom ( name "FIFA International Soccer (USA).cue" size 5755 crc bf8a281e md5 7859520ce8ae3116c0826f644dd39ea8 sha1 d31d832f1c8aaa65701688384409d7d0616eece6 )
+)
+
+game (
+	name "Final Fight CD (Europe)"
+	description "Final Fight CD (Europe)"
+	rom ( name "Final Fight CD (Europe).cue" size 3050 crc 771d2e80 md5 1c02e40e5a787fd0c7991f7a4daa47c8 sha1 978a6f4432f8a62d04d50eeeb0e037a03bd8de02 )
+)
+
+game (
+	name "Final Fight CD (Japan)"
+	description "Final Fight CD (Japan)"
+	rom ( name "Final Fight CD (Japan).cue" size 3375 crc 68256ab8 md5 b565c89cd43372b4d4423fa8175c89bf sha1 7e4824c1bff11f38e86104fed175f7f9ee634a8c )
+)
+
+game (
+	name "Final Fight CD (Japan) (Rev A)"
+	description "Final Fight CD (Japan) (Rev A)"
+	rom ( name "Final Fight CD (Japan) (Rev A).cue" size 3630 crc dda5dfe9 md5 bb4dee153c500ea1a685e372bb97249b sha1 39bc760195b2cd630db5d40ccb66842190a83306 )
+)
+
+game (
+	name "Final Fight CD (USA)"
+	description "Final Fight CD (USA)"
+	rom ( name "Final Fight CD (USA).cue" size 2995 crc 76c97d18 md5 73d80b38253553f6ed91b02eae2056f9 sha1 9f334d5ed30c7da79c90e617f491b562dc61bc46 )
+)
+
+game (
+	name "Formula One World Championship - Beyond the Limit (USA)"
+	description "Formula One World Championship - Beyond the Limit (USA)"
+	rom ( name "Formula One World Championship - Beyond the Limit (USA).cue" size 5532 crc 6d432c22 md5 b2d646317424a3565d0c4885e537bbef sha1 f95e57462255586077cac8af8a2a5b5002f9542c )
+)
+
+game (
+	name "Game no Kandume Vol. 1 (Japan)"
+	description "Game no Kandume Vol. 1 (Japan)"
+	rom ( name "Game no Kandume Vol. 1 (Japan).cue" size 3857 crc 3f895846 md5 55cc56cb2ef56a928cbbef88adc07e82 sha1 d99cf7772e981dc88f3a208bbbc17a3721163b6d )
+)
+
+game (
+	name "Game no Kandume Vol. 2 (Japan)"
+	description "Game no Kandume Vol. 2 (Japan)"
+	rom ( name "Game no Kandume Vol. 2 (Japan).cue" size 2982 crc ebc4cb69 md5 d9c42477e5f4ccb1e67c67b01f0353e8 sha1 8ae0a646d2f24306e135d81cc08f9d6c4de6ebf2 )
+)
+
+game (
+	name "Garou Densetsu Special (Japan)"
+	description "Garou Densetsu Special (Japan)"
+	rom ( name "Garou Densetsu Special (Japan).cue" size 4732 crc a1d75963 md5 d7538642bd08d1867cafa1ed0e2c3215 sha1 02b23c90fbc4237fe9d923c6ac1528b72dc2fdb9 )
+)
+
+game (
+	name "Genei Toshi - Illusion City (Japan)"
+	description "Genei Toshi - Illusion City (Japan)"
+	rom ( name "Genei Toshi - Illusion City (Japan).cue" size 1305 crc f1f84c87 md5 24909ffc90ce674ab3e670fb07c6a5fa sha1 3da8310a72fe7f367a833c74e2a943efadc1bcc7 )
+)
+
+game (
+	name "Ground Zero Texas (Europe) (Disc 1)"
+	description "Ground Zero Texas (Europe) (Disc 1)"
+	rom ( name "Ground Zero Texas (Europe) (Disc 1).cue" size 240 crc 2743534d md5 bdc38914981d9c2b84c59da76028f451 sha1 f05765338ce5f5e85431a81078630e885e34017c )
+)
+
+game (
+	name "Ground Zero Texas (Europe) (Disc 2)"
+	description "Ground Zero Texas (Europe) (Disc 2)"
+	rom ( name "Ground Zero Texas (Europe) (Disc 2).cue" size 240 crc 61c20637 md5 24e2379a013f8ab61d3c55fea74ecae5 sha1 19921f7377c81b4224c4118619eae56f705216fa )
+)
+
+game (
+	name "Ground Zero Texas (USA) (Disc 1)"
+	description "Ground Zero Texas (USA) (Disc 1)"
+	rom ( name "Ground Zero Texas (USA) (Disc 1).cue" size 257 crc d0c584c7 md5 113dd7490af1f86d08f70448d443ed93 sha1 2041c4c954bb0b19ede6dbef1190836c9f2c72b7 )
+)
+
+game (
+	name "Ground Zero Texas (USA) (Disc 2)"
+	description "Ground Zero Texas (USA) (Disc 2)"
+	rom ( name "Ground Zero Texas (USA) (Disc 2).cue" size 257 crc 67c4ee28 md5 cd2402ce5cf06aed8bebd05837185fe2 sha1 055ff36efb360b9189542402e06da4181640d687 )
+)
+
+game (
+	name "Gyuwambler Jiko Chuushinha 2 - Gekitou! Tokyo Mahjongland Hen (Japan)"
+	description "Gyuwambler Jiko Chuushinha 2 - Gekitou! Tokyo Mahjongland Hen (Japan)"
+	rom ( name "Gyuwambler Jiko Chuushinha 2 - Gekitou! Tokyo Mahjongland Hen (Japan).cue" size 8205 crc 02c2968f md5 d0f53e8bb6625fd08bb3591236039a5b sha1 fee916305fbe46c2288e1af8b715e887716c96d0 )
+)
+
+game (
+	name "Heart of the Alien - Out of This World Parts I and II (USA) (RE)"
+	description "Heart of the Alien - Out of This World Parts I and II (USA) (RE)"
+	rom ( name "Heart of the Alien - Out of This World Parts I and II (USA) (RE).cue" size 6683 crc 6df21d8c md5 9e96595d417c0ea7e72bb3b0872b0a34 sha1 5fc104d96437f8897d118833040021631a1c819c )
+)
+
+game (
+	name "Heavenly Symphony - Formula One World Championship 1993 (Japan)"
+	description "Heavenly Symphony - Formula One World Championship 1993 (Japan)"
+	rom ( name "Heavenly Symphony - Formula One World Championship 1993 (Japan).cue" size 5851 crc f7c96302 md5 b07fd67469be940157b2bb2ebb270429 sha1 1571549fb7bf4895d0432b6692577a0accbfe2b0 )
+)
+
+game (
+	name "Heavy Nova (Japan)"
+	description "Heavy Nova (Japan)"
+	rom ( name "Heavy Nova (Japan).cue" size 1813 crc 82207b4b md5 7fa8aed9f492139c19fd00c056d8040e sha1 feedbebe14b394471b41b6c5e8cf523094d99973 )
+)
+
+game (
+	name "Heimdall (Japan)"
+	description "Heimdall (Japan)"
+	rom ( name "Heimdall (Japan).cue" size 2646 crc d5465570 md5 a8b94534f93643794301ebaf47e2a01f sha1 db9250a1d24932b7d0ee37a3c220118ef77ec6e9 )
+)
+
+game (
+	name "Heimdall (USA)"
+	description "Heimdall (USA)"
+	rom ( name "Heimdall (USA).cue" size 2294 crc d9024819 md5 efe0f4d6da5b56c260bf6af3b1ccf174 sha1 66e858090085673dbfdea26d06dd354504b2296d )
+)
+
+game (
+	name "Hook (USA)"
+	description "Hook (USA)"
+	rom ( name "Hook (USA).cue" size 2315 crc ba07f18d md5 04df168eace6dcf1753b049f6e0d2a47 sha1 a56f37f5255523b507f4b183bdb5371cbd194cd8 )
+)
+
+game (
+	name "Iron Helix (USA)"
+	description "Iron Helix (USA)"
+	rom ( name "Iron Helix (USA).cue" size 225 crc f96206fe md5 40c27ae2fd92bbe5af54778eea789170 sha1 f72bd0f63a225618437597c97298c6cd485cc4bb )
+)
+
+game (
+	name "Jaguar XJ220 (Europe) (En,Ja)"
+	description "Jaguar XJ220 (Europe) (En,Ja)"
+	rom ( name "Jaguar XJ220 (Europe) (En,Ja).cue" size 1617 crc bf12258d md5 307d6051f6295009352a399b122af467 sha1 7096de1cc8956a6695e162c52bf6093be13598bc )
+)
+
+game (
+	name "Jaguar XJ220 (Japan) (En,Ja)"
+	description "Jaguar XJ220 (Japan) (En,Ja)"
+	rom ( name "Jaguar XJ220 (Japan) (En,Ja).cue" size 1604 crc 4016d26f md5 cd5c169c94f67a692930458d670ec4b6 sha1 390e72ff691bd038a369bfa09f1ef0ae0dfdbf7d )
+)
+
+game (
+	name "Jangou World Cup (Japan)"
+	description "Jangou World Cup (Japan)"
+	rom ( name "Jangou World Cup (Japan).cue" size 2005 crc b53cdd58 md5 524807532c053927e80ce348801bb22d sha1 6de5f6c3b18bc57bea75d5fb5f4e3d9c9ee9be82 )
+)
+
+game (
+	name "Jeopardy! (USA)"
+	description "Jeopardy! (USA)"
+	rom ( name "Jeopardy! (USA).cue" size 309 crc 6c28da39 md5 43ccd1f797fb9d76824fcec13693f90d sha1 d6cac996cac2f558349818e901dfbd38731d6156 )
+)
+
+game (
+	name "Joe Montana's NFL Football (USA)"
+	description "Joe Montana's NFL Football (USA)"
+	rom ( name "Joe Montana's NFL Football (USA).cue" size 761 crc 981e4777 md5 2bc3110fe8d93c90d4b1d4b9e40e222e sha1 d9d0a8b6315ffc543cf59b0449010f66d19b6be0 )
+)
+
+game (
+	name "Jurassic Park (Europe)"
+	description "Jurassic Park (Europe)"
+	rom ( name "Jurassic Park (Europe).cue" size 3726 crc a5fdb459 md5 5496d8aa934a468637ec9b4bbf65f452 sha1 2002560826e77f032918fdfff69aaa536816f2d5 )
+)
+
+game (
+	name "Jurassic Park (USA) (RE)"
+	description "Jurassic Park (USA) (RE)"
+	rom ( name "Jurassic Park (USA) (RE).cue" size 3813 crc 4f6937aa md5 ef4d8c68f82f0d84cfcff1994d0781ba sha1 4a3ae1f58d930c55510809f98a815941f24dfb79 )
+)
+
+game (
+	name "Kamen Rider ZO (Japan)"
+	description "Kamen Rider ZO (Japan)"
+	rom ( name "Kamen Rider ZO (Japan).cue" size 585 crc 780c5c99 md5 d1f098e1781cad6b08f4983cb4d6fc71 sha1 215d1646403df5bcd4a3f94193d880ac3ce1b083 )
+)
+
+game (
+	name "Keiou Yuugekitai (Japan)"
+	description "Keiou Yuugekitai (Japan)"
+	rom ( name "Keiou Yuugekitai (Japan).cue" size 2957 crc e1a6760b md5 c217cd015c05d9e8816f7395072b28ae sha1 090f772ee8781de7735f77b8b4bc19a60875c186 )
+)
+
+game (
+	name "Kids on Site (USA)"
+	description "Kids on Site (USA)"
+	rom ( name "Kids on Site (USA).cue" size 229 crc 9d823eca md5 724647094a1d79ed14e3a74585194169 sha1 07902cd2dc2b021484d69e3c8235825818bfeaef )
+)
+
+game (
+	name "Lethal Enforcers (Japan)"
+	description "Lethal Enforcers (Japan)"
+	rom ( name "Lethal Enforcers (Japan).cue" size 2742 crc 7f3e7b5c md5 ddba63d6614e44525e2cf1a6f7ed81db sha1 a6940116f8c4044060f1c4c33948d845afd8293b )
+)
+
+game (
+	name "Lethal Enforcers (USA) (U11)"
+	description "Lethal Enforcers (USA) (U11)"
+	rom ( name "Lethal Enforcers (USA) (U11).cue" size 2834 crc 999db635 md5 caa49b88d537e12e21017e6d6597f8ad sha1 cb26a7f204b2e6b2fa7d7b5c9120e7da6c6041af )
+)
+
+game (
+	name "Lethal Enforcers (USA) (U12)"
+	description "Lethal Enforcers (USA) (U12)"
+	rom ( name "Lethal Enforcers (USA) (U12).cue" size 2811 crc dcc52475 md5 c492454ec35d0cbf0fa50f84e25aad8e sha1 f87d1195088fd80df3058e6300a1f0ca57b14f88 )
+)
+
+game (
+	name "Lethal Enforcers II - Gun Fighters (Europe)"
+	description "Lethal Enforcers II - Gun Fighters (Europe)"
+	rom ( name "Lethal Enforcers II - Gun Fighters (Europe).cue" size 3156 crc 7d74c5ce md5 aaa502531ae344d93d005177dca78ab2 sha1 58379dd640cbd97f436184a865c9340e5349592c )
+)
+
+game (
+	name "Lethal Enforcers II - Gun Fighters (USA)"
+	description "Lethal Enforcers II - Gun Fighters (USA)"
+	rom ( name "Lethal Enforcers II - Gun Fighters (USA).cue" size 3087 crc 9b8fce6d md5 d89875f4fc90228b467b5dda0fbf8418 sha1 e3905d6ff2c3e14bf565f79b76b5d08aa1278dfb )
+)
+
+game (
+	name "Loadstar - The Legend of Tully Bodine (USA)"
+	description "Loadstar - The Legend of Tully Bodine (USA)"
+	rom ( name "Loadstar - The Legend of Tully Bodine (USA).cue" size 279 crc 0799fdc0 md5 85efd60a9defe291a6d0546e6a76b772 sha1 16527805b0a853f542765632d5a387c20dd8e894 )
+)
+
+game (
+	name "Lords of Thunder (USA)"
+	description "Lords of Thunder (USA)"
+	rom ( name "Lords of Thunder (USA).cue" size 2462 crc fa2e14b7 md5 b671665459694ea092d0300f27060952 sha1 e5dc85ec465196a5c430fd764366781c2b27c9a6 )
+)
+
+game (
+	name "Lunar - Eternal Blue (Japan)"
+	description "Lunar - Eternal Blue (Japan)"
+	rom ( name "Lunar - Eternal Blue (Japan).cue" size 493 crc d081bc4d md5 e6eaac02ed26fad2795c1c95db8e242f sha1 1634cb9b96832560b402d154c7d3da4a24eb69d6 )
+)
+
+game (
+	name "Lunar - Eternal Blue (Japan) (Rev A)"
+	description "Lunar - Eternal Blue (Japan) (Rev A)"
+	rom ( name "Lunar - Eternal Blue (Japan) (Rev A).cue" size 525 crc ed80908f md5 62017276ee2f3d6b59ab1c0f2681f5e5 sha1 4166d4347206292616f90738e80c5097a04d9325 )
+)
+
+game (
+	name "Lunar - Eternal Blue (USA)"
+	description "Lunar - Eternal Blue (USA)"
+	rom ( name "Lunar - Eternal Blue (USA).cue" size 365 crc bea3dfdd md5 b55c0aeb6952b9895b5da8c3c31cb8c0 sha1 85c8e51c788d0c4686ab36248c928c7cf1091277 )
+)
+
+game (
+	name "Lunar - The Silver Star (Japan)"
+	description "Lunar - The Silver Star (Japan)"
+	rom ( name "Lunar - The Silver Star (Japan).cue" size 6557 crc 0b826907 md5 2789d51c6badf3bd91b9291c545f910d sha1 4ec6559b4a0d68c5b787d9ca57ec242636b05899 )
+)
+
+game (
+	name "Lunar - The Silver Star (USA) (RE)"
+	description "Lunar - The Silver Star (USA) (RE)"
+	rom ( name "Lunar - The Silver Star (USA) (RE).cue" size 6713 crc 13944ed8 md5 f19d754d46cc7ab027eca06cec16ebe4 sha1 7c276859aa1415eeb06532bba2784539c80de185 )
+)
+
+game (
+	name "Mad Dog McCree (USA)"
+	description "Mad Dog McCree (USA)"
+	rom ( name "Mad Dog McCree (USA).cue" size 803 crc 4251b074 md5 e51a141b968be4d4cd6e7a4f19142826 sha1 c7c3b770b43b05c28758165a47514bef1daf0da0 )
+)
+
+game (
+	name "Mansion of Hidden Souls (USA)"
+	description "Mansion of Hidden Souls (USA)"
+	rom ( name "Mansion of Hidden Souls (USA).cue" size 251 crc 4a02627d md5 2ccf56d8598133d732b2691a76bb8ab2 sha1 ede5614d1016ccca056656fbc126f0353fad3309 )
+)
+
+game (
+	name "Mary Shelley's Frankenstein (USA)"
+	description "Mary Shelley's Frankenstein (USA)"
+	rom ( name "Mary Shelley's Frankenstein (USA).cue" size 871 crc de4adb8b md5 7f32eff6e832ab9696f67ba998835b96 sha1 b66c91b19bd4400bf8365dc6915498a802347162 )
+)
+
+game (
+	name "Mega Schwarzschild (Japan)"
+	description "Mega Schwarzschild (Japan)"
+	rom ( name "Mega Schwarzschild (Japan).cue" size 2062 crc b32ce22b md5 c1785a3cd4b9cfe75e3ba79e912444cd sha1 28284ccbf2d9851ee1c7b3c1a4c2eb8a8049d3f5 )
+)
+
+game (
+	name "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA)"
+	description "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA)"
+	rom ( name "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA).cue" size 4322 crc a34680c2 md5 0d2e9732f43ca0d04a317d51cc6766b0 sha1 807141e5041ed93b1aedf41ad159140a9382fa34 )
+)
+
+game (
+	name "Mickey Mania (Europe)"
+	description "Mickey Mania (Europe)"
+	rom ( name "Mickey Mania (Europe).cue" size 3230 crc 27e28c06 md5 d3c9ae0c7c0ae8c5853ae09ea77fb586 sha1 d5ace84de82a38edc09e0b9ca50a4e10c324d555 )
+)
+
+game (
+	name "Microcosm (Japan)"
+	description "Microcosm (Japan)"
+	rom ( name "Microcosm (Japan).cue" size 1004 crc bbbee764 md5 4203e2952bbd4d2da813a1d7a5ab4e3a sha1 80f2d3ccc6986d5073f6de5884ec4ceb88765a69 )
+)
+
+game (
+	name "Microcosm (USA)"
+	description "Microcosm (USA)"
+	rom ( name "Microcosm (USA).cue" size 963 crc c644650c md5 2764d48ed61ff4eee8b53c5447ce8625 sha1 5f0e537a31d7dc8aa67eaba0c72bb81ecf24e5d8 )
+)
+
+game (
+	name "Midnight Raiders (USA)"
+	description "Midnight Raiders (USA)"
+	rom ( name "Midnight Raiders (USA).cue" size 237 crc 3f58e4bc md5 d58b5a21c07b8d50e901a2ea110fa922 sha1 d54075fbee45dcf9f6330eecee99d766b5a0177f )
+)
+
+game (
+	name "Might and Magic III - Isles of Terra (Japan)"
+	description "Might and Magic III - Isles of Terra (Japan)"
+	rom ( name "Might and Magic III - Isles of Terra (Japan).cue" size 6399 crc 7f43026b md5 7f32fdba435bf460459f2997c3158fbb sha1 d6a5575e9497298605ddf7c73d792b906a301380 )
+)
+
+game (
+	name "Mighty Morphin Power Rangers (USA)"
+	description "Mighty Morphin Power Rangers (USA)"
+	rom ( name "Mighty Morphin Power Rangers (USA).cue" size 261 crc bd9ee789 md5 99b64ed4df709f6c01076333c506bc6b sha1 87262cbc791ef6018748ac2b654c5f56b50f59e6 )
+)
+
+game (
+	name "Mortal Kombat (Europe)"
+	description "Mortal Kombat (Europe)"
+	rom ( name "Mortal Kombat (Europe).cue" size 2002 crc c1c7dd5f md5 4f1983022d44d209f82a0f200a31cb0c sha1 817fb0865e32a722dab4615546d9436f592188ba )
+)
+
+game (
+	name "Mortal Kombat (USA)"
+	description "Mortal Kombat (USA)"
+	rom ( name "Mortal Kombat (USA).cue" size 2376 crc 4e47aa2c md5 96bf1a9061c27317920b9beffa9c0418 sha1 c5ed1880d4b61dde2acc06cca19bb275af5dbcea )
+)
+
+game (
+	name "Mortal Kombat Kanzenban (Japan)"
+	description "Mortal Kombat Kanzenban (Japan)"
+	rom ( name "Mortal Kombat Kanzenban (Japan).cue" size 2628 crc 96d17354 md5 862efdecc0c1c0e4b6de72e18831ac3b sha1 fb2e06dd3ee1e2fb99493ec59d2b9f0838b9d3b8 )
+)
+
+game (
+	name "NBA Jam (Europe)"
+	description "NBA Jam (Europe)"
+	rom ( name "NBA Jam (Europe).cue" size 972 crc 15ddb4c3 md5 e6d5f514abf7c7392360c5a7a73e8378 sha1 4b8c5eb199c14c25cbf02d59d8a0dddb52f1bc70 )
+)
+
+game (
+	name "NBA Jam (USA)"
+	description "NBA Jam (USA)"
+	rom ( name "NBA Jam (USA).cue" size 945 crc cdf4a699 md5 1fa5a7e3006f864b36486c1d07b6f1bf sha1 fbfd6e5bf180965155e37a85d099378210a6a4a4 )
+)
+
+game (
+	name "NFL's Greatest - San Francisco vs. Dallas 1978-1993 (USA)"
+	description "NFL's Greatest - San Francisco vs. Dallas 1978-1993 (USA)"
+	rom ( name "NFL's Greatest - San Francisco vs. Dallas 1978-1993 (USA).cue" size 284 crc 82157b37 md5 4c28fa7316b818fbd24364ad31fec18e sha1 754f14d3c7261f7f09f0bdf0f91ba4ca1bf70004 )
+)
+
+game (
+	name "NHL '94 (USA)"
+	description "NHL '94 (USA)"
+	rom ( name "NHL '94 (USA).cue" size 8537 crc 8359c30e md5 fb01ac81824003355f93cb0773e2a940 sha1 18da2ae1ba35b3404a58b207b1a632c82c94ef5a )
+)
+
+game (
+	name "Night Striker (Japan, Korea)"
+	description "Night Striker (Japan, Korea)"
+	rom ( name "Night Striker (Japan, Korea).cue" size 4825 crc 3c2fb94c md5 659aa871af0761faa49a9c9ce821d74a sha1 fda1cf6b1a5295947183e5a64a9995b0a1683d44 )
+)
+
+game (
+	name "Night Trap (Europe) (Disc 1)"
+	description "Night Trap (Europe) (Disc 1)"
+	rom ( name "Night Trap (Europe) (Disc 1).cue" size 226 crc 0377a0b6 md5 df5c4f55a734b7c9590e99c70d1a7f0d sha1 b921cbbb7cbf1e74f46563aac42723806ba3dd98 )
+)
+
+game (
+	name "Night Trap (Europe) (Disc 2)"
+	description "Night Trap (Europe) (Disc 2)"
+	rom ( name "Night Trap (Europe) (Disc 2).cue" size 226 crc f4cde93a md5 bf2ba99cf5abf19a00ae80f42382c163 sha1 449271679f1fba890a5cce7efc1ffab7a7de09ec )
+)
+
+game (
+	name "Night Trap (Japan) (Disc 1)"
+	description "Night Trap (Japan) (Disc 1)"
+	rom ( name "Night Trap (Japan) (Disc 1).cue" size 224 crc f3527896 md5 00e50cc53351bd0f4c7cd04119b79878 sha1 fa0dbd8786f591a2df3b60b13bde124b21c582fe )
+)
+
+game (
+	name "Night Trap (Japan) (Disc 2)"
+	description "Night Trap (Japan) (Disc 2)"
+	rom ( name "Night Trap (Japan) (Disc 2).cue" size 224 crc 7970405a md5 dc7f21e237e845c690383c39e0519f69 sha1 80d564f614f76902465cb3e361425bc03b47c6cf )
+)
+
+game (
+	name "Night Trap (USA) (Disc 1)"
+	description "Night Trap (USA) (Disc 1)"
+	rom ( name "Night Trap (USA) (Disc 1).cue" size 91 crc b5fae72b md5 ffa171a71a90baf0a6cc6a6717c9209d sha1 ca092e38457e7fc1b11e90ab0cd6c93627c3de9b )
+)
+
+game (
+	name "Night Trap (USA) (Disc 1) (Alt)"
+	description "Night Trap (USA) (Disc 1) (Alt)"
+	rom ( name "Night Trap (USA) (Disc 1) (Alt).cue" size 97 crc f2950016 md5 c9261a74b06972b2e1fbf7addc5fb5a0 sha1 2456d059254e74ebaf8b8f17fc665222fa47c323 )
+)
+
+game (
+	name "Night Trap (USA) (Disc 1) (Sega CD 32X)"
+	description "Night Trap (USA) (Disc 1) (Sega CD 32X)"
+	rom ( name "Night Trap (USA) (Disc 1) (Sega CD 32X).cue" size 271 crc a4637eab md5 52d961b81fc6d37cf776075d7ab3dd85 sha1 717f4c6f48d891fb8b74fb205d582a9cdc8c464c )
+)
+
+game (
+	name "Night Trap (USA) (Disc 2)"
+	description "Night Trap (USA) (Disc 2)"
+	rom ( name "Night Trap (USA) (Disc 2).cue" size 114 crc 6bf8d43b md5 59258dbc6176050aecea81d1d920c0e6 sha1 43295d218e1b3fc1f388b3b58fae0856a08d54b5 )
+)
+
+game (
+	name "Night Trap (USA) (Disc 2) (Sega CD 32X)"
+	description "Night Trap (USA) (Disc 2) (Sega CD 32X)"
+	rom ( name "Night Trap (USA) (Disc 2) (Sega CD 32X).cue" size 271 crc 5fceea3d md5 7b0c832bf34fd50f939c8b3823a5b7ab sha1 365d09b40df5a6d58b6edbac06aa8e21acce37fd )
+)
+
+game (
+	name "Nostalgia 1907 (Japan)"
+	description "Nostalgia 1907 (Japan)"
+	rom ( name "Nostalgia 1907 (Japan).cue" size 237 crc 5034c420 md5 0f16dc342989a6729975fe72d68ac498 sha1 f0707c9124ec7343b244a6b466ca4527b5ebc51b )
+)
+
+game (
+	name "Pier Solar and the Great Architects Enhanced Soundtrack Disc (USA)"
+	description "Pier Solar and the Great Architects Enhanced Soundtrack Disc (USA)"
+	rom ( name "Pier Solar and the Great Architects Enhanced Soundtrack Disc (USA).cue" size 622 crc 6d317fa8 md5 f0e03431664704058746f511e21c0958 sha1 ef30161fe9b6737346530bd74644996b3dc58041 )
+)
+
+game (
+	name "Pitfall - The Mayan Adventure (Europe)"
+	description "Pitfall - The Mayan Adventure (Europe)"
+	rom ( name "Pitfall - The Mayan Adventure (Europe).cue" size 1151 crc 888eace4 md5 e58532a1cad5f325f028ae21092a9906 sha1 c4bcc5248b5a8ac364bde45df8c79723b77f4f05 )
+)
+
+game (
+	name "Pitfall - The Mayan Adventure (USA)"
+	description "Pitfall - The Mayan Adventure (USA)"
+	rom ( name "Pitfall - The Mayan Adventure (USA).cue" size 2995 crc 650fa631 md5 4661a6a824d19ec0cb1d60a07c13a55f sha1 b2f26cb7412669aaddb8e6b15941250cd3b15bd9 )
+)
+
+game (
+	name "Popful Mail (Japan)"
+	description "Popful Mail (Japan)"
+	rom ( name "Popful Mail (Japan).cue" size 321 crc 76e15750 md5 3f3c04f195c269c16e0a86dde36249fc sha1 b93d3f6723493fa8aa3448fa71d7673561fe516d )
+)
+
+game (
+	name "Popful Mail (USA)"
+	description "Popful Mail (USA)"
+	rom ( name "Popful Mail (USA).cue" size 449 crc 2414276b md5 f324f3bf93e3ff4b0dba22d22ec262ab sha1 26a42b82895a203bbb79dff6567492e05e0d18a7 )
+)
+
+game (
+	name "Prince of Persia (Europe)"
+	description "Prince of Persia (Europe)"
+	rom ( name "Prince of Persia (Europe).cue" size 2982 crc 973d4c21 md5 9e115ddc742332a7b252ae44989532ba sha1 be793d741def0f7f39e05a955eddfce7acdf9c37 )
+)
+
+game (
+	name "Prince of Persia (Japan)"
+	description "Prince of Persia (Japan)"
+	rom ( name "Prince of Persia (Japan).cue" size 2980 crc 1d03649a md5 1cb28a723908cd98a076f572fba3e82a sha1 089e1f13c72f20d0e911af2147cb85690b298045 )
+)
+
+game (
+	name "Prince of Persia (USA)"
+	description "Prince of Persia (USA)"
+	rom ( name "Prince of Persia (USA).cue" size 2930 crc e0a8ba4d md5 e2e318720feab6ea25aec8d782e59985 sha1 a9ef705c0a2bfb73dff30a783d8e0e0e66f877f4 )
+)
+
+game (
+	name "Prize Fighter (Japan) (Disc 1)"
+	description "Prize Fighter (Japan) (Disc 1)"
+	rom ( name "Prize Fighter (Japan) (Disc 1).cue" size 230 crc 14907451 md5 6cdf88f9f3e7da2866a519ee80e10775 sha1 74b0225ea8ae3e61704cea25333c6afed97a0d52 )
+)
+
+game (
+	name "Prize Fighter (Japan) (Disc 2)"
+	description "Prize Fighter (Japan) (Disc 2)"
+	rom ( name "Prize Fighter (Japan) (Disc 2).cue" size 230 crc 42f0970b md5 bee2403e0d4cb9549e924c12b75a663b sha1 0fec6bdcf7ffc59973b2059d28876bd27a49e2b0 )
+)
+
+game (
+	name "Prize Fighter (USA) (Disc 1)"
+	description "Prize Fighter (USA) (Disc 1)"
+	rom ( name "Prize Fighter (USA) (Disc 1).cue" size 226 crc 008693c6 md5 5d9afab480f10aff98863b7bb6e35eb2 sha1 88788d86717177eca87075169ee40d0fdc683286 )
+)
+
+game (
+	name "Pro Yakyuu Super League CD (Japan)"
+	description "Pro Yakyuu Super League CD (Japan)"
+	rom ( name "Pro Yakyuu Super League CD (Japan).cue" size 2972 crc 23d25357 md5 694a0f7c74b16b49aef26461ebc0bfc2 sha1 ea4ead8c5968da610caebb0f45477f49240b7a57 )
+)
+
+game (
+	name "Puggsy (USA)"
+	description "Puggsy (USA)"
+	rom ( name "Puggsy (USA).cue" size 2359 crc 0b5e33c1 md5 d74e7279652848abd18202f153a14e66 sha1 0ec47637d9d12852cd1528302f27facf098c5268 )
+)
+
+game (
+	name "Quiz Scramble Special (Japan) (Rev B)"
+	description "Quiz Scramble Special (Japan) (Rev B)"
+	rom ( name "Quiz Scramble Special (Japan) (Rev B).cue" size 5417 crc ce82b7e7 md5 0e438a275477cbfa79ab33b47d54c8a5 sha1 a7e40d96cd5b421eef39bd8ae6cf12fa622ccd14 )
+)
+
+game (
+	name "Quiz Tonosama no Yabou (Japan)"
+	description "Quiz Tonosama no Yabou (Japan)"
+	rom ( name "Quiz Tonosama no Yabou (Japan).cue" size 253 crc b109fb8f md5 89b250ca92e42cd23d05eda4fa184420 sha1 e01cfbfd09313219172b0d454c4b7d20b8aa8d3a )
+)
+
+game (
+	name "Racing Aces (USA)"
+	description "Racing Aces (USA)"
+	rom ( name "Racing Aces (USA).cue" size 1214 crc 84e9bb9b md5 293ece452f4a2585f5dd28ece1607d37 sha1 cbdc9e1e27d8965b905e1de79b0f14790fba9b99 )
+)
+
+game (
+	name "Ranma 1-2 - Byakuranaika (Japan)"
+	description "Ranma 1-2 - Byakuranaika (Japan)"
+	rom ( name "Ranma 1-2 - Byakuranaika (Japan).cue" size 3180 crc 719e00d5 md5 4a636b78fb6db17c97e4d074a23bd812 sha1 4e09cb87a331adcfd1359ad64104bbebad4d68d1 )
+)
+
+game (
+	name "RDF - Global Conflict (USA)"
+	description "RDF - Global Conflict (USA)"
+	rom ( name "RDF - Global Conflict (USA).cue" size 852 crc 29c93c89 md5 66072c384f42e3a2d08458dfa51d0f13 sha1 0ff3b55ddaf143adf19b72e007481bec8b555dd8 )
+)
+
+game (
+	name "Record of Lodoss War (Japan)"
+	description "Record of Lodoss War (Japan)"
+	rom ( name "Record of Lodoss War (Japan).cue" size 1727 crc 16329bfe md5 efb718776e3ea5e2a68a63f68a3bfba9 sha1 603048794be0d5a16ea6a603ea6985a2c488aba7 )
+)
+
+game (
+	name "Revenge of the Ninja (USA)"
+	description "Revenge of the Ninja (USA)"
+	rom ( name "Revenge of the Ninja (USA).cue" size 605 crc d0164406 md5 6246e90340569515b3b551726aa2caa4 sha1 a54072c20d5b464f1a8d9ad6c274970fbfba1c9e )
+)
+
+game (
+	name "Rise of the Dragon - A Blade Hunter Mystery (Japan)"
+	description "Rise of the Dragon - A Blade Hunter Mystery (Japan)"
+	rom ( name "Rise of the Dragon - A Blade Hunter Mystery (Japan).cue" size 730 crc 77fd088d md5 61f089aff48fc7cd22681fed5832fc3c sha1 db0329d30c2980f93fb4caf57385150b22663bdb )
+)
+
+game (
+	name "Rise of the Dragon (USA)"
+	description "Rise of the Dragon (USA)"
+	rom ( name "Rise of the Dragon (USA).cue" size 595 crc 52b3bf17 md5 1f04d1799a3c8ded606dbd635fcc5ab5 sha1 3c241ceefc31754d411b682b7b397494fae7f059 )
+)
+
+game (
+	name "Rise of the Dragon (USA) (RE)"
+	description "Rise of the Dragon (USA) (RE)"
+	rom ( name "Rise of the Dragon (USA) (RE).cue" size 620 crc f289a675 md5 78d57e4bb001ef3bd09a2cd59a106888 sha1 7e72b3671ff8870ce6e77a1de416f6a892e04f25 )
+)
+
+game (
+	name "Road Avenger (Europe)"
+	description "Road Avenger (Europe)"
+	rom ( name "Road Avenger (Europe).cue" size 465 crc cffb5de2 md5 53750e9142f8de77cbe02ce2af779792 sha1 eaa07c98bde6876a3879a3b2be0317ae81251b13 )
+)
+
+game (
+	name "Road Avenger (USA)"
+	description "Road Avenger (USA)"
+	rom ( name "Road Avenger (USA).cue" size 453 crc 9e7d5e08 md5 840ebb398cce8d27cf3a5d253d8b575d sha1 cd2b55540b911786886f43aae99e228d9f85efc5 )
+)
+
+game (
+	name "Robo Aleste (Europe)"
+	description "Robo Aleste (Europe)"
+	rom ( name "Robo Aleste (Europe).cue" size 1960 crc c079e5a1 md5 a9a8f1de5cd3c4f47a99d93a1fcfc0f0 sha1 9d105b82cf85f272cf24f3f33d61ed20c1368209 )
+)
+
+game (
+	name "Sangokushi III (Japan)"
+	description "Sangokushi III (Japan)"
+	rom ( name "Sangokushi III (Japan).cue" size 5855 crc 4bd0bf86 md5 f10c7b6ea697c2e7092c169f1f671705 sha1 66e75f948be301a3c4be2f8dba6a9fba00414ae4 )
+)
+
+game (
+	name "Secret of Monkey Island, The (Japan)"
+	description "Secret of Monkey Island, The (Japan)"
+	rom ( name "Secret of Monkey Island, The (Japan).cue" size 3542 crc 952183eb md5 a8cdf8c28ffdc1b0932f3db88d6250f0 sha1 835e3bf7c532c9f8a042feee3bf872257c0a544e )
+)
+
+game (
+	name "Secret of Monkey Island, The (USA)"
+	description "Secret of Monkey Island, The (USA)"
+	rom ( name "Secret of Monkey Island, The (USA).cue" size 3488 crc 04a1e02f md5 027ccf6397d96b6d9a5b7b33adcaa9fc sha1 2c14e74a3fca8214008621434a530d861268307c )
+)
+
+game (
+	name "Sega Classic Arcade Collection - Limited Edition (Japan)"
+	description "Sega Classic Arcade Collection - Limited Edition (Japan)"
+	rom ( name "Sega Classic Arcade Collection - Limited Edition (Japan).cue" size 1817 crc 3a1d8ad1 md5 8c68a3df771ceb33ba8edf3b0bc4001c sha1 46833c4dcda26e7898916dfe761879338805014d )
+)
+
+game (
+	name "Sega Classics Arcade Collection - Limited Edition (Europe)"
+	description "Sega Classics Arcade Collection - Limited Edition (Europe)"
+	rom ( name "Sega Classics Arcade Collection - Limited Edition (Europe).cue" size 1818 crc 902047fd md5 e4c32e7467ac08633879b46f54dc97fd sha1 72535419c5ff210acedab0f8a9733e6c9ec85b47 )
+)
+
+game (
+	name "Sega Classics Arcade Collection (USA) (5-in-1)"
+	description "Sega Classics Arcade Collection (USA) (5-in-1)"
+	rom ( name "Sega Classics Arcade Collection (USA) (5-in-1).cue" size 1674 crc cddb46f5 md5 354f5361fd5125cc2a194698d66e1aad sha1 16e4b4129038ae845da9c10a98edbe0668cd5266 )
+)
+
+game (
+	name "Sega Classics Arcade Collection (USA) (RE) (4-in-1)"
+	description "Sega Classics Arcade Collection (USA) (RE) (4-in-1)"
+	rom ( name "Sega Classics Arcade Collection (USA) (RE) (4-in-1).cue" size 1757 crc e8f8a601 md5 ad2f339bd1053b415d2aa77977523926 sha1 f2df03f67c2a6af397ca1856f2f472509a2ac5d8 )
+)
+
+game (
+	name "Seima Densetsu 3x3 Eyes (Japan, Korea)"
+	description "Seima Densetsu 3x3 Eyes (Japan, Korea)"
+	rom ( name "Seima Densetsu 3x3 Eyes (Japan, Korea).cue" size 6256 crc 90bf9598 md5 38edd2ddd5b91e29d72945fdd9bf7aad sha1 4e78e685314007218970e0113c82e23ccd630302 )
+)
+
+game (
+	name "Seirei Shinseiki - Fhey Area (Japan)"
+	description "Seirei Shinseiki - Fhey Area (Japan)"
+	rom ( name "Seirei Shinseiki - Fhey Area (Japan).cue" size 11140 crc 3beff0dc md5 8b72c232b789d1631e61547d2f10a1cf sha1 f71249a1f78c0ab01a17dddd4509efef02c3dd97 )
+)
+
+game (
+	name "Sensible Soccer (Europe) (Demo)"
+	description "Sensible Soccer (Europe) (Demo)"
+	rom ( name "Sensible Soccer (Europe) (Demo).cue" size 9939 crc 7b088108 md5 70c7965d952ded290e3e9c9da7c9a7a7 sha1 351fb905b4334160e7f24229db3419c1bea667d6 )
+)
+
+game (
+	name "Sewer Shark (Europe)"
+	description "Sewer Shark (Europe)"
+	rom ( name "Sewer Shark (Europe).cue" size 210 crc c41da738 md5 8391963d25d91ada013e89c3328ae9bc sha1 05c673d8452828fe02a61d2f8cc83390571b8eeb )
+)
+
+game (
+	name "Sewer Shark (USA)"
+	description "Sewer Shark (USA)"
+	rom ( name "Sewer Shark (USA).cue" size 83 crc 1db0c2a0 md5 d952dfe13456fd6800109e173b4b8657 sha1 e306c648550a6903078abb9a8da66cc8764cde60 )
+)
+
+game (
+	name "Sewer Shark (USA) (Rev A)"
+	description "Sewer Shark (USA) (Rev A)"
+	rom ( name "Sewer Shark (USA) (Rev A).cue" size 91 crc e59af91d md5 bd5e5ebbfa9bea5df129fa3664b34a0b sha1 f243fb01bf84ec90ed0c5ab7935fe8214a0cb51f )
+)
+
+game (
+	name "Sewer Shark (USA) (Rev B)"
+	description "Sewer Shark (USA) (Rev B)"
+	rom ( name "Sewer Shark (USA) (Rev B).cue" size 220 crc 1e9feed1 md5 dbd7e31d113d6d271be4efa3ba5cdaaa sha1 0675f61b5f82b9f097677d32c7d5d6dbfd4fcfb5 )
+)
+
+game (
+	name "Sewer Shark (USA) (Rev B) (Alt 1)"
+	description "Sewer Shark (USA) (Rev B) (Alt 1)"
+	rom ( name "Sewer Shark (USA) (Rev B) (Alt 1).cue" size 259 crc 2e7eb382 md5 b48b4d62a9654af9f2a7881147cc0c68 sha1 e4f116197617758c52d8cb74deae1d82c9ba13c0 )
+)
+
+game (
+	name "Sewer Shark (USA) (Rev B) (Alt 2)"
+	description "Sewer Shark (USA) (Rev B) (Alt 2)"
+	rom ( name "Sewer Shark (USA) (Rev B) (Alt 2).cue" size 259 crc 7b9ea82e md5 438fa37c99d184491ae32cf3dd925a05 sha1 e4d22527f59cc2c4432e63bc63c174807d5e2c12 )
+)
+
+game (
+	name "Shadow of the Beast II - Juushin no Jubaku (Japan)"
+	description "Shadow of the Beast II - Juushin no Jubaku (Japan)"
+	rom ( name "Shadow of the Beast II - Juushin no Jubaku (Japan).cue" size 2035 crc ae3b3ca9 md5 09803e7db7dff92454af588883cfe1ab sha1 c91ca1a0b2255feecc05aea14e0b615dace51cac )
+)
+
+game (
+	name "Shadow of the Beast II (Europe)"
+	description "Shadow of the Beast II (Europe)"
+	rom ( name "Shadow of the Beast II (Europe).cue" size 1895 crc ec506677 md5 076727f6edf476f6de17a0241100d271 sha1 9aeffbcc1d918d112f83ab3e86d7a5b8a263e838 )
+)
+
+game (
+	name "Shadowrun (Japan)"
+	description "Shadowrun (Japan)"
+	rom ( name "Shadowrun (Japan).cue" size 315 crc f1c278f4 md5 b0ffebb8d298f61c5c9e056c6f6bcd66 sha1 2997117bf5f27af8494ec99397d98fb5a2c109ec )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective (USA)"
+	description "Sherlock Holmes - Consulting Detective (USA)"
+	rom ( name "Sherlock Holmes - Consulting Detective (USA).cue" size 281 crc 5c2bcbff md5 9504970bad61ba73e2b27b99a2965cff sha1 34ceaafb35b61e4b1b7ca7db60fec5ccaf76569e )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective Vol. I (Europe)"
+	description "Sherlock Holmes - Consulting Detective Vol. I (Europe)"
+	rom ( name "Sherlock Holmes - Consulting Detective Vol. I (Europe).cue" size 120 crc 0e54ae48 md5 102e79e5831b8bdef1989e483ccdbfec sha1 155c11efd218c8c4f94ed211a211da3b9b41d6fa )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 1)"
+	description "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 1)"
+	rom ( name "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 1).cue" size 315 crc e1d8ae76 md5 ca56f7e35a09e9cc0b8e6b441eb6ec30 sha1 8d6e34e22d07b9fbbbd0ec5145be1e32a7d51a58 )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 2)"
+	description "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 2)"
+	rom ( name "Sherlock Holmes - Consulting Detective Vol. II (USA) (Disc 2).cue" size 292 crc 674422a7 md5 0c19ba83a56e773527e452cf2ee4b492 sha1 dba9ae3fa5d776626bc5393b393c0d648aa02415 )
+)
+
+game (
+	name "Shin Megami Tensei (Japan)"
+	description "Shin Megami Tensei (Japan)"
+	rom ( name "Shin Megami Tensei (Japan).cue" size 3491 crc 8b795266 md5 7b1d54674c4181cb791cc7ae0263c419 sha1 4dcf8cd00a4bbef60d06ce29604a5ebb8419ad8f )
+)
+
+game (
+	name "Shining Force CD (Japan)"
+	description "Shining Force CD (Japan)"
+	rom ( name "Shining Force CD (Japan).cue" size 4170 crc 2a717918 md5 6f398e1c94c956dadcecd600ddea726b sha1 ee387d013016d894f1b61d2d00462b2d8a619a18 )
+)
+
+game (
+	name "Shining Force CD (USA)"
+	description "Shining Force CD (USA)"
+	rom ( name "Shining Force CD (USA).cue" size 4054 crc ede67263 md5 c03ab568a171a27b41040ed64d0c53ce sha1 eb1fc704754691e6ce559c3162003f69b4eda959 )
+)
+
+game (
+	name "Shining Force CD (USA) (Alt)"
+	description "Shining Force CD (USA) (Alt)"
+	rom ( name "Shining Force CD (USA) (Alt).cue" size 4310 crc dea9a2a7 md5 1f424ea3d0a81c56de5d3ed478b0c7a4 sha1 caf86625f79f5eaaef658e259d706a33059f4592 )
+)
+
+game (
+	name "Silpheed (Europe)"
+	description "Silpheed (Europe)"
+	rom ( name "Silpheed (Europe).cue" size 870 crc e8000097 md5 7a691842fcddf9cbf40860fd3834db20 sha1 df6fb8fa4fcf0252a5d5a75b6085b5ef8b79ea37 )
+)
+
+game (
+	name "Silpheed (Japan)"
+	description "Silpheed (Japan)"
+	rom ( name "Silpheed (Japan).cue" size 885 crc 919e959c md5 bfa7987b32c4d2683fe6aa37df7f1169 sha1 565f0060bd29d7487e4d75ee66492b68a967b7b5 )
+)
+
+game (
+	name "Silpheed (USA)"
+	description "Silpheed (USA)"
+	rom ( name "Silpheed (USA).cue" size 869 crc cf49bdcb md5 175ed28a29f9091dcb6d582b97103431 sha1 acbdc673a2a430b879cda9e91978061fea79662a )
+)
+
+game (
+	name "Slam City with Scottie Pippen (Europe) (Disc 1)"
+	description "Slam City with Scottie Pippen (Europe) (Disc 1)"
+	rom ( name "Slam City with Scottie Pippen (Europe) (Disc 1).cue" size 264 crc 0b845292 md5 6d02c25193f903f5ab983e8ed3441393 sha1 841e73f0965dfab566c7d61a4f173f8c269e093b )
+)
+
+game (
+	name "Slam City with Scottie Pippen (Europe) (Disc 2)"
+	description "Slam City with Scottie Pippen (Europe) (Disc 2)"
+	rom ( name "Slam City with Scottie Pippen (Europe) (Disc 2).cue" size 264 crc 966f2185 md5 e9c14ea30676ecbfe89c14066d6a72c0 sha1 7103037e0665e906b9007ad51a1cc59fd0dbda29 )
+)
+
+game (
+	name "Slam City with Scottie Pippen (USA) (Disc 1) (Fingers)"
+	description "Slam City with Scottie Pippen (USA) (Disc 1) (Fingers)"
+	rom ( name "Slam City with Scottie Pippen (USA) (Disc 1) (Fingers).cue" size 301 crc 3f50c8bc md5 35ca36913af0a3df72cf8c3492eceec1 sha1 e3511c717bb78966f75e0dd4a2190b5d390faefe )
+)
+
+game (
+	name "Slam City with Scottie Pippen (USA) (Disc 2) (Juice)"
+	description "Slam City with Scottie Pippen (USA) (Disc 2) (Juice)"
+	rom ( name "Slam City with Scottie Pippen (USA) (Disc 2) (Juice).cue" size 297 crc 75d2a63d md5 6d0113ae09701a38d2ec399652594514 sha1 b5c6f12707a969292565fcf80e01ed615ef800ed )
+)
+
+game (
+	name "Slam City with Scottie Pippen (USA) (Disc 3) (Mad Dog)"
+	description "Slam City with Scottie Pippen (USA) (Disc 3) (Mad Dog)"
+	rom ( name "Slam City with Scottie Pippen (USA) (Disc 3) (Mad Dog).cue" size 301 crc c701cd59 md5 883fb65ee2ecf7ac26861ff93cbf0ce1 sha1 de1d961f1bbdaf46f197d6ffa9fc1de245453327 )
+)
+
+game (
+	name "Slam City with Scottie Pippen (USA) (Disc 4) (Smash)"
+	description "Slam City with Scottie Pippen (USA) (Disc 4) (Smash)"
+	rom ( name "Slam City with Scottie Pippen (USA) (Disc 4) (Smash).cue" size 297 crc 7c9f6cc5 md5 bdfe12aec4a8ddcbb3d98f0c2d11f8cc sha1 3eb3d1f45cd765957c564e75726a16af6e98c272 )
+)
+
+game (
+	name "Smurfs, The (Europe) (En,Fr,De,Es,It)"
+	description "Smurfs, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Smurfs, The (Europe) (En,Fr,De,Es,It).cue" size 2754 crc feff73f0 md5 f1823b1dd0779d20d424482b6339fe3c sha1 942ff0686e4f400b6532c57cad1b02af994b7ae9 )
+)
+
+game (
+	name "Snatcher (USA)"
+	description "Snatcher (USA)"
+	rom ( name "Snatcher (USA).cue" size 2271 crc 13845fdf md5 fe305d5467811e10fee501bc9135efb5 sha1 c6bdafb2bdb8b2558c8104549cbfdd9ef9a1817f )
+)
+
+game (
+	name "Software Toolworks' Star Wars Chess, The (USA)"
+	description "Software Toolworks' Star Wars Chess, The (USA)"
+	rom ( name "Software Toolworks' Star Wars Chess, The (USA).cue" size 262 crc eddd396f md5 2c12f949441867e21c6dccb35b89358b sha1 035cdc6ea08fa0a16cb356faea54951c8bcc6131 )
+)
+
+game (
+	name "Sol-Feace (Europe)"
+	description "Sol-Feace (Europe)"
+	rom ( name "Sol-Feace (Europe).cue" size 2016 crc daa7de5d md5 d8f152a971f2d875754c206a458cfb6e sha1 95eedf2ef26ddf1d65af128952c59b0b035e9c9f )
+)
+
+game (
+	name "Sol-Feace (Europe) (R1)"
+	description "Sol-Feace (Europe) (R1)"
+	rom ( name "Sol-Feace (Europe) (R1).cue" size 2106 crc 87833560 md5 5d428c54541f95a874f13db690276b90 sha1 1b34ac631e16c46f3b720f1a79d8109d90489cb3 )
+)
+
+game (
+	name "Sol-Feace (Japan)"
+	description "Sol-Feace (Japan)"
+	rom ( name "Sol-Feace (Japan).cue" size 2469 crc 14290399 md5 3147f45c2884f80537f04aea4a1eb8e2 sha1 ad068514ada2504ecdb2a9a8bf300add33fd034f )
+)
+
+game (
+	name "Sol-Feace (USA) (RE2)"
+	description "Sol-Feace (USA) (RE2)"
+	rom ( name "Sol-Feace (USA) (RE2).cue" size 2093 crc c5a409c6 md5 ffdcd949f1487eab3d8f4c8ce67da61e sha1 db492dbb3499a4d617cc1c706d6c9c4400d51565 )
+)
+
+game (
+	name "Sonic CD (Europe)"
+	description "Sonic CD (Europe)"
+	rom ( name "Sonic CD (Europe).cue" size 3902 crc e19b0360 md5 35885a77b7c5c6a4f4b60908b75f06e8 sha1 7efff2fc0a359d94d94cdce8470b14ff42a2ce59 )
+)
+
+game (
+	name "Sonic CD (USA)"
+	description "Sonic CD (USA)"
+	rom ( name "Sonic CD (USA).cue" size 3820 crc 33b99240 md5 638f1e41830319de1914772076096626 sha1 5b085f78a6904d275715dcfeb454ecc262e704e5 )
+)
+
+game (
+	name "Sonic CD (USA) (RE125)"
+	description "Sonic CD (USA) (RE125)"
+	rom ( name "Sonic CD (USA) (RE125).cue" size 4100 crc e8a15187 md5 92d0c52b29c25b21e8d0bef3e3086115 sha1 ff275b2a8bf5c301fed311addca55aee8a1a13ab )
+)
+
+game (
+	name "Sonic CD (USA) (RE125) (Alt)"
+	description "Sonic CD (USA) (RE125) (Alt)"
+	rom ( name "Sonic CD (USA) (RE125) (Alt).cue" size 4310 crc 53948c76 md5 ac75d9b8331ba59da608c49e5cc03cb7 sha1 4d190b6a7cc7e2284f7c16f6afaf94ff625dfb8c )
+)
+
+game (
+	name "Sonic The Hedgehog CD (Japan)"
+	description "Sonic The Hedgehog CD (Japan)"
+	rom ( name "Sonic The Hedgehog CD (Japan).cue" size 4345 crc 8cb933b6 md5 a254b036947c26edb3c7c5692c299c1a sha1 24f0906eb7c7ccc5a2b05ee888c2ba14d9c1ec9a )
+)
+
+game (
+	name "SoulStar (Europe)"
+	description "SoulStar (Europe)"
+	rom ( name "SoulStar (Europe).cue" size 403 crc cb919722 md5 b69be453e3c3fa3873ef380d04993c5a sha1 efef345788642b58830d6db58930dc9c2fce16bb )
+)
+
+game (
+	name "SoulStar (Europe) (En,Fr,De)"
+	description "SoulStar (Europe) (En,Fr,De)"
+	rom ( name "SoulStar (Europe) (En,Fr,De).cue" size 1728 crc f61747a2 md5 447786ee8413487675750dfdc8587434 sha1 ff24045d30620596c5555dc2fc2bd74a3f78909f )
+)
+
+game (
+	name "SoulStar (USA)"
+	description "SoulStar (USA)"
+	rom ( name "SoulStar (USA).cue" size 1858 crc abd6f11a md5 60a9cd1064fe684a48237b0e7d82db33 sha1 7a48145bf6bb4196decb79afaef4898e4d730397 )
+)
+
+game (
+	name "Space Ace (USA)"
+	description "Space Ace (USA)"
+	rom ( name "Space Ace (USA).cue" size 200 crc 2d1fa0f5 md5 ae880100bad12052e2f241802e522a11 sha1 675ef3486253a90e1c61f593c212f61947b05774 )
+)
+
+game (
+	name "Space Adventure, The - Cobra - The Legendary Bandit (Europe)"
+	description "Space Adventure, The - Cobra - The Legendary Bandit (Europe)"
+	rom ( name "Space Adventure, The - Cobra - The Legendary Bandit (Europe).cue" size 683 crc 8e777dbe md5 6ccdb4a6892735a9cb3bfc5d49dd5e61 sha1 c7691ef19f825a8b10cdd6ab35707b4c7d7262c4 )
+)
+
+game (
+	name "Star Wars - Rebel Assault (Europe)"
+	description "Star Wars - Rebel Assault (Europe)"
+	rom ( name "Star Wars - Rebel Assault (Europe).cue" size 238 crc 6f455677 md5 5d30caecffacd8de9c0317e587d11caf sha1 70e62b52926b4774f721433fa748c27ea270d107 )
+)
+
+game (
+	name "Star Wars - Rebel Assault (Japan)"
+	description "Star Wars - Rebel Assault (Japan)"
+	rom ( name "Star Wars - Rebel Assault (Japan).cue" size 259 crc 62ab3f80 md5 59e49b9d9240d68ca4765fcad1ee4998 sha1 0fc0e6de33e02fc82c9e235ba4adc76bcd677edd )
+)
+
+game (
+	name "Star Wars - Rebel Assault (USA)"
+	description "Star Wars - Rebel Assault (USA)"
+	rom ( name "Star Wars - Rebel Assault (USA).cue" size 255 crc 607886c6 md5 e4294711cffda13dadee08ea73bc3dfe sha1 c7ebd28eceaf9325d572ff5b8629f656483d7138 )
+)
+
+game (
+	name "Starblade (Japan)"
+	description "Starblade (Japan)"
+	rom ( name "Starblade (Japan).cue" size 227 crc b06f20bd md5 6ecd04495fb2d32d379d4ed3a913e567 sha1 1a296dde2ff82d01bf8646bce7bd699c7f889af3 )
+)
+
+game (
+	name "Starblade (USA)"
+	description "Starblade (USA)"
+	rom ( name "Starblade (USA).cue" size 200 crc ae85834b md5 6e22cb519a92dc0289585f54232eac12 sha1 0c9d7e4f642284204db77a345f928e41b0531065 )
+)
+
+game (
+	name "Stellar-Fire (USA)"
+	description "Stellar-Fire (USA)"
+	rom ( name "Stellar-Fire (USA).cue" size 2378 crc dcd7cf9a md5 0cf2f7cf7ce5e2d258a28ddd97218135 sha1 4c6cdd003bfc92ab6d843785511298dc1389b662 )
+)
+
+game (
+	name "Surgical Strike (USA)"
+	description "Surgical Strike (USA)"
+	rom ( name "Surgical Strike (USA).cue" size 327 crc 5e7052c3 md5 63920b1c6a7b3917286e7a241312aa8e sha1 015f1b4b5ae51d66fc1560d9dfd20000af2f2215 )
+)
+
+game (
+	name "Switch (Japan)"
+	description "Switch (Japan)"
+	rom ( name "Switch (Japan).cue" size 5019 crc 24f07b4f md5 1c832f5b1c097561ed1df05aa39a39ed sha1 af9da4375f51152df7a04a2d1b7a2681f3e47f46 )
+)
+
+game (
+	name "Tenbu Mega CD Special (Japan)"
+	description "Tenbu Mega CD Special (Japan)"
+	rom ( name "Tenbu Mega CD Special (Japan).cue" size 1112 crc 425a1bb0 md5 fafba4d55831e17292784562d57a4b3d sha1 99396c8003488e5aaf6fa43ed46ab91d6f2fee6b )
+)
+
+game (
+	name "Tenkafubu - Eiyuutachi no Houkou (Japan)"
+	description "Tenkafubu - Eiyuutachi no Houkou (Japan)"
+	rom ( name "Tenkafubu - Eiyuutachi no Houkou (Japan).cue" size 2570 crc e88322f8 md5 50bc19d581b562b0b5af895f7ae80687 sha1 1d6d230b497b87dc182225ac513ced728eb2d93d )
+)
+
+game (
+	name "Terminator, The (Europe)"
+	description "Terminator, The (Europe)"
+	rom ( name "Terminator, The (Europe).cue" size 1195 crc 3d42f120 md5 3c76b0296a559993db5dbedc95498673 sha1 65781577c76c64830efbfa1e36fb4b9df3001b4d )
+)
+
+game (
+	name "Terminator, The (USA)"
+	description "Terminator, The (USA)"
+	rom ( name "Terminator, The (USA).cue" size 1165 crc 5f9f4e4b md5 68a66526821f2ca794cc1f8a4e489dcc sha1 0523868e28061d3d02ec488ed1b37b8bc0c4ff92 )
+)
+
+game (
+	name "Thunder Storm FX (Japan)"
+	description "Thunder Storm FX (Japan)"
+	rom ( name "Thunder Storm FX (Japan).cue" size 241 crc 80e087fc md5 5d4f920c0e09bf19b3dfd9ae1750daee sha1 e25d045a41f7883486c1f62f6bc331a15d0bb881 )
+)
+
+game (
+	name "Thunderhawk (Europe) (En,Fr,De,Es)"
+	description "Thunderhawk (Europe) (En,Fr,De,Es)"
+	rom ( name "Thunderhawk (Europe) (En,Fr,De,Es).cue" size 1553 crc 89c0159b md5 243a76f8c2542d16ae1674292bc73ec8 sha1 aeb1ede2b2673f95e3d84d0985a1cc8a80b252f9 )
+)
+
+game (
+	name "Thunderhawk (Japan)"
+	description "Thunderhawk (Japan)"
+	rom ( name "Thunderhawk (Japan).cue" size 1236 crc f4ae0600 md5 f978f70d83f40509315fcf5643204164 sha1 dd00d09b1be56c86baee89799b6ff747764481aa )
+)
+
+game (
+	name "Time Gal (Europe)"
+	description "Time Gal (Europe)"
+	rom ( name "Time Gal (Europe).cue" size 204 crc 70dba7fd md5 823a227c8e0f448511f1f3ee39541f65 sha1 7a8400d1c85a524dca665bfa0f46412e761fc1c7 )
+)
+
+game (
+	name "Time Gal (Japan)"
+	description "Time Gal (Japan)"
+	rom ( name "Time Gal (Japan).cue" size 202 crc a50da29e md5 e4e0d8624d52bdaae35caeef7e06d83e sha1 c5f080dd05a0254926a9c4f61178d5348341611d )
+)
+
+game (
+	name "Time Gal (USA)"
+	description "Time Gal (USA)"
+	rom ( name "Time Gal (USA).cue" size 221 crc 014bd3e0 md5 27a44c1344def701bfbc9b08b7b6ee7c sha1 a5d0045c36ba17ee1e31b8eb58c39ec0886f0c2d )
+)
+
+game (
+	name "Tomcat Alley (Europe)"
+	description "Tomcat Alley (Europe)"
+	rom ( name "Tomcat Alley (Europe).cue" size 212 crc ba3e5b0f md5 aebaca9cfc58ce9525c95091a0415086 sha1 9939eb7e2bf693775aed0f9e838dbe954b30e2d2 )
+)
+
+game (
+	name "Tomcat Alley (Germany)"
+	description "Tomcat Alley (Germany)"
+	rom ( name "Tomcat Alley (Germany).cue" size 214 crc 2bde10ab md5 1c4407e8e0c470555f1613ff136b7773 sha1 af6e031d7b05b8ebab65dd51ec2085191bf42784 )
+)
+
+game (
+	name "Tomcat Alley (USA)"
+	description "Tomcat Alley (USA)"
+	rom ( name "Tomcat Alley (USA).cue" size 229 crc 472a189e md5 779b6e95b27983fce151ddbc350d1651 sha1 84aca06cfb9bfb2cb881eddfe2251a4aabc4891c )
+)
+
+game (
+	name "Tomcat Alley (USA) (Alt)"
+	description "Tomcat Alley (USA) (Alt)"
+	rom ( name "Tomcat Alley (USA) (Alt).cue" size 218 crc b4acd552 md5 55cef196cbe56a489a7554bea2d61692 sha1 8dc43b9f279a160571fbf513be9c51077da19e1d )
+)
+
+game (
+	name "Urusei Yatsura - Dear My Friends (Japan)"
+	description "Urusei Yatsura - Dear My Friends (Japan)"
+	rom ( name "Urusei Yatsura - Dear My Friends (Japan).cue" size 430 crc 94be6e3b md5 0146be2ed06e6606b5ac6a02dad59902 sha1 e209b5205d712585a39da18e648e04ac5b689f6c )
+)
+
+game (
+	name "Vay - Ryuusei no Yoroi (Japan)"
+	description "Vay - Ryuusei no Yoroi (Japan)"
+	rom ( name "Vay - Ryuusei no Yoroi (Japan).cue" size 2107 crc b0351491 md5 cd3d0d9da77716533a2eab7b7cd2837f sha1 3291ba5ac17646f46080c50950bae2b2ebe6e971 )
+)
+
+game (
+	name "Vay (USA)"
+	description "Vay (USA)"
+	rom ( name "Vay (USA).cue" size 2293 crc 47a228e8 md5 b3a9694fcfa531bbcabeb4a5c2d372d2 sha1 0ac359d68e4f54a8279ef9a1a2209744dcaab364 )
+)
+
+game (
+	name "Wakusei Woodstock - Funky Horror Band (Japan)"
+	description "Wakusei Woodstock - Funky Horror Band (Japan)"
+	rom ( name "Wakusei Woodstock - Funky Horror Band (Japan).cue" size 700 crc 6e6934b7 md5 981b9f8788c3cd3c16f88b6b4070e582 sha1 5cb81ae63920a0b9e0c0fce63296a6b26cbd2ccb )
+)
+
+game (
+	name "Wheel of Fortune (USA)"
+	description "Wheel of Fortune (USA)"
+	rom ( name "Wheel of Fortune (USA).cue" size 910 crc a383dffe md5 4ac0d254922af7ad392ca55b0be35baa sha1 a5182cf7743562cef80696553595cf58bcd46618 )
+)
+
+game (
+	name "Who Shot Johnny Rock (USA)"
+	description "Who Shot Johnny Rock (USA)"
+	rom ( name "Who Shot Johnny Rock (USA).cue" size 245 crc 788f141f md5 c41fc6148f2c0722058f4a63f3371f69 sha1 e0f9947d4c648056d30b70ba80f2b10f1d982881 )
+)
+
+game (
+	name "Wing Commander (Japan)"
+	description "Wing Commander (Japan)"
+	rom ( name "Wing Commander (Japan).cue" size 816 crc 17ea2a2c md5 60bc24331069c5b953da72ff3f82fcff sha1 2963e38d4d107e2db0c7c5af41bdb2e13528eafa )
+)
+
+game (
+	name "Wing Commander (USA)"
+	description "Wing Commander (USA)"
+	rom ( name "Wing Commander (USA).cue" size 804 crc 47b303b2 md5 e284ba5630e5fe637c75a23dcae937ef sha1 0384cbd28a94e93e4a26561329e7c86e61f45721 )
+)
+
+game (
+	name "Winning Post (Japan)"
+	description "Winning Post (Japan)"
+	rom ( name "Winning Post (Japan).cue" size 2167 crc 0a09b085 md5 d62815c01736025634df5865589859e2 sha1 38c55dfe2ad65bdcfd7bb3ca8f7456b48a563d94 )
+)
+
+game (
+	name "WireHead (USA)"
+	description "WireHead (USA)"
+	rom ( name "WireHead (USA).cue" size 221 crc 2ec162e1 md5 cdc78b8d197a76ace26295a2ef1179ec sha1 323d827469093030548ed52722ab37312f9ce71b )
+)
+
+game (
+	name "Wolfchild (Europe)"
+	description "Wolfchild (Europe)"
+	rom ( name "Wolfchild (Europe).cue" size 1225 crc c9122a4f md5 ff11580b111b54864a4f070723bf472f sha1 fb61b74220896bed556e21555eafec3af42e4125 )
+)
+
+game (
+	name "Wolfchild (Japan)"
+	description "Wolfchild (Japan)"
+	rom ( name "Wolfchild (Japan).cue" size 1214 crc d3f5888a md5 0529e705417c7919e10010d64f9418c9 sha1 c246770fa437f883b1c806ee1357b77c40fa5614 )
+)
+
+game (
+	name "Wonder Dog (Japan)"
+	description "Wonder Dog (Japan)"
+	rom ( name "Wonder Dog (Japan).cue" size 2355 crc e62fe1de md5 31d02ad12bbf5a9cf3b4398ea6f5cfd0 sha1 2dbfcf18c671af8dc3e8d2a4768375f9280646c0 )
+)
+
+game (
+	name "WonderMega Collection (Japan)"
+	description "WonderMega Collection (Japan)"
+	rom ( name "WonderMega Collection (Japan).cue" size 4345 crc 0f225de4 md5 9385856a7e5221a8a137090126257c2a sha1 1ee3d746ec03352cac9acb56b836bca0b0181cae )
+)
+
+game (
+	name "World Cup USA '94 (USA)"
+	description "World Cup USA '94 (USA)"
+	rom ( name "World Cup USA '94 (USA).cue" size 2129 crc 4de8096f md5 d4ad9c5d6d551ef8036f57bd40c95e09 sha1 d0e67e85e3778a2cc408af14a2b6db475e0bda54 )
+)
+
+game (
+	name "WWF - Rage in the Cage (USA)"
+	description "WWF - Rage in the Cage (USA)"
+	rom ( name "WWF - Rage in the Cage (USA).cue" size 249 crc 441f81ae md5 ac6e90c5f1a67e8979469a12fc920205 sha1 884fc60aa3c55b030436fa8708fe84873a455a8b )
+)
+
+game (
+	name "WWF Mania Tour - WWF - Rage in the Cage (Japan)"
+	description "WWF Mania Tour - WWF - Rage in the Cage (Japan)"
+	rom ( name "WWF Mania Tour - WWF - Rage in the Cage (Japan).cue" size 264 crc d3284176 md5 4800081f6e2c8a1272e55c10f2862f66 sha1 eb42e6e7ca5cc80ed11c122c9c0dbd2ab45abe78 )
+)
+
+game (
+	name "Yumemi Mystery Mansion (Europe)"
+	description "Yumemi Mystery Mansion (Europe)"
+	rom ( name "Yumemi Mystery Mansion (Europe).cue" size 232 crc 56a7bc07 md5 f7b0a77bd3dda51cb69eeae87054edc0 sha1 09ae181c8b6fac5d85ed06b20e91d4cb306d2fd0 )
+)
+
+game (
+	name "Yumemi Yakata no Monogatari (Japan)"
+	description "Yumemi Yakata no Monogatari (Japan)"
+	rom ( name "Yumemi Yakata no Monogatari (Japan).cue" size 240 crc e9b007a4 md5 b4338ded09a542d8ef761045dabefba3 sha1 3afd7340413845bcd79f00f197229ce89e99a755 )
+)
+
+game (
+	name "Yumimi Mix (Japan)"
+	description "Yumimi Mix (Japan)"
+	rom ( name "Yumimi Mix (Japan).cue" size 453 crc 491b26ab md5 4b3dda941913eaa86200d574dd37efba sha1 271355a353c73e7268fe609ab1f6afa00e9961a8 )
+)


### PR DESCRIPTION
This adds [Redump](http://redump.org/)'s `Sega - Mega-CD - Sega CD.dat`, as requested in https://github.com/libretro/libretro-database/issues/232 . This was built using [libretro-sega-mega-cd.dat](https://github.com/RobLoach/libretro-sega-mega-cd.dat), which just indexes the .cue files. Genesis Plus GX has cue file support, so this is the first step for adding support for browsing/launching Mega CD games.

Thank you to @shinra358, @markwkidd in #232 and libretro/RetroArch#3353 for bringing up that this was missing.