### PR TITLE
(NDS) New undub dat

### DIFF
--- a/dat/Nintendo - Nintendo DS Decrypted.dat
+++ b/dat/Nintendo - Nintendo DS Decrypted.dat
@@ -2631,6 +2631,13 @@ game (
 )
 
 game (
+	name "Avalon Code (USA) (Undub)"
+	description "Avalon Code (USA) (Undub)"
+	serial "YOGE"
+	rom ( name "Avalon Code (USA) (Undub).nds size 114851840 crc a54a6a96 md5 65ec54f6f76a49fa1846d92b4c81b26 sha1 a11f2502efa39566e11827a38c6fcc5853d158b2 )
+)
+
+game (
 	name "Avalon Code (Japan)"
 	description "Avalon Code (Japan)"
 	serial "YOGJ"
@@ -9239,6 +9246,13 @@ game (
 )
 
 game (
+	name "Disgaea DS (USA) (Undub)"
+	description "Disgaea DS (USA) (Undub)"
+	serial "CDGE"
+	rom ( name "Disgaea DS (USA) (Undub).nds" size 67330048 crc febde0a9 md5 6acb0d1808099511489838a923604978 sha1 f009ddb9a04c28d8bb288f256b07945d3f141384 )
+)
+
+game (
 	name "Disney Big Hero 6 - Battle in the Bay (USA)"
 	description "Disney Big Hero 6 - Battle in the Bay (USA)"
 	serial "TB6E"
@@ -12785,6 +12799,13 @@ game (
 	description "Final Fantasy IV (USA) (En,Fr,Es)"
 	serial "YF4E"
 	rom ( name "Final Fantasy IV (USA) (En,Fr,Es).nds" size 134217728 crc 264FAC77 md5 68C977B762D5E95F43A3A39026421C04 sha1 11400E26610E9247871AC963576A83EBBEBD6CF1 flags verified )
+)
+
+game (
+	name "Final Fantasy IV (USA) (En,Fr,Es) (Undub)"
+	description "Final Fantasy IV (USA) (En,Fr,Es) (Undub)"
+	serial "YF4E"
+	rom ( name "Final Fantasy IV (USA) (En,Fr,Es) (Undub).nds" size 132210688 crc 76dd2f21 md5 300eb0fb2bac685d93ee963a9f45900e sha1 e50090202a29f9e0a8e4455c214428785aff17a0 )
 )
 
 game (
@@ -23659,10 +23680,24 @@ game (
 )
 
 game (
+	name "Lufia - Curse of the Sinistrals (USA) (Undub)"
+	description "Lufia - Curse of the Sinistrals (USA) (Undub)"
+	serial "BSDE"
+	rom ( name "Lufia - Curse of the Sinistrals (USA) (Undub).nds" size 64978944 crc cf3d9f2f md5 c25be68d6ebf5c254c12bb50a9a540ef sha1 6ac1bf6dd4e0d5b77cfc04b3a7cc93aca7535274 )
+)
+
+game (
 	name "Luminous Arc (USA)"
 	description "Luminous Arc (USA)"
 	serial "ANIE"
 	rom ( name "Luminous Arc (USA).nds" size 134217728 crc A02C3FDC md5 CC5AA096E73DF3A2FFFC23A779A6052F sha1 F0FFB601CDA448EC886C3C0075EC61309C5C5412 )
+)
+
+game (
+	name "Luminous Arc (USA) (Undub)"
+	description "Luminous Arc (USA) (Undub)"
+	serial "ANIE"
+	rom ( name "Luminous Arc (USA) (Undub).nds" size 118231040 crc 11924e7d md5 28d8205b70c368d1cdb0c6dea3c6aba3 sha1 62abfe21736d822a0afe8e7ba128c937cf602a42 )
 )
 
 game (
@@ -23691,6 +23726,13 @@ game (
 	description "Luminous Arc 2 (USA)"
 	serial "YL2E"
 	rom ( name "Luminous Arc 2 (USA).nds" size 134217728 crc 561E459D md5 128599FF3E6B27397DF31F58CEEB2EA0 sha1 AE0452778D5DC76AD4D6F1C7CEA3CA044F86155E )
+)
+
+game (
+	name "Luminous Arc 2 (USA) (Undub)"
+	description "Luminous Arc 2 (USA) (Undub)"
+	serial "YL2E"
+	rom ( name "Luminous Arc 2 (USA) (Undub).nds" size 126734336 crc 084fac37 md5 3d996a6b33bd3246bbf73e60115025fb sha1 bcd8e30edec9fb891a661aee5114dde7f6b07921 )
 )
 
 game (
@@ -32458,6 +32500,13 @@ game (
 )
 
 game (
+	name "Phantasy Star 0 (USA) (Undub)"
+	description "Phantasy Star 0 (USA) (Undub)"
+	serial "C24E"
+	rom ( name "Phantasy Star 0 (USA) (Undub).nds" size 134221824 crc 1db5086c md5 4927b18af8dce73280430c81cb63c9f6 sha1 7fd57fdefd18cfe13e01bef8a2325134e5b568ef )
+)
+
+game (
 	name "Phantasy Star 0 (Europe)"
 	description "Phantasy Star 0 (Europe)"
 	serial "C24P"
@@ -37393,6 +37442,13 @@ game (
 )
 
 game (
+	name "Sands of Destruction (USA) (Undub)"
+	description "Sands of Destruction (USA) (Undub)"
+	serial "YSLE"
+	rom ( name Sands of Destruction (USA) (Undub).nds" size 248111104 crc 8503af81 md5 f40dbd2424d8ebd4091823d4631ffc23 sha1 b4b13e3075bec9e6e7126af7bdfbb615423bdf37 )
+)
+
+game (
 	name "Sangokushi DS 2 (Japan) (Rev 1)"
 	description "Sangokushi DS 2 (Japan) (Rev 1)"
 	serial "A3FJ"
@@ -41506,6 +41562,13 @@ game (
 	description "Summon Night - Twin Age (USA)"
 	serial "AS7E"
 	rom ( name "Summon Night - Twin Age (USA).nds" size 134217728 crc 59A23213 md5 A73553673A2B10C94F265AEC8E6C422D sha1 B07D13FB6E0ECD40E93632BC262DE7452F97DF6D )
+)
+
+game (
+	name "Summon Night - Twin Age (USA) (Undub)"
+	description "Summon Night - Twin Age (USA) (Undub)"
+	serial "AS7E"
+	rom ( name "Summon Night - Twin Age (USA) (Undub).nds" size 77025280 crc 7887b2d2 md5 f4d23a2b1b0ce579eae976870540af70 sha1 ab6af7ebd384eaaa56b8c71de64fbd9fb6ec4ca6 )
 )
 
 game (

--- a/metadat/developer/Nintendo - Nintendo DS Decrypted.dat
+++ b/metadat/developer/Nintendo - Nintendo DS Decrypted.dat
@@ -1,0 +1,274 @@
+clrmamepro (
+	name "Nintendo - Nintendo DS"
+)
+
+game (
+	name "Avalon Code (USA)"
+	developer "Matrix Software"
+	rom (
+		crc F1A30D9C
+	)
+)
+
+game (
+	name "Avalon Code (USA) (Undub)"
+	developer "Matrix Software"
+	rom (
+		crc a54a6a96
+	)
+)
+
+game (
+	name "Avalon Code (Japan)"
+	developer "Matrix Software"
+	rom (
+		crc 3D35B3D4
+	)
+)
+
+game (
+	name "Avalon Code (Europe) (En,Fr,De)"
+	developer "Matrix Software"
+	rom (
+		crc 3BB9B9E4
+	)
+)
+
+game (
+	name "Disgaea DS (Europe) (En,Fr)"
+	developer "iNippon Ichi Software"
+	rom (
+		crc 5D33EB3D
+	)
+)
+
+game (
+	name "Disgaea DS (USA)"
+	developer "Nippon Ichi Software"
+	rom (
+		crc 5581AA4D
+	)
+)
+
+game (
+	name "Disgaea DS (USA) (Undub)"
+	developer "Nippon Ichi Software"
+	rom (
+		crc febde0a9
+	)
+)
+
+game (
+	name "Final Fantasy IV (Japan)"
+	developer "Matrix Software/Square Enix"
+	rom (
+		crc 856E17F4
+	)
+)
+
+game (
+	name "Final Fantasy IV (USA) (En,Fr,Es)"
+	developer "Matrix Software/Square Enix"
+	rom (
+		crc 264FAC77
+	)
+)
+
+game (
+	name "Final Fantasy IV (USA) (En,Fr,Es) (Undub)"
+	developer "Matrix Software/Square Enix"
+	rom (
+		crc 76dd2f21
+	)
+)
+
+game (
+	name "Final Fantasy IV (Europe) (En,Fr,De,Es,It)"
+	developer "Matrix Software/Square Enix"
+	rom (
+		crc 7A3B1A57
+	)
+)
+
+game (
+	name "Lufia - Curse of the Sinistrals (USA)"
+	developer "Neverland/Square Enix"
+	rom (
+		crc CAC43A4E
+	)
+)
+
+game (
+	name "Lufia - Curse of the Sinistrals (USA) (Undub)"
+	developer "Neverland/Square Enix"
+	rom (
+		crc cf3d9f2f
+	)
+)
+
+game (
+	name "Luminous Arc (USA)"
+	developer "imageepoch"
+	rom (
+		crc A02C3FDC
+	)
+)
+
+game (
+	name "Luminous Arc (USA) (Undub)"
+	developer "imageepoch"
+	rom (
+		crc 11924e7d
+	)
+)
+
+game (
+	name "Luminous Arc (Europe)"
+	developer "imageepoch"
+	rom (
+		crc A5318B76
+)
+
+game (                       
+	name "Luminous Arc (Japan)"
+	developer "imageepoch"
+	rom (
+		crc 9ED016F7
+	)
+)
+
+game (
+	name "Luminous Arc 2 (Europe)"
+	developer "imageepoch"
+	rom (
+		crc E561223C
+	)
+)
+
+game (
+	name "Luminous Arc 2 (USA)"
+	developer "imageepoch"
+	rom (
+		crc 561E459D 
+	)
+)
+
+game (
+	name "Luminous Arc 2 (USA) (Undub)"
+	developer "imageepoch"
+	rom (
+		crc 084fac37
+	)
+)
+
+game (
+	name "Luminous Arc 2 - Will (Japan)"
+	developer "imageepoch"
+	rom (
+		crc 719C5AE5
+	)
+)
+
+game (
+	name "Luminous Arc 3 - Eyes (Japan) [b]"
+	developer "imageepoch"
+	rom (
+		crc 848822FD
+	)
+)
+
+game (
+	name "Phantasy Star 0 (USA)"
+	developer "Sega"
+	rom (
+		crc AFFB07CF
+	)
+)
+
+game (
+	name "Phantasy Star 0 (USA) (Undub)"
+	developer "Sega"
+	rom (
+		crc 1db5086c
+	)
+)
+
+game (
+	name "Phantasy Star 0 (Europe)"
+	developer "Sega"
+	rom (
+		crc B9027C0C
+	)
+)
+
+game (
+	name "Phantasy Star 0 (Japan)"
+	developer "Sega"
+	rom (
+		crc 512251F9
+	)
+)
+
+game (
+	name "Sands of Destruction (USA)"
+	developer "imageepoch"
+	rom (
+		crc 29C604EF
+	)
+)                                                                                 
+
+game (
+	name "Sands of Destruction (USA) (Undub)"
+	developer "imageepoch"
+	rom (
+		crc 8503af81
+	)
+) 
+
+game (
+	name "Summon Night (Japan)"
+	developer "Flight-Plan"
+	rom (
+		crc 798D1AB6
+	)
+)                                                                                 
+
+game (
+	name "Summon Night - Twin Age (USA)"
+	developer "Flight-Plan"
+	rom (
+		crc 59A23213
+	)
+)
+
+game (
+	name "Summon Night - Twin Age (USA) (Undub)"
+	developer "Flight-Plan"
+	rom (
+		crc 7887b2d2 md5
+	)
+)
+
+game (
+	name "Summon Night 2 (Japan)"
+	developer "Flight-Plan"
+	rom (
+		crc A47065F7
+	)
+)
+
+game (
+	name "Summon Night Twin Age - Seirei-tachi no Koe (Japan)"
+	developer "Flight-Plan"
+	rom (
+		crc 3592C2E8
+	)
+)
+
+game (
+	name "Summon Night X - Tears Crown (Japan) [b]"
+	developer "Flight-Plan"
+	rom (
+		crc 655BA68F
+	)
+)


### PR DESCRIPTION
~~Do not merge yet.~~

I noticed that several of my nds roms are not scanning because they are undubbed so I added them to the dat file. However after making the changes, cloning libretro-super, replacing the dat file with the new one and using libretro-build-database.sh the resulting rdb file does not have any of these undubbed roms.

So my questions are what am I doing wrong? And would you agree that adding these undubbed roms to the dat file is a good idea?