### PR TITLE
Update NEC - PC Engine CD with Redump, Trurip and TOSEC

### DIFF
--- a/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
+++ b/dat/NEC - PC Engine CD - TurboGrafx-CD.dat
@@ -1,9 +1,9 @@
 clrmamepro (
 	name "NEC - PC Engine CD - TurboGrafx-CD"
 	description "NEC - PC Engine CD - TurboGrafx-CD"
-	version "0.1.0"
-	comment "libretro-database's DAT file for NEC - PC Engine CD - TurboGrafx-CD"
-	homepage "https://github.com/RobLoach/libretro-nec-pc-engine-cd-turbografx-cd"
+	version "0.3.0"
+	comment "Assembled from Redump, TOSEC, and Trurip, for libretro-database."
+	homepage "http://github.com/robloach/libretro-dats"
 )
 
 game (
@@ -1378,6 +1378,18 @@ game (
 	name "Fray CD - Xak Gaiden (Japan)"
 	description "Fray CD - Xak Gaiden (Japan)"
 	rom ( name "Fray CD - Xak Gaiden (Japan).cue" size 23659 crc 5e54ee71 md5 151ccdfd69483c27bdd5ce23f490b562 sha1 e3925952977c05f2ff4af38caa1b9cdde1e4b9db )
+)
+
+game (
+	name "Frog Feast (demo) (2005)(RasterSoft)(NTSC)(PD)[Req Super CD-ROM2]"
+	description "Frog Feast (demo) (2005)(RasterSoft)(NTSC)(PD)[Req Super CD-ROM2]"
+	rom ( name "Frog Feast (demo) (2005)(RasterSoft)(NTSC)(PD)[Req Super CD-ROM2].iso" size 921600 crc 37116a87 md5 e3738da1900544b382000e6ba417915d sha1 742a671724f5bc69350997a8b328a9cbe8191730 )
+)
+
+game (
+	name "Frog Feast (USA)"
+	description "Frog Feast (USA)"
+	rom ( name "Frog Feast (USA).iso" size 921600 crc 37116a87 md5 e3738da1900544b382000e6ba417915d sha1 742a671724f5bc69350997a8b328a9cbe8191730 )
 )
 
 game (


### PR DESCRIPTION
Revamped the optical media DATs to read from Redump, Trurip, and TOSEC:
https://github.com/RobLoach/libretro-dats