### PR TITLE
Rename Fire Red to FireRed

### DIFF
--- a/cht/Game Boy Advance/CodeBreaker/Pokmon.cht
+++ b/cht/Game Boy Advance/CodeBreaker/Pokmon.cht
@@ -8,7 +8,7 @@ cheat1_desc = ") "
 cheat1_code = "000014D1+000A+10044EC8+0007+83005000+61A1+83005002+0A35"
 cheat1_enable = false 
 
-cheat2_desc = "PokÃÂ©mon Fire Red-Enable Code (Must Be On)"
+cheat2_desc = "PokÃÂ©mon FireRed-Enable Code (Must Be On)"
 cheat2_code = "0000BE99+000A+10044EC8+0007+83005000+61A1+83005002+0A35"
 cheat2_enable = false 
 

--- a/metadat/developer/Nintendo - Game Boy Advance.dat
+++ b/metadat/developer/Nintendo - Game Boy Advance.dat
@@ -12187,7 +12187,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan)"
+	name "Pocket Monsters - FireRed (Japan)"
 	developer "Game Freak"
 	rom (
 		crc 3B2056E9
@@ -12195,7 +12195,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan) (Rev 1)"
+	name "Pocket Monsters - FireRed (Japan) (Rev 1)"
 	developer "Game Freak"
 	rom (
 		crc BB640DF7
@@ -12251,7 +12251,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA)"
+	name "Pokemon - FireRed Version (USA)"
 	developer "Game Freak"
 	rom (
 		crc DD88761C
@@ -12259,7 +12259,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA, Europe) (Rev 1)"
+	name "Pokemon - FireRed Version (USA, Europe) (Rev 1)"
 	developer "Game Freak"
 	rom (
 		crc 84EE4776

--- a/metadat/releasemonth/Nintendo - Game Boy Advance.dat
+++ b/metadat/releasemonth/Nintendo - Game Boy Advance.dat
@@ -11763,7 +11763,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan)"
+	name "Pocket Monsters - FireRed (Japan)"
 	releasemonth 9
 	rom (
 		crc 3B2056E9
@@ -11771,7 +11771,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan) (Rev 1)"
+	name "Pocket Monsters - FireRed (Japan) (Rev 1)"
 	releasemonth 9
 	rom (
 		crc BB640DF7
@@ -11827,7 +11827,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA)"
+	name "Pokemon - FireRed Version (USA)"
 	releasemonth 9
 	rom (
 		crc DD88761C
@@ -11835,7 +11835,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA, Europe) (Rev 1)"
+	name "Pokemon - FireRed Version (USA, Europe) (Rev 1)"
 	releasemonth 9
 	rom (
 		crc 84EE4776

--- a/metadat/releaseyear/Nintendo - Game Boy Advance.dat
+++ b/metadat/releaseyear/Nintendo - Game Boy Advance.dat
@@ -12147,7 +12147,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan)"
+	name "Pocket Monsters - FireRed (Japan)"
 	releaseyear "2004"
 	rom (
 		crc 3B2056E9
@@ -12155,7 +12155,7 @@ game (
 )
 
 game (
-	name "Pocket Monsters - Fire Red (Japan) (Rev 1)"
+	name "Pocket Monsters - FireRed (Japan) (Rev 1)"
 	releaseyear "2004"
 	rom (
 		crc BB640DF7
@@ -12211,7 +12211,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA)"
+	name "Pokemon - FireRed Version (USA)"
 	releaseyear "2004"
 	rom (
 		crc DD88761C
@@ -12219,7 +12219,7 @@ game (
 )
 
 game (
-	name "Pokemon - Fire Red Version (USA, Europe) (Rev 1)"
+	name "Pokemon - FireRed Version (USA, Europe) (Rev 1)"
 	releaseyear "2004"
 	rom (
 		crc 84EE4776


### PR DESCRIPTION
These should be `FireRed`, not `Fire Red`. However when trying to make a new rdb with `libretro-build-database.sh` it still scans for `Fire Red` and the rdb file has references to both naming conventions. What am I missing?