### PR TITLE
Update Atari - 2600 to use libretro-dats

### DIFF
--- a/metadat/libretro-dats/Atari - 2600.dat
+++ b/metadat/libretro-dats/Atari - 2600.dat
@@ -1,11 +1,9 @@
 clrmamepro (
 	name "Atari - 2600"
 	description "Atari - 2600"
-	version "11"
-	date "2016-07-13"
-	comment "Atari 2600 DAT for libretro"
-	homepage "http://github.com/robloach/libretro-atari-2600.dat"
-	author "ROM Hunter"
+	version "2016.9.25"
+	comment "Assembled from Redump, Trurip, TOSEC, Darkwater and AdvanceSCENE, for libretro-database."
+	homepage "http://github.com/robloach/libretro-dats"
 )
 
 game (
@@ -11275,4 +11273,3 @@ game (
 	description "Zoo Keeper Sounds (1984) (Atari, Christopher H. Omarzu, Robert Vieira) (CX26121) (Prototype) ~"
 	rom ( name "Zoo Keeper Sounds (1984) (Atari, Christopher H. Omarzu, Robert Vieira) (CX26121) (Prototype) ~.bin" size 2048 crc ae15c45d md5 undefined sha1 7f115cb41fc70889b933fd2c808044a2b6367261 )
 )
-


### PR DESCRIPTION
Added Atari - 2600 to https://github.com/robloach/libretro-dats .