### PR TITLE
Add NEC - PC Engine CD / TurboGrafx-CD

### DIFF
--- a/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
+++ b/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
@@ -1,0 +1,1921 @@
+clrmamepro (
+	name "NEC - PC Engine CD - TurboGrafx-CD"
+	description "NEC - PC Engine CD - TurboGrafx-CD"
+	version "0.0.1"
+	comment "libretro-database's DAT file for NEC - PC Engine CD - TurboGrafx-CD"
+	homepage "https://github.com/RobLoach/libretro-nec-pc-engine-cd-turbografx-cd"
+)
+
+game (
+	name "1552 Tenka Tairan (Japan) (Rev 4)"
+	description "1552 Tenka Tairan (Japan) (Rev 4)"
+	rom ( name "1552 Tenka Tairan (Japan) (Rev 4).cue" size 3042 crc 679b909d md5 1019cd145f7063bf3fb6e5fd7be03821 sha1 b24662ce9bb263724866e7199ca453ac78c94a6b )
+)
+
+game (
+	name "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1)"
+	description "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1)"
+	rom ( name "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1).cue" size 3723 crc 3cf86ed3 md5 26af72bbf3a037780146478ce0b1fbfe sha1 c7cfdbc3370e5d8a6f3f23d1778703d841168463 )
+)
+
+game (
+	name "3x3 Eyes - Sanjiyan Henjou (Japan) (HE100523)"
+	description "3x3 Eyes - Sanjiyan Henjou (Japan) (HE100523)"
+	rom ( name "3x3 Eyes - Sanjiyan Henjou (Japan) (HE100523).cue" size 914 crc 4134d5ce md5 7bf7c4821cbc4dda16b8f5ac6ffd16d4 sha1 b1138e58ea385ca2126229cd781143008d17f54b )
+)
+
+game (
+	name "A.III. - A Ressha de Ikou III (Japan)"
+	description "A.III. - A Ressha de Ikou III (Japan)"
+	rom ( name "A.III. - A Ressha de Ikou III (Japan).cue" size 722 crc 287311e6 md5 4f1e738686ae29dd88e53d32e26e68d1 sha1 a9e009624f96e1f3da9f3e3b4d236a9b43ea694b )
+)
+
+game (
+	name "Advanced V.G. (Japan)"
+	description "Advanced V.G. (Japan)"
+	rom ( name "Advanced V.G. (Japan).cue" size 3543 crc 08fb23e6 md5 39b67de686bdea7f25cb17bb5dd59bf3 sha1 e957bd617790e9942879f5f866778b85cefeea12 )
+)
+
+game (
+	name "Adventure Quiz - Capcom World + Hatena no Daibouken (Japan) (Rev 2)"
+	description "Adventure Quiz - Capcom World + Hatena no Daibouken (Japan) (Rev 2)"
+	rom ( name "Adventure Quiz - Capcom World + Hatena no Daibouken (Japan) (Rev 2).cue" size 1040 crc bd41c297 md5 e9de4283963675f05298632a00702771 sha1 6907eaf9828d394bf3f9242e7bb81a4d69c61999 )
+)
+
+game (
+	name "Ai Chou Aniki (Japan)"
+	description "Ai Chou Aniki (Japan)"
+	rom ( name "Ai Chou Aniki (Japan).cue" size 2032 crc 4724a3c1 md5 f2a8da82d0e82eacdfd7d26d11f8e971 sha1 e0f009a3be8795c0335e2cc36c1f9fc974bd7c2a )
+)
+
+game (
+	name "Akumajou Dracula X - Chi no Rondo (Japan) (FABT, FACT)"
+	description "Akumajou Dracula X - Chi no Rondo (Japan) (FABT, FACT)"
+	rom ( name "Akumajou Dracula X - Chi no Rondo (Japan) (FABT, FACT).cue" size 2851 crc 9aa50f74 md5 1d5f5fc48632ea2117379b99d3703666 sha1 35276f6a2dd1c12ec413608afaed5a4a66cdaed2 )
+)
+
+game (
+	name "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FAAT)"
+	description "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FAAT)"
+	rom ( name "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FAAT).cue" size 5595 crc 5f8b94c9 md5 ce5044098bc0f5c9e01010f9f4d77086 sha1 5e5f5351a4e8f58f4ea7eb8036f18fe91c674edc )
+)
+
+game (
+	name "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FABT)"
+	description "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FABT)"
+	rom ( name "Alnam no Kiba - Juuzoku Juuni Shinto Densetsu (Japan) (FABT).cue" size 5618 crc 53efd685 md5 bdc21bb0494fbdcd3ba103da2b3a496f sha1 3d76d944b2447d0f2797418061e26fd6a69e4a95 )
+)
+
+game (
+	name "Ane-san (Japan)"
+	description "Ane-san (Japan)"
+	rom ( name "Ane-san (Japan).cue" size 2597 crc 2d2fb7a9 md5 8d461d9a22036b71c0d572f53378eeb4 sha1 0f6847247d818e4599cea411c312a3349f233786 )
+)
+
+game (
+	name "Atlas, The - Renaissance Voyager (Japan)"
+	description "Atlas, The - Renaissance Voyager (Japan)"
+	rom ( name "Atlas, The - Renaissance Voyager (Japan).cue" size 1642 crc 39c78883 md5 7eca3d381c38176dff007a23b5dc57e2 sha1 49356e7884ddb0af56b21cf42bc7f1622851e5ed )
+)
+
+game (
+	name "Aurora Quest - Otaku no Seiza in Another World (Japan)"
+	description "Aurora Quest - Otaku no Seiza in Another World (Japan)"
+	rom ( name "Aurora Quest - Otaku no Seiza in Another World (Japan).cue" size 2622 crc ccc2f3d5 md5 243c5fc5cc27e6bf2ca7a0a2b0b703b6 sha1 4d1e3e45a577a7821b42936c802bc8c87b20c3bc )
+)
+
+game (
+	name "AV Tanjou (Japan) (Unl)"
+	description "AV Tanjou (Japan) (Unl)"
+	rom ( name "AV Tanjou (Japan) (Unl).cue" size 7728 crc 32fc4232 md5 fca36db1951c7dfe1a06fcceccc57908 sha1 b0720a8c6143bd5f9fd79f9c62df5fcc2f34b3e6 )
+)
+
+game (
+	name "Avenger (Japan) (Rev 4)"
+	description "Avenger (Japan) (Rev 4)"
+	rom ( name "Avenger (Japan) (Rev 4).cue" size 4317 crc a41dda7d md5 adbbc9193b3f6b62dadb40f8a1d33cc5 sha1 292ad7704152c980cbf6e6a69fb425125c76cf9f )
+)
+
+game (
+	name "Babel (Japan)"
+	description "Babel (Japan)"
+	rom ( name "Babel (Japan).cue" size 8704 crc 8d71bb59 md5 bc0f55938618ec057022e9e3fcbf51d9 sha1 09d70149d600a9daa0ffaadd1d4789bcf13f0ef8 )
+)
+
+game (
+	name "Bakushou Yoshimoto Shinkigeki (Japan) (FABT)"
+	description "Bakushou Yoshimoto Shinkigeki (Japan) (FABT)"
+	rom ( name "Bakushou Yoshimoto Shinkigeki (Japan) (FABT).cue" size 3582 crc 5060f11e md5 baab7b53976a98bcf58e3877eee61099 sha1 f57483e35771a475115be359862bbaba1cbd348d )
+)
+
+game (
+	name "Battle Shanghai - Dragon's Eye ~ Shanghai III - Dragon's Eye (Japan)"
+	description "Battle Shanghai - Dragon's Eye ~ Shanghai III - Dragon's Eye (Japan)"
+	rom ( name "Battle Shanghai - Dragon's Eye ~ Shanghai III - Dragon's Eye (Japan).cue" size 1782 crc de6a2ae7 md5 6c99f3b313864669d3931034244b75f0 sha1 6fbd581406dcf697a51337b0926875580b4c547a )
+)
+
+game (
+	name "Bikkuriman Daijikai (Japan) (Rev 2)"
+	description "Bikkuriman Daijikai (Japan) (Rev 2)"
+	rom ( name "Bikkuriman Daijikai (Japan) (Rev 2).cue" size 7913 crc a2aaa7b1 md5 3b17cb32e1cbcc9b400c9a7af1405356 sha1 ca1122c14021d93a32bf30fc02ba8c7d3a5e10b7 )
+)
+
+game (
+	name "Bishoujo Senshi Sailor Moon (Japan)"
+	description "Bishoujo Senshi Sailor Moon (Japan)"
+	rom ( name "Bishoujo Senshi Sailor Moon (Japan).cue" size 2619 crc 0542f068 md5 a75f79125e4e30f19fcdc61ad4cd727f sha1 e24d584d81aba54e2aeb55feb71aa2ee069bb053 )
+)
+
+game (
+	name "Bishoujo Senshi Sailor Moon Collection (Japan)"
+	description "Bishoujo Senshi Sailor Moon Collection (Japan)"
+	rom ( name "Bishoujo Senshi Sailor Moon Collection (Japan).cue" size 1703 crc 71a76b24 md5 f8ba402d42cfad9a02b01f973dbe6b46 sha1 584179834892f33b67fdd20feabfde09b984f582 )
+)
+
+game (
+	name "Black Hole Assault (Japan)"
+	description "Black Hole Assault (Japan)"
+	rom ( name "Black Hole Assault (Japan).cue" size 2426 crc 9089758b md5 0f577575046ea78cef960c8af1eba46a sha1 79e536acfdfd9a574f4b2cf3aa889171cff55d71 )
+)
+
+game (
+	name "Blood Gear (Japan)"
+	description "Blood Gear (Japan)"
+	rom ( name "Blood Gear (Japan).cue" size 4152 crc 750afee7 md5 c23a2b7ff6b1556e955243742b304c5d sha1 976eb3b38982c1a833071ce72185812a1716ced3 )
+)
+
+game (
+	name "Bomberman - Panic Bomber (Japan) (FAAT)"
+	description "Bomberman - Panic Bomber (Japan) (FAAT)"
+	rom ( name "Bomberman - Panic Bomber (Japan) (FAAT).cue" size 3543 crc d5abae20 md5 06b9e9a63ae300c9efd2b34a5bf8b5a1 sha1 00919561ffcf5849a60550948a9661438b48cede )
+)
+
+game (
+	name "Bomberman - Panic Bomber (Japan) (FABT)"
+	description "Bomberman - Panic Bomber (Japan) (FABT)"
+	rom ( name "Bomberman - Panic Bomber (Japan) (FABT).cue" size 3543 crc 355df0a7 md5 f4c8e2fd588bb0b9969769dee7be7ca9 sha1 13b1b34474a6bee2e58e7dbbdf3fc88318482650 )
+)
+
+game (
+	name "Bonanza Bros. (Japan)"
+	description "Bonanza Bros. (Japan)"
+	rom ( name "Bonanza Bros. (Japan).cue" size 2241 crc 55901056 md5 58860eea3ea6676f0268196835905ca6 sha1 0a05452e3cbcee8bc2e16315c7ae49f30549f04b )
+)
+
+game (
+	name "Browning (Japan) (Rev 6)"
+	description "Browning (Japan) (Rev 6)"
+	rom ( name "Browning (Japan) (Rev 6).cue" size 2666 crc 29ae53c0 md5 2cd91f259dc9fa2a3a455ba5b056ae40 sha1 94b566a935ba610720b4d769740c7e0920b257ea )
+)
+
+game (
+	name "BuilderLand - The Story of Melba (Japan)"
+	description "BuilderLand - The Story of Melba (Japan)"
+	rom ( name "BuilderLand - The Story of Melba (Japan).cue" size 962 crc e9be4cdc md5 26ee72d90128b86a4600583df9e1475b sha1 2648dd64408c0f4c0747c8277ceb12a4c5c47b00 )
+)
+
+game (
+	name "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6)"
+	description "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6)"
+	rom ( name "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6).cue" size 8906 crc 739cc5db md5 4f482e45bfd551696740f46febda2fb5 sha1 5ba1b67b294cba6ef99ec30a2ec1639b6d197650 )
+)
+
+game (
+	name "Burai II - Yami Koutei no Gyakushuu (Japan) (Rev 2)"
+	description "Burai II - Yami Koutei no Gyakushuu (Japan) (Rev 2)"
+	rom ( name "Burai II - Yami Koutei no Gyakushuu (Japan) (Rev 2).cue" size 5637 crc ad71d7d5 md5 13b39b49b2f5bf1c20b753c6bd71cfa5 sha1 8aa238915e04564a3bd08dba0f6466092fc78d4e )
+)
+
+game (
+	name "Buster Bros. (USA)"
+	description "Buster Bros. (USA)"
+	rom ( name "Buster Bros. (USA).cue" size 2262 crc 611eda79 md5 a958f232f77503e63c07df7c06d16e54 sha1 1353074ea838c9f7a12a4bbc4d182c9e474d0804 )
+)
+
+game (
+	name "CAL II (Japan)"
+	description "CAL II (Japan)"
+	rom ( name "CAL II (Japan).cue" size 697 crc f4637255 md5 8efecd45795f5ddfc9f3817e3e929086 sha1 26a6a801be87ea93e3dd7f76d6eb8d42a1a74405 )
+)
+
+game (
+	name "CAL II (Japan) (Alt)"
+	description "CAL II (Japan) (Alt)"
+	rom ( name "CAL II (Japan) (Alt).cue" size 739 crc a59171bf md5 e55e848051497252077718033c127a29 sha1 d5ef65ee5456b44d675bd501f881d0d4409c824c )
+)
+
+game (
+	name "CAL III - Kanketsu-hen (Japan)"
+	description "CAL III - Kanketsu-hen (Japan)"
+	rom ( name "CAL III - Kanketsu-hen (Japan).cue" size 607 crc b03697fb md5 5bf6d8cc6fcf933f76756a8f4f4c6941 sha1 6d5cc7a010fb8feeed7e0707cccb4eb780095365 )
+)
+
+game (
+	name "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
+	description "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
+	rom ( name "Campaign Version - Daisenryaku II (Japan) (Rev 4).cue" size 1647 crc 0adbebba md5 87f7c3d5a30b3fba929a6fbb44ae22b2 sha1 0167fdd6608d3ac6798eb3613b58b266ddbed639 )
+)
+
+game (
+	name "Cardangels (Japan)"
+	description "Cardangels (Japan)"
+	rom ( name "Cardangels (Japan).cue" size 3877 crc 2a67d8c6 md5 639b8c4e5d938789a2613d00eeba7a99 sha1 f2322b9ee295c406c3a4a65e5a692bfe1f15198a )
+)
+
+game (
+	name "CD Battle - Hikari no Yuusha-tachi (Japan)"
+	description "CD Battle - Hikari no Yuusha-tachi (Japan)"
+	rom ( name "CD Battle - Hikari no Yuusha-tachi (Japan).cue" size 503 crc b5cd5281 md5 a1f82d0d3cfad5f0dad44be57285a511 sha1 6ed0076bbed1bd0e6aadf6e516cdd9c1bb55f180 )
+)
+
+game (
+	name "CD Denjin - Rockabilly Tengoku (Japan)"
+	description "CD Denjin - Rockabilly Tengoku (Japan)"
+	rom ( name "CD Denjin - Rockabilly Tengoku (Japan).cue" size 2742 crc 06c7fe8a md5 88beabe6a99d393ba31b55c071377a0a sha1 8c1085672cb1d2ec0b73ffc7f6f2e952aa7b96f3 )
+)
+
+game (
+	name "CD Mahjong Bishoujo Chuushinha (Japan) (Unl)"
+	description "CD Mahjong Bishoujo Chuushinha (Japan) (Unl)"
+	rom ( name "CD Mahjong Bishoujo Chuushinha (Japan) (Unl).cue" size 2762 crc 1b638cc8 md5 eba06760ac0d006275824a80c49836a8 sha1 034d976e69f6d19ebcbd65fecf619863187ee378 )
+)
+
+game (
+	name "Chou Jikuu Yousai Macross - Eien no Love Song (Japan)"
+	description "Chou Jikuu Yousai Macross - Eien no Love Song (Japan)"
+	rom ( name "Chou Jikuu Yousai Macross - Eien no Love Song (Japan).cue" size 5824 crc f60f840d md5 9f2e2e1590195b83a6154fc18ba5ee9a sha1 b637dcec81961a2588923ccaac026fdafaed3173 )
+)
+
+game (
+	name "Chou Jikuu Yousai Macross 2036 (Japan)"
+	description "Chou Jikuu Yousai Macross 2036 (Japan)"
+	rom ( name "Chou Jikuu Yousai Macross 2036 (Japan).cue" size 3975 crc 8a4c3e28 md5 ec5c52970db184e7d5831c20ed39ab30 sha1 b413b6fb68d18f236bd9c0effd28817c4635e75f )
+)
+
+game (
+	name "Cosmic Fantasy - Bouken Shounen Yuu (Japan)"
+	description "Cosmic Fantasy - Bouken Shounen Yuu (Japan)"
+	rom ( name "Cosmic Fantasy - Bouken Shounen Yuu (Japan).cue" size 11464 crc c53df0b9 md5 f79003716a6bc53ffe320674aa52294e sha1 0002d3938f85ddf04bb3dc23906eb1429365fda3 )
+)
+
+game (
+	name "Cosmic Fantasy - Bouken Shounen Yuu (Japan) (Alt)"
+	description "Cosmic Fantasy - Bouken Shounen Yuu (Japan) (Alt)"
+	rom ( name "Cosmic Fantasy - Bouken Shounen Yuu (Japan) (Alt).cue" size 12058 crc 0fcd9e67 md5 95f0295f57836e4a8c72e5515dfc1170 sha1 125757141c7aacd60909c3903f0a8b0a9de60a72 )
+)
+
+game (
+	name "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan)"
+	description "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan)"
+	rom ( name "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan).cue" size 13914 crc 83908b2b md5 5c760cd4bbeb95b8201a5c0ba7ca0b81 sha1 e988a4e55d3a3b6e9eaa3f811b96f940297bc344 )
+)
+
+game (
+	name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan)"
+	description "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan)"
+	rom ( name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan).cue" size 13119 crc 9506f41d md5 e407589b6fd5e4508ede98d8e8a91431 sha1 f06f7288198ced912699571fa1740db90dce6966 )
+)
+
+game (
+	name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou-hen (Japan)"
+	description "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou-hen (Japan)"
+	rom ( name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou-hen (Japan).cue" size 8067 crc 9a534c17 md5 9c7b58323b352e07dca6810bba7230a6 sha1 cc50ce4caadeb0588451fef356bb409948b56595 )
+)
+
+game (
+	name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan)"
+	description "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan)"
+	rom ( name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan).cue" size 10103 crc 4dc80b5a md5 33e043db071ce053cda8fdcb55ed185d sha1 9856e61955fff8529e924b27d2f3fd5e7818c24b )
+)
+
+game (
+	name "Cyber City Oedo 808 - Kemono no Alignment (Japan)"
+	description "Cyber City Oedo 808 - Kemono no Alignment (Japan)"
+	rom ( name "Cyber City Oedo 808 - Kemono no Alignment (Japan).cue" size 10722 crc c3f4d7c2 md5 d7941dcfdb05b5e5deb0d42e43e825a6 sha1 26f2259b568c8fe061f05886f4580e72a0a33bfa )
+)
+
+game (
+	name "Davis Cup Tennis, The (Japan)"
+	description "Davis Cup Tennis, The (Japan)"
+	rom ( name "Davis Cup Tennis, The (Japan).cue" size 2195 crc 30da9d0e md5 844a02217f3803078f48f894fdd555a9 sha1 b66b116f41ae7f7761ac1bfb274b7eded4b9988f )
+)
+
+game (
+	name "De-Ja (Japan)"
+	description "De-Ja (Japan)"
+	rom ( name "De-Ja (Japan).cue" size 219 crc e0b9b081 md5 0ef4f126671c0884217251874c5c4dfd sha1 d30921b8d12f1d25ddbb3382abefb70877697b59 )
+)
+
+game (
+	name "Death Bringer - The Knight of Darkness (Japan) (Rev 4)"
+	description "Death Bringer - The Knight of Darkness (Japan) (Rev 4)"
+	rom ( name "Death Bringer - The Knight of Darkness (Japan) (Rev 4).cue" size 3602 crc 01be576c md5 28bd9d3135f1ff738f16f23b737ac0ab sha1 014d793dc097810073ff9fa552aaca05910b9b0a )
+)
+
+game (
+	name "Dekoboko Densetsu - Hashiru Wagamanmaa (Japan) (Rev 3)"
+	description "Dekoboko Densetsu - Hashiru Wagamanmaa (Japan) (Rev 3)"
+	rom ( name "Dekoboko Densetsu - Hashiru Wagamanmaa (Japan) (Rev 3).cue" size 3350 crc f91671b8 md5 a05b7e2f1087e38c69501bb4cfa4f96b sha1 ca828cacb4e55c3cdfc6f136a4bca5206cf4efa6 )
+)
+
+game (
+	name "Dennou Tenshi - Digital Ange (Japan)"
+	description "Dennou Tenshi - Digital Ange (Japan)"
+	rom ( name "Dennou Tenshi - Digital Ange (Japan).cue" size 609 crc 9c1ca969 md5 af9b104153be6899879ec12b86498e94 sha1 a1c4eee3b12f42347fce6684fbf8b5e022da7376 )
+)
+
+game (
+	name "Double Dragon II - The Revenge (Japan)"
+	description "Double Dragon II - The Revenge (Japan)"
+	rom ( name "Double Dragon II - The Revenge (Japan).cue" size 2939 crc 675186d5 md5 b2bd3caefc88f7eb2bb2d32fc26da7d6 sha1 a6fee1a484a74d8b4dd18e89d2cffb230bf661ab )
+)
+
+game (
+	name "Doukyuusei (Japan)"
+	description "Doukyuusei (Japan)"
+	rom ( name "Doukyuusei (Japan).cue" size 697 crc fe7901fb md5 59f57a37af3f873322f94c5e3217afeb sha1 429ed4e79b2ca123964a2926864885dbdc5d1a90 )
+)
+
+game (
+	name "Doukyuusei (Japan) (Alt 1)"
+	description "Doukyuusei (Japan) (Alt 1)"
+	rom ( name "Doukyuusei (Japan) (Alt 1).cue" size 753 crc f95c5066 md5 59ba2322a2b6eda72df2c57c3032cfa1 sha1 350c171603d519200575ef195067fa0be53f4265 )
+)
+
+game (
+	name "Doukyuusei (Japan) (Alt 2)"
+	description "Doukyuusei (Japan) (Alt 2)"
+	rom ( name "Doukyuusei (Japan) (Alt 2).cue" size 753 crc 0061231c md5 5bcfc59d071408744e56158f9bf5a15e sha1 e70d6489ca63b3122427f050f7f4658eac312c76 )
+)
+
+game (
+	name "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT)"
+	description "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT)"
+	rom ( name "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT).cue" size 2024 crc 509050aa md5 bfecdb17b767f7916cd5a1e5abff0fe4 sha1 4e6bed613fb71275e66738d6dd569db3ac929a38 )
+)
+
+game (
+	name "Dragon Half (Japan)"
+	description "Dragon Half (Japan)"
+	rom ( name "Dragon Half (Japan).cue" size 2104 crc 43b5b909 md5 bd2b3ab2cfbae22c4fc4d825d512c712 sha1 691892ab2509b26533ee31c7f515f4de667b63cc )
+)
+
+game (
+	name "Dragon Knight II (Japan)"
+	description "Dragon Knight II (Japan)"
+	rom ( name "Dragon Knight II (Japan).cue" size 3558 crc de5ab8bc md5 cba357eae910318c0cbc902fba83d872 sha1 482890d74e6483550ffbd77516a0e429cf9badde )
+)
+
+game (
+	name "Dragon Knight III (Japan)"
+	description "Dragon Knight III (Japan)"
+	rom ( name "Dragon Knight III (Japan).cue" size 1945 crc 8d2eee05 md5 afb37026d3e31dbc7aed21548c7c4968 sha1 4e8b4d5be4e62eb9630fa7fc2e78dadf75ef17c4 )
+)
+
+game (
+	name "Dragon Slayer - The Legend of Heroes (Japan)"
+	description "Dragon Slayer - The Legend of Heroes (Japan)"
+	rom ( name "Dragon Slayer - The Legend of Heroes (Japan).cue" size 2654 crc a3793925 md5 55259e6136d702bb6888bb5e6e453636 sha1 5ce6b1229c76ee330f3742889af8d05513d6b679 )
+)
+
+game (
+	name "Dragon Slayer - The Legend of Heroes (USA) (Rev 1)"
+	description "Dragon Slayer - The Legend of Heroes (USA) (Rev 1)"
+	rom ( name "Dragon Slayer - The Legend of Heroes (USA) (Rev 1).cue" size 2786 crc 1b43f3da md5 4de6f6c68e724ec93158897f44c8be1c sha1 5ee3b80afffd638262f40d00d469ba332afdcc40 )
+)
+
+game (
+	name "Dragon Slayer - The Legend of Heroes II (Japan)"
+	description "Dragon Slayer - The Legend of Heroes II (Japan)"
+	rom ( name "Dragon Slayer - The Legend of Heroes II (Japan).cue" size 2930 crc 68a57eff md5 8321f28830cbf0153f0e7967a768022c sha1 63af122474ab0ba33da2dbcbe201d93c0ce5e14d )
+)
+
+game (
+	name "Dungeon Explorer II (Japan) (Rev 5)"
+	description "Dungeon Explorer II (Japan) (Rev 5)"
+	rom ( name "Dungeon Explorer II (Japan) (Rev 5).cue" size 3740 crc 33c75650 md5 82d0780c9478653156352324c23004d5 sha1 448b02332223f11cdf8c356e94e961ff801fd3a6 )
+)
+
+game (
+	name "Dungeon Explorer II (USA)"
+	description "Dungeon Explorer II (USA)"
+	rom ( name "Dungeon Explorer II (USA).cue" size 3400 crc 2f84b574 md5 435cd7261f905702e9ce9e9fa188b4bc sha1 68f3c5530762151ef6cd62b7301a9eb8be461fbf )
+)
+
+game (
+	name "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
+	description "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
+	rom ( name "Dungeon Master - Theron's Quest (Japan) (Rev 1).cue" size 2363 crc e7e53704 md5 85706e7c2f658bc2792511d618dfc7a5 sha1 55ee4a0fb1249fc0d448c63db2eba531552e0670 )
+)
+
+game (
+	name "Dungeon Master - Theron's Quest (USA)"
+	description "Dungeon Master - Theron's Quest (USA)"
+	rom ( name "Dungeon Master - Theron's Quest (USA).cue" size 2173 crc f09fb9c5 md5 63dbd2fab613b2e8030ff4e44b978a39 sha1 faeeb80715979a809ec7b0811e8ea3e2e12ee2d0 )
+)
+
+game (
+	name "Efera & Jiliora - The Emblem from Darkness (Japan)"
+	description "Efera & Jiliora - The Emblem from Darkness (Japan)"
+	rom ( name "Efera & Jiliora - The Emblem from Darkness (Japan).cue" size 2176 crc fdab3274 md5 b8a240288617d6fce354a380adcf1dc5 sha1 776aa8c7bcb07d5fa4b43ef8ce3b3dd94045911c )
+)
+
+game (
+	name "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan)"
+	description "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan)"
+	rom ( name "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan).cue" size 4011 crc 2685eca0 md5 358a2c75f8ae993fbf3aedc2bcce2853 sha1 971ff86be6bd24dd9efb8664f1cd3192d83f0c70 )
+)
+
+game (
+	name "Emerald Dragon (Japan) (HE50225)"
+	description "Emerald Dragon (Japan) (HE50225)"
+	rom ( name "Emerald Dragon (Japan) (HE50225).cue" size 3298 crc c923fa3e md5 958cc95462740cd82d324bb660215c28 sha1 3aa7ea3c8940db0e1a8c4b66a7e0448027b5926f )
+)
+
+game (
+	name "Emerald Dragon (Japan) (HE51129)"
+	description "Emerald Dragon (Japan) (HE51129)"
+	rom ( name "Emerald Dragon (Japan) (HE51129).cue" size 3298 crc 40924689 md5 8e3fb76c863ce46825fa8cf61a996e35 sha1 cb968e8e23e41bddac20eb8543517bf914cc7a77 )
+)
+
+game (
+	name "Exile - Toki no Hasama e (Japan)"
+	description "Exile - Toki no Hasama e (Japan)"
+	rom ( name "Exile - Toki no Hasama e (Japan).cue" size 4130 crc 6942f3de md5 967146da783aad6d894021e08f1e9d90 sha1 274f7298b9970dc3157c1f1ce67ff498c52e0bde )
+)
+
+game (
+	name "Exile II - Janen no Jishou (Japan)"
+	description "Exile II - Janen no Jishou (Japan)"
+	rom ( name "Exile II - Janen no Jishou (Japan).cue" size 3042 crc 1fe14ada md5 5c2e8acd2b449190992042a11014ee40 sha1 31f71cfd068761c646b7f3ff4f2303e685ddcc45 )
+)
+
+game (
+	name "F1 Circus Special - Pole to Win (Japan) (FAAT, FACT)"
+	description "F1 Circus Special - Pole to Win (Japan) (FAAT, FACT)"
+	rom ( name "F1 Circus Special - Pole to Win (Japan) (FAAT, FACT).cue" size 7891 crc 009974af md5 8a4a5ed952fcc2e6806f7b9203136b6c sha1 beb923e974d9f34ebb0470bc5c73d89eb29845be )
+)
+
+game (
+	name "F1 Circus Special - Pole to Win (Japan) (FABT)"
+	description "F1 Circus Special - Pole to Win (Japan) (FABT)"
+	rom ( name "F1 Circus Special - Pole to Win (Japan) (FABT).cue" size 7513 crc d6d1dbca md5 ea0cf98d5643de300f3fe9e22abeddfe sha1 244bf4a01305c6218de357e1685190eeddf50d49 )
+)
+
+game (
+	name "F1 Team Simulation - Project F (Japan)"
+	description "F1 Team Simulation - Project F (Japan)"
+	rom ( name "F1 Team Simulation - Project F (Japan).cue" size 3512 crc eaaa9390 md5 a0160a9609c11ae6c2fc264263068510 sha1 f419f03df4578884adad87d68afc40fcffae2958 )
+)
+
+game (
+	name "Faceball (Japan)"
+	description "Faceball (Japan)"
+	rom ( name "Faceball (Japan).cue" size 1510 crc 1d39808b md5 e1b2000de014b19cb7793c3b9415a824 sha1 c567c0212e835e819e56f3561729c6adab761120 )
+)
+
+game (
+	name "Faceball (Japan) (Sample)"
+	description "Faceball (Japan) (Sample)"
+	rom ( name "Faceball (Japan) (Sample).cue" size 1529 crc 7c9748ce md5 77d4b5386ef423804c81b7d815455b65 sha1 73159be26571d7d748e307ee2e4e3d55f8800fc8 )
+)
+
+game (
+	name "Faerie Dust Story - Meikyuu no Elfeene (Japan) (Rev 2)"
+	description "Faerie Dust Story - Meikyuu no Elfeene (Japan) (Rev 2)"
+	rom ( name "Faerie Dust Story - Meikyuu no Elfeene (Japan) (Rev 2).cue" size 13218 crc 79d34570 md5 d6b1a05f27a686427e1891d900913ff0 sha1 c4288060ff641e42ab0bce10ed470860f947a0a2 )
+)
+
+game (
+	name "Fantastic Night Dreams - Cotton (Japan) (En,Ja)"
+	description "Fantastic Night Dreams - Cotton (Japan) (En,Ja)"
+	rom ( name "Fantastic Night Dreams - Cotton (Japan) (En,Ja).cue" size 3292 crc 759c284e md5 608d74e6379b5bd12ba7fae963223a9f sha1 eb1294cfb0022839abe13a6f52178f008c926dea )
+)
+
+game (
+	name "Fantastic Night Dreams - Cotton (USA)"
+	description "Fantastic Night Dreams - Cotton (USA)"
+	rom ( name "Fantastic Night Dreams - Cotton (USA).cue" size 3045 crc 31d6f660 md5 38514d361500c7819cf473eedf9ba89c sha1 0aba9e5aae72cd635373c6a02ddcd7bb681fb857 )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Rev 2)"
+	description "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Rev 2)"
+	rom ( name "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Rev 2).cue" size 4794 crc b105476c md5 b6b5a46f0d61ae836e2529fd55fe7225 sha1 27a09d1d1e81a1b5dc48d4d881dcdfa53347c74e )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Sample) (Rev 1)"
+	description "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Sample) (Rev 1)"
+	rom ( name "Far East of Eden - Tengai Makyou - Fuun Kabuki-den (Japan) (Sample) (Rev 1).cue" size 1270 crc 02be88a4 md5 32db1d83a2625c61f5935104a6a8714d sha1 2f4cb90950e3f73d0354f6df9936848b23d526cc )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Hibaihin) (Rev 1)"
+	description "Far East of Eden - Tengai Makyou - Ziria (Japan) (Hibaihin) (Rev 1)"
+	rom ( name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Hibaihin) (Rev 1).cue" size 930 crc 9fe8a09f md5 316f208c0c9dc83bb6abb535731487fa sha1 339ccb4af06b9609f9c6057cee13e2d2ae01cd85 )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 6)"
+	description "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 6)"
+	rom ( name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 6).cue" size 864 crc 1cb5ce72 md5 20ea25acd21983ca654a35ca6100d272 sha1 83b79f3dcda0d3aa29bb7843056622e0815c20ba )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 7)"
+	description "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 7)"
+	rom ( name "Far East of Eden - Tengai Makyou - Ziria (Japan) (Rev 7).cue" size 864 crc 18a057c4 md5 20fecd3047e1f547476a9b2f4487440d sha1 f887de91a0d087023ea14d8a3796f7dceceaf39c )
+)
+
+game (
+	name "Far East of Eden - Tengai Makyou II - Manji Maru (Japan) (Rev 1)"
+	description "Far East of Eden - Tengai Makyou II - Manji Maru (Japan) (Rev 1)"
+	rom ( name "Far East of Eden - Tengai Makyou II - Manji Maru (Japan) (Rev 1).cue" size 3474 crc cf4b1b4a md5 25fb36f55c3456e5042909c4c3b5e9f4 sha1 171c05369f45fd94375ad4f97f531cb9b077d856 )
+)
+
+game (
+	name "Fiend Hunter (Japan) (Rev 2)"
+	description "Fiend Hunter (Japan) (Rev 2)"
+	rom ( name "Fiend Hunter (Japan) (Rev 2).cue" size 2274 crc 0648c769 md5 8d0f842eceae07e7c4467e7bea9bde70 sha1 2f18daf89e3561201d938579a4a1a611598b4f41 )
+)
+
+game (
+	name "Fighting Street (Japan) (Rev 5)"
+	description "Fighting Street (Japan) (Rev 5)"
+	rom ( name "Fighting Street (Japan) (Rev 5).cue" size 2780 crc d614f62e md5 fd7c30391b08de76d99c70944a079454 sha1 5196dddff2760d34b13ce27e25147b2f10071729 )
+)
+
+game (
+	name "Final Zone II (Japan) (Rev 3)"
+	description "Final Zone II (Japan) (Rev 3)"
+	rom ( name "Final Zone II (Japan) (Rev 3).cue" size 5629 crc fbb0b937 md5 f59636931c52cf4bd863bc984f666136 sha1 536fb353a9913f106e60a36b4b585ecb937edd8f )
+)
+
+game (
+	name "Forgotten Worlds (Japan)"
+	description "Forgotten Worlds (Japan)"
+	rom ( name "Forgotten Worlds (Japan).cue" size 2502 crc 5af24e61 md5 192e80417682b37f7b580b40a3a38e48 sha1 6d01639727b912f0a8566df2366cc8e28aa0ef36 )
+)
+
+game (
+	name "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1)"
+	description "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1)"
+	rom ( name "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1).cue" size 1335 crc 164801e7 md5 378b5e1dae54f6907b7d08f63631888e sha1 5582c0a61063b961b814ac6cb9a7622d84b5bf97 )
+)
+
+game (
+	name "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (FABT, FAET, FAFT)"
+	description "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (FABT, FAET, FAFT)"
+	rom ( name "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (FABT, FAET, FAFT).cue" size 2779 crc df7020b2 md5 ee5429409475963c8e6d4dc1d3b8af47 sha1 35d1cb376dc0a145a6a9bd25524b1ce37faf354b )
+)
+
+game (
+	name "Garou Densetsu Special (Japan) (FABT)"
+	description "Garou Densetsu Special (Japan) (FABT)"
+	rom ( name "Garou Densetsu Special (Japan) (FABT).cue" size 2586 crc 8233ee8d md5 a6c38fb85cd82c71bb34dbaeb5ca495e sha1 8329ce2a1ce13e4dbb53152ffbadf8b3b351af63 )
+)
+
+game (
+	name "Gate of Thunder (Japan) (FACT, FADT)"
+	description "Gate of Thunder (Japan) (FACT, FADT)"
+	rom ( name "Gate of Thunder (Japan) (FACT, FADT).cue" size 2023 crc b5cc9fd7 md5 eb0cf042644ad5a78a9805a84fc6b133 sha1 fc69ecb3d387ec671bcf1d038e57c6d155cb2377 )
+)
+
+game (
+	name "Genocide (Japan) (Rev 2)"
+	description "Genocide (Japan) (Rev 2)"
+	rom ( name "Genocide (Japan) (Rev 2).cue" size 2406 crc cad278e1 md5 8bed660ca35b26369852a46b1989d927 sha1 e4576f4927f1b82afaaf4d013215286bf70e2c91 )
+)
+
+game (
+	name "Ginga Fukei Densetsu Sapphire (Japan) (Reprint)"
+	description "Ginga Fukei Densetsu Sapphire (Japan) (Reprint)"
+	rom ( name "Ginga Fukei Densetsu Sapphire (Japan) (Reprint).cue" size 2401 crc 5fbfb2b4 md5 d797837b5183e04731372bdba080b248 sha1 afe842162ab772fede42d2a668cd78fa81ddde64 )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna (Japan) (FACT)"
+	description "Ginga Ojousama Densetsu Yuna (Japan) (FACT)"
+	rom ( name "Ginga Ojousama Densetsu Yuna (Japan) (FACT).cue" size 1229 crc 251dfa40 md5 aebab2a372d18bbf6613dbc55b46a1e3 sha1 c3f0abe39c4f909492b0743505c30c83324832f8 )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna (Japan) (FAFT)"
+	description "Ginga Ojousama Densetsu Yuna (Japan) (FAFT)"
+	rom ( name "Ginga Ojousama Densetsu Yuna (Japan) (FAFT).cue" size 1252 crc 34be6b8b md5 33ab3582998f2df33b7642a770eac1fd sha1 02607c05fac38492742656773e83822dfd729de9 )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT)"
+	description "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT)"
+	rom ( name "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT).cue" size 3230 crc f69ea536 md5 598e8589b799db4826cafbdd21828719 sha1 aa9e2a3da3a3e13c210b1ddf47dbf693ee840c2d )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna HuVIDEO CD (Japan)"
+	description "Ginga Ojousama Densetsu Yuna HuVIDEO CD (Japan)"
+	rom ( name "Ginga Ojousama Densetsu Yuna HuVIDEO CD (Japan).cue" size 287 crc dac6204a md5 7468aac2f421a2fad37a1deed121b493 sha1 df81f7a3d02ca3e8604e135107fdda8f1742fc66 )
+)
+
+game (
+	name "God Panic - Shijou Saikyou no Gundan (Japan)"
+	description "God Panic - Shijou Saikyou no Gundan (Japan)"
+	rom ( name "God Panic - Shijou Saikyou no Gundan (Japan).cue" size 2951 crc 9abfa8fc md5 ed8412dcab1a084d298395c937cb7317 sha1 bfeac6abcd0dd7f904496df4934e36b819f17404 )
+)
+
+game (
+	name "Godzilla Bakutou Retsuden (Japan) (Rev 1)"
+	description "Godzilla Bakutou Retsuden (Japan) (Rev 1)"
+	rom ( name "Godzilla Bakutou Retsuden (Japan) (Rev 1).cue" size 2814 crc 510198e4 md5 64cf5b0ec07185fd430987aafc655d9e sha1 6f5deecfe856314454ba66a4c2eb602cbc01166d )
+)
+
+game (
+	name "Goetzendiener (Japan)"
+	description "Goetzendiener (Japan)"
+	rom ( name "Goetzendiener (Japan).cue" size 1283 crc 4450f28d md5 46785608f2213d722fa78958c9302f35 sha1 6bfd90ccf98c0eea9a110bfe26faa833451dbd9e )
+)
+
+game (
+	name "Golden Axe (Japan)"
+	description "Golden Axe (Japan)"
+	rom ( name "Golden Axe (Japan).cue" size 6441 crc 0119a5bd md5 9c9045a3875bd3adf788354e08417670 sha1 f600ab5c92122d62ae40b826d41d4e8b56ec62c6 )
+)
+
+game (
+	name "Golden Axe (Japan) (Alt)"
+	description "Golden Axe (Japan) (Alt)"
+	rom ( name "Golden Axe (Japan) (Alt).cue" size 6867 crc 3c8e93b5 md5 f2a0f20f4ee7145727c26e53dc1ad1e2 sha1 b6879c3dd0b75fefb403915d9ed75c1051085a34 )
+)
+
+game (
+	name "Gradius II - Gofer no Yabou (Japan)"
+	description "Gradius II - Gofer no Yabou (Japan)"
+	rom ( name "Gradius II - Gofer no Yabou (Japan).cue" size 3098 crc 00738bf2 md5 c350d8caedf75342e6bc90f971ef8bd8 sha1 5ee196838abcab72fca933849f76d6091c00f069 )
+)
+
+game (
+	name "Gulclight TDF 2 (Japan) (Rev 2)"
+	description "Gulclight TDF 2 (Japan) (Rev 2)"
+	rom ( name "Gulclight TDF 2 (Japan) (Rev 2).cue" size 1647 crc a3434efb md5 324df186c6b7fbae121c3197afdb9904 sha1 558ad7f77831630761feb3a010d2cd1d037e3493 )
+)
+
+game (
+	name "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan)"
+	description "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan)"
+	rom ( name "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan).cue" size 1339 crc ce139e06 md5 3d599f9f207504fa8acbc9e657066847 sha1 5fc2f9ed207be8c0ba308a6c0e32a24b58f2a592 )
+)
+
+game (
+	name "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan) (Alt)"
+	description "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan) (Alt)"
+	rom ( name "Gyuwambler Jiko Chuushinha - Gekitou 36 Janshi (Japan) (Alt).cue" size 1399 crc 17f3d59c md5 684f0b2620662758fcd087aec0fe280c sha1 67cecdcc087a077a6f26b07aa03ad18964831cc5 )
+)
+
+game (
+	name "Gyuwambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan)"
+	description "Gyuwambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan)"
+	rom ( name "Gyuwambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan).cue" size 3022 crc 918079d7 md5 3e8a18a928903b275c33a99290dbc256 sha1 245192f3b3ab441c1aa463709bd61c41ece5c912 )
+)
+
+game (
+	name "Hataraku Shoujo - Tekipaki Working Love (Japan)"
+	description "Hataraku Shoujo - Tekipaki Working Love (Japan)"
+	rom ( name "Hataraku Shoujo - Tekipaki Working Love (Japan).cue" size 2459 crc 15bf9402 md5 441745d8c55d8bbd4e91ddcf28767c66 sha1 5d8ea3cc7a3d02c6e995d9a738a6f59dd6a9fb25 )
+)
+
+game (
+	name "Hatsukoi Monogatari (Japan) (HRTI20307)"
+	description "Hatsukoi Monogatari (Japan) (HRTI20307)"
+	rom ( name "Hatsukoi Monogatari (Japan) (HRTI20307).cue" size 734 crc 91807ab5 md5 3e258269a2235af3f705852c0b7b7b4e sha1 54cf0788ab6e62de34c3ce922898d009d2e54dab )
+)
+
+game (
+	name "Hatsukoi Monogatari (Japan) (HRTI20727)"
+	description "Hatsukoi Monogatari (Japan) (HRTI20727)"
+	rom ( name "Hatsukoi Monogatari (Japan) (HRTI20727).cue" size 734 crc 7feccb2b md5 b60c8bb38c01ab2ba7f99ad427ead6a0 sha1 2939b2cbef53ba531e450cd0c10c963cf6f4f18c )
+)
+
+game (
+	name "High Grenadier (Japan) (Rev 2)"
+	description "High Grenadier (Japan) (Rev 2)"
+	rom ( name "High Grenadier (Japan) (Rev 2).cue" size 1298 crc a8f225ca md5 fb372612f90ccfd0f5f5ba8dcc1c4d01 sha1 dde161fe8b16e65b9b95989bf9e5d3188f957c85 )
+)
+
+game (
+	name "Himitsu no Hanazono (Japan)"
+	description "Himitsu no Hanazono (Japan)"
+	rom ( name "Himitsu no Hanazono (Japan).cue" size 466 crc 7dc0aaf4 md5 1835229a8091df26f3fd10d0604e874d sha1 266a18e4e15e2715e64bdc0789d1eb35db17819a )
+)
+
+game (
+	name "Hokutosei no Onna - Nishimura Kyoutarou (Japan)"
+	description "Hokutosei no Onna - Nishimura Kyoutarou (Japan)"
+	rom ( name "Hokutosei no Onna - Nishimura Kyoutarou (Japan).cue" size 2816 crc db7c6a50 md5 449029d19400a28f9ed40536deac76c2 sha1 0c51f6c95b3d59f2649e6fdbd4c118bbf8cd536a )
+)
+
+game (
+	name "Horror Story (Japan)"
+	description "Horror Story (Japan)"
+	rom ( name "Horror Story (Japan).cue" size 1574 crc c142edf7 md5 e89a8beee37cfa4506c11362b392b1c3 sha1 697171a04804c4ea781b96a159fc125bf52c8e06 )
+)
+
+game (
+	name "Hu PGA Tour - PowerGolf 2 - Golfer (Japan)"
+	description "Hu PGA Tour - PowerGolf 2 - Golfer (Japan)"
+	rom ( name "Hu PGA Tour - PowerGolf 2 - Golfer (Japan).cue" size 1219 crc 64971bcf md5 8708d09aba94c69c1b4968acfc8e18a6 sha1 c51dae89a33a0edd1df4fab290b2dc4c3a750bfa )
+)
+
+game (
+	name "Human Sports Festival (Japan) (Rev 3)"
+	description "Human Sports Festival (Japan) (Rev 3)"
+	rom ( name "Human Sports Festival (Japan) (Rev 3).cue" size 2609 crc 4a1647e4 md5 5246521665928e2d0e03c294142cff03 sha1 09c97633036728d3719ceb0f809109fc803260a8 )
+)
+
+game (
+	name "Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan)"
+	description "Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan)"
+	rom ( name "Hyaku Monogatari - Honto ni Atta Kowai Hanashi (Japan).cue" size 3681 crc 420b06cf md5 b79a0e8b70482ae2e22f4f7dd32b4b75 sha1 e7de53eab6e75a2ad628d4b81752d0bfe3bc31ee )
+)
+
+game (
+	name "Hyper Wars (Japan)"
+	description "Hyper Wars (Japan)"
+	rom ( name "Hyper Wars (Japan).cue" size 1818 crc e64a6594 md5 345ddd412935aae850443bba39324218 sha1 4b62b31414262182b9d4758953fc719b8c69104a )
+)
+
+game (
+	name "Iga Ninden Gaiou (Japan)"
+	description "Iga Ninden Gaiou (Japan)"
+	rom ( name "Iga Ninden Gaiou (Japan).cue" size 3535 crc 29a0cecb md5 7e30ce49c071cb2cba3019928820e52f sha1 9ea37a8afb90158b077bf45cb57c26b9f9da9809 )
+)
+
+game (
+	name "ImageFight II - Operation Deepstriker (Japan)"
+	description "ImageFight II - Operation Deepstriker (Japan)"
+	rom ( name "ImageFight II - Operation Deepstriker (Japan).cue" size 3004 crc 8f8e70ee md5 a1cc661be36b6a0955af80fe1b911655 sha1 4efbe918865db3d7ebd74bd1707f8b52df823583 )
+)
+
+game (
+	name "In Magical Adventure - Fray CD - Xak Gaiden (Japan)"
+	description "In Magical Adventure - Fray CD - Xak Gaiden (Japan)"
+	rom ( name "In Magical Adventure - Fray CD - Xak Gaiden (Japan).cue" size 6990 crc 5345162a md5 2ac1ac951d6509bff8839823b3306d66 sha1 494de964519e1f61f3dba6f500cd699f71710d48 )
+)
+
+game (
+	name "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan)"
+	description "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan)"
+	rom ( name "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan).cue" size 1208 crc b3e2d147 md5 1a1fd70bf3e16bf016224cf08068bf88 sha1 2c6f6d8f1f5b5de290d155d8d8154fd24c3cf928 )
+)
+
+game (
+	name "IQ Panic (Japan) (Rev 3)"
+	description "IQ Panic (Japan) (Rev 3)"
+	rom ( name "IQ Panic (Japan) (Rev 3).cue" size 7658 crc f0976372 md5 a18a82eaf33ed02861ad549acf7aea10 sha1 c7c96240d9072a9c9cc859aa049e477781383415 )
+)
+
+game (
+	name "J. B. Harold Series #1 - Murder Club (Japan) (Rev 7)"
+	description "J. B. Harold Series #1 - Murder Club (Japan) (Rev 7)"
+	rom ( name "J. B. Harold Series #1 - Murder Club (Japan) (Rev 7).cue" size 1466 crc 4ffa222d md5 ab4f687e5833d643bc94284e349cfdb8 sha1 59215b7dbc9c94c5d4bcff72c2b3dba7ace987e6 )
+)
+
+game (
+	name "J. League Tremendous Soccer '94 (Japan)"
+	description "J. League Tremendous Soccer '94 (Japan)"
+	rom ( name "J. League Tremendous Soccer '94 (Japan).cue" size 2960 crc a0ab09c8 md5 51afcf23bf49d39ed7f350d245c9c5c7 sha1 994fd932b03d67b776fe0f62f24febbc9eae7ecc )
+)
+
+game (
+	name "Jack Nicklaus' World Tour Golf - 162 Holes (Japan) (Rev 2)"
+	description "Jack Nicklaus' World Tour Golf - 162 Holes (Japan) (Rev 2)"
+	rom ( name "Jack Nicklaus' World Tour Golf - 162 Holes (Japan) (Rev 2).cue" size 1532 crc 52a40a7a md5 a56c4eee36cfbf235de70a336041dcb9 sha1 20493dd701da418dd24c325beb90d741df5aebe7 )
+)
+
+game (
+	name "Jantei Monogatari (Japan)"
+	description "Jantei Monogatari (Japan)"
+	rom ( name "Jantei Monogatari (Japan).cue" size 531 crc e5eb11fe md5 2b59bfd0d393789f48c40ebf10c86b81 sha1 3b363eee89ae26119000425830f3f8c8c08ad184 )
+)
+
+game (
+	name "Jantei Monogatari 2 - Uchuu Tantei Diban - Kanketsu-hen (Japan)"
+	description "Jantei Monogatari 2 - Uchuu Tantei Diban - Kanketsu-hen (Japan)"
+	rom ( name "Jantei Monogatari 2 - Uchuu Tantei Diban - Kanketsu-hen (Japan).cue" size 772 crc 4280c1b0 md5 af9c9b1a127db9076087642cf0a042d8 sha1 3f7c5d8c4000aea154c1be5da59c1df252a88209 )
+)
+
+game (
+	name "Jantei Monogatari 2 - Uchuu Tantei Diban - Shutsudou-hen (Japan)"
+	description "Jantei Monogatari 2 - Uchuu Tantei Diban - Shutsudou-hen (Japan)"
+	rom ( name "Jantei Monogatari 2 - Uchuu Tantei Diban - Shutsudou-hen (Japan).cue" size 777 crc 3e4337ee md5 bd7b4e247e180d69a4f895f20fe01ff3 sha1 bed372ea1b9f2407b62a17a2fe26e5d78fec463f )
+)
+
+game (
+	name "Jantei Monogatari 3 - Saver Angels (Japan)"
+	description "Jantei Monogatari 3 - Saver Angels (Japan)"
+	rom ( name "Jantei Monogatari 3 - Saver Angels (Japan).cue" size 2126 crc 9b3bcb65 md5 53825263a11f6e78258c4614b02952c9 sha1 95f4d7115b85fd109f794c2cd4ce5b87187393a0 )
+)
+
+game (
+	name "Juuouki (Japan) (HA10109)"
+	description "Juuouki (Japan) (HA10109)"
+	rom ( name "Juuouki (Japan) (HA10109).cue" size 1049 crc df6affe8 md5 c709f899888f88136268ce8582152c91 sha1 136a1418f9c2cf2d85dfd2f13239b8f8a3aa37c6 )
+)
+
+game (
+	name "Juuouki (Japan) (HA10817)"
+	description "Juuouki (Japan) (HA10817)"
+	rom ( name "Juuouki (Japan) (HA10817).cue" size 915 crc e3880100 md5 01af39c34a3164577cb4661a9e1d24cf sha1 1d535189d53e33479d827f9fa80e5ca5b214df41 )
+)
+
+game (
+	name "Kagami no Kuni no Legend (Japan) (Rev 6)"
+	description "Kagami no Kuni no Legend (Japan) (Rev 6)"
+	rom ( name "Kagami no Kuni no Legend (Japan) (Rev 6).cue" size 879 crc 39255207 md5 65af3f06fe782efc8fd117ea3e9c8f17 sha1 33ebc50dee49682cf2e54ff64f33a523831b9151 )
+)
+
+game (
+	name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
+	description "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
+	rom ( name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan).cue" size 6805 crc ffc004fe md5 3a55f6f2796a0cc436d4e5efca946f69 sha1 11a73031ca7050943c7cd652fd08729e5bbf44ab )
+)
+
+game (
+	name "Kaze no Densetsu Xanadu (Japan) (Sample)"
+	description "Kaze no Densetsu Xanadu (Japan) (Sample)"
+	rom ( name "Kaze no Densetsu Xanadu (Japan) (Sample).cue" size 2006 crc dd8ffd19 md5 acfdaef8e71c8dc4a5d41e046bd05e96 sha1 1e19ec32840d768859ff5474075f32de8685db7d )
+)
+
+game (
+	name "Kiaidan 00 (Japan)"
+	description "Kiaidan 00 (Japan)"
+	rom ( name "Kiaidan 00 (Japan).cue" size 3381 crc 96856963 md5 fc64a6363a1049829b371ac8fe00de31 sha1 1e03ccd129c004004948e0ea99282f3d73255691 )
+)
+
+game (
+	name "Kick Boxing, The (Japan) (Rev 9)"
+	description "Kick Boxing, The (Japan) (Rev 9)"
+	rom ( name "Kick Boxing, The (Japan) (Rev 9).cue" size 1581 crc 6b4e69e8 md5 68c531398fac59fee9d871ef68c44d80 sha1 1e0112991f0ac4e997c689a40b23ed63786c6edf )
+)
+
+game (
+	name "Kisou Louga (Japan) (FABT)"
+	description "Kisou Louga (Japan) (FABT)"
+	rom ( name "Kisou Louga (Japan) (FABT).cue" size 2235 crc 714bc898 md5 adfa811da777c802a833b95a7229ae77 sha1 81dd8b937b5d34d7ba19c56bb9ac6e2b2c5c7a2d )
+)
+
+game (
+	name "Kisou Louga II - The Ends of Shangrila (Japan)"
+	description "Kisou Louga II - The Ends of Shangrila (Japan)"
+	rom ( name "Kisou Louga II - The Ends of Shangrila (Japan).cue" size 3878 crc dceff56e md5 33a75568b0b186832959b6bcf8462f4e sha1 99947ec29fed8bc85046cdd2d0795cf5c3e4c31a )
+)
+
+game (
+	name "KO Seiki Beast Sanjuushi - Gaia Fukkatsu Kanketsu-hen (Japan)"
+	description "KO Seiki Beast Sanjuushi - Gaia Fukkatsu Kanketsu-hen (Japan)"
+	rom ( name "KO Seiki Beast Sanjuushi - Gaia Fukkatsu Kanketsu-hen (Japan).cue" size 3693 crc bd1946f2 md5 f7d941ce2bdede611594fab5e381c620 sha1 607be659b9391ce2a78f8e9424c05f41dcea9ce6 )
+)
+
+game (
+	name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3)"
+	description "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3)"
+	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3).cue" size 1302 crc 95042c12 md5 b6cdbc1012b23f222b61057eef6bf49f sha1 722b6700d2a6b676ab08c3a5dbf3f44698f60fda )
+)
+
+game (
+	name "L-Dis (Japan) (Rev 6)"
+	description "L-Dis (Japan) (Rev 6)"
+	rom ( name "L-Dis (Japan) (Rev 6).cue" size 5405 crc f86fe378 md5 b46763bc7f41124887066f6da3dd94f2 sha1 dfa4d2533e4a6f524c6181457f6206932195bdd5 )
+)
+
+game (
+	name "Lady Phantom (Japan) (FABT)"
+	description "Lady Phantom (Japan) (FABT)"
+	rom ( name "Lady Phantom (Japan) (FABT).cue" size 5200 crc 1bdc7f6c md5 21d91be3a9649f916e75e3145088f02d sha1 67c2edc4582acbd1f738a725fdfb5dc1aa61a6e4 )
+)
+
+game (
+	name "Langrisser - Hikari no Matsuei (Japan)"
+	description "Langrisser - Hikari no Matsuei (Japan)"
+	rom ( name "Langrisser - Hikari no Matsuei (Japan).cue" size 4254 crc e4c8e677 md5 1ba0ada172e83fc17ecb83d420110100 sha1 ac801ef157993bbf5fa130e5f22551fe3271850f )
+)
+
+game (
+	name "Laplace no Ma (Japan) (Rev 3)"
+	description "Laplace no Ma (Japan) (Rev 3)"
+	rom ( name "Laplace no Ma (Japan) (Rev 3).cue" size 1516 crc 12e975b6 md5 4d65a6cd4badb0a756af9f6432af570e sha1 4c8e4e790c9d39a65d656f720538eca282f67068 )
+)
+
+game (
+	name "Last Armageddon (Japan) (Rev 6)"
+	description "Last Armageddon (Japan) (Rev 6)"
+	rom ( name "Last Armageddon (Japan) (Rev 6).cue" size 2059 crc f6b4d1fd md5 4d89ec837916388f1321dbdc19748cd5 sha1 91fe891c284a4a72cfe54d1c5d90fd7b3ed246d8 )
+)
+
+game (
+	name "Legend of Xanadu - Kaze no Densetsu Xanadu (Japan)"
+	description "Legend of Xanadu - Kaze no Densetsu Xanadu (Japan)"
+	rom ( name "Legend of Xanadu - Kaze no Densetsu Xanadu (Japan).cue" size 2176 crc dea17c4e md5 6ef9080dd8b2a78f82ded7a78dfcffa1 sha1 1091b393db45cfde9a3a870f78fadf90ec20098c )
+)
+
+game (
+	name "Legend of Xanadu - Kaze no Densetsu Xanadu II (Japan)"
+	description "Legend of Xanadu - Kaze no Densetsu Xanadu II (Japan)"
+	rom ( name "Legend of Xanadu - Kaze no Densetsu Xanadu II (Japan).cue" size 6102 crc e5bde173 md5 fce54007d3fc0724aa72f6034aa05cb4 sha1 fa7f8690da2ad837723c4596d82f80111c5557c1 )
+)
+
+game (
+	name "Linda^3 (Japan)"
+	description "Linda^3 (Japan)"
+	rom ( name "Linda^3 (Japan).cue" size 2510 crc f7c7328e md5 2a5d50c5c2151186b0f3b3abb432ae7e sha1 c7193263cbc4544505b45e89228475b33e0917d8 )
+)
+
+game (
+	name "Loom (Japan) (Rev 3)"
+	description "Loom (Japan) (Rev 3)"
+	rom ( name "Loom (Japan) (Rev 3).cue" size 2218 crc e4a0fe8b md5 f169cfc4326812a571f0b746630c3e50 sha1 08e0c188ea14ea8d803ac45beb6ef992ade070cc )
+)
+
+game (
+	name "Lord of Wars (Japan)"
+	description "Lord of Wars (Japan)"
+	rom ( name "Lord of Wars (Japan).cue" size 994 crc 3622b402 md5 91e2be8bec5b315c942cd13a6d1eada6 sha1 b7f7bd1fdb9a5a7fcbeac8067cebe4e7bf4c8569 )
+)
+
+game (
+	name "Lords of Thunder (USA)"
+	description "Lords of Thunder (USA)"
+	rom ( name "Lords of Thunder (USA).cue" size 2264 crc 21b7921d md5 6d3048fa92edbffb53fb278b3544000e sha1 97ba44a16452777d9d35a70e2e3f05b412680e3c )
+)
+
+game (
+	name "Madou Monogatari I - Honoo no Sotsuenji (Japan)"
+	description "Madou Monogatari I - Honoo no Sotsuenji (Japan)"
+	rom ( name "Madou Monogatari I - Honoo no Sotsuenji (Japan).cue" size 3910 crc 5193c66c md5 14e7b75231b223fa8a412ca92411817f sha1 311243fcdfc02494d8397f9cd44d27d6759f2828 )
+)
+
+game (
+	name "Magical Saurus Tour (Japan) (Rev 3)"
+	description "Magical Saurus Tour (Japan) (Rev 3)"
+	rom ( name "Magical Saurus Tour (Japan) (Rev 3).cue" size 526 crc 5d0a1bb3 md5 da2134540acada550ec513e030a06d49 sha1 ce4525d45e56dc3847c4480b3a148f00b2830c08 )
+)
+
+game (
+	name "Magicoal (Japan)"
+	description "Magicoal (Japan)"
+	rom ( name "Magicoal (Japan).cue" size 2714 crc 5f23f966 md5 a4df187260a031af216e841b97664cc0 sha1 c71954430b0d39b6fe7547ab2fdcab9518d63506 )
+)
+
+game (
+	name "Mahjong Lemon Angel (Japan)"
+	description "Mahjong Lemon Angel (Japan)"
+	rom ( name "Mahjong Lemon Angel (Japan).cue" size 8296 crc 6f54e3ed md5 1545bf28a19b73e80f0e418a171b856b sha1 1df872ca0e18e899b4d5b5d17d69c5678a98acfb )
+)
+
+game (
+	name "Mahjong Vanilla Syndrome (Japan)"
+	description "Mahjong Vanilla Syndrome (Japan)"
+	rom ( name "Mahjong Vanilla Syndrome (Japan).cue" size 8110 crc 4bf393c2 md5 782e964c1e0e777a56ac24d81435eb2d sha1 dfa90ccfd1c3e5f977eb7a7f01b4f3655807b9f4 )
+)
+
+game (
+	name "Mahjong Vanilla Syndrome (Japan) (Alt)"
+	description "Mahjong Vanilla Syndrome (Japan) (Alt)"
+	rom ( name "Mahjong Vanilla Syndrome (Japan) (Alt).cue" size 8572 crc c91f457c md5 00ce41c9ffb05a659f8d7a8bee3be93f sha1 3bf6aee6792acd31ad2531d24263ce22165207f4 )
+)
+
+game (
+	name "Manhole, The (Japan)"
+	description "Manhole, The (Japan)"
+	rom ( name "Manhole, The (Japan).cue" size 3414 crc e0e87ac8 md5 e6176bfb94fe9d8c7f7da4a48b143cff sha1 4601dd264da00e1ee0bdc98ae3c29ea1d6cf4699 )
+)
+
+game (
+	name "Mashou Denki - La Valeur (Japan) (Rev 4)"
+	description "Mashou Denki - La Valeur (Japan) (Rev 4)"
+	rom ( name "Mashou Denki - La Valeur (Japan) (Rev 4).cue" size 2790 crc 611e78ea md5 3b2fc3a6eb5f7e2a292e3ac0f456ec00 sha1 d7f30afa2eeb421e3626213292803493299b6f81 )
+)
+
+game (
+	name "Master of Monsters (Japan)"
+	description "Master of Monsters (Japan)"
+	rom ( name "Master of Monsters (Japan).cue" size 536 crc 9ff713e5 md5 23191a9f656ea447eb84d9f06a4059ed sha1 f6d2776c03070468263b8de7c24efcac1c99da0b )
+)
+
+game (
+	name "Mateki Densetsu Astralius (Japan)"
+	description "Mateki Densetsu Astralius (Japan)"
+	rom ( name "Mateki Densetsu Astralius (Japan).cue" size 5009 crc 73fac4b5 md5 26dbf7ea8de90b7d29002e82615907ea sha1 ff9a06991c3be99d8e4f855577f823b933957ce1 )
+)
+
+game (
+	name "Megami Paradise (Japan)"
+	description "Megami Paradise (Japan)"
+	rom ( name "Megami Paradise (Japan).cue" size 4187 crc 0b754bd7 md5 59c80ea63dd19af2fef59f1593a7e545 sha1 dde4a9caa000fc7f7f21f404f2b419c0e8218b30 )
+)
+
+game (
+	name "Metal Angel (Japan) (Rev 1)"
+	description "Metal Angel (Japan) (Rev 1)"
+	rom ( name "Metal Angel (Japan) (Rev 1).cue" size 1191 crc 8ed11b0b md5 c9b8d6b19668af74f50a459122e697ff sha1 2e80f6b9d17ca94bdc771ab1b999c48ef1209296 )
+)
+
+game (
+	name "Might and Magic (Japan)"
+	description "Might and Magic (Japan)"
+	rom ( name "Might and Magic (Japan).cue" size 1147 crc ff7ec5fa md5 068a30848882baaefc41c0c44fd2bbf0 sha1 50e6aca311eaee9dbd12ff710f68fe48af8abac1 )
+)
+
+game (
+	name "Might and Magic III - Isles of Terra (Japan)"
+	description "Might and Magic III - Isles of Terra (Japan)"
+	rom ( name "Might and Magic III - Isles of Terra (Japan).cue" size 1958 crc 3755288c md5 e1dc36e4c8e01cd40393b7e86fa4c805 sha1 c96825247a7731af8134cde730f05f7a15b082cb )
+)
+
+game (
+	name "Minesweeper (Japan) (Rev 1)"
+	description "Minesweeper (Japan) (Rev 1)"
+	rom ( name "Minesweeper (Japan) (Rev 1).cue" size 2450 crc 20641c7c md5 86ba5a24fbff5305021a7a26cf931a2a sha1 28f2ad8f0ff94ceab89b2c95a8a0cec23728e076 )
+)
+
+game (
+	name "Mirai Shounen Conan (Japan)"
+	description "Mirai Shounen Conan (Japan)"
+	rom ( name "Mirai Shounen Conan (Japan).cue" size 5717 crc d7889763 md5 f5ae0b1568d9ff5eea77e1f61ee07f74 sha1 4d60ae05a53f2ef98669067df39206b29be19404 )
+)
+
+game (
+	name "Mitsubachi Gakuen (Japan)"
+	description "Mitsubachi Gakuen (Japan)"
+	rom ( name "Mitsubachi Gakuen (Japan).cue" size 1437 crc fc27e1bb md5 f3ff2be726cdb4f370201476a5967b8b sha1 522db7daff965d160d80f1358672a534c6cc652d )
+)
+
+game (
+	name "Monster Maker - Yami no Ryuukishi (Japan)"
+	description "Monster Maker - Yami no Ryuukishi (Japan)"
+	rom ( name "Monster Maker - Yami no Ryuukishi (Japan).cue" size 4057 crc 9407db4f md5 86e767fe0d2dd30c4a677c56da2b7db2 sha1 bcb2b3c6a6724d2975fc43ff047f4bd9c654c680 )
+)
+
+game (
+	name "Monster Maker - Yami no Ryuukishi (Japan) (Alt)"
+	description "Monster Maker - Yami no Ryuukishi (Japan) (Alt)"
+	rom ( name "Monster Maker - Yami no Ryuukishi (Japan) (Alt).cue" size 4267 crc 4143f3fb md5 f2d13a8131610655ac3b3ad8bd562e40 sha1 2918e7216f06f07e5d74eb3a7f8d22d4b8443e05 )
+)
+
+game (
+	name "Moonlight Lady (Japan)"
+	description "Moonlight Lady (Japan)"
+	rom ( name "Moonlight Lady (Japan).cue" size 4614 crc d915ccea md5 b0c11fea871677ac012ba353255cd1ba sha1 c84db150a3174efe4548ba1b3f7c7d2132149d87 )
+)
+
+game (
+	name "Motteke Tamago (Japan)"
+	description "Motteke Tamago (Japan)"
+	rom ( name "Motteke Tamago (Japan).cue" size 939 crc 74741fe0 md5 337f4e153e864a1ccd653b8800aa76a9 sha1 a2b3a73f35381f5ca23baab2ebc2fa1e842f0b15 )
+)
+
+game (
+	name "Mugen Senshi Valis - The Legend of a Fantasm Soldier (Japan)"
+	description "Mugen Senshi Valis - The Legend of a Fantasm Soldier (Japan)"
+	rom ( name "Mugen Senshi Valis - The Legend of a Fantasm Soldier (Japan).cue" size 3902 crc d2257f54 md5 1dff437d5b0cc6a3861b7554322f5839 sha1 e6a2a8a04bb6db99eaf8d1799385cb75ec9a4b77 )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan)"
+	description "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan)"
+	rom ( name "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan).cue" size 7046 crc 90b24990 md5 01725cb8bd6de25e50a807a5df2d8d3c sha1 85d26f26ff5bbec57d4a77ab6c0604c95140bb0a )
+)
+
+game (
+	name "Nemurenu Yoru no Chiisana Ohanashi (Japan)"
+	description "Nemurenu Yoru no Chiisana Ohanashi (Japan)"
+	rom ( name "Nemurenu Yoru no Chiisana Ohanashi (Japan).cue" size 7991 crc ca2de754 md5 f1d5dab8106cfd29c5c54bbcab94d580 sha1 7514a7a8f1d2b90a53c9951224a8032082c34124 )
+)
+
+game (
+	name "Neo Nectaris (Japan) (Rev 3)"
+	description "Neo Nectaris (Japan) (Rev 3)"
+	rom ( name "Neo Nectaris (Japan) (Rev 3).cue" size 3202 crc d79a1fb8 md5 066dc041b8f9d448fbdcc7c03c2a9334 sha1 64d735bd079146493b7594f41cf33ff2e80cb301 )
+)
+
+game (
+	name "NEXZR (Japan) (Rev 2)"
+	description "NEXZR (Japan) (Rev 2)"
+	rom ( name "NEXZR (Japan) (Rev 2).cue" size 2241 crc 21380ff1 md5 5db9f217ff8b9bd85a5cc3adf7136e14 sha1 d1158dc005d7e611bea587738b3906c5457f16a7 )
+)
+
+game (
+	name "No-Ri-Ko (Japan)"
+	description "No-Ri-Ko (Japan)"
+	rom ( name "No-Ri-Ko (Japan).cue" size 8703 crc 90cc2a57 md5 b3cb106796f7666937194ae4680f465e sha1 8484dd1f21fe54a17d683425cf1c131e8ca056ce )
+)
+
+game (
+	name "Nobunaga no Yabou - Zenkokuban (Japan)"
+	description "Nobunaga no Yabou - Zenkokuban (Japan)"
+	rom ( name "Nobunaga no Yabou - Zenkokuban (Japan).cue" size 1083 crc b0b8c043 md5 439bf7caecad3ce4f9e01427d2e33f4b sha1 0ad5ac658c506fe1402d3e396d0d7500200fab1b )
+)
+
+game (
+	name "Ookami-teki Monshou - Crest of Wolf (Japan)"
+	description "Ookami-teki Monshou - Crest of Wolf (Japan)"
+	rom ( name "Ookami-teki Monshou - Crest of Wolf (Japan).cue" size 2839 crc 724b5431 md5 7a417e20d41e743dd36f06eb2bb60668 sha1 d55464af05f7fcd84bc500022696009cd50a67c1 )
+)
+
+game (
+	name "Pachio-kun - Maboroshi no Densetsu (Japan)"
+	description "Pachio-kun - Maboroshi no Densetsu (Japan)"
+	rom ( name "Pachio-kun - Maboroshi no Densetsu (Japan).cue" size 5432 crc f38d7340 md5 2c51dcc07947c6fbba53b883440f0252 sha1 699a097650a5234ee6cd0fa86c5b3cf834b4a3bc )
+)
+
+game (
+	name "Pachio-kun - Warau Uchuu (Japan)"
+	description "Pachio-kun - Warau Uchuu (Japan)"
+	rom ( name "Pachio-kun - Warau Uchuu (Japan).cue" size 2910 crc a2af02ed md5 2764f7856e45a756699cd55dca49cac1 sha1 e237db26220143393d00998595c92f94f182c84a )
+)
+
+game (
+	name "Pachio-kun 3 - Pachi-Slot & Pachinko (Japan)"
+	description "Pachio-kun 3 - Pachi-Slot & Pachinko (Japan)"
+	rom ( name "Pachio-kun 3 - Pachi-Slot & Pachinko (Japan).cue" size 2654 crc 7987368f md5 9cb2a847ef16a746bdd6f41fe588cd5d sha1 017c1f3c2b5771fe2eec0490279c905aa9da2258 )
+)
+
+game (
+	name "Palladion - Auto Crusher Palladium (Japan)"
+	description "Palladion - Auto Crusher Palladium (Japan)"
+	rom ( name "Palladion - Auto Crusher Palladium (Japan).cue" size 2154 crc 68b401e4 md5 46ee8ccf10054625f39106e9a62f19ee sha1 2382cdc6cf820bfbddb940a763f210807418b37e )
+)
+
+game (
+	name "Pastel Lime (Japan)"
+	description "Pastel Lime (Japan)"
+	rom ( name "Pastel Lime (Japan).cue" size 1871 crc 143a144b md5 9383db43c4d0cfbd2bfe08331f4a14fb sha1 1ca81a6b8b043e0877751b842fa1cdf093ab48f7 )
+)
+
+game (
+	name "Patlabor - Chapter of Griffon (Japan) (Rev 1)"
+	description "Patlabor - Chapter of Griffon (Japan) (Rev 1)"
+	rom ( name "Patlabor - Chapter of Griffon (Japan) (Rev 1).cue" size 4899 crc f8a28aae md5 f1bc76ef3153d112707b8323afffc63c sha1 acee426643491c2d0cd50da3544726fdf98bc47e )
+)
+
+game (
+	name "Pomping World (Japan) (Rev 1)"
+	description "Pomping World (Japan) (Rev 1)"
+	rom ( name "Pomping World (Japan) (Rev 1).cue" size 2526 crc 2236f4e5 md5 5df5cd3146869a1f7ecd567613767b05 sha1 d17f402a0bff0e01aeacbe0d627f8bcb66330116 )
+)
+
+game (
+	name "Populous - The Promised Lands (Japan) (Rev 3)"
+	description "Populous - The Promised Lands (Japan) (Rev 3)"
+	rom ( name "Populous - The Promised Lands (Japan) (Rev 3).cue" size 1740 crc 914deaeb md5 6e3fd245d96a07319ae4b5223fdc2284 sha1 bb1690c9ee5307cd37934a095fb20030a70e6de0 )
+)
+
+game (
+	name "Prince of Persia (Japan)"
+	description "Prince of Persia (Japan)"
+	rom ( name "Prince of Persia (Japan).cue" size 1926 crc 593ba47d md5 b35cb4ea1b48d2da599ce93a2e6479c6 sha1 0c94bd5be83593b7f1db7e3e592fc94cc6d52a92 )
+)
+
+game (
+	name "Princess Maker 1 (Japan)"
+	description "Princess Maker 1 (Japan)"
+	rom ( name "Princess Maker 1 (Japan).cue" size 5094 crc 7de946e5 md5 140053ab9de0c92ff68d94883636e0be sha1 640358eb34c93a8f90dc6fb88da15af5116d4e38 )
+)
+
+game (
+	name "Princess Maker 2 (Japan)"
+	description "Princess Maker 2 (Japan)"
+	rom ( name "Princess Maker 2 (Japan).cue" size 2186 crc 33c1ae01 md5 fa06214077ed0eb14790b573c8b9e796 sha1 d9a8881e5a14432fff97e6fcb8c3a712663706d4 )
+)
+
+game (
+	name "Princess Minerva (Japan)"
+	description "Princess Minerva (Japan)"
+	rom ( name "Princess Minerva (Japan).cue" size 2666 crc d388e9e9 md5 b1432317e4ed375a9601c34c6f06411a sha1 6d0fa094dc7ba2031485da6c4c8c08dedd3a460b )
+)
+
+game (
+	name "Private Eye dol (Japan)"
+	description "Private Eye dol (Japan)"
+	rom ( name "Private Eye dol (Japan).cue" size 2449 crc 7b76f470 md5 9f2aff8d7ffef473307f733c21d574f1 sha1 50123ee0ee73248f68fb0cb5cf89c03c623d29d0 )
+)
+
+game (
+	name "Pro Yakyuu Super, The (Japan) (FABT)"
+	description "Pro Yakyuu Super, The (Japan) (FABT)"
+	rom ( name "Pro Yakyuu Super, The (Japan) (FABT).cue" size 3211 crc 7659c3d0 md5 b96b458976eca33e67de29a3cdd3203a sha1 74bfa3e171b9cc1699e3d968be52f0ad3fdcb61d )
+)
+
+game (
+	name "Pro Yakyuu, The (Japan)"
+	description "Pro Yakyuu, The (Japan)"
+	rom ( name "Pro Yakyuu, The (Japan).cue" size 2074 crc 400ff63d md5 ec457b67201b4595cdeac943db39019b sha1 21e65b4bad2b5ff28c8cda5739f184ce45d71451 )
+)
+
+game (
+	name "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1)"
+	description "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1)"
+	rom ( name "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1).cue" size 1218 crc efa66054 md5 a772c3653cffd1335d314437d66aced2 sha1 6733589553dd964de805a50c040cb65677ba5274 )
+)
+
+game (
+	name "Psychic Storm (Japan)"
+	description "Psychic Storm (Japan)"
+	rom ( name "Psychic Storm (Japan).cue" size 2427 crc 1c772037 md5 8e3b644026d0da25fd80fd321669da56 sha1 0a333993d2204c81be0e48bffce0b9385868b8be )
+)
+
+game (
+	name "Puyo Puyo CD (Japan)"
+	description "Puyo Puyo CD (Japan)"
+	rom ( name "Puyo Puyo CD (Japan).cue" size 3506 crc 7773aa51 md5 858e5d2a3f78c509475a4bb2d20fe4c9 sha1 99b133283d53cd50968e28581243532e83a96cb3 )
+)
+
+game (
+	name "Puyo Puyo CD Tsuu (Japan)"
+	description "Puyo Puyo CD Tsuu (Japan)"
+	rom ( name "Puyo Puyo CD Tsuu (Japan).cue" size 7959 crc fcf274fa md5 2f25b730ffc6b3141300fb4029a96baf sha1 04c24257154acfa9888263e70a6bc845706668f1 )
+)
+
+game (
+	name "Quest of Jongmaster - Janshin Densetsu (Japan)"
+	description "Quest of Jongmaster - Janshin Densetsu (Japan)"
+	rom ( name "Quest of Jongmaster - Janshin Densetsu (Japan).cue" size 3378 crc e011c64f md5 7951f43815a9b21caf72efd4a94c41cd sha1 487c83458ee4dc4b725d28a65084ae18825d7938 )
+)
+
+game (
+	name "Quiz Avenue (Japan)"
+	description "Quiz Avenue (Japan)"
+	rom ( name "Quiz Avenue (Japan).cue" size 709 crc de9a848b md5 315f474292f61dfffdc44de91438a40c sha1 5fe6aa12cb55c4a0109d3e8f5dce91b8651cfbf1 )
+)
+
+game (
+	name "Quiz Avenue II (Japan)"
+	description "Quiz Avenue II (Japan)"
+	rom ( name "Quiz Avenue II (Japan).cue" size 846 crc eba0c070 md5 e05ced31e9a96c90c254383eb61370ad sha1 ff2f988bab39c6bdfdbffdf28994a93bfa07b8fc )
+)
+
+game (
+	name "Quiz Caravan Cult Q (Japan) (Rev 4)"
+	description "Quiz Caravan Cult Q (Japan) (Rev 4)"
+	rom ( name "Quiz Caravan Cult Q (Japan) (Rev 4).cue" size 3712 crc e91f295e md5 fdb19709aa2bbebd751cd7152ad442dd sha1 00d7366e8b34199aff3d958d272f3e23618f8fb4 )
+)
+
+game (
+	name "Quiz de Gakuensai (Japan)"
+	description "Quiz de Gakuensai (Japan)"
+	rom ( name "Quiz de Gakuensai (Japan).cue" size 7474 crc fc9d051f md5 c2925142f447b8460a2834b8b2648aa2 sha1 2b5c4beff27d4d43251a6efc39213d78eed4238b )
+)
+
+game (
+	name "Quiz Marugoto the World (Japan) (Rev 7)"
+	description "Quiz Marugoto the World (Japan) (Rev 7)"
+	rom ( name "Quiz Marugoto the World (Japan) (Rev 7).cue" size 2516 crc 4b829e12 md5 38cf12fcd702aca047348a63648563d4 sha1 e145cdccdf9eb213710baa24053ded63a049d465 )
+)
+
+game (
+	name "Quiz Marugoto the World (Japan) (Rev 8)"
+	description "Quiz Marugoto the World (Japan) (Rev 8)"
+	rom ( name "Quiz Marugoto the World (Japan) (Rev 8).cue" size 2516 crc 334f4645 md5 b3689ca344b867a58261cbd5189129b1 sha1 3f57da3cfc8e6fa90219ccffb8b97f01630d7143 )
+)
+
+game (
+	name "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan)"
+	description "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan)"
+	rom ( name "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan).cue" size 5553 crc 57d515ae md5 9e9b64fc5d1adebd65c32ef2443fc310 sha1 2627240ef2dfaaa29e740b40a71d2ed3dc13b167 )
+)
+
+game (
+	name "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5)"
+	description "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5)"
+	rom ( name "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5).cue" size 5206 crc 41cb147f md5 ddf81a2f80cefdb8f345189264dc89c2 sha1 957df35246fed795a7a7ba2941a2d8f33415fa5b )
+)
+
+game (
+	name "Quiz Tonosama no Yabou (Japan)"
+	description "Quiz Tonosama no Yabou (Japan)"
+	rom ( name "Quiz Tonosama no Yabou (Japan).cue" size 3774 crc 0568a525 md5 5eb7c0e53ca3fd2b715d54b7624c1e55 sha1 bda27a5170fd5453a51a609f21d5b2509a755061 )
+)
+
+game (
+	name "R-Type Complete CD (Japan) (Rev 1)"
+	description "R-Type Complete CD (Japan) (Rev 1)"
+	rom ( name "R-Type Complete CD (Japan) (Rev 1).cue" size 4978 crc b15a4ef7 md5 ecb1fc6cb6d5b1ae1fdfccffc27fa0cd sha1 09a4f66cbf217ef57947ac6249158ec32fff9812 )
+)
+
+game (
+	name "Rally Championship (Japan) (FABT)"
+	description "Rally Championship (Japan) (FABT)"
+	rom ( name "Rally Championship (Japan) (FABT).cue" size 1129 crc 05b47e26 md5 4dc03965e56a8fab06a7821e7124ec3c sha1 c0ae94e831d42151bc088f10c21186a1009fa7a8 )
+)
+
+game (
+	name "Ranma 1-2 - Datou, Ganso Musabetsu Kakutou-ryuu! (Japan) (Rev 3)"
+	description "Ranma 1-2 - Datou, Ganso Musabetsu Kakutou-ryuu! (Japan) (Rev 3)"
+	rom ( name "Ranma 1-2 - Datou, Ganso Musabetsu Kakutou-ryuu! (Japan) (Rev 3).cue" size 9866 crc f4114f4e md5 f8ccad063e9ed35feee6f9ba5b7aca8c sha1 2732b9dd5fbc8f266333682f75c7515dc90929e8 )
+)
+
+game (
+	name "Ranma 1-2 - Toraware no Hanayome (Japan) (Rev 2)"
+	description "Ranma 1-2 - Toraware no Hanayome (Japan) (Rev 2)"
+	rom ( name "Ranma 1-2 - Toraware no Hanayome (Japan) (Rev 2).cue" size 4514 crc 7d339d56 md5 b61c94b84b3f2ee4dec1cd2b6c63f7cb sha1 ea72971cd3bbe3e68bbaf95cf9152786801303c4 )
+)
+
+game (
+	name "Ranma 1-2 (Japan) (Rev 4)"
+	description "Ranma 1-2 (Japan) (Rev 4)"
+	rom ( name "Ranma 1-2 (Japan) (Rev 4).cue" size 5409 crc cf668f88 md5 3e14c239398541ad1e74bf6be618db8f sha1 273fd2277a9f8338a21f6e13e49f8f37362cf9af )
+)
+
+game (
+	name "Rayxanber II (Japan) (Rev 3)"
+	description "Rayxanber II (Japan) (Rev 3)"
+	rom ( name "Rayxanber II (Japan) (Rev 3).cue" size 1702 crc 6b452412 md5 70efaa31556137301882192975dbe693 sha1 02da58d9525d7ec2931a0b695f9f42a215a34cbc )
+)
+
+game (
+	name "Record of Lodoss War (Japan) (Rev 2)"
+	description "Record of Lodoss War (Japan) (Rev 2)"
+	rom ( name "Record of Lodoss War (Japan) (Rev 2).cue" size 744 crc a737a9ed md5 b0ad51711b02032ddce123138750a8b0 sha1 19391cf80e44507677435ac3831e9162b420ac4b )
+)
+
+game (
+	name "Record of Lodoss War II (Japan) (Rev 2)"
+	description "Record of Lodoss War II (Japan) (Rev 2)"
+	rom ( name "Record of Lodoss War II (Japan) (Rev 2).cue" size 1323 crc bcd98112 md5 21a88f802f31758431b1b5a6ef24c84a sha1 a0b1c10b2b42aa50eeaaa7568cb8e669e6c10ba6 )
+)
+
+game (
+	name "Record of Lodoss War II (Japan) (Sample)"
+	description "Record of Lodoss War II (Japan) (Sample)"
+	rom ( name "Record of Lodoss War II (Japan) (Sample).cue" size 1334 crc d81d6854 md5 d3113118fa0d57dd163eb2eca89edc07 sha1 e132a2403f93a0c9e266a8c49c8a990ff687fa42 )
+)
+
+game (
+	name "Red Alert (Japan) (Rev 3)"
+	description "Red Alert (Japan) (Rev 3)"
+	rom ( name "Red Alert (Japan) (Rev 3).cue" size 5700 crc e3d06737 md5 16b1026c20254e12806bf07db5d0f82d sha1 d5226fed0a56dea14fdc7461657ed50a49f196f8 )
+)
+
+game (
+	name "Rising Sun (Japan) (Rev 3)"
+	description "Rising Sun (Japan) (Rev 3)"
+	rom ( name "Rising Sun (Japan) (Rev 3).cue" size 5268 crc b0edcd6f md5 45131841c89e21a33374c4ef862f7602 sha1 981327aebc712529a3e914d7c3c558979a903f73 )
+)
+
+game (
+	name "Road Spirits (Japan) (Rev 2)"
+	description "Road Spirits (Japan) (Rev 2)"
+	rom ( name "Road Spirits (Japan) (Rev 2).cue" size 2202 crc b2ccddeb md5 8548c4331dd01f8e0f9fb3746d1cf5c0 sha1 ea8c18832f513f990febab6047e2bf8c23e06711 )
+)
+
+game (
+	name "ROM ROM Stadium (Japan) (Rev 3)"
+	description "ROM ROM Stadium (Japan) (Rev 3)"
+	rom ( name "ROM ROM Stadium (Japan) (Rev 3).cue" size 1722 crc 9b8bfec3 md5 421c6634f7b30f778dd98f52f10bc727 sha1 dcd7f30f543d14228d9d34eeddcd99a0d65c24ae )
+)
+
+game (
+	name "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT)"
+	description "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT)"
+	rom ( name "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT).cue" size 4293 crc 50dffde3 md5 d78a5009974e8616665a7c89568c4619 sha1 11bff73c7eb2f4e1c35883df862d4d70cd9ded96 )
+)
+
+game (
+	name "Sangokushi - Eiketsu Tenka ni Nozomu (Japan) (Rev 5)"
+	description "Sangokushi - Eiketsu Tenka ni Nozomu (Japan) (Rev 5)"
+	rom ( name "Sangokushi - Eiketsu Tenka ni Nozomu (Japan) (Rev 5).cue" size 9278 crc 69c0729a md5 7fa6780c96efa293577aaa155e37943a sha1 a4b4bbb111b269e9361966f353ecd2f58262d922 )
+)
+
+game (
+	name "Sangokushi III (Japan)"
+	description "Sangokushi III (Japan)"
+	rom ( name "Sangokushi III (Japan).cue" size 2899 crc 2215d87c md5 0d2992fac145206339bb0228377065e2 sha1 f9193b7fa4169456e07c9f6b4de49aa65c1d0b20 )
+)
+
+game (
+	name "Seirei Senshi Spriggan (Japan)"
+	description "Seirei Senshi Spriggan (Japan)"
+	rom ( name "Seirei Senshi Spriggan (Japan).cue" size 2856 crc c9e4556c md5 11894de1a875670a71e1506db5244822 sha1 bc6b59bc688e25e82c2b8025ecd744f8485a655b )
+)
+
+game (
+	name "Seiryuu Densetsu - Monbit (Japan) (Rev 1)"
+	description "Seiryuu Densetsu - Monbit (Japan) (Rev 1)"
+	rom ( name "Seiryuu Densetsu - Monbit (Japan) (Rev 1).cue" size 662 crc 41ff0687 md5 ab7a9504d0134c4233ed8cfb03fb540c sha1 7bec2e063d6667a7f4be41eb9d4784f8990bb151 )
+)
+
+game (
+	name "Seiryuu Densetsu - Monbit (Japan) (Rev 4)"
+	description "Seiryuu Densetsu - Monbit (Japan) (Rev 4)"
+	rom ( name "Seiryuu Densetsu - Monbit (Japan) (Rev 4).cue" size 662 crc 84b2e324 md5 41d8a446914c39ffa3556dcd5ec9a7a7 sha1 229ce341c652d05242c81b16169cb7b31f0ef398 )
+)
+
+game (
+	name "Sengoku Kantou Sangokushi (Japan)"
+	description "Sengoku Kantou Sangokushi (Japan)"
+	rom ( name "Sengoku Kantou Sangokushi (Japan).cue" size 7977 crc d952d762 md5 938e14b2af30ccfd48a9d3b03bbbb407 sha1 f323d10ffcfdbb7d9fc3752229bde6f2d51be020 )
+)
+
+game (
+	name "Sexy Idol Mahjong - Fashion Monogatari (Japan)"
+	description "Sexy Idol Mahjong - Fashion Monogatari (Japan)"
+	rom ( name "Sexy Idol Mahjong - Fashion Monogatari (Japan).cue" size 3619 crc 25c53c0b md5 8d18c3c9fa2fd3b02e61b9f70eff8820 sha1 ebea6759ff3832c157e15d81e0562fece93a4a8f )
+)
+
+game (
+	name "Sexy Idol Mahjong - Yakyuuken no Uta (Japan)"
+	description "Sexy Idol Mahjong - Yakyuuken no Uta (Japan)"
+	rom ( name "Sexy Idol Mahjong - Yakyuuken no Uta (Japan).cue" size 3118 crc 844de591 md5 97f049f9cde8c918205ceb3d23fe4af7 sha1 dc97c81408bfea9ba889d37b3817d811b3cb4a5c )
+)
+
+game (
+	name "Sexy Idol Mahjong (Japan)"
+	description "Sexy Idol Mahjong (Japan)"
+	rom ( name "Sexy Idol Mahjong (Japan).cue" size 2139 crc 4bd7142e md5 05b695bfcc33ddcc0ff5f941f1c81bcb sha1 37abf91a7112c35385092d841e908eef749ee26c )
+)
+
+game (
+	name "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1)"
+	description "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1)"
+	rom ( name "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1).cue" size 1352 crc b4793056 md5 94b3498ea0b9ecf92a55b76687aadfd8 sha1 f36c7563cd5a04bf8a3e9f671671fde88ea3c3dd )
+)
+
+game (
+	name "Shanghai II (Japan) (Rev 2)"
+	description "Shanghai II (Japan) (Rev 2)"
+	rom ( name "Shanghai II (Japan) (Rev 2).cue" size 1389 crc d95369e1 md5 db588aed21fbb2b664507bed7ca62c60 sha1 e21acec3b7ab1620e1a72f5e53684cedccc170b8 )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective (Japan) (Rev 4)"
+	description "Sherlock Holmes - Consulting Detective (Japan) (Rev 4)"
+	rom ( name "Sherlock Holmes - Consulting Detective (Japan) (Rev 4).cue" size 143 crc 98cad491 md5 380b235403d55a08fa96c67f5e0febd9 sha1 53f41074c179262f5222779bc23f8445559fe5bf )
+)
+
+game (
+	name "Sherlock Holmes - Consulting Detective Vol. II (Japan)"
+	description "Sherlock Holmes - Consulting Detective Vol. II (Japan)"
+	rom ( name "Sherlock Holmes - Consulting Detective Vol. II (Japan).cue" size 143 crc 17f988ac md5 38b76137f1adb926f24cd54a27692d53 sha1 be924df00cc6fcc1f7234c5c79a676b7eae5f5b6 )
+)
+
+game (
+	name "Shin Megami Tensei (Japan)"
+	description "Shin Megami Tensei (Japan)"
+	rom ( name "Shin Megami Tensei (Japan).cue" size 1642 crc eb2a066d md5 77cef5a07b14fd88dd3ad4e91e32e02d sha1 ca8b20cdb5cd386ad7e7a67c4cd0d1a91ef312ee )
+)
+
+game (
+	name "Shin Nihon Pro Wrestling - '94 Battlefield in Tokyo Dome (Japan)"
+	description "Shin Nihon Pro Wrestling - '94 Battlefield in Tokyo Dome (Japan)"
+	rom ( name "Shin Nihon Pro Wrestling - '94 Battlefield in Tokyo Dome (Japan).cue" size 4290 crc d087fb43 md5 eacb252857a1910d01871652ef361f13 sha1 3d8305229e61033cb552c2ac8ba5f837dea4f90e )
+)
+
+game (
+	name "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl)"
+	description "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl)"
+	rom ( name "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl).cue" size 1707 crc b25ac230 md5 7dd0778a9f13fcf406605003c9e8fa14 sha1 bb0f98db4e10a2ea37a9ab806a798c46516dc52a )
+)
+
+game (
+	name "SimEarth - The Living Planet (Japan)"
+	description "SimEarth - The Living Planet (Japan)"
+	rom ( name "SimEarth - The Living Planet (Japan).cue" size 3882 crc 561f4f07 md5 7bc802534560d2118777baf8511fd761 sha1 8298ce6a81207afcccbf69d041d7b082f91ed7b9 )
+)
+
+game (
+	name "Snatcher CD-ROMantic - Pilot Disk (Japan)"
+	description "Snatcher CD-ROMantic - Pilot Disk (Japan)"
+	rom ( name "Snatcher CD-ROMantic - Pilot Disk (Japan).cue" size 3944 crc d63d2d8a md5 c27c711f0a4bd2dc5e9b0ebf3ba43366 sha1 d985965d7fc838ed91136618637f01493e1053f6 )
+)
+
+game (
+	name "Snatcher CD-ROMantic (Japan)"
+	description "Snatcher CD-ROMantic (Japan)"
+	rom ( name "Snatcher CD-ROMantic (Japan).cue" size 2502 crc 922a190e md5 0ebc8178d69488000db3b0b845120906 sha1 40c91a0873ba05e4caf2fe2917b0a5f7fa9d1175 )
+)
+
+game (
+	name "Sol Bianca (Japan) (Rev 8)"
+	description "Sol Bianca (Japan) (Rev 8)"
+	rom ( name "Sol Bianca (Japan) (Rev 8).cue" size 9914 crc 1e6c3486 md5 85d9879d96fa7836ea45f8558abdc3f5 sha1 b4e8c74651aa7f6804ce8c8eae03ed627c6322b0 )
+)
+
+game (
+	name "Sorcerian (Japan) (Rev 4)"
+	description "Sorcerian (Japan) (Rev 4)"
+	rom ( name "Sorcerian (Japan) (Rev 4).cue" size 5049 crc d6e56aab md5 00029e9a34a325522b1c7d2b56e85d72 sha1 4527b5c9d1bcae1f5906e107b8b81ce2b2638047 )
+)
+
+game (
+	name "Sotsugyou - Graduation (Japan) (NA360601)"
+	description "Sotsugyou - Graduation (Japan) (NA360601)"
+	rom ( name "Sotsugyou - Graduation (Japan) (NA360601).cue" size 3266 crc affb9e07 md5 6a24b9addcea592f351d7e2a66d92758 sha1 f273886767710a305774a2554b60c5dddbf64aed )
+)
+
+game (
+	name "Sotsugyou - Graduation (Japan) (NA361216)"
+	description "Sotsugyou - Graduation (Japan) (NA361216)"
+	rom ( name "Sotsugyou - Graduation (Japan) (NA361216).cue" size 3266 crc ece90f9c md5 5855c9ad329c7b0ef8b0214a5e95f415 sha1 99481dc6496d72de9a51d119768dd4e89742feb4 )
+)
+
+game (
+	name "Sotsugyou II - Neo Generation (Japan)"
+	description "Sotsugyou II - Neo Generation (Japan)"
+	rom ( name "Sotsugyou II - Neo Generation (Japan).cue" size 2145 crc 45278129 md5 b57a8be398a865a38f164b6199a2741d sha1 5d265f3a94507d826ebb47d3a9c51540cb571b42 )
+)
+
+game (
+	name "Sotsugyou Shashin - Miki (Japan)"
+	description "Sotsugyou Shashin - Miki (Japan)"
+	rom ( name "Sotsugyou Shashin - Miki (Japan).cue" size 4886 crc 3c41d1ae md5 979fc6cadd368ca951bb1b795a04ba2f sha1 e67478c7b246b87ca64a9932c7c29c8cea64ef14 )
+)
+
+game (
+	name "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan) (Rev 5)"
+	description "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan) (Rev 5)"
+	rom ( name "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan) (Rev 5).cue" size 1710 crc 0ec66e37 md5 c460ec4212b2e621b4586c04436daac1 sha1 19a1bae4c9f6c825475a83e50423955b5942f1fe )
+)
+
+game (
+	name "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7)"
+	description "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7)"
+	rom ( name "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7).cue" size 1281 crc a8a099f8 md5 b7e40310ef16ace0c5ff8fea46c5da3c sha1 34240e33b6ad40dc748cecec0336902fdec4075e )
+)
+
+game (
+	name "Splash Lake - Ostrich Daibouken (Japan)"
+	description "Splash Lake - Ostrich Daibouken (Japan)"
+	rom ( name "Splash Lake - Ostrich Daibouken (Japan).cue" size 1628 crc 18481697 md5 944efec36ade6a3097b29f1b858340d8 sha1 9e852a918ecd436366fca179a62107dbfd0b5dfd )
+)
+
+game (
+	name "Star Breaker (Japan)"
+	description "Star Breaker (Japan)"
+	rom ( name "Star Breaker (Japan).cue" size 1666 crc 96d6b28c md5 28e7b16e6bb31955adf65d632feff222 sha1 a0ce647fc358870056333b276ec5735bee56d1a2 )
+)
+
+game (
+	name "Star Parodier (Japan) (Rev 2)"
+	description "Star Parodier (Japan) (Rev 2)"
+	rom ( name "Star Parodier (Japan) (Rev 2).cue" size 2526 crc dc1f1349 md5 3c65cbc3d2a89e175fb592158cbfd249 sha1 aa00a15280c63cbe01c219fe79fb0a235bdd9e42 )
+)
+
+game (
+	name "Startling Odyssey (Japan)"
+	description "Startling Odyssey (Japan)"
+	rom ( name "Startling Odyssey (Japan).cue" size 2139 crc f9f5b3e2 md5 eabb0988f46a8010724f9d290110145d sha1 04adbc3685360acd76a2ce079cda19db461b5af6 )
+)
+
+game (
+	name "Startling Odyssey II - Maryuu Sensou (Japan)"
+	description "Startling Odyssey II - Maryuu Sensou (Japan)"
+	rom ( name "Startling Odyssey II - Maryuu Sensou (Japan).cue" size 6134 crc f08773b2 md5 acc043f8f82ce5c31a7f000e98074bf1 sha1 240862c1e38a201f25276af4d57c09ac8e35edfd )
+)
+
+game (
+	name "Startling Odyssey II - Maryuu Sensou (Japan) (Sample)"
+	description "Startling Odyssey II - Maryuu Sensou (Japan) (Sample)"
+	rom ( name "Startling Odyssey II - Maryuu Sensou (Japan) (Sample).cue" size 1602 crc c53909d0 md5 97e413b0209cc430f8d24fcff465b091 sha1 d629e2160fc062f2155e1c813ac448fd41f8e16c )
+)
+
+game (
+	name "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3)"
+	description "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3)"
+	rom ( name "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3).cue" size 1047 crc 11177e52 md5 5955565a544f16565295bbc85a94b829 sha1 947593e9d1fa01e13cc37f4c88bd2c546b7ad00b )
+)
+
+game (
+	name "Super Albatross (Japan) (Rev 3)"
+	description "Super Albatross (Japan) (Rev 3)"
+	rom ( name "Super Albatross (Japan) (Rev 3).cue" size 6151 crc 65795530 md5 55f94013f37e607f1242b2689efece76 sha1 e1b77148c092877a50f6f75e2133454116f1ba60 )
+)
+
+game (
+	name "Super CD-ROM^2 Taiken Soft Shuu (Japan)"
+	description "Super CD-ROM^2 Taiken Soft Shuu (Japan)"
+	rom ( name "Super CD-ROM^2 Taiken Soft Shuu (Japan).cue" size 2951 crc 73b099cb md5 bd7d7a452f88812e3b80e2f0fe135502 sha1 91b2bf136772f789adb60cc233156dc39c77786d )
+)
+
+game (
+	name "Super Daisenryaku (Japan) (Rev 3)"
+	description "Super Daisenryaku (Japan) (Rev 3)"
+	rom ( name "Super Daisenryaku (Japan) (Rev 3).cue" size 1010 crc 1189b6bd md5 0e72a900b60138bd96d598b37fe01eb9 sha1 a24f7d0bc34a7eb0d04e5a682956034cd91b8183 )
+)
+
+game (
+	name "Super Darius (Japan)"
+	description "Super Darius (Japan)"
+	rom ( name "Super Darius (Japan).cue" size 1799 crc cbabcc20 md5 3f8d1cad94095beff87acf900703abad sha1 f55d6eb98edcf94ccadb77de8860d32b578a0e71 )
+)
+
+game (
+	name "Super Darius (Japan) (Alt)"
+	description "Super Darius (Japan) (Alt)"
+	rom ( name "Super Darius (Japan) (Alt).cue" size 1913 crc 6ccd7cf5 md5 54554aeeed9c758bff9954fcfb402361 sha1 bc44e1689901763abe0b392b1d8774a23464e140 )
+)
+
+game (
+	name "Super Mahjong Taikai (Japan) (Rev 1)"
+	description "Super Mahjong Taikai (Japan) (Rev 1)"
+	rom ( name "Super Mahjong Taikai (Japan) (Rev 1).cue" size 6690 crc fe3c5d1e md5 a7166a8fc9fa0e6210191436c2674dda sha1 afb02aa51c5908085a641efdc94c4d19e33a3d39 )
+)
+
+game (
+	name "Super Real Mahjong P.V Custom (Japan)"
+	description "Super Real Mahjong P.V Custom (Japan)"
+	rom ( name "Super Real Mahjong P.V Custom (Japan).cue" size 7405 crc 0eb440bf md5 06f05844fecf996203bc46553d6096a6 sha1 6793513bc833738e49403e28926162b50759c4a5 )
+)
+
+game (
+	name "Super Real Mahjong PII-III Custom (Japan)"
+	description "Super Real Mahjong PII-III Custom (Japan)"
+	rom ( name "Super Real Mahjong PII-III Custom (Japan).cue" size 8577 crc 1abb43d9 md5 47f2b99f1e2fadc9a4c039fed4386c3a sha1 e6ecb3b7a4d7babaf3277164a61ffcce289c0f28 )
+)
+
+game (
+	name "Super Real Mahjong PIV Custom (Japan) (Rev 1)"
+	description "Super Real Mahjong PIV Custom (Japan) (Rev 1)"
+	rom ( name "Super Real Mahjong PIV Custom (Japan) (Rev 1).cue" size 4665 crc 25fb7b78 md5 73fa51d6a645b3e35aa5dac103fdcd9e sha1 fe50f87210b84e8a889e42b53c865687435bdc43 )
+)
+
+game (
+	name "Super Real Mahjong Special - Miki Kasumi Shouko no Omoide yori (Japan) (Rev 1)"
+	description "Super Real Mahjong Special - Miki Kasumi Shouko no Omoide yori (Japan) (Rev 1)"
+	rom ( name "Super Real Mahjong Special - Miki Kasumi Shouko no Omoide yori (Japan) (Rev 1).cue" size 10602 crc 80b6358f md5 bb3f92849dc0510ac8bd3436dd473fd2 sha1 edf79f83a484be7ec34808e59791a78b992cf158 )
+)
+
+game (
+	name "Super Schwarzschild (Japan)"
+	description "Super Schwarzschild (Japan)"
+	rom ( name "Super Schwarzschild (Japan).cue" size 1983 crc a4cbd810 md5 68de9cc5c853be8fc46b609882052e86 sha1 f70f48e37d71fbab01c63331cfe7dfb58086c81a )
+)
+
+game (
+	name "Super Schwarzschild 2 (Japan)"
+	description "Super Schwarzschild 2 (Japan)"
+	rom ( name "Super Schwarzschild 2 (Japan).cue" size 2324 crc 9e564f08 md5 95591d2d37c5fe278ef49c8b58dfd0d3 sha1 f38bc5e82e8bec03b7b4c8ddd87a9f92c4d815e0 )
+)
+
+game (
+	name "Taiheiki (Japan) (FAAT, FABT)"
+	description "Taiheiki (Japan) (FAAT, FABT)"
+	rom ( name "Taiheiki (Japan) (FAAT, FABT).cue" size 3816 crc 3faa5c41 md5 6e7db0189b991dde7476dac60ea8645e sha1 8f4cdc08c7ea36cfb164915b43eb6546ed7da09c )
+)
+
+game (
+	name "Tanjou - Debut (Japan)"
+	description "Tanjou - Debut (Japan)"
+	rom ( name "Tanjou - Debut (Japan).cue" size 3768 crc 048e8037 md5 f535ff913e88e891491b96a5761bd04c sha1 76ebdd4d123d4a796145a80b8e2f4124397bdcee )
+)
+
+game (
+	name "Tecmo World Cup Super Soccer (Japan)"
+	description "Tecmo World Cup Super Soccer (Japan)"
+	rom ( name "Tecmo World Cup Super Soccer (Japan).cue" size 2319 crc 6866de49 md5 2c49dd46144f35d2bc576f5e8ddbc230 sha1 bf1bba5d286ea01fc923145dee2914786e2b3eed )
+)
+
+game (
+	name "Tenchi Muyou! Ryououki (Japan)"
+	description "Tenchi Muyou! Ryououki (Japan)"
+	rom ( name "Tenchi Muyou! Ryououki (Japan).cue" size 1428 crc 9cdf80e9 md5 4d715a9cc84d101bee0cc837072526ba sha1 372cd3d3719c76832c8632cf370cdc4478e00889 )
+)
+
+game (
+	name "Tengai Makyou - Deden no Kabuki-den (Japan)"
+	description "Tengai Makyou - Deden no Kabuki-den (Japan)"
+	rom ( name "Tengai Makyou - Deden no Kabuki-den (Japan).cue" size 279 crc a8f29026 md5 0a980f25bf8846e14d4bc45eaa3ae065 sha1 2f9eba5231477f6c444f4cc64d6b1dc2458a0e9a )
+)
+
+game (
+	name "Tenshi no Uta (Japan) (Rev 6)"
+	description "Tenshi no Uta (Japan) (Rev 6)"
+	rom ( name "Tenshi no Uta (Japan) (Rev 6).cue" size 3407 crc cacbae9b md5 bad4d153d36e3a7b83def22545ee1e06 sha1 aac9270c19f86eb3cc241ad11fbf8f3462722a56 )
+)
+
+game (
+	name "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1)"
+	description "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1)"
+	rom ( name "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1).cue" size 4358 crc cf4955cd md5 c877a4a5659b1504c2502c3434f5609a sha1 a600b58c217cc642a1edcacdaacc44290f793f27 )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (HRKM70217)"
+	description "Tokimeki Memorial (Japan) (HRKM70217)"
+	rom ( name "Tokimeki Memorial (Japan) (HRKM70217).cue" size 1017 crc bdd59697 md5 5d1e7ec1c71466de6bb1d2634ab63c20 sha1 2007f81fa6e4f858efedf5d374dab735d4739f79 )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (HRKM70414) (FAAT, FABT)"
+	description "Tokimeki Memorial (Japan) (HRKM70414) (FAAT, FABT)"
+	rom ( name "Tokimeki Memorial (Japan) (HRKM70414) (FAAT, FABT).cue" size 1098 crc 61fa7166 md5 1bc85d4c81e76fbb9645553e705ab9ce sha1 2e89041485c75313714721ce22f324b1e47e205a )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (HRKM71014) (FABT)"
+	description "Tokimeki Memorial (Japan) (HRKM71014) (FABT)"
+	rom ( name "Tokimeki Memorial (Japan) (HRKM71014) (FABT).cue" size 1050 crc 16304733 md5 ff2d860bec41ba99bebfc2e5d8458e0d sha1 7a9e4f6bdb1b2be731061a8026d789b5cdce9a57 )
+)
+
+game (
+	name "Top o Nerae! GunBuster Vol. 1 (Japan)"
+	description "Top o Nerae! GunBuster Vol. 1 (Japan)"
+	rom ( name "Top o Nerae! GunBuster Vol. 1 (Japan).cue" size 642 crc 31228006 md5 7b67b2192323f0b09b84809a4c28b978 sha1 94534a3e2321474b9d0143b87681a39a02b91f69 )
+)
+
+game (
+	name "Top o Nerae! GunBuster Vol. 2 (Japan)"
+	description "Top o Nerae! GunBuster Vol. 2 (Japan)"
+	rom ( name "Top o Nerae! GunBuster Vol. 2 (Japan).cue" size 4680 crc fa4fc2e5 md5 8365369d8da24f1d43306934d1e5f8d4 sha1 37167d01bf641ec7c2040121f7278c0e43d4d122 )
+)
+
+game (
+	name "Travel Eple (Japan) (Rev 6)"
+	description "Travel Eple (Japan) (Rev 6)"
+	rom ( name "Travel Eple (Japan) (Rev 6).cue" size 7890 crc b693ac68 md5 528459d3939a598fc044c1c7be896449 sha1 b9fcad01df746901400494d840605aaa388953d3 )
+)
+
+game (
+	name "Uchuu Senkan Yamato (Japan)"
+	description "Uchuu Senkan Yamato (Japan)"
+	rom ( name "Uchuu Senkan Yamato (Japan).cue" size 1686 crc b92b79cb md5 f7f0563e97d9b8f767c94058d07bffbe sha1 93a18aebb37a39fc5f52cc09881c9fdb7dd3237a )
+)
+
+game (
+	name "Ultra Box 3-gou (Japan) (Rev 1)"
+	description "Ultra Box 3-gou (Japan) (Rev 1)"
+	rom ( name "Ultra Box 3-gou (Japan) (Rev 1).cue" size 9754 crc 2cda4fcc md5 d3663ee1a404e235ae82303829aa2877 sha1 95fc1ef2b707b686c4168d5b844b054f699ca84a )
+)
+
+game (
+	name "Ultra Box 4-gou (Japan) (Rev 1)"
+	description "Ultra Box 4-gou (Japan) (Rev 1)"
+	rom ( name "Ultra Box 4-gou (Japan) (Rev 1).cue" size 3810 crc 9a0d5d2f md5 8e7c43835b762cd3e050b4521fa139dd sha1 ab1d5add0dafa455a856fbd6765af9d0d59e4675 )
+)
+
+game (
+	name "Ultra Box 6-gou (Japan)"
+	description "Ultra Box 6-gou (Japan)"
+	rom ( name "Ultra Box 6-gou (Japan).cue" size 2667 crc 7e99b63b md5 e4d75239cf2ad169a115870859fef1c4 sha1 cc8abdc945380de456a5f5e0876271942b783a76 )
+)
+
+game (
+	name "Urusei Yatsura - Stay with You (Japan) (Rev 6)"
+	description "Urusei Yatsura - Stay with You (Japan) (Rev 6)"
+	rom ( name "Urusei Yatsura - Stay with You (Japan) (Rev 6).cue" size 687 crc 2e35940a md5 442d5e5cb684afe0da367c15118207b7 sha1 eed15911582261c3c19f78295be98b7af74521d9 )
+)
+
+game (
+	name "Valis II (Japan)"
+	description "Valis II (Japan)"
+	rom ( name "Valis II (Japan).cue" size 6290 crc 8a6025e6 md5 61618ff93cd5cea2084f6e7efe92b603 sha1 c1da43fb5b7b46d35edc79330d751f44b1f929f5 )
+)
+
+game (
+	name "Valis II (Japan) (Alt)"
+	description "Valis II (Japan) (Alt)"
+	rom ( name "Valis II (Japan) (Alt).cue" size 5315 crc 98ace296 md5 978e89dd4816ad67df126e4bfc846fa1 sha1 88f54f2ac044c80ea5ed92b569e54c469f2ded5b )
+)
+
+game (
+	name "Valis III (Japan)"
+	description "Valis III (Japan)"
+	rom ( name "Valis III (Japan).cue" size 8982 crc 99a46983 md5 58c6ccbd7b426bdcbad3e77a5efd0fee sha1 1db098ed4e6b3799f11865602e02700b502dbc49 )
+)
+
+game (
+	name "Valis III (Japan) (Alt)"
+	description "Valis III (Japan) (Alt)"
+	rom ( name "Valis III (Japan) (Alt).cue" size 7735 crc 1b9e3931 md5 49ec4d502d6b255383f74e45284a3ba0 sha1 d3ce9d195ed5b862be015807d86e65b84b6f2499 )
+)
+
+game (
+	name "Valis IV (Japan)"
+	description "Valis IV (Japan)"
+	rom ( name "Valis IV (Japan).cue" size 9853 crc 9595e237 md5 e071f86c70fbef65aa098e0f1084f496 sha1 13c332870c27fdd5e5b30c578b690da78f7baef7 )
+)
+
+game (
+	name "Vasteel (Japan) (Rev 10)"
+	description "Vasteel (Japan) (Rev 10)"
+	rom ( name "Vasteel (Japan) (Rev 10).cue" size 3174 crc 02b75781 md5 81d99f446e37251b9d1b26de09ddecdb sha1 2b5d95d6e3cd9ed76d8f7c6254cba48fa2fe3ddc )
+)
+
+game (
+	name "Vasteel 2 (Japan) (Rev 1)"
+	description "Vasteel 2 (Japan) (Rev 1)"
+	rom ( name "Vasteel 2 (Japan) (Rev 1).cue" size 2596 crc f95f58fc md5 0b81207b59959df30a1a0866f386ba5f sha1 53800bf62d38be38df810b20b2e79cf2f38c39c2 )
+)
+
+game (
+	name "Where in the World Is Carmen Sandiego (Japan) (En,Ja) (Rev 3)"
+	description "Where in the World Is Carmen Sandiego (Japan) (En,Ja) (Rev 3)"
+	rom ( name "Where in the World Is Carmen Sandiego (Japan) (En,Ja) (Rev 3).cue" size 4596 crc f5b5b97e md5 9505b3f271a87ebb7b9296e1e32d1ba6 sha1 6b266d4f8a553c8a28af99163b9ea36c28d0cbf0 )
+)
+
+game (
+	name "Winds of Thunder (Japan)"
+	description "Winds of Thunder (Japan)"
+	rom ( name "Winds of Thunder (Japan).cue" size 2310 crc 34f101c4 md5 3ea022ff8106b1e72b49864c21ea653c sha1 98f94c755e18f0c451f4c48f8c244c21239b71c7 )
+)
+
+game (
+	name "Wizardry I-II (Japan)"
+	description "Wizardry I-II (Japan)"
+	rom ( name "Wizardry I-II (Japan).cue" size 1497 crc 5aeaf042 md5 38f59ab20479c1ef1e6df06680d327c0 sha1 8d73c4196b26cb837918550b0d3333b2a63e0caf )
+)
+
+game (
+	name "Wizardry III-IV (Japan)"
+	description "Wizardry III-IV (Japan)"
+	rom ( name "Wizardry III-IV (Japan).cue" size 1622 crc e4872daa md5 bff834b97ce6752082e58c4a73af258e sha1 e5c5e10e2c0e52dd8474c9fbcce94cf7e0c6455f )
+)
+
+game (
+	name "Wizardry V - Heart of the Maelstrom (Japan)"
+	description "Wizardry V - Heart of the Maelstrom (Japan)"
+	rom ( name "Wizardry V - Heart of the Maelstrom (Japan).cue" size 10797 crc 50041f3c md5 4e663da6e295b8b143bb50d3e35b2fbe sha1 52e0835075eea8b28f3848ab492d84d466769359 )
+)
+
+game (
+	name "World Heroes 2 (Japan) (FAAT, FABT)"
+	description "World Heroes 2 (Japan) (FAAT, FABT)"
+	rom ( name "World Heroes 2 (Japan) (FAAT, FABT).cue" size 4466 crc 2472c6ec md5 aa3353aed4d5b2a04883ae7fb5d067bc sha1 877c4c98ccc5d9bd63697e0f97facec534a3978c )
+)
+
+game (
+	name "Xak (Japan)"
+	description "Xak (Japan)"
+	rom ( name "Xak (Japan).cue" size 2532 crc 0d93c7f9 md5 c0078a1403a27c54123f3acf193bfff5 sha1 9ce7204e8421ea6a0feb6117145378d3154bbc84 )
+)
+
+game (
+	name "Xak III - The Eternal Recurrence (Japan)"
+	description "Xak III - The Eternal Recurrence (Japan)"
+	rom ( name "Xak III - The Eternal Recurrence (Japan).cue" size 3994 crc 5cbea73b md5 00eacd547e8ae0b5ff37988b30e54319 sha1 b96edccf717166f04560d9640c867ec5ab65b051 )
+)
+
+game (
+	name "Yamamura Misa Suspense - Kinsenka Kyouezara Satsujin Jiken (Japan)"
+	description "Yamamura Misa Suspense - Kinsenka Kyouezara Satsujin Jiken (Japan)"
+	rom ( name "Yamamura Misa Suspense - Kinsenka Kyouezara Satsujin Jiken (Japan).cue" size 3828 crc 0cafa324 md5 440362071305a2e8085410abacf6e9ba sha1 9f71546ebb14f062a593192857a430e11a969c4a )
+)
+
+game (
+	name "YaWaRa! 2 - A Fashionable Judo Girl! (Japan)"
+	description "YaWaRa! 2 - A Fashionable Judo Girl! (Japan)"
+	rom ( name "YaWaRa! 2 - A Fashionable Judo Girl! (Japan).cue" size 792 crc 7182784e md5 dae88c83285d1ced8bc6a4ea8330c223 sha1 9729c9a2678732d0fb9e8a791f134e55a96d289a )
+)
+
+game (
+	name "YaWaRa! A Fashionable Judo Girl! (Japan) (Rev 1)"
+	description "YaWaRa! A Fashionable Judo Girl! (Japan) (Rev 1)"
+	rom ( name "YaWaRa! A Fashionable Judo Girl! (Japan) (Rev 1).cue" size 907 crc 97ccdf29 md5 f5488f2b797aa20112d8f591986e5f49 sha1 a753bf42d3a8a9cc4fbef16cd4cd8122600abaa1 )
+)
+
+game (
+	name "Yokoyama Mitsuteru Shin Sangokushi - Tenka wa Ware ni (Japan) (Rev 7)"
+	description "Yokoyama Mitsuteru Shin Sangokushi - Tenka wa Ware ni (Japan) (Rev 7)"
+	rom ( name "Yokoyama Mitsuteru Shin Sangokushi - Tenka wa Ware ni (Japan) (Rev 7).cue" size 9831 crc cca09924 md5 98b52401858b44b9991b122168a81e10 sha1 257ace93c102cd55718398dc1ef531b6b6bad5f3 )
+)
+
+game (
+	name "Ys Book I & II (USA) (Rev 2)"
+	description "Ys Book I & II (USA) (Rev 2)"
+	rom ( name "Ys Book I & II (USA) (Rev 2).cue" size 4374 crc b4867522 md5 ec9f70e68e62da05aa65f2efc210b720 sha1 88d5660af827b1917411033403aa3dd775179adf )
+)
+
+game (
+	name "Ys I & II (Japan) (Rev 6)"
+	description "Ys I & II (Japan) (Rev 6)"
+	rom ( name "Ys I & II (Japan) (Rev 6).cue" size 4245 crc 373675d8 md5 6c1daf2b65999d431c374c8537b2d808 sha1 898806928065bce534b46786997ea89e9948ca54 )
+)
+
+game (
+	name "Ys III - Wanderers from Ys (USA) (Rev 1)"
+	description "Ys III - Wanderers from Ys (USA) (Rev 1)"
+	rom ( name "Ys III - Wanderers from Ys (USA) (Rev 1).cue" size 2874 crc 7daed48d md5 c0086941c5316d14034c84fb995c008f sha1 4c28b8e0a8d05aedeeb54c46b3a2aa706f809519 )
+)
+
+game (
+	name "Ys III (Japan) (Rev 9)"
+	description "Ys III (Japan) (Rev 9)"
+	rom ( name "Ys III (Japan) (Rev 9).cue" size 2424 crc b55dcca3 md5 b346ec47ad17a3cb838c37f8019002db sha1 e3f9ef81c211209b0242187462d95fb253ecb318 )
+)
+
+game (
+	name "Ys IV - The Dawn of Ys (Japan) (Rev 3)"
+	description "Ys IV - The Dawn of Ys (Japan) (Rev 3)"
+	rom ( name "Ys IV - The Dawn of Ys (Japan) (Rev 3).cue" size 3622 crc fa7ea57e md5 e42f62d283c5e29bf32ab5c3d1d71f05 sha1 2ac8f48485162cfc7cfab55273abeffc6b865009 )
+)
+
+game (
+	name "Zan - Kagerou no Toki (Japan) (Rev 4)"
+	description "Zan - Kagerou no Toki (Japan) (Rev 4)"
+	rom ( name "Zan - Kagerou no Toki (Japan) (Rev 4).cue" size 9040 crc acddee92 md5 f2e9075c6f640b6025d72215d89944e3 sha1 20348c39cd8d3c0ffc93753f49308957e8c5d3d1 )
+)
+
+game (
+	name "Zero 4 Champ II (Japan) (Rev 1)"
+	description "Zero 4 Champ II (Japan) (Rev 1)"
+	rom ( name "Zero 4 Champ II (Japan) (Rev 1).cue" size 4531 crc bbb526a6 md5 f8875368a43735b6779cb6d6cce26e55 sha1 a0e3bd08844522d24ffc1bbcae215d375a0ced4c )
+)


### PR DESCRIPTION
Built from [Redump](http://redump.org), through https://github.com/RobLoach/libretro-nec-pc-engine-cd-turbografx-cd .

## References

- https://github.com/libretro/libretro-database/issues/234 .