### PR TITLE
Remove Undub Nintendo DS from main DAT

### DIFF
--- a/dat/Nintendo - Nintendo DS Decrypted.dat
+++ b/dat/Nintendo - Nintendo DS Decrypted.dat
@@ -2631,13 +2631,6 @@ game (
 )
 
 game (
-	name "Avalon Code (USA) (Undub)"
-	description "Avalon Code (USA) (Undub)"
-	serial "YOGE"
-	rom ( name "Avalon Code (USA) (Undub).nds" size 114851840 crc a54a6a96 md5 65ec54f6f76a49fa1846d92b4c81b26 sha1 a11f2502efa39566e11827a38c6fcc5853d158b2 )
-)
-
-game (
 	name "Avalon Code (Japan)"
 	description "Avalon Code (Japan)"
 	serial "YOGJ"
@@ -9246,13 +9239,6 @@ game (
 )
 
 game (
-	name "Disgaea DS (USA) (Undub)"
-	description "Disgaea DS (USA) (Undub)"
-	serial "CDGE"
-	rom ( name "Disgaea DS (USA) (Undub).nds" size 67330048 crc febde0a9 md5 6acb0d1808099511489838a923604978 sha1 f009ddb9a04c28d8bb288f256b07945d3f141384 )
-)
-
-game (
 	name "Disney Big Hero 6 - Battle in the Bay (USA)"
 	description "Disney Big Hero 6 - Battle in the Bay (USA)"
 	serial "TB6E"
@@ -12799,13 +12785,6 @@ game (
 	description "Final Fantasy IV (USA) (En,Fr,Es)"
 	serial "YF4E"
 	rom ( name "Final Fantasy IV (USA) (En,Fr,Es).nds" size 134217728 crc 264FAC77 md5 68C977B762D5E95F43A3A39026421C04 sha1 11400E26610E9247871AC963576A83EBBEBD6CF1 flags verified )
-)
-
-game (
-	name "Final Fantasy IV (USA) (En,Fr,Es) (Undub)"
-	description "Final Fantasy IV (USA) (En,Fr,Es) (Undub)"
-	serial "YF4E"
-	rom ( name "Final Fantasy IV (USA) (En,Fr,Es) (Undub).nds" size 132210688 crc 76dd2f21 md5 300eb0fb2bac685d93ee963a9f45900e sha1 e50090202a29f9e0a8e4455c214428785aff17a0 )
 )
 
 game (
@@ -23680,24 +23659,10 @@ game (
 )
 
 game (
-	name "Lufia - Curse of the Sinistrals (USA) (Undub)"
-	description "Lufia - Curse of the Sinistrals (USA) (Undub)"
-	serial "BSDE"
-	rom ( name "Lufia - Curse of the Sinistrals (USA) (Undub).nds" size 64978944 crc cf3d9f2f md5 c25be68d6ebf5c254c12bb50a9a540ef sha1 6ac1bf6dd4e0d5b77cfc04b3a7cc93aca7535274 )
-)
-
-game (
 	name "Luminous Arc (USA)"
 	description "Luminous Arc (USA)"
 	serial "ANIE"
 	rom ( name "Luminous Arc (USA).nds" size 134217728 crc A02C3FDC md5 CC5AA096E73DF3A2FFFC23A779A6052F sha1 F0FFB601CDA448EC886C3C0075EC61309C5C5412 )
-)
-
-game (
-	name "Luminous Arc (USA) (Undub)"
-	description "Luminous Arc (USA) (Undub)"
-	serial "ANIE"
-	rom ( name "Luminous Arc (USA) (Undub).nds" size 118231040 crc 11924e7d md5 28d8205b70c368d1cdb0c6dea3c6aba3 sha1 62abfe21736d822a0afe8e7ba128c937cf602a42 )
 )
 
 game (
@@ -23726,13 +23691,6 @@ game (
 	description "Luminous Arc 2 (USA)"
 	serial "YL2E"
 	rom ( name "Luminous Arc 2 (USA).nds" size 134217728 crc 561E459D md5 128599FF3E6B27397DF31F58CEEB2EA0 sha1 AE0452778D5DC76AD4D6F1C7CEA3CA044F86155E )
-)
-
-game (
-	name "Luminous Arc 2 (USA) (Undub)"
-	description "Luminous Arc 2 (USA) (Undub)"
-	serial "YL2E"
-	rom ( name "Luminous Arc 2 (USA) (Undub).nds" size 126734336 crc 084fac37 md5 3d996a6b33bd3246bbf73e60115025fb sha1 bcd8e30edec9fb891a661aee5114dde7f6b07921 )
 )
 
 game (
@@ -32500,13 +32458,6 @@ game (
 )
 
 game (
-	name "Phantasy Star 0 (USA) (Undub)"
-	description "Phantasy Star 0 (USA) (Undub)"
-	serial "C24E"
-	rom ( name "Phantasy Star 0 (USA) (Undub).nds" size 134221824 crc 1db5086c md5 4927b18af8dce73280430c81cb63c9f6 sha1 7fd57fdefd18cfe13e01bef8a2325134e5b568ef )
-)
-
-game (
 	name "Phantasy Star 0 (Europe)"
 	description "Phantasy Star 0 (Europe)"
 	serial "C24P"
@@ -37442,13 +37393,6 @@ game (
 )
 
 game (
-	name "Sands of Destruction (USA) (Undub)"
-	description "Sands of Destruction (USA) (Undub)"
-	serial "YSLE"
-	rom ( name "Sands of Destruction (USA) (Undub).nds" size 248111104 crc 8503af81 md5 f40dbd2424d8ebd4091823d4631ffc23 sha1 b4b13e3075bec9e6e7126af7bdfbb615423bdf37 )
-)
-
-game (
 	name "Sangokushi DS 2 (Japan) (Rev 1)"
 	description "Sangokushi DS 2 (Japan) (Rev 1)"
 	serial "A3FJ"
@@ -41562,13 +41506,6 @@ game (
 	description "Summon Night - Twin Age (USA)"
 	serial "AS7E"
 	rom ( name "Summon Night - Twin Age (USA).nds" size 134217728 crc 59A23213 md5 A73553673A2B10C94F265AEC8E6C422D sha1 B07D13FB6E0ECD40E93632BC262DE7452F97DF6D )
-)
-
-game (
-	name "Summon Night - Twin Age (USA) (Undub)"
-	description "Summon Night - Twin Age (USA) (Undub)"
-	serial "AS7E"
-	rom ( name "Summon Night - Twin Age (USA) (Undub).nds" size 77025280 crc 7887b2d2 md5 f4d23a2b1b0ce579eae976870540af70 sha1 ab6af7ebd384eaaa56b8c71de64fbd9fb6ec4ca6 )
 )
 
 game (
@@ -48850,4 +48787,3 @@ game (
 	serial "AU8J"
 	rom ( name "Zunou Nouryoku Koujou Machine - Touch de Zunoo DS (Japan).nds" size 67108864 crc 40495A9B md5 816DE4C963B4B0F97170F8798261A055 sha1 637C8494E495F21AAB3FAFCDC9093C1CA28AC40D )
 )
-


### PR DESCRIPTION
They exist in the metadat/developer DAT.

@orbea Could you confirm you moved them all over?