### PR TITLE
Add Nintendo - GameCube and Wii DATs

### DIFF
--- a/metadat/libretro-dats/Nintendo - GameCube.dat
+++ b/metadat/libretro-dats/Nintendo - GameCube.dat
@@ -1,0 +1,20659 @@
+clrmamepro (
+	name "Nintendo - GameCube"
+	description "Nintendo - GameCube"
+	version "2016.9.25"
+	comment "Assembled from Redump, Trurip, TOSEC, Darkwater and AdvanceSCENE, for libretro-database."
+	homepage "http://github.com/robloach/libretro-dats"
+)
+
+game (
+	name "007 - Agent im Kreuzfeuer (2002)(Electronic Arts)(DE)"
+	description "007 - Agent im Kreuzfeuer (2002)(Electronic Arts)(DE)"
+	rom ( name "007 - Agent im Kreuzfeuer (2002)(Electronic Arts)(DE).iso" size 1459978240 crc 43c1d6a0 md5 a91e2b43028eee80f6e953a542dee9c9 sha1 34d610e08042b896fc5c077e6e7060fc00b77aa4 )
+)
+
+game (
+	name "007 - Agent im Kreuzfeuer (DE)"
+	description "007 - Agent im Kreuzfeuer (DE)"
+	rom ( name "007 - Agent im Kreuzfeuer (DE).iso" size 1459978240 crc 43c1d6a0 md5 a91e2b43028eee80f6e953a542dee9c9 sha1 34d610e08042b896fc5c077e6e7060fc00b77aa4 )
+)
+
+game (
+	name "007 - Agent im Kreuzfeuer (Germany)"
+	description "007 - Agent im Kreuzfeuer (Germany)"
+	rom ( name "007 - Agent im Kreuzfeuer (Germany).iso" size 1459978240 crc 43c1d6a0 md5 a91e2b43028eee80f6e953a542dee9c9 sha1 34d610e08042b896fc5c077e6e7060fc00b77aa4 )
+)
+
+game (
+	name "007 - Agent Under Fire (2002)(Electronic Arts)(EU)(en)"
+	description "007 - Agent Under Fire (2002)(Electronic Arts)(EU)(en)"
+	rom ( name "007 - Agent Under Fire (2002)(Electronic Arts)(EU)(en).iso" size 1459978240 crc e3b90f14 md5 54d17b5c7a4eee4bfbd648251bfab15e sha1 1b0ec6bbb9b098906acc9d86a41e036816b90d74 )
+)
+
+game (
+	name "007 - Agent Under Fire (EU)"
+	description "007 - Agent Under Fire (EU)"
+	rom ( name "007 - Agent Under Fire (EU).iso" size 1459978240 crc e3b90f14 md5 54d17b5c7a4eee4bfbd648251bfab15e sha1 1b0ec6bbb9b098906acc9d86a41e036816b90d74 )
+)
+
+game (
+	name "007 - Agent Under Fire (Europe)"
+	description "007 - Agent Under Fire (Europe)"
+	rom ( name "007 - Agent Under Fire (Europe).iso" size 1459978240 crc e3b90f14 md5 54d17b5c7a4eee4bfbd648251bfab15e sha1 1b0ec6bbb9b098906acc9d86a41e036816b90d74 )
+)
+
+game (
+	name "007 - Agent Under Fire (US)"
+	description "007 - Agent Under Fire (US)"
+	rom ( name "007 - Agent Under Fire (US) - [v1.00].iso" size 1459978240 crc 04486e6c md5 987af8dca9dd263c27305b4f139a3547 sha1 e518156ce617a7153d5f4320decd57070fd35620 )
+)
+
+game (
+	name "007 - Agent Under Fire (USA) (v1.00)"
+	description "007 - Agent Under Fire (USA) (v1.00)"
+	rom ( name "007 - Agent Under Fire (USA) (v1.00).iso" size 1459978240 crc 04486e6c md5 987af8dca9dd263c27305b4f139a3547 sha1 e518156ce617a7153d5f4320decd57070fd35620 )
+)
+
+game (
+	name "007 - Agent Under Fire (USA) (v1.01)"
+	description "007 - Agent Under Fire (USA) (v1.01)"
+	rom ( name "007 - Agent Under Fire (USA) (v1.01).iso" size 1459978240 crc e9a1e1b2 md5 998e51a469dcad2d9e9842acf7debe5f sha1 7c8a0148f0e5d5b1f40bdfb098eba1935df1932e )
+)
+
+game (
+	name "007 - Agent Under Fire Rev 0 (2002)(Electronic Arts)(US)"
+	description "007 - Agent Under Fire Rev 0 (2002)(Electronic Arts)(US)"
+	rom ( name "007 - Agent Under Fire Rev 0 (2002)(Electronic Arts)(US).iso" size 1459978240 crc 04486e6c md5 987af8dca9dd263c27305b4f139a3547 sha1 e518156ce617a7153d5f4320decd57070fd35620 )
+)
+
+game (
+	name "007 - Agent Under Fire Rev 1 (2002)(Electronic Arts)(US)"
+	description "007 - Agent Under Fire Rev 1 (2002)(Electronic Arts)(US)"
+	rom ( name "007 - Agent Under Fire Rev 1 (2002)(Electronic Arts)(US).iso" size 1459978240 crc e9a1e1b2 md5 998e51a469dcad2d9e9842acf7debe5f sha1 7c8a0148f0e5d5b1f40bdfb098eba1935df1932e )
+)
+
+game (
+	name "007 - Alles oder Nichts (2004)(Electronic Arts)(DE)"
+	description "007 - Alles oder Nichts (2004)(Electronic Arts)(DE)"
+	rom ( name "007 - Alles oder Nichts (2004)(Electronic Arts)(DE).iso" size 1459978240 crc fc49c6bd md5 7cb6e2ad23e86b05ef50529f19d15b8b sha1 bc068d22693cac5957496c4467cef556b390b4ba )
+)
+
+game (
+	name "007 - Alles oder Nichts (DE)"
+	description "007 - Alles oder Nichts (DE)"
+	rom ( name "007 - Alles oder Nichts (DE).iso" size 1459978240 crc fc49c6bd md5 7cb6e2ad23e86b05ef50529f19d15b8b sha1 bc068d22693cac5957496c4467cef556b390b4ba )
+)
+
+game (
+	name "007 - Alles oder Nichts (Germany)"
+	description "007 - Alles oder Nichts (Germany)"
+	rom ( name "007 - Alles oder Nichts (Germany).iso" size 1459978240 crc fc49c6bd md5 7cb6e2ad23e86b05ef50529f19d15b8b sha1 bc068d22693cac5957496c4467cef556b390b4ba )
+)
+
+game (
+	name "007 - Bons Baisers de Russie (2004)(Electronic Arts)(FR)"
+	description "007 - Bons Baisers de Russie (2004)(Electronic Arts)(FR)"
+	rom ( name "007 - Bons Baisers de Russie (2004)(Electronic Arts)(FR).iso" size 1459978240 crc af7f5faa md5 660085d3965b1b432e7acbe1d0d2b350 sha1 29d4248004ab6bedb29bc31a9926b4dbe2c142a8 )
+)
+
+game (
+	name "007 - Bons Baisers de Russie (FR)"
+	description "007 - Bons Baisers de Russie (FR)"
+	rom ( name "007 - Bons Baisers de Russie (FR).iso" size 1459978240 crc af7f5faa md5 660085d3965b1b432e7acbe1d0d2b350 sha1 29d4248004ab6bedb29bc31a9926b4dbe2c142a8 )
+)
+
+game (
+	name "007 - Bons Baisers de Russie (France)"
+	description "007 - Bons Baisers de Russie (France)"
+	rom ( name "007 - Bons Baisers de Russie (France).iso" size 1459978240 crc af7f5faa md5 660085d3965b1b432e7acbe1d0d2b350 sha1 29d4248004ab6bedb29bc31a9926b4dbe2c142a8 )
+)
+
+game (
+	name "007 - Espion pour Cible (2002)(Electronic Arts)(FR)"
+	description "007 - Espion pour Cible (2002)(Electronic Arts)(FR)"
+	rom ( name "007 - Espion pour Cible (2002)(Electronic Arts)(FR).iso" size 1459978240 crc 970521de md5 3fee29cde764103d702bc9ea55373fde sha1 0d0ffbf962010cc7da04349ce15f87bb40762c3e )
+)
+
+game (
+	name "007 - Espion pour Cible (FR)"
+	description "007 - Espion pour Cible (FR)"
+	rom ( name "007 - Espion pour Cible (FR).iso" size 1459978240 crc 970521de md5 3fee29cde764103d702bc9ea55373fde sha1 0d0ffbf962010cc7da04349ce15f87bb40762c3e )
+)
+
+game (
+	name "007 - Espion pour Cible (France)"
+	description "007 - Espion pour Cible (France)"
+	rom ( name "007 - Espion pour Cible (France).iso" size 1459978240 crc 970521de md5 3fee29cde764103d702bc9ea55373fde sha1 0d0ffbf962010cc7da04349ce15f87bb40762c3e )
+)
+
+game (
+	name "007 - Everything or Nothing (2004)(Electronic Arts)(EU)(M4)"
+	description "007 - Everything or Nothing (2004)(Electronic Arts)(EU)(M4)"
+	rom ( name "007 - Everything or Nothing (2004)(Electronic Arts)(EU)(M4).iso" size 1459978240 crc f0356f22 md5 69789ca120bb6951bddbdb857d65e723 sha1 9830e960506ade0cec2fda35b215308b3af60f72 )
+)
+
+game (
+	name "007 - Everything or Nothing (2004)(Electronic Arts)(JP)"
+	description "007 - Everything or Nothing (2004)(Electronic Arts)(JP)"
+	rom ( name "007 - Everything or Nothing (2004)(Electronic Arts)(JP).iso" size 1459978240 crc 6e9a34b3 md5 703522b936e28c37b964e27feec79a01 sha1 4e198b8dd28d2d9fa4167e084db9c815d8095b4d )
+)
+
+game (
+	name "007 - Everything or Nothing (2004)(Electronic Arts)(US)"
+	description "007 - Everything or Nothing (2004)(Electronic Arts)(US)"
+	rom ( name "007 - Everything or Nothing (2004)(Electronic Arts)(US).iso" size 1459978240 crc 6c5e9ac5 md5 765fcce09699b8632119402ab23d8e89 sha1 850fc473afcca94171864e754a098a81d9276e98 )
+)
+
+game (
+	name "007 - Everything or Nothing (EU)"
+	description "007 - Everything or Nothing (EU)"
+	rom ( name "007 - Everything or Nothing (EU).iso" size 1459978240 crc f0356f22 md5 69789ca120bb6951bddbdb857d65e723 sha1 9830e960506ade0cec2fda35b215308b3af60f72 )
+)
+
+game (
+	name "007 - Everything or Nothing (Europe) (En,It,Nl,Sv)"
+	description "007 - Everything or Nothing (Europe) (En,It,Nl,Sv)"
+	rom ( name "007 - Everything or Nothing (Europe) (En,It,Nl,Sv).iso" size 1459978240 crc f0356f22 md5 69789ca120bb6951bddbdb857d65e723 sha1 9830e960506ade0cec2fda35b215308b3af60f72 )
+)
+
+game (
+	name "007 - Everything or Nothing (Japan)"
+	description "007 - Everything or Nothing (Japan)"
+	rom ( name "007 - Everything or Nothing (Japan).iso" size 1459978240 crc 6e9a34b3 md5 703522b936e28c37b964e27feec79a01 sha1 4e198b8dd28d2d9fa4167e084db9c815d8095b4d )
+)
+
+game (
+	name "007 - Everything or Nothing (JP) - 007 eburisingu oa natusingu"
+	description "007 - Everything or Nothing (JP) - 007 eburisingu oa natusingu"
+	rom ( name "007 - Everything or Nothing (JP).iso" size 1459978240 crc 6e9a34b3 md5 703522b936e28c37b964e27feec79a01 sha1 4e198b8dd28d2d9fa4167e084db9c815d8095b4d )
+)
+
+game (
+	name "007 - Everything or Nothing (US)"
+	description "007 - Everything or Nothing (US)"
+	rom ( name "007 - Everything or Nothing (US).iso" size 1459978240 crc 6c5e9ac5 md5 765fcce09699b8632119402ab23d8e89 sha1 850fc473afcca94171864e754a098a81d9276e98 )
+)
+
+game (
+	name "007 - Everything or Nothing (USA)"
+	description "007 - Everything or Nothing (USA)"
+	rom ( name "007 - Everything or Nothing (USA).iso" size 1459978240 crc 6c5e9ac5 md5 765fcce09699b8632119402ab23d8e89 sha1 850fc473afcca94171864e754a098a81d9276e98 )
+)
+
+game (
+	name "007 - From Russia with Love (2004)(Electronic Arts)(EU)(en)"
+	description "007 - From Russia with Love (2004)(Electronic Arts)(EU)(en)"
+	rom ( name "007 - From Russia with Love (2004)(Electronic Arts)(EU)(en).iso" size 1459978240 crc 2002f5ba md5 b06a75020dde3f6d3c296da11743d080 sha1 1a7f562ecdc2f3ee61dacf820470751e100f2a01 )
+)
+
+game (
+	name "007 - From Russia with Love (2004)(Electronic Arts)(US)"
+	description "007 - From Russia with Love (2004)(Electronic Arts)(US)"
+	rom ( name "007 - From Russia with Love (2004)(Electronic Arts)(US).iso" size 1459978240 crc d2fd9a69 md5 978b18050fac6b4bd47fab6069704bfa sha1 0f002bca477a6631cc90e909b39f53fc27e60855 )
+)
+
+game (
+	name "007 - From Russia with Love (EU)"
+	description "007 - From Russia with Love (EU)"
+	rom ( name "007 - From Russia with Love (EU).iso" size 1459978240 crc 2002f5ba md5 b06a75020dde3f6d3c296da11743d080 sha1 1a7f562ecdc2f3ee61dacf820470751e100f2a01 )
+)
+
+game (
+	name "007 - From Russia with Love (Europe)"
+	description "007 - From Russia with Love (Europe)"
+	rom ( name "007 - From Russia with Love (Europe).iso" size 1459978240 crc 2002f5ba md5 b06a75020dde3f6d3c296da11743d080 sha1 1a7f562ecdc2f3ee61dacf820470751e100f2a01 )
+)
+
+game (
+	name "007 - From Russia with Love (US)"
+	description "007 - From Russia with Love (US)"
+	rom ( name "007 - From Russia with Love (US).iso" size 1459978240 crc d2fd9a69 md5 978b18050fac6b4bd47fab6069704bfa sha1 0f002bca477a6631cc90e909b39f53fc27e60855 )
+)
+
+game (
+	name "007 - From Russia with Love (USA)"
+	description "007 - From Russia with Love (USA)"
+	rom ( name "007 - From Russia with Love (USA).iso" size 1459978240 crc d2fd9a69 md5 978b18050fac6b4bd47fab6069704bfa sha1 0f002bca477a6631cc90e909b39f53fc27e60855 )
+)
+
+game (
+	name "007 - Liebesgruesse aus Moskau (DE)"
+	description "007 - Liebesgruesse aus Moskau (DE)"
+	rom ( name "007 - Liebesgruesse aus Moskau (DE).iso" size 1459978240 crc 13b37cd3 md5 0c1288c3a8011a686e1b049be36cb6cb sha1 eb6fd9a83f23e765db4753da1d251f70ae366db2 )
+)
+
+game (
+	name "007 - Liebesgruesse aus Moskau (Germany)"
+	description "007 - Liebesgruesse aus Moskau (Germany)"
+	rom ( name "007 - Liebesgruesse aus Moskau (Germany).iso" size 1459978240 crc 13b37cd3 md5 0c1288c3a8011a686e1b049be36cb6cb sha1 eb6fd9a83f23e765db4753da1d251f70ae366db2 )
+)
+
+game (
+	name "007 - Nightfire (2002)(Electronic Arts)(DE)"
+	description "007 - Nightfire (2002)(Electronic Arts)(DE)"
+	rom ( name "007 - Nightfire (2002)(Electronic Arts)(DE).iso" size 1459978240 crc 1bfa78a6 md5 4a8b63224e4889cc27749f877060430f sha1 6810d2ee62966d570d2afb8ca7a60d5b66059c6e )
+)
+
+game (
+	name "007 - Nightfire (2002)(Electronic Arts)(ES)"
+	description "007 - Nightfire (2002)(Electronic Arts)(ES)"
+	rom ( name "007 - Nightfire (2002)(Electronic Arts)(ES).iso" size 1459978240 crc 8fad7f86 md5 79cae3e9f1176b776e6ae2c033e62627 sha1 2c0ecc806a8fa4340f3e90834bc07b38a83f21b2 )
+)
+
+game (
+	name "007 - Nightfire (2002)(Electronic Arts)(EU)(M4)"
+	description "007 - Nightfire (2002)(Electronic Arts)(EU)(M4)"
+	rom ( name "007 - Nightfire (2002)(Electronic Arts)(EU)(M4).iso" size 1459978240 crc a94b37e8 md5 3971f7e05cf87c6288c740caa299a000 sha1 a1952b927298c47b58713825e0d30b8bddc79d66 )
+)
+
+game (
+	name "007 - Nightfire (2002)(Electronic Arts)(FR)"
+	description "007 - Nightfire (2002)(Electronic Arts)(FR)"
+	rom ( name "007 - Nightfire (2002)(Electronic Arts)(FR).iso" size 1459978240 crc 72ca3f54 md5 e55862c205c1cedf2426e7ca10675a01 sha1 5dadf79f76df0a25a375696c31304e10bc39b22d )
+)
+
+game (
+	name "007 - Nightfire (2002)(Electronic Arts)(US)"
+	description "007 - Nightfire (2002)(Electronic Arts)(US)"
+	rom ( name "007 - Nightfire (2002)(Electronic Arts)(US).iso" size 1459978240 crc 737977cf md5 a824f5a7a553b7598592c6c129378262 sha1 7275e43f04caa3c9ec6f3675a54d043d4c544bf3 )
+)
+
+game (
+	name "007 - Nightfire (DE)"
+	description "007 - Nightfire (DE)"
+	rom ( name "007 - Nightfire (DE).iso" size 1459978240 crc 1bfa78a6 md5 4a8b63224e4889cc27749f877060430f sha1 6810d2ee62966d570d2afb8ca7a60d5b66059c6e )
+)
+
+game (
+	name "007 - Nightfire (ES)"
+	description "007 - Nightfire (ES)"
+	rom ( name "007 - Nightfire (ES).iso" size 1459978240 crc 8fad7f86 md5 79cae3e9f1176b776e6ae2c033e62627 sha1 2c0ecc806a8fa4340f3e90834bc07b38a83f21b2 )
+)
+
+game (
+	name "007 - Nightfire (EU)"
+	description "007 - Nightfire (EU)"
+	rom ( name "007 - Nightfire (EU).iso" size 1459978240 crc a94b37e8 md5 3971f7e05cf87c6288c740caa299a000 sha1 a1952b927298c47b58713825e0d30b8bddc79d66 )
+)
+
+game (
+	name "007 - Nightfire (Europe) (En,It,Nl,Sv)"
+	description "007 - Nightfire (Europe) (En,It,Nl,Sv)"
+	rom ( name "007 - Nightfire (Europe) (En,It,Nl,Sv).iso" size 1459978240 crc a94b37e8 md5 3971f7e05cf87c6288c740caa299a000 sha1 a1952b927298c47b58713825e0d30b8bddc79d66 )
+)
+
+game (
+	name "007 - Nightfire (FR)"
+	description "007 - Nightfire (FR)"
+	rom ( name "007 - Nightfire (FR).iso" size 1459978240 crc 72ca3f54 md5 e55862c205c1cedf2426e7ca10675a01 sha1 5dadf79f76df0a25a375696c31304e10bc39b22d )
+)
+
+game (
+	name "007 - Nightfire (France)"
+	description "007 - Nightfire (France)"
+	rom ( name "007 - Nightfire (France).iso" size 1459978240 crc 72ca3f54 md5 e55862c205c1cedf2426e7ca10675a01 sha1 5dadf79f76df0a25a375696c31304e10bc39b22d )
+)
+
+game (
+	name "007 - Nightfire (Germany)"
+	description "007 - Nightfire (Germany)"
+	rom ( name "007 - Nightfire (Germany).iso" size 1459978240 crc 1bfa78a6 md5 4a8b63224e4889cc27749f877060430f sha1 6810d2ee62966d570d2afb8ca7a60d5b66059c6e )
+)
+
+game (
+	name "007 - Nightfire (Spain)"
+	description "007 - Nightfire (Spain)"
+	rom ( name "007 - Nightfire (Spain).iso" size 1459978240 crc 8fad7f86 md5 79cae3e9f1176b776e6ae2c033e62627 sha1 2c0ecc806a8fa4340f3e90834bc07b38a83f21b2 )
+)
+
+game (
+	name "007 - Nightfire (US)"
+	description "007 - Nightfire (US)"
+	rom ( name "007 - Nightfire (US).iso" size 1459978240 crc 737977cf md5 a824f5a7a553b7598592c6c129378262 sha1 7275e43f04caa3c9ec6f3675a54d043d4c544bf3 )
+)
+
+game (
+	name "007 - Nightfire (USA)"
+	description "007 - Nightfire (USA)"
+	rom ( name "007 - Nightfire (USA).iso" size 1459978240 crc 737977cf md5 a824f5a7a553b7598592c6c129378262 sha1 7275e43f04caa3c9ec6f3675a54d043d4c544bf3 )
+)
+
+game (
+	name "007 - Quitte ou Double (2004)(Electronic Arts)(FR)"
+	description "007 - Quitte ou Double (2004)(Electronic Arts)(FR)"
+	rom ( name "007 - Quitte ou Double (2004)(Electronic Arts)(FR).iso" size 1459978240 crc 43ae8049 md5 dabddecce4356901b13078f95157179b sha1 7509eebf08d9624aadb3f8c69a02ea51c173c3fb )
+)
+
+game (
+	name "007 - Quitte ou Double (FR)"
+	description "007 - Quitte ou Double (FR)"
+	rom ( name "007 - Quitte ou Double (FR).iso" size 1459978240 crc 43ae8049 md5 dabddecce4356901b13078f95157179b sha1 7509eebf08d9624aadb3f8c69a02ea51c173c3fb )
+)
+
+game (
+	name "007 - Quitte ou Double (France)"
+	description "007 - Quitte ou Double (France)"
+	rom ( name "007 - Quitte ou Double (France).iso" size 1459978240 crc 43ae8049 md5 dabddecce4356901b13078f95157179b sha1 7509eebf08d9624aadb3f8c69a02ea51c173c3fb )
+)
+
+game (
+	name "007 - Todo o Nada (2004)(Electronic Arts)(ES)"
+	description "007 - Todo o Nada (2004)(Electronic Arts)(ES)"
+	rom ( name "007 - Todo o Nada (2004)(Electronic Arts)(ES).iso" size 1459978240 crc 8b9af943 md5 7d50ecfdbe7572359b1a3b46337e2db8 sha1 3de7f4aebcd34a647d6527a0174cbfac682b9114 )
+)
+
+game (
+	name "007 - Todo o Nada (ES)"
+	description "007 - Todo o Nada (ES)"
+	rom ( name "007 - Todo o Nada (ES).iso" size 1459978240 crc 8b9af943 md5 7d50ecfdbe7572359b1a3b46337e2db8 sha1 3de7f4aebcd34a647d6527a0174cbfac682b9114 )
+)
+
+game (
+	name "007 - Todo o Nada (Spain)"
+	description "007 - Todo o Nada (Spain)"
+	rom ( name "007 - Todo o Nada (Spain).iso" size 1459978240 crc 8b9af943 md5 7d50ecfdbe7572359b1a3b46337e2db8 sha1 3de7f4aebcd34a647d6527a0174cbfac682b9114 )
+)
+
+game (
+	name "007 - Liebesgrusse aus Moskau (2004)(Electronic Arts)(DE)"
+	description "007 - Liebesgrusse aus Moskau (2004)(Electronic Arts)(DE)"
+	rom ( name "007 - Liebesgrusse aus Moskau (2004)(Electronic Arts)(DE).iso" size 1459978240 crc 13b37cd3 md5 0c1288c3a8011a686e1b049be36cb6cb sha1 eb6fd9a83f23e765db4753da1d251f70ae366db2 )
+)
+
+game (
+	name "1080 Avalanche (2003)(Nintendo)(EU)(M5)"
+	description "1080 Avalanche (2003)(Nintendo)(EU)(M5)"
+	rom ( name "1080 Avalanche (2003)(Nintendo)(EU)(M5).iso" size 1459978240 crc 32c98b7f md5 3a95a080a8359f7026c3aedc00b99f53 sha1 5ba38c32bc978093466602511f6f4fbe5d789721 )
+)
+
+game (
+	name "1080 Avalanche (2003)(Nintendo)(US)"
+	description "1080 Avalanche (2003)(Nintendo)(US)"
+	rom ( name "1080 Avalanche (2003)(Nintendo)(US).iso" size 1459978240 crc 2c37cf08 md5 dd2a3befbcb26481ba5edd203e470174 sha1 09b059208054434df2dadf20b96292b8e11fa908 )
+)
+
+game (
+	name "1080 Avalanche (EU)"
+	description "1080 Avalanche (EU)"
+	rom ( name "1080 Avalanche (EU).iso" size 1459978240 crc 32c98b7f md5 3a95a080a8359f7026c3aedc00b99f53 sha1 5ba38c32bc978093466602511f6f4fbe5d789721 )
+)
+
+game (
+	name "1080 Avalanche (Europe) (En,Fr,De,Es,It)"
+	description "1080 Avalanche (Europe) (En,Fr,De,Es,It)"
+	rom ( name "1080 Avalanche (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 32c98b7f md5 3a95a080a8359f7026c3aedc00b99f53 sha1 5ba38c32bc978093466602511f6f4fbe5d789721 )
+)
+
+game (
+	name "1080 Avalanche (US)"
+	description "1080 Avalanche (US)"
+	rom ( name "1080 Avalanche (US).iso" size 1459978240 crc 2c37cf08 md5 dd2a3befbcb26481ba5edd203e470174 sha1 09b059208054434df2dadf20b96292b8e11fa908 )
+)
+
+game (
+	name "1080 Avalanche (USA)"
+	description "1080 Avalanche (USA)"
+	rom ( name "1080 Avalanche (USA).iso" size 1459978240 crc 2c37cf08 md5 dd2a3befbcb26481ba5edd203e470174 sha1 09b059208054434df2dadf20b96292b8e11fa908 )
+)
+
+game (
+	name "1080 Silver Storm (2004)(Nintendo)(JP)"
+	description "1080 Silver Storm (2004)(Nintendo)(JP)"
+	rom ( name "1080 Silver Storm (2004)(Nintendo)(JP).iso" size 1459978240 crc 5e6c9506 md5 3142122db24a5165f1fa6a3032cf37b0 sha1 c484ef03e13328a4a15123b1d96eb21d00d3c26f )
+)
+
+game (
+	name "1080 Silver Storm (Japan)"
+	description "1080 Silver Storm (Japan)"
+	rom ( name "1080 Silver Storm (Japan).iso" size 1459978240 crc 5e6c9506 md5 3142122db24a5165f1fa6a3032cf37b0 sha1 c484ef03e13328a4a15123b1d96eb21d00d3c26f )
+)
+
+game (
+	name "1080 Silver Storm (JP) - teneitei+sirubasutomu"
+	description "1080 Silver Storm (JP) - teneitei+sirubasutomu"
+	rom ( name "1080 Silver Storm (JP).iso" size 1459978240 crc 5e6c9506 md5 3142122db24a5165f1fa6a3032cf37b0 sha1 c484ef03e13328a4a15123b1d96eb21d00d3c26f )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(EU)(M4)"
+	description "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(EU)(M4)"
+	rom ( name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(EU)(M4).iso" size 1459978240 crc fa022acd md5 eb0c047c08553c724dfee090a259794f sha1 76aeb734574df9e335b25ff46bfe34ab082cc04e )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(JP)"
+	description "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(JP)"
+	rom ( name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(JP).iso" size 1459978240 crc ad289205 md5 36e8da0a88826bf6e1f6e9e3ceace7b4 sha1 e651488b2755bfc17d593a14308127eaf37e1014 )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(US)"
+	description "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(US)"
+	rom ( name "18 Wheeler - American Pro Trucker (2001)(Acclaim - Sega)(US).iso" size 1459978240 crc f827ab43 md5 0581d5e7a897de3b1c999e823b31287d sha1 5fea37dc1e9b4e7112f14e81bfda67e38410bd11 )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (EU)"
+	description "18 Wheeler - American Pro Trucker (EU)"
+	rom ( name "18 Wheeler - American Pro Trucker (EU).iso" size 1459978240 crc fa022acd md5 eb0c047c08553c724dfee090a259794f sha1 76aeb734574df9e335b25ff46bfe34ab082cc04e )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es)"
+	description "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es)"
+	rom ( name "18 Wheeler - American Pro Trucker (Europe) (En,Fr,De,Es).iso" size 1459978240 crc fa022acd md5 eb0c047c08553c724dfee090a259794f sha1 76aeb734574df9e335b25ff46bfe34ab082cc04e )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (Japan)"
+	description "18 Wheeler - American Pro Trucker (Japan)"
+	rom ( name "18 Wheeler - American Pro Trucker (Japan).iso" size 1459978240 crc ad289205 md5 36e8da0a88826bf6e1f6e9e3ceace7b4 sha1 e651488b2755bfc17d593a14308127eaf37e1014 )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (JP) - eiteinhoira"
+	description "18 Wheeler - American Pro Trucker (JP) - eiteinhoira"
+	rom ( name "18 Wheeler - American Pro Trucker (JP).iso" size 1459978240 crc ad289205 md5 36e8da0a88826bf6e1f6e9e3ceace7b4 sha1 e651488b2755bfc17d593a14308127eaf37e1014 )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (US)"
+	description "18 Wheeler - American Pro Trucker (US)"
+	rom ( name "18 Wheeler - American Pro Trucker (US).iso" size 1459978240 crc f827ab43 md5 0581d5e7a897de3b1c999e823b31287d sha1 5fea37dc1e9b4e7112f14e81bfda67e38410bd11 )
+)
+
+game (
+	name "18 Wheeler - American Pro Trucker (USA)"
+	description "18 Wheeler - American Pro Trucker (USA)"
+	rom ( name "18 Wheeler - American Pro Trucker (USA).iso" size 1459978240 crc f827ab43 md5 0581d5e7a897de3b1c999e823b31287d sha1 5fea37dc1e9b4e7112f14e81bfda67e38410bd11 )
+)
+
+game (
+	name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (Bob L'eponge - Le Film) (FR^BE^NL)"
+	description "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (Bob L'eponge - Le Film) (FR^BE^NL)"
+	rom ( name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (Bob L'eponge - Le Film) (FR^BE^NL) - (Disc 1 of 2) [Bob L'eponge - Le Film].iso" size 1459978240 crc 3cb489d7 md5 592585ee660990d4953e8d6b9f961d3c sha1 e52e6b4d76461a9041dfbcc95ecef8b1d1ecc051 )
+)
+
+game (
+	name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 1) (Bob L'eponge - Le Film)"
+	description "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 1) (Bob L'eponge - Le Film)"
+	rom ( name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 1) (Bob L'eponge - Le Film).iso" size 1459978240 crc 3cb489d7 md5 592585ee660990d4953e8d6b9f961d3c sha1 e52e6b4d76461a9041dfbcc95ecef8b1d1ecc051 )
+)
+
+game (
+	name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 2) (Tak 2 - Le Sceptre des Reves)"
+	description "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 2) (Tak 2 - Le Sceptre des Reves)"
+	rom ( name "2 Games in 1 - Bob L'eponge - Le Film + Tak 2 - Le Sceptre des Reves (France) (Disc 2) (Tak 2 - Le Sceptre des Reves).iso" size 1459978240 crc 601795ee md5 64b9637a1866f784182d274d56c00235 sha1 f3ae51410782d51b30d5f33b26f82a45f4d2498c )
+)
+
+game (
+	name "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 1)"
+	description "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 1)"
+	rom ( name "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 1).iso" size 1459978240 crc 3cb489d7 md5 592585ee660990d4953e8d6b9f961d3c sha1 e52e6b4d76461a9041dfbcc95ecef8b1d1ecc051 )
+)
+
+game (
+	name "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 2)"
+	description "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 2)"
+	rom ( name "2 Games in 1 - Bob l'eponge, le film + Tak 2 - Le Sceptre des Reves (2006)(THQ)(FR)(fr-nl)(Disc 2).iso" size 1459978240 crc 601795ee md5 64b9637a1866f784182d274d56c00235 sha1 f3ae51410782d51b30d5f33b26f82a45f4d2498c )
+)
+
+game (
+	name "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 1)"
+	description "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 1)"
+	rom ( name "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 1).iso" size 1459978240 crc 977e170b md5 249f3c69db9324e92a3faf66c3c2ac3d sha1 3523afb30a1d38e11b1cdb540027392346602deb )
+)
+
+game (
+	name "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 2)"
+	description "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 2)"
+	rom ( name "2 Games in 1 - Der SpongeBob Schwammkopf Film + SpongeBob Schwammkopf - Schlacht um Bikini Bottom (2006)(THQ)(DE)(Disc 2).iso" size 1459978240 crc 893397ae md5 0057239560246895369d37efd0aa2185 sha1 b78e0385bd4a2398ca6f407e0ae3aa128c699ee6 )
+)
+
+game (
+	name "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 1)"
+	description "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 1)"
+	rom ( name "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 1).iso" size 1459978240 crc 2f1904a8 md5 33012f2d1c29c684c17cc79f3177577d sha1 de99e8d3427c5b3821cce5d91cd03c0fc1afc905 )
+)
+
+game (
+	name "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 2)"
+	description "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 2)"
+	rom ( name "2 Games in 1 - Der SpongeBob Schwammkopf Film + Tak 2 - Der Stab der Traume (2006)(THQ)(DE)(Disc 2).iso" size 1459978240 crc 58e2c01d md5 bbd3c0d5b10ae4fd96d378efb1bcb09e sha1 33be45cab7b45337b01b60f680fc2b85b7f4f73d )
+)
+
+game (
+	name "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 1)"
+	description "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 1)"
+	rom ( name "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 1).iso" size 1459978240 crc 30127b72 md5 91ebe9828eb044a2e52242acb7f8ceef sha1 af6fd8297768fb208cd8e701dbce853e1da737f1 )
+)
+
+game (
+	name "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 2)"
+	description "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 2)"
+	rom ( name "2 Games in 1 - Die Unglaublichen + Findet Nemo (2006)(THQ)(DE)(Disc 2).iso" size 1459978240 crc e5d67d74 md5 c1ae965be09edfe7733351da3ac5f02b sha1 6a4356967af7bb6b2012a5dfd25de0ccf637c531 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (DE)"
+	description "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (DE)"
+	rom ( name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (DE) - (Disc 1 of 2).iso" size 1459978240 crc 30127b72 md5 91ebe9828eb044a2e52242acb7f8ceef sha1 af6fd8297768fb208cd8e701dbce853e1da737f1 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 1)"
+	description "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 1)"
+	rom ( name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 1).iso" size 1459978240 crc 30127b72 md5 91ebe9828eb044a2e52242acb7f8ceef sha1 af6fd8297768fb208cd8e701dbce853e1da737f1 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 2)"
+	description "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 2)"
+	rom ( name "2 Games in 1 - Disney-Pixar Die Unglaublichen + Disney-Pixar Findet Nemo (Germany) (Disc 2).iso" size 1459978240 crc e5d67d74 md5 c1ae965be09edfe7733351da3ac5f02b sha1 6a4356967af7bb6b2012a5dfd25de0ccf637c531 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 1) (Les Indestructibles)"
+	description "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 1) (Les Indestructibles)"
+	rom ( name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 1) (Les Indestructibles).iso" size 1459978240 crc 6a6e66ee md5 4e51d0bec2705a23b61284e4bc338ff9 sha1 683a5dd7d75a4c5c4f966dce6ec274da492bdfc5 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 2) (Le Monde de Nemo)"
+	description "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 2) (Le Monde de Nemo)"
+	rom ( name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (France) (Disc 2) (Le Monde de Nemo).iso" size 1459978240 crc f957ee96 md5 2aff07d9d37a3acd0e4d9d1021f944a1 sha1 dd2b753bbe3ec69ce743692ce35ad6941bf3eda6 )
+)
+
+game (
+	name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (Les Indestructibles) (FR)"
+	description "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (Les Indestructibles) (FR)"
+	rom ( name "2 Games in 1 - Disney-Pixar Les Indestructibles + Disney-Pixar Le Monde de Nemo (Les Indestructibles) (FR) - (Disc 1 of 2) [Les Indestructibles].iso" size 1459978240 crc 6a6e66ee md5 4e51d0bec2705a23b61284e4bc338ff9 sha1 683a5dd7d75a4c5c4f966dce6ec274da492bdfc5 )
+)
+
+game (
+	name "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 1)"
+	description "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 1)"
+	rom ( name "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 1).iso" size 1459978240 crc 6a6e66ee md5 4e51d0bec2705a23b61284e4bc338ff9 sha1 683a5dd7d75a4c5c4f966dce6ec274da492bdfc5 )
+)
+
+game (
+	name "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 2)"
+	description "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 2)"
+	rom ( name "2 Games in 1 - Les Indestructibles + Le Monde de Nemo (2006)(THQ)(FR)(Disc 2).iso" size 1459978240 crc f957ee96 md5 2aff07d9d37a3acd0e4d9d1021f944a1 sha1 dd2b753bbe3ec69ce743692ce35ad6941bf3eda6 )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (DE)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (DE)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (DE) - (Disc 1 of 2).iso" size 1459978240 crc 977e170b md5 249f3c69db9324e92a3faf66c3c2ac3d sha1 3523afb30a1d38e11b1cdb540027392346602deb )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 1)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 1)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 1).iso" size 1459978240 crc 977e170b md5 249f3c69db9324e92a3faf66c3c2ac3d sha1 3523afb30a1d38e11b1cdb540027392346602deb )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 2)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 2)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon SpongeBob Schwammkopf - Schlacht um Bikini Bottom (Germany) (Disc 2).iso" size 1459978240 crc 893397ae md5 0057239560246895369d37efd0aa2185 sha1 b78e0385bd4a2398ca6f407e0ae3aa128c699ee6 )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (DE)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (DE)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (DE) - (Disc 1 of 2).iso" size 1459978240 crc 2f1904a8 md5 33012f2d1c29c684c17cc79f3177577d sha1 de99e8d3427c5b3821cce5d91cd03c0fc1afc905 )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 1)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 1)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 1).iso" size 1459978240 crc 2f1904a8 md5 33012f2d1c29c684c17cc79f3177577d sha1 de99e8d3427c5b3821cce5d91cd03c0fc1afc905 )
+)
+
+game (
+	name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 2)"
+	description "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 2)"
+	rom ( name "2 Games in 1 - Nickelodeon SpongeBob Schwammkopf - Der Film + Nickelodeon Tak 2 - Der Stab der Traeume (Germany) (Disc 2).iso" size 1459978240 crc 58e2c01d md5 bbd3c0d5b10ae4fd96d378efb1bcb09e sha1 33be45cab7b45337b01b60f680fc2b85b7f4f73d )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(DE)"
+	description "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(DE)"
+	rom ( name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(DE).iso" size 1459978240 crc 3508278d md5 91fbde7508247e51b42286926d1a9781 sha1 aee664fe47ace928f9a2a0f37598b48213274266 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(en)"
+	description "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(en)"
+	rom ( name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(en).iso" size 1459978240 crc 510c6864 md5 52124ca10af6550fcfda836680847d62 sha1 b4be262730a88d019cf99c785117bd5a7e0b4fa6 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(fr-nl)"
+	description "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(fr-nl)"
+	rom ( name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(EU)(fr-nl).iso" size 1459978240 crc 5980022f md5 54411489d800faf171f5ff203b1a0c46 sha1 b7e6aa5d84e35fe1de1879c9dcd12c0c1987e275 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(JP)"
+	description "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(JP)"
+	rom ( name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(JP).iso" size 1459978240 crc 352435de md5 4a5991f0e44035f7efff79fc644ebadf sha1 f44d4ecd2e89ebb0038f27ebfa87c4c71079cd79 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(US)"
+	description "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(US)"
+	rom ( name "2002 FIFA World Cup Korea Japan (2002)(Electronic Arts)(US).iso" size 1459978240 crc 0f793a29 md5 e53b25f12dcdea0b3633e77b1bed24b2 sha1 0e4e9ad320de2502a2405548c1cc691720b591aa )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (DE)"
+	description "2002 FIFA World Cup Korea Japan (DE)"
+	rom ( name "2002 FIFA World Cup Korea Japan (DE).iso" size 1459978240 crc 3508278d md5 91fbde7508247e51b42286926d1a9781 sha1 aee664fe47ace928f9a2a0f37598b48213274266 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (EU)"
+	description "2002 FIFA World Cup Korea Japan (EU)"
+	rom ( name "2002 FIFA World Cup Korea Japan (EU).iso" size 1459978240 crc 510c6864 md5 52124ca10af6550fcfda836680847d62 sha1 b4be262730a88d019cf99c785117bd5a7e0b4fa6 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (Europe)"
+	description "2002 FIFA World Cup Korea Japan (Europe)"
+	rom ( name "2002 FIFA World Cup Korea Japan (Europe).iso" size 1459978240 crc 510c6864 md5 52124ca10af6550fcfda836680847d62 sha1 b4be262730a88d019cf99c785117bd5a7e0b4fa6 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (Europe) (Fr,Nl)"
+	description "2002 FIFA World Cup Korea Japan (Europe) (Fr,Nl)"
+	rom ( name "2002 FIFA World Cup Korea Japan (Europe) (Fr,Nl).iso" size 1459978240 crc 5980022f md5 54411489d800faf171f5ff203b1a0c46 sha1 b7e6aa5d84e35fe1de1879c9dcd12c0c1987e275 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (FR^BE^NL)"
+	description "2002 FIFA World Cup Korea Japan (FR^BE^NL)"
+	rom ( name "2002 FIFA World Cup Korea Japan (FR^BE^NL).iso" size 1459978240 crc 5980022f md5 54411489d800faf171f5ff203b1a0c46 sha1 b7e6aa5d84e35fe1de1879c9dcd12c0c1987e275 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (Germany)"
+	description "2002 FIFA World Cup Korea Japan (Germany)"
+	rom ( name "2002 FIFA World Cup Korea Japan (Germany).iso" size 1459978240 crc 3508278d md5 91fbde7508247e51b42286926d1a9781 sha1 aee664fe47ace928f9a2a0f37598b48213274266 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (Japan)"
+	description "2002 FIFA World Cup Korea Japan (Japan)"
+	rom ( name "2002 FIFA World Cup Korea Japan (Japan).iso" size 1459978240 crc 352435de md5 4a5991f0e44035f7efff79fc644ebadf sha1 f44d4ecd2e89ebb0038f27ebfa87c4c71079cd79 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (JP) - 2002+FIFA+warudokatupu"
+	description "2002 FIFA World Cup Korea Japan (JP) - 2002+FIFA+warudokatupu"
+	rom ( name "2002 FIFA World Cup Korea Japan (JP).iso" size 1459978240 crc 352435de md5 4a5991f0e44035f7efff79fc644ebadf sha1 f44d4ecd2e89ebb0038f27ebfa87c4c71079cd79 )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (US)"
+	description "2002 FIFA World Cup Korea Japan (US)"
+	rom ( name "2002 FIFA World Cup Korea Japan (US).iso" size 1459978240 crc 0f793a29 md5 e53b25f12dcdea0b3633e77b1bed24b2 sha1 0e4e9ad320de2502a2405548c1cc691720b591aa )
+)
+
+game (
+	name "2002 FIFA World Cup Korea Japan (USA)"
+	description "2002 FIFA World Cup Korea Japan (USA)"
+	rom ( name "2002 FIFA World Cup Korea Japan (USA).iso" size 1459978240 crc 0f793a29 md5 e53b25f12dcdea0b3633e77b1bed24b2 sha1 0e4e9ad320de2502a2405548c1cc691720b591aa )
+)
+
+game (
+	name "4 Fantastiques, Les (2005)(Activision)(FR)"
+	description "4 Fantastiques, Les (2005)(Activision)(FR)"
+	rom ( name "4 Fantastiques, Les (2005)(Activision)(FR).iso" size 1459978240 crc 4c7bb703 md5 d4e1d0da02324fc820105017ce652f5f sha1 75578d38a551f3a74b6b6166d67750bcdc5c47f9 )
+)
+
+game (
+	name "4 Fantastiques, Les (FR)"
+	description "4 Fantastiques, Les (FR)"
+	rom ( name "4 Fantastiques, Les (FR).iso" size 1459978240 crc 4c7bb703 md5 d4e1d0da02324fc820105017ce652f5f sha1 75578d38a551f3a74b6b6166d67750bcdc5c47f9 )
+)
+
+game (
+	name "4 Fantastiques, Les (France)"
+	description "4 Fantastiques, Les (France)"
+	rom ( name "4 Fantastiques, Les (France).iso" size 1459978240 crc 4c7bb703 md5 d4e1d0da02324fc820105017ce652f5f sha1 75578d38a551f3a74b6b6166d67750bcdc5c47f9 )
+)
+
+game (
+	name "4x4 EVO 2 (2002)(Universal)(US)"
+	description "4x4 EVO 2 (2002)(Universal)(US)"
+	rom ( name "4x4 EVO 2 (2002)(Universal)(US).iso" size 1459978240 crc 9d473312 md5 dfbf9c9a7985723180816ac49495f55f sha1 7a384b777c3bc06ca67f0707e4b610831024f307 )
+)
+
+game (
+	name "4x4 Evo 2 (US)"
+	description "4x4 Evo 2 (US)"
+	rom ( name "4x4 Evo 2 (US).iso" size 1459978240 crc 9d473312 md5 dfbf9c9a7985723180816ac49495f55f sha1 7a384b777c3bc06ca67f0707e4b610831024f307 )
+)
+
+game (
+	name "4x4 Evo 2 (USA)"
+	description "4x4 Evo 2 (USA)"
+	rom ( name "4x4 Evo 2 (USA).iso" size 1459978240 crc 9d473312 md5 dfbf9c9a7985723180816ac49495f55f sha1 7a384b777c3bc06ca67f0707e4b610831024f307 )
+)
+
+game (
+	name "Ace Golf (EU)"
+	description "Ace Golf (EU)"
+	rom ( name "Ace Golf (EU).iso" size 1459978240 crc c4e54bee md5 e8a77e4c9c3a935c564d2a0399d34f5a sha1 7c2529a724489d2643dbef3b3b356303e2e2089a )
+)
+
+game (
+	name "Ace Golf (Europe) (En,Fr)"
+	description "Ace Golf (Europe) (En,Fr)"
+	rom ( name "Ace Golf (Europe) (En,Fr).iso" size 1459978240 crc c4e54bee md5 e8a77e4c9c3a935c564d2a0399d34f5a sha1 7c2529a724489d2643dbef3b3b356303e2e2089a )
+)
+
+game (
+	name "Aggressive Inline (EU)"
+	description "Aggressive Inline (EU)"
+	rom ( name "Aggressive Inline (EU).iso" size 1459978240 crc ba889f64 md5 e7b3463eb2da28c476fc075192fa44a8 sha1 f18fc2380ecd8f307e146479366081a9313a839e )
+)
+
+game (
+	name "Aggressive Inline (Europe) (En,Fr,De,Es)"
+	description "Aggressive Inline (Europe) (En,Fr,De,Es)"
+	rom ( name "Aggressive Inline (Europe) (En,Fr,De,Es).iso" size 1459978240 crc ba889f64 md5 e7b3463eb2da28c476fc075192fa44a8 sha1 f18fc2380ecd8f307e146479366081a9313a839e )
+)
+
+game (
+	name "Aggressive Inline (US)"
+	description "Aggressive Inline (US)"
+	rom ( name "Aggressive Inline (US).iso" size 1459978240 crc 5d9f46f1 md5 9a09306a54395805bb92876fc6862be0 sha1 5df120bab0042b81b8bbd01774ed9318cecec62f )
+)
+
+game (
+	name "Aggressive Inline (USA)"
+	description "Aggressive Inline (USA)"
+	rom ( name "Aggressive Inline (USA).iso" size 1459978240 crc 5d9f46f1 md5 9a09306a54395805bb92876fc6862be0 sha1 5df120bab0042b81b8bbd01774ed9318cecec62f )
+)
+
+game (
+	name "Alien Hominid (US)"
+	description "Alien Hominid (US)"
+	rom ( name "Alien Hominid (US).iso" size 1459978240 crc d5371e2d md5 4f055ff8e9efac089ca774a54d76ca5b sha1 227ba514263da3d51e2288672414ad496507a77d )
+)
+
+game (
+	name "Alien Hominid (USA)"
+	description "Alien Hominid (USA)"
+	rom ( name "Alien Hominid (USA).iso" size 1459978240 crc d5371e2d md5 4f055ff8e9efac089ca774a54d76ca5b sha1 227ba514263da3d51e2288672414ad496507a77d )
+)
+
+game (
+	name "All-Star Baseball 2002 (US)"
+	description "All-Star Baseball 2002 (US)"
+	rom ( name "All-Star Baseball 2002 (US).iso" size 1459978240 crc b7a4726c md5 bc4b7d305ca3416348706d21d0006666 sha1 074f624da00da21216c14b9086efac9b22168254 )
+)
+
+game (
+	name "All-Star Baseball 2002 (USA)"
+	description "All-Star Baseball 2002 (USA)"
+	rom ( name "All-Star Baseball 2002 (USA).iso" size 1459978240 crc b7a4726c md5 bc4b7d305ca3416348706d21d0006666 sha1 074f624da00da21216c14b9086efac9b22168254 )
+)
+
+game (
+	name "All-Star Baseball 2003 featuring Derek Jeter (Japan)"
+	description "All-Star Baseball 2003 featuring Derek Jeter (Japan)"
+	rom ( name "All-Star Baseball 2003 featuring Derek Jeter (Japan).iso" size 1459978240 crc 128e5b27 md5 71ccde7b7df2151264d5594c68a2d52d sha1 049bb84d35085923fc3c5a0a8c3ff16c07184612 )
+)
+
+game (
+	name "All-Star Baseball 2003 featuring Derek Jeter (JP) - orusutabesuboru2003"
+	description "All-Star Baseball 2003 featuring Derek Jeter (JP) - orusutabesuboru2003"
+	rom ( name "All-Star Baseball 2003 featuring Derek Jeter (JP).iso" size 1459978240 crc 128e5b27 md5 71ccde7b7df2151264d5594c68a2d52d sha1 049bb84d35085923fc3c5a0a8c3ff16c07184612 )
+)
+
+game (
+	name "All-Star Baseball 2003 featuring Derek Jeter (US)"
+	description "All-Star Baseball 2003 featuring Derek Jeter (US)"
+	rom ( name "All-Star Baseball 2003 featuring Derek Jeter (US).iso" size 1459978240 crc 3fa2cd5e md5 f45fb0469da1261c7b23e5ed0b43f1df sha1 c16946c178cbf38add8cebd3a31e9b9cc8815c25 )
+)
+
+game (
+	name "All-Star Baseball 2003 featuring Derek Jeter (USA)"
+	description "All-Star Baseball 2003 featuring Derek Jeter (USA)"
+	rom ( name "All-Star Baseball 2003 featuring Derek Jeter (USA).iso" size 1459978240 crc 3fa2cd5e md5 f45fb0469da1261c7b23e5ed0b43f1df sha1 c16946c178cbf38add8cebd3a31e9b9cc8815c25 )
+)
+
+game (
+	name "All-Star Baseball 2004 featuring Derek Jeter (US)"
+	description "All-Star Baseball 2004 featuring Derek Jeter (US)"
+	rom ( name "All-Star Baseball 2004 featuring Derek Jeter (US).iso" size 1459978240 crc 5dd1cbe5 md5 befeee719d51a63b88afcfede9e5d9cc sha1 72130d8dfba37ef562ea758bab5a55420e3858f8 )
+)
+
+game (
+	name "All-Star Baseball 2004 featuring Derek Jeter (USA)"
+	description "All-Star Baseball 2004 featuring Derek Jeter (USA)"
+	rom ( name "All-Star Baseball 2004 featuring Derek Jeter (USA).iso" size 1459978240 crc 5dd1cbe5 md5 befeee719d51a63b88afcfede9e5d9cc sha1 72130d8dfba37ef562ea758bab5a55420e3858f8 )
+)
+
+game (
+	name "Amazing Island (US)"
+	description "Amazing Island (US)"
+	rom ( name "Amazing Island (US).iso" size 1459978240 crc 200f5305 md5 46d3d0acdb0f176626428db3d939f1cb sha1 b82cb04d83b9448e63b594409b378302772c5e38 )
+)
+
+game (
+	name "Amazing Island (USA)"
+	description "Amazing Island (USA)"
+	rom ( name "Amazing Island (USA).iso" size 1459978240 crc 200f5305 md5 46d3d0acdb0f176626428db3d939f1cb sha1 b82cb04d83b9448e63b594409b378302772c5e38 )
+)
+
+game (
+	name "American Chopper 2 - Full Throttle (US)"
+	description "American Chopper 2 - Full Throttle (US)"
+	rom ( name "American Chopper 2 - Full Throttle (US).iso" size 1459978240 crc 569086d0 md5 4dbc387a9e22db502be5792625d7d070 sha1 a56283207bf046faf262afee1278605834329390 )
+)
+
+game (
+	name "American Chopper 2 - Full Throttle (USA)"
+	description "American Chopper 2 - Full Throttle (USA)"
+	rom ( name "American Chopper 2 - Full Throttle (USA).iso" size 1459978240 crc 569086d0 md5 4dbc387a9e22db502be5792625d7d070 sha1 a56283207bf046faf262afee1278605834329390 )
+)
+
+game (
+	name "Animal Crossing (AU)"
+	description "Animal Crossing (AU)"
+	rom ( name "Animal Crossing (AU).iso" size 1459978240 crc 06caa2ee md5 d59b1c438b21970446102a19f1e0e861 sha1 9c50eb2182812e2dadfd47309764e59aaa76d485 )
+)
+
+game (
+	name "Animal Crossing (Australia)"
+	description "Animal Crossing (Australia)"
+	rom ( name "Animal Crossing (Australia).iso" size 1459978240 crc 06caa2ee md5 d59b1c438b21970446102a19f1e0e861 sha1 9c50eb2182812e2dadfd47309764e59aaa76d485 )
+)
+
+game (
+	name "Animal Crossing (EU)"
+	description "Animal Crossing (EU)"
+	rom ( name "Animal Crossing (EU).iso" size 1459978240 crc 37b56050 md5 c5a4d1535655ddbc84a95c305fecda55 sha1 e5358089343299de67cbc87d8868dfe07baac44f )
+)
+
+game (
+	name "Animal Crossing (Europe) (En,Fr,De,Es,It)"
+	description "Animal Crossing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Animal Crossing (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 37b56050 md5 c5a4d1535655ddbc84a95c305fecda55 sha1 e5358089343299de67cbc87d8868dfe07baac44f )
+)
+
+game (
+	name "Animal Crossing (US)"
+	description "Animal Crossing (US)"
+	rom ( name "Animal Crossing (US).iso" size 1459978240 crc 7be72542 md5 7853049ccd0c1e2bffeb5b12393a5409 sha1 2d2b1fa3883f49af779ce9ca133db3be17be8f32 )
+)
+
+game (
+	name "Animal Crossing (USA)"
+	description "Animal Crossing (USA)"
+	rom ( name "Animal Crossing (USA).iso" size 1459978240 crc 7be72542 md5 7853049ccd0c1e2bffeb5b12393a5409 sha1 2d2b1fa3883f49af779ce9ca133db3be17be8f32 )
+)
+
+game (
+	name "Animaniacs - The Great Edgar Hunt (EU)"
+	description "Animaniacs - The Great Edgar Hunt (EU)"
+	rom ( name "Animaniacs - The Great Edgar Hunt (EU).iso" size 1459978240 crc f3eb5044 md5 fadea1a87a38bbfabbe0ad0333de2a6d sha1 48e9f5473b9878079a2b1ce96b2d3a599c4e4bca )
+)
+
+game (
+	name "Animaniacs - The Great Edgar Hunt (Europe) (En,Fr,De,Es,It)"
+	description "Animaniacs - The Great Edgar Hunt (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Animaniacs - The Great Edgar Hunt (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f3eb5044 md5 fadea1a87a38bbfabbe0ad0333de2a6d sha1 48e9f5473b9878079a2b1ce96b2d3a599c4e4bca )
+)
+
+game (
+	name "Animaniacs - The Great Edgar Hunt (US)"
+	description "Animaniacs - The Great Edgar Hunt (US)"
+	rom ( name "Animaniacs - The Great Edgar Hunt (US).iso" size 1459978240 crc efa60854 md5 a3de47f3c1a2c373fa3e94f62acd489c sha1 b21bf13c0d297ab350edbdc80d682e054328a743 )
+)
+
+game (
+	name "Animaniacs - The Great Edgar Hunt (USA)"
+	description "Animaniacs - The Great Edgar Hunt (USA)"
+	rom ( name "Animaniacs - The Great Edgar Hunt (USA).iso" size 1459978240 crc efa60854 md5 a3de47f3c1a2c373fa3e94f62acd489c sha1 b21bf13c0d297ab350edbdc80d682e054328a743 )
+)
+
+game (
+	name "Ant Bully, The (US)"
+	description "Ant Bully, The (US)"
+	rom ( name "Ant Bully, The (US).iso" size 1459978240 crc 82e88bc9 md5 3ebba6487c94fbe1a63f5caa4014958f sha1 2f55464b07983a4e89ce5d360339a73ef106320b )
+)
+
+game (
+	name "Ant Bully, The (USA) (En,Fr)"
+	description "Ant Bully, The (USA) (En,Fr)"
+	rom ( name "Ant Bully, The (USA) (En,Fr).iso" size 1459978240 crc 82e88bc9 md5 3ebba6487c94fbe1a63f5caa4014958f sha1 2f55464b07983a4e89ce5d360339a73ef106320b )
+)
+
+game (
+	name "Aquaman - Battle for Atlantis (US)"
+	description "Aquaman - Battle for Atlantis (US)"
+	rom ( name "Aquaman - Battle for Atlantis (US).iso" size 1459978240 crc e3d04cb9 md5 552f5dd38ce5fe189f690be653473048 sha1 547231c50378665ac2e4a6b3045b1381a96898be )
+)
+
+game (
+	name "Aquaman - Battle for Atlantis (USA)"
+	description "Aquaman - Battle for Atlantis (USA)"
+	rom ( name "Aquaman - Battle for Atlantis (USA).iso" size 1459978240 crc e3d04cb9 md5 552f5dd38ce5fe189f690be653473048 sha1 547231c50378665ac2e4a6b3045b1381a96898be )
+)
+
+game (
+	name "Army Men - Air Combat - The Elite Missions (US)"
+	description "Army Men - Air Combat - The Elite Missions (US)"
+	rom ( name "Army Men - Air Combat - The Elite Missions (US).iso" size 1459978240 crc c7bdbcba md5 1502e3b63cb7a71528c9b56244fff21c sha1 1fadea0db0547efe014d4dd8030afd32b7230b1c )
+)
+
+game (
+	name "Army Men - Air Combat - The Elite Missions (USA)"
+	description "Army Men - Air Combat - The Elite Missions (USA)"
+	rom ( name "Army Men - Air Combat - The Elite Missions (USA).iso" size 1459978240 crc c7bdbcba md5 1502e3b63cb7a71528c9b56244fff21c sha1 1fadea0db0547efe014d4dd8030afd32b7230b1c )
+)
+
+game (
+	name "Army Men - RTS (US)"
+	description "Army Men - RTS (US)"
+	rom ( name "Army Men - RTS (US).iso" size 1459978240 crc 98867ba8 md5 a6f0efcd45f9f1350ec6ec363e6bb9e9 sha1 6a17e1535a4a40d84f7737bcad4fa5599a1f3a14 )
+)
+
+game (
+	name "Army Men - RTS (USA)"
+	description "Army Men - RTS (USA)"
+	rom ( name "Army Men - RTS (USA).iso" size 1459978240 crc 98867ba8 md5 a6f0efcd45f9f1350ec6ec363e6bb9e9 sha1 6a17e1535a4a40d84f7737bcad4fa5599a1f3a14 )
+)
+
+game (
+	name "Army Men - Sarge's War (US)"
+	description "Army Men - Sarge's War (US)"
+	rom ( name "Army Men - Sarge's War (US).iso" size 1459978240 crc 378153a0 md5 0bbaacfcdd866b0eaef401e03f77a11a sha1 21ab1185a4dec9c40e1999500ed9bca7d99eddb3 )
+)
+
+game (
+	name "Army Men - Sarge's War (USA)"
+	description "Army Men - Sarge's War (USA)"
+	rom ( name "Army Men - Sarge's War (USA).iso" size 1459978240 crc 378153a0 md5 0bbaacfcdd866b0eaef401e03f77a11a sha1 21ab1185a4dec9c40e1999500ed9bca7d99eddb3 )
+)
+
+game (
+	name "Asterix & Obelix XXL (EU)"
+	description "Asterix & Obelix XXL (EU)"
+	rom ( name "Asterix & Obelix XXL (EU).iso" size 1459978240 crc e1bbde8f md5 63cef5f1c7ffc3b3d311e71bfc717835 sha1 5add4b341a2fce468e00e2ff78ca4955b8232d4b )
+)
+
+game (
+	name "Asterix & Obelix XXL (Europe) (En,Fr,De,Es,It)"
+	description "Asterix & Obelix XXL (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Asterix & Obelix XXL (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e1bbde8f md5 63cef5f1c7ffc3b3d311e71bfc717835 sha1 5add4b341a2fce468e00e2ff78ca4955b8232d4b )
+)
+
+game (
+	name "Atsumare!! Made in Wario (Japan)"
+	description "Atsumare!! Made in Wario (Japan)"
+	rom ( name "Atsumare!! Made in Wario (Japan).iso" size 1459978240 crc e3338ca2 md5 349eaa09717564bb0fee60f962495453 sha1 725b7c01e3075432f8bf3c49e6320811eaf747fe )
+)
+
+game (
+	name "Atsumare!! Made in Wario (JP) - atumare!!+made+in+wario"
+	description "Atsumare!! Made in Wario (JP) - atumare!!+made+in+wario"
+	rom ( name "Atsumare!! Made in Wario (JP).iso" size 1459978240 crc e3338ca2 md5 349eaa09717564bb0fee60f962495453 sha1 725b7c01e3075432f8bf3c49e6320811eaf747fe )
+)
+
+game (
+	name "ATV - Quad Power Racing 2 (EU)"
+	description "ATV - Quad Power Racing 2 (EU)"
+	rom ( name "ATV - Quad Power Racing 2 (EU).iso" size 1459978240 crc d16161b8 md5 6f3333aabb42daa702471cc91a082995 sha1 14f79375a078fb4aaf3c172493ac12bf92e0e51e )
+)
+
+game (
+	name "ATV - Quad Power Racing 2 (Europe) (En,Fr,De,Es,It)"
+	description "ATV - Quad Power Racing 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "ATV - Quad Power Racing 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc d16161b8 md5 6f3333aabb42daa702471cc91a082995 sha1 14f79375a078fb4aaf3c172493ac12bf92e0e51e )
+)
+
+game (
+	name "ATV - Quad Power Racing 2 (US)"
+	description "ATV - Quad Power Racing 2 (US)"
+	rom ( name "ATV - Quad Power Racing 2 (US).iso" size 1459978240 crc 8af3eed7 md5 4712e192117bee2d53fc8ec7577f0a38 sha1 f9c6a0bdd336d0e3a3d48b8d25874f514635f37f )
+)
+
+game (
+	name "ATV - Quad Power Racing 2 (USA)"
+	description "ATV - Quad Power Racing 2 (USA)"
+	rom ( name "ATV - Quad Power Racing 2 (USA).iso" size 1459978240 crc 8af3eed7 md5 4712e192117bee2d53fc8ec7577f0a38 sha1 f9c6a0bdd336d0e3a3d48b8d25874f514635f37f )
+)
+
+game (
+	name "Auto Modellista - U.S.-tuned (Japan)"
+	description "Auto Modellista - U.S.-tuned (Japan)"
+	rom ( name "Auto Modellista - U.S.-tuned (Japan).iso" size 1459978240 crc fa116fdd md5 ec27a03b20e85f56b11581beb692172d sha1 da31232e3286250a11ae8f43d1bf4e3e1a4fb316 )
+)
+
+game (
+	name "Auto Modellista - U.S.-tuned (JP) - automoderisuta+U.S.-tuned"
+	description "Auto Modellista - U.S.-tuned (JP) - automoderisuta+U.S.-tuned"
+	rom ( name "Auto Modellista - U.S.-tuned (JP).iso" size 1459978240 crc fa116fdd md5 ec27a03b20e85f56b11581beb692172d sha1 da31232e3286250a11ae8f43d1bf4e3e1a4fb316 )
+)
+
+game (
+	name "Auto Modellista (US)"
+	description "Auto Modellista (US)"
+	rom ( name "Auto Modellista (US).iso" size 1459978240 crc ab80ecfb md5 15c01fd233fb32e0ccf147c4214f9699 sha1 800b74412f60939c2d93d7f1ce679cd3da068e55 )
+)
+
+game (
+	name "Auto Modellista (USA)"
+	description "Auto Modellista (USA)"
+	rom ( name "Auto Modellista (USA).iso" size 1459978240 crc ab80ecfb md5 15c01fd233fb32e0ccf147c4214f9699 sha1 800b74412f60939c2d93d7f1ce679cd3da068e55 )
+)
+
+game (
+	name "Avatar - The Last Airbender (US)"
+	description "Avatar - The Last Airbender (US)"
+	rom ( name "Avatar - The Last Airbender (US).iso" size 1459978240 crc 31f0c2ec md5 204aed24a403072e2470b473099b18c7 sha1 b7e478e3f29da261a4bd6b2709843470530760a0 )
+)
+
+game (
+	name "Avatar - The Last Airbender (USA)"
+	description "Avatar - The Last Airbender (USA)"
+	rom ( name "Avatar - The Last Airbender (USA).iso" size 1459978240 crc 31f0c2ec md5 204aed24a403072e2470b473099b18c7 sha1 b7e478e3f29da261a4bd6b2709843470530760a0 )
+)
+
+game (
+	name "Backyard Baseball (US)"
+	description "Backyard Baseball (US)"
+	rom ( name "Backyard Baseball (US).iso" size 1459978240 crc 252d25ea md5 ee9a820d440b0317144dc36ee86ac4fa sha1 25477c45eef85de8058635353c74f829512e2826 )
+)
+
+game (
+	name "Backyard Baseball (USA)"
+	description "Backyard Baseball (USA)"
+	rom ( name "Backyard Baseball (USA).iso" size 1459978240 crc 252d25ea md5 ee9a820d440b0317144dc36ee86ac4fa sha1 25477c45eef85de8058635353c74f829512e2826 )
+)
+
+game (
+	name "Backyard Football (US)"
+	description "Backyard Football (US)"
+	rom ( name "Backyard Football (US).iso" size 1459978240 crc a00eb5c8 md5 6a6362b28f7e9ec6dea652c34d69f2c6 sha1 0aecb7fd86ec9994bc1a440796536fbac733c1b4 )
+)
+
+game (
+	name "Backyard Football (USA)"
+	description "Backyard Football (USA)"
+	rom ( name "Backyard Football (USA).iso" size 1459978240 crc a00eb5c8 md5 6a6362b28f7e9ec6dea652c34d69f2c6 sha1 0aecb7fd86ec9994bc1a440796536fbac733c1b4 )
+)
+
+game (
+	name "Backyard Sports - Baseball 2007 (US)"
+	description "Backyard Sports - Baseball 2007 (US)"
+	rom ( name "Backyard Sports - Baseball 2007 (US).iso" size 1459978240 crc 81d63aa4 md5 831f0c05a4c42c89147bc8ffc5b7a66d sha1 4e2a0c9458984d01cbbd41540296236f231ba33b )
+)
+
+game (
+	name "Backyard Sports - Baseball 2007 (USA)"
+	description "Backyard Sports - Baseball 2007 (USA)"
+	rom ( name "Backyard Sports - Baseball 2007 (USA).iso" size 1459978240 crc 81d63aa4 md5 831f0c05a4c42c89147bc8ffc5b7a66d sha1 4e2a0c9458984d01cbbd41540296236f231ba33b )
+)
+
+game (
+	name "Bad Boys - Miami Takedown (US)"
+	description "Bad Boys - Miami Takedown (US)"
+	rom ( name "Bad Boys - Miami Takedown (US).iso" size 1459978240 crc 1a5addaf md5 9e04a779bcf190e3f4cd98cf5fcb5f06 sha1 6960d88596dfe89e5da516c70ac2700b8089d38f )
+)
+
+game (
+	name "Bad Boys - Miami Takedown (USA)"
+	description "Bad Boys - Miami Takedown (USA)"
+	rom ( name "Bad Boys - Miami Takedown (USA).iso" size 1459978240 crc 1a5addaf md5 9e04a779bcf190e3f4cd98cf5fcb5f06 sha1 6960d88596dfe89e5da516c70ac2700b8089d38f )
+)
+
+game (
+	name "Bad Boys II (EU)"
+	description "Bad Boys II (EU)"
+	rom ( name "Bad Boys II (EU).iso" size 1459978240 crc a2286865 md5 1e9b87ccb012ecc4eb1cbd731b11f8b7 sha1 d7814edae68893c9f10ee140888fffcee34b5a46 )
+)
+
+game (
+	name "Bad Boys II (Europe) (En,Fr,De,Es,It)"
+	description "Bad Boys II (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Bad Boys II (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a2286865 md5 1e9b87ccb012ecc4eb1cbd731b11f8b7 sha1 d7814edae68893c9f10ee140888fffcee34b5a46 )
+)
+
+game (
+	name "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (Japan)"
+	description "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (Japan)"
+	rom ( name "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (Japan).iso" size 1459978240 crc 6cfc23ff md5 448c3ffccfb2999e06a95692a1bb420e sha1 0f59eee37a63caf412e0df31091d34d759602b85 )
+)
+
+game (
+	name "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (JP) - Bao Zhuan siyuto+beiburedo2002+Re Dou !magunetatugubatoru!"
+	description "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (JP) - Bao Zhuan siyuto+beiburedo2002+Re Dou !magunetatugubatoru!"
+	rom ( name "Bakuten Shoot Beyblade 2002 - Nettou! Magne Tag Battle! (JP).iso" size 1459978240 crc 6cfc23ff md5 448c3ffccfb2999e06a95692a1bb420e sha1 0f59eee37a63caf412e0df31091d34d759602b85 )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (DE)"
+	description "Baldur's Gate - Dark Alliance (DE)"
+	rom ( name "Baldur's Gate - Dark Alliance (DE).iso" size 1459978240 crc 35730d05 md5 273ae0e6d23ee22e54f624ed5a34c31d sha1 45f1de5acffa2ad939c7e98b874bf0e30bf90870 )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (Europe)"
+	description "Baldur's Gate - Dark Alliance (Europe)"
+	rom ( name "Baldur's Gate - Dark Alliance (Europe).iso" size 1459978240 crc 26225b33 md5 ba9e4d872a0dc2f69f37f06dd0e8e67f sha1 542dc663b9747d48b7908553c3feb33713dd8ead )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (FR)"
+	description "Baldur's Gate - Dark Alliance (FR)"
+	rom ( name "Baldur's Gate - Dark Alliance (FR).iso" size 1459978240 crc 3c7de362 md5 113ddfb6d582b99677df2d7e79f2c576 sha1 bc1cc762f89558907b10bc1dffe8e1bc3a435960 )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (France)"
+	description "Baldur's Gate - Dark Alliance (France)"
+	rom ( name "Baldur's Gate - Dark Alliance (France).iso" size 1459978240 crc 3c7de362 md5 113ddfb6d582b99677df2d7e79f2c576 sha1 bc1cc762f89558907b10bc1dffe8e1bc3a435960 )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (GB)"
+	description "Baldur's Gate - Dark Alliance (GB)"
+	rom ( name "Baldur's Gate - Dark Alliance (GB).iso" size 1459978240 crc 26225b33 md5 ba9e4d872a0dc2f69f37f06dd0e8e67f sha1 542dc663b9747d48b7908553c3feb33713dd8ead )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (Germany)"
+	description "Baldur's Gate - Dark Alliance (Germany)"
+	rom ( name "Baldur's Gate - Dark Alliance (Germany).iso" size 1459978240 crc 35730d05 md5 273ae0e6d23ee22e54f624ed5a34c31d sha1 45f1de5acffa2ad939c7e98b874bf0e30bf90870 )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (US)"
+	description "Baldur's Gate - Dark Alliance (US)"
+	rom ( name "Baldur's Gate - Dark Alliance (US).iso" size 1459978240 crc d942d22a md5 3b428c5f5e7f60d1dac28a792d5c0367 sha1 c2d49e31143dbb4818b9f9198446618e6265190e )
+)
+
+game (
+	name "Baldur's Gate - Dark Alliance (USA)"
+	description "Baldur's Gate - Dark Alliance (USA)"
+	rom ( name "Baldur's Gate - Dark Alliance (USA).iso" size 1459978240 crc d942d22a md5 3b428c5f5e7f60d1dac28a792d5c0367 sha1 c2d49e31143dbb4818b9f9198446618e6265190e )
+)
+
+game (
+	name "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (Japan)"
+	description "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (Japan)"
+	rom ( name "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (Japan).iso" size 1459978240 crc e4592ff5 md5 d3ad5466ef90ff5c6b6ab94f3cb1d8e1 sha1 bb0ac70d6adb939aff99e7e89644baa3587b4b0d )
+)
+
+game (
+	name "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (JP) - THE+BASEBALL+2003+batoruborupakuXuan Yan +pahuekutopurepuroYe Qiu"
+	description "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (JP) - THE+BASEBALL+2003+batoruborupakuXuan Yan +pahuekutopurepuroYe Qiu"
+	rom ( name "Baseball 2003, The - Battle Ball Park Sengen Perfect Play Pro Yakyuu (JP).iso" size 1459978240 crc e4592ff5 md5 d3ad5466ef90ff5c6b6ab94f3cb1d8e1 sha1 bb0ac70d6adb939aff99e7e89644baa3587b4b0d )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (Japan)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (Japan)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (Japan).iso" size 1459978240 crc e5643fc5 md5 520534e0510064140d2820940a459e67 sha1 c7e199162da5512779011361760d8b35f8d98aee )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (JP) - batenkaitosu+Zhong waranaiYi toShi waretaHai +supesiyaruTi Yan deisuku"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (JP) - batenkaitosu+Zhong waranaiYi toShi waretaHai +supesiyaruTi Yan deisuku"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean - Special Experience Disc (JP).iso" size 1459978240 crc e5643fc5 md5 520534e0510064140d2820940a459e67 sha1 c7e199162da5512779011361760d8b35f8d98aee )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (EU)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (EU)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (EU) - (Disc 1 of 2).iso" size 1459978240 crc 33313506 md5 bbaa18906e55acbf8d1016459653e25e sha1 8e82342567ccaabf5d31929d5f465cffe5654d10 )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 33313506 md5 bbaa18906e55acbf8d1016459653e25e sha1 8e82342567ccaabf5d31929d5f465cffe5654d10 )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 89ca97c6 md5 aed7dcac956ce8f677545f9a82c1afb0 sha1 2b9e223da2da295b41e92eda523accedd06275e3 )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (US)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (US)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (US) - (Disc 1 of 2).iso" size 1459978240 crc 045b4a8d md5 59d99ac5058174bb5bdfaf71a0c1347b sha1 0ce23b9b41bee99e475812b46e236c89a0987956 )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 1)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 1)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 1).iso" size 1459978240 crc 045b4a8d md5 59d99ac5058174bb5bdfaf71a0c1347b sha1 0ce23b9b41bee99e475812b46e236c89a0987956 )
+)
+
+game (
+	name "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 2)"
+	description "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 2)"
+	rom ( name "Baten Kaitos - Eternal Wings and the Lost Ocean (USA) (Disc 2).iso" size 1459978240 crc c5cf7b30 md5 29365851deaad16e865a351c3444ea39 sha1 a2a4b75e7866d9272407da95ec93986bef4c7dfc )
+)
+
+game (
+	name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 1)"
+	description "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 1)"
+	rom ( name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 1).iso" size 1459978240 crc 1e35cabf md5 8059457a72c98b010de282ef2955e7f3 sha1 c956a9b6271f0eef8cc200e520d51f9b8c552423 )
+)
+
+game (
+	name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 2)"
+	description "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 2)"
+	rom ( name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (Japan) (Disc 2).iso" size 1459978240 crc 97f827dd md5 fef7c8581860c4b86b60e9839f7fd24e sha1 f6a377234af417d8f7f765073d0d21004f8f6448 )
+)
+
+game (
+	name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (JP) - batenkaitosu+Zhong waranaiYi toShi waretaHai"
+	description "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (JP) - batenkaitosu+Zhong waranaiYi toShi waretaHai"
+	rom ( name "Baten Kaitos - Owaranai Tsubasa to Ushinawareta Umi (JP) - (Disc 1 of 2).iso" size 1459978240 crc 1e35cabf md5 8059457a72c98b010de282ef2955e7f3 sha1 c956a9b6271f0eef8cc200e520d51f9b8c552423 )
+)
+
+game (
+	name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 1)"
+	description "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 1)"
+	rom ( name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 1).iso" size 1459978240 crc 0cb5efc3 md5 7f5361396b6507a3c12039e4c00c19ed sha1 43dac2d95ee62f98fda1b4c45df97807a41498e5 )
+)
+
+game (
+	name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 2)"
+	description "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 2)"
+	rom ( name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (Japan) (Disc 2).iso" size 1459978240 crc c2c5b93d md5 f6be39c1dfbb467f32becfe6630b60b2 sha1 29165fb67eebc8c7473cbed8b0ad35ef033b0b82 )
+)
+
+game (
+	name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (JP) - batenkaitosuII Shi marinoYi toShen "noSi Zi"
+	description "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (JP) - batenkaitosuII Shi marinoYi toShen "noSi Zi"
+	rom ( name "Baten Kaitos II - Hajimari no Tsubasa to Kamigami no Shishi (JP) - (Disc 1 of 2).iso" size 1459978240 crc 0cb5efc3 md5 7f5361396b6507a3c12039e4c00c19ed sha1 43dac2d95ee62f98fda1b4c45df97807a41498e5 )
+)
+
+game (
+	name "Baten Kaitos Origins (US)"
+	description "Baten Kaitos Origins (US)"
+	rom ( name "Baten Kaitos Origins (US) - (Disc 1 of 2).iso" size 1459978240 crc adf9fcb3 md5 67a443e8e6c8e50de87f45433ebfbddc sha1 b5e6aafae4aa171caa558875ca7d66b465a78f7f )
+)
+
+game (
+	name "Baten Kaitos Origins (USA) (Disc 1)"
+	description "Baten Kaitos Origins (USA) (Disc 1)"
+	rom ( name "Baten Kaitos Origins (USA) (Disc 1).iso" size 1459978240 crc adf9fcb3 md5 67a443e8e6c8e50de87f45433ebfbddc sha1 b5e6aafae4aa171caa558875ca7d66b465a78f7f )
+)
+
+game (
+	name "Baten Kaitos Origins (USA) (Disc 2)"
+	description "Baten Kaitos Origins (USA) (Disc 2)"
+	rom ( name "Baten Kaitos Origins (USA) (Disc 2).iso" size 1459978240 crc b835fe56 md5 89dccbcfa40699cfdb5cd9506f1123c4 sha1 706774280ed6dba841a9ed600066f8773c80a8c0 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (EU)"
+	description "Batman - Dark Tomorrow (EU)"
+	rom ( name "Batman - Dark Tomorrow (EU).iso" size 1459978240 crc 67e11667 md5 6c6db2130345fe1f02b7f5a05a152a5a sha1 d540f08246a0f890f6b44bf78c65cf8354a38f99 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (Europe) (En,Fr,De,Es,It)"
+	description "Batman - Dark Tomorrow (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Batman - Dark Tomorrow (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 67e11667 md5 6c6db2130345fe1f02b7f5a05a152a5a sha1 d540f08246a0f890f6b44bf78c65cf8354a38f99 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (Japan)"
+	description "Batman - Dark Tomorrow (Japan)"
+	rom ( name "Batman - Dark Tomorrow (Japan).iso" size 1459978240 crc e46515f8 md5 3d2dcb7b01ef013d12b34a96b31ef317 sha1 37860ac33eb3d937f4d4ef039780c29c0a8442a1 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (JP) - batutoman+dakutoumoro"
+	description "Batman - Dark Tomorrow (JP) - batutoman+dakutoumoro"
+	rom ( name "Batman - Dark Tomorrow (JP).iso" size 1459978240 crc e46515f8 md5 3d2dcb7b01ef013d12b34a96b31ef317 sha1 37860ac33eb3d937f4d4ef039780c29c0a8442a1 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (US)"
+	description "Batman - Dark Tomorrow (US)"
+	rom ( name "Batman - Dark Tomorrow (US).iso" size 1459978240 crc c30991fa md5 70a7d63e5eaefbcccbd9f95ea588b983 sha1 d167f54a3732044dea8f61de4db1b98fc92f4463 )
+)
+
+game (
+	name "Batman - Dark Tomorrow (USA)"
+	description "Batman - Dark Tomorrow (USA)"
+	rom ( name "Batman - Dark Tomorrow (USA).iso" size 1459978240 crc c30991fa md5 70a7d63e5eaefbcccbd9f95ea588b983 sha1 d167f54a3732044dea8f61de4db1b98fc92f4463 )
+)
+
+game (
+	name "Batman - Rise of Sin Tzu (EU)"
+	description "Batman - Rise of Sin Tzu (EU)"
+	rom ( name "Batman - Rise of Sin Tzu (EU).iso" size 1459978240 crc a640902d md5 ea8289eeb44f2eef2b8c1b9e2158523e sha1 b37076d0a4a0544b091d7967ed1a965d11859d39 )
+)
+
+game (
+	name "Batman - Rise of Sin Tzu (Europe) (En,Fr,De,Es,It)"
+	description "Batman - Rise of Sin Tzu (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Batman - Rise of Sin Tzu (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a640902d md5 ea8289eeb44f2eef2b8c1b9e2158523e sha1 b37076d0a4a0544b091d7967ed1a965d11859d39 )
+)
+
+game (
+	name "Batman - Rise of Sin Tzu (US)"
+	description "Batman - Rise of Sin Tzu (US)"
+	rom ( name "Batman - Rise of Sin Tzu (US).iso" size 1459978240 crc e9a1b02c md5 a1134226646c60912d2e8b553a961ea5 sha1 3bff604cff117b3c4879ac180033c1ce8d3e2686 )
+)
+
+game (
+	name "Batman - Rise of Sin Tzu (USA) (En,Fr,Es)"
+	description "Batman - Rise of Sin Tzu (USA) (En,Fr,Es)"
+	rom ( name "Batman - Rise of Sin Tzu (USA) (En,Fr,Es).iso" size 1459978240 crc e9a1b02c md5 a1134226646c60912d2e8b553a961ea5 sha1 3bff604cff117b3c4879ac180033c1ce8d3e2686 )
+)
+
+game (
+	name "Batman - Vengeance (EU)"
+	description "Batman - Vengeance (EU)"
+	rom ( name "Batman - Vengeance (EU).iso" size 1459978240 crc 66acef15 md5 1be277a1f13bd36b06420b645812d522 sha1 154a461b4620e185cf023d25a81fdba2fb90e082 )
+)
+
+game (
+	name "Batman - Vengeance (Europe) (En,Fr,De,Es,It)"
+	description "Batman - Vengeance (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Batman - Vengeance (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 66acef15 md5 1be277a1f13bd36b06420b645812d522 sha1 154a461b4620e185cf023d25a81fdba2fb90e082 )
+)
+
+game (
+	name "Batman - Vengeance (US)"
+	description "Batman - Vengeance (US)"
+	rom ( name "Batman - Vengeance (US).iso" size 1459978240 crc e566702e md5 f54fd223ec22def35fe06a0ed4a7cad9 sha1 810ad7fd141270df8579710ebeec71f58c1e5ec2 )
+)
+
+game (
+	name "Batman - Vengeance (USA) (En,Fr,Es)"
+	description "Batman - Vengeance (USA) (En,Fr,Es)"
+	rom ( name "Batman - Vengeance (USA) (En,Fr,Es).iso" size 1459978240 crc e566702e md5 f54fd223ec22def35fe06a0ed4a7cad9 sha1 810ad7fd141270df8579710ebeec71f58c1e5ec2 )
+)
+
+game (
+	name "Batman Begins (EU)"
+	description "Batman Begins (EU)"
+	rom ( name "Batman Begins (EU).iso" size 1459978240 crc 02018d7b md5 78508a608ebf3aa8bd5ee69f7c3335b0 sha1 58f81ff36ef88b61826ad33edcdeff0c655c1493 )
+)
+
+game (
+	name "Batman Begins (Europe) (En,Fr,De,Es,Nl)"
+	description "Batman Begins (Europe) (En,Fr,De,Es,Nl)"
+	rom ( name "Batman Begins (Europe) (En,Fr,De,Es,Nl).iso" size 1459978240 crc 02018d7b md5 78508a608ebf3aa8bd5ee69f7c3335b0 sha1 58f81ff36ef88b61826ad33edcdeff0c655c1493 )
+)
+
+game (
+	name "Batman Begins (US)"
+	description "Batman Begins (US)"
+	rom ( name "Batman Begins (US).iso" size 1459978240 crc 1201b031 md5 39307e2374e1c6606a7d2e023d1c7e96 sha1 e8044b6eb8bf3734956a8398f910071013b2b0e6 )
+)
+
+game (
+	name "Batman Begins (USA)"
+	description "Batman Begins (USA)"
+	rom ( name "Batman Begins (USA).iso" size 1459978240 crc 1201b031 md5 39307e2374e1c6606a7d2e023d1c7e96 sha1 e8044b6eb8bf3734956a8398f910071013b2b0e6 )
+)
+
+game (
+	name "Battalion Wars (EU)"
+	description "Battalion Wars (EU)"
+	rom ( name "Battalion Wars (EU).iso" size 1459978240 crc 8910ab71 md5 fb021b57319ae96b77d01787acedb640 sha1 c7e459d64ec1defb329894ab1dd65336b1aee6e0 )
+)
+
+game (
+	name "Battalion Wars (Europe) (En,Fr,De,Es,It)"
+	description "Battalion Wars (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Battalion Wars (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 8910ab71 md5 fb021b57319ae96b77d01787acedb640 sha1 c7e459d64ec1defb329894ab1dd65336b1aee6e0 )
+)
+
+game (
+	name "Battalion Wars (US)"
+	description "Battalion Wars (US)"
+	rom ( name "Battalion Wars (US).iso" size 1459978240 crc f697e65a md5 e02a6a1b3700c3c551571f2f286d476d sha1 6b121f88608643dc7fda373b4b39143dec2f6f6f )
+)
+
+game (
+	name "Battalion Wars (USA)"
+	description "Battalion Wars (USA)"
+	rom ( name "Battalion Wars (USA).iso" size 1459978240 crc f697e65a md5 e02a6a1b3700c3c551571f2f286d476d sha1 6b121f88608643dc7fda373b4b39143dec2f6f6f )
+)
+
+game (
+	name "Battle Houshin (Japan)"
+	description "Battle Houshin (Japan)"
+	rom ( name "Battle Houshin (Japan).iso" size 1459978240 crc 192601b2 md5 f5b9f0fa760650f1b3099917b09733e7 sha1 160260d16b3f9fbe2cf4ca9f227ff3bebbbc5e1c )
+)
+
+game (
+	name "Battle Houshin (JP) - batoruFeng Shen"
+	description "Battle Houshin (JP) - batoruFeng Shen"
+	rom ( name "Battle Houshin (JP).iso" size 1459978240 crc 192601b2 md5 f5b9f0fa760650f1b3099917b09733e7 sha1 160260d16b3f9fbe2cf4ca9f227ff3bebbbc5e1c )
+)
+
+game (
+	name "Battle Stadium D.O.N (Japan)"
+	description "Battle Stadium D.O.N (Japan)"
+	rom ( name "Battle Stadium D.O.N (Japan).iso" size 1459978240 crc b86cba75 md5 3fc33706589009e85e67e54add496c1f sha1 491cf401284f35733823d007a67c91190ef232d2 )
+)
+
+game (
+	name "Battle Stadium D.O.N. (JP)"
+	description "Battle Stadium D.O.N. (JP)"
+	rom ( name "Battle Stadium D.O.N. (JP).iso" size 1459978240 crc b86cba75 md5 3fc33706589009e85e67e54add496c1f sha1 491cf401284f35733823d007a67c91190ef232d2 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (EU)"
+	description "Beach Spikers - Virtua Beach Volleyball (EU)"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (EU).iso" size 1459978240 crc 35d1d351 md5 75591d7514b72276a32f4a0faa424f32 sha1 35e7b5edd64196dc84b9e39bcde8a9d9f39b6fa8 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (Europe) (En,Fr,De,Es,It)"
+	description "Beach Spikers - Virtua Beach Volleyball (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 35d1d351 md5 75591d7514b72276a32f4a0faa424f32 sha1 35e7b5edd64196dc84b9e39bcde8a9d9f39b6fa8 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (Japan)"
+	description "Beach Spikers - Virtua Beach Volleyball (Japan)"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (Japan).iso" size 1459978240 crc a71e628a md5 400b37a71b352c6be8a3e6f6c16e447d sha1 79f800dcbc73537aeb44fcfac70100714dafc7b3 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (JP) - biti+supaikazu"
+	description "Beach Spikers - Virtua Beach Volleyball (JP) - biti+supaikazu"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (JP).iso" size 1459978240 crc a71e628a md5 400b37a71b352c6be8a3e6f6c16e447d sha1 79f800dcbc73537aeb44fcfac70100714dafc7b3 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (US)"
+	description "Beach Spikers - Virtua Beach Volleyball (US)"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (US).iso" size 1459978240 crc 7bd812c3 md5 c18f2fae7fc17adfea6656213c76e097 sha1 ec8732c318dd6facf97da6c12e054220dc5f1dc5 )
+)
+
+game (
+	name "Beach Spikers - Virtua Beach Volleyball (USA)"
+	description "Beach Spikers - Virtua Beach Volleyball (USA)"
+	rom ( name "Beach Spikers - Virtua Beach Volleyball (USA).iso" size 1459978240 crc 7bd812c3 md5 c18f2fae7fc17adfea6656213c76e097 sha1 ec8732c318dd6facf97da6c12e054220dc5f1dc5 )
+)
+
+game (
+	name "Beyblade VForce - Super Tournament Battle (EU)"
+	description "Beyblade VForce - Super Tournament Battle (EU)"
+	rom ( name "Beyblade VForce - Super Tournament Battle (EU).iso" size 1459978240 crc ba59953f md5 5b3df8a487cf85f51ac1292fa0e992fe sha1 52fc206111247194abf936a101d2499e09da4c42 )
+)
+
+game (
+	name "Beyblade VForce - Super Tournament Battle (Europe) (En,Fr,De,Es,It)"
+	description "Beyblade VForce - Super Tournament Battle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Beyblade VForce - Super Tournament Battle (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ba59953f md5 5b3df8a487cf85f51ac1292fa0e992fe sha1 52fc206111247194abf936a101d2499e09da4c42 )
+)
+
+game (
+	name "Beyblade VForce - Super Tournament Battle (US)"
+	description "Beyblade VForce - Super Tournament Battle (US)"
+	rom ( name "Beyblade VForce - Super Tournament Battle (US).iso" size 1459978240 crc 1474062c md5 8f658496ffaca32a7113e4b5db43102d sha1 586a832d1b3b1c148d919acba8f909ce0cae0441 )
+)
+
+game (
+	name "Beyblade VForce - Super Tournament Battle (USA)"
+	description "Beyblade VForce - Super Tournament Battle (USA)"
+	rom ( name "Beyblade VForce - Super Tournament Battle (USA).iso" size 1459978240 crc 1474062c md5 8f658496ffaca32a7113e4b5db43102d sha1 586a832d1b3b1c148d919acba8f909ce0cae0441 )
+)
+
+game (
+	name "Beyond Good & Evil (DE^IT)"
+	description "Beyond Good & Evil (DE^IT)"
+	rom ( name "Beyond Good & Evil (DE^IT).iso" size 1459978240 crc 4bc001e0 md5 a3b541f8b7a4f222b02a2316bd8018dc sha1 29adc8d092a2f7163cac0423a85df62a5952f398 )
+)
+
+game (
+	name "Beyond Good & Evil (EU)"
+	description "Beyond Good & Evil (EU)"
+	rom ( name "Beyond Good & Evil (EU).iso" size 1459978240 crc 469f7fe8 md5 6c1a8f8af44044099e89d55ee892eff2 sha1 2c087ce257aaf936fe5292306c8085a05687020d )
+)
+
+game (
+	name "Beyond Good & Evil (Europe) (De,It)"
+	description "Beyond Good & Evil (Europe) (De,It)"
+	rom ( name "Beyond Good & Evil (Europe) (De,It).iso" size 1459978240 crc 4bc001e0 md5 a3b541f8b7a4f222b02a2316bd8018dc sha1 29adc8d092a2f7163cac0423a85df62a5952f398 )
+)
+
+game (
+	name "Beyond Good & Evil (Europe) (En,Es)"
+	description "Beyond Good & Evil (Europe) (En,Es)"
+	rom ( name "Beyond Good & Evil (Europe) (En,Es).iso" size 1459978240 crc 469f7fe8 md5 6c1a8f8af44044099e89d55ee892eff2 sha1 2c087ce257aaf936fe5292306c8085a05687020d )
+)
+
+game (
+	name "Beyond Good & Evil (Europe) (Fr,Nl)"
+	description "Beyond Good & Evil (Europe) (Fr,Nl)"
+	rom ( name "Beyond Good & Evil (Europe) (Fr,Nl).iso" size 1459978240 crc 4d4a10fe md5 7bc9d08f58779059d0d197852767023e sha1 527f2e48632dc36a163de8f83e61df58424c7909 )
+)
+
+game (
+	name "Beyond Good & Evil (FR^BE^NL)"
+	description "Beyond Good & Evil (FR^BE^NL)"
+	rom ( name "Beyond Good & Evil (FR^BE^NL).iso" size 1459978240 crc 4d4a10fe md5 7bc9d08f58779059d0d197852767023e sha1 527f2e48632dc36a163de8f83e61df58424c7909 )
+)
+
+game (
+	name "Beyond Good & Evil (US)"
+	description "Beyond Good & Evil (US)"
+	rom ( name "Beyond Good & Evil (US).iso" size 1459978240 crc 0d246034 md5 2142ae6ee5f2ab49583b193d521aec07 sha1 e66bb146ceac59d4b3f4281b2dc9501ffef92d7d )
+)
+
+game (
+	name "Beyond Good & Evil (USA) (En,Es)"
+	description "Beyond Good & Evil (USA) (En,Es)"
+	rom ( name "Beyond Good & Evil (USA) (En,Es).iso" size 1459978240 crc 0d246034 md5 2142ae6ee5f2ab49583b193d521aec07 sha1 e66bb146ceac59d4b3f4281b2dc9501ffef92d7d )
+)
+
+game (
+	name "Big Air Freestyle (EU)"
+	description "Big Air Freestyle (EU)"
+	rom ( name "Big Air Freestyle (EU).iso" size 1459978240 crc aca384d7 md5 ce0b08bf8a0f0a820ab8c86d67460f46 sha1 0a3ebf69a680f8cbddbe26e06087494739a7500c )
+)
+
+game (
+	name "Big Air Freestyle (Europe) (En,Fr,De,Es,It)"
+	description "Big Air Freestyle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Big Air Freestyle (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc aca384d7 md5 ce0b08bf8a0f0a820ab8c86d67460f46 sha1 0a3ebf69a680f8cbddbe26e06087494739a7500c )
+)
+
+game (
+	name "Big Air Freestyle (US)"
+	description "Big Air Freestyle (US)"
+	rom ( name "Big Air Freestyle (US).iso" size 1459978240 crc 3fbefc7c md5 6831e6539172b69d14f27fc6f11f9516 sha1 ca599cd060f88500753a2424a5ec33e21838898e )
+)
+
+game (
+	name "Big Air Freestyle (USA)"
+	description "Big Air Freestyle (USA)"
+	rom ( name "Big Air Freestyle (USA).iso" size 1459978240 crc 3fbefc7c md5 6831e6539172b69d14f27fc6f11f9516 sha1 ca599cd060f88500753a2424a5ec33e21838898e )
+)
+
+game (
+	name "Big Mutha Truckers (EU)"
+	description "Big Mutha Truckers (EU)"
+	rom ( name "Big Mutha Truckers (EU).iso" size 1459978240 crc 11ff3e59 md5 c2ff6c9e8e5a3f06e874fca1d7dcf4a7 sha1 e856d403935361b0bbc304feebd33feaee1b813e )
+)
+
+game (
+	name "Big Mutha Truckers (Europe) (En,Fr,De,Es,It)"
+	description "Big Mutha Truckers (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Big Mutha Truckers (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 11ff3e59 md5 c2ff6c9e8e5a3f06e874fca1d7dcf4a7 sha1 e856d403935361b0bbc304feebd33feaee1b813e )
+)
+
+game (
+	name "Big Mutha Truckers (US)"
+	description "Big Mutha Truckers (US)"
+	rom ( name "Big Mutha Truckers (US).iso" size 1459978240 crc 5a141367 md5 43130d87fe3631ec252fa91da9c26313 sha1 dd812fb631dd9a7bd530cb900010f81da0e2c931 )
+)
+
+game (
+	name "Big Mutha Truckers (USA)"
+	description "Big Mutha Truckers (USA)"
+	rom ( name "Big Mutha Truckers (USA).iso" size 1459978240 crc 5a141367 md5 43130d87fe3631ec252fa91da9c26313 sha1 dd812fb631dd9a7bd530cb900010f81da0e2c931 )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (Demo) (EU)"
+	description "Billy Hatcher and the Giant Egg (Demo) (EU)"
+	rom ( name "Billy Hatcher and the Giant Egg (Demo) (EU).iso" size 1459978240 crc 097da801 md5 adc9af8f66fc770b6fceb06c9f599500 sha1 b72a029056ceb4abb38dc13fd15a5e94484c84e6 )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (EU)"
+	description "Billy Hatcher and the Giant Egg (EU)"
+	rom ( name "Billy Hatcher and the Giant Egg (EU).iso" size 1459978240 crc ca8761d7 md5 cba94226817049a859c0246c69f8703f sha1 d81ec14313a99164674d792b4d1abc1de2860ede )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (Europe) (Demo)"
+	description "Billy Hatcher and the Giant Egg (Europe) (Demo)"
+	rom ( name "Billy Hatcher and the Giant Egg (Europe) (Demo).iso" size 1459978240 crc 097da801 md5 adc9af8f66fc770b6fceb06c9f599500 sha1 b72a029056ceb4abb38dc13fd15a5e94484c84e6 )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Billy Hatcher and the Giant Egg (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Billy Hatcher and the Giant Egg (Europe) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc ca8761d7 md5 cba94226817049a859c0246c69f8703f sha1 d81ec14313a99164674d792b4d1abc1de2860ede )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (US)"
+	description "Billy Hatcher and the Giant Egg (US)"
+	rom ( name "Billy Hatcher and the Giant Egg (US).iso" size 1459978240 crc 894ddff0 md5 bc8af5c06a3bff09351f7cb16724ffce sha1 de0a702c6e542b84be3be4f73164e6c0e0d7a844 )
+)
+
+game (
+	name "Billy Hatcher and the Giant Egg (USA)"
+	description "Billy Hatcher and the Giant Egg (USA)"
+	rom ( name "Billy Hatcher and the Giant Egg (USA).iso" size 1459978240 crc 894ddff0 md5 bc8af5c06a3bff09351f7cb16724ffce sha1 de0a702c6e542b84be3be4f73164e6c0e0d7a844 )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Kanzenban (Collector's Box) (JP) - baiohazado+kodo:beronika+~Wan Quan Ban ~"
+	description "Biohazard - Code - Veronica - Kanzenban (Collector's Box) (JP) - baiohazado+kodo:beronika+~Wan Quan Ban ~"
+	rom ( name "Biohazard - Code - Veronica - Kanzenban (Collector's Box) (JP) - (Disc 1 of 2).iso" size 1459978240 crc 2d513956 md5 6c988307da488343cf4f3a39479f351b sha1 98d7993593549a2f4de119798e7d22ff2ae4a6f6 )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1)"
+	description "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1)"
+	rom ( name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 1).iso" size 1459978240 crc 2d513956 md5 6c988307da488343cf4f3a39479f351b sha1 98d7993593549a2f4de119798e7d22ff2ae4a6f6 )
+)
+
+game (
+	name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2)"
+	description "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2)"
+	rom ( name "Biohazard - Code - Veronica - Kanzenban (Japan) (Disc 2).iso" size 1459978240 crc 5a30d35b md5 12e934a615a20dcaa07b7b2d689973ed sha1 153bd2844d304cb48b234ddb5b3451137b3d9fe3 )
+)
+
+game (
+	name "Biohazard - Special Edition (Japan)"
+	description "Biohazard - Special Edition (Japan)"
+	rom ( name "Biohazard - Special Edition (Japan).iso" size 1459978240 crc 4435e4bf md5 7515a6cb0f3655f151b4ed23d21194be sha1 efcc1c75562854d4768e2bc94d83efef5fb13f6b )
+)
+
+game (
+	name "Biohazard - Special Edition (JP) - baiohazado+Te Bie Ban"
+	description "Biohazard - Special Edition (JP) - baiohazado+Te Bie Ban"
+	rom ( name "Biohazard - Special Edition (JP).iso" size 1459978240 crc 4435e4bf md5 7515a6cb0f3655f151b4ed23d21194be sha1 efcc1c75562854d4768e2bc94d83efef5fb13f6b )
+)
+
+game (
+	name "Biohazard (Japan) (Disc 1)"
+	description "Biohazard (Japan) (Disc 1)"
+	rom ( name "Biohazard (Japan) (Disc 1).iso" size 1459978240 crc 15108252 md5 20cb8d4cb322aa503d1b8a49c43cdebf sha1 0f70a4168fc9f28bcec24f01ca7fdbd195a13ab6 )
+)
+
+game (
+	name "Biohazard (Japan) (Disc 2)"
+	description "Biohazard (Japan) (Disc 2)"
+	rom ( name "Biohazard (Japan) (Disc 2).iso" size 1459978240 crc 99c1d130 md5 bfbf8e0f249cf8dd8fcb913793301a8c sha1 e85928a2bed988781cc46abf4cc816b6f190af46 )
+)
+
+game (
+	name "Biohazard (JP) - baiohazado"
+	description "Biohazard (JP) - baiohazado"
+	rom ( name "Biohazard (JP) - (Disc 1 of 2).iso" size 1459978240 crc 15108252 md5 20cb8d4cb322aa503d1b8a49c43cdebf sha1 0f70a4168fc9f28bcec24f01ca7fdbd195a13ab6 )
+)
+
+game (
+	name "Biohazard 2 (Collector's Box) (JP) - baiohazado2"
+	description "Biohazard 2 (Collector's Box) (JP) - baiohazado2"
+	rom ( name "Biohazard 2 (Collector's Box) (JP).iso" size 1459978240 crc 98616697 md5 8602e48fdec20c43857f7ae6bcc93431 sha1 a9e9c1b63e518ab9e236442e9ff0dee01e368362 )
+)
+
+game (
+	name "Biohazard 2 (Japan)"
+	description "Biohazard 2 (Japan)"
+	rom ( name "Biohazard 2 (Japan).iso" size 1459978240 crc 98616697 md5 8602e48fdec20c43857f7ae6bcc93431 sha1 a9e9c1b63e518ab9e236442e9ff0dee01e368362 )
+)
+
+game (
+	name "Biohazard 3 - Last Escape (Collector's Box) (JP) - baiohazado3+rasutoesukepu"
+	description "Biohazard 3 - Last Escape (Collector's Box) (JP) - baiohazado3+rasutoesukepu"
+	rom ( name "Biohazard 3 - Last Escape (Collector's Box) (JP).iso" size 1459978240 crc 414aacc2 md5 245a4269337f3a290abf57a6ff156f7d sha1 0a24a51e8b8ee6c36d564d88f1c0544a7367a374 )
+)
+
+game (
+	name "Biohazard 3 - Last Escape (Japan)"
+	description "Biohazard 3 - Last Escape (Japan)"
+	rom ( name "Biohazard 3 - Last Escape (Japan).iso" size 1459978240 crc 414aacc2 md5 245a4269337f3a290abf57a6ff156f7d sha1 0a24a51e8b8ee6c36d564d88f1c0544a7367a374 )
+)
+
+game (
+	name "Biohazard 4 (Japan) (Disc 1)"
+	description "Biohazard 4 (Japan) (Disc 1)"
+	rom ( name "Biohazard 4 (Japan) (Disc 1).iso" size 1459978240 crc 561a7d27 md5 6b57d0ae0b872a50457276fb84d58cf2 sha1 d0ca01aaacf802faa0cda041c4e494caeb40eb54 )
+)
+
+game (
+	name "Biohazard 4 (Japan) (Disc 2)"
+	description "Biohazard 4 (Japan) (Disc 2)"
+	rom ( name "Biohazard 4 (Japan) (Disc 2).iso" size 1459978240 crc f2174aa9 md5 499cbec401c8d80d35b521b215e8d039 sha1 5e5d722696de7803db03fe5d022acc45956d959b )
+)
+
+game (
+	name "Biohazard 4 (Japan) (Taikenban)"
+	description "Biohazard 4 (Japan) (Taikenban)"
+	rom ( name "Biohazard 4 (Japan) (Taikenban).iso" size 1459978240 crc 496e2b76 md5 a3fba779dbc1e2dca59b92a12d391c6b sha1 6e6e7661443141150526bdbe95cfc710301f172a )
+)
+
+game (
+	name "Biohazard 4 (JP) - baiohazado4"
+	description "Biohazard 4 (JP) - baiohazado4"
+	rom ( name "Biohazard 4 (JP) - (Disc 1 of 2).iso" size 1459978240 crc 561a7d27 md5 6b57d0ae0b872a50457276fb84d58cf2 sha1 d0ca01aaacf802faa0cda041c4e494caeb40eb54 )
+)
+
+game (
+	name "Biohazard 4 (Taikenban) (JP) - baiohazado4"
+	description "Biohazard 4 (Taikenban) (JP) - baiohazado4"
+	rom ( name "Biohazard 4 (Taikenban) (JP).iso" size 1459978240 crc 496e2b76 md5 a3fba779dbc1e2dca59b92a12d391c6b sha1 6e6e7661443141150526bdbe95cfc710301f172a )
+)
+
+game (
+	name "Biohazard Zero - Trial Edition (Japan)"
+	description "Biohazard Zero - Trial Edition (Japan)"
+	rom ( name "Biohazard Zero - Trial Edition (Japan).iso" size 1459978240 crc c089501e md5 c899ff60d41eaa5acc3e79d95264ae19 sha1 4bdeef939026e8eef36802703c29b5f77281a18c )
+)
+
+game (
+	name "Biohazard Zero - Trial Edition (JP) - baiohazado0+-TRIAL+EDITION-"
+	description "Biohazard Zero - Trial Edition (JP) - baiohazado0+-TRIAL+EDITION-"
+	rom ( name "Biohazard Zero - Trial Edition (JP).iso" size 1459978240 crc c089501e md5 c899ff60d41eaa5acc3e79d95264ae19 sha1 4bdeef939026e8eef36802703c29b5f77281a18c )
+)
+
+game (
+	name "Biohazard Zero (Collector's Box) (JP) - baiohazado0"
+	description "Biohazard Zero (Collector's Box) (JP) - baiohazado0"
+	rom ( name "Biohazard Zero (Collector's Box) (JP) - (Disc 1 of 2).iso" size 1459978240 crc eeee4e93 md5 d042c42ab577de62da0c9e483008a5a3 sha1 ca05364e6b55bc517cada9560912fb6b2194e83e )
+)
+
+game (
+	name "Biohazard Zero (Japan) (Disc 1)"
+	description "Biohazard Zero (Japan) (Disc 1)"
+	rom ( name "Biohazard Zero (Japan) (Disc 1).iso" size 1459978240 crc eeee4e93 md5 d042c42ab577de62da0c9e483008a5a3 sha1 ca05364e6b55bc517cada9560912fb6b2194e83e )
+)
+
+game (
+	name "Biohazard Zero (Japan) (Disc 2)"
+	description "Biohazard Zero (Japan) (Disc 2)"
+	rom ( name "Biohazard Zero (Japan) (Disc 2).iso" size 1459978240 crc fb5b204a md5 ccd0978d8e5b3b4d4c69b5460b1e410a sha1 5d1d5fbc8de48403764cbf812c9bf6d5392919eb )
+)
+
+game (
+	name "Bionicle (EU)"
+	description "Bionicle (EU)"
+	rom ( name "Bionicle (EU).iso" size 1459978240 crc b2b57c1c md5 bb7bf25a744ebebacbe25b2877b11c21 sha1 7da0d3d1cd7933c8ab8b87d175f81b7d9b6a7537 )
+)
+
+game (
+	name "Bionicle (Europe) (En,Fr,De,Es,It,Da)"
+	description "Bionicle (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "Bionicle (Europe) (En,Fr,De,Es,It,Da).iso" size 1459978240 crc b2b57c1c md5 bb7bf25a744ebebacbe25b2877b11c21 sha1 7da0d3d1cd7933c8ab8b87d175f81b7d9b6a7537 )
+)
+
+game (
+	name "Bionicle (US)"
+	description "Bionicle (US)"
+	rom ( name "Bionicle (US).iso" size 1459978240 crc 3a2944d5 md5 07c9f2080508231eb8b3a4a37aec7034 sha1 d5f1153a2f83160e44ebc98497f4bdc11de623b2 )
+)
+
+game (
+	name "Bionicle (USA)"
+	description "Bionicle (USA)"
+	rom ( name "Bionicle (USA).iso" size 1459978240 crc 3a2944d5 md5 07c9f2080508231eb8b3a4a37aec7034 sha1 d5f1153a2f83160e44ebc98497f4bdc11de623b2 )
+)
+
+game (
+	name "Bionicle Heroes (US)"
+	description "Bionicle Heroes (US)"
+	rom ( name "Bionicle Heroes (US).iso" size 1459978240 crc a9ad9601 md5 86d7098e6710963aba2cd80ef3ee307f sha1 a4244a958c65ae826ee37d6d7f9a3840f1c78fc4 )
+)
+
+game (
+	name "Bionicle Heroes (USA)"
+	description "Bionicle Heroes (USA)"
+	rom ( name "Bionicle Heroes (USA).iso" size 1459978240 crc a9ad9601 md5 86d7098e6710963aba2cd80ef3ee307f sha1 a4244a958c65ae826ee37d6d7f9a3840f1c78fc4 )
+)
+
+game (
+	name "Black & Bruised (EU)"
+	description "Black & Bruised (EU)"
+	rom ( name "Black & Bruised (EU).iso" size 1459978240 crc d28dedbc md5 ca5c26bce0577e4a485088fe5879c557 sha1 1ecbd0f027a05d92c809dc82fbfe287a115f47ed )
+)
+
+game (
+	name "Black & Bruised (Europe) (En,Fr,De)"
+	description "Black & Bruised (Europe) (En,Fr,De)"
+	rom ( name "Black & Bruised (Europe) (En,Fr,De).iso" size 1459978240 crc d28dedbc md5 ca5c26bce0577e4a485088fe5879c557 sha1 1ecbd0f027a05d92c809dc82fbfe287a115f47ed )
+)
+
+game (
+	name "Black & Bruised (US)"
+	description "Black & Bruised (US)"
+	rom ( name "Black & Bruised (US).iso" size 1459978240 crc 73c2bbb8 md5 7dfacd44a49258043bd7a30359f3986c sha1 df0c2be013b42a784bd69c9c99903e5f52e20ff2 )
+)
+
+game (
+	name "Black & Bruised (USA)"
+	description "Black & Bruised (USA)"
+	rom ( name "Black & Bruised (USA).iso" size 1459978240 crc 73c2bbb8 md5 7dfacd44a49258043bd7a30359f3986c sha1 df0c2be013b42a784bd69c9c99903e5f52e20ff2 )
+)
+
+game (
+	name "Bleach GC - Tasogare Ni Mamieru Shinigami (Japan)"
+	description "Bleach GC - Tasogare Ni Mamieru Shinigami (Japan)"
+	rom ( name "Bleach GC - Tasogare Ni Mamieru Shinigami (Japan).iso" size 1459978240 crc c586cf28 md5 7e5526fad8e1f5718eafefd8761ab925 sha1 30a9b2f9a97562b20a8e5384562f74a233ec791f )
+)
+
+game (
+	name "Bleach GC - Tasogare Ni Mamieru Shinigami (JP) - buritiGC+Huang Hun nimamieruSi Shen"
+	description "Bleach GC - Tasogare Ni Mamieru Shinigami (JP) - buritiGC+Huang Hun nimamieruSi Shen"
+	rom ( name "Bleach GC - Tasogare Ni Mamieru Shinigami (JP).iso" size 1459978240 crc c586cf28 md5 7e5526fad8e1f5718eafefd8761ab925 sha1 30a9b2f9a97562b20a8e5384562f74a233ec791f )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (DE)"
+	description "Blood Omen 2 - The Legacy of Kain Series (DE)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (DE).iso" size 1459978240 crc 68bb4d6e md5 e851b2aec4de56e3d2496b5bfbf6a511 sha1 93a1e8d9d42582f5b13751935dddca0374997676 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (EU)"
+	description "Blood Omen 2 - The Legacy of Kain Series (EU)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (EU).iso" size 1459978240 crc d6983b59 md5 67a82b0bc5f12909af976f7f52e8c536 sha1 0fb945e51597c6da19e1c0dfad74d941feb276b9 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (Europe)"
+	description "Blood Omen 2 - The Legacy of Kain Series (Europe)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (Europe).iso" size 1459978240 crc d6983b59 md5 67a82b0bc5f12909af976f7f52e8c536 sha1 0fb945e51597c6da19e1c0dfad74d941feb276b9 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (FR)"
+	description "Blood Omen 2 - The Legacy of Kain Series (FR)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (FR).iso" size 1459978240 crc 5bab6a3b md5 9b3c3ffa235d1f8bcd7602ebfeefc87b sha1 710aacb35ac93ce5340d18c7c1770832c2e578f4 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (France)"
+	description "Blood Omen 2 - The Legacy of Kain Series (France)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (France).iso" size 1459978240 crc 5bab6a3b md5 9b3c3ffa235d1f8bcd7602ebfeefc87b sha1 710aacb35ac93ce5340d18c7c1770832c2e578f4 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (Germany)"
+	description "Blood Omen 2 - The Legacy of Kain Series (Germany)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (Germany).iso" size 1459978240 crc 68bb4d6e md5 e851b2aec4de56e3d2496b5bfbf6a511 sha1 93a1e8d9d42582f5b13751935dddca0374997676 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (US)"
+	description "Blood Omen 2 - The Legacy of Kain Series (US)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (US).iso" size 1459978240 crc 5dded798 md5 1628c6a7964dca68d42bcac65a9ef446 sha1 247dbd262c1a45c7b03491efefa5812c6ca4aae8 )
+)
+
+game (
+	name "Blood Omen 2 - The Legacy of Kain Series (USA)"
+	description "Blood Omen 2 - The Legacy of Kain Series (USA)"
+	rom ( name "Blood Omen 2 - The Legacy of Kain Series (USA).iso" size 1459978240 crc 5dded798 md5 1628c6a7964dca68d42bcac65a9ef446 sha1 247dbd262c1a45c7b03491efefa5812c6ca4aae8 )
+)
+
+game (
+	name "BloodRayne (ES)"
+	description "BloodRayne (ES)"
+	rom ( name "BloodRayne (ES).iso" size 1459978240 crc 45a67c7c md5 cb842b4da4272d293134dc14f845d8e2 sha1 fd4a3ec811d087972e189b49fc9bc139530dba0e )
+)
+
+game (
+	name "BloodRayne (Europe)"
+	description "BloodRayne (Europe)"
+	rom ( name "BloodRayne (Europe).iso" size 1459978240 crc 6d9f7b7b md5 389368cf41edb7ce01ac70bb96bef6a4 sha1 33e9320db1c53912f9ee3b13ec9935481bf7f0ee )
+)
+
+game (
+	name "BloodRayne (FR)"
+	description "BloodRayne (FR)"
+	rom ( name "BloodRayne (FR).iso" size 1459978240 crc ac9c713f md5 df297efbbeef545b8ba8d7f5dd067fd8 sha1 7863773e3d1381330b09da368f37291f90f9906e )
+)
+
+game (
+	name "BloodRayne (France)"
+	description "BloodRayne (France)"
+	rom ( name "BloodRayne (France).iso" size 1459978240 crc ac9c713f md5 df297efbbeef545b8ba8d7f5dd067fd8 sha1 7863773e3d1381330b09da368f37291f90f9906e )
+)
+
+game (
+	name "BloodRayne (GB)"
+	description "BloodRayne (GB)"
+	rom ( name "BloodRayne (GB).iso" size 1459978240 crc 6d9f7b7b md5 389368cf41edb7ce01ac70bb96bef6a4 sha1 33e9320db1c53912f9ee3b13ec9935481bf7f0ee )
+)
+
+game (
+	name "BloodRayne (Spain)"
+	description "BloodRayne (Spain)"
+	rom ( name "BloodRayne (Spain).iso" size 1459978240 crc 45a67c7c md5 cb842b4da4272d293134dc14f845d8e2 sha1 fd4a3ec811d087972e189b49fc9bc139530dba0e )
+)
+
+game (
+	name "BloodRayne (US)"
+	description "BloodRayne (US)"
+	rom ( name "BloodRayne (US).iso" size 1459978240 crc eda1fd05 md5 df2acbb111c08596b51a335fdbca4995 sha1 5856de94fd4ea99b5ddbe00b15920db963737c09 )
+)
+
+game (
+	name "BloodRayne (USA)"
+	description "BloodRayne (USA)"
+	rom ( name "BloodRayne (USA).iso" size 1459978240 crc eda1fd05 md5 df2acbb111c08596b51a335fdbca4995 sha1 5856de94fd4ea99b5ddbe00b15920db963737c09 )
+)
+
+game (
+	name "Bloody Roar - Extreme (Japan)"
+	description "Bloody Roar - Extreme (Japan)"
+	rom ( name "Bloody Roar - Extreme (Japan).iso" size 1459978240 crc 9ebecf47 md5 3583e338d5e6a517a2eb07463cc4b7c7 sha1 6b3a23efe9089e4e1c8ae57aba356c96acca75c4 )
+)
+
+game (
+	name "Bloody Roar - Extreme (JP) - buratudei+roa+ekusutorimu"
+	description "Bloody Roar - Extreme (JP) - buratudei+roa+ekusutorimu"
+	rom ( name "Bloody Roar - Extreme (JP).iso" size 1459978240 crc 9ebecf47 md5 3583e338d5e6a517a2eb07463cc4b7c7 sha1 6b3a23efe9089e4e1c8ae57aba356c96acca75c4 )
+)
+
+game (
+	name "Bloody Roar - Primal Fury (EU)"
+	description "Bloody Roar - Primal Fury (EU)"
+	rom ( name "Bloody Roar - Primal Fury (EU).iso" size 1459978240 crc 99ec3adc md5 c7704cf99e822ee61c954388211cc94d sha1 940261af84782067e84b79c2fbb9494127383f16 )
+)
+
+game (
+	name "Bloody Roar - Primal Fury (Europe)"
+	description "Bloody Roar - Primal Fury (Europe)"
+	rom ( name "Bloody Roar - Primal Fury (Europe).iso" size 1459978240 crc 99ec3adc md5 c7704cf99e822ee61c954388211cc94d sha1 940261af84782067e84b79c2fbb9494127383f16 )
+)
+
+game (
+	name "Bloody Roar - Primal Fury (US)"
+	description "Bloody Roar - Primal Fury (US)"
+	rom ( name "Bloody Roar - Primal Fury (US).iso" size 1459978240 crc 677c5c12 md5 cd526093d9a8d77230aea8f49b1f25b3 sha1 56560182b75717a04ecfa4fb797c2eb13cab0f88 )
+)
+
+game (
+	name "Bloody Roar - Primal Fury (USA)"
+	description "Bloody Roar - Primal Fury (USA)"
+	rom ( name "Bloody Roar - Primal Fury (USA).iso" size 1459978240 crc 677c5c12 md5 cd526093d9a8d77230aea8f49b1f25b3 sha1 56560182b75717a04ecfa4fb797c2eb13cab0f88 )
+)
+
+game (
+	name "Blowout (US)"
+	description "Blowout (US)"
+	rom ( name "Blowout (US).iso" size 1459978240 crc 5c683d53 md5 a1e080eff097394e0ecf304f2d6dfff9 sha1 3620b5f5df6634d226968dddf01bae277720181e )
+)
+
+game (
+	name "Blowout (USA)"
+	description "Blowout (USA)"
+	rom ( name "Blowout (USA).iso" size 1459978240 crc 5c683d53 md5 a1e080eff097394e0ecf304f2d6dfff9 sha1 3620b5f5df6634d226968dddf01bae277720181e )
+)
+
+game (
+	name "BMX XXX (EU)"
+	description "BMX XXX (EU)"
+	rom ( name "BMX XXX (EU).iso" size 1459978240 crc fb96b569 md5 6e055e37ba55299a33671ff85f4d6876 sha1 4b2cb21f91a42df34b094d2c528cdbef35ca6c08 )
+)
+
+game (
+	name "BMX XXX (Europe) (En,Fr,De,Es)"
+	description "BMX XXX (Europe) (En,Fr,De,Es)"
+	rom ( name "BMX XXX (Europe) (En,Fr,De,Es).iso" size 1459978240 crc fb96b569 md5 6e055e37ba55299a33671ff85f4d6876 sha1 4b2cb21f91a42df34b094d2c528cdbef35ca6c08 )
+)
+
+game (
+	name "BMX XXX (US)"
+	description "BMX XXX (US)"
+	rom ( name "BMX XXX (US).iso" size 1459978240 crc e84d9bd6 md5 c3fe071d90154f78558b8beccd444d64 sha1 8e0957bf307226fd46da4acd7bd18ecb1f31a78f )
+)
+
+game (
+	name "BMX XXX (USA)"
+	description "BMX XXX (USA)"
+	rom ( name "BMX XXX (USA).iso" size 1459978240 crc e84d9bd6 md5 c3fe071d90154f78558b8beccd444d64 sha1 8e0957bf307226fd46da4acd7bd18ecb1f31a78f )
+)
+
+game (
+	name "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (Japan)"
+	description "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (Japan)"
+	rom ( name "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (Japan).iso" size 1459978240 crc fe7af832 md5 0dd7a9b923e409309eda87752391e30a sha1 08dfb5289e780657687ab239a47c11f3493f4a17 )
+)
+
+game (
+	name "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (JP) - bobobobobobobo+Tuo Chu !!+hazikerowaiyaru"
+	description "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (JP) - bobobobobobobo+Tuo Chu !!+hazikerowaiyaru"
+	rom ( name "Bobobo-bo Bo-bobo Dassutsu! Hajike Royale (JP).iso" size 1459978240 crc fe7af832 md5 0dd7a9b923e409309eda87752391e30a sha1 08dfb5289e780657687ab239a47c11f3493f4a17 )
+)
+
+game (
+	name "Bokujou Monogatari - Shiawase no Uta (Japan)"
+	description "Bokujou Monogatari - Shiawase no Uta (Japan)"
+	rom ( name "Bokujou Monogatari - Shiawase no Uta (Japan).iso" size 1459978240 crc c79de776 md5 8006ac3104cdd36dc3f111c1a5b1f537 sha1 0dd1abb721dc0439d8e58cfb2dfe65e143f6eaec )
+)
+
+game (
+	name "Bokujou Monogatari - Shiawase no Uta (JP) - Mu Chang Wu Yu +siawasenoShi"
+	description "Bokujou Monogatari - Shiawase no Uta (JP) - Mu Chang Wu Yu +siawasenoShi"
+	rom ( name "Bokujou Monogatari - Shiawase no Uta (JP).iso" size 1459978240 crc c79de776 md5 8006ac3104cdd36dc3f111c1a5b1f537 sha1 0dd1abb721dc0439d8e58cfb2dfe65e143f6eaec )
+)
+
+game (
+	name "Bokujou Monogatari - Shiawase no Uta for World (Japan)"
+	description "Bokujou Monogatari - Shiawase no Uta for World (Japan)"
+	rom ( name "Bokujou Monogatari - Shiawase no Uta for World (Japan).iso" size 1459978240 crc dfad36d4 md5 652010a7f20491c0716be3031328b47e sha1 6e9a189bead2c2c254edb0391a71316adb63b37c )
+)
+
+game (
+	name "Bokujou Monogatari - Shiawase no Uta for World (JP) - Mu Chang Wu Yu +siawasenoShi +for+warudo"
+	description "Bokujou Monogatari - Shiawase no Uta for World (JP) - Mu Chang Wu Yu +siawasenoShi +for+warudo"
+	rom ( name "Bokujou Monogatari - Shiawase no Uta for World (JP).iso" size 1459978240 crc dfad36d4 md5 652010a7f20491c0716be3031328b47e sha1 6e9a189bead2c2c254edb0391a71316adb63b37c )
+)
+
+game (
+	name "Bokujou Monogatari - Wonderful Life (Japan)"
+	description "Bokujou Monogatari - Wonderful Life (Japan)"
+	rom ( name "Bokujou Monogatari - Wonderful Life (Japan).iso" size 1459978240 crc a5a47f09 md5 2bd9b086f7e7b4c15e1e8149f9b4899f sha1 5b807cd4132db57bd3f7afb12c63689ebf3cd056 )
+)
+
+game (
+	name "Bokujou Monogatari - Wonderful Life (JP) - Mu Chang Wu Yu +wandahururaihu"
+	description "Bokujou Monogatari - Wonderful Life (JP) - Mu Chang Wu Yu +wandahururaihu"
+	rom ( name "Bokujou Monogatari - Wonderful Life (JP).iso" size 1459978240 crc a5a47f09 md5 2bd9b086f7e7b4c15e1e8149f9b4899f sha1 5b807cd4132db57bd3f7afb12c63689ebf3cd056 )
+)
+
+game (
+	name "Bokujou Monogatari - Wonderful Life for Girls (Japan)"
+	description "Bokujou Monogatari - Wonderful Life for Girls (Japan)"
+	rom ( name "Bokujou Monogatari - Wonderful Life for Girls (Japan).iso" size 1459978240 crc 49f6ac56 md5 7dad8557e8ab6a0f35d8f57b9902d8f2 sha1 af6b2323a57da0549a3be80438c27cdddd9cbdb7 )
+)
+
+game (
+	name "Bokujou Monogatari - Wonderful Life for Girls (JP) - Mu Chang Wu Yu +wandahururaihu+for+garu"
+	description "Bokujou Monogatari - Wonderful Life for Girls (JP) - Mu Chang Wu Yu +wandahururaihu+for+garu"
+	rom ( name "Bokujou Monogatari - Wonderful Life for Girls (JP).iso" size 1459978240 crc 49f6ac56 md5 7dad8557e8ab6a0f35d8f57b9902d8f2 sha1 af6b2323a57da0549a3be80438c27cdddd9cbdb7 )
+)
+
+game (
+	name "Bomberman Generation (EU)"
+	description "Bomberman Generation (EU)"
+	rom ( name "Bomberman Generation (EU).iso" size 1459978240 crc d46faff3 md5 5e85f53136d139205c3b3da2d16b7b15 sha1 163ca32f868be040d85e899f83aee6945441f21f )
+)
+
+game (
+	name "Bomberman Generation (Europe) (En,Fr,De)"
+	description "Bomberman Generation (Europe) (En,Fr,De)"
+	rom ( name "Bomberman Generation (Europe) (En,Fr,De).iso" size 1459978240 crc d46faff3 md5 5e85f53136d139205c3b3da2d16b7b15 sha1 163ca32f868be040d85e899f83aee6945441f21f )
+)
+
+game (
+	name "Bomberman Generation (Japan)"
+	description "Bomberman Generation (Japan)"
+	rom ( name "Bomberman Generation (Japan).iso" size 1459978240 crc b4c2505d md5 8b52310c8f7d2e60e0a96e2c7f74dc04 sha1 2c4a9b1d730372ded80915304aac75e327ae955f )
+)
+
+game (
+	name "Bomberman Generation (JP) - bonbamanzieneresiyon"
+	description "Bomberman Generation (JP) - bonbamanzieneresiyon"
+	rom ( name "Bomberman Generation (JP).iso" size 1459978240 crc b4c2505d md5 8b52310c8f7d2e60e0a96e2c7f74dc04 sha1 2c4a9b1d730372ded80915304aac75e327ae955f )
+)
+
+game (
+	name "Bomberman Generation (US)"
+	description "Bomberman Generation (US)"
+	rom ( name "Bomberman Generation (US).iso" size 1459978240 crc 14b78773 md5 ec608eb5cbf9b5ba72756c929bee04b6 sha1 678cdf8a227bee854ddcf4ff03f9729d87f76ad1 )
+)
+
+game (
+	name "Bomberman Generation (USA)"
+	description "Bomberman Generation (USA)"
+	rom ( name "Bomberman Generation (USA).iso" size 1459978240 crc 14b78773 md5 ec608eb5cbf9b5ba72756c929bee04b6 sha1 678cdf8a227bee854ddcf4ff03f9729d87f76ad1 )
+)
+
+game (
+	name "Bomberman Jetters (Japan)"
+	description "Bomberman Jetters (Japan)"
+	rom ( name "Bomberman Jetters (Japan).iso" size 1459978240 crc cd233d37 md5 af9d21fd2b0331461db9c651c003e043 sha1 ecd904a3c70877dc52336c39d714e45cffb76c6a )
+)
+
+game (
+	name "Bomberman Jetters (JP) - bonbaman+zietutazu"
+	description "Bomberman Jetters (JP) - bonbaman+zietutazu"
+	rom ( name "Bomberman Jetters (JP).iso" size 1459978240 crc cd233d37 md5 af9d21fd2b0331461db9c651c003e043 sha1 ecd904a3c70877dc52336c39d714e45cffb76c6a )
+)
+
+game (
+	name "Bomberman Jetters (US)"
+	description "Bomberman Jetters (US)"
+	rom ( name "Bomberman Jetters (US).iso" size 1459978240 crc a1389149 md5 aa77fb6553efe3866df8dd3f83a6a1d3 sha1 1d07cdec9249c33937bffbafc24cd0a3dfd089b6 )
+)
+
+game (
+	name "Bomberman Jetters (USA)"
+	description "Bomberman Jetters (USA)"
+	rom ( name "Bomberman Jetters (USA).iso" size 1459978240 crc a1389149 md5 aa77fb6553efe3866df8dd3f83a6a1d3 sha1 1d07cdec9249c33937bffbafc24cd0a3dfd089b6 )
+)
+
+game (
+	name "Bomberman Land 2 (Japan)"
+	description "Bomberman Land 2 (Japan)"
+	rom ( name "Bomberman Land 2 (Japan).iso" size 1459978240 crc 37a12b37 md5 38c81513c5ee1cfc1b2c36825d6b2e6b sha1 270ad06de305e3cbc076e81be4920113d8306c5b )
+)
+
+game (
+	name "Bomberman Land 2 (JP) - bonbamanrando2"
+	description "Bomberman Land 2 (JP) - bonbamanrando2"
+	rom ( name "Bomberman Land 2 (JP).iso" size 1459978240 crc 37a12b37 md5 38c81513c5ee1cfc1b2c36825d6b2e6b sha1 270ad06de305e3cbc076e81be4920113d8306c5b )
+)
+
+game (
+	name "Bratz - Forever Diamondz (Europe) (En,Fr)"
+	description "Bratz - Forever Diamondz (Europe) (En,Fr)"
+	rom ( name "Bratz - Forever Diamondz (Europe) (En,Fr).iso" size 1459978240 crc 5aa84e06 md5 0ef35b3c0328e6833dc69e3b0a27749d sha1 0c863225739837f78e5c0e5d7d49a48f8126b055 )
+)
+
+game (
+	name "Bratz - Forever Diamondz (GB)"
+	description "Bratz - Forever Diamondz (GB)"
+	rom ( name "Bratz - Forever Diamondz (GB).iso" size 1459978240 crc 5aa84e06 md5 0ef35b3c0328e6833dc69e3b0a27749d sha1 0c863225739837f78e5c0e5d7d49a48f8126b055 )
+)
+
+game (
+	name "Bratz - Forever Diamondz (US)"
+	description "Bratz - Forever Diamondz (US)"
+	rom ( name "Bratz - Forever Diamondz (US).iso" size 1459978240 crc d6452c30 md5 fb8238ac0b6574bf30d0c3346269151a sha1 1482917a868d7e65e981dabf4802cd6bad5efec9 )
+)
+
+game (
+	name "Bratz - Forever Diamondz (USA)"
+	description "Bratz - Forever Diamondz (USA)"
+	rom ( name "Bratz - Forever Diamondz (USA).iso" size 1459978240 crc d6452c30 md5 fb8238ac0b6574bf30d0c3346269151a sha1 1482917a868d7e65e981dabf4802cd6bad5efec9 )
+)
+
+game (
+	name "Bratz - Rock Angelz (DE)"
+	description "Bratz - Rock Angelz (DE)"
+	rom ( name "Bratz - Rock Angelz (DE).iso" size 1459978240 crc 7218d1ab md5 1fcbdd6ad640ec8709dd6a19088984c5 sha1 f4bb61b1622190b922411a322efadc3ee3c7f07a )
+)
+
+game (
+	name "Bratz - Rock Angelz (Europe)"
+	description "Bratz - Rock Angelz (Europe)"
+	rom ( name "Bratz - Rock Angelz (Europe).iso" size 1459978240 crc 52d2054c md5 2f5272bb431910c4dad7933c01053b9f sha1 45cae3fe3060457203d4b0aa4b6362c670267c6f )
+)
+
+game (
+	name "Bratz - Rock Angelz (FR)"
+	description "Bratz - Rock Angelz (FR)"
+	rom ( name "Bratz - Rock Angelz (FR).iso" size 1459978240 crc c7c89409 md5 ff324584f196b5a2162137ca74efea4b sha1 db82a02dc6f1fa3ef814ba5669a1fe2c84ad8545 )
+)
+
+game (
+	name "Bratz - Rock Angelz (France)"
+	description "Bratz - Rock Angelz (France)"
+	rom ( name "Bratz - Rock Angelz (France).iso" size 1459978240 crc c7c89409 md5 ff324584f196b5a2162137ca74efea4b sha1 db82a02dc6f1fa3ef814ba5669a1fe2c84ad8545 )
+)
+
+game (
+	name "Bratz - Rock Angelz (GB)"
+	description "Bratz - Rock Angelz (GB)"
+	rom ( name "Bratz - Rock Angelz (GB).iso" size 1459978240 crc 52d2054c md5 2f5272bb431910c4dad7933c01053b9f sha1 45cae3fe3060457203d4b0aa4b6362c670267c6f )
+)
+
+game (
+	name "Bratz - Rock Angelz (Germany)"
+	description "Bratz - Rock Angelz (Germany)"
+	rom ( name "Bratz - Rock Angelz (Germany).iso" size 1459978240 crc 7218d1ab md5 1fcbdd6ad640ec8709dd6a19088984c5 sha1 f4bb61b1622190b922411a322efadc3ee3c7f07a )
+)
+
+game (
+	name "Bratz - Rock Angelz (US)"
+	description "Bratz - Rock Angelz (US)"
+	rom ( name "Bratz - Rock Angelz (US).iso" size 1459978240 crc defe192a md5 e1f4cc3696bcd96d682134bec9510d9b sha1 b4cd5496e03b14a05c4fe6f15e73347a5a3aa96f )
+)
+
+game (
+	name "Bratz - Rock Angelz (USA)"
+	description "Bratz - Rock Angelz (USA)"
+	rom ( name "Bratz - Rock Angelz (USA).iso" size 1459978240 crc defe192a md5 e1f4cc3696bcd96d682134bec9510d9b sha1 b4cd5496e03b14a05c4fe6f15e73347a5a3aa96f )
+)
+
+game (
+	name "Buffy contre les Vampires - Chaos Bleeds (FR)"
+	description "Buffy contre les Vampires - Chaos Bleeds (FR)"
+	rom ( name "Buffy contre les Vampires - Chaos Bleeds (FR).iso" size 1459978240 crc bedaac80 md5 9e64005de134b3dc0d9a759edaf3e440 sha1 73e503226656dc360d5cd4913ea8627d98f97d59 )
+)
+
+game (
+	name "Buffy contre les Vampires - Chaos Bleeds (France)"
+	description "Buffy contre les Vampires - Chaos Bleeds (France)"
+	rom ( name "Buffy contre les Vampires - Chaos Bleeds (France).iso" size 1459978240 crc bedaac80 md5 9e64005de134b3dc0d9a759edaf3e440 sha1 73e503226656dc360d5cd4913ea8627d98f97d59 )
+)
+
+game (
+	name "Buffy im Bann der Daemonen - Chaos Bleeds (DE)"
+	description "Buffy im Bann der Daemonen - Chaos Bleeds (DE)"
+	rom ( name "Buffy im Bann der Daemonen - Chaos Bleeds (DE).iso" size 1459978240 crc 388c65d2 md5 266fa8f542a03834ec5da69b54a65757 sha1 e564fe2876c14ac78a197ec95b953fc9f407b20a )
+)
+
+game (
+	name "Buffy im Bann der Daemonen - Chaos Bleeds (Germany)"
+	description "Buffy im Bann der Daemonen - Chaos Bleeds (Germany)"
+	rom ( name "Buffy im Bann der Daemonen - Chaos Bleeds (Germany).iso" size 1459978240 crc 388c65d2 md5 266fa8f542a03834ec5da69b54a65757 sha1 e564fe2876c14ac78a197ec95b953fc9f407b20a )
+)
+
+game (
+	name "Buffy the Vampire Slayer - Chaos Bleeds (Europe)"
+	description "Buffy the Vampire Slayer - Chaos Bleeds (Europe)"
+	rom ( name "Buffy the Vampire Slayer - Chaos Bleeds (Europe).iso" size 1459978240 crc 46e25097 md5 1e3f73052b05d8cbc1179f375a21bbf8 sha1 2d2c2ca0cc00a609c5c21c9f956b36c792ef0b71 )
+)
+
+game (
+	name "Buffy the Vampire Slayer - Chaos Bleeds (GB)"
+	description "Buffy the Vampire Slayer - Chaos Bleeds (GB)"
+	rom ( name "Buffy the Vampire Slayer - Chaos Bleeds (GB).iso" size 1459978240 crc 46e25097 md5 1e3f73052b05d8cbc1179f375a21bbf8 sha1 2d2c2ca0cc00a609c5c21c9f956b36c792ef0b71 )
+)
+
+game (
+	name "Buffy the Vampire Slayer - Chaos Bleeds (US)"
+	description "Buffy the Vampire Slayer - Chaos Bleeds (US)"
+	rom ( name "Buffy the Vampire Slayer - Chaos Bleeds (US).iso" size 1459978240 crc e81553bd md5 20968e92927def53807faa3c0a4403a6 sha1 45aa604f6e212e0e1d128a92511165acbbbefa5e )
+)
+
+game (
+	name "Buffy the Vampire Slayer - Chaos Bleeds (USA)"
+	description "Buffy the Vampire Slayer - Chaos Bleeds (USA)"
+	rom ( name "Buffy the Vampire Slayer - Chaos Bleeds (USA).iso" size 1459978240 crc e81553bd md5 20968e92927def53807faa3c0a4403a6 sha1 45aa604f6e212e0e1d128a92511165acbbbefa5e )
+)
+
+game (
+	name "Burnout (EU)"
+	description "Burnout (EU)"
+	rom ( name "Burnout (EU).iso" size 1459978240 crc 34fe6355 md5 939360f9a439d6e66d378c97bae206af sha1 5da12787062af526f2a0e888809af06582933da9 )
+)
+
+game (
+	name "Burnout (Europe) (En,Fr,De,Es,It)"
+	description "Burnout (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Burnout (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 34fe6355 md5 939360f9a439d6e66d378c97bae206af sha1 5da12787062af526f2a0e888809af06582933da9 )
+)
+
+game (
+	name "Burnout (US)"
+	description "Burnout (US)"
+	rom ( name "Burnout (US).iso" size 1459978240 crc b1a16069 md5 e2b9cf9780a740a504ab35d404c62666 sha1 b263caadee2f4029339aad2966da6438f130b06a )
+)
+
+game (
+	name "Burnout (USA)"
+	description "Burnout (USA)"
+	rom ( name "Burnout (USA).iso" size 1459978240 crc b1a16069 md5 e2b9cf9780a740a504ab35d404c62666 sha1 b263caadee2f4029339aad2966da6438f130b06a )
+)
+
+game (
+	name "Burnout 2 - Point of Impact (EU)"
+	description "Burnout 2 - Point of Impact (EU)"
+	rom ( name "Burnout 2 - Point of Impact (EU).iso" size 1459978240 crc bccfe680 md5 1c7cf73f219cb287f9f7cc3ce5f6b261 sha1 85c3d36a29177d5862facc2b90749234600f1a97 )
+)
+
+game (
+	name "Burnout 2 - Point of Impact (Europe) (En,Fr,De,Es,It)"
+	description "Burnout 2 - Point of Impact (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Burnout 2 - Point of Impact (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc bccfe680 md5 1c7cf73f219cb287f9f7cc3ce5f6b261 sha1 85c3d36a29177d5862facc2b90749234600f1a97 )
+)
+
+game (
+	name "Burnout 2 - Point of Impact (US)"
+	description "Burnout 2 - Point of Impact (US)"
+	rom ( name "Burnout 2 - Point of Impact (US).iso" size 1459978240 crc 58be54d3 md5 81d34a3eb120dbe3aa534d0c40af0aaf sha1 ca6c18abdf9a99fe0095e48ce740f409a7b75fc0 )
+)
+
+game (
+	name "Burnout 2 - Point of Impact (USA)"
+	description "Burnout 2 - Point of Impact (USA)"
+	rom ( name "Burnout 2 - Point of Impact (USA).iso" size 1459978240 crc 58be54d3 md5 81d34a3eb120dbe3aa534d0c40af0aaf sha1 ca6c18abdf9a99fe0095e48ce740f409a7b75fc0 )
+)
+
+game (
+	name "Buscando a Nemo (ES)"
+	description "Buscando a Nemo (ES)"
+	rom ( name "Buscando a Nemo (ES).iso" size 1459978240 crc 1695c621 md5 ec7ef437bc8006eb90fd03b4adb2339a sha1 ca3056c6c883e8424c432ae2d572c3da81bf9a7e )
+)
+
+game (
+	name "Buscando a Nemo (Spain)"
+	description "Buscando a Nemo (Spain)"
+	rom ( name "Buscando a Nemo (Spain).iso" size 1459978240 crc 1695c621 md5 ec7ef437bc8006eb90fd03b4adb2339a sha1 ca3056c6c883e8424c432ae2d572c3da81bf9a7e )
+)
+
+game (
+	name "Bust-A-Move 3000 (US)"
+	description "Bust-A-Move 3000 (US)"
+	rom ( name "Bust-A-Move 3000 (US).iso" size 1459978240 crc a612cb3c md5 8174224176d43215b856d5282193fdc5 sha1 c110a0cd14273ebc986525fbef2b0de96b0a2c6d )
+)
+
+game (
+	name "Bust-A-Move 3000 (USA)"
+	description "Bust-A-Move 3000 (USA)"
+	rom ( name "Bust-A-Move 3000 (USA).iso" size 1459978240 crc a612cb3c md5 8174224176d43215b856d5282193fdc5 sha1 c110a0cd14273ebc986525fbef2b0de96b0a2c6d )
+)
+
+game (
+	name "Butt-Ugly Martians - Zoom or Doom! (EU)"
+	description "Butt-Ugly Martians - Zoom or Doom! (EU)"
+	rom ( name "Butt-Ugly Martians - Zoom or Doom! (EU).iso" size 1459978240 crc 6d8d3bd4 md5 105e2bbc5b5c23a8fab5540aab8f68bc sha1 aa56e59210c6a88adbf1bc63817021bee8e38cb4 )
+)
+
+game (
+	name "Butt-Ugly Martians - Zoom or Doom! (Europe) (En,Fr,De,Es,It)"
+	description "Butt-Ugly Martians - Zoom or Doom! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Butt-Ugly Martians - Zoom or Doom! (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 6d8d3bd4 md5 105e2bbc5b5c23a8fab5540aab8f68bc sha1 aa56e59210c6a88adbf1bc63817021bee8e38cb4 )
+)
+
+game (
+	name "Cabela's Big Game Hunter 2005 Adventures (US)"
+	description "Cabela's Big Game Hunter 2005 Adventures (US)"
+	rom ( name "Cabela's Big Game Hunter 2005 Adventures (US).iso" size 1459978240 crc 5bcf4946 md5 8660dc7a418dcaf5334009524e290a6c sha1 850f29ca0d98cad7d604c8f980876c54e273d5a5 )
+)
+
+game (
+	name "Cabela's Big Game Hunter 2005 Adventures (USA)"
+	description "Cabela's Big Game Hunter 2005 Adventures (USA)"
+	rom ( name "Cabela's Big Game Hunter 2005 Adventures (USA).iso" size 1459978240 crc 5bcf4946 md5 8660dc7a418dcaf5334009524e290a6c sha1 850f29ca0d98cad7d604c8f980876c54e273d5a5 )
+)
+
+game (
+	name "Cabela's Dangerous Hunts 2 (US)"
+	description "Cabela's Dangerous Hunts 2 (US)"
+	rom ( name "Cabela's Dangerous Hunts 2 (US).iso" size 1459978240 crc f389716c md5 ae8cb4de019117b8dc760b87c5de92d4 sha1 74dc14c809c5c6f0f2867851afed825c24cee63c )
+)
+
+game (
+	name "Cabela's Dangerous Hunts 2 (USA)"
+	description "Cabela's Dangerous Hunts 2 (USA)"
+	rom ( name "Cabela's Dangerous Hunts 2 (USA).iso" size 1459978240 crc f389716c md5 ae8cb4de019117b8dc760b87c5de92d4 sha1 74dc14c809c5c6f0f2867851afed825c24cee63c )
+)
+
+game (
+	name "Cabela's Outdoor Adventures (US)"
+	description "Cabela's Outdoor Adventures (US)"
+	rom ( name "Cabela's Outdoor Adventures (US).iso" size 1459978240 crc 4b9e0cb2 md5 f0a7cff7fe5cbfa42b8af2a0f1f88e00 sha1 37a7098d5817df09eae29b2bae3a5c216094f93f )
+)
+
+game (
+	name "Cabela's Outdoor Adventures (USA)"
+	description "Cabela's Outdoor Adventures (USA)"
+	rom ( name "Cabela's Outdoor Adventures (USA).iso" size 1459978240 crc 4b9e0cb2 md5 f0a7cff7fe5cbfa42b8af2a0f1f88e00 sha1 37a7098d5817df09eae29b2bae3a5c216094f93f )
+)
+
+game (
+	name "Call of Duty - Finest Hour (DE)"
+	description "Call of Duty - Finest Hour (DE)"
+	rom ( name "Call of Duty - Finest Hour (DE).iso" size 1459978240 crc d3abfb57 md5 5e985879323371fb6613824c7de14158 sha1 d7c51431a07d99bcc022218cef32e4348194bb17 )
+)
+
+game (
+	name "Call of Duty - Finest Hour (EU)"
+	description "Call of Duty - Finest Hour (EU)"
+	rom ( name "Call of Duty - Finest Hour (EU).iso" size 1459978240 crc 47920848 md5 6261b4c3f2c77a215f4c0a5994ccf495 sha1 004c5a33302daaf9899e1d34bb3ece8a3a9df8ff )
+)
+
+game (
+	name "Call of Duty - Finest Hour (Europe)"
+	description "Call of Duty - Finest Hour (Europe)"
+	rom ( name "Call of Duty - Finest Hour (Europe).iso" size 1459978240 crc 47920848 md5 6261b4c3f2c77a215f4c0a5994ccf495 sha1 004c5a33302daaf9899e1d34bb3ece8a3a9df8ff )
+)
+
+game (
+	name "Call of Duty - Finest Hour (FR)"
+	description "Call of Duty - Finest Hour (FR)"
+	rom ( name "Call of Duty - Finest Hour (FR).iso" size 1459978240 crc 14093ccf md5 1a7e5a60778b82e27a9a7ef6be0d2b74 sha1 b62550ef667f3adfed38f406133da71897290c37 )
+)
+
+game (
+	name "Call of Duty - Finest Hour (France)"
+	description "Call of Duty - Finest Hour (France)"
+	rom ( name "Call of Duty - Finest Hour (France).iso" size 1459978240 crc 14093ccf md5 1a7e5a60778b82e27a9a7ef6be0d2b74 sha1 b62550ef667f3adfed38f406133da71897290c37 )
+)
+
+game (
+	name "Call of Duty - Finest Hour (Germany)"
+	description "Call of Duty - Finest Hour (Germany)"
+	rom ( name "Call of Duty - Finest Hour (Germany).iso" size 1459978240 crc d3abfb57 md5 5e985879323371fb6613824c7de14158 sha1 d7c51431a07d99bcc022218cef32e4348194bb17 )
+)
+
+game (
+	name "Call of Duty - Finest Hour (US)"
+	description "Call of Duty - Finest Hour (US)"
+	rom ( name "Call of Duty - Finest Hour (US).iso" size 1459978240 crc 23f77e19 md5 cbf5ba6030dd979517bf78e93ad596eb sha1 4ce36ab8246ee4d11f636cd89b6906b07ceb5519 )
+)
+
+game (
+	name "Call of Duty - Finest Hour (USA)"
+	description "Call of Duty - Finest Hour (USA)"
+	rom ( name "Call of Duty - Finest Hour (USA).iso" size 1459978240 crc 23f77e19 md5 cbf5ba6030dd979517bf78e93ad596eb sha1 4ce36ab8246ee4d11f636cd89b6906b07ceb5519 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (DE)"
+	description "Call of Duty 2 - Big Red One (DE)"
+	rom ( name "Call of Duty 2 - Big Red One (DE).iso" size 1459978240 crc ec60e3b5 md5 3b42f9f0a3c78a514d843c8933ba577c sha1 797d30f9b4c7808713ecb50c7ea65604655dcd88 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (ES)"
+	description "Call of Duty 2 - Big Red One (ES)"
+	rom ( name "Call of Duty 2 - Big Red One (ES).iso" size 1459978240 crc 84ec74b5 md5 fec2224af6f99fa72ed4126dca16c3c5 sha1 ac4159689c5e932a7a1bc9ecc44caee7005feb10 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (EU)"
+	description "Call of Duty 2 - Big Red One (EU)"
+	rom ( name "Call of Duty 2 - Big Red One (EU).iso" size 1459978240 crc 11d6b1f0 md5 27371ff3f86f3a64d436f1c27d3ebd44 sha1 5442fbf5b5fd7ea45194d1f6347e69a00c44d217 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (Europe)"
+	description "Call of Duty 2 - Big Red One (Europe)"
+	rom ( name "Call of Duty 2 - Big Red One (Europe).iso" size 1459978240 crc 11d6b1f0 md5 27371ff3f86f3a64d436f1c27d3ebd44 sha1 5442fbf5b5fd7ea45194d1f6347e69a00c44d217 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (FR)"
+	description "Call of Duty 2 - Big Red One (FR)"
+	rom ( name "Call of Duty 2 - Big Red One (FR).iso" size 1459978240 crc dd77b4cc md5 39961252d6e13cf924b8d8e065bbc110 sha1 b5e15d6cc569e5018bbd8634e7cd8df40ad28ef3 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (France)"
+	description "Call of Duty 2 - Big Red One (France)"
+	rom ( name "Call of Duty 2 - Big Red One (France).iso" size 1459978240 crc dd77b4cc md5 39961252d6e13cf924b8d8e065bbc110 sha1 b5e15d6cc569e5018bbd8634e7cd8df40ad28ef3 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (Germany)"
+	description "Call of Duty 2 - Big Red One (Germany)"
+	rom ( name "Call of Duty 2 - Big Red One (Germany).iso" size 1459978240 crc ec60e3b5 md5 3b42f9f0a3c78a514d843c8933ba577c sha1 797d30f9b4c7808713ecb50c7ea65604655dcd88 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (IT)"
+	description "Call of Duty 2 - Big Red One (IT)"
+	rom ( name "Call of Duty 2 - Big Red One (IT).iso" size 1459978240 crc 177f8b36 md5 91fe9860da63797d2dce125822348d30 sha1 77252de06367a60f74596d103f66d1ea5102b413 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (Italy)"
+	description "Call of Duty 2 - Big Red One (Italy)"
+	rom ( name "Call of Duty 2 - Big Red One (Italy).iso" size 1459978240 crc 177f8b36 md5 91fe9860da63797d2dce125822348d30 sha1 77252de06367a60f74596d103f66d1ea5102b413 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (Spain)"
+	description "Call of Duty 2 - Big Red One (Spain)"
+	rom ( name "Call of Duty 2 - Big Red One (Spain).iso" size 1459978240 crc 84ec74b5 md5 fec2224af6f99fa72ed4126dca16c3c5 sha1 ac4159689c5e932a7a1bc9ecc44caee7005feb10 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (US)"
+	description "Call of Duty 2 - Big Red One (US)"
+	rom ( name "Call of Duty 2 - Big Red One (US).iso" size 1459978240 crc f6c12c86 md5 13422f77d3e88287471c8935127823ba sha1 168feed4c8baaccdc21bf5362a46cb49498f1f64 )
+)
+
+game (
+	name "Call of Duty 2 - Big Red One (USA)"
+	description "Call of Duty 2 - Big Red One (USA)"
+	rom ( name "Call of Duty 2 - Big Red One (USA).iso" size 1459978240 crc f6c12c86 md5 13422f77d3e88287471c8935127823ba sha1 168feed4c8baaccdc21bf5362a46cb49498f1f64 )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (EU)"
+	description "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (EU)"
+	rom ( name "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (EU).iso" size 1459978240 crc ff84c3d3 md5 c56a8a3f2930f85d270b7e880e01ca08 sha1 9546224c012b2431deedd4e2d6fbbae46a1b9e2f )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (Europe)"
+	description "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (Europe)"
+	rom ( name "Capcom vs. SNK 2 EO - Millionaire Fighting 2001 (Europe).iso" size 1459978240 crc ff84c3d3 md5 c56a8a3f2930f85d270b7e880e01ca08 sha1 9546224c012b2431deedd4e2d6fbbae46a1b9e2f )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO (Japan)"
+	description "Capcom vs. SNK 2 EO (Japan)"
+	rom ( name "Capcom vs. SNK 2 EO (Japan).iso" size 1459978240 crc b2c307e1 md5 bf6872dacaea7d6c08b97e826242902a sha1 67ce498bc63c4fc99c5639666d439e9eb19209ac )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO (JP) - kapukon+basasu+esuenukei+2+EO"
+	description "Capcom vs. SNK 2 EO (JP) - kapukon+basasu+esuenukei+2+EO"
+	rom ( name "Capcom vs. SNK 2 EO (JP).iso" size 1459978240 crc b2c307e1 md5 bf6872dacaea7d6c08b97e826242902a sha1 67ce498bc63c4fc99c5639666d439e9eb19209ac )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO (US)"
+	description "Capcom vs. SNK 2 EO (US)"
+	rom ( name "Capcom vs. SNK 2 EO (US).iso" size 1459978240 crc 5f03b7d8 md5 0f153f7d7b97c9df1d4d55a9f70cfde6 sha1 f5ecef62b8a6ed8f76eec3319be7168352c5d5ae )
+)
+
+game (
+	name "Capcom vs. SNK 2 EO (USA)"
+	description "Capcom vs. SNK 2 EO (USA)"
+	rom ( name "Capcom vs. SNK 2 EO (USA).iso" size 1459978240 crc 5f03b7d8 md5 0f153f7d7b97c9df1d4d55a9f70cfde6 sha1 f5ecef62b8a6ed8f76eec3319be7168352c5d5ae )
+)
+
+game (
+	name "Captain Tsubasa - Ougon Sedai no Chousen (Japan)"
+	description "Captain Tsubasa - Ougon Sedai no Chousen (Japan)"
+	rom ( name "Captain Tsubasa - Ougon Sedai no Chousen (Japan).iso" size 1459978240 crc 1743bb98 md5 b67bf43d02ed42408fd35091a9306f7b sha1 d9b472100dc423812b75d66f43f4794c9a0d17f3 )
+)
+
+game (
+	name "Captain Tsubasa - Ougon Sedai no Chousen (JP) - kiyaputenYi +Huang Jin Shi Dai noTiao Zhan"
+	description "Captain Tsubasa - Ougon Sedai no Chousen (JP) - kiyaputenYi +Huang Jin Shi Dai noTiao Zhan"
+	rom ( name "Captain Tsubasa - Ougon Sedai no Chousen (JP).iso" size 1459978240 crc 1743bb98 md5 b67bf43d02ed42408fd35091a9306f7b sha1 d9b472100dc423812b75d66f43f4794c9a0d17f3 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (DE^ES)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (DE^ES)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (DE^ES).iso" size 1459978240 crc 9bc4436e md5 7d1dd64efed21a2f9a8d0246543ac32e sha1 45f33a73d0f188a7ac2fa2010ae1210862633606 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (EU)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (EU)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (EU).iso" size 1459978240 crc 5c63cdd1 md5 65a7575fbab68bb8178eeb6a669d1605 sha1 d4dce87e6d1cc33e65971eef758e28c15684fac0 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (De,Es)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (De,Es)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (De,Es).iso" size 1459978240 crc 9bc4436e md5 7d1dd64efed21a2f9a8d0246543ac32e sha1 45f33a73d0f188a7ac2fa2010ae1210862633606 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (En,Fr)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (En,Fr)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (Europe) (En,Fr).iso" size 1459978240 crc 5c63cdd1 md5 65a7575fbab68bb8178eeb6a669d1605 sha1 d4dce87e6d1cc33e65971eef758e28c15684fac0 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (US)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (US)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (US).iso" size 1459978240 crc ee1dab3f md5 bfa572af12c904844d39cb89564a1d26 sha1 ef9c30f14ce455507c1789a980d711d592c89499 )
+)
+
+game (
+	name "Carmen Sandiego - The Secret of the Stolen Drums (USA) (En,Fr)"
+	description "Carmen Sandiego - The Secret of the Stolen Drums (USA) (En,Fr)"
+	rom ( name "Carmen Sandiego - The Secret of the Stolen Drums (USA) (En,Fr).iso" size 1459978240 crc ee1dab3f md5 bfa572af12c904844d39cb89564a1d26 sha1 ef9c30f14ce455507c1789a980d711d592c89499 )
+)
+
+game (
+	name "Casper - Spirit Dimensions (EU)"
+	description "Casper - Spirit Dimensions (EU)"
+	rom ( name "Casper - Spirit Dimensions (EU).iso" size 1459978240 crc 3caf68b2 md5 550d6f9e3ce2de34a283f77a1d32fbdb sha1 53a9285d603dab2911065d43b4a61fde6ce23945 )
+)
+
+game (
+	name "Casper - Spirit Dimensions (Europe) (En,Fr,De,Es,It)"
+	description "Casper - Spirit Dimensions (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Casper - Spirit Dimensions (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3caf68b2 md5 550d6f9e3ce2de34a283f77a1d32fbdb sha1 53a9285d603dab2911065d43b4a61fde6ce23945 )
+)
+
+game (
+	name "Casper - Spirit Dimensions (US)"
+	description "Casper - Spirit Dimensions (US)"
+	rom ( name "Casper - Spirit Dimensions (US).iso" size 1459978240 crc afae94cd md5 8766cf629f34ad44e43cbb91d06dd11e sha1 5a8d37443f4c2aa73ee1b5f83854df33fc860908 )
+)
+
+game (
+	name "Casper - Spirit Dimensions (USA)"
+	description "Casper - Spirit Dimensions (USA)"
+	rom ( name "Casper - Spirit Dimensions (USA).iso" size 1459978240 crc afae94cd md5 8766cf629f34ad44e43cbb91d06dd11e sha1 5a8d37443f4c2aa73ee1b5f83854df33fc860908 )
+)
+
+game (
+	name "Castleween (EU)"
+	description "Castleween (EU)"
+	rom ( name "Castleween (EU).iso" size 1459978240 crc 363afcfb md5 2e4e50406bda95c73d91f181bf66729a sha1 516e4e425ba4c568233ed0eac9ebc955da6c8d92 )
+)
+
+game (
+	name "Castleween (Europe) (En,Fr,De,Es,It)"
+	description "Castleween (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Castleween (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 363afcfb md5 2e4e50406bda95c73d91f181bf66729a sha1 516e4e425ba4c568233ed0eac9ebc955da6c8d92 )
+)
+
+game (
+	name "Catwoman (EU)"
+	description "Catwoman (EU)"
+	rom ( name "Catwoman (EU).iso" size 1459978240 crc cb9eb3fa md5 f3562f632a43a99eee77d7ef3f0854ce sha1 5527f5b7edc04b67695cf08c810a47518df0d621 )
+)
+
+game (
+	name "Catwoman (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Catwoman (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Catwoman (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc cb9eb3fa md5 f3562f632a43a99eee77d7ef3f0854ce sha1 5527f5b7edc04b67695cf08c810a47518df0d621 )
+)
+
+game (
+	name "Catwoman (US)"
+	description "Catwoman (US)"
+	rom ( name "Catwoman (US).iso" size 1459978240 crc 210c61e4 md5 35a7d1a35dfbcde290597b593ebd42b8 sha1 0adc3a1802c07031af0417f1a839269b566d6112 )
+)
+
+game (
+	name "Catwoman (USA)"
+	description "Catwoman (USA)"
+	rom ( name "Catwoman (USA).iso" size 1459978240 crc 210c61e4 md5 35a7d1a35dfbcde290597b593ebd42b8 sha1 0adc3a1802c07031af0417f1a839269b566d6112 )
+)
+
+game (
+	name "Cel Damage (EU)"
+	description "Cel Damage (EU)"
+	rom ( name "Cel Damage (EU).iso" size 1459978240 crc 53528776 md5 3b7d5f5d80b770152ee2ecdb16329003 sha1 d473a80a6aa78751f8abf14fcc1090c353d8c50f )
+)
+
+game (
+	name "Cel Damage (Europe)"
+	description "Cel Damage (Europe)"
+	rom ( name "Cel Damage (Europe).iso" size 1459978240 crc 53528776 md5 3b7d5f5d80b770152ee2ecdb16329003 sha1 d473a80a6aa78751f8abf14fcc1090c353d8c50f )
+)
+
+game (
+	name "Cel Damage (US)"
+	description "Cel Damage (US)"
+	rom ( name "Cel Damage (US).iso" size 1459978240 crc c2d8f5aa md5 65a4f5f72b111380ef56f94b106cef88 sha1 dceda7cdfde5dde7756fbd1f9e89613174a084d6 )
+)
+
+game (
+	name "Cel Damage (USA)"
+	description "Cel Damage (USA)"
+	rom ( name "Cel Damage (USA).iso" size 1459978240 crc c2d8f5aa md5 65a4f5f72b111380ef56f94b106cef88 sha1 dceda7cdfde5dde7756fbd1f9e89613174a084d6 )
+)
+
+game (
+	name "Chaos Field (US)"
+	description "Chaos Field (US)"
+	rom ( name "Chaos Field (US).iso" size 1459978240 crc 00a68227 md5 4d1ef4fa47842ec159ffd37b956e0172 sha1 b982918918f8d08f945e3bdedea0d3a96bd18ef6 )
+)
+
+game (
+	name "Chaos Field (USA)"
+	description "Chaos Field (USA)"
+	rom ( name "Chaos Field (USA).iso" size 1459978240 crc 00a68227 md5 4d1ef4fa47842ec159ffd37b956e0172 sha1 b982918918f8d08f945e3bdedea0d3a96bd18ef6 )
+)
+
+game (
+	name "Chaos Field Expanded (Japan)"
+	description "Chaos Field Expanded (Japan)"
+	rom ( name "Chaos Field Expanded (Japan).iso" size 1459978240 crc c2b02efd md5 8c77faa2ceac8fd9b4c662c1ff1800de sha1 02911d217fbde4a8c3f7354123cbaf7f97fc73c4 )
+)
+
+game (
+	name "Chaos Field Expanded (JP) - kaosuhuirudo+ekusupandetudo"
+	description "Chaos Field Expanded (JP) - kaosuhuirudo+ekusupandetudo"
+	rom ( name "Chaos Field Expanded (JP).iso" size 1459978240 crc c2b02efd md5 8c77faa2ceac8fd9b4c662c1ff1800de sha1 02911d217fbde4a8c3f7354123cbaf7f97fc73c4 )
+)
+
+game (
+	name "Charinko Hero (Japan)"
+	description "Charinko Hero (Japan)"
+	rom ( name "Charinko Hero (Japan).iso" size 1459978240 crc b558797d md5 0e6af83330cff1017ce7050587646644 sha1 a2b87c9888cecc28b2050843121f348d759a19cd )
+)
+
+game (
+	name "Charinko Hero (JP) - tiyarinkohiro"
+	description "Charinko Hero (JP) - tiyarinkohiro"
+	rom ( name "Charinko Hero (JP).iso" size 1459978240 crc b558797d md5 0e6af83330cff1017ce7050587646644 sha1 a2b87c9888cecc28b2050843121f348d759a19cd )
+)
+
+game (
+	name "Charlie and the Chocolate Factory (EU)"
+	description "Charlie and the Chocolate Factory (EU)"
+	rom ( name "Charlie and the Chocolate Factory (EU).iso" size 1459978240 crc aca26a5f md5 f993271efe8ce11a13e7e08551c75fd8 sha1 78e8b932eddc4276eff53a3c8876c2784a807365 )
+)
+
+game (
+	name "Charlie and the Chocolate Factory (Europe) (En,Fr,Es,Nl)"
+	description "Charlie and the Chocolate Factory (Europe) (En,Fr,Es,Nl)"
+	rom ( name "Charlie and the Chocolate Factory (Europe) (En,Fr,Es,Nl).iso" size 1459978240 crc aca26a5f md5 f993271efe8ce11a13e7e08551c75fd8 sha1 78e8b932eddc4276eff53a3c8876c2784a807365 )
+)
+
+game (
+	name "Charlie and the Chocolate Factory (US)"
+	description "Charlie and the Chocolate Factory (US)"
+	rom ( name "Charlie and the Chocolate Factory (US).iso" size 1459978240 crc 6c712650 md5 de69170bc54027451324c173dacae490 sha1 f3984d9dec14fea626bea5b07d1716aa9f502510 )
+)
+
+game (
+	name "Charlie and the Chocolate Factory (USA)"
+	description "Charlie and the Chocolate Factory (USA)"
+	rom ( name "Charlie and the Chocolate Factory (USA).iso" size 1459978240 crc 6c712650 md5 de69170bc54027451324c173dacae490 sha1 f3984d9dec14fea626bea5b07d1716aa9f502510 )
+)
+
+game (
+	name "Charlie's Angels (EU)"
+	description "Charlie's Angels (EU)"
+	rom ( name "Charlie's Angels (EU).iso" size 1459978240 crc 020feb8e md5 79354c3962e4d5d76e42ff8163ccf0ed sha1 6a42a0980c063137d5838ce8de515ffe12302b47 )
+)
+
+game (
+	name "Charlie's Angels (Europe) (En,Fr,De)"
+	description "Charlie's Angels (Europe) (En,Fr,De)"
+	rom ( name "Charlie's Angels (Europe) (En,Fr,De).iso" size 1459978240 crc 020feb8e md5 79354c3962e4d5d76e42ff8163ccf0ed sha1 6a42a0980c063137d5838ce8de515ffe12302b47 )
+)
+
+game (
+	name "Charlie's Angels (US)"
+	description "Charlie's Angels (US)"
+	rom ( name "Charlie's Angels (US).iso" size 1459978240 crc e51aa467 md5 e1983338ce204342f602b2e5dc4c7978 sha1 f0a34263015fa73d22a96a4bac75aa88b4dcc7de )
+)
+
+game (
+	name "Charlie's Angels (USA) (En,Fr)"
+	description "Charlie's Angels (USA) (En,Fr)"
+	rom ( name "Charlie's Angels (USA) (En,Fr).iso" size 1459978240 crc e51aa467 md5 e1983338ce204342f602b2e5dc4c7978 sha1 f0a34263015fa73d22a96a4bac75aa88b4dcc7de )
+)
+
+game (
+	name "Chibi-Robo! (EU)"
+	description "Chibi-Robo! (EU)"
+	rom ( name "Chibi-Robo! (EU).iso" size 1459978240 crc 88080c8f md5 3491a233b72d2e5ebc1fa34d37ce84cf sha1 f321aa7fb1ae5101ec60f1bbca8184898142135a )
+)
+
+game (
+	name "Chibi-Robo! (Europe) (En,Fr,De,Es,It)"
+	description "Chibi-Robo! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Chibi-Robo! (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 88080c8f md5 3491a233b72d2e5ebc1fa34d37ce84cf sha1 f321aa7fb1ae5101ec60f1bbca8184898142135a )
+)
+
+game (
+	name "Chibi-Robo! Plug into Adventure! (US)"
+	description "Chibi-Robo! Plug into Adventure! (US)"
+	rom ( name "Chibi-Robo! Plug into Adventure! (US).iso" size 1459978240 crc db4c3c85 md5 fb0123c05fceb74892b16acc9387e894 sha1 9052f186411b49845323eaaeb014755bcf96321b )
+)
+
+game (
+	name "Chibi-Robo! Plug into Adventure! (USA)"
+	description "Chibi-Robo! Plug into Adventure! (USA)"
+	rom ( name "Chibi-Robo! Plug into Adventure! (USA).iso" size 1459978240 crc db4c3c85 md5 fb0123c05fceb74892b16acc9387e894 sha1 9052f186411b49845323eaaeb014755bcf96321b )
+)
+
+game (
+	name "ChibiRobo! (Japan)"
+	description "ChibiRobo! (Japan)"
+	rom ( name "ChibiRobo! (Japan).iso" size 1459978240 crc d3a3126f md5 b02364b7d3ef7ed39d00110712d32de3 sha1 af96a3d370a8bfd8c2082327b7d3e1ed1e9ad7b0 )
+)
+
+game (
+	name "ChibiRobo! (JP) - tibirobo!"
+	description "ChibiRobo! (JP) - tibirobo!"
+	rom ( name "ChibiRobo! (JP).iso" size 1459978240 crc d3a3126f md5 b02364b7d3ef7ed39d00110712d32de3 sha1 af96a3d370a8bfd8c2082327b7d3e1ed1e9ad7b0 )
+)
+
+game (
+	name "Choro Q! (Japan)"
+	description "Choro Q! (Japan)"
+	rom ( name "Choro Q! (Japan).iso" size 1459978240 crc 986e00eb md5 2096ce257a73a53b54ac100f60485f51 sha1 0aee93e3a766510867a9f266513cde34fb681303 )
+)
+
+game (
+	name "Choro Q! (JP) - tiyoroQ!"
+	description "Choro Q! (JP) - tiyoroQ!"
+	rom ( name "Choro Q! (JP).iso" size 1459978240 crc 986e00eb md5 2096ce257a73a53b54ac100f60485f51 sha1 0aee93e3a766510867a9f266513cde34fb681303 )
+)
+
+game (
+	name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (Europe)"
+	description "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (Europe)"
+	rom ( name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (Europe).iso" size 1459978240 crc ad622e09 md5 9b10b18ec72a18d091704e424ea75110 sha1 950e2eedcc5f444d60cc89b79f488546335392bd )
+)
+
+game (
+	name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (GB)"
+	description "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (GB)"
+	rom ( name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (GB).iso" size 1459978240 crc ad622e09 md5 9b10b18ec72a18d091704e424ea75110 sha1 950e2eedcc5f444d60cc89b79f488546335392bd )
+)
+
+game (
+	name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (US)"
+	description "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (US)"
+	rom ( name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (US).iso" size 1459978240 crc 1bf8a4ce md5 836c0290c215c76c597b05521895775b sha1 5aa6db1ee5414fcaef74feb7ea37386880907d90 )
+)
+
+game (
+	name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (USA)"
+	description "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (USA)"
+	rom ( name "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe (USA).iso" size 1459978240 crc 1bf8a4ce md5 836c0290c215c76c597b05521895775b sha1 5aa6db1ee5414fcaef74feb7ea37386880907d90 )
+)
+
+game (
+	name "Chroniken von Narnia, Die - Der Koenig von Narnia (DE)"
+	description "Chroniken von Narnia, Die - Der Koenig von Narnia (DE)"
+	rom ( name "Chroniken von Narnia, Die - Der Koenig von Narnia (DE).iso" size 1459978240 crc 18535d7f md5 dd5dcfe9e2cd25bae2786aa5f2a5bba3 sha1 0c8e1cb0713fe66a765e7085abc73035379b67c4 )
+)
+
+game (
+	name "Chroniken von Narnia, Die - Der Koenig von Narnia (Germany)"
+	description "Chroniken von Narnia, Die - Der Koenig von Narnia (Germany)"
+	rom ( name "Chroniken von Narnia, Die - Der Koenig von Narnia (Germany).iso" size 1459978240 crc 18535d7f md5 dd5dcfe9e2cd25bae2786aa5f2a5bba3 sha1 0c8e1cb0713fe66a765e7085abc73035379b67c4 )
+)
+
+game (
+	name "City Racer (US)"
+	description "City Racer (US)"
+	rom ( name "City Racer (US).iso" size 1459978240 crc bcf7b772 md5 be7305194ab6e833288ab58d9c06f35b sha1 2a496fc130c0c60c91eef18e69b5699113621bc5 )
+)
+
+game (
+	name "City Racer (USA)"
+	description "City Racer (USA)"
+	rom ( name "City Racer (USA).iso" size 1459978240 crc bcf7b772 md5 be7305194ab6e833288ab58d9c06f35b sha1 2a496fc130c0c60c91eef18e69b5699113621bc5 )
+)
+
+game (
+	name "Club Nintendo Original E-Catalog 2004 (Japan)"
+	description "Club Nintendo Original E-Catalog 2004 (Japan)"
+	rom ( name "Club Nintendo Original E-Catalog 2004 (Japan).iso" size 1459978240 crc 643e910f md5 0b8c6c73ec9211d5d702e8cbaac5194d sha1 d84dd449e4fa20c49368b482da02c0feb2f13283 )
+)
+
+game (
+	name "Club Nintendo Original E-Catalog 2004 (Taikenban) (JP) - kurabunintendoorizinaruekatarogu+2004"
+	description "Club Nintendo Original E-Catalog 2004 (Taikenban) (JP) - kurabunintendoorizinaruekatarogu+2004"
+	rom ( name "Club Nintendo Original E-Catalog 2004 (Taikenban) (JP).iso" size 1459978240 crc 643e910f md5 0b8c6c73ec9211d5d702e8cbaac5194d sha1 d84dd449e4fa20c49368b482da02c0feb2f13283 )
+)
+
+game (
+	name "Cocoto Funfair (EU)"
+	description "Cocoto Funfair (EU)"
+	rom ( name "Cocoto Funfair (EU).iso" size 1459978240 crc 0f06b965 md5 0a8b8bacff83dddaec1f76e11e73fbaf sha1 0d2c3fc1fadda0603259a4a1dbb35ea3dfcb856c )
+)
+
+game (
+	name "Cocoto Funfair (Europe) (En,Fr,De,Es,It)"
+	description "Cocoto Funfair (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Cocoto Funfair (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 0f06b965 md5 0a8b8bacff83dddaec1f76e11e73fbaf sha1 0d2c3fc1fadda0603259a4a1dbb35ea3dfcb856c )
+)
+
+game (
+	name "Cocoto Kart Racer (EU)"
+	description "Cocoto Kart Racer (EU)"
+	rom ( name "Cocoto Kart Racer (EU).iso" size 1459978240 crc 2600e2c1 md5 e99df0f5d1b22a086d0d6d9868b7b35b sha1 d9f17976695f54551299e72185f0c0a3f6d1aa1c )
+)
+
+game (
+	name "Cocoto Kart Racer (Europe) (En,Fr,De,Es,It)"
+	description "Cocoto Kart Racer (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Cocoto Kart Racer (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 2600e2c1 md5 e99df0f5d1b22a086d0d6d9868b7b35b sha1 d9f17976695f54551299e72185f0c0a3f6d1aa1c )
+)
+
+game (
+	name "Cocoto Platform Jumper (EU)"
+	description "Cocoto Platform Jumper (EU)"
+	rom ( name "Cocoto Platform Jumper (EU).iso" size 1459978240 crc d244cc6b md5 e39809c8acbe04b91c8482fe060cfaff sha1 580fc52b44f4ad17ed8be454e497c513de1bb2a9 )
+)
+
+game (
+	name "Cocoto Platform Jumper (Europe) (En,Fr,De,Es,It)"
+	description "Cocoto Platform Jumper (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Cocoto Platform Jumper (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc d244cc6b md5 e39809c8acbe04b91c8482fe060cfaff sha1 580fc52b44f4ad17ed8be454e497c513de1bb2a9 )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (Europe)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (Europe)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (Europe).iso" size 1459978240 crc de4eb118 md5 7b8afebbbd9f50af5dd5f4be87dc426a sha1 f50ae6bf2c255405fbf8061d90aa4e0fc6c395c9 )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (GB)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (GB)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (GB).iso" size 1459978240 crc de4eb118 md5 7b8afebbbd9f50af5dd5f4be87dc426a sha1 f50ae6bf2c255405fbf8061d90aa4e0fc6c395c9 )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (US)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (US)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (US).iso" size 1459978240 crc 1b596fbd md5 9fc82976f0071f81fa0af5d4e6423add sha1 023adc8434b3c2b763bc04c1566cb7b40b1cd762 )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (USA)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (USA)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.G.A.M.E. (USA).iso" size 1459978240 crc 1b596fbd md5 9fc82976f0071f81fa0af5d4e6423add sha1 023adc8434b3c2b763bc04c1566cb7b40b1cd762 )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (DE)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (DE)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (DE).iso" size 1459978240 crc d9393c54 md5 8366ba6c0f0ef3fe30617159c21f5939 sha1 7727a90d90af34ab4c8d7898e8c15a82054d0e5f )
+)
+
+game (
+	name "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (Germany)"
+	description "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (Germany)"
+	rom ( name "Codename - Kids Next Door - Operation - V.I.D.E.O.S.P.I.E.L. (Germany).iso" size 1459978240 crc d9393c54 md5 8366ba6c0f0ef3fe30617159c21f5939 sha1 7727a90d90af34ab4c8d7898e8c15a82054d0e5f )
+)
+
+game (
+	name "Conan (EU)"
+	description "Conan (EU)"
+	rom ( name "Conan (EU) - (Disc 1 of 2).iso" size 1459978240 crc 308b036b md5 7b7d3131578383e0cbb2df1855d05450 sha1 6b2c4e99e1a77ed43b0950718176a0b43a0ea2bf )
+)
+
+game (
+	name "Conan (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Conan (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Conan (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 308b036b md5 7b7d3131578383e0cbb2df1855d05450 sha1 6b2c4e99e1a77ed43b0950718176a0b43a0ea2bf )
+)
+
+game (
+	name "Conan (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Conan (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Conan (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 86238ef4 md5 a784429bd55368000d1e8989fde2f3ea sha1 fd3c3ddc6be7ecb8b1848e1648b638264692b63f )
+)
+
+game (
+	name "Conflict - Desert Storm (EU)"
+	description "Conflict - Desert Storm (EU)"
+	rom ( name "Conflict - Desert Storm (EU).iso" size 1459978240 crc 981b490b md5 e756eead045d85efbafd7defae7155c0 sha1 1e7473697a029b88ff7d415814cee6f3646ff817 )
+)
+
+game (
+	name "Conflict - Desert Storm (Europe) (En,Fr,De,Es,It)"
+	description "Conflict - Desert Storm (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Conflict - Desert Storm (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 981b490b md5 e756eead045d85efbafd7defae7155c0 sha1 1e7473697a029b88ff7d415814cee6f3646ff817 )
+)
+
+game (
+	name "Conflict - Desert Storm (US)"
+	description "Conflict - Desert Storm (US)"
+	rom ( name "Conflict - Desert Storm (US) - [v1.00].iso" size 1459978240 crc 8e02d08b md5 16931c7f188899b234158eb3b17ecbd8 sha1 5e13c8e22c63898aef040d2ad2a9efe19b5e6980 )
+)
+
+game (
+	name "Conflict - Desert Storm (USA) (v1.00)"
+	description "Conflict - Desert Storm (USA) (v1.00)"
+	rom ( name "Conflict - Desert Storm (USA) (v1.00).iso" size 1459978240 crc 8e02d08b md5 16931c7f188899b234158eb3b17ecbd8 sha1 5e13c8e22c63898aef040d2ad2a9efe19b5e6980 )
+)
+
+game (
+	name "Conflict - Desert Storm (USA) (v1.01)"
+	description "Conflict - Desert Storm (USA) (v1.01)"
+	rom ( name "Conflict - Desert Storm (USA) (v1.01).iso" size 1459978240 crc f8abef1f md5 44698b7cea635b83e2f3a8f50b1bf863 sha1 1a6578e365516474e62eefbcdd3925295fef4690 )
+)
+
+game (
+	name "Conflict - Desert Storm II - Back to Baghdad (US)"
+	description "Conflict - Desert Storm II - Back to Baghdad (US)"
+	rom ( name "Conflict - Desert Storm II - Back to Baghdad (US).iso" size 1459978240 crc 0eeb2191 md5 7a52c85861bed0376d48bb8156a0ec2c sha1 9612a07c22a4f848de834194dbaa1ca0a5bdda3f )
+)
+
+game (
+	name "Conflict - Desert Storm II - Back to Baghdad (USA)"
+	description "Conflict - Desert Storm II - Back to Baghdad (USA)"
+	rom ( name "Conflict - Desert Storm II - Back to Baghdad (USA).iso" size 1459978240 crc 0eeb2191 md5 7a52c85861bed0376d48bb8156a0ec2c sha1 9612a07c22a4f848de834194dbaa1ca0a5bdda3f )
+)
+
+game (
+	name "Conflict - Desert Storm II (EU)"
+	description "Conflict - Desert Storm II (EU)"
+	rom ( name "Conflict - Desert Storm II (EU).iso" size 1459978240 crc 97b5de11 md5 48e84c19c050616d1f7b81ea9e9ed8fc sha1 0a926d18a97bd18dcb4ef51048d04fe9d327d700 )
+)
+
+game (
+	name "Conflict - Desert Storm II (Europe) (En,Fr,De,Es,It)"
+	description "Conflict - Desert Storm II (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Conflict - Desert Storm II (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 97b5de11 md5 48e84c19c050616d1f7b81ea9e9ed8fc sha1 0a926d18a97bd18dcb4ef51048d04fe9d327d700 )
+)
+
+game (
+	name "Crash Bandicoot - Bakuso! Nitro Kart (Japan)"
+	description "Crash Bandicoot - Bakuso! Nitro Kart (Japan)"
+	rom ( name "Crash Bandicoot - Bakuso! Nitro Kart (Japan).iso" size 1459978240 crc 3af534b9 md5 20251a5a2b94c49b0a618f5c0daf960d sha1 1d863527ad8820b6fab670d8b689b414e402d60c )
+)
+
+game (
+	name "Crash Bandicoot - Bakuso! Nitro Kart (JP) - kuratusiyubandeiku Bao Zou !nitorokato"
+	description "Crash Bandicoot - Bakuso! Nitro Kart (JP) - kuratusiyubandeiku Bao Zou !nitorokato"
+	rom ( name "Crash Bandicoot - Bakuso! Nitro Kart (JP).iso" size 1459978240 crc 3af534b9 md5 20251a5a2b94c49b0a618f5c0daf960d sha1 1d863527ad8820b6fab670d8b689b414e402d60c )
+)
+
+game (
+	name "Crash Bandicoot - Gacchanko World (JP) - kuratusiyubandeiku+gatutiyankowarudo"
+	description "Crash Bandicoot - Gacchanko World (JP) - kuratusiyubandeiku+gatutiyankowarudo"
+	rom ( name "Crash Bandicoot - Gacchanko World (JP).iso" size 1459978240 crc b0acbb9d md5 162e56104302c0a302377754fd30f489 sha1 8e2f3de288c92416601ce8a27e9d085fe1f81bfc )
+)
+
+game (
+	name "Crash Bandicoot - Gatchanko World (Japan)"
+	description "Crash Bandicoot - Gatchanko World (Japan)"
+	rom ( name "Crash Bandicoot - Gatchanko World (Japan).iso" size 1459978240 crc b0acbb9d md5 162e56104302c0a302377754fd30f489 sha1 8e2f3de288c92416601ce8a27e9d085fe1f81bfc )
+)
+
+game (
+	name "Crash Bandicoot - The Wrath of Cortex (EU)"
+	description "Crash Bandicoot - The Wrath of Cortex (EU)"
+	rom ( name "Crash Bandicoot - The Wrath of Cortex (EU).iso" size 1459978240 crc 148178ed md5 40c3d26290293ee0b37a5b2edce01b08 sha1 145bab33f2582ab0e39be7d3b09efdc9f089903b )
+)
+
+game (
+	name "Crash Bandicoot - The Wrath of Cortex (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	description "Crash Bandicoot - The Wrath of Cortex (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	rom ( name "Crash Bandicoot - The Wrath of Cortex (Europe) (En,Fr,De,Es,It,Nl) (v1.00).iso" size 1459978240 crc 148178ed md5 40c3d26290293ee0b37a5b2edce01b08 sha1 145bab33f2582ab0e39be7d3b09efdc9f089903b )
+)
+
+game (
+	name "Crash Bandicoot - The Wrath of Cortex (Europe) (v1.01)"
+	description "Crash Bandicoot - The Wrath of Cortex (Europe) (v1.01)"
+	rom ( name "Crash Bandicoot - The Wrath of Cortex (Europe) (v1.01).iso" size 1459978240 crc 4c383054 md5 932d62bdd2a494d022637898aba0c20a sha1 f8e26c22cce2a687150423f4c0eccd6b86c89e8c )
+)
+
+game (
+	name "Crash Bandicoot - The Wrath of Cortex (US)"
+	description "Crash Bandicoot - The Wrath of Cortex (US)"
+	rom ( name "Crash Bandicoot - The Wrath of Cortex (US).iso" size 1459978240 crc adcc7698 md5 c8236b85c85656fa5bff93cf19f6e586 sha1 08baf3fdef38908ee2d0a826afc728198048bd38 )
+)
+
+game (
+	name "Crash Bandicoot - The Wrath of Cortex (USA)"
+	description "Crash Bandicoot - The Wrath of Cortex (USA)"
+	rom ( name "Crash Bandicoot - The Wrath of Cortex (USA).iso" size 1459978240 crc adcc7698 md5 c8236b85c85656fa5bff93cf19f6e586 sha1 08baf3fdef38908ee2d0a826afc728198048bd38 )
+)
+
+game (
+	name "Crash Bandicoot 4 - Sakuretsu! Majin Power (Japan)"
+	description "Crash Bandicoot 4 - Sakuretsu! Majin Power (Japan)"
+	rom ( name "Crash Bandicoot 4 - Sakuretsu! Majin Power (Japan).iso" size 1459978240 crc b7f7e3bc md5 e334ce5c62b0809d965cd6db2c17f40f sha1 25379d1db72e11b7764dc7a2e6dcab4a633a3780 )
+)
+
+game (
+	name "Crash Bandicoot 4 - Sakuretsu! Majin Power (JP) - kuratusiyubandeiku4+sakuretu!Mo Shen pawa"
+	description "Crash Bandicoot 4 - Sakuretsu! Majin Power (JP) - kuratusiyubandeiku4+sakuretu!Mo Shen pawa"
+	rom ( name "Crash Bandicoot 4 - Sakuretsu! Majin Power (JP).iso" size 1459978240 crc b7f7e3bc md5 e334ce5c62b0809d965cd6db2c17f40f sha1 25379d1db72e11b7764dc7a2e6dcab4a633a3780 )
+)
+
+game (
+	name "Crash Nitro Kart (EU)"
+	description "Crash Nitro Kart (EU)"
+	rom ( name "Crash Nitro Kart (EU).iso" size 1459978240 crc 0c6080c9 md5 e6495b2dc4bca6170d20892b694deb6a sha1 274161fa8ee1313283815603d1783c0638aa4089 )
+)
+
+game (
+	name "Crash Nitro Kart (Europe)"
+	description "Crash Nitro Kart (Europe)"
+	rom ( name "Crash Nitro Kart (Europe).iso" size 1459978240 crc 0c6080c9 md5 e6495b2dc4bca6170d20892b694deb6a sha1 274161fa8ee1313283815603d1783c0638aa4089 )
+)
+
+game (
+	name "Crash Nitro Kart (US)"
+	description "Crash Nitro Kart (US)"
+	rom ( name "Crash Nitro Kart (US).iso" size 1459978240 crc d172937b md5 fed9263fe9f69b66b12b969a84eb3a6d sha1 7bf25d9e915dd40ae286fb73f400b01391d4884f )
+)
+
+game (
+	name "Crash Nitro Kart (USA)"
+	description "Crash Nitro Kart (USA)"
+	rom ( name "Crash Nitro Kart (USA).iso" size 1459978240 crc d172937b md5 fed9263fe9f69b66b12b969a84eb3a6d sha1 7bf25d9e915dd40ae286fb73f400b01391d4884f )
+)
+
+game (
+	name "Crash Tag Team Racing (DE)"
+	description "Crash Tag Team Racing (DE)"
+	rom ( name "Crash Tag Team Racing (DE).iso" size 1459978240 crc b90d3d2c md5 0b1d297ade58406dea50695dcf0d5652 sha1 52038cd117e426a613f5ff47b00f4aa09889915b )
+)
+
+game (
+	name "Crash Tag Team Racing (EU^AU)"
+	description "Crash Tag Team Racing (EU^AU)"
+	rom ( name "Crash Tag Team Racing (EU^AU).iso" size 1459978240 crc 30016797 md5 3daea3e78d153edf556a3e320ce8cb56 sha1 70fa7d596735ac03a6f3d49f60cd3754ab10cda8 )
+)
+
+game (
+	name "Crash Tag Team Racing (Europe, Australia)"
+	description "Crash Tag Team Racing (Europe, Australia)"
+	rom ( name "Crash Tag Team Racing (Europe, Australia).iso" size 1459978240 crc 30016797 md5 3daea3e78d153edf556a3e320ce8cb56 sha1 70fa7d596735ac03a6f3d49f60cd3754ab10cda8 )
+)
+
+game (
+	name "Crash Tag Team Racing (FR)"
+	description "Crash Tag Team Racing (FR)"
+	rom ( name "Crash Tag Team Racing (FR).iso" size 1459978240 crc 5d694e8d md5 67aec8ec038d1f765a39f168c67ebec2 sha1 b56d7430b02a3503970da4495674b4f7c9cb275e )
+)
+
+game (
+	name "Crash Tag Team Racing (France)"
+	description "Crash Tag Team Racing (France)"
+	rom ( name "Crash Tag Team Racing (France).iso" size 1459978240 crc 5d694e8d md5 67aec8ec038d1f765a39f168c67ebec2 sha1 b56d7430b02a3503970da4495674b4f7c9cb275e )
+)
+
+game (
+	name "Crash Tag Team Racing (Germany)"
+	description "Crash Tag Team Racing (Germany)"
+	rom ( name "Crash Tag Team Racing (Germany).iso" size 1459978240 crc b90d3d2c md5 0b1d297ade58406dea50695dcf0d5652 sha1 52038cd117e426a613f5ff47b00f4aa09889915b )
+)
+
+game (
+	name "Crash Tag Team Racing (Netherlands)"
+	description "Crash Tag Team Racing (Netherlands)"
+	rom ( name "Crash Tag Team Racing (Netherlands).iso" size 1459978240 crc 3bc2a113 md5 64e2908e0b142ece72197f0b7afc65b7 sha1 c50da45119f7c37c5ebafeba8d9bf0526e7c34e6 )
+)
+
+game (
+	name "Crash Tag Team Racing (US)"
+	description "Crash Tag Team Racing (US)"
+	rom ( name "Crash Tag Team Racing (US).iso" size 1459978240 crc fb527d10 md5 10932189ae0f98a02e37086b9961589f sha1 8ae2f09cffdc728709e461a6541594acbf482466 )
+)
+
+game (
+	name "Crash Tag Team Racing (USA)"
+	description "Crash Tag Team Racing (USA)"
+	rom ( name "Crash Tag Team Racing (USA).iso" size 1459978240 crc fb527d10 md5 10932189ae0f98a02e37086b9961589f sha1 8ae2f09cffdc728709e461a6541594acbf482466 )
+)
+
+game (
+	name "Crazy Taxi (EU)"
+	description "Crazy Taxi (EU)"
+	rom ( name "Crazy Taxi (EU).iso" size 1459978240 crc 7f951e48 md5 4d9fc7779be8376688476bac503ef3e0 sha1 d477f678567e5f4b5197d5d74c9922a994441938 )
+)
+
+game (
+	name "Crazy Taxi (Europe) (En,Fr,De,Es)"
+	description "Crazy Taxi (Europe) (En,Fr,De,Es)"
+	rom ( name "Crazy Taxi (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 7f951e48 md5 4d9fc7779be8376688476bac503ef3e0 sha1 d477f678567e5f4b5197d5d74c9922a994441938 )
+)
+
+game (
+	name "Crazy Taxi (Japan)"
+	description "Crazy Taxi (Japan)"
+	rom ( name "Crazy Taxi (Japan).iso" size 1459978240 crc 647f948d md5 686b682740f0a9db7af6b40c02d45fc9 sha1 f361fce9f8f9b1bff76a99d126ed6f0600cc07fa )
+)
+
+game (
+	name "Crazy Taxi (JP) - kureizitakusi"
+	description "Crazy Taxi (JP) - kureizitakusi"
+	rom ( name "Crazy Taxi (JP).iso" size 1459978240 crc 647f948d md5 686b682740f0a9db7af6b40c02d45fc9 sha1 f361fce9f8f9b1bff76a99d126ed6f0600cc07fa )
+)
+
+game (
+	name "Crazy Taxi (US)"
+	description "Crazy Taxi (US)"
+	rom ( name "Crazy Taxi (US).iso" size 1459978240 crc 6cef11a9 md5 e903be751aacf4a237e33f2e5dd89822 sha1 01fa0b4a8d0957d8c24a49ddd8241e474c7a8b2d )
+)
+
+game (
+	name "Crazy Taxi (USA)"
+	description "Crazy Taxi (USA)"
+	rom ( name "Crazy Taxi (USA).iso" size 1459978240 crc 6cef11a9 md5 e903be751aacf4a237e33f2e5dd89822 sha1 01fa0b4a8d0957d8c24a49ddd8241e474c7a8b2d )
+)
+
+game (
+	name "Croket! Banking no Kiki wo Sukue (Japan)"
+	description "Croket! Banking no Kiki wo Sukue (Japan)"
+	rom ( name "Croket! Banking no Kiki wo Sukue (Japan).iso" size 1459978240 crc 9ba1d8b0 md5 8b407c51493454f59832cf8576665eda sha1 4ac9cbc5a6e7a7ff999ad3abc3bbc8b367843633 )
+)
+
+game (
+	name "Croket! Banking no Kiki wo Sukue (JP) - korotuke! banWang noWei Ji woJiu e"
+	description "Croket! Banking no Kiki wo Sukue (JP) - korotuke! banWang noWei Ji woJiu e"
+	rom ( name "Croket! Banking no Kiki wo Sukue (JP).iso" size 1459978240 crc 9ba1d8b0 md5 8b407c51493454f59832cf8576665eda sha1 4ac9cbc5a6e7a7ff999ad3abc3bbc8b367843633 )
+)
+
+game (
+	name "Cubivore (US)"
+	description "Cubivore (US)"
+	rom ( name "Cubivore (US).iso" size 1459978240 crc 0b2e2939 md5 756327c68651c4f25689bf58dafdca2d sha1 673474d1ab82c4af0c3acee97beec6951145ec41 )
+)
+
+game (
+	name "Cubivore (USA)"
+	description "Cubivore (USA)"
+	rom ( name "Cubivore (USA).iso" size 1459978240 crc 0b2e2939 md5 756327c68651c4f25689bf58dafdca2d sha1 673474d1ab82c4af0c3acee97beec6951145ec41 )
+)
+
+game (
+	name "Cubix Robots for Everyone - Showdown (US)"
+	description "Cubix Robots for Everyone - Showdown (US)"
+	rom ( name "Cubix Robots for Everyone - Showdown (US).iso" size 1459978240 crc f4b0546e md5 0d97340fb612c1a87a3218f1dea5fca4 sha1 aedd2cc98f5750a69a401e5ce742cae3a02140c2 )
+)
+
+game (
+	name "Cubix Robots for Everyone - Showdown (USA)"
+	description "Cubix Robots for Everyone - Showdown (USA)"
+	rom ( name "Cubix Robots for Everyone - Showdown (USA).iso" size 1459978240 crc f4b0546e md5 0d97340fb612c1a87a3218f1dea5fca4 sha1 aedd2cc98f5750a69a401e5ce742cae3a02140c2 )
+)
+
+game (
+	name "Curious George (US)"
+	description "Curious George (US)"
+	rom ( name "Curious George (US).iso" size 1459978240 crc 76119441 md5 ff721acc78cf9f3c0328f20d8c293257 sha1 5fb6506ecd8d087a4108870769e6f7d03cf74418 )
+)
+
+game (
+	name "Curious George (USA)"
+	description "Curious George (USA)"
+	rom ( name "Curious George (USA).iso" size 1459978240 crc 76119441 md5 ff721acc78cf9f3c0328f20d8c293257 sha1 5fb6506ecd8d087a4108870769e6f7d03cf74418 )
+)
+
+game (
+	name "Custom Robo - Battle Revolution (Japan)"
+	description "Custom Robo - Battle Revolution (Japan)"
+	rom ( name "Custom Robo - Battle Revolution (Japan).iso" size 1459978240 crc 4df76b35 md5 6c74f607554a4d991e0a783b14d8b232 sha1 5bc6196df3cee9410f07777d6bbc7593f5ad1948 )
+)
+
+game (
+	name "Custom Robo - Battle Revolution (JP) - kasutamurobo+batorureboriyusiyon"
+	description "Custom Robo - Battle Revolution (JP) - kasutamurobo+batorureboriyusiyon"
+	rom ( name "Custom Robo - Battle Revolution (JP).iso" size 1459978240 crc 4df76b35 md5 6c74f607554a4d991e0a783b14d8b232 sha1 5bc6196df3cee9410f07777d6bbc7593f5ad1948 )
+)
+
+game (
+	name "Custom Robo (US)"
+	description "Custom Robo (US)"
+	rom ( name "Custom Robo (US).iso" size 1459978240 crc c450109c md5 546e5108173bceb4d5c8ca27b3fcfc96 sha1 fff6e74590366a5c0c5ba0d40c8ccf94770bcb16 )
+)
+
+game (
+	name "Custom Robo (USA)"
+	description "Custom Robo (USA)"
+	rom ( name "Custom Robo (USA).iso" size 1459978240 crc c450109c md5 546e5108173bceb4d5c8ca27b3fcfc96 sha1 fff6e74590366a5c0c5ba0d40c8ccf94770bcb16 )
+)
+
+game (
+	name "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.00)"
+	description "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.00)"
+	rom ( name "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.00).iso" size 1459978240 crc 57ea8f81 md5 378be81bb6c38febd847fc4b7f7dc36f sha1 fe23c91b63b0731ef727c13253b6a8c6757432ac )
+)
+
+game (
+	name "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.02)"
+	description "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.02)"
+	rom ( name "Dairantou Smash Brothers DX (Japan) (En,Ja) (v1.02).iso" size 1459978240 crc 85f37345 md5 dc07abd4b6a5e1517da575274ceefcf8 sha1 71255a30a47b4c6aabb90308d7a514d09d93a7b5 )
+)
+
+game (
+	name "Dairantou Smash Brothers DX (Japan) (Taikenban)"
+	description "Dairantou Smash Brothers DX (Japan) (Taikenban)"
+	rom ( name "Dairantou Smash Brothers DX (Japan) (Taikenban).iso" size 1459978240 crc d8954dae md5 986487c59e3ad40870135aabe90f1ac8 sha1 c7c0866fbe6d7ebf3b9c4236f4f32f4c8f65b578 )
+)
+
+game (
+	name "Dairantou Smash Brothers DX (JP) - Da Luan Dou sumatusiyuburazazuDX"
+	description "Dairantou Smash Brothers DX (JP) - Da Luan Dou sumatusiyuburazazuDX"
+	rom ( name "Dairantou Smash Brothers DX (JP) - [v1.00].iso" size 1459978240 crc 57ea8f81 md5 378be81bb6c38febd847fc4b7f7dc36f sha1 fe23c91b63b0731ef727c13253b6a8c6757432ac )
+)
+
+game (
+	name "Dairantou Smash Brothers DX (Taikenban) (JP) - Da Luan Dou sumatusiyuburazazuDX"
+	description "Dairantou Smash Brothers DX (Taikenban) (JP) - Da Luan Dou sumatusiyuburazazuDX"
+	rom ( name "Dairantou Smash Brothers DX (Taikenban) (JP).iso" size 1459978240 crc d8954dae md5 986487c59e3ad40870135aabe90f1ac8 sha1 c7c0866fbe6d7ebf3b9c4236f4f32f4c8f65b578 )
+)
+
+game (
+	name "Dakar 2 - The World's Ultimate Rally (US)"
+	description "Dakar 2 - The World's Ultimate Rally (US)"
+	rom ( name "Dakar 2 - The World's Ultimate Rally (US).iso" size 1459978240 crc fd421f87 md5 b603f891b9601b1e09e359919595a679 sha1 d87edcb7e85eb7c2e068f3fca99fcafd1486288c )
+)
+
+game (
+	name "Dakar 2 - The World's Ultimate Rally (USA) (En,Fr,De,Es,It)"
+	description "Dakar 2 - The World's Ultimate Rally (USA) (En,Fr,De,Es,It)"
+	rom ( name "Dakar 2 - The World's Ultimate Rally (USA) (En,Fr,De,Es,It).iso" size 1459978240 crc fd421f87 md5 b603f891b9601b1e09e359919595a679 sha1 d87edcb7e85eb7c2e068f3fca99fcafd1486288c )
+)
+
+game (
+	name "Dakar 2 (EU)"
+	description "Dakar 2 (EU)"
+	rom ( name "Dakar 2 (EU).iso" size 1459978240 crc 010d1982 md5 dc71d75741cf8761bfb95160e07e52d5 sha1 6c02418be937cf90856c5e67913bfe13e5bcbb2a )
+)
+
+game (
+	name "Dakar 2 (Europe) (En,Fr,De,Es,It)"
+	description "Dakar 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dakar 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 010d1982 md5 dc71d75741cf8761bfb95160e07e52d5 sha1 6c02418be937cf90856c5e67913bfe13e5bcbb2a )
+)
+
+game (
+	name "Dance Dance Revolution - Mario Mix (US)"
+	description "Dance Dance Revolution - Mario Mix (US)"
+	rom ( name "Dance Dance Revolution - Mario Mix (US).iso" size 1459978240 crc b6ac6014 md5 7c862ab7fea3687c6dd0a269a8866d86 sha1 97bfeeb6e9c6c490a72b46975d638a266f41d3ef )
+)
+
+game (
+	name "Dance Dance Revolution - Mario Mix (USA)"
+	description "Dance Dance Revolution - Mario Mix (USA)"
+	rom ( name "Dance Dance Revolution - Mario Mix (USA).iso" size 1459978240 crc b6ac6014 md5 7c862ab7fea3687c6dd0a269a8866d86 sha1 97bfeeb6e9c6c490a72b46975d638a266f41d3ef )
+)
+
+game (
+	name "Dance Dance Revolution with Mario (Japan)"
+	description "Dance Dance Revolution with Mario (Japan)"
+	rom ( name "Dance Dance Revolution with Mario (Japan).iso" size 1459978240 crc 416cbc19 md5 7fb810eac86abf488d4ddcd486626433 sha1 aad1f82e51876e9d445dcf1386fee363df0e30dd )
+)
+
+game (
+	name "Dance Dance Revolution with Mario (JP) - dansudansureboriyusiyon+uizu+mario"
+	description "Dance Dance Revolution with Mario (JP) - dansudansureboriyusiyon+uizu+mario"
+	rom ( name "Dance Dance Revolution with Mario (JP).iso" size 1459978240 crc 416cbc19 md5 7fb810eac86abf488d4ddcd486626433 sha1 aad1f82e51876e9d445dcf1386fee363df0e30dd )
+)
+
+game (
+	name "Dancing Stage Mario Mix (Dance Pad) (EU)"
+	description "Dancing Stage Mario Mix (Dance Pad) (EU)"
+	rom ( name "Dancing Stage Mario Mix (Dance Pad) (EU).iso" size 1459978240 crc ad8ab59a md5 7b3cab3d2e31210837946ee35466b245 sha1 935606117bb6babd75558851e2b5551bf85a6c92 )
+)
+
+game (
+	name "Dancing Stage Mario Mix (Europe) (En,Fr,De,Es,It)"
+	description "Dancing Stage Mario Mix (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dancing Stage Mario Mix (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ad8ab59a md5 7b3cab3d2e31210837946ee35466b245 sha1 935606117bb6babd75558851e2b5551bf85a6c92 )
+)
+
+game (
+	name "Dark Summit (EU)"
+	description "Dark Summit (EU)"
+	rom ( name "Dark Summit (EU).iso" size 1459978240 crc 73a6dc10 md5 1886c920d82686e6d66ded8c121efccc sha1 96d59802ef0a7e5f1d688b49121ef326127ad08a )
+)
+
+game (
+	name "Dark Summit (Europe) (En,Fr,De)"
+	description "Dark Summit (Europe) (En,Fr,De)"
+	rom ( name "Dark Summit (Europe) (En,Fr,De).iso" size 1459978240 crc 73a6dc10 md5 1886c920d82686e6d66ded8c121efccc sha1 96d59802ef0a7e5f1d688b49121ef326127ad08a )
+)
+
+game (
+	name "Dark Summit (US)"
+	description "Dark Summit (US)"
+	rom ( name "Dark Summit (US).iso" size 1459978240 crc 7cc1bf12 md5 321828fcbbcdbc6dfe498dab7a86f120 sha1 dfcf1bab1c633198a7eb6b71779a860a0b84b380 )
+)
+
+game (
+	name "Dark Summit (USA)"
+	description "Dark Summit (USA)"
+	rom ( name "Dark Summit (USA).iso" size 1459978240 crc 7cc1bf12 md5 321828fcbbcdbc6dfe498dab7a86f120 sha1 dfcf1bab1c633198a7eb6b71779a860a0b84b380 )
+)
+
+game (
+	name "Darkened Skye (EU)"
+	description "Darkened Skye (EU)"
+	rom ( name "Darkened Skye (EU).iso" size 1459978240 crc 13827f09 md5 da8c7d6bcc79fb5853c61fdcd9f13877 sha1 1cc60ad6d34d41e46100189342677a61f71e6669 )
+)
+
+game (
+	name "Darkened Skye (Europe) (En,Fr,De)"
+	description "Darkened Skye (Europe) (En,Fr,De)"
+	rom ( name "Darkened Skye (Europe) (En,Fr,De).iso" size 1459978240 crc 13827f09 md5 da8c7d6bcc79fb5853c61fdcd9f13877 sha1 1cc60ad6d34d41e46100189342677a61f71e6669 )
+)
+
+game (
+	name "Darkened Skye (US)"
+	description "Darkened Skye (US)"
+	rom ( name "Darkened Skye (US).iso" size 1459978240 crc 086f3589 md5 1dc19408dda627f102e57c3e93c330dc sha1 902477680fca2e2d312adeb8776887c0d53d4237 )
+)
+
+game (
+	name "Darkened Skye (USA)"
+	description "Darkened Skye (USA)"
+	rom ( name "Darkened Skye (USA).iso" size 1459978240 crc 086f3589 md5 1dc19408dda627f102e57c3e93c330dc sha1 902477680fca2e2d312adeb8776887c0d53d4237 )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX 2 (EU)"
+	description "Dave Mirra Freestyle BMX 2 (EU)"
+	rom ( name "Dave Mirra Freestyle BMX 2 (EU).iso" size 1459978240 crc f9ba4e10 md5 c3c12a7976f8fcf510da8f412e98405a sha1 3f0641dacae931fba289d7a748e810fbd064896b )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX 2 (Europe)"
+	description "Dave Mirra Freestyle BMX 2 (Europe)"
+	rom ( name "Dave Mirra Freestyle BMX 2 (Europe).iso" size 1459978240 crc f9ba4e10 md5 c3c12a7976f8fcf510da8f412e98405a sha1 3f0641dacae931fba289d7a748e810fbd064896b )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX 2 (US)"
+	description "Dave Mirra Freestyle BMX 2 (US)"
+	rom ( name "Dave Mirra Freestyle BMX 2 (US).iso" size 1459978240 crc 528bb8e8 md5 2f1097d0fccee88157e80b75c74faf27 sha1 d6d67bfcfd87ce68e1861f0d21c2bc8159b3f404 )
+)
+
+game (
+	name "Dave Mirra Freestyle BMX 2 (USA)"
+	description "Dave Mirra Freestyle BMX 2 (USA)"
+	rom ( name "Dave Mirra Freestyle BMX 2 (USA).iso" size 1459978240 crc 528bb8e8 md5 2f1097d0fccee88157e80b75c74faf27 sha1 d6d67bfcfd87ce68e1861f0d21c2bc8159b3f404 )
+)
+
+game (
+	name "Dead to Rights (EU)"
+	description "Dead to Rights (EU)"
+	rom ( name "Dead to Rights (EU).iso" size 1459978240 crc ce19d0ca md5 593af0b28a362b20d292d48e5a98a168 sha1 43e70bd817e672deeaeebfac059a8cd1e86e873d )
+)
+
+game (
+	name "Dead to Rights (Europe) (En,Fr,Es,It)"
+	description "Dead to Rights (Europe) (En,Fr,Es,It)"
+	rom ( name "Dead to Rights (Europe) (En,Fr,Es,It).iso" size 1459978240 crc ce19d0ca md5 593af0b28a362b20d292d48e5a98a168 sha1 43e70bd817e672deeaeebfac059a8cd1e86e873d )
+)
+
+game (
+	name "Dead to Rights (US)"
+	description "Dead to Rights (US)"
+	rom ( name "Dead to Rights (US).iso" size 1459978240 crc f5ea2abf md5 3138124f7886e8e192e50e2ab99a1ba8 sha1 cfe1c2a4c48d0648cfa732237a2614deb00c72e8 )
+)
+
+game (
+	name "Dead to Rights (USA)"
+	description "Dead to Rights (USA)"
+	rom ( name "Dead to Rights (USA).iso" size 1459978240 crc f5ea2abf md5 3138124f7886e8e192e50e2ab99a1ba8 sha1 cfe1c2a4c48d0648cfa732237a2614deb00c72e8 )
+)
+
+game (
+	name "Def Jam - Fight for NY (EU)"
+	description "Def Jam - Fight for NY (EU)"
+	rom ( name "Def Jam - Fight for NY (EU).iso" size 1459978240 crc 6c3bf428 md5 17a790fdf771837ab2aec44ec91a5c8b sha1 e667f1735720f68cd3a20d50662d8cd24d9f5466 )
+)
+
+game (
+	name "Def Jam - Fight for NY (Europe) (En,Fr)"
+	description "Def Jam - Fight for NY (Europe) (En,Fr)"
+	rom ( name "Def Jam - Fight for NY (Europe) (En,Fr).iso" size 1459978240 crc 6c3bf428 md5 17a790fdf771837ab2aec44ec91a5c8b sha1 e667f1735720f68cd3a20d50662d8cd24d9f5466 )
+)
+
+game (
+	name "Def Jam - Fight for NY (US)"
+	description "Def Jam - Fight for NY (US)"
+	rom ( name "Def Jam - Fight for NY (US).iso" size 1459978240 crc 6b67d4d7 md5 2b10be2a0b71d529ada5c7e2f41ffc1e sha1 eab72bb2d1b08aa6807b5c86a2ac4f67ebbbaff4 )
+)
+
+game (
+	name "Def Jam - Fight for NY (USA)"
+	description "Def Jam - Fight for NY (USA)"
+	rom ( name "Def Jam - Fight for NY (USA).iso" size 1459978240 crc 6b67d4d7 md5 2b10be2a0b71d529ada5c7e2f41ffc1e sha1 eab72bb2d1b08aa6807b5c86a2ac4f67ebbbaff4 )
+)
+
+game (
+	name "Def Jam - Vendetta (EU)"
+	description "Def Jam - Vendetta (EU)"
+	rom ( name "Def Jam - Vendetta (EU).iso" size 1459978240 crc c8bb393a md5 4d4bf242e7eca13b91f87c0644deea3b sha1 8ff7c4fc7aae2959c25f1bf439daf5787bed6d68 )
+)
+
+game (
+	name "Def Jam - Vendetta (Europe)"
+	description "Def Jam - Vendetta (Europe)"
+	rom ( name "Def Jam - Vendetta (Europe).iso" size 1459978240 crc c8bb393a md5 4d4bf242e7eca13b91f87c0644deea3b sha1 8ff7c4fc7aae2959c25f1bf439daf5787bed6d68 )
+)
+
+game (
+	name "Def Jam - Vendetta (US)"
+	description "Def Jam - Vendetta (US)"
+	rom ( name "Def Jam - Vendetta (US).iso" size 1459978240 crc d5f430c5 md5 8c9156214939e47c13030ecfe16ebf4a sha1 33ebeab2db687c96a958a40f4ba2fca987587be7 )
+)
+
+game (
+	name "Def Jam - Vendetta (USA)"
+	description "Def Jam - Vendetta (USA)"
+	rom ( name "Def Jam - Vendetta (USA).iso" size 1459978240 crc d5f430c5 md5 8c9156214939e47c13030ecfe16ebf4a sha1 33ebeab2db687c96a958a40f4ba2fca987587be7 )
+)
+
+game (
+	name "Defender - For All Mankind (EU)"
+	description "Defender - For All Mankind (EU)"
+	rom ( name "Defender - For All Mankind (EU).iso" size 1459978240 crc eb7ee458 md5 aaf205c648d9f4ff6b946e1ce9da126b sha1 b440611c014727b68aaa47a0192d225949dbbd3c )
+)
+
+game (
+	name "Defender - For All Mankind (Europe) (En,Fr,De,Es,It)"
+	description "Defender - For All Mankind (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Defender - For All Mankind (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc eb7ee458 md5 aaf205c648d9f4ff6b946e1ce9da126b sha1 b440611c014727b68aaa47a0192d225949dbbd3c )
+)
+
+game (
+	name "Defender (US)"
+	description "Defender (US)"
+	rom ( name "Defender (US).iso" size 1459978240 crc 53ae96a5 md5 ba494301ef873157b61a1299cf6328be sha1 e5d9991b638686b8debdca39203e3d08e6551a96 )
+)
+
+game (
+	name "Defender (USA)"
+	description "Defender (USA)"
+	rom ( name "Defender (USA).iso" size 1459978240 crc 53ae96a5 md5 ba494301ef873157b61a1299cf6328be sha1 e5d9991b638686b8debdca39203e3d08e6551a96 )
+)
+
+game (
+	name "Densetsu no Quiz Ou Ketteisen (Japan)"
+	description "Densetsu no Quiz Ou Ketteisen (Japan)"
+	rom ( name "Densetsu no Quiz Ou Ketteisen (Japan).iso" size 1459978240 crc d62f1303 md5 ccef64c67d79c189524a13643e7c1143 sha1 366bc922814da5271a42493eb16e0e096551ec17 )
+)
+
+game (
+	name "Densetsu no Quiz Ou Ketteisen (JP) - Chuan Shuo nokuizuWang Jue Ding Zhan"
+	description "Densetsu no Quiz Ou Ketteisen (JP) - Chuan Shuo nokuizuWang Jue Ding Zhan"
+	rom ( name "Densetsu no Quiz Ou Ketteisen (JP).iso" size 1459978240 crc d62f1303 md5 ccef64c67d79c189524a13643e7c1143 sha1 366bc922814da5271a42493eb16e0e096551ec17 )
+)
+
+game (
+	name "Derby Tsuku 3 - Derby Uma o Tsukurou! (Japan)"
+	description "Derby Tsuku 3 - Derby Uma o Tsukurou! (Japan)"
+	rom ( name "Derby Tsuku 3 - Derby Uma o Tsukurou! (Japan).iso" size 1459978240 crc 1fa08988 md5 d30e6d8cc1d60c7f5b3114dda039ec52 sha1 37ec2a6b493c4fd2b910e693775a61c132c797d7 )
+)
+
+game (
+	name "Derby Tsuku 3 - Derby Uma o Tsukurou! (JP) - dabituku+3+dabiMa wotukurou!"
+	description "Derby Tsuku 3 - Derby Uma o Tsukurou! (JP) - dabituku+3+dabiMa wotukurou!"
+	rom ( name "Derby Tsuku 3 - Derby Uma o Tsukurou! (JP).iso" size 1459978240 crc 1fa08988 md5 d30e6d8cc1d60c7f5b3114dda039ec52 sha1 37ec2a6b493c4fd2b910e693775a61c132c797d7 )
+)
+
+game (
+	name "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (FR)"
+	description "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (FR)"
+	rom ( name "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (FR).iso" size 1459978240 crc a57a35ca md5 478276566f680d52b7604bd0818ecd85 sha1 b0872daaf55ed77c8e94c6b103e82e40693aa30f )
+)
+
+game (
+	name "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (France)"
+	description "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (France)"
+	rom ( name "Desastreuses Aventures des Orphelins Baudelaire, Les - D'Apres Lemony Snicket (France).iso" size 1459978240 crc a57a35ca md5 478276566f680d52b7604bd0818ecd85 sha1 b0872daaf55ed77c8e94c6b103e82e40693aa30f )
+)
+
+game (
+	name "Die Hard - Vendetta (DE)"
+	description "Die Hard - Vendetta (DE)"
+	rom ( name "Die Hard - Vendetta (DE).iso" size 1459978240 crc 044e194b md5 f97a7b734a223ffda848a21cfdd83bb3 sha1 6eab6ac61aec86240f884121ee0041ebc41075a5 )
+)
+
+game (
+	name "Die Hard - Vendetta (EU)"
+	description "Die Hard - Vendetta (EU)"
+	rom ( name "Die Hard - Vendetta (EU).iso" size 1459978240 crc 2ddf499b md5 958358ba5ed10745a5607aa0211e98a4 sha1 85a812bbcb789294cd03db03c216d6845ce77ae2 )
+)
+
+game (
+	name "Die Hard - Vendetta (Europe) (En,Fr)"
+	description "Die Hard - Vendetta (Europe) (En,Fr)"
+	rom ( name "Die Hard - Vendetta (Europe) (En,Fr).iso" size 1459978240 crc 2ddf499b md5 958358ba5ed10745a5607aa0211e98a4 sha1 85a812bbcb789294cd03db03c216d6845ce77ae2 )
+)
+
+game (
+	name "Die Hard - Vendetta (Europe) (Es,It)"
+	description "Die Hard - Vendetta (Europe) (Es,It)"
+	rom ( name "Die Hard - Vendetta (Europe) (Es,It).iso" size 1459978240 crc 9d941c40 md5 7b4935263105330cec6f85ebd42cc493 sha1 8687982941e18b4948da0b858fd80ec0069e0452 )
+)
+
+game (
+	name "Die Hard - Vendetta (Germany) (En,De)"
+	description "Die Hard - Vendetta (Germany) (En,De)"
+	rom ( name "Die Hard - Vendetta (Germany) (En,De).iso" size 1459978240 crc 044e194b md5 f97a7b734a223ffda848a21cfdd83bb3 sha1 6eab6ac61aec86240f884121ee0041ebc41075a5 )
+)
+
+game (
+	name "Die Hard - Vendetta (IT^ES)"
+	description "Die Hard - Vendetta (IT^ES)"
+	rom ( name "Die Hard - Vendetta (IT^ES).iso" size 1459978240 crc 9d941c40 md5 7b4935263105330cec6f85ebd42cc493 sha1 8687982941e18b4948da0b858fd80ec0069e0452 )
+)
+
+game (
+	name "Die Hard - Vendetta (US)"
+	description "Die Hard - Vendetta (US)"
+	rom ( name "Die Hard - Vendetta (US).iso" size 1459978240 crc 956ea8a8 md5 e41acd161ed9206e4c16ea1bfeef52ae sha1 7469b1769f259267202c2a5e01966bc3bbdfa61f )
+)
+
+game (
+	name "Die Hard - Vendetta (USA)"
+	description "Die Hard - Vendetta (USA)"
+	rom ( name "Die Hard - Vendetta (USA).iso" size 1459978240 crc 956ea8a8 md5 e41acd161ed9206e4c16ea1bfeef52ae sha1 7469b1769f259267202c2a5e01966bc3bbdfa61f )
+)
+
+game (
+	name "Digimon Battle Chronicle (Japan)"
+	description "Digimon Battle Chronicle (Japan)"
+	rom ( name "Digimon Battle Chronicle (Japan).iso" size 1459978240 crc b937bb5d md5 aaac2f0fa823f662b9fd90e4676e5d42 sha1 600e39b99b9822c361a161dcc707bbf66ff119c4 )
+)
+
+game (
+	name "Digimon Battle Chronicle (JP) - dezimonbatorukuronikuru"
+	description "Digimon Battle Chronicle (JP) - dezimonbatorukuronikuru"
+	rom ( name "Digimon Battle Chronicle (JP).iso" size 1459978240 crc b937bb5d md5 aaac2f0fa823f662b9fd90e4676e5d42 sha1 600e39b99b9822c361a161dcc707bbf66ff119c4 )
+)
+
+game (
+	name "Digimon Rumble Arena 2 (EU)"
+	description "Digimon Rumble Arena 2 (EU)"
+	rom ( name "Digimon Rumble Arena 2 (EU).iso" size 1459978240 crc 29a225df md5 66dbc7fe3e36e80eb960de61f0003886 sha1 68f33a997fb2cab450ddeedfd6a05670d22b166e )
+)
+
+game (
+	name "Digimon Rumble Arena 2 (Europe) (En,Fr,De,Es)"
+	description "Digimon Rumble Arena 2 (Europe) (En,Fr,De,Es)"
+	rom ( name "Digimon Rumble Arena 2 (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 29a225df md5 66dbc7fe3e36e80eb960de61f0003886 sha1 68f33a997fb2cab450ddeedfd6a05670d22b166e )
+)
+
+game (
+	name "Digimon Rumble Arena 2 (US)"
+	description "Digimon Rumble Arena 2 (US)"
+	rom ( name "Digimon Rumble Arena 2 (US).iso" size 1459978240 crc 0d75e917 md5 3220755e6471a3b8ac8b2d4635f968b4 sha1 636b1ffc9a14d191b0bda92b2343eb27adf31fde )
+)
+
+game (
+	name "Digimon Rumble Arena 2 (USA)"
+	description "Digimon Rumble Arena 2 (USA)"
+	rom ( name "Digimon Rumble Arena 2 (USA).iso" size 1459978240 crc 0d75e917 md5 3220755e6471a3b8ac8b2d4635f968b4 sha1 636b1ffc9a14d191b0bda92b2343eb27adf31fde )
+)
+
+game (
+	name "Digimon World 4 (US)"
+	description "Digimon World 4 (US)"
+	rom ( name "Digimon World 4 (US).iso" size 1459978240 crc 9e152cbc md5 65c7b4887d21efd526a69ff060f631b5 sha1 6a2aa8272538521531c803abf7f86dd430f9ad90 )
+)
+
+game (
+	name "Digimon World 4 (USA)"
+	description "Digimon World 4 (USA)"
+	rom ( name "Digimon World 4 (USA).iso" size 1459978240 crc 9e152cbc md5 65c7b4887d21efd526a69ff060f631b5 sha1 6a2aa8272538521531c803abf7f86dd430f9ad90 )
+)
+
+game (
+	name "Digimon World X (Japan)"
+	description "Digimon World X (Japan)"
+	rom ( name "Digimon World X (Japan).iso" size 1459978240 crc 88cf0d84 md5 f6cfd185ed340b37deb31dbdee685040 sha1 57e68ff150223961fd2873248673894370425041 )
+)
+
+game (
+	name "Digimon World X (JP) - dezimon+warudo+X"
+	description "Digimon World X (JP) - dezimon+warudo+X"
+	rom ( name "Digimon World X (JP).iso" size 1459978240 crc 88cf0d84 md5 f6cfd185ed340b37deb31dbdee685040 sha1 57e68ff150223961fd2873248673894370425041 )
+)
+
+game (
+	name "Dinotopia - The Sunstone Odyssey (US)"
+	description "Dinotopia - The Sunstone Odyssey (US)"
+	rom ( name "Dinotopia - The Sunstone Odyssey (US).iso" size 1459978240 crc 17330304 md5 d3b8c6582b460581feee3e2f21cc09ef sha1 b0f4fd932099853b7e831227954ea1787f027be4 )
+)
+
+game (
+	name "Dinotopia - The Sunstone Odyssey (USA)"
+	description "Dinotopia - The Sunstone Odyssey (USA)"
+	rom ( name "Dinotopia - The Sunstone Odyssey (USA).iso" size 1459978240 crc 17330304 md5 d3b8c6582b460581feee3e2f21cc09ef sha1 b0f4fd932099853b7e831227954ea1787f027be4 )
+)
+
+game (
+	name "Disney Chicken Little (FR)"
+	description "Disney Chicken Little (FR)"
+	rom ( name "Disney Chicken Little (FR).iso" size 1459978240 crc df75b9d0 md5 96fb149472e7d15866ed93fc2f2ecc3e sha1 a5c94f64fc9211c515b9f7a12b64a4fd31bcd8d9 )
+)
+
+game (
+	name "Disney Chicken Little (France)"
+	description "Disney Chicken Little (France)"
+	rom ( name "Disney Chicken Little (France).iso" size 1459978240 crc df75b9d0 md5 96fb149472e7d15866ed93fc2f2ecc3e sha1 a5c94f64fc9211c515b9f7a12b64a4fd31bcd8d9 )
+)
+
+game (
+	name "Disney Les Aventures de Porcinet (FR)"
+	description "Disney Les Aventures de Porcinet (FR)"
+	rom ( name "Disney Les Aventures de Porcinet (FR).iso" size 1459978240 crc cb9fc502 md5 08a70125f87b1f49a9a6e98d9e6fef9b sha1 c60b34febb0d59c82b6bf3c47fa36c8b8e386ff7 )
+)
+
+game (
+	name "Disney Les Aventures de Porcinet (France)"
+	description "Disney Les Aventures de Porcinet (France)"
+	rom ( name "Disney Les Aventures de Porcinet (France).iso" size 1459978240 crc cb9fc502 md5 08a70125f87b1f49a9a6e98d9e6fef9b sha1 c60b34febb0d59c82b6bf3c47fa36c8b8e386ff7 )
+)
+
+game (
+	name "Disney no Magical Park (Japan)"
+	description "Disney no Magical Park (Japan)"
+	rom ( name "Disney no Magical Park (Japan).iso" size 1459978240 crc 424a87e4 md5 897c4749ea2f7f1abe56eda0a10e2957 sha1 174fd6f295dd840ebb6a59e636df5c7aa936b260 )
+)
+
+game (
+	name "Disney no Magical Park (JP) - deizuninomazikarupaku"
+	description "Disney no Magical Park (JP) - deizuninomazikarupaku"
+	rom ( name "Disney no Magical Park (JP).iso" size 1459978240 crc 424a87e4 md5 897c4749ea2f7f1abe56eda0a10e2957 sha1 174fd6f295dd840ebb6a59e636df5c7aa936b260 )
+)
+
+game (
+	name "Disney Sports - American Football (Japan)"
+	description "Disney Sports - American Football (Japan)"
+	rom ( name "Disney Sports - American Football (Japan).iso" size 1459978240 crc 7225d2ea md5 9404e21c1860c39f06fd33a309296c1e sha1 4f249f1786bdd1926e8231b08a261018f2c6cc02 )
+)
+
+game (
+	name "Disney Sports - American Football (JP) - deizuni+supotu:+amerikan+hututoboru"
+	description "Disney Sports - American Football (JP) - deizuni+supotu:+amerikan+hututoboru"
+	rom ( name "Disney Sports - American Football (JP).iso" size 1459978240 crc 7225d2ea md5 9404e21c1860c39f06fd33a309296c1e sha1 4f249f1786bdd1926e8231b08a261018f2c6cc02 )
+)
+
+game (
+	name "Disney Sports - Basketball (EU)"
+	description "Disney Sports - Basketball (EU)"
+	rom ( name "Disney Sports - Basketball (EU).iso" size 1459978240 crc 28782fbc md5 6090bd95f4e9653b5c458947db93dc00 sha1 63a984cbbd0b3beb5df7feaf3d6980e9bf2bca70 )
+)
+
+game (
+	name "Disney Sports - Basketball (Europe) (En,Fr,De,Es,It)"
+	description "Disney Sports - Basketball (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney Sports - Basketball (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 28782fbc md5 6090bd95f4e9653b5c458947db93dc00 sha1 63a984cbbd0b3beb5df7feaf3d6980e9bf2bca70 )
+)
+
+game (
+	name "Disney Sports - Basketball (Japan)"
+	description "Disney Sports - Basketball (Japan)"
+	rom ( name "Disney Sports - Basketball (Japan).iso" size 1459978240 crc 9d0b3393 md5 5d315df64b06d0bcc322afbb6df5defb sha1 bd6525a9822ab714cfbbd41e2ddf609198c91369 )
+)
+
+game (
+	name "Disney Sports - Basketball (JP) - deizuni+supotu:+basuketutoboru"
+	description "Disney Sports - Basketball (JP) - deizuni+supotu:+basuketutoboru"
+	rom ( name "Disney Sports - Basketball (JP).iso" size 1459978240 crc 9d0b3393 md5 5d315df64b06d0bcc322afbb6df5defb sha1 bd6525a9822ab714cfbbd41e2ddf609198c91369 )
+)
+
+game (
+	name "Disney Sports - Basketball (US)"
+	description "Disney Sports - Basketball (US)"
+	rom ( name "Disney Sports - Basketball (US).iso" size 1459978240 crc 02407581 md5 7f227d0969b5f5763464a249d6f5029b sha1 da22ec4b9993ac3bb4c649990bd780c928fec3b7 )
+)
+
+game (
+	name "Disney Sports - Basketball (USA)"
+	description "Disney Sports - Basketball (USA)"
+	rom ( name "Disney Sports - Basketball (USA).iso" size 1459978240 crc 02407581 md5 7f227d0969b5f5763464a249d6f5029b sha1 da22ec4b9993ac3bb4c649990bd780c928fec3b7 )
+)
+
+game (
+	name "Disney Sports - Football (EU)"
+	description "Disney Sports - Football (EU)"
+	rom ( name "Disney Sports - Football (EU).iso" size 1459978240 crc 460d7017 md5 d793d8762abd7969c59c74d7fce0b05b sha1 240231e030966eb329066f88d34d0c327fc9bac5 )
+)
+
+game (
+	name "Disney Sports - Football (Europe) (En,Fr,De,Es,It)"
+	description "Disney Sports - Football (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney Sports - Football (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 460d7017 md5 d793d8762abd7969c59c74d7fce0b05b sha1 240231e030966eb329066f88d34d0c327fc9bac5 )
+)
+
+game (
+	name "Disney Sports - Football (US)"
+	description "Disney Sports - Football (US)"
+	rom ( name "Disney Sports - Football (US).iso" size 1459978240 crc 609bcfc4 md5 9558fba98e2e8a7abe319f47bc8b84fe sha1 c2c1784739f25f71869718ab7c9e737350228ff5 )
+)
+
+game (
+	name "Disney Sports - Football (USA)"
+	description "Disney Sports - Football (USA)"
+	rom ( name "Disney Sports - Football (USA).iso" size 1459978240 crc 609bcfc4 md5 9558fba98e2e8a7abe319f47bc8b84fe sha1 c2c1784739f25f71869718ab7c9e737350228ff5 )
+)
+
+game (
+	name "Disney Sports - Skateboarding (EU)"
+	description "Disney Sports - Skateboarding (EU)"
+	rom ( name "Disney Sports - Skateboarding (EU).iso" size 1459978240 crc 1700cae2 md5 4ca73f7a1c22caf78778f14ba0792bbd sha1 4935c4cefe42cd37bb5ac873b3be07b45e3a80f9 )
+)
+
+game (
+	name "Disney Sports - Skateboarding (Europe) (En,Fr,De,Es,It)"
+	description "Disney Sports - Skateboarding (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney Sports - Skateboarding (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1700cae2 md5 4ca73f7a1c22caf78778f14ba0792bbd sha1 4935c4cefe42cd37bb5ac873b3be07b45e3a80f9 )
+)
+
+game (
+	name "Disney Sports - Skateboarding (Japan)"
+	description "Disney Sports - Skateboarding (Japan)"
+	rom ( name "Disney Sports - Skateboarding (Japan).iso" size 1459978240 crc 5c30c8ae md5 9bcc83e783d0e5d0ef35bfe3999c5a6a sha1 35bb2350a23021b0e9d7344aad3816b54c32fe00 )
+)
+
+game (
+	name "Disney Sports - Skateboarding (JP) - deizunisupotu:suketobodeingu"
+	description "Disney Sports - Skateboarding (JP) - deizunisupotu:suketobodeingu"
+	rom ( name "Disney Sports - Skateboarding (JP).iso" size 1459978240 crc 5c30c8ae md5 9bcc83e783d0e5d0ef35bfe3999c5a6a sha1 35bb2350a23021b0e9d7344aad3816b54c32fe00 )
+)
+
+game (
+	name "Disney Sports - Skateboarding (US)"
+	description "Disney Sports - Skateboarding (US)"
+	rom ( name "Disney Sports - Skateboarding (US).iso" size 1459978240 crc b769edff md5 ffdbbb0be4a664d18973f3af9cfa5302 sha1 a09d860f92ec40100ed1bc0c5fd7a7e1218c2bda )
+)
+
+game (
+	name "Disney Sports - Skateboarding (USA)"
+	description "Disney Sports - Skateboarding (USA)"
+	rom ( name "Disney Sports - Skateboarding (USA).iso" size 1459978240 crc b769edff md5 ffdbbb0be4a664d18973f3af9cfa5302 sha1 a09d860f92ec40100ed1bc0c5fd7a7e1218c2bda )
+)
+
+game (
+	name "Disney Sports - Soccer (Japan)"
+	description "Disney Sports - Soccer (Japan)"
+	rom ( name "Disney Sports - Soccer (Japan).iso" size 1459978240 crc aebd0b85 md5 4147b70838104d0af57f355eba43d0aa sha1 cd8f7a2df0278538190083c06aa23770c254d76b )
+)
+
+game (
+	name "Disney Sports - Soccer (JP) - deizunisupotu:satuka"
+	description "Disney Sports - Soccer (JP) - deizunisupotu:satuka"
+	rom ( name "Disney Sports - Soccer (JP).iso" size 1459978240 crc aebd0b85 md5 4147b70838104d0af57f355eba43d0aa sha1 cd8f7a2df0278538190083c06aa23770c254d76b )
+)
+
+game (
+	name "Disney Sports - Soccer (US)"
+	description "Disney Sports - Soccer (US)"
+	rom ( name "Disney Sports - Soccer (US).iso" size 1459978240 crc 16be950f md5 f4fc53df07e411ec7ad0b8a8fa972949 sha1 622833775231b615aed19c4d7589aff5c8081631 )
+)
+
+game (
+	name "Disney Sports - Soccer (USA)"
+	description "Disney Sports - Soccer (USA)"
+	rom ( name "Disney Sports - Soccer (USA).iso" size 1459978240 crc 16be950f md5 f4fc53df07e411ec7ad0b8a8fa972949 sha1 622833775231b615aed19c4d7589aff5c8081631 )
+)
+
+game (
+	name "Disney-Pixar Cars (DE)"
+	description "Disney-Pixar Cars (DE)"
+	rom ( name "Disney-Pixar Cars (DE).iso" size 1459978240 crc 59c7e6b6 md5 55fbedeeec6e6810e90467c1b56cd48c sha1 c9d8b23c28904b164d9326afa3b3f04b0b594b3c )
+)
+
+game (
+	name "Disney-Pixar Cars (ES)"
+	description "Disney-Pixar Cars (ES)"
+	rom ( name "Disney-Pixar Cars (ES).iso" size 1459978240 crc e7068bde md5 ead36c18846537c52d89202809423fb5 sha1 dc76879d9b9be7659c61e73975386cc0ad0bca96 )
+)
+
+game (
+	name "Disney-Pixar Cars (EU)"
+	description "Disney-Pixar Cars (EU)"
+	rom ( name "Disney-Pixar Cars (EU).iso" size 1459978240 crc 9805f682 md5 b17157a13c7fc220388e56c07732dc34 sha1 33fc544ec42b03e99177fad589544ee4fda5117f )
+)
+
+game (
+	name "Disney-Pixar Cars (Europe)"
+	description "Disney-Pixar Cars (Europe)"
+	rom ( name "Disney-Pixar Cars (Europe).iso" size 1459978240 crc 9805f682 md5 b17157a13c7fc220388e56c07732dc34 sha1 33fc544ec42b03e99177fad589544ee4fda5117f )
+)
+
+game (
+	name "Disney-Pixar Cars (FR)"
+	description "Disney-Pixar Cars (FR)"
+	rom ( name "Disney-Pixar Cars (FR).iso" size 1459978240 crc c2d22a58 md5 b6ad4a7aaaa2e133ecbbd2598f4d4b21 sha1 9315451546f73a8cde2f2a8a0ba05dd0a51c3f43 )
+)
+
+game (
+	name "Disney-Pixar Cars (France)"
+	description "Disney-Pixar Cars (France)"
+	rom ( name "Disney-Pixar Cars (France).iso" size 1459978240 crc c2d22a58 md5 b6ad4a7aaaa2e133ecbbd2598f4d4b21 sha1 9315451546f73a8cde2f2a8a0ba05dd0a51c3f43 )
+)
+
+game (
+	name "Disney-Pixar Cars (Germany)"
+	description "Disney-Pixar Cars (Germany)"
+	rom ( name "Disney-Pixar Cars (Germany).iso" size 1459978240 crc 59c7e6b6 md5 55fbedeeec6e6810e90467c1b56cd48c sha1 c9d8b23c28904b164d9326afa3b3f04b0b594b3c )
+)
+
+game (
+	name "Disney-Pixar Cars (Japan)"
+	description "Disney-Pixar Cars (Japan)"
+	rom ( name "Disney-Pixar Cars (Japan).iso" size 1459978240 crc 8e0cc9c2 md5 b3eeb8a8eb72758ab7667c2d272ca0b0 sha1 a53e54aaa6ec9ba4b99bd96c671d8076c127cd65 )
+)
+
+game (
+	name "Disney-Pixar Cars (JP) - kazu"
+	description "Disney-Pixar Cars (JP) - kazu"
+	rom ( name "Disney-Pixar Cars (JP).iso" size 1459978240 crc 8e0cc9c2 md5 b3eeb8a8eb72758ab7667c2d272ca0b0 sha1 a53e54aaa6ec9ba4b99bd96c671d8076c127cd65 )
+)
+
+game (
+	name "Disney-Pixar Cars (Netherlands)"
+	description "Disney-Pixar Cars (Netherlands)"
+	rom ( name "Disney-Pixar Cars (Netherlands).iso" size 1459978240 crc f455d131 md5 b9972032a9ca8e30edda795c8222f913 sha1 869a41cc676e373ec9cf85d8bb5ab1f685a8efef )
+)
+
+game (
+	name "Disney-Pixar Cars (NL)"
+	description "Disney-Pixar Cars (NL)"
+	rom ( name "Disney-Pixar Cars (NL).iso" size 1459978240 crc f455d131 md5 b9972032a9ca8e30edda795c8222f913 sha1 869a41cc676e373ec9cf85d8bb5ab1f685a8efef )
+)
+
+game (
+	name "Disney-Pixar Cars (Spain)"
+	description "Disney-Pixar Cars (Spain)"
+	rom ( name "Disney-Pixar Cars (Spain).iso" size 1459978240 crc e7068bde md5 ead36c18846537c52d89202809423fb5 sha1 dc76879d9b9be7659c61e73975386cc0ad0bca96 )
+)
+
+game (
+	name "Disney-Pixar Cars (US)"
+	description "Disney-Pixar Cars (US)"
+	rom ( name "Disney-Pixar Cars (US).iso" size 1459978240 crc e4c276f2 md5 ae41fe9270967d6928793899740e6d43 sha1 6b380ff29cf6a204a65059397689e68632ec6aec )
+)
+
+game (
+	name "Disney-Pixar Cars (USA)"
+	description "Disney-Pixar Cars (USA)"
+	rom ( name "Disney-Pixar Cars (USA).iso" size 1459978240 crc e4c276f2 md5 ae41fe9270967d6928793899740e6d43 sha1 6b380ff29cf6a204a65059397689e68632ec6aec )
+)
+
+game (
+	name "Disney-Pixar Die Unglaublichen (DE)"
+	description "Disney-Pixar Die Unglaublichen (DE)"
+	rom ( name "Disney-Pixar Die Unglaublichen (DE).iso" size 1459978240 crc 1c65db37 md5 dca559bfb0312a0de268480449068358 sha1 12f096ccce09b62ec1a671d75785a549475ab147 )
+)
+
+game (
+	name "Disney-Pixar Die Unglaublichen (Germany)"
+	description "Disney-Pixar Die Unglaublichen (Germany)"
+	rom ( name "Disney-Pixar Die Unglaublichen (Germany).iso" size 1459978240 crc 1c65db37 md5 dca559bfb0312a0de268480449068358 sha1 12f096ccce09b62ec1a671d75785a549475ab147 )
+)
+
+game (
+	name "Disney-Pixar Finding Nemo (US)"
+	description "Disney-Pixar Finding Nemo (US)"
+	rom ( name "Disney-Pixar Finding Nemo (US) - [v1.00].iso" size 1459978240 crc a997457f md5 18f7f037f7de19ef40defa1c1891dcb6 sha1 c9dac666b835a3092d3aca68f3621b343d145dcb )
+)
+
+game (
+	name "Disney-Pixar Finding Nemo (USA) (v1.00)"
+	description "Disney-Pixar Finding Nemo (USA) (v1.00)"
+	rom ( name "Disney-Pixar Finding Nemo (USA) (v1.00).iso" size 1459978240 crc a997457f md5 18f7f037f7de19ef40defa1c1891dcb6 sha1 c9dac666b835a3092d3aca68f3621b343d145dcb )
+)
+
+game (
+	name "Disney-Pixar Finding Nemo (USA) (v1.01)"
+	description "Disney-Pixar Finding Nemo (USA) (v1.01)"
+	rom ( name "Disney-Pixar Finding Nemo (USA) (v1.01).iso" size 1459978240 crc ae9836ec md5 65f782b114ae1cf3f98d565bce1e46ae sha1 39d23ba191ce922a9c35971f5f47572eac9e9e6c )
+)
+
+game (
+	name "Disney-Pixar Le Monde de Nemo (FR)"
+	description "Disney-Pixar Le Monde de Nemo (FR)"
+	rom ( name "Disney-Pixar Le Monde de Nemo (FR).iso" size 1459978240 crc f2152a1c md5 02ec927965fc5d159b13836acf555557 sha1 df85c7a732d8c8bcbfe2e843aff29bf426dcc2db )
+)
+
+game (
+	name "Disney-Pixar Le Monde de Nemo (France)"
+	description "Disney-Pixar Le Monde de Nemo (France)"
+	rom ( name "Disney-Pixar Le Monde de Nemo (France).iso" size 1459978240 crc f2152a1c md5 02ec927965fc5d159b13836acf555557 sha1 df85c7a732d8c8bcbfe2e843aff29bf426dcc2db )
+)
+
+game (
+	name "Disney-Pixar Les Indestructibles (FR)"
+	description "Disney-Pixar Les Indestructibles (FR)"
+	rom ( name "Disney-Pixar Les Indestructibles (FR).iso" size 1459978240 crc 15011304 md5 ddbffc0eded125cc964643700ef2bd61 sha1 22b77d5ae5bb44eee6ae31ff7941ba4478e76aa6 )
+)
+
+game (
+	name "Disney-Pixar Les Indestructibles (France)"
+	description "Disney-Pixar Les Indestructibles (France)"
+	rom ( name "Disney-Pixar Les Indestructibles (France).iso" size 1459978240 crc 15011304 md5 ddbffc0eded125cc964643700ef2bd61 sha1 22b77d5ae5bb44eee6ae31ff7941ba4478e76aa6 )
+)
+
+game (
+	name "Disney-Pixar Monsters, Inc. - Scream Arena (EU)"
+	description "Disney-Pixar Monsters, Inc. - Scream Arena (EU)"
+	rom ( name "Disney-Pixar Monsters, Inc. - Scream Arena (EU).iso" size 1459978240 crc 1b8eaba2 md5 b2c9ba8474c55548dc661c2fbe0e7dce sha1 3ba8c36393f22ae7d2b2022022a8ec716e576d08 )
+)
+
+game (
+	name "Disney-Pixar Monsters, Inc. - Scream Arena (Europe) (En,Fr,De,Es,It)"
+	description "Disney-Pixar Monsters, Inc. - Scream Arena (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney-Pixar Monsters, Inc. - Scream Arena (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1b8eaba2 md5 b2c9ba8474c55548dc661c2fbe0e7dce sha1 3ba8c36393f22ae7d2b2022022a8ec716e576d08 )
+)
+
+game (
+	name "Disney-Pixar Monsters, Inc. - Scream Arena (US)"
+	description "Disney-Pixar Monsters, Inc. - Scream Arena (US)"
+	rom ( name "Disney-Pixar Monsters, Inc. - Scream Arena (US).iso" size 1459978240 crc 325879b5 md5 745d25a6458af6b943fbf98337094bef sha1 e7a64f7d450b6b275e1ef44e7e96a87708a27034 )
+)
+
+game (
+	name "Disney-Pixar Monsters, Inc. - Scream Arena (USA)"
+	description "Disney-Pixar Monsters, Inc. - Scream Arena (USA)"
+	rom ( name "Disney-Pixar Monsters, Inc. - Scream Arena (USA).iso" size 1459978240 crc 325879b5 md5 745d25a6458af6b943fbf98337094bef sha1 e7a64f7d450b6b275e1ef44e7e96a87708a27034 )
+)
+
+game (
+	name "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (Japan)"
+	description "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (Japan)"
+	rom ( name "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (Japan).iso" size 1459978240 crc 9c0aefd7 md5 9c780140c65d75bb2834a8fdcff93c4c sha1 b0fa305d6435048478ccf8f4d2667404ea2c87e1 )
+)
+
+game (
+	name "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (JP) - Mr.+inkuredeiburu+Qiang Di andamainaDeng Chang"
+	description "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (JP) - Mr.+inkuredeiburu+Qiang Di andamainaDeng Chang"
+	rom ( name "Disney-Pixar Mr. Incredible - Kyouteki Underminder Toujou (JP).iso" size 1459978240 crc 9c0aefd7 md5 9c780140c65d75bb2834a8fdcff93c4c sha1 b0fa305d6435048478ccf8f4d2667404ea2c87e1 )
+)
+
+game (
+	name "Disney-Pixar Mr. Incredible (Japan)"
+	description "Disney-Pixar Mr. Incredible (Japan)"
+	rom ( name "Disney-Pixar Mr. Incredible (Japan).iso" size 1459978240 crc e0addb4c md5 3dd63a89d5982eb7ab97170787aa00bf sha1 31ff0e4916d0fb704cf6e392f50885b17a6da235 )
+)
+
+game (
+	name "Disney-Pixar Mr. Incredible (JP) - Mr.inkuredeiburu"
+	description "Disney-Pixar Mr. Incredible (JP) - Mr.inkuredeiburu"
+	rom ( name "Disney-Pixar Mr. Incredible (JP).iso" size 1459978240 crc e0addb4c md5 3dd63a89d5982eb7ab97170787aa00bf sha1 31ff0e4916d0fb704cf6e392f50885b17a6da235 )
+)
+
+game (
+	name "Disney-Pixar Ratatouille (FR)"
+	description "Disney-Pixar Ratatouille (FR)"
+	rom ( name "Disney-Pixar Ratatouille (FR).iso" size 1459978240 crc a881872b md5 23f52359347b4f38911ce8465a33cd60 sha1 b392f6591277941ae28e728c237f39c4a5f29ca1 )
+)
+
+game (
+	name "Disney-Pixar Ratatouille (France)"
+	description "Disney-Pixar Ratatouille (France)"
+	rom ( name "Disney-Pixar Ratatouille (France).iso" size 1459978240 crc a881872b md5 23f52359347b4f38911ce8465a33cd60 sha1 b392f6591277941ae28e728c237f39c4a5f29ca1 )
+)
+
+game (
+	name "Disney-Pixar Ratatouille (US)"
+	description "Disney-Pixar Ratatouille (US)"
+	rom ( name "Disney-Pixar Ratatouille (US).iso" size 1459978240 crc b8fc1dd1 md5 f4eb6225f2bbd2664321e646a1351144 sha1 37e41a67a74a1043c72dd2138fe3ba14ffc6f3e1 )
+)
+
+game (
+	name "Disney-Pixar Ratatouille (USA)"
+	description "Disney-Pixar Ratatouille (USA)"
+	rom ( name "Disney-Pixar Ratatouille (USA).iso" size 1459978240 crc b8fc1dd1 md5 f4eb6225f2bbd2664321e646a1351144 sha1 37e41a67a74a1043c72dd2138fe3ba14ffc6f3e1 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (DE^FR)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (DE^FR)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (DE^FR).iso" size 1459978240 crc f1faffb9 md5 9d35107bd340e65a047df0635e7e730b sha1 77eebc4066f40628af9bcf5302fbcefa19638c4c )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (EU)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (EU)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (EU).iso" size 1459978240 crc 66c57057 md5 c54ce84a91f3bbed61e56204fdc87e1f sha1 5e4f0f9690aa5ac3d53ecc47614f7ae718e040ea )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (En,Fr)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (En,Fr)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (En,Fr).iso" size 1459978240 crc 66c57057 md5 c54ce84a91f3bbed61e56204fdc87e1f sha1 5e4f0f9690aa5ac3d53ecc47614f7ae718e040ea )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (Fr,De)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (Fr,De)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (Europe) (Fr,De).iso" size 1459978240 crc f1faffb9 md5 9d35107bd340e65a047df0635e7e730b sha1 77eebc4066f40628af9bcf5302fbcefa19638c4c )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (US)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (US)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (US).iso" size 1459978240 crc 539e1ca6 md5 776efc70a57fb62e2dc77f011f870473 sha1 e9015fc11b1a33796c932eab724d77883e71d867 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles - Rise of the Underminer (USA)"
+	description "Disney-Pixar The Incredibles - Rise of the Underminer (USA)"
+	rom ( name "Disney-Pixar The Incredibles - Rise of the Underminer (USA).iso" size 1459978240 crc 539e1ca6 md5 776efc70a57fb62e2dc77f011f870473 sha1 e9015fc11b1a33796c932eab724d77883e71d867 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (EU)"
+	description "Disney-Pixar The Incredibles (EU)"
+	rom ( name "Disney-Pixar The Incredibles (EU).iso" size 1459978240 crc baca665a md5 b982c00f57f7000297d55aa3cac57ba0 sha1 17c1d040c22684e981ba2e82f6294c8489dba842 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (Europe)"
+	description "Disney-Pixar The Incredibles (Europe)"
+	rom ( name "Disney-Pixar The Incredibles (Europe).iso" size 1459978240 crc baca665a md5 b982c00f57f7000297d55aa3cac57ba0 sha1 17c1d040c22684e981ba2e82f6294c8489dba842 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (Netherlands)"
+	description "Disney-Pixar The Incredibles (Netherlands)"
+	rom ( name "Disney-Pixar The Incredibles (Netherlands).iso" size 1459978240 crc 65d638f6 md5 102a3dc6504152fa77e94744327a5781 sha1 53013829858d71bfd2ffb55120c91c5e681a874d )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (NL)"
+	description "Disney-Pixar The Incredibles (NL)"
+	rom ( name "Disney-Pixar The Incredibles (NL).iso" size 1459978240 crc 65d638f6 md5 102a3dc6504152fa77e94744327a5781 sha1 53013829858d71bfd2ffb55120c91c5e681a874d )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (US)"
+	description "Disney-Pixar The Incredibles (US)"
+	rom ( name "Disney-Pixar The Incredibles (US).iso" size 1459978240 crc e1023994 md5 8a7c0f17f840793c19d0fe608ed59528 sha1 cf2e5f81f2bd721afe830c374dccfd8815eee357 )
+)
+
+game (
+	name "Disney-Pixar The Incredibles (USA)"
+	description "Disney-Pixar The Incredibles (USA)"
+	rom ( name "Disney-Pixar The Incredibles (USA).iso" size 1459978240 crc e1023994 md5 8a7c0f17f840793c19d0fe608ed59528 sha1 cf2e5f81f2bd721afe830c374dccfd8815eee357 )
+)
+
+game (
+	name "Disney's Chicken Little (Europe)"
+	description "Disney's Chicken Little (Europe)"
+	rom ( name "Disney's Chicken Little (Europe).iso" size 1459978240 crc 0444ce35 md5 172a02e376a37d326da1720662212bce sha1 be2832c6394290a69a15517a490d1f9a4509bfbe )
+)
+
+game (
+	name "Disney's Chicken Little (GB)"
+	description "Disney's Chicken Little (GB)"
+	rom ( name "Disney's Chicken Little (GB).iso" size 1459978240 crc 0444ce35 md5 172a02e376a37d326da1720662212bce sha1 be2832c6394290a69a15517a490d1f9a4509bfbe )
+)
+
+game (
+	name "Disney's Chicken Little (Japan)"
+	description "Disney's Chicken Little (Japan)"
+	rom ( name "Disney's Chicken Little (Japan).iso" size 1459978240 crc 46cbf564 md5 e082d0208430577a2f37f1636cb9d792 sha1 a4b08ebb3fe7b41a904c69034ebc20fac62354ed )
+)
+
+game (
+	name "Disney's Chicken Little (JP) - tikin*ritoru"
+	description "Disney's Chicken Little (JP) - tikin*ritoru"
+	rom ( name "Disney's Chicken Little (JP).iso" size 1459978240 crc 46cbf564 md5 e082d0208430577a2f37f1636cb9d792 sha1 a4b08ebb3fe7b41a904c69034ebc20fac62354ed )
+)
+
+game (
+	name "Disney's Chicken Little (US)"
+	description "Disney's Chicken Little (US)"
+	rom ( name "Disney's Chicken Little (US).iso" size 1459978240 crc 8124d7b4 md5 c405accb2cb596da872fad9541909fa8 sha1 cdf5837a29f27f882ef1fa74e169b1a8e0d1e996 )
+)
+
+game (
+	name "Disney's Chicken Little (USA)"
+	description "Disney's Chicken Little (USA)"
+	rom ( name "Disney's Chicken Little (USA).iso" size 1459978240 crc 8124d7b4 md5 c405accb2cb596da872fad9541909fa8 sha1 cdf5837a29f27f882ef1fa74e169b1a8e0d1e996 )
+)
+
+game (
+	name "Disney's Donald Duck - Goin' Quackers (US)"
+	description "Disney's Donald Duck - Goin' Quackers (US)"
+	rom ( name "Disney's Donald Duck - Goin' Quackers (US).iso" size 1459978240 crc f8769f5d md5 f6b779f5a7757f9a5d3258a832545b5a sha1 ba86d4ee6d56f6c1977d975907be8028a22699bb )
+)
+
+game (
+	name "Disney's Donald Duck - Goin' Quackers (USA) (En,Fr)"
+	description "Disney's Donald Duck - Goin' Quackers (USA) (En,Fr)"
+	rom ( name "Disney's Donald Duck - Goin' Quackers (USA) (En,Fr).iso" size 1459978240 crc f8769f5d md5 f6b779f5a7757f9a5d3258a832545b5a sha1 ba86d4ee6d56f6c1977d975907be8028a22699bb )
+)
+
+game (
+	name "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (EU)"
+	description "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (EU)"
+	rom ( name "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (EU).iso" size 1459978240 crc b265ea6e md5 7380bd8887a4338cedc76f2f53d90aa8 sha1 acec0a3fe6da742a64aeaa97f27b3eb742eb46e4 )
+)
+
+game (
+	name "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b265ea6e md5 7380bd8887a4338cedc76f2f53d90aa8 sha1 acec0a3fe6da742a64aeaa97f27b3eb742eb46e4 )
+)
+
+game (
+	name "Disney's Donald Duck - Quack Attack (EU)"
+	description "Disney's Donald Duck - Quack Attack (EU)"
+	rom ( name "Disney's Donald Duck - Quack Attack (EU).iso" size 1459978240 crc c70d859d md5 ae62daf163809c1a58a153298ffa56b4 sha1 89fa851892bd0f05192c7d79d15aa83668f833cf )
+)
+
+game (
+	name "Disney's Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc c70d859d md5 ae62daf163809c1a58a153298ffa56b4 sha1 89fa851892bd0f05192c7d79d15aa83668f833cf )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (DE^FR)"
+	description "Disney's Extreme Skate Adventure (DE^FR)"
+	rom ( name "Disney's Extreme Skate Adventure (DE^FR).iso" size 1459978240 crc 3544f0b0 md5 810f4a0f4c2fbde06a5d3355edcf0732 sha1 cc6f87117d4a239ef3328d24b18a757c44ad3a64 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (Europe)"
+	description "Disney's Extreme Skate Adventure (Europe)"
+	rom ( name "Disney's Extreme Skate Adventure (Europe).iso" size 1459978240 crc 119f3b75 md5 a66e632cea696e5489b724e84d6aec13 sha1 12fc768643018f4f72d8dc36809d6cf34141b956 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (Europe) (Es,It)"
+	description "Disney's Extreme Skate Adventure (Europe) (Es,It)"
+	rom ( name "Disney's Extreme Skate Adventure (Europe) (Es,It).iso" size 1459978240 crc 5f08972a md5 1d4b3ec22f4876847a11ff8387fac5f5 sha1 bdb76353026e44619b95e3417d4d5f06e6bd0377 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (Europe) (Fr,De)"
+	description "Disney's Extreme Skate Adventure (Europe) (Fr,De)"
+	rom ( name "Disney's Extreme Skate Adventure (Europe) (Fr,De).iso" size 1459978240 crc 3544f0b0 md5 810f4a0f4c2fbde06a5d3355edcf0732 sha1 cc6f87117d4a239ef3328d24b18a757c44ad3a64 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (GB)"
+	description "Disney's Extreme Skate Adventure (GB)"
+	rom ( name "Disney's Extreme Skate Adventure (GB).iso" size 1459978240 crc 119f3b75 md5 a66e632cea696e5489b724e84d6aec13 sha1 12fc768643018f4f72d8dc36809d6cf34141b956 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (IT^ES)"
+	description "Disney's Extreme Skate Adventure (IT^ES)"
+	rom ( name "Disney's Extreme Skate Adventure (IT^ES).iso" size 1459978240 crc 5f08972a md5 1d4b3ec22f4876847a11ff8387fac5f5 sha1 bdb76353026e44619b95e3417d4d5f06e6bd0377 )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (US)"
+	description "Disney's Extreme Skate Adventure (US)"
+	rom ( name "Disney's Extreme Skate Adventure (US).iso" size 1459978240 crc 940c7c23 md5 cbf0b925d7ef55098574f861627f5324 sha1 21d616bebf834bba3fbfb09ea7df27f4d3637c3a )
+)
+
+game (
+	name "Disney's Extreme Skate Adventure (USA)"
+	description "Disney's Extreme Skate Adventure (USA)"
+	rom ( name "Disney's Extreme Skate Adventure (USA).iso" size 1459978240 crc 940c7c23 md5 cbf0b925d7ef55098574f861627f5324 sha1 21d616bebf834bba3fbfb09ea7df27f4d3637c3a )
+)
+
+game (
+	name "Disney's Hide & Sneak (EU)"
+	description "Disney's Hide & Sneak (EU)"
+	rom ( name "Disney's Hide & Sneak (EU).iso" size 1459978240 crc f79900ff md5 ff7f7ba0b516a65c618bc6f136227d72 sha1 be0885c5a5ca6c94e2271d657d52073a23b33f06 )
+)
+
+game (
+	name "Disney's Hide & Sneak (Europe) (En,Fr,De)"
+	description "Disney's Hide & Sneak (Europe) (En,Fr,De)"
+	rom ( name "Disney's Hide & Sneak (Europe) (En,Fr,De).iso" size 1459978240 crc f79900ff md5 ff7f7ba0b516a65c618bc6f136227d72 sha1 be0885c5a5ca6c94e2271d657d52073a23b33f06 )
+)
+
+game (
+	name "Disney's Hide & Sneak (US)"
+	description "Disney's Hide & Sneak (US)"
+	rom ( name "Disney's Hide & Sneak (US).iso" size 1459978240 crc 489321af md5 38c74e0587c845548ecd2269c1d8c232 sha1 d747cbc9e71636490b98fdc26ecad40323a46a08 )
+)
+
+game (
+	name "Disney's Hide & Sneak (USA)"
+	description "Disney's Hide & Sneak (USA)"
+	rom ( name "Disney's Hide & Sneak (USA).iso" size 1459978240 crc 489321af md5 38c74e0587c845548ecd2269c1d8c232 sha1 d747cbc9e71636490b98fdc26ecad40323a46a08 )
+)
+
+game (
+	name "Disney's Magical Mirror Starring Mickey Mouse (EU)"
+	description "Disney's Magical Mirror Starring Mickey Mouse (EU)"
+	rom ( name "Disney's Magical Mirror Starring Mickey Mouse (EU).iso" size 1459978240 crc af3fbca8 md5 ab2ac45f906726ff11509556452f38ee sha1 041a3ff4f1e2b405180478f43408ece5a552ba8f )
+)
+
+game (
+	name "Disney's Magical Mirror Starring Mickey Mouse (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Magical Mirror Starring Mickey Mouse (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Magical Mirror Starring Mickey Mouse (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc af3fbca8 md5 ab2ac45f906726ff11509556452f38ee sha1 041a3ff4f1e2b405180478f43408ece5a552ba8f )
+)
+
+game (
+	name "Disney's Magical Mirror Starring Mickey Mouse (US)"
+	description "Disney's Magical Mirror Starring Mickey Mouse (US)"
+	rom ( name "Disney's Magical Mirror Starring Mickey Mouse (US).iso" size 1459978240 crc 61f36ffd md5 baf1ffe1b585fa447dce54444e463fc4 sha1 4896cabdedacc60a5d7c74d0aefe1092f56336c5 )
+)
+
+game (
+	name "Disney's Magical Mirror Starring Mickey Mouse (USA)"
+	description "Disney's Magical Mirror Starring Mickey Mouse (USA)"
+	rom ( name "Disney's Magical Mirror Starring Mickey Mouse (USA).iso" size 1459978240 crc 61f36ffd md5 baf1ffe1b585fa447dce54444e463fc4 sha1 4896cabdedacc60a5d7c74d0aefe1092f56336c5 )
+)
+
+game (
+	name "Disney's Mickey Mouse no Fushigi na Kagami (Japan)"
+	description "Disney's Mickey Mouse no Fushigi na Kagami (Japan)"
+	rom ( name "Disney's Mickey Mouse no Fushigi na Kagami (Japan).iso" size 1459978240 crc 650bbc8c md5 3c6301f69e37f46c9603f1b4541bffb2 sha1 361fe4b288e9ad9f0c338618d0c16114fc4d7a6d )
+)
+
+game (
+	name "Disney's Mickey Mouse no Fushigi na Kagami (JP) - deizuninomitukimausunoBu Si Yi naJing"
+	description "Disney's Mickey Mouse no Fushigi na Kagami (JP) - deizuninomitukimausunoBu Si Yi naJing"
+	rom ( name "Disney's Mickey Mouse no Fushigi na Kagami (JP).iso" size 1459978240 crc 650bbc8c md5 3c6301f69e37f46c9603f1b4541bffb2 sha1 361fe4b288e9ad9f0c338618d0c16114fc4d7a6d )
+)
+
+game (
+	name "Disney's Mickey to Minnie Trick & Chase (Japan)"
+	description "Disney's Mickey to Minnie Trick & Chase (Japan)"
+	rom ( name "Disney's Mickey to Minnie Trick & Chase (Japan).iso" size 1459978240 crc 583d116e md5 ff155ea04cdf72d31bd0e33fbd264ba2 sha1 42b944d1a178ccb396f351f2f456e49503b5f8bd )
+)
+
+game (
+	name "Disney's Mickey to Minnie Trick & Chase (JP) - deizuninomituki&mini+torituku&tieisu"
+	description "Disney's Mickey to Minnie Trick & Chase (JP) - deizuninomituki&mini+torituku&tieisu"
+	rom ( name "Disney's Mickey to Minnie Trick & Chase (JP).iso" size 1459978240 crc 583d116e md5 ff155ea04cdf72d31bd0e33fbd264ba2 sha1 42b944d1a178ccb396f351f2f456e49503b5f8bd )
+)
+
+game (
+	name "Disney's Party (EU)"
+	description "Disney's Party (EU)"
+	rom ( name "Disney's Party (EU).iso" size 1459978240 crc 7a5c5be0 md5 780048192af3fe8368e9ce9f5ee197e7 sha1 ff81b366334a61ca4b0ff9b62abe879b6157f4a6 )
+)
+
+game (
+	name "Disney's Party (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Party (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7a5c5be0 md5 780048192af3fe8368e9ce9f5ee197e7 sha1 ff81b366334a61ca4b0ff9b62abe879b6157f4a6 )
+)
+
+game (
+	name "Disney's Party (US)"
+	description "Disney's Party (US)"
+	rom ( name "Disney's Party (US).iso" size 1459978240 crc dcaef127 md5 0b65436787bf060dc8e0333d017ee892 sha1 ce491a27669e84a106be4ad60606b339ba33a280 )
+)
+
+game (
+	name "Disney's Party (USA)"
+	description "Disney's Party (USA)"
+	rom ( name "Disney's Party (USA).iso" size 1459978240 crc dcaef127 md5 0b65436787bf060dc8e0333d017ee892 sha1 ce491a27669e84a106be4ad60606b339ba33a280 )
+)
+
+game (
+	name "Disney's Piglet's Big Game (Europe)"
+	description "Disney's Piglet's Big Game (Europe)"
+	rom ( name "Disney's Piglet's Big Game (Europe).iso" size 1459978240 crc 9945cb3d md5 6b0dd0013e48770bf3c541f9f78a7ecd sha1 f187c54cd6e7cf37770ad456e5aa7debfa26aa95 )
+)
+
+game (
+	name "Disney's Piglet's Big Game (GB)"
+	description "Disney's Piglet's Big Game (GB)"
+	rom ( name "Disney's Piglet's Big Game (GB).iso" size 1459978240 crc 9945cb3d md5 6b0dd0013e48770bf3c541f9f78a7ecd sha1 f187c54cd6e7cf37770ad456e5aa7debfa26aa95 )
+)
+
+game (
+	name "Disney's Piglet's Big Game (US)"
+	description "Disney's Piglet's Big Game (US)"
+	rom ( name "Disney's Piglet's Big Game (US).iso" size 1459978240 crc 03134803 md5 6dcc11dab3bf7fc938163af3681b510f sha1 9cd021bd95b6cc96cc4b81b506f4bf74a56914c1 )
+)
+
+game (
+	name "Disney's Piglet's Big Game (USA)"
+	description "Disney's Piglet's Big Game (USA)"
+	rom ( name "Disney's Piglet's Big Game (USA).iso" size 1459978240 crc 03134803 md5 6dcc11dab3bf7fc938163af3681b510f sha1 9cd021bd95b6cc96cc4b81b506f4bf74a56914c1 )
+)
+
+game (
+	name "Disney's PK - Out of the Shadows (US)"
+	description "Disney's PK - Out of the Shadows (US)"
+	rom ( name "Disney's PK - Out of the Shadows (US).iso" size 1459978240 crc da5f53dd md5 f0ffa80667c71ecfdc6d181bc49de7bc sha1 b67f3494c9e403382d0be3985800685e70a8f198 )
+)
+
+game (
+	name "Disney's PK - Out of the Shadows (USA) (En,Fr,De,It)"
+	description "Disney's PK - Out of the Shadows (USA) (En,Fr,De,It)"
+	rom ( name "Disney's PK - Out of the Shadows (USA) (En,Fr,De,It).iso" size 1459978240 crc da5f53dd md5 f0ffa80667c71ecfdc6d181bc49de7bc sha1 b67f3494c9e403382d0be3985800685e70a8f198 )
+)
+
+game (
+	name "Disney's Tarzan - Freeride (EU)"
+	description "Disney's Tarzan - Freeride (EU)"
+	rom ( name "Disney's Tarzan - Freeride (EU).iso" size 1459978240 crc 251ad1e8 md5 fbd0cd21a89fde6338cef789c9dab039 sha1 42efd57c2961c5dce5cd9139103168ee15f866c8 )
+)
+
+game (
+	name "Disney's Tarzan - Freeride (Europe) (En,Fr,De,Es,It)"
+	description "Disney's Tarzan - Freeride (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney's Tarzan - Freeride (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 251ad1e8 md5 fbd0cd21a89fde6338cef789c9dab039 sha1 42efd57c2961c5dce5cd9139103168ee15f866c8 )
+)
+
+game (
+	name "Disney's Tarzan - Untamed (US)"
+	description "Disney's Tarzan - Untamed (US)"
+	rom ( name "Disney's Tarzan - Untamed (US).iso" size 1459978240 crc ef54571a md5 b39c6f3e9c0613b3de67344e98a820be sha1 df981e1ccb8fe6bde8991817dbfda4e788e7e8ee )
+)
+
+game (
+	name "Disney's Tarzan - Untamed (USA) (En,Fr)"
+	description "Disney's Tarzan - Untamed (USA) (En,Fr)"
+	rom ( name "Disney's Tarzan - Untamed (USA) (En,Fr).iso" size 1459978240 crc ef54571a md5 b39c6f3e9c0613b3de67344e98a820be sha1 df981e1ccb8fe6bde8991817dbfda4e788e7e8ee )
+)
+
+game (
+	name "Disney's The Haunted Mansion (US)"
+	description "Disney's The Haunted Mansion (US)"
+	rom ( name "Disney's The Haunted Mansion (US).iso" size 1459978240 crc 457b6b08 md5 2082f0d43283addaa4c7cb4fa22aed6f sha1 9e0f4693146295d3705745ebab25354ce6dd9244 )
+)
+
+game (
+	name "Disney's The Haunted Mansion (USA)"
+	description "Disney's The Haunted Mansion (USA)"
+	rom ( name "Disney's The Haunted Mansion (USA).iso" size 1459978240 crc 457b6b08 md5 2082f0d43283addaa4c7cb4fa22aed6f sha1 9e0f4693146295d3705745ebab25354ce6dd9244 )
+)
+
+game (
+	name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (EU)"
+	description "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (EU)"
+	rom ( name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (EU).iso" size 1459978240 crc 27252f80 md5 6eb08cd7bacdcdba5a44cf44a1255b88 sha1 17c2c749dc603a933252c129387339ba5b715a69 )
+)
+
+game (
+	name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 27252f80 md5 6eb08cd7bacdcdba5a44cf44a1255b88 sha1 17c2c749dc603a933252c129387339ba5b715a69 )
+)
+
+game (
+	name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (US)"
+	description "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (US)"
+	rom ( name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (US).iso" size 1459978240 crc 87234a2b md5 0d256b70d7223dd1608f3706169631a4 sha1 73b2a2c2796faaef5370dff8a8646a14f757b699 )
+)
+
+game (
+	name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (USA) (En,Fr,Es)"
+	description "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (USA) (En,Fr,Es)"
+	rom ( name "Disney's Winnie the Pooh's Rumbly Tumbly Adventure (USA) (En,Fr,Es).iso" size 1459978240 crc 87234a2b md5 0d256b70d7223dd1608f3706169631a4 sha1 73b2a2c2796faaef5370dff8a8646a14f757b699 )
+)
+
+game (
+	name "Disneys Ferkels grosses Abenteuer-Spiel (DE)"
+	description "Disneys Ferkels grosses Abenteuer-Spiel (DE)"
+	rom ( name "Disneys Ferkels grosses Abenteuer-Spiel (DE).iso" size 1459978240 crc 6c4440fb md5 0e343628722205209b960cfb262c88b8 sha1 45611a2146cb1ae983bdb054afca87df9f2ede43 )
+)
+
+game (
+	name "Disneys Ferkels grosses Abenteuer-Spiel (Germany)"
+	description "Disneys Ferkels grosses Abenteuer-Spiel (Germany)"
+	rom ( name "Disneys Ferkels grosses Abenteuer-Spiel (Germany).iso" size 1459978240 crc 6c4440fb md5 0e343628722205209b960cfb262c88b8 sha1 45611a2146cb1ae983bdb054afca87df9f2ede43 )
+)
+
+game (
+	name "Disneys Himmel und Huhn (DE)"
+	description "Disneys Himmel und Huhn (DE)"
+	rom ( name "Disneys Himmel und Huhn (DE).iso" size 1459978240 crc 2d91c0d7 md5 01dd787ce08884591bcba4aa8f45fd86 sha1 a66950d0764c84f82f08d0f6169120c0da999280 )
+)
+
+game (
+	name "Disneys Himmel und Huhn (Germany)"
+	description "Disneys Himmel und Huhn (Germany)"
+	rom ( name "Disneys Himmel und Huhn (Germany).iso" size 1459978240 crc 2d91c0d7 md5 01dd787ce08884591bcba4aa8f45fd86 sha1 a66950d0764c84f82f08d0f6169120c0da999280 )
+)
+
+game (
+	name "Dokapon DX - Wataru Sekai wa Oni Darake (Japan)"
+	description "Dokapon DX - Wataru Sekai wa Oni Darake (Japan)"
+	rom ( name "Dokapon DX - Wataru Sekai wa Oni Darake (Japan).iso" size 1459978240 crc 96804941 md5 1cde120473a6c1ae54c7fde9164322b8 sha1 a0050fdf2a11c959f37a4432f985b8198487ea31 )
+)
+
+game (
+	name "Dokapon DX - Wataru Sekai wa Oni Darake (JP) - dokaponDX+wataruShi Jie haonidarake"
+	description "Dokapon DX - Wataru Sekai wa Oni Darake (JP) - dokaponDX+wataruShi Jie haonidarake"
+	rom ( name "Dokapon DX - Wataru Sekai wa Oni Darake (JP).iso" size 1459978240 crc 96804941 md5 1cde120473a6c1ae54c7fde9164322b8 sha1 a0050fdf2a11c959f37a4432f985b8198487ea31 )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (EU)"
+	description "Donkey Kong Jungle Beat (EU)"
+	rom ( name "Donkey Kong Jungle Beat (EU).iso" size 1459978240 crc 1d591587 md5 c1cdfec5befcbf7b08302b363b8a442a sha1 37352289d94159c440cafe2a68644c84e6669098 )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (Europe) (En,Fr,De,Es,It)"
+	description "Donkey Kong Jungle Beat (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Donkey Kong Jungle Beat (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1d591587 md5 c1cdfec5befcbf7b08302b363b8a442a sha1 37352289d94159c440cafe2a68644c84e6669098 )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (Japan)"
+	description "Donkey Kong Jungle Beat (Japan)"
+	rom ( name "Donkey Kong Jungle Beat (Japan).iso" size 1459978240 crc 40c1c2d2 md5 c73781d0db509a8c91c034c8d843d6b2 sha1 0a580d3a0c4fbae0f258b0741e25fc3ee6ae5f5a )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (JP) - donkikongu+ziyangurubito"
+	description "Donkey Kong Jungle Beat (JP) - donkikongu+ziyangurubito"
+	rom ( name "Donkey Kong Jungle Beat (JP).iso" size 1459978240 crc 40c1c2d2 md5 c73781d0db509a8c91c034c8d843d6b2 sha1 0a580d3a0c4fbae0f258b0741e25fc3ee6ae5f5a )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (US)"
+	description "Donkey Kong Jungle Beat (US)"
+	rom ( name "Donkey Kong Jungle Beat (US).iso" size 1459978240 crc f2a9e980 md5 ba18c0991c45cb54fa38e2e5916fca60 sha1 b89828458ac16c887678d1f9ad109be3c8af7498 )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (USA)"
+	description "Donkey Kong Jungle Beat (USA)"
+	rom ( name "Donkey Kong Jungle Beat (USA).iso" size 1459978240 crc f2a9e980 md5 ba18c0991c45cb54fa38e2e5916fca60 sha1 b89828458ac16c887678d1f9ad109be3c8af7498 )
+)
+
+game (
+	name "Donkey Konga (EU)"
+	description "Donkey Konga (EU)"
+	rom ( name "Donkey Konga (EU).iso" size 1459978240 crc 16342fb3 md5 7d302c00610d347b56cd4ac7d0a03c48 sha1 bf94c187ad0a57d4339885e218a302365d4a453a )
+)
+
+game (
+	name "Donkey Konga (Europe) (En,Fr,De,Es,It)"
+	description "Donkey Konga (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Donkey Konga (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 16342fb3 md5 7d302c00610d347b56cd4ac7d0a03c48 sha1 bf94c187ad0a57d4339885e218a302365d4a453a )
+)
+
+game (
+	name "Donkey Konga (Japan)"
+	description "Donkey Konga (Japan)"
+	rom ( name "Donkey Konga (Japan).iso" size 1459978240 crc 9d8c527b md5 320687e475a183692c2e24b7de43efba sha1 a1c4821232355b7e1220b2dbd849df6646782c15 )
+)
+
+game (
+	name "Donkey Konga (JP) - donkikonga"
+	description "Donkey Konga (JP) - donkikonga"
+	rom ( name "Donkey Konga (JP).iso" size 1459978240 crc 9d8c527b md5 320687e475a183692c2e24b7de43efba sha1 a1c4821232355b7e1220b2dbd849df6646782c15 )
+)
+
+game (
+	name "Donkey Konga (US)"
+	description "Donkey Konga (US)"
+	rom ( name "Donkey Konga (US).iso" size 1459978240 crc 31a8ad20 md5 e5b73629e885d5bd3391f2fba3cc751c sha1 6e85c9f6d93c1ec0055e9a2ef7722d3174b398f1 )
+)
+
+game (
+	name "Donkey Konga (USA)"
+	description "Donkey Konga (USA)"
+	rom ( name "Donkey Konga (USA).iso" size 1459978240 crc 31a8ad20 md5 e5b73629e885d5bd3391f2fba3cc751c sha1 6e85c9f6d93c1ec0055e9a2ef7722d3174b398f1 )
+)
+
+game (
+	name "Donkey Konga 2 (EU)"
+	description "Donkey Konga 2 (EU)"
+	rom ( name "Donkey Konga 2 (EU).iso" size 1459978240 crc 17badc37 md5 0a7615a21f204628ad30c6b6f9a7242d sha1 e353032678e2583bd8fc80b1a2960e6d40737d3c )
+)
+
+game (
+	name "Donkey Konga 2 (Europe) (En,Fr,De,Es,It)"
+	description "Donkey Konga 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Donkey Konga 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 17badc37 md5 0a7615a21f204628ad30c6b6f9a7242d sha1 e353032678e2583bd8fc80b1a2960e6d40737d3c )
+)
+
+game (
+	name "Donkey Konga 2 (Japan)"
+	description "Donkey Konga 2 (Japan)"
+	rom ( name "Donkey Konga 2 (Japan).iso" size 1459978240 crc 83d4b6b7 md5 164e01612eb8d3adb45fbb52aec359ee sha1 14f9bb9707509ac794b35e41d352e120ec1b496e )
+)
+
+game (
+	name "Donkey Konga 2 (JP) - donkikonga2"
+	description "Donkey Konga 2 (JP) - donkikonga2"
+	rom ( name "Donkey Konga 2 (JP).iso" size 1459978240 crc 83d4b6b7 md5 164e01612eb8d3adb45fbb52aec359ee sha1 14f9bb9707509ac794b35e41d352e120ec1b496e )
+)
+
+game (
+	name "Donkey Konga 2 (US)"
+	description "Donkey Konga 2 (US)"
+	rom ( name "Donkey Konga 2 (US).iso" size 1459978240 crc 2e31a3de md5 583506969ab42c376309946ebc3f1e40 sha1 0dd09785ccf7ea60b112dcf916ff5d1fc19d9d6d )
+)
+
+game (
+	name "Donkey Konga 2 (USA)"
+	description "Donkey Konga 2 (USA)"
+	rom ( name "Donkey Konga 2 (USA).iso" size 1459978240 crc 2e31a3de md5 583506969ab42c376309946ebc3f1e40 sha1 0dd09785ccf7ea60b112dcf916ff5d1fc19d9d6d )
+)
+
+game (
+	name "Donkey Konga 3 (Japan)"
+	description "Donkey Konga 3 (Japan)"
+	rom ( name "Donkey Konga 3 (Japan).iso" size 1459978240 crc 27c4e790 md5 815684c4b43466b7db847b633d37ae96 sha1 877022acc53a3eb97a4290c45f69be345defa0e0 )
+)
+
+game (
+	name "Donkey Konga 3 (JP) - donkikonga3"
+	description "Donkey Konga 3 (JP) - donkikonga3"
+	rom ( name "Donkey Konga 3 (JP).iso" size 1459978240 crc 27c4e790 md5 815684c4b43466b7db847b633d37ae96 sha1 877022acc53a3eb97a4290c45f69be345defa0e0 )
+)
+
+game (
+	name "Dora the Explorer - Journey to the Purple Planet (US)"
+	description "Dora the Explorer - Journey to the Purple Planet (US)"
+	rom ( name "Dora the Explorer - Journey to the Purple Planet (US).iso" size 1459978240 crc 7c1e032a md5 b7c6d0fff5f5727a340fdf671a8cafc5 sha1 7e1212fa693e337dc509550e21b215968d81fa70 )
+)
+
+game (
+	name "Dora the Explorer - Journey to the Purple Planet (USA)"
+	description "Dora the Explorer - Journey to the Purple Planet (USA)"
+	rom ( name "Dora the Explorer - Journey to the Purple Planet (USA).iso" size 1459978240 crc 7c1e032a md5 b7c6d0fff5f5727a340fdf671a8cafc5 sha1 7e1212fa693e337dc509550e21b215968d81fa70 )
+)
+
+game (
+	name "Doraemon - Minna de Asobou! Miniland (Japan)"
+	description "Doraemon - Minna de Asobou! Miniland (Japan)"
+	rom ( name "Doraemon - Minna de Asobou! Miniland (Japan).iso" size 1459978240 crc 7a183211 md5 46298a90dcd3768f36f47c0146a498f6 sha1 7e736639d6ddcbfc91c480f7ff63e04be4931646 )
+)
+
+game (
+	name "Doraemon - Minna de Asobou! Miniland (JP) - doraemon+minnadeYou bou!minidorando"
+	description "Doraemon - Minna de Asobou! Miniland (JP) - doraemon+minnadeYou bou!minidorando"
+	rom ( name "Doraemon - Minna de Asobou! Miniland (JP).iso" size 1459978240 crc 7a183211 md5 46298a90dcd3768f36f47c0146a498f6 sha1 7e736639d6ddcbfc91c480f7ff63e04be4931646 )
+)
+
+game (
+	name "Doshin the Giant (EU)"
+	description "Doshin the Giant (EU)"
+	rom ( name "Doshin the Giant (EU).iso" size 1459978240 crc 10f7328a md5 749b736efd4b7a6c495ae543c371fb65 sha1 85aded0068de903f3727726f36c67426883e9101 )
+)
+
+game (
+	name "Doshin the Giant (Europe) (En,Fr,De,Es,It)"
+	description "Doshin the Giant (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Doshin the Giant (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 10f7328a md5 749b736efd4b7a6c495ae543c371fb65 sha1 85aded0068de903f3727726f36c67426883e9101 )
+)
+
+game (
+	name "Doubutsu Banchou (Japan)"
+	description "Doubutsu Banchou (Japan)"
+	rom ( name "Doubutsu Banchou (Japan).iso" size 1459978240 crc 865abec9 md5 e8b8813af3348a13eaf9d4e8d0c9d67c sha1 71aeec4a90c6edb79c4ca72d7fb64cbad9dcc562 )
+)
+
+game (
+	name "Doubutsu Banchou (JP) - Dong Wu Fan Chang +(dobutu+bantiyo)"
+	description "Doubutsu Banchou (JP) - Dong Wu Fan Chang +(dobutu+bantiyo)"
+	rom ( name "Doubutsu Banchou (JP).iso" size 1459978240 crc 865abec9 md5 e8b8813af3348a13eaf9d4e8d0c9d67c sha1 71aeec4a90c6edb79c4ca72d7fb64cbad9dcc562 )
+)
+
+game (
+	name "Doubutsu no Mori + (Japan)"
+	description "Doubutsu no Mori + (Japan)"
+	rom ( name "Doubutsu no Mori + (Japan).iso" size 1459978240 crc d3e6d277 md5 6bfe84e44da33fb9c329ea31a2983ec9 sha1 640687f9f4f748a83c02e0df4d37e55c403d3b7d )
+)
+
+game (
+	name "Doubutsu no Mori + (JP) - doubutunoSen +"
+	description "Doubutsu no Mori + (JP) - doubutunoSen +"
+	rom ( name "Doubutsu no Mori + (JP).iso" size 1459978240 crc d3e6d277 md5 6bfe84e44da33fb9c329ea31a2983ec9 sha1 640687f9f4f748a83c02e0df4d37e55c403d3b7d )
+)
+
+game (
+	name "Doubutsu no Mori e+ (Japan)"
+	description "Doubutsu no Mori e+ (Japan)"
+	rom ( name "Doubutsu no Mori e+ (Japan).iso" size 1459978240 crc 26621f87 md5 67e9c6d58829c7c737766fac3bbfbce2 sha1 bb70f6cd4e54649693a3e4a9c6c49bf74d25b1fe )
+)
+
+game (
+	name "Doubutsu no Mori e+ (JP) - doubutunoSen +e+"
+	description "Doubutsu no Mori e+ (JP) - doubutunoSen +e+"
+	rom ( name "Doubutsu no Mori e+ (JP).iso" size 1459978240 crc 26621f87 md5 67e9c6d58829c7c737766fac3bbfbce2 sha1 bb70f6cd4e54649693a3e4a9c6c49bf74d25b1fe )
+)
+
+game (
+	name "Dr. Muto (US)"
+	description "Dr. Muto (US)"
+	rom ( name "Dr. Muto (US).iso" size 1459978240 crc 699c292a md5 4b83818218e96dfc83c42d1d329f613c sha1 0f7e1d331d8b8c6f6c90cd6219dea3b2239bb640 )
+)
+
+game (
+	name "Dr. Muto (USA)"
+	description "Dr. Muto (USA)"
+	rom ( name "Dr. Muto (USA).iso" size 1459978240 crc 699c292a md5 4b83818218e96dfc83c42d1d329f613c sha1 0f7e1d331d8b8c6f6c90cd6219dea3b2239bb640 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai (Europe) (En,Fr,De,Es,It)"
+	description "Dragon Ball Z - Budokai (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon Ball Z - Budokai (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a4997206 md5 e71d45b8177be0ec49af721b5f1c17ce sha1 a3c82ef95802ac9c7af7d028867b1848d9ed2a65 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai (Player's Choice) (EU)"
+	description "Dragon Ball Z - Budokai (Player's Choice) (EU)"
+	rom ( name "Dragon Ball Z - Budokai (Player's Choice) (EU).iso" size 1459978240 crc a4997206 md5 e71d45b8177be0ec49af721b5f1c17ce sha1 a3c82ef95802ac9c7af7d028867b1848d9ed2a65 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai (US)"
+	description "Dragon Ball Z - Budokai (US)"
+	rom ( name "Dragon Ball Z - Budokai (US).iso" size 1459978240 crc d1cc6810 md5 4acffb854772fe3d6919519f4de4c9c9 sha1 4cc5688261a1a86b6141012af661cd2ffa88ea8a )
+)
+
+game (
+	name "Dragon Ball Z - Budokai (USA)"
+	description "Dragon Ball Z - Budokai (USA)"
+	rom ( name "Dragon Ball Z - Budokai (USA).iso" size 1459978240 crc d1cc6810 md5 4acffb854772fe3d6919519f4de4c9c9 sha1 4cc5688261a1a86b6141012af661cd2ffa88ea8a )
+)
+
+game (
+	name "Dragon Ball Z - Budokai 2 (EU)"
+	description "Dragon Ball Z - Budokai 2 (EU)"
+	rom ( name "Dragon Ball Z - Budokai 2 (EU).iso" size 1459978240 crc 764d492d md5 947d9ca0279abbe7ece8377b6e6aa4f6 sha1 0f01d6c23836ee92eb168200d2dd20225774a0b8 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai 2 (Europe) (En,Fr,De,Es,It)"
+	description "Dragon Ball Z - Budokai 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon Ball Z - Budokai 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 764d492d md5 947d9ca0279abbe7ece8377b6e6aa4f6 sha1 0f01d6c23836ee92eb168200d2dd20225774a0b8 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai 2 (US)"
+	description "Dragon Ball Z - Budokai 2 (US)"
+	rom ( name "Dragon Ball Z - Budokai 2 (US).iso" size 1459978240 crc 460f66fe md5 7aec3a61b1324cf841044c683e9d40ec sha1 cb0d8fa950245ad9e585e0289fd6244ae54122c2 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai 2 (USA)"
+	description "Dragon Ball Z - Budokai 2 (USA)"
+	rom ( name "Dragon Ball Z - Budokai 2 (USA).iso" size 1459978240 crc 460f66fe md5 7aec3a61b1324cf841044c683e9d40ec sha1 cb0d8fa950245ad9e585e0289fd6244ae54122c2 )
+)
+
+game (
+	name "Dragon Ball Z - Sagas (US)"
+	description "Dragon Ball Z - Sagas (US)"
+	rom ( name "Dragon Ball Z - Sagas (US).iso" size 1459978240 crc 5e44abc8 md5 2e92b08b0db17a913de953d9c4a44cd9 sha1 d76a242214895baf91bb1e694d3c2d9a9675a243 )
+)
+
+game (
+	name "Dragon Ball Z - Sagas (USA)"
+	description "Dragon Ball Z - Sagas (USA)"
+	rom ( name "Dragon Ball Z - Sagas (USA).iso" size 1459978240 crc 5e44abc8 md5 2e92b08b0db17a913de953d9c4a44cd9 sha1 d76a242214895baf91bb1e694d3c2d9a9675a243 )
+)
+
+game (
+	name "Dragon Ball Z (Japan)"
+	description "Dragon Ball Z (Japan)"
+	rom ( name "Dragon Ball Z (Japan).iso" size 1459978240 crc 5421b026 md5 372abf1c213e848d5cdc7d6259fb51f3 sha1 9d1bfe80a44cf4321729cfef14812294ab62baef )
+)
+
+game (
+	name "Dragon Ball Z (JP) - doragonboruZ"
+	description "Dragon Ball Z (JP) - doragonboruZ"
+	rom ( name "Dragon Ball Z (JP).iso" size 1459978240 crc 5421b026 md5 372abf1c213e848d5cdc7d6259fb51f3 sha1 9d1bfe80a44cf4321729cfef14812294ab62baef )
+)
+
+game (
+	name "Dragon Drive - D-Masters Shot (Japan)"
+	description "Dragon Drive - D-Masters Shot (Japan)"
+	rom ( name "Dragon Drive - D-Masters Shot (Japan).iso" size 1459978240 crc d8613785 md5 d8787a0d516dec5991198610e38296d7 sha1 20a2d9a8e2cfb7cc3ed97e2e4b2de45ebe81e2bd )
+)
+
+game (
+	name "Dragon Drive - D-Masters Shot (Japan) (Anime Disc)"
+	description "Dragon Drive - D-Masters Shot (Japan) (Anime Disc)"
+	rom ( name "Dragon Drive - D-Masters Shot (Japan) (Anime Disc).iso" size 1459978240 crc da779b93 md5 b7ca67e05bfa9246097cac03b41aad60 sha1 e9ecd2a7b0d92b5e72d72c24fa4671d17dd2f5be )
+)
+
+game (
+	name "Dragon Drive - D-Masters Shot (JP) - doragondoraibu+deimasutazusiyotuto"
+	description "Dragon Drive - D-Masters Shot (JP) - doragondoraibu+deimasutazusiyotuto"
+	rom ( name "Dragon Drive - D-Masters Shot (JP) - (Disc 1 of 2).iso" size 1459978240 crc d8613785 md5 d8787a0d516dec5991198610e38296d7 sha1 20a2d9a8e2cfb7cc3ed97e2e4b2de45ebe81e2bd )
+)
+
+game (
+	name "Dragon's Lair 3D - Return to the Lair (US)"
+	description "Dragon's Lair 3D - Return to the Lair (US)"
+	rom ( name "Dragon's Lair 3D - Return to the Lair (US).iso" size 1459978240 crc 605e9e95 md5 bb19ff01b83cc83084d2485234df1750 sha1 c29017a1fb9655d3f60701d19c47c4b15767ad37 )
+)
+
+game (
+	name "Dragon's Lair 3D - Return to the Lair (USA)"
+	description "Dragon's Lair 3D - Return to the Lair (USA)"
+	rom ( name "Dragon's Lair 3D - Return to the Lair (USA).iso" size 1459978240 crc 605e9e95 md5 bb19ff01b83cc83084d2485234df1750 sha1 c29017a1fb9655d3f60701d19c47c4b15767ad37 )
+)
+
+game (
+	name "Dragon's Lair 3D - Special Edition (EU)"
+	description "Dragon's Lair 3D - Special Edition (EU)"
+	rom ( name "Dragon's Lair 3D - Special Edition (EU).iso" size 1459978240 crc 6cec873a md5 f82475d96d5974b835cecdda60899d88 sha1 ed88a2aaaa441fa13f137c9750e51a22427ed84e )
+)
+
+game (
+	name "Dragon's Lair 3D - Special Edition (Europe) (En,Fr,De,Es,It)"
+	description "Dragon's Lair 3D - Special Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon's Lair 3D - Special Edition (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 6cec873a md5 f82475d96d5974b835cecdda60899d88 sha1 ed88a2aaaa441fa13f137c9750e51a22427ed84e )
+)
+
+game (
+	name "Dream Mix TV - World Fighters (Japan)"
+	description "Dream Mix TV - World Fighters (Japan)"
+	rom ( name "Dream Mix TV - World Fighters (Japan).iso" size 1459978240 crc 8583a998 md5 0b28a56610c882ae5240632e8e1fd03f sha1 44de6ebca300e9165d6d311223688908ea56ca98 )
+)
+
+game (
+	name "Dream Mix TV - World Fighters (JP) - dorimumitukusuTV+warudohuaitazu"
+	description "Dream Mix TV - World Fighters (JP) - dorimumitukusuTV+warudohuaitazu"
+	rom ( name "Dream Mix TV - World Fighters (JP).iso" size 1459978240 crc 8583a998 md5 0b28a56610c882ae5240632e8e1fd03f sha1 44de6ebca300e9165d6d311223688908ea56ca98 )
+)
+
+game (
+	name "DreamWorks & Aardman Flushed Away (EU)"
+	description "DreamWorks & Aardman Flushed Away (EU)"
+	rom ( name "DreamWorks & Aardman Flushed Away (EU).iso" size 1459978240 crc de37599d md5 5088ba0b287e37346fd75be83696c9c9 sha1 9ac4d00bd0fe6ebefba43e07672557367c511fd2 )
+)
+
+game (
+	name "DreamWorks & Aardman Flushed Away (Europe) (En,Fr,De,Es,It)"
+	description "DreamWorks & Aardman Flushed Away (Europe) (En,Fr,De,Es,It)"
+	rom ( name "DreamWorks & Aardman Flushed Away (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc de37599d md5 5088ba0b287e37346fd75be83696c9c9 sha1 9ac4d00bd0fe6ebefba43e07672557367c511fd2 )
+)
+
+game (
+	name "DreamWorks & Aardman Flushed Away (US)"
+	description "DreamWorks & Aardman Flushed Away (US)"
+	rom ( name "DreamWorks & Aardman Flushed Away (US).iso" size 1459978240 crc f8cbfb44 md5 c01549c62efa6fcd9456a20c0890fbb1 sha1 99b1a2c350fa94a38afb8d1034a6513560e05561 )
+)
+
+game (
+	name "DreamWorks & Aardman Flushed Away (USA)"
+	description "DreamWorks & Aardman Flushed Away (USA)"
+	rom ( name "DreamWorks & Aardman Flushed Away (USA).iso" size 1459978240 crc f8cbfb44 md5 c01549c62efa6fcd9456a20c0890fbb1 sha1 99b1a2c350fa94a38afb8d1034a6513560e05561 )
+)
+
+game (
+	name "DreamWorks Ab durch die Hecke (DE)"
+	description "DreamWorks Ab durch die Hecke (DE)"
+	rom ( name "DreamWorks Ab durch die Hecke (DE).iso" size 1459978240 crc 93155c68 md5 1ef0bad369dd2daa37ff9c1c4de438c1 sha1 3052db1d43a841b2fe33e80e4f608629b52e82bc )
+)
+
+game (
+	name "DreamWorks Ab durch die Hecke (Germany)"
+	description "DreamWorks Ab durch die Hecke (Germany)"
+	rom ( name "DreamWorks Ab durch die Hecke (Germany).iso" size 1459978240 crc 93155c68 md5 1ef0bad369dd2daa37ff9c1c4de438c1 sha1 3052db1d43a841b2fe33e80e4f608629b52e82bc )
+)
+
+game (
+	name "DreamWorks Gang de requins (FR)"
+	description "DreamWorks Gang de requins (FR)"
+	rom ( name "DreamWorks Gang de requins (FR).iso" size 1459978240 crc af6c0a7b md5 6e52d177812b826d342d197500704af4 sha1 187d69c4832a54b8a8dd197cb2903c7f02c1ad87 )
+)
+
+game (
+	name "DreamWorks Gang de Requins (France)"
+	description "DreamWorks Gang de Requins (France)"
+	rom ( name "DreamWorks Gang de Requins (France).iso" size 1459978240 crc af6c0a7b md5 6e52d177812b826d342d197500704af4 sha1 187d69c4832a54b8a8dd197cb2903c7f02c1ad87 )
+)
+
+game (
+	name "DreamWorks Grosse Haie - Kleine Fische (DE)"
+	description "DreamWorks Grosse Haie - Kleine Fische (DE)"
+	rom ( name "DreamWorks Grosse Haie - Kleine Fische (DE).iso" size 1459978240 crc 6a893530 md5 09b59ad1d5a804c8a8b86dcfc1ca9aa5 sha1 b79c530779a194bc3b9dc7dddec35bd95f46c7b3 )
+)
+
+game (
+	name "DreamWorks Grosse Haie - Kleine Fische (Germany)"
+	description "DreamWorks Grosse Haie - Kleine Fische (Germany)"
+	rom ( name "DreamWorks Grosse Haie - Kleine Fische (Germany).iso" size 1459978240 crc 6a893530 md5 09b59ad1d5a804c8a8b86dcfc1ca9aa5 sha1 b79c530779a194bc3b9dc7dddec35bd95f46c7b3 )
+)
+
+game (
+	name "DreamWorks Madagascar (ES)"
+	description "DreamWorks Madagascar (ES)"
+	rom ( name "DreamWorks Madagascar (ES).iso" size 1459978240 crc 36410399 md5 fb6d12be48aa0cab56dc48875b8d2edc sha1 da9677b1a35862a4c43c4252873bf3bec366031c )
+)
+
+game (
+	name "DreamWorks Madagascar (EU)"
+	description "DreamWorks Madagascar (EU)"
+	rom ( name "DreamWorks Madagascar (EU).iso" size 1459978240 crc e89d6c09 md5 4830cdfc264ebf2d30164a4f400834f1 sha1 82f4f6ae957372078fddec5712ad840d4a78a2df )
+)
+
+game (
+	name "DreamWorks Madagascar (Europe) (Fr,De)"
+	description "DreamWorks Madagascar (Europe) (Fr,De)"
+	rom ( name "DreamWorks Madagascar (Europe) (Fr,De).iso" size 1459978240 crc e89d6c09 md5 4830cdfc264ebf2d30164a4f400834f1 sha1 82f4f6ae957372078fddec5712ad840d4a78a2df )
+)
+
+game (
+	name "DreamWorks Madagascar (GB)"
+	description "DreamWorks Madagascar (GB)"
+	rom ( name "DreamWorks Madagascar (GB).iso" size 1459978240 crc 41f0cb68 md5 aa8083445dfd0d15223a98119f3c33a3 sha1 2b2ce79375bff7f2a8dfae09574febab36560f75 )
+)
+
+game (
+	name "DreamWorks Madagascar (IT)"
+	description "DreamWorks Madagascar (IT)"
+	rom ( name "DreamWorks Madagascar (IT).iso" size 1459978240 crc 47252652 md5 71fa26bbe58f927f04cf5e98e3d02a43 sha1 d0cbf0240600543b987188c14b306192278e039a )
+)
+
+game (
+	name "DreamWorks Madagascar (Italy)"
+	description "DreamWorks Madagascar (Italy)"
+	rom ( name "DreamWorks Madagascar (Italy).iso" size 1459978240 crc 47252652 md5 71fa26bbe58f927f04cf5e98e3d02a43 sha1 d0cbf0240600543b987188c14b306192278e039a )
+)
+
+game (
+	name "DreamWorks Madagascar (Japan)"
+	description "DreamWorks Madagascar (Japan)"
+	rom ( name "DreamWorks Madagascar (Japan).iso" size 1459978240 crc 52de05ed md5 cb03aca18294d3baaf00043a544a3e4d sha1 efc9d4a9a45a4745b4b7381402ecf7bc5c8043ee )
+)
+
+game (
+	name "DreamWorks Madagascar (JP) - madagasukaru"
+	description "DreamWorks Madagascar (JP) - madagasukaru"
+	rom ( name "DreamWorks Madagascar (JP).iso" size 1459978240 crc 52de05ed md5 cb03aca18294d3baaf00043a544a3e4d sha1 efc9d4a9a45a4745b4b7381402ecf7bc5c8043ee )
+)
+
+game (
+	name "DreamWorks Madagascar (Netherlands)"
+	description "DreamWorks Madagascar (Netherlands)"
+	rom ( name "DreamWorks Madagascar (Netherlands).iso" size 1459978240 crc 3425434f md5 503db655f404b2855f923907f95b3b41 sha1 65c278aabc22b47dee59a2c192b14ed8798f0356 )
+)
+
+game (
+	name "DreamWorks Madagascar (NL)"
+	description "DreamWorks Madagascar (NL)"
+	rom ( name "DreamWorks Madagascar (NL).iso" size 1459978240 crc 3425434f md5 503db655f404b2855f923907f95b3b41 sha1 65c278aabc22b47dee59a2c192b14ed8798f0356 )
+)
+
+game (
+	name "DreamWorks Madagascar (Spain)"
+	description "DreamWorks Madagascar (Spain)"
+	rom ( name "DreamWorks Madagascar (Spain).iso" size 1459978240 crc 36410399 md5 fb6d12be48aa0cab56dc48875b8d2edc sha1 da9677b1a35862a4c43c4252873bf3bec366031c )
+)
+
+game (
+	name "DreamWorks Madagascar (UK)"
+	description "DreamWorks Madagascar (UK)"
+	rom ( name "DreamWorks Madagascar (UK).iso" size 1459978240 crc 41f0cb68 md5 aa8083445dfd0d15223a98119f3c33a3 sha1 2b2ce79375bff7f2a8dfae09574febab36560f75 )
+)
+
+game (
+	name "DreamWorks Madagascar (US)"
+	description "DreamWorks Madagascar (US)"
+	rom ( name "DreamWorks Madagascar (US).iso" size 1459978240 crc dec444a2 md5 16326b19640fc05c795c0a03956b0993 sha1 22b1d89787c64f867916dc25eba13c67ac0574e0 )
+)
+
+game (
+	name "DreamWorks Madagascar (USA)"
+	description "DreamWorks Madagascar (USA)"
+	rom ( name "DreamWorks Madagascar (USA).iso" size 1459978240 crc dec444a2 md5 16326b19640fc05c795c0a03956b0993 sha1 22b1d89787c64f867916dc25eba13c67ac0574e0 )
+)
+
+game (
+	name "DreamWorks Nos Voisins, les Hommes (FR)"
+	description "DreamWorks Nos Voisins, les Hommes (FR)"
+	rom ( name "DreamWorks Nos Voisins, les Hommes (FR).iso" size 1459978240 crc 59b8bd1b md5 c258686b55940e65d82357bde87a5363 sha1 44c3a7f0ae691913285adfed9ce60b86066d9ae2 )
+)
+
+game (
+	name "DreamWorks Nos Voisins, les Hommes (France)"
+	description "DreamWorks Nos Voisins, les Hommes (France)"
+	rom ( name "DreamWorks Nos Voisins, les Hommes (France).iso" size 1459978240 crc 59b8bd1b md5 c258686b55940e65d82357bde87a5363 sha1 44c3a7f0ae691913285adfed9ce60b86066d9ae2 )
+)
+
+game (
+	name "DreamWorks Over the Hedge (Europe)"
+	description "DreamWorks Over the Hedge (Europe)"
+	rom ( name "DreamWorks Over the Hedge (Europe).iso" size 1459978240 crc 03d01b8f md5 524d5501130ebe3c53e43334b75d358b sha1 882ed2d3afa4bbed53522e449c8df02597543d12 )
+)
+
+game (
+	name "DreamWorks Over the Hedge (GB)"
+	description "DreamWorks Over the Hedge (GB)"
+	rom ( name "DreamWorks Over the Hedge (GB).iso" size 1459978240 crc 03d01b8f md5 524d5501130ebe3c53e43334b75d358b sha1 882ed2d3afa4bbed53522e449c8df02597543d12 )
+)
+
+game (
+	name "DreamWorks Over the Hedge (US)"
+	description "DreamWorks Over the Hedge (US)"
+	rom ( name "DreamWorks Over the Hedge (US).iso" size 1459978240 crc e13de317 md5 a877e9b332dd19ac48e13f465740c595 sha1 86d88cf36a749443415e3a4e2efcca3cfb6b0202 )
+)
+
+game (
+	name "DreamWorks Over the Hedge (USA)"
+	description "DreamWorks Over the Hedge (USA)"
+	rom ( name "DreamWorks Over the Hedge (USA).iso" size 1459978240 crc e13de317 md5 a877e9b332dd19ac48e13f465740c595 sha1 86d88cf36a749443415e3a4e2efcca3cfb6b0202 )
+)
+
+game (
+	name "DreamWorks Shark Tale (Europe)"
+	description "DreamWorks Shark Tale (Europe)"
+	rom ( name "DreamWorks Shark Tale (Europe).iso" size 1459978240 crc 6ba364c4 md5 b2a68f49a30b00ec46c23dd4979a30e8 sha1 48bf5f1dcc6b21cb1aae0cf48a23dcc65660a1aa )
+)
+
+game (
+	name "DreamWorks Shark Tale (GB)"
+	description "DreamWorks Shark Tale (GB)"
+	rom ( name "DreamWorks Shark Tale (GB).iso" size 1459978240 crc 6ba364c4 md5 b2a68f49a30b00ec46c23dd4979a30e8 sha1 48bf5f1dcc6b21cb1aae0cf48a23dcc65660a1aa )
+)
+
+game (
+	name "DreamWorks Shark Tale (IT)"
+	description "DreamWorks Shark Tale (IT)"
+	rom ( name "DreamWorks Shark Tale (IT).iso" size 1459978240 crc 459e3eb9 md5 54a3acaf1de5bb99e0108e69f59450f6 sha1 682f635ef5f1c32a78b534851c8fe930f8b3f44c )
+)
+
+game (
+	name "DreamWorks Shark Tale (Italy)"
+	description "DreamWorks Shark Tale (Italy)"
+	rom ( name "DreamWorks Shark Tale (Italy).iso" size 1459978240 crc 459e3eb9 md5 54a3acaf1de5bb99e0108e69f59450f6 sha1 682f635ef5f1c32a78b534851c8fe930f8b3f44c )
+)
+
+game (
+	name "DreamWorks Shark Tale (Japan)"
+	description "DreamWorks Shark Tale (Japan)"
+	rom ( name "DreamWorks Shark Tale (Japan).iso" size 1459978240 crc 3de4f014 md5 67057116ccae845380195d03c54adb21 sha1 01a50395aac77f9009a6bad8d31fbcfd38553e33 )
+)
+
+game (
+	name "DreamWorks Shark Tale (JP) - DreamWorks+siyakuteiru"
+	description "DreamWorks Shark Tale (JP) - DreamWorks+siyakuteiru"
+	rom ( name "DreamWorks Shark Tale (JP).iso" size 1459978240 crc 3de4f014 md5 67057116ccae845380195d03c54adb21 sha1 01a50395aac77f9009a6bad8d31fbcfd38553e33 )
+)
+
+game (
+	name "DreamWorks Shark Tale (US)"
+	description "DreamWorks Shark Tale (US)"
+	rom ( name "DreamWorks Shark Tale (US).iso" size 1459978240 crc 968600d1 md5 e0d52f0670ae6b800dc522a8d66c097d sha1 fc1eceb0161cfedd5693dc063090315ccd9e3bbf )
+)
+
+game (
+	name "DreamWorks Shark Tale (USA)"
+	description "DreamWorks Shark Tale (USA)"
+	rom ( name "DreamWorks Shark Tale (USA).iso" size 1459978240 crc 968600d1 md5 e0d52f0670ae6b800dc522a8d66c097d sha1 fc1eceb0161cfedd5693dc063090315ccd9e3bbf )
+)
+
+game (
+	name "DreamWorks Shrek - Smash n' Crash Racing (EU)"
+	description "DreamWorks Shrek - Smash n' Crash Racing (EU)"
+	rom ( name "DreamWorks Shrek - Smash n' Crash Racing (EU).iso" size 1459978240 crc 13005004 md5 56f8c5dc4096396adb6cd7e5ab8ba5aa sha1 ba32fea4b7bcbd5d467b8d3a9f095c833e6e4434 )
+)
+
+game (
+	name "DreamWorks Shrek - Smash n' Crash Racing (Europe) (En,Fr,De)"
+	description "DreamWorks Shrek - Smash n' Crash Racing (Europe) (En,Fr,De)"
+	rom ( name "DreamWorks Shrek - Smash n' Crash Racing (Europe) (En,Fr,De).iso" size 1459978240 crc 13005004 md5 56f8c5dc4096396adb6cd7e5ab8ba5aa sha1 ba32fea4b7bcbd5d467b8d3a9f095c833e6e4434 )
+)
+
+game (
+	name "DreamWorks Shrek - Smash n' Crash Racing (US)"
+	description "DreamWorks Shrek - Smash n' Crash Racing (US)"
+	rom ( name "DreamWorks Shrek - Smash n' Crash Racing (US).iso" size 1459978240 crc 5bc554bd md5 110f717a1a6229a530005ad9cd26253b sha1 7293eac13c897f95c830142b96631af5c8788496 )
+)
+
+game (
+	name "DreamWorks Shrek - Smash n' Crash Racing (USA)"
+	description "DreamWorks Shrek - Smash n' Crash Racing (USA)"
+	rom ( name "DreamWorks Shrek - Smash n' Crash Racing (USA).iso" size 1459978240 crc 5bc554bd md5 110f717a1a6229a530005ad9cd26253b sha1 7293eac13c897f95c830142b96631af5c8788496 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (DE)"
+	description "DreamWorks Shrek - SuperSlam (DE)"
+	rom ( name "DreamWorks Shrek - SuperSlam (DE).iso" size 1459978240 crc ba48943a md5 8ed80aa6e2410b595ca2e8884b32db3b sha1 0b0954030c54195a061d84194229fed2f2932603 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (EU)"
+	description "DreamWorks Shrek - SuperSlam (EU)"
+	rom ( name "DreamWorks Shrek - SuperSlam (EU).iso" size 1459978240 crc 2bd507c3 md5 ebba8aebda5b68c144c14800ecc3343b sha1 8bdd081ca2c49254b45eb615eeefe0eabb19a281 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (Europe)"
+	description "DreamWorks Shrek - SuperSlam (Europe)"
+	rom ( name "DreamWorks Shrek - SuperSlam (Europe).iso" size 1459978240 crc a5b27ee8 md5 0b82f430bcf48b84819e2e4b676444d3 sha1 387ce067f0dcbc8bde76d1a0c4a9f60b39fd2d69 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (Europe) (En,Fr,Es,It)"
+	description "DreamWorks Shrek - SuperSlam (Europe) (En,Fr,Es,It)"
+	rom ( name "DreamWorks Shrek - SuperSlam (Europe) (En,Fr,Es,It).iso" size 1459978240 crc 2bd507c3 md5 ebba8aebda5b68c144c14800ecc3343b sha1 8bdd081ca2c49254b45eb615eeefe0eabb19a281 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (GB)"
+	description "DreamWorks Shrek - SuperSlam (GB)"
+	rom ( name "DreamWorks Shrek - SuperSlam (GB).iso" size 1459978240 crc a5b27ee8 md5 0b82f430bcf48b84819e2e4b676444d3 sha1 387ce067f0dcbc8bde76d1a0c4a9f60b39fd2d69 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (Germany)"
+	description "DreamWorks Shrek - SuperSlam (Germany)"
+	rom ( name "DreamWorks Shrek - SuperSlam (Germany).iso" size 1459978240 crc ba48943a md5 8ed80aa6e2410b595ca2e8884b32db3b sha1 0b0954030c54195a061d84194229fed2f2932603 )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (US)"
+	description "DreamWorks Shrek - SuperSlam (US)"
+	rom ( name "DreamWorks Shrek - SuperSlam (US).iso" size 1459978240 crc ce6e3f54 md5 54da19f15ce0fc1f6bad3587e5144e6d sha1 6d3f4ec581595dc401d901d15e052068ede0ff7d )
+)
+
+game (
+	name "DreamWorks Shrek - SuperSlam (USA)"
+	description "DreamWorks Shrek - SuperSlam (USA)"
+	rom ( name "DreamWorks Shrek - SuperSlam (USA).iso" size 1459978240 crc ce6e3f54 md5 54da19f15ce0fc1f6bad3587e5144e6d sha1 6d3f4ec581595dc401d901d15e052068ede0ff7d )
+)
+
+game (
+	name "Driven (EU)"
+	description "Driven (EU)"
+	rom ( name "Driven (EU).iso" size 1459978240 crc 10aa713d md5 8e4937d335b908efbb93c71275fab92a sha1 2f100f4baa7430e72f704e9d144929fd531c848e )
+)
+
+game (
+	name "Driven (Europe) (En,Fr,De,Es,It)"
+	description "Driven (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Driven (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 10aa713d md5 8e4937d335b908efbb93c71275fab92a sha1 2f100f4baa7430e72f704e9d144929fd531c848e )
+)
+
+game (
+	name "Driven (US)"
+	description "Driven (US)"
+	rom ( name "Driven (US).iso" size 1459978240 crc d3ecbac7 md5 9ac406c4292ed67dbeee284acb1be532 sha1 596f617f8f119c3a3305244aa3a9588adce05992 )
+)
+
+game (
+	name "Driven (USA) (En,Fr,De,Es,It)"
+	description "Driven (USA) (En,Fr,De,Es,It)"
+	rom ( name "Driven (USA) (En,Fr,De,Es,It).iso" size 1459978240 crc d3ecbac7 md5 9ac406c4292ed67dbeee284acb1be532 sha1 596f617f8f119c3a3305244aa3a9588adce05992 )
+)
+
+game (
+	name "Drome Racers (EU)"
+	description "Drome Racers (EU)"
+	rom ( name "Drome Racers (EU).iso" size 1459978240 crc c3ffaf21 md5 403ad0b695ab4b5d88e051174e083c21 sha1 8ec3e3756609ba800b438cac960f830f0438216d )
+)
+
+game (
+	name "Drome Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	description "Drome Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	rom ( name "Drome Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).iso" size 1459978240 crc c3ffaf21 md5 403ad0b695ab4b5d88e051174e083c21 sha1 8ec3e3756609ba800b438cac960f830f0438216d )
+)
+
+game (
+	name "Drome Racers (US)"
+	description "Drome Racers (US)"
+	rom ( name "Drome Racers (US).iso" size 1459978240 crc 85b18fcb md5 41a13138f87af8d1ff3a943a4f724e6f sha1 0c5827ee8cb4dc2d9b3af0552a6fedceba889d35 )
+)
+
+game (
+	name "Drome Racers (USA)"
+	description "Drome Racers (USA)"
+	rom ( name "Drome Racers (USA).iso" size 1459978240 crc 85b18fcb md5 41a13138f87af8d1ff3a943a4f724e6f sha1 0c5827ee8cb4dc2d9b3af0552a6fedceba889d35 )
+)
+
+game (
+	name "Duel Masters Nettou! Battle Arena (Japan)"
+	description "Duel Masters Nettou! Battle Arena (Japan)"
+	rom ( name "Duel Masters Nettou! Battle Arena (Japan).iso" size 1459978240 crc 083490ef md5 a90d05d08e14a4c8fbdd7dd2a9866177 sha1 2719818be042f40578249b7cb3c03f54f244de80 )
+)
+
+game (
+	name "Duel Masters Nettou! Battle Arena (JP) - deyuerumasutazu+Re Dou !+batoruarina"
+	description "Duel Masters Nettou! Battle Arena (JP) - deyuerumasutazu+Re Dou !+batoruarina"
+	rom ( name "Duel Masters Nettou! Battle Arena (JP).iso" size 1459978240 crc 083490ef md5 a90d05d08e14a4c8fbdd7dd2a9866177 sha1 2719818be042f40578249b7cb3c03f54f244de80 )
+)
+
+game (
+	name "Ed, Edd n Eddy - The Mis-Edventures (US)"
+	description "Ed, Edd n Eddy - The Mis-Edventures (US)"
+	rom ( name "Ed, Edd n Eddy - The Mis-Edventures (US).iso" size 1459978240 crc f0af8dc3 md5 31256eb96d1caa1f28e7e4579b4f4ce9 sha1 a3a5f156c79a526c9bebf82e19db513bfbecd473 )
+)
+
+game (
+	name "Ed, Edd n Eddy - The Mis-Edventures (USA)"
+	description "Ed, Edd n Eddy - The Mis-Edventures (USA)"
+	rom ( name "Ed, Edd n Eddy - The Mis-Edventures (USA).iso" size 1459978240 crc f0af8dc3 md5 31256eb96d1caa1f28e7e4579b4f4ce9 sha1 a3a5f156c79a526c9bebf82e19db513bfbecd473 )
+)
+
+game (
+	name "Egg Mania - Eggstreme Madness (US)"
+	description "Egg Mania - Eggstreme Madness (US)"
+	rom ( name "Egg Mania - Eggstreme Madness (US).iso" size 1459978240 crc 7e2a4243 md5 b86592a531e6ac8062a98d2ce069a415 sha1 4bdcaaf48f11d58a833206739a65c5690ea8af51 )
+)
+
+game (
+	name "Egg Mania - Eggstreme Madness (USA)"
+	description "Egg Mania - Eggstreme Madness (USA)"
+	rom ( name "Egg Mania - Eggstreme Madness (USA).iso" size 1459978240 crc 7e2a4243 md5 b86592a531e6ac8062a98d2ce069a415 sha1 4bdcaaf48f11d58a833206739a65c5690ea8af51 )
+)
+
+game (
+	name "Eggo Mania (EU)"
+	description "Eggo Mania (EU)"
+	rom ( name "Eggo Mania (EU).iso" size 1459978240 crc df626911 md5 2778e6decba24f5b14468088c751dc6b sha1 c11b60a9e33245e367ee7ba6fb858a8b22a14ede )
+)
+
+game (
+	name "Eggo Mania (Europe) (En,Fr,De)"
+	description "Eggo Mania (Europe) (En,Fr,De)"
+	rom ( name "Eggo Mania (Europe) (En,Fr,De).iso" size 1459978240 crc df626911 md5 2778e6decba24f5b14468088c751dc6b sha1 c11b60a9e33245e367ee7ba6fb858a8b22a14ede )
+)
+
+game (
+	name "Eisei Meijin VI (Japan)"
+	description "Eisei Meijin VI (Japan)"
+	rom ( name "Eisei Meijin VI (Japan).iso" size 1459978240 crc 2e9c1e53 md5 2d0f1c6490c1c1ed6911c644ff7956ed sha1 89418f55891cec5dc09f5adc36918db5788d4947 )
+)
+
+game (
+	name "Eisei Meijin VI (JP) - Yong Shi Ming Ren VI"
+	description "Eisei Meijin VI (JP) - Yong Shi Ming Ren VI"
+	rom ( name "Eisei Meijin VI (JP).iso" size 1459978240 crc 2e9c1e53 md5 2d0f1c6490c1c1ed6911c644ff7956ed sha1 89418f55891cec5dc09f5adc36918db5788d4947 )
+)
+
+game (
+	name "Enter the Matrix (EU)"
+	description "Enter the Matrix (EU)"
+	rom ( name "Enter the Matrix (EU) - (Disc 1 of 2).iso" size 1459978240 crc 7f8c8d91 md5 632b85c203fdbf2862eafe9493a4c868 sha1 c44f5042608f39f87fa3b4de753e3ea200077e55 )
+)
+
+game (
+	name "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 7f8c8d91 md5 632b85c203fdbf2862eafe9493a4c868 sha1 c44f5042608f39f87fa3b4de753e3ea200077e55 )
+)
+
+game (
+	name "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Enter the Matrix (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 6f934586 md5 9d1aa1629b83f9791bbf893662bc3250 sha1 05b85a70c1b342235b9cda4dd7f81962d69d40aa )
+)
+
+game (
+	name "Enter the Matrix (Japan) (Disc 1)"
+	description "Enter the Matrix (Japan) (Disc 1)"
+	rom ( name "Enter the Matrix (Japan) (Disc 1).iso" size 1459978240 crc 11314349 md5 f70d27e850b2fd892e73d35fbbbcf322 sha1 0ce2d432c40f2d6ec1baf10758415834c5a427de )
+)
+
+game (
+	name "Enter the Matrix (Japan) (Disc 2)"
+	description "Enter the Matrix (Japan) (Disc 2)"
+	rom ( name "Enter the Matrix (Japan) (Disc 2).iso" size 1459978240 crc 9e503207 md5 f0be79a8967bc099e6a2c2d8c98a478c sha1 a4dd0b1712d19314321672c941ec3c068a85d443 )
+)
+
+game (
+	name "Enter the Matrix (JP) - enta+za+matoritukusu"
+	description "Enter the Matrix (JP) - enta+za+matoritukusu"
+	rom ( name "Enter the Matrix (JP) - (Disc 1 of 2).iso" size 1459978240 crc 11314349 md5 f70d27e850b2fd892e73d35fbbbcf322 sha1 0ce2d432c40f2d6ec1baf10758415834c5a427de )
+)
+
+game (
+	name "Enter the Matrix (US)"
+	description "Enter the Matrix (US)"
+	rom ( name "Enter the Matrix (US) - (Disc 1 of 2).iso" size 1459978240 crc a43514dd md5 bf4942c4463bcf96c41038662608eb77 sha1 5f162a4c7d189e5ea821c2206548402692c4998a )
+)
+
+game (
+	name "Enter the Matrix (USA) (Disc 1)"
+	description "Enter the Matrix (USA) (Disc 1)"
+	rom ( name "Enter the Matrix (USA) (Disc 1).iso" size 1459978240 crc a43514dd md5 bf4942c4463bcf96c41038662608eb77 sha1 5f162a4c7d189e5ea821c2206548402692c4998a )
+)
+
+game (
+	name "Enter the Matrix (USA) (Disc 2)"
+	description "Enter the Matrix (USA) (Disc 2)"
+	rom ( name "Enter the Matrix (USA) (Disc 2).iso" size 1459978240 crc 65531d54 md5 f9f269c53b1f0c60d970667d4209acd9 sha1 947fd35cac720507d85c32c5a2017d8ba5352d9c )
+)
+
+game (
+	name "ESPN International Winter Sports (EU)"
+	description "ESPN International Winter Sports (EU)"
+	rom ( name "ESPN International Winter Sports (EU).iso" size 1459978240 crc 6709e88e md5 e04c90b9debf16a07e8c7b026cf0b3ba sha1 09755604b9360f5133afc4c8d995b8c22483614f )
+)
+
+game (
+	name "ESPN International Winter Sports (Europe) (En,Fr,De,It)"
+	description "ESPN International Winter Sports (Europe) (En,Fr,De,It)"
+	rom ( name "ESPN International Winter Sports (Europe) (En,Fr,De,It).iso" size 1459978240 crc 6709e88e md5 e04c90b9debf16a07e8c7b026cf0b3ba sha1 09755604b9360f5133afc4c8d995b8c22483614f )
+)
+
+game (
+	name "ESPN International Winter Sports 2002 (US)"
+	description "ESPN International Winter Sports 2002 (US)"
+	rom ( name "ESPN International Winter Sports 2002 (US).iso" size 1459978240 crc 6f3bc227 md5 165bc0683c3bb5044016f149dc17b23a sha1 22a9dd9b0480e9926b488dd98f3d0b7ec9aaac61 )
+)
+
+game (
+	name "ESPN International Winter Sports 2002 (USA)"
+	description "ESPN International Winter Sports 2002 (USA)"
+	rom ( name "ESPN International Winter Sports 2002 (USA).iso" size 1459978240 crc 6f3bc227 md5 165bc0683c3bb5044016f149dc17b23a sha1 22a9dd9b0480e9926b488dd98f3d0b7ec9aaac61 )
+)
+
+game (
+	name "ESPN MLS ExtraTime 2002 (US)"
+	description "ESPN MLS ExtraTime 2002 (US)"
+	rom ( name "ESPN MLS ExtraTime 2002 (US).iso" size 1459978240 crc d16f9ed3 md5 9b09ba9faf2739e0cb6a0b6d6e2ab135 sha1 b0f76a6236acb9b8bc24ae0d3c4b4a7469e3bbf7 )
+)
+
+game (
+	name "ESPN MLS ExtraTime 2002 (USA)"
+	description "ESPN MLS ExtraTime 2002 (USA)"
+	rom ( name "ESPN MLS ExtraTime 2002 (USA).iso" size 1459978240 crc d16f9ed3 md5 9b09ba9faf2739e0cb6a0b6d6e2ab135 sha1 b0f76a6236acb9b8bc24ae0d3c4b4a7469e3bbf7 )
+)
+
+game (
+	name "Eternal Arcadia Legends (Japan)"
+	description "Eternal Arcadia Legends (Japan)"
+	rom ( name "Eternal Arcadia Legends (Japan).iso" size 1459978240 crc 3da0e910 md5 325f0955cfd8324b96ef56ddeb82f29f sha1 bb06f5ba75a8e928a62f7b01c2b375b7e2693309 )
+)
+
+game (
+	name "Eternal Arcadia Legends (JP) - etanaruarukadeia+reziendo"
+	description "Eternal Arcadia Legends (JP) - etanaruarukadeia+reziendo"
+	rom ( name "Eternal Arcadia Legends (JP).iso" size 1459978240 crc 3da0e910 md5 325f0955cfd8324b96ef56ddeb82f29f sha1 bb06f5ba75a8e928a62f7b01c2b375b7e2693309 )
+)
+
+game (
+	name "Eternal Darkness - Manekareta 13-nin (Japan)"
+	description "Eternal Darkness - Manekareta 13-nin (Japan)"
+	rom ( name "Eternal Darkness - Manekareta 13-nin (Japan).iso" size 1459978240 crc af4d0e9e md5 ae427c8f680f7c9dbb2a9b17c7583de6 sha1 c176d3afcf151f743d7f45d56330916ea1756b1a )
+)
+
+game (
+	name "Eternal Darkness - Manekareta 13-nin (JP) - etanarudakunesu+-Zhao kareta13Ren -"
+	description "Eternal Darkness - Manekareta 13-nin (JP) - etanarudakunesu+-Zhao kareta13Ren -"
+	rom ( name "Eternal Darkness - Manekareta 13-nin (JP).iso" size 1459978240 crc af4d0e9e md5 ae427c8f680f7c9dbb2a9b17c7583de6 sha1 c176d3afcf151f743d7f45d56330916ea1756b1a )
+)
+
+game (
+	name "Eternal Darkness - Sanity's Requiem (EU)"
+	description "Eternal Darkness - Sanity's Requiem (EU)"
+	rom ( name "Eternal Darkness - Sanity's Requiem (EU).iso" size 1459978240 crc fae4d261 md5 c784fa979dec9f2c38259b878138fda5 sha1 5ec7bc2ebb56c5706cfcb913eb2806dd78a9f75d )
+)
+
+game (
+	name "Eternal Darkness - Sanity's Requiem (Europe) (En,Fr,De,Es,It)"
+	description "Eternal Darkness - Sanity's Requiem (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Eternal Darkness - Sanity's Requiem (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc fae4d261 md5 c784fa979dec9f2c38259b878138fda5 sha1 5ec7bc2ebb56c5706cfcb913eb2806dd78a9f75d )
+)
+
+game (
+	name "Eternal Darkness - Sanity's Requiem (US)"
+	description "Eternal Darkness - Sanity's Requiem (US)"
+	rom ( name "Eternal Darkness - Sanity's Requiem (US).iso" size 1459978240 crc 1987a637 md5 118e4cbf529719528f15d065130511e2 sha1 2bebaa7a17d69057f8c02fe00349b558abc30ff6 )
+)
+
+game (
+	name "Eternal Darkness - Sanity's Requiem (USA)"
+	description "Eternal Darkness - Sanity's Requiem (USA)"
+	rom ( name "Eternal Darkness - Sanity's Requiem (USA).iso" size 1459978240 crc 1987a637 md5 118e4cbf529719528f15d065130511e2 sha1 2bebaa7a17d69057f8c02fe00349b558abc30ff6 )
+)
+
+game (
+	name "Evolution Skateboarding (EU)"
+	description "Evolution Skateboarding (EU)"
+	rom ( name "Evolution Skateboarding (EU).iso" size 1459978240 crc b591a35f md5 6fa21d785c0841a7d99d1b3d2ac78f6c sha1 a177e4d1918a7e9cb54f008459cb4fa02a988788 )
+)
+
+game (
+	name "Evolution Skateboarding (Europe) (En,Fr,De)"
+	description "Evolution Skateboarding (Europe) (En,Fr,De)"
+	rom ( name "Evolution Skateboarding (Europe) (En,Fr,De).iso" size 1459978240 crc b591a35f md5 6fa21d785c0841a7d99d1b3d2ac78f6c sha1 a177e4d1918a7e9cb54f008459cb4fa02a988788 )
+)
+
+game (
+	name "Evolution Skateboarding (Japan)"
+	description "Evolution Skateboarding (Japan)"
+	rom ( name "Evolution Skateboarding (Japan).iso" size 1459978240 crc b729eb39 md5 a1362fb92d631775a753c5fc5c17c823 sha1 a34ca0f99f7f08ef31d85b249645a23e07d5ad18 )
+)
+
+game (
+	name "Evolution Skateboarding (JP) - eboriyusiyon+suketobodeingu"
+	description "Evolution Skateboarding (JP) - eboriyusiyon+suketobodeingu"
+	rom ( name "Evolution Skateboarding (JP).iso" size 1459978240 crc b729eb39 md5 a1362fb92d631775a753c5fc5c17c823 sha1 a34ca0f99f7f08ef31d85b249645a23e07d5ad18 )
+)
+
+game (
+	name "Evolution Skateboarding (US)"
+	description "Evolution Skateboarding (US)"
+	rom ( name "Evolution Skateboarding (US).iso" size 1459978240 crc 46e6e286 md5 6b955e15e65a77c77a4065fcb0ebeb7f sha1 a52b2af80da62c02062b36609e2694080564920d )
+)
+
+game (
+	name "Evolution Skateboarding (USA)"
+	description "Evolution Skateboarding (USA)"
+	rom ( name "Evolution Skateboarding (USA).iso" size 1459978240 crc 46e6e286 md5 6b955e15e65a77c77a4065fcb0ebeb7f sha1 a52b2af80da62c02062b36609e2694080564920d )
+)
+
+game (
+	name "Evolution Snowboarding (EU)"
+	description "Evolution Snowboarding (EU)"
+	rom ( name "Evolution Snowboarding (EU).iso" size 1459978240 crc a8d158ff md5 2bf707cb25b8d1191cb20dd546929c64 sha1 d4c1e0b35b135f431e29d2821c809ada10c19d36 )
+)
+
+game (
+	name "Evolution Snowboarding (Europe) (En,Fr,De)"
+	description "Evolution Snowboarding (Europe) (En,Fr,De)"
+	rom ( name "Evolution Snowboarding (Europe) (En,Fr,De).iso" size 1459978240 crc a8d158ff md5 2bf707cb25b8d1191cb20dd546929c64 sha1 d4c1e0b35b135f431e29d2821c809ada10c19d36 )
+)
+
+game (
+	name "Evolution Snowboarding (US)"
+	description "Evolution Snowboarding (US)"
+	rom ( name "Evolution Snowboarding (US).iso" size 1459978240 crc a18d2b49 md5 0f613a77d9132ab61fd017a39a5649e6 sha1 3e6dc183cb2bb248e443f15b14eacb1d174016a0 )
+)
+
+game (
+	name "Evolution Snowboarding (USA)"
+	description "Evolution Snowboarding (USA)"
+	rom ( name "Evolution Snowboarding (USA).iso" size 1459978240 crc a18d2b49 md5 0f613a77d9132ab61fd017a39a5649e6 sha1 3e6dc183cb2bb248e443f15b14eacb1d174016a0 )
+)
+
+game (
+	name "Evolution Worlds (EU)"
+	description "Evolution Worlds (EU)"
+	rom ( name "Evolution Worlds (EU).iso" size 1459978240 crc 7388f4f9 md5 6aa131e245ca47e29cf54505902ccdcd sha1 601c01391eb41979167779dc05b28e096143044c )
+)
+
+game (
+	name "Evolution Worlds (Europe)"
+	description "Evolution Worlds (Europe)"
+	rom ( name "Evolution Worlds (Europe).iso" size 1459978240 crc 7388f4f9 md5 6aa131e245ca47e29cf54505902ccdcd sha1 601c01391eb41979167779dc05b28e096143044c )
+)
+
+game (
+	name "Evolution Worlds (US)"
+	description "Evolution Worlds (US)"
+	rom ( name "Evolution Worlds (US).iso" size 1459978240 crc bfcb4d4f md5 052f49f094488d2002e4a5df1067435d sha1 e38eb9eb3641e727e79e83f7671dee4c41ecfa65 )
+)
+
+game (
+	name "Evolution Worlds (USA)"
+	description "Evolution Worlds (USA)"
+	rom ( name "Evolution Worlds (USA).iso" size 1459978240 crc bfcb4d4f md5 052f49f094488d2002e4a5df1067435d sha1 e38eb9eb3641e727e79e83f7671dee4c41ecfa65 )
+)
+
+game (
+	name "F-Zero GX (EU)"
+	description "F-Zero GX (EU)"
+	rom ( name "F-Zero GX (EU).iso" size 1459978240 crc 7065fd23 md5 e1081d2e1701de9dd5114388e361dbdf sha1 7db5630d62ffcc92e91b4112e73e3675a6cea401 )
+)
+
+game (
+	name "F-Zero GX (Europe) (En,Fr,De,Es,It)"
+	description "F-Zero GX (Europe) (En,Fr,De,Es,It)"
+	rom ( name "F-Zero GX (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7065fd23 md5 e1081d2e1701de9dd5114388e361dbdf sha1 7db5630d62ffcc92e91b4112e73e3675a6cea401 )
+)
+
+game (
+	name "F-Zero GX (Japan)"
+	description "F-Zero GX (Japan)"
+	rom ( name "F-Zero GX (Japan).iso" size 1459978240 crc efe948c7 md5 38249b82be648aaf08b42909064a957d sha1 937e94b572b4ec83fa5016239edd3976c8862887 )
+)
+
+game (
+	name "F-Zero GX (JP) - ehuzero+GX"
+	description "F-Zero GX (JP) - ehuzero+GX"
+	rom ( name "F-Zero GX (JP).iso" size 1459978240 crc efe948c7 md5 38249b82be648aaf08b42909064a957d sha1 937e94b572b4ec83fa5016239edd3976c8862887 )
+)
+
+game (
+	name "F-Zero GX (US)"
+	description "F-Zero GX (US)"
+	rom ( name "F-Zero GX (US).iso" size 1459978240 crc 3186fcbe md5 81293462cf48c6a482c33e25c4097ac0 sha1 cc3beb4ae027eae208d4ffb00eaa13674f56d25e )
+)
+
+game (
+	name "F-Zero GX (USA)"
+	description "F-Zero GX (USA)"
+	rom ( name "F-Zero GX (USA).iso" size 1459978240 crc 3186fcbe md5 81293462cf48c6a482c33e25c4097ac0 sha1 cc3beb4ae027eae208d4ffb00eaa13674f56d25e )
+)
+
+game (
+	name "F1 2002 (EU)"
+	description "F1 2002 (EU)"
+	rom ( name "F1 2002 (EU).iso" size 1459978240 crc 969d34f8 md5 9cae9f74de1c7189872eaa57b170a13c sha1 172278f665b2e98f22c7eaf7121f569ff13d6af0 )
+)
+
+game (
+	name "F1 2002 (Europe) (En,Fr,De,It)"
+	description "F1 2002 (Europe) (En,Fr,De,It)"
+	rom ( name "F1 2002 (Europe) (En,Fr,De,It).iso" size 1459978240 crc 969d34f8 md5 9cae9f74de1c7189872eaa57b170a13c sha1 172278f665b2e98f22c7eaf7121f569ff13d6af0 )
+)
+
+game (
+	name "F1 2002 (US)"
+	description "F1 2002 (US)"
+	rom ( name "F1 2002 (US).iso" size 1459978240 crc 5283d6b6 md5 aa748e8e0a8c91bb3635889d95f3243e sha1 120275accab67a9645921db92b50d69af7ef5213 )
+)
+
+game (
+	name "F1 2002 (USA) (En,Fr,De,It)"
+	description "F1 2002 (USA) (En,Fr,De,It)"
+	rom ( name "F1 2002 (USA) (En,Fr,De,It).iso" size 1459978240 crc 5283d6b6 md5 aa748e8e0a8c91bb3635889d95f3243e sha1 120275accab67a9645921db92b50d69af7ef5213 )
+)
+
+game (
+	name "F1 Career Challenge (EU)"
+	description "F1 Career Challenge (EU)"
+	rom ( name "F1 Career Challenge (EU).iso" size 1459978240 crc 361f47d5 md5 21991c0ba6184a4fd75f5af3b911be4f sha1 5999f5bd5bf793dddf0326e7a14b60379173b5bc )
+)
+
+game (
+	name "F1 Career Challenge (Europe) (En,Fr,De,It)"
+	description "F1 Career Challenge (Europe) (En,Fr,De,It)"
+	rom ( name "F1 Career Challenge (Europe) (En,Fr,De,It).iso" size 1459978240 crc 361f47d5 md5 21991c0ba6184a4fd75f5af3b911be4f sha1 5999f5bd5bf793dddf0326e7a14b60379173b5bc )
+)
+
+game (
+	name "Fairly OddParents, The - Breakin' da Rules (US)"
+	description "Fairly OddParents, The - Breakin' da Rules (US)"
+	rom ( name "Fairly OddParents, The - Breakin' da Rules (US).iso" size 1459978240 crc 2f1368f6 md5 b5052ea184d3b725473e503b66d485ea sha1 2b5591f7dce9950e635b49c17dd8b2e9ae5edcf2 )
+)
+
+game (
+	name "Fairly OddParents, The - Breakin' da Rules (USA)"
+	description "Fairly OddParents, The - Breakin' da Rules (USA)"
+	rom ( name "Fairly OddParents, The - Breakin' da Rules (USA).iso" size 1459978240 crc 2f1368f6 md5 b5052ea184d3b725473e503b66d485ea sha1 2b5591f7dce9950e635b49c17dd8b2e9ae5edcf2 )
+)
+
+game (
+	name "Fairly OddParents, The - Shadow Showdown (US)"
+	description "Fairly OddParents, The - Shadow Showdown (US)"
+	rom ( name "Fairly OddParents, The - Shadow Showdown (US).iso" size 1459978240 crc 97194e38 md5 949e22308c8d269245f1fc66076fbeea sha1 6db97025f9d7aad45b9ceb8049cdfb93895e9358 )
+)
+
+game (
+	name "Fairly OddParents, The - Shadow Showdown (USA)"
+	description "Fairly OddParents, The - Shadow Showdown (USA)"
+	rom ( name "Fairly OddParents, The - Shadow Showdown (USA).iso" size 1459978240 crc 97194e38 md5 949e22308c8d269245f1fc66076fbeea sha1 6db97025f9d7aad45b9ceb8049cdfb93895e9358 )
+)
+
+game (
+	name "Family Stadium 2003 (Japan)"
+	description "Family Stadium 2003 (Japan)"
+	rom ( name "Family Stadium 2003 (Japan).iso" size 1459978240 crc 69b9e609 md5 d6fe5f8e1b6c915c6812b073ac23aada sha1 d49244a31f95a77c296fba70b8b6550b7e017efc )
+)
+
+game (
+	name "Family Stadium 2003 (JP) - huamirisutaziamu+2003"
+	description "Family Stadium 2003 (JP) - huamirisutaziamu+2003"
+	rom ( name "Family Stadium 2003 (JP).iso" size 1459978240 crc 69b9e609 md5 d6fe5f8e1b6c915c6812b073ac23aada sha1 d49244a31f95a77c296fba70b8b6550b7e017efc )
+)
+
+game (
+	name "Fantastic 4 (DE)"
+	description "Fantastic 4 (DE)"
+	rom ( name "Fantastic 4 (DE).iso" size 1459978240 crc c57a318d md5 2d64888fc0fa8d48bc7b3a4bf6701e8e sha1 69248a75267c4256309c04a58323a2c6236afa92 )
+)
+
+game (
+	name "Fantastic 4 (ES)"
+	description "Fantastic 4 (ES)"
+	rom ( name "Fantastic 4 (ES).iso" size 1459978240 crc 167a9ca6 md5 a21ac401f25789a8b33f70cfe1e6c5df sha1 1925072630a0ac8f51e5f15403ff8deee9f22b3e )
+)
+
+game (
+	name "Fantastic 4 (Europe)"
+	description "Fantastic 4 (Europe)"
+	rom ( name "Fantastic 4 (Europe).iso" size 1459978240 crc f621dcbd md5 7458fabc0e0e4cbf0f185d3185378038 sha1 ebea8ffe65e257988075347c669f91fd5843d72b )
+)
+
+game (
+	name "Fantastic 4 (GB)"
+	description "Fantastic 4 (GB)"
+	rom ( name "Fantastic 4 (GB).iso" size 1459978240 crc f621dcbd md5 7458fabc0e0e4cbf0f185d3185378038 sha1 ebea8ffe65e257988075347c669f91fd5843d72b )
+)
+
+game (
+	name "Fantastic 4 (Germany)"
+	description "Fantastic 4 (Germany)"
+	rom ( name "Fantastic 4 (Germany).iso" size 1459978240 crc c57a318d md5 2d64888fc0fa8d48bc7b3a4bf6701e8e sha1 69248a75267c4256309c04a58323a2c6236afa92 )
+)
+
+game (
+	name "Fantastic 4 (Netherlands)"
+	description "Fantastic 4 (Netherlands)"
+	rom ( name "Fantastic 4 (Netherlands).iso" size 1459978240 crc bb91f33d md5 1db6f3e8e3e00ea03eb69d6e99e58900 sha1 fe85e12193472254399104ca457a7e9ab554988b )
+)
+
+game (
+	name "Fantastic 4 (NL)"
+	description "Fantastic 4 (NL)"
+	rom ( name "Fantastic 4 (NL).iso" size 1459978240 crc bb91f33d md5 1db6f3e8e3e00ea03eb69d6e99e58900 sha1 fe85e12193472254399104ca457a7e9ab554988b )
+)
+
+game (
+	name "Fantastic 4 (Spain)"
+	description "Fantastic 4 (Spain)"
+	rom ( name "Fantastic 4 (Spain).iso" size 1459978240 crc 167a9ca6 md5 a21ac401f25789a8b33f70cfe1e6c5df sha1 1925072630a0ac8f51e5f15403ff8deee9f22b3e )
+)
+
+game (
+	name "Fantastic 4 (US)"
+	description "Fantastic 4 (US)"
+	rom ( name "Fantastic 4 (US).iso" size 1459978240 crc 68ae5965 md5 eea5a284c44699068824b60882768c5e sha1 c8e2fbdd6cee241a1847bb64f572af85759848b0 )
+)
+
+game (
+	name "Fantastic 4 (USA)"
+	description "Fantastic 4 (USA)"
+	rom ( name "Fantastic 4 (USA).iso" size 1459978240 crc 68ae5965 md5 eea5a284c44699068824b60882768c5e sha1 c8e2fbdd6cee241a1847bb64f572af85759848b0 )
+)
+
+game (
+	name "Fantastici 4, I (IT)"
+	description "Fantastici 4, I (IT)"
+	rom ( name "Fantastici 4, I (IT).iso" size 1459978240 crc 9afbee92 md5 46c998d7cf5078afd4f6fba345cd16bc sha1 407dfed33f32da01d52512eb2d7d0a0ae58da4d4 )
+)
+
+game (
+	name "Fantastici 4, I (Italy)"
+	description "Fantastici 4, I (Italy)"
+	rom ( name "Fantastici 4, I (Italy).iso" size 1459978240 crc 9afbee92 md5 46c998d7cf5078afd4f6fba345cd16bc sha1 407dfed33f32da01d52512eb2d7d0a0ae58da4d4 )
+)
+
+game (
+	name "FIFA 06 (DE)"
+	description "FIFA 06 (DE)"
+	rom ( name "FIFA 06 (DE).iso" size 1459978240 crc 912e44b4 md5 0d079f1d95cf1f426a4efb15a921947d sha1 f18acecf2ac31e8cead20505d8279821b5e2a985 )
+)
+
+game (
+	name "FIFA 06 (ES)"
+	description "FIFA 06 (ES)"
+	rom ( name "FIFA 06 (ES).iso" size 1459978240 crc 9b8602f3 md5 e67e8ed42337792914dc7eb9aed21a17 sha1 d37046145f704da4b7a5ec1586cd82874f1b1f3c )
+)
+
+game (
+	name "FIFA 06 (Europe)"
+	description "FIFA 06 (Europe)"
+	rom ( name "FIFA 06 (Europe).iso" size 1459978240 crc 4d1a4b15 md5 7845c034bd33a9742ab219f7aa4eed2b sha1 4b1ebc261315636c9d2cba6b603f4c3400da56cd )
+)
+
+game (
+	name "FIFA 06 (FR)"
+	description "FIFA 06 (FR)"
+	rom ( name "FIFA 06 (FR).iso" size 1459978240 crc aa0c4cdf md5 3ce0b2aef4c19378de797c3b9d710b47 sha1 808d1a7c2f78554e5de355d2adb6c3bd1d286d64 )
+)
+
+game (
+	name "FIFA 06 (France)"
+	description "FIFA 06 (France)"
+	rom ( name "FIFA 06 (France).iso" size 1459978240 crc aa0c4cdf md5 3ce0b2aef4c19378de797c3b9d710b47 sha1 808d1a7c2f78554e5de355d2adb6c3bd1d286d64 )
+)
+
+game (
+	name "FIFA 06 (GB)"
+	description "FIFA 06 (GB)"
+	rom ( name "FIFA 06 (GB).iso" size 1459978240 crc 4d1a4b15 md5 7845c034bd33a9742ab219f7aa4eed2b sha1 4b1ebc261315636c9d2cba6b603f4c3400da56cd )
+)
+
+game (
+	name "FIFA 06 (Germany)"
+	description "FIFA 06 (Germany)"
+	rom ( name "FIFA 06 (Germany).iso" size 1459978240 crc 912e44b4 md5 0d079f1d95cf1f426a4efb15a921947d sha1 f18acecf2ac31e8cead20505d8279821b5e2a985 )
+)
+
+game (
+	name "FIFA 06 (IT)"
+	description "FIFA 06 (IT)"
+	rom ( name "FIFA 06 (IT).iso" size 1459978240 crc 4aa1ee85 md5 55f681af34420ca638535a823d160adc sha1 37454ed952bdbe1300d4efbb07866031d4dbf567 )
+)
+
+game (
+	name "FIFA 06 (Italy)"
+	description "FIFA 06 (Italy)"
+	rom ( name "FIFA 06 (Italy).iso" size 1459978240 crc 4aa1ee85 md5 55f681af34420ca638535a823d160adc sha1 37454ed952bdbe1300d4efbb07866031d4dbf567 )
+)
+
+game (
+	name "FIFA 06 (Netherlands)"
+	description "FIFA 06 (Netherlands)"
+	rom ( name "FIFA 06 (Netherlands).iso" size 1459978240 crc 80f35332 md5 9f4b8772dac8c75d73436e143342309b sha1 0cc8ddbe3d379d599c7e93ff19ff411fc9f2fbaf )
+)
+
+game (
+	name "FIFA 06 (Player's Choice) (NL)"
+	description "FIFA 06 (Player's Choice) (NL)"
+	rom ( name "FIFA 06 (Player's Choice) (NL).iso" size 1459978240 crc 80f35332 md5 9f4b8772dac8c75d73436e143342309b sha1 0cc8ddbe3d379d599c7e93ff19ff411fc9f2fbaf )
+)
+
+game (
+	name "FIFA 06 (Spain)"
+	description "FIFA 06 (Spain)"
+	rom ( name "FIFA 06 (Spain).iso" size 1459978240 crc 9b8602f3 md5 e67e8ed42337792914dc7eb9aed21a17 sha1 d37046145f704da4b7a5ec1586cd82874f1b1f3c )
+)
+
+game (
+	name "FIFA 07 (DE)"
+	description "FIFA 07 (DE)"
+	rom ( name "FIFA 07 (DE).iso" size 1459978240 crc 414d14c6 md5 7bd6a22f4478e3ba4b0df76520fa1450 sha1 4aa861f6a7079547f8849dec236287445b12dd89 )
+)
+
+game (
+	name "FIFA 07 (Europe)"
+	description "FIFA 07 (Europe)"
+	rom ( name "FIFA 07 (Europe).iso" size 1459978240 crc 3a7fb361 md5 92ecbc7822ea771d09b1885e22c7252e sha1 4d569e248ad1c77f3019a0d8137918386fdf38a7 )
+)
+
+game (
+	name "FIFA 07 (FR)"
+	description "FIFA 07 (FR)"
+	rom ( name "FIFA 07 (FR).iso" size 1459978240 crc eb78ebca md5 1956c1b911a0e3b9f83d5f6d24a45483 sha1 116329c7c0fc2f37ad724dc00243108a76a005c5 )
+)
+
+game (
+	name "FIFA 07 (France)"
+	description "FIFA 07 (France)"
+	rom ( name "FIFA 07 (France).iso" size 1459978240 crc eb78ebca md5 1956c1b911a0e3b9f83d5f6d24a45483 sha1 116329c7c0fc2f37ad724dc00243108a76a005c5 )
+)
+
+game (
+	name "FIFA 07 (GB)"
+	description "FIFA 07 (GB)"
+	rom ( name "FIFA 07 (GB).iso" size 1459978240 crc 3a7fb361 md5 92ecbc7822ea771d09b1885e22c7252e sha1 4d569e248ad1c77f3019a0d8137918386fdf38a7 )
+)
+
+game (
+	name "FIFA 07 (Germany)"
+	description "FIFA 07 (Germany)"
+	rom ( name "FIFA 07 (Germany).iso" size 1459978240 crc 414d14c6 md5 7bd6a22f4478e3ba4b0df76520fa1450 sha1 4aa861f6a7079547f8849dec236287445b12dd89 )
+)
+
+game (
+	name "FIFA 2002 - Road to FIFA World Cup (Japan)"
+	description "FIFA 2002 - Road to FIFA World Cup (Japan)"
+	rom ( name "FIFA 2002 - Road to FIFA World Cup (Japan).iso" size 1459978240 crc 84711d48 md5 48e530487f2b246141674151716b2090 sha1 1dda150c2efb805c1220d129fa45201d609e0396 )
+)
+
+game (
+	name "FIFA 2002 - Road to FIFA World Cup (JP) - FIFA+2002:+rodo+tou+FIFA+warudokatupu"
+	description "FIFA 2002 - Road to FIFA World Cup (JP) - FIFA+2002:+rodo+tou+FIFA+warudokatupu"
+	rom ( name "FIFA 2002 - Road to FIFA World Cup (JP).iso" size 1459978240 crc 84711d48 md5 48e530487f2b246141674151716b2090 sha1 1dda150c2efb805c1220d129fa45201d609e0396 )
+)
+
+game (
+	name "FIFA 2003 (Japan)"
+	description "FIFA 2003 (Japan)"
+	rom ( name "FIFA 2003 (Japan).iso" size 1459978240 crc 7085dcf5 md5 cd3372175bc4e6caaae450ba6070a73c sha1 11b633d400897edaacee7e7f49c7ea5d65cb431a )
+)
+
+game (
+	name "FIFA 2003 (JP) - FIFA+2003+yorotupasatuka"
+	description "FIFA 2003 (JP) - FIFA+2003+yorotupasatuka"
+	rom ( name "FIFA 2003 (JP).iso" size 1459978240 crc 7085dcf5 md5 cd3372175bc4e6caaae450ba6070a73c sha1 11b633d400897edaacee7e7f49c7ea5d65cb431a )
+)
+
+game (
+	name "FIFA Football 2003 (DE)"
+	description "FIFA Football 2003 (DE)"
+	rom ( name "FIFA Football 2003 (DE).iso" size 1459978240 crc 2d1bc6dc md5 a7c7ac37b72a2509ea7b5aff38733720 sha1 828d7641f068dfbdf60d98d8f30741917587ddb0 )
+)
+
+game (
+	name "FIFA Football 2003 (ES)"
+	description "FIFA Football 2003 (ES)"
+	rom ( name "FIFA Football 2003 (ES).iso" size 1459978240 crc a69e1a79 md5 85265a395bbdf4481890232d9cd7676f sha1 703f618df1048f53b96b95337bd7e10e3fee43f4 )
+)
+
+game (
+	name "FIFA Football 2003 (Europe)"
+	description "FIFA Football 2003 (Europe)"
+	rom ( name "FIFA Football 2003 (Europe).iso" size 1459978240 crc 60db66fa md5 e8cf77c31e4f89fb5ef64fb533934696 sha1 fbb57289dab1d0e835733f680af7767e3b0be800 )
+)
+
+game (
+	name "FIFA Football 2003 (France)"
+	description "FIFA Football 2003 (France)"
+	rom ( name "FIFA Football 2003 (France).iso" size 1459978240 crc 0f05cfef md5 2d127a84f01491b61050f82c3a16382d sha1 2a53cbbf266fa24e84eb550d5b7337e5d87bf712 )
+)
+
+game (
+	name "FIFA Football 2003 (GB)"
+	description "FIFA Football 2003 (GB)"
+	rom ( name "FIFA Football 2003 (GB).iso" size 1459978240 crc 60db66fa md5 e8cf77c31e4f89fb5ef64fb533934696 sha1 fbb57289dab1d0e835733f680af7767e3b0be800 )
+)
+
+game (
+	name "FIFA Football 2003 (Germany)"
+	description "FIFA Football 2003 (Germany)"
+	rom ( name "FIFA Football 2003 (Germany).iso" size 1459978240 crc 2d1bc6dc md5 a7c7ac37b72a2509ea7b5aff38733720 sha1 828d7641f068dfbdf60d98d8f30741917587ddb0 )
+)
+
+game (
+	name "FIFA Football 2003 (IT)"
+	description "FIFA Football 2003 (IT)"
+	rom ( name "FIFA Football 2003 (IT).iso" size 1459978240 crc 5530e06e md5 b79e4b8d47749d11619eea013d565734 sha1 8fb08bd99a03667d80bee75503c8d5c06d759833 )
+)
+
+game (
+	name "FIFA Football 2003 (Italy)"
+	description "FIFA Football 2003 (Italy)"
+	rom ( name "FIFA Football 2003 (Italy).iso" size 1459978240 crc 5530e06e md5 b79e4b8d47749d11619eea013d565734 sha1 8fb08bd99a03667d80bee75503c8d5c06d759833 )
+)
+
+game (
+	name "FIFA Football 2003 (Player's Choice) (FR)"
+	description "FIFA Football 2003 (Player's Choice) (FR)"
+	rom ( name "FIFA Football 2003 (Player's Choice) (FR).iso" size 1459978240 crc 0f05cfef md5 2d127a84f01491b61050f82c3a16382d sha1 2a53cbbf266fa24e84eb550d5b7337e5d87bf712 )
+)
+
+game (
+	name "FIFA Football 2003 (Spain)"
+	description "FIFA Football 2003 (Spain)"
+	rom ( name "FIFA Football 2003 (Spain).iso" size 1459978240 crc a69e1a79 md5 85265a395bbdf4481890232d9cd7676f sha1 703f618df1048f53b96b95337bd7e10e3fee43f4 )
+)
+
+game (
+	name "FIFA Football 2004 (DE)"
+	description "FIFA Football 2004 (DE)"
+	rom ( name "FIFA Football 2004 (DE).iso" size 1459978240 crc 3de6fdef md5 e88dd237b7bf73efbb3c66a444c51a6b sha1 b6fdabcf942ccbe93227afa3dbce2c5cafed5939 )
+)
+
+game (
+	name "FIFA Football 2004 (ES)"
+	description "FIFA Football 2004 (ES)"
+	rom ( name "FIFA Football 2004 (ES).iso" size 1459978240 crc 3db8288c md5 588527c276efb3a3ae7b43b646a81790 sha1 9c95317b714433f85e390e5aed8d83d9d904fdea )
+)
+
+game (
+	name "FIFA Football 2004 (Europe)"
+	description "FIFA Football 2004 (Europe)"
+	rom ( name "FIFA Football 2004 (Europe).iso" size 1459978240 crc 62f6c8e5 md5 e3aadcccd20a4e19acbdb3e1ec689b94 sha1 f6f9361385d03cc4c311ec7ef9e1c62bc075767b )
+)
+
+game (
+	name "FIFA Football 2004 (FR)"
+	description "FIFA Football 2004 (FR)"
+	rom ( name "FIFA Football 2004 (FR).iso" size 1459978240 crc 2bd1f339 md5 158b239f3499b40a2eadb32dc0a04f4b sha1 ac34b131b3b85a9ebd82a094c65eda6ab586f084 )
+)
+
+game (
+	name "FIFA Football 2004 (France)"
+	description "FIFA Football 2004 (France)"
+	rom ( name "FIFA Football 2004 (France).iso" size 1459978240 crc 2bd1f339 md5 158b239f3499b40a2eadb32dc0a04f4b sha1 ac34b131b3b85a9ebd82a094c65eda6ab586f084 )
+)
+
+game (
+	name "FIFA Football 2004 (GB)"
+	description "FIFA Football 2004 (GB)"
+	rom ( name "FIFA Football 2004 (GB).iso" size 1459978240 crc 62f6c8e5 md5 e3aadcccd20a4e19acbdb3e1ec689b94 sha1 f6f9361385d03cc4c311ec7ef9e1c62bc075767b )
+)
+
+game (
+	name "FIFA Football 2004 (Germany)"
+	description "FIFA Football 2004 (Germany)"
+	rom ( name "FIFA Football 2004 (Germany).iso" size 1459978240 crc 3de6fdef md5 e88dd237b7bf73efbb3c66a444c51a6b sha1 b6fdabcf942ccbe93227afa3dbce2c5cafed5939 )
+)
+
+game (
+	name "FIFA Football 2004 (IT)"
+	description "FIFA Football 2004 (IT)"
+	rom ( name "FIFA Football 2004 (IT).iso" size 1459978240 crc 1cf67d77 md5 f7c3e01f734064c385d8417b4032335e sha1 855030e5a400b02b805d30be89def7c7f979829f )
+)
+
+game (
+	name "FIFA Football 2004 (Italy)"
+	description "FIFA Football 2004 (Italy)"
+	rom ( name "FIFA Football 2004 (Italy).iso" size 1459978240 crc 1cf67d77 md5 f7c3e01f734064c385d8417b4032335e sha1 855030e5a400b02b805d30be89def7c7f979829f )
+)
+
+game (
+	name "FIFA Football 2004 (Spain)"
+	description "FIFA Football 2004 (Spain)"
+	rom ( name "FIFA Football 2004 (Spain).iso" size 1459978240 crc 3db8288c md5 588527c276efb3a3ae7b43b646a81790 sha1 9c95317b714433f85e390e5aed8d83d9d904fdea )
+)
+
+game (
+	name "FIFA Football 2005 (DE)"
+	description "FIFA Football 2005 (DE)"
+	rom ( name "FIFA Football 2005 (DE).iso" size 1459978240 crc 49f80c2f md5 d994fe281e98f6d184b6695757248822 sha1 00677c2d7853e6a757403654752d0ad88be59789 )
+)
+
+game (
+	name "FIFA Football 2005 (ES)"
+	description "FIFA Football 2005 (ES)"
+	rom ( name "FIFA Football 2005 (ES).iso" size 1459978240 crc b1f61dd4 md5 66f8155426da7a5a633a8f06c228fa00 sha1 bcdf06c2282115cc9813e115caec094e148059c5 )
+)
+
+game (
+	name "FIFA Football 2005 (Europe)"
+	description "FIFA Football 2005 (Europe)"
+	rom ( name "FIFA Football 2005 (Europe).iso" size 1459978240 crc 8ad89cf9 md5 481556bf89c77ca4942d659bb516cdfb sha1 7956de8610a011685ae70ac65bc746bd8cca3547 )
+)
+
+game (
+	name "FIFA Football 2005 (FR)"
+	description "FIFA Football 2005 (FR)"
+	rom ( name "FIFA Football 2005 (FR).iso" size 1459978240 crc f8d59705 md5 d77d6b3180ee39072ecc9b5505b6db3d sha1 94894b260771be1e9e178ded539650a337ebc108 )
+)
+
+game (
+	name "FIFA Football 2005 (France)"
+	description "FIFA Football 2005 (France)"
+	rom ( name "FIFA Football 2005 (France).iso" size 1459978240 crc f8d59705 md5 d77d6b3180ee39072ecc9b5505b6db3d sha1 94894b260771be1e9e178ded539650a337ebc108 )
+)
+
+game (
+	name "FIFA Football 2005 (GB)"
+	description "FIFA Football 2005 (GB)"
+	rom ( name "FIFA Football 2005 (GB).iso" size 1459978240 crc 8ad89cf9 md5 481556bf89c77ca4942d659bb516cdfb sha1 7956de8610a011685ae70ac65bc746bd8cca3547 )
+)
+
+game (
+	name "FIFA Football 2005 (Germany)"
+	description "FIFA Football 2005 (Germany)"
+	rom ( name "FIFA Football 2005 (Germany).iso" size 1459978240 crc 49f80c2f md5 d994fe281e98f6d184b6695757248822 sha1 00677c2d7853e6a757403654752d0ad88be59789 )
+)
+
+game (
+	name "FIFA Football 2005 (IT)"
+	description "FIFA Football 2005 (IT)"
+	rom ( name "FIFA Football 2005 (IT).iso" size 1459978240 crc b94ac12c md5 c872140176671dae66b3221cd58c718b sha1 e691271df4d472440488a1aa8ea9c8f22a19138d )
+)
+
+game (
+	name "FIFA Football 2005 (Italy)"
+	description "FIFA Football 2005 (Italy)"
+	rom ( name "FIFA Football 2005 (Italy).iso" size 1459978240 crc b94ac12c md5 c872140176671dae66b3221cd58c718b sha1 e691271df4d472440488a1aa8ea9c8f22a19138d )
+)
+
+game (
+	name "FIFA Football 2005 (Netherlands)"
+	description "FIFA Football 2005 (Netherlands)"
+	rom ( name "FIFA Football 2005 (Netherlands).iso" size 1459978240 crc 98e0eab6 md5 964a4a8e1246f358aa419d02e4f3e188 sha1 5a7079656549bf1d1714b709f46068bb32a10230 )
+)
+
+game (
+	name "FIFA Football 2005 (NL)"
+	description "FIFA Football 2005 (NL)"
+	rom ( name "FIFA Football 2005 (NL).iso" size 1459978240 crc 98e0eab6 md5 964a4a8e1246f358aa419d02e4f3e188 sha1 5a7079656549bf1d1714b709f46068bb32a10230 )
+)
+
+game (
+	name "FIFA Football 2005 (Spain)"
+	description "FIFA Football 2005 (Spain)"
+	rom ( name "FIFA Football 2005 (Spain).iso" size 1459978240 crc b1f61dd4 md5 66f8155426da7a5a633a8f06c228fa00 sha1 bcdf06c2282115cc9813e115caec094e148059c5 )
+)
+
+game (
+	name "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (DE)"
+	description "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (DE)"
+	rom ( name "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (DE).iso" size 1459978240 crc 10dc663f md5 5c82c77c71dad32a0015f4a7e8a1858d sha1 65778416343c7e5d7e9205ed538cc97efe2e8c72 )
+)
+
+game (
+	name "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (Germany)"
+	description "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (Germany)"
+	rom ( name "FIFA Fussball-Weltmeisterschaft Deutschland 2006 (Germany).iso" size 1459978240 crc 10dc663f md5 5c82c77c71dad32a0015f4a7e8a1858d sha1 65778416343c7e5d7e9205ed538cc97efe2e8c72 )
+)
+
+game (
+	name "FIFA Soccer 06 (US)"
+	description "FIFA Soccer 06 (US)"
+	rom ( name "FIFA Soccer 06 (US).iso" size 1459978240 crc cf5816a2 md5 7fed21160ed91035b90751201c9d5530 sha1 87b1bf075b3a50b25a8e20132fbad0713d01d322 )
+)
+
+game (
+	name "FIFA Soccer 06 (USA)"
+	description "FIFA Soccer 06 (USA)"
+	rom ( name "FIFA Soccer 06 (USA).iso" size 1459978240 crc cf5816a2 md5 7fed21160ed91035b90751201c9d5530 sha1 87b1bf075b3a50b25a8e20132fbad0713d01d322 )
+)
+
+game (
+	name "FIFA Soccer 07 (US)"
+	description "FIFA Soccer 07 (US)"
+	rom ( name "FIFA Soccer 07 (US).iso" size 1459978240 crc 0446245a md5 f0b588d5efc57990d0733682eb5a2513 sha1 a292ce6a726372fc4f138af4b540629023afbfc2 )
+)
+
+game (
+	name "FIFA Soccer 07 (USA) (En,Es)"
+	description "FIFA Soccer 07 (USA) (En,Es)"
+	rom ( name "FIFA Soccer 07 (USA) (En,Es).iso" size 1459978240 crc 0446245a md5 f0b588d5efc57990d0733682eb5a2513 sha1 a292ce6a726372fc4f138af4b540629023afbfc2 )
+)
+
+game (
+	name "FIFA Soccer 2002 (US)"
+	description "FIFA Soccer 2002 (US)"
+	rom ( name "FIFA Soccer 2002 (US).iso" size 1459978240 crc 4d8d0766 md5 2b743fda73dce40a2071fb07cd8bee69 sha1 cda388fcfcc0d05f261271a106edcf7dcc494329 )
+)
+
+game (
+	name "FIFA Soccer 2002 (USA)"
+	description "FIFA Soccer 2002 (USA)"
+	rom ( name "FIFA Soccer 2002 (USA).iso" size 1459978240 crc 4d8d0766 md5 2b743fda73dce40a2071fb07cd8bee69 sha1 cda388fcfcc0d05f261271a106edcf7dcc494329 )
+)
+
+game (
+	name "FIFA Soccer 2003 (US)"
+	description "FIFA Soccer 2003 (US)"
+	rom ( name "FIFA Soccer 2003 (US).iso" size 1459978240 crc b6e52a67 md5 805d8c85f25bed24cc030a2369315afa sha1 ef1910c48953f724c69e5b5240a2727f6a72bca9 )
+)
+
+game (
+	name "FIFA Soccer 2003 (USA)"
+	description "FIFA Soccer 2003 (USA)"
+	rom ( name "FIFA Soccer 2003 (USA).iso" size 1459978240 crc b6e52a67 md5 805d8c85f25bed24cc030a2369315afa sha1 ef1910c48953f724c69e5b5240a2727f6a72bca9 )
+)
+
+game (
+	name "FIFA Soccer 2004 (US)"
+	description "FIFA Soccer 2004 (US)"
+	rom ( name "FIFA Soccer 2004 (US).iso" size 1459978240 crc 2f6e97ad md5 242f192238c60ba899ec87259e3317df sha1 8a8404cb5e100681d3a37870edded290253d92af )
+)
+
+game (
+	name "FIFA Soccer 2004 (USA)"
+	description "FIFA Soccer 2004 (USA)"
+	rom ( name "FIFA Soccer 2004 (USA).iso" size 1459978240 crc 2f6e97ad md5 242f192238c60ba899ec87259e3317df sha1 8a8404cb5e100681d3a37870edded290253d92af )
+)
+
+game (
+	name "FIFA Soccer 2005 (US)"
+	description "FIFA Soccer 2005 (US)"
+	rom ( name "FIFA Soccer 2005 (US).iso" size 1459978240 crc d018f726 md5 ce472749d333a25c153130bcbefd8d16 sha1 a4d529e7b6c4db4885cc3c9c2c6c6bc5eae63387 )
+)
+
+game (
+	name "FIFA Soccer 2005 (USA) (En,Es)"
+	description "FIFA Soccer 2005 (USA) (En,Es)"
+	rom ( name "FIFA Soccer 2005 (USA) (En,Es).iso" size 1459978240 crc d018f726 md5 ce472749d333a25c153130bcbefd8d16 sha1 a4d529e7b6c4db4885cc3c9c2c6c6bc5eae63387 )
+)
+
+game (
+	name "FIFA Street (EU)"
+	description "FIFA Street (EU)"
+	rom ( name "FIFA Street (EU).iso" size 1459978240 crc a66856f5 md5 23eb8790b3200f9a9bf060de12cff987 sha1 d7a205c5bda57da4a268727f673e6fdea3a12e57 )
+)
+
+game (
+	name "FIFA Street (Europe) (En,Fr,De)"
+	description "FIFA Street (Europe) (En,Fr,De)"
+	rom ( name "FIFA Street (Europe) (En,Fr,De).iso" size 1459978240 crc a66856f5 md5 23eb8790b3200f9a9bf060de12cff987 sha1 d7a205c5bda57da4a268727f673e6fdea3a12e57 )
+)
+
+game (
+	name "FIFA Street (US)"
+	description "FIFA Street (US)"
+	rom ( name "FIFA Street (US).iso" size 1459978240 crc ff647575 md5 02244977f193b4c5aca40ed9645e077f sha1 6ea03c339d79284f8ebfe3357c555b3204ea0c5f )
+)
+
+game (
+	name "FIFA Street (USA) (En,Es)"
+	description "FIFA Street (USA) (En,Es)"
+	rom ( name "FIFA Street (USA) (En,Es).iso" size 1459978240 crc ff647575 md5 02244977f193b4c5aca40ed9645e077f sha1 6ea03c339d79284f8ebfe3357c555b3204ea0c5f )
+)
+
+game (
+	name "FIFA Street 2 (EU)"
+	description "FIFA Street 2 (EU)"
+	rom ( name "FIFA Street 2 (EU).iso" size 1459978240 crc 71f33bac md5 a93d6515b20e1ca407d301a9f4168605 sha1 132dc7bd0592d1cba6c04b1b01de2e19746e290c )
+)
+
+game (
+	name "FIFA Street 2 (Europe) (En,Fr,De)"
+	description "FIFA Street 2 (Europe) (En,Fr,De)"
+	rom ( name "FIFA Street 2 (Europe) (En,Fr,De).iso" size 1459978240 crc 71f33bac md5 a93d6515b20e1ca407d301a9f4168605 sha1 132dc7bd0592d1cba6c04b1b01de2e19746e290c )
+)
+
+game (
+	name "FIFA Street 2 (US)"
+	description "FIFA Street 2 (US)"
+	rom ( name "FIFA Street 2 (US).iso" size 1459978240 crc 57da4a2e md5 4fcc0557da4400f8b2257dde9c29e405 sha1 33f585f3b4b3a39391651a57f620123349a6eb07 )
+)
+
+game (
+	name "FIFA Street 2 (USA) (En,Es)"
+	description "FIFA Street 2 (USA) (En,Es)"
+	rom ( name "FIFA Street 2 (USA) (En,Es).iso" size 1459978240 crc 57da4a2e md5 4fcc0557da4400f8b2257dde9c29e405 sha1 33f585f3b4b3a39391651a57f620123349a6eb07 )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (Europe)"
+	description "FIFA World Cup Germany 2006 (Europe)"
+	rom ( name "FIFA World Cup Germany 2006 (Europe).iso" size 1459978240 crc a9e2b9f5 md5 facea37db16c2693176b7b55998c435f sha1 73ce48eaba1b217712b28b64718233c50a2072e8 )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (FR)"
+	description "FIFA World Cup Germany 2006 (FR)"
+	rom ( name "FIFA World Cup Germany 2006 (FR).iso" size 1459978240 crc 2ec09cb9 md5 2e32631fa46330de206f1b26c240bcc4 sha1 17dac219e3b7df44106b9247d4eebc4cd73d089e )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (France)"
+	description "FIFA World Cup Germany 2006 (France)"
+	rom ( name "FIFA World Cup Germany 2006 (France).iso" size 1459978240 crc 2ec09cb9 md5 2e32631fa46330de206f1b26c240bcc4 sha1 17dac219e3b7df44106b9247d4eebc4cd73d089e )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (GB)"
+	description "FIFA World Cup Germany 2006 (GB)"
+	rom ( name "FIFA World Cup Germany 2006 (GB).iso" size 1459978240 crc a9e2b9f5 md5 facea37db16c2693176b7b55998c435f sha1 73ce48eaba1b217712b28b64718233c50a2072e8 )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (US)"
+	description "FIFA World Cup Germany 2006 (US)"
+	rom ( name "FIFA World Cup Germany 2006 (US).iso" size 1459978240 crc 89b553bf md5 164d1527b93dad57252c61fa77f17c27 sha1 5a5ffb1ff4c170de89e988a430dcd55b0011a474 )
+)
+
+game (
+	name "FIFA World Cup Germany 2006 (USA)"
+	description "FIFA World Cup Germany 2006 (USA)"
+	rom ( name "FIFA World Cup Germany 2006 (USA).iso" size 1459978240 crc 89b553bf md5 164d1527b93dad57252c61fa77f17c27 sha1 5a5ffb1ff4c170de89e988a430dcd55b0011a474 )
+)
+
+game (
+	name "Fight Night Round 2 (EU)"
+	description "Fight Night Round 2 (EU)"
+	rom ( name "Fight Night Round 2 (EU).iso" size 1459978240 crc a2fedce2 md5 284f1ff8862a0d5868157076700e80db sha1 521238cf191e4ec5edd44d3bc5e0c8d46a8da0ad )
+)
+
+game (
+	name "Fight Night Round 2 (Europe) (En,Fr,De)"
+	description "Fight Night Round 2 (Europe) (En,Fr,De)"
+	rom ( name "Fight Night Round 2 (Europe) (En,Fr,De).iso" size 1459978240 crc a2fedce2 md5 284f1ff8862a0d5868157076700e80db sha1 521238cf191e4ec5edd44d3bc5e0c8d46a8da0ad )
+)
+
+game (
+	name "Fight Night Round 2 (Japan)"
+	description "Fight Night Round 2 (Japan)"
+	rom ( name "Fight Night Round 2 (Japan).iso" size 1459978240 crc dd300b2d md5 d83d7c3479d4e028498e1a72d5b6d466 sha1 497d466406df9031e8d294fc5803edf250c28d5b )
+)
+
+game (
+	name "Fight Night Round 2 (JP) - huaitonaitoraundo2"
+	description "Fight Night Round 2 (JP) - huaitonaitoraundo2"
+	rom ( name "Fight Night Round 2 (JP).iso" size 1459978240 crc dd300b2d md5 d83d7c3479d4e028498e1a72d5b6d466 sha1 497d466406df9031e8d294fc5803edf250c28d5b )
+)
+
+game (
+	name "Fight Night Round 2 (US)"
+	description "Fight Night Round 2 (US)"
+	rom ( name "Fight Night Round 2 (US).iso" size 1459978240 crc 87e690e3 md5 1f6264dabc522271dbc5e3cd5fb6593b sha1 2ce875dd5b19150b4de35e41d3631a72f50c9f0d )
+)
+
+game (
+	name "Fight Night Round 2 (USA)"
+	description "Fight Night Round 2 (USA)"
+	rom ( name "Fight Night Round 2 (USA).iso" size 1459978240 crc 87e690e3 md5 1f6264dabc522271dbc5e3cd5fb6593b sha1 2ce875dd5b19150b4de35e41d3631a72f50c9f0d )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (EU)"
+	description "Final Fantasy - Crystal Chronicles (EU)"
+	rom ( name "Final Fantasy - Crystal Chronicles (EU).iso" size 1459978240 crc 1c68474c md5 018b43a323a75bb73d124498327810cd sha1 0b3b7c1f48319e28905ca6eff66b815d1c09c6d3 )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (Europe) (En,Fr,De,Es,It)"
+	description "Final Fantasy - Crystal Chronicles (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Final Fantasy - Crystal Chronicles (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1c68474c md5 018b43a323a75bb73d124498327810cd sha1 0b3b7c1f48319e28905ca6eff66b815d1c09c6d3 )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (Japan)"
+	description "Final Fantasy - Crystal Chronicles (Japan)"
+	rom ( name "Final Fantasy - Crystal Chronicles (Japan).iso" size 1459978240 crc 8e6bc496 md5 04e85610877150dd2d3f1097de6b09ae sha1 c62a0320b473a122b8bc9284fcfb4fb7a45fcd5d )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (JP) - huainaruhuantazikurisutarukuronikuru"
+	description "Final Fantasy - Crystal Chronicles (JP) - huainaruhuantazikurisutarukuronikuru"
+	rom ( name "Final Fantasy - Crystal Chronicles (JP).iso" size 1459978240 crc 8e6bc496 md5 04e85610877150dd2d3f1097de6b09ae sha1 c62a0320b473a122b8bc9284fcfb4fb7a45fcd5d )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (US)"
+	description "Final Fantasy - Crystal Chronicles (US)"
+	rom ( name "Final Fantasy - Crystal Chronicles (US).iso" size 1459978240 crc 141aeac0 md5 a6d6064396b20c0d0d836afad97d3a4c sha1 3aced85176e0d3299fc86e06fece2fc25996e914 )
+)
+
+game (
+	name "Final Fantasy - Crystal Chronicles (USA)"
+	description "Final Fantasy - Crystal Chronicles (USA)"
+	rom ( name "Final Fantasy - Crystal Chronicles (USA).iso" size 1459978240 crc 141aeac0 md5 a6d6064396b20c0d0d836afad97d3a4c sha1 3aced85176e0d3299fc86e06fece2fc25996e914 )
+)
+
+game (
+	name "Findet Nemo (DE)"
+	description "Findet Nemo (DE)"
+	rom ( name "Findet Nemo (DE).iso" size 1459978240 crc 80c21a71 md5 f7e01141ca1f1f30a20ab865be952763 sha1 25ee447324591bd6210d813ba71f1f21303ed422 )
+)
+
+game (
+	name "Findet Nemo (Germany)"
+	description "Findet Nemo (Germany)"
+	rom ( name "Findet Nemo (Germany).iso" size 1459978240 crc 80c21a71 md5 f7e01141ca1f1f30a20ab865be952763 sha1 25ee447324591bd6210d813ba71f1f21303ed422 )
+)
+
+game (
+	name "Finding Nemo (Europe)"
+	description "Finding Nemo (Europe)"
+	rom ( name "Finding Nemo (Europe).iso" size 1459978240 crc b0bec04e md5 244607e2f6f92a1c4385fb421df4cb26 sha1 477605e6228d728608195efbc0b7ad4f7c52b1fd )
+)
+
+game (
+	name "Finding Nemo (GB)"
+	description "Finding Nemo (GB)"
+	rom ( name "Finding Nemo (GB).iso" size 1459978240 crc b0bec04e md5 244607e2f6f92a1c4385fb421df4cb26 sha1 477605e6228d728608195efbc0b7ad4f7c52b1fd )
+)
+
+game (
+	name "Finding Nemo (Japan)"
+	description "Finding Nemo (Japan)"
+	rom ( name "Finding Nemo (Japan).iso" size 1459978240 crc 03d07259 md5 5f3c684e665d17dd0a11f7b027c2ca80 sha1 2b5ae441fa825749ed2a62790c8b602b472c8a77 )
+)
+
+game (
+	name "Finding Nemo (JP) - huaindeingunimo"
+	description "Finding Nemo (JP) - huaindeingunimo"
+	rom ( name "Finding Nemo (JP).iso" size 1459978240 crc 03d07259 md5 5f3c684e665d17dd0a11f7b027c2ca80 sha1 2b5ae441fa825749ed2a62790c8b602b472c8a77 )
+)
+
+game (
+	name "Fire Emblem - Path of Radiance (EU)"
+	description "Fire Emblem - Path of Radiance (EU)"
+	rom ( name "Fire Emblem - Path of Radiance (EU).iso" size 1459978240 crc ad6508bd md5 0bf72c4840de405ee5ca1b8e3bff56aa sha1 fa37e09f5cc124602edabbf54f77162d0f3f31f0 )
+)
+
+game (
+	name "Fire Emblem - Path of Radiance (Europe) (En,Fr,De,Es,It)"
+	description "Fire Emblem - Path of Radiance (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Fire Emblem - Path of Radiance (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ad6508bd md5 0bf72c4840de405ee5ca1b8e3bff56aa sha1 fa37e09f5cc124602edabbf54f77162d0f3f31f0 )
+)
+
+game (
+	name "Fire Emblem - Path of Radiance (US)"
+	description "Fire Emblem - Path of Radiance (US)"
+	rom ( name "Fire Emblem - Path of Radiance (US).iso" size 1459978240 crc f24cb38a md5 4098af6d672eeae8749f9da67309c537 sha1 2f80ed4bcdc32fb0bcc5c79d96d4451cf2e2355c )
+)
+
+game (
+	name "Fire Emblem - Path of Radiance (USA)"
+	description "Fire Emblem - Path of Radiance (USA)"
+	rom ( name "Fire Emblem - Path of Radiance (USA).iso" size 1459978240 crc f24cb38a md5 4098af6d672eeae8749f9da67309c537 sha1 2f80ed4bcdc32fb0bcc5c79d96d4451cf2e2355c )
+)
+
+game (
+	name "Fire Emblem - Souen no Kiseki (Japan)"
+	description "Fire Emblem - Souen no Kiseki (Japan)"
+	rom ( name "Fire Emblem - Souen no Kiseki (Japan).iso" size 1459978240 crc ac406ef9 md5 e8277ee53984b2820ab5c2659e194443 sha1 e93de4096df261870177551dc81e75051c702343 )
+)
+
+game (
+	name "Fire Emblem - Souen no Kiseki (JP) - huaiaemuburemu+Cang Yan noGui Ji"
+	description "Fire Emblem - Souen no Kiseki (JP) - huaiaemuburemu+Cang Yan noGui Ji"
+	rom ( name "Fire Emblem - Souen no Kiseki (JP).iso" size 1459978240 crc ac406ef9 md5 e8277ee53984b2820ab5c2659e194443 sha1 e93de4096df261870177551dc81e75051c702343 )
+)
+
+game (
+	name "FireBlade (EU)"
+	description "FireBlade (EU)"
+	rom ( name "FireBlade (EU).iso" size 1459978240 crc 10a3de38 md5 2abcb22171a6194fc39b00c53f207e7f sha1 501c21858267f835aad6bfcd83a18658b6dc646f )
+)
+
+game (
+	name "FireBlade (Europe) (En,Fr,De,Es,It)"
+	description "FireBlade (Europe) (En,Fr,De,Es,It)"
+	rom ( name "FireBlade (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 10a3de38 md5 2abcb22171a6194fc39b00c53f207e7f sha1 501c21858267f835aad6bfcd83a18658b6dc646f )
+)
+
+game (
+	name "FireBlade (US)"
+	description "FireBlade (US)"
+	rom ( name "FireBlade (US).iso" size 1459978240 crc 88f6fa17 md5 4d902c074e84b7532e9f45fcb147b153 sha1 9e3a4dc5f5599e1f43e424ab4a96d5e58fd2d3eb )
+)
+
+game (
+	name "FireBlade (USA)"
+	description "FireBlade (USA)"
+	rom ( name "FireBlade (USA).iso" size 1459978240 crc 88f6fa17 md5 4d902c074e84b7532e9f45fcb147b153 sha1 9e3a4dc5f5599e1f43e424ab4a96d5e58fd2d3eb )
+)
+
+game (
+	name "Franklin - Un anniversaire surprise (FR)"
+	description "Franklin - Un anniversaire surprise (FR)"
+	rom ( name "Franklin - Un anniversaire surprise (FR).iso" size 1459978240 crc 9f54ba04 md5 02cf21e25943d3c9d63aba26e01aa6c7 sha1 ce4cc8c4723a44cd14e7706cd2bc675e8e479ad4 )
+)
+
+game (
+	name "Franklin - Un anniversaire surprise (France)"
+	description "Franklin - Un anniversaire surprise (France)"
+	rom ( name "Franklin - Un anniversaire surprise (France).iso" size 1459978240 crc 9f54ba04 md5 02cf21e25943d3c9d63aba26e01aa6c7 sha1 ce4cc8c4723a44cd14e7706cd2bc675e8e479ad4 )
+)
+
+game (
+	name "Freaky Flyers (US)"
+	description "Freaky Flyers (US)"
+	rom ( name "Freaky Flyers (US) - (Disc 1 of 2).iso" size 1459978240 crc 889a6f5d md5 9ef093501c06832a9045d15cfe0efb12 sha1 64b14b21e66b15c0fe98820728c4ff85c66be141 )
+)
+
+game (
+	name "Freaky Flyers (USA) (Disc 1)"
+	description "Freaky Flyers (USA) (Disc 1)"
+	rom ( name "Freaky Flyers (USA) (Disc 1).iso" size 1459978240 crc 889a6f5d md5 9ef093501c06832a9045d15cfe0efb12 sha1 64b14b21e66b15c0fe98820728c4ff85c66be141 )
+)
+
+game (
+	name "Freaky Flyers (USA) (Disc 2)"
+	description "Freaky Flyers (USA) (Disc 2)"
+	rom ( name "Freaky Flyers (USA) (Disc 2).iso" size 1459978240 crc 8feff47c md5 2c79b31bdc8883636392f334952b755a sha1 701e9daeb06d441ab84e508bc4737e3818cc420d )
+)
+
+game (
+	name "Freedom Fighters (DE)"
+	description "Freedom Fighters (DE)"
+	rom ( name "Freedom Fighters (DE).iso" size 1459978240 crc 672c3d6a md5 124ba31342e7faab772a0f6167488e48 sha1 674983649e40dcc8fc74700a046f54e9ddafce7a )
+)
+
+game (
+	name "Freedom Fighters (Europe)"
+	description "Freedom Fighters (Europe)"
+	rom ( name "Freedom Fighters (Europe).iso" size 1459978240 crc 9cc5b41e md5 9c9324ff9ee6e79bebe2e39b41de5eb8 sha1 2a09f9f07e0bbd6ef35d8942241de952f370ebb8 )
+)
+
+game (
+	name "Freedom Fighters (FR)"
+	description "Freedom Fighters (FR)"
+	rom ( name "Freedom Fighters (FR).iso" size 1459978240 crc efb3ef9f md5 66a6c714e23c218680cfebd9fc142980 sha1 f40edd7829240b3c2241fc42f45b1f6ce2c6c6c8 )
+)
+
+game (
+	name "Freedom Fighters (France)"
+	description "Freedom Fighters (France)"
+	rom ( name "Freedom Fighters (France).iso" size 1459978240 crc efb3ef9f md5 66a6c714e23c218680cfebd9fc142980 sha1 f40edd7829240b3c2241fc42f45b1f6ce2c6c6c8 )
+)
+
+game (
+	name "Freedom Fighters (GB)"
+	description "Freedom Fighters (GB)"
+	rom ( name "Freedom Fighters (GB).iso" size 1459978240 crc 9cc5b41e md5 9c9324ff9ee6e79bebe2e39b41de5eb8 sha1 2a09f9f07e0bbd6ef35d8942241de952f370ebb8 )
+)
+
+game (
+	name "Freedom Fighters (Germany)"
+	description "Freedom Fighters (Germany)"
+	rom ( name "Freedom Fighters (Germany).iso" size 1459978240 crc 672c3d6a md5 124ba31342e7faab772a0f6167488e48 sha1 674983649e40dcc8fc74700a046f54e9ddafce7a )
+)
+
+game (
+	name "Freedom Fighters (US)"
+	description "Freedom Fighters (US)"
+	rom ( name "Freedom Fighters (US).iso" size 1459978240 crc 35e87d53 md5 9b41db45e84764720d5b579187f23172 sha1 97a4363714a546f9befecd37e837e47697663513 )
+)
+
+game (
+	name "Freedom Fighters (USA)"
+	description "Freedom Fighters (USA)"
+	rom ( name "Freedom Fighters (USA).iso" size 1459978240 crc 35e87d53 md5 9b41db45e84764720d5b579187f23172 sha1 97a4363714a546f9befecd37e837e47697663513 )
+)
+
+game (
+	name "Freekstyle (EU)"
+	description "Freekstyle (EU)"
+	rom ( name "Freekstyle (EU).iso" size 1459978240 crc bb4d7b8b md5 6f61e6bb706d434d97d67af6036090dd sha1 beacaa99fa921bf29f058ae5df52439f292f81bf )
+)
+
+game (
+	name "Freekstyle (Europe) (En,Fr,De)"
+	description "Freekstyle (Europe) (En,Fr,De)"
+	rom ( name "Freekstyle (Europe) (En,Fr,De).iso" size 1459978240 crc bb4d7b8b md5 6f61e6bb706d434d97d67af6036090dd sha1 beacaa99fa921bf29f058ae5df52439f292f81bf )
+)
+
+game (
+	name "Freekstyle (US)"
+	description "Freekstyle (US)"
+	rom ( name "Freekstyle (US).iso" size 1459978240 crc 63737d85 md5 d3de22d5dc572c6c60eb654827d90822 sha1 97c6a9911a5a2cb7b6c9adde4bbc4804bb1136a2 )
+)
+
+game (
+	name "Freekstyle (USA)"
+	description "Freekstyle (USA)"
+	rom ( name "Freekstyle (USA).iso" size 1459978240 crc 63737d85 md5 d3de22d5dc572c6c60eb654827d90822 sha1 97c6a9911a5a2cb7b6c9adde4bbc4804bb1136a2 )
+)
+
+game (
+	name "Freestyle Metal X (US)"
+	description "Freestyle Metal X (US)"
+	rom ( name "Freestyle Metal X (US).iso" size 1459978240 crc 7b59a773 md5 56d73e3be3a25cd080302519970c41c2 sha1 ee6d2787f8809e61d41e94eac12efe255c1ff6b9 )
+)
+
+game (
+	name "Freestyle Metal X (USA)"
+	description "Freestyle Metal X (USA)"
+	rom ( name "Freestyle Metal X (USA).iso" size 1459978240 crc 7b59a773 md5 56d73e3be3a25cd080302519970c41c2 sha1 ee6d2787f8809e61d41e94eac12efe255c1ff6b9 )
+)
+
+game (
+	name "Freestyle Street Soccer (US)"
+	description "Freestyle Street Soccer (US)"
+	rom ( name "Freestyle Street Soccer (US).iso" size 1459978240 crc f6e1ac8c md5 193a2a26b4fa916ab893212f706e71f3 sha1 515344a21206067e7af9ffaa04ce54267b2d7a0b )
+)
+
+game (
+	name "Freestyle Street Soccer (USA)"
+	description "Freestyle Street Soccer (USA)"
+	rom ( name "Freestyle Street Soccer (USA).iso" size 1459978240 crc f6e1ac8c md5 193a2a26b4fa916ab893212f706e71f3 sha1 515344a21206067e7af9ffaa04ce54267b2d7a0b )
+)
+
+game (
+	name "Frogger - Ancient Shadow (US)"
+	description "Frogger - Ancient Shadow (US)"
+	rom ( name "Frogger - Ancient Shadow (US).iso" size 1459978240 crc 232ffdd4 md5 e5efb0529b5daa067bae5e024aa5f857 sha1 550da76aea8fb869751e164fb4a3d38f80728761 )
+)
+
+game (
+	name "Frogger - Ancient Shadow (USA) (En,Es)"
+	description "Frogger - Ancient Shadow (USA) (En,Es)"
+	rom ( name "Frogger - Ancient Shadow (USA) (En,Es).iso" size 1459978240 crc 232ffdd4 md5 e5efb0529b5daa067bae5e024aa5f857 sha1 550da76aea8fb869751e164fb4a3d38f80728761 )
+)
+
+game (
+	name "Frogger (Japan)"
+	description "Frogger (Japan)"
+	rom ( name "Frogger (Japan).iso" size 1459978240 crc d42140e1 md5 ef21cc212ea6e44f5fe442852cd90824 sha1 6b3b04b5fb9dad8c311040d9676a0af4ceff54d4 )
+)
+
+game (
+	name "Frogger (JP) - hurotuga"
+	description "Frogger (JP) - hurotuga"
+	rom ( name "Frogger (JP).iso" size 1459978240 crc d42140e1 md5 ef21cc212ea6e44f5fe442852cd90824 sha1 6b3b04b5fb9dad8c311040d9676a0af4ceff54d4 )
+)
+
+game (
+	name "Frogger Beyond (EU)"
+	description "Frogger Beyond (EU)"
+	rom ( name "Frogger Beyond (EU).iso" size 1459978240 crc bcf58cb2 md5 7a34b037e86558752ec1b5324651c3d9 sha1 ab68389aae8829ab7ba6ad207aa455a9aa17eb3c )
+)
+
+game (
+	name "Frogger Beyond (Europe) (En,Fr,De,Es,It)"
+	description "Frogger Beyond (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Frogger Beyond (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc bcf58cb2 md5 7a34b037e86558752ec1b5324651c3d9 sha1 ab68389aae8829ab7ba6ad207aa455a9aa17eb3c )
+)
+
+game (
+	name "Frogger Beyond (US)"
+	description "Frogger Beyond (US)"
+	rom ( name "Frogger Beyond (US).iso" size 1459978240 crc d1d8b3e4 md5 6dd00a49c4714085d3e958dd5d5b8f1d sha1 c29e996e108463ad9e7f21e2763d8260c7898c9b )
+)
+
+game (
+	name "Frogger Beyond (USA)"
+	description "Frogger Beyond (USA)"
+	rom ( name "Frogger Beyond (USA).iso" size 1459978240 crc d1d8b3e4 md5 6dd00a49c4714085d3e958dd5d5b8f1d sha1 c29e996e108463ad9e7f21e2763d8260c7898c9b )
+)
+
+game (
+	name "Frogger's Adventures - The Rescue (US)"
+	description "Frogger's Adventures - The Rescue (US)"
+	rom ( name "Frogger's Adventures - The Rescue (US).iso" size 1459978240 crc 72d21a8e md5 44c22d035c7302e9eeb0349affa6bd2b sha1 d449a569b1e875b3a20227fcb18431b1bf3fc2dc )
+)
+
+game (
+	name "Frogger's Adventures - The Rescue (USA)"
+	description "Frogger's Adventures - The Rescue (USA)"
+	rom ( name "Frogger's Adventures - The Rescue (USA).iso" size 1459978240 crc 72d21a8e md5 44c22d035c7302e9eeb0349affa6bd2b sha1 d449a569b1e875b3a20227fcb18431b1bf3fc2dc )
+)
+
+game (
+	name "From TV Animation - One Piece Treasure Battle! (JP) - From+TV+Animation:+One+Piece+toreziyabatoru!"
+	description "From TV Animation - One Piece Treasure Battle! (JP) - From+TV+Animation:+One+Piece+toreziyabatoru!"
+	rom ( name "From TV Animation - One Piece Treasure Battle! (JP).iso" size 1459978240 crc 81039a96 md5 4b97a8f0fe27b40b305ade2a8244d917 sha1 c3ca1dbc4a8cd6f81a74c5231ef3a4f556e01efc )
+)
+
+game (
+	name "From TV Animation One Piece - Treasure Battle! (Japan)"
+	description "From TV Animation One Piece - Treasure Battle! (Japan)"
+	rom ( name "From TV Animation One Piece - Treasure Battle! (Japan).iso" size 1459978240 crc 81039a96 md5 4b97a8f0fe27b40b305ade2a8244d917 sha1 c3ca1dbc4a8cd6f81a74c5231ef3a4f556e01efc )
+)
+
+game (
+	name "Future Tactics - The Uprising (EU)"
+	description "Future Tactics - The Uprising (EU)"
+	rom ( name "Future Tactics - The Uprising (EU).iso" size 1459978240 crc 123fd890 md5 f29d4f8a2e88128ea36b14be2c8415c8 sha1 186f8f25e9dbe21505268618099160459e972092 )
+)
+
+game (
+	name "Future Tactics - The Uprising (Europe) (En,Fr,De,Es,It)"
+	description "Future Tactics - The Uprising (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Future Tactics - The Uprising (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 123fd890 md5 f29d4f8a2e88128ea36b14be2c8415c8 sha1 186f8f25e9dbe21505268618099160459e972092 )
+)
+
+game (
+	name "Future Tactics - The Uprising (US)"
+	description "Future Tactics - The Uprising (US)"
+	rom ( name "Future Tactics - The Uprising (US).iso" size 1459978240 crc 0c4d4061 md5 6a77e5d966166316617f0966b8c4b182 sha1 c9d7927051715232445c54eb8638f3a2d59ba93f )
+)
+
+game (
+	name "Future Tactics - The Uprising (USA)"
+	description "Future Tactics - The Uprising (USA)"
+	rom ( name "Future Tactics - The Uprising (USA).iso" size 1459978240 crc 0c4d4061 md5 6a77e5d966166316617f0966b8c4b182 sha1 c9d7927051715232445c54eb8638f3a2d59ba93f )
+)
+
+game (
+	name "Gadget Racers (EU)"
+	description "Gadget Racers (EU)"
+	rom ( name "Gadget Racers (EU).iso" size 1459978240 crc e04a0eba md5 c7945229eefae34dc586af3dbc01634a sha1 a7edbc83364c164ebc06cfa420fec7ddbee8a7b6 )
+)
+
+game (
+	name "Gadget Racers (Europe) (En,Fr,De,Es,It)"
+	description "Gadget Racers (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Gadget Racers (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e04a0eba md5 c7945229eefae34dc586af3dbc01634a sha1 a7edbc83364c164ebc06cfa420fec7ddbee8a7b6 )
+)
+
+game (
+	name "Gakuen Toshi Vara Noir Roses (Japan)"
+	description "Gakuen Toshi Vara Noir Roses (Japan)"
+	rom ( name "Gakuen Toshi Vara Noir Roses (Japan).iso" size 1459978240 crc cf6d0aa5 md5 364f6513ce08ebbfc312e7a05a6b4225 sha1 d403770cba0c71520df8fd853275508130ac04f4 )
+)
+
+game (
+	name "Gakuen Toshi Vara Noir Roses (JP) - Xue Yuan Du Shi vuaranowaru rozesu"
+	description "Gakuen Toshi Vara Noir Roses (JP) - Xue Yuan Du Shi vuaranowaru rozesu"
+	rom ( name "Gakuen Toshi Vara Noir Roses (JP).iso" size 1459978240 crc cf6d0aa5 md5 364f6513ce08ebbfc312e7a05a6b4225 sha1 d403770cba0c71520df8fd853275508130ac04f4 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (EU)"
+	description "Game Boy Player Start-Up Disc (EU)"
+	rom ( name "Game Boy Player Start-Up Disc (EU) - [v1.01].iso" size 1459978240 crc 5ecd9681 md5 019a4ebb28d180d1a734ee011cea1ca7 sha1 f8ac4741e85de70d9e96922a93dfb28edc45161f )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
+	description "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
+	rom ( name "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It,Nl) (v1.02).iso" size 1459978240 crc 1e26380c md5 a064265997d2e5b378793a45e18e48b7 sha1 ede1fb4415e68f948e5febe93aa01c90a05f0a59 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Game Boy Player Start-Up Disc (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 1459978240 crc 5ecd9681 md5 019a4ebb28d180d1a734ee011cea1ca7 sha1 f8ac4741e85de70d9e96922a93dfb28edc45161f )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (Japan)"
+	description "Game Boy Player Start-Up Disc (Japan)"
+	rom ( name "Game Boy Player Start-Up Disc (Japan).iso" size 1459978240 crc dff567cb md5 add4733c48c596619df27b36a4a499f3 sha1 1040b0508ee01e00d5bf1b71d9e830f0f761c0f7 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (JP) - gemuboipureiya"
+	description "Game Boy Player Start-Up Disc (JP) - gemuboipureiya"
+	rom ( name "Game Boy Player Start-Up Disc (JP).iso" size 1459978240 crc dff567cb md5 add4733c48c596619df27b36a4a499f3 sha1 1040b0508ee01e00d5bf1b71d9e830f0f761c0f7 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (US)"
+	description "Game Boy Player Start-Up Disc (US)"
+	rom ( name "Game Boy Player Start-Up Disc (US) - [v1.00].iso" size 1459978240 crc e502dc79 md5 dc2c63f02f74785d83d50b80edb66d74 sha1 ea758b006d24d0661fcd05486e614a77406ec650 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (USA) (v1.02)"
+	description "Game Boy Player Start-Up Disc (USA) (v1.02)"
+	rom ( name "Game Boy Player Start-Up Disc (USA) (v1.02).iso" size 1459978240 crc dcd8fa3d md5 03c6f44267aa4a5c42ab20698f88f477 sha1 f2439bbe1ff64133050fbc00574be8478210a958 )
+)
+
+game (
+	name "Game Boy Player Start-Up Disc (USA) (v1.03)"
+	description "Game Boy Player Start-Up Disc (USA) (v1.03)"
+	rom ( name "Game Boy Player Start-Up Disc (USA) (v1.03).iso" size 1459978240 crc e502dc79 md5 dc2c63f02f74785d83d50b80edb66d74 sha1 ea758b006d24d0661fcd05486e614a77406ec650 )
+)
+
+game (
+	name "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Japan)"
+	description "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Japan)"
+	rom ( name "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Japan).iso" size 1459978240 crc 385bdc6a md5 08edf0dd8bfdb9cc42f7c5a0f5b298a4 sha1 e9629dbe5477403008e50afa989f929b8cf7782e )
+)
+
+game (
+	name "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Promo) (JP) - gemuDa Hui You Sheng Ji Nian :Te Zhi sumaburaDXmubideisuku"
+	description "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Promo) (JP) - gemuDa Hui You Sheng Ji Nian :Te Zhi sumaburaDXmubideisuku"
+	rom ( name "Game Taikai Yuushou Kinen - Tokusei SmaBro DX Movie Disc (Promo) (JP).iso" size 1459978240 crc 385bdc6a md5 08edf0dd8bfdb9cc42f7c5a0f5b298a4 sha1 e9629dbe5477403008e50afa989f929b8cf7782e )
+)
+
+game (
+	name "Gauntlet - Dark Legacy (EU)"
+	description "Gauntlet - Dark Legacy (EU)"
+	rom ( name "Gauntlet - Dark Legacy (EU).iso" size 1459978240 crc 038b400a md5 a69526f27fa4b993def536f757e26802 sha1 78b52089983289339a0454a13e4f283304496de5 )
+)
+
+game (
+	name "Gauntlet - Dark Legacy (Europe) (En,Fr,De)"
+	description "Gauntlet - Dark Legacy (Europe) (En,Fr,De)"
+	rom ( name "Gauntlet - Dark Legacy (Europe) (En,Fr,De).iso" size 1459978240 crc 038b400a md5 a69526f27fa4b993def536f757e26802 sha1 78b52089983289339a0454a13e4f283304496de5 )
+)
+
+game (
+	name "Gauntlet - Dark Legacy (US)"
+	description "Gauntlet - Dark Legacy (US)"
+	rom ( name "Gauntlet - Dark Legacy (US).iso" size 1459978240 crc 5bd30dd8 md5 308cab2e7a82f72a5aed2209d766f65a sha1 8046ffb66a16a612277df12246390ed21b6db4ad )
+)
+
+game (
+	name "Gauntlet - Dark Legacy (USA)"
+	description "Gauntlet - Dark Legacy (USA)"
+	rom ( name "Gauntlet - Dark Legacy (USA).iso" size 1459978240 crc 5bd30dd8 md5 308cab2e7a82f72a5aed2209d766f65a sha1 8046ffb66a16a612277df12246390ed21b6db4ad )
+)
+
+game (
+	name "Geist (EU)"
+	description "Geist (EU)"
+	rom ( name "Geist (EU).iso" size 1459978240 crc b484b0b0 md5 b05b590f098c47d2bcd185a6ea7b9b6a sha1 04948663d224826b284c8070d1944a45b871f720 )
+)
+
+game (
+	name "Geist (Europe) (En,Fr,De,Es,It)"
+	description "Geist (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Geist (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b484b0b0 md5 b05b590f098c47d2bcd185a6ea7b9b6a sha1 04948663d224826b284c8070d1944a45b871f720 )
+)
+
+game (
+	name "Geist (US)"
+	description "Geist (US)"
+	rom ( name "Geist (US).iso" size 1459978240 crc 2b606740 md5 e6519bc68b09b9587d2a0b62514a4f19 sha1 0ae8391712a8f3654228d58a26173aeefa17c5a3 )
+)
+
+game (
+	name "Geist (USA)"
+	description "Geist (USA)"
+	rom ( name "Geist (USA).iso" size 1459978240 crc 2b606740 md5 e6519bc68b09b9587d2a0b62514a4f19 sha1 0ae8391712a8f3654228d58a26173aeefa17c5a3 )
+)
+
+game (
+	name "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (Japan)"
+	description "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (Japan)"
+	rom ( name "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (Japan).iso" size 1459978240 crc 1758503b md5 07227b055bbeb7868d5d960250606460 sha1 66c33dd39d28fe7f0a33d4a96f4c5a4e12e19e07 )
+)
+
+game (
+	name "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (JP) - Ji Dou puroYe Qiu +Shui Dao Xin Si orusutazu+VS+puroYe Qiu"
+	description "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (JP) - Ji Dou puroYe Qiu +Shui Dao Xin Si orusutazu+VS+puroYe Qiu"
+	rom ( name "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu (JP).iso" size 1459978240 crc 1758503b md5 07227b055bbeb7868d5d960250606460 sha1 66c33dd39d28fe7f0a33d4a96f4c5a4e12e19e07 )
+)
+
+game (
+	name "Generation of Chaos Exceed - Yami no Koujo Roze (Japan)"
+	description "Generation of Chaos Exceed - Yami no Koujo Roze (Japan)"
+	rom ( name "Generation of Chaos Exceed - Yami no Koujo Roze (Japan).iso" size 1459978240 crc a02c9488 md5 10ebf8122d7f51bbf6e02e4e913ded40 sha1 9231f18a0f51c09ff8a13ec3e9d779e7d49e50ca )
+)
+
+game (
+	name "Generation of Chaos Exceed - Yami no Koujo Roze (JP) - zieneresiyon obu kaosu ikusido ~An noHuang Nu roze~"
+	description "Generation of Chaos Exceed - Yami no Koujo Roze (JP) - zieneresiyon obu kaosu ikusido ~An noHuang Nu roze~"
+	rom ( name "Generation of Chaos Exceed - Yami no Koujo Roze (JP).iso" size 1459978240 crc a02c9488 md5 10ebf8122d7f51bbf6e02e4e913ded40 sha1 9231f18a0f51c09ff8a13ec3e9d779e7d49e50ca )
+)
+
+game (
+	name "Giant Egg - Billy Hatcher no Daibouken (Japan)"
+	description "Giant Egg - Billy Hatcher no Daibouken (Japan)"
+	rom ( name "Giant Egg - Billy Hatcher no Daibouken (Japan).iso" size 1459978240 crc 55ad7de7 md5 6b9169da201664446d6634bc24b908b2 sha1 0f0c9f900d0c45141d1450725366ffd2faf2a899 )
+)
+
+game (
+	name "Giant Egg - Billy Hatcher no Daibouken (JP) - ziyaiantoetugu+birihatutiyanoDa Mou Xian"
+	description "Giant Egg - Billy Hatcher no Daibouken (JP) - ziyaiantoetugu+birihatutiyanoDa Mou Xian"
+	rom ( name "Giant Egg - Billy Hatcher no Daibouken (JP).iso" size 1459978240 crc 55ad7de7 md5 6b9169da201664446d6634bc24b908b2 sha1 0f0c9f900d0c45141d1450725366ffd2faf2a899 )
+)
+
+game (
+	name "Giftpia (Japan)"
+	description "Giftpia (Japan)"
+	rom ( name "Giftpia (Japan).iso" size 1459978240 crc c06ab1af md5 ac8f05741e690cc3873a7189bb08d989 sha1 52d0610ae78a2a5bc4bdd79cf3bfcd97c7f0a638 )
+)
+
+game (
+	name "Giftpia (JP) - gihutopia"
+	description "Giftpia (JP) - gihutopia"
+	rom ( name "Giftpia (JP).iso" size 1459978240 crc c06ab1af md5 ac8f05741e690cc3873a7189bb08d989 sha1 52d0610ae78a2a5bc4bdd79cf3bfcd97c7f0a638 )
+)
+
+game (
+	name "Gladius (DE)"
+	description "Gladius (DE)"
+	rom ( name "Gladius (DE).iso" size 1459978240 crc fc4f3434 md5 9e28ad915cdf85d88149f6d12a4570c6 sha1 cf1ca0fe1ef6668a44ac7ffdef9f7b1838c6723c )
+)
+
+game (
+	name "Gladius (EU)"
+	description "Gladius (EU)"
+	rom ( name "Gladius (EU).iso" size 1459978240 crc b52a7368 md5 4e7f13f4599bc2f49db4e24e5269528a sha1 29bec8c0c44674edac8ed9b4852968816ef1861a )
+)
+
+game (
+	name "Gladius (Europe)"
+	description "Gladius (Europe)"
+	rom ( name "Gladius (Europe).iso" size 1459978240 crc b52a7368 md5 4e7f13f4599bc2f49db4e24e5269528a sha1 29bec8c0c44674edac8ed9b4852968816ef1861a )
+)
+
+game (
+	name "Gladius (Germany)"
+	description "Gladius (Germany)"
+	rom ( name "Gladius (Germany).iso" size 1459978240 crc fc4f3434 md5 9e28ad915cdf85d88149f6d12a4570c6 sha1 cf1ca0fe1ef6668a44ac7ffdef9f7b1838c6723c )
+)
+
+game (
+	name "Gladius (US)"
+	description "Gladius (US)"
+	rom ( name "Gladius (US).iso" size 1459978240 crc fb5f6c4f md5 a78d6e1c9de69886ce827ad2a7507339 sha1 e1d0ff67c91a5243b2fea6f288dc883b451ec238 )
+)
+
+game (
+	name "Gladius (USA)"
+	description "Gladius (USA)"
+	rom ( name "Gladius (USA).iso" size 1459978240 crc fb5f6c4f md5 a78d6e1c9de69886ce827ad2a7507339 sha1 e1d0ff67c91a5243b2fea6f288dc883b451ec238 )
+)
+
+game (
+	name "Go! Go! Hypergrind (US)"
+	description "Go! Go! Hypergrind (US)"
+	rom ( name "Go! Go! Hypergrind (US).iso" size 1459978240 crc c5aa4628 md5 f035b336cea1f00eb03c04b05af07cc0 sha1 6fcf4bffcd5e92f21579ef94358f7a4ed6191c5f )
+)
+
+game (
+	name "Go! Go! Hypergrind (USA)"
+	description "Go! Go! Hypergrind (USA)"
+	rom ( name "Go! Go! Hypergrind (USA).iso" size 1459978240 crc c5aa4628 md5 f035b336cea1f00eb03c04b05af07cc0 sha1 6fcf4bffcd5e92f21579ef94358f7a4ed6191c5f )
+)
+
+game (
+	name "Goblin Commander - Unleash the Horde (EU)"
+	description "Goblin Commander - Unleash the Horde (EU)"
+	rom ( name "Goblin Commander - Unleash the Horde (EU).iso" size 1459978240 crc 59f0535c md5 7a0a5b65f09a0a07dc3d3c024d01c50e sha1 d8d027aebbe59717628166bc03210a3f10bb5cb8 )
+)
+
+game (
+	name "Goblin Commander - Unleash the Horde (Europe) (En,Fr,De)"
+	description "Goblin Commander - Unleash the Horde (Europe) (En,Fr,De)"
+	rom ( name "Goblin Commander - Unleash the Horde (Europe) (En,Fr,De).iso" size 1459978240 crc 59f0535c md5 7a0a5b65f09a0a07dc3d3c024d01c50e sha1 d8d027aebbe59717628166bc03210a3f10bb5cb8 )
+)
+
+game (
+	name "Goblin Commander - Unleash the Horde (US)"
+	description "Goblin Commander - Unleash the Horde (US)"
+	rom ( name "Goblin Commander - Unleash the Horde (US).iso" size 1459978240 crc b2398c14 md5 c2faef3ecffb3fabbf2e411cfc0d0036 sha1 2fcceaccb763208f084540f2c06bbdeb8573d294 )
+)
+
+game (
+	name "Goblin Commander - Unleash the Horde (USA)"
+	description "Goblin Commander - Unleash the Horde (USA)"
+	rom ( name "Goblin Commander - Unleash the Horde (USA).iso" size 1459978240 crc b2398c14 md5 c2faef3ecffb3fabbf2e411cfc0d0036 sha1 2fcceaccb763208f084540f2c06bbdeb8573d294 )
+)
+
+game (
+	name "Godzilla - Destroy All Monsters Melee (EU)"
+	description "Godzilla - Destroy All Monsters Melee (EU)"
+	rom ( name "Godzilla - Destroy All Monsters Melee (EU).iso" size 1459978240 crc 54e53d5a md5 72618787a045f59ecb6d1246d4ca0935 sha1 83747f8a7153e8cbb24ce52de93e77d799f02408 )
+)
+
+game (
+	name "Godzilla - Destroy All Monsters Melee (Europe) (En,Fr,De,Es,It)"
+	description "Godzilla - Destroy All Monsters Melee (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Godzilla - Destroy All Monsters Melee (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 54e53d5a md5 72618787a045f59ecb6d1246d4ca0935 sha1 83747f8a7153e8cbb24ce52de93e77d799f02408 )
+)
+
+game (
+	name "Godzilla - Destroy All Monsters Melee (US)"
+	description "Godzilla - Destroy All Monsters Melee (US)"
+	rom ( name "Godzilla - Destroy All Monsters Melee (US).iso" size 1459978240 crc 95c6df8f md5 c07222ef7cb99341b68301e92d9c1c5d sha1 f4cbd98d090043c3ccc5d0a7365c3d09a24bba86 )
+)
+
+game (
+	name "Godzilla - Destroy All Monsters Melee (USA)"
+	description "Godzilla - Destroy All Monsters Melee (USA)"
+	rom ( name "Godzilla - Destroy All Monsters Melee (USA).iso" size 1459978240 crc 95c6df8f md5 c07222ef7cb99341b68301e92d9c1c5d sha1 f4cbd98d090043c3ccc5d0a7365c3d09a24bba86 )
+)
+
+game (
+	name "Godzilla - Kaijuu Dairantou (Japan)"
+	description "Godzilla - Kaijuu Dairantou (Japan)"
+	rom ( name "Godzilla - Kaijuu Dairantou (Japan).iso" size 1459978240 crc 8c5efd4d md5 0c6915aa951c86448f886667271ca888 sha1 6884b97138b61025ed3b9b9b435e811adb1ac52e )
+)
+
+game (
+	name "Godzilla - Kaijuu Dairantou (JP) - gozira Guai Swu Da Luan Dou"
+	description "Godzilla - Kaijuu Dairantou (JP) - gozira Guai Swu Da Luan Dou"
+	rom ( name "Godzilla - Kaijuu Dairantou (JP).iso" size 1459978240 crc 8c5efd4d md5 0c6915aa951c86448f886667271ca888 sha1 6884b97138b61025ed3b9b9b435e811adb1ac52e )
+)
+
+game (
+	name "GoldenEye - Agente Corrupto (ES)"
+	description "GoldenEye - Agente Corrupto (ES)"
+	rom ( name "GoldenEye - Agente Corrupto (ES) - (Disc 1 of 2).iso" size 1459978240 crc 8a1122d6 md5 75751a30aca36dd24df97f05f9b2bc5d sha1 6973f79e43f83392e2901913a20dbbf0ed3b44f1 )
+)
+
+game (
+	name "GoldenEye - Agente Corrupto (Spain) (Disc 1)"
+	description "GoldenEye - Agente Corrupto (Spain) (Disc 1)"
+	rom ( name "GoldenEye - Agente Corrupto (Spain) (Disc 1).iso" size 1459978240 crc 8a1122d6 md5 75751a30aca36dd24df97f05f9b2bc5d sha1 6973f79e43f83392e2901913a20dbbf0ed3b44f1 )
+)
+
+game (
+	name "GoldenEye - Agente Corrupto (Spain) (Disc 2)"
+	description "GoldenEye - Agente Corrupto (Spain) (Disc 2)"
+	rom ( name "GoldenEye - Agente Corrupto (Spain) (Disc 2).iso" size 1459978240 crc 6f6dd988 md5 700a28a8f1287c85e8d39595a547097f sha1 582a2b0d1ab271f71c789c53f43625447b7234e0 )
+)
+
+game (
+	name "GoldenEye - Dark Agent (Japan) (Disc 1)"
+	description "GoldenEye - Dark Agent (Japan) (Disc 1)"
+	rom ( name "GoldenEye - Dark Agent (Japan) (Disc 1).iso" size 1459978240 crc 667a54f1 md5 663f6c14d5bcc8d9c3d1f89edc1523c3 sha1 52df6d3938dd8e1de56c5b72921ba51f71083960 )
+)
+
+game (
+	name "GoldenEye - Dark Agent (Japan) (Disc 2)"
+	description "GoldenEye - Dark Agent (Japan) (Disc 2)"
+	rom ( name "GoldenEye - Dark Agent (Japan) (Disc 2).iso" size 1459978240 crc ae9eb914 md5 fa4ea21237c6a0c62f8ef90ce288ef75 sha1 e280dc1f5b62bf3e0fdd0d4ca2b1fee126cfbf47 )
+)
+
+game (
+	name "GoldenEye - Dark Agent (JP) - gorudenai+dakueziento"
+	description "GoldenEye - Dark Agent (JP) - gorudenai+dakueziento"
+	rom ( name "GoldenEye - Dark Agent (JP) - (Disc 1 of 2).iso" size 1459978240 crc 667a54f1 md5 663f6c14d5bcc8d9c3d1f89edc1523c3 sha1 52df6d3938dd8e1de56c5b72921ba51f71083960 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (DE)"
+	description "GoldenEye - Rogue Agent (DE)"
+	rom ( name "GoldenEye - Rogue Agent (DE) - (Disc 1 of 2).iso" size 1459978240 crc 0e162916 md5 c2782e38279e020191c516943d15e8d3 sha1 b7d281d25645f88fc57bd4665c711969823c2f98 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (EU)"
+	description "GoldenEye - Rogue Agent (EU)"
+	rom ( name "GoldenEye - Rogue Agent (EU) - (Disc 1 of 2).iso" size 1459978240 crc 6467ec57 md5 c0cfc5c7cf21e93efebdb5461578130d sha1 e8656530cd6c99f1d72320d3f9dbd19688c246d0 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 1)"
+	description "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 1)"
+	rom ( name "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 1).iso" size 1459978240 crc 6467ec57 md5 c0cfc5c7cf21e93efebdb5461578130d sha1 e8656530cd6c99f1d72320d3f9dbd19688c246d0 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 2)"
+	description "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 2)"
+	rom ( name "GoldenEye - Rogue Agent (Europe) (En,It,Nl,Sv) (Disc 2).iso" size 1459978240 crc 638836f2 md5 1b8165c8d2db2563158f1d2709f30849 sha1 a422026df608ef8740244880a1c53147d97d2a71 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (FR)"
+	description "GoldenEye - Rogue Agent (FR)"
+	rom ( name "GoldenEye - Rogue Agent (FR) - (Disc 1 of 2).iso" size 1459978240 crc 4564bb01 md5 08110ba8ac059a8f735bf951bee12edd sha1 107e792ae93495179f5bd657da166947751e37cc )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (France) (Disc 1)"
+	description "GoldenEye - Rogue Agent (France) (Disc 1)"
+	rom ( name "GoldenEye - Rogue Agent (France) (Disc 1).iso" size 1459978240 crc 4564bb01 md5 08110ba8ac059a8f735bf951bee12edd sha1 107e792ae93495179f5bd657da166947751e37cc )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (France) (Disc 2)"
+	description "GoldenEye - Rogue Agent (France) (Disc 2)"
+	rom ( name "GoldenEye - Rogue Agent (France) (Disc 2).iso" size 1459978240 crc dba8aa7f md5 57f801c71548bd7a6e281b0b028a4ac6 sha1 7bb6875321b6ea90146bfb71bb730f6317c2a172 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (Germany) (Disc 1)"
+	description "GoldenEye - Rogue Agent (Germany) (Disc 1)"
+	rom ( name "GoldenEye - Rogue Agent (Germany) (Disc 1).iso" size 1459978240 crc 0e162916 md5 c2782e38279e020191c516943d15e8d3 sha1 b7d281d25645f88fc57bd4665c711969823c2f98 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (Germany) (Disc 2)"
+	description "GoldenEye - Rogue Agent (Germany) (Disc 2)"
+	rom ( name "GoldenEye - Rogue Agent (Germany) (Disc 2).iso" size 1459978240 crc f1e31557 md5 8fcba9f784c49b257796e16def1f69f0 sha1 1eebe76262f20080fd0481afe915ea14afdc5377 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (US)"
+	description "GoldenEye - Rogue Agent (US)"
+	rom ( name "GoldenEye - Rogue Agent (US) - (Disc 1 of 2).iso" size 1459978240 crc c9c97e97 md5 90b22781a7d78756548b0b2d954ffb45 sha1 9f218f5fa87406a596fd7a070bd6be8bea3ae1d3 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (USA) (Disc 1)"
+	description "GoldenEye - Rogue Agent (USA) (Disc 1)"
+	rom ( name "GoldenEye - Rogue Agent (USA) (Disc 1).iso" size 1459978240 crc c9c97e97 md5 90b22781a7d78756548b0b2d954ffb45 sha1 9f218f5fa87406a596fd7a070bd6be8bea3ae1d3 )
+)
+
+game (
+	name "GoldenEye - Rogue Agent (USA) (Disc 2)"
+	description "GoldenEye - Rogue Agent (USA) (Disc 2)"
+	rom ( name "GoldenEye - Rogue Agent (USA) (Disc 2).iso" size 1459978240 crc 22e8d92b md5 5e64f97b46fb8168417d87bdef14cb05 sha1 09405c4b97d0d687492dc76a80301e04abd001b3 )
+)
+
+game (
+	name "Gotcha Force (EU)"
+	description "Gotcha Force (EU)"
+	rom ( name "Gotcha Force (EU).iso" size 1459978240 crc 5531245a md5 a1b1a397d23d9e8d68422325138469e8 sha1 a94df10304e6a18827c7325169e9ace117f17a00 )
+)
+
+game (
+	name "Gotcha Force (Europe) (En,Fr,De)"
+	description "Gotcha Force (Europe) (En,Fr,De)"
+	rom ( name "Gotcha Force (Europe) (En,Fr,De).iso" size 1459978240 crc 5531245a md5 a1b1a397d23d9e8d68422325138469e8 sha1 a94df10304e6a18827c7325169e9ace117f17a00 )
+)
+
+game (
+	name "Gotcha Force (Japan)"
+	description "Gotcha Force (Japan)"
+	rom ( name "Gotcha Force (Japan).iso" size 1459978240 crc 62d97378 md5 4473742552671f2054a44f539fcd9486 sha1 1b413f219a47e6b3e862a3f7a469a046e88be893 )
+)
+
+game (
+	name "Gotcha Force (JP) - gatiyahuosu"
+	description "Gotcha Force (JP) - gatiyahuosu"
+	rom ( name "Gotcha Force (JP).iso" size 1459978240 crc 62d97378 md5 4473742552671f2054a44f539fcd9486 sha1 1b413f219a47e6b3e862a3f7a469a046e88be893 )
+)
+
+game (
+	name "Gotcha Force (US)"
+	description "Gotcha Force (US)"
+	rom ( name "Gotcha Force (US).iso" size 1459978240 crc dd429377 md5 2198b7b63bb61996ac7da3eeb4a6f3eb sha1 dfe963e5070b9bec02bbbefba3f038b04dac953e )
+)
+
+game (
+	name "Gotcha Force (USA)"
+	description "Gotcha Force (USA)"
+	rom ( name "Gotcha Force (USA).iso" size 1459978240 crc dd429377 md5 2198b7b63bb61996ac7da3eeb4a6f3eb sha1 dfe963e5070b9bec02bbbefba3f038b04dac953e )
+)
+
+game (
+	name "Grim Adventures of Billy & Mandy, The (US)"
+	description "Grim Adventures of Billy & Mandy, The (US)"
+	rom ( name "Grim Adventures of Billy & Mandy, The (US).iso" size 1459978240 crc 7540bd03 md5 4a1d6c9ac138932e5a6486f49297a007 sha1 6011cd05f76f3f9bf5dc4af76a671f2f7630e995 )
+)
+
+game (
+	name "Grim Adventures of Billy & Mandy, The (USA)"
+	description "Grim Adventures of Billy & Mandy, The (USA)"
+	rom ( name "Grim Adventures of Billy & Mandy, The (USA).iso" size 1459978240 crc 7540bd03 md5 4a1d6c9ac138932e5a6486f49297a007 sha1 6011cd05f76f3f9bf5dc4af76a671f2f7630e995 )
+)
+
+game (
+	name "Groove Adventure Rave - Fighting Live (Japan)"
+	description "Groove Adventure Rave - Fighting Live (Japan)"
+	rom ( name "Groove Adventure Rave - Fighting Live (Japan).iso" size 1459978240 crc 92c7291f md5 7daf74bd604e36dcaec07085d3d62954 sha1 327d082e64c50c87c85f14a81ecf339e5343f559 )
+)
+
+game (
+	name "Groove Adventure Rave - Fighting Live (JP) - guruvu+adobentiya+reivu+huaiteinguraibu"
+	description "Groove Adventure Rave - Fighting Live (JP) - guruvu+adobentiya+reivu+huaiteinguraibu"
+	rom ( name "Groove Adventure Rave - Fighting Live (JP).iso" size 1459978240 crc 92c7291f md5 7daf74bd604e36dcaec07085d3d62954 sha1 327d082e64c50c87c85f14a81ecf339e5343f559 )
+)
+
+game (
+	name "Grooverider - Slot Car Thunder (US)"
+	description "Grooverider - Slot Car Thunder (US)"
+	rom ( name "Grooverider - Slot Car Thunder (US).iso" size 1459978240 crc 9dd1131e md5 009d434d0913930bdaeae6d164909a26 sha1 5ce2766c9d231f367e15166048afe516e5a038b3 )
+)
+
+game (
+	name "Grooverider - Slot Car Thunder (USA)"
+	description "Grooverider - Slot Car Thunder (USA)"
+	rom ( name "Grooverider - Slot Car Thunder (USA).iso" size 1459978240 crc 9dd1131e md5 009d434d0913930bdaeae6d164909a26 sha1 5ce2766c9d231f367e15166048afe516e5a038b3 )
+)
+
+game (
+	name "GT Cube (Japan)"
+	description "GT Cube (Japan)"
+	rom ( name "GT Cube (Japan).iso" size 1459978240 crc 9d548e41 md5 c597b036def037e7f35013aa50ffcaea sha1 49e6a3ca391ae5870171f50c08be0df4985e7522 )
+)
+
+game (
+	name "GT Cube (JP) - ziteikiyubu"
+	description "GT Cube (JP) - ziteikiyubu"
+	rom ( name "GT Cube (JP).iso" size 1459978240 crc 9d548e41 md5 c597b036def037e7f35013aa50ffcaea sha1 49e6a3ca391ae5870171f50c08be0df4985e7522 )
+)
+
+game (
+	name "Gun (DE)"
+	description "Gun (DE)"
+	rom ( name "Gun (DE).iso" size 1459978240 crc fd40ca10 md5 83f9a8c0d653479e6278e87f81087ef1 sha1 884b09969e5739c5ef5beb3fd0fb694a4c71c529 )
+)
+
+game (
+	name "Gun (EU)"
+	description "Gun (EU)"
+	rom ( name "Gun (EU).iso" size 1459978240 crc aa652d0d md5 fa092e0701f2c02bca4d614ee74e073b sha1 cd3674a6537b4f50cbbc4533e354288c7ae11318 )
+)
+
+game (
+	name "Gun (Europe) (En,Fr,Es,It)"
+	description "Gun (Europe) (En,Fr,Es,It)"
+	rom ( name "Gun (Europe) (En,Fr,Es,It).iso" size 1459978240 crc aa652d0d md5 fa092e0701f2c02bca4d614ee74e073b sha1 cd3674a6537b4f50cbbc4533e354288c7ae11318 )
+)
+
+game (
+	name "Gun (Germany) (En,De)"
+	description "Gun (Germany) (En,De)"
+	rom ( name "Gun (Germany) (En,De).iso" size 1459978240 crc fd40ca10 md5 83f9a8c0d653479e6278e87f81087ef1 sha1 884b09969e5739c5ef5beb3fd0fb694a4c71c529 )
+)
+
+game (
+	name "Gun (US)"
+	description "Gun (US)"
+	rom ( name "Gun (US).iso" size 1459978240 crc f06ee11b md5 29ca9557c484216e7dc15f08d7b21812 sha1 ca106930bbc2c724b48bf470347220a2f7348dbd )
+)
+
+game (
+	name "Gun (USA)"
+	description "Gun (USA)"
+	rom ( name "Gun (USA).iso" size 1459978240 crc f06ee11b md5 29ca9557c484216e7dc15f08d7b21812 sha1 ca106930bbc2c724b48bf470347220a2f7348dbd )
+)
+
+game (
+	name "Happy Feet (US)"
+	description "Happy Feet (US)"
+	rom ( name "Happy Feet (US).iso" size 1459978240 crc 3c4be722 md5 d036e1820b9ec692c1040b045db78c73 sha1 aeac0856b5c32a4e85d7014392b276d80eedc532 )
+)
+
+game (
+	name "Happy Feet (USA) (En,Fr)"
+	description "Happy Feet (USA) (En,Fr)"
+	rom ( name "Happy Feet (USA) (En,Fr).iso" size 1459978240 crc 3c4be722 md5 d036e1820b9ec692c1040b045db78c73 sha1 aeac0856b5c32a4e85d7014392b276d80eedc532 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (DE^FR^IT^ES)"
+	description "Harry Potter - Quidditch World Cup (DE^FR^IT^ES)"
+	rom ( name "Harry Potter - Quidditch World Cup (DE^FR^IT^ES).iso" size 1459978240 crc d123dc76 md5 4ff1402cff7f8d3fb64b2e8a67b4f54d sha1 b61f925504aac322b2a8961ef3ba7c1cd969d64f )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (EU)"
+	description "Harry Potter - Quidditch World Cup (EU)"
+	rom ( name "Harry Potter - Quidditch World Cup (EU).iso" size 1459978240 crc 8d4011e2 md5 24b0bd8e6ea071750bcc5e115a9aee38 sha1 e0bdd08941986b2d485b5e55c389a3db327152c3 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (Europe) (En,Nl,Sv)"
+	description "Harry Potter - Quidditch World Cup (Europe) (En,Nl,Sv)"
+	rom ( name "Harry Potter - Quidditch World Cup (Europe) (En,Nl,Sv).iso" size 1459978240 crc 8d4011e2 md5 24b0bd8e6ea071750bcc5e115a9aee38 sha1 e0bdd08941986b2d485b5e55c389a3db327152c3 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (Europe) (Fr,De,Es,It)"
+	description "Harry Potter - Quidditch World Cup (Europe) (Fr,De,Es,It)"
+	rom ( name "Harry Potter - Quidditch World Cup (Europe) (Fr,De,Es,It).iso" size 1459978240 crc d123dc76 md5 4ff1402cff7f8d3fb64b2e8a67b4f54d sha1 b61f925504aac322b2a8961ef3ba7c1cd969d64f )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (Japan)"
+	description "Harry Potter - Quidditch World Cup (Japan)"
+	rom ( name "Harry Potter - Quidditch World Cup (Japan).iso" size 1459978240 crc c74b831c md5 4d82e431211ec394efaa041b027319f8 sha1 c63a474e3cbfd8c4a5424c74a6e8ef73b96ceea1 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (JP) - haripotuta+kuideituti+warudokatupu"
+	description "Harry Potter - Quidditch World Cup (JP) - haripotuta+kuideituti+warudokatupu"
+	rom ( name "Harry Potter - Quidditch World Cup (JP).iso" size 1459978240 crc c74b831c md5 4d82e431211ec394efaa041b027319f8 sha1 c63a474e3cbfd8c4a5424c74a6e8ef73b96ceea1 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (US)"
+	description "Harry Potter - Quidditch World Cup (US)"
+	rom ( name "Harry Potter - Quidditch World Cup (US).iso" size 1459978240 crc 7a4816b9 md5 72b04d46b25c1af1145d210e06640d03 sha1 786007bda7ccbf90b6894ef7116fc16ce05a3ff1 )
+)
+
+game (
+	name "Harry Potter - Quidditch World Cup (USA) (En,Fr,Es)"
+	description "Harry Potter - Quidditch World Cup (USA) (En,Fr,Es)"
+	rom ( name "Harry Potter - Quidditch World Cup (USA) (En,Fr,Es).iso" size 1459978240 crc 7a4816b9 md5 72b04d46b25c1af1145d210e06640d03 sha1 786007bda7ccbf90b6894ef7116fc16ce05a3ff1 )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (DE^FR)"
+	description "Harry Potter and the Chamber of Secrets (DE^FR)"
+	rom ( name "Harry Potter and the Chamber of Secrets (DE^FR).iso" size 1459978240 crc e97541b4 md5 d1c41b717ea84f7cefd8157591665ec0 sha1 5cfc262cfe3f0bb06417b42ada960b7cddbbb948 )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (Europe)"
+	description "Harry Potter and the Chamber of Secrets (Europe)"
+	rom ( name "Harry Potter and the Chamber of Secrets (Europe).iso" size 1459978240 crc 97d0fbb3 md5 2e0df737435beb701c77672d7e80e113 sha1 92c7119517cd53c75a7c13f302951b53810e2c2c )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (Europe) (En,Fr,De)"
+	description "Harry Potter and the Chamber of Secrets (Europe) (En,Fr,De)"
+	rom ( name "Harry Potter and the Chamber of Secrets (Europe) (En,Fr,De).iso" size 1459978240 crc e97541b4 md5 d1c41b717ea84f7cefd8157591665ec0 sha1 5cfc262cfe3f0bb06417b42ada960b7cddbbb948 )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (Europe) (Es,It,Pt)"
+	description "Harry Potter and the Chamber of Secrets (Europe) (Es,It,Pt)"
+	rom ( name "Harry Potter and the Chamber of Secrets (Europe) (Es,It,Pt).iso" size 1459978240 crc ea3a774b md5 a93940325551e194cb844b01ee58ce87 sha1 8d1f052bee04e1b0696b85cb65fb2177077292c8 )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (GB)"
+	description "Harry Potter and the Chamber of Secrets (GB)"
+	rom ( name "Harry Potter and the Chamber of Secrets (GB).iso" size 1459978240 crc 97d0fbb3 md5 2e0df737435beb701c77672d7e80e113 sha1 92c7119517cd53c75a7c13f302951b53810e2c2c )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (IT^ES)"
+	description "Harry Potter and the Chamber of Secrets (IT^ES)"
+	rom ( name "Harry Potter and the Chamber of Secrets (IT^ES).iso" size 1459978240 crc ea3a774b md5 a93940325551e194cb844b01ee58ce87 sha1 8d1f052bee04e1b0696b85cb65fb2177077292c8 )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (US)"
+	description "Harry Potter and the Chamber of Secrets (US)"
+	rom ( name "Harry Potter and the Chamber of Secrets (US).iso" size 1459978240 crc 115f3228 md5 233351fd9856337ac9ff799f520a52d3 sha1 1d95b792293ccdb5b12b7551105998cbcfbbdb1f )
+)
+
+game (
+	name "Harry Potter and the Chamber of Secrets (USA)"
+	description "Harry Potter and the Chamber of Secrets (USA)"
+	rom ( name "Harry Potter and the Chamber of Secrets (USA).iso" size 1459978240 crc 115f3228 md5 233351fd9856337ac9ff799f520a52d3 sha1 1d95b792293ccdb5b12b7551105998cbcfbbdb1f )
+)
+
+game (
+	name "Harry Potter and the Goblet of Fire (Europe)"
+	description "Harry Potter and the Goblet of Fire (Europe)"
+	rom ( name "Harry Potter and the Goblet of Fire (Europe).iso" size 1459978240 crc ad2d1a78 md5 cf0749fd978e8d2066b724e96f669570 sha1 a5b26a200702536eeba16cfe2e6bfde5c1c7fe8b )
+)
+
+game (
+	name "Harry Potter and the Goblet of Fire (GB)"
+	description "Harry Potter and the Goblet of Fire (GB)"
+	rom ( name "Harry Potter and the Goblet of Fire (GB).iso" size 1459978240 crc ad2d1a78 md5 cf0749fd978e8d2066b724e96f669570 sha1 a5b26a200702536eeba16cfe2e6bfde5c1c7fe8b )
+)
+
+game (
+	name "Harry Potter and the Goblet of Fire (US)"
+	description "Harry Potter and the Goblet of Fire (US)"
+	rom ( name "Harry Potter and the Goblet of Fire (US).iso" size 1459978240 crc 66e3a8f7 md5 6a503ca555cb774e107c39abbeb96754 sha1 5b6032bcc40f30913b305e2460ca781eadfe5bfc )
+)
+
+game (
+	name "Harry Potter and the Goblet of Fire (USA)"
+	description "Harry Potter and the Goblet of Fire (USA)"
+	rom ( name "Harry Potter and the Goblet of Fire (USA).iso" size 1459978240 crc 66e3a8f7 md5 6a503ca555cb774e107c39abbeb96754 sha1 5b6032bcc40f30913b305e2460ca781eadfe5bfc )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (DE^FR)"
+	description "Harry Potter and the Philosopher's Stone (DE^FR)"
+	rom ( name "Harry Potter and the Philosopher's Stone (DE^FR).iso" size 1459978240 crc 777b2324 md5 842a62b31fd88034926757b6fb8cf619 sha1 08e811a257c1ab73a3ac1b04d42117fad7c92fc5 )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (EU)"
+	description "Harry Potter and the Philosopher's Stone (EU)"
+	rom ( name "Harry Potter and the Philosopher's Stone (EU).iso" size 1459978240 crc 643145c6 md5 466291326b0d1b111c669d3e85ff72d5 sha1 9d9b786a025050fcd4a009cb505f4dbbe0459c48 )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (Europe) (En,Nl)"
+	description "Harry Potter and the Philosopher's Stone (Europe) (En,Nl)"
+	rom ( name "Harry Potter and the Philosopher's Stone (Europe) (En,Nl).iso" size 1459978240 crc 643145c6 md5 466291326b0d1b111c669d3e85ff72d5 sha1 9d9b786a025050fcd4a009cb505f4dbbe0459c48 )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (Europe) (En,Sv)"
+	description "Harry Potter and the Philosopher's Stone (Europe) (En,Sv)"
+	rom ( name "Harry Potter and the Philosopher's Stone (Europe) (En,Sv).iso" size 1459978240 crc f3cc9d08 md5 9e9f4d3a03541165060c7f0c22ec146f sha1 eefb8cff54c448f291dcf3c27c4f7fbbe0298e49 )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (Europe) (Es,It)"
+	description "Harry Potter and the Philosopher's Stone (Europe) (Es,It)"
+	rom ( name "Harry Potter and the Philosopher's Stone (Europe) (Es,It).iso" size 1459978240 crc 8a9850f1 md5 dbbba237e6c07cf2033b474e4a90c91d sha1 1881498a7fb9ae0f2147b85a3dd27b1676d6b3cd )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (Europe) (Fr,De)"
+	description "Harry Potter and the Philosopher's Stone (Europe) (Fr,De)"
+	rom ( name "Harry Potter and the Philosopher's Stone (Europe) (Fr,De).iso" size 1459978240 crc 777b2324 md5 842a62b31fd88034926757b6fb8cf619 sha1 08e811a257c1ab73a3ac1b04d42117fad7c92fc5 )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (IT^ES)"
+	description "Harry Potter and the Philosopher's Stone (IT^ES)"
+	rom ( name "Harry Potter and the Philosopher's Stone (IT^ES).iso" size 1459978240 crc 8a9850f1 md5 dbbba237e6c07cf2033b474e4a90c91d sha1 1881498a7fb9ae0f2147b85a3dd27b1676d6b3cd )
+)
+
+game (
+	name "Harry Potter and the Philosopher's Stone (SE)"
+	description "Harry Potter and the Philosopher's Stone (SE)"
+	rom ( name "Harry Potter and the Philosopher's Stone (SE).iso" size 1459978240 crc f3cc9d08 md5 9e9f4d3a03541165060c7f0c22ec146f sha1 eefb8cff54c448f291dcf3c27c4f7fbbe0298e49 )
+)
+
+game (
+	name "Harry Potter and the Prisoner of Azkaban (Europe)"
+	description "Harry Potter and the Prisoner of Azkaban (Europe)"
+	rom ( name "Harry Potter and the Prisoner of Azkaban (Europe).iso" size 1459978240 crc 1084d213 md5 ef68b05b8c165a81b1cd2db3e4d55a31 sha1 9d523ca3584b20a0335ebc93d31384c8eec1534b )
+)
+
+game (
+	name "Harry Potter and the Prisoner of Azkaban (GB)"
+	description "Harry Potter and the Prisoner of Azkaban (GB)"
+	rom ( name "Harry Potter and the Prisoner of Azkaban (GB).iso" size 1459978240 crc 1084d213 md5 ef68b05b8c165a81b1cd2db3e4d55a31 sha1 9d523ca3584b20a0335ebc93d31384c8eec1534b )
+)
+
+game (
+	name "Harry Potter and the Prisoner of Azkaban (US)"
+	description "Harry Potter and the Prisoner of Azkaban (US)"
+	rom ( name "Harry Potter and the Prisoner of Azkaban (US).iso" size 1459978240 crc 9adb1f47 md5 7a064f4fcdd9a320b626899c3cc41200 sha1 88013b5726128dec738453d361fb0704a826ef14 )
+)
+
+game (
+	name "Harry Potter and the Prisoner of Azkaban (USA)"
+	description "Harry Potter and the Prisoner of Azkaban (USA)"
+	rom ( name "Harry Potter and the Prisoner of Azkaban (USA).iso" size 1459978240 crc 9adb1f47 md5 7a064f4fcdd9a320b626899c3cc41200 sha1 88013b5726128dec738453d361fb0704a826ef14 )
+)
+
+game (
+	name "Harry Potter and the Sorcerer's Stone (US)"
+	description "Harry Potter and the Sorcerer's Stone (US)"
+	rom ( name "Harry Potter and the Sorcerer's Stone (US).iso" size 1459978240 crc 3d08dd19 md5 047000888da263ff4485a6756671204f sha1 e6c71386f53430080b8622d3efd7641c0af3f4b5 )
+)
+
+game (
+	name "Harry Potter and the Sorcerer's Stone (USA) (En,Es)"
+	description "Harry Potter and the Sorcerer's Stone (USA) (En,Es)"
+	rom ( name "Harry Potter and the Sorcerer's Stone (USA) (En,Es).iso" size 1459978240 crc 3d08dd19 md5 047000888da263ff4485a6756671204f sha1 e6c71386f53430080b8622d3efd7641c0af3f4b5 )
+)
+
+game (
+	name "Harry Potter e il Calice di Fuoco (IT)"
+	description "Harry Potter e il Calice di Fuoco (IT)"
+	rom ( name "Harry Potter e il Calice di Fuoco (IT).iso" size 1459978240 crc 6efa63f0 md5 8b8cc5a5709eb6ece9414c48df94dc1c sha1 7f6556091b3722e675d2dacb07aff591bdec95e5 )
+)
+
+game (
+	name "Harry Potter e il Calice di Fuoco (Italy)"
+	description "Harry Potter e il Calice di Fuoco (Italy)"
+	rom ( name "Harry Potter e il Calice di Fuoco (Italy).iso" size 1459978240 crc 6efa63f0 md5 8b8cc5a5709eb6ece9414c48df94dc1c sha1 7f6556091b3722e675d2dacb07aff591bdec95e5 )
+)
+
+game (
+	name "Harry Potter e il Prigioniero di Azkaban (IT)"
+	description "Harry Potter e il Prigioniero di Azkaban (IT)"
+	rom ( name "Harry Potter e il Prigioniero di Azkaban (IT).iso" size 1459978240 crc 36eeac38 md5 4b149c0e3d330452d3f537aadc594304 sha1 f7c03aebc58eb26fcb2a482db88f3e71c6d04421 )
+)
+
+game (
+	name "Harry Potter e il Prigioniero di Azkaban (Italy)"
+	description "Harry Potter e il Prigioniero di Azkaban (Italy)"
+	rom ( name "Harry Potter e il Prigioniero di Azkaban (Italy).iso" size 1459978240 crc 36eeac38 md5 4b149c0e3d330452d3f537aadc594304 sha1 f7c03aebc58eb26fcb2a482db88f3e71c6d04421 )
+)
+
+game (
+	name "Harry Potter en de gevangene van Azkaban (Netherlands)"
+	description "Harry Potter en de gevangene van Azkaban (Netherlands)"
+	rom ( name "Harry Potter en de gevangene van Azkaban (Netherlands).iso" size 1459978240 crc 87b6039c md5 f28f08b06bc8972ef4cfa7f8a05d3f33 sha1 6a37241895fa091a2136e753ed43cf7f3cc1c907 )
+)
+
+game (
+	name "Harry Potter en de gevangene van Azkaban (NL)"
+	description "Harry Potter en de gevangene van Azkaban (NL)"
+	rom ( name "Harry Potter en de gevangene van Azkaban (NL).iso" size 1459978240 crc 87b6039c md5 f28f08b06bc8972ef4cfa7f8a05d3f33 sha1 6a37241895fa091a2136e753ed43cf7f3cc1c907 )
+)
+
+game (
+	name "Harry Potter en de Vuurbeker (Netherlands)"
+	description "Harry Potter en de Vuurbeker (Netherlands)"
+	rom ( name "Harry Potter en de Vuurbeker (Netherlands).iso" size 1459978240 crc d169b5cc md5 8fd35136abd95c7d8a244d86276a6636 sha1 1462b833667c15aa0914b6e5b73cd2b5244466b2 )
+)
+
+game (
+	name "Harry Potter en de Vuurbeker (NL)"
+	description "Harry Potter en de Vuurbeker (NL)"
+	rom ( name "Harry Potter en de Vuurbeker (NL).iso" size 1459978240 crc d169b5cc md5 8fd35136abd95c7d8a244d86276a6636 sha1 1462b833667c15aa0914b6e5b73cd2b5244466b2 )
+)
+
+game (
+	name "Harry Potter et la Coupe de Feu (FR)"
+	description "Harry Potter et la Coupe de Feu (FR)"
+	rom ( name "Harry Potter et la Coupe de Feu (FR).iso" size 1459978240 crc 1479b2d3 md5 749913df3075cf89bad39262448e0b6a sha1 d725e1587b7e005d3533e9af8fb9e5c7725f16e8 )
+)
+
+game (
+	name "Harry Potter et la Coupe de Feu (France)"
+	description "Harry Potter et la Coupe de Feu (France)"
+	rom ( name "Harry Potter et la Coupe de Feu (France).iso" size 1459978240 crc 1479b2d3 md5 749913df3075cf89bad39262448e0b6a sha1 d725e1587b7e005d3533e9af8fb9e5c7725f16e8 )
+)
+
+game (
+	name "Harry Potter et le Prisonnier d'Azkaban (FR)"
+	description "Harry Potter et le Prisonnier d'Azkaban (FR)"
+	rom ( name "Harry Potter et le Prisonnier d'Azkaban (FR).iso" size 1459978240 crc 84e0d67f md5 ffbbd8b2829f43d188465602905deeef sha1 7abf9c8f3a313962e28e152f2431a150244cb043 )
+)
+
+game (
+	name "Harry Potter et le Prisonnier d'Azkaban (France)"
+	description "Harry Potter et le Prisonnier d'Azkaban (France)"
+	rom ( name "Harry Potter et le Prisonnier d'Azkaban (France).iso" size 1459978240 crc 84e0d67f md5 ffbbd8b2829f43d188465602905deeef sha1 7abf9c8f3a313962e28e152f2431a150244cb043 )
+)
+
+game (
+	name "Harry Potter och den flammande Baegaren (SE)"
+	description "Harry Potter och den flammande Baegaren (SE)"
+	rom ( name "Harry Potter och den flammande Baegaren (SE).iso" size 1459978240 crc 9caa2a38 md5 a4e5e0d81dfd245475a987242e7d4585 sha1 798d5314bcf0e752f330585a452c34508d1e5b6c )
+)
+
+game (
+	name "Harry Potter och den flammande baegaren (Sweden)"
+	description "Harry Potter och den flammande baegaren (Sweden)"
+	rom ( name "Harry Potter och den flammande baegaren (Sweden).iso" size 1459978240 crc 9caa2a38 md5 a4e5e0d81dfd245475a987242e7d4585 sha1 798d5314bcf0e752f330585a452c34508d1e5b6c )
+)
+
+game (
+	name "Harry Potter och fangen fran Azkaban (SE)"
+	description "Harry Potter och fangen fran Azkaban (SE)"
+	rom ( name "Harry Potter och fangen fran Azkaban (SE).iso" size 1459978240 crc 7508a0e4 md5 571bbcbb06f5d15a247ea1acb941f364 sha1 001815d426be646ed7b4a83608ceba33d6da47a6 )
+)
+
+game (
+	name "Harry Potter och fangen fran Azkaban (Sweden)"
+	description "Harry Potter och fangen fran Azkaban (Sweden)"
+	rom ( name "Harry Potter och fangen fran Azkaban (Sweden).iso" size 1459978240 crc 7508a0e4 md5 571bbcbb06f5d15a247ea1acb941f364 sha1 001815d426be646ed7b4a83608ceba33d6da47a6 )
+)
+
+game (
+	name "Harry Potter to Azkaban no Shuujin (Japan)"
+	description "Harry Potter to Azkaban no Shuujin (Japan)"
+	rom ( name "Harry Potter to Azkaban no Shuujin (Japan).iso" size 1459978240 crc bd1bb981 md5 1e7a203a2c0be74281307fc122d6e93d sha1 71b41ae86b04a90cf49e6160a5bf2eb7e7d7d1b1 )
+)
+
+game (
+	name "Harry Potter to Azkaban no Shuujin (JP) - haripotutatoazukabannoQiu Ren"
+	description "Harry Potter to Azkaban no Shuujin (JP) - haripotutatoazukabannoQiu Ren"
+	rom ( name "Harry Potter to Azkaban no Shuujin (JP).iso" size 1459978240 crc bd1bb981 md5 1e7a203a2c0be74281307fc122d6e93d sha1 71b41ae86b04a90cf49e6160a5bf2eb7e7d7d1b1 )
+)
+
+game (
+	name "Harry Potter to Himitsu no Heiya (Japan)"
+	description "Harry Potter to Himitsu no Heiya (Japan)"
+	rom ( name "Harry Potter to Himitsu no Heiya (Japan).iso" size 1459978240 crc 1a09bb28 md5 23c11cdcfa81775a5fd6389df4878004 sha1 f7a6730a479da32b956ac744bd866a97d26fd25a )
+)
+
+game (
+	name "Harry Potter to Himitsu no Heiya (JP) - haripotutatoMi Mi noBu Wu"
+	description "Harry Potter to Himitsu no Heiya (JP) - haripotutatoMi Mi noBu Wu"
+	rom ( name "Harry Potter to Himitsu no Heiya (JP).iso" size 1459978240 crc 1a09bb28 md5 23c11cdcfa81775a5fd6389df4878004 sha1 f7a6730a479da32b956ac744bd866a97d26fd25a )
+)
+
+game (
+	name "Harry Potter to Honoo no Goblet (Japan)"
+	description "Harry Potter to Honoo no Goblet (Japan)"
+	rom ( name "Harry Potter to Honoo no Goblet (Japan).iso" size 1459978240 crc 7b3e25e3 md5 d47042f0bf060fa4abbfd74c2bfb9848 sha1 cfd0ff54d9a329a090b8d66eb21382f5ba31e718 )
+)
+
+game (
+	name "Harry Potter to Honoo no Goblet (JP) - haripotutatoYan nogoburetuto"
+	description "Harry Potter to Honoo no Goblet (JP) - haripotutatoYan nogoburetuto"
+	rom ( name "Harry Potter to Honoo no Goblet (JP).iso" size 1459978240 crc 7b3e25e3 md5 d47042f0bf060fa4abbfd74c2bfb9848 sha1 cfd0ff54d9a329a090b8d66eb21382f5ba31e718 )
+)
+
+game (
+	name "Harry Potter to Kenja no Ishi (Japan) (En,Ja)"
+	description "Harry Potter to Kenja no Ishi (Japan) (En,Ja)"
+	rom ( name "Harry Potter to Kenja no Ishi (Japan) (En,Ja).iso" size 1459978240 crc 8f5b7b5e md5 5916173cf3d75b4368da162507fffbfe sha1 42d307861eeddce818656bd9622be62281b381a1 )
+)
+
+game (
+	name "Harry Potter to Kenja no Ishi (JP) - haripotutatoXian Zhe noShi"
+	description "Harry Potter to Kenja no Ishi (JP) - haripotutatoXian Zhe noShi"
+	rom ( name "Harry Potter to Kenja no Ishi (JP).iso" size 1459978240 crc 8f5b7b5e md5 5916173cf3d75b4368da162507fffbfe sha1 42d307861eeddce818656bd9622be62281b381a1 )
+)
+
+game (
+	name "Harry Potter und der Feuerkelch (DE)"
+	description "Harry Potter und der Feuerkelch (DE)"
+	rom ( name "Harry Potter und der Feuerkelch (DE).iso" size 1459978240 crc 2a5ecf3a md5 a2780f60322f9ecd132a32c8279d95f3 sha1 e4243117d0f665b80c11a30d1277f64405284e4d )
+)
+
+game (
+	name "Harry Potter und der Feuerkelch (Germany)"
+	description "Harry Potter und der Feuerkelch (Germany)"
+	rom ( name "Harry Potter und der Feuerkelch (Germany).iso" size 1459978240 crc 2a5ecf3a md5 a2780f60322f9ecd132a32c8279d95f3 sha1 e4243117d0f665b80c11a30d1277f64405284e4d )
+)
+
+game (
+	name "Harry Potter und der Gefangene von Askaban (DE)"
+	description "Harry Potter und der Gefangene von Askaban (DE)"
+	rom ( name "Harry Potter und der Gefangene von Askaban (DE).iso" size 1459978240 crc 397a6b4b md5 00a408be48ed1385d6d2ea591e739e33 sha1 156ab9d9fc144eef0eccad966f5f0c850fd1ee96 )
+)
+
+game (
+	name "Harry Potter und der Gefangene von Askaban (Germany)"
+	description "Harry Potter und der Gefangene von Askaban (Germany)"
+	rom ( name "Harry Potter und der Gefangene von Askaban (Germany).iso" size 1459978240 crc 397a6b4b md5 00a408be48ed1385d6d2ea591e739e33 sha1 156ab9d9fc144eef0eccad966f5f0c850fd1ee96 )
+)
+
+game (
+	name "Harry Potter y el Caliz de Fuego (ES)"
+	description "Harry Potter y el Caliz de Fuego (ES)"
+	rom ( name "Harry Potter y el Caliz de Fuego (ES).iso" size 1459978240 crc 0f9f1b03 md5 293c8a344c44eacf3f0122d7335ba40d sha1 2a0dc449e863ff2472951513356417101978f9a8 )
+)
+
+game (
+	name "Harry Potter y el Caliz de Fuego (Spain)"
+	description "Harry Potter y el Caliz de Fuego (Spain)"
+	rom ( name "Harry Potter y el Caliz de Fuego (Spain).iso" size 1459978240 crc 0f9f1b03 md5 293c8a344c44eacf3f0122d7335ba40d sha1 2a0dc449e863ff2472951513356417101978f9a8 )
+)
+
+game (
+	name "Harry Potter y el prisionero de Azkaban (ES)"
+	description "Harry Potter y el prisionero de Azkaban (ES)"
+	rom ( name "Harry Potter y el prisionero de Azkaban (ES).iso" size 1459978240 crc 53801ce4 md5 f150ce3ef73bfcb788facd19cff0e483 sha1 9660223ba48bf94a98542a8564cb15cad23855e8 )
+)
+
+game (
+	name "Harry Potter y el prisionero de Azkaban (Spain)"
+	description "Harry Potter y el prisionero de Azkaban (Spain)"
+	rom ( name "Harry Potter y el prisionero de Azkaban (Spain).iso" size 1459978240 crc 53801ce4 md5 f150ce3ef73bfcb788facd19cff0e483 sha1 9660223ba48bf94a98542a8564cb15cad23855e8 )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (DE)"
+	description "Harvest Moon - A Wonderful Life (DE)"
+	rom ( name "Harvest Moon - A Wonderful Life (DE).iso" size 1459978240 crc e439a68b md5 4cfaa94313149c4bd839e965026a4240 sha1 c1061bdb1fb459f61ff576ccfa46f8f1a41a66ac )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (Europe)"
+	description "Harvest Moon - A Wonderful Life (Europe)"
+	rom ( name "Harvest Moon - A Wonderful Life (Europe).iso" size 1459978240 crc 877aeb09 md5 9e9b1d087aef6e2993c7bbd9e7b2fcc9 sha1 d7678741a5f42db157b0ca2087ad38fb33f11c64 )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (GB)"
+	description "Harvest Moon - A Wonderful Life (GB)"
+	rom ( name "Harvest Moon - A Wonderful Life (GB).iso" size 1459978240 crc 877aeb09 md5 9e9b1d087aef6e2993c7bbd9e7b2fcc9 sha1 d7678741a5f42db157b0ca2087ad38fb33f11c64 )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (Germany)"
+	description "Harvest Moon - A Wonderful Life (Germany)"
+	rom ( name "Harvest Moon - A Wonderful Life (Germany).iso" size 1459978240 crc e439a68b md5 4cfaa94313149c4bd839e965026a4240 sha1 c1061bdb1fb459f61ff576ccfa46f8f1a41a66ac )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (US)"
+	description "Harvest Moon - A Wonderful Life (US)"
+	rom ( name "Harvest Moon - A Wonderful Life (US).iso" size 1459978240 crc d5c265c1 md5 1b25d35660f163ebdc97165708b22f94 sha1 8d0f26063d0ebf2ea3e7a18e86de01b8cc1e5191 )
+)
+
+game (
+	name "Harvest Moon - A Wonderful Life (USA)"
+	description "Harvest Moon - A Wonderful Life (USA)"
+	rom ( name "Harvest Moon - A Wonderful Life (USA).iso" size 1459978240 crc d5c265c1 md5 1b25d35660f163ebdc97165708b22f94 sha1 8d0f26063d0ebf2ea3e7a18e86de01b8cc1e5191 )
+)
+
+game (
+	name "Harvest Moon - Another Wonderful Life (US)"
+	description "Harvest Moon - Another Wonderful Life (US)"
+	rom ( name "Harvest Moon - Another Wonderful Life (US).iso" size 1459978240 crc 2be7ea37 md5 af4bc131320ca06ab198202db78f3b06 sha1 55c2e08b7e3aa27ffb61c5d21385886ca5710532 )
+)
+
+game (
+	name "Harvest Moon - Another Wonderful Life (USA)"
+	description "Harvest Moon - Another Wonderful Life (USA)"
+	rom ( name "Harvest Moon - Another Wonderful Life (USA).iso" size 1459978240 crc 2be7ea37 md5 af4bc131320ca06ab198202db78f3b06 sha1 55c2e08b7e3aa27ffb61c5d21385886ca5710532 )
+)
+
+game (
+	name "Harvest Moon - Magical Melody (Player's Choice) (US)"
+	description "Harvest Moon - Magical Melody (Player's Choice) (US)"
+	rom ( name "Harvest Moon - Magical Melody (Player's Choice) (US).iso" size 1459978240 crc 02778d03 md5 0b84b6ba545ea33206392fe750401c2a sha1 d4a0c43d8749db80b2121736ceacef493d93d861 )
+)
+
+game (
+	name "Harvest Moon - Magical Melody (USA)"
+	description "Harvest Moon - Magical Melody (USA)"
+	rom ( name "Harvest Moon - Magical Melody (USA).iso" size 1459978240 crc 02778d03 md5 0b84b6ba545ea33206392fe750401c2a sha1 d4a0c43d8749db80b2121736ceacef493d93d861 )
+)
+
+game (
+	name "Hello Kitty - Roller Rescue (EU)"
+	description "Hello Kitty - Roller Rescue (EU)"
+	rom ( name "Hello Kitty - Roller Rescue (EU).iso" size 1459978240 crc b4c6d6d1 md5 3deee463f33437db5386c871baf0d5b4 sha1 5cafa0fbaa4dc4387cee49f4c03a909eefa474ed )
+)
+
+game (
+	name "Hello Kitty - Roller Rescue (Europe) (En,Fr,De,Es,It)"
+	description "Hello Kitty - Roller Rescue (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Hello Kitty - Roller Rescue (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b4c6d6d1 md5 3deee463f33437db5386c871baf0d5b4 sha1 5cafa0fbaa4dc4387cee49f4c03a909eefa474ed )
+)
+
+game (
+	name "Hello Kitty - Roller Rescue (US)"
+	description "Hello Kitty - Roller Rescue (US)"
+	rom ( name "Hello Kitty - Roller Rescue (US).iso" size 1459978240 crc d5946e12 md5 ab6549e841a3b091296b58d96f1eda12 sha1 0dffd6b0e3f46eab9945c8f81c7144fb0e26b315 )
+)
+
+game (
+	name "Hello Kitty - Roller Rescue (USA)"
+	description "Hello Kitty - Roller Rescue (USA)"
+	rom ( name "Hello Kitty - Roller Rescue (USA).iso" size 1459978240 crc d5946e12 md5 ab6549e841a3b091296b58d96f1eda12 sha1 0dffd6b0e3f46eab9945c8f81c7144fb0e26b315 )
+)
+
+game (
+	name "Herr der Ringe, Der - Das dritte Zeitalter (DE)"
+	description "Herr der Ringe, Der - Das dritte Zeitalter (DE)"
+	rom ( name "Herr der Ringe, Der - Das dritte Zeitalter (DE) - (Disc 1 of 2).iso" size 1459978240 crc 7d2f408e md5 0d8989d1d358af77ca2dccdb049d773f sha1 3584ebfd536358c470c1c846aa6f72d5ba85cf1c )
+)
+
+game (
+	name "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 1)"
+	description "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 1)"
+	rom ( name "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 1).iso" size 1459978240 crc 7d2f408e md5 0d8989d1d358af77ca2dccdb049d773f sha1 3584ebfd536358c470c1c846aa6f72d5ba85cf1c )
+)
+
+game (
+	name "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 2)"
+	description "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 2)"
+	rom ( name "Herr der Ringe, Der - Das dritte Zeitalter (Germany) (Disc 2).iso" size 1459978240 crc ad4ff1d8 md5 78855eb17863e7369c2c0583c2d86e4d sha1 1b78797c84f3ffad6b1895b06016d791884f4a8b )
+)
+
+game (
+	name "Herr der Ringe, Der - Die Rueckkehr des Koenigs (DE)"
+	description "Herr der Ringe, Der - Die Rueckkehr des Koenigs (DE)"
+	rom ( name "Herr der Ringe, Der - Die Rueckkehr des Koenigs (DE).iso" size 1459978240 crc 014ffa71 md5 7826cbe142afd44997649a646cecb1db sha1 a37eae6c2e7917b885a417e95b0215fe474b9679 )
+)
+
+game (
+	name "Herr der Ringe, Der - Die Rueckkehr des Koenigs (Germany)"
+	description "Herr der Ringe, Der - Die Rueckkehr des Koenigs (Germany)"
+	rom ( name "Herr der Ringe, Der - Die Rueckkehr des Koenigs (Germany).iso" size 1459978240 crc 014ffa71 md5 7826cbe142afd44997649a646cecb1db sha1 a37eae6c2e7917b885a417e95b0215fe474b9679 )
+)
+
+game (
+	name "Herr der Ringe, Der - Die zwei Tuerme (DE)"
+	description "Herr der Ringe, Der - Die zwei Tuerme (DE)"
+	rom ( name "Herr der Ringe, Der - Die zwei Tuerme (DE).iso" size 1459978240 crc 32129813 md5 9e516d61afea913a900c9ca3080ffe3b sha1 5d777bea6dc0505287860a73b71fe53a0348cae5 )
+)
+
+game (
+	name "Herr der Ringe, Der - Die zwei Tuerme (Germany)"
+	description "Herr der Ringe, Der - Die zwei Tuerme (Germany)"
+	rom ( name "Herr der Ringe, Der - Die zwei Tuerme (Germany).iso" size 1459978240 crc 32129813 md5 9e516d61afea913a900c9ca3080ffe3b sha1 5d777bea6dc0505287860a73b71fe53a0348cae5 )
+)
+
+game (
+	name "Hikaru no Go 3 (Japan)"
+	description "Hikaru no Go 3 (Japan)"
+	rom ( name "Hikaru no Go 3 (Japan).iso" size 1459978240 crc 9e36503d md5 b7311a73cc90c8a93cea01beaa362307 sha1 9fe49bae89fbcdf6afee711dd96fe89c696e1a19 )
+)
+
+game (
+	name "Hikaru no Go 3 (JP) - hikarunoQi 3"
+	description "Hikaru no Go 3 (JP) - hikarunoQi 3"
+	rom ( name "Hikaru no Go 3 (JP).iso" size 1459978240 crc 9e36503d md5 b7311a73cc90c8a93cea01beaa362307 sha1 9fe49bae89fbcdf6afee711dd96fe89c696e1a19 )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (DE)"
+	description "Hitman 2 - Silent Assassin (DE)"
+	rom ( name "Hitman 2 - Silent Assassin (DE).iso" size 1459978240 crc 8f650eec md5 fadfbfb9cd3aeba7ea2e96aceb0888dc sha1 4bf34297a1d54a22665a3a01e90b87996e2772df )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (Europe)"
+	description "Hitman 2 - Silent Assassin (Europe)"
+	rom ( name "Hitman 2 - Silent Assassin (Europe).iso" size 1459978240 crc 3477a697 md5 fdcf687f5016ddc57e49d6d2b0d6dc76 sha1 b96b6d78b72dde5eaad5c7cdb84fa9f54c88e515 )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (FR)"
+	description "Hitman 2 - Silent Assassin (FR)"
+	rom ( name "Hitman 2 - Silent Assassin (FR).iso" size 1459978240 crc b9dd012b md5 98dbb24142d799b1352743b33b6173ce sha1 53697fe56557ed1d988e52f478930e200368d7ea )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (France)"
+	description "Hitman 2 - Silent Assassin (France)"
+	rom ( name "Hitman 2 - Silent Assassin (France).iso" size 1459978240 crc b9dd012b md5 98dbb24142d799b1352743b33b6173ce sha1 53697fe56557ed1d988e52f478930e200368d7ea )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (GB)"
+	description "Hitman 2 - Silent Assassin (GB)"
+	rom ( name "Hitman 2 - Silent Assassin (GB).iso" size 1459978240 crc 3477a697 md5 fdcf687f5016ddc57e49d6d2b0d6dc76 sha1 b96b6d78b72dde5eaad5c7cdb84fa9f54c88e515 )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (Germany)"
+	description "Hitman 2 - Silent Assassin (Germany)"
+	rom ( name "Hitman 2 - Silent Assassin (Germany).iso" size 1459978240 crc 8f650eec md5 fadfbfb9cd3aeba7ea2e96aceb0888dc sha1 4bf34297a1d54a22665a3a01e90b87996e2772df )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (US)"
+	description "Hitman 2 - Silent Assassin (US)"
+	rom ( name "Hitman 2 - Silent Assassin (US).iso" size 1459978240 crc 23d81915 md5 b8808d20deebdcf6994b07a221d9a60f sha1 12b6b66ba3690f7c13c1723c119de92ff00f31ed )
+)
+
+game (
+	name "Hitman 2 - Silent Assassin (USA)"
+	description "Hitman 2 - Silent Assassin (USA)"
+	rom ( name "Hitman 2 - Silent Assassin (USA).iso" size 1459978240 crc 23d81915 md5 b8808d20deebdcf6994b07a221d9a60f sha1 12b6b66ba3690f7c13c1723c119de92ff00f31ed )
+)
+
+game (
+	name "Hobbit, The - The Prelude to the Lord of the Rings (EU)"
+	description "Hobbit, The - The Prelude to the Lord of the Rings (EU)"
+	rom ( name "Hobbit, The - The Prelude to the Lord of the Rings (EU).iso" size 1459978240 crc 41ebff57 md5 081a2f65a0aaf3377cb28eb2adcd82bf sha1 3fcbc8ec295f0f0847cf06120715fb83b35a3a60 )
+)
+
+game (
+	name "Hobbit, The - The Prelude to the Lord of the Rings (Europe) (En,Fr,De,Es,It)"
+	description "Hobbit, The - The Prelude to the Lord of the Rings (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Hobbit, The - The Prelude to the Lord of the Rings (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 41ebff57 md5 081a2f65a0aaf3377cb28eb2adcd82bf sha1 3fcbc8ec295f0f0847cf06120715fb83b35a3a60 )
+)
+
+game (
+	name "Hobbit, The - The Prelude to the Lord of the Rings (US)"
+	description "Hobbit, The - The Prelude to the Lord of the Rings (US)"
+	rom ( name "Hobbit, The - The Prelude to the Lord of the Rings (US).iso" size 1459978240 crc 54ebda42 md5 2b23db4fbec38938018bc9ae2fa8336e sha1 ecee716fe6dc876e49989f1ba99f91353e03bb40 )
+)
+
+game (
+	name "Hobbit, The - The Prelude to the Lord of the Rings (USA)"
+	description "Hobbit, The - The Prelude to the Lord of the Rings (USA)"
+	rom ( name "Hobbit, The - The Prelude to the Lord of the Rings (USA).iso" size 1459978240 crc 54ebda42 md5 2b23db4fbec38938018bc9ae2fa8336e sha1 ecee716fe6dc876e49989f1ba99f91353e03bb40 )
+)
+
+game (
+	name "Home Run King (US)"
+	description "Home Run King (US)"
+	rom ( name "Home Run King (US).iso" size 1459978240 crc e76b8a96 md5 ad59341c4767e039c9cefd6c916e9774 sha1 d5a3ef8f401b43935010b9997a5bb89087bbf7e6 )
+)
+
+game (
+	name "Home Run King (USA)"
+	description "Home Run King (USA)"
+	rom ( name "Home Run King (USA).iso" size 1459978240 crc e76b8a96 md5 ad59341c4767e039c9cefd6c916e9774 sha1 d5a3ef8f401b43935010b9997a5bb89087bbf7e6 )
+)
+
+game (
+	name "Homeland (Japan)"
+	description "Homeland (Japan)"
+	rom ( name "Homeland (Japan).iso" size 1459978240 crc c49982d2 md5 977532c2d71fe81fdfc96fe7bda6bab8 sha1 3ff1435f2a7bac9160546bd4d19dcc5711625bbd )
+)
+
+game (
+	name "Homeland (JP) - homurando"
+	description "Homeland (JP) - homurando"
+	rom ( name "Homeland (JP).iso" size 1459978240 crc c49982d2 md5 977532c2d71fe81fdfc96fe7bda6bab8 sha1 3ff1435f2a7bac9160546bd4d19dcc5711625bbd )
+)
+
+game (
+	name "Homeland Test Disc (Japan)"
+	description "Homeland Test Disc (Japan)"
+	rom ( name "Homeland Test Disc (Japan).iso" size 1459978240 crc 00d4bc6d md5 0dda6a84db3ff1e65323c0dff0a6f6d2 sha1 d997d829b91a125616427676e8433a5ff49af9c4 )
+)
+
+game (
+	name "Homeland Test Disc (JP) - homurando+tesuto+deisuku"
+	description "Homeland Test Disc (JP) - homurando+tesuto+deisuku"
+	rom ( name "Homeland Test Disc (JP).iso" size 1459978240 crc 00d4bc6d md5 0dda6a84db3ff1e65323c0dff0a6f6d2 sha1 d997d829b91a125616427676e8433a5ff49af9c4 )
+)
+
+game (
+	name "Hot Wheels - Velocity X (EU)"
+	description "Hot Wheels - Velocity X (EU)"
+	rom ( name "Hot Wheels - Velocity X (EU).iso" size 1459978240 crc 8c0a8a48 md5 2e054dd1650bb9fcad69053c07120671 sha1 59c364b85c9db7a5a5c9481979c448e01a8e0308 )
+)
+
+game (
+	name "Hot Wheels - Velocity X (Europe)"
+	description "Hot Wheels - Velocity X (Europe)"
+	rom ( name "Hot Wheels - Velocity X (Europe).iso" size 1459978240 crc 8c0a8a48 md5 2e054dd1650bb9fcad69053c07120671 sha1 59c364b85c9db7a5a5c9481979c448e01a8e0308 )
+)
+
+game (
+	name "Hot Wheels - Velocity X (US)"
+	description "Hot Wheels - Velocity X (US)"
+	rom ( name "Hot Wheels - Velocity X (US).iso" size 1459978240 crc f13412ce md5 819f06787ec1ca0a9b8608215abb7270 sha1 9c12aff2cc9fde0295e9eb547267eb645df119f0 )
+)
+
+game (
+	name "Hot Wheels - Velocity X (USA)"
+	description "Hot Wheels - Velocity X (USA)"
+	rom ( name "Hot Wheels - Velocity X (USA).iso" size 1459978240 crc f13412ce md5 819f06787ec1ca0a9b8608215abb7270 sha1 9c12aff2cc9fde0295e9eb547267eb645df119f0 )
+)
+
+game (
+	name "Hot Wheels - World Race (Europe)"
+	description "Hot Wheels - World Race (Europe)"
+	rom ( name "Hot Wheels - World Race (Europe).iso" size 1459978240 crc efd2e2c1 md5 7598fc38f4a67970507cb13211fc0c54 sha1 8810426669802f638a17d169dd0bc676f1cec5e6 )
+)
+
+game (
+	name "Hot Wheels - World Race (GB)"
+	description "Hot Wheels - World Race (GB)"
+	rom ( name "Hot Wheels - World Race (GB).iso" size 1459978240 crc efd2e2c1 md5 7598fc38f4a67970507cb13211fc0c54 sha1 8810426669802f638a17d169dd0bc676f1cec5e6 )
+)
+
+game (
+	name "Hot Wheels - World Race (US)"
+	description "Hot Wheels - World Race (US)"
+	rom ( name "Hot Wheels - World Race (US).iso" size 1459978240 crc a0fd866b md5 4d189c2c75de4a8bb7c9a16769dcd470 sha1 d685a660bfb71ed5a38812f43031c4953dc02968 )
+)
+
+game (
+	name "Hot Wheels - World Race (USA)"
+	description "Hot Wheels - World Race (USA)"
+	rom ( name "Hot Wheels - World Race (USA).iso" size 1459978240 crc a0fd866b md5 4d189c2c75de4a8bb7c9a16769dcd470 sha1 d685a660bfb71ed5a38812f43031c4953dc02968 )
+)
+
+game (
+	name "Hudson Selection Vol. 1 - Cubic Lode Runner (Japan)"
+	description "Hudson Selection Vol. 1 - Cubic Lode Runner (Japan)"
+	rom ( name "Hudson Selection Vol. 1 - Cubic Lode Runner (Japan).iso" size 1459978240 crc e887ef9b md5 78d6ed41213baa582be1f925bf9a8966 sha1 e8324e9717833e77732c1f8b158997db16dd5cbd )
+)
+
+game (
+	name "Hudson Selection Vol. 1 - Cubic Lode Runner (JP) - hadosonserekusiyonVol.1+kiyubitukurodoranna"
+	description "Hudson Selection Vol. 1 - Cubic Lode Runner (JP) - hadosonserekusiyonVol.1+kiyubitukurodoranna"
+	rom ( name "Hudson Selection Vol. 1 - Cubic Lode Runner (JP).iso" size 1459978240 crc e887ef9b md5 78d6ed41213baa582be1f925bf9a8966 sha1 e8324e9717833e77732c1f8b158997db16dd5cbd )
+)
+
+game (
+	name "Hudson Selection Vol. 2 - Star Soldier (Japan)"
+	description "Hudson Selection Vol. 2 - Star Soldier (Japan)"
+	rom ( name "Hudson Selection Vol. 2 - Star Soldier (Japan).iso" size 1459978240 crc 6e7dab62 md5 12d57be8a6ede1e5f80fe7edad7d4ba6 sha1 8b814013ce1dd09159ae0d4fb5545aedf7492b1b )
+)
+
+game (
+	name "Hudson Selection Vol. 2 - Star Soldier (JP) - hadosonserekusiyonVol.2+sutasoruziya"
+	description "Hudson Selection Vol. 2 - Star Soldier (JP) - hadosonserekusiyonVol.2+sutasoruziya"
+	rom ( name "Hudson Selection Vol. 2 - Star Soldier (JP).iso" size 1459978240 crc 6e7dab62 md5 12d57be8a6ede1e5f80fe7edad7d4ba6 sha1 8b814013ce1dd09159ae0d4fb5545aedf7492b1b )
+)
+
+game (
+	name "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (Japan)"
+	description "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (Japan)"
+	rom ( name "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (Japan).iso" size 1459978240 crc e2549d61 md5 77de041e583ce11029181933b3c6e9ec sha1 dad59ea0105c2459700a30b8aa1136f33c75740d )
+)
+
+game (
+	name "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (JP) - hadosonserekusiyonVol.3+PCYuan Ren"
+	description "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (JP) - hadosonserekusiyonVol.3+PCYuan Ren"
+	rom ( name "Hudson Selection Vol. 3 - PC Genjin - Pithecanthropus Computerurus (JP).iso" size 1459978240 crc e2549d61 md5 77de041e583ce11029181933b3c6e9ec sha1 dad59ea0105c2459700a30b8aa1136f33c75740d )
+)
+
+game (
+	name "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (Japan)"
+	description "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (Japan)"
+	rom ( name "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (Japan).iso" size 1459978240 crc 93933829 md5 c693783932da479d1e375434c2486b4b sha1 c021cfc3b8a6a3a355abfff3048bc45cb6e842f5 )
+)
+
+game (
+	name "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (JP) - hadosonserekusiyonVol.4+Gao Qiao Ming Ren noMou Xian Dao"
+	description "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (JP) - hadosonserekusiyonVol.4+Gao Qiao Ming Ren noMou Xian Dao"
+	rom ( name "Hudson Selection Vol. 4 - Takahashi-Meijin no Boukenjima (JP).iso" size 1459978240 crc 93933829 md5 c693783932da479d1e375434c2486b4b sha1 c021cfc3b8a6a3a355abfff3048bc45cb6e842f5 )
+)
+
+game (
+	name "Hulk (DE)"
+	description "Hulk (DE)"
+	rom ( name "Hulk (DE).iso" size 1459978240 crc ced72e4b md5 1086a2e93d0a373aff813b7b051d22aa sha1 6c2fe678daadf9cbd50c50b143bde84b3d89d21f )
+)
+
+game (
+	name "Hulk (ES)"
+	description "Hulk (ES)"
+	rom ( name "Hulk (ES).iso" size 1459978240 crc 6a1ff38e md5 83efa92c51f52d6a0432de138f0180db sha1 15cded70bf85dc25288cf6f3d761dac1908609e1 )
+)
+
+game (
+	name "Hulk (EU)"
+	description "Hulk (EU)"
+	rom ( name "Hulk (EU).iso" size 1459978240 crc ffdabe9b md5 7d74ba8cb577fe0540b4f2527fe40a98 sha1 0752f48bf3edbfa2007708fdac3c8372e378c145 )
+)
+
+game (
+	name "Hulk (Europe)"
+	description "Hulk (Europe)"
+	rom ( name "Hulk (Europe).iso" size 1459978240 crc ffdabe9b md5 7d74ba8cb577fe0540b4f2527fe40a98 sha1 0752f48bf3edbfa2007708fdac3c8372e378c145 )
+)
+
+game (
+	name "Hulk (FR)"
+	description "Hulk (FR)"
+	rom ( name "Hulk (FR).iso" size 1459978240 crc d99457a8 md5 06985b015f2ab42eb57fc7e290d01405 sha1 241fd5b9336350aa322e6621b910c0e9ae3d0cdf )
+)
+
+game (
+	name "Hulk (France)"
+	description "Hulk (France)"
+	rom ( name "Hulk (France).iso" size 1459978240 crc d99457a8 md5 06985b015f2ab42eb57fc7e290d01405 sha1 241fd5b9336350aa322e6621b910c0e9ae3d0cdf )
+)
+
+game (
+	name "Hulk (Germany)"
+	description "Hulk (Germany)"
+	rom ( name "Hulk (Germany).iso" size 1459978240 crc ced72e4b md5 1086a2e93d0a373aff813b7b051d22aa sha1 6c2fe678daadf9cbd50c50b143bde84b3d89d21f )
+)
+
+game (
+	name "Hulk (Spain)"
+	description "Hulk (Spain)"
+	rom ( name "Hulk (Spain).iso" size 1459978240 crc 6a1ff38e md5 83efa92c51f52d6a0432de138f0180db sha1 15cded70bf85dc25288cf6f3d761dac1908609e1 )
+)
+
+game (
+	name "Hulk (US)"
+	description "Hulk (US)"
+	rom ( name "Hulk (US).iso" size 1459978240 crc 451cf050 md5 1fb6ed9b459e647447bb4d9374c9fedf sha1 aa586a0a4c3d0179c80fe637e3ea56a6a53b4e78 )
+)
+
+game (
+	name "Hulk (USA)"
+	description "Hulk (USA)"
+	rom ( name "Hulk (USA).iso" size 1459978240 crc 451cf050 md5 1fb6ed9b459e647447bb4d9374c9fedf sha1 aa586a0a4c3d0179c80fe637e3ea56a6a53b4e78 )
+)
+
+game (
+	name "Hunter - The Reckoning (EU)"
+	description "Hunter - The Reckoning (EU)"
+	rom ( name "Hunter - The Reckoning (EU).iso" size 1459978240 crc 2305710c md5 0c3c5f9da9e39a1e032b28f88863353b sha1 24cba1b8060e1c761322864680fd64834ea4bf54 )
+)
+
+game (
+	name "Hunter - The Reckoning (Europe) (En,Fr,De)"
+	description "Hunter - The Reckoning (Europe) (En,Fr,De)"
+	rom ( name "Hunter - The Reckoning (Europe) (En,Fr,De).iso" size 1459978240 crc 2305710c md5 0c3c5f9da9e39a1e032b28f88863353b sha1 24cba1b8060e1c761322864680fd64834ea4bf54 )
+)
+
+game (
+	name "Hunter - The Reckoning (US)"
+	description "Hunter - The Reckoning (US)"
+	rom ( name "Hunter - The Reckoning (US).iso" size 1459978240 crc 24fa0328 md5 29b2760cdc12720840d031ac5a9ab202 sha1 9ba56d66dabc7b7272206debb07d29d7bbd86044 )
+)
+
+game (
+	name "Hunter - The Reckoning (USA)"
+	description "Hunter - The Reckoning (USA)"
+	rom ( name "Hunter - The Reckoning (USA).iso" size 1459978240 crc 24fa0328 md5 29b2760cdc12720840d031ac5a9ab202 sha1 9ba56d66dabc7b7272206debb07d29d7bbd86044 )
+)
+
+game (
+	name "Hyper Sports 2002 Winter (Japan)"
+	description "Hyper Sports 2002 Winter (Japan)"
+	rom ( name "Hyper Sports 2002 Winter (Japan).iso" size 1459978240 crc 6a33b92e md5 a6b8cc139d7a925c26394e481abdbc41 sha1 4bb689221520adb3486b2f4b10252bd6ec292eb8 )
+)
+
+game (
+	name "Hyper Sports 2002 Winter (JP) - haipasupotu2002WINTER"
+	description "Hyper Sports 2002 Winter (JP) - haipasupotu2002WINTER"
+	rom ( name "Hyper Sports 2002 Winter (JP).iso" size 1459978240 crc 6a33b92e md5 a6b8cc139d7a925c26394e481abdbc41 sha1 4bb689221520adb3486b2f4b10252bd6ec292eb8 )
+)
+
+game (
+	name "I-Ninja (US)"
+	description "I-Ninja (US)"
+	rom ( name "I-Ninja (US).iso" size 1459978240 crc 46d100b8 md5 5967d3d4041ce3f3a240c92ef42fc18a sha1 8d3ee6a8469e570bc4e40d2d5b27dbd15a17f15e )
+)
+
+game (
+	name "I-Ninja (USA)"
+	description "I-Ninja (USA)"
+	rom ( name "I-Ninja (USA).iso" size 1459978240 crc 46d100b8 md5 5967d3d4041ce3f3a240c92ef42fc18a sha1 8d3ee6a8469e570bc4e40d2d5b27dbd15a17f15e )
+)
+
+game (
+	name "Ice Age 2 - The Meltdown (EU)"
+	description "Ice Age 2 - The Meltdown (EU)"
+	rom ( name "Ice Age 2 - The Meltdown (EU).iso" size 1459978240 crc a7e661da md5 e446973ca12a66f54f5cc2fd5299811e sha1 1402cf45209ae18bfc609dcec05574670ee78e5f )
+)
+
+game (
+	name "Ice Age 2 - The Meltdown (Europe) (En,Fr,De)"
+	description "Ice Age 2 - The Meltdown (Europe) (En,Fr,De)"
+	rom ( name "Ice Age 2 - The Meltdown (Europe) (En,Fr,De).iso" size 1459978240 crc a7e661da md5 e446973ca12a66f54f5cc2fd5299811e sha1 1402cf45209ae18bfc609dcec05574670ee78e5f )
+)
+
+game (
+	name "Ice Age 2 - The Meltdown (US)"
+	description "Ice Age 2 - The Meltdown (US)"
+	rom ( name "Ice Age 2 - The Meltdown (US).iso" size 1459978240 crc ffa77e19 md5 abe55d7ec7d4817d181b92fce1143367 sha1 c20363438297ef040e8c64b2740e213feee69375 )
+)
+
+game (
+	name "Ice Age 2 - The Meltdown (USA)"
+	description "Ice Age 2 - The Meltdown (USA)"
+	rom ( name "Ice Age 2 - The Meltdown (USA).iso" size 1459978240 crc ffa77e19 md5 abe55d7ec7d4817d181b92fce1143367 sha1 c20363438297ef040e8c64b2740e213feee69375 )
+)
+
+game (
+	name "Ikaruga (Europe)"
+	description "Ikaruga (Europe)"
+	rom ( name "Ikaruga (Europe).iso" size 1459978240 crc 8b34852b md5 0ea0114e1c10dc74500a23aaf246f350 sha1 28daad029e94a51b4ad8a958aa9de9f7e8baf449 )
+)
+
+game (
+	name "Ikaruga (GB)"
+	description "Ikaruga (GB)"
+	rom ( name "Ikaruga (GB).iso" size 1459978240 crc 8b34852b md5 0ea0114e1c10dc74500a23aaf246f350 sha1 28daad029e94a51b4ad8a958aa9de9f7e8baf449 )
+)
+
+game (
+	name "Ikaruga (Japan)"
+	description "Ikaruga (Japan)"
+	rom ( name "Ikaruga (Japan).iso" size 1459978240 crc 03afaf7e md5 b155542f69263f8a16e035066a086dfd sha1 2f98893fbe114b19d51ecbc16b9b9069ddaa6f38 )
+)
+
+game (
+	name "Ikaruga (JP) - Ban Jiu"
+	description "Ikaruga (JP) - Ban Jiu"
+	rom ( name "Ikaruga (JP).iso" size 1459978240 crc 03afaf7e md5 b155542f69263f8a16e035066a086dfd sha1 2f98893fbe114b19d51ecbc16b9b9069ddaa6f38 )
+)
+
+game (
+	name "Ikaruga (US)"
+	description "Ikaruga (US)"
+	rom ( name "Ikaruga (US).iso" size 1459978240 crc b150985f md5 1cdc856fff6589f03cde183cf6bcf450 sha1 890148efe35692915948c3a0f1d681e5d6f9f008 )
+)
+
+game (
+	name "Ikaruga (USA)"
+	description "Ikaruga (USA)"
+	rom ( name "Ikaruga (USA).iso" size 1459978240 crc b150985f md5 1cdc856fff6589f03cde183cf6bcf450 sha1 890148efe35692915948c3a0f1d681e5d6f9f008 )
+)
+
+game (
+	name "Incredible Hulk, The - Ultimate Destruction (EU)"
+	description "Incredible Hulk, The - Ultimate Destruction (EU)"
+	rom ( name "Incredible Hulk, The - Ultimate Destruction (EU).iso" size 1459978240 crc c9c8e10b md5 4767706623aaf8191298200eb8f7d5b5 sha1 8b44a56c1e429fbde8936bece08c89c43ea0d80c )
+)
+
+game (
+	name "Incredible Hulk, The - Ultimate Destruction (Europe) (En,Es,It)"
+	description "Incredible Hulk, The - Ultimate Destruction (Europe) (En,Es,It)"
+	rom ( name "Incredible Hulk, The - Ultimate Destruction (Europe) (En,Es,It).iso" size 1459978240 crc c9c8e10b md5 4767706623aaf8191298200eb8f7d5b5 sha1 8b44a56c1e429fbde8936bece08c89c43ea0d80c )
+)
+
+game (
+	name "Incredible Hulk, The - Ultimate Destruction (US)"
+	description "Incredible Hulk, The - Ultimate Destruction (US)"
+	rom ( name "Incredible Hulk, The - Ultimate Destruction (US).iso" size 1459978240 crc 88186314 md5 0098a2aa4913fd9a7091dc4f5879101d sha1 e182e97b4d73a2407ed41e1b895ca2254a9e3a93 )
+)
+
+game (
+	name "Incredible Hulk, The - Ultimate Destruction (USA)"
+	description "Incredible Hulk, The - Ultimate Destruction (USA)"
+	rom ( name "Incredible Hulk, The - Ultimate Destruction (USA).iso" size 1459978240 crc 88186314 md5 0098a2aa4913fd9a7091dc4f5879101d sha1 e182e97b4d73a2407ed41e1b895ca2254a9e3a93 )
+)
+
+game (
+	name "Intellivision Lives! (US)"
+	description "Intellivision Lives! (US)"
+	rom ( name "Intellivision Lives! (US).iso" size 1459978240 crc a28bd52f md5 9cd10fe7077012bc2acfd8dc62b1acfa sha1 7a34b04a467fa39aca4c57752b63f3015bee9723 )
+)
+
+game (
+	name "Intellivision Lives! (USA)"
+	description "Intellivision Lives! (USA)"
+	rom ( name "Intellivision Lives! (USA).iso" size 1459978240 crc a28bd52f md5 9cd10fe7077012bc2acfd8dc62b1acfa sha1 7a34b04a467fa39aca4c57752b63f3015bee9723 )
+)
+
+game (
+	name "Interactive Disc Catalog Summer 2003 (Japan)"
+	description "Interactive Disc Catalog Summer 2003 (Japan)"
+	rom ( name "Interactive Disc Catalog Summer 2003 (Japan).iso" size 1459978240 crc e938e1df md5 b63728cbc34bcfed902d52db33ce7c0a sha1 462fdd7fc6972c1315b0393d30db1966211c19ad )
+)
+
+game (
+	name "Interactive Disc Catalog Summer 2003 (JP)"
+	description "Interactive Disc Catalog Summer 2003 (JP)"
+	rom ( name "Interactive Disc Catalog Summer 2003 (JP).iso" size 1459978240 crc e938e1df md5 b63728cbc34bcfed902d52db33ce7c0a sha1 462fdd7fc6972c1315b0393d30db1966211c19ad )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - August 2002 (US)"
+	description "Interactive Multi-Game Demo Disc - August 2002 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - August 2002 (US).iso" size 1459978240 crc c29882e1 md5 e98d60cca9b4dc210245ad3dff43e3d1 sha1 decf7f5abd9d1cc2001d821ada1c4fca8bfe0315 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - August 2002 (USA)"
+	description "Interactive Multi-Game Demo Disc - August 2002 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - August 2002 (USA).iso" size 1459978240 crc c29882e1 md5 e98d60cca9b4dc210245ad3dff43e3d1 sha1 decf7f5abd9d1cc2001d821ada1c4fca8bfe0315 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - January 2002 (US)"
+	description "Interactive Multi-Game Demo Disc - January 2002 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - January 2002 (US).iso" size 1459978240 crc d0f3ea0a md5 0e0474431111f383cb3ecd67fe214eea sha1 eb5b20a1740f9170680e4df6c26be2afc0840d62 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - January 2002 (USA)"
+	description "Interactive Multi-Game Demo Disc - January 2002 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - January 2002 (USA).iso" size 1459978240 crc d0f3ea0a md5 0e0474431111f383cb3ecd67fe214eea sha1 eb5b20a1740f9170680e4df6c26be2afc0840d62 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - January 2004 (Japan)"
+	description "Interactive Multi-Game Demo Disc - January 2004 (Japan)"
+	rom ( name "Interactive Multi-Game Demo Disc - January 2004 (Japan).iso" size 1459978240 crc f0e6589b md5 b571f0c044da782a53e3f917ae275640 sha1 4612374bc7ce8cbbc1fd7f5c79cf823fc3e58ea1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - January 2004 (JP)"
+	description "Interactive Multi-Game Demo Disc - January 2004 (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - January 2004 (JP).iso" size 1459978240 crc f0e6589b md5 b571f0c044da782a53e3f917ae275640 sha1 4612374bc7ce8cbbc1fd7f5c79cf823fc3e58ea1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (D33J) (JP)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (D33J) (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (D33J) (JP).iso" size 1459978240 crc 86dacab6 md5 84936411bf7768bcdac3be8f401ad8eb sha1 4d7d77f67288902ba17bf6f42d19679e45cbcb54 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (D34J) (JP)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (D34J) (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (D34J) (JP).iso" size 1459978240 crc 878c6dea md5 f185e3c31a81519ee0c0b2539ebcd442 sha1 8b863d521ce96c85c9de60a9d95ccf10e6d8edb6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D33J)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D33J)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D33J).iso" size 1459978240 crc 86dacab6 md5 84936411bf7768bcdac3be8f401ad8eb sha1 4d7d77f67288902ba17bf6f42d19679e45cbcb54 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D34J)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D34J)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (Japan) (D34J).iso" size 1459978240 crc 878c6dea md5 f185e3c31a81519ee0c0b2539ebcd442 sha1 8b863d521ce96c85c9de60a9d95ccf10e6d8edb6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (US)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (US).iso" size 1459978240 crc 3101db76 md5 8417046b747ec2525d61ffc632406860 sha1 fab8a7173b0c6ab93c4d61aa598bda5b1f2ba951 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2002 (USA)"
+	description "Interactive Multi-Game Demo Disc - July 2002 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2002 (USA).iso" size 1459978240 crc 3101db76 md5 8417046b747ec2525d61ffc632406860 sha1 fab8a7173b0c6ab93c4d61aa598bda5b1f2ba951 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2004 (Japan)"
+	description "Interactive Multi-Game Demo Disc - July 2004 (Japan)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2004 (Japan).iso" size 1459978240 crc 5f8a38ed md5 75e985fb5292c7f8103605bffb1503fc sha1 3a2789f975a323f663d71779a89895a8a569e6c2 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - July 2004 (JP)"
+	description "Interactive Multi-Game Demo Disc - July 2004 (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - July 2004 (JP).iso" size 1459978240 crc 5f8a38ed md5 75e985fb5292c7f8103605bffb1503fc sha1 3a2789f975a323f663d71779a89895a8a569e6c2 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - June 2002 (Japan)"
+	description "Interactive Multi-Game Demo Disc - June 2002 (Japan)"
+	rom ( name "Interactive Multi-Game Demo Disc - June 2002 (Japan).iso" size 1459978240 crc 8c63ed7d md5 72989eef047e97918465592f4bdc1587 sha1 dac2090baf6a9b1121b07cf14cebf38111069d7e )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - June 2002 (JP)"
+	description "Interactive Multi-Game Demo Disc - June 2002 (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - June 2002 (JP).iso" size 1459978240 crc 8c63ed7d md5 72989eef047e97918465592f4bdc1587 sha1 dac2090baf6a9b1121b07cf14cebf38111069d7e )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - June 2002 (US)"
+	description "Interactive Multi-Game Demo Disc - June 2002 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - June 2002 (US).iso" size 1459978240 crc 4f2cdf12 md5 528e56732ce9664c0c4c60b3aa2bcadd sha1 0b36ea6a801d4f558c4a35062634517f53d72ffb )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - June 2002 (USA)"
+	description "Interactive Multi-Game Demo Disc - June 2002 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - June 2002 (USA).iso" size 1459978240 crc 4f2cdf12 md5 528e56732ce9664c0c4c60b3aa2bcadd sha1 0b36ea6a801d4f558c4a35062634517f53d72ffb )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - March 2002 (US)"
+	description "Interactive Multi-Game Demo Disc - March 2002 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - March 2002 (US).iso" size 1459978240 crc 5892c570 md5 fcb1b79c7c88718f8f8bff9950866688 sha1 a5bf38c8ae2672fffa23948847abb0416bf56350 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - March 2002 (USA)"
+	description "Interactive Multi-Game Demo Disc - March 2002 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - March 2002 (USA).iso" size 1459978240 crc 5892c570 md5 fcb1b79c7c88718f8f8bff9950866688 sha1 a5bf38c8ae2672fffa23948847abb0416bf56350 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - May 2002 (Japan)"
+	description "Interactive Multi-Game Demo Disc - May 2002 (Japan)"
+	rom ( name "Interactive Multi-Game Demo Disc - May 2002 (Japan).iso" size 1459978240 crc 87e9b682 md5 d74671494b007f3bc4daca9e3683a779 sha1 ed7fb765e115aae814f1112f1960ea4dd275d82a )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - May 2002 (JP)"
+	description "Interactive Multi-Game Demo Disc - May 2002 (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - May 2002 (JP).iso" size 1459978240 crc 87e9b682 md5 d74671494b007f3bc4daca9e3683a779 sha1 ed7fb765e115aae814f1112f1960ea4dd275d82a )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - May 2004 (Japan)"
+	description "Interactive Multi-Game Demo Disc - May 2004 (Japan)"
+	rom ( name "Interactive Multi-Game Demo Disc - May 2004 (Japan).iso" size 1459978240 crc 161888cf md5 9a96af77a50795eb283d5b09e29f0d15 sha1 8928b971bcb1c5513e594b639a578e94fa510193 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - May 2004 (JP)"
+	description "Interactive Multi-Game Demo Disc - May 2004 (JP)"
+	rom ( name "Interactive Multi-Game Demo Disc - May 2004 (JP).iso" size 1459978240 crc 161888cf md5 9a96af77a50795eb283d5b09e29f0d15 sha1 8928b971bcb1c5513e594b639a578e94fa510193 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - October 2001 (US)"
+	description "Interactive Multi-Game Demo Disc - October 2001 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc - October 2001 (US).iso" size 1459978240 crc 2942cd97 md5 02859909271edb13b6f7da804b65c550 sha1 f3bf253766c4910e52b7809a271d44538fc5655f )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc - October 2001 (USA)"
+	description "Interactive Multi-Game Demo Disc - October 2001 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc - October 2001 (USA).iso" size 1459978240 crc 2942cd97 md5 02859909271edb13b6f7da804b65c550 sha1 f3bf253766c4910e52b7809a271d44538fc5655f )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 10 (US)"
+	description "Interactive Multi-Game Demo Disc Version 10 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 10 (US).iso" size 1459978240 crc 7d7c372e md5 47483783f7dedb0b6abf376d6060cb44 sha1 313ff16939c46b505950375b2015d934445937f6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 10 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 10 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 10 (USA).iso" size 1459978240 crc 7d7c372e md5 47483783f7dedb0b6abf376d6060cb44 sha1 313ff16939c46b505950375b2015d934445937f6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 11 (US)"
+	description "Interactive Multi-Game Demo Disc Version 11 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 11 (US).iso" size 1459978240 crc 5cf265c9 md5 5b357c1c176c39dc5695c6af600777da sha1 dd0864b14de9546ba5ec1fc27e716583a7dcc029 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 11 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 11 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 11 (USA).iso" size 1459978240 crc 5cf265c9 md5 5b357c1c176c39dc5695c6af600777da sha1 dd0864b14de9546ba5ec1fc27e716583a7dcc029 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 12 (US)"
+	description "Interactive Multi-Game Demo Disc Version 12 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 12 (US).iso" size 1459978240 crc 27be9f92 md5 5913444b3696201fe1becb3a0022be6e sha1 9f1482b34ad699a11cea3b775653a1c06f420751 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 12 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 12 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 12 (USA).iso" size 1459978240 crc 27be9f92 md5 5913444b3696201fe1becb3a0022be6e sha1 9f1482b34ad699a11cea3b775653a1c06f420751 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 13 (US)"
+	description "Interactive Multi-Game Demo Disc Version 13 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 13 (US).iso" size 1459978240 crc 641ad4de md5 534859ddf15412a370eb4187496b00b0 sha1 92ef6ec2b49d34c0a022d98e348d5a3187419414 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 13 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 13 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 13 (USA).iso" size 1459978240 crc 641ad4de md5 534859ddf15412a370eb4187496b00b0 sha1 92ef6ec2b49d34c0a022d98e348d5a3187419414 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 14 (US)"
+	description "Interactive Multi-Game Demo Disc Version 14 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 14 (US).iso" size 1459978240 crc 96537575 md5 544ffd302817cd8c907d58cb257c0c6e sha1 4a0164c1b3638eb86654ba7d854ab93eb2fe843b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 14 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 14 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 14 (USA).iso" size 1459978240 crc 96537575 md5 544ffd302817cd8c907d58cb257c0c6e sha1 4a0164c1b3638eb86654ba7d854ab93eb2fe843b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 15 (US)"
+	description "Interactive Multi-Game Demo Disc Version 15 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 15 (US).iso" size 1459978240 crc 42966702 md5 0b6a6c90bc162acb29d36e05b82822b3 sha1 ea33e96b866579235b25c1f153d675d480058e0d )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 15 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 15 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 15 (USA).iso" size 1459978240 crc 42966702 md5 0b6a6c90bc162acb29d36e05b82822b3 sha1 ea33e96b866579235b25c1f153d675d480058e0d )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 16 (US)"
+	description "Interactive Multi-Game Demo Disc Version 16 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 16 (US).iso" size 1459978240 crc 6b3df446 md5 cd01cd6209060189e75d39fa76de4687 sha1 9ad05f0392c211f4bc5d5a62224fea9be4246d19 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 16 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 16 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 16 (USA).iso" size 1459978240 crc 6b3df446 md5 cd01cd6209060189e75d39fa76de4687 sha1 9ad05f0392c211f4bc5d5a62224fea9be4246d19 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 17 (US)"
+	description "Interactive Multi-Game Demo Disc Version 17 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 17 (US).iso" size 1459978240 crc c0f9768a md5 44d018838b39aeeddb25bbfc5802ddc7 sha1 a7bdde3eec1b49e5d82e2e4f37603b808335ff55 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 17 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 17 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 17 (USA).iso" size 1459978240 crc c0f9768a md5 44d018838b39aeeddb25bbfc5802ddc7 sha1 a7bdde3eec1b49e5d82e2e4f37603b808335ff55 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 18 (US)"
+	description "Interactive Multi-Game Demo Disc Version 18 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 18 (US).iso" size 1459978240 crc d3a5251f md5 70315e5a0fad21aa08402680f7e2f0db sha1 eb3891dfb80ecb0cda68338e35d83d1988821f69 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 18 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 18 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 18 (USA).iso" size 1459978240 crc d3a5251f md5 70315e5a0fad21aa08402680f7e2f0db sha1 eb3891dfb80ecb0cda68338e35d83d1988821f69 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 19 (US)"
+	description "Interactive Multi-Game Demo Disc Version 19 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 19 (US).iso" size 1459978240 crc 486465c7 md5 4e5a8bdaf3feab07dd6073b547cdf5c4 sha1 9fc282f0f0e6d17a87d4ee6acfd025e159b7c750 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 19 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 19 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 19 (USA).iso" size 1459978240 crc 486465c7 md5 4e5a8bdaf3feab07dd6073b547cdf5c4 sha1 9fc282f0f0e6d17a87d4ee6acfd025e159b7c750 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 20 (US)"
+	description "Interactive Multi-Game Demo Disc Version 20 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 20 (US).iso" size 1459978240 crc 8ae77c83 md5 c8490eee3f9d38e016c989d4f47c8d8b sha1 ab021b973ce8b3bbafba7495c33352eb731c8610 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 20 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 20 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 20 (USA).iso" size 1459978240 crc 8ae77c83 md5 c8490eee3f9d38e016c989d4f47c8d8b sha1 ab021b973ce8b3bbafba7495c33352eb731c8610 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 21 (US)"
+	description "Interactive Multi-Game Demo Disc Version 21 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 21 (US).iso" size 1459978240 crc 06b3d6f3 md5 96a5c06c7bf6f4d0d189dbe3cb6b0904 sha1 113ae1259ebe036e9273973260a40eb6dc4a722b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 21 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 21 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 21 (USA).iso" size 1459978240 crc 06b3d6f3 md5 96a5c06c7bf6f4d0d189dbe3cb6b0904 sha1 113ae1259ebe036e9273973260a40eb6dc4a722b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 22 (US)"
+	description "Interactive Multi-Game Demo Disc Version 22 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 22 (US).iso" size 1459978240 crc ce3fdc74 md5 877ac909159ad93269d35be2b1665d0d sha1 d39b6f5751bd55a27cb31a8f1d666161ed556aac )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 22 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 22 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 22 (USA).iso" size 1459978240 crc ce3fdc74 md5 877ac909159ad93269d35be2b1665d0d sha1 d39b6f5751bd55a27cb31a8f1d666161ed556aac )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 23 (US)"
+	description "Interactive Multi-Game Demo Disc Version 23 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 23 (US).iso" size 1459978240 crc 04ee6c59 md5 66d59d2397a25959b1bc68447a20dc44 sha1 a94dff8ba4b81fff93756d305cab1643f8743b2b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 23 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 23 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 23 (USA).iso" size 1459978240 crc 04ee6c59 md5 66d59d2397a25959b1bc68447a20dc44 sha1 a94dff8ba4b81fff93756d305cab1643f8743b2b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 24 (US)"
+	description "Interactive Multi-Game Demo Disc Version 24 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 24 (US).iso" size 1459978240 crc 9cf6404c md5 8f787d8f270f9b5be9e92da6a9841bca sha1 51e96a6b4cafbf1ee13d44df944769a1f330d3db )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 24 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 24 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 24 (USA).iso" size 1459978240 crc 9cf6404c md5 8f787d8f270f9b5be9e92da6a9841bca sha1 51e96a6b4cafbf1ee13d44df944769a1f330d3db )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 25 (US)"
+	description "Interactive Multi-Game Demo Disc Version 25 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 25 (US).iso" size 1459978240 crc 1810dc0b md5 afde3e6d61a31e39627c82413389927a sha1 23d91b280dc97701e93629dd9bf27ea797bf78f8 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 25 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 25 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 25 (USA).iso" size 1459978240 crc 1810dc0b md5 afde3e6d61a31e39627c82413389927a sha1 23d91b280dc97701e93629dd9bf27ea797bf78f8 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 26 (US)"
+	description "Interactive Multi-Game Demo Disc Version 26 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 26 (US).iso" size 1459978240 crc f2675688 md5 04499c4891a66baac4e6b03db07ed3d5 sha1 d11bb3e1100d054f1650b63a548ae3266a709a99 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 26 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 26 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 26 (USA).iso" size 1459978240 crc f2675688 md5 04499c4891a66baac4e6b03db07ed3d5 sha1 d11bb3e1100d054f1650b63a548ae3266a709a99 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 27 (US)"
+	description "Interactive Multi-Game Demo Disc Version 27 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 27 (US).iso" size 1459978240 crc 87b8add6 md5 e223786d4682f0dc70c3ff3764500040 sha1 fbb0f4976b3f6544405bd6976e20445945ab6139 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 27 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 27 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 27 (USA).iso" size 1459978240 crc 87b8add6 md5 e223786d4682f0dc70c3ff3764500040 sha1 fbb0f4976b3f6544405bd6976e20445945ab6139 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 28 (US)"
+	description "Interactive Multi-Game Demo Disc Version 28 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 28 (US).iso" size 1459978240 crc d936a2c2 md5 053f342344a581858c35ff24110018ba sha1 913dcf9e4b961d4130ebd29493de6bd48e8b0d38 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 28 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 28 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 28 (USA).iso" size 1459978240 crc 052a45b7 md5 fa0b961ba1f3a50411a9c0a23fd642e8 sha1 693319c7c40e5605e0a1cfb2e69ace7ca8f9cb4c )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 29 (US)"
+	description "Interactive Multi-Game Demo Disc Version 29 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 29 (US).iso" size 1459978240 crc 052a45b7 md5 fa0b961ba1f3a50411a9c0a23fd642e8 sha1 693319c7c40e5605e0a1cfb2e69ace7ca8f9cb4c )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 29 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 29 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 29 (USA).iso" size 1459978240 crc d936a2c2 md5 053f342344a581858c35ff24110018ba sha1 913dcf9e4b961d4130ebd29493de6bd48e8b0d38 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 30 (US)"
+	description "Interactive Multi-Game Demo Disc Version 30 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 30 (US).iso" size 1459978240 crc 509003fb md5 0f0da9c9b0ea03c1193d9e8a60436e41 sha1 e52a5a29e03c30664e5fc186f8324c56007a3dc0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 30 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 30 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 30 (USA).iso" size 1459978240 crc 509003fb md5 0f0da9c9b0ea03c1193d9e8a60436e41 sha1 e52a5a29e03c30664e5fc186f8324c56007a3dc0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 31 (US)"
+	description "Interactive Multi-Game Demo Disc Version 31 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 31 (US).iso" size 1459978240 crc 7f831187 md5 655540c5f08eb0c65ed3316405bfaaf2 sha1 6cba85dd15f1e7ed74152caead2d00eb106d85b5 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 31 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 31 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 31 (USA).iso" size 1459978240 crc 7f831187 md5 655540c5f08eb0c65ed3316405bfaaf2 sha1 6cba85dd15f1e7ed74152caead2d00eb106d85b5 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 32 (US)"
+	description "Interactive Multi-Game Demo Disc Version 32 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 32 (US).iso" size 1459978240 crc 76819e81 md5 e8ce2f5f6735403c2656b1fb7b082116 sha1 09da9e4795c107ae23db737e212d5c0236b92966 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 32 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 32 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 32 (USA).iso" size 1459978240 crc 76819e81 md5 e8ce2f5f6735403c2656b1fb7b082116 sha1 09da9e4795c107ae23db737e212d5c0236b92966 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 33 (US)"
+	description "Interactive Multi-Game Demo Disc Version 33 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 33 (US).iso" size 1459978240 crc 60574c2c md5 61fcbe3d7bc00d75c074f9f8c563152d sha1 3773baa8372fccf8339e98e05c708e01d41ee186 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 33 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 33 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 33 (USA).iso" size 1459978240 crc 60574c2c md5 61fcbe3d7bc00d75c074f9f8c563152d sha1 3773baa8372fccf8339e98e05c708e01d41ee186 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 34 (US)"
+	description "Interactive Multi-Game Demo Disc Version 34 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 34 (US).iso" size 1459978240 crc 47b7f19c md5 edbcdef9bb2726645957d5dc76dde81b sha1 033986c6d49c96685b7c9a30e7d05601dc05c2d1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 34 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 34 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 34 (USA).iso" size 1459978240 crc 47b7f19c md5 edbcdef9bb2726645957d5dc76dde81b sha1 033986c6d49c96685b7c9a30e7d05601dc05c2d1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 35 (US)"
+	description "Interactive Multi-Game Demo Disc Version 35 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 35 (US).iso" size 1459978240 crc 616d2b99 md5 a7ed05f25acde1775780def52c649812 sha1 51f2c6856ec4679a20a535814c6801ea28ebabe3 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 35 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 35 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 35 (USA).iso" size 1459978240 crc 616d2b99 md5 a7ed05f25acde1775780def52c649812 sha1 51f2c6856ec4679a20a535814c6801ea28ebabe3 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 7 (US)"
+	description "Interactive Multi-Game Demo Disc Version 7 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 7 (US).iso" size 1459978240 crc de89fc11 md5 579f51c6fc33958549f353b13f988780 sha1 b75f4a4b4bec06a129ed34c8d677ea94d30c8f95 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 7 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 7 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 7 (USA).iso" size 1459978240 crc de89fc11 md5 579f51c6fc33958549f353b13f988780 sha1 b75f4a4b4bec06a129ed34c8d677ea94d30c8f95 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 8 (US)"
+	description "Interactive Multi-Game Demo Disc Version 8 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 8 (US).iso" size 1459978240 crc 21613e61 md5 009cd0b3cbc7b5956deeb3b2440fe1e8 sha1 b697fe7b20c346f425178d0c53ca45162c0ff05a )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 8 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 8 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 8 (USA).iso" size 1459978240 crc 21613e61 md5 009cd0b3cbc7b5956deeb3b2440fe1e8 sha1 b697fe7b20c346f425178d0c53ca45162c0ff05a )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 9 (US)"
+	description "Interactive Multi-Game Demo Disc Version 9 (US)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 9 (US).iso" size 1459978240 crc c4e004cb md5 d4dc336eea8d77dd95977c7ceda0c598 sha1 74720d42c9a67129aade032ace234a6f4ba40c7b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disc Version 9 (USA)"
+	description "Interactive Multi-Game Demo Disc Version 9 (USA)"
+	rom ( name "Interactive Multi-Game Demo Disc Version 9 (USA).iso" size 1459978240 crc c4e004cb md5 d4dc336eea8d77dd95977c7ceda0c598 sha1 74720d42c9a67129aade032ace234a6f4ba40c7b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2003 (AU)"
+	description "Interactive Multi-Game Demo Disk - April 2003 (AU)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2003 (AU).iso" size 1459978240 crc 3271381a md5 19f94d21d4ec78ef1de50f326b5092ad sha1 7f4fec28614cf07a68ec987c930e01c39214efda )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2003 (Australia) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - April 2003 (Australia) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2003 (Australia) (En,Fr,De,Es,It).iso" size 1459978240 crc 3271381a md5 19f94d21d4ec78ef1de50f326b5092ad sha1 7f4fec28614cf07a68ec987c930e01c39214efda )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2003 (EU)"
+	description "Interactive Multi-Game Demo Disk - April 2003 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2003 (EU).iso" size 1459978240 crc 5400521f md5 3fb4c1f280c214c73b6372297c250264 sha1 e1eed8949b1c7b4ae901af38e7e7169a4a5cab0b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2003 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - April 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 5400521f md5 3fb4c1f280c214c73b6372297c250264 sha1 e1eed8949b1c7b4ae901af38e7e7169a4a5cab0b )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2005 (EU)"
+	description "Interactive Multi-Game Demo Disk - April 2005 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2005 (EU).iso" size 1459978240 crc 7a9846e0 md5 c4663e81433c0d0f2a0eb5489ec82bf9 sha1 a916fff97acea6205583cccad0033267517fbe0c )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2005 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - April 2005 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2005 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7a9846e0 md5 c4663e81433c0d0f2a0eb5489ec82bf9 sha1 a916fff97acea6205583cccad0033267517fbe0c )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2006 (EU)"
+	description "Interactive Multi-Game Demo Disk - April 2006 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2006 (EU).iso" size 1459978240 crc 37045253 md5 932d2ac0c3d09b24a0990e65079c8a0e sha1 0cd5c244783138cccec715f5d82e4f7f3f82a867 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - April 2006 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - April 2006 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - April 2006 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 37045253 md5 932d2ac0c3d09b24a0990e65079c8a0e sha1 0cd5c244783138cccec715f5d82e4f7f3f82a867 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - December 2002 (EU)"
+	description "Interactive Multi-Game Demo Disk - December 2002 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - December 2002 (EU).iso" size 1459978240 crc 271b16d3 md5 3bd9e2f907b78bf26fc653da1debf116 sha1 65c04bf13888bf8647d77ac4401abb52dcce7db0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - December 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - December 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - December 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 271b16d3 md5 3bd9e2f907b78bf26fc653da1debf116 sha1 65c04bf13888bf8647d77ac4401abb52dcce7db0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2003 (EU)"
+	description "Interactive Multi-Game Demo Disk - February 2003 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2003 (EU).iso" size 1459978240 crc 76a3d320 md5 cb68ca8b495fd5d487a82acbf72d5a68 sha1 bb11f319e458e32ae9fbf3bbcfbff7de9784d98e )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2003 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - February 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 76a3d320 md5 cb68ca8b495fd5d487a82acbf72d5a68 sha1 bb11f319e458e32ae9fbf3bbcfbff7de9784d98e )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2005 (AU)"
+	description "Interactive Multi-Game Demo Disk - February 2005 (AU)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2005 (AU).iso" size 1459978240 crc f5928085 md5 cdbaf3c4c1246525c64a09477beb4af4 sha1 4be919999b0879def8ff104a34984f5900b2dbc1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2005 (Australia) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - February 2005 (Australia) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2005 (Australia) (En,Fr,De,Es,It).iso" size 1459978240 crc f5928085 md5 cdbaf3c4c1246525c64a09477beb4af4 sha1 4be919999b0879def8ff104a34984f5900b2dbc1 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2005 (EU)"
+	description "Interactive Multi-Game Demo Disk - February 2005 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2005 (EU).iso" size 1459978240 crc 579544db md5 87e5299f3fb6b455ce537b0360416874 sha1 11f774394452b1f4bbdf061cf3769403f138a358 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - February 2005 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - February 2005 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - February 2005 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 579544db md5 87e5299f3fb6b455ce537b0360416874 sha1 11f774394452b1f4bbdf061cf3769403f138a358 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - July 2004 (EU)"
+	description "Interactive Multi-Game Demo Disk - July 2004 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - July 2004 (EU).iso" size 1459978240 crc 3789ad2c md5 ca07a8a980ac05996dcd591a254c054d sha1 e3614fe383c4be08c7adebf99eb0a4f3d89b7bf6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - July 2004 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - July 2004 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - July 2004 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3789ad2c md5 ca07a8a980ac05996dcd591a254c054d sha1 e3614fe383c4be08c7adebf99eb0a4f3d89b7bf6 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - June 2003 (EU)"
+	description "Interactive Multi-Game Demo Disk - June 2003 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - June 2003 (EU).iso" size 1459978240 crc 65d22d6b md5 9f8012ac86667bd82a8adfd78cc06d75 sha1 977358c41150f1d4ac303353eb731ef827a6ca71 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - June 2003 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - June 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - June 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 65d22d6b md5 9f8012ac86667bd82a8adfd78cc06d75 sha1 977358c41150f1d4ac303353eb731ef827a6ca71 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - March 2002 (EU)"
+	description "Interactive Multi-Game Demo Disk - March 2002 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - March 2002 (EU).iso" size 1459978240 crc 84a48d07 md5 c0648270c5c0b1d50563b75f3af6c580 sha1 776b51cf46ef7338c23dbd219a2827dda38ec740 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - March 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - March 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - March 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 84a48d07 md5 c0648270c5c0b1d50563b75f3af6c580 sha1 776b51cf46ef7338c23dbd219a2827dda38ec740 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - March 2004 (EU)"
+	description "Interactive Multi-Game Demo Disk - March 2004 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - March 2004 (EU).iso" size 1459978240 crc 382ec0d8 md5 08b0bbc6d08fef9316228a1272897f8e sha1 b4e8118ba7e651ff46ac73ae52867e68e628e540 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - March 2004 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - March 2004 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - March 2004 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 382ec0d8 md5 08b0bbc6d08fef9316228a1272897f8e sha1 b4e8118ba7e651ff46ac73ae52867e68e628e540 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2002 (EU)"
+	description "Interactive Multi-Game Demo Disk - May 2002 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2002 (EU).iso" size 1459978240 crc 7e940a6b md5 d13fada686d2174aa2d2060779682f22 sha1 8dc05ad02a04e3087ec979330842213329bd3cf0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - May 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7e940a6b md5 d13fada686d2174aa2d2060779682f22 sha1 8dc05ad02a04e3087ec979330842213329bd3cf0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2004 (EU)"
+	description "Interactive Multi-Game Demo Disk - May 2004 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2004 (EU).iso" size 1459978240 crc 4f06ca18 md5 bd83d63adea2812160d550fa8f110e15 sha1 f25f6c3d2a72df76c5d6179e6cad723ae2892a15 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2004 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - May 2004 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2004 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 4f06ca18 md5 bd83d63adea2812160d550fa8f110e15 sha1 f25f6c3d2a72df76c5d6179e6cad723ae2892a15 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2005 (EU)"
+	description "Interactive Multi-Game Demo Disk - May 2005 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2005 (EU).iso" size 1459978240 crc f356e64c md5 9001b5a060bdbbab4952c984758fd2b9 sha1 f21799019468c61814fd7be223fc0e63999f9a44 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - May 2005 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - May 2005 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - May 2005 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f356e64c md5 9001b5a060bdbbab4952c984758fd2b9 sha1 f21799019468c61814fd7be223fc0e63999f9a44 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2002 (EU)"
+	description "Interactive Multi-Game Demo Disk - November 2002 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2002 (EU).iso" size 1459978240 crc e29f67f7 md5 1002b04aef2953827ef0ce0e28abd187 sha1 e09c476eb2963eb8f0891f417e696367ff6e72b5 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - November 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e29f67f7 md5 1002b04aef2953827ef0ce0e28abd187 sha1 e09c476eb2963eb8f0891f417e696367ff6e72b5 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2003 (AU)"
+	description "Interactive Multi-Game Demo Disk - November 2003 (AU)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2003 (AU).iso" size 1459978240 crc f4740c7e md5 63a6b5264ee3fc9844113757695d9ed8 sha1 6d2de0cfeb5053349b2a8f99403b685fc421199f )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2003 (Australia) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - November 2003 (Australia) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2003 (Australia) (En,Fr,De,Es,It).iso" size 1459978240 crc f4740c7e md5 63a6b5264ee3fc9844113757695d9ed8 sha1 6d2de0cfeb5053349b2a8f99403b685fc421199f )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2003 (EU)"
+	description "Interactive Multi-Game Demo Disk - November 2003 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2003 (EU).iso" size 1459978240 crc fb77f000 md5 4159ba513c40ef945f54fed3ec919321 sha1 8ea5a7493669f99f921494b288cdffde03f05187 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2003 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - November 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc fb77f000 md5 4159ba513c40ef945f54fed3ec919321 sha1 8ea5a7493669f99f921494b288cdffde03f05187 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2004 (EU)"
+	description "Interactive Multi-Game Demo Disk - November 2004 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2004 (EU).iso" size 1459978240 crc 0eed226f md5 b2e979aa986ca14e164f48c35641b469 sha1 dbbd671302ecbeece69e881f8cc93d158bf18907 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - November 2004 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - November 2004 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - November 2004 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 0eed226f md5 b2e979aa986ca14e164f48c35641b469 sha1 dbbd671302ecbeece69e881f8cc93d158bf18907 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - October 2005 (EU)"
+	description "Interactive Multi-Game Demo Disk - October 2005 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - October 2005 (EU).iso" size 1459978240 crc 158e12f2 md5 9f427886c0f2262e56fae14d4769849a sha1 4bafd1c8864b203795246a323da1ffa8c89fae78 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - October 2005 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - October 2005 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - October 2005 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 158e12f2 md5 9f427886c0f2262e56fae14d4769849a sha1 4bafd1c8864b203795246a323da1ffa8c89fae78 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2002 (AU)"
+	description "Interactive Multi-Game Demo Disk - September 2002 (AU)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2002 (AU).iso" size 1459978240 crc 25fcca0f md5 7ba2fb437b1682b3ab4b90a6c316e2ba sha1 694b8b2849a02b4da7b262b988b42f5a8eda5668 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2002 (Australia) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - September 2002 (Australia) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2002 (Australia) (En,Fr,De,Es,It).iso" size 1459978240 crc 25fcca0f md5 7ba2fb437b1682b3ab4b90a6c316e2ba sha1 694b8b2849a02b4da7b262b988b42f5a8eda5668 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2002 (EU)"
+	description "Interactive Multi-Game Demo Disk - September 2002 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2002 (EU).iso" size 1459978240 crc e38c117c md5 d5c71eabe573332799b734cccae00d32 sha1 eba97ab8c64199c275db151e5ff0a137fd2dc9bb )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - September 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e38c117c md5 d5c71eabe573332799b734cccae00d32 sha1 eba97ab8c64199c275db151e5ff0a137fd2dc9bb )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2003 (EU)"
+	description "Interactive Multi-Game Demo Disk - September 2003 (EU)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2003 (EU).iso" size 1459978240 crc 55fb8878 md5 bbf2c5802c1644e72aef034532a82cbf sha1 7f3c8542cdbbdd0b2b0f24cd2c1d9d2cd527afb0 )
+)
+
+game (
+	name "Interactive Multi-Game Demo Disk - September 2003 (Europe) (En,Fr,De,Es,It)"
+	description "Interactive Multi-Game Demo Disk - September 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Interactive Multi-Game Demo Disk - September 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 55fb8878 md5 bbf2c5802c1644e72aef034532a82cbf sha1 7f3c8542cdbbdd0b2b0f24cd2c1d9d2cd527afb0 )
+)
+
+game (
+	name "International Superstar Soccer 2 (EU)"
+	description "International Superstar Soccer 2 (EU)"
+	rom ( name "International Superstar Soccer 2 (EU).iso" size 1459978240 crc 1d4a5f3e md5 0674708e6e2f884b3142f0b4de874b6b sha1 afcc235775aa279471bd4885f188d91bd32e6596 )
+)
+
+game (
+	name "International Superstar Soccer 2 (Europe) (En,Fr,De,Es,It)"
+	description "International Superstar Soccer 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "International Superstar Soccer 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1d4a5f3e md5 0674708e6e2f884b3142f0b4de874b6b sha1 afcc235775aa279471bd4885f188d91bd32e6596 )
+)
+
+game (
+	name "International Superstar Soccer 3 (EU)"
+	description "International Superstar Soccer 3 (EU)"
+	rom ( name "International Superstar Soccer 3 (EU).iso" size 1459978240 crc 9c44d6ff md5 4a5b451f3912ee7de941e9ca49bbb6e8 sha1 2a899ce460de9c6ac18824a901874bf370176998 )
+)
+
+game (
+	name "International Superstar Soccer 3 (Europe) (En,Fr,De,Es,It)"
+	description "International Superstar Soccer 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "International Superstar Soccer 3 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9c44d6ff md5 4a5b451f3912ee7de941e9ca49bbb6e8 sha1 2a899ce460de9c6ac18824a901874bf370176998 )
+)
+
+game (
+	name "Italian Job, The (EU)"
+	description "Italian Job, The (EU)"
+	rom ( name "Italian Job, The (EU).iso" size 1459978240 crc 4bbf11bc md5 405a3159b34aa88fb483567413f06295 sha1 b748029f67a22129ad1428b1d6c7d43a8828bb6a )
+)
+
+game (
+	name "Italian Job, The (Europe) (En,Fr,De,Es,It)"
+	description "Italian Job, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Italian Job, The (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 4bbf11bc md5 405a3159b34aa88fb483567413f06295 sha1 b748029f67a22129ad1428b1d6c7d43a8828bb6a )
+)
+
+game (
+	name "Italian Job, The (US)"
+	description "Italian Job, The (US)"
+	rom ( name "Italian Job, The (US).iso" size 1459978240 crc 7f6469ab md5 e8bac2fd2e6da9eb244bdd591b8ef32a sha1 bf1fdef7d2b04ce849765448ec4f78da2afe11a6 )
+)
+
+game (
+	name "Italian Job, The (USA)"
+	description "Italian Job, The (USA)"
+	rom ( name "Italian Job, The (USA).iso" size 1459978240 crc 7f6469ab md5 e8bac2fd2e6da9eb244bdd591b8ef32a sha1 bf1fdef7d2b04ce849765448ec4f78da2afe11a6 )
+)
+
+game (
+	name "Jeremy McGrath Supercross World (EU)"
+	description "Jeremy McGrath Supercross World (EU)"
+	rom ( name "Jeremy McGrath Supercross World (EU).iso" size 1459978240 crc 323be88c md5 684524d11d3de76ca1d2a46098f979d6 sha1 f1a1c09d15a2d48b00563d6ed5be56d5fcde432f )
+)
+
+game (
+	name "Jeremy McGrath Supercross World (Europe) (En,Fr,De,Es,It)"
+	description "Jeremy McGrath Supercross World (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Jeremy McGrath Supercross World (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 323be88c md5 684524d11d3de76ca1d2a46098f979d6 sha1 f1a1c09d15a2d48b00563d6ed5be56d5fcde432f )
+)
+
+game (
+	name "Jeremy McGrath Supercross World (US)"
+	description "Jeremy McGrath Supercross World (US)"
+	rom ( name "Jeremy McGrath Supercross World (US).iso" size 1459978240 crc 0a74f23a md5 c38826d6ce5d8858f1b7db2fe5dcc9a6 sha1 0d0edfab5bcb738c66117c38eef613c99b90e091 )
+)
+
+game (
+	name "Jeremy McGrath Supercross World (USA)"
+	description "Jeremy McGrath Supercross World (USA)"
+	rom ( name "Jeremy McGrath Supercross World (USA).iso" size 1459978240 crc 0a74f23a md5 c38826d6ce5d8858f1b7db2fe5dcc9a6 sha1 0d0edfab5bcb738c66117c38eef613c99b90e091 )
+)
+
+game (
+	name "Jikkyou Powerful Major League (Japan)"
+	description "Jikkyou Powerful Major League (Japan)"
+	rom ( name "Jikkyou Powerful Major League (Japan).iso" size 1459978240 crc 69beb71d md5 06ad33cfcfd1f209875867d66f7a35c6 sha1 bbee81b1c8d8a859f3ebc85a2fe4cdf5be1d96f8 )
+)
+
+game (
+	name "Jikkyou Powerful Major League (JP) - Shi Kuang pawahuru+meziyarigu"
+	description "Jikkyou Powerful Major League (JP) - Shi Kuang pawahuru+meziyarigu"
+	rom ( name "Jikkyou Powerful Major League (JP).iso" size 1459978240 crc 69beb71d md5 06ad33cfcfd1f209875867d66f7a35c6 sha1 bbee81b1c8d8a859f3ebc85a2fe4cdf5be1d96f8 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 10 (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 10 (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 10 (Japan).iso" size 1459978240 crc 16e40639 md5 17b84783d8cd2edf40e2f4295fe5e024 sha1 a11954fb1e9a4be9985ebba94758563bea6fe61a )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 10 (JP) - Shi Kuang pawahurupuroYe Qiu 10"
+	description "Jikkyou Powerful Pro Yakyuu 10 (JP) - Shi Kuang pawahurupuroYe Qiu 10"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 10 (JP).iso" size 1459978240 crc 16e40639 md5 17b84783d8cd2edf40e2f4295fe5e024 sha1 a11954fb1e9a4be9985ebba94758563bea6fe61a )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (Japan).iso" size 1459978240 crc 81a05981 md5 4c5e56314894bff209c31e6bec60f740 sha1 ff28779e5ecccc970bed91d0410cca6925405f20 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (JP)"
+	description "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (JP)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial (JP).iso" size 1459978240 crc 81a05981 md5 4c5e56314894bff209c31e6bec60f740 sha1 ff28779e5ecccc970bed91d0410cca6925405f20 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 11 (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 11 (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 11 (Japan).iso" size 1459978240 crc a9f89b28 md5 f6824525ebae69a5f55676dfea93768c sha1 04af72900b10158c895e5d62e8c213755c9d0cfe )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 11 (JP) - Shi Kuang pawahurupuroYe Qiu +11"
+	description "Jikkyou Powerful Pro Yakyuu 11 (JP) - Shi Kuang pawahurupuroYe Qiu +11"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 11 (JP).iso" size 1459978240 crc a9f89b28 md5 f6824525ebae69a5f55676dfea93768c sha1 04af72900b10158c895e5d62e8c213755c9d0cfe )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (Japan).iso" size 1459978240 crc e838bed2 md5 36f12ec0e25638fdfd9868c499258bec sha1 91ed37138a0c7ab9de3db9124ae59be0496d30cb )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu +11+Chao Jue Ding Ban"
+	description "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu +11+Chao Jue Ding Ban"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban (JP).iso" size 1459978240 crc e838bed2 md5 36f12ec0e25638fdfd9868c499258bec sha1 91ed37138a0c7ab9de3db9124ae59be0496d30cb )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (Japan).iso" size 1459978240 crc 16faa65b md5 619dde16ed7122838308d8f9aeb3189d sha1 b0ef8d0fb9be2a17ac98ff91381ccfb0ee0f6e53 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu 12"
+	description "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu 12"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 12 - Ketteiban (JP).iso" size 1459978240 crc 16faa65b md5 619dde16ed7122838308d8f9aeb3189d sha1 b0ef8d0fb9be2a17ac98ff91381ccfb0ee0f6e53 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 12 (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 12 (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 12 (Japan).iso" size 1459978240 crc a7ac5df7 md5 bb6614e6d71023d46d38e5837ffc292f sha1 bb098b38999f6c11f106a6f60a56ff1b76d0eb11 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 12 (JP) - Shi Kuang pawahurupuroYe Qiu 12Jue Ding Ban"
+	description "Jikkyou Powerful Pro Yakyuu 12 (JP) - Shi Kuang pawahurupuroYe Qiu 12Jue Ding Ban"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 12 (JP).iso" size 1459978240 crc a7ac5df7 md5 bb6614e6d71023d46d38e5837ffc292f sha1 bb098b38999f6c11f106a6f60a56ff1b76d0eb11 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (Japan).iso" size 1459978240 crc fa09af6e md5 4c792871f66087b7a397d945f5a94576 sha1 4e6008eed0186043fe9caa6778cf1679d513e072 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu +9"
+	description "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (JP) - Shi Kuang pawahurupuroYe Qiu +9"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 9 - Ketteiban (JP).iso" size 1459978240 crc fa09af6e md5 4c792871f66087b7a397d945f5a94576 sha1 4e6008eed0186043fe9caa6778cf1679d513e072 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 9 (Japan)"
+	description "Jikkyou Powerful Pro Yakyuu 9 (Japan)"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 9 (Japan).iso" size 1459978240 crc 9b7268c4 md5 0fc7781da7dd28303c0b3cd1f0f0391e sha1 8a029784b41819d54944a3f1d449db6177c36ec4 )
+)
+
+game (
+	name "Jikkyou Powerful Pro Yakyuu 9 (JP) - Shi Kuang pawahurupuroYe Qiu 9Jue Ding Ban"
+	description "Jikkyou Powerful Pro Yakyuu 9 (JP) - Shi Kuang pawahurupuroYe Qiu 9Jue Ding Ban"
+	rom ( name "Jikkyou Powerful Pro Yakyuu 9 (JP).iso" size 1459978240 crc 9b7268c4 md5 0fc7781da7dd28303c0b3cd1f0f0391e sha1 8a029784b41819d54944a3f1d449db6177c36ec4 )
+)
+
+game (
+	name "Jikkyou World Soccer 2002 (Japan)"
+	description "Jikkyou World Soccer 2002 (Japan)"
+	rom ( name "Jikkyou World Soccer 2002 (Japan).iso" size 1459978240 crc 4229cff9 md5 1bfcb7dca128f200de792650c4de3a97 sha1 ccb971a16aa5adc5db728734945e616d86574efa )
+)
+
+game (
+	name "Jikkyou World Soccer 2002 (JP) - Shi Kuang warudosatuka+2002"
+	description "Jikkyou World Soccer 2002 (JP) - Shi Kuang warudosatuka+2002"
+	rom ( name "Jikkyou World Soccer 2002 (JP).iso" size 1459978240 crc 4229cff9 md5 1bfcb7dca128f200de792650c4de3a97 sha1 ccb971a16aa5adc5db728734945e616d86574efa )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (DE)"
+	description "Judge Dredd - Dredd vs. Death (DE)"
+	rom ( name "Judge Dredd - Dredd vs. Death (DE).iso" size 1459978240 crc 638f2200 md5 ac234afecae90d154ddad699c89307ce sha1 afe249944b1790b6c47b607116d895893a90b06d )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (EU)"
+	description "Judge Dredd - Dredd vs. Death (EU)"
+	rom ( name "Judge Dredd - Dredd vs. Death (EU).iso" size 1459978240 crc 39d04d0a md5 082fa5b1e84068f6fa256f11e60431e9 sha1 df842d2aea6b4a047917c8e2cb3b726959502a7f )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (Europe) (En,Fr)"
+	description "Judge Dredd - Dredd vs. Death (Europe) (En,Fr)"
+	rom ( name "Judge Dredd - Dredd vs. Death (Europe) (En,Fr).iso" size 1459978240 crc 39d04d0a md5 082fa5b1e84068f6fa256f11e60431e9 sha1 df842d2aea6b4a047917c8e2cb3b726959502a7f )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (Germany) (En,De)"
+	description "Judge Dredd - Dredd vs. Death (Germany) (En,De)"
+	rom ( name "Judge Dredd - Dredd vs. Death (Germany) (En,De).iso" size 1459978240 crc 638f2200 md5 ac234afecae90d154ddad699c89307ce sha1 afe249944b1790b6c47b607116d895893a90b06d )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (US)"
+	description "Judge Dredd - Dredd vs. Death (US)"
+	rom ( name "Judge Dredd - Dredd vs. Death (US).iso" size 1459978240 crc 19fa8d6c md5 4b78c00906e4b782c336810166663e9a sha1 c2ae432c60734c5961dd5b2573ff3d56d4ffac15 )
+)
+
+game (
+	name "Judge Dredd - Dredd vs. Death (USA)"
+	description "Judge Dredd - Dredd vs. Death (USA)"
+	rom ( name "Judge Dredd - Dredd vs. Death (USA).iso" size 1459978240 crc 19fa8d6c md5 4b78c00906e4b782c336810166663e9a sha1 c2ae432c60734c5961dd5b2573ff3d56d4ffac15 )
+)
+
+game (
+	name "Kaijuu no Shima - Amazing Island (Japan)"
+	description "Kaijuu no Shima - Amazing Island (Japan)"
+	rom ( name "Kaijuu no Shima - Amazing Island (Japan).iso" size 1459978240 crc 45401a74 md5 7ae5919951263daf3099aa6c7992a093 sha1 e99e3b4007fcb6939fd9f592d6995ff77191e012 )
+)
+
+game (
+	name "Kaijuu no Shima - Amazing Island (JP) - kaiziyuunoDao +~amezinguairando~"
+	description "Kaijuu no Shima - Amazing Island (JP) - kaiziyuunoDao +~amezinguairando~"
+	rom ( name "Kaijuu no Shima - Amazing Island (JP).iso" size 1459978240 crc 45401a74 md5 7ae5919951263daf3099aa6c7992a093 sha1 e99e3b4007fcb6939fd9f592d6995ff77191e012 )
+)
+
+game (
+	name "Kao the Kangaroo - Round 2 (EU)"
+	description "Kao the Kangaroo - Round 2 (EU)"
+	rom ( name "Kao the Kangaroo - Round 2 (EU).iso" size 1459978240 crc 2894392a md5 87e907c5b14099dce1bdb146d3afbfdf sha1 89badc3e8dd4b3c4b28f893f0cf56e42c8d4c359 )
+)
+
+game (
+	name "Kao the Kangaroo - Round 2 (Europe) (En,Fr,De,Es,It)"
+	description "Kao the Kangaroo - Round 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kao the Kangaroo - Round 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 2894392a md5 87e907c5b14099dce1bdb146d3afbfdf sha1 89badc3e8dd4b3c4b28f893f0cf56e42c8d4c359 )
+)
+
+game (
+	name "Kao the Kangaroo - Round 2 (US)"
+	description "Kao the Kangaroo - Round 2 (US)"
+	rom ( name "Kao the Kangaroo - Round 2 (US).iso" size 1459978240 crc 3c858664 md5 34b71d6dd1674f81d6d861ab68b00099 sha1 ca8d40d38ec676b81a463ee0e01f877ad3a61520 )
+)
+
+game (
+	name "Kao the Kangaroo - Round 2 (USA)"
+	description "Kao the Kangaroo - Round 2 (USA)"
+	rom ( name "Kao the Kangaroo - Round 2 (USA).iso" size 1459978240 crc 3c858664 md5 34b71d6dd1674f81d6d861ab68b00099 sha1 ca8d40d38ec676b81a463ee0e01f877ad3a61520 )
+)
+
+game (
+	name "Karaoke Revolution Party (US)"
+	description "Karaoke Revolution Party (US)"
+	rom ( name "Karaoke Revolution Party (US).iso" size 1459978240 crc af292ddc md5 044d5336d7d473c7582e712412c95535 sha1 dd955e2c5e594749d4406f080a6e95aae6cbd6f5 )
+)
+
+game (
+	name "Karaoke Revolution Party (USA)"
+	description "Karaoke Revolution Party (USA)"
+	rom ( name "Karaoke Revolution Party (USA).iso" size 1459978240 crc af292ddc md5 044d5336d7d473c7582e712412c95535 sha1 dd955e2c5e594749d4406f080a6e95aae6cbd6f5 )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (EU)"
+	description "Kelly Slater's Pro Surfer (EU)"
+	rom ( name "Kelly Slater's Pro Surfer (EU).iso" size 1459978240 crc b4709cc4 md5 98648830ef3683fba4f526aaded05367 sha1 d7bb0317eefe3f10aba10531e6f1a7b09fb2ae2e )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (Europe)"
+	description "Kelly Slater's Pro Surfer (Europe)"
+	rom ( name "Kelly Slater's Pro Surfer (Europe).iso" size 1459978240 crc 81976bf2 md5 4b7e77ec727d0659955967c827f889bb sha1 9890a8804b8edab23839c708affe969d611752d1 )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (Europe) (En,Fr,De)"
+	description "Kelly Slater's Pro Surfer (Europe) (En,Fr,De)"
+	rom ( name "Kelly Slater's Pro Surfer (Europe) (En,Fr,De).iso" size 1459978240 crc b4709cc4 md5 98648830ef3683fba4f526aaded05367 sha1 d7bb0317eefe3f10aba10531e6f1a7b09fb2ae2e )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (GB)"
+	description "Kelly Slater's Pro Surfer (GB)"
+	rom ( name "Kelly Slater's Pro Surfer (GB).iso" size 1459978240 crc 81976bf2 md5 4b7e77ec727d0659955967c827f889bb sha1 9890a8804b8edab23839c708affe969d611752d1 )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (US)"
+	description "Kelly Slater's Pro Surfer (US)"
+	rom ( name "Kelly Slater's Pro Surfer (US).iso" size 1459978240 crc 3ee8a0da md5 aa7bb7d8426832d25712a62a098ab485 sha1 fe8b890354a796ceae9efd8316706ccc65e41861 )
+)
+
+game (
+	name "Kelly Slater's Pro Surfer (USA)"
+	description "Kelly Slater's Pro Surfer (USA)"
+	rom ( name "Kelly Slater's Pro Surfer (USA).iso" size 1459978240 crc 3ee8a0da md5 aa7bb7d8426832d25712a62a098ab485 sha1 fe8b890354a796ceae9efd8316706ccc65e41861 )
+)
+
+game (
+	name "Kero Kero King DX (Japan)"
+	description "Kero Kero King DX (Japan)"
+	rom ( name "Kero Kero King DX (Japan).iso" size 1459978240 crc 8c8f0ef3 md5 9b4d0d019c15efbe22d5f695c6cdd3e6 sha1 2940791f4261fe787e66dc0de43c98e141612a75 )
+)
+
+game (
+	name "Kero Kero King DX (JP) - kerokerokinguDX"
+	description "Kero Kero King DX (JP) - kerokerokinguDX"
+	rom ( name "Kero Kero King DX (JP).iso" size 1459978240 crc 8c8f0ef3 md5 9b4d0d019c15efbe22d5f695c6cdd3e6 sha1 2940791f4261fe787e66dc0de43c98e141612a75 )
+)
+
+game (
+	name "Kidou Senshi Gundam - Gundam vs. Z Gundam (Japan)"
+	description "Kidou Senshi Gundam - Gundam vs. Z Gundam (Japan)"
+	rom ( name "Kidou Senshi Gundam - Gundam vs. Z Gundam (Japan).iso" size 1459978240 crc ad128a51 md5 a32538feea555161a9d616bc8ff9c6b1 sha1 b1535a65e7dd6484a9f997ad93f989230819924e )
+)
+
+game (
+	name "Kidou Senshi Gundam - Gundam vs. Z Gundam (JP) - Ji Dong Zhan Shi +gandamu+gandamu+vs.+Zgandamu"
+	description "Kidou Senshi Gundam - Gundam vs. Z Gundam (JP) - Ji Dong Zhan Shi +gandamu+gandamu+vs.+Zgandamu"
+	rom ( name "Kidou Senshi Gundam - Gundam vs. Z Gundam (JP).iso" size 1459978240 crc ad128a51 md5 a32538feea555161a9d616bc8ff9c6b1 sha1 b1535a65e7dd6484a9f997ad93f989230819924e )
+)
+
+game (
+	name "Kidou Senshi Gundam - Senshitachi no Kiseki (Japan)"
+	description "Kidou Senshi Gundam - Senshitachi no Kiseki (Japan)"
+	rom ( name "Kidou Senshi Gundam - Senshitachi no Kiseki (Japan).iso" size 1459978240 crc 53ed327b md5 67e92b0f150d1747f70eabb070a9e2ca sha1 6dbfa755390c3fdf396923aa194cb8edc8f617de )
+)
+
+game (
+	name "Kidou Senshi Gundam - Senshitachi no Kiseki (JP) - Ji Dong Zhan Shi gandamu+Zhan Shi Da noGui Ji"
+	description "Kidou Senshi Gundam - Senshitachi no Kiseki (JP) - Ji Dong Zhan Shi gandamu+Zhan Shi Da noGui Ji"
+	rom ( name "Kidou Senshi Gundam - Senshitachi no Kiseki (JP).iso" size 1459978240 crc 53ed327b md5 67e92b0f150d1747f70eabb070a9e2ca sha1 6dbfa755390c3fdf396923aa194cb8edc8f617de )
+)
+
+game (
+	name "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Japan)"
+	description "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Japan)"
+	rom ( name "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Japan).iso" size 1459978240 crc 05458fad md5 1bbb309c44bfa67b0b4246233df9f93c sha1 2ee37d857ae5671d88f1440b21105decd15ee7de )
+)
+
+game (
+	name "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Limited Edition) (JP) - Ji Dong Zhan Shi gandamu+Zhan Shi Da noGui Ji +supesiyarudeisuku"
+	description "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Limited Edition) (JP) - Ji Dong Zhan Shi gandamu+Zhan Shi Da noGui Ji +supesiyarudeisuku"
+	rom ( name "Kidou Senshi Gundam - Senshitachi no Kiseki Special Disc (Limited Edition) (JP).iso" size 1459978240 crc 05458fad md5 1bbb309c44bfa67b0b4246233df9f93c sha1 2ee37d857ae5671d88f1440b21105decd15ee7de )
+)
+
+game (
+	name "Killer 7 (EU)"
+	description "Killer 7 (EU)"
+	rom ( name "Killer 7 (EU) - (Disc 1 of 2).iso" size 1459978240 crc 77aec1e7 md5 b55ca1e15ea751501a9fb684b6f1a6a3 sha1 c0320797013ff9e3bc2bf703a6e30357aa31c056 )
+)
+
+game (
+	name "Killer 7 (Europe) (En,Fr,De) (Disc 1)"
+	description "Killer 7 (Europe) (En,Fr,De) (Disc 1)"
+	rom ( name "Killer 7 (Europe) (En,Fr,De) (Disc 1).iso" size 1459978240 crc 77aec1e7 md5 b55ca1e15ea751501a9fb684b6f1a6a3 sha1 c0320797013ff9e3bc2bf703a6e30357aa31c056 )
+)
+
+game (
+	name "Killer 7 (Europe) (En,Fr,De) (Disc 2)"
+	description "Killer 7 (Europe) (En,Fr,De) (Disc 2)"
+	rom ( name "Killer 7 (Europe) (En,Fr,De) (Disc 2).iso" size 1459978240 crc c0a57674 md5 fda1f2fa62b0a0999f94471f56a662a3 sha1 7bcc386ee8dbb85a0a9b241e69c2189459049311 )
+)
+
+game (
+	name "Killer 7 (Japan) (Disc 1)"
+	description "Killer 7 (Japan) (Disc 1)"
+	rom ( name "Killer 7 (Japan) (Disc 1).iso" size 1459978240 crc f5b8313f md5 705faf2118e0f456ae7866024577a7f3 sha1 75480f110b642ccc469914528edaf762161d5717 )
+)
+
+game (
+	name "Killer 7 (Japan) (Disc 2)"
+	description "Killer 7 (Japan) (Disc 2)"
+	rom ( name "Killer 7 (Japan) (Disc 2).iso" size 1459978240 crc d24ac1b5 md5 c6efb28197fa52eb76d3ba877770f63b sha1 19daec84a3ded20ff3e9aa8abd05d9278ead6719 )
+)
+
+game (
+	name "Killer 7 (JP) - kira7"
+	description "Killer 7 (JP) - kira7"
+	rom ( name "Killer 7 (JP) - (Disc 1 of 2).iso" size 1459978240 crc f5b8313f md5 705faf2118e0f456ae7866024577a7f3 sha1 75480f110b642ccc469914528edaf762161d5717 )
+)
+
+game (
+	name "Killer 7 (US)"
+	description "Killer 7 (US)"
+	rom ( name "Killer 7 (US) - (Disc 1 of 2).iso" size 1459978240 crc 64f21d40 md5 4cdb132c4ab2d95b9095fdb1647e9636 sha1 20d7c2a1b7f156c671166d3d552ad4645fa0c3d7 )
+)
+
+game (
+	name "Killer 7 (USA) (Disc 1)"
+	description "Killer 7 (USA) (Disc 1)"
+	rom ( name "Killer 7 (USA) (Disc 1).iso" size 1459978240 crc 64f21d40 md5 4cdb132c4ab2d95b9095fdb1647e9636 sha1 20d7c2a1b7f156c671166d3d552ad4645fa0c3d7 )
+)
+
+game (
+	name "Killer 7 (USA) (Disc 2)"
+	description "Killer 7 (USA) (Disc 2)"
+	rom ( name "Killer 7 (USA) (Disc 2).iso" size 1459978240 crc 3d830b55 md5 58a84314ef4ccf17bd118a03009f93ad sha1 6c3aad4b78364b8c2c18241650783128dc1d0dbe )
+)
+
+game (
+	name "King Arthur (EU)"
+	description "King Arthur (EU)"
+	rom ( name "King Arthur (EU).iso" size 1459978240 crc ee3c9cf7 md5 452c3b82f3652f1e137e8f0e8a4a9c1a sha1 59587e5bcd5467c13d725b2b86af4743782cecee )
+)
+
+game (
+	name "King Arthur (Europe) (En,Fr,De,Es,It)"
+	description "King Arthur (Europe) (En,Fr,De,Es,It)"
+	rom ( name "King Arthur (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ee3c9cf7 md5 452c3b82f3652f1e137e8f0e8a4a9c1a sha1 59587e5bcd5467c13d725b2b86af4743782cecee )
+)
+
+game (
+	name "King Arthur (US)"
+	description "King Arthur (US)"
+	rom ( name "King Arthur (US).iso" size 1459978240 crc cc22363f md5 4197c40fe47a3c496fc5fa4a76935943 sha1 6c4429304367afa00fcf30efed047dad78da3e98 )
+)
+
+game (
+	name "King Arthur (USA)"
+	description "King Arthur (USA)"
+	rom ( name "King Arthur (USA).iso" size 1459978240 crc cc22363f md5 4197c40fe47a3c496fc5fa4a76935943 sha1 6c4429304367afa00fcf30efed047dad78da3e98 )
+)
+
+game (
+	name "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (Japan)"
+	description "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (Japan)"
+	rom ( name "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (Japan).iso" size 1459978240 crc df30f976 md5 80b118e606bff06a44e84a67938cea03 sha1 daab2a72b362941db7f85285805873398678f85f )
+)
+
+game (
+	name "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (JP) - kinRou manIIShi +Xin Shi Dai Chao Ren VSChuan Shuo Chao Ren"
+	description "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (JP) - kinRou manIIShi +Xin Shi Dai Chao Ren VSChuan Shuo Chao Ren"
+	rom ( name "Kinnikuman Nisei - Shinsedai Choujin vs. Densetsu Choujin (JP).iso" size 1459978240 crc df30f976 md5 80b118e606bff06a44e84a67938cea03 sha1 daab2a72b362941db7f85285805873398678f85f )
+)
+
+game (
+	name "Kirby Air Ride (EU)"
+	description "Kirby Air Ride (EU)"
+	rom ( name "Kirby Air Ride (EU).iso" size 1459978240 crc fb84bfc5 md5 6732cefabda3b8c8c590a2157ed2e45b sha1 ccdc2ba3675a8b738d7fdc3b34cf0b0d5f3a11db )
+)
+
+game (
+	name "Kirby Air Ride (Europe) (En,Fr,De,Es,It)"
+	description "Kirby Air Ride (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kirby Air Ride (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc fb84bfc5 md5 6732cefabda3b8c8c590a2157ed2e45b sha1 ccdc2ba3675a8b738d7fdc3b34cf0b0d5f3a11db )
+)
+
+game (
+	name "Kirby Air Ride (US)"
+	description "Kirby Air Ride (US)"
+	rom ( name "Kirby Air Ride (US).iso" size 1459978240 crc f1a3e7a2 md5 bd936616ba7f998d8d0a1eb3f553b634 sha1 b57132b1d0990264c271a1ad2168aa75b93b2f92 )
+)
+
+game (
+	name "Kirby Air Ride (USA)"
+	description "Kirby Air Ride (USA)"
+	rom ( name "Kirby Air Ride (USA).iso" size 1459978240 crc f1a3e7a2 md5 bd936616ba7f998d8d0a1eb3f553b634 sha1 b57132b1d0990264c271a1ad2168aa75b93b2f92 )
+)
+
+game (
+	name "Kirby's Airride (Japan)"
+	description "Kirby's Airride (Japan)"
+	rom ( name "Kirby's Airride (Japan).iso" size 1459978240 crc 03186e58 md5 a2710feb35ef1b2fc8a8ca3a3c30edbf sha1 34062ecaecf3764dfc1c6e37e345f05facfafd0c )
+)
+
+game (
+	name "Kirby's Airride (JP) - kabiinoearaido"
+	description "Kirby's Airride (JP) - kabiinoearaido"
+	rom ( name "Kirby's Airride (JP).iso" size 1459978240 crc 03186e58 md5 a2710feb35ef1b2fc8a8ca3a3c30edbf sha1 34062ecaecf3764dfc1c6e37e345f05facfafd0c )
+)
+
+game (
+	name "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (Japan)"
+	description "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (Japan)"
+	rom ( name "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (Japan).iso" size 1459978240 crc 2583be45 md5 d9ab28d05e75d3f0f1440f04c9dbba06 sha1 b028fc27aecd29d3fd1c8c0b19938130b91f55a6 )
+)
+
+game (
+	name "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (JP) - Ji +Ma Que DX+II+The+4th+MONDO21Cup+Competition"
+	description "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (JP) - Ji +Ma Que DX+II+The+4th+MONDO21Cup+Competition"
+	rom ( name "Kiwame Mahjong DX II - The 4th MONDO21Cup Competition (JP).iso" size 1459978240 crc 2583be45 md5 d9ab28d05e75d3f0f1440f04c9dbba06 sha1 b028fc27aecd29d3fd1c8c0b19938130b91f55a6 )
+)
+
+game (
+	name "Knights of the Temple - Infernal Crusade (EU)"
+	description "Knights of the Temple - Infernal Crusade (EU)"
+	rom ( name "Knights of the Temple - Infernal Crusade (EU).iso" size 1459978240 crc 3114d1c4 md5 a6931e704eb6d2a9321df0ac144fdb48 sha1 28344fb6d7d18866b0990a9261a5e7a91a82838d )
+)
+
+game (
+	name "Knights of the Temple - Infernal Crusade (Europe) (En,Fr,De,Es)"
+	description "Knights of the Temple - Infernal Crusade (Europe) (En,Fr,De,Es)"
+	rom ( name "Knights of the Temple - Infernal Crusade (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 3114d1c4 md5 a6931e704eb6d2a9321df0ac144fdb48 sha1 28344fb6d7d18866b0990a9261a5e7a91a82838d )
+)
+
+game (
+	name "Knockout Kings 2003 (EU)"
+	description "Knockout Kings 2003 (EU)"
+	rom ( name "Knockout Kings 2003 (EU).iso" size 1459978240 crc ee59e1db md5 a41e7d2bdb0c85f6fb669f348d3ec189 sha1 8eb557add452f63057c17821eed957fde16b6286 )
+)
+
+game (
+	name "Knockout Kings 2003 (Europe) (En,Fr,De)"
+	description "Knockout Kings 2003 (Europe) (En,Fr,De)"
+	rom ( name "Knockout Kings 2003 (Europe) (En,Fr,De).iso" size 1459978240 crc ee59e1db md5 a41e7d2bdb0c85f6fb669f348d3ec189 sha1 8eb557add452f63057c17821eed957fde16b6286 )
+)
+
+game (
+	name "Knockout Kings 2003 (US)"
+	description "Knockout Kings 2003 (US)"
+	rom ( name "Knockout Kings 2003 (US).iso" size 1459978240 crc 119d506e md5 0e3d5ac1d1d75d4662a9bed9e26628c5 sha1 8be2cf518f0beb5393d18ef1ca59f17ad0fe56e9 )
+)
+
+game (
+	name "Knockout Kings 2003 (USA)"
+	description "Knockout Kings 2003 (USA)"
+	rom ( name "Knockout Kings 2003 (USA).iso" size 1459978240 crc 119d506e md5 0e3d5ac1d1d75d4662a9bed9e26628c5 sha1 8be2cf518f0beb5393d18ef1ca59f17ad0fe56e9 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (Japan)"
+	description "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (Japan)"
+	rom ( name "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (Japan).iso" size 1459978240 crc 06fa3328 md5 6d67bbefb1c1283b248be402eb9a615d sha1 ae56218a47939e900357372e8e2b4851e2eed7e4 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (JP) - Jin Se nogatusiyuberu!!go!go!Mo Wu huaito!!"
+	description "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (JP) - Jin Se nogatusiyuberu!!go!go!Mo Wu huaito!!"
+	rom ( name "Konjiki no Gashbell!! Go! Go! Mamono Fight!! (JP).iso" size 1459978240 crc 06fa3328 md5 6d67bbefb1c1283b248be402eb9a615d sha1 ae56218a47939e900357372e8e2b4851e2eed7e4 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (Japan)"
+	description "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (Japan)"
+	rom ( name "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (Japan).iso" size 1459978240 crc 658027e8 md5 6277dedb0e6e242908e9a3aa3d83bfad sha1 6701d931e8d953f09933356e43609518ef4508b6 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (JP) - Jin Se nogatusiyuberu!!You Qing tatugubatoru+FULL+POWER"
+	description "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (JP) - Jin Se nogatusiyuberu!!You Qing tatugubatoru+FULL+POWER"
+	rom ( name "Konjiki no Gashbell!! Yuujou Tag Battle - Full Power (JP).iso" size 1459978240 crc 658027e8 md5 6277dedb0e6e242908e9a3aa3d83bfad sha1 6701d931e8d953f09933356e43609518ef4508b6 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Yuujou Tag Battle 2 (Japan)"
+	description "Konjiki no Gashbell!! Yuujou Tag Battle 2 (Japan)"
+	rom ( name "Konjiki no Gashbell!! Yuujou Tag Battle 2 (Japan).iso" size 1459978240 crc b6f18a4a md5 f3c672f6fbb300a92cbfb826141746e9 sha1 4883736213f43157f6a659234ea5a72ac4f3d534 )
+)
+
+game (
+	name "Konjiki no Gashbell!! Yuujou Tag Battle 2 (JP) - Jin Se nogatusiyuberu!!You Qing tatugubatoru2"
+	description "Konjiki no Gashbell!! Yuujou Tag Battle 2 (JP) - Jin Se nogatusiyuberu!!You Qing tatugubatoru2"
+	rom ( name "Konjiki no Gashbell!! Yuujou Tag Battle 2 (JP).iso" size 1459978240 crc b6f18a4a md5 f3c672f6fbb300a92cbfb826141746e9 sha1 4883736213f43157f6a659234ea5a72ac4f3d534 )
+)
+
+game (
+	name "Kururin Squash! (Japan)"
+	description "Kururin Squash! (Japan)"
+	rom ( name "Kururin Squash! (Japan).iso" size 1459978240 crc 8be76fa2 md5 b6768b74ab521063420a8aa8b957e599 sha1 f1e5e50751cee4fa654182e0904f7f6ef721e5cc )
+)
+
+game (
+	name "Kururin Squash! (JP) - kururinsukatusiyu!"
+	description "Kururin Squash! (JP) - kururinsukatusiyu!"
+	rom ( name "Kururin Squash! (JP).iso" size 1459978240 crc 8be76fa2 md5 b6768b74ab521063420a8aa8b957e599 sha1 f1e5e50751cee4fa654182e0904f7f6ef721e5cc )
+)
+
+game (
+	name "Kyojin no Doshin (Japan)"
+	description "Kyojin no Doshin (Japan)"
+	rom ( name "Kyojin no Doshin (Japan).iso" size 1459978240 crc 21fc1ca2 md5 e50ae224bae53b9c139b8c04bd61dc9c sha1 832a2845a1a0d1320dace4caed4df0ca01e44c95 )
+)
+
+game (
+	name "Kyojin no Doshin (JP) - Ju Ren nodosin"
+	description "Kyojin no Doshin (JP) - Ju Ren nodosin"
+	rom ( name "Kyojin no Doshin (JP).iso" size 1459978240 crc 21fc1ca2 md5 e50ae224bae53b9c139b8c04bd61dc9c sha1 832a2845a1a0d1320dace4caed4df0ca01e44c95 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (DE)"
+	description "Lara Croft Tomb Raider - Legend (DE)"
+	rom ( name "Lara Croft Tomb Raider - Legend (DE).iso" size 1459978240 crc ec0a495b md5 84fe3036a2d369135720ff9b2613a52b sha1 6825657689302c720c69d8f04f9439f5cd58cf50 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (Europe)"
+	description "Lara Croft Tomb Raider - Legend (Europe)"
+	rom ( name "Lara Croft Tomb Raider - Legend (Europe).iso" size 1459978240 crc b9ecf301 md5 4ca7a5a4b95e2a25a152e31a4cdb324f sha1 264ea6e743892402583d7a266d4c509eb4172737 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (FR)"
+	description "Lara Croft Tomb Raider - Legend (FR)"
+	rom ( name "Lara Croft Tomb Raider - Legend (FR).iso" size 1459978240 crc fc703cb9 md5 e60c702eecb049f8029ad6ff67495f72 sha1 1bdb4e412530c58523eb53a21c5a9f021efd7805 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (France)"
+	description "Lara Croft Tomb Raider - Legend (France)"
+	rom ( name "Lara Croft Tomb Raider - Legend (France).iso" size 1459978240 crc fc703cb9 md5 e60c702eecb049f8029ad6ff67495f72 sha1 1bdb4e412530c58523eb53a21c5a9f021efd7805 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (GB)"
+	description "Lara Croft Tomb Raider - Legend (GB)"
+	rom ( name "Lara Croft Tomb Raider - Legend (GB).iso" size 1459978240 crc b9ecf301 md5 4ca7a5a4b95e2a25a152e31a4cdb324f sha1 264ea6e743892402583d7a266d4c509eb4172737 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (Germany)"
+	description "Lara Croft Tomb Raider - Legend (Germany)"
+	rom ( name "Lara Croft Tomb Raider - Legend (Germany).iso" size 1459978240 crc ec0a495b md5 84fe3036a2d369135720ff9b2613a52b sha1 6825657689302c720c69d8f04f9439f5cd58cf50 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (US)"
+	description "Lara Croft Tomb Raider - Legend (US)"
+	rom ( name "Lara Croft Tomb Raider - Legend (US).iso" size 1459978240 crc a5f49142 md5 a34832c3f04682c9c8b18a0e94aef28b sha1 70554803a2230589e42415aaf0025733977ffc63 )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Legend (USA)"
+	description "Lara Croft Tomb Raider - Legend (USA)"
+	rom ( name "Lara Croft Tomb Raider - Legend (USA).iso" size 1459978240 crc a5f49142 md5 a34832c3f04682c9c8b18a0e94aef28b sha1 70554803a2230589e42415aaf0025733977ffc63 )
+)
+
+game (
+	name "Largo Winch - Empire Under Threat (EU)"
+	description "Largo Winch - Empire Under Threat (EU)"
+	rom ( name "Largo Winch - Empire Under Threat (EU).iso" size 1459978240 crc ce0a38b3 md5 7f73d149cfe9f877abe99c3cba26ed4e sha1 82a4680fd87fada55ca84016eff508d485317906 )
+)
+
+game (
+	name "Largo Winch - Empire Under Threat (Europe) (En,Fr,De,Es,It)"
+	description "Largo Winch - Empire Under Threat (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Largo Winch - Empire Under Threat (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ce0a38b3 md5 7f73d149cfe9f877abe99c3cba26ed4e sha1 82a4680fd87fada55ca84016eff508d485317906 )
+)
+
+game (
+	name "Legend of Golfer (Japan)"
+	description "Legend of Golfer (Japan)"
+	rom ( name "Legend of Golfer (Japan).iso" size 1459978240 crc eaaa2990 md5 bac7a8076c49d6c0737a137d62c78c91 sha1 62489a9adb36bfbc37ab8660c9cb78b375543c32 )
+)
+
+game (
+	name "Legend of Golfer (JP) - reziendo+obu+goruhua"
+	description "Legend of Golfer (JP) - reziendo+obu+goruhua"
+	rom ( name "Legend of Golfer (JP).iso" size 1459978240 crc eaaa2990 md5 bac7a8076c49d6c0737a137d62c78c91 sha1 62489a9adb36bfbc37ab8660c9cb78b375543c32 )
+)
+
+game (
+	name "Legend of Spyro, The - A New Beginning (EU)"
+	description "Legend of Spyro, The - A New Beginning (EU)"
+	rom ( name "Legend of Spyro, The - A New Beginning (EU).iso" size 1459978240 crc 23d400cb md5 6f68a94ff9c4c0c1648416983e2e381d sha1 5ea2b4fd1aa6c0db48647b969c77c95df8a5c945 )
+)
+
+game (
+	name "Legend of Spyro, The - A New Beginning (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Legend of Spyro, The - A New Beginning (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Legend of Spyro, The - A New Beginning (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 23d400cb md5 6f68a94ff9c4c0c1648416983e2e381d sha1 5ea2b4fd1aa6c0db48647b969c77c95df8a5c945 )
+)
+
+game (
+	name "Legend of Spyro, The - A New Beginning (US)"
+	description "Legend of Spyro, The - A New Beginning (US)"
+	rom ( name "Legend of Spyro, The - A New Beginning (US).iso" size 1459978240 crc 8b1a3dff md5 652a91ff450633d2e1fd2eb7bfdd3571 sha1 1e7668425fcae4f1bf184ac1a42e47e3bc24ddc3 )
+)
+
+game (
+	name "Legend of Spyro, The - A New Beginning (USA)"
+	description "Legend of Spyro, The - A New Beginning (USA)"
+	rom ( name "Legend of Spyro, The - A New Beginning (USA).iso" size 1459978240 crc 8b1a3dff md5 652a91ff450633d2e1fd2eb7bfdd3571 sha1 1e7668425fcae4f1bf184ac1a42e47e3bc24ddc3 )
+)
+
+game (
+	name "Legend of Zelda, The - Collector's Edition (Europe) (En,Fr,De,Es,It)"
+	description "Legend of Zelda, The - Collector's Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of Zelda, The - Collector's Edition (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 667329d4 md5 1c9fa0c8adc9584e5169d4cfb51425f3 sha1 fa16772e967ad667ebff39fb6b035ff1f80bc8e4 )
+)
+
+game (
+	name "Legend of Zelda, The - Collector's Edition (Promo) (EU)"
+	description "Legend of Zelda, The - Collector's Edition (Promo) (EU)"
+	rom ( name "Legend of Zelda, The - Collector's Edition (Promo) (EU).iso" size 1459978240 crc 667329d4 md5 1c9fa0c8adc9584e5169d4cfb51425f3 sha1 fa16772e967ad667ebff39fb6b035ff1f80bc8e4 )
+)
+
+game (
+	name "Legend of Zelda, The - Collector's Edition (Promo) (US)"
+	description "Legend of Zelda, The - Collector's Edition (Promo) (US)"
+	rom ( name "Legend of Zelda, The - Collector's Edition (Promo) (US).iso" size 1459978240 crc 8d2141cf md5 2c66f072455ccdbe97a72e5c94784df8 sha1 35e66bf6a0f32597beb5f8b055c1d424a41a89d7 )
+)
+
+game (
+	name "Legend of Zelda, The - Collector's Edition (USA)"
+	description "Legend of Zelda, The - Collector's Edition (USA)"
+	rom ( name "Legend of Zelda, The - Collector's Edition (USA).iso" size 1459978240 crc 8d2141cf md5 2c66f072455ccdbe97a72e5c94784df8 sha1 35e66bf6a0f32597beb5f8b055c1d424a41a89d7 )
+)
+
+game (
+	name "Legend of Zelda, The - Four Swords Adventures (EU)"
+	description "Legend of Zelda, The - Four Swords Adventures (EU)"
+	rom ( name "Legend of Zelda, The - Four Swords Adventures (EU).iso" size 1459978240 crc d99f34e4 md5 a8665e36c64c2369628aabef6b268c42 sha1 e9842565f6f39a321f28f56e621a0b6de58bc960 )
+)
+
+game (
+	name "Legend of Zelda, The - Four Swords Adventures (Europe) (En,Fr,De,Es,It)"
+	description "Legend of Zelda, The - Four Swords Adventures (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of Zelda, The - Four Swords Adventures (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc d99f34e4 md5 a8665e36c64c2369628aabef6b268c42 sha1 e9842565f6f39a321f28f56e621a0b6de58bc960 )
+)
+
+game (
+	name "Legend of Zelda, The - Four Swords Adventures (US)"
+	description "Legend of Zelda, The - Four Swords Adventures (US)"
+	rom ( name "Legend of Zelda, The - Four Swords Adventures (US).iso" size 1459978240 crc afb151e4 md5 6156867bd3aa2fc410e9e307fe0fd98c sha1 4bd926835dfbeaae72d01abe5fb581b527154a30 )
+)
+
+game (
+	name "Legend of Zelda, The - Four Swords Adventures (USA)"
+	description "Legend of Zelda, The - Four Swords Adventures (USA)"
+	rom ( name "Legend of Zelda, The - Four Swords Adventures (USA).iso" size 1459978240 crc afb151e4 md5 6156867bd3aa2fc410e9e307fe0fd98c sha1 4bd926835dfbeaae72d01abe5fb581b527154a30 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (AU)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (AU)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (AU).iso" size 1459978240 crc 2de26446 md5 57ba9619faf904125e3bae8cf2f7950a sha1 81290c365052a85ce7f078c8419b6872029a838c )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (Australia) (En,Fr,De)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (Australia) (En,Fr,De)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (Australia) (En,Fr,De).iso" size 1459978240 crc 2de26446 md5 57ba9619faf904125e3bae8cf2f7950a sha1 81290c365052a85ce7f078c8419b6872029a838c )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (Europe) (En,Fr,De)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (Europe) (En,Fr,De)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (Europe) (En,Fr,De).iso" size 1459978240 crc 089b978d md5 b18019b6b399c9826bae843f06c43d08 sha1 d0c95b2cb3c6682a171db267932af7af8cf5fa82 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (Korea)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (Korea)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (Korea).iso" size 1459978240 crc 9724ccc4 md5 79b9e6e503e867c7d5cfb46a56d34034 sha1 f41c7e6d39c49172322dd6b93426feb348ee9659 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (EU)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (EU)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (EU).iso" size 1459978240 crc 089b978d md5 b18019b6b399c9826bae843f06c43d08 sha1 d0c95b2cb3c6682a171db267932af7af8cf5fa82 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (KR)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (KR)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (Limited Edition) (KR).iso" size 1459978240 crc 9724ccc4 md5 79b9e6e503e867c7d5cfb46a56d34034 sha1 f41c7e6d39c49172322dd6b93426feb348ee9659 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (US)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (US)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (US).iso" size 1459978240 crc c1719a28 md5 1e23afc69bff50a7d20f32c5b739dc06 sha1 e959019e5c0bd7a816f90c2f68a09a60892ecaa8 )
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time & Master Quest (USA)"
+	description "Legend of Zelda, The - Ocarina of Time & Master Quest (USA)"
+	rom ( name "Legend of Zelda, The - Ocarina of Time & Master Quest (USA).iso" size 1459978240 crc c1719a28 md5 1e23afc69bff50a7d20f32c5b739dc06 sha1 e959019e5c0bd7a816f90c2f68a09a60892ecaa8 )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (Europe) (En,Fr,De,Es,It)"
+	description "Legend of Zelda, The - The Wind Waker (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of Zelda, The - The Wind Waker (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 61fc5423 md5 9841cc876fb7be6c61ead51deeabf280 sha1 98f0a19d9a3b2ca3352621c77f47a547c97a27f1 )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (Korea)"
+	description "Legend of Zelda, The - The Wind Waker (Korea)"
+	rom ( name "Legend of Zelda, The - The Wind Waker (Korea).iso" size 1459978240 crc 79706bf2 md5 0037016b197dec26e4076db20e6aba4c sha1 5b8cf416a58c075a92812c800ce5d14e35ad9391 )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (KR) - jeldayi jeonseol baramyi taegteu"
+	description "Legend of Zelda, The - The Wind Waker (KR) - jeldayi jeonseol baramyi taegteu"
+	rom ( name "Legend of Zelda, The - The Wind Waker (KR).iso" size 1459978240 crc 79706bf2 md5 0037016b197dec26e4076db20e6aba4c sha1 5b8cf416a58c075a92812c800ce5d14e35ad9391 )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (Player's Choice) (EU)"
+	description "Legend of Zelda, The - The Wind Waker (Player's Choice) (EU)"
+	rom ( name "Legend of Zelda, The - The Wind Waker (Player's Choice) (EU).iso" size 1459978240 crc 61fc5423 md5 9841cc876fb7be6c61ead51deeabf280 sha1 98f0a19d9a3b2ca3352621c77f47a547c97a27f1 )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (US)"
+	description "Legend of Zelda, The - The Wind Waker (US)"
+	rom ( name "Legend of Zelda, The - The Wind Waker (US).iso" size 1459978240 crc ad21c2ba md5 d8e4d45af2032a081a0f446384e9261b sha1 6b5f06c10d50ebb4099cded88217eb71e5bfbb4a )
+)
+
+game (
+	name "Legend of Zelda, The - The Wind Waker (USA)"
+	description "Legend of Zelda, The - The Wind Waker (USA)"
+	rom ( name "Legend of Zelda, The - The Wind Waker (USA).iso" size 1459978240 crc ad21c2ba md5 d8e4d45af2032a081a0f446384e9261b sha1 6b5f06c10d50ebb4099cded88217eb71e5bfbb4a )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (EU)"
+	description "Legend of Zelda, The - Twilight Princess (EU)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (EU).iso" size 1459978240 crc 61fe14da md5 f9c47b0c8a34d345c06061f24e0db277 sha1 2601822a488eeb86fb89db16ca8f29c2c953e1ca )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It)"
+	description "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 61fe14da md5 f9c47b0c8a34d345c06061f24e0db277 sha1 2601822a488eeb86fb89db16ca8f29c2c953e1ca )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (US)"
+	description "Legend of Zelda, The - Twilight Princess (US)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (US).iso" size 1459978240 crc 0ab54d43 md5 41deff9b1fd2831f48fbfa2dd1054e4d sha1 75edd3ddff41f125d1b4ce1a40378f1b565519e7 )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (USA)"
+	description "Legend of Zelda, The - Twilight Princess (USA)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA).iso" size 1459978240 crc 0ab54d43 md5 41deff9b1fd2831f48fbfa2dd1054e4d sha1 75edd3ddff41f125d1b4ce1a40378f1b565519e7 )
+)
+
+game (
+	name "Legends of Wrestling (EU)"
+	description "Legends of Wrestling (EU)"
+	rom ( name "Legends of Wrestling (EU).iso" size 1459978240 crc d61d8252 md5 98ca97b113c2511c17c5f16a3918d940 sha1 95dd0a9baaa1ac0ecb66d53ceb09c9271c7c7ceb )
+)
+
+game (
+	name "Legends of Wrestling (Europe)"
+	description "Legends of Wrestling (Europe)"
+	rom ( name "Legends of Wrestling (Europe).iso" size 1459978240 crc d61d8252 md5 98ca97b113c2511c17c5f16a3918d940 sha1 95dd0a9baaa1ac0ecb66d53ceb09c9271c7c7ceb )
+)
+
+game (
+	name "Legends of Wrestling (US)"
+	description "Legends of Wrestling (US)"
+	rom ( name "Legends of Wrestling (US).iso" size 1459978240 crc a1e7b7f3 md5 b9d3b563834c2a67c57ece1739be0bf1 sha1 22b6200e2b603c6064a2b66668c759f7111da95e )
+)
+
+game (
+	name "Legends of Wrestling (USA)"
+	description "Legends of Wrestling (USA)"
+	rom ( name "Legends of Wrestling (USA).iso" size 1459978240 crc a1e7b7f3 md5 b9d3b563834c2a67c57ece1739be0bf1 sha1 22b6200e2b603c6064a2b66668c759f7111da95e )
+)
+
+game (
+	name "Legends of Wrestling 2 (US)"
+	description "Legends of Wrestling 2 (US)"
+	rom ( name "Legends of Wrestling 2 (US).iso" size 1459978240 crc c1f26489 md5 0da8e690157c2d2ff3770d1cb93cea89 sha1 4800f338d120e1ecd9cb48a2a295050ebcff887f )
+)
+
+game (
+	name "Legends of Wrestling II (EU)"
+	description "Legends of Wrestling II (EU)"
+	rom ( name "Legends of Wrestling II (EU).iso" size 1459978240 crc 99ca4717 md5 a6f6b91502712a0fbb96a67ea7d470c3 sha1 f5e1bb5a5415858052b8f3a5704bacec920b7b1d )
+)
+
+game (
+	name "Legends of Wrestling II (Europe)"
+	description "Legends of Wrestling II (Europe)"
+	rom ( name "Legends of Wrestling II (Europe).iso" size 1459978240 crc 99ca4717 md5 a6f6b91502712a0fbb96a67ea7d470c3 sha1 f5e1bb5a5415858052b8f3a5704bacec920b7b1d )
+)
+
+game (
+	name "Legends of Wrestling II (USA)"
+	description "Legends of Wrestling II (USA)"
+	rom ( name "Legends of Wrestling II (USA).iso" size 1459978240 crc c1f26489 md5 0da8e690157c2d2ff3770d1cb93cea89 sha1 4800f338d120e1ecd9cb48a2a295050ebcff887f )
+)
+
+game (
+	name "LEGO Star Wars - The Video Game (Europe)"
+	description "LEGO Star Wars - The Video Game (Europe)"
+	rom ( name "LEGO Star Wars - The Video Game (Europe).iso" size 1459978240 crc 0d2ca119 md5 a83cc0581cc51cdb5d90ec66aa8510b5 sha1 3098a117c8febab5b342a1c9f326089772ce601f )
+)
+
+game (
+	name "LEGO Star Wars - The Video Game (Europe) (Fr,De)"
+	description "LEGO Star Wars - The Video Game (Europe) (Fr,De)"
+	rom ( name "LEGO Star Wars - The Video Game (Europe) (Fr,De).iso" size 1459978240 crc d43d1d0e md5 e55770f10bb763d9a2ade3c46069a01c sha1 93c1dcf381ce1e3556c20598a5528f04651c7bc5 )
+)
+
+game (
+	name "LEGO Star Wars - The Video Game (GB)"
+	description "LEGO Star Wars - The Video Game (GB)"
+	rom ( name "LEGO Star Wars - The Video Game (GB).iso" size 1459978240 crc 0d2ca119 md5 a83cc0581cc51cdb5d90ec66aa8510b5 sha1 3098a117c8febab5b342a1c9f326089772ce601f )
+)
+
+game (
+	name "LEGO Star Wars - The Video Game (US)"
+	description "LEGO Star Wars - The Video Game (US)"
+	rom ( name "LEGO Star Wars - The Video Game (US).iso" size 1459978240 crc d43d1d0e md5 e55770f10bb763d9a2ade3c46069a01c sha1 93c1dcf381ce1e3556c20598a5528f04651c7bc5 )
+)
+
+game (
+	name "LEGO Star Wars - The Video Game (USA)"
+	description "LEGO Star Wars - The Video Game (USA)"
+	rom ( name "LEGO Star Wars - The Video Game (USA).iso" size 1459978240 crc 8416d40e md5 f7383a85d57345468d360cb68ebd4a88 sha1 28a61c8be3404941e734899d8faec38616207f7a )
+)
+
+game (
+	name "LEGO Star Wars II - The Original Trilogy (EU)"
+	description "LEGO Star Wars II - The Original Trilogy (EU)"
+	rom ( name "LEGO Star Wars II - The Original Trilogy (EU) - [v1.00].iso" size 1459978240 crc fe39cc58 md5 ccfec9c72124de261da72fd61d3aac19 sha1 229c1048dd45d547da7289a0ac9cd385fb69c196 )
+)
+
+game (
+	name "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.00)"
+	description "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.00)"
+	rom ( name "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.00).iso" size 1459978240 crc fe39cc58 md5 ccfec9c72124de261da72fd61d3aac19 sha1 229c1048dd45d547da7289a0ac9cd385fb69c196 )
+)
+
+game (
+	name "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.01)"
+	description "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.01)"
+	rom ( name "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Da) (v1.01).iso" size 1459978240 crc 8a5483e9 md5 8f1891665e48b9ab9f5a68d79f3827bc sha1 af3d7503bd78ef9c3eca7bbd835cc87dfa447e0e )
+)
+
+game (
+	name "LEGO Star Wars II - The Original Trilogy (US)"
+	description "LEGO Star Wars II - The Original Trilogy (US)"
+	rom ( name "LEGO Star Wars II - The Original Trilogy (US).iso" size 1459978240 crc cea162cd md5 12be79c1b0b1c16a8239cc428328b61d sha1 c05b3c23a9836f1b5ae48e113e6749f9a1588012 )
+)
+
+game (
+	name "LEGO Star Wars II - The Original Trilogy (USA)"
+	description "LEGO Star Wars II - The Original Trilogy (USA)"
+	rom ( name "LEGO Star Wars II - The Original Trilogy (USA).iso" size 1459978240 crc cea162cd md5 12be79c1b0b1c16a8239cc428328b61d sha1 c05b3c23a9836f1b5ae48e113e6749f9a1588012 )
+)
+
+game (
+	name "Lemony Snicket - Raetselhafte Ereignisse (DE)"
+	description "Lemony Snicket - Raetselhafte Ereignisse (DE)"
+	rom ( name "Lemony Snicket - Raetselhafte Ereignisse (DE).iso" size 1459978240 crc 63b66ff7 md5 a399b12d7a4aef65d67288371b51c9a6 sha1 16ef2429e89d679aabd7c9aadf0ee3a70ca94446 )
+)
+
+game (
+	name "Lemony Snicket - Raetselhafte Ereignisse (Germany)"
+	description "Lemony Snicket - Raetselhafte Ereignisse (Germany)"
+	rom ( name "Lemony Snicket - Raetselhafte Ereignisse (Germany).iso" size 1459978240 crc 63b66ff7 md5 a399b12d7a4aef65d67288371b51c9a6 sha1 16ef2429e89d679aabd7c9aadf0ee3a70ca94446 )
+)
+
+game (
+	name "Lemony Snicket's A Series of Unfortunate Events (Europe)"
+	description "Lemony Snicket's A Series of Unfortunate Events (Europe)"
+	rom ( name "Lemony Snicket's A Series of Unfortunate Events (Europe).iso" size 1459978240 crc 77d6ca5f md5 97ca33727b82a7f2282f724bce8f0848 sha1 4a76dc5f0b1d3c37dba3a50f6a123269e183d83a )
+)
+
+game (
+	name "Lemony Snicket's A Series of Unfortunate Events (GB)"
+	description "Lemony Snicket's A Series of Unfortunate Events (GB)"
+	rom ( name "Lemony Snicket's A Series of Unfortunate Events (GB).iso" size 1459978240 crc 77d6ca5f md5 97ca33727b82a7f2282f724bce8f0848 sha1 4a76dc5f0b1d3c37dba3a50f6a123269e183d83a )
+)
+
+game (
+	name "Lemony Snicket's A Series of Unfortunate Events (US)"
+	description "Lemony Snicket's A Series of Unfortunate Events (US)"
+	rom ( name "Lemony Snicket's A Series of Unfortunate Events (US).iso" size 1459978240 crc 7c5aee12 md5 d7e043a973530ab94342b7af5031b086 sha1 7001141c6a169f80d56f6f5650570ae2c1796872 )
+)
+
+game (
+	name "Lemony Snicket's A Series of Unfortunate Events (USA)"
+	description "Lemony Snicket's A Series of Unfortunate Events (USA)"
+	rom ( name "Lemony Snicket's A Series of Unfortunate Events (USA).iso" size 1459978240 crc 7c5aee12 md5 d7e043a973530ab94342b7af5031b086 sha1 7001141c6a169f80d56f6f5650570ae2c1796872 )
+)
+
+game (
+	name "Looney Tunes - Back in Action (EU)"
+	description "Looney Tunes - Back in Action (EU)"
+	rom ( name "Looney Tunes - Back in Action (EU).iso" size 1459978240 crc 127250f2 md5 6ef36eec5c3c81fef12fab7930a1ef79 sha1 9e1c49636e69b81b23e47e4ca71b0b4af16ade89 )
+)
+
+game (
+	name "Looney Tunes - Back in Action (Europe) (En,Fr,De,Es,It)"
+	description "Looney Tunes - Back in Action (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Looney Tunes - Back in Action (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 127250f2 md5 6ef36eec5c3c81fef12fab7930a1ef79 sha1 9e1c49636e69b81b23e47e4ca71b0b4af16ade89 )
+)
+
+game (
+	name "Looney Tunes - Back in Action (US)"
+	description "Looney Tunes - Back in Action (US)"
+	rom ( name "Looney Tunes - Back in Action (US).iso" size 1459978240 crc 5250ae52 md5 4a3f890fa3eca4bc8b6bec4cf20186f2 sha1 dbf4443aaba38d1d37fa8dcf7226e84e8f7139d5 )
+)
+
+game (
+	name "Looney Tunes - Back in Action (USA)"
+	description "Looney Tunes - Back in Action (USA)"
+	rom ( name "Looney Tunes - Back in Action (USA).iso" size 1459978240 crc 5250ae52 md5 4a3f890fa3eca4bc8b6bec4cf20186f2 sha1 dbf4443aaba38d1d37fa8dcf7226e84e8f7139d5 )
+)
+
+game (
+	name "Lord of the Rings - Futatsu no Tou (Japan)"
+	description "Lord of the Rings - Futatsu no Tou (Japan)"
+	rom ( name "Lord of the Rings - Futatsu no Tou (Japan).iso" size 1459978240 crc 5ca96026 md5 23234b6490e03fefc26b3477c0298f98 sha1 1378e02998c8c5c4187a704a876b86b0680c1f2c )
+)
+
+game (
+	name "Lord of the Rings - Futatsu no Tou (JP) - rodo+obuza+ringu+Er tunoTa"
+	description "Lord of the Rings - Futatsu no Tou (JP) - rodo+obuza+ringu+Er tunoTa"
+	rom ( name "Lord of the Rings - Futatsu no Tou (JP).iso" size 1459978240 crc 5ca96026 md5 23234b6490e03fefc26b3477c0298f98 sha1 1378e02998c8c5c4187a704a876b86b0680c1f2c )
+)
+
+game (
+	name "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 1)"
+	description "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 1)"
+	rom ( name "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 1).iso" size 1459978240 crc ec243c47 md5 fa1ba4dec1087e0dbe3222e2c1404752 sha1 db2e59a5089043962c70a693c6230207a8a3ec53 )
+)
+
+game (
+	name "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 2)"
+	description "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 2)"
+	rom ( name "Lord of the Rings - Nakatsu Kuni Daisanki (Japan) (Disc 2).iso" size 1459978240 crc 62cd531e md5 c1af519d772ff607ab76ecbde3e2bd72 sha1 2f4a82ab93371a5ae2446f88354ccd8b83fe1200 )
+)
+
+game (
+	name "Lord of the Rings - Nakatsu Kuni Daisanki (JP) - rodoobuzaringu+Zhong tuGuo Di San Ji"
+	description "Lord of the Rings - Nakatsu Kuni Daisanki (JP) - rodoobuzaringu+Zhong tuGuo Di San Ji"
+	rom ( name "Lord of the Rings - Nakatsu Kuni Daisanki (JP) - (Disc 1 of 2).iso" size 1459978240 crc ec243c47 md5 fa1ba4dec1087e0dbe3222e2c1404752 sha1 db2e59a5089043962c70a693c6230207a8a3ec53 )
+)
+
+game (
+	name "Lord of the Rings - Ou no Kikan (Japan)"
+	description "Lord of the Rings - Ou no Kikan (Japan)"
+	rom ( name "Lord of the Rings - Ou no Kikan (Japan).iso" size 1459978240 crc 084083c2 md5 9b404a35a87cb1b391d07e022be021d9 sha1 1202c1c2e7f49e8f429eb914d06cacb96a8c05bc )
+)
+
+game (
+	name "Lord of the Rings - Ou no Kikan (JP) - rodoobuzaringu+Wang noGui Huan"
+	description "Lord of the Rings - Ou no Kikan (JP) - rodoobuzaringu+Wang noGui Huan"
+	rom ( name "Lord of the Rings - Ou no Kikan (JP).iso" size 1459978240 crc 084083c2 md5 9b404a35a87cb1b391d07e022be021d9 sha1 1202c1c2e7f49e8f429eb914d06cacb96a8c05bc )
+)
+
+game (
+	name "Lord of the Rings, The - The Return of the King (EU)"
+	description "Lord of the Rings, The - The Return of the King (EU)"
+	rom ( name "Lord of the Rings, The - The Return of the King (EU).iso" size 1459978240 crc e44886ce md5 c5ace0a8144d2eb05fa50bdcc293040a sha1 65a1e265b6edeb5683d8ad77e4026fc61ec0e930 )
+)
+
+game (
+	name "Lord of the Rings, The - The Return of the King (Europe) (En,Nl,Sv)"
+	description "Lord of the Rings, The - The Return of the King (Europe) (En,Nl,Sv)"
+	rom ( name "Lord of the Rings, The - The Return of the King (Europe) (En,Nl,Sv).iso" size 1459978240 crc e44886ce md5 c5ace0a8144d2eb05fa50bdcc293040a sha1 65a1e265b6edeb5683d8ad77e4026fc61ec0e930 )
+)
+
+game (
+	name "Lord of the Rings, The - The Return of the King (US)"
+	description "Lord of the Rings, The - The Return of the King (US)"
+	rom ( name "Lord of the Rings, The - The Return of the King (US).iso" size 1459978240 crc 9caa554a md5 623e3d80bd885823573ae22b319f96e0 sha1 a5a3b252eec3759319f599b2c0687c0b76b2135f )
+)
+
+game (
+	name "Lord of the Rings, The - The Return of the King (USA)"
+	description "Lord of the Rings, The - The Return of the King (USA)"
+	rom ( name "Lord of the Rings, The - The Return of the King (USA).iso" size 1459978240 crc 9caa554a md5 623e3d80bd885823573ae22b319f96e0 sha1 a5a3b252eec3759319f599b2c0687c0b76b2135f )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (Europe) (Disc 1)"
+	description "Lord of the Rings, The - The Third Age (Europe) (Disc 1)"
+	rom ( name "Lord of the Rings, The - The Third Age (Europe) (Disc 1).iso" size 1459978240 crc d82e7757 md5 c7f407d6beacd2601c6594acf5235b69 sha1 3ba66823abcacc2354609f0dc2187c57e7165316 )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (Europe) (Disc 2)"
+	description "Lord of the Rings, The - The Third Age (Europe) (Disc 2)"
+	rom ( name "Lord of the Rings, The - The Third Age (Europe) (Disc 2).iso" size 1459978240 crc dd886d7c md5 889f65d01c6741d77f74b9e3ad4b887a sha1 a8982b590975e4276a714d78bb2b24f98284c2b1 )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (GB)"
+	description "Lord of the Rings, The - The Third Age (GB)"
+	rom ( name "Lord of the Rings, The - The Third Age (GB) - (Disc 1 of 2).iso" size 1459978240 crc d82e7757 md5 c7f407d6beacd2601c6594acf5235b69 sha1 3ba66823abcacc2354609f0dc2187c57e7165316 )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (US)"
+	description "Lord of the Rings, The - The Third Age (US)"
+	rom ( name "Lord of the Rings, The - The Third Age (US) - (Disc 1 of 2).iso" size 1459978240 crc d1f2b4b3 md5 87884ec09614bff4813f506470f97d06 sha1 9b029e9b480476b9b32098b094d8dd138c240772 )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (USA) (Disc 1)"
+	description "Lord of the Rings, The - The Third Age (USA) (Disc 1)"
+	rom ( name "Lord of the Rings, The - The Third Age (USA) (Disc 1).iso" size 1459978240 crc d1f2b4b3 md5 87884ec09614bff4813f506470f97d06 sha1 9b029e9b480476b9b32098b094d8dd138c240772 )
+)
+
+game (
+	name "Lord of the Rings, The - The Third Age (USA) (Disc 2)"
+	description "Lord of the Rings, The - The Third Age (USA) (Disc 2)"
+	rom ( name "Lord of the Rings, The - The Third Age (USA) (Disc 2).iso" size 1459978240 crc 5ebf714e md5 8cff44cd0bbaa022e58dbb991460f592 sha1 98e4ad747b62a7105baf998c260567ed68c4ffcc )
+)
+
+game (
+	name "Lord of the Rings, The - The Two Towers (EU)"
+	description "Lord of the Rings, The - The Two Towers (EU)"
+	rom ( name "Lord of the Rings, The - The Two Towers (EU).iso" size 1459978240 crc 221f5b1b md5 bc12ace28720323a9b9c7b3a85347c82 sha1 1e5ca6d8186d5f7d13d7f9e8c3438c7c47adbc5d )
+)
+
+game (
+	name "Lord of the Rings, The - The Two Towers (Europe) (En,Nl)"
+	description "Lord of the Rings, The - The Two Towers (Europe) (En,Nl)"
+	rom ( name "Lord of the Rings, The - The Two Towers (Europe) (En,Nl).iso" size 1459978240 crc 221f5b1b md5 bc12ace28720323a9b9c7b3a85347c82 sha1 1e5ca6d8186d5f7d13d7f9e8c3438c7c47adbc5d )
+)
+
+game (
+	name "Lord of the Rings, The - The Two Towers (US)"
+	description "Lord of the Rings, The - The Two Towers (US)"
+	rom ( name "Lord of the Rings, The - The Two Towers (US).iso" size 1459978240 crc b47e9571 md5 5a5a0b7e7b082701a20b2f0f2472397e sha1 952ac69493470329b52c724f025b1f0db2f99470 )
+)
+
+game (
+	name "Lord of the Rings, The - The Two Towers (USA)"
+	description "Lord of the Rings, The - The Two Towers (USA)"
+	rom ( name "Lord of the Rings, The - The Two Towers (USA).iso" size 1459978240 crc b47e9571 md5 5a5a0b7e7b082701a20b2f0f2472397e sha1 952ac69493470329b52c724f025b1f0db2f99470 )
+)
+
+game (
+	name "Lost Kingdoms (EU)"
+	description "Lost Kingdoms (EU)"
+	rom ( name "Lost Kingdoms (EU).iso" size 1459978240 crc 258c7e46 md5 f7810ef152f3287ea9874235b973c223 sha1 b9f1c3f2a17509e33b897f2cb54e57acbd53df6b )
+)
+
+game (
+	name "Lost Kingdoms (Europe) (En,Fr)"
+	description "Lost Kingdoms (Europe) (En,Fr)"
+	rom ( name "Lost Kingdoms (Europe) (En,Fr).iso" size 1459978240 crc 258c7e46 md5 f7810ef152f3287ea9874235b973c223 sha1 b9f1c3f2a17509e33b897f2cb54e57acbd53df6b )
+)
+
+game (
+	name "Lost Kingdoms (US)"
+	description "Lost Kingdoms (US)"
+	rom ( name "Lost Kingdoms (US).iso" size 1459978240 crc ce6b2479 md5 181d5c18f4325d22148098759ca21b28 sha1 3f300d00816192c2cf25e81bde79efbf320145d8 )
+)
+
+game (
+	name "Lost Kingdoms (USA)"
+	description "Lost Kingdoms (USA)"
+	rom ( name "Lost Kingdoms (USA).iso" size 1459978240 crc ce6b2479 md5 181d5c18f4325d22148098759ca21b28 sha1 3f300d00816192c2cf25e81bde79efbf320145d8 )
+)
+
+game (
+	name "Lost Kingdoms II (EU)"
+	description "Lost Kingdoms II (EU)"
+	rom ( name "Lost Kingdoms II (EU).iso" size 1459978240 crc 5487d388 md5 d52720780d9f895a217d810a956d2b1b sha1 722e8de2d882308fb170718f193ae0fc03857a89 )
+)
+
+game (
+	name "Lost Kingdoms II (Europe) (En,Fr,De)"
+	description "Lost Kingdoms II (Europe) (En,Fr,De)"
+	rom ( name "Lost Kingdoms II (Europe) (En,Fr,De).iso" size 1459978240 crc 5487d388 md5 d52720780d9f895a217d810a956d2b1b sha1 722e8de2d882308fb170718f193ae0fc03857a89 )
+)
+
+game (
+	name "Lost Kingdoms II (US)"
+	description "Lost Kingdoms II (US)"
+	rom ( name "Lost Kingdoms II (US).iso" size 1459978240 crc 116d9c73 md5 37d3f930fd53334040f4dfcce94970c8 sha1 83eaa46670081b0782dd3920ef2c8c4f3c5a859d )
+)
+
+game (
+	name "Lost Kingdoms II (USA)"
+	description "Lost Kingdoms II (USA)"
+	rom ( name "Lost Kingdoms II (USA).iso" size 1459978240 crc 116d9c73 md5 37d3f930fd53334040f4dfcce94970c8 sha1 83eaa46670081b0782dd3920ef2c8c4f3c5a859d )
+)
+
+game (
+	name "Lotus Challenge (US)"
+	description "Lotus Challenge (US)"
+	rom ( name "Lotus Challenge (US).iso" size 1459978240 crc 0b125f9d md5 9a70b464d669e403ea279dd47c740383 sha1 645f80d205485df7e433d051436856f39770fb13 )
+)
+
+game (
+	name "Lotus Challenge (USA)"
+	description "Lotus Challenge (USA)"
+	rom ( name "Lotus Challenge (USA).iso" size 1459978240 crc 0b125f9d md5 9a70b464d669e403ea279dd47c740383 sha1 645f80d205485df7e433d051436856f39770fb13 )
+)
+
+game (
+	name "Luigi's Mansion (EU)"
+	description "Luigi's Mansion (EU)"
+	rom ( name "Luigi's Mansion (EU) - [v1.00].iso" size 1459978240 crc c1022f24 md5 ee1ddbe62f96b09b2394772a2900d82f sha1 93805bf1f56983b5cf973e61208e431320f42df7 )
+)
+
+game (
+	name "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 1459978240 crc c1022f24 md5 ee1ddbe62f96b09b2394772a2900d82f sha1 93805bf1f56983b5cf973e61208e431320f42df7 )
+)
+
+game (
+	name "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Luigi's Mansion (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 1459978240 crc 9a75e03a md5 109274d9078b5aecf3bfa9af1d10688c sha1 3f742bf1db42bd3b24ec50bc66320f762b043752 )
+)
+
+game (
+	name "Luigi's Mansion (Japan)"
+	description "Luigi's Mansion (Japan)"
+	rom ( name "Luigi's Mansion (Japan).iso" size 1459978240 crc a98be430 md5 83839f063e42f04147157382dcb019b2 sha1 3441c0580dce21bdf58443230f5bffac6bb05632 )
+)
+
+game (
+	name "Luigi's Mansion (JP) - ruizimansiyon"
+	description "Luigi's Mansion (JP) - ruizimansiyon"
+	rom ( name "Luigi's Mansion (JP).iso" size 1459978240 crc a98be430 md5 83839f063e42f04147157382dcb019b2 sha1 3441c0580dce21bdf58443230f5bffac6bb05632 )
+)
+
+game (
+	name "Luigi's Mansion (Player's Choice) (EU)"
+	description "Luigi's Mansion (Player's Choice) (EU)"
+	rom ( name "Luigi's Mansion (Player's Choice) (EU) - [v1.01] [Players].iso" size 1459978240 crc 9a75e03a md5 109274d9078b5aecf3bfa9af1d10688c sha1 3f742bf1db42bd3b24ec50bc66320f762b043752 )
+)
+
+game (
+	name "Luigi's Mansion (US)"
+	description "Luigi's Mansion (US)"
+	rom ( name "Luigi's Mansion (US).iso" size 1459978240 crc 0b0c339d md5 6e3d9ae0ed2fbd2f77fa1ca09a60c494 sha1 96a7d2e6b6e0a355f6e57ef76bd37f6ee837ed25 )
+)
+
+game (
+	name "Luigi's Mansion (USA)"
+	description "Luigi's Mansion (USA)"
+	rom ( name "Luigi's Mansion (USA).iso" size 1459978240 crc 0b0c339d md5 6e3d9ae0ed2fbd2f77fa1ca09a60c494 sha1 96a7d2e6b6e0a355f6e57ef76bd37f6ee837ed25 )
+)
+
+game (
+	name "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 1)"
+	description "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 1)"
+	rom ( name "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 1).iso" size 1459978240 crc 172c7836 md5 2f83d6bb9422c8d6a1d84eb08614b014 sha1 7097c62bb0dad853eedd17fab86e333937fc207d )
+)
+
+game (
+	name "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 2)"
+	description "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 2)"
+	rom ( name "Lupin III - Umi ni Kieta Hihou (Japan) (Disc 2).iso" size 1459978240 crc 83c059eb md5 17aac00dfda4d9ed47d2e5e2ba77b4ff sha1 a99fde5437736922df221a4f709d4564163b6002 )
+)
+
+game (
+	name "Lupin III - Umi ni Kieta Hihou (JP) - rupanSan Shi +Hai niXiao etaMi Bao"
+	description "Lupin III - Umi ni Kieta Hihou (JP) - rupanSan Shi +Hai niXiao etaMi Bao"
+	rom ( name "Lupin III - Umi ni Kieta Hihou (JP) - (Disc 1 of 2).iso" size 1459978240 crc 172c7836 md5 2f83d6bb9422c8d6a1d84eb08614b014 sha1 7097c62bb0dad853eedd17fab86e333937fc207d )
+)
+
+game (
+	name "Madden NFL 06 (Europe)"
+	description "Madden NFL 06 (Europe)"
+	rom ( name "Madden NFL 06 (Europe).iso" size 1459978240 crc 4bdf0add md5 af2ef9cfca13ec9371ed1df03d3d5ef9 sha1 a57e33834ba940ad1570bd37a4aca40f52b5cd62 )
+)
+
+game (
+	name "Madden NFL 06 (GB)"
+	description "Madden NFL 06 (GB)"
+	rom ( name "Madden NFL 06 (GB).iso" size 1459978240 crc 4bdf0add md5 af2ef9cfca13ec9371ed1df03d3d5ef9 sha1 a57e33834ba940ad1570bd37a4aca40f52b5cd62 )
+)
+
+game (
+	name "Madden NFL 06 (US)"
+	description "Madden NFL 06 (US)"
+	rom ( name "Madden NFL 06 (US).iso" size 1459978240 crc 202067fd md5 5e1ded0c91abcdf70a43e3bfd1774997 sha1 0d43b51443081ca9a4c5a074521d5a22a1a96fbc )
+)
+
+game (
+	name "Madden NFL 06 (USA)"
+	description "Madden NFL 06 (USA)"
+	rom ( name "Madden NFL 06 (USA).iso" size 1459978240 crc 202067fd md5 5e1ded0c91abcdf70a43e3bfd1774997 sha1 0d43b51443081ca9a4c5a074521d5a22a1a96fbc )
+)
+
+game (
+	name "Madden NFL 07 (US)"
+	description "Madden NFL 07 (US)"
+	rom ( name "Madden NFL 07 (US).iso" size 1459978240 crc 43560925 md5 6a0422b8a999b93e2b207eeeca2128d4 sha1 8d7f6c7504c3d305fca696e1d505d0a4d3adbd6a )
+)
+
+game (
+	name "Madden NFL 07 (USA)"
+	description "Madden NFL 07 (USA)"
+	rom ( name "Madden NFL 07 (USA).iso" size 1459978240 crc 43560925 md5 6a0422b8a999b93e2b207eeeca2128d4 sha1 8d7f6c7504c3d305fca696e1d505d0a4d3adbd6a )
+)
+
+game (
+	name "Madden NFL 08 (US)"
+	description "Madden NFL 08 (US)"
+	rom ( name "Madden NFL 08 (US).iso" size 1459978240 crc af33d165 md5 69f6a02af4a8f8047008eaabef212fc7 sha1 541e84858b71ebd1241494ee4b67d25a4ce9af8e )
+)
+
+game (
+	name "Madden NFL 08 (USA)"
+	description "Madden NFL 08 (USA)"
+	rom ( name "Madden NFL 08 (USA).iso" size 1459978240 crc af33d165 md5 69f6a02af4a8f8047008eaabef212fc7 sha1 541e84858b71ebd1241494ee4b67d25a4ce9af8e )
+)
+
+game (
+	name "Madden NFL 2002 (US)"
+	description "Madden NFL 2002 (US)"
+	rom ( name "Madden NFL 2002 (US).iso" size 1459978240 crc 8f2ae860 md5 6138333c4ff6829e7c01c7a4c0598c86 sha1 8e666fd73fe2539808024396e6fa1605a134da0b )
+)
+
+game (
+	name "Madden NFL 2002 (USA)"
+	description "Madden NFL 2002 (USA)"
+	rom ( name "Madden NFL 2002 (USA).iso" size 1459978240 crc 8f2ae860 md5 6138333c4ff6829e7c01c7a4c0598c86 sha1 8e666fd73fe2539808024396e6fa1605a134da0b )
+)
+
+game (
+	name "Madden NFL 2003 (EU)"
+	description "Madden NFL 2003 (EU)"
+	rom ( name "Madden NFL 2003 (EU).iso" size 1459978240 crc 3ad4fbcd md5 f02fa9a87edbd9bacb6713d64b367987 sha1 b3c920f3fabd5c27f163d40be92a72ac7137b2bd )
+)
+
+game (
+	name "Madden NFL 2003 (Europe)"
+	description "Madden NFL 2003 (Europe)"
+	rom ( name "Madden NFL 2003 (Europe).iso" size 1459978240 crc 3ad4fbcd md5 f02fa9a87edbd9bacb6713d64b367987 sha1 b3c920f3fabd5c27f163d40be92a72ac7137b2bd )
+)
+
+game (
+	name "Madden NFL 2003 (US)"
+	description "Madden NFL 2003 (US)"
+	rom ( name "Madden NFL 2003 (US).iso" size 1459978240 crc a1719769 md5 c98f878f98d66f9e530581aec966551d sha1 e63c0fdc66d0dac341327ac7abe5f4bce788dc5d )
+)
+
+game (
+	name "Madden NFL 2003 (USA)"
+	description "Madden NFL 2003 (USA)"
+	rom ( name "Madden NFL 2003 (USA).iso" size 1459978240 crc a1719769 md5 c98f878f98d66f9e530581aec966551d sha1 e63c0fdc66d0dac341327ac7abe5f4bce788dc5d )
+)
+
+game (
+	name "Madden NFL 2004 (EU)"
+	description "Madden NFL 2004 (EU)"
+	rom ( name "Madden NFL 2004 (EU).iso" size 1459978240 crc 461fc5f9 md5 24a2f2a260bd8d92480bd47cba1cee7d sha1 2f26e4c464782495a50c4693f4ec2d776d2c273c )
+)
+
+game (
+	name "Madden NFL 2004 (Europe)"
+	description "Madden NFL 2004 (Europe)"
+	rom ( name "Madden NFL 2004 (Europe).iso" size 1459978240 crc 461fc5f9 md5 24a2f2a260bd8d92480bd47cba1cee7d sha1 2f26e4c464782495a50c4693f4ec2d776d2c273c )
+)
+
+game (
+	name "Madden NFL 2004 (US)"
+	description "Madden NFL 2004 (US)"
+	rom ( name "Madden NFL 2004 (US) - [v1.00].iso" size 1459978240 crc fd972f12 md5 5b5faea1ebd1f196210b9267c2c717c4 sha1 001c5d485a0120c2aff0aabbd4d555c36bbdc9c3 )
+)
+
+game (
+	name "Madden NFL 2004 (USA) (v1.00)"
+	description "Madden NFL 2004 (USA) (v1.00)"
+	rom ( name "Madden NFL 2004 (USA) (v1.00).iso" size 1459978240 crc fd972f12 md5 5b5faea1ebd1f196210b9267c2c717c4 sha1 001c5d485a0120c2aff0aabbd4d555c36bbdc9c3 )
+)
+
+game (
+	name "Madden NFL 2004 (USA) (v1.01)"
+	description "Madden NFL 2004 (USA) (v1.01)"
+	rom ( name "Madden NFL 2004 (USA) (v1.01).iso" size 1459978240 crc ecef8d57 md5 131fb5a29defecf04511d68ffa1d0894 sha1 d79b3c739dea683cab4031c7d48c73c3014c6aba )
+)
+
+game (
+	name "Madden NFL 2005 (EU)"
+	description "Madden NFL 2005 (EU)"
+	rom ( name "Madden NFL 2005 (EU).iso" size 1459978240 crc 328e3a00 md5 7051eb43a4496c32ec490fd38a6a2dac sha1 a00cb53c6be00a446f99c2b754543136dd7d2eed )
+)
+
+game (
+	name "Madden NFL 2005 (Europe)"
+	description "Madden NFL 2005 (Europe)"
+	rom ( name "Madden NFL 2005 (Europe).iso" size 1459978240 crc 328e3a00 md5 7051eb43a4496c32ec490fd38a6a2dac sha1 a00cb53c6be00a446f99c2b754543136dd7d2eed )
+)
+
+game (
+	name "Madden NFL 2005 (US)"
+	description "Madden NFL 2005 (US)"
+	rom ( name "Madden NFL 2005 (US).iso" size 1459978240 crc 6c027878 md5 7e5d91ca3bf751d53bd7718b7c278f9b sha1 9f30b6116ce76fb2d4da5b56f5798dbd38f60748 )
+)
+
+game (
+	name "Madden NFL 2005 (USA)"
+	description "Madden NFL 2005 (USA)"
+	rom ( name "Madden NFL 2005 (USA).iso" size 1459978240 crc 6c027878 md5 7e5d91ca3bf751d53bd7718b7c278f9b sha1 9f30b6116ce76fb2d4da5b56f5798dbd38f60748 )
+)
+
+game (
+	name "Mahou no Pumpkin - An to Greg no Daibouken (Japan)"
+	description "Mahou no Pumpkin - An to Greg no Daibouken (Japan)"
+	rom ( name "Mahou no Pumpkin - An to Greg no Daibouken (Japan).iso" size 1459978240 crc 5e7c586a md5 50e84a8ae017eada404f2edda28224e1 sha1 f40a8e3efb9df6a1937ad79cb373b11f69f22adc )
+)
+
+game (
+	name "Mahou no Pumpkin - An to Greg no Daibouken (JP) - Mo Fa nopanpukin+~antoguretugunoDa Mou Xian ~"
+	description "Mahou no Pumpkin - An to Greg no Daibouken (JP) - Mo Fa nopanpukin+~antoguretugunoDa Mou Xian ~"
+	rom ( name "Mahou no Pumpkin - An to Greg no Daibouken (JP).iso" size 1459978240 crc 5e7c586a md5 50e84a8ae017eada404f2edda28224e1 sha1 f40a8e3efb9df6a1937ad79cb373b11f69f22adc )
+)
+
+game (
+	name "Major League Baseball 2K6 (US)"
+	description "Major League Baseball 2K6 (US)"
+	rom ( name "Major League Baseball 2K6 (US).iso" size 1459978240 crc 412b04d1 md5 f52a1e2167d3d854a9f05c1df6257f1c sha1 109b0bed805512e92af743c2c6bfe95f9fa03fdc )
+)
+
+game (
+	name "Major League Baseball 2K6 (USA)"
+	description "Major League Baseball 2K6 (USA)"
+	rom ( name "Major League Baseball 2K6 (USA).iso" size 1459978240 crc 412b04d1 md5 f52a1e2167d3d854a9f05c1df6257f1c sha1 109b0bed805512e92af743c2c6bfe95f9fa03fdc )
+)
+
+game (
+	name "Mario Golf - Family Tour (Japan)"
+	description "Mario Golf - Family Tour (Japan)"
+	rom ( name "Mario Golf - Family Tour (Japan).iso" size 1459978240 crc d23eae99 md5 262e3f6c8d1255871c5a02034fdea82d sha1 0cee5d025395dee0c1ff0a0629a91e40604cecb2 )
+)
+
+game (
+	name "Mario Golf - Family Tour (JP) - mariogoruhu+huamiritua"
+	description "Mario Golf - Family Tour (JP) - mariogoruhu+huamiritua"
+	rom ( name "Mario Golf - Family Tour (JP).iso" size 1459978240 crc d23eae99 md5 262e3f6c8d1255871c5a02034fdea82d sha1 0cee5d025395dee0c1ff0a0629a91e40604cecb2 )
+)
+
+game (
+	name "Mario Golf - Toadstool Tour (EU)"
+	description "Mario Golf - Toadstool Tour (EU)"
+	rom ( name "Mario Golf - Toadstool Tour (EU).iso" size 1459978240 crc 126a6db1 md5 a7506d6a7e7cfbda7ee81c0482c4834b sha1 1ccdbc6c4f3f62e6c36de3e042126b4a234d6bcf )
+)
+
+game (
+	name "Mario Golf - Toadstool Tour (Europe) (En,Fr,De,Es,It)"
+	description "Mario Golf - Toadstool Tour (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Golf - Toadstool Tour (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 126a6db1 md5 a7506d6a7e7cfbda7ee81c0482c4834b sha1 1ccdbc6c4f3f62e6c36de3e042126b4a234d6bcf )
+)
+
+game (
+	name "Mario Golf - Toadstool Tour (US)"
+	description "Mario Golf - Toadstool Tour (US)"
+	rom ( name "Mario Golf - Toadstool Tour (US).iso" size 1459978240 crc 38a86294 md5 5fd9909e73df7fb704d2e443e17346b5 sha1 7e7118fa9dbe6fbbe37b2a64626aefbf1b2c4426 )
+)
+
+game (
+	name "Mario Golf - Toadstool Tour (USA)"
+	description "Mario Golf - Toadstool Tour (USA)"
+	rom ( name "Mario Golf - Toadstool Tour (USA).iso" size 1459978240 crc 38a86294 md5 5fd9909e73df7fb704d2e443e17346b5 sha1 7e7118fa9dbe6fbbe37b2a64626aefbf1b2c4426 )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (EU)"
+	description "Mario Kart - Double Dash!! (EU)"
+	rom ( name "Mario Kart - Double Dash!! (EU).iso" size 1459978240 crc a211edb6 md5 d9a2e9c73f4be1a0456734445402d35d sha1 7beacb902785df2a2752c0bf0a805a246241696b )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (Europe) (En,Fr,De,Es,It)"
+	description "Mario Kart - Double Dash!! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Kart - Double Dash!! (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a211edb6 md5 d9a2e9c73f4be1a0456734445402d35d sha1 7beacb902785df2a2752c0bf0a805a246241696b )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (Japan)"
+	description "Mario Kart - Double Dash!! (Japan)"
+	rom ( name "Mario Kart - Double Dash!! (Japan).iso" size 1459978240 crc b87f0038 md5 7bb506ab9f88fa124ed308c727e494d6 sha1 97fd0c4708fa36ce2b4ea7417397e1e305f95476 )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (JP) - mariokato+daburudatusiyu!!"
+	description "Mario Kart - Double Dash!! (JP) - mariokato+daburudatusiyu!!"
+	rom ( name "Mario Kart - Double Dash!! (JP).iso" size 1459978240 crc b87f0038 md5 7bb506ab9f88fa124ed308c727e494d6 sha1 97fd0c4708fa36ce2b4ea7417397e1e305f95476 )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (US)"
+	description "Mario Kart - Double Dash!! (US)"
+	rom ( name "Mario Kart - Double Dash!! (US) - (Disc 1 of 2).iso" size 1459978240 crc 099e2c6d md5 97f9ebc39ab4244e419848793988561a sha1 34bdef709a1ae9799fdabe8e54cff1c7d3665f2b )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (USA)"
+	description "Mario Kart - Double Dash!! (USA)"
+	rom ( name "Mario Kart - Double Dash!! (USA).iso" size 1459978240 crc 099e2c6d md5 97f9ebc39ab4244e419848793988561a sha1 34bdef709a1ae9799fdabe8e54cff1c7d3665f2b )
+)
+
+game (
+	name "Mario Kart - Double Dash!! (USA) (Bonus Disc)"
+	description "Mario Kart - Double Dash!! (USA) (Bonus Disc)"
+	rom ( name "Mario Kart - Double Dash!! (USA) (Bonus Disc).iso" size 1459978240 crc 7c7068a9 md5 2d4b9f26fc33de2d4d4fff5232e4e592 sha1 2ce40058a13c89964988851a1a0174e711d1f0b6 )
+)
+
+game (
+	name "Mario Party 4 (EU)"
+	description "Mario Party 4 (EU)"
+	rom ( name "Mario Party 4 (EU) - [v1.00].iso" size 1459978240 crc bdd1556f md5 5dc6f6949f09da56fd0313cbdb85fca5 sha1 43969c1ad08c0c1769bb358ed9bfd33d25dee27d )
+)
+
+game (
+	name "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 1459978240 crc bdd1556f md5 5dc6f6949f09da56fd0313cbdb85fca5 sha1 43969c1ad08c0c1769bb358ed9bfd33d25dee27d )
+)
+
+game (
+	name "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.02)"
+	description "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.02)"
+	rom ( name "Mario Party 4 (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 1459978240 crc fad57787 md5 f6740fc00d9818ad1f161889382c7902 sha1 4fb35b168f93094d813c6e4ad27058605cc06b2e )
+)
+
+game (
+	name "Mario Party 4 (Japan)"
+	description "Mario Party 4 (Japan)"
+	rom ( name "Mario Party 4 (Japan).iso" size 1459978240 crc 2bf0295a md5 1cacd8b53f6fd030c78e716834c049c3 sha1 00a6ab6f61ef8a721bc88a493129d7c29ac7add2 )
+)
+
+game (
+	name "Mario Party 4 (JP) - mariopatei4"
+	description "Mario Party 4 (JP) - mariopatei4"
+	rom ( name "Mario Party 4 (JP).iso" size 1459978240 crc 2bf0295a md5 1cacd8b53f6fd030c78e716834c049c3 sha1 00a6ab6f61ef8a721bc88a493129d7c29ac7add2 )
+)
+
+game (
+	name "Mario Party 4 (Player's Choice) (EU)"
+	description "Mario Party 4 (Player's Choice) (EU)"
+	rom ( name "Mario Party 4 (Player's Choice) (EU) - [v1.02] [Players].iso" size 1459978240 crc fad57787 md5 f6740fc00d9818ad1f161889382c7902 sha1 4fb35b168f93094d813c6e4ad27058605cc06b2e )
+)
+
+game (
+	name "Mario Party 4 (US)"
+	description "Mario Party 4 (US)"
+	rom ( name "Mario Party 4 (US) - [v1.00].iso" size 1459978240 crc 150a4c40 md5 6eda0e31dcf1622ef749c5ce8f1196a3 sha1 a13a7c6bc47466be7c055dc42a26998f17ef57e7 )
+)
+
+game (
+	name "Mario Party 4 (USA) (v1.00)"
+	description "Mario Party 4 (USA) (v1.00)"
+	rom ( name "Mario Party 4 (USA) (v1.00).iso" size 1459978240 crc 150a4c40 md5 6eda0e31dcf1622ef749c5ce8f1196a3 sha1 a13a7c6bc47466be7c055dc42a26998f17ef57e7 )
+)
+
+game (
+	name "Mario Party 4 (USA) (v1.01)"
+	description "Mario Party 4 (USA) (v1.01)"
+	rom ( name "Mario Party 4 (USA) (v1.01).iso" size 1459978240 crc 06ae54f0 md5 01de13ad52f1554975e7f316370ba086 sha1 f4b287e3d1a9b05ea6cb5e573414f768370e1ed8 )
+)
+
+game (
+	name "Mario Party 5 (EU)"
+	description "Mario Party 5 (EU)"
+	rom ( name "Mario Party 5 (EU).iso" size 1459978240 crc afc58f78 md5 661634c2817e65cfa257796e3fb5f7c2 sha1 705d833bc2ee1200dc5f426b3c1e36b4264e90e2 )
+)
+
+game (
+	name "Mario Party 5 (Europe) (En,Fr,De,Es,It)"
+	description "Mario Party 5 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Party 5 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc afc58f78 md5 661634c2817e65cfa257796e3fb5f7c2 sha1 705d833bc2ee1200dc5f426b3c1e36b4264e90e2 )
+)
+
+game (
+	name "Mario Party 5 (Japan)"
+	description "Mario Party 5 (Japan)"
+	rom ( name "Mario Party 5 (Japan).iso" size 1459978240 crc 2f14b6ee md5 556bea088a1072502121bfe6d883ad0c sha1 933dc62c964212e7e40c630a522f1267d60753cf )
+)
+
+game (
+	name "Mario Party 5 (JP) - mariopatei5"
+	description "Mario Party 5 (JP) - mariopatei5"
+	rom ( name "Mario Party 5 (JP).iso" size 1459978240 crc 2f14b6ee md5 556bea088a1072502121bfe6d883ad0c sha1 933dc62c964212e7e40c630a522f1267d60753cf )
+)
+
+game (
+	name "Mario Party 5 (US)"
+	description "Mario Party 5 (US)"
+	rom ( name "Mario Party 5 (US).iso" size 1459978240 crc 099bb35a md5 6b3699ee1f18447c4b2fabb3dd2ebf39 sha1 e9a46143f6910241996a61f8e590d334e4fab336 )
+)
+
+game (
+	name "Mario Party 5 (USA)"
+	description "Mario Party 5 (USA)"
+	rom ( name "Mario Party 5 (USA).iso" size 1459978240 crc 099bb35a md5 6b3699ee1f18447c4b2fabb3dd2ebf39 sha1 e9a46143f6910241996a61f8e590d334e4fab336 )
+)
+
+game (
+	name "Mario Party 6 (EU)"
+	description "Mario Party 6 (EU)"
+	rom ( name "Mario Party 6 (EU).iso" size 1459978240 crc e1dda2c9 md5 e4015f1a9f6259528773e5235c8bec63 sha1 41c98106eb7b5e0f60854a46d75319f3203086bd )
+)
+
+game (
+	name "Mario Party 6 (Europe) (En,Fr,De,Es,It)"
+	description "Mario Party 6 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Party 6 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e1dda2c9 md5 e4015f1a9f6259528773e5235c8bec63 sha1 41c98106eb7b5e0f60854a46d75319f3203086bd )
+)
+
+game (
+	name "Mario Party 6 (Japan)"
+	description "Mario Party 6 (Japan)"
+	rom ( name "Mario Party 6 (Japan).iso" size 1459978240 crc 0fadba1e md5 5faebc5e4ecd1813a51ca1c843615b45 sha1 a4f2af3e1b874e570902c8ea555b0cdfdd30e1be )
+)
+
+game (
+	name "Mario Party 6 (JP) - mariopatei6"
+	description "Mario Party 6 (JP) - mariopatei6"
+	rom ( name "Mario Party 6 (JP).iso" size 1459978240 crc 0fadba1e md5 5faebc5e4ecd1813a51ca1c843615b45 sha1 a4f2af3e1b874e570902c8ea555b0cdfdd30e1be )
+)
+
+game (
+	name "Mario Party 6 (US)"
+	description "Mario Party 6 (US)"
+	rom ( name "Mario Party 6 (US).iso" size 1459978240 crc abc622ec md5 010dece78287bcb8cafdeb15f035127a sha1 be55ece288c9cd63c7087a961c22394cd4da7646 )
+)
+
+game (
+	name "Mario Party 6 (USA)"
+	description "Mario Party 6 (USA)"
+	rom ( name "Mario Party 6 (USA).iso" size 1459978240 crc abc622ec md5 010dece78287bcb8cafdeb15f035127a sha1 be55ece288c9cd63c7087a961c22394cd4da7646 )
+)
+
+game (
+	name "Mario Party 7 (EU)"
+	description "Mario Party 7 (EU)"
+	rom ( name "Mario Party 7 (EU).iso" size 1459978240 crc a543adbc md5 b82a9ddaf4265c53062cb8cda7129312 sha1 165b185e846a118caa45d6ee8a0dfdaf9c7234b7 )
+)
+
+game (
+	name "Mario Party 7 (Europe) (En,Fr,De,Es,It)"
+	description "Mario Party 7 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Party 7 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a543adbc md5 b82a9ddaf4265c53062cb8cda7129312 sha1 165b185e846a118caa45d6ee8a0dfdaf9c7234b7 )
+)
+
+game (
+	name "Mario Party 7 (Japan)"
+	description "Mario Party 7 (Japan)"
+	rom ( name "Mario Party 7 (Japan).iso" size 1459978240 crc 78c91bb8 md5 ee9f181b20a8c1f79d70b109d4372367 sha1 7b92e85a9d643970a7bde46224f9fd2c813d4094 )
+)
+
+game (
+	name "Mario Party 7 (JP) - mariopatei7"
+	description "Mario Party 7 (JP) - mariopatei7"
+	rom ( name "Mario Party 7 (JP).iso" size 1459978240 crc 78c91bb8 md5 ee9f181b20a8c1f79d70b109d4372367 sha1 7b92e85a9d643970a7bde46224f9fd2c813d4094 )
+)
+
+game (
+	name "Mario Party 7 (US)"
+	description "Mario Party 7 (US)"
+	rom ( name "Mario Party 7 (US).iso" size 1459978240 crc 8582361b md5 bd367c67fca5d93e581a43d1f61f4514 sha1 8fc22158c0af3aea521e81893012e8718eff1dab )
+)
+
+game (
+	name "Mario Party 7 (USA)"
+	description "Mario Party 7 (USA)"
+	rom ( name "Mario Party 7 (USA).iso" size 1459978240 crc 8582361b md5 bd367c67fca5d93e581a43d1f61f4514 sha1 8fc22158c0af3aea521e81893012e8718eff1dab )
+)
+
+game (
+	name "Mario Power Tennis (Best Seller) (US)"
+	description "Mario Power Tennis (Best Seller) (US)"
+	rom ( name "Mario Power Tennis (Best Seller) (US) - [v1.01] [Bestseller].iso" size 1459978240 crc ef719371 md5 286c7fae43220b6bb45c169185d36ad3 sha1 511df0d4f09cc504574f97060b938cbcab16eb33 )
+)
+
+game (
+	name "Mario Power Tennis (EU)"
+	description "Mario Power Tennis (EU)"
+	rom ( name "Mario Power Tennis (EU).iso" size 1459978240 crc 1523102b md5 0f09da2b8e32bcb352bfb727fb1ea725 sha1 68341d3cb0793f7e51cfdf8ac38167857c6adc62 )
+)
+
+game (
+	name "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
+	description "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Power Tennis (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1523102b md5 0f09da2b8e32bcb352bfb727fb1ea725 sha1 68341d3cb0793f7e51cfdf8ac38167857c6adc62 )
+)
+
+game (
+	name "Mario Power Tennis (US)"
+	description "Mario Power Tennis (US)"
+	rom ( name "Mario Power Tennis (US) - [v1.00].iso" size 1459978240 crc 14ac75c2 md5 5532d17918026a58af3593aa4aaaa450 sha1 bd2bc374f18b9ede202e17aac0868da0c2e3ea94 )
+)
+
+game (
+	name "Mario Power Tennis (USA) (v1.00)"
+	description "Mario Power Tennis (USA) (v1.00)"
+	rom ( name "Mario Power Tennis (USA) (v1.00).iso" size 1459978240 crc 14ac75c2 md5 5532d17918026a58af3593aa4aaaa450 sha1 bd2bc374f18b9ede202e17aac0868da0c2e3ea94 )
+)
+
+game (
+	name "Mario Power Tennis (USA) (v1.01)"
+	description "Mario Power Tennis (USA) (v1.01)"
+	rom ( name "Mario Power Tennis (USA) (v1.01).iso" size 1459978240 crc ef719371 md5 286c7fae43220b6bb45c169185d36ad3 sha1 511df0d4f09cc504574f97060b938cbcab16eb33 )
+)
+
+game (
+	name "Mario Smash Football (EU)"
+	description "Mario Smash Football (EU)"
+	rom ( name "Mario Smash Football (EU).iso" size 1459978240 crc 77677e49 md5 a8f5af5a3af020a9b3d1303d900bffe2 sha1 db6a96581f2489f388a227bdca9223d95ec71472 )
+)
+
+game (
+	name "Mario Smash Football (Europe) (En,Fr,De,Es,It)"
+	description "Mario Smash Football (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Smash Football (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 77677e49 md5 a8f5af5a3af020a9b3d1303d900bffe2 sha1 db6a96581f2489f388a227bdca9223d95ec71472 )
+)
+
+game (
+	name "Mario Superstar Baseball (EU)"
+	description "Mario Superstar Baseball (EU)"
+	rom ( name "Mario Superstar Baseball (EU).iso" size 1459978240 crc fa1ccfc7 md5 025877b2ee61ad6081830979b8e77a0c sha1 eeac3441284722b4ec7b742655ec450f61864879 )
+)
+
+game (
+	name "Mario Superstar Baseball (Europe)"
+	description "Mario Superstar Baseball (Europe)"
+	rom ( name "Mario Superstar Baseball (Europe).iso" size 1459978240 crc fa1ccfc7 md5 025877b2ee61ad6081830979b8e77a0c sha1 eeac3441284722b4ec7b742655ec450f61864879 )
+)
+
+game (
+	name "Mario Superstar Baseball (US)"
+	description "Mario Superstar Baseball (US)"
+	rom ( name "Mario Superstar Baseball (US).iso" size 1459978240 crc 89cdb7b7 md5 3797367d5c0ca1ef0bb522698227f6f1 sha1 f6debe1b3be4ddff875fdfee5eba34b666aeeaee )
+)
+
+game (
+	name "Mario Superstar Baseball (USA)"
+	description "Mario Superstar Baseball (USA)"
+	rom ( name "Mario Superstar Baseball (USA).iso" size 1459978240 crc 89cdb7b7 md5 3797367d5c0ca1ef0bb522698227f6f1 sha1 f6debe1b3be4ddff875fdfee5eba34b666aeeaee )
+)
+
+game (
+	name "Mario Tennis GC (Japan) (v1.00)"
+	description "Mario Tennis GC (Japan) (v1.00)"
+	rom ( name "Mario Tennis GC (Japan) (v1.00).iso" size 1459978240 crc 84cd2f16 md5 19c7e0406176b93ee81fac648f11093e sha1 0a433f944f5d9b454eadcd1e43fcd3703be68c15 )
+)
+
+game (
+	name "Mario Tennis GC (Japan) (v1.01)"
+	description "Mario Tennis GC (Japan) (v1.01)"
+	rom ( name "Mario Tennis GC (Japan) (v1.01).iso" size 1459978240 crc 9264a2ec md5 60a52be1d4d5fadc3838d73d6de200f5 sha1 2f3cb98096f1ae09eb88e5f2874ce00ccbdb64df )
+)
+
+game (
+	name "Mario Tennis GC (JP) - mariotenisuGC"
+	description "Mario Tennis GC (JP) - mariotenisuGC"
+	rom ( name "Mario Tennis GC (JP) - [v1.00].iso" size 1459978240 crc 84cd2f16 md5 19c7e0406176b93ee81fac648f11093e sha1 0a433f944f5d9b454eadcd1e43fcd3703be68c15 )
+)
+
+game (
+	name "Mark Davis Pro Bass Challenge (US)"
+	description "Mark Davis Pro Bass Challenge (US)"
+	rom ( name "Mark Davis Pro Bass Challenge (US).iso" size 1459978240 crc 89bc8c9f md5 73cee4f4d72e45048cb8cbee3dcfae17 sha1 f573b62d9592fe43ffcd1466647a4450ee16baad )
+)
+
+game (
+	name "Mark Davis Pro Bass Challenge (USA)"
+	description "Mark Davis Pro Bass Challenge (USA)"
+	rom ( name "Mark Davis Pro Bass Challenge (USA).iso" size 1459978240 crc 89bc8c9f md5 73cee4f4d72e45048cb8cbee3dcfae17 sha1 f573b62d9592fe43ffcd1466647a4450ee16baad )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (DE)"
+	description "Marvel Nemesis - Rise of the Imperfects (DE)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (DE).iso" size 1459978240 crc 64ab1401 md5 a20c15e3f18e51aea9f994ee9f746c65 sha1 754f495c42923e1f033f719a56526d0407633b6f )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (Europe)"
+	description "Marvel Nemesis - Rise of the Imperfects (Europe)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (Europe).iso" size 1459978240 crc 6e534882 md5 78159b716612d408ffa9d6bece0e5fb9 sha1 f0d59032aa8ecfb31d7b5c378d3a1d34c9f458ea )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (GB)"
+	description "Marvel Nemesis - Rise of the Imperfects (GB)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (GB).iso" size 1459978240 crc 6e534882 md5 78159b716612d408ffa9d6bece0e5fb9 sha1 f0d59032aa8ecfb31d7b5c378d3a1d34c9f458ea )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (Germany)"
+	description "Marvel Nemesis - Rise of the Imperfects (Germany)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (Germany).iso" size 1459978240 crc 64ab1401 md5 a20c15e3f18e51aea9f994ee9f746c65 sha1 754f495c42923e1f033f719a56526d0407633b6f )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (US)"
+	description "Marvel Nemesis - Rise of the Imperfects (US)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (US).iso" size 1459978240 crc a3776354 md5 bb1197fe630e14e33818267aff206f3d sha1 ed770d229d99eaaedb873cecabb0f62d9f5aae6b )
+)
+
+game (
+	name "Marvel Nemesis - Rise of the Imperfects (USA)"
+	description "Marvel Nemesis - Rise of the Imperfects (USA)"
+	rom ( name "Marvel Nemesis - Rise of the Imperfects (USA).iso" size 1459978240 crc a3776354 md5 bb1197fe630e14e33818267aff206f3d sha1 ed770d229d99eaaedb873cecabb0f62d9f5aae6b )
+)
+
+game (
+	name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (EU)"
+	description "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (EU)"
+	rom ( name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (EU).iso" size 1459978240 crc 2b432841 md5 6b754b72a6f3e600495ac0b2702b48ca sha1 76912f95d72f6e4f0380430565817ec01db896c9 )
+)
+
+game (
+	name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (Europe)"
+	description "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (Europe)"
+	rom ( name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (Europe).iso" size 1459978240 crc 2b432841 md5 6b754b72a6f3e600495ac0b2702b48ca sha1 76912f95d72f6e4f0380430565817ec01db896c9 )
+)
+
+game (
+	name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (US)"
+	description "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (US)"
+	rom ( name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (US).iso" size 1459978240 crc 817d3137 md5 a10b12cc8632b36e002c6fcee22c1282 sha1 366e51d517857ed24531657aeebfd9e27eea18d2 )
+)
+
+game (
+	name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (USA)"
+	description "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (USA)"
+	rom ( name "Mary-Kate and Ashley - Sweet 16 - Licensed to Drive (USA).iso" size 1459978240 crc 817d3137 md5 a10b12cc8632b36e002c6fcee22c1282 sha1 366e51d517857ed24531657aeebfd9e27eea18d2 )
+)
+
+game (
+	name "Mat Hoffman's Pro BMX 2 (EU)"
+	description "Mat Hoffman's Pro BMX 2 (EU)"
+	rom ( name "Mat Hoffman's Pro BMX 2 (EU).iso" size 1459978240 crc 7dd73eb3 md5 b3a39de8a6878a2e81ade8d001f79d33 sha1 bbc490d9aa6cbce4c366effb4deb8ee6d976df7b )
+)
+
+game (
+	name "Mat Hoffman's Pro BMX 2 (Europe)"
+	description "Mat Hoffman's Pro BMX 2 (Europe)"
+	rom ( name "Mat Hoffman's Pro BMX 2 (Europe).iso" size 1459978240 crc 7dd73eb3 md5 b3a39de8a6878a2e81ade8d001f79d33 sha1 bbc490d9aa6cbce4c366effb4deb8ee6d976df7b )
+)
+
+game (
+	name "Mat Hoffman's Pro BMX 2 (US)"
+	description "Mat Hoffman's Pro BMX 2 (US)"
+	rom ( name "Mat Hoffman's Pro BMX 2 (US).iso" size 1459978240 crc cdfad5b1 md5 08c430a108055243426c6b39c498eefb sha1 2c5467b21c171f7ae9afebac198aa91b285b98a5 )
+)
+
+game (
+	name "Mat Hoffman's Pro BMX 2 (USA)"
+	description "Mat Hoffman's Pro BMX 2 (USA)"
+	rom ( name "Mat Hoffman's Pro BMX 2 (USA).iso" size 1459978240 crc cdfad5b1 md5 08c430a108055243426c6b39c498eefb sha1 2c5467b21c171f7ae9afebac198aa91b285b98a5 )
+)
+
+game (
+	name "MC Groovz Dance Craze (Beat Pad) (EU)"
+	description "MC Groovz Dance Craze (Beat Pad) (EU)"
+	rom ( name "MC Groovz Dance Craze (Beat Pad) (EU).iso" size 1459978240 crc ec6ed5ae md5 26f19a580a180a33ba88e960def9fc51 sha1 6f8f2ee2e811f792e6b74cc440c1bb149296dfe3 )
+)
+
+game (
+	name "MC Groovz Dance Craze (Europe) (En,Fr,De,Es,It)"
+	description "MC Groovz Dance Craze (Europe) (En,Fr,De,Es,It)"
+	rom ( name "MC Groovz Dance Craze (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ec6ed5ae md5 26f19a580a180a33ba88e960def9fc51 sha1 6f8f2ee2e811f792e6b74cc440c1bb149296dfe3 )
+)
+
+game (
+	name "MC Groovz Dance Craze (US)"
+	description "MC Groovz Dance Craze (US)"
+	rom ( name "MC Groovz Dance Craze (US).iso" size 1459978240 crc 9b5dff04 md5 e51a8da2bfea7f971727816e562c84fd sha1 c6bbebce6a6e782d9cec0b3bdfdba41d3f119dbe )
+)
+
+game (
+	name "MC Groovz Dance Craze (USA)"
+	description "MC Groovz Dance Craze (USA)"
+	rom ( name "MC Groovz Dance Craze (USA).iso" size 1459978240 crc 9b5dff04 md5 e51a8da2bfea7f971727816e562c84fd sha1 c6bbebce6a6e782d9cec0b3bdfdba41d3f119dbe )
+)
+
+game (
+	name "Medabots Infinity (EU)"
+	description "Medabots Infinity (EU)"
+	rom ( name "Medabots Infinity (EU).iso" size 1459978240 crc 0c2a51ec md5 0cc1267f8758c983cf8a32b37958b85b sha1 9fcf735947b02da4c3b41bc249081e17a2146b37 )
+)
+
+game (
+	name "Medabots Infinity (Europe) (En,Fr,De,Nl)"
+	description "Medabots Infinity (Europe) (En,Fr,De,Nl)"
+	rom ( name "Medabots Infinity (Europe) (En,Fr,De,Nl).iso" size 1459978240 crc 0c2a51ec md5 0cc1267f8758c983cf8a32b37958b85b sha1 9fcf735947b02da4c3b41bc249081e17a2146b37 )
+)
+
+game (
+	name "Medabots Infinity (US)"
+	description "Medabots Infinity (US)"
+	rom ( name "Medabots Infinity (US) - [v1.00].iso" size 1459978240 crc 26dd621f md5 4f22990fcd37e9aaac6dc96bc2752140 sha1 e4af1ea19d8a9e85c33c647a788b228c11a24eab )
+)
+
+game (
+	name "Medabots Infinity (USA) (v1.00)"
+	description "Medabots Infinity (USA) (v1.00)"
+	rom ( name "Medabots Infinity (USA) (v1.00).iso" size 1459978240 crc 26dd621f md5 4f22990fcd37e9aaac6dc96bc2752140 sha1 e4af1ea19d8a9e85c33c647a788b228c11a24eab )
+)
+
+game (
+	name "Medabots Infinity (USA) (v1.01)"
+	description "Medabots Infinity (USA) (v1.01)"
+	rom ( name "Medabots Infinity (USA) (v1.01).iso" size 1459978240 crc 257d7250 md5 36f8606d222e614dab20d2286184dc6d sha1 c415d73345c7063bf0c96da27cf2ff5965845c77 )
+)
+
+game (
+	name "Medal of Honor - En Premiere Ligne (FR)"
+	description "Medal of Honor - En Premiere Ligne (FR)"
+	rom ( name "Medal of Honor - En Premiere Ligne (FR).iso" size 1459978240 crc 70286e7b md5 5fed090c1d01ab8c84ba0cc4fe31e70f sha1 49355ba5b1a9018e8ac1e5d8dda609676a74d9c5 )
+)
+
+game (
+	name "Medal of Honor - En Premiere Ligne (France)"
+	description "Medal of Honor - En Premiere Ligne (France)"
+	rom ( name "Medal of Honor - En Premiere Ligne (France).iso" size 1459978240 crc 70286e7b md5 5fed090c1d01ab8c84ba0cc4fe31e70f sha1 49355ba5b1a9018e8ac1e5d8dda609676a74d9c5 )
+)
+
+game (
+	name "Medal of Honor - Europa Kyoushuu (Japan)"
+	description "Medal of Honor - Europa Kyoushuu (Japan)"
+	rom ( name "Medal of Honor - Europa Kyoushuu (Japan).iso" size 1459978240 crc d1237e99 md5 b9dd0b9596e110c7ff6b5485ebfc7fef sha1 36fd355d5a1f34ea6b8e209dec41dd6a2a06f014 )
+)
+
+game (
+	name "Medal of Honor - Europa Kyoushuu (JP) - medaru+obu+ona+yorotupa+Qiang Xi"
+	description "Medal of Honor - Europa Kyoushuu (JP) - medaru+obu+ona+yorotupa+Qiang Xi"
+	rom ( name "Medal of Honor - Europa Kyoushuu (JP).iso" size 1459978240 crc d1237e99 md5 b9dd0b9596e110c7ff6b5485ebfc7fef sha1 36fd355d5a1f34ea6b8e209dec41dd6a2a06f014 )
+)
+
+game (
+	name "Medal of Honor - European Assault (DE)"
+	description "Medal of Honor - European Assault (DE)"
+	rom ( name "Medal of Honor - European Assault (DE).iso" size 1459978240 crc e8069949 md5 431530db74ef7ccfb38942c198ab0a7e sha1 06d7e3b910d39d02d5e7f849f6214fa0865d5a0f )
+)
+
+game (
+	name "Medal of Honor - European Assault (EU)"
+	description "Medal of Honor - European Assault (EU)"
+	rom ( name "Medal of Honor - European Assault (EU).iso" size 1459978240 crc 2852d9b5 md5 d85bc7691c39e39c351563fd185fa035 sha1 3b663b403025cd7c99bfea0c960b0ccbc2ba3820 )
+)
+
+game (
+	name "Medal of Honor - European Assault (Europe)"
+	description "Medal of Honor - European Assault (Europe)"
+	rom ( name "Medal of Honor - European Assault (Europe).iso" size 1459978240 crc 2852d9b5 md5 d85bc7691c39e39c351563fd185fa035 sha1 3b663b403025cd7c99bfea0c960b0ccbc2ba3820 )
+)
+
+game (
+	name "Medal of Honor - European Assault (Germany)"
+	description "Medal of Honor - European Assault (Germany)"
+	rom ( name "Medal of Honor - European Assault (Germany).iso" size 1459978240 crc e8069949 md5 431530db74ef7ccfb38942c198ab0a7e sha1 06d7e3b910d39d02d5e7f849f6214fa0865d5a0f )
+)
+
+game (
+	name "Medal of Honor - European Assault (US)"
+	description "Medal of Honor - European Assault (US)"
+	rom ( name "Medal of Honor - European Assault (US).iso" size 1459978240 crc b8925a76 md5 e70a05b36b9aad79997f73f034aa2a7c sha1 d4015be71ca8c4cc087adffed68b86d7f7cef342 )
+)
+
+game (
+	name "Medal of Honor - European Assault (USA)"
+	description "Medal of Honor - European Assault (USA)"
+	rom ( name "Medal of Honor - European Assault (USA).iso" size 1459978240 crc b8925a76 md5 e70a05b36b9aad79997f73f034aa2a7c sha1 d4015be71ca8c4cc087adffed68b86d7f7cef342 )
+)
+
+game (
+	name "Medal of Honor - Frontline (DE)"
+	description "Medal of Honor - Frontline (DE)"
+	rom ( name "Medal of Honor - Frontline (DE).iso" size 1459978240 crc 8707598d md5 8be1705cbc9678d91d741b59cc227af6 sha1 de99642888516fb7786b9f333544e9a1b7c789dc )
+)
+
+game (
+	name "Medal of Honor - Frontline (ES)"
+	description "Medal of Honor - Frontline (ES)"
+	rom ( name "Medal of Honor - Frontline (ES).iso" size 1459978240 crc 315bb8ba md5 7cdfad92b8ce9b0a7f0167c18e2fdee9 sha1 93d640cbe546c0f5dfe319794a6ebc927e0c31bb )
+)
+
+game (
+	name "Medal of Honor - Frontline (Europe)"
+	description "Medal of Honor - Frontline (Europe)"
+	rom ( name "Medal of Honor - Frontline (Europe).iso" size 1459978240 crc 2430a324 md5 b07b611405fc84198e00f3b3d97b4f9a sha1 f5fb0d3d3a0a202cb8a21ef6cab3a89bfe0b6880 )
+)
+
+game (
+	name "Medal of Honor - Frontline (GB)"
+	description "Medal of Honor - Frontline (GB)"
+	rom ( name "Medal of Honor - Frontline (GB).iso" size 1459978240 crc 2430a324 md5 b07b611405fc84198e00f3b3d97b4f9a sha1 f5fb0d3d3a0a202cb8a21ef6cab3a89bfe0b6880 )
+)
+
+game (
+	name "Medal of Honor - Frontline (Germany)"
+	description "Medal of Honor - Frontline (Germany)"
+	rom ( name "Medal of Honor - Frontline (Germany).iso" size 1459978240 crc 8707598d md5 8be1705cbc9678d91d741b59cc227af6 sha1 de99642888516fb7786b9f333544e9a1b7c789dc )
+)
+
+game (
+	name "Medal of Honor - Frontline (IT)"
+	description "Medal of Honor - Frontline (IT)"
+	rom ( name "Medal of Honor - Frontline (IT).iso" size 1459978240 crc 580dbd0a md5 349e99dacde4b9a4cdd0fca09e44264b sha1 e1ffe50a6e196398d0478eb1bc46271ff775e542 )
+)
+
+game (
+	name "Medal of Honor - Frontline (Italy)"
+	description "Medal of Honor - Frontline (Italy)"
+	rom ( name "Medal of Honor - Frontline (Italy).iso" size 1459978240 crc 580dbd0a md5 349e99dacde4b9a4cdd0fca09e44264b sha1 e1ffe50a6e196398d0478eb1bc46271ff775e542 )
+)
+
+game (
+	name "Medal of Honor - Frontline (Spain)"
+	description "Medal of Honor - Frontline (Spain)"
+	rom ( name "Medal of Honor - Frontline (Spain).iso" size 1459978240 crc 315bb8ba md5 7cdfad92b8ce9b0a7f0167c18e2fdee9 sha1 93d640cbe546c0f5dfe319794a6ebc927e0c31bb )
+)
+
+game (
+	name "Medal of Honor - Frontline (US)"
+	description "Medal of Honor - Frontline (US)"
+	rom ( name "Medal of Honor - Frontline (US).iso" size 1459978240 crc 33295df7 md5 b6cdf7e9090f32ca51360341f951e51f sha1 483c0e66fddf9a7dd7a4ac1db94d14f34694071c )
+)
+
+game (
+	name "Medal of Honor - Frontline (USA)"
+	description "Medal of Honor - Frontline (USA)"
+	rom ( name "Medal of Honor - Frontline (USA).iso" size 1459978240 crc 33295df7 md5 b6cdf7e9090f32ca51360341f951e51f sha1 483c0e66fddf9a7dd7a4ac1db94d14f34694071c )
+)
+
+game (
+	name "Medal of Honor - Les Faucons de Guerre (FR)"
+	description "Medal of Honor - Les Faucons de Guerre (FR)"
+	rom ( name "Medal of Honor - Les Faucons de Guerre (FR).iso" size 1459978240 crc 49e17288 md5 4acc3c88798c671cfb80fb55f2912098 sha1 530cbdba2e89d623fc9724062a5d9159106bddda )
+)
+
+game (
+	name "Medal of Honor - Les Faucons de Guerre (France)"
+	description "Medal of Honor - Les Faucons de Guerre (France)"
+	rom ( name "Medal of Honor - Les Faucons de Guerre (France).iso" size 1459978240 crc 49e17288 md5 4acc3c88798c671cfb80fb55f2912098 sha1 530cbdba2e89d623fc9724062a5d9159106bddda )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (DE)"
+	description "Medal of Honor - Rising Sun (DE)"
+	rom ( name "Medal of Honor - Rising Sun (DE) - (Disc 1 of 2).iso" size 1459978240 crc 2c73ec74 md5 600659bd7ad07ded23b344d9f2b6bf04 sha1 9bb4f71417d363e25b63979c6a44f9f3377135da )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (EU)"
+	description "Medal of Honor - Rising Sun (EU)"
+	rom ( name "Medal of Honor - Rising Sun (EU) - (Disc 1 of 2).iso" size 1459978240 crc 92481f32 md5 76d6e0a9d13922aaebccf4dfa363bf1d sha1 040313b97dba24885997a41be7c7eb47cba61a76 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 1)"
+	description "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 1)"
+	rom ( name "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 1).iso" size 1459978240 crc 92481f32 md5 76d6e0a9d13922aaebccf4dfa363bf1d sha1 040313b97dba24885997a41be7c7eb47cba61a76 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 2)"
+	description "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 2)"
+	rom ( name "Medal of Honor - Rising Sun (Europe) (En,Es,It,Nl,Sv) (Disc 2).iso" size 1459978240 crc b2b5a18f md5 8b32e9ef34fa2d3c22cefd1c63da8067 sha1 1207381d94b5eb4166420ba940e0fb1e22f15da9 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Germany) (Disc 1)"
+	description "Medal of Honor - Rising Sun (Germany) (Disc 1)"
+	rom ( name "Medal of Honor - Rising Sun (Germany) (Disc 1).iso" size 1459978240 crc 2c73ec74 md5 600659bd7ad07ded23b344d9f2b6bf04 sha1 9bb4f71417d363e25b63979c6a44f9f3377135da )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Germany) (Disc 2)"
+	description "Medal of Honor - Rising Sun (Germany) (Disc 2)"
+	rom ( name "Medal of Honor - Rising Sun (Germany) (Disc 2).iso" size 1459978240 crc 8e136fe4 md5 9ae88d41b322b6480457ea0c0ed86512 sha1 a47fdc77ffb67a4dabf0f32387f02f8b4c711f48 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Japan) (Disc 1)"
+	description "Medal of Honor - Rising Sun (Japan) (Disc 1)"
+	rom ( name "Medal of Honor - Rising Sun (Japan) (Disc 1).iso" size 1459978240 crc 23ad9efc md5 ba767c78b3f411a42053d2765a5f4408 sha1 6bfd136101ca5200aa4ea276fcfb1f83a23bcf33 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (Japan) (Disc 2)"
+	description "Medal of Honor - Rising Sun (Japan) (Disc 2)"
+	rom ( name "Medal of Honor - Rising Sun (Japan) (Disc 2).iso" size 1459978240 crc 36bf719e md5 988ba5983b3b729993bcfca821e838fb sha1 e673a867696457a3ff498490997f545c6c4e0707 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (JP) - medaru+obu+ona+raizingusan"
+	description "Medal of Honor - Rising Sun (JP) - medaru+obu+ona+raizingusan"
+	rom ( name "Medal of Honor - Rising Sun (JP) - (Disc 1 of 2).iso" size 1459978240 crc 23ad9efc md5 ba767c78b3f411a42053d2765a5f4408 sha1 6bfd136101ca5200aa4ea276fcfb1f83a23bcf33 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (US)"
+	description "Medal of Honor - Rising Sun (US)"
+	rom ( name "Medal of Honor - Rising Sun (US) - (Disc 1 of 2).iso" size 1459978240 crc 2f2f6f2a md5 f5ac375a401aa9728b9a6591b05d3da9 sha1 5a14fe7fbb7d7da17c0fe8c6cc0f803779a33c21 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (USA) (Disc 1)"
+	description "Medal of Honor - Rising Sun (USA) (Disc 1)"
+	rom ( name "Medal of Honor - Rising Sun (USA) (Disc 1).iso" size 1459978240 crc 2f2f6f2a md5 f5ac375a401aa9728b9a6591b05d3da9 sha1 5a14fe7fbb7d7da17c0fe8c6cc0f803779a33c21 )
+)
+
+game (
+	name "Medal of Honor - Rising Sun (USA) (Disc 2)"
+	description "Medal of Honor - Rising Sun (USA) (Disc 2)"
+	rom ( name "Medal of Honor - Rising Sun (USA) (Disc 2).iso" size 1459978240 crc 7572a915 md5 416b1061c226f509c40a885e87fba2f2 sha1 cf590999919364772ccea35ddd47bfa81a34f74a )
+)
+
+game (
+	name "Medal of Honor - Soleil Levant (FR)"
+	description "Medal of Honor - Soleil Levant (FR)"
+	rom ( name "Medal of Honor - Soleil Levant (FR) - (Disc 1 of 2).iso" size 1459978240 crc 210da06d md5 9b28a091fdcef6c08a5bd7cfe65d029a sha1 5bd3b7cdaebb1a81872f8097f20c1a8446edb69d )
+)
+
+game (
+	name "Medal of Honor - Soleil Levant (France) (Disc 1)"
+	description "Medal of Honor - Soleil Levant (France) (Disc 1)"
+	rom ( name "Medal of Honor - Soleil Levant (France) (Disc 1).iso" size 1459978240 crc 210da06d md5 9b28a091fdcef6c08a5bd7cfe65d029a sha1 5bd3b7cdaebb1a81872f8097f20c1a8446edb69d )
+)
+
+game (
+	name "Medal of Honor - Soleil Levant (France) (Disc 2)"
+	description "Medal of Honor - Soleil Levant (France) (Disc 2)"
+	rom ( name "Medal of Honor - Soleil Levant (France) (Disc 2).iso" size 1459978240 crc bf4c34f9 md5 b582f6719f9f53e11add209dfb88fa6a sha1 68c78a9ee12659c257198ef4b2d6e0af7daaeb82 )
+)
+
+game (
+	name "Medarot Brave (Japan)"
+	description "Medarot Brave (Japan)"
+	rom ( name "Medarot Brave (Japan).iso" size 1459978240 crc cec865c6 md5 1847bb8c04c6c3a75e222cef42f6ec86 sha1 06c050f7610176ae8e29bf0010a07509c1daede5 )
+)
+
+game (
+	name "Medarot Brave (JP) - medarotuto+bureibu"
+	description "Medarot Brave (JP) - medarotuto+bureibu"
+	rom ( name "Medarot Brave (JP).iso" size 1459978240 crc cec865c6 md5 1847bb8c04c6c3a75e222cef42f6ec86 sha1 06c050f7610176ae8e29bf0010a07509c1daede5 )
+)
+
+game (
+	name "Mega Man - Network Transmission (Europe)"
+	description "Mega Man - Network Transmission (Europe)"
+	rom ( name "Mega Man - Network Transmission (Europe).iso" size 1459978240 crc faebcdf1 md5 9ce508e45fec6d36444ddfbc8938c7b7 sha1 c12676e91174a8a78fc758bafbc256565ca24e56 )
+)
+
+game (
+	name "Mega Man - Network Transmission (GB)"
+	description "Mega Man - Network Transmission (GB)"
+	rom ( name "Mega Man - Network Transmission (GB).iso" size 1459978240 crc faebcdf1 md5 9ce508e45fec6d36444ddfbc8938c7b7 sha1 c12676e91174a8a78fc758bafbc256565ca24e56 )
+)
+
+game (
+	name "Mega Man - Network Transmission (US)"
+	description "Mega Man - Network Transmission (US)"
+	rom ( name "Mega Man - Network Transmission (US).iso" size 1459978240 crc 17d7a329 md5 db7c0b15e99bd0b52a2c44100e7b40cb sha1 974552ef9b061ce61dca65cdbfe1231e78267040 )
+)
+
+game (
+	name "Mega Man - Network Transmission (USA)"
+	description "Mega Man - Network Transmission (USA)"
+	rom ( name "Mega Man - Network Transmission (USA).iso" size 1459978240 crc 17d7a329 md5 db7c0b15e99bd0b52a2c44100e7b40cb sha1 974552ef9b061ce61dca65cdbfe1231e78267040 )
+)
+
+game (
+	name "Mega Man Anniversary Collection (US)"
+	description "Mega Man Anniversary Collection (US)"
+	rom ( name "Mega Man Anniversary Collection (US).iso" size 1459978240 crc 0b24ea35 md5 ce11389361d3b5c60f30ccb1d197f169 sha1 80da199d62493396d201e32dc9cb9e00da6ea2fd )
+)
+
+game (
+	name "Mega Man Anniversary Collection (USA)"
+	description "Mega Man Anniversary Collection (USA)"
+	rom ( name "Mega Man Anniversary Collection (USA).iso" size 1459978240 crc 0b24ea35 md5 ce11389361d3b5c60f30ccb1d197f169 sha1 80da199d62493396d201e32dc9cb9e00da6ea2fd )
+)
+
+game (
+	name "Mega Man X - Command Mission (EU)"
+	description "Mega Man X - Command Mission (EU)"
+	rom ( name "Mega Man X - Command Mission (EU).iso" size 1459978240 crc d2c90d02 md5 bd0f6597c620b7f7264d383e4e2531f8 sha1 4ca848d2285b1a288513a705a1399d223f64ea0d )
+)
+
+game (
+	name "Mega Man X - Command Mission (Europe) (En,Fr,De)"
+	description "Mega Man X - Command Mission (Europe) (En,Fr,De)"
+	rom ( name "Mega Man X - Command Mission (Europe) (En,Fr,De).iso" size 1459978240 crc d2c90d02 md5 bd0f6597c620b7f7264d383e4e2531f8 sha1 4ca848d2285b1a288513a705a1399d223f64ea0d )
+)
+
+game (
+	name "Mega Man X - Command Mission (US)"
+	description "Mega Man X - Command Mission (US)"
+	rom ( name "Mega Man X - Command Mission (US).iso" size 1459978240 crc 82115bd2 md5 ddaf03e8bb5b7ca43ae2f2d77087f917 sha1 98fafeb1fbe04dfec9a4ff1d0c159627bb288aad )
+)
+
+game (
+	name "Mega Man X - Command Mission (USA)"
+	description "Mega Man X - Command Mission (USA)"
+	rom ( name "Mega Man X - Command Mission (USA).iso" size 1459978240 crc 82115bd2 md5 ddaf03e8bb5b7ca43ae2f2d77087f917 sha1 98fafeb1fbe04dfec9a4ff1d0c159627bb288aad )
+)
+
+game (
+	name "Mega Man X Collection (US)"
+	description "Mega Man X Collection (US)"
+	rom ( name "Mega Man X Collection (US).iso" size 1459978240 crc dd9fe721 md5 74b153a4f45ef6750c4a6baf4b249b94 sha1 399ad15d4793f94bed89f2aadf0a1da5fe57753f )
+)
+
+game (
+	name "Mega Man X Collection (USA)"
+	description "Mega Man X Collection (USA)"
+	rom ( name "Mega Man X Collection (USA).iso" size 1459978240 crc dd9fe721 md5 74b153a4f45ef6750c4a6baf4b249b94 sha1 399ad15d4793f94bed89f2aadf0a1da5fe57753f )
+)
+
+game (
+	name "Men in Black II - Alien Escape (EU)"
+	description "Men in Black II - Alien Escape (EU)"
+	rom ( name "Men in Black II - Alien Escape (EU).iso" size 1459978240 crc 08d61684 md5 e9213452956db666d6f5141c2f3821a5 sha1 25b5e28bf2f1b96847477213b875e1349c7d80dc )
+)
+
+game (
+	name "Men in Black II - Alien Escape (Europe) (En,Fr,De,Es,It)"
+	description "Men in Black II - Alien Escape (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Men in Black II - Alien Escape (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 08d61684 md5 e9213452956db666d6f5141c2f3821a5 sha1 25b5e28bf2f1b96847477213b875e1349c7d80dc )
+)
+
+game (
+	name "Men in Black II - Alien Escape (US)"
+	description "Men in Black II - Alien Escape (US)"
+	rom ( name "Men in Black II - Alien Escape (US).iso" size 1459978240 crc 7b0c45de md5 87d5078c547207920a56ccc81bce82d1 sha1 c6d0f7aa4e53a70effcc10bf41c6f75ffde4845d )
+)
+
+game (
+	name "Men in Black II - Alien Escape (USA)"
+	description "Men in Black II - Alien Escape (USA)"
+	rom ( name "Men in Black II - Alien Escape (USA).iso" size 1459978240 crc 7b0c45de md5 87d5078c547207920a56ccc81bce82d1 sha1 c6d0f7aa4e53a70effcc10bf41c6f75ffde4845d )
+)
+
+game (
+	name "Metal Arms - Glitch in the System (Europe)"
+	description "Metal Arms - Glitch in the System (Europe)"
+	rom ( name "Metal Arms - Glitch in the System (Europe).iso" size 1459978240 crc 363ea2c2 md5 d6b0c2d46433e09e5f98caab73d20912 sha1 aa56b1505a396cb9607fddbbf7b5d63949ffd3de )
+)
+
+game (
+	name "Metal Arms - Glitch in the System (GB)"
+	description "Metal Arms - Glitch in the System (GB)"
+	rom ( name "Metal Arms - Glitch in the System (GB).iso" size 1459978240 crc 363ea2c2 md5 d6b0c2d46433e09e5f98caab73d20912 sha1 aa56b1505a396cb9607fddbbf7b5d63949ffd3de )
+)
+
+game (
+	name "Metal Arms - Glitch in the System (US)"
+	description "Metal Arms - Glitch in the System (US)"
+	rom ( name "Metal Arms - Glitch in the System (US).iso" size 1459978240 crc 239a5474 md5 c0127b69963591edcac97437bc407272 sha1 b73ead2e11f5d6ec80c5270855b0e57f96a63455 )
+)
+
+game (
+	name "Metal Arms - Glitch in the System (USA)"
+	description "Metal Arms - Glitch in the System (USA)"
+	rom ( name "Metal Arms - Glitch in the System (USA).iso" size 1459978240 crc 239a5474 md5 c0127b69963591edcac97437bc407272 sha1 b73ead2e11f5d6ec80c5270855b0e57f96a63455 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes - Special Disc (Japan)"
+	description "Metal Gear Solid - The Twin Snakes - Special Disc (Japan)"
+	rom ( name "Metal Gear Solid - The Twin Snakes - Special Disc (Japan).iso" size 1459978240 crc 7697e706 md5 8433b28379d8533ecd3d09dd864d078e sha1 7deb1f25832a40d3db234122ed675294cc4c3cf6 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes - Special Disc (JP) - metarugia+supesiyarudeisuku"
+	description "Metal Gear Solid - The Twin Snakes - Special Disc (JP) - metarugia+supesiyarudeisuku"
+	rom ( name "Metal Gear Solid - The Twin Snakes - Special Disc (JP).iso" size 1459978240 crc 7697e706 md5 8433b28379d8533ecd3d09dd864d078e sha1 7deb1f25832a40d3db234122ed675294cc4c3cf6 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (EU)"
+	description "Metal Gear Solid - The Twin Snakes (EU)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (EU) - (Disc 1 of 2).iso" size 1459978240 crc 09bf72f6 md5 4d44fc6da6d2fbc7a47e7fdda868139c sha1 8335976eda2ffe46986e9251574c62befc8e8c0a )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 09bf72f6 md5 4d44fc6da6d2fbc7a47e7fdda868139c sha1 8335976eda2ffe46986e9251574c62befc8e8c0a )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 95986481 md5 f8bf95d701e46bdbaf9e4a9f9b632c04 sha1 28f3e671242b291ffbe825d0725258f7dbf09362 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 1)"
+	description "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 1)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 1).iso" size 1459978240 crc dc5c4e83 md5 796319a44e67e9d34e90482d36b26e18 sha1 7ddfe2365b1ac00e80a5d6c69305766965b2538c )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 2)"
+	description "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 2)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (Japan) (En,Ja) (Disc 2).iso" size 1459978240 crc 7d103293 md5 4b0bc9bfe1c4098725bef272f5e03f4d sha1 6669fbed0207282890a9a1c0d897c8c79de8c475 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (JP) - metarugiasoritudo zatuinsunekusu"
+	description "Metal Gear Solid - The Twin Snakes (JP) - metarugiasoritudo zatuinsunekusu"
+	rom ( name "Metal Gear Solid - The Twin Snakes (JP) - (Disc 1 of 2).iso" size 1459978240 crc dc5c4e83 md5 796319a44e67e9d34e90482d36b26e18 sha1 7ddfe2365b1ac00e80a5d6c69305766965b2538c )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (US)"
+	description "Metal Gear Solid - The Twin Snakes (US)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (US) - (Disc 1 of 2).iso" size 1459978240 crc 02ab12f2 md5 0720e3d3fe42587b2ce22fbb8a60b847 sha1 e7ef51fd4e1d6030213b03cb315259c88e8474f8 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (USA) (Disc 1)"
+	description "Metal Gear Solid - The Twin Snakes (USA) (Disc 1)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (USA) (Disc 1).iso" size 1459978240 crc 02ab12f2 md5 0720e3d3fe42587b2ce22fbb8a60b847 sha1 e7ef51fd4e1d6030213b03cb315259c88e8474f8 )
+)
+
+game (
+	name "Metal Gear Solid - The Twin Snakes (USA) (Disc 2)"
+	description "Metal Gear Solid - The Twin Snakes (USA) (Disc 2)"
+	rom ( name "Metal Gear Solid - The Twin Snakes (USA) (Disc 2).iso" size 1459978240 crc ff7bcd0a md5 8d316f3b9438977101b7b8e0cb5c1418 sha1 53feecef9a16509d82946dee6a88d353c054f1ae )
+)
+
+game (
+	name "Metroid Prime (EU)"
+	description "Metroid Prime (EU)"
+	rom ( name "Metroid Prime (EU).iso" size 1459978240 crc aed8bc02 md5 b1379c44e0ebc521e18215de3e5dbeea sha1 34ac8a764a3c1db3326c39071cee2fc49e730aca )
+)
+
+game (
+	name "Metroid Prime (Europe) (En,Fr,De,Es,It)"
+	description "Metroid Prime (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Metroid Prime (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc aed8bc02 md5 b1379c44e0ebc521e18215de3e5dbeea sha1 34ac8a764a3c1db3326c39071cee2fc49e730aca )
+)
+
+game (
+	name "Metroid Prime (Japan)"
+	description "Metroid Prime (Japan)"
+	rom ( name "Metroid Prime (Japan).iso" size 1459978240 crc e3daea72 md5 b8d973124613dc3053a635b645a5f78c sha1 ee6c58b46012ebffb615506ec43e02ba71905662 )
+)
+
+game (
+	name "Metroid Prime (JP) - metoroidopuraimu"
+	description "Metroid Prime (JP) - metoroidopuraimu"
+	rom ( name "Metroid Prime (JP).iso" size 1459978240 crc e3daea72 md5 b8d973124613dc3053a635b645a5f78c sha1 ee6c58b46012ebffb615506ec43e02ba71905662 )
+)
+
+game (
+	name "Metroid Prime (USA) (v1.00)"
+	description "Metroid Prime (USA) (v1.00)"
+	rom ( name "Metroid Prime (USA) (v1.00).iso" size 1459978240 crc 852b658c md5 eeacd0ced8e2bae491eca14f141a4b7c sha1 ac20c744db18fdf0339f37945e880708fd317231 )
+)
+
+game (
+	name "Metroid Prime (USA) (v1.02)"
+	description "Metroid Prime (USA) (v1.02)"
+	rom ( name "Metroid Prime (USA) (v1.02).iso" size 1459978240 crc 61592372 md5 fdfc41b8414dd7d24834c800f567c0f8 sha1 1a737910b55b59c6ad91be9e3e3c43517fd52efb )
+)
+
+game (
+	name "Metroid Prime (v1.00) (US)"
+	description "Metroid Prime (v1.00) (US)"
+	rom ( name "Metroid Prime (v1.00) (US) - [v1.00].iso" size 1459978240 crc 852b658c md5 eeacd0ced8e2bae491eca14f141a4b7c sha1 ac20c744db18fdf0339f37945e880708fd317231 )
+)
+
+game (
+	name "Metroid Prime (v1.02) (US)"
+	description "Metroid Prime (v1.02) (US)"
+	rom ( name "Metroid Prime (v1.02) (US) - [v1.02].iso" size 1459978240 crc 61592372 md5 fdfc41b8414dd7d24834c800f567c0f8 sha1 1a737910b55b59c6ad91be9e3e3c43517fd52efb )
+)
+
+game (
+	name "Metroid Prime 2 - Dark Echoes (Japan)"
+	description "Metroid Prime 2 - Dark Echoes (Japan)"
+	rom ( name "Metroid Prime 2 - Dark Echoes (Japan).iso" size 1459978240 crc 0ee92a35 md5 c3a180b9c99b6a1590762c6510f29063 sha1 6cd6def1ca3db2ec7dc3882ad783ee4cd15076c7 )
+)
+
+game (
+	name "Metroid Prime 2 - Dark Echoes (JP) - metoroidopuraimu2+dakuekozu"
+	description "Metroid Prime 2 - Dark Echoes (JP) - metoroidopuraimu2+dakuekozu"
+	rom ( name "Metroid Prime 2 - Dark Echoes (JP).iso" size 1459978240 crc 0ee92a35 md5 c3a180b9c99b6a1590762c6510f29063 sha1 6cd6def1ca3db2ec7dc3882ad783ee4cd15076c7 )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (Bonus Disc) (US)"
+	description "Metroid Prime 2 - Echoes (Bonus Disc) (US)"
+	rom ( name "Metroid Prime 2 - Echoes (Bonus Disc) (US) - [Bonus Disc].iso" size 1459978240 crc 2db1d1b2 md5 9f896293ce056a5675c4968ca6285fb6 sha1 dfbbaa44e5c8a1cf4cc9500c9f382f4f41c60503 )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (EU)"
+	description "Metroid Prime 2 - Echoes (EU)"
+	rom ( name "Metroid Prime 2 - Echoes (EU).iso" size 1459978240 crc cf4eae03 md5 37fa7767fff54cd4c19bf0db30443520 sha1 a779afd7c705743e003a21412ad6bc8be345fbad )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (Europe) (En,Fr,De,Es,It)"
+	description "Metroid Prime 2 - Echoes (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Metroid Prime 2 - Echoes (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc cf4eae03 md5 37fa7767fff54cd4c19bf0db30443520 sha1 a779afd7c705743e003a21412ad6bc8be345fbad )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (US)"
+	description "Metroid Prime 2 - Echoes (US)"
+	rom ( name "Metroid Prime 2 - Echoes (US).iso" size 1459978240 crc f9bc88b6 md5 ce781ad1452311ca86667cf8dbd7d112 sha1 6af3496391bfe4ae97769f2fe85f0f575f2e3d5a )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (USA)"
+	description "Metroid Prime 2 - Echoes (USA)"
+	rom ( name "Metroid Prime 2 - Echoes (USA).iso" size 1459978240 crc f9bc88b6 md5 ce781ad1452311ca86667cf8dbd7d112 sha1 6af3496391bfe4ae97769f2fe85f0f575f2e3d5a )
+)
+
+game (
+	name "Metroid Prime 2 - Echoes (USA) (Bonus Disc)"
+	description "Metroid Prime 2 - Echoes (USA) (Bonus Disc)"
+	rom ( name "Metroid Prime 2 - Echoes (USA) (Bonus Disc).iso" size 1459978240 crc 2db1d1b2 md5 9f896293ce056a5675c4968ca6285fb6 sha1 dfbbaa44e5c8a1cf4cc9500c9f382f4f41c60503 )
+)
+
+game (
+	name "Micro Machines (EU)"
+	description "Micro Machines (EU)"
+	rom ( name "Micro Machines (EU).iso" size 1459978240 crc a8f0ce2f md5 a3842e886346497ad83c66915111821d sha1 62b9b212a46426f45f3c4880b12648611fcea1a6 )
+)
+
+game (
+	name "Micro Machines (Europe) (En,Fr,De,Es,It)"
+	description "Micro Machines (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Micro Machines (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a8f0ce2f md5 a3842e886346497ad83c66915111821d sha1 62b9b212a46426f45f3c4880b12648611fcea1a6 )
+)
+
+game (
+	name "Midway Arcade Treasures (US)"
+	description "Midway Arcade Treasures (US)"
+	rom ( name "Midway Arcade Treasures (US).iso" size 1459978240 crc 884bf5c1 md5 6b4a7c29354a9c312dbd3d7a5ae23210 sha1 cd0c7f3fc49bbe42bda3eb6494a027c90adfb82c )
+)
+
+game (
+	name "Midway Arcade Treasures (USA)"
+	description "Midway Arcade Treasures (USA)"
+	rom ( name "Midway Arcade Treasures (USA).iso" size 1459978240 crc 884bf5c1 md5 6b4a7c29354a9c312dbd3d7a5ae23210 sha1 cd0c7f3fc49bbe42bda3eb6494a027c90adfb82c )
+)
+
+game (
+	name "Midway Arcade Treasures 2 (US)"
+	description "Midway Arcade Treasures 2 (US)"
+	rom ( name "Midway Arcade Treasures 2 (US).iso" size 1459978240 crc 865fe16e md5 45bbe4821952e38bebb928ee3db137dc sha1 4f5f5bba87381777936150fd3ea2030a3ad5c14c )
+)
+
+game (
+	name "Midway Arcade Treasures 2 (USA)"
+	description "Midway Arcade Treasures 2 (USA)"
+	rom ( name "Midway Arcade Treasures 2 (USA).iso" size 1459978240 crc 865fe16e md5 45bbe4821952e38bebb928ee3db137dc sha1 4f5f5bba87381777936150fd3ea2030a3ad5c14c )
+)
+
+game (
+	name "Midway Arcade Treasures 3 (US)"
+	description "Midway Arcade Treasures 3 (US)"
+	rom ( name "Midway Arcade Treasures 3 (US).iso" size 1459978240 crc 22fa1d1d md5 89ae6da8f1eeacf1fe79b5b66b29de01 sha1 dd8cbae58fd652d7f583485dc5a2895e141adad1 )
+)
+
+game (
+	name "Midway Arcade Treasures 3 (USA)"
+	description "Midway Arcade Treasures 3 (USA)"
+	rom ( name "Midway Arcade Treasures 3 (USA).iso" size 1459978240 crc 22fa1d1d md5 89ae6da8f1eeacf1fe79b5b66b29de01 sha1 dd8cbae58fd652d7f583485dc5a2895e141adad1 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (DE)"
+	description "Minority Report - Everybody Runs (DE)"
+	rom ( name "Minority Report - Everybody Runs (DE).iso" size 1459978240 crc ad25b7e6 md5 bff0db5e3d9b5f7d76dee5bd486302e3 sha1 50f4c04081de40c7bab7046303eaa63cc3badba8 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (Europe)"
+	description "Minority Report - Everybody Runs (Europe)"
+	rom ( name "Minority Report - Everybody Runs (Europe).iso" size 1459978240 crc f2604c79 md5 89f57158fa7648804aaf8d828164a557 sha1 6dacd25dd5c4c5ae2843bf19c4f8cbf14f52cd71 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (GB)"
+	description "Minority Report - Everybody Runs (GB)"
+	rom ( name "Minority Report - Everybody Runs (GB).iso" size 1459978240 crc f2604c79 md5 89f57158fa7648804aaf8d828164a557 sha1 6dacd25dd5c4c5ae2843bf19c4f8cbf14f52cd71 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (Germany)"
+	description "Minority Report - Everybody Runs (Germany)"
+	rom ( name "Minority Report - Everybody Runs (Germany).iso" size 1459978240 crc ad25b7e6 md5 bff0db5e3d9b5f7d76dee5bd486302e3 sha1 50f4c04081de40c7bab7046303eaa63cc3badba8 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (US)"
+	description "Minority Report - Everybody Runs (US)"
+	rom ( name "Minority Report - Everybody Runs (US).iso" size 1459978240 crc 0e4372a9 md5 7a601a4058a20e7955e4d2da0252c7e0 sha1 6f53c75ed682ed6ee3b27803685f3b78d1ce2641 )
+)
+
+game (
+	name "Minority Report - Everybody Runs (USA)"
+	description "Minority Report - Everybody Runs (USA)"
+	rom ( name "Minority Report - Everybody Runs (USA).iso" size 1459978240 crc 0e4372a9 md5 7a601a4058a20e7955e4d2da0252c7e0 sha1 6f53c75ed682ed6ee3b27803685f3b78d1ce2641 )
+)
+
+game (
+	name "Minority Report - Le Futur vous Rattrape (FR)"
+	description "Minority Report - Le Futur vous Rattrape (FR)"
+	rom ( name "Minority Report - Le Futur vous Rattrape (FR).iso" size 1459978240 crc 8c2b0bbf md5 a36cb7ef1458adfd153f525396f062f4 sha1 76ab9111c20212037a3a9e8f7ea2062eff816a4f )
+)
+
+game (
+	name "Minority Report - Le Futur vous Rattrape (France)"
+	description "Minority Report - Le Futur vous Rattrape (France)"
+	rom ( name "Minority Report - Le Futur vous Rattrape (France).iso" size 1459978240 crc 8c2b0bbf md5 a36cb7ef1458adfd153f525396f062f4 sha1 76ab9111c20212037a3a9e8f7ea2062eff816a4f )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (EU)"
+	description "Mission - Impossible - Operation Surma (EU)"
+	rom ( name "Mission - Impossible - Operation Surma (EU).iso" size 1459978240 crc 610ee714 md5 c423cb1b3eaf35e389d3124c99a78a56 sha1 5d3be60baa507b3077c4a429b9b8c80bb5535c69 )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (Europe) (En,Fr,De,Es,It)"
+	description "Mission - Impossible - Operation Surma (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mission - Impossible - Operation Surma (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 610ee714 md5 c423cb1b3eaf35e389d3124c99a78a56 sha1 5d3be60baa507b3077c4a429b9b8c80bb5535c69 )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (Japan)"
+	description "Mission - Impossible - Operation Surma (Japan)"
+	rom ( name "Mission - Impossible - Operation Surma (Japan).iso" size 1459978240 crc 4fd53bc6 md5 32b63d11dee10127737d30fa11e2edd5 sha1 4ee856982767c1b690948a798cfdd542db676221 )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (JP) - mitusiyon:inpotusiburu+-Operation+Surma-"
+	description "Mission - Impossible - Operation Surma (JP) - mitusiyon:inpotusiburu+-Operation+Surma-"
+	rom ( name "Mission - Impossible - Operation Surma (JP).iso" size 1459978240 crc 4fd53bc6 md5 32b63d11dee10127737d30fa11e2edd5 sha1 4ee856982767c1b690948a798cfdd542db676221 )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (US)"
+	description "Mission - Impossible - Operation Surma (US)"
+	rom ( name "Mission - Impossible - Operation Surma (US).iso" size 1459978240 crc 5595d6bb md5 a467e35791894810d26fedf562a42c43 sha1 93bb0d0f8cecb8ef6d9b8971a4ce8fc0be8454e8 )
+)
+
+game (
+	name "Mission - Impossible - Operation Surma (USA)"
+	description "Mission - Impossible - Operation Surma (USA)"
+	rom ( name "Mission - Impossible - Operation Surma (USA).iso" size 1459978240 crc 5595d6bb md5 a467e35791894810d26fedf562a42c43 sha1 93bb0d0f8cecb8ef6d9b8971a4ce8fc0be8454e8 )
+)
+
+game (
+	name "MLB SlugFest 2003 (US)"
+	description "MLB SlugFest 2003 (US)"
+	rom ( name "MLB SlugFest 2003 (US).iso" size 1459978240 crc a1aab9d9 md5 a8beca930233f9ecc185e5b41bd84399 sha1 5d503f254e148073449c1c63b257caa84e4309d5 )
+)
+
+game (
+	name "MLB SlugFest 2003 (USA)"
+	description "MLB SlugFest 2003 (USA)"
+	rom ( name "MLB SlugFest 2003 (USA).iso" size 1459978240 crc a1aab9d9 md5 a8beca930233f9ecc185e5b41bd84399 sha1 5d503f254e148073449c1c63b257caa84e4309d5 )
+)
+
+game (
+	name "MLB SlugFest 2004 (US)"
+	description "MLB SlugFest 2004 (US)"
+	rom ( name "MLB SlugFest 2004 (US).iso" size 1459978240 crc 71c33ab7 md5 7fcf6fcc9c71bb5dc8ea4e6f31469abd sha1 f1422f2bb4f39eac915bf4411b99dedb3b8176a3 )
+)
+
+game (
+	name "MLB SlugFest 2004 (USA)"
+	description "MLB SlugFest 2004 (USA)"
+	rom ( name "MLB SlugFest 2004 (USA).iso" size 1459978240 crc 71c33ab7 md5 7fcf6fcc9c71bb5dc8ea4e6f31469abd sha1 f1422f2bb4f39eac915bf4411b99dedb3b8176a3 )
+)
+
+game (
+	name "Momotaro Dentetsu 11 - Black Bombee Shutsugen! no Kan (JP) - Tao Tai Lang Dian Tie 11:+buratukubonbiChu Xian !noJuan"
+	description "Momotaro Dentetsu 11 - Black Bombee Shutsugen! no Kan (JP) - Tao Tai Lang Dian Tie 11:+buratukubonbiChu Xian !noJuan"
+	rom ( name "Momotaro Dentetsu 11 - Black Bombee Shutsugen! no Kan (JP).iso" size 1459978240 crc 11aaa0d2 md5 9d9e62433a9e0d96d8209ced63a51602 sha1 9421acb0d07e5b912b3addf0dd1c7a7b17790198 )
+)
+
+game (
+	name "Momotaro Dentetsu 12 - Nishi Nihon hen mo Arimasse! (JP) - Tao Tai Lang Dian Tie 12:+Xi Ri Ben Bian moarimatuse!"
+	description "Momotaro Dentetsu 12 - Nishi Nihon hen mo Arimasse! (JP) - Tao Tai Lang Dian Tie 12:+Xi Ri Ben Bian moarimatuse!"
+	rom ( name "Momotaro Dentetsu 12 - Nishi Nihon hen mo Arimasse! (JP).iso" size 1459978240 crc e5bae879 md5 01e508cb2001e0b9faa4948160de6bd1 sha1 d76a154f751acf6204520ca32fab4336cb362e20 )
+)
+
+game (
+	name "Momotarou Dentetsu 11 - Black Bombee Shutsugen! no Kan (Japan)"
+	description "Momotarou Dentetsu 11 - Black Bombee Shutsugen! no Kan (Japan)"
+	rom ( name "Momotarou Dentetsu 11 - Black Bombee Shutsugen! no Kan (Japan).iso" size 1459978240 crc 11aaa0d2 md5 9d9e62433a9e0d96d8209ced63a51602 sha1 9421acb0d07e5b912b3addf0dd1c7a7b17790198 )
+)
+
+game (
+	name "Momotarou Dentetsu 12 - Nishi Nihon hen mo Arimasse! (Japan)"
+	description "Momotarou Dentetsu 12 - Nishi Nihon hen mo Arimasse! (Japan)"
+	rom ( name "Momotarou Dentetsu 12 - Nishi Nihon hen mo Arimasse! (Japan).iso" size 1459978240 crc e5bae879 md5 01e508cb2001e0b9faa4948160de6bd1 sha1 d76a154f751acf6204520ca32fab4336cb362e20 )
+)
+
+game (
+	name "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (FR)"
+	description "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (FR)"
+	rom ( name "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (FR).iso" size 1459978240 crc a2ac5b8a md5 47b65f51bd92a1f675120e332c232169 sha1 0a187961fe6ac3c1fc09bb4c148cc34befbcfc8d )
+)
+
+game (
+	name "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (France)"
+	description "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (France)"
+	rom ( name "Monde de Narnia, Le - Le Lion, la Sorciere et l'Armoire Magique (France).iso" size 1459978240 crc a2ac5b8a md5 47b65f51bd92a1f675120e332c232169 sha1 0a187961fe6ac3c1fc09bb4c148cc34befbcfc8d )
+)
+
+game (
+	name "Monopoly - Mezase!! Daifugou Jinsei!! (Japan)"
+	description "Monopoly - Mezase!! Daifugou Jinsei!! (Japan)"
+	rom ( name "Monopoly - Mezase!! Daifugou Jinsei!! (Japan).iso" size 1459978240 crc 2b31868c md5 8c36109e584f95f6af6fbab8b9147d65 sha1 435010851ee8aee92fcb124c7e48bbea8f12691c )
+)
+
+game (
+	name "Monopoly - Mezase!! Daifugou Jinsei!! (JP) - monopori+mezasetu!!+Da Fu Hao Ren Sheng !!"
+	description "Monopoly - Mezase!! Daifugou Jinsei!! (JP) - monopori+mezasetu!!+Da Fu Hao Ren Sheng !!"
+	rom ( name "Monopoly - Mezase!! Daifugou Jinsei!! (JP).iso" size 1459978240 crc 2b31868c md5 8c36109e584f95f6af6fbab8b9147d65 sha1 435010851ee8aee92fcb124c7e48bbea8f12691c )
+)
+
+game (
+	name "Monopoly Party (EU)"
+	description "Monopoly Party (EU)"
+	rom ( name "Monopoly Party (EU).iso" size 1459978240 crc 1be3d91c md5 a9e18b6dd8a171d727d895a47d7e7147 sha1 15870d3d7f415224d4a602e847e6c5308964a606 )
+)
+
+game (
+	name "Monopoly Party (Europe) (En,Fr,De,Es,It)"
+	description "Monopoly Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Monopoly Party (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1be3d91c md5 a9e18b6dd8a171d727d895a47d7e7147 sha1 15870d3d7f415224d4a602e847e6c5308964a606 )
+)
+
+game (
+	name "Monopoly Party (US)"
+	description "Monopoly Party (US)"
+	rom ( name "Monopoly Party (US).iso" size 1459978240 crc 62ca8da8 md5 2158401ff581e002d5436cdf857d0fa3 sha1 bb4ee851d8842430d5b7069a5bf40aa91b5ba436 )
+)
+
+game (
+	name "Monopoly Party (USA)"
+	description "Monopoly Party (USA)"
+	rom ( name "Monopoly Party (USA).iso" size 1459978240 crc 62ca8da8 md5 2158401ff581e002d5436cdf857d0fa3 sha1 bb4ee851d8842430d5b7069a5bf40aa91b5ba436 )
+)
+
+game (
+	name "Monster 4x4 - Masters of Metal (US)"
+	description "Monster 4x4 - Masters of Metal (US)"
+	rom ( name "Monster 4x4 - Masters of Metal (US).iso" size 1459978240 crc 4bf445bc md5 9e3d9b672d863d8055e0950f72a831f5 sha1 b9b2a6d54e1e158ab47d4a65fd65191a3bd88b5d )
+)
+
+game (
+	name "Monster 4x4 - Masters of Metal (USA)"
+	description "Monster 4x4 - Masters of Metal (USA)"
+	rom ( name "Monster 4x4 - Masters of Metal (USA).iso" size 1459978240 crc 4bf445bc md5 9e3d9b672d863d8055e0950f72a831f5 sha1 b9b2a6d54e1e158ab47d4a65fd65191a3bd88b5d )
+)
+
+game (
+	name "Monster House (EU)"
+	description "Monster House (EU)"
+	rom ( name "Monster House (EU).iso" size 1459978240 crc 7c687243 md5 acb470cfb7b8299f0e3ecefd6cd65893 sha1 5fd5930179e56d52cb0646868a75494904afc251 )
+)
+
+game (
+	name "Monster House (Europe)"
+	description "Monster House (Europe)"
+	rom ( name "Monster House (Europe).iso" size 1459978240 crc 1ad234df md5 3654d185f772cc2b9958b19239b39a8f sha1 54b7a72387b12e308ed7d47e3c619564cee761a8 )
+)
+
+game (
+	name "Monster House (Europe) (En,Fr,De,Es,It)"
+	description "Monster House (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Monster House (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7c687243 md5 acb470cfb7b8299f0e3ecefd6cd65893 sha1 5fd5930179e56d52cb0646868a75494904afc251 )
+)
+
+game (
+	name "Monster House (GB)"
+	description "Monster House (GB)"
+	rom ( name "Monster House (GB).iso" size 1459978240 crc 1ad234df md5 3654d185f772cc2b9958b19239b39a8f sha1 54b7a72387b12e308ed7d47e3c619564cee761a8 )
+)
+
+game (
+	name "Monster House (US)"
+	description "Monster House (US)"
+	rom ( name "Monster House (US).iso" size 1459978240 crc 135d4207 md5 1ee274ecf918ef7ec0cc677fb1635af5 sha1 9b9cc2a7b1c2f8526e4b0474814632431916230d )
+)
+
+game (
+	name "Monster House (USA) (En,Fr)"
+	description "Monster House (USA) (En,Fr)"
+	rom ( name "Monster House (USA) (En,Fr).iso" size 1459978240 crc 135d4207 md5 1ee274ecf918ef7ec0cc677fb1635af5 sha1 9b9cc2a7b1c2f8526e4b0474814632431916230d )
+)
+
+game (
+	name "Monster Jam - Maximum Destruction (EU)"
+	description "Monster Jam - Maximum Destruction (EU)"
+	rom ( name "Monster Jam - Maximum Destruction (EU).iso" size 1459978240 crc a60cc9b0 md5 4052c7b9baf85e3a72dfc279382b6bdb sha1 666b46af0c67932012e0c019c2ebf708da5fbfe6 )
+)
+
+game (
+	name "Monster Jam - Maximum Destruction (Europe)"
+	description "Monster Jam - Maximum Destruction (Europe)"
+	rom ( name "Monster Jam - Maximum Destruction (Europe).iso" size 1459978240 crc a60cc9b0 md5 4052c7b9baf85e3a72dfc279382b6bdb sha1 666b46af0c67932012e0c019c2ebf708da5fbfe6 )
+)
+
+game (
+	name "Monster Jam - Maximum Destruction (US)"
+	description "Monster Jam - Maximum Destruction (US)"
+	rom ( name "Monster Jam - Maximum Destruction (US).iso" size 1459978240 crc 5e022327 md5 a78314726ae7415e2ddccd9a53ebe79f sha1 57fcc43b8c74c6e631c701e59e2a5f27d120cf60 )
+)
+
+game (
+	name "Monster Jam - Maximum Destruction (USA)"
+	description "Monster Jam - Maximum Destruction (USA)"
+	rom ( name "Monster Jam - Maximum Destruction (USA).iso" size 1459978240 crc 5e022327 md5 a78314726ae7415e2ddccd9a53ebe79f sha1 57fcc43b8c74c6e631c701e59e2a5f27d120cf60 )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (DE)"
+	description "Mortal Kombat - Deadly Alliance (DE)"
+	rom ( name "Mortal Kombat - Deadly Alliance (DE).iso" size 1459978240 crc 6b8d9169 md5 c2ae14b33d9435f13762b83391c110f7 sha1 d8fd1cd073123c0d1c7ef5d27ec5c0fbf44c1ee2 )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (EU)"
+	description "Mortal Kombat - Deadly Alliance (EU)"
+	rom ( name "Mortal Kombat - Deadly Alliance (EU).iso" size 1459978240 crc ea7dbbbc md5 ee5e87edf64e42130580ff044673fbd0 sha1 af3a1db5c732049e7a6e25d5d1852014a92a8717 )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (Europe) (En,Fr,De,Es,It)"
+	description "Mortal Kombat - Deadly Alliance (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mortal Kombat - Deadly Alliance (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ea7dbbbc md5 ee5e87edf64e42130580ff044673fbd0 sha1 af3a1db5c732049e7a6e25d5d1852014a92a8717 )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (Germany) (En,Fr,De,Es,It)"
+	description "Mortal Kombat - Deadly Alliance (Germany) (En,Fr,De,Es,It)"
+	rom ( name "Mortal Kombat - Deadly Alliance (Germany) (En,Fr,De,Es,It).iso" size 1459978240 crc 6b8d9169 md5 c2ae14b33d9435f13762b83391c110f7 sha1 d8fd1cd073123c0d1c7ef5d27ec5c0fbf44c1ee2 )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (US)"
+	description "Mortal Kombat - Deadly Alliance (US)"
+	rom ( name "Mortal Kombat - Deadly Alliance (US).iso" size 1459978240 crc 5c380e32 md5 7b2a52d5d19fe179811c168aa2cc0875 sha1 1a1c84e8bc1a5ec1d8a6d3d3c7b6ff2ac6e3e95c )
+)
+
+game (
+	name "Mortal Kombat - Deadly Alliance (USA)"
+	description "Mortal Kombat - Deadly Alliance (USA)"
+	rom ( name "Mortal Kombat - Deadly Alliance (USA).iso" size 1459978240 crc 5c380e32 md5 7b2a52d5d19fe179811c168aa2cc0875 sha1 1a1c84e8bc1a5ec1d8a6d3d3c7b6ff2ac6e3e95c )
+)
+
+game (
+	name "Mortal Kombat - Deception (US)"
+	description "Mortal Kombat - Deception (US)"
+	rom ( name "Mortal Kombat - Deception (US).iso" size 1459978240 crc aa45d0b6 md5 bdef32ed1dcb85bc6da370fa5c2d949d sha1 489c6b57b70390933dff7d8d9d12424f58a8f821 )
+)
+
+game (
+	name "Mortal Kombat - Deception (USA)"
+	description "Mortal Kombat - Deception (USA)"
+	rom ( name "Mortal Kombat - Deception (USA).iso" size 1459978240 crc aa45d0b6 md5 bdef32ed1dcb85bc6da370fa5c2d949d sha1 489c6b57b70390933dff7d8d9d12424f58a8f821 )
+)
+
+game (
+	name "Mr. Driller - Drill Land (Japan)"
+	description "Mr. Driller - Drill Land (Japan)"
+	rom ( name "Mr. Driller - Drill Land (Japan).iso" size 1459978240 crc a643b38e md5 21a066f02b3f3e8e6367000bbde12188 sha1 f737e98e40cc94e1d3ad38df76746a8cefafa429 )
+)
+
+game (
+	name "Mr. Driller - Drill Land (JP) - misutadorira+dorirurando"
+	description "Mr. Driller - Drill Land (JP) - misutadorira+dorirurando"
+	rom ( name "Mr. Driller - Drill Land (JP).iso" size 1459978240 crc a643b38e md5 21a066f02b3f3e8e6367000bbde12188 sha1 f737e98e40cc94e1d3ad38df76746a8cefafa429 )
+)
+
+game (
+	name "Muppets - Party Cruise (US)"
+	description "Muppets - Party Cruise (US)"
+	rom ( name "Muppets - Party Cruise (US).iso" size 1459978240 crc 50c0281c md5 432e2a9e51ca71f5cf2b9e8e193ea4a0 sha1 76ea7c1b0a3e599becf4104bcaa3bd28c633054d )
+)
+
+game (
+	name "Muppets - Party Cruise (USA)"
+	description "Muppets - Party Cruise (USA)"
+	rom ( name "Muppets - Party Cruise (USA).iso" size 1459978240 crc 50c0281c md5 432e2a9e51ca71f5cf2b9e8e193ea4a0 sha1 76ea7c1b0a3e599becf4104bcaa3bd28c633054d )
+)
+
+game (
+	name "Muscle Champion - Kinnikutou no Kessen (Japan)"
+	description "Muscle Champion - Kinnikutou no Kessen (Japan)"
+	rom ( name "Muscle Champion - Kinnikutou no Kessen (Japan).iso" size 1459978240 crc ee359d36 md5 34810d5c723983a9298d51ab920f957f sha1 f174c1e05d9d9a678a95b405e22b8c0108a60faf )
+)
+
+game (
+	name "Muscle Champion - Kinnikutou no Kessen (JP) - matusurutiyanpiyon+Jin Rou Dao noJue Zhan"
+	description "Muscle Champion - Kinnikutou no Kessen (JP) - matusurutiyanpiyon+Jin Rou Dao noJue Zhan"
+	rom ( name "Muscle Champion - Kinnikutou no Kessen (JP).iso" size 1459978240 crc ee359d36 md5 34810d5c723983a9298d51ab920f957f sha1 f174c1e05d9d9a678a95b405e22b8c0108a60faf )
+)
+
+game (
+	name "Mutsu to Nohohon (Japan)"
+	description "Mutsu to Nohohon (Japan)"
+	rom ( name "Mutsu to Nohohon (Japan).iso" size 1459978240 crc d9bede37 md5 453762613fc1c014b52dd2224063c75b sha1 c7909624dca2d60d2b115db4fb54fdaf0bb04dc2 )
+)
+
+game (
+	name "Mutsu to Nohohon (JP) - MUTSU+tonohohon"
+	description "Mutsu to Nohohon (JP) - MUTSU+tonohohon"
+	rom ( name "Mutsu to Nohohon (JP).iso" size 1459978240 crc d9bede37 md5 453762613fc1c014b52dd2224063c75b sha1 c7909624dca2d60d2b115db4fb54fdaf0bb04dc2 )
+)
+
+game (
+	name "MVP Baseball 2004 (US)"
+	description "MVP Baseball 2004 (US)"
+	rom ( name "MVP Baseball 2004 (US).iso" size 1459978240 crc 24e7e406 md5 36a2c220c0ad4537b9c16670fb85ba8c sha1 853b634d2ca9842db85cdc6c5d081695650f13b8 )
+)
+
+game (
+	name "MVP Baseball 2004 (USA)"
+	description "MVP Baseball 2004 (USA)"
+	rom ( name "MVP Baseball 2004 (USA).iso" size 1459978240 crc 24e7e406 md5 36a2c220c0ad4537b9c16670fb85ba8c sha1 853b634d2ca9842db85cdc6c5d081695650f13b8 )
+)
+
+game (
+	name "MVP Baseball 2005 (US)"
+	description "MVP Baseball 2005 (US)"
+	rom ( name "MVP Baseball 2005 (US).iso" size 1459978240 crc 1906a04e md5 bde89e9178c2066e457c9c4b34935280 sha1 445a5f329aa340703a6e62723f73efc24fc71340 )
+)
+
+game (
+	name "MVP Baseball 2005 (USA)"
+	description "MVP Baseball 2005 (USA)"
+	rom ( name "MVP Baseball 2005 (USA).iso" size 1459978240 crc 1906a04e md5 bde89e9178c2066e457c9c4b34935280 sha1 445a5f329aa340703a6e62723f73efc24fc71340 )
+)
+
+game (
+	name "MX SuperFly (EU)"
+	description "MX SuperFly (EU)"
+	rom ( name "MX SuperFly (EU).iso" size 1459978240 crc e32d18d8 md5 99a777a7a0ef117925f97644f3785d20 sha1 b1f75a8a4b37e7698b10ab4872d318b596655195 )
+)
+
+game (
+	name "MX SuperFly (Europe)"
+	description "MX SuperFly (Europe)"
+	rom ( name "MX SuperFly (Europe).iso" size 1459978240 crc e32d18d8 md5 99a777a7a0ef117925f97644f3785d20 sha1 b1f75a8a4b37e7698b10ab4872d318b596655195 )
+)
+
+game (
+	name "MX SuperFly (USA)"
+	description "MX SuperFly (USA)"
+	rom ( name "MX SuperFly (USA).iso" size 1459978240 crc 94f77878 md5 cab7d9e495f15896e36027a96d3aa976 sha1 86bdd68b75865a4cd53350bcf4665713a5d8b760 )
+)
+
+game (
+	name "MX SuperFly featuring Ricky Carmichael (US)"
+	description "MX SuperFly featuring Ricky Carmichael (US)"
+	rom ( name "MX SuperFly featuring Ricky Carmichael (US).iso" size 1459978240 crc 94f77878 md5 cab7d9e495f15896e36027a96d3aa976 sha1 86bdd68b75865a4cd53350bcf4665713a5d8b760 )
+)
+
+game (
+	name "Mystic Heroes (DE)"
+	description "Mystic Heroes (DE)"
+	rom ( name "Mystic Heroes (DE).iso" size 1459978240 crc e737555b md5 87d643dbb4f3f1d199b90baa72a41bc7 sha1 99f56f1430f84309c56886a12b7634644cd1ccba )
+)
+
+game (
+	name "Mystic Heroes (EU)"
+	description "Mystic Heroes (EU)"
+	rom ( name "Mystic Heroes (EU).iso" size 1459978240 crc 68446d9d md5 cc49e5ba086345710b363cabe8e58592 sha1 3a83e2bde78ddc7e9d9803fecef609db4d3f4256 )
+)
+
+game (
+	name "Mystic Heroes (Europe)"
+	description "Mystic Heroes (Europe)"
+	rom ( name "Mystic Heroes (Europe).iso" size 1459978240 crc 68446d9d md5 cc49e5ba086345710b363cabe8e58592 sha1 3a83e2bde78ddc7e9d9803fecef609db4d3f4256 )
+)
+
+game (
+	name "Mystic Heroes (FR)"
+	description "Mystic Heroes (FR)"
+	rom ( name "Mystic Heroes (FR).iso" size 1459978240 crc b6bfb5bc md5 edf593cf07ff622ccb92c41323d905d1 sha1 a6f927e8a5a4f87907342772e891ff64cdae6cca )
+)
+
+game (
+	name "Mystic Heroes (France)"
+	description "Mystic Heroes (France)"
+	rom ( name "Mystic Heroes (France).iso" size 1459978240 crc b6bfb5bc md5 edf593cf07ff622ccb92c41323d905d1 sha1 a6f927e8a5a4f87907342772e891ff64cdae6cca )
+)
+
+game (
+	name "Mystic Heroes (Germany)"
+	description "Mystic Heroes (Germany)"
+	rom ( name "Mystic Heroes (Germany).iso" size 1459978240 crc e737555b md5 87d643dbb4f3f1d199b90baa72a41bc7 sha1 99f56f1430f84309c56886a12b7634644cd1ccba )
+)
+
+game (
+	name "Mystic Heroes (US)"
+	description "Mystic Heroes (US)"
+	rom ( name "Mystic Heroes (US).iso" size 1459978240 crc 080d3384 md5 30e9296bd2bca38e63e106930722660e sha1 e02fe0ebe68431be9fefdfddb5776f65cd1268ab )
+)
+
+game (
+	name "Mystic Heroes (USA)"
+	description "Mystic Heroes (USA)"
+	rom ( name "Mystic Heroes (USA).iso" size 1459978240 crc 080d3384 md5 30e9296bd2bca38e63e106930722660e sha1 e02fe0ebe68431be9fefdfddb5776f65cd1268ab )
+)
+
+game (
+	name "Namco Museum (US)"
+	description "Namco Museum (US)"
+	rom ( name "Namco Museum (US).iso" size 1459978240 crc 316232a1 md5 4d8c33d91ecc2256f107959f07c030ef sha1 37e1aa080fb79cf857ad76adf0a86bdbd011959b )
+)
+
+game (
+	name "Namco Museum (USA)"
+	description "Namco Museum (USA)"
+	rom ( name "Namco Museum (USA).iso" size 1459978240 crc 316232a1 md5 4d8c33d91ecc2256f107959f07c030ef sha1 37e1aa080fb79cf857ad76adf0a86bdbd011959b )
+)
+
+game (
+	name "Namco Museum 50th Anniversary (EU)"
+	description "Namco Museum 50th Anniversary (EU)"
+	rom ( name "Namco Museum 50th Anniversary (EU).iso" size 1459978240 crc 361fcd95 md5 2e354b89a06ba201c91161ecf9740e70 sha1 3ec88a7fed241122b76bf993bc9d03e0cef4b92f )
+)
+
+game (
+	name "Namco Museum 50th Anniversary (Europe) (En,Fr,De,Es,It)"
+	description "Namco Museum 50th Anniversary (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Namco Museum 50th Anniversary (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 361fcd95 md5 2e354b89a06ba201c91161ecf9740e70 sha1 3ec88a7fed241122b76bf993bc9d03e0cef4b92f )
+)
+
+game (
+	name "Namco Museum 50th Anniversary (US)"
+	description "Namco Museum 50th Anniversary (US)"
+	rom ( name "Namco Museum 50th Anniversary (US).iso" size 1459978240 crc db8a8831 md5 97fc6fdc7757f70678f8640917c28114 sha1 96052b07ac71cdb1ace7abe72a8eac6a3191eff7 )
+)
+
+game (
+	name "Namco Museum 50th Anniversary (USA)"
+	description "Namco Museum 50th Anniversary (USA)"
+	rom ( name "Namco Museum 50th Anniversary (USA).iso" size 1459978240 crc db8a8831 md5 97fc6fdc7757f70678f8640917c28114 sha1 96052b07ac71cdb1ace7abe72a8eac6a3191eff7 )
+)
+
+game (
+	name "Naruto - Clash of Ninja (EU)"
+	description "Naruto - Clash of Ninja (EU)"
+	rom ( name "Naruto - Clash of Ninja (EU).iso" size 1459978240 crc e8e1dcb8 md5 2b76e07ee007ce1674a197b20a0555fe sha1 e6c56a4083d77096f542066685b164fed9a84ee2 )
+)
+
+game (
+	name "Naruto - Clash of Ninja (Europe) (En,Fr,De,Es,It)"
+	description "Naruto - Clash of Ninja (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Naruto - Clash of Ninja (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e8e1dcb8 md5 2b76e07ee007ce1674a197b20a0555fe sha1 e6c56a4083d77096f542066685b164fed9a84ee2 )
+)
+
+game (
+	name "Naruto - Clash of Ninja (US)"
+	description "Naruto - Clash of Ninja (US)"
+	rom ( name "Naruto - Clash of Ninja (US).iso" size 1459978240 crc 6853771d md5 28cdd8c9eae1ebbbe8d11a8c91b366fd sha1 d805ce192324ad414de66c23b2222cd18c913f92 )
+)
+
+game (
+	name "Naruto - Clash of Ninja (USA)"
+	description "Naruto - Clash of Ninja (USA)"
+	rom ( name "Naruto - Clash of Ninja (USA).iso" size 1459978240 crc 6853771d md5 28cdd8c9eae1ebbbe8d11a8c91b366fd sha1 d805ce192324ad414de66c23b2222cd18c913f92 )
+)
+
+game (
+	name "Naruto - Clash of Ninja 2 (Demo) (US)"
+	description "Naruto - Clash of Ninja 2 (Demo) (US)"
+	rom ( name "Naruto - Clash of Ninja 2 (Demo) (US).iso" size 1459978240 crc a58b7bf7 md5 60ab975a509e8c71c48d078f1142689e sha1 6b53d6be8b52a2189143571ddaaf1a1789d866d1 )
+)
+
+game (
+	name "Naruto - Clash of Ninja 2 (US)"
+	description "Naruto - Clash of Ninja 2 (US)"
+	rom ( name "Naruto - Clash of Ninja 2 (US).iso" size 1459978240 crc 81a9f11d md5 1345ddb06467c7cc2c5c82d0d5e7b1d6 sha1 c5865c64b490862a7e1499db3622a07192eaa9ac )
+)
+
+game (
+	name "Naruto - Clash of Ninja 2 (USA)"
+	description "Naruto - Clash of Ninja 2 (USA)"
+	rom ( name "Naruto - Clash of Ninja 2 (USA).iso" size 1459978240 crc 81a9f11d md5 1345ddb06467c7cc2c5c82d0d5e7b1d6 sha1 c5865c64b490862a7e1499db3622a07192eaa9ac )
+)
+
+game (
+	name "Naruto - Clash of Ninja 2 (USA) (Demo)"
+	description "Naruto - Clash of Ninja 2 (USA) (Demo)"
+	rom ( name "Naruto - Clash of Ninja 2 (USA) (Demo).iso" size 1459978240 crc a58b7bf7 md5 60ab975a509e8c71c48d078f1142689e sha1 6b53d6be8b52a2189143571ddaaf1a1789d866d1 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! (Japan)"
+	description "Naruto - Gekitou Ninja Taisen! (Japan)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! (Japan).iso" size 1459978240 crc d4d66a59 md5 60984e9954be576fee160737c57c9f93 sha1 8803996c6bf5d737980f717dae61b1a3908784b4 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !"
+	description "Naruto - Gekitou Ninja Taisen! (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !"
+	rom ( name "Naruto - Gekitou Ninja Taisen! (JP).iso" size 1459978240 crc d4d66a59 md5 60984e9954be576fee160737c57c9f93 sha1 8803996c6bf5d737980f717dae61b1a3908784b4 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.00)"
+	description "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.00)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.00).iso" size 1459978240 crc 96c9fcb5 md5 f3d7ca2374c4e756a2680d8208016223 sha1 199a3a0741947ca2ea64cf8e7e14869a023e5cb2 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.01)"
+	description "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.01)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 2 (Japan) (v1.01).iso" size 1459978240 crc b49ec944 md5 fd3aa8640fdb9410d4d6cbac7c35c272 sha1 d4150ca736a64ca1c5e2ce2b096a4af7a614a2f9 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 2 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !2"
+	description "Naruto - Gekitou Ninja Taisen! 2 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !2"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 2 (JP) - [v1.00].iso" size 1459978240 crc 96c9fcb5 md5 f3d7ca2374c4e756a2680d8208016223 sha1 199a3a0741947ca2ea64cf8e7e14869a023e5cb2 )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.00)"
+	description "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.00)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.00).iso" size 1459978240 crc 102146fd md5 f65096558efa7a004cbbd215f9087e0e sha1 13cfe03840739dff23c37c129bb698ca6ce3a12b )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.01)"
+	description "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.01)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 3 (Japan) (v1.01).iso" size 1459978240 crc b1493f38 md5 fe115430566380f23768623f57ddafa0 sha1 23ed9f6499d772869d0fb411c8a24c584218182b )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 3 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !3"
+	description "Naruto - Gekitou Ninja Taisen! 3 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !3"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 3 (JP) - [v1.00].iso" size 1459978240 crc 102146fd md5 f65096558efa7a004cbbd215f9087e0e sha1 13cfe03840739dff23c37c129bb698ca6ce3a12b )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 4 (Japan)"
+	description "Naruto - Gekitou Ninja Taisen! 4 (Japan)"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 4 (Japan).iso" size 1459978240 crc 60aefa3e md5 20cdb87874ce4f2db4717fb43682e026 sha1 14ddb65699d885e3e7ebd0f728c3d44f0ec0332d )
+)
+
+game (
+	name "Naruto - Gekitou Ninja Taisen! 4 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !4"
+	description "Naruto - Gekitou Ninja Taisen! 4 (JP) - NARUTO-naruto-+Ji Dou Ren Zhe Da Zhan !4"
+	rom ( name "Naruto - Gekitou Ninja Taisen! 4 (JP).iso" size 1459978240 crc 60aefa3e md5 20cdb87874ce4f2db4717fb43682e026 sha1 14ddb65699d885e3e7ebd0f728c3d44f0ec0332d )
+)
+
+game (
+	name "Naruto Collection (Demo) (JP) - naruto+korekusiyon"
+	description "Naruto Collection (Demo) (JP) - naruto+korekusiyon"
+	rom ( name "Naruto Collection (Demo) (JP).iso" size 1459978240 crc 435e70ec md5 26b110b68039c43ddee1944c7de6ff23 sha1 d30391ef091eb5d11a5340564a4af0b684bbc3a8 )
+)
+
+game (
+	name "Naruto Collection (Japan) (Demo)"
+	description "Naruto Collection (Japan) (Demo)"
+	rom ( name "Naruto Collection (Japan) (Demo).iso" size 1459978240 crc 435e70ec md5 26b110b68039c43ddee1944c7de6ff23 sha1 d30391ef091eb5d11a5340564a4af0b684bbc3a8 )
+)
+
+game (
+	name "NASCAR - Dirt to Daytona (US)"
+	description "NASCAR - Dirt to Daytona (US)"
+	rom ( name "NASCAR - Dirt to Daytona (US).iso" size 1459978240 crc 700fdf19 md5 03983112d67c9e84d32b83935795d303 sha1 b72bd4d03ea271594e7b0c6705b96ee5eabb57a2 )
+)
+
+game (
+	name "NASCAR - Dirt to Daytona (USA)"
+	description "NASCAR - Dirt to Daytona (USA)"
+	rom ( name "NASCAR - Dirt to Daytona (USA).iso" size 1459978240 crc 700fdf19 md5 03983112d67c9e84d32b83935795d303 sha1 b72bd4d03ea271594e7b0c6705b96ee5eabb57a2 )
+)
+
+game (
+	name "NASCAR 2005 - Chase for the Cup (US)"
+	description "NASCAR 2005 - Chase for the Cup (US)"
+	rom ( name "NASCAR 2005 - Chase for the Cup (US).iso" size 1459978240 crc 59d346ef md5 f84f61616e2947daa43aecc27d57898d sha1 58dcc5a4bc19a6d7773ff9f3449657c6b800a821 )
+)
+
+game (
+	name "NASCAR 2005 - Chase for the Cup (USA)"
+	description "NASCAR 2005 - Chase for the Cup (USA)"
+	rom ( name "NASCAR 2005 - Chase for the Cup (USA).iso" size 1459978240 crc 59d346ef md5 f84f61616e2947daa43aecc27d57898d sha1 58dcc5a4bc19a6d7773ff9f3449657c6b800a821 )
+)
+
+game (
+	name "NASCAR Thunder 2003 (US)"
+	description "NASCAR Thunder 2003 (US)"
+	rom ( name "NASCAR Thunder 2003 (US).iso" size 1459978240 crc def6d55d md5 d1636dfea6881e01230e4d7265938ef4 sha1 c4c20cc8f638aa4bf7ddf6a184ec8c9d3abfb9cc )
+)
+
+game (
+	name "NASCAR Thunder 2003 (USA)"
+	description "NASCAR Thunder 2003 (USA)"
+	rom ( name "NASCAR Thunder 2003 (USA).iso" size 1459978240 crc def6d55d md5 d1636dfea6881e01230e4d7265938ef4 sha1 c4c20cc8f638aa4bf7ddf6a184ec8c9d3abfb9cc )
+)
+
+game (
+	name "NBA 2K2 (US)"
+	description "NBA 2K2 (US)"
+	rom ( name "NBA 2K2 (US).iso" size 1459978240 crc 099a0fc4 md5 f4a5df3326e5b394184cf721e2b88237 sha1 b642ae6ad49f9f929d4ac910010d4c8f7ef5cb8f )
+)
+
+game (
+	name "NBA 2K2 (USA)"
+	description "NBA 2K2 (USA)"
+	rom ( name "NBA 2K2 (USA).iso" size 1459978240 crc 099a0fc4 md5 f4a5df3326e5b394184cf721e2b88237 sha1 b642ae6ad49f9f929d4ac910010d4c8f7ef5cb8f )
+)
+
+game (
+	name "NBA 2K3 (EU)"
+	description "NBA 2K3 (EU)"
+	rom ( name "NBA 2K3 (EU).iso" size 1459978240 crc 14362ac2 md5 2b74d7c334c440062705ea325036bf06 sha1 c195d7457fd1503c61831eaf111760c3f0e3afb8 )
+)
+
+game (
+	name "NBA 2K3 (Europe)"
+	description "NBA 2K3 (Europe)"
+	rom ( name "NBA 2K3 (Europe).iso" size 1459978240 crc 14362ac2 md5 2b74d7c334c440062705ea325036bf06 sha1 c195d7457fd1503c61831eaf111760c3f0e3afb8 )
+)
+
+game (
+	name "NBA 2K3 (US)"
+	description "NBA 2K3 (US)"
+	rom ( name "NBA 2K3 (US).iso" size 1459978240 crc 89df66d0 md5 f030b9c24bfacad63a1539a2ff5bf4b0 sha1 9b842fc34bd640645481cdb5f625d707daec8c02 )
+)
+
+game (
+	name "NBA 2K3 (USA)"
+	description "NBA 2K3 (USA)"
+	rom ( name "NBA 2K3 (USA).iso" size 1459978240 crc 89df66d0 md5 f030b9c24bfacad63a1539a2ff5bf4b0 sha1 9b842fc34bd640645481cdb5f625d707daec8c02 )
+)
+
+game (
+	name "NBA Courtside 2002 (EU)"
+	description "NBA Courtside 2002 (EU)"
+	rom ( name "NBA Courtside 2002 (EU).iso" size 1459978240 crc 58ef59fd md5 3660a90e46ce81f83d4c6218c121bc02 sha1 dd0c2b22e8b2d847ff74a8438550c00d6d1ea07a )
+)
+
+game (
+	name "NBA Courtside 2002 (Europe)"
+	description "NBA Courtside 2002 (Europe)"
+	rom ( name "NBA Courtside 2002 (Europe).iso" size 1459978240 crc 58ef59fd md5 3660a90e46ce81f83d4c6218c121bc02 sha1 dd0c2b22e8b2d847ff74a8438550c00d6d1ea07a )
+)
+
+game (
+	name "NBA Courtside 2002 (Japan)"
+	description "NBA Courtside 2002 (Japan)"
+	rom ( name "NBA Courtside 2002 (Japan).iso" size 1459978240 crc 3b0d9c54 md5 548961672448b0c3fc171ec92894e53b sha1 9f90ab2133fdfe3c3ad1cbb1fc9269698cc05bbb )
+)
+
+game (
+	name "NBA Courtside 2002 (JP) - NBA+kotosaido+2002"
+	description "NBA Courtside 2002 (JP) - NBA+kotosaido+2002"
+	rom ( name "NBA Courtside 2002 (JP).iso" size 1459978240 crc 3b0d9c54 md5 548961672448b0c3fc171ec92894e53b sha1 9f90ab2133fdfe3c3ad1cbb1fc9269698cc05bbb )
+)
+
+game (
+	name "NBA Courtside 2002 (US)"
+	description "NBA Courtside 2002 (US)"
+	rom ( name "NBA Courtside 2002 (US).iso" size 1459978240 crc ed55d776 md5 a44981f541acfe09945b6946f05a282e sha1 cf2852ca7aa9b277acf6a7d82493b2844b958902 )
+)
+
+game (
+	name "NBA Courtside 2002 (USA)"
+	description "NBA Courtside 2002 (USA)"
+	rom ( name "NBA Courtside 2002 (USA).iso" size 1459978240 crc ed55d776 md5 a44981f541acfe09945b6946f05a282e sha1 cf2852ca7aa9b277acf6a7d82493b2844b958902 )
+)
+
+game (
+	name "NBA Live 06 (EU)"
+	description "NBA Live 06 (EU)"
+	rom ( name "NBA Live 06 (EU).iso" size 1459978240 crc ba493c66 md5 6ca8d48e4979b78938e6dd0f3b0f92f9 sha1 5cec1e16104faba26aecbd916f1893e08580907d )
+)
+
+game (
+	name "NBA Live 06 (Europe) (En,Fr)"
+	description "NBA Live 06 (Europe) (En,Fr)"
+	rom ( name "NBA Live 06 (Europe) (En,Fr).iso" size 1459978240 crc ba493c66 md5 6ca8d48e4979b78938e6dd0f3b0f92f9 sha1 5cec1e16104faba26aecbd916f1893e08580907d )
+)
+
+game (
+	name "NBA Live 06 (US)"
+	description "NBA Live 06 (US)"
+	rom ( name "NBA Live 06 (US).iso" size 1459978240 crc 545fdf09 md5 ac9121a54a70d8fe730aef477d571790 sha1 943709a91f52641abea6d2872f48fb6809675b5c )
+)
+
+game (
+	name "NBA Live 06 (USA)"
+	description "NBA Live 06 (USA)"
+	rom ( name "NBA Live 06 (USA).iso" size 1459978240 crc 545fdf09 md5 ac9121a54a70d8fe730aef477d571790 sha1 943709a91f52641abea6d2872f48fb6809675b5c )
+)
+
+game (
+	name "NBA Live 2003 (EU)"
+	description "NBA Live 2003 (EU)"
+	rom ( name "NBA Live 2003 (EU).iso" size 1459978240 crc 3bae0ba4 md5 c32ce3fcc22e5c2c61616d95e77d6b85 sha1 be3dc74a2bb565b60198d32151be1f2e9dc7ca3f )
+)
+
+game (
+	name "NBA Live 2003 (Europe) (En,Fr,De,Es,It)"
+	description "NBA Live 2003 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "NBA Live 2003 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3bae0ba4 md5 c32ce3fcc22e5c2c61616d95e77d6b85 sha1 be3dc74a2bb565b60198d32151be1f2e9dc7ca3f )
+)
+
+game (
+	name "NBA Live 2003 (US)"
+	description "NBA Live 2003 (US)"
+	rom ( name "NBA Live 2003 (US).iso" size 1459978240 crc 901baa7d md5 09464d7290bba3b6d83c1f49ae0b06a9 sha1 2eb42f61fb1eaf8adca1d5b69cca6533ca3d6679 )
+)
+
+game (
+	name "NBA Live 2003 (USA)"
+	description "NBA Live 2003 (USA)"
+	rom ( name "NBA Live 2003 (USA).iso" size 1459978240 crc 901baa7d md5 09464d7290bba3b6d83c1f49ae0b06a9 sha1 2eb42f61fb1eaf8adca1d5b69cca6533ca3d6679 )
+)
+
+game (
+	name "NBA Live 2004 (EU)"
+	description "NBA Live 2004 (EU)"
+	rom ( name "NBA Live 2004 (EU).iso" size 1459978240 crc 1f937a8e md5 712f0698da9775ba5a199248c2fb9b13 sha1 1eb8711b7793cedfbdfce6672d02621cf0a55d68 )
+)
+
+game (
+	name "NBA Live 2004 (Europe) (En,Fr,De,Es,It)"
+	description "NBA Live 2004 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "NBA Live 2004 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1f937a8e md5 712f0698da9775ba5a199248c2fb9b13 sha1 1eb8711b7793cedfbdfce6672d02621cf0a55d68 )
+)
+
+game (
+	name "NBA Live 2004 (US)"
+	description "NBA Live 2004 (US)"
+	rom ( name "NBA Live 2004 (US).iso" size 1459978240 crc 06eeb2e0 md5 69da3a3801f4bc736a75429d80f730b6 sha1 9893783a5c95b8d243cc6a8ef658a892831bba01 )
+)
+
+game (
+	name "NBA Live 2004 (USA)"
+	description "NBA Live 2004 (USA)"
+	rom ( name "NBA Live 2004 (USA).iso" size 1459978240 crc 06eeb2e0 md5 69da3a3801f4bc736a75429d80f730b6 sha1 9893783a5c95b8d243cc6a8ef658a892831bba01 )
+)
+
+game (
+	name "NBA Live 2005 (EU)"
+	description "NBA Live 2005 (EU)"
+	rom ( name "NBA Live 2005 (EU).iso" size 1459978240 crc d3d92020 md5 bf9d5bce884cc12e402e6b2a6f1aba21 sha1 310fdfcb4b0d788c269559c318544d32b5fa2afb )
+)
+
+game (
+	name "NBA Live 2005 (Europe) (En,Fr)"
+	description "NBA Live 2005 (Europe) (En,Fr)"
+	rom ( name "NBA Live 2005 (Europe) (En,Fr).iso" size 1459978240 crc d3d92020 md5 bf9d5bce884cc12e402e6b2a6f1aba21 sha1 310fdfcb4b0d788c269559c318544d32b5fa2afb )
+)
+
+game (
+	name "NBA Live 2005 (US)"
+	description "NBA Live 2005 (US)"
+	rom ( name "NBA Live 2005 (US).iso" size 1459978240 crc f2ece8e7 md5 a7eb69f4d502f3d687b6194d98b348cf sha1 215ad9b6f02213536fbc9503036e4335efd282c6 )
+)
+
+game (
+	name "NBA Live 2005 (USA)"
+	description "NBA Live 2005 (USA)"
+	rom ( name "NBA Live 2005 (USA).iso" size 1459978240 crc f2ece8e7 md5 a7eb69f4d502f3d687b6194d98b348cf sha1 215ad9b6f02213536fbc9503036e4335efd282c6 )
+)
+
+game (
+	name "NBA Street (Japan)"
+	description "NBA Street (Japan)"
+	rom ( name "NBA Street (Japan).iso" size 1459978240 crc 7d074b15 md5 1278439a5224bf8abfe17930db78e1c9 sha1 29b4b928a54a99e5baabe00b0a549ee0ae8e7a87 )
+)
+
+game (
+	name "NBA Street (JP) - NBA+sutorito"
+	description "NBA Street (JP) - NBA+sutorito"
+	rom ( name "NBA Street (JP).iso" size 1459978240 crc 7d074b15 md5 1278439a5224bf8abfe17930db78e1c9 sha1 29b4b928a54a99e5baabe00b0a549ee0ae8e7a87 )
+)
+
+game (
+	name "NBA Street (US)"
+	description "NBA Street (US)"
+	rom ( name "NBA Street (US).iso" size 1459978240 crc dc7a2da4 md5 cf24de778cb8e400d57513124eb6653a sha1 84314b26365d3e8894bf0d0a8500ded618196ab1 )
+)
+
+game (
+	name "NBA Street (USA)"
+	description "NBA Street (USA)"
+	rom ( name "NBA Street (USA).iso" size 1459978240 crc dc7a2da4 md5 cf24de778cb8e400d57513124eb6653a sha1 84314b26365d3e8894bf0d0a8500ded618196ab1 )
+)
+
+game (
+	name "NBA Street V3 - Mario de Dunk (Japan)"
+	description "NBA Street V3 - Mario de Dunk (Japan)"
+	rom ( name "NBA Street V3 - Mario de Dunk (Japan).iso" size 1459978240 crc 9f4dcbdd md5 f1465c20c9d8c431dad348c9e9c16841 sha1 bbe2066f093916bfde725d9e2fb318b492fb2f7a )
+)
+
+game (
+	name "NBA Street V3 - Mario de Dunk (JP) - NBAsutoritoV3+mariodedanku"
+	description "NBA Street V3 - Mario de Dunk (JP) - NBAsutoritoV3+mariodedanku"
+	rom ( name "NBA Street V3 - Mario de Dunk (JP).iso" size 1459978240 crc 9f4dcbdd md5 f1465c20c9d8c431dad348c9e9c16841 sha1 bbe2066f093916bfde725d9e2fb318b492fb2f7a )
+)
+
+game (
+	name "NBA Street V3 (EU)"
+	description "NBA Street V3 (EU)"
+	rom ( name "NBA Street V3 (EU).iso" size 1459978240 crc 42be441b md5 4ddeaa137d88f67de1099c938d082751 sha1 66b3b332e99cd1662ee5a54707a9e4e2c13439cd )
+)
+
+game (
+	name "NBA Street V3 (Europe) (En,Fr,De)"
+	description "NBA Street V3 (Europe) (En,Fr,De)"
+	rom ( name "NBA Street V3 (Europe) (En,Fr,De).iso" size 1459978240 crc 42be441b md5 4ddeaa137d88f67de1099c938d082751 sha1 66b3b332e99cd1662ee5a54707a9e4e2c13439cd )
+)
+
+game (
+	name "NBA Street V3 (US)"
+	description "NBA Street V3 (US)"
+	rom ( name "NBA Street V3 (US).iso" size 1459978240 crc 8a0e96cb md5 2da7d788886a972420a08faf5fa04632 sha1 5474b36795484e18d26c7120ef431613bdde0d29 )
+)
+
+game (
+	name "NBA Street V3 (USA)"
+	description "NBA Street V3 (USA)"
+	rom ( name "NBA Street V3 (USA).iso" size 1459978240 crc 8a0e96cb md5 2da7d788886a972420a08faf5fa04632 sha1 5474b36795484e18d26c7120ef431613bdde0d29 )
+)
+
+game (
+	name "NBA Street Vol. 2 (EU)"
+	description "NBA Street Vol. 2 (EU)"
+	rom ( name "NBA Street Vol. 2 (EU).iso" size 1459978240 crc 48bca6cc md5 d1a5a64826ef87eddb18a9a0523cfd30 sha1 a5a2f912ac4919487d3451276bcce5c068839cba )
+)
+
+game (
+	name "NBA Street Vol. 2 (Europe) (En,Fr)"
+	description "NBA Street Vol. 2 (Europe) (En,Fr)"
+	rom ( name "NBA Street Vol. 2 (Europe) (En,Fr).iso" size 1459978240 crc 48bca6cc md5 d1a5a64826ef87eddb18a9a0523cfd30 sha1 a5a2f912ac4919487d3451276bcce5c068839cba )
+)
+
+game (
+	name "NBA Street Vol. 2 (US)"
+	description "NBA Street Vol. 2 (US)"
+	rom ( name "NBA Street Vol. 2 (US).iso" size 1459978240 crc c099c71e md5 a575f3dbeff9da2e3eb87d371a497d70 sha1 58f504bc4ca750f2a84d110e3a1ed65aab374270 )
+)
+
+game (
+	name "NBA Street Vol. 2 (USA)"
+	description "NBA Street Vol. 2 (USA)"
+	rom ( name "NBA Street Vol. 2 (USA).iso" size 1459978240 crc c099c71e md5 a575f3dbeff9da2e3eb87d371a497d70 sha1 58f504bc4ca750f2a84d110e3a1ed65aab374270 )
+)
+
+game (
+	name "NCAA College Basketball 2K3 (US)"
+	description "NCAA College Basketball 2K3 (US)"
+	rom ( name "NCAA College Basketball 2K3 (US).iso" size 1459978240 crc 561d5e32 md5 fec56edcd474fc7f1f0627710d2c878d sha1 1651fc666119118d6bb37e3279d4ae56a18c9a95 )
+)
+
+game (
+	name "NCAA College Basketball 2K3 (USA)"
+	description "NCAA College Basketball 2K3 (USA)"
+	rom ( name "NCAA College Basketball 2K3 (USA).iso" size 1459978240 crc 561d5e32 md5 fec56edcd474fc7f1f0627710d2c878d sha1 1651fc666119118d6bb37e3279d4ae56a18c9a95 )
+)
+
+game (
+	name "NCAA College Football 2K3 (US)"
+	description "NCAA College Football 2K3 (US)"
+	rom ( name "NCAA College Football 2K3 (US).iso" size 1459978240 crc 024f098d md5 a267e1b627497cd8270551114a63c78b sha1 f4475e1fb86243615a218608f88d823675d9fe7e )
+)
+
+game (
+	name "NCAA College Football 2K3 (USA)"
+	description "NCAA College Football 2K3 (USA)"
+	rom ( name "NCAA College Football 2K3 (USA).iso" size 1459978240 crc 024f098d md5 a267e1b627497cd8270551114a63c78b sha1 f4475e1fb86243615a218608f88d823675d9fe7e )
+)
+
+game (
+	name "NCAA Football 2003 (US)"
+	description "NCAA Football 2003 (US)"
+	rom ( name "NCAA Football 2003 (US).iso" size 1459978240 crc 78433638 md5 ed722ecf2fdf7e0c5d4dd3190eb905e4 sha1 7d7b0c4187397103a15d043c03294412630f5d46 )
+)
+
+game (
+	name "NCAA Football 2003 (USA)"
+	description "NCAA Football 2003 (USA)"
+	rom ( name "NCAA Football 2003 (USA).iso" size 1459978240 crc 78433638 md5 ed722ecf2fdf7e0c5d4dd3190eb905e4 sha1 7d7b0c4187397103a15d043c03294412630f5d46 )
+)
+
+game (
+	name "NCAA Football 2004 (US)"
+	description "NCAA Football 2004 (US)"
+	rom ( name "NCAA Football 2004 (US).iso" size 1459978240 crc 87edc790 md5 1065eec6fec91e81d93ceeb05a90673e sha1 42d2ec1860010153434b9f90e41a201cc19d25d0 )
+)
+
+game (
+	name "NCAA Football 2004 (USA)"
+	description "NCAA Football 2004 (USA)"
+	rom ( name "NCAA Football 2004 (USA).iso" size 1459978240 crc 87edc790 md5 1065eec6fec91e81d93ceeb05a90673e sha1 42d2ec1860010153434b9f90e41a201cc19d25d0 )
+)
+
+game (
+	name "NCAA Football 2005 (US)"
+	description "NCAA Football 2005 (US)"
+	rom ( name "NCAA Football 2005 (US).iso" size 1459978240 crc 2d24164c md5 a5046f1bfa86702bf3ae78ff763d2334 sha1 2c6e1bcab1e933891f5753199c9fed5b626a0b3e )
+)
+
+game (
+	name "NCAA Football 2005 (USA)"
+	description "NCAA Football 2005 (USA)"
+	rom ( name "NCAA Football 2005 (USA).iso" size 1459978240 crc 2d24164c md5 a5046f1bfa86702bf3ae78ff763d2334 sha1 2c6e1bcab1e933891f5753199c9fed5b626a0b3e )
+)
+
+game (
+	name "Need for Speed - Carbon (DE)"
+	description "Need for Speed - Carbon (DE)"
+	rom ( name "Need for Speed - Carbon (DE).iso" size 1459978240 crc fd7813ff md5 6446175d09f065c84d4919450178fd44 sha1 3b414e7c0a01a156910537d61823d46aa34fee3c )
+)
+
+game (
+	name "Need for Speed - Carbon (Europe)"
+	description "Need for Speed - Carbon (Europe)"
+	rom ( name "Need for Speed - Carbon (Europe).iso" size 1459978240 crc 00052f80 md5 d1ae4bebadc01c4ca1dde6d100e3dedb sha1 a732a02abba8bd9109bc84bc8d0f047644a24597 )
+)
+
+game (
+	name "Need for Speed - Carbon (FR)"
+	description "Need for Speed - Carbon (FR)"
+	rom ( name "Need for Speed - Carbon (FR).iso" size 1459978240 crc 582270b0 md5 c12c489ba30b4a02ff9ae44bc8337b5a sha1 cd0fe2586fd5c450e694cf2572eee2b5e925a54a )
+)
+
+game (
+	name "Need for Speed - Carbon (France)"
+	description "Need for Speed - Carbon (France)"
+	rom ( name "Need for Speed - Carbon (France).iso" size 1459978240 crc 582270b0 md5 c12c489ba30b4a02ff9ae44bc8337b5a sha1 cd0fe2586fd5c450e694cf2572eee2b5e925a54a )
+)
+
+game (
+	name "Need for Speed - Carbon (GB)"
+	description "Need for Speed - Carbon (GB)"
+	rom ( name "Need for Speed - Carbon (GB).iso" size 1459978240 crc 00052f80 md5 d1ae4bebadc01c4ca1dde6d100e3dedb sha1 a732a02abba8bd9109bc84bc8d0f047644a24597 )
+)
+
+game (
+	name "Need for Speed - Carbon (Germany)"
+	description "Need for Speed - Carbon (Germany)"
+	rom ( name "Need for Speed - Carbon (Germany).iso" size 1459978240 crc fd7813ff md5 6446175d09f065c84d4919450178fd44 sha1 3b414e7c0a01a156910537d61823d46aa34fee3c )
+)
+
+game (
+	name "Need for Speed - Carbon (US)"
+	description "Need for Speed - Carbon (US)"
+	rom ( name "Need for Speed - Carbon (US).iso" size 1459978240 crc ff139c62 md5 e9ecacbd68a425337be47944b7ea6b87 sha1 0dcbcada6cdfa50a026327785a86376e1059f5d9 )
+)
+
+game (
+	name "Need for Speed - Carbon (USA)"
+	description "Need for Speed - Carbon (USA)"
+	rom ( name "Need for Speed - Carbon (USA).iso" size 1459978240 crc ff139c62 md5 e9ecacbd68a425337be47944b7ea6b87 sha1 0dcbcada6cdfa50a026327785a86376e1059f5d9 )
+)
+
+game (
+	name "Need for Speed - Hot Pursuit 2 (EU)"
+	description "Need for Speed - Hot Pursuit 2 (EU)"
+	rom ( name "Need for Speed - Hot Pursuit 2 (EU).iso" size 1459978240 crc 39fe6d58 md5 11b6dfe2d930485917f7ac69d9d449c5 sha1 10b0dd40e9cee2c3ee3cba002018623d8d8a9242 )
+)
+
+game (
+	name "Need for Speed - Hot Pursuit 2 (Europe) (En,Fr,De)"
+	description "Need for Speed - Hot Pursuit 2 (Europe) (En,Fr,De)"
+	rom ( name "Need for Speed - Hot Pursuit 2 (Europe) (En,Fr,De).iso" size 1459978240 crc 39fe6d58 md5 11b6dfe2d930485917f7ac69d9d449c5 sha1 10b0dd40e9cee2c3ee3cba002018623d8d8a9242 )
+)
+
+game (
+	name "Need for Speed - Hot Pursuit 2 (US)"
+	description "Need for Speed - Hot Pursuit 2 (US)"
+	rom ( name "Need for Speed - Hot Pursuit 2 (US).iso" size 1459978240 crc 6e9f4afe md5 f12d73674be53affb0a87a9e48e101e8 sha1 196f068f33ca03489ebb45d249753bd29f61f29e )
+)
+
+game (
+	name "Need for Speed - Hot Pursuit 2 (USA)"
+	description "Need for Speed - Hot Pursuit 2 (USA)"
+	rom ( name "Need for Speed - Hot Pursuit 2 (USA).iso" size 1459978240 crc 6e9f4afe md5 f12d73674be53affb0a87a9e48e101e8 sha1 196f068f33ca03489ebb45d249753bd29f61f29e )
+)
+
+game (
+	name "Need for Speed - Most Wanted (DE)"
+	description "Need for Speed - Most Wanted (DE)"
+	rom ( name "Need for Speed - Most Wanted (DE).iso" size 1459978240 crc fc0c00e1 md5 f2246e483f25cd3c1d325a9240497c6d sha1 01d0ab9a91cc1adea2726afb25ae19c969ad765e )
+)
+
+game (
+	name "Need for Speed - Most Wanted (EU)"
+	description "Need for Speed - Most Wanted (EU)"
+	rom ( name "Need for Speed - Most Wanted (EU).iso" size 1459978240 crc 9713eec0 md5 b8c865d5b6a440fba1e55850bd1f66c8 sha1 0ddb88b8ae7412100a5e98fe36f022997c4258e5 )
+)
+
+game (
+	name "Need for Speed - Most Wanted (Europe)"
+	description "Need for Speed - Most Wanted (Europe)"
+	rom ( name "Need for Speed - Most Wanted (Europe).iso" size 1459978240 crc 9713eec0 md5 b8c865d5b6a440fba1e55850bd1f66c8 sha1 0ddb88b8ae7412100a5e98fe36f022997c4258e5 )
+)
+
+game (
+	name "Need for Speed - Most Wanted (FR)"
+	description "Need for Speed - Most Wanted (FR)"
+	rom ( name "Need for Speed - Most Wanted (FR).iso" size 1459978240 crc 37196f5a md5 2c945df089d7967e1f5eb13d1c40f43a sha1 9fc63840b422f5a3e83c1c92c04951a77480c8fc )
+)
+
+game (
+	name "Need for Speed - Most Wanted (France)"
+	description "Need for Speed - Most Wanted (France)"
+	rom ( name "Need for Speed - Most Wanted (France).iso" size 1459978240 crc 37196f5a md5 2c945df089d7967e1f5eb13d1c40f43a sha1 9fc63840b422f5a3e83c1c92c04951a77480c8fc )
+)
+
+game (
+	name "Need for Speed - Most Wanted (Germany)"
+	description "Need for Speed - Most Wanted (Germany)"
+	rom ( name "Need for Speed - Most Wanted (Germany).iso" size 1459978240 crc fc0c00e1 md5 f2246e483f25cd3c1d325a9240497c6d sha1 01d0ab9a91cc1adea2726afb25ae19c969ad765e )
+)
+
+game (
+	name "Need for Speed - Most Wanted (Japan)"
+	description "Need for Speed - Most Wanted (Japan)"
+	rom ( name "Need for Speed - Most Wanted (Japan).iso" size 1459978240 crc 538a5ed9 md5 10adf7ad68c62a0cc76aeb3412461bd5 sha1 82d566de225a0de1e46db4e6761c91337f1439fc )
+)
+
+game (
+	name "Need for Speed - Most Wanted (JP) - nidohuosupido+mosutouontetudo"
+	description "Need for Speed - Most Wanted (JP) - nidohuosupido+mosutouontetudo"
+	rom ( name "Need for Speed - Most Wanted (JP).iso" size 1459978240 crc 538a5ed9 md5 10adf7ad68c62a0cc76aeb3412461bd5 sha1 82d566de225a0de1e46db4e6761c91337f1439fc )
+)
+
+game (
+	name "Need for Speed - Most Wanted (US)"
+	description "Need for Speed - Most Wanted (US)"
+	rom ( name "Need for Speed - Most Wanted (US).iso" size 1459978240 crc d9f1d3e5 md5 ccae1994b8ab098ff427e6ef95ea7909 sha1 8cfef78c00835c572523663e30a11c34ef3758b7 )
+)
+
+game (
+	name "Need for Speed - Most Wanted (USA)"
+	description "Need for Speed - Most Wanted (USA)"
+	rom ( name "Need for Speed - Most Wanted (USA).iso" size 1459978240 crc d9f1d3e5 md5 ccae1994b8ab098ff427e6ef95ea7909 sha1 8cfef78c00835c572523663e30a11c34ef3758b7 )
+)
+
+game (
+	name "Need for Speed - Underground (DE)"
+	description "Need for Speed - Underground (DE)"
+	rom ( name "Need for Speed - Underground (DE).iso" size 1459978240 crc 89160c7c md5 e80ab06493365fca7e400d4c87e778d6 sha1 65f646bd48de53ebdeb14ce261b2e3a15534cd1e )
+)
+
+game (
+	name "Need for Speed - Underground (Europe)"
+	description "Need for Speed - Underground (Europe)"
+	rom ( name "Need for Speed - Underground (Europe).iso" size 1459978240 crc 4584dc3b md5 4ee3b6c5d66cc088c8b82baf8c02eae5 sha1 a3c0c830a015d167900757148030f69b867efc31 )
+)
+
+game (
+	name "Need for Speed - Underground (Europe) (Alt)"
+	description "Need for Speed - Underground (Europe) (Alt)"
+	rom ( name "Need for Speed - Underground (Europe) (Alt).iso" size 1459978240 crc 3873b78f md5 bb87941bef76e658dff90d98b6a1e6a2 sha1 798c8e855cdf883ca2f00558e18439155fb08815 )
+)
+
+game (
+	name "Need for Speed - Underground (FR)"
+	description "Need for Speed - Underground (FR)"
+	rom ( name "Need for Speed - Underground (FR).iso" size 1459978240 crc 1952782e md5 bb44feab0886e3da4070d4d55611fedf sha1 bd87e25d36a9a8a3d23380aaa533c0ea8b3824e6 )
+)
+
+game (
+	name "Need for Speed - Underground (France)"
+	description "Need for Speed - Underground (France)"
+	rom ( name "Need for Speed - Underground (France).iso" size 1459978240 crc 1952782e md5 bb44feab0886e3da4070d4d55611fedf sha1 bd87e25d36a9a8a3d23380aaa533c0ea8b3824e6 )
+)
+
+game (
+	name "Need for Speed - Underground (Germany)"
+	description "Need for Speed - Underground (Germany)"
+	rom ( name "Need for Speed - Underground (Germany).iso" size 1459978240 crc 89160c7c md5 e80ab06493365fca7e400d4c87e778d6 sha1 65f646bd48de53ebdeb14ce261b2e3a15534cd1e )
+)
+
+game (
+	name "Need for Speed - Underground (Japan)"
+	description "Need for Speed - Underground (Japan)"
+	rom ( name "Need for Speed - Underground (Japan).iso" size 1459978240 crc 836cfeda md5 0bbec5772993666a3d4a235aaa63cf12 sha1 a6be9b697d06a3dc12b0b88b466a247233ce176e )
+)
+
+game (
+	name "Need for Speed - Underground (JP) - nidohuosupido ~andaguraundo~"
+	description "Need for Speed - Underground (JP) - nidohuosupido ~andaguraundo~"
+	rom ( name "Need for Speed - Underground (JP).iso" size 1459978240 crc 836cfeda md5 0bbec5772993666a3d4a235aaa63cf12 sha1 a6be9b697d06a3dc12b0b88b466a247233ce176e )
+)
+
+game (
+	name "Need for Speed - Underground (Original) (GB)"
+	description "Need for Speed - Underground (Original) (GB)"
+	rom ( name "Need for Speed - Underground (Original) (GB).iso" size 1459978240 crc 4584dc3b md5 4ee3b6c5d66cc088c8b82baf8c02eae5 sha1 a3c0c830a015d167900757148030f69b867efc31 )
+)
+
+game (
+	name "Need for Speed - Underground (Player's Choice) (GB)"
+	description "Need for Speed - Underground (Player's Choice) (GB)"
+	rom ( name "Need for Speed - Underground (Player's Choice) (GB).iso" size 1459978240 crc 3873b78f md5 bb87941bef76e658dff90d98b6a1e6a2 sha1 798c8e855cdf883ca2f00558e18439155fb08815 )
+)
+
+game (
+	name "Need for Speed - Underground (Player's Choice) (US)"
+	description "Need for Speed - Underground (Player's Choice) (US)"
+	rom ( name "Need for Speed - Underground (Player's Choice) (US).iso" size 1459978240 crc 01c154ba md5 c20f02454166bc8fa08f84307871ac7d sha1 d6882a712509e8bba75ee8837bcac65f8352b1d1 )
+)
+
+game (
+	name "Need for Speed - Underground (USA)"
+	description "Need for Speed - Underground (USA)"
+	rom ( name "Need for Speed - Underground (USA).iso" size 1459978240 crc 01c154ba md5 c20f02454166bc8fa08f84307871ac7d sha1 d6882a712509e8bba75ee8837bcac65f8352b1d1 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (DE)"
+	description "Need for Speed - Underground 2 (DE)"
+	rom ( name "Need for Speed - Underground 2 (DE).iso" size 1459978240 crc 83b3c758 md5 89c3c4148a5ae00db23fc68834d9ea84 sha1 831eee2df2899f7e0d91442a33071dabeac89ccf )
+)
+
+game (
+	name "Need for Speed - Underground 2 (EU)"
+	description "Need for Speed - Underground 2 (EU)"
+	rom ( name "Need for Speed - Underground 2 (EU).iso" size 1459978240 crc 1d8ab780 md5 308b4bad57a4666d2597a6b4e0e85722 sha1 bc13ffbdc8558c3172f2fb7c29a24d9615016cf5 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (Europe)"
+	description "Need for Speed - Underground 2 (Europe)"
+	rom ( name "Need for Speed - Underground 2 (Europe).iso" size 1459978240 crc 1d8ab780 md5 308b4bad57a4666d2597a6b4e0e85722 sha1 bc13ffbdc8558c3172f2fb7c29a24d9615016cf5 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (FR)"
+	description "Need for Speed - Underground 2 (FR)"
+	rom ( name "Need for Speed - Underground 2 (FR).iso" size 1459978240 crc fa76df3a md5 6e846832929e4d025d34358f69748c80 sha1 ef3b371500fd786f9d151be38671e978cd22ecb4 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (France)"
+	description "Need for Speed - Underground 2 (France)"
+	rom ( name "Need for Speed - Underground 2 (France).iso" size 1459978240 crc fa76df3a md5 6e846832929e4d025d34358f69748c80 sha1 ef3b371500fd786f9d151be38671e978cd22ecb4 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (Germany)"
+	description "Need for Speed - Underground 2 (Germany)"
+	rom ( name "Need for Speed - Underground 2 (Germany).iso" size 1459978240 crc 83b3c758 md5 89c3c4148a5ae00db23fc68834d9ea84 sha1 831eee2df2899f7e0d91442a33071dabeac89ccf )
+)
+
+game (
+	name "Need for Speed - Underground 2 (Japan)"
+	description "Need for Speed - Underground 2 (Japan)"
+	rom ( name "Need for Speed - Underground 2 (Japan).iso" size 1459978240 crc 909806ff md5 5a87df1521e05790544696829fb15b35 sha1 f48152195058b5d40d1955d3db43e4ee81fd6f15 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (JP) - nidohuosupido ~andaguraundo2~"
+	description "Need for Speed - Underground 2 (JP) - nidohuosupido ~andaguraundo2~"
+	rom ( name "Need for Speed - Underground 2 (JP).iso" size 1459978240 crc 909806ff md5 5a87df1521e05790544696829fb15b35 sha1 f48152195058b5d40d1955d3db43e4ee81fd6f15 )
+)
+
+game (
+	name "Need for Speed - Underground 2 (US)"
+	description "Need for Speed - Underground 2 (US)"
+	rom ( name "Need for Speed - Underground 2 (US).iso" size 1459978240 crc 5e49b1d7 md5 4d5120a533007d18d3297ee2edab9533 sha1 e22ebaa2ee05cab39e0c64ee1d1e40ac0b38d5ed )
+)
+
+game (
+	name "Need for Speed - Underground 2 (USA)"
+	description "Need for Speed - Underground 2 (USA)"
+	rom ( name "Need for Speed - Underground 2 (USA).iso" size 1459978240 crc 5e49b1d7 md5 4d5120a533007d18d3297ee2edab9533 sha1 e22ebaa2ee05cab39e0c64ee1d1e40ac0b38d5ed )
+)
+
+game (
+	name "Neighbours from Hell (EU)"
+	description "Neighbours from Hell (EU)"
+	rom ( name "Neighbours from Hell (EU).iso" size 1459978240 crc dabc41e2 md5 af7f2f51b45befeb3d5139f9769fa7cc sha1 edaa52325d6eb3966d991b76c2ec53c31713b4d2 )
+)
+
+game (
+	name "Neighbours from Hell (Europe) (En,Fr,De,Es,It)"
+	description "Neighbours from Hell (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Neighbours from Hell (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc dabc41e2 md5 af7f2f51b45befeb3d5139f9769fa7cc sha1 edaa52325d6eb3966d991b76c2ec53c31713b4d2 )
+)
+
+game (
+	name "NFL 2K3 (EU)"
+	description "NFL 2K3 (EU)"
+	rom ( name "NFL 2K3 (EU).iso" size 1459978240 crc 0dc826be md5 f59ba869c01b9ba476ddefe99f0afbb8 sha1 a90b16e22c18be7e9a20e570ba6b06ffb67a7035 )
+)
+
+game (
+	name "NFL 2K3 (Europe)"
+	description "NFL 2K3 (Europe)"
+	rom ( name "NFL 2K3 (Europe).iso" size 1459978240 crc 0dc826be md5 f59ba869c01b9ba476ddefe99f0afbb8 sha1 a90b16e22c18be7e9a20e570ba6b06ffb67a7035 )
+)
+
+game (
+	name "NFL 2K3 (US)"
+	description "NFL 2K3 (US)"
+	rom ( name "NFL 2K3 (US).iso" size 1459978240 crc aedf964d md5 98d73433025ee858e640cb37a0f00fbe sha1 5b161f246f50eff9dbd0f375cc7a2f87950a26a4 )
+)
+
+game (
+	name "NFL 2K3 (USA)"
+	description "NFL 2K3 (USA)"
+	rom ( name "NFL 2K3 (USA).iso" size 1459978240 crc aedf964d md5 98d73433025ee858e640cb37a0f00fbe sha1 5b161f246f50eff9dbd0f375cc7a2f87950a26a4 )
+)
+
+game (
+	name "NFL Blitz 2002 (US)"
+	description "NFL Blitz 2002 (US)"
+	rom ( name "NFL Blitz 2002 (US).iso" size 1459978240 crc 5debb376 md5 d7c60755566e573903891b4adc22a8eb sha1 adfdde63c00c3973cf6e8a8874355d80bfc42a3a )
+)
+
+game (
+	name "NFL Blitz 2002 (USA)"
+	description "NFL Blitz 2002 (USA)"
+	rom ( name "NFL Blitz 2002 (USA).iso" size 1459978240 crc 5debb376 md5 d7c60755566e573903891b4adc22a8eb sha1 adfdde63c00c3973cf6e8a8874355d80bfc42a3a )
+)
+
+game (
+	name "NFL Blitz 2003 (US)"
+	description "NFL Blitz 2003 (US)"
+	rom ( name "NFL Blitz 2003 (US).iso" size 1459978240 crc 3f4d220c md5 d5061d91f42481f7a9c120249945e128 sha1 60a244415a3ed88d056561918797f9f9589cb0a7 )
+)
+
+game (
+	name "NFL Blitz 2003 (USA)"
+	description "NFL Blitz 2003 (USA)"
+	rom ( name "NFL Blitz 2003 (USA).iso" size 1459978240 crc 3f4d220c md5 d5061d91f42481f7a9c120249945e128 sha1 60a244415a3ed88d056561918797f9f9589cb0a7 )
+)
+
+game (
+	name "NFL Blitz Pro (US)"
+	description "NFL Blitz Pro (US)"
+	rom ( name "NFL Blitz Pro (US).iso" size 1459978240 crc f2c785cd md5 1d92bf6a0467e48ead6251c444a3e341 sha1 84a36774d2d597d77ff1e016788b913c39fdc282 )
+)
+
+game (
+	name "NFL Blitz Pro (USA)"
+	description "NFL Blitz Pro (USA)"
+	rom ( name "NFL Blitz Pro (USA).iso" size 1459978240 crc f2c785cd md5 1d92bf6a0467e48ead6251c444a3e341 sha1 84a36774d2d597d77ff1e016788b913c39fdc282 )
+)
+
+game (
+	name "NFL QB Club 2002 (US)"
+	description "NFL QB Club 2002 (US)"
+	rom ( name "NFL QB Club 2002 (US).iso" size 1459978240 crc 535ff7f0 md5 ed249f6e029f92158c86d00e28b4926e sha1 03634509d1d8f8cb63c011e47c24091fa8bda762 )
+)
+
+game (
+	name "NFL QB Club 2002 (USA)"
+	description "NFL QB Club 2002 (USA)"
+	rom ( name "NFL QB Club 2002 (USA).iso" size 1459978240 crc 535ff7f0 md5 ed249f6e029f92158c86d00e28b4926e sha1 03634509d1d8f8cb63c011e47c24091fa8bda762 )
+)
+
+game (
+	name "NFL Street (EU)"
+	description "NFL Street (EU)"
+	rom ( name "NFL Street (EU).iso" size 1459978240 crc 40b4ed94 md5 f53dbe9f04864394cbb05f906be96095 sha1 bbf34b22ac9ba6b55da302537ea5d5dbbadb984c )
+)
+
+game (
+	name "NFL Street (Europe)"
+	description "NFL Street (Europe)"
+	rom ( name "NFL Street (Europe).iso" size 1459978240 crc 40b4ed94 md5 f53dbe9f04864394cbb05f906be96095 sha1 bbf34b22ac9ba6b55da302537ea5d5dbbadb984c )
+)
+
+game (
+	name "NFL Street (US)"
+	description "NFL Street (US)"
+	rom ( name "NFL Street (US).iso" size 1459978240 crc 1864e9ac md5 78a89ed4baf2602feff65b61b63b2134 sha1 813c4511ba3135059a13de424555647e8252254b )
+)
+
+game (
+	name "NFL Street (USA)"
+	description "NFL Street (USA)"
+	rom ( name "NFL Street (USA).iso" size 1459978240 crc 1864e9ac md5 78a89ed4baf2602feff65b61b63b2134 sha1 813c4511ba3135059a13de424555647e8252254b )
+)
+
+game (
+	name "NFL Street 2 (Europe)"
+	description "NFL Street 2 (Europe)"
+	rom ( name "NFL Street 2 (Europe).iso" size 1459978240 crc 9e2ae981 md5 5a73ce1f5fbc92a6ebbf92da41671e58 sha1 e20715c92072b1b387103f6a75834f7a08d5175d )
+)
+
+game (
+	name "NFL Street 2 (GB)"
+	description "NFL Street 2 (GB)"
+	rom ( name "NFL Street 2 (GB).iso" size 1459978240 crc 9e2ae981 md5 5a73ce1f5fbc92a6ebbf92da41671e58 sha1 e20715c92072b1b387103f6a75834f7a08d5175d )
+)
+
+game (
+	name "NFL Street 2 (US)"
+	description "NFL Street 2 (US)"
+	rom ( name "NFL Street 2 (US).iso" size 1459978240 crc 2909d1b7 md5 6ac216d88f4c833b0cb2fd9424264dce sha1 d8603281a9a84a525ac7ae3dddbc30ea4f6bb190 )
+)
+
+game (
+	name "NFL Street 2 (USA)"
+	description "NFL Street 2 (USA)"
+	rom ( name "NFL Street 2 (USA).iso" size 1459978240 crc 2909d1b7 md5 6ac216d88f4c833b0cb2fd9424264dce sha1 d8603281a9a84a525ac7ae3dddbc30ea4f6bb190 )
+)
+
+game (
+	name "NHK Tensai Bit-Kun - Gramon Battle (Japan)"
+	description "NHK Tensai Bit-Kun - Gramon Battle (Japan)"
+	rom ( name "NHK Tensai Bit-Kun - Gramon Battle (Japan).iso" size 1459978240 crc c8f2ad10 md5 3afb1bcdb21045c5446ba16e8a94c4bd sha1 3be62e6d6f99784febbe711c80d5acbdc1a94de3 )
+)
+
+game (
+	name "NHK Tensai Bit-Kun - Gramon Battle (JP) - NHK+Tian Cai bitutokun+guramon+batoru"
+	description "NHK Tensai Bit-Kun - Gramon Battle (JP) - NHK+Tian Cai bitutokun+guramon+batoru"
+	rom ( name "NHK Tensai Bit-Kun - Gramon Battle (JP).iso" size 1459978240 crc c8f2ad10 md5 3afb1bcdb21045c5446ba16e8a94c4bd sha1 3be62e6d6f99784febbe711c80d5acbdc1a94de3 )
+)
+
+game (
+	name "NHL 06 (EU)"
+	description "NHL 06 (EU)"
+	rom ( name "NHL 06 (EU).iso" size 1459978240 crc 860de55b md5 5ef5b9d7e2eab0df6d94652285fece42 sha1 0f4577387b17ecccf19fccebe42d32f0a68fb78a )
+)
+
+game (
+	name "NHL 06 (Europe) (En,Fr)"
+	description "NHL 06 (Europe) (En,Fr)"
+	rom ( name "NHL 06 (Europe) (En,Fr).iso" size 1459978240 crc 860de55b md5 5ef5b9d7e2eab0df6d94652285fece42 sha1 0f4577387b17ecccf19fccebe42d32f0a68fb78a )
+)
+
+game (
+	name "NHL 06 (US)"
+	description "NHL 06 (US)"
+	rom ( name "NHL 06 (US).iso" size 1459978240 crc 5687bfe7 md5 3b4142b89e66342de6f42c0712a9aff5 sha1 769a9b052634554e251f7d7cd7d1a0847a5321da )
+)
+
+game (
+	name "NHL 06 (USA) (En,Fr)"
+	description "NHL 06 (USA) (En,Fr)"
+	rom ( name "NHL 06 (USA) (En,Fr).iso" size 1459978240 crc 5687bfe7 md5 3b4142b89e66342de6f42c0712a9aff5 sha1 769a9b052634554e251f7d7cd7d1a0847a5321da )
+)
+
+game (
+	name "NHL 2003 (EU)"
+	description "NHL 2003 (EU)"
+	rom ( name "NHL 2003 (EU).iso" size 1459978240 crc 4deafc44 md5 1e93dbe42c9a1d7fe90dfe49cd307ae4 sha1 009162c43cfbeafd9cb30043c5838f384404edc6 )
+)
+
+game (
+	name "NHL 2003 (Europe) (En,Fr,De,Sv,Fi,Cs)"
+	description "NHL 2003 (Europe) (En,Fr,De,Sv,Fi,Cs)"
+	rom ( name "NHL 2003 (Europe) (En,Fr,De,Sv,Fi,Cs).iso" size 1459978240 crc 4deafc44 md5 1e93dbe42c9a1d7fe90dfe49cd307ae4 sha1 009162c43cfbeafd9cb30043c5838f384404edc6 )
+)
+
+game (
+	name "NHL 2003 (US)"
+	description "NHL 2003 (US)"
+	rom ( name "NHL 2003 (US).iso" size 1459978240 crc 8c3011fb md5 d59e50fb88199840e192c2c61926f1d6 sha1 5ab23f2e89069fb8a977f61b48cb4e7435578175 )
+)
+
+game (
+	name "NHL 2003 (USA)"
+	description "NHL 2003 (USA)"
+	rom ( name "NHL 2003 (USA).iso" size 1459978240 crc 8c3011fb md5 d59e50fb88199840e192c2c61926f1d6 sha1 5ab23f2e89069fb8a977f61b48cb4e7435578175 )
+)
+
+game (
+	name "NHL 2004 (EU)"
+	description "NHL 2004 (EU)"
+	rom ( name "NHL 2004 (EU).iso" size 1459978240 crc 86334735 md5 54af4aafc13572b971c849aa1f138698 sha1 1c05b7e75f38f190d1a7c501ad771052f96dda85 )
+)
+
+game (
+	name "NHL 2004 (Europe) (En,Fr,De,Sv,Fi)"
+	description "NHL 2004 (Europe) (En,Fr,De,Sv,Fi)"
+	rom ( name "NHL 2004 (Europe) (En,Fr,De,Sv,Fi).iso" size 1459978240 crc 86334735 md5 54af4aafc13572b971c849aa1f138698 sha1 1c05b7e75f38f190d1a7c501ad771052f96dda85 )
+)
+
+game (
+	name "NHL 2004 (US)"
+	description "NHL 2004 (US)"
+	rom ( name "NHL 2004 (US).iso" size 1459978240 crc f5946439 md5 61aa515d14b56254634ea4722abd7e83 sha1 8228dac2a526910aca0c2c2667f9287d7f6ffe4f )
+)
+
+game (
+	name "NHL 2004 (USA)"
+	description "NHL 2004 (USA)"
+	rom ( name "NHL 2004 (USA).iso" size 1459978240 crc f5946439 md5 61aa515d14b56254634ea4722abd7e83 sha1 8228dac2a526910aca0c2c2667f9287d7f6ffe4f )
+)
+
+game (
+	name "NHL 2005 (EU)"
+	description "NHL 2005 (EU)"
+	rom ( name "NHL 2005 (EU).iso" size 1459978240 crc adcde0a7 md5 8529104bd02c680edc7c7f5371d3b9a3 sha1 8a146565a75800b0b32b15602ed774ebbb934af5 )
+)
+
+game (
+	name "NHL 2005 (Europe) (En,Fr,De)"
+	description "NHL 2005 (Europe) (En,Fr,De)"
+	rom ( name "NHL 2005 (Europe) (En,Fr,De).iso" size 1459978240 crc adcde0a7 md5 8529104bd02c680edc7c7f5371d3b9a3 sha1 8a146565a75800b0b32b15602ed774ebbb934af5 )
+)
+
+game (
+	name "NHL 2005 (US)"
+	description "NHL 2005 (US)"
+	rom ( name "NHL 2005 (US).iso" size 1459978240 crc b17faa37 md5 83b64504907b99b4b54ba7697e034529 sha1 eb8f71c36da7bdf15af2fe231e45bbe5cdc59147 )
+)
+
+game (
+	name "NHL 2005 (USA) (En,Fr)"
+	description "NHL 2005 (USA) (En,Fr)"
+	rom ( name "NHL 2005 (USA) (En,Fr).iso" size 1459978240 crc b17faa37 md5 83b64504907b99b4b54ba7697e034529 sha1 eb8f71c36da7bdf15af2fe231e45bbe5cdc59147 )
+)
+
+game (
+	name "NHL 2K3 (EU)"
+	description "NHL 2K3 (EU)"
+	rom ( name "NHL 2K3 (EU).iso" size 1459978240 crc 60090fc9 md5 56a89c3e2c492d88f701e989291ab7db sha1 bb9f3dfbcc2100126c81a5380a8e83928866ae6a )
+)
+
+game (
+	name "NHL 2K3 (Europe)"
+	description "NHL 2K3 (Europe)"
+	rom ( name "NHL 2K3 (Europe).iso" size 1459978240 crc 60090fc9 md5 56a89c3e2c492d88f701e989291ab7db sha1 bb9f3dfbcc2100126c81a5380a8e83928866ae6a )
+)
+
+game (
+	name "NHL 2K3 (US)"
+	description "NHL 2K3 (US)"
+	rom ( name "NHL 2K3 (US).iso" size 1459978240 crc cb7879b1 md5 00931b098c8bdfccb014c54f5c4d7bc4 sha1 a447a503a5da759e037b42c75e03ec2005dfca42 )
+)
+
+game (
+	name "NHL 2K3 (USA)"
+	description "NHL 2K3 (USA)"
+	rom ( name "NHL 2K3 (USA).iso" size 1459978240 crc cb7879b1 md5 00931b098c8bdfccb014c54f5c4d7bc4 sha1 a447a503a5da759e037b42c75e03ec2005dfca42 )
+)
+
+game (
+	name "NHL Hitz 2002 (EU)"
+	description "NHL Hitz 2002 (EU)"
+	rom ( name "NHL Hitz 2002 (EU).iso" size 1459978240 crc f8f19d9c md5 9b04a5dadd1de2ef1e428994506370a0 sha1 c3966219b00b3dbd33ef3070427e03cd4f7f721d )
+)
+
+game (
+	name "NHL Hitz 2002 (Europe)"
+	description "NHL Hitz 2002 (Europe)"
+	rom ( name "NHL Hitz 2002 (Europe).iso" size 1459978240 crc f8f19d9c md5 9b04a5dadd1de2ef1e428994506370a0 sha1 c3966219b00b3dbd33ef3070427e03cd4f7f721d )
+)
+
+game (
+	name "NHL Hitz 2002 (US)"
+	description "NHL Hitz 2002 (US)"
+	rom ( name "NHL Hitz 2002 (US).iso" size 1459978240 crc 53f2137a md5 488d2a15d25da53fa4451a5e8471dfbc sha1 64d8b607aa2b5fa5fbbb5bfb0be149080781370f )
+)
+
+game (
+	name "NHL Hitz 2002 (USA)"
+	description "NHL Hitz 2002 (USA)"
+	rom ( name "NHL Hitz 2002 (USA).iso" size 1459978240 crc 53f2137a md5 488d2a15d25da53fa4451a5e8471dfbc sha1 64d8b607aa2b5fa5fbbb5bfb0be149080781370f )
+)
+
+game (
+	name "NHL Hitz 2003 (EU)"
+	description "NHL Hitz 2003 (EU)"
+	rom ( name "NHL Hitz 2003 (EU).iso" size 1459978240 crc f1a17a9d md5 3779ffd4ae284fe3e6da6307e8fa3c6a sha1 432d9e0113e3073c42b47e9a0ee0200e454edbc4 )
+)
+
+game (
+	name "NHL Hitz 2003 (Europe)"
+	description "NHL Hitz 2003 (Europe)"
+	rom ( name "NHL Hitz 2003 (Europe).iso" size 1459978240 crc f1a17a9d md5 3779ffd4ae284fe3e6da6307e8fa3c6a sha1 432d9e0113e3073c42b47e9a0ee0200e454edbc4 )
+)
+
+game (
+	name "NHL Hitz 2003 (US)"
+	description "NHL Hitz 2003 (US)"
+	rom ( name "NHL Hitz 2003 (US).iso" size 1459978240 crc bb9fc845 md5 1f26fd56ed2598b410f35945e199c45d sha1 fb98d0e483ccdb84343707c421b6c7a8fe436288 )
+)
+
+game (
+	name "NHL Hitz 2003 (USA)"
+	description "NHL Hitz 2003 (USA)"
+	rom ( name "NHL Hitz 2003 (USA).iso" size 1459978240 crc bb9fc845 md5 1f26fd56ed2598b410f35945e199c45d sha1 fb98d0e483ccdb84343707c421b6c7a8fe436288 )
+)
+
+game (
+	name "NHL Hitz Pro (US)"
+	description "NHL Hitz Pro (US)"
+	rom ( name "NHL Hitz Pro (US).iso" size 1459978240 crc 83791ce1 md5 14e6a4524ef4f370a81aa8019bc3ecc7 sha1 f54a031f29494814254e46f57acdcc60ed088cd7 )
+)
+
+game (
+	name "NHL Hitz Pro (USA)"
+	description "NHL Hitz Pro (USA)"
+	rom ( name "NHL Hitz Pro (USA).iso" size 1459978240 crc 83791ce1 md5 14e6a4524ef4f370a81aa8019bc3ecc7 sha1 f54a031f29494814254e46f57acdcc60ed088cd7 )
+)
+
+game (
+	name "Nick Jr. Dora the Explorer - Journey to the Purple Planet (EU)"
+	description "Nick Jr. Dora the Explorer - Journey to the Purple Planet (EU)"
+	rom ( name "Nick Jr. Dora the Explorer - Journey to the Purple Planet (EU).iso" size 1459978240 crc 278087cc md5 2196dfb872b9423a330668eba7ca0699 sha1 0a909d11ff972003d22cf459d97c2d8c99155f17 )
+)
+
+game (
+	name "Nick Jr. Dora the Explorer - Journey to the Purple Planet (Europe) (En,Fr)"
+	description "Nick Jr. Dora the Explorer - Journey to the Purple Planet (Europe) (En,Fr)"
+	rom ( name "Nick Jr. Dora the Explorer - Journey to the Purple Planet (Europe) (En,Fr).iso" size 1459978240 crc 278087cc md5 2196dfb872b9423a330668eba7ca0699 sha1 0a909d11ff972003d22cf459d97c2d8c99155f17 )
+)
+
+game (
+	name "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (DE)"
+	description "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (DE)"
+	rom ( name "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (DE).iso" size 1459978240 crc 07edb498 md5 a4537e318eaa1ca954ee427add9edcf5 sha1 73b4b5023dcb76620289bddb8ef79c6214d5b8b8 )
+)
+
+game (
+	name "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (Germany)"
+	description "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (Germany)"
+	rom ( name "Nick SpongeBob Schwammkopf - Die Kreatur aus der Krossen Krabbe (Germany).iso" size 1459978240 crc 07edb498 md5 a4537e318eaa1ca954ee427add9edcf5 sha1 73b4b5023dcb76620289bddb8ef79c6214d5b8b8 )
+)
+
+game (
+	name "Nickelodeon Avatar - The Legend of Aang (EU)"
+	description "Nickelodeon Avatar - The Legend of Aang (EU)"
+	rom ( name "Nickelodeon Avatar - The Legend of Aang (EU).iso" size 1459978240 crc 44884718 md5 580bb4d1c08e079e640777cebafc0a8a sha1 da71a7366daebbd8cb79a45fb592a22cdc4c3d2a )
+)
+
+game (
+	name "Nickelodeon Avatar - The Legend of Aang (Europe) (En,Fr,Nl)"
+	description "Nickelodeon Avatar - The Legend of Aang (Europe) (En,Fr,Nl)"
+	rom ( name "Nickelodeon Avatar - The Legend of Aang (Europe) (En,Fr,Nl).iso" size 1459978240 crc 44884718 md5 580bb4d1c08e079e640777cebafc0a8a sha1 da71a7366daebbd8cb79a45fb592a22cdc4c3d2a )
+)
+
+game (
+	name "Nickelodeon Barnyard (EU)"
+	description "Nickelodeon Barnyard (EU)"
+	rom ( name "Nickelodeon Barnyard (EU).iso" size 1459978240 crc 81bb3b5a md5 5027c12e466a640a3391e6d3bc41baf8 sha1 96f7624d6939a0eea19ee27a134f222588317c8d )
+)
+
+game (
+	name "Nickelodeon Barnyard (Europe)"
+	description "Nickelodeon Barnyard (Europe)"
+	rom ( name "Nickelodeon Barnyard (Europe).iso" size 1459978240 crc 5ded17ac md5 5ef2f2c24714a0dbdbd74224ea8bb167 sha1 50a853cdec2558517d8033ee653a23c4aa34bb25 )
+)
+
+game (
+	name "Nickelodeon Barnyard (Europe) (Fr,Es,It,Nl)"
+	description "Nickelodeon Barnyard (Europe) (Fr,Es,It,Nl)"
+	rom ( name "Nickelodeon Barnyard (Europe) (Fr,Es,It,Nl).iso" size 1459978240 crc 81bb3b5a md5 5027c12e466a640a3391e6d3bc41baf8 sha1 96f7624d6939a0eea19ee27a134f222588317c8d )
+)
+
+game (
+	name "Nickelodeon Barnyard (GB)"
+	description "Nickelodeon Barnyard (GB)"
+	rom ( name "Nickelodeon Barnyard (GB).iso" size 1459978240 crc 5ded17ac md5 5ef2f2c24714a0dbdbd74224ea8bb167 sha1 50a853cdec2558517d8033ee653a23c4aa34bb25 )
+)
+
+game (
+	name "Nickelodeon Barnyard (US)"
+	description "Nickelodeon Barnyard (US)"
+	rom ( name "Nickelodeon Barnyard (US).iso" size 1459978240 crc 6bc16c42 md5 f5cbb6aeed3d53c803445cae124bf165 sha1 a09a38d0ad9a68a52af7474c877c255cf6ece718 )
+)
+
+game (
+	name "Nickelodeon Barnyard (USA)"
+	description "Nickelodeon Barnyard (USA)"
+	rom ( name "Nickelodeon Barnyard (USA).iso" size 1459978240 crc 6bc16c42 md5 f5cbb6aeed3d53c803445cae124bf165 sha1 a09a38d0ad9a68a52af7474c877c255cf6ece718 )
+)
+
+game (
+	name "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (FR)"
+	description "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (FR)"
+	rom ( name "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (FR).iso" size 1459978240 crc b41eaa06 md5 62348380609818f7c8d04fef5d5d1459 sha1 e58b89d009d77e0cb329159fb4561fc6b01f20b4 )
+)
+
+game (
+	name "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (France)"
+	description "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (France)"
+	rom ( name "Nickelodeon Bob L'eponge - La Creature du Crabe Croustillant (France).iso" size 1459978240 crc b41eaa06 md5 62348380609818f7c8d04fef5d5d1459 sha1 e58b89d009d77e0cb329159fb4561fc6b01f20b4 )
+)
+
+game (
+	name "Nickelodeon Bob L'eponge - Silence on Tourne! (FR)"
+	description "Nickelodeon Bob L'eponge - Silence on Tourne! (FR)"
+	rom ( name "Nickelodeon Bob L'eponge - Silence on Tourne! (FR).iso" size 1459978240 crc 8b0e1254 md5 5d427a5024414e042f1a2d7f8ee2410e sha1 19b8b325795f29a4da076e95ba2f1e7d46519451 )
+)
+
+game (
+	name "Nickelodeon Bob L'eponge - Silence on Tourne! (France)"
+	description "Nickelodeon Bob L'eponge - Silence on Tourne! (France)"
+	rom ( name "Nickelodeon Bob L'eponge - Silence on Tourne! (France).iso" size 1459978240 crc 8b0e1254 md5 5d427a5024414e042f1a2d7f8ee2410e sha1 19b8b325795f29a4da076e95ba2f1e7d46519451 )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (Europe)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (Europe)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (Europe).iso" size 1459978240 crc fc40d4c4 md5 c2595a8a0d347d2cdea219b3c3121604 sha1 c7e695c833fc05b6af8f2554f7b4b9aca8e6cad7 )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (GB)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (GB)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (GB).iso" size 1459978240 crc fc40d4c4 md5 c2595a8a0d347d2cdea219b3c3121604 sha1 c7e695c833fc05b6af8f2554f7b4b9aca8e6cad7 )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (US)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (US)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (US).iso" size 1459978240 crc 76d5e3e5 md5 739271ad8766faf561f2a63133bf0396 sha1 193626387dc3fbb7dee93ae3a7a1d9bb63c3e95e )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (USA)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (USA)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius - Attack of the Twonkies (USA).iso" size 1459978240 crc 76d5e3e5 md5 739271ad8766faf561f2a63133bf0396 sha1 193626387dc3fbb7dee93ae3a7a1d9bb63c3e95e )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius (EU)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius (EU)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius (EU).iso" size 1459978240 crc dde140e6 md5 f86da2a0b1f62ac739b5285c5ff44c9f sha1 113c01a27ed0c9a68d5e85ba65dd218a484a17ba )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius (Europe)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius (Europe)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius (Europe).iso" size 1459978240 crc dde140e6 md5 f86da2a0b1f62ac739b5285c5ff44c9f sha1 113c01a27ed0c9a68d5e85ba65dd218a484a17ba )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius (US)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius (US)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius (US).iso" size 1459978240 crc 8988c485 md5 e278a2ddc10185a691ed99dde12d47c2 sha1 90861e1c1e5003388449b1ca41b7de014526ce1c )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Boy Genius (USA)"
+	description "Nickelodeon Jimmy Neutron - Boy Genius (USA)"
+	rom ( name "Nickelodeon Jimmy Neutron - Boy Genius (USA).iso" size 1459978240 crc 8988c485 md5 e278a2ddc10185a691ed99dde12d47c2 sha1 90861e1c1e5003388449b1ca41b7de014526ce1c )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Der mutige Erfinder (DE)"
+	description "Nickelodeon Jimmy Neutron - Der mutige Erfinder (DE)"
+	rom ( name "Nickelodeon Jimmy Neutron - Der mutige Erfinder (DE).iso" size 1459978240 crc 7b8e27a0 md5 9a321eb08dd8cfdf09991e716f67531e sha1 8b6e65b1f4dcff45768ed1e87140f0c612cdd393 )
+)
+
+game (
+	name "Nickelodeon Jimmy Neutron - Der mutige Erfinder (Germany)"
+	description "Nickelodeon Jimmy Neutron - Der mutige Erfinder (Germany)"
+	rom ( name "Nickelodeon Jimmy Neutron - Der mutige Erfinder (Germany).iso" size 1459978240 crc 7b8e27a0 md5 9a321eb08dd8cfdf09991e716f67531e sha1 8b6e65b1f4dcff45768ed1e87140f0c612cdd393 )
+)
+
+game (
+	name "Nickelodeon Party Blast (EU)"
+	description "Nickelodeon Party Blast (EU)"
+	rom ( name "Nickelodeon Party Blast (EU).iso" size 1459978240 crc 934da42f md5 96880c826c6e37897226b47e3f72b66c sha1 6e8485afe135b4fc1201b83d9d31ace1202c74e5 )
+)
+
+game (
+	name "Nickelodeon Party Blast (Europe) (En,Fr,De,Es,It)"
+	description "Nickelodeon Party Blast (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Nickelodeon Party Blast (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 934da42f md5 96880c826c6e37897226b47e3f72b66c sha1 6e8485afe135b4fc1201b83d9d31ace1202c74e5 )
+)
+
+game (
+	name "Nickelodeon Party Blast (US)"
+	description "Nickelodeon Party Blast (US)"
+	rom ( name "Nickelodeon Party Blast (US).iso" size 1459978240 crc e84cc90b md5 5dc69a828717d8a2f1822c010084eb3a sha1 0c9835d3c38797a956a258ef68504c9a45a2a877 )
+)
+
+game (
+	name "Nickelodeon Party Blast (USA)"
+	description "Nickelodeon Party Blast (USA)"
+	rom ( name "Nickelodeon Party Blast (USA).iso" size 1459978240 crc e84cc90b md5 5dc69a828717d8a2f1822c010084eb3a sha1 0c9835d3c38797a956a258ef68504c9a45a2a877 )
+)
+
+game (
+	name "Nickelodeon Rocket Power - Beach Bandits (EU)"
+	description "Nickelodeon Rocket Power - Beach Bandits (EU)"
+	rom ( name "Nickelodeon Rocket Power - Beach Bandits (EU).iso" size 1459978240 crc dd16da20 md5 da450bc5a1327f6edb260651e7bcd109 sha1 f647cbec7463fc48a38eda2e68be2fe14c8f9727 )
+)
+
+game (
+	name "Nickelodeon Rocket Power - Beach Bandits (Europe)"
+	description "Nickelodeon Rocket Power - Beach Bandits (Europe)"
+	rom ( name "Nickelodeon Rocket Power - Beach Bandits (Europe).iso" size 1459978240 crc dd16da20 md5 da450bc5a1327f6edb260651e7bcd109 sha1 f647cbec7463fc48a38eda2e68be2fe14c8f9727 )
+)
+
+game (
+	name "Nickelodeon Rocket Power - Beach Bandits (US)"
+	description "Nickelodeon Rocket Power - Beach Bandits (US)"
+	rom ( name "Nickelodeon Rocket Power - Beach Bandits (US).iso" size 1459978240 crc 8be53ce8 md5 12c23048ab2a91d9c5e194e7766820da sha1 cfc591a840c031b3010cdb29c248cb4f33ffa5c9 )
+)
+
+game (
+	name "Nickelodeon Rocket Power - Beach Bandits (USA)"
+	description "Nickelodeon Rocket Power - Beach Bandits (USA)"
+	rom ( name "Nickelodeon Rocket Power - Beach Bandits (USA).iso" size 1459978240 crc 8be53ce8 md5 12c23048ab2a91d9c5e194e7766820da sha1 cfc591a840c031b3010cdb29c248cb4f33ffa5c9 )
+)
+
+game (
+	name "Nickelodeon Rugrats - Royal Ransom (Europe)"
+	description "Nickelodeon Rugrats - Royal Ransom (Europe)"
+	rom ( name "Nickelodeon Rugrats - Royal Ransom (Europe).iso" size 1459978240 crc 98d0769b md5 64911fe5e43c58adc9f04f9e9114106c sha1 7510f40b588330a4d4d403bcce104347c9222bf8 )
+)
+
+game (
+	name "Nickelodeon Rugrats - Royal Ransom (GB)"
+	description "Nickelodeon Rugrats - Royal Ransom (GB)"
+	rom ( name "Nickelodeon Rugrats - Royal Ransom (GB).iso" size 1459978240 crc 98d0769b md5 64911fe5e43c58adc9f04f9e9114106c sha1 7510f40b588330a4d4d403bcce104347c9222bf8 )
+)
+
+game (
+	name "Nickelodeon Rugrats - Royal Ransom (US)"
+	description "Nickelodeon Rugrats - Royal Ransom (US)"
+	rom ( name "Nickelodeon Rugrats - Royal Ransom (US).iso" size 1459978240 crc 118a3804 md5 257cef6900c7c886a9617c3521247507 sha1 cf3d3d7da44623546a45605a47712af8262f880a )
+)
+
+game (
+	name "Nickelodeon Rugrats - Royal Ransom (USA)"
+	description "Nickelodeon Rugrats - Royal Ransom (USA)"
+	rom ( name "Nickelodeon Rugrats - Royal Ransom (USA).iso" size 1459978240 crc 118a3804 md5 257cef6900c7c886a9617c3521247507 sha1 cf3d3d7da44623546a45605a47712af8262f880a )
+)
+
+game (
+	name "Nickelodeon SpongeBob Schwammkopf - Der Film (DE)"
+	description "Nickelodeon SpongeBob Schwammkopf - Der Film (DE)"
+	rom ( name "Nickelodeon SpongeBob Schwammkopf - Der Film (DE).iso" size 1459978240 crc 2e2565bb md5 d4eea40e3ed3140dd6c747042a1cfb15 sha1 809e49a33a6bae3f8b6e927e96122a4519210b7a )
+)
+
+game (
+	name "Nickelodeon SpongeBob Schwammkopf - Der Film (Germany)"
+	description "Nickelodeon SpongeBob Schwammkopf - Der Film (Germany)"
+	rom ( name "Nickelodeon SpongeBob Schwammkopf - Der Film (Germany).iso" size 1459978240 crc 2e2565bb md5 d4eea40e3ed3140dd6c747042a1cfb15 sha1 809e49a33a6bae3f8b6e927e96122a4519210b7a )
+)
+
+game (
+	name "Nickelodeon SpongeBob Schwammkopf - Film ab! (DE)"
+	description "Nickelodeon SpongeBob Schwammkopf - Film ab! (DE)"
+	rom ( name "Nickelodeon SpongeBob Schwammkopf - Film ab! (DE).iso" size 1459978240 crc 400df3af md5 c8ee914aad66ed1ba191f719b57c62c4 sha1 5d7258cfbedc01c1afa4ff6eda955582cb8bc11b )
+)
+
+game (
+	name "Nickelodeon SpongeBob Schwammkopf - Film ab! (Germany)"
+	description "Nickelodeon SpongeBob Schwammkopf - Film ab! (Germany)"
+	rom ( name "Nickelodeon SpongeBob Schwammkopf - Film ab! (Germany).iso" size 1459978240 crc 400df3af md5 c8ee914aad66ed1ba191f719b57c62c4 sha1 5d7258cfbedc01c1afa4ff6eda955582cb8bc11b )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe).iso" size 1459978240 crc 5dcf1734 md5 10b725bed9a3be326a776db800682b47 sha1 53238fd27c00b2f51b19e2fcf4f3bc8ae34aa612 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (GB)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (GB)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (GB).iso" size 1459978240 crc 5dcf1734 md5 10b725bed9a3be326a776db800682b47 sha1 53238fd27c00b2f51b19e2fcf4f3bc8ae34aa612 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (US)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (US)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (US).iso" size 1459978240 crc 85535b74 md5 715464b04132ce5567802f64ad6d3aef sha1 29a6725e503a992f8050b94b20baab03282e3ce1 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA).iso" size 1459978240 crc 85535b74 md5 715464b04132ce5567802f64ad6d3aef sha1 29a6725e503a992f8050b94b20baab03282e3ce1 )
+)
+
+game (
+	name "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (Netherlands)"
+	description "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (Netherlands)"
+	rom ( name "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (Netherlands).iso" size 1459978240 crc c94da0aa md5 4e8e084fbe32a7635eca6c3e5fb008de sha1 4a17f80c7f6c887bdc446f556c06aca0beb459f7 )
+)
+
+game (
+	name "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (NL)"
+	description "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (NL)"
+	rom ( name "Nickelodeon SpongeBob Squarepants - Licht uit, Camera aan! (NL).iso" size 1459978240 crc c94da0aa md5 4e8e084fbe32a7635eca6c3e5fb008de sha1 4a17f80c7f6c887bdc446f556c06aca0beb459f7 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (Europe)"
+	description "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (Europe)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (Europe).iso" size 1459978240 crc ebf5a0bb md5 6a6e47551f938ef98602e740edac5463 sha1 f551238b03c2a4b0b2760d99e5092f7efe2906df )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (GB)"
+	description "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (GB)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (GB).iso" size 1459978240 crc ebf5a0bb md5 6a6e47551f938ef98602e740edac5463 sha1 f551238b03c2a4b0b2760d99e5092f7efe2906df )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (US)"
+	description "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (US)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (US).iso" size 1459978240 crc 135f55e4 md5 2c5d625bba29d8b1240430b383847b15 sha1 a1e81e76e3399b319e5791e9514b09fdafdfeb73 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (USA)"
+	description "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants! (USA).iso" size 1459978240 crc 135f55e4 md5 2c5d625bba29d8b1240430b383847b15 sha1 a1e81e76e3399b319e5791e9514b09fdafdfeb73 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (Europe)"
+	description "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (Europe)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (Europe).iso" size 1459978240 crc 354be7e2 md5 e023a779e54d753f264c030a5c44868c sha1 8ef18faf8839db520cf0a5b27670bf9026d21e0b )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (GB)"
+	description "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (GB)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (GB).iso" size 1459978240 crc 354be7e2 md5 e023a779e54d753f264c030a5c44868c sha1 8ef18faf8839db520cf0a5b27670bf9026d21e0b )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (US)"
+	description "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (US)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (US).iso" size 1459978240 crc f2facf74 md5 30b0601c43c4ee30b7498427c2aa70f5 sha1 290df71e8fd1633b7c2af4cbb5b81ebdf6e539e4 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (USA)"
+	description "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (USA).iso" size 1459978240 crc f2facf74 md5 30b0601c43c4ee30b7498427c2aa70f5 sha1 290df71e8fd1633b7c2af4cbb5b81ebdf6e539e4 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (Europe)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (Europe)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (Europe).iso" size 1459978240 crc 334aac70 md5 62bc84bfcad66e8d24f83873b247b628 sha1 f13f66669639b95d2c63f51cc3deea1b334998e5 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (Europe) (Fr,Nl)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (Europe) (Fr,Nl)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (Europe) (Fr,Nl).iso" size 1459978240 crc 084ea086 md5 5c8a6eeeb849e20c59bc245a56d4f174 sha1 09606bce7bc063d257f006973f1b5c70e8e9cd42 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (FR^BE^NL)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (FR^BE^NL)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (FR^BE^NL).iso" size 1459978240 crc 084ea086 md5 5c8a6eeeb849e20c59bc245a56d4f174 sha1 09606bce7bc063d257f006973f1b5c70e8e9cd42 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (GB)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (GB)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (GB).iso" size 1459978240 crc 334aac70 md5 62bc84bfcad66e8d24f83873b247b628 sha1 f13f66669639b95d2c63f51cc3deea1b334998e5 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (US)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (US)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (US).iso" size 1459978240 crc 77be3cc6 md5 9fbad7186b2168190082a54fa20d63b7 sha1 2aea159b1e98a220a6e4534f0f017b8722ce4caa )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - The Movie (USA)"
+	description "Nickelodeon SpongeBob SquarePants - The Movie (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - The Movie (USA).iso" size 1459978240 crc 77be3cc6 md5 9fbad7186b2168190082a54fa20d63b7 sha1 2aea159b1e98a220a6e4534f0f017b8722ce4caa )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants and Friends Unite! (EU)"
+	description "Nickelodeon SpongeBob SquarePants and Friends Unite! (EU)"
+	rom ( name "Nickelodeon SpongeBob SquarePants and Friends Unite! (EU).iso" size 1459978240 crc a8ff9c4f md5 cd1e06f9ca333957b1dcd8dc2dfc7c64 sha1 35901972fcf5cf39ae72a6d8ec83fbdece393772 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants and Friends Unite! (Europe) (En,Fr,De,Nl)"
+	description "Nickelodeon SpongeBob SquarePants and Friends Unite! (Europe) (En,Fr,De,Nl)"
+	rom ( name "Nickelodeon SpongeBob SquarePants and Friends Unite! (Europe) (En,Fr,De,Nl).iso" size 1459978240 crc a8ff9c4f md5 cd1e06f9ca333957b1dcd8dc2dfc7c64 sha1 35901972fcf5cf39ae72a6d8ec83fbdece393772 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (EU)"
+	description "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (EU)"
+	rom ( name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (EU).iso" size 1459978240 crc dc6d2747 md5 f85c0da977ef6679de67d2d5532f9d23 sha1 528238ce6e7ccaf258e8e18dea59ba18730ca207 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (Europe)"
+	description "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (Europe)"
+	rom ( name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (Europe).iso" size 1459978240 crc dc6d2747 md5 f85c0da977ef6679de67d2d5532f9d23 sha1 528238ce6e7ccaf258e8e18dea59ba18730ca207 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (US)"
+	description "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (US)"
+	rom ( name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (US).iso" size 1459978240 crc 658f36bc md5 9e18f9a0032c4f3092945dc38a6517d3 sha1 9e13b75e3c045956fd5117821f53f7fce098c3fd )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (USA)"
+	description "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants in - Battle for Bikini Bottom (USA).iso" size 1459978240 crc 658f36bc md5 9e18f9a0032c4f3092945dc38a6517d3 sha1 9e13b75e3c045956fd5117821f53f7fce098c3fd )
+)
+
+game (
+	name "Nickelodeon Tak - The Great Juju Challenge (EU)"
+	description "Nickelodeon Tak - The Great Juju Challenge (EU)"
+	rom ( name "Nickelodeon Tak - The Great Juju Challenge (EU).iso" size 1459978240 crc 287c43ea md5 92c8f09bdcfdf9c9aa50d73374403a08 sha1 a59cb3ce4636ecea77aa658af483dff4998f9f65 )
+)
+
+game (
+	name "Nickelodeon Tak - The Great Juju Challenge (Europe) (En,De)"
+	description "Nickelodeon Tak - The Great Juju Challenge (Europe) (En,De)"
+	rom ( name "Nickelodeon Tak - The Great Juju Challenge (Europe) (En,De).iso" size 1459978240 crc 287c43ea md5 92c8f09bdcfdf9c9aa50d73374403a08 sha1 a59cb3ce4636ecea77aa658af483dff4998f9f65 )
+)
+
+game (
+	name "Nickelodeon Tak - The Great Juju Challenge (US)"
+	description "Nickelodeon Tak - The Great Juju Challenge (US)"
+	rom ( name "Nickelodeon Tak - The Great Juju Challenge (US).iso" size 1459978240 crc 080ac649 md5 f27af4f1b85c7e1fd8f13abbc8f920a1 sha1 99ae73dc9a5e50380c8769d64acfcd41d26dcf3c )
+)
+
+game (
+	name "Nickelodeon Tak - The Great Juju Challenge (USA)"
+	description "Nickelodeon Tak - The Great Juju Challenge (USA)"
+	rom ( name "Nickelodeon Tak - The Great Juju Challenge (USA).iso" size 1459978240 crc 080ac649 md5 f27af4f1b85c7e1fd8f13abbc8f920a1 sha1 99ae73dc9a5e50380c8769d64acfcd41d26dcf3c )
+)
+
+game (
+	name "Nickelodeon Tak 2 - Der Stab der Traeume (DE)"
+	description "Nickelodeon Tak 2 - Der Stab der Traeume (DE)"
+	rom ( name "Nickelodeon Tak 2 - Der Stab der Traeume (DE).iso" size 1459978240 crc a72f2241 md5 60f8e0f2d4fe756c9845c998ce097b3b sha1 afebcc1e47e0a1936beb784da136d5a323a14449 )
+)
+
+game (
+	name "Nickelodeon Tak 2 - Der Stab der Traeume (Germany)"
+	description "Nickelodeon Tak 2 - Der Stab der Traeume (Germany)"
+	rom ( name "Nickelodeon Tak 2 - Der Stab der Traeume (Germany).iso" size 1459978240 crc a72f2241 md5 60f8e0f2d4fe756c9845c998ce097b3b sha1 afebcc1e47e0a1936beb784da136d5a323a14449 )
+)
+
+game (
+	name "Nickelodeon Tak 2 - Le Sceptre des Reves (FR)"
+	description "Nickelodeon Tak 2 - Le Sceptre des Reves (FR)"
+	rom ( name "Nickelodeon Tak 2 - Le Sceptre des Reves (FR).iso" size 1459978240 crc b2d3bd98 md5 4072bd6d33c57a8a3016c8358fef05b1 sha1 56d33130881314f01bfb0c604e260b0ad877e9c6 )
+)
+
+game (
+	name "Nickelodeon Tak 2 - Le Sceptre des Reves (France)"
+	description "Nickelodeon Tak 2 - Le Sceptre des Reves (France)"
+	rom ( name "Nickelodeon Tak 2 - Le Sceptre des Reves (France).iso" size 1459978240 crc b2d3bd98 md5 4072bd6d33c57a8a3016c8358fef05b1 sha1 56d33130881314f01bfb0c604e260b0ad877e9c6 )
+)
+
+game (
+	name "Nickelodeon Tak 2 - The Staff of Dreams (Europe)"
+	description "Nickelodeon Tak 2 - The Staff of Dreams (Europe)"
+	rom ( name "Nickelodeon Tak 2 - The Staff of Dreams (Europe).iso" size 1459978240 crc d6a7895c md5 929849c06e20d1799c371c162a373c03 sha1 c7567851d0e695ed08460d1f083296b4d87c381f )
+)
+
+game (
+	name "Nickelodeon Tak 2 - The Staff of Dreams (GB)"
+	description "Nickelodeon Tak 2 - The Staff of Dreams (GB)"
+	rom ( name "Nickelodeon Tak 2 - The Staff of Dreams (GB).iso" size 1459978240 crc d6a7895c md5 929849c06e20d1799c371c162a373c03 sha1 c7567851d0e695ed08460d1f083296b4d87c381f )
+)
+
+game (
+	name "Nickelodeon Tak 2 - The Staff of Dreams (US)"
+	description "Nickelodeon Tak 2 - The Staff of Dreams (US)"
+	rom ( name "Nickelodeon Tak 2 - The Staff of Dreams (US).iso" size 1459978240 crc ca5ada0f md5 0d9a7c74d1ff98dd5ad867bd67377bb1 sha1 bc36de899604771551b93638ce204da92e0b7582 )
+)
+
+game (
+	name "Nickelodeon Tak 2 - The Staff of Dreams (USA)"
+	description "Nickelodeon Tak 2 - The Staff of Dreams (USA)"
+	rom ( name "Nickelodeon Tak 2 - The Staff of Dreams (USA).iso" size 1459978240 crc ca5ada0f md5 0d9a7c74d1ff98dd5ad867bd67377bb1 sha1 bc36de899604771551b93638ce204da92e0b7582 )
+)
+
+game (
+	name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (Europe)"
+	description "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (Europe)"
+	rom ( name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (Europe).iso" size 1459978240 crc ee46773d md5 28b5c7152cddd8a572058d55ecf9459c sha1 e54a16d80d6b1dcbaf77619151cf472b3245347a )
+)
+
+game (
+	name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (GB)"
+	description "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (GB)"
+	rom ( name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (GB).iso" size 1459978240 crc ee46773d md5 28b5c7152cddd8a572058d55ecf9459c sha1 e54a16d80d6b1dcbaf77619151cf472b3245347a )
+)
+
+game (
+	name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (US)"
+	description "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (US)"
+	rom ( name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (US).iso" size 1459978240 crc 71ce8acf md5 2d0776c1e7193ead437ed26239f89aae sha1 16d6b0de926486764e7c4e9cef659d99a20308a7 )
+)
+
+game (
+	name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (USA)"
+	description "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (USA)"
+	rom ( name "Nickelodeon The Adventures of Jimmy Neutron - Boy Genius - Jet Fusion (USA).iso" size 1459978240 crc 71ce8acf md5 2d0776c1e7193ead437ed26239f89aae sha1 16d6b0de926486764e7c4e9cef659d99a20308a7 )
+)
+
+game (
+	name "Nicktoons - Battle for Volcano Island (US)"
+	description "Nicktoons - Battle for Volcano Island (US)"
+	rom ( name "Nicktoons - Battle for Volcano Island (US).iso" size 1459978240 crc a66a86f7 md5 cd9584b6abd10a30d18bace5af7435c5 sha1 df028b9b6cc724a19ea17f4462a0277a5ff73a23 )
+)
+
+game (
+	name "Nicktoons - Battle for Volcano Island (USA)"
+	description "Nicktoons - Battle for Volcano Island (USA)"
+	rom ( name "Nicktoons - Battle for Volcano Island (USA).iso" size 1459978240 crc a66a86f7 md5 cd9584b6abd10a30d18bace5af7435c5 sha1 df028b9b6cc724a19ea17f4462a0277a5ff73a23 )
+)
+
+game (
+	name "Nicktoons Unite! (US)"
+	description "Nicktoons Unite! (US)"
+	rom ( name "Nicktoons Unite! (US).iso" size 1459978240 crc c0bda1f6 md5 232fce9fef02b7bf2df4d77f3f479521 sha1 00443381af33ec2715ac60dfc251eb5a3553158a )
+)
+
+game (
+	name "Nicktoons Unite! (USA)"
+	description "Nicktoons Unite! (USA)"
+	rom ( name "Nicktoons Unite! (USA).iso" size 1459978240 crc c0bda1f6 md5 232fce9fef02b7bf2df4d77f3f479521 sha1 00443381af33ec2715ac60dfc251eb5a3553158a )
+)
+
+game (
+	name "Nintendo GameCube Preview Disc - May 2003 (US)"
+	description "Nintendo GameCube Preview Disc - May 2003 (US)"
+	rom ( name "Nintendo GameCube Preview Disc - May 2003 (US).iso" size 1459978240 crc d45c8c07 md5 73e092844193533bfd6d5c27034446a3 sha1 43047f599583e1b0357881d21cba2e3958c57822 )
+)
+
+game (
+	name "Nintendo GameCube Preview Disc - May 2003 (USA)"
+	description "Nintendo GameCube Preview Disc - May 2003 (USA)"
+	rom ( name "Nintendo GameCube Preview Disc - May 2003 (USA).iso" size 1459978240 crc d45c8c07 md5 73e092844193533bfd6d5c27034446a3 sha1 43047f599583e1b0357881d21cba2e3958c57822 )
+)
+
+game (
+	name "Nintendo GameCube Service Disc Version 1.0-03 (US)"
+	description "Nintendo GameCube Service Disc Version 1.0-03 (US)"
+	rom ( name "Nintendo GameCube Service Disc Version 1.0-03 (US).iso" size 1459978240 crc be031bbe md5 536dba21b557c8d8cd8292534cfaa260 sha1 64099291333796b56a0431ace77c0f30e3ff77a9 )
+)
+
+game (
+	name "Nintendo GameCube Service Disc Version 1.0-03 (USA)"
+	description "Nintendo GameCube Service Disc Version 1.0-03 (USA)"
+	rom ( name "Nintendo GameCube Service Disc Version 1.0-03 (USA).iso" size 1459978240 crc be031bbe md5 536dba21b557c8d8cd8292534cfaa260 sha1 64099291333796b56a0431ace77c0f30e3ff77a9 )
+)
+
+game (
+	name "Nintendo GameCube Soft e-Catalogue 2003 Spring (Japan)"
+	description "Nintendo GameCube Soft e-Catalogue 2003 Spring (Japan)"
+	rom ( name "Nintendo GameCube Soft e-Catalogue 2003 Spring (Japan).iso" size 1459978240 crc d38bdbd7 md5 b753e4fa6923e421432eb6decf1dffb3 sha1 f4c7eee5872f06efc8dbe15b0a315d18374082fa )
+)
+
+game (
+	name "Nintendo GameCube Soft e-Catalogue 2003 Spring (JP) - nintendogemukiyubusohutoekatarogu 2003Chun"
+	description "Nintendo GameCube Soft e-Catalogue 2003 Spring (JP) - nintendogemukiyubusohutoekatarogu 2003Chun"
+	rom ( name "Nintendo GameCube Soft e-Catalogue 2003 Spring (JP).iso" size 1459978240 crc d38bdbd7 md5 b753e4fa6923e421432eb6decf1dffb3 sha1 f4c7eee5872f06efc8dbe15b0a315d18374082fa )
+)
+
+game (
+	name "Nintendo Puzzle Collection (Japan)"
+	description "Nintendo Puzzle Collection (Japan)"
+	rom ( name "Nintendo Puzzle Collection (Japan).iso" size 1459978240 crc 496105d8 md5 deff493b8e1631e89e320dbf1e54a36c sha1 4b5056c7ed26877cd8b5e46e567c520eb79ad27d )
+)
+
+game (
+	name "Nintendo Puzzle Collection GBA Link Cable) (JP) - NINTENDO+pazurukorekusiyon"
+	description "Nintendo Puzzle Collection GBA Link Cable) (JP) - NINTENDO+pazurukorekusiyon"
+	rom ( name "Nintendo Puzzle Collection GBA Link Cable) (JP).iso" size 1459978240 crc 496105d8 md5 deff493b8e1631e89e320dbf1e54a36c sha1 4b5056c7ed26877cd8b5e46e567c520eb79ad27d )
+)
+
+game (
+	name "Odama (EU)"
+	description "Odama (EU)"
+	rom ( name "Odama (EU).iso" size 1459978240 crc 54960550 md5 86b28367df1dbb2087a1d895f2fe6da5 sha1 5cdf4043e6537e6443ef1e7e6b938b433711c89a )
+)
+
+game (
+	name "Odama (Europe) (En,Fr,De,Es,It)"
+	description "Odama (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Odama (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 54960550 md5 86b28367df1dbb2087a1d895f2fe6da5 sha1 5cdf4043e6537e6443ef1e7e6b938b433711c89a )
+)
+
+game (
+	name "Odama (Japan)"
+	description "Odama (Japan)"
+	rom ( name "Odama (Japan).iso" size 1459978240 crc e90214a2 md5 0e15f80a6409b292b2aec19ac70e01b5 sha1 f2d7e61e83097de275e098dc04efa70d8af8575e )
+)
+
+game (
+	name "Odama (Microphone) (JP) - Da Yu"
+	description "Odama (Microphone) (JP) - Da Yu"
+	rom ( name "Odama (Microphone) (JP).iso" size 1459978240 crc e90214a2 md5 0e15f80a6409b292b2aec19ac70e01b5 sha1 f2d7e61e83097de275e098dc04efa70d8af8575e )
+)
+
+game (
+	name "Odama (US)"
+	description "Odama (US)"
+	rom ( name "Odama (US).iso" size 1459978240 crc 489f7c1a md5 27116ebb1bd8a71ca2f7be022a3e32a1 sha1 17802b5cd6f768fffdc896194cb5643a450b02c5 )
+)
+
+game (
+	name "Odama (USA)"
+	description "Odama (USA)"
+	rom ( name "Odama (USA).iso" size 1459978240 crc 489f7c1a md5 27116ebb1bd8a71ca2f7be022a3e32a1 sha1 17802b5cd6f768fffdc896194cb5643a450b02c5 )
+)
+
+game (
+	name "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (Japan)"
+	description "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (Japan)"
+	rom ( name "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (Japan).iso" size 1459978240 crc 7ada6106 md5 a01fb3bfdf67817a92c68ed7a9ac0fe8 sha1 a599eef347b78c9aacf0a5d1ee069add88b56a90 )
+)
+
+game (
+	name "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (JP) - oBian Lu san+Fa Xin noDao Chang +(A Bo Guo )+Bian"
+	description "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (JP) - oBian Lu san+Fa Xin noDao Chang +(A Bo Guo )+Bian"
+	rom ( name "Ohenro-San - Hosshin no Dojo (Awa Kuni) Hen (JP).iso" size 1459978240 crc 7ada6106 md5 a01fb3bfdf67817a92c68ed7a9ac0fe8 sha1 a599eef347b78c9aacf0a5d1ee069add88b56a90 )
+)
+
+game (
+	name "One Piece - Grand Battle! 3 (Japan)"
+	description "One Piece - Grand Battle! 3 (Japan)"
+	rom ( name "One Piece - Grand Battle! 3 (Japan).iso" size 1459978240 crc 4690825c md5 9d3003e2d67ee34090c7221b47fc6d32 sha1 0d1843e9a9d745d24e419e5051d92223619b79f0 )
+)
+
+game (
+	name "One Piece - Grand Battle! 3 (JP) - ONE PIECE ~gurandobatoru!3~"
+	description "One Piece - Grand Battle! 3 (JP) - ONE PIECE ~gurandobatoru!3~"
+	rom ( name "One Piece - Grand Battle! 3 (JP).iso" size 1459978240 crc 4690825c md5 9d3003e2d67ee34090c7221b47fc6d32 sha1 0d1843e9a9d745d24e419e5051d92223619b79f0 )
+)
+
+game (
+	name "One Piece - Grand Battle! Rush (Japan)"
+	description "One Piece - Grand Battle! Rush (Japan)"
+	rom ( name "One Piece - Grand Battle! Rush (Japan).iso" size 1459978240 crc 6aae2dfb md5 8409358fd01657ee5bb9d8e9a46fab56 sha1 06d781ecd8632f56ac62834b67c40069763d24e2 )
+)
+
+game (
+	name "One Piece - Grand Battle! Rush (JP) - wanpisu+gurabato!+ratusiyu"
+	description "One Piece - Grand Battle! Rush (JP) - wanpisu+gurabato!+ratusiyu"
+	rom ( name "One Piece - Grand Battle! Rush (JP).iso" size 1459978240 crc 6aae2dfb md5 8409358fd01657ee5bb9d8e9a46fab56 sha1 06d781ecd8632f56ac62834b67c40069763d24e2 )
+)
+
+game (
+	name "One Piece - Pirates Carnival (Japan)"
+	description "One Piece - Pirates Carnival (Japan)"
+	rom ( name "One Piece - Pirates Carnival (Japan).iso" size 1459978240 crc d959d086 md5 fffa57eea1ba8723ee256d2c26a83d8b sha1 5bbc976df9a49534988016f6b824a5ca1a35ba65 )
+)
+
+game (
+	name "One Piece - Pirates Carnival (JP) - wanpisu+pairetukanibaru"
+	description "One Piece - Pirates Carnival (JP) - wanpisu+pairetukanibaru"
+	rom ( name "One Piece - Pirates Carnival (JP).iso" size 1459978240 crc d959d086 md5 fffa57eea1ba8723ee256d2c26a83d8b sha1 5bbc976df9a49534988016f6b824a5ca1a35ba65 )
+)
+
+game (
+	name "Open Season (DE^IT)"
+	description "Open Season (DE^IT)"
+	rom ( name "Open Season (DE^IT).iso" size 1459978240 crc 310c93fc md5 031fc87bf00373181fb9531102beaef8 sha1 b62fb4cf77b66a8b0c0acb6cac44f5ae6986e550 )
+)
+
+game (
+	name "Open Season (EU)"
+	description "Open Season (EU)"
+	rom ( name "Open Season (EU).iso" size 1459978240 crc f80e5aed md5 56fd2ac0586c82c3b2700b3292be644d sha1 cae1c86621af41c166b447b1ce06d56f4339e6a2 )
+)
+
+game (
+	name "Open Season (Europe) (En,Fr,De,Es,It)"
+	description "Open Season (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Open Season (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 310c93fc md5 031fc87bf00373181fb9531102beaef8 sha1 b62fb4cf77b66a8b0c0acb6cac44f5ae6986e550 )
+)
+
+game (
+	name "Open Season (Europe) (En,Fr,Es)"
+	description "Open Season (Europe) (En,Fr,Es)"
+	rom ( name "Open Season (Europe) (En,Fr,Es).iso" size 1459978240 crc f80e5aed md5 56fd2ac0586c82c3b2700b3292be644d sha1 cae1c86621af41c166b447b1ce06d56f4339e6a2 )
+)
+
+game (
+	name "Open Season (US)"
+	description "Open Season (US)"
+	rom ( name "Open Season (US).iso" size 1459978240 crc 59d09ea9 md5 1b6080380144f968e2b36990a0a46d23 sha1 61e04f1dbfea8c34024638bbfda544b50abe33fe )
+)
+
+game (
+	name "Open Season (USA) (En,Fr,Es)"
+	description "Open Season (USA) (En,Fr,Es)"
+	rom ( name "Open Season (USA) (En,Fr,Es).iso" size 1459978240 crc 59d09ea9 md5 1b6080380144f968e2b36990a0a46d23 sha1 61e04f1dbfea8c34024638bbfda544b50abe33fe )
+)
+
+game (
+	name "Outlaw Golf (EU)"
+	description "Outlaw Golf (EU)"
+	rom ( name "Outlaw Golf (EU).iso" size 1459978240 crc 5bb255fd md5 72eb900e042e9c76061def3e6fcead7d sha1 d47e5ee854970e415b7e2ccbb793945522411795 )
+)
+
+game (
+	name "Outlaw Golf (Europe) (En,Fr,De)"
+	description "Outlaw Golf (Europe) (En,Fr,De)"
+	rom ( name "Outlaw Golf (Europe) (En,Fr,De).iso" size 1459978240 crc 5bb255fd md5 72eb900e042e9c76061def3e6fcead7d sha1 d47e5ee854970e415b7e2ccbb793945522411795 )
+)
+
+game (
+	name "Outlaw Golf (US)"
+	description "Outlaw Golf (US)"
+	rom ( name "Outlaw Golf (US).iso" size 1459978240 crc 3054d0fd md5 a000c965968d98aeec0fe84598e02443 sha1 3806d257bee314a59ff443426549cf6cfa239fc1 )
+)
+
+game (
+	name "Outlaw Golf (USA)"
+	description "Outlaw Golf (USA)"
+	rom ( name "Outlaw Golf (USA).iso" size 1459978240 crc 3054d0fd md5 a000c965968d98aeec0fe84598e02443 sha1 3806d257bee314a59ff443426549cf6cfa239fc1 )
+)
+
+game (
+	name "P.N. 03 (Demo) (EU)"
+	description "P.N. 03 (Demo) (EU)"
+	rom ( name "P.N. 03 (Demo) (EU).iso" size 1459978240 crc 965f3101 md5 9e61d49977f63c924c81d2f18e58b9bb sha1 ee9bbb75376ca8ca099d0501a244b5f1e40d44ee )
+)
+
+game (
+	name "P.N. 03 (EU)"
+	description "P.N. 03 (EU)"
+	rom ( name "P.N. 03 (EU).iso" size 1459978240 crc e8fcfd60 md5 a8b580c8a7473eef631d821d8dc0b500 sha1 aff34d325443c2f7f1f51c81630624cbd9ef0704 )
+)
+
+game (
+	name "P.N. 03 (Europe) (En,Fr,De,Es,It)"
+	description "P.N. 03 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "P.N. 03 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e8fcfd60 md5 a8b580c8a7473eef631d821d8dc0b500 sha1 aff34d325443c2f7f1f51c81630624cbd9ef0704 )
+)
+
+game (
+	name "P.N. 03 (Europe) (En,Fr,De,Es,It) (Demo)"
+	description "P.N. 03 (Europe) (En,Fr,De,Es,It) (Demo)"
+	rom ( name "P.N. 03 (Europe) (En,Fr,De,Es,It) (Demo).iso" size 1459978240 crc 965f3101 md5 9e61d49977f63c924c81d2f18e58b9bb sha1 ee9bbb75376ca8ca099d0501a244b5f1e40d44ee )
+)
+
+game (
+	name "P.N. 03 (Japan)"
+	description "P.N. 03 (Japan)"
+	rom ( name "P.N. 03 (Japan).iso" size 1459978240 crc eb535a34 md5 e2bcc58b1128db5a146d7b30b41459e3 sha1 95e52920a6baddf046f42cb8ffbdd85a17c2e0fd )
+)
+
+game (
+	name "P.N. 03 (JP) - pienusuri"
+	description "P.N. 03 (JP) - pienusuri"
+	rom ( name "P.N. 03 (JP).iso" size 1459978240 crc eb535a34 md5 e2bcc58b1128db5a146d7b30b41459e3 sha1 95e52920a6baddf046f42cb8ffbdd85a17c2e0fd )
+)
+
+game (
+	name "P.N. 03 (US)"
+	description "P.N. 03 (US)"
+	rom ( name "P.N. 03 (US).iso" size 1459978240 crc 24061157 md5 4af4013136bb2db2053b26e811c8f9c1 sha1 3be89d60c2c6d3ced85bf3b8af6475e71497a4b5 )
+)
+
+game (
+	name "P.N. 03 (USA)"
+	description "P.N. 03 (USA)"
+	rom ( name "P.N. 03 (USA).iso" size 1459978240 crc 24061157 md5 4af4013136bb2db2053b26e811c8f9c1 sha1 3be89d60c2c6d3ced85bf3b8af6475e71497a4b5 )
+)
+
+game (
+	name "Pac-Man Fever (US)"
+	description "Pac-Man Fever (US)"
+	rom ( name "Pac-Man Fever (US).iso" size 1459978240 crc 2e6425f3 md5 af91e12f3e9fa08ba748122f42690f0a sha1 f11a52dce24720f7e266f0bbc3aff94fef2f13e5 )
+)
+
+game (
+	name "Pac-Man Fever (USA)"
+	description "Pac-Man Fever (USA)"
+	rom ( name "Pac-Man Fever (USA).iso" size 1459978240 crc 2e6425f3 md5 af91e12f3e9fa08ba748122f42690f0a sha1 f11a52dce24720f7e266f0bbc3aff94fef2f13e5 )
+)
+
+game (
+	name "Pac-Man Vs. (EU)"
+	description "Pac-Man Vs. (EU)"
+	rom ( name "Pac-Man Vs. (EU).iso" size 1459978240 crc 46748a09 md5 a475bacb0b67f832f65b7f6e6325ed97 sha1 5b7ef96bc41af75388a06adc21f713cfd2a19abb )
+)
+
+game (
+	name "Pac-Man Vs. (Europe) (En,Fr,De,Es,It)"
+	description "Pac-Man Vs. (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pac-Man Vs. (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 46748a09 md5 a475bacb0b67f832f65b7f6e6325ed97 sha1 5b7ef96bc41af75388a06adc21f713cfd2a19abb )
+)
+
+game (
+	name "Pac-Man Vs. (Japan)"
+	description "Pac-Man Vs. (Japan)"
+	rom ( name "Pac-Man Vs. (Japan).iso" size 1459978240 crc 93a80006 md5 99821e6427280c55b00ff3fd6fdd3b94 sha1 29b08d9ea3c4bd37524b3cfbae356c82d82ee170 )
+)
+
+game (
+	name "Pac-Man Vs. (JP) - patukuman+VS."
+	description "Pac-Man Vs. (JP) - patukuman+VS."
+	rom ( name "Pac-Man Vs. (JP).iso" size 1459978240 crc 93a80006 md5 99821e6427280c55b00ff3fd6fdd3b94 sha1 29b08d9ea3c4bd37524b3cfbae356c82d82ee170 )
+)
+
+game (
+	name "Pac-Man Vs. (Promo) (US)"
+	description "Pac-Man Vs. (Promo) (US)"
+	rom ( name "Pac-Man Vs. (Promo) (US).iso" size 1459978240 crc ce5317c4 md5 e293a4c90bc4c91f51335ab68c6188da sha1 cda363b4e024b756597bb3d4808df56322953f28 )
+)
+
+game (
+	name "Pac-Man Vs. (USA)"
+	description "Pac-Man Vs. (USA)"
+	rom ( name "Pac-Man Vs. (USA).iso" size 1459978240 crc ce5317c4 md5 e293a4c90bc4c91f51335ab68c6188da sha1 cda363b4e024b756597bb3d4808df56322953f28 )
+)
+
+game (
+	name "Pac-Man World 2 (EU)"
+	description "Pac-Man World 2 (EU)"
+	rom ( name "Pac-Man World 2 (EU).iso" size 1459978240 crc ef936793 md5 b8ffac2f417f23521af659340517640d sha1 cd0c009c10cf57c5e50115e7c97903f46fa606ef )
+)
+
+game (
+	name "Pac-Man World 2 (Europe) (En,Fr,De,Es,It)"
+	description "Pac-Man World 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pac-Man World 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ef936793 md5 b8ffac2f417f23521af659340517640d sha1 cd0c009c10cf57c5e50115e7c97903f46fa606ef )
+)
+
+game (
+	name "Pac-Man World 2 (Player's Choice) (US)"
+	description "Pac-Man World 2 (Player's Choice) (US)"
+	rom ( name "Pac-Man World 2 (Player's Choice) (US).iso" size 1459978240 crc 3e95583a md5 d35c1bd0d46f4642e5e9dc5d87d420c6 sha1 3bbedcca3b1118872483bccf41f0f0893ed90ef2 )
+)
+
+game (
+	name "Pac-Man World 2 (USA)"
+	description "Pac-Man World 2 (USA)"
+	rom ( name "Pac-Man World 2 (USA).iso" size 1459978240 crc 3e95583a md5 d35c1bd0d46f4642e5e9dc5d87d420c6 sha1 3bbedcca3b1118872483bccf41f0f0893ed90ef2 )
+)
+
+game (
+	name "Pac-Man World 3 (EU)"
+	description "Pac-Man World 3 (EU)"
+	rom ( name "Pac-Man World 3 (EU).iso" size 1459978240 crc 5ad70cd5 md5 2ab9caf12b9a03d8272190d03d77d122 sha1 019c79aefa0f8aaaa66379137aead237848acf94 )
+)
+
+game (
+	name "Pac-Man World 3 (Europe) (En,Fr,De,Es,It)"
+	description "Pac-Man World 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pac-Man World 3 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 5ad70cd5 md5 2ab9caf12b9a03d8272190d03d77d122 sha1 019c79aefa0f8aaaa66379137aead237848acf94 )
+)
+
+game (
+	name "Pac-Man World 3 (US)"
+	description "Pac-Man World 3 (US)"
+	rom ( name "Pac-Man World 3 (US).iso" size 1459978240 crc 694b5e2d md5 65db291bba4770479fc822c119792582 sha1 bbea03f66ce62f95a1c1daad05d4b5b1fe1178e9 )
+)
+
+game (
+	name "Pac-Man World 3 (USA)"
+	description "Pac-Man World 3 (USA)"
+	rom ( name "Pac-Man World 3 (USA).iso" size 1459978240 crc 694b5e2d md5 65db291bba4770479fc822c119792582 sha1 bbea03f66ce62f95a1c1daad05d4b5b1fe1178e9 )
+)
+
+game (
+	name "Pac-Man World Rally (US)"
+	description "Pac-Man World Rally (US)"
+	rom ( name "Pac-Man World Rally (US).iso" size 1459978240 crc c2e521a7 md5 c88e8c76ba0323526f5d30afe33fc3fd sha1 3e801ad28da1413e706c4b9bfc26eb2ec9d79033 )
+)
+
+game (
+	name "Pac-Man World Rally (USA)"
+	description "Pac-Man World Rally (USA)"
+	rom ( name "Pac-Man World Rally (USA).iso" size 1459978240 crc c2e521a7 md5 c88e8c76ba0323526f5d30afe33fc3fd sha1 3e801ad28da1413e706c4b9bfc26eb2ec9d79033 )
+)
+
+game (
+	name "Paper Mario - The Thousand-Year Door (EU)"
+	description "Paper Mario - The Thousand-Year Door (EU)"
+	rom ( name "Paper Mario - The Thousand-Year Door (EU).iso" size 1459978240 crc a624277b md5 81321e8256205e3cfb71257e6ba2970f sha1 e751145434aad75cc1f363ea25ec71e2b69f950e )
+)
+
+game (
+	name "Paper Mario - The Thousand-Year Door (Europe) (En,Fr,De,Es,It)"
+	description "Paper Mario - The Thousand-Year Door (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Paper Mario - The Thousand-Year Door (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a624277b md5 81321e8256205e3cfb71257e6ba2970f sha1 e751145434aad75cc1f363ea25ec71e2b69f950e )
+)
+
+game (
+	name "Paper Mario - The Thousand-Year Door (US)"
+	description "Paper Mario - The Thousand-Year Door (US)"
+	rom ( name "Paper Mario - The Thousand-Year Door (US).iso" size 1459978240 crc 5a682160 md5 db9a997a617ee03bbc32336d6945ec02 sha1 8e403c1cb6a51967698b0bfeafdaf2a4fa96a61f )
+)
+
+game (
+	name "Paper Mario - The Thousand-Year Door (USA)"
+	description "Paper Mario - The Thousand-Year Door (USA)"
+	rom ( name "Paper Mario - The Thousand-Year Door (USA).iso" size 1459978240 crc 5a682160 md5 db9a997a617ee03bbc32336d6945ec02 sha1 8e403c1cb6a51967698b0bfeafdaf2a4fa96a61f )
+)
+
+game (
+	name "Paper Mario RPG (Japan)"
+	description "Paper Mario RPG (Japan)"
+	rom ( name "Paper Mario RPG (Japan).iso" size 1459978240 crc 0f35e6ed md5 bec52fb8c1912bc6f8014801b6281422 sha1 2b3d283d539c14976ee790894b079ca5aa2a0f81 )
+)
+
+game (
+	name "Paper Mario RPG (JP) - pepamarioRPG"
+	description "Paper Mario RPG (JP) - pepamarioRPG"
+	rom ( name "Paper Mario RPG (JP).iso" size 1459978240 crc 0f35e6ed md5 bec52fb8c1912bc6f8014801b6281422 sha1 2b3d283d539c14976ee790894b079ca5aa2a0f81 )
+)
+
+game (
+	name "Peter Jackson's King Kong - The Official Game of the Movie (EU)"
+	description "Peter Jackson's King Kong - The Official Game of the Movie (EU)"
+	rom ( name "Peter Jackson's King Kong - The Official Game of the Movie (EU).iso" size 1459978240 crc 974eaebf md5 7552639b78544caff01d5690f5945a52 sha1 e49408083fa13aeb8834fbafba599a7f8951e288 )
+)
+
+game (
+	name "Peter Jackson's King Kong - The Official Game of the Movie (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
+	description "Peter Jackson's King Kong - The Official Game of the Movie (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
+	rom ( name "Peter Jackson's King Kong - The Official Game of the Movie (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).iso" size 1459978240 crc 974eaebf md5 7552639b78544caff01d5690f5945a52 sha1 e49408083fa13aeb8834fbafba599a7f8951e288 )
+)
+
+game (
+	name "Peter Jackson's King Kong - The Official Game of the Movie (US)"
+	description "Peter Jackson's King Kong - The Official Game of the Movie (US)"
+	rom ( name "Peter Jackson's King Kong - The Official Game of the Movie (US).iso" size 1459978240 crc eeffa5eb md5 8ac57d2645ed752a491bd9f88703d394 sha1 1db20e6c9cd7a238e3d13d5726c342b6c4ca7cea )
+)
+
+game (
+	name "Peter Jackson's King Kong - The Official Game of the Movie (USA) (En,Fr,Es)"
+	description "Peter Jackson's King Kong - The Official Game of the Movie (USA) (En,Fr,Es)"
+	rom ( name "Peter Jackson's King Kong - The Official Game of the Movie (USA) (En,Fr,Es).iso" size 1459978240 crc eeffa5eb md5 8ac57d2645ed752a491bd9f88703d394 sha1 1db20e6c9cd7a238e3d13d5726c342b6c4ca7cea )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (EU)"
+	description "Phantasy Star Online Episode I & II (EU)"
+	rom ( name "Phantasy Star Online Episode I & II (EU).iso" size 1459978240 crc c9c7fbfe md5 ee4c772cc90ecb6537a331538e1bf4db sha1 da74531ed5bd62af29af4afe8ac33d97b0d21d4c )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (Europe) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Episode I & II (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Episode I & II (Europe) (En,Ja,Fr,De,Es).iso" size 1459978240 crc c9c7fbfe md5 ee4c772cc90ecb6537a331538e1bf4db sha1 da74531ed5bd62af29af4afe8ac33d97b0d21d4c )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (Japan) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Episode I & II (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Episode I & II (Japan) (En,Ja,Fr,De,Es).iso" size 1459978240 crc 15652426 md5 b4e4f4a315c485868437a010deb72aee sha1 e83d1f1e414ef9fee3de9a7e9bf792065ef529fd )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (JP) - huantasisutaonrain episodo1&2"
+	description "Phantasy Star Online Episode I & II (JP) - huantasisutaonrain episodo1&2"
+	rom ( name "Phantasy Star Online Episode I & II (JP).iso" size 1459978240 crc 15652426 md5 b4e4f4a315c485868437a010deb72aee sha1 e83d1f1e414ef9fee3de9a7e9bf792065ef529fd )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (US)"
+	description "Phantasy Star Online Episode I & II (US)"
+	rom ( name "Phantasy Star Online Episode I & II (US) - [v1.00].iso" size 1459978240 crc 25b0368b md5 478bf75c63d6ff30315c9b34cee288ab sha1 d6b591ddc34e689d6792fa5190feda88e969c041 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.00)"
+	description "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.00)"
+	rom ( name "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.00).iso" size 1459978240 crc 25b0368b md5 478bf75c63d6ff30315c9b34cee288ab sha1 d6b591ddc34e689d6792fa5190feda88e969c041 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.01)"
+	description "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.01)"
+	rom ( name "Phantasy Star Online Episode I & II (USA) (En,Ja,Fr,De,Es) (v1.01).iso" size 1459978240 crc 98e98759 md5 81724d71a2143a4fccf49020737d3add sha1 2b7eda3e2f7bdc7479f803684a590992377a4617 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Plus (Japan) (En,Ja,Fr,De,Es) (v1.05)"
+	description "Phantasy Star Online Episode I & II Plus (Japan) (En,Ja,Fr,De,Es) (v1.05)"
+	rom ( name "Phantasy Star Online Episode I & II Plus (Japan) (En,Ja,Fr,De,Es) (v1.05).iso" size 1459978240 crc 42c1febd md5 23384e9d3dd6e28dba39231660d1fcad sha1 33616332f2be3ef1538fe488f6bcdbd3c368d041 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Plus (JP) - huantasisutaonrain episodo1&2 purasu"
+	description "Phantasy Star Online Episode I & II Plus (JP) - huantasisutaonrain episodo1&2 purasu"
+	rom ( name "Phantasy Star Online Episode I & II Plus (JP) - [v1.05].iso" size 1459978240 crc 42c1febd md5 23384e9d3dd6e28dba39231660d1fcad sha1 33616332f2be3ef1538fe488f6bcdbd3c368d041 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Plus (US)"
+	description "Phantasy Star Online Episode I & II Plus (US)"
+	rom ( name "Phantasy Star Online Episode I & II Plus (US).iso" size 1459978240 crc cdc9bc9a md5 36a7f90ad904975b745df9294a06baea sha1 0ff155311f4cc57951c03baeb1a8cc15de5fe1cd )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Plus (USA) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Episode I & II Plus (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Episode I & II Plus (USA) (En,Ja,Fr,De,Es).iso" size 1459978240 crc cdc9bc9a md5 36a7f90ad904975b745df9294a06baea sha1 0ff155311f4cc57951c03baeb1a8cc15de5fe1cd )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Trial (Taikenban) (JP) - huantasi+suta+onrain+Episode+I&II+toraiaru+edeisiyon"
+	description "Phantasy Star Online Episode I & II Trial (Taikenban) (JP) - huantasi+suta+onrain+Episode+I&II+toraiaru+edeisiyon"
+	rom ( name "Phantasy Star Online Episode I & II Trial (Taikenban) (JP).iso" size 1459978240 crc 53a6f59c md5 344add1b5b11771f3b01ff47e8606063 sha1 aab94bda129e5ccef426b3a7146b2dcd364c9f93 )
+)
+
+game (
+	name "Phantasy Star Online Episode I & II Trial Edition (Japan) (Taikenban)"
+	description "Phantasy Star Online Episode I & II Trial Edition (Japan) (Taikenban)"
+	rom ( name "Phantasy Star Online Episode I & II Trial Edition (Japan) (Taikenban).iso" size 1459978240 crc 53a6f59c md5 344add1b5b11771f3b01ff47e8606063 sha1 aab94bda129e5ccef426b3a7146b2dcd364c9f93 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Europe) (En,Ja,Fr,De,Es)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Europe) (En,Ja,Fr,De,Es).iso" size 1459978240 crc c09ffb89 md5 d4f78ba62b93f609d3867e6fddffed71 sha1 00767e70e10f27da343476900e98cc8988629ba7 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (GB)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (GB)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (GB).iso" size 1459978240 crc c09ffb89 md5 d4f78ba62b93f609d3867e6fddffed71 sha1 00767e70e10f27da343476900e98cc8988629ba7 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan).iso" size 1459978240 crc 37f76934 md5 bf25d3ae9cd5eb4827ec8f77fe367006 sha1 20a9fcee7b5374ba90fc14fd0cc9562f318cfff0 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan) (Taikenban)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan) (Taikenban)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Japan) (Taikenban).iso" size 1459978240 crc 230570e1 md5 9bb50932002a39647afb23ad7b0a8b9a sha1 053dd0cf25247dd087fec77a2d5018d7c58a6979 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (JP) - huantasisutaonrain+episodo3+kadoreboriyusiyon"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (JP) - huantasisutaonrain+episodo3+kadoreboriyusiyon"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (JP).iso" size 1459978240 crc 37f76934 md5 bf25d3ae9cd5eb4827ec8f77fe367006 sha1 20a9fcee7b5374ba90fc14fd0cc9562f318cfff0 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Taikenban) (JP) - huantasisutaonrainepisodo3 ~kadoreboriyusiyon~ toraiaruedeisiyon"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (Taikenban) (JP) - huantasisutaonrainepisodo3 ~kadoreboriyusiyon~ toraiaruedeisiyon"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (Taikenban) (JP).iso" size 1459978240 crc 230570e1 md5 9bb50932002a39647afb23ad7b0a8b9a sha1 053dd0cf25247dd087fec77a2d5018d7c58a6979 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (US)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (US)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (US).iso" size 1459978240 crc 45f216fe md5 c0d2c8a25b12249ee70c5655b2270069 sha1 a394d642a90a0d233aecb34743d8f484753d2056 )
+)
+
+game (
+	name "Phantasy Star Online Episode III - C.A.R.D. Revolution (USA) (En,Ja)"
+	description "Phantasy Star Online Episode III - C.A.R.D. Revolution (USA) (En,Ja)"
+	rom ( name "Phantasy Star Online Episode III - C.A.R.D. Revolution (USA) (En,Ja).iso" size 1459978240 crc 45f216fe md5 c0d2c8a25b12249ee70c5655b2270069 sha1 a394d642a90a0d233aecb34743d8f484753d2056 )
+)
+
+game (
+	name "Pikmin (EU)"
+	description "Pikmin (EU)"
+	rom ( name "Pikmin (EU).iso" size 1459978240 crc 07ae1f8b md5 f8a29cb63d0599f8297efa899a504ebf sha1 40c46bd6921e55558e9838930a9ffd2179802b4f )
+)
+
+game (
+	name "Pikmin (Europe) (En,Fr,De,Es,It)"
+	description "Pikmin (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pikmin (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 07ae1f8b md5 f8a29cb63d0599f8297efa899a504ebf sha1 40c46bd6921e55558e9838930a9ffd2179802b4f )
+)
+
+game (
+	name "Pikmin (Japan) (Jitsuen-you Sample)"
+	description "Pikmin (Japan) (Jitsuen-you Sample)"
+	rom ( name "Pikmin (Japan) (Jitsuen-you Sample).iso" size 1459978240 crc d38f1968 md5 6e5d520487c7f2473c98ae1718314e2c sha1 a9be88b47aa7927e1cd9eab70857bc72f47d8edd )
+)
+
+game (
+	name "Pikmin (Japan) (v1.01)"
+	description "Pikmin (Japan) (v1.01)"
+	rom ( name "Pikmin (Japan) (v1.01).iso" size 1459978240 crc 3371b99a md5 1fe42e4bdb0ef1442103c74fca7c9dce sha1 a78b8f20928822edd4ba76c4a80cd9fe7175fba6 )
+)
+
+game (
+	name "Pikmin (Japan) (v1.02)"
+	description "Pikmin (Japan) (v1.02)"
+	rom ( name "Pikmin (Japan) (v1.02).iso" size 1459978240 crc 3145afbc md5 859749be98199eef4ea1ffe412053624 sha1 c0e1987321e114d743167dd093e835387f32a00f )
+)
+
+game (
+	name "Pikmin (JP) - pikumin"
+	description "Pikmin (JP) - pikumin"
+	rom ( name "Pikmin (JP) - [v1.00].iso" size 1459978240 crc 3371b99a md5 1fe42e4bdb0ef1442103c74fca7c9dce sha1 a78b8f20928822edd4ba76c4a80cd9fe7175fba6 )
+)
+
+game (
+	name "Pikmin (Player's Choice) (US)"
+	description "Pikmin (Player's Choice) (US)"
+	rom ( name "Pikmin (Player's Choice) (US) - [v1.01].iso" size 1459978240 crc 5c680247 md5 a249b6aac02b24223b0156fc2eaf8853 sha1 23a153cb225fef488f57073e76df0de26789c218 )
+)
+
+game (
+	name "Pikmin (US)"
+	description "Pikmin (US)"
+	rom ( name "Pikmin (US) - [v1.00].iso" size 1459978240 crc be71db21 md5 ad7cabf64f5e8446596407dc537867a7 sha1 8e1281a16c94b27b007a2af475128e68e967503b )
+)
+
+game (
+	name "Pikmin (USA) (v1.00)"
+	description "Pikmin (USA) (v1.00)"
+	rom ( name "Pikmin (USA) (v1.00).iso" size 1459978240 crc be71db21 md5 ad7cabf64f5e8446596407dc537867a7 sha1 8e1281a16c94b27b007a2af475128e68e967503b )
+)
+
+game (
+	name "Pikmin (USA) (v1.01)"
+	description "Pikmin (USA) (v1.01)"
+	rom ( name "Pikmin (USA) (v1.01).iso" size 1459978240 crc 5c680247 md5 a249b6aac02b24223b0156fc2eaf8853 sha1 23a153cb225fef488f57073e76df0de26789c218 )
+)
+
+game (
+	name "Pikmin 2 (EU)"
+	description "Pikmin 2 (EU)"
+	rom ( name "Pikmin 2 (EU).iso" size 1459978240 crc 9b7d1623 md5 1b4f19133c426b18ba782be83a8a31a9 sha1 38ffc0b79d0fbe327ef4b09fd62521ff7bf9b07c )
+)
+
+game (
+	name "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
+	description "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pikmin 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9b7d1623 md5 1b4f19133c426b18ba782be83a8a31a9 sha1 38ffc0b79d0fbe327ef4b09fd62521ff7bf9b07c )
+)
+
+game (
+	name "Pikmin 2 (Japan)"
+	description "Pikmin 2 (Japan)"
+	rom ( name "Pikmin 2 (Japan).iso" size 1459978240 crc 157317e3 md5 4276b6a56cc117d2f6ac711a542ea415 sha1 c34ad9436df91b5c22e1f48273651bf2a58e56c0 )
+)
+
+game (
+	name "Pikmin 2 (JP) - pikumin2"
+	description "Pikmin 2 (JP) - pikumin2"
+	rom ( name "Pikmin 2 (JP).iso" size 1459978240 crc 157317e3 md5 4276b6a56cc117d2f6ac711a542ea415 sha1 c34ad9436df91b5c22e1f48273651bf2a58e56c0 )
+)
+
+game (
+	name "Pikmin 2 (US)"
+	description "Pikmin 2 (US)"
+	rom ( name "Pikmin 2 (US).iso" size 1459978240 crc 3541416b md5 66f8d886afa0742cd9901d1bfe3b114f sha1 63a68c656d654388e096d27a768e85823dcf3327 )
+)
+
+game (
+	name "Pikmin 2 (USA)"
+	description "Pikmin 2 (USA)"
+	rom ( name "Pikmin 2 (USA).iso" size 1459978240 crc 3541416b md5 66f8d886afa0742cd9901d1bfe3b114f sha1 63a68c656d654388e096d27a768e85823dcf3327 )
+)
+
+game (
+	name "Pinball Hall of Fame - The Gottlieb Collection (US)"
+	description "Pinball Hall of Fame - The Gottlieb Collection (US)"
+	rom ( name "Pinball Hall of Fame - The Gottlieb Collection (US).iso" size 1459978240 crc aa588203 md5 5dbd5ef2b1c70dfae4bb82055ee83200 sha1 b9d482889c6e517fc6e1a4ef5fac357743707cdb )
+)
+
+game (
+	name "Pinball Hall of Fame - The Gottlieb Collection (USA)"
+	description "Pinball Hall of Fame - The Gottlieb Collection (USA)"
+	rom ( name "Pinball Hall of Fame - The Gottlieb Collection (USA).iso" size 1459978240 crc aa588203 md5 5dbd5ef2b1c70dfae4bb82055ee83200 sha1 b9d482889c6e517fc6e1a4ef5fac357743707cdb )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (DE)"
+	description "Pitfall - The Lost Expedition (DE)"
+	rom ( name "Pitfall - The Lost Expedition (DE).iso" size 1459978240 crc fa416892 md5 2b38e9ba5f3a42d2a50ee576b6ee9843 sha1 3d92ccf93fb3891bdf3aa4879c8edd4ac30a7f6e )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (Europe)"
+	description "Pitfall - The Lost Expedition (Europe)"
+	rom ( name "Pitfall - The Lost Expedition (Europe).iso" size 1459978240 crc 99a36b91 md5 a9dd81217659e5e2a51763a51b7e1fe9 sha1 425c4ba75f1468ebab6456d4b124cca7e914aabc )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (FR)"
+	description "Pitfall - The Lost Expedition (FR)"
+	rom ( name "Pitfall - The Lost Expedition (FR).iso" size 1459978240 crc 0c3f3c9c md5 8404f0041cf4ad5018b7b7c45ace7b40 sha1 0c8b5b67bbbf766f474debab68488b54cb2b4b86 )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (France)"
+	description "Pitfall - The Lost Expedition (France)"
+	rom ( name "Pitfall - The Lost Expedition (France).iso" size 1459978240 crc 0c3f3c9c md5 8404f0041cf4ad5018b7b7c45ace7b40 sha1 0c8b5b67bbbf766f474debab68488b54cb2b4b86 )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (GB)"
+	description "Pitfall - The Lost Expedition (GB)"
+	rom ( name "Pitfall - The Lost Expedition (GB).iso" size 1459978240 crc 99a36b91 md5 a9dd81217659e5e2a51763a51b7e1fe9 sha1 425c4ba75f1468ebab6456d4b124cca7e914aabc )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (Germany)"
+	description "Pitfall - The Lost Expedition (Germany)"
+	rom ( name "Pitfall - The Lost Expedition (Germany).iso" size 1459978240 crc fa416892 md5 2b38e9ba5f3a42d2a50ee576b6ee9843 sha1 3d92ccf93fb3891bdf3aa4879c8edd4ac30a7f6e )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (US)"
+	description "Pitfall - The Lost Expedition (US)"
+	rom ( name "Pitfall - The Lost Expedition (US).iso" size 1459978240 crc a692d9d0 md5 ad35176fc7a9fad11c38ec68ddcbb621 sha1 3a8c29744092a119828e449d289f9ef7b76a5260 )
+)
+
+game (
+	name "Pitfall - The Lost Expedition (USA)"
+	description "Pitfall - The Lost Expedition (USA)"
+	rom ( name "Pitfall - The Lost Expedition (USA).iso" size 1459978240 crc a692d9d0 md5 ad35176fc7a9fad11c38ec68ddcbb621 sha1 3a8c29744092a119828e449d289f9ef7b76a5260 )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (EU)"
+	description "Pokemon Box - Ruby & Sapphire (EU)"
+	rom ( name "Pokemon Box - Ruby & Sapphire (EU).iso" size 1459978240 crc e927919f md5 77f08fb8725ba7bf5a77207d131cbe47 sha1 c8ed3799bb1dad3173a02ed08e13918fed164e9f )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (Europe) (En,Fr,De,Es,It)"
+	description "Pokemon Box - Ruby & Sapphire (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pokemon Box - Ruby & Sapphire (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e927919f md5 77f08fb8725ba7bf5a77207d131cbe47 sha1 c8ed3799bb1dad3173a02ed08e13918fed164e9f )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (Japan)"
+	description "Pokemon Box - Ruby & Sapphire (Japan)"
+	rom ( name "Pokemon Box - Ruby & Sapphire (Japan).iso" size 1459978240 crc a25ead61 md5 6e7ee88f125b1d5ef40c41649f4b1b69 sha1 8851ddd0f6a7427750c97fe76af6461b51c2ae55 )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (JP) - pokemonbotukusu+rubi&sahuaia"
+	description "Pokemon Box - Ruby & Sapphire (JP) - pokemonbotukusu+rubi&sahuaia"
+	rom ( name "Pokemon Box - Ruby & Sapphire (JP).iso" size 1459978240 crc a25ead61 md5 6e7ee88f125b1d5ef40c41649f4b1b69 sha1 8851ddd0f6a7427750c97fe76af6461b51c2ae55 )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (US)"
+	description "Pokemon Box - Ruby & Sapphire (US)"
+	rom ( name "Pokemon Box - Ruby & Sapphire (US).iso" size 1459978240 crc cf0b538f md5 ae6b4ba657b1cecdb4b139c3c839c426 sha1 b53ed6fb99dff0d5f0e9fa0103cf1113650817b4 )
+)
+
+game (
+	name "Pokemon Box - Ruby & Sapphire (USA)"
+	description "Pokemon Box - Ruby & Sapphire (USA)"
+	rom ( name "Pokemon Box - Ruby & Sapphire (USA).iso" size 1459978240 crc cf0b538f md5 ae6b4ba657b1cecdb4b139c3c839c426 sha1 b53ed6fb99dff0d5f0e9fa0103cf1113650817b4 )
+)
+
+game (
+	name "Pokemon Channel - Bangumi Kakuchou Pack (Japan)"
+	description "Pokemon Channel - Bangumi Kakuchou Pack (Japan)"
+	rom ( name "Pokemon Channel - Bangumi Kakuchou Pack (Japan).iso" size 1459978240 crc 092cb122 md5 6d5943a801ac7a186af91cd742668287 sha1 05768272a73497fb4559cd0bee501120fe445817 )
+)
+
+game (
+	name "Pokemon Channel - Bangumi Kakuchou Pack (JP) - pokemontiyanneru+Fan Zu Kuo Zhang patuku"
+	description "Pokemon Channel - Bangumi Kakuchou Pack (JP) - pokemontiyanneru+Fan Zu Kuo Zhang patuku"
+	rom ( name "Pokemon Channel - Bangumi Kakuchou Pack (JP).iso" size 1459978240 crc 092cb122 md5 6d5943a801ac7a186af91cd742668287 sha1 05768272a73497fb4559cd0bee501120fe445817 )
+)
+
+game (
+	name "Pokemon Channel (AU)"
+	description "Pokemon Channel (AU)"
+	rom ( name "Pokemon Channel (AU).iso" size 1459978240 crc bbda6e33 md5 b8458021c748c1462302e053ef5b202d sha1 71b4703d8f5fcf72d75cd70e5e3ae94f134b6f7f )
+)
+
+game (
+	name "Pokemon Channel (Australia)"
+	description "Pokemon Channel (Australia)"
+	rom ( name "Pokemon Channel (Australia).iso" size 1459978240 crc bbda6e33 md5 b8458021c748c1462302e053ef5b202d sha1 71b4703d8f5fcf72d75cd70e5e3ae94f134b6f7f )
+)
+
+game (
+	name "Pokemon Channel (EU)"
+	description "Pokemon Channel (EU)"
+	rom ( name "Pokemon Channel (EU) - [v1.00].iso" size 1459978240 crc 58ae95aa md5 b570d1f6ea59c66ceaf8497871b01e88 sha1 64dc845f39e971b1c15c0e20622bfc09050b1d75 )
+)
+
+game (
+	name "Pokemon Channel (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Pokemon Channel (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Pokemon Channel (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 1459978240 crc 58ae95aa md5 b570d1f6ea59c66ceaf8497871b01e88 sha1 64dc845f39e971b1c15c0e20622bfc09050b1d75 )
+)
+
+game (
+	name "Pokemon Channel (Japan)"
+	description "Pokemon Channel (Japan)"
+	rom ( name "Pokemon Channel (Japan).iso" size 1459978240 crc d1ae9f88 md5 7a71668c8d9b6b8b1f038df208332116 sha1 7e64cf41852a957d4d5d3a031aa96c600b12372e )
+)
+
+game (
+	name "Pokemon Channel (JP)"
+	description "Pokemon Channel (JP)"
+	rom ( name "Pokemon Channel (JP).iso" size 1459978240 crc d1ae9f88 md5 7a71668c8d9b6b8b1f038df208332116 sha1 7e64cf41852a957d4d5d3a031aa96c600b12372e )
+)
+
+game (
+	name "Pokemon Channel (US)"
+	description "Pokemon Channel (US)"
+	rom ( name "Pokemon Channel (US).iso" size 1459978240 crc 5d1bb3f9 md5 e38ea020f7a711053c8ce93e9b85a88d sha1 559d108818704474c147ef8c17f2e1751ac1c145 )
+)
+
+game (
+	name "Pokemon Channel (USA)"
+	description "Pokemon Channel (USA)"
+	rom ( name "Pokemon Channel (USA).iso" size 1459978240 crc 5d1bb3f9 md5 e38ea020f7a711053c8ce93e9b85a88d sha1 559d108818704474c147ef8c17f2e1751ac1c145 )
+)
+
+game (
+	name "Pokemon Colosseum (Bonus Disc) (US)"
+	description "Pokemon Colosseum (Bonus Disc) (US)"
+	rom ( name "Pokemon Colosseum (Bonus Disc) (US) - [Bonus Disc].iso" size 1459978240 crc 147f54c9 md5 81620f774d142df466aab9c4bff7a686 sha1 f21a6883f3a29679472a913813341b3f59f4173a )
+)
+
+game (
+	name "Pokemon Colosseum (EU)"
+	description "Pokemon Colosseum (EU)"
+	rom ( name "Pokemon Colosseum (EU).iso" size 1459978240 crc d53438c1 md5 2be2607ae4826cbc77efb4ef4ada6385 sha1 127c4cb4d3c9c2e181f3a29e96b44fa55a77dfb2 )
+)
+
+game (
+	name "Pokemon Colosseum (Europe) (En,Fr,De,Es,It)"
+	description "Pokemon Colosseum (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pokemon Colosseum (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc d53438c1 md5 2be2607ae4826cbc77efb4ef4ada6385 sha1 127c4cb4d3c9c2e181f3a29e96b44fa55a77dfb2 )
+)
+
+game (
+	name "Pokemon Colosseum (Japan)"
+	description "Pokemon Colosseum (Japan)"
+	rom ( name "Pokemon Colosseum (Japan).iso" size 1459978240 crc 3a421d80 md5 ec80218d9079ccae07350e42356748ce sha1 170f72ae718a375f49e9ccae526d5da1b493fca0 )
+)
+
+game (
+	name "Pokemon Colosseum (JP) - pokemonkorosiamu"
+	description "Pokemon Colosseum (JP) - pokemonkorosiamu"
+	rom ( name "Pokemon Colosseum (JP).iso" size 1459978240 crc 3a421d80 md5 ec80218d9079ccae07350e42356748ce sha1 170f72ae718a375f49e9ccae526d5da1b493fca0 )
+)
+
+game (
+	name "Pokemon Colosseum (US)"
+	description "Pokemon Colosseum (US)"
+	rom ( name "Pokemon Colosseum (US).iso" size 1459978240 crc 0704554f md5 e3f389dc5662b9f941769e370195ec90 sha1 96b2b686d202a13dd15261fb7cffbcb2f08c0a77 )
+)
+
+game (
+	name "Pokemon Colosseum (USA)"
+	description "Pokemon Colosseum (USA)"
+	rom ( name "Pokemon Colosseum (USA).iso" size 1459978240 crc 0704554f md5 e3f389dc5662b9f941769e370195ec90 sha1 96b2b686d202a13dd15261fb7cffbcb2f08c0a77 )
+)
+
+game (
+	name "Pokemon Colosseum (USA) (Bonus Disc)"
+	description "Pokemon Colosseum (USA) (Bonus Disc)"
+	rom ( name "Pokemon Colosseum (USA) (Bonus Disc).iso" size 1459978240 crc 147f54c9 md5 81620f774d142df466aab9c4bff7a686 sha1 f21a6883f3a29679472a913813341b3f59f4173a )
+)
+
+game (
+	name "Pokemon XD - Gale of Darkness (EU)"
+	description "Pokemon XD - Gale of Darkness (EU)"
+	rom ( name "Pokemon XD - Gale of Darkness (EU).iso" size 1459978240 crc 0850ddb9 md5 f36d14bebf8fea6a046404bff6adb7e6 sha1 2b7e287df4264ddd07824d316a9d6e063d96aec5 )
+)
+
+game (
+	name "Pokemon XD - Gale of Darkness (Europe) (En,Fr,De,Es,It)"
+	description "Pokemon XD - Gale of Darkness (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pokemon XD - Gale of Darkness (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 0850ddb9 md5 f36d14bebf8fea6a046404bff6adb7e6 sha1 2b7e287df4264ddd07824d316a9d6e063d96aec5 )
+)
+
+game (
+	name "Pokemon XD - Gale of Darkness (US)"
+	description "Pokemon XD - Gale of Darkness (US)"
+	rom ( name "Pokemon XD - Gale of Darkness (US).iso" size 1459978240 crc c0f69d18 md5 3bc1671806cf763a8712a5d398f62ad3 sha1 c1b5218f832403d15aa500ac4d6aacc8865c792d )
+)
+
+game (
+	name "Pokemon XD - Gale of Darkness (USA)"
+	description "Pokemon XD - Gale of Darkness (USA)"
+	rom ( name "Pokemon XD - Gale of Darkness (USA).iso" size 1459978240 crc c0f69d18 md5 3bc1671806cf763a8712a5d398f62ad3 sha1 c1b5218f832403d15aa500ac4d6aacc8865c792d )
+)
+
+game (
+	name "Pokemon XD - Yami no Kaze Dark Lugia (Japan)"
+	description "Pokemon XD - Yami no Kaze Dark Lugia (Japan)"
+	rom ( name "Pokemon XD - Yami no Kaze Dark Lugia (Japan).iso" size 1459978240 crc 46387be4 md5 e92856cb965f8411e29ccfc818bd6d5b sha1 c803390dd982fccb43a958471debf9ddaa8c6407 )
+)
+
+game (
+	name "Pokemon XD - Yami no Kaze Dark Lugia (JP) - pokemonXD+An noXuan Feng +dakurugia"
+	description "Pokemon XD - Yami no Kaze Dark Lugia (JP) - pokemonXD+An noXuan Feng +dakurugia"
+	rom ( name "Pokemon XD - Yami no Kaze Dark Lugia (JP).iso" size 1459978240 crc 46387be4 md5 e92856cb965f8411e29ccfc818bd6d5b sha1 c803390dd982fccb43a958471debf9ddaa8c6407 )
+)
+
+game (
+	name "Polar Express, The (EU)"
+	description "Polar Express, The (EU)"
+	rom ( name "Polar Express, The (EU).iso" size 1459978240 crc 3e9f084d md5 87ad1d6d255ee4f6025aa3a9457f325e sha1 16e9f9c7fb61f16eff4b84931c51ab28ce998b51 )
+)
+
+game (
+	name "Polar Express, The (Europe) (En,Fr,De,Es,It)"
+	description "Polar Express, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Polar Express, The (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3e9f084d md5 87ad1d6d255ee4f6025aa3a9457f325e sha1 16e9f9c7fb61f16eff4b84931c51ab28ce998b51 )
+)
+
+game (
+	name "Polar Express, The (US)"
+	description "Polar Express, The (US)"
+	rom ( name "Polar Express, The (US).iso" size 1459978240 crc 347e9da2 md5 ecad1abccc9cae1f510a0bb5cc4f62b3 sha1 540ff0c5cbe26804484749dbea83d536c187bf4f )
+)
+
+game (
+	name "Polar Express, The (USA)"
+	description "Polar Express, The (USA)"
+	rom ( name "Polar Express, The (USA).iso" size 1459978240 crc 347e9da2 md5 ecad1abccc9cae1f510a0bb5cc4f62b3 sha1 540ff0c5cbe26804484749dbea83d536c187bf4f )
+)
+
+game (
+	name "Pool Edge (Japan)"
+	description "Pool Edge (Japan)"
+	rom ( name "Pool Edge (Japan).iso" size 1459978240 crc 1a3c500f md5 2835b1db45bee2721b1e4f74a1d911f8 sha1 c8eb8969f5e4b5bd70d36b897196355e39ba7b79 )
+)
+
+game (
+	name "Pool Edge (JP) - puru+etuzi"
+	description "Pool Edge (JP) - puru+etuzi"
+	rom ( name "Pool Edge (JP).iso" size 1459978240 crc 1a3c500f md5 2835b1db45bee2721b1e4f74a1d911f8 sha1 c8eb8969f5e4b5bd70d36b897196355e39ba7b79 )
+)
+
+game (
+	name "Pool Paradise (EU)"
+	description "Pool Paradise (EU)"
+	rom ( name "Pool Paradise (EU).iso" size 1459978240 crc 9a489b25 md5 6c5a279ac55f646476c9dc854c52ef00 sha1 57c64bc996a65c353626fe67007a57b500f6a7c6 )
+)
+
+game (
+	name "Pool Paradise (Europe) (En,Fr,De,Es,It)"
+	description "Pool Paradise (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pool Paradise (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9a489b25 md5 6c5a279ac55f646476c9dc854c52ef00 sha1 57c64bc996a65c353626fe67007a57b500f6a7c6 )
+)
+
+game (
+	name "Pool Paradise (US)"
+	description "Pool Paradise (US)"
+	rom ( name "Pool Paradise (US).iso" size 1459978240 crc 53bb0b9c md5 21ca392eb0024d57a4fddc09f58d1979 sha1 c4b698bc42e19095b5c4a8b0605df02328d29e43 )
+)
+
+game (
+	name "Pool Paradise (USA)"
+	description "Pool Paradise (USA)"
+	rom ( name "Pool Paradise (USA).iso" size 1459978240 crc 53bb0b9c md5 21ca392eb0024d57a4fddc09f58d1979 sha1 c4b698bc42e19095b5c4a8b0605df02328d29e43 )
+)
+
+game (
+	name "Power Rangers - Dino Thunder (Europe)"
+	description "Power Rangers - Dino Thunder (Europe)"
+	rom ( name "Power Rangers - Dino Thunder (Europe).iso" size 1459978240 crc 55177f51 md5 189912197afbcfb668b6e20f1d243224 sha1 232e1879a4fe531d097a4f33d38f5e6546024723 )
+)
+
+game (
+	name "Power Rangers - Dino Thunder (GB)"
+	description "Power Rangers - Dino Thunder (GB)"
+	rom ( name "Power Rangers - Dino Thunder (GB).iso" size 1459978240 crc 55177f51 md5 189912197afbcfb668b6e20f1d243224 sha1 232e1879a4fe531d097a4f33d38f5e6546024723 )
+)
+
+game (
+	name "Power Rangers - Dino Thunder (US)"
+	description "Power Rangers - Dino Thunder (US)"
+	rom ( name "Power Rangers - Dino Thunder (US).iso" size 1459978240 crc e8dac398 md5 0825b00a5e7aaac9466676cd465b626c sha1 9533b10de33c8f0b9462055a693819e685aefe62 )
+)
+
+game (
+	name "Power Rangers - Dino Thunder (USA)"
+	description "Power Rangers - Dino Thunder (USA)"
+	rom ( name "Power Rangers - Dino Thunder (USA).iso" size 1459978240 crc e8dac398 md5 0825b00a5e7aaac9466676cd465b626c sha1 9533b10de33c8f0b9462055a693819e685aefe62 )
+)
+
+game (
+	name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (EU)"
+	description "Powerpuff Girls, The - Relish Rampage - Pickled Edition (EU)"
+	rom ( name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (EU).iso" size 1459978240 crc 4e9cde37 md5 44ff7a3e8a06d600c40d2653266e0903 sha1 b0af3ffc5b6a2a5952be5b3cbc718b9b99eba329 )
+)
+
+game (
+	name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (Europe) (En,Fr,De,Es)"
+	description "Powerpuff Girls, The - Relish Rampage - Pickled Edition (Europe) (En,Fr,De,Es)"
+	rom ( name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 4e9cde37 md5 44ff7a3e8a06d600c40d2653266e0903 sha1 b0af3ffc5b6a2a5952be5b3cbc718b9b99eba329 )
+)
+
+game (
+	name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (US)"
+	description "Powerpuff Girls, The - Relish Rampage - Pickled Edition (US)"
+	rom ( name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (US).iso" size 1459978240 crc bf42cbfa md5 6629910122450bd7953936122ea92711 sha1 9a2cc7d03b35bb12e7a1628f7b154baae1eeedcf )
+)
+
+game (
+	name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (USA)"
+	description "Powerpuff Girls, The - Relish Rampage - Pickled Edition (USA)"
+	rom ( name "Powerpuff Girls, The - Relish Rampage - Pickled Edition (USA).iso" size 1459978240 crc bf42cbfa md5 6629910122450bd7953936122ea92711 sha1 9a2cc7d03b35bb12e7a1628f7b154baae1eeedcf )
+)
+
+game (
+	name "Prince of Persia - The Sands of Time (EU)"
+	description "Prince of Persia - The Sands of Time (EU)"
+	rom ( name "Prince of Persia - The Sands of Time (EU).iso" size 1459978240 crc 17e54b61 md5 c1c89efb6bcffe0386dd724a5a884a21 sha1 26dcc735470ca663e9e28d3a984eb7a07b7cf657 )
+)
+
+game (
+	name "Prince of Persia - The Sands of Time (Europe) (En,Fr,De,Es,It)"
+	description "Prince of Persia - The Sands of Time (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Prince of Persia - The Sands of Time (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 17e54b61 md5 c1c89efb6bcffe0386dd724a5a884a21 sha1 26dcc735470ca663e9e28d3a984eb7a07b7cf657 )
+)
+
+game (
+	name "Prince of Persia - The Sands of Time (US)"
+	description "Prince of Persia - The Sands of Time (US)"
+	rom ( name "Prince of Persia - The Sands of Time (US) - [v1.00].iso" size 1459978240 crc 292e5cdc md5 df7cd3837909dc41dd0a6b1821466d56 sha1 f575aad19eb14c2371c8187b03c395882da7a999 )
+)
+
+game (
+	name "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.00)"
+	description "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.00).iso" size 1459978240 crc 292e5cdc md5 df7cd3837909dc41dd0a6b1821466d56 sha1 f575aad19eb14c2371c8187b03c395882da7a999 )
+)
+
+game (
+	name "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.01)"
+	description "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Prince of Persia - The Sands of Time (USA) (En,Fr,Es) (v1.01).iso" size 1459978240 crc 67c8c2a5 md5 4fd126445e3ef0792efc77ffac213ef0 sha1 b77c416a068c0ecae17095a46f1c98264b3cbae2 )
+)
+
+game (
+	name "Prince of Persia - The Two Thrones (EU)"
+	description "Prince of Persia - The Two Thrones (EU)"
+	rom ( name "Prince of Persia - The Two Thrones (EU).iso" size 1459978240 crc a9e03774 md5 158fe130869669bd4129ad6a3f8d83ba sha1 aed20616af2b5177547d19fdf4fde62ec178b58e )
+)
+
+game (
+	name "Prince of Persia - The Two Thrones (Europe) (En,Fr,De,Es,It)"
+	description "Prince of Persia - The Two Thrones (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Prince of Persia - The Two Thrones (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a9e03774 md5 158fe130869669bd4129ad6a3f8d83ba sha1 aed20616af2b5177547d19fdf4fde62ec178b58e )
+)
+
+game (
+	name "Prince of Persia - The Two Thrones (US)"
+	description "Prince of Persia - The Two Thrones (US)"
+	rom ( name "Prince of Persia - The Two Thrones (US).iso" size 1459978240 crc 22deb1f0 md5 88bfad6bc3f1356741aaa5c36ce1ec39 sha1 ec028be55c244809a0d29829f9a0c7dffa98cf7a )
+)
+
+game (
+	name "Prince of Persia - The Two Thrones (USA) (En,Fr,Es)"
+	description "Prince of Persia - The Two Thrones (USA) (En,Fr,Es)"
+	rom ( name "Prince of Persia - The Two Thrones (USA) (En,Fr,Es).iso" size 1459978240 crc 22deb1f0 md5 88bfad6bc3f1356741aaa5c36ce1ec39 sha1 ec028be55c244809a0d29829f9a0c7dffa98cf7a )
+)
+
+game (
+	name "Prince of Persia - Warrior Within (EU)"
+	description "Prince of Persia - Warrior Within (EU)"
+	rom ( name "Prince of Persia - Warrior Within (EU).iso" size 1459978240 crc 33abcb80 md5 2ac58c9a30bd3c8de87e4e77f5223ca9 sha1 a3b4145780ba2b26a1d50801769cc8a402c2a925 )
+)
+
+game (
+	name "Prince of Persia - Warrior Within (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Prince of Persia - Warrior Within (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Prince of Persia - Warrior Within (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 33abcb80 md5 2ac58c9a30bd3c8de87e4e77f5223ca9 sha1 a3b4145780ba2b26a1d50801769cc8a402c2a925 )
+)
+
+game (
+	name "Prince of Persia - Warrior Within (US)"
+	description "Prince of Persia - Warrior Within (US)"
+	rom ( name "Prince of Persia - Warrior Within (US).iso" size 1459978240 crc 546484d5 md5 dce5a1a75982905554d9d465a743ff3b sha1 b427358f4dd11866b2d88e0fbfff643c0df48f75 )
+)
+
+game (
+	name "Prince of Persia - Warrior Within (USA) (En,Fr,Es)"
+	description "Prince of Persia - Warrior Within (USA) (En,Fr,Es)"
+	rom ( name "Prince of Persia - Warrior Within (USA) (En,Fr,Es).iso" size 1459978240 crc 546484d5 md5 dce5a1a75982905554d9d465a743ff3b sha1 b427358f4dd11866b2d88e0fbfff643c0df48f75 )
+)
+
+game (
+	name "Pro Rally 2002 (EU)"
+	description "Pro Rally 2002 (EU)"
+	rom ( name "Pro Rally 2002 (EU).iso" size 1459978240 crc 63698a7c md5 714ce464af4e79b046388f0e9019c616 sha1 7a80a7c324bb31be71ee6868fa44a767195e12eb )
+)
+
+game (
+	name "Pro Rally 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Pro Rally 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pro Rally 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 63698a7c md5 714ce464af4e79b046388f0e9019c616 sha1 7a80a7c324bb31be71ee6868fa44a767195e12eb )
+)
+
+game (
+	name "Pro Rally 2002 (US)"
+	description "Pro Rally 2002 (US)"
+	rom ( name "Pro Rally 2002 (US).iso" size 1459978240 crc 9d11e4f0 md5 af3e4ffac4c1e4b71e081af42c452ee3 sha1 4ab92ac9dbd32ecbb71d60633b3e36bceba1f287 )
+)
+
+game (
+	name "Pro Rally 2002 (USA) (En,Fr,Es)"
+	description "Pro Rally 2002 (USA) (En,Fr,Es)"
+	rom ( name "Pro Rally 2002 (USA) (En,Fr,Es).iso" size 1459978240 crc 9d11e4f0 md5 af3e4ffac4c1e4b71e081af42c452ee3 sha1 4ab92ac9dbd32ecbb71d60633b3e36bceba1f287 )
+)
+
+game (
+	name "Pro Tennis WTA Tour (EU)"
+	description "Pro Tennis WTA Tour (EU)"
+	rom ( name "Pro Tennis WTA Tour (EU).iso" size 1459978240 crc 4eb8ded2 md5 ef40bc018224e989423cfb02bf3c2864 sha1 713e82cf3f65324743dabcb0f9bb794d6bc0a2b2 )
+)
+
+game (
+	name "Pro Tennis WTA Tour (Europe)"
+	description "Pro Tennis WTA Tour (Europe)"
+	rom ( name "Pro Tennis WTA Tour (Europe).iso" size 1459978240 crc 4eb8ded2 md5 ef40bc018224e989423cfb02bf3c2864 sha1 713e82cf3f65324743dabcb0f9bb794d6bc0a2b2 )
+)
+
+game (
+	name "Puyo Pop Fever (EU)"
+	description "Puyo Pop Fever (EU)"
+	rom ( name "Puyo Pop Fever (EU).iso" size 1459978240 crc 8fa68fad md5 a5fba1dd07fea4e5a548185b7fdfd362 sha1 1e5fa60a5cd6e662d8d42ca391917ac9c0bb0052 )
+)
+
+game (
+	name "Puyo Pop Fever (Europe) (En,Fr,De,Es,It)"
+	description "Puyo Pop Fever (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Puyo Pop Fever (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 8fa68fad md5 a5fba1dd07fea4e5a548185b7fdfd362 sha1 1e5fa60a5cd6e662d8d42ca391917ac9c0bb0052 )
+)
+
+game (
+	name "Puyo Pop Fever (US)"
+	description "Puyo Pop Fever (US)"
+	rom ( name "Puyo Pop Fever (US).iso" size 1459978240 crc e3b99e37 md5 8bb0e238c43b19f3d16aa6427aaf8631 sha1 54ae83c0e261450ebc5e89c671924ac3b42f301d )
+)
+
+game (
+	name "Puyo Pop Fever (USA) (En,Ja,Fr,De,Es,It)"
+	description "Puyo Pop Fever (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Puyo Pop Fever (USA) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc e3b99e37 md5 8bb0e238c43b19f3d16aa6427aaf8631 sha1 54ae83c0e261450ebc5e89c671924ac3b42f301d )
+)
+
+game (
+	name "Puyo Puyo Fever (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Puyo Puyo Fever (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Puyo Puyo Fever (Japan) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc 7abac8b4 md5 a1f264cfdba51ccbd91c5d8227f9486c sha1 8d1ede3f8d4cb4196935a36b6845da5b423abe6e )
+)
+
+game (
+	name "Puyo Puyo Fever (JP) - puyopuyohuiba"
+	description "Puyo Puyo Fever (JP) - puyopuyohuiba"
+	rom ( name "Puyo Puyo Fever (JP).iso" size 1459978240 crc 7abac8b4 md5 a1f264cfdba51ccbd91c5d8227f9486c sha1 8d1ede3f8d4cb4196935a36b6845da5b423abe6e )
+)
+
+game (
+	name "R-Racing (EU)"
+	description "R-Racing (EU)"
+	rom ( name "R-Racing (EU).iso" size 1459978240 crc cff4d68a md5 664039ddb018164fdbc6ba190a85c020 sha1 f2088d61a683569281bc2374db6a6733ddb4340b )
+)
+
+game (
+	name "R-Racing (Europe) (En,Fr,De,Es,It)"
+	description "R-Racing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "R-Racing (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc cff4d68a md5 664039ddb018164fdbc6ba190a85c020 sha1 f2088d61a683569281bc2374db6a6733ddb4340b )
+)
+
+game (
+	name "R-Racing Evolution - Life in the Fast Lane (Japan)"
+	description "R-Racing Evolution - Life in the Fast Lane (Japan)"
+	rom ( name "R-Racing Evolution - Life in the Fast Lane (Japan).iso" size 1459978240 crc b4d639f9 md5 ea37d996d705cef9e9bb2099e3f8c86e sha1 6d1af5e03faf84bddd77703f29bd03e38336c08e )
+)
+
+game (
+	name "R-Racing Evolution - Life in the Fast Lane (JP) - R+resinguevuoriyusiyon"
+	description "R-Racing Evolution - Life in the Fast Lane (JP) - R+resinguevuoriyusiyon"
+	rom ( name "R-Racing Evolution - Life in the Fast Lane (JP).iso" size 1459978240 crc b4d639f9 md5 ea37d996d705cef9e9bb2099e3f8c86e sha1 6d1af5e03faf84bddd77703f29bd03e38336c08e )
+)
+
+game (
+	name "R-Racing Evolution (US)"
+	description "R-Racing Evolution (US)"
+	rom ( name "R-Racing Evolution (US).iso" size 1459978240 crc 059e8cce md5 cb0cb99aa8a3bfe5e8e832cb866c990e sha1 f04e500607367e5aa568dac82a05ba9c8d280fcf )
+)
+
+game (
+	name "R-Racing Evolution (USA)"
+	description "R-Racing Evolution (USA)"
+	rom ( name "R-Racing Evolution (USA).iso" size 1459978240 crc 059e8cce md5 cb0cb99aa8a3bfe5e8e832cb866c990e sha1 f04e500607367e5aa568dac82a05ba9c8d280fcf )
+)
+
+game (
+	name "Radirgy Generic (Japan)"
+	description "Radirgy Generic (Japan)"
+	rom ( name "Radirgy Generic (Japan).iso" size 1459978240 crc e02444fa md5 820840a80cc6c7d803cfec292e0d9e94 sha1 88774d190727aa88cf3ae7f3bacab62837c38d2f )
+)
+
+game (
+	name "Radirgy Generic (JP) - razirugizienerituku"
+	description "Radirgy Generic (JP) - razirugizienerituku"
+	rom ( name "Radirgy Generic (JP).iso" size 1459978240 crc e02444fa md5 820840a80cc6c7d803cfec292e0d9e94 sha1 88774d190727aa88cf3ae7f3bacab62837c38d2f )
+)
+
+game (
+	name "Rally Championship (Europe) (En,Fr,De,Es,It)"
+	description "Rally Championship (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rally Championship (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ea136912 md5 cada25f283e6d328d821c759558482d3 sha1 5b55025e97c7788c812fcc69bdf6d71e731ce78e )
+)
+
+game (
+	name "Rally Championship (GB)"
+	description "Rally Championship (GB)"
+	rom ( name "Rally Championship (GB).iso" size 1459978240 crc ea136912 md5 cada25f283e6d328d821c759558482d3 sha1 5b55025e97c7788c812fcc69bdf6d71e731ce78e )
+)
+
+game (
+	name "Rally Championship (US)"
+	description "Rally Championship (US)"
+	rom ( name "Rally Championship (US).iso" size 1459978240 crc df1f2afa md5 a217cf3d0a44dc2b744567eec5739aaa sha1 03d957ece6f00dc7970ddfc94903dc8bc58b21d2 )
+)
+
+game (
+	name "Rally Championship (USA)"
+	description "Rally Championship (USA)"
+	rom ( name "Rally Championship (USA).iso" size 1459978240 crc df1f2afa md5 a217cf3d0a44dc2b744567eec5739aaa sha1 03d957ece6f00dc7970ddfc94903dc8bc58b21d2 )
+)
+
+game (
+	name "Rampage - Total Destruction (US)"
+	description "Rampage - Total Destruction (US)"
+	rom ( name "Rampage - Total Destruction (US).iso" size 1459978240 crc 98c550d1 md5 51167bb3cecea86d774678f2761eb441 sha1 5dc1854e99026e20fe7f0f126d45e987cd744832 )
+)
+
+game (
+	name "Rampage - Total Destruction (USA)"
+	description "Rampage - Total Destruction (USA)"
+	rom ( name "Rampage - Total Destruction (USA).iso" size 1459978240 crc 98c550d1 md5 51167bb3cecea86d774678f2761eb441 sha1 5dc1854e99026e20fe7f0f126d45e987cd744832 )
+)
+
+game (
+	name "Rave Master (US)"
+	description "Rave Master (US)"
+	rom ( name "Rave Master (US).iso" size 1459978240 crc fa90d92a md5 f37d9954250469e99d1a74fbf5f5972b sha1 cf4cb064cf7588a0d16b96fe12dcd301e9193dd4 )
+)
+
+game (
+	name "Rave Master (USA)"
+	description "Rave Master (USA)"
+	rom ( name "Rave Master (USA).iso" size 1459978240 crc fa90d92a md5 f37d9954250469e99d1a74fbf5f5972b sha1 cf4cb064cf7588a0d16b96fe12dcd301e9193dd4 )
+)
+
+game (
+	name "Rayman 3 - Hoodlum Havoc (EU)"
+	description "Rayman 3 - Hoodlum Havoc (EU)"
+	rom ( name "Rayman 3 - Hoodlum Havoc (EU).iso" size 1459978240 crc 7337e8c2 md5 f00fd89b8c855535d26c595865a1ba35 sha1 b32fd1c7ad23559d6878ca757b850d92987c1b32 )
+)
+
+game (
+	name "Rayman 3 - Hoodlum Havoc (Europe) (En,Fr,De,Es,It)"
+	description "Rayman 3 - Hoodlum Havoc (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rayman 3 - Hoodlum Havoc (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7337e8c2 md5 f00fd89b8c855535d26c595865a1ba35 sha1 b32fd1c7ad23559d6878ca757b850d92987c1b32 )
+)
+
+game (
+	name "Rayman 3 - Hoodlum Havoc (US)"
+	description "Rayman 3 - Hoodlum Havoc (US)"
+	rom ( name "Rayman 3 - Hoodlum Havoc (US).iso" size 1459978240 crc 913d67a3 md5 40386ae7cb46600bf05e8980c0773ffc sha1 3941d6fc1e312bc89e1f54579e687fbfda2b1127 )
+)
+
+game (
+	name "Rayman 3 - Hoodlum Havoc (USA) (En,Fr,De,Es,It)"
+	description "Rayman 3 - Hoodlum Havoc (USA) (En,Fr,De,Es,It)"
+	rom ( name "Rayman 3 - Hoodlum Havoc (USA) (En,Fr,De,Es,It).iso" size 1459978240 crc 913d67a3 md5 40386ae7cb46600bf05e8980c0773ffc sha1 3941d6fc1e312bc89e1f54579e687fbfda2b1127 )
+)
+
+game (
+	name "Rayman Arena (US)"
+	description "Rayman Arena (US)"
+	rom ( name "Rayman Arena (US).iso" size 1459978240 crc e0f783ed md5 4e7b4dd0444ebfeb7ec2ab253116d437 sha1 de0c744db56f18c23a12609ec7b17f47aac9caae )
+)
+
+game (
+	name "Rayman Arena (USA)"
+	description "Rayman Arena (USA)"
+	rom ( name "Rayman Arena (USA).iso" size 1459978240 crc e0f783ed md5 4e7b4dd0444ebfeb7ec2ab253116d437 sha1 de0c744db56f18c23a12609ec7b17f47aac9caae )
+)
+
+game (
+	name "Red Faction II (DE)"
+	description "Red Faction II (DE)"
+	rom ( name "Red Faction II (DE).iso" size 1459978240 crc 8b868c6d md5 c8b636933e1af09d8171638d843b851f sha1 3fcf380dae8f1f90f319a837eab841be0f47772a )
+)
+
+game (
+	name "Red Faction II (EU)"
+	description "Red Faction II (EU)"
+	rom ( name "Red Faction II (EU).iso" size 1459978240 crc cb9f3974 md5 cefd67fc6f5efe2109c8196d65b0e417 sha1 3828ae885321a98c839983d0bf07740499218600 )
+)
+
+game (
+	name "Red Faction II (Europe)"
+	description "Red Faction II (Europe)"
+	rom ( name "Red Faction II (Europe).iso" size 1459978240 crc cb9f3974 md5 cefd67fc6f5efe2109c8196d65b0e417 sha1 3828ae885321a98c839983d0bf07740499218600 )
+)
+
+game (
+	name "Red Faction II (FR)"
+	description "Red Faction II (FR)"
+	rom ( name "Red Faction II (FR).iso" size 1459978240 crc d4444c50 md5 3bab9c254a5dcbe5d6e5b114e4ab8738 sha1 dd71f20ae59cc4c7d58cc098a73fafbc95bf3745 )
+)
+
+game (
+	name "Red Faction II (France)"
+	description "Red Faction II (France)"
+	rom ( name "Red Faction II (France).iso" size 1459978240 crc d4444c50 md5 3bab9c254a5dcbe5d6e5b114e4ab8738 sha1 dd71f20ae59cc4c7d58cc098a73fafbc95bf3745 )
+)
+
+game (
+	name "Red Faction II (Germany)"
+	description "Red Faction II (Germany)"
+	rom ( name "Red Faction II (Germany).iso" size 1459978240 crc 8b868c6d md5 c8b636933e1af09d8171638d843b851f sha1 3fcf380dae8f1f90f319a837eab841be0f47772a )
+)
+
+game (
+	name "Red Faction II (US)"
+	description "Red Faction II (US)"
+	rom ( name "Red Faction II (US).iso" size 1459978240 crc 33c916c8 md5 ebf367961c483aeda8cefd73da296295 sha1 36a27f9954ae4a701c0ef83ef809a9c670238c28 )
+)
+
+game (
+	name "Red Faction II (USA)"
+	description "Red Faction II (USA)"
+	rom ( name "Red Faction II (USA).iso" size 1459978240 crc 33c916c8 md5 ebf367961c483aeda8cefd73da296295 sha1 36a27f9954ae4a701c0ef83ef809a9c670238c28 )
+)
+
+game (
+	name "RedCard (EU)"
+	description "RedCard (EU)"
+	rom ( name "RedCard (EU).iso" size 1459978240 crc fa4d2f9b md5 00a8186a68e4c917ebab9eeca48571ad sha1 e4642777509e89b9d1fbb6851e1cdd87572606ab )
+)
+
+game (
+	name "RedCard (Europe) (En,Fr,De,Es,It)"
+	description "RedCard (Europe) (En,Fr,De,Es,It)"
+	rom ( name "RedCard (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc fa4d2f9b md5 00a8186a68e4c917ebab9eeca48571ad sha1 e4642777509e89b9d1fbb6851e1cdd87572606ab )
+)
+
+game (
+	name "RedCard 2003 (US)"
+	description "RedCard 2003 (US)"
+	rom ( name "RedCard 2003 (US).iso" size 1459978240 crc f07387d3 md5 a89f62517c5133b4605e578abd20a819 sha1 44b78ec19415f9f9a5a7f294f482d8011e8716b0 )
+)
+
+game (
+	name "RedCard 2003 (USA)"
+	description "RedCard 2003 (USA)"
+	rom ( name "RedCard 2003 (USA).iso" size 1459978240 crc f07387d3 md5 a89f62517c5133b4605e578abd20a819 sha1 44b78ec19415f9f9a5a7f294f482d8011e8716b0 )
+)
+
+game (
+	name "Rei Fighter Gekitsui Senki (Japan)"
+	description "Rei Fighter Gekitsui Senki (Japan)"
+	rom ( name "Rei Fighter Gekitsui Senki (Japan).iso" size 1459978240 crc fb1c32e3 md5 9f869274101983c2e60ea1296d45661b sha1 7d75d2f3f7eca0e6ed4cd8a40c7d16f76fd015d9 )
+)
+
+game (
+	name "Rei Fighter Gekitsui Senki (JP) - Ling huaita+Ji Zhui Zhan Ji"
+	description "Rei Fighter Gekitsui Senki (JP) - Ling huaita+Ji Zhui Zhan Ji"
+	rom ( name "Rei Fighter Gekitsui Senki (JP).iso" size 1459978240 crc fb1c32e3 md5 9f869274101983c2e60ea1296d45661b sha1 7d75d2f3f7eca0e6ed4cd8a40c7d16f76fd015d9 )
+)
+
+game (
+	name "Reign of Fire (EU)"
+	description "Reign of Fire (EU)"
+	rom ( name "Reign of Fire (EU).iso" size 1459978240 crc e6f3c841 md5 e7eea54f0af76c80c70b81791c5cc90f sha1 42fab3ffa0d0850957268caaa30ce70a2d40edc6 )
+)
+
+game (
+	name "Reign of Fire (Europe) (En,Fr,De,Es,It)"
+	description "Reign of Fire (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Reign of Fire (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e6f3c841 md5 e7eea54f0af76c80c70b81791c5cc90f sha1 42fab3ffa0d0850957268caaa30ce70a2d40edc6 )
+)
+
+game (
+	name "Reign of Fire (US)"
+	description "Reign of Fire (US)"
+	rom ( name "Reign of Fire (US).iso" size 1459978240 crc d4e87138 md5 daff86cd5da46786b570e12d5dc58d7e sha1 cdae55f1529cd452ad87e3c2c68ff90639c21031 )
+)
+
+game (
+	name "Reign of Fire (USA)"
+	description "Reign of Fire (USA)"
+	rom ( name "Reign of Fire (USA).iso" size 1459978240 crc d4e87138 md5 daff86cd5da46786b570e12d5dc58d7e sha1 cdae55f1529cd452ad87e3c2c68ff90639c21031 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (EU)"
+	description "Resident Evil - Code - Veronica X (EU)"
+	rom ( name "Resident Evil - Code - Veronica X (EU) - (Disc 1 of 2).iso" size 1459978240 crc 048e89b3 md5 e518c5cbc3c5596f8468b765cd16c1f2 sha1 901fd98bf587bcbe63e0ed1e39b3091317ab3a7e )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 048e89b3 md5 e518c5cbc3c5596f8468b765cd16c1f2 sha1 901fd98bf587bcbe63e0ed1e39b3091317ab3a7e )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica X (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc ced63059 md5 eecdddbff7b57f5a174a03cc83a06f8b sha1 1e0429156d62c1588a981ca7e11c0f51869b4b1c )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (US)"
+	description "Resident Evil - Code - Veronica X (US)"
+	rom ( name "Resident Evil - Code - Veronica X (US) - (Disc 1 of 2).iso" size 1459978240 crc 4bfe0a5c md5 4353d37246529d9493ef5db3aef419a0 sha1 8920fa8a7e3de1a3c64fbe5d53c7d7b48de91773 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (USA) (Disc 1)"
+	description "Resident Evil - Code - Veronica X (USA) (Disc 1)"
+	rom ( name "Resident Evil - Code - Veronica X (USA) (Disc 1).iso" size 1459978240 crc 4bfe0a5c md5 4353d37246529d9493ef5db3aef419a0 sha1 8920fa8a7e3de1a3c64fbe5d53c7d7b48de91773 )
+)
+
+game (
+	name "Resident Evil - Code - Veronica X (USA) (Disc 2)"
+	description "Resident Evil - Code - Veronica X (USA) (Disc 2)"
+	rom ( name "Resident Evil - Code - Veronica X (USA) (Disc 2).iso" size 1459978240 crc 17270b07 md5 c4373cdcaa79b863fba94b1cae0efeb0 sha1 4feae623f0c38caa28fc19075a7d28637273b251 )
+)
+
+game (
+	name "Resident Evil (EU)"
+	description "Resident Evil (EU)"
+	rom ( name "Resident Evil (EU) - (Disc 1 of 2).iso" size 1459978240 crc 3431e6f1 md5 c581fab5fd10f55b76188e86194199c1 sha1 3717ee92672a6c6194e34a8ec07111fc71d8e5f1 )
+)
+
+game (
+	name "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 3431e6f1 md5 c581fab5fd10f55b76188e86194199c1 sha1 3717ee92672a6c6194e34a8ec07111fc71d8e5f1 )
+)
+
+game (
+	name "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Resident Evil (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc e68566ac md5 457944f833fc2f5e8ff394cfdf2e1b7c sha1 ef16289779911b90dda11789bc0f5fbd1d415d86 )
+)
+
+game (
+	name "Resident Evil (US)"
+	description "Resident Evil (US)"
+	rom ( name "Resident Evil (US) - (Disc 1 of 2).iso" size 1459978240 crc 24519740 md5 bdd0fe3848c4ab1441dc6c9ee209426b sha1 a176666f7d48dde2f464788ea8f2cef28c182537 )
+)
+
+game (
+	name "Resident Evil (USA) (Disc 1)"
+	description "Resident Evil (USA) (Disc 1)"
+	rom ( name "Resident Evil (USA) (Disc 1).iso" size 1459978240 crc 24519740 md5 bdd0fe3848c4ab1441dc6c9ee209426b sha1 a176666f7d48dde2f464788ea8f2cef28c182537 )
+)
+
+game (
+	name "Resident Evil (USA) (Disc 2)"
+	description "Resident Evil (USA) (Disc 2)"
+	rom ( name "Resident Evil (USA) (Disc 2).iso" size 1459978240 crc 8e5597c1 md5 7defd099e98944bc93684d4733bfe68b sha1 a44bcc7dc3ab10f68727d0ecf722c80a2be41156 )
+)
+
+game (
+	name "Resident Evil 2 (EU)"
+	description "Resident Evil 2 (EU)"
+	rom ( name "Resident Evil 2 (EU).iso" size 1459978240 crc 7b211913 md5 96798436434e7af83b5e52b0c8786923 sha1 eee9bab385b0e5bb2da3f743789636198d1b0b83 )
+)
+
+game (
+	name "Resident Evil 2 (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7b211913 md5 96798436434e7af83b5e52b0c8786923 sha1 eee9bab385b0e5bb2da3f743789636198d1b0b83 )
+)
+
+game (
+	name "Resident Evil 2 (US)"
+	description "Resident Evil 2 (US)"
+	rom ( name "Resident Evil 2 (US).iso" size 1459978240 crc b93a8a1f md5 ee2967ed8ccda671999a5151f2026723 sha1 7b60cea77ef270f9df61c81837bd3951109d6e98 )
+)
+
+game (
+	name "Resident Evil 2 (USA)"
+	description "Resident Evil 2 (USA)"
+	rom ( name "Resident Evil 2 (USA).iso" size 1459978240 crc b93a8a1f md5 ee2967ed8ccda671999a5151f2026723 sha1 7b60cea77ef270f9df61c81837bd3951109d6e98 )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (EU)"
+	description "Resident Evil 3 - Nemesis (EU)"
+	rom ( name "Resident Evil 3 - Nemesis (EU).iso" size 1459978240 crc 6c368ef2 md5 be608fb975ad73d792244a2e0a286693 sha1 4fd9202584a6da624607b5e2e0c468e9a310048c )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil 3 - Nemesis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil 3 - Nemesis (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 6c368ef2 md5 be608fb975ad73d792244a2e0a286693 sha1 4fd9202584a6da624607b5e2e0c468e9a310048c )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (US)"
+	description "Resident Evil 3 - Nemesis (US)"
+	rom ( name "Resident Evil 3 - Nemesis (US).iso" size 1459978240 crc 075fadb6 md5 428abf23e4c06dbfcbd3cea2fa577385 sha1 1644b7cbb4a46306ffcfc0a757408ffc1da34fd3 )
+)
+
+game (
+	name "Resident Evil 3 - Nemesis (USA)"
+	description "Resident Evil 3 - Nemesis (USA)"
+	rom ( name "Resident Evil 3 - Nemesis (USA).iso" size 1459978240 crc 075fadb6 md5 428abf23e4c06dbfcbd3cea2fa577385 sha1 1644b7cbb4a46306ffcfc0a757408ffc1da34fd3 )
+)
+
+game (
+	name "Resident Evil 4 (Australia) (En,Fr,De,Es,It) (Bonus Disc)"
+	description "Resident Evil 4 (Australia) (En,Fr,De,Es,It) (Bonus Disc)"
+	rom ( name "Resident Evil 4 (Australia) (En,Fr,De,Es,It) (Bonus Disc).iso" size 1459978240 crc 1d369cda md5 beb62bbbca5ac0b2bd558a6b3b6ece88 sha1 5773c5c824384619991776e617e86f00b1396505 )
+)
+
+game (
+	name "Resident Evil 4 (DE)"
+	description "Resident Evil 4 (DE)"
+	rom ( name "Resident Evil 4 (DE) - (Disc 1 of 2).iso" size 1459978240 crc 18960ecf md5 290d0b60e8b4d53a05c478d91a3ccda2 sha1 c9b85d4d14317f8bc101d74a0021d49886e42a69 )
+)
+
+game (
+	name "Resident Evil 4 (EU)"
+	description "Resident Evil 4 (EU)"
+	rom ( name "Resident Evil 4 (EU) - (Disc 1 of 2).iso" size 1459978240 crc 977d78fb md5 22db91d40629df75e63a019e0f9d72f5 sha1 9e58a28b32cbbddd215f2fcbecb79c41812f5f54 )
+)
+
+game (
+	name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Bonus Disc)"
+	description "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Bonus Disc)"
+	rom ( name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Bonus Disc).iso" size 1459978240 crc 99b43c29 md5 982a363f1edc388d8dd5e78b0393bb62 sha1 54c84c6d2f394ab423b65de00dd5fb8dd8800467 )
+)
+
+game (
+	name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 977d78fb md5 22db91d40629df75e63a019e0f9d72f5 sha1 9e58a28b32cbbddd215f2fcbecb79c41812f5f54 )
+)
+
+game (
+	name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Resident Evil 4 (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc d84695ae md5 41a0f650dd5a80dc8d0c268037ff2320 sha1 5dc7461496040f6656ecd7e187ab9f54d05d58fd )
+)
+
+game (
+	name "Resident Evil 4 (GameCube) (AU)"
+	description "Resident Evil 4 (GameCube) (AU)"
+	rom ( name "Resident Evil 4 (GameCube) (AU) - [Bonus Disc].iso" size 1459978240 crc 1d369cda md5 beb62bbbca5ac0b2bd558a6b3b6ece88 sha1 5773c5c824384619991776e617e86f00b1396505 )
+)
+
+game (
+	name "Resident Evil 4 (GameCube) (EU)"
+	description "Resident Evil 4 (GameCube) (EU)"
+	rom ( name "Resident Evil 4 (GameCube) (EU) - [Bonus Disc].iso" size 1459978240 crc 99b43c29 md5 982a363f1edc388d8dd5e78b0393bb62 sha1 54c84c6d2f394ab423b65de00dd5fb8dd8800467 )
+)
+
+game (
+	name "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 1)"
+	description "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 18960ecf md5 290d0b60e8b4d53a05c478d91a3ccda2 sha1 c9b85d4d14317f8bc101d74a0021d49886e42a69 )
+)
+
+game (
+	name "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 2)"
+	description "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Resident Evil 4 (Germany) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc f7d97a76 md5 7b6c469694e9bb14effec5d0017e08dd sha1 c77316a9132a735108096f55194d16450498a193 )
+)
+
+game (
+	name "Resident Evil 4 (Preview Disc) (US)"
+	description "Resident Evil 4 (Preview Disc) (US)"
+	rom ( name "Resident Evil 4 (Preview Disc) (US).iso" size 1459978240 crc b5612163 md5 a13adfc2b37255389cc4eef8ab45c0da sha1 ad76df637b4abff2f2db8fb714b9526e9f8b1e8c )
+)
+
+game (
+	name "Resident Evil 4 (US)"
+	description "Resident Evil 4 (US)"
+	rom ( name "Resident Evil 4 (US) - (Disc 1 of 2).iso" size 1459978240 crc f5c51b40 md5 ca749757e3b9d119f3feb1f9f0f81bd7 sha1 9de89c7f6d8ffb2e27423900a39d4aec1439f4e3 )
+)
+
+game (
+	name "Resident Evil 4 (USA) (Disc 1)"
+	description "Resident Evil 4 (USA) (Disc 1)"
+	rom ( name "Resident Evil 4 (USA) (Disc 1).iso" size 1459978240 crc f5c51b40 md5 ca749757e3b9d119f3feb1f9f0f81bd7 sha1 9de89c7f6d8ffb2e27423900a39d4aec1439f4e3 )
+)
+
+game (
+	name "Resident Evil 4 (USA) (Disc 2)"
+	description "Resident Evil 4 (USA) (Disc 2)"
+	rom ( name "Resident Evil 4 (USA) (Disc 2).iso" size 1459978240 crc 6c83a5ff md5 2381acd2199d6e7566932df86901903d sha1 c75f7936814636ffe03277f363fc3427c98602ee )
+)
+
+game (
+	name "Resident Evil 4 (USA) (Preview Disc)"
+	description "Resident Evil 4 (USA) (Preview Disc)"
+	rom ( name "Resident Evil 4 (USA) (Preview Disc).iso" size 1459978240 crc b5612163 md5 a13adfc2b37255389cc4eef8ab45c0da sha1 ad76df637b4abff2f2db8fb714b9526e9f8b1e8c )
+)
+
+game (
+	name "Resident Evil Zero (EU)"
+	description "Resident Evil Zero (EU)"
+	rom ( name "Resident Evil Zero (EU) - (Disc 1 of 2).iso" size 1459978240 crc dda63a9f md5 5ea73a9328c549c74c4feaf68abae7bc sha1 c497341f869e923d1e1c977a7a9ce8dba1f0e462 )
+)
+
+game (
+	name "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc dda63a9f md5 5ea73a9328c549c74c4feaf68abae7bc sha1 c497341f869e923d1e1c977a7a9ce8dba1f0e462 )
+)
+
+game (
+	name "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Resident Evil Zero (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 4970460d md5 9d0c9be6e329768b1092d5fb0e7358e4 sha1 c1920fc5ba042faf3abdb88161838b2c9ae92ad2 )
+)
+
+game (
+	name "Resident Evil Zero (US)"
+	description "Resident Evil Zero (US)"
+	rom ( name "Resident Evil Zero (US) - (Disc 1 of 2).iso" size 1459978240 crc bcc348bf md5 0ee40d54f7da504b559ae7eb4bb31b9d sha1 350e5e7b00373bed18dab879cdd2de82111dd222 )
+)
+
+game (
+	name "Resident Evil Zero (USA) (Disc 1)"
+	description "Resident Evil Zero (USA) (Disc 1)"
+	rom ( name "Resident Evil Zero (USA) (Disc 1).iso" size 1459978240 crc bcc348bf md5 0ee40d54f7da504b559ae7eb4bb31b9d sha1 350e5e7b00373bed18dab879cdd2de82111dd222 )
+)
+
+game (
+	name "Resident Evil Zero (USA) (Disc 2)"
+	description "Resident Evil Zero (USA) (Disc 2)"
+	rom ( name "Resident Evil Zero (USA) (Disc 2).iso" size 1459978240 crc 4daf0830 md5 51f50b40a979ce53b2b19f8161ad9cd0 sha1 9ed77923f2c6de99bab804f31cbb8dd61875096d )
+)
+
+game (
+	name "Ribbit King (EU)"
+	description "Ribbit King (EU)"
+	rom ( name "Ribbit King (EU).iso" size 1459978240 crc b4cf112f md5 28a18a5c62f46923e6349c7b47587bf3 sha1 cbee7599c5eeaefa93b636dda09c4c1585738ec7 )
+)
+
+game (
+	name "Ribbit King (Europe) (En,Fr,De,Es,It)"
+	description "Ribbit King (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Ribbit King (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b4cf112f md5 28a18a5c62f46923e6349c7b47587bf3 sha1 cbee7599c5eeaefa93b636dda09c4c1585738ec7 )
+)
+
+game (
+	name "Ribbit King (US)"
+	description "Ribbit King (US)"
+	rom ( name "Ribbit King (US).iso" size 1459978240 crc e46d465d md5 67b83d2ef427326b8f69e995fa104245 sha1 1d6cc36ec5ffa402d0d898b81d71fc778c34b34a )
+)
+
+game (
+	name "Ribbit King (USA) (En,Es)"
+	description "Ribbit King (USA) (En,Es)"
+	rom ( name "Ribbit King (USA) (En,Es).iso" size 1459978240 crc e46d465d md5 67b83d2ef427326b8f69e995fa104245 sha1 1d6cc36ec5ffa402d0d898b81d71fc778c34b34a )
+)
+
+game (
+	name "Ribbit King Plus! (Bonus Disc) (US)"
+	description "Ribbit King Plus! (Bonus Disc) (US)"
+	rom ( name "Ribbit King Plus! (Bonus Disc) (US).iso" size 1459978240 crc e5e731eb md5 a7c4d17e34bade211b797fd3c7130fc0 sha1 3d6c301bbc54b0939307aa8772e008ac467215dd )
+)
+
+game (
+	name "Ribbit King Plus! (USA) (Bonus Disc)"
+	description "Ribbit King Plus! (USA) (Bonus Disc)"
+	rom ( name "Ribbit King Plus! (USA) (Bonus Disc).iso" size 1459978240 crc e5e731eb md5 a7c4d17e34bade211b797fd3c7130fc0 sha1 3d6c301bbc54b0939307aa8772e008ac467215dd )
+)
+
+game (
+	name "Road Trip - The Arcade Edition (US)"
+	description "Road Trip - The Arcade Edition (US)"
+	rom ( name "Road Trip - The Arcade Edition (US).iso" size 1459978240 crc 550d6fe7 md5 297d13cd9485baab035df30b289a1bcd sha1 c3f3567cd955468ef98b420d415613936f46bb40 )
+)
+
+game (
+	name "Road Trip - The Arcade Edition (USA)"
+	description "Road Trip - The Arcade Edition (USA)"
+	rom ( name "Road Trip - The Arcade Edition (USA).iso" size 1459978240 crc 550d6fe7 md5 297d13cd9485baab035df30b289a1bcd sha1 c3f3567cd955468ef98b420d415613936f46bb40 )
+)
+
+game (
+	name "RoadKill (US)"
+	description "RoadKill (US)"
+	rom ( name "RoadKill (US).iso" size 1459978240 crc 097f4736 md5 cc7dac0c9c33410d81fc9ffa0c7a54ab sha1 2539b58572a3bb38433b7a2a9e53808787ffcc4a )
+)
+
+game (
+	name "RoadKill (USA)"
+	description "RoadKill (USA)"
+	rom ( name "RoadKill (USA).iso" size 1459978240 crc 097f4736 md5 cc7dac0c9c33410d81fc9ffa0c7a54ab sha1 2539b58572a3bb38433b7a2a9e53808787ffcc4a )
+)
+
+game (
+	name "RoboCop - Aratanaru Kiki (Japan)"
+	description "RoboCop - Aratanaru Kiki (Japan)"
+	rom ( name "RoboCop - Aratanaru Kiki (Japan).iso" size 1459978240 crc bfc3aed4 md5 a696e5b968baf90495c302e10871399e sha1 406457870dcb6d52cb051abc000ab231e6c36fcc )
+)
+
+game (
+	name "RoboCop - Aratanaru Kiki (JP) - robokotupu+Xin tanaruWei Ji"
+	description "RoboCop - Aratanaru Kiki (JP) - robokotupu+Xin tanaruWei Ji"
+	rom ( name "RoboCop - Aratanaru Kiki (JP).iso" size 1459978240 crc bfc3aed4 md5 a696e5b968baf90495c302e10871399e sha1 406457870dcb6d52cb051abc000ab231e6c36fcc )
+)
+
+game (
+	name "Robotech - Battlecry (EU)"
+	description "Robotech - Battlecry (EU)"
+	rom ( name "Robotech - Battlecry (EU).iso" size 1459978240 crc af5c6f08 md5 be33e1428d9d1da5f436744bcdd9ccf7 sha1 02ba7ca8c6ad08f3a34d758b40d4abb6396938ac )
+)
+
+game (
+	name "Robotech - Battlecry (Europe) (En,Fr,De,Es,It)"
+	description "Robotech - Battlecry (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Robotech - Battlecry (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc af5c6f08 md5 be33e1428d9d1da5f436744bcdd9ccf7 sha1 02ba7ca8c6ad08f3a34d758b40d4abb6396938ac )
+)
+
+game (
+	name "Robotech - Battlecry (US)"
+	description "Robotech - Battlecry (US)"
+	rom ( name "Robotech - Battlecry (US).iso" size 1459978240 crc 6ee515dc md5 cd48d2eea3103e5bd6f1d154937199c0 sha1 4875e9be673813f8d9b87667424733363485a43a )
+)
+
+game (
+	name "Robotech - Battlecry (USA)"
+	description "Robotech - Battlecry (USA)"
+	rom ( name "Robotech - Battlecry (USA).iso" size 1459978240 crc 6ee515dc md5 cd48d2eea3103e5bd6f1d154937199c0 sha1 4875e9be673813f8d9b87667424733363485a43a )
+)
+
+game (
+	name "Robots (EU)"
+	description "Robots (EU)"
+	rom ( name "Robots (EU).iso" size 1459978240 crc 22360576 md5 1f48b48587f9870a5e807bb4e38134e8 sha1 18b2cf6a73b5638fb72327894abd431ad94ce264 )
+)
+
+game (
+	name "Robots (Europe) (En,Fr,De,Es,It)"
+	description "Robots (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Robots (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 22360576 md5 1f48b48587f9870a5e807bb4e38134e8 sha1 18b2cf6a73b5638fb72327894abd431ad94ce264 )
+)
+
+game (
+	name "Robots (Japan)"
+	description "Robots (Japan)"
+	rom ( name "Robots (Japan).iso" size 1459978240 crc dd7888ed md5 1041b47dd00f72076b76b8a7fbc04f71 sha1 f95570c9af62fd32a0d79e991a57030485d45cdf )
+)
+
+game (
+	name "Robots (JP) - robotutu"
+	description "Robots (JP) - robotutu"
+	rom ( name "Robots (JP).iso" size 1459978240 crc dd7888ed md5 1041b47dd00f72076b76b8a7fbc04f71 sha1 f95570c9af62fd32a0d79e991a57030485d45cdf )
+)
+
+game (
+	name "Robots (US)"
+	description "Robots (US)"
+	rom ( name "Robots (US).iso" size 1459978240 crc f978ca04 md5 befbc956176da84f6b30c23c0a221713 sha1 98cef132f3ae139414d089df2e09b9c63d7833e7 )
+)
+
+game (
+	name "Robots (USA)"
+	description "Robots (USA)"
+	rom ( name "Robots (USA).iso" size 1459978240 crc f978ca04 md5 befbc956176da84f6b30c23c0a221713 sha1 98cef132f3ae139414d089df2e09b9c63d7833e7 )
+)
+
+game (
+	name "Rockman EXE Transmission (Japan)"
+	description "Rockman EXE Transmission (Japan)"
+	rom ( name "Rockman EXE Transmission (Japan).iso" size 1459978240 crc f470a6f4 md5 470005ff8a5591220ac64ecee325728e sha1 4ade9bbba8b3172be24d896bf62ef697278d8124 )
+)
+
+game (
+	name "Rockman EXE Transmission (JP) - rotukumaneguze+toransumitusiyon"
+	description "Rockman EXE Transmission (JP) - rotukumaneguze+toransumitusiyon"
+	rom ( name "Rockman EXE Transmission (JP).iso" size 1459978240 crc f470a6f4 md5 470005ff8a5591220ac64ecee325728e sha1 4ade9bbba8b3172be24d896bf62ef697278d8124 )
+)
+
+game (
+	name "Rockman X - Command Mission (Japan)"
+	description "Rockman X - Command Mission (Japan)"
+	rom ( name "Rockman X - Command Mission (Japan).iso" size 1459978240 crc 179cf63b md5 65134582e63c2aefb9bd01eedd3b2453 sha1 529af57404d2b8f799d14093acdd469fa615a766 )
+)
+
+game (
+	name "Rockman X - Command Mission (JP) - rotukumanX+komandomitusiyon"
+	description "Rockman X - Command Mission (JP) - rotukumanX+komandomitusiyon"
+	rom ( name "Rockman X - Command Mission (JP).iso" size 1459978240 crc 179cf63b md5 65134582e63c2aefb9bd01eedd3b2453 sha1 529af57404d2b8f799d14093acdd469fa615a766 )
+)
+
+game (
+	name "Rocky (EU)"
+	description "Rocky (EU)"
+	rom ( name "Rocky (EU).iso" size 1459978240 crc 7875f632 md5 de8229f9a6d08290708a9372da899eef sha1 30aec117e93d5f7b674d2b03fe15df196a855e4c )
+)
+
+game (
+	name "Rocky (Europe) (En,Fr,De,Es,It)"
+	description "Rocky (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rocky (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7875f632 md5 de8229f9a6d08290708a9372da899eef sha1 30aec117e93d5f7b674d2b03fe15df196a855e4c )
+)
+
+game (
+	name "Rocky (US)"
+	description "Rocky (US)"
+	rom ( name "Rocky (US).iso" size 1459978240 crc f7df84b4 md5 c4c09035a2c19c810e1d2374c0322e39 sha1 ca5b71e248c1cfbbddf5fe10cedd9f40fea9dd7e )
+)
+
+game (
+	name "Rocky (USA)"
+	description "Rocky (USA)"
+	rom ( name "Rocky (USA).iso" size 1459978240 crc f7df84b4 md5 c4c09035a2c19c810e1d2374c0322e39 sha1 ca5b71e248c1cfbbddf5fe10cedd9f40fea9dd7e )
+)
+
+game (
+	name "Rogue Ops (EU)"
+	description "Rogue Ops (EU)"
+	rom ( name "Rogue Ops (EU).iso" size 1459978240 crc 131c7666 md5 9b38131fa1869eb30120f08c5501bd4a sha1 62cd93914f379712224291aae2be5ece6d3c462e )
+)
+
+game (
+	name "Rogue Ops (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Rogue Ops (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Rogue Ops (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 131c7666 md5 9b38131fa1869eb30120f08c5501bd4a sha1 62cd93914f379712224291aae2be5ece6d3c462e )
+)
+
+game (
+	name "Rogue Ops (Japan)"
+	description "Rogue Ops (Japan)"
+	rom ( name "Rogue Ops (Japan).iso" size 1459978240 crc 692b809d md5 902c568cc460e64feaebf82e23a7dead sha1 f8845a119cf46a2f70a024a7fc09a60eaa9324ee )
+)
+
+game (
+	name "Rogue Ops (JP) - rogu+opusu"
+	description "Rogue Ops (JP) - rogu+opusu"
+	rom ( name "Rogue Ops (JP).iso" size 1459978240 crc 692b809d md5 902c568cc460e64feaebf82e23a7dead sha1 f8845a119cf46a2f70a024a7fc09a60eaa9324ee )
+)
+
+game (
+	name "Rogue Ops (US)"
+	description "Rogue Ops (US)"
+	rom ( name "Rogue Ops (US).iso" size 1459978240 crc 2913aee5 md5 7c2792b3e196cd312f35dc8ca41a9fe8 sha1 e81615c635721b25e71694d2639b045d6d949a42 )
+)
+
+game (
+	name "Rogue Ops (USA)"
+	description "Rogue Ops (USA)"
+	rom ( name "Rogue Ops (USA).iso" size 1459978240 crc 2913aee5 md5 7c2792b3e196cd312f35dc8ca41a9fe8 sha1 e81615c635721b25e71694d2639b045d6d949a42 )
+)
+
+game (
+	name "Rune (Japan)"
+	description "Rune (Japan)"
+	rom ( name "Rune (Japan).iso" size 1459978240 crc 1a3e593e md5 6360d68c74e1aabcb46649d54a4fc308 sha1 cbf5faa109d2199dfcf51e7c6b68110b48cca1c4 )
+)
+
+game (
+	name "Rune (JP) - run"
+	description "Rune (JP) - run"
+	rom ( name "Rune (JP).iso" size 1459978240 crc 1a3e593e md5 6360d68c74e1aabcb46649d54a4fc308 sha1 cbf5faa109d2199dfcf51e7c6b68110b48cca1c4 )
+)
+
+game (
+	name "Rune II - Koruten no Kagi no Himitsu (Japan)"
+	description "Rune II - Koruten no Kagi no Himitsu (Japan)"
+	rom ( name "Rune II - Koruten no Kagi no Himitsu (Japan).iso" size 1459978240 crc da18dc25 md5 6659a52d5f293e76f02a9a363c1ab099 sha1 664f586b7e6f3675b44e1622d63a80811164fbcf )
+)
+
+game (
+	name "Rune II - Koruten no Kagi no Himitsu (Japan) (Taikenban)"
+	description "Rune II - Koruten no Kagi no Himitsu (Japan) (Taikenban)"
+	rom ( name "Rune II - Koruten no Kagi no Himitsu (Japan) (Taikenban).iso" size 1459978240 crc e3295a1a md5 e6a7b56b6797522eebde066c7b908888 sha1 93cdfd981976cdae55cebbc235bbaab0d142025f )
+)
+
+game (
+	name "Rune II - Koruten no Kagi no Himitsu (JP) - runII+korutennoJian noMi Mi"
+	description "Rune II - Koruten no Kagi no Himitsu (JP) - runII+korutennoJian noMi Mi"
+	rom ( name "Rune II - Koruten no Kagi no Himitsu (JP).iso" size 1459978240 crc da18dc25 md5 6659a52d5f293e76f02a9a363c1ab099 sha1 664f586b7e6f3675b44e1622d63a80811164fbcf )
+)
+
+game (
+	name "Rune II - Koruten no Kagi no Himitsu (Taikenban) (JP) - runII+korutennoJian noMi Mi"
+	description "Rune II - Koruten no Kagi no Himitsu (Taikenban) (JP) - runII+korutennoJian noMi Mi"
+	rom ( name "Rune II - Koruten no Kagi no Himitsu (Taikenban) (JP).iso" size 1459978240 crc e3295a1a md5 e6a7b56b6797522eebde066c7b908888 sha1 93cdfd981976cdae55cebbc235bbaab0d142025f )
+)
+
+game (
+	name "Samurai Jack - The Shadow of Aku (EU)"
+	description "Samurai Jack - The Shadow of Aku (EU)"
+	rom ( name "Samurai Jack - The Shadow of Aku (EU).iso" size 1459978240 crc 3ade38f4 md5 180a1e9789864dcede6a166a0cc262d6 sha1 7ba390b5e46e142b5a40648494a2fc8d785d7f15 )
+)
+
+game (
+	name "Samurai Jack - The Shadow of Aku (Europe) (En,Fr,De,Es,It)"
+	description "Samurai Jack - The Shadow of Aku (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Samurai Jack - The Shadow of Aku (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3ade38f4 md5 180a1e9789864dcede6a166a0cc262d6 sha1 7ba390b5e46e142b5a40648494a2fc8d785d7f15 )
+)
+
+game (
+	name "Samurai Jack - The Shadow of Aku (US)"
+	description "Samurai Jack - The Shadow of Aku (US)"
+	rom ( name "Samurai Jack - The Shadow of Aku (US).iso" size 1459978240 crc 7dac3582 md5 c2a43d76d4d8b3beeb604d74e5458a66 sha1 77df2a14e2c8b3d9973e1ba16cb4c48ec1df8c0b )
+)
+
+game (
+	name "Samurai Jack - The Shadow of Aku (USA)"
+	description "Samurai Jack - The Shadow of Aku (USA)"
+	rom ( name "Samurai Jack - The Shadow of Aku (USA).iso" size 1459978240 crc 7dac3582 md5 c2a43d76d4d8b3beeb604d74e5458a66 sha1 77df2a14e2c8b3d9973e1ba16cb4c48ec1df8c0b )
+)
+
+game (
+	name "Scaler (US)"
+	description "Scaler (US)"
+	rom ( name "Scaler (US).iso" size 1459978240 crc 80a156c2 md5 7416adc649f6f831501acc232c92958a sha1 cbb39dc0410096a568c04b71635ac6be85cc27c3 )
+)
+
+game (
+	name "Scaler (USA) (En,Fr)"
+	description "Scaler (USA) (En,Fr)"
+	rom ( name "Scaler (USA) (En,Fr).iso" size 1459978240 crc 80a156c2 md5 7416adc649f6f831501acc232c92958a sha1 cbb39dc0410096a568c04b71635ac6be85cc27c3 )
+)
+
+game (
+	name "Scooby-Doo! Fluch der Folianten (DE)"
+	description "Scooby-Doo! Fluch der Folianten (DE)"
+	rom ( name "Scooby-Doo! Fluch der Folianten (DE).iso" size 1459978240 crc 586dc955 md5 5423bdc41509eeaeba054e0ab641e099 sha1 954f0c8b43a9869cef2693710c6084dee3d81fb6 )
+)
+
+game (
+	name "Scooby-Doo! Fluch der Folianten (Germany)"
+	description "Scooby-Doo! Fluch der Folianten (Germany)"
+	rom ( name "Scooby-Doo! Fluch der Folianten (Germany).iso" size 1459978240 crc 586dc955 md5 5423bdc41509eeaeba054e0ab641e099 sha1 954f0c8b43a9869cef2693710c6084dee3d81fb6 )
+)
+
+game (
+	name "Scooby-Doo! Le Livre des Tenebres (FR)"
+	description "Scooby-Doo! Le Livre des Tenebres (FR)"
+	rom ( name "Scooby-Doo! Le Livre des Tenebres (FR).iso" size 1459978240 crc 1dc2dace md5 749da2151fca95e299722938014bb134 sha1 17b68f16c2c238a0f0f3b0b496288eb879c6de9e )
+)
+
+game (
+	name "Scooby-Doo! Le Livre des Tenebres (France)"
+	description "Scooby-Doo! Le Livre des Tenebres (France)"
+	rom ( name "Scooby-Doo! Le Livre des Tenebres (France).iso" size 1459978240 crc 1dc2dace md5 749da2151fca95e299722938014bb134 sha1 17b68f16c2c238a0f0f3b0b496288eb879c6de9e )
+)
+
+game (
+	name "Scooby-Doo! Mystery Mayhem (Europe)"
+	description "Scooby-Doo! Mystery Mayhem (Europe)"
+	rom ( name "Scooby-Doo! Mystery Mayhem (Europe).iso" size 1459978240 crc 44786c13 md5 e2ba90cade06225b7bef8b10476e6f3f sha1 962fe7d9022339c92e918351914d90519454787e )
+)
+
+game (
+	name "Scooby-Doo! Mystery Mayhem (GB)"
+	description "Scooby-Doo! Mystery Mayhem (GB)"
+	rom ( name "Scooby-Doo! Mystery Mayhem (GB).iso" size 1459978240 crc 44786c13 md5 e2ba90cade06225b7bef8b10476e6f3f sha1 962fe7d9022339c92e918351914d90519454787e )
+)
+
+game (
+	name "Scooby-Doo! Mystery Mayhem (US)"
+	description "Scooby-Doo! Mystery Mayhem (US)"
+	rom ( name "Scooby-Doo! Mystery Mayhem (US).iso" size 1459978240 crc fbec80e6 md5 1a04ff3ddd293329ccba164a99d29da7 sha1 4aee03668f2e2e15c46dd5c342205658cf1633cf )
+)
+
+game (
+	name "Scooby-Doo! Mystery Mayhem (USA)"
+	description "Scooby-Doo! Mystery Mayhem (USA)"
+	rom ( name "Scooby-Doo! Mystery Mayhem (USA).iso" size 1459978240 crc fbec80e6 md5 1a04ff3ddd293329ccba164a99d29da7 sha1 4aee03668f2e2e15c46dd5c342205658cf1633cf )
+)
+
+game (
+	name "Scooby-Doo! Nacht der 100 Schrecken (DE)"
+	description "Scooby-Doo! Nacht der 100 Schrecken (DE)"
+	rom ( name "Scooby-Doo! Nacht der 100 Schrecken (DE).iso" size 1459978240 crc a7a3dace md5 bda091b76e492271bbcf0fa030768ebe sha1 8b3d3cb494aa00ee332a27a521703b6d430bbc51 )
+)
+
+game (
+	name "Scooby-Doo! Nacht der 100 Schrecken (Germany)"
+	description "Scooby-Doo! Nacht der 100 Schrecken (Germany)"
+	rom ( name "Scooby-Doo! Nacht der 100 Schrecken (Germany).iso" size 1459978240 crc a7a3dace md5 bda091b76e492271bbcf0fa030768ebe sha1 8b3d3cb494aa00ee332a27a521703b6d430bbc51 )
+)
+
+game (
+	name "Scooby-Doo! Night of 100 Frights (Europe)"
+	description "Scooby-Doo! Night of 100 Frights (Europe)"
+	rom ( name "Scooby-Doo! Night of 100 Frights (Europe).iso" size 1459978240 crc ac9948a6 md5 db7ce894e31f45b9cede204fb0ac6dfa sha1 437b1ef67bad5446f9a0a203d0f5a0bbf5fc5864 )
+)
+
+game (
+	name "Scooby-Doo! Night of 100 Frights (GB)"
+	description "Scooby-Doo! Night of 100 Frights (GB)"
+	rom ( name "Scooby-Doo! Night of 100 Frights (GB).iso" size 1459978240 crc ac9948a6 md5 db7ce894e31f45b9cede204fb0ac6dfa sha1 437b1ef67bad5446f9a0a203d0f5a0bbf5fc5864 )
+)
+
+game (
+	name "Scooby-Doo! Night of 100 Frights (US)"
+	description "Scooby-Doo! Night of 100 Frights (US)"
+	rom ( name "Scooby-Doo! Night of 100 Frights (US) - [v1.00].iso" size 1459978240 crc 9aea6fc1 md5 6f078c687c81e26b8e81127ba4b747ba sha1 2b79163f69aebe0307fff934f765407fed3de1d7 )
+)
+
+game (
+	name "Scooby-Doo! Night of 100 Frights (USA) (v1.00)"
+	description "Scooby-Doo! Night of 100 Frights (USA) (v1.00)"
+	rom ( name "Scooby-Doo! Night of 100 Frights (USA) (v1.00).iso" size 1459978240 crc 9aea6fc1 md5 6f078c687c81e26b8e81127ba4b747ba sha1 2b79163f69aebe0307fff934f765407fed3de1d7 )
+)
+
+game (
+	name "Scooby-Doo! Night of 100 Frights (USA) (v1.01)"
+	description "Scooby-Doo! Night of 100 Frights (USA) (v1.01)"
+	rom ( name "Scooby-Doo! Night of 100 Frights (USA) (v1.01).iso" size 1459978240 crc b29a2a47 md5 6dca7f5ed6b400c8216526107e83f3cd sha1 cf5638fd61a7862e07066fb290381bdfc77d1f37 )
+)
+
+game (
+	name "Scooby-Doo! Unmasked (EU)"
+	description "Scooby-Doo! Unmasked (EU)"
+	rom ( name "Scooby-Doo! Unmasked (EU).iso" size 1459978240 crc cc68c3c1 md5 e4066ccb91f2ca85abf8e64a4786210b sha1 b757670b2af9b34ab4209b75d4ce0cbe7924aad6 )
+)
+
+game (
+	name "Scooby-Doo! Unmasked (Europe) (En,Fr,Es,It)"
+	description "Scooby-Doo! Unmasked (Europe) (En,Fr,Es,It)"
+	rom ( name "Scooby-Doo! Unmasked (Europe) (En,Fr,Es,It).iso" size 1459978240 crc cc68c3c1 md5 e4066ccb91f2ca85abf8e64a4786210b sha1 b757670b2af9b34ab4209b75d4ce0cbe7924aad6 )
+)
+
+game (
+	name "Scooby-Doo! Unmasked (US)"
+	description "Scooby-Doo! Unmasked (US)"
+	rom ( name "Scooby-Doo! Unmasked (US).iso" size 1459978240 crc 7a5a6f45 md5 d51dda17ebb0725db3f962ee4b4dd560 sha1 55e89686d8606b09a6dbc1eca92a2c53dd6939b0 )
+)
+
+game (
+	name "Scooby-Doo! Unmasked (USA) (En,Fr)"
+	description "Scooby-Doo! Unmasked (USA) (En,Fr)"
+	rom ( name "Scooby-Doo! Unmasked (USA) (En,Fr).iso" size 1459978240 crc 7a5a6f45 md5 d51dda17ebb0725db3f962ee4b4dd560 sha1 55e89686d8606b09a6dbc1eca92a2c53dd6939b0 )
+)
+
+game (
+	name "Scorpion King, The - Rise of the Akkadian (EU)"
+	description "Scorpion King, The - Rise of the Akkadian (EU)"
+	rom ( name "Scorpion King, The - Rise of the Akkadian (EU).iso" size 1459978240 crc 88143199 md5 d4cb61cbe9a31a818ef666e520b165dd sha1 bde7a01af10c0c877dc13fe7d33c6ad160b20c20 )
+)
+
+game (
+	name "Scorpion King, The - Rise of the Akkadian (Europe) (En,Fr,De,Es,It)"
+	description "Scorpion King, The - Rise of the Akkadian (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Scorpion King, The - Rise of the Akkadian (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 88143199 md5 d4cb61cbe9a31a818ef666e520b165dd sha1 bde7a01af10c0c877dc13fe7d33c6ad160b20c20 )
+)
+
+game (
+	name "Scorpion King, The - Rise of the Akkadian (US)"
+	description "Scorpion King, The - Rise of the Akkadian (US)"
+	rom ( name "Scorpion King, The - Rise of the Akkadian (US).iso" size 1459978240 crc 9e55240c md5 87c847b9c241e6d66b97378b7be38c95 sha1 debf7239220bc6104ac4c5ee0eb203c77b6635ae )
+)
+
+game (
+	name "Scorpion King, The - Rise of the Akkadian (USA)"
+	description "Scorpion King, The - Rise of the Akkadian (USA)"
+	rom ( name "Scorpion King, The - Rise of the Akkadian (USA).iso" size 1459978240 crc 9e55240c md5 87c847b9c241e6d66b97378b7be38c95 sha1 debf7239220bc6104ac4c5ee0eb203c77b6635ae )
+)
+
+game (
+	name "SD Gundam - Gashapon Wars (Japan)"
+	description "SD Gundam - Gashapon Wars (Japan)"
+	rom ( name "SD Gundam - Gashapon Wars (Japan).iso" size 1459978240 crc d5f67251 md5 df13fef53a110c6a92ed121e62783d60 sha1 e76a2e3956dc6ad8ad4cfd839e5358288be2368f )
+)
+
+game (
+	name "SD Gundam - Gashapon Wars (Japan) (Taikenban)"
+	description "SD Gundam - Gashapon Wars (Japan) (Taikenban)"
+	rom ( name "SD Gundam - Gashapon Wars (Japan) (Taikenban).iso" size 1459978240 crc 1644b443 md5 cbe0951ad0852fa269a3435c859d325d sha1 ff47e2bccfb74d000b2a745da57a0fdf9be56365 )
+)
+
+game (
+	name "SD Gundam - Gashapon Wars (JP) - SDgandamu+gasiyaponuozu"
+	description "SD Gundam - Gashapon Wars (JP) - SDgandamu+gasiyaponuozu"
+	rom ( name "SD Gundam - Gashapon Wars (JP).iso" size 1459978240 crc d5f67251 md5 df13fef53a110c6a92ed121e62783d60 sha1 e76a2e3956dc6ad8ad4cfd839e5358288be2368f )
+)
+
+game (
+	name "SD Gundam - Gashapon Wars (Taikenban) (JP) - SDgandamu+gasiyaponuozu+Ti Yan Ban"
+	description "SD Gundam - Gashapon Wars (Taikenban) (JP) - SDgandamu+gasiyaponuozu+Ti Yan Ban"
+	rom ( name "SD Gundam - Gashapon Wars (Taikenban) (JP).iso" size 1459978240 crc 1644b443 md5 cbe0951ad0852fa269a3435c859d325d sha1 ff47e2bccfb74d000b2a745da57a0fdf9be56365 )
+)
+
+game (
+	name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (EU)"
+	description "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (EU)"
+	rom ( name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (EU).iso" size 1459978240 crc 5cdafbc1 md5 af890c5b7649fd4e0993f23bdc3fb809 sha1 7fb14118005f80a0e715407b3c36f11e65394255 )
+)
+
+game (
+	name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (Europe)"
+	description "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (Europe)"
+	rom ( name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (Europe).iso" size 1459978240 crc 5cdafbc1 md5 af890c5b7649fd4e0993f23bdc3fb809 sha1 7fb14118005f80a0e715407b3c36f11e65394255 )
+)
+
+game (
+	name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (US)"
+	description "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (US)"
+	rom ( name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (US).iso" size 1459978240 crc bacf314c md5 cfc11a29905bf15c353c4c040f878525 sha1 549931c10112ba43245b7e962ef600a09fe1de4a )
+)
+
+game (
+	name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (USA)"
+	description "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (USA)"
+	rom ( name "SeaWorld Adventure Parks - Shamu's Deep Sea Adventures (USA).iso" size 1459978240 crc bacf314c md5 cfc11a29905bf15c353c4c040f878525 sha1 549931c10112ba43245b7e962ef600a09fe1de4a )
+)
+
+game (
+	name "Second Sight (EU)"
+	description "Second Sight (EU)"
+	rom ( name "Second Sight (EU).iso" size 1459978240 crc 224b2525 md5 c22fe0894d76d8a81a11cd75c8d7b4f9 sha1 791f26acf620f247461c66a9ab0fadb8042f012b )
+)
+
+game (
+	name "Second Sight (Europe) (En,Fr,De,Es,It)"
+	description "Second Sight (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Second Sight (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 224b2525 md5 c22fe0894d76d8a81a11cd75c8d7b4f9 sha1 791f26acf620f247461c66a9ab0fadb8042f012b )
+)
+
+game (
+	name "Second Sight (US)"
+	description "Second Sight (US)"
+	rom ( name "Second Sight (US).iso" size 1459978240 crc fe31f0bf md5 9c14c0e39cdb9166999e49fc1ef44fd8 sha1 0502fc5689cc763de92f216c0e4734598489cccd )
+)
+
+game (
+	name "Second Sight (USA)"
+	description "Second Sight (USA)"
+	rom ( name "Second Sight (USA).iso" size 1459978240 crc fe31f0bf md5 9c14c0e39cdb9166999e49fc1ef44fd8 sha1 0502fc5689cc763de92f216c0e4734598489cccd )
+)
+
+game (
+	name "Sega Soccer Slam (EU)"
+	description "Sega Soccer Slam (EU)"
+	rom ( name "Sega Soccer Slam (EU).iso" size 1459978240 crc 4fd440c5 md5 2e54ab0d13f9eb085d01dc3b2f0da0e8 sha1 fff60543668c3521c01159e5d2f96c044d778cfa )
+)
+
+game (
+	name "Sega Soccer Slam (Europe)"
+	description "Sega Soccer Slam (Europe)"
+	rom ( name "Sega Soccer Slam (Europe).iso" size 1459978240 crc 4fd440c5 md5 2e54ab0d13f9eb085d01dc3b2f0da0e8 sha1 fff60543668c3521c01159e5d2f96c044d778cfa )
+)
+
+game (
+	name "Sega Soccer Slam (Japan)"
+	description "Sega Soccer Slam (Japan)"
+	rom ( name "Sega Soccer Slam (Japan).iso" size 1459978240 crc de99a222 md5 554d45dcd3cbfb69a602ba8e2cbf01e7 sha1 bd292ca08fbe3f564e832a8c5649c1f4c14c9f06 )
+)
+
+game (
+	name "Sega Soccer Slam (JP) - sega+satukasuramu"
+	description "Sega Soccer Slam (JP) - sega+satukasuramu"
+	rom ( name "Sega Soccer Slam (JP).iso" size 1459978240 crc de99a222 md5 554d45dcd3cbfb69a602ba8e2cbf01e7 sha1 bd292ca08fbe3f564e832a8c5649c1f4c14c9f06 )
+)
+
+game (
+	name "Sega Soccer Slam (US)"
+	description "Sega Soccer Slam (US)"
+	rom ( name "Sega Soccer Slam (US).iso" size 1459978240 crc 887f3876 md5 9c1b0c55e9bd9c69cbb5bc3fc0034d4c sha1 d00123a8af05123ca03d9341626ff4e4cbeb9aa0 )
+)
+
+game (
+	name "Sega Soccer Slam (USA)"
+	description "Sega Soccer Slam (USA)"
+	rom ( name "Sega Soccer Slam (USA).iso" size 1459978240 crc 887f3876 md5 9c1b0c55e9bd9c69cbb5bc3fc0034d4c sha1 d00123a8af05123ca03d9341626ff4e4cbeb9aa0 )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Le Retour du Roi (FR)"
+	description "Seigneur des Anneaux, Le - Le Retour du Roi (FR)"
+	rom ( name "Seigneur des Anneaux, Le - Le Retour du Roi (FR).iso" size 1459978240 crc 2010369a md5 f62cbefd48ac834aa6ccb3fdcb99b5e1 sha1 ff0459ff9b97bad79c622d17b996279112876d4a )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Le Retour du Roi (France)"
+	description "Seigneur des Anneaux, Le - Le Retour du Roi (France)"
+	rom ( name "Seigneur des Anneaux, Le - Le Retour du Roi (France).iso" size 1459978240 crc 2010369a md5 f62cbefd48ac834aa6ccb3fdcb99b5e1 sha1 ff0459ff9b97bad79c622d17b996279112876d4a )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Le Tiers Age (FR)"
+	description "Seigneur des Anneaux, Le - Le Tiers Age (FR)"
+	rom ( name "Seigneur des Anneaux, Le - Le Tiers Age (FR) - (Disc 1 of 2).iso" size 1459978240 crc d71b4319 md5 eb63139c3c80a61a801faf6350221726 sha1 49765474dc0abd845b31a08412242e4d6bc5c6f6 )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 1)"
+	description "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 1)"
+	rom ( name "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 1).iso" size 1459978240 crc d71b4319 md5 eb63139c3c80a61a801faf6350221726 sha1 49765474dc0abd845b31a08412242e4d6bc5c6f6 )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 2)"
+	description "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 2)"
+	rom ( name "Seigneur des Anneaux, Le - Le Tiers Age (France) (Disc 2).iso" size 1459978240 crc c155e76f md5 a9f322857d3c300a0408a10957663aa0 sha1 a5f9b5a6ae2a80375f13bf9226deef58a2de336f )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Les Deux Tours (FR)"
+	description "Seigneur des Anneaux, Le - Les Deux Tours (FR)"
+	rom ( name "Seigneur des Anneaux, Le - Les Deux Tours (FR).iso" size 1459978240 crc a1d07587 md5 f58b95bf1c52a4f17653ee208a37b688 sha1 b0a0ef75442510c0d3e495d02362b2b2dcd1015f )
+)
+
+game (
+	name "Seigneur des Anneaux, Le - Les Deux Tours (France)"
+	description "Seigneur des Anneaux, Le - Les Deux Tours (France)"
+	rom ( name "Seigneur des Anneaux, Le - Les Deux Tours (France).iso" size 1459978240 crc a1d07587 md5 f58b95bf1c52a4f17653ee208a37b688 sha1 b0a0ef75442510c0d3e495d02362b2b2dcd1015f )
+)
+
+game (
+	name "Senor de los Anillos, El - El Retorno del Rey (ES)"
+	description "Senor de los Anillos, El - El Retorno del Rey (ES)"
+	rom ( name "Senor de los Anillos, El - El Retorno del Rey (ES).iso" size 1459978240 crc 0767aac0 md5 e36af70dbc8d6710b9e63651285bb158 sha1 df1b53f00400882b8a1e92199a5311e51af74eff )
+)
+
+game (
+	name "Senor de los Anillos, El - El Retorno del Rey (Spain)"
+	description "Senor de los Anillos, El - El Retorno del Rey (Spain)"
+	rom ( name "Senor de los Anillos, El - El Retorno del Rey (Spain).iso" size 1459978240 crc 0767aac0 md5 e36af70dbc8d6710b9e63651285bb158 sha1 df1b53f00400882b8a1e92199a5311e51af74eff )
+)
+
+game (
+	name "Senor de los Anillos, El - La Tercera Edad (ES)"
+	description "Senor de los Anillos, El - La Tercera Edad (ES)"
+	rom ( name "Senor de los Anillos, El - La Tercera Edad (ES) - (Disc 1 of 2).iso" size 1459978240 crc 54b81ca5 md5 7138d44e060bc3621817b044ea64ae9a sha1 af9059c82800700838342c255f12a1387c4b5255 )
+)
+
+game (
+	name "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 1)"
+	description "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 1)"
+	rom ( name "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 1).iso" size 1459978240 crc 54b81ca5 md5 7138d44e060bc3621817b044ea64ae9a sha1 af9059c82800700838342c255f12a1387c4b5255 )
+)
+
+game (
+	name "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 2)"
+	description "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 2)"
+	rom ( name "Senor de los Anillos, El - La Tercera Edad (Spain) (Disc 2).iso" size 1459978240 crc 8d4652ee md5 03f20fe0baa698d2ff463a9211e67d06 sha1 78c8c98ebcb65f3adc87da04ae0c1c5e6edb93ee )
+)
+
+game (
+	name "Senor de los Anillos, El - Las Dos Torres (ES)"
+	description "Senor de los Anillos, El - Las Dos Torres (ES)"
+	rom ( name "Senor de los Anillos, El - Las Dos Torres (ES).iso" size 1459978240 crc 66265042 md5 5b6ef30ca8d65039d5a7f8e15101e19b sha1 0ca9eea60e2ed0da701ddf80597b541f2bcc5a0e )
+)
+
+game (
+	name "Senor de los Anillos, El - Las Dos Torres (Spain)"
+	description "Senor de los Anillos, El - Las Dos Torres (Spain)"
+	rom ( name "Senor de los Anillos, El - Las Dos Torres (Spain).iso" size 1459978240 crc 66265042 md5 5b6ef30ca8d65039d5a7f8e15101e19b sha1 0ca9eea60e2ed0da701ddf80597b541f2bcc5a0e )
+)
+
+game (
+	name "Serious Sam - Next Encounter (EU)"
+	description "Serious Sam - Next Encounter (EU)"
+	rom ( name "Serious Sam - Next Encounter (EU).iso" size 1459978240 crc 37e669a7 md5 82050b101e49e36519d46774f7521672 sha1 70296be19673cc0216f45f6040541a81e507497d )
+)
+
+game (
+	name "Serious Sam - Next Encounter (Europe) (En,Fr,De)"
+	description "Serious Sam - Next Encounter (Europe) (En,Fr,De)"
+	rom ( name "Serious Sam - Next Encounter (Europe) (En,Fr,De).iso" size 1459978240 crc 37e669a7 md5 82050b101e49e36519d46774f7521672 sha1 70296be19673cc0216f45f6040541a81e507497d )
+)
+
+game (
+	name "Serious Sam - Next Encounter (US)"
+	description "Serious Sam - Next Encounter (US)"
+	rom ( name "Serious Sam - Next Encounter (US).iso" size 1459978240 crc 2caec8b9 md5 9d8573fdfa6a958f20c98038e80970aa sha1 0e79448360c80a2105bdf13e4953dfb721ce5931 )
+)
+
+game (
+	name "Serious Sam - Next Encounter (USA)"
+	description "Serious Sam - Next Encounter (USA)"
+	rom ( name "Serious Sam - Next Encounter (USA).iso" size 1459978240 crc 2caec8b9 md5 9d8573fdfa6a958f20c98038e80970aa sha1 0e79448360c80a2105bdf13e4953dfb721ce5931 )
+)
+
+game (
+	name "Shadow The Hedgehog (EU)"
+	description "Shadow The Hedgehog (EU)"
+	rom ( name "Shadow The Hedgehog (EU).iso" size 1459978240 crc db7d8cd9 md5 c93225c1a4f1fa4aad5d1dd330293c1a sha1 05b34c82c0fe8aa504539e4dfbba89957c7fc788 )
+)
+
+game (
+	name "Shadow The Hedgehog (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Shadow The Hedgehog (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Shadow The Hedgehog (Europe) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc db7d8cd9 md5 c93225c1a4f1fa4aad5d1dd330293c1a sha1 05b34c82c0fe8aa504539e4dfbba89957c7fc788 )
+)
+
+game (
+	name "Shadow The Hedgehog (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Shadow The Hedgehog (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Shadow The Hedgehog (Japan) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc 529baa3a md5 dfb476c117536bbb1a1e1c103fb65216 sha1 1d4d1a069d87bdcc6985ffd16d1d19328bb3ae69 )
+)
+
+game (
+	name "Shadow The Hedgehog (JP) - siyadouzahetuzihotugu"
+	description "Shadow The Hedgehog (JP) - siyadouzahetuzihotugu"
+	rom ( name "Shadow The Hedgehog (JP).iso" size 1459978240 crc 529baa3a md5 dfb476c117536bbb1a1e1c103fb65216 sha1 1d4d1a069d87bdcc6985ffd16d1d19328bb3ae69 )
+)
+
+game (
+	name "Shadow The Hedgehog (US)"
+	description "Shadow The Hedgehog (US)"
+	rom ( name "Shadow The Hedgehog (US).iso" size 1459978240 crc f582cf1e md5 fc936c9b0144c925b45b805fd39da2ac sha1 5dc81ad9c97549394e30bedc252bfa37d4db1de0 )
+)
+
+game (
+	name "Shadow The Hedgehog (USA) (En,Ja,Fr,De,Es,It)"
+	description "Shadow The Hedgehog (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Shadow The Hedgehog (USA) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc f582cf1e md5 fc936c9b0144c925b45b805fd39da2ac sha1 5dc81ad9c97549394e30bedc252bfa37d4db1de0 )
+)
+
+game (
+	name "Shaman King - Soul Fight (Japan)"
+	description "Shaman King - Soul Fight (Japan)"
+	rom ( name "Shaman King - Soul Fight (Japan).iso" size 1459978240 crc 7863705e md5 4087c0ad7788da4c972f505fb1e44948 sha1 0675777d24bd1167fe77bbf60ff6d60a1cc7cfa1 )
+)
+
+game (
+	name "Shaman King - Soul Fight (JP) - siyamankingu+souruhuaito"
+	description "Shaman King - Soul Fight (JP) - siyamankingu+souruhuaito"
+	rom ( name "Shaman King - Soul Fight (JP).iso" size 1459978240 crc 7863705e md5 4087c0ad7788da4c972f505fb1e44948 sha1 0675777d24bd1167fe77bbf60ff6d60a1cc7cfa1 )
+)
+
+game (
+	name "Shikigami no Shiro II (Japan)"
+	description "Shikigami no Shiro II (Japan)"
+	rom ( name "Shikigami no Shiro II (Japan).iso" size 1459978240 crc 03641eb3 md5 334d7fcc51e15d4a4563a1e5f1ca4670 sha1 055d1864ff3c50c01cb30494f9e8d20945024c1d )
+)
+
+game (
+	name "Shikigami no Shiro II (JP) - Shi Shen noCheng II"
+	description "Shikigami no Shiro II (JP) - Shi Shen noCheng II"
+	rom ( name "Shikigami no Shiro II (JP).iso" size 1459978240 crc 03641eb3 md5 334d7fcc51e15d4a4563a1e5f1ca4670 sha1 055d1864ff3c50c01cb30494f9e8d20945024c1d )
+)
+
+game (
+	name "Shinki Sekai Evolutia (Japan)"
+	description "Shinki Sekai Evolutia (Japan)"
+	rom ( name "Shinki Sekai Evolutia (Japan).iso" size 1459978240 crc 8f6f5f3e md5 b5a94f957590db8406901f24db445ddd sha1 bf07041859e9be4431eb528684230d5e125f02ae )
+)
+
+game (
+	name "Shinki Sekai Evolutia (JP) - Shen Ji Shi Jie evuorusia"
+	description "Shinki Sekai Evolutia (JP) - Shen Ji Shi Jie evuorusia"
+	rom ( name "Shinki Sekai Evolutia (JP).iso" size 1459978240 crc 8f6f5f3e md5 b5a94f957590db8406901f24db445ddd sha1 bf07041859e9be4431eb528684230d5e125f02ae )
+)
+
+game (
+	name "Shinseiki GPX Cyber Formula - Road to the Evolution (Japan)"
+	description "Shinseiki GPX Cyber Formula - Road to the Evolution (Japan)"
+	rom ( name "Shinseiki GPX Cyber Formula - Road to the Evolution (Japan).iso" size 1459978240 crc 6faebf04 md5 885cad943f5f91ad888ff78be8614f19 sha1 fd46226b01a5243ce1b5729a3843b8ea75947d76 )
+)
+
+game (
+	name "Shinseiki GPX Cyber Formula - Road to the Evolution (JP) - Xin Shi Ji GPXsaibahuomiyura+rodo+tou+za+eboriyusiyon"
+	description "Shinseiki GPX Cyber Formula - Road to the Evolution (JP) - Xin Shi Ji GPXsaibahuomiyura+rodo+tou+za+eboriyusiyon"
+	rom ( name "Shinseiki GPX Cyber Formula - Road to the Evolution (JP).iso" size 1459978240 crc 6faebf04 md5 885cad943f5f91ad888ff78be8614f19 sha1 fd46226b01a5243ce1b5729a3843b8ea75947d76 )
+)
+
+game (
+	name "Shonen Jump's One Piece - Grand Adventure (US)"
+	description "Shonen Jump's One Piece - Grand Adventure (US)"
+	rom ( name "Shonen Jump's One Piece - Grand Adventure (US).iso" size 1459978240 crc af0fbd81 md5 5903bdd79d8bf683fa49e9c10f532f9c sha1 4113a4cfe208d4b3e27fd679ee7a2a482c8d3569 )
+)
+
+game (
+	name "Shonen Jump's One Piece - Grand Adventure (USA)"
+	description "Shonen Jump's One Piece - Grand Adventure (USA)"
+	rom ( name "Shonen Jump's One Piece - Grand Adventure (USA).iso" size 1459978240 crc af0fbd81 md5 5903bdd79d8bf683fa49e9c10f532f9c sha1 4113a4cfe208d4b3e27fd679ee7a2a482c8d3569 )
+)
+
+game (
+	name "Shonen Jump's One Piece - Grand Battle (US)"
+	description "Shonen Jump's One Piece - Grand Battle (US)"
+	rom ( name "Shonen Jump's One Piece - Grand Battle (US).iso" size 1459978240 crc 08b36fe0 md5 bb5a789fd7fb81f17da2ff2f88eed23c sha1 c61a729fd2efa1dc74ab1e460f3cf2e6b9ac2776 )
+)
+
+game (
+	name "Shonen Jump's One Piece - Grand Battle (USA)"
+	description "Shonen Jump's One Piece - Grand Battle (USA)"
+	rom ( name "Shonen Jump's One Piece - Grand Battle (USA).iso" size 1459978240 crc 08b36fe0 md5 bb5a789fd7fb81f17da2ff2f88eed23c sha1 c61a729fd2efa1dc74ab1e460f3cf2e6b9ac2776 )
+)
+
+game (
+	name "Shonen Jump's One Piece - Pirates' Carnival (US)"
+	description "Shonen Jump's One Piece - Pirates' Carnival (US)"
+	rom ( name "Shonen Jump's One Piece - Pirates' Carnival (US).iso" size 1459978240 crc 83911f16 md5 844efce2d2a3f7d73793cda69b589eb9 sha1 5521c5a3306d8fca7959dedba450e95b4bd1ae7a )
+)
+
+game (
+	name "Shonen Jump's One Piece - Pirates' Carnival (USA)"
+	description "Shonen Jump's One Piece - Pirates' Carnival (USA)"
+	rom ( name "Shonen Jump's One Piece - Pirates' Carnival (USA).iso" size 1459978240 crc 83911f16 md5 844efce2d2a3f7d73793cda69b589eb9 sha1 5521c5a3306d8fca7959dedba450e95b4bd1ae7a )
+)
+
+game (
+	name "Shrek 2 (DE)"
+	description "Shrek 2 (DE)"
+	rom ( name "Shrek 2 (DE).iso" size 1459978240 crc 38c20d67 md5 f7cea1dcdaf9688266d2b4e49d5cb8bb sha1 b59a61d49210f9f16d979d109b7bc2d82cc6c8e0 )
+)
+
+game (
+	name "Shrek 2 (Europe) (v1.00)"
+	description "Shrek 2 (Europe) (v1.00)"
+	rom ( name "Shrek 2 (Europe) (v1.00).iso" size 1459978240 crc 132cefdd md5 417672fcc3871de39c16a2e75f85f159 sha1 357c898cad24f1c57a304987635eede34996f127 )
+)
+
+game (
+	name "Shrek 2 (Europe) (v1.01)"
+	description "Shrek 2 (Europe) (v1.01)"
+	rom ( name "Shrek 2 (Europe) (v1.01).iso" size 1459978240 crc 6e42d3ae md5 5f4a717d514e3ed5b5d111631ef1c13d sha1 98b6e48b4f2d7e831137120e4372c74aa50b461e )
+)
+
+game (
+	name "Shrek 2 (FR)"
+	description "Shrek 2 (FR)"
+	rom ( name "Shrek 2 (FR).iso" size 1459978240 crc b7ed13f2 md5 8191fee2d38ba9581f662a707af0b5e5 sha1 b4b1ba1af162b9f8855c64946080856fe04ae777 )
+)
+
+game (
+	name "Shrek 2 (France)"
+	description "Shrek 2 (France)"
+	rom ( name "Shrek 2 (France).iso" size 1459978240 crc b7ed13f2 md5 8191fee2d38ba9581f662a707af0b5e5 sha1 b4b1ba1af162b9f8855c64946080856fe04ae777 )
+)
+
+game (
+	name "Shrek 2 (GB)"
+	description "Shrek 2 (GB)"
+	rom ( name "Shrek 2 (GB).iso" size 1459978240 crc 132cefdd md5 417672fcc3871de39c16a2e75f85f159 sha1 357c898cad24f1c57a304987635eede34996f127 )
+)
+
+game (
+	name "Shrek 2 (Germany)"
+	description "Shrek 2 (Germany)"
+	rom ( name "Shrek 2 (Germany).iso" size 1459978240 crc 38c20d67 md5 f7cea1dcdaf9688266d2b4e49d5cb8bb sha1 b59a61d49210f9f16d979d109b7bc2d82cc6c8e0 )
+)
+
+game (
+	name "Shrek 2 (SE)"
+	description "Shrek 2 (SE)"
+	rom ( name "Shrek 2 (SE).iso" size 1459978240 crc 7ba40525 md5 9556822e393b7eac3da5b292b952c209 sha1 9cd2a49af06aecd4c90097949fed9f346ba3ab46 )
+)
+
+game (
+	name "Shrek 2 (Sweden)"
+	description "Shrek 2 (Sweden)"
+	rom ( name "Shrek 2 (Sweden).iso" size 1459978240 crc 7ba40525 md5 9556822e393b7eac3da5b292b952c209 sha1 9cd2a49af06aecd4c90097949fed9f346ba3ab46 )
+)
+
+game (
+	name "Shrek 2 (US)"
+	description "Shrek 2 (US)"
+	rom ( name "Shrek 2 (US).iso" size 1459978240 crc d1b56156 md5 27b4fa5dbe919fbcdf60a5e77cf08309 sha1 4c653bc925cc57cfb9e62f5e42dd92622bccee7a )
+)
+
+game (
+	name "Shrek 2 (USA)"
+	description "Shrek 2 (USA)"
+	rom ( name "Shrek 2 (USA).iso" size 1459978240 crc d1b56156 md5 27b4fa5dbe919fbcdf60a5e77cf08309 sha1 4c653bc925cc57cfb9e62f5e42dd92622bccee7a )
+)
+
+game (
+	name "Shrek Extra Large (EU)"
+	description "Shrek Extra Large (EU)"
+	rom ( name "Shrek Extra Large (EU).iso" size 1459978240 crc 001d987b md5 75a08b381f0a6bf815adeb69883c3c54 sha1 8558b5307f4feb812d0592edd45cede0b3e5380e )
+)
+
+game (
+	name "Shrek Extra Large (Europe) (En,Fr,De,Es,It)"
+	description "Shrek Extra Large (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Shrek Extra Large (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 001d987b md5 75a08b381f0a6bf815adeb69883c3c54 sha1 8558b5307f4feb812d0592edd45cede0b3e5380e )
+)
+
+game (
+	name "Shrek Extra Large (US)"
+	description "Shrek Extra Large (US)"
+	rom ( name "Shrek Extra Large (US).iso" size 1459978240 crc f2b6e2c1 md5 10b1b5ea73da563f92dd7104182f4c5d sha1 2f963e775c29100fcd6eb9533d3bad1ed7d1fd3d )
+)
+
+game (
+	name "Shrek Extra Large (USA)"
+	description "Shrek Extra Large (USA)"
+	rom ( name "Shrek Extra Large (USA).iso" size 1459978240 crc f2b6e2c1 md5 10b1b5ea73da563f92dd7104182f4c5d sha1 2f963e775c29100fcd6eb9533d3bad1ed7d1fd3d )
+)
+
+game (
+	name "Shrek Super Party (EU)"
+	description "Shrek Super Party (EU)"
+	rom ( name "Shrek Super Party (EU).iso" size 1459978240 crc 7675f608 md5 1ec9e9ca710e745e98726f6e65031323 sha1 f99af00ca3e7f1aac94603bd779394681166d9c8 )
+)
+
+game (
+	name "Shrek Super Party (Europe) (En,Fr,De,Es,It)"
+	description "Shrek Super Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Shrek Super Party (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7675f608 md5 1ec9e9ca710e745e98726f6e65031323 sha1 f99af00ca3e7f1aac94603bd779394681166d9c8 )
+)
+
+game (
+	name "Shrek Super Party (US)"
+	description "Shrek Super Party (US)"
+	rom ( name "Shrek Super Party (US).iso" size 1459978240 crc 2c34401a md5 c2e91e244cd30bd717a4d203dece1976 sha1 e45b67f1039202f108800d48f0cf1c64c566502f )
+)
+
+game (
+	name "Shrek Super Party (USA)"
+	description "Shrek Super Party (USA)"
+	rom ( name "Shrek Super Party (USA).iso" size 1459978240 crc 2c34401a md5 c2e91e244cd30bd717a4d203dece1976 sha1 e45b67f1039202f108800d48f0cf1c64c566502f )
+)
+
+game (
+	name "Signore degli Anelli, Il - Il ritorno del Re (IT)"
+	description "Signore degli Anelli, Il - Il ritorno del Re (IT)"
+	rom ( name "Signore degli Anelli, Il - Il ritorno del Re (IT).iso" size 1459978240 crc daebbd65 md5 24659b841122e95a9ba28dd06862fb79 sha1 3b63a8c44fdf1ae1e8ac45674fccc9a290b833d6 )
+)
+
+game (
+	name "Signore degli Anelli, Il - Il ritorno del Re (Italy)"
+	description "Signore degli Anelli, Il - Il ritorno del Re (Italy)"
+	rom ( name "Signore degli Anelli, Il - Il ritorno del Re (Italy).iso" size 1459978240 crc daebbd65 md5 24659b841122e95a9ba28dd06862fb79 sha1 3b63a8c44fdf1ae1e8ac45674fccc9a290b833d6 )
+)
+
+game (
+	name "Signore degli Anelli, Il - Le Due Torri (IT)"
+	description "Signore degli Anelli, Il - Le Due Torri (IT)"
+	rom ( name "Signore degli Anelli, Il - Le Due Torri (IT).iso" size 1459978240 crc 61cb1cce md5 f98d2c0f6fe053e8bfcdb5ee9e2c5731 sha1 6f0f49f26cbe20936cf2bb40a702d29652380717 )
+)
+
+game (
+	name "Signore degli Anelli, Il - Le Due Torri (Italy)"
+	description "Signore degli Anelli, Il - Le Due Torri (Italy)"
+	rom ( name "Signore degli Anelli, Il - Le Due Torri (Italy).iso" size 1459978240 crc 61cb1cce md5 f98d2c0f6fe053e8bfcdb5ee9e2c5731 sha1 6f0f49f26cbe20936cf2bb40a702d29652380717 )
+)
+
+game (
+	name "Simpsons, The - Hit & Run (Europe) (En,Fr,De)"
+	description "Simpsons, The - Hit & Run (Europe) (En,Fr,De)"
+	rom ( name "Simpsons, The - Hit & Run (Europe) (En,Fr,De).iso" size 1459978240 crc fcff3d0a md5 f9a01088d2bac7e48af3b69f63f62174 sha1 0194c084858eb6b490feb034bcea9c0485808b35 )
+)
+
+game (
+	name "Simpsons, The - Hit & Run (Player's Choice) (EU)"
+	description "Simpsons, The - Hit & Run (Player's Choice) (EU)"
+	rom ( name "Simpsons, The - Hit & Run (Player's Choice) (EU).iso" size 1459978240 crc fcff3d0a md5 f9a01088d2bac7e48af3b69f63f62174 sha1 0194c084858eb6b490feb034bcea9c0485808b35 )
+)
+
+game (
+	name "Simpsons, The - Hit & Run (US)"
+	description "Simpsons, The - Hit & Run (US)"
+	rom ( name "Simpsons, The - Hit & Run (US).iso" size 1459978240 crc da7ce8df md5 1e40a2405da61fa5ea7f2487a99439ea sha1 71648c53f19135ef006cb583628d52027df6fba8 )
+)
+
+game (
+	name "Simpsons, The - Hit & Run (USA)"
+	description "Simpsons, The - Hit & Run (USA)"
+	rom ( name "Simpsons, The - Hit & Run (USA).iso" size 1459978240 crc da7ce8df md5 1e40a2405da61fa5ea7f2487a99439ea sha1 71648c53f19135ef006cb583628d52027df6fba8 )
+)
+
+game (
+	name "Simpsons, The - Road Rage (EU)"
+	description "Simpsons, The - Road Rage (EU)"
+	rom ( name "Simpsons, The - Road Rage (EU).iso" size 1459978240 crc 4c36e9e4 md5 8a34b24c0b7f659f361887c7cae65dc9 sha1 165c0705d7a24c4db7eb09ebe05c2148708363c9 )
+)
+
+game (
+	name "Simpsons, The - Road Rage (Europe) (En,Fr,De)"
+	description "Simpsons, The - Road Rage (Europe) (En,Fr,De)"
+	rom ( name "Simpsons, The - Road Rage (Europe) (En,Fr,De).iso" size 1459978240 crc 4c36e9e4 md5 8a34b24c0b7f659f361887c7cae65dc9 sha1 165c0705d7a24c4db7eb09ebe05c2148708363c9 )
+)
+
+game (
+	name "Simpsons, The - Road Rage (US)"
+	description "Simpsons, The - Road Rage (US)"
+	rom ( name "Simpsons, The - Road Rage (US).iso" size 1459978240 crc 18dd3b5a md5 6afdecc1d7414ae277ae981167150265 sha1 0902bf469aea0f0be9530b3ab8c5b8f972893aa5 )
+)
+
+game (
+	name "Simpsons, The - Road Rage (USA)"
+	description "Simpsons, The - Road Rage (USA)"
+	rom ( name "Simpsons, The - Road Rage (USA).iso" size 1459978240 crc 18dd3b5a md5 6afdecc1d7414ae277ae981167150265 sha1 0902bf469aea0f0be9530b3ab8c5b8f972893aa5 )
+)
+
+game (
+	name "Sims 2, The - Pets (EU)"
+	description "Sims 2, The - Pets (EU)"
+	rom ( name "Sims 2, The - Pets (EU).iso" size 1459978240 crc 0032356d md5 85cd1905195458ac93f07fa9fe836302 sha1 42047506fc923051d67c29107331b754244361ee )
+)
+
+game (
+	name "Sims 2, The - Pets (Europe) (En,Fr,De)"
+	description "Sims 2, The - Pets (Europe) (En,Fr,De)"
+	rom ( name "Sims 2, The - Pets (Europe) (En,Fr,De).iso" size 1459978240 crc 0032356d md5 85cd1905195458ac93f07fa9fe836302 sha1 42047506fc923051d67c29107331b754244361ee )
+)
+
+game (
+	name "Sims 2, The - Pets (US)"
+	description "Sims 2, The - Pets (US)"
+	rom ( name "Sims 2, The - Pets (US).iso" size 1459978240 crc be2b127c md5 f3f5b13600ae780e042a8dc7b4106751 sha1 38750d2b70e58165587a9f75fe8d82a1c4cd9381 )
+)
+
+game (
+	name "Sims 2, The - Pets (USA)"
+	description "Sims 2, The - Pets (USA)"
+	rom ( name "Sims 2, The - Pets (USA).iso" size 1459978240 crc be2b127c md5 f3f5b13600ae780e042a8dc7b4106751 sha1 38750d2b70e58165587a9f75fe8d82a1c4cd9381 )
+)
+
+game (
+	name "Sims 2, The (EU)"
+	description "Sims 2, The (EU)"
+	rom ( name "Sims 2, The (EU).iso" size 1459978240 crc e9bb9d5e md5 ab75f91fcd50f76fcaf184d89beb7270 sha1 644577943df675b0f91c56e3aa9c3edbf4bc096e )
+)
+
+game (
+	name "Sims 2, The (Europe) (En,Fr,De,Nl)"
+	description "Sims 2, The (Europe) (En,Fr,De,Nl)"
+	rom ( name "Sims 2, The (Europe) (En,Fr,De,Nl).iso" size 1459978240 crc e9bb9d5e md5 ab75f91fcd50f76fcaf184d89beb7270 sha1 644577943df675b0f91c56e3aa9c3edbf4bc096e )
+)
+
+game (
+	name "Sims 2, The (US)"
+	description "Sims 2, The (US)"
+	rom ( name "Sims 2, The (US).iso" size 1459978240 crc 44dd3b94 md5 dc5038fa00bcf4a7c507cd6a92fb3429 sha1 e1c0bd24e6365db8e7c9e9920380973a5713530f )
+)
+
+game (
+	name "Sims 2, The (USA)"
+	description "Sims 2, The (USA)"
+	rom ( name "Sims 2, The (USA).iso" size 1459978240 crc 44dd3b94 md5 dc5038fa00bcf4a7c507cd6a92fb3429 sha1 e1c0bd24e6365db8e7c9e9920380973a5713530f )
+)
+
+game (
+	name "Sims, The - Bustin' Out (EU)"
+	description "Sims, The - Bustin' Out (EU)"
+	rom ( name "Sims, The - Bustin' Out (EU).iso" size 1459978240 crc f6eedf9a md5 5a1bac829b877003eaf0752dc4dd1acc sha1 0cf28bff09e4912f0440681db4109b7e058e9a06 )
+)
+
+game (
+	name "Sims, The - Bustin' Out (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Sims, The - Bustin' Out (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Sims, The - Bustin' Out (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc f6eedf9a md5 5a1bac829b877003eaf0752dc4dd1acc sha1 0cf28bff09e4912f0440681db4109b7e058e9a06 )
+)
+
+game (
+	name "Sims, The - Bustin' Out (US)"
+	description "Sims, The - Bustin' Out (US)"
+	rom ( name "Sims, The - Bustin' Out (US).iso" size 1459978240 crc 6939bbc4 md5 ed9dd7a0bdbb2057a0b3c1b771129769 sha1 59d2a3308ee4c3ef853ffc472e556baf20156f4e )
+)
+
+game (
+	name "Sims, The - Bustin' Out (USA)"
+	description "Sims, The - Bustin' Out (USA)"
+	rom ( name "Sims, The - Bustin' Out (USA).iso" size 1459978240 crc 6939bbc4 md5 ed9dd7a0bdbb2057a0b3c1b771129769 sha1 59d2a3308ee4c3ef853ffc472e556baf20156f4e )
+)
+
+game (
+	name "Sims, The (EU)"
+	description "Sims, The (EU)"
+	rom ( name "Sims, The (EU).iso" size 1459978240 crc f9afdba2 md5 64d50e63a62241779b379fda4136acaa sha1 d53d3b9c4fcf1b6bf63ff0bbb0a10c6c48e215bd )
+)
+
+game (
+	name "Sims, The (Europe) (En,Fr,De,Es,It)"
+	description "Sims, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sims, The (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f9afdba2 md5 64d50e63a62241779b379fda4136acaa sha1 d53d3b9c4fcf1b6bf63ff0bbb0a10c6c48e215bd )
+)
+
+game (
+	name "Sims, The (Japan)"
+	description "Sims, The (Japan)"
+	rom ( name "Sims, The (Japan).iso" size 1459978240 crc 81d29446 md5 9492c7d3ee2b07187fbdd532671b0668 sha1 92a6b10e67e63b500409e3f1ddf262559f92eb74 )
+)
+
+game (
+	name "Sims, The (JP) - zasimuzu"
+	description "Sims, The (JP) - zasimuzu"
+	rom ( name "Sims, The (JP).iso" size 1459978240 crc 81d29446 md5 9492c7d3ee2b07187fbdd532671b0668 sha1 92a6b10e67e63b500409e3f1ddf262559f92eb74 )
+)
+
+game (
+	name "Sims, The (Player's Choice) (US)"
+	description "Sims, The (Player's Choice) (US)"
+	rom ( name "Sims, The (Player's Choice) (US).iso" size 1459978240 crc 019589c8 md5 554d552c82fb423caeb0e98e7d8c7650 sha1 378a3589e3f4e35ac844c9cfe6a25f9e764c9299 )
+)
+
+game (
+	name "Sims, The (USA)"
+	description "Sims, The (USA)"
+	rom ( name "Sims, The (USA).iso" size 1459978240 crc 019589c8 md5 554d552c82fb423caeb0e98e7d8c7650 sha1 378a3589e3f4e35ac844c9cfe6a25f9e764c9299 )
+)
+
+game (
+	name "Skies of Arcadia Legends (EU)"
+	description "Skies of Arcadia Legends (EU)"
+	rom ( name "Skies of Arcadia Legends (EU).iso" size 1459978240 crc a8e18c76 md5 bd814992f1e39d4147c775ff8b32d022 sha1 30ee1d7777fe51bcd7c4deeb867651d5b6e96e41 )
+)
+
+game (
+	name "Skies of Arcadia Legends (Europe) (En,Fr,De,Es)"
+	description "Skies of Arcadia Legends (Europe) (En,Fr,De,Es)"
+	rom ( name "Skies of Arcadia Legends (Europe) (En,Fr,De,Es).iso" size 1459978240 crc a8e18c76 md5 bd814992f1e39d4147c775ff8b32d022 sha1 30ee1d7777fe51bcd7c4deeb867651d5b6e96e41 )
+)
+
+game (
+	name "Skies of Arcadia Legends (US)"
+	description "Skies of Arcadia Legends (US)"
+	rom ( name "Skies of Arcadia Legends (US).iso" size 1459978240 crc 23e347b6 md5 3e7fa5033c4a2704434fb6ba98195ecd sha1 46105320553c858f25fafc5fd357566b505a4940 )
+)
+
+game (
+	name "Skies of Arcadia Legends (USA)"
+	description "Skies of Arcadia Legends (USA)"
+	rom ( name "Skies of Arcadia Legends (USA).iso" size 1459978240 crc 23e347b6 md5 3e7fa5033c4a2704434fb6ba98195ecd sha1 46105320553c858f25fafc5fd357566b505a4940 )
+)
+
+game (
+	name "SmaBro DX Event-you Disc (Japan)"
+	description "SmaBro DX Event-you Disc (Japan)"
+	rom ( name "SmaBro DX Event-you Disc (Japan).iso" size 1459978240 crc 0dd683ce md5 a2b8c2d7c38f1034134a31b4d7b9c8d3 sha1 f86edb90800f06a9c2cd6d9d7eb6de765085a810 )
+)
+
+game (
+	name "SmaBro DX Event-you Disc (Promo) (JP) - sumaburaDX+ibentoYong deisuku"
+	description "SmaBro DX Event-you Disc (Promo) (JP) - sumaburaDX+ibentoYong deisuku"
+	rom ( name "SmaBro DX Event-you Disc (Promo) (JP).iso" size 1459978240 crc 0dd683ce md5 a2b8c2d7c38f1034134a31b4d7b9c8d3 sha1 f86edb90800f06a9c2cd6d9d7eb6de765085a810 )
+)
+
+game (
+	name "Smashing Drive (US)"
+	description "Smashing Drive (US)"
+	rom ( name "Smashing Drive (US).iso" size 1459978240 crc a25abf5f md5 b27ae90ff97ad3af42d57dba6408d5dd sha1 7b8e5c6e668ce8a1b7fa2250d21b0bd539cceee0 )
+)
+
+game (
+	name "Smashing Drive (USA)"
+	description "Smashing Drive (USA)"
+	rom ( name "Smashing Drive (USA).iso" size 1459978240 crc a25abf5f md5 b27ae90ff97ad3af42d57dba6408d5dd sha1 7b8e5c6e668ce8a1b7fa2250d21b0bd539cceee0 )
+)
+
+game (
+	name "Smuggler's Run - Warzones (EU)"
+	description "Smuggler's Run - Warzones (EU)"
+	rom ( name "Smuggler's Run - Warzones (EU).iso" size 1459978240 crc 8e13c356 md5 0384b0a39e4c2775276979705e0ccb7d sha1 71b84cb5e7e0992b6db45294100296d653b61e1d )
+)
+
+game (
+	name "Smuggler's Run - Warzones (Europe) (En,Fr,De,It)"
+	description "Smuggler's Run - Warzones (Europe) (En,Fr,De,It)"
+	rom ( name "Smuggler's Run - Warzones (Europe) (En,Fr,De,It).iso" size 1459978240 crc 8e13c356 md5 0384b0a39e4c2775276979705e0ccb7d sha1 71b84cb5e7e0992b6db45294100296d653b61e1d )
+)
+
+game (
+	name "Smuggler's Run - Warzones (US)"
+	description "Smuggler's Run - Warzones (US)"
+	rom ( name "Smuggler's Run - Warzones (US).iso" size 1459978240 crc f2e1766b md5 ff14e6bc242bb413ecb24773fa8018fa sha1 5ab8a0871af19670283c5e0145b80c8f3b8aa3de )
+)
+
+game (
+	name "Smuggler's Run - Warzones (USA)"
+	description "Smuggler's Run - Warzones (USA)"
+	rom ( name "Smuggler's Run - Warzones (USA).iso" size 1459978240 crc f2e1766b md5 ff14e6bc242bb413ecb24773fa8018fa sha1 5ab8a0871af19670283c5e0145b80c8f3b8aa3de )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (EU)"
+	description "Sonic Adventure 2 - Battle (EU)"
+	rom ( name "Sonic Adventure 2 - Battle (EU).iso" size 1459978240 crc c576b909 md5 46c84273d5cd803715988a33ca3e5664 sha1 118d5c2b654fba80de2efd37ebabff351c836e7a )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (Europe) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure 2 - Battle (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure 2 - Battle (Europe) (En,Ja,Fr,De,Es).iso" size 1459978240 crc c576b909 md5 46c84273d5cd803715988a33ca3e5664 sha1 118d5c2b654fba80de2efd37ebabff351c836e7a )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (Japan) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure 2 - Battle (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure 2 - Battle (Japan) (En,Ja,Fr,De,Es).iso" size 1459978240 crc 6fae7e27 md5 caab090aca184c21784330665896eeed sha1 c56a04c85bde5ade065dbe3459c7883b158df3f2 )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (JP) - sonitukuadobentiya2+batoru"
+	description "Sonic Adventure 2 - Battle (JP) - sonitukuadobentiya2+batoru"
+	rom ( name "Sonic Adventure 2 - Battle (JP).iso" size 1459978240 crc 6fae7e27 md5 caab090aca184c21784330665896eeed sha1 c56a04c85bde5ade065dbe3459c7883b158df3f2 )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (US)"
+	description "Sonic Adventure 2 - Battle (US)"
+	rom ( name "Sonic Adventure 2 - Battle (US).iso" size 1459978240 crc 024f4f8f md5 9ef5fadf4b8756af820df997468a5a16 sha1 f8cc51128df2a3b0da9d6f3a234c895a4cd7dc22 )
+)
+
+game (
+	name "Sonic Adventure 2 - Battle (USA) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure 2 - Battle (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure 2 - Battle (USA) (En,Ja,Fr,De,Es).iso" size 1459978240 crc 024f4f8f md5 9ef5fadf4b8756af820df997468a5a16 sha1 f8cc51128df2a3b0da9d6f3a234c895a4cd7dc22 )
+)
+
+game (
+	name "Sonic Adventure DX - Director's Cut (EU)"
+	description "Sonic Adventure DX - Director's Cut (EU)"
+	rom ( name "Sonic Adventure DX - Director's Cut (EU).iso" size 1459978240 crc 9ba7f3af md5 2136ed4b6a27dc64066c8a689918dce0 sha1 99ce5f51388919a95d571a730c50362ba14277c3 )
+)
+
+game (
+	name "Sonic Adventure DX - Director's Cut (Europe) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure DX - Director's Cut (Europe) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure DX - Director's Cut (Europe) (En,Ja,Fr,De,Es).iso" size 1459978240 crc 9ba7f3af md5 2136ed4b6a27dc64066c8a689918dce0 sha1 99ce5f51388919a95d571a730c50362ba14277c3 )
+)
+
+game (
+	name "Sonic Adventure DX - Director's Cut (US)"
+	description "Sonic Adventure DX - Director's Cut (US)"
+	rom ( name "Sonic Adventure DX - Director's Cut (US).iso" size 1459978240 crc f4e4e141 md5 b5d979135826338fa0d90d40f907c9b2 sha1 70c7ae65cd83c65675e279cd15cbf69cdda29565 )
+)
+
+game (
+	name "Sonic Adventure DX - Director's Cut (USA) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure DX - Director's Cut (USA) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure DX - Director's Cut (USA) (En,Ja,Fr,De,Es).iso" size 1459978240 crc f4e4e141 md5 b5d979135826338fa0d90d40f907c9b2 sha1 70c7ae65cd83c65675e279cd15cbf69cdda29565 )
+)
+
+game (
+	name "Sonic Adventure DX (Japan) (En,Ja,Fr,De,Es)"
+	description "Sonic Adventure DX (Japan) (En,Ja,Fr,De,Es)"
+	rom ( name "Sonic Adventure DX (Japan) (En,Ja,Fr,De,Es).iso" size 1459978240 crc df558413 md5 33a86929c71dcb0cab980121379eb5de sha1 7c969b25acfec194382ff24f8ebcc7e7671368d9 )
+)
+
+game (
+	name "Sonic Adventure DX (JP) - sonituku+adobentiya+DX+deratukusu"
+	description "Sonic Adventure DX (JP) - sonituku+adobentiya+DX+deratukusu"
+	rom ( name "Sonic Adventure DX (JP).iso" size 1459978240 crc df558413 md5 33a86929c71dcb0cab980121379eb5de sha1 7c969b25acfec194382ff24f8ebcc7e7671368d9 )
+)
+
+game (
+	name "Sonic Gems Collection (EU)"
+	description "Sonic Gems Collection (EU)"
+	rom ( name "Sonic Gems Collection (EU).iso" size 1459978240 crc 89d239b3 md5 4f1c8baf18a46811e54c39157c1e5621 sha1 d38eba95df0908a9637738e3b76fc626a46f14f8 )
+)
+
+game (
+	name "Sonic Gems Collection (Europe) (En,Fr,De,Es,It)"
+	description "Sonic Gems Collection (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sonic Gems Collection (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 89d239b3 md5 4f1c8baf18a46811e54c39157c1e5621 sha1 d38eba95df0908a9637738e3b76fc626a46f14f8 )
+)
+
+game (
+	name "Sonic Gems Collection (Japan)"
+	description "Sonic Gems Collection (Japan)"
+	rom ( name "Sonic Gems Collection (Japan).iso" size 1459978240 crc 8266d5c5 md5 236c641cfe9bc0b489345102c558c135 sha1 d7024535cb8de9936ac690c2a4ad6286adaec28c )
+)
+
+game (
+	name "Sonic Gems Collection (JP) - sonituku+ziemuzu+korekusiyon"
+	description "Sonic Gems Collection (JP) - sonituku+ziemuzu+korekusiyon"
+	rom ( name "Sonic Gems Collection (JP).iso" size 1459978240 crc 8266d5c5 md5 236c641cfe9bc0b489345102c558c135 sha1 d7024535cb8de9936ac690c2a4ad6286adaec28c )
+)
+
+game (
+	name "Sonic Gems Collection (US)"
+	description "Sonic Gems Collection (US)"
+	rom ( name "Sonic Gems Collection (US).iso" size 1459978240 crc fff7ec04 md5 f72b3b462e3c26a2d3a9fbbadaf79c6e sha1 b140277e283346e1e9b212ef5395f7e23195e724 )
+)
+
+game (
+	name "Sonic Gems Collection (USA)"
+	description "Sonic Gems Collection (USA)"
+	rom ( name "Sonic Gems Collection (USA).iso" size 1459978240 crc fff7ec04 md5 f72b3b462e3c26a2d3a9fbbadaf79c6e sha1 b140277e283346e1e9b212ef5395f7e23195e724 )
+)
+
+game (
+	name "Sonic Heroes (EU)"
+	description "Sonic Heroes (EU)"
+	rom ( name "Sonic Heroes (EU).iso" size 1459978240 crc c27a3cac md5 45bf89bc3455c84c6eb54fbb41ad5287 sha1 8dcbe1de97db28b6392454c140093ccac34f875c )
+)
+
+game (
+	name "Sonic Heroes (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Heroes (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Heroes (Europe) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc c27a3cac md5 45bf89bc3455c84c6eb54fbb41ad5287 sha1 8dcbe1de97db28b6392454c140093ccac34f875c )
+)
+
+game (
+	name "Sonic Heroes (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Heroes (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Heroes (Japan) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc b4923d04 md5 f52de0b95c82de9d1974cedd1f185488 sha1 6f867789bb2fbd084deca6b78c5bcc7b6a690c61 )
+)
+
+game (
+	name "Sonic Heroes (JP) - sonituku+hirozu"
+	description "Sonic Heroes (JP) - sonituku+hirozu"
+	rom ( name "Sonic Heroes (JP).iso" size 1459978240 crc b4923d04 md5 f52de0b95c82de9d1974cedd1f185488 sha1 6f867789bb2fbd084deca6b78c5bcc7b6a690c61 )
+)
+
+game (
+	name "Sonic Heroes (US)"
+	description "Sonic Heroes (US)"
+	rom ( name "Sonic Heroes (US).iso" size 1459978240 crc 48ce3c79 md5 b8c74bdcebb29eadd8b9a6c7e1899216 sha1 dd752c8aa64f2f043c32be0f0bd5b8617357bfe6 )
+)
+
+game (
+	name "Sonic Heroes (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Heroes (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Heroes (USA) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc 48ce3c79 md5 b8c74bdcebb29eadd8b9a6c7e1899216 sha1 dd752c8aa64f2f043c32be0f0bd5b8617357bfe6 )
+)
+
+game (
+	name "Sonic Mega Collection (EU)"
+	description "Sonic Mega Collection (EU)"
+	rom ( name "Sonic Mega Collection (EU).iso" size 1459978240 crc 9aa972fc md5 0261d1b772152f35123cb6b5651c454f sha1 2e52b2d8c11a67ccef8fde6c00a9ce91aebe34a7 )
+)
+
+game (
+	name "Sonic Mega Collection (Europe) (En,Fr,De,Es,It)"
+	description "Sonic Mega Collection (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sonic Mega Collection (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9aa972fc md5 0261d1b772152f35123cb6b5651c454f sha1 2e52b2d8c11a67ccef8fde6c00a9ce91aebe34a7 )
+)
+
+game (
+	name "Sonic Mega Collection (Japan)"
+	description "Sonic Mega Collection (Japan)"
+	rom ( name "Sonic Mega Collection (Japan).iso" size 1459978240 crc 545f93a6 md5 37fff656fc04f4f4719690d8eebd73f3 sha1 f997a8ac49a76ed3c747a28fbe69aacfeea0e19e )
+)
+
+game (
+	name "Sonic Mega Collection (JP) - sonituku+megakorekusiyon"
+	description "Sonic Mega Collection (JP) - sonituku+megakorekusiyon"
+	rom ( name "Sonic Mega Collection (JP).iso" size 1459978240 crc 545f93a6 md5 37fff656fc04f4f4719690d8eebd73f3 sha1 f997a8ac49a76ed3c747a28fbe69aacfeea0e19e )
+)
+
+game (
+	name "Sonic Mega Collection (US)"
+	description "Sonic Mega Collection (US)"
+	rom ( name "Sonic Mega Collection (US).iso" size 1459978240 crc 01b52739 md5 85a525df1481d0ad67d8761f832dca12 sha1 06eb6d15b4d7f90ec0fed9ce9a77db41358d74ed )
+)
+
+game (
+	name "Sonic Mega Collection (USA)"
+	description "Sonic Mega Collection (USA)"
+	rom ( name "Sonic Mega Collection (USA).iso" size 1459978240 crc 01b52739 md5 85a525df1481d0ad67d8761f832dca12 sha1 06eb6d15b4d7f90ec0fed9ce9a77db41358d74ed )
+)
+
+game (
+	name "Sonic Riders (EU)"
+	description "Sonic Riders (EU)"
+	rom ( name "Sonic Riders (EU).iso" size 1459978240 crc f8ea461e md5 f6f2f170702c3de8b50f9d8ecdb308a9 sha1 60c7477d0b640616f5f5eeddb4269d65056e376c )
+)
+
+game (
+	name "Sonic Riders (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Riders (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Riders (Europe) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc f8ea461e md5 f6f2f170702c3de8b50f9d8ecdb308a9 sha1 60c7477d0b640616f5f5eeddb4269d65056e376c )
+)
+
+game (
+	name "Sonic Riders (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Riders (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Riders (Japan) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc 24529150 md5 7eb29658744208dd505227bd8d3d6126 sha1 bf5f67e9c820913fd811980ef1183c55a9a3386f )
+)
+
+game (
+	name "Sonic Riders (JP) - sonitukuraidazu"
+	description "Sonic Riders (JP) - sonitukuraidazu"
+	rom ( name "Sonic Riders (JP).iso" size 1459978240 crc 24529150 md5 7eb29658744208dd505227bd8d3d6126 sha1 bf5f67e9c820913fd811980ef1183c55a9a3386f )
+)
+
+game (
+	name "Sonic Riders (US)"
+	description "Sonic Riders (US)"
+	rom ( name "Sonic Riders (US).iso" size 1459978240 crc 1dabe6ee md5 80155de587c0233e39ab545c2e771749 sha1 ce0cecf57034bef8bab7d6f588ce92c85a849613 )
+)
+
+game (
+	name "Sonic Riders (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Riders (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Riders (USA) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc 1dabe6ee md5 80155de587c0233e39ab545c2e771749 sha1 ce0cecf57034bef8bab7d6f588ce92c85a849613 )
+)
+
+game (
+	name "Soulcalibur II (Demo) (US)"
+	description "Soulcalibur II (Demo) (US)"
+	rom ( name "Soulcalibur II (Demo) (US).iso" size 1459978240 crc 989e11d9 md5 a1b88b3099aaeaffbc11204ea0dfe6e3 sha1 d4edce2b38653e232ac8e7a16139f7093bb4448d )
+)
+
+game (
+	name "Soulcalibur II (EU)"
+	description "Soulcalibur II (EU)"
+	rom ( name "Soulcalibur II (EU).iso" size 1459978240 crc 7d1b46d7 md5 9d9ca74dca5d850e2da6a4559a391524 sha1 96e4362732f53c519440c58cdcff340fe2ddb4d6 )
+)
+
+game (
+	name "Soulcalibur II (Europe) (En,Fr,De,Es,It)"
+	description "Soulcalibur II (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Soulcalibur II (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7d1b46d7 md5 9d9ca74dca5d850e2da6a4559a391524 sha1 96e4362732f53c519440c58cdcff340fe2ddb4d6 )
+)
+
+game (
+	name "Soulcalibur II (Japan)"
+	description "Soulcalibur II (Japan)"
+	rom ( name "Soulcalibur II (Japan).iso" size 1459978240 crc d4899b21 md5 897837b3f2e4e1f8fbcbdac9dabc31d4 sha1 7bd0a872fc74e086ef330ca2da1623beea9119cb )
+)
+
+game (
+	name "Soulcalibur II (JP) - sourukiyaribaII"
+	description "Soulcalibur II (JP) - sourukiyaribaII"
+	rom ( name "Soulcalibur II (JP).iso" size 1459978240 crc d4899b21 md5 897837b3f2e4e1f8fbcbdac9dabc31d4 sha1 7bd0a872fc74e086ef330ca2da1623beea9119cb )
+)
+
+game (
+	name "Soulcalibur II (US)"
+	description "Soulcalibur II (US)"
+	rom ( name "Soulcalibur II (US).iso" size 1459978240 crc 89779810 md5 0c8ec93f3f4f4e00d5a46443225c169c sha1 49f281fbe7086a4eb400a03c869fcac5f90df55a )
+)
+
+game (
+	name "Soulcalibur II (USA)"
+	description "Soulcalibur II (USA)"
+	rom ( name "Soulcalibur II (USA).iso" size 1459978240 crc 89779810 md5 0c8ec93f3f4f4e00d5a46443225c169c sha1 49f281fbe7086a4eb400a03c869fcac5f90df55a )
+)
+
+game (
+	name "Soulcalibur II (USA) (Demo)"
+	description "Soulcalibur II (USA) (Demo)"
+	rom ( name "Soulcalibur II (USA) (Demo).iso" size 1459978240 crc 989e11d9 md5 a1b88b3099aaeaffbc11204ea0dfe6e3 sha1 d4edce2b38653e232ac8e7a16139f7093bb4448d )
+)
+
+game (
+	name "Space Raiders (Japan)"
+	description "Space Raiders (Japan)"
+	rom ( name "Space Raiders (Japan).iso" size 1459978240 crc aae6405b md5 025ad670dd18dad2b2af515bce6abafa sha1 5949871c1c8cb1780857354b70a911e85a6a886e )
+)
+
+game (
+	name "Space Raiders (JP) - supesu+reidasu"
+	description "Space Raiders (JP) - supesu+reidasu"
+	rom ( name "Space Raiders (JP).iso" size 1459978240 crc aae6405b md5 025ad670dd18dad2b2af515bce6abafa sha1 5949871c1c8cb1780857354b70a911e85a6a886e )
+)
+
+game (
+	name "Space Raiders (US)"
+	description "Space Raiders (US)"
+	rom ( name "Space Raiders (US).iso" size 1459978240 crc 834bdaf9 md5 b87430184cd450b2b21ac005fd0c904e sha1 56884783e19bd3c099332c7ae31058ed855e2212 )
+)
+
+game (
+	name "Space Raiders (USA)"
+	description "Space Raiders (USA)"
+	rom ( name "Space Raiders (USA).iso" size 1459978240 crc 834bdaf9 md5 b87430184cd450b2b21ac005fd0c904e sha1 56884783e19bd3c099332c7ae31058ed855e2212 )
+)
+
+game (
+	name "Spartan - Total Warrior (DE)"
+	description "Spartan - Total Warrior (DE)"
+	rom ( name "Spartan - Total Warrior (DE).iso" size 1459978240 crc f4b2a045 md5 c29477217c58261532c8df9bd2fad139 sha1 cc5d7f0a5d715c13c7b1a2398197b73658481a02 )
+)
+
+game (
+	name "Spartan - Total Warrior (EU)"
+	description "Spartan - Total Warrior (EU)"
+	rom ( name "Spartan - Total Warrior (EU).iso" size 1459978240 crc 5bf65abe md5 ce5c331cea9cd294ab8952a7c4b57720 sha1 fd2d0c6704ed750e6ffd2ad4fbf12ee20be3748a )
+)
+
+game (
+	name "Spartan - Total Warrior (Europe) (En,Es,It)"
+	description "Spartan - Total Warrior (Europe) (En,Es,It)"
+	rom ( name "Spartan - Total Warrior (Europe) (En,Es,It).iso" size 1459978240 crc 5bf65abe md5 ce5c331cea9cd294ab8952a7c4b57720 sha1 fd2d0c6704ed750e6ffd2ad4fbf12ee20be3748a )
+)
+
+game (
+	name "Spartan - Total Warrior (FR)"
+	description "Spartan - Total Warrior (FR)"
+	rom ( name "Spartan - Total Warrior (FR).iso" size 1459978240 crc 6ee2ab41 md5 4f525e62a939ab1187083621cd0ed662 sha1 7a54383ed509f18b7930dc4861ff01cf6425aed8 )
+)
+
+game (
+	name "Spartan - Total Warrior (France)"
+	description "Spartan - Total Warrior (France)"
+	rom ( name "Spartan - Total Warrior (France).iso" size 1459978240 crc 6ee2ab41 md5 4f525e62a939ab1187083621cd0ed662 sha1 7a54383ed509f18b7930dc4861ff01cf6425aed8 )
+)
+
+game (
+	name "Spartan - Total Warrior (Germany)"
+	description "Spartan - Total Warrior (Germany)"
+	rom ( name "Spartan - Total Warrior (Germany).iso" size 1459978240 crc f4b2a045 md5 c29477217c58261532c8df9bd2fad139 sha1 cc5d7f0a5d715c13c7b1a2398197b73658481a02 )
+)
+
+game (
+	name "Spartan - Total Warrior (US)"
+	description "Spartan - Total Warrior (US)"
+	rom ( name "Spartan - Total Warrior (US).iso" size 1459978240 crc 4e26fe50 md5 76c35516a148f5e221ad0c55b6f6345f sha1 4a0542e481e027a8e6a26b62e9fbfb90e26da4f5 )
+)
+
+game (
+	name "Spartan - Total Warrior (USA)"
+	description "Spartan - Total Warrior (USA)"
+	rom ( name "Spartan - Total Warrior (USA).iso" size 1459978240 crc 4e26fe50 md5 76c35516a148f5e221ad0c55b6f6345f sha1 4a0542e481e027a8e6a26b62e9fbfb90e26da4f5 )
+)
+
+game (
+	name "Spawn - Armageddon (EU)"
+	description "Spawn - Armageddon (EU)"
+	rom ( name "Spawn - Armageddon (EU).iso" size 1459978240 crc 2dcb5258 md5 bdc8d65ef01c2710f0470421f13e4170 sha1 6b25a8bfc2bb08513707351fff906a69ce796c01 )
+)
+
+game (
+	name "Spawn - Armageddon (Europe) (En,Fr,De,Es,It)"
+	description "Spawn - Armageddon (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Spawn - Armageddon (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 2dcb5258 md5 bdc8d65ef01c2710f0470421f13e4170 sha1 6b25a8bfc2bb08513707351fff906a69ce796c01 )
+)
+
+game (
+	name "Spawn - Armageddon (US)"
+	description "Spawn - Armageddon (US)"
+	rom ( name "Spawn - Armageddon (US).iso" size 1459978240 crc 27df6bec md5 14fc76a34700adaede628521a8956cbf sha1 d98360041f77194ab7b787b010535ceaa2dc494e )
+)
+
+game (
+	name "Spawn - Armageddon (USA)"
+	description "Spawn - Armageddon (USA)"
+	rom ( name "Spawn - Armageddon (USA).iso" size 1459978240 crc 27df6bec md5 14fc76a34700adaede628521a8956cbf sha1 d98360041f77194ab7b787b010535ceaa2dc494e )
+)
+
+game (
+	name "Special Jinsei Game (Japan)"
+	description "Special Jinsei Game (Japan)"
+	rom ( name "Special Jinsei Game (Japan).iso" size 1459978240 crc 10557cf7 md5 4f6a663f47e6d2419bca1d4bab1d57bc sha1 28e51a335f91664558db7cc701893a5fd3a083c9 )
+)
+
+game (
+	name "Special Jinsei Game (JP) - Special+Ren Sheng gemu"
+	description "Special Jinsei Game (JP) - Special+Ren Sheng gemu"
+	rom ( name "Special Jinsei Game (JP).iso" size 1459978240 crc 10557cf7 md5 4f6a663f47e6d2419bca1d4bab1d57bc sha1 28e51a335f91664558db7cc701893a5fd3a083c9 )
+)
+
+game (
+	name "Speed Challenge - Jacques Villeneuve's Racing Vision (EU)"
+	description "Speed Challenge - Jacques Villeneuve's Racing Vision (EU)"
+	rom ( name "Speed Challenge - Jacques Villeneuve's Racing Vision (EU).iso" size 1459978240 crc e649640a md5 13730f9eda5e6877e556a21bb43e939b sha1 52f465d3123c161118504f31e6601defc7b45e46 )
+)
+
+game (
+	name "Speed Challenge - Jacques Villeneuve's Racing Vision (Europe) (En,Fr)"
+	description "Speed Challenge - Jacques Villeneuve's Racing Vision (Europe) (En,Fr)"
+	rom ( name "Speed Challenge - Jacques Villeneuve's Racing Vision (Europe) (En,Fr).iso" size 1459978240 crc e649640a md5 13730f9eda5e6877e556a21bb43e939b sha1 52f465d3123c161118504f31e6601defc7b45e46 )
+)
+
+game (
+	name "Speed Kings (EU)"
+	description "Speed Kings (EU)"
+	rom ( name "Speed Kings (EU).iso" size 1459978240 crc 6d62d060 md5 f64268ee24cddb9573152a620588fe37 sha1 a738b5b738cff3785fd64b067d60aed47b220c65 )
+)
+
+game (
+	name "Speed Kings (Europe) (En,Fr,De,Es,It)"
+	description "Speed Kings (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Speed Kings (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 6d62d060 md5 f64268ee24cddb9573152a620588fe37 sha1 a738b5b738cff3785fd64b067d60aed47b220c65 )
+)
+
+game (
+	name "Speed Kings (US)"
+	description "Speed Kings (US)"
+	rom ( name "Speed Kings (US).iso" size 1459978240 crc 390b126b md5 5bba141dcecf34e8891322b91d6bd377 sha1 8b62dd419db34744c92b0aff498825080fcc8a75 )
+)
+
+game (
+	name "Speed Kings (USA)"
+	description "Speed Kings (USA)"
+	rom ( name "Speed Kings (USA).iso" size 1459978240 crc 390b126b md5 5bba141dcecf34e8891322b91d6bd377 sha1 8b62dd419db34744c92b0aff498825080fcc8a75 )
+)
+
+game (
+	name "Sphinx and the Cursed Mummy (EU)"
+	description "Sphinx and the Cursed Mummy (EU)"
+	rom ( name "Sphinx and the Cursed Mummy (EU).iso" size 1459978240 crc 4e830e05 md5 dcc0b76b0045a6f63e5b0387e314acae sha1 30f48439fb101d040cc87f523ec064144af6c21c )
+)
+
+game (
+	name "Sphinx and the Cursed Mummy (Europe) (En,Fr,De,Es,It)"
+	description "Sphinx and the Cursed Mummy (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sphinx and the Cursed Mummy (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 4e830e05 md5 dcc0b76b0045a6f63e5b0387e314acae sha1 30f48439fb101d040cc87f523ec064144af6c21c )
+)
+
+game (
+	name "Sphinx and the Cursed Mummy (US)"
+	description "Sphinx and the Cursed Mummy (US)"
+	rom ( name "Sphinx and the Cursed Mummy (US).iso" size 1459978240 crc 242f4ff4 md5 4e635d238507f1898b40bd7ab0491155 sha1 93f7ee4eb240bdf0db225bdfee4c41b94d58eb1a )
+)
+
+game (
+	name "Sphinx and the Cursed Mummy (USA)"
+	description "Sphinx and the Cursed Mummy (USA)"
+	rom ( name "Sphinx and the Cursed Mummy (USA).iso" size 1459978240 crc 242f4ff4 md5 4e635d238507f1898b40bd7ab0491155 sha1 93f7ee4eb240bdf0db225bdfee4c41b94d58eb1a )
+)
+
+game (
+	name "Spider-Man (DE)"
+	description "Spider-Man (DE)"
+	rom ( name "Spider-Man (DE).iso" size 1459978240 crc 67ac4bb0 md5 ca4f9c0e234fdb373cd92082b5d1e7d0 sha1 e4335636514ca51d7518e7b9d99ae9cec166d5cb )
+)
+
+game (
+	name "Spider-Man (EU)"
+	description "Spider-Man (EU)"
+	rom ( name "Spider-Man (EU).iso" size 1459978240 crc f517d49e md5 03bd5fc248b055381580912cdb076e7a sha1 182e90fd881e056b5860fafab8db0ab6073cc106 )
+)
+
+game (
+	name "Spider-Man (Europe)"
+	description "Spider-Man (Europe)"
+	rom ( name "Spider-Man (Europe).iso" size 1459978240 crc f517d49e md5 03bd5fc248b055381580912cdb076e7a sha1 182e90fd881e056b5860fafab8db0ab6073cc106 )
+)
+
+game (
+	name "Spider-Man (FR)"
+	description "Spider-Man (FR)"
+	rom ( name "Spider-Man (FR).iso" size 1459978240 crc d2f5d804 md5 f197f77296a52e123e23d48495c6dc2c sha1 f1a22bc606bb1dbf068cb1ef981915423f90d32d )
+)
+
+game (
+	name "Spider-Man (France)"
+	description "Spider-Man (France)"
+	rom ( name "Spider-Man (France).iso" size 1459978240 crc d2f5d804 md5 f197f77296a52e123e23d48495c6dc2c sha1 f1a22bc606bb1dbf068cb1ef981915423f90d32d )
+)
+
+game (
+	name "Spider-Man (Germany)"
+	description "Spider-Man (Germany)"
+	rom ( name "Spider-Man (Germany).iso" size 1459978240 crc 67ac4bb0 md5 ca4f9c0e234fdb373cd92082b5d1e7d0 sha1 e4335636514ca51d7518e7b9d99ae9cec166d5cb )
+)
+
+game (
+	name "Spider-Man (Japan)"
+	description "Spider-Man (Japan)"
+	rom ( name "Spider-Man (Japan).iso" size 1459978240 crc 2fc9cd32 md5 b30ae74ee766bcf9dbf08d00f523ea0d sha1 cbaee82b6e0472c70a67cec3228a55fdf862c773 )
+)
+
+game (
+	name "Spider-Man (JP) - supaidaman"
+	description "Spider-Man (JP) - supaidaman"
+	rom ( name "Spider-Man (JP).iso" size 1459978240 crc 2fc9cd32 md5 b30ae74ee766bcf9dbf08d00f523ea0d sha1 cbaee82b6e0472c70a67cec3228a55fdf862c773 )
+)
+
+game (
+	name "Spider-Man (US)"
+	description "Spider-Man (US)"
+	rom ( name "Spider-Man (US).iso" size 1459978240 crc a8f905fb md5 3adc8c214b6eb3e21e9b407b7657eff7 sha1 a1dbd9917ad4763f5619974169c99f4665c31b18 )
+)
+
+game (
+	name "Spider-Man (USA)"
+	description "Spider-Man (USA)"
+	rom ( name "Spider-Man (USA).iso" size 1459978240 crc a8f905fb md5 3adc8c214b6eb3e21e9b407b7657eff7 sha1 a1dbd9917ad4763f5619974169c99f4665c31b18 )
+)
+
+game (
+	name "Spider-Man 2 (DE)"
+	description "Spider-Man 2 (DE)"
+	rom ( name "Spider-Man 2 (DE).iso" size 1459978240 crc 4c9579da md5 69be60e45eb86d6ae1e4acaf90541228 sha1 0e2180737800241fb22ec2c7704d1057c3715638 )
+)
+
+game (
+	name "Spider-Man 2 (Europe)"
+	description "Spider-Man 2 (Europe)"
+	rom ( name "Spider-Man 2 (Europe).iso" size 1459978240 crc 69b4f5f6 md5 ddaf3e01678474020afbaa4d00bfe1b1 sha1 5912c8e2a1ef54f9a0208e78dd7d9645ef653654 )
+)
+
+game (
+	name "Spider-Man 2 (FR)"
+	description "Spider-Man 2 (FR)"
+	rom ( name "Spider-Man 2 (FR).iso" size 1459978240 crc f4c10a62 md5 64dd25e8bb2f5799a74f80892694659e sha1 9e22c28b61b129acd3ed5e3285e6a3ad361178bb )
+)
+
+game (
+	name "Spider-Man 2 (France)"
+	description "Spider-Man 2 (France)"
+	rom ( name "Spider-Man 2 (France).iso" size 1459978240 crc f4c10a62 md5 64dd25e8bb2f5799a74f80892694659e sha1 9e22c28b61b129acd3ed5e3285e6a3ad361178bb )
+)
+
+game (
+	name "Spider-Man 2 (GB)"
+	description "Spider-Man 2 (GB)"
+	rom ( name "Spider-Man 2 (GB).iso" size 1459978240 crc 69b4f5f6 md5 ddaf3e01678474020afbaa4d00bfe1b1 sha1 5912c8e2a1ef54f9a0208e78dd7d9645ef653654 )
+)
+
+game (
+	name "Spider-Man 2 (Germany)"
+	description "Spider-Man 2 (Germany)"
+	rom ( name "Spider-Man 2 (Germany).iso" size 1459978240 crc 4c9579da md5 69be60e45eb86d6ae1e4acaf90541228 sha1 0e2180737800241fb22ec2c7704d1057c3715638 )
+)
+
+game (
+	name "Spider-Man 2 (US)"
+	description "Spider-Man 2 (US)"
+	rom ( name "Spider-Man 2 (US).iso" size 1459978240 crc 08964518 md5 a2762a6acc32d4e523ac6848589cc147 sha1 96bb5128146dabbda8a6748925acd3650f16029f )
+)
+
+game (
+	name "Spider-Man 2 (USA)"
+	description "Spider-Man 2 (USA)"
+	rom ( name "Spider-Man 2 (USA).iso" size 1459978240 crc 08964518 md5 a2762a6acc32d4e523ac6848589cc147 sha1 96bb5128146dabbda8a6748925acd3650f16029f )
+)
+
+game (
+	name "Spirits & Spells (US)"
+	description "Spirits & Spells (US)"
+	rom ( name "Spirits & Spells (US).iso" size 1459978240 crc 81e06cb9 md5 8744284823d2e768d07097250bb89744 sha1 c97b1d9faa64e5ad79411f2c806a757c7dab747b )
+)
+
+game (
+	name "Spirits & Spells (USA)"
+	description "Spirits & Spells (USA)"
+	rom ( name "Spirits & Spells (USA).iso" size 1459978240 crc 81e06cb9 md5 8744284823d2e768d07097250bb89744 sha1 c97b1d9faa64e5ad79411f2c806a757c7dab747b )
+)
+
+game (
+	name "SpyHunter (EU)"
+	description "SpyHunter (EU)"
+	rom ( name "SpyHunter (EU).iso" size 1459978240 crc 6e368bcc md5 3335dc9efc3b0da58572ca3f77c529fa sha1 f3d37ef76af0e34533b9a6292ce66c3d00938f83 )
+)
+
+game (
+	name "SpyHunter (Europe) (En,Fr,De,Es,It)"
+	description "SpyHunter (Europe) (En,Fr,De,Es,It)"
+	rom ( name "SpyHunter (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 6e368bcc md5 3335dc9efc3b0da58572ca3f77c529fa sha1 f3d37ef76af0e34533b9a6292ce66c3d00938f83 )
+)
+
+game (
+	name "SpyHunter (US)"
+	description "SpyHunter (US)"
+	rom ( name "SpyHunter (US).iso" size 1459978240 crc 5048da05 md5 676d15ca76fb94e13b3583a39400f673 sha1 fe3bccb3b0424d328e645109a223afe84819009b )
+)
+
+game (
+	name "SpyHunter (USA)"
+	description "SpyHunter (USA)"
+	rom ( name "SpyHunter (USA).iso" size 1459978240 crc 5048da05 md5 676d15ca76fb94e13b3583a39400f673 sha1 fe3bccb3b0424d328e645109a223afe84819009b )
+)
+
+game (
+	name "Spyro - A Hero's Tail (EU)"
+	description "Spyro - A Hero's Tail (EU)"
+	rom ( name "Spyro - A Hero's Tail (EU).iso" size 1459978240 crc b1c3b03c md5 f007472216f3cc10ab68d991f441216c sha1 7c6f74d45918d45b76bc5d9bcc7b40ae075d8cf5 )
+)
+
+game (
+	name "Spyro - A Hero's Tail (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Spyro - A Hero's Tail (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Spyro - A Hero's Tail (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc b1c3b03c md5 f007472216f3cc10ab68d991f441216c sha1 7c6f74d45918d45b76bc5d9bcc7b40ae075d8cf5 )
+)
+
+game (
+	name "Spyro - A Hero's Tail (US)"
+	description "Spyro - A Hero's Tail (US)"
+	rom ( name "Spyro - A Hero's Tail (US).iso" size 1459978240 crc 57708149 md5 dad9e57a1da344a7354a4b3276558eb1 sha1 718bd74c1345f23ebfeeff2f527d7dfb007fc531 )
+)
+
+game (
+	name "Spyro - A Hero's Tail (USA)"
+	description "Spyro - A Hero's Tail (USA)"
+	rom ( name "Spyro - A Hero's Tail (USA).iso" size 1459978240 crc 57708149 md5 dad9e57a1da344a7354a4b3276558eb1 sha1 718bd74c1345f23ebfeeff2f527d7dfb007fc531 )
+)
+
+game (
+	name "Spyro - Enter the Dragonfly (EU)"
+	description "Spyro - Enter the Dragonfly (EU)"
+	rom ( name "Spyro - Enter the Dragonfly (EU).iso" size 1459978240 crc c413de23 md5 f50e631c014b968d707d839a4afd69c5 sha1 5455ed1bc9137636745cb0e60867eed1ca3bc850 )
+)
+
+game (
+	name "Spyro - Enter the Dragonfly (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Spyro - Enter the Dragonfly (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Spyro - Enter the Dragonfly (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc c413de23 md5 f50e631c014b968d707d839a4afd69c5 sha1 5455ed1bc9137636745cb0e60867eed1ca3bc850 )
+)
+
+game (
+	name "Spyro - Enter the Dragonfly (US)"
+	description "Spyro - Enter the Dragonfly (US)"
+	rom ( name "Spyro - Enter the Dragonfly (US).iso" size 1459978240 crc 0956a8df md5 b6d438d5f29577d356f6214b5277f1e6 sha1 458e763718e574b4a595dce720a203a5a2a1d791 )
+)
+
+game (
+	name "Spyro - Enter the Dragonfly (USA)"
+	description "Spyro - Enter the Dragonfly (USA)"
+	rom ( name "Spyro - Enter the Dragonfly (USA).iso" size 1459978240 crc 0956a8df md5 b6d438d5f29577d356f6214b5277f1e6 sha1 458e763718e574b4a595dce720a203a5a2a1d791 )
+)
+
+game (
+	name "SRS - Street Racing Syndicate (EU)"
+	description "SRS - Street Racing Syndicate (EU)"
+	rom ( name "SRS - Street Racing Syndicate (EU).iso" size 1459978240 crc 8dd1d444 md5 4d9c85203f6cdb4bd8c92415d812728a sha1 ec93bda1ac8010df333d881600a608cc9d08fe8d )
+)
+
+game (
+	name "SRS - Street Racing Syndicate (Europe) (En,Fr,De,Es,It)"
+	description "SRS - Street Racing Syndicate (Europe) (En,Fr,De,Es,It)"
+	rom ( name "SRS - Street Racing Syndicate (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 8dd1d444 md5 4d9c85203f6cdb4bd8c92415d812728a sha1 ec93bda1ac8010df333d881600a608cc9d08fe8d )
+)
+
+game (
+	name "SRS - Street Racing Syndicate (US)"
+	description "SRS - Street Racing Syndicate (US)"
+	rom ( name "SRS - Street Racing Syndicate (US).iso" size 1459978240 crc 718f9112 md5 548dda53207aff4f16b1942ad62fe812 sha1 51f51587bf1ba669cb0745501f3e2395fb80cb4a )
+)
+
+game (
+	name "SRS - Street Racing Syndicate (USA)"
+	description "SRS - Street Racing Syndicate (USA)"
+	rom ( name "SRS - Street Racing Syndicate (USA).iso" size 1459978240 crc 718f9112 md5 548dda53207aff4f16b1942ad62fe812 sha1 51f51587bf1ba669cb0745501f3e2395fb80cb4a )
+)
+
+game (
+	name "SSX 3 (EU)"
+	description "SSX 3 (EU)"
+	rom ( name "SSX 3 (EU).iso" size 1459978240 crc 8eb360c9 md5 087a5a59d976b0843ab5917df38d0b45 sha1 f9e40540666e7d5c5f1ffee5d28947cfdc89a9c9 )
+)
+
+game (
+	name "SSX 3 (Europe) (En,Fr,De,Es)"
+	description "SSX 3 (Europe) (En,Fr,De,Es)"
+	rom ( name "SSX 3 (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 8eb360c9 md5 087a5a59d976b0843ab5917df38d0b45 sha1 f9e40540666e7d5c5f1ffee5d28947cfdc89a9c9 )
+)
+
+game (
+	name "SSX 3 (Japan)"
+	description "SSX 3 (Japan)"
+	rom ( name "SSX 3 (Japan).iso" size 1459978240 crc 281ee750 md5 8b25854016fe7289cfa444543b2e9aa8 sha1 003e6c542d911cc1ef64f93f1a7aa9808cfb1779 )
+)
+
+game (
+	name "SSX 3 (JP)"
+	description "SSX 3 (JP)"
+	rom ( name "SSX 3 (JP).iso" size 1459978240 crc 281ee750 md5 8b25854016fe7289cfa444543b2e9aa8 sha1 003e6c542d911cc1ef64f93f1a7aa9808cfb1779 )
+)
+
+game (
+	name "SSX 3 (US)"
+	description "SSX 3 (US)"
+	rom ( name "SSX 3 (US).iso" size 1459978240 crc bd94fd62 md5 fb6ce25daf8550dae472b8d84596acc1 sha1 9f047c3c3389b5f2ad464afc472dd15cb0083474 )
+)
+
+game (
+	name "SSX 3 (USA)"
+	description "SSX 3 (USA)"
+	rom ( name "SSX 3 (USA).iso" size 1459978240 crc bd94fd62 md5 fb6ce25daf8550dae472b8d84596acc1 sha1 9f047c3c3389b5f2ad464afc472dd15cb0083474 )
+)
+
+game (
+	name "SSX On Tour (DE^FR)"
+	description "SSX On Tour (DE^FR)"
+	rom ( name "SSX On Tour (DE^FR).iso" size 1459978240 crc 886defd6 md5 e86b6fc0db336d2e55c08b23d76ab554 sha1 2a6055689d79602d92a5bbbcf9d5a9613301d802 )
+)
+
+game (
+	name "SSX On Tour (EU)"
+	description "SSX On Tour (EU)"
+	rom ( name "SSX On Tour (EU).iso" size 1459978240 crc d8e0133a md5 733ddb87d8c86f1b85d54286757ae9f7 sha1 f6f62212eea172243f7247db390ae64e2a545299 )
+)
+
+game (
+	name "SSX On Tour (Europe)"
+	description "SSX On Tour (Europe)"
+	rom ( name "SSX On Tour (Europe).iso" size 1459978240 crc d8e0133a md5 733ddb87d8c86f1b85d54286757ae9f7 sha1 f6f62212eea172243f7247db390ae64e2a545299 )
+)
+
+game (
+	name "SSX On Tour (Europe) (En,Fr,De)"
+	description "SSX On Tour (Europe) (En,Fr,De)"
+	rom ( name "SSX On Tour (Europe) (En,Fr,De).iso" size 1459978240 crc 886defd6 md5 e86b6fc0db336d2e55c08b23d76ab554 sha1 2a6055689d79602d92a5bbbcf9d5a9613301d802 )
+)
+
+game (
+	name "SSX On Tour (US)"
+	description "SSX On Tour (US)"
+	rom ( name "SSX On Tour (US).iso" size 1459978240 crc 4e61b495 md5 3eb9a702b5a42f81222ea47ae0c6cef0 sha1 f633939221a42114c5b185de796529a63ddc0839 )
+)
+
+game (
+	name "SSX On Tour (USA)"
+	description "SSX On Tour (USA)"
+	rom ( name "SSX On Tour (USA).iso" size 1459978240 crc 4e61b495 md5 3eb9a702b5a42f81222ea47ae0c6cef0 sha1 f633939221a42114c5b185de796529a63ddc0839 )
+)
+
+game (
+	name "SSX On Tour with Mario (Japan)"
+	description "SSX On Tour with Mario (Japan)"
+	rom ( name "SSX On Tour with Mario (Japan).iso" size 1459978240 crc 9a452794 md5 43cc22b1d72b5fdc190bcb6ee58142dc sha1 e70d66334a81edd218f171f1d3690e680d38c215 )
+)
+
+game (
+	name "SSX On Tour with Mario (JP) - SSX+on+tua+with+mario"
+	description "SSX On Tour with Mario (JP) - SSX+on+tua+with+mario"
+	rom ( name "SSX On Tour with Mario (JP).iso" size 1459978240 crc 9a452794 md5 43cc22b1d72b5fdc190bcb6ee58142dc sha1 e70d66334a81edd218f171f1d3690e680d38c215 )
+)
+
+game (
+	name "SSX Tricky (EU)"
+	description "SSX Tricky (EU)"
+	rom ( name "SSX Tricky (EU).iso" size 1459978240 crc e0e8b174 md5 54cabb3c41f91af0134e761a980b7da8 sha1 360c53b9e61f9beed6d31ff2e4782a60cdc111e3 )
+)
+
+game (
+	name "SSX Tricky (Europe) (En,Fr,De)"
+	description "SSX Tricky (Europe) (En,Fr,De)"
+	rom ( name "SSX Tricky (Europe) (En,Fr,De).iso" size 1459978240 crc e0e8b174 md5 54cabb3c41f91af0134e761a980b7da8 sha1 360c53b9e61f9beed6d31ff2e4782a60cdc111e3 )
+)
+
+game (
+	name "SSX Tricky (Japan)"
+	description "SSX Tricky (Japan)"
+	rom ( name "SSX Tricky (Japan).iso" size 1459978240 crc a0f36492 md5 bea4da9c3d9f965bd3c386f6eadb7de6 sha1 4241aa2d9c6f9722250cc388b5040b7f71da4985 )
+)
+
+game (
+	name "SSX Tricky (JP) - SSX+torituki"
+	description "SSX Tricky (JP) - SSX+torituki"
+	rom ( name "SSX Tricky (JP).iso" size 1459978240 crc a0f36492 md5 bea4da9c3d9f965bd3c386f6eadb7de6 sha1 4241aa2d9c6f9722250cc388b5040b7f71da4985 )
+)
+
+game (
+	name "SSX Tricky (US)"
+	description "SSX Tricky (US)"
+	rom ( name "SSX Tricky (US).iso" size 1459978240 crc 753173c7 md5 47c64f8e60ecd70161b772adb7f25109 sha1 7adecbf91fff0c2b5907b2fd725a11d060ef95e0 )
+)
+
+game (
+	name "SSX Tricky (USA)"
+	description "SSX Tricky (USA)"
+	rom ( name "SSX Tricky (USA).iso" size 1459978240 crc 753173c7 md5 47c64f8e60ecd70161b772adb7f25109 sha1 7adecbf91fff0c2b5907b2fd725a11d060ef95e0 )
+)
+
+game (
+	name "Star Fox - Assault (EU)"
+	description "Star Fox - Assault (EU)"
+	rom ( name "Star Fox - Assault (EU).iso" size 1459978240 crc ee2d4247 md5 d77a7aa0d0e3bf52572ce4b8251c1339 sha1 5b4dd349d9fbf36024b7e729419b0f19e690f05f )
+)
+
+game (
+	name "Star Fox - Assault (Europe) (En,Fr,De,Es,It)"
+	description "Star Fox - Assault (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Star Fox - Assault (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ee2d4247 md5 d77a7aa0d0e3bf52572ce4b8251c1339 sha1 5b4dd349d9fbf36024b7e729419b0f19e690f05f )
+)
+
+game (
+	name "Star Fox - Assault (Japan)"
+	description "Star Fox - Assault (Japan)"
+	rom ( name "Star Fox - Assault (Japan).iso" size 1459978240 crc 089208f3 md5 27aed37f24061b1ff06cdd3640053481 sha1 43327ab2772003d0e5122c5b321153b1436131d3 )
+)
+
+game (
+	name "Star Fox - Assault (JP) - sutahuotukusu+asaruto"
+	description "Star Fox - Assault (JP) - sutahuotukusu+asaruto"
+	rom ( name "Star Fox - Assault (JP).iso" size 1459978240 crc 089208f3 md5 27aed37f24061b1ff06cdd3640053481 sha1 43327ab2772003d0e5122c5b321153b1436131d3 )
+)
+
+game (
+	name "Star Fox - Assault (US)"
+	description "Star Fox - Assault (US)"
+	rom ( name "Star Fox - Assault (US).iso" size 1459978240 crc 07166d23 md5 992e00b7df1960d4ca03c76801502f91 sha1 065341b8575adea00fd0a75e389f135d32840423 )
+)
+
+game (
+	name "Star Fox - Assault (USA)"
+	description "Star Fox - Assault (USA)"
+	rom ( name "Star Fox - Assault (USA).iso" size 1459978240 crc 07166d23 md5 992e00b7df1960d4ca03c76801502f91 sha1 065341b8575adea00fd0a75e389f135d32840423 )
+)
+
+game (
+	name "Star Fox Adventures (EU)"
+	description "Star Fox Adventures (EU)"
+	rom ( name "Star Fox Adventures (EU) - [v1.00].iso" size 1459978240 crc 8c56e950 md5 3ea71068b7b02a362fe31353a52b8da9 sha1 0ad671eefbe0833ac0a38e34a9f543ffe8c3cd7f )
+)
+
+game (
+	name "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 1459978240 crc 8c56e950 md5 3ea71068b7b02a362fe31353a52b8da9 sha1 0ad671eefbe0833ac0a38e34a9f543ffe8c3cd7f )
+)
+
+game (
+	name "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Star Fox Adventures (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 1459978240 crc 3cd4be1c md5 a55aef0762adcc91552dfb6bc97a6b9f sha1 fa09928f2dc196259521893b0e89eae297dc3df5 )
+)
+
+game (
+	name "Star Fox Adventures (Japan) (v1.00)"
+	description "Star Fox Adventures (Japan) (v1.00)"
+	rom ( name "Star Fox Adventures (Japan) (v1.00).iso" size 1459978240 crc dad4c2df md5 fe5246a097987645e061e04f6da807e6 sha1 77630a55768d6342c263497ee78f8eb5a187003a )
+)
+
+game (
+	name "Star Fox Adventures (Japan) (v1.01)"
+	description "Star Fox Adventures (Japan) (v1.01)"
+	rom ( name "Star Fox Adventures (Japan) (v1.01).iso" size 1459978240 crc 9781203a md5 ebff34930b3e8846167047bf71d25fbc sha1 979e8f24000cb9a8b332228a6b0fbf8a59aa0cab )
+)
+
+game (
+	name "Star Fox Adventures (JP) - sutahuotukusuadobentiya"
+	description "Star Fox Adventures (JP) - sutahuotukusuadobentiya"
+	rom ( name "Star Fox Adventures (JP) - [v1.00].iso" size 1459978240 crc dad4c2df md5 fe5246a097987645e061e04f6da807e6 sha1 77630a55768d6342c263497ee78f8eb5a187003a )
+)
+
+game (
+	name "Star Fox Adventures (Player's Choice) (EU)"
+	description "Star Fox Adventures (Player's Choice) (EU)"
+	rom ( name "Star Fox Adventures (Player's Choice) (EU) - [v1.01].iso" size 1459978240 crc 3cd4be1c md5 a55aef0762adcc91552dfb6bc97a6b9f sha1 fa09928f2dc196259521893b0e89eae297dc3df5 )
+)
+
+game (
+	name "Star Fox Adventures (Player's Choice) (US)"
+	description "Star Fox Adventures (Player's Choice) (US)"
+	rom ( name "Star Fox Adventures (Player's Choice) (US) - [v1.01].iso" size 1459978240 crc 477bf336 md5 969adb11a3e840745c3705a02dab24b5 sha1 ef451d04ead0824d9717ced0d3375bf8b9649612 )
+)
+
+game (
+	name "Star Fox Adventures (US)"
+	description "Star Fox Adventures (US)"
+	rom ( name "Star Fox Adventures (US) - [v1.00].iso" size 1459978240 crc 0f4b0960 md5 afb0306454b581e37a62170fdfd1de09 sha1 fa400b813e8359f24667fd6d4b368af0c325bef6 )
+)
+
+game (
+	name "Star Fox Adventures (USA) (v1.00)"
+	description "Star Fox Adventures (USA) (v1.00)"
+	rom ( name "Star Fox Adventures (USA) (v1.00).iso" size 1459978240 crc 0f4b0960 md5 afb0306454b581e37a62170fdfd1de09 sha1 fa400b813e8359f24667fd6d4b368af0c325bef6 )
+)
+
+game (
+	name "Star Fox Adventures (USA) (v1.01)"
+	description "Star Fox Adventures (USA) (v1.01)"
+	rom ( name "Star Fox Adventures (USA) (v1.01).iso" size 1459978240 crc 477bf336 md5 969adb11a3e840745c3705a02dab24b5 sha1 ef451d04ead0824d9717ced0d3375bf8b9649612 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (DE)"
+	description "Star Wars - Bounty Hunter (DE)"
+	rom ( name "Star Wars - Bounty Hunter (DE).iso" size 1459978240 crc f2a5e260 md5 d5ccf1f7241ea4e8188d2b3d1401368e sha1 87d389b9938f4de2acbbcd9430598efe7394831e )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (ES)"
+	description "Star Wars - Bounty Hunter (ES)"
+	rom ( name "Star Wars - Bounty Hunter (ES).iso" size 1459978240 crc 3c24be94 md5 5b5a0708869117a885ffea967992da1a sha1 9e771dabbfd7cea671a982537a51933cb7b94b45 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (Europe)"
+	description "Star Wars - Bounty Hunter (Europe)"
+	rom ( name "Star Wars - Bounty Hunter (Europe).iso" size 1459978240 crc 3a77a561 md5 0c13af64ecacefcb40064b18e3124af8 sha1 4ead5aa31ef0120b7ee74353a957cdc6d421f0b3 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (FR)"
+	description "Star Wars - Bounty Hunter (FR)"
+	rom ( name "Star Wars - Bounty Hunter (FR).iso" size 1459978240 crc d4205184 md5 c405b9cc619166253235bcdd06d84a9a sha1 18a2a1d5d44f589392e8009a4173ec6d08aa0700 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (France)"
+	description "Star Wars - Bounty Hunter (France)"
+	rom ( name "Star Wars - Bounty Hunter (France).iso" size 1459978240 crc d4205184 md5 c405b9cc619166253235bcdd06d84a9a sha1 18a2a1d5d44f589392e8009a4173ec6d08aa0700 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (GB)"
+	description "Star Wars - Bounty Hunter (GB)"
+	rom ( name "Star Wars - Bounty Hunter (GB).iso" size 1459978240 crc 3a77a561 md5 0c13af64ecacefcb40064b18e3124af8 sha1 4ead5aa31ef0120b7ee74353a957cdc6d421f0b3 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (Germany)"
+	description "Star Wars - Bounty Hunter (Germany)"
+	rom ( name "Star Wars - Bounty Hunter (Germany).iso" size 1459978240 crc f2a5e260 md5 d5ccf1f7241ea4e8188d2b3d1401368e sha1 87d389b9938f4de2acbbcd9430598efe7394831e )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (Spain)"
+	description "Star Wars - Bounty Hunter (Spain)"
+	rom ( name "Star Wars - Bounty Hunter (Spain).iso" size 1459978240 crc 3c24be94 md5 5b5a0708869117a885ffea967992da1a sha1 9e771dabbfd7cea671a982537a51933cb7b94b45 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (US)"
+	description "Star Wars - Bounty Hunter (US)"
+	rom ( name "Star Wars - Bounty Hunter (US).iso" size 1459978240 crc 9e0e33de md5 1e1fa515cda90e433c4a1862a4f3d73d sha1 f82fff40254867aaa549c8d5f1dbbd6cfa20aeb2 )
+)
+
+game (
+	name "Star Wars - Bounty Hunter (USA)"
+	description "Star Wars - Bounty Hunter (USA)"
+	rom ( name "Star Wars - Bounty Hunter (USA).iso" size 1459978240 crc 9e0e33de md5 1e1fa515cda90e433c4a1862a4f3d73d sha1 f82fff40254867aaa549c8d5f1dbbd6cfa20aeb2 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (DE)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (DE)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (DE).iso" size 1459978240 crc 0e217c55 md5 e5b9cc8834dd557937040dcabe6182b7 sha1 51e5d69786b28963124e2da95daabce7916c0439 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (EU)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (EU)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (EU).iso" size 1459978240 crc d127d5ad md5 b396c281feec034c2357390d899ef475 sha1 1dcbfbb5d5fb96a765a4322164d98d5805a7d747 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (Europe)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (Europe)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (Europe).iso" size 1459978240 crc d127d5ad md5 b396c281feec034c2357390d899ef475 sha1 1dcbfbb5d5fb96a765a4322164d98d5805a7d747 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (FR)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (FR)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (FR).iso" size 1459978240 crc 609a01a6 md5 913d7bb99bb2b6f6bbf28298287fc19e sha1 2a981901729983d72af9b95737a2741316f8c5aa )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (France)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (France)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (France).iso" size 1459978240 crc 609a01a6 md5 913d7bb99bb2b6f6bbf28298287fc19e sha1 2a981901729983d72af9b95737a2741316f8c5aa )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (Germany)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (Germany)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (Germany).iso" size 1459978240 crc 0e217c55 md5 e5b9cc8834dd557937040dcabe6182b7 sha1 51e5d69786b28963124e2da95daabce7916c0439 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (US)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (US)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (US).iso" size 1459978240 crc 80308da6 md5 09262abbd032a0ed9e7f7d390b2f07a8 sha1 c1a2b5c11ef07e28c09a23b70ecb5fc297ee4396 )
+)
+
+game (
+	name "Star Wars - Jedi Knight II - Jedi Outcast (USA)"
+	description "Star Wars - Jedi Knight II - Jedi Outcast (USA)"
+	rom ( name "Star Wars - Jedi Knight II - Jedi Outcast (USA).iso" size 1459978240 crc 80308da6 md5 09262abbd032a0ed9e7f7d390b2f07a8 sha1 c1a2b5c11ef07e28c09a23b70ecb5fc297ee4396 )
+)
+
+game (
+	name "Star Wars - Las Guerras Clon (ES)"
+	description "Star Wars - Las Guerras Clon (ES)"
+	rom ( name "Star Wars - Las Guerras Clon (ES).iso" size 1459978240 crc 7f6214a4 md5 20fc62f465ba2befa6c3b8c164372f6f sha1 30b9de7c7127e08c6b9b51b8bfba1f817a17e7e0 )
+)
+
+game (
+	name "Star Wars - Las Guerras Clon (Spain)"
+	description "Star Wars - Las Guerras Clon (Spain)"
+	rom ( name "Star Wars - Las Guerras Clon (Spain).iso" size 1459978240 crc 7f6214a4 md5 20fc62f465ba2befa6c3b8c164372f6f sha1 30b9de7c7127e08c6b9b51b8bfba1f817a17e7e0 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (DE)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (DE)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (DE).iso" size 1459978240 crc 9b78462d md5 fe32765ce6fcbb67ffd9e6f63d09cae0 sha1 6aad47b1c47f578b01d150e5a24ea4ed9a0a659b )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (ES)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (ES)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (ES).iso" size 1459978240 crc c5a234d5 md5 bb7eebbbb11fc8dc97f483a4dc3382cc sha1 fc9daac74cdcadc78074972750983f38100a7c82 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (Europe)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (Europe)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (Europe).iso" size 1459978240 crc 51fc19e0 md5 15c49ff1dc836d19a1f275ac46ef4398 sha1 0a0bf8aa760b6f3afadd299bbdf89ed8ec15ffba )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (FR)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (FR)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (FR).iso" size 1459978240 crc 3f7b5726 md5 776a1046f8c47d7aad0cd732b53587ca sha1 3828186cbc9fbc6d06b1bf266f977b7e50a82c45 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (France)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (France)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (France).iso" size 1459978240 crc 3f7b5726 md5 776a1046f8c47d7aad0cd732b53587ca sha1 3828186cbc9fbc6d06b1bf266f977b7e50a82c45 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (GB)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (GB)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (GB).iso" size 1459978240 crc 51fc19e0 md5 15c49ff1dc836d19a1f275ac46ef4398 sha1 0a0bf8aa760b6f3afadd299bbdf89ed8ec15ffba )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (Germany)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (Germany)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (Germany).iso" size 1459978240 crc 9b78462d md5 fe32765ce6fcbb67ffd9e6f63d09cae0 sha1 6aad47b1c47f578b01d150e5a24ea4ed9a0a659b )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (Spain)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (Spain)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (Spain).iso" size 1459978240 crc c5a234d5 md5 bb7eebbbb11fc8dc97f483a4dc3382cc sha1 fc9daac74cdcadc78074972750983f38100a7c82 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (US)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (US)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (US).iso" size 1459978240 crc e9d4823d md5 0bf391bee90da09d6042016d23e7a9b1 sha1 4add0e2411c0940d5c30dd408677085427f80aa9 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II - Rogue Leader (USA)"
+	description "Star Wars - Rogue Squadron II - Rogue Leader (USA)"
+	rom ( name "Star Wars - Rogue Squadron II - Rogue Leader (USA).iso" size 1459978240 crc e9d4823d md5 0bf391bee90da09d6042016d23e7a9b1 sha1 4add0e2411c0940d5c30dd408677085427f80aa9 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II (Japan)"
+	description "Star Wars - Rogue Squadron II (Japan)"
+	rom ( name "Star Wars - Rogue Squadron II (Japan).iso" size 1459978240 crc eb88ddf3 md5 64c27983a9e05d05f980a9f5ce256358 sha1 60217e5b1f87148d2f34b7b58a9f1cad3fa62453 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron II (JP) - sutauozu rogu sukodoron+II"
+	description "Star Wars - Rogue Squadron II (JP) - sutauozu rogu sukodoron+II"
+	rom ( name "Star Wars - Rogue Squadron II (JP).iso" size 1459978240 crc eb88ddf3 md5 64c27983a9e05d05f980a9f5ce256358 sha1 60217e5b1f87148d2f34b7b58a9f1cad3fa62453 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (US)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (US)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (US).iso" size 1459978240 crc 1621d87a md5 236088fbf738089f5af43cafc360720a sha1 5f9596e1819cd2574a6846562dd67da0e08b81ec )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (USA)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (USA)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike - Limited Edition Preview Disc (USA).iso" size 1459978240 crc 1621d87a md5 236088fbf738089f5af43cafc360720a sha1 5f9596e1819cd2574a6846562dd67da0e08b81ec )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (DE)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (DE)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (DE).iso" size 1459978240 crc 220c4ea3 md5 47625f0b0b4b0a5f9ae2308144e32465 sha1 c0066152153800d73271f165049c2b45fb95e6a8 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (Demo) (EU)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (Demo) (EU)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (Demo) (EU).iso" size 1459978240 crc 3657ba07 md5 7ae2720a0984e16489e2f049c224fe71 sha1 b47bc2a3bbcaa56b680d9efc2e2b32812ae42e04 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (EU)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (EU)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (EU).iso" size 1459978240 crc 54ca6364 md5 4e2e2806303314bda2cd989a86358653 sha1 f3134c1238fe86f343d2e8ac992d4e2f8ac09294 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 54ca6364 md5 4e2e2806303314bda2cd989a86358653 sha1 f3134c1238fe86f343d2e8ac992d4e2f8ac09294 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It) (Demo)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It) (Demo)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (Europe) (En,Fr,De,Es,It) (Demo).iso" size 1459978240 crc 3657ba07 md5 7ae2720a0984e16489e2f049c224fe71 sha1 b47bc2a3bbcaa56b680d9efc2e2b32812ae42e04 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (FR)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (FR)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (FR).iso" size 1459978240 crc e4438bb0 md5 955f45a43abf1017b6ddf5b1a4e3ed4e sha1 c474c29c9b001d096b3f90b90581d2f57478c939 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (France)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (France)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (France).iso" size 1459978240 crc e4438bb0 md5 955f45a43abf1017b6ddf5b1a4e3ed4e sha1 c474c29c9b001d096b3f90b90581d2f57478c939 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (Germany)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (Germany)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (Germany).iso" size 1459978240 crc 220c4ea3 md5 47625f0b0b4b0a5f9ae2308144e32465 sha1 c0066152153800d73271f165049c2b45fb95e6a8 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (US)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (US)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (US).iso" size 1459978240 crc 040a6155 md5 a7e88ee9209080785c4923b571cc1936 sha1 4d648ddcc354e9ab15c51530501a4ca2ee087fb7 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III - Rebel Strike (USA)"
+	description "Star Wars - Rogue Squadron III - Rebel Strike (USA)"
+	rom ( name "Star Wars - Rogue Squadron III - Rebel Strike (USA).iso" size 1459978240 crc 040a6155 md5 a7e88ee9209080785c4923b571cc1936 sha1 4d648ddcc354e9ab15c51530501a4ca2ee087fb7 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III (Japan)"
+	description "Star Wars - Rogue Squadron III (Japan)"
+	rom ( name "Star Wars - Rogue Squadron III (Japan).iso" size 1459978240 crc 496a6823 md5 54c100435255fbf2e94b2fa0446a7c62 sha1 2e361177b858ac0a84b4fc7a2b01ad7377c1b8f8 )
+)
+
+game (
+	name "Star Wars - Rogue Squadron III (JP) - sutauozu+rogu+sukodoron+III"
+	description "Star Wars - Rogue Squadron III (JP) - sutauozu+rogu+sukodoron+III"
+	rom ( name "Star Wars - Rogue Squadron III (JP).iso" size 1459978240 crc 496a6823 md5 54c100435255fbf2e94b2fa0446a7c62 sha1 2e361177b858ac0a84b4fc7a2b01ad7377c1b8f8 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (DE)"
+	description "Star Wars - The Clone Wars (DE)"
+	rom ( name "Star Wars - The Clone Wars (DE).iso" size 1459978240 crc 0a8f3265 md5 07d63b09ccfa46b6e07559287af41bbb sha1 831cf8d19424bee8328d509f6a39decccc276d27 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (EU)"
+	description "Star Wars - The Clone Wars (EU)"
+	rom ( name "Star Wars - The Clone Wars (EU).iso" size 1459978240 crc 5350b404 md5 dd55d3ead90afe85f63b8c40fe8761bb sha1 f79a0f6ae48b210bf5d5e5c6a2a6e9b18042c33f )
+)
+
+game (
+	name "Star Wars - The Clone Wars (Europe)"
+	description "Star Wars - The Clone Wars (Europe)"
+	rom ( name "Star Wars - The Clone Wars (Europe).iso" size 1459978240 crc 5350b404 md5 dd55d3ead90afe85f63b8c40fe8761bb sha1 f79a0f6ae48b210bf5d5e5c6a2a6e9b18042c33f )
+)
+
+game (
+	name "Star Wars - The Clone Wars (FR)"
+	description "Star Wars - The Clone Wars (FR)"
+	rom ( name "Star Wars - The Clone Wars (FR).iso" size 1459978240 crc 44621664 md5 bf06942c75ce10b35a7bde61691dc3ca sha1 e09301c17d0801102dc3b3d2ac4b2be8f564ca4e )
+)
+
+game (
+	name "Star Wars - The Clone Wars (France)"
+	description "Star Wars - The Clone Wars (France)"
+	rom ( name "Star Wars - The Clone Wars (France).iso" size 1459978240 crc 44621664 md5 bf06942c75ce10b35a7bde61691dc3ca sha1 e09301c17d0801102dc3b3d2ac4b2be8f564ca4e )
+)
+
+game (
+	name "Star Wars - The Clone Wars (Germany)"
+	description "Star Wars - The Clone Wars (Germany)"
+	rom ( name "Star Wars - The Clone Wars (Germany).iso" size 1459978240 crc 0a8f3265 md5 07d63b09ccfa46b6e07559287af41bbb sha1 831cf8d19424bee8328d509f6a39decccc276d27 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (Japan)"
+	description "Star Wars - The Clone Wars (Japan)"
+	rom ( name "Star Wars - The Clone Wars (Japan).iso" size 1459978240 crc 24a75a9e md5 40c2bc36599f6ebf07c7750d868f7282 sha1 2d46067aa1cc64c8964b7f2087112d6002d7d627 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (JP) - sutauozu+kuronZhan Zheng"
+	description "Star Wars - The Clone Wars (JP) - sutauozu+kuronZhan Zheng"
+	rom ( name "Star Wars - The Clone Wars (JP).iso" size 1459978240 crc 24a75a9e md5 40c2bc36599f6ebf07c7750d868f7282 sha1 2d46067aa1cc64c8964b7f2087112d6002d7d627 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (US)"
+	description "Star Wars - The Clone Wars (US)"
+	rom ( name "Star Wars - The Clone Wars (US).iso" size 1459978240 crc 8d24a2c1 md5 f9025a00b50cb231c27373cf297b8799 sha1 99c6007b4f1ccdceeef03fe0a1f6631cd80d48b5 )
+)
+
+game (
+	name "Star Wars - The Clone Wars (USA)"
+	description "Star Wars - The Clone Wars (USA)"
+	rom ( name "Star Wars - The Clone Wars (USA).iso" size 1459978240 crc 8d24a2c1 md5 f9025a00b50cb231c27373cf297b8799 sha1 99c6007b4f1ccdceeef03fe0a1f6631cd80d48b5 )
+)
+
+game (
+	name "Starsky & Hutch (EU)"
+	description "Starsky & Hutch (EU)"
+	rom ( name "Starsky & Hutch (EU).iso" size 1459978240 crc 636cc433 md5 41a62d8e258b124b3d51a75d4adf1df5 sha1 9c4de7d2ac5dc7a13f60bf5aea50c8b0f6faa5a9 )
+)
+
+game (
+	name "Starsky & Hutch (Europe) (En,Fr,De,Es,It)"
+	description "Starsky & Hutch (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Starsky & Hutch (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 636cc433 md5 41a62d8e258b124b3d51a75d4adf1df5 sha1 9c4de7d2ac5dc7a13f60bf5aea50c8b0f6faa5a9 )
+)
+
+game (
+	name "Starsky & Hutch (US)"
+	description "Starsky & Hutch (US)"
+	rom ( name "Starsky & Hutch (US).iso" size 1459978240 crc 9295ec63 md5 c242016a80d6edbd6c04a67f315ee493 sha1 6da4e3a99d73ebe1ba7a5eebd02097facad6a898 )
+)
+
+game (
+	name "Starsky & Hutch (USA)"
+	description "Starsky & Hutch (USA)"
+	rom ( name "Starsky & Hutch (USA).iso" size 1459978240 crc 9295ec63 md5 c242016a80d6edbd6c04a67f315ee493 sha1 6da4e3a99d73ebe1ba7a5eebd02097facad6a898 )
+)
+
+game (
+	name "Street Hoops (US)"
+	description "Street Hoops (US)"
+	rom ( name "Street Hoops (US).iso" size 1459978240 crc 7b36751e md5 44ed8269e1850bbe099b5b7911dcdfba sha1 fa8b2af2a52a48892bb526014ff3d8db2b79f792 )
+)
+
+game (
+	name "Street Hoops (USA)"
+	description "Street Hoops (USA)"
+	rom ( name "Street Hoops (USA).iso" size 1459978240 crc 7b36751e md5 44ed8269e1850bbe099b5b7911dcdfba sha1 fa8b2af2a52a48892bb526014ff3d8db2b79f792 )
+)
+
+game (
+	name "Strike Force Bowling (US)"
+	description "Strike Force Bowling (US)"
+	rom ( name "Strike Force Bowling (US).iso" size 1459978240 crc 64629bfd md5 592aa62ab70f087df705ffed4b621454 sha1 52543d2f581371f62fb2dacce73a7be24a73b1d5 )
+)
+
+game (
+	name "Strike Force Bowling (USA)"
+	description "Strike Force Bowling (USA)"
+	rom ( name "Strike Force Bowling (USA).iso" size 1459978240 crc 64629bfd md5 592aa62ab70f087df705ffed4b621454 sha1 52543d2f581371f62fb2dacce73a7be24a73b1d5 )
+)
+
+game (
+	name "Sum of All Fears, The (EU)"
+	description "Sum of All Fears, The (EU)"
+	rom ( name "Sum of All Fears, The (EU).iso" size 1459978240 crc 796a1ab7 md5 c644711b75776f2e2c1e02987a568d5d sha1 0175fe42683b30d0b5daabd55401dbb22dae311f )
+)
+
+game (
+	name "Sum of All Fears, The (Europe) (En,Fr,De,Es,It)"
+	description "Sum of All Fears, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sum of All Fears, The (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 796a1ab7 md5 c644711b75776f2e2c1e02987a568d5d sha1 0175fe42683b30d0b5daabd55401dbb22dae311f )
+)
+
+game (
+	name "Sum of All Fears, The (US)"
+	description "Sum of All Fears, The (US)"
+	rom ( name "Sum of All Fears, The (US).iso" size 1459978240 crc bd2704b3 md5 7d8d67653e6eb85e8575948c93cf2b1c sha1 c7214e84362f41983703328a187f4e056177da37 )
+)
+
+game (
+	name "Sum of All Fears, The (USA)"
+	description "Sum of All Fears, The (USA)"
+	rom ( name "Sum of All Fears, The (USA).iso" size 1459978240 crc bd2704b3 md5 7d8d67653e6eb85e8575948c93cf2b1c sha1 c7214e84362f41983703328a187f4e056177da37 )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (DE)"
+	description "Summoner - A Goddess Reborn (DE)"
+	rom ( name "Summoner - A Goddess Reborn (DE).iso" size 1459978240 crc 53939196 md5 9aa169191026034c95f807447236a25b sha1 e6b325bc8faabf14ae9d4d2a7fedaa4a9084e251 )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (EU)"
+	description "Summoner - A Goddess Reborn (EU)"
+	rom ( name "Summoner - A Goddess Reborn (EU).iso" size 1459978240 crc f4b5818e md5 56be1ff99350a84fe52476e8704e8fab sha1 f8ec66bafb880d5d34c09e7d78e0e52a964a71c7 )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (Europe)"
+	description "Summoner - A Goddess Reborn (Europe)"
+	rom ( name "Summoner - A Goddess Reborn (Europe).iso" size 1459978240 crc f4b5818e md5 56be1ff99350a84fe52476e8704e8fab sha1 f8ec66bafb880d5d34c09e7d78e0e52a964a71c7 )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (Germany)"
+	description "Summoner - A Goddess Reborn (Germany)"
+	rom ( name "Summoner - A Goddess Reborn (Germany).iso" size 1459978240 crc 53939196 md5 9aa169191026034c95f807447236a25b sha1 e6b325bc8faabf14ae9d4d2a7fedaa4a9084e251 )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (US)"
+	description "Summoner - A Goddess Reborn (US)"
+	rom ( name "Summoner - A Goddess Reborn (US).iso" size 1459978240 crc 72b8b6f4 md5 8067dc66f5da7126a7777c1a3beb616e sha1 8bcd66fa68b87e8ea28c6909508f3d378911969a )
+)
+
+game (
+	name "Summoner - A Goddess Reborn (USA)"
+	description "Summoner - A Goddess Reborn (USA)"
+	rom ( name "Summoner - A Goddess Reborn (USA).iso" size 1459978240 crc 72b8b6f4 md5 8067dc66f5da7126a7777c1a3beb616e sha1 8bcd66fa68b87e8ea28c6909508f3d378911969a )
+)
+
+game (
+	name "Super Bubble Pop (US)"
+	description "Super Bubble Pop (US)"
+	rom ( name "Super Bubble Pop (US).iso" size 1459978240 crc 3e57a93c md5 0daa6547ae3ad0fa28f0ca2b04d6a909 sha1 b9a2c37860a1f6536bb47c8cb67b38e94c0519ea )
+)
+
+game (
+	name "Super Bubble Pop (USA)"
+	description "Super Bubble Pop (USA)"
+	rom ( name "Super Bubble Pop (USA).iso" size 1459978240 crc 3e57a93c md5 0daa6547ae3ad0fa28f0ca2b04d6a909 sha1 b9a2c37860a1f6536bb47c8cb67b38e94c0519ea )
+)
+
+game (
+	name "Super Bust-A-Move All Stars (EU)"
+	description "Super Bust-A-Move All Stars (EU)"
+	rom ( name "Super Bust-A-Move All Stars (EU).iso" size 1459978240 crc 2bb79fa6 md5 928b003d30952ef6bf0f6f496413f3c3 sha1 1e5c87fb04ab982362e177b988206069d6e04829 )
+)
+
+game (
+	name "Super Bust-A-Move All Stars (Europe) (En,Fr,De,Es,It)"
+	description "Super Bust-A-Move All Stars (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Bust-A-Move All Stars (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 2bb79fa6 md5 928b003d30952ef6bf0f6f496413f3c3 sha1 1e5c87fb04ab982362e177b988206069d6e04829 )
+)
+
+game (
+	name "Super Mario Stadium - Miracle Baseball (Japan)"
+	description "Super Mario Stadium - Miracle Baseball (Japan)"
+	rom ( name "Super Mario Stadium - Miracle Baseball (Japan).iso" size 1459978240 crc 81b98d0b md5 19d70d6236f2fef165eb7d276fbf36e4 sha1 cfae0a787c7a0025c923886c57de522396039b2a )
+)
+
+game (
+	name "Super Mario Stadium - Miracle Baseball (JP) - supamariosutaziamu+mirakurubesuboru"
+	description "Super Mario Stadium - Miracle Baseball (JP) - supamariosutaziamu+mirakurubesuboru"
+	rom ( name "Super Mario Stadium - Miracle Baseball (JP).iso" size 1459978240 crc 81b98d0b md5 19d70d6236f2fef165eb7d276fbf36e4 sha1 cfae0a787c7a0025c923886c57de522396039b2a )
+)
+
+game (
+	name "Super Mario Strikers (Japan)"
+	description "Super Mario Strikers (Japan)"
+	rom ( name "Super Mario Strikers (Japan).iso" size 1459978240 crc 1737fce3 md5 c299463a1db65e7aa29aaeecf203e808 sha1 0e5e42b290b254ebf134edf3bc145b9c386da7d7 )
+)
+
+game (
+	name "Super Mario Strikers (JP) - supamario+sutoraikazu"
+	description "Super Mario Strikers (JP) - supamario+sutoraikazu"
+	rom ( name "Super Mario Strikers (JP).iso" size 1459978240 crc 1737fce3 md5 c299463a1db65e7aa29aaeecf203e808 sha1 0e5e42b290b254ebf134edf3bc145b9c386da7d7 )
+)
+
+game (
+	name "Super Mario Strikers (US)"
+	description "Super Mario Strikers (US)"
+	rom ( name "Super Mario Strikers (US).iso" size 1459978240 crc 2ec051cf md5 8788cfdf60258c975fcb8632eb295f58 sha1 c29918ab83fa01694fdaa444efdc4bf2dc89c4f8 )
+)
+
+game (
+	name "Super Mario Strikers (USA)"
+	description "Super Mario Strikers (USA)"
+	rom ( name "Super Mario Strikers (USA).iso" size 1459978240 crc 2ec051cf md5 8788cfdf60258c975fcb8632eb295f58 sha1 c29918ab83fa01694fdaa444efdc4bf2dc89c4f8 )
+)
+
+game (
+	name "Super Mario Sunshine (EU)"
+	description "Super Mario Sunshine (EU)"
+	rom ( name "Super Mario Sunshine (EU).iso" size 1459978240 crc 4c1d3641 md5 72c4860d8555d5e790628e348abc244d sha1 26798080de5e5c0f154915324c5c7dd6aa36056a )
+)
+
+game (
+	name "Super Mario Sunshine (Europe) (En,Fr,De,Es,It)"
+	description "Super Mario Sunshine (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Mario Sunshine (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 4c1d3641 md5 72c4860d8555d5e790628e348abc244d sha1 26798080de5e5c0f154915324c5c7dd6aa36056a )
+)
+
+game (
+	name "Super Mario Sunshine (Japan)"
+	description "Super Mario Sunshine (Japan)"
+	rom ( name "Super Mario Sunshine (Japan).iso" size 1459978240 crc c3b17583 md5 3b07a4bb22db926b177e207f9d7f0d87 sha1 dde76117189ff8ca5922cb0ec3f175164a7f9780 )
+)
+
+game (
+	name "Super Mario Sunshine (JP) - supamariosansiyain"
+	description "Super Mario Sunshine (JP) - supamariosansiyain"
+	rom ( name "Super Mario Sunshine (JP).iso" size 1459978240 crc c3b17583 md5 3b07a4bb22db926b177e207f9d7f0d87 sha1 dde76117189ff8ca5922cb0ec3f175164a7f9780 )
+)
+
+game (
+	name "Super Mario Sunshine (Korea)"
+	description "Super Mario Sunshine (Korea)"
+	rom ( name "Super Mario Sunshine (Korea).iso" size 1459978240 crc 1e1cd796 md5 1f8d7bc062ab3c532a76811fbcceb229 sha1 b4ea51d4f5c113d7d914ac939f9dd96405dbd773 )
+)
+
+game (
+	name "Super Mario Sunshine (KR) - syupeo+mario+seonsyain"
+	description "Super Mario Sunshine (KR) - syupeo+mario+seonsyain"
+	rom ( name "Super Mario Sunshine (KR).iso" size 1459978240 crc 1e1cd796 md5 1f8d7bc062ab3c532a76811fbcceb229 sha1 b4ea51d4f5c113d7d914ac939f9dd96405dbd773 )
+)
+
+game (
+	name "Super Mario Sunshine (US)"
+	description "Super Mario Sunshine (US)"
+	rom ( name "Super Mario Sunshine (US).iso" size 1459978240 crc 771ad977 md5 0c6d2edae9fdf40dfc410ff1623e4119 sha1 8d094f2c5c112aba9660f0478b16c7f2caf63cbf )
+)
+
+game (
+	name "Super Mario Sunshine (USA)"
+	description "Super Mario Sunshine (USA)"
+	rom ( name "Super Mario Sunshine (USA).iso" size 1459978240 crc 771ad977 md5 0c6d2edae9fdf40dfc410ff1623e4119 sha1 8d094f2c5c112aba9660f0478b16c7f2caf63cbf )
+)
+
+game (
+	name "Super Monkey Ball (EU)"
+	description "Super Monkey Ball (EU)"
+	rom ( name "Super Monkey Ball (EU).iso" size 1459978240 crc 8b7a5754 md5 5cf514fe9e3d1b0d601c1189af1b844f sha1 f0e74c7671d023df285bd143690d94a2f4e168ae )
+)
+
+game (
+	name "Super Monkey Ball (Europe) (En,Fr,De,Es,It)"
+	description "Super Monkey Ball (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Monkey Ball (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 8b7a5754 md5 5cf514fe9e3d1b0d601c1189af1b844f sha1 f0e74c7671d023df285bd143690d94a2f4e168ae )
+)
+
+game (
+	name "Super Monkey Ball (Japan)"
+	description "Super Monkey Ball (Japan)"
+	rom ( name "Super Monkey Ball (Japan).iso" size 1459978240 crc d35205b7 md5 527f5186b24a3f1f04f5f12c4df560c5 sha1 ac58d44e2f5282eb066bc0b4e4c041b736f924df )
+)
+
+game (
+	name "Super Monkey Ball (JP) - supamonkiboru"
+	description "Super Monkey Ball (JP) - supamonkiboru"
+	rom ( name "Super Monkey Ball (JP).iso" size 1459978240 crc d35205b7 md5 527f5186b24a3f1f04f5f12c4df560c5 sha1 ac58d44e2f5282eb066bc0b4e4c041b736f924df )
+)
+
+game (
+	name "Super Monkey Ball (US)"
+	description "Super Monkey Ball (US)"
+	rom ( name "Super Monkey Ball (US).iso" size 1459978240 crc 7726c879 md5 391b8e620d8d924f150dc40343ced8a5 sha1 2cca02879db51ca2850949c7b2349cf470607cf5 )
+)
+
+game (
+	name "Super Monkey Ball (USA)"
+	description "Super Monkey Ball (USA)"
+	rom ( name "Super Monkey Ball (USA).iso" size 1459978240 crc 7726c879 md5 391b8e620d8d924f150dc40343ced8a5 sha1 2cca02879db51ca2850949c7b2349cf470607cf5 )
+)
+
+game (
+	name "Super Monkey Ball 2 (EU)"
+	description "Super Monkey Ball 2 (EU)"
+	rom ( name "Super Monkey Ball 2 (EU).iso" size 1459978240 crc 2f726b39 md5 4dfd33540b3b6c7ae742a9e4c1ba3692 sha1 eaec3ebb485dfca3ae6966d44c5bb0c015a49fff )
+)
+
+game (
+	name "Super Monkey Ball 2 (Europe) (En,Fr,De,Es,It)"
+	description "Super Monkey Ball 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Monkey Ball 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 2f726b39 md5 4dfd33540b3b6c7ae742a9e4c1ba3692 sha1 eaec3ebb485dfca3ae6966d44c5bb0c015a49fff )
+)
+
+game (
+	name "Super Monkey Ball 2 (Japan)"
+	description "Super Monkey Ball 2 (Japan)"
+	rom ( name "Super Monkey Ball 2 (Japan).iso" size 1459978240 crc eef3b2d8 md5 bdda137a7a73b0214c61deb14288de70 sha1 579bc2001c57009aac374e17ba9a5a9b36928506 )
+)
+
+game (
+	name "Super Monkey Ball 2 (JP) - supamonkiboru2"
+	description "Super Monkey Ball 2 (JP) - supamonkiboru2"
+	rom ( name "Super Monkey Ball 2 (JP).iso" size 1459978240 crc eef3b2d8 md5 bdda137a7a73b0214c61deb14288de70 sha1 579bc2001c57009aac374e17ba9a5a9b36928506 )
+)
+
+game (
+	name "Super Monkey Ball 2 (US)"
+	description "Super Monkey Ball 2 (US)"
+	rom ( name "Super Monkey Ball 2 (US).iso" size 1459978240 crc c54e40e8 md5 29dd871cf4a00b2455c9d03e9328e7bd sha1 36902d42ee1ecea8b2144f3aef2c0fc3a62b71da )
+)
+
+game (
+	name "Super Monkey Ball 2 (USA)"
+	description "Super Monkey Ball 2 (USA)"
+	rom ( name "Super Monkey Ball 2 (USA).iso" size 1459978240 crc c54e40e8 md5 29dd871cf4a00b2455c9d03e9328e7bd sha1 36902d42ee1ecea8b2144f3aef2c0fc3a62b71da )
+)
+
+game (
+	name "Super Monkey Ball Adventure (EU)"
+	description "Super Monkey Ball Adventure (EU)"
+	rom ( name "Super Monkey Ball Adventure (EU).iso" size 1459978240 crc f23f2654 md5 cf490be25b5fc30ba6f056ca3aa14645 sha1 11c5a5a7a1ed9f0e93e11a8390912fe44f19c64b )
+)
+
+game (
+	name "Super Monkey Ball Adventure (Europe) (En,Fr,De,Es,It)"
+	description "Super Monkey Ball Adventure (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Monkey Ball Adventure (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f23f2654 md5 cf490be25b5fc30ba6f056ca3aa14645 sha1 11c5a5a7a1ed9f0e93e11a8390912fe44f19c64b )
+)
+
+game (
+	name "Super Monkey Ball Adventure (US)"
+	description "Super Monkey Ball Adventure (US)"
+	rom ( name "Super Monkey Ball Adventure (US).iso" size 1459978240 crc 29e4ca79 md5 90322c7821baf92bee9ab54b0a7d8f47 sha1 f93aafe7a0e7f20889087a467673c324a305dc59 )
+)
+
+game (
+	name "Super Monkey Ball Adventure (USA)"
+	description "Super Monkey Ball Adventure (USA)"
+	rom ( name "Super Monkey Ball Adventure (USA).iso" size 1459978240 crc 29e4ca79 md5 90322c7821baf92bee9ab54b0a7d8f47 sha1 f93aafe7a0e7f20889087a467673c324a305dc59 )
+)
+
+game (
+	name "Super Puzzle Bobble All Stars (Japan)"
+	description "Super Puzzle Bobble All Stars (Japan)"
+	rom ( name "Super Puzzle Bobble All Stars (Japan).iso" size 1459978240 crc 32d6f96a md5 423cc81f0e70a267c3d70cb7eaaf3cad sha1 05603b55ddf2b5212618a21777b6b7960e6843b2 )
+)
+
+game (
+	name "Super Puzzle Bobble All Stars (JP) - supapazuruboburu+orusutazu"
+	description "Super Puzzle Bobble All Stars (JP) - supapazuruboburu+orusutazu"
+	rom ( name "Super Puzzle Bobble All Stars (JP).iso" size 1459978240 crc 32d6f96a md5 423cc81f0e70a267c3d70cb7eaaf3cad sha1 05603b55ddf2b5212618a21777b6b7960e6843b2 )
+)
+
+game (
+	name "Super Robot Taisen GC (Japan)"
+	description "Super Robot Taisen GC (Japan)"
+	rom ( name "Super Robot Taisen GC (Japan).iso" size 1459978240 crc 0cc8f2bf md5 e7094d70e1df2cf104b7aa590945aa52 sha1 b200ff936716c2b096a0e3895798c861a2fc5254 )
+)
+
+game (
+	name "Super Robot Taisen GC (JP) - suparobotutoDa Zhan GC"
+	description "Super Robot Taisen GC (JP) - suparobotutoDa Zhan GC"
+	rom ( name "Super Robot Taisen GC (JP).iso" size 1459978240 crc 0cc8f2bf md5 e7094d70e1df2cf104b7aa590945aa52 sha1 b200ff936716c2b096a0e3895798c861a2fc5254 )
+)
+
+game (
+	name "Super Smash Bros. Melee (EU)"
+	description "Super Smash Bros. Melee (EU)"
+	rom ( name "Super Smash Bros. Melee (EU).iso" size 1459978240 crc 0fd01424 md5 5e118fc2d85350b7b092d0192bfb0f1a sha1 d0a925866379c546ceb739eeb780d011383cb07c )
+)
+
+game (
+	name "Super Smash Bros. Melee (Europe) (En,Fr,De,Es,It)"
+	description "Super Smash Bros. Melee (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Smash Bros. Melee (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 0fd01424 md5 5e118fc2d85350b7b092d0192bfb0f1a sha1 d0a925866379c546ceb739eeb780d011383cb07c )
+)
+
+game (
+	name "Super Smash Bros. Melee (Player's Choice) (US)"
+	description "Super Smash Bros. Melee (Player's Choice) (US)"
+	rom ( name "Super Smash Bros. Melee (Player's Choice) (US) - [v1.02].iso" size 1459978240 crc 5365c84b md5 0e63d4223b01d9aba596259dc155a174 sha1 d4e70c064cc714ba8400a849cf299dbd1aa326fc )
+)
+
+game (
+	name "Super Smash Bros. Melee (US)"
+	description "Super Smash Bros. Melee (US)"
+	rom ( name "Super Smash Bros. Melee (US) - [v1.00].iso" size 1459978240 crc 873ddd72 md5 3a62f8d10fd210d4928ad37e3816e33c sha1 5ab1553a941307bb949020fd582b68aabebecb30 )
+)
+
+game (
+	name "Super Smash Bros. Melee (USA) (En,Ja) (v1.00)"
+	description "Super Smash Bros. Melee (USA) (En,Ja) (v1.00)"
+	rom ( name "Super Smash Bros. Melee (USA) (En,Ja) (v1.00).iso" size 1459978240 crc 873ddd72 md5 3a62f8d10fd210d4928ad37e3816e33c sha1 5ab1553a941307bb949020fd582b68aabebecb30 )
+)
+
+game (
+	name "Super Smash Bros. Melee (USA) (En,Ja) (v1.01)"
+	description "Super Smash Bros. Melee (USA) (En,Ja) (v1.01)"
+	rom ( name "Super Smash Bros. Melee (USA) (En,Ja) (v1.01).iso" size 1459978240 crc 85175e75 md5 67136bd167b471e0ad72e98d10cf4356 sha1 5ecab83cd72c0ff515d750280f92713f19fa46f1 )
+)
+
+game (
+	name "Super Smash Bros. Melee (USA) (En,Ja) (v1.02)"
+	description "Super Smash Bros. Melee (USA) (En,Ja) (v1.02)"
+	rom ( name "Super Smash Bros. Melee (USA) (En,Ja) (v1.02).iso" size 1459978240 crc 5365c84b md5 0e63d4223b01d9aba596259dc155a174 sha1 d4e70c064cc714ba8400a849cf299dbd1aa326fc )
+)
+
+game (
+	name "Superman - Shadow of Apokolips (EU)"
+	description "Superman - Shadow of Apokolips (EU)"
+	rom ( name "Superman - Shadow of Apokolips (EU).iso" size 1459978240 crc 9c5e9810 md5 208722aa0338c2e540a0bbcda6053bf7 sha1 fb6edef0f9fc916742ec08ad05d09e2ffe4774a3 )
+)
+
+game (
+	name "Superman - Shadow of Apokolips (Europe) (En,Fr,De,Es,It)"
+	description "Superman - Shadow of Apokolips (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Superman - Shadow of Apokolips (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9c5e9810 md5 208722aa0338c2e540a0bbcda6053bf7 sha1 fb6edef0f9fc916742ec08ad05d09e2ffe4774a3 )
+)
+
+game (
+	name "Superman - Shadow of Apokolips (US)"
+	description "Superman - Shadow of Apokolips (US)"
+	rom ( name "Superman - Shadow of Apokolips (US).iso" size 1459978240 crc 5b91235c md5 3c8d06224e42e584465b90ea7bbda090 sha1 291f546cf059f5cddfa3a465a4f6c9ab56360424 )
+)
+
+game (
+	name "Superman - Shadow of Apokolips (USA)"
+	description "Superman - Shadow of Apokolips (USA)"
+	rom ( name "Superman - Shadow of Apokolips (USA).iso" size 1459978240 crc 5b91235c md5 3c8d06224e42e584465b90ea7bbda090 sha1 291f546cf059f5cddfa3a465a4f6c9ab56360424 )
+)
+
+game (
+	name "Surf's Up (US)"
+	description "Surf's Up (US)"
+	rom ( name "Surf's Up (US).iso" size 1459978240 crc 6bbeb345 md5 800ee6b1e25870455150f384fb000064 sha1 35dfd9a73b1fab0084b955ea15771eea3076e802 )
+)
+
+game (
+	name "Surf's Up (USA) (En,Fr,Es)"
+	description "Surf's Up (USA) (En,Fr,Es)"
+	rom ( name "Surf's Up (USA) (En,Fr,Es).iso" size 1459978240 crc 6bbeb345 md5 800ee6b1e25870455150f384fb000064 sha1 35dfd9a73b1fab0084b955ea15771eea3076e802 )
+)
+
+game (
+	name "Swingerz Golf (US)"
+	description "Swingerz Golf (US)"
+	rom ( name "Swingerz Golf (US).iso" size 1459978240 crc 92bdd171 md5 5f34224d2a93070e7c9d68b819610f4d sha1 728cebaa52ee4a75db418d1ae1b4fa0c515a0d1a )
+)
+
+game (
+	name "Swingerz Golf (USA)"
+	description "Swingerz Golf (USA)"
+	rom ( name "Swingerz Golf (USA).iso" size 1459978240 crc 92bdd171 md5 5f34224d2a93070e7c9d68b819610f4d sha1 728cebaa52ee4a75db418d1ae1b4fa0c515a0d1a )
+)
+
+game (
+	name "SX Superstar (EU)"
+	description "SX Superstar (EU)"
+	rom ( name "SX Superstar (EU).iso" size 1459978240 crc 620f8c2d md5 7b9dbf456858458f45687ab15f95ff16 sha1 5af235c4143596f1a0353ace32a6f48cae8dbfb3 )
+)
+
+game (
+	name "SX Superstar (Europe) (En,Fr,De,Es)"
+	description "SX Superstar (Europe) (En,Fr,De,Es)"
+	rom ( name "SX Superstar (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 620f8c2d md5 7b9dbf456858458f45687ab15f95ff16 sha1 5af235c4143596f1a0353ace32a6f48cae8dbfb3 )
+)
+
+game (
+	name "SX Superstar (US)"
+	description "SX Superstar (US)"
+	rom ( name "SX Superstar (US).iso" size 1459978240 crc be6371cb md5 730b0308cd2f94302130f449202bdaeb sha1 7a9635030d77b193ab901cddf837e9b71fd2a1ce )
+)
+
+game (
+	name "SX Superstar (USA)"
+	description "SX Superstar (USA)"
+	rom ( name "SX Superstar (USA).iso" size 1459978240 crc be6371cb md5 730b0308cd2f94302130f449202bdaeb sha1 7a9635030d77b193ab901cddf837e9b71fd2a1ce )
+)
+
+game (
+	name "Tak & Le Pouvoir de Juju (FR)"
+	description "Tak & Le Pouvoir de Juju (FR)"
+	rom ( name "Tak & Le Pouvoir de Juju (FR).iso" size 1459978240 crc 459e843b md5 bd3b8bb5a61fa602216a12f98716438b sha1 7945e4e1e7ad03614498405162f673b27c995e58 )
+)
+
+game (
+	name "Tak & Le Pouvoir de Juju (France)"
+	description "Tak & Le Pouvoir de Juju (France)"
+	rom ( name "Tak & Le Pouvoir de Juju (France).iso" size 1459978240 crc 459e843b md5 bd3b8bb5a61fa602216a12f98716438b sha1 7945e4e1e7ad03614498405162f673b27c995e58 )
+)
+
+game (
+	name "Tak and the Power of Juju (Europe)"
+	description "Tak and the Power of Juju (Europe)"
+	rom ( name "Tak and the Power of Juju (Europe).iso" size 1459978240 crc b36e831e md5 5e2faa6803cf221f587d6c11d5e325cc sha1 8b9f2c72da5afe797f427bbe71185a14bcef0ba9 )
+)
+
+game (
+	name "Tak and the Power of Juju (GB)"
+	description "Tak and the Power of Juju (GB)"
+	rom ( name "Tak and the Power of Juju (GB).iso" size 1459978240 crc b36e831e md5 5e2faa6803cf221f587d6c11d5e325cc sha1 8b9f2c72da5afe797f427bbe71185a14bcef0ba9 )
+)
+
+game (
+	name "Tak and the Power of Juju (US)"
+	description "Tak and the Power of Juju (US)"
+	rom ( name "Tak and the Power of Juju (US).iso" size 1459978240 crc 20753d97 md5 62c2605ce1c60b37321a17758eccb289 sha1 ac9b16004e7a8eb87e5acebb5c095541ace72e18 )
+)
+
+game (
+	name "Tak and the Power of Juju (USA)"
+	description "Tak and the Power of Juju (USA)"
+	rom ( name "Tak and the Power of Juju (USA).iso" size 1459978240 crc 20753d97 md5 62c2605ce1c60b37321a17758eccb289 sha1 ac9b16004e7a8eb87e5acebb5c095541ace72e18 )
+)
+
+game (
+	name "Tak und die Macht des Juju (DE)"
+	description "Tak und die Macht des Juju (DE)"
+	rom ( name "Tak und die Macht des Juju (DE).iso" size 1459978240 crc b94b1d88 md5 ab59ed481ce1514b38f487a6c84a3a5c sha1 dde24e40f49c0d878b9b8174bba70a2355d3a4e2 )
+)
+
+game (
+	name "Tak und die Macht des Juju (Germany)"
+	description "Tak und die Macht des Juju (Germany)"
+	rom ( name "Tak und die Macht des Juju (Germany).iso" size 1459978240 crc b94b1d88 md5 ab59ed481ce1514b38f487a6c84a3a5c sha1 dde24e40f49c0d878b9b8174bba70a2355d3a4e2 )
+)
+
+game (
+	name "Tales of Symphonia (DE)"
+	description "Tales of Symphonia (DE)"
+	rom ( name "Tales of Symphonia (DE) - (Disc 1 of 2).iso" size 1459978240 crc 59b0e2d2 md5 fc4caeaa8bafba662abb400de9c97579 sha1 38ac71a99713119025d5b80dadaa5cf710b73830 )
+)
+
+game (
+	name "Tales of Symphonia (ES)"
+	description "Tales of Symphonia (ES)"
+	rom ( name "Tales of Symphonia (ES) - (Disc 1 of 2).iso" size 1459978240 crc b0817701 md5 20d47d6b39446c64d877439b372d2e44 sha1 c5b22d4feab05f54a50c5e7bd22ca78525d01bf2 )
+)
+
+game (
+	name "Tales of Symphonia (Europe) (Disc 1)"
+	description "Tales of Symphonia (Europe) (Disc 1)"
+	rom ( name "Tales of Symphonia (Europe) (Disc 1).iso" size 1459978240 crc 6ba54b37 md5 a797655b74d8218d5f0c8229f393ab60 sha1 7d8f0e31d7226f70b0810622e8a455c4e4fc6a2a )
+)
+
+game (
+	name "Tales of Symphonia (Europe) (Disc 2)"
+	description "Tales of Symphonia (Europe) (Disc 2)"
+	rom ( name "Tales of Symphonia (Europe) (Disc 2).iso" size 1459978240 crc 7690fdda md5 ee81ac0afdca6d3930cad14370cbea75 sha1 74636b61d1ee02e46b8e927265ee5329a4860990 )
+)
+
+game (
+	name "Tales of Symphonia (FR)"
+	description "Tales of Symphonia (FR)"
+	rom ( name "Tales of Symphonia (FR) - (Disc 1 of 2).iso" size 1459978240 crc 99ec2579 md5 057dd0466cfcd64957a880e212180d3b sha1 d38365eb13f09f185b058826ec3f45e6e1118e66 )
+)
+
+game (
+	name "Tales of Symphonia (France) (Disc 1)"
+	description "Tales of Symphonia (France) (Disc 1)"
+	rom ( name "Tales of Symphonia (France) (Disc 1).iso" size 1459978240 crc 99ec2579 md5 057dd0466cfcd64957a880e212180d3b sha1 d38365eb13f09f185b058826ec3f45e6e1118e66 )
+)
+
+game (
+	name "Tales of Symphonia (France) (Disc 2)"
+	description "Tales of Symphonia (France) (Disc 2)"
+	rom ( name "Tales of Symphonia (France) (Disc 2).iso" size 1459978240 crc 609d66bc md5 83b3d38e342cd2a026b671908ed43574 sha1 d66b673c9979be546c2253b5de96337981273335 )
+)
+
+game (
+	name "Tales of Symphonia (GB)"
+	description "Tales of Symphonia (GB)"
+	rom ( name "Tales of Symphonia (GB) - (Disc 1 of 2).iso" size 1459978240 crc 6ba54b37 md5 a797655b74d8218d5f0c8229f393ab60 sha1 7d8f0e31d7226f70b0810622e8a455c4e4fc6a2a )
+)
+
+game (
+	name "Tales of Symphonia (Germany) (Disc 1)"
+	description "Tales of Symphonia (Germany) (Disc 1)"
+	rom ( name "Tales of Symphonia (Germany) (Disc 1).iso" size 1459978240 crc 59b0e2d2 md5 fc4caeaa8bafba662abb400de9c97579 sha1 38ac71a99713119025d5b80dadaa5cf710b73830 )
+)
+
+game (
+	name "Tales of Symphonia (Germany) (Disc 2)"
+	description "Tales of Symphonia (Germany) (Disc 2)"
+	rom ( name "Tales of Symphonia (Germany) (Disc 2).iso" size 1459978240 crc cd5a94f3 md5 97ce6f8eab0272e7bbdc71dc96c6651a sha1 5f1dafa0ddf231ecbf679ea1b87e4c839803a663 )
+)
+
+game (
+	name "Tales of Symphonia (IT)"
+	description "Tales of Symphonia (IT)"
+	rom ( name "Tales of Symphonia (IT) - (Disc 1 of 2).iso" size 1459978240 crc 5faf5aee md5 1a87ba0556d23553518940a6b9dc5561 sha1 ed8d2fcf8e9ff1658bd27fce31a41f1940281d9f )
+)
+
+game (
+	name "Tales of Symphonia (Italy) (Disc 1)"
+	description "Tales of Symphonia (Italy) (Disc 1)"
+	rom ( name "Tales of Symphonia (Italy) (Disc 1).iso" size 1459978240 crc 5faf5aee md5 1a87ba0556d23553518940a6b9dc5561 sha1 ed8d2fcf8e9ff1658bd27fce31a41f1940281d9f )
+)
+
+game (
+	name "Tales of Symphonia (Italy) (Disc 2)"
+	description "Tales of Symphonia (Italy) (Disc 2)"
+	rom ( name "Tales of Symphonia (Italy) (Disc 2).iso" size 1459978240 crc 1d870a39 md5 1f053b0874212a310e2a2eaa57eb2ffc sha1 54419b0edba98fc85ebc07e74594caa2db4add87 )
+)
+
+game (
+	name "Tales of Symphonia (Japan) (Disc 1)"
+	description "Tales of Symphonia (Japan) (Disc 1)"
+	rom ( name "Tales of Symphonia (Japan) (Disc 1).iso" size 1459978240 crc 0943d08b md5 a005a10a69a164f32d9d88aae8013ecf sha1 e3dcaf683a21a14ed406db0f4e7bba464a17fe0a )
+)
+
+game (
+	name "Tales of Symphonia (Japan) (Disc 2)"
+	description "Tales of Symphonia (Japan) (Disc 2)"
+	rom ( name "Tales of Symphonia (Japan) (Disc 2).iso" size 1459978240 crc 072d9d7c md5 fb96c11a1b3bed38942de37a5b6a72ea sha1 36aba753b7729f75705b8a04f0bf0a5f7fd83d51 )
+)
+
+game (
+	name "Tales of Symphonia (JP) - teiruzu+obu+sinhuonia"
+	description "Tales of Symphonia (JP) - teiruzu+obu+sinhuonia"
+	rom ( name "Tales of Symphonia (JP) - (Disc 1 of 2).iso" size 1459978240 crc 0943d08b md5 a005a10a69a164f32d9d88aae8013ecf sha1 e3dcaf683a21a14ed406db0f4e7bba464a17fe0a )
+)
+
+game (
+	name "Tales of Symphonia (Spain) (Disc 1)"
+	description "Tales of Symphonia (Spain) (Disc 1)"
+	rom ( name "Tales of Symphonia (Spain) (Disc 1).iso" size 1459978240 crc b0817701 md5 20d47d6b39446c64d877439b372d2e44 sha1 c5b22d4feab05f54a50c5e7bd22ca78525d01bf2 )
+)
+
+game (
+	name "Tales of Symphonia (Spain) (Disc 2)"
+	description "Tales of Symphonia (Spain) (Disc 2)"
+	rom ( name "Tales of Symphonia (Spain) (Disc 2).iso" size 1459978240 crc 43ef73b4 md5 25469c4b5d39670c99e31546031c8d58 sha1 0d51d99a86177795e2347d17986da5c03c81f9a6 )
+)
+
+game (
+	name "Tales of Symphonia (US)"
+	description "Tales of Symphonia (US)"
+	rom ( name "Tales of Symphonia (US) - (Disc 1 of 2).iso" size 1459978240 crc 7fe3b9f7 md5 a427c43797ab0ad5c024014142d1c3e1 sha1 99d8668e9badd485879b7374339ddd9e1ffc80b6 )
+)
+
+game (
+	name "Tales of Symphonia (USA) (Disc 1)"
+	description "Tales of Symphonia (USA) (Disc 1)"
+	rom ( name "Tales of Symphonia (USA) (Disc 1).iso" size 1459978240 crc 7fe3b9f7 md5 a427c43797ab0ad5c024014142d1c3e1 sha1 99d8668e9badd485879b7374339ddd9e1ffc80b6 )
+)
+
+game (
+	name "Tales of Symphonia (USA) (Disc 2)"
+	description "Tales of Symphonia (USA) (Disc 2)"
+	rom ( name "Tales of Symphonia (USA) (Disc 2).iso" size 1459978240 crc a65645eb md5 1078706dc88043ba6e7ab1a9aa708b32 sha1 b069c1d6cff7364230c5730c4cb513cab896ed63 )
+)
+
+game (
+	name "Taxi 3 - Le Jeu (FR)"
+	description "Taxi 3 - Le Jeu (FR)"
+	rom ( name "Taxi 3 - Le Jeu (FR).iso" size 1459978240 crc 3a1a8d90 md5 b55d89c0b235b0050eabe894d2f0ee31 sha1 fc104322da45ee740b331ede2e410e13e78b5d75 )
+)
+
+game (
+	name "Taxi 3 - Le Jeu (France)"
+	description "Taxi 3 - Le Jeu (France)"
+	rom ( name "Taxi 3 - Le Jeu (France).iso" size 1459978240 crc 3a1a8d90 md5 b55d89c0b235b0050eabe894d2f0ee31 sha1 fc104322da45ee740b331ede2e410e13e78b5d75 )
+)
+
+game (
+	name "Taz - Wanted (EU)"
+	description "Taz - Wanted (EU)"
+	rom ( name "Taz - Wanted (EU).iso" size 1459978240 crc c160ef87 md5 68c1e1a0657cd09994454ce4c2ec029a sha1 8c899d84c8a52383f5b08e4e19e6fedc5c32e4f8 )
+)
+
+game (
+	name "Taz - Wanted (Europe) (En,Fr,De,Es,It)"
+	description "Taz - Wanted (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Taz - Wanted (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc c160ef87 md5 68c1e1a0657cd09994454ce4c2ec029a sha1 8c899d84c8a52383f5b08e4e19e6fedc5c32e4f8 )
+)
+
+game (
+	name "Taz - Wanted (US)"
+	description "Taz - Wanted (US)"
+	rom ( name "Taz - Wanted (US).iso" size 1459978240 crc a6c9c6a1 md5 029dfab32a3e3f360bbb902dcc1f1320 sha1 0a640b9988f16f133a50fd3366ee0f806776a4b8 )
+)
+
+game (
+	name "Taz - Wanted (USA) (En,Fr,De,Es,It)"
+	description "Taz - Wanted (USA) (En,Fr,De,Es,It)"
+	rom ( name "Taz - Wanted (USA) (En,Fr,De,Es,It).iso" size 1459978240 crc a6c9c6a1 md5 029dfab32a3e3f360bbb902dcc1f1320 sha1 0a640b9988f16f133a50fd3366ee0f806776a4b8 )
+)
+
+game (
+	name "Teen Titans (US)"
+	description "Teen Titans (US)"
+	rom ( name "Teen Titans (US).iso" size 1459978240 crc 5a179dc5 md5 2a5f7650d7026f4c6ef8249caaa3374a sha1 6f55d82121ad1ecd18050d4210fb7b85083a8c51 )
+)
+
+game (
+	name "Teen Titans (USA) (En,Fr)"
+	description "Teen Titans (USA) (En,Fr)"
+	rom ( name "Teen Titans (USA) (En,Fr).iso" size 1459978240 crc 5a179dc5 md5 2a5f7650d7026f4c6ef8249caaa3374a sha1 6f55d82121ad1ecd18050d4210fb7b85083a8c51 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles (EU)"
+	description "Teenage Mutant Ninja Turtles (EU)"
+	rom ( name "Teenage Mutant Ninja Turtles (EU).iso" size 1459978240 crc b488a2df md5 8e742678cba3a5b2ac643fc2a80d9ea2 sha1 83df06b31a40f4b76a7136e39001951249446a46 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles (Europe) (En,Fr,De,Es,It)"
+	description "Teenage Mutant Ninja Turtles (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Teenage Mutant Ninja Turtles (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b488a2df md5 8e742678cba3a5b2ac643fc2a80d9ea2 sha1 83df06b31a40f4b76a7136e39001951249446a46 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles (US)"
+	description "Teenage Mutant Ninja Turtles (US)"
+	rom ( name "Teenage Mutant Ninja Turtles (US).iso" size 1459978240 crc c87e442a md5 08ec942b06ab6cdefad9b7ad6ccbc64a sha1 0a6b662897e9162faf6a94eae574382ebeb5d338 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles (USA)"
+	description "Teenage Mutant Ninja Turtles (USA)"
+	rom ( name "Teenage Mutant Ninja Turtles (USA).iso" size 1459978240 crc c87e442a md5 08ec942b06ab6cdefad9b7ad6ccbc64a sha1 0a6b662897e9162faf6a94eae574382ebeb5d338 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (EU)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (EU)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (EU) - (Disc 1 of 2).iso" size 1459978240 crc ade8c8f2 md5 a178801d131efcfcaee327e1521c3ba3 sha1 bd3a08f3800eae9c9c7bc63ce0def268a207430d )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc ade8c8f2 md5 a178801d131efcfcaee327e1521c3ba3 sha1 bd3a08f3800eae9c9c7bc63ce0def268a207430d )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc a24ab7ac md5 b64c44d3d2d6fe664343ee9ba0b71013 sha1 490226b71abfe77c383eeb3648feff5aea4763ea )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (US)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (US)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (US) - (Disc 1 of 2).iso" size 1459978240 crc 8e1cd4f7 md5 78226fcfb3b12090a6d06e9754ab2262 sha1 ea373ed9ce433f46eb783f93ed81798ed652bf45 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 1)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 1)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 1).iso" size 1459978240 crc 8e1cd4f7 md5 78226fcfb3b12090a6d06e9754ab2262 sha1 ea373ed9ce433f46eb783f93ed81798ed652bf45 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 2)"
+	description "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 2)"
+	rom ( name "Teenage Mutant Ninja Turtles 2 - Battle Nexus (USA) (Disc 2).iso" size 1459978240 crc 93a6c844 md5 88532ad2719be508171d6ffa3f2703b4 sha1 d5e581c87302dba7518e2a1d95d5107adc5bc62b )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (US)"
+	description "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (US)"
+	rom ( name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (US) - (Disc 1 of 2).iso" size 1459978240 crc ce63a657 md5 e0f2f0add9bbc2f7277470f6ddf6304e sha1 388fdbc489d13ae61b4a78003847f19f59a9f92f )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 1)"
+	description "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 1)"
+	rom ( name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 1).iso" size 1459978240 crc ce63a657 md5 e0f2f0add9bbc2f7277470f6ddf6304e sha1 388fdbc489d13ae61b4a78003847f19f59a9f92f )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 2)"
+	description "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 2)"
+	rom ( name "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare (USA) (Disc 2).iso" size 1459978240 crc f9948b84 md5 3c9e9444ab263f618c5262c4897e719d sha1 8e06ada1faa70da671a16e6878be6cf1ab3a5929 )
+)
+
+game (
+	name "Tengai Makyou II - Manji Maru (Japan)"
+	description "Tengai Makyou II - Manji Maru (Japan)"
+	rom ( name "Tengai Makyou II - Manji Maru (Japan).iso" size 1459978240 crc d9b37f9b md5 199bff6193d8b632b1c95a063c55c7b7 sha1 1ca9ea6edb3217d8ea8bea36254d16fe25d8ee70 )
+)
+
+game (
+	name "Tengai Makyou II - Manji Maru (JP) - Tian Wai Mo Jing II+MANJIMARU"
+	description "Tengai Makyou II - Manji Maru (JP) - Tian Wai Mo Jing II+MANJIMARU"
+	rom ( name "Tengai Makyou II - Manji Maru (JP).iso" size 1459978240 crc d9b37f9b md5 199bff6193d8b632b1c95a063c55c7b7 sha1 1ca9ea6edb3217d8ea8bea36254d16fe25d8ee70 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (EU)"
+	description "Terminator 3 - The Redemption (EU)"
+	rom ( name "Terminator 3 - The Redemption (EU).iso" size 1459978240 crc 888bba20 md5 22cd3e745261d294b1cbd27eda0ca1cc sha1 9cc96fc37fb5ae7d467159fe510ffc9eb8e13307 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (Europe) (En,Fr,De,Es,It)"
+	description "Terminator 3 - The Redemption (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Terminator 3 - The Redemption (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 888bba20 md5 22cd3e745261d294b1cbd27eda0ca1cc sha1 9cc96fc37fb5ae7d467159fe510ffc9eb8e13307 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (Japan)"
+	description "Terminator 3 - The Redemption (Japan)"
+	rom ( name "Terminator 3 - The Redemption (Japan).iso" size 1459978240 crc cebb20c1 md5 21ebe48d672f7a4c2a7caf459b08bed9 sha1 724799e7ca09fa6ff574483ecbfc1c4c022c5e19 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (JP) - tamineta3+zaredenpusiyon"
+	description "Terminator 3 - The Redemption (JP) - tamineta3+zaredenpusiyon"
+	rom ( name "Terminator 3 - The Redemption (JP).iso" size 1459978240 crc cebb20c1 md5 21ebe48d672f7a4c2a7caf459b08bed9 sha1 724799e7ca09fa6ff574483ecbfc1c4c022c5e19 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (US)"
+	description "Terminator 3 - The Redemption (US)"
+	rom ( name "Terminator 3 - The Redemption (US).iso" size 1459978240 crc 20c05d5e md5 57cbc56c20c1c832856eebcf3291522d sha1 2b4a50f3a9b4259e88dda6947e97772d128f8b00 )
+)
+
+game (
+	name "Terminator 3 - The Redemption (USA)"
+	description "Terminator 3 - The Redemption (USA)"
+	rom ( name "Terminator 3 - The Redemption (USA).iso" size 1459978240 crc 20c05d5e md5 57cbc56c20c1c832856eebcf3291522d sha1 2b4a50f3a9b4259e88dda6947e97772d128f8b00 )
+)
+
+game (
+	name "Tetris Worlds (EU)"
+	description "Tetris Worlds (EU)"
+	rom ( name "Tetris Worlds (EU).iso" size 1459978240 crc 41d8bffb md5 2419912f5dbd7c7cfd6c1914fe764e92 sha1 3f0248086bacde63e662c09ad40f75340ccbe857 )
+)
+
+game (
+	name "Tetris Worlds (Europe) (En,Fr,De)"
+	description "Tetris Worlds (Europe) (En,Fr,De)"
+	rom ( name "Tetris Worlds (Europe) (En,Fr,De).iso" size 1459978240 crc 41d8bffb md5 2419912f5dbd7c7cfd6c1914fe764e92 sha1 3f0248086bacde63e662c09ad40f75340ccbe857 )
+)
+
+game (
+	name "Tetris Worlds (Japan)"
+	description "Tetris Worlds (Japan)"
+	rom ( name "Tetris Worlds (Japan).iso" size 1459978240 crc eea0418f md5 fd93fb175d2b285952eb2df0896dac0c sha1 a0fb02bdad87bc304e2bec5f17671b1f1c1bfbf9 )
+)
+
+game (
+	name "Tetris Worlds (JP) - tetorisu+warudo"
+	description "Tetris Worlds (JP) - tetorisu+warudo"
+	rom ( name "Tetris Worlds (JP).iso" size 1459978240 crc eea0418f md5 fd93fb175d2b285952eb2df0896dac0c sha1 a0fb02bdad87bc304e2bec5f17671b1f1c1bfbf9 )
+)
+
+game (
+	name "Tetris Worlds (US)"
+	description "Tetris Worlds (US)"
+	rom ( name "Tetris Worlds (US).iso" size 1459978240 crc 2db716f1 md5 5320cb95e693c1f4552a8f9f3bd1fdc0 sha1 f7a4c79b0711a60e850b0c1cce0dc05b34f613d4 )
+)
+
+game (
+	name "Tetris Worlds (USA)"
+	description "Tetris Worlds (USA)"
+	rom ( name "Tetris Worlds (USA).iso" size 1459978240 crc 2db716f1 md5 5320cb95e693c1f4552a8f9f3bd1fdc0 sha1 f7a4c79b0711a60e850b0c1cce0dc05b34f613d4 )
+)
+
+game (
+	name "Tierisch verrueckte Bauernhof, Der (DE)"
+	description "Tierisch verrueckte Bauernhof, Der (DE)"
+	rom ( name "Tierisch verrueckte Bauernhof, Der (DE).iso" size 1459978240 crc dc7cd950 md5 a42b2e506508da079a4ab3bda9979363 sha1 2d646a596df7fba462aa1f45ae12efaa8630a001 )
+)
+
+game (
+	name "Tierisch verrueckte Bauernhof, Der (Germany)"
+	description "Tierisch verrueckte Bauernhof, Der (Germany)"
+	rom ( name "Tierisch verrueckte Bauernhof, Der (Germany).iso" size 1459978240 crc dc7cd950 md5 a42b2e506508da079a4ab3bda9979363 sha1 2d646a596df7fba462aa1f45ae12efaa8630a001 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 06 (EU)"
+	description "Tiger Woods PGA Tour 06 (EU)"
+	rom ( name "Tiger Woods PGA Tour 06 (EU).iso" size 1459978240 crc ff30727a md5 5640fd7df180d5b11b6f3631588e5232 sha1 613447a597d287bf9ea27b1f3654f60581c499f8 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 06 (Europe) (En,Fr,De)"
+	description "Tiger Woods PGA Tour 06 (Europe) (En,Fr,De)"
+	rom ( name "Tiger Woods PGA Tour 06 (Europe) (En,Fr,De).iso" size 1459978240 crc ff30727a md5 5640fd7df180d5b11b6f3631588e5232 sha1 613447a597d287bf9ea27b1f3654f60581c499f8 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 06 (US)"
+	description "Tiger Woods PGA Tour 06 (US)"
+	rom ( name "Tiger Woods PGA Tour 06 (US).iso" size 1459978240 crc 9fc02c26 md5 89215c25d3bb7521eec659a37d337cd0 sha1 af75850bbfaea2ff371f27ea8870b9083750f7c2 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 06 (USA)"
+	description "Tiger Woods PGA Tour 06 (USA)"
+	rom ( name "Tiger Woods PGA Tour 06 (USA).iso" size 1459978240 crc 9fc02c26 md5 89215c25d3bb7521eec659a37d337cd0 sha1 af75850bbfaea2ff371f27ea8870b9083750f7c2 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2003 (EU)"
+	description "Tiger Woods PGA Tour 2003 (EU)"
+	rom ( name "Tiger Woods PGA Tour 2003 (EU).iso" size 1459978240 crc a98ecd99 md5 9e9f78c32ca554bf849c8e24a58006bb sha1 f83ab1833b377a9032698e026849aca36c9abbfe )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2003 (Europe)"
+	description "Tiger Woods PGA Tour 2003 (Europe)"
+	rom ( name "Tiger Woods PGA Tour 2003 (Europe).iso" size 1459978240 crc a98ecd99 md5 9e9f78c32ca554bf849c8e24a58006bb sha1 f83ab1833b377a9032698e026849aca36c9abbfe )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2003 (US)"
+	description "Tiger Woods PGA Tour 2003 (US)"
+	rom ( name "Tiger Woods PGA Tour 2003 (US).iso" size 1459978240 crc 9efc5f20 md5 306eacdb0252d8958122d8f303ecfa65 sha1 72c3b5bbce515d1443bfa07504c7332ce42e5df4 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2003 (USA)"
+	description "Tiger Woods PGA Tour 2003 (USA)"
+	rom ( name "Tiger Woods PGA Tour 2003 (USA).iso" size 1459978240 crc 9efc5f20 md5 306eacdb0252d8958122d8f303ecfa65 sha1 72c3b5bbce515d1443bfa07504c7332ce42e5df4 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (EU)"
+	description "Tiger Woods PGA Tour 2004 (EU)"
+	rom ( name "Tiger Woods PGA Tour 2004 (EU) - (Disc 1 of 2) [v1.00].iso" size 1459978240 crc 28bb37dd md5 2ae87a7103e8d24bd66c7908b455a863 sha1 fda0fb65b7f91b2e392f76f9cb1d171e3bb71c9c )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.00)"
+	description "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.00)"
+	rom ( name "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.00).iso" size 1459978240 crc 28bb37dd md5 2ae87a7103e8d24bd66c7908b455a863 sha1 fda0fb65b7f91b2e392f76f9cb1d171e3bb71c9c )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.01)"
+	description "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.01)"
+	rom ( name "Tiger Woods PGA Tour 2004 (Europe) (Disc 1) (v1.01).iso" size 1459978240 crc 5c2d88e4 md5 dc8a8164e37cb0bafd982a4d30946e8a sha1 7d5273708a7494573992e6f5259277864ef6a5e8 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.00)"
+	description "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.00)"
+	rom ( name "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.00).iso" size 1459978240 crc 669a1b9b md5 a53ee73d2a01bb136b5cc52703c8e228 sha1 9a4bba64b3c8a949950917e19ad0c7e98769e70f )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.01)"
+	description "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.01)"
+	rom ( name "Tiger Woods PGA Tour 2004 (Europe) (Disc 2) (v1.01).iso" size 1459978240 crc 0de3148c md5 95fd974f151c4a48fd65e3f8c8158419 sha1 ecb22d032bf28fae511c9879612443cd3a90bfb3 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (GB)"
+	description "Tiger Woods PGA Tour 2004 (GB)"
+	rom ( name "Tiger Woods PGA Tour 2004 (GB) - (Disc 1 of 2) [v1.01].iso" size 1459978240 crc 5c2d88e4 md5 dc8a8164e37cb0bafd982a4d30946e8a sha1 7d5273708a7494573992e6f5259277864ef6a5e8 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (US)"
+	description "Tiger Woods PGA Tour 2004 (US)"
+	rom ( name "Tiger Woods PGA Tour 2004 (US) - (Disc 1 of 2).iso" size 1459978240 crc 8ae50a20 md5 81ba9b53904348a25db2ee0ae46d3b6c sha1 2a8eb9382e99c6942cabeed8a9e9b7df6b13c91f )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (USA) (Disc 1)"
+	description "Tiger Woods PGA Tour 2004 (USA) (Disc 1)"
+	rom ( name "Tiger Woods PGA Tour 2004 (USA) (Disc 1).iso" size 1459978240 crc 8ae50a20 md5 81ba9b53904348a25db2ee0ae46d3b6c sha1 2a8eb9382e99c6942cabeed8a9e9b7df6b13c91f )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2004 (USA) (Disc 2)"
+	description "Tiger Woods PGA Tour 2004 (USA) (Disc 2)"
+	rom ( name "Tiger Woods PGA Tour 2004 (USA) (Disc 2).iso" size 1459978240 crc 755874ba md5 4df313d253f54222944f382ece74ef81 sha1 0677f2c4a4492bc852b93acc0d1946dbd94d8a5a )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (EU)"
+	description "Tiger Woods PGA Tour 2005 (EU)"
+	rom ( name "Tiger Woods PGA Tour 2005 (EU) - (Disc 1 of 2).iso" size 1459978240 crc 8e95b0c1 md5 496078910fafd1f2559891ade036ea70 sha1 582ee55d97c936486c984e6d0aedf1aeacf39aed )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 1)"
+	description "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 1)"
+	rom ( name "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 1).iso" size 1459978240 crc 8e95b0c1 md5 496078910fafd1f2559891ade036ea70 sha1 582ee55d97c936486c984e6d0aedf1aeacf39aed )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 2)"
+	description "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 2)"
+	rom ( name "Tiger Woods PGA Tour 2005 (Europe) (En,Fr,De) (Disc 2).iso" size 1459978240 crc 29dc1d0c md5 4844db86d886cbef5b50d251e1ebd32b sha1 02ff52cf1e05572ad412afa4cabc1d6a916e9131 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (US)"
+	description "Tiger Woods PGA Tour 2005 (US)"
+	rom ( name "Tiger Woods PGA Tour 2005 (US) - (Disc 1 of 2).iso" size 1459978240 crc fb45905a md5 265e41ea68cf1f94034c4d566fe9c2c7 sha1 d0c707abc7a3e0e3d121b413c073d52b57a6065a )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (USA) (Disc 1)"
+	description "Tiger Woods PGA Tour 2005 (USA) (Disc 1)"
+	rom ( name "Tiger Woods PGA Tour 2005 (USA) (Disc 1).iso" size 1459978240 crc fb45905a md5 265e41ea68cf1f94034c4d566fe9c2c7 sha1 d0c707abc7a3e0e3d121b413c073d52b57a6065a )
+)
+
+game (
+	name "Tiger Woods PGA Tour 2005 (USA) (Disc 2)"
+	description "Tiger Woods PGA Tour 2005 (USA) (Disc 2)"
+	rom ( name "Tiger Woods PGA Tour 2005 (USA) (Disc 2).iso" size 1459978240 crc eb2e3a1f md5 01873f3420bebcafbf8f70e1a78a4633 sha1 2e7f926579e07d9c1bf2ca5bc26518be0c876732 )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (DE)"
+	description "TimeSplitters - Future Perfect (DE)"
+	rom ( name "TimeSplitters - Future Perfect (DE).iso" size 1459978240 crc 5bebd4f6 md5 ac610f06818ad601958de5d6f7378ab3 sha1 fc52e6c634f37f31ac0b6ba805f355af2bce68fc )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (Europe)"
+	description "TimeSplitters - Future Perfect (Europe)"
+	rom ( name "TimeSplitters - Future Perfect (Europe).iso" size 1459978240 crc 883bbd40 md5 8743dfa398de3e3448febe87d75d626c sha1 d02123d0ea7c8fc74a9150166be18739f8534c7a )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (FR)"
+	description "TimeSplitters - Future Perfect (FR)"
+	rom ( name "TimeSplitters - Future Perfect (FR).iso" size 1459978240 crc 946825e7 md5 0e451d7f41d5d5843fd666c6f07a8537 sha1 920871d4592a605d6acbd746f991eb8fbe32e72a )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (France)"
+	description "TimeSplitters - Future Perfect (France)"
+	rom ( name "TimeSplitters - Future Perfect (France).iso" size 1459978240 crc 946825e7 md5 0e451d7f41d5d5843fd666c6f07a8537 sha1 920871d4592a605d6acbd746f991eb8fbe32e72a )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (GB)"
+	description "TimeSplitters - Future Perfect (GB)"
+	rom ( name "TimeSplitters - Future Perfect (GB).iso" size 1459978240 crc 883bbd40 md5 8743dfa398de3e3448febe87d75d626c sha1 d02123d0ea7c8fc74a9150166be18739f8534c7a )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (Germany)"
+	description "TimeSplitters - Future Perfect (Germany)"
+	rom ( name "TimeSplitters - Future Perfect (Germany).iso" size 1459978240 crc 5bebd4f6 md5 ac610f06818ad601958de5d6f7378ab3 sha1 fc52e6c634f37f31ac0b6ba805f355af2bce68fc )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (US)"
+	description "TimeSplitters - Future Perfect (US)"
+	rom ( name "TimeSplitters - Future Perfect (US).iso" size 1459978240 crc 09e3d0ee md5 af8710863bad728de9a26231d398e99b sha1 2963ddb22a407108bead5e5bf64d6a9606eec80a )
+)
+
+game (
+	name "TimeSplitters - Future Perfect (USA)"
+	description "TimeSplitters - Future Perfect (USA)"
+	rom ( name "TimeSplitters - Future Perfect (USA).iso" size 1459978240 crc 09e3d0ee md5 af8710863bad728de9a26231d398e99b sha1 2963ddb22a407108bead5e5bf64d6a9606eec80a )
+)
+
+game (
+	name "TimeSplitters - Futuro Perfecto (ES)"
+	description "TimeSplitters - Futuro Perfecto (ES)"
+	rom ( name "TimeSplitters - Futuro Perfecto (ES).iso" size 1459978240 crc 83eb1e86 md5 94bc6075a9509dae9b12f1a9c69a3141 sha1 4d7107664aec328ec607ee29094fde7f1db770e0 )
+)
+
+game (
+	name "TimeSplitters - Futuro Perfecto (Spain)"
+	description "TimeSplitters - Futuro Perfecto (Spain)"
+	rom ( name "TimeSplitters - Futuro Perfecto (Spain).iso" size 1459978240 crc 83eb1e86 md5 94bc6075a9509dae9b12f1a9c69a3141 sha1 4d7107664aec328ec607ee29094fde7f1db770e0 )
+)
+
+game (
+	name "TimeSplitters 2 (EU)"
+	description "TimeSplitters 2 (EU)"
+	rom ( name "TimeSplitters 2 (EU).iso" size 1459978240 crc e42e08e8 md5 f1a546493a43a75513f842e0e55e51db sha1 a511d7c3483a61aaf542f1c7d75dd2f6b628bdd0 )
+)
+
+game (
+	name "TimeSplitters 2 (Europe) (En,Fr,De,Es,It)"
+	description "TimeSplitters 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "TimeSplitters 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e42e08e8 md5 f1a546493a43a75513f842e0e55e51db sha1 a511d7c3483a61aaf542f1c7d75dd2f6b628bdd0 )
+)
+
+game (
+	name "TimeSplitters 2 (US)"
+	description "TimeSplitters 2 (US)"
+	rom ( name "TimeSplitters 2 (US).iso" size 1459978240 crc f4081f05 md5 6732fb668e1203fbda42b5bbf1fa9f34 sha1 abe5b47010098009f5228ed7cadeeebdcfad5a6f )
+)
+
+game (
+	name "TimeSplitters 2 (USA)"
+	description "TimeSplitters 2 (USA)"
+	rom ( name "TimeSplitters 2 (USA).iso" size 1459978240 crc f4081f05 md5 6732fb668e1203fbda42b5bbf1fa9f34 sha1 abe5b47010098009f5228ed7cadeeebdcfad5a6f )
+)
+
+game (
+	name "TMNT - Mutant Melee (US)"
+	description "TMNT - Mutant Melee (US)"
+	rom ( name "TMNT - Mutant Melee (US).iso" size 1459978240 crc 2eb43a22 md5 b17b54ae5e8efc4316e97676a9716004 sha1 0c6f6bf4726e8dec64b5d2dcb6a10259b5f9b201 )
+)
+
+game (
+	name "TMNT - Mutant Melee (USA)"
+	description "TMNT - Mutant Melee (USA)"
+	rom ( name "TMNT - Mutant Melee (USA).iso" size 1459978240 crc 2eb43a22 md5 b17b54ae5e8efc4316e97676a9716004 sha1 0c6f6bf4726e8dec64b5d2dcb6a10259b5f9b201 )
+)
+
+game (
+	name "TMNT (EU)"
+	description "TMNT (EU)"
+	rom ( name "TMNT (EU).iso" size 1459978240 crc 1731f531 md5 6e958c31a57777ae696941a6bddf3803 sha1 2432202be9f6422b7af07950d7d99fb94668cbf2 )
+)
+
+game (
+	name "TMNT (Europe) (En,Fr,De,Es,It)"
+	description "TMNT (Europe) (En,Fr,De,Es,It)"
+	rom ( name "TMNT (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1731f531 md5 6e958c31a57777ae696941a6bddf3803 sha1 2432202be9f6422b7af07950d7d99fb94668cbf2 )
+)
+
+game (
+	name "TMNT (US)"
+	description "TMNT (US)"
+	rom ( name "TMNT (US).iso" size 1459978240 crc 9f10edbc md5 c42b49bd54bf0f0195e6cc2241d8dfeb sha1 590f408297cc12b46528a12c7b6b8ea9a439bfdd )
+)
+
+game (
+	name "TMNT (USA) (En,Fr,Es)"
+	description "TMNT (USA) (En,Fr,Es)"
+	rom ( name "TMNT (USA) (En,Fr,Es).iso" size 1459978240 crc 9f10edbc md5 c42b49bd54bf0f0195e6cc2241d8dfeb sha1 590f408297cc12b46528a12c7b6b8ea9a439bfdd )
+)
+
+game (
+	name "Tom and Jerry in War of the Whiskers (US)"
+	description "Tom and Jerry in War of the Whiskers (US)"
+	rom ( name "Tom and Jerry in War of the Whiskers (US).iso" size 1459978240 crc 6435e657 md5 3f837a87dad6384731b1fa1dcae03466 sha1 6edc7f06977580b75fb9f08a05aca676f2c39e12 )
+)
+
+game (
+	name "Tom and Jerry in War of the Whiskers (USA)"
+	description "Tom and Jerry in War of the Whiskers (USA)"
+	rom ( name "Tom and Jerry in War of the Whiskers (USA).iso" size 1459978240 crc 6435e657 md5 3f837a87dad6384731b1fa1dcae03466 sha1 6edc7f06977580b75fb9f08a05aca676f2c39e12 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (DE)"
+	description "Tom Clancy's Ghost Recon (DE)"
+	rom ( name "Tom Clancy's Ghost Recon (DE).iso" size 1459978240 crc 477cbf69 md5 c8f82be9d9b0470f0b12f9d4a8145c1d sha1 5eb012c5488498b70296ef337b098e360793645d )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (EU)"
+	description "Tom Clancy's Ghost Recon (EU)"
+	rom ( name "Tom Clancy's Ghost Recon (EU).iso" size 1459978240 crc 40c8b0a6 md5 14b186c3cb5224527e15ae5b7344ab11 sha1 c249b5c55365eccc55c841243d901f3a6e8446d8 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (Europe) (En,Fr,Es,It)"
+	description "Tom Clancy's Ghost Recon (Europe) (En,Fr,Es,It)"
+	rom ( name "Tom Clancy's Ghost Recon (Europe) (En,Fr,Es,It).iso" size 1459978240 crc 40c8b0a6 md5 14b186c3cb5224527e15ae5b7344ab11 sha1 c249b5c55365eccc55c841243d901f3a6e8446d8 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (Germany)"
+	description "Tom Clancy's Ghost Recon (Germany)"
+	rom ( name "Tom Clancy's Ghost Recon (Germany).iso" size 1459978240 crc 477cbf69 md5 c8f82be9d9b0470f0b12f9d4a8145c1d sha1 5eb012c5488498b70296ef337b098e360793645d )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (US)"
+	description "Tom Clancy's Ghost Recon (US)"
+	rom ( name "Tom Clancy's Ghost Recon (US).iso" size 1459978240 crc 2a5cfb16 md5 3c368791c5862a16268725c9572ba175 sha1 ecf0e90e84b74de813d1c9127ddaad7043077d08 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (USA)"
+	description "Tom Clancy's Ghost Recon (USA)"
+	rom ( name "Tom Clancy's Ghost Recon (USA).iso" size 1459978240 crc 2a5cfb16 md5 3c368791c5862a16268725c9572ba175 sha1 ecf0e90e84b74de813d1c9127ddaad7043077d08 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon 2 (EU)"
+	description "Tom Clancy's Ghost Recon 2 (EU)"
+	rom ( name "Tom Clancy's Ghost Recon 2 (EU).iso" size 1459978240 crc e719bbf8 md5 da413bbb96072817a6ca4193339debd1 sha1 d84377d8d82164a89fbd031a4505e8e8d3dc7147 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon 2 (Europe) (En,Fr,De,Es,It)"
+	description "Tom Clancy's Ghost Recon 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tom Clancy's Ghost Recon 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e719bbf8 md5 da413bbb96072817a6ca4193339debd1 sha1 d84377d8d82164a89fbd031a4505e8e8d3dc7147 )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon 2 (US)"
+	description "Tom Clancy's Ghost Recon 2 (US)"
+	rom ( name "Tom Clancy's Ghost Recon 2 (US).iso" size 1459978240 crc eb315761 md5 839f98843558879b748e9f00b06bb93a sha1 61e2dada41ebc40263e4b4b73ca375e09c8ff4ab )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon 2 (USA) (En,Fr,Es)"
+	description "Tom Clancy's Ghost Recon 2 (USA) (En,Fr,Es)"
+	rom ( name "Tom Clancy's Ghost Recon 2 (USA) (En,Fr,Es).iso" size 1459978240 crc eb315761 md5 839f98843558879b748e9f00b06bb93a sha1 61e2dada41ebc40263e4b4b73ca375e09c8ff4ab )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six - Lockdown (EU)"
+	description "Tom Clancy's Rainbow Six - Lockdown (EU)"
+	rom ( name "Tom Clancy's Rainbow Six - Lockdown (EU).iso" size 1459978240 crc 47df5b17 md5 9b75b766f28098623a8343a86c653017 sha1 116b3ae022ce268856b489a297f90847f6187c07 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six - Lockdown (Europe) (En,Fr,De,Es,It)"
+	description "Tom Clancy's Rainbow Six - Lockdown (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tom Clancy's Rainbow Six - Lockdown (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 47df5b17 md5 9b75b766f28098623a8343a86c653017 sha1 116b3ae022ce268856b489a297f90847f6187c07 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six - Lockdown (US)"
+	description "Tom Clancy's Rainbow Six - Lockdown (US)"
+	rom ( name "Tom Clancy's Rainbow Six - Lockdown (US).iso" size 1459978240 crc 5609a8e7 md5 8f82f3e14e9866d2889e91e2d1e26aeb sha1 3a1f8fe4ec5e98f11df1f6e0d0c7d98d9cabfd6a )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six - Lockdown (USA)"
+	description "Tom Clancy's Rainbow Six - Lockdown (USA)"
+	rom ( name "Tom Clancy's Rainbow Six - Lockdown (USA).iso" size 1459978240 crc 5609a8e7 md5 8f82f3e14e9866d2889e91e2d1e26aeb sha1 3a1f8fe4ec5e98f11df1f6e0d0c7d98d9cabfd6a )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six 3 (EU)"
+	description "Tom Clancy's Rainbow Six 3 (EU)"
+	rom ( name "Tom Clancy's Rainbow Six 3 (EU).iso" size 1459978240 crc 7280ea66 md5 f58d322d86316cb6bc990a453b27e598 sha1 4ecefb477905719bf3f76105f007f08c7f61e169 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six 3 (Europe) (En,Fr,De,Es,It)"
+	description "Tom Clancy's Rainbow Six 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tom Clancy's Rainbow Six 3 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 7280ea66 md5 f58d322d86316cb6bc990a453b27e598 sha1 4ecefb477905719bf3f76105f007f08c7f61e169 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six 3 (US)"
+	description "Tom Clancy's Rainbow Six 3 (US)"
+	rom ( name "Tom Clancy's Rainbow Six 3 (US).iso" size 1459978240 crc aafa9da8 md5 3fc75e64761569b55d4a500424bde572 sha1 2fe964566b77aa12c75e43f1b72e7ab8bce56205 )
+)
+
+game (
+	name "Tom Clancy's Rainbow Six 3 (USA)"
+	description "Tom Clancy's Rainbow Six 3 (USA)"
+	rom ( name "Tom Clancy's Rainbow Six 3 (USA).iso" size 1459978240 crc aafa9da8 md5 3fc75e64761569b55d4a500424bde572 sha1 2fe964566b77aa12c75e43f1b72e7ab8bce56205 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (EU)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (EU)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (EU) - (Disc 1 of 2).iso" size 1459978240 crc a8498ddc md5 c802fcb5ae87d4a3db3678a862c09f3b sha1 ad1240f74cbe7611177a8cc5e607aec038c4482c )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc a8498ddc md5 c802fcb5ae87d4a3db3678a862c09f3b sha1 ad1240f74cbe7611177a8cc5e607aec038c4482c )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 853b9425 md5 47593564721c9c0f3f5137552ef686ff sha1 296b8ee5289dda312c8d2e389842f106f4971334 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (US)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (US)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (US) - (Disc 1 of 2).iso" size 1459978240 crc ab312170 md5 d2ff2c7ae7af806ceb63b0b52cf16296 sha1 f9d005fab7970e5d8ff09ecde8be089919f90093 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 1)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 1)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 1).iso" size 1459978240 crc ab312170 md5 d2ff2c7ae7af806ceb63b0b52cf16296 sha1 f9d005fab7970e5d8ff09ecde8be089919f90093 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 2)"
+	description "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 2)"
+	rom ( name "Tom Clancy's Splinter Cell - Chaos Theory (USA) (En,Fr,Es) (Disc 2).iso" size 1459978240 crc f4b4a0f2 md5 4fe5fcdcbd423d45e754c2e8627104ec sha1 3d6c017f014ff933c37a39f2734647d3768b0c30 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (EU)"
+	description "Tom Clancy's Splinter Cell - Double Agent (EU)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (EU) - (Disc 1 of 2).iso" size 1459978240 crc 662a25c4 md5 2d9a422d651e3a201bc198c8ca7387b8 sha1 6d31e599572798d4e0a077b78ee30b0be2345d2b )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	description "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 1)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 1).iso" size 1459978240 crc 662a25c4 md5 2d9a422d651e3a201bc198c8ca7387b8 sha1 6d31e599572798d4e0a077b78ee30b0be2345d2b )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	description "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 2)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It) (Disc 2).iso" size 1459978240 crc 0bb49d94 md5 b802b5ee80ad84393e2c9d6e52f34eb0 sha1 932e820279da8524001c1b492b0ec96e3faba99e )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (US)"
+	description "Tom Clancy's Splinter Cell - Double Agent (US)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (US) - (Disc 1 of 2).iso" size 1459978240 crc 1a31ba3d md5 d5929781448ec137c7bcb9cb24de7d2d sha1 b818d5009fbde1ddaaf5bba302ba1cf4c7132887 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 1)"
+	description "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 1)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 1).iso" size 1459978240 crc 1a31ba3d md5 d5929781448ec137c7bcb9cb24de7d2d sha1 b818d5009fbde1ddaaf5bba302ba1cf4c7132887 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 2)"
+	description "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 2)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es) (Disc 2).iso" size 1459978240 crc 77ce66b9 md5 8c55fdc926634ee9864c503a13dfbacd sha1 38190b1efc9158a5f18eb1ffefa86517959ec6bc )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (EU)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (EU)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (EU).iso" size 1459978240 crc 385aa575 md5 c377b2cf4ae34d593ac307737787d5b7 sha1 6d4edfbf3542db027516dafe3e86282fd302021a )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe).iso" size 1459978240 crc 355d85bd md5 398f0a775bc1c0ba2df9725f4c2ac8ba sha1 ac9d2d98d1977dfea50df4ed05b22dd6340fb55e )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe) (Fr,De,Es,It)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe) (Fr,De,Es,It)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe) (Fr,De,Es,It).iso" size 1459978240 crc 385aa575 md5 c377b2cf4ae34d593ac307737787d5b7 sha1 6d4edfbf3542db027516dafe3e86282fd302021a )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (GB)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (GB)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (GB).iso" size 1459978240 crc 355d85bd md5 398f0a775bc1c0ba2df9725f4c2ac8ba sha1 ac9d2d98d1977dfea50df4ed05b22dd6340fb55e )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (US)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (US)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (US).iso" size 1459978240 crc c6d5fe92 md5 31aaed3da0f5ca647fdcfc417b3d10e8 sha1 288a4ca97feed1ec3e30961e281abefabfd8d33c )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Pandora Tomorrow (USA)"
+	description "Tom Clancy's Splinter Cell - Pandora Tomorrow (USA)"
+	rom ( name "Tom Clancy's Splinter Cell - Pandora Tomorrow (USA).iso" size 1459978240 crc c6d5fe92 md5 31aaed3da0f5ca647fdcfc417b3d10e8 sha1 288a4ca97feed1ec3e30961e281abefabfd8d33c )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (Demo) (EU)"
+	description "Tom Clancy's Splinter Cell (Demo) (EU)"
+	rom ( name "Tom Clancy's Splinter Cell (Demo) (EU).iso" size 1459978240 crc ce53a492 md5 f67314c8c39db317575ae8c8f9d90964 sha1 c35b5c78a5380ea481eabdb60c1540f9d1e691d2 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (EU)"
+	description "Tom Clancy's Splinter Cell (EU)"
+	rom ( name "Tom Clancy's Splinter Cell (EU).iso" size 1459978240 crc f21a73a8 md5 d7e09902b7e7c266c59577cb66b3c863 sha1 7eac076ccc42a314a1a6696a7f91ced828a9857a )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It)"
+	description "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f21a73a8 md5 d7e09902b7e7c266c59577cb66b3c863 sha1 7eac076ccc42a314a1a6696a7f91ced828a9857a )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Demo)"
+	description "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Demo)"
+	rom ( name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Demo).iso" size 1459978240 crc ce53a492 md5 f67314c8c39db317575ae8c8f9d90964 sha1 c35b5c78a5380ea481eabdb60c1540f9d1e691d2 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Promo)"
+	description "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Promo)"
+	rom ( name "Tom Clancy's Splinter Cell (Europe) (En,Fr,De,Es,It) (Promo).iso" size 1459978240 crc 981dbbb1 md5 dd616fed6c2f2f703c3bc14abbd61826 sha1 a601595d6780636483d3ee94be1495b808dc0c35 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (Promo) (EU)"
+	description "Tom Clancy's Splinter Cell (Promo) (EU)"
+	rom ( name "Tom Clancy's Splinter Cell (Promo) (EU).iso" size 1459978240 crc 981dbbb1 md5 dd616fed6c2f2f703c3bc14abbd61826 sha1 a601595d6780636483d3ee94be1495b808dc0c35 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (US)"
+	description "Tom Clancy's Splinter Cell (US)"
+	rom ( name "Tom Clancy's Splinter Cell (US).iso" size 1459978240 crc cbf5d874 md5 56c6f8a0c98e23ffbcde0e1139146001 sha1 f45ed55c0e7be802d444a1bc4509c8cabbce4d89 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell (USA)"
+	description "Tom Clancy's Splinter Cell (USA)"
+	rom ( name "Tom Clancy's Splinter Cell (USA).iso" size 1459978240 crc cbf5d874 md5 56c6f8a0c98e23ffbcde0e1139146001 sha1 f45ed55c0e7be802d444a1bc4509c8cabbce4d89 )
+)
+
+game (
+	name "Tonka - Rescue Patrol (US)"
+	description "Tonka - Rescue Patrol (US)"
+	rom ( name "Tonka - Rescue Patrol (US).iso" size 1459978240 crc 87cd0ee9 md5 40af2a2d9295a6481a58a50ffd76d56a sha1 03f8503d727e77a446915d636b1dea980e68adab )
+)
+
+game (
+	name "Tonka - Rescue Patrol (USA)"
+	description "Tonka - Rescue Patrol (USA)"
+	rom ( name "Tonka - Rescue Patrol (USA).iso" size 1459978240 crc 87cd0ee9 md5 40af2a2d9295a6481a58a50ffd76d56a sha1 03f8503d727e77a446915d636b1dea980e68adab )
+)
+
+game (
+	name "Tony Hawk's American Wasteland (EU)"
+	description "Tony Hawk's American Wasteland (EU)"
+	rom ( name "Tony Hawk's American Wasteland (EU).iso" size 1459978240 crc 3ec7d3c9 md5 4a157077fc4a05575d9f4447bf1d8548 sha1 20b16219077172cb7e8ed3c364dcb4046cdc4283 )
+)
+
+game (
+	name "Tony Hawk's American Wasteland (Europe) (En,Fr,De,Es,It)"
+	description "Tony Hawk's American Wasteland (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tony Hawk's American Wasteland (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3ec7d3c9 md5 4a157077fc4a05575d9f4447bf1d8548 sha1 20b16219077172cb7e8ed3c364dcb4046cdc4283 )
+)
+
+game (
+	name "Tony Hawk's American Wasteland (US)"
+	description "Tony Hawk's American Wasteland (US)"
+	rom ( name "Tony Hawk's American Wasteland (US).iso" size 1459978240 crc 6ca729f6 md5 e76efb41bb6341d7a3d670615205e07c sha1 ddd58854b62d1d55d283f57aafd1f70e571f7113 )
+)
+
+game (
+	name "Tony Hawk's American Wasteland (USA)"
+	description "Tony Hawk's American Wasteland (USA)"
+	rom ( name "Tony Hawk's American Wasteland (USA).iso" size 1459978240 crc 6ca729f6 md5 e76efb41bb6341d7a3d670615205e07c sha1 ddd58854b62d1d55d283f57aafd1f70e571f7113 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (DE)"
+	description "Tony Hawk's Pro Skater 3 (DE)"
+	rom ( name "Tony Hawk's Pro Skater 3 (DE).iso" size 1459978240 crc f33f9b32 md5 5c57d62f00d94a2e8272af3a24bd2919 sha1 031571ff577868033329cfc124bb009a8846344c )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (EU)"
+	description "Tony Hawk's Pro Skater 3 (EU)"
+	rom ( name "Tony Hawk's Pro Skater 3 (EU).iso" size 1459978240 crc ac6b9437 md5 ae72f487bd9f0593810195f6834156bf sha1 860039f6fefe683a1cef237b585f9f0ea04eb259 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (Europe)"
+	description "Tony Hawk's Pro Skater 3 (Europe)"
+	rom ( name "Tony Hawk's Pro Skater 3 (Europe).iso" size 1459978240 crc ac6b9437 md5 ae72f487bd9f0593810195f6834156bf sha1 860039f6fefe683a1cef237b585f9f0ea04eb259 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (FR)"
+	description "Tony Hawk's Pro Skater 3 (FR)"
+	rom ( name "Tony Hawk's Pro Skater 3 (FR).iso" size 1459978240 crc a136cbbb md5 876f3f3687cc8bf29f00b723d850cb7c sha1 0031a875dbaae7fbe1d4d3e9144682a2f8abaae0 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (France)"
+	description "Tony Hawk's Pro Skater 3 (France)"
+	rom ( name "Tony Hawk's Pro Skater 3 (France).iso" size 1459978240 crc a136cbbb md5 876f3f3687cc8bf29f00b723d850cb7c sha1 0031a875dbaae7fbe1d4d3e9144682a2f8abaae0 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (Germany)"
+	description "Tony Hawk's Pro Skater 3 (Germany)"
+	rom ( name "Tony Hawk's Pro Skater 3 (Germany).iso" size 1459978240 crc f33f9b32 md5 5c57d62f00d94a2e8272af3a24bd2919 sha1 031571ff577868033329cfc124bb009a8846344c )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (Japan)"
+	description "Tony Hawk's Pro Skater 3 (Japan)"
+	rom ( name "Tony Hawk's Pro Skater 3 (Japan).iso" size 1459978240 crc 26eeeeb7 md5 8803a2a9374087651b6ae7f5f21a0dcc sha1 37152344d4ebb97517fab8ce33fa7a9c1cd4fcaa )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (JP) - tonihoku+purosuketa3"
+	description "Tony Hawk's Pro Skater 3 (JP) - tonihoku+purosuketa3"
+	rom ( name "Tony Hawk's Pro Skater 3 (JP).iso" size 1459978240 crc 26eeeeb7 md5 8803a2a9374087651b6ae7f5f21a0dcc sha1 37152344d4ebb97517fab8ce33fa7a9c1cd4fcaa )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (US)"
+	description "Tony Hawk's Pro Skater 3 (US)"
+	rom ( name "Tony Hawk's Pro Skater 3 (US).iso" size 1459978240 crc 38e54e39 md5 8fd5510e28b32545f8f31c365e467e55 sha1 8563eda345d77e0b655c2a35aa3c0bf12125f854 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 3 (USA)"
+	description "Tony Hawk's Pro Skater 3 (USA)"
+	rom ( name "Tony Hawk's Pro Skater 3 (USA).iso" size 1459978240 crc 38e54e39 md5 8fd5510e28b32545f8f31c365e467e55 sha1 8563eda345d77e0b655c2a35aa3c0bf12125f854 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (DE)"
+	description "Tony Hawk's Pro Skater 4 (DE)"
+	rom ( name "Tony Hawk's Pro Skater 4 (DE).iso" size 1459978240 crc 5ad4598d md5 bca716048c807f305c2254f0543021a9 sha1 466176daafd08f35cb3a8f3fbf824c566b7193e0 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (Europe)"
+	description "Tony Hawk's Pro Skater 4 (Europe)"
+	rom ( name "Tony Hawk's Pro Skater 4 (Europe).iso" size 1459978240 crc b101a4a0 md5 2254d8e30f6652c392270cc57025f9a9 sha1 5ccd0914ff074d002452440edbc5720c1bb581a9 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (FR)"
+	description "Tony Hawk's Pro Skater 4 (FR)"
+	rom ( name "Tony Hawk's Pro Skater 4 (FR).iso" size 1459978240 crc 1265bf17 md5 578f44eb81f78d7e751d992f8965b210 sha1 cfb9448eb14859c8bb11cda3493ebdca4eb5bb58 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (France)"
+	description "Tony Hawk's Pro Skater 4 (France)"
+	rom ( name "Tony Hawk's Pro Skater 4 (France).iso" size 1459978240 crc 1265bf17 md5 578f44eb81f78d7e751d992f8965b210 sha1 cfb9448eb14859c8bb11cda3493ebdca4eb5bb58 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (GB)"
+	description "Tony Hawk's Pro Skater 4 (GB)"
+	rom ( name "Tony Hawk's Pro Skater 4 (GB).iso" size 1459978240 crc b101a4a0 md5 2254d8e30f6652c392270cc57025f9a9 sha1 5ccd0914ff074d002452440edbc5720c1bb581a9 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (Germany)"
+	description "Tony Hawk's Pro Skater 4 (Germany)"
+	rom ( name "Tony Hawk's Pro Skater 4 (Germany).iso" size 1459978240 crc 5ad4598d md5 bca716048c807f305c2254f0543021a9 sha1 466176daafd08f35cb3a8f3fbf824c566b7193e0 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (US)"
+	description "Tony Hawk's Pro Skater 4 (US)"
+	rom ( name "Tony Hawk's Pro Skater 4 (US).iso" size 1459978240 crc aa90dafb md5 d2fd8eb536ba6bc3b078d02428ac9dba sha1 e2ae3583a0e790cf387fbdd57cb2c3c116c28ad7 )
+)
+
+game (
+	name "Tony Hawk's Pro Skater 4 (USA)"
+	description "Tony Hawk's Pro Skater 4 (USA)"
+	rom ( name "Tony Hawk's Pro Skater 4 (USA).iso" size 1459978240 crc aa90dafb md5 d2fd8eb536ba6bc3b078d02428ac9dba sha1 e2ae3583a0e790cf387fbdd57cb2c3c116c28ad7 )
+)
+
+game (
+	name "Tony Hawk's Underground (EU)"
+	description "Tony Hawk's Underground (EU)"
+	rom ( name "Tony Hawk's Underground (EU).iso" size 1459978240 crc bdf95da4 md5 c4d092c25a5575a2f2f5763717648662 sha1 d9f4259fda2fd32162bb6efe4cff8a27592d3842 )
+)
+
+game (
+	name "Tony Hawk's Underground (Europe) (En,Fr,De)"
+	description "Tony Hawk's Underground (Europe) (En,Fr,De)"
+	rom ( name "Tony Hawk's Underground (Europe) (En,Fr,De).iso" size 1459978240 crc bdf95da4 md5 c4d092c25a5575a2f2f5763717648662 sha1 d9f4259fda2fd32162bb6efe4cff8a27592d3842 )
+)
+
+game (
+	name "Tony Hawk's Underground (US)"
+	description "Tony Hawk's Underground (US)"
+	rom ( name "Tony Hawk's Underground (US).iso" size 1459978240 crc c2c4dbd1 md5 3903200569bc1e4040764a45926828e7 sha1 4755209d13882d6ec6e1fd810551bd415f7d7da6 )
+)
+
+game (
+	name "Tony Hawk's Underground (USA)"
+	description "Tony Hawk's Underground (USA)"
+	rom ( name "Tony Hawk's Underground (USA).iso" size 1459978240 crc c2c4dbd1 md5 3903200569bc1e4040764a45926828e7 sha1 4755209d13882d6ec6e1fd810551bd415f7d7da6 )
+)
+
+game (
+	name "Tony Hawk's Underground 2 (EU)"
+	description "Tony Hawk's Underground 2 (EU)"
+	rom ( name "Tony Hawk's Underground 2 (EU).iso" size 1459978240 crc 34a3fe67 md5 e692ebf948e5fa2d1f7a62679ef35076 sha1 1fc26664fa960d0751e708d7e2a7d17b83aed3a6 )
+)
+
+game (
+	name "Tony Hawk's Underground 2 (Europe) (En,Fr,De)"
+	description "Tony Hawk's Underground 2 (Europe) (En,Fr,De)"
+	rom ( name "Tony Hawk's Underground 2 (Europe) (En,Fr,De).iso" size 1459978240 crc 34a3fe67 md5 e692ebf948e5fa2d1f7a62679ef35076 sha1 1fc26664fa960d0751e708d7e2a7d17b83aed3a6 )
+)
+
+game (
+	name "Tony Hawk's Underground 2 (US)"
+	description "Tony Hawk's Underground 2 (US)"
+	rom ( name "Tony Hawk's Underground 2 (US).iso" size 1459978240 crc cca24ad9 md5 1f857954e3cf9787ba4c65ebfef23e2a sha1 06af37a69dd220012b6738e171c7562eabeb76a2 )
+)
+
+game (
+	name "Tony Hawk's Underground 2 (USA)"
+	description "Tony Hawk's Underground 2 (USA)"
+	rom ( name "Tony Hawk's Underground 2 (USA).iso" size 1459978240 crc cca24ad9 md5 1f857954e3cf9787ba4c65ebfef23e2a sha1 06af37a69dd220012b6738e171c7562eabeb76a2 )
+)
+
+game (
+	name "Top Angler - Real Bass Fishing (Europe)"
+	description "Top Angler - Real Bass Fishing (Europe)"
+	rom ( name "Top Angler - Real Bass Fishing (Europe).iso" size 1459978240 crc 32c0e4e8 md5 15657559848baf10841b1a943fbbf39e sha1 01d40eda949a6ed589c5611e3feedade71a66e0f )
+)
+
+game (
+	name "Top Angler - Real Bass Fishing (GB)"
+	description "Top Angler - Real Bass Fishing (GB)"
+	rom ( name "Top Angler - Real Bass Fishing (GB).iso" size 1459978240 crc 32c0e4e8 md5 15657559848baf10841b1a943fbbf39e sha1 01d40eda949a6ed589c5611e3feedade71a66e0f )
+)
+
+game (
+	name "Top Angler - Real Bass Fishing (US)"
+	description "Top Angler - Real Bass Fishing (US)"
+	rom ( name "Top Angler - Real Bass Fishing (US).iso" size 1459978240 crc 988ed4f2 md5 cea87ae8376b1a025d1c919e4c15384e sha1 75d0f18f2e29a0f0c19f3dba2db44173532f94b7 )
+)
+
+game (
+	name "Top Angler - Real Bass Fishing (USA)"
+	description "Top Angler - Real Bass Fishing (USA)"
+	rom ( name "Top Angler - Real Bass Fishing (USA).iso" size 1459978240 crc 988ed4f2 md5 cea87ae8376b1a025d1c919e4c15384e sha1 75d0f18f2e29a0f0c19f3dba2db44173532f94b7 )
+)
+
+game (
+	name "Top Gun - Ace of the Sky (Japan)"
+	description "Top Gun - Ace of the Sky (Japan)"
+	rom ( name "Top Gun - Ace of the Sky (Japan).iso" size 1459978240 crc 9e57ecd2 md5 b610d5cb406f970db846cc7c02844d38 sha1 6205926bd4ded731754c4348d37e3fd847c09f6b )
+)
+
+game (
+	name "Top Gun - Ace of the Sky (JP) - totupugan+esu+obu+za+sukai"
+	description "Top Gun - Ace of the Sky (JP) - totupugan+esu+obu+za+sukai"
+	rom ( name "Top Gun - Ace of the Sky (JP).iso" size 1459978240 crc 9e57ecd2 md5 b610d5cb406f970db846cc7c02844d38 sha1 6205926bd4ded731754c4348d37e3fd847c09f6b )
+)
+
+game (
+	name "Top Gun - Combat Zones (EU)"
+	description "Top Gun - Combat Zones (EU)"
+	rom ( name "Top Gun - Combat Zones (EU).iso" size 1459978240 crc 677421ad md5 7f9422fd21744d54a40e100b15d74198 sha1 e3ef36cb0d5324577abfc4f8e7c079995b0cf768 )
+)
+
+game (
+	name "Top Gun - Combat Zones (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Top Gun - Combat Zones (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Top Gun - Combat Zones (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 677421ad md5 7f9422fd21744d54a40e100b15d74198 sha1 e3ef36cb0d5324577abfc4f8e7c079995b0cf768 )
+)
+
+game (
+	name "Top Gun - Combat Zones (US)"
+	description "Top Gun - Combat Zones (US)"
+	rom ( name "Top Gun - Combat Zones (US).iso" size 1459978240 crc ff8ccd79 md5 7af2e1c73b8f6a4ce7956813b6b95e54 sha1 b9536ffde4c27cbee8a8f0c676388994745265b2 )
+)
+
+game (
+	name "Top Gun - Combat Zones (USA)"
+	description "Top Gun - Combat Zones (USA)"
+	rom ( name "Top Gun - Combat Zones (USA).iso" size 1459978240 crc ff8ccd79 md5 7af2e1c73b8f6a4ce7956813b6b95e54 sha1 b9536ffde4c27cbee8a8f0c676388994745265b2 )
+)
+
+game (
+	name "Totsugeki!! Famicom Wars (Japan)"
+	description "Totsugeki!! Famicom Wars (Japan)"
+	rom ( name "Totsugeki!! Famicom Wars (Japan).iso" size 1459978240 crc ed987629 md5 edd9c78deed24f0807c3ed380a8f61d8 sha1 2abe94f9e12918d5688f1995beff198a2a096350 )
+)
+
+game (
+	name "Totsugeki!! Famicom Wars (JP) - Tu Ji !!+huamikonuozu"
+	description "Totsugeki!! Famicom Wars (JP) - Tu Ji !!+huamikonuozu"
+	rom ( name "Totsugeki!! Famicom Wars (JP).iso" size 1459978240 crc ed987629 md5 edd9c78deed24f0807c3ed380a8f61d8 sha1 2abe94f9e12918d5688f1995beff198a2a096350 )
+)
+
+game (
+	name "Tower of Druaga, The (Japan)"
+	description "Tower of Druaga, The (Japan)"
+	rom ( name "Tower of Druaga, The (Japan).iso" size 1459978240 crc 97f48212 md5 ee1b5ef49f909cc43e202acfe632afdf sha1 f1ff4fa75bd02ad2809d59b27c22dac38c455a5a )
+)
+
+game (
+	name "Tower of Druaga, The (JP) - doruaganoTa"
+	description "Tower of Druaga, The (JP) - doruaganoTa"
+	rom ( name "Tower of Druaga, The (JP).iso" size 1459978240 crc 97f48212 md5 ee1b5ef49f909cc43e202acfe632afdf sha1 f1ff4fa75bd02ad2809d59b27c22dac38c455a5a )
+)
+
+game (
+	name "TransWorld Surf - Next Wave (US)"
+	description "TransWorld Surf - Next Wave (US)"
+	rom ( name "TransWorld Surf - Next Wave (US).iso" size 1459978240 crc 3cb7dde8 md5 1f29e5a7c273edf66f00359d85887fc3 sha1 ea8850975b69a5f766337f6ed8caa4d4c373e0a2 )
+)
+
+game (
+	name "TransWorld Surf - Next Wave (USA)"
+	description "TransWorld Surf - Next Wave (USA)"
+	rom ( name "TransWorld Surf - Next Wave (USA).iso" size 1459978240 crc 3cb7dde8 md5 1f29e5a7c273edf66f00359d85887fc3 sha1 ea8850975b69a5f766337f6ed8caa4d4c373e0a2 )
+)
+
+game (
+	name "Trigger Man (US)"
+	description "Trigger Man (US)"
+	rom ( name "Trigger Man (US).iso" size 1459978240 crc a3f6d1d0 md5 045e37639094d46d33e1b4ef2dcf1ffc sha1 81e37af7a47b71f41fddc29da84cb8a2e65b3ac3 )
+)
+
+game (
+	name "Trigger Man (USA)"
+	description "Trigger Man (USA)"
+	rom ( name "Trigger Man (USA).iso" size 1459978240 crc a3f6d1d0 md5 045e37639094d46d33e1b4ef2dcf1ffc sha1 81e37af7a47b71f41fddc29da84cb8a2e65b3ac3 )
+)
+
+game (
+	name "True Crime - New York City (DE)"
+	description "True Crime - New York City (DE)"
+	rom ( name "True Crime - New York City (DE).iso" size 1459978240 crc 09e363d6 md5 20123e6c1df395c9e63d4af9e42fa160 sha1 60d1295dcd76a0be4ab1a6dd154168c66a8977a2 )
+)
+
+game (
+	name "True Crime - New York City (EU)"
+	description "True Crime - New York City (EU)"
+	rom ( name "True Crime - New York City (EU).iso" size 1459978240 crc d90e962a md5 7a16c6a75cbc069143eea5962be2eeb1 sha1 51e18ca04a6673699809d24a7192dd7a219a6f4e )
+)
+
+game (
+	name "True Crime - New York City (Europe)"
+	description "True Crime - New York City (Europe)"
+	rom ( name "True Crime - New York City (Europe).iso" size 1459978240 crc 0307ccb5 md5 8208a1904e82dd8a15f9088711520225 sha1 7a08b5daea04c1a16bcf574e3edc3c61bd230097 )
+)
+
+game (
+	name "True Crime - New York City (Europe) (Fr,Es,It)"
+	description "True Crime - New York City (Europe) (Fr,Es,It)"
+	rom ( name "True Crime - New York City (Europe) (Fr,Es,It).iso" size 1459978240 crc d90e962a md5 7a16c6a75cbc069143eea5962be2eeb1 sha1 51e18ca04a6673699809d24a7192dd7a219a6f4e )
+)
+
+game (
+	name "True Crime - New York City (GB)"
+	description "True Crime - New York City (GB)"
+	rom ( name "True Crime - New York City (GB).iso" size 1459978240 crc 0307ccb5 md5 8208a1904e82dd8a15f9088711520225 sha1 7a08b5daea04c1a16bcf574e3edc3c61bd230097 )
+)
+
+game (
+	name "True Crime - New York City (Germany)"
+	description "True Crime - New York City (Germany)"
+	rom ( name "True Crime - New York City (Germany).iso" size 1459978240 crc 09e363d6 md5 20123e6c1df395c9e63d4af9e42fa160 sha1 60d1295dcd76a0be4ab1a6dd154168c66a8977a2 )
+)
+
+game (
+	name "True Crime - New York City (US)"
+	description "True Crime - New York City (US)"
+	rom ( name "True Crime - New York City (US).iso" size 1459978240 crc bb036f8c md5 5355a98005eb3b9116101be98da840bd sha1 ca96110d999ddfcf20b6a9e18dc906a7c5fb04c9 )
+)
+
+game (
+	name "True Crime - New York City (USA)"
+	description "True Crime - New York City (USA)"
+	rom ( name "True Crime - New York City (USA).iso" size 1459978240 crc bb036f8c md5 5355a98005eb3b9116101be98da840bd sha1 ca96110d999ddfcf20b6a9e18dc906a7c5fb04c9 )
+)
+
+game (
+	name "True Crime - Streets of LA (EU)"
+	description "True Crime - Streets of LA (EU)"
+	rom ( name "True Crime - Streets of LA (EU).iso" size 1459978240 crc afcfe335 md5 e1f8d525da59ac0bbf2bb86f8038f66e sha1 0621b8cf122b1f7892e463eb162ec47018897726 )
+)
+
+game (
+	name "True Crime - Streets of LA (Europe)"
+	description "True Crime - Streets of LA (Europe)"
+	rom ( name "True Crime - Streets of LA (Europe).iso" size 1459978240 crc 0efe4060 md5 8c05d79afbdeb97b0bb7137ffc459f61 sha1 8114420505cf65be21875c143ae6ea065bd2e1bc )
+)
+
+game (
+	name "True Crime - Streets of LA (Europe) (En,Fr,De)"
+	description "True Crime - Streets of LA (Europe) (En,Fr,De)"
+	rom ( name "True Crime - Streets of LA (Europe) (En,Fr,De).iso" size 1459978240 crc afcfe335 md5 e1f8d525da59ac0bbf2bb86f8038f66e sha1 0621b8cf122b1f7892e463eb162ec47018897726 )
+)
+
+game (
+	name "True Crime - Streets of LA (GB)"
+	description "True Crime - Streets of LA (GB)"
+	rom ( name "True Crime - Streets of LA (GB).iso" size 1459978240 crc 0efe4060 md5 8c05d79afbdeb97b0bb7137ffc459f61 sha1 8114420505cf65be21875c143ae6ea065bd2e1bc )
+)
+
+game (
+	name "True Crime - Streets of LA (Player's Choice) (US)"
+	description "True Crime - Streets of LA (Player's Choice) (US)"
+	rom ( name "True Crime - Streets of LA (Player's Choice) (US).iso" size 1459978240 crc 008c8b49 md5 25a21ec4733cbfdec08f5f6e3f51454c sha1 e6f80176c5d016c33bf796c0db16682406275809 )
+)
+
+game (
+	name "True Crime - Streets of LA (USA)"
+	description "True Crime - Streets of LA (USA)"
+	rom ( name "True Crime - Streets of LA (USA).iso" size 1459978240 crc 008c8b49 md5 25a21ec4733cbfdec08f5f6e3f51454c sha1 e6f80176c5d016c33bf796c0db16682406275809 )
+)
+
+game (
+	name "Tsukande! Mawashite! Dossun Puzzle EggMania (Japan)"
+	description "Tsukande! Mawashite! Dossun Puzzle EggMania (Japan)"
+	rom ( name "Tsukande! Mawashite! Dossun Puzzle EggMania (Japan).iso" size 1459978240 crc 86db9a9f md5 aceab25b950148e8593b0663508d069e sha1 8a4bfc55596bf8279913b9c37e6b608c0e385206 )
+)
+
+game (
+	name "Tsukande! Mawashite! Dossun Puzzle EggMania (JP) - tukande!mawasite!dotusunpazu~ru!!etugumania"
+	description "Tsukande! Mawashite! Dossun Puzzle EggMania (JP) - tukande!mawasite!dotusunpazu~ru!!etugumania"
+	rom ( name "Tsukande! Mawashite! Dossun Puzzle EggMania (JP).iso" size 1459978240 crc 86db9a9f md5 aceab25b950148e8593b0663508d069e sha1 8a4bfc55596bf8279913b9c37e6b608c0e385206 )
+)
+
+game (
+	name "Tube Slider - The Championship of Future Formula (US)"
+	description "Tube Slider - The Championship of Future Formula (US)"
+	rom ( name "Tube Slider - The Championship of Future Formula (US).iso" size 1459978240 crc 0d764212 md5 17487d338dc398b7445e63e1f9b94015 sha1 aa394b7038c264b031e70f46c6360ce7928ff760 )
+)
+
+game (
+	name "Tube Slider - The Championship of Future Formula (USA)"
+	description "Tube Slider - The Championship of Future Formula (USA)"
+	rom ( name "Tube Slider - The Championship of Future Formula (USA).iso" size 1459978240 crc 0d764212 md5 17487d338dc398b7445e63e1f9b94015 sha1 aa394b7038c264b031e70f46c6360ce7928ff760 )
+)
+
+game (
+	name "Turok - Evolution (DE)"
+	description "Turok - Evolution (DE)"
+	rom ( name "Turok - Evolution (DE).iso" size 1459978240 crc f079d911 md5 fdef9194031884f7315015508d251b7c sha1 941f0364250f06d9526f15e47894685f0312e34b )
+)
+
+game (
+	name "Turok - Evolution (EU)"
+	description "Turok - Evolution (EU)"
+	rom ( name "Turok - Evolution (EU).iso" size 1459978240 crc bd21b185 md5 538048a82c03bd6f8e00440e9beb851c sha1 550c2a589df8a2b6b290c4c1de5fcaa018a35007 )
+)
+
+game (
+	name "Turok - Evolution (Europe) (En,Fr,Es,It)"
+	description "Turok - Evolution (Europe) (En,Fr,Es,It)"
+	rom ( name "Turok - Evolution (Europe) (En,Fr,Es,It).iso" size 1459978240 crc bd21b185 md5 538048a82c03bd6f8e00440e9beb851c sha1 550c2a589df8a2b6b290c4c1de5fcaa018a35007 )
+)
+
+game (
+	name "Turok - Evolution (Germany)"
+	description "Turok - Evolution (Germany)"
+	rom ( name "Turok - Evolution (Germany).iso" size 1459978240 crc f079d911 md5 fdef9194031884f7315015508d251b7c sha1 941f0364250f06d9526f15e47894685f0312e34b )
+)
+
+game (
+	name "Turok - Evolution (US)"
+	description "Turok - Evolution (US)"
+	rom ( name "Turok - Evolution (US).iso" size 1459978240 crc 3b09f9ed md5 faed7e27740270e4184c97018b2c8b36 sha1 080da776fce1e3d2f0c5091675a6cd5dc226c05b )
+)
+
+game (
+	name "Turok - Evolution (USA)"
+	description "Turok - Evolution (USA)"
+	rom ( name "Turok - Evolution (USA).iso" size 1459978240 crc 3b09f9ed md5 faed7e27740270e4184c97018b2c8b36 sha1 080da776fce1e3d2f0c5091675a6cd5dc226c05b )
+)
+
+game (
+	name "TY the Tasmanian Tiger - Night of the Quinkan (US)"
+	description "TY the Tasmanian Tiger - Night of the Quinkan (US)"
+	rom ( name "TY the Tasmanian Tiger - Night of the Quinkan (US).iso" size 1459978240 crc 0580f689 md5 96b98555222f5450579af11d89a1ce3b sha1 34c4809c04868086d75c89ba2e1554a5163db85c )
+)
+
+game (
+	name "TY the Tasmanian Tiger - Night of the Quinkan (USA)"
+	description "TY the Tasmanian Tiger - Night of the Quinkan (USA)"
+	rom ( name "TY the Tasmanian Tiger - Night of the Quinkan (USA).iso" size 1459978240 crc 0580f689 md5 96b98555222f5450579af11d89a1ce3b sha1 34c4809c04868086d75c89ba2e1554a5163db85c )
+)
+
+game (
+	name "TY the Tasmanian Tiger (EU)"
+	description "TY the Tasmanian Tiger (EU)"
+	rom ( name "TY the Tasmanian Tiger (EU).iso" size 1459978240 crc b30a2bad md5 a1ce51bc67b68cd7264e9c13ed3f4c16 sha1 1d9387eef888176eb42e12b4e1b85dde1a0c1d95 )
+)
+
+game (
+	name "TY the Tasmanian Tiger (Europe) (En,Fr,De,Es,It)"
+	description "TY the Tasmanian Tiger (Europe) (En,Fr,De,Es,It)"
+	rom ( name "TY the Tasmanian Tiger (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b30a2bad md5 a1ce51bc67b68cd7264e9c13ed3f4c16 sha1 1d9387eef888176eb42e12b4e1b85dde1a0c1d95 )
+)
+
+game (
+	name "TY the Tasmanian Tiger (US)"
+	description "TY the Tasmanian Tiger (US)"
+	rom ( name "TY the Tasmanian Tiger (US).iso" size 1459978240 crc f4d308cc md5 8ab3b0df681cd40cdb9ed70b3f8346f6 sha1 f7c2a13498af113eea7ba6f18903480f52cd398d )
+)
+
+game (
+	name "TY the Tasmanian Tiger (USA)"
+	description "TY the Tasmanian Tiger (USA)"
+	rom ( name "TY the Tasmanian Tiger (USA).iso" size 1459978240 crc f4d308cc md5 8ab3b0df681cd40cdb9ed70b3f8346f6 sha1 f7c2a13498af113eea7ba6f18903480f52cd398d )
+)
+
+game (
+	name "TY the Tasmanian Tiger 2 - Bush Rescue (EU)"
+	description "TY the Tasmanian Tiger 2 - Bush Rescue (EU)"
+	rom ( name "TY the Tasmanian Tiger 2 - Bush Rescue (EU).iso" size 1459978240 crc 28f8097d md5 f1bfb131500479bd6d47898003f8e3a8 sha1 b75e55f94d3392e028e5e530eb6aba72afdf4351 )
+)
+
+game (
+	name "TY the Tasmanian Tiger 2 - Bush Rescue (Europe) (En,Fr,De)"
+	description "TY the Tasmanian Tiger 2 - Bush Rescue (Europe) (En,Fr,De)"
+	rom ( name "TY the Tasmanian Tiger 2 - Bush Rescue (Europe) (En,Fr,De).iso" size 1459978240 crc 28f8097d md5 f1bfb131500479bd6d47898003f8e3a8 sha1 b75e55f94d3392e028e5e530eb6aba72afdf4351 )
+)
+
+game (
+	name "TY the Tasmanian Tiger 2 - Bush Rescue (US)"
+	description "TY the Tasmanian Tiger 2 - Bush Rescue (US)"
+	rom ( name "TY the Tasmanian Tiger 2 - Bush Rescue (US).iso" size 1459978240 crc 228c96be md5 1ebafa9484da7438da17401c526de12e sha1 ecd85c6a6bdf4898b892625ac23a22edf8c62eec )
+)
+
+game (
+	name "TY the Tasmanian Tiger 2 - Bush Rescue (USA)"
+	description "TY the Tasmanian Tiger 2 - Bush Rescue (USA)"
+	rom ( name "TY the Tasmanian Tiger 2 - Bush Rescue (USA).iso" size 1459978240 crc 228c96be md5 1ebafa9484da7438da17401c526de12e sha1 ecd85c6a6bdf4898b892625ac23a22edf8c62eec )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (DE)"
+	description "UEFA Champions League 2004-2005 (DE)"
+	rom ( name "UEFA Champions League 2004-2005 (DE).iso" size 1459978240 crc 06ddb584 md5 2dd03fdf5bf7cae2da173f36574b1876 sha1 62c949e6d64283e5dbf44f9bbdc13379658e97f7 )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (Europe)"
+	description "UEFA Champions League 2004-2005 (Europe)"
+	rom ( name "UEFA Champions League 2004-2005 (Europe).iso" size 1459978240 crc 73c4baf2 md5 8ea0a562cd55ba9dc877ae6b565f4bda sha1 86f390b815688ce7358e813060153d3516cf6640 )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (FR)"
+	description "UEFA Champions League 2004-2005 (FR)"
+	rom ( name "UEFA Champions League 2004-2005 (FR).iso" size 1459978240 crc 3a1d0536 md5 7e7101908a0b4dad8cec10caff746681 sha1 4fe0973f8487131da0f32b3560847b65e72991e2 )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (France)"
+	description "UEFA Champions League 2004-2005 (France)"
+	rom ( name "UEFA Champions League 2004-2005 (France).iso" size 1459978240 crc 3a1d0536 md5 7e7101908a0b4dad8cec10caff746681 sha1 4fe0973f8487131da0f32b3560847b65e72991e2 )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (GB)"
+	description "UEFA Champions League 2004-2005 (GB)"
+	rom ( name "UEFA Champions League 2004-2005 (GB).iso" size 1459978240 crc 73c4baf2 md5 8ea0a562cd55ba9dc877ae6b565f4bda sha1 86f390b815688ce7358e813060153d3516cf6640 )
+)
+
+game (
+	name "UEFA Champions League 2004-2005 (Germany)"
+	description "UEFA Champions League 2004-2005 (Germany)"
+	rom ( name "UEFA Champions League 2004-2005 (Germany).iso" size 1459978240 crc 06ddb584 md5 2dd03fdf5bf7cae2da173f36574b1876 sha1 62c949e6d64283e5dbf44f9bbdc13379658e97f7 )
+)
+
+game (
+	name "UFC - Throwdown (EU)"
+	description "UFC - Throwdown (EU)"
+	rom ( name "UFC - Throwdown (EU).iso" size 1459978240 crc bb3fee57 md5 acde7217cc44964c08359fd25a7a121b sha1 2295101186bc6c5ae5896c92c98cf7809f05c348 )
+)
+
+game (
+	name "UFC - Throwdown (Europe)"
+	description "UFC - Throwdown (Europe)"
+	rom ( name "UFC - Throwdown (Europe).iso" size 1459978240 crc bb3fee57 md5 acde7217cc44964c08359fd25a7a121b sha1 2295101186bc6c5ae5896c92c98cf7809f05c348 )
+)
+
+game (
+	name "UFC - Throwdown (US)"
+	description "UFC - Throwdown (US)"
+	rom ( name "UFC - Throwdown (US).iso" size 1459978240 crc 774ae996 md5 237a4bbea6ed96b4e84998244ad0af96 sha1 af391d624e1bd9659ee2a97f62dce20d6ffd2e20 )
+)
+
+game (
+	name "UFC - Throwdown (USA)"
+	description "UFC - Throwdown (USA)"
+	rom ( name "UFC - Throwdown (USA).iso" size 1459978240 crc 774ae996 md5 237a4bbea6ed96b4e84998244ad0af96 sha1 af391d624e1bd9659ee2a97f62dce20d6ffd2e20 )
+)
+
+game (
+	name "UFC2 Tapout Final Spec (Japan)"
+	description "UFC2 Tapout Final Spec (Japan)"
+	rom ( name "UFC2 Tapout Final Spec (Japan).iso" size 1459978240 crc 1e98a9d1 md5 248c7e0ef61512c64e54d0885535b40a sha1 874af8677e3ca1309ca2a2b8013658918aa0f2fe )
+)
+
+game (
+	name "UFC2 Tapout Final Spec (JP) - aruteimetuto*huaiteingu*tiyanpionsitupu+2+tatupuauto+huainarusupetuku"
+	description "UFC2 Tapout Final Spec (JP) - aruteimetuto*huaiteingu*tiyanpionsitupu+2+tatupuauto+huainarusupetuku"
+	rom ( name "UFC2 Tapout Final Spec (JP).iso" size 1459978240 crc 1e98a9d1 md5 248c7e0ef61512c64e54d0885535b40a sha1 874af8677e3ca1309ca2a2b8013658918aa0f2fe )
+)
+
+game (
+	name "Ultimate Muscle - Legends vs. New Generation (US)"
+	description "Ultimate Muscle - Legends vs. New Generation (US)"
+	rom ( name "Ultimate Muscle - Legends vs. New Generation (US).iso" size 1459978240 crc 2f93164c md5 15c0d6d46e293b6eb8a2a543add8f81a sha1 10b9d5fa0f9d6b4d1707ff0e311783542ccc20d2 )
+)
+
+game (
+	name "Ultimate Muscle - Legends vs. New Generation (USA)"
+	description "Ultimate Muscle - Legends vs. New Generation (USA)"
+	rom ( name "Ultimate Muscle - Legends vs. New Generation (USA).iso" size 1459978240 crc 2f93164c md5 15c0d6d46e293b6eb8a2a543add8f81a sha1 10b9d5fa0f9d6b4d1707ff0e311783542ccc20d2 )
+)
+
+game (
+	name "Ultimate Spider-Man (DE)"
+	description "Ultimate Spider-Man (DE)"
+	rom ( name "Ultimate Spider-Man (DE).iso" size 1459978240 crc 30070485 md5 8a8b841ec64ab63c3dccae5df579758a sha1 5dff825b14dbb92422a9aef711287cb7eacb5273 )
+)
+
+game (
+	name "Ultimate Spider-Man (ES)"
+	description "Ultimate Spider-Man (ES)"
+	rom ( name "Ultimate Spider-Man (ES).iso" size 1459978240 crc 35e22fe7 md5 0e05910842b18564a246774a3f946e20 sha1 0f682cf7eb565e4177fbda33b1af08c79a850c97 )
+)
+
+game (
+	name "Ultimate Spider-Man (EU)"
+	description "Ultimate Spider-Man (EU)"
+	rom ( name "Ultimate Spider-Man (EU).iso" size 1459978240 crc 8438bfae md5 69bb98acf730c0a837f786af8b27b38b sha1 84c39478d8305a35dda0512c132bc70fa05cb5b2 )
+)
+
+game (
+	name "Ultimate Spider-Man (Europe)"
+	description "Ultimate Spider-Man (Europe)"
+	rom ( name "Ultimate Spider-Man (Europe).iso" size 1459978240 crc 8438bfae md5 69bb98acf730c0a837f786af8b27b38b sha1 84c39478d8305a35dda0512c132bc70fa05cb5b2 )
+)
+
+game (
+	name "Ultimate Spider-Man (FR)"
+	description "Ultimate Spider-Man (FR)"
+	rom ( name "Ultimate Spider-Man (FR).iso" size 1459978240 crc c01d176e md5 cf794893821efca19b413156dee536bb sha1 e16c871a2951a0efa457879cb5b550823c7abec4 )
+)
+
+game (
+	name "Ultimate Spider-Man (France)"
+	description "Ultimate Spider-Man (France)"
+	rom ( name "Ultimate Spider-Man (France).iso" size 1459978240 crc c01d176e md5 cf794893821efca19b413156dee536bb sha1 e16c871a2951a0efa457879cb5b550823c7abec4 )
+)
+
+game (
+	name "Ultimate Spider-Man (Germany)"
+	description "Ultimate Spider-Man (Germany)"
+	rom ( name "Ultimate Spider-Man (Germany).iso" size 1459978240 crc 30070485 md5 8a8b841ec64ab63c3dccae5df579758a sha1 5dff825b14dbb92422a9aef711287cb7eacb5273 )
+)
+
+game (
+	name "Ultimate Spider-Man (IT)"
+	description "Ultimate Spider-Man (IT)"
+	rom ( name "Ultimate Spider-Man (IT).iso" size 1459978240 crc c57d1850 md5 e2c5840c06f68a21876c1d52634d9df3 sha1 c75f15972d0574e8ddad277f0789f44e73f54d4d )
+)
+
+game (
+	name "Ultimate Spider-Man (Italy)"
+	description "Ultimate Spider-Man (Italy)"
+	rom ( name "Ultimate Spider-Man (Italy).iso" size 1459978240 crc c57d1850 md5 e2c5840c06f68a21876c1d52634d9df3 sha1 c75f15972d0574e8ddad277f0789f44e73f54d4d )
+)
+
+game (
+	name "Ultimate Spider-Man (Japan)"
+	description "Ultimate Spider-Man (Japan)"
+	rom ( name "Ultimate Spider-Man (Japan).iso" size 1459978240 crc 36393d7c md5 b014cd0fd1c6048398667b4ca613520b sha1 a3f4ed3ba011c6aa66c37fa2d920be28c0d20eb3 )
+)
+
+game (
+	name "Ultimate Spider-Man (JP) - aruteimetuto+supaidaman"
+	description "Ultimate Spider-Man (JP) - aruteimetuto+supaidaman"
+	rom ( name "Ultimate Spider-Man (JP).iso" size 1459978240 crc 36393d7c md5 b014cd0fd1c6048398667b4ca613520b sha1 a3f4ed3ba011c6aa66c37fa2d920be28c0d20eb3 )
+)
+
+game (
+	name "Ultimate Spider-Man (Spain)"
+	description "Ultimate Spider-Man (Spain)"
+	rom ( name "Ultimate Spider-Man (Spain).iso" size 1459978240 crc 35e22fe7 md5 0e05910842b18564a246774a3f946e20 sha1 0f682cf7eb565e4177fbda33b1af08c79a850c97 )
+)
+
+game (
+	name "Ultimate Spider-Man (US)"
+	description "Ultimate Spider-Man (US)"
+	rom ( name "Ultimate Spider-Man (US).iso" size 1459978240 crc 1858118d md5 2fc4364cba13534eacda868311c3d6e4 sha1 602dc1ff1537f5944093fe944a24a16dcf1144fa )
+)
+
+game (
+	name "Ultimate Spider-Man (USA)"
+	description "Ultimate Spider-Man (USA)"
+	rom ( name "Ultimate Spider-Man (USA).iso" size 1459978240 crc 1858118d md5 2fc4364cba13534eacda868311c3d6e4 sha1 602dc1ff1537f5944093fe944a24a16dcf1144fa )
+)
+
+game (
+	name "Una Serie de Catastroficas Desdichas de Lemony Snicket (ES)"
+	description "Una Serie de Catastroficas Desdichas de Lemony Snicket (ES)"
+	rom ( name "Una Serie de Catastroficas Desdichas de Lemony Snicket (ES).iso" size 1459978240 crc 03487e7a md5 931ffece90fcb762114a0b4f2e78c270 sha1 4b268f922c874f9c1448738c86cabcd1f1b6639e )
+)
+
+game (
+	name "Una Serie de Catastroficas Desdichas de Lemony Snicket (Spain)"
+	description "Una Serie de Catastroficas Desdichas de Lemony Snicket (Spain)"
+	rom ( name "Una Serie de Catastroficas Desdichas de Lemony Snicket (Spain).iso" size 1459978240 crc 03487e7a md5 931ffece90fcb762114a0b4f2e78c270 sha1 4b268f922c874f9c1448738c86cabcd1f1b6639e )
+)
+
+game (
+	name "Universal Studios Japan Adventure (Japan)"
+	description "Universal Studios Japan Adventure (Japan)"
+	rom ( name "Universal Studios Japan Adventure (Japan).iso" size 1459978240 crc 9c1bc747 md5 0c69fcacf8f91e7d3a8681a45e3a6560 sha1 ddf05a46dca79ad3009d8a670995da32d51de3fe )
+)
+
+game (
+	name "Universal Studios Japan Adventure (JP) - yunibasarusutazioziyapanadobentiya"
+	description "Universal Studios Japan Adventure (JP) - yunibasarusutazioziyapanadobentiya"
+	rom ( name "Universal Studios Japan Adventure (JP).iso" size 1459978240 crc 9c1bc747 md5 0c69fcacf8f91e7d3a8681a45e3a6560 sha1 ddf05a46dca79ad3009d8a670995da32d51de3fe )
+)
+
+game (
+	name "Universal Studios Theme Park Adventure (EU)"
+	description "Universal Studios Theme Park Adventure (EU)"
+	rom ( name "Universal Studios Theme Park Adventure (EU).iso" size 1459978240 crc 8a739c2b md5 d991a32c4c2b212cb5a7e2781500597c sha1 5daea861237316596c4289cf5e85e95903736924 )
+)
+
+game (
+	name "Universal Studios Theme Park Adventure (Europe) (En,Fr,De,Es)"
+	description "Universal Studios Theme Park Adventure (Europe) (En,Fr,De,Es)"
+	rom ( name "Universal Studios Theme Park Adventure (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 8a739c2b md5 d991a32c4c2b212cb5a7e2781500597c sha1 5daea861237316596c4289cf5e85e95903736924 )
+)
+
+game (
+	name "Universal Studios Theme Park Adventure (US)"
+	description "Universal Studios Theme Park Adventure (US)"
+	rom ( name "Universal Studios Theme Park Adventure (US).iso" size 1459978240 crc 6cdf5761 md5 8636f8a4aec34663bf80551e6d91c1f0 sha1 eadf3e9c6b30e3214c94dcefd694f10572d65aa3 )
+)
+
+game (
+	name "Universal Studios Theme Park Adventure (USA)"
+	description "Universal Studios Theme Park Adventure (USA)"
+	rom ( name "Universal Studios Theme Park Adventure (USA).iso" size 1459978240 crc 6cdf5761 md5 8636f8a4aec34663bf80551e6d91c1f0 sha1 eadf3e9c6b30e3214c94dcefd694f10572d65aa3 )
+)
+
+game (
+	name "Urban Freestyle Soccer (EU)"
+	description "Urban Freestyle Soccer (EU)"
+	rom ( name "Urban Freestyle Soccer (EU).iso" size 1459978240 crc 01cf3e39 md5 b80e5f1622f83c829205a17235a43e99 sha1 6c12e2f608077a678a3a1fe2f35903a61b249552 )
+)
+
+game (
+	name "Urban Freestyle Soccer (Europe) (En,Fr,De,Es,It)"
+	description "Urban Freestyle Soccer (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Urban Freestyle Soccer (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 01cf3e39 md5 b80e5f1622f83c829205a17235a43e99 sha1 6c12e2f608077a678a3a1fe2f35903a61b249552 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (Europe) (En,Fr,De,Es,Nl)"
+	description "Urbz, The - Sims in the City (Europe) (En,Fr,De,Es,Nl)"
+	rom ( name "Urbz, The - Sims in the City (Europe) (En,Fr,De,Es,Nl).iso" size 1459978240 crc 8b2031cd md5 a665b11c4448646e3fc8ef3e0a14506d sha1 1299c18c26ac8dd4b6ee0d72f21ca56f00b25122 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (GB)"
+	description "Urbz, The - Sims in the City (GB)"
+	rom ( name "Urbz, The - Sims in the City (GB).iso" size 1459978240 crc 8b2031cd md5 a665b11c4448646e3fc8ef3e0a14506d sha1 1299c18c26ac8dd4b6ee0d72f21ca56f00b25122 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (Japan)"
+	description "Urbz, The - Sims in the City (Japan)"
+	rom ( name "Urbz, The - Sims in the City (Japan).iso" size 1459978240 crc b19ef16d md5 5aea50ef2bbc78c2ae41aec1f8367fef sha1 924801e0a65ebcf963ce831eaf8fbbb2a5640b27 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (JP) - zaabuzu+simuzuinzasitei"
+	description "Urbz, The - Sims in the City (JP) - zaabuzu+simuzuinzasitei"
+	rom ( name "Urbz, The - Sims in the City (JP).iso" size 1459978240 crc b19ef16d md5 5aea50ef2bbc78c2ae41aec1f8367fef sha1 924801e0a65ebcf963ce831eaf8fbbb2a5640b27 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (US)"
+	description "Urbz, The - Sims in the City (US)"
+	rom ( name "Urbz, The - Sims in the City (US).iso" size 1459978240 crc cf228612 md5 769774f4cc8849ad9aee8124db2b02ab sha1 91c3f970d526c9878cfb8737252d77854fab3536 )
+)
+
+game (
+	name "Urbz, The - Sims in the City (USA)"
+	description "Urbz, The - Sims in the City (USA)"
+	rom ( name "Urbz, The - Sims in the City (USA).iso" size 1459978240 crc cf228612 md5 769774f4cc8849ad9aee8124db2b02ab sha1 91c3f970d526c9878cfb8737252d77854fab3536 )
+)
+
+game (
+	name "V-Rally 3 (Europe) (En,Fr,De,Es,It)"
+	description "V-Rally 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "V-Rally 3 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 239e56cf md5 ddd092926231a913f8d5917181389a1b sha1 3e865b6fbe436582ce6adf4f9e80e4d8507f7dc5 )
+)
+
+game (
+	name "V-Rally 3 (GB)"
+	description "V-Rally 3 (GB)"
+	rom ( name "V-Rally 3 (GB).iso" size 1459978240 crc 239e56cf md5 ddd092926231a913f8d5917181389a1b sha1 3e865b6fbe436582ce6adf4f9e80e4d8507f7dc5 )
+)
+
+game (
+	name "V-Rally 3 (Japan) (En,Ja,Fr,De,Es,It)"
+	description "V-Rally 3 (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "V-Rally 3 (Japan) (En,Ja,Fr,De,Es,It).iso" size 1459978240 crc c7182992 md5 712ace43bce94c4cbbf0d956853dcadb sha1 f8bd9439dfee3b5b54c5b20ae19a415c78d809bf )
+)
+
+game (
+	name "V-Rally 3 (JP) - V-RALLY3"
+	description "V-Rally 3 (JP) - V-RALLY3"
+	rom ( name "V-Rally 3 (JP).iso" size 1459978240 crc c7182992 md5 712ace43bce94c4cbbf0d956853dcadb sha1 f8bd9439dfee3b5b54c5b20ae19a415c78d809bf )
+)
+
+game (
+	name "Vexx (EU)"
+	description "Vexx (EU)"
+	rom ( name "Vexx (EU).iso" size 1459978240 crc 140f8abb md5 1fed1adf1a9918ec4f38856216c71188 sha1 35f69444fd214b865752a7f8fa7dd351f24fc773 )
+)
+
+game (
+	name "Vexx (Europe) (En,Fr,De,Es,It)"
+	description "Vexx (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Vexx (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 140f8abb md5 1fed1adf1a9918ec4f38856216c71188 sha1 35f69444fd214b865752a7f8fa7dd351f24fc773 )
+)
+
+game (
+	name "Vexx (US)"
+	description "Vexx (US)"
+	rom ( name "Vexx (US).iso" size 1459978240 crc 66c7457b md5 4198d93d1fc7a267a4ae5b78c22e8a64 sha1 071742b3735d768bdf0fdc822808045c8aa8791b )
+)
+
+game (
+	name "Vexx (USA)"
+	description "Vexx (USA)"
+	rom ( name "Vexx (USA).iso" size 1459978240 crc 66c7457b md5 4198d93d1fc7a267a4ae5b78c22e8a64 sha1 071742b3735d768bdf0fdc822808045c8aa8791b )
+)
+
+game (
+	name "Viewtiful Joe - Battle Carnival (Japan)"
+	description "Viewtiful Joe - Battle Carnival (Japan)"
+	rom ( name "Viewtiful Joe - Battle Carnival (Japan).iso" size 1459978240 crc 83f0950c md5 eba1f35591d9c04e8ecfbe0fab1b6d5c sha1 378808c3f78444f70f28e98b30a82dab63d63e65 )
+)
+
+game (
+	name "Viewtiful Joe - Battle Carnival (JP) - biyuteihuruziyo+batorukanibaru"
+	description "Viewtiful Joe - Battle Carnival (JP) - biyuteihuruziyo+batorukanibaru"
+	rom ( name "Viewtiful Joe - Battle Carnival (JP).iso" size 1459978240 crc 83f0950c md5 eba1f35591d9c04e8ecfbe0fab1b6d5c sha1 378808c3f78444f70f28e98b30a82dab63d63e65 )
+)
+
+game (
+	name "Viewtiful Joe - Red Hot Rumble (EU)"
+	description "Viewtiful Joe - Red Hot Rumble (EU)"
+	rom ( name "Viewtiful Joe - Red Hot Rumble (EU).iso" size 1459978240 crc 3a26b188 md5 41dac2e1ff9d5eee1b939fac3165af2f sha1 555789c864fa4fa3d8f21d502702fbf622a4eea1 )
+)
+
+game (
+	name "Viewtiful Joe - Red Hot Rumble (Europe) (En,Fr,De,Es,It)"
+	description "Viewtiful Joe - Red Hot Rumble (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Viewtiful Joe - Red Hot Rumble (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 3a26b188 md5 41dac2e1ff9d5eee1b939fac3165af2f sha1 555789c864fa4fa3d8f21d502702fbf622a4eea1 )
+)
+
+game (
+	name "Viewtiful Joe - Red Hot Rumble (US)"
+	description "Viewtiful Joe - Red Hot Rumble (US)"
+	rom ( name "Viewtiful Joe - Red Hot Rumble (US).iso" size 1459978240 crc 68af0a7d md5 8632b2fde4697a5fa37d11f753487ac6 sha1 c166e3a11af341af8a2d939b71b855ede56208ba )
+)
+
+game (
+	name "Viewtiful Joe - Red Hot Rumble (USA)"
+	description "Viewtiful Joe - Red Hot Rumble (USA)"
+	rom ( name "Viewtiful Joe - Red Hot Rumble (USA).iso" size 1459978240 crc 68af0a7d md5 8632b2fde4697a5fa37d11f753487ac6 sha1 c166e3a11af341af8a2d939b71b855ede56208ba )
+)
+
+game (
+	name "Viewtiful Joe (Demo) (DE)"
+	description "Viewtiful Joe (Demo) (DE)"
+	rom ( name "Viewtiful Joe (Demo) (DE).iso" size 1459978240 crc fca0084c md5 34a96bc2999c05cf2812efd54870849e sha1 5c28fe99af51f2e56917cc922620e7fb6ac294fc )
+)
+
+game (
+	name "Viewtiful Joe (EU)"
+	description "Viewtiful Joe (EU)"
+	rom ( name "Viewtiful Joe (EU).iso" size 1459978240 crc 205a62cf md5 a1a4dd42b98207b744215e9e1140de11 sha1 dd5739a45974f70f4ce1ce0e309d2341cde5eac9 )
+)
+
+game (
+	name "Viewtiful Joe (Europe) (En,Fr,De,Es,It)"
+	description "Viewtiful Joe (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Viewtiful Joe (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 205a62cf md5 a1a4dd42b98207b744215e9e1140de11 sha1 dd5739a45974f70f4ce1ce0e309d2341cde5eac9 )
+)
+
+game (
+	name "Viewtiful Joe (Europe) (Promo)"
+	description "Viewtiful Joe (Europe) (Promo)"
+	rom ( name "Viewtiful Joe (Europe) (Promo).iso" size 1459978240 crc aff83635 md5 d77b3dbb6555a82feff166a40401dc7a sha1 924667a79d97d813d1cf1cb53e8d653af2378d13 )
+)
+
+game (
+	name "Viewtiful Joe (Germany) (En,Fr,De,Es,It) (Demo)"
+	description "Viewtiful Joe (Germany) (En,Fr,De,Es,It) (Demo)"
+	rom ( name "Viewtiful Joe (Germany) (En,Fr,De,Es,It) (Demo).iso" size 1459978240 crc fca0084c md5 34a96bc2999c05cf2812efd54870849e sha1 5c28fe99af51f2e56917cc922620e7fb6ac294fc )
+)
+
+game (
+	name "Viewtiful Joe (Japan)"
+	description "Viewtiful Joe (Japan)"
+	rom ( name "Viewtiful Joe (Japan).iso" size 1459978240 crc 3c5b5171 md5 5e0eb6b53bd2fc7e79fb211cae777428 sha1 1a571d59434ea2196bdda3b43b65e0552625806e )
+)
+
+game (
+	name "Viewtiful Joe (JP) - biyuteihuru+ziyo"
+	description "Viewtiful Joe (JP) - biyuteihuru+ziyo"
+	rom ( name "Viewtiful Joe (JP).iso" size 1459978240 crc 3c5b5171 md5 5e0eb6b53bd2fc7e79fb211cae777428 sha1 1a571d59434ea2196bdda3b43b65e0552625806e )
+)
+
+game (
+	name "Viewtiful Joe (Promo) (EU)"
+	description "Viewtiful Joe (Promo) (EU)"
+	rom ( name "Viewtiful Joe (Promo) (EU).iso" size 1459978240 crc aff83635 md5 d77b3dbb6555a82feff166a40401dc7a sha1 924667a79d97d813d1cf1cb53e8d653af2378d13 )
+)
+
+game (
+	name "Viewtiful Joe (US)"
+	description "Viewtiful Joe (US)"
+	rom ( name "Viewtiful Joe (US).iso" size 1459978240 crc 121a9a8e md5 5137df30cb87ee7987bebab8c19cb994 sha1 7731dfedec98750cdb57fa401a19be24956e38a2 )
+)
+
+game (
+	name "Viewtiful Joe (USA)"
+	description "Viewtiful Joe (USA)"
+	rom ( name "Viewtiful Joe (USA).iso" size 1459978240 crc 121a9a8e md5 5137df30cb87ee7987bebab8c19cb994 sha1 7731dfedec98750cdb57fa401a19be24956e38a2 )
+)
+
+game (
+	name "Viewtiful Joe 2 - Black Film no Nazo (Japan)"
+	description "Viewtiful Joe 2 - Black Film no Nazo (Japan)"
+	rom ( name "Viewtiful Joe 2 - Black Film no Nazo (Japan).iso" size 1459978240 crc 3b2e6215 md5 4ec086aa491d7623a7b75b8e898d3175 sha1 9c0da460719a82ebf32465c1b69d66bc31c3b637 )
+)
+
+game (
+	name "Viewtiful Joe 2 - Black Film no Nazo (JP) - biyuteihuru+ziyo+2+buratukuhuirumunoMi"
+	description "Viewtiful Joe 2 - Black Film no Nazo (JP) - biyuteihuru+ziyo+2+buratukuhuirumunoMi"
+	rom ( name "Viewtiful Joe 2 - Black Film no Nazo (JP).iso" size 1459978240 crc 3b2e6215 md5 4ec086aa491d7623a7b75b8e898d3175 sha1 9c0da460719a82ebf32465c1b69d66bc31c3b637 )
+)
+
+game (
+	name "Viewtiful Joe 2 (EU)"
+	description "Viewtiful Joe 2 (EU)"
+	rom ( name "Viewtiful Joe 2 (EU).iso" size 1459978240 crc 937045a1 md5 135ce44a440289e9a8ba6e06500615fe sha1 a87e88afe94e133ef2ff774b6679232b0cb19cb5 )
+)
+
+game (
+	name "Viewtiful Joe 2 (Europe) (En,Fr,De,Es,It)"
+	description "Viewtiful Joe 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Viewtiful Joe 2 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 937045a1 md5 135ce44a440289e9a8ba6e06500615fe sha1 a87e88afe94e133ef2ff774b6679232b0cb19cb5 )
+)
+
+game (
+	name "Viewtiful Joe 2 (US)"
+	description "Viewtiful Joe 2 (US)"
+	rom ( name "Viewtiful Joe 2 (US).iso" size 1459978240 crc f07ac0d5 md5 a699c7877262014a1aee35793a945875 sha1 0d28d082d9c4860661cda87e868fc242cd9d2453 )
+)
+
+game (
+	name "Viewtiful Joe 2 (USA)"
+	description "Viewtiful Joe 2 (USA)"
+	rom ( name "Viewtiful Joe 2 (USA).iso" size 1459978240 crc f07ac0d5 md5 a699c7877262014a1aee35793a945875 sha1 0d28d082d9c4860661cda87e868fc242cd9d2453 )
+)
+
+game (
+	name "Viewtiful Joe Revival (Japan)"
+	description "Viewtiful Joe Revival (Japan)"
+	rom ( name "Viewtiful Joe Revival (Japan).iso" size 1459978240 crc 6ff8a1a6 md5 ff63b99622cb342edf18403112669d7e sha1 37fb61386495a7c5da1d50a70d17f92ac5f49372 )
+)
+
+game (
+	name "Viewtiful Joe Revival (JP) - biyuteihuruziyo+ribaibaru"
+	description "Viewtiful Joe Revival (JP) - biyuteihuruziyo+ribaibaru"
+	rom ( name "Viewtiful Joe Revival (JP).iso" size 1459978240 crc 6ff8a1a6 md5 ff63b99622cb342edf18403112669d7e sha1 37fb61386495a7c5da1d50a70d17f92ac5f49372 )
+)
+
+game (
+	name "Virtua Fighter Cyber Generation - Judgment Six no Yabou (Japan)"
+	description "Virtua Fighter Cyber Generation - Judgment Six no Yabou (Japan)"
+	rom ( name "Virtua Fighter Cyber Generation - Judgment Six no Yabou (Japan).iso" size 1459978240 crc 755ddecf md5 69901ab660b48fe8c716e40d9058c2ad sha1 9a181134b3f0bbd236e0a8e0860e1c711ee08b03 )
+)
+
+game (
+	name "Virtua Fighter Cyber Generation - Judgment Six no Yabou (JP) - batiyahuaitasaibazieneresiyon+ziyatuzimentositukusunoYe Wang"
+	description "Virtua Fighter Cyber Generation - Judgment Six no Yabou (JP) - batiyahuaitasaibazieneresiyon+ziyatuzimentositukusunoYe Wang"
+	rom ( name "Virtua Fighter Cyber Generation - Judgment Six no Yabou (JP).iso" size 1459978240 crc 755ddecf md5 69901ab660b48fe8c716e40d9058c2ad sha1 9a181134b3f0bbd236e0a8e0860e1c711ee08b03 )
+)
+
+game (
+	name "Virtua Quest (US)"
+	description "Virtua Quest (US)"
+	rom ( name "Virtua Quest (US).iso" size 1459978240 crc 95c68988 md5 86f5d3dcdbb5b6bf0f97f5e06e1335ed sha1 aac4b3be734d295397eacf80d69da1f82def2f3e )
+)
+
+game (
+	name "Virtua Quest (USA)"
+	description "Virtua Quest (USA)"
+	rom ( name "Virtua Quest (USA).iso" size 1459978240 crc 95c68988 md5 86f5d3dcdbb5b6bf0f97f5e06e1335ed sha1 aac4b3be734d295397eacf80d69da1f82def2f3e )
+)
+
+game (
+	name "Virtua Striker 2002 (US)"
+	description "Virtua Striker 2002 (US)"
+	rom ( name "Virtua Striker 2002 (US).iso" size 1459978240 crc c5e3de37 md5 eaaecc530771a5fd37aa615dafdb834c sha1 8daa5dceae514426b52d0ddc0e0b106e0a77a029 )
+)
+
+game (
+	name "Virtua Striker 2002 (USA)"
+	description "Virtua Striker 2002 (USA)"
+	rom ( name "Virtua Striker 2002 (USA).iso" size 1459978240 crc c5e3de37 md5 eaaecc530771a5fd37aa615dafdb834c sha1 8daa5dceae514426b52d0ddc0e0b106e0a77a029 )
+)
+
+game (
+	name "Virtua Striker 3 Ver. 2002 (EU)"
+	description "Virtua Striker 3 Ver. 2002 (EU)"
+	rom ( name "Virtua Striker 3 Ver. 2002 (EU).iso" size 1459978240 crc 8f84ded4 md5 2d8c6f6877e838e49352a2e69ac22dab sha1 164d9e17eca273cc5b199410439445514a9027ac )
+)
+
+game (
+	name "Virtua Striker 3 Ver. 2002 (Europe) (En,Fr,De,Es,It)"
+	description "Virtua Striker 3 Ver. 2002 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Virtua Striker 3 Ver. 2002 (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 8f84ded4 md5 2d8c6f6877e838e49352a2e69ac22dab sha1 164d9e17eca273cc5b199410439445514a9027ac )
+)
+
+game (
+	name "Virtua Striker 3 Ver. 2002 (Japan)"
+	description "Virtua Striker 3 Ver. 2002 (Japan)"
+	rom ( name "Virtua Striker 3 Ver. 2002 (Japan).iso" size 1459978240 crc b0293fed md5 6b3e9ad3a312c425844177c0317cb1b3 sha1 e4add77b14837f6aa46a6b0fe2df459d1e2b72ab )
+)
+
+game (
+	name "Virtua Striker 3 Ver. 2002 (JP) - batiyasutoraika3+Ver.2002"
+	description "Virtua Striker 3 Ver. 2002 (JP) - batiyasutoraika3+Ver.2002"
+	rom ( name "Virtua Striker 3 Ver. 2002 (JP).iso" size 1459978240 crc b0293fed md5 6b3e9ad3a312c425844177c0317cb1b3 sha1 e4add77b14837f6aa46a6b0fe2df459d1e2b72ab )
+)
+
+game (
+	name "Wai Wai Golf (Japan)"
+	description "Wai Wai Golf (Japan)"
+	rom ( name "Wai Wai Golf (Japan).iso" size 1459978240 crc a7b76963 md5 5a8eb5e15b92a9704dd11f54bbddf2aa sha1 d01159f40f3a47e434275b40970aa0844ee91892 )
+)
+
+game (
+	name "Wai Wai Golf (JP) - waiwaigoruhu"
+	description "Wai Wai Golf (JP) - waiwaigoruhu"
+	rom ( name "Wai Wai Golf (JP).iso" size 1459978240 crc a7b76963 md5 5a8eb5e15b92a9704dd11f54bbddf2aa sha1 d01159f40f3a47e434275b40970aa0844ee91892 )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (EU)"
+	description "Wallace & Gromit in Project Zoo (EU)"
+	rom ( name "Wallace & Gromit in Project Zoo (EU).iso" size 1459978240 crc 9071b965 md5 5843838d805a05e547bddcfc83b59239 sha1 ce6c54f2a3508a92aa28798e51a8e019c4d23075 )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (Europe)"
+	description "Wallace & Gromit in Project Zoo (Europe)"
+	rom ( name "Wallace & Gromit in Project Zoo (Europe).iso" size 1459978240 crc c58576dd md5 dfe55017cc9a76da5863382f4f48de3f sha1 adcbdc5a4fdb2701ad2130f68be20c577e4dc981 )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (Europe) (En,Fr,De,Es,It)"
+	description "Wallace & Gromit in Project Zoo (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wallace & Gromit in Project Zoo (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 9071b965 md5 5843838d805a05e547bddcfc83b59239 sha1 ce6c54f2a3508a92aa28798e51a8e019c4d23075 )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (GB)"
+	description "Wallace & Gromit in Project Zoo (GB)"
+	rom ( name "Wallace & Gromit in Project Zoo (GB).iso" size 1459978240 crc c58576dd md5 dfe55017cc9a76da5863382f4f48de3f sha1 adcbdc5a4fdb2701ad2130f68be20c577e4dc981 )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (US)"
+	description "Wallace & Gromit in Project Zoo (US)"
+	rom ( name "Wallace & Gromit in Project Zoo (US).iso" size 1459978240 crc a5369975 md5 3cf7f689e268ae505f36545bf1dd5e14 sha1 350dde55f43f3eae65e110f10a20484f71a1c5cb )
+)
+
+game (
+	name "Wallace & Gromit in Project Zoo (USA)"
+	description "Wallace & Gromit in Project Zoo (USA)"
+	rom ( name "Wallace & Gromit in Project Zoo (USA).iso" size 1459978240 crc a5369975 md5 3cf7f689e268ae505f36545bf1dd5e14 sha1 350dde55f43f3eae65e110f10a20484f71a1c5cb )
+)
+
+game (
+	name "Walt Disney Pictures Presents Meet the Robinsons (US)"
+	description "Walt Disney Pictures Presents Meet the Robinsons (US)"
+	rom ( name "Walt Disney Pictures Presents Meet the Robinsons (US).iso" size 1459978240 crc f9986b70 md5 938d0b2f2c46aeb3503a3f78a69c3fea sha1 0a5b6ed7fc0e2ea441afd0da653e8f8470d15663 )
+)
+
+game (
+	name "Walt Disney Pictures Presents Meet the Robinsons (USA)"
+	description "Walt Disney Pictures Presents Meet the Robinsons (USA)"
+	rom ( name "Walt Disney Pictures Presents Meet the Robinsons (USA).iso" size 1459978240 crc f9986b70 md5 938d0b2f2c46aeb3503a3f78a69c3fea sha1 0a5b6ed7fc0e2ea441afd0da653e8f8470d15663 )
+)
+
+game (
+	name "Wario World (EU)"
+	description "Wario World (EU)"
+	rom ( name "Wario World (EU).iso" size 1459978240 crc b3bc4aee md5 8ce6a4ef8866b51424078b7257ef9014 sha1 a8cf5dc1085550d909e991a784cc38809a1ebcec )
+)
+
+game (
+	name "Wario World (Europe) (En,Fr,De,Es,It)"
+	description "Wario World (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wario World (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc b3bc4aee md5 8ce6a4ef8866b51424078b7257ef9014 sha1 a8cf5dc1085550d909e991a784cc38809a1ebcec )
+)
+
+game (
+	name "Wario World (Japan)"
+	description "Wario World (Japan)"
+	rom ( name "Wario World (Japan).iso" size 1459978240 crc abf6cfad md5 33483304b7f190ddad9581bc271f6ce0 sha1 f589e452625c246d8b83ec8bbe2b0711386a42e1 )
+)
+
+game (
+	name "Wario World (JP) - wariowarudo"
+	description "Wario World (JP) - wariowarudo"
+	rom ( name "Wario World (JP).iso" size 1459978240 crc abf6cfad md5 33483304b7f190ddad9581bc271f6ce0 sha1 f589e452625c246d8b83ec8bbe2b0711386a42e1 )
+)
+
+game (
+	name "Wario World (US)"
+	description "Wario World (US)"
+	rom ( name "Wario World (US).iso" size 1459978240 crc 6a9546aa md5 6d8785d3212d7f51a225e80500a1f5eb sha1 c8dfa091d738e3d0e79014929ba0f2e3e3f4501c )
+)
+
+game (
+	name "Wario World (USA)"
+	description "Wario World (USA)"
+	rom ( name "Wario World (USA).iso" size 1459978240 crc 6a9546aa md5 6d8785d3212d7f51a225e80500a1f5eb sha1 c8dfa091d738e3d0e79014929ba0f2e3e3f4501c )
+)
+
+game (
+	name "WarioWare, Inc. - Mega Party Game$! (EU)"
+	description "WarioWare, Inc. - Mega Party Game$! (EU)"
+	rom ( name "WarioWare, Inc. - Mega Party Game$! (EU).iso" size 1459978240 crc e89580be md5 3446c699c1b20b72988b81f6c6d2e225 sha1 a08457d9ba76996346653235181f9ce04b3b0f10 )
+)
+
+game (
+	name "WarioWare, Inc. - Mega Party Game$! (Europe) (En,Fr,De,Es,It)"
+	description "WarioWare, Inc. - Mega Party Game$! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "WarioWare, Inc. - Mega Party Game$! (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc e89580be md5 3446c699c1b20b72988b81f6c6d2e225 sha1 a08457d9ba76996346653235181f9ce04b3b0f10 )
+)
+
+game (
+	name "WarioWare, Inc. - Mega Party Game$! (US)"
+	description "WarioWare, Inc. - Mega Party Game$! (US)"
+	rom ( name "WarioWare, Inc. - Mega Party Game$! (US).iso" size 1459978240 crc 673e9ce1 md5 556075718d1b65fe04a9386722fcec8a sha1 afde21223299e24b41f38034528a5a186a1e71ef )
+)
+
+game (
+	name "WarioWare, Inc. - Mega Party Game$! (USA)"
+	description "WarioWare, Inc. - Mega Party Game$! (USA)"
+	rom ( name "WarioWare, Inc. - Mega Party Game$! (USA).iso" size 1459978240 crc 673e9ce1 md5 556075718d1b65fe04a9386722fcec8a sha1 afde21223299e24b41f38034528a5a186a1e71ef )
+)
+
+game (
+	name "Warrior Blade - Rastan vs. Barbarian (Japan)"
+	description "Warrior Blade - Rastan vs. Barbarian (Japan)"
+	rom ( name "Warrior Blade - Rastan vs. Barbarian (Japan).iso" size 1459978240 crc e7fdf42f md5 7b5c92f41c487f14fdb5a5fbabfe73a9 sha1 b29bf648395b527bd2d123bc8c4201add3d8ece0 )
+)
+
+game (
+	name "Warrior Blade - Rastan vs. Barbarian (JP)"
+	description "Warrior Blade - Rastan vs. Barbarian (JP)"
+	rom ( name "Warrior Blade - Rastan vs. Barbarian (JP).iso" size 1459978240 crc e7fdf42f md5 7b5c92f41c487f14fdb5a5fbabfe73a9 sha1 b29bf648395b527bd2d123bc8c4201add3d8ece0 )
+)
+
+game (
+	name "Wave Race - Blue Storm (EU)"
+	description "Wave Race - Blue Storm (EU)"
+	rom ( name "Wave Race - Blue Storm (EU).iso" size 1459978240 crc a78bb8f3 md5 7b1ee77bb2f8ac5dbe9f000cbc6db5fa sha1 61626809881164567ee77f196ef36b01bd10d668 )
+)
+
+game (
+	name "Wave Race - Blue Storm (Europe) (En,Fr,De,Es,It)"
+	description "Wave Race - Blue Storm (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wave Race - Blue Storm (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc a78bb8f3 md5 7b1ee77bb2f8ac5dbe9f000cbc6db5fa sha1 61626809881164567ee77f196ef36b01bd10d668 )
+)
+
+game (
+	name "Wave Race - Blue Storm (Japan)"
+	description "Wave Race - Blue Storm (Japan)"
+	rom ( name "Wave Race - Blue Storm (Japan).iso" size 1459978240 crc fd72a6f0 md5 a34dd206c49f78056b1a4fd6a9854752 sha1 a49bffe71f141172610ca74d82142d539fbf9006 )
+)
+
+game (
+	name "Wave Race - Blue Storm (JP) - ueburesu+burusutomu"
+	description "Wave Race - Blue Storm (JP) - ueburesu+burusutomu"
+	rom ( name "Wave Race - Blue Storm (JP).iso" size 1459978240 crc fd72a6f0 md5 a34dd206c49f78056b1a4fd6a9854752 sha1 a49bffe71f141172610ca74d82142d539fbf9006 )
+)
+
+game (
+	name "Wave Race - Blue Storm (US)"
+	description "Wave Race - Blue Storm (US)"
+	rom ( name "Wave Race - Blue Storm (US).iso" size 1459978240 crc d2ee9ccd md5 dff711fc30af8010da68502e62e03827 sha1 389ce9dc75074a1ca43097c7a105815c7d20ee2c )
+)
+
+game (
+	name "Wave Race - Blue Storm (USA)"
+	description "Wave Race - Blue Storm (USA)"
+	rom ( name "Wave Race - Blue Storm (USA).iso" size 1459978240 crc d2ee9ccd md5 dff711fc30af8010da68502e62e03827 sha1 389ce9dc75074a1ca43097c7a105815c7d20ee2c )
+)
+
+game (
+	name "Whirl Tour (EU)"
+	description "Whirl Tour (EU)"
+	rom ( name "Whirl Tour (EU).iso" size 1459978240 crc f608b1df md5 b3c232928b149c83daa0e7a030e98f97 sha1 b563796617c04c6f90938a09b8d8348fac006a88 )
+)
+
+game (
+	name "Whirl Tour (Europe) (En,Fr,De,Es,It)"
+	description "Whirl Tour (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Whirl Tour (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc f608b1df md5 b3c232928b149c83daa0e7a030e98f97 sha1 b563796617c04c6f90938a09b8d8348fac006a88 )
+)
+
+game (
+	name "Whirl Tour (US)"
+	description "Whirl Tour (US)"
+	rom ( name "Whirl Tour (US).iso" size 1459978240 crc 2b4c7d32 md5 fb9ad38f2b197375456dc33c3530ad17 sha1 77b67764d42a45187a16c928e9ed7640237fea95 )
+)
+
+game (
+	name "Whirl Tour (USA)"
+	description "Whirl Tour (USA)"
+	rom ( name "Whirl Tour (USA).iso" size 1459978240 crc 2b4c7d32 md5 fb9ad38f2b197375456dc33c3530ad17 sha1 77b67764d42a45187a16c928e9ed7640237fea95 )
+)
+
+game (
+	name "World Racing (EU)"
+	description "World Racing (EU)"
+	rom ( name "World Racing (EU).iso" size 1459978240 crc ba953fbe md5 49c8c1933e1039111cb55980b8c76f09 sha1 9a28cfbfcf22b4a6f2b1eb01917606c9bebb6bef )
+)
+
+game (
+	name "World Racing (Europe) (En,Fr,De,Es,It)"
+	description "World Racing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "World Racing (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ba953fbe md5 49c8c1933e1039111cb55980b8c76f09 sha1 9a28cfbfcf22b4a6f2b1eb01917606c9bebb6bef )
+)
+
+game (
+	name "World Series of Poker (US)"
+	description "World Series of Poker (US)"
+	rom ( name "World Series of Poker (US).iso" size 1459978240 crc 94510ffe md5 9f8d36a47cbb18ee3c322402ce24cb89 sha1 fb4ca36a6b8259159e9ae66129ef194d5c4dd46a )
+)
+
+game (
+	name "World Series of Poker (USA)"
+	description "World Series of Poker (USA)"
+	rom ( name "World Series of Poker (USA).iso" size 1459978240 crc 94510ffe md5 9f8d36a47cbb18ee3c322402ce24cb89 sha1 fb4ca36a6b8259159e9ae66129ef194d5c4dd46a )
+)
+
+game (
+	name "World Soccer Winning Eleven 6 - Final Evolution (Japan)"
+	description "World Soccer Winning Eleven 6 - Final Evolution (Japan)"
+	rom ( name "World Soccer Winning Eleven 6 - Final Evolution (Japan).iso" size 1459978240 crc 07f76bcc md5 db339f4d36b698e0c18de99a91c0c165 sha1 4d0a7142474ad5a4d6e7245f252eab308f783fbe )
+)
+
+game (
+	name "World Soccer Winning Eleven 6 - Final Evolution (JP) - warudosatuka+uininguirebun6+huainaruevuoriyusiyon"
+	description "World Soccer Winning Eleven 6 - Final Evolution (JP) - warudosatuka+uininguirebun6+huainaruevuoriyusiyon"
+	rom ( name "World Soccer Winning Eleven 6 - Final Evolution (JP).iso" size 1459978240 crc 07f76bcc md5 db339f4d36b698e0c18de99a91c0c165 sha1 4d0a7142474ad5a4d6e7245f252eab308f783fbe )
+)
+
+game (
+	name "Worms 3D (EU)"
+	description "Worms 3D (EU)"
+	rom ( name "Worms 3D (EU).iso" size 1459978240 crc ab590663 md5 48b3b483bada75b9527cdaf7ef44c37f sha1 756e59298589abc8d0e41720ba6399a7a7210ea6 )
+)
+
+game (
+	name "Worms 3D (Europe) (En,Fr,De,Es,It)"
+	description "Worms 3D (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Worms 3D (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ab590663 md5 48b3b483bada75b9527cdaf7ef44c37f sha1 756e59298589abc8d0e41720ba6399a7a7210ea6 )
+)
+
+game (
+	name "Worms 3D (US)"
+	description "Worms 3D (US)"
+	rom ( name "Worms 3D (US).iso" size 1459978240 crc c6e188b4 md5 b13cf3eb32fa0561593be6383c841b3a sha1 373505dce585f72ef1428b4c3b75202a3f31f308 )
+)
+
+game (
+	name "Worms 3D (USA) (En,Fr)"
+	description "Worms 3D (USA) (En,Fr)"
+	rom ( name "Worms 3D (USA) (En,Fr).iso" size 1459978240 crc c6e188b4 md5 b13cf3eb32fa0561593be6383c841b3a sha1 373505dce585f72ef1428b4c3b75202a3f31f308 )
+)
+
+game (
+	name "Worms Blast (EU)"
+	description "Worms Blast (EU)"
+	rom ( name "Worms Blast (EU).iso" size 1459978240 crc 85d42f70 md5 a6d3764b27767cc74efdf40582ede258 sha1 b4d7a76a34ba1bda6f220b365a4eeddf860c28a6 )
+)
+
+game (
+	name "Worms Blast (Europe) (En,Fr,De,Es,It)"
+	description "Worms Blast (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Worms Blast (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 85d42f70 md5 a6d3764b27767cc74efdf40582ede258 sha1 b4d7a76a34ba1bda6f220b365a4eeddf860c28a6 )
+)
+
+game (
+	name "Worms Blast (US)"
+	description "Worms Blast (US)"
+	rom ( name "Worms Blast (US).iso" size 1459978240 crc 8cd70182 md5 6c310462e4dcbc74717beaa5f13384d0 sha1 8d82e8205e5121cb867193b3f110bb2832ab2e8a )
+)
+
+game (
+	name "Worms Blast (USA) (En,Fr,Es)"
+	description "Worms Blast (USA) (En,Fr,Es)"
+	rom ( name "Worms Blast (USA) (En,Fr,Es).iso" size 1459978240 crc 8cd70182 md5 6c310462e4dcbc74717beaa5f13384d0 sha1 8d82e8205e5121cb867193b3f110bb2832ab2e8a )
+)
+
+game (
+	name "Wreckless - The Yakuza Missions (EU)"
+	description "Wreckless - The Yakuza Missions (EU)"
+	rom ( name "Wreckless - The Yakuza Missions (EU).iso" size 1459978240 crc 547d483f md5 6f9aeab14c90bb0dc26207b938ca3636 sha1 213b6a6a6af56885ea6ad5eb2bd11bf8de54c6fb )
+)
+
+game (
+	name "Wreckless - The Yakuza Missions (Europe) (En,Fr,De)"
+	description "Wreckless - The Yakuza Missions (Europe) (En,Fr,De)"
+	rom ( name "Wreckless - The Yakuza Missions (Europe) (En,Fr,De).iso" size 1459978240 crc 547d483f md5 6f9aeab14c90bb0dc26207b938ca3636 sha1 213b6a6a6af56885ea6ad5eb2bd11bf8de54c6fb )
+)
+
+game (
+	name "Wreckless - The Yakuza Missions (US)"
+	description "Wreckless - The Yakuza Missions (US)"
+	rom ( name "Wreckless - The Yakuza Missions (US).iso" size 1459978240 crc 31501d9a md5 925956b9633047c34dc04e74c63f052a sha1 2787081ddd05fe5311a8be988a2972a20542b992 )
+)
+
+game (
+	name "Wreckless - The Yakuza Missions (USA)"
+	description "Wreckless - The Yakuza Missions (USA)"
+	rom ( name "Wreckless - The Yakuza Missions (USA).iso" size 1459978240 crc 31501d9a md5 925956b9633047c34dc04e74c63f052a sha1 2787081ddd05fe5311a8be988a2972a20542b992 )
+)
+
+game (
+	name "WTA Tour Tennis - Pro Evolution (Japan)"
+	description "WTA Tour Tennis - Pro Evolution (Japan)"
+	rom ( name "WTA Tour Tennis - Pro Evolution (Japan).iso" size 1459978240 crc 12f33c3f md5 dbd1c1e7b7861598018e7ce5b274e587 sha1 b13b6b1ea76df7e1518a1a0fe16757339736a056 )
+)
+
+game (
+	name "WTA Tour Tennis - Pro Evolution (JP) - WTAtuatenisu+puroeboriyusiyon"
+	description "WTA Tour Tennis - Pro Evolution (JP) - WTAtuatenisu+puroeboriyusiyon"
+	rom ( name "WTA Tour Tennis - Pro Evolution (JP).iso" size 1459978240 crc 12f33c3f md5 dbd1c1e7b7861598018e7ce5b274e587 sha1 b13b6b1ea76df7e1518a1a0fe16757339736a056 )
+)
+
+game (
+	name "WTA Tour Tennis (US)"
+	description "WTA Tour Tennis (US)"
+	rom ( name "WTA Tour Tennis (US).iso" size 1459978240 crc 2869aa07 md5 b52269da25e94e6f74bff7d49093852e sha1 a1485e794bd5f995805d91c133f33307eb76a8c4 )
+)
+
+game (
+	name "WTA Tour Tennis (USA)"
+	description "WTA Tour Tennis (USA)"
+	rom ( name "WTA Tour Tennis (USA).iso" size 1459978240 crc 2869aa07 md5 b52269da25e94e6f74bff7d49093852e sha1 a1485e794bd5f995805d91c133f33307eb76a8c4 )
+)
+
+game (
+	name "WWE Crush Hour (EU)"
+	description "WWE Crush Hour (EU)"
+	rom ( name "WWE Crush Hour (EU).iso" size 1459978240 crc 45ba3b10 md5 a5149505a6929d0f4879eb2905ce9f00 sha1 0c5bf0fed3a8b82531221dca6405570400aaf6dc )
+)
+
+game (
+	name "WWE Crush Hour (Europe)"
+	description "WWE Crush Hour (Europe)"
+	rom ( name "WWE Crush Hour (Europe).iso" size 1459978240 crc 45ba3b10 md5 a5149505a6929d0f4879eb2905ce9f00 sha1 0c5bf0fed3a8b82531221dca6405570400aaf6dc )
+)
+
+game (
+	name "WWE Crush Hour (US)"
+	description "WWE Crush Hour (US)"
+	rom ( name "WWE Crush Hour (US).iso" size 1459978240 crc 0f41d7a7 md5 df519bfd14bee790fe2d644a0a963507 sha1 3016f706eb15fedfd663699697d9bfb91315b336 )
+)
+
+game (
+	name "WWE Crush Hour (USA)"
+	description "WWE Crush Hour (USA)"
+	rom ( name "WWE Crush Hour (USA).iso" size 1459978240 crc 0f41d7a7 md5 df519bfd14bee790fe2d644a0a963507 sha1 3016f706eb15fedfd663699697d9bfb91315b336 )
+)
+
+game (
+	name "WWE Day of Reckoning (EU)"
+	description "WWE Day of Reckoning (EU)"
+	rom ( name "WWE Day of Reckoning (EU) - [v1.00].iso" size 1459978240 crc 54be3da6 md5 18ee1317099ae3d1164278e8b17f6569 sha1 435be34e19a29c10d8643fe213416140a1cddf5b )
+)
+
+game (
+	name "WWE Day of Reckoning (Europe) (v1.00)"
+	description "WWE Day of Reckoning (Europe) (v1.00)"
+	rom ( name "WWE Day of Reckoning (Europe) (v1.00).iso" size 1459978240 crc 54be3da6 md5 18ee1317099ae3d1164278e8b17f6569 sha1 435be34e19a29c10d8643fe213416140a1cddf5b )
+)
+
+game (
+	name "WWE Day of Reckoning (Europe) (v1.01)"
+	description "WWE Day of Reckoning (Europe) (v1.01)"
+	rom ( name "WWE Day of Reckoning (Europe) (v1.01).iso" size 1459978240 crc f1960a2b md5 48626d24a99cdf44e8b1d8acc099f9b5 sha1 cad7358cc4262d7d144620b9e5fe04662b2e436f )
+)
+
+game (
+	name "WWE Day of Reckoning (Japan)"
+	description "WWE Day of Reckoning (Japan)"
+	rom ( name "WWE Day of Reckoning (Japan).iso" size 1459978240 crc dbd7ef56 md5 8d9c9f1c93fb20efd725230613b5496d sha1 0ea922e28e16881c7352f40920dbf9a4452182d4 )
+)
+
+game (
+	name "WWE Day of Reckoning (JP) - WWE+deioburekoningu"
+	description "WWE Day of Reckoning (JP) - WWE+deioburekoningu"
+	rom ( name "WWE Day of Reckoning (JP).iso" size 1459978240 crc dbd7ef56 md5 8d9c9f1c93fb20efd725230613b5496d sha1 0ea922e28e16881c7352f40920dbf9a4452182d4 )
+)
+
+game (
+	name "WWE Day of Reckoning (Player's Choice) (EU)"
+	description "WWE Day of Reckoning (Player's Choice) (EU)"
+	rom ( name "WWE Day of Reckoning (Player's Choice) (EU) - [v1.01].iso" size 1459978240 crc f1960a2b md5 48626d24a99cdf44e8b1d8acc099f9b5 sha1 cad7358cc4262d7d144620b9e5fe04662b2e436f )
+)
+
+game (
+	name "WWE Day of Reckoning (US)"
+	description "WWE Day of Reckoning (US)"
+	rom ( name "WWE Day of Reckoning (US).iso" size 1459978240 crc 5a944fd2 md5 509b1a90c4ba801ad609f957cbe03e64 sha1 eaefe9d80198b598cba19a3a13edf2d9d3cce7ce )
+)
+
+game (
+	name "WWE Day of Reckoning (USA)"
+	description "WWE Day of Reckoning (USA)"
+	rom ( name "WWE Day of Reckoning (USA).iso" size 1459978240 crc 5a944fd2 md5 509b1a90c4ba801ad609f957cbe03e64 sha1 eaefe9d80198b598cba19a3a13edf2d9d3cce7ce )
+)
+
+game (
+	name "WWE Day of Reckoning 2 (EU)"
+	description "WWE Day of Reckoning 2 (EU)"
+	rom ( name "WWE Day of Reckoning 2 (EU).iso" size 1459978240 crc 069a9097 md5 4aba987ccdc00115e01c91ef5ea71bbc sha1 117b885e85c2b3b246aff1bebe331f821d6cc955 )
+)
+
+game (
+	name "WWE Day of Reckoning 2 (Europe)"
+	description "WWE Day of Reckoning 2 (Europe)"
+	rom ( name "WWE Day of Reckoning 2 (Europe).iso" size 1459978240 crc 069a9097 md5 4aba987ccdc00115e01c91ef5ea71bbc sha1 117b885e85c2b3b246aff1bebe331f821d6cc955 )
+)
+
+game (
+	name "WWE Day of Reckoning 2 (US)"
+	description "WWE Day of Reckoning 2 (US)"
+	rom ( name "WWE Day of Reckoning 2 (US).iso" size 1459978240 crc bb092c3a md5 fac766a3bb0ebf32a200907d41e3ff8f sha1 01322b3738ff5720fb612497522a9d0afe0a6fed )
+)
+
+game (
+	name "WWE Day of Reckoning 2 (USA)"
+	description "WWE Day of Reckoning 2 (USA)"
+	rom ( name "WWE Day of Reckoning 2 (USA).iso" size 1459978240 crc bb092c3a md5 fac766a3bb0ebf32a200907d41e3ff8f sha1 01322b3738ff5720fb612497522a9d0afe0a6fed )
+)
+
+game (
+	name "WWE WrestleMania X8 (EU)"
+	description "WWE WrestleMania X8 (EU)"
+	rom ( name "WWE WrestleMania X8 (EU).iso" size 1459978240 crc 1f1f9bc4 md5 8d45ee6b24f6dfc1f536a6b6a1c3def3 sha1 e4bd18ef200b4694ca26ba281b5dc036aa623a86 )
+)
+
+game (
+	name "WWE WrestleMania X8 (Europe)"
+	description "WWE WrestleMania X8 (Europe)"
+	rom ( name "WWE WrestleMania X8 (Europe).iso" size 1459978240 crc 1f1f9bc4 md5 8d45ee6b24f6dfc1f536a6b6a1c3def3 sha1 e4bd18ef200b4694ca26ba281b5dc036aa623a86 )
+)
+
+game (
+	name "WWE WrestleMania X8 (Japan)"
+	description "WWE WrestleMania X8 (Japan)"
+	rom ( name "WWE WrestleMania X8 (Japan).iso" size 1459978240 crc 879a0d04 md5 0bfd0256f6a321a826bc522a6281e914 sha1 c8ecbec3adbf14a473b55fe19d52df06a3504244 )
+)
+
+game (
+	name "WWE WrestleMania X8 (JP) - retusurumaniaX8"
+	description "WWE WrestleMania X8 (JP) - retusurumaniaX8"
+	rom ( name "WWE WrestleMania X8 (JP).iso" size 1459978240 crc 879a0d04 md5 0bfd0256f6a321a826bc522a6281e914 sha1 c8ecbec3adbf14a473b55fe19d52df06a3504244 )
+)
+
+game (
+	name "WWE WrestleMania X8 (US)"
+	description "WWE WrestleMania X8 (US)"
+	rom ( name "WWE WrestleMania X8 (US).iso" size 1459978240 crc a37b1923 md5 b7badf498f504a4b78c59d96d29b12a0 sha1 eecf81eb80f9349a142dc049629dec7afd252a1d )
+)
+
+game (
+	name "WWE WrestleMania X8 (USA)"
+	description "WWE WrestleMania X8 (USA)"
+	rom ( name "WWE WrestleMania X8 (USA).iso" size 1459978240 crc a37b1923 md5 b7badf498f504a4b78c59d96d29b12a0 sha1 eecf81eb80f9349a142dc049629dec7afd252a1d )
+)
+
+game (
+	name "WWE WrestleMania XIX (EU)"
+	description "WWE WrestleMania XIX (EU)"
+	rom ( name "WWE WrestleMania XIX (EU).iso" size 1459978240 crc b5e83a66 md5 edc6b6274960219acf546376dca90862 sha1 8f58c79033b90749a2edc615bf343dbe4dcd7222 )
+)
+
+game (
+	name "WWE WrestleMania XIX (Europe, Australia)"
+	description "WWE WrestleMania XIX (Europe, Australia)"
+	rom ( name "WWE WrestleMania XIX (Europe, Australia).iso" size 1459978240 crc b5e83a66 md5 edc6b6274960219acf546376dca90862 sha1 8f58c79033b90749a2edc615bf343dbe4dcd7222 )
+)
+
+game (
+	name "WWE WrestleMania XIX (Japan)"
+	description "WWE WrestleMania XIX (Japan)"
+	rom ( name "WWE WrestleMania XIX (Japan).iso" size 1459978240 crc 46f53afb md5 a2c5fed081aa7b9768785ffd4209e092 sha1 85d713f41e548be53afa5fc78759fdd4643d6152 )
+)
+
+game (
+	name "WWE WrestleMania XIX (JP) - retusurumaniaXIX"
+	description "WWE WrestleMania XIX (JP) - retusurumaniaXIX"
+	rom ( name "WWE WrestleMania XIX (JP).iso" size 1459978240 crc 46f53afb md5 a2c5fed081aa7b9768785ffd4209e092 sha1 85d713f41e548be53afa5fc78759fdd4643d6152 )
+)
+
+game (
+	name "WWE WrestleMania XIX (US)"
+	description "WWE WrestleMania XIX (US)"
+	rom ( name "WWE WrestleMania XIX (US).iso" size 1459978240 crc 635116c6 md5 c13c47a5ed24a675545c99a15e44529d sha1 4746c3b9de58f43d1a5c803ed0c3adba628ee861 )
+)
+
+game (
+	name "WWE WrestleMania XIX (USA)"
+	description "WWE WrestleMania XIX (USA)"
+	rom ( name "WWE WrestleMania XIX (USA).iso" size 1459978240 crc 635116c6 md5 c13c47a5ed24a675545c99a15e44529d sha1 4746c3b9de58f43d1a5c803ed0c3adba628ee861 )
+)
+
+game (
+	name "X-Men - Next Dimension (EU)"
+	description "X-Men - Next Dimension (EU)"
+	rom ( name "X-Men - Next Dimension (EU).iso" size 1459978240 crc c6b5cb92 md5 2dd9f6eb4d85ba50860e0dac2b3a8c89 sha1 918b997aaa84be2537f76bb13d6e26c1fb03a44d )
+)
+
+game (
+	name "X-Men - Next Dimension (Europe)"
+	description "X-Men - Next Dimension (Europe)"
+	rom ( name "X-Men - Next Dimension (Europe).iso" size 1459978240 crc c6b5cb92 md5 2dd9f6eb4d85ba50860e0dac2b3a8c89 sha1 918b997aaa84be2537f76bb13d6e26c1fb03a44d )
+)
+
+game (
+	name "X-Men - Next Dimension (US)"
+	description "X-Men - Next Dimension (US)"
+	rom ( name "X-Men - Next Dimension (US).iso" size 1459978240 crc cce0cff0 md5 a8da08418ceb0f94ae4b3eb5083d211c sha1 de86322228ddcf90a605612f0f8eb87d27af967b )
+)
+
+game (
+	name "X-Men - Next Dimension (USA)"
+	description "X-Men - Next Dimension (USA)"
+	rom ( name "X-Men - Next Dimension (USA).iso" size 1459978240 crc cce0cff0 md5 a8da08418ceb0f94ae4b3eb5083d211c sha1 de86322228ddcf90a605612f0f8eb87d27af967b )
+)
+
+game (
+	name "X-Men - The Official Game (EU)"
+	description "X-Men - The Official Game (EU)"
+	rom ( name "X-Men - The Official Game (EU).iso" size 1459978240 crc db9e8eff md5 e512799807220136b0b76a5c65ddb594 sha1 c2b251ba673d53df8a3353c18bb8a641389b03c4 )
+)
+
+game (
+	name "X-Men - The Official Game (Europe) (En,Fr)"
+	description "X-Men - The Official Game (Europe) (En,Fr)"
+	rom ( name "X-Men - The Official Game (Europe) (En,Fr).iso" size 1459978240 crc db9e8eff md5 e512799807220136b0b76a5c65ddb594 sha1 c2b251ba673d53df8a3353c18bb8a641389b03c4 )
+)
+
+game (
+	name "X-Men - The Official Game (US)"
+	description "X-Men - The Official Game (US)"
+	rom ( name "X-Men - The Official Game (US).iso" size 1459978240 crc 5be81aad md5 f79a3dd407014b11f686c94f22b1b3e2 sha1 a52beec479dbd3fe09f016b0cd36ca6f48746325 )
+)
+
+game (
+	name "X-Men - The Official Game (USA)"
+	description "X-Men - The Official Game (USA)"
+	rom ( name "X-Men - The Official Game (USA).iso" size 1459978240 crc 5be81aad md5 f79a3dd407014b11f686c94f22b1b3e2 sha1 a52beec479dbd3fe09f016b0cd36ca6f48746325 )
+)
+
+game (
+	name "X-Men 2 - Wolverine's Revenge (EU)"
+	description "X-Men 2 - Wolverine's Revenge (EU)"
+	rom ( name "X-Men 2 - Wolverine's Revenge (EU).iso" size 1459978240 crc cb63c6bc md5 bc2c66b5899a505d7990c9e9e5013ae7 sha1 650d35557e6a470437ae1da6ec0090f8ddc6e8a2 )
+)
+
+game (
+	name "X-Men 2 - Wolverine's Revenge (Europe)"
+	description "X-Men 2 - Wolverine's Revenge (Europe)"
+	rom ( name "X-Men 2 - Wolverine's Revenge (Europe).iso" size 1459978240 crc aab221f8 md5 30dfce9be9ba41aad0e0d81a129f9900 sha1 e36486ed74e09056c44d3b816317c944701125d5 )
+)
+
+game (
+	name "X-Men 2 - Wolverine's Revenge (Europe) (Fr,De,Es)"
+	description "X-Men 2 - Wolverine's Revenge (Europe) (Fr,De,Es)"
+	rom ( name "X-Men 2 - Wolverine's Revenge (Europe) (Fr,De,Es).iso" size 1459978240 crc cb63c6bc md5 bc2c66b5899a505d7990c9e9e5013ae7 sha1 650d35557e6a470437ae1da6ec0090f8ddc6e8a2 )
+)
+
+game (
+	name "X-Men 2 - Wolverine's Revenge (GB)"
+	description "X-Men 2 - Wolverine's Revenge (GB)"
+	rom ( name "X-Men 2 - Wolverine's Revenge (GB).iso" size 1459978240 crc aab221f8 md5 30dfce9be9ba41aad0e0d81a129f9900 sha1 e36486ed74e09056c44d3b816317c944701125d5 )
+)
+
+game (
+	name "X-Men Legends (EU)"
+	description "X-Men Legends (EU)"
+	rom ( name "X-Men Legends (EU).iso" size 1459978240 crc 6bd8d896 md5 8d1bf694987c027a1296d2705804ac86 sha1 0a7003cd7a07d2512a9ec281678dac8e0973328d )
+)
+
+game (
+	name "X-Men Legends (Europe)"
+	description "X-Men Legends (Europe)"
+	rom ( name "X-Men Legends (Europe).iso" size 1459978240 crc b2c2ead5 md5 2510e752f87fabafd4a44545a53849e7 sha1 3a3f1be12281f1f6380aad9d4a9c234e7e1a8620 )
+)
+
+game (
+	name "X-Men Legends (Europe) (En,Fr,De)"
+	description "X-Men Legends (Europe) (En,Fr,De)"
+	rom ( name "X-Men Legends (Europe) (En,Fr,De).iso" size 1459978240 crc 6bd8d896 md5 8d1bf694987c027a1296d2705804ac86 sha1 0a7003cd7a07d2512a9ec281678dac8e0973328d )
+)
+
+game (
+	name "X-Men Legends (GB)"
+	description "X-Men Legends (GB)"
+	rom ( name "X-Men Legends (GB).iso" size 1459978240 crc b2c2ead5 md5 2510e752f87fabafd4a44545a53849e7 sha1 3a3f1be12281f1f6380aad9d4a9c234e7e1a8620 )
+)
+
+game (
+	name "X-Men Legends (US)"
+	description "X-Men Legends (US)"
+	rom ( name "X-Men Legends (US).iso" size 1459978240 crc 6c580e51 md5 dd484633b421626a29407396569803d7 sha1 59709ffd80caa7ddb7655184d5879504ef9fa0e9 )
+)
+
+game (
+	name "X-Men Legends (USA)"
+	description "X-Men Legends (USA)"
+	rom ( name "X-Men Legends (USA).iso" size 1459978240 crc 6c580e51 md5 dd484633b421626a29407396569803d7 sha1 59709ffd80caa7ddb7655184d5879504ef9fa0e9 )
+)
+
+game (
+	name "X-Men Legends II - El Ascenso de Apocalipsis (ES)"
+	description "X-Men Legends II - El Ascenso de Apocalipsis (ES)"
+	rom ( name "X-Men Legends II - El Ascenso de Apocalipsis (ES).iso" size 1459978240 crc 2dcc4180 md5 cb3b79be2326e322e77edbdf30e602f8 sha1 c205c81806fd23572294b61b8599cadb86aeb7eb )
+)
+
+game (
+	name "X-Men Legends II - El Ascenso de Apocalipsis (Spain)"
+	description "X-Men Legends II - El Ascenso de Apocalipsis (Spain)"
+	rom ( name "X-Men Legends II - El Ascenso de Apocalipsis (Spain).iso" size 1459978240 crc 2dcc4180 md5 cb3b79be2326e322e77edbdf30e602f8 sha1 c205c81806fd23572294b61b8599cadb86aeb7eb )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (DE)"
+	description "X-Men Legends II - Rise of Apocalypse (DE)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (DE).iso" size 1459978240 crc 0974ee6d md5 cc501af1590a1b4f5ed3675c2c664f40 sha1 381f1b2d08855dbb88c804a72012747234f319da )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (EU)"
+	description "X-Men Legends II - Rise of Apocalypse (EU)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (EU).iso" size 1459978240 crc 052e0391 md5 c03a70c1bf6fe241b5d8f73248875331 sha1 d6d2c0946da1f10b3750f11354208179251154a5 )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (Europe) (En,Fr,It)"
+	description "X-Men Legends II - Rise of Apocalypse (Europe) (En,Fr,It)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (Europe) (En,Fr,It).iso" size 1459978240 crc 052e0391 md5 c03a70c1bf6fe241b5d8f73248875331 sha1 d6d2c0946da1f10b3750f11354208179251154a5 )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (Germany)"
+	description "X-Men Legends II - Rise of Apocalypse (Germany)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (Germany).iso" size 1459978240 crc 0974ee6d md5 cc501af1590a1b4f5ed3675c2c664f40 sha1 381f1b2d08855dbb88c804a72012747234f319da )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (US)"
+	description "X-Men Legends II - Rise of Apocalypse (US)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (US).iso" size 1459978240 crc 00734c55 md5 b7b01496bf643bd150ce05e6a4786317 sha1 caa5ce2f109f308b8a13e9d7b42a74307fa63fd5 )
+)
+
+game (
+	name "X-Men Legends II - Rise of Apocalypse (USA)"
+	description "X-Men Legends II - Rise of Apocalypse (USA)"
+	rom ( name "X-Men Legends II - Rise of Apocalypse (USA).iso" size 1459978240 crc 00734c55 md5 b7b01496bf643bd150ce05e6a4786317 sha1 caa5ce2f109f308b8a13e9d7b42a74307fa63fd5 )
+)
+
+game (
+	name "X2 - Wolverine's Revenge (US)"
+	description "X2 - Wolverine's Revenge (US)"
+	rom ( name "X2 - Wolverine's Revenge (US).iso" size 1459978240 crc b70be5fd md5 f783fdecb6ddded2924c837efbf451de sha1 f19500c6e71073fad4f5c1b59fc31e0647f5c7ab )
+)
+
+game (
+	name "X2 - Wolverine's Revenge (USA)"
+	description "X2 - Wolverine's Revenge (USA)"
+	rom ( name "X2 - Wolverine's Revenge (USA).iso" size 1459978240 crc b70be5fd md5 f783fdecb6ddded2924c837efbf451de sha1 f19500c6e71073fad4f5c1b59fc31e0647f5c7ab )
+)
+
+game (
+	name "XGIII - Extreme G Racing (Europe) (En,Fr,De,Es)"
+	description "XGIII - Extreme G Racing (Europe) (En,Fr,De,Es)"
+	rom ( name "XGIII - Extreme G Racing (Europe) (En,Fr,De,Es).iso" size 1459978240 crc 9d77760d md5 300f65a027f731c99fbb1e15c4bda02a sha1 bcec2f55d0f611ad3fa6bc52fbc190263be9cfee )
+)
+
+game (
+	name "XGIII - Extreme G Racing (Japan)"
+	description "XGIII - Extreme G Racing (Japan)"
+	rom ( name "XGIII - Extreme G Racing (Japan).iso" size 1459978240 crc 13a3ce89 md5 4d5fe170eee3dd84c3d856a211f5d694 sha1 5f5e2efb241c35852f61a16a1c17cafb2c1d1270 )
+)
+
+game (
+	name "XGIII - Extreme G Racing (USA)"
+	description "XGIII - Extreme G Racing (USA)"
+	rom ( name "XGIII - Extreme G Racing (USA).iso" size 1459978240 crc 9cfcac40 md5 26c786ee5638c008c064bf5dd048489b sha1 0f9e290723f7cf20110a999296626aad17f9bf67 )
+)
+
+game (
+	name "XGIII (EU)"
+	description "XGIII (EU)"
+	rom ( name "XGIII (EU).iso" size 1459978240 crc 9d77760d md5 300f65a027f731c99fbb1e15c4bda02a sha1 bcec2f55d0f611ad3fa6bc52fbc190263be9cfee )
+)
+
+game (
+	name "XGIII (JP) - ekusutorimuG3"
+	description "XGIII (JP) - ekusutorimuG3"
+	rom ( name "XGIII (JP).iso" size 1459978240 crc 13a3ce89 md5 4d5fe170eee3dd84c3d856a211f5d694 sha1 5f5e2efb241c35852f61a16a1c17cafb2c1d1270 )
+)
+
+game (
+	name "XGIII (US)"
+	description "XGIII (US)"
+	rom ( name "XGIII (US).iso" size 1459978240 crc 9cfcac40 md5 26c786ee5638c008c064bf5dd048489b sha1 0f9e290723f7cf20110a999296626aad17f9bf67 )
+)
+
+game (
+	name "XGRA - Extreme G Racing Association (EU)"
+	description "XGRA - Extreme G Racing Association (EU)"
+	rom ( name "XGRA - Extreme G Racing Association (EU).iso" size 1459978240 crc ae048852 md5 eedaeaaf6e0ca8e3c1619a1c2e9417f6 sha1 49f3543f80b752ed99d5efa1141c2e49464644eb )
+)
+
+game (
+	name "XGRA - Extreme G Racing Association (Europe) (En,Fr,De,Es,It)"
+	description "XGRA - Extreme G Racing Association (Europe) (En,Fr,De,Es,It)"
+	rom ( name "XGRA - Extreme G Racing Association (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc ae048852 md5 eedaeaaf6e0ca8e3c1619a1c2e9417f6 sha1 49f3543f80b752ed99d5efa1141c2e49464644eb )
+)
+
+game (
+	name "XGRA - Extreme G Racing Association (US)"
+	description "XGRA - Extreme G Racing Association (US)"
+	rom ( name "XGRA - Extreme G Racing Association (US).iso" size 1459978240 crc 4228038d md5 ff403ffb95646f00da9edb4c09aeea58 sha1 4e0856276de302323357633ba2dbaa55b562e934 )
+)
+
+game (
+	name "XGRA - Extreme G Racing Association (USA)"
+	description "XGRA - Extreme G Racing Association (USA)"
+	rom ( name "XGRA - Extreme G Racing Association (USA).iso" size 1459978240 crc 4228038d md5 ff403ffb95646f00da9edb4c09aeea58 sha1 4e0856276de302323357633ba2dbaa55b562e934 )
+)
+
+game (
+	name "XIII (EU)"
+	description "XIII (EU)"
+	rom ( name "XIII (EU).iso" size 1459978240 crc 55bfdbe1 md5 08c39a364e5e34e9299c01fa1350c5be sha1 d7171b9caa496f212963fa3b89362eea7aa20294 )
+)
+
+game (
+	name "XIII (Europe)"
+	description "XIII (Europe)"
+	rom ( name "XIII (Europe).iso" size 1459978240 crc 8fe48666 md5 9d4c9624a295faa79aff14759514a030 sha1 81764e0786262ef03f78b3a18bceb9ceb8421b2d )
+)
+
+game (
+	name "XIII (Europe) (Fr,De,Es,It)"
+	description "XIII (Europe) (Fr,De,Es,It)"
+	rom ( name "XIII (Europe) (Fr,De,Es,It).iso" size 1459978240 crc 55bfdbe1 md5 08c39a364e5e34e9299c01fa1350c5be sha1 d7171b9caa496f212963fa3b89362eea7aa20294 )
+)
+
+game (
+	name "XIII (GB)"
+	description "XIII (GB)"
+	rom ( name "XIII (GB).iso" size 1459978240 crc 8fe48666 md5 9d4c9624a295faa79aff14759514a030 sha1 81764e0786262ef03f78b3a18bceb9ceb8421b2d )
+)
+
+game (
+	name "XIII (US)"
+	description "XIII (US)"
+	rom ( name "XIII (US).iso" size 1459978240 crc 22502290 md5 9a13a9f1d9e5b57c0934645a879499fc sha1 90f719a97045b63cadc81e407047cd9b02148a67 )
+)
+
+game (
+	name "XIII (USA) (En,Fr,Es)"
+	description "XIII (USA) (En,Fr,Es)"
+	rom ( name "XIII (USA) (En,Fr,Es).iso" size 1459978240 crc 22502290 md5 9a13a9f1d9e5b57c0934645a879499fc sha1 90f719a97045b63cadc81e407047cd9b02148a67 )
+)
+
+game (
+	name "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Japan)"
+	description "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Japan)"
+	rom ( name "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Japan).iso" size 1459978240 crc 82e211c1 md5 b67194c8a3d3d3d3f1789b2b65daa925 sha1 104d65e2a2f64c2978bbda0d971ff24ae9566fc5 )
+)
+
+game (
+	name "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Promo) (JP) - Yu Yue Te Dian :pokemonkorosiamuRen Tian Tang Te Zhi deisuku"
+	description "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Promo) (JP) - Yu Yue Te Dian :pokemonkorosiamuRen Tian Tang Te Zhi deisuku"
+	rom ( name "Yoyaku Tokuten - Pokemon Colosseum - Nintendo Tokusei Disc (Promo) (JP).iso" size 1459978240 crc 82e211c1 md5 b67194c8a3d3d3d3f1789b2b65daa925 sha1 104d65e2a2f64c2978bbda0d971ff24ae9566fc5 )
+)
+
+game (
+	name "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (Japan)"
+	description "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (Japan)"
+	rom ( name "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (Japan).iso" size 1459978240 crc a6927c83 md5 a0d9fb242e90287186610a7fd5b37a5f sha1 93f764ba9454014c72008ed6a7c80ec80798ac0e )
+)
+
+game (
+	name "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (JP) - You Xi Wang +huorusubaundo+kingudamu+Xu Gou niBi zasaretaWang Guo"
+	description "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (JP) - You Xi Wang +huorusubaundo+kingudamu+Xu Gou niBi zasaretaWang Guo"
+	rom ( name "Yu-Gi-Oh! Kyokou ni Tozasareta Oukoku (JP).iso" size 1459978240 crc a6927c83 md5 a0d9fb242e90287186610a7fd5b37a5f sha1 93f764ba9454014c72008ed6a7c80ec80798ac0e )
+)
+
+game (
+	name "Yu-Gi-Oh! The Falsebound Kingdom (Europe) (En,Fr,De,Es,It)"
+	description "Yu-Gi-Oh! The Falsebound Kingdom (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Yu-Gi-Oh! The Falsebound Kingdom (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 1e42f6a9 md5 acb058e216875277b32ff1a776174d79 sha1 354c4d3655a3695c95dc564cadb856bcaf45218d )
+)
+
+game (
+	name "Yu-Gi-Oh! The Falsebound Kingdom (GB)"
+	description "Yu-Gi-Oh! The Falsebound Kingdom (GB)"
+	rom ( name "Yu-Gi-Oh! The Falsebound Kingdom (GB).iso" size 1459978240 crc 1e42f6a9 md5 acb058e216875277b32ff1a776174d79 sha1 354c4d3655a3695c95dc564cadb856bcaf45218d )
+)
+
+game (
+	name "Yu-Gi-Oh! The Falsebound Kingdom (US)"
+	description "Yu-Gi-Oh! The Falsebound Kingdom (US)"
+	rom ( name "Yu-Gi-Oh! The Falsebound Kingdom (US).iso" size 1459978240 crc 8f1e8dca md5 343dd929ea574503b558c0ac0c1c3886 sha1 809a89a8484e898f999e26d3927b5ad816b98cbb )
+)
+
+game (
+	name "Yu-Gi-Oh! The Falsebound Kingdom (USA)"
+	description "Yu-Gi-Oh! The Falsebound Kingdom (USA)"
+	rom ( name "Yu-Gi-Oh! The Falsebound Kingdom (USA).iso" size 1459978240 crc 8f1e8dca md5 343dd929ea574503b558c0ac0c1c3886 sha1 809a89a8484e898f999e26d3927b5ad816b98cbb )
+)
+
+game (
+	name "Zapper (EU)"
+	description "Zapper (EU)"
+	rom ( name "Zapper (EU).iso" size 1459978240 crc 00e9b608 md5 3e39468d1ed10c571ae0a0050dff0332 sha1 5df8fb6d53c7953ec1d6c0ec7e825a3cc3deec2a )
+)
+
+game (
+	name "Zapper (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Zapper (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Zapper (Europe) (En,Fr,De,Es,It,Nl).iso" size 1459978240 crc 00e9b608 md5 3e39468d1ed10c571ae0a0050dff0332 sha1 5df8fb6d53c7953ec1d6c0ec7e825a3cc3deec2a )
+)
+
+game (
+	name "Zapper (US)"
+	description "Zapper (US)"
+	rom ( name "Zapper (US).iso" size 1459978240 crc 0e322b3b md5 13e2eaa0a0dd2b17104abe0c6d328224 sha1 409962bc90f337b3b4d1d795af63a4df6067d54f )
+)
+
+game (
+	name "Zapper (USA)"
+	description "Zapper (USA)"
+	rom ( name "Zapper (USA).iso" size 1459978240 crc 0e322b3b md5 13e2eaa0a0dd2b17104abe0c6d328224 sha1 409962bc90f337b3b4d1d795af63a4df6067d54f )
+)
+
+game (
+	name "Zatch Bell! Mamodo Battles (US)"
+	description "Zatch Bell! Mamodo Battles (US)"
+	rom ( name "Zatch Bell! Mamodo Battles (US).iso" size 1459978240 crc c98837d7 md5 b4f50c006078e08fd34580192fd0cb2d sha1 90e8d0883d35e9a7fb65e013379426d137c0ae26 )
+)
+
+game (
+	name "Zatch Bell! Mamodo Battles (USA)"
+	description "Zatch Bell! Mamodo Battles (USA)"
+	rom ( name "Zatch Bell! Mamodo Battles (USA).iso" size 1459978240 crc c98837d7 md5 b4f50c006078e08fd34580192fd0cb2d sha1 90e8d0883d35e9a7fb65e013379426d137c0ae26 )
+)
+
+game (
+	name "Zatch Bell! Mamodo Fury (US)"
+	description "Zatch Bell! Mamodo Fury (US)"
+	rom ( name "Zatch Bell! Mamodo Fury (US).iso" size 1459978240 crc 55deab54 md5 e78705f99f075c1e7f0bcba586952b70 sha1 2ad6103a27e90941b070e3451a2f1c4e3ff1b1f2 )
+)
+
+game (
+	name "Zatch Bell! Mamodo Fury (USA)"
+	description "Zatch Bell! Mamodo Fury (USA)"
+	rom ( name "Zatch Bell! Mamodo Fury (USA).iso" size 1459978240 crc 55deab54 md5 e78705f99f075c1e7f0bcba586952b70 sha1 2ad6103a27e90941b070e3451a2f1c4e3ff1b1f2 )
+)
+
+game (
+	name "Zelda Collection (Japan)"
+	description "Zelda Collection (Japan)"
+	rom ( name "Zelda Collection (Japan).iso" size 1459978240 crc b15b4dc2 md5 42325f753b9f6d220666bdd289dc0c4c sha1 809b095969b5dad659de9a6fb46f58e52303e7f3 )
+)
+
+game (
+	name "Zelda Collection (Limited Edition) (JP) - zeruda+korekusiyon"
+	description "Zelda Collection (Limited Edition) (JP) - zeruda+korekusiyon"
+	rom ( name "Zelda Collection (Limited Edition) (JP).iso" size 1459978240 crc b15b4dc2 md5 42325f753b9f6d220666bdd289dc0c4c sha1 809b095969b5dad659de9a6fb46f58e52303e7f3 )
+)
+
+game (
+	name "Zelda no Densetsu - 4tsu no Tsurugi Plus (Japan)"
+	description "Zelda no Densetsu - 4tsu no Tsurugi Plus (Japan)"
+	rom ( name "Zelda no Densetsu - 4tsu no Tsurugi Plus (Japan).iso" size 1459978240 crc f16e9ec7 md5 2ad411b817c86d887b0f80a03fe8d66e sha1 520d86a7b82c45aaa26cb6dd29300ccfb671cd95 )
+)
+
+game (
+	name "Zelda no Densetsu - 4tsu no Tsurugi Plus (JP) - zerudanoChuan Shuo +4tunoJian +"
+	description "Zelda no Densetsu - 4tsu no Tsurugi Plus (JP) - zerudanoChuan Shuo +4tunoJian +"
+	rom ( name "Zelda no Densetsu - 4tsu no Tsurugi Plus (JP).iso" size 1459978240 crc f16e9ec7 md5 2ad411b817c86d887b0f80a03fe8d66e sha1 520d86a7b82c45aaa26cb6dd29300ccfb671cd95 )
+)
+
+game (
+	name "Zelda no Densetsu - Kaze no Takuto (Japan)"
+	description "Zelda no Densetsu - Kaze no Takuto (Japan)"
+	rom ( name "Zelda no Densetsu - Kaze no Takuto (Japan).iso" size 1459978240 crc c58b4e93 md5 41d77584a33d0af6bdd88fce48dba2b0 sha1 1c4b574d7e0555ddc2b652c1a4bb02f01440c755 )
+)
+
+game (
+	name "Zelda no Densetsu - Kaze no Takuto (JP) - zerudanoChuan Shuo +Feng notakuto"
+	description "Zelda no Densetsu - Kaze no Takuto (JP) - zerudanoChuan Shuo +Feng notakuto"
+	rom ( name "Zelda no Densetsu - Kaze no Takuto (JP).iso" size 1459978240 crc c58b4e93 md5 41d77584a33d0af6bdd88fce48dba2b0 sha1 1c4b574d7e0555ddc2b652c1a4bb02f01440c755 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC (Japan)"
+	description "Zelda no Densetsu - Toki no Ocarina GC (Japan)"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (Japan).iso" size 1459978240 crc c878307d md5 adbbd707810cef91bd86413c25b39f19 sha1 53ce3bad885feaae782ce8815c988699026e7ae0 )
+)
+
+game (
+	name "Zelda no Densetsu - Toki no Ocarina GC (Limited Edition) (JP) - zerudanoChuan Shuo +Shi nookarinaGC+Li baziyonDa Zai"
+	description "Zelda no Densetsu - Toki no Ocarina GC (Limited Edition) (JP) - zerudanoChuan Shuo +Shi nookarinaGC+Li baziyonDa Zai"
+	rom ( name "Zelda no Densetsu - Toki no Ocarina GC (Limited Edition) (JP).iso" size 1459978240 crc c878307d md5 adbbd707810cef91bd86413c25b39f19 sha1 53ce3bad885feaae782ce8815c988699026e7ae0 )
+)
+
+game (
+	name "Zelda no Densetsu - Twilight Princess (Japan)"
+	description "Zelda no Densetsu - Twilight Princess (Japan)"
+	rom ( name "Zelda no Densetsu - Twilight Princess (Japan).iso" size 1459978240 crc 38415aa3 md5 b130d78bb78cd63b501ddff210fde498 sha1 4a04d0ff1ce744b19822c5dcd60c2266e2facc2d )
+)
+
+game (
+	name "Zelda no Densetsu - Twilight Princess (JP) - zerudanoChuan Shuo +towairaitopurinsesu"
+	description "Zelda no Densetsu - Twilight Princess (JP) - zerudanoChuan Shuo +towairaitopurinsesu"
+	rom ( name "Zelda no Densetsu - Twilight Princess (JP).iso" size 1459978240 crc 38415aa3 md5 b130d78bb78cd63b501ddff210fde498 sha1 4a04d0ff1ce744b19822c5dcd60c2266e2facc2d )
+)
+
+game (
+	name "Zoids - Battle Legends (US)"
+	description "Zoids - Battle Legends (US)"
+	rom ( name "Zoids - Battle Legends (US).iso" size 1459978240 crc 0f6ec75e md5 3eec134fda353eff584085d4f883ff86 sha1 6a53d5a98836a78159d6c9061a096e93a30f79ff )
+)
+
+game (
+	name "Zoids - Battle Legends (USA)"
+	description "Zoids - Battle Legends (USA)"
+	rom ( name "Zoids - Battle Legends (USA).iso" size 1459978240 crc 0f6ec75e md5 3eec134fda353eff584085d4f883ff86 sha1 6a53d5a98836a78159d6c9061a096e93a30f79ff )
+)
+
+game (
+	name "Zoids - Full Metal Crash (Japan)"
+	description "Zoids - Full Metal Crash (Japan)"
+	rom ( name "Zoids - Full Metal Crash (Japan).iso" size 1459978240 crc 86f1bb88 md5 eed2160781bc5bcce40a75bba05370e3 sha1 ecf37551f3ddcc0d1440a6c062edc9a33a00f978 )
+)
+
+game (
+	name "Zoids - Full Metal Crash (JP)"
+	description "Zoids - Full Metal Crash (JP)"
+	rom ( name "Zoids - Full Metal Crash (JP).iso" size 1459978240 crc 86f1bb88 md5 eed2160781bc5bcce40a75bba05370e3 sha1 ecf37551f3ddcc0d1440a6c062edc9a33a00f978 )
+)
+
+game (
+	name "Zoids vs. (Japan)"
+	description "Zoids vs. (Japan)"
+	rom ( name "Zoids vs. (Japan).iso" size 1459978240 crc 0e0403c3 md5 d80d1f2d0619b74e79368909c761efd6 sha1 245646d06744e6a21ed95f7bdaa66617732f4ea3 )
+)
+
+game (
+	name "Zoids vs. (JP) - zoido+basasu"
+	description "Zoids vs. (JP) - zoido+basasu"
+	rom ( name "Zoids vs. (JP).iso" size 1459978240 crc 0e0403c3 md5 d80d1f2d0619b74e79368909c761efd6 sha1 245646d06744e6a21ed95f7bdaa66617732f4ea3 )
+)
+
+game (
+	name "Zoids vs. II (Japan)"
+	description "Zoids vs. II (Japan)"
+	rom ( name "Zoids vs. II (Japan).iso" size 1459978240 crc 047409b7 md5 7ec4e298d9393808a81ad9e1b6b9b50b sha1 24cac3af282a816174112badcd9c14afc9cdfdb2 )
+)
+
+game (
+	name "Zoids vs. II (JP)"
+	description "Zoids vs. II (JP)"
+	rom ( name "Zoids vs. II (JP).iso" size 1459978240 crc 047409b7 md5 7ec4e298d9393808a81ad9e1b6b9b50b sha1 24cac3af282a816174112badcd9c14afc9cdfdb2 )
+)
+
+game (
+	name "Zoids vs. III (Japan)"
+	description "Zoids vs. III (Japan)"
+	rom ( name "Zoids vs. III (Japan).iso" size 1459978240 crc 13d67703 md5 71a5cdae1a6c69fc9d7067bee228caba sha1 b90e034c3d698aaff184fc514a0fcba6df754e64 )
+)
+
+game (
+	name "Zoids vs. III (JP) - zoido+basasu+III"
+	description "Zoids vs. III (JP) - zoido+basasu+III"
+	rom ( name "Zoids vs. III (JP).iso" size 1459978240 crc 13d67703 md5 71a5cdae1a6c69fc9d7067bee228caba sha1 b90e034c3d698aaff184fc514a0fcba6df754e64 )
+)
+
+game (
+	name "ZooCube (EU)"
+	description "ZooCube (EU)"
+	rom ( name "ZooCube (EU).iso" size 1459978240 crc 755595b3 md5 5649dcc570ce9f8e445bdbce0be7ef67 sha1 dab818d42942c75a40e026f503f33f6d6adff756 )
+)
+
+game (
+	name "ZooCube (Europe) (En,Fr,De,Es,It)"
+	description "ZooCube (Europe) (En,Fr,De,Es,It)"
+	rom ( name "ZooCube (Europe) (En,Fr,De,Es,It).iso" size 1459978240 crc 755595b3 md5 5649dcc570ce9f8e445bdbce0be7ef67 sha1 dab818d42942c75a40e026f503f33f6d6adff756 )
+)
+
+game (
+	name "ZooCube (Japan)"
+	description "ZooCube (Japan)"
+	rom ( name "ZooCube (Japan).iso" size 1459978240 crc 7b8a9cca md5 a3a68a3af3e98a5e892dd4d37d6f1654 sha1 e405dfdeb7196ec71a65d2e3f8e78e46fa1814f1 )
+)
+
+game (
+	name "Zoocube (JP) - zukiyubu"
+	description "Zoocube (JP) - zukiyubu"
+	rom ( name "Zoocube (JP).iso" size 1459978240 crc 7b8a9cca md5 a3a68a3af3e98a5e892dd4d37d6f1654 sha1 e405dfdeb7196ec71a65d2e3f8e78e46fa1814f1 )
+)
+
+game (
+	name "ZooCube (US)"
+	description "ZooCube (US)"
+	rom ( name "ZooCube (US).iso" size 1459978240 crc dc26206c md5 817624b30e3b8b620dfe96ad28c085fb sha1 843feb050b6c258b489c7168b997c1ec839efa44 )
+)
+
+game (
+	name "ZooCube (USA)"
+	description "ZooCube (USA)"
+	rom ( name "ZooCube (USA).iso" size 1459978240 crc dc26206c md5 817624b30e3b8b620dfe96ad28c085fb sha1 843feb050b6c258b489c7168b997c1ec839efa44 )
+)

--- a/metadat/libretro-dats/Nintendo - Wii.dat
+++ b/metadat/libretro-dats/Nintendo - Wii.dat
@@ -1,0 +1,6691 @@
+clrmamepro (
+	name "Nintendo - Wii"
+	description "Nintendo - Wii"
+	version "2016.9.25"
+	comment "Assembled from Redump, Trurip, TOSEC, Darkwater and AdvanceSCENE, for libretro-database."
+	homepage "http://github.com/robloach/libretro-dats"
+)
+
+game (
+	name "007 - Quantum of Solace (USA) (En,Fr)"
+	description "007 - Quantum of Solace (USA) (En,Fr)"
+	rom ( name "007 - Quantum of Solace (USA) (En,Fr).iso" size 4699979776 crc 12154a63 md5 607833438fd6b61de9fcf1381171fa05 sha1 dc4e3fb3c06f5a652076efb36c0bbb9dd3b7c447 )
+)
+
+game (
+	name "2010 FIFA World Cup South Africa (Europe) (En,Nl)"
+	description "2010 FIFA World Cup South Africa (Europe) (En,Nl)"
+	rom ( name "2010 FIFA World Cup South Africa (Europe) (En,Nl).iso" size 4699979776 crc 6de8366c md5 9639b04484c3524ddb12563a322a873f sha1 764da0cc19bd5534c2471ebe6dd74e2123007577 )
+)
+
+game (
+	name "2010 FIFA World Cup South Africa (Europe) (Es,It)"
+	description "2010 FIFA World Cup South Africa (Europe) (Es,It)"
+	rom ( name "2010 FIFA World Cup South Africa (Europe) (Es,It).iso" size 4699979776 crc fa8e441c md5 20016b1b1be023f38e5e775cd7da1d33 sha1 3352be19aeaa941b231689f3ba886631df97a932 )
+)
+
+game (
+	name "2010 FIFA World Cup South Africa (Europe) (Fr,De)"
+	description "2010 FIFA World Cup South Africa (Europe) (Fr,De)"
+	rom ( name "2010 FIFA World Cup South Africa (Europe) (Fr,De).iso" size 4699979776 crc a1f92eac md5 55633171adeb2dbd8f2cc74f35cd2210 sha1 b075d6503fbf0b8ca5e60a44417f76abb5ca31eb )
+)
+
+game (
+	name "428 - Fuusa Sareta Shibuya de (Japan)"
+	description "428 - Fuusa Sareta Shibuya de (Japan)"
+	rom ( name "428 - Fuusa Sareta Shibuya de (Japan).iso" size 4699979776 crc eb81d9d3 md5 1f3a03e9d6cf6dc9437eecadfb4822e8 sha1 7ff4a662bfec444417df4513e296a79844d72629 )
+)
+
+game (
+	name "Action Girlz Racing (Europe)"
+	description "Action Girlz Racing (Europe)"
+	rom ( name "Action Girlz Racing (Europe).iso" size 4699979776 crc 7b46f4b4 md5 32bc4f3910c277b78914ad768b550ece sha1 fbe9b8a6abaae9f8f19adaba245dc7c57c896f6b )
+)
+
+game (
+	name "Alan Hansen's Sports Challenge (Europe) (En,Fr,De,Es,It)"
+	description "Alan Hansen's Sports Challenge (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Alan Hansen's Sports Challenge (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0714544a md5 0781e6dfc7ccbaf5d1b8dee7c8df859b sha1 3c0e829c1ccdbed5a66f2068f23b18f8ebcf6f95 )
+)
+
+game (
+	name "Alien Syndrome (Europe) (En,Fr,De,Es,It)"
+	description "Alien Syndrome (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Alien Syndrome (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 07c44dff md5 4ad2fff2575197b6902a2c49e5a65f89 sha1 6a87c987bba92f02630223152bd08ad58720a05c )
+)
+
+game (
+	name "Alien Syndrome (USA)"
+	description "Alien Syndrome (USA)"
+	rom ( name "Alien Syndrome (USA).iso" size 4699979776 crc 52fe88b3 md5 20f3e3e1629bbc41b78daa359ab9c306 sha1 b527073e130d64a81654221559c80e8dafae4e95 )
+)
+
+game (
+	name "Aliens in the Attic (Europe) (En,Fr,De,Es,It)"
+	description "Aliens in the Attic (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Aliens in the Attic (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5aed0552 md5 512c20342799ad455ccf48a887967b9a sha1 b933a38aebb0f90488315eacdf6e88c29f233ad4 )
+)
+
+game (
+	name "All Star Cheer Squad (USA)"
+	description "All Star Cheer Squad (USA)"
+	rom ( name "All Star Cheer Squad (USA).iso" size 4699979776 crc 1769047a md5 aeaef5625333873e2df50b5f6cb281ad sha1 38d7454e413dbf7847a24bb082e826c9a124cf0e )
+)
+
+game (
+	name "All Star Cheer Squad 2 (USA)"
+	description "All Star Cheer Squad 2 (USA)"
+	rom ( name "All Star Cheer Squad 2 (USA).iso" size 4699979776 crc 55089c6e md5 0dae2241a297c338e7b318ee9e682bac sha1 456af520a62d13246512ca79aef926b9d2ad83dc )
+)
+
+game (
+	name "All Star Cheerleader (Europe)"
+	description "All Star Cheerleader (Europe)"
+	rom ( name "All Star Cheerleader (Europe).iso" size 4699979776 crc 9d775b2c md5 b9682080852d1d9b09d6289c08bf0d88 sha1 8db45dbc14d26e777e8c22e182ed4c0e70c9870a )
+)
+
+game (
+	name "All Star Cheerleader 2 (Europe, Australia)"
+	description "All Star Cheerleader 2 (Europe, Australia)"
+	rom ( name "All Star Cheerleader 2 (Europe, Australia).iso" size 4699979776 crc 11d481ed md5 1f3309d9821b6760b1e14464e19af459 sha1 a1b7b66a3c5b08d158ff243c426de969d2743bef )
+)
+
+game (
+	name "All Star Karate (Europe) (En,Fr,De,Es,It,Nl)"
+	description "All Star Karate (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "All Star Karate (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc ca6da037 md5 65ceb982511a60e3ee40c176639f3bde sha1 afff4cc7906d00f949fca471975ebf8157838135 )
+)
+
+game (
+	name "Alone in the Dark (Europe) (En,Fr,De,Es,It)"
+	description "Alone in the Dark (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Alone in the Dark (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 116d6fca md5 00bb31f1677582dcaffd17fb100111e0 sha1 cc4f1ec595e4dde5437c660cd2eb7fdf0d65f3a8 )
+)
+
+game (
+	name "Alone in the Dark (USA) (En,Fr,Es)"
+	description "Alone in the Dark (USA) (En,Fr,Es)"
+	rom ( name "Alone in the Dark (USA) (En,Fr,Es).iso" size 4699979776 crc 5726d71a md5 af224b980afd8637473e2b33e1a2eeab sha1 97314fd611475cb6530e6d386fc3124efc426e23 )
+)
+
+game (
+	name "Alvin and the Chipmunks - The Squeakquel (USA)"
+	description "Alvin and the Chipmunks - The Squeakquel (USA)"
+	rom ( name "Alvin and the Chipmunks - The Squeakquel (USA).iso" size 4699979776 crc 69ca5263 md5 4404353ab51be9e47114f42e61fdd370 sha1 f6d5010d419aaf0ff82f98eb4c1a97d90e140990 )
+)
+
+game (
+	name "Alvin and the Chipmunks (USA) (En,Fr)"
+	description "Alvin and the Chipmunks (USA) (En,Fr)"
+	rom ( name "Alvin and the Chipmunks (USA) (En,Fr).iso" size 4699979776 crc 6a519a0e md5 70a409fa5925c757fe0a2aa49e7dec39 sha1 a420772de313b6c6d5c2f353c98721ba8b451e62 )
+)
+
+game (
+	name "Amazing Spider-Man, The (USA) (En,Fr,Es)"
+	description "Amazing Spider-Man, The (USA) (En,Fr,Es)"
+	rom ( name "Amazing Spider-Man, The (USA) (En,Fr,Es).iso" size 4699979776 crc f94f8240 md5 a0727cf1a369150e58a487a51d8e4cef sha1 5e881d99b29cb17169e4ebf73f9ebca4b671e148 )
+)
+
+game (
+	name "America's Next Top Model (USA)"
+	description "America's Next Top Model (USA)"
+	rom ( name "America's Next Top Model (USA).iso" size 4699979776 crc df1db0a4 md5 f00d973e98df3c10f4f9e22361e7f64b sha1 1ad948041af38ffcc51e5e32312afcb520906582 )
+)
+
+game (
+	name "AMF Bowling - Pinbusters! (Europe) (En,Fr,De,Es,It)"
+	description "AMF Bowling - Pinbusters! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "AMF Bowling - Pinbusters! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5983db24 md5 12cc3b9670adafb4462d6232b8d2daa9 sha1 cbfab97cb57be38ce704eb6ecaf1fd8bc74f35cf )
+)
+
+game (
+	name "AMF Bowling - Pinbusters! (USA)"
+	description "AMF Bowling - Pinbusters! (USA)"
+	rom ( name "AMF Bowling - Pinbusters! (USA).iso" size 4699979776 crc 6b57f886 md5 dae421ee97cf84e87161c5342d31d8a0 sha1 4d3422e18e1b196aa71d76033051e2c58f8c7a68 )
+)
+
+game (
+	name "Angry Birds Star Wars (USA) (En,Fr,Es,Pt)"
+	description "Angry Birds Star Wars (USA) (En,Fr,Es,Pt)"
+	rom ( name "Angry Birds Star Wars (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 002b6c6e md5 6964897a2faff6b1787a7f41c43c0851 sha1 3e3706518ea6d2f3950c9a672249688c77f32021 )
+)
+
+game (
+	name "Angry Birds Trilogy (USA) (En,Fr)"
+	description "Angry Birds Trilogy (USA) (En,Fr)"
+	rom ( name "Angry Birds Trilogy (USA) (En,Fr).iso" size 4699979776 crc 9f5b94b0 md5 d00510bd29dfc8e9d80710f7e4f0d7a9 sha1 1b85642b1a1bda24e69a505b0feb0e7acdc8c670 )
+)
+
+game (
+	name "Animal Crossing - City Folk (USA) (En,Fr,Es)"
+	description "Animal Crossing - City Folk (USA) (En,Fr,Es)"
+	rom ( name "Animal Crossing - City Folk (USA) (En,Fr,Es).iso" size 4699979776 crc 2f468135 md5 732d7cddfd2f958d30b98ffeb72eeac4 sha1 a75c7389877b331a520803529798f909b0dd0122 )
+)
+
+game (
+	name "Animal Crossing - Let's Go to the City (Europe) (En,Fr,De,Es,It)"
+	description "Animal Crossing - Let's Go to the City (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Animal Crossing - Let's Go to the City (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ecdbce00 md5 68039075bd476d0f0bd5d31d1e474f76 sha1 e406847a2350a9d188817dfae75d3a5e89485116 )
+)
+
+game (
+	name "Anno - Create a New World (Europe) (En,Fr,De,Es,It)"
+	description "Anno - Create a New World (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Anno - Create a New World (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6e8471aa md5 bcac9ea6082951bb058d2652dbb01c20 sha1 2f1fdd1d2f6e780d6df0d85f69f48feed15c242b )
+)
+
+game (
+	name "Another Code R - A Journey into Lost Memories (Europe) (En,Fr,De,Es,It)"
+	description "Another Code R - A Journey into Lost Memories (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Another Code R - A Journey into Lost Memories (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0b4a7487 md5 4e0b7bcc43c130fe85e452537e258213 sha1 46b213063933ecfc83746049e20c90f4408e4411 )
+)
+
+game (
+	name "Another Code R - Kioku no Tobira (Japan)"
+	description "Another Code R - Kioku no Tobira (Japan)"
+	rom ( name "Another Code R - Kioku no Tobira (Japan).iso" size 4699979776 crc 92c00450 md5 29640af6a5ec19c21833340a779cb143 sha1 52a1996d5ba74ee4712d9b882819aecd661410e1 )
+)
+
+game (
+	name "Ant Bully, The (Europe) (En,Fr,De,Es,It)"
+	description "Ant Bully, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Ant Bully, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7478438f md5 4ea2c9d47cfcfc944895b030e46a545c sha1 8930dc444d07bc59768cf1fa015d774db61a0bfd )
+)
+
+game (
+	name "Aqua Panic! (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Aqua Panic! (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Aqua Panic! (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc a460a9d1 md5 d2487ab4ac59e63106722f5b2cada3fa sha1 dfb79aa627c17894d55ded36b62acbc72b80904f )
+)
+
+game (
+	name "Arc Rise Fantasia (Japan)"
+	description "Arc Rise Fantasia (Japan)"
+	rom ( name "Arc Rise Fantasia (Japan).iso" size 4699979776 crc f92834dc md5 31aebda4cb726a80763bb6c4e76211e2 sha1 383599d38df8105da21a32d7a18fb4a30514878e )
+)
+
+game (
+	name "Arc Rise Fantasia (USA)"
+	description "Arc Rise Fantasia (USA)"
+	rom ( name "Arc Rise Fantasia (USA).iso" size 4699979776 crc 7c461f3d md5 d70eab544ac48ccd22a36457a4fa12d6 sha1 71d1ce8a2e02566dfc416349a50fbe93f4beb23d )
+)
+
+game (
+	name "Are You Smarter Than a 5th Grader - Game Time (USA)"
+	description "Are You Smarter Than a 5th Grader - Game Time (USA)"
+	rom ( name "Are You Smarter Than a 5th Grader - Game Time (USA).iso" size 4699979776 crc 34c89e96 md5 1ebe65b98ceb63d5e99cc128cea309c9 sha1 a0b8f605e3c90049e7a64fb17f19d72ff8c37ab8 )
+)
+
+game (
+	name "Are You Smarter Than a 5th Grader - Make the Grade (USA)"
+	description "Are You Smarter Than a 5th Grader - Make the Grade (USA)"
+	rom ( name "Are You Smarter Than a 5th Grader - Make the Grade (USA).iso" size 4699979776 crc a8b7a9d3 md5 9b10ae1662fb732bdccd3011f6bcc2a1 sha1 c631b3645d9db94e568c23efcfd09ddf0580029f )
+)
+
+game (
+	name "Army Men - Soldiers of Misfortune (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Army Men - Soldiers of Misfortune (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Army Men - Soldiers of Misfortune (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc fdad78b2 md5 7c5793d11353549da000e23cf565bdb0 sha1 3a5145ee744bdd862b110620bf9c682e270c2095 )
+)
+
+game (
+	name "Ashes Cricket 2009 (Europe)"
+	description "Ashes Cricket 2009 (Europe)"
+	rom ( name "Ashes Cricket 2009 (Europe).iso" size 4699979776 crc 3b69bb28 md5 e01d377a05a6fa41eb857e6f18ed755c sha1 f62074b94f36ee3ebce766a96ce1ccc55a77ad6e )
+)
+
+game (
+	name "Asterix at the Olympic Games (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Asterix at the Olympic Games (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Asterix at the Olympic Games (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 0277211e md5 9b52009e8b0a6c115b6b51ea60d2348a sha1 347aa5dc829aeaab919a4c024684a2df2598c549 )
+)
+
+game (
+	name "Astro Boy - The Video Game (USA) (En,Fr,Es)"
+	description "Astro Boy - The Video Game (USA) (En,Fr,Es)"
+	rom ( name "Astro Boy - The Video Game (USA) (En,Fr,Es).iso" size 4699979776 crc c33551a3 md5 bafb2c8de9e8ec34bde2b47c2fe7c52c sha1 8c3cc8c561d5269e757ea4fe6510b2ea468acdfb )
+)
+
+game (
+	name "Avatar - The Last Airbender - Into the Inferno (USA)"
+	description "Avatar - The Last Airbender - Into the Inferno (USA)"
+	rom ( name "Avatar - The Last Airbender - Into the Inferno (USA).iso" size 4699979776 crc c27c2445 md5 9e2ee27118a5b46643aecd75562f70aa sha1 6ccb950fb2f32ba027d9ad070eed6742fe5b76f8 )
+)
+
+game (
+	name "Baby and Me (Europe) (En,Fr,De,Es,It)"
+	description "Baby and Me (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Baby and Me (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc eafdd051 md5 aff2e155ead773d15262d63ea009015a sha1 6a55ac5768777fb7c4ec134c20d09e9eee71ef46 )
+)
+
+game (
+	name "Babysitting Mama (USA)"
+	description "Babysitting Mama (USA)"
+	rom ( name "Babysitting Mama (USA).iso" size 4699979776 crc 3bdb4c23 md5 25d22f6a40143f70e5ec2fcf9c51e3f7 sha1 95ccf018c64000228a3ef8dc654813a2076b1961 )
+)
+
+game (
+	name "Back to the Future - The Game (USA) (En,Fr,De)"
+	description "Back to the Future - The Game (USA) (En,Fr,De)"
+	rom ( name "Back to the Future - The Game (USA) (En,Fr,De).iso" size 4699979776 crc 7f2979b4 md5 17aab1ab2706edd7261e2b7f37a57340 sha1 2ca5458c3a3052b6bcce691ab2d213b4cf81d459 )
+)
+
+game (
+	name "Backyard Baseball '10 (USA)"
+	description "Backyard Baseball '10 (USA)"
+	rom ( name "Backyard Baseball '10 (USA).iso" size 4699979776 crc 7c148b74 md5 1e8ad2e1854eb9ded2b95301d6f3237a sha1 e88f5f763b96bbb4780bdb2e0c1f64ba6ee1b75f )
+)
+
+game (
+	name "Bakugan - Battle Brawlers - Toys'R'Us Edition (USA) (En,Fr)"
+	description "Bakugan - Battle Brawlers - Toys'R'Us Edition (USA) (En,Fr)"
+	rom ( name "Bakugan - Battle Brawlers - Toys'R'Us Edition (USA) (En,Fr).iso" size 4699979776 crc 2b31375e md5 f3a8ecb4dd40e5ec7f98e12134246291 sha1 f564ad72ec2f7dd69297d9e590803442812a1a27 )
+)
+
+game (
+	name "Bakugan - Battle Brawlers (Europe) (En,Fr,De,Es,It,Nl,Sv)"
+	description "Bakugan - Battle Brawlers (Europe) (En,Fr,De,Es,It,Nl,Sv)"
+	rom ( name "Bakugan - Battle Brawlers (Europe) (En,Fr,De,Es,It,Nl,Sv).iso" size 4699979776 crc dc0ee917 md5 a10387eaeceaf17ec03f94d9620ca864 sha1 e0e6dabb440a5172c2404ac72fb1c89261e2aee5 )
+)
+
+game (
+	name "Bakugan - Battle Brawlers (USA) (En,Fr)"
+	description "Bakugan - Battle Brawlers (USA) (En,Fr)"
+	rom ( name "Bakugan - Battle Brawlers (USA) (En,Fr).iso" size 4699979776 crc 798735d6 md5 fa6716a77b6e9fbacf4ef776c2af8097 sha1 06c2d6326ee8188478232fb5dcc361ac1c012f15 )
+)
+
+game (
+	name "Balls of Fury (Europe) (En,Fr,De,Es,It)"
+	description "Balls of Fury (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Balls of Fury (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9b288c19 md5 8df65127eeb85ec49f7a3f3de954d3ad sha1 c09a6e9d354f1319f4ef6ee6996407b03050d4ab )
+)
+
+game (
+	name "Band Hero (Europe) (En,Fr,De,Es,It)"
+	description "Band Hero (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Band Hero (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15b8bbca md5 800295c82835dbd1bc8210b295da8770 sha1 2a4f756375887eb9d7ebcbdc2555f5bdefead439 )
+)
+
+game (
+	name "Band Hero (USA)"
+	description "Band Hero (USA)"
+	rom ( name "Band Hero (USA).iso" size 4699979776 crc 87d3b832 md5 07ab0d7f47fbee1caa84b570a2c462b1 sha1 30e0b4902698dab201e81f071a919a60d8376baa )
+)
+
+game (
+	name "Baroque (USA)"
+	description "Baroque (USA)"
+	rom ( name "Baroque (USA).iso" size 4699979776 crc 7911d3ce md5 1ba20a004f7d03b605f9bd42a227ea71 sha1 aa3720e6ec92f00c0a30fe2ac642c6d15c627920 )
+)
+
+game (
+	name "Bass Pro Shops - The Strike (USA)"
+	description "Bass Pro Shops - The Strike (USA)"
+	rom ( name "Bass Pro Shops - The Strike (USA).iso" size 4699979776 crc d537930e md5 f878f9458257dd690318f4482df2506d sha1 42d5f798dda323ddaf111b73aa0da83ee0e7d4b7 )
+)
+
+game (
+	name "Batman - The Brave and the Bold - The Videogame (USA) (En,Fr,Es)"
+	description "Batman - The Brave and the Bold - The Videogame (USA) (En,Fr,Es)"
+	rom ( name "Batman - The Brave and the Bold - The Videogame (USA) (En,Fr,Es).iso" size 4699979776 crc ed0a8e07 md5 bf5a9b4f4253d8069b8331652a1b96a0 sha1 2369beb354cd9537740236e466a7cda2fcdc750e )
+)
+
+game (
+	name "Battalion Wars 2 (Europe) (En,Fr,De,Es,It)"
+	description "Battalion Wars 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Battalion Wars 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 24f09ee6 md5 7c56dd60937035438c6c5479689e7c3a sha1 531d3396aa7323aba3f2d379e0f2fae524ac8299 )
+)
+
+game (
+	name "Battalion Wars 2 (USA)"
+	description "Battalion Wars 2 (USA)"
+	rom ( name "Battalion Wars 2 (USA).iso" size 4699979776 crc b8e6d7bd md5 b2f5a32adbba7f7edaa8990d8f19edd9 sha1 c1c9f8336e7e04786dbee8c575181ebaa4979655 )
+)
+
+game (
+	name "Battle of the Bands (Europe) (En,Fr,De,Es,It)"
+	description "Battle of the Bands (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Battle of the Bands (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d1022c7f md5 44dcac381cd3a6681d162eb159f7ee13 sha1 399f38e9b43e0e80c36e350b5f0c5fb91d7860a0 )
+)
+
+game (
+	name "Battle of the Bands (USA)"
+	description "Battle of the Bands (USA)"
+	rom ( name "Battle of the Bands (USA).iso" size 4699979776 crc 8f3e9601 md5 b356c6dcd2fc8a9e7397aed43335b38c sha1 46b54df629f64e7a858d99b94aa5fb522ae3022f )
+)
+
+game (
+	name "Beatles, The - Rock Band (Europe) (En,Fr,De,Es,It)"
+	description "Beatles, The - Rock Band (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Beatles, The - Rock Band (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 26ca6a56 md5 fa9c862586923be8b76d291dee06c176 sha1 65491445c80278fa6bb9bc80cbf43ac76b702253 )
+)
+
+game (
+	name "Beatles, The - Rock Band (USA)"
+	description "Beatles, The - Rock Band (USA)"
+	rom ( name "Beatles, The - Rock Band (USA).iso" size 4699979776 crc eb8224bf md5 0b476b1f9f3479e9576954d46f5d380e sha1 cc451c2c34a9860c7008085e8add2274130f1b79 )
+)
+
+game (
+	name "Bee Movie Game (USA)"
+	description "Bee Movie Game (USA)"
+	rom ( name "Bee Movie Game (USA).iso" size 4699979776 crc 012d5dce md5 c51d6c10be3b8631ea09e6b031045b8a sha1 99617d9e5b0db3f25498ac038347156820b204d8 )
+)
+
+game (
+	name "Ben 10 - Alien Force - Vilgax Attacks (USA) (En,Fr,Es)"
+	description "Ben 10 - Alien Force - Vilgax Attacks (USA) (En,Fr,Es)"
+	rom ( name "Ben 10 - Alien Force - Vilgax Attacks (USA) (En,Fr,Es).iso" size 4699979776 crc b22dea8d md5 c75ee4467dbff582dedcce1293e677fe sha1 aeb28c5d94f0aaad67b141ff904d683dc5f0ca71 )
+)
+
+game (
+	name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It)"
+	description "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 92333fdf md5 ad8eae8f2a9ca025f716f8be9d741303 sha1 297d78ebafcfc8e6913fa8361edd9a6fcc0a6f6f )
+)
+
+game (
+	name "Ben 10 - Alien Force (USA) (En,Fr,Es)"
+	description "Ben 10 - Alien Force (USA) (En,Fr,Es)"
+	rom ( name "Ben 10 - Alien Force (USA) (En,Fr,Es).iso" size 4699979776 crc d4bd5ff9 md5 28852ed1110f601a7bba5dc2cfef9d56 sha1 36938b1245faf43528355e625eb2bb575d5c5e43 )
+)
+
+game (
+	name "Ben 10 - Protector of Earth (USA)"
+	description "Ben 10 - Protector of Earth (USA)"
+	rom ( name "Ben 10 - Protector of Earth (USA).iso" size 4699979776 crc 354015dd md5 d342fb9f96ab61fcd6ad49b0dc7f955a sha1 33485c37f4b181f59079d01086a43c5a3d06f312 )
+)
+
+game (
+	name "Beyblade - Metal Fusion - Counter Leone (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Beyblade - Metal Fusion - Counter Leone (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Beyblade - Metal Fusion - Counter Leone (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 80b22ebd md5 4c18436be8cf969c8bf6c64406490e0d sha1 0cb493e94ef1753812f38ebce61c8a04ccc483ed )
+)
+
+game (
+	name "Big Beach Sports (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Big Beach Sports (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Big Beach Sports (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 13099587 md5 e2c38ed0c6558fccf37a9b0a68762bea sha1 1d5ee8202d0dd425f35af74986d040af2c586b39 )
+)
+
+game (
+	name "Big Beach Sports (USA) (En,Fr,Es)"
+	description "Big Beach Sports (USA) (En,Fr,Es)"
+	rom ( name "Big Beach Sports (USA) (En,Fr,Es).iso" size 4699979776 crc c6e0741c md5 1a4b014a20dac8540fabe07c4c6ce987 sha1 9508b591b5541ca2d28871b72a3419ccb6daa4de )
+)
+
+game (
+	name "Big Beach Sports 2 (USA)"
+	description "Big Beach Sports 2 (USA)"
+	rom ( name "Big Beach Sports 2 (USA).iso" size 4699979776 crc 01b4fd65 md5 78cc5c6d302a5c60ebd8e4b7ec3e349a sha1 72fee79ccc786155e051ce2bbe7ce4563dedf094 )
+)
+
+game (
+	name "Big Brain Academy - Wii Degree (USA) (En,Fr,Es)"
+	description "Big Brain Academy - Wii Degree (USA) (En,Fr,Es)"
+	rom ( name "Big Brain Academy - Wii Degree (USA) (En,Fr,Es).iso" size 4699979776 crc d0457e26 md5 238165ae6eac575890a1e59a132303fb sha1 37896d2a60172695467d911e1d77d02f846a9856 )
+)
+
+game (
+	name "Big Brain Academy for Wii (Europe) (En,Fr,De,Es,It)"
+	description "Big Brain Academy for Wii (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Big Brain Academy for Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6538bbd9 md5 e9710660538d07454d069dd3d99a1a4c sha1 fbece33c107b50a3b810097c2519f2fb08a3d897 )
+)
+
+game (
+	name "Big Family Games (Europe) (En,Fr,De,Es,It)"
+	description "Big Family Games (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Big Family Games (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 481093e8 md5 d44bc385442fed7b3da0c0b825814b44 sha1 85180cc73df13118e613401e4492095dfc567f96 )
+)
+
+game (
+	name "Big League Sports - Summer (USA) (En,Fr)"
+	description "Big League Sports - Summer (USA) (En,Fr)"
+	rom ( name "Big League Sports - Summer (USA) (En,Fr).iso" size 4699979776 crc ca541c84 md5 7cf9917d4d0ffb99bc4847785d5c85c7 sha1 3e087aec5c7a31308aaafb239045ae33d1f95e2e )
+)
+
+game (
+	name "Big League Sports (USA) (En,Fr)"
+	description "Big League Sports (USA) (En,Fr)"
+	rom ( name "Big League Sports (USA) (En,Fr).iso" size 4699979776 crc 59eaed17 md5 f7a7fb786fad22dea2ae9c1d0cda0e1d sha1 3644b925540ccca73fdbd8836474f524830b894c )
+)
+
+game (
+	name "Biggest Loser, The (USA)"
+	description "Biggest Loser, The (USA)"
+	rom ( name "Biggest Loser, The (USA).iso" size 4699979776 crc b8bf5ba9 md5 4c1c504bb23a8864ffe0de52cec32f67 sha1 209f6fea57233fca0da5d8ef647d0e79407ffc59 )
+)
+
+game (
+	name "Bigs 2, The - Baseball (Europe)"
+	description "Bigs 2, The - Baseball (Europe)"
+	rom ( name "Bigs 2, The - Baseball (Europe).iso" size 4699979776 crc 0662fd3b md5 01b8a3dbafcf5f394089a524727dd232 sha1 2397b4e5df8d88fda69147263a9750b18199156d )
+)
+
+game (
+	name "Bigs 2, The (USA)"
+	description "Bigs 2, The (USA)"
+	rom ( name "Bigs 2, The (USA).iso" size 4699979776 crc 43d7cfa8 md5 0c09d156fc0c4a61e5f936b783afffbb sha1 09b63e581548df85599504d070b1183b174fbce8 )
+)
+
+game (
+	name "Bigs, The (USA)"
+	description "Bigs, The (USA)"
+	rom ( name "Bigs, The (USA).iso" size 4699979776 crc d0e0c15f md5 b3e6f84408d318a19573b6ecd8f3c41e sha1 46c2195789309ab396ea131764230f7c54e74ad2 )
+)
+
+game (
+	name "Biohazard - The Darkside Chronicles (Japan)"
+	description "Biohazard - The Darkside Chronicles (Japan)"
+	rom ( name "Biohazard - The Darkside Chronicles (Japan).iso" size 4699979776 crc b931d421 md5 318dc2d1991b2398e8c125d51bbfc860 sha1 9b50e7979a56a6629eb8f41f48840b93179850dc )
+)
+
+game (
+	name "Biohazard - Umbrella Chronicles (Japan) (v1.00)"
+	description "Biohazard - Umbrella Chronicles (Japan) (v1.00)"
+	rom ( name "Biohazard - Umbrella Chronicles (Japan) (v1.00).iso" size 4699979776 crc 69fbf647 md5 7f06147bdb6b3cb663f0fdae877c8068 sha1 ebd6d59d9b7f83fca3de1512984a710f6a16129d )
+)
+
+game (
+	name "Biohazard - Umbrella Chronicles (Japan) (v1.01)"
+	description "Biohazard - Umbrella Chronicles (Japan) (v1.01)"
+	rom ( name "Biohazard - Umbrella Chronicles (Japan) (v1.01).iso" size 4699979776 crc e93def9b md5 f22275ea12db88b2edcc4ade39eb04b4 sha1 ddb9bf60a9532348ab01286997e8766102658fd9 )
+)
+
+game (
+	name "Biohazard (Japan)"
+	description "Biohazard (Japan)"
+	rom ( name "Biohazard (Japan).iso" size 4699979776 crc 525d47d9 md5 b2cba9d58898510d45e9808b91dd4087 sha1 a1b17b3d290f7ae0c3f18b4bd6231203d17f907b )
+)
+
+game (
+	name "Biohazard 4 - Wii Edition (Japan) (v1.00)"
+	description "Biohazard 4 - Wii Edition (Japan) (v1.00)"
+	rom ( name "Biohazard 4 - Wii Edition (Japan) (v1.00).iso" size 4699979776 crc 535ec7d0 md5 253c9431389bbb0dbb17f5fdfb234549 sha1 3d3382fd74802be233771ba735a526c2d5179756 )
+)
+
+game (
+	name "Biohazard 4 - Wii Edition (Japan) (v1.01)"
+	description "Biohazard 4 - Wii Edition (Japan) (v1.01)"
+	rom ( name "Biohazard 4 - Wii Edition (Japan) (v1.01).iso" size 4699979776 crc db6c7d78 md5 2416b963e3234eab75509643dce3cb8a sha1 e0354cf256542d514e6849cadd7f6f13b36ff1a0 )
+)
+
+game (
+	name "Biohazard Zero (Japan)"
+	description "Biohazard Zero (Japan)"
+	rom ( name "Biohazard Zero (Japan).iso" size 4699979776 crc 73e0444d md5 018f4658d33b39b5e097564d1e876661 sha1 a620b0b723233f7da40730bd96aa3fb8578e857a )
+)
+
+game (
+	name "Bit.Trip Complete (Europe)"
+	description "Bit.Trip Complete (Europe)"
+	rom ( name "Bit.Trip Complete (Europe).iso" size 4699979776 crc 964e4df5 md5 e21fc6f26958f5d49738b83b6366c48e sha1 de1f4ec683791193290846998672bc837f97ed12 )
+)
+
+game (
+	name "Bit.Trip Complete (USA)"
+	description "Bit.Trip Complete (USA)"
+	rom ( name "Bit.Trip Complete (USA).iso" size 4699979776 crc abdd046a md5 5bd47f5c25522bbf3470db6fddd6065d sha1 3aae644bfa7d8e17a794b45645102c8f3e8c5950 )
+)
+
+game (
+	name "Black Eyed Peas Experience, The (Europe) (En,Fr,De,Es,It)"
+	description "Black Eyed Peas Experience, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Black Eyed Peas Experience, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 300c7cf9 md5 6c969f09e5d181e6a1b7783e30e5d83c sha1 d0002b1f92c7f9f1b6804d7c53d18e4b5aa3dc14 )
+)
+
+game (
+	name "Black Eyed Peas Experience, The (USA) (En,Fr,Es)"
+	description "Black Eyed Peas Experience, The (USA) (En,Fr,Es)"
+	rom ( name "Black Eyed Peas Experience, The (USA) (En,Fr,Es).iso" size 4699979776 crc 3be4cf40 md5 98021b3a1a04f2121e36e29c41a9d6bc sha1 1ee5b7268298589efa203eae6ad44ca31a1ee60f )
+)
+
+game (
+	name "Blast Works - Build, Trade, Destroy (Europe)"
+	description "Blast Works - Build, Trade, Destroy (Europe)"
+	rom ( name "Blast Works - Build, Trade, Destroy (Europe).iso" size 4699979776 crc 2a390a44 md5 57dd6c8cd58499b546ce276c8c146766 sha1 fc3c80f3e26ca1170ba8f0ef6aaeb4a0c3d13ecc )
+)
+
+game (
+	name "Blast Works - Build, Trade, Destroy (USA)"
+	description "Blast Works - Build, Trade, Destroy (USA)"
+	rom ( name "Blast Works - Build, Trade, Destroy (USA).iso" size 4699979776 crc f5e79dd5 md5 78b1aba7d6064aadf817d57ee94ce06b sha1 ac22b634ff12f86722076cec6b8f5c9e267ed86a )
+)
+
+game (
+	name "Blazing Angels - Squadrons of WWII (USA) (En,Fr,Es)"
+	description "Blazing Angels - Squadrons of WWII (USA) (En,Fr,Es)"
+	rom ( name "Blazing Angels - Squadrons of WWII (USA) (En,Fr,Es).iso" size 4699979776 crc 49c49da2 md5 2b8f410ecee02ce5d3dfd053d760e98f sha1 3aaa5213e5b2d26eb2ff784c4f05399d5250475e )
+)
+
+game (
+	name "Bleach - Shattered Blade (USA)"
+	description "Bleach - Shattered Blade (USA)"
+	rom ( name "Bleach - Shattered Blade (USA).iso" size 4699979776 crc f6086152 md5 2e95c47294bc519497dabdc666842e57 sha1 6af272f4399984e54f22a46b99a49dc939195bd3 )
+)
+
+game (
+	name "Block Party - 20 Games (USA) (En,Fr)"
+	description "Block Party - 20 Games (USA) (En,Fr)"
+	rom ( name "Block Party - 20 Games (USA) (En,Fr).iso" size 4699979776 crc 143e0f38 md5 2756bfe23ee28acb403c41fa4cf95455 sha1 530ea87629ee6f3dae9c0582719fd29274525f80 )
+)
+
+game (
+	name "Bolt (USA) (En,Fr,Es)"
+	description "Bolt (USA) (En,Fr,Es)"
+	rom ( name "Bolt (USA) (En,Fr,Es).iso" size 4699979776 crc 749686bc md5 b00b62e9baec8c1315049bab3300547f sha1 da8f0454eb2a5071cff7e17da562bfb1bcced072 )
+)
+
+game (
+	name "Bomberman Land (USA)"
+	description "Bomberman Land (USA)"
+	rom ( name "Bomberman Land (USA).iso" size 4699979776 crc b74e7962 md5 6b4ab0301aa224c5f91874c41f3dddf4 sha1 f3dc173f101703237316fbafef9dbc6882ec718a )
+)
+
+game (
+	name "Boogie (Europe) (En,Fr,De,Es,It,Nl,Pt)"
+	description "Boogie (Europe) (En,Fr,De,Es,It,Nl,Pt)"
+	rom ( name "Boogie (Europe) (En,Fr,De,Es,It,Nl,Pt).iso" size 4699979776 crc 148a71fd md5 5230f6f42439f0bcc67c1b42852039ce sha1 a5eca0ae57b1458470fdf95d455c5b48a7ae4f26 )
+)
+
+game (
+	name "Boogie SuperStar (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Boogie SuperStar (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Boogie SuperStar (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 3cda7645 md5 a87d34a173c7af5200469d78d789da8f sha1 ee9852bd27c1d346b149fb0f77eeb89bb91fe175 )
+)
+
+game (
+	name "Boom Blox (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Boom Blox (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Boom Blox (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc f40a63bf md5 bbab2f34194e3abac4c86211545c396c sha1 61a4669ac9c6259b8bcfce51d4bc74c5ef8f4de1 )
+)
+
+game (
+	name "Boom Blox (USA) (En,Fr,Es)"
+	description "Boom Blox (USA) (En,Fr,Es)"
+	rom ( name "Boom Blox (USA) (En,Fr,Es).iso" size 4699979776 crc 7b15e8ce md5 63d749ffdde0ab32dc69d535ef8f373e sha1 80d87ee6cdd8323e28d023b8693645becb901d90 )
+)
+
+game (
+	name "Boom Blox Bash Party (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Boom Blox Bash Party (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Boom Blox Bash Party (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 2e3ae3cd md5 5dae66cc989f75d0478b991f41f9ff5b sha1 898c4ba18fd6060426713d0035cf990ef58a0517 )
+)
+
+game (
+	name "Boom Blox Bash Party (USA) (En,Fr,Es)"
+	description "Boom Blox Bash Party (USA) (En,Fr,Es)"
+	rom ( name "Boom Blox Bash Party (USA) (En,Fr,Es).iso" size 4699979776 crc cba13de6 md5 52d0a58b91908fcf1e6e4d85ff0f6efb sha1 f1d8101814b16d9d2171b4f5fa291e069137471c )
+)
+
+game (
+	name "Boom Street (Europe) (En,Fr,De,Es,It)"
+	description "Boom Street (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Boom Street (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 49cb59c8 md5 4369ef2518224bdec0e51f9582445a2b sha1 e171e575dd061ca36cda8d677bf5b06324ea18b1 )
+)
+
+game (
+	name "Boy and His Blob, A (Europe)"
+	description "Boy and His Blob, A (Europe)"
+	rom ( name "Boy and His Blob, A (Europe).iso" size 4699979776 crc 08b18d7d md5 ef5250332b6748a548b73d468f647b1c sha1 0516cfd3ff8287cd1c1b2a8c180c4f37bdaac877 )
+)
+
+game (
+	name "Boy and His Blob, A (USA)"
+	description "Boy and His Blob, A (USA)"
+	rom ( name "Boy and His Blob, A (USA).iso" size 4699979776 crc 9c1e4907 md5 b836e06ab7c01e2b8b61394e34bdb782 sha1 7f893817a0078aa599365fe7712b783c21aa7c0b )
+)
+
+game (
+	name "Bratz - Girlz Really Rock (USA) (En,Fr)"
+	description "Bratz - Girlz Really Rock (USA) (En,Fr)"
+	rom ( name "Bratz - Girlz Really Rock (USA) (En,Fr).iso" size 4699979776 crc 0bea8553 md5 23414eef965da01c6687c55db31f458a sha1 a54ec4f336c151c40b6630bcef8c2b12fe8cea91 )
+)
+
+game (
+	name "Bratz - The Movie (UK) (En,Fr)"
+	description "Bratz - The Movie (UK) (En,Fr)"
+	rom ( name "Bratz - The Movie (UK) (En,Fr).iso" size 4699979776 crc e58157c9 md5 5029e64642c49e9930af06132230beb8 sha1 2eda7eb169ad230195f03480a2c6c3af43671356 )
+)
+
+game (
+	name "Bratz - The Movie (USA)"
+	description "Bratz - The Movie (USA)"
+	rom ( name "Bratz - The Movie (USA).iso" size 4699979776 crc 0d15cc2b md5 6ce100fea8e00bdd68c391da074ad54a sha1 35f0afaa6a3161e5b34676a41fb27ea82e4b4c2e )
+)
+
+game (
+	name "Broken Sword - Shadow of the Templars - The Director's Cut (Europe) (En,Fr,De,Es,It)"
+	description "Broken Sword - Shadow of the Templars - The Director's Cut (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Broken Sword - Shadow of the Templars - The Director's Cut (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7de189cb md5 f3de5f3eb741e5b831615f36ae3b994e sha1 800a1167797ff5e9823cb4a0e6dc571943ae95a9 )
+)
+
+game (
+	name "Broken Sword - Shadow of the Templars - The Director's Cut (USA) (En,Fr,Es)"
+	description "Broken Sword - Shadow of the Templars - The Director's Cut (USA) (En,Fr,Es)"
+	rom ( name "Broken Sword - Shadow of the Templars - The Director's Cut (USA) (En,Fr,Es).iso" size 4699979776 crc bab2c4ba md5 9db304c8583c85f54c3032c953905c7b sha1 b6bca710e1a534027221384358b0cc97a958c25c )
+)
+
+game (
+	name "Brothers in Arms - Earned in Blood (Europe) (En,Fr,De,Es,It)"
+	description "Brothers in Arms - Earned in Blood (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Brothers in Arms - Earned in Blood (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9ca00c47 md5 1f6217b94162b7dbd14b2413def1601a sha1 5176029be0236db189d256cbb70389df0063dff6 )
+)
+
+game (
+	name "Brothers in Arms - Road to Hill 30 (Europe) (En,Fr,De,Es,It)"
+	description "Brothers in Arms - Road to Hill 30 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Brothers in Arms - Road to Hill 30 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b3c567fb md5 327d8757c6e7dc2d8b0c4978d2c17fc3 sha1 54edfca79cfb08a9e3707f07c5fc9f022d8fa993 )
+)
+
+game (
+	name "Brunswick Pro Bowling (USA)"
+	description "Brunswick Pro Bowling (USA)"
+	rom ( name "Brunswick Pro Bowling (USA).iso" size 4699979776 crc 67f75ac4 md5 5c37d985e89f7c8a772b99b4308f687d sha1 00d2e64267af9602e0a46ed2130f7880731f75a4 )
+)
+
+game (
+	name "Bully - Scholarship Edition (Europe) (En,Fr,De,Es,It)"
+	description "Bully - Scholarship Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Bully - Scholarship Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3ad58ac7 md5 c77a6a2175a2a45c51e02873ed64bbd3 sha1 e46f410db51c2b89763318e99ef3122bdca4d051 )
+)
+
+game (
+	name "Bully - Scholarship Edition (USA) (En,Fr,Es)"
+	description "Bully - Scholarship Edition (USA) (En,Fr,Es)"
+	rom ( name "Bully - Scholarship Edition (USA) (En,Fr,Es).iso" size 4699979776 crc d4b9002c md5 18afd11722f8dd1b88e1678facc4bdca sha1 09b41f744ddda2943f77dbdae97baa98e4e69bab )
+)
+
+game (
+	name "Bust-A-Move Bash! (USA)"
+	description "Bust-A-Move Bash! (USA)"
+	rom ( name "Bust-A-Move Bash! (USA).iso" size 4699979776 crc ef75b035 md5 47d03649883df10d89920b6ff171153d sha1 4db6f6a4225cabdc261d1b087189e6c387ee3799 )
+)
+
+game (
+	name "Cabela's Adventure Camp (USA) (En,Fr)"
+	description "Cabela's Adventure Camp (USA) (En,Fr)"
+	rom ( name "Cabela's Adventure Camp (USA) (En,Fr).iso" size 4699979776 crc 0ca22e5c md5 795ebd630ea365c6c930b00f6d5b17b5 sha1 f19af995fe59d95b877c8e01e0d738d9013babfc )
+)
+
+game (
+	name "Cabela's Big Game Hunter (USA)"
+	description "Cabela's Big Game Hunter (USA)"
+	rom ( name "Cabela's Big Game Hunter (USA).iso" size 4699979776 crc 1bfa8a42 md5 680e67cc24127ec54cca1cc1c079a175 sha1 01bd17c0b4f760b57edfbb21db8bb1748726ff6e )
+)
+
+game (
+	name "Cabela's Big Game Hunter 2010 (USA)"
+	description "Cabela's Big Game Hunter 2010 (USA)"
+	rom ( name "Cabela's Big Game Hunter 2010 (USA).iso" size 4699979776 crc a9bd6b44 md5 55f0bc19d1a1a37d7a307d5c985e163b sha1 244785ee493106a475737ec9975eeec0eaf9368b )
+)
+
+game (
+	name "Cabela's Legendary Adventures (USA)"
+	description "Cabela's Legendary Adventures (USA)"
+	rom ( name "Cabela's Legendary Adventures (USA).iso" size 4699979776 crc 6261f718 md5 8e5e2c93dcf781a5691b75d1e6063612 sha1 d3deefe4d9820f398f46cef1487310f9f2bc98e3 )
+)
+
+game (
+	name "Cabela's Outdoor Adventures 2010 (USA)"
+	description "Cabela's Outdoor Adventures 2010 (USA)"
+	rom ( name "Cabela's Outdoor Adventures 2010 (USA).iso" size 4699979776 crc b98b9102 md5 4c40eb044dda7d78497e1b2c6c592404 sha1 dc89a88457624dfbfe9c76567416f7117c6e92eb )
+)
+
+game (
+	name "Cabela's Survival - Shadows of Katmai (USA) (En,Fr)"
+	description "Cabela's Survival - Shadows of Katmai (USA) (En,Fr)"
+	rom ( name "Cabela's Survival - Shadows of Katmai (USA) (En,Fr).iso" size 4699979776 crc 2e7beda5 md5 264906b0cdb224ee20250bb9ca59dabf sha1 6d808ae35bf05e692acdc4823650a7c4354667c1 )
+)
+
+game (
+	name "Cabela's Trophy Bucks (USA)"
+	description "Cabela's Trophy Bucks (USA)"
+	rom ( name "Cabela's Trophy Bucks (USA).iso" size 4699979776 crc 8b23a371 md5 1faa11d9e643b417aaf5ed9e7d3a82fe sha1 4657b44db67b9753b1bf8b93b760699bf2f3d9c8 )
+)
+
+game (
+	name "Caduceus - New Blood (Japan)"
+	description "Caduceus - New Blood (Japan)"
+	rom ( name "Caduceus - New Blood (Japan).iso" size 4699979776 crc b61629ce md5 da0e25f9e0889418f26fff917cb820ac sha1 36701c28f23f5b71b52a9188e05490fa1fce5a73 )
+)
+
+game (
+	name "Caduceus Z - Futatsu no Chou Shittou (Japan)"
+	description "Caduceus Z - Futatsu no Chou Shittou (Japan)"
+	rom ( name "Caduceus Z - Futatsu no Chou Shittou (Japan).iso" size 4699979776 crc 5086c049 md5 917c60d73fcc9d77348a37a3c6244c91 sha1 37bfd9c1d4f11996053bb1f29493b4861ca88fee )
+)
+
+game (
+	name "Call of Duty - Black Ops (Europe)"
+	description "Call of Duty - Black Ops (Europe)"
+	rom ( name "Call of Duty - Black Ops (Europe).iso" size 4699979776 crc 0fc116cc md5 f52815b24a926c48e050ccc09627406e sha1 79a18297b0ca8ea6fb6238f16071c46ab37b2197 )
+)
+
+game (
+	name "Call of Duty - Black Ops (Spain)"
+	description "Call of Duty - Black Ops (Spain)"
+	rom ( name "Call of Duty - Black Ops (Spain).iso" size 4699979776 crc 9b5c5b6b md5 c2ba307b7a1506464da7d7cd21d8f191 sha1 d02fde81aca5aa5037e2d8a7148e9f9adf0d328c )
+)
+
+game (
+	name "Call of Duty - Modern Warfare - Reflex (Europe) (Es,It)"
+	description "Call of Duty - Modern Warfare - Reflex (Europe) (Es,It)"
+	rom ( name "Call of Duty - Modern Warfare - Reflex (Europe) (Es,It).iso" size 4699979776 crc 1fa44c79 md5 fd22bfe0ea9f7b089fc31d7c8f43c7bc sha1 aceceeab4e979a289ba29fc894825c42bb6feafd )
+)
+
+game (
+	name "Call of Duty - Modern Warfare - Reflex (USA)"
+	description "Call of Duty - Modern Warfare - Reflex (USA)"
+	rom ( name "Call of Duty - Modern Warfare - Reflex (USA).iso" size 4699979776 crc 94857937 md5 c6b0070d87cff24b81ee2c01c3283c18 sha1 983444e5fc7c494073780828b6552b7e1babb472 )
+)
+
+game (
+	name "Call of Duty - World at War (Europe) (En,Fr)"
+	description "Call of Duty - World at War (Europe) (En,Fr)"
+	rom ( name "Call of Duty - World at War (Europe) (En,Fr).iso" size 4699979776 crc a974a563 md5 1a5b360240ced4de2b5078b3a3a8cace sha1 c5c81d9b50b8bda02d5af68bb3af1e34830c637d )
+)
+
+game (
+	name "Call of Duty - World at War (Europe) (Es,It)"
+	description "Call of Duty - World at War (Europe) (Es,It)"
+	rom ( name "Call of Duty - World at War (Europe) (Es,It).iso" size 4699979776 crc 1aa2a0bc md5 c5dfbaf92d31bc95ff12af5df8c6362c sha1 f9b76c78cbb5eb31095c99776d15159a5996d540 )
+)
+
+game (
+	name "Call of Duty - World at War (USA)"
+	description "Call of Duty - World at War (USA)"
+	rom ( name "Call of Duty - World at War (USA).iso" size 4699979776 crc 1fb5fa99 md5 62e9b3bb03d91471fbad890244172843 sha1 0fa4cab1e42f9c5b6ea743c758898ff3ba30210b )
+)
+
+game (
+	name "Call of Duty 3 (Europe)"
+	description "Call of Duty 3 (Europe)"
+	rom ( name "Call of Duty 3 (Europe).iso" size 4699979776 crc dd1365c4 md5 9ff892a81c0655fd787ec89e464c3375 sha1 b02db9ff59da3c66040c749cff0a4809ba149778 )
+)
+
+game (
+	name "Call of Duty 3 (Europe) (Fr,Es,It)"
+	description "Call of Duty 3 (Europe) (Fr,Es,It)"
+	rom ( name "Call of Duty 3 (Europe) (Fr,Es,It).iso" size 4699979776 crc a5fcf04a md5 084cd45ad400571832e34327e8824c3e sha1 ff79cba8bbaf15164052b90ef69e01a0716dc23f )
+)
+
+game (
+	name "Call of Duty 3 (Germany)"
+	description "Call of Duty 3 (Germany)"
+	rom ( name "Call of Duty 3 (Germany).iso" size 4699979776 crc 95fa3751 md5 d62cb97233a238f5b5ed84b9e180b304 sha1 0064267a91b93fb2317f327af18a1c94b46747ec )
+)
+
+game (
+	name "Call of Duty 3 (USA)"
+	description "Call of Duty 3 (USA)"
+	rom ( name "Call of Duty 3 (USA).iso" size 4699979776 crc f9b88f4d md5 c674ee750f5217f1ddcb98e6404f7088 sha1 bc72b9d2f36912e9f73167cd6f03a96d41fa2357 )
+)
+
+game (
+	name "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It)"
+	description "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fc5e7494 md5 40bc90b7ba88a1c852823bd5bc6d7089 sha1 824973f53fe723ee5743c0df2e4d9b04b6edac26 )
+)
+
+game (
+	name "Captain Rainbow (Japan)"
+	description "Captain Rainbow (Japan)"
+	rom ( name "Captain Rainbow (Japan).iso" size 4699979776 crc 99fad2c9 md5 5334ea85ed04b1cacb6c85fc8267d38d sha1 022ed16eb9ffdef6cb6cfbe3933dfd56b15b5dcd )
+)
+
+game (
+	name "Carnival Funfair Games (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Carnival Funfair Games (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Carnival Funfair Games (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc db297a70 md5 de5894361e375edb3abc6224cbaf595a sha1 f525ab56dc54878748c934c3c426f520ed52389f )
+)
+
+game (
+	name "Carnival Games - MiniGolf (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Carnival Games - MiniGolf (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Carnival Games - MiniGolf (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc c9c09ff8 md5 78d9665e5cad95be3d79548471a61d49 sha1 f2a99c91853a2dee33bfc8a16a359b7dc3bb7a23 )
+)
+
+game (
+	name "Carnival Games - MiniGolf (USA) (En,Fr,Es)"
+	description "Carnival Games - MiniGolf (USA) (En,Fr,Es)"
+	rom ( name "Carnival Games - MiniGolf (USA) (En,Fr,Es).iso" size 4699979776 crc b809a7b1 md5 568597225a37f8604b40cffd6cb15a16 sha1 e541cadcc5954b606e443017c5f93f2ce3324a60 )
+)
+
+game (
+	name "Carnival Games (USA)"
+	description "Carnival Games (USA)"
+	rom ( name "Carnival Games (USA).iso" size 4699979776 crc b5ad3c0d md5 82bef1c81ef6534dcbb7b7ce86664ea5 sha1 bc3112b62e7bd3e63f1983fb3b437e334ec69366 )
+)
+
+game (
+	name "Cartoon Network - Punch Time Explosion XL (USA)"
+	description "Cartoon Network - Punch Time Explosion XL (USA)"
+	rom ( name "Cartoon Network - Punch Time Explosion XL (USA).iso" size 4699979776 crc ee64838b md5 e7063f9f3715c61affe1bda87ed19c5a sha1 7b2d335bf613bc927c028e559d0641395537934d )
+)
+
+game (
+	name "Castle of Shikigami III (USA)"
+	description "Castle of Shikigami III (USA)"
+	rom ( name "Castle of Shikigami III (USA).iso" size 4699979776 crc 3e1f4e0b md5 5364458bd724bf36274e05a98497ccd0 sha1 037bd3c900240c48f4b998bb4e7796816c190a01 )
+)
+
+game (
+	name "Castlevania Judgment (Europe) (En,Fr,De,Es,It)"
+	description "Castlevania Judgment (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Castlevania Judgment (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 40857c4c md5 4b1aa6ad15247671c15e996356e0ecee sha1 a5d94c2ca474424fa7f281fb66a14688b9d2686d )
+)
+
+game (
+	name "Castlevania Judgment (USA)"
+	description "Castlevania Judgment (USA)"
+	rom ( name "Castlevania Judgment (USA).iso" size 4699979776 crc b93695a9 md5 62ee1575ac6caf3e040115266cf67a8d sha1 0843870e38c794a09173efd32634be17101ee3b9 )
+)
+
+game (
+	name "Chaotic - Shadow Warriors (USA) (En,Fr)"
+	description "Chaotic - Shadow Warriors (USA) (En,Fr)"
+	rom ( name "Chaotic - Shadow Warriors (USA) (En,Fr).iso" size 4699979776 crc 7906a620 md5 48b0c898c382cc8d484f656cf613b96a sha1 3a86306553940ba7ccd9c70ae023cdc269d04fce )
+)
+
+game (
+	name "Cheoeum Mannaneun Wii (Korea)"
+	description "Cheoeum Mannaneun Wii (Korea)"
+	rom ( name "Cheoeum Mannaneun Wii (Korea).iso" size 4699979776 crc 7de3f3e2 md5 d6c68652d9c77604cc12361656ff0882 sha1 6edca414fbfc6ec6784c2359ddff3787fe5c72e7 )
+)
+
+game (
+	name "Chicken Blaster (Europe) (En,Fr,De,Es,It)"
+	description "Chicken Blaster (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Chicken Blaster (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1c2e0c9e md5 2688ffaa8fd61d6c6f311ee3283a4112 sha1 58f583262b0906ac3f951a2fb57f80f703b2d86f )
+)
+
+game (
+	name "Chocobo no Fushigi na Dungeon - Toki-wasure no Meikyuu (Japan)"
+	description "Chocobo no Fushigi na Dungeon - Toki-wasure no Meikyuu (Japan)"
+	rom ( name "Chocobo no Fushigi na Dungeon - Toki-wasure no Meikyuu (Japan).iso" size 4699979776 crc 498bf8d5 md5 b03ec47d5434dd5dd6d8a79fe54fc866 sha1 cdefaf29a097f7245025bc36186dcbb0acac6dae )
+)
+
+game (
+	name "Chronicles of Narnia, The - Prince Caspian (Europe)"
+	description "Chronicles of Narnia, The - Prince Caspian (Europe)"
+	rom ( name "Chronicles of Narnia, The - Prince Caspian (Europe).iso" size 4699979776 crc fc9fa0b3 md5 37d618bf2006b7d34ff170adaddfe500 sha1 a1565872e2346f8e26660f608012dcb65bad2b58 )
+)
+
+game (
+	name "Chronicles of Narnia, The - Prince Caspian (Europe) (De,It)"
+	description "Chronicles of Narnia, The - Prince Caspian (Europe) (De,It)"
+	rom ( name "Chronicles of Narnia, The - Prince Caspian (Europe) (De,It).iso" size 4699979776 crc afb6c651 md5 ead691bb61beadba4003a7f24914614b sha1 0ebc466a2e5fc461b98447db16199fbe88788c69 )
+)
+
+game (
+	name "Chronicles of Narnia, The - Prince Caspian (USA)"
+	description "Chronicles of Narnia, The - Prince Caspian (USA)"
+	rom ( name "Chronicles of Narnia, The - Prince Caspian (USA).iso" size 4699979776 crc e302b317 md5 8567b56a77daab8606f9fa0fe62b4b50 sha1 be694ec96803382accab75823d31a1cc803c9a54 )
+)
+
+game (
+	name "CID the Dummy (Europe) (En,Fr,De,Es,It)"
+	description "CID the Dummy (Europe) (En,Fr,De,Es,It)"
+	rom ( name "CID the Dummy (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 135d433c md5 a7259ca79a9e492b401faf15d4d9adaa sha1 5b3eca90e20e12fb3e3b11a8eb4828ef19f73449 )
+)
+
+game (
+	name "Cloudy with a Chance of Meatballs (USA) (En,Fr,Es)"
+	description "Cloudy with a Chance of Meatballs (USA) (En,Fr,Es)"
+	rom ( name "Cloudy with a Chance of Meatballs (USA) (En,Fr,Es).iso" size 4699979776 crc 669ba6e1 md5 5d95979c201475a4b3fa8acd21d0bc9e sha1 02d54d0c011fbbd1324924374cba0381f4998f8b )
+)
+
+game (
+	name "Conduit 2 (USA) (En,Fr,Es)"
+	description "Conduit 2 (USA) (En,Fr,Es)"
+	rom ( name "Conduit 2 (USA) (En,Fr,Es).iso" size 4699979776 crc e346af15 md5 d1b748ec63b60f3787046c3979d02372 sha1 027a314d591e7fc68e80c7522e8afdb7f3b4e2d3 )
+)
+
+game (
+	name "Conduit, The (Europe) (En,Fr,De,Es,It)"
+	description "Conduit, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Conduit, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc acf43a74 md5 f634e02cd78096459411182b66207f8f sha1 4243b17e94438fb45eb3a940ee5b5b444cc96c8d )
+)
+
+game (
+	name "Conduit, The (USA) (En,Fr,Es)"
+	description "Conduit, The (USA) (En,Fr,Es)"
+	rom ( name "Conduit, The (USA) (En,Fr,Es).iso" size 4699979776 crc 5b1d3809 md5 618c877e6f4087e5b5e1a1deca1a0507 sha1 d557b7123dc6e58f1f1ec9de164fb6b70a2440a7 )
+)
+
+game (
+	name "Cooking Mama - Cook Off (USA)"
+	description "Cooking Mama - Cook Off (USA)"
+	rom ( name "Cooking Mama - Cook Off (USA).iso" size 4699979776 crc 6e371e61 md5 425e07c59d25288afb37d00d781561ce sha1 18d54ec5b8fe9d73cea81dc056130e2568136861 )
+)
+
+game (
+	name "Cooking Mama - World Kitchen (USA)"
+	description "Cooking Mama - World Kitchen (USA)"
+	rom ( name "Cooking Mama - World Kitchen (USA).iso" size 4699979776 crc 8f533a17 md5 27e784afb195ffe86708c0f156d8e434 sha1 a20d46df0cf6aef6dcb6b1858f3feb2efafee77a )
+)
+
+game (
+	name "Cooking Party (Europe) (En,Fr,De,Es,It)"
+	description "Cooking Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Cooking Party (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 78e47fc2 md5 23b9b1a3be9ce0dd83be5bab60705275 sha1 975416ede0ad6c845a1df08684bb5a33abd1101a )
+)
+
+game (
+	name "Coraline (USA) (En,Fr,Es)"
+	description "Coraline (USA) (En,Fr,Es)"
+	rom ( name "Coraline (USA) (En,Fr,Es).iso" size 4699979776 crc 4d22bc5a md5 89095f684c98a81a41750f60112906a0 sha1 476c16a3f741001a08b2eb33edeb6f02c2e5f061 )
+)
+
+game (
+	name "Counter Force (USA)"
+	description "Counter Force (USA)"
+	rom ( name "Counter Force (USA).iso" size 4699979776 crc b0dee9a6 md5 a22f3e2cea28f79ddbd27afd2fff748e sha1 f9108f9c519d49d0e87caa9448ca2dd927e04e6b )
+)
+
+game (
+	name "Cranium Kabookii (Europe) (En,Fr,De,Es,It)"
+	description "Cranium Kabookii (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Cranium Kabookii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c0314d4d md5 4a0fd08c9e83fe7bf0d6681ac1cd7e21 sha1 6a2799b1620a1b589c362f7e7c84a68f9fa2f6e8 )
+)
+
+game (
+	name "Crash - Mind over Mutant (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Crash - Mind over Mutant (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Crash - Mind over Mutant (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc ba0b88bb md5 615700adab56284d98e16d71773b3431 sha1 10b88dcd84fe5676f99f5465336e9225922dec8e )
+)
+
+game (
+	name "Crash - Mind over Mutant (USA) (En,Fr)"
+	description "Crash - Mind over Mutant (USA) (En,Fr)"
+	rom ( name "Crash - Mind over Mutant (USA) (En,Fr).iso" size 4699979776 crc ef37d3c4 md5 95c170f51dbfc394321f038fc6a27695 sha1 6f9ef9c6abdca4e9f43fa5dbe4bdf3360176b968 )
+)
+
+game (
+	name "Crash of the Titans (Europe) (En,Sv,No,Da,Fi)"
+	description "Crash of the Titans (Europe) (En,Sv,No,Da,Fi)"
+	rom ( name "Crash of the Titans (Europe) (En,Sv,No,Da,Fi).iso" size 4699979776 crc 9ecd7c38 md5 1bcd3a96b35ee0df45ec3373df41b0a0 sha1 378a9e6b41512e0706c460ddd8fa1105e8c42ab6 )
+)
+
+game (
+	name "Crash of the Titans (USA)"
+	description "Crash of the Titans (USA)"
+	rom ( name "Crash of the Titans (USA).iso" size 4699979776 crc e39282e1 md5 81f6784d95a4e9ff01818e79464b690b sha1 705697e6a8c2f254af726eb5349d90010a88c654 )
+)
+
+game (
+	name "Cruis'n (USA) (En,Fr,Es)"
+	description "Cruis'n (USA) (En,Fr,Es)"
+	rom ( name "Cruis'n (USA) (En,Fr,Es).iso" size 4699979776 crc 98f95a47 md5 7a8b3a4a08b5d0f3916162cd3c8eace1 sha1 ebb9822126d35362ab15407ccf2a54bd5209b6fd )
+)
+
+game (
+	name "Cruise Ship Vacation Games (USA)"
+	description "Cruise Ship Vacation Games (USA)"
+	rom ( name "Cruise Ship Vacation Games (USA).iso" size 4699979776 crc f211cd39 md5 900217748f41b1edb2f22cf35c2f4552 sha1 dc9b774707b0c7fe1eec9918aa5f68abdc442ce1 )
+)
+
+game (
+	name "CSI - Crime Scene Investigation - Hard Evidence (Europe)"
+	description "CSI - Crime Scene Investigation - Hard Evidence (Europe)"
+	rom ( name "CSI - Crime Scene Investigation - Hard Evidence (Europe).iso" size 4699979776 crc d663dc3b md5 7794b556f3fadff8be6fcdde4128dc78 sha1 964411f08356e9f8b045236d5b819967e30ecfe2 )
+)
+
+game (
+	name "CSI - Crime Scene Investigation - Hard Evidence (USA) (En,Fr,Es)"
+	description "CSI - Crime Scene Investigation - Hard Evidence (USA) (En,Fr,Es)"
+	rom ( name "CSI - Crime Scene Investigation - Hard Evidence (USA) (En,Fr,Es).iso" size 4699979776 crc 2aea9784 md5 43e2abbd083ef68b530cd6c2f7446b7f sha1 83b2098d68338bc0f51643d513961af6a9e35dfa )
+)
+
+game (
+	name "Cursed Mountain (Europe)"
+	description "Cursed Mountain (Europe)"
+	rom ( name "Cursed Mountain (Europe).iso" size 4699979776 crc ec4146e1 md5 36a204c54e923bbc4696a129028e146e sha1 c62ab5142872bf56c9827ef6dd86bf371e74ea20 )
+)
+
+game (
+	name "Dance Dance Revolution - Hottest Party 3 (USA)"
+	description "Dance Dance Revolution - Hottest Party 3 (USA)"
+	rom ( name "Dance Dance Revolution - Hottest Party 3 (USA).iso" size 4699979776 crc 8138c74a md5 8fbbb7c068f97362863aafc8eaffa96b sha1 b9b583d06cef1fcec3f2537cdc3601f653ec3f2f )
+)
+
+game (
+	name "Dance Dance Revolution - Winx Club (Europe) (En,Fr,De,Es,It)"
+	description "Dance Dance Revolution - Winx Club (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dance Dance Revolution - Winx Club (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f3012788 md5 6e55bc6670748f29ffb24c3e86a1d18e sha1 9600f402b5e82a878353ee24becd2c25f95d0da8 )
+)
+
+game (
+	name "Dance on Broadway (Europe) (En,Fr,De,Es,It)"
+	description "Dance on Broadway (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dance on Broadway (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0998e671 md5 5064ee7d334d094a17124f546363a8c6 sha1 88912c1a73399e2ca76453fb8902456fa4fc0baf )
+)
+
+game (
+	name "Dancing with the Stars - Get Your Dance On! (USA)"
+	description "Dancing with the Stars - Get Your Dance On! (USA)"
+	rom ( name "Dancing with the Stars - Get Your Dance On! (USA).iso" size 4699979776 crc faf3b013 md5 fa33475831967854d3a7470996b19dbb sha1 f13996e427bca215373e3c8e5285733a268d7f4f )
+)
+
+game (
+	name "Data East Arcade Classics (USA)"
+	description "Data East Arcade Classics (USA)"
+	rom ( name "Data East Arcade Classics (USA).iso" size 4699979776 crc 5daee9cd md5 29c372a8e016d2950ad54c82697a9d34 sha1 783715bfe466c755a3323e7bcc0aaf204465e8a4 )
+)
+
+game (
+	name "de Blob (Europe) (En,Fr,De,Es,It,Nl)"
+	description "de Blob (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "de Blob (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 5dd6158a md5 452ce2da35ebb60263f0ebcf307ac152 sha1 18ce11d418457ae0c9722b4ca0566ce4f0513674 )
+)
+
+game (
+	name "de Blob (USA) (En,Fr,Es)"
+	description "de Blob (USA) (En,Fr,Es)"
+	rom ( name "de Blob (USA) (En,Fr,Es).iso" size 4699979776 crc 3cbe5131 md5 0a76fc53d7f4568fd3d00f7157ed8cd2 sha1 8de864abedd70440d318b7aea8ce6f5e0c4055c8 )
+)
+
+game (
+	name "de Blob 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "de Blob 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "de Blob 2 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 353af7b0 md5 6bcc1b3c43ad431ee70b4d6c73fa9cb8 sha1 15e0f5ef1e98bd7de6bd38d26b006d7d6d420ff9 )
+)
+
+game (
+	name "de Blob 2 (USA) (En,Fr)"
+	description "de Blob 2 (USA) (En,Fr)"
+	rom ( name "de Blob 2 (USA) (En,Fr).iso" size 4699979776 crc 91a0a381 md5 0b3d75d7a23087213accde8aab94f3fc sha1 34ab383604c57fd8150a106ae16fb34fcace5a05 )
+)
+
+game (
+	name "Dead Rising - Chop Till You Drop (Europe) (En,Fr,De,Es,It)"
+	description "Dead Rising - Chop Till You Drop (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dead Rising - Chop Till You Drop (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7b850fe2 md5 b22990d632e8a301764318ddfd52bb55 sha1 d7c94d153e2cf0695037099089e562cb7a7d63ed )
+)
+
+game (
+	name "Dead Rising - Chop Till You Drop (USA) (En,Fr,Es)"
+	description "Dead Rising - Chop Till You Drop (USA) (En,Fr,Es)"
+	rom ( name "Dead Rising - Chop Till You Drop (USA) (En,Fr,Es).iso" size 4699979776 crc ce7386a8 md5 05c340b91cdc9073073862666bf20a8e sha1 05ceb5be48be70466611e007e65c7bfa2bd2d2ec )
+)
+
+game (
+	name "Dead Space - Extraction (Europe) (En,Fr,De,It)"
+	description "Dead Space - Extraction (Europe) (En,Fr,De,It)"
+	rom ( name "Dead Space - Extraction (Europe) (En,Fr,De,It).iso" size 4699979776 crc 0ef06f46 md5 aebb783f7b1fd3ff6db8feaa103dd338 sha1 57433eb4572fa8a6008154d82f9ba450854c60bc )
+)
+
+game (
+	name "Dead Space - Extraction (USA) (En,Fr)"
+	description "Dead Space - Extraction (USA) (En,Fr)"
+	rom ( name "Dead Space - Extraction (USA) (En,Fr).iso" size 4699979776 crc f8e52bd6 md5 7e67420e8754a42205d5bb1ecf87cd55 sha1 762ee876d50ff916b873d87f08755231ae47338a )
+)
+
+game (
+	name "Deadly Creatures (Europe) (En,Fr,De,Es,It)"
+	description "Deadly Creatures (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Deadly Creatures (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ef10df95 md5 58e7f555c268b49f28d6d7d453febd0b sha1 5fa61e9e93af8a695b2dffb9b46ff5e8bb9dff35 )
+)
+
+game (
+	name "Deadly Creatures (USA) (En,Fr,Es)"
+	description "Deadly Creatures (USA) (En,Fr,Es)"
+	rom ( name "Deadly Creatures (USA) (En,Fr,Es).iso" size 4699979776 crc d48e7d17 md5 ccbf7b6f01eea7a7950db9617676c05e sha1 c75f7b0f0ba13626ddab9412e2b6bb71ea4b584e )
+)
+
+game (
+	name "Deal or No Deal (USA)"
+	description "Deal or No Deal (USA)"
+	rom ( name "Deal or No Deal (USA).iso" size 4699979776 crc 6d459a08 md5 0751202ebe06a0b1519f68d1700afc2a sha1 73f5c30eeb81b95e3b7ec24ccdc2b02d55f4d3df )
+)
+
+game (
+	name "Deca Sports (USA)"
+	description "Deca Sports (USA)"
+	rom ( name "Deca Sports (USA).iso" size 4699979776 crc b27f913f md5 de343945288afc4daf7b6317616a7bf5 sha1 c53fe2b25a03874c72f71a10415d746493a3cc1e )
+)
+
+game (
+	name "Deca Sports 2 (USA) (En,Fr,Es)"
+	description "Deca Sports 2 (USA) (En,Fr,Es)"
+	rom ( name "Deca Sports 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 7205d2b1 md5 010b33456cd6f894c2464227e5f110b2 sha1 bf4bb79c24b8dc8c570534d84005e8171c8b0a8e )
+)
+
+game (
+	name "Deepak Chopra's Leela (USA) (En,Fr)"
+	description "Deepak Chopra's Leela (USA) (En,Fr)"
+	rom ( name "Deepak Chopra's Leela (USA) (En,Fr).iso" size 4699979776 crc 4238d078 md5 53502abef921b96d5a49e2f461c2d774 sha1 cd2e6df5e827f2a240de3e28c8fc3ac47bcc2b53 )
+)
+
+game (
+	name "Deer Drive (USA)"
+	description "Deer Drive (USA)"
+	rom ( name "Deer Drive (USA).iso" size 4699979776 crc 5c016368 md5 b8572ab082bd830d3c6f492fcd609c9b sha1 68c1e0543ff76f6cae4a2b577b635ac64124cd78 )
+)
+
+game (
+	name "Destroy All Humans! Big Willy Unleashed (USA) (En,Fr)"
+	description "Destroy All Humans! Big Willy Unleashed (USA) (En,Fr)"
+	rom ( name "Destroy All Humans! Big Willy Unleashed (USA) (En,Fr).iso" size 4699979776 crc 84c7a661 md5 8420577137d2e9dc2d8f2d656377c00c sha1 fc3f284c652220e146c68cd729f09b93a447746d )
+)
+
+game (
+	name "Dewy's Adventure (USA)"
+	description "Dewy's Adventure (USA)"
+	rom ( name "Dewy's Adventure (USA).iso" size 4699979776 crc 724a3267 md5 a12d091fe7aeff10a984fee261023343 sha1 a42636f420ba08bdfc50b5da62cc06f6e13947ce )
+)
+
+game (
+	name "DiRT 2 (USA) (En,Fr,Es)"
+	description "DiRT 2 (USA) (En,Fr,Es)"
+	rom ( name "DiRT 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 9c8484ed md5 8fceb3af8168e7be451e0e75014349c3 sha1 f05b51d26b5834307ad859ddc5ec684d30d8b4c8 )
+)
+
+game (
+	name "Disaster - Day of Crisis (Europe) (En,Fr,De,Es,It)"
+	description "Disaster - Day of Crisis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disaster - Day of Crisis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc aa406f9e md5 729d8b13498dd0556d7423e49457a75a sha1 f933471681936beb06391ab2ef9488c52df1fba2 )
+)
+
+game (
+	name "Disney Epic Mickey (Europe) (De,Es,It)"
+	description "Disney Epic Mickey (Europe) (De,Es,It)"
+	rom ( name "Disney Epic Mickey (Europe) (De,Es,It).iso" size 4699979776 crc 6167eb78 md5 b748dc7941da7952962b41e4cac2f35e sha1 58664de577933d7905d3a67340e02e9d48cea1d1 )
+)
+
+game (
+	name "Disney Epic Mickey (Europe) (En,Fr,Nl)"
+	description "Disney Epic Mickey (Europe) (En,Fr,Nl)"
+	rom ( name "Disney Epic Mickey (Europe) (En,Fr,Nl).iso" size 4699979776 crc a5ad65f8 md5 38899b09a20e46410cc67c150eb3abf8 sha1 7265ae5d517abaa87b665dba5dc2ad9a0f6f4b39 )
+)
+
+game (
+	name "Disney Epic Mickey (USA) (En,Fr,Es)"
+	description "Disney Epic Mickey (USA) (En,Fr,Es)"
+	rom ( name "Disney Epic Mickey (USA) (En,Fr,Es).iso" size 4699979776 crc 1c44c614 md5 4e91f88eab7b48ee7ec98c70930d8a94 sha1 439f34445f7cd0c4e5dd2697902b75edef5fdc28 )
+)
+
+game (
+	name "Disney Epic Mickey 2 - The Power of Two (USA)"
+	description "Disney Epic Mickey 2 - The Power of Two (USA)"
+	rom ( name "Disney Epic Mickey 2 - The Power of Two (USA).iso" size 4699979776 crc 55509501 md5 4df38d3d74f2db971470ac708e80091a sha1 abd5e464fbc6b28e124fade89b495dab1df123b8 )
+)
+
+game (
+	name "Disney G-Force (Europe) (En,Fr,Es,Nl)"
+	description "Disney G-Force (Europe) (En,Fr,Es,Nl)"
+	rom ( name "Disney G-Force (Europe) (En,Fr,Es,Nl).iso" size 4699979776 crc c0fcd211 md5 12811f06cfd63f69271ad6fa579a48b7 sha1 c6ad668e6d5547c1eaf71475b9798f2c343e7d03 )
+)
+
+game (
+	name "Disney Guilty Party - Mystery Fun for Everyone! (USA)"
+	description "Disney Guilty Party - Mystery Fun for Everyone! (USA)"
+	rom ( name "Disney Guilty Party - Mystery Fun for Everyone! (USA).iso" size 4699979776 crc 4c4d4de4 md5 ae8e2f0254a4bf6022c0ea923a0eb7fb sha1 713c226718c83675d2034d03976be0b61ccc1b0c )
+)
+
+game (
+	name "Disney Hannah Montana - Spotlight World Tour (Europe) (En,De,Es)"
+	description "Disney Hannah Montana - Spotlight World Tour (Europe) (En,De,Es)"
+	rom ( name "Disney Hannah Montana - Spotlight World Tour (Europe) (En,De,Es).iso" size 4699979776 crc be06063b md5 beeead9422e02742336cb340260871eb sha1 566d5e906b942cf44424f5ab04839a310fe33bf3 )
+)
+
+game (
+	name "Disney Hannah Montana - Spotlight World Tour (USA)"
+	description "Disney Hannah Montana - Spotlight World Tour (USA)"
+	rom ( name "Disney Hannah Montana - Spotlight World Tour (USA).iso" size 4699979776 crc 7c0a4c41 md5 107e16f57b2e9f2e42856faad1d52876 sha1 ba2a57be7ee0fb982a14e76fe2379f1eedb444ea )
+)
+
+game (
+	name "Disney High School Musical - Sing It! (Europe) (En,Fr,De,Es,It)"
+	description "Disney High School Musical - Sing It! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney High School Musical - Sing It! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ba194fc6 md5 157858678781d1cb65f5649ca20355cf sha1 2f0bad7724e9b0097ed6ef875957b6c549194888 )
+)
+
+game (
+	name "Disney Phineas and Ferb - Across the 2nd Dimension (USA)"
+	description "Disney Phineas and Ferb - Across the 2nd Dimension (USA)"
+	rom ( name "Disney Phineas and Ferb - Across the 2nd Dimension (USA).iso" size 4699979776 crc d3d009f5 md5 8b4d3b57768bb95f0c78d68344d57f36 sha1 4a4a517ecd0dd052d406e812e820dab21d26cbf2 )
+)
+
+game (
+	name "Disney Pirates of the Caribbean - At World's End (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Disney Pirates of the Caribbean - At World's End (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Disney Pirates of the Caribbean - At World's End (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 12d862d8 md5 03dc8aabdbc55851a2e4ca1b9b83a361 sha1 eb999b268f99978d982c77f8a16985f60452a057 )
+)
+
+game (
+	name "Disney Pirates of the Caribbean - At World's End (USA) (v1.00)"
+	description "Disney Pirates of the Caribbean - At World's End (USA) (v1.00)"
+	rom ( name "Disney Pirates of the Caribbean - At World's End (USA) (v1.00).iso" size 4699979776 crc 6034c410 md5 edc6eac7622851081d566b23a152a5f0 sha1 18650e205a1d4216d9ed32e01905ff76ff7691a8 )
+)
+
+game (
+	name "Disney Pirates of the Caribbean - At World's End (USA) (v1.01)"
+	description "Disney Pirates of the Caribbean - At World's End (USA) (v1.01)"
+	rom ( name "Disney Pirates of the Caribbean - At World's End (USA) (v1.01).iso" size 4699979776 crc ef8dcfa6 md5 8f80026f453240085a3eceae501afeb3 sha1 056a5fc3c4b2282fa60d291b161e39604b4375be )
+)
+
+game (
+	name "Disney Sing It - High School Musical 3 - Senior Year (Europe) (En,Fr,De,Es,It)"
+	description "Disney Sing It - High School Musical 3 - Senior Year (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Disney Sing It - High School Musical 3 - Senior Year (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 388b40c0 md5 9654499bb05cabc9acf77a6aadba832a sha1 cb18ce491d301167b17a8c738044cdf029b74874 )
+)
+
+game (
+	name "Disney Sing It - Party Hits (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Disney Sing It - Party Hits (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Disney Sing It - Party Hits (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 3ff45da6 md5 2b6f18556aa917a2bd89f2f8ed10e3a2 sha1 4e4d2725d848f3b207daeb3f79108a1731c98254 )
+)
+
+game (
+	name "Disney The Princess and the Frog (USA)"
+	description "Disney The Princess and the Frog (USA)"
+	rom ( name "Disney The Princess and the Frog (USA).iso" size 4699979776 crc 26d53983 md5 8e51a70b28e060bde2b9389df81319f3 sha1 a4f537136885196fc13faaae408d20b85af31f8d )
+)
+
+game (
+	name "Disney The Princess and the Frog (USA) (En,Fr,Es)"
+	description "Disney The Princess and the Frog (USA) (En,Fr,Es)"
+	rom ( name "Disney The Princess and the Frog (USA) (En,Fr,Es).iso" size 4699979776 crc a0828426 md5 e5e993560e8838bdf1e323567ffbd43e sha1 1bed622ab09c4e811b1524b22dc3727eb34ebc47 )
+)
+
+game (
+	name "Disney Think Fast (USA)"
+	description "Disney Think Fast (USA)"
+	rom ( name "Disney Think Fast (USA).iso" size 4699979776 crc 2915f451 md5 ef8e6f4e439ac0578aa26b7c34a3ed67 sha1 997e25ff49ab707d6130ee6ef21bb9f7405afc36 )
+)
+
+game (
+	name "Disney Universe (USA) (En,Fr,Es)"
+	description "Disney Universe (USA) (En,Fr,Es)"
+	rom ( name "Disney Universe (USA) (En,Fr,Es).iso" size 4699979776 crc fd41f1c8 md5 004722f3290c25b57b67118db4cc7c91 sha1 74d74753b15d8ef228d3ddef3ea7f5ebd880a88b )
+)
+
+game (
+	name "Disney Wreck-It Ralph (USA) (En,Fr)"
+	description "Disney Wreck-It Ralph (USA) (En,Fr)"
+	rom ( name "Disney Wreck-It Ralph (USA) (En,Fr).iso" size 4699979776 crc f7820313 md5 4b9272aa0872107739ec7e852129aaa0 sha1 f5bd4c8425b9974b64aa4f5110be844a5402bf88 )
+)
+
+game (
+	name "Disney-Pixar Cars - Mater-National Championship (USA) (En,Es)"
+	description "Disney-Pixar Cars - Mater-National Championship (USA) (En,Es)"
+	rom ( name "Disney-Pixar Cars - Mater-National Championship (USA) (En,Es).iso" size 4699979776 crc 60b79c84 md5 1cd5061abc5a42e1761e0c658850329a sha1 b418297c62698ce96d347614dfaa0fef0003f4b3 )
+)
+
+game (
+	name "Disney-Pixar Cars - Race-O-Rama (USA) (En,Fr)"
+	description "Disney-Pixar Cars - Race-O-Rama (USA) (En,Fr)"
+	rom ( name "Disney-Pixar Cars - Race-O-Rama (USA) (En,Fr).iso" size 4699979776 crc f9d1b981 md5 549974498ee04b1a90d22a629eb0a4e6 sha1 7c5b23fa9d0f7143422ee73f8fa93e11cb96e5e9 )
+)
+
+game (
+	name "Disney-Pixar Cars (USA) (En,Es)"
+	description "Disney-Pixar Cars (USA) (En,Es)"
+	rom ( name "Disney-Pixar Cars (USA) (En,Es).iso" size 4699979776 crc 9240fe27 md5 f0f57036d75cbd6b132e55fa4796eb1a sha1 b2f460a651839c62e2bef0a02fdf29595dd174f5 )
+)
+
+game (
+	name "Disney-Pixar Cars 2 (USA)"
+	description "Disney-Pixar Cars 2 (USA)"
+	rom ( name "Disney-Pixar Cars 2 (USA).iso" size 4699979776 crc a2f5f37f md5 ce037db9f2868de8ab5f5d49377fea91 sha1 f519eaf1b61d95173a8422c7d43a37137df5c7c3 )
+)
+
+game (
+	name "Disney-Pixar Ratatouille (USA)"
+	description "Disney-Pixar Ratatouille (USA)"
+	rom ( name "Disney-Pixar Ratatouille (USA).iso" size 4699979776 crc 77796b8e md5 dd43c13d2f7ba81eb19ff2ba8b94564a sha1 d529f31c4fad79bdb73c0d02995c85c2c089998c )
+)
+
+game (
+	name "Disney-Pixar Toy Story 3 (Europe)"
+	description "Disney-Pixar Toy Story 3 (Europe)"
+	rom ( name "Disney-Pixar Toy Story 3 (Europe).iso" size 4699979776 crc deb7783a md5 dad93c156213c233101dabe5e23a0468 sha1 e70e97560107068ad5e1d844a7bd7a54ee19cacb )
+)
+
+game (
+	name "Disney-Pixar Toy Story Mania! (Europe) (En,Fr,De,It,Nl)"
+	description "Disney-Pixar Toy Story Mania! (Europe) (En,Fr,De,It,Nl)"
+	rom ( name "Disney-Pixar Toy Story Mania! (Europe) (En,Fr,De,It,Nl).iso" size 4699979776 crc 90b9c313 md5 def6ce8651f63bbb46981a4151cd30ca sha1 54d24cded78f364c5e38f1ea82885cafa2af9ed3 )
+)
+
+game (
+	name "Disney-Pixar Toy Story Mania! (USA) (En,Fr,Es)"
+	description "Disney-Pixar Toy Story Mania! (USA) (En,Fr,Es)"
+	rom ( name "Disney-Pixar Toy Story Mania! (USA) (En,Fr,Es).iso" size 4699979776 crc 1d45e56c md5 f4b96a9e50a7a98145c32e5933259fe4 sha1 82b3f24de685fdd214f7a3cd8299945d0d6190c2 )
+)
+
+game (
+	name "Disney-Pixar Up (USA) (En,Fr)"
+	description "Disney-Pixar Up (USA) (En,Fr)"
+	rom ( name "Disney-Pixar Up (USA) (En,Fr).iso" size 4699979776 crc 0b1470a6 md5 9093474d93d0b14a373de5e77888f461 sha1 c6dfd369ccdbc2fdd8b933c125c21a1c1fd2d3ef )
+)
+
+game (
+	name "Disney-Pixar WALL-E (Europe)"
+	description "Disney-Pixar WALL-E (Europe)"
+	rom ( name "Disney-Pixar WALL-E (Europe).iso" size 4699979776 crc 8d9bb0aa md5 febe5fc6ab99372752b7cd941b6df118 sha1 bf75d4c19d5845a38c3122531a86630d327df72c )
+)
+
+game (
+	name "Disney-Pixar WALL-E (USA) (En,Fr)"
+	description "Disney-Pixar WALL-E (USA) (En,Fr)"
+	rom ( name "Disney-Pixar WALL-E (USA) (En,Fr).iso" size 4699979776 crc 6a0a212e md5 e3787dc62d168be76dcfe324f3e3effd sha1 fd8488d1c425ab24de692b108a5ad3ad78780dbb )
+)
+
+game (
+	name "Diva Girls - Princess on Ice (Europe) (En,Fr,De,Es,It)"
+	description "Diva Girls - Princess on Ice (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Diva Girls - Princess on Ice (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a2789428 md5 761db4b5fe0a5f9da5dc40678a838f6b sha1 bb76927102cfb559839f0457d5c7f8c1236ce598 )
+)
+
+game (
+	name "DJ Hero (Europe) (En,Fr,De,Es,It)"
+	description "DJ Hero (Europe) (En,Fr,De,Es,It)"
+	rom ( name "DJ Hero (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 2df87b61 md5 b4777727ef799fa46b7acd10bd9ccc45 sha1 338516cf887c785cc18b432b6d4384b1a01733d0 )
+)
+
+game (
+	name "DJ Hero (USA) (En,Fr)"
+	description "DJ Hero (USA) (En,Fr)"
+	rom ( name "DJ Hero (USA) (En,Fr).iso" size 4699979776 crc 57305a8d md5 314f750ba4c359e4b058b6f5900e7bb1 sha1 0314ba942caaa2f127c9c32658a7a6306e4f3f5e )
+)
+
+game (
+	name "DJ Hero 2 (Europe) (En,Fr,De,Es,It)"
+	description "DJ Hero 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "DJ Hero 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f52fed6b md5 8500300b5e3afc2b09926525dc8e91e5 sha1 3958065ebabe28c11983a87467799740f67e88da )
+)
+
+game (
+	name "DJ Hero 2 (USA) (En,Fr)"
+	description "DJ Hero 2 (USA) (En,Fr)"
+	rom ( name "DJ Hero 2 (USA) (En,Fr).iso" size 4699979776 crc 95b4b48a md5 d4e8fdf288b7a32394e775b9624d8df3 sha1 8362e237f8d876473024919a26a8df43e6e6d2c5 )
+)
+
+game (
+	name "Dokapon Kingdom (USA)"
+	description "Dokapon Kingdom (USA)"
+	rom ( name "Dokapon Kingdom (USA).iso" size 4699979776 crc 398975c8 md5 5f681993301b50e2f6256e036deacd61 sha1 82cf3518a7f6d190761130d4388c7baed7715132 )
+)
+
+game (
+	name "Don Bluth Presents Dragon's Lair Trilogy (USA)"
+	description "Don Bluth Presents Dragon's Lair Trilogy (USA)"
+	rom ( name "Don Bluth Presents Dragon's Lair Trilogy (USA).iso" size 4699979776 crc b2e53b65 md5 5fa3f59ccdbcbaab707145f3283aa7e6 sha1 2cd35a8d05eb49f4f157f265b2fc4cd13c8f40e7 )
+)
+
+game (
+	name "Don King Boxing (Europe) (En,Fr,De,Es,It)"
+	description "Don King Boxing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Don King Boxing (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e4df184c md5 5fcafef473bf5a58a9e0172624533342 sha1 366ea6f3c6d87f679267234fa6210a20ce97a544 )
+)
+
+game (
+	name "Don King Boxing (USA) (En,Fr,Es)"
+	description "Don King Boxing (USA) (En,Fr,Es)"
+	rom ( name "Don King Boxing (USA) (En,Fr,Es).iso" size 4699979776 crc 61b0aba6 md5 ed2428b86394962ee535de767f015401 sha1 b97e7afe96608e67a6b5a7c27ec5cb477c6d43d0 )
+)
+
+game (
+	name "Donkey Kong - Barrel Blast (USA)"
+	description "Donkey Kong - Barrel Blast (USA)"
+	rom ( name "Donkey Kong - Barrel Blast (USA).iso" size 4699979776 crc 04c2b1a6 md5 71abed92d7d92d05cd8e34de4bcf017e sha1 684cb6c80ba0fe3fd665b65665bdfa167010e55c )
+)
+
+game (
+	name "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It)"
+	description "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a1c33316 md5 8ecfcd59ed3fa9241af62f694ebcb343 sha1 9c957bb34e46c3c6fd9e48acb09dfcb9933301cf )
+)
+
+game (
+	name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00)"
+	description "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 9737a7a7 md5 d88b8280ecfd89f40b77925dfba15f9c sha1 9f2185ca3220249d056783757e85704ca787fe43 )
+)
+
+game (
+	name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01)"
+	description "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 063ded8d md5 09ab792ad383280a0b5fba8f5d34ff97 sha1 bfd468160eff04622f70d845ac539b042e55e7b2 )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (Europe, Australia) (En,Fr,De,Es,It)"
+	description "Donkey Kong Jungle Beat (Europe, Australia) (En,Fr,De,Es,It)"
+	rom ( name "Donkey Kong Jungle Beat (Europe, Australia) (En,Fr,De,Es,It).iso" size 4699979776 crc ca64629d md5 7140663959d5de169131cc4345bdffdf sha1 e77c64810189555270637f3bca549f02cabd4acc )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (Japan)"
+	description "Donkey Kong Jungle Beat (Japan)"
+	rom ( name "Donkey Kong Jungle Beat (Japan).iso" size 4699979776 crc 077a63e8 md5 0679a018133cb64ff7823c87b0451f28 sha1 ece3736d8e7000cc8b2af751e1f85bf873f1408f )
+)
+
+game (
+	name "Donkey Kong Jungle Beat (USA) (En,Fr,Es)"
+	description "Donkey Kong Jungle Beat (USA) (En,Fr,Es)"
+	rom ( name "Donkey Kong Jungle Beat (USA) (En,Fr,Es).iso" size 4699979776 crc b88f74ea md5 aefb59ac51ecc07b3d057b3d568a1ea1 sha1 2060d010f303d37ad25ecda8c6d7ab97aaf2fd72 )
+)
+
+game (
+	name "Donkey Kong Returns (Japan)"
+	description "Donkey Kong Returns (Japan)"
+	rom ( name "Donkey Kong Returns (Japan).iso" size 4699979776 crc 09905fc7 md5 71ff333cfd7f913c4aabf8d9f5a74774 sha1 3dd9348d68d94d53077247a0a020e5e7c779e27c )
+)
+
+game (
+	name "Donkey Kong Taru Jet Race (Japan)"
+	description "Donkey Kong Taru Jet Race (Japan)"
+	rom ( name "Donkey Kong Taru Jet Race (Japan).iso" size 4699979776 crc da2c1c4d md5 259e4531dbe8e122cce413ef420ae29a sha1 622b172e16f70eb121773f2ced632095de1a8ef0 )
+)
+
+game (
+	name "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.00)"
+	description "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.00)"
+	rom ( name "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.00).iso" size 4699979776 crc e7082406 md5 6c8c83f6469756ad0bfee1dc5e6ea503 sha1 a9cfbae8137f2a22810f2fe96da68bddcf87e98b )
+)
+
+game (
+	name "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.01)"
+	description "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.01)"
+	rom ( name "Dora the Explorer - Dora Saves the Snow Princess (USA) (v1.01).iso" size 4699979776 crc bf3ac30c md5 bf51b29bf59ef6dbe97d9346d2cc1e46 sha1 621f06be210e02cea094f45c41c49f129a497098 )
+)
+
+game (
+	name "Dragon Ball - Revenge of King Piccolo (Europe) (En,Fr,De,Es,It)"
+	description "Dragon Ball - Revenge of King Piccolo (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon Ball - Revenge of King Piccolo (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 846a1632 md5 c03e4c2b9c82c850e2659659d47fa046 sha1 ebd6c744e52e9938c69602e6896b7edf96c88730 )
+)
+
+game (
+	name "Dragon Ball - Revenge of King Piccolo (USA)"
+	description "Dragon Ball - Revenge of King Piccolo (USA)"
+	rom ( name "Dragon Ball - Revenge of King Piccolo (USA).iso" size 4699979776 crc 65e161cd md5 72dd3b753e7868c13bc6036e9d68c1a5 sha1 9288d98efd066155553c27b7b0db13c5807df014 )
+)
+
+game (
+	name "Dragon Ball - Tenkaichi Daibouken (Japan)"
+	description "Dragon Ball - Tenkaichi Daibouken (Japan)"
+	rom ( name "Dragon Ball - Tenkaichi Daibouken (Japan).iso" size 4699979776 crc 2208e63b md5 28d09c7616a0d58ad6f128c786c68acd sha1 cd1a2388933830eec276e40795ba412a2123c4b1 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
+	description "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja).iso" size 4699979776 crc 0c713740 md5 41abf80c95fde8a90ae831c8ee1f7777 sha1 9de2efd8cc7517e5a464d6810a142c60317b731b )
+)
+
+game (
+	name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
+	description "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a5e94186 md5 656723af3267f554f5be2c166f0fbc92 sha1 7ff74ddaf87a63940dc6115c0dc52a87c4ed9370 )
+)
+
+game (
+	name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
+	description "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja).iso" size 4699979776 crc 8f4a3b7b md5 691421036ae73128691634d20f50ce8a sha1 97ed07738895c863db0f6012e0b36eee7bdffa2c )
+)
+
+game (
+	name "Dragon Quest Swords - Kamen no Joou to Kagami no Tou (Japan)"
+	description "Dragon Quest Swords - Kamen no Joou to Kagami no Tou (Japan)"
+	rom ( name "Dragon Quest Swords - Kamen no Joou to Kagami no Tou (Japan).iso" size 4699979776 crc 1b459354 md5 51fff8ee3507ac80f9f00cb76a3cc9e9 sha1 6ed2d2e0ee1987468f4bd456b5ca2bb268e08898 )
+)
+
+game (
+	name "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (Europe) (En,Fr,De,Es,It)"
+	description "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 65beaf9f md5 14d1b0f2f4cd2acdb682f44f57fee118 sha1 a6de84a36b7694c2304c9be831d5cb373bbd6477 )
+)
+
+game (
+	name "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (USA)"
+	description "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (USA)"
+	rom ( name "Dragon Quest Swords - The Masked Queen and the Tower of Mirrors (USA).iso" size 4699979776 crc 10305b14 md5 f164669f5c2c7d4edbec03542eac4729 sha1 541264b4711eaca8e7af3e3e20a369daf9357db2 )
+)
+
+game (
+	name "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 1)"
+	description "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 1)"
+	rom ( name "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 1).iso" size 4699979776 crc 16b68180 md5 adef3d5eb13f121f91a2b6d20ba69251 sha1 b51bab6d41c2cbf3fdd7a7b11168c66e9e355235 )
+)
+
+game (
+	name "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 2)"
+	description "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 2)"
+	rom ( name "Dragon Quest X - Mezameshi Itsutsu no Shuzoku Online (Japan) (Disc 2).iso" size 4699979776 crc 31d75bb7 md5 7693004cd2d7e000fccce7b88e62c170 sha1 85e802372c0bf3ce8559a609227d1820af6f272a )
+)
+
+game (
+	name "Drawn to Life - The Next Chapter (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Drawn to Life - The Next Chapter (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Drawn to Life - The Next Chapter (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc a3d61be2 md5 8a0a33490ba72c8bd45353e239a2ad53 sha1 ed2db6378ec02529a76e8519e8f1629468971350 )
+)
+
+game (
+	name "Drawn to Life - The Next Chapter (USA) (En,Fr)"
+	description "Drawn to Life - The Next Chapter (USA) (En,Fr)"
+	rom ( name "Drawn to Life - The Next Chapter (USA) (En,Fr).iso" size 4699979776 crc c8ebd172 md5 6c0a24518b8e072c5718aeb962ad51e7 sha1 a83b5e036badc6b3d6dd134dceee2ff7d9b133e3 )
+)
+
+game (
+	name "Dream Pinball 3D (Europe) (En,Fr,De,Es,It)"
+	description "Dream Pinball 3D (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Dream Pinball 3D (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3b44fc64 md5 66a29f1b425cab00c4fc895b8676b04a sha1 f39744d98ad127d520384eadc307c5e513eb4265 )
+)
+
+game (
+	name "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr)"
+	description "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr)"
+	rom ( name "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr).iso" size 4699979776 crc 307c955c md5 4b5b9bce046c9c51cd8dbba0444f552c sha1 0f0126f580202c33f71f515bb45369765d2774b8 )
+)
+
+game (
+	name "DreamWorks Kung Fu Panda (USA) (En,Fr)"
+	description "DreamWorks Kung Fu Panda (USA) (En,Fr)"
+	rom ( name "DreamWorks Kung Fu Panda (USA) (En,Fr).iso" size 4699979776 crc e7bfd8d1 md5 c82ef6db3048e82940da2efa30b02efb sha1 b92744a9eff56631bf654e5f4d003ecdb464581a )
+)
+
+game (
+	name "DreamWorks Madagascar - Escape 2 Africa (USA) (En,Fr)"
+	description "DreamWorks Madagascar - Escape 2 Africa (USA) (En,Fr)"
+	rom ( name "DreamWorks Madagascar - Escape 2 Africa (USA) (En,Fr).iso" size 4699979776 crc 74461a61 md5 1dfce6ff9baa5dafc3df93b5ea75881a sha1 8db26d5ecd937bd6db5278e3145adc3ff5aeb305 )
+)
+
+game (
+	name "DreamWorks Monsters vs. Aliens (Europe) (En,Fr,De,Es,It,Nl)"
+	description "DreamWorks Monsters vs. Aliens (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "DreamWorks Monsters vs. Aliens (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 53ebe928 md5 a9f7711958e7cf7d2814e1a2f9620da8 sha1 c0abd50d9c0cdb4c228acf848e165e421535c95c )
+)
+
+game (
+	name "DreamWorks Monsters vs. Aliens (USA) (En,Fr)"
+	description "DreamWorks Monsters vs. Aliens (USA) (En,Fr)"
+	rom ( name "DreamWorks Monsters vs. Aliens (USA) (En,Fr).iso" size 4699979776 crc 5ba6586b md5 772977eabb56eba14d5fe8e131d88921 sha1 b2745b5a2e137abec04d04e42ae723a38f19ad55 )
+)
+
+game (
+	name "DreamWorks Puss in Boots (USA) (En,Fr)"
+	description "DreamWorks Puss in Boots (USA) (En,Fr)"
+	rom ( name "DreamWorks Puss in Boots (USA) (En,Fr).iso" size 4699979776 crc 99f0e959 md5 78e5ed1dde029f8e425d2c81357ced70 sha1 f31cea5be8c9bff9dc36ed6ab2361fd2fa11117c )
+)
+
+game (
+	name "DreamWorks Shrek the Third (USA)"
+	description "DreamWorks Shrek the Third (USA)"
+	rom ( name "DreamWorks Shrek the Third (USA).iso" size 4699979776 crc b65ac283 md5 1167752db3e7628c8d07d8d5972d004a sha1 1abfe2532b3def5a1f5063490e80ee6b857bf7ee )
+)
+
+game (
+	name "DreamWorks Shrek's Carnival Craze - Party Games (USA) (En,Fr)"
+	description "DreamWorks Shrek's Carnival Craze - Party Games (USA) (En,Fr)"
+	rom ( name "DreamWorks Shrek's Carnival Craze - Party Games (USA) (En,Fr).iso" size 4699979776 crc 9e7b371d md5 3f2cef45dfd74160c384b93bb6205ed4 sha1 dab917b026b57751d923afcca5b6d93b72a1e21b )
+)
+
+game (
+	name "DreamWorks Super Star Kartz (USA) (En,Fr)"
+	description "DreamWorks Super Star Kartz (USA) (En,Fr)"
+	rom ( name "DreamWorks Super Star Kartz (USA) (En,Fr).iso" size 4699979776 crc 0bf75a2a md5 4649aced830b8d1d8d2479f447ffb570 sha1 9afff17e86c4ce33fa63f00f0894312ada0918b1 )
+)
+
+game (
+	name "Driver - San Francisco (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	description "Driver - San Francisco (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	rom ( name "Driver - San Francisco (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da).iso" size 4699979776 crc 801cd88c md5 cbf8877f42b73de48a22e32693472bdb sha1 7960efdbf107da1c8c801d6a3af9e9e78be3183b )
+)
+
+game (
+	name "Driver - San Francisco (USA) (En,Fr,Es)"
+	description "Driver - San Francisco (USA) (En,Fr,Es)"
+	rom ( name "Driver - San Francisco (USA) (En,Fr,Es).iso" size 4699979776 crc 6b81928f md5 dd3e040f9aeb20f581b209830e2d5cfb sha1 c57ba1becb11b13fa13985564f52ad5852377337 )
+)
+
+game (
+	name "EA Playground (Europe) (En,Fr,De,Es,It)"
+	description "EA Playground (Europe) (En,Fr,De,Es,It)"
+	rom ( name "EA Playground (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9a034426 md5 3c3081c8651706d7a07080cb763f3024 sha1 98ba0b77945381e96e2d29f49e1fe97106c85763 )
+)
+
+game (
+	name "EA Sports Active - More Workouts (USA) (En,Fr)"
+	description "EA Sports Active - More Workouts (USA) (En,Fr)"
+	rom ( name "EA Sports Active - More Workouts (USA) (En,Fr).iso" size 4699979776 crc e246cc09 md5 301175481043157134d4779d1a46b450 sha1 81a48b98b135cc700127d169180398e09dfd6a2a )
+)
+
+game (
+	name "EA Sports Active - NFL Training Camp (USA)"
+	description "EA Sports Active - NFL Training Camp (USA)"
+	rom ( name "EA Sports Active - NFL Training Camp (USA).iso" size 4699979776 crc 45b1e7e9 md5 c3da8497858f1a2061308abbe256a2a3 sha1 6055d54c79073437f8f4d984667d75e3e8d9aa2e )
+)
+
+game (
+	name "EA Sports Active - Personal Trainer (Europe) (En,Fr,De,Es,It,Nl)"
+	description "EA Sports Active - Personal Trainer (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "EA Sports Active - Personal Trainer (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 2a1e9f85 md5 a7c980dbabdb9373b0d8d64575ab67c5 sha1 fe9ee8b9b8b0ce0cf5aed4c02207498fe7d539d2 )
+)
+
+game (
+	name "EA Sports Active - Personal Trainer (USA) (En,Fr)"
+	description "EA Sports Active - Personal Trainer (USA) (En,Fr)"
+	rom ( name "EA Sports Active - Personal Trainer (USA) (En,Fr).iso" size 4699979776 crc f6c7ed79 md5 8d79b3215a1fa9baafffb9e3ed41007c sha1 d4eb4f03df17deb5fd198dacb1a3d39f2010877e )
+)
+
+game (
+	name "EA Sports Active 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "EA Sports Active 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "EA Sports Active 2 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 9f480a19 md5 8cf8648c7e7b48455457e1687a68d46b sha1 8e5c34b90280dad59bac370bf14182e3fb0bba99 )
+)
+
+game (
+	name "EA Sports Active 2 (USA) (En,Fr,Es)"
+	description "EA Sports Active 2 (USA) (En,Fr,Es)"
+	rom ( name "EA Sports Active 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 6ee8aac5 md5 4150d488eb3b04a370f0002dca7c18a7 sha1 8945290a3d8042e1867e9d2ef95a45d7a9414f8f )
+)
+
+game (
+	name "Earth Seeker (Japan)"
+	description "Earth Seeker (Japan)"
+	rom ( name "Earth Seeker (Japan).iso" size 4699979776 crc 659f4425 md5 92f0e8a6890f5b765982b8f3c427b163 sha1 c884f2e825fa899bbf5ffe94bab7596c9d068429 )
+)
+
+game (
+	name "El Padrino - El Chantaje (Spain)"
+	description "El Padrino - El Chantaje (Spain)"
+	rom ( name "El Padrino - El Chantaje (Spain).iso" size 4699979776 crc 25001c65 md5 2e80ea669da84c80be197348f9041fbf sha1 b80f8748386676df537943a3279fda2363143d20 )
+)
+
+game (
+	name "Elebits (USA)"
+	description "Elebits (USA)"
+	rom ( name "Elebits (USA).iso" size 4699979776 crc 15699741 md5 2c9b3256a7eea4a8a99fe7ba9d1ba7f5 sha1 251d1a871b2461b80f57a7d8b4954032d9d1aa73 )
+)
+
+game (
+	name "Eledees (Europe) (En,Fr,De,Es,It)"
+	description "Eledees (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Eledees (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ea869af4 md5 e76b0ab663807b7afa98eeecb2612923 sha1 e4f7b017db87584a6e0de27ad2742570dd0a1db1 )
+)
+
+game (
+	name "Emergency Heroes (Europe) (En,Fr,De,Es,It)"
+	description "Emergency Heroes (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Emergency Heroes (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1b1d2b93 md5 a01e74d0a5055207ef7a746c79ac1dc2 sha1 b9bff97ecef78860064fa87cf9ec6704b6c49ca4 )
+)
+
+game (
+	name "Endless Ocean - Blue World (USA)"
+	description "Endless Ocean - Blue World (USA)"
+	rom ( name "Endless Ocean - Blue World (USA).iso" size 4699979776 crc e6a34b32 md5 a62fea1de880968b8dc7649e1e2fcfec sha1 e628f0ecad4c7c8b50f500b1e89cba45626a2986 )
+)
+
+game (
+	name "Endless Ocean (Europe) (En,Fr,De,Es,It)"
+	description "Endless Ocean (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Endless Ocean (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 474628d8 md5 1a46c8acf9843982c7006a9286287be9 sha1 e7f010697c7c8976559da11d876b8ca6912aaac7 )
+)
+
+game (
+	name "Endless Ocean (USA) (En,Fr,Es)"
+	description "Endless Ocean (USA) (En,Fr,Es)"
+	rom ( name "Endless Ocean (USA) (En,Fr,Es).iso" size 4699979776 crc ad392b40 md5 720c5020b8603fea7bfdb623fb5d3bdb sha1 a6cec1e1fbbaf858233bedab579d16d9302c33f8 )
+)
+
+game (
+	name "Excite Truck (Europe) (En,Fr,De,Es,It)"
+	description "Excite Truck (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Excite Truck (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 55c1f91f md5 52ca2f0bca745b0194604a3d176d93b8 sha1 7e8efe5a6c4a3974eacd790fa8e1d941f5680b8f )
+)
+
+game (
+	name "Excite Truck (USA)"
+	description "Excite Truck (USA)"
+	rom ( name "Excite Truck (USA).iso" size 4699979776 crc 00b746f7 md5 214b54c48427ce47c183e83195dbfcde sha1 d7598ca4e6ed2c43f92ec173c84468eec136077c )
+)
+
+game (
+	name "ExciteBots - Trick Racing (USA)"
+	description "ExciteBots - Trick Racing (USA)"
+	rom ( name "ExciteBots - Trick Racing (USA).iso" size 4699979776 crc 8419ac77 md5 a2c3e5b799168de52561d22f9c5a3721 sha1 38b43e1e61326dd2bbae60df8da29c50dc880245 )
+)
+
+game (
+	name "ExerBeat (USA) (En,Fr,Es)"
+	description "ExerBeat (USA) (En,Fr,Es)"
+	rom ( name "ExerBeat (USA) (En,Fr,Es).iso" size 4699979776 crc 6ca2004b md5 9074a9ef2364c1437c53b1c042b9dfe2 sha1 f82d1e191638a93a682bd251796c01a658100fd7 )
+)
+
+game (
+	name "Eyeshield 21 - Field Saikyou no Senshi-tachi (Japan)"
+	description "Eyeshield 21 - Field Saikyou no Senshi-tachi (Japan)"
+	rom ( name "Eyeshield 21 - Field Saikyou no Senshi-tachi (Japan).iso" size 4699979776 crc 11853987 md5 18c567e7ae4cc309cd311ce4805ccde2 sha1 06ad55eec1405e9f2b69bbc7e322184dc148b6c6 )
+)
+
+game (
+	name "FaceBreaker K.O. Party (USA) (En,Fr)"
+	description "FaceBreaker K.O. Party (USA) (En,Fr)"
+	rom ( name "FaceBreaker K.O. Party (USA) (En,Fr).iso" size 4699979776 crc fee0a8b7 md5 49cbbc568bfa7960570a52f6407d91c9 sha1 fff9fad489c19459c6efa9c89dd129b39ef52187 )
+)
+
+game (
+	name "Family Fest Presents Circus Games (USA) (En,Fr,Es)"
+	description "Family Fest Presents Circus Games (USA) (En,Fr,Es)"
+	rom ( name "Family Fest Presents Circus Games (USA) (En,Fr,Es).iso" size 4699979776 crc fd67cc8a md5 b4d5fc98c195b50a9363f64df5049115 sha1 e2ba472870c920451c854f87c4e7eab92e74aeb9 )
+)
+
+game (
+	name "Family Feud - 2010 Edition (USA)"
+	description "Family Feud - 2010 Edition (USA)"
+	rom ( name "Family Feud - 2010 Edition (USA).iso" size 4699979776 crc 35c5833d md5 37ae2a5341df061a9f63c2b78de2da6b sha1 80d83127919458ae6111a8ce91979cae047c03cb )
+)
+
+game (
+	name "Family Game Night 4 - The Game Show (USA)"
+	description "Family Game Night 4 - The Game Show (USA)"
+	rom ( name "Family Game Night 4 - The Game Show (USA).iso" size 4699979776 crc 7ef6b7d9 md5 2f5bb5a69dd5e523f4f471e18f1aa1a1 sha1 99b75e01c1ab595177e564e36ecd85f9235eeb78 )
+)
+
+game (
+	name "Family Gameshow (USA)"
+	description "Family Gameshow (USA)"
+	rom ( name "Family Gameshow (USA).iso" size 4699979776 crc 0b74526b md5 3ade2f1ee0204bcff0a72e78e6450d9f sha1 af04edc0bca0639fe8c833f706a9bed18650e36c )
+)
+
+game (
+	name "Family Ski (Europe) (En,Fr,De,Es,It)"
+	description "Family Ski (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Family Ski (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5d23f0f2 md5 d1c3691e666dcfb81394c52586865a20 sha1 038ee38fe2c0d1dbb95f1b40244ada75a41b88b8 )
+)
+
+game (
+	name "Family Ski & Snowboard (Europe) (En,Fr,De,Es,It)"
+	description "Family Ski & Snowboard (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Family Ski & Snowboard (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7b91cc5f md5 fe9be842f4ae7c658cdadb168682793c sha1 7f7efb7875b42cb483576424e3d52d8a7cb0cb67 )
+)
+
+game (
+	name "Family Trainer - Extreme Challenge (Europe) (En,Fr,De,Es,It)"
+	description "Family Trainer - Extreme Challenge (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Family Trainer - Extreme Challenge (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e2cdd11f md5 2bf4520c233c0c4b2bea126371766c5b sha1 098738801fbe8bb7aa2b50c47a3ecbbf6ae13aae )
+)
+
+game (
+	name "Family Trainer (Europe) (En,Fr,De,Es,It)"
+	description "Family Trainer (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Family Trainer (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f3f6ff99 md5 1f408619c338f82c179a7168ab5bed9d sha1 f8bbbb60d82ef6009df47763c7d98b798668b6d0 )
+)
+
+game (
+	name "Fantastic Four - Rise of the Silver Surfer (USA) (En,Fr)"
+	description "Fantastic Four - Rise of the Silver Surfer (USA) (En,Fr)"
+	rom ( name "Fantastic Four - Rise of the Silver Surfer (USA) (En,Fr).iso" size 4699979776 crc 89985afa md5 e117f8e2ae86817888a62fc4872304e7 sha1 532d6298496c3247b37fdede0070d9c669e2c8cf )
+)
+
+game (
+	name "Far Cry Vengeance (Europe) (En,Fr,De,Es,It)"
+	description "Far Cry Vengeance (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Far Cry Vengeance (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3ec7a588 md5 826f88388092840ab9e56f435f91a43e sha1 3f4d02a1a20b5c13c97b49a52ec84b5bd2d88a87 )
+)
+
+game (
+	name "Far Cry Vengeance (USA) (En,Fr,Es)"
+	description "Far Cry Vengeance (USA) (En,Fr,Es)"
+	rom ( name "Far Cry Vengeance (USA) (En,Fr,Es).iso" size 4699979776 crc 76cc4f60 md5 76594f1c163f54dfd80e4043379814d9 sha1 edb2ea9b9404e535de0079723c6fa66e9a4a6b01 )
+)
+
+game (
+	name "Ferrari Challenge - Trofeo Pirelli (USA) (En,Fr)"
+	description "Ferrari Challenge - Trofeo Pirelli (USA) (En,Fr)"
+	rom ( name "Ferrari Challenge - Trofeo Pirelli (USA) (En,Fr).iso" size 4699979776 crc 72bb2cb9 md5 255971a169273ec264d7ba86350a67b5 sha1 0feec038c8946622930cd53d96552df0dff53178 )
+)
+
+game (
+	name "FIFA 08 (Europe) (En,Nl)"
+	description "FIFA 08 (Europe) (En,Nl)"
+	rom ( name "FIFA 08 (Europe) (En,Nl).iso" size 4699979776 crc 950b8e26 md5 6b920b7e050e6800c446d3fb70796939 sha1 a2b227f4ecd909266b727f235e1d0317678157ad )
+)
+
+game (
+	name "FIFA 08 (Europe) (Es,It)"
+	description "FIFA 08 (Europe) (Es,It)"
+	rom ( name "FIFA 08 (Europe) (Es,It).iso" size 4699979776 crc 815cd2b0 md5 384ee48d073e179452d05cc9250469ba sha1 7d900b8417cd4702cb959b3e27ac0c7698cff45f )
+)
+
+game (
+	name "FIFA 09 All-Play (Europe) (En,Nl)"
+	description "FIFA 09 All-Play (Europe) (En,Nl)"
+	rom ( name "FIFA 09 All-Play (Europe) (En,Nl).iso" size 4699979776 crc ee55c651 md5 6404c250b8d876ba03b0de1a231a2d2b sha1 4231300d5d33ada274d01cace59884cdcb0706e9 )
+)
+
+game (
+	name "FIFA 09 All-Play (Europe) (Es,It)"
+	description "FIFA 09 All-Play (Europe) (Es,It)"
+	rom ( name "FIFA 09 All-Play (Europe) (Es,It).iso" size 4699979776 crc 2a2b8c35 md5 1d662ef9bf453d1d9e078efe47eda37a sha1 cfdbbb0458bafaff092bff26998d9949ac188aef )
+)
+
+game (
+	name "FIFA 10 (Europe) (En,Nl)"
+	description "FIFA 10 (Europe) (En,Nl)"
+	rom ( name "FIFA 10 (Europe) (En,Nl).iso" size 4699979776 crc 48236f75 md5 7ff997bc9297ba76543f3c6eb61206d2 sha1 ec42e31243139eb4697b6d126e4f20d38a33bc20 )
+)
+
+game (
+	name "FIFA 10 (Europe) (Es,It)"
+	description "FIFA 10 (Europe) (Es,It)"
+	rom ( name "FIFA 10 (Europe) (Es,It).iso" size 4699979776 crc 07b9f26b md5 5bdc97971587b569b7502b340882d197 sha1 5fb92f1fb4ffafff40273cf27f9fc4a33f617149 )
+)
+
+game (
+	name "FIFA 13 (Europe) (De,Es,It)"
+	description "FIFA 13 (Europe) (De,Es,It)"
+	rom ( name "FIFA 13 (Europe) (De,Es,It).iso" size 4699979776 crc fa3069bc md5 08f4bbeaa0fd32e23ea83458cd220c80 sha1 f4c6fca46cda7401ee9eb292cf6ec3d938cbc31b )
+)
+
+game (
+	name "FIFA 13 (Europe) (En,Fr,Nl)"
+	description "FIFA 13 (Europe) (En,Fr,Nl)"
+	rom ( name "FIFA 13 (Europe) (En,Fr,Nl).iso" size 4699979776 crc 745bc776 md5 55465079499c7c72aeadd5166ba54772 sha1 ef1f2aeea81c782cd28a260539589c56876c50a6 )
+)
+
+game (
+	name "FIFA Soccer 10 (USA)"
+	description "FIFA Soccer 10 (USA)"
+	rom ( name "FIFA Soccer 10 (USA).iso" size 4699979776 crc eaac4201 md5 7af397a0673ac9edf574dd9bf87820b2 sha1 ca8fe7706c9afd52753b6dd810df99092fd204ff )
+)
+
+game (
+	name "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es)"
+	description "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es)"
+	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es).iso" size 4699979776 crc e8663b8b md5 80e60fa6e8802e3773606a05c99980c0 sha1 7bcca1d5e94c7e0b67486c33ed9e44a216ea69ae )
+)
+
+game (
+	name "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es)"
+	description "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es)"
+	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es).iso" size 4699979776 crc 0bc95379 md5 ea2b120e323d5259d7871ec465e4dab6 sha1 0c7ac30cc373c9876879080ba2758a50cdcc3fb5 )
+)
+
+game (
+	name "Final Fantasy Crystal Chronicles - The Crystal Bearers (Europe) (En,Fr,De,Es)"
+	description "Final Fantasy Crystal Chronicles - The Crystal Bearers (Europe) (En,Fr,De,Es)"
+	rom ( name "Final Fantasy Crystal Chronicles - The Crystal Bearers (Europe) (En,Fr,De,Es).iso" size 4699979776 crc 3bacd4de md5 c0fc022714c010e0a78484b33f3f02d8 sha1 0d5e40ac309746c2a17a27445d9fd2c1c9393305 )
+)
+
+game (
+	name "Final Fantasy Crystal Chronicles - The Crystal Bearers (USA) (En,Fr,Es)"
+	description "Final Fantasy Crystal Chronicles - The Crystal Bearers (USA) (En,Fr,Es)"
+	rom ( name "Final Fantasy Crystal Chronicles - The Crystal Bearers (USA) (En,Fr,Es).iso" size 4699979776 crc 7822d84b md5 b8b813a822bf174698d52c2281ae96b7 sha1 e40ef12ff5ae45cc8e60db55103fc2f7e7a35842 )
+)
+
+game (
+	name "Final Fantasy Fables - Chocobo's Dungeon (Europe) (En,Fr,De,Es)"
+	description "Final Fantasy Fables - Chocobo's Dungeon (Europe) (En,Fr,De,Es)"
+	rom ( name "Final Fantasy Fables - Chocobo's Dungeon (Europe) (En,Fr,De,Es).iso" size 4699979776 crc 8cf76806 md5 6e70e7147edc4cba8afd391dc6577e30 sha1 c4b485bec664a8a9b0c32c0ca552328e352be521 )
+)
+
+game (
+	name "Final Fantasy Fables - Chocobo's Dungeon (USA)"
+	description "Final Fantasy Fables - Chocobo's Dungeon (USA)"
+	rom ( name "Final Fantasy Fables - Chocobo's Dungeon (USA).iso" size 4699979776 crc 589cc931 md5 f926f9f719034d7bb07300ef1495d5d7 sha1 b59d7f6fcabcd11477577ee0184c23c34449a97f )
+)
+
+game (
+	name "Fire Emblem - Radiant Dawn (Europe) (En,Fr,De,Es,It)"
+	description "Fire Emblem - Radiant Dawn (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Fire Emblem - Radiant Dawn (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7e12e5ca md5 1cddd1e4afeac1c2f8c06a56702478b4 sha1 b9e09e44cf0ab540bc01fa585e9d416d7a304dca )
+)
+
+game (
+	name "Fire Emblem - Radiant Dawn (USA) (v1.00)"
+	description "Fire Emblem - Radiant Dawn (USA) (v1.00)"
+	rom ( name "Fire Emblem - Radiant Dawn (USA) (v1.00).iso" size 4699979776 crc 5843dd9b md5 f23bc9391f2e5075d05bd08dd50cdf0e sha1 7b8f509ee847b906a4a7eea97a6d67f832964ce4 )
+)
+
+game (
+	name "Fire Emblem - Radiant Dawn (USA) (v1.01)"
+	description "Fire Emblem - Radiant Dawn (USA) (v1.01)"
+	rom ( name "Fire Emblem - Radiant Dawn (USA) (v1.01).iso" size 4699979776 crc ce7e4abc md5 0729f9c46e1b9820152362aec9f24a83 sha1 1b75077919326bbd4396fb59961b17da599eea07 )
+)
+
+game (
+	name "Fishing Master World Tour (USA) (En,Fr,Es)"
+	description "Fishing Master World Tour (USA) (En,Fr,Es)"
+	rom ( name "Fishing Master World Tour (USA) (En,Fr,Es).iso" size 4699979776 crc 02943067 md5 7fe8e6ee2b4f1f7c2e05e451a247a574 sha1 e761e035953647722f310d06a95e853f03521653 )
+)
+
+game (
+	name "FlingSmash (USA) (En,Fr,Es)"
+	description "FlingSmash (USA) (En,Fr,Es)"
+	rom ( name "FlingSmash (USA) (En,Fr,Es).iso" size 4699979776 crc 96811e04 md5 304128285c1c40b4740c922efdb79436 sha1 c8d7e1a248b8d67bc4820dce9c26bf108a7646b6 )
+)
+
+game (
+	name "Formula 1 2009 (Europe) (En,Fr,De,Es,It)"
+	description "Formula 1 2009 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Formula 1 2009 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 51019edd md5 75b95fdbbfe2e481c9dacc5f7dc7fedc sha1 8010a51a486460fa5ed23aa32fce51307fe91d06 )
+)
+
+game (
+	name "Formula 1 2009 (USA) (En,Fr,Es)"
+	description "Formula 1 2009 (USA) (En,Fr,Es)"
+	rom ( name "Formula 1 2009 (USA) (En,Fr,Es).iso" size 4699979776 crc 4540ad49 md5 52096dea6d48c707281b4e005580f22f sha1 69fdf4c980f5adc1cb2c945c9eea0a698b7d4fc6 )
+)
+
+game (
+	name "Fortune Street (USA)"
+	description "Fortune Street (USA)"
+	rom ( name "Fortune Street (USA).iso" size 4699979776 crc b531055d md5 c1623427cdbf6120b840f4d0a29e482e sha1 2292ecc8ed3fbae7496d2605a3656a9dc60f8fef )
+)
+
+game (
+	name "Fragile - Sayonara Tsuki no Haikyo (Japan)"
+	description "Fragile - Sayonara Tsuki no Haikyo (Japan)"
+	rom ( name "Fragile - Sayonara Tsuki no Haikyo (Japan).iso" size 4699979776 crc 15c961d1 md5 143cdeb34fac8f70794f1dacbc08525b sha1 dbcc17f942bcebeb4dace374bd79194ea760cb2a )
+)
+
+game (
+	name "Fragile Dreams - Farewell Ruins of the Moon (Europe) (En,Ja,Fr,De)"
+	description "Fragile Dreams - Farewell Ruins of the Moon (Europe) (En,Ja,Fr,De)"
+	rom ( name "Fragile Dreams - Farewell Ruins of the Moon (Europe) (En,Ja,Fr,De).iso" size 4699979776 crc 10363d54 md5 6384605047ac168d8db61722fce34f1e sha1 78d86a2cd74ce7482f3f059c56e0b5b90c125334 )
+)
+
+game (
+	name "Fragile Dreams - Farewell Ruins of the Moon (USA) (En,Ja,Fr)"
+	description "Fragile Dreams - Farewell Ruins of the Moon (USA) (En,Ja,Fr)"
+	rom ( name "Fragile Dreams - Farewell Ruins of the Moon (USA) (En,Ja,Fr).iso" size 4699979776 crc 8eaeb945 md5 c1f9631e6cf9fde466a17ff8edd74d43 sha1 7e84f6d2c73aaaf6f7e3bc5067f478ff17bb5db4 )
+)
+
+game (
+	name "Freeloader for Nintendo Wii (Europe)"
+	description "Freeloader for Nintendo Wii (Europe)"
+	rom ( name "Freeloader for Nintendo Wii (Europe).iso" size 1459978240 crc 50f17581 md5 7482e3e2c4581692a091cbbd8272bfd9 sha1 5bf7aac9a3607873319a0e3590c81e332a4387ab )
+)
+
+game (
+	name "Funfair Party (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Funfair Party (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Funfair Party (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 79485875 md5 b7c4e22592a100db3bcce0d2048cc1c7 sha1 40970ad78101cf4c4c6e414a0e533e8d9dd96f09 )
+)
+
+game (
+	name "Fushigi no Dungeon - Fuurai no Shiren 3 - Karakuri Yashiki no Nemuri Hime (Japan)"
+	description "Fushigi no Dungeon - Fuurai no Shiren 3 - Karakuri Yashiki no Nemuri Hime (Japan)"
+	rom ( name "Fushigi no Dungeon - Fuurai no Shiren 3 - Karakuri Yashiki no Nemuri Hime (Japan).iso" size 4699979776 crc 561d83a1 md5 bb1e406b21f517a9caf5ac796059685b sha1 f3a196dd1fcb0ab2b689bf12dea6ecad2a107225 )
+)
+
+game (
+	name "G-Force (USA) (En,Fr,Es)"
+	description "G-Force (USA) (En,Fr,Es)"
+	rom ( name "G-Force (USA) (En,Fr,Es).iso" size 4699979776 crc 10d9742b md5 848ca4e6a9400ba5e322afe64544be5e sha1 72d5a4f1817440de690480d7de1852640bd7cf1e )
+)
+
+game (
+	name "G.I. Joe - The Rise of Cobra (USA) (En,Fr)"
+	description "G.I. Joe - The Rise of Cobra (USA) (En,Fr)"
+	rom ( name "G.I. Joe - The Rise of Cobra (USA) (En,Fr).iso" size 4699979776 crc 2a39d8b7 md5 39b8f14979be6d5021f74126bacfd0b3 sha1 0f607654642de62571ebc364116360f8505159f1 )
+)
+
+game (
+	name "G1 Jockey Wii 2008 (Europe)"
+	description "G1 Jockey Wii 2008 (Europe)"
+	rom ( name "G1 Jockey Wii 2008 (Europe).iso" size 4699979776 crc 997561de md5 8653bb77ed04cf57fa034a7e0298f1ff sha1 4e316154f60d29c9f942e5c5f36a155454163ddd )
+)
+
+game (
+	name "Game Party (Europe) (En,Fr,De,Es,It)"
+	description "Game Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Game Party (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 2e1026c3 md5 cff1fd09f3e4be7eb8d75839f177b8b5 sha1 b1876974524ab2cd18aaad5b2f66135ba334ba62 )
+)
+
+game (
+	name "Game Party (USA) (v1.01)"
+	description "Game Party (USA) (v1.01)"
+	rom ( name "Game Party (USA) (v1.01).iso" size 4699979776 crc ff51b944 md5 702b4035914c3c83d0acb549e58cc2f0 sha1 5e2c12f11bdd0eca7542b53217205488e37690c1 )
+)
+
+game (
+	name "Garfield Show, The - Threat of the Space Lasagna (USA)"
+	description "Garfield Show, The - Threat of the Space Lasagna (USA)"
+	rom ( name "Garfield Show, The - Threat of the Space Lasagna (USA).iso" size 4699979776 crc 50ba2c16 md5 81aba388b99f66321f7981251982e704 sha1 a78c213e0c6995cee8520c532b1d0dbdd6ade9bb )
+)
+
+game (
+	name "Generator Rex - Agent of Providence (USA) (En,Fr)"
+	description "Generator Rex - Agent of Providence (USA) (En,Fr)"
+	rom ( name "Generator Rex - Agent of Providence (USA) (En,Fr).iso" size 4699979776 crc e3ae8e0f md5 c8d995db5421db0b3bfcc5f2ab2be6c2 sha1 08a76b764c132e1d2acd2cc5abf24e5076a02aec )
+)
+
+game (
+	name "Geometry Wars - Galaxies (USA)"
+	description "Geometry Wars - Galaxies (USA)"
+	rom ( name "Geometry Wars - Galaxies (USA).iso" size 4699979776 crc 2dc94673 md5 9b32389183920351829292a7a004571a sha1 0e4b65b65c2d0ad593079b8c4e190c0e9ecf5111 )
+)
+
+game (
+	name "Get Up and Dance (USA)"
+	description "Get Up and Dance (USA)"
+	rom ( name "Get Up and Dance (USA).iso" size 4699979776 crc d68f8a38 md5 6fcd738e83714c4041ebf4d6ddfc590b sha1 30d12fb9aa72917cf9ba429c1f5a274f964c7a5f )
+)
+
+game (
+	name "Ghost Squad (Europe) (En,Fr,De,Es,It)"
+	description "Ghost Squad (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Ghost Squad (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b098a5f3 md5 929b23cd6d143efe733880ab82c89bc7 sha1 521c9f870868200253221133b61e1df64c01c139 )
+)
+
+game (
+	name "Ghost Squad (USA)"
+	description "Ghost Squad (USA)"
+	rom ( name "Ghost Squad (USA).iso" size 4699979776 crc 3ec8fd4c md5 3368e91951ed48ec778f8936f9eda442 sha1 5573b038976f3e07d0e489e8878de8678f17f999 )
+)
+
+game (
+	name "Ghostbusters - The Video Game (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Ghostbusters - The Video Game (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Ghostbusters - The Video Game (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 8f8defdc md5 1d8ae539aca75d21f307237f5f424182 sha1 ac1d1cbee5608558b73eb7f24447ae871a01d9a1 )
+)
+
+game (
+	name "Ghostbusters - The Video Game (USA) (En,Fr,Es)"
+	description "Ghostbusters - The Video Game (USA) (En,Fr,Es)"
+	rom ( name "Ghostbusters - The Video Game (USA) (En,Fr,Es).iso" size 4699979776 crc a6539a7a md5 f47a1b56cebfb062a373ff8ec581fac2 sha1 10246d33ca4adf24917835ab45bc3397f617522c )
+)
+
+game (
+	name "Glee Karaoke Revolution - Volume 3 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Glee Karaoke Revolution - Volume 3 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Glee Karaoke Revolution - Volume 3 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 00d2ed39 md5 c654e663700f43b7ff086424029d256e sha1 379d8207ea73de2d63cca6db5c040827a0784397 )
+)
+
+game (
+	name "Glee Karaoke Revolution (USA)"
+	description "Glee Karaoke Revolution (USA)"
+	rom ( name "Glee Karaoke Revolution (USA).iso" size 4699979776 crc 1d0e821c md5 b5541664b50112c1467e0a80fc2ed83d sha1 fe062176bee4c0d55bf6de1461d2d77da4dab82f )
+)
+
+game (
+	name "Go Diego Go! Safari Rescue (USA)"
+	description "Go Diego Go! Safari Rescue (USA)"
+	rom ( name "Go Diego Go! Safari Rescue (USA).iso" size 4699979776 crc 4b3c3350 md5 761641cf3830937930fef543754bf426 sha1 2fb53727e01f331077b0a4e3f331dcbae240e4b2 )
+)
+
+game (
+	name "Go Play - Lumberjacks (USA)"
+	description "Go Play - Lumberjacks (USA)"
+	rom ( name "Go Play - Lumberjacks (USA).iso" size 4699979776 crc c512a853 md5 430d5858d7f3f51fc37595b51fb79183 sha1 07488b786b73d5e23bc49180b197f73bcb620809 )
+)
+
+game (
+	name "Go Vacation (Japan)"
+	description "Go Vacation (Japan)"
+	rom ( name "Go Vacation (Japan).iso" size 4699979776 crc e50c8350 md5 0da5dfe7ce14e14b08c90d5f9d7c238c sha1 163ee446598eca752ebb607dd9fa0b80fa245b4a )
+)
+
+game (
+	name "Godfather, The - Blackhand Edition (USA)"
+	description "Godfather, The - Blackhand Edition (USA)"
+	rom ( name "Godfather, The - Blackhand Edition (USA).iso" size 4699979776 crc 6a4c8225 md5 aa5d1387b58c6313d6d330c1dfd6f7d9 sha1 81663c5fa6ae75b8e7ada713a6f30eb35c80b1a0 )
+)
+
+game (
+	name "Gold's Gym - Cardio Workout (USA)"
+	description "Gold's Gym - Cardio Workout (USA)"
+	rom ( name "Gold's Gym - Cardio Workout (USA).iso" size 4699979776 crc f8a9c90c md5 9e3f4cb7e254134f2b9db20f27b81cb7 sha1 8b942daa3805b6af8273245f1d35658ec4598d19 )
+)
+
+game (
+	name "Golden Compass, The (Europe) (En,Fr,De,Es,It)"
+	description "Golden Compass, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Golden Compass, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 628720e0 md5 64c0e38445ce772d495530640531b4ce sha1 76b43c7c1abc6bd85e07fa2e17d9f8562f1ec93a )
+)
+
+game (
+	name "GoldenEye 007 (Europe) (En,Fr,De,Es,It)"
+	description "GoldenEye 007 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "GoldenEye 007 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0887e887 md5 0a1b8673d25e730080b4f47107fa324d sha1 0a0185b26d8bab49a07dcc137334209f0b0b9e9e )
+)
+
+game (
+	name "GoldenEye 007 (USA)"
+	description "GoldenEye 007 (USA)"
+	rom ( name "GoldenEye 007 (USA).iso" size 4699979776 crc 08c1016c md5 e9a863892fcc96cb407c9e9143722af7 sha1 5a36c58e93418cd4e25a5e51a65f4b2fd9460ee0 )
+)
+
+game (
+	name "Gottlieb Pinball Classics (Europe) (En,Fr,De,Es,It)"
+	description "Gottlieb Pinball Classics (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Gottlieb Pinball Classics (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 82c8e070 md5 aa471ac5200b2667470ef763ce69defa sha1 6daab201a25fe28856e79e6a407e638dab064b36 )
+)
+
+game (
+	name "Grand Slam Tennis (Europe) (En,Fr,De,Es,It)"
+	description "Grand Slam Tennis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Grand Slam Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0e74fcbb md5 d60e1ffeb964ee74fe934f8deda7647c sha1 93b067e3c634b769b2fee467b5c644e61ffdb62f )
+)
+
+game (
+	name "Grand Slam Tennis (USA) (En,Fr)"
+	description "Grand Slam Tennis (USA) (En,Fr)"
+	rom ( name "Grand Slam Tennis (USA) (En,Fr).iso" size 4699979776 crc 45109b54 md5 b524c6550977b93e7ef5a5b82283f565 sha1 cf69325c740e8a2ee80ad62e1c1780eb6bceac46 )
+)
+
+game (
+	name "Grease - The Official Videogame (Europe) (En,Fr,De,Es,It)"
+	description "Grease - The Official Videogame (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Grease - The Official Videogame (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d3f856f1 md5 696e6863f5c3e97134f9a1d61d2de058 sha1 9abdd241c265dda1224aabdc12e9c79991ad716e )
+)
+
+game (
+	name "Green Day - Rock Band (Europe) (En,Fr,De,Es,It)"
+	description "Green Day - Rock Band (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Green Day - Rock Band (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e2b91c90 md5 a707589f6e26acfcd97c0d9a5ca0add1 sha1 03afa34ec2927776255386b5bf86bce9bc6e3466 )
+)
+
+game (
+	name "Green Lantern - Rise of the Manhunters (USA) (En,Fr,Es,Pt)"
+	description "Green Lantern - Rise of the Manhunters (USA) (En,Fr,Es,Pt)"
+	rom ( name "Green Lantern - Rise of the Manhunters (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc eadfaebd md5 a1d91498175b4770e71241a4e570b915 sha1 27eb15eca85cbc56803fe5b8fbcb01d9c17a2ee1 )
+)
+
+game (
+	name "GT Pro Series (USA)"
+	description "GT Pro Series (USA)"
+	rom ( name "GT Pro Series (USA).iso" size 4699979776 crc a2fa8f26 md5 0cde8f6a4d59456b260a94aeb2bb28aa sha1 405da30653d3ad9465f6196380ff3b021adb52b5 )
+)
+
+game (
+	name "Guilty Gear XX Accent Core (Europe)"
+	description "Guilty Gear XX Accent Core (Europe)"
+	rom ( name "Guilty Gear XX Accent Core (Europe).iso" size 4699979776 crc 3ddba2a7 md5 0841ee4643e5b0dc0b635ee2d75aeeb2 sha1 2492a67e144dc9abae04dfe314b2d3c5663d1a13 )
+)
+
+game (
+	name "Guilty Gear XX Accent Core Plus (USA)"
+	description "Guilty Gear XX Accent Core Plus (USA)"
+	rom ( name "Guilty Gear XX Accent Core Plus (USA).iso" size 4699979776 crc e59b5d66 md5 ff7bdd553f93b1a0f3bf8ff774493c1c sha1 1c4656ab931bbf989d3827447c55c30bd0dd2555 )
+)
+
+game (
+	name "Guinness World Records - The Videogame (Europe)"
+	description "Guinness World Records - The Videogame (Europe)"
+	rom ( name "Guinness World Records - The Videogame (Europe).iso" size 4699979776 crc 13cb1d88 md5 38896de9df086416e9751e121247a9f5 sha1 6f9305688e2a4a0966f1f313a4289795e1b09cc7 )
+)
+
+game (
+	name "Guinness World Records - The Videogame (USA) (En,Fr,Es)"
+	description "Guinness World Records - The Videogame (USA) (En,Fr,Es)"
+	rom ( name "Guinness World Records - The Videogame (USA) (En,Fr,Es).iso" size 4699979776 crc f947a55b md5 c7e3d66318baa267365dfb64108201f7 sha1 b311f7d4c39f2261b81e254bdb8f32cbe05bb82a )
+)
+
+game (
+	name "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It)"
+	description "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1d182535 md5 d3be83f8c8f031a2d7e4dfabc0bc2f6c sha1 cc26205e1c6b9d088e930c84369433fa9f74e734 )
+)
+
+game (
+	name "Guitar Hero - Aerosmith (USA) (En,Fr)"
+	description "Guitar Hero - Aerosmith (USA) (En,Fr)"
+	rom ( name "Guitar Hero - Aerosmith (USA) (En,Fr).iso" size 4699979776 crc faf37e3d md5 d6f875d4774adfeb88bfa83f5593645d sha1 b95dab2697b4f0571f5512b3fcce1a5a75e021eb )
+)
+
+game (
+	name "Guitar Hero - Metallica (Europe) (En,Fr,De,Es,It)"
+	description "Guitar Hero - Metallica (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Guitar Hero - Metallica (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d04fd384 md5 9f8ebd9d37e5c664f85c82e5c0712e17 sha1 4a7168374ca9fb497f5dab61d3793ea0cbf022ac )
+)
+
+game (
+	name "Guitar Hero - Metallica (USA) (En,Fr)"
+	description "Guitar Hero - Metallica (USA) (En,Fr)"
+	rom ( name "Guitar Hero - Metallica (USA) (En,Fr).iso" size 4699979776 crc e1b6fafd md5 a3bfc7b1b0a89d8ba9a68ee46a8c88a6 sha1 cfd6e8c49a480256b13d46494f3eb09ce36c74ee )
+)
+
+game (
+	name "Guitar Hero - Smash Hits (USA) (En,Fr)"
+	description "Guitar Hero - Smash Hits (USA) (En,Fr)"
+	rom ( name "Guitar Hero - Smash Hits (USA) (En,Fr).iso" size 4699979776 crc 694c50cc md5 4a45d718c0ab7648fe3ec030a816ae7c sha1 638c8447b43301529c8251c763b324dd92224031 )
+)
+
+game (
+	name "Guitar Hero - Van Halen (Europe) (En,Fr,De,Es,It)"
+	description "Guitar Hero - Van Halen (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Guitar Hero - Van Halen (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 923b88d7 md5 266e98109a0df2f4007f16639c8b43cd sha1 3ffdcc80feb9fd474feb888c26c2d6488ee548eb )
+)
+
+game (
+	name "Guitar Hero - Van Halen (USA) (En,Fr)"
+	description "Guitar Hero - Van Halen (USA) (En,Fr)"
+	rom ( name "Guitar Hero - Van Halen (USA) (En,Fr).iso" size 4699979776 crc 04b67e4a md5 9d81b6dc83c5fbc305ef246e78617556 sha1 aa39dc4c1320eb3e7bf0878fd7d746618cedd7f1 )
+)
+
+game (
+	name "Guitar Hero - Warriors of Rock (Europe) (En,Fr,De,Es,It)"
+	description "Guitar Hero - Warriors of Rock (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Guitar Hero - Warriors of Rock (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 658dc5c1 md5 02c13b2a7614be061e6e2e5fa52205a4 sha1 c21bb31032d403541ac345f5248d325732491ed8 )
+)
+
+game (
+	name "Guitar Hero - Warriors of Rock (USA)"
+	description "Guitar Hero - Warriors of Rock (USA)"
+	rom ( name "Guitar Hero - Warriors of Rock (USA).iso" size 4699979776 crc 9794b23a md5 b377d52e40c58547e5b1d9ffbf7ae6e9 sha1 292f89307a162084b221c7110db68ef4c73c569f )
+)
+
+game (
+	name "Guitar Hero 5 (USA)"
+	description "Guitar Hero 5 (USA)"
+	rom ( name "Guitar Hero 5 (USA).iso" size 4699979776 crc 8d238f7a md5 9f7b10b884741d0282fc36d490cb9484 sha1 da767c37db7c5326ce6b29cba002f93fa05f13b7 )
+)
+
+game (
+	name "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc 0448eff4 md5 e5d27cf0a25bef4c6c207a927b39c48e sha1 01dfdc438636ad885b3d766f8b6af053ab29045e )
+)
+
+game (
+	name "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Guitar Hero III - Legends of Rock (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc ac2b08ac md5 2bd1c76cb18e1df04eb9228a0e40f42d sha1 5ea4787a89b836766d6e610913cfc73e1af41fd6 )
+)
+
+game (
+	name "Guitar Hero III - Legends of Rock (USA) (v1.00)"
+	description "Guitar Hero III - Legends of Rock (USA) (v1.00)"
+	rom ( name "Guitar Hero III - Legends of Rock (USA) (v1.00).iso" size 4699979776 crc 798a4719 md5 eafd92008d4aef3cad199c26500bf44b sha1 851150480fdbaaa6b08f49c3163308e6cbfeb9cf )
+)
+
+game (
+	name "Guitar Hero III - Legends of Rock (USA) (v1.01)"
+	description "Guitar Hero III - Legends of Rock (USA) (v1.01)"
+	rom ( name "Guitar Hero III - Legends of Rock (USA) (v1.01).iso" size 4699979776 crc d9ebaa27 md5 ae0485bc39947250a25389c43ecbb336 sha1 7555e6064a43bad59aaed69997f4f3dd0dfdf23e )
+)
+
+game (
+	name "Guitar Hero World Tour (Europe) (En,Fr,De,Es,It)"
+	description "Guitar Hero World Tour (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Guitar Hero World Tour (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7dbe7979 md5 4a22d8641637301b4a51b21568bd94be sha1 cf366968d641e9b7b73cda556c78c71bad71b324 )
+)
+
+game (
+	name "Guitar Hero World Tour (USA) (En,Fr)"
+	description "Guitar Hero World Tour (USA) (En,Fr)"
+	rom ( name "Guitar Hero World Tour (USA) (En,Fr).iso" size 4699979776 crc 8e1168f7 md5 8cf66a908c14f4ae78d3d27fc7f148ae sha1 bf9182ade27e14bb3f7100d42724b7348c5a9d76 )
+)
+
+game (
+	name "Gunblade NY & L.A. Machineguns Arcade Hits Pack (Europe) (En,Fr,De,Es,It)"
+	description "Gunblade NY & L.A. Machineguns Arcade Hits Pack (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Gunblade NY & L.A. Machineguns Arcade Hits Pack (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7bff8798 md5 b1cca42fcb25154923bb003e0d64d2a2 sha1 707f1d88ae96942dde61814aa29c680de17932d8 )
+)
+
+game (
+	name "Gunblade NY & L.A. Machineguns Arcade Hits Pack (USA) (En,Fr,Es)"
+	description "Gunblade NY & L.A. Machineguns Arcade Hits Pack (USA) (En,Fr,Es)"
+	rom ( name "Gunblade NY & L.A. Machineguns Arcade Hits Pack (USA) (En,Fr,Es).iso" size 4699979776 crc 235fa5b2 md5 a54905790c36f204bee98faaf093a463 sha1 6f8e6c6a4d503a3873546009a8a42811aca11b64 )
+)
+
+game (
+	name "Hagane no Renkinjutsushi - Fullmetal Alchemist - Akatsuki no Ouji (Japan)"
+	description "Hagane no Renkinjutsushi - Fullmetal Alchemist - Akatsuki no Ouji (Japan)"
+	rom ( name "Hagane no Renkinjutsushi - Fullmetal Alchemist - Akatsuki no Ouji (Japan).iso" size 4699979776 crc f740aed4 md5 5eb624c62929f82e254180f48d61575e sha1 2d1be6922fd2cb745beebba282e177a2d74fef2b )
+)
+
+game (
+	name "Hajimete no Wii (Asia)"
+	description "Hajimete no Wii (Asia)"
+	rom ( name "Hajimete no Wii (Asia).iso" size 4699979776 crc beb77f1b md5 2d31671424372612d3e0f58aff37f13a sha1 114bb2b3d1cbea6655844a8e7076996e0b157d91 )
+)
+
+game (
+	name "Hajimete no Wii (Japan)"
+	description "Hajimete no Wii (Japan)"
+	rom ( name "Hajimete no Wii (Japan).iso" size 4699979776 crc b30898b3 md5 570ec18c26a72064c71270dec73a9786 sha1 5b588f71ba8d13c2cd88293db89154525c0aaa92 )
+)
+
+game (
+	name "Hannah Montana - The Movie (Europe)"
+	description "Hannah Montana - The Movie (Europe)"
+	rom ( name "Hannah Montana - The Movie (Europe).iso" size 4699979776 crc 9dc10d2c md5 81120c44531088b437194bb30b236818 sha1 9d7a4d29bbe17b305919988c87612ba582e43540 )
+)
+
+game (
+	name "Hannah Montana - The Movie (USA)"
+	description "Hannah Montana - The Movie (USA)"
+	rom ( name "Hannah Montana - The Movie (USA).iso" size 4699979776 crc 1bcd3281 md5 e212ae2d04fb6e4aba0639a1abd2c06c sha1 044cfcc62d238867f40c52d255d86aee9195faa8 )
+)
+
+game (
+	name "Harry Potter and the Deathly Hallows - Part 1 (Europe) (En,Fr,De,Es,It)"
+	description "Harry Potter and the Deathly Hallows - Part 1 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Harry Potter and the Deathly Hallows - Part 1 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e0cc39cb md5 2f13f000ea0d86eba0c0daaa1e7767e8 sha1 df01740792976a781c395a31c08d084a2c543b58 )
+)
+
+game (
+	name "Harry Potter and the Deathly Hallows - Part 1 (USA) (En,Fr,Es)"
+	description "Harry Potter and the Deathly Hallows - Part 1 (USA) (En,Fr,Es)"
+	rom ( name "Harry Potter and the Deathly Hallows - Part 1 (USA) (En,Fr,Es).iso" size 4699979776 crc 5cce03bb md5 15d12ce50780b23969f653f801385313 sha1 ae7282e7afd8240a9e97d3059b4fc88853f3476d )
+)
+
+game (
+	name "Harry Potter and the Deathly Hallows - Part 2 (Europe) (En,Fr,De,Es,It)"
+	description "Harry Potter and the Deathly Hallows - Part 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Harry Potter and the Deathly Hallows - Part 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0b6c3990 md5 870ce0ae7b1f447dfd7dd16fba9a1dd4 sha1 cfb15bae22a07600eb5ee889cc6ec4422d79ad49 )
+)
+
+game (
+	name "Harry Potter and the Deathly Hallows - Part 2 (USA) (En,Fr,Es)"
+	description "Harry Potter and the Deathly Hallows - Part 2 (USA) (En,Fr,Es)"
+	rom ( name "Harry Potter and the Deathly Hallows - Part 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 0ccb6de1 md5 fe5bd9b047289274ed2ae47cc3b020b3 sha1 80a2cc051407f351279b874172630b88c6863395 )
+)
+
+game (
+	name "Harry Potter and the Half-Blood Prince (USA) (En,Fr,Es)"
+	description "Harry Potter and the Half-Blood Prince (USA) (En,Fr,Es)"
+	rom ( name "Harry Potter and the Half-Blood Prince (USA) (En,Fr,Es).iso" size 4699979776 crc 10cff2c0 md5 c7d3877c2a53680122fe070536439c14 sha1 daabe265ffb20753fec7f13f013513795e26ece9 )
+)
+
+game (
+	name "Harry Potter and the Order of the Phoenix (USA)"
+	description "Harry Potter and the Order of the Phoenix (USA)"
+	rom ( name "Harry Potter and the Order of the Phoenix (USA).iso" size 4699979776 crc d3581c3f md5 40735f473b4e91d5662abcd6fa868c13 sha1 f424dbffaaa8cde022e8322efd2f1235204542fc )
+)
+
+game (
+	name "Harvest Moon - Animal Parade (Europe) (En,Fr,De,Es,It)"
+	description "Harvest Moon - Animal Parade (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Harvest Moon - Animal Parade (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4aeabf6f md5 5263000f4573c2233791ea4e96a4ff4f sha1 d4f1ebf91cb13994f5128e946ab90519da12bd74 )
+)
+
+game (
+	name "Harvest Moon - Animal Parade (USA)"
+	description "Harvest Moon - Animal Parade (USA)"
+	rom ( name "Harvest Moon - Animal Parade (USA).iso" size 4699979776 crc c18fd540 md5 982ac17f97f5a2635666f514d1aeea77 sha1 b323f3685863cfa34af3ba8cadfb86ba8859c260 )
+)
+
+game (
+	name "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It)"
+	description "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 407fedf2 md5 22d8bacaa8227ea2e1fc2ac830a48738 sha1 b9b5d710848a282f2ecaf4db83e876ff4cfb7125 )
+)
+
+game (
+	name "Harvest Moon - Tree of Tranquility (Europe) (En,Fr,De,Es,It)"
+	description "Harvest Moon - Tree of Tranquility (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Harvest Moon - Tree of Tranquility (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc dd3ae44e md5 08cf39fc5011b8fb9d09dc38112d2fd5 sha1 82d7b68e512e4b301e01aa3dff394697329ab6dd )
+)
+
+game (
+	name "Harvest Moon - Tree of Tranquility (USA) (v1.00)"
+	description "Harvest Moon - Tree of Tranquility (USA) (v1.00)"
+	rom ( name "Harvest Moon - Tree of Tranquility (USA) (v1.00).iso" size 4699979776 crc e9daf4ce md5 ae6a9993aabc4cffa5bcf883a5dd288e sha1 18bb79251149efb216d0fc9c0f5247e81aa4feff )
+)
+
+game (
+	name "Harvest Moon - Tree of Tranquility (USA) (v1.01)"
+	description "Harvest Moon - Tree of Tranquility (USA) (v1.01)"
+	rom ( name "Harvest Moon - Tree of Tranquility (USA) (v1.01).iso" size 4699979776 crc 64c3175e md5 b43de5a95756ee0365c10b52c8f668dd sha1 d7403ea2de355bd3c02ad943edb1df9ee71b1d10 )
+)
+
+game (
+	name "Harvey Birdman - Attorney at Law (USA)"
+	description "Harvey Birdman - Attorney at Law (USA)"
+	rom ( name "Harvey Birdman - Attorney at Law (USA).iso" size 4699979776 crc bef766c4 md5 252ba4516bcd12bc31445422254ac452 sha1 10328e55719414373efb39a215d91ca4aa0132ef )
+)
+
+game (
+	name "Hasbro Family Game Night (Europe) (En,Fr,De,Es,Nl)"
+	description "Hasbro Family Game Night (Europe) (En,Fr,De,Es,Nl)"
+	rom ( name "Hasbro Family Game Night (Europe) (En,Fr,De,Es,Nl).iso" size 4699979776 crc 5afbd1e3 md5 850e6dd156e03696ba9b2bd5d9ebfd6e sha1 77ec53e6440c27102208c69d1a76e6b253ecdc81 )
+)
+
+game (
+	name "Hasbro Family Game Night (USA) (En,Fr,Es)"
+	description "Hasbro Family Game Night (USA) (En,Fr,Es)"
+	rom ( name "Hasbro Family Game Night (USA) (En,Fr,Es).iso" size 4699979776 crc 610d87f0 md5 9a789aa3fc0198c070d45ba00a819298 sha1 4b26bbed1ef906570d2f1179d443c34080517b83 )
+)
+
+game (
+	name "Hasbro Family Game Night 2 (Europe) (En,Fr,De,Es,Nl)"
+	description "Hasbro Family Game Night 2 (Europe) (En,Fr,De,Es,Nl)"
+	rom ( name "Hasbro Family Game Night 2 (Europe) (En,Fr,De,Es,Nl).iso" size 4699979776 crc dee37886 md5 d8d3b5ccbafa70c4987bce4e291159c6 sha1 8ddf319b179c59a468672fd5c016b6f27ceb43c8 )
+)
+
+game (
+	name "Hasbro Family Game Night 2 (USA) (En,Fr,Es)"
+	description "Hasbro Family Game Night 2 (USA) (En,Fr,Es)"
+	rom ( name "Hasbro Family Game Night 2 (USA) (En,Fr,Es).iso" size 4699979776 crc a24909c8 md5 669e3267515a9aaa6c67ea97e6db2a68 sha1 76cf0810732e89d4b3b61daeb316ff8e80b5ff45 )
+)
+
+game (
+	name "Heatseeker (Europe) (En,Fr)"
+	description "Heatseeker (Europe) (En,Fr)"
+	rom ( name "Heatseeker (Europe) (En,Fr).iso" size 4699979776 crc 0fc669c4 md5 8cd1daa660e6d0379078a5058673c30e sha1 8519aaf236b9e0735021a5add8887ebc0f0b023c )
+)
+
+game (
+	name "Heatseeker (Europe) (Es,It)"
+	description "Heatseeker (Europe) (Es,It)"
+	rom ( name "Heatseeker (Europe) (Es,It).iso" size 4699979776 crc 4aa1eeb3 md5 d00fbef18e0500859ccd3567e43129d0 sha1 ddba1f93ebfbffd891f165f5e528512ec76055a0 )
+)
+
+game (
+	name "Heatseeker (USA)"
+	description "Heatseeker (USA)"
+	rom ( name "Heatseeker (USA).iso" size 4699979776 crc 4f152ab6 md5 78490e720eac02705c27f4d9e144a5ca sha1 9fbde9817b806917fd0c8ba39f7a2f6bc2780dc8 )
+)
+
+game (
+	name "Heavy Fire - Afghanistan (USA)"
+	description "Heavy Fire - Afghanistan (USA)"
+	rom ( name "Heavy Fire - Afghanistan (USA).iso" size 4699979776 crc b1e9ca94 md5 91021311aea10f97a28c2f0d901376af sha1 37e2fc6296bd0172cbb125ae5d780d3e82bd9208 )
+)
+
+game (
+	name "Hell's Kitchen - The Game (USA) (En,Fr,Es)"
+	description "Hell's Kitchen - The Game (USA) (En,Fr,Es)"
+	rom ( name "Hell's Kitchen - The Game (USA) (En,Fr,Es).iso" size 4699979776 crc cdd24f6e md5 4fc53c32c7ceee847a57cbd8d23fb62d sha1 d9ecce3ce38f6388c4cf35ebee6c3dd0bde766b0 )
+)
+
+game (
+	name "Help Wanted (USA) (En,Fr,Es)"
+	description "Help Wanted (USA) (En,Fr,Es)"
+	rom ( name "Help Wanted (USA) (En,Fr,Es).iso" size 4699979776 crc 77f00ad6 md5 172e47614a1f9caeba0eff25dd6d34c7 sha1 8685cd45815baefb5568e24953ecb712f94d9b56 )
+)
+
+game (
+	name "Hirano Aya Premium Movie Disc from Suzumiya Haruhi no Gekidou (Japan)"
+	description "Hirano Aya Premium Movie Disc from Suzumiya Haruhi no Gekidou (Japan)"
+	rom ( name "Hirano Aya Premium Movie Disc from Suzumiya Haruhi no Gekidou (Japan).iso" size 4699979776 crc f12b3c60 md5 3872140eff97c9261f5b1123c4b0075d sha1 733c0289521892e9953a235a780a5556f624954e )
+)
+
+game (
+	name "Hoshi no Kirby - 20 Shuunen Special Collection (Japan)"
+	description "Hoshi no Kirby - 20 Shuunen Special Collection (Japan)"
+	rom ( name "Hoshi no Kirby - 20 Shuunen Special Collection (Japan).iso" size 4699979776 crc fff04cb2 md5 44ca9f1187c63581c673c08f92113e86 sha1 6be3d068349b67b3da166826dd83051a502cd071 )
+)
+
+game (
+	name "Hot Wheels - Battle Force 5 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Hot Wheels - Battle Force 5 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Hot Wheels - Battle Force 5 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc b8c4c598 md5 d99f1bced1f5c80b7bb062b7ec1cb7cd sha1 43b2a43967976744d34e6fd6dc9936ef157e62ec )
+)
+
+game (
+	name "Hot Wheels - Beat That! (USA)"
+	description "Hot Wheels - Beat That! (USA)"
+	rom ( name "Hot Wheels - Beat That! (USA).iso" size 4699979776 crc 98a8a2f9 md5 80b623a4883c541c6bc7864007491388 sha1 913895bde0505a4230f3c98a2e46253bccff02a1 )
+)
+
+game (
+	name "House of the Dead 2 & 3 Return, The (Europe) (En,Ja,Fr,De,Es,It)"
+	description "House of the Dead 2 & 3 Return, The (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "House of the Dead 2 & 3 Return, The (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc e0417404 md5 e54b26d0780481362488ccc78f3a0f15 sha1 5a984331417852666f69b9d8b848c86440b6eaa2 )
+)
+
+game (
+	name "House of the Dead 2 & 3 Return, The (USA) (En,Fr,Es)"
+	description "House of the Dead 2 & 3 Return, The (USA) (En,Fr,Es)"
+	rom ( name "House of the Dead 2 & 3 Return, The (USA) (En,Fr,Es).iso" size 4699979776 crc 804280c2 md5 4b88e836aa6140d132557d26e418e1f6 sha1 95e7b687caf0a2a68d429f598b33f71736837ae4 )
+)
+
+game (
+	name "House of the Dead, The - Overkill (Europe) (En,Fr,Es,It)"
+	description "House of the Dead, The - Overkill (Europe) (En,Fr,Es,It)"
+	rom ( name "House of the Dead, The - Overkill (Europe) (En,Fr,Es,It).iso" size 4699979776 crc 59ef0ed6 md5 405ee54b6519303800165e436f922bcc sha1 6de3d2b14830ffc3f120f735431e2f32a3aa1c90 )
+)
+
+game (
+	name "House of the Dead, The - Overkill (Japan)"
+	description "House of the Dead, The - Overkill (Japan)"
+	rom ( name "House of the Dead, The - Overkill (Japan).iso" size 4699979776 crc c3e55313 md5 0e7154a474641be3a2e81e7331b540ae sha1 8b5bf2d9ae04d7d36fded10c691f04d504c4e0b9 )
+)
+
+game (
+	name "House of the Dead, The - Overkill (USA) (En,Fr,Es,It)"
+	description "House of the Dead, The - Overkill (USA) (En,Fr,Es,It)"
+	rom ( name "House of the Dead, The - Overkill (USA) (En,Fr,Es,It).iso" size 4699979776 crc 79a26ab2 md5 bc092d04e7ee32def5af8be1e7d98de6 sha1 53115d592e08e4f7c177d5335c031c33b2b00d7c )
+)
+
+game (
+	name "I Spy - Spooky Mansion (USA)"
+	description "I Spy - Spooky Mansion (USA)"
+	rom ( name "I Spy - Spooky Mansion (USA).iso" size 4699979776 crc bf30eb25 md5 9afddf45e0c0145c4b074aad0d3020b8 sha1 9ebfbee1badb4a33b3fc07dec5046a0340a2f47a )
+)
+
+game (
+	name "Ice Age - Dawn of the Dinosaurs (USA) (En,Fr)"
+	description "Ice Age - Dawn of the Dinosaurs (USA) (En,Fr)"
+	rom ( name "Ice Age - Dawn of the Dinosaurs (USA) (En,Fr).iso" size 4699979776 crc 5723019f md5 e2c95a018fa8cab6350309e24f4429dc sha1 0f4243a97948f05319a17075c8b45a4c85441b40 )
+)
+
+game (
+	name "Ice Age 2 - The Meltdown (USA)"
+	description "Ice Age 2 - The Meltdown (USA)"
+	rom ( name "Ice Age 2 - The Meltdown (USA).iso" size 4699979776 crc f04df98f md5 82872679fd1592663bd041aa4b29e116 sha1 902d71c95fa87d429e00b401dceb53c2637d8396 )
+)
+
+game (
+	name "Igor - The Game (Europe) (En,Fr,De,Es,It)"
+	description "Igor - The Game (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Igor - The Game (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 795cc56a md5 786836f80ba951db1fcc0aa68a67ada9 sha1 4e55c2b3c1bd289939f4f5855c5729d00649f80b )
+)
+
+game (
+	name "Imabikisou Kaimei-hen (Japan)"
+	description "Imabikisou Kaimei-hen (Japan)"
+	rom ( name "Imabikisou Kaimei-hen (Japan).iso" size 4699979776 crc 378453f4 md5 9a7ad3f147777b8ec0846c22bf78cc29 sha1 b2ee1b89c9301bda6b76531aacc9cadddd386cd3 )
+)
+
+game (
+	name "Inazuma Eleven Strikers (Europe) (En,Es,It)"
+	description "Inazuma Eleven Strikers (Europe) (En,Es,It)"
+	rom ( name "Inazuma Eleven Strikers (Europe) (En,Es,It).iso" size 4699979776 crc b29f2046 md5 15debf05a1bee86b1f05483b6ff79426 sha1 0bfffffe90eaa7f086f0d18fd10409ec83c2dc01 )
+)
+
+game (
+	name "Inazuma Eleven Strikers (Japan)"
+	description "Inazuma Eleven Strikers (Japan)"
+	rom ( name "Inazuma Eleven Strikers (Japan).iso" size 4699979776 crc 45606dee md5 d63f5fb95b6629c7c074eee1e61c6a45 sha1 0c7bd44017553816551828f9c28882fa6a984645 )
+)
+
+game (
+	name "Inazuma Eleven Strikers 2012 Xtreme (Japan)"
+	description "Inazuma Eleven Strikers 2012 Xtreme (Japan)"
+	rom ( name "Inazuma Eleven Strikers 2012 Xtreme (Japan).iso" size 4699979776 crc e5355615 md5 467852cfe56a8923511dfec0dc21c0ae sha1 74293c602c691735e0898005847322a65830eff7 )
+)
+
+game (
+	name "Incredible Hulk, The (USA) (En,Fr)"
+	description "Incredible Hulk, The (USA) (En,Fr)"
+	rom ( name "Incredible Hulk, The (USA) (En,Fr).iso" size 4699979776 crc 81fe4d56 md5 bdc0b9464145fd94f859ad3cb05b2bf6 sha1 35ec3951cd239182d774d94511d011200ff72e0f )
+)
+
+game (
+	name "Indiana Jones and the Staff of Kings (Europe) (En,Fr,De,Es,It)"
+	description "Indiana Jones and the Staff of Kings (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Indiana Jones and the Staff of Kings (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc bd463432 md5 8a8f1caa0ef612163ebe6560f0c26395 sha1 fc50bcf02bd1e03d1e2e005d954bc738b68e5f28 )
+)
+
+game (
+	name "Indiana Jones and the Staff of Kings (USA) (En,Fr,Es)"
+	description "Indiana Jones and the Staff of Kings (USA) (En,Fr,Es)"
+	rom ( name "Indiana Jones and the Staff of Kings (USA) (En,Fr,Es).iso" size 4699979776 crc 69d95c0e md5 16cea398ffa8ff6ef6d7f3d916271080 sha1 23cf8684c04f97c95151912a8fd8051b072376a4 )
+)
+
+game (
+	name "Iron Man (USA) (En,Fr,Es)"
+	description "Iron Man (USA) (En,Fr,Es)"
+	rom ( name "Iron Man (USA) (En,Fr,Es).iso" size 4699979776 crc 2d76a0b1 md5 1a8b6efe9554fd4bb2a98aa9bd1845db sha1 5d2c243f1d029897a26166a8ab63909c8a946e1e )
+)
+
+game (
+	name "Ivy the Kiwi (USA) (En,Fr,Es)"
+	description "Ivy the Kiwi (USA) (En,Fr,Es)"
+	rom ( name "Ivy the Kiwi (USA) (En,Fr,Es).iso" size 4699979776 crc eda99bc8 md5 c2bad81ac3168ef22b9aa59c168e4423 sha1 d601d80531899be0bee4cc5a5620182a87e17f5e )
+)
+
+game (
+	name "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
+	description "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
+	rom ( name "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi).iso" size 4699979776 crc 528d7a25 md5 a1be405079f67faf7b8799a857c897d0 sha1 8a0ea595460e4e06829e23064db01cb5a6511269 )
+)
+
+game (
+	name "James Cameron's Avatar - The Game (Europe) (En,Fr,De,Es,It)"
+	description "James Cameron's Avatar - The Game (Europe) (En,Fr,De,Es,It)"
+	rom ( name "James Cameron's Avatar - The Game (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6be218f5 md5 9510bdc63a05afc8b68e3fccb3113c7a sha1 1fded872f34f9af24b863f199aa6ea2e9e19b367 )
+)
+
+game (
+	name "James Cameron's Avatar - The Game (USA) (En,Fr,Es)"
+	description "James Cameron's Avatar - The Game (USA) (En,Fr,Es)"
+	rom ( name "James Cameron's Avatar - The Game (USA) (En,Fr,Es).iso" size 4699979776 crc 7ca3f11c md5 4e70c62b9987a13d8dc950ce85fbdeb4 sha1 56e202bbd569b5b77b1d268696647e8d887bf60d )
+)
+
+game (
+	name "Jelly Belly - Ballistic Beans (USA) (En,Fr,Es)"
+	description "Jelly Belly - Ballistic Beans (USA) (En,Fr,Es)"
+	rom ( name "Jelly Belly - Ballistic Beans (USA) (En,Fr,Es).iso" size 4699979776 crc 5b10c70d md5 3d99126fb82280ad0a60423ee66aa803 sha1 41b5e680a892078a946742e5692c3301c4d1e84a )
+)
+
+game (
+	name "Jerry Rice & Nitus' Dog Football (USA)"
+	description "Jerry Rice & Nitus' Dog Football (USA)"
+	rom ( name "Jerry Rice & Nitus' Dog Football (USA).iso" size 4699979776 crc 21c89063 md5 ef389123bb90c39352a0d66d960f4ad2 sha1 f94087201c3af6f98b09af333d3ad88ea6633f3c )
+)
+
+game (
+	name "Job Island (Europe) (En,Fr,De,Es,It)"
+	description "Job Island (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Job Island (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc acf49023 md5 e082906bf09bc658461fa86e4e8636e3 sha1 d6a001810d9107965305d5d307022e391d24ac11 )
+)
+
+game (
+	name "Jumper - Griffin's Story (Europe) (En,Fr,De,Es,It)"
+	description "Jumper - Griffin's Story (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Jumper - Griffin's Story (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6924cbb8 md5 90a137805117d1f197bcdf4ec88b7088 sha1 a0e10abd325d57498ada53e84cc714d22995538c )
+)
+
+game (
+	name "Jurassic - The Hunted (USA)"
+	description "Jurassic - The Hunted (USA)"
+	rom ( name "Jurassic - The Hunted (USA).iso" size 4699979776 crc 1b7d7dc0 md5 aec5c8f58f7311f10ca9ddf9600d3143 sha1 0f6f5c804154e22d21538ea09f3bb6d6cb5ce156 )
+)
+
+game (
+	name "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl)"
+	description "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl)"
+	rom ( name "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl).iso" size 4699979776 crc 28562a9a md5 2a90121a4a9ae51f0ad8675c86b096a4 sha1 9e4e25b44795d50bde0e38a5eafbbec0f1046824 )
+)
+
+game (
+	name "Just Dance - Greatest Hits (USA) (En,Fr,Es)"
+	description "Just Dance - Greatest Hits (USA) (En,Fr,Es)"
+	rom ( name "Just Dance - Greatest Hits (USA) (En,Fr,Es).iso" size 4699979776 crc 2016edc0 md5 d00435c77f9ee5e71bfede9e4af91ab9 sha1 7016a71bb2b32ecd4f0d078da35904ce8ccd5e86 )
+)
+
+game (
+	name "Just Dance - Summer Party (USA)"
+	description "Just Dance - Summer Party (USA)"
+	rom ( name "Just Dance - Summer Party (USA).iso" size 4699979776 crc 4d000679 md5 0bc9096371d9ba3850ffa59cd5198190 sha1 c96bc7ced56e3e4bbb7866c21ac489505a5e5357 )
+)
+
+game (
+	name "Just Dance 2 (Europe) (En,Fr,De,Es,It)"
+	description "Just Dance 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Just Dance 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 158c8fbc md5 ce3f60efede73455c66afbe6a2bd4413 sha1 6f4a3a0e4771ecd62368b94e886dcfba5f2efc2c )
+)
+
+game (
+	name "Just Dance 2014 (USA)"
+	description "Just Dance 2014 (USA)"
+	rom ( name "Just Dance 2014 (USA).iso" size 4699979776 crc 1fe94c32 md5 64d469178d925d5b79ae26f7289d165b sha1 5200b41d771c3f5f71fdf45752e27d44d3cffb64 )
+)
+
+game (
+	name "Just Dance 2015 (USA)"
+	description "Just Dance 2015 (USA)"
+	rom ( name "Just Dance 2015 (USA).iso" size 4699979776 crc ada3ce0e md5 6142795d6f0700963b9754ca59c92d90 sha1 af98bcd15d31a7a1b8ac1982b0d490e422b455dc )
+)
+
+game (
+	name "Just Dance 2016 (USA)"
+	description "Just Dance 2016 (USA)"
+	rom ( name "Just Dance 2016 (USA).iso" size 4699979776 crc 350cdaca md5 8041c2a5ad9465cb5fac6657514e3ea2 sha1 881ae88bda44a71835b8817eba70fd268345063c )
+)
+
+game (
+	name "Just Dance 3 (USA) (En,Fr,Es)"
+	description "Just Dance 3 (USA) (En,Fr,Es)"
+	rom ( name "Just Dance 3 (USA) (En,Fr,Es).iso" size 4699979776 crc f49d9aab md5 e46877c360dcbb6cc8c5814762b424a3 sha1 19f0913f06d7f82098b2d607e1ff61d0fd5f6059 )
+)
+
+game (
+	name "Just Dance 4 (USA) (En,Fr,Es)"
+	description "Just Dance 4 (USA) (En,Fr,Es)"
+	rom ( name "Just Dance 4 (USA) (En,Fr,Es).iso" size 4699979776 crc 5a1ee1ba md5 cfa93ad1209bd9dd61cf9df3d9b6adc4 sha1 f656364f82fbdb0e75546f5eff4f6c0c38e3974f )
+)
+
+game (
+	name "Just Dance Kids 2 (USA) (En,Fr,Es)"
+	description "Just Dance Kids 2 (USA) (En,Fr,Es)"
+	rom ( name "Just Dance Kids 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 9f1955f6 md5 125a3f6214022f19f423d405b9f6bfb0 sha1 a208dc171d6e0d76cc57538bea976b961805d0fc )
+)
+
+game (
+	name "Just Dance Wii (Japan)"
+	description "Just Dance Wii (Japan)"
+	rom ( name "Just Dance Wii (Japan).iso" size 4699979776 crc 62a8e250 md5 455dcba92fba6ecc9c269c28c928eaab sha1 cb2d2c7c19a011ed2d3305a4fac2d931f78cb2c4 )
+)
+
+game (
+	name "Kage no Tou (Japan)"
+	description "Kage no Tou (Japan)"
+	rom ( name "Kage no Tou (Japan).iso" size 4699979776 crc f817c6ee md5 9895ea282c824d0cd71f83b41894b4fc sha1 84318b312fa6138e106da3661154716fb906ba0c )
+)
+
+game (
+	name "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan)"
+	description "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan)"
+	rom ( name "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan).iso" size 4699979776 crc f3c968e5 md5 c206d934c5898eee1d034fb70821d1a2 sha1 24158d2a812bc8e4052bd7e4bd1c9d8fc4628e24 )
+)
+
+game (
+	name "Kawasaki Jet Ski (USA)"
+	description "Kawasaki Jet Ski (USA)"
+	rom ( name "Kawasaki Jet Ski (USA).iso" size 4699979776 crc b5b1eea2 md5 2c29beea005ce08a697757c6c787a930 sha1 2899dab60c01cf4ef0b264c1cf837abf93452212 )
+)
+
+game (
+	name "Kawasaki Quad Bikes (USA)"
+	description "Kawasaki Quad Bikes (USA)"
+	rom ( name "Kawasaki Quad Bikes (USA).iso" size 4699979776 crc 50d0f473 md5 0270b6930b37c36be1c4b5ba1fd7e8e3 sha1 118fc806eb080da6ec0345c93e13c5c7bf83870d )
+)
+
+game (
+	name "Keito no Kirby (Japan)"
+	description "Keito no Kirby (Japan)"
+	rom ( name "Keito no Kirby (Japan).iso" size 4699979776 crc 00344f55 md5 7e63aa8485c82012f791616d723f9cfc sha1 429babe94d5cac138b8440fc79236326c3663ca5 )
+)
+
+game (
+	name "Kidz Sports Basketball (Europe)"
+	description "Kidz Sports Basketball (Europe)"
+	rom ( name "Kidz Sports Basketball (Europe).iso" size 4699979776 crc 69d6f1f0 md5 b3d775f4882dab7742063eeb9520cec8 sha1 6bb92d530a214006213aaa694c21bebb73c5ded8 )
+)
+
+game (
+	name "Kidz Sports Basketball (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Kidz Sports Basketball (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Kidz Sports Basketball (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc f4fb7ca9 md5 0bd6a9596f7fb41c2321c29d1cd6b0d6 sha1 d69e9a06d532ef712e6ccde82ec82362d4e8abc4 )
+)
+
+game (
+	name "King of Clubs (Europe) (En,Fr,De,Es,It)"
+	description "King of Clubs (Europe) (En,Fr,De,Es,It)"
+	rom ( name "King of Clubs (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3bde08fc md5 8ea386cd3b59215edec8b17031aa7d59 sha1 9ba21b7d8773173c38ceffb9a6673f38f31c76da )
+)
+
+game (
+	name "King of Fighters Collection, The - The Orochi Saga (Europe)"
+	description "King of Fighters Collection, The - The Orochi Saga (Europe)"
+	rom ( name "King of Fighters Collection, The - The Orochi Saga (Europe).iso" size 4699979776 crc 57ad182e md5 646fe054f4e39bf8c4754c846d18f2a8 sha1 75f29cef20f1240bdf15ef16e55e5b64dea4825d )
+)
+
+game (
+	name "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It)"
+	description "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ed20d6cd md5 3e7e59cf9507ff5f7fb1fe536a730459 sha1 e09cf8cd58a05f0f7c0d6f0b8e4917c73f8f8021 )
+)
+
+game (
+	name "Kirby's Dream Collection - Special Edition (USA)"
+	description "Kirby's Dream Collection - Special Edition (USA)"
+	rom ( name "Kirby's Dream Collection - Special Edition (USA).iso" size 4699979776 crc 780fdad9 md5 2f584b2a7ea6b20ebd0c61a811db8248 sha1 598ec9e2a29ae82ed04a4a4c0c261fb80c3f82e5 )
+)
+
+game (
+	name "Kirby's Epic Yarn (Europe) (En,Fr,De,Es,It)"
+	description "Kirby's Epic Yarn (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kirby's Epic Yarn (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 88e2f649 md5 8aeef7bc4b90bf45209a8f88fbdf9465 sha1 547aa7ca4d045594237154814786306f7645551f )
+)
+
+game (
+	name "Kirby's Epic Yarn (USA) (En,Fr,Es)"
+	description "Kirby's Epic Yarn (USA) (En,Fr,Es)"
+	rom ( name "Kirby's Epic Yarn (USA) (En,Fr,Es).iso" size 4699979776 crc eb41477e md5 acdbd566baf471a45a53c8d8c93539a4 sha1 934683f734412386042060f7036d5f3db20cb53f )
+)
+
+game (
+	name "Kirby's Return to Dream Land (USA) (En,Fr,Es)"
+	description "Kirby's Return to Dream Land (USA) (En,Fr,Es)"
+	rom ( name "Kirby's Return to Dream Land (USA) (En,Fr,Es).iso" size 4699979776 crc ae51ec85 md5 dade208216bd03a370e8217439bedbd8 sha1 d7adcdc8e3fe7f164eb95f53094974fc31e76ccb )
+)
+
+game (
+	name "Klonoa (Europe) (En,Fr,De,Es,It)"
+	description "Klonoa (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Klonoa (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5258a666 md5 82eb5ad197217f9830496bd4f4b35863 sha1 def988727ce83c30b251fa9b7079a6cbf425b3c8 )
+)
+
+game (
+	name "Klonoa (USA) (En,Fr,Es)"
+	description "Klonoa (USA) (En,Fr,Es)"
+	rom ( name "Klonoa (USA) (En,Fr,Es).iso" size 4699979776 crc e58dfea0 md5 0f6608247c6f96de6dbd33d04e979033 sha1 9f1546fdcc0c548528c9d74cf58fc4dd990a28ae )
+)
+
+game (
+	name "Knockout Party (Europe)"
+	description "Knockout Party (Europe)"
+	rom ( name "Knockout Party (Europe).iso" size 4699979776 crc 4751f875 md5 ce1c91be9e6c7dc8f78f5983444108ce sha1 30a6d1c31ab2ac6c3e8d7601bde388d2ae3e0dec )
+)
+
+game (
+	name "Kore Gang, The (Europe) (En,Fr,De,Es)"
+	description "Kore Gang, The (Europe) (En,Fr,De,Es)"
+	rom ( name "Kore Gang, The (Europe) (En,Fr,De,Es).iso" size 4699979776 crc 465ae01c md5 e60916573b6e06d88cc92f11531133f4 sha1 80b286c99ecc7093bce2798623ff8fe88bcbeb08 )
+)
+
+game (
+	name "Kore Gang, The (USA) (En,Fr,Es)"
+	description "Kore Gang, The (USA) (En,Fr,Es)"
+	rom ( name "Kore Gang, The (USA) (En,Fr,Es).iso" size 4699979776 crc 42cd18f7 md5 668bc10715aca75a2b7021fb99600809 sha1 04560c10bfaf3375c46309ce39d850aec0520095 )
+)
+
+game (
+	name "Kororinpa - Marble Mania (USA)"
+	description "Kororinpa - Marble Mania (USA)"
+	rom ( name "Kororinpa - Marble Mania (USA).iso" size 4699979776 crc 0caea4a9 md5 7697a6d5212b672845e6baa15d09fbc7 sha1 9c81ddd62396aad0cb2552d64fb0ac5d822ce571 )
+)
+
+game (
+	name "Kororinpa (Europe) (En,Fr,De,Es,It)"
+	description "Kororinpa (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Kororinpa (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a09911b4 md5 c778a9ed02f8ed1f8cb36fbb35a9a501 sha1 288671ae7cc52e171cc6116c2455abf74646b7fc )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Anniversary (Europe) (En,Fr,De,Es,It)"
+	description "Lara Croft Tomb Raider - Anniversary (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Lara Croft Tomb Raider - Anniversary (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 184e1216 md5 87f556045ccf9589c57ea862260d1fa7 sha1 647fe68c1b3626b6c2866af788e4b9dd7ded1f2b )
+)
+
+game (
+	name "Lara Croft Tomb Raider - Anniversary (USA) (En,Fr,Es)"
+	description "Lara Croft Tomb Raider - Anniversary (USA) (En,Fr,Es)"
+	rom ( name "Lara Croft Tomb Raider - Anniversary (USA) (En,Fr,Es).iso" size 4699979776 crc fa8bafc6 md5 297d9d0b0144b442f213bacbee8eb7cc sha1 69346332a97c318fba74f12f7d5af4fcac78f227 )
+)
+
+game (
+	name "Last Story, The (Europe) (En,Fr,De,Es,It)"
+	description "Last Story, The (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Last Story, The (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc aaf574d4 md5 a85b1f8b40860789fc3a6649d5231819 sha1 37e97fbbac7716fdc25b7d4ecee40042aaa242d9 )
+)
+
+game (
+	name "Last Story, The (Japan)"
+	description "Last Story, The (Japan)"
+	rom ( name "Last Story, The (Japan).iso" size 4699979776 crc 57ac40ee md5 09fed88298502515cb5d7c8ab5294b31 sha1 fb30df3a599754c6cc36c24a8572de9566c57c14 )
+)
+
+game (
+	name "Last Story, The (USA) (En,Fr,Es)"
+	description "Last Story, The (USA) (En,Fr,Es)"
+	rom ( name "Last Story, The (USA) (En,Fr,Es).iso" size 8511160320 crc 930b68b4 md5 8f6ae9291453ba7f049f22529c3d7004 sha1 8695d6224896a7323cc79f11e7d78dc4b9edcf43 )
+)
+
+game (
+	name "Legend of Spyro, The - Dawn of the Dragon (USA) (En,Fr,Es)"
+	description "Legend of Spyro, The - Dawn of the Dragon (USA) (En,Fr,Es)"
+	rom ( name "Legend of Spyro, The - Dawn of the Dragon (USA) (En,Fr,Es).iso" size 4699979776 crc f2fc1851 md5 ac19b11ca5d0e420d71bbcdce226e770 sha1 01be3d2896879d0d6603879e4e064632734c66a7 )
+)
+
+game (
+	name "Legend of Spyro, The - The Eternal Night (USA)"
+	description "Legend of Spyro, The - The Eternal Night (USA)"
+	rom ( name "Legend of Spyro, The - The Eternal Night (USA).iso" size 4699979776 crc ab07b47c md5 3a2bc8fd7456ae3cc4a3ff89ce259f2e sha1 b6465e92cc92db32794e50c331ed8f462d584068 )
+)
+
+game (
+	name "Legend of the Dragon (Europe) (En,Fr,De,Es,It)"
+	description "Legend of the Dragon (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of the Dragon (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1b04bedb md5 60bae2ce0f114ff1db4934fb3d55295a sha1 19ea560e209bb0bb37a03c1cb50b08193c79d4bf )
+)
+
+game (
+	name "Legend of the Guardians - The Owls of Ga'Hoole (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Legend of the Guardians - The Owls of Ga'Hoole (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Legend of the Guardians - The Owls of Ga'Hoole (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 21a7be4b md5 1f8db4d7048155ce734a41be8619781d sha1 963c2c2f934cc306ea31ea795b7a67988f36914e )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc d7ac6bdd md5 f32bd185cb71ec9d87d2a65c9385d3d8 sha1 6e2dd566757adfd970e24e2da3cec81fedd4087b )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 96e2705b md5 ea5745a17a1a4e999b5443be839a5c6f sha1 110c5dff4a54a961bea8237ac03d4e59c167bca6 )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (Korea)"
+	description "Legend of Zelda, The - Skyward Sword (Korea)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (Korea).iso" size 4699979776 crc 720f39a5 md5 8dd4066b3b05746eea03f8209f013b3f sha1 7034f140ab34bb03c52998b85fbc19f5c71c0b75 )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.00)"
+	description "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 2b48d050 md5 e7c39bb46cf938a5a030a01a677ef7d1 sha1 9cf9a4a7ed2a6a4abb4582e3304af1327c160640 )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.01)"
+	description "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc d5cad9b0 md5 9c802c4c92f7425339c0515c0bb3d455 sha1 9abe26cb43e234fdeb23955fcb95801e617c4649 )
+)
+
+game (
+	name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.02)"
+	description "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.02)"
+	rom ( name "Legend of Zelda, The - Skyward Sword (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 4f090549 md5 89387d670395b2a2c32f77f167763115 sha1 a60435a2f929a0026aa1038aab6197b7a74ad8fd )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It)"
+	description "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 576d9391 md5 c46c133885383f96e7515c5cefd152d2 sha1 c708744c08d499962ad5760ab1b76748dea9914b )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (Korea)"
+	description "Legend of Zelda, The - Twilight Princess (Korea)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (Korea).iso" size 4699979776 crc 40cb5b42 md5 fa5021cd3df8648646ddfcf3d901109a sha1 d071aaa6445cdd83950f4ee2b82030ab3c30c9dc )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (USA) (Demo)"
+	description "Legend of Zelda, The - Twilight Princess (USA) (Demo)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (Demo).iso" size 4699979776 crc d6b7555e md5 810c1f6141d64723362123dad17fa6cd sha1 d0efe717a6c4b99e42d43f86fa90d75489d443d7 )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02)"
+	description "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc b5825844 md5 70946e09da8f0bb218bb3b3542953d63 sha1 e9f9b22fee0d1e3be46fa01b7189d390f51c7f87 )
+)
+
+game (
+	name "Legend of Zelda, The - Twilight Princess (USA) (v1.00)"
+	description "Legend of Zelda, The - Twilight Princess (USA) (v1.00)"
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (v1.00).iso" size 4699979776 crc a1bc9066 md5 25003a3e3666edf79c99080be9083b34 sha1 e45f35bef5a5949539ac3cabfc231e97ee9343cf )
+)
+
+game (
+	name "LEGO Batman - The Videogame (Europe) (En,Fr,De,Es,It,Da)"
+	description "LEGO Batman - The Videogame (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "LEGO Batman - The Videogame (Europe) (En,Fr,De,Es,It,Da).iso" size 4699979776 crc f12bf428 md5 20ff35cde0ec1955bfc03e2a69cff355 sha1 f22805ef410fc06d5e11b8f53971c6a02d7d1016 )
+)
+
+game (
+	name "LEGO Batman - The Videogame (USA) (En,Fr,Es)"
+	description "LEGO Batman - The Videogame (USA) (En,Fr,Es)"
+	rom ( name "LEGO Batman - The Videogame (USA) (En,Fr,Es).iso" size 4699979776 crc 0994f546 md5 801d9722e4d61df0fdd9f35a9a5d91f7 sha1 4839d37135944c1ac9baa8a7800666896f2414a0 )
+)
+
+game (
+	name "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt)"
+	description "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt)"
+	rom ( name "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 855a352f md5 3ffc5c4f2fd821be9a68df20efc10478 sha1 7e32f47ad712ed3ff413318e4457aaa1787dcd99 )
+)
+
+game (
+	name "LEGO Harry Potter - Years 1-4 (Europe) (En,Fr,De,Es,It,Da)"
+	description "LEGO Harry Potter - Years 1-4 (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "LEGO Harry Potter - Years 1-4 (Europe) (En,Fr,De,Es,It,Da).iso" size 4699979776 crc 085009bb md5 703717a88c5a21153ce5c4cb46486761 sha1 17562b53951047aa77424b554b6abe7526ef3f13 )
+)
+
+game (
+	name "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.00)"
+	description "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc def27fce md5 115fa3d0f4f62d2222c50dcdbd8c6274 sha1 5207c5ac8b132a266a916e7f80bcb048c8cad7fc )
+)
+
+game (
+	name "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.01)"
+	description "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "LEGO Harry Potter - Years 1-4 (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 7edf0ce6 md5 c1386d28d8481670aaf066eadb3d73c4 sha1 6dbdd4b1a9f7ca975d4e06050ba2a070843e7704 )
+)
+
+game (
+	name "LEGO Harry Potter - Years 5-7 (Europe) (En,Fr,De,Es,It,Nl,Da)"
+	description "LEGO Harry Potter - Years 5-7 (Europe) (En,Fr,De,Es,It,Nl,Da)"
+	rom ( name "LEGO Harry Potter - Years 5-7 (Europe) (En,Fr,De,Es,It,Nl,Da).iso" size 4699979776 crc 3842de54 md5 49af9c27a5fdd078936eee4011f2d473 sha1 b5c7ebdf7ea3d3ef2d356881d94da21b57facc7e )
+)
+
+game (
+	name "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.00)"
+	description "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.00)"
+	rom ( name "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.00).iso" size 4699979776 crc 4b0b58d5 md5 99d74c00a825a93e1961dc067f2de825 sha1 fa24a948a63584801059c4a4206f433a4a9b325e )
+)
+
+game (
+	name "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.01)"
+	description "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.01)"
+	rom ( name "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt) (v1.01).iso" size 4699979776 crc 4f51eaeb md5 768a723daba592ebfe2c4e31a87ec462 sha1 4a19147dc383ec1f4589d937dec2a1c2c40a7b3e )
+)
+
+game (
+	name "LEGO Indiana Jones - The Original Adventures (Europe) (En,Fr,De,Es,It)"
+	description "LEGO Indiana Jones - The Original Adventures (Europe) (En,Fr,De,Es,It)"
+	rom ( name "LEGO Indiana Jones - The Original Adventures (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7f5207e7 md5 aaefe15afe2b1446d6e4a1f24bd1e416 sha1 083fc70b9b341ec3e5fb51e6e7e1447517e8c381 )
+)
+
+game (
+	name "LEGO Indiana Jones - The Original Adventures (USA) (En,Fr,Es)"
+	description "LEGO Indiana Jones - The Original Adventures (USA) (En,Fr,Es)"
+	rom ( name "LEGO Indiana Jones - The Original Adventures (USA) (En,Fr,Es).iso" size 4699979776 crc 0c1b363f md5 d055f4e3e52a53424becf994ede70e08 sha1 6f1c22276e6f709dfcc2ffabc5f8a382fef8db44 )
+)
+
+game (
+	name "LEGO Indiana Jones 2 - The Adventure Continues (Europe) (En,Fr,De,Es,It,Da)"
+	description "LEGO Indiana Jones 2 - The Adventure Continues (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "LEGO Indiana Jones 2 - The Adventure Continues (Europe) (En,Fr,De,Es,It,Da).iso" size 4699979776 crc 44ad7639 md5 597fcff0e23349544c38f467e2e27004 sha1 721761665885e52727d59b526637ab40df7efa05 )
+)
+
+game (
+	name "LEGO Indiana Jones 2 - The Adventure Continues (USA) (En,Fr,Es)"
+	description "LEGO Indiana Jones 2 - The Adventure Continues (USA) (En,Fr,Es)"
+	rom ( name "LEGO Indiana Jones 2 - The Adventure Continues (USA) (En,Fr,Es).iso" size 4699979776 crc bbe5a6bd md5 2b98339b812058dc1344bb6c7eec9e53 sha1 3baae0289753c7e2346806df5d2788f679ce0f9f )
+)
+
+game (
+	name "LEGO Pirates of the Caribbean - The Video Game (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	description "LEGO Pirates of the Caribbean - The Video Game (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	rom ( name "LEGO Pirates of the Caribbean - The Video Game (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da).iso" size 4699979776 crc 4665f34d md5 719e1a40ca70a3c05febc3f3eb3d96c2 sha1 bebf54d1e3b604d71c9588a6c484f2dc6ded8633 )
+)
+
+game (
+	name "LEGO Pirates of the Caribbean - The Video Game (USA) (En,Fr,Es)"
+	description "LEGO Pirates of the Caribbean - The Video Game (USA) (En,Fr,Es)"
+	rom ( name "LEGO Pirates of the Caribbean - The Video Game (USA) (En,Fr,Es).iso" size 4699979776 crc 52392e77 md5 09853bc340760fd65c02b67259c725d8 sha1 43fb36ae138ceff50c702226c3895ebc6491c692 )
+)
+
+game (
+	name "LEGO Rock Band (Europe) (En,Fr,De,Es,It)"
+	description "LEGO Rock Band (Europe) (En,Fr,De,Es,It)"
+	rom ( name "LEGO Rock Band (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc aa760894 md5 887c8d83dcec845b959e92c1d41f383c sha1 de5b29ee1e54e58bb3bdc51e657c684ce6d65045 )
+)
+
+game (
+	name "LEGO Rock Band (USA) (En,Fr,Es)"
+	description "LEGO Rock Band (USA) (En,Fr,Es)"
+	rom ( name "LEGO Rock Band (USA) (En,Fr,Es).iso" size 4699979776 crc cb2dfd36 md5 73482b1e5c15da7f38a988d238fa42bd sha1 9e8c6f2cfb68d276194d8d02419ed1df5ce25d14 )
+)
+
+game (
+	name "LEGO Star Wars - The Complete Saga (Europe) (En,Da)"
+	description "LEGO Star Wars - The Complete Saga (Europe) (En,Da)"
+	rom ( name "LEGO Star Wars - The Complete Saga (Europe) (En,Da).iso" size 4699979776 crc a9aa9858 md5 1e8b4d81c119628f22fa7bd70767b74d sha1 10f4bc81b7c262abe8c9020d7ef62e66e1a8cb6d )
+)
+
+game (
+	name "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.00)"
+	description "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 8cb52573 md5 16789a916e0f6908356fcda74540faec sha1 abbf2d8be682ec81877371a2bba13e02d74aa140 )
+)
+
+game (
+	name "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.01)"
+	description "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "LEGO Star Wars - The Complete Saga (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 7b91ed0a md5 512cb5d1ecfccf15019be9685c6b2fbf sha1 413606e38834e7599c26f91ce1c4da926e8f8f20 )
+)
+
+game (
+	name "LEGO Star Wars III - The Clone Wars (Europe) (En,Fr,De,Es,It,Da)"
+	description "LEGO Star Wars III - The Clone Wars (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "LEGO Star Wars III - The Clone Wars (Europe) (En,Fr,De,Es,It,Da).iso" size 4699979776 crc 616d9fea md5 3782d62d67d8a8ca4b304576d12c2403 sha1 70a108b66af10865ca496d60ef77f4ecf05ec209 )
+)
+
+game (
+	name "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.00)"
+	description "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 84f1c9a4 md5 73581920d2137a6c379ec2406a88773e sha1 90dcdc0dd57878127abe42fb04f6dfaed1182ef9 )
+)
+
+game (
+	name "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.01)"
+	description "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc b9ac9e5a md5 ad9139b53ff3a6f254660269f3a6efcd sha1 ddcd1636f9691d4243560a0a3c05f9e8661c03d4 )
+)
+
+game (
+	name "LEGO The Lord of the Rings (Europe) (En,Fr,De,Es,It,Nl,Da)"
+	description "LEGO The Lord of the Rings (Europe) (En,Fr,De,Es,It,Nl,Da)"
+	rom ( name "LEGO The Lord of the Rings (Europe) (En,Fr,De,Es,It,Nl,Da).iso" size 4699979776 crc f2d7a3c3 md5 ce65f1255c0e901cb2be00244a33e371 sha1 e687887ad91620b613413d2b57901f3980ea6532 )
+)
+
+game (
+	name "LEGO The Lord of the Rings (USA) (En,Fr,Es,Pt)"
+	description "LEGO The Lord of the Rings (USA) (En,Fr,Es,Pt)"
+	rom ( name "LEGO The Lord of the Rings (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 5bd81509 md5 8199c0d508f6a3a9513e81b00331bd67 sha1 72aa0a196825ac524c5da7e55b56f9fc06a360e8 )
+)
+
+game (
+	name "Let's Tap (Europe) (En,Fr,De,Es,It)"
+	description "Let's Tap (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Let's Tap (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f9a81e57 md5 e5a623eb44a307dad99f7f6c4f1130ff sha1 30dea45cd0fc5db699e1330d58c7a01c46f70ada )
+)
+
+game (
+	name "Line Rider Freestyle (Europe) (En,Fr,De,Es,It)"
+	description "Line Rider Freestyle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Line Rider Freestyle (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d6cd2710 md5 c4b829a212e5ac1dab284d69ade1afc8 sha1 91393e521d10187b1ac50fc0955a1f6bcfba25c0 )
+)
+
+game (
+	name "Link no Bowgun Training (Japan)"
+	description "Link no Bowgun Training (Japan)"
+	rom ( name "Link no Bowgun Training (Japan).iso" size 4699979776 crc 15ba8da1 md5 6db2c6a6980a67dc9c1823f1accf5c2f sha1 988b855fd303c18e498eb72ad8bb858ae8984363 )
+)
+
+game (
+	name "Link's Crossbow Training (Europe) (En,Fr,De,Es,It)"
+	description "Link's Crossbow Training (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Link's Crossbow Training (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 80a94fd8 md5 394402b3950749f4ff37706ac8bf2879 sha1 0c38143c3d35e9e22b83ca8c386ddc852bb88193 )
+)
+
+game (
+	name "Link's Crossbow Training (USA) (En,Fr,Es) (v1.00)"
+	description "Link's Crossbow Training (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Link's Crossbow Training (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc a165f04c md5 ead23ad9a9a63133ed22efc6dc4cdcf2 sha1 00e2864a93e17883c739e0f5affd3b9bc7b12782 )
+)
+
+game (
+	name "Link's Crossbow Training (USA) (En,Fr,Es) (v1.01)"
+	description "Link's Crossbow Training (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Link's Crossbow Training (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 98d41086 md5 eb15265dc42a5963b1a581aa4f09ed90 sha1 80ad2d15078bce3e41dcb0b6e57825824dba390e )
+)
+
+game (
+	name "Linkui Sagyeok Training (Korea)"
+	description "Linkui Sagyeok Training (Korea)"
+	rom ( name "Linkui Sagyeok Training (Korea).iso" size 4699979776 crc a472d156 md5 3db1f95748c98253cdd4bc016577ec76 sha1 f2311694157777f8c0c30c53c38da5fc61254d8b )
+)
+
+game (
+	name "Little King's Story (Europe) (En,Fr,De,Es,It)"
+	description "Little King's Story (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Little King's Story (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 73c72bb9 md5 3bfb9dddf056787e971016a67845e629 sha1 c7b72ed6424ee337fcf1970b7df71248821a358f )
+)
+
+game (
+	name "Little King's Story (USA) (En,Fr,Es)"
+	description "Little King's Story (USA) (En,Fr,Es)"
+	rom ( name "Little King's Story (USA) (En,Fr,Es).iso" size 4699979776 crc 4c3ba3c6 md5 17d17adcbe65a5c26e868b55be26234c sha1 59ea4417c87c166ec04b9aedf1aedc443ef8076e )
+)
+
+game (
+	name "London Taxi Rushour (USA)"
+	description "London Taxi Rushour (USA)"
+	rom ( name "London Taxi Rushour (USA).iso" size 4699979776 crc cb1ae185 md5 28d0c2f4b47e1acfa5f2b5bc5168fb94 sha1 85260ba3ec67c8460f0c667d024594ce898819ac )
+)
+
+game (
+	name "Lord of the Rings, The - Aragorn's Quest (USA) (En,Fr,Es)"
+	description "Lord of the Rings, The - Aragorn's Quest (USA) (En,Fr,Es)"
+	rom ( name "Lord of the Rings, The - Aragorn's Quest (USA) (En,Fr,Es).iso" size 4699979776 crc 0651157e md5 4e1627ae1d2515138bc74c903609de2a sha1 f38d56c41efaee488b96619a31c941612b567122 )
+)
+
+game (
+	name "Lost in Shadow (USA) (En,Fr,Es)"
+	description "Lost in Shadow (USA) (En,Fr,Es)"
+	rom ( name "Lost in Shadow (USA) (En,Fr,Es).iso" size 4699979776 crc e41530a6 md5 c120da26b63b97b6fe6776243b772d8d sha1 0b59c2917a1ef78ad4e4726a25613c1ebb6720e2 )
+)
+
+game (
+	name "Machi e Ikouyo - Doubutsu no Mori (Japan)"
+	description "Machi e Ikouyo - Doubutsu no Mori (Japan)"
+	rom ( name "Machi e Ikouyo - Doubutsu no Mori (Japan).iso" size 4699979776 crc 337c2aef md5 eb03eb3bc9491609e6273de76f59d2ee sha1 b4fd78369c25314a445390970a3db0d34ba48d94 )
+)
+
+game (
+	name "Mad Dog McCree - Gunslinger Pack (Europe) (En,Fr,De,Es,It)"
+	description "Mad Dog McCree - Gunslinger Pack (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mad Dog McCree - Gunslinger Pack (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6354e20c md5 ff51be19dd62a399dc01c0a1f463ef2b sha1 d5f8316c6e370b342d0d9773c8d7fdc283f734e7 )
+)
+
+game (
+	name "Mad Dog McCree - Gunslinger Pack (USA) (En,Fr,Es)"
+	description "Mad Dog McCree - Gunslinger Pack (USA) (En,Fr,Es)"
+	rom ( name "Mad Dog McCree - Gunslinger Pack (USA) (En,Fr,Es).iso" size 4699979776 crc fb60a4d8 md5 13efc11f388440c46e0a68c9c83c062b sha1 38f81d136663f6ac90fbe7aaa0ba7d841e1aebb4 )
+)
+
+game (
+	name "Madden NFL 08 (USA)"
+	description "Madden NFL 08 (USA)"
+	rom ( name "Madden NFL 08 (USA).iso" size 4699979776 crc 736f640e md5 714656cece1167ebdf8b66e70eb5445b sha1 6639131c05bb34304fb00e85f6eb82ac7aa62954 )
+)
+
+game (
+	name "Madden NFL 09 - All-Play (USA)"
+	description "Madden NFL 09 - All-Play (USA)"
+	rom ( name "Madden NFL 09 - All-Play (USA).iso" size 4699979776 crc a2df195d md5 de66a69c024c9195ab874d86c1bd53ee sha1 ba024bef2b633e10613a08de8614b13bdfbfa6f7 )
+)
+
+game (
+	name "Madden NFL 10 (USA)"
+	description "Madden NFL 10 (USA)"
+	rom ( name "Madden NFL 10 (USA).iso" size 4699979776 crc 58a35a0d md5 32818ce94a1a5b82c85fc63b09317e02 sha1 871ce345e0a0ebbd3a160e0d36b10d37693dd0fc )
+)
+
+game (
+	name "Madden NFL 11 (USA)"
+	description "Madden NFL 11 (USA)"
+	rom ( name "Madden NFL 11 (USA).iso" size 4699979776 crc 9be67aa8 md5 4057c5f112f48bea097b170f83465c0f sha1 ea92710efd9fdddfcc4ceff52bd8c1286804e4c7 )
+)
+
+game (
+	name "MadWorld (Europe) (En,Fr,Es,It)"
+	description "MadWorld (Europe) (En,Fr,Es,It)"
+	rom ( name "MadWorld (Europe) (En,Fr,Es,It).iso" size 4699979776 crc f765f13b md5 99cf03f650f23bcd989af0082758f239 sha1 140b936c0bdc1b4b6987238e617749aca24d9d32 )
+)
+
+game (
+	name "MadWorld (Japan) (En,Ja)"
+	description "MadWorld (Japan) (En,Ja)"
+	rom ( name "MadWorld (Japan) (En,Ja).iso" size 4699979776 crc 52d30cc7 md5 5907faa3b3788911379e770b2a777620 sha1 ded0e2c7d420ebffdb18b0f0c2e7d5602ba7cdab )
+)
+
+game (
+	name "MadWorld (USA) (En,Fr,Es,It)"
+	description "MadWorld (USA) (En,Fr,Es,It)"
+	rom ( name "MadWorld (USA) (En,Fr,Es,It).iso" size 4699979776 crc 27fa6ac0 md5 12c86df1dde503c453a40223b273c984 sha1 5daefee01611b326ef0c3ad1c6370aa6c4837a6d )
+)
+
+game (
+	name "Major League Baseball 2K12 (USA)"
+	description "Major League Baseball 2K12 (USA)"
+	rom ( name "Major League Baseball 2K12 (USA).iso" size 4699979776 crc 221b7c00 md5 1fd4a5debd5e4b87a72c8f2886862eab sha1 8810fbafd59d0d6a86f2b8e274ceccbf9c919646 )
+)
+
+game (
+	name "Major League Baseball 2K8 (USA)"
+	description "Major League Baseball 2K8 (USA)"
+	rom ( name "Major League Baseball 2K8 (USA).iso" size 4699979776 crc a88a172d md5 3eba136498ab6d38e0ac6f4b49650aed sha1 feee901dd8e665bcbb3ca6ab597296d17d0e9d4e )
+)
+
+game (
+	name "Major League Baseball 2K9 (USA)"
+	description "Major League Baseball 2K9 (USA)"
+	rom ( name "Major League Baseball 2K9 (USA).iso" size 4699979776 crc 394cd872 md5 d4f9284dd5853a62f80c2078db5f45ec sha1 a4fe7d7b79dbd76aa0851f8ac178a0486a271e43 )
+)
+
+game (
+	name "Manhunt 2 (Europe) (En,Fr,De,Es,It)"
+	description "Manhunt 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Manhunt 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 8f3f725d md5 57a144802777314982ce4ba2d45dad82 sha1 4d0ad5deb09b71b159f7cbaf988bae0f8d6a9848 )
+)
+
+game (
+	name "Manhunt 2 (USA) (En,Fr,Es)"
+	description "Manhunt 2 (USA) (En,Fr,Es)"
+	rom ( name "Manhunt 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 9a1554c5 md5 f8291f1fb37eb437d84e40cd5e1217a7 sha1 79f42f1a416da48e3345657d97dbcfabc4c30c73 )
+)
+
+game (
+	name "Marbles! Balance Challenge (Europe) (En,Fr,De,Es,It)"
+	description "Marbles! Balance Challenge (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Marbles! Balance Challenge (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9e2be88a md5 3e556cba52b97ed00699afbe62156a0e sha1 b95da6f788d0d50185b41683243e993b85f653b2 )
+)
+
+game (
+	name "Marines - Modern Urban Combat (USA)"
+	description "Marines - Modern Urban Combat (USA)"
+	rom ( name "Marines - Modern Urban Combat (USA).iso" size 4699979776 crc 4cf0030c md5 c5a0b6168e8d7e0c5a9dc47658e47591 sha1 e97198378323c2e7df88d6233b338799985a29fe )
+)
+
+game (
+	name "Mario & Sonic at the London 2012 Olympic Games (USA) (En,Fr,Es)"
+	description "Mario & Sonic at the London 2012 Olympic Games (USA) (En,Fr,Es)"
+	rom ( name "Mario & Sonic at the London 2012 Olympic Games (USA) (En,Fr,Es).iso" size 4699979776 crc f9ed41ea md5 18186092013105ee65f2ae0b5c2d1e4d sha1 3462212de952c14ada27149ad6744f235182ef3d )
+)
+
+game (
+	name "Mario & Sonic at the Olympic Games (Europe)"
+	description "Mario & Sonic at the Olympic Games (Europe)"
+	rom ( name "Mario & Sonic at the Olympic Games (Europe).iso" size 4699979776 crc 3b2cd909 md5 f21322e29f285c6a40f854c4fab6c03c sha1 9ea5a7617f2b0096b2b2fec4dd6dea51d060570d )
+)
+
+game (
+	name "Mario & Sonic at the Olympic Games (USA) (En,Fr,Es)"
+	description "Mario & Sonic at the Olympic Games (USA) (En,Fr,Es)"
+	rom ( name "Mario & Sonic at the Olympic Games (USA) (En,Fr,Es).iso" size 4699979776 crc f9b76d37 md5 13e3bef2d959feb9c01a3751688508cc sha1 009a4dd406e165091079df165b0b1fd849b89493 )
+)
+
+game (
+	name "Mario & Sonic at the Olympic Winter Games (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Mario & Sonic at the Olympic Winter Games (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Mario & Sonic at the Olympic Winter Games (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc b6c58791 md5 243cc579b2e294e552f98d6d82720be6 sha1 6242a9bbf7efd7396daa4e3a9821a1f6ad19e4cb )
+)
+
+game (
+	name "Mario & Sonic at the Olympic Winter Games (USA) (En,Ja,Fr,Es)"
+	description "Mario & Sonic at the Olympic Winter Games (USA) (En,Ja,Fr,Es)"
+	rom ( name "Mario & Sonic at the Olympic Winter Games (USA) (En,Ja,Fr,Es).iso" size 4699979776 crc 04a2a794 md5 2e9a953c74e48ad291a339f0ebd93452 sha1 bc2208028f22bd593211884c0d32201fcbe952ae )
+)
+
+game (
+	name "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
+	description "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Kart Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a70d78b md5 e7b1ff1fabb0789482ce2cb0661d986e sha1 4fde5ce38d68f632d92c5b0d52bbab0b1d355a95 )
+)
+
+game (
+	name "Mario Kart Wii (Japan)"
+	description "Mario Kart Wii (Japan)"
+	rom ( name "Mario Kart Wii (Japan).iso" size 4699979776 crc 36b9a6b2 md5 1942f9c144af686cb99557ee6a1a120d sha1 6539bada98dd48aed072082eba9e6049b53959bb )
+)
+
+game (
+	name "Mario Kart Wii (USA) (En,Fr,Es)"
+	description "Mario Kart Wii (USA) (En,Fr,Es)"
+	rom ( name "Mario Kart Wii (USA) (En,Fr,Es).iso" size 4699979776 crc 0cc7b4d5 md5 bb7f2c926cbcdee65e2a48b7002a52ea sha1 9faca97115fb267c1b8a4d8a05fb22f42a904733 )
+)
+
+game (
+	name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc c0621009 md5 5030e8dfbc5e0c71a70898cb648f5d3c sha1 902286817d0fd5cd63f5d6ff253dd78c839b12f2 )
+)
+
+game (
+	name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc dfe8361a md5 a80fe065339638c73b260af7409ada57 sha1 fe4688283c9d2b7d76fda13ed991afdcacf182cd )
+)
+
+game (
+	name "Mario Party 8 (USA) (v1.01)"
+	description "Mario Party 8 (USA) (v1.01)"
+	rom ( name "Mario Party 8 (USA) (v1.01).iso" size 4699979776 crc 4d63d260 md5 a2feb2d57ec670615ac9f1d13e1db49b sha1 2252edd39961d3de9cf8ce529b721856960b8715 )
+)
+
+game (
+	name "Mario Party 8 (USA) (v1.02)"
+	description "Mario Party 8 (USA) (v1.02)"
+	rom ( name "Mario Party 8 (USA) (v1.02).iso" size 4699979776 crc 50829c66 md5 944c3f7db81170c9d86fc73dab1da24b sha1 f00bfeead8de26504571d30e83a0b84ea8c38c21 )
+)
+
+game (
+	name "Mario Party 9 (Europe) (En,Fr,De,Es,It)"
+	description "Mario Party 9 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Party 9 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15f44aaf md5 48722e664aecee14b181ee0ff56a7ec8 sha1 c0b62c218118c77494cab0feb41be69f6ea84c73 )
+)
+
+game (
+	name "Mario Party 9 (Japan)"
+	description "Mario Party 9 (Japan)"
+	rom ( name "Mario Party 9 (Japan).iso" size 4699979776 crc 21c8d345 md5 02245d8da3a7b57bdc14ff1c55301fa1 sha1 06bee0298050d966f3de41ea540fd2a064958ebc )
+)
+
+game (
+	name "Mario Party 9 (USA) (En,Fr,Es)"
+	description "Mario Party 9 (USA) (En,Fr,Es)"
+	rom ( name "Mario Party 9 (USA) (En,Fr,Es).iso" size 4699979776 crc 3caea203 md5 a9aa140b48e67ccdba9c7c9afc9884bc sha1 bf3048189e0195fe4e230d2989db9f7d69ffd559 )
+)
+
+game (
+	name "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
+	description "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Power Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5532686d md5 0f29a21513495a096d68a7fb5c88e5fd sha1 f7dcfc46030ac305e76d13c5509690e5644103c6 )
+)
+
+game (
+	name "Mario Power Tennis (USA) (En,Fr,Es)"
+	description "Mario Power Tennis (USA) (En,Fr,Es)"
+	rom ( name "Mario Power Tennis (USA) (En,Fr,Es).iso" size 4699979776 crc 8e838298 md5 3bc8110b208074e4b39193145d3a8e78 sha1 b3a03ef79f942cb95c5dff8bdb00393fb355da6c )
+)
+
+game (
+	name "Mario Sports Mix (Europe) (En,Fr,De,Es,It)"
+	description "Mario Sports Mix (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mario Sports Mix (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5c6fc758 md5 a63c794fca194c7ccbb57a82a857d821 sha1 06db56218697cff5089402167246d6556674cddd )
+)
+
+game (
+	name "Mario Sports Mix (USA) (En,Fr,Es)"
+	description "Mario Sports Mix (USA) (En,Fr,Es)"
+	rom ( name "Mario Sports Mix (USA) (En,Fr,Es).iso" size 4699979776 crc b67d2cf3 md5 29c4d4d4e9853b95b769105a746d544f sha1 aa1079bc1d0eaaa4f5b0bfd8466695a98a3ee9cb )
+)
+
+game (
+	name "Mario Strikers Charged (Japan)"
+	description "Mario Strikers Charged (Japan)"
+	rom ( name "Mario Strikers Charged (Japan).iso" size 4699979776 crc 55761a62 md5 2da5f39693bcbbc15583b16f3f50b733 sha1 b447b46e1c8b386f25b27a51f777d8ea20dbe353 )
+)
+
+game (
+	name "Mario Strikers Charged (USA) (En,Fr,Es)"
+	description "Mario Strikers Charged (USA) (En,Fr,Es)"
+	rom ( name "Mario Strikers Charged (USA) (En,Fr,Es).iso" size 4699979776 crc 99814bef md5 edb27cb204cc18959528b15c1450c356 sha1 4b6789a71069f131132f5f6b4a4150f9781f5a18 )
+)
+
+game (
+	name "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc fd24b93f md5 6348adcd8337d22567b88a9472785c9a sha1 b56d6a9e162f67d7c09161d623d3f9b30e4bcfe6 )
+)
+
+game (
+	name "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.02)"
+	description "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.02)"
+	rom ( name "Mario Strikers Charged Football (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 561faa52 md5 6bc055ad70656ae01e6540d052a03772 sha1 73942eb07eb92c135c92ec3917a588db0601e9b9 )
+)
+
+game (
+	name "Mario Super Sluggers (USA) (En,Fr,Es)"
+	description "Mario Super Sluggers (USA) (En,Fr,Es)"
+	rom ( name "Mario Super Sluggers (USA) (En,Fr,Es).iso" size 4699979776 crc c4adc0a0 md5 77d12cb938f12365fc2e522afe408cbe sha1 265a0897dde8192016c57a4236bc9b9bf57ab06c )
+)
+
+game (
+	name "Marvel - Ultimate Alliance (USA)"
+	description "Marvel - Ultimate Alliance (USA)"
+	rom ( name "Marvel - Ultimate Alliance (USA).iso" size 4699979776 crc ef65090d md5 2fac0df64c76b9d4318b70eaa8ebb4c0 sha1 48fce0eba687118adcf1703fb66350462754de15 )
+)
+
+game (
+	name "Marvel - Ultimate Alliance 2 (USA)"
+	description "Marvel - Ultimate Alliance 2 (USA)"
+	rom ( name "Marvel - Ultimate Alliance 2 (USA).iso" size 4699979776 crc 2ee6ff19 md5 cfd3d33f9756293b8fd065849c8db02f sha1 5ba1c9640200bbde37cd340a70be5060f0371c8c )
+)
+
+game (
+	name "Marvel Super Hero Squad (USA) (En,Fr,Es)"
+	description "Marvel Super Hero Squad (USA) (En,Fr,Es)"
+	rom ( name "Marvel Super Hero Squad (USA) (En,Fr,Es).iso" size 4699979776 crc db425e3f md5 20c83351a453a6a05059dcaf2e2d8ba1 sha1 f7dbc0fd85b290ad31ef3a811c05964bd53903b4 )
+)
+
+game (
+	name "Maximum Racing - Super Truck Racer (USA)"
+	description "Maximum Racing - Super Truck Racer (USA)"
+	rom ( name "Maximum Racing - Super Truck Racer (USA).iso" size 4699979776 crc 3c681027 md5 e7647f4c8655d692c70f11e2a739df83 sha1 a2b2935fac01325a781a3439ac48a1405cd8630a )
+)
+
+game (
+	name "Medal of Honor - Heroes 2 (Europe)"
+	description "Medal of Honor - Heroes 2 (Europe)"
+	rom ( name "Medal of Honor - Heroes 2 (Europe).iso" size 4699979776 crc 411579f0 md5 886ce2b21dcb77810b4fdcfc73db3a07 sha1 6781df7e6c7c2193e8db78a62e49805b31dd9ca3 )
+)
+
+game (
+	name "Medal of Honor - Heroes 2 (USA)"
+	description "Medal of Honor - Heroes 2 (USA)"
+	rom ( name "Medal of Honor - Heroes 2 (USA).iso" size 4699979776 crc 460a2ca9 md5 c93713681cb54df66eea289fecd95f2b sha1 269227385f5b4331d5a86cfbe7a8c0d9aea08614 )
+)
+
+game (
+	name "Medal of Honor - Vanguard (Europe) (En,Fr,De,Es,It)"
+	description "Medal of Honor - Vanguard (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Medal of Honor - Vanguard (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 2e4d2a35 md5 0aa8dc8aad0596686ea9dcdf614c6b5b sha1 334ca19bc1a003d812bcbf988db731957b91b56f )
+)
+
+game (
+	name "Medal of Honor - Vanguard (UK)"
+	description "Medal of Honor - Vanguard (UK)"
+	rom ( name "Medal of Honor - Vanguard (UK).iso" size 4699979776 crc d020554d md5 e63dc83790a483bff5b1da3a06f823b7 sha1 afe8503d4e8feb65efaa86152e0b2a71d6eea5e6 )
+)
+
+game (
+	name "Medal of Honor - Vanguard (USA)"
+	description "Medal of Honor - Vanguard (USA)"
+	rom ( name "Medal of Honor - Vanguard (USA).iso" size 4699979776 crc 3c5b6264 md5 44cddd3c37c3585b58cc2ac107fe2d34 sha1 01c968521f6d71322e1ec4964eb72b91da9230ab )
+)
+
+game (
+	name "Medieval Games (Europe) (En,Fr,De,Es,It)"
+	description "Medieval Games (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Medieval Games (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 8ec5cbea md5 53ed905440be99c9e017b86edb7c9a23 sha1 10694c5e0ad8c42bef40b0aab9cc2a209968e2ae )
+)
+
+game (
+	name "Meitantei Conan - Tsuioku no Mirage (Japan)"
+	description "Meitantei Conan - Tsuioku no Mirage (Japan)"
+	rom ( name "Meitantei Conan - Tsuioku no Mirage (Japan).iso" size 4699979776 crc 8316c026 md5 ff3c05777b1c1efa438dac12b881f134 sha1 44647ce9b90c2b1a99b03adac4077ce0d1c45c38 )
+)
+
+game (
+	name "Mercury Meltdown Revolution (Europe) (En,Fr,De,Es,It)"
+	description "Mercury Meltdown Revolution (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mercury Meltdown Revolution (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 562d3858 md5 f222ea589b15c8a54c55c47a493f19d9 sha1 206e7105e81dc775b197a0917e9afaba0cba5cf5 )
+)
+
+game (
+	name "Mercury Meltdown Revolution (USA) (En,Fr,Es)"
+	description "Mercury Meltdown Revolution (USA) (En,Fr,Es)"
+	rom ( name "Mercury Meltdown Revolution (USA) (En,Fr,Es).iso" size 4699979776 crc 60f0d9ba md5 8d985b6a1b230ab6685844881269f797 sha1 e937a5aadc12b9be79aeafca4ee4a37cf4553689 )
+)
+
+game (
+	name "Metal Slug Anthology (Europe)"
+	description "Metal Slug Anthology (Europe)"
+	rom ( name "Metal Slug Anthology (Europe).iso" size 4699979776 crc dfbc84b1 md5 eed6370f56f9ea00e734a7a7fd47865e sha1 7c6bb0cea04bc12fcac8dae788f1272bf6bd481b )
+)
+
+game (
+	name "Metal Slug Anthology (USA)"
+	description "Metal Slug Anthology (USA)"
+	rom ( name "Metal Slug Anthology (USA).iso" size 4699979776 crc 68ed804e md5 16d7bab53fa02d4ddd61b47da66cef93 sha1 9c793e1283bed848a01b38fcaf64f395c1d2f72d )
+)
+
+game (
+	name "Metal Slug Complete (Japan)"
+	description "Metal Slug Complete (Japan)"
+	rom ( name "Metal Slug Complete (Japan).iso" size 4699979776 crc c9d4e7cd md5 1392e957fc0c92ecb3c1d8092b3378b2 sha1 b80d12425f67c351720d8951933a678827a58727 )
+)
+
+game (
+	name "Metroid - Other M (Europe) (En,Fr,De,Es,It)"
+	description "Metroid - Other M (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Metroid - Other M (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 582dea6c md5 c188f8704b96e40e3f86b4f698599b3c sha1 e169caa7ac194f779cbc3c3c014f86fb90d96e11 )
+)
+
+game (
+	name "Metroid - Other M (Japan) (En,Ja)"
+	description "Metroid - Other M (Japan) (En,Ja)"
+	rom ( name "Metroid - Other M (Japan) (En,Ja).iso" size 8511160320 crc cee0a3c9 md5 da0bf8f2e1f3c586053e6a38fca43a2e sha1 29c13a4785ba677c2c0aecfc9c956294f68c26cc )
+)
+
+game (
+	name "Metroid - Other M (USA) (En,Fr,Es) (v1.00)"
+	description "Metroid - Other M (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.00).iso" size 8511160320 crc 29da327a md5 8c66027b1023fe8e64645611fadd2a95 sha1 a22962468be3f137633275c05505cdc2b50ecc3b )
+)
+
+game (
+	name "Metroid - Other M (USA) (En,Fr,Es) (v1.01)"
+	description "Metroid - Other M (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.01).iso" size 8511160320 crc 62515755 md5 3e6170d5deb86ccf11a90aedea35097e sha1 afca5b8f0a9d6c632c81471e04a4f96c209f91f0 )
+)
+
+game (
+	name "Metroid Prime 3 - Corruption (Europe) (En,Fr,De,Es,It)"
+	description "Metroid Prime 3 - Corruption (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Metroid Prime 3 - Corruption (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ba6a0568 md5 f4c734a1e191c45e9ac037d92e14485d sha1 1fb2a7ae44f97f9a380368717d26b01e9b272159 )
+)
+
+game (
+	name "Metroid Prime 3 - Corruption (Japan)"
+	description "Metroid Prime 3 - Corruption (Japan)"
+	rom ( name "Metroid Prime 3 - Corruption (Japan).iso" size 4699979776 crc fd592ea4 md5 3d29b79527b966bb4723f131a95c38a1 sha1 6f7e46cafba9ae988813062d53be57321155f7fe )
+)
+
+game (
+	name "Metroid Prime 3 - Corruption (USA)"
+	description "Metroid Prime 3 - Corruption (USA)"
+	rom ( name "Metroid Prime 3 - Corruption (USA).iso" size 4699979776 crc e6b6f1dd md5 6a6fc8eb6873f80c5d240b0e89f8518c sha1 c6c5a57b8e55104fa197d91ea8a89c34b04d3120 )
+)
+
+game (
+	name "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It)"
+	description "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 7506b685 md5 735c0d0c16177e3294f5e0faf7a69571 sha1 0c80815eedca8f597f01d5a380489766c56acf88 )
+)
+
+game (
+	name "Metroid Prime Trilogy (USA)"
+	description "Metroid Prime Trilogy (USA)"
+	rom ( name "Metroid Prime Trilogy (USA).iso" size 8511160320 crc 8a4b439d md5 823df1c3c425f1383529f368f6479359 sha1 2204e5b19039d44b2379ab2065fd548c800ba680 )
+)
+
+game (
+	name "Michael Jackson - The Experience (Europe) (En,Fr,De,Es,It)"
+	description "Michael Jackson - The Experience (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Michael Jackson - The Experience (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ae0077e8 md5 a003043476f8e45a2290190ca8f8e6c5 sha1 968d2f311fa9d9a60ae5c1be87d812c42a15a8bd )
+)
+
+game (
+	name "Michael Jackson - The Experience (USA) (En,Fr,Es)"
+	description "Michael Jackson - The Experience (USA) (En,Fr,Es)"
+	rom ( name "Michael Jackson - The Experience (USA) (En,Fr,Es).iso" size 4699979776 crc 41133b75 md5 d30a66a289bab866e92a7d7253b3fecc sha1 b9c8eded732dd47533a22cdf762f4cd95317b777 )
+)
+
+game (
+	name "Mind. Body. Soul. - Nutrition Matters (Europe)"
+	description "Mind. Body. Soul. - Nutrition Matters (Europe)"
+	rom ( name "Mind. Body. Soul. - Nutrition Matters (Europe).iso" size 4699979776 crc f0d97991 md5 076635119e4c33bfd72c7cf35969509f sha1 8f6e2d9e11ccb96377a296f0e74e99558578c033 )
+)
+
+game (
+	name "Mini Desktop Racing (Europe)"
+	description "Mini Desktop Racing (Europe)"
+	rom ( name "Mini Desktop Racing (Europe).iso" size 4699979776 crc 004fe255 md5 2a6ca70aed4241616b0bd6d17bf07c3c sha1 f3bb91e1532b2db941c1c2c9649e2e92723e26c6 )
+)
+
+game (
+	name "Mini Ninjas (USA) (En,Fr,Es)"
+	description "Mini Ninjas (USA) (En,Fr,Es)"
+	rom ( name "Mini Ninjas (USA) (En,Fr,Es).iso" size 4699979776 crc 5e9240cc md5 fefb0aa57b1aa3ea9c0c92d764f1c00b sha1 a91564914eb22c5f917cff726aacda42768ab66a )
+)
+
+game (
+	name "MLB Power Pros (USA)"
+	description "MLB Power Pros (USA)"
+	rom ( name "MLB Power Pros (USA).iso" size 4699979776 crc 2e7ee3f2 md5 8f1b2a2ae0f7e8101746afd87f16f039 sha1 6b989dccf50ae79c9f3138570945a75b0697f69f )
+)
+
+game (
+	name "MLB Power Pros 2008 (USA)"
+	description "MLB Power Pros 2008 (USA)"
+	rom ( name "MLB Power Pros 2008 (USA).iso" size 4699979776 crc 8a7e45ab md5 b8799968c154c0f66200e36b9358c4d7 sha1 b56115682d9656088ea3193deff038e1a1108b41 )
+)
+
+game (
+	name "Monkey King, The - The Legend Begins (USA)"
+	description "Monkey King, The - The Legend Begins (USA)"
+	rom ( name "Monkey King, The - The Legend Begins (USA).iso" size 4699979776 crc aaab022d md5 e5d51656dc76670660a6a0e80647174d sha1 fa00c10a91ea3b381036a787b01d9341c5229bc0 )
+)
+
+game (
+	name "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi)"
+	description "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi)"
+	rom ( name "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi).iso" size 4699979776 crc df1a3655 md5 d3f9e3db53cd27272e8f3a36d6cd9531 sha1 4fc41d05c54958c374f19e8f113617ce3db048a0 )
+)
+
+game (
+	name "Monopoly (USA) (En,Fr,Es)"
+	description "Monopoly (USA) (En,Fr,Es)"
+	rom ( name "Monopoly (USA) (En,Fr,Es).iso" size 4699979776 crc 875a49d6 md5 e0e8a12d7b191de05433793418865706 sha1 89995b443ef346829a6e6df082e252c49434ac49 )
+)
+
+game (
+	name "Monster 4x4 - World Circuit (Europe) (En,Fr,De,Es,It)"
+	description "Monster 4x4 - World Circuit (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Monster 4x4 - World Circuit (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 39304784 md5 cfc37bb8842324cb89d8ca9e30c7bda7 sha1 aaeff882f8d18273607ee8ec06b1eabff95fd9b1 )
+)
+
+game (
+	name "Monster 4x4 - World Circuit (USA) (En,Fr,Es)"
+	description "Monster 4x4 - World Circuit (USA) (En,Fr,Es)"
+	rom ( name "Monster 4x4 - World Circuit (USA) (En,Fr,Es).iso" size 4699979776 crc 213f5f8e md5 e9cca5830a96fb28f1a559d676b94c5d sha1 bb7127bb76b14354a5cbc730e7d3ddb935ea3933 )
+)
+
+game (
+	name "Monster Hunter 3 tri- (Japan)"
+	description "Monster Hunter 3 tri- (Japan)"
+	rom ( name "Monster Hunter 3 tri- (Japan).iso" size 4699979776 crc 45b60a5f md5 0257306a8aeafe9ad64d6597ba8c30bc sha1 2ec421eb125db1382c208d6b88fd2b56166e5ad0 )
+)
+
+game (
+	name "Monster Hunter Tri (Europe) (En,Fr,De,Es,It)"
+	description "Monster Hunter Tri (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Monster Hunter Tri (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e6a54872 md5 b4b777ced147aecb45d4c87ac9ac4b4c sha1 66525f8181284e85abc2229a1c5b6273214024c0 )
+)
+
+game (
+	name "Monster Hunter Tri (USA)"
+	description "Monster Hunter Tri (USA)"
+	rom ( name "Monster Hunter Tri (USA).iso" size 4699979776 crc 46848f76 md5 a56b231600a6a084eb91514e124194eb sha1 ea0e5098509c241b5ec1997c14deace08dd95280 )
+)
+
+game (
+	name "Monster Trux Offroad (USA)"
+	description "Monster Trux Offroad (USA)"
+	rom ( name "Monster Trux Offroad (USA).iso" size 4699979776 crc ccda55b9 md5 7f84a2b3ba0b1dbbf1e32d995ab45292 sha1 0ecb9201989fde33711091995ccdd789d72344e3 )
+)
+
+game (
+	name "More Game Party (Europe) (En,Fr,De,Es,It)"
+	description "More Game Party (Europe) (En,Fr,De,Es,It)"
+	rom ( name "More Game Party (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 59b580e8 md5 eb93b4da73ca1b91d3c7196dbbb68a44 sha1 95efe7defe60e9579f8c8b19582e765b7dfa8531 )
+)
+
+game (
+	name "Mortal Kombat - Armageddon (Europe) (En,Fr,De,Es,It)"
+	description "Mortal Kombat - Armageddon (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Mortal Kombat - Armageddon (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fc676264 md5 b19800d1e0b59e5b2ddafc79c868e78c sha1 dc2e9a4e09dbb998fff8df04dddbf207e7dbc7a0 )
+)
+
+game (
+	name "Mortal Kombat - Armageddon (USA)"
+	description "Mortal Kombat - Armageddon (USA)"
+	rom ( name "Mortal Kombat - Armageddon (USA).iso" size 4699979776 crc f155a31f md5 29c23cb7794e18ff91813c570035107a sha1 9603232ab3a537d8555e2b32362768e6a0881063 )
+)
+
+game (
+	name "MotoGP (USA) (En,Fr,Es)"
+	description "MotoGP (USA) (En,Fr,Es)"
+	rom ( name "MotoGP (USA) (En,Fr,Es).iso" size 4699979776 crc c1fcc425 md5 c1418c92a95fd609c807a4122236f3cf sha1 afc8da14d0e6399856ee60a02b3c2b662c3839d8 )
+)
+
+game (
+	name "Movie Studios Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	description "Movie Studios Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	rom ( name "Movie Studios Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da).iso" size 4699979776 crc 5142aef9 md5 ad9a5063cf8eb44ca54d7d7e1050142d sha1 1e07e508de526664900d2b3a0c22fbde39e70b59 )
+)
+
+game (
+	name "Mummy, The - Tomb of the Dragon Emperor (USA) (En,Fr,Es)"
+	description "Mummy, The - Tomb of the Dragon Emperor (USA) (En,Fr,Es)"
+	rom ( name "Mummy, The - Tomb of the Dragon Emperor (USA) (En,Fr,Es).iso" size 4699979776 crc ea6d3ff0 md5 a73fe347c8b7a88eaca80536a2c333dd sha1 9b08f162ac96e2ceccac189dde51ef81bed87385 )
+)
+
+game (
+	name "Munchables, The (USA) (En,Fr,Es)"
+	description "Munchables, The (USA) (En,Fr,Es)"
+	rom ( name "Munchables, The (USA) (En,Fr,Es).iso" size 4699979776 crc ceb7f6b4 md5 9dbeedee64ee623b4cd8c4b3b5af08ab sha1 5f0671f98d0c79c4f0aac6712c3953951ae62c47 )
+)
+
+game (
+	name "Muramasa - The Demon Blade (Europe) (En,Fr,De,Es,It)"
+	description "Muramasa - The Demon Blade (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Muramasa - The Demon Blade (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fd68bc74 md5 5f76bf463774db2948d9b3086e1d6ced sha1 5f37800209e149b58611d0682e77e105da6164a5 )
+)
+
+game (
+	name "Muramasa - The Demon Blade (USA)"
+	description "Muramasa - The Demon Blade (USA)"
+	rom ( name "Muramasa - The Demon Blade (USA).iso" size 4699979776 crc 5a6e270b md5 682d33e55046fc02153862bab21b4d23 sha1 b40307079aa4d4a96d0a7d751bf5608649298874 )
+)
+
+game (
+	name "Mushroom Men - The Spore Wars (USA) (En,Fr,Es)"
+	description "Mushroom Men - The Spore Wars (USA) (En,Fr,Es)"
+	rom ( name "Mushroom Men - The Spore Wars (USA) (En,Fr,Es).iso" size 4699979776 crc 2081dec5 md5 6854eff1558581c67b0c0597c516aabc sha1 06609d42908f8911ecc579d790f646d7ef08bd43 )
+)
+
+game (
+	name "MX vs. ATV Untamed (USA)"
+	description "MX vs. ATV Untamed (USA)"
+	rom ( name "MX vs. ATV Untamed (USA).iso" size 4699979776 crc a5a0ebda md5 504b45a2637944f8a820783e3b37bbb8 sha1 c567f95bf25e9321652d03f6773da60bec694ff9 )
+)
+
+game (
+	name "My Baby First Steps (USA) (En,Fr,Es)"
+	description "My Baby First Steps (USA) (En,Fr,Es)"
+	rom ( name "My Baby First Steps (USA) (En,Fr,Es).iso" size 4699979776 crc 6677f8bc md5 2e0203f07caac258d18106d900553e8a sha1 b6c87dc81bb89585f814332ef279bd3fda120360 )
+)
+
+game (
+	name "My Fitness Coach - Cardio Workout (Europe) (En,Fr,De,Es,It)"
+	description "My Fitness Coach - Cardio Workout (Europe) (En,Fr,De,Es,It)"
+	rom ( name "My Fitness Coach - Cardio Workout (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c9ea38a1 md5 fb0128cd508cea578d6ec8e718e17c8b sha1 2b607b2c25efc6e225daf4e158bbac00fa5f67c7 )
+)
+
+game (
+	name "My Fitness Coach - Dance Workout (Europe, Australia) (En,Fr,De,Es,It)"
+	description "My Fitness Coach - Dance Workout (Europe, Australia) (En,Fr,De,Es,It)"
+	rom ( name "My Fitness Coach - Dance Workout (Europe, Australia) (En,Fr,De,Es,It).iso" size 4699979776 crc bc069dc3 md5 01ebb4c555c746bda868375df2c7ae66 sha1 6ec9659d037cc9c5755d53162e38a4320966e701 )
+)
+
+game (
+	name "My Personal Golf Trainer (USA)"
+	description "My Personal Golf Trainer (USA)"
+	rom ( name "My Personal Golf Trainer (USA).iso" size 4699979776 crc c6610ff7 md5 9456fa1a8c9b198c84faca18e511e230 sha1 53c10a5556304a108877893e5e720c215ca73bfd )
+)
+
+game (
+	name "My Spanish Coach - Improve Your Spanish (Europe)"
+	description "My Spanish Coach - Improve Your Spanish (Europe)"
+	rom ( name "My Spanish Coach - Improve Your Spanish (Europe).iso" size 4699979776 crc beb61ad1 md5 31a7a96e5d7020a94ae2ce6ff2d12bf4 sha1 0285228d69730a6d45557536f6d4cc685ba50050 )
+)
+
+game (
+	name "My Word Coach (Europe)"
+	description "My Word Coach (Europe)"
+	rom ( name "My Word Coach (Europe).iso" size 4699979776 crc f3e9ba05 md5 2a2cf25db1671b9a484480b821fa796f sha1 28c9db7b91187e5395d32a2dfead371001ead695 )
+)
+
+game (
+	name "My Word Coach (USA)"
+	description "My Word Coach (USA)"
+	rom ( name "My Word Coach (USA).iso" size 4699979776 crc 9fe35932 md5 07d8a5b31bf67163380ede5ea182151d sha1 62d1a2127eef91a6a4dbdc4fb2ea9fe797d81479 )
+)
+
+game (
+	name "MySims (USA) (En,Fr,Es)"
+	description "MySims (USA) (En,Fr,Es)"
+	rom ( name "MySims (USA) (En,Fr,Es).iso" size 4699979776 crc ff1bdcd1 md5 d66072f70cf5cc138e16a1c8346786db sha1 d772a1ec72d6f9d5a89022ad11a593da74c566cf )
+)
+
+game (
+	name "MySims Kingdom (USA) (En,Fr,Es)"
+	description "MySims Kingdom (USA) (En,Fr,Es)"
+	rom ( name "MySims Kingdom (USA) (En,Fr,Es).iso" size 4699979776 crc 88bf31fa md5 d5442e6d1c31406977a154b31e093505 sha1 94726101ae5456d531124820def1375564a2f75a )
+)
+
+game (
+	name "MySims Party (USA) (En,Fr,Es)"
+	description "MySims Party (USA) (En,Fr,Es)"
+	rom ( name "MySims Party (USA) (En,Fr,Es).iso" size 4699979776 crc 36e9a1be md5 227a27f3db8ac2aa78d3908181d86da1 sha1 6c223e0f4f14793b378d73deb88315e29b2c95f5 )
+)
+
+game (
+	name "MySims Racing (Europe) (En,Fr,De,Es,It,Nl)"
+	description "MySims Racing (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "MySims Racing (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 2c8d2f2d md5 d8657e87b8cace078e4ed604ba15c1a1 sha1 8ce16fe4c2ae8e0af7efa243ae09bd61c2b8232f )
+)
+
+game (
+	name "MySims Racing (USA) (En,Fr,Es)"
+	description "MySims Racing (USA) (En,Fr,Es)"
+	rom ( name "MySims Racing (USA) (En,Fr,Es).iso" size 4699979776 crc c550bee8 md5 58f473117529bbdb9cdb600467c00164 sha1 0a27731edbfa106bcf78a7961b25cfd13d720b01 )
+)
+
+game (
+	name "Mystery Case Files - The Malgrave Incident (USA)"
+	description "Mystery Case Files - The Malgrave Incident (USA)"
+	rom ( name "Mystery Case Files - The Malgrave Incident (USA).iso" size 4699979776 crc 1f0ed55d md5 2d516390efa9bab69f62aca10742d963 sha1 332082ee374791bee2fbff10c6bffc68ff426207 )
+)
+
+game (
+	name "Myth Makers Orbs of Doom (USA)"
+	description "Myth Makers Orbs of Doom (USA)"
+	rom ( name "Myth Makers Orbs of Doom (USA).iso" size 4699979776 crc 6d1a92af md5 e3db684d32c49f8a737c80840ae39807 sha1 82e6cfad7fe3951547e9cde0eb127dc2d5cdfc85 )
+)
+
+game (
+	name "Namco Museum Remix (Europe) (En,Fr,De,Es,It)"
+	description "Namco Museum Remix (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Namco Museum Remix (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d3173f05 md5 ee5fdf64d27dd4e5b67aa945b2970abc sha1 360889e4a356a529225cae4facd24de577ed4046 )
+)
+
+game (
+	name "Nancy Drew - The White Wolf of Icicle Creek (USA)"
+	description "Nancy Drew - The White Wolf of Icicle Creek (USA)"
+	rom ( name "Nancy Drew - The White Wolf of Icicle Creek (USA).iso" size 4699979776 crc e5964c1a md5 17e31424f3fb030c8916c41fd60cff15 sha1 b269432bdcc0a41902d0b968a2cd8dcab1539475 )
+)
+
+game (
+	name "Naruto - Clash of Ninja Revolution (Europe) (En,Fr,De,Es,It)"
+	description "Naruto - Clash of Ninja Revolution (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Naruto - Clash of Ninja Revolution (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b7abb199 md5 208a6f8eb0ec52fe57ec1309998b58e0 sha1 678241de0fc775d9bc79f3e14996216399819667 )
+)
+
+game (
+	name "Naruto - Clash of Ninja Revolution (USA)"
+	description "Naruto - Clash of Ninja Revolution (USA)"
+	rom ( name "Naruto - Clash of Ninja Revolution (USA).iso" size 4699979776 crc 09e6502c md5 5144559306fea024c060b9ea9d0fe7dd sha1 486a5a689f887eb3417e7e46016bb8b3692f66ed )
+)
+
+game (
+	name "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es)"
+	description "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es)"
+	rom ( name "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es).iso" size 4699979776 crc eb279052 md5 b959d02591c33c9cc3e8f3df1692f0f4 sha1 0e1acc214f10c76c2f5cfe654dacc137eb4b0ba2 )
+)
+
+game (
+	name "Naruto Shippuden - Clash of Ninja Revolution III (USA)"
+	description "Naruto Shippuden - Clash of Ninja Revolution III (USA)"
+	rom ( name "Naruto Shippuden - Clash of Ninja Revolution III (USA).iso" size 4699979776 crc e9931cd0 md5 a4d5c9c9aa2b285c8fecf5c700a0bb10 sha1 a92de4e3397a0f40348b890ed86392ab646b3306 )
+)
+
+game (
+	name "Naruto Shippuden - Gekitou Ninja Taisen! EX (Japan)"
+	description "Naruto Shippuden - Gekitou Ninja Taisen! EX (Japan)"
+	rom ( name "Naruto Shippuden - Gekitou Ninja Taisen! EX (Japan).iso" size 4699979776 crc 6fb90f35 md5 5301520851d0ffd39a053a49593f10e0 sha1 695ea24878be38c21af5981e999c603d2fb71515 )
+)
+
+game (
+	name "Naruto Shippuden - Gekitou Ninja Taisen! EX2 (Japan)"
+	description "Naruto Shippuden - Gekitou Ninja Taisen! EX2 (Japan)"
+	rom ( name "Naruto Shippuden - Gekitou Ninja Taisen! EX2 (Japan).iso" size 4699979776 crc 2492c891 md5 4f176cfd0584c0f7b32da703ffaa67d7 sha1 e5d8f1ec40a2f243274c42c98c077c34e1ac24ba )
+)
+
+game (
+	name "Naruto Shippuden - Ryujinki (Japan)"
+	description "Naruto Shippuden - Ryujinki (Japan)"
+	rom ( name "Naruto Shippuden - Ryujinki (Japan).iso" size 4699979776 crc 8d93b3cb md5 d447e576652576fbcfab9f31a44fb512 sha1 a97c6e7cebf1cb68ca57e40ebefa3be90ad9a123 )
+)
+
+game (
+	name "NASCAR Kart Racing (USA)"
+	description "NASCAR Kart Racing (USA)"
+	rom ( name "NASCAR Kart Racing (USA).iso" size 4699979776 crc 898ef9d0 md5 f421a3a1303d9bc672fba503347924d2 sha1 998b8829e421ec33785311bd7932667bcb5dd08e )
+)
+
+game (
+	name "NASCAR Unleashed (USA)"
+	description "NASCAR Unleashed (USA)"
+	rom ( name "NASCAR Unleashed (USA).iso" size 4699979776 crc 72800644 md5 a371f8d793658ef5aefce1dfde0893e5 sha1 2766cbca3b83f1c40b57bec0eee4e187f4b98fae )
+)
+
+game (
+	name "National Geographic - Challenge! (Europe) (En,Fr,De,Es,It)"
+	description "National Geographic - Challenge! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "National Geographic - Challenge! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 416f9a54 md5 1d9b1cdd05d7c846436eca8ade6b2995 sha1 f3999568fcbb8e78a8f1ffb0d6dc4e6684b8bab5 )
+)
+
+game (
+	name "NBA 2K10 (USA)"
+	description "NBA 2K10 (USA)"
+	rom ( name "NBA 2K10 (USA).iso" size 4699979776 crc ee9fe484 md5 9f55a7531a8bd96343c8fa3f0d0fb58f sha1 ffedadc39416873c3c91097b86e40372a0ccc603 )
+)
+
+game (
+	name "NBA Jam (USA)"
+	description "NBA Jam (USA)"
+	rom ( name "NBA Jam (USA).iso" size 4699979776 crc f318b1d6 md5 26edca9ec3d8ae641876dceeae3ec759 sha1 9ad89c3c4cf2b8a2f0911a3b8d34115d687e3976 )
+)
+
+game (
+	name "NBA Live 08 (USA)"
+	description "NBA Live 08 (USA)"
+	rom ( name "NBA Live 08 (USA).iso" size 4699979776 crc 4a3415e7 md5 ee0021029286176e7199ba6f397ed7db sha1 b778ab1e5ee180d5571a93b7ac847a5928069d25 )
+)
+
+game (
+	name "NCAA Football 09 All-Play (USA)"
+	description "NCAA Football 09 All-Play (USA)"
+	rom ( name "NCAA Football 09 All-Play (USA).iso" size 4699979776 crc 9807ac26 md5 8873add7d71b1d2c5f7bbab90369f6c6 sha1 5ad8b51b9ad296bbc2081f1efa9eb5a649ebaea3 )
+)
+
+game (
+	name "Need for Speed - Carbon (USA)"
+	description "Need for Speed - Carbon (USA)"
+	rom ( name "Need for Speed - Carbon (USA).iso" size 4699979776 crc 3ac65cad md5 b5edd42a6ed6b1ca25c6e16c1c468f81 sha1 7432d23b9bf926016b86ebfcdf34f7009c0ea179 )
+)
+
+game (
+	name "Need for Speed - Nitro (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Need for Speed - Nitro (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Need for Speed - Nitro (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 5d01339f md5 182662c1714551625610a8b42b526ffc sha1 e718d113b7c565f8099379528caaac4e454d7024 )
+)
+
+game (
+	name "Need for Speed - Nitro (USA) (En,Fr,Es)"
+	description "Need for Speed - Nitro (USA) (En,Fr,Es)"
+	rom ( name "Need for Speed - Nitro (USA) (En,Fr,Es).iso" size 4699979776 crc c1806c8c md5 233d6f1e6ad3326f62cd4d81692ad12f sha1 8d3f568c656fbec545bbe9b17ec925a9ac9cd5cd )
+)
+
+game (
+	name "Need for Speed - ProStreet (USA)"
+	description "Need for Speed - ProStreet (USA)"
+	rom ( name "Need for Speed - ProStreet (USA).iso" size 4699979776 crc 8ec321d0 md5 61a47fb111261221583a61f6ec8047de sha1 c84e376a247911c6920ac3c61e13ba10bfde6660 )
+)
+
+game (
+	name "Need for Speed - Undercover (Europe) (En,Nl)"
+	description "Need for Speed - Undercover (Europe) (En,Nl)"
+	rom ( name "Need for Speed - Undercover (Europe) (En,Nl).iso" size 4699979776 crc f035f9ed md5 ce4ab3d9ad9e0e112c075836eabc9a1b sha1 96bcaaab517b861a688ca23fe0d82cf2f6c0eecf )
+)
+
+game (
+	name "Neighborhood Games (USA)"
+	description "Neighborhood Games (USA)"
+	rom ( name "Neighborhood Games (USA).iso" size 4699979776 crc f4c6ab3e md5 d4d5cd4665db4d239fdf110d8eb2615f sha1 6bd2880d8d580a60222a53ad24b545cece10cda5 )
+)
+
+game (
+	name "Nerf N-Strike (Europe) (En,De,Es)"
+	description "Nerf N-Strike (Europe) (En,De,Es)"
+	rom ( name "Nerf N-Strike (Europe) (En,De,Es).iso" size 4699979776 crc 6af44e05 md5 7bb2cbc5e1614a288cb6d4da2e3d3aa4 sha1 9a45b064a21be03319a5e598fd46bbb560e375f7 )
+)
+
+game (
+	name "Netflix (USA)"
+	description "Netflix (USA)"
+	rom ( name "Netflix (USA).iso" size 4699979776 crc c69a7acd md5 e9016c841434bcaa7824ecb6d97f8310 sha1 82a23ba1b32d1c99e8150af1266bb66148ab1146 )
+)
+
+game (
+	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc e71b9bc7 md5 fc335c3187c6940a290f7c971fbdc576 sha1 8c0408ae7ed6539fccc9b002d50eecb994000af7 )
+)
+
+game (
+	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
+	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 2a9344fb md5 ea2698f30aef31182d1c506d9ae5cbd2 sha1 91ff55875b0e0401e6246d5bc2a52d7a80517860 )
+)
+
+game (
+	name "New Super Mario Bros. Wii (Japan)"
+	description "New Super Mario Bros. Wii (Japan)"
+	rom ( name "New Super Mario Bros. Wii (Japan).iso" size 4699979776 crc 1a1e2e29 md5 3e3337ea0fab653aa50807c839ceeec4 sha1 019b9a7abfcf9f2429b2d106d884a72d17fb922d )
+)
+
+game (
+	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
+	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 1cc03c30 md5 05022377c66dcc13dd8308b333c202db sha1 aa7b134a7606435ddcd735f2964ebdecde38c2ef )
+)
+
+game (
+	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
+	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 8c30d1d7 md5 b31a7da0d493ec1f558b4e1899406a14 sha1 9ac7242a5feebe1d0a6e2775c21f482c471b2240 )
+)
+
+game (
+	name "NHL 2K9 (USA) (En,Fr,Es)"
+	description "NHL 2K9 (USA) (En,Fr,Es)"
+	rom ( name "NHL 2K9 (USA) (En,Fr,Es).iso" size 4699979776 crc 361dbef0 md5 72c5d11e980d80154d8d30a1aef98586 sha1 57f9f33c239ba30aa849f79b1da15be0260cd00d )
+)
+
+game (
+	name "Nickelodeon Avatar - The Last Airbender - The Burning Earth (USA)"
+	description "Nickelodeon Avatar - The Last Airbender - The Burning Earth (USA)"
+	rom ( name "Nickelodeon Avatar - The Last Airbender - The Burning Earth (USA).iso" size 4699979776 crc 33b18b4a md5 088ef97ae3d89084545427c66082c974 sha1 33212b238e0ced9ee10014fe8af9d3511b9d762b )
+)
+
+game (
+	name "Nickelodeon Avatar - The Legend of Aang - The Burning Earth (Europe) (En,Fr,De,Nl)"
+	description "Nickelodeon Avatar - The Legend of Aang - The Burning Earth (Europe) (En,Fr,De,Nl)"
+	rom ( name "Nickelodeon Avatar - The Legend of Aang - The Burning Earth (Europe) (En,Fr,De,Nl).iso" size 4699979776 crc ef8a01d3 md5 65456023e7d442e17d1e80f79c230c3b sha1 93a1c26271acaee3f8fa082bdb62706e169f7ff5 )
+)
+
+game (
+	name "Nickelodeon Barnyard (USA)"
+	description "Nickelodeon Barnyard (USA)"
+	rom ( name "Nickelodeon Barnyard (USA).iso" size 4699979776 crc aa84abac md5 534b618644b9255a47dc1828777c48cb sha1 180d316e6abcb3ab5fcd0924790f551a10179ea0 )
+)
+
+game (
+	name "Nickelodeon Bob Esponja - Atrapados en el Congelador (Spain)"
+	description "Nickelodeon Bob Esponja - Atrapados en el Congelador (Spain)"
+	rom ( name "Nickelodeon Bob Esponja - Atrapados en el Congelador (Spain).iso" size 4699979776 crc 510733b0 md5 aa4064c7bf06391d38d72f1edbf7e5e2 sha1 572837d82a3a8546a5af4e4b8dc1496c670da005 )
+)
+
+game (
+	name "Nickelodeon Dance (USA)"
+	description "Nickelodeon Dance (USA)"
+	rom ( name "Nickelodeon Dance (USA).iso" size 4699979776 crc 9908a1f4 md5 73bb667771892b8163ec9bcac71e8f97 sha1 b9ca56f6c614c8788156c39e9f0e3bd4024608b0 )
+)
+
+game (
+	name "Nickelodeon Go Diego Go! Great Dinosaur Rescue (USA) (En,Fr)"
+	description "Nickelodeon Go Diego Go! Great Dinosaur Rescue (USA) (En,Fr)"
+	rom ( name "Nickelodeon Go Diego Go! Great Dinosaur Rescue (USA) (En,Fr).iso" size 4699979776 crc 6b92919c md5 ffbfe733adeaabfcc4e2b07aa20708ea sha1 3c4c914e9cdbdefbebdcee80d27ef20f4566b483 )
+)
+
+game (
+	name "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe)"
+	description "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe)"
+	rom ( name "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe).iso" size 4699979776 crc 9f305f02 md5 9615cd69ca692a5acea7a1a0cec63b25 sha1 3f8146e8732d34df2866aaf33ee512dd363708bb )
+)
+
+game (
+	name "Nickelodeon SpongeBob Squarepants - Boating Bash (Europe) (En,De)"
+	description "Nickelodeon SpongeBob Squarepants - Boating Bash (Europe) (En,De)"
+	rom ( name "Nickelodeon SpongeBob Squarepants - Boating Bash (Europe) (En,De).iso" size 4699979776 crc 17cd29c9 md5 9944e684eb85bff2cdcc2adaebb5a91f sha1 87f0a86acc521efb4e9f66690edee69f913ba74f )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe) (En,Fr,De)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe) (En,Fr,De)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (Europe) (En,Fr,De).iso" size 4699979776 crc b49a1f1f md5 f0b0eb37c082f41a2f56133330f2189e sha1 fba731a60a34798039855ecc43474d1325bd8db2 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA)"
+	description "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA)"
+	rom ( name "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab (USA).iso" size 4699979776 crc 3577cef7 md5 5db76c3abdf57f11be7672b9fe1ee990 sha1 9522ec5fe71b011b9a3d446ce6cbe2a6b4d5a252 )
+)
+
+game (
+	name "Nickelodeon SpongeBob SquarePants featuring Nicktoons - Globs of Doom (USA) (En,Fr)"
+	description "Nickelodeon SpongeBob SquarePants featuring Nicktoons - Globs of Doom (USA) (En,Fr)"
+	rom ( name "Nickelodeon SpongeBob SquarePants featuring Nicktoons - Globs of Doom (USA) (En,Fr).iso" size 4699979776 crc 7b5f65a5 md5 6f279a8d2a60109826c90f818dbc7751 sha1 99231e4764a73b9285b5390336d8206018377730 )
+)
+
+game (
+	name "Nickelodeon SpongeBob's Atlantis SquarePantis (USA)"
+	description "Nickelodeon SpongeBob's Atlantis SquarePantis (USA)"
+	rom ( name "Nickelodeon SpongeBob's Atlantis SquarePantis (USA).iso" size 4699979776 crc 6e150afe md5 c131a5bf2ffb92c481333a2c0b1e14f4 sha1 2318475b18d370f8f248cc9e3943f673652db90c )
+)
+
+game (
+	name "Nickelodeon SpongeBob's Truth or Square (USA)"
+	description "Nickelodeon SpongeBob's Truth or Square (USA)"
+	rom ( name "Nickelodeon SpongeBob's Truth or Square (USA).iso" size 4699979776 crc 1b73aaf8 md5 6b3d277e638f41fa6cc4985ce7ef05bd sha1 eacbd13978be3e660221eeac98b3cbf669d4a10d )
+)
+
+game (
+	name "Nickelodeon Tak and the Guardians of Gross (USA)"
+	description "Nickelodeon Tak and the Guardians of Gross (USA)"
+	rom ( name "Nickelodeon Tak and the Guardians of Gross (USA).iso" size 4699979776 crc 6ef897e3 md5 97ac3dac3504352cbace90840bde24d1 sha1 ec6b0cca52bbcc8d3d16a23d5bf01f0eb9ba1320 )
+)
+
+game (
+	name "Nicktoons - Attack of the Toybots (USA)"
+	description "Nicktoons - Attack of the Toybots (USA)"
+	rom ( name "Nicktoons - Attack of the Toybots (USA).iso" size 4699979776 crc 75a98c95 md5 5b27c3f480fb8568c0640102c6085c9b sha1 29fd5b03690512400ffcd2c6268edeb8bb02c9e7 )
+)
+
+game (
+	name "Nights - Journey of Dreams (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Nights - Journey of Dreams (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Nights - Journey of Dreams (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 17a6c982 md5 92939a07dd975966d9607de8d2599685 sha1 102d091c578846ad890173cd6043f4f7bcefd30b )
+)
+
+game (
+	name "Nights - Journey of Dreams (USA) (En,Ja,Fr,De,Es,It)"
+	description "Nights - Journey of Dreams (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Nights - Journey of Dreams (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 35af615a md5 1dd7d7a20586c4714465ff7a7e46ffbe sha1 6b977534de79d3c9b14663f327d047738db1d8bb )
+)
+
+game (
+	name "Ninja Reflex (USA) (En,Fr,Es)"
+	description "Ninja Reflex (USA) (En,Fr,Es)"
+	rom ( name "Ninja Reflex (USA) (En,Fr,Es).iso" size 4699979776 crc 5808f3e0 md5 31d5b31992f677fea41cb4296bb37b5f sha1 6dbc49da21ea969d791488889541e1cdd27b4ad9 )
+)
+
+game (
+	name "Ninjabread Man (Europe)"
+	description "Ninjabread Man (Europe)"
+	rom ( name "Ninjabread Man (Europe).iso" size 4699979776 crc c5b12ab6 md5 38c9a626a206858c4e72f3ed0fc2e477 sha1 074e19bc1d73a1b859a8624a0bc3ed9a9d3acf7b )
+)
+
+game (
+	name "Nitrobike (Europe) (En,Fr,De,Es,It)"
+	description "Nitrobike (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Nitrobike (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc eff59185 md5 079b465096d45d206a04438c4b6146ff sha1 20fc209e75a5233efda33c87f6d29d9e98d4f2da )
+)
+
+game (
+	name "Nitrobike (USA)"
+	description "Nitrobike (USA)"
+	rom ( name "Nitrobike (USA).iso" size 4699979776 crc 87cfc9d0 md5 d0fd28816638976994dc665b97c75946 sha1 8826a6fb5b02d2ee31abce12600c9051d31e6dc3 )
+)
+
+game (
+	name "No More Heroes (Europe) (En,Fr,De,Es,It)"
+	description "No More Heroes (Europe) (En,Fr,De,Es,It)"
+	rom ( name "No More Heroes (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc bd29d584 md5 9a7e2c53d59dfe7664a620b835396f83 sha1 55219e66da692c43f436c642f97ad5824ceaa09b )
+)
+
+game (
+	name "No More Heroes (Japan)"
+	description "No More Heroes (Japan)"
+	rom ( name "No More Heroes (Japan).iso" size 4699979776 crc 0d3e2141 md5 ff4e941467825a200e13e78c34a16c6b sha1 25e9cc6273badd224476b2fdc0020f194f5806c4 )
+)
+
+game (
+	name "No More Heroes (USA) (En,Fr,Es)"
+	description "No More Heroes (USA) (En,Fr,Es)"
+	rom ( name "No More Heroes (USA) (En,Fr,Es).iso" size 4699979776 crc 4cf0ebe2 md5 6421acd04a9cb6781b1fd765701b7b20 sha1 a8a193fb32238aa64757b3439de9c8c58467bd48 )
+)
+
+game (
+	name "No More Heroes 2 - Desperate Struggle (Europe) (En,Fr,De,Es,It)"
+	description "No More Heroes 2 - Desperate Struggle (Europe) (En,Fr,De,Es,It)"
+	rom ( name "No More Heroes 2 - Desperate Struggle (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 70ddae8f md5 e5d3c08aef715b0b1a5393fe7138aa9e sha1 ab9fb4e40f8767e74dbac1487bca6f676d9438ef )
+)
+
+game (
+	name "No More Heroes 2 - Desperate Struggle (USA) (En,Fr,Es)"
+	description "No More Heroes 2 - Desperate Struggle (USA) (En,Fr,Es)"
+	rom ( name "No More Heroes 2 - Desperate Struggle (USA) (En,Fr,Es).iso" size 4699979776 crc af61e139 md5 00cb871d08c1859d81102dfd35d860c8 sha1 6f89a7fe49ef211ca01be73fc7332b8147d8ef78 )
+)
+
+game (
+	name "North American Hunting Extravaganza 2 (USA)"
+	description "North American Hunting Extravaganza 2 (USA)"
+	rom ( name "North American Hunting Extravaganza 2 (USA).iso" size 4699979776 crc f670eb15 md5 f1f602b8c33e33b1282deac2dd217fb8 sha1 c60425cdc15a30286d8c3df6aaf68a2ab6102fb1 )
+)
+
+game (
+	name "Oboro Muramasa (Japan)"
+	description "Oboro Muramasa (Japan)"
+	rom ( name "Oboro Muramasa (Japan).iso" size 4699979776 crc 1de890ba md5 0ff33af4ef84752c5ecfa21b62960cb5 sha1 2d06e72dfd2f190a0d286b058b23bbd89830e020 )
+)
+
+game (
+	name "ObsCure II (Europe) (En,Fr,De,Es,It)"
+	description "ObsCure II (Europe) (En,Fr,De,Es,It)"
+	rom ( name "ObsCure II (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e89b6f09 md5 17eeea93a5ddf5f067124f1c7245aa65 sha1 bed988362122a1549e74ea91b4440c1f2deef95e )
+)
+
+game (
+	name "Odoru Made in Wario (Japan)"
+	description "Odoru Made in Wario (Japan)"
+	rom ( name "Odoru Made in Wario (Japan).iso" size 4699979776 crc da0c55d1 md5 560bc493cd16251cc1f878c4a21dab6a sha1 ef9e2ba6c3888bde63ba401661a8dda328563f4c )
+)
+
+game (
+	name "Okami (Europe) (En,Fr,De)"
+	description "Okami (Europe) (En,Fr,De)"
+	rom ( name "Okami (Europe) (En,Fr,De).iso" size 4699979776 crc cc823c96 md5 86b621b0dce79d6397d5f9bb2fe90a22 sha1 03c5ffdc55ca9af4f35410d5e645cd716fa906ca )
+)
+
+game (
+	name "Okami (USA)"
+	description "Okami (USA)"
+	rom ( name "Okami (USA).iso" size 4699979776 crc d31c3e93 md5 dac4e2030f2ab1ec147a8991d6cbcb0a sha1 b4618f9b0c088a74b688b215509cb0aa663a3610 )
+)
+
+game (
+	name "One Piece - Unlimited Cruise - Episode 1 - Nami ni Yureru Hihou (Japan)"
+	description "One Piece - Unlimited Cruise - Episode 1 - Nami ni Yureru Hihou (Japan)"
+	rom ( name "One Piece - Unlimited Cruise - Episode 1 - Nami ni Yureru Hihou (Japan).iso" size 4699979776 crc 97404544 md5 11f3c1e8ae77e135bf3fec378c8b0e92 sha1 aed572f5cbd1877495dab66415d789b81cec72b5 )
+)
+
+game (
+	name "Onechanbara - Bikini Zombie Slayers (USA) (En,Fr)"
+	description "Onechanbara - Bikini Zombie Slayers (USA) (En,Fr)"
+	rom ( name "Onechanbara - Bikini Zombie Slayers (USA) (En,Fr).iso" size 4699979776 crc a9d9dc47 md5 f9c82717183d15d3e4a80452af0b31b3 sha1 bcfcf64aefad56959a0051d790a6a36679c08e20 )
+)
+
+game (
+	name "Opoona (Europe) (En,Fr,De)"
+	description "Opoona (Europe) (En,Fr,De)"
+	rom ( name "Opoona (Europe) (En,Fr,De).iso" size 4699979776 crc 6fc5df2a md5 1edb8f320a8c1944772df21980d96bc1 sha1 3b21fa54e7e2f223ef2c070e0a49bde94d147832 )
+)
+
+game (
+	name "Order Up! (Europe) (En,Fr,De,Es,It)"
+	description "Order Up! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Order Up! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 070826bb md5 fa2b0da2e13cae10bb0ab62b2f0efa80 sha1 754ec00e85edbc8be29a9e452c06c50359363681 )
+)
+
+game (
+	name "Order Up! (UK)"
+	description "Order Up! (UK)"
+	rom ( name "Order Up! (UK).iso" size 4699979776 crc fd1c72f2 md5 dc5678a7ccfa74ffce04a327d14cbeb7 sha1 19af74ad01eadd0de87996674f92454eed058499 )
+)
+
+game (
+	name "Outdoor Action Double Pack (USA)"
+	description "Outdoor Action Double Pack (USA)"
+	rom ( name "Outdoor Action Double Pack (USA).iso" size 4699979776 crc 4d05ca7b md5 4b0bb8e14a97a4cdf21ac055b64cdefa sha1 7c2ee59d3af6bcc0e89eac1f24a8d1041f8208e4 )
+)
+
+game (
+	name "Overlord - Dark Legend (USA) (En,Fr,Es)"
+	description "Overlord - Dark Legend (USA) (En,Fr,Es)"
+	rom ( name "Overlord - Dark Legend (USA) (En,Fr,Es).iso" size 4699979776 crc 68ce591f md5 1d1603a0592e95d1760f361c3e44fd9c sha1 9311e7b649e3e7fa6baa4aa730a05b75acb3f441 )
+)
+
+game (
+	name "Pac-Man Party (Japan)"
+	description "Pac-Man Party (Japan)"
+	rom ( name "Pac-Man Party (Japan).iso" size 4699979776 crc 0a454c41 md5 bfa4b88d6c15ac0f98b5f4b69830c404 sha1 b6a439934fea8d781fa1dbcb537960665a8325a4 )
+)
+
+game (
+	name "Pajama Sam - Don't Fear the Dark (USA)"
+	description "Pajama Sam - Don't Fear the Dark (USA)"
+	rom ( name "Pajama Sam - Don't Fear the Dark (USA).iso" size 4699979776 crc 999d5277 md5 198d75e1605b57acb1497ff677eb8f9f sha1 f39dc68ef52dacd57ff1354285b72c74486e0804 )
+)
+
+game (
+	name "Pandora no Tou - Kimi no Moto e Kaeru made (Japan)"
+	description "Pandora no Tou - Kimi no Moto e Kaeru made (Japan)"
+	rom ( name "Pandora no Tou - Kimi no Moto e Kaeru made (Japan).iso" size 4699979776 crc 5bdfdf3a md5 40c2f8c2d9d94d44d12871182b9a05dc sha1 c23b2680fc9cba45651eeb9818dc887e4415b3e6 )
+)
+
+game (
+	name "Pandora's Tower (Europe) (En,Fr,De,Es,It)"
+	description "Pandora's Tower (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pandora's Tower (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4acb6d26 md5 518bfc0cb7e374f85568ca88975c7ef6 sha1 ff425322460a98aa8f56335372ba0d696450ee28 )
+)
+
+game (
+	name "Pandora's Tower (USA) (En,Fr,Es)"
+	description "Pandora's Tower (USA) (En,Fr,Es)"
+	rom ( name "Pandora's Tower (USA) (En,Fr,Es).iso" size 4699979776 crc 8398c943 md5 5bf999114d6741c04fe2e84d1b7b0509 sha1 66284691913ed85029b394eef194024f4a99c614 )
+)
+
+game (
+	name "Pangya! Golf with Style (Europe) (En,Fr,De,Es,It)"
+	description "Pangya! Golf with Style (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pangya! Golf with Style (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9cb20c2f md5 ef6bb0f37a8c7a196dc277220ba0903d sha1 3057567ad3548e455cb42d2bf21c365d3185483d )
+)
+
+game (
+	name "Paws & Claws - Pet Vet (USA) (En,Fr,Es)"
+	description "Paws & Claws - Pet Vet (USA) (En,Fr,Es)"
+	rom ( name "Paws & Claws - Pet Vet (USA) (En,Fr,Es).iso" size 4699979776 crc 1e4baed0 md5 829536ca97e2e3741e5d2746851989c6 sha1 230cb3357125ac2875f22e75c705dd083ac31b26 )
+)
+
+game (
+	name "PDC World Championship Darts 2008 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "PDC World Championship Darts 2008 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "PDC World Championship Darts 2008 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 49d7d4c0 md5 735516c760d4448702493b5b7d72de19 sha1 2ff1286d914cf9b5ebcdcb3de32f5a8a76da667a )
+)
+
+game (
+	name "PDC World Championship Darts 2009 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "PDC World Championship Darts 2009 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "PDC World Championship Darts 2009 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc e1064d9d md5 42dc64e013a9a23c203b365d436eee88 sha1 13ee54ec71d942a7712ae3513d7dd7d50bbff83f )
+)
+
+game (
+	name "PES 2008 - Pro Evolution Soccer (Europe) (En,Fr,De,Es,It,Pt)"
+	description "PES 2008 - Pro Evolution Soccer (Europe) (En,Fr,De,Es,It,Pt)"
+	rom ( name "PES 2008 - Pro Evolution Soccer (Europe) (En,Fr,De,Es,It,Pt).iso" size 4699979776 crc 62e0f03c md5 f389d957622177571d746f8884d90c6a sha1 82c3ac3ef6ad69590e27257f770ef9292722fea9 )
+)
+
+game (
+	name "PES 2009 - Pro Evolution Soccer (Europe) (En,Fr,De)"
+	description "PES 2009 - Pro Evolution Soccer (Europe) (En,Fr,De)"
+	rom ( name "PES 2009 - Pro Evolution Soccer (Europe) (En,Fr,De).iso" size 4699979776 crc 97605dc4 md5 fa4d3ec9837a0f93405759dd47dfdfa7 sha1 d1257da8b80a70d653566d85991ef7b6d59d39f7 )
+)
+
+game (
+	name "PES 2010 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,El)"
+	description "PES 2010 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,El)"
+	rom ( name "PES 2010 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,El).iso" size 4699979776 crc 74c41544 md5 981ee51693b1a53d36d0b98d16e02daa sha1 75cfd7797902291ce949a9d052494056c871990b )
+)
+
+game (
+	name "PES 2011 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,Tr)"
+	description "PES 2011 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,Tr)"
+	rom ( name "PES 2011 - Pro Evolution Soccer (Europe) (En,Nl,Sv,Ru,Tr).iso" size 4699979776 crc 43764033 md5 abedb18c4cbaeb3120b352f69c9b4030 sha1 19669a7695985f9d4b4d0eedfda1445d0994a472 )
+)
+
+game (
+	name "PES 2012 - Pro Evolution Soccer (Europe) (En,Sv,Da,Ru,Tr)"
+	description "PES 2012 - Pro Evolution Soccer (Europe) (En,Sv,Da,Ru,Tr)"
+	rom ( name "PES 2012 - Pro Evolution Soccer (Europe) (En,Sv,Da,Ru,Tr).iso" size 4699979776 crc 33e38004 md5 f3218ab104c22f8af795873fd2be6412 sha1 8285c8c21e9ab5909f60aada9b9f0878889bdd35 )
+)
+
+game (
+	name "PES 2012 - Pro Evolution Soccer (Europe) (Fr,De,El)"
+	description "PES 2012 - Pro Evolution Soccer (Europe) (Fr,De,El)"
+	rom ( name "PES 2012 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc 54731550 md5 3dc0df44c21a8f36d171938abef8703d sha1 d04c86910428aaf3072bcd81f9a4282206e59fc3 )
+)
+
+game (
+	name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
+	description "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
+	rom ( name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc f9a8040b md5 9de67539e64b3544bbedd137a59d401f sha1 c56632c087b14356d82ff3042be8baee69167e1c )
+)
+
+game (
+	name "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc fde9f955 md5 3ca050ac702df96ae53d0cb1763a1831 sha1 b44623b9763feabe2e24d18e24001cb596e3a3e9 )
+)
+
+game (
+	name "Phantom Brave - We Meet Again (USA)"
+	description "Phantom Brave - We Meet Again (USA)"
+	rom ( name "Phantom Brave - We Meet Again (USA).iso" size 4699979776 crc d63815f8 md5 8d4166825fd86391b843152723a60860 sha1 f184cd5e051fcb7caa45ef476f4ad78e0739cf57 )
+)
+
+game (
+	name "Pikmin (Europe) (En,Fr,De,Es,It)"
+	description "Pikmin (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pikmin (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b999d726 md5 eded803e145c760bad2983caf19ff504 sha1 7aa500b30b242edeabaf340c26242c9b36b24b23 )
+)
+
+game (
+	name "Pikmin (USA) (En,Fr,Es)"
+	description "Pikmin (USA) (En,Fr,Es)"
+	rom ( name "Pikmin (USA) (En,Fr,Es).iso" size 4699979776 crc 4f34ddc2 md5 092f509fdd7370903ab2c3e993e1ae3c sha1 abdef200f685aa5f38d14633a837a01ca3b9e8c1 )
+)
+
+game (
+	name "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
+	description "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Pikmin 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c3f982e7 md5 2cf3a242c243652e9d174e155e91bef6 sha1 779b63380319d419f8e1e65f59da66311748c43b )
+)
+
+game (
+	name "Pikmin 2 (USA) (En,Fr,Es)"
+	description "Pikmin 2 (USA) (En,Fr,Es)"
+	rom ( name "Pikmin 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 5ecfe4cc md5 bbc83bf55728c0a3ec689579f2eb795e sha1 77c7e815fbf3e83b71c398a70369d674bf413caa )
+)
+
+game (
+	name "Pirates vs. Ninjas - Dodgeball (USA) (En,Fr,Es)"
+	description "Pirates vs. Ninjas - Dodgeball (USA) (En,Fr,Es)"
+	rom ( name "Pirates vs. Ninjas - Dodgeball (USA) (En,Fr,Es).iso" size 4699979776 crc 2f512300 md5 7a5b86aea8c1fe18636e2386a5b08737 sha1 a3688cf798bc6fb23b433f1ee78149453e6f9146 )
+)
+
+game (
+	name "Pitfall - The Big Adventure (USA) (En,Fr)"
+	description "Pitfall - The Big Adventure (USA) (En,Fr)"
+	rom ( name "Pitfall - The Big Adventure (USA) (En,Fr).iso" size 4699979776 crc cdb1742a md5 dd28800c6fae72ee502afd87bc687294 sha1 4e2f635902ccb221af6b3ebde6e25f1b9ef50471 )
+)
+
+game (
+	name "Playmobil Circus (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	description "Playmobil Circus (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
+	rom ( name "Playmobil Circus (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da).iso" size 4699979776 crc 3ce73ca3 md5 8a8c6282da89d5b5c83735625897eb16 sha1 d5ce957371ecaee96b5c82590e90032b74e6ae9b )
+)
+
+game (
+	name "Pokemon Battle Revolution (Japan)"
+	description "Pokemon Battle Revolution (Japan)"
+	rom ( name "Pokemon Battle Revolution (Japan).iso" size 4699979776 crc 5b4ad0ac md5 bd0b845933fc6284f865500027f243c4 sha1 8d2604d2aaed9de30f95521947799c5e6c022b48 )
+)
+
+game (
+	name "Pokemon Battle Revolution (USA)"
+	description "Pokemon Battle Revolution (USA)"
+	rom ( name "Pokemon Battle Revolution (USA).iso" size 4699979776 crc 3bb40b20 md5 95a1a518cbec79fa217319e235cf31d7 sha1 dbb81d960549f82514c5669de460c345bed76a65 )
+)
+
+game (
+	name "PokePark 2 - Beyond the World (Japan)"
+	description "PokePark 2 - Beyond the World (Japan)"
+	rom ( name "PokePark 2 - Beyond the World (Japan).iso" size 4699979776 crc f54efff2 md5 67fc38ad22b11028be86e44288cf8e86 sha1 f2da92054cb11b67291124db4c284456aafd1c6d )
+)
+
+game (
+	name "PokePark 2 - Wonders Beyond (USA)"
+	description "PokePark 2 - Wonders Beyond (USA)"
+	rom ( name "PokePark 2 - Wonders Beyond (USA).iso" size 4699979776 crc 7771d7ef md5 4b087f066230fa72db05362186532899 sha1 e429a232431ea7075ae959b030a7675846357c19 )
+)
+
+game (
+	name "PokePark Wii - Pikachu's Adventure (Europe) (En,Fr,De,Es,It)"
+	description "PokePark Wii - Pikachu's Adventure (Europe) (En,Fr,De,Es,It)"
+	rom ( name "PokePark Wii - Pikachu's Adventure (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b95a6bdd md5 08c3f7b1a3904ea855ce87ba41720fbb sha1 ee8d5683dac2d5df40afc87132787322b2821637 )
+)
+
+game (
+	name "PokePark Wii - Pikachu's Adventure (USA)"
+	description "PokePark Wii - Pikachu's Adventure (USA)"
+	rom ( name "PokePark Wii - Pikachu's Adventure (USA).iso" size 4699979776 crc 26e533d5 md5 e77a98f49c984f7685207b19bb7f3157 sha1 c9a6f7601fd54b5e21a0909084839d30874a9a37 )
+)
+
+game (
+	name "PopStar Guitar (Europe) (En,Fr,De,Es,It)"
+	description "PopStar Guitar (Europe) (En,Fr,De,Es,It)"
+	rom ( name "PopStar Guitar (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 925b0cc5 md5 090ddc5fb9dced59ac5a917feb17070a sha1 3ec9a2b1e543e1bfb4d624bfa831755a867d7ace )
+)
+
+game (
+	name "Price Is Right, The - 2010 Edition (USA) (En,Fr)"
+	description "Price Is Right, The - 2010 Edition (USA) (En,Fr)"
+	rom ( name "Price Is Right, The - 2010 Edition (USA) (En,Fr).iso" size 4699979776 crc b21a2980 md5 019a9c3e8eb75fb49b19093b08af5fae sha1 818096e71a0794d4a736b94e830174d8022b0234 )
+)
+
+game (
+	name "Price Is Right, The - Decades (USA)"
+	description "Price Is Right, The - Decades (USA)"
+	rom ( name "Price Is Right, The - Decades (USA).iso" size 4699979776 crc e4fe0b47 md5 c2cd3d27872a06887ceb8290f8d77216 sha1 baee1a7e859081215331479510078a9b99ef70c1 )
+)
+
+game (
+	name "Price Is Right, The (USA) (En,Fr)"
+	description "Price Is Right, The (USA) (En,Fr)"
+	rom ( name "Price Is Right, The (USA) (En,Fr).iso" size 4699979776 crc 37806d85 md5 165d4d3cbc5528c4d0df8108804d74da sha1 2a51d829c0fc54be343e5622c1ae349883d7291d )
+)
+
+game (
+	name "Prince of Persia - Rival Swords (Europe) (En,Fr,De,Es,It)"
+	description "Prince of Persia - Rival Swords (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Prince of Persia - Rival Swords (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ef7b8efe md5 777fc6256229a833e0726c1ede154cef sha1 bd0b8055a288bbe5bddb12147cef667c96294b22 )
+)
+
+game (
+	name "Prince of Persia - Rival Swords (USA) (En,Fr,Es)"
+	description "Prince of Persia - Rival Swords (USA) (En,Fr,Es)"
+	rom ( name "Prince of Persia - Rival Swords (USA) (En,Fr,Es).iso" size 4699979776 crc 7cd51cbd md5 4ed9e1be2f24fbb59e6d2f56c6b61ba0 sha1 82d8d217d392b87d8e2ad5f9c456b7a96a9a9709 )
+)
+
+game (
+	name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc d0b4fa69 md5 aaaf8d9226365969db23460c1ffda396 sha1 ac8415e87ee45a6457b60294892758f877d8d7e3 )
+)
+
+game (
+	name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es)"
+	description "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es)"
+	rom ( name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es).iso" size 4699979776 crc f91314fd md5 7048c2caad084bd96bbf812a87c29ba5 sha1 bc7d035a71e11cc4a70bc985bf5f3b2f612bf3b2 )
+)
+
+game (
+	name "Prince of Persia - The Forgotten Sands + 1989 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Prince of Persia - The Forgotten Sands + 1989 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Prince of Persia - The Forgotten Sands + 1989 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 8885efe2 md5 e09b6058fcca8ab191ffeb361288a49d sha1 5a7bc5e9d6dbdf760d2a4cea8a6ce55ad3a34408 )
+)
+
+game (
+	name "Pro Golfer Saru (Japan)"
+	description "Pro Golfer Saru (Japan)"
+	rom ( name "Pro Golfer Saru (Japan).iso" size 4699979776 crc 4b1ce85a md5 ee6a86c5fc41ab23bc0ac03a5dbb2507 sha1 e14302c89b1634bb6d026b0e4f5bca8ad3778a75 )
+)
+
+game (
+	name "Professor Heinz Wolff's Gravity (Europe) (En,Fr,De,Es,It)"
+	description "Professor Heinz Wolff's Gravity (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Professor Heinz Wolff's Gravity (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc dfbf1916 md5 73217180f78f84802f98033b55b4c2fe sha1 5b1fb65fd320394942a3f5dd11c918e2d2008d70 )
+)
+
+game (
+	name "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It)"
+	description "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 04deedb6 md5 7ddbcbff22ab64b3e99604d402bfa3d8 sha1 a6e647f0218a2a1aed7be6c85f3d6422414e163a )
+)
+
+game (
+	name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc fa85b484 md5 41e6916519d67f457298fd988b7e9f65 sha1 f3d09de0b94a09f7ae8c4c92cdd477d21fa7bf90 )
+)
+
+game (
+	name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 4d837073 md5 19807f20a3866ed657c8cfeb3734b238 sha1 40aea2fc8f738727f6293477de5d4e8df4de83dd )
+)
+
+game (
+	name "Punch-Out!! (USA) (En,Fr,Es)"
+	description "Punch-Out!! (USA) (En,Fr,Es)"
+	rom ( name "Punch-Out!! (USA) (En,Fr,Es).iso" size 4699979776 crc c1f5f0e4 md5 6d0e5884cac674ac50d132cb1f3aa762 sha1 0232f0c61285e9e810847f504b1c626f6a6d472a )
+)
+
+game (
+	name "Puzzle Kingdoms (Europe) (En,Fr,De,Es,It)"
+	description "Puzzle Kingdoms (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Puzzle Kingdoms (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 88428375 md5 00c242a902d57dd70ff030488e34bc9d sha1 56b3fc392ca6b04de8796c18543761dad5ca6b9f )
+)
+
+game (
+	name "Puzzle Kingdoms (USA) (En,Fr,Es)"
+	description "Puzzle Kingdoms (USA) (En,Fr,Es)"
+	rom ( name "Puzzle Kingdoms (USA) (En,Fr,Es).iso" size 4699979776 crc 56131f48 md5 518aca2590d49a7b28b5b5902cf6266d sha1 071d83aba327398ac3974ca9a7e8ea74fa3c302c )
+)
+
+game (
+	name "Puzzler Collection (Europe)"
+	description "Puzzler Collection (Europe)"
+	rom ( name "Puzzler Collection (Europe).iso" size 4699979776 crc 6de7b65e md5 70bd87d1537c85a10f370d5b257473cb sha1 e21ff59a30beee56477f2da47e9dacbfc30abfb5 )
+)
+
+game (
+	name "Rabbids - Go Home (Japan)"
+	description "Rabbids - Go Home (Japan)"
+	rom ( name "Rabbids - Go Home (Japan).iso" size 4699979776 crc f8de6f4e md5 3bf61d3866aa1a8c197af22d9dddd600 sha1 6dffef166313444eb56245ef18508adfe0135e6e )
+)
+
+game (
+	name "Rabbids Go Home (Europe) (En,Fr,De,Es,It,Nl,No,Da,Fi)"
+	description "Rabbids Go Home (Europe) (En,Fr,De,Es,It,Nl,No,Da,Fi)"
+	rom ( name "Rabbids Go Home (Europe) (En,Fr,De,Es,It,Nl,No,Da,Fi).iso" size 4699979776 crc b9ab373b md5 538052124b2ea0fb228baf5229f8bba3 sha1 497488b795ee9fbc0f43041502a7925ab2f278e8 )
+)
+
+game (
+	name "Rabbids Go Home (USA) (En,Fr,Es)"
+	description "Rabbids Go Home (USA) (En,Fr,Es)"
+	rom ( name "Rabbids Go Home (USA) (En,Fr,Es).iso" size 4699979776 crc 6f27a103 md5 5c0453356f94d021530ac99fc28c50ff sha1 21c2d1cccc6ab0c557e97453ef0802ca293f57d4 )
+)
+
+game (
+	name "Rabbids Party - Time Travel (Japan)"
+	description "Rabbids Party - Time Travel (Japan)"
+	rom ( name "Rabbids Party - Time Travel (Japan).iso" size 4699979776 crc 1b9d6594 md5 7fd1c849fef560fc0ba9d3adcc671ba6 sha1 9b21b8b9ea85024628243d4ca095bf7be4e8636a )
+)
+
+game (
+	name "Rabbids Party - TV Party (Japan)"
+	description "Rabbids Party - TV Party (Japan)"
+	rom ( name "Rabbids Party - TV Party (Japan).iso" size 4699979776 crc af9fbcd0 md5 cc635525f99334e6319fbeb191d98ce7 sha1 26d115691b92dd5fe12c8e155fa59cc12c07079b )
+)
+
+game (
+	name "Rabbids Party Returns (Japan)"
+	description "Rabbids Party Returns (Japan)"
+	rom ( name "Rabbids Party Returns (Japan).iso" size 4699979776 crc 4ca6426e md5 0f4a4acc35635d7ea142afa8c685e1cf sha1 6b93473343dbab41d67a066ed4e323b868b4f99c )
+)
+
+game (
+	name "Racquet Sports (USA)"
+	description "Racquet Sports (USA)"
+	rom ( name "Racquet Sports (USA).iso" size 4699979776 crc bec259d5 md5 8de403bb81369479d69e3fb88c5cf7ac sha1 d22cf728a3798678d2da4ad66c5fa5649983c020 )
+)
+
+game (
+	name "Rampage - Total Destruction (Europe) (En,Fr,De,Es,It)"
+	description "Rampage - Total Destruction (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rampage - Total Destruction (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1bf67fbf md5 e6e0d32d4701bba9658f5e234aee7fc7 sha1 433272bada0177138fdf53866f80b4dbac9e6bcc )
+)
+
+game (
+	name "Rampage - Total Destruction (USA)"
+	description "Rampage - Total Destruction (USA)"
+	rom ( name "Rampage - Total Destruction (USA).iso" size 4699979776 crc 5512f6f6 md5 a489cf68ec7541aed8f7bc3a44b13b52 sha1 f1485f19bd590c90afec80916a913f8dc6446ba3 )
+)
+
+game (
+	name "Rango (Europe) (En,Fr,De,Es,It)"
+	description "Rango (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rango (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 8d84381b md5 cd122336250f495e4c118b7339f813c7 sha1 6adfacb162b685cf841ac176fb188430fbbf2ddb )
+)
+
+game (
+	name "Rapala Tournament Fishing! (USA)"
+	description "Rapala Tournament Fishing! (USA)"
+	rom ( name "Rapala Tournament Fishing! (USA).iso" size 4699979776 crc 3a0a8886 md5 8832722295ed4e534de90bdec541bc07 sha1 848e6aaceaa4df90a49b4535b590adea7555f8e7 )
+)
+
+game (
+	name "Rapala's Fishing Frenzy (USA)"
+	description "Rapala's Fishing Frenzy (USA)"
+	rom ( name "Rapala's Fishing Frenzy (USA).iso" size 4699979776 crc 071a480b md5 60128f2e512de8a40d95323a8f40cbae sha1 f88475988dc29e8416d88e9bd3457e19429a2659 )
+)
+
+game (
+	name "Raving Rabbids - Party Collection (USA) (En,Fr,Es)"
+	description "Raving Rabbids - Party Collection (USA) (En,Fr,Es)"
+	rom ( name "Raving Rabbids - Party Collection (USA) (En,Fr,Es).iso" size 8511160320 crc b635df1f md5 f8dd516b98a20a12373e98086e98fe5b sha1 7cb2d90f88f19330131656b17277b307e8ff293e )
+)
+
+game (
+	name "Raving Rabbids - Travel in Time (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Raving Rabbids - Travel in Time (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Raving Rabbids - Travel in Time (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 3c0ecfeb md5 f408acefd0907e95e6ea6365bba63f76 sha1 e4201908c3c7e112a07aadcccd43ac968b021ab3 )
+)
+
+game (
+	name "Raving Rabbids - Travel in Time (USA) (En,Fr,Es)"
+	description "Raving Rabbids - Travel in Time (USA) (En,Fr,Es)"
+	rom ( name "Raving Rabbids - Travel in Time (USA) (En,Fr,Es).iso" size 4699979776 crc f5d7a6cc md5 9a47ce29692cf7a84de60b871db758e2 sha1 07f6854cf1ba13fb7617289a128e517ef0bcd15b )
+)
+
+game (
+	name "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	description "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	rom ( name "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.00).iso" size 4699979776 crc 9fe19815 md5 a51716de105eaef716d7a67b8f1fba10 sha1 83bf12370d828232339a9b28ab613ec12868fb01 )
+)
+
+game (
+	name "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
+	description "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
+	rom ( name "Rayman - Raving Rabbids - TV Party (Europe) (En,Fr,De,Es,It,Nl) (v1.01).iso" size 4699979776 crc ef151313 md5 484f3f9c7e5f5b3c4f421e595a01068a sha1 b405607dcf15fa293d32f8e510c1e05594075ba1 )
+)
+
+game (
+	name "Rayman - Raving Rabbids - TV Party (USA) (En,Fr,Es)"
+	description "Rayman - Raving Rabbids - TV Party (USA) (En,Fr,Es)"
+	rom ( name "Rayman - Raving Rabbids - TV Party (USA) (En,Fr,Es).iso" size 4699979776 crc 9b5f0944 md5 8de01d607c45fb2cf632eb430f6c399a sha1 a5658cb62ca16679d0ad4017efd7c4000d2f1ded )
+)
+
+game (
+	name "Rayman - Raving Rabbids (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Rayman - Raving Rabbids (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Rayman - Raving Rabbids (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 4ff8e3e3 md5 93087b19813fa71c7b82fe0a983ded10 sha1 ec9d8677eede7859d5703e2670c55c3f4fb101f0 )
+)
+
+game (
+	name "Rayman - Raving Rabbids (USA) (En,Fr,Es)"
+	description "Rayman - Raving Rabbids (USA) (En,Fr,Es)"
+	rom ( name "Rayman - Raving Rabbids (USA) (En,Fr,Es).iso" size 4699979776 crc d9cc8f7c md5 821581e806ebe25f867c4003087fbb0c sha1 bfbbbae29da89fc593796e80243e43e8aa19232f )
+)
+
+game (
+	name "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	description "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.00)"
+	rom ( name "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.00).iso" size 4699979776 crc b38e8f16 md5 63601882e426041e0375c4e3f5adec27 sha1 7bb35b76bbac7131bdb3eddbaeb9214ca2d58b6f )
+)
+
+game (
+	name "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
+	description "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
+	rom ( name "Rayman - Raving Rabbids 2 (Europe) (En,Fr,De,Es,It,Nl) (v1.01).iso" size 4699979776 crc 596dc924 md5 e0d902ed6e1fa47df2c57d765131ade7 sha1 eb0ace6b12190560cde7cfd092d56ba5e2eab4ab )
+)
+
+game (
+	name "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.00)"
+	description "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 053ea2bc md5 7e2500880bdcbac4e8781bbe038fd46b sha1 265440d5d2a26c9301e009de72d8d69891e55a26 )
+)
+
+game (
+	name "Rayman - Raving Rabbids 2 (USA) (v1.01)"
+	description "Rayman - Raving Rabbids 2 (USA) (v1.01)"
+	rom ( name "Rayman - Raving Rabbids 2 (USA) (v1.01).iso" size 4699979776 crc e55a3ba2 md5 75dec3dbcd7da58031746f46efff37d7 sha1 4c1c263e41164e9a4be055763fa723f983cf890b )
+)
+
+game (
+	name "Rayman Origins (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Rayman Origins (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Rayman Origins (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 15d2e3f3 md5 198cc22f33ba10b995ad24073fb7a950 sha1 1840214a394b470322f1889229df60baa38693c0 )
+)
+
+game (
+	name "Rayman Origins (USA) (En,Fr,Es)"
+	description "Rayman Origins (USA) (En,Fr,Es)"
+	rom ( name "Rayman Origins (USA) (En,Fr,Es).iso" size 4699979776 crc 4855eaf4 md5 a589436a25994f615151c3d0628775e9 sha1 3545272d53cd6783c3751fbd831d6c63e7890dc2 )
+)
+
+game (
+	name "Ready 2 Rumble - Revolution (USA) (En,Fr,Es)"
+	description "Ready 2 Rumble - Revolution (USA) (En,Fr,Es)"
+	rom ( name "Ready 2 Rumble - Revolution (USA) (En,Fr,Es).iso" size 4699979776 crc 1c80f38c md5 ba94999e12833f917fbe216b0e9157a4 sha1 434fa58acf23b68cd11654268e0b1ae1515b455f )
+)
+
+game (
+	name "Red Steel (Europe) (En,Fr,De,Es,It)"
+	description "Red Steel (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Red Steel (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6edecc25 md5 76e9c46b13a95e003c3c064ac42a37b3 sha1 80f072b2c1c92962bf1199c3d9852e9ae7f7af70 )
+)
+
+game (
+	name "Red Steel (USA) (En,Fr,Es)"
+	description "Red Steel (USA) (En,Fr,Es)"
+	rom ( name "Red Steel (USA) (En,Fr,Es).iso" size 4699979776 crc 3f33c77a md5 fd4cd9260cd9d2aa52968bb64abec8e1 sha1 71b0bf94847a79af9bdc2095fb7d1a3561981a11 )
+)
+
+game (
+	name "Red Steel 2 (Europe) (En,Fr,De,Es,It)"
+	description "Red Steel 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Red Steel 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e44c39c2 md5 5b89c7c2ee2a0a0e200366db13936896 sha1 64effa20881e318f6aa7a35277d1d2662d6faddc )
+)
+
+game (
+	name "Red Steel 2 (USA) (En,Fr,Es)"
+	description "Red Steel 2 (USA) (En,Fr,Es)"
+	rom ( name "Red Steel 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 7076cbe7 md5 b0777f57b04617703ad2171831b6cba3 sha1 8ed7f64d9e2937b2b350b76c8679dd653b8e2c33 )
+)
+
+game (
+	name "Resident Evil - The Darkside Chronicles (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Resident Evil - The Darkside Chronicles (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Resident Evil - The Darkside Chronicles (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc ec1aeca1 md5 19a03a302a5590515b4a5e0aa686358f sha1 8a204928a6f86dd268725a8f13924b91d86ff20b )
+)
+
+game (
+	name "Resident Evil - The Darkside Chronicles (USA)"
+	description "Resident Evil - The Darkside Chronicles (USA)"
+	rom ( name "Resident Evil - The Darkside Chronicles (USA).iso" size 4699979776 crc 0908a1fc md5 e5437dffa882abb3e85dc44348a02f37 sha1 a1474d7b9ab42397873ccf05a6523b708f76535b )
+)
+
+game (
+	name "Resident Evil - The Umbrella Chronicles (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil - The Umbrella Chronicles (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil - The Umbrella Chronicles (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 2ff3ea46 md5 864f3e3f46ca1fdea8e88971fadbcde8 sha1 244c21c8f4ea8201bbd58cb10fedfd0ca15be451 )
+)
+
+game (
+	name "Resident Evil - The Umbrella Chronicles (USA)"
+	description "Resident Evil - The Umbrella Chronicles (USA)"
+	rom ( name "Resident Evil - The Umbrella Chronicles (USA).iso" size 4699979776 crc c1572f7f md5 d25f7f58343886238a58e5c22830b449 sha1 ae52bca6e1a0bf90d8e91cb62fbfba7a9ba750f7 )
+)
+
+game (
+	name "Resident Evil 4 - Wii Edition (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil 4 - Wii Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil 4 - Wii Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f24511ae md5 7937da542499a4846419d7536b131e9b sha1 4209013a05e6d8bcaff2241ac4e727c043d3cb66 )
+)
+
+game (
+	name "Resident Evil 4 - Wii Edition (USA)"
+	description "Resident Evil 4 - Wii Edition (USA)"
+	rom ( name "Resident Evil 4 - Wii Edition (USA).iso" size 4699979776 crc 19016866 md5 1235cb29693d7b52b63d60103a7d4f47 sha1 62218f84ac3ca545992fb34c537e4fd01efb9c46 )
+)
+
+game (
+	name "Resident Evil Archives - Resident Evil (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil Archives - Resident Evil (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil Archives - Resident Evil (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 22f47f33 md5 eb3851c456798da02f822a988305340a sha1 7c532451fd87a903c0414f9132901282168b7de4 )
+)
+
+game (
+	name "Resident Evil Archives - Resident Evil (USA)"
+	description "Resident Evil Archives - Resident Evil (USA)"
+	rom ( name "Resident Evil Archives - Resident Evil (USA).iso" size 4699979776 crc 1c1acdac md5 6e738ceac7795b9bd14def905f7faa3c sha1 2f2d1c3b0215dc0e7e4612d9579ea91693ea1ef1 )
+)
+
+game (
+	name "Resident Evil Archives - Resident Evil Zero (Europe) (En,Fr,De,Es,It)"
+	description "Resident Evil Archives - Resident Evil Zero (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Resident Evil Archives - Resident Evil Zero (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 98004ab4 md5 0ed69d67dfeab9ab0d6a46bb3db64b4b sha1 0dffaf840de37078d95424a1ab1a78d897ca57ec )
+)
+
+game (
+	name "Resident Evil Archives - Resident Evil Zero (USA)"
+	description "Resident Evil Archives - Resident Evil Zero (USA)"
+	rom ( name "Resident Evil Archives - Resident Evil Zero (USA).iso" size 4699979776 crc 61e6ada0 md5 b781c861deb5fd78d82ce8db02548843 sha1 cfb7c88eaf4cead7c0dc7ebb98c020560c7864a7 )
+)
+
+game (
+	name "Rhythm Heaven Fever (USA)"
+	description "Rhythm Heaven Fever (USA)"
+	rom ( name "Rhythm Heaven Fever (USA).iso" size 4699979776 crc 027faf58 md5 c378c96944e4006014b88c62e6830b66 sha1 23ed93266a05e515277cc6b75f075783dfae9375 )
+)
+
+game (
+	name "Rig Racer 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Rig Racer 2 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Rig Racer 2 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc cd70e4f7 md5 a7485ae842cdbfc4abb03aeecd265754 sha1 767a5b40c0278475646ff41b6d7ae24f4f021820 )
+)
+
+game (
+	name "Rig Racer 2 (USA)"
+	description "Rig Racer 2 (USA)"
+	rom ( name "Rig Racer 2 (USA).iso" size 4699979776 crc bfa9d9f6 md5 8ee307d9fb4e0e847bd7a9155f910321 sha1 924bf0e0e9827c7436245fe0feb4c01d852165e0 )
+)
+
+game (
+	name "Ringling Bros. and Barnum & Baily (USA)"
+	description "Ringling Bros. and Barnum & Baily (USA)"
+	rom ( name "Ringling Bros. and Barnum & Baily (USA).iso" size 4699979776 crc 744f2d5f md5 38663246aedc5a4eec979501ed9f2f72 sha1 9ca32de255f64bffceec4612901868f69750633f )
+)
+
+game (
+	name "Rock Band - Song Pack 1 (Europe) (En,Fr,De,Es,It)"
+	description "Rock Band - Song Pack 1 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rock Band - Song Pack 1 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc eb320018 md5 cddffc39d949f640b1453aac908f8a36 sha1 135d34b95ea3808407a1c4b0d05377e33236b893 )
+)
+
+game (
+	name "Rock Band - Song Pack 2 (Europe) (En,Fr,De,Es,It)"
+	description "Rock Band - Song Pack 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rock Band - Song Pack 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 31f533d7 md5 1e00d581314fc16cb5e2e2924181493d sha1 6952819b1ab27f72c9012f1566a342106c7e6ea1 )
+)
+
+game (
+	name "Rock Band - Track Pack Volume 1 (USA)"
+	description "Rock Band - Track Pack Volume 1 (USA)"
+	rom ( name "Rock Band - Track Pack Volume 1 (USA).iso" size 4699979776 crc 6eb965c6 md5 761053ac54c6bed05128bf27de381330 sha1 ac374c34c404d96acdbb6718c66947abc116b209 )
+)
+
+game (
+	name "Rock Band (Europe) (En,Fr,De,Es,It)"
+	description "Rock Band (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rock Band (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 8fab01f3 md5 16487a321608521d07ae548a0e7be530 sha1 90f6e2fe9c56bc441fb177eea40815ecb9ed871f )
+)
+
+game (
+	name "Rock Band (USA)"
+	description "Rock Band (USA)"
+	rom ( name "Rock Band (USA).iso" size 4699979776 crc 9c651e8d md5 ac7a3d3dc7e92ac14b00d82f5006e261 sha1 52f5cae9ed675b94c9a32d2a826805041af9bf17 )
+)
+
+game (
+	name "Rock Band 2 (USA)"
+	description "Rock Band 2 (USA)"
+	rom ( name "Rock Band 2 (USA).iso" size 4699979776 crc 8be9e0dc md5 accf2d08c6188d64293358bb5ba6dc66 sha1 427d264d643226ba03f5298ab1156555759a1317 )
+)
+
+game (
+	name "Rock Band 3 (Europe) (En,Fr,De,Es,It)"
+	description "Rock Band 3 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rock Band 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 49a0ffa2 md5 e4f964edb64daaac8e47843433f9ca97 sha1 b19471f966236a27c46ae1b94a56555d5aad17ea )
+)
+
+game (
+	name "Rock Band 3 (USA)"
+	description "Rock Band 3 (USA)"
+	rom ( name "Rock Band 3 (USA).iso" size 4699979776 crc d97aac86 md5 ee09ce641dc75b5a024a43e69907aa01 sha1 27fcfe385c3dfa9b13ee25cc1e77333f73a4ad8e )
+)
+
+game (
+	name "Rockstar Games Presents Table Tennis (Europe) (En,Fr,De,Es,It)"
+	description "Rockstar Games Presents Table Tennis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Rockstar Games Presents Table Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc eed4425a md5 7f804a69c57e64cb3bf92447a8ea4d96 sha1 464e1243c4bbbaf38a516b282a5973a5b721b36f )
+)
+
+game (
+	name "Rockstar Games Presents Table Tennis (USA)"
+	description "Rockstar Games Presents Table Tennis (USA)"
+	rom ( name "Rockstar Games Presents Table Tennis (USA).iso" size 4699979776 crc cb9ff51e md5 9eac8756136f1f00ccab8f3f9f6e759d sha1 33c0bdce435ec66be646a9fa916ebec2d92e2931 )
+)
+
+game (
+	name "Rodea the Sky Soldier (USA)"
+	description "Rodea the Sky Soldier (USA)"
+	rom ( name "Rodea the Sky Soldier (USA).iso" size 4699979776 crc ac68bc6a md5 cb89f1778801a77f5c0764105d32c5cd sha1 b5cb04d912b163f7d1fa5700a747e698439dca5f )
+)
+
+game (
+	name "Roogoo - Twisted Towers (USA) (En,Fr,Es)"
+	description "Roogoo - Twisted Towers (USA) (En,Fr,Es)"
+	rom ( name "Roogoo - Twisted Towers (USA) (En,Fr,Es).iso" size 4699979776 crc 595376df md5 e67be505ea7e6ecd61e200a28df1e6e0 sha1 f83b7d9f1ea0ce9e57f08e2833f8cf99ad1ef6e0 )
+)
+
+game (
+	name "RTL Winter Sports 2008 - The Ultimate Challenge (Europe) (En,De)"
+	description "RTL Winter Sports 2008 - The Ultimate Challenge (Europe) (En,De)"
+	rom ( name "RTL Winter Sports 2008 - The Ultimate Challenge (Europe) (En,De).iso" size 4699979776 crc 32536f1f md5 08156cb4a0dc9d511cb97f1625b785e8 sha1 4b9b054edeff425224bc4e5dcea967e67ae7afe3 )
+)
+
+game (
+	name "RTL Winter Sports 2009 - The Next Challenge (Europe) (En,De)"
+	description "RTL Winter Sports 2009 - The Next Challenge (Europe) (En,De)"
+	rom ( name "RTL Winter Sports 2009 - The Next Challenge (Europe) (En,De).iso" size 4699979776 crc e3c82009 md5 fd16bce98d19b0435ab8c2f893da817c sha1 61556a2e10d9b8948fd581881c019436246bb922 )
+)
+
+game (
+	name "Rugby League 3 (Europe)"
+	description "Rugby League 3 (Europe)"
+	rom ( name "Rugby League 3 (Europe).iso" size 4699979776 crc fd0e1ea9 md5 d4d8d3e1fef9b985fe4a13c12343d56e sha1 ad0294325ff348466c34a537cd580b8fd036da95 )
+)
+
+game (
+	name "Rune Factory - Frontier (Europe) (En,Fr,De)"
+	description "Rune Factory - Frontier (Europe) (En,Fr,De)"
+	rom ( name "Rune Factory - Frontier (Europe) (En,Fr,De).iso" size 4699979776 crc a89d4dbc md5 7d8ee2193ad8ba840e7d4b6007793fc7 sha1 109ae74ea86b11f9c0aa71688aece8da007bd728 )
+)
+
+game (
+	name "Rune Factory - Frontier (USA)"
+	description "Rune Factory - Frontier (USA)"
+	rom ( name "Rune Factory - Frontier (USA).iso" size 4699979776 crc 46d5f135 md5 0111bb9782390d4aca6ed6e863af91b3 sha1 f570b651ed98463354abdba083c98b8bff0775ad )
+)
+
+game (
+	name "Rune Factory - Tides of Destiny (USA)"
+	description "Rune Factory - Tides of Destiny (USA)"
+	rom ( name "Rune Factory - Tides of Destiny (USA).iso" size 4699979776 crc f4b7b417 md5 404672b23263c77a281cd1bd84692cfd sha1 d52b0027c21d7f9910aa1f7024452e81487c2fbd )
+)
+
+game (
+	name "Rygar - The Battle of Argus (USA)"
+	description "Rygar - The Battle of Argus (USA)"
+	rom ( name "Rygar - The Battle of Argus (USA).iso" size 4699979776 crc 008868ca md5 3abf955e0ac6a0205a2937530cd46917 sha1 674cd253351af2ad959c6683c45b156bd7f92b65 )
+)
+
+game (
+	name "Safecracker (Europe) (En,Fr,De,Es,It)"
+	description "Safecracker (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Safecracker (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9bb763b9 md5 737c388c3ba2b10d7468365b813c78cb sha1 50047738998115b436b086c994a67a77c64edc1e )
+)
+
+game (
+	name "Safecracker (USA)"
+	description "Safecracker (USA)"
+	rom ( name "Safecracker (USA).iso" size 4699979776 crc 20970d64 md5 bd8d74480bfedadaa4c6b77ad46dfe4d sha1 bc4042c358094ec7bd9377ce3d6bf76a4f7c660a )
+)
+
+game (
+	name "Sakura Wars - So Long, My Love (USA)"
+	description "Sakura Wars - So Long, My Love (USA)"
+	rom ( name "Sakura Wars - So Long, My Love (USA).iso" size 8511160320 crc 945a3588 md5 7a1fccc631ec48b0a1a4766b35d9c4dd sha1 57b919bdebd777c3b8db1428155eb919577f6102 )
+)
+
+game (
+	name "Sam & Max - Season One (Europe) (En,Fr,De,Es,It)"
+	description "Sam & Max - Season One (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sam & Max - Season One (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3cdde6fc md5 b0190dcae008b57516aae8d8b70e3af7 sha1 8680b4d4ce65c7aec55b2fa530c66c9ca16ef44c )
+)
+
+game (
+	name "Sam & Max - Season One (USA) (En,Fr,Es)"
+	description "Sam & Max - Season One (USA) (En,Fr,Es)"
+	rom ( name "Sam & Max - Season One (USA) (En,Fr,Es).iso" size 4699979776 crc 197c96f2 md5 2e59c46365a893fb32bd3315817e8550 sha1 bac2e65fd29bf58acacf449c397f1e3521dcf55b )
+)
+
+game (
+	name "Samba de Amigo (Europe) (En,Fr,De,Nl)"
+	description "Samba de Amigo (Europe) (En,Fr,De,Nl)"
+	rom ( name "Samba de Amigo (Europe) (En,Fr,De,Nl).iso" size 4699979776 crc 62362771 md5 b659ff68ab1148248c7e405c2eb94ff4 sha1 c0710a14016757d7db36260b536f9eb24c1d4cc6 )
+)
+
+game (
+	name "Samba de Amigo (USA) (En,Fr,Es)"
+	description "Samba de Amigo (USA) (En,Fr,Es)"
+	rom ( name "Samba de Amigo (USA) (En,Fr,Es).iso" size 4699979776 crc d872b529 md5 9f51b2ecce6fda6a6517533e1252403d sha1 28e3d518aa1c098f3c21393aa3c07819ef524376 )
+)
+
+game (
+	name "Samurai Shodown Anthology (Europe)"
+	description "Samurai Shodown Anthology (Europe)"
+	rom ( name "Samurai Shodown Anthology (Europe).iso" size 4699979776 crc 518683bd md5 1fd7681077c86081e4465c3070af0176 sha1 fcd56576407fa7311012c1ca0503337d5241909e )
+)
+
+game (
+	name "Samurai Warriors - Katana (USA)"
+	description "Samurai Warriors - Katana (USA)"
+	rom ( name "Samurai Warriors - Katana (USA).iso" size 4699979776 crc 1a87601a md5 0d7b072643999f9e951077ed3f9e226c sha1 50e8362c3fc4621bd08b5605a8f53ee3cc5020be )
+)
+
+game (
+	name "Santa Claus Is Comin' to Town! (USA)"
+	description "Santa Claus Is Comin' to Town! (USA)"
+	rom ( name "Santa Claus Is Comin' to Town! (USA).iso" size 4699979776 crc 913de894 md5 780fccbcedfd32670b1184453afa65b5 sha1 9000c9a1b71a820290c97c413deaa2424f9780fc )
+)
+
+game (
+	name "Scene It Bright Lights! Big Screen! (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Scene It Bright Lights! Big Screen! (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Scene It Bright Lights! Big Screen! (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc aed4303a md5 ee7fb04a3e913a517e9fccc5daec0503 sha1 53be993aa765ee89c56807b3524b0f87d9379534 )
+)
+
+game (
+	name "Schlag den Raab (Germany)"
+	description "Schlag den Raab (Germany)"
+	rom ( name "Schlag den Raab (Germany).iso" size 4699979776 crc 5fb5c59d md5 fd8dd519cac1c2856c90f77558b83206 sha1 d03a030ae8f11225db321684f1b3bc6f1ff9f956 )
+)
+
+game (
+	name "Science Papa (Europe) (En,Fr,De,Es,It)"
+	description "Science Papa (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Science Papa (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a875802e md5 3041eed11b57ce22e411fa76dae1db12 sha1 301966214a94a2faad7831d1c5ee4b4b4e7f7882 )
+)
+
+game (
+	name "Scooby-Doo! First Frights (USA) (En,Fr,Es)"
+	description "Scooby-Doo! First Frights (USA) (En,Fr,Es)"
+	rom ( name "Scooby-Doo! First Frights (USA) (En,Fr,Es).iso" size 4699979776 crc c4da1158 md5 6dc0c58f03c41798a3b811227fc95928 sha1 1b782ce5568bb44edd483ffe8a78048cf5f813d9 )
+)
+
+game (
+	name "SD Gundam - Gashapon Wars (Japan)"
+	description "SD Gundam - Gashapon Wars (Japan)"
+	rom ( name "SD Gundam - Gashapon Wars (Japan).iso" size 4699979776 crc 580bf102 md5 17440f1f75aa987b8ab0eec67e6e121d sha1 378b68b5dbc6ce3847d809da99c286bb582323c6 )
+)
+
+game (
+	name "SD Gundam - GGeneration Wars (Japan)"
+	description "SD Gundam - GGeneration Wars (Japan)"
+	rom ( name "SD Gundam - GGeneration Wars (Japan).iso" size 4699979776 crc 0417193e md5 6ec8dee6ddddba64399a511e99247d4f sha1 5dac36ef8dd2039d3495a378dc064332314ea0a6 )
+)
+
+game (
+	name "SD Gundam - GGeneration World (Japan)"
+	description "SD Gundam - GGeneration World (Japan)"
+	rom ( name "SD Gundam - GGeneration World (Japan).iso" size 4699979776 crc f6d61a35 md5 3521f33dec5aa085bd05d39fd1857c5d sha1 4bc3c0479f787e1543cb33ce810f41521f179e0c )
+)
+
+game (
+	name "Secret Files - Tunguska (Europe) (En,Fr,De,Es,It)"
+	description "Secret Files - Tunguska (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Secret Files - Tunguska (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c0853a4d md5 a8841ecf704d0dcfcba22f2997c78297 sha1 18a8a6cadb7100daf2f7e0c7a594c7c04d1c40e4 )
+)
+
+game (
+	name "Secret Files - Tunguska (USA)"
+	description "Secret Files - Tunguska (USA)"
+	rom ( name "Secret Files - Tunguska (USA).iso" size 4699979776 crc 3cacab99 md5 007d3b21031eb487a80d9b6d175dce5c sha1 6ac10728413bd02f9a9466f0c619d436b4f1d733 )
+)
+
+game (
+	name "Secret Files 2 - Puritas Cordis (Europe) (En,Fr,De,Es,It)"
+	description "Secret Files 2 - Puritas Cordis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Secret Files 2 - Puritas Cordis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5231b8de md5 28d242edefb3c73776704431561c1b10 sha1 26e7b1fecace2155152fbaa703fb8dfd0a052f0f )
+)
+
+game (
+	name "Secret Saturdays, The - Beasts of the 5th Sun (Europe) (En,Fr,De,Es,It)"
+	description "Secret Saturdays, The - Beasts of the 5th Sun (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Secret Saturdays, The - Beasts of the 5th Sun (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 091619bf md5 70a61e77cfc5e5118cbd90cfc99a1d50 sha1 280b8d4343dfd24ec0234b89c643cfcecb8a8fba )
+)
+
+game (
+	name "Secret Saturdays, The - Beasts of the 5th Sun (USA) (En,Fr,Es)"
+	description "Secret Saturdays, The - Beasts of the 5th Sun (USA) (En,Fr,Es)"
+	rom ( name "Secret Saturdays, The - Beasts of the 5th Sun (USA) (En,Fr,Es).iso" size 4699979776 crc de78a0d1 md5 526ff8b6c34ba0cb06ac1061ff0af9b0 sha1 6d980ca7a67dab59811839294019377bc7c684c3 )
+)
+
+game (
+	name "Sega Bass Fishing (Europe) (En,Fr,De,Es,It)"
+	description "Sega Bass Fishing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sega Bass Fishing (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9b10bb5a md5 763866273baf16a90b4c1957f3f59802 sha1 849569c1ee57c869262e4237c1f619c2003c7bc8 )
+)
+
+game (
+	name "Sega Bass Fishing (USA)"
+	description "Sega Bass Fishing (USA)"
+	rom ( name "Sega Bass Fishing (USA).iso" size 4699979776 crc a69915d7 md5 735eb193e2d5ff71a4e0384659d97816 sha1 967a970b7f8bd01b849579c69efa1d223a49d72b )
+)
+
+game (
+	name "Sega Superstars Tennis (Europe) (En,Fr,De,Es,It)"
+	description "Sega Superstars Tennis (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sega Superstars Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 6ad118b9 md5 597ca3ceb4436d8c3df5c7afe2a590ed sha1 ec35ac71adafe2a71747b258212a5e7b76118691 )
+)
+
+game (
+	name "Sega Superstars Tennis (USA) (En,Fr,Es)"
+	description "Sega Superstars Tennis (USA) (En,Fr,Es)"
+	rom ( name "Sega Superstars Tennis (USA) (En,Fr,Es).iso" size 4699979776 crc 9a1f1697 md5 c0e8f141133a97e5065694fdb45c11ea sha1 3ac9e0041250d6c87b7c979e5635707cfeafaaaf )
+)
+
+game (
+	name "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es)"
+	description "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es)"
+	rom ( name "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es).iso" size 4699979776 crc cdb50439 md5 8a807910e8eb6c0e96182a5e788dc6b0 sha1 93493a4ad597f734933d3bb5158f5abeda9cc600 )
+)
+
+game (
+	name "Sengoku Musou 3 (Japan)"
+	description "Sengoku Musou 3 (Japan)"
+	rom ( name "Sengoku Musou 3 (Japan).iso" size 8511160320 crc 10ce4364 md5 c39a18160a484b864da50d486401539e sha1 4c9a86d490c51f18a6df97684fcce6791fb31af4 )
+)
+
+game (
+	name "Sesame Street - Ready, Set, Grover! (Australia)"
+	description "Sesame Street - Ready, Set, Grover! (Australia)"
+	rom ( name "Sesame Street - Ready, Set, Grover! (Australia).iso" size 4699979776 crc a475703f md5 ef2bd3c6d34b2e5dadc7ee456cbc5258 sha1 f48707aa3ef122bd9364e8183bdee4dcdcb0e268 )
+)
+
+game (
+	name "Sesame Street - Ready, Set, Grover! (Europe) (Es,Nl)"
+	description "Sesame Street - Ready, Set, Grover! (Europe) (Es,Nl)"
+	rom ( name "Sesame Street - Ready, Set, Grover! (Europe) (Es,Nl).iso" size 4699979776 crc 5f65f3b5 md5 531df92ea84997d3252808406bf83ec0 sha1 c6bf618607f7361245835d4bc62dc5b1602d09d9 )
+)
+
+game (
+	name "Shaun White Snowboarding - Road Trip (Europe) (En,Fr,De,Es,It)"
+	description "Shaun White Snowboarding - Road Trip (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Shaun White Snowboarding - Road Trip (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 42b3a8a4 md5 866dd3fb9c28e8970c33c714200632bf sha1 aa8f505ad11c28c045af3776ea1d77d1546e68fd )
+)
+
+game (
+	name "Shaun White Snowboarding - Road Trip (USA) (En,Fr,Es)"
+	description "Shaun White Snowboarding - Road Trip (USA) (En,Fr,Es)"
+	rom ( name "Shaun White Snowboarding - Road Trip (USA) (En,Fr,Es).iso" size 4699979776 crc 24547880 md5 b77b9f86c069363f37ea714d3a083b66 sha1 936941ef03f2b6e0b58db1aa4842ad69e8911471 )
+)
+
+game (
+	name "Shaun White Snowboarding - World Stage (UK)"
+	description "Shaun White Snowboarding - World Stage (UK)"
+	rom ( name "Shaun White Snowboarding - World Stage (UK).iso" size 4699979776 crc 8c189393 md5 cc1b146df6208d2fb7ff1ddb26e93327 sha1 bab244bf1df231fe02353379a28802b6b3b7140b )
+)
+
+game (
+	name "Shaun White Snowboarding - World Stage (USA) (En,Fr,Es)"
+	description "Shaun White Snowboarding - World Stage (USA) (En,Fr,Es)"
+	rom ( name "Shaun White Snowboarding - World Stage (USA) (En,Fr,Es).iso" size 4699979776 crc 7b105f89 md5 aa2d0f03889e58b51d89e2eb1bd5c2fc sha1 10cc9abda5e5a942eaba1bc4db1e7ff35bb2cded )
+)
+
+game (
+	name "Shonen Jump One Piece - Unlimited Adventure (USA)"
+	description "Shonen Jump One Piece - Unlimited Adventure (USA)"
+	rom ( name "Shonen Jump One Piece - Unlimited Adventure (USA).iso" size 4699979776 crc c03aded9 md5 719e7878592dc0a7eff4ea0ca79a5db1 sha1 512e0cae8bbdda65ae0c985488044e9b79e5a518 )
+)
+
+game (
+	name "Silent Hill - Shattered Memories (Europe) (En,Fr,De,Es,It)"
+	description "Silent Hill - Shattered Memories (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Silent Hill - Shattered Memories (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 28b32771 md5 45d2e11b638387f617f950d8bb59a18a sha1 2f79c1c2822490cec22c2892e2a4db8c2862327a )
+)
+
+game (
+	name "SimAnimals (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi)"
+	description "SimAnimals (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi)"
+	rom ( name "SimAnimals (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi).iso" size 4699979776 crc 447bd384 md5 16e8cee2e77c6c47332a4124bb3a7882 sha1 f05859a48490c682c496c7408f53d9c2cb0dad8e )
+)
+
+game (
+	name "SimAnimals (USA) (En,Fr,Es)"
+	description "SimAnimals (USA) (En,Fr,Es)"
+	rom ( name "SimAnimals (USA) (En,Fr,Es).iso" size 4699979776 crc 826c40ec md5 e995bce8aea07d8a844880121e7b3664 sha1 4770275a8c789c2ab35b210a46ac2d5e6851396c )
+)
+
+game (
+	name "SimAnimals Africa (Japan)"
+	description "SimAnimals Africa (Japan)"
+	rom ( name "SimAnimals Africa (Japan).iso" size 4699979776 crc 68802be9 md5 1f3f8dd47087d77c310ba76b64769085 sha1 4f53086e22bef58a426af7448179cc1fd26e672f )
+)
+
+game (
+	name "Simpson, Les - Le Jeu (France)"
+	description "Simpson, Les - Le Jeu (France)"
+	rom ( name "Simpson, Les - Le Jeu (France).iso" size 4699979776 crc 597e0b71 md5 7a360584535311e850d341004fa9115a sha1 cc2b4a36ff200d75817e824323c11593d0398865 )
+)
+
+game (
+	name "Simpsons Game, The (USA)"
+	description "Simpsons Game, The (USA)"
+	rom ( name "Simpsons Game, The (USA).iso" size 4699979776 crc 6cd0e501 md5 4780e6bd68caae9ed0a169b78b0ae1d3 sha1 febbed33ead6e32fd1ba9464d90d0ea4e3f64b3b )
+)
+
+game (
+	name "Sims 2, The - Castaway (USA)"
+	description "Sims 2, The - Castaway (USA)"
+	rom ( name "Sims 2, The - Castaway (USA).iso" size 4699979776 crc 01dedf3e md5 79eb215b782878b6c450dd3166d7b93f sha1 ad6781edbd9a30439042dfd0770cf1408ef44d5d )
+)
+
+game (
+	name "Sims 2, The - Pets (USA)"
+	description "Sims 2, The - Pets (USA)"
+	rom ( name "Sims 2, The - Pets (USA).iso" size 4699979776 crc 300143e6 md5 f2c09d0bd528ea507001747152f769b6 sha1 b63346da51eab874c862825658dfb4a46e56ecd9 )
+)
+
+game (
+	name "Sin & Punishment - Star Successor (USA)"
+	description "Sin & Punishment - Star Successor (USA)"
+	rom ( name "Sin & Punishment - Star Successor (USA).iso" size 4699979776 crc 7df9d581 md5 ba9fad8530fac4a7f0c318b6c4036b71 sha1 76de816f77798136c870bd4a57d00eccc61d6cc3 )
+)
+
+game (
+	name "Sin and Punishment - Successor of the Skies (Europe) (En,Fr,De,Es,It)"
+	description "Sin and Punishment - Successor of the Skies (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sin and Punishment - Successor of the Skies (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 792d4630 md5 666b1b991e96ed8778d8c393a2b36b54 sha1 a6d94b53fa74a39150a08060b1997915360d1373 )
+)
+
+game (
+	name "Skate It (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Skate It (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Skate It (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc c4de2dd7 md5 451c5bc1f37674966f4fea4647fa0bbb sha1 8444524808a609e20c827da2a9525dd6c04b544b )
+)
+
+game (
+	name "Skate It (USA) (En,Fr,Es)"
+	description "Skate It (USA) (En,Fr,Es)"
+	rom ( name "Skate It (USA) (En,Fr,Es).iso" size 4699979776 crc 99c5bea7 md5 5d599116335922f99795c2dc87ddedc6 sha1 9843fc0a22850bdfe3aeea6f3db96e6cbdf6aeec )
+)
+
+game (
+	name "Ski and Shoot (USA) (En,Fr)"
+	description "Ski and Shoot (USA) (En,Fr)"
+	rom ( name "Ski and Shoot (USA) (En,Fr).iso" size 4699979776 crc 8370bf6e md5 5b21d5e65b61337e17a1e233be9fb288 sha1 d58718ed5ec2384a33c8ec1dcb7ce65740af7320 )
+)
+
+game (
+	name "Sky Crawlers, The - Innocent Aces (USA) (En,Fr,Es)"
+	description "Sky Crawlers, The - Innocent Aces (USA) (En,Fr,Es)"
+	rom ( name "Sky Crawlers, The - Innocent Aces (USA) (En,Fr,Es).iso" size 4699979776 crc d7265868 md5 e735582fe567492fdd29fd3e107679cf sha1 ba1d0907aedf382c0e67456a2cec4a8ace89dc1b )
+)
+
+game (
+	name "Skylanders - Giants (Europe)"
+	description "Skylanders - Giants (Europe)"
+	rom ( name "Skylanders - Giants (Europe).iso" size 4699979776 crc 313e260d md5 d9dfc5425b56a360920dd5a41ae4453c sha1 a3fcd3be1160f8fe3a3ed1b5d9c758ff568f9f74 )
+)
+
+game (
+	name "Skylanders - Giants (Europe) (De,Es,It)"
+	description "Skylanders - Giants (Europe) (De,Es,It)"
+	rom ( name "Skylanders - Giants (Europe) (De,Es,It).iso" size 4699979776 crc 1c9b5f25 md5 98acca123fa84576fb18db6cb9b7cd06 sha1 2a0bac26415e44434cc1889c7dc9adfbd89517de )
+)
+
+game (
+	name "Skylanders - Giants (USA)"
+	description "Skylanders - Giants (USA)"
+	rom ( name "Skylanders - Giants (USA).iso" size 4699979776 crc 5af8cb69 md5 f1f8345f81f0a5f16a84a7db150f525b sha1 911090111fe5f9cf10526dedc3f5a790fab2548b )
+)
+
+game (
+	name "Skylanders - Spyro's Adventure (Europe)"
+	description "Skylanders - Spyro's Adventure (Europe)"
+	rom ( name "Skylanders - Spyro's Adventure (Europe).iso" size 4699979776 crc 5f0c73eb md5 e93649a6379292d8e87a5894439710ba sha1 6f6889cca454d63cc77bf91b591fee4e91aed60e )
+)
+
+game (
+	name "Skylanders - Spyro's Adventure (USA)"
+	description "Skylanders - Spyro's Adventure (USA)"
+	rom ( name "Skylanders - Spyro's Adventure (USA).iso" size 4699979776 crc a558b2db md5 bbf93219cc63efd88cb3600485f22e55 sha1 7df3a483241cf3f7e80868ef56ab88478c8792ff )
+)
+
+game (
+	name "Skylanders - Swap Force (Europe) (Es,It)"
+	description "Skylanders - Swap Force (Europe) (Es,It)"
+	rom ( name "Skylanders - Swap Force (Europe) (Es,It).iso" size 4699979776 crc ccb3a774 md5 32d4e91c03e84ba70ecd188a8c795c84 sha1 676852e28f9d9c1f03464bac39cc02047ba55f7d )
+)
+
+game (
+	name "Smarty Pants - Trivia Fun for Everyone! (Europe) (En,Fr,De,Es,It)"
+	description "Smarty Pants - Trivia Fun for Everyone! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Smarty Pants - Trivia Fun for Everyone! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fa725575 md5 b76668a075ed6ca8cc96157628f65a89 sha1 13a16bb31e91c92a96f5a62749eeec3723b9631f )
+)
+
+game (
+	name "Smarty Pants - Trivia Fun for Everyone! (USA)"
+	description "Smarty Pants - Trivia Fun for Everyone! (USA)"
+	rom ( name "Smarty Pants - Trivia Fun for Everyone! (USA).iso" size 4699979776 crc f54477ac md5 92e16df85174b1e91d841c80413f2c66 sha1 3a8dba5bb43bf46102313f79c2f80c34d5008e13 )
+)
+
+game (
+	name "Smiley World - Island Challenge (Europe) (En,Fr,De,Es,It)"
+	description "Smiley World - Island Challenge (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Smiley World - Island Challenge (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4126c958 md5 d0969e0d7bd11d2f012e42d347fc4eb3 sha1 d098332c07aa6a661b7b41b45f4b56bf9224b299 )
+)
+
+game (
+	name "Smiley World - Island Challenge (USA) (En,Fr,Es)"
+	description "Smiley World - Island Challenge (USA) (En,Fr,Es)"
+	rom ( name "Smiley World - Island Challenge (USA) (En,Fr,Es).iso" size 4699979776 crc 66086015 md5 e95129ecfd3fd1b72b640b5ed1de7596 sha1 936c65584a45658cc33ae6363c97535c6ba8f0ed )
+)
+
+game (
+	name "Smurfs, The - Dance Party (USA)"
+	description "Smurfs, The - Dance Party (USA)"
+	rom ( name "Smurfs, The - Dance Party (USA).iso" size 4699979776 crc 0845a979 md5 71daf4fd4f4c10d66a04decd73f31399 sha1 2af9163509065c52155717e3ad628a46a65332a4 )
+)
+
+game (
+	name "Sonic & Sega All-Stars Racing (Europe) (En,Fr,De,Es,It)"
+	description "Sonic & Sega All-Stars Racing (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sonic & Sega All-Stars Racing (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 005bb7ef md5 cb18afd32cd42d97e4fccc00dc5129df sha1 1fa6f214f9259df40dfc2b33112ab70806eed50a )
+)
+
+game (
+	name "Sonic & Sega All-Stars Racing (USA) (En,Fr,Es)"
+	description "Sonic & Sega All-Stars Racing (USA) (En,Fr,Es)"
+	rom ( name "Sonic & Sega All-Stars Racing (USA) (En,Fr,Es).iso" size 4699979776 crc fe587e18 md5 3e1f6ef3d56058e139f5484b4739b783 sha1 efb3fd932642c981be295ae9291667a19393b509 )
+)
+
+game (
+	name "Sonic and the Black Knight (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Sonic and the Black Knight (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic and the Black Knight (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc bb721bd0 md5 db5d9791019e23f1e1677255fab612b8 sha1 7102cad19ef040a56aa49c90baa6d61694c0f16d )
+)
+
+game (
+	name "Sonic and the Black Knight (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic and the Black Knight (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic and the Black Knight (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc d1aed6e5 md5 12b9892a5f26a903a1b3afa209718db1 sha1 d3e83bc9a7350b35e46836a35aef20146bd2a969 )
+)
+
+game (
+	name "Sonic and the Secret Rings (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Sonic and the Secret Rings (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic and the Secret Rings (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 6b4c1de2 md5 5ce0cb1ca691a7651aced9c62db98441 sha1 9d8f860cb6fdd4873ff51a9eb123576acb0b5ea5 )
+)
+
+game (
+	name "Sonic and the Secret Rings (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic and the Secret Rings (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic and the Secret Rings (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc f8a19250 md5 0cd6c14b7d1fe86382a4c9137a5cda5c sha1 e2476691d315567811dd7fc9380ba41798241807 )
+)
+
+game (
+	name "Sonic Colors (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Colors (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Colors (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc eb2a36b4 md5 a7a197fa20348e49b3b43b7dc0cebc35 sha1 dc9904fb2bc09e86cc840dbcb6eb62d796b306c0 )
+)
+
+game (
+	name "Sonic Colours (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Colours (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Colours (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc ec9129d3 md5 977acab35b84ce8b0e3420574a8acde5 sha1 8dd6878ed2cc845ec3997ca12f7b8489c7116b73 )
+)
+
+game (
+	name "Sonic Riders - Zero Gravity (Europe) (En,Fr,De,Es,It)"
+	description "Sonic Riders - Zero Gravity (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sonic Riders - Zero Gravity (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3cdc27ca md5 190a2c6fb9005af53937e3c5f53aaf7b sha1 38448063119c4971097c0f8731ef2701506c7a7c )
+)
+
+game (
+	name "Sonic Riders - Zero Gravity (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Riders - Zero Gravity (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Riders - Zero Gravity (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 675f9e22 md5 1da7ec409fcb5f2592a5b9bb15b0e4b3 sha1 6baf5844f7433d187de2c584a349fec348d6c592 )
+)
+
+game (
+	name "Sonic to Ankoku no Kishi (Japan) (En,Ja,Fr,De,Es,It)"
+	description "Sonic to Ankoku no Kishi (Japan) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic to Ankoku no Kishi (Japan) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc d6ba9efa md5 1661b4b992f3d7b37edb571f74f9a3fb sha1 a7525f759e79374a48108096d2245fce9fc2e47d )
+)
+
+game (
+	name "Sonic Unleashed (USA) (En,Ja,Fr,De,Es,It)"
+	description "Sonic Unleashed (USA) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Sonic Unleashed (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 698738ac md5 2ff85c46143c86922ab68061097ced34 sha1 e3f792b613ff82f2adde06329a0c1b179be4091d )
+)
+
+game (
+	name "Sonic World Adventure (Japan)"
+	description "Sonic World Adventure (Japan)"
+	rom ( name "Sonic World Adventure (Japan).iso" size 4699979776 crc 61f2055f md5 1f904185bf139836443e60b8670ae20e sha1 985fa131df91daedb5fce4b9f48106d6c4c69f78 )
+)
+
+game (
+	name "Soul Eater - Monotone Princess (Japan)"
+	description "Soul Eater - Monotone Princess (Japan)"
+	rom ( name "Soul Eater - Monotone Princess (Japan).iso" size 4699979776 crc 4c574631 md5 8fa4a82a43e3effdcc8ce177652c840b sha1 a5979d22af122d05a468baa681a6d3efc92d457a )
+)
+
+game (
+	name "Soulcalibur Legends (Europe) (En,Fr,De,Es,It)"
+	description "Soulcalibur Legends (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Soulcalibur Legends (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f481c829 md5 3bf17c920cf68bbfc028eac9633c466c sha1 8983d99534acbd74555595e9887bb431e9d8f199 )
+)
+
+game (
+	name "Soulcalibur Legends (Japan)"
+	description "Soulcalibur Legends (Japan)"
+	rom ( name "Soulcalibur Legends (Japan).iso" size 4699979776 crc 514021ef md5 7a7701b96302e53d2cf5a0b6d6f3da63 sha1 71e044de7de6372be13736b2f50acd662785d537 )
+)
+
+game (
+	name "Soulcalibur Legends (USA)"
+	description "Soulcalibur Legends (USA)"
+	rom ( name "Soulcalibur Legends (USA).iso" size 4699979776 crc c61d7423 md5 d5167f28453f55b532b14e6c40fa2def sha1 a17c5b250695128263e7c5c844eefb91ec448b30 )
+)
+
+game (
+	name "Spectrobes Origins (USA)"
+	description "Spectrobes Origins (USA)"
+	rom ( name "Spectrobes Origins (USA).iso" size 4699979776 crc 7cb77c30 md5 47e38869f5f1bc2ece28f21f1b565a07 sha1 2eb904397a44f57f9749914cce203693b207706b )
+)
+
+game (
+	name "Speed Racer - The Videogame (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Speed Racer - The Videogame (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Speed Racer - The Videogame (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 4cb95d43 md5 f251f06be53eed114510eadca1e2f8ae sha1 446a51b0dc0abbef9f54e7ac4c3be8a08ea7f361 )
+)
+
+game (
+	name "Speed Racer - The Videogame (USA) (En,Fr,Es,Pt)"
+	description "Speed Racer - The Videogame (USA) (En,Fr,Es,Pt)"
+	rom ( name "Speed Racer - The Videogame (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc ef4fbaf0 md5 d9f8c8949c9e18263ad8729ba6443bc7 sha1 21e8c30201c222636478b72842359e6097d00685 )
+)
+
+game (
+	name "Spider-Man - Friend or Foe (USA)"
+	description "Spider-Man - Friend or Foe (USA)"
+	rom ( name "Spider-Man - Friend or Foe (USA).iso" size 4699979776 crc 5d061449 md5 c45d87156826137bd26874f63b895a72 sha1 dffbb54954bc92b30cd86a3f291ec68dd0fac1ba )
+)
+
+game (
+	name "Spider-Man - Shattered Dimensions (USA)"
+	description "Spider-Man - Shattered Dimensions (USA)"
+	rom ( name "Spider-Man - Shattered Dimensions (USA).iso" size 4699979776 crc 664c624a md5 e708b6a457559abbb60ad36fb25d1118 sha1 888038b5a93c11d68bf5b0e656b0f2db435f0143 )
+)
+
+game (
+	name "Spider-Man - Web of Shadows (USA) (En,Fr)"
+	description "Spider-Man - Web of Shadows (USA) (En,Fr)"
+	rom ( name "Spider-Man - Web of Shadows (USA) (En,Fr).iso" size 4699979776 crc 8e148031 md5 395422c97fb8b0a40402b563bee6985d sha1 45c3173a582cc71803222555cd4e90b722a216fc )
+)
+
+game (
+	name "Spider-Man 3 (USA)"
+	description "Spider-Man 3 (USA)"
+	rom ( name "Spider-Man 3 (USA).iso" size 4699979776 crc edc80639 md5 df761e58b4bd556519d9e5f2a9b5fce4 sha1 5c099250561a38d766e2cebb197f7960739c9bd3 )
+)
+
+game (
+	name "Spore Hero (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	description "Spore Hero (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)"
+	rom ( name "Spore Hero (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).iso" size 4699979776 crc 23174390 md5 08abd3b59e00f9e7d63898c7c5eb7771 sha1 37ba66ad855dc51a33cf662c1406fac2463c5cd7 )
+)
+
+game (
+	name "Spore Hero (USA)"
+	description "Spore Hero (USA)"
+	rom ( name "Spore Hero (USA).iso" size 4699979776 crc c6c2104e md5 18300d09b9622e63c7b7aa3e725fe041 sha1 808f043e833d44591e8252df0f406d6264568a12 )
+)
+
+game (
+	name "Sports Island (Europe) (En,Fr,De,Es,It)"
+	description "Sports Island (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sports Island (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3f2fb8c5 md5 c495e23a4ce2a26b704ac947a0087e08 sha1 84a0d7b42e854eaa9849fd08f6d3d7903f2a6938 )
+)
+
+game (
+	name "Sports Island 2 (Europe) (En,Fr,De,Es,It)"
+	description "Sports Island 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Sports Island 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7ade71a4 md5 5688c2e8001b36884094043d6d20cdbf sha1 0d4f45c7be8bdad54c7fa9ada1cd5bcba45a871f )
+)
+
+game (
+	name "Sports Party (Europe)"
+	description "Sports Party (Europe)"
+	rom ( name "Sports Party (Europe).iso" size 4699979776 crc 88bf4fa7 md5 cea6da0b1020ffc887d050fd3520b52b sha1 30c4a13b9694758a88ee78c3c307ade38cf97b0b )
+)
+
+game (
+	name "SPRay (USA)"
+	description "SPRay (USA)"
+	rom ( name "SPRay (USA).iso" size 4699979776 crc 9a24d056 md5 408a77920afb0c371f93a9ffb1a5e053 sha1 3a552f321420686f5e13412f704f0fbba47bcd52 )
+)
+
+game (
+	name "Spy Fox - Dry Cereal (USA)"
+	description "Spy Fox - Dry Cereal (USA)"
+	rom ( name "Spy Fox - Dry Cereal (USA).iso" size 4699979776 crc 14f59612 md5 5febc95cb87dfc2e1265fd346a5e1391 sha1 8f0d87ebf4a19e6f6d7a1700bd67ade2f0ef887e )
+)
+
+game (
+	name "Spyborgs (USA) (En,Fr,Es)"
+	description "Spyborgs (USA) (En,Fr,Es)"
+	rom ( name "Spyborgs (USA) (En,Fr,Es).iso" size 4699979776 crc 4c88bde5 md5 1865e974821587366dc997300a2d06b9 sha1 b463f69c89c52cd6156cf09fef6b0f3e14040acc )
+)
+
+game (
+	name "SSX Blur (Europe) (En,Fr,De,Es,It)"
+	description "SSX Blur (Europe) (En,Fr,De,Es,It)"
+	rom ( name "SSX Blur (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b140da6b md5 ab86da64739c9195ac4396ed7fb6e133 sha1 74042a969c4ae2a9b5ea3a07807b35705a58e2dc )
+)
+
+game (
+	name "SSX Blur (Japan)"
+	description "SSX Blur (Japan)"
+	rom ( name "SSX Blur (Japan).iso" size 4699979776 crc 8b759339 md5 496feae65567c7c1a7e41dce6c45f007 sha1 d13e3cc90ea9aec86fc78dc886daf204a428b67b )
+)
+
+game (
+	name "SSX Blur (USA) (En,Fr)"
+	description "SSX Blur (USA) (En,Fr)"
+	rom ( name "SSX Blur (USA) (En,Fr).iso" size 4699979776 crc 14540d82 md5 df20f4a1da0ada886ae6833a880b0c22 sha1 726084c129d0b24c7c93c179697f21bc68200c95 )
+)
+
+game (
+	name "Star Trek - Conquest (Europe) (En,De)"
+	description "Star Trek - Conquest (Europe) (En,De)"
+	rom ( name "Star Trek - Conquest (Europe) (En,De).iso" size 4699979776 crc 199e6ecc md5 59add9f56723df13511662c6302c6bbb sha1 691ee25b98a19c315296f0215640fff782f6ff31 )
+)
+
+game (
+	name "Star Trek - Conquest (USA)"
+	description "Star Trek - Conquest (USA)"
+	rom ( name "Star Trek - Conquest (USA).iso" size 4699979776 crc a1a4563c md5 baa4cef91d8bfbd871afd813c356a69b sha1 b5df60141f48fefbcb38938804e83c854a362aa7 )
+)
+
+game (
+	name "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It)"
+	description "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1ed5d26c md5 4fe0b71f051fa087cc699a73200f30d5 sha1 ef155d2b0a1955aafab58d0fb0f45e68d0d78a57 )
+)
+
+game (
+	name "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr)"
+	description "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr)"
+	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr).iso" size 4699979776 crc 118d8520 md5 b6a8fdc0e72e49ad6a5406bd9d4c0480 sha1 174dee8c37c73cc2efb4a3a24038989e150c7859 )
+)
+
+game (
+	name "Star Wars - The Clone Wars - Republic Heroes (USA) (En,Fr,Es)"
+	description "Star Wars - The Clone Wars - Republic Heroes (USA) (En,Fr,Es)"
+	rom ( name "Star Wars - The Clone Wars - Republic Heroes (USA) (En,Fr,Es).iso" size 4699979776 crc 0cf8d7c9 md5 c7e990a601b4bb1ed78c5690cb50b15b sha1 47759d73539f6f2049a2784b44bd40e950c3a79a )
+)
+
+game (
+	name "Star Wars - The Force Unleashed (Europe) (En,Fr,De,Es,It)"
+	description "Star Wars - The Force Unleashed (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Star Wars - The Force Unleashed (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 9cb4dc12 md5 a0b787221bdc3e26ee72bf83b7daa2a9 sha1 1b89ff353d3d271a5958912314c37a8b2b7cac86 )
+)
+
+game (
+	name "Star Wars - The Force Unleashed (USA) (En,Fr)"
+	description "Star Wars - The Force Unleashed (USA) (En,Fr)"
+	rom ( name "Star Wars - The Force Unleashed (USA) (En,Fr).iso" size 4699979776 crc 404ef924 md5 a0fda28b34589c57bed29d3e9e6e5bb5 sha1 ec6b938e5dd7776cfc1174b60afce2147077f6b1 )
+)
+
+game (
+	name "Star Wars - The Force Unleashed II (Europe) (En,Fr,De,Es,It)"
+	description "Star Wars - The Force Unleashed II (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Star Wars - The Force Unleashed II (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0d95d281 md5 325ab85743489f24dcb2b6b01c89a317 sha1 224d6f9f6ccf257a984e3786b34b066b4396ccc7 )
+)
+
+game (
+	name "Star Wars - The Force Unleashed II (USA)"
+	description "Star Wars - The Force Unleashed II (USA)"
+	rom ( name "Star Wars - The Force Unleashed II (USA).iso" size 4699979776 crc 6eb87435 md5 b8f85efe0152d83aaae0ec0a0087a6f3 sha1 659f6f6d3ae8941bd9ff41647e7502e1985ae75e )
+)
+
+game (
+	name "Storybook Workshop (USA) (En,Fr,Es)"
+	description "Storybook Workshop (USA) (En,Fr,Es)"
+	rom ( name "Storybook Workshop (USA) (En,Fr,Es).iso" size 4699979776 crc 2a62cd5e md5 c0756825dffe7229f80a1e6aeb071231 sha1 7cd9d8ef896cce25a885d3d7b39a0d109dee3ff8 )
+)
+
+game (
+	name "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc d569d7bb md5 e173198b5a3f914810e5e91cbf8871e8 sha1 9bc8d68b41df6c247f9b750cc4ebe06e2706c76c )
+)
+
+game (
+	name "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Summer Athletics (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 5ae60931 md5 20d3e41282eaa1f88d3c5315f99d0ffc sha1 e3cfae5d2182a3e522e618be0d2ecc953bf8d7c1 )
+)
+
+game (
+	name "Super Fruit Fall (Europe)"
+	description "Super Fruit Fall (Europe)"
+	rom ( name "Super Fruit Fall (Europe).iso" size 4699979776 crc 854b0feb md5 50e8c804dfe5a24560fde1d729c82dc9 sha1 af82fff2a46d7a2a1a7c759fa432b2398250a85b )
+)
+
+game (
+	name "Super Mario All-Stars (Europe)"
+	description "Super Mario All-Stars (Europe)"
+	rom ( name "Super Mario All-Stars (Europe).iso" size 4699979776 crc e7d03c7b md5 1d223c5a34bec71760b6c83eaa099e2d sha1 af1f1bd7d4b30302115097b3feb38d02559b7be3 )
+)
+
+game (
+	name "Super Mario All-Stars (USA)"
+	description "Super Mario All-Stars (USA)"
+	rom ( name "Super Mario All-Stars (USA).iso" size 4699979776 crc a2e7380d md5 e8eae447a0a38af680e699d2fb5f0f2b sha1 404748b4f9ecec10ac3616f223f9db55d6c43a70 )
+)
+
+game (
+	name "Super Mario Collection (Japan)"
+	description "Super Mario Collection (Japan)"
+	rom ( name "Super Mario Collection (Japan).iso" size 4699979776 crc b697a35e md5 8616a2e1c99cc159d205c9425f7d9e80 sha1 41ce1e37a169fca5f193b46373e52cd253543924 )
+)
+
+game (
+	name "Super Mario Galaxy (Europe) (En,Fr,De,Es,It)"
+	description "Super Mario Galaxy (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Mario Galaxy (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 0aeffd47 md5 a8c962d1922f7521dc4b07348e4e8a51 sha1 4ad985eb39b6f60be00a44c3a41bc3ed31b083c2 )
+)
+
+game (
+	name "Super Mario Galaxy (Japan)"
+	description "Super Mario Galaxy (Japan)"
+	rom ( name "Super Mario Galaxy (Japan).iso" size 4699979776 crc 9cdb7505 md5 de205dd5e379f5bd2e0fcea8cae9497b sha1 ebbeb06a222efd78846254bc829f411d0987db99 )
+)
+
+game (
+	name "Super Mario Galaxy (USA) (En,Fr,Es)"
+	description "Super Mario Galaxy (USA) (En,Fr,Es)"
+	rom ( name "Super Mario Galaxy (USA) (En,Fr,Es).iso" size 4699979776 crc 1047de4c md5 f99a97f9ae4dccd1db45e9aaab9cebd8 sha1 a36105c9fbfff6041dc5babf4318c6a216ad470a )
+)
+
+game (
+	name "Super Mario Galaxy 2 (Europe) (En,Fr,De,Es,It)"
+	description "Super Mario Galaxy 2 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Mario Galaxy 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 04637269 md5 c9db57815bc78aac6db07248a1524b80 sha1 b427448646fddbed64667a113fabda5a09d0e84b )
+)
+
+game (
+	name "Super Mario Galaxy 2 (USA) (En,Fr,Es)"
+	description "Super Mario Galaxy 2 (USA) (En,Fr,Es)"
+	rom ( name "Super Mario Galaxy 2 (USA) (En,Fr,Es).iso" size 4699979776 crc fbc19306 md5 09a28c6fc53435b2d478516aac50055c sha1 83fbe312615f65be2123d1a88c5eb532e1feec2f )
+)
+
+game (
+	name "Super Mario Stadium - Family Baseball (Japan)"
+	description "Super Mario Stadium - Family Baseball (Japan)"
+	rom ( name "Super Mario Stadium - Family Baseball (Japan).iso" size 4699979776 crc 7464bd0b md5 3e44d111bd78dee736487024d70870ff sha1 28ccb21adda8493d7a3e878df0bb26a14da9ec59 )
+)
+
+game (
+	name "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It)"
+	description "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc af64c370 md5 eb4c7bc397f78f9f48778d289c7d5f09 sha1 17b840a49273b48d512df15c7b937e4fd3c4f44b )
+)
+
+game (
+	name "Super Monkey Ball - Banana Blitz (USA)"
+	description "Super Monkey Ball - Banana Blitz (USA)"
+	rom ( name "Super Monkey Ball - Banana Blitz (USA).iso" size 4699979776 crc ad99f707 md5 0043d80c3d70f90787522adb7cb6fdf1 sha1 8489e61fc7af5c42478649371ff0eb9d94120b68 )
+)
+
+game (
+	name "Super Monkey Ball - Step & Roll (Europe)"
+	description "Super Monkey Ball - Step & Roll (Europe)"
+	rom ( name "Super Monkey Ball - Step & Roll (Europe).iso" size 4699979776 crc 9733b44e md5 f9bcf8383e6ca8237941a24e6488ec29 sha1 a3f8718d4ac00fa72c6294c7cbb9607ea60b6cc1 )
+)
+
+game (
+	name "Super Monkey Ball - Step & Roll (USA)"
+	description "Super Monkey Ball - Step & Roll (USA)"
+	rom ( name "Super Monkey Ball - Step & Roll (USA).iso" size 4699979776 crc c64e229e md5 6b1ed46bc3506331014cd49be3e05d03 sha1 965a9066f7f8503a344fbc0c994d41841018c99c )
+)
+
+game (
+	name "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc 9aa033e1 md5 38048fdd50616374cae924adf1eafe0d sha1 81aebd46f19da87ec5731fc645bb345d910ba62c )
+)
+
+game (
+	name "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Super Paper Mario (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc ad00ca01 md5 a7450810f197b3403069f03f09b5ce01 sha1 f86ce80049aa35f11d1fdf498d60087dc3806ac2 )
+)
+
+game (
+	name "Super Paper Mario (Japan) (v1.00)"
+	description "Super Paper Mario (Japan) (v1.00)"
+	rom ( name "Super Paper Mario (Japan) (v1.00).iso" size 4699979776 crc 738e3fa5 md5 b683ed344b4933228e70a06163f9614d sha1 1ffed67d9c1441cc9aa2b1afd6ebd2145683e865 )
+)
+
+game (
+	name "Super Paper Mario (Japan) (v1.01)"
+	description "Super Paper Mario (Japan) (v1.01)"
+	rom ( name "Super Paper Mario (Japan) (v1.01).iso" size 4699979776 crc 928fec96 md5 e105123946d298d4c740c19280cb3940 sha1 2ad8bbb0f1b5d05b520a1167ac7e4d7c7cca3555 )
+)
+
+game (
+	name "Super Paper Mario (USA) (v1.00)"
+	description "Super Paper Mario (USA) (v1.00)"
+	rom ( name "Super Paper Mario (USA) (v1.00).iso" size 4699979776 crc ebdcbdae md5 fe441d77d5cb9a7f01de954e84e6ca49 sha1 441c05ddd378ced5ef3b0f610a20f9a499f75ab0 )
+)
+
+game (
+	name "Super Paper Mario (USA) (v1.02)"
+	description "Super Paper Mario (USA) (v1.02)"
+	rom ( name "Super Paper Mario (USA) (v1.02).iso" size 4699979776 crc 69f55eed md5 89976060c338b096277b134aa15cc210 sha1 37a3c98f3da7aede9e5c98c9bcd68091826c245b )
+)
+
+game (
+	name "Super Robot Taisen Neo (Japan)"
+	description "Super Robot Taisen Neo (Japan)"
+	rom ( name "Super Robot Taisen Neo (Japan).iso" size 4699979776 crc 6b73ba00 md5 e2c410c2fcb1a2de909cdadff322bf59 sha1 ba71d57fc5a483919c3dfe01c02d476c55baca50 )
+)
+
+game (
+	name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 8511160320 crc 6757c5f2 md5 549c19aefd56c3651571c32e3c32e5b3 sha1 42ab0684b9601405b2cb349ea64550a7807173cf )
+)
+
+game (
+	name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 8511160320 crc cb762c85 md5 c2255d53e08d6e1e6d25114be9f1bec1 sha1 666ad47a8c4010faecf77a92565e1f4e077a586b )
+)
+
+game (
+	name "Super Smash Bros. Brawl (USA) (v1.01)"
+	description "Super Smash Bros. Brawl (USA) (v1.01)"
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.01).iso" size 8511160320 crc 7d5228c6 md5 d18726e6dfdc8bdbdad540b561051087 sha1 0e95949ac585f357e79fcd34b20670b5dca97ac2 )
+)
+
+game (
+	name "Super Smash Bros. Brawl (USA) (v1.02)"
+	description "Super Smash Bros. Brawl (USA) (v1.02)"
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.02).iso" size 8511160320 crc 854b2889 md5 52ce7160ced2505ad5e397477d0ea4fe sha1 59432f150bf6b871ab378bb5b28e92005e0862f6 )
+)
+
+game (
+	name "Super Swing Golf (USA)"
+	description "Super Swing Golf (USA)"
+	rom ( name "Super Swing Golf (USA).iso" size 4699979776 crc e09c87a4 md5 98fa619e6d247f1fbf134e5130eeaf9b sha1 b29927e4fa61a3a4f9cb8c1c8da8b7b811bb1187 )
+)
+
+game (
+	name "Suzumiya Haruhi no Gekidou (Japan)"
+	description "Suzumiya Haruhi no Gekidou (Japan)"
+	rom ( name "Suzumiya Haruhi no Gekidou (Japan).iso" size 4699979776 crc f2678b83 md5 0958aeca07af5348d08a4699539f075c sha1 1185ec2456644ba5c32f291939bd5ce02e37c955 )
+)
+
+game (
+	name "Suzumiya Haruhi no Heiretsu (Japan)"
+	description "Suzumiya Haruhi no Heiretsu (Japan)"
+	rom ( name "Suzumiya Haruhi no Heiretsu (Japan).iso" size 4699979776 crc d98bfcbb md5 63dc19de5026e3df91c7bb06dcb727b1 sha1 3e31fbd58c4ee83885c99c6024dacb4381431ef7 )
+)
+
+game (
+	name "Table Football (Europe) (En,Fr,De,Es,It)"
+	description "Table Football (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Table Football (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a394ecd md5 a998175fc2245a15c0906a5d103c8aaa sha1 f63266e8db19263202690434eaf472fa3899905e )
+)
+
+game (
+	name "Taiko no Tatsujin Wii (Japan)"
+	description "Taiko no Tatsujin Wii (Japan)"
+	rom ( name "Taiko no Tatsujin Wii (Japan).iso" size 4699979776 crc f7b2e429 md5 f29234eecb79123a09ecd81821d62c06 sha1 d90c9f6c26fbe54b151db1e1d3b3ddd35e0e233e )
+)
+
+game (
+	name "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It)"
+	description "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15abeb61 md5 462ca4153007c8f2bea2236cf5fdb0dd sha1 7e2f2a788e4e587385dda51ca0f1adc84fd73b03 )
+)
+
+game (
+	name "Tales of Symphonia - Dawn of the New World (USA)"
+	description "Tales of Symphonia - Dawn of the New World (USA)"
+	rom ( name "Tales of Symphonia - Dawn of the New World (USA).iso" size 4699979776 crc e1295152 md5 1ae414ac8b40c70662b9d9410f8fc819 sha1 e41f7276d6a0042f65aec332b4375ac64452703f )
+)
+
+game (
+	name "Tales of Symphonia - Ratatosk no Kishi (Japan)"
+	description "Tales of Symphonia - Ratatosk no Kishi (Japan)"
+	rom ( name "Tales of Symphonia - Ratatosk no Kishi (Japan).iso" size 4699979776 crc 121798e6 md5 1e304d3f5b429c3217298fe068d91c30 sha1 bffb0ba27f4506daabdf268c6c40aa6ae0fee6b2 )
+)
+
+game (
+	name "Tataite Hazumu - Super Smash Ball Plus (Japan)"
+	description "Tataite Hazumu - Super Smash Ball Plus (Japan)"
+	rom ( name "Tataite Hazumu - Super Smash Ball Plus (Japan).iso" size 4699979776 crc f0022ae5 md5 3a34dacba0895b28ded2f54dceff48da sha1 4679055c6e15439708bbbf6c445ff4a64016fce4 )
+)
+
+game (
+	name "Tatsunoko vs. Capcom - Cross Generation of Heroes (Japan)"
+	description "Tatsunoko vs. Capcom - Cross Generation of Heroes (Japan)"
+	rom ( name "Tatsunoko vs. Capcom - Cross Generation of Heroes (Japan).iso" size 4699979776 crc a3aebee5 md5 e6b7732aaf80586dca871ed128fb3411 sha1 ea1c005160c16bad5c9006db0fb57d7ad701ad14 )
+)
+
+game (
+	name "Tatsunoko vs. Capcom - Ultimate All-Stars (Europe)"
+	description "Tatsunoko vs. Capcom - Ultimate All-Stars (Europe)"
+	rom ( name "Tatsunoko vs. Capcom - Ultimate All-Stars (Europe).iso" size 4699979776 crc ed3a9a54 md5 e15eaca463951baa5e50dda2b98428aa sha1 31fca93263b801aa48c15579382f8ac0ccac26c5 )
+)
+
+game (
+	name "Tatsunoko vs. Capcom - Ultimate All-Stars (Japan)"
+	description "Tatsunoko vs. Capcom - Ultimate All-Stars (Japan)"
+	rom ( name "Tatsunoko vs. Capcom - Ultimate All-Stars (Japan).iso" size 4699979776 crc 3df78884 md5 ccab63963bc58cba2441b23c1cfa50d8 sha1 6a838caac35741bb38d86b5a16c614d3898d017f )
+)
+
+game (
+	name "Tatsunoko vs. Capcom - Ultimate All-Stars (USA)"
+	description "Tatsunoko vs. Capcom - Ultimate All-Stars (USA)"
+	rom ( name "Tatsunoko vs. Capcom - Ultimate All-Stars (USA).iso" size 4699979776 crc 00b91869 md5 c885ec1bacb424281845fe925d6a0fab sha1 4cae082be6f3e8be35ba30bb342745d025190b18 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
+	description "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
+	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (Europe).iso" size 4699979776 crc a732c637 md5 e9fc3a03595a4869988baf5883717fbe sha1 51b1e95793583f2985e889ae35e83650b3a10e61 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It)"
+	description "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It)"
+	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It).iso" size 4699979776 crc 2f59d424 md5 29237aee3325787cab85595f82f13ab6 sha1 f059293fb15c319b378d860d95f5d1fd5c6cd4c9 )
+)
+
+game (
+	name "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
+	description "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
+	rom ( name "Teenage Mutant Ninja Turtles (USA) (En,Fr).iso" size 4699979776 crc 46ce2ad6 md5 53636e5efe2042d540962cdec58626c0 sha1 11ef981c246bece78c713eefdf45e3632c840363 )
+)
+
+game (
+	name "Telly Addicts (Europe)"
+	description "Telly Addicts (Europe)"
+	rom ( name "Telly Addicts (Europe).iso" size 4699979776 crc 92b69fe1 md5 36d385e03bd89463919abf588467475e sha1 360a09044868e427e47681b9b69e21758adce893 )
+)
+
+game (
+	name "Tenchu - Shadow Assassins (Europe) (En,Fr,De,Es,It)"
+	description "Tenchu - Shadow Assassins (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tenchu - Shadow Assassins (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4ee42b35 md5 d73549db2b750dfe939d317a7282af79 sha1 be70124cc86777a6867d18db94c6d47350f01adb )
+)
+
+game (
+	name "Tenchu - Shadow Assassins (USA) (En,Fr,Es)"
+	description "Tenchu - Shadow Assassins (USA) (En,Fr,Es)"
+	rom ( name "Tenchu - Shadow Assassins (USA) (En,Fr,Es).iso" size 4699979776 crc 95e68658 md5 c73a5bd3ddb0a7420e5101146260d63f sha1 fa0e4699195d2221068beed63da3c6d882f803c4 )
+)
+
+game (
+	name "Tenchu 4 (Japan)"
+	description "Tenchu 4 (Japan)"
+	rom ( name "Tenchu 4 (Japan).iso" size 4699979776 crc fe46fe28 md5 d835bf8f51299a2a6ee6c376428b604c sha1 f5f51ac8e1b3e876e7ae41d55e49a3776f2ac6f4 )
+)
+
+game (
+	name "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 68094068 md5 7fdfd25a87ed18f7320e64bc040186ea sha1 a0d2f903b15a4b968fdb197da08ec8901524e7fc )
+)
+
+game (
+	name "Tetris Party Deluxe (USA) (En,Fr,Es)"
+	description "Tetris Party Deluxe (USA) (En,Fr,Es)"
+	rom ( name "Tetris Party Deluxe (USA) (En,Fr,Es).iso" size 4699979776 crc 1c43e200 md5 c99e8eb54624753640c9275a13da97a8 sha1 d31c6c78288a06152fbddd3e12d3cc64da895175 )
+)
+
+game (
+	name "Thor - God of Thunder (USA) (En,Fr,Es)"
+	description "Thor - God of Thunder (USA) (En,Fr,Es)"
+	rom ( name "Thor - God of Thunder (USA) (En,Fr,Es).iso" size 4699979776 crc 8d4a277e md5 bb29139391c38fa525305c446e65f96d sha1 2b34e17049c47220aa2ab9e1c014d94d31242d0e )
+)
+
+game (
+	name "Thrillville - Off the Rails (Europe) (En,Fr,De,Es,It)"
+	description "Thrillville - Off the Rails (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Thrillville - Off the Rails (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc f3176724 md5 210380bac7cc84fd3cdc161eba7adf3f sha1 bec979153ba74c2c1f6a4667ea6ea49026a26328 )
+)
+
+game (
+	name "Thrillville - Off the Rails (USA)"
+	description "Thrillville - Off the Rails (USA)"
+	rom ( name "Thrillville - Off the Rails (USA).iso" size 4699979776 crc 0d3f0173 md5 357284c39e933e0735da03329846fbe7 sha1 90c6a8752b4c34a956913a89d4f88cafefba85de )
+)
+
+game (
+	name "Tiger Woods PGA Tour 07 (Europe)"
+	description "Tiger Woods PGA Tour 07 (Europe)"
+	rom ( name "Tiger Woods PGA Tour 07 (Europe).iso" size 4699979776 crc 6eb5aaa8 md5 fc58ea61d42314ff15ac2cf3bf68aa99 sha1 16ef5904fad10f82e62d8165e3ed23e521974f0c )
+)
+
+game (
+	name "Tiger Woods PGA Tour 07 (USA)"
+	description "Tiger Woods PGA Tour 07 (USA)"
+	rom ( name "Tiger Woods PGA Tour 07 (USA).iso" size 4699979776 crc d475a248 md5 00aa570a9ead9e6eaf6156e82b2004e6 sha1 7f3b6341ebf52c69a02b29540797252fc4bb594d )
+)
+
+game (
+	name "Tiger Woods PGA Tour 08 (Europe) (En,Fr)"
+	description "Tiger Woods PGA Tour 08 (Europe) (En,Fr)"
+	rom ( name "Tiger Woods PGA Tour 08 (Europe) (En,Fr).iso" size 4699979776 crc 2238f23f md5 f33c6252a7080ed4c882584d02c5bf71 sha1 cd7110e952abeb1e7a9ed4022e14af9a130ac697 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 08 (USA) (En,Fr)"
+	description "Tiger Woods PGA Tour 08 (USA) (En,Fr)"
+	rom ( name "Tiger Woods PGA Tour 08 (USA) (En,Fr).iso" size 4699979776 crc ccde0cee md5 108aa2b0e5c91931486e92061d9debbc sha1 7e093628c957cacb4205d614a678dd5f49fa2139 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 09 All-Play (Europe)"
+	description "Tiger Woods PGA Tour 09 All-Play (Europe)"
+	rom ( name "Tiger Woods PGA Tour 09 All-Play (Europe).iso" size 4699979776 crc b13fb541 md5 a3b6d9e1cc717d6a7e5804093b11bda6 sha1 6d184b92f7b386fd1b374658543e85fae83ab974 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 09 All-Play (USA)"
+	description "Tiger Woods PGA Tour 09 All-Play (USA)"
+	rom ( name "Tiger Woods PGA Tour 09 All-Play (USA).iso" size 4699979776 crc 79263693 md5 4e6aaee5d82c162d0b315f375e52b8b8 sha1 2f23be813f11a80ace50b1491465b053035cf2fb )
+)
+
+game (
+	name "Tiger Woods PGA Tour 10 (Europe)"
+	description "Tiger Woods PGA Tour 10 (Europe)"
+	rom ( name "Tiger Woods PGA Tour 10 (Europe).iso" size 4699979776 crc 336eb2d0 md5 8016f70fce29c6bd4309c6f1eb5c86b0 sha1 6fb9d670dce7dcc391c1caa5f20679836b7af107 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 10 (USA)"
+	description "Tiger Woods PGA Tour 10 (USA)"
+	rom ( name "Tiger Woods PGA Tour 10 (USA).iso" size 4699979776 crc a1055ec6 md5 b99aa4d815bff8eea8bf63f22f7002c7 sha1 200e3b755f2fcd937d372d2393b60d14de91f5cf )
+)
+
+game (
+	name "Tiger Woods PGA Tour 11 (Europe, Australia)"
+	description "Tiger Woods PGA Tour 11 (Europe, Australia)"
+	rom ( name "Tiger Woods PGA Tour 11 (Europe, Australia).iso" size 4699979776 crc ad29f6bb md5 d4a92a8bfe58f557ebdb045970373741 sha1 6a986c1b4fe0c448b4d05d487947ed37c9f8fd96 )
+)
+
+game (
+	name "Tiger Woods PGA Tour 12 (USA)"
+	description "Tiger Woods PGA Tour 12 (USA)"
+	rom ( name "Tiger Woods PGA Tour 12 (USA).iso" size 4699979776 crc 1cd3f947 md5 1f5fc413808447edef99eebcfde0323a sha1 12709b7de72d76823f92144cf8f2a7019b581c39 )
+)
+
+game (
+	name "TMNT (USA) (En,Fr,Es)"
+	description "TMNT (USA) (En,Fr,Es)"
+	rom ( name "TMNT (USA) (En,Fr,Es).iso" size 4699979776 crc 194636cc md5 4c9aa8e2ae4bceb3dd0e6b87de776a50 sha1 f9f75e3050a0fb0392ed03e7dc12362e0ffdd9a3 )
+)
+
+game (
+	name "TNA Impact! Total Nonstop Action Wrestling (Europe) (En,Fr,De,Es,It)"
+	description "TNA Impact! Total Nonstop Action Wrestling (Europe) (En,Fr,De,Es,It)"
+	rom ( name "TNA Impact! Total Nonstop Action Wrestling (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc aaecb55a md5 41b80cf18274b4c0ab61ae3a1c96e773 sha1 f08fcca995c3d63d472f6faf2701a054c71739ea )
+)
+
+game (
+	name "Tom Clancy's Ghost Recon (USA)"
+	description "Tom Clancy's Ghost Recon (USA)"
+	rom ( name "Tom Clancy's Ghost Recon (USA).iso" size 4699979776 crc 3c81cdc8 md5 a6dec9dc0b0bfdcda1327fc9cc450895 sha1 afc33db8b169d56d36f993ab410748c2f70ed718 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (Europe)"
+	description "Tom Clancy's Splinter Cell - Double Agent (Europe)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (Europe).iso" size 4699979776 crc 683ec80b md5 3645c0906155cf0adf5d875b22c84424 sha1 9e8dfaf35c8479bf00034bd767353e469d3c47d2 )
+)
+
+game (
+	name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es)"
+	description "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es)"
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es).iso" size 4699979776 crc b7a08b7c md5 494fb46106ba8820e21b227bcbdb68cf sha1 429c74820c6cea4b462c2bfaf24743ac4b7861e0 )
+)
+
+game (
+	name "Tomb Raider - Underworld (Europe) (En,Fr,De,Es,It)"
+	description "Tomb Raider - Underworld (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tomb Raider - Underworld (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b370db9f md5 1a560d490ebbd31d804699cea2194ca3 sha1 524eb60a92a314cd9888ba90c712aa492cf3ad23 )
+)
+
+game (
+	name "Tomb Raider - Underworld (USA) (En,Fr,Es)"
+	description "Tomb Raider - Underworld (USA) (En,Fr,Es)"
+	rom ( name "Tomb Raider - Underworld (USA) (En,Fr,Es).iso" size 4699979776 crc bd9696f2 md5 dc04df593e70d5e15cfe111a30d61749 sha1 c166185b367fa29cb263ecdb2186cc604ba38a06 )
+)
+
+game (
+	name "Tony Hawk - Shred (Europe)"
+	description "Tony Hawk - Shred (Europe)"
+	rom ( name "Tony Hawk - Shred (Europe).iso" size 4699979776 crc 1c147312 md5 4a1f5cee4ea14d84156f7b1de996660d sha1 cbf5ad1f36122204d2feedfd411a7b0c5781533e )
+)
+
+game (
+	name "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	description "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3f78048a md5 52d07455ab229836e57ed988f0f5e3dd sha1 3c939ed80bd6e1e9abd5c7802ec1545faefb4792 )
+)
+
+game (
+	name "Tony Hawk's Downhill Jam (USA)"
+	description "Tony Hawk's Downhill Jam (USA)"
+	rom ( name "Tony Hawk's Downhill Jam (USA).iso" size 4699979776 crc 69d90dc8 md5 7f89885ff73b29cdcfec396685b3e7c2 sha1 1d57e5a2142ec026efd7b14140051e069236db84 )
+)
+
+game (
+	name "Tony Hawk's Proving Ground (USA)"
+	description "Tony Hawk's Proving Ground (USA)"
+	rom ( name "Tony Hawk's Proving Ground (USA).iso" size 4699979776 crc b832e40d md5 f59ffb625986c0ab7acf04fd0e835aef sha1 7daf6a68db4668bba36ba1f7dac121948c3baab9 )
+)
+
+game (
+	name "Top Shot Dinosaur Hunter (USA)"
+	description "Top Shot Dinosaur Hunter (USA)"
+	rom ( name "Top Shot Dinosaur Hunter (USA).iso" size 4699979776 crc 923a7146 md5 5db053ddd736887ad6acdebb262ba22a sha1 c02b94de422020996f778e33395519ff8228efed )
+)
+
+game (
+	name "Top Spin 3 (USA) (En,Fr,Es)"
+	description "Top Spin 3 (USA) (En,Fr,Es)"
+	rom ( name "Top Spin 3 (USA) (En,Fr,Es).iso" size 4699979776 crc b804a332 md5 352c1047aa91adbc66a275d8331bbfcb sha1 99482a31aff9867e7ca032af910f7ef38860c04f )
+)
+
+game (
+	name "Top Trumps - Doctor Who (UK)"
+	description "Top Trumps - Doctor Who (UK)"
+	rom ( name "Top Trumps - Doctor Who (UK).iso" size 4699979776 crc 00ddec9e md5 60aab6280fb1cadb97c826653aa9c837 sha1 0bc9d8413d556dc3c5710dfabbe915cd791404f2 )
+)
+
+game (
+	name "Top Trumps Adventures (UK) (En,Fr,De,Es,It)"
+	description "Top Trumps Adventures (UK) (En,Fr,De,Es,It)"
+	rom ( name "Top Trumps Adventures (UK) (En,Fr,De,Es,It).iso" size 4699979776 crc 38bcf8b0 md5 8a755622a254bb568bbde0035b93f5bb sha1 0ea177a32ab166c1049b1eef4e7a63648b9103e1 )
+)
+
+game (
+	name "Tornado Outbreak (USA) (En,Fr,Es)"
+	description "Tornado Outbreak (USA) (En,Fr,Es)"
+	rom ( name "Tornado Outbreak (USA) (En,Fr,Es).iso" size 4699979776 crc 67e7817f md5 6d4a0b77a804e2f93e4c7a512c269faf sha1 ec9921e64b2961ee29492ddd6cc033c6fe4e9d88 )
+)
+
+game (
+	name "Totally Spies! Totally Party (USA) (En,Fr,Es)"
+	description "Totally Spies! Totally Party (USA) (En,Fr,Es)"
+	rom ( name "Totally Spies! Totally Party (USA) (En,Fr,Es).iso" size 4699979776 crc 5ada2510 md5 ef96b345c246b4744c74986affe9e740 sha1 58a15aa7df9fef6dc3a99e6dea009404850013ec )
+)
+
+game (
+	name "Tournament of Legends (USA)"
+	description "Tournament of Legends (USA)"
+	rom ( name "Tournament of Legends (USA).iso" size 4699979776 crc 04cb072e md5 fcc1f65d223f727ce6f9ab5cd2145347 sha1 d2e2b5879fa64e1bb5a6bb30a0bb69bd84b15d0b )
+)
+
+game (
+	name "Transformers - Dark of the Moon - Stealth Force Edition (Europe) (En,Fr,De,Es,It)"
+	description "Transformers - Dark of the Moon - Stealth Force Edition (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Transformers - Dark of the Moon - Stealth Force Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ee748fab md5 e1e817d1df3a0de69978b6b613cd802f sha1 08ecbec6d71f4f9f8dc15ad1f97eb8d56a444465 )
+)
+
+game (
+	name "Transformers - Revenge of the Fallen (Europe) (En,Fr,De,Es,It)"
+	description "Transformers - Revenge of the Fallen (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Transformers - Revenge of the Fallen (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b9c5f963 md5 ca95a31eac9255394f996c1ce93500ee sha1 b27014cd7f5a06c604bd0191f2676cf53c809f78 )
+)
+
+game (
+	name "Transformers - Revenge of the Fallen (USA) (En,Fr)"
+	description "Transformers - Revenge of the Fallen (USA) (En,Fr)"
+	rom ( name "Transformers - Revenge of the Fallen (USA) (En,Fr).iso" size 4699979776 crc f878f4e2 md5 93529e230a5e9b950d5c5f77b408c690 sha1 fdb04992b1ad7a49341358b6a1fac87a9aaa77cd )
+)
+
+game (
+	name "Transformers - The Game (USA)"
+	description "Transformers - The Game (USA)"
+	rom ( name "Transformers - The Game (USA).iso" size 4699979776 crc fe2da7c3 md5 f443c8bd16344abb242299a7a131f7f5 sha1 527087e47e5253f0213ad4855a627fded1336a44 )
+)
+
+game (
+	name "Transformers Prime - The Game (USA) (En,Fr)"
+	description "Transformers Prime - The Game (USA) (En,Fr)"
+	rom ( name "Transformers Prime - The Game (USA) (En,Fr).iso" size 4699979776 crc dcb8f45b md5 bc12f61688d429b828a80ede9d02003c sha1 6127579155fcb892a1c3bf409abbec4a2051f06e )
+)
+
+game (
+	name "Trauma Center - New Blood (Europe) (En,Fr,De,Es,It)"
+	description "Trauma Center - New Blood (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Trauma Center - New Blood (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7f68ecad md5 dd65b7f1009e305c659b82f533b85a47 sha1 51af00a716103637ea4d5de9f13e1ca6f0ac5093 )
+)
+
+game (
+	name "Trauma Center - New Blood (USA)"
+	description "Trauma Center - New Blood (USA)"
+	rom ( name "Trauma Center - New Blood (USA).iso" size 4699979776 crc 1b9fc0a4 md5 4ece4485e318a2fa2aab5cbf5aab1b18 sha1 3778e0c4d0b74be925c894813c9f6e2c6078dda5 )
+)
+
+game (
+	name "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It)"
+	description "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc cba4c93f md5 16119b96d5c60500d5e49b1dda79009e sha1 dd1ac732543918dcd7e9e66a97c8ab57ec4da7f3 )
+)
+
+game (
+	name "Trauma Center - Second Opinion (USA)"
+	description "Trauma Center - Second Opinion (USA)"
+	rom ( name "Trauma Center - Second Opinion (USA).iso" size 4699979776 crc bee895ad md5 217ebd710577b541cb15adaab3fa79ba sha1 af121a056a4c8d7c9473bbd880d7049676b0f9df )
+)
+
+game (
+	name "Trauma Team (USA)"
+	description "Trauma Team (USA)"
+	rom ( name "Trauma Team (USA).iso" size 4699979776 crc f989bb8d md5 dfc0f957956eebc614a01e4fe60d20cb sha1 2f1c6efb312447170de75c5da013a8f7558f1256 )
+)
+
+game (
+	name "Trivial Pursuit - Bet You Know It (USA) (En,Fr)"
+	description "Trivial Pursuit - Bet You Know It (USA) (En,Fr)"
+	rom ( name "Trivial Pursuit - Bet You Know It (USA) (En,Fr).iso" size 4699979776 crc 28e9fd69 md5 9a91257e7d672b48727bf3b72c7b5e53 sha1 9c2013f6947fbf247d6ab462227385ce74039c02 )
+)
+
+game (
+	name "Trivial Pursuit (USA) (En,Fr)"
+	description "Trivial Pursuit (USA) (En,Fr)"
+	rom ( name "Trivial Pursuit (USA) (En,Fr).iso" size 4699979776 crc 80298f12 md5 61b64accac6dc592440c53a4cceb64cb sha1 746db89fc783ba548f279efc18f53e7e1f23e487 )
+)
+
+game (
+	name "Truth or Lies (Europe) (En,De)"
+	description "Truth or Lies (Europe) (En,De)"
+	rom ( name "Truth or Lies (Europe) (En,De).iso" size 4699979776 crc 5226f5d6 md5 b3cd7919f0e9bf0728b294a248f18b87 sha1 a1100f79f194c30f62981c521255580c68b5f26b )
+)
+
+game (
+	name "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl)"
+	description "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 9e32bc1c md5 08c9ab501b089079d79d332cfabfbcf9 sha1 d138caadd87426a22f63b54f2d4180fcb29b4187 )
+)
+
+game (
+	name "U-Sing (Europe) (En,Nl)"
+	description "U-Sing (Europe) (En,Nl)"
+	rom ( name "U-Sing (Europe) (En,Nl).iso" size 4699979776 crc a8c97a2d md5 9b1fb989a20acd1183ccea3ec4b4977d sha1 61c00df6bf146be831d25dd1e5820e9495c450fc )
+)
+
+game (
+	name "uDraw Disney Princess - Enchanting Storybooks (Europe, Australia)"
+	description "uDraw Disney Princess - Enchanting Storybooks (Europe, Australia)"
+	rom ( name "uDraw Disney Princess - Enchanting Storybooks (Europe, Australia).iso" size 4699979776 crc abb0b658 md5 66e57972b60b64ed8a626f803c5ef78e sha1 dc8d382778e79c20e57e38ee2011ede93b853db6 )
+)
+
+game (
+	name "uDraw Pictionary (Australia)"
+	description "uDraw Pictionary (Australia)"
+	rom ( name "uDraw Pictionary (Australia).iso" size 4699979776 crc 374343ac md5 91d60ca553d433a96c06c8953a713dce sha1 519a35a9f36997df186fe26c8b240db25818595c )
+)
+
+game (
+	name "uDraw Studio - Instant Artist (Europe) (En,Fr,De,Es,It,Nl)"
+	description "uDraw Studio - Instant Artist (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "uDraw Studio - Instant Artist (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 60d6337e md5 5ddae36351ebbcd4c52f58f7f1408538 sha1 f4dba1f9cbd159150aec7d4e773895d2f3aee82d )
+)
+
+game (
+	name "uDraw Studio - Instant Artist (USA) (En,Fr,Es)"
+	description "uDraw Studio - Instant Artist (USA) (En,Fr,Es)"
+	rom ( name "uDraw Studio - Instant Artist (USA) (En,Fr,Es).iso" size 4699979776 crc 3126743e md5 a8a19372f864049f4ff1083d8b550af9 sha1 aca015d590ccfc6c3378e32f8ee5634e9273d306 )
+)
+
+game (
+	name "uDraw Studio (USA)"
+	description "uDraw Studio (USA)"
+	rom ( name "uDraw Studio (USA).iso" size 4699979776 crc 03a31a48 md5 b117b164bda2b59db21b2df174d5cc4e sha1 05939130bdfa94bcd9064ab846a9decbae75099e )
+)
+
+game (
+	name "Ultimate Band (USA) (En,Fr,Es)"
+	description "Ultimate Band (USA) (En,Fr,Es)"
+	rom ( name "Ultimate Band (USA) (En,Fr,Es).iso" size 4699979776 crc 996ca8f3 md5 e6baf21b27726eb7ee3ab80659a157a0 sha1 b6a00a20a403abaaa7693bec1b6a840e39c4643e )
+)
+
+game (
+	name "Ultimate Board Game Collection (Europe) (En,Fr,De,Es,It)"
+	description "Ultimate Board Game Collection (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Ultimate Board Game Collection (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 2708e01f md5 69dc63dfba4e1bb2939efd6bdcf366f2 sha1 79e676013767b527a3f047ca0ebd4fe4ffcdf94c )
+)
+
+game (
+	name "Ultimate Duck Hunting - Hunting & Retrieving Ducks (USA) (En,Fr,Es)"
+	description "Ultimate Duck Hunting - Hunting & Retrieving Ducks (USA) (En,Fr,Es)"
+	rom ( name "Ultimate Duck Hunting - Hunting & Retrieving Ducks (USA) (En,Fr,Es).iso" size 4699979776 crc 7662fec9 md5 acbe4fcd9049f6f7b02a0eb0cc97c702 sha1 037e104713cf2a22406df4876395ad7f4cb5caf1 )
+)
+
+game (
+	name "Ultimate I Spy (Europe)"
+	description "Ultimate I Spy (Europe)"
+	rom ( name "Ultimate I Spy (Europe).iso" size 4699979776 crc 3d8b61d2 md5 7740571af972bd57902ff8132a3c1c64 sha1 d935692a477afe9dc951f1ebce455c89d20ee094 )
+)
+
+game (
+	name "Ultimate Party Challenge (USA)"
+	description "Ultimate Party Challenge (USA)"
+	rom ( name "Ultimate Party Challenge (USA).iso" size 4699979776 crc 1d6661f4 md5 600a2848b1fa4781e6dfb0c9a06847a3 sha1 d43ba8dfbef961e5de5d2550b327991a2dff3ce8 )
+)
+
+game (
+	name "Valhalla Knights - Eldar Saga (USA)"
+	description "Valhalla Knights - Eldar Saga (USA)"
+	rom ( name "Valhalla Knights - Eldar Saga (USA).iso" size 4699979776 crc b9eba063 md5 5af258375691b6b7c6d2d70646ef6475 sha1 212da0c425255d64c715fdc27701cafd643c1752 )
+)
+
+game (
+	name "Victorious Boxers Challenge (Europe)"
+	description "Victorious Boxers Challenge (Europe)"
+	rom ( name "Victorious Boxers Challenge (Europe).iso" size 4699979776 crc 1778720a md5 c20dfb3ee332dc6a6bc29936ec99e67c sha1 2eb71fb211e74c9d747dbe9f96623791e2993e9e )
+)
+
+game (
+	name "Virtua Tennis 2009 (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Virtua Tennis 2009 (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Virtua Tennis 2009 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc f1f7fac1 md5 bd2062128b738e67cabb4f4d25e2e372 sha1 8ec1b4f030a2c558a82aca5c892238fc9ccf77a5 )
+)
+
+game (
+	name "Wacky World of Sports (USA) (En,Fr,Es)"
+	description "Wacky World of Sports (USA) (En,Fr,Es)"
+	rom ( name "Wacky World of Sports (USA) (En,Fr,Es).iso" size 4699979776 crc 89c07890 md5 e767b3cd5cb11b60fe0a747e90c1f7f6 sha1 0a7cac479f5d5509bee7a682047719b7673d0dc1 )
+)
+
+game (
+	name "Walk It Out (USA) (En,Fr,Es)"
+	description "Walk It Out (USA) (En,Fr,Es)"
+	rom ( name "Walk It Out (USA) (En,Fr,Es).iso" size 4699979776 crc 1c1474ec md5 d1f8434a8a47a8e4d39ea8a78c510f03 sha1 658817e0973fe9cc03a68760338484eb7b019345 )
+)
+
+game (
+	name "Wario Land - Shake It! (USA) (En,Fr,Es)"
+	description "Wario Land - Shake It! (USA) (En,Fr,Es)"
+	rom ( name "Wario Land - Shake It! (USA) (En,Fr,Es).iso" size 4699979776 crc fccdd2cd md5 9ee8421657db2ba03296a6acd02772b6 sha1 d9b06f17f7d7860ddc46cb3a1dcd6cb00b7d1017 )
+)
+
+game (
+	name "Wario Land - The Shake Dimension (Europe) (En,Fr,De,Es,It)"
+	description "Wario Land - The Shake Dimension (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wario Land - The Shake Dimension (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 936d9216 md5 f8d3599798297dc2beeb2acf4a181601 sha1 2f086df1aa2e7885fe41321b960f4c6c8551237a )
+)
+
+game (
+	name "Wario Land Shake (Japan)"
+	description "Wario Land Shake (Japan)"
+	rom ( name "Wario Land Shake (Japan).iso" size 4699979776 crc ff24afeb md5 33d6c752f928ad247b7940515d85168b sha1 1a6a3f4efe44ca57ff9e6db5fa508b1101974994 )
+)
+
+game (
+	name "WarioWare - Smooth Moves (Europe) (En,Fr,De,Es,It)"
+	description "WarioWare - Smooth Moves (Europe) (En,Fr,De,Es,It)"
+	rom ( name "WarioWare - Smooth Moves (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e9482d2d md5 d9ad8fafac267b989627cbb0f3907364 sha1 88ab8b4cad0b3ad4834d8d1ab7232707910f0dbe )
+)
+
+game (
+	name "WarioWare - Smooth Moves (USA)"
+	description "WarioWare - Smooth Moves (USA)"
+	rom ( name "WarioWare - Smooth Moves (USA).iso" size 4699979776 crc 3ddee91c md5 159aa59a44989385c3533cdcf06be132 sha1 fb20262f03b8dc72ebf79d94555630303e81c555 )
+)
+
+game (
+	name "We Cheer (USA) (En,Fr,Es)"
+	description "We Cheer (USA) (En,Fr,Es)"
+	rom ( name "We Cheer (USA) (En,Fr,Es).iso" size 4699979776 crc b2164abc md5 a8776ba3b80c1c74bf30aeb8912b5bb9 sha1 beb56c18b6149783f73e02d5953231b4970b60a3 )
+)
+
+game (
+	name "We Dare - Flirty Fun for All (Europe)"
+	description "We Dare - Flirty Fun for All (Europe)"
+	rom ( name "We Dare - Flirty Fun for All (Europe).iso" size 4699979776 crc b6540b48 md5 c771877b8103900d73cdb657c1718855 sha1 b49c55674e24e75e90d1d910f33c94e3032bbfcc )
+)
+
+game (
+	name "We Love Golf! (Europe) (En,Fr,De,Es,It)"
+	description "We Love Golf! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "We Love Golf! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc e2804662 md5 4ffe4e5c9452faba5b3a8e44a8b49f6e sha1 2006584d2ff0f2e0e78e4d158e537da1380a21b3 )
+)
+
+game (
+	name "We Love Golf! (USA) (En,Fr,Es)"
+	description "We Love Golf! (USA) (En,Fr,Es)"
+	rom ( name "We Love Golf! (USA) (En,Fr,Es).iso" size 4699979776 crc a680c023 md5 30fac42c13f467006d7c84d830e532e6 sha1 8a2f83eeb771248f807d70e213b2f18b6c8c0204 )
+)
+
+game (
+	name "We Sing Robbie Williams (Europe) (En,Fr,De,Es,It)"
+	description "We Sing Robbie Williams (Europe) (En,Fr,De,Es,It)"
+	rom ( name "We Sing Robbie Williams (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 82364a30 md5 7539d2eca5cbfef644ec88db32fc712b sha1 968673c2620f0444b7d537e37b041bee96a390a2 )
+)
+
+game (
+	name "We Ski (USA) (En,Fr,Es)"
+	description "We Ski (USA) (En,Fr,Es)"
+	rom ( name "We Ski (USA) (En,Fr,Es).iso" size 4699979776 crc a90854cf md5 fb5b8a4dfe460fe98e5e20030bec11a1 sha1 b5df2256c4ee611e7f831f5f6d7b6f7061bc929e )
+)
+
+game (
+	name "We Ski & Snowboard (USA) (En,Fr,Es)"
+	description "We Ski & Snowboard (USA) (En,Fr,Es)"
+	rom ( name "We Ski & Snowboard (USA) (En,Fr,Es).iso" size 4699979776 crc 5e4c07a2 md5 4e03e5cdf05000ce5c6e57c1b858eb1b sha1 6c34b8f5b3165e7f5ed63dbd4cd0ee40e7a1077d )
+)
+
+game (
+	name "Where's Waldo - The Fantastic Journey (USA) (En,Fr)"
+	description "Where's Waldo - The Fantastic Journey (USA) (En,Fr)"
+	rom ( name "Where's Waldo - The Fantastic Journey (USA) (En,Fr).iso" size 4699979776 crc 08832e74 md5 59b87d7341505e4a48ce35bedea8d6ba sha1 d4078e019784e47c0fd9bd5f926e25ee94659cf3 )
+)
+
+game (
+	name "Wii Chess (Europe) (En,Fr,De)"
+	description "Wii Chess (Europe) (En,Fr,De)"
+	rom ( name "Wii Chess (Europe) (En,Fr,De).iso" size 4699979776 crc 0637f090 md5 fc038ad366fdd1aa8bbb651b7df53d81 sha1 ef7de9bd4b3c808496d12a723041b84f3fa31085 )
+)
+
+game (
+	name "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc 2aec75b4 md5 60b0decf6349311cdb6fb4841f3c8040 sha1 4c17f07da0f6ff3ce0436d41612b5aaedb26a8b6 )
+)
+
+game (
+	name "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Wii Fit (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 08986337 md5 7db4e1c3a0911cc2b2c5e9c3c0b40e5d sha1 f966733f01b6556f355071290d0c7cfd5250cd74 )
+)
+
+game (
+	name "Wii Fit (Japan)"
+	description "Wii Fit (Japan)"
+	rom ( name "Wii Fit (Japan).iso" size 4699979776 crc 1635ac31 md5 a405e33d2b939cfa03702450102cae2f sha1 f51408d5ec5729da0bee8b0ccdcdb5f2db741238 )
+)
+
+game (
+	name "Wii Fit (USA) (En,Fr,Es) (v1.00)"
+	description "Wii Fit (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Wii Fit (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 9371e450 md5 f3a74ecfd4236156a62f7fb5170128ad sha1 ec7dd9f0b0efc1ed01cc2aa40adfef252f418212 )
+)
+
+game (
+	name "Wii Fit (USA) (En,Fr,Es) (v1.01)"
+	description "Wii Fit (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Wii Fit (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc ef29316c md5 f4b8410c845d71e0158f8335fd6bb4ff sha1 e8c38b1af8993ff93623772ac0c7ee151eb59e35 )
+)
+
+game (
+	name "Wii Fit Plus (Asia)"
+	description "Wii Fit Plus (Asia)"
+	rom ( name "Wii Fit Plus (Asia).iso" size 4699979776 crc 3f8e21c0 md5 5dc961f0745188724a6b8ad9dc6c915d sha1 1126d7bc53e4c9864460fce71c6d3513304a8d30 )
+)
+
+game (
+	name "Wii Fit Plus (Europe, Australia) (En,Fr,De,Es,It)"
+	description "Wii Fit Plus (Europe, Australia) (En,Fr,De,Es,It)"
+	rom ( name "Wii Fit Plus (Europe, Australia) (En,Fr,De,Es,It).iso" size 4699979776 crc 1dfe5245 md5 2da4ae82485293c227c94901449710bb sha1 75ab2048c2323afbf7959cb20847e0e84138bf01 )
+)
+
+game (
+	name "Wii Fit Plus (USA) (En,Fr)"
+	description "Wii Fit Plus (USA) (En,Fr)"
+	rom ( name "Wii Fit Plus (USA) (En,Fr).iso" size 4699979776 crc 3123d399 md5 f0b64a98090267c9450243ea557ba399 sha1 5b9c83266681293f16dafba0cfe5ac5775df0330 )
+)
+
+game (
+	name "Wii Music (Europe) (En,Fr,De,Es,It)"
+	description "Wii Music (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wii Music (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 64d60dd7 md5 f3233c86be1310c277efd512ef791977 sha1 4c1b821c49c402079e4e3509cf572ad3cef8405f )
+)
+
+game (
+	name "Wii Music (USA) (En,Fr,Es)"
+	description "Wii Music (USA) (En,Fr,Es)"
+	rom ( name "Wii Music (USA) (En,Fr,Es).iso" size 4699979776 crc 59d46fe4 md5 ce0d062df2a18fcbb145e52634679ca6 sha1 50c784119b4e5cfed244a744183c9d5214227840 )
+)
+
+game (
+	name "Wii Party (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Wii Party (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Wii Party (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 3a519fe4 md5 a8e6e6df84d023a6eb4291031b308857 sha1 0cbc0892661d1c17a79c714e46cb7586bdd427c4 )
+)
+
+game (
+	name "Wii Party (USA) (En,Fr,Es)"
+	description "Wii Party (USA) (En,Fr,Es)"
+	rom ( name "Wii Party (USA) (En,Fr,Es).iso" size 4699979776 crc e81db0f0 md5 f42e3a48f60950877b1bdaea1146c564 sha1 281a556b08b90bf89d76705ca6d026e21226b8d9 )
+)
+
+game (
+	name "Wii Play - Motion (Europe) (En,Fr,De,Es,It)"
+	description "Wii Play - Motion (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wii Play - Motion (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc cf65b024 md5 38f5217cc047c683af257ad3b2d8e540 sha1 ae8b0ba412cf2063ad3eb5115bef09a7c5abb55b )
+)
+
+game (
+	name "Wii Play - Motion (USA)"
+	description "Wii Play - Motion (USA)"
+	rom ( name "Wii Play - Motion (USA).iso" size 4699979776 crc e5dcdfe4 md5 3dc1e805bb0bfa98145126fe6321112e sha1 1e8589c298105d2272b3211e0137d67ff559f80a )
+)
+
+game (
+	name "Wii Play (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Wii Play (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Wii Play (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc c57946de md5 a76b3c2a813084dac0c8556291244139 sha1 36563b60cb2fd0b5bf87550f458dcbff65268565 )
+)
+
+game (
+	name "Wii Play (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Wii Play (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Wii Play (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 18d23a50 md5 c841cfee2061d56b04439b8106baabb6 sha1 d3aa819a58dee297a2bbe035e4a170d2676e96c5 )
+)
+
+game (
+	name "Wii Play (USA) (v1.00)"
+	description "Wii Play (USA) (v1.00)"
+	rom ( name "Wii Play (USA) (v1.00).iso" size 4699979776 crc 4df3d026 md5 175f13b59326738bc430e8302ad67934 sha1 dc2668746e7100a6034e9b89535bc1e2a4af9678 )
+)
+
+game (
+	name "Wii Play (USA) (v1.01)"
+	description "Wii Play (USA) (v1.01)"
+	rom ( name "Wii Play (USA) (v1.01).iso" size 4699979776 crc c73e458a md5 cdd4c74ab291c609f431beb5860df0e8 sha1 80c223ea5eaf35f5f7876c9fc5904472b103334e )
+)
+
+game (
+	name "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.00)"
+	description "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.00)"
+	rom ( name "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc 87bded9d md5 8f45c4f518719a7e8b0eeacd044f4d2d sha1 9ec91a82c2e1d095856bc15c56b747820d2a7a0b )
+)
+
+game (
+	name "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.01)"
+	description "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.01)"
+	rom ( name "Wii Sports (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc 7210d7b5 md5 197fa7bd7a4abc0c761057402ce194f1 sha1 3ef6ffe45ea5c05b8c02171282819a3c4fdde4b5 )
+)
+
+game (
+	name "Wii Sports (Japan)"
+	description "Wii Sports (Japan)"
+	rom ( name "Wii Sports (Japan).iso" size 4699979776 crc 86ae9331 md5 9479d6b1b25d4c4b7d1e3b1631baff30 sha1 daeea63ae2971036c7d838c2ba66ea60a9285bee )
+)
+
+game (
+	name "Wii Sports (USA) (v1.00)"
+	description "Wii Sports (USA) (v1.00)"
+	rom ( name "Wii Sports (USA) (v1.00).iso" size 4699979776 crc 349b6f28 md5 8342bb2164a482e7f98d8945d94ccc7e sha1 7f806af5116a5bf71a8dd5ff01de3deed4173c6d )
+)
+
+game (
+	name "Wii Sports (USA) (v1.01)"
+	description "Wii Sports (USA) (v1.01)"
+	rom ( name "Wii Sports (USA) (v1.01).iso" size 4699979776 crc 7335fb54 md5 b6d6d751d4cad1880bee742594af6f76 sha1 316f73eb9276318f86d28731e7ccdbe17413011c )
+)
+
+game (
+	name "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
+	description "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 199014df md5 f9d6a6c2600a54f72c8fe9cb61321fe7 sha1 1310aeba93aaccfb9e9a614d3e4850f5199bc1d9 )
+)
+
+game (
+	name "Wii Sports & Wii Sports Resort (USA)"
+	description "Wii Sports & Wii Sports Resort (USA)"
+	rom ( name "Wii Sports & Wii Sports Resort (USA).iso" size 4699979776 crc 51cc6185 md5 5221c4f094f9373699370a864be5fa74 sha1 978471af1873061bab7b50ac43ade4090af6f5d4 )
+)
+
+game (
+	name "Wii Sports Resort (Asia)"
+	description "Wii Sports Resort (Asia)"
+	rom ( name "Wii Sports Resort (Asia).iso" size 4699979776 crc b6a77297 md5 cc5c74d1e2dd7a97d20ad0972025d284 sha1 2803d767541740d194a0817c19da9ac04d303fc9 )
+)
+
+game (
+	name "Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
+	description "Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wii Sports Resort (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 18b07bb0 md5 3aabcdd66c89a8d6d1d4c9eb7003e6ef sha1 a502c6063d692e1d5286e9b303f067dfe748bb84 )
+)
+
+game (
+	name "Wii Sports Resort (USA) (En,Fr,Es) (v1.00)"
+	description "Wii Sports Resort (USA) (En,Fr,Es) (v1.00)"
+	rom ( name "Wii Sports Resort (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc c0171bcc md5 315cdb6b77cd1e1f7189631cb93f0aa2 sha1 6fdb3d807dfb4069769c04966936d599038ba2ef )
+)
+
+game (
+	name "Wii Sports Resort (USA) (En,Fr,Es) (v1.01)"
+	description "Wii Sports Resort (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Wii Sports Resort (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 21b4e2ae md5 ee2f2288e77822bc91aa471967aea1f9 sha1 b5ff7df7525fe226a490937dc9baca6942553ec4 )
+)
+
+game (
+	name "Wild Earth - African Safari (Europe) (En,Fr,De,Es,It)"
+	description "Wild Earth - African Safari (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Wild Earth - African Safari (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4821d352 md5 05f7a7745c77d9d45609fcdc02ff7aee sha1 b36bbe3181a83710a6755cbed0b379104ae82c1f )
+)
+
+game (
+	name "Wild Earth - African Safari (USA)"
+	description "Wild Earth - African Safari (USA)"
+	rom ( name "Wild Earth - African Safari (USA).iso" size 4699979776 crc bf136265 md5 b77b3dc3d5b5213a68408ab052b8d5a9 sha1 938470585064b4725433166949c6a4ea7da120c4 )
+)
+
+game (
+	name "Williams Pinball Classics (Europe) (En,Fr,De,Es)"
+	description "Williams Pinball Classics (Europe) (En,Fr,De,Es)"
+	rom ( name "Williams Pinball Classics (Europe) (En,Fr,De,Es).iso" size 4699979776 crc 14b63276 md5 aa91bda8c1e3cecc4d592d92cc2c42a3 sha1 64c796dbd01fc0f1bc1de40e466a0b83ca14771b )
+)
+
+game (
+	name "Wing Island (USA) (En,Fr,Es)"
+	description "Wing Island (USA) (En,Fr,Es)"
+	rom ( name "Wing Island (USA) (En,Fr,Es).iso" size 4699979776 crc e79db704 md5 0aefe9a0b171085daf1944ec7459dfd4 sha1 5137a840dd996239e341b821f0b45655402c554c )
+)
+
+game (
+	name "Winter Sports 2008 - The Ultimate Challenge (Europe)"
+	description "Winter Sports 2008 - The Ultimate Challenge (Europe)"
+	rom ( name "Winter Sports 2008 - The Ultimate Challenge (Europe).iso" size 4699979776 crc d65f527f md5 4487e51d0605c22f6d0899accc856a75 sha1 a0a2c60914c7827764c6ee936092b56cbddb7439 )
+)
+
+game (
+	name "Winter Stars (Europe) (En,Fr,De,Es,It)"
+	description "Winter Stars (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Winter Stars (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 07088141 md5 11fac5f0c409a7aec2568664d2eeee5a sha1 ef7e9722b4d4f880ee8aba25a8a07aa2bc099a5c )
+)
+
+game (
+	name "Wonder World - Amusement Park (Europe) (En,Fr,De,Es,It,Nl)"
+	description "Wonder World - Amusement Park (Europe) (En,Fr,De,Es,It,Nl)"
+	rom ( name "Wonder World - Amusement Park (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc bacb68b9 md5 05c371cd77e710f9205ec459d19025bf sha1 f8011c43a712c69e5d99bfcf1aaa049cb7239739 )
+)
+
+game (
+	name "Wonder World - Amusement Park (USA)"
+	description "Wonder World - Amusement Park (USA)"
+	rom ( name "Wonder World - Amusement Park (USA).iso" size 4699979776 crc 5e3672bd md5 4777453167603f3b334c509badb39cf3 sha1 85c5614d4997a907e1b4a2e8751d54ccf84edeac )
+)
+
+game (
+	name "World of Zoo (USA) (En,Fr,Es)"
+	description "World of Zoo (USA) (En,Fr,Es)"
+	rom ( name "World of Zoo (USA) (En,Fr,Es).iso" size 4699979776 crc c1a84119 md5 f0072c3355f63957568a63d9ea8ccf31 sha1 c342d1a55e7e7e1be0daf88d0a37af69a0b22ec7 )
+)
+
+game (
+	name "Worms - A Space Oddity (Europe) (En,Fr,De,Es,It)"
+	description "Worms - A Space Oddity (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Worms - A Space Oddity (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b68412c7 md5 6de83e39b4dc0841b1ccc1fec9b52bc0 sha1 8136ebb04c701281330b158487a7017b7e31046a )
+)
+
+game (
+	name "Worms - A Space Oddity (USA) (En,Fr)"
+	description "Worms - A Space Oddity (USA) (En,Fr)"
+	rom ( name "Worms - A Space Oddity (USA) (En,Fr).iso" size 4699979776 crc c71de0fd md5 be23c5907294adc8c05103a18d579e99 sha1 55f04a2a1f0e1cfcedd02918fe1f2103b3758691 )
+)
+
+game (
+	name "Worms Battle Island (USA) (En,Fr,Es)"
+	description "Worms Battle Island (USA) (En,Fr,Es)"
+	rom ( name "Worms Battle Island (USA) (En,Fr,Es).iso" size 4699979776 crc 0a6d0f52 md5 1fac2bb62a48f5751b3872619a367867 sha1 f49b72902960703fde29bdeeb9dcfaf577e4d062 )
+)
+
+game (
+	name "WSC Real 08 - World Snooker Championship (Europe)"
+	description "WSC Real 08 - World Snooker Championship (Europe)"
+	rom ( name "WSC Real 08 - World Snooker Championship (Europe).iso" size 4699979776 crc 09e8b8e8 md5 9c8c61452e92239cf10d085bee7da3d8 sha1 27f2d3d4292022ba06d601f723ef3acc358abd80 )
+)
+
+game (
+	name "WSC Real 09 - World Snooker Championship (UK)"
+	description "WSC Real 09 - World Snooker Championship (UK)"
+	rom ( name "WSC Real 09 - World Snooker Championship (UK).iso" size 4699979776 crc af032530 md5 a776255ea802d0c69e251df4b7ec412f sha1 ee8d525b1fc53cbe413ee1be3a1b9814014ce86d )
+)
+
+game (
+	name "WWE All Stars (USA) (En,Fr,Es)"
+	description "WWE All Stars (USA) (En,Fr,Es)"
+	rom ( name "WWE All Stars (USA) (En,Fr,Es).iso" size 4699979776 crc c0c0837b md5 642753ca42671981d5777863789e8494 sha1 fa2a079e74ddff79ccbeb487826dc436481e96f7 )
+)
+
+game (
+	name "WWE SmackDown vs. Raw 2008 (USA)"
+	description "WWE SmackDown vs. Raw 2008 (USA)"
+	rom ( name "WWE SmackDown vs. Raw 2008 (USA).iso" size 4699979776 crc a6740570 md5 cf8f80c459e6a7a133bc0fe8100fca12 sha1 dc1e7ca64a391615179e18c758159382cf5d7263 )
+)
+
+game (
+	name "WWE SmackDown vs. Raw 2009 (Europe)"
+	description "WWE SmackDown vs. Raw 2009 (Europe)"
+	rom ( name "WWE SmackDown vs. Raw 2009 (Europe).iso" size 4699979776 crc 437d94bf md5 432f1c7e16d55c56f8b2c2365d85264b sha1 8e035c76a8c38cf7176c4113c634323173a6be5c )
+)
+
+game (
+	name "WWE SmackDown vs. Raw 2009 (USA) (En,Fr)"
+	description "WWE SmackDown vs. Raw 2009 (USA) (En,Fr)"
+	rom ( name "WWE SmackDown vs. Raw 2009 (USA) (En,Fr).iso" size 4699979776 crc 1e0dd604 md5 fa5d055bb76f09a042413d1fd1a32240 sha1 fda6fe256075a711bb44220354f38c0384071229 )
+)
+
+game (
+	name "WWE SmackDown vs. Raw 2010 (Europe) (En,Fr,De,Es,It)"
+	description "WWE SmackDown vs. Raw 2010 (Europe) (En,Fr,De,Es,It)"
+	rom ( name "WWE SmackDown vs. Raw 2010 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7e26495b md5 e55bd05fb1de662371d23250a8b2cd76 sha1 0874d35632196e017d73aeb6ec676c1d00281347 )
+)
+
+game (
+	name "WWE SmackDown vs. Raw 2010 (USA) (En,Fr,Es)"
+	description "WWE SmackDown vs. Raw 2010 (USA) (En,Fr,Es)"
+	rom ( name "WWE SmackDown vs. Raw 2010 (USA) (En,Fr,Es).iso" size 4699979776 crc 3454355e md5 96e4431949d8b293c001f9daac6f2fac sha1 5aefb8bb3471fdcb4024898a5c1a52cfa0f060a0 )
+)
+
+game (
+	name "X Factor, The (Europe) (En,Fr,De,It,Nl)"
+	description "X Factor, The (Europe) (En,Fr,De,It,Nl)"
+	rom ( name "X Factor, The (Europe) (En,Fr,De,It,Nl).iso" size 4699979776 crc 23bf5aac md5 24afef04e1c371d9af948f7bdd4e30b4 sha1 392bb379c61c32ebfc2d49c60aa504fddfb1481b )
+)
+
+game (
+	name "X-Men Origins - Wolverine (USA) (En,Fr)"
+	description "X-Men Origins - Wolverine (USA) (En,Fr)"
+	rom ( name "X-Men Origins - Wolverine (USA) (En,Fr).iso" size 4699979776 crc de6b1538 md5 3d340acae88d39efe412f2ab323e031d sha1 cfeb67dd351809f4cfbe24edae7b0b5a709e88d8 )
+)
+
+game (
+	name "Xenoblade (Japan)"
+	description "Xenoblade (Japan)"
+	rom ( name "Xenoblade (Japan).iso" size 4699979776 crc 1ad204ff md5 e0784dfb12830f5e77b61935dde3db48 sha1 1eb3ab8ce62690604d3242da2092f2b9de10b6fd )
+)
+
+game (
+	name "Xenoblade Chronicles (Europe) (En,Fr,De,Es,It)"
+	description "Xenoblade Chronicles (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Xenoblade Chronicles (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 96abeb7c md5 7a8ab73269be9a81a8fac07d2e9c5edb sha1 d4ba488ebeb4338331b584ba36208559b029bad5 )
+)
+
+game (
+	name "Xenoblade Chronicles (USA) (En,Fr,Es)"
+	description "Xenoblade Chronicles (USA) (En,Fr,Es)"
+	rom ( name "Xenoblade Chronicles (USA) (En,Fr,Es).iso" size 8511160320 crc 472ffed2 md5 f76e76b2656b92490df354e7a757257b sha1 5c7a23d87af7d736226f4795ebf10b6f428f67c9 )
+)
+
+game (
+	name "You Don't Know Jack (USA)"
+	description "You Don't Know Jack (USA)"
+	rom ( name "You Don't Know Jack (USA).iso" size 4699979776 crc b348237d md5 78459fdeac3da5b2e9d45b5d1b4d5ec5 sha1 1b9859972f780d9626e0dbea59bae460639f45bd )
+)
+
+game (
+	name "Your Shape (Europe)"
+	description "Your Shape (Europe)"
+	rom ( name "Your Shape (Europe).iso" size 4699979776 crc 8b82b09c md5 e3dea5f995b62b78b72bc2875598de0d sha1 e5bf7cd200cb11635ddaf5a5cec1e06d8fb4961d )
+)
+
+game (
+	name "Zack & Wiki - Quest for Barbaros' Treasure (Europe) (En,Ja,Fr,De,Es,It)"
+	description "Zack & Wiki - Quest for Barbaros' Treasure (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "Zack & Wiki - Quest for Barbaros' Treasure (Europe) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 6135c69d md5 565ac97dfac547a07fe62feec6c91963 sha1 5c94af646d14cac8ed7c6ec91d1f940f58c622c2 )
+)
+
+game (
+	name "Zack & Wiki - Quest for Barbaros' Treasure (USA)"
+	description "Zack & Wiki - Quest for Barbaros' Treasure (USA)"
+	rom ( name "Zack & Wiki - Quest for Barbaros' Treasure (USA).iso" size 4699979776 crc f751b21f md5 35c196aafdb90640169b696939c4d97a sha1 f588c59cd239ce5f052c63a935a07916d4a0926e )
+)
+
+game (
+	name "Zelda no Densetsu - Skyward Sword (Japan)"
+	description "Zelda no Densetsu - Skyward Sword (Japan)"
+	rom ( name "Zelda no Densetsu - Skyward Sword (Japan).iso" size 4699979776 crc f5c8a148 md5 ca34457eb03dd6de35383f8439f4bf70 sha1 a708f6939ba7955c56905df82ef6807cc13cf136 )
+)
+
+game (
+	name "Zelda no Densetsu - Twilight Princess (Japan)"
+	description "Zelda no Densetsu - Twilight Princess (Japan)"
+	rom ( name "Zelda no Densetsu - Twilight Princess (Japan).iso" size 4699979776 crc 2bf3cd23 md5 4979793d525198ef13e19ef369311743 sha1 fda756a07158dcfa77d496eb5c8793848b5330dd )
+)
+
+game (
+	name "Zero - Shinku no Chou (Japan)"
+	description "Zero - Shinku no Chou (Japan)"
+	rom ( name "Zero - Shinku no Chou (Japan).iso" size 4699979776 crc 199a932d md5 a3fc746ab1ad5a6ca07bb362b9afd4d2 sha1 e7491b672bf2915112bee77a1b318f78ec1da935 )
+)
+
+game (
+	name "Zero - Tsukihami no Kamen (Japan)"
+	description "Zero - Tsukihami no Kamen (Japan)"
+	rom ( name "Zero - Tsukihami no Kamen (Japan).iso" size 4699979776 crc 5bacf607 md5 b3e4f1b9fef5ac9e7931890bb8cb50a9 sha1 e166ed9564a10071e41597d9ed82f5e796ad74b8 )
+)


### PR DESCRIPTION
Built from the DAT sources over in https://github.com/robloach/libretro-dats .