### PR TITLE
Add size, CRC, MD5 and SHA1 to Atari 5200 BIOS

### DIFF
--- a/dat/libretro - Bios.dat
+++ b/dat/libretro - Bios.dat
@@ -20,7 +20,7 @@ game (
 game (
 	name "Atari - 5200"
 	description "Atari - 5200"
-	rom ( name "5200.rom" md5 281f20ea4320404ec820fb7ec0693b38 )
+	rom ( name "5200.rom" size 2048 crc 4248D3E3 md5 281F20EA4320404EC820FB7EC0693B38 sha1 6AD7A1E8C9FAD486FBEC9498CB48BF5BC3ADC530 )
 )
 
 game (


### PR DESCRIPTION
Completes the info for the 5200 bios.