### PR TITLE
(PSX) Fix swapped serials

### DIFF
--- a/dat/Sony - PlayStation.dat
+++ b/dat/Sony - PlayStation.dat
@@ -25757,7 +25757,7 @@ game (
 game (
 	name "Legend of Legaia (USA)"
 	rom (
-		serial "SCUS-94366"
+		serial "SCUS-94254"
 		image "Legend of Legaia (USA).cue"
 	)
 )
@@ -25765,7 +25765,7 @@ game (
 game (
 	name "Legend of Legaia (USA) (Demo)"
 	rom (
-		serial "SCUS-94254"
+		serial "SCUS-94366"
 		image "Legend of Legaia (USA) (Demo).cue"
 	)
 )

--- a/metadat/developer/Sony - PlayStation.dat
+++ b/metadat/developer/Sony - PlayStation.dat
@@ -9879,7 +9879,7 @@ game (
 	name "Legend of Legaia (USA)"
 	developer "Contrail"
 	rom (
-		serial "SCUS-94366"
+		serial "SCUS-94254"
 		image "Legend of Legaia (USA).cue"
 	)
 )
@@ -9888,7 +9888,7 @@ game (
 	name "Legend of Legaia (USA) (Demo)"
 	developer "Contrail"
 	rom (
-		serial "SCUS-94254"
+		serial "SCUS-94366"
 		image "Legend of Legaia (USA) (Demo).cue"
 	)
 )


### PR DESCRIPTION
Someone accidentally swapped the `Legend of Legaia` demo and full release serials causing the scanner to confuse the full release with the demo and vica versa.

I tested the change with `libretro-build-database.sh` and it worked as expected.

Reference:
http://playstationmuseum.com/tag/scus-94254/
http://redump.org/disc/12310/