### PR TITLE
Fix Trurip overwriting Redump CRCs

### DIFF
--- a/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
+++ b/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
@@ -111,6 +111,12 @@ game (
 game (
 	name "Advanced V.G. (Japan)"
 	description "Advanced V.G. (Japan)"
+	rom ( name "Advanced V.G. (Japan).cue" size 3543 crc 08fb23e6 md5 39b67de686bdea7f25cb17bb5dd59bf3 sha1 e957bd617790e9942879f5f866778b85cefeea12 )
+)
+
+game (
+	name "Advanced V.G. (Japan)"
+	description "Advanced V.G. (Japan)"
 	rom ( name "Advanced V.G. (Japan).cue" size 15957 crc fcf40591 md5 98165fdae144af23d403a2b47f6f29b1 sha1 a7f044f7d87ee0906d78cc16438139b8059eae8a )
 )
 
@@ -339,6 +345,12 @@ game (
 game (
 	name "Bishoujo Senshi Sailor Moon (Japan)"
 	description "Bishoujo Senshi Sailor Moon (Japan)"
+	rom ( name "Bishoujo Senshi Sailor Moon (Japan).cue" size 2619 crc 0542f068 md5 a75f79125e4e30f19fcdc61ad4cd727f sha1 e24d584d81aba54e2aeb55feb71aa2ee069bb053 )
+)
+
+game (
+	name "Bishoujo Senshi Sailor Moon (Japan)"
+	description "Bishoujo Senshi Sailor Moon (Japan)"
 	rom ( name "Bishoujo Senshi Sailor Moon (Japan).cue" size 10413 crc e645ac0f md5 e2ff3e2d9c65c45fbb0b6d4f2d933175 sha1 d825610729d4b5ef63937aa3c7c78bb925513458 )
 )
 
@@ -357,7 +369,19 @@ game (
 game (
 	name "Black Hole Assault (Japan)"
 	description "Black Hole Assault (Japan)"
+	rom ( name "Black Hole Assault (Japan).cue" size 2426 crc 9089758b md5 0f577575046ea78cef960c8af1eba46a sha1 79e536acfdfd9a574f4b2cf3aa889171cff55d71 )
+)
+
+game (
+	name "Black Hole Assault (Japan)"
+	description "Black Hole Assault (Japan)"
 	rom ( name "Black Hole Assault (Japan).cue" size 10548 crc 67a89154 md5 5d1d8da931298c4729b9980891e1c792 sha1 d3e8836aae518734d7e1bedbee641223b863559c )
+)
+
+game (
+	name "Blood Gear (Japan)"
+	description "Blood Gear (Japan)"
+	rom ( name "Blood Gear (Japan).cue" size 4152 crc 750afee7 md5 c23a2b7ff6b1556e955243742b304c5d sha1 976eb3b38982c1a833071ce72185812a1716ced3 )
 )
 
 game (
@@ -471,6 +495,12 @@ game (
 game (
 	name "Buster Bros. (USA)"
 	description "Buster Bros. (USA)"
+	rom ( name "Buster Bros. (USA).cue" size 2262 crc 611eda79 md5 a958f232f77503e63c07df7c06d16e54 sha1 1353074ea838c9f7a12a4bbc4d182c9e474d0804 )
+)
+
+game (
+	name "Buster Bros. (USA)"
+	description "Buster Bros. (USA)"
 	rom ( name "Buster Bros. (USA).cue" size 10689 crc 9a754870 md5 dd31510b3bfc170617306738eb27bedb sha1 f7a3b39a93ef7a035dacfe130c44c4514b4e4c37 )
 )
 
@@ -514,6 +544,12 @@ game (
 	name "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
 	description "Campaign Version - Daisenryaku II (Japan) (Rev 4)"
 	rom ( name "Campaign Version - Daisenryaku II (Japan) (Rev 4).cue" size 1647 crc 0adbebba md5 87f7c3d5a30b3fba929a6fbb44ae22b2 sha1 0167fdd6608d3ac6798eb3613b58b266ddbed639 )
+)
+
+game (
+	name "Cardangels (Japan)"
+	description "Cardangels (Japan)"
+	rom ( name "Cardangels (Japan).cue" size 3877 crc 2a67d8c6 md5 639b8c4e5d938789a2613d00eeba7a99 sha1 f2322b9ee295c406c3a4a65e5a692bfe1f15198a )
 )
 
 game (
@@ -915,6 +951,12 @@ game (
 game (
 	name "Dragon Half (Japan)"
 	description "Dragon Half (Japan)"
+	rom ( name "Dragon Half (Japan).cue" size 2104 crc 43b5b909 md5 bd2b3ab2cfbae22c4fc4d825d512c712 sha1 691892ab2509b26533ee31c7f515f4de667b63cc )
+)
+
+game (
+	name "Dragon Half (Japan)"
+	description "Dragon Half (Japan)"
 	rom ( name "Dragon Half (Japan).cue" size 9880 crc 9963171d md5 b919a8eb5a93fe82a2c2b52826cec702 sha1 0d856247e626ba8e25105b8540cf7303a9eb2b6e )
 )
 
@@ -1018,6 +1060,12 @@ game (
 	name "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
 	description "Dungeon Master - Theron's Quest (Japan) (Rev 1)"
 	rom ( name "Dungeon Master - Theron's Quest (Japan) (Rev 1).cue" size 2363 crc e7e53704 md5 85706e7c2f658bc2792511d618dfc7a5 sha1 55ee4a0fb1249fc0d448c63db2eba531552e0670 )
+)
+
+game (
+	name "Dungeon Master - Theron's Quest (USA)"
+	description "Dungeon Master - Theron's Quest (USA)"
+	rom ( name "Dungeon Master - Theron's Quest (USA).cue" size 2173 crc f09fb9c5 md5 63dbd2fab613b2e8030ff4e44b978a39 sha1 faeeb80715979a809ec7b0811e8ea3e2e12ee2d0 )
 )
 
 game (
@@ -1144,6 +1192,12 @@ game (
 	name "F1 Team Simulation Project F (Japan)"
 	description "F1 Team Simulation Project F (Japan)"
 	rom ( name "F1 Team Simulation Project F (Japan).cue" size 13542 crc 079559b2 md5 0aa3a9915ca00d06d00ec3decbeeb251 sha1 def03c69154b55036f11e35d9c6f3be5364f072d )
+)
+
+game (
+	name "Faceball (Japan)"
+	description "Faceball (Japan)"
+	rom ( name "Faceball (Japan).cue" size 1510 crc 1d39808b md5 e1b2000de014b19cb7793c3b9415a824 sha1 c567c0212e835e819e56f3561729c6adab761120 )
 )
 
 game (
@@ -1557,6 +1611,12 @@ game (
 game (
 	name "Gradius II - Gofer no Yabou (Japan)"
 	description "Gradius II - Gofer no Yabou (Japan)"
+	rom ( name "Gradius II - Gofer no Yabou (Japan).cue" size 3098 crc 00738bf2 md5 c350d8caedf75342e6bc90f971ef8bd8 sha1 5ee196838abcab72fca933849f76d6091c00f069 )
+)
+
+game (
+	name "Gradius II - Gofer no Yabou (Japan)"
+	description "Gradius II - Gofer no Yabou (Japan)"
 	rom ( name "Gradius II - Gofer no Yabou (Japan).cue" size 12326 crc f961059b md5 87f1bbf74ca8f8a09b046e17dac130c0 sha1 4c7d4262d7d3cca4d40c6af2c4cc5170f6a7b165 )
 )
 
@@ -1665,6 +1725,12 @@ game (
 game (
 	name "Himitsu no Hanazono (Japan)"
 	description "Himitsu no Hanazono (Japan)"
+	rom ( name "Himitsu no Hanazono (Japan).cue" size 466 crc 7dc0aaf4 md5 1835229a8091df26f3fd10d0604e874d sha1 266a18e4e15e2715e64bdc0789d1eb35db17819a )
+)
+
+game (
+	name "Himitsu no Hanazono (Japan)"
+	description "Himitsu no Hanazono (Japan)"
 	rom ( name "Himitsu no Hanazono (Japan).cue" size 2449 crc ed56d0be md5 bf15b7df688b29b24df7e6a05f3f57c2 sha1 fa1d7995d63f31b34e452c7aa6f3ddbcb1a8cde9 )
 )
 
@@ -1678,6 +1744,12 @@ game (
 	name "Hokutosei no Onna - Nishimura Kyoutarou (Japan) - 北斗星の女+西村京太郎"
 	description "Hokutosei no Onna - Nishimura Kyoutarou (Japan) - 北斗星の女+西村京太郎"
 	rom ( name "Hokutosei no Onna - Nishimura Kyoutarou (Japan).cue" size 10313 crc 190481f7 md5 0f2de0a77be83254b25a3de6622367da sha1 f502184187918e53135810c58fa42d84847da05b )
+)
+
+game (
+	name "Horror Story (Japan)"
+	description "Horror Story (Japan)"
+	rom ( name "Horror Story (Japan).cue" size 1574 crc c142edf7 md5 e89a8beee37cfa4506c11362b392b1c3 sha1 697171a04804c4ea781b96a159fc125bf52c8e06 )
 )
 
 game (
@@ -1749,7 +1821,19 @@ game (
 game (
 	name "Hyper Wars (Japan)"
 	description "Hyper Wars (Japan)"
+	rom ( name "Hyper Wars (Japan).cue" size 1818 crc e64a6594 md5 345ddd412935aae850443bba39324218 sha1 4b62b31414262182b9d4758953fc719b8c69104a )
+)
+
+game (
+	name "Hyper Wars (Japan)"
+	description "Hyper Wars (Japan)"
 	rom ( name "Hyper Wars (Japan).cue" size 9177 crc 48b81a7d md5 392955cde5ecd1da82d9a9cd7009b239 sha1 42e3daae67517176e0067c1a206b53fdbe018fc3 )
+)
+
+game (
+	name "Iga Ninden Gaiou (Japan)"
+	description "Iga Ninden Gaiou (Japan)"
+	rom ( name "Iga Ninden Gaiou (Japan).cue" size 3535 crc 29a0cecb md5 7e30ce49c071cb2cba3019928820e52f sha1 9ea37a8afb90158b077bf45cb57c26b9f9da9809 )
 )
 
 game (
@@ -1845,6 +1929,12 @@ game (
 game (
 	name "J. League Tremendous Soccer '94 (Japan)"
 	description "J. League Tremendous Soccer '94 (Japan)"
+	rom ( name "J. League Tremendous Soccer '94 (Japan).cue" size 2960 crc a0ab09c8 md5 51afcf23bf49d39ed7f350d245c9c5c7 sha1 994fd932b03d67b776fe0f62f24febbc9eae7ecc )
+)
+
+game (
+	name "J. League Tremendous Soccer '94 (Japan)"
+	description "J. League Tremendous Soccer '94 (Japan)"
 	rom ( name "J. League Tremendous Soccer '94 (Japan).cue" size 11371 crc 3d98b224 md5 3101dccc4a5a6574c7b66ddb2709b2ef sha1 4f38c45fd5d72757e81c9a23168f7eea2a3e0c63 )
 )
 
@@ -1870,6 +1960,12 @@ game (
 	name "Janshin Densetsu - Quest of Jongmaster (Japan)"
 	description "Janshin Densetsu - Quest of Jongmaster (Japan)"
 	rom ( name "Janshin Densetsu - Quest of Jongmaster (Japan).cue" size 12188 crc fa2a1a77 md5 db09e3a5f741604177f58c0d265ab18c sha1 b926494e414e1b485f38c9461c49ff59cfb41b45 )
+)
+
+game (
+	name "Jantei Monogatari (Japan)"
+	description "Jantei Monogatari (Japan)"
+	rom ( name "Jantei Monogatari (Japan).cue" size 531 crc e5eb11fe md5 2b59bfd0d393789f48c40ebf10c86b81 sha1 3b363eee89ae26119000425830f3f8c8c08ad184 )
 )
 
 game (
@@ -1959,6 +2055,12 @@ game (
 game (
 	name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
 	description "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
+	rom ( name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan).cue" size 6805 crc ffc004fe md5 3a55f6f2796a0cc436d4e5efca946f69 sha1 11a73031ca7050943c7cd652fd08729e5bbf44ab )
+)
+
+game (
+	name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
+	description "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan)"
 	rom ( name "Kaizou Choujin Shubibinman 3 - Ikai no Princess (Japan).cue" size 22322 crc 1a4016c9 md5 17312541dc0724b651603e6c6d413c63 sha1 659c42a79399d3eac43dc144b6fd28592a94a668 )
 )
 
@@ -1989,6 +2091,12 @@ game (
 game (
 	name "Kaze no Densetsu Xanadu (Japan) (Sample)"
 	description "Kaze no Densetsu Xanadu (Japan) (Sample)"
+	rom ( name "Kaze no Densetsu Xanadu (Japan) (Sample).cue" size 2006 crc dd8ffd19 md5 acfdaef8e71c8dc4a5d41e046bd05e96 sha1 1e19ec32840d768859ff5474075f32de8685db7d )
+)
+
+game (
+	name "Kaze no Densetsu Xanadu (Japan) (Sample)"
+	description "Kaze no Densetsu Xanadu (Japan) (Sample)"
 	rom ( name "Kaze no Densetsu Xanadu (Japan) (Sample).cue" size 7876 crc 9bf324a8 md5 447c620919f254a7d43d8752c468c75d sha1 d9a311a5c27306bfd0d574fcf420fa3eb55fb242 )
 )
 
@@ -1996,6 +2104,12 @@ game (
 	name "Kaze no Densetsu Xanadu II (Japan)"
 	description "Kaze no Densetsu Xanadu II (Japan)"
 	rom ( name "Kaze no Densetsu Xanadu II (Japan).cue" size 20425 crc d2c96719 md5 4d193e17bf90da67a908ab65646dc927 sha1 9132cec0ba9ba1f1b41e521288fc664fc9b31e35 )
+)
+
+game (
+	name "Kiaidan 00 (Japan)"
+	description "Kiaidan 00 (Japan)"
+	rom ( name "Kiaidan 00 (Japan).cue" size 3381 crc 96856963 md5 fc64a6363a1049829b371ac8fe00de31 sha1 1e03ccd129c004004948e0ea99282f3d73255691 )
 )
 
 game (
@@ -2032,6 +2146,12 @@ game (
 	name "Kisou Louga (Japan) (FABT)"
 	description "Kisou Louga (Japan) (FABT)"
 	rom ( name "Kisou Louga (Japan) (FABT).cue" size 2235 crc 714bc898 md5 adfa811da777c802a833b95a7229ae77 sha1 81dd8b937b5d34d7ba19c56bb9ac6e2b2c5c7a2d )
+)
+
+game (
+	name "Kisou Louga II - The Ends of Shangrila (Japan)"
+	description "Kisou Louga II - The Ends of Shangrila (Japan)"
+	rom ( name "Kisou Louga II - The Ends of Shangrila (Japan).cue" size 3878 crc dceff56e md5 33a75568b0b186832959b6bcf8462f4e sha1 99947ec29fed8bc85046cdd2d0795cf5c3e4c31a )
 )
 
 game (
@@ -2235,6 +2355,12 @@ game (
 game (
 	name "Lord of Wars (Japan)"
 	description "Lord of Wars (Japan)"
+	rom ( name "Lord of Wars (Japan).cue" size 994 crc 3622b402 md5 91e2be8bec5b315c942cd13a6d1eada6 sha1 b7f7bd1fdb9a5a7fcbeac8067cebe4e7bf4c8569 )
+)
+
+game (
+	name "Lord of Wars (Japan)"
+	description "Lord of Wars (Japan)"
 	rom ( name "Lord of Wars (Japan).cue" size 4872 crc f0e94cb8 md5 20199255046fe44751b75d7448c1607c sha1 32ce2479ce31c16c870cfc52e78c0197696e9552 )
 )
 
@@ -2242,6 +2368,12 @@ game (
 	name "Lords of the Rising Sun (USA)"
 	description "Lords of the Rising Sun (USA)"
 	rom ( name "Lords of the Rising Sun (USA).cue" size 17841 crc 43670140 md5 d7ae35f0db2e62f7bee13b3f6e618639 sha1 f54cd7f0a58e88b6d21eeae25113fcf95ea44fd0 )
+)
+
+game (
+	name "Lords of Thunder (USA)"
+	description "Lords of Thunder (USA)"
+	rom ( name "Lords of Thunder (USA).cue" size 2264 crc 21b7921d md5 6d3048fa92edbffb53fb278b3544000e sha1 97ba44a16452777d9d35a70e2e3f05b412680e3c )
 )
 
 game (
@@ -2307,6 +2439,12 @@ game (
 game (
 	name "Magicoal (Japan)"
 	description "Magicoal (Japan)"
+	rom ( name "Magicoal (Japan).cue" size 2714 crc 5f23f966 md5 a4df187260a031af216e841b97664cc0 sha1 c71954430b0d39b6fe7547ab2fdcab9518d63506 )
+)
+
+game (
+	name "Magicoal (Japan)"
+	description "Magicoal (Japan)"
 	rom ( name "Magicoal (Japan).cue" size 12968 crc 0274bbde md5 5d654c67c74efbb121f3895618ad72f2 sha1 0df8e1f9d10c5a044b6d7cbd571049cdaa441aca )
 )
 
@@ -2314,6 +2452,12 @@ game (
 	name "Mahjong Clinic Special (Japan)"
 	description "Mahjong Clinic Special (Japan)"
 	rom ( name "Mahjong Clinic Special (Japan).cue" size 7461 crc aba57389 md5 933919c0db70a4830662fdbf19677c0d sha1 67170dbc8a12d4ae470c0966f722d360d79893c7 )
+)
+
+game (
+	name "Mahjong Lemon Angel (Japan)"
+	description "Mahjong Lemon Angel (Japan)"
+	rom ( name "Mahjong Lemon Angel (Japan).cue" size 8296 crc 6f54e3ed md5 1545bf28a19b73e80f0e418a171b856b sha1 1df872ca0e18e899b4d5b5d17d69c5678a98acfb )
 )
 
 game (
@@ -2373,6 +2517,12 @@ game (
 game (
 	name "Manhole, The (Japan)"
 	description "Manhole, The (Japan)"
+	rom ( name "Manhole, The (Japan).cue" size 3414 crc e0e87ac8 md5 e6176bfb94fe9d8c7f7da4a48b143cff sha1 4601dd264da00e1ee0bdc98ae3c29ea1d6cf4699 )
+)
+
+game (
+	name "Manhole, The (Japan)"
+	description "Manhole, The (Japan)"
 	rom ( name "Manhole, The (Japan).cue" size 15551 crc 5d7eb494 md5 1c90d6397660db151dc833884d87ab91 sha1 9dcbdd39c4c27fb4217def844d2d84fd26825c0c )
 )
 
@@ -2421,6 +2571,12 @@ game (
 game (
 	name "Megami Paradise (Japan)"
 	description "Megami Paradise (Japan)"
+	rom ( name "Megami Paradise (Japan).cue" size 4187 crc 0b754bd7 md5 59c80ea63dd19af2fef59f1593a7e545 sha1 dde4a9caa000fc7f7f21f404f2b419c0e8218b30 )
+)
+
+game (
+	name "Megami Paradise (Japan)"
+	description "Megami Paradise (Japan)"
 	rom ( name "Megami Paradise (Japan).cue" size 18389 crc f0ec249f md5 2b476b182e19fe8fa7b722c5d131f330 sha1 596b7843f3ae18281ead8d75fe47522011e455de )
 )
 
@@ -2451,7 +2607,19 @@ game (
 game (
 	name "Might and Magic (Japan)"
 	description "Might and Magic (Japan)"
+	rom ( name "Might and Magic (Japan).cue" size 1147 crc ff7ec5fa md5 068a30848882baaefc41c0c44fd2bbf0 sha1 50e6aca311eaee9dbd12ff710f68fe48af8abac1 )
+)
+
+game (
+	name "Might and Magic (Japan)"
+	description "Might and Magic (Japan)"
 	rom ( name "Might and Magic (Japan).cue" size 5429 crc e8750c30 md5 ab5120fa6360b32ba540c4a9c6a6bf81 sha1 917605d3357530c1df232dee77dbb24fdb6fa0ad )
+)
+
+game (
+	name "Might and Magic III - Isles of Terra (Japan)"
+	description "Might and Magic III - Isles of Terra (Japan)"
+	rom ( name "Might and Magic III - Isles of Terra (Japan).cue" size 1958 crc 3755288c md5 e1dc36e4c8e01cd40393b7e86fa4c805 sha1 c96825247a7731af8134cde730f05f7a15b082cb )
 )
 
 game (
@@ -2482,6 +2650,12 @@ game (
 	name "Mirai Shounen Conan (Japan)"
 	description "Mirai Shounen Conan (Japan)"
 	rom ( name "Mirai Shounen Conan (Japan).cue" size 5717 crc d7889763 md5 f5ae0b1568d9ff5eea77e1f61ee07f74 sha1 4d60ae05a53f2ef98669067df39206b29be19404 )
+)
+
+game (
+	name "Mitsubachi Gakuen (Japan)"
+	description "Mitsubachi Gakuen (Japan)"
+	rom ( name "Mitsubachi Gakuen (Japan).cue" size 1437 crc fc27e1bb md5 f3ff2be726cdb4f370201476a5967b8b sha1 522db7daff965d160d80f1358672a534c6cc652d )
 )
 
 game (
@@ -2529,6 +2703,12 @@ game (
 game (
 	name "Moonlight Lady (Japan)"
 	description "Moonlight Lady (Japan)"
+	rom ( name "Moonlight Lady (Japan).cue" size 4614 crc d915ccea md5 b0c11fea871677ac012ba353255cd1ba sha1 c84db150a3174efe4548ba1b3f7c7d2132149d87 )
+)
+
+game (
+	name "Moonlight Lady (Japan)"
+	description "Moonlight Lady (Japan)"
 	rom ( name "Moonlight Lady (Japan).cue" size 20413 crc 80595633 md5 4cbf9753bccf74962358a76275d13516 sha1 8048c52079beee8dd2cfa22bc8299852bcfab239 )
 )
 
@@ -2536,6 +2716,12 @@ game (
 	name "Motoroader MC (Japan)"
 	description "Motoroader MC (Japan)"
 	rom ( name "Motoroader MC (Japan).cue" size 8113 crc c0d387ee md5 d9113fe96eefb9e28c97e3d21e5fb22f sha1 9257ab5af4023ee4ee1308dabc5bb2284b5849f0 )
+)
+
+game (
+	name "Motteke Tamago (Japan)"
+	description "Motteke Tamago (Japan)"
+	rom ( name "Motteke Tamago (Japan).cue" size 939 crc 74741fe0 md5 337f4e153e864a1ccd653b8800aa76a9 sha1 a2b3a73f35381f5ca23baab2ebc2fa1e842f0b15 )
 )
 
 game (
@@ -2709,6 +2895,12 @@ game (
 game (
 	name "Pastel Lime (Japan)"
 	description "Pastel Lime (Japan)"
+	rom ( name "Pastel Lime (Japan).cue" size 1871 crc 143a144b md5 9383db43c4d0cfbd2bfe08331f4a14fb sha1 1ca81a6b8b043e0877751b842fa1cdf093ab48f7 )
+)
+
+game (
+	name "Pastel Lime (Japan)"
+	description "Pastel Lime (Japan)"
 	rom ( name "Pastel Lime (Japan).cue" size 8921 crc 236944b4 md5 913a2c355d6cdf1365f6e167ff252a1d sha1 c20cdaee8454dbdb1eee36b86abc35ecda2b9cb7 )
 )
 
@@ -2818,6 +3010,12 @@ game (
 	name "Populous - The Promised Lands (Japan) (Rev 3)"
 	description "Populous - The Promised Lands (Japan) (Rev 3)"
 	rom ( name "Populous - The Promised Lands (Japan) (Rev 3).cue" size 1740 crc 914deaeb md5 6e3fd245d96a07319ae4b5223fdc2284 sha1 bb1690c9ee5307cd37934a095fb20030a70e6de0 )
+)
+
+game (
+	name "Prince of Persia (Japan)"
+	description "Prince of Persia (Japan)"
+	rom ( name "Prince of Persia (Japan).cue" size 1926 crc 593ba47d md5 b35cb4ea1b48d2da599ce93a2e6479c6 sha1 0c94bd5be83593b7f1db7e3e592fc94cc6d52a92 )
 )
 
 game (
@@ -2937,13 +3135,31 @@ game (
 game (
 	name "Psychic Storm (Japan)"
 	description "Psychic Storm (Japan)"
+	rom ( name "Psychic Storm (Japan).cue" size 2427 crc 1c772037 md5 8e3b644026d0da25fd80fd321669da56 sha1 0a333993d2204c81be0e48bffce0b9385868b8be )
+)
+
+game (
+	name "Psychic Storm (Japan)"
+	description "Psychic Storm (Japan)"
 	rom ( name "Psychic Storm (Japan).cue" size 11097 crc 6e8338c6 md5 30069f5f3062244c305a501bf8bd0aa4 sha1 1e257fda572b99f6c1382daa64457b1b4ca3b8b7 )
 )
 
 game (
 	name "Puyo Puyo CD (Japan)"
 	description "Puyo Puyo CD (Japan)"
+	rom ( name "Puyo Puyo CD (Japan).cue" size 3506 crc 7773aa51 md5 858e5d2a3f78c509475a4bb2d20fe4c9 sha1 99b133283d53cd50968e28581243532e83a96cb3 )
+)
+
+game (
+	name "Puyo Puyo CD (Japan)"
+	description "Puyo Puyo CD (Japan)"
 	rom ( name "Puyo Puyo CD (Japan).cue" size 15956 crc 8553ae4a md5 c8ac56c3cbee8cc8c77d2166ef076e70 sha1 0336530cc517e406ad21fff8cc0f04347ef44719 )
+)
+
+game (
+	name "Puyo Puyo CD Tsuu (Japan)"
+	description "Puyo Puyo CD Tsuu (Japan)"
+	rom ( name "Puyo Puyo CD Tsuu (Japan).cue" size 7959 crc fcf274fa md5 2f25b730ffc6b3141300fb4029a96baf sha1 04c24257154acfa9888263e70a6bc845706668f1 )
 )
 
 game (
@@ -2998,6 +3214,12 @@ game (
 	name "Quiz Caravan Cult Q (Japan) (Rev 4)"
 	description "Quiz Caravan Cult Q (Japan) (Rev 4)"
 	rom ( name "Quiz Caravan Cult Q (Japan) (Rev 4).cue" size 3712 crc e91f295e md5 fdb19709aa2bbebd751cd7152ad442dd sha1 00d7366e8b34199aff3d958d272f3e23618f8fb4 )
+)
+
+game (
+	name "Quiz de Gakuensai (Japan)"
+	description "Quiz de Gakuensai (Japan)"
+	rom ( name "Quiz de Gakuensai (Japan).cue" size 7474 crc fc9d051f md5 c2925142f447b8460a2834b8b2648aa2 sha1 2b5c4beff27d4d43251a6efc39213d78eed4238b )
 )
 
 game (
@@ -3321,6 +3543,12 @@ game (
 game (
 	name "Seirei Senshi Spriggan (Japan)"
 	description "Seirei Senshi Spriggan (Japan)"
+	rom ( name "Seirei Senshi Spriggan (Japan).cue" size 2856 crc c9e4556c md5 11894de1a875670a71e1506db5244822 sha1 bc6b59bc688e25e82c2b8025ecd744f8485a655b )
+)
+
+game (
+	name "Seirei Senshi Spriggan (Japan)"
+	description "Seirei Senshi Spriggan (Japan)"
 	rom ( name "Seirei Senshi Spriggan (Japan).cue" size 11916 crc 1695aa03 md5 ff5a33e886e952ab1965f18ab53d445e sha1 a911cbfb1ff47f9d4de4063a20113c76db0ce8d0 )
 )
 
@@ -3507,6 +3735,12 @@ game (
 game (
 	name "Shin Megami Tensei (Japan)"
 	description "Shin Megami Tensei (Japan)"
+	rom ( name "Shin Megami Tensei (Japan).cue" size 1642 crc eb2a066d md5 77cef5a07b14fd88dd3ad4e91e32e02d sha1 ca8b20cdb5cd386ad7e7a67c4cd0d1a91ef312ee )
+)
+
+game (
+	name "Shin Megami Tensei (Japan)"
+	description "Shin Megami Tensei (Japan)"
 	rom ( name "Shin Megami Tensei (Japan).cue" size 7308 crc ef54f7e9 md5 27275d63a42a98db2f857dae82e9bd20 sha1 64501072679db42edf936b985a0bd49a7fec8626 )
 )
 
@@ -3586,6 +3820,12 @@ game (
 	name "Snatcher CD-ROMantic - Pilot Disk (Japan)"
 	description "Snatcher CD-ROMantic - Pilot Disk (Japan)"
 	rom ( name "Snatcher CD-ROMantic - Pilot Disk (Japan).cue" size 3944 crc d63d2d8a md5 c27c711f0a4bd2dc5e9b0ebf3ba43366 sha1 d985965d7fc838ed91136618637f01493e1053f6 )
+)
+
+game (
+	name "Snatcher CD-ROMantic (Japan)"
+	description "Snatcher CD-ROMantic (Japan)"
+	rom ( name "Snatcher CD-ROMantic (Japan).cue" size 2502 crc 922a190e md5 0ebc8178d69488000db3b0b845120906 sha1 40c91a0873ba05e4caf2fe2917b0a5f7fa9d1175 )
 )
 
 game (
@@ -3675,6 +3915,12 @@ game (
 game (
 	name "Sotsugyou Shashin - Miki (Japan)"
 	description "Sotsugyou Shashin - Miki (Japan)"
+	rom ( name "Sotsugyou Shashin - Miki (Japan).cue" size 4886 crc 3c41d1ae md5 979fc6cadd368ca951bb1b795a04ba2f sha1 e67478c7b246b87ca64a9932c7c29c8cea64ef14 )
+)
+
+game (
+	name "Sotsugyou Shashin - Miki (Japan)"
+	description "Sotsugyou Shashin - Miki (Japan)"
 	rom ( name "Sotsugyou Shashin - Miki (Japan).cue" size 19613 crc f5c0e1c9 md5 17c521a313a4c4ca906005e20ab62187 sha1 94158b0e778d9517f44624d88d59082298185cd4 )
 )
 
@@ -3741,6 +3987,12 @@ game (
 game (
 	name "Star Breaker (Japan)"
 	description "Star Breaker (Japan)"
+	rom ( name "Star Breaker (Japan).cue" size 1666 crc 96d6b28c md5 28e7b16e6bb31955adf65d632feff222 sha1 a0ce647fc358870056333b276ec5735bee56d1a2 )
+)
+
+game (
+	name "Star Breaker (Japan)"
+	description "Star Breaker (Japan)"
 	rom ( name "Star Breaker (Japan).cue" size 7856 crc 8afe4ad7 md5 95462e9557f61af4e45a626630b77486 sha1 7cbbfd705a163574d587073026af8ed62c4e0733 )
 )
 
@@ -3760,6 +4012,12 @@ game (
 	name "Star Parodier (Japan) (Rev 2)"
 	description "Star Parodier (Japan) (Rev 2)"
 	rom ( name "Star Parodier (Japan) (Rev 2).cue" size 2526 crc dc1f1349 md5 3c65cbc3d2a89e175fb592158cbfd249 sha1 aa00a15280c63cbe01c219fe79fb0a235bdd9e42 )
+)
+
+game (
+	name "Startling Odyssey (Japan)"
+	description "Startling Odyssey (Japan)"
+	rom ( name "Startling Odyssey (Japan).cue" size 2139 crc f9f5b3e2 md5 eabb0988f46a8010724f9d290110145d sha1 04adbc3685360acd76a2ce079cda19db461b5af6 )
 )
 
 game (
@@ -3856,6 +4114,12 @@ game (
 	name "Super Daisenryaku (Japan) (Rev 3)"
 	description "Super Daisenryaku (Japan) (Rev 3)"
 	rom ( name "Super Daisenryaku (Japan) (Rev 3).cue" size 1010 crc 1189b6bd md5 0e72a900b60138bd96d598b37fe01eb9 sha1 a24f7d0bc34a7eb0d04e5a682956034cd91b8183 )
+)
+
+game (
+	name "Super Darius (Japan)"
+	description "Super Darius (Japan)"
+	rom ( name "Super Darius (Japan).cue" size 1799 crc cbabcc20 md5 3f8d1cad94095beff87acf900703abad sha1 f55d6eb98edcf94ccadb77de8860d32b578a0e71 )
 )
 
 game (
@@ -4011,6 +4275,12 @@ game (
 game (
 	name "Tecmo World Cup Super Soccer (Japan)"
 	description "Tecmo World Cup Super Soccer (Japan)"
+	rom ( name "Tecmo World Cup Super Soccer (Japan).cue" size 2319 crc 6866de49 md5 2c49dd46144f35d2bc576f5e8ddbc230 sha1 bf1bba5d286ea01fc923145dee2914786e2b3eed )
+)
+
+game (
+	name "Tecmo World Cup Super Soccer (Japan)"
+	description "Tecmo World Cup Super Soccer (Japan)"
 	rom ( name "Tecmo World Cup Super Soccer (Japan).cue" size 9343 crc fb16d164 md5 4f3bdba0a2578a56764c090a5b9c7f4b sha1 6f8dda169240b0926dfc94940a9acf3ad3d2227b )
 )
 
@@ -4018,6 +4288,12 @@ game (
 	name "Tekipaki Working Love (Japan)"
 	description "Tekipaki Working Love (Japan)"
 	rom ( name "Tekipaki Working Love (Japan).cue" size 9080 crc 9c6cb315 md5 e279faa4b2819a7cf2beaccd170d654b sha1 435d4989c28469bc0d8052c6abf482f1e726ab70 )
+)
+
+game (
+	name "Tenchi Muyou! Ryououki (Japan)"
+	description "Tenchi Muyou! Ryououki (Japan)"
+	rom ( name "Tenchi Muyou! Ryououki (Japan).cue" size 1428 crc 9cdf80e9 md5 4d715a9cc84d101bee0cc837072526ba sha1 372cd3d3719c76832c8632cf370cdc4478e00889 )
 )
 
 game (
@@ -4191,6 +4467,12 @@ game (
 game (
 	name "Uchuu Senkan Yamato (Japan)"
 	description "Uchuu Senkan Yamato (Japan)"
+	rom ( name "Uchuu Senkan Yamato (Japan).cue" size 1686 crc b92b79cb md5 f7f0563e97d9b8f767c94058d07bffbe sha1 93a18aebb37a39fc5f52cc09881c9fdb7dd3237a )
+)
+
+game (
+	name "Uchuu Senkan Yamato (Japan)"
+	description "Uchuu Senkan Yamato (Japan)"
 	rom ( name "Uchuu Senkan Yamato (Japan).cue" size 7458 crc 386ed864 md5 a1add8246a44f05bb6554045a5d96cfc sha1 3c7693aecbc28120197464c27dab93cbd4191089 )
 )
 
@@ -4341,6 +4623,12 @@ game (
 game (
 	name "Winds of Thunder (Japan)"
 	description "Winds of Thunder (Japan)"
+	rom ( name "Winds of Thunder (Japan).cue" size 2310 crc 34f101c4 md5 3ea022ff8106b1e72b49864c21ea653c sha1 98f94c755e18f0c451f4c48f8c244c21239b71c7 )
+)
+
+game (
+	name "Winds of Thunder (Japan)"
+	description "Winds of Thunder (Japan)"
 	rom ( name "Winds of Thunder (Japan).cue" size 10290 crc 983a99a8 md5 fbd102e5f7a251e35e8c70d88901bda5 sha1 5af6c54258ef8000063a37be448864616b5733f0 )
 )
 
@@ -4408,6 +4696,12 @@ game (
 	name "Xak I & II (Japan) - サークI-II"
 	description "Xak I & II (Japan) - サークI-II"
 	rom ( name "Xak I & II (Japan).cue" size 12858 crc 095c5528 md5 d7ff250186599c1417df6fa968dba875 sha1 2181da844026a2cab5f76f4d0cf88b17d47aad17 )
+)
+
+game (
+	name "Xak III - The Eternal Recurrence (Japan)"
+	description "Xak III - The Eternal Recurrence (Japan)"
+	rom ( name "Xak III - The Eternal Recurrence (Japan).cue" size 3994 crc 5cbea73b md5 00eacd547e8ae0b5ff37988b30e54319 sha1 b96edccf717166f04560d9640c867ec5ab65b051 )
 )
 
 game (


### PR DESCRIPTION
Trurip was overwriting the Redump games when they had the same name. This fixes it.