### PR TITLE
Add Trurip's NEC PC Engine CD - TurboGrafx-CD

### DIFF
--- a/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
+++ b/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
@@ -1,9 +1,15 @@
 clrmamepro (
 	name "NEC - PC Engine CD - TurboGrafx-CD"
 	description "NEC - PC Engine CD - TurboGrafx-CD"
-	version "0.0.1"
+	version "0.1.0"
 	comment "libretro-database's DAT file for NEC - PC Engine CD - TurboGrafx-CD"
 	homepage "https://github.com/RobLoach/libretro-nec-pc-engine-cd-turbografx-cd"
+)
+
+game (
+	name "1552 Tenka Dairan (Japan) - 1552天下大乱"
+	description "1552 Tenka Dairan (Japan) - 1552天下大乱"
+	rom ( name "1552 Tenka Dairan (Japan).cue" size 12316 crc 5f6b4d0f md5 83440db97503c3d3e85d2ae18106fb45 sha1 b5aff1a00214a35ce837a3e9310adfe98f6429bc )
 )
 
 game (
@@ -13,9 +19,63 @@ game (
 )
 
 game (
+	name "1992 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1992+ハドソン+CD•ROM²+音楽全集"
+	description "1992 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1992+ハドソン+CD•ROM²+音楽全集"
+	rom ( name "1992 Hudson CD-ROM2 Complete Music Works (Japan) (Audio).cue" size 10996 crc 604e3062 md5 73e663946cf43e1f0eb0944e490bef9a sha1 d1bd6192c03e5981276a41e5e2c0f86877f49065 )
+)
+
+game (
+	name "1993 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1993+ハドソン+CD•ROM²+音楽全集"
+	description "1993 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1993+ハドソン+CD•ROM²+音楽全集"
+	rom ( name "1993 Hudson CD-ROM2 Complete Music Works (Japan) (Audio).cue" size 10996 crc e2f5b755 md5 51660bff1d97472b8a4594862d219852 sha1 cac69bafbe59135d3463d626cd9f503b0af2e2f0 )
+)
+
+game (
+	name "1994 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1994+ハドソン+CD•ROM²+音楽全集"
+	description "1994 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1994+ハドソン+CD•ROM²+音楽全集"
+	rom ( name "1994 Hudson CD-ROM2 Complete Music Works (Japan) (Audio).cue" size 9898 crc ef6548cd md5 74e379de4f7a0d2382d2861c6bbc1622 sha1 ae25ddda02754d5c2ac7bb157a367893c8c6fbcc )
+)
+
+game (
+	name "1994 Hudson CD-ROM2 Complete Music Works II (Japan) (Audio) - 1994+ハドソン+CD•ROM²+音楽全集II"
+	description "1994 Hudson CD-ROM2 Complete Music Works II (Japan) (Audio) - 1994+ハドソン+CD•ROM²+音楽全集II"
+	rom ( name "1994 Hudson CD-ROM2 Complete Music Works II (Japan) (Audio).cue" size 12646 crc 1dfb95e9 md5 c3f9a1d231c5ecfa9f9b5b307d9468ab sha1 6bcb4b2cf2ac913e94e7ab9c88011b5e1bb52de4 )
+)
+
+game (
+	name "1995 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1995+ハドソン+CD•ROM²+音楽全集"
+	description "1995 Hudson CD-ROM2 Complete Music Works (Japan) (Audio) - 1995+ハドソン+CD•ROM²+音楽全集"
+	rom ( name "1995 Hudson CD-ROM2 Complete Music Works (Japan) (Audio).cue" size 9349 crc 6e100bce md5 2fe2222aa72622532c43ab158d686f75 sha1 a870eaa0bf765f4941ba74e38b34b46b1e94627c )
+)
+
+game (
+	name "1996 Hudson Game Music Complete Works (Japan) (Audio) - 1996+ハドソンゲーム音楽全集"
+	description "1996 Hudson Game Music Complete Works (Japan) (Audio) - 1996+ハドソンゲーム音楽全集"
+	rom ( name "1996 Hudson Game Music Complete Works (Japan) (Audio).cue" size 19894 crc 797315ca md5 51b4d9ac08c1fbe18865af87c61a4169 sha1 ede76a56c872907dbefe7ce9d5970b5156befe6b )
+)
+
+game (
+	name "1997 Hudson Presents Caravan on the Radio (Japan) (Audio) - キャラバン・オン・ザ・ラジオ"
+	description "1997 Hudson Presents Caravan on the Radio (Japan) (Audio) - キャラバン・オン・ザ・ラジオ"
+	rom ( name "1997 Hudson Presents Caravan on the Radio (Japan) (Audio).cue" size 14075 crc 16e38a06 md5 db102d75b1b6092f3e7188c30d6c38a9 sha1 89a9c3328379942c87611c0f873292ea0a7c53ea )
+)
+
+game (
 	name "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1)"
 	description "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1)"
 	rom ( name "3 Games in 1 - Gate of Thunder + Bonk's Adventure + Bonk's Revenge (USA) (Rev 1).cue" size 3723 crc 3cf86ed3 md5 26af72bbf3a037780146478ce0b1fbfe sha1 c7cfdbc3370e5d8a6f3f23d1778703d841168463 )
+)
+
+game (
+	name "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100523)"
+	description "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100523)"
+	rom ( name "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100523).cue" size 3833 crc 476100d1 md5 428280e7535b824e1669e19e061d4a82 sha1 d57d193d9eb80871c8300b6c89b4a60f95989f2f )
+)
+
+game (
+	name "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100802)"
+	description "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100802)"
+	rom ( name "3 x 3 Eyes - Sanjiyan Hensei (Japan) (HE100802).cue" size 3833 crc a4330975 md5 90f645cdafa1ff7134a9107a67410cd1 sha1 9cd698526a2930cdfb7de831eed0c1d2ec2da26b )
 )
 
 game (
@@ -25,15 +85,45 @@ game (
 )
 
 game (
+	name "4 in 1 Super CD (USA)"
+	description "4 in 1 Super CD (USA)"
+	rom ( name "4 in 1 Super CD (USA).cue" size 11017 crc 7c1031ed md5 cac42ee8856f6e7313d62739c6c5dddb sha1 ba2ffff736f96fe827ab61c2e7d5652d18e0c26c )
+)
+
+game (
+	name "A Ressha de Ikou III (Japan) - A列車で行こうIII"
+	description "A Ressha de Ikou III (Japan) - A列車で行こうIII"
+	rom ( name "A Ressha de Ikou III (Japan).cue" size 3260 crc 00e79447 md5 1dcbe760aefebf7af8c46fb00150c8c4 sha1 c21023dbe194703b8c1934dc07feda3050bdea40 )
+)
+
+game (
 	name "A.III. - A Ressha de Ikou III (Japan)"
 	description "A.III. - A Ressha de Ikou III (Japan)"
 	rom ( name "A.III. - A Ressha de Ikou III (Japan).cue" size 722 crc 287311e6 md5 4f1e738686ae29dd88e53d32e26e68d1 sha1 a9e009624f96e1f3da9f3e3b4d236a9b43ea694b )
 )
 
 game (
+	name "Addams Family, The (USA)"
+	description "Addams Family, The (USA)"
+	rom ( name "Addams Family, The (USA).cue" size 943 crc 60dab39e md5 265773d12f3fb7aeb412d3f154505ef6 sha1 29861a24651d34c4ec55f37531841e80b87afdd0 )
+)
+
+game (
 	name "Advanced V.G. (Japan)"
 	description "Advanced V.G. (Japan)"
-	rom ( name "Advanced V.G. (Japan).cue" size 3543 crc 08fb23e6 md5 39b67de686bdea7f25cb17bb5dd59bf3 sha1 e957bd617790e9942879f5f866778b85cefeea12 )
+	rom ( name "Advanced V.G. (Japan).cue" size 15957 crc fcf40591 md5 98165fdae144af23d403a2b47f6f29b1 sha1 a7f044f7d87ee0906d78cc16438139b8059eae8a )
+)
+
+game (
+	name "Advanced V.G. (Japan) (Sample)"
+	description "Advanced V.G. (Japan) (Sample)"
+	rom ( name "Advanced V.G. (Japan) (Sample).cue" size 9891 crc 3c450ba7 md5 65886263d4adf2cd93fafabe7266c640 sha1 05e17152c8e95e93524a315a8346926e9857a016 )
+)
+
+game (
+	name "Adventure Quiz - Capcom World & Hatena no Dai Bouken (Japan)"
+	description "Adventure Quiz - Capcom World & Hatena no Dai Bouken (Japan)"
+	rom ( name "Adventure Quiz - Capcom World & Hatena no Dai Bouken (Japan).cue" size 3697 crc 0fa53418 md5 a70f4077016b7723c623e57c5c9aeed7 sha1 ff38a21fc28562749308bd5957464186fd477c51 )
 )
 
 game (
@@ -46,6 +136,18 @@ game (
 	name "Ai Chou Aniki (Japan)"
 	description "Ai Chou Aniki (Japan)"
 	rom ( name "Ai Chou Aniki (Japan).cue" size 2032 crc 4724a3c1 md5 f2a8da82d0e82eacdfd7d26d11f8e971 sha1 e0f009a3be8795c0335e2cc36c1f9fc974bd7c2a )
+)
+
+game (
+	name "Ai Chouaniki (Japan)"
+	description "Ai Chouaniki (Japan)"
+	rom ( name "Ai Chouaniki (Japan).cue" size 9476 crc d6b3194c md5 03908af3df793051c6981628e5093f2b sha1 24040cb60e0f395b8666f7ec74259f262be161a6 )
+)
+
+game (
+	name "Akumajou Dracula X - Chi no Rondo (Japan)"
+	description "Akumajou Dracula X - Chi no Rondo (Japan)"
+	rom ( name "Akumajou Dracula X - Chi no Rondo (Japan).cue" size 9902 crc e8301204 md5 6f20fd685e605b245274574e5651b50e sha1 91f98e0264327184ca980088e22b6882f5890c7f )
 )
 
 game (
@@ -67,9 +169,39 @@ game (
 )
 
 game (
+	name "Alnam no Kiba - Shouzoku Juunishin-to Densetsu (Japan) - アルナムの牙+獣族十二神徒伝説"
+	description "Alnam no Kiba - Shouzoku Juunishin-to Densetsu (Japan) - アルナムの牙+獣族十二神徒伝説"
+	rom ( name "Alnam no Kiba - Shouzoku Juunishin-to Densetsu (Japan).cue" size 17866 crc 5ff26fcd md5 f16665fb4b9ed950c521cf4d541423f3 sha1 6234541519d000fabc4fbc73ad28cd1d70227763 )
+)
+
+game (
+	name "Alshark (Japan)"
+	description "Alshark (Japan)"
+	rom ( name "Alshark (Japan).cue" size 7041 crc dc2f6902 md5 6f66d6fc06848d41f84fd397197c311c sha1 d0551a3db5d1f15a111c193c994ad0780ec08f8c )
+)
+
+game (
 	name "Ane-san (Japan)"
 	description "Ane-san (Japan)"
 	rom ( name "Ane-san (Japan).cue" size 2597 crc 2d2fb7a9 md5 8d461d9a22036b71c0d572f53378eeb4 sha1 0f6847247d818e4599cea411c312a3349f233786 )
+)
+
+game (
+	name "Ane-San (Japan)"
+	description "Ane-San (Japan)"
+	rom ( name "Ane-San (Japan).cue" size 12562 crc 6a21eba5 md5 f427b24a32c91f01819defa8995cbaa3 sha1 efca44e746e4217d71170ca05168c2c67aeb4670 )
+)
+
+game (
+	name "Asuka 120% Maxima Burning Fest (Japan)"
+	description "Asuka 120% Maxima Burning Fest (Japan)"
+	rom ( name "Asuka 120% Maxima Burning Fest (Japan).cue" size 11114 crc 11e7a13d md5 8fb5333afdbbcf63f300e9a366dd410d sha1 645e2c6be5dbeb200a0d09ee435719ae2f3beedd )
+)
+
+game (
+	name "Atlas - The Renaissance Voyager (Japan) - アトラス+ルネッサンスボイジャー"
+	description "Atlas - The Renaissance Voyager (Japan) - アトラス+ルネッサンスボイジャー"
+	rom ( name "Atlas - The Renaissance Voyager (Japan).cue" size 6511 crc ce823fb3 md5 ffed4c4744509c2992836ddd0dd5dce3 sha1 912539005d63729a264c55fa8f3e879d9553f078 )
 )
 
 game (
@@ -85,9 +217,27 @@ game (
 )
 
 game (
+	name "Aurora Quest - Otaku no Seiza in Another World (Japan) - オーロラクエスト+おたくの星座+in+Another+World"
+	description "Aurora Quest - Otaku no Seiza in Another World (Japan) - オーロラクエスト+おたくの星座+in+Another+World"
+	rom ( name "Aurora Quest - Otaku no Seiza in Another World (Japan).cue" size 9105 crc f19d7cc3 md5 fec09109df6716c8bc280fef20d23082 sha1 f94ceebd54b90a4a843527837ae6ba83da4d4f60 )
+)
+
+game (
+	name "AV Tanjou (Japan)"
+	description "AV Tanjou (Japan)"
+	rom ( name "AV Tanjou (Japan).cue" size 29025 crc c2f76fb1 md5 67296678e2fa20f996864442e6b9a2e7 sha1 8e66cff734ccff1792aff73f30319a1149901b35 )
+)
+
+game (
 	name "AV Tanjou (Japan) (Unl)"
 	description "AV Tanjou (Japan) (Unl)"
 	rom ( name "AV Tanjou (Japan) (Unl).cue" size 7728 crc 32fc4232 md5 fca36db1951c7dfe1a06fcceccc57908 sha1 b0720a8c6143bd5f9fd79f9c62df5fcc2f34b3e6 )
+)
+
+game (
+	name "Avenger (Japan)"
+	description "Avenger (Japan)"
+	rom ( name "Avenger (Japan).cue" size 19691 crc 25a21bc8 md5 32689c7970b44be9447ab1ea386ae9cb sha1 7df32cb00b659e907f83b8226825ac01ab1e5838 )
 )
 
 game (
@@ -103,9 +253,45 @@ game (
 )
 
 game (
+	name "Babel (Japan) - バベル"
+	description "Babel (Japan) - バベル"
+	rom ( name "Babel (Japan).cue" size 43550 crc 7af3a7f9 md5 183881ecb7099e8948a0512ba2b76e12 sha1 6324dc3ad98c0b85789782aa228ee464b7ff3dbe )
+)
+
+game (
+	name "Baby Jo - The Super Hero (Japan)"
+	description "Baby Jo - The Super Hero (Japan)"
+	rom ( name "Baby Jo - The Super Hero (Japan).cue" size 2859 crc 8be3b5a8 md5 22aa0cb7b2a6431b05230e3e85b514bf sha1 f1c1b1f0bf1e6c9fc1d874efc0b454232d988ed0 )
+)
+
+game (
+	name "Bakuden Unbalance Zone (Japan)"
+	description "Bakuden Unbalance Zone (Japan)"
+	rom ( name "Bakuden Unbalance Zone (Japan).cue" size 16222 crc d1c02bbb md5 7331d5953f61388521c7af032511c112 sha1 d72f90b112b96c18320db48b762a21149765f644 )
+)
+
+game (
+	name "Bakuretsu Hunter Duo Comic (Japan)"
+	description "Bakuretsu Hunter Duo Comic (Japan)"
+	rom ( name "Bakuretsu Hunter Duo Comic (Japan).cue" size 3010 crc eda27713 md5 5c111b7eb57f0053618a98dc775ec2be sha1 c704aaf522c5df18b57e016a524b71ae48193dfc )
+)
+
+game (
+	name "Bakushou Yoshimoto Shinkigeki (Japan) - 爆笑吉本新喜劇"
+	description "Bakushou Yoshimoto Shinkigeki (Japan) - 爆笑吉本新喜劇"
+	rom ( name "Bakushou Yoshimoto Shinkigeki (Japan).cue" size 13282 crc add1137b md5 af49a19a0a5c190c0978b565ac234d0a sha1 de9082e7f5ad4c52ab9ccf1e340de3a71d52eea7 )
+)
+
+game (
 	name "Bakushou Yoshimoto Shinkigeki (Japan) (FABT)"
 	description "Bakushou Yoshimoto Shinkigeki (Japan) (FABT)"
 	rom ( name "Bakushou Yoshimoto Shinkigeki (Japan) (FABT).cue" size 3582 crc 5060f11e md5 baab7b53976a98bcf58e3877eee61099 sha1 f57483e35771a475115be359862bbaba1cbd348d )
+)
+
+game (
+	name "Basted (Japan)"
+	description "Basted (Japan)"
+	rom ( name "Basted (Japan).cue" size 16611 crc c78c8890 md5 74131b195bdf837d6693751134295530 sha1 12a5c5000bd80da0041133a056d404578998cc4e )
 )
 
 game (
@@ -115,15 +301,45 @@ game (
 )
 
 game (
+	name "Battlefield '94 In Super Battle Dream (Japan)"
+	description "Battlefield '94 In Super Battle Dream (Japan)"
+	rom ( name "Battlefield '94 In Super Battle Dream (Japan).cue" size 13402 crc abd0d842 md5 ecef93eed7e21e15100829e8230a0dd0 sha1 73b93fb56ecdce04dcac511a6d3d62fe53b95aae )
+)
+
+game (
+	name "Bazaru de Gozaru no Game Degozaru (Japan)"
+	description "Bazaru de Gozaru no Game Degozaru (Japan)"
+	rom ( name "Bazaru de Gozaru no Game Degozaru (Japan).cue" size 12183 crc 6361a92d md5 925220b5cad02a63aa0f34b78c1d2881 sha1 56be5bc45b467167a933c942fc45e1af16a0c508 )
+)
+
+game (
+	name "Bikini Girls (USA)"
+	description "Bikini Girls (USA)"
+	rom ( name "Bikini Girls (USA).cue" size 937 crc 731edaec md5 e1714492112983074b37cf3067fca678 sha1 2d614c3d35964214d33741eab41813140cbfac9c )
+)
+
+game (
+	name "Bikkuriman Daijikai (Japan)"
+	description "Bikkuriman Daijikai (Japan)"
+	rom ( name "Bikkuriman Daijikai (Japan).cue" size 30543 crc e71ada6f md5 96cbb8e05e7ee0c839042361e7b0f7ee sha1 1bc19d816b5806e86d90beda38a4599a571c957d )
+)
+
+game (
 	name "Bikkuriman Daijikai (Japan) (Rev 2)"
 	description "Bikkuriman Daijikai (Japan) (Rev 2)"
 	rom ( name "Bikkuriman Daijikai (Japan) (Rev 2).cue" size 7913 crc a2aaa7b1 md5 3b17cb32e1cbcc9b400c9a7af1405356 sha1 ca1122c14021d93a32bf30fc02ba8c7d3a5e10b7 )
 )
 
 game (
+	name "Bishoujo Jyanshi Idol Pai (Japan)"
+	description "Bishoujo Jyanshi Idol Pai (Japan)"
+	rom ( name "Bishoujo Jyanshi Idol Pai (Japan).cue" size 48166 crc 57fdef68 md5 e1a30033d54f7ee97ccdfaeca5565c6a sha1 742275d6a8eb90e71da8f2488917e1c020b34960 )
+)
+
+game (
 	name "Bishoujo Senshi Sailor Moon (Japan)"
 	description "Bishoujo Senshi Sailor Moon (Japan)"
-	rom ( name "Bishoujo Senshi Sailor Moon (Japan).cue" size 2619 crc 0542f068 md5 a75f79125e4e30f19fcdc61ad4cd727f sha1 e24d584d81aba54e2aeb55feb71aa2ee069bb053 )
+	rom ( name "Bishoujo Senshi Sailor Moon (Japan).cue" size 10413 crc e645ac0f md5 e2ff3e2d9c65c45fbb0b6d4f2d933175 sha1 d825610729d4b5ef63937aa3c7c78bb925513458 )
 )
 
 game (
@@ -133,15 +349,21 @@ game (
 )
 
 game (
+	name "Bishoujo Senshi Sailor Moon Collection (Japan) - 美少女戦士セーラームーンコレクション"
+	description "Bishoujo Senshi Sailor Moon Collection (Japan) - 美少女戦士セーラームーンコレクション"
+	rom ( name "Bishoujo Senshi Sailor Moon Collection (Japan).cue" size 6374 crc 95c134df md5 ac836c8a82d6240c1abd704be4a15320 sha1 36bfa0cb85bd7e82970ebfae245a43328a01ab16 )
+)
+
+game (
 	name "Black Hole Assault (Japan)"
 	description "Black Hole Assault (Japan)"
-	rom ( name "Black Hole Assault (Japan).cue" size 2426 crc 9089758b md5 0f577575046ea78cef960c8af1eba46a sha1 79e536acfdfd9a574f4b2cf3aa889171cff55d71 )
+	rom ( name "Black Hole Assault (Japan).cue" size 10548 crc 67a89154 md5 5d1d8da931298c4729b9980891e1c792 sha1 d3e8836aae518734d7e1bedbee641223b863559c )
 )
 
 game (
 	name "Blood Gear (Japan)"
 	description "Blood Gear (Japan)"
-	rom ( name "Blood Gear (Japan).cue" size 4152 crc 750afee7 md5 c23a2b7ff6b1556e955243742b304c5d sha1 976eb3b38982c1a833071ce72185812a1716ced3 )
+	rom ( name "Blood Gear (Japan).cue" size 19194 crc 2881da2c md5 bfcc57748b66a41e6f32e07663caf280 sha1 d41ea6e8c3a0aba305b195b4de9a0439f8c4200f )
 )
 
 game (
@@ -157,9 +379,51 @@ game (
 )
 
 game (
+	name "Bomberman '94 Taikenban (Japan)"
+	description "Bomberman '94 Taikenban (Japan)"
+	rom ( name "Bomberman '94 Taikenban (Japan).cue" size 1499 crc 4de25aaa md5 899000cc90454358777a8d8e9f302d5c sha1 56d8fc3de2b495605a8bb464ff3e1c37f13d8006 )
+)
+
+game (
+	name "Bomberman Panic Bomber (Japan) (3FAAT)"
+	description "Bomberman Panic Bomber (Japan) (3FAAT)"
+	rom ( name "Bomberman Panic Bomber (Japan) (3FAAT).cue" size 13544 crc 166369e6 md5 a9974d76d7ccb2dd1fc839814e7b6c17 sha1 b1145e7e9f9038e6338cec1f7b86d272a743cea5 )
+)
+
+game (
+	name "Bomberman Panic Bomber (Japan) (3FABT)"
+	description "Bomberman Panic Bomber (Japan) (3FABT)"
+	rom ( name "Bomberman Panic Bomber (Japan) (3FABT).cue" size 13544 crc 57d62902 md5 3ef90f66479ccda1f5070517b461871e sha1 22420af100458e47a1cc75f397d53771f105f394 )
+)
+
+game (
+	name "Bomberman Panic Bomber (Japan) (Sample)"
+	description "Bomberman Panic Bomber (Japan) (Sample)"
+	rom ( name "Bomberman Panic Bomber (Japan) (Sample).cue" size 11371 crc 30a6dda9 md5 cd548d7cc0515a96e1e2e3fe363cde5a sha1 8b584ce7b829b828436913eaa19c9fe3a11a9805 )
+)
+
+game (
 	name "Bonanza Bros. (Japan)"
 	description "Bonanza Bros. (Japan)"
 	rom ( name "Bonanza Bros. (Japan).cue" size 2241 crc 55901056 md5 58860eea3ea6676f0268196835905ca6 sha1 0a05452e3cbcee8bc2e16315c7ae49f30549f04b )
+)
+
+game (
+	name "Bonanza Brothers (Japan)"
+	description "Bonanza Brothers (Japan)"
+	rom ( name "Bonanza Brothers (Japan).cue" size 10290 crc fb4818a8 md5 ce4188c70222c8320db62f0bf8b83d12 sha1 7fa0075b39cf4dce43a08b60f4dbdb66c2b279b2 )
+)
+
+game (
+	name "Brandish (Japan)"
+	description "Brandish (Japan)"
+	rom ( name "Brandish (Japan).cue" size 13927 crc 78857029 md5 68bf46e4b18650f8fe64c34c84763358 sha1 3c1f4dc45993b662432426ea3a257a4c19589b22 )
+)
+
+game (
+	name "Browning (Japan)"
+	description "Browning (Japan)"
+	rom ( name "Browning (Japan).cue" size 11753 crc 62aa38c1 md5 ef4ac4697eb3b2e3bccc84ba93e020f9 sha1 1a7778b5d8394924f142136e92546d770e82be47 )
 )
 
 game (
@@ -175,9 +439,27 @@ game (
 )
 
 game (
+	name "Builderland (Japan) - ビルダーランド"
+	description "Builderland (Japan) - ビルダーランド"
+	rom ( name "Builderland (Japan).cue" size 4061 crc 5f293936 md5 8f2ee00fc7daa38fdacb60d965ed6e3a sha1 c44eb343a0eee5e4401f2c2be21e3286a149a963 )
+)
+
+game (
+	name "Burai - Hachigyoku no Yuushi Densetsu (Japan) - ブライ+八玉の勇士伝説幻左京"
+	description "Burai - Hachigyoku no Yuushi Densetsu (Japan) - ブライ+八玉の勇士伝説幻左京"
+	rom ( name "Burai - Hachigyoku no Yuushi Densetsu (Japan).cue" size 29751 crc 31630925 md5 ed5121db0a1a6ee05e2a0172304fb2f6 sha1 4a3b3c548599532f58591b667375782f9f92431a )
+)
+
+game (
 	name "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6)"
 	description "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6)"
 	rom ( name "Burai - Yatsudama no Yuushi Densetsu (Japan) (Rev 6).cue" size 8906 crc 739cc5db md5 4f482e45bfd551696740f46febda2fb5 sha1 5ba1b67b294cba6ef99ec30a2ec1639b6d197650 )
+)
+
+game (
+	name "Burai II - Yami Koutei no Gyakushuu (Japan)"
+	description "Burai II - Yami Koutei no Gyakushuu (Japan)"
+	rom ( name "Burai II - Yami Koutei no Gyakushuu (Japan).cue" size 19219 crc d5612523 md5 eb546569bfc585d794a0ea8ec3df1a0a sha1 8095345f07569e90d15fe2150e0dec7eb052bf3f )
 )
 
 game (
@@ -189,13 +471,19 @@ game (
 game (
 	name "Buster Bros. (USA)"
 	description "Buster Bros. (USA)"
-	rom ( name "Buster Bros. (USA).cue" size 2262 crc 611eda79 md5 a958f232f77503e63c07df7c06d16e54 sha1 1353074ea838c9f7a12a4bbc4d182c9e474d0804 )
+	rom ( name "Buster Bros. (USA).cue" size 10689 crc 9a754870 md5 dd31510b3bfc170617306738eb27bedb sha1 f7a3b39a93ef7a035dacfe130c44c4514b4e4c37 )
 )
 
 game (
 	name "CAL II (Japan)"
 	description "CAL II (Japan)"
 	rom ( name "CAL II (Japan).cue" size 697 crc f4637255 md5 8efecd45795f5ddfc9f3817e3e929086 sha1 26a6a801be87ea93e3dd7f76d6eb8d42a1a74405 )
+)
+
+game (
+	name "Cal II (Japan) - キャルII"
+	description "Cal II (Japan) - キャルII"
+	rom ( name "Cal II (Japan).cue" size 3800 crc f657de89 md5 06c2592572a2b666000c2e631228fa7d sha1 86f67a40d7a1dd53957e1f4641d1aa8a251fd732 )
 )
 
 game (
@@ -211,6 +499,18 @@ game (
 )
 
 game (
+	name "Cal III - Kanketsuhen (Japan) - キャルIII+完結編"
+	description "Cal III - Kanketsuhen (Japan) - キャルIII+完結編"
+	rom ( name "Cal III - Kanketsuhen (Japan).cue" size 3005 crc 02616087 md5 4b5cecb5a2f6abde7f8cc55cb82485f5 sha1 e11d39b6d204641a210aa58df8d87a93cf508cc8 )
+)
+
+game (
+	name "Camp California (USA)"
+	description "Camp California (USA)"
+	rom ( name "Camp California (USA).cue" size 31135 crc 83b0f537 md5 0ac3eaadc9408719391a5ece3015652d sha1 b91dda2102e3f9e3f5f72b9980616a07b4e87f49 )
+)
+
+game (
 	name "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
 	description "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
 	rom ( name "Campaign Version - Daisenryaku II (Japan) (Rev 4).cue" size 1647 crc 0adbebba md5 87f7c3d5a30b3fba929a6fbb44ae22b2 sha1 0167fdd6608d3ac6798eb3613b58b266ddbed639 )
@@ -219,7 +519,7 @@ game (
 game (
 	name "Cardangels (Japan)"
 	description "Cardangels (Japan)"
-	rom ( name "Cardangels (Japan).cue" size 3877 crc 2a67d8c6 md5 639b8c4e5d938789a2613d00eeba7a99 sha1 f2322b9ee295c406c3a4a65e5a692bfe1f15198a )
+	rom ( name "Cardangels (Japan).cue" size 17974 crc 09780861 md5 9633fad54ea7f2de83372ee578e34fa0 sha1 e8d11c3c191dbfa99884cdb4e25aa645c6398985 )
 )
 
 game (
@@ -229,15 +529,111 @@ game (
 )
 
 game (
+	name "CD Battle Hikari no Yuushatachi (Japan)"
+	description "CD Battle Hikari no Yuushatachi (Japan)"
+	rom ( name "CD Battle Hikari no Yuushatachi (Japan).cue" size 2461 crc eb2e8495 md5 a67cb4fbf2725f5454a8b4ae81e56651 sha1 347ef64322e553170c4a57a75ff8df2639de0cc3 )
+)
+
+game (
+	name "CD Bishoujo Pachinko Kyuuma Yon Shimai (Japan)"
+	description "CD Bishoujo Pachinko Kyuuma Yon Shimai (Japan)"
+	rom ( name "CD Bishoujo Pachinko Kyuuma Yon Shimai (Japan).cue" size 19082 crc ba905455 md5 3dfa0a261f7e032501126810274dbace sha1 b371279bd95a90591a6b5d31d1d2d7595beaced5 )
+)
+
+game (
 	name "CD Denjin - Rockabilly Tengoku (Japan)"
 	description "CD Denjin - Rockabilly Tengoku (Japan)"
 	rom ( name "CD Denjin - Rockabilly Tengoku (Japan).cue" size 2742 crc 06c7fe8a md5 88beabe6a99d393ba31b55c071377a0a sha1 8c1085672cb1d2ec0b73ffc7f6f2e952aa7b96f3 )
 )
 
 game (
+	name "CD Denjin Rockabilly Tengoku (Japan)"
+	description "CD Denjin Rockabilly Tengoku (Japan)"
+	rom ( name "CD Denjin Rockabilly Tengoku (Japan).cue" size 10707 crc 74f4147c md5 30bd4c0bf93b1967fcd524c32819aeca sha1 eabb97a6518503f0afce295fbd8a79feba2f9b56 )
+)
+
+game (
+	name "CD Hanafuda Bishoujo Fan Club (Japan)"
+	description "CD Hanafuda Bishoujo Fan Club (Japan)"
+	rom ( name "CD Hanafuda Bishoujo Fan Club (Japan).cue" size 16328 crc bd6012ae md5 a86a7b56bec7fa641b587f4c9293959d sha1 3948c8242a115fa8bcd292334fdd5d834580166e )
+)
+
+game (
+	name "CD Mahjong Bishoujo Chuushinha (Japan)"
+	description "CD Mahjong Bishoujo Chuushinha (Japan)"
+	rom ( name "CD Mahjong Bishoujo Chuushinha (Japan).cue" size 11388 crc 1394a996 md5 eedbf10b2eb32852fbd6a1b7432d737a sha1 da87d173c3f8396861c3457c48bee07c95b40947 )
+)
+
+game (
 	name "CD Mahjong Bishoujo Chuushinha (Japan) (Unl)"
 	description "CD Mahjong Bishoujo Chuushinha (Japan) (Unl)"
 	rom ( name "CD Mahjong Bishoujo Chuushinha (Japan) (Unl).cue" size 2762 crc 1b638cc8 md5 eba06760ac0d006275824a80c49836a8 sha1 034d976e69f6d19ebcbd65fecf619863187ee378 )
+)
+
+game (
+	name "CD Pachisuro Bishoujo Gambler (Japan)"
+	description "CD Pachisuro Bishoujo Gambler (Japan)"
+	rom ( name "CD Pachisuro Bishoujo Gambler (Japan).cue" size 24563 crc ca70a896 md5 00e1722c45762dd065c0164bfb913d07 sha1 897428f11c46c4a5a495a84961da9bcdfb44ad8e )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox 2 Go (Japan) - CD-ROM+マガジンウルトラボックス2号"
+	description "CD-ROM Magazine Ultrabox 2 Go (Japan) - CD-ROM+マガジンウルトラボックス2号"
+	rom ( name "CD-ROM Magazine Ultrabox 2 Go (Japan).cue" size 14758 crc 91305ba5 md5 833ec6ee2f8745fdf135da73497175ec sha1 915d04aeb732971830bc88775477a82a2cbc171a )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox 3 Go (Japan) - CD-ROM+マガジンウルトラボックス3号"
+	description "CD-ROM Magazine Ultrabox 3 Go (Japan) - CD-ROM+マガジンウルトラボックス3号"
+	rom ( name "CD-ROM Magazine Ultrabox 3 Go (Japan).cue" size 39271 crc 7b8212d8 md5 e24f3168c8767e0a3c2a854acd40897f sha1 cc2eb2b8203c0be5a6476fd5273469dee0beb54c )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox 4 Go (Japan) - CD-ROM+マガジンウルトラボックス4号"
+	description "CD-ROM Magazine Ultrabox 4 Go (Japan) - CD-ROM+マガジンウルトラボックス4号"
+	rom ( name "CD-ROM Magazine Ultrabox 4 Go (Japan).cue" size 15568 crc 116a95f3 md5 cbd2aa9a9a62e5c683bf6a58d9f28a64 sha1 e44d323e99d0eba879182993106da2070eddebe1 )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox 5 Go (Japan) - CD-ROM+マガジンウルトラボックス5号"
+	description "CD-ROM Magazine Ultrabox 5 Go (Japan) - CD-ROM+マガジンウルトラボックス5号"
+	rom ( name "CD-ROM Magazine Ultrabox 5 Go (Japan).cue" size 13399 crc a168c10b md5 9a5052c69254e65e98499c3ebdc2e1a0 sha1 68ba14052a10b654a79eed766726c9093f2765d1 )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox 6 Go (Japan) - CD-ROM+マガジンウルトラボックス6号"
+	description "CD-ROM Magazine Ultrabox 6 Go (Japan) - CD-ROM+マガジンウルトラボックス6号"
+	rom ( name "CD-ROM Magazine Ultrabox 6 Go (Japan).cue" size 11923 crc 599373bb md5 db45d7aa281b9ee1dc96de25f06e8274 sha1 0d59b533812aefc580edd31108c57bdf29e3e6fc )
+)
+
+game (
+	name "CD-ROM Magazine Ultrabox Sohkan Go (Japan)"
+	description "CD-ROM Magazine Ultrabox Sohkan Go (Japan)"
+	rom ( name "CD-ROM Magazine Ultrabox Sohkan Go (Japan).cue" size 12589 crc e67780d8 md5 8f5e82524579f0ea0e39179e388654a0 sha1 ca3d534630568b8d7258fc31e1bfa68fb2ad7bac )
+)
+
+game (
+	name "Championship Rally (Japan)"
+	description "Championship Rally (Japan)"
+	rom ( name "Championship Rally (Japan).cue" size 5027 crc 9f39df81 md5 e1edee72489f85b014e4056b272fd466 sha1 74c172b2b5031cf1fc8cb21f1e29fad47ce3716e )
+)
+
+game (
+	name "Chiki Chiki Boys (Japan)"
+	description "Chiki Chiki Boys (Japan)"
+	rom ( name "Chiki Chiki Boys (Japan).cue" size 11505 crc 75d0132f md5 e866ccebd06553d3b5a5a222739177ad sha1 530ce38db482d4f5f9dd2fb52ae2bf5beaa5d07e )
+)
+
+game (
+	name "Chou Aniki (Japan)"
+	description "Chou Aniki (Japan)"
+	rom ( name "Chou Aniki (Japan).cue" size 12160 crc cb7507ce md5 370d32210e4578f2a87df8c9229266c6 sha1 4bdbb60d00adb843cd0475fa11675c69b1952975 )
+)
+
+game (
+	name "Chou Eiyuu Denstsu - Dynastic Hero (Japan)"
+	description "Chou Eiyuu Denstsu - Dynastic Hero (Japan)"
+	rom ( name "Chou Eiyuu Denstsu - Dynastic Hero (Japan).cue" size 12184 crc 318127af md5 88cbc7969aa722de71a4f2587d8784d8 sha1 01a440b4111ae587574abfb1d4288b9b3ccd77e5 )
 )
 
 game (
@@ -253,9 +649,21 @@ game (
 )
 
 game (
+	name "Color Wars (Japan)"
+	description "Color Wars (Japan)"
+	rom ( name "Color Wars (Japan).cue" size 7300 crc e9b290fb md5 cf9a7fb0b7ed934e0682a2b72e1c4c88 sha1 145bb9dd7ddde5768f72bb69a71e14ac036a4859 )
+)
+
+game (
 	name "Cosmic Fantasy - Bouken Shounen Yuu (Japan)"
 	description "Cosmic Fantasy - Bouken Shounen Yuu (Japan)"
 	rom ( name "Cosmic Fantasy - Bouken Shounen Yuu (Japan).cue" size 11464 crc c53df0b9 md5 f79003716a6bc53ffe320674aa52294e sha1 0002d3938f85ddf04bb3dc23906eb1429365fda3 )
+)
+
+game (
+	name "Cosmic Fantasy - Bouken Shounen Yuu (Japan) - コズミックファンタジー+冒険少年ユウ"
+	description "Cosmic Fantasy - Bouken Shounen Yuu (Japan) - コズミックファンタジー+冒険少年ユウ"
+	rom ( name "Cosmic Fantasy - Bouken Shounen Yuu (Japan).cue" size 41089 crc ae30368a md5 7e8a5a559eb2c5b5b75b3ac562f9a6b6 sha1 d3602e732255f62e3f8e82883726f2b771020a65 )
 )
 
 game (
@@ -271,9 +679,33 @@ game (
 )
 
 game (
+	name "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan) - コズミックファンタジー2+冒険少年バン"
+	description "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan) - コズミックファンタジー2+冒険少年バン"
+	rom ( name "Cosmic Fantasy 2 - Bouken Shounen Ban (Japan).cue" size 54164 crc 835477a0 md5 3684f63c557ecb6c5b610b1908558864 sha1 5f0cca9c9eea6a5190161ca53de8c1276249a5d6 )
+)
+
+game (
+	name "Cosmic Fantasy 2 (USA)"
+	description "Cosmic Fantasy 2 (USA)"
+	rom ( name "Cosmic Fantasy 2 (USA).cue" size 54141 crc b74221aa md5 b5067a95d3b5eeee734de2aae86c9d85 sha1 289723ffb3ecc32fbcd929c0c25ef5fe0750bb8c )
+)
+
+game (
 	name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan)"
 	description "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan)"
 	rom ( name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan).cue" size 13119 crc 9506f41d md5 e407589b6fd5e4508ede98d8e8a91431 sha1 f06f7288198ced912699571fa1740db90dce6966 )
+)
+
+game (
+	name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan) - コズミックファンタジー3+冒険少年レイ"
+	description "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan) - コズミックファンタジー3+冒険少年レイ"
+	rom ( name "Cosmic Fantasy 3 - Bouken Shounen Rei (Japan).cue" size 50131 crc 523da97d md5 58aa9a5af1479188913b125be0492470 sha1 68870ff1f66c0de878cc7b3a71eaacbde38f73f9 )
+)
+
+game (
+	name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou Hen (Japan)"
+	description "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou Hen (Japan)"
+	rom ( name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Gekitou Hen (Japan).cue" size 24909 crc 97eb96a1 md5 04c717d233c67bfddacf10fcbb085830 sha1 b1d0060b5a9e20d05bb99926f8210b7ea7b398cc )
 )
 
 game (
@@ -283,9 +715,33 @@ game (
 )
 
 game (
+	name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu Hen (Japan)"
+	description "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu Hen (Japan)"
+	rom ( name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu Hen (Japan).cue" size 30581 crc 4b248617 md5 63e269776d31fd141311d4b41bf3b7cd sha1 87d8ccba52821876955a7dbe62d89293e6c694ed )
+)
+
+game (
 	name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan)"
 	description "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan)"
 	rom ( name "Cosmic Fantasy 4 - Ginga Shounen Densetsu - Totsunyuu-hen (Japan).cue" size 10103 crc 4dc80b5a md5 33e043db071ce053cda8fdcb55ed185d sha1 9856e61955fff8529e924b27d2f3fd5e7818c24b )
+)
+
+game (
+	name "Cotton - Fantastic Night Dreams (Japan)"
+	description "Cotton - Fantastic Night Dreams (Japan)"
+	rom ( name "Cotton - Fantastic Night Dreams (Japan).cue" size 11925 crc 7cfff858 md5 eece7b4e0df1d38ff311073309ed4b94 sha1 1c1cef653ac08eaf2dd9ea0fb735bb263d0aa419 )
+)
+
+game (
+	name "Cotton - Fantastic Night Dreams (USA)"
+	description "Cotton - Fantastic Night Dreams (USA)"
+	rom ( name "Cotton - Fantastic Night Dreams (USA).cue" size 11923 crc 6e749645 md5 b8ac115917ea49295ce241f4c6516224 sha1 cdbb0398ebffb0b28d37284df4f08c90a882a1ac )
+)
+
+game (
+	name "Crest of Wolf (Japan)"
+	description "Crest of Wolf (Japan)"
+	rom ( name "Crest of Wolf (Japan).cue" size 10692 crc 2e81f2c7 md5 b22e1c56b239945f66e8edc6b0dd7c10 sha1 a1b5da69d015127a9a152eff803626bda4b1108f )
 )
 
 game (
@@ -295,9 +751,39 @@ game (
 )
 
 game (
+	name "Cyber City Oedo 808 - Kemono no Zokusei (Japan) - サイバーシティ+Oedo+808+獣の属性"
+	description "Cyber City Oedo 808 - Kemono no Zokusei (Japan) - サイバーシティ+Oedo+808+獣の属性"
+	rom ( name "Cyber City Oedo 808 - Kemono no Zokusei (Japan).cue" size 36489 crc 7355f011 md5 2fc85274b9be22bf003bdabeecfaa408 sha1 47babb276c7856a6b54efb3e205e9da398dda870 )
+)
+
+game (
+	name "Daisenpuu Custom (Japan)"
+	description "Daisenpuu Custom (Japan)"
+	rom ( name "Daisenpuu Custom (Japan).cue" size 4620 crc 6ecb520c md5 22f5d64f8fa45f483e17a46dab0743b2 sha1 8055d923410b54803c2a5100e4a1b8e3644c56ec )
+)
+
+game (
+	name "Daisenryaku II - Campaign Version (Japan)"
+	description "Daisenryaku II - Campaign Version (Japan)"
+	rom ( name "Daisenryaku II - Campaign Version (Japan).cue" size 6108 crc 0f63e8f9 md5 303695c050b30ceb0f50d5a325665d86 sha1 4c44e6ba1a041e281069dc1a5d889abe3c44903e )
+)
+
+game (
 	name "Davis Cup Tennis, The (Japan)"
 	description "Davis Cup Tennis, The (Japan)"
 	rom ( name "Davis Cup Tennis, The (Japan).cue" size 2195 crc 30da9d0e md5 844a02217f3803078f48f894fdd555a9 sha1 b66b116f41ae7f7761ac1bfb274b7eded4b9988f )
+)
+
+game (
+	name "Davis Cup Tennis, The (Japan) - ザデビスカップテニス"
+	description "Davis Cup Tennis, The (Japan) - ザデビスカップテニス"
+	rom ( name "Davis Cup Tennis, The (Japan).cue" size 9336 crc 3ebad720 md5 1343c304cda9812c847e1adbc89e5291 sha1 6143b087096d1644c900e5d4fd282ad7a322c3de )
+)
+
+game (
+	name "De Ja (Japan)"
+	description "De Ja (Japan)"
+	rom ( name "De Ja (Japan).cue" size 1481 crc effce7a1 md5 6c05aca8db3787e892b187da3720606a sha1 58aa872afb31d539446b2eb56ce1c41524417561 )
 )
 
 game (
@@ -307,9 +793,33 @@ game (
 )
 
 game (
+	name "Dead of The Brain 1 & 2 (Japan) - Dead of The Brain 1 ; 2"
+	description "Dead of The Brain 1 & 2 (Japan) - Dead of The Brain 1 ; 2"
+	rom ( name "Dead of The Brain 1 & 2 (Japan).cue" size 14752 crc d69b645a md5 c8da7f861f084a9e907947358d40b439 sha1 cbcf60f6145844b8ecf277b4831b5995129049ec )
+)
+
+game (
+	name "Death Bringer - The Knight of Darkness (Japan) - デスブリンガー"
+	description "Death Bringer - The Knight of Darkness (Japan) - デスブリンガー"
+	rom ( name "Death Bringer - The Knight of Darkness (Japan).cue" size 12188 crc 87f9717c md5 601f3d5d824c5779c481875f04528739 sha1 ea1fca551869c24853ed2a7fe226928e179f92ff )
+)
+
+game (
 	name "Death Bringer - The Knight of Darkness (Japan) (Rev 4)"
 	description "Death Bringer - The Knight of Darkness (Japan) (Rev 4)"
 	rom ( name "Death Bringer - The Knight of Darkness (Japan) (Rev 4).cue" size 3602 crc 01be576c md5 28bd9d3135f1ff738f16f23b737ac0ab sha1 014d793dc097810073ff9fa552aaca05910b9b0a )
+)
+
+game (
+	name "Deden no Den (Japan)"
+	description "Deden no Den (Japan)"
+	rom ( name "Deden no Den (Japan).cue" size 1488 crc 1c996183 md5 532fdb76a325c7b156d5c295c1aff9d6 sha1 12bc00184a05d9ae84a490a6585e20a6ec920b4a )
+)
+
+game (
+	name "Dekoboko Densetsu - Hashire Wagamanma (Japan)"
+	description "Dekoboko Densetsu - Hashire Wagamanma (Japan)"
+	rom ( name "Dekoboko Densetsu - Hashire Wagamanma (Japan).cue" size 11377 crc ae265b4e md5 a00a444968d9f4df339687bc46401c70 sha1 1a6da36a665c9a197e5a90e270d70e0298f61024 )
 )
 
 game (
@@ -325,15 +835,51 @@ game (
 )
 
 game (
+	name "Dennou Tenshi - Digital Angel (Japan)"
+	description "Dennou Tenshi - Digital Angel (Japan)"
+	rom ( name "Dennou Tenshi - Digital Angel (Japan).cue" size 2864 crc ce3668c8 md5 1120acc0883804b1dbc463fcb19c040e sha1 4c5feeb1f3bee52f0eddad55b825b2ecd9f008f7 )
+)
+
+game (
+	name "Develo Magazine Volume I (Japan)"
+	description "Develo Magazine Volume I (Japan)"
+	rom ( name "Develo Magazine Volume I (Japan).cue" size 18542 crc 17a05b04 md5 14d9850d0942155b94ffa979eb29fb34 sha1 35e41312fa8fc7c54a19f337d4b23602dd933b50 )
+)
+
+game (
+	name "Develo Starter Kit - Assembler (Japan)"
+	description "Develo Starter Kit - Assembler (Japan)"
+	rom ( name "Develo Starter Kit - Assembler (Japan).cue" size 4080 crc 0377f470 md5 1fa507a56f9075bb9cb9251797286423 sha1 70891a646c40794c556f0aef1ce6837a12d7ccdb )
+)
+
+game (
+	name "Doraemon Nobita no Dorabian Night (Japan)"
+	description "Doraemon Nobita no Dorabian Night (Japan)"
+	rom ( name "Doraemon Nobita no Dorabian Night (Japan).cue" size 15977 crc 49d47179 md5 2e818c1c716c302a1972972f94010a5a sha1 879b6b4c64fa1f22a813ffaa9c56f88d0a25b921 )
+)
+
+game (
 	name "Double Dragon II - The Revenge (Japan)"
 	description "Double Dragon II - The Revenge (Japan)"
 	rom ( name "Double Dragon II - The Revenge (Japan).cue" size 2939 crc 675186d5 md5 b2bd3caefc88f7eb2bb2d32fc26da7d6 sha1 a6fee1a484a74d8b4dd18e89d2cffb230bf661ab )
 )
 
 game (
+	name "Double Dragon II - The Revenge (Japan) - ダブルドラゴンII"
+	description "Double Dragon II - The Revenge (Japan) - ダブルドラゴンII"
+	rom ( name "Double Dragon II - The Revenge (Japan).cue" size 11519 crc 01b3b036 md5 b49ac999ad3d16430850480b74ec7462 sha1 e48ea395a1132fa261ecdf27b9952b1a2bea7238 )
+)
+
+game (
 	name "Doukyuusei (Japan)"
 	description "Doukyuusei (Japan)"
 	rom ( name "Doukyuusei (Japan).cue" size 697 crc fe7901fb md5 59f57a37af3f873322f94c5e3217afeb sha1 429ed4e79b2ca123964a2926864885dbdc5d1a90 )
+)
+
+game (
+	name "Doukyuusei (Japan) (A) - 同級生"
+	description "Doukyuusei (Japan) (A) - 同級生"
+	rom ( name "Doukyuusei (Japan) (A).cue" size 3659 crc 4523e736 md5 f5a49bdefa0085c9dccb60aee2c660e7 sha1 11218c2970e3dea5ab8c3676b06c5ebfeccdb170 )
 )
 
 game (
@@ -349,6 +895,18 @@ game (
 )
 
 game (
+	name "Doukyuusei (Japan) (B) - 同級生"
+	description "Doukyuusei (Japan) (B) - 同級生"
+	rom ( name "Doukyuusei (Japan) (B).cue" size 3659 crc 08608691 md5 1d478cd0a7371005448c280591d8245e sha1 c1cf26b99d43c56e88c8f27a7d8f407f7e8b4d43 )
+)
+
+game (
+	name "Download II (Japan)"
+	description "Download II (Japan)"
+	rom ( name "Download II (Japan).cue" size 7450 crc b7d45d56 md5 60f802e618dbfbdcad926e1923a4d3aa sha1 b5663a0b5dc7c9d789d4c6af894284102e6d2573 )
+)
+
+game (
 	name "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT)"
 	description "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT)"
 	rom ( name "Dragon Ball Z - Idainaru Son Gokuu Densetsu (Japan) (FABT).cue" size 2024 crc 509050aa md5 bfecdb17b767f7916cd5a1e5abff0fe4 sha1 4e6bed613fb71275e66738d6dd569db3ac929a38 )
@@ -357,7 +915,13 @@ game (
 game (
 	name "Dragon Half (Japan)"
 	description "Dragon Half (Japan)"
-	rom ( name "Dragon Half (Japan).cue" size 2104 crc 43b5b909 md5 bd2b3ab2cfbae22c4fc4d825d512c712 sha1 691892ab2509b26533ee31c7f515f4de667b63cc )
+	rom ( name "Dragon Half (Japan).cue" size 9880 crc 9963171d md5 b919a8eb5a93fe82a2c2b52826cec702 sha1 0d856247e626ba8e25105b8540cf7303a9eb2b6e )
+)
+
+game (
+	name "Dragon Knight & Grafitti (Japan)"
+	description "Dragon Knight & Grafitti (Japan)"
+	rom ( name "Dragon Knight & Grafitti (Japan).cue" size 5843 crc 8b4487a8 md5 cdb4c62d3b6f06ae20d590d00efdb92e sha1 ab4575f51db6e781857c351bd12ae17c1693c6e4 )
 )
 
 game (
@@ -367,15 +931,45 @@ game (
 )
 
 game (
+	name "Dragon Knight II (Japan) - ドラゴンナイトII"
+	description "Dragon Knight II (Japan) - ドラゴンナイトII"
+	rom ( name "Dragon Knight II (Japan).cue" size 15555 crc 450c38fe md5 d11e9b582b734637bd2ef244ad3f6a62 sha1 b24132ce6742b3593dda0f7655941509bead50dd )
+)
+
+game (
 	name "Dragon Knight III (Japan)"
 	description "Dragon Knight III (Japan)"
 	rom ( name "Dragon Knight III (Japan).cue" size 1945 crc 8d2eee05 md5 afb37026d3e31dbc7aed21548c7c4968 sha1 4e8b4d5be4e62eb9630fa7fc2e78dadf75ef17c4 )
 )
 
 game (
+	name "Dragon Knight III (Japan) - ドラゴンナイトIII"
+	description "Dragon Knight III (Japan) - ドラゴンナイトIII"
+	rom ( name "Dragon Knight III (Japan).cue" size 8671 crc 038fff0f md5 2f448e0ebcfe1567c13f6cc63a5c3879 sha1 ae73e0a0fedb8ba1ce26722ba0607dd3f8b92350 )
+)
+
+game (
+	name "Dragon Slayer - Eiyuu Densetsu (Japan) - ドラゴンスレイヤー+英雄伝説"
+	description "Dragon Slayer - Eiyuu Densetsu (Japan) - ドラゴンスレイヤー+英雄伝説"
+	rom ( name "Dragon Slayer - Eiyuu Densetsu (Japan).cue" size 9899 crc 61aa36b0 md5 0c4c10099f319df8a1c521d9daf8333d sha1 e22c4e2b9584fa6d9f97a8c6aa6c3e285439bff7 )
+)
+
+game (
+	name "Dragon Slayer - Eiyuu Densetsu II (Japan) - ドラゴンスレイヤー+英雄伝説II"
+	description "Dragon Slayer - Eiyuu Densetsu II (Japan) - ドラゴンスレイヤー+英雄伝説II"
+	rom ( name "Dragon Slayer - Eiyuu Densetsu II (Japan).cue" size 10563 crc 119d3837 md5 b730494b13dc3fd1f098ed7852d38a76 sha1 b11ca1ef110960c8ad878191e3b6f1fa5666aaa9 )
+)
+
+game (
 	name "Dragon Slayer - The Legend of Heroes (Japan)"
 	description "Dragon Slayer - The Legend of Heroes (Japan)"
 	rom ( name "Dragon Slayer - The Legend of Heroes (Japan).cue" size 2654 crc a3793925 md5 55259e6136d702bb6888bb5e6e453636 sha1 5ce6b1229c76ee330f3742889af8d05513d6b679 )
+)
+
+game (
+	name "Dragon Slayer - The Legend of Heroes (USA)"
+	description "Dragon Slayer - The Legend of Heroes (USA)"
+	rom ( name "Dragon Slayer - The Legend of Heroes (USA).cue" size 9903 crc eae8061d md5 525b33519f4c776e3baa53cf1d20dc0c sha1 6e4b67013ac7870fae1b8e7a76ce57e10d6728d5 )
 )
 
 game (
@@ -391,6 +985,18 @@ game (
 )
 
 game (
+	name "Dragonball Z - Idainaru Son Gokuu Densetsu (Japan)"
+	description "Dragonball Z - Idainaru Son Gokuu Densetsu (Japan)"
+	rom ( name "Dragonball Z - Idainaru Son Gokuu Densetsu (Japan).cue" size 6927 crc 833f64e5 md5 a9920251f704d276667e4e23aac9e9ea sha1 c758fb2fbfc1bec5dac76b1330ec64753be75d7a )
+)
+
+game (
+	name "Dungeon Explorer II (Japan)"
+	description "Dungeon Explorer II (Japan)"
+	rom ( name "Dungeon Explorer II (Japan).cue" size 14748 crc e1c63cea md5 f733f22e4368afcf4f40d0d995c60764 sha1 94442fcc870b5a818dc712c738149b9478ef8d37 )
+)
+
+game (
 	name "Dungeon Explorer II (Japan) (Rev 5)"
 	description "Dungeon Explorer II (Japan) (Rev 5)"
 	rom ( name "Dungeon Explorer II (Japan) (Rev 5).cue" size 3740 crc 33c75650 md5 82d0780c9478653156352324c23004d5 sha1 448b02332223f11cdf8c356e94e961ff801fd3a6 )
@@ -403,6 +1009,12 @@ game (
 )
 
 game (
+	name "Dungeon Master - Theron's Quest (Japan) - ダンジジョンマスター+セエロンズクエスト"
+	description "Dungeon Master - Theron's Quest (Japan) - ダンジジョンマスター+セエロンズクエスト"
+	rom ( name "Dungeon Master - Theron's Quest (Japan).cue" size 8685 crc 0759d570 md5 96389818199445859780cbe229cb80cb sha1 3543824824d13113edc45ae9677f9205a55948c9 )
+)
+
+game (
 	name "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
 	description "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
 	rom ( name "Dungeon Master - Theron's Quest (Japan) (Rev 1).cue" size 2363 crc e7e53704 md5 85706e7c2f658bc2792511d618dfc7a5 sha1 55ee4a0fb1249fc0d448c63db2eba531552e0670 )
@@ -411,7 +1023,7 @@ game (
 game (
 	name "Dungeon Master - Theron's Quest (USA)"
 	description "Dungeon Master - Theron's Quest (USA)"
-	rom ( name "Dungeon Master - Theron's Quest (USA).cue" size 2173 crc f09fb9c5 md5 63dbd2fab613b2e8030ff4e44b978a39 sha1 faeeb80715979a809ec7b0811e8ea3e2e12ee2d0 )
+	rom ( name "Dungeon Master - Theron's Quest (USA).cue" size 8683 crc a1b049f1 md5 7b0965fde85d679ea10b94f8e26c3b10 sha1 18bd99fc52ce4604649dd9abd0a694d09f6fb590 )
 )
 
 game (
@@ -421,9 +1033,33 @@ game (
 )
 
 game (
+	name "Efera & Jiliora - The Emblem From Darkness (Japan)"
+	description "Efera & Jiliora - The Emblem From Darkness (Japan)"
+	rom ( name "Efera & Jiliora - The Emblem From Darkness (Japan).cue" size 7886 crc 005c200e md5 1b1a2952505be8d279c56a0e3f3fec99 sha1 43e0ff205af2d428667717c175858f3cb1a4bf6b )
+)
+
+game (
+	name "Eikan ha Kimini - Koukou Yakyuu Zenkoku Taikai (Japan)"
+	description "Eikan ha Kimini - Koukou Yakyuu Zenkoku Taikai (Japan)"
+	rom ( name "Eikan ha Kimini - Koukou Yakyuu Zenkoku Taikai (Japan).cue" size 13411 crc b756bc37 md5 8b8565dbe61a2a5986271afa47db36b0 sha1 d1a9ba6d2903c80bc3731ba935daf8ffe3e98bae )
+)
+
+game (
 	name "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan)"
 	description "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan)"
 	rom ( name "Eikan wa Kimi ni - Koukou Yakyuu Zenkoku Taikai (Japan).cue" size 4011 crc 2685eca0 md5 358a2c75f8ae993fbf3aedc2bcce2853 sha1 971ff86be6bd24dd9efb8664f1cd3192d83f0c70 )
+)
+
+game (
+	name "Eiyuu Sangokushi (Japan)"
+	description "Eiyuu Sangokushi (Japan)"
+	rom ( name "Eiyuu Sangokushi (Japan).cue" size 6901 crc 19d59b0b md5 b5fcbea06693555856eb208e8d4bf7f6 sha1 3d33ed9ba51ab1eb505fb5a4988cac8f34134ea3 )
+)
+
+game (
+	name "Emerald Dragon (Japan)"
+	description "Emerald Dragon (Japan)"
+	rom ( name "Emerald Dragon (Japan).cue" size 13379 crc 4d9be3e0 md5 c6274901095540d42f6ca4d9d231c4ad sha1 13b8e7cdad02a4affb36bbf559f2ccf6cd3e7028 )
 )
 
 game (
@@ -439,15 +1075,51 @@ game (
 )
 
 game (
+	name "Emerald Dragon Taikenban (Japan)"
+	description "Emerald Dragon Taikenban (Japan)"
+	rom ( name "Emerald Dragon Taikenban (Japan).cue" size 8934 crc db4dd66c md5 a5c8be49ef234128460c75ac6c237522 sha1 5af68186eba16fc86577f93eb4cefacc9eba8556 )
+)
+
+game (
 	name "Exile - Toki no Hasama e (Japan)"
 	description "Exile - Toki no Hasama e (Japan)"
 	rom ( name "Exile - Toki no Hasama e (Japan).cue" size 4130 crc 6942f3de md5 967146da783aad6d894021e08f1e9d90 sha1 274f7298b9970dc3157c1f1ce67ff498c52e0bde )
 )
 
 game (
+	name "Exile - Toki no Hasama he (Japan)"
+	description "Exile - Toki no Hasama he (Japan)"
+	rom ( name "Exile - Toki no Hasama he (Japan).cue" size 16630 crc 9d717f79 md5 af16e7662612fcd6286de2df5615a1e8 sha1 ae71203b448949e97f3b4ad9abc278e618c718e4 )
+)
+
+game (
+	name "Exile (USA)"
+	description "Exile (USA)"
+	rom ( name "Exile (USA).cue" size 16203 crc e03bbf09 md5 1f6713effcb8900e43b63c272ef3b419 sha1 ab32880eaa8d0b492023d61a73929f5a186d3f4f )
+)
+
+game (
 	name "Exile II - Janen no Jishou (Japan)"
 	description "Exile II - Janen no Jishou (Japan)"
 	rom ( name "Exile II - Janen no Jishou (Japan).cue" size 3042 crc 1fe14ada md5 5c2e8acd2b449190992042a11014ee40 sha1 31f71cfd068761c646b7f3ff4f2303e685ddcc45 )
+)
+
+game (
+	name "Exile II - Janen no Jishou (Japan) - エグザイルII+邪念の事象"
+	description "Exile II - Janen no Jishou (Japan) - エグザイルII+邪念の事象"
+	rom ( name "Exile II - Janen no Jishou (Japan).cue" size 12176 crc c475a230 md5 f7f2c883f028a9c16526ef144f598253 sha1 4511dd0e1332e78d5ec815827b3c7cca14f659b7 )
+)
+
+game (
+	name "F1 Circus Special - Pole to Win (Japan) (4FABT) - エフワンサーカススペシャル+ポールトゥウイン"
+	description "F1 Circus Special - Pole to Win (Japan) (4FABT) - エフワンサーカススペシャル+ポールトゥウイン"
+	rom ( name "F1 Circus Special - Pole to Win (Japan) (4FABT).cue" size 26513 crc 8b9e9b9d md5 dfa836a37833660c44bcbcb92a5e9737 sha1 86303f6339a1679494a1cf62705bc4e9fd657de7 )
+)
+
+game (
+	name "F1 Circus Special - Pole to Win (Japan) (4FACT) - エフワンサーカススペシャル+ポールトゥウイン"
+	description "F1 Circus Special - Pole to Win (Japan) (4FACT) - エフワンサーカススペシャル+ポールトゥウイン"
+	rom ( name "F1 Circus Special - Pole to Win (Japan) (4FACT).cue" size 26513 crc 33fd6c4b md5 cd59846614bc7a6d9fbee7601ad0f889 sha1 4e220ae71bf649b35b9176bc17d963647dd8168f )
 )
 
 game (
@@ -469,15 +1141,33 @@ game (
 )
 
 game (
+	name "F1 Team Simulation Project F (Japan)"
+	description "F1 Team Simulation Project F (Japan)"
+	rom ( name "F1 Team Simulation Project F (Japan).cue" size 13542 crc 079559b2 md5 0aa3a9915ca00d06d00ec3decbeeb251 sha1 def03c69154b55036f11e35d9c6f3be5364f072d )
+)
+
+game (
 	name "Faceball (Japan)"
 	description "Faceball (Japan)"
-	rom ( name "Faceball (Japan).cue" size 1510 crc 1d39808b md5 e1b2000de014b19cb7793c3b9415a824 sha1 c567c0212e835e819e56f3561729c6adab761120 )
+	rom ( name "Faceball (Japan).cue" size 7447 crc 1c46e0c9 md5 820a1f8a81b2f81deedb157bcd48b43f sha1 d64ab297a6866ed54a33df71642a17bba952e3f9 )
 )
 
 game (
 	name "Faceball (Japan) (Sample)"
 	description "Faceball (Japan) (Sample)"
 	rom ( name "Faceball (Japan) (Sample).cue" size 1529 crc 7c9748ce md5 77d4b5386ef423804c81b7d815455b65 sha1 73159be26571d7d748e307ee2e4e3d55f8800fc8 )
+)
+
+game (
+	name "Faceball Taikenban (Japan)"
+	description "Faceball Taikenban (Japan)"
+	rom ( name "Faceball Taikenban (Japan).cue" size 6903 crc 3129a37c md5 7926168b62c542628b1a20522eb562e1 sha1 dbee34bbd4a2e08320b3c26b7070bd4397801d0d )
+)
+
+game (
+	name "Faerie Dust Story - Meikyuu no Elfeene (Japan)"
+	description "Faerie Dust Story - Meikyuu no Elfeene (Japan)"
+	rom ( name "Faerie Dust Story - Meikyuu no Elfeene (Japan).cue" size 45737 crc 93aeb291 md5 3e40d5df0b82895888170e36c3f19669 sha1 6414c5d837e4252020c2c6df310ccbea70eb03cd )
 )
 
 game (
@@ -535,9 +1225,33 @@ game (
 )
 
 game (
+	name "Farjius no Jakoutei - Neo Metal Fantasy (Japan)"
+	description "Farjius no Jakoutei - Neo Metal Fantasy (Japan)"
+	rom ( name "Farjius no Jakoutei - Neo Metal Fantasy (Japan).cue" size 13148 crc 990cae09 md5 9c81f847394cac7c60d77076c50d9a86 sha1 3a134016ac3f2b25a794b62d2da4b9409464b6e8 )
+)
+
+game (
+	name "Faussete Amour (Japan) - Fausseté Amour"
+	description "Faussete Amour (Japan) - Fausseté Amour"
+	rom ( name "Faussete Amour (Japan).cue" size 19603 crc b1a661fa md5 ff6283c09ca316be6d740c5abf96fdd8 sha1 45e6bf12f236e04506f32c11af092996311e87f9 )
+)
+
+game (
+	name "Fiend Hunter (Japan)"
+	description "Fiend Hunter (Japan)"
+	rom ( name "Fiend Hunter (Japan).cue" size 9732 crc 1ee32bdb md5 cc829dc1afbd9508969b242fdcd2f5ed sha1 2dabf8b1435f2cb04df9fe7a2a5067bdeeb5fa6c )
+)
+
+game (
 	name "Fiend Hunter (Japan) (Rev 2)"
 	description "Fiend Hunter (Japan) (Rev 2)"
 	rom ( name "Fiend Hunter (Japan) (Rev 2).cue" size 2274 crc 0648c769 md5 8d0f842eceae07e7c4467e7bea9bde70 sha1 2f18daf89e3561201d938579a4a1a611598b4f41 )
+)
+
+game (
+	name "Fighting Street (Japan)"
+	description "Fighting Street (Japan)"
+	rom ( name "Fighting Street (Japan).cue" size 11504 crc 4b0a493d md5 0920fc1c9234a8f22ed3f7584de43766 sha1 37870b714d13358d952b13d570f10ed17ebd5027 )
 )
 
 game (
@@ -547,9 +1261,39 @@ game (
 )
 
 game (
+	name "Fighting Street (USA)"
+	description "Fighting Street (USA)"
+	rom ( name "Fighting Street (USA).cue" size 11502 crc 2f817c27 md5 3947322b99aedf5ed242133cc3d1d72f sha1 f00d2e95152136233729e0fd3852e1ac10f67b92 )
+)
+
+game (
+	name "Final Zone II (Japan)"
+	description "Final Zone II (Japan)"
+	rom ( name "Final Zone II (Japan).cue" size 23098 crc a541bc59 md5 c7de76a8ef208da86ae7ce60f2ae371d sha1 53c6b9d715947c3c8883cf19f2c9888630855478 )
+)
+
+game (
 	name "Final Zone II (Japan) (Rev 3)"
 	description "Final Zone II (Japan) (Rev 3)"
 	rom ( name "Final Zone II (Japan) (Rev 3).cue" size 5629 crc fbb0b937 md5 f59636931c52cf4bd863bc984f666136 sha1 536fb353a9913f106e60a36b4b585ecb937edd8f )
+)
+
+game (
+	name "Final Zone II (USA)"
+	description "Final Zone II (USA)"
+	rom ( name "Final Zone II (USA).cue" size 23096 crc 175ad101 md5 27293bc8a5b72f91062db223e9b6dfbf sha1 dfb2b0e9e721d7c72da2a9f9ba5224eb6d2cbcc6 )
+)
+
+game (
+	name "Fire Pro Jyoshi - Dome Chojyo Taisen (Japan)"
+	description "Fire Pro Jyoshi - Dome Chojyo Taisen (Japan)"
+	rom ( name "Fire Pro Jyoshi - Dome Chojyo Taisen (Japan).cue" size 8946 crc 508dd6ce md5 148509c1acb571b921b5ba26168ee6b9 sha1 44c5d453cf0c88aea893b32c6221f6a4392e2596 )
+)
+
+game (
+	name "Flash Hiders (Japan)"
+	description "Flash Hiders (Japan)"
+	rom ( name "Flash Hiders (Japan).cue" size 18791 crc a739ae96 md5 b3bf444d4b243cfa177d87311b8d8cd1 sha1 0200575f020edbed682985af6edca1f75021383f )
 )
 
 game (
@@ -559,9 +1303,81 @@ game (
 )
 
 game (
+	name "Forgotten Worlds (Packed with Avenue Pad 3) (Japan) - フォゴットンワールド"
+	description "Forgotten Worlds (Packed with Avenue Pad 3) (Japan) - フォゴットンワールド"
+	rom ( name "Forgotten Worlds (Packed with Avenue Pad 3) (Japan).cue" size 11127 crc b551550b md5 3dc409cc2bf91ce1eb3465a07ca69cf7 sha1 2ed28cad2f6397525ae377b6986d50e2a19b6f07 )
+)
+
+game (
+	name "Forgotten Worlds (USA)"
+	description "Forgotten Worlds (USA)"
+	rom ( name "Forgotten Worlds (USA).cue" size 11098 crc 285dd38b md5 20f93db272d3f7a92d344b4b83eacb10 sha1 b34053fd10c244b90a25f170a820227fb35f2a04 )
+)
+
+game (
+	name "Formation Soccer '95 - Della Serie A (Japan)"
+	description "Formation Soccer '95 - Della Serie A (Japan)"
+	rom ( name "Formation Soccer '95 - Della Serie A (Japan).cue" size 13401 crc a2cbe47b md5 8d9f3847e9bb7b2fff5bd01d89dc16ff sha1 ea4478f3eea7a416058e6329c27c230c450ab5ca )
+)
+
+game (
+	name "Fray CD - Xak Gaiden (Japan)"
+	description "Fray CD - Xak Gaiden (Japan)"
+	rom ( name "Fray CD - Xak Gaiden (Japan).cue" size 23659 crc 5e54ee71 md5 151ccdfd69483c27bdd5ce23f490b562 sha1 e3925952977c05f2ff4af38caa1b9cdde1e4b9db )
+)
+
+game (
 	name "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1)"
 	description "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1)"
 	rom ( name "Fushigi no Umi no Nadia - The Secret of Blue Water (Japan) (Rev 1).cue" size 1335 crc 164801e7 md5 378b5e1dae54f6907b7d08f63631888e sha1 5582c0a61063b961b814ac6cb9a7622d84b5bf97 )
+)
+
+game (
+	name "Fushigi no Umi no Nadia (Japan)"
+	description "Fushigi no Umi no Nadia (Japan)"
+	rom ( name "Fushigi no Umi no Nadia (Japan).cue" size 4627 crc 0776506d md5 0c6b4805deef569f2f683d560e175cb4 sha1 9835295c5606755c8c48372695247323a85e3400 )
+)
+
+game (
+	name "Gain Ground SX (Japan)"
+	description "Gain Ground SX (Japan)"
+	rom ( name "Gain Ground SX (Japan).cue" size 4874 crc b520601e md5 0ca6b81528dd92c603bfb1528b872d40 sha1 8c87df56c9e44646f257c8c4b69113d8f730d9cb )
+)
+
+game (
+	name "Galaxy Deka Gayvan (Japan)"
+	description "Galaxy Deka Gayvan (Japan)"
+	rom ( name "Galaxy Deka Gayvan (Japan).cue" size 7862 crc 445ad169 md5 e95b4c4bb8aaf7e20cec57f55a8947fb sha1 c808e1fe39f6b39bb7b54722d18437d0093627f8 )
+)
+
+game (
+	name "Galaxy Fraulein Yuna HuVideo CD (Japan)"
+	description "Galaxy Fraulein Yuna HuVideo CD (Japan)"
+	rom ( name "Galaxy Fraulein Yuna HuVideo CD (Japan).cue" size 1507 crc dd67f3ff md5 b5f8ed996f674013bc24467c3e0775fd sha1 77feca1e35d246b6e1375bd9ccd534d32ac2a983 )
+)
+
+game (
+	name "Gambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan) - ぎゅわんぶらぁ自己中心派+麻雀パズルコレクション"
+	description "Gambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan) - ぎゅわんぶらぁ自己中心派+麻雀パズルコレクション"
+	rom ( name "Gambler Jiko Chuushinha - Mahjong Puzzle Collection (Japan).cue" size 9771 crc d1391ba1 md5 15f1f8ed98554c8f903272e518531489 sha1 0ce1b2b6a27a1bd4667e8a57d4567f9ccb12e698 )
+)
+
+game (
+	name "Gambler Jikochuushinha (Japan)"
+	description "Gambler Jikochuushinha (Japan)"
+	rom ( name "Gambler Jikochuushinha (Japan).cue" size 5031 crc 8515c6e2 md5 7cc2786e76112f30092ad778ca3bede9 sha1 e65351a60d9cf1ccc593e594e5eccc3226f5a7a2 )
+)
+
+game (
+	name "Ganchouhishi - Aoki Ookami to Shiroki Mejika (Japan)"
+	description "Ganchouhishi - Aoki Ookami to Shiroki Mejika (Japan)"
+	rom ( name "Ganchouhishi - Aoki Ookami to Shiroki Mejika (Japan).cue" size 7483 crc dbd286d0 md5 617c32c62b7196031db55fd367038523 sha1 d1e75e5ee6fee573a566c25f903ded90ab0b0625 )
+)
+
+game (
+	name "Garou Densetsu 2 - Aratanaru Tatakai (Japan) - 餓狼伝説2+新たなる闘い"
+	description "Garou Densetsu 2 - Aratanaru Tatakai (Japan) - 餓狼伝説2+新たなる闘い"
+	rom ( name "Garou Densetsu 2 - Aratanaru Tatakai (Japan).cue" size 9095 crc 49c66b72 md5 26b74212b6dfbb72f57ca1966234ad34 sha1 353393e73aee022a94714eefbf4eb76656f45a6f )
 )
 
 game (
@@ -571,9 +1387,33 @@ game (
 )
 
 game (
+	name "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (Sample)"
+	description "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (Sample)"
+	rom ( name "Garou Densetsu 2 - Aratanaru Tatakai (Japan) (Sample).cue" size 9509 crc d5ffac03 md5 6777d3afe103bb03291cdcce00757808 sha1 78697ad814c714d5846fa5bf42fde1f62a943a67 )
+)
+
+game (
+	name "Garou Densetsu Special (Japan)"
+	description "Garou Densetsu Special (Japan)"
+	rom ( name "Garou Densetsu Special (Japan).cue" size 10296 crc 139f4af5 md5 46ccaf78ee5b98d4dfacfe987b837e53 sha1 e9dabc594f2ed3e80be358aea760d113f24a6503 )
+)
+
+game (
 	name "Garou Densetsu Special (Japan) (FABT)"
 	description "Garou Densetsu Special (Japan) (FABT)"
 	rom ( name "Garou Densetsu Special (Japan) (FABT).cue" size 2586 crc 8233ee8d md5 a6c38fb85cd82c71bb34dbaeb5ca495e sha1 8329ce2a1ce13e4dbb53152ffbadf8b3b351af63 )
+)
+
+game (
+	name "Garou Densetsu Special (Japan) (Sample)"
+	description "Garou Densetsu Special (Japan) (Sample)"
+	rom ( name "Garou Densetsu Special (Japan) (Sample).cue" size 9751 crc 9b34e18d md5 5fe7d3924d698f62108fbaaf3989a46b sha1 9a9947d0da58671f10e3c8cb505e0a3ce8023d6d )
+)
+
+game (
+	name "Gate of Thunder (Japan)"
+	description "Gate of Thunder (Japan)"
+	rom ( name "Gate of Thunder (Japan).cue" size 8264 crc 3ce07a68 md5 f216f32b97b39f0124f7b9df732ea382 sha1 44b5e409a8c5e7c6ee0f31858ba01042c966b989 )
 )
 
 game (
@@ -583,15 +1423,39 @@ game (
 )
 
 game (
+	name "Genocide (Japan)"
+	description "Genocide (Japan)"
+	rom ( name "Genocide (Japan).cue" size 10687 crc 7ccd20c0 md5 6dcbba0a7a510be4adb184a8ab81146e sha1 d4808f1d4f9a680f1dd4aa63d5072cc43f6ead03 )
+)
+
+game (
 	name "Genocide (Japan) (Rev 2)"
 	description "Genocide (Japan) (Rev 2)"
 	rom ( name "Genocide (Japan) (Rev 2).cue" size 2406 crc cad278e1 md5 8bed660ca35b26369852a46b1989d927 sha1 e4576f4927f1b82afaaf4d013215286bf70e2c91 )
 )
 
 game (
+	name "Gensou Tairiku Auleria (Japan)"
+	description "Gensou Tairiku Auleria (Japan)"
+	rom ( name "Gensou Tairiku Auleria (Japan).cue" size 13941 crc 7f1dcd57 md5 06972c1bad7d280881a32da06fab6a4a sha1 c59fc4301dfc15582ae5c454fd8e27cb293977b3 )
+)
+
+game (
+	name "Ginga Fukei Densetsu Sapphire (Japan) (Bootleg)"
+	description "Ginga Fukei Densetsu Sapphire (Japan) (Bootleg)"
+	rom ( name "Ginga Fukei Densetsu Sapphire (Japan) (Bootleg).cue" size 9755 crc ccda904b md5 438cbd313ef6cd9346f6743d4e52a133 sha1 e977a213400c01c83e1649a82bc71a04d41fb129 )
+)
+
+game (
 	name "Ginga Fukei Densetsu Sapphire (Japan) (Reprint)"
 	description "Ginga Fukei Densetsu Sapphire (Japan) (Reprint)"
 	rom ( name "Ginga Fukei Densetsu Sapphire (Japan) (Reprint).cue" size 2401 crc 5fbfb2b4 md5 d797837b5183e04731372bdba080b248 sha1 afe842162ab772fede42d2a668cd78fa81ddde64 )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna (Japan)"
+	description "Ginga Ojousama Densetsu Yuna (Japan)"
+	rom ( name "Ginga Ojousama Densetsu Yuna (Japan).cue" size 5037 crc a74f05da md5 0dded831a5f09035be31cf389f89934f sha1 a00a06f62a9aad12780bc20de0208d977018e1b3 )
 )
 
 game (
@@ -607,9 +1471,21 @@ game (
 )
 
 game (
+	name "Ginga Ojousama Densetsu Yuna (Japan) (Hu Video)"
+	description "Ginga Ojousama Densetsu Yuna (Japan) (Hu Video)"
+	rom ( name "Ginga Ojousama Densetsu Yuna (Japan) (Hu Video).cue" size 5048 crc 6587fae9 md5 43a07ff5b749ee8288e1fe9846506766 sha1 f0d4322180f2b296d179ac2b1423f152367f1abf )
+)
+
+game (
 	name "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT)"
 	description "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT)"
 	rom ( name "Ginga Ojousama Densetsu Yuna 2 - Eien no Princess (Japan) (FABT).cue" size 3230 crc f69ea536 md5 598e8589b799db4826cafbdd21828719 sha1 aa9e2a3da3a3e13c210b1ddf47dbf693ee840c2d )
+)
+
+game (
+	name "Ginga Ojousama Densetsu Yuna 2 (Japan)"
+	description "Ginga Ojousama Densetsu Yuna 2 (Japan)"
+	rom ( name "Ginga Ojousama Densetsu Yuna 2 (Japan).cue" size 10304 crc 970acc18 md5 a0ae16caeea8f331a21bd86314286baa sha1 016b19224b7a0c7d7a0e718769ef5aeffd90f45f )
 )
 
 game (
@@ -625,6 +1501,24 @@ game (
 )
 
 game (
+	name "God Panic - Shijyou Saikyo Gundan (Japan)"
+	description "God Panic - Shijyou Saikyo Gundan (Japan)"
+	rom ( name "God Panic - Shijyou Saikyo Gundan (Japan).cue" size 10968 crc ddd7c083 md5 ceef84a2b6648c737fb03c4dc79dd1bf sha1 481f8035d59f49f7da803dc39402b120e8a3f14f )
+)
+
+game (
+	name "Godzilla - Bakutou Retsu Den (Japan)"
+	description "Godzilla - Bakutou Retsu Den (Japan)"
+	rom ( name "Godzilla - Bakutou Retsu Den (Japan).cue" size 10707 crc c7d3b063 md5 9ef8682e79ec3c8eac2423a7092e37b2 sha1 59831fb2c9f188ff221b4cedd689e3bc0e79d643 )
+)
+
+game (
+	name "Godzilla (USA)"
+	description "Godzilla (USA)"
+	rom ( name "Godzilla (USA).cue" size 10685 crc a694911e md5 93d48cc80466f9c3633c9d537dd94ac9 sha1 aeb3f5c51eeae6b3a377365426d792d3370cfba4 )
+)
+
+game (
 	name "Godzilla Bakutou Retsuden (Japan) (Rev 1)"
 	description "Godzilla Bakutou Retsuden (Japan) (Rev 1)"
 	rom ( name "Godzilla Bakutou Retsuden (Japan) (Rev 1).cue" size 2814 crc 510198e4 md5 64cf5b0ec07185fd430987aafc655d9e sha1 6f5deecfe856314454ba66a4c2eb602cbc01166d )
@@ -637,9 +1531,21 @@ game (
 )
 
 game (
+	name "Goetzendiener (Japan) - Götzendiener"
+	description "Goetzendiener (Japan) - Götzendiener"
+	rom ( name "Goetzendiener (Japan).cue" size 6088 crc 08e5cc8b md5 e7373960de07674a4477cea3d6161fe3 sha1 27620f0950272000e2178fc8ecaad4a1330f8a31 )
+)
+
+game (
 	name "Golden Axe (Japan)"
 	description "Golden Axe (Japan)"
 	rom ( name "Golden Axe (Japan).cue" size 6441 crc 0119a5bd md5 9c9045a3875bd3adf788354e08417670 sha1 f600ab5c92122d62ae40b826d41d4e8b56ec62c6 )
+)
+
+game (
+	name "Golden Axe (Japan) - ゴールデンアックス"
+	description "Golden Axe (Japan) - ゴールデンアックス"
+	rom ( name "Golden Axe (Japan).cue" size 29575 crc e34ef7e8 md5 04e88c76d81ffe0c5b9b935fab7bfcda sha1 55e2bd4d9194008fdb5f171e1090aebaa3d73874 )
 )
 
 game (
@@ -651,7 +1557,19 @@ game (
 game (
 	name "Gradius II - Gofer no Yabou (Japan)"
 	description "Gradius II - Gofer no Yabou (Japan)"
-	rom ( name "Gradius II - Gofer no Yabou (Japan).cue" size 3098 crc 00738bf2 md5 c350d8caedf75342e6bc90f971ef8bd8 sha1 5ee196838abcab72fca933849f76d6091c00f069 )
+	rom ( name "Gradius II - Gofer no Yabou (Japan).cue" size 12326 crc f961059b md5 87f1bbf74ca8f8a09b046e17dac130c0 sha1 4c7d4262d7d3cca4d40c6af2c4cc5170f6a7b165 )
+)
+
+game (
+	name "GS Mikami (Japan)"
+	description "GS Mikami (Japan)"
+	rom ( name "GS Mikami (Japan).cue" size 8109 crc c26c31b0 md5 c27af04ee304dc1fb6783d65a6332272 sha1 530eab659547984dbad9941b749229a4d1e36c40 )
+)
+
+game (
+	name "Gulclight TDF 2 (Japan)"
+	description "Gulclight TDF 2 (Japan)"
+	rom ( name "Gulclight TDF 2 (Japan).cue" size 7049 crc 8ea0e7fd md5 3348a7266fd8bb637bf0594686076c0c sha1 f9cd2487057d3830dcd09c7c96573df2f3a543bd )
 )
 
 game (
@@ -685,6 +1603,12 @@ game (
 )
 
 game (
+	name "Hatsukoi Monogatari (Japan) - 初恋物語"
+	description "Hatsukoi Monogatari (Japan) - 初恋物語"
+	rom ( name "Hatsukoi Monogatari (Japan).cue" size 3259 crc cc67c76b md5 4666dfea9dac8239d7b7532662107b34 sha1 3684e534c7dfe75904a2f2b108dc150b8ec22118 )
+)
+
+game (
 	name "Hatsukoi Monogatari (Japan) (HRTI20307)"
 	description "Hatsukoi Monogatari (Japan) (HRTI20307)"
 	rom ( name "Hatsukoi Monogatari (Japan) (HRTI20307).cue" size 734 crc 91807ab5 md5 3e258269a2235af3f705852c0b7b7b4e sha1 54cf0788ab6e62de34c3ce922898d009d2e54dab )
@@ -697,15 +1621,51 @@ game (
 )
 
 game (
+	name "Hawaiian Island Girls (USA)"
+	description "Hawaiian Island Girls (USA)"
+	rom ( name "Hawaiian Island Girls (USA).cue" size 946 crc 10bf173d md5 bd617bd2ae72848efff9bd078540cf15 sha1 f11a72f30248d4cf2f12fc487d9d40b5c96d8aed )
+)
+
+game (
+	name "Hawk F-123 (Japan)"
+	description "Hawk F-123 (Japan)"
+	rom ( name "Hawk F-123 (Japan).cue" size 12160 crc 384a764b md5 755a8ab36715a8b232fb9bfe866489fa sha1 7a67ad95388340494a7294330be28aae15006f78 )
+)
+
+game (
+	name "Hellfire S (Japan)"
+	description "Hellfire S (Japan)"
+	rom ( name "Hellfire S (Japan).cue" size 10689 crc 59321883 md5 60975b9270da98151f47b32cbbc86943 sha1 42b2fbe76424f06dde20bb0e71de108468ec406c )
+)
+
+game (
+	name "Hi-Leg Fantasy (Japan)"
+	description "Hi-Leg Fantasy (Japan)"
+	rom ( name "Hi-Leg Fantasy (Japan).cue" size 7529 crc cb6775e9 md5 de41466e42669e1d6b562039107cefb0 sha1 36b76fce8f3677c98f8bbf3354d9629654072da9 )
+)
+
+game (
+	name "High Grenadier (Japan) - ハイグレネーダー"
+	description "High Grenadier (Japan) - ハイグレネーダー"
+	rom ( name "High Grenadier (Japan).cue" size 5684 crc 56a5224d md5 5d9aafd9e86bcf759c28ff29ee95b435 sha1 1eaf55adad3c4d19439cf8de5889fbd2b0127343 )
+)
+
+game (
 	name "High Grenadier (Japan) (Rev 2)"
 	description "High Grenadier (Japan) (Rev 2)"
 	rom ( name "High Grenadier (Japan) (Rev 2).cue" size 1298 crc a8f225ca md5 fb372612f90ccfd0f5f5ba8dcc1c4d01 sha1 dde161fe8b16e65b9b95989bf9e5d3188f957c85 )
 )
 
 game (
+	name "Hihou Densetsu Kris no Bouken (Japan)"
+	description "Hihou Densetsu Kris no Bouken (Japan)"
+	rom ( name "Hihou Densetsu Kris no Bouken (Japan).cue" size 11923 crc 1d2d910f md5 5e455dbad5db9178e7aeb2f7d19556cf sha1 22bb58e5087ed6b34cbe6c769fb36683605ea776 )
+)
+
+game (
 	name "Himitsu no Hanazono (Japan)"
 	description "Himitsu no Hanazono (Japan)"
-	rom ( name "Himitsu no Hanazono (Japan).cue" size 466 crc 7dc0aaf4 md5 1835229a8091df26f3fd10d0604e874d sha1 266a18e4e15e2715e64bdc0789d1eb35db17819a )
+	rom ( name "Himitsu no Hanazono (Japan).cue" size 2449 crc ed56d0be md5 bf15b7df688b29b24df7e6a05f3f57c2 sha1 fa1d7995d63f31b34e452c7aa6f3ddbcb1a8cde9 )
 )
 
 game (
@@ -715,15 +1675,39 @@ game (
 )
 
 game (
+	name "Hokutosei no Onna - Nishimura Kyoutarou (Japan) - 北斗星の女+西村京太郎"
+	description "Hokutosei no Onna - Nishimura Kyoutarou (Japan) - 北斗星の女+西村京太郎"
+	rom ( name "Hokutosei no Onna - Nishimura Kyoutarou (Japan).cue" size 10313 crc 190481f7 md5 0f2de0a77be83254b25a3de6622367da sha1 f502184187918e53135810c58fa42d84847da05b )
+)
+
+game (
 	name "Horror Story (Japan)"
 	description "Horror Story (Japan)"
-	rom ( name "Horror Story (Japan).cue" size 1574 crc c142edf7 md5 e89a8beee37cfa4506c11362b392b1c3 sha1 697171a04804c4ea781b96a159fc125bf52c8e06 )
+	rom ( name "Horror Story (Japan).cue" size 7451 crc 7b1b652d md5 1a5e4e70104cfe740d8273f682f1a299 sha1 09db766b78d37f5a32ddf7185ebfd8133fb6fb97 )
 )
 
 game (
 	name "Hu PGA Tour - PowerGolf 2 - Golfer (Japan)"
 	description "Hu PGA Tour - PowerGolf 2 - Golfer (Japan)"
 	rom ( name "Hu PGA Tour - PowerGolf 2 - Golfer (Japan).cue" size 1219 crc 64971bcf md5 8708d09aba94c69c1b4968acfc8e18a6 sha1 c51dae89a33a0edd1df4fab290b2dc4c3a750bfa )
+)
+
+game (
+	name "Hu PGA Tour Power Golf 2 - Golfer (Japan) - パワーゴルフ2+ゴルファー"
+	description "Hu PGA Tour Power Golf 2 - Golfer (Japan) - パワーゴルフ2+ゴルファー"
+	rom ( name "Hu PGA Tour Power Golf 2 - Golfer (Japan).cue" size 5042 crc 001d8028 md5 b35cf647b3d8540cdbf5c044d1df40b2 sha1 428de644b5d231b92fdd36cd30353b3e48bb87e7 )
+)
+
+game (
+	name "Hudson's CD Game Music Collection '93 (USA) (Audio)"
+	description "Hudson's CD Game Music Collection '93 (USA) (Audio)"
+	rom ( name "Hudson's CD Game Music Collection '93 (USA) (Audio).cue" size 8246 crc 3c4e9aa5 md5 db2c5be0c004669f944e2351a479d535 sha1 7589b9025b4056e801c10375aaec7b5b46f17843 )
+)
+
+game (
+	name "Human Sports Festival (Japan) - ヒューマンスポーツフェスティバル"
+	description "Human Sports Festival (Japan) - ヒューマンスポーツフェスティバル"
+	rom ( name "Human Sports Festival (Japan).cue" size 10295 crc 98a2910d md5 24018f409e9dc796335e888645a8bc39 sha1 78216a36236ce92bd0e4bd016753d1d4927f3372 )
 )
 
 game (
@@ -739,21 +1723,57 @@ game (
 )
 
 game (
+	name "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan)"
+	description "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan)"
+	rom ( name "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan).cue" size 12639 crc 24240046 md5 5f4bfdafb32253c5d33da79fc6aeb875 sha1 4b349debf5f527e445a94dc2977ba085509f091b )
+)
+
+game (
+	name "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan) (Sample)"
+	description "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan) (Sample)"
+	rom ( name "Hyaku Monogatari - Hontou ni Atta Kowai Hanashi (Japan) (Sample).cue" size 6978 crc ab389e99 md5 1f56e87d75b5a321a4aef558adbaa111 sha1 0de2a163d804a835460b1140784ba482d2b7b116 )
+)
+
+game (
+	name "Hyper Dyne SideArms Special (Japan) (A)"
+	description "Hyper Dyne SideArms Special (Japan) (A)"
+	rom ( name "Hyper Dyne SideArms Special (Japan) (A).cue" size 10156 crc aa90acf5 md5 5ecc109ace5e7775890011819736b025 sha1 f0b65502c31e82c3ac758cf9fb34b2d7e460cfb4 )
+)
+
+game (
+	name "Hyper Dyne SideArms Special (Japan) (B)"
+	description "Hyper Dyne SideArms Special (Japan) (B)"
+	rom ( name "Hyper Dyne SideArms Special (Japan) (B).cue" size 10156 crc 1180df6b md5 e121670ea97a48b7063a32d6b0967ade sha1 8b37a63271b52724d8ca61249826ea6cee23ea7f )
+)
+
+game (
 	name "Hyper Wars (Japan)"
 	description "Hyper Wars (Japan)"
-	rom ( name "Hyper Wars (Japan).cue" size 1818 crc e64a6594 md5 345ddd412935aae850443bba39324218 sha1 4b62b31414262182b9d4758953fc719b8c69104a )
+	rom ( name "Hyper Wars (Japan).cue" size 9177 crc 48b81a7d md5 392955cde5ecd1da82d9a9cd7009b239 sha1 42e3daae67517176e0067c1a206b53fdbe018fc3 )
 )
 
 game (
 	name "Iga Ninden Gaiou (Japan)"
 	description "Iga Ninden Gaiou (Japan)"
-	rom ( name "Iga Ninden Gaiou (Japan).cue" size 3535 crc 29a0cecb md5 7e30ce49c071cb2cba3019928820e52f sha1 9ea37a8afb90158b077bf45cb57c26b9f9da9809 )
+	rom ( name "Iga Ninden Gaiou (Japan).cue" size 15555 crc 2117ec20 md5 12023879c3dad54af5c8133b1624bb95 sha1 ab0fdf78d4df5e8d09fdc1a28274a18822788333 )
+)
+
+game (
+	name "Image Fight II (Japan)"
+	description "Image Fight II (Japan)"
+	rom ( name "Image Fight II (Japan).cue" size 11098 crc bf05a56c md5 c52a1d045266194e095ad33c8f6c78b4 sha1 426dc27eb254b86cd0683aac2af03504dfa5f5ff )
 )
 
 game (
 	name "ImageFight II - Operation Deepstriker (Japan)"
 	description "ImageFight II - Operation Deepstriker (Japan)"
 	rom ( name "ImageFight II - Operation Deepstriker (Japan).cue" size 3004 crc 8f8e70ee md5 a1cc661be36b6a0955af80fe1b911655 sha1 4efbe918865db3d7ebd74bd1707f8b52df823583 )
+)
+
+game (
+	name "Implode (USA)"
+	description "Implode (USA)"
+	rom ( name "Implode (USA).cue" size 6017 crc 0fccc986 md5 b55c6e6cbc821cd964d49a3c40c158d5 sha1 497453afb7eabf545ae4d9d7dec3246fbe6ad8a3 )
 )
 
 game (
@@ -769,9 +1789,51 @@ game (
 )
 
 game (
+	name "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan) - 井上麻美+この星にたったひとりのキミ"
+	description "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan) - 井上麻美+この星にたったひとりのキミ"
+	rom ( name "Inoue Mami - Kono Hoshi ni Tatta Hitori no Kimi (Japan).cue" size 4502 crc f61da2bc md5 982857d9456fb550b1e8518a41861088 sha1 f8c1f2c053228ef3a6cc9239e0843a9473619b6d )
+)
+
+game (
+	name "Insanity (USA)"
+	description "Insanity (USA)"
+	rom ( name "Insanity (USA).cue" size 7521 crc 6e1f13cd md5 a0fe07baaf2fa913540f71bccf9df94d sha1 711cb66bcc2a0645f2b2f69a8cf76366880728a8 )
+)
+
+game (
+	name "IQ Panic (Japan) - アイキューパニック"
+	description "IQ Panic (Japan) - アイキューパニック"
+	rom ( name "IQ Panic (Japan).cue" size 32813 crc cc84ede8 md5 1d3d3cc9fc32402db08919f065d220af sha1 e7149aa565afb456d28c02d827c20457ce89f8b6 )
+)
+
+game (
 	name "IQ Panic (Japan) (Rev 3)"
 	description "IQ Panic (Japan) (Rev 3)"
 	rom ( name "IQ Panic (Japan) (Rev 3).cue" size 7658 crc f0976372 md5 a18a82eaf33ed02861ad549acf7aea10 sha1 c7c96240d9072a9c9cc859aa049e477781383415 )
+)
+
+game (
+	name "It Came from The Desert (USA)"
+	description "It Came from The Desert (USA)"
+	rom ( name "It Came from The Desert (USA).cue" size 11217 crc 0e7bc317 md5 0a1e89b4732a76507d9293eeba0b23df sha1 1e8e61154d8bcf18bcbfc741fa93dfb49e814de6 )
+)
+
+game (
+	name "J Thunder (Japan)"
+	description "J Thunder (Japan)"
+	rom ( name "J Thunder (Japan).cue" size 8514 crc ddbe04d7 md5 5a764d245f0efe5915eeb48d2e41fd27 sha1 d247e999bb27b9d864f1f349c96e55983ee49d69 )
+)
+
+game (
+	name "J. B. Harold Murder Club (Japan)"
+	description "J. B. Harold Murder Club (Japan)"
+	rom ( name "J. B. Harold Murder Club (Japan).cue" size 5438 crc f2363ab4 md5 b415328fe1d8f516050c6f022745314c sha1 018eec0c20b00263bdae54f7589b110728b47655 )
+)
+
+game (
+	name "J. B. Harold Murder Club (USA)"
+	description "J. B. Harold Murder Club (USA)"
+	rom ( name "J. B. Harold Murder Club (USA).cue" size 5436 crc 23277ed4 md5 68cdd5848a4d08a52dac10a7d15b5a96 sha1 125d929b1e2a76f9c28d81204a65858261c7746e )
 )
 
 game (
@@ -783,7 +1845,13 @@ game (
 game (
 	name "J. League Tremendous Soccer '94 (Japan)"
 	description "J. League Tremendous Soccer '94 (Japan)"
-	rom ( name "J. League Tremendous Soccer '94 (Japan).cue" size 2960 crc a0ab09c8 md5 51afcf23bf49d39ed7f350d245c9c5c7 sha1 994fd932b03d67b776fe0f62f24febbc9eae7ecc )
+	rom ( name "J. League Tremendous Soccer '94 (Japan).cue" size 11371 crc 3d98b224 md5 3101dccc4a5a6574c7b66ddb2709b2ef sha1 4f38c45fd5d72757e81c9a23168f7eea2a3e0c63 )
+)
+
+game (
+	name "Jack Nicklaus Turbo Golf (USA)"
+	description "Jack Nicklaus Turbo Golf (USA)"
+	rom ( name "Jack Nicklaus Turbo Golf (USA).cue" size 5436 crc 077cb8ab md5 75ff9f4e616fd171fcd9cdddc836af61 sha1 73aa2926a4275d5e146f9f26dc8aa37fb1550ff0 )
 )
 
 game (
@@ -793,9 +1861,21 @@ game (
 )
 
 game (
+	name "Jack Nicklaus' World Tour Golf (Japan) - ジャックニクラウス+ワールドゴルフツアー"
+	description "Jack Nicklaus' World Tour Golf (Japan) - ジャックニクラウス+ワールドゴルフツアー"
+	rom ( name "Jack Nicklaus' World Tour Golf (Japan).cue" size 5444 crc 628225cb md5 885a882d4906d9c781e6c411ee00199f sha1 a0547f9083df0751992f5f67cfbd623930843c9c )
+)
+
+game (
+	name "Janshin Densetsu - Quest of Jongmaster (Japan)"
+	description "Janshin Densetsu - Quest of Jongmaster (Japan)"
+	rom ( name "Janshin Densetsu - Quest of Jongmaster (Japan).cue" size 12188 crc fa2a1a77 md5 db09e3a5f741604177f58c0d265ab18c sha1 b926494e414e1b485f38c9461c49ff59cfb41b45 )
+)
+
+game (
 	name "Jantei Monogatari (Japan)"
 	description "Jantei Monogatari (Japan)"
-	rom ( name "Jantei Monogatari (Japan).cue" size 531 crc e5eb11fe md5 2b59bfd0d393789f48c40ebf10c86b81 sha1 3b363eee89ae26119000425830f3f8c8c08ad184 )
+	rom ( name "Jantei Monogatari (Japan).cue" size 2852 crc 068a7d2d md5 57ae226cc9a1611ae24e467744f6a144 sha1 378800294c1c862fab520acb934da2ed44df9d93 )
 )
 
 game (
@@ -811,9 +1891,45 @@ game (
 )
 
 game (
+	name "Jantei Monogatari 2 - Uchuu Tantei Divan Kanketsu Hen (Japan)"
+	description "Jantei Monogatari 2 - Uchuu Tantei Divan Kanketsu Hen (Japan)"
+	rom ( name "Jantei Monogatari 2 - Uchuu Tantei Divan Kanketsu Hen (Japan).cue" size 3037 crc db925462 md5 62a42c717f6b1a4947d7018f31ce5943 sha1 f56b90bddd808c6e945cd8d1a8513406cddef6ef )
+)
+
+game (
+	name "Jantei Monogatari 2 - Uchuu Tantei Divan Shutsudou Hen (Japan)"
+	description "Jantei Monogatari 2 - Uchuu Tantei Divan Shutsudou Hen (Japan)"
+	rom ( name "Jantei Monogatari 2 - Uchuu Tantei Divan Shutsudou Hen (Japan).cue" size 3038 crc 1fcf6f4a md5 40a1bfda48e8bc321438ba6e5bbf878d sha1 2cb7ebc209c46a4175fd62613ef081c60e3cc4cd )
+)
+
+game (
+	name "Jantei Monogatari 3 - Saber Angel (Japan)"
+	description "Jantei Monogatari 3 - Saber Angel (Japan)"
+	rom ( name "Jantei Monogatari 3 - Saber Angel (Japan).cue" size 8133 crc 602f0c63 md5 b40eb3cb0dcc5b1ecfa0da95293c449f sha1 1cf20514ec3d3ce9330f9fcfc15dfcc240a0bd46 )
+)
+
+game (
 	name "Jantei Monogatari 3 - Saver Angels (Japan)"
 	description "Jantei Monogatari 3 - Saver Angels (Japan)"
 	rom ( name "Jantei Monogatari 3 - Saver Angels (Japan).cue" size 2126 crc 9b3bcb65 md5 53825263a11f6e78258c4614b02952c9 sha1 95f4d7115b85fd109f794c2cd4ce5b87187393a0 )
+)
+
+game (
+	name "Jim Power - In Mutant Planet (Japan)"
+	description "Jim Power - In Mutant Planet (Japan)"
+	rom ( name "Jim Power - In Mutant Planet (Japan).cue" size 5698 crc db78fa80 md5 59abdae1165bd9ece59f1757307ed16d sha1 6b34d81cdd24895614fea61649254a15abbb8596 )
+)
+
+game (
+	name "John Madden Duo CD Football (USA)"
+	description "John Madden Duo CD Football (USA)"
+	rom ( name "John Madden Duo CD Football (USA).cue" size 5844 crc 3b571d55 md5 6fe7c602aede60bb70abbf9337693812 sha1 ef1e9ceb18ce3d5d7bb6859755ea9300a557e430 )
+)
+
+game (
+	name "Juuouki (Japan)"
+	description "Juuouki (Japan)"
+	rom ( name "Juuouki (Japan).cue" size 4462 crc 7f6e8327 md5 7667afdc05fbc66ac7cce391eadc5273 sha1 1b9a14655b72f4673bcb6b8215d375110b0052c2 )
 )
 
 game (
@@ -829,6 +1945,12 @@ game (
 )
 
 game (
+	name "Kagamai no Kuni no Legend (Japan) - 鏡の国のレジェンド"
+	description "Kagamai no Kuni no Legend (Japan) - 鏡の国のレジェンド"
+	rom ( name "Kagamai no Kuni no Legend (Japan).cue" size 3819 crc b9a99764 md5 54a6274b9a8cce9e97d9d7338ba7c112 sha1 d1acfb76a5ede1815f9139a65cbbc38983074e8d )
+)
+
+game (
 	name "Kagami no Kuni no Legend (Japan) (Rev 6)"
 	description "Kagami no Kuni no Legend (Japan) (Rev 6)"
 	rom ( name "Kagami no Kuni no Legend (Japan) (Rev 6).cue" size 879 crc 39255207 md5 65af3f06fe782efc8fd117ea3e9c8f17 sha1 33ebc50dee49682cf2e54ff64f33a523831b9151 )
@@ -837,25 +1959,73 @@ game (
 game (
 	name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
 	description "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
-	rom ( name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan).cue" size 6805 crc ffc004fe md5 3a55f6f2796a0cc436d4e5efca946f69 sha1 11a73031ca7050943c7cd652fd08729e5bbf44ab )
+	rom ( name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan).cue" size 22322 crc 1a4016c9 md5 17312541dc0724b651603e6c6d413c63 sha1 659c42a79399d3eac43dc144b6fd28592a94a668 )
+)
+
+game (
+	name "Kakutou Haou Densetsu Algunos (Japan)"
+	description "Kakutou Haou Densetsu Algunos (Japan)"
+	rom ( name "Kakutou Haou Densetsu Algunos (Japan).cue" size 6253 crc b4938a0c md5 57c66246ccf50ba9de313b98ccf0a5c8 sha1 5ceaaae4c129885b638dbc7394a0f9599d5d947d )
+)
+
+game (
+	name "Kawa no Nushizuri - Shizenha (Japan)"
+	description "Kawa no Nushizuri - Shizenha (Japan)"
+	rom ( name "Kawa no Nushizuri - Shizenha (Japan).cue" size 12988 crc eb09ee88 md5 059911b743b8cb29befc2ba009a7c7e0 sha1 03cba0dd65d4939a3055fdcad3147efc0cbbfc53 )
+)
+
+game (
+	name "Kaze Kiri Ninja Action (Japan)"
+	description "Kaze Kiri Ninja Action (Japan)"
+	rom ( name "Kaze Kiri Ninja Action (Japan).cue" size 10701 crc c778498c md5 3dab6bf1640ab0cc6a53f3092dd18bd6 sha1 08b17533ddfd5cf945e98b107851a2e1b37b4be3 )
+)
+
+game (
+	name "Kaze no Densetsu Xanadu (Japan)"
+	description "Kaze no Densetsu Xanadu (Japan)"
+	rom ( name "Kaze no Densetsu Xanadu (Japan).cue" size 7867 crc ae1b01d3 md5 47136cb653e7a33d5ec33a765809fd5e sha1 13e09f01f8759d65049a5e042821815b5611e891 )
 )
 
 game (
 	name "Kaze no Densetsu Xanadu (Japan) (Sample)"
 	description "Kaze no Densetsu Xanadu (Japan) (Sample)"
-	rom ( name "Kaze no Densetsu Xanadu (Japan) (Sample).cue" size 2006 crc dd8ffd19 md5 acfdaef8e71c8dc4a5d41e046bd05e96 sha1 1e19ec32840d768859ff5474075f32de8685db7d )
+	rom ( name "Kaze no Densetsu Xanadu (Japan) (Sample).cue" size 7876 crc 9bf324a8 md5 447c620919f254a7d43d8752c468c75d sha1 d9a311a5c27306bfd0d574fcf420fa3eb55fb242 )
+)
+
+game (
+	name "Kaze no Densetsu Xanadu II (Japan)"
+	description "Kaze no Densetsu Xanadu II (Japan)"
+	rom ( name "Kaze no Densetsu Xanadu II (Japan).cue" size 20425 crc d2c96719 md5 4d193e17bf90da67a908ab65646dc927 sha1 9132cec0ba9ba1f1b41e521288fc664fc9b31e35 )
 )
 
 game (
 	name "Kiaidan 00 (Japan)"
 	description "Kiaidan 00 (Japan)"
-	rom ( name "Kiaidan 00 (Japan).cue" size 3381 crc 96856963 md5 fc64a6363a1049829b371ac8fe00de31 sha1 1e03ccd129c004004948e0ea99282f3d73255691 )
+	rom ( name "Kiaidan 00 (Japan).cue" size 15805 crc 253225e8 md5 a31a84412a301977fed60b21357165bd sha1 efac4536159e80bf00eb04c76488ded7ddea6a22 )
+)
+
+game (
+	name "Kick Boxing, The (Japan) - ザキックボクシング"
+	description "Kick Boxing, The (Japan) - ザキックボクシング"
+	rom ( name "Kick Boxing, The (Japan).cue" size 6789 crc 126af6a1 md5 f3a4eb18749c870f3725f15bd7f03295 sha1 01222fc41403f7c9fac9cbe11e5617ed817b72be )
 )
 
 game (
 	name "Kick Boxing, The (Japan) (Rev 9)"
 	description "Kick Boxing, The (Japan) (Rev 9)"
 	rom ( name "Kick Boxing, The (Japan) (Rev 9).cue" size 1581 crc 6b4e69e8 md5 68c531398fac59fee9d871ef68c44d80 sha1 1e0112991f0ac4e997c689a40b23ed63786c6edf )
+)
+
+game (
+	name "Kidou Keisatsu Patlabor - Griffon Hen (Japan)"
+	description "Kidou Keisatsu Patlabor - Griffon Hen (Japan)"
+	rom ( name "Kidou Keisatsu Patlabor - Griffon Hen (Japan).cue" size 17601 crc fadd7a52 md5 bd570a645113a5c864411bd1451e53eb sha1 01cf7dc83e90c346081c88064cfa8a8bd1fd96d2 )
+)
+
+game (
+	name "Kisou Louga (Japan)"
+	description "Kisou Louga (Japan)"
+	rom ( name "Kisou Louga (Japan).cue" size 9880 crc 04407587 md5 aa27df917cbdb6e2253f886e314d78d5 sha1 a2c8e71a23955b2b8210247ba65ab512c8f1946c )
 )
 
 game (
@@ -867,7 +2037,13 @@ game (
 game (
 	name "Kisou Louga II - The Ends of Shangrila (Japan)"
 	description "Kisou Louga II - The Ends of Shangrila (Japan)"
-	rom ( name "Kisou Louga II - The Ends of Shangrila (Japan).cue" size 3878 crc dceff56e md5 33a75568b0b186832959b6bcf8462f4e sha1 99947ec29fed8bc85046cdd2d0795cf5c3e4c31a )
+	rom ( name "Kisou Louga II - The Ends of Shangrila (Japan).cue" size 13957 crc 4b198817 md5 6ec2cd68864c0f7565ff7202f5710f3a sha1 e4aedf1d2bdc00b5e552461bd145ee48d4db4f63 )
+)
+
+game (
+	name "KO Seiki Beast - Gaia Fukkatsu Kanketsu Hen (Japan)"
+	description "KO Seiki Beast - Gaia Fukkatsu Kanketsu Hen (Japan)"
+	rom ( name "KO Seiki Beast - Gaia Fukkatsu Kanketsu Hen (Japan).cue" size 11937 crc e8bdc5ae md5 1513638bee263f67f5dad3f565e07626 sha1 47b8029bbcaf4569120ae960820256f35cacbcff )
 )
 
 game (
@@ -877,15 +2053,39 @@ game (
 )
 
 game (
+	name "Kuusou Kagaku Sekai Gulliver Boy (Japan)"
+	description "Kuusou Kagaku Sekai Gulliver Boy (Japan)"
+	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan).cue" size 5041 crc 77844ce0 md5 36e065f53858fa6f11bce3f87381cb8c sha1 993d834428dfda45af22c71d788edd93f1c977e6 )
+)
+
+game (
 	name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3)"
 	description "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3)"
 	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Rev 3).cue" size 1302 crc 95042c12 md5 b6cdbc1012b23f222b61057eef6bf49f sha1 722b6700d2a6b676ab08c3a5dbf3f44698f60fda )
 )
 
 game (
+	name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Sample)"
+	description "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Sample)"
+	rom ( name "Kuusou Kagaku Sekai Gulliver Boy (Japan) (Sample).cue" size 5050 crc 89a0dfbe md5 819c721947f8d32e80d271a3ee440e48 sha1 1b6c402017260a9cec0a9df0c0503500240c3cf3 )
+)
+
+game (
+	name "L-Dis (Japan)"
+	description "L-Dis (Japan)"
+	rom ( name "L-Dis (Japan).cue" size 25236 crc 0a7d2984 md5 fe038c5f9da91c2f9d5bee1f7c85b9cd sha1 f832f6f3f65a3e41e072503abc16d686f497a77b )
+)
+
+game (
 	name "L-Dis (Japan) (Rev 6)"
 	description "L-Dis (Japan) (Rev 6)"
 	rom ( name "L-Dis (Japan) (Rev 6).cue" size 5405 crc f86fe378 md5 b46763bc7f41124887066f6da3dd94f2 sha1 dfa4d2533e4a6f524c6181457f6206932195bdd5 )
+)
+
+game (
+	name "Lady Phantom (Japan) - レディファントム"
+	description "Lady Phantom (Japan) - レディファントム"
+	rom ( name "Lady Phantom (Japan).cue" size 23186 crc 0af50e0d md5 38c6e1add5a9138a3884fa793b40a2db sha1 dacefb8431bc84094098bcdca128c83546675ded )
 )
 
 game (
@@ -901,9 +2101,51 @@ game (
 )
 
 game (
+	name "Langrisser - Hikari no Matsuei (Japan) - ラングリッサー+光輝の末裔"
+	description "Langrisser - Hikari no Matsuei (Japan) - ラングリッサー+光輝の末裔"
+	rom ( name "Langrisser - Hikari no Matsuei (Japan).cue" size 16230 crc 5c2934eb md5 fc53bcc59535ba1553b196e1147ae1a4 sha1 a0ff2207ce2dc0853eacb7cb5c48e365cb100482 )
+)
+
+game (
+	name "Laplace no Ma (Japan)"
+	description "Laplace no Ma (Japan)"
+	rom ( name "Laplace no Ma (Japan).cue" size 6642 crc 452ed7fc md5 0bdbb9a18870d22cae36f9816ed8e341 sha1 c2e6430e5c3ebac87b2a73d0789a01d8925761c0 )
+)
+
+game (
 	name "Laplace no Ma (Japan) (Rev 3)"
 	description "Laplace no Ma (Japan) (Rev 3)"
 	rom ( name "Laplace no Ma (Japan) (Rev 3).cue" size 1516 crc 12e975b6 md5 4d65a6cd4badb0a756af9f6432af570e sha1 4c8e4e790c9d39a65d656f720538eca282f67068 )
+)
+
+game (
+	name "Laser Soft Visual Collection Volume I - Cosmic Fantasy Visual Shuu (Japan)"
+	description "Laser Soft Visual Collection Volume I - Cosmic Fantasy Visual Shuu (Japan)"
+	rom ( name "Laser Soft Visual Collection Volume I - Cosmic Fantasy Visual Shuu (Japan).cue" size 38690 crc aa52ab8b md5 9c6a02cecd14bb5544f7f6d07c1a7cb5 sha1 94b9faf887c46c395831e19d2c2fad6386188ab8 )
+)
+
+game (
+	name "Laser Soft Visual Collection Volume II - Valis Visual Shuu (Japan)"
+	description "Laser Soft Visual Collection Volume II - Valis Visual Shuu (Japan)"
+	rom ( name "Laser Soft Visual Collection Volume II - Valis Visual Shuu (Japan).cue" size 33417 crc 64bad469 md5 51475d515d36b0222f8ccb329332ffd8 sha1 4f92045e76d111e3d8210ac6becd2df3e771761e )
+)
+
+game (
+	name "Last Alert (USA)"
+	description "Last Alert (USA)"
+	rom ( name "Last Alert (USA).cue" size 25267 crc 5c1723a1 md5 b006d81f9a4e684a32828fe4dbe5fef1 sha1 7ad2c7b6db87c68183d2da5b8d5bdeca952b73a0 )
+)
+
+game (
+	name "Last Armageddon (Japan) (6)"
+	description "Last Armageddon (Japan) (6)"
+	rom ( name "Last Armageddon (Japan) (6).cue" size 8673 crc 7ddb0770 md5 336168d6e10467e40628e02b4dbf8d05 sha1 9911e4f5e0fa088f1076b0c69495ed45f7386b3a )
+)
+
+game (
+	name "Last Armageddon (Japan) (7)"
+	description "Last Armageddon (Japan) (7)"
+	rom ( name "Last Armageddon (Japan) (7).cue" size 8673 crc bafad554 md5 8bc31b5171eeebc1c76be0bb30725857 sha1 ad6cdad6dfe58e1d8b46f7ab4cae174055778afc )
 )
 
 game (
@@ -925,9 +2167,57 @@ game (
 )
 
 game (
+	name "Legion (Japan)"
+	description "Legion (Japan)"
+	rom ( name "Legion (Japan).cue" size 9321 crc 4b5ed123 md5 9eecbe0f36d3a21b1f9b9c30a2bbbeee sha1 b9462fc77557f5aac14b64be8fbe0af44b191778 )
+)
+
+game (
+	name "Lemmings (Japan)"
+	description "Lemmings (Japan)"
+	rom ( name "Lemmings (Japan).cue" size 11092 crc f3571cf3 md5 d203989168c21e48c73f7709eb465e02 sha1 c70569c80fc89db4681ee36812fa5ce67e31ef98 )
+)
+
+game (
+	name "Linda 3 (Japan) - Linda³"
+	description "Linda 3 (Japan) - Linda³"
+	rom ( name "Linda 3 (Japan).cue" size 12157 crc b68d870a md5 1edff8b4c7a0ee9e7c1b1e0cedebcb0c sha1 c8d958d291b9d660c88fb95937773c7149939efe )
+)
+
+game (
 	name "Linda^3 (Japan)"
 	description "Linda^3 (Japan)"
 	rom ( name "Linda^3 (Japan).cue" size 2510 crc f7c7328e md5 2a5d50c5c2151186b0f3b3abb432ae7e sha1 c7193263cbc4544505b45e89228475b33e0917d8 )
+)
+
+game (
+	name "Local Girls of Hawaii, The (USA)"
+	description "Local Girls of Hawaii, The (USA)"
+	rom ( name "Local Girls of Hawaii, The (USA).cue" size 951 crc 22a2c29d md5 4ae545eab1bf51ab58bfaf1e3cc43e36 sha1 f7cbe14293e650daba073fdc3cdb8d8ddb7cbb0d )
+)
+
+game (
+	name "Lodoss Tou Senki - Taikenban (Japan)"
+	description "Lodoss Tou Senki - Taikenban (Japan)"
+	rom ( name "Lodoss Tou Senki - Taikenban (Japan).cue" size 3417 crc 3551af9a md5 b25df2ffa16681813a4c949fe73ca860 sha1 78a717e288a3da557b5b6e95e6bd981ca5b3bec8 )
+)
+
+game (
+	name "Lodoss Tou Senki (Japan) - ロードス島戦記"
+	description "Lodoss Tou Senki (Japan) - ロードス島戦記"
+	rom ( name "Lodoss Tou Senki (Japan).cue" size 3405 crc 132ae692 md5 0405f1eea39bb9f167dbcde628ea333e sha1 6fef2a9642509066a27966229b19e49d00d92656 )
+)
+
+game (
+	name "Lodoss Tou Senki II (Japan)"
+	description "Lodoss Tou Senki II (Japan)"
+	rom ( name "Lodoss Tou Senki II (Japan).cue" size 5433 crc 1546b3d4 md5 ae458afb0b7fe10ec4ac28cf6614bd77 sha1 3e05f376d97c8a0c9507414e894f6f18031bd7cb )
+)
+
+game (
+	name "Loom (Japan)"
+	description "Loom (Japan)"
+	rom ( name "Loom (Japan).cue" size 10278 crc 2dd50c96 md5 61123521fb20fc3f441df5b7d2dde9be sha1 01f152df52063bca87cb83e8cd0d0d4b30969df0 )
 )
 
 game (
@@ -937,21 +2227,75 @@ game (
 )
 
 game (
+	name "Loom (USA)"
+	description "Loom (USA)"
+	rom ( name "Loom (USA).cue" size 10276 crc daf118c3 md5 54139be33e03cf713ba1ce3e87d88ad6 sha1 0e45b5f99869c1f843f2efa88cfc2908d914ddb0 )
+)
+
+game (
 	name "Lord of Wars (Japan)"
 	description "Lord of Wars (Japan)"
-	rom ( name "Lord of Wars (Japan).cue" size 994 crc 3622b402 md5 91e2be8bec5b315c942cd13a6d1eada6 sha1 b7f7bd1fdb9a5a7fcbeac8067cebe4e7bf4c8569 )
+	rom ( name "Lord of Wars (Japan).cue" size 4872 crc f0e94cb8 md5 20199255046fe44751b75d7448c1607c sha1 32ce2479ce31c16c870cfc52e78c0197696e9552 )
+)
+
+game (
+	name "Lords of the Rising Sun (USA)"
+	description "Lords of the Rising Sun (USA)"
+	rom ( name "Lords of the Rising Sun (USA).cue" size 17841 crc 43670140 md5 d7ae35f0db2e62f7bee13b3f6e618639 sha1 f54cd7f0a58e88b6d21eeae25113fcf95ea44fd0 )
 )
 
 game (
 	name "Lords of Thunder (USA)"
 	description "Lords of Thunder (USA)"
-	rom ( name "Lords of Thunder (USA).cue" size 2264 crc 21b7921d md5 6d3048fa92edbffb53fb278b3544000e sha1 97ba44a16452777d9d35a70e2e3f05b412680e3c )
+	rom ( name "Lords of Thunder (USA).cue" size 10288 crc f02e6674 md5 35131e4fa0480d0cddea39efb91795f1 sha1 7a9855467efe8d50d76fcb7d38fed9df7d2d7b36 )
+)
+
+game (
+	name "Macross 2036 (Japan)"
+	description "Macross 2036 (Japan)"
+	rom ( name "Macross 2036 (Japan).cue" size 15290 crc 356e5665 md5 2c92a6495ac467df565b0f26b8bb94b3 sha1 8266897b06796ec5f9a5de1b6e5ab4163960a829 )
+)
+
+game (
+	name "Macross Eien no Love Song (Japan)"
+	description "Macross Eien no Love Song (Japan)"
+	rom ( name "Macross Eien no Love Song (Japan).cue" size 19465 crc ce79e6d9 md5 a12decf074e7864c87753a099e17999f sha1 bae8c0384e79d8cd714249d2d2a60960021618de )
+)
+
+game (
+	name "Mad Stalker - Full Metal Force (Japan)"
+	description "Mad Stalker - Full Metal Force (Japan)"
+	rom ( name "Mad Stalker - Full Metal Force (Japan).cue" size 14759 crc d8f0b6a7 md5 fd0979272412df47fcfd705ca38c15ab sha1 8f42305a63973474db8374b416dd145d5ad030e0 )
+)
+
+game (
+	name "Mad Stalker - Full Metal Force (Japan) (Sample)"
+	description "Mad Stalker - Full Metal Force (Japan) (Sample)"
+	rom ( name "Mad Stalker - Full Metal Force (Japan) (Sample).cue" size 3279 crc 63a697a3 md5 73daebbd51f471946a5fd22efeb74b84 sha1 dcdd816475bb9977a2efc64ba210d840c663c2ee )
 )
 
 game (
 	name "Madou Monogatari I - Honoo no Sotsuenji (Japan)"
 	description "Madou Monogatari I - Honoo no Sotsuenji (Japan)"
 	rom ( name "Madou Monogatari I - Honoo no Sotsuenji (Japan).cue" size 3910 crc 5193c66c md5 14e7b75231b223fa8a412ca92411817f sha1 311243fcdfc02494d8397f9cd44d27d6759f2828 )
+)
+
+game (
+	name "Magical Dinosaur Tour (USA)"
+	description "Magical Dinosaur Tour (USA)"
+	rom ( name "Magical Dinosaur Tour (USA).cue" size 2598 crc 4a4acd59 md5 347407e0ff53dda8bb660f56d4dd1903 sha1 b8526de2121c046d90ccafd4c33675ce1e2ffa8d )
+)
+
+game (
+	name "Magical Fantasy Adventure - Popful Mail (Japan)"
+	description "Magical Fantasy Adventure - Popful Mail (Japan)"
+	rom ( name "Magical Fantasy Adventure - Popful Mail (Japan).cue" size 14214 crc 5e7bbd22 md5 3af99f01fb81618f8fc8cef4f7167600 sha1 b8bc58ee042f7258fe71252c0f43ba51343aa5dc )
+)
+
+game (
+	name "Magical Saurus Tour (Japan)"
+	description "Magical Saurus Tour (Japan)"
+	rom ( name "Magical Saurus Tour (Japan).cue" size 2598 crc 26bd4d20 md5 04bc2015fd14c3982ab7b2a2207b09fd sha1 298b2e9ccf3a6b2be65fa8751e84ea5348815c04 )
 )
 
 game (
@@ -963,13 +2307,31 @@ game (
 game (
 	name "Magicoal (Japan)"
 	description "Magicoal (Japan)"
-	rom ( name "Magicoal (Japan).cue" size 2714 crc 5f23f966 md5 a4df187260a031af216e841b97664cc0 sha1 c71954430b0d39b6fe7547ab2fdcab9518d63506 )
+	rom ( name "Magicoal (Japan).cue" size 12968 crc 0274bbde md5 5d654c67c74efbb121f3895618ad72f2 sha1 0df8e1f9d10c5a044b6d7cbd571049cdaa441aca )
+)
+
+game (
+	name "Mahjong Clinic Special (Japan)"
+	description "Mahjong Clinic Special (Japan)"
+	rom ( name "Mahjong Clinic Special (Japan).cue" size 7461 crc aba57389 md5 933919c0db70a4830662fdbf19677c0d sha1 67170dbc8a12d4ae470c0966f722d360d79893c7 )
 )
 
 game (
 	name "Mahjong Lemon Angel (Japan)"
 	description "Mahjong Lemon Angel (Japan)"
-	rom ( name "Mahjong Lemon Angel (Japan).cue" size 8296 crc 6f54e3ed md5 1545bf28a19b73e80f0e418a171b856b sha1 1df872ca0e18e899b4d5b5d17d69c5678a98acfb )
+	rom ( name "Mahjong Lemon Angel (Japan).cue" size 34593 crc 9bf8436e md5 15b5193be092f16082ed15de3e8323cc sha1 337d287b2c2ccf3ff6a6a746734e10947d082922 )
+)
+
+game (
+	name "Mahjong on The Beach (Japan)"
+	description "Mahjong on The Beach (Japan)"
+	rom ( name "Mahjong on The Beach (Japan).cue" size 8674 crc 05dc2c52 md5 f9903029207e37b97232887032c878e3 sha1 d01614e4e97242e8b73f5d9a095b2abdd628b8ed )
+)
+
+game (
+	name "Mahjong Sword - Princess Quest Gaiden (Japan)"
+	description "Mahjong Sword - Princess Quest Gaiden (Japan)"
+	rom ( name "Mahjong Sword - Princess Quest Gaiden (Japan).cue" size 29346 crc 0ce2d5be md5 3843769911132b480ec8bedae63efee7 sha1 7179853ecb8261ed177f61d108ba51204d86c627 )
 )
 
 game (
@@ -979,15 +2341,51 @@ game (
 )
 
 game (
+	name "Mahjong Vanilla Syndrome (Japan) - まーじゃんバニラシンドローム"
+	description "Mahjong Vanilla Syndrome (Japan) - まーじゃんバニラシンドローム"
+	rom ( name "Mahjong Vanilla Syndrome (Japan).cue" size 32168 crc 344564b8 md5 889adfd3f20c7c2c347eb045589fef6b sha1 bf98cfbdf2240f5bb6f58537ff46597bdb2a2e96 )
+)
+
+game (
 	name "Mahjong Vanilla Syndrome (Japan) (Alt)"
 	description "Mahjong Vanilla Syndrome (Japan) (Alt)"
 	rom ( name "Mahjong Vanilla Syndrome (Japan) (Alt).cue" size 8572 crc c91f457c md5 00ce41c9ffb05a659f8d7a8bee3be93f sha1 3bf6aee6792acd31ad2531d24263ce22165207f4 )
 )
 
 game (
+	name "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (1)"
+	description "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (1)"
+	rom ( name "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (1).cue" size 11389 crc 197a76b2 md5 1e947e64e0e1664e7c35e6e3ed5b1bb2 sha1 767a0d7395c99065fa57efa7e2779331771bc382 )
+)
+
+game (
+	name "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (2)"
+	description "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (2)"
+	rom ( name "Mamono Hunter Youko - Makai Kara no Tenkousei (Japan) (2).cue" size 11389 crc 292095dd md5 39b6142a84e24478478e541a1ede260f sha1 e63acfa73947744b972fc96f179baa8a84776349 )
+)
+
+game (
+	name "Mamono Hunter Youko - Tooki Yobigoe (Japan)"
+	description "Mamono Hunter Youko - Tooki Yobigoe (Japan)"
+	rom ( name "Mamono Hunter Youko - Tooki Yobigoe (Japan).cue" size 8540 crc e9a2b0de md5 9a49320613c65eea478e23e6ed33ed4e sha1 5cface1ef700f33295d5852d97000183f2410627 )
+)
+
+game (
 	name "Manhole, The (Japan)"
 	description "Manhole, The (Japan)"
-	rom ( name "Manhole, The (Japan).cue" size 3414 crc e0e87ac8 md5 e6176bfb94fe9d8c7f7da4a48b143cff sha1 4601dd264da00e1ee0bdc98ae3c29ea1d6cf4699 )
+	rom ( name "Manhole, The (Japan).cue" size 15551 crc 5d7eb494 md5 1c90d6397660db151dc833884d87ab91 sha1 9dcbdd39c4c27fb4217def844d2d84fd26825c0c )
+)
+
+game (
+	name "Martial Champion (Japan)"
+	description "Martial Champion (Japan)"
+	rom ( name "Martial Champion (Japan).cue" size 33780 crc 92ae1dd5 md5 19f087584bc973ca02fafa18f6cac779 sha1 736795a762c726adb2645a5d195d2e1dd7809e5f )
+)
+
+game (
+	name "Mashou Denki - La Valeur (Japan) - 魔晶伝記+ラヴァルー"
+	description "Mashou Denki - La Valeur (Japan) - 魔晶伝記+ラヴァルー"
+	rom ( name "Mashou Denki - La Valeur (Japan).cue" size 10703 crc 12bb82ad md5 aa11afcccb6d2bd959df18e085706881 sha1 14af3e7e064d047637f516fd533d7894052f2aed )
 )
 
 game (
@@ -1003,15 +2401,33 @@ game (
 )
 
 game (
+	name "Master of Monsters (Japan) - マスターオブモンスターズ"
+	description "Master of Monsters (Japan) - マスターオブモンスターズ"
+	rom ( name "Master of Monsters (Japan).cue" size 2853 crc 27cd0423 md5 e8f189ab3fa80e7ed40f62ac67636af4 sha1 90b2264c6405dda03ce69ddcf917149c9799c7da )
+)
+
+game (
 	name "Mateki Densetsu Astralius (Japan)"
 	description "Mateki Densetsu Astralius (Japan)"
 	rom ( name "Mateki Densetsu Astralius (Japan).cue" size 5009 crc 73fac4b5 md5 26dbf7ea8de90b7d29002e82615907ea sha1 ff9a06991c3be99d8e4f855577f823b933957ce1 )
 )
 
 game (
+	name "Mateki Densetsu Astralius (Japan) - 魔笛伝説アストラリウス"
+	description "Mateki Densetsu Astralius (Japan) - 魔笛伝説アストラリウス"
+	rom ( name "Mateki Densetsu Astralius (Japan).cue" size 19870 crc 8f5cf111 md5 df6e41500599fb86a94e09ccc870b5bf sha1 98c88e6c5da90a9eb92d563a5ba64756c29bdbee )
+)
+
+game (
 	name "Megami Paradise (Japan)"
 	description "Megami Paradise (Japan)"
-	rom ( name "Megami Paradise (Japan).cue" size 4187 crc 0b754bd7 md5 59c80ea63dd19af2fef59f1593a7e545 sha1 dde4a9caa000fc7f7f21f404f2b419c0e8218b30 )
+	rom ( name "Megami Paradise (Japan).cue" size 18389 crc f0ec249f md5 2b476b182e19fe8fa7b722c5d131f330 sha1 596b7843f3ae18281ead8d75fe47522011e455de )
+)
+
+game (
+	name "Metal Angel (Japan)"
+	description "Metal Angel (Japan)"
+	rom ( name "Metal Angel (Japan).cue" size 5425 crc 864a94bd md5 6508b5f0dbc75ed0cd8115a73c29e920 sha1 816006449639b5ba21668c7d7c9c750af4ca51d4 )
 )
 
 game (
@@ -1021,21 +2437,45 @@ game (
 )
 
 game (
+	name "Metal Angel 2 (Japan)"
+	description "Metal Angel 2 (Japan)"
+	rom ( name "Metal Angel 2 (Japan).cue" size 6237 crc e09ef420 md5 02565c4ae24aae7915970e49878b77e4 sha1 3bd4c54a9ba2d102fbc54fa0b1462763296297b6 )
+)
+
+game (
+	name "Metamor Jupiter (Japan)"
+	description "Metamor Jupiter (Japan)"
+	rom ( name "Metamor Jupiter (Japan).cue" size 19182 crc 1f90c3f8 md5 cdd17f498ee34a486a11b83d10b9ef0c sha1 c47cdd9ec01f1595d0a78f8cc5c885dddec3ede3 )
+)
+
+game (
 	name "Might and Magic (Japan)"
 	description "Might and Magic (Japan)"
-	rom ( name "Might and Magic (Japan).cue" size 1147 crc ff7ec5fa md5 068a30848882baaefc41c0c44fd2bbf0 sha1 50e6aca311eaee9dbd12ff710f68fe48af8abac1 )
+	rom ( name "Might and Magic (Japan).cue" size 5429 crc e8750c30 md5 ab5120fa6360b32ba540c4a9c6a6bf81 sha1 917605d3357530c1df232dee77dbb24fdb6fa0ad )
 )
 
 game (
 	name "Might and Magic III - Isles of Terra (Japan)"
 	description "Might and Magic III - Isles of Terra (Japan)"
-	rom ( name "Might and Magic III - Isles of Terra (Japan).cue" size 1958 crc 3755288c md5 e1dc36e4c8e01cd40393b7e86fa4c805 sha1 c96825247a7731af8134cde730f05f7a15b082cb )
+	rom ( name "Might and Magic III - Isles of Terra (Japan).cue" size 7475 crc 46a5032d md5 30188e54519e42a20b8640cfd0a8efc0 sha1 f6c98309e5933d2549515266cff0612dbaa86e33 )
+)
+
+game (
+	name "Mine Sweeper (Japan)"
+	description "Mine Sweeper (Japan)"
+	rom ( name "Mine Sweeper (Japan).cue" size 10542 crc 68976da3 md5 cb270febcccc2638b0a21655e68a4d6a sha1 606c5d67490f48a02a2f618b58efb503a5ba7546 )
 )
 
 game (
 	name "Minesweeper (Japan) (Rev 1)"
 	description "Minesweeper (Japan) (Rev 1)"
 	rom ( name "Minesweeper (Japan) (Rev 1).cue" size 2450 crc 20641c7c md5 86ba5a24fbff5305021a7a26cf931a2a sha1 28f2ad8f0ff94ceab89b2c95a8a0cec23728e076 )
+)
+
+game (
+	name "Mirai Shonen Conan (Japan)"
+	description "Mirai Shonen Conan (Japan)"
+	rom ( name "Mirai Shonen Conan (Japan).cue" size 23913 crc db69c308 md5 3c21f20e7aa6b59a514008bf899828da sha1 17ca313c0a063c51279cc3760571401d902fdce6 )
 )
 
 game (
@@ -1047,13 +2487,37 @@ game (
 game (
 	name "Mitsubachi Gakuen (Japan)"
 	description "Mitsubachi Gakuen (Japan)"
-	rom ( name "Mitsubachi Gakuen (Japan).cue" size 1437 crc fc27e1bb md5 f3ff2be726cdb4f370201476a5967b8b sha1 522db7daff965d160d80f1358672a534c6cc652d )
+	rom ( name "Mitsubachi Gakuen (Japan).cue" size 6646 crc 36baee61 md5 9724baae467a622d46c96f55405fd242 sha1 e9f21a0395099ed1284e2c8297e7290d3a433b29 )
+)
+
+game (
+	name "Monster Lair - Wonderboy III (Japan)"
+	description "Monster Lair - Wonderboy III (Japan)"
+	rom ( name "Monster Lair - Wonderboy III (Japan).cue" size 7467 crc 223a3e70 md5 2bfbc7a085fb7c536a8f6724ea59d136 sha1 1b9b20dc3e2a7e5e89a37db97a602063878c4ca0 )
+)
+
+game (
+	name "Monster Lair (USA)"
+	description "Monster Lair (USA)"
+	rom ( name "Monster Lair (USA).cue" size 7449 crc 9f66650e md5 c827bc3b999347f319c2f3df3a2bf611 sha1 f5c3a71150e698236c404acc55043d8ea58f8d82 )
 )
 
 game (
 	name "Monster Maker - Yami no Ryuukishi (Japan)"
 	description "Monster Maker - Yami no Ryuukishi (Japan)"
 	rom ( name "Monster Maker - Yami no Ryuukishi (Japan).cue" size 4057 crc 9407db4f md5 86e767fe0d2dd30c4a677c56da2b7db2 sha1 bcb2b3c6a6724d2975fc43ff047f4bd9c654c680 )
+)
+
+game (
+	name "Monster Maker - Yami no Ryuukishi (Japan) (2) - モンスターメーカー+闇の龍騎士"
+	description "Monster Maker - Yami no Ryuukishi (Japan) (2) - モンスターメーカー+闇の龍騎士"
+	rom ( name "Monster Maker - Yami no Ryuukishi (Japan) (2).cue" size 15171 crc e93a77d3 md5 73bacb087aa7596a9e33e0a0ca743595 sha1 08af7af204c4aa1974013ec018a0c6dc48208d21 )
+)
+
+game (
+	name "Monster Maker - Yami no Ryuukishi (Japan) (3) - モンスターメーカー+闇の龍騎士"
+	description "Monster Maker - Yami no Ryuukishi (Japan) (3) - モンスターメーカー+闇の龍騎士"
+	rom ( name "Monster Maker - Yami no Ryuukishi (Japan) (3).cue" size 15171 crc ae8a5573 md5 a9f144319a1995241fc222a9da50d64d sha1 e20229f09996160e3e144fa2c8124d87ce4608ae )
 )
 
 game (
@@ -1065,13 +2529,31 @@ game (
 game (
 	name "Moonlight Lady (Japan)"
 	description "Moonlight Lady (Japan)"
-	rom ( name "Moonlight Lady (Japan).cue" size 4614 crc d915ccea md5 b0c11fea871677ac012ba353255cd1ba sha1 c84db150a3174efe4548ba1b3f7c7d2132149d87 )
+	rom ( name "Moonlight Lady (Japan).cue" size 20413 crc 80595633 md5 4cbf9753bccf74962358a76275d13516 sha1 8048c52079beee8dd2cfa22bc8299852bcfab239 )
+)
+
+game (
+	name "Motoroader MC (Japan)"
+	description "Motoroader MC (Japan)"
+	rom ( name "Motoroader MC (Japan).cue" size 8113 crc c0d387ee md5 d9113fe96eefb9e28c97e3d21e5fb22f sha1 9257ab5af4023ee4ee1308dabc5bb2284b5849f0 )
 )
 
 game (
 	name "Motteke Tamago (Japan)"
 	description "Motteke Tamago (Japan)"
-	rom ( name "Motteke Tamago (Japan).cue" size 939 crc 74741fe0 md5 337f4e153e864a1ccd653b8800aa76a9 sha1 a2b3a73f35381f5ca23baab2ebc2fa1e842f0b15 )
+	rom ( name "Motteke Tamago (Japan).cue" size 4618 crc ce2f64d9 md5 f26f9be9a2f8d41042e653b53b56b7af sha1 857adb6719c5dd6613e2553cf1941409fbbfa5a3 )
+)
+
+game (
+	name "Motteke Tamago (Japan) (translated into english)"
+	description "Motteke Tamago (Japan) (translated into english)"
+	rom ( name "Motteke Tamago (Japan) (translated into english).cue" size 525 crc 4B8D1E28 md5 C873975C4A0DC7CF9A66CAEFABF8EF30 sha1 D0EC97D70351666608D4207B697296B30B2F517E )
+)
+
+game (
+	name "Mugen Senshi Valis - Legend of a Fantasm Soldier (Japan)"
+	description "Mugen Senshi Valis - Legend of a Fantasm Soldier (Japan)"
+	rom ( name "Mugen Senshi Valis - Legend of a Fantasm Soldier (Japan).cue" size 12603 crc e5edac40 md5 3936cfbb3f3f54c460285907e42df215 sha1 e58ff54788d42105db02f24ffeba37c46bf2d7d6 )
 )
 
 game (
@@ -1081,9 +2563,33 @@ game (
 )
 
 game (
+	name "Mystic Formula (Japan)"
+	description "Mystic Formula (Japan)"
+	rom ( name "Mystic Formula (Japan).cue" size 18793 crc 155521cb md5 a67b36e105a2be766a90c90cb26fca55 sha1 845acd63a81c2c3c2e3c3a091ee49cdb651e9c99 )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball Bu - Soccer Hen CD (Japan) - 熱血高校ドッジボール部+サッカー編CD"
+	description "Nekketsu Koukou Dodgeball Bu - Soccer Hen CD (Japan) - 熱血高校ドッジボール部+サッカー編CD"
+	rom ( name "Nekketsu Koukou Dodgeball Bu - Soccer Hen CD (Japan).cue" size 23683 crc 1c70baa8 md5 31c5b4442aabc83ed7a24d3b3fcd42f5 sha1 5a831bdc2a355439ab0edba520e83762495dbb40 )
+)
+
+game (
 	name "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan)"
 	description "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan)"
 	rom ( name "Nekketsu Koukou Dodgeball-bu CD - Soccer-hen (Japan).cue" size 7046 crc 90b24990 md5 01725cb8bd6de25e50a807a5df2d8d3c sha1 85d26f26ff5bbec57d4a77ab6c0604c95140bb0a )
+)
+
+game (
+	name "Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan)"
+	description "Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan)"
+	rom ( name "Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan).cue" size 22873 crc da34e857 md5 fcc160e2984c7afc95cbecf6e3b53e65 sha1 c5010fe4b8bfd5c7ef9d643ae1dc4eb6e890ad88 )
+)
+
+game (
+	name "Nekketsu Legend Baseball (Japan)"
+	description "Nekketsu Legend Baseball (Japan)"
+	rom ( name "Nekketsu Legend Baseball (Japan).cue" size 8934 crc cd02d71a md5 6942346c1fe527e233dfadcf3932fa7d sha1 60e0ed5777288ea526fead1fad1990ea3261f3e2 )
 )
 
 game (
@@ -1093,9 +2599,27 @@ game (
 )
 
 game (
+	name "Nemurenumori no Chiisana Ohanashi (Japan)"
+	description "Nemurenumori no Chiisana Ohanashi (Japan)"
+	rom ( name "Nemurenumori no Chiisana Ohanashi (Japan).cue" size 29081 crc ca4bf2e4 md5 995b94bafac8595e267d0dd28fa8234f sha1 08d3cc2cb6df5546380ac3dabd1ab86055b54e6d )
+)
+
+game (
+	name "Neo Nectaris (Japan)"
+	description "Neo Nectaris (Japan)"
+	rom ( name "Neo Nectaris (Japan).cue" size 13526 crc f0ac0eb8 md5 4513590cb99b8076c48a780e4b279344 sha1 8f6fba9b4ad8be10d7bcdd0025cc2b34da63e87a )
+)
+
+game (
 	name "Neo Nectaris (Japan) (Rev 3)"
 	description "Neo Nectaris (Japan) (Rev 3)"
 	rom ( name "Neo Nectaris (Japan) (Rev 3).cue" size 3202 crc d79a1fb8 md5 066dc041b8f9d448fbdcc7c03c2a9334 sha1 64d735bd079146493b7594f41cf33ff2e80cb301 )
+)
+
+game (
+	name "Nexzr (Japan)"
+	description "Nexzr (Japan)"
+	rom ( name "Nexzr (Japan).cue" size 10279 crc 126ee303 md5 338487a32a81ed8af65b1a471fc610eb sha1 caecb354bc298d8522e0c0aac8007fd061c9ab5f )
 )
 
 game (
@@ -1111,9 +2635,21 @@ game (
 )
 
 game (
+	name "No.Ri.Ko (Japan) - 小川範子"
+	description "No.Ri.Ko (Japan) - 小川範子"
+	rom ( name "No.Ri.Ko (Japan).cue" size 40657 crc de891009 md5 a547f6d0048af86202ca50ecc6c9335c sha1 9524328d8f6bb7b9567d6b6f6664e097e95121e2 )
+)
+
+game (
 	name "Nobunaga no Yabou - Zenkokuban (Japan)"
 	description "Nobunaga no Yabou - Zenkokuban (Japan)"
 	rom ( name "Nobunaga no Yabou - Zenkokuban (Japan).cue" size 1083 crc b0b8c043 md5 439bf7caecad3ce4f9e01427d2e33f4b sha1 0ad5ac658c506fe1402d3e396d0d7500200fab1b )
+)
+
+game (
+	name "Nobunaga no Yabou Zenkokuban (Japan)"
+	description "Nobunaga no Yabou Zenkokuban (Japan)"
+	rom ( name "Nobunaga no Yabou Zenkokuban (Japan).cue" size 4632 crc a88fb056 md5 7690a37465b175fde30dca76384d820e sha1 3228a8ad88ff3b50e8120a0b49b147cc303908c4 )
 )
 
 game (
@@ -1141,15 +2677,39 @@ game (
 )
 
 game (
+	name "Pachiokun 3 - Pachisuro & Pachinko (Japan)"
+	description "Pachiokun 3 - Pachisuro & Pachinko (Japan)"
+	rom ( name "Pachiokun 3 - Pachisuro & Pachinko (Japan).cue" size 9903 crc 504343d6 md5 71280745d9d1d1bc4e28b5039ea402a3 sha1 8e07bf0731d6f6a903263cc0e70c2d7da4aa1711 )
+)
+
+game (
+	name "Pachiokun Maboroshi no Densetsu (Japan)"
+	description "Pachiokun Maboroshi no Densetsu (Japan)"
+	rom ( name "Pachiokun Maboroshi no Densetsu (Japan).cue" size 19876 crc a346b2fe md5 dd79154ca895588f7c3784781c44aa85 sha1 75287b01f0587c0bb9a2f978b11161c882c2504e )
+)
+
+game (
+	name "Pachiokun Warau Uchuu (Japan)"
+	description "Pachiokun Warau Uchuu (Japan)"
+	rom ( name "Pachiokun Warau Uchuu (Japan).cue" size 11915 crc 2398728b md5 190e4f6b5dd5479f763739ed19ebcfc4 sha1 dcf6699bd12d5ee185e7d73f204884c926bcac98 )
+)
+
+game (
 	name "Palladion - Auto Crusher Palladium (Japan)"
 	description "Palladion - Auto Crusher Palladium (Japan)"
 	rom ( name "Palladion - Auto Crusher Palladium (Japan).cue" size 2154 crc 68b401e4 md5 46ee8ccf10054625f39106e9a62f19ee sha1 2382cdc6cf820bfbddb940a763f210807418b37e )
 )
 
 game (
+	name "Paradion - Auto Crusher Palladium (Japan)"
+	description "Paradion - Auto Crusher Palladium (Japan)"
+	rom ( name "Paradion - Auto Crusher Palladium (Japan).cue" size 8282 crc d086229a md5 47c7eff5592d2023aca8a9116b358e42 sha1 8d8beede2c295e20953d24b0103fbe4bfef64c97 )
+)
+
+game (
 	name "Pastel Lime (Japan)"
 	description "Pastel Lime (Japan)"
-	rom ( name "Pastel Lime (Japan).cue" size 1871 crc 143a144b md5 9383db43c4d0cfbd2bfe08331f4a14fb sha1 1ca81a6b8b043e0877751b842fa1cdf093ab48f7 )
+	rom ( name "Pastel Lime (Japan).cue" size 8921 crc 236944b4 md5 913a2c355d6cdf1365f6e167ff252a1d sha1 c20cdaee8454dbdb1eee36b86abc35ecda2b9cb7 )
 )
 
 game (
@@ -1159,9 +2719,99 @@ game (
 )
 
 game (
+	name "PCEngine Fan Special CD-Rom Volume I (Japan) (2)"
+	description "PCEngine Fan Special CD-Rom Volume I (Japan) (2)"
+	rom ( name "PCEngine Fan Special CD-Rom Volume I (Japan) (2).cue" size 4495 crc 45228bbd md5 147df88d0b5af5e7f644b2a0ea0f97cd sha1 e3546b2d86be84d79a30ef40c243ea042b605053 )
+)
+
+game (
+	name "PCEngine Fan Special CD-Rom Volume I (Japan) (5)"
+	description "PCEngine Fan Special CD-Rom Volume I (Japan) (5)"
+	rom ( name "PCEngine Fan Special CD-Rom Volume I (Japan) (5).cue" size 4495 crc 7b43230c md5 29303a8e04f4866347c84efc382858b0 sha1 ca02b0fdcfed6885f30255f403f042000309ae9a )
+)
+
+game (
+	name "PCEngine Hyper Catalog (Japan)"
+	description "PCEngine Hyper Catalog (Japan)"
+	rom ( name "PCEngine Hyper Catalog (Japan).cue" size 12976 crc 81cb6137 md5 49a689f45caf2603e86db378e6f1b898 sha1 6c15c73207b62568d218e910790e25feebb55ca6 )
+)
+
+game (
+	name "PCEngine Hyper Catalog 2 (Japan)"
+	description "PCEngine Hyper Catalog 2 (Japan)"
+	rom ( name "PCEngine Hyper Catalog 2 (Japan).cue" size 17353 crc b9dc063a md5 a8240d33409b4de53359a1cfa341935a sha1 c629ac2075497ce5afb7ef2b16566191de81b3a3 )
+)
+
+game (
+	name "PCEngine Hyper Catalog 3 (Japan)"
+	description "PCEngine Hyper Catalog 3 (Japan)"
+	rom ( name "PCEngine Hyper Catalog 3 (Japan).cue" size 18163 crc ac18a489 md5 0e3ea457475f90fd60ecac49f8adc8e3 sha1 1b949f2a3b42a2db7e9afce98e2337f6c14e7a8c )
+)
+
+game (
+	name "PCEngine Hyper Catalog 4 (Japan)"
+	description "PCEngine Hyper Catalog 4 (Japan)"
+	rom ( name "PCEngine Hyper Catalog 4 (Japan).cue" size 29977 crc a62712b6 md5 0b70f5f909d7ac28b5da6642b8137e14 sha1 3b14192f07d659df17f8a3ffb89306d55033f941 )
+)
+
+game (
+	name "PCEngine Hyper Catalog 5 (Japan)"
+	description "PCEngine Hyper Catalog 5 (Japan)"
+	rom ( name "PCEngine Hyper Catalog 5 (Japan).cue" size 24350 crc d8d6c928 md5 405087d0a81ed459b854fea5bba173a6 sha1 378623b358e477bdec38b54015ea9c51a397b85b )
+)
+
+game (
+	name "PCEngine Hyper Catalog 6 (Japan) (Disc 1)"
+	description "PCEngine Hyper Catalog 6 (Japan) (Disc 1)"
+	rom ( name "PCEngine Hyper Catalog 6 (Japan) (Disc 1).cue" size 16046 crc 4639e3c3 md5 78ff6460ce1d4a42cc46840564a1af90 sha1 7cb711d9491450f6580bcd108e8c6e5167e7abc9 )
+)
+
+game (
+	name "PCEngine Hyper Catalog 6 (Japan) (Disc 2)"
+	description "PCEngine Hyper Catalog 6 (Japan) (Disc 2)"
+	rom ( name "PCEngine Hyper Catalog 6 (Japan) (Disc 2).cue" size 21050 crc 6e92958c md5 e037470358f46ffb82712e6497356b9b sha1 9d6dbf455a4293e5fdb6c96be3ccb288461ab8ff )
+)
+
+game (
+	name "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 1)"
+	description "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 1)"
+	rom ( name "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 1).cue" size 16051 crc e0682805 md5 ec91c1f42e8b1673738b6fd9c6366a01 sha1 8ae87112ec0c75caca49bec2e05648fddb920832 )
+)
+
+game (
+	name "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 2)"
+	description "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 2)"
+	rom ( name "PCEngine Hyper Catalog Duo-RX (Japan) (Disc 2).cue" size 20101 crc 7a889353 md5 4c0258e163c5a9de276be09ea0aa6418 sha1 bb0660b29f3fcc253267e56ac554f92c4e804491 )
+)
+
+game (
+	name "Police Connection (Japan)"
+	description "Police Connection (Japan)"
+	rom ( name "Police Connection (Japan).cue" size 10696 crc 153928aa md5 13b27e597b9457450f818ead4d963022 sha1 c4d2b6bec5d9b3d1abf1690488da6a35bb625830 )
+)
+
+game (
+	name "Pomping World (Japan)"
+	description "Pomping World (Japan)"
+	rom ( name "Pomping World (Japan).cue" size 10692 crc 69114f2f md5 fe0efcb326a1c565b3d242d3cadb373a sha1 3d56decd6ee2565baae3041f2c10d4b81c8b39e8 )
+)
+
+game (
 	name "Pomping World (Japan) (Rev 1)"
 	description "Pomping World (Japan) (Rev 1)"
 	rom ( name "Pomping World (Japan) (Rev 1).cue" size 2526 crc 2236f4e5 md5 5df5cd3146869a1f7ecd567613767b05 sha1 d17f402a0bff0e01aeacbe0d627f8bcb66330116 )
+)
+
+game (
+	name "Pop'n Magic (Japan)"
+	description "Pop'n Magic (Japan)"
+	rom ( name "Pop'n Magic (Japan).cue" size 16754 crc 90259d51 md5 5e0f2ced6707c819f6da7e1e23756bba sha1 4936543c3f619d5c7b07c830bc1dfd805a07cc0f )
+)
+
+game (
+	name "Populous - The Promised Lands (Japan)"
+	description "Populous - The Promised Lands (Japan)"
+	rom ( name "Populous - The Promised Lands (Japan).cue" size 6658 crc 10e92eae md5 a1e90ae345857ae5d1fea61f8a898a03 sha1 96ae9d61d5aeb813d6c57914998e1d833c03267a )
 )
 
 game (
@@ -1173,7 +2823,13 @@ game (
 game (
 	name "Prince of Persia (Japan)"
 	description "Prince of Persia (Japan)"
-	rom ( name "Prince of Persia (Japan).cue" size 1926 crc 593ba47d md5 b35cb4ea1b48d2da599ce93a2e6479c6 sha1 0c94bd5be83593b7f1db7e3e592fc94cc6d52a92 )
+	rom ( name "Prince of Persia (Japan).cue" size 8670 crc 340bd043 md5 4703c9c2386e048ffc51074f9a3292a1 sha1 efbece7c6eb461ac114d11e74b801613b859b35b )
+)
+
+game (
+	name "Prince of Persia (USA)"
+	description "Prince of Persia (USA)"
+	rom ( name "Prince of Persia (USA).cue" size 8668 crc 279c104f md5 ab5fb1994816f6a35c1ec6eea0eedbf4 sha1 5aa34bc1f32bab568bf1e488e3a724d8cafa3c32 )
 )
 
 game (
@@ -1183,9 +2839,27 @@ game (
 )
 
 game (
+	name "Princess Maker 1 (Japan) (Disc 1) - プリンセスメーカー1+(プリンセスメーカー1+オリジナル+シングル+CD)"
+	description "Princess Maker 1 (Japan) (Disc 1) - プリンセスメーカー1+(プリンセスメーカー1+オリジナル+シングル+CD)"
+	rom ( name "Princess Maker 1 (Japan) (Disc 1).cue" size 22044 crc 079e6da0 md5 9071e0328a12af2c7282b5b4dfd44297 sha1 c2f452f264de2a27505f7464114faf0c92f3f8a5 )
+)
+
+game (
+	name "Princess Maker 1 (Japan) (Disc 2) (Audio) - プリンセスメーカー1+(プリンセスメーカー1+オリジナル+シングル+CD)"
+	description "Princess Maker 1 (Japan) (Disc 2) (Audio) - プリンセスメーカー1+(プリンセスメーカー1+オリジナル+シングル+CD)"
+	rom ( name "Princess Maker 1 (Japan) (Disc 2) (Audio).cue" size 2053 crc f7bc7f06 md5 b5606859ece14a272c20658148c10825 sha1 8f19a5864f088669cfc45a1bb164ab8b99a8518b )
+)
+
+game (
 	name "Princess Maker 2 (Japan)"
 	description "Princess Maker 2 (Japan)"
 	rom ( name "Princess Maker 2 (Japan).cue" size 2186 crc 33c1ae01 md5 fa06214077ed0eb14790b573c8b9e796 sha1 d9a8881e5a14432fff97e6fcb8c3a712663706d4 )
+)
+
+game (
+	name "Princess Maker 2 (Japan) - プリンセスメーカー2"
+	description "Princess Maker 2 (Japan) - プリンセスメーカー2"
+	rom ( name "Princess Maker 2 (Japan).cue" size 9736 crc 2046c306 md5 0980d4d8aa281236c17cde0196b5f617 sha1 efd77a402786c2cd02b85e31be638b83652b82e1 )
 )
 
 game (
@@ -1195,9 +2869,33 @@ game (
 )
 
 game (
+	name "Princess Minerva (Japan) - プリンセスミネルバ"
+	description "Princess Minerva (Japan) - プリンセスミネルバ"
+	rom ( name "Princess Minerva (Japan).cue" size 11761 crc 1f4fb807 md5 d5b97d04c41ec3c46b44c6d8f3faf0bb sha1 0df5c1a2ea17177026b9893d4b82445e19539273 )
+)
+
+game (
 	name "Private Eye dol (Japan)"
 	description "Private Eye dol (Japan)"
 	rom ( name "Private Eye dol (Japan).cue" size 2449 crc 7b76f470 md5 9f2aff8d7ffef473307f733c21d574f1 sha1 50123ee0ee73248f68fb0cb5cf89c03c623d29d0 )
+)
+
+game (
+	name "Private Eyedol (Japan)"
+	description "Private Eyedol (Japan)"
+	rom ( name "Private Eyedol (Japan).cue" size 10949 crc 460157b2 md5 ee1fb8925ca05eceacc59395456a96cb sha1 e07c35932af346d9e425b78477e21d0788ea6e7b )
+)
+
+game (
+	name "Pro Yakyuu Super '94, The (Japan)"
+	description "Pro Yakyuu Super '94, The (Japan)"
+	rom ( name "Pro Yakyuu Super '94, The (Japan).cue" size 13134 crc d94e396c md5 2f80f6ee1bee237ef4ca9036a7e4356c sha1 81f26652f6564063b97cfa1e9e1a07a8d90535ab )
+)
+
+game (
+	name "Pro Yakyuu Super, The (Japan) - ザプロ野球+Super"
+	description "Pro Yakyuu Super, The (Japan) - ザプロ野球+Super"
+	rom ( name "Pro Yakyuu Super, The (Japan).cue" size 12725 crc 5e577888 md5 31877556632fef74f4bca649183bb3d1 sha1 58d2e52cb91870a31fa97a91fb8c5257ecf86bda )
 )
 
 game (
@@ -1213,27 +2911,45 @@ game (
 )
 
 game (
+	name "Pro Yakyuu, The (Japan) - ザプロ野球"
+	description "Pro Yakyuu, The (Japan) - ザプロ野球"
+	rom ( name "Pro Yakyuu, The (Japan).cue" size 9479 crc 7bb9b8f2 md5 670a44d59b1bc1f463dd45c217a39acd sha1 6ad3d11e6eb9d9abec9547c10132885f3b013b16 )
+)
+
+game (
+	name "Psychic Detective Series Vol. 3 - Aya (Japan) - サイキック+ディテクティブ+シリーズ3+アヤ"
+	description "Psychic Detective Series Vol. 3 - Aya (Japan) - サイキック+ディテクティブ+シリーズ3+アヤ"
+	rom ( name "Psychic Detective Series Vol. 3 - Aya (Japan).cue" size 4641 crc dcbdbc8c md5 be0396bd52366be0654f2ed8ebfdc6ba sha1 76d28f361b3eeb0e8190910d850f93b30bfaa6c4 )
+)
+
+game (
 	name "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1)"
 	description "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1)"
 	rom ( name "Psychic Detective Series Vol. 3 - Aya (Japan) (Rev 1).cue" size 1218 crc efa66054 md5 a772c3653cffd1335d314437d66aced2 sha1 6733589553dd964de805a50c040cb65677ba5274 )
 )
 
 game (
+	name "Psychic Detective Series Vol. 4 - Orgel (Japan)"
+	description "Psychic Detective Series Vol. 4 - Orgel (Japan)"
+	rom ( name "Psychic Detective Series Vol. 4 - Orgel (Japan).cue" size 4089 crc 3fd734f0 md5 5a87fb7b4ae37c4e3576defdc0ead024 sha1 f8af5d4f1eedf3cc03b765dde86ed1c1c52b80d6 )
+)
+
+game (
 	name "Psychic Storm (Japan)"
 	description "Psychic Storm (Japan)"
-	rom ( name "Psychic Storm (Japan).cue" size 2427 crc 1c772037 md5 8e3b644026d0da25fd80fd321669da56 sha1 0a333993d2204c81be0e48bffce0b9385868b8be )
+	rom ( name "Psychic Storm (Japan).cue" size 11097 crc 6e8338c6 md5 30069f5f3062244c305a501bf8bd0aa4 sha1 1e257fda572b99f6c1382daa64457b1b4ca3b8b7 )
 )
 
 game (
 	name "Puyo Puyo CD (Japan)"
 	description "Puyo Puyo CD (Japan)"
-	rom ( name "Puyo Puyo CD (Japan).cue" size 3506 crc 7773aa51 md5 858e5d2a3f78c509475a4bb2d20fe4c9 sha1 99b133283d53cd50968e28581243532e83a96cb3 )
+	rom ( name "Puyo Puyo CD (Japan).cue" size 15956 crc 8553ae4a md5 c8ac56c3cbee8cc8c77d2166ef076e70 sha1 0336530cc517e406ad21fff8cc0f04347ef44719 )
 )
 
 game (
 	name "Puyo Puyo CD Tsuu (Japan)"
 	description "Puyo Puyo CD Tsuu (Japan)"
-	rom ( name "Puyo Puyo CD Tsuu (Japan).cue" size 7959 crc fcf274fa md5 2f25b730ffc6b3141300fb4029a96baf sha1 04c24257154acfa9888263e70a6bc845706668f1 )
+	rom ( name "Puyo Puyo CD Tsuu (Japan).cue" size 33781 crc 9039477d md5 73fbfe46b8a4608f83e54f48d1358604 sha1 1569dd621ff45d79335a8160d8cd6b37be0cdd1f )
 )
 
 game (
@@ -1249,9 +2965,33 @@ game (
 )
 
 game (
+	name "Quiz Avenue (Japan) - クイズアベニュー"
+	description "Quiz Avenue (Japan) - クイズアベニュー"
+	rom ( name "Quiz Avenue (Japan).cue" size 3805 crc e43be2a8 md5 0279884b98de609e643a9fdef3db34f1 sha1 b5982f867ba04bb9a2fd59d3a9f1a37cb710ceb7 )
+)
+
+game (
+	name "Quiz Avenue 2 (Japan)"
+	description "Quiz Avenue 2 (Japan)"
+	rom ( name "Quiz Avenue 2 (Japan).cue" size 4212 crc 9a6e3d78 md5 1b56c780035490614ffca5a85f2eeebd sha1 5a78bdf50eddd6768a173b1e938d818494bcc619 )
+)
+
+game (
+	name "Quiz Avenue 3 (Japan)"
+	description "Quiz Avenue 3 (Japan)"
+	rom ( name "Quiz Avenue 3 (Japan).cue" size 4212 crc 778124dc md5 16c0e1a4f6e7494ea17b3ae498ca2c7b sha1 52b80dbb798aa0afdd82aff3df2e7af8a3a98962 )
+)
+
+game (
 	name "Quiz Avenue II (Japan)"
 	description "Quiz Avenue II (Japan)"
 	rom ( name "Quiz Avenue II (Japan).cue" size 846 crc eba0c070 md5 e05ced31e9a96c90c254383eb61370ad sha1 ff2f988bab39c6bdfdbffdf28994a93bfa07b8fc )
+)
+
+game (
+	name "Quiz Caravan Cult Q (Japan) - クイズキャラバン+カルトQ"
+	description "Quiz Caravan Cult Q (Japan) - クイズキャラバン+カルトQ"
+	rom ( name "Quiz Caravan Cult Q (Japan).cue" size 14599 crc 780d8287 md5 5cb96586b85f073a39ca54c3aa5d3cb9 sha1 9f907cee1f2f86f4e1d8bebe1559584cbc34e81c )
 )
 
 game (
@@ -1263,7 +3003,13 @@ game (
 game (
 	name "Quiz de Gakuensai (Japan)"
 	description "Quiz de Gakuensai (Japan)"
-	rom ( name "Quiz de Gakuensai (Japan).cue" size 7474 crc fc9d051f md5 c2925142f447b8460a2834b8b2648aa2 sha1 2b5c4beff27d4d43251a6efc39213d78eed4238b )
+	rom ( name "Quiz de Gakuensai (Japan).cue" size 31756 crc 15dcb256 md5 04df01f783242987387362388c9005c8 sha1 d7dcaec4c0f6d1268151f43b1a6f3821c7c70fd5 )
+)
+
+game (
+	name "Quiz Marugoto the World (Japan) - Quiz+まるごと+the+ワールド"
+	description "Quiz Marugoto the World (Japan) - Quiz+まるごと+the+ワールド"
+	rom ( name "Quiz Marugoto the World (Japan).cue" size 9743 crc 1fe4c45f md5 ad46e678cde1f331d782bb3b1111b118 sha1 23ddc275538c57ced80380ad86838cf25f3eede9 )
 )
 
 game (
@@ -1285,9 +3031,21 @@ game (
 )
 
 game (
+	name "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan) - Quiz+まるごと+the+ワールド2+タイムマシンにおねがい!"
+	description "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan) - Quiz+まるごと+the+ワールド2+タイムマシンにおねがい!"
+	rom ( name "Quiz Marugoto the World 2 - Time Machine ni Onegai! (Japan).cue" size 17871 crc 42677a0a md5 2af5e1d493dc8ecaae7204333697c3aa sha1 bd06cb32bab9100efcf5ec2773f8f5696b1e1d87 )
+)
+
+game (
 	name "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5)"
 	description "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5)"
 	rom ( name "Quiz no Hoshi - Star of Quiz (Japan) (Rev 5).cue" size 5206 crc 41cb147f md5 ddf81a2f80cefdb8f345189264dc89c2 sha1 957df35246fed795a7a7ba2941a2d8f33415fa5b )
+)
+
+game (
+	name "Quiz no Hoshi (Japan)"
+	description "Quiz no Hoshi (Japan)"
+	rom ( name "Quiz no Hoshi (Japan).cue" size 18792 crc 6a384683 md5 14390ed03aa0f468ab6612dada2fdc31 sha1 fd483e4a516cc2bcfabc3c3d470270c5b9e71943 )
 )
 
 game (
@@ -1297,15 +3055,51 @@ game (
 )
 
 game (
+	name "Quiz Tonosama no Yabou (Japan) - クイズ殿様の野望"
+	description "Quiz Tonosama no Yabou (Japan) - クイズ殿様の野望"
+	rom ( name "Quiz Tonosama no Yabou (Japan).cue" size 15583 crc 6f255a84 md5 27e45ca05db0fe1b671ad24ce95a1c64 sha1 7c07a4935b248de7bbd9eb521b5cde085a46f103 )
+)
+
+game (
+	name "R-Type Complete CD (Japan)"
+	description "R-Type Complete CD (Japan)"
+	rom ( name "R-Type Complete CD (Japan).cue" size 19607 crc 2a87a3d2 md5 92ad450a9c200e5d84572f19eb02d496 sha1 96b4fc3ebad6ebeb7e2eab352de013a6f9473379 )
+)
+
+game (
 	name "R-Type Complete CD (Japan) (Rev 1)"
 	description "R-Type Complete CD (Japan) (Rev 1)"
 	rom ( name "R-Type Complete CD (Japan) (Rev 1).cue" size 4978 crc b15a4ef7 md5 ecb1fc6cb6d5b1ae1fdfccffc27fa0cd sha1 09a4f66cbf217ef57947ac6249158ec32fff9812 )
 )
 
 game (
+	name "Rainbow Islands (Japan)"
+	description "Rainbow Islands (Japan)"
+	rom ( name "Rainbow Islands (Japan).cue" size 13934 crc 28269b61 md5 e9378095367c81d6585cc0d73e4c2fc0 sha1 b7ab635f6dc5bef5e7df6eb715f5837704815475 )
+)
+
+game (
 	name "Rally Championship (Japan) (FABT)"
 	description "Rally Championship (Japan) (FABT)"
 	rom ( name "Rally Championship (Japan) (FABT).cue" size 1129 crc 05b47e26 md5 4dc03965e56a8fab06a7821e7124ec3c sha1 c0ae94e831d42151bc088f10c21186a1009fa7a8 )
+)
+
+game (
+	name "Ranma 0.5 (Japan) - Ranma ½"
+	description "Ranma 0.5 (Japan) - Ranma ½"
+	rom ( name "Ranma 0.5 (Japan).cue" size 23094 crc 7c724465 md5 187eb652cde78843580b339c4a54dfd6 sha1 ad8a33c8c40ab3586220e1832765a172c07866bc )
+)
+
+game (
+	name "Ranma 0.5 Datou, Ganso Musabetsu Kakutou-Ryuu! (Japan) - Ranma ½ Datou, Ganso Musabetsu Kakutou-Ryuu!"
+	description "Ranma 0.5 Datou, Ganso Musabetsu Kakutou-Ryuu! (Japan) - Ranma ½ Datou, Ganso Musabetsu Kakutou-Ryuu!"
+	rom ( name "Ranma 0.5 Datou, Ganso Musabetsu Kakutou-Ryuu! (Japan).cue" size 30016 crc c32edd6c md5 695d42be5706fc35eda6604b73c18afb sha1 0525029cd6dee0f7480461d408cfb78b2f1e2326 )
+)
+
+game (
+	name "Ranma 0.5 Toraware no Hanayome (Japan) - Ranma ½ Toraware no Hanayome"
+	description "Ranma 0.5 Toraware no Hanayome (Japan) - Ranma ½ Toraware no Hanayome"
+	rom ( name "Ranma 0.5 Toraware no Hanayome (Japan).cue" size 15825 crc 67db2f4b md5 ad7200d22e9df0f1dfe638ab1f4c214b sha1 0f8106689b4c65ad2731e77fbd1128e5fdef859a )
 )
 
 game (
@@ -1327,9 +3121,21 @@ game (
 )
 
 game (
+	name "Rayxanber II (Japan)"
+	description "Rayxanber II (Japan)"
+	rom ( name "Rayxanber II (Japan).cue" size 7451 crc 80d37d1c md5 2343a22e6b7542594ab6480e8c3824f7 sha1 dc5e2d2bcc15a9e51b3f28d6838f3dd5fe860cb8 )
+)
+
+game (
 	name "Rayxanber II (Japan) (Rev 3)"
 	description "Rayxanber II (Japan) (Rev 3)"
 	rom ( name "Rayxanber II (Japan) (Rev 3).cue" size 1702 crc 6b452412 md5 70efaa31556137301882192975dbe693 sha1 02da58d9525d7ec2931a0b695f9f42a215a34cbc )
+)
+
+game (
+	name "Rayxanber III (Japan)"
+	description "Rayxanber III (Japan)"
+	rom ( name "Rayxanber III (Japan).cue" size 8262 crc c9f24c69 md5 974471034d5565840f9662fd36d52de9 sha1 fd86b762e0d0a09bbf5b560198410e5ff65111d4 )
 )
 
 game (
@@ -1351,9 +3157,27 @@ game (
 )
 
 game (
+	name "Red Alert (Japan)"
+	description "Red Alert (Japan)"
+	rom ( name "Red Alert (Japan).cue" size 24309 crc 33ec4234 md5 1e0a573c014c22ee13b81167bdc9a71a sha1 73b5782c6ed15582a56d745e5d4422de1cbf43c3 )
+)
+
+game (
 	name "Red Alert (Japan) (Rev 3)"
 	description "Red Alert (Japan) (Rev 3)"
 	rom ( name "Red Alert (Japan) (Rev 3).cue" size 5700 crc e3d06737 md5 16b1026c20254e12806bf07db5d0f82d sha1 d5226fed0a56dea14fdc7461657ed50a49f196f8 )
+)
+
+game (
+	name "Riot Zone (USA)"
+	description "Riot Zone (USA)"
+	rom ( name "Riot Zone (USA).cue" size 10686 crc cbc26f91 md5 63433b499f5854bd4480d31f8a5cc212 sha1 d04cc45483e043271d8679f3d859006608cf75d2 )
+)
+
+game (
+	name "Rising Sun (Japan) - ライジングサン"
+	description "Rising Sun (Japan) - ライジングサン"
+	rom ( name "Rising Sun (Japan).cue" size 22285 crc 91a5a7e7 md5 9d4b9e6764a22aa93877506dd038e0f2 sha1 c654848da0738e68dbb41b0ec2c810a2821f9aec )
 )
 
 game (
@@ -1363,9 +3187,21 @@ game (
 )
 
 game (
+	name "Road Spirits (Japan) - ロードスピリッツ"
+	description "Road Spirits (Japan) - ロードスピリッツ"
+	rom ( name "Road Spirits (Japan).cue" size 9476 crc 3eeefe88 md5 5bf09d55eea0ad3cbc37bf038320f1a2 sha1 4f3b98833812c07e1d3d37bcdaf77fc84e488168 )
+)
+
+game (
 	name "Road Spirits (Japan) (Rev 2)"
 	description "Road Spirits (Japan) (Rev 2)"
 	rom ( name "Road Spirits (Japan) (Rev 2).cue" size 2202 crc b2ccddeb md5 8548c4331dd01f8e0f9fb3746d1cf5c0 sha1 ea8c18832f513f990febab6047e2bf8c23e06711 )
+)
+
+game (
+	name "ROM ROM Stadium (Japan) - ROMROMスタジアム"
+	description "ROM ROM Stadium (Japan) - ROMROMスタジアム"
+	rom ( name "ROM ROM Stadium (Japan).cue" size 7305 crc 10c0a001 md5 c72fae5fc3ea71415bae13bd4601939f sha1 5d4478bd1a6a9d11508b7db33cee2d2009b2285e )
 )
 
 game (
@@ -1375,9 +3211,87 @@ game (
 )
 
 game (
+	name "Rom2 Karaoke - Volume 1 - Suteki ni Standard (Japan) - Rom² Karaoke: Volume 1: Suteki ni Standard"
+	description "Rom2 Karaoke - Volume 1 - Suteki ni Standard (Japan) - Rom² Karaoke: Volume 1: Suteki ni Standard"
+	rom ( name "Rom2 Karaoke - Volume 1 - Suteki ni Standard (Japan).cue" size 6268 crc c5aa5142 md5 9d421a939b471c0af2f65bb25f022792 sha1 bc178f29832f356a4f223f2479e5ba6830af2c8e )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 1 (Japan) - Rom² Karaoke: Volume 1"
+	description "Rom2 Karaoke - Volume 1 (Japan) - Rom² Karaoke: Volume 1"
+	rom ( name "Rom2 Karaoke - Volume 1 (Japan).cue" size 6440 crc 942a6ca9 md5 e6ebbd710a0a07cc369decf12eccbd46 sha1 ba45d4f73d1f4f5b7ce722f4258c9c0a662a764d )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 2 - Nattoku Idol (Japan) - Rom² Karaoke: Volume 2: Nattoku Idol"
+	description "Rom2 Karaoke - Volume 2 - Nattoku Idol (Japan) - Rom² Karaoke: Volume 2: Nattoku Idol"
+	rom ( name "Rom2 Karaoke - Volume 2 - Nattoku Idol (Japan).cue" size 6262 crc c33481ca md5 cf990ce6cfce868204d8c84ada9b37a1 sha1 9e96f3d8680df5350d66f8fbba9dcb8df46b6442 )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 2 (Japan) - Rom² Karaoke: Volume 2"
+	description "Rom2 Karaoke - Volume 2 (Japan) - Rom² Karaoke: Volume 2"
+	rom ( name "Rom2 Karaoke - Volume 2 (Japan).cue" size 6440 crc c828b500 md5 addc11033df1985066f4f0c88778980d sha1 ff2c4c531862be2e8c675aff2f0e14d619d7c7a6 )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 3 - Yappashi Band (Japan) - Rom² Karaoke: Volume 3: Yappashi Band"
+	description "Rom2 Karaoke - Volume 3 - Yappashi Band (Japan) - Rom² Karaoke: Volume 3: Yappashi Band"
+	rom ( name "Rom2 Karaoke - Volume 3 - Yappashi Band (Japan).cue" size 6263 crc 59896b39 md5 35a2166af975961fe50e10ee8cbdb1b8 sha1 922f5c565cdfa591f478a2f5a8b5f703feaff2b6 )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 3 (Japan) - Rom² Karaoke: Volume 3"
+	description "Rom2 Karaoke - Volume 3 (Japan) - Rom² Karaoke: Volume 3"
+	rom ( name "Rom2 Karaoke - Volume 3 (Japan).cue" size 6440 crc 1f0d871f md5 4954d251a1dca1256daae69dfbdd20a4 sha1 ade633406b7b4e062b3a71b11c96889a00e15bba )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 4 - Choito Otona (Japan) - Rom² Karaoke: Volume 4: Choito Otona!?"
+	description "Rom2 Karaoke - Volume 4 - Choito Otona (Japan) - Rom² Karaoke: Volume 4: Choito Otona!?"
+	rom ( name "Rom2 Karaoke - Volume 4 - Choito Otona (Japan).cue" size 6262 crc c3d5b70d md5 27698ec179c028ef5d85b8b514d27d8c sha1 cedb1c1c7b397c0a09a1c4c95ae05af50940e4da )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 4 (Japan) - Rom² Karaoke: Volume 4"
+	description "Rom2 Karaoke - Volume 4 (Japan) - Rom² Karaoke: Volume 4"
+	rom ( name "Rom2 Karaoke - Volume 4 (Japan).cue" size 6440 crc e265e208 md5 376848c267d9be7b22f62f6517f6754f sha1 d0fc025002c7904a329db32c693ba6b722a910b5 )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 5 - Maku no Uchi (Japan) - Rom² Karaoke: Volume 5: Maku no Uchi"
+	description "Rom2 Karaoke - Volume 5 - Maku no Uchi (Japan) - Rom² Karaoke: Volume 5: Maku no Uchi"
+	rom ( name "Rom2 Karaoke - Volume 5 - Maku no Uchi (Japan).cue" size 6262 crc a61bebd6 md5 4389310d114606521e6cb4c6bc89d181 sha1 979a866b4397f0c8bc9485a97736977b2449798b )
+)
+
+game (
+	name "Rom2 Karaoke - Volume 5 (Japan) - Rom² Karaoke: Volume 5"
+	description "Rom2 Karaoke - Volume 5 (Japan) - Rom² Karaoke: Volume 5"
+	rom ( name "Rom2 Karaoke - Volume 5 (Japan).cue" size 6989 crc cb4fb04d md5 88c6f742e0cf5a501c3f46f11c505918 sha1 a12e7f7d573c9c1cd5e3edaa2ca88109c90d2c29 )
+)
+
+game (
+	name "Ruin - Kami no Isan (Japan)"
+	description "Ruin - Kami no Isan (Japan)"
+	rom ( name "Ruin - Kami no Isan (Japan).cue" size 10293 crc d998cfc2 md5 4b91418ad2b5277c7c3da0e2e5c0c3f0 sha1 cb05fef6f716c0fd2fd4d8b053714e94bbdca6e9 )
+)
+
+game (
+	name "Ryuuko no Ken (Japan) - 龍虎の拳"
+	description "Ryuuko no Ken (Japan) - 龍虎の拳"
+	rom ( name "Ryuuko no Ken (Japan).cue" size 17959 crc 83640c9b md5 1357cce3c335aa2ee2193432ce394a48 sha1 a56e5a5cec2b2a75c61afa064eab7523fd28424b )
+)
+
+game (
 	name "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT)"
 	description "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT)"
 	rom ( name "Ryuuko no Ken (Japan) (En,Ja,Es) (FABT).cue" size 4293 crc 50dffde3 md5 d78a5009974e8616665a7c89568c4619 sha1 11bff73c7eb2f4e1c35883df862d4d70cd9ded96 )
+)
+
+game (
+	name "Ryuuko no Ken (Japan) (Sample)"
+	description "Ryuuko no Ken (Japan) (Sample)"
+	rom ( name "Ryuuko no Ken (Japan) (Sample).cue" size 13792 crc 69b55f98 md5 7b67ce75b204a0e929b6ccf0788803d5 sha1 56378a794ddb68b358c12c47c6cb7c121248ac3b )
 )
 
 game (
@@ -1387,15 +3301,27 @@ game (
 )
 
 game (
+	name "Sangokushi Eiketsu - Tenka ni Nozomu (Japan)"
+	description "Sangokushi Eiketsu - Tenka ni Nozomu (Japan)"
+	rom ( name "Sangokushi Eiketsu - Tenka ni Nozomu (Japan).cue" size 30965 crc 98bac414 md5 3af8dc833ceead468fd10720edee77bb sha1 251fc8ebb9271db8edb2c56b2dc743e02712a414 )
+)
+
+game (
 	name "Sangokushi III (Japan)"
 	description "Sangokushi III (Japan)"
 	rom ( name "Sangokushi III (Japan).cue" size 2899 crc 2215d87c md5 0d2992fac145206339bb0228377065e2 sha1 f9193b7fa4169456e07c9f6b4de49aa65c1d0b20 )
 )
 
 game (
+	name "Sangokushi III (Japan) - 三國志III"
+	description "Sangokushi III (Japan) - 三國志III"
+	rom ( name "Sangokushi III (Japan).cue" size 13123 crc 63df1b1e md5 c85e7d6af963550f18e9adf10409cf1a sha1 0d47a1562a76e844d2e3edc473a1893485caaeb2 )
+)
+
+game (
 	name "Seirei Senshi Spriggan (Japan)"
 	description "Seirei Senshi Spriggan (Japan)"
-	rom ( name "Seirei Senshi Spriggan (Japan).cue" size 2856 crc c9e4556c md5 11894de1a875670a71e1506db5244822 sha1 bc6b59bc688e25e82c2b8025ecd744f8485a655b )
+	rom ( name "Seirei Senshi Spriggan (Japan).cue" size 11916 crc 1695aa03 md5 ff5a33e886e952ab1965f18ab53d445e sha1 a911cbfb1ff47f9d4de4063a20113c76db0ce8d0 )
 )
 
 game (
@@ -1411,9 +3337,39 @@ game (
 )
 
 game (
+	name "Seiryuu Densetsu Monbit (Japan)"
+	description "Seiryuu Densetsu Monbit (Japan)"
+	rom ( name "Seiryuu Densetsu Monbit (Japan).cue" size 3007 crc a8b533f6 md5 540adefb8f34fa4e2698c20a6539c415 sha1 7565dc53faaf5114fc7d07ccf423a53e51a4460d )
+)
+
+game (
+	name "Seisenshi Denshou - Jantaku no Kishi (Japan)"
+	description "Seisenshi Denshou - Jantaku no Kishi (Japan)"
+	rom ( name "Seisenshi Denshou - Jantaku no Kishi (Japan).cue" size 11525 crc f715c377 md5 ac25fe12663fd5235833457cd8047d08 sha1 01e0c32135be4af8de788b9376a7f0d3604d01f1 )
+)
+
+game (
+	name "Seiya Monogatari - Anearth Fantasy Stories (Japan)"
+	description "Seiya Monogatari - Anearth Fantasy Stories (Japan)"
+	rom ( name "Seiya Monogatari - Anearth Fantasy Stories (Japan).cue" size 13961 crc 65b43635 md5 a67dc9b447f15974553355fa064d3e4b sha1 b4085d3271abd3f83f0f6adb2572b8c0b88bf9ba )
+)
+
+game (
+	name "Seiya Monogatari - Anearth Fantasy Stories Taikenban (Japan)"
+	description "Seiya Monogatari - Anearth Fantasy Stories Taikenban (Japan)"
+	rom ( name "Seiya Monogatari - Anearth Fantasy Stories Taikenban (Japan).cue" size 13971 crc 7c2c5fec md5 faa366df5b3eaebfa79a987d0d32f71d sha1 c1e37b416938970e2b517ce77fab939279f9ae19 )
+)
+
+game (
 	name "Sengoku Kantou Sangokushi (Japan)"
 	description "Sengoku Kantou Sangokushi (Japan)"
 	rom ( name "Sengoku Kantou Sangokushi (Japan).cue" size 7977 crc d952d762 md5 938e14b2af30ccfd48a9d3b03bbbb407 sha1 f323d10ffcfdbb7d9fc3752229bde6f2d51be020 )
+)
+
+game (
+	name "Sengoku Kantou Sankokushi (Japan) - 戦国関東三国志"
+	description "Sengoku Kantou Sankokushi (Japan) - 戦国関東三国志"
+	rom ( name "Sengoku Kantou Sankokushi (Japan).cue" size 31359 crc 2798ea94 md5 e967c97e31645284e4e27e8132f284ef sha1 a80e917e80b74787bcfa7623220b430720807c74 )
 )
 
 game (
@@ -1435,15 +3391,69 @@ game (
 )
 
 game (
+	name "Sexy Idol Mahjong (Japan) - セクシーアイドル麻雀"
+	description "Sexy Idol Mahjong (Japan) - セクシーアイドル麻雀"
+	rom ( name "Sexy Idol Mahjong (Japan).cue" size 9481 crc 0b0e6efb md5 e88546ca9852a151115424c0889510cd sha1 e09d5e7df8cb4e7baa20f4ffeb88e045f10598eb )
+)
+
+game (
+	name "Sexy Idol Mahjong Fashion Monogatari (Japan)"
+	description "Sexy Idol Mahjong Fashion Monogatari (Japan)"
+	rom ( name "Sexy Idol Mahjong Fashion Monogatari (Japan).cue" size 13145 crc 64ff65af md5 cced8991559ca270d0c8c6174d766801 sha1 cd389dd47a5990114cf961297615485a981043d3 )
+)
+
+game (
+	name "Sexy Idol Mahjong Yakyuuken no Uta (Japan)"
+	description "Sexy Idol Mahjong Yakyuuken no Uta (Japan)"
+	rom ( name "Sexy Idol Mahjong Yakyuuken no Uta (Japan).cue" size 11523 crc f3d46413 md5 6fc538b0a9a28a7d7d8a5f08408baee5 sha1 f271fbcb41f601392bdbdc027e40407983f6874f )
+)
+
+game (
+	name "Shadow of the Beast - Mashou no Okite (Japan) - シャドーオブザビースト+魔性の掟"
+	description "Shadow of the Beast - Mashou no Okite (Japan) - シャドーオブザビースト+魔性の掟"
+	rom ( name "Shadow of the Beast - Mashou no Okite (Japan).cue" size 5046 crc ad2fefa4 md5 f51ad6abb006eb8482a5d076752baf8c sha1 094f609e30bb599c1fcf3ba7725eadc53ab06ce5 )
+)
+
+game (
 	name "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1)"
 	description "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1)"
 	rom ( name "Shadow of the Beast - Mashou no Okite (Japan) (Rev 1).cue" size 1352 crc b4793056 md5 94b3498ea0b9ecf92a55b76687aadfd8 sha1 f36c7563cd5a04bf8a3e9f671671fde88ea3c3dd )
 )
 
 game (
+	name "Shadow of the Beast (USA)"
+	description "Shadow of the Beast (USA)"
+	rom ( name "Shadow of the Beast (USA).cue" size 5026 crc b416a623 md5 625be1ebe41c75db9aba957e767c5c68 sha1 5bdd96ca04ae2bad5750a713eeac8388d9cf3449 )
+)
+
+game (
+	name "Shanghai II (Japan) - 上海II"
+	description "Shanghai II (Japan) - 上海II"
+	rom ( name "Shanghai II (Japan).cue" size 6235 crc 6b02ee22 md5 ea1f992b6cca6dfe90a2586d4147b7cb sha1 d22595d1978880f6dbd34ff50d83489c292ae880 )
+)
+
+game (
 	name "Shanghai II (Japan) (Rev 2)"
 	description "Shanghai II (Japan) (Rev 2)"
 	rom ( name "Shanghai II (Japan) (Rev 2).cue" size 1389 crc d95369e1 md5 db588aed21fbb2b664507bed7ca62c60 sha1 e21acec3b7ab1620e1a72f5e53684cedccc170b8 )
+)
+
+game (
+	name "Shanghai III - Dragon's Eye (Japan) - 上海III+ドラゴンズアイ"
+	description "Shanghai III - Dragon's Eye (Japan) - 上海III+ドラゴンズアイ"
+	rom ( name "Shanghai III - Dragon's Eye (Japan).cue" size 5846 crc 25a275b3 md5 d21fa39213e284adce93c323313a9bcc sha1 039163be5227b6d91e6eeb530404523f01b39256 )
+)
+
+game (
+	name "Shape Shifter (USA)"
+	description "Shape Shifter (USA)"
+	rom ( name "Shape Shifter (USA).cue" size 54191 crc 577c76b3 md5 341fd07c5360c5a79cad286954f4443a sha1 93e11e60bdc7d63f0411b5db47ad494cdbd027f0 )
+)
+
+game (
+	name "Shapeshifter - Makai Eiyuu Den (Japan)"
+	description "Shapeshifter - Makai Eiyuu Den (Japan)"
+	rom ( name "Shapeshifter - Makai Eiyuu Den (Japan).cue" size 54210 crc 35d0f064 md5 30fff2414aa574202fdb6d8024b58027 sha1 c641cc3e18e2ddb9a50a2e67950a536fdcd04222 )
 )
 
 game (
@@ -1459,9 +3469,45 @@ game (
 )
 
 game (
+	name "Sherlock Holmes Consulting Detective (USA)"
+	description "Sherlock Holmes Consulting Detective (USA)"
+	rom ( name "Sherlock Holmes Consulting Detective (USA).cue" size 961 crc d8869710 md5 d0b67b6dbb1f573f9eb8e28c73b723f9 sha1 dbf97723e73e190161ba5cbaaa3b1fc3f20dbc0a )
+)
+
+game (
+	name "Sherlock Holmes Consulting Detective Volume 2 (USA)"
+	description "Sherlock Holmes Consulting Detective Volume 2 (USA)"
+	rom ( name "Sherlock Holmes Consulting Detective Volume 2 (USA).cue" size 1519 crc 4cae482c md5 c7904dbf7c416d29b0b5098f14b8cd6a sha1 306fe3771b4b0c06c596766db74d879e4c9a56e1 )
+)
+
+game (
+	name "Sherlock Holmes no Tantei Kouza (Japan) - シャーロックホームズの探偵講座"
+	description "Sherlock Holmes no Tantei Kouza (Japan) - シャーロックホームズの探偵講座"
+	rom ( name "Sherlock Holmes no Tantei Kouza (Japan).cue" size 958 crc 6cf62e03 md5 f9b85262fe37ed1981633ce4e6e9971b sha1 377759ad045e7aa5f147de9da54cf7feb8fe2270 )
+)
+
+game (
+	name "Sherlock Holmes no Tantei Kouza II (Japan) - シャーロックホームズの探偵講座II"
+	description "Sherlock Holmes no Tantei Kouza II (Japan) - シャーロックホームズの探偵講座II"
+	rom ( name "Sherlock Holmes no Tantei Kouza II (Japan).cue" size 961 crc bfdf524e md5 4a6514b4c157e9a43ac2ac2dc9d971ef sha1 1a86686e8525e86d67640b5d48e0532e66ac3b32 )
+)
+
+game (
+	name "Shiawase Usagi - Nureta Bishoujo Ichi Hajimete na no ni (Japan)"
+	description "Shiawase Usagi - Nureta Bishoujo Ichi Hajimete na no ni (Japan)"
+	rom ( name "Shiawase Usagi - Nureta Bishoujo Ichi Hajimete na no ni (Japan).cue" size 7089 crc 7fa2ee50 md5 58e48b5c456f1b5e78d58f3fd887e57e sha1 0f09756c019b34a4900bd30fc408b7278d058ba3 )
+)
+
+game (
+	name "Shiawase Usagi II - Toraware Usagi Sailor Z (Japan)"
+	description "Shiawase Usagi II - Toraware Usagi Sailor Z (Japan)"
+	rom ( name "Shiawase Usagi II - Toraware Usagi Sailor Z (Japan).cue" size 6928 crc c43b6511 md5 a8af124d00e94e0497dd40d032f7279d sha1 961d02f8a4a176bc0c5b78ed29be4c623219ea6e )
+)
+
+game (
 	name "Shin Megami Tensei (Japan)"
 	description "Shin Megami Tensei (Japan)"
-	rom ( name "Shin Megami Tensei (Japan).cue" size 1642 crc eb2a066d md5 77cef5a07b14fd88dd3ad4e91e32e02d sha1 ca8b20cdb5cd386ad7e7a67c4cd0d1a91ef312ee )
+	rom ( name "Shin Megami Tensei (Japan).cue" size 7308 crc ef54f7e9 md5 27275d63a42a98db2f857dae82e9bd20 sha1 64501072679db42edf936b985a0bd49a7fec8626 )
 )
 
 game (
@@ -1471,15 +3517,69 @@ game (
 )
 
 game (
+	name "Shin Onryou Senki (Japan)"
+	description "Shin Onryou Senki (Japan)"
+	rom ( name "Shin Onryou Senki (Japan).cue" size 2447 crc 1cfd80a2 md5 61fb58046362cc85cb2b39931cc8fca0 sha1 85cdec297586ae75c01d4e7e6c870d79de085dd7 )
+)
+
+game (
+	name "Shin Sangokushi - Tenka ha Ware ni (Japan)"
+	description "Shin Sangokushi - Tenka ha Ware ni (Japan)"
+	rom ( name "Shin Sangokushi - Tenka ha Ware ni (Japan).cue" size 28938 crc 7d2f05ab md5 695b1dd45a7f047456eecf556053237b sha1 1a70f36a30d39b5327277e8069a9e148c7059496 )
+)
+
+game (
+	name "Shinsetsu Shiawase Usagi (Japan)"
+	description "Shinsetsu Shiawase Usagi (Japan)"
+	rom ( name "Shinsetsu Shiawase Usagi (Japan).cue" size 6099 crc 0d7374b1 md5 0096cc49273422547473fb81f450f0c2 sha1 6a9b15afb5265a2d1b54282db1d0f7520f95dda4 )
+)
+
+game (
 	name "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl)"
 	description "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl)"
 	rom ( name "Shinsetsu Shiawase Usagi 2 - Kairaku e no Invitation (Japan) (Unl).cue" size 1707 crc b25ac230 md5 7dd0778a9f13fcf406605003c9e8fa14 sha1 bb0f98db4e10a2ea37a9ab806a798c46516dc52a )
 )
 
 game (
+	name "Shinsetsu Shiawase Usagi 2 - Kairaku heno Invitation (Japan)"
+	description "Shinsetsu Shiawase Usagi 2 - Kairaku heno Invitation (Japan)"
+	rom ( name "Shinsetsu Shiawase Usagi 2 - Kairaku heno Invitation (Japan).cue" size 5722 crc fded88fc md5 81c37e2a955e3fa9484300034b29a435 sha1 56f477aee1e2a3b6b15765d15f80064d19d96e21 )
+)
+
+game (
+	name "Shinsetsu Shiawase Usagi F - Yuujiyou Yorimo Aiyoku (Japan)"
+	description "Shinsetsu Shiawase Usagi F - Yuujiyou Yorimo Aiyoku (Japan)"
+	rom ( name "Shinsetsu Shiawase Usagi F - Yuujiyou Yorimo Aiyoku (Japan).cue" size 5721 crc 978db6f9 md5 e12eb65fcd61c360468a11002410eb78 sha1 1bec84b005ecdb41bb7fc6254a97fd5b1f274a4e )
+)
+
+game (
+	name "Sim Earth - The Living Planet (Japan) - シムアース"
+	description "Sim Earth - The Living Planet (Japan) - シムアース"
+	rom ( name "Sim Earth - The Living Planet (Japan).cue" size 15163 crc d563a168 md5 cd96b730c6c9ad236696fdb4a91648df sha1 dcc70266955ce8df0e04454ac73a450ee816df1e )
+)
+
+game (
+	name "Sim Earth - The Living Planet (USA)"
+	description "Sim Earth - The Living Planet (USA)"
+	rom ( name "Sim Earth - The Living Planet (USA).cue" size 15161 crc 25a6727b md5 1ab0b89cdc0e1129fe0abc6a9cd9d455 sha1 623060145a16462c1c02634b5bfba4d02b8b2623 )
+)
+
+game (
 	name "SimEarth - The Living Planet (Japan)"
 	description "SimEarth - The Living Planet (Japan)"
 	rom ( name "SimEarth - The Living Planet (Japan).cue" size 3882 crc 561f4f07 md5 7bc802534560d2118777baf8511fd761 sha1 8298ce6a81207afcccbf69d041d7b082f91ed7b9 )
+)
+
+game (
+	name "Slime World (Japan)"
+	description "Slime World (Japan)"
+	rom ( name "Slime World (Japan).cue" size 8921 crc 0444f880 md5 2672c6fbe13637ea5f17f1abb9e93cd5 sha1 ba1e8d1b4c3cd96526539d4dc0fff5069df7cdeb )
+)
+
+game (
+	name "Slot Gambler (Japan)"
+	description "Slot Gambler (Japan)"
+	rom ( name "Slot Gambler (Japan).cue" size 9476 crc 1dc4664b md5 c274339d1b2e7a6f376f95c1c3286508 sha1 af5dd9447527b5b30fb5f5b49b9c606923c74f3e )
 )
 
 game (
@@ -1491,13 +3591,43 @@ game (
 game (
 	name "Snatcher CD-ROMantic (Japan)"
 	description "Snatcher CD-ROMantic (Japan)"
-	rom ( name "Snatcher CD-ROMantic (Japan).cue" size 2502 crc 922a190e md5 0ebc8178d69488000db3b0b845120906 sha1 40c91a0873ba05e4caf2fe2917b0a5f7fa9d1175 )
+	rom ( name "Snatcher CD-ROMantic (Japan).cue" size 10699 crc 8eefdfa0 md5 de4e4be16232f92c732da8f7127120bd sha1 ccc3b49ba8232a126d629cddd4346259823502dc )
+)
+
+game (
+	name "Snatcher CD-ROMantic Pilot Disk (Japan)"
+	description "Snatcher CD-ROMantic Pilot Disk (Japan)"
+	rom ( name "Snatcher CD-ROMantic Pilot Disk (Japan).cue" size 14760 crc 8fc20f30 md5 c8b6fa6f31d04d022512048f6f0e28ef sha1 a3877236581249d00b5bd0247e12b4291fa3413a )
+)
+
+game (
+	name "Sol Bianca (Japan) - ソルビアンカ"
+	description "Sol Bianca (Japan) - ソルビアンカ"
+	rom ( name "Sol Bianca (Japan).cue" size 41779 crc 38f83f9c md5 894e13d8f9d5658d0f5730320cf10da3 sha1 442f47ef4f695743799eff9c3fe09c5be1cdd52a )
 )
 
 game (
 	name "Sol Bianca (Japan) (Rev 8)"
 	description "Sol Bianca (Japan) (Rev 8)"
 	rom ( name "Sol Bianca (Japan) (Rev 8).cue" size 9914 crc 1e6c3486 md5 85d9879d96fa7836ea45f8558abdc3f5 sha1 b4e8c74651aa7f6804ce8c8eae03ed627c6322b0 )
+)
+
+game (
+	name "Sol Moonarge (Japan)"
+	description "Sol Moonarge (Japan)"
+	rom ( name "Sol Moonarge (Japan).cue" size 10286 crc caff7acd md5 dee3f773be0b02dbed05122624a553f4 sha1 6686898cf9b39270d4304410ee48011b07287639 )
+)
+
+game (
+	name "Solid Force (Japan)"
+	description "Solid Force (Japan)"
+	rom ( name "Solid Force (Japan).cue" size 9475 crc 4e6113b6 md5 7f34383e65fb372ba79b8f2f1813433e sha1 6ad6a3a74ce7fffae5ab038a2fa6ce54da1625b2 )
+)
+
+game (
+	name "Sorcerian (Japan)"
+	description "Sorcerian (Japan)"
+	rom ( name "Sorcerian (Japan).cue" size 21623 crc 97cac5cc md5 c8228e6af282af844acebe21860d33a5 sha1 a3bd6a7751286fe67651cbbdc14ca3f56ecfebf4 )
 )
 
 game (
@@ -1513,9 +3643,21 @@ game (
 )
 
 game (
+	name "Sotsugyou - Graduation (Japan) (NA360601) - 卒業+グラデュエーション"
+	description "Sotsugyou - Graduation (Japan) (NA360601) - 卒業+グラデュエーション"
+	rom ( name "Sotsugyou - Graduation (Japan) (NA360601).cue" size 12332 crc 958611e2 md5 a8fb8447644d8c6e16aa1a0a843dccfb sha1 203e68f956bdf9f20b113e3d8da0018eb84a9d45 )
+)
+
+game (
 	name "Sotsugyou - Graduation (Japan) (NA361216)"
 	description "Sotsugyou - Graduation (Japan) (NA361216)"
 	rom ( name "Sotsugyou - Graduation (Japan) (NA361216).cue" size 3266 crc ece90f9c md5 5855c9ad329c7b0ef8b0214a5e95f415 sha1 99481dc6496d72de9a51d119768dd4e89742feb4 )
+)
+
+game (
+	name "Sotsugyou - Graduation (Japan) (NA361216) - 卒業+グラデュエーション"
+	description "Sotsugyou - Graduation (Japan) (NA361216) - 卒業+グラデュエーション"
+	rom ( name "Sotsugyou - Graduation (Japan) (NA361216).cue" size 12332 crc 967d5c93 md5 e53efbdc52b8d54d56e64b7dc2cb25f0 sha1 efdd76cb888ce1d08b547813dfcba5eaf2e9d5f0 )
 )
 
 game (
@@ -1525,9 +3667,21 @@ game (
 )
 
 game (
+	name "Sotsugyou II - Neo Generation (Japan) - 卒業II+ネオジェネレーション"
+	description "Sotsugyou II - Neo Generation (Japan) - 卒業II+ネオジェネレーション"
+	rom ( name "Sotsugyou II - Neo Generation (Japan).cue" size 8534 crc 56d22f46 md5 ac15acdec2530aa8365f5449d0a42aa0 sha1 eb06919ea14f36216719f3aa07b1ffd69282309f )
+)
+
+game (
 	name "Sotsugyou Shashin - Miki (Japan)"
 	description "Sotsugyou Shashin - Miki (Japan)"
-	rom ( name "Sotsugyou Shashin - Miki (Japan).cue" size 4886 crc 3c41d1ae md5 979fc6cadd368ca951bb1b795a04ba2f sha1 e67478c7b246b87ca64a9932c7c29c8cea64ef14 )
+	rom ( name "Sotsugyou Shashin - Miki (Japan).cue" size 19613 crc f5c0e1c9 md5 17c521a313a4c4ca906005e20ab62187 sha1 94158b0e778d9517f44624d88d59082298185cd4 )
+)
+
+game (
+	name "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan) - Space+Adventure+コブラ+黒竜王の伝説"
+	description "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan) - Space+Adventure+コブラ+黒竜王の伝説"
+	rom ( name "Space Adventure Cobra - Kokuryuuou no Densetsu (Japan).cue" size 5865 crc d8cf800b md5 e374964ba7f7eaa45352352f7602f89f sha1 055ee580d70d6d3f6066327a090473ad8754ab89 )
 )
 
 game (
@@ -1537,9 +3691,27 @@ game (
 )
 
 game (
+	name "Space Adventure Cobra II - Densetsu no Otoko (Japan) - コブラII+伝説の男"
+	description "Space Adventure Cobra II - Densetsu no Otoko (Japan) - コブラII+伝説の男"
+	rom ( name "Space Adventure Cobra II - Densetsu no Otoko (Japan).cue" size 4648 crc 82246c93 md5 d6fb78b37d00907cad8f4f531981098f sha1 2ce339c9f0a2c43bbbbb7e126b40c8b4f0826129 )
+)
+
+game (
 	name "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7)"
 	description "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7)"
 	rom ( name "Space Adventure Cobra II - Densetsu no Otoko (Japan) (Rev 7).cue" size 1281 crc a8a099f8 md5 b7e40310ef16ace0c5ff8fea46c5da3c sha1 34240e33b6ad40dc748cecec0336902fdec4075e )
+)
+
+game (
+	name "Space Fantasy Zone (Japan) - スペースファンタジーゾーン"
+	description "Space Fantasy Zone (Japan) - スペースファンタジーゾーン"
+	rom ( name "Space Fantasy Zone (Japan).cue" size 5742 crc cbd99506 md5 bcc9bc520df1d442438e5b9ea881ea83 sha1 28da32ee0febd6dcf5fd0ea1d4e6eab590203eb1 )
+)
+
+game (
+	name "Space Invaders - The Original Game (Japan)"
+	description "Space Invaders - The Original Game (Japan)"
+	rom ( name "Space Invaders - The Original Game (Japan).cue" size 3828 crc ea36f498 md5 1214ef74f60b6628574cd59fe2c73276 sha1 30217649e12a820a1c2cbc5edd0e04bd6b03cb07 )
 )
 
 game (
@@ -1549,9 +3721,39 @@ game (
 )
 
 game (
+	name "Splash Lake (Japan)"
+	description "Splash Lake (Japan)"
+	rom ( name "Splash Lake (Japan).cue" size 6491 crc 85903547 md5 3da99285e51d9ef0178501ba54872d59 sha1 377e4f1e7050888247861428fdabf334e8f50ec1 )
+)
+
+game (
+	name "Splash Lake (USA)"
+	description "Splash Lake (USA)"
+	rom ( name "Splash Lake (USA).cue" size 6489 crc c6875bd0 md5 33007dd180030a1c766107f9cb133df9 sha1 7f6f779701e29d1b0b73a3dc7a9570c819b970ed )
+)
+
+game (
+	name "Spriggan Mark 2 - Re Terraform Project (Japan)"
+	description "Spriggan Mark 2 - Re Terraform Project (Japan)"
+	rom ( name "Spriggan Mark 2 - Re Terraform Project (Japan).cue" size 18619 crc 625795cf md5 0139918168e023cac2d9bdcd7bef7112 sha1 e8dc530d4b6508135c38be28e55f2dab9e5e13f3 )
+)
+
+game (
 	name "Star Breaker (Japan)"
 	description "Star Breaker (Japan)"
-	rom ( name "Star Breaker (Japan).cue" size 1666 crc 96d6b28c md5 28e7b16e6bb31955adf65d632feff222 sha1 a0ce647fc358870056333b276ec5735bee56d1a2 )
+	rom ( name "Star Breaker (Japan).cue" size 7856 crc 8afe4ad7 md5 95462e9557f61af4e45a626630b77486 sha1 7cbbfd705a163574d587073026af8ed62c4e0733 )
+)
+
+game (
+	name "Star Mobile (Japan)"
+	description "Star Mobile (Japan)"
+	rom ( name "Star Mobile (Japan).cue" size 6640 crc 2403931e md5 c0a193e14b817050c752d21c7d800a50 sha1 30bd868b685d49670126491346ec01bc1c5dffea )
+)
+
+game (
+	name "Star Parodia (Japan)"
+	description "Star Parodia (Japan)"
+	rom ( name "Star Parodia (Japan).cue" size 10691 crc 07617ddf md5 66f137d5b999317d2ebb695e8b698b08 sha1 9ca6195834d9699cc24675855f79b78d62485cc1 )
 )
 
 game (
@@ -1563,7 +3765,7 @@ game (
 game (
 	name "Startling Odyssey (Japan)"
 	description "Startling Odyssey (Japan)"
-	rom ( name "Startling Odyssey (Japan).cue" size 2139 crc f9f5b3e2 md5 eabb0988f46a8010724f9d290110145d sha1 04adbc3685360acd76a2ce079cda19db461b5af6 )
+	rom ( name "Startling Odyssey (Japan).cue" size 9481 crc 066b38e2 md5 61116024e3bae213ec607a0b27d6f09c sha1 2fcf4d841770b51ceb60f3dcf26a8ba1eda868c2 )
 )
 
 game (
@@ -1579,9 +3781,51 @@ game (
 )
 
 game (
+	name "Startling Odyssey II (Japan)"
+	description "Startling Odyssey II (Japan)"
+	rom ( name "Startling Odyssey II (Japan).cue" size 22039 crc 1dacbabe md5 a7d49382ac72bd1907c3878197461ec3 sha1 492d18603dea0a7831faf97decf3c93eee9fc612 )
+)
+
+game (
+	name "Startling Odyssey II (Japan) (Sample)"
+	description "Startling Odyssey II (Japan) (Sample)"
+	rom ( name "Startling Odyssey II (Japan) (Sample).cue" size 5848 crc 2f408ad4 md5 137c25e5b97a61731a673d5ad8903208 sha1 63eab346df77a0e0beb654dc6b2e3187fd5646ad )
+)
+
+game (
+	name "Strider Hiryuu (Japan)"
+	description "Strider Hiryuu (Japan)"
+	rom ( name "Strider Hiryuu (Japan).cue" size 13123 crc 05bdf015 md5 6823676d87690fc2025b30ed429f6b99 sha1 c33f96be240dce8bbd2d3f3676b5ffae772cec80 )
+)
+
+game (
+	name "Sugoroku '92 Nari Tore Nariagari Trendy (Japan)"
+	description "Sugoroku '92 Nari Tore Nariagari Trendy (Japan)"
+	rom ( name "Sugoroku '92 Nari Tore Nariagari Trendy (Japan).cue" size 3833 crc 0d50ec3a md5 4da1481de156906e5db3ff8b0da17626 sha1 71194c28f1e17ccad61710ead368a645f181498f )
+)
+
+game (
 	name "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3)"
 	description "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3)"
 	rom ( name "Sugoroku, The '92 - Nari Tore - Nariagari Trendy (Japan) (Rev 3).cue" size 1047 crc 11177e52 md5 5955565a544f16565295bbc85a94b829 sha1 947593e9d1fa01e13cc37f4c88bd2c546b7ad00b )
+)
+
+game (
+	name "Summer Carnival '92 - Alzadick (Japan)"
+	description "Summer Carnival '92 - Alzadick (Japan)"
+	rom ( name "Summer Carnival '92 - Alzadick (Japan).cue" size 7725 crc 3873764b md5 c1df6c6af3f259e5fcb6e2d2c842a486 sha1 718063a5b777a2e0dca3935b563e6db3e397ecd8 )
+)
+
+game (
+	name "Summer Carnival '93 - Nexzr Special (Japan)"
+	description "Summer Carnival '93 - Nexzr Special (Japan)"
+	rom ( name "Summer Carnival '93 - Nexzr Special (Japan).cue" size 10309 crc 55fde243 md5 8fe3508caba30c1986dc33376bc0887c sha1 7ca687311e51b4f9ae00531c4b88244f8a6662bb )
+)
+
+game (
+	name "Super Albatross (Japan) - スーパーアルバトロス"
+	description "Super Albatross (Japan) - スーパーアルバトロス"
+	rom ( name "Super Albatross (Japan).cue" size 22354 crc 96c4e02e md5 c07aa79a883168a23f9e2f3c2d6f4e59 sha1 44fec8a2ca223d1a7b395c8d7f8048aed7a35c85 )
 )
 
 game (
@@ -1597,6 +3841,18 @@ game (
 )
 
 game (
+	name "Super CD-ROM2 Taiken Soft Shuu (Japan) - SUPER+CD-ROM²+体験ソフト集"
+	description "Super CD-ROM2 Taiken Soft Shuu (Japan) - SUPER+CD-ROM²+体験ソフト集"
+	rom ( name "Super CD-ROM2 Taiken Soft Shuu (Japan).cue" size 11551 crc 1bb7d521 md5 10dbf95417bf30b2a53b52fe47de1a6f sha1 7ea66a6c25fd1694f4984ffe8224930550cdbb46 )
+)
+
+game (
+	name "Super Daisenryaku (Japan)"
+	description "Super Daisenryaku (Japan)"
+	rom ( name "Super Daisenryaku (Japan).cue" size 4472 crc a46bbb65 md5 65d0027869ff928ec2f7c5e7372f23fa sha1 6d19a96093945131bfba4711170500d40da111fa )
+)
+
+game (
 	name "Super Daisenryaku (Japan) (Rev 3)"
 	description "Super Daisenryaku (Japan) (Rev 3)"
 	rom ( name "Super Daisenryaku (Japan) (Rev 3).cue" size 1010 crc 1189b6bd md5 0e72a900b60138bd96d598b37fe01eb9 sha1 a24f7d0bc34a7eb0d04e5a682956034cd91b8183 )
@@ -1605,7 +3861,7 @@ game (
 game (
 	name "Super Darius (Japan)"
 	description "Super Darius (Japan)"
-	rom ( name "Super Darius (Japan).cue" size 1799 crc cbabcc20 md5 3f8d1cad94095beff87acf900703abad sha1 f55d6eb98edcf94ccadb77de8860d32b578a0e71 )
+	rom ( name "Super Darius (Japan).cue" size 8517 crc 28b62be0 md5 868aa05ac5e633369bc7f4091ac6a23f sha1 a3f35e9575910f425e22b0ecb0b4093fc912c1f9 )
 )
 
 game (
@@ -1615,9 +3871,45 @@ game (
 )
 
 game (
+	name "Super Darius II (Japan)"
+	description "Super Darius II (Japan)"
+	rom ( name "Super Darius II (Japan).cue" size 8669 crc 6a61b1dd md5 388237e32036213893f2b02f14c33170 sha1 d1c356ee25a1776756ea6bec357a94acbd9aa2aa )
+)
+
+game (
+	name "Super Mahjong Taikai (Japan) - Super+麻雀大会"
+	description "Super Mahjong Taikai (Japan) - Super+麻雀大会"
+	rom ( name "Super Mahjong Taikai (Japan).cue" size 25684 crc 4c356660 md5 daebfcda8d70a2ead882d9dc3bedb4a8 sha1 0b9eb47f8b20c52af8e44b3b4a5425608161f0f1 )
+)
+
+game (
 	name "Super Mahjong Taikai (Japan) (Rev 1)"
 	description "Super Mahjong Taikai (Japan) (Rev 1)"
 	rom ( name "Super Mahjong Taikai (Japan) (Rev 1).cue" size 6690 crc fe3c5d1e md5 a7166a8fc9fa0e6210191436c2674dda sha1 afb02aa51c5908085a641efdc94c4d19e33a3d39 )
+)
+
+game (
+	name "Super Raiden (Japan)"
+	description "Super Raiden (Japan)"
+	rom ( name "Super Raiden (Japan).cue" size 7046 crc 9344ecf2 md5 3bd439995d209ab73165583ebef07e0d sha1 5e75052e91c94a74efa671e8d5b0cc962cccaa51 )
+)
+
+game (
+	name "Super Real Mahjong P II & III Custom (Japan)"
+	description "Super Real Mahjong P II & III Custom (Japan)"
+	rom ( name "Super Real Mahjong P II & III Custom (Japan).cue" size 31392 crc 3d6e6e65 md5 2defcd1d44daa6d89dd2939968c1b395 sha1 dc7f36fb81d2ded3374459d15121c0c3e3d4aae4 )
+)
+
+game (
+	name "Super Real Mahjong P IV Custom (Japan)"
+	description "Super Real Mahjong P IV Custom (Japan)"
+	rom ( name "Super Real Mahjong P IV Custom (Japan).cue" size 16784 crc 53be6b01 md5 79263532a32b17531da6b1d1d82975db sha1 c526d97fb953f73b8478002589318307ee3a4bac )
+)
+
+game (
+	name "Super Real Mahjong P V Custom (Japan)"
+	description "Super Real Mahjong P V Custom (Japan)"
+	rom ( name "Super Real Mahjong P V Custom (Japan).cue" size 28123 crc df907810 md5 c253ebafb0c2266782945b9bfef8fe38 sha1 9edfd1a4b78a55c6f64152005418414819c70f29 )
 )
 
 game (
@@ -1645,6 +3937,24 @@ game (
 )
 
 game (
+	name "Super Real Mahjong Special (Japan)"
+	description "Super Real Mahjong Special (Japan)"
+	rom ( name "Super Real Mahjong Special (Japan).cue" size 29335 crc 45186e0a md5 849608eebfb72d6a7724777efedc5ac9 sha1 df3b2975d3e51df976d7b3eb3401e8fd847110b0 )
+)
+
+game (
+	name "Super Schwartzschild (Japan) - スーパーシュヴァルツシルト"
+	description "Super Schwartzschild (Japan) - スーパーシュヴァルツシルト"
+	rom ( name "Super Schwartzschild (Japan).cue" size 8674 crc e5c4fc37 md5 85836c6a42f00a429986c576098999c1 sha1 1cf15350c271d875d1b4b1b76e370d179f88ed3a )
+)
+
+game (
+	name "Super Schwartzschild 2 (Japan) - スーパーシュヴァルツシルト2"
+	description "Super Schwartzschild 2 (Japan) - スーパーシュヴァルツシルト2"
+	rom ( name "Super Schwartzschild 2 (Japan).cue" size 9891 crc 17d2a0aa md5 f82d4083c54afe0311144b6b49cca4af sha1 71610a99bed57c72dad9e81950ccd817d6785b28 )
+)
+
+game (
 	name "Super Schwarzschild (Japan)"
 	description "Super Schwarzschild (Japan)"
 	rom ( name "Super Schwarzschild (Japan).cue" size 1983 crc a4cbd810 md5 68de9cc5c853be8fc46b609882052e86 sha1 f70f48e37d71fbab01c63331cfe7dfb58086c81a )
@@ -1654,6 +3964,30 @@ game (
 	name "Super Schwarzschild 2 (Japan)"
 	description "Super Schwarzschild 2 (Japan)"
 	rom ( name "Super Schwarzschild 2 (Japan).cue" size 2324 crc 9e564f08 md5 95591d2d37c5fe278ef49c8b58dfd0d3 sha1 f38bc5e82e8bec03b7b4c8ddd87a9f92c4d815e0 )
+)
+
+game (
+	name "SUPER-CD-DEMO2 (Japan) - SUPER-CD-DEMO²"
+	description "SUPER-CD-DEMO2 (Japan) - SUPER-CD-DEMO²"
+	rom ( name "SUPER-CD-DEMO2 (Japan).cue" size 12121 crc e628be33 md5 4ec3e539ae039c106a810b84b4ebcd84 sha1 4b8f21b2fcb72cbea6f80be67032d96078265615 )
+)
+
+game (
+	name "Sword Master (Japan)"
+	description "Sword Master (Japan)"
+	rom ( name "Sword Master (Japan).cue" size 13377 crc 1dd7bdd0 md5 964f86027a5513cdceb5f61d2e563e90 sha1 af3fe54d29c7b822c102ebcad12a34a448d2050c )
+)
+
+game (
+	name "Tadaima Yusha Boshuuchuu (Japan)"
+	description "Tadaima Yusha Boshuuchuu (Japan)"
+	rom ( name "Tadaima Yusha Boshuuchuu (Japan).cue" size 5033 crc 220e8553 md5 8e7f1b6ac662ed5281db90efd986f42f sha1 60251219671740de2c292e2d8c30a2e6ba685e67 )
+)
+
+game (
+	name "Taiheiki (Japan)"
+	description "Taiheiki (Japan)"
+	rom ( name "Taiheiki (Japan).cue" size 15952 crc 55219820 md5 5b46c8b572edb644b5e6efcc18a67542 sha1 4f19702e139101f6fced73f0b6706aa8a5bbb8e0 )
 )
 
 game (
@@ -1669,15 +4003,69 @@ game (
 )
 
 game (
+	name "Tanjou Debut (Japan) - 誕生+～Ｄｅｂｕｔ～"
+	description "Tanjou Debut (Japan) - 誕生+～Ｄｅｂｕｔ～"
+	rom ( name "Tanjou Debut (Japan).cue" size 16766 crc ce9f3147 md5 b8b809e87ca8408e7b3949e2ffb078f6 sha1 a2276bcf119600de835526b9093c7a6a58b3bea1 )
+)
+
+game (
 	name "Tecmo World Cup Super Soccer (Japan)"
 	description "Tecmo World Cup Super Soccer (Japan)"
-	rom ( name "Tecmo World Cup Super Soccer (Japan).cue" size 2319 crc 6866de49 md5 2c49dd46144f35d2bc576f5e8ddbc230 sha1 bf1bba5d286ea01fc923145dee2914786e2b3eed )
+	rom ( name "Tecmo World Cup Super Soccer (Japan).cue" size 9343 crc fb16d164 md5 4f3bdba0a2578a56764c090a5b9c7f4b sha1 6f8dda169240b0926dfc94940a9acf3ad3d2227b )
+)
+
+game (
+	name "Tekipaki Working Love (Japan)"
+	description "Tekipaki Working Love (Japan)"
+	rom ( name "Tekipaki Working Love (Japan).cue" size 9080 crc 9c6cb315 md5 e279faa4b2819a7cf2beaccd170d654b sha1 435d4989c28469bc0d8052c6abf482f1e726ab70 )
 )
 
 game (
 	name "Tenchi Muyou! Ryououki (Japan)"
 	description "Tenchi Muyou! Ryououki (Japan)"
-	rom ( name "Tenchi Muyou! Ryououki (Japan).cue" size 1428 crc 9cdf80e9 md5 4d715a9cc84d101bee0cc837072526ba sha1 372cd3d3719c76832c8632cf370cdc4478e00889 )
+	rom ( name "Tenchi Muyou! Ryououki (Japan).cue" size 6246 crc fa676255 md5 ba7a1e63774e26e2414921e402166578 sha1 a08304d9636d2499835bbf98e1b0a5bea1027c99 )
+)
+
+game (
+	name "Tenchi wo Kurau (Japan)"
+	description "Tenchi wo Kurau (Japan)"
+	rom ( name "Tenchi wo Kurau (Japan).cue" size 9074 crc 508be122 md5 029e59598eec1c585c24233589d8712c sha1 7345266d1332e293e8831f4883dd8f046bdab8d4 )
+)
+
+game (
+	name "Tengai Makyo - Fuun Kabuki Den Shutsugeki no Sho (Japan)"
+	description "Tengai Makyo - Fuun Kabuki Den Shutsugeki no Sho (Japan)"
+	rom ( name "Tengai Makyo - Fuun Kabuki Den Shutsugeki no Sho (Japan).cue" size 4247 crc bb6deaf6 md5 9d5f34e979da717a2bce05431fa291de sha1 bf633ec816380cc29ccb1f492c2a951ac17d5dc6 )
+)
+
+game (
+	name "Tengai Makyo - Kabuki Den (Japan) - 天外魔境+風雲カブキ伝"
+	description "Tengai Makyo - Kabuki Den (Japan) - 天外魔境+風雲カブキ伝"
+	rom ( name "Tengai Makyo - Kabuki Den (Japan).cue" size 14754 crc 71ff6478 md5 2937656bb185fd2d11b2a3563fe80db8 sha1 439af15fb69f06b9bd69892053a5e99dc8a69337 )
+)
+
+game (
+	name "Tengai Makyo - Kabuki Itouryodan (Japan)"
+	description "Tengai Makyo - Kabuki Itouryodan (Japan)"
+	rom ( name "Tengai Makyo - Kabuki Itouryodan (Japan).cue" size 12736 crc 444ebce6 md5 abd2fadc33f8f53bb3da72440d981fff sha1 f4838a85571e72e6395551080a5066fe5ba05abb )
+)
+
+game (
+	name "Tengai Makyo - Ziria (Japan) - 天外魔境+Ziria"
+	description "Tengai Makyo - Ziria (Japan) - 天外魔境+Ziria"
+	rom ( name "Tengai Makyo - Ziria (Japan).cue" size 3409 crc fa20e238 md5 9254f872a576a5d202cf0de495e96761 sha1 abab2015542be26c305283ffb6ee24133c89e7bd )
+)
+
+game (
+	name "Tengai Makyo - Ziria SCD Hibaihin (Japan)"
+	description "Tengai Makyo - Ziria SCD Hibaihin (Japan)"
+	rom ( name "Tengai Makyo - Ziria SCD Hibaihin (Japan).cue" size 3422 crc 993fef92 md5 65c11119d6cabb51c2a5ec6d2febf27b sha1 3bd75328058300e707dc38ac2fc5c4ca64ecf619 )
+)
+
+game (
+	name "Tengai Makyo II - Manji Maru (Japan) - 天外魔境II+卍+Maru"
+	description "Tengai Makyo II - Manji Maru (Japan) - 天外魔境II+卍+Maru"
+	rom ( name "Tengai Makyo II - Manji Maru (Japan).cue" size 10963 crc ebf6a560 md5 2015defb54c1153d79db0cf8c2fac6a8 sha1 f18ee72b4094f9c8ecfd9f762eb0d4a83ecbbd91 )
 )
 
 game (
@@ -1687,15 +4075,57 @@ game (
 )
 
 game (
+	name "Tenshi no Uta (Japan) - 天使の詩"
+	description "Tenshi no Uta (Japan) - 天使の詩"
+	rom ( name "Tenshi no Uta (Japan).cue" size 14188 crc 8c518f70 md5 3ae619ed9e62b32e33fd5e3938b801ea sha1 772ebc9975e95d015e094a171ff2453476cafa73 )
+)
+
+game (
 	name "Tenshi no Uta (Japan) (Rev 6)"
 	description "Tenshi no Uta (Japan) (Rev 6)"
 	rom ( name "Tenshi no Uta (Japan) (Rev 6).cue" size 3407 crc cacbae9b md5 bad4d153d36e3a7b83def22545ee1e06 sha1 aac9270c19f86eb3cc241ad11fbf8f3462722a56 )
 )
 
 game (
+	name "Tenshi no Uta II - Datenshi no Sentaku (Japan) - 天使の詩II+堕天使の選択"
+	description "Tenshi no Uta II - Datenshi no Sentaku (Japan) - 天使の詩II+堕天使の選択"
+	rom ( name "Tenshi no Uta II - Datenshi no Sentaku (Japan).cue" size 14618 crc b1f8ac6a md5 a84c0fb33d49f6a6314af57c121d2879 sha1 e1726e60c48bb5a8cdd2f3412bc157155ab40b18 )
+)
+
+game (
 	name "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1)"
 	description "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1)"
 	rom ( name "Tenshi no Uta II - Datenshi no Sentaku (Japan) (Rev 1).cue" size 4358 crc cf4955cd md5 c877a4a5659b1504c2502c3434f5609a sha1 a600b58c217cc642a1edcacdaacc44290f793f27 )
+)
+
+game (
+	name "Terraforming (Japan)"
+	description "Terraforming (Japan)"
+	rom ( name "Terraforming (Japan).cue" size 6492 crc 88adede2 md5 87ef50368fdca77272493475a632546c sha1 f0b9733a6551b5e1c68298a45dea6820ad680150 )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (1)(A) - ときめきメモリアル"
+	description "Tokimeki Memorial (Japan) (1)(A) - ときめきメモリアル"
+	rom ( name "Tokimeki Memorial (Japan) (1)(A).cue" size 4516 crc 616bc38d md5 126419763d3ae0e4d48fd1ae4a418ee4 sha1 b4572b4657db0e2fddca2d7073f3d604a6a79406 )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (2)(A) - ときめきメモリアル"
+	description "Tokimeki Memorial (Japan) (2)(A) - ときめきメモリアル"
+	rom ( name "Tokimeki Memorial (Japan) (2)(A).cue" size 4516 crc 886cf266 md5 00d2b18cde171b2013c2189ddeb0e15a sha1 ae7cb685658d00cbd70a6ad557299e49f8e6df9c )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (3)(B) - ときめきメモリアル"
+	description "Tokimeki Memorial (Japan) (3)(B) - ときめきメモリアル"
+	rom ( name "Tokimeki Memorial (Japan) (3)(B).cue" size 4516 crc ab4f01f7 md5 79fb0903561612fcf20758890e8abcb1 sha1 e13d1228f92edfd300521c5dcba1278f3ca6c7fc )
+)
+
+game (
+	name "Tokimeki Memorial (Japan) (4)(A) - ときめきメモリアル"
+	description "Tokimeki Memorial (Japan) (4)(A) - ときめきメモリアル"
+	rom ( name "Tokimeki Memorial (Japan) (4)(A).cue" size 4516 crc 9ff260b1 md5 2084a19496f49d8148e5ad7df8af7637 sha1 11a5eb1f6dae6e111b0339ef3ec31009c7ece83c )
 )
 
 game (
@@ -1729,15 +4159,39 @@ game (
 )
 
 game (
+	name "Top o Nerae! GunBuster Volume 1 (Japan) - トップをねらえ!+GunBuster+Vol.1"
+	description "Top o Nerae! GunBuster Volume 1 (Japan) - トップをねらえ!+GunBuster+Vol.1"
+	rom ( name "Top o Nerae! GunBuster Volume 1 (Japan).cue" size 3015 crc 1babf1f2 md5 ffddbb20ec04add306066542520010dd sha1 46456e9a52381250032937ba7246d9e73d877bf9 )
+)
+
+game (
+	name "Top o Nerae! GunBuster Volume 2 (Japan) - トップをねらえ!+GunBuster+Vol.2"
+	description "Top o Nerae! GunBuster Volume 2 (Japan) - トップをねらえ!+GunBuster+Vol.2"
+	rom ( name "Top o Nerae! GunBuster Volume 2 (Japan).cue" size 18000 crc a72c9e97 md5 519224fca0e6ecd5c475cfd889c0a941 sha1 3e49e8dbd511a5deabadf1c00c89d12efdb21ccb )
+)
+
+game (
 	name "Travel Eple (Japan) (Rev 6)"
 	description "Travel Eple (Japan) (Rev 6)"
 	rom ( name "Travel Eple (Japan) (Rev 6).cue" size 7890 crc b693ac68 md5 528459d3939a598fc044c1c7be896449 sha1 b9fcad01df746901400494d840605aaa388953d3 )
 )
 
 game (
+	name "Travel Epuru (Japan)"
+	description "Travel Epuru (Japan)"
+	rom ( name "Travel Epuru (Japan).cue" size 33759 crc 772b1e59 md5 819b70dc151292250f252638857f2b19 sha1 6aebf44eecf3d167c2b268decb62297c2082de25 )
+)
+
+game (
+	name "Travelers! Densetsu wo ButtobaSe (Japan)"
+	description "Travelers! Densetsu wo ButtobaSe (Japan)"
+	rom ( name "Travelers! Densetsu wo ButtobaSe (Japan).cue" size 4231 crc 16394dc9 md5 b7a5fd5a39fa3a367c3006dd04d3b470 sha1 38cb9d49f596be265b49f17bc118dbe890f25fef )
+)
+
+game (
 	name "Uchuu Senkan Yamato (Japan)"
 	description "Uchuu Senkan Yamato (Japan)"
-	rom ( name "Uchuu Senkan Yamato (Japan).cue" size 1686 crc b92b79cb md5 f7f0563e97d9b8f767c94058d07bffbe sha1 93a18aebb37a39fc5f52cc09881c9fdb7dd3237a )
+	rom ( name "Uchuu Senkan Yamato (Japan).cue" size 7458 crc 386ed864 md5 a1add8246a44f05bb6554045a5d96cfc sha1 3c7693aecbc28120197464c27dab93cbd4191089 )
 )
 
 game (
@@ -1759,9 +4213,27 @@ game (
 )
 
 game (
+	name "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 1)"
+	description "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 1)"
+	rom ( name "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 1).cue" size 3041 crc 1f3756fd md5 142b5bc1598642e86fa81dbc267db338 sha1 e98ace765689710def1c70c1de2bb66672392eef )
+)
+
+game (
+	name "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 2)"
+	description "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 2)"
+	rom ( name "Urusei Yatsura - Stay With You (Japan) (Limited Edition) (Disc 2).cue" size 11005 crc 5d725466 md5 5a853a70ba44665f75424a97c4951a44 sha1 b3ffb50abdb5441208c488d915d035a1e6db4976 )
+)
+
+game (
 	name "Urusei Yatsura - Stay with You (Japan) (Rev 6)"
 	description "Urusei Yatsura - Stay with You (Japan) (Rev 6)"
 	rom ( name "Urusei Yatsura - Stay with You (Japan) (Rev 6).cue" size 687 crc 2e35940a md5 442d5e5cb684afe0da367c15118207b7 sha1 eed15911582261c3c19f78295be98b7af74521d9 )
+)
+
+game (
+	name "Valis II - The Fantasm Soldier (Japan)"
+	description "Valis II - The Fantasm Soldier (Japan)"
+	rom ( name "Valis II - The Fantasm Soldier (Japan).cue" size 23520 crc 67d2d4f2 md5 4aaa3262bc199b4fcf56b72fd53165bc sha1 db9e875346621068c7693aac916825b24a82990c )
 )
 
 game (
@@ -1777,6 +4249,18 @@ game (
 )
 
 game (
+	name "Valis II (USA)"
+	description "Valis II (USA)"
+	rom ( name "Valis II (USA).cue" size 23091 crc 56e557e1 md5 9f79f25b007ec5f313130a55f0476ec8 sha1 01d6571f3b286714c9155879f7e761ce9278dc62 )
+)
+
+game (
+	name "Valis III - The Fantasm Soldier (Japan)"
+	description "Valis III - The Fantasm Soldier (Japan)"
+	rom ( name "Valis III - The Fantasm Soldier (Japan).cue" size 34838 crc 3de6f8d0 md5 96c9f061d82dc5865263fb0cc18d6375 sha1 b142daf2a41b7f7c0e582b74edb936d278763f7e )
+)
+
+game (
 	name "Valis III (Japan)"
 	description "Valis III (Japan)"
 	rom ( name "Valis III (Japan).cue" size 8982 crc 99a46983 md5 58c6ccbd7b426bdcbad3e77a5efd0fee sha1 1db098ed4e6b3799f11865602e02700b502dbc49 )
@@ -1789,9 +4273,27 @@ game (
 )
 
 game (
+	name "Valis III (USA)"
+	description "Valis III (USA)"
+	rom ( name "Valis III (USA).cue" size 31169 crc 8d371a40 md5 8cc440805b73decb2ef2b28ab3c9a583 sha1 58152978ba58c3cb08064e79de706d78276eb772 )
+)
+
+game (
+	name "Valis IV - The Fantasm Soldier (Japan) - ヴァリスIV"
+	description "Valis IV - The Fantasm Soldier (Japan) - ヴァリスIV"
+	rom ( name "Valis IV - The Fantasm Soldier (Japan).cue" size 47556 crc 7ba3590c md5 a83608fb6137c337b73e4b02c7797194 sha1 9636feea005ec9310cc501eb6ba6549e823b8349 )
+)
+
+game (
 	name "Valis IV (Japan)"
 	description "Valis IV (Japan)"
 	rom ( name "Valis IV (Japan).cue" size 9853 crc 9595e237 md5 e071f86c70fbef65aa098e0f1084f496 sha1 13c332870c27fdd5e5b30c578b690da78f7baef7 )
+)
+
+game (
+	name "Vasteel (Japan) - バスティール"
+	description "Vasteel (Japan) - バスティール"
+	rom ( name "Vasteel (Japan).cue" size 13926 crc c0e9dd62 md5 796e05d8bc8604cfa15c02d4dad991f8 sha1 63d63c1f1606552ccc16f9292c9747e80addb153 )
 )
 
 game (
@@ -1801,9 +4303,33 @@ game (
 )
 
 game (
+	name "Vasteel (USA)"
+	description "Vasteel (USA)"
+	rom ( name "Vasteel (USA).cue" size 13775 crc e9364afc md5 2fbd7b24e392f5001a8eaa98f463df70 sha1 8386b275fc9ae0f6971659d8ee0ded05ce15066e )
+)
+
+game (
 	name "Vasteel 2 (Japan) (Rev 1)"
 	description "Vasteel 2 (Japan) (Rev 1)"
 	rom ( name "Vasteel 2 (Japan) (Rev 1).cue" size 2596 crc f95f58fc md5 0b81207b59959df30a1a0866f386ba5f sha1 53800bf62d38be38df810b20b2e79cf2f38c39c2 )
+)
+
+game (
+	name "Vasteel II (Japan)"
+	description "Vasteel II (Japan)"
+	rom ( name "Vasteel II (Japan).cue" size 11350 crc aa9e3781 md5 53defd976b1d72965b5717b227c1bd5d sha1 708de460514e958428f82e580523a9c868a66806 )
+)
+
+game (
+	name "Virgin Dream (Japan)"
+	description "Virgin Dream (Japan)"
+	rom ( name "Virgin Dream (Japan).cue" size 2847 crc b61d534b md5 a65d36b0d4933ea901a80d487dec80e7 sha1 282759f1f3e794870b07fc090809c60fe80bfbcf )
+)
+
+game (
+	name "Where in the World Is Carmen Sandiego (Japan) - カルメンサンディエゴを追え!+世界編"
+	description "Where in the World Is Carmen Sandiego (Japan) - カルメンサンディエゴを追え!+世界編"
+	rom ( name "Where in the World Is Carmen Sandiego (Japan).cue" size 14617 crc 17a7dd3e md5 0ca5f9cbfefb065db0d55a0eb13a75f8 sha1 956491f3fb0f8a76df82a5a23b9a22ce05295013 )
 )
 
 game (
@@ -1815,13 +4341,25 @@ game (
 game (
 	name "Winds of Thunder (Japan)"
 	description "Winds of Thunder (Japan)"
-	rom ( name "Winds of Thunder (Japan).cue" size 2310 crc 34f101c4 md5 3ea022ff8106b1e72b49864c21ea653c sha1 98f94c755e18f0c451f4c48f8c244c21239b71c7 )
+	rom ( name "Winds of Thunder (Japan).cue" size 10290 crc 983a99a8 md5 fbd102e5f7a251e35e8c70d88901bda5 sha1 5af6c54258ef8000063a37be448864616b5733f0 )
+)
+
+game (
+	name "Wizardry I & II (Japan)"
+	description "Wizardry I & II (Japan)"
+	rom ( name "Wizardry I & II (Japan).cue" size 7049 crc 5be5ee6a md5 3a356b0ae9174754596ad18b0ed5f206 sha1 d1ef0f57d7b467ebb86a6ba50b8fc20662e5807e )
 )
 
 game (
 	name "Wizardry I-II (Japan)"
 	description "Wizardry I-II (Japan)"
 	rom ( name "Wizardry I-II (Japan).cue" size 1497 crc 5aeaf042 md5 38f59ab20479c1ef1e6df06680d327c0 sha1 8d73c4196b26cb837918550b0d3333b2a63e0caf )
+)
+
+game (
+	name "Wizardry III & IV (Japan)"
+	description "Wizardry III & IV (Japan)"
+	rom ( name "Wizardry III & IV (Japan).cue" size 7456 crc b36851db md5 2ec03820db03c732e9920179895fb675 sha1 34c9fb6bc66179ca310804689de87881478e1907 )
 )
 
 game (
@@ -1837,9 +4375,27 @@ game (
 )
 
 game (
+	name "Wizardry V - Heart of the Maelstrom (Japan) - ウィザードリィV"
+	description "Wizardry V - Heart of the Maelstrom (Japan) - ウィザードリィV"
+	rom ( name "Wizardry V - Heart of the Maelstrom (Japan).cue" size 38659 crc 1db07c9c md5 2a402372d578169d368e405f4ccf750d sha1 846fa146bfea228686eefc6ff1058b5d6513a605 )
+)
+
+game (
+	name "World Heroes 2 (Japan) - ワールドヒーローズ2"
+	description "World Heroes 2 (Japan) - ワールドヒーローズ2"
+	rom ( name "World Heroes 2 (Japan).cue" size 17578 crc 93cfc0e8 md5 22d2722c34101d77c16a7797c0b9ca91 sha1 18449face28de050ff844769ea6d67d0f552df21 )
+)
+
+game (
 	name "World Heroes 2 (Japan) (FAAT, FABT)"
 	description "World Heroes 2 (Japan) (FAAT, FABT)"
 	rom ( name "World Heroes 2 (Japan) (FAAT, FABT).cue" size 4466 crc 2472c6ec md5 aa3353aed4d5b2a04883ae7fb5d067bc sha1 877c4c98ccc5d9bd63697e0f97facec534a3978c )
+)
+
+game (
+	name "Wrestling Angels - Double Impact (Japan)"
+	description "Wrestling Angels - Double Impact (Japan)"
+	rom ( name "Wrestling Angels - Double Impact (Japan).cue" size 3016 crc a0b5667d md5 98da703835ea91b3fde6188f5e0839c5 sha1 c9a339ab1e24ae0354c438d3af2f8202e4e520a4 )
 )
 
 game (
@@ -1849,9 +4405,27 @@ game (
 )
 
 game (
+	name "Xak I & II (Japan) - サークI-II"
+	description "Xak I & II (Japan) - サークI-II"
+	rom ( name "Xak I & II (Japan).cue" size 12858 crc 095c5528 md5 d7ff250186599c1417df6fa968dba875 sha1 2181da844026a2cab5f76f4d0cf88b17d47aad17 )
+)
+
+game (
 	name "Xak III - The Eternal Recurrence (Japan)"
 	description "Xak III - The Eternal Recurrence (Japan)"
-	rom ( name "Xak III - The Eternal Recurrence (Japan).cue" size 3994 crc 5cbea73b md5 00eacd547e8ae0b5ff37988b30e54319 sha1 b96edccf717166f04560d9640c867ec5ab65b051 )
+	rom ( name "Xak III - The Eternal Recurrence (Japan).cue" size 15017 crc bbf03d60 md5 03ef977c7e02c4160073287ad3af16d3 sha1 7675107e0997d8fc733087a808b4ba07402061ca )
+)
+
+game (
+	name "Xak III - The Eternal Recurrence (Japan) (translated into english)"
+	description "Xak III - The Eternal Recurrence (Japan) (translated into english)"
+	rom ( name "Xak III - The Eternal Recurrence (Japan) (translated into english).cue" size 1581 crc 841B70EC md5 6AA2272A06AE2F09E5EFF79288CD1610 sha1 A0461911D6025B934924F96627107874BEA55A33 )
+)
+
+game (
+	name "Yamamura Misa Suspense - Kinsen Ka Kyo E Zara Satsu Jin Ji Ken (Japan)"
+	description "Yamamura Misa Suspense - Kinsen Ka Kyo E Zara Satsu Jin Ji Ken (Japan)"
+	rom ( name "Yamamura Misa Suspense - Kinsen Ka Kyo E Zara Satsu Jin Ji Ken (Japan).cue" size 11956 crc 11987de8 md5 bbeae260a1b8e9219f945c5676f19b6f sha1 071044a38c62b6b94499a8d188c64cae9e041e35 )
 )
 
 game (
@@ -1861,9 +4435,27 @@ game (
 )
 
 game (
+	name "Yami no Ketsuzoku Harukanaru Kioku (Japan)"
+	description "Yami no Ketsuzoku Harukanaru Kioku (Japan)"
+	rom ( name "Yami no Ketsuzoku Harukanaru Kioku (Japan).cue" size 6258 crc 5dec9e2f md5 795dcb38136500e17b4c6222d16544a9 sha1 5aade9b1261a69aee057cf834888db9ff83c32d4 )
+)
+
+game (
+	name "Yawara! (Japan) - ヤワラ!"
+	description "Yawara! (Japan) - ヤワラ!"
+	rom ( name "Yawara! (Japan).cue" size 3652 crc 603ebf63 md5 261b3421a43fbc3581d22495e175e8a6 sha1 de59042237f1da9c350f4e9721487e9596c642bc )
+)
+
+game (
 	name "YaWaRa! 2 - A Fashionable Judo Girl! (Japan)"
 	description "YaWaRa! 2 - A Fashionable Judo Girl! (Japan)"
 	rom ( name "YaWaRa! 2 - A Fashionable Judo Girl! (Japan).cue" size 792 crc 7182784e md5 dae88c83285d1ced8bc6a4ea8330c223 sha1 9729c9a2678732d0fb9e8a791f134e55a96d289a )
+)
+
+game (
+	name "Yawara! 2 (Japan)"
+	description "Yawara! 2 (Japan)"
+	rom ( name "Yawara! 2 (Japan).cue" size 3398 crc 20248292 md5 2a272279ed8437c662ebaa40c006a085 sha1 eefc11f1e6dd2887990f02f0b2552a543a11c096 )
 )
 
 game (
@@ -1879,15 +4471,45 @@ game (
 )
 
 game (
+	name "Ys Book I & II (USA)"
+	description "Ys Book I & II (USA)"
+	rom ( name "Ys Book I & II (USA).cue" size 18237 crc 1369f1e0 md5 502cf96d5d6ae2bada26fc9c035c5c02 sha1 c58634f7170d996e3e72d13fd26b24dd0734f13a )
+)
+
+game (
 	name "Ys Book I & II (USA) (Rev 2)"
 	description "Ys Book I & II (USA) (Rev 2)"
 	rom ( name "Ys Book I & II (USA) (Rev 2).cue" size 4374 crc b4867522 md5 ec9f70e68e62da05aa65f2efc210b720 sha1 88d5660af827b1917411033403aa3dd775179adf )
 )
 
 game (
+	name "Ys I & II - Ancient Ys Vanished (Japan) (HCD4074) - イースI-II"
+	description "Ys I & II - Ancient Ys Vanished (Japan) (HCD4074) - イースI-II"
+	rom ( name "Ys I & II - Ancient Ys Vanished (Japan) (HCD4074).cue" size 18266 crc 13c3e45b md5 3af09f970eb45586aabee2b61c8b216c sha1 b43343d0cb1c2dbab259bdf6789221fe06db7662 )
+)
+
+game (
+	name "Ys I & II - Ancient Ys Vanished (Japan) (HCD9009) - イースI-II"
+	description "Ys I & II - Ancient Ys Vanished (Japan) (HCD9009) - イースI-II"
+	rom ( name "Ys I & II - Ancient Ys Vanished (Japan) (HCD9009).cue" size 18266 crc a72e3883 md5 7040b971e799cc28feb21fd99f1a46a5 sha1 4d2cffc3f389f5873693c86534fc458c0bed20ac )
+)
+
+game (
 	name "Ys I & II (Japan) (Rev 6)"
 	description "Ys I & II (Japan) (Rev 6)"
 	rom ( name "Ys I & II (Japan) (Rev 6).cue" size 4245 crc 373675d8 md5 6c1daf2b65999d431c374c8537b2d808 sha1 898806928065bce534b46786997ea89e9948ca54 )
+)
+
+game (
+	name "Ys III - Wanderers from Ys (Japan) - イースIII"
+	description "Ys III - Wanderers from Ys (Japan) - イースIII"
+	rom ( name "Ys III - Wanderers from Ys (Japan).cue" size 10961 crc 0c0d218e md5 c90149c41e755f1a2676be332de7c835 sha1 066143c80dac125ec5cca829053285f70d0a698d )
+)
+
+game (
+	name "Ys III - Wanderers from Ys (USA)"
+	description "Ys III - Wanderers from Ys (USA)"
+	rom ( name "Ys III - Wanderers from Ys (USA).cue" size 10959 crc c96db962 md5 8cd169f4d5fa6c9f57775f77df9bda4e sha1 bc43bef2550a6eba393938854aa6e5d652f47802 )
 )
 
 game (
@@ -1903,9 +4525,33 @@ game (
 )
 
 game (
+	name "Ys IV - The Dawn of Ys (Japan) - イースIV+ザドーンオブイース"
+	description "Ys IV - The Dawn of Ys (Japan) - イースIV+ザドーンオブイース"
+	rom ( name "Ys IV - The Dawn of Ys (Japan).cue" size 13941 crc 0c387999 md5 ca28c80c1d3d94056a7bd3414939ea23 sha1 c2e10cec04057271688352545780116f0533b322 )
+)
+
+game (
 	name "Ys IV - The Dawn of Ys (Japan) (Rev 3)"
 	description "Ys IV - The Dawn of Ys (Japan) (Rev 3)"
 	rom ( name "Ys IV - The Dawn of Ys (Japan) (Rev 3).cue" size 3622 crc fa7ea57e md5 e42f62d283c5e29bf32ab5c3d1d71f05 sha1 2ac8f48485162cfc7cfab55273abeffc6b865009 )
+)
+
+game (
+	name "Ys IV - The Dawn of Ys (Japan) (translated into english) - イースIV+ザドーンオブイース"
+	description "Ys IV - The Dawn of Ys (Japan) (translated into english) - イースIV+ザドーンオブイース"
+	rom ( name "Ys IV - The Dawn of Ys (Japan) (translated into english).cue" size 4237 crc EAD4DCF4 md5 2151D80D3E653584ADE7F8844DF78D65 sha1 8401F2137700BB714F7F9B9A6E42356F57646870 )
+)
+
+game (
+	name "Yu Yu Hakusho (Japan)"
+	description "Yu Yu Hakusho (Japan)"
+	rom ( name "Yu Yu Hakusho (Japan).cue" size 12568 crc 2cd9477d md5 fd0a504e98554cd9e03b2b4243de1160 sha1 f7cbcb85071e14f9df08a296393a466090a3552c )
+)
+
+game (
+	name "Zan - Kagerou no Toki (Japan)"
+	description "Zan - Kagerou no Toki (Japan)"
+	rom ( name "Zan - Kagerou no Toki (Japan).cue" size 34190 crc ea60908d md5 e68a36a23480a44a6f83089e8c1a8d35 sha1 d9e8d5c89dee7da4d0416c4aff8d6dc69c4d671a )
 )
 
 game (
@@ -1915,7 +4561,19 @@ game (
 )
 
 game (
+	name "Zero 4 Champ II (Japan)"
+	description "Zero 4 Champ II (Japan)"
+	rom ( name "Zero 4 Champ II (Japan).cue" size 18389 crc 8317f077 md5 253d2a3b2525bfd5711c0ee988672017 sha1 126a88b675001049a5ce92a202dea7eca694ac9c )
+)
+
+game (
 	name "Zero 4 Champ II (Japan) (Rev 1)"
 	description "Zero 4 Champ II (Japan) (Rev 1)"
 	rom ( name "Zero 4 Champ II (Japan) (Rev 1).cue" size 4531 crc bbb526a6 md5 f8875368a43735b6779cb6d6cce26e55 sha1 a0e3bd08844522d24ffc1bbcae215d375a0ced4c )
+)
+
+game (
+	name "Zero Wing (Japan)"
+	description "Zero Wing (Japan)"
+	rom ( name "Zero Wing (Japan).cue" size 12308 crc f21f29d7 md5 f9c87d292e26297b2d5889bde5eea576 sha1 a64bd09157111502e01a13ff7b4b3a9d0681ffcf )
 )


### PR DESCRIPTION
This adds http://database.trurip.org NEC PC Engine CD & TurboGrafx-CD DAT information to the DAT. Handled through the script over at https://github.com/RobLoach/libretro-nec-pc-engine-cd-turbografx-cd .