### PR TITLE
Add Sega - Dreamcast DAT

### DIFF
--- a/dat/Sega - Dreamcast.dat
+++ b/dat/Sega - Dreamcast.dat
@@ -1,0 +1,3439 @@
+clrmamepro (
+	name "Sega - Dreamcast"
+	description "Sega - Dreamcast"
+	version "0.1.1"
+	comment "libretro-database's DAT file for Sega - Dreamcast"
+	homepage "https://github.com/RobLoach/libretro-sega-dreamcast.dat"
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es)"
+	description "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es)"
+	rom ( name "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es).gdi" size 276 crc 6f1ca823 md5 7348f3f1082cbd349d4a9977ed07b7af sha1 5b6beed05ffb6714dc2c2af0b486c070664c70ba )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (Japan)"
+	description "18 Wheeler - American Pro Trucker (Japan)"
+	rom ( name "18 Wheeler - American Pro Trucker (Japan).gdi" size 231 crc ed940f74 md5 4065ae1d95d3035ffa820258f4b3e44c sha1 aaf4804a56df2947e585472a87adbd8a723fba8a )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (USA)"
+	description "18 Wheeler - American Pro Trucker (USA)"
+	rom ( name "18 Wheeler - American Pro Trucker (USA).gdi" size 225 crc 3460f287 md5 95f6a45db8722322c1a435e76b7de72b sha1 2d542bef13f37103723c316f99d93d2f7c1daf65 )
+)
+
+game (
+	name "4 Wheel Thunder (Europe) (En,Fr)"
+	description "4 Wheel Thunder (Europe) (En,Fr)"
+	rom ( name "4 Wheel Thunder (Europe) (En,Fr).gdi" size 1264 crc 7c677305 md5 5ab408da163670c3de81b36350f80819 sha1 9dd3de90fda791a6b67eeac129b9e1f9a6b8f0c1 )
+)
+
+game (
+	name "4 Wheel Thunder (USA)"
+	description "4 Wheel Thunder (USA)"
+	rom ( name "4 Wheel Thunder (USA).gdi" size 1066 crc 3b5a27af md5 be4f27fb70bb0b032699befd2dbccc9f sha1 9cc0fb729d050ad59dd29547ba620e091677e008 )
+)
+
+game (
+	name "4x4 Evo (USA)"
+	description "4x4 Evo (USA)"
+	rom ( name "4x4 Evo (USA).gdi" size 565 crc 7b904cea md5 b7e6593c685b5dfebe1447153f6b1afc sha1 a45485d055c341c218e653b9df9c07d370211856 )
+)
+
+game (
+	name "90 Minutes - Sega Championship Football (Europe) (En,Fr,De,Es,It)"
+	description "90 Minutes - Sega Championship Football (Europe) (En,Fr,De,Es,It)"
+	rom ( name "90 Minutes - Sega Championship Football (Europe) (En,Fr,De,Es,It).gdi" size 303 crc ab59bc9d md5 a3dfa2f876e82b6317b4d5f7efe6e73c sha1 dfb875bf8c58f47fc21db035708980c5f7899b8a )
+)
+
+game (
+	name "Aero Dancing F (Japan) (Taikenban)"
+	description "Aero Dancing F (Japan) (Taikenban)"
+	rom ( name "Aero Dancing F (Japan) (Taikenban).gdi" size 210 crc e081d152 md5 77488246e00500d8dc652c5d2607d194 sha1 6ea760f21dcf4d0491335b3e3bf66f877d7afbf5 )
+)
+
+game (
+	name "Aero Dancing featuring Blue Impulse (Japan)"
+	description "Aero Dancing featuring Blue Impulse (Japan)"
+	rom ( name "Aero Dancing featuring Blue Impulse (Japan).gdi" size 237 crc 99db2c17 md5 ab1c5ddfff05ccdc69f33383063286cc sha1 b17263eb8b4090ea5a9a404df9da8068fe9fa3e6 )
+)
+
+game (
+	name "AeroWings (Europe) (En,Fr,De)"
+	description "AeroWings (Europe) (En,Fr,De)"
+	rom ( name "AeroWings (Europe) (En,Fr,De).gdi" size 195 crc 3d735cce md5 64a0848df806b1b24f75d370b7c53921 sha1 1a1e0f3d51ed648e8feaad70d9586c4328fc59c8 )
+)
+
+game (
+	name "AeroWings (USA)"
+	description "AeroWings (USA)"
+	rom ( name "AeroWings (USA).gdi" size 153 crc de1f9cce md5 9805e97f6c7eba3b386956a24f959177 sha1 155ffa5ce24956861379ed2e0fe48e921360b755 )
+)
+
+game (
+	name "AeroWings 2 - Airstrike (USA)"
+	description "AeroWings 2 - Airstrike (USA)"
+	rom ( name "AeroWings 2 - Airstrike (USA).gdi" size 195 crc 41b14cd7 md5 c5be8144ed81311daafc81459a6fdce7 sha1 1a320c9c95ee603ae26346454aa640422ed8df76 )
+)
+
+game (
+	name "AirForce Delta (Japan)"
+	description "AirForce Delta (Japan)"
+	rom ( name "AirForce Delta (Japan).gdi" size 1804 crc 98dfdf77 md5 b9012495ee6faa58b1c51f42bb48c54a sha1 73ab6ef4117ceb4d94dcaf07a7d18360238bc223 )
+)
+
+game (
+	name "AirForce Delta (USA)"
+	description "AirForce Delta (USA)"
+	rom ( name "AirForce Delta (USA).gdi" size 1744 crc 5c1d8999 md5 a24aa23826e763e29fad17c409924b87 sha1 ce6caaaacaaaf8da20e53df88647d8fd596bcd4b )
+)
+
+game (
+	name "Alienfront Online (USA)"
+	description "Alienfront Online (USA)"
+	rom ( name "Alienfront Online (USA).gdi" size 298 crc 8a0549ab md5 76cc9a621b43821401b9d77cb960563c sha1 6e4b1e1ab338f5f6fa5ac4a36199d14d8167db35 )
+)
+
+game (
+	name "Alone in the Dark - The New Nightmare (USA) (Disc 1)"
+	description "Alone in the Dark - The New Nightmare (USA) (Disc 1)"
+	rom ( name "Alone in the Dark - The New Nightmare (USA) (Disc 1).gdi" size 443 crc 6a16e4cd md5 16b39f9e10732f70054860374c4794b0 sha1 47f935ecdbd8baca67ef52b961c49ec5fdd95f95 )
+)
+
+game (
+	name "Alone in the Dark - The New Nightmare (USA) (Disc 2)"
+	description "Alone in the Dark - The New Nightmare (USA) (Disc 2)"
+	rom ( name "Alone in the Dark - The New Nightmare (USA) (Disc 2).gdi" size 438 crc 421b48dd md5 f0d1c3f7f921b6e9b7b97edf6bc27238 sha1 5adb90b3511c48c9763c27b2d7e7c64db4c90256 )
+)
+
+game (
+	name "Armada (USA)"
+	description "Armada (USA)"
+	rom ( name "Armada (USA).gdi" size 243 crc 2ae2d1ba md5 3fbc736910d4156484eab773154278a1 sha1 0db48d29ab76eb7845ae90c913646c0aeaed0b0e )
+)
+
+game (
+	name "Army Men - Sarge's Heroes (USA)"
+	description "Army Men - Sarge's Heroes (USA)"
+	rom ( name "Army Men - Sarge's Heroes (USA).gdi" size 338 crc d0e94f0b md5 ad565d1ae428f34ac1ed2bc1367b0b77 sha1 0f2689d607c6ec42cbe8cf2eabb2dc47118c4bd8 )
+)
+
+game (
+	name "Atari Anniversary Edition (USA)"
+	description "Atari Anniversary Edition (USA)"
+	rom ( name "Atari Anniversary Edition (USA).gdi" size 338 crc 9b596288 md5 510ec1c9e5651479848c97bc1282414e sha1 ea43c04e27290748876f7ac4b7a0df7034d3b9b4 )
+)
+
+game (
+	name "Bakuretsu Muteki Bangaioh (Japan)"
+	description "Bakuretsu Muteki Bangaioh (Japan)"
+	rom ( name "Bakuretsu Muteki Bangaioh (Japan).gdi" size 2631 crc c142b03e md5 f2c01522c3162b77f5ef19a00fe65279 sha1 d74fc3a7b85ae9b83b66f384f4d4addc08bb19b2 )
+)
+
+game (
+	name "Bang! Gunship Elite (USA)"
+	description "Bang! Gunship Elite (USA)"
+	rom ( name "Bang! Gunship Elite (USA).gdi" size 552 crc 9b3eb9ef md5 6771ac1e7690a81b6bd41f7fd089f68c sha1 48b7822f4bd83424aa705b4bc8293c12a4797ff6 )
+)
+
+game (
+	name "Bangai-O (USA)"
+	description "Bangai-O (USA)"
+	rom ( name "Bangai-O (USA).gdi" size 1928 crc e785e620 md5 47fcc47c531e11622d16cbc4f2af2560 sha1 52f0bf65c3a78f2eb50e65e6dfcde1725840c476 )
+)
+
+game (
+	name "Berserk - Millennium Falcon Hen Wasurebana no Shou (Japan)"
+	description "Berserk - Millennium Falcon Hen Wasurebana no Shou (Japan)"
+	rom ( name "Berserk - Millennium Falcon Hen Wasurebana no Shou (Japan).gdi" size 282 crc 4e50c1f1 md5 eefe5fbd883f4f7a1d1b789ac32893cd sha1 84200d9b3a2289941d5c30ce2cddc971d33fbc67 )
+)
+
+game (
+	name "BikkuriMan 2000 - Viva! Festiva! (Japan)"
+	description "BikkuriMan 2000 - Viva! Festiva! (Japan)"
+	rom ( name "BikkuriMan 2000 - Viva! Festiva! (Japan).gdi" size 228 crc 0ab77dbf md5 0bbd5254b3778865cc1bf125e53df665 sha1 3f449136020f783e7a443c70293d2c61f56ef5aa )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1)"
+	description "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1)"
+	rom ( name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1).gdi" size 276 crc d09e4d27 md5 f1ec221a65c8bca237fe2936582336ef sha1 5bd13fc948303f2cb5ee77128af9becc6b8e7ddd )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2)"
+	description "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2)"
+	rom ( name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2).gdi" size 276 crc 07778850 md5 38c0eb4863268e63da16aa850c676448 sha1 62934e38be9dfabf4f470efd042c52c2fc776483 )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Trial Edition (Japan)"
+	description "Biohazard - Code - Veronica - Trial Edition (Japan)"
+	rom ( name "Biohazard - Code - Veronica - Trial Edition (Japan).gdi" size 261 crc 1edff6aa md5 b98b53171bd06255219f495513aad3b5 sha1 ba41b2ce50e06124dc279d19fac943c4d86d5566 )
+)
+
+game (
+	name "Biohazard - Code - Veronica (Japan) (Disc 1) (Genteiban)"
+	description "Biohazard - Code - Veronica (Japan) (Disc 1) (Genteiban)"
+	rom ( name "Biohazard - Code - Veronica (Japan) (Disc 1) (Genteiban).gdi" size 276 crc a6fa4970 md5 e05017ecb8b5951ca6ac53ee71738d55 sha1 8a4ddda7c2500fd5ee499fca247569ff477d080c )
+)
+
+game (
+	name "Biohazard - Code - Veronica (Japan) (Disc 2) (Genteiban)"
+	description "Biohazard - Code - Veronica (Japan) (Disc 2) (Genteiban)"
+	rom ( name "Biohazard - Code - Veronica (Japan) (Disc 2) (Genteiban).gdi" size 276 crc 9d47ab72 md5 702f30844bd1a00c4ea0897b2a7af306 sha1 af48b69894d3fc07e061265e1db9c1e9c285684f )
+)
+
+game (
+	name "Biohazard 2 - Value Plus (Japan) (Disc 1)"
+	description "Biohazard 2 - Value Plus (Japan) (Disc 1)"
+	rom ( name "Biohazard 2 - Value Plus (Japan) (Disc 1).gdi" size 465 crc 2b8e3e30 md5 3810c5e2226048c97ad3c62a4fe18ec0 sha1 d76e744485eeef1cd8ecb1bf9cd3b814d1b036d9 )
+)
+
+game (
+	name "Biohazard 2 - Value Plus (Japan) (Disc 2)"
+	description "Biohazard 2 - Value Plus (Japan) (Disc 2)"
+	rom ( name "Biohazard 2 - Value Plus (Japan) (Disc 2).gdi" size 465 crc 26cb80a4 md5 942014610dd276a55118c91d6aea3066 sha1 79598f7456012b721c268b82a7e2389daf269c86 )
+)
+
+game (
+	name "Biohazard 3 - Last Escape (Japan)"
+	description "Biohazard 3 - Last Escape (Japan)"
+	rom ( name "Biohazard 3 - Last Escape (Japan).gdi" size 207 crc 082f4c35 md5 f2692b8d9c6362e72f675a16650a3de7 sha1 465964f3a8c2dac37ce729e0c00f1851b1124550 )
+)
+
+game (
+	name "Blue Stinger (Europe)"
+	description "Blue Stinger (Europe)"
+	rom ( name "Blue Stinger (Europe).gdi" size 171 crc f10fb2c3 md5 955eec032e58a9ddb8b261718b1962f3 sha1 3274f81ee64cf2a1dd3719a371050a2c7a4f33ea )
+)
+
+game (
+	name "Blue Stinger (Germany) (En,De)"
+	description "Blue Stinger (Germany) (En,De)"
+	rom ( name "Blue Stinger (Germany) (En,De).gdi" size 198 crc 04ba55f7 md5 df456f455d6d99c862d29bd3b9e7f5ad sha1 6e5760daf842208b224892aa1c10011fe3dc477d )
+)
+
+game (
+	name "Blue Stinger (Japan)"
+	description "Blue Stinger (Japan)"
+	rom ( name "Blue Stinger (Japan).gdi" size 168 crc e0f1bb50 md5 13f7a410ac37fb5a03ef5d63c330ea1a sha1 70508a3e47eff77b95fa9c7bc4f8074ed98d4f4e )
+)
+
+game (
+	name "Blue Stinger (USA)"
+	description "Blue Stinger (USA)"
+	rom ( name "Blue Stinger (USA).gdi" size 162 crc 146c9fc7 md5 fbe691cfdcf50bd92d4ab29476ae4d15 sha1 61a8fa7debf61b8ab59eeb87c43699f2fd354a33 )
+)
+
+game (
+	name "Bomberman Online (USA)"
+	description "Bomberman Online (USA)"
+	rom ( name "Bomberman Online (USA).gdi" size 174 crc bc11b66b md5 26e225b7a1bf7502767518d0285cb3b3 sha1 08e304c14201fd2bfdd0b56e04aa068f7ba27bac )
+)
+
+game (
+	name "Broadband Passport (Japan) (2M)"
+	description "Broadband Passport (Japan) (2M)"
+	rom ( name "Broadband Passport (Japan) (2M).gdi" size 201 crc 7a837014 md5 7e540c438baeb87ddfcf52aa75703ac4 sha1 6103135a7f15e45604e79e94e789e678aa2e5e30 )
+)
+
+game (
+	name "Buggy Heat (Europe) (En,Fr,De,Es)"
+	description "Buggy Heat (Europe) (En,Fr,De,Es)"
+	rom ( name "Buggy Heat (Europe) (En,Fr,De,Es).gdi" size 207 crc 25a8fa52 md5 c102c4d6df2f998692f74f9e268e4cbe sha1 010fc42fa5856575460868914f16cfcbcaba60fc )
+)
+
+game (
+	name "Buggy Heat (Japan)"
+	description "Buggy Heat (Japan)"
+	rom ( name "Buggy Heat (Japan).gdi" size 162 crc c2abfa28 md5 1958becd8308566ff94ad1b67ef09954 sha1 de505d21f21781179d21aa1d36403ac73d73c865 )
+)
+
+game (
+	name "Bust-A-Move 4 (USA)"
+	description "Bust-A-Move 4 (USA)"
+	rom ( name "Bust-A-Move 4 (USA).gdi" size 1486 crc c69487f8 md5 abbdceaa3c65348f7b6803ddf9cad5a0 sha1 d8cbb3139da2c8424d1cc04616ee83c7a10bfd6e )
+)
+
+game (
+	name "Caesars Palace 2000 - Millennium Gold Edition (Europe)"
+	description "Caesars Palace 2000 - Millennium Gold Edition (Europe)"
+	rom ( name "Caesars Palace 2000 - Millennium Gold Edition (Europe).gdi" size 1844 crc 75f4f184 md5 36a2def593376a8b00d4334cce37c5bd sha1 0915345849db98b841b94fb00943806e5215cf0d )
+)
+
+game (
+	name "Caesars Palace 2000 - Millennium Gold Edition (USA)"
+	description "Caesars Palace 2000 - Millennium Gold Edition (USA)"
+	rom ( name "Caesars Palace 2000 - Millennium Gold Edition (USA).gdi" size 1784 crc 0f62f347 md5 feb8da8573d6751fc9f90a2abb3e1856 sha1 16fe1ac8d8c84ac19611896ca855657a3fdb9059 )
+)
+
+game (
+	name "Canary - Kono Omoi wo Uta ni Nosete (Japan)"
+	description "Canary - Kono Omoi wo Uta ni Nosete (Japan)"
+	rom ( name "Canary - Kono Omoi wo Uta ni Nosete (Japan).gdi" size 237 crc 48259145 md5 3ee597c816e57e7e52eec3df6714fc49 sha1 9ff19c9adc0241a9fe12fb4d3586343626ed793d )
+)
+
+game (
+	name "Cannon Spike (USA)"
+	description "Cannon Spike (USA)"
+	rom ( name "Cannon Spike (USA).gdi" size 162 crc 6fc75747 md5 b5343b0d01470da32a1f5a113fa706ac sha1 cf3a260cb9cd37ece6b18b195f8f1667a73feafb )
+)
+
+game (
+	name "Capcom vs. SNK - Millennium Fight 2000 (Japan)"
+	description "Capcom vs. SNK - Millennium Fight 2000 (Japan)"
+	rom ( name "Capcom vs. SNK - Millennium Fight 2000 (Japan).gdi" size 246 crc 938b19f6 md5 1d24a352b9f0d0524930d6ee00764dd6 sha1 833dffa29ba84aa0af92dbedf18104d5d475a8b2 )
+)
+
+game (
+	name "Capcom vs. SNK (USA)"
+	description "Capcom vs. SNK (USA)"
+	rom ( name "Capcom vs. SNK (USA).gdi" size 168 crc f4ab9da8 md5 f6430a7ca6843c077e116f520e208f62 sha1 ac3d1a90dd735593408d4f6729eabb28908a361d )
+)
+
+game (
+	name "Championship Surfer (USA)"
+	description "Championship Surfer (USA)"
+	rom ( name "Championship Surfer (USA).gdi" size 886 crc bff51d6c md5 0f1c5d89a9fc93bda198773a81836e7b sha1 54ba265f24acdfc2cf9fd4342e656640a88c3110 )
+)
+
+game (
+	name "Chicken Run (Europe) (Fr,De,Es,It)"
+	description "Chicken Run (Europe) (Fr,De,Es,It)"
+	rom ( name "Chicken Run (Europe) (Fr,De,Es,It).gdi" size 353 crc 5b0c6420 md5 043087ad366809c407a61921c6c6c191 sha1 cfb944a9b83cc59d0a4fdb9276f879767b7402f4 )
+)
+
+game (
+	name "Chicken Run (USA)"
+	description "Chicken Run (USA)"
+	rom ( name "Chicken Run (USA).gdi" size 268 crc f825d9c8 md5 0acbbbc74b1c2a8d8e98bff6b9a7d89b sha1 fa6bf43c256beca26df225c020ddbe7f75c0a58b )
+)
+
+game (
+	name "Chu-Chu Rocket! (Japan)"
+	description "Chu-Chu Rocket! (Japan)"
+	rom ( name "Chu-Chu Rocket! (Japan).gdi" size 1163 crc 7c15c1d8 md5 c0ab65c12fcd72135c55b898b331ee01 sha1 31d6bd05049da4236596ec82b1adb73d09b3de14 )
+)
+
+game (
+	name "ChuChu Rocket! (Europe) (En,Ja,Fr,De,Es)"
+	description "ChuChu Rocket! (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "ChuChu Rocket! (Europe) (En,Ja,Fr,De,Es).gdi" size 1486 crc 64bcfaf6 md5 965c0baa91fe69694500af754029722b sha1 042572069c542ef65ded1e762e6a6a1ad8860606 )
+)
+
+game (
+	name "ChuChu Rocket! (USA) (En,Ja,Fr,De,Es)"
+	description "ChuChu Rocket! (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "ChuChu Rocket! (USA) (En,Ja,Fr,De,Es).gdi" size 1429 crc bf0d82ba md5 08bf674e414dd1744fac90f412a2b4bb sha1 d4c2fc1b9c3d83d971576f4aa3c31cd84963a945 )
+)
+
+game (
+	name "Climax Landers (Japan)"
+	description "Climax Landers (Japan)"
+	rom ( name "Climax Landers (Japan).gdi" size 174 crc a8362887 md5 8b14bd7521aee3ab2cb7deabb59f696d sha1 4cfcd16ab12303b0628f9c51ead8288aae988a2e )
+)
+
+game (
+	name "Coaster Works (USA)"
+	description "Coaster Works (USA)"
+	rom ( name "Coaster Works (USA).gdi" size 973 crc 228175c0 md5 d0c27f295bc22f665588443f3ce206c0 sha1 78ef12d672dff46b939a0cd81e0712854e100596 )
+)
+
+game (
+	name "Confidential Mission (Europe) (En,Fr,De,Es)"
+	description "Confidential Mission (Europe) (En,Fr,De,Es)"
+	rom ( name "Confidential Mission (Europe) (En,Fr,De,Es).gdi" size 237 crc 8b7c10a7 md5 0aed4a71622d46d3f979986062996956 sha1 5df2232497dd56b16cab7ab19441190cf684588b )
+)
+
+game (
+	name "Confidential Mission (Japan) (En,Ja,Fr,De,Es)"
+	description "Confidential Mission (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Confidential Mission (Japan) (En,Ja,Fr,De,Es).gdi" size 243 crc 80313bcc md5 174e59fbb85e110ae536451982697d3a sha1 09fd8d8549cb2064b1d9eb6de6abe6426279185c )
+)
+
+game (
+	name "Conflict Zone (Europe) (En,Fr,De)"
+	description "Conflict Zone (Europe) (En,Fr,De)"
+	rom ( name "Conflict Zone (Europe) (En,Fr,De).gdi" size 348 crc ab79df0c md5 8791a94e98d3777b859fd04914b2e700 sha1 70a7b88ece8eaab843d12cce852af112e4152a82 )
+)
+
+game (
+	name "Cool Boarders Burrrn! (Japan)"
+	description "Cool Boarders Burrrn! (Japan)"
+	rom ( name "Cool Boarders Burrrn! (Japan).gdi" size 1277 crc 80d5772c md5 acb562e8959c78f94189ae34cd2fc944 sha1 1949fedd6336e180d74badb52d6598f2618626ff )
+)
+
+game (
+	name "Crazy Taxi (Europe)"
+	description "Crazy Taxi (Europe)"
+	rom ( name "Crazy Taxi (Europe).gdi" size 165 crc f19896d7 md5 20caaaf732735f8452c6650be8adf74a sha1 d08ca3cc38bac7257f7533d19af67105fe003d4d )
+)
+
+game (
+	name "Crazy Taxi (Japan)"
+	description "Crazy Taxi (Japan)"
+	rom ( name "Crazy Taxi (Japan).gdi" size 162 crc 2db119b7 md5 cdfd61dde70fd8d0e2a469e52e252900 sha1 9d77caf5c0edc1594e372847939ca0a17f82d4ab )
+)
+
+game (
+	name "Crazy Taxi (USA)"
+	description "Crazy Taxi (USA)"
+	rom ( name "Crazy Taxi (USA).gdi" size 156 crc 14db3401 md5 dab0c227dad3df659aa3a454426f2916 sha1 058b2eda664ee953caeb5ad35efbbdbcfc60d85f )
+)
+
+game (
+	name "Crazy Taxi 2 (Japan)"
+	description "Crazy Taxi 2 (Japan)"
+	rom ( name "Crazy Taxi 2 (Japan).gdi" size 168 crc 6b60945f md5 06720ef1fdbede7e20d6643fa438a248 sha1 f868cf1ce7455dff67ad23ddac2d4df5919b1a3b )
+)
+
+game (
+	name "Crazy Taxi 2 (USA)"
+	description "Crazy Taxi 2 (USA)"
+	rom ( name "Crazy Taxi 2 (USA).gdi" size 162 crc fdf903cf md5 cb87532e5ab1e48da68200d85b2cd7d4 sha1 64274eac25d47c9927aa3f09f0c6c82c634f2610 )
+)
+
+game (
+	name "D2 (USA) (Disc 1)"
+	description "D2 (USA) (Disc 1)"
+	rom ( name "D2 (USA) (Disc 1).gdi" size 159 crc 6005fd26 md5 2dac1189010471cc8a281209afd2686c sha1 f42c5bdfa550f2a667d544ab5b9d7fe308f23c60 )
+)
+
+game (
+	name "D2 (USA) (Disc 2)"
+	description "D2 (USA) (Disc 2)"
+	rom ( name "D2 (USA) (Disc 2).gdi" size 159 crc 837c3884 md5 a0bdaacedc91e31b4dae54d8e2c6e64c sha1 21f684c2be4a8e6d9923f542ce9717177b567145 )
+)
+
+game (
+	name "D2 (USA) (Disc 3)"
+	description "D2 (USA) (Disc 3)"
+	rom ( name "D2 (USA) (Disc 3).gdi" size 159 crc 6b7b8625 md5 8c12f2eff0376790fc59e1eb7e88e3c7 sha1 1db29821c0749c3730dbcbb5e6a55a4ce1f4ac6d )
+)
+
+game (
+	name "D2 (USA) (Disc 4)"
+	description "D2 (USA) (Disc 4)"
+	rom ( name "D2 (USA) (Disc 4).gdi" size 159 crc 9efeb581 md5 5cf265cb17000c16a853b0ad48356eb2 sha1 83d5c47e5070bb97914eff2a1b86c00e35ed877d )
+)
+
+game (
+	name "D2 Shock (Japan)"
+	description "D2 Shock (Japan)"
+	rom ( name "D2 Shock (Japan).gdi" size 156 crc 07cfa2f4 md5 3bda1fb0396843ee147068bb379f2e51 sha1 7f05aeab5cf4744135a9cf193eb9f76b102d6a9d )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX (Europe)"
+	description "Dave Mirra Freestyle BMX (Europe)"
+	rom ( name "Dave Mirra Freestyle BMX (Europe).gdi" size 998 crc eb92c2ad md5 61723ec0d131992d4908a12e9951bece sha1 ac4afecaa79ec08ca05d732203bf0bb3cde7e539 )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX (USA)"
+	description "Dave Mirra Freestyle BMX (USA)"
+	rom ( name "Dave Mirra Freestyle BMX (USA).gdi" size 956 crc 19343eb5 md5 ef6ba7cba01ee3471ff4dd85c9057231 sha1 057dd8bc705622fed5bc3f437d246963c0feeba3 )
+)
+
+game (
+	name "Daytona USA (USA)"
+	description "Daytona USA (USA)"
+	rom ( name "Daytona USA (USA).gdi" size 159 crc e907bafb md5 6555466af0bf6e8ca2dd12ec15994e16 sha1 7841a578bbb64c3a06ee1b8beec9662171fee191 )
+)
+
+game (
+	name "Daytona USA 2001 (Japan)"
+	description "Daytona USA 2001 (Japan)"
+	rom ( name "Daytona USA 2001 (Japan).gdi" size 180 crc 5965a3d3 md5 eb6b40e12bb3bb7eef7de8cbac58cbfa sha1 634c131e6930e012ce5aa43026471479db8d8e94 )
+)
+
+game (
+	name "De La Jet Set Radio (Japan) (En,Ja,Fr,De,Es)"
+	description "De La Jet Set Radio (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "De La Jet Set Radio (Japan) (En,Ja,Fr,De,Es).gdi" size 240 crc 012917d3 md5 5a6717802f4b42d83914482edd4bf57e sha1 8dd38ca148140dc43bf305e571a462c00df2d430 )
+)
+
+game (
+	name "Dead or Alive 2 (Europe)"
+	description "Dead or Alive 2 (Europe)"
+	rom ( name "Dead or Alive 2 (Europe).gdi" size 180 crc 2903a13e md5 13cadc3f5f082034e8569f4d38438084 sha1 b2c2e961bf9474169d807a5954934004dfc89515 )
+)
+
+game (
+	name "Dead or Alive 2 (Japan) (Shokai Genteiban)"
+	description "Dead or Alive 2 (Japan) (Shokai Genteiban)"
+	rom ( name "Dead or Alive 2 (Japan) (Shokai Genteiban).gdi" size 234 crc 227baf31 md5 907919839d6891ec44302c4350bee055 sha1 328e8ba70de5235e43d1f8bea0127561b292c2bb )
+)
+
+game (
+	name "Dead or Alive 2 (USA)"
+	description "Dead or Alive 2 (USA)"
+	rom ( name "Dead or Alive 2 (USA).gdi" size 171 crc 8748ba6d md5 36def589910d587b4795c006c0e6ae2e sha1 298947dc01594021ebb978572273f762741d58f7 )
+)
+
+game (
+	name "Deadly Skies (Europe) (En,Fr,De,Es,It)"
+	description "Deadly Skies (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Deadly Skies (Europe) (En,Fr,De,Es,It).gdi" size 2284 crc 7b535fe5 md5 4ed415f94721d35afbb659736bec17f8 sha1 e28cc21e697ff560adefe010227fda40770059a7 )
+)
+
+game (
+	name "Death Crimson 2 (Japan)"
+	description "Death Crimson 2 (Japan)"
+	rom ( name "Death Crimson 2 (Japan).gdi" size 177 crc 990d783d md5 b4d89c6d1081f70e759cb0bd0d5281b1 sha1 109e4d57b3ab80ed45ca09a2ac46732126f200cc )
+)
+
+game (
+	name "Death Crimson OX (USA)"
+	description "Death Crimson OX (USA)"
+	rom ( name "Death Crimson OX (USA).gdi" size 174 crc 4abf151f md5 54614bf7a5ab6325870b333aa1176364 sha1 da5cd7b6750c05b643b257d15f9773430d158eed )
+)
+
+game (
+	name "Deep Fighter (Europe) (En,It) (Disc 1)"
+	description "Deep Fighter (Europe) (En,It) (Disc 1)"
+	rom ( name "Deep Fighter (Europe) (En,It) (Disc 1).gdi" size 1524 crc b65b3890 md5 e627100c75e244cd21b52f73fe581d5d sha1 dbac6087e7a35c8b3f88c51f4da4767173bdef95 )
+)
+
+game (
+	name "Deep Fighter (Europe) (En,It) (Disc 2)"
+	description "Deep Fighter (Europe) (En,It) (Disc 2)"
+	rom ( name "Deep Fighter (Europe) (En,It) (Disc 2).gdi" size 1980 crc 6f4af2cd md5 fdf0fbd6b33186b46c9940e4067e5ce9 sha1 63e44e6e703e111b9179def8c2b4143689fe38ac )
+)
+
+game (
+	name "Dennou Senki - Virtual-On - Oratorio Tangram (Japan)"
+	description "Dennou Senki - Virtual-On - Oratorio Tangram (Japan)"
+	rom ( name "Dennou Senki - Virtual-On - Oratorio Tangram (Japan).gdi" size 5224 crc cc9ab50d md5 eabe3233974a467aacb585e88710f84a sha1 26470e700d15c0f030aaa4c1b80da6db8f0310f9 )
+)
+
+game (
+	name "Derby Tsuku - Derby Uma o Tsukurou! (Japan)"
+	description "Derby Tsuku - Derby Uma o Tsukurou! (Japan)"
+	rom ( name "Derby Tsuku - Derby Uma o Tsukurou! (Japan).gdi" size 237 crc ae56083c md5 62fbef0d609883a431e47717cdc33878 sha1 e54a664fbe92f6bd198d78c5310731f394cf49b3 )
+)
+
+game (
+	name "Dino Crisis (Europe)"
+	description "Dino Crisis (Europe)"
+	rom ( name "Dino Crisis (Europe).gdi" size 168 crc 1ad3efcd md5 5c92f8423d2c3d4b526d8ee317bb7bbc sha1 8d102cef2eb0872218024aa16adc2c2628388983 )
+)
+
+game (
+	name "Dino Crisis (Germany)"
+	description "Dino Crisis (Germany)"
+	rom ( name "Dino Crisis (Germany).gdi" size 171 crc 15d6e07f md5 bb55af0dcdf26f81d28218a1510de0b3 sha1 9ae7f5e34d6473129ce377d32c562e6061993646 )
+)
+
+game (
+	name "Dino Crisis (Japan)"
+	description "Dino Crisis (Japan)"
+	rom ( name "Dino Crisis (Japan).gdi" size 165 crc d0f1b9a1 md5 8ba9234bae6ae98206e50192eaf63442 sha1 a44c6c4af20735133ca90b9544377e1881a185a3 )
+)
+
+game (
+	name "Dino Crisis (USA)"
+	description "Dino Crisis (USA)"
+	rom ( name "Dino Crisis (USA).gdi" size 159 crc 9fbe5c3a md5 a7783c1e2d4a708d8dde579dcbb46470 sha1 49e427b2f75fb29e61abf8df00f5eeb764e211d4 )
+)
+
+game (
+	name "Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
+	description "Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
+	rom ( name "Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).gdi" size 303 crc 885d9718 md5 8f34574680e0c74ec4c2e01edbbe50b4 sha1 7c182ea1cc333cd70c7f2474230972904d91e2ac )
+)
+
+game (
+	name "Disney's 102 Dalmatians - Puppies to the Rescue (Europe) (Fr,De,Es,It)"
+	description "Disney's 102 Dalmatians - Puppies to the Rescue (Europe) (Fr,De,Es,It)"
+	rom ( name "Disney's 102 Dalmatians - Puppies to the Rescue (Europe) (Fr,De,Es,It).gdi" size 533 crc b285097c md5 eedf56db00547a97fb5ade41f459c04b sha1 2770137843564b23113456f5c16c3cc022290438 )
+)
+
+game (
+	name "Disney's 102 Dalmatians - Puppies to the Rescue (USA)"
+	description "Disney's 102 Dalmatians - Puppies to the Rescue (USA)"
+	rom ( name "Disney's 102 Dalmatians - Puppies to the Rescue (USA).gdi" size 448 crc e0137c83 md5 df71d23acecac0d4ac154e43891efd9f sha1 103ed89cc5331817f91202622b9387d29b9f5675 )
+)
+
+game (
+	name "Disney's Dinosaur (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Dinosaur (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Dinosaur (Europe) (En,Fr,De,Es,It).gdi" size 237 crc d94284b2 md5 f9dc31c00d0de49473d6f17ea4f2adec sha1 4c35cc37fbf75f0a3bb11a24f1c3935da2cdf88a )
+)
+
+game (
+	name "Dorimaga GD Vol. 3 (Japan)"
+	description "Dorimaga GD Vol. 3 (Japan)"
+	rom ( name "Dorimaga GD Vol. 3 (Japan).gdi" size 772 crc a407f16e md5 931ad483a42f39a7352b60b9e369cf97 sha1 644ea8f3903eff20af88d2c9b500cde8ee6433c6 )
+)
+
+game (
+	name "Draconus - Cult of the Wyrm (USA)"
+	description "Draconus - Cult of the Wyrm (USA)"
+	rom ( name "Draconus - Cult of the Wyrm (USA).gdi" size 343 crc 39643206 md5 722ff130bd66b67b537f7ef37daaca1e sha1 6e9b902ebd1f4b44dab17876d88b1bc4a07860f1 )
+)
+
+game (
+	name "Dragons Blood (Europe) (En,Fr,De)"
+	description "Dragons Blood (Europe) (En,Fr,De)"
+	rom ( name "Dragons Blood (Europe) (En,Fr,De).gdi" size 343 crc dfb05ed2 md5 2a7123f425aa1b805997ad0588b5110c sha1 0b9c780a89812a984fa3a4de61e676c33245d572 )
+)
+
+game (
+	name "Dream Passport (Japan)"
+	description "Dream Passport (Japan)"
+	rom ( name "Dream Passport (Japan).gdi" size 174 crc 3c6fa231 md5 7c9c63311721d504d7e5728bd3f9c023 sha1 dbe9f83accb52e2eaeda65576a5676fb6981413e )
+)
+
+game (
+	name "Dream Passport 3 (Japan)"
+	description "Dream Passport 3 (Japan)"
+	rom ( name "Dream Passport 3 (Japan).gdi" size 180 crc 939fcee7 md5 c36a9b4ccaa15a5d4272db59ccefadaf sha1 6bd3a01220de515124b9859e1e8b27ce69e3d70b )
+)
+
+game (
+	name "DreamFlyer (Japan)"
+	description "DreamFlyer (Japan)"
+	rom ( name "DreamFlyer (Japan).gdi" size 162 crc 6b4fb7cc md5 d38e184fa3e385c53224f21f7566af24 sha1 ff84d031b444e3d9042fd66cb6d5333c189f4faf )
+)
+
+game (
+	name "Dreamkey Version 1.0 (Europe)"
+	description "Dreamkey Version 1.0 (Europe)"
+	rom ( name "Dreamkey Version 1.0 (Europe).gdi" size 195 crc 8b03f8a9 md5 6f1ea0d5ab2055edac64e922e505741b sha1 5c0274fbf09002734e88ad4eca89a6d51e5cf21e )
+)
+
+game (
+	name "Dreamkey Version 1.0 (Europe) (Rev B)"
+	description "Dreamkey Version 1.0 (Europe) (Rev B)"
+	rom ( name "Dreamkey Version 1.0 (Europe) (Rev B).gdi" size 219 crc 06242ef1 md5 0abfd8f59ad5723b135676e2cb77e442 sha1 cbb1870c5a9d81d504ff890323a1ad14f4daed3b )
+)
+
+game (
+	name "Dreamkey Version 1.5 (Europe)"
+	description "Dreamkey Version 1.5 (Europe)"
+	rom ( name "Dreamkey Version 1.5 (Europe).gdi" size 195 crc 3d1996d2 md5 d7646edbee607f8f18878e214a104108 sha1 68d398fb7cf3b1202638b93d5b85d4698ccebb38 )
+)
+
+game (
+	name "Dreamkey Version 1.5 (France)"
+	description "Dreamkey Version 1.5 (France)"
+	rom ( name "Dreamkey Version 1.5 (France).gdi" size 195 crc 96a2b87d md5 5ee55561701e67d5040a12bdc97894ee sha1 cd2a4d699c84d09a25a790a808a2ef76e0710ca5 )
+)
+
+game (
+	name "Dreamkey Version 2.0 (Europe) (En,Fr,De,Es,It)"
+	description "Dreamkey Version 2.0 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dreamkey Version 2.0 (Europe) (En,Fr,De,Es,It).gdi" size 413 crc 81dedcc6 md5 e36293c155dd7bc8e7b085e4c083a6fc sha1 6ce2062a11a5b2402022196ef1dea82dab558186 )
+)
+
+game (
+	name "Dreamkey Version 3.0 (Europe) (En,Fr,De,It)"
+	description "Dreamkey Version 3.0 (Europe) (En,Fr,De,It)"
+	rom ( name "Dreamkey Version 3.0 (Europe) (En,Fr,De,It).gdi" size 237 crc a3734609 md5 f569e66e329901ce42d6dd805ae63d86 sha1 7d6b7da2d020cc12c1d4bcf28ba1b308934c22d0 )
+)
+
+game (
+	name "Dreamon Collection 2 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Collection 2 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Collection 2 (Europe) (En,Fr,De,Es).gdi" size 627 crc f0f71aed md5 26d2a25d9af941d38333dd07e718ff36 sha1 b651cda7870471ab39626e6eeda051f2c22e76b8 )
+)
+
+game (
+	name "Dreamon Collection 3 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Collection 3 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Collection 3 (Europe) (En,Fr,De,Es).gdi" size 237 crc aec2b9a6 md5 95bb7abf79effc4ff0e1aaeba835ea7b sha1 e53936d0f05b83e6c6c6745972da14c4c69808cc )
+)
+
+game (
+	name "Dreamon Collection 4 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Collection 4 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Collection 4 (Europe) (En,Fr,De,Es).gdi" size 237 crc a14e3100 md5 79fa9c63cd0beac37600ea1c0e2b2576 sha1 b96f6415ca456584f4c3967d7a56dac26bdf1d15 )
+)
+
+game (
+	name "Dreamon Volume 1 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 1 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 1 (Europe) (En,Fr,De,Es).gdi" size 678 crc e8b2026d md5 a310bfd3802d2e8d3f307a3c643695e2 sha1 bb060fe5731f28ca86949d990f8797b586748356 )
+)
+
+game (
+	name "Dreamon Volume 10 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 10 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 10 (Europe) (En,Fr,De,Es).gdi" size 383 crc e6f48d86 md5 a462e66e46b56670c52d6ebb0487aa80 sha1 03a50e88b33cbc1f5685d95f6300e5fea4e398ce )
+)
+
+game (
+	name "Dreamon Volume 10 (France)"
+	description "Dreamon Volume 10 (France)"
+	rom ( name "Dreamon Volume 10 (France).gdi" size 313 crc b7535963 md5 ffb5e47539f7878b41483167341efa18 sha1 cff041578d5cbc00a8ab58516702ec4021174bba )
+)
+
+game (
+	name "Dreamon Volume 10 (Germany) (En,Fr,De,Es)"
+	description "Dreamon Volume 10 (Germany) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 10 (Germany) (En,Fr,De,Es).gdi" size 388 crc 7a455848 md5 7d79e96b91bf29228e8c124bf413a8b7 sha1 fcd3da421de15c28ee8ecdafb27b9d5dd38703fe )
+)
+
+game (
+	name "Dreamon Volume 11 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 11 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 11 (Europe) (En,Fr,De,Es).gdi" size 383 crc d5cd6b25 md5 95460cf9b4476c1176727255aa28d54d sha1 28f622c5d1df9ead3a7180ebfa9e95e5cfd1761c )
+)
+
+game (
+	name "Dreamon Volume 12 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 12 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 12 (Europe) (En,Fr,De,Es).gdi" size 228 crc efe1322a md5 5e69e86e093d5bcc6225f9e82db549f6 sha1 f43ef1e8737c6b1f545ddea03f5bbd991067d27f )
+)
+
+game (
+	name "Dreamon Volume 13 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 13 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 13 (Europe) (En,Fr,De,Es).gdi" size 228 crc 0062a7fb md5 04821a1c85a438ac6f0612217c6b7cb9 sha1 134312e53c4a7a359977b37337da40071a743981 )
+)
+
+game (
+	name "Dreamon Volume 14 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 14 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 14 (Europe) (En,Fr,De,Es).gdi" size 383 crc 8c88fb29 md5 60a6194558290e872508fbb7bb9b7d2f sha1 39d6b9c1b7714adb6cc21b7f5ff9d5c61da01571 )
+)
+
+game (
+	name "Dreamon Volume 15 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 15 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 15 (Europe) (En,Fr,De,Es).gdi" size 611 crc 8a227571 md5 f3788470a8a00f7636decb42d79c9976 sha1 fe67a3e230a9cd6721898b5c33cade63c4a679ba )
+)
+
+game (
+	name "Dreamon Volume 16 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 16 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 16 (Europe) (En,Fr,De,Es).gdi" size 940 crc 54808283 md5 f14e7fe23dcb2d835afe4774aaa4d6b7 sha1 05ff983ccb14e00c3a284a095a4003bac74891a8 )
+)
+
+game (
+	name "Dreamon Volume 17 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 17 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 17 (Europe) (En,Fr,De,Es).gdi" size 535 crc 9cf726c0 md5 fb6c02920651b2b133dc5212b24265fa sha1 eb8115f39603de1392b4db68dbe978154b9f19f7 )
+)
+
+game (
+	name "Dreamon Volume 18 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 18 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 18 (Europe) (En,Fr,De,Es).gdi" size 228 crc fa4fa845 md5 6170f48d73a8369d3ecbc77be6bb1554 sha1 ff05e04286a4a515cda947387f775070d910d26e )
+)
+
+game (
+	name "Dreamon Volume 19 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 19 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 19 (Europe) (En,Fr,De,Es).gdi" size 383 crc 35dbc90a md5 2252b307ef03a02bc2020cc9362998fc sha1 3f2e44cac55d357e6634f7077a0e302bc9572895 )
+)
+
+game (
+	name "Dreamon Volume 2 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 2 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 2 (Europe) (En,Fr,De,Es).gdi" size 378 crc c8fca0ca md5 d98f490b0a97b433e0ef789c3b989442 sha1 6c8ef0cf1f3389f6f3d6808e598f07ac6d9173bd )
+)
+
+game (
+	name "Dreamon Volume 20 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 20 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 20 (Europe) (En,Fr,De,Es).gdi" size 228 crc 23abbbf1 md5 e8c1a75474ec4b2baf54b227952c6444 sha1 58799a8afea81f6b064863d99fc2c084ef121d80 )
+)
+
+game (
+	name "Dreamon Volume 21 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 21 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 21 (Europe) (En,Fr,De,Es).gdi" size 228 crc cc282e20 md5 2ee9d13fe54a99814416072c680b4c39 sha1 1b59b33b78b61ed55ffddbafb43db9ad7318ddd2 )
+)
+
+game (
+	name "Dreamon Volume 22 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 22 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 22 (Europe) (En,Fr,De,Es).gdi" size 228 crc 27dd9612 md5 4654bc384514673c958ec7aa26461de2 sha1 595332b99a0dcb14c6f9c6713bac21c49782be41 )
+)
+
+game (
+	name "Dreamon Volume 3 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 3 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 3 (Europe) (En,Fr,De,Es).gdi" size 378 crc 58dddccb md5 da996f99b041a75893abe9f1aef81793 sha1 8f20443aba633e55b94585ee832246b807579d99 )
+)
+
+game (
+	name "Dreamon Volume 4 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 4 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 4 (Europe) (En,Fr,De,Es).gdi" size 928 crc 68f336ab md5 c29d32893aad97593de0b26a45815a41 sha1 d85f38657f934985b457aa9ee2732a4c31b7621a )
+)
+
+game (
+	name "Dreamon Volume 5 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 5 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 5 (Europe) (En,Fr,De,Es).gdi" size 453 crc e80a1af9 md5 8d19dd9437945ab5285629e776b24a59 sha1 7cb1487bfc1a219acfd910a378d163db4cb73175 )
+)
+
+game (
+	name "Dreamon Volume 6 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 6 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 6 (Europe) (En,Fr,De,Es).gdi" size 225 crc 7de9a491 md5 b63f2ec4678f1093d2b6642fb03fd2b4 sha1 1447baf8d580e095e2a26753b6c036a8ca2ce41c )
+)
+
+game (
+	name "Dreamon Volume 7 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 7 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 7 (Europe) (En,Fr,De,Es).gdi" size 603 crc 305ce384 md5 291e9bddb87ebb95f1ae240574a018e9 sha1 16b8fac6a1be2ec0dd0c256139d782878a4c395b )
+)
+
+game (
+	name "Dreamon Volume 8 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 8 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 8 (Europe) (En,Fr,De,Es).gdi" size 225 crc 5c97af70 md5 fdc5aa9dfe5fe58714038c570b05bdb3 sha1 8717dae900d2700a25844829ca5f7324e12b753b )
+)
+
+game (
+	name "Dreamon Volume 9 (Europe) (En,Fr,De,Es)"
+	description "Dreamon Volume 9 (Europe) (En,Fr,De,Es)"
+	rom ( name "Dreamon Volume 9 (Europe) (En,Fr,De,Es).gdi" size 225 crc 6ae43ddb md5 d530af639a2f3c8cdc3305c693fb379b sha1 f4c545876b278a41f5c39dd37cc9e8e885974e07 )
+)
+
+game (
+	name "Ducati World - Racing Challenge (USA)"
+	description "Ducati World - Racing Challenge (USA)"
+	rom ( name "Ducati World - Racing Challenge (USA).gdi" size 1129 crc c835e154 md5 534994027b62fc5751e398abfb6b6916 sha1 fa1ad27664f90917e9eaebfdc8f8c4a041b57314 )
+)
+
+game (
+	name "Ducati World (Europe) (En,Fr,De,It)"
+	description "Ducati World (Europe) (En,Fr,De,It)"
+	rom ( name "Ducati World (Europe) (En,Fr,De,It).gdi" size 1099 crc 49bfcefc md5 fae7f3f8ec140d10fe0c712ebec7a0be sha1 9f2d64e4295b73bea7c680f2e76d92d4cd67ed03 )
+)
+
+game (
+	name "Dynamite Cop! (USA)"
+	description "Dynamite Cop! (USA)"
+	rom ( name "Dynamite Cop! (USA).gdi" size 165 crc 3307fb77 md5 724f2f300e537e3508df757a894b80b9 sha1 e9c103096fd4484d3a43749c02e64380f231d774 )
+)
+
+game (
+	name "Dynamite Deka 2 (Japan)"
+	description "Dynamite Deka 2 (Japan)"
+	rom ( name "Dynamite Deka 2 (Japan).gdi" size 177 crc 976ffb21 md5 9e57a8e826afc9811cde0635c5ff367b sha1 88b060654529e7f2730057db7d5ffca3b5e99b90 )
+)
+
+game (
+	name "Ecco the Dolphin - Defender of the Future (Europe) (En,Fr,De,Es)"
+	description "Ecco the Dolphin - Defender of the Future (Europe) (En,Fr,De,Es)"
+	rom ( name "Ecco the Dolphin - Defender of the Future (Europe) (En,Fr,De,Es).gdi" size 498 crc 6569e964 md5 3cc38e77374b39516f97f39b7cbaa991 sha1 b22e7708f59510b800f106e2299bf76e392bdd3c )
+)
+
+game (
+	name "Ecco the Dolphin - Defender of the Future (USA) (En,Fr,De,Es)"
+	description "Ecco the Dolphin - Defender of the Future (USA) (En,Fr,De,Es)"
+	rom ( name "Ecco the Dolphin - Defender of the Future (USA) (En,Fr,De,Es).gdi" size 483 crc 6430bf76 md5 11ebcec414b2c7f2148422433280c3d7 sha1 ed1a312227ff2990f0248b0893c2431f586cb756 )
+)
+
+game (
+	name "ECW Anarchy Rulz (Europe)"
+	description "ECW Anarchy Rulz (Europe)"
+	rom ( name "ECW Anarchy Rulz (Europe).gdi" size 308 crc b1583fac md5 d739dcf6f515c10eaea3f4e118a0d457 sha1 d21c44a2ae005666f751bcd32c58cfb10bd30b81 )
+)
+
+game (
+	name "ECW Anarchy Rulz (USA)"
+	description "ECW Anarchy Rulz (USA)"
+	rom ( name "ECW Anarchy Rulz (USA).gdi" size 293 crc 8f13f998 md5 77f94f1b75481bc49befda16f6fdef09 sha1 129ceaaa90d3a2fda5f6c9639d576075558532ad )
+)
+
+game (
+	name "ECW Hardcore Revolution (Europe)"
+	description "ECW Hardcore Revolution (Europe)"
+	rom ( name "ECW Hardcore Revolution (Europe).gdi" size 343 crc 590b20f6 md5 4b172ae81634a8bfcb61804154e53eae sha1 ae7a89e49cb79ae059b609d5a4e5bef104f40a89 )
+)
+
+game (
+	name "ECW Hardcore Revolution (USA)"
+	description "ECW Hardcore Revolution (USA)"
+	rom ( name "ECW Hardcore Revolution (USA).gdi" size 328 crc 71daf917 md5 01bb654e879eea54b72a64aa8811d8ca sha1 091394215c6820965c98b282ef2bf0ce900084a1 )
+)
+
+game (
+	name "Eisei Meijin III - Game Creator Yoshimura Nobuhiro no Zunou (Japan)"
+	description "Eisei Meijin III - Game Creator Yoshimura Nobuhiro no Zunou (Japan)"
+	rom ( name "Eisei Meijin III - Game Creator Yoshimura Nobuhiro no Zunou (Japan).gdi" size 1159 crc 50b61453 md5 dfadeb742a5faa1da82358fe4c8953cb sha1 5374d6912fd6190773bca76ad1488d974274f9cc )
+)
+
+game (
+	name "Espion-Age-nts (Japan)"
+	description "Espion-Age-nts (Japan)"
+	rom ( name "Espion-Age-nts (Japan).gdi" size 174 crc 1ecfbd54 md5 e4ac121cf7761bbb866b127c70ab767a sha1 2b38b666b9437f09a78a69e1a107672e00c6fcb0 )
+)
+
+game (
+	name "ESPN International Track & Field (Europe) (En,Fr,De)"
+	description "ESPN International Track & Field (Europe) (En,Fr,De)"
+	rom ( name "ESPN International Track & Field (Europe) (En,Fr,De).gdi" size 264 crc ba756aa4 md5 77b8b1ef4d0986a67363dd18e70abdd0 sha1 9eec7de2bfc9f683b3eed168ad5d9346f0af291b )
+)
+
+game (
+	name "ESPN International Track & Field (USA)"
+	description "ESPN International Track & Field (USA)"
+	rom ( name "ESPN International Track & Field (USA).gdi" size 222 crc 0666b279 md5 3163b32b035c70d9a9bc5c807e9184a5 sha1 32e783804b4863cb4c9dbfd4490ae504b43ba48e )
+)
+
+game (
+	name "ESPN NBA 2Night (USA)"
+	description "ESPN NBA 2Night (USA)"
+	rom ( name "ESPN NBA 2Night (USA).gdi" size 288 crc 91e7cb25 md5 0d8aa9a1cc86128eb40c31b5ca57612d sha1 84dbe9a19d6c22baa852ac27c101b74d0523ed36 )
+)
+
+game (
+	name "Eternal Arcadia (Japan) (Disc 1)"
+	description "Eternal Arcadia (Japan) (Disc 1)"
+	rom ( name "Eternal Arcadia (Japan) (Disc 1).gdi" size 204 crc 7b456cf2 md5 2e2b4fd6fa0345de6ed10f6790636230 sha1 fb63a4f6e9ace4562c0ec0ad3e7dc9b751a046bb )
+)
+
+game (
+	name "Eternal Arcadia (Japan) (Disc 2)"
+	description "Eternal Arcadia (Japan) (Disc 2)"
+	rom ( name "Eternal Arcadia (Japan) (Disc 2).gdi" size 204 crc 1c07504b md5 075d49d69ce9ea2d73b77980ee118f2e sha1 28e0875e9ce80e1b6701a39d75d4aad563bfbee8 )
+)
+
+game (
+	name "European Super League (Europe) (En,Fr,De,Es,It,Pt)"
+	description "European Super League (Europe) (En,Fr,De,Es,It,Pt)"
+	rom ( name "European Super League (Europe) (En,Fr,De,Es,It,Pt).gdi" size 258 crc 42d4cea3 md5 ce358061331383c4f2fb0b36b03e218c sha1 782cee05b800b8bc04368e5d4ada49ab20b5274a )
+)
+
+game (
+	name "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 1)"
+	description "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 1)"
+	rom ( name "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 1).gdi" size 273 crc cc5b0006 md5 867f1880cdde312195df28a66f3fb424 sha1 d738773e2aa79286f99114facff5d95fb3fbe522 )
+)
+
+game (
+	name "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 2)"
+	description "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 2)"
+	rom ( name "Eve Zero Kanzenban - Ark of the Matter (Japan) (Disc 2).gdi" size 273 crc 6f0effec md5 6a96e35fec27e6b03947ee6a7c80f309 sha1 9688b46221a5c3677b1a9ccb994eda36b2fc257f )
+)
+
+game (
+	name "Evil Dead - Hail to the King (France)"
+	description "Evil Dead - Hail to the King (France)"
+	rom ( name "Evil Dead - Hail to the King (France).gdi" size 363 crc a3b2f414 md5 c163119eeed675e92e4329f334aeb0f9 sha1 53de85f2c39b4d33d82376f4b73e40a4bbcb9767 )
+)
+
+game (
+	name "Evolution - The World of Sacred Device (Europe)"
+	description "Evolution - The World of Sacred Device (Europe)"
+	rom ( name "Evolution - The World of Sacred Device (Europe).gdi" size 249 crc 26cb8026 md5 9b6ece9dff6cddda03ef453d7f189379 sha1 32aab94566ab7bb9bba207ca7df7f8b74d86d0bb )
+)
+
+game (
+	name "Exodus Guilty Neos (Japan)"
+	description "Exodus Guilty Neos (Japan)"
+	rom ( name "Exodus Guilty Neos (Japan).gdi" size 308 crc b48900a5 md5 f33da4ae17d2e366299ad4438ec7d1d9 sha1 7f4ae1f84936f12b249c7bce77d92527da861e32 )
+)
+
+game (
+	name "Expendable (USA) (En,Fr,De,Es,It)"
+	description "Expendable (USA) (En,Fr,De,Es,It)"
+	rom ( name "Expendable (USA) (En,Fr,De,Es,It).gdi" size 1992 crc 6585ca38 md5 ef95f1505ff9b9b395d3148d5f0e40b4 sha1 d67f7d445846b9f1e1f222435f96c3f3efdb15c1 )
+)
+
+game (
+	name "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
+	description "F1 Racing Championship (Europe) (En,Fr,De,Es,It)"
+	rom ( name "F1 Racing Championship (Europe) (En,Fr,De,Es,It).gdi" size 1036 crc a3d73ad1 md5 ecea26b189a8ec760c13ceb726301424 sha1 00c360925e5e8b30ff68a1dfb1b35bcee546b02d )
+)
+
+game (
+	name "F1 World Grand Prix (Europe) (En,Fr,De,Es)"
+	description "F1 World Grand Prix (Europe) (En,Fr,De,Es)"
+	rom ( name "F1 World Grand Prix (Europe) (En,Fr,De,Es).gdi" size 1844 crc 6cf990be md5 a7ec685b85f79e71911591239df5a727 sha1 99ab99e2f022a781f7a93055dcc627e39309da65 )
+)
+
+game (
+	name "F355 Challenge - Passione Rossa (Europe) (En,Fr,De,Es,It)"
+	description "F355 Challenge - Passione Rossa (Europe) (En,Fr,De,Es,It)"
+	rom ( name "F355 Challenge - Passione Rossa (Europe) (En,Fr,De,Es,It).gdi" size 279 crc 6068b37e md5 48e4f60ce13b3aaecec875e89cd7857e sha1 4c24d4ab2a5567248af69ade887e8268fe65f684 )
+)
+
+game (
+	name "F355 Challenge - Passione Rossa (USA)"
+	description "F355 Challenge - Passione Rossa (USA)"
+	rom ( name "F355 Challenge - Passione Rossa (USA).gdi" size 219 crc c6685011 md5 33fadfea4d7becf3c94156154c29d7d3 sha1 7999a89442a4d9a5e2149792c02a461a1ebcd3fb )
+)
+
+game (
+	name "F355 Challenge (Japan)"
+	description "F355 Challenge (Japan)"
+	rom ( name "F355 Challenge (Japan).gdi" size 174 crc dcc3777a md5 d7b1f69690cd44ce016635c4b1b18515 sha1 28679b363a4a283d0a09d5f2f6f78c516859f693 )
+)
+
+game (
+	name "Fatal Fury - Mark of the Wolves (USA)"
+	description "Fatal Fury - Mark of the Wolves (USA)"
+	rom ( name "Fatal Fury - Mark of the Wolves (USA).gdi" size 368 crc 45d13c99 md5 4763985f34203b1526516bb066993d79 sha1 3a1dd9d73dc1a0c2e3486947c35bcc1baf26ccca )
+)
+
+game (
+	name "Fighting Force 2 (Europe) (En,Fr)"
+	description "Fighting Force 2 (Europe) (En,Fr)"
+	rom ( name "Fighting Force 2 (Europe) (En,Fr).gdi" size 417 crc 8bdd92ae md5 8a94c8311a21bcee3ce858b1463fa4d0 sha1 2a99dbbc227387883324d0f6b52e11cbfa1d219c )
+)
+
+game (
+	name "Fighting Force 2 (Germany)"
+	description "Fighting Force 2 (Germany)"
+	rom ( name "Fighting Force 2 (Germany).gdi" size 375 crc e572393d md5 83656cdb5b5cadeb08158ce71b37fcd7 sha1 0c795f28c22ef7d19a527a89ed466524d8ce3969 )
+)
+
+game (
+	name "Fighting Force 2 (USA)"
+	description "Fighting Force 2 (USA)"
+	rom ( name "Fighting Force 2 (USA).gdi" size 351 crc 3e2ae35b md5 f2513bda411a2119193abcedcc4f26c1 sha1 1baaa5ad41f911c8163094ee59d9da8b7a22cd38 )
+)
+
+game (
+	name "Fighting Vipers 2 (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Fighting Vipers 2 (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Fighting Vipers 2 (Europe) (En,Ja,Fr,De,Es,It).gdi" size 246 crc 7ec63c40 md5 eda977010c2240cef15e1657c32e3cb3 sha1 767d135338762a6164a5bfa510787ef2fd1dac11 )
+)
+
+game (
+	name "Fighting Vipers 2 (Japan) (En,Ja)"
+	description "Fighting Vipers 2 (Japan) (En,Ja)"
+	rom ( name "Fighting Vipers 2 (Japan) (En,Ja).gdi" size 207 crc 6904a5fa md5 776bcd06df23bf5947ffa4da30750bc5 sha1 3676dc34bdfe2a62ccdacfcfd353b1035b8da1d2 )
+)
+
+game (
+	name "Flag to Flag (USA)"
+	description "Flag to Flag (USA)"
+	rom ( name "Flag to Flag (USA).gdi" size 1348 crc 5827dff7 md5 a4004f484632ff4d8701a97d32ccbd85 sha1 15f3eb5049cf4f41d01ad59691c2fd4b8142c125 )
+)
+
+game (
+	name "Floigan Bros. - Episode 1 (Europe)"
+	description "Floigan Bros. - Episode 1 (Europe)"
+	rom ( name "Floigan Bros. - Episode 1 (Europe).gdi" size 353 crc 558ad632 md5 e8b1538b1aa7b38199b4f36a6271409e sha1 5c92806a8e38ea239ebaf7413effbbbaa6930966 )
+)
+
+game (
+	name "Freestyle Scooter (Europe)"
+	description "Freestyle Scooter (Europe)"
+	rom ( name "Freestyle Scooter (Europe).gdi" size 772 crc 54fd5e8e md5 d94939c39ad94c204f174e704ffe51fb sha1 d2a12b15c4b0c472835aa511347c3549d21343c8 )
+)
+
+game (
+	name "Frogger 2 - Swampy's Revenge (USA)"
+	description "Frogger 2 - Swampy's Revenge (USA)"
+	rom ( name "Frogger 2 - Swampy's Revenge (USA).gdi" size 353 crc 147934f9 md5 34f644dc17c8d7ad62eeab114bd8d803 sha1 4d869155f99ed319cf9384485a9996458bc2b76f )
+)
+
+game (
+	name "Fur Fighters (USA) (En,Fr,De,Es) (Rev B)"
+	description "Fur Fighters (USA) (En,Fr,De,Es) (Rev B)"
+	rom ( name "Fur Fighters (USA) (En,Fr,De,Es) (Rev B).gdi" size 228 crc 70d6d045 md5 f15d10d2dcfb2f94db3f990897d1f12a sha1 1cc99b6c5ffe2cc4922623ecefe8b0f2e30a48d0 )
+)
+
+game (
+	name "Fushigi no Dungeon - Fuurai no Shiren Gaiden - Onna Kenshi Asuka Kenzan! (Japan)"
+	description "Fushigi no Dungeon - Fuurai no Shiren Gaiden - Onna Kenshi Asuka Kenzan! (Japan)"
+	rom ( name "Fushigi no Dungeon - Fuurai no Shiren Gaiden - Onna Kenshi Asuka Kenzan! (Japan).gdi" size 583 crc d91912ca md5 511847b8a02d0757c8afecf7aa8d2b42 sha1 d585c8e91d4317a3766824f3a4b91516c3181ed1 )
+)
+
+game (
+	name "Ganbare! Nippon! Olympic 2000 (Japan)"
+	description "Ganbare! Nippon! Olympic 2000 (Japan)"
+	rom ( name "Ganbare! Nippon! Olympic 2000 (Japan).gdi" size 219 crc 875fab6f md5 1b6070c366f3096a0ed161856c6b43d8 sha1 83c69abbea2e0c1f2048933319fca25a10b1da1b )
+)
+
+game (
+	name "Gauntlet Legends (Europe) (En,Fr,De)"
+	description "Gauntlet Legends (Europe) (En,Fr,De)"
+	rom ( name "Gauntlet Legends (Europe) (En,Fr,De).gdi" size 363 crc ec229bb2 md5 1b445598e93e0fbd9999fc456214dde2 sha1 2e12c14d0914a3838e2fce041d98dbd1542a689e )
+)
+
+game (
+	name "Gauntlet Legends (USA)"
+	description "Gauntlet Legends (USA)"
+	rom ( name "Gauntlet Legends (USA).gdi" size 293 crc c75d0937 md5 fd488b23b08643ec79c174632661a080 sha1 36c15834d1a45403e0a11504fe0812e6533d7e01 )
+)
+
+game (
+	name "Generator Vol. 1 (USA)"
+	description "Generator Vol. 1 (USA)"
+	rom ( name "Generator Vol. 1 (USA).gdi" size 525 crc fda4375f md5 f3496c39425bbbdb81a6563d7c1b7018 sha1 a457e6ccf5465c31444af13bc1cc8642892c9663 )
+)
+
+game (
+	name "Get Bass (Japan)"
+	description "Get Bass (Japan)"
+	rom ( name "Get Bass (Japan).gdi" size 156 crc 5f3c7bba md5 f73048dfd37b60ca61355952e34d45a2 sha1 91abeb75237d22cf50b0cce55727ea18f65beedc )
+)
+
+game (
+	name "GigaWing (Japan)"
+	description "GigaWing (Japan)"
+	rom ( name "GigaWing (Japan).gdi" size 652 crc e0bcef1b md5 0d92435281a1ac3662ad8ed423e5258f sha1 ab9f7490242147b974794b2ccc3dee3c3fcc5219 )
+)
+
+game (
+	name "GigaWing (USA)"
+	description "GigaWing (USA)"
+	rom ( name "GigaWing (USA).gdi" size 628 crc 73693173 md5 e7917f91e5ef0eb595550f86f103589e sha1 2b69c0667e055bac757aeca201c073ca4030deee )
+)
+
+game (
+	name "GigaWing 2 (Japan)"
+	description "GigaWing 2 (Japan)"
+	rom ( name "GigaWing 2 (Japan).gdi" size 162 crc 267e5507 md5 361c0c693df9b6be58a9225dc5f17c42 sha1 e74dc4f153c9dbec50bae6514e7a5e0295bca01d )
+)
+
+game (
+	name "GigaWing 2 (USA)"
+	description "GigaWing 2 (USA)"
+	rom ( name "GigaWing 2 (USA).gdi" size 156 crc 4c880793 md5 60e68148db49b7fc47b9c38f920311ca sha1 7c7a08c52e64fb92b3cca37114d917f35400ef05 )
+)
+
+game (
+	name "GK - Giant Killers (Europe)"
+	description "GK - Giant Killers (Europe)"
+	rom ( name "GK - Giant Killers (Europe).gdi" size 318 crc 496ae1fb md5 8f8864819d7e60791e9ba5dcc0c6aeb3 sha1 a02e5cd84cafc9be24e9143beb34553e5d35ab36 )
+)
+
+game (
+	name "Golf Shiyouyo - Course Data Shuu - Adventure Hen (Japan)"
+	description "Golf Shiyouyo - Course Data Shuu - Adventure Hen (Japan)"
+	rom ( name "Golf Shiyouyo - Course Data Shuu - Adventure Hen (Japan).gdi" size 276 crc e233f401 md5 3f953f27c89ab87af812649675d1f627 sha1 f8420a5d2af711c7402ea4cb5fd81dcb7cf87c78 )
+)
+
+game (
+	name "Grand Theft Auto 2 (Europe) (En,Fr,De,Es,It)"
+	description "Grand Theft Auto 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Grand Theft Auto 2 (Europe) (En,Fr,De,Es,It).gdi" size 403 crc cb1fb1ee md5 be8804bebcbd6485575663fece2a9daa sha1 57ae2538cea2530107134d2c6aa01a1bf1fb3e62 )
+)
+
+game (
+	name "Grand Theft Auto 2 (USA)"
+	description "Grand Theft Auto 2 (USA)"
+	rom ( name "Grand Theft Auto 2 (USA).gdi" size 303 crc 76a7d336 md5 ac4049c4a5920845c31cd6e8b245577c sha1 b974e3112115ee3c8822f09a6acd718745650550 )
+)
+
+game (
+	name "Grandia II (Europe)"
+	description "Grandia II (Europe)"
+	rom ( name "Grandia II (Europe).gdi" size 273 crc 6bb24026 md5 0adb0a372f66d1a9513775087f427c37 sha1 f5b5d975c5419eb47219856d3f0b55ea9e309b3c )
+)
+
+game (
+	name "Grandia II (Japan)"
+	description "Grandia II (Japan)"
+	rom ( name "Grandia II (Japan).gdi" size 162 crc e690d3fa md5 3823adf91a3e089b01fcac446ebef0d6 sha1 95db68c0f32191467c24d027c07846a8b8292774 )
+)
+
+game (
+	name "Grinch, The (Europe) (En,Fr,De,Es,It)"
+	description "Grinch, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Grinch, The (Europe) (En,Fr,De,Es,It).gdi" size 368 crc 4eb93f30 md5 1cb01376fd2fb75093d7a73005cb46e6 sha1 e3fee2e0eafeac0c5fbe496b616b4e53a3d8c3bd )
+)
+
+game (
+	name "Grinch, The (USA) (En,Fr,Es)"
+	description "Grinch, The (USA) (En,Fr,Es)"
+	rom ( name "Grinch, The (USA) (En,Fr,Es).gdi" size 323 crc 64d2b309 md5 bbc1a0bf46c258c82e89c6f9c1b9ed3a sha1 033c46b2abbebd9f3c2846ff0e3c3f6279571063 )
+)
+
+game (
+	name "Guilty Gear X - By Your Side (Japan) (Rev A) (10M) (En)"
+	description "Guilty Gear X - By Your Side (Japan) (Rev A) (10M) (En)"
+	rom ( name "Guilty Gear X - By Your Side (Japan) (Rev A) (10M) (En).gdi" size 3538 crc 0a54d055 md5 5703830e35bf1372d3e879bdfc5b0535 sha1 012eab6e0f67d44c73db6b16d793282d833ff8a2 )
+)
+
+game (
+	name "Gunbird 2 (USA)"
+	description "Gunbird 2 (USA)"
+	rom ( name "Gunbird 2 (USA).gdi" size 153 crc 51cf65f0 md5 b00d7fd3a4bd7799f8ac92bba8006ebd sha1 1fb1f1b6b803c4bbc1c765006f9bb1ed8dd53780 )
+)
+
+game (
+	name "Gundam Battle Online (Japan)"
+	description "Gundam Battle Online (Japan)"
+	rom ( name "Gundam Battle Online (Japan).gdi" size 323 crc 2be47b3f md5 508d6d4fa499fa14626d5e43a6c989fd sha1 1ebc91f1cf08aa2c3df4165cb712b9a4f46b9a35 )
+)
+
+game (
+	name "Gundam Side Story 0079 - Rise from the Ashes (USA)"
+	description "Gundam Side Story 0079 - Rise from the Ashes (USA)"
+	rom ( name "Gundam Side Story 0079 - Rise from the Ashes (USA).gdi" size 258 crc 0475ef9b md5 801f1f2c611807aeb90a72b276ed4aad sha1 48691426aee29bd6dcf2ee86b3199802db3b6ded )
+)
+
+game (
+	name "Happy Lesson - First Lesson (Japan)"
+	description "Happy Lesson - First Lesson (Japan)"
+	rom ( name "Happy Lesson - First Lesson (Japan).gdi" size 213 crc c2741f08 md5 2bd201543279e0d6f98131a456d7678c sha1 dbc83f236c393a7f9355dd9dac100d08cff9aea7 )
+)
+
+game (
+	name "Harusame Youbi (Japan)"
+	description "Harusame Youbi (Japan)"
+	rom ( name "Harusame Youbi (Japan).gdi" size 174 crc 09d72a7d md5 b29d6604251f3f646a4700a19b0cdb07 sha1 78a837ad896e380e44738c47ca483cdd7c34aa07 )
+)
+
+game (
+	name "Heavy Metal - Geomatrix (Europe) (En,Fr,De,Es)"
+	description "Heavy Metal - Geomatrix (Europe) (En,Fr,De,Es)"
+	rom ( name "Heavy Metal - Geomatrix (Europe) (En,Fr,De,Es).gdi" size 246 crc bd3c578e md5 8f3836a53754590527481f57ad904705 sha1 fc06e5d3dec6c41f0d25162dad8ad806d0e4e3c1 )
+)
+
+game (
+	name "Heavy Metal - Geomatrix (USA)"
+	description "Heavy Metal - Geomatrix (USA)"
+	rom ( name "Heavy Metal - Geomatrix (USA).gdi" size 195 crc e34c0031 md5 6963348c80fb7e9934a9d281679df6d0 sha1 99eb0b71cd913b1b1dc3e041bc21568a21ea32dd )
+)
+
+game (
+	name "Hello Kitty - Garden Panic (Japan)"
+	description "Hello Kitty - Garden Panic (Japan)"
+	rom ( name "Hello Kitty - Garden Panic (Japan).gdi" size 210 crc 28651dcc md5 c334930cafbae085e28d705b49235ea5 sha1 a4e331e7aabcba6c236800a6b71ca23d036b6912 )
+)
+
+game (
+	name "Hidden & Dangerous (Europe) (En,Fr,De,Es)"
+	description "Hidden & Dangerous (Europe) (En,Fr,De,Es)"
+	rom ( name "Hidden & Dangerous (Europe) (En,Fr,De,Es).gdi" size 388 crc 090bb46c md5 383a7a11d263313d8c4c119dc35b3afb sha1 e8acaa6bd6e3d7b7ad0996292f2e2a0a54da39fc )
+)
+
+game (
+	name "House of the Dead 2, The (Europe) (En,Fr,De,Es)"
+	description "House of the Dead 2, The (Europe) (En,Fr,De,Es)"
+	rom ( name "House of the Dead 2, The (Europe) (En,Fr,De,Es).gdi" size 249 crc ffafb154 md5 1a4591e29c3f6bf64ff45bcfb9d5ff7e sha1 8bbf61945ee7fa320910098aa934fcaea5ac6d14 )
+)
+
+game (
+	name "House of the Dead 2, The (Japan)"
+	description "House of the Dead 2, The (Japan)"
+	rom ( name "House of the Dead 2, The (Japan).gdi" size 204 crc 466bb29a md5 1636f57575cc4ceefecd71f691d6178a sha1 2fb8d5d7a49fd26b9858fde2e53bf4c052501c36 )
+)
+
+game (
+	name "House of the Dead 2, The (USA)"
+	description "House of the Dead 2, The (USA)"
+	rom ( name "House of the Dead 2, The (USA).gdi" size 198 crc 53495e2c md5 cf444c4e0ffdaebceaa0ec731974e9b7 sha1 798541418cc3967e747dac63f1d9fea62e606772 )
+)
+
+game (
+	name "Hydro Thunder (Europe)"
+	description "Hydro Thunder (Europe)"
+	rom ( name "Hydro Thunder (Europe).gdi" size 2224 crc 2e64e72c md5 80573bdbaa208d25e16964e1911c99ad sha1 6971b4b9b896ad9becd144c9a15bb8926af56d9f )
+)
+
+game (
+	name "Hydro Thunder (USA)"
+	description "Hydro Thunder (USA)"
+	rom ( name "Hydro Thunder (USA).gdi" size 2113 crc 27ac7728 md5 bc76929919c7579352b43f5153af2a1e sha1 e37c539cca443c7a7215214c8ce52a0709f65f0d )
+)
+
+game (
+	name "Hydro Thunder (USA) (Rev A)"
+	description "Hydro Thunder (USA) (Rev A)"
+	rom ( name "Hydro Thunder (USA) (Rev A).gdi" size 2409 crc 86bdc2bf md5 d8bf6454f9a02f84828b7ff942a2774f sha1 8a202f45570aedd9df35d556c863e6263e3b7c3b )
+)
+
+game (
+	name "Ikaruga (Japan)"
+	description "Ikaruga (Japan)"
+	rom ( name "Ikaruga (Japan).gdi" size 153 crc c08c1b3b md5 6eedc180dbab97f72ebb0df175a3d233 sha1 3a777281def35b8cd3f471714c42a103b388db61 )
+)
+
+game (
+	name "Internet Browser V3.0 for Dreamcast (USA)"
+	description "Internet Browser V3.0 for Dreamcast (USA)"
+	rom ( name "Internet Browser V3.0 for Dreamcast (USA).gdi" size 231 crc 4182ac1c md5 29ecf4320196abe7e639ac34eb49aab3 sha1 5a0de3b24e4c96d6b3a0d2de84e042cf146906b1 )
+)
+
+game (
+	name "Iron Aces (Europe)"
+	description "Iron Aces (Europe)"
+	rom ( name "Iron Aces (Europe).gdi" size 162 crc 41244380 md5 182bb755b5be0bdf443ce41c6b9931be sha1 d7765567fd60275ec398a29f22e7d6e650d32e90 )
+)
+
+game (
+	name "J. League Pro Soccer Club o Tsukurou! (Japan)"
+	description "J. League Pro Soccer Club o Tsukurou! (Japan)"
+	rom ( name "J. League Pro Soccer Club o Tsukurou! (Japan).gdi" size 403 crc 53f958b6 md5 d0cbcd0f60d63d70152ca602719f4eed sha1 bde70c051dea704f5a060129bba2c36791b94a75 )
+)
+
+game (
+	name "Jeremy McGrath Supercross 2000 (Europe) (En,Fr,De)"
+	description "Jeremy McGrath Supercross 2000 (Europe) (En,Fr,De)"
+	rom ( name "Jeremy McGrath Supercross 2000 (Europe) (En,Fr,De).gdi" size 433 crc 199a382d md5 0c9f0a32ebda66c7bbc8938eff45f1d5 sha1 e675ba469a33719f858bddceffda88fc1e3da25b )
+)
+
+game (
+	name "Jet Grind Radio (USA)"
+	description "Jet Grind Radio (USA)"
+	rom ( name "Jet Grind Radio (USA).gdi" size 171 crc 2d1d008d md5 fb6258660fd68586d9f8ec0ce04b3c10 sha1 bf7f8d2131ba8a0ca2d4ec7e367425adb28c2e0a )
+)
+
+game (
+	name "Jet Set Radio (Europe) (En,Fr,De,Es)"
+	description "Jet Set Radio (Europe) (En,Fr,De,Es)"
+	rom ( name "Jet Set Radio (Europe) (En,Fr,De,Es).gdi" size 216 crc 053b1695 md5 71bd923bcd6c5f3d39d3ca93056fb8de sha1 c69ff92e4e76d88ce197c00d22c463a68edc7d82 )
+)
+
+game (
+	name "Jet Set Radio (Japan)"
+	description "Jet Set Radio (Japan)"
+	rom ( name "Jet Set Radio (Japan).gdi" size 171 crc 52b1b591 md5 c95bfcaba178e52bc30a560611595845 sha1 06158ea50b77fbc5b8347485b9c812cbd929f68c )
+)
+
+game (
+	name "Jimmy White's 2 - Cueball (Europe) (En,Fr,De,Es,It)"
+	description "Jimmy White's 2 - Cueball (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Jimmy White's 2 - Cueball (Europe) (En,Fr,De,Es,It).gdi" size 261 crc cc714840 md5 b3543774a0b4372a35631b6ac7020ef3 sha1 9466c7895f17d7979a1c6f808c95167d6f8d728c )
+)
+
+game (
+	name "Jissen Pachi-Slot Hisshouhou! @VPACHI Kingdom (Japan)"
+	description "Jissen Pachi-Slot Hisshouhou! @VPACHI Kingdom (Japan)"
+	rom ( name "Jissen Pachi-Slot Hisshouhou! @VPACHI Kingdom (Japan).gdi" size 267 crc 67a313e2 md5 e730ac65dbd2f57d22c7bd39a8a56977 sha1 3a23ae6f1bff221cccc459b8431e5496dbfc464e )
+)
+
+game (
+	name "Jojo no Kimyou na Bouken - Mirai he no Isan (Japan)"
+	description "Jojo no Kimyou na Bouken - Mirai he no Isan (Japan)"
+	rom ( name "Jojo no Kimyou na Bouken - Mirai he no Isan (Japan).gdi" size 261 crc 90b302a9 md5 06c04611c17fa8ec70829294eaa81cb2 sha1 6eabac8a514e948ccb3e23d457548699b1c74a08 )
+)
+
+game (
+	name "JoJo's Bizarre Adventure (USA)"
+	description "JoJo's Bizarre Adventure (USA)"
+	rom ( name "JoJo's Bizarre Adventure (USA).gdi" size 198 crc abdd27f1 md5 33078e86555b665891f0db2be030ac5b sha1 ac14d7b41d1db64a8ce9116e6e4173b78c85c710 )
+)
+
+game (
+	name "July (Japan)"
+	description "July (Japan)"
+	rom ( name "July (Japan).gdi" size 144 crc c2eb1aa6 md5 0333720170fd0a6ab76a65dbbd4813a1 sha1 b7d7365ba9a44f955f6d26a2ddc99532fb2c2a38 )
+)
+
+game (
+	name "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 1)"
+	description "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 1)"
+	rom ( name "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 1).gdi" size 261 crc 59ecc034 md5 609566d99e5b1e5db73c1b2145cc6994 sha1 5b73251d478740619d98e18d2da51fd30d8f4bf1 )
+)
+
+game (
+	name "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 2)"
+	description "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 2)"
+	rom ( name "Kaen Seibo - The Virgin on Megiddo (Japan) (Disc 2).gdi" size 261 crc 9c833b95 md5 d24440a6d473a2c2d0ee879981ba43ac sha1 bf61a61a680014db87001ef037140ea8bbf1cc65 )
+)
+
+game (
+	name "Kao the Kangaroo (Europe) (En,Fr,De,Es,It)"
+	description "Kao the Kangaroo (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kao the Kangaroo (Europe) (En,Fr,De,Es,It).gdi" size 4644 crc cc2c4d87 md5 85be72bbb18aa72ce13089c54459c0f6 sha1 bfb64c938c019cd43d60216cdaa895191e76cbd5 )
+)
+
+game (
+	name "Kao the Kangaroo (USA) (En,Es)"
+	description "Kao the Kangaroo (USA) (En,Es)"
+	rom ( name "Kao the Kangaroo (USA) (En,Es).gdi" size 3948 crc c4f286fa md5 3baaff9c6b22ff71ba505b35c6c9118d sha1 0d051c94310377edb5e53f73c9850a28e31597aa )
+)
+
+game (
+	name "King of Fighters 2000, The (Japan)"
+	description "King of Fighters 2000, The (Japan)"
+	rom ( name "King of Fighters 2000, The (Japan).gdi" size 353 crc af4d622c md5 e9fd0560f1a1d302bb511454f7886c48 sha1 608b4e649293ed2c8e36c62ac419a59bed772362 )
+)
+
+game (
+	name "King of Fighters, The - Dream Match 1999 (Japan) (En,Ja,Es,Pt)"
+	description "King of Fighters, The - Dream Match 1999 (Japan) (En,Ja,Es,Pt)"
+	rom ( name "King of Fighters, The - Dream Match 1999 (Japan) (En,Ja,Es,Pt).gdi" size 4304 crc d72a8c2d md5 d709dfccf9687114ed34c64be0b9330c sha1 a804912162ec05eb7c23c102fa4d3b3b155e017f )
+)
+
+game (
+	name "King of Fighters, The - Dream Match 1999 (USA) (En,Ja,Es,Pt)"
+	description "King of Fighters, The - Dream Match 1999 (USA) (En,Ja,Es,Pt)"
+	rom ( name "King of Fighters, The - Dream Match 1999 (USA) (En,Ja,Es,Pt).gdi" size 4218 crc 0f8c69c4 md5 30b31fac4354208cf39f16596d37c88c sha1 78bcf704daa8948fe033ea4e5fa1855a29014cad )
+)
+
+game (
+	name "King of Fighters, The - Evolution (USA) (En,Ja,Es,Pt)"
+	description "King of Fighters, The - Evolution (USA) (En,Ja,Es,Pt)"
+	rom ( name "King of Fighters, The - Evolution (USA) (En,Ja,Es,Pt).gdi" size 267 crc 19e79f02 md5 dba5230aa0878fdc9910426633dc0f1c sha1 740de5e3fb08f2cf21ee8595fea042a0003291be )
+)
+
+game (
+	name "Kita e. - White Illumination (Japan)"
+	description "Kita e. - White Illumination (Japan)"
+	rom ( name "Kita e. - White Illumination (Japan).gdi" size 216 crc d288ad73 md5 812a29402d0e282907c318c0c1a652b3 sha1 6fce4751da9c489340e6a1070577b46ed2e2a67a )
+)
+
+game (
+	name "Kiteretsu Boy's Gangagan (Japan)"
+	description "Kiteretsu Boy's Gangagan (Japan)"
+	rom ( name "Kiteretsu Boy's Gangagan (Japan).gdi" size 204 crc 3af3da1e md5 8e4f01375ca001e365a8d3c900bd5ea7 sha1 40d0db6e55632f99030f5511a690cbd580e97ccd )
+)
+
+game (
+	name "Konohana - True Report (Japan)"
+	description "Konohana - True Report (Japan)"
+	rom ( name "Konohana - True Report (Japan).gdi" size 333 crc 472a7c7f md5 3bcaec05ada8fbe0ae491533c238758f sha1 b8a420d52b1c08775a0c0a28b81fd35f60940fec )
+)
+
+game (
+	name "Konohana 2 - Todokanai Requiem (Japan)"
+	description "Konohana 2 - Todokanai Requiem (Japan)"
+	rom ( name "Konohana 2 - Todokanai Requiem (Japan).gdi" size 373 crc eef56f41 md5 d07bd707424783f38009df74c254481b sha1 83ed3adab27026fde463d931be27d3d89eb1a6be )
+)
+
+game (
+	name "Kuon no Kizuna - Sairinshou (Japan)"
+	description "Kuon no Kizuna - Sairinshou (Japan)"
+	rom ( name "Kuon no Kizuna - Sairinshou (Japan).gdi" size 213 crc 15a72083 md5 d69166a13e25d38d1ced8d073cdf6095 sha1 11adefaee37cdc46964081e39f4617971e1ceab8 )
+)
+
+game (
+	name "Last Blade 2, The - Heart of the Samurai (USA)"
+	description "Last Blade 2, The - Heart of the Samurai (USA)"
+	rom ( name "Last Blade 2, The - Heart of the Samurai (USA).gdi" size 408 crc 3811af0f md5 0e5ce4c38423426bd9c857bddde44100 sha1 50365ac150787805ffacb50fa86ccb50d03b5812 )
+)
+
+game (
+	name "Legacy of Kain - Soul Reaver (Europe)"
+	description "Legacy of Kain - Soul Reaver (Europe)"
+	rom ( name "Legacy of Kain - Soul Reaver (Europe).gdi" size 368 crc 470b21ec md5 ce8473af9b73770757742c54886db8ad sha1 dd0f79d7769dbf8ceb91ead30f528cf1499ce132 )
+)
+
+game (
+	name "Legacy of Kain - Soul Reaver (France)"
+	description "Legacy of Kain - Soul Reaver (France)"
+	rom ( name "Legacy of Kain - Soul Reaver (France).gdi" size 368 crc f288bd42 md5 bd009f136ed8458aaf5da3085bb63df6 sha1 f813357141a6c9e16225f53e3d3d9ec3a84709b4 )
+)
+
+game (
+	name "Legacy of Kain - Soul Reaver (Germany)"
+	description "Legacy of Kain - Soul Reaver (Germany)"
+	rom ( name "Legacy of Kain - Soul Reaver (Germany).gdi" size 373 crc 71de6e17 md5 3b472d7e69ed765f82f5abd4de667651 sha1 13b880169e8b40a5eeec3254842db91c0968d4b4 )
+)
+
+game (
+	name "Legacy of Kain - Soul Reaver (USA)"
+	description "Legacy of Kain - Soul Reaver (USA)"
+	rom ( name "Legacy of Kain - Soul Reaver (USA).gdi" size 353 crc af938fd5 md5 b8e45f108f4c3d7b350de71ea6600ad4 sha1 71b9445d6e8229bd09248370bf90e157b21eae13 )
+)
+
+game (
+	name "Lodoss Tou Senki - Jashin Kourin (Japan)"
+	description "Lodoss Tou Senki - Jashin Kourin (Japan)"
+	rom ( name "Lodoss Tou Senki - Jashin Kourin (Japan).gdi" size 383 crc 63aca56c md5 e700431d84f0e6c77f7953f0bde4aefd sha1 4c3055916ef12b13a1898b6a862b65a77b07a312 )
+)
+
+game (
+	name "Love Hina - Smile Again (Japan)"
+	description "Love Hina - Smile Again (Japan)"
+	rom ( name "Love Hina - Smile Again (Japan).gdi" size 201 crc 57c73c75 md5 0dfa3dc31d20888bd5885d24ede696f0 sha1 3e266d6c2932f64eb8c20a91de03c154b7a25cb8 )
+)
+
+game (
+	name "MagForce Racing (Europe) (En,Fr,De,Es,It)"
+	description "MagForce Racing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "MagForce Racing (Europe) (En,Fr,De,Es,It).gdi" size 1031 crc c3f67654 md5 46f8d8c7c9e28603c104a6a40d8c727e sha1 ae30fc9fcdd9c8bccaf3b1d9da56855cdacb91b5 )
+)
+
+game (
+	name "MagForce Racing (USA) (En,Fr,De,Es,It)"
+	description "MagForce Racing (USA) (En,Fr,De,Es,It)"
+	rom ( name "MagForce Racing (USA) (En,Fr,De,Es,It).gdi" size 992 crc 9e21f7aa md5 e9a91c3f9558e8ac3516fc680fcc95bd sha1 67d14b2a7063063794e4d47c901a88278a57320b )
+)
+
+game (
+	name "Magic - The Gathering (Japan)"
+	description "Magic - The Gathering (Japan)"
+	rom ( name "Magic - The Gathering (Japan).gdi" size 393 crc b71cf3d7 md5 18dcb25b05093eb97843a015cdae5ab7 sha1 e673db06b1d7fc9db961ee969b85113e3b67ef7f )
+)
+
+game (
+	name "Maken X (Japan)"
+	description "Maken X (Japan)"
+	rom ( name "Maken X (Japan).gdi" size 453 crc 624c8059 md5 db00117bedff02e4e4896c5b9c30f978 sha1 9aa360f6e9420686d73c96d5af13450d1d4011fe )
+)
+
+game (
+	name "Maken X (USA)"
+	description "Maken X (USA)"
+	rom ( name "Maken X (USA).gdi" size 435 crc 47f773dd md5 c13b656430a5a0e9f98dc02545e0dd27 sha1 3581c735505a73b417202bfe5e3434e036c874b8 )
+)
+
+game (
+	name "Mars Matrix (USA)"
+	description "Mars Matrix (USA)"
+	rom ( name "Mars Matrix (USA).gdi" size 159 crc 07e09025 md5 8fcbe46b0466a7ce8c6e97250364e2f6 sha1 f27976909dbb80ace9aea22c90da861b9e6f3501 )
+)
+
+game (
+	name "Marvel vs. Capcom - Clash of Super Heroes (Europe)"
+	description "Marvel vs. Capcom - Clash of Super Heroes (Europe)"
+	rom ( name "Marvel vs. Capcom - Clash of Super Heroes (Europe).gdi" size 258 crc b2d74943 md5 c0a1fec21cf917b603ee9e2bf00dd439 sha1 8d20496caedd5e1dd7ead0be60b43a4b67fa6e6d )
+)
+
+game (
+	name "Marvel vs. Capcom - Clash of Super Heroes (Japan)"
+	description "Marvel vs. Capcom - Clash of Super Heroes (Japan)"
+	rom ( name "Marvel vs. Capcom - Clash of Super Heroes (Japan).gdi" size 255 crc fe04cada md5 78653109a6bc3e7dd8e3897fbf0f8366 sha1 720b5bcaa5d62caca8cda03b14be08d0a4512cc0 )
+)
+
+game (
+	name "Marvel vs. Capcom - Clash of Super Heroes (USA)"
+	description "Marvel vs. Capcom - Clash of Super Heroes (USA)"
+	rom ( name "Marvel vs. Capcom - Clash of Super Heroes (USA).gdi" size 249 crc 1a9adf80 md5 b1f20d5d8b09c5c1e809223e1e741413 sha1 475fc0e0a662628f14ee9e6767ea7b0bc1527aa9 )
+)
+
+game (
+	name "Max Steel - Covert Missions (USA)"
+	description "Max Steel - Covert Missions (USA)"
+	rom ( name "Max Steel - Covert Missions (USA).gdi" size 348 crc 6672c6bf md5 11ae69491faeb0ad6ec7342c6ec15336 sha1 cc6b2a7d6dbcc1a6961e08c8170e73480d8d22a4 )
+)
+
+game (
+	name "Maximum Pool (USA)"
+	description "Maximum Pool (USA)"
+	rom ( name "Maximum Pool (USA).gdi" size 273 crc 7e5990c5 md5 8c0cdd19c827fb59b36c2b571460b02b sha1 e0141c5493b6c234e7c4928664a7c175636be673 )
+)
+
+game (
+	name "MDK2 (Europe) (En,Fr,De,Es,It)"
+	description "MDK2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "MDK2 (Europe) (En,Fr,De,Es,It).gdi" size 2112 crc 42f30dd8 md5 37a44aaf1282f0027b9dcc691d7408c8 sha1 380e375ad597e53298de245f9fc8dd1aaced6327 )
+)
+
+game (
+	name "MDK2 (USA)"
+	description "MDK2 (USA)"
+	rom ( name "MDK2 (USA).gdi" size 1492 crc b95db5bf md5 74218beb39cdc5a3e20ec94644512366 sha1 f44827208c569edfa95d00a1360c79f392375579 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits - Volume 1 (Europe)"
+	description "Midway's Greatest Arcade Hits - Volume 1 (Europe)"
+	rom ( name "Midway's Greatest Arcade Hits - Volume 1 (Europe).gdi" size 428 crc 5965472b md5 250b85d16e6b9583e094afaece327062 sha1 20c82c124c21cb7a1a37eab5108146a54e95acf8 )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits - Volume 1 (USA)"
+	description "Midway's Greatest Arcade Hits - Volume 1 (USA)"
+	rom ( name "Midway's Greatest Arcade Hits - Volume 1 (USA).gdi" size 413 crc 5efdaffc md5 d52f726b27cc0eca8c6760ff18724a14 sha1 eae31fbcd3b2a12e9112d2a7374ee8ed67db7e9d )
+)
+
+game (
+	name "Midway's Greatest Arcade Hits - Volume 2 (USA)"
+	description "Midway's Greatest Arcade Hits - Volume 2 (USA)"
+	rom ( name "Midway's Greatest Arcade Hits - Volume 2 (USA).gdi" size 2524 crc d7dcea21 md5 a5f05ee6171bd303be7c9a39f8c2d2ef sha1 763dcf78decc9c7a13b155c3d3a3b029614f09c6 )
+)
+
+game (
+	name "Millennium Soldier - Expendable (Europe) (En,Fr,De,Es,It)"
+	description "Millennium Soldier - Expendable (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Millennium Soldier - Expendable (Europe) (En,Fr,De,Es,It).gdi" size 2664 crc 800752a5 md5 6319e579ca211fb1a285328e33326aba sha1 71bb895fca42af20cb391066e7f0c8732850d9f4 )
+)
+
+game (
+	name "Missing Parts - The Tantei Stories (Japan)"
+	description "Missing Parts - The Tantei Stories (Japan)"
+	rom ( name "Missing Parts - The Tantei Stories (Japan).gdi" size 234 crc f0c8212d md5 dc510d434b4b25bd0e86d6f45be5507c sha1 d06e172fd952c9ad6d4b3dc2749ce8430788be4a )
+)
+
+game (
+	name "Missing Parts 2 - The Tantei Stories (Japan)"
+	description "Missing Parts 2 - The Tantei Stories (Japan)"
+	rom ( name "Missing Parts 2 - The Tantei Stories (Japan).gdi" size 240 crc 5687e3c9 md5 afbf9c75bdc23b4b1bd10c16af13b62c sha1 768e12065c8260c679e133fae7b3b648b57ca555 )
+)
+
+game (
+	name "Missing Parts 3 - The Tantei Stories (Japan)"
+	description "Missing Parts 3 - The Tantei Stories (Japan)"
+	rom ( name "Missing Parts 3 - The Tantei Stories (Japan).gdi" size 240 crc 0ec46a97 md5 7d32c6757ce101d8d46c645684f859e7 sha1 ea5eab948cce3806074a1dfc30390eaa08519799 )
+)
+
+game (
+	name "Monaco Grand Prix Racing Simulation 2 (Japan)"
+	description "Monaco Grand Prix Racing Simulation 2 (Japan)"
+	rom ( name "Monaco Grand Prix Racing Simulation 2 (Japan).gdi" size 1830 crc 36a077f2 md5 e8b2baf51750912e18f02baa9e1d6d52 sha1 2a26374a4bf150198057910cfeee62c94d17523f )
+)
+
+game (
+	name "Mortal Kombat Gold (Europe)"
+	description "Mortal Kombat Gold (Europe)"
+	rom ( name "Mortal Kombat Gold (Europe).gdi" size 3449 crc 2d82bbee md5 81cdc75ff8dd6a70dffd8febd36a5d51 sha1 e9d621458236379dcc88c083de21dbcd6b7ea99a )
+)
+
+game (
+	name "Mortal Kombat Gold (USA)"
+	description "Mortal Kombat Gold (USA)"
+	rom ( name "Mortal Kombat Gold (USA).gdi" size 3290 crc 5cb78e18 md5 dd8313ce26ad9480acb4d36794a84dc6 sha1 d5d0e5cf4c7ad6ca2bc9ed1609864cdca5552c53 )
+)
+
+game (
+	name "Mr. Driller (Europe) (En,Fr,De,Es,It)"
+	description "Mr. Driller (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mr. Driller (Europe) (En,Fr,De,Es,It).gdi" size 2179 crc 7f9c3c87 md5 6f4771125b53ec43b74f9d710770876a sha1 c5108043b378b7715fc509b7818e6e929b1a2f13 )
+)
+
+game (
+	name "Mr. Driller (Japan)"
+	description "Mr. Driller (Japan)"
+	rom ( name "Mr. Driller (Japan).gdi" size 1657 crc 6ee2b8f3 md5 416bf930cf5cc93f8ab1825fd710a3cd sha1 7f20eac6848012ed6c2264e577f7ff93b098fc31 )
+)
+
+game (
+	name "Mr. Driller (USA)"
+	description "Mr. Driller (USA)"
+	rom ( name "Mr. Driller (USA).gdi" size 1599 crc 463c2771 md5 e043043f0366ef311e422ad736ef5a64 sha1 abed7cb706652032e87daccbe9277481f56edb14 )
+)
+
+game (
+	name "Ms. Pac-Man Maze Madness (USA)"
+	description "Ms. Pac-Man Maze Madness (USA)"
+	rom ( name "Ms. Pac-Man Maze Madness (USA).gdi" size 1296 crc 63323e0b md5 eded247c47664f92789a75b0948e048b sha1 db74f22d24f97c11087ced0e05501c93ba494e9b )
+)
+
+game (
+	name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es)"
+	description "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es)"
+	rom ( name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es).gdi" size 264 crc e7e3cb82 md5 d190f7e4b7827ae11e02289100654378 sha1 b6b35651698d82c0cd397adf6a92889b8bd0b6a6 )
+)
+
+game (
+	name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev A)"
+	description "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev A)"
+	rom ( name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev A).gdi" size 288 crc 041a597b md5 e35aefd02f1d1017586345f34f28459c sha1 e2c436e5d02b401134b822028b598fb60a225049 )
+)
+
+game (
+	name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev B)"
+	description "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev B)"
+	rom ( name "MSR - Metropolis Street Racer (Europe) (En,Fr,De,Es) (Rev B).gdi" size 288 crc 82e8ef68 md5 38b15fdf5b7bd6b47d3f493c67705678 sha1 bbf4d76ce89ee8c6495578318b0555ffbdf2f568 )
+)
+
+game (
+	name "MSR - Metropolis Street Racer (USA) (Rev. A)"
+	description "MSR - Metropolis Street Racer (USA) (Rev. A)"
+	rom ( name "MSR - Metropolis Street Racer (USA) (Rev. A).gdi" size 240 crc 74eb8599 md5 5c6cf3abaff0ba23c611ebcdefd196c2 sha1 1dec93bfd92e86b0feb3d2b3ccbfe5a45a7245df )
+)
+
+game (
+	name "MTV Sports - Skateboarding featuring Andy Macdonald (Europe)"
+	description "MTV Sports - Skateboarding featuring Andy Macdonald (Europe)"
+	rom ( name "MTV Sports - Skateboarding featuring Andy Macdonald (Europe).gdi" size 483 crc b158eb47 md5 75cfe3d8aec7fa40e8d3eeb7f7e1ff95 sha1 1ef8aa835ec4fad81ed14a2d678cd9220b25eed8 )
+)
+
+game (
+	name "MTV Sports - Skateboarding featuring Andy Macdonald (USA)"
+	description "MTV Sports - Skateboarding featuring Andy Macdonald (USA)"
+	rom ( name "MTV Sports - Skateboarding featuring Andy Macdonald (USA).gdi" size 468 crc 66ba5fe1 md5 43f13143d0cdf6321ec37c62b9837028 sha1 e7490b6bdc877b5466c50e6cc2857ef5377f5dd5 )
+)
+
+game (
+	name "Namco Museum (USA)"
+	description "Namco Museum (USA)"
+	rom ( name "Namco Museum (USA).gdi" size 273 crc f841d1e2 md5 b2f5203e57b0bc2255750666cfb7507e sha1 ebcd6d8e97aab25e709f93020b6b88d7a722fb0c )
+)
+
+game (
+	name "NBA 2K (Europe) (En,Fr,De,Es)"
+	description "NBA 2K (Europe) (En,Fr,De,Es)"
+	rom ( name "NBA 2K (Europe) (En,Fr,De,Es).gdi" size 323 crc e1fe4336 md5 5263910009a63d21b40d9938135e86dd sha1 09cb521691d871103e36014979198ba9e467c319 )
+)
+
+game (
+	name "NBA 2K (Japan)"
+	description "NBA 2K (Japan)"
+	rom ( name "NBA 2K (Japan).gdi" size 253 crc 6f61ec86 md5 138e51b52ae20f8df83b86862aac1c8c sha1 f25dff59579b98e6acfe7bd2ebe662c3c5959e13 )
+)
+
+game (
+	name "NBA 2K (USA)"
+	description "NBA 2K (USA)"
+	rom ( name "NBA 2K (USA).gdi" size 243 crc 82f434c5 md5 e6ee6bdfb8edc541f671c89ebfc594a0 sha1 4b7036e23f0e2cf542759e361323ce97178ea718 )
+)
+
+game (
+	name "NBA 2K1 (USA)"
+	description "NBA 2K1 (USA)"
+	rom ( name "NBA 2K1 (USA).gdi" size 248 crc 5b717af3 md5 ee9c0baf7ad4d8bbfb82e19a4dcdff92 sha1 5375a5195d839830fbd4d5f76f98990aeed35805 )
+)
+
+game (
+	name "NBA 2K2 (Europe)"
+	description "NBA 2K2 (Europe)"
+	rom ( name "NBA 2K2 (Europe).gdi" size 263 crc e80bd14e md5 acd6cbb8439f58ae077c6859fa8ee042 sha1 61cc3e9fbfb242648fd17fd95b2769c0d85df68c )
+)
+
+game (
+	name "NBA 2K2 (USA)"
+	description "NBA 2K2 (USA)"
+	rom ( name "NBA 2K2 (USA).gdi" size 248 crc 8776cd2e md5 fe2ff872266f0a92442c6f78d96dfb5b sha1 dd5d7fc90e3a6f1511409ead26169940d042d53a )
+)
+
+game (
+	name "NBA Hoopz (USA)"
+	description "NBA Hoopz (USA)"
+	rom ( name "NBA Hoopz (USA).gdi" size 258 crc 73d3def3 md5 45a5cbebbbb361929eb19238c269008c sha1 f71b065200acce50b215e0ae2b09ea91915af88e )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC (Europe)"
+	description "NBA Showtime - NBA on NBC (Europe)"
+	rom ( name "NBA Showtime - NBA on NBC (Europe).gdi" size 353 crc 50b76e88 md5 4524ea7ded3c3e725878a101f073ce2d sha1 238ea2bfa51602b587bd484b16256b0162512b0d )
+)
+
+game (
+	name "NBA Showtime - NBA on NBC (USA)"
+	description "NBA Showtime - NBA on NBC (USA)"
+	rom ( name "NBA Showtime - NBA on NBC (USA).gdi" size 338 crc a3b91892 md5 48a0468b1da4d58936350807bebfc59d sha1 3d54b46dadfc954d1448ffac95eb69b51dd5b92b )
+)
+
+game (
+	name "NCAA College Football 2K2 - Road to the Rose Bowl (USA)"
+	description "NCAA College Football 2K2 - Road to the Rose Bowl (USA)"
+	rom ( name "NCAA College Football 2K2 - Road to the Rose Bowl (USA).gdi" size 458 crc bf3efa5a md5 2dc0f52c0b65df822bc05005fc824ac9 sha1 5d33a1aeb4daef2470109055c8777d4d96275274 )
+)
+
+game (
+	name "Neppachi II - CR Harenchi Gakuen (Japan)"
+	description "Neppachi II - CR Harenchi Gakuen (Japan)"
+	rom ( name "Neppachi II - CR Harenchi Gakuen (Japan).gdi" size 228 crc 994ccb57 md5 c51e4e695766b216b791c7e9964e2f80 sha1 1d013de69ab701485573dd246ed9b119d1578959 )
+)
+
+game (
+	name "Neppachi V - CR Monster House (Japan)"
+	description "Neppachi V - CR Monster House (Japan)"
+	rom ( name "Neppachi V - CR Monster House (Japan).gdi" size 219 crc a8636d95 md5 1b9601007dc7ea476244e87e6e8dc86f sha1 995233458656a95939e24f8574b3e1d4036ba137 )
+)
+
+game (
+	name "Net Golf (Japan)"
+	description "Net Golf (Japan)"
+	rom ( name "Net Golf (Japan).gdi" size 156 crc 268a566b md5 6e1b144802230d7e1e7f256cb43f0033 sha1 3b6e4d286d4a8c467bdf9d408e24e3fd4d5cbef7 )
+)
+
+game (
+	name "Netto De Para (Japan)"
+	description "Netto De Para (Japan)"
+	rom ( name "Netto De Para (Japan).gdi" size 345 crc b1b52e47 md5 f82d148e5719b4d3eb5154a6ec3615fd sha1 125883c1b042d5406a04b9ed59f88945947f4140 )
+)
+
+game (
+	name "NFL 2K (USA)"
+	description "NFL 2K (USA)"
+	rom ( name "NFL 2K (USA).gdi" size 238 crc b70e19da md5 c175026f9f686015372b99c093d5fe57 sha1 aa5b7141838e35f66eb2c50c7108116f7a838283 )
+)
+
+game (
+	name "NFL 2K1 (USA)"
+	description "NFL 2K1 (USA)"
+	rom ( name "NFL 2K1 (USA).gdi" size 243 crc db6fafde md5 902a6cc40c04921784b3a0db1056da97 sha1 dcd39cdfd9cc1f8a19f21adc330f693a532a66f0 )
+)
+
+game (
+	name "NFL 2K2 (USA)"
+	description "NFL 2K2 (USA)"
+	rom ( name "NFL 2K2 (USA).gdi" size 243 crc 54068b33 md5 c3ed23bbc804abfae0b6ece5c6b061f2 sha1 d3a815a6a455203cb4b2e35815da51e8b0646462 )
+)
+
+game (
+	name "NFL Blitz 2000 (Europe)"
+	description "NFL Blitz 2000 (Europe)"
+	rom ( name "NFL Blitz 2000 (Europe).gdi" size 298 crc e5449b9c md5 1d79129e8bef1b1cdfb1e0b1fd5bd5c1 sha1 41a44bf0930a501cbf1092d307a14b584c632017 )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (Europe)"
+	description "NFL Quarterback Club 2000 (Europe)"
+	rom ( name "NFL Quarterback Club 2000 (Europe).gdi" size 353 crc 157ce5dc md5 6ed3462504c239d514579dcfd51e3ca5 sha1 a0f3880c93e769546712234458ce26e820e5e103 )
+)
+
+game (
+	name "NFL Quarterback Club 2000 (USA)"
+	description "NFL Quarterback Club 2000 (USA)"
+	rom ( name "NFL Quarterback Club 2000 (USA).gdi" size 338 crc e713f18c md5 0a92cddb5232f8d1942f2971c2a51d20 sha1 957e88a549eb8b6946a6d18826270595b0d23c64 )
+)
+
+game (
+	name "NHL 2K (Europe)"
+	description "NHL 2K (Europe)"
+	rom ( name "NHL 2K (Europe).gdi" size 258 crc 8786ca53 md5 da1e62281c4e29bc77e87ff106432dc8 sha1 acc78d13241c757ed8b091687ac0a75426b5f42a )
+)
+
+game (
+	name "NHL 2K (USA)"
+	description "NHL 2K (USA)"
+	rom ( name "NHL 2K (USA).gdi" size 243 crc d284a8e7 md5 98dded04b2437982240c6038e19dd6c0 sha1 7ba009c224d8677e304c96bbb520c4f3bd5be81f )
+)
+
+game (
+	name "NHL 2K2 (USA)"
+	description "NHL 2K2 (USA)"
+	rom ( name "NHL 2K2 (USA).gdi" size 248 crc 48d76af3 md5 8aaf7d196f5f6191da8297c271c23448 sha1 3cd92e82f177c83cfc6d53ced76378b7080ed303 )
+)
+
+game (
+	name "Nightmare Creatures II (Europe) (En,Fr,De,Es)"
+	description "Nightmare Creatures II (Europe) (En,Fr,De,Es)"
+	rom ( name "Nightmare Creatures II (Europe) (En,Fr,De,Es).gdi" size 7474 crc 3e9d6e4c md5 a4690065701ffbec1503a12e7ba0e5f6 sha1 381883e688dc11380c3219e5c4b8ed4288c0c542 )
+)
+
+game (
+	name "Nightmare Creatures II (USA)"
+	description "Nightmare Creatures II (USA)"
+	rom ( name "Nightmare Creatures II (USA).gdi" size 5878 crc 547892b9 md5 daaba4bb889d7d4d6d3d6e5f34f5ffd6 sha1 a81be403484079442a0c31aa42165228f09dd947 )
+)
+
+game (
+	name "Nomad Soul, The (France)"
+	description "Nomad Soul, The (France)"
+	rom ( name "Nomad Soul, The (France).gdi" size 303 crc 591b2863 md5 993ff4059301bcb635daea2d3ce34438 sha1 93a03ce4997338798a60b56c8921d04daecfadb5 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 10 - January 2001 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 10 - January 2001 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 10 - January 2001 (USA).gdi" size 994 crc cc26a534 md5 f2b8db28d3e410aa37700ebcf4c950cd sha1 d120c86c76cdd39c02dcba031f1e3d58efdf8cfa )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 2 - November 1999 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 2 - November 1999 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 2 - November 1999 (USA).gdi" size 585 crc 91246f04 md5 ca54483bf119ae341f47ca271b1d4453 sha1 93314f1c91473ef6661be582c4c760fd352234d2 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 3 - January 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 3 - January 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 3 - January 2000 (USA).gdi" size 483 crc 05a2a6f4 md5 e4508a42b9e0cba9ccd5b869ece06c51 sha1 932d536ed944b7f578efe4123a80b2fab56e1534 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 4 - March 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 4 - March 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 4 - March 2000 (USA).gdi" size 1924 crc 7474f99d md5 a7aa2c1117240bd51c58af5c347a1226 sha1 3432c6ccd5cf3a5d3ece8519fa9842ee2906df64 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 6 - July 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 6 - July 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 6 - July 2000 (USA).gdi" size 561 crc 5eb22553 md5 bc1bebff605463e58e596c3b13b6c3c1 sha1 95d07759a2eb40a4bd73f5d77d32ab16fc08b226 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 7 - September 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 7 - September 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 7 - September 2000 (USA).gdi" size 591 crc ccf48130 md5 4c8768da805edcf2a35ab6e536402a9e sha1 76058c49ffdae0e2dfde6a9ce58a8e75bb9c68d2 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 8 - November 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 8 - November 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 8 - November 2000 (USA).gdi" size 682 crc 5fac4505 md5 6c22fc8e3dc5e056489dccce6b02022a sha1 ee545adbb54aeb4691e056cb8321b9ef08357dc0 )
+)
+
+game (
+	name "Official Sega Dreamcast Magazine Vol. 9 - December 2000 (USA)"
+	description "Official Sega Dreamcast Magazine Vol. 9 - December 2000 (USA)"
+	rom ( name "Official Sega Dreamcast Magazine Vol. 9 - December 2000 (USA).gdi" size 1687 crc 5c32bbd4 md5 dc0a4d79345fee82c85bace1e6ba3a29 sha1 fe75a3df1dc54435f1a8a27ee80559c7a6437507 )
+)
+
+game (
+	name "Omikron - The Nomad Soul (USA) (En,Fr,De,Es,It)"
+	description "Omikron - The Nomad Soul (USA) (En,Fr,De,Es,It)"
+	rom ( name "Omikron - The Nomad Soul (USA) (En,Fr,De,Es,It).gdi" size 418 crc 1b53acd4 md5 8d09389f387203686d2ee48064d1bb11 sha1 3ac9a431177e5711b5f18ac241889a4ec0da31a7 )
+)
+
+game (
+	name "PenPen TriIcelon (Japan) (v2.000)"
+	description "PenPen TriIcelon (Japan) (v2.000)"
+	rom ( name "PenPen TriIcelon (Japan) (v2.000).gdi" size 3412 crc 829ecd8b md5 b3fa41ec516eeb7fcae0f1b5ee03cc21 sha1 e81c35b02eefb0546dee2a634b33a62b47369513 )
+)
+
+game (
+	name "Phantasy Star Online (Europe) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online (Europe) (En,Ja,Fr,De,Es).gdi" size 246 crc 28520467 md5 946bcfd70fc9be77f2536e04fbe89388 sha1 fc10155102c7bc8837df2af69dca6c602d0e0188 )
+)
+
+game (
+	name "Phantasy Star Online (Japan) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online (Japan) (En,Ja,Fr,De,Es).gdi" size 243 crc 158831e9 md5 9605ed2da811e738c0e9bd193dd3f28f sha1 f9ef825f0c84c0a3dffc7b3b1eeba37cf9786419 )
+)
+
+game (
+	name "Phantasy Star Online (USA) (En,Ja,Fr,De,Es) (Rev B)"
+	description "Phantasy Star Online (USA) (En,Ja,Fr,De,Es) (Rev B)"
+	rom ( name "Phantasy Star Online (USA) (En,Ja,Fr,De,Es) (Rev B).gdi" size 261 crc c67ba0fc md5 c5aef662c01a8549e335a17ba2d8a138 sha1 1e47569acbf0b135f065a7a8f249f78d1dec8a9d )
+)
+
+game (
+	name "Phantasy Star Online Ver. 2 (Japan) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Ver. 2 (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Ver. 2 (Japan) (En,Ja,Fr,De,Es).gdi" size 264 crc 2402d8bf md5 1f737eead94d578615c789f001ea4176 sha1 031a99c5eef4cc03c5f8bd2ffcb893a5f6c1436e )
+)
+
+game (
+	name "Phantasy Star Online Ver. 2 (USA) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Ver. 2 (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Ver. 2 (USA) (En,Ja,Fr,De,Es).gdi" size 258 crc 846f70e9 md5 93ce4118c25b6ffb6ca7a6c535e3a3b4 sha1 773fc5eaced12aa94bd364454e760cff685fef3d )
+)
+
+game (
+	name "Planet Ring (Europe) (En,Fr,De,Es)"
+	description "Planet Ring (Europe) (En,Fr,De,Es)"
+	rom ( name "Planet Ring (Europe) (En,Fr,De,Es).gdi" size 210 crc 3ce5fc74 md5 f08e1b42cc9927201314468f7a6c61fd sha1 392172ca744d10fc8164e81b73aa0471f35b9c3d )
+)
+
+game (
+	name "Plasma Sword - Nightmare of Bilstein (Europe)"
+	description "Plasma Sword - Nightmare of Bilstein (Europe)"
+	rom ( name "Plasma Sword - Nightmare of Bilstein (Europe).gdi" size 5482 crc 4085fb2c md5 94b8ba14ed4444152d57719d71072ee2 sha1 cdb4fd11501689701a39b60073d65b436b6561a1 )
+)
+
+game (
+	name "Plasma Sword - Nightmare of Bilstein (USA)"
+	description "Plasma Sword - Nightmare of Bilstein (USA)"
+	rom ( name "Plasma Sword - Nightmare of Bilstein (USA).gdi" size 5284 crc 61e89996 md5 34f7c2128c68d190dc96f7e97a2af423 sha1 9c6f820b7d79fa57d39e60fbece5c966f0d20691 )
+)
+
+game (
+	name "POD 2 - Multiplayer Online (Europe)"
+	description "POD 2 - Multiplayer Online (Europe)"
+	rom ( name "POD 2 - Multiplayer Online (Europe).gdi" size 807 crc 6fc7a288 md5 f0ad9f89118895766691065bdfaa3863 sha1 bc10d0c5374dd5a19e05d82a6f9655ab10896529 )
+)
+
+game (
+	name "Power Smash - Sega Professional Tennis (Japan)"
+	description "Power Smash - Sega Professional Tennis (Japan)"
+	rom ( name "Power Smash - Sega Professional Tennis (Japan).gdi" size 246 crc 63e66bd3 md5 30bb5be1a0d170b0ff0cb170eb5189b9 sha1 ba75e4ba5205048fb891747568460063fca9ea5a )
+)
+
+game (
+	name "Power Smash 2 - Sega Professional Tennis (Japan)"
+	description "Power Smash 2 - Sega Professional Tennis (Japan)"
+	rom ( name "Power Smash 2 - Sega Professional Tennis (Japan).gdi" size 252 crc 51749640 md5 ec10284be0003363009de3cf19ab3c13 sha1 189c62abdb01d01005842912918bb0208c1f9c56 )
+)
+
+game (
+	name "Power Stone (Europe)"
+	description "Power Stone (Europe)"
+	rom ( name "Power Stone (Europe).gdi" size 168 crc 1431133d md5 0da5693a05d3a6fc6c48529da2e800a6 sha1 b8b2f9b245f6a1a31a2a33225d933a63476521ea )
+)
+
+game (
+	name "Power Stone (Japan)"
+	description "Power Stone (Japan)"
+	rom ( name "Power Stone (Japan).gdi" size 165 crc 74bddbaf md5 bfc4a3fd4e9e38e4767b5d34a815e87c sha1 77cce9045092732cdbd6acd0a85907ed22a0f4dd )
+)
+
+game (
+	name "Power Stone (USA)"
+	description "Power Stone (USA)"
+	rom ( name "Power Stone (USA).gdi" size 159 crc fb44c9d3 md5 1f0283db0ec54f58edf10181e70fe49d sha1 329c3c23bb0465f2a71557d4715f08cf5e490ccc )
+)
+
+game (
+	name "Power Stone 2 (Europe)"
+	description "Power Stone 2 (Europe)"
+	rom ( name "Power Stone 2 (Europe).gdi" size 174 crc 1d822896 md5 c437bc2456882decc4f9d12e620aba72 sha1 c0d2a073019dc557e068686a9bfcd910f038a24b )
+)
+
+game (
+	name "Power Stone 2 (Japan)"
+	description "Power Stone 2 (Japan)"
+	rom ( name "Power Stone 2 (Japan).gdi" size 171 crc 53180165 md5 02bbcbf85a0101332d4c4b6424404fa7 sha1 af00d209d11e6da6412e9d3a4a5f546a98194bba )
+)
+
+game (
+	name "Power Stone 2 (USA)"
+	description "Power Stone 2 (USA)"
+	rom ( name "Power Stone 2 (USA).gdi" size 165 crc db86ee99 md5 65954029919af7e11f81a090a5f1673a sha1 8d8cd10c6cab80251b7006ca68a5a19eb9bb6978 )
+)
+
+game (
+	name "Prince of Persia - Arabian Nights (USA)"
+	description "Prince of Persia - Arabian Nights (USA)"
+	rom ( name "Prince of Persia - Arabian Nights (USA).gdi" size 378 crc 02727a30 md5 d4656b7ed5f912c0b78546a419adcda5 sha1 01b617a6426233437ad64ba8055a609e8be6c0a1 )
+)
+
+game (
+	name "Project Berkley (Japan)"
+	description "Project Berkley (Japan)"
+	rom ( name "Project Berkley (Japan).gdi" size 177 crc a0d77899 md5 32598b06fb778af6d502e834138e4e5d sha1 325ed267e24de36cd851760e60d47524e1879489 )
+)
+
+game (
+	name "Project Justice (USA)"
+	description "Project Justice (USA)"
+	rom ( name "Project Justice (USA).gdi" size 171 crc 77aa2be9 md5 6b1169692c5ee9770de534cd0de5df91 sha1 ec76419a2e893339c8465ee2bda7fb48484f03d9 )
+)
+
+game (
+	name "Psychic Force 2012 (Europe)"
+	description "Psychic Force 2012 (Europe)"
+	rom ( name "Psychic Force 2012 (Europe).gdi" size 189 crc 6e9ca712 md5 469b2d092911f33776ab7a64c1043b05 sha1 f24a04e30a9ac00975942e5c6c707657a13d2d58 )
+)
+
+game (
+	name "Psychic Force 2012 (Japan)"
+	description "Psychic Force 2012 (Japan)"
+	rom ( name "Psychic Force 2012 (Japan).gdi" size 186 crc 45ca2ea4 md5 59d8931c7cad3b60a52af3bc5fdaa510 sha1 e9f88e3c77eaec957f26583ee13802541a1d5b89 )
+)
+
+game (
+	name "Psychic Force 2012 (USA)"
+	description "Psychic Force 2012 (USA)"
+	rom ( name "Psychic Force 2012 (USA).gdi" size 180 crc 5319db45 md5 b1bea3df9c841845f99854c24d65135e sha1 9a8ecdf1073d9d77f4daf3a26da5d14886fe9afd )
+)
+
+game (
+	name "Puyo Puyoon (Japan)"
+	description "Puyo Puyoon (Japan)"
+	rom ( name "Puyo Puyoon (Japan).gdi" size 1543 crc d4d95d94 md5 58df474af7fe44eff06c4bcc3a94d429 sha1 a8219c340625aa4f92058358d5acbd97a998b5db )
+)
+
+game (
+	name "Q-bert (USA)"
+	description "Q-bert (USA)"
+	rom ( name "Q-bert (USA).gdi" size 654 crc 38fa93c1 md5 e6b5fe0760d17ee7c4d83f210372976c sha1 81b44248bba8529d311a9ca3a52847266641c229 )
+)
+
+game (
+	name "Quake III - Arena (Europe) (En,Fr,De,Es)"
+	description "Quake III - Arena (Europe) (En,Fr,De,Es)"
+	rom ( name "Quake III - Arena (Europe) (En,Fr,De,Es).gdi" size 1564 crc 8856e163 md5 6002c7d21f1aa653b91bebe424213e86 sha1 122997a6c535af270808520fa5342b5360a4c8ee )
+)
+
+game (
+	name "Quake III - Arena (USA)"
+	description "Quake III - Arena (USA)"
+	rom ( name "Quake III - Arena (USA).gdi" size 1224 crc 93e7a135 md5 73477ad9a2d08a1a70e9c4a96e70ab01 sha1 0f22f19ea1cd18d8042c3a1afce09a10b5d618e8 )
+)
+
+game (
+	name "Racing Simulation - Monaco Grand Prix (Europe) (En,Fr,De,Es,It)"
+	description "Racing Simulation - Monaco Grand Prix (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Racing Simulation - Monaco Grand Prix (Europe) (En,Fr,De,Es,It).gdi" size 2327 crc 703a806a md5 0fa977be27024ec7f9ed053c255ba4de sha1 082ef54bc54156eb00a7d4f518e620c8df7cf2ec )
+)
+
+game (
+	name "Railroad Tycoon II (Europe) (En,Fr,De)"
+	description "Railroad Tycoon II (Europe) (En,Fr,De)"
+	rom ( name "Railroad Tycoon II (Europe) (En,Fr,De).gdi" size 992 crc f319cf14 md5 631b4c17aa33dada25948b4eb6361118 sha1 a3f00ca47a1686f71972ec63a95da8c3a17818aa )
+)
+
+game (
+	name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
+	description "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).gdi" size 267 crc d84aa583 md5 39efd4f2200bceda5aecb89c88efd268 sha1 46f4e77d9130bfd63c18e741e9b42d1f4241f998 )
+)
+
+game (
+	name "Re-Volt (USA)"
+	description "Re-Volt (USA)"
+	rom ( name "Re-Volt (USA).gdi" size 922 crc 9e1527dc md5 405e74236653455ae9bfe7a22dbdc05e sha1 5c192875d2c077dfdc55f18363ba1748a094323f )
+)
+
+game (
+	name "Ready 2 Rumble Boxing - Round 2 (Europe) (En,Fr,De)"
+	description "Ready 2 Rumble Boxing - Round 2 (Europe) (En,Fr,De)"
+	rom ( name "Ready 2 Rumble Boxing - Round 2 (Europe) (En,Fr,De).gdi" size 433 crc b4173cfe md5 aa7e1fea9cd78313b19419001d2f4488 sha1 67604c2fda7eee371f6b3836b1c2c78b5ad885db )
+)
+
+game (
+	name "Ready 2 Rumble Boxing - Uchikome Warai no Megaton Punch!! (Japan) (En,Ja,Fr,De)"
+	description "Ready 2 Rumble Boxing - Uchikome Warai no Megaton Punch!! (Japan) (En,Ja,Fr,De)"
+	rom ( name "Ready 2 Rumble Boxing - Uchikome Warai no Megaton Punch!! (Japan) (En,Ja,Fr,De).gdi" size 808 crc c50baebe md5 e636f423e66738ab0bdc9842a73f4843 sha1 f87d1bcca6fb860a97c5c1277c4ce2e0c28ed1c3 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
+	description "Ready 2 Rumble Boxing (Europe) (En,Fr,De)"
+	rom ( name "Ready 2 Rumble Boxing (Europe) (En,Fr,De).gdi" size 542 crc d5625ac0 md5 6a0477565809cfe560457fe07490adb5 sha1 90763bffce8f825bdd3b532a01b4ce244ddfd2c1 )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (USA)"
+	description "Ready 2 Rumble Boxing (USA)"
+	rom ( name "Ready 2 Rumble Boxing (USA).gdi" size 444 crc 5890d11c md5 e956f3b4db640fcfc126d3553affc46b sha1 15659f149e250f8e2352c6bc2bd92aa3b8bb1fee )
+)
+
+game (
+	name "Ready 2 Rumble Boxing (USA) (RE)"
+	description "Ready 2 Rumble Boxing (USA) (RE)"
+	rom ( name "Ready 2 Rumble Boxing (USA) (RE).gdi" size 479 crc 998d6d17 md5 e14d71a89152f904d29486a7298e4488 sha1 4764dc3a5996f33b72ae6ec79501ae14a5af2bf3 )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 1) (v1.006)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 1) (v1.006)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 1) (v1.006).gdi" size 267 crc 5b8cdc87 md5 686b5ff4be97be4bc095ced255bb2ca9 sha1 700468fe77732efa635c6f0fa99e68717540434f )
+)
+
+game (
+	name "Real Sound - Kaze no Regret (Japan) (Disc 2) (v1.005)"
+	description "Real Sound - Kaze no Regret (Japan) (Disc 2) (v1.005)"
+	rom ( name "Real Sound - Kaze no Regret (Japan) (Disc 2) (v1.005).gdi" size 267 crc 15ecd454 md5 ca249ed3eefd1163666da03a2933993d sha1 46b4a953aef0f3d5b3b112232c5b910c93b77910 )
+)
+
+game (
+	name "Record of Lodoss War (Europe)"
+	description "Record of Lodoss War (Europe)"
+	rom ( name "Record of Lodoss War (Europe).gdi" size 328 crc e1135748 md5 463537f958e2a122205e7c304e0076b0 sha1 693c032d450fe5328d220bc1905fe95987a0431d )
+)
+
+game (
+	name "Record of Lodoss War (Germany)"
+	description "Record of Lodoss War (Germany)"
+	rom ( name "Record of Lodoss War (Germany).gdi" size 333 crc 1f3069f4 md5 2fe5f8eac6663395687d5ee548fabf31 sha1 9d991ee6d691467d69e566b6b08eab6d711dd807 )
+)
+
+game (
+	name "Record of Lodoss War (USA)"
+	description "Record of Lodoss War (USA)"
+	rom ( name "Record of Lodoss War (USA).gdi" size 313 crc 80811790 md5 cc8b5c798a7bf66a74d48b1b54ed2a68 sha1 9356c2ec4eca51d9b9126fd57ea732fd0cdb739b )
+)
+
+game (
+	name "Red Dog - Superior Firepower (Europe) (En,Fr,De,Es)"
+	description "Red Dog - Superior Firepower (Europe) (En,Fr,De,Es)"
+	rom ( name "Red Dog - Superior Firepower (Europe) (En,Fr,De,Es).gdi" size 261 crc 1884e64c md5 c556f6aa0d1e065406e4205418ef44de sha1 fc62bfb55a0999869b7f60a0ebede34551887d15 )
+)
+
+game (
+	name "Redline Racer (Japan)"
+	description "Redline Racer (Japan)"
+	rom ( name "Redline Racer (Japan).gdi" size 653 crc 8edfad6f md5 2d1b2a1ceaf3879bc8e61d3c0e034b5f sha1 9b063db6742c8947215c0c4cc4ca761fea54eca9 )
+)
+
+game (
+	name "Reel Fishing + Wild (USA)"
+	description "Reel Fishing + Wild (USA)"
+	rom ( name "Reel Fishing + Wild (USA).gdi" size 1327 crc 392f3134 md5 ca115be44978ec9f1238f5a492a970d6 sha1 490c54fedf6ff7a00ed2eb39ae1237d863bda467 )
+)
+
+game (
+	name "Rent a Hero No.1 (Japan)"
+	description "Rent a Hero No.1 (Japan)"
+	rom ( name "Rent a Hero No.1 (Japan).gdi" size 180 crc c86a9e18 md5 14d372c7eae16ad2ff0620e2920d9b13 sha1 f7a1ebec55e4bcd173cf2274dfeeaa7e8445767e )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (Europe) (Disc 1)"
+	description "Resident Evil - Code - Veronica (Europe) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica (Europe) (Disc 1).gdi" size 255 crc 8678eec8 md5 25264e38c24673bf83bdcf1f6bd5385c sha1 fc7683de45cbf9dfe5a7d397ae34bda576b2ab6c )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (Europe) (Disc 2)"
+	description "Resident Evil - Code - Veronica (Europe) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica (Europe) (Disc 2).gdi" size 255 crc 6f35e64a md5 df6f11b2f8acc16e6c914db06b9b6453 sha1 003d784483cbcd9f3f92a87bb1f3dd9b18c4ac91 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (France) (Disc 1)"
+	description "Resident Evil - Code - Veronica (France) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica (France) (Disc 1).gdi" size 255 crc c4ffad28 md5 4c9f338faedb1f9bc36816a545224003 sha1 1fdcfe0615cce34cfc3db460d00249d47e985200 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (France) (Disc 2)"
+	description "Resident Evil - Code - Veronica (France) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica (France) (Disc 2).gdi" size 255 crc 2db2a5aa md5 a1b6d4e221ca9c0b1cf09fa1dc79dfa6 sha1 239f5786a91615730d799f3ed6f21e46ffdd9be7 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (Germany) (Disc 1)"
+	description "Resident Evil - Code - Veronica (Germany) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica (Germany) (Disc 1).gdi" size 258 crc 2da52083 md5 4528389d220540fb33214fb50bbaed44 sha1 219f5882a0c11bb235f3fe49432dea46293944c7 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (Germany) (Disc 2)"
+	description "Resident Evil - Code - Veronica (Germany) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica (Germany) (Disc 2).gdi" size 258 crc 7cc7da54 md5 94d9592c2d2160b05d8b80f8d4c06276 sha1 3b0b3aa58c13b56775763c8313153f9c16516876 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (Spain) (Disc 2)"
+	description "Resident Evil - Code - Veronica (Spain) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica (Spain) (Disc 2).gdi" size 252 crc 48f963f7 md5 a0ad564b88414a4f4fc6b0858f063e26 sha1 f2716d204174c807c2b560d7e794a1129e9b353e )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (USA) (Disc 1)"
+	description "Resident Evil - Code - Veronica (USA) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica (USA) (Disc 1).gdi" size 246 crc 424049dd md5 c0a47b3045f63ec54a67c4f9ba302560 sha1 7d5be9071535585056f244f760cdb4a046d5c0b4 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica (USA) (Disc 2)"
+	description "Resident Evil - Code - Veronica (USA) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica (USA) (Disc 2).gdi" size 246 crc dfbe9710 md5 dd70f927812c58140ec0d0cb04dbb291 sha1 7b5c7f25f7e2292b04cc94e7c86f2e408c740c41 )
+)
+
+game (
+	name "Resident Evil 2 (Europe) (En,Fr) (Disc 1)"
+	description "Resident Evil 2 (Europe) (En,Fr) (Disc 1)"
+	rom ( name "Resident Evil 2 (Europe) (En,Fr) (Disc 1).gdi" size 465 crc 5b1227f1 md5 7c1c0b4432018d33daa1ead9f9b30ea9 sha1 fbf37fc232bb28de1145c77ffa40e2f8342047f0 )
+)
+
+game (
+	name "Resident Evil 2 (Europe) (En,Fr) (Disc 2)"
+	description "Resident Evil 2 (Europe) (En,Fr) (Disc 2)"
+	rom ( name "Resident Evil 2 (Europe) (En,Fr) (Disc 2).gdi" size 465 crc 2dad508c md5 e2871c698eb22816c0d1358531840373 sha1 915132cdded4dd67835943cf73a136a08c1bfe8a )
+)
+
+game (
+	name "Resident Evil 2 (USA) (Disc 1)"
+	description "Resident Evil 2 (USA) (Disc 1)"
+	rom ( name "Resident Evil 2 (USA) (Disc 1).gdi" size 399 crc 35042454 md5 65416227a2372e4a499273e94cad090d sha1 61afab7eabdc4e7e0ede7f67d1132a69efec2ce6 )
+)
+
+game (
+	name "Resident Evil 2 (USA) (Disc 2)"
+	description "Resident Evil 2 (USA) (Disc 2)"
+	rom ( name "Resident Evil 2 (USA) (Disc 2).gdi" size 399 crc a369a599 md5 a3ff82e7eb726c87e022b2a8ffd354d9 sha1 279be92da78e5780ad28af94a2eba4f9b31f1f42 )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (Europe)"
+	description "Resident Evil 3 - Nemesis (Europe)"
+	rom ( name "Resident Evil 3 - Nemesis (Europe).gdi" size 210 crc 7b00ce27 md5 0463aa6e0ad0724105af9eca3f4d39ac sha1 90bef6c1650d3227dc13557c9236a375ea261e1e )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (Europe) (Fr,Es)"
+	description "Resident Evil 3 - Nemesis (Europe) (Fr,Es)"
+	rom ( name "Resident Evil 3 - Nemesis (Europe) (Fr,Es).gdi" size 234 crc 1b0c8193 md5 c32a8f22b43595c78ff21d3d80fcbf23 sha1 ab1b1efe8ac248535524b90be9b6eb69691d51cd )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (Germany)"
+	description "Resident Evil 3 - Nemesis (Germany)"
+	rom ( name "Resident Evil 3 - Nemesis (Germany).gdi" size 213 crc fda73502 md5 e2d35980739f3d6bb98cf866ee12bc7b sha1 c01a89f719670962eb2fa81c7c34066f99a2cb0e )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (USA)"
+	description "Resident Evil 3 - Nemesis (USA)"
+	rom ( name "Resident Evil 3 - Nemesis (USA).gdi" size 201 crc fe44cd36 md5 05ca638e9641ad8b887574f9b67b2731 sha1 3fec4f636fa027afdbfcc8372af78f5c4f10436d )
+)
+
+game (
+	name "Rez (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Rez (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Rez (Europe) (En,Ja,Fr,De,Es,It).gdi" size 204 crc d010839a md5 8ae225a757c782941883115004b4c293 sha1 9dde936526cc5cbd72d102108a6b457f9ab31a0b )
+)
+
+game (
+	name "Rez (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Rez (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Rez (Japan) (En,Ja,Fr,De,Es,It).gdi" size 201 crc d4e4abdf md5 2c338b983dd0459b85ec702decc6caf8 sha1 9ac225ffc680335604af2150640e9e324da5fcf3 )
+)
+
+game (
+	name "Ring, The (Japan)"
+	description "Ring, The (Japan)"
+	rom ( name "Ring, The (Japan).gdi" size 159 crc daae4f4f md5 b8406ef1b82e5345c0baea7ab2cd8ecc sha1 b95d17b4cbc29222c14a34f479fbdad861972c1e )
+)
+
+game (
+	name "Rippin' Riders (USA)"
+	description "Rippin' Riders (USA)"
+	rom ( name "Rippin' Riders (USA).gdi" size 1106 crc 334a68e5 md5 ecc56aa29ca37f5590a4879024292c92 sha1 a6983bc4cd7966938e40d6f375d05ac0f0a99ece )
+)
+
+game (
+	name "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Roadsters (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Roadsters (Europe) (En,Fr,De,Es,It,Nl).gdi" size 916 crc dd77571c md5 d90aed17a71163e486d0647335bb361f sha1 b711324b3a07360d1ddcca2bcc9ed35c45a3091e )
+)
+
+game (
+	name "Roadsters (USA)"
+	description "Roadsters (USA)"
+	rom ( name "Roadsters (USA).gdi" size 640 crc f583fde8 md5 669df3c19f700c6ef5c954a209867221 sha1 ffd4ed0a3a42080901a19ddde1949a0c096136d3 )
+)
+
+game (
+	name "Run=Dim as Black Soul (Japan)"
+	description "Run=Dim as Black Soul (Japan)"
+	rom ( name "Run=Dim as Black Soul (Japan).gdi" size 195 crc 7ce2b4b9 md5 e3b3b7f6311828d4e60e637fc9b0ba83 sha1 1321f090d731138be99393badf4eb3fd1653c58e )
+)
+
+game (
+	name "Saka Tsuku Tokudai Gou 2 - J. League Pro Soccer Club wo Tsukurou! (Japan)"
+	description "Saka Tsuku Tokudai Gou 2 - J. League Pro Soccer Club wo Tsukurou! (Japan)"
+	rom ( name "Saka Tsuku Tokudai Gou 2 - J. League Pro Soccer Club wo Tsukurou! (Japan).gdi" size 543 crc 8a09da79 md5 b77fb8e319b1c35028b2d6c5b467d693 sha1 ca9575971e46a5a5e8684ffe9e4a00459d6050c6 )
+)
+
+game (
+	name "Sakura Taisen - Hanagumi Taisen Columns 2 (Japan)"
+	description "Sakura Taisen - Hanagumi Taisen Columns 2 (Japan)"
+	rom ( name "Sakura Taisen - Hanagumi Taisen Columns 2 (Japan).gdi" size 255 crc d373128d md5 0d359d11705aaefcba659f1b528cffc3 sha1 e39522f429707474fcd8358325a027700148775f )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 1)"
+	description "Sakura Taisen (Japan) (Disc 1)"
+	rom ( name "Sakura Taisen (Japan) (Disc 1).gdi" size 198 crc 6d2e13f1 md5 2b5c7982885fa6a1c9b7a96aa916dc84 sha1 794c3b2a5b560875f17b932583303788549bb48b )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Disc 2)"
+	description "Sakura Taisen (Japan) (Disc 2)"
+	rom ( name "Sakura Taisen (Japan) (Disc 2).gdi" size 198 crc 13b4a7bd md5 75fbe39786e40201e372918b9b6549f8 sha1 d68568c02eb28887acee788a8c501bb7361324cf )
+)
+
+game (
+	name "Sakura Taisen (Japan) (Omake Disc)"
+	description "Sakura Taisen (Japan) (Omake Disc)"
+	rom ( name "Sakura Taisen (Japan) (Omake Disc).gdi" size 210 crc 827c2d91 md5 a0b56f0dea2c706717a97c9cb2b92a4f sha1 59083f7e39d89ef7241d61fb2ddad03c55525b12 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 1).gdi" size 297 crc f60c430c md5 4fd91fc4bf1e09b94e67ae49f447cb6a sha1 8dbcec6f911202e59000b348af07536aad29be50 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 2).gdi" size 297 crc 3697eca2 md5 9bde11d15201d8b69a6082a12bcf4bf6 sha1 f2e153ad4be5b43fe96353183b595361ff51dd66 )
+)
+
+game (
+	name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3)"
+	description "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3)"
+	rom ( name "Sakura Taisen 2 - Kimi, Shinitamou Koto Nakare (Japan) (Disc 3).gdi" size 297 crc 76e17638 md5 cca9128a615c5fcac306b4ef981b2605 sha1 08171d6b0a04266a457747bb0c715d86e51ada47 )
+)
+
+game (
+	name "Sakura Taisen 3 - Les Chattes Noires (Japan)"
+	description "Sakura Taisen 3 - Les Chattes Noires (Japan)"
+	rom ( name "Sakura Taisen 3 - Les Chattes Noires (Japan).gdi" size 240 crc c08ca3aa md5 2b34af66182d3903e7ac13b6fed9f0f2 sha1 1547ca4093f530df29bb939084c4a4c6aef03346 )
+)
+
+game (
+	name "Sakura Taisen 3 - Paris wa Moeteiru ka - Drama Download Disc (Japan)"
+	description "Sakura Taisen 3 - Paris wa Moeteiru ka - Drama Download Disc (Japan)"
+	rom ( name "Sakura Taisen 3 - Paris wa Moeteiru ka - Drama Download Disc (Japan).gdi" size 312 crc 26bba210 md5 7c65ab6dad24ef49dcf8d83da2159c73 sha1 fdd43dce66b4ba963b130bb9b2f96276ebe6a80b )
+)
+
+game (
+	name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 1)"
+	description "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 1)"
+	rom ( name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 1).gdi" size 273 crc 391d5edf md5 2a5a95d5a875269b3af3d6bc7ed7eada sha1 24f19625c5012dccd9629d4b09150861d821e4c8 )
+)
+
+game (
+	name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 2)"
+	description "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 2)"
+	rom ( name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 2).gdi" size 273 crc 9a48a135 md5 4ee0b3342ef21dd6659a3feb6fe9550d sha1 f706db65c8534c13953335f3cd1b61abd80cb563 )
+)
+
+game (
+	name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 3)"
+	description "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 3)"
+	rom ( name "Sakura Taisen 3 - Paris wa Moeteiru ka (Japan) (Disc 3).gdi" size 273 crc 4dab09ac md5 2096b73905082cbb2347f5a2dedd8b13 sha1 00c6db67586ed768230dae260d6ace93ccb4394c )
+)
+
+game (
+	name "Sakura Taisen 4 - Koi Se Yo Otome (Japan)"
+	description "Sakura Taisen 4 - Koi Se Yo Otome (Japan)"
+	rom ( name "Sakura Taisen 4 - Koi Se Yo Otome (Japan).gdi" size 231 crc 8ddb5e5b md5 962674633e455c8aead0f4b6aec7427c sha1 b8bd2e5cefdf1d95b898a7bee038ff0a8d244e49 )
+)
+
+game (
+	name "Sakura Taisen 4 - Koi Se Yo Otome (Preview Disc) (Japan)"
+	description "Sakura Taisen 4 - Koi Se Yo Otome (Preview Disc) (Japan)"
+	rom ( name "Sakura Taisen 4 - Koi Se Yo Otome (Preview Disc) (Japan).gdi" size 276 crc 98234eb1 md5 f40270dd52856541ae40917ad273a70e sha1 cd9d6d7c1cf15da9c0b97747ea56ae7263f54370 )
+)
+
+game (
+	name "Sakura Taisen Online - Paris no Yuugana Hibi (Japan)"
+	description "Sakura Taisen Online - Paris no Yuugana Hibi (Japan)"
+	rom ( name "Sakura Taisen Online - Paris no Yuugana Hibi (Japan).gdi" size 264 crc 9ee25f93 md5 df798fc5bc9e8d4af43893217927fc40 sha1 939f1fd05b466b5c6ba69c69cfcc883274b0dc38 )
+)
+
+game (
+	name "Sakura Taisen Online - Teito no Nagai Hibi (Japan)"
+	description "Sakura Taisen Online - Teito no Nagai Hibi (Japan)"
+	rom ( name "Sakura Taisen Online - Teito no Nagai Hibi (Japan).gdi" size 258 crc fd3ed0e2 md5 53e9f6e58c2f3f4001e104554cb76658 sha1 a10cb25ae0826261946d112dd147ffc7a354f513 )
+)
+
+game (
+	name "Samba de Amigo (Japan)"
+	description "Samba de Amigo (Japan)"
+	rom ( name "Samba de Amigo (Japan).gdi" size 174 crc 0f0d52ae md5 ce1207db48407fc1cbf784fbc70557c3 sha1 34ea846c65aec80f14371a71e47e5f4bcf124be9 )
+)
+
+game (
+	name "Samba de Amigo Ver. 2000 (Japan)"
+	description "Samba de Amigo Ver. 2000 (Japan)"
+	rom ( name "Samba de Amigo Ver. 2000 (Japan).gdi" size 204 crc e771bac1 md5 4b9ab2e36337c1da0dd13b1add41a9e9 sha1 da0f7e577b18e17a77420a60098cd937d675e83c )
+)
+
+game (
+	name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).gdi" size 438 crc a2a1cefd md5 15b2a2f59a81e1ef558653f9a7559b70 sha1 0b815933fb6d3307a38b6e7a1a86e79cfdcf6575 )
+)
+
+game (
+	name "Seaman (USA)"
+	description "Seaman (USA)"
+	rom ( name "Seaman (USA).gdi" size 144 crc c7005c5b md5 f5d1dc73378aaa2dcab1bdc8494f5bba sha1 a19c41f7ac6c578575ab76a62269979f370f0ec4 )
+)
+
+game (
+	name "Sega Bass Fishing (USA)"
+	description "Sega Bass Fishing (USA)"
+	rom ( name "Sega Bass Fishing (USA).gdi" size 177 crc ec5fff1a md5 d8885568cab6026f12f73058cfb1a907 sha1 783dbbd602f288ea70227bf1e67bf7b2e758c4d3 )
+)
+
+game (
+	name "Sega Extreme Sports (Europe) (En,Fr,De,Es)"
+	description "Sega Extreme Sports (Europe) (En,Fr,De,Es)"
+	rom ( name "Sega Extreme Sports (Europe) (En,Fr,De,Es).gdi" size 3044 crc aecba64f md5 f073808f128532e98cdbf37dd3b47fe2 sha1 37bf638d64fa74efcb515f79830e3419b33a9311 )
+)
+
+game (
+	name "Sega GT - Homologation Special (Japan)"
+	description "Sega GT - Homologation Special (Japan)"
+	rom ( name "Sega GT - Homologation Special (Japan).gdi" size 1144 crc 628d1188 md5 30fb7256a087fd33aafa086bea7eb519 sha1 03907c47886012241f130282449e1dbf0f40e942 )
+)
+
+game (
+	name "Sega GT (Europe) (En,Fr,De,Es)"
+	description "Sega GT (Europe) (En,Fr,De,Es)"
+	rom ( name "Sega GT (Europe) (En,Fr,De,Es).gdi" size 1024 crc 7cb3e89b md5 19dac05e02c6aea1ee545b673e37053e sha1 3d7b3d1f60607f755b81be1d58ceeb6fb618d36a )
+)
+
+game (
+	name "Sega GT (USA)"
+	description "Sega GT (USA)"
+	rom ( name "Sega GT (USA).gdi" size 769 crc bcef4a66 md5 425f7a3d67e8935d3b0487bbe1e9aa19 sha1 7ddf1585c5a363e2d0df8e0e6c82c5334433d482 )
+)
+
+game (
+	name "Sega Rally 2 - Sega Rally Championship (Europe) (v1.000)"
+	description "Sega Rally 2 - Sega Rally Championship (Europe) (v1.000)"
+	rom ( name "Sega Rally 2 - Sega Rally Championship (Europe) (v1.000).gdi" size 1978 crc 96737c20 md5 0628474cf9fb369c4fdcee510b7ce30c sha1 9c2c3f36a4c9f161dae3099dda501e54bdb9779a )
+)
+
+game (
+	name "Sega Rally 2 - Sega Rally Championship (Europe) (v1.001)"
+	description "Sega Rally 2 - Sega Rally Championship (Europe) (v1.001)"
+	rom ( name "Sega Rally 2 - Sega Rally Championship (Europe) (v1.001).gdi" size 1978 crc 63d82148 md5 99e80d10d2858022c4de19eda4b64efc sha1 32c4e29bd058f8aa53bd7a7836554f0a3cd83eb1 )
+)
+
+game (
+	name "Sega Rally 2 - Sega Rally Championship (USA)"
+	description "Sega Rally 2 - Sega Rally Championship (USA)"
+	rom ( name "Sega Rally 2 - Sega Rally Championship (USA).gdi" size 1726 crc 69450d41 md5 463dc21142018154b8c1619e426bc5f4 sha1 3c902f717141e83c403c0d58c7fb2d73a704a5bc )
+)
+
+game (
+	name "Sega Rally 2 (Japan)"
+	description "Sega Rally 2 (Japan)"
+	rom ( name "Sega Rally 2 (Japan).gdi" size 1338 crc 85f073f0 md5 a166dbc408986e7d5576d05ad9972fb6 sha1 b41c428d60e429482dca2ae97be6804979761c86 )
+)
+
+game (
+	name "Sega Smash Pack - Volume 1 (USA)"
+	description "Sega Smash Pack - Volume 1 (USA)"
+	rom ( name "Sega Smash Pack - Volume 1 (USA).gdi" size 2804 crc 7817d5d9 md5 df536db6acd6e5a4bf9f37ea9c5240ee sha1 42bdf63f041f04b8588185f55ee3257ce0f5006b )
+)
+
+game (
+	name "Sega Worldwide Soccer 2000 - Euro Edition (Europe) (En,Fr,De,Es)"
+	description "Sega Worldwide Soccer 2000 - Euro Edition (Europe) (En,Fr,De,Es)"
+	rom ( name "Sega Worldwide Soccer 2000 - Euro Edition (Europe) (En,Fr,De,Es).gdi" size 503 crc a7bddc8b md5 df815e509ff781e2e315975b2c814065 sha1 188902b800a04bbe49640cd2086dcd95472be2ff )
+)
+
+game (
+	name "Seitai Heiki Expendable (Japan)"
+	description "Seitai Heiki Expendable (Japan)"
+	rom ( name "Seitai Heiki Expendable (Japan).gdi" size 1936 crc c7f6d1c2 md5 9f230baf3ef927f4329452e42d6fd53d sha1 15e1e20ae266398dfc2cb5b3912b2858e7c490bf )
+)
+
+game (
+	name "Sentimental Graffiti 2 (Japan) (Disc 1)"
+	description "Sentimental Graffiti 2 (Japan) (Disc 1)"
+	rom ( name "Sentimental Graffiti 2 (Japan) (Disc 1).gdi" size 225 crc d88fab1a md5 aed24ac13c65dd5bc62ae61e6e3b3953 sha1 d168b43638318fb7b5cf4c33c894d9b12ff6313f )
+)
+
+game (
+	name "Sentimental Graffiti 2 (Japan) (Disc 2)"
+	description "Sentimental Graffiti 2 (Japan) (Disc 2)"
+	rom ( name "Sentimental Graffiti 2 (Japan) (Disc 2).gdi" size 225 crc 3c2b9394 md5 8d07178abe5f7dbdee234d6a5a8d403c sha1 033e1e06f0410a26aa3057b23963433f8bc7bc24 )
+)
+
+game (
+	name "Seventh Cross (Japan)"
+	description "Seventh Cross (Japan)"
+	rom ( name "Seventh Cross (Japan).gdi" size 1007 crc d0b0f536 md5 3a87defc3a3221727a7384d7e34aadc9 sha1 3d474eec0fbd7e7707b1d0846dcc7378a946fd05 )
+)
+
+game (
+	name "Shadow Man (Europe) (En,Fr,Es,It)"
+	description "Shadow Man (Europe) (En,Fr,Es,It)"
+	rom ( name "Shadow Man (Europe) (En,Fr,Es,It).gdi" size 348 crc 9a142030 md5 5a55da4b6fb64977b8d4168b456dccca sha1 ce5218c8c4f5b26f31b8e31b6999738541036d5a )
+)
+
+game (
+	name "Shadow Man (Germany)"
+	description "Shadow Man (Germany)"
+	rom ( name "Shadow Man (Germany).gdi" size 283 crc fec44dc1 md5 f81d958987210da0520a7cc104d294a2 sha1 74405e64d850b9062d7913cfae0cdc04e03b10ef )
+)
+
+game (
+	name "Shadow Man (USA)"
+	description "Shadow Man (USA)"
+	rom ( name "Shadow Man (USA).gdi" size 263 crc e1cea9b9 md5 a04b07cca82fd1e2d8c0d241ec7ce7b1 sha1 23eda8935dff63b7b07c5ece455735afa4005a3a )
+)
+
+game (
+	name "Shenmue - Ichishou Yokosuka (Japan) (Disc 1)"
+	description "Shenmue - Ichishou Yokosuka (Japan) (Disc 1)"
+	rom ( name "Shenmue - Ichishou Yokosuka (Japan) (Disc 1).gdi" size 483 crc 63d104b4 md5 0a0ad151db3e1119d9b9f86ff26a568b sha1 db4fe93eb4569bbe4b184139d852a545670f871f )
+)
+
+game (
+	name "Shenmue - Ichishou Yokosuka (Japan) (Disc 2)"
+	description "Shenmue - Ichishou Yokosuka (Japan) (Disc 2)"
+	rom ( name "Shenmue - Ichishou Yokosuka (Japan) (Disc 2).gdi" size 483 crc c4467a12 md5 696ad1f29d40df39223ed4b39ba94821 sha1 78ecaae90084c1696afb98cea8f24d6ad12cc289 )
+)
+
+game (
+	name "Shenmue - Ichishou Yokosuka (Japan) (Disc 3)"
+	description "Shenmue - Ichishou Yokosuka (Japan) (Disc 3)"
+	rom ( name "Shenmue - Ichishou Yokosuka (Japan) (Disc 3).gdi" size 477 crc 40dc151f md5 cb79b4707ec34e71a47d7e9d9032663c sha1 f09b2292bba7ca29145686e0df59452deb3ca58a )
+)
+
+game (
+	name "Shenmue - Ichishou Yokosuka (Japan) (Shenmue Passport)"
+	description "Shenmue - Ichishou Yokosuka (Japan) (Shenmue Passport)"
+	rom ( name "Shenmue - Ichishou Yokosuka (Japan) (Shenmue Passport).gdi" size 626 crc fcb3c9c3 md5 aa1893ad4767fc9d4277a451fd150239 sha1 8bd78b731fb2de2bf381eadd4422f572d8f9e666 )
+)
+
+game (
+	name "Shenmue (Europe) (En,Fr,De,Es) (Disc 1)"
+	description "Shenmue (Europe) (En,Fr,De,Es) (Disc 1)"
+	rom ( name "Shenmue (Europe) (En,Fr,De,Es) (Disc 1).gdi" size 453 crc ee35f253 md5 ae76f9ccc0520284ae2eef0dd3ee8183 sha1 12965309ad5f1abf658ede9ae51fb1322c2c68bf )
+)
+
+game (
+	name "Shenmue (Europe) (En,Fr,De,Es) (Disc 2)"
+	description "Shenmue (Europe) (En,Fr,De,Es) (Disc 2)"
+	rom ( name "Shenmue (Europe) (En,Fr,De,Es) (Disc 2).gdi" size 453 crc d0f752d6 md5 4b30390c671210b99f33a3492d89269e sha1 0fcc49f94b0fb22f9b14c0e000dc73c0fa97201d )
+)
+
+game (
+	name "Shenmue (Europe) (En,Fr,De,Es) (Disc 3)"
+	description "Shenmue (Europe) (En,Fr,De,Es) (Disc 3)"
+	rom ( name "Shenmue (Europe) (En,Fr,De,Es) (Disc 3).gdi" size 453 crc bffc258e md5 2bd2ee004641ea3285b56e939b64a36a sha1 eb8cbe895f213776bb094212ba424f406e074626 )
+)
+
+game (
+	name "Shenmue (Europe) (En,Fr,De,Es) (Shenmue Passport)"
+	description "Shenmue (Europe) (En,Fr,De,Es) (Shenmue Passport)"
+	rom ( name "Shenmue (Europe) (En,Fr,De,Es) (Shenmue Passport).gdi" size 591 crc 20ad8067 md5 97c9636e4884ddf30f0b969cea840618 sha1 a3d19d82d7c7bb0b9f6926e9ffaeac057032a349 )
+)
+
+game (
+	name "Shenmue (USA) (Disc 1)"
+	description "Shenmue (USA) (Disc 1)"
+	rom ( name "Shenmue (USA) (Disc 1).gdi" size 351 crc 037b3409 md5 5ba4a8d8c60306e14dadb40f463ee7ed sha1 a6a3e7807fc538ca10b0cfddac6d19b2f8202529 )
+)
+
+game (
+	name "Shenmue (USA) (Disc 2)"
+	description "Shenmue (USA) (Disc 2)"
+	rom ( name "Shenmue (USA) (Disc 2).gdi" size 351 crc 4d21cf1f md5 c6de4787ec3abcf46b408888f3d80364 sha1 edd07d1579552ea3a010d30cf691d92001726fd8 )
+)
+
+game (
+	name "Shenmue (USA) (Disc 3)"
+	description "Shenmue (USA) (Disc 3)"
+	rom ( name "Shenmue (USA) (Disc 3).gdi" size 351 crc 6549095c md5 b5c6e938012267c721c5919e3cdbca1c sha1 fbd2322f2bb98da34df6e59353c51385dfa0bdfa )
+)
+
+game (
+	name "Shenmue (USA) (Shenmue Passport)"
+	description "Shenmue (USA) (Shenmue Passport)"
+	rom ( name "Shenmue (USA) (Shenmue Passport).gdi" size 472 crc 80aaab03 md5 92ff251aa3e6d02607c175d2a37c49bc sha1 12e5e2e8a26db74b3dd5b30a577623cf6251a47b )
+)
+
+game (
+	name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 1)"
+	description "Shenmue II (Europe) (En,Fr,De,Es) (Disc 1)"
+	rom ( name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 1).gdi" size 471 crc 21b293fb md5 9ba928c9a42382583d51715380273f8f sha1 33b26dd65861c610b931cc69c158e32b47f2b530 )
+)
+
+game (
+	name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 2)"
+	description "Shenmue II (Europe) (En,Fr,De,Es) (Disc 2)"
+	rom ( name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 2).gdi" size 234 crc 99315706 md5 5352fd83911f7daf086fd6f372b1af1c sha1 50bea56dee31d9abd4d137aa71acf5e959d36495 )
+)
+
+game (
+	name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 3)"
+	description "Shenmue II (Europe) (En,Fr,De,Es) (Disc 3)"
+	rom ( name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 3).gdi" size 234 crc 2af33441 md5 b685398eb499ff79b136dd365ba9534a sha1 16fd9c671dd9296a7b38492132d7c5c7c04d8bde )
+)
+
+game (
+	name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 4)"
+	description "Shenmue II (Europe) (En,Fr,De,Es) (Disc 4)"
+	rom ( name "Shenmue II (Europe) (En,Fr,De,Es) (Disc 4).gdi" size 234 crc 8a70b5d5 md5 3022fbc9fc7db706245c1763676ea6df sha1 cb171eb63d6a1df4be9c81f2f34db51cf8493520 )
+)
+
+game (
+	name "Shenmue II (Japan) (Disc 1)"
+	description "Shenmue II (Japan) (Disc 1)"
+	rom ( name "Shenmue II (Japan) (Disc 1).gdi" size 381 crc db85c885 md5 8164dafa35efce8f477e7f90a6b205e7 sha1 bdb158ed2e010efc3503c3cd4fbafcb8df9489d4 )
+)
+
+game (
+	name "Shenmue II (Japan) (Disc 2)"
+	description "Shenmue II (Japan) (Disc 2)"
+	rom ( name "Shenmue II (Japan) (Disc 2).gdi" size 251 crc 94ccb103 md5 997107209f00cedd1bcf38846e1e5562 sha1 1ad82cddd4babddcebcdc275deabc0914e29ee21 )
+)
+
+game (
+	name "Shenmue II (Japan) (Disc 3)"
+	description "Shenmue II (Japan) (Disc 3)"
+	rom ( name "Shenmue II (Japan) (Disc 3).gdi" size 251 crc 3db4e4c1 md5 572e01f580b85b8131ad5fe4f20e5500 sha1 298081226686a4494a9b2015ab6c1afb2d4ed831 )
+)
+
+game (
+	name "Shenmue II (Japan) (Disc 4)"
+	description "Shenmue II (Japan) (Disc 4)"
+	rom ( name "Shenmue II (Japan) (Disc 4).gdi" size 255 crc a1fb2f94 md5 18d6fe29d2783dd410823f38e980bb54 sha1 08bc354efe40a95f792f62e3bf5e873b5da4a453 )
+)
+
+game (
+	name "Shikigami no Shiro II (Japan)"
+	description "Shikigami no Shiro II (Japan)"
+	rom ( name "Shikigami no Shiro II (Japan).gdi" size 195 crc cf3ec5a3 md5 5fe244bad6bd5c5c776f4ba9e208bdfc sha1 45587d4ea4ad926c7d4c724bcf06d69c4aecf122 )
+)
+
+game (
+	name "Shinki Sekai Evolution (Japan)"
+	description "Shinki Sekai Evolution (Japan)"
+	rom ( name "Shinki Sekai Evolution (Japan).gdi" size 198 crc fe48c60a md5 92d4c2ad0d2daa50dda1a0c982d46d43 sha1 c8f1f2394305c1c180793caac50394edaba3399d )
+)
+
+game (
+	name "Shutokou Battle (Japan)"
+	description "Shutokou Battle (Japan)"
+	rom ( name "Shutokou Battle (Japan).gdi" size 1285 crc d9799eb8 md5 ed1b5e61eab2201c0be29879f761e00c sha1 3a414743465b841e4ad67a9187e9e51bfb8cbed0 )
+)
+
+game (
+	name "Shutokou Battle 2 (Japan)"
+	description "Shutokou Battle 2 (Japan)"
+	rom ( name "Shutokou Battle 2 (Japan).gdi" size 183 crc 31dab589 md5 21c73ba508982cf90ab5c11db0063746 sha1 371cf24f2204346524e25c1db64b273f27f5b5a9 )
+)
+
+game (
+	name "Silent Scope (USA)"
+	description "Silent Scope (USA)"
+	rom ( name "Silent Scope (USA).gdi" size 162 crc 9d77b2dd md5 8998604b72995486eace27fea928bfa8 sha1 454516789fb4030e381ed7ef678be1bf44ed022c )
+)
+
+game (
+	name "Silver (Europe) (En,Nl)"
+	description "Silver (Europe) (En,Nl)"
+	rom ( name "Silver (Europe) (En,Nl).gdi" size 177 crc fdcb3fe5 md5 83020d93f6f0b9aa9714648172a61d48 sha1 c1bb69c0d14fcc452a7810015410e9e02d126e82 )
+)
+
+game (
+	name "Silver (France) (Fr,It,Pt)"
+	description "Silver (France) (Fr,It,Pt)"
+	rom ( name "Silver (France) (Fr,It,Pt).gdi" size 186 crc d9582a53 md5 aad128f4a40ffe4b25d0c84b23731d4f sha1 6c03bafa7fd360c76fd640d77b66ac94b3a084fe )
+)
+
+game (
+	name "Simple 2000 Series DC Vol. 01 - Bittersweet Fools - The Renai Adventure (Japan)"
+	description "Simple 2000 Series DC Vol. 01 - Bittersweet Fools - The Renai Adventure (Japan)"
+	rom ( name "Simple 2000 Series DC Vol. 01 - Bittersweet Fools - The Renai Adventure (Japan).gdi" size 345 crc 1df4ff90 md5 015818f75c55c851577815b5f0c74632 sha1 4b191d9d2cc3bb060b568a385c273ad9e0181e57 )
+)
+
+game (
+	name "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 1)"
+	description "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 1)"
+	rom ( name "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 1).gdi" size 252 crc 579b708d md5 9f9b61aa3ebe4deff34116c975dc7fa5 sha1 894b50db558ba0cbab7815496995473ddb782614 )
+)
+
+game (
+	name "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 2)"
+	description "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 2)"
+	rom ( name "Skies of Arcadia (Europe) (En,Fr,De,Es) (Disc 2).gdi" size 252 crc 9ac6ccd0 md5 0db927425c15e2b6b56352a7dd9bc5f3 sha1 1363c52350f5bade6369e971544d05843c3a1695 )
+)
+
+game (
+	name "Skies of Arcadia (USA) (Disc 1)"
+	description "Skies of Arcadia (USA) (Disc 1)"
+	rom ( name "Skies of Arcadia (USA) (Disc 1).gdi" size 201 crc 31a6333c md5 8897120b553d1fe21e3ca11b14d8cb0b sha1 5a14a33bdc851d7cd5ed005bf562232ddf13eef1 )
+)
+
+game (
+	name "Skies of Arcadia (USA) (Disc 2)"
+	description "Skies of Arcadia (USA) (Disc 2)"
+	rom ( name "Skies of Arcadia (USA) (Disc 2).gdi" size 201 crc 79a41b12 md5 ddc57b624038e76abe700d4e445934de sha1 6e5a42e294d412b3b83e4793d932ec9f401968cf )
+)
+
+game (
+	name "Slave Zero (USA)"
+	description "Slave Zero (USA)"
+	rom ( name "Slave Zero (USA).gdi" size 263 crc 297cf5bf md5 877fe6342489d1fa4499c71af5c78eb5 sha1 ebbf7497fa2eeb30c6176d335e1d2af1a3461a98 )
+)
+
+game (
+	name "SnoCross Championship Racing (Europe) (En,Fr,De)"
+	description "SnoCross Championship Racing (Europe) (En,Fr,De)"
+	rom ( name "SnoCross Championship Racing (Europe) (En,Fr,De).gdi" size 1466 crc c52e810b md5 2dca9ffb4a3859343a01247a6e683a80 sha1 eb20afdec18d803afbb7478cba39133d1cc89411 )
+)
+
+game (
+	name "Snow (Japan)"
+	description "Snow (Japan)"
+	rom ( name "Snow (Japan).gdi" size 144 crc 4f64b5a9 md5 ae606e050327e5c9f97baca3c879c54e sha1 85d26efc83efff68073e4c2577607fd7fafc7b66 )
+)
+
+game (
+	name "Snow Surfers (Europe)"
+	description "Snow Surfers (Europe)"
+	rom ( name "Snow Surfers (Europe).gdi" size 1125 crc 62c0bda1 md5 548d9f2db223b7a5302c7c3b45ae9aab sha1 a89ba26a5290506cca488d0334e4d56a7f7e5c17 )
+)
+
+game (
+	name "Sonic Adventure (Europe) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure (Europe) (En,Ja,Fr,De,Es).gdi" size 231 crc 47059280 md5 00dce1826d8bd25a390cab9b259976d1 sha1 6e1ebd9639c74e6f1e68e0232e2831430908b3c0 )
+)
+
+game (
+	name "Sonic Adventure (Japan)"
+	description "Sonic Adventure (Japan)"
+	rom ( name "Sonic Adventure (Japan).gdi" size 177 crc 44671997 md5 786ebe9e2abb93035a95df63e65e7b1e sha1 503c4e06f8fc3f43e5a6d3f5f7439ec99ad8ae70 )
+)
+
+game (
+	name "Sonic Adventure (USA) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure (USA) (En,Ja,Fr,De,Es).gdi" size 222 crc 098aefeb md5 5ccd80a82a534d0c833f607f68f0a751 sha1 813d03ef08fcdbba7599251a4b77af6fc07b0055 )
+)
+
+game (
+	name "Sonic Adventure 2 - The Trial (Europe) (En,Ja)"
+	description "Sonic Adventure 2 - The Trial (Europe) (En,Ja)"
+	rom ( name "Sonic Adventure 2 - The Trial (Europe) (En,Ja).gdi" size 246 crc 41c3227a md5 b8f7ff61a181656c5d7defaac5dd76eb sha1 f990567894c3bc7d41189f3a6a620755b290897d )
+)
+
+game (
+	name "Sonic Adventure 2 - The Trial (USA, Japan) (En,Ja)"
+	description "Sonic Adventure 2 - The Trial (USA, Japan) (En,Ja)"
+	rom ( name "Sonic Adventure 2 - The Trial (USA, Japan) (En,Ja).gdi" size 258 crc fae81f35 md5 525117d1aa3dfba741cdddd99eb6a0a7 sha1 09b1cb70996fd7a6cc273969e2f419fd301dc778 )
+)
+
+game (
+	name "Sonic Adventure 2 (Europe) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure 2 (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure 2 (Europe) (En,Ja,Fr,De,Es).gdi" size 237 crc 33228be8 md5 b41371f9a7650605e84a849aeb04f7d7 sha1 524b53855ce21b4a6881b77b9fd5be106fcc6ab7 )
+)
+
+game (
+	name "Sonic Adventure 2 (Japan) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure 2 (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure 2 (Japan) (En,Ja,Fr,De,Es).gdi" size 234 crc 7fda0e20 md5 f863c40b2e568af2d76a6c19ca1293ab sha1 d41f1dad8689d27ba4e977b46e88d267ac93356a )
+)
+
+game (
+	name "Sonic Adventure International (Japan) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure International (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure International (Japan) (En,Ja,Fr,De,Es).gdi" size 270 crc 6cf59406 md5 47d9f7431fb2183e4249df8cd7f45c37 sha1 69306478aeedd9675efa23e07283f19cb5bf6a20 )
+)
+
+game (
+	name "Sorcerian - Shichisei Mahou no Shito (Japan)"
+	description "Sorcerian - Shichisei Mahou no Shito (Japan)"
+	rom ( name "Sorcerian - Shichisei Mahou no Shito (Japan).gdi" size 240 crc dbd5f957 md5 0dddcb401fc80ae8e7f6aab59bf09a61 sha1 730f78e464beb3583f494df0e410b7dd3c418e82 )
+)
+
+game (
+	name "Soul Fighter (Europe)"
+	description "Soul Fighter (Europe)"
+	rom ( name "Soul Fighter (Europe).gdi" size 889 crc 1a219c21 md5 91caae0b8a004e74a377670bcb957f29 sha1 72efaeb12648855fea9d90ab8ed09a330811150d )
+)
+
+game (
+	name "Soul Fighter (USA)"
+	description "Soul Fighter (USA)"
+	rom ( name "Soul Fighter (USA).gdi" size 844 crc 81726e2c md5 df63ec0533d7f79aa6f73bde242c301e sha1 c86298b9ae6feaf5702715029b2c4f25e3a358e7 )
+)
+
+game (
+	name "Soulcalibur (Europe) (En,Fr,De,Es)"
+	description "Soulcalibur (Europe) (En,Fr,De,Es)"
+	rom ( name "Soulcalibur (Europe) (En,Fr,De,Es).gdi" size 210 crc 3bb8547a md5 99db0beff7304f46525530e3bba7a0ed sha1 1c1a207182f81cfdee7349d73465874b91d0b258 )
+)
+
+game (
+	name "Soulcalibur (Japan)"
+	description "Soulcalibur (Japan)"
+	rom ( name "Soulcalibur (Japan).gdi" size 165 crc 93d069d9 md5 2bc35ff3b8c5a262dcf676b67e71f353 sha1 ed5d698aa29f11e4cf96ddc6a1d67cc797eb499d )
+)
+
+game (
+	name "Soulcalibur (USA)"
+	description "Soulcalibur (USA)"
+	rom ( name "Soulcalibur (USA).gdi" size 159 crc ef285deb md5 cee23f666f7e7040cc84709c554e0757 sha1 11d56848cd99df29f31fa203ebc281fbc5619421 )
+)
+
+game (
+	name "South Park - Chef's Luv Shack (USA)"
+	description "South Park - Chef's Luv Shack (USA)"
+	rom ( name "South Park - Chef's Luv Shack (USA).gdi" size 358 crc c9622f61 md5 f0e8aae7870e965fa56b348cc5bb04ef sha1 3d4fc4282bce69cb6ee768dc1abc02c907c4805f )
+)
+
+game (
+	name "Space Channel 5 (Japan)"
+	description "Space Channel 5 (Japan)"
+	rom ( name "Space Channel 5 (Japan).gdi" size 293 crc 9f726cda md5 cdd4c7bd5b4b53a796d5211eedff64b7 sha1 26b20a6559e3160fbb919fb944475851563e3c06 )
+)
+
+game (
+	name "Space Channel 5 (USA)"
+	description "Space Channel 5 (USA)"
+	rom ( name "Space Channel 5 (USA).gdi" size 171 crc 4c7b8e5b md5 572f21639eae0615bc2f648634263b60 sha1 9eb1eaf49d8f66696055fe116db7a01505f51a2a )
+)
+
+game (
+	name "Space Channel 5 Part 2 (Japan)"
+	description "Space Channel 5 Part 2 (Japan)"
+	rom ( name "Space Channel 5 Part 2 (Japan).gdi" size 198 crc 5a231fd0 md5 371e2064d84026f622199b64cf27e467 sha1 1a2d5ff78caef8d6ca2b22e5a91346486cfc797d )
+)
+
+game (
+	name "Spawn - In the Demon's Hand (USA)"
+	description "Spawn - In the Demon's Hand (USA)"
+	rom ( name "Spawn - In the Demon's Hand (USA).gdi" size 207 crc 0fd244b0 md5 173823264aca19ae3bf01a57a2ca69a7 sha1 601573f005a3a803725666ff7695692a08d2bd57 )
+)
+
+game (
+	name "Spec Ops II - Omega Squad (Europe) (En,Fr,De,Es,It)"
+	description "Spec Ops II - Omega Squad (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Spec Ops II - Omega Squad (Europe) (En,Fr,De,Es,It).gdi" size 1072 crc 338b774c md5 1b05a4a3dfba37af5a4d910e6b5b1c8d sha1 2a751f31f2ae0b06ae224c8e154e7e6a5c3e4596 )
+)
+
+game (
+	name "Speed Devils (Europe) (En,Fr,De,Es,It)"
+	description "Speed Devils (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Speed Devils (Europe) (En,Fr,De,Es,It).gdi" size 840 crc 88bd5768 md5 573d327f774d3b89bc0262ae4b559bce sha1 5b6dabbec11072e0c72f6d067e1dd877f5e787a5 )
+)
+
+game (
+	name "Speed Devils (Japan)"
+	description "Speed Devils (Japan)"
+	rom ( name "Speed Devils (Japan).gdi" size 642 crc 8effaec9 md5 2316cd763a75441f7a6e08b987d73f80 sha1 eaf61b370c84917672224ee85edaba1d534c8b39 )
+)
+
+game (
+	name "Speed Devils (USA)"
+	description "Speed Devils (USA)"
+	rom ( name "Speed Devils (USA).gdi" size 620 crc a211ddf7 md5 2a68ef26dbcace7c7ce41f5b1c8c5c7e sha1 cfe70ef03b8ed89ad41025f3349c75297bbd92e8 )
+)
+
+game (
+	name "Spirit of Speed 1937 (Europe) (En,Fr,De,Es)"
+	description "Spirit of Speed 1937 (Europe) (En,Fr,De,Es)"
+	rom ( name "Spirit of Speed 1937 (Europe) (En,Fr,De,Es).gdi" size 635 crc f2bb6c70 md5 826dbd1e26d687d0cb4c59ee56da2d79 sha1 dc93c32e1eb23118a04272b2a9e4443c2d25bf3c )
+)
+
+game (
+	name "Star Gladiator 2 - Nightmare of Bilstein (Japan)"
+	description "Star Gladiator 2 - Nightmare of Bilstein (Japan)"
+	rom ( name "Star Gladiator 2 - Nightmare of Bilstein (Japan).gdi" size 5680 crc 8cdc4357 md5 3a535ee99283019d88d78e24ef715554 sha1 78184349a6250833370873f8858a6a7a20b45603 )
+)
+
+game (
+	name "Star Wars - Demolition (Europe)"
+	description "Star Wars - Demolition (Europe)"
+	rom ( name "Star Wars - Demolition (Europe).gdi" size 1039 crc 8ee5c832 md5 7e9daedf6500ea436c5ffac031a7d39c sha1 aaf4ef67d00878f1cc345dccf173777d6a5d4542 )
+)
+
+game (
+	name "Star Wars - Episode I - Racer (USA)"
+	description "Star Wars - Episode I - Racer (USA)"
+	rom ( name "Star Wars - Episode I - Racer (USA).gdi" size 358 crc 0e422ba7 md5 fdc51513fcd2133dfb8372fc923ab1da sha1 5035d0f303ba506a3f782df00b2fd1cf50ad4056 )
+)
+
+game (
+	name "StarLancer (USA)"
+	description "StarLancer (USA)"
+	rom ( name "StarLancer (USA).gdi" size 263 crc 6c01cf12 md5 891dd3281c96050e0e22de570200dd9d sha1 b4e67a86868851f9dd46d9ad62a979d1e1485b7f )
+)
+
+game (
+	name "Street Fighter Alpha 3 (Europe)"
+	description "Street Fighter Alpha 3 (Europe)"
+	rom ( name "Street Fighter Alpha 3 (Europe).gdi" size 201 crc 0dd4d0b6 md5 b5f0075c368ac72db152b2026f7785e7 sha1 aa879124d2dfc0f98e0bd3dccc9a992c7350d0ed )
+)
+
+game (
+	name "Street Fighter Alpha 3 (USA)"
+	description "Street Fighter Alpha 3 (USA)"
+	rom ( name "Street Fighter Alpha 3 (USA).gdi" size 192 crc 32de9ea1 md5 e1e575855270c32fca1d1c069f8ad7ed sha1 6cb8b2bb7f78a0f422cde2b7613acb4e13288054 )
+)
+
+game (
+	name "Street Fighter III - 3rd Strike - Fight for the Future (Japan)"
+	description "Street Fighter III - 3rd Strike - Fight for the Future (Japan)"
+	rom ( name "Street Fighter III - 3rd Strike - Fight for the Future (Japan).gdi" size 294 crc 8fef2ed4 md5 a379904b67bb00c8f6c8936887751a0b sha1 8a5d9c0ba97e67d527713780ee006921c1876f47 )
+)
+
+game (
+	name "Street Fighter III - 3rd Strike (USA)"
+	description "Street Fighter III - 3rd Strike (USA)"
+	rom ( name "Street Fighter III - 3rd Strike (USA).gdi" size 219 crc c1ea35c4 md5 e950cf648f7952b2fb2e2676d5022f2f sha1 2d49356c2183bb14467e40e38e3c8724e7d4b699 )
+)
+
+game (
+	name "Street Fighter III - Double Impact (USA)"
+	description "Street Fighter III - Double Impact (USA)"
+	rom ( name "Street Fighter III - Double Impact (USA).gdi" size 228 crc 6a4dc642 md5 d521766beef6fd8daa6772df8672dde8 sha1 597ca08227a3124a54fd1d777c2113496a9a80de )
+)
+
+game (
+	name "Street Fighter III - W Impact (Japan)"
+	description "Street Fighter III - W Impact (Japan)"
+	rom ( name "Street Fighter III - W Impact (Japan).gdi" size 219 crc 4e13b9bb md5 1afa0b36b1f73fd505aeae77a76d98ab sha1 878fea78eed2ed9bd48e7fa46e5ca886ed2b4e80 )
+)
+
+game (
+	name "Street Fighter Zero 3 - Saikyo-ryu Dojo (Japan)"
+	description "Street Fighter Zero 3 - Saikyo-ryu Dojo (Japan)"
+	rom ( name "Street Fighter Zero 3 - Saikyo-ryu Dojo (Japan).gdi" size 249 crc 83a31dca md5 20d7bb0558341be02c349adab9061e8e sha1 9af87f2de35d6a79734303f0fa92d901c3988fee )
+)
+
+game (
+	name "Street Fighter Zero 3 - Saikyo-ryu Dojo for Matching Service (Japan)"
+	description "Street Fighter Zero 3 - Saikyo-ryu Dojo for Matching Service (Japan)"
+	rom ( name "Street Fighter Zero 3 - Saikyo-ryu Dojo for Matching Service (Japan).gdi" size 312 crc 82dc7c01 md5 0154a42a3336d8c47fce63d21ebed1b4 sha1 0aadd7fff44cd951500ac301f7551f35a8d37cda )
+)
+
+game (
+	name "Super Magnetic Neo (Europe) (En,Fr,De)"
+	description "Super Magnetic Neo (Europe) (En,Fr,De)"
+	rom ( name "Super Magnetic Neo (Europe) (En,Fr,De).gdi" size 222 crc acd02a2f md5 7feaa104020b649aada05d397622c641 sha1 0392f1d4ecb754c2215a413e40295d113148e1f2 )
+)
+
+game (
+	name "Super Robot Taisen Alpha (Japan)"
+	description "Super Robot Taisen Alpha (Japan)"
+	rom ( name "Super Robot Taisen Alpha (Japan).gdi" size 204 crc eccf3241 md5 f97cb153395c918499fdb5dc06019018 sha1 5dc123bbc6d42664fbfd94b3a75faf5235dbd42a )
+)
+
+game (
+	name "Super Runabout - San Francisco Edition (Europe)"
+	description "Super Runabout - San Francisco Edition (Europe)"
+	rom ( name "Super Runabout - San Francisco Edition (Europe).gdi" size 1959 crc ff8ef929 md5 16eab7503ea53bf5cfa49b283ad1cd54 sha1 9be9941650d9677fd1a772209804ff4043eb949b )
+)
+
+game (
+	name "Super Runabout (Japan)"
+	description "Super Runabout (Japan)"
+	rom ( name "Super Runabout (Japan).gdi" size 1384 crc 2fc22219 md5 c9970061c18b5b9909ea6afbec1f512e sha1 a0a068e5457f7b639104f1eb173e163024a94b7e )
+)
+
+game (
+	name "Super Speed Racing (Japan)"
+	description "Super Speed Racing (Japan)"
+	rom ( name "Super Speed Racing (Japan).gdi" size 1540 crc 3eaff761 md5 1cdc22027c5823e5ca96ad36c62ffe17 sha1 ffbe79961ef56fbd94457ef79615f34b1c948d6f )
+)
+
+game (
+	name "Surf Rocket Racers (USA)"
+	description "Surf Rocket Racers (USA)"
+	rom ( name "Surf Rocket Racers (USA).gdi" size 303 crc 18867f9e md5 181cfe2275ac9b852b57569044aeb236 sha1 87d4ce5aafc5055c3a34ceea6e355a0e2dec0b19 )
+)
+
+game (
+	name "Suzuki Alstare - Extreme Racing (Europe) (En,Fr,De,Es,It)"
+	description "Suzuki Alstare - Extreme Racing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Suzuki Alstare - Extreme Racing (Europe) (En,Fr,De,Es,It).gdi" size 1429 crc 092273d0 md5 72f8a8bc1fa7b195852f1895f3066e5c sha1 a7a295ac51cc0dbb4b69a2efc0e660e0a3ca6c0b )
+)
+
+game (
+	name "Sword of the Berserk - Guts' Rage (USA)"
+	description "Sword of the Berserk - Guts' Rage (USA)"
+	rom ( name "Sword of the Berserk - Guts' Rage (USA).gdi" size 225 crc bec84911 md5 50835664e3ca5f0a279b87bf9ac63004 sha1 c52387e647fbf7bb2d144118a46bcba3497c4e09 )
+)
+
+game (
+	name "Sydney 2000 (Japan)"
+	description "Sydney 2000 (Japan)"
+	rom ( name "Sydney 2000 (Japan).gdi" size 333 crc 074793de md5 c16398d0175805065796e2940522f875 sha1 e50616e9d5f235f75bef479abc8960041e663e36 )
+)
+
+game (
+	name "Sydney 2000 (USA)"
+	description "Sydney 2000 (USA)"
+	rom ( name "Sydney 2000 (USA).gdi" size 321 crc 04763b9d md5 e63d6bb92684ded953a69fee4720e3db sha1 6cadb4dd92331b8c3c4bae09535b084e88886fa3 )
+)
+
+game (
+	name "Tantei Shinshi Dash! (Japan)"
+	description "Tantei Shinshi Dash! (Japan)"
+	rom ( name "Tantei Shinshi Dash! (Japan).gdi" size 323 crc b3b51b6d md5 85c638e0be9e7459d31c49e6222fe870 sha1 2c10ffae9f6404ba4ebff7c3e22789001afdfff4 )
+)
+
+game (
+	name "Tech Romancer (Europe)"
+	description "Tech Romancer (Europe)"
+	rom ( name "Tech Romancer (Europe).gdi" size 174 crc 744febe3 md5 2f172ef4224587148530c4dc1613ce66 sha1 1bc488a1ae7299d76615655cd4178b10274b1e69 )
+)
+
+game (
+	name "Tee Off (Europe)"
+	description "Tee Off (Europe)"
+	rom ( name "Tee Off (Europe).gdi" size 156 crc 321f4f7b md5 f2fb0caf6f62f3aae2bdea9deb1895ce sha1 a58341a410a35c9c1894372988066b88c209a310 )
+)
+
+game (
+	name "Tee Off (USA)"
+	description "Tee Off (USA)"
+	rom ( name "Tee Off (USA).gdi" size 147 crc 331334c3 md5 447c5f9a83fb3c6c82cc85a0dc4b16d5 sha1 3f860c58958b1ccb9520f1546015915b02d225ab )
+)
+
+game (
+	name "Tennis 2K2 (USA) (En,Ja,Fr,De,Es) (Rev A)"
+	description "Tennis 2K2 (USA) (En,Ja,Fr,De,Es) (Rev A)"
+	rom ( name "Tennis 2K2 (USA) (En,Ja,Fr,De,Es) (Rev A).gdi" size 231 crc bbde2d03 md5 c7d4d8d00e7c9594cd21c7c2d9065c1a sha1 104ae4310d04dfada5cf0f67b53048a2ae3856c7 )
+)
+
+game (
+	name "Tetris 4D (Japan)"
+	description "Tetris 4D (Japan)"
+	rom ( name "Tetris 4D (Japan).gdi" size 321 crc 1211b0fb md5 2db0dac65dcc1aea59fa7a7361ec185b sha1 1e3278aa145398432ee956dcc9c7c1aef5ecb27b )
+)
+
+game (
+	name "Time Stalkers (USA)"
+	description "Time Stalkers (USA)"
+	rom ( name "Time Stalkers (USA).gdi" size 165 crc d8532de3 md5 1d71001ba052ab5ad8e4af0fde2b4860 sha1 b7f4e4fa3f69ec88adf9e84122204882a3cf9996 )
+)
+
+game (
+	name "Tokyo Highway Challenge (Europe)"
+	description "Tokyo Highway Challenge (Europe)"
+	rom ( name "Tokyo Highway Challenge (Europe).gdi" size 1474 crc 378812aa md5 68aab178eeef993c5769ef325541e1e5 sha1 72619c584001c1105f4f69773fb5876004ea0692 )
+)
+
+game (
+	name "Tokyo Xtreme Racer (USA)"
+	description "Tokyo Xtreme Racer (USA)"
+	rom ( name "Tokyo Xtreme Racer (USA).gdi" size 1306 crc ae3f783c md5 e23f98da3f8446f75da24205cf8dc676 sha1 6e50ecb88800d9b59f66ba9de0c9a3c15bc9f58a )
+)
+
+game (
+	name "Tokyo Xtreme Racer 2 (USA)"
+	description "Tokyo Xtreme Racer 2 (USA)"
+	rom ( name "Tokyo Xtreme Racer 2 (USA).gdi" size 186 crc 913f83f2 md5 7a92e795a6f651feb5e67cb810b6527f sha1 3b23665c4328839a1358ab0ac68c52f517a23db1 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six - Rogue Spear + Mission Pack - Urban Operations (Germany)"
+	description "Tom Clancy's Rainbow Six - Rogue Spear + Mission Pack - Urban Operations (Germany)"
+	rom ( name "Tom Clancy's Rainbow Six - Rogue Spear + Mission Pack - Urban Operations (Germany).gdi" size 11764 crc 3aca2b2e md5 869d7c5fb1c26a8e40b677abd264d184 sha1 c39f6fa8f696d29c9d979d4416353b9887c13e02 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six (Germany)"
+	description "Tom Clancy's Rainbow Six (Germany)"
+	rom ( name "Tom Clancy's Rainbow Six (Germany).gdi" size 2524 crc 2af92a2e md5 dbfa43cdc73d08024a5a0493355c9990 sha1 0e9d271c42f8a608fca76f575c0d4a902277ccb7 )
+)
+
+game (
+	name "Tomb Raider - Die Chronik (Germany)"
+	description "Tomb Raider - Die Chronik (Germany)"
+	rom ( name "Tomb Raider - Die Chronik (Germany).gdi" size 213 crc af88b0bb md5 be27895abcbc1e1ee1e2acc677cfd9a9 sha1 f5bace95a06f07bb2d17ad160f44e828f352adc9 )
+)
+
+game (
+	name "Tomb Raider - The Last Revelation (Europe)"
+	description "Tomb Raider - The Last Revelation (Europe)"
+	rom ( name "Tomb Raider - The Last Revelation (Europe).gdi" size 234 crc f76fae2e md5 2d605fd0e061b663336a371de250ccb7 sha1 745d42b757cebc874e2ea0670b213aae232fb4bd )
+)
+
+game (
+	name "Tomb Raider - The Last Revelation (USA)"
+	description "Tomb Raider - The Last Revelation (USA)"
+	rom ( name "Tomb Raider - The Last Revelation (USA).gdi" size 225 crc 0d231181 md5 3c87339b903c39cd14cf778947985821 sha1 7fc71e026fccdd12971e224104cceb01dca22395 )
+)
+
+game (
+	name "Tomb Raider Chronicles (Europe)"
+	description "Tomb Raider Chronicles (Europe)"
+	rom ( name "Tomb Raider Chronicles (Europe).gdi" size 201 crc 7a4f6dba md5 847198901734095fe911c15a692b7568 sha1 aa0007e3f48c24be26990e4ab4ea9ed7dbf5459c )
+)
+
+game (
+	name "Tomb Raider IV - The Last Revelation (Germany)"
+	description "Tomb Raider IV - The Last Revelation (Germany)"
+	rom ( name "Tomb Raider IV - The Last Revelation (Germany).gdi" size 246 crc c5919a08 md5 e4b33a869f1e115e1032361c8d3e0ade sha1 73b6b0ecba17664ca2e536a13808ee879c444774 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater (USA)"
+	description "Tony Hawk's Pro Skater (USA)"
+	rom ( name "Tony Hawk's Pro Skater (USA).gdi" size 318 crc 3e085ab1 md5 aa7cc90b6a5bf3096797b167934df645 sha1 752c19b56e3812faf129c551f897c2f2ab534634 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2 (Europe)"
+	description "Tony Hawk's Pro Skater 2 (Europe)"
+	rom ( name "Tony Hawk's Pro Skater 2 (Europe).gdi" size 348 crc c95d4afc md5 58c4be8cb4c29395160197cc9fb54431 sha1 5aa4b2cfa57956a45d187877a25c567ec03fa492 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2 (Germany)"
+	description "Tony Hawk's Pro Skater 2 (Germany)"
+	rom ( name "Tony Hawk's Pro Skater 2 (Germany).gdi" size 353 crc f5a67b9c md5 7f79d70b00af38046a047bba86e9fcf7 sha1 3d191f0940506b47d66aeffb72d9e33ac577b506 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 2 (USA)"
+	description "Tony Hawk's Pro Skater 2 (USA)"
+	rom ( name "Tony Hawk's Pro Skater 2 (USA).gdi" size 333 crc 71424247 md5 482c74167db0c5b94a728225be4cc29a sha1 d0c14c2d4927f522226c7976d31bfed16e9cbf6b )
+)
+
+game (
+	name "Toy Commander (USA) (En,Fr,De,Es)"
+	description "Toy Commander (USA) (En,Fr,De,Es)"
+	rom ( name "Toy Commander (USA) (En,Fr,De,Es).gdi" size 1069 crc 65310f76 md5 fab7286b6ec82c17dbdfdb9e6dcf513c sha1 6605710591f2d80524ec43805de2525a7d17da3c )
+)
+
+game (
+	name "Toy Racer (Europe) (En,Fr,De,Es)"
+	description "Toy Racer (Europe) (En,Fr,De,Es)"
+	rom ( name "Toy Racer (Europe) (En,Fr,De,Es).gdi" size 984 crc aee1fb8e md5 0697ea2e183e13000a13ebaac0b3c118 sha1 45643a25107c7b31e0bcaa8a62cc1901459e8e33 )
+)
+
+game (
+	name "TrickStyle (Europe) (En,Fr,De,Es,It)"
+	description "TrickStyle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "TrickStyle (Europe) (En,Fr,De,Es,It).gdi" size 1114 crc f7c69b3b md5 2ee4e97e5bc06714764ff9312d776ffe sha1 9e51a7750390f45eccf88275ce22079e05bbb518 )
+)
+
+game (
+	name "TrickStyle (USA)"
+	description "TrickStyle (USA)"
+	rom ( name "TrickStyle (USA).gdi" size 814 crc e0387600 md5 13b272a4a1f88423a7ebcb91928751d6 sha1 f97e718203235d58aac2df088bb3090cef50a2de )
+)
+
+game (
+	name "Triggerheart Exelica (Japan)"
+	description "Triggerheart Exelica (Japan)"
+	rom ( name "Triggerheart Exelica (Japan).gdi" size 192 crc cba0b926 md5 21afbd39ca1149a7b4fd3f61b1c74121 sha1 b8970b223bb9ce5249fa39f1ed391c234d3fbd1e )
+)
+
+game (
+	name "UEFA Dream Soccer (Europe) (En,Fr,De,Es)"
+	description "UEFA Dream Soccer (Europe) (En,Fr,De,Es)"
+	rom ( name "UEFA Dream Soccer (Europe) (En,Fr,De,Es).gdi" size 611 crc 1588884a md5 ea119e53ef95b835459697c9c2211919 sha1 7c79a2419983e0ca6e7fa74bd68ffd77d9dfc28b )
+)
+
+game (
+	name "UEFA Dream Soccer (France) (En,Fr,De,Es)"
+	description "UEFA Dream Soccer (France) (En,Fr,De,Es)"
+	rom ( name "UEFA Dream Soccer (France) (En,Fr,De,Es).gdi" size 611 crc 1f1416eb md5 19eaa45053131d2892753cf067688bf6 sha1 02dffc6e8d65f858943459ad34ab396501ff8d60 )
+)
+
+game (
+	name "UEFA Dream Soccer (Germany) (En,Fr,De,Es)"
+	description "UEFA Dream Soccer (Germany) (En,Fr,De,Es)"
+	rom ( name "UEFA Dream Soccer (Germany) (En,Fr,De,Es).gdi" size 619 crc fd347c79 md5 9a520f247aefb6e28bb3d2520471985a sha1 31c42ab2f9cf9b7d183703d577866a5f4354cb8b )
+)
+
+game (
+	name "UEFA Striker (Europe) (En,Fr,De,Es,It,Nl)"
+	description "UEFA Striker (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "UEFA Striker (Europe) (En,Fr,De,Es,It,Nl).gdi" size 542 crc c6edc7e0 md5 3b36721cbc5dcd3812e6986b479039b9 sha1 1f1979927c0ea2a8e1884624bcc6bbf52c94c427 )
+)
+
+game (
+	name "Ultimate Fighting Championship (Europe)"
+	description "Ultimate Fighting Championship (Europe)"
+	rom ( name "Ultimate Fighting Championship (Europe).gdi" size 373 crc e0023192 md5 ac19982f4a17cc7aade9c5841ae2843c sha1 581fc3e728e8a34b3bc96617cdb3658004f97257 )
+)
+
+game (
+	name "Ultimate Fighting Championship (Japan)"
+	description "Ultimate Fighting Championship (Japan)"
+	rom ( name "Ultimate Fighting Championship (Japan).gdi" size 222 crc 124575e1 md5 9a82c6da9829751b49935bd93d69a062 sha1 ca4ec373e1b3b3853b77ec669359df4036e84ee4 )
+)
+
+game (
+	name "Under Defeat (Japan)"
+	description "Under Defeat (Japan)"
+	rom ( name "Under Defeat (Japan).gdi" size 168 crc 15be62c2 md5 04174393951c0dd578d5852e84ad36ae sha1 d7c0278d101f5a55144f55d47ad93456441f6ab1 )
+)
+
+game (
+	name "Unreal Tournament (USA)"
+	description "Unreal Tournament (USA)"
+	rom ( name "Unreal Tournament (USA).gdi" size 1407 crc afb2582b md5 437966789f43414b6c5b037a83bbb473 sha1 3927c7709f927817716b25b5ee4eb77da1c6a7e2 )
+)
+
+game (
+	name "Urban Chaos (Europe) (En,Fr)"
+	description "Urban Chaos (Europe) (En,Fr)"
+	rom ( name "Urban Chaos (Europe) (En,Fr).gdi" size 318 crc 56bb7cf6 md5 0f336c691dd2cc8b81154d374cea164e sha1 7354f71fdc86ead7fd3cb622e8d28b85727c8d54 )
+)
+
+game (
+	name "Urban Chaos (USA) (En,Fr)"
+	description "Urban Chaos (USA) (En,Fr)"
+	rom ( name "Urban Chaos (USA) (En,Fr).gdi" size 303 crc d1a8b5bb md5 521bda80017e5c1aa03e9e475b8d8cff sha1 f4aad1ac51d287b4880e3461326fed84b2b66adc )
+)
+
+game (
+	name "V-Rally 2 - Expert Edition (Europe) (En,Fr,De)"
+	description "V-Rally 2 - Expert Edition (Europe) (En,Fr,De)"
+	rom ( name "V-Rally 2 - Expert Edition (Europe) (En,Fr,De).gdi" size 844 crc 53678f01 md5 066fb9f091ee07d9303027605a188940 sha1 f6cf3de7d2c088cd723f791cd84e61b55888e304 )
+)
+
+game (
+	name "Vanishing Point (Europe) (En,Fr,De,Es,It)"
+	description "Vanishing Point (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Vanishing Point (Europe) (En,Fr,De,Es,It).gdi" size 1268 crc b023a1df md5 7631379274e0365f9c0ae5211155e139 sha1 0195da91ac196eee989a9bc2d463d13fd73f14f3 )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offense (Europe)"
+	description "Vigilante 8 - 2nd Offense (Europe)"
+	rom ( name "Vigilante 8 - 2nd Offense (Europe).gdi" size 1444 crc 41803284 md5 a96f992e209903ad0e2a08f8af80be3e sha1 914a17a61ce7759829c31ecc4715db1545dc59a5 )
+)
+
+game (
+	name "Vigilante 8 - 2nd Offense (USA)"
+	description "Vigilante 8 - 2nd Offense (USA)"
+	rom ( name "Vigilante 8 - 2nd Offense (USA).gdi" size 1384 crc 489c9b26 md5 3bfdabb46d964f180c9b3b045c5d6408 sha1 863d58e64767f9684fd75c38a33e053bc471f224 )
+)
+
+game (
+	name "Virtua Athlete 2000 (USA) (En,Fr,De,Es)"
+	description "Virtua Athlete 2000 (USA) (En,Fr,De,Es)"
+	rom ( name "Virtua Athlete 2000 (USA) (En,Fr,De,Es).gdi" size 225 crc f016b88c md5 c19e6ab0feb1b0be4fb8d4255fbd292f sha1 f261579591a728105dd39c7d6eec622c4a439ddd )
+)
+
+game (
+	name "Virtua Athlete 2K (Europe) (En,Fr,De,Es)"
+	description "Virtua Athlete 2K (Europe) (En,Fr,De,Es)"
+	rom ( name "Virtua Athlete 2K (Europe) (En,Fr,De,Es).gdi" size 228 crc 4d2e944d md5 a7e01407d1ed3b5f05ef53f2de9bf071 sha1 2ce9492c7af9be9e28a459f687d3dea30d350924 )
+)
+
+game (
+	name "Virtua Athlete 2K (Japan)"
+	description "Virtua Athlete 2K (Japan)"
+	rom ( name "Virtua Athlete 2K (Japan).gdi" size 183 crc 4ee9faaf md5 63c8d418e87d6069164038ec9e74df34 sha1 19c7fdfde9486f31068dba268519f84f2f351621 )
+)
+
+game (
+	name "Virtua Cop 2 (Japan)"
+	description "Virtua Cop 2 (Japan)"
+	rom ( name "Virtua Cop 2 (Japan).gdi" size 2266 crc 52e12175 md5 b7cbf011a372cc813c861e38223dc65d sha1 00c5ce8c5ca2ea97e47215810edafd17bf27c056 )
+)
+
+game (
+	name "Virtua Fighter 3tb (Europe)"
+	description "Virtua Fighter 3tb (Europe)"
+	rom ( name "Virtua Fighter 3tb (Europe).gdi" size 189 crc 40b058aa md5 ebc13ae755f154426700b66225f2812d sha1 13e8e7e55a11a5548464d650e6c3aee675dc84be )
+)
+
+game (
+	name "Virtua Fighter 3tb (Japan) (v1.000)"
+	description "Virtua Fighter 3tb (Japan) (v1.000)"
+	rom ( name "Virtua Fighter 3tb (Japan) (v1.000).gdi" size 213 crc 04f516d6 md5 b24bcd00d9ae6fbf975749374f805e19 sha1 cb06e10807dc67ba1b7684ce69074e15be60e532 )
+)
+
+game (
+	name "Virtua Fighter 3tb (Japan) (v1.003)"
+	description "Virtua Fighter 3tb (Japan) (v1.003)"
+	rom ( name "Virtua Fighter 3tb (Japan) (v1.003).gdi" size 213 crc 15644fc1 md5 f12b22366b64f42694ecb4ccf2cf7ec2 sha1 ac5bfff04d11b728afb630871f5e79fd20dd5ee2 )
+)
+
+game (
+	name "Virtua Fighter 3tb (USA)"
+	description "Virtua Fighter 3tb (USA)"
+	rom ( name "Virtua Fighter 3tb (USA).gdi" size 180 crc 38cbfa9c md5 a0c9be5eb816ccc9f4d95df8b17cd7ef sha1 8cda6c35100161c63a29cd7c8e011c13695b752f )
+)
+
+game (
+	name "Virtua Fighter 4 Passport (Japan)"
+	description "Virtua Fighter 4 Passport (Japan)"
+	rom ( name "Virtua Fighter 4 Passport (Japan).gdi" size 207 crc 5e42dea3 md5 ab119b4aebcfb5042a1f7650286fbcef sha1 260767e4c9ecc536dbe48d480ac90f4cb070b08b )
+)
+
+game (
+	name "Virtua Fighter History & VF4 (Japan)"
+	description "Virtua Fighter History & VF4 (Japan)"
+	rom ( name "Virtua Fighter History & VF4 (Japan).gdi" size 287 crc df2c36cf md5 d3766ddbd3b51ba4bd329d8c515ca86a sha1 bb80c13c095c6986574eb179836647edbfa67b16 )
+)
+
+game (
+	name "Virtua Striker 2 Ver. 2000.1 (Europe) (En,Ja,Fr,De,Es)"
+	description "Virtua Striker 2 Ver. 2000.1 (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Virtua Striker 2 Ver. 2000.1 (Europe) (En,Ja,Fr,De,Es).gdi" size 270 crc d578d8c5 md5 ece9fa06b18724b139578a9764a47c2e sha1 3ceb9c17e5da615c501cc702bf27b0e276aa6328 )
+)
+
+game (
+	name "Virtua Striker 2 Ver. 2000.1 (Japan) (En,Ja,Fr,De,Es)"
+	description "Virtua Striker 2 Ver. 2000.1 (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Virtua Striker 2 Ver. 2000.1 (Japan) (En,Ja,Fr,De,Es).gdi" size 267 crc 01533d7a md5 6afceb9045a0ab9334177095cef61226 sha1 200089cd491373b3114ea5d62f80aeca7180eaf7 )
+)
+
+game (
+	name "Virtua Tennis - Sega Professional Tennis (Europe) (En,Fr,De,Es)"
+	description "Virtua Tennis - Sega Professional Tennis (Europe) (En,Fr,De,Es)"
+	rom ( name "Virtua Tennis - Sega Professional Tennis (Europe) (En,Fr,De,Es).gdi" size 297 crc 7bf900b5 md5 166415a6dd7f579a15b1cf9b1f155d0c sha1 a7a85354d7cbc334793de0411637bf1453e7925e )
+)
+
+game (
+	name "Virtua Tennis 2 - Sega Professional Tennis (Europe) (En,Fr,De,Es)"
+	description "Virtua Tennis 2 - Sega Professional Tennis (Europe) (En,Fr,De,Es)"
+	rom ( name "Virtua Tennis 2 - Sega Professional Tennis (Europe) (En,Fr,De,Es).gdi" size 303 crc c01e4b94 md5 c7d73c32abec02a6ccb4b3aadf09ec5f sha1 cebea3db8f95aa75dd52426c939684b32cfaa24a )
+)
+
+game (
+	name "Walt Disney World Quest - Magical Racing Tour (USA)"
+	description "Walt Disney World Quest - Magical Racing Tour (USA)"
+	rom ( name "Walt Disney World Quest - Magical Racing Tour (USA).gdi" size 1695 crc 491e4548 md5 a65d2b0be7f260dfca84125de3c0aa33 sha1 d2ae120f3e8c341aab3917b6f1386425d83a9b26 )
+)
+
+game (
+	name "Web Browser (USA)"
+	description "Web Browser (USA)"
+	rom ( name "Web Browser (USA).gdi" size 268 crc 01f54186 md5 c468783fee4ab440b1345effce981d06 sha1 8814d1ca87f956f03742d04bffebb244efbcd63b )
+)
+
+game (
+	name "Web Browser (USA) (Rev A)"
+	description "Web Browser (USA) (Rev A)"
+	rom ( name "Web Browser (USA) (Rev A).gdi" size 308 crc 8c07b83d md5 2709bc2dffca9ee3fbfb4a4a16dacec7 sha1 fedfbfc36fbeef4e66dee96a6c04de88dc8f871b )
+)
+
+game (
+	name "Web Browser 2.0 (USA)"
+	description "Web Browser 2.0 (USA)"
+	rom ( name "Web Browser 2.0 (USA).gdi" size 288 crc caa227cb md5 698a32b14bdbdaff79131f9d5e8c6918 sha1 eb01f07b3c51f04fab75a41941811223cbe607a7 )
+)
+
+game (
+	name "Wetrix+ (Europe) (En,Fr,De)"
+	description "Wetrix+ (Europe) (En,Fr,De)"
+	rom ( name "Wetrix+ (Europe) (En,Fr,De).gdi" size 849 crc 05ad610d md5 03db2721fb2d35cd89293ad436ee345c sha1 9b0c03efcae12332e1f7f27a4d92b1ff2eb0e51c )
+)
+
+game (
+	name "Wetrix+ (USA)"
+	description "Wetrix+ (USA)"
+	rom ( name "Wetrix+ (USA).gdi" size 667 crc 6c4da5eb md5 caea937d5cb35c4ea077c03b7cee236b sha1 3508b52c9ad419b6bf045a931e4fe74e4120dacc )
+)
+
+game (
+	name "Who Wants to Be a Millionaire (Europe)"
+	description "Who Wants to Be a Millionaire (Europe)"
+	rom ( name "Who Wants to Be a Millionaire (Europe).gdi" size 373 crc 6651f802 md5 7466cb63959d97b3c824dc9289855e1a sha1 7e05ed04e2d6ffc30db5d11071a9e64fed6e4615 )
+)
+
+game (
+	name "Who Wants to Beat Up a Millionaire (USA)"
+	description "Who Wants to Beat Up a Millionaire (USA)"
+	rom ( name "Who Wants to Beat Up a Millionaire (USA).gdi" size 383 crc 05e50c0b md5 d50c2d2d761fba676e911f5bba4dfb6e sha1 c4894d2f0ad2efe083defff73050e559749c9cb7 )
+)
+
+game (
+	name "World Series Baseball 2K2 (USA)"
+	description "World Series Baseball 2K2 (USA)"
+	rom ( name "World Series Baseball 2K2 (USA).gdi" size 338 crc 20d2a6be md5 974f6b632aa53dde2bedab5a3b4de13f sha1 b70fbf52b6974e5670a1adf7fdf0ca8fc8a79f0e )
+)
+
+game (
+	name "Worms Armageddon (Europe) (En,Fr,De,Nl,Sv,No,Da)"
+	description "Worms Armageddon (Europe) (En,Fr,De,Nl,Sv,No,Da)"
+	rom ( name "Worms Armageddon (Europe) (En,Fr,De,Nl,Sv,No,Da).gdi" size 675 crc 4606b8b7 md5 a2086b27bd01c1e96075b1844027d4e5 sha1 3b17f3035f261ea68e2768399311faf1f55dab2b )
+)
+
+game (
+	name "Worms Armageddon (USA) (En,Fr,De,Nl,Sv,No,Da)"
+	description "Worms Armageddon (USA) (En,Fr,De,Nl,Sv,No,Da)"
+	rom ( name "Worms Armageddon (USA) (En,Fr,De,Nl,Sv,No,Da).gdi" size 651 crc 6b64127e md5 93f1d019466e69132c96c4253bf878af sha1 219ee6e6379ab93617ef8087df6e0a9b6cd58245 )
+)
+
+game (
+	name "Worms World Party (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	description "Worms World Party (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	rom ( name "Worms World Party (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).gdi" size 1624 crc c1caa567 md5 65b1f820150ab1c034b3bb436cff8d20 sha1 bef2dc7324d52eb73ab656e47756147f3d9e4a63 )
+)
+
+game (
+	name "Worms World Party (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	description "Worms World Party (USA) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	rom ( name "Worms World Party (USA) (En,Fr,De,Es,It,Nl,Sv,Da).gdi" size 1570 crc b2cc833e md5 b115b59b287916f21060c38acaf911ff sha1 87bf97c7ff6884981cfe4352633cf9df28517715 )
+)
+
+game (
+	name "WWF Attitude (Europe)"
+	description "WWF Attitude (Europe)"
+	rom ( name "WWF Attitude (Europe).gdi" size 288 crc 680939e4 md5 0ae0beea50be7a63580016afe6749e33 sha1 1471c4136da018e72aebd08378959abc49cfcde8 )
+)
+
+game (
+	name "WWF Royal Rumble (Europe)"
+	description "WWF Royal Rumble (Europe)"
+	rom ( name "WWF Royal Rumble (Europe).gdi" size 183 crc 00e473b4 md5 0398a204944486024a24c347e47a06a6 sha1 951fc73a3cde2cbda7e124fe101d85a0963fd7bc )
+)
+
+game (
+	name "WWF Royal Rumble (USA)"
+	description "WWF Royal Rumble (USA)"
+	rom ( name "WWF Royal Rumble (USA).gdi" size 174 crc d5a73308 md5 bcd630f1c8ef6fbd23f6cc18bf70a7ae sha1 9fe8ed17a3b18122111844b6a0f1fea8d56b3577 )
+)
+
+game (
+	name "Yume Baken '99 - Internet (Japan)"
+	description "Yume Baken '99 - Internet (Japan)"
+	rom ( name "Yume Baken '99 - Internet (Japan).gdi" size 207 crc e3d35441 md5 b397c8098bf9e24586d28f8821327e1b sha1 bb86d53b016d2481cfcc7f39f9b3037ce8dbbac6 )
+)
+
+game (
+	name "Zombie Revenge (Japan)"
+	description "Zombie Revenge (Japan)"
+	rom ( name "Zombie Revenge (Japan).gdi" size 174 crc 9e532dfe md5 0c77da5dbb99e9eadd06901b375df379 sha1 4d24cb205cb3c54167aa7c9948497e1de1e3140b )
+)
+
+game (
+	name "Zombie Revenge (Japan) (Rev A)"
+	description "Zombie Revenge (Japan) (Rev A)"
+	rom ( name "Zombie Revenge (Japan) (Rev A).gdi" size 198 crc 283dad3e md5 d3f4ea1f5a698aae9b825ee0f14e9608 sha1 1dcecf5746721d06255c1c3cf707571d0715947b )
+)


### PR DESCRIPTION
This adds a DAT that will index Sega - Dreamcast games, built from [Redump](http://redump.org) through [this script](https://github.com/RobLoach/libretro-sega-dreamcast.dat). Reicast needs just the GDI files.