### PR TITLE
Update Atari -2600 to be more like No-Intro.

### DIFF
--- a/metadat/libretro-dats/Atari - 2600.dat
+++ b/metadat/libretro-dats/Atari - 2600.dat
@@ -1,11275 +1,3402 @@
 clrmamepro (
 	name "Atari - 2600"
 	description "Atari - 2600"
-	version "2016.9.25"
-	comment "Assembled from Redump, Trurip, TOSEC, Darkwater and AdvanceSCENE, for libretro-database."
-	homepage "http://github.com/robloach/libretro-dats"
+	version "20160315-220600"
+	comment "Based on Rom Hunter V11 from AtariMania.com. Updated by RetroUp.com to follow No-intro.org standards."
 )
 
 game (
-	name "2 Pak Special - Cavern Blaster, City War (1992) (HES) (773-867) (PAL)"
-	description "2 Pak Special - Cavern Blaster, City War (1992) (HES) (773-867) (PAL)"
-	rom ( name "2 Pak Special - Cavern Blaster, City War (1992) (HES) (773-867) (PAL).bin" size 16384 crc 00500b31 md5 undefined sha1 bf069a4dd5b65403beea6cc60d91206577ea1c0e )
+	name "3-D Tic-Tac-Toe (USA)"
+	description "3-D Tic-Tac-Toe (USA)"
+	rom ( name "3-D Tic-Tac-Toe (USA).a26" size 2048 crc 58805709 md5 0db4f4150fecf77e4ce72ca4d04c052f sha1 21d983f2f52b84c22ecae84b0943678ae2c31c10 )
 )
 
 game (
-	name "2 Pak Special - Challenge, Surfing (1990) (HES) (771-333) (PAL)"
-	description "2 Pak Special - Challenge, Surfing (1990) (HES) (771-333) (PAL)"
-	rom ( name "2 Pak Special - Challenge, Surfing (1990) (HES) (771-333) (PAL).bin" size 16384 crc 07bfb506 md5 undefined sha1 05664dcc45d02ce585cd79d551c5c20fc2c7a833 )
+	name "32 in 1 Game Cartridge (Europe)"
+	description "32 in 1 Game Cartridge (Europe)"
+	rom ( name "32 in 1 Game Cartridge (Europe).a26" size 65536 crc EAEF28EA md5 291BCDB05F2B37CDF9452D2BF08E0321 sha1 97FFC252438A5C9361096A1151BDBF79BD717CB3 )
 )
 
 game (
-	name "2 Pak Special - Dolphin, Oink (1990) (HES) (771-341) (PAL)"
-	description "2 Pak Special - Dolphin, Oink (1990) (HES) (771-341) (PAL)"
-	rom ( name "2 Pak Special - Dolphin, Oink (1990) (HES) (771-341) (PAL).bin" size 16384 crc ddbc3ed4 md5 undefined sha1 0c5ed716e4477f8e22f6dd5e62756cd618ac154b )
+	name "Acid Drop (USA)"
+	description "Acid Drop (USA)"
+	rom ( name "Acid Drop (USA).a26" size 16384 crc 14cddac7 md5 17ee23e5da931be82f733917adcb6386 sha1 d7c62df8300a68b21ce672cfaa4d0f2f4b3d0ce1 )
 )
 
 game (
-	name "2 Pak Special - Dolphin, Pigs 'n' Wolf (1990) (HES) (771-341) (PAL)"
-	description "2 Pak Special - Dolphin, Pigs 'n' Wolf (1990) (HES) (771-341) (PAL)"
-	rom ( name "2 Pak Special - Dolphin, Pigs 'n' Wolf (1990) (HES) (771-341) (PAL).bin" size 16384 crc 0b8e3332 md5 undefined sha1 e4a26a828572ac877e50862fd92c21315c7f2ed2 )
+	name "Action Force (USA)"
+	description "Action Force (USA)"
+	rom ( name "Action Force (USA).a26" size 4096 crc 896446cf md5 b9f6fa399b8cd386c235983ec45e4355 sha1 9e6fb047ee9fa0a454ca23673ed9693430032dc6 )
 )
 
 game (
-	name "2 Pak Special - Dungeon Master, Creature Strike (1992) (HES) (773-891) (PAL)"
-	description "2 Pak Special - Dungeon Master, Creature Strike (1992) (HES) (773-891) (PAL)"
-	rom ( name "2 Pak Special - Dungeon Master, Creature Strike (1992) (HES) (773-891) (PAL).bin" size 16384 crc c9920339 md5 undefined sha1 96e42866669225c1a8c078c263e16703d080ffdf )
+	name "Activision Decathlon, The (USA)"
+	description "Activision Decathlon, The (USA)"
+	rom ( name "Activision Decathlon, The (USA).a26" size 8192 crc 3feb39b1 md5 525f2dfc8b21b0186cff2568e0509bfc sha1 e0d47565df935c064bc4055636f37a0432ab3727 )
 )
 
 game (
-	name "2 Pak Special - Hoppy, Alien Force (1992) (HES) (773-875) (PAL)"
-	description "2 Pak Special - Hoppy, Alien Force (1992) (HES) (773-875) (PAL)"
-	rom ( name "2 Pak Special - Hoppy, Alien Force (1992) (HES) (773-875) (PAL).bin" size 16384 crc 38c5b48f md5 undefined sha1 b08c6e94becadd76a7be0d473622a698f00255ef )
+	name "Adventure (USA)"
+	description "Adventure (USA)"
+	rom ( name "Adventure (USA).a26" size 4096 crc a6db4b3a md5 157bddb7192754a45372be196797f284 sha1 e07e48d463d30321239a8acc00c490f27f1f7422 )
 )
 
 game (
-	name "2 Pak Special - Motocross, Boom Bang (1990) (HES) (701-157) (PAL)"
-	description "2 Pak Special - Motocross, Boom Bang (1990) (HES) (701-157) (PAL)"
-	rom ( name "2 Pak Special - Motocross, Boom Bang (1990) (HES) (701-157) (PAL).bin" size 16384 crc 0a05d00c md5 undefined sha1 bfcc35feee3713f5028122844d027c88a84772b6 )
+	name "Adventures of TRON (USA)"
+	description "Adventures of TRON (USA)"
+	rom ( name "Adventures of TRON (USA).a26" size 4096 crc 1b8019d6 md5 ca4f8c5b4d6fb9d608bb96bc7ebd26c7 sha1 03a495c7bfa0671e24aa4d9460d232731f68cb43 )
 )
 
 game (
-	name "2 Pak Special - Space Voyage, Fire Alert (1992) (HES) (773-883) (PAL)"
-	description "2 Pak Special - Space Voyage, Fire Alert (1992) (HES) (773-883) (PAL)"
-	rom ( name "2 Pak Special - Space Voyage, Fire Alert (1992) (HES) (773-883) (PAL).bin" size 16384 crc 989cd871 md5 undefined sha1 6ad5c412304ef92af37ede1d8fe42ec484dac004 )
+	name "Air Raid (USA)"
+	description "Air Raid (USA)"
+	rom ( name "Air Raid (USA).a26" size 4096 crc b0e53814 md5 35be55426c1fec32dfb503b4f0651572 sha1 3b02e7dacb418c44d0d3dc77d60a9663b90b0fbc )
 )
 
 game (
-	name "2 Pak Special - Star Warrior, Frogger (1990) (HES) (771-422) (PAL)"
-	description "2 Pak Special - Star Warrior, Frogger (1990) (HES) (771-422) (PAL)"
-	rom ( name "2 Pak Special - Star Warrior, Frogger (1990) (HES) (771-422) (PAL).bin" size 16384 crc cb78caec md5 undefined sha1 f4885610503bff2c4ca816f4f28d1fe517b92f35 )
+	name "Air Raiders (USA)"
+	description "Air Raiders (USA)"
+	rom ( name "Air Raiders (USA).a26" size 4096 crc bb16539d md5 a9cb638cd2cb2e8e0643d7a67db4281c sha1 29f5c73d1fe806a4284547274dd73f9972a7ed70 )
 )
 
 game (
-	name "2 Pak Special - Wall Defender, Planet Patrol (1990) (HES) (771-406) (PAL)"
-	description "2 Pak Special - Wall Defender, Planet Patrol (1990) (HES) (771-406) (PAL)"
-	rom ( name "2 Pak Special - Wall Defender, Planet Patrol (1990) (HES) (771-406) (PAL).bin" size 16384 crc 0c8c40f3 md5 undefined sha1 40058f86488c905a67cfb3f6595dbb4d62150011 )
+	name "Air-Sea Battle - Target Fun (USA)"
+	description "Air-Sea Battle - Target Fun (USA)"
+	rom ( name "Air-Sea Battle - Target Fun (USA).a26" size 2048 crc 1fc6c0f1 md5 16cb43492987d2f32b423817cdaaf7c4 sha1 a746fdc82b336a9d499bf17f50b41e0193ba595e )
 )
 
 game (
-	name "3-D Genesis (1983) (Amiga, Jerry Lawson, Dan McElroy) (Prototype) ~"
-	description "3-D Genesis (1983) (Amiga, Jerry Lawson, Dan McElroy) (Prototype) ~"
-	rom ( name "3-D Genesis (1983) (Amiga, Jerry Lawson, Dan McElroy) (Prototype) ~.bin" size 8192 crc 931a0bdc md5 undefined sha1 0e146e5eb1a68cba4f8fa55ec6f125438efcfcb4 )
+	name "Airlock (USA)"
+	description "Airlock (USA)"
+	rom ( name "Airlock (USA).a26" size 4096 crc 25c90ce7 md5 4d77f291dca1518d7d8e47838695f54b sha1 0376c242819b785310b8af43c03b1d1156bd5f02 )
 )
 
 game (
-	name "3-D Ghost Attack (1983) (Amiga, Michael K. Glass, Jerry Lawson) (Prototype) ~"
-	description "3-D Ghost Attack (1983) (Amiga, Michael K. Glass, Jerry Lawson) (Prototype) ~"
-	rom ( name "3-D Ghost Attack (1983) (Amiga, Michael K. Glass, Jerry Lawson) (Prototype) ~.bin" size 16384 crc 11396d94 md5 undefined sha1 29e431c27ddb8649ec3f15966011505822907139 )
+	name "Alien (USA)"
+	description "Alien (USA)"
+	rom ( name "Alien (USA).a26" size 4096 crc 6d61059f md5 f1a0a23e6464d954e3a9579c4ccd01c8 sha1 01d99bf307262825db58631e8002dd008a42cb1e )
 )
 
 game (
-	name "3-D Havoc (1983) (Amiga, Frank Ellis, Jerry Lawson) (2110) (Prototype) ~"
-	description "3-D Havoc (1983) (Amiga, Frank Ellis, Jerry Lawson) (2110) (Prototype) ~"
-	rom ( name "3-D Havoc (1983) (Amiga, Frank Ellis, Jerry Lawson) (2110) (Prototype) ~.bin" size 8192 crc f75ddad1 md5 undefined sha1 ce616d66d4ed90ddc972ea22555df73f6b41af8c )
+	name "Aliens Return (USA)"
+	description "Aliens Return (USA)"
+	rom ( name "Aliens Return (USA).a26" size 4096 crc c161f53b md5 103f1756d9dc0dd2b16b53ad0f0f1859 sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
 )
 
 game (
-	name "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw - Sears) (CX2618 - 49-75123) ~"
-	description "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw - Sears) (CX2618 - 49-75123) ~"
-	rom ( name "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw - Sears) (CX2618 - 49-75123) ~.bin" size 2048 crc 58805709 md5 undefined sha1 21d983f2f52b84c22ecae84b0943678ae2c31c10 )
+	name "Alligator People (USA) (Proto)"
+	description "Alligator People (USA) (Proto)"
+	rom ( name "Alligator People (USA) (Proto).a26" size 4096 crc b3f6d395 md5 e1a51690792838c5c687da80cd764d78 sha1 a1795d6371ddb0bc93ba6df70299cc548dc88b99 )
 )
 
 game (
-	name "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw) (CX2618, CX2618P) (PAL)"
-	description "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw) (CX2618, CX2618P) (PAL)"
-	rom ( name "3-D Tic-Tac-Toe (1980) (Atari, Carol Shaw) (CX2618, CX2618P) (PAL).bin" size 2048 crc 7322ebc6 md5 undefined sha1 6b163aa967e4204a5bd98a59bd8e80f159004e34 )
+	name "Alpha Beam with Ernie (USA)"
+	description "Alpha Beam with Ernie (USA)"
+	rom ( name "Alpha Beam with Ernie (USA).a26" size 8192 crc 27c6b897 md5 9e01f7f95cb8596765e03b9a36e8e33c sha1 a1f660827ce291f19719a5672f2c5d277d903b03 )
 )
 
 game (
-	name "3-D Zapper (12-15-82) (U.S. Games Corporation, Todd Marshall) (prototype) ~"
-	description "3-D Zapper (12-15-82) (U.S. Games Corporation, Todd Marshall) (prototype) ~"
-	rom ( name "3-D Zapper (12-15-82) (U.S. Games Corporation, Todd Marshall) (prototype) ~.bin" size 4096 crc 93c49a58 md5 undefined sha1 5bef293d891747e790cc083f1d663efe372cec3b )
+	name "Amidar (USA)"
+	description "Amidar (USA)"
+	rom ( name "Amidar (USA).a26" size 4096 crc 8eb5bd72 md5 acb7750b4d0c4bd34969802a7deb2990 sha1 b89a5ac6593e83fbebee1fe7d4cec81a7032c544 )
 )
 
 game (
-	name "3-D Zapper (U.S. Games Corporation, Todd Marshall) (prototype)"
-	description "3-D Zapper (U.S. Games Corporation, Todd Marshall) (prototype)"
-	rom ( name "3-D Zapper (U.S. Games Corporation, Todd Marshall) (prototype).bin" size 4096 crc 4f405595 md5 undefined sha1 af75d0e4b9c3f46d444121c9cf96ceb3a349fc1d )
+	name "Apples And Dolls (USA)"
+	description "Apples And Dolls (USA)"
+	rom ( name "Apples And Dolls (USA).a26" size 4096 crc e7514705 md5 e73838c43040bcbc83e4204a3e72eef4 sha1 62e92508cf43acc28bff8b03a197137d56a5df79 )
 )
 
 game (
-	name "32 in 1 Console ROM (02-10-1989) (Atari) (Prototype) (PAL)"
-	description "32 in 1 Console ROM (02-10-1989) (Atari) (Prototype) (PAL)"
-	rom ( name "32 in 1 Console ROM (02-10-1989) (Atari) (Prototype) (PAL).bin" size 65536 crc 05438099 md5 undefined sha1 8dccc90be602903a0196e85962eda62f99181a17 )
+	name "Aquaventure (USA) (Proto)"
+	description "Aquaventure (USA) (Proto)"
+	rom ( name "Aquaventure (USA) (Proto).a26" size 8192 crc 87a8cb8b md5 038e1e79c3d4410defde4bfe0b99cc32 sha1 7d132ab776ff755b86bf4f204165aa54e9e1f1cf )
 )
 
 game (
-	name "32 in 1 Game Cartridge (1988) (Atari) (CX26163P) (PAL)"
-	description "32 in 1 Game Cartridge (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "32 in 1 Game Cartridge (1988) (Atari) (CX26163P) (PAL).bin" size 65536 crc eaef28ea md5 undefined sha1 97ffc252438a5c9361096a1151bdbf79bd717cb3 )
+	name "Armor Ambush (USA)"
+	description "Armor Ambush (USA)"
+	rom ( name "Armor Ambush (USA).a26" size 4096 crc fc35704b md5 a7b584937911d60c120677fe0d47f36f sha1 9b6a54969240baf64928118741c3affee148d721 )
 )
 
 game (
-	name "32 in 1 Game ROM (1988) (Atari) (Prototype) (PAL)"
-	description "32 in 1 Game ROM (1988) (Atari) (Prototype) (PAL)"
-	rom ( name "32 in 1 Game ROM (1988) (Atari) (Prototype) (PAL).bin" size 65536 crc eaef28ea md5 undefined sha1 97ffc252438a5c9361096a1151bdbf79bd717cb3 )
+	name "Artillery Duel (USA)"
+	description "Artillery Duel (USA)"
+	rom ( name "Artillery Duel (USA).a26" size 8192 crc 1d0f7e8d md5 c77c35a6fc3c0f12bf9e8bae48cba54b sha1 8c249e9eaa83fc6be16039f05ec304efdf987beb )
 )
 
 game (
-	name "3D Tic-Tac-Toe (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL)"
-	description "3D Tic-Tac-Toe (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL)"
-	rom ( name "3D Tic-Tac-Toe (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL).bin" size 2048 crc e2dd8da6 md5 undefined sha1 fd8f2a6eb9248227edca6ae60de93ca38c0ed2ea )
+	name "Assault (USA)"
+	description "Assault (USA)"
+	rom ( name "Assault (USA).a26" size 4096 crc ab3a2b77 md5 de78b3a064d374390ac0710f95edde92 sha1 0c03eba97df5178eec5d4d0aea4a6fe2f961c88f )
 )
 
 game (
-	name "4 Game in One - Ice Hockey, Phantom UFO, Spy Vs. Spy, Cosmic Avenger (1983) (Bit Corporation) (PAL)"
-	description "4 Game in One - Ice Hockey, Phantom UFO, Spy Vs. Spy, Cosmic Avenger (1983) (Bit Corporation) (PAL)"
-	rom ( name "4 Game in One - Ice Hockey, Phantom UFO, Spy Vs. Spy, Cosmic Avenger (1983) (Bit Corporation) (PAL).bin" size 16384 crc caf86fa7 md5 undefined sha1 724c1ce352d0219699892f7c78083f825a71ac1a )
+	name "Asteroids (USA)"
+	description "Asteroids (USA)"
+	rom ( name "Asteroids (USA).a26" size 8192 crc c7d64c94 md5 dd7884b4f93cab423ac471aa1935e3df sha1 d68937e57a367e61eaa4b44550ae8b9d69456661 )
 )
 
 game (
-	name "4 Game in One - Rodeo Champ, Open Sesame, Bobby Is Going Home, Festival (1983) (Bit Corporation) (P460) (PAL)"
-	description "4 Game in One - Rodeo Champ, Open Sesame, Bobby Is Going Home, Festival (1983) (Bit Corporation) (P460) (PAL)"
-	rom ( name "4 Game in One - Rodeo Champ, Open Sesame, Bobby Is Going Home, Festival (1983) (Bit Corporation) (P460) (PAL).bin" size 16384 crc 69ca1a92 md5 undefined sha1 b6193826df511f39077013369e625e56577f2f36 )
+	name "Astroblast (USA)"
+	description "Astroblast (USA)"
+	rom ( name "Astroblast (USA).a26" size 4096 crc 1de25331 md5 170e7589a48739cfb9cc782cbb0fe25a sha1 8e83fd77e198b27eb5b02a6dc02a5ab37b5a76bd )
 )
 
 game (
-	name "4 in 1 - Canyon Bomber, Home Run, Night Driver, Sky Diver (02-19-1987) (Atari) (CX26137) (Prototype)"
-	description "4 in 1 - Canyon Bomber, Home Run, Night Driver, Sky Diver (02-19-1987) (Atari) (CX26137) (Prototype)"
-	rom ( name "4 in 1 - Canyon Bomber, Home Run, Night Driver, Sky Diver (02-19-1987) (Atari) (CX26137) (Prototype).bin" size 8192 crc 8b304851 md5 undefined sha1 bc60987b668d6fa26c49f5aba5815622710140d9 )
+	name "Astrowar (USA)"
+	description "Astrowar (USA)"
+	rom ( name "Astrowar (USA).a26" size 4096 crc e83f5848 md5 317a4cdbab090dcc996833d07cb40165 sha1 eca0764f26168424633b620a9ff9b274b236135f )
 )
 
 game (
-	name "8 in 1 (Supergames 8 in 1) (01-16-92) (Atari) (CX26193) (Prototype)"
-	description "8 in 1 (Supergames 8 in 1) (01-16-92) (Atari) (CX26193) (Prototype)"
-	rom ( name "8 in 1 (Supergames 8 in 1) (01-16-92) (Atari) (CX26193) (Prototype).bin" size 65536 crc 5ddf79f5 md5 undefined sha1 c066942446c3fc7075ee8430a381d5da4adaec41 )
+	name "Atari Video Cube (USA)"
+	description "Atari Video Cube (USA)"
+	rom ( name "Atari Video Cube (USA).a26" size 4096 crc 272ae37f md5 3f540a30fdee0b20aed7288e4a5ea528 sha1 d1563c24208766cf8d28de7af995021a9f89d7e1 )
 )
 
 game (
-	name "A-Team, The (AKA Saboteur) (03-30-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype)"
-	description "A-Team, The (AKA Saboteur) (03-30-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype)"
-	rom ( name "A-Team, The (AKA Saboteur) (03-30-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype).bin" size 8192 crc 74ea91dd md5 undefined sha1 53413577afe7def1d390e3892c45822405513c07 )
+	name "Atlantis (USA)"
+	description "Atlantis (USA)"
+	rom ( name "Atlantis (USA).a26" size 4096 crc 92560498 md5 9ad36e699ef6f45d9eb6c4cf90475c9f sha1 c6b1dcdb2f024ab682316db45763bacc6949c33c )
 )
 
 game (
-	name "A-Team, The (AKA Saboteur) (05-08-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype)"
-	description "A-Team, The (AKA Saboteur) (05-08-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype)"
-	rom ( name "A-Team, The (AKA Saboteur) (05-08-1984) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26133) (Prototype).bin" size 8192 crc 389bd695 md5 undefined sha1 bcbd36389c56e9b408e8fc4bc595dc731aaf0e02 )
+	name "Atlantis II (USA)"
+	description "Atlantis II (USA)"
+	rom ( name "Atlantis II (USA).a26" size 4096 crc BA5566AA md5 826481F6FC53EA47C9F272F7050EEDF7 sha1 F4E838DE9159C149AC080AB85E4F830D5B299963 )
 )
 
 game (
-	name "Acid Drop (1992) (Salu, Dennis M. Kiss) (460758) (PAL) ~"
-	description "Acid Drop (1992) (Salu, Dennis M. Kiss) (460758) (PAL) ~"
-	rom ( name "Acid Drop (1992) (Salu, Dennis M. Kiss) (460758) (PAL) ~.bin" size 16384 crc 14cddac7 md5 undefined sha1 d7c62df8300a68b21ce672cfaa4d0f2f4b3d0ce1 )
+	name "Bachelor Party (USA)"
+	description "Bachelor Party (USA)"
+	rom ( name "Bachelor Party (USA).a26" size 4096 crc d9cd6c95 md5 5b124850de9eea66781a50b2e9837000 sha1 75e7efa861f7e7d8e367c09bf7c0cc351b472f03 )
 )
 
 game (
-	name "Action Man - Action Force (AKA G.I. Joe - Cobra Strike) (Paddle) (1983) (Parker Brothers, John Emerson) (931511) (PAL)"
-	description "Action Man - Action Force (AKA G.I. Joe - Cobra Strike) (Paddle) (1983) (Parker Brothers, John Emerson) (931511) (PAL)"
-	rom ( name "Action Man - Action Force (AKA G.I. Joe - Cobra Strike) (Paddle) (1983) (Parker Brothers, John Emerson) (931511) (PAL).bin" size 4096 crc 896446cf md5 undefined sha1 9e6fb047ee9fa0a454ca23673ed9693430032dc6 )
+	name "Backgammon (USA)"
+	description "Backgammon (USA)"
+	rom ( name "Backgammon (USA).a26" size 4096 crc e2a7ffa6 md5 8556b42aa05f94bc29ff39c39b11bff4 sha1 9b1da7fbd0bf6fcadf1b60c11eeb31b6a61a03c3 )
 )
 
 game (
-	name "Activision Decathlon, The - Zehnkampf (1983) (Activision, David Crane - Ariola) (EAZ-030, EAZ-030-04B, EAZ-030-04I - 711 030-725) (PAL)"
-	description "Activision Decathlon, The - Zehnkampf (1983) (Activision, David Crane - Ariola) (EAZ-030, EAZ-030-04B, EAZ-030-04I - 711 030-725) (PAL)"
-	rom ( name "Activision Decathlon, The - Zehnkampf (1983) (Activision, David Crane - Ariola) (EAZ-030, EAZ-030-04B, EAZ-030-04I - 711 030-725) (PAL).bin" size 8192 crc 2452adab md5 undefined sha1 082fc914d6ebf415926fbb6cf781de209a4d052d )
+	name "Bank Heist (USA)"
+	description "Bank Heist (USA)"
+	rom ( name "Bank Heist (USA).a26" size 4096 crc 7aa79d1e md5 00ce0bdd43aed84a983bef38fe7f5ee3 sha1 80d4020575b14e130f28146bf45921e001f9f649 )
 )
 
 game (
-	name "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) [fixed] ~"
-	description "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) [fixed] ~"
-	rom ( name "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) [fixed] ~.bin" size 8192 crc 3feb39b1 md5 undefined sha1 e0d47565df935c064bc4055636f37a0432ab3727 )
+	name "Barnstorming (USA)"
+	description "Barnstorming (USA)"
+	rom ( name "Barnstorming (USA).a26" size 4096 crc 4a005181 md5 f8240e62d8c0a64a61e19388414e3104 sha1 372663097b419ced64f44ef743fe8d0af4317f46 )
 )
 
 game (
-	name "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) ~"
-	description "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) ~"
-	rom ( name "Activision Decathlon, The (1983) (Activision, David Crane) (AG-930-04, AZ-030) ~.bin" size 8192 crc 91b8f1b2 md5 undefined sha1 717656f561823edaa69240471c3106963f5c307e )
+	name "Base Attack (USA)"
+	description "Base Attack (USA)"
+	rom ( name "Base Attack (USA).a26" size 4096 crc 81f1e5dd md5 d6dc9b4508da407e2437bfa4de53d1b2 sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
 )
 
 game (
-	name "Activision Decathlon, The (1983) (Activision, David Crane) (EAZ-030) (SECAM)"
-	description "Activision Decathlon, The (1983) (Activision, David Crane) (EAZ-030) (SECAM)"
-	rom ( name "Activision Decathlon, The (1983) (Activision, David Crane) (EAZ-030) (SECAM).bin" size 8192 crc 716d9d1d md5 undefined sha1 7da9cc2383d09835d345ec7d6e76d223591d2a2a )
+	name "Basic Math - Math (USA)"
+	description "Basic Math - Math (USA)"
+	rom ( name "Basic Math - Math (USA).a26" size 2048 crc d48ebac0 md5 819aeeb9a2e11deb54e6de334f843894 sha1 5cc4010eb2858afe8ce77f53a89d37c7584e15b4 )
 )
 
 game (
-	name "Adventure (1980) (Atari, Warren Robinett - Sears) (CX2613 - 49-75154) ~"
-	description "Adventure (1980) (Atari, Warren Robinett - Sears) (CX2613 - 49-75154) ~"
-	rom ( name "Adventure (1980) (Atari, Warren Robinett - Sears) (CX2613 - 49-75154) ~.bin" size 4096 crc a6db4b3a md5 undefined sha1 e07e48d463d30321239a8acc00c490f27f1f7422 )
+	name "BASIC Programming (USA)"
+	description "BASIC Programming (USA)"
+	rom ( name "BASIC Programming (USA).a26" size 4096 crc 26a3c844 md5 9f48eeb47836cf145a15771775f0767a sha1 6c56fad688b2e9bb783f8a5a2360c80ad2338e47 )
 )
 
 game (
-	name "Adventure (1980) (Atari, Warren Robinett) (CX2613, CX2613P) (PAL)"
-	description "Adventure (1980) (Atari, Warren Robinett) (CX2613, CX2613P) (PAL)"
-	rom ( name "Adventure (1980) (Atari, Warren Robinett) (CX2613, CX2613P) (PAL).bin" size 4096 crc 18dc23f9 md5 undefined sha1 ec23bbea83cf47277482e775ad58ac8e6d1483fe )
+	name "Basketball (USA)"
+	description "Basketball (USA)"
+	rom ( name "Basketball (USA).a26" size 2048 crc b31d49f0 md5 ab4ac994865fb16ebb85738316309457 sha1 bffe99454cb055552e5d612f0dba25470137328d )
 )
 
 game (
-	name "Adventures of TRON (TRON Joystick) (1982) (M Network, Hal Finney, Glenn Hightower, Peter Kaminski - INTV) (MT4317) ~"
-	description "Adventures of TRON (TRON Joystick) (1982) (M Network, Hal Finney, Glenn Hightower, Peter Kaminski - INTV) (MT4317) ~"
-	rom ( name "Adventures of TRON (TRON Joystick) (1982) (M Network, Hal Finney, Glenn Hightower, Peter Kaminski - INTV) (MT4317) ~.bin" size 4096 crc 1b8019d6 md5 undefined sha1 03a495c7bfa0671e24aa4d9460d232731f68cb43 )
+	name "Battlezone (USA)"
+	description "Battlezone (USA)"
+	rom ( name "Battlezone (USA).a26" size 8192 crc 9155dd1d md5 41f252a66c6301f1e8ab3612c19bc5d4 sha1 e4134a3b4a065c856802bc935c12fa7e9868110a )
 )
 
 game (
-	name "Adventures on GX-12 (AKA Adventures of TRON) (1989) (Telegames) (4317 A009) (PAL)"
-	description "Adventures on GX-12 (AKA Adventures of TRON) (1989) (Telegames) (4317 A009) (PAL)"
-	rom ( name "Adventures on GX-12 (AKA Adventures of TRON) (1989) (Telegames) (4317 A009) (PAL).bin" size 4096 crc 4264eb6a md5 undefined sha1 6e420544bf91f603639188824a2b570738bb7e02 )
+	name "Beamrider (USA)"
+	description "Beamrider (USA)"
+	rom ( name "Beamrider (USA).a26" size 8192 crc 1618565b md5 79ab4123a83dc11d468fb2108ea09e2e sha1 47619edb352f7f955f811cbb03a00746c8e099b1 )
 )
 
 game (
-	name "Air Raid (Men-A-Vision) (PAL) ~"
-	description "Air Raid (Men-A-Vision) (PAL) ~"
-	rom ( name "Air Raid (Men-A-Vision) (PAL) ~.bin" size 4096 crc b0e53814 md5 undefined sha1 3b02e7dacb418c44d0d3dc77d60a9663b90b0fbc )
+	name "Beany Bopper (USA)"
+	description "Beany Bopper (USA)"
+	rom ( name "Beany Bopper (USA).a26" size 4096 crc b722bc8f md5 d0b9df57bfea66378c0418ec68cfe37f sha1 fad0c97331a525a4aeba67987552ba324629a7a0 )
 )
 
 game (
-	name "Air Raiders (Air Battle) (1982) (M Network, Larry Zwick - INTV) (MT5861) ~"
-	description "Air Raiders (Air Battle) (1982) (M Network, Larry Zwick - INTV) (MT5861) ~"
-	rom ( name "Air Raiders (Air Battle) (1982) (M Network, Larry Zwick - INTV) (MT5861) ~.bin" size 4096 crc bb16539d md5 undefined sha1 29f5c73d1fe806a4284547274dd73f9972a7ed70 )
+	name "Beat 'Em & Eat 'Em (USA)"
+	description "Beat 'Em & Eat 'Em (USA)"
+	rom ( name "Beat 'Em & Eat 'Em (USA).a26" size 4096 crc c90d4f84 md5 59e96de9628e8373d1c685f5e57dcf10 sha1 e2c29d0a73a4575028b62dca745476a17f07c8f0 )
 )
 
 game (
-	name "Air Raiders (Unknown) (PAL)"
-	description "Air Raiders (Unknown) (PAL)"
-	rom ( name "Air Raiders (Unknown) (PAL).bin" size 4096 crc 42395399 md5 undefined sha1 e65a0c6c5a1f9f05ebcfaaa7b2c9ee6625bf2d83 )
+	name "Berenstain Bears (USA)"
+	description "Berenstain Bears (USA)"
+	rom ( name "Berenstain Bears (USA).a26" size 8192 crc 29d28baf md5 ee6665683ebdb539e89ba620981cb0f6 sha1 c3afd7909b72b49ca7d4485465b622d5e55f8913 )
 )
 
 game (
-	name "Air-Sea Battle - Air Sea Battle - Target Fun (Anti-Aircraft) (1977) (Atari, Larry Kaplan - Sears) (CX2602 - 99802, 6-99802, 49-75102) ~"
-	description "Air-Sea Battle - Air Sea Battle - Target Fun (Anti-Aircraft) (1977) (Atari, Larry Kaplan - Sears) (CX2602 - 99802, 6-99802, 49-75102) ~"
-	rom ( name "Air-Sea Battle - Air Sea Battle - Target Fun (Anti-Aircraft) (1977) (Atari, Larry Kaplan - Sears) (CX2602 - 99802, 6-99802, 49-75102) ~.bin" size 2048 crc 1fc6c0f1 md5 undefined sha1 a746fdc82b336a9d499bf17f50b41e0193ba595e )
+	name "Bermuda Triangle (USA)"
+	description "Bermuda Triangle (USA)"
+	rom ( name "Bermuda Triangle (USA).a26" size 4096 crc 0fcb5b94 md5 b8ed78afdb1e6cfe44ef6e3428789d5f sha1 fcad0e5130de24f06b98fb86a7c3214841ca42e2 )
 )
 
 game (
-	name "Air-Sea Battle - Air Sea Battle (Anti-Aircraft) (1977) (Atari, Larry Kaplan) (CX2602, CX2602P) (PAL)"
-	description "Air-Sea Battle - Air Sea Battle (Anti-Aircraft) (1977) (Atari, Larry Kaplan) (CX2602, CX2602P) (PAL)"
-	rom ( name "Air-Sea Battle - Air Sea Battle (Anti-Aircraft) (1977) (Atari, Larry Kaplan) (CX2602, CX2602P) (PAL).bin" size 2048 crc cf7f8944 md5 undefined sha1 b96c7a509bf610f61f82377bfd506db3dba2b423 )
+	name "Berzerk (USA)"
+	description "Berzerk (USA)"
+	rom ( name "Berzerk (USA).a26" size 4096 crc 2e8b4b5f md5 136f75c4dd02c29283752b7e5799f978 sha1 08bcbc8954473e8f0242b881315b0af4466998ae )
 )
 
 game (
-	name "Air-Sea Battle (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL)"
-	description "Air-Sea Battle (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL)"
-	rom ( name "Air-Sea Battle (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL).bin" size 2048 crc 5865356e md5 undefined sha1 eac7d1fb227d257a206a60da4bf76ee5e571b394 )
+	name "Big Bird's Egg Catch (USA)"
+	description "Big Bird's Egg Catch (USA)"
+	rom ( name "Big Bird's Egg Catch (USA).a26" size 8192 crc 96dc9a9c md5 1802cc46b879b229272501998c5de04f sha1 5e4517db83c061926130ab65975e3b83d9401cc9 )
 )
 
 game (
-	name "Air-Sea Battle (Hack) (Unknown) (4K)"
-	description "Air-Sea Battle (Hack) (Unknown) (4K)"
-	rom ( name "Air-Sea Battle (Hack) (Unknown) (4K).bin" size 4096 crc 2a765130 md5 undefined sha1 af5b9f33ccb7778b42957da4f20f2bc000992366 )
+	name "Bionic Breakthrough (USA) (Proto)"
+	description "Bionic Breakthrough (USA) (Proto)"
+	rom ( name "Bionic Breakthrough (USA) (Proto).a26" size 8192 crc 928e4b47 md5 f0541d2f7cda5ec7bab6d62b6128b823 sha1 f6a41507b8cf890ab7c59bb1424f0500534385ce )
 )
 
 game (
-	name "Airlock (1982) (Data Age) (DA1004) (Prototype)"
-	description "Airlock (1982) (Data Age) (DA1004) (Prototype)"
-	rom ( name "Airlock (1982) (Data Age) (DA1004) (Prototype).bin" size 4096 crc b6ae31c6 md5 undefined sha1 09ae3715873a88386b3bc11e429f82919b91fa1a )
+	name "Blackjack - Black Jack (USA)"
+	description "Blackjack - Black Jack (USA)"
+	rom ( name "Blackjack - Black Jack (USA).a26" size 2048 crc 4b0ee010 md5 0a981c03204ac2b278ba392674682560 sha1 edfd905a34870196f8acb2a9cd41f79f4326f88d )
 )
 
 game (
-	name "Airlock (1982) (Data Age) (DA1004) ~"
-	description "Airlock (1982) (Data Age) (DA1004) ~"
-	rom ( name "Airlock (1982) (Data Age) (DA1004) ~.bin" size 4096 crc 25c90ce7 md5 undefined sha1 0376c242819b785310b8af43c03b1d1156bd5f02 )
+	name "Blueprint (USA)"
+	description "Blueprint (USA)"
+	rom ( name "Blueprint (USA).a26" size 8192 crc da7b9dfa md5 33d68c3cd74e5bc4cf0df3716c5848bc sha1 0fadef01ce28192880f745b23a5fbb64c5a96efe )
 )
 
 game (
-	name "Alices Abenteuer - Lilly Adventure (1983) (Quelle) (732.273 8 - 600273, 781644) (PAL)"
-	description "Alices Abenteuer - Lilly Adventure (1983) (Quelle) (732.273 8 - 600273, 781644) (PAL)"
-	rom ( name "Alices Abenteuer - Lilly Adventure (1983) (Quelle) (732.273 8 - 600273, 781644) (PAL).bin" size 4096 crc f5feaa7b md5 undefined sha1 7be2899d776cc28f1ca81584a02e5c228a4f603e )
+	name "BMX Air Master (USA)"
+	description "BMX Air Master (USA)"
+	rom ( name "BMX Air Master (USA).a26" size 16384 crc b4017ee3 md5 968efc79d500dce52a906870a97358ab sha1 ff25ed062dcc430448b358d2ac745787410e1169 )
 )
 
 game (
-	name "Alien (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11006) ~"
-	description "Alien (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11006) ~"
-	rom ( name "Alien (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11006) ~.bin" size 4096 crc 6d61059f md5 undefined sha1 01d99bf307262825db58631e8002dd008a42cb1e )
+	name "Bobby Is Going Home (USA)"
+	description "Bobby Is Going Home (USA)"
+	rom ( name "Bobby Is Going Home (USA).a26" size 4096 crc f061e27f md5 2823364702595feea24a3fbee138a243 sha1 50e26688fdd3eadcfa83240616267a8f60216c25 )
 )
 
 game (
-	name "Alien (CCE)"
-	description "Alien (CCE)"
-	rom ( name "Alien (CCE).bin" size 4096 crc e61021ec md5 undefined sha1 abf186c0108791d998f7738324d0e49a977b015b )
+	name "Boggle (USA) (Proto)"
+	description "Boggle (USA) (Proto)"
+	rom ( name "Boggle (USA) (Proto).a26" size 2048 crc 26b6bfef md5 a5855d73d304d83ef07dde03e379619f sha1 4accd4cc4f8f3a935ca178449a4ac62283639c53 )
 )
 
 game (
-	name "Alien's Return (AKA Go Go Home) (1983) (ITT Family Games) (554-33 391) (PAL)"
-	description "Alien's Return (AKA Go Go Home) (1983) (ITT Family Games) (554-33 391) (PAL)"
-	rom ( name "Alien's Return (AKA Go Go Home) (1983) (ITT Family Games) (554-33 391) (PAL).bin" size 4096 crc c161f53b md5 undefined sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
+	name "Boing! (USA)"
+	description "Boing! (USA)"
+	rom ( name "Boing! (USA).a26" size 4096 crc ad380487 md5 14c2548712099c220964d7f044c59fd9 sha1 d106bb41a38ed222dead608d839e8a3f0d0ecc18 )
 )
 
 game (
-	name "Alligator People (1983) (20th Century Fox Video Games, John Russell) (Prototype) ~"
-	description "Alligator People (1983) (20th Century Fox Video Games, John Russell) (Prototype) ~"
-	rom ( name "Alligator People (1983) (20th Century Fox Video Games, John Russell) (Prototype) ~.bin" size 4096 crc b3f6d395 md5 undefined sha1 a1795d6371ddb0bc93ba6df70299cc548dc88b99 )
+	name "Bowling (USA)"
+	description "Bowling (USA)"
+	rom ( name "Bowling (USA).a26" size 2048 crc fea0d6d5 md5 c9b7afad3bfd922e006a6bfc1d4f3fe7 sha1 cf6ce244b3edaad7ad5e9ca5f01668135c2f93d0 )
 )
 
 game (
-	name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (06-03-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype) (PAL)"
-	description "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (06-03-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype) (PAL)"
-	rom ( name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (06-03-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype) (PAL).bin" size 8192 crc 1651f45e md5 undefined sha1 ea1124a3eac39133f59d664545c33cc514022067 )
+	name "Boxing (USA)"
+	description "Boxing (USA)"
+	rom ( name "Boxing (USA).a26" size 2048 crc 9ece0021 md5 c3ef5c4653212088eda54dc91d787870 sha1 14b9cd91188c7fb0d4566442d639870f8d6f174d )
 )
 
 game (
-	name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (12-22-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype)"
-	description "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (12-22-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype)"
-	rom ( name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (12-22-1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (Prototype).bin" size 8192 crc 85f1cb08 md5 undefined sha1 7118f2401a0d34996762d9838d2f4bacf745fde3 )
+	name "Brain Games (USA)"
+	description "Brain Games (USA)"
+	rom ( name "Brain Games (USA).a26" size 2048 crc 150709c2 md5 1cca2197d95c5a41f2add49a13738055 sha1 238915cafd26f69bc8a3b9aa7d880dde59f6f12d )
 )
 
 game (
-	name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (PAL)"
-	description "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (PAL)"
-	rom ( name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) (PAL).bin" size 8192 crc d1ed3112 md5 undefined sha1 4be3ff4904fc75e047c72ec7e1b1b361c7ae6d50 )
+	name "Breakout - Breakaway IV (USA)"
+	description "Breakout - Breakaway IV (USA)"
+	rom ( name "Breakout - Breakaway IV (USA).a26" size 2048 crc 3037638c md5 f34f08e5eb96e500e851a80be3277a56 sha1 8d473b87b70e26890268e6c417c0bb7f01e402eb )
 )
 
 game (
-	name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) ~"
-	description "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) ~"
-	rom ( name "Alpha Beam with Ernie (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Michael Callahan, Preston Stuart) (CX26103) ~.bin" size 8192 crc 27c6b897 md5 undefined sha1 a1f660827ce291f19719a5672f2c5d277d903b03 )
+	name "Bridge (USA)"
+	description "Bridge (USA)"
+	rom ( name "Bridge (USA).a26" size 4096 crc 8db95d1e md5 413c925c5fdcea62842a63a4c671a5f2 sha1 6df43b75ae080240d97754ab69c39c32370800a7 )
 )
 
 game (
-	name "Amidar (1982) (Parker Brothers, Ed Temple) (931504) (PAL)"
-	description "Amidar (1982) (Parker Brothers, Ed Temple) (931504) (PAL)"
-	rom ( name "Amidar (1982) (Parker Brothers, Ed Temple) (931504) (PAL).bin" size 4096 crc e9b05565 md5 undefined sha1 fb9bba6556fc45904dac8750fa18155e6196b2c0 )
+	name "Buck Rogers - Planet of Zoom (USA)"
+	description "Buck Rogers - Planet of Zoom (USA)"
+	rom ( name "Buck Rogers - Planet of Zoom (USA).a26" size 8192 crc 2030f686 md5 1cf59fc7b11cdbcefe931e41641772f6 sha1 a65dea2d9790f3eb308c048a01566e35e8c24549 )
 )
 
 game (
-	name "Amidar (1982) (Parker Brothers, Ed Temple) (PB5310) ~"
-	description "Amidar (1982) (Parker Brothers, Ed Temple) (PB5310) ~"
-	rom ( name "Amidar (1982) (Parker Brothers, Ed Temple) (PB5310) ~.bin" size 4096 crc 8eb5bd72 md5 undefined sha1 b89a5ac6593e83fbebee1fe7d4cec81a7032c544 )
+	name "Bugs (USA)"
+	description "Bugs (USA)"
+	rom ( name "Bugs (USA).a26" size 4096 crc 1202427c md5 68597264c8e57ada93be3a5be4565096 sha1 67387d0d3d48a44800c44860bf15339a81f41aa9 )
 )
 
 game (
-	name "AndroMan on the Moon (1984) (Western Technologies, Michael Case, Lenny Carlson) (Prototype) ~"
-	description "AndroMan on the Moon (1984) (Western Technologies, Michael Case, Lenny Carlson) (Prototype) ~"
-	rom ( name "AndroMan on the Moon (1984) (Western Technologies, Michael Case, Lenny Carlson) (Prototype) ~.bin" size 8192 crc 18344a20 md5 undefined sha1 3d3623fa0d87ea02f2a080d959a127223e757b3f )
+	name "Bugs Bunny (USA) (Proto)"
+	description "Bugs Bunny (USA) (Proto)"
+	rom ( name "Bugs Bunny (USA) (Proto).a26" size 8192 crc bd164019 md5 a3486c0b8110d9d4b1db5d8a280723c6 sha1 b3ff124891de0fb3d44c35115d838fd7e135ca04 )
 )
 
 game (
-	name "Angeln I (AKA Fishing Derby) (Videospielkassette - Ariola) (PGP237) (PAL)"
-	description "Angeln I (AKA Fishing Derby) (Videospielkassette - Ariola) (PGP237) (PAL)"
-	rom ( name "Angeln I (AKA Fishing Derby) (Videospielkassette - Ariola) (PGP237) (PAL).bin" size 2048 crc 214f0076 md5 undefined sha1 a7638a2e79524b068038f0be035b46d0ce65f7ea )
+	name "Bump 'n' Jump (USA)"
+	description "Bump 'n' Jump (USA)"
+	rom ( name "Bump 'n' Jump (USA).a26" size 16384 crc df2bc303 md5 76f53abbbf39a0063f24036d6ee0968a sha1 1819ef408c1216c83dcfeceec28d13f6ea5ca477 )
 )
 
 game (
-	name "Angriff der Luftflotten - Paris Attack (AKA M.A.D.) (1983) (Quelle) (495.463 2 - 746381) (PAL)"
-	description "Angriff der Luftflotten - Paris Attack (AKA M.A.D.) (1983) (Quelle) (495.463 2 - 746381) (PAL)"
-	rom ( name "Angriff der Luftflotten - Paris Attack (AKA M.A.D.) (1983) (Quelle) (495.463 2 - 746381) (PAL).bin" size 4096 crc 74fe8262 md5 undefined sha1 ac58ac94ceab78725a1182cc7b907376c011b0c8 )
+	name "Bumper Bash (USA)"
+	description "Bumper Bash (USA)"
+	rom ( name "Bumper Bash (USA).a26" size 4096 crc b1a6a23e md5 aa1c41f86ec44c0a44eb64c332ce08af sha1 6c199782c79686dc0cbce6d5fe805f276a86a3f5 )
 )
 
 game (
-	name "Ant Party (AKA Cosmic Swarm) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Ant Party (AKA Cosmic Swarm) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Ant Party (AKA Cosmic Swarm) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 33f3cb23 md5 undefined sha1 545abc0cda5ab3f76b5f1fb65d954d39daf3e1c3 )
+	name "BurgerTime (USA)"
+	description "BurgerTime (USA)"
+	rom ( name "BurgerTime (USA).a26" size 16384 crc c183fbbc md5 0443cfa9872cdb49069186413275fa21 sha1 49e01b8048ae344cb65838f6b1c1de0e1f416f29 )
 )
 
 game (
-	name "Apples and Dolls (AKA Open Sesame) (CCE)"
-	description "Apples and Dolls (AKA Open Sesame) (CCE)"
-	rom ( name "Apples and Dolls (AKA Open Sesame) (CCE).bin" size 4096 crc e7514705 md5 undefined sha1 62e92508cf43acc28bff8b03a197137d56a5df79 )
+	name "Burning Desire (USA)"
+	description "Burning Desire (USA)"
+	rom ( name "Burning Desire (USA).a26" size 4096 crc 92f91d36 md5 19d6956ff17a959c48fcd8f4706a848d sha1 b233c37aa5164a54e2e7cc3dc621b331ddc6e55b )
 )
 
 game (
-	name "Aquatak (AKA Skindiver) (1983) (John Sands Electronics) (JS145C) (PAL)"
-	description "Aquatak (AKA Skindiver) (1983) (John Sands Electronics) (JS145C) (PAL)"
-	rom ( name "Aquatak (AKA Skindiver) (1983) (John Sands Electronics) (JS145C) (PAL).bin" size 4096 crc 9a98888c md5 undefined sha1 a86bf5762c4766c4de00b49b29d0df9a7ee417e0 )
+	name "Cabbage Patch Kids - Adventures in the Park (USA) (Proto)"
+	description "Cabbage Patch Kids - Adventures in the Park (USA) (Proto)"
+	rom ( name "Cabbage Patch Kids - Adventures in the Park (USA) (Proto).a26" size 8192 crc 7025d30d md5 66fcf7643d554f5e15d4d06bab59fe70 sha1 ffdba8ae22784ccc81a5a2e81a236ace09e5b7f4 )
 )
 
 game (
-	name "Aquaventure (CCE)"
-	description "Aquaventure (CCE)"
-	rom ( name "Aquaventure (CCE).bin" size 8192 crc 7fa61fa0 md5 undefined sha1 cb400de2653e125e704abd8b0fe5dddb43e3438b )
+	name "Cakewalk (USA)"
+	description "Cakewalk (USA)"
+	rom ( name "Cakewalk (USA).a26" size 4096 crc 73494211 md5 7f6533386644c7d6358f871666c86e79 sha1 3f1f17cf620f462355009f5302cddffa730fa2fa )
 )
 
 game (
-	name "Aquaventure (Sea Sentinel) (08-12-1983) (Atari, Tod Frye, Gary Shannon) (Prototype) ~"
-	description "Aquaventure (Sea Sentinel) (08-12-1983) (Atari, Tod Frye, Gary Shannon) (Prototype) ~"
-	rom ( name "Aquaventure (Sea Sentinel) (08-12-1983) (Atari, Tod Frye, Gary Shannon) (Prototype) ~.bin" size 8192 crc 87a8cb8b md5 undefined sha1 7d132ab776ff755b86bf4f204165aa54e9e1f1cf )
+	name "California Games (USA)"
+	description "California Games (USA)"
+	rom ( name "California Games (USA).a26" size 16384 crc e9a3fdc3 md5 9ab72d3fd2cc1a0c9adb504502579037 sha1 609c20365c3a71ce45cb277c66ec3ce6b2c50980 )
 )
 
 game (
-	name "Armor Ambush (1989) (Telegames) (PAL)"
-	description "Armor Ambush (1989) (Telegames) (PAL)"
-	rom ( name "Armor Ambush (1989) (Telegames) (PAL).bin" size 4096 crc c974c21a md5 undefined sha1 6122220c8fbf42fdf0437073ebe2407d6f875a40 )
+	name "Canyon Bomber (USA)"
+	description "Canyon Bomber (USA)"
+	rom ( name "Canyon Bomber (USA).a26" size 2048 crc e914b8ca md5 feedcc20bc3ca34851cd5d9e38aa2ca6 sha1 b89443a0029e765c2716774fe2582be37650115c )
 )
 
 game (
-	name "Armor Ambush (Tank Battle) (1982) (M Network, Hal Finney - INTV) (MT5661) ~"
-	description "Armor Ambush (Tank Battle) (1982) (M Network, Hal Finney - INTV) (MT5661) ~"
-	rom ( name "Armor Ambush (Tank Battle) (1982) (M Network, Hal Finney - INTV) (MT5661) ~.bin" size 4096 crc fc35704b md5 undefined sha1 9b6a54969240baf64928118741c3affee148d721 )
+	name "Care Bears (USA) (Proto)"
+	description "Care Bears (USA) (Proto)"
+	rom ( name "Care Bears (USA) (Proto).a26" size 4096 crc a14a81d1 md5 151c33a71b99e6bcffb34b43c6f0ec23 sha1 48576a24a40482151f6b3c9687be442db27115a8 )
 )
 
 game (
-	name "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) (PAL)"
-	description "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) (PAL)"
-	rom ( name "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) (PAL).bin" size 8192 crc 1708647c md5 undefined sha1 013142aa1338d132724876c1d55a322a1d049380 )
+	name "Carnival (USA)"
+	description "Carnival (USA)"
+	rom ( name "Carnival (USA).a26" size 4096 crc 7ac3c700 md5 028024fb8e5e5f18ea586652f9799c96 sha1 e1acf7a845b56e4b3d18192a75a81c7afa6f341a )
 )
 
 game (
-	name "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) ~"
-	description "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) ~"
-	rom ( name "Artillery Duel (1983) (Xonox - K-Tel Software, John Perkins) (6230, 7210, 06004, 99004) ~.bin" size 8192 crc 1d0f7e8d md5 undefined sha1 8c249e9eaa83fc6be16039f05ec304efdf987beb )
+	name "Casino - Poker Plus (USA)"
+	description "Casino - Poker Plus (USA)"
+	rom ( name "Casino - Poker Plus (USA).a26" size 4096 crc 420b8248 md5 b816296311019ab69a21cb9e9e235d12 sha1 08598101e38756916613f37581ef1b61c719016f )
 )
 
 game (
-	name "Ases do Ar (AKA Sky Jinks) (Dismac)"
-	description "Ases do Ar (AKA Sky Jinks) (Dismac)"
-	rom ( name "Ases do Ar (AKA Sky Jinks) (Dismac).bin" size 2048 crc 931fb27e md5 undefined sha1 4d0689a98008bf89caab949249ff0f543abf5e0c )
+	name "Cat Trax (USA)"
+	description "Cat Trax (USA)"
+	rom ( name "Cat Trax (USA).a26" size 4096 crc c847e5ec md5 76f66ce3b83d7a104a899b4b3354a2f2 sha1 e979de719cecab2115affd9c0552c6c596b1999a )
 )
 
 game (
-	name "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281)"
-	description "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281)"
-	rom ( name "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281).bin" size 4096 crc ab3a2b77 md5 undefined sha1 0c03eba97df5178eec5d4d0aea4a6fe2f961c88f )
+	name "Cathouse Blues (USA)"
+	description "Cathouse Blues (USA)"
+	rom ( name "Cathouse Blues (USA).a26" size 4096 crc 3c4e3f41 md5 9e192601829f5f5c2d3b51f8ae25dbe5 sha1 6adf70e0b7b5dab74cf4778f56000de7605e8713 )
 )
 
 game (
-	name "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281) (PAL)"
-	description "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281) (PAL)"
-	rom ( name "Assault (AKA Sky Alien) (1983) (Bomb - Onbase) (CA281) (PAL).bin" size 4096 crc a23eaac5 md5 undefined sha1 12acae81097b752d2446c9456996bdccc3d625d5 )
+	name "Centipede (USA)"
+	description "Centipede (USA)"
+	rom ( name "Centipede (USA).a26" size 8192 crc 77396102 md5 91c2098e88a6b13f977af8c003e0bca5 sha1 0b5914bc1526a9beaf54d7fd11408175cd8fcc72 )
 )
 
 game (
-	name "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696)"
-	description "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696)"
-	rom ( name "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696).bin" size 8192 crc b238706d md5 undefined sha1 1a094f92e46a8127d9c29889b5389865561c0a6f )
+	name "Challenge (USA)"
+	description "Challenge (USA)"
+	rom ( name "Challenge (USA).a26" size 4096 crc 1f19aa5d md5 73158ea51d77bf521e1369311d26c27b sha1 b2b1bd165b3c10cde5316ed0f9f05a509aac828d )
 )
 
 game (
-	name "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696) (PAL)"
-	description "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696) (PAL)"
-	rom ( name "Asterix (AKA Taz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2696) (PAL).bin" size 8192 crc 2e3deb79 md5 undefined sha1 ff31d885ea3d96850547fdb8978d12d0965a2c1f )
+	name "Challenge of.... Nexar, The (USA)"
+	description "Challenge of.... Nexar, The (USA)"
+	rom ( name "Challenge of.... Nexar, The (USA).a26" size 4096 crc 74cc37d4 md5 5d799bfa9e1e7b6224877162accada0d sha1 ac9b0c62ba0ca7a975d08fabbbc7c7448ecdf18d )
 )
 
 game (
-	name "Asteroid Belt (AKA Asteroid Fire) (Suntek) (SS-029) (PAL)"
-	description "Asteroid Belt (AKA Asteroid Fire) (Suntek) (SS-029) (PAL)"
-	rom ( name "Asteroid Belt (AKA Asteroid Fire) (Suntek) (SS-029) (PAL).bin" size 4096 crc 70aebb22 md5 undefined sha1 429c3c21bf89dc08892d16c420b72b0c88c9e03c )
+	name "Championship Soccer - Soccer (USA)"
+	description "Championship Soccer - Soccer (USA)"
+	rom ( name "Championship Soccer - Soccer (USA).a26" size 4096 crc 3f59bb60 md5 ace319dc4f76548659876741a6690d57 sha1 832283530f5dee332f29cf8c4854dd554f2030a0 )
 )
 
 game (
-	name "Asteroid Fire (1983) (Home Vision - Gem International Corp.) (VCS83111) (PAL) ~"
-	description "Asteroid Fire (1983) (Home Vision - Gem International Corp.) (VCS83111) (PAL) ~"
-	rom ( name "Asteroid Fire (1983) (Home Vision - Gem International Corp.) (VCS83111) (PAL) ~.bin" size 4096 crc 58010be3 md5 undefined sha1 8f4a00cb4ab6a6f809be0e055d97e8fe17f19e7d )
+	name "Chase the Chuckwagon (USA)"
+	description "Chase the Chuckwagon (USA)"
+	rom ( name "Chase the Chuckwagon (USA).a26" size 4096 crc 63e4fc7f md5 3e33ac10dcf2dff014bc1decf8a9aea4 sha1 872b2f9aa7edbcbb2368de0db3696c90998ff016 )
 )
 
 game (
-	name "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) [no copyright] ~"
-	description "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) [no copyright] ~"
-	rom ( name "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) [no copyright] ~.bin" size 8192 crc 70a59647 md5 undefined sha1 8423f99092b454aed89f89f5d7da658caf7af016 )
+	name "Checkers (USA)"
+	description "Checkers (USA)"
+	rom ( name "Checkers (USA).a26" size 2048 crc e74f1b59 md5 3f5a43602f960ede330cd2f43a25139e sha1 39b5bb27a6c4cb6532bd9d4cc520415c59dac653 )
 )
 
 game (
-	name "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) ~"
-	description "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) ~"
-	rom ( name "Asteroids (1981) (Atari, Brad Stewart - Sears) (CX2649 - 49-75163) ~.bin" size 8192 crc c7d64c94 md5 undefined sha1 d68937e57a367e61eaa4b44550ae8b9d69456661 )
+	name "China Syndrome (USA)"
+	description "China Syndrome (USA)"
+	rom ( name "China Syndrome (USA).a26" size 4096 crc a714e79c md5 749fec9918160921576f850b2375b516 sha1 0b1bb76769ae3f8b4936f0f95f4941d276791bde )
 )
 
 game (
-	name "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL)"
-	description "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL)"
-	rom ( name "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL).bin" size 8192 crc 0a2f8288 md5 undefined sha1 1cb8f057acad6dc65fef07d3202088ff4ae355cd )
+	name "Chopper Command (USA)"
+	description "Chopper Command (USA)"
+	rom ( name "Chopper Command (USA).a26" size 4096 crc 1dfa64df md5 c1cb228470a87beb5f36e90ac745da26 sha1 51a53bbfdbcc22925515ae0af79df434df6ee68a )
 )
 
 game (
-	name "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL) [no copyright]"
-	description "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL) [no copyright]"
-	rom ( name "Asteroids (1981) (Atari, Brad Stewart) (CX2649, CX2649P) (PAL) [no copyright].bin" size 8192 crc ffcb5e99 md5 undefined sha1 7c0f522d5796c4f307dccf9ce515ab022778b3c7 )
+	name "Chuck Norris Superkicks (USA)"
+	description "Chuck Norris Superkicks (USA)"
+	rom ( name "Chuck Norris Superkicks (USA).a26" size 8192 crc 96210c6c md5 3f58f972276d1e4e0e09582521ed7a5b sha1 1637b6b9cd1a918339ec054cf95b924e7ce4789a )
 )
 
 game (
-	name "Astro Attack (AKA Time Warp) (1983) (Goliath - Hot Shot) (83-214) (PAL)"
-	description "Astro Attack (AKA Time Warp) (1983) (Goliath - Hot Shot) (83-214) (PAL)"
-	rom ( name "Astro Attack (AKA Time Warp) (1983) (Goliath - Hot Shot) (83-214) (PAL).bin" size 4096 crc 32f16d22 md5 undefined sha1 90041b76b873d214276a567cca3af53bfa3222ac )
+	name "Circus Atari - Circus (USA)"
+	description "Circus Atari - Circus (USA)"
+	rom ( name "Circus Atari - Circus (USA).a26" size 4096 crc d2a330a3 md5 a7b96a8150600b3e800a4689c3ec60a2 sha1 8a91ecdbd8bf9d412da051c3422abb004eab8603 )
 )
 
 game (
-	name "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) [fixed] ~"
-	description "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) [fixed] ~"
-	rom ( name "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) [fixed] ~.bin" size 4096 crc 1de25331 md5 undefined sha1 8e83fd77e198b27eb5b02a6dc02a5ab37b5a76bd )
+	name "Coco Nuts (USA)"
+	description "Coco Nuts (USA)"
+	rom ( name "Coco Nuts (USA).a26" size 4096 crc b3e44e5c md5 1e587ca91518a47753a28217cd4fd586 sha1 3f56d1a376702b64b3992b2d5652a3842c56ffad )
 )
 
 game (
-	name "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) ~"
-	description "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) ~"
-	rom ( name "Astroblast (Paddle) (1982) (M Network, Hal Finney - INTV) (MT5666) ~.bin" size 4096 crc d214f241 md5 undefined sha1 b850bd72d18906d9684e1c7251cb699588cbcf64 )
+	name "Codebreaker - Code Breaker (USA)"
+	description "Codebreaker - Code Breaker (USA)"
+	rom ( name "Codebreaker - Code Breaker (USA).a26" size 2048 crc 947edb18 md5 5846b1d34c296bf7afc2fa05bbc16e98 sha1 137bd3d3f36e2549c6e1cc3a60f2a7574f767775 )
 )
 
 game (
-	name "Astroblast (Paddle) (1989) (Telegames) (PAL)"
-	description "Astroblast (Paddle) (1989) (Telegames) (PAL)"
-	rom ( name "Astroblast (Paddle) (1989) (Telegames) (PAL).bin" size 4096 crc a1df435e md5 undefined sha1 ab8af3c4e0d8858481f3e52b59b5040b18ceb4d7 )
+	name "Color Bar Generator (USA)"
+	description "Color Bar Generator (USA)"
+	rom ( name "Color Bar Generator (USA).a26" size 4096 crc 19b52142 md5 76a9bf05a6de8418a3ebc7fc254b71b4 sha1 53c324ae736afa92a83d619b04e4fe72182281a6 )
 )
 
 game (
-	name "Astrowar (1983) (Goliath) (2) (PAL)"
-	description "Astrowar (1983) (Goliath) (2) (PAL)"
-	rom ( name "Astrowar (1983) (Goliath) (2) (PAL).bin" size 4096 crc e83f5848 md5 undefined sha1 eca0764f26168424633b620a9ff9b274b236135f )
+	name "Combat - Tank-Plus (USA)"
+	description "Combat - Tank-Plus (USA)"
+	rom ( name "Combat - Tank-Plus (USA).a26" size 2048 crc 9c326a97 md5 4c8832ed387bbafc055320c05205bc08 sha1 ce7580059e8b41cb4a1e734c9b35ce3774bf777a )
 )
 
 game (
-	name "Astrowar (Astrobattle) (Dimax - Sinmax) (SM8002) (PAL) ~"
-	description "Astrowar (Astrobattle) (Dimax - Sinmax) (SM8002) (PAL) ~"
-	rom ( name "Astrowar (Astrobattle) (Dimax - Sinmax) (SM8002) (PAL) ~.bin" size 4096 crc e83f5848 md5 undefined sha1 eca0764f26168424633b620a9ff9b274b236135f )
+	name "Combat Two (USA) (Proto)"
+	description "Combat Two (USA) (Proto)"
+	rom ( name "Combat Two (USA) (Proto).a26" size 8192 crc 8cabe1fd md5 b0c9cf89a6d4e612524f4fd48b5bb562 sha1 66014de1f8e9f39483ee3f97ca0d97d026ffc3bb )
 )
 
 game (
-	name "Astrowar (Unknown)"
-	description "Astrowar (Unknown)"
-	rom ( name "Astrowar (Unknown).bin" size 4096 crc 7b4b7eaf md5 undefined sha1 b6f01797e3e8d80f4e33da73e64aa2935af96038 )
+	name "Commando (USA)"
+	description "Commando (USA)"
+	rom ( name "Commando (USA).a26" size 16384 crc 8d3025dc md5 5d2cc33ca798783dee435eb29debf6d6 sha1 68a7cb3ff847cd987a551f3dd9cda5f90ce0a3bf )
 )
 
 game (
-	name "Atari VCS Point-of-Purchase ROM (1982) (Atari)"
-	description "Atari VCS Point-of-Purchase ROM (1982) (Atari)"
-	rom ( name "Atari VCS Point-of-Purchase ROM (1982) (Atari).bin" size 2048 crc 9d3cfba6 md5 undefined sha1 b84c34aaedd84fca30b6e8223ee062439acf4fe0 )
+	name "Commando Raid (USA)"
+	description "Commando Raid (USA)"
+	rom ( name "Commando Raid (USA).a26" size 4096 crc e46583e6 md5 f457674cef449cfd85f21db2b4f631a7 sha1 8dad05085657e95e567f47836502be515b42f66b )
 )
 
 game (
-	name "Atari Video Cube (Atari Cube, Video Cube) (1982) (Atari - GCC) (CX2670) ~"
-	description "Atari Video Cube (Atari Cube, Video Cube) (1982) (Atari - GCC) (CX2670) ~"
-	rom ( name "Atari Video Cube (Atari Cube, Video Cube) (1982) (Atari - GCC) (CX2670) ~.bin" size 4096 crc 272ae37f md5 undefined sha1 d1563c24208766cf8d28de7af995021a9f89d7e1 )
+	name "Communist Mutants from Space (USA)"
+	description "Communist Mutants from Space (USA)"
+	rom ( name "Communist Mutants from Space (USA).a26" size 8448 crc d64ec816 md5 2c8835aed7f52a0da9ade5226ee5aa75 sha1 9a113bacc576d1d1f80a26622359c49df97b16bc )
 )
 
 game (
-	name "Atlantis (1983) (CCE) (C-832)"
-	description "Atlantis (1983) (CCE) (C-832)"
-	rom ( name "Atlantis (1983) (CCE) (C-832).bin" size 4096 crc f3ec0baf md5 undefined sha1 e9d6ac3fd807cc71de6d9144177c18f3a7881b5b )
+	name "Computer Chess (USA) (Proto)"
+	description "Computer Chess (USA) (Proto)"
+	rom ( name "Computer Chess (USA) (Proto).a26" size 4096 crc 0c44d49a md5 6a2c68f7a77736ba02c0f21a6ba0985b sha1 dbc0c0451dee44425810e04df8f1d26d1c2d3993 )
 )
 
 game (
-	name "Atlantis (1983) (CCE) (C-832) [a]"
-	description "Atlantis (1983) (CCE) (C-832) [a]"
-	rom ( name "Atlantis (1983) (CCE) (C-832) [a].bin" size 4096 crc 193f693e md5 undefined sha1 5c9be3bd180e4627117fbab3fa4a9a80f32552d5 )
+	name "Condor Attack (USA)"
+	description "Condor Attack (USA)"
+	rom ( name "Condor Attack (USA).a26" size 4096 crc b6c582eb md5 1f21666b8f78b65051b7a609f1d48608 sha1 2ebd0f43ee76833f75759ac1bbb45a8e0c3b86e9 )
 )
 
 game (
-	name "Atlantis (1983) (Digitel)"
-	description "Atlantis (1983) (Digitel)"
-	rom ( name "Atlantis (1983) (Digitel).bin" size 4096 crc e40f6c0f md5 undefined sha1 086ca9c0bab692104590338ce8aaa061dfa2dde4 )
+	name "Confrontation (USA) (Proto)"
+	description "Confrontation (USA) (Proto)"
+	rom ( name "Confrontation (USA) (Proto).a26" size 4096 crc c2dbcefe md5 f965cc981cbb0822f955641f8d84e774 sha1 5512a0ed4306edc007a78bb52dbcf492adf798ec )
 )
 
 game (
-	name "Atlantis (1983) (Dynacom)"
-	description "Atlantis (1983) (Dynacom)"
-	rom ( name "Atlantis (1983) (Dynacom).bin" size 4096 crc 78c57e9f md5 undefined sha1 cbdace660923e0b2c6d97c24877b0dc16521d913 )
+	name "Congo Bongo (USA)"
+	description "Congo Bongo (USA)"
+	rom ( name "Congo Bongo (USA).a26" size 8192 crc 3f6e7e0c md5 00b7b4cbec81570642283e7fc1ef17af sha1 3a77db43b6583e8689435f0f14aa04b9e57bdded )
 )
 
 game (
-	name "Atlantis (Dactari - Milmar)"
-	description "Atlantis (Dactari - Milmar)"
-	rom ( name "Atlantis (Dactari - Milmar).bin" size 4096 crc 5e5e95bd md5 undefined sha1 c22fde31c885b3b6f531bbee96f916907e5e3daf )
+	name "Cookie Monster Munch (USA)"
+	description "Cookie Monster Munch (USA)"
+	rom ( name "Cookie Monster Munch (USA).a26" size 8192 crc 97ba488f md5 57c5b351d4de021785cf8ed8191a195c sha1 f4a62ba0ff59803c5f40d59eeed1e126fe37979b )
 )
 
 game (
-	name "Atlantis (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Atlantis (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Atlantis (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc d55f3e68 md5 undefined sha1 08c54371fd7c72df1f36aae43188705561a3f8bd )
+	name "Cosmic Ark (USA)"
+	description "Cosmic Ark (USA)"
+	rom ( name "Cosmic Ark (USA).a26" size 4096 crc cb374f0e md5 ab5bf1ef5e463ad1cbb11b6a33797228 sha1 187983fd14d37498437d0ef8f3fbd05675feb6ae )
 )
 
 game (
-	name "Atlantis (Hack) (Unknown) (PAL)"
-	description "Atlantis (Hack) (Unknown) (PAL)"
-	rom ( name "Atlantis (Hack) (Unknown) (PAL).bin" size 4096 crc 5779ea8f md5 undefined sha1 8eeb85d98e4319a23b76cccab925734b782dca8b )
+	name "Cosmic Commuter (USA)"
+	description "Cosmic Commuter (USA)"
+	rom ( name "Cosmic Commuter (USA).a26" size 4096 crc 4939ba40 md5 133b56de011d562cbab665968bde352b sha1 3717c97bbb0f547e4389db8fc954d1bad992444c )
 )
 
 game (
-	name "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-1A, 720103-1B, IA3203, IX-010-04) ~"
-	description "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-1A, 720103-1B, IA3203, IX-010-04) ~"
-	rom ( name "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-1A, 720103-1B, IA3203, IX-010-04) ~.bin" size 4096 crc 92560498 md5 undefined sha1 c6b1dcdb2f024ab682316db45763bacc6949c33c )
+	name "Cosmic Creeps (USA)"
+	description "Cosmic Creeps (USA)"
+	rom ( name "Cosmic Creeps (USA).a26" size 4096 crc 47aaa2dd md5 3c853d864a1d5534ed0d4b325347f131 sha1 22ff281b1e698e8a5d7a6f6173c86c46d3cd8561 )
 )
 
 game (
-	name "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-2A, IA3203P, EIX-010-04I) (PAL)"
-	description "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-2A, IA3203P, EIX-010-04I) (PAL)"
-	rom ( name "Atlantis (Lost City of Atlantis) (1982) (Imagic, Dennis Koble) (720103-2A, IA3203P, EIX-010-04I) (PAL).bin" size 4096 crc 85706802 md5 undefined sha1 7b9975dc1aabc34def2d19854b39f237e4afe088 )
+	name "Cosmic Swarm (USA)"
+	description "Cosmic Swarm (USA)"
+	rom ( name "Cosmic Swarm (USA).a26" size 2048 crc 27f1ae48 md5 e5f17b3e62a21d0df1ca9aee1aa8c7c5 sha1 c01354760f2ca8d6e4d01b230f31611973c6ae2d )
 )
 
 game (
-	name "Atlantis II (1982) (Imagic, Dennis Koble) (720103-1A, IA3203)"
-	description "Atlantis II (1982) (Imagic, Dennis Koble) (720103-1A, IA3203)"
-	rom ( name "Atlantis II (1982) (Imagic, Dennis Koble) (720103-1A, IA3203).bin" size 4096 crc ba5566aa md5 undefined sha1 f4e838de9159c149ac080ab85e4f830d5b299963 )
+	name "Crack'ed (USA) (Proto)"
+	description "Crack'ed (USA) (Proto)"
+	rom ( name "Crack'ed (USA) (Proto).a26" size 16384 crc 1b5e52a7 md5 fe67087f9c22655ce519616fc6c6ef4d sha1 d226e8af4e38d1d4eb8bb69cdf6bccdad561c804 )
 )
 
 game (
-	name "Atom Smasher (1984) (Video Soft) (Prototype) ~"
-	description "Atom Smasher (1984) (Video Soft) (Prototype) ~"
-	rom ( name "Atom Smasher (1984) (Video Soft) (Prototype) ~.bin" size 8192 crc 1712423a md5 undefined sha1 ff2a4cec8005a1b04c20671f9d06aefebbb0fda1 )
+	name "Crackpots (USA)"
+	description "Crackpots (USA)"
+	rom ( name "Crackpots (USA).a26" size 4096 crc ecd891b3 md5 a184846d8904396830951217b47d13d9 sha1 6ee0a26af4643ff250198dfc1c2b7c6568b4f207 )
 )
 
 game (
-	name "Aufruhr im Zoo (AKA Panda Chase) (1983) (Quelle) (719.694 2) (PAL)"
-	description "Aufruhr im Zoo (AKA Panda Chase) (1983) (Quelle) (719.694 2) (PAL)"
-	rom ( name "Aufruhr im Zoo (AKA Panda Chase) (1983) (Quelle) (719.694 2) (PAL).bin" size 4096 crc 99ce60e6 md5 undefined sha1 f14d270d429fc3ecf5dd04d71e87e79daf52fd5f )
+	name "Crash Dive (USA)"
+	description "Crash Dive (USA)"
+	rom ( name "Crash Dive (USA).a26" size 4096 crc 59fe4666 md5 fb88c400d602fe759ae74ef1716ee84e sha1 73d68f32d1fb73883ceb183d5150bff5f1065de4 )
 )
 
 game (
-	name "Autorennen (AKA Grand Prix) (Videospielkassette - Ariola) (PGP232) (PAL)"
-	description "Autorennen (AKA Grand Prix) (Videospielkassette - Ariola) (PGP232) (PAL)"
-	rom ( name "Autorennen (AKA Grand Prix) (Videospielkassette - Ariola) (PGP232) (PAL).bin" size 4096 crc e5afda35 md5 undefined sha1 04359079d6960d0abc2f49330873fac10c9d9e21 )
+	name "Crazy Climber (USA)"
+	description "Crazy Climber (USA)"
+	rom ( name "Crazy Climber (USA).a26" size 8192 crc a3a3c009 md5 55ef7b65066428367844342ed59f956c sha1 70e723aa67d68f8549d9bd8f96d8b1262cbdac3c )
 )
 
 game (
-	name "Bachelor Party (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1002) ~"
-	description "Bachelor Party (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1002) ~"
-	rom ( name "Bachelor Party (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1002) ~.bin" size 4096 crc d9cd6c95 md5 undefined sha1 75e7efa861f7e7d8e367c09bf7c0cc351b472f03 )
+	name "Crazy Valet (USA)"
+	description "Crazy Valet (USA)"
+	rom ( name "Crazy Valet (USA).a26" size 4096 crc 00f7c122 md5 4a7eee19c2dfb6aeb4d9d0a01d37e127 sha1 dd385886fdd20727c060bad6c92541938661e2b4 )
 )
 
 game (
-	name "Bachelor Party (Paddle) (1982) (PlayAround - J.H.M.) (205)"
-	description "Bachelor Party (Paddle) (1982) (PlayAround - J.H.M.) (205)"
-	rom ( name "Bachelor Party (Paddle) (1982) (PlayAround - J.H.M.) (205).bin" size 4096 crc d9cd6c95 md5 undefined sha1 75e7efa861f7e7d8e367c09bf7c0cc351b472f03 )
+	name "Cross Force (USA)"
+	description "Cross Force (USA)"
+	rom ( name "Cross Force (USA).a26" size 4096 crc 41b0d615 md5 c17bdc7d14a36e10837d039f43ee5fa3 sha1 b1b3d8d6afe94b73a43c36668cc756c5b6fdc1c3 )
 )
 
 game (
-	name "Bachelorette Party (AKA Bachelor Party) (Paddle) (1982) (PlayAround - J.H.M.) (202)"
-	description "Bachelorette Party (AKA Bachelor Party) (Paddle) (1982) (PlayAround - J.H.M.) (202)"
-	rom ( name "Bachelorette Party (AKA Bachelor Party) (Paddle) (1982) (PlayAround - J.H.M.) (202).bin" size 4096 crc e8189eeb md5 undefined sha1 b88ca823aaa10a7a4a3d325023881b2de969c156 )
+	name "Crossbow (USA)"
+	description "Crossbow (USA)"
+	rom ( name "Crossbow (USA).a26" size 16384 crc 1f233140 md5 8cd26dcf249456fe4aeb8db42d49df74 sha1 5da3d089ccda960ce244adb855975877c670e615 )
 )
 
 game (
-	name "Backgammon (Paddle) (1979) (Atari, Craig Nelson - Sears) (CX2617 - 49-75183) ~"
-	description "Backgammon (Paddle) (1979) (Atari, Craig Nelson - Sears) (CX2617 - 49-75183) ~"
-	rom ( name "Backgammon (Paddle) (1979) (Atari, Craig Nelson - Sears) (CX2617 - 49-75183) ~.bin" size 4096 crc e2a7ffa6 md5 undefined sha1 9b1da7fbd0bf6fcadf1b60c11eeb31b6a61a03c3 )
+	name "Crypts of Chaos (USA)"
+	description "Crypts of Chaos (USA)"
+	rom ( name "Crypts of Chaos (USA).a26" size 4096 crc c5b29962 md5 384f5fbf57b5e92ed708935ebf8a8610 sha1 a57062f44e7ac793d4c39d1350521dc5bc2a665f )
 )
 
 game (
-	name "Backgammon (Paddle) (1979) (Atari, Craig Nelson) (CX2617, CX2617P) (PAL)"
-	description "Backgammon (Paddle) (1979) (Atari, Craig Nelson) (CX2617, CX2617P) (PAL)"
-	rom ( name "Backgammon (Paddle) (1979) (Atari, Craig Nelson) (CX2617, CX2617P) (PAL).bin" size 4096 crc a3d119c6 md5 undefined sha1 bda9fbd4c75c2c70ab0a6a639a0a839d0397b536 )
+	name "Crystal Castles (USA)"
+	description "Crystal Castles (USA)"
+	rom ( name "Crystal Castles (USA).a26" size 16384 crc 9007b5ac md5 1c6eb740d3c485766cade566abab8208 sha1 2e4ee5ee040b08be1fe568602d1859664e607efb )
 )
 
 game (
-	name "Bank Heist (208 in 1) (Unknown) (PAL)"
-	description "Bank Heist (208 in 1) (Unknown) (PAL)"
-	rom ( name "Bank Heist (208 in 1) (Unknown) (PAL).bin" size 4096 crc 29983dd6 md5 undefined sha1 c4ce09be4b997b37b09803d0401e4a75b6f295db )
+	name "Cubicolor (USA) (Proto)"
+	description "Cubicolor (USA) (Proto)"
+	rom ( name "Cubicolor (USA) (Proto).a26" size 4096 crc d5d43a7a md5 6fa0ac6943e33637d8e77df14962fbfc sha1 0dd72a3461b4167f2d68c93511ed4985d97e6adc )
 )
 
 game (
-	name "Bank Heist (Action Hi-Tech - Hi-Score) (PAL)"
-	description "Bank Heist (Action Hi-Tech - Hi-Score) (PAL)"
-	rom ( name "Bank Heist (Action Hi-Tech - Hi-Score) (PAL).bin" size 4096 crc 47d4b652 md5 undefined sha1 07a6adc78299d981cfdf2d96e708b1f8e4f7fb4b )
+	name "Custer's Revenge (USA)"
+	description "Custer's Revenge (USA)"
+	rom ( name "Custer's Revenge (USA).a26" size 4096 crc 21283941 md5 58513bae774360b96866a07ca0e8fd8e sha1 4b3d02b59e17520b4d60236568d5cb50a4e6aeb3 )
 )
 
 game (
-	name "Bank Heist (Bonnie and Clyde, Holdup, Roaring 20's) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11012) ~"
-	description "Bank Heist (Bonnie and Clyde, Holdup, Roaring 20's) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11012) ~"
-	rom ( name "Bank Heist (Bonnie and Clyde, Holdup, Roaring 20's) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11012) ~.bin" size 4096 crc 7aa79d1e md5 undefined sha1 80d4020575b14e130f28146bf45921e001f9f649 )
+	name "Dancing Plate (USA)"
+	description "Dancing Plate (USA)"
+	rom ( name "Dancing Plate (USA).a26" size 4096 crc 250c4e3f md5 ece463abde92e8b89bcd867ec71751b8 sha1 85500dc5f7b083ce2d743c223c56163ff95b39e3 )
 )
 
 game (
-	name "Barnstorming - Die tollkeuhnen Flieger (1982) (Activision, Steve Cartwright - Ariola) (EAX-013, PAX-013 - 711 013-720) (PAL)"
-	description "Barnstorming - Die tollkeuhnen Flieger (1982) (Activision, Steve Cartwright - Ariola) (EAX-013, PAX-013 - 711 013-720) (PAL)"
-	rom ( name "Barnstorming - Die tollkeuhnen Flieger (1982) (Activision, Steve Cartwright - Ariola) (EAX-013, PAX-013 - 711 013-720) (PAL).bin" size 4096 crc f866dbf7 md5 undefined sha1 0e146b4081ae08d7a527bd0e7abd23bb1d42dffb )
+	name "Dark Cavern (USA)"
+	description "Dark Cavern (USA)"
+	rom ( name "Dark Cavern (USA).a26" size 4096 crc 0481078c md5 a422194290c64ef9d444da9d6a207807 sha1 0ae2fc87f87a5cc199c3b9a17444bf3c2f6a829b )
 )
 
 game (
-	name "Barnstorming (1982) (Activision, Steve Cartwright) (AX-013) ~"
-	description "Barnstorming (1982) (Activision, Steve Cartwright) (AX-013) ~"
-	rom ( name "Barnstorming (1982) (Activision, Steve Cartwright) (AX-013) ~.bin" size 4096 crc 4a005181 md5 undefined sha1 372663097b419ced64f44ef743fe8d0af4317f46 )
+	name "Dark Chambers (USA)"
+	description "Dark Chambers (USA)"
+	rom ( name "Dark Chambers (USA).a26" size 16384 crc 83900281 md5 106855474c69d08c8ffa308d47337269 sha1 fbb4814973fcb4e101521515e04daa6424c45f5c )
 )
 
 game (
-	name "Barnstorming (CCE)"
-	description "Barnstorming (CCE)"
-	rom ( name "Barnstorming (CCE).bin" size 4096 crc 281736d6 md5 undefined sha1 72f0bd35b49e4a35f6e51df6ec8ea579b5a673eb )
+	name "Dark Mage (USA)"
+	description "Dark Mage (USA)"
+	rom ( name "Dark Mage (USA).a26" size 4096 crc 51593f62 md5 dba270850ae997969a18ee0001675821 sha1 3457224389f8cdd870cb969c01ac9a98817ea987 )
 )
 
 game (
-	name "Barnstorming (Unknown) (PAL)"
-	description "Barnstorming (Unknown) (PAL)"
-	rom ( name "Barnstorming (Unknown) (PAL).bin" size 4096 crc 5e67c6a9 md5 undefined sha1 568d790d1dc8c28167b6c061ae4c00bea738353c )
+	name "Deadly Duck (USA)"
+	description "Deadly Duck (USA)"
+	rom ( name "Deadly Duck (USA).a26" size 4096 crc f33a9a2d md5 e4c00beb17fdc5881757855f2838c816 sha1 68de291d5e9cbebfed72d2f9039e60581b6dbdc5 )
 )
 
 game (
-	name "Base Attack (1983) (Home Vision - Gem International Corp.) (VCS83113) (PAL) ~"
-	description "Base Attack (1983) (Home Vision - Gem International Corp.) (VCS83113) (PAL) ~"
-	rom ( name "Base Attack (1983) (Home Vision - Gem International Corp.) (VCS83113) (PAL) ~.bin" size 4096 crc 81f1e5dd md5 undefined sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
+	name "Death Trap (USA)"
+	description "Death Trap (USA)"
+	rom ( name "Death Trap (USA).a26" size 4096 crc fdf79a60 md5 4e15ddfd48bca4f0bf999240c47b49f5 sha1 5f710a1148740760b4ebcc42861a1f9c3384799e )
 )
 
 game (
-	name "Base Attack (Hack) (Unknown)"
-	description "Base Attack (Hack) (Unknown)"
-	rom ( name "Base Attack (Hack) (Unknown).bin" size 4096 crc 0a14f24c md5 undefined sha1 d0bdd609ebc6e69fb351ba469ff322406bcbab50 )
+	name "Defender (USA)"
+	description "Defender (USA)"
+	rom ( name "Defender (USA).a26" size 4096 crc 0df43d8e md5 0f643c34e40e3f1daafd9c524d3ffe64 sha1 79facc1bf70e642685057999f5c2b8e94b102439 )
 )
 
 game (
-	name "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016)"
-	description "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016)"
-	rom ( name "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016).bin" size 4096 crc f7e88ec2 md5 undefined sha1 dfce4d6436f91d8d385f8b01f0d8e3488400407b )
+	name "Demolition Herby (USA)"
+	description "Demolition Herby (USA)"
+	rom ( name "Demolition Herby (USA).a26" size 4096 crc e9305ae2 md5 d09935802d6760ae58253685ff649268 sha1 5aae618292a728b55ad7f00242d870736b5356d3 )
 )
 
 game (
-	name "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016) (PAL)"
-	description "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016) (PAL)"
-	rom ( name "Baseball (AKA Super Challenge Baseball) (1989) (Telegames) (5665 A016) (PAL).bin" size 4096 crc b248547e md5 undefined sha1 2ae3bf2295020192aca587aa5a4f2426543fbf80 )
+	name "Demon Attack (USA)"
+	description "Demon Attack (USA)"
+	rom ( name "Demon Attack (USA).a26" size 4096 crc 31c9df5e md5 b12a7f63787a6bb08e683837a8ed3f18 sha1 e5011b85a0e3c148087865bebd7e9b6608c32292 )
 )
 
 game (
-	name "Basic Math - Math (Math Pack) (1977) (Atari, Gary Palmer - Sears) (CX2661 - 99808, 6-99808) ~"
-	description "Basic Math - Math (Math Pack) (1977) (Atari, Gary Palmer - Sears) (CX2661 - 99808, 6-99808) ~"
-	rom ( name "Basic Math - Math (Math Pack) (1977) (Atari, Gary Palmer - Sears) (CX2661 - 99808, 6-99808) ~.bin" size 2048 crc d48ebac0 md5 undefined sha1 5cc4010eb2858afe8ce77f53a89d37c7584e15b4 )
+	name "Demons to Diamonds (USA)"
+	description "Demons to Diamonds (USA)"
+	rom ( name "Demons to Diamonds (USA).a26" size 4096 crc 9b97c3da md5 f91fb8da3223b79f1c9a07b77ebfa0b2 sha1 b45582de81c48b04c2bb758d69021e8088c70ce7 )
 )
 
 game (
-	name "Basic Math (208 in 1) (Unknown) (PAL)"
-	description "Basic Math (208 in 1) (Unknown) (PAL)"
-	rom ( name "Basic Math (208 in 1) (Unknown) (PAL).bin" size 2048 crc 7826266d md5 undefined sha1 dda685cea74e202e1b473b0f890c3910c89c7f79 )
+	name "Depth Charge (USA) (Proto)"
+	description "Depth Charge (USA) (Proto)"
+	rom ( name "Depth Charge (USA) (Proto).a26" size 4096 crc 442d6289 md5 519f007c0e14fb90208dbb5199dfb604 sha1 d72fd778313dca0d70202d2ff2c20213b0d3ed30 )
 )
 
 game (
-	name "Basic Math (Math Pack) (1977) (Atari, Gary Palmer) (CX2661) (PAL)"
-	description "Basic Math (Math Pack) (1977) (Atari, Gary Palmer) (CX2661) (PAL)"
-	rom ( name "Basic Math (Math Pack) (1977) (Atari, Gary Palmer) (CX2661) (PAL).bin" size 2048 crc 5456cdca md5 undefined sha1 ebdc9fc929a6ef47daea8ab539b769a244243a1a )
+	name "Desert Falcon (USA)"
+	description "Desert Falcon (USA)"
+	rom ( name "Desert Falcon (USA).a26" size 16384 crc caa0054e md5 fd4f5536fd80f35c64d365df85873418 sha1 ccea2d5095441d7e1b1468e3879a6ab556dc8b7a )
 )
 
 game (
-	name "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620, CX2620P) (PAL)"
-	description "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620, CX2620P) (PAL)"
-	rom ( name "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620, CX2620P) (PAL).bin" size 4096 crc c207f43e md5 undefined sha1 ff4da01319153a2bde2d2cb1bb1dd900ae105e9a )
+	name "Dice Puzzle (USA)"
+	description "Dice Puzzle (USA)"
+	rom ( name "Dice Puzzle (USA).a26" size 4096 crc f691b853 md5 e02156294393818ff872d4314fc2f38e sha1 509eeb7b113b09e7326618b74f90fa2eb1ddfc95 )
 )
 
 game (
-	name "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620) ~"
-	description "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620) ~"
-	rom ( name "BASIC Programming (Keyboard Controller) (1979) (Atari, Warren Robinett) (CX2620) ~.bin" size 4096 crc 26a3c844 md5 undefined sha1 6c56fad688b2e9bb783f8a5a2360c80ad2338e47 )
+	name "Dig Dug (USA)"
+	description "Dig Dug (USA)"
+	rom ( name "Dig Dug (USA).a26" size 16384 crc ee7b80d1 md5 6dda84fb8e442ecf34241ac0d1d91d69 sha1 79e746524520da546249149c33614fc23a4f2a51 )
 )
 
 game (
-	name "Basketball (1978) (Atari, Alan Miller - Sears) (CX2624 - 6-99826, 49-75113) ~"
-	description "Basketball (1978) (Atari, Alan Miller - Sears) (CX2624 - 6-99826, 49-75113) ~"
-	rom ( name "Basketball (1978) (Atari, Alan Miller - Sears) (CX2624 - 6-99826, 49-75113) ~.bin" size 2048 crc b31d49f0 md5 undefined sha1 bffe99454cb055552e5d612f0dba25470137328d )
+	name "Dodge 'Em - Dodger Cars (USA)"
+	description "Dodge 'Em - Dodger Cars (USA)"
+	rom ( name "Dodge 'Em - Dodger Cars (USA).a26" size 4096 crc 0c74479b md5 83bdc819980db99bf89a7f2ed6a2de59 sha1 157117df23cb5229386d06bbdb3af20a208722e0 )
 )
 
 game (
-	name "Basketball (1978) (Atari, Alan Miller) (CX2624, CX2624P) (PAL)"
-	description "Basketball (1978) (Atari, Alan Miller) (CX2624, CX2624P) (PAL)"
-	rom ( name "Basketball (1978) (Atari, Alan Miller) (CX2624, CX2624P) (PAL).bin" size 2048 crc 711a2340 md5 undefined sha1 9375c5c5298e81b37224dbde9bc5af151181ca27 )
+	name "Dolphin (USA)"
+	description "Dolphin (USA)"
+	rom ( name "Dolphin (USA).a26" size 4096 crc 9e38a7b9 md5 ca09fa7406b7d2aea10d969b6fc90195 sha1 e3985d759f8a8f4705f543ce7eb5e93bf63722b5 )
 )
 
 game (
-	name "Basketball (208 in 1) (Unknown) (PAL)"
-	description "Basketball (208 in 1) (Unknown) (PAL)"
-	rom ( name "Basketball (208 in 1) (Unknown) (PAL).bin" size 2048 crc ed6442ae md5 undefined sha1 a27de23f8020792decdf9476cc047a70914f6200 )
+	name "Donald Duck's Speedboat (USA) (Proto)"
+	description "Donald Duck's Speedboat (USA) (Proto)"
+	rom ( name "Donald Duck's Speedboat (USA) (Proto).a26" size 8192 crc 8db92c76 md5 937736d899337036de818391a87271e0 sha1 4606c0751f560200aede6598ec9c8e6249a105f5 )
 )
 
 game (
-	name "Basketball (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL)"
-	description "Basketball (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL)"
-	rom ( name "Basketball (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL).bin" size 2048 crc 958e0d64 md5 undefined sha1 3a5736b2fb19451463801bb76a818a93f6c5dc29 )
+	name "Donkey Kong (USA)"
+	description "Donkey Kong (USA)"
+	rom ( name "Donkey Kong (USA).a26" size 4096 crc f331b069 md5 36b20c427975760cb9cf4a47e41369e4 sha1 6e6e37ec8d66aea1c13ed444863e3db91497aa35 )
 )
 
 game (
-	name "Basketball (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Basketball (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Basketball (Hack) (208 in 1) (Unknown) (PAL).bin" size 2048 crc 44f7cf68 md5 undefined sha1 b310d38269168839c953ee445b7ad2570bc2f8eb )
+	name "Donkey Kong Junior (USA)"
+	description "Donkey Kong Junior (USA)"
+	rom ( name "Donkey Kong Junior (USA).a26" size 8192 crc 9ef649e5 md5 c8fa5d69d9e555eb16068ef87b1c9c45 sha1 98f98ac0728c68de66afda6500cafbdffe8ab50a )
 )
 
 game (
-	name "Battlezone (05-02-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype)"
-	description "Battlezone (05-02-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype)"
-	rom ( name "Battlezone (05-02-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype).bin" size 8192 crc c1e6d7cf md5 undefined sha1 fafd522e36a4888dfc2a40b1d5879ee8a33d7931 )
+	name "Double Dragon (USA)"
+	description "Double Dragon (USA)"
+	rom ( name "Double Dragon (USA).a26" size 16384 crc 8320bb37 md5 7e2fe40a788e56765fe56a3576019968 sha1 cc99dba0a78fedd171387f492e9810f3037a5f05 )
 )
 
 game (
-	name "Battlezone (05-12-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype)"
-	description "Battlezone (05-12-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype)"
-	rom ( name "Battlezone (05-12-1983) (Atari - GCC, Mike Feinstein) (CX2681) (Prototype).bin" size 8192 crc 63f31af6 md5 undefined sha1 3e226d8ffa975b937d808f73f79b3f052c3b067e )
+	name "Double Dunk (USA)"
+	description "Double Dunk (USA)"
+	rom ( name "Double Dunk (USA).a26" size 16384 crc 208f6c20 md5 368d88a6c071caba60b4f778615aae94 sha1 8e2ea320b23994dc87abe69d61249489f3a0fccc )
 )
 
 game (
-	name "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681, CX2681P) (PAL)"
-	description "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681, CX2681P) (PAL)"
-	rom ( name "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681, CX2681P) (PAL).bin" size 8192 crc 5cc921f6 md5 undefined sha1 d33a367fc4890bea8c2d9a7283d84720b20cabf8 )
+	name "Dragon Defender (Europe)"
+	description "Dragon Defender (Europe)"
+	rom ( name "Dragon Defender (Europe).a26" size 4096 crc 0d57e23d md5 95e542a7467c94b1e4ab24a3ebe907f1 sha1 794625475863c52259478ebd928ead829c1aaee3 )
 )
 
 game (
-	name "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681) ~"
-	description "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681) ~"
-	rom ( name "Battlezone (1983) (Atari - GCC, Mike Feinstein) (CX2681) ~.bin" size 8192 crc 9155dd1d md5 undefined sha1 e4134a3b4a065c856802bc935c12fa7e9868110a )
+	name "Dragonfire (USA)"
+	description "Dragonfire (USA)"
+	rom ( name "Dragonfire (USA).a26" size 4096 crc ba5dc02c md5 41810dd94bd0de1110bedc5092bef5b0 sha1 b446381fe480156077b0b3c51747d156e5dde89f )
 )
 
 game (
-	name "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (AZ-037-04) ~"
-	description "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (AZ-037-04) ~"
-	rom ( name "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (AZ-037-04) ~.bin" size 8192 crc 1618565b md5 undefined sha1 47619edb352f7f955f811cbb03a00746c8e099b1 )
+	name "Dragonstomper (USA)"
+	description "Dragonstomper (USA)"
+	rom ( name "Dragonstomper (USA).a26" size 25344 crc 291f7f92 md5 90ccf4f30a5ad8c801090b388ddd5613 sha1 d0777b4572903756c25559538ecde1a301a0b003 )
 )
 
 game (
-	name "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (EAZ-037-04, EAZ-037-04I) (PAL)"
-	description "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (EAZ-037-04, EAZ-037-04I) (PAL)"
-	rom ( name "Beamrider (1984) (Activision, David Rolfe - Cheshire Engineering) (EAZ-037-04, EAZ-037-04I) (PAL).bin" size 8192 crc 6ed2e636 md5 undefined sha1 0ae5d0f01e63e053baba4bdaaed8a82e59334aaf )
+	name "Dragster (USA)"
+	description "Dragster (USA)"
+	rom ( name "Dragster (USA).a26" size 2048 crc 4042d3ab md5 77057d9d14b99e465ea9e29783af0ae3 sha1 944c52de85464070a946813b050518977750e939 )
 )
 
 game (
-	name "Beany Bopper (1982) (20th Century Fox Video Games - Sirius Software, Grady Ward) (11002) ~"
-	description "Beany Bopper (1982) (20th Century Fox Video Games - Sirius Software, Grady Ward) (11002) ~"
-	rom ( name "Beany Bopper (1982) (20th Century Fox Video Games - Sirius Software, Grady Ward) (11002) ~.bin" size 4096 crc b722bc8f md5 undefined sha1 fad0c97331a525a4aeba67987552ba324629a7a0 )
+	name "Duck Shoot (USA)"
+	description "Duck Shoot (USA)"
+	rom ( name "Duck Shoot (USA).a26" size 4096 crc 907f1d90 md5 1bb91bae919ddbd655fa25c54ea6f532 sha1 d1437e291fbc1927fcce14abc21a58a423e15368 )
 )
 
 game (
-	name "Beany Bopper (1983) (CCE) (C-835)"
-	description "Beany Bopper (1983) (CCE) (C-835)"
-	rom ( name "Beany Bopper (1983) (CCE) (C-835).bin" size 4096 crc 624c9345 md5 undefined sha1 73d55cf63ccabf881148e71dfdbd7d4445889f80 )
+	name "Dukes of Hazzard (USA)"
+	description "Dukes of Hazzard (USA)"
+	rom ( name "Dukes of Hazzard (USA).a26" size 16384 crc 2db406dc md5 51de328e79d919d7234cf19c1cd77fbc sha1 c061d753435dcb7275a8764f4ad003b05fa100ed )
 )
 
 game (
-	name "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1003) ~"
-	description "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1003) ~"
-	rom ( name "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1003) ~.bin" size 4096 crc c90d4f84 md5 undefined sha1 e2c29d0a73a4575028b62dca745476a17f07c8f0 )
+	name "Dumbo's Flying Circus (USA) (Proto)"
+	description "Dumbo's Flying Circus (USA) (Proto)"
+	rom ( name "Dumbo's Flying Circus (USA) (Proto).a26" size 8192 crc ae915725 md5 3897744dd3c756ea4b1542e5e181e02a sha1 fa8b32359035c51df9baca2881582bb09ab4a3d4 )
 )
 
 game (
-	name "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL)"
-	description "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL)"
-	rom ( name "Beat 'Em & Eat 'Em (Paddle) (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL).bin" size 4096 crc 461c9f2c md5 undefined sha1 8b7d6a0c5e14c52ddb18e7be7c84f45abef94bc0 )
+	name "Dune (USA) (Proto)"
+	description "Dune (USA) (Proto)"
+	rom ( name "Dune (USA) (Proto).a26" size 8192 crc f01f7c55 md5 469473ff6fed8cc8d65f3c334f963aab sha1 5e2b2d07dba3692db0ec0582b0a2cb4c2b6ad31f )
 )
 
 game (
-	name "Beat 'Em & Eat 'Em (Paddle) (1982) (PlayAround - J.H.M.) (204)"
-	description "Beat 'Em & Eat 'Em (Paddle) (1982) (PlayAround - J.H.M.) (204)"
-	rom ( name "Beat 'Em & Eat 'Em (Paddle) (1982) (PlayAround - J.H.M.) (204).bin" size 4096 crc c90d4f84 md5 undefined sha1 e2c29d0a73a4575028b62dca745476a17f07c8f0 )
+	name "E.T. - The Extra-Terrestrial (USA)"
+	description "E.T. - The Extra-Terrestrial (USA)"
+	rom ( name "E.T. - The Extra-Terrestrial (USA).a26" size 8192 crc 6d0a475f md5 615a3bf251a38eb6638cdc7ffbde5480 sha1 9e34f9ca51573c92918720f8a259b9449a0cd65e )
 )
 
 game (
-	name "Beat 'Em & Eat 'Em (Paddle) (1983) (Dynacom)"
-	description "Beat 'Em & Eat 'Em (Paddle) (1983) (Dynacom)"
-	rom ( name "Beat 'Em & Eat 'Em (Paddle) (1983) (Dynacom).bin" size 4096 crc e4f66058 md5 undefined sha1 8e8e334fa481698d0adb7f9cb7852e49ac462eb9 )
+	name "Earth Dies Screaming, The (USA)"
+	description "Earth Dies Screaming, The (USA)"
+	rom ( name "Earth Dies Screaming, The (USA).a26" size 4096 crc 8a6c65f0 md5 033e21521e0bf4e54e8816873943406d sha1 1f834923eac271bf04c18621ac2aada68d426917 )
 )
 
 game (
-	name "Berenstain Bears (Kid Vid Voice Module) (1983) (Coleco) (2658) ~"
-	description "Berenstain Bears (Kid Vid Voice Module) (1983) (Coleco) (2658) ~"
-	rom ( name "Berenstain Bears (Kid Vid Voice Module) (1983) (Coleco) (2658) ~.bin" size 8192 crc 29d28baf md5 undefined sha1 c3afd7909b72b49ca7d4485465b622d5e55f8913 )
+	name "Eggomania (USA)"
+	description "Eggomania (USA)"
+	rom ( name "Eggomania (USA).a26" size 4096 crc c78ec927 md5 42b2c3b4545f1499a083cfbc4a3b7640 sha1 68cbfadf097ae2d1e838f315c7cc7b70bbf2ccc8 )
 )
 
 game (
-	name "Bermuda (AKA River Raid) (1983) (Quelle) (322.913 5) (PAL)"
-	description "Bermuda (AKA River Raid) (1983) (Quelle) (322.913 5) (PAL)"
-	rom ( name "Bermuda (AKA River Raid) (1983) (Quelle) (322.913 5) (PAL).bin" size 4096 crc b8553453 md5 undefined sha1 275cc126481bdc747e1e61e48f52250062da9752 )
+	name "Elevator Action (USA) (Proto)"
+	description "Elevator Action (USA) (Proto)"
+	rom ( name "Elevator Action (USA) (Proto).a26" size 8192 crc dc5a9d77 md5 71f8bacfbdca019113f3f0801849057e sha1 bab872ee41695cefe41d88e4932132eca6c4e69c )
 )
 
 game (
-	name "Bermuda (AKA River Raid) (Unknown) (PAL)"
-	description "Bermuda (AKA River Raid) (Unknown) (PAL)"
-	rom ( name "Bermuda (AKA River Raid) (Unknown) (PAL).bin" size 4096 crc 8bb1dc81 md5 undefined sha1 3f56cfd8fea71a2e9669e0f7396f447292dca27e )
+	name "Eli's Ladder (USA)"
+	description "Eli's Ladder (USA)"
+	rom ( name "Eli's Ladder (USA).a26" size 4096 crc 2c5e6932 md5 b6812eaf87127f043e78f91f2028f9f4 sha1 475fc2b23c0ee273388539a4eeafa34f8f8d3fd8 )
 )
 
 game (
-	name "Bermuda Triangle (1982) (Data Age) (112-007) ~"
-	description "Bermuda Triangle (1982) (Data Age) (112-007) ~"
-	rom ( name "Bermuda Triangle (1982) (Data Age) (112-007) ~.bin" size 4096 crc 0fcb5b94 md5 undefined sha1 fcad0e5130de24f06b98fb86a7c3214841ca42e2 )
+	name "Elk Attack (USA) (Proto)"
+	description "Elk Attack (USA) (Proto)"
+	rom ( name "Elk Attack (USA) (Proto).a26" size 8192 crc 02ddde9f md5 7eafc9827e8d5b1336905939e097aae7 sha1 3983e109fc0b38c0b559a09a001f3e5f2bb1dc2a )
 )
 
 game (
-	name "Bermuda Triangle (1983) (Gameworld) (133-007) (PAL)"
-	description "Bermuda Triangle (1983) (Gameworld) (133-007) (PAL)"
-	rom ( name "Bermuda Triangle (1983) (Gameworld) (133-007) (PAL).bin" size 4096 crc a8c0aec9 md5 undefined sha1 9a566ae9354fc94da9fe7a53db49dba57f53c260 )
+	name "Encounter at L-5 (USA)"
+	description "Encounter at L-5 (USA)"
+	rom ( name "Encounter at L-5 (USA).a26" size 4096 crc e78fe552 md5 dbc8829ef6f12db8f463e30f60af209f sha1 205af4051ea39fb5a038a8545c78bff91df321b7 )
 )
 
 game (
-	name "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL)"
-	description "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL)"
-	rom ( name "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL).bin" size 4096 crc b8553453 md5 undefined sha1 275cc126481bdc747e1e61e48f52250062da9752 )
+	name "Enduro (USA)"
+	description "Enduro (USA)"
+	rom ( name "Enduro (USA).a26" size 4096 crc 2ef17b2e md5 94b92a882f6dbaa6993a46e2dcc58402 sha1 82e9b2dd6d99f15381506a76ef958a1773a7ba21 )
 )
 
 game (
-	name "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL) [a]"
-	description "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL) [a]"
-	rom ( name "Bermuda, The (AKA River Raid) (Rainbow Vision - Suntek) (SS-009) (PAL) [a].bin" size 4096 crc 5e5ff905 md5 undefined sha1 bd0989a2ba74d2b0543e5c7c88c31f524aa9ef11 )
+	name "Entity, The (USA) (Proto)"
+	description "Entity, The (USA) (Proto)"
+	rom ( name "Entity, The (USA) (Proto).a26" size 4096 crc 3366ccb7 md5 9f5096a6f1a5049df87798eb59707583 sha1 180d6aad4f5fe5dea553ef2e2ff233bd63592d00 )
 )
 
 game (
-	name "Berzerk (1982) (Atari, Dan Hitchens - Sears) (CX2650 - 49-75168) ~"
-	description "Berzerk (1982) (Atari, Dan Hitchens - Sears) (CX2650 - 49-75168) ~"
-	rom ( name "Berzerk (1982) (Atari, Dan Hitchens - Sears) (CX2650 - 49-75168) ~.bin" size 4096 crc 2e8b4b5f md5 undefined sha1 08bcbc8954473e8f0242b881315b0af4466998ae )
+	name "Entombed (USA)"
+	description "Entombed (USA)"
+	rom ( name "Entombed (USA).a26" size 4096 crc e48ec9dc md5 6b683be69f92958abe0e2a9945157ad5 sha1 7905aee90a6dd64d9538e0b8e772f833ba9feb83 )
 )
 
 game (
-	name "Berzerk (1982) (Atari, Dan Hitchens) (CX2650) (PAL)"
-	description "Berzerk (1982) (Atari, Dan Hitchens) (CX2650) (PAL)"
-	rom ( name "Berzerk (1982) (Atari, Dan Hitchens) (CX2650) (PAL).bin" size 4096 crc d7f66624 md5 undefined sha1 afb983a2f881a017b2cfb593b0d32742093612dd )
+	name "Escape from the Mindmaster (USA)"
+	description "Escape from the Mindmaster (USA)"
+	rom ( name "Escape from the Mindmaster (USA).a26" size 33792 crc fd0c8bfc md5 81f4f0285f651399a12ff2e2f35bab77 sha1 adb24298457e15faacda532d50b7253bef0ef3b2 )
 )
 
 game (
-	name "Berzerk (CCE)"
-	description "Berzerk (CCE)"
-	rom ( name "Berzerk (CCE).bin" size 4096 crc f973d708 md5 undefined sha1 6bffbbe1207662de89c7ea02c1fcd004071fb9e4 )
+	name "Espial (USA)"
+	description "Espial (USA)"
+	rom ( name "Espial (USA).a26" size 8192 crc 1f95351a md5 f344ac1279152157d63e64aa39479599 sha1 5db168bb450dc82f618dfa60b9f271ade3a057c7 )
 )
 
 game (
-	name "Berzerk (Unknown) (PAL)"
-	description "Berzerk (Unknown) (PAL)"
-	rom ( name "Berzerk (Unknown) (PAL).bin" size 4096 crc e3b6f475 md5 undefined sha1 549aba726f9a11c414ddb16193104e2e59b3de96 )
+	name "Exocet (Europe)"
+	description "Exocet (Europe)"
+	rom ( name "Exocet (Europe).a26" size 4096 crc 5cc39028 md5 7ac4f4fb425db38288fa07fb8ff4b21d sha1 07b12357904ec3a4846d27b3790581f6eb5da2b7 )
 )
 
 game (
-	name "Berzerk (Unknown) (PAL) [a]"
-	description "Berzerk (Unknown) (PAL) [a]"
-	rom ( name "Berzerk (Unknown) (PAL) [a].bin" size 4096 crc edb95efa md5 undefined sha1 0b4deef0d1f6d95e26923e08891e49dbc3c52d5b )
+	name "Extra Terrestrials (USA)"
+	description "Extra Terrestrials (USA)"
+	rom ( name "Extra Terrestrials (USA).a26" size 4096 crc 3889D018 md5 EBD2488DCACE40474C1A78FA53EBFADF sha1 C7BA5912D40EB2992FDA0F99EB7028D99EDAD72C )
 )
 
 game (
-	name "Bi! Bi! (AKA Skindiver) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) (PAL)"
-	description "Bi! Bi! (AKA Skindiver) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) (PAL)"
-	rom ( name "Bi! Bi! (AKA Skindiver) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) (PAL).bin" size 4096 crc 1cc3c6a8 md5 undefined sha1 d370e020567e488e9a694dffcf36bef8e45448bc )
+	name "Fantastic Voyage (USA)"
+	description "Fantastic Voyage (USA)"
+	rom ( name "Fantastic Voyage (USA).a26" size 4096 crc a60e153f md5 b80d50ecee73919a507498d0a4d922ae sha1 6297dd336a6343f98cd142d1d3d76ce84770a488 )
 )
 
 game (
-	name "Bi! Bi! (AKA Skindiver) (Rainbow Vision - Suntek) (SS-013) (PAL)"
-	description "Bi! Bi! (AKA Skindiver) (Rainbow Vision - Suntek) (SS-013) (PAL)"
-	rom ( name "Bi! Bi! (AKA Skindiver) (Rainbow Vision - Suntek) (SS-013) (PAL).bin" size 4096 crc 9c3a516b md5 undefined sha1 d2bcc767b170b0fc0a2a0903f4337a821623abb4 )
+	name "Farmyard Fun (USA)"
+	description "Farmyard Fun (USA)"
+	rom ( name "Farmyard Fun (USA).a26" size 4096 crc 73474b03 md5 f7e07080ed8396b68f2e5788a5c245e2 sha1 63a24d4f86529974ee38f0e3bd6602470835c993 )
 )
 
 game (
-	name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-02-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	description "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-02-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	rom ( name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-02-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype).bin" size 8192 crc eeb65efa md5 undefined sha1 aafb88ef8f95b1051cb8b6a153b165215c95c7bd )
+	name "Fast Eddie (USA)"
+	description "Fast Eddie (USA)"
+	rom ( name "Fast Eddie (USA).a26" size 4096 crc 0c0a7a02 md5 9de0d45731f90a0a922ab09228510393 sha1 a5614c751f29118ddb3dec9794612b98a0f00b98 )
 )
 
 game (
-	name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-17-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	description "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-17-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	rom ( name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (05-17-1983) (Atari, Christopher H. Omarzu) (CX26104) (Prototype).bin" size 8192 crc 3a4038ac md5 undefined sha1 e2b0304de695cea7c98344642254b7f181e928d2 )
+	name "Fast Food (USA)"
+	description "Fast Food (USA)"
+	rom ( name "Fast Food (USA).a26" size 4096 crc 62388455 md5 665b8f8ead0eef220ed53886fbd61ec9 sha1 c62a70645939480b184e3b2e378ec4bcbd484bc7 )
 )
 
 game (
-	name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (12-08-1982) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	description "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (12-08-1982) (Atari, Christopher H. Omarzu) (CX26104) (Prototype)"
-	rom ( name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (12-08-1982) (Atari, Christopher H. Omarzu) (CX26104) (Prototype).bin" size 8192 crc 9de03520 md5 undefined sha1 a3ab3699d945ac356aeff637046f197f9d6f7063 )
+	name "Fatal Run (Europe)"
+	description "Fatal Run (Europe)"
+	rom ( name "Fatal Run (Europe).a26" size 32768 crc 991d2348 md5 074ec425ec20579e64a7ded592155d48 sha1 d0bb58ea1fc37e929e5f7cdead037bb14a166451 )
 )
 
 game (
-	name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) (PAL)"
-	description "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) (PAL)"
-	rom ( name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) (PAL).bin" size 8192 crc b0555578 md5 undefined sha1 fd9822ec54add04569b629d631182d9deac7184d )
+	name "Fathom (USA)"
+	description "Fathom (USA)"
+	rom ( name "Fathom (USA).a26" size 8192 crc 93da13cc md5 0b55399cf640a2a00ba72dd155a0c140 sha1 686427cc47b69980d292d04597270347942773ff )
 )
 
 game (
-	name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) ~"
-	description "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) ~"
-	rom ( name "Big Bird's Egg Catch (Grover's Egg Catch) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu) (CX26104) ~.bin" size 8192 crc 96dc9a9c md5 undefined sha1 5e4517db83c061926130ab65975e3b83d9401cc9 )
+	name "Final Approach (USA)"
+	description "Final Approach (USA)"
+	rom ( name "Final Approach (USA).a26" size 4096 crc ff23f469 md5 211fbbdbbca1102dc5b43dc8157c09b3 sha1 ba9a8ccfeb552dd756c660ea843a39619d3c77e9 )
 )
 
 game (
-	name "Billard (AKA Trick Shot) (1983) (Quelle) (626.610 0) (PAL)"
-	description "Billard (AKA Trick Shot) (1983) (Quelle) (626.610 0) (PAL)"
-	rom ( name "Billard (AKA Trick Shot) (1983) (Quelle) (626.610 0) (PAL).bin" size 4096 crc 9171d624 md5 undefined sha1 92c4996ef658bdcc9ae227ba2e3f69ed7a6ba082 )
+	name "Fire Fighter (USA)"
+	description "Fire Fighter (USA)"
+	rom ( name "Fire Fighter (USA).a26" size 4096 crc e361fb42 md5 d09f1830fb316515b90694c45728d702 sha1 f76cc14afd7aef367c5a5defbd84f3bbb2f98ba3 )
 )
 
 game (
-	name "Bingo (AKA Dice Puzzle) (1983) (CCE) (C-868) (PAL)"
-	description "Bingo (AKA Dice Puzzle) (1983) (CCE) (C-868) (PAL)"
-	rom ( name "Bingo (AKA Dice Puzzle) (1983) (CCE) (C-868) (PAL).bin" size 4096 crc 8dc55df7 md5 undefined sha1 cdd890276df3414af0fc66ecf251fb48523ad451 )
+	name "Fire Fly (USA)"
+	description "Fire Fly (USA)"
+	rom ( name "Fire Fly (USA).a26" size 4096 crc 7a8e4ec7 md5 20dca534b997bf607d658e77fbb3c0ee sha1 df5420eb0f71e681e7222ede8e211a7601e7a327 )
 )
 
 game (
-	name "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (06-22-1984) (Atari, Paul Donaldson) (Prototype)"
-	description "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (06-22-1984) (Atari, Paul Donaldson) (Prototype)"
-	rom ( name "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (06-22-1984) (Atari, Paul Donaldson) (Prototype).bin" size 8192 crc 347b9516 md5 undefined sha1 eeed5312b62f9a5c2bce785956bd61c421dd4431 )
+	name "Fire Spinner (USA)"
+	description "Fire Spinner (USA)"
+	rom ( name "Fire Spinner (USA).a26" size 4096 crc f497456e md5 d3171407c3a8bb401a3a62eb578f48fb sha1 e30e6195642884954bc98df2e82c3e972db49a57 )
 )
 
 game (
-	name "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (1984) (Atari, Paul Donaldson) (Prototype) ~"
-	description "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (1984) (Atari, Paul Donaldson) (Prototype) ~"
-	rom ( name "Bionic Breakthrough (Headband - Super Breakout) (Mindlink Controller) (1984) (Atari, Paul Donaldson) (Prototype) ~.bin" size 8192 crc 928e4b47 md5 undefined sha1 f6a41507b8cf890ab7c59bb1424f0500534385ce )
+	name "Fireball (USA)"
+	description "Fireball (USA)"
+	rom ( name "Fireball (USA).a26" size 8448 crc b32ae162 md5 386ff28ac5e254ba1b1bac6916bcc93a sha1 9fa9ed2622d29636f175b8745892dde48a871fd1 )
 )
 
 game (
-	name "Black Hole (AKA Cosmic Ark) (Double-Game Package) (1983) (Quelle) (311388) (PAL)"
-	description "Black Hole (AKA Cosmic Ark) (Double-Game Package) (1983) (Quelle) (311388) (PAL)"
-	rom ( name "Black Hole (AKA Cosmic Ark) (Double-Game Package) (1983) (Quelle) (311388) (PAL).bin" size 4096 crc cbeb7a56 md5 undefined sha1 fa6a186f553d7d141e4b2f6d4be0457c4896f857 )
+	name "Fishing Derby (USA)"
+	description "Fishing Derby (USA)"
+	rom ( name "Fishing Derby (USA).a26" size 2048 crc 204c928f md5 b8865f05676e64f3bec72b9defdacfa7 sha1 531e995aef6cd47b0efea72ae3e56aeee449d798 )
 )
 
 game (
-	name "Blackjack - Black Jack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead - Sears) (CX2651 - 99805, 49-75602) ~"
-	description "Blackjack - Black Jack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead - Sears) (CX2651 - 99805, 49-75602) ~"
-	rom ( name "Blackjack - Black Jack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead - Sears) (CX2651 - 99805, 49-75602) ~.bin" size 2048 crc 4b0ee010 md5 undefined sha1 edfd905a34870196f8acb2a9cd41f79f4326f88d )
+	name "Flag Capture - Capture (USA)"
+	description "Flag Capture - Capture (USA)"
+	rom ( name "Flag Capture - Capture (USA).a26" size 2048 crc 8aa1c41e md5 30512e0e83903fc05541d2f6a6a62654 sha1 ac05f05f3365f5e348e1e618410065a1c2a88ee4 )
 )
 
 game (
-	name "Blackjack (32 in 1) (Paddle) (1988) (Atari, Bob Whitehead) (CX26163P) (PAL)"
-	description "Blackjack (32 in 1) (Paddle) (1988) (Atari, Bob Whitehead) (CX26163P) (PAL)"
-	rom ( name "Blackjack (32 in 1) (Paddle) (1988) (Atari, Bob Whitehead) (CX26163P) (PAL).bin" size 2048 crc 0382e98d md5 undefined sha1 628ad1bc3b303a7822aca2eb09200f2d118185b5 )
+	name "Flash Gordon (USA)"
+	description "Flash Gordon (USA)"
+	rom ( name "Flash Gordon (USA).a26" size 4096 crc 0d61ce7d md5 8786c1e56ef221d946c64f6b65b697e9 sha1 fb870ec3d51468fa4cf40e0efae9617e60c1c91c )
 )
 
 game (
-	name "Blackjack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead) (CX2651) (PAL)"
-	description "Blackjack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead) (CX2651) (PAL)"
-	rom ( name "Blackjack (Gambling) (Paddle) (1977) (Atari, Bob Whitehead) (CX2651) (PAL).bin" size 2048 crc 7125a8b9 md5 undefined sha1 59b74bb16cb046da0fb38c28750d28c3f071f1c0 )
+	name "Football (USA)"
+	description "Football (USA)"
+	rom ( name "Football (USA).a26" size 2048 crc 3b73ee02 md5 e549f1178e038fa88dc6d657dc441146 sha1 c6fe4ce24bc1ebd538258d98cfe829963323acca )
 )
 
 game (
-	name "Blackjack (Paddle) (Unknown) (PAL)"
-	description "Blackjack (Paddle) (Unknown) (PAL)"
-	rom ( name "Blackjack (Paddle) (Unknown) (PAL).bin" size 2048 crc c36dde62 md5 undefined sha1 9b15906f4011927a47ef353dc2f299e821e38341 )
+	name "Forest (Europe)"
+	description "Forest (Europe)"
+	rom ( name "Forest (Europe).a26" size 4096 crc 1aaab749 md5 213e5e82ecb42af237cfed8612c128ac sha1 790e0a597270a5090110e3bfbdc3a076a47ced14 )
 )
 
 game (
-	name "Bloody Human Freeway (Human Freeway) (Freeway Beta) (Activision, David Crane) (AG-009) (Prototype)"
-	description "Bloody Human Freeway (Human Freeway) (Freeway Beta) (Activision, David Crane) (AG-009) (Prototype)"
-	rom ( name "Bloody Human Freeway (Human Freeway) (Freeway Beta) (Activision, David Crane) (AG-009) (Prototype).bin" size 2048 crc 7afb2277 md5 undefined sha1 feb0d05f4f9203d6f4df01095cebacae9ad3f42f )
+	name "Frankenstein's Monster (USA)"
+	description "Frankenstein's Monster (USA)"
+	rom ( name "Frankenstein's Monster (USA).a26" size 4096 crc ad44dff9 md5 15dd21c2608e0d7d9f54c0d3f08cca1f sha1 c6023bf73818c78b2e477a9c6dac411cdbf9c0aa )
 )
 
 game (
-	name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) (Prototype)"
-	description "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) (Prototype)"
-	rom ( name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) (Prototype).bin" size 8192 crc 5a95a4f4 md5 undefined sha1 66753a7fffaa432bdacdb18e7dcf0976e27d8abe )
+	name "Freeway (USA)"
+	description "Freeway (USA)"
+	rom ( name "Freeway (USA).a26" size 2048 crc b13ec413 md5 8e0ab801b1705a740b476b7f588c6d16 sha1 91cc7e5cd6c0d4a6f42ed66353b7ee7bb972fa3f )
 )
 
 game (
-	name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) ~"
-	description "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) ~"
-	rom ( name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L 2486 5000) ~.bin" size 8192 crc da7b9dfa md5 undefined sha1 0fadef01ce28192880f745b23a5fbb64c5a96efe )
+	name "Frisco (Europe)"
+	description "Frisco (Europe)"
+	rom ( name "Frisco (Europe).a26" size 4096 crc 5b47448c md5 cb4a7b507372c24f8b9390d22d54a918 sha1 59cc30a376901462e43bc78586495c72bab81fce )
 )
 
 game (
-	name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L2477, 4L2482, 4L2485, 4L4171) (PAL)"
-	description "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L2477, 4L2482, 4L2485, 4L4171) (PAL)"
-	rom ( name "Blueprint (1983) (CBS Electronics, Tom DiDomenico) (4L2477, 4L2482, 4L2485, 4L4171) (PAL).bin" size 8192 crc 71139a5e md5 undefined sha1 1b7bdc477b5b8488fc1c5566ca910297dc81f488 )
+	name "Frog Demo (Europe)"
+	description "Frog Demo (Europe)"
+	rom ( name "Frog Demo (Europe).a26" size 2048 crc ec5ff220 md5 45a4f55bb9a5083d470ad479afd8bca2 sha1 ded4c64d60ffce5304d73e016be7deb5f2db45d4 )
 )
 
 game (
-	name "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) (PAL)"
-	description "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) (PAL)"
-	rom ( name "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) (PAL).bin" size 16384 crc 02838b54 md5 undefined sha1 b54ab700ec9441aeb72665d095475035a155aa22 )
+	name "Frog Pond (USA) (Proto)"
+	description "Frog Pond (USA) (Proto)"
+	rom ( name "Frog Pond (USA) (Proto).a26" size 8192 crc 5874385a md5 f67181b3a01b9c9159840b15449b87b0 sha1 0d6a96f857ae0e813b4d493866e2420cc5c4bad5 )
 )
 
 game (
-	name "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) ~"
-	description "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) ~"
-	rom ( name "BMX Air Master (1989) (TNT Games, Adam Clayton) (26192) ~.bin" size 16384 crc b4017ee3 md5 undefined sha1 ff25ed062dcc430448b358d2ac745787410e1169 )
+	name "Frogger (USA)"
+	description "Frogger (USA)"
+	rom ( name "Frogger (USA).a26" size 4096 crc f5e1af92 md5 081e2c114c9c20b61acf25fc95c71bf4 sha1 e859b935a36494f3c4b4bf5547392600fb9c96f0 )
 )
 
 game (
-	name "BMX Air Master (1990) (Atari) (CX26190)"
-	description "BMX Air Master (1990) (Atari) (CX26190)"
-	rom ( name "BMX Air Master (1990) (Atari) (CX26190).bin" size 16384 crc b4017ee3 md5 undefined sha1 ff25ed062dcc430448b358d2ac745787410e1169 )
+	name "Frogger II - Threeedeep! (USA)"
+	description "Frogger II - Threeedeep! (USA)"
+	rom ( name "Frogger II - Threeedeep! (USA).a26" size 8192 crc 3ba0d9bf md5 27c6a2ca16ad7d814626ceea62fa8fb4 sha1 6b9e591cc53844795725fc66c564f0364d1fbe40 )
 )
 
 game (
-	name "BMX Air Master (1990) (Atari) (CX26190) (PAL)"
-	description "BMX Air Master (1990) (Atari) (CX26190) (PAL)"
-	rom ( name "BMX Air Master (1990) (Atari) (CX26190) (PAL).bin" size 16384 crc db722dd7 md5 undefined sha1 30d52041c59a240a8ebe2749e4de32bbc74988ee )
+	name "Frogs and Flies (USA)"
+	description "Frogs and Flies (USA)"
+	rom ( name "Frogs and Flies (USA).a26" size 4096 crc 6476c136 md5 dcc2956c7a39fdbf1e861fc5c595da0d sha1 f344d5a8dc895c5a2ae0288f3c6cb66650e49167 )
 )
 
 game (
-	name "Bob Is Going Home (AKA Bobby Is Going Home) (JVP)"
-	description "Bob Is Going Home (AKA Bobby Is Going Home) (JVP)"
-	rom ( name "Bob Is Going Home (AKA Bobby Is Going Home) (JVP).bin" size 4096 crc 7d620b52 md5 undefined sha1 0888582c21b504f8f7ebe17b3d5a3acd7b6ffa93 )
+	name "Front Line (USA)"
+	description "Front Line (USA)"
+	rom ( name "Front Line (USA).a26" size 8192 crc c352f290 md5 e556e07cc06c803f2955986f53ef63ed sha1 cf32bfcd7f2c3b7d2a6ad2f298aea2dfad8242e7 )
 )
 
 game (
-	name "Bobby geht nach Hause (AKA Bobby Is Going Home) (1983) (Quelle) (476.774 5) (PAL)"
-	description "Bobby geht nach Hause (AKA Bobby Is Going Home) (1983) (Quelle) (476.774 5) (PAL)"
-	rom ( name "Bobby geht nach Hause (AKA Bobby Is Going Home) (1983) (Quelle) (476.774 5) (PAL).bin" size 4096 crc 5ebc42c9 md5 undefined sha1 6f89ec06bc360013ef4c00d51c54df502a80e3bf )
+	name "Frostbite (USA)"
+	description "Frostbite (USA)"
+	rom ( name "Frostbite (USA).a26" size 4096 crc b61be7a3 md5 4ca73eb959299471788f0b685c3ba0b5 sha1 b9e60437e7691d5ef9002cfc7d15ae95f1c03a12 )
 )
 
 game (
-	name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206)"
-	description "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206)"
-	rom ( name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206).bin" size 4096 crc 99a2a654 md5 undefined sha1 6c4a96aec21f6cede3f43cd12842bc7238648770 )
+	name "Funky Fish (USA) (Proto)"
+	description "Funky Fish (USA) (Proto)"
+	rom ( name "Funky Fish (USA) (Proto).a26" size 8192 crc b53b33f1 md5 d3bb42228a6cd452c111c1932503cc03 sha1 fba461d2a2d1395945806c883f4dca925712885e )
 )
 
 game (
-	name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) [demonstration cartridge]"
-	description "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) [demonstration cartridge]"
-	rom ( name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) [demonstration cartridge].bin" size 4096 crc 3e662128 md5 undefined sha1 4aef30b43249621e09a690d54ebe23377289a997 )
+	name "G.I. Joe - Cobra Strike (USA)"
+	description "G.I. Joe - Cobra Strike (USA)"
+	rom ( name "G.I. Joe - Cobra Strike (USA).a26" size 4096 crc 6bcbcd37 md5 c1fdd44efda916414be3527a47752c75 sha1 9cfb6288a5c2dae63ee6f5e9325200ccd21a3055 )
 )
 
 game (
-	name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) ~"
-	description "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) ~"
-	rom ( name "Bobby Is Going Home - Bobby geht Heim (1983) (Bit Corporation) (PG206) (PAL) ~.bin" size 4096 crc f061e27f md5 undefined sha1 50e26688fdd3eadcfa83240616267a8f60216c25 )
+	name "Galaxian (USA)"
+	description "Galaxian (USA)"
+	rom ( name "Galaxian (USA).a26" size 8192 crc 4e9fe271 md5 211774f4c5739042618be8ff67351177 sha1 b081b327ac32d951c36cb4b3ff812be95685d52f )
 )
 
 game (
-	name "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803)"
-	description "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803)"
-	rom ( name "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803).bin" size 4096 crc 358940e3 md5 undefined sha1 e00202da428db2d05e30cdd59488e5e0d405c678 )
+	name "Gamma-Attack (USA)"
+	description "Gamma-Attack (USA)"
+	rom ( name "Gamma-Attack (USA).a26" size 2048 crc D1EFE8BB md5 DB971B6AFC9D243F614EBF380AF0AC60 sha1 20ABF6BA6A9685627220128BABF74C303B7C8D30 )
 )
 
 game (
-	name "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803) (PAL)"
-	description "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803) (PAL)"
-	rom ( name "Bobby Is Going Home - Bobby Vai Para Casa (1983) (CCE) (C-803) (PAL).bin" size 4096 crc 5c4a04c8 md5 undefined sha1 876c3b01e68568100db716bc69bf58189acb72c2 )
+	name "Gangster Alley (USA)"
+	description "Gangster Alley (USA)"
+	rom ( name "Gangster Alley (USA).a26" size 4096 crc 03c2452c md5 20edcc3aa6c189259fa7e2f044a99c49 sha1 8cf49d43bd62308df788cfacbfcd80e9226c7590 )
 )
 
 game (
-	name "Bobby Is Going Home (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Bobby Is Going Home (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Bobby Is Going Home (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 377f06e2 md5 undefined sha1 689573acea2b67f653f41e21c6b10de1a3b518d6 )
+	name "Garfield (USA) (Proto)"
+	description "Garfield (USA) (Proto)"
+	rom ( name "Garfield (USA) (Proto).a26" size 16384 crc f20cadcf md5 dc13df8420ec69841a7c51e41b9fbba5 sha1 bc0d1edc251d8d4db3d5234ec83dee171642a547 )
 )
 
 game (
-	name "Bobby Is Going Home (Rentacom)"
-	description "Bobby Is Going Home (Rentacom)"
-	rom ( name "Bobby Is Going Home (Rentacom).bin" size 4096 crc 23988055 md5 undefined sha1 7d5ed036a57fdb60927121b9a3353e8a3cdaaefa )
+	name "Gas Hog (USA)"
+	description "Gas Hog (USA)"
+	rom ( name "Gas Hog (USA).a26" size 4096 crc 40699ca5 md5 5cbd7c31443fb9c308e9f0b54d94a395 sha1 e919ee03e8a17fd85be1e53b4d5ff76dae54d099 )
 )
 
 game (
-	name "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030)"
-	description "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030)"
-	rom ( name "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030).bin" size 4096 crc a44eb837 md5 undefined sha1 282cad17482f5f87805065d1a62e49e662d5b4bb )
+	name "Gauntlet (USA)"
+	description "Gauntlet (USA)"
+	rom ( name "Gauntlet (USA).a26" size 4096 crc c7ac23c7 md5 e64a8008812327853877a37befeb6465 sha1 73adae38d86d50360b1a247244df05892e33da46 )
 )
 
 game (
-	name "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030) (PAL)"
-	description "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030) (PAL)"
-	rom ( name "Bogey Blaster (AKA Air Raiders) (1989) (Telegames) (5861 A030) (PAL).bin" size 4096 crc 5d61b833 md5 undefined sha1 6e3af361bbf70a4a85d6c8d4ed4070e8fed963cb )
+	name "Ghost Manor (USA)"
+	description "Ghost Manor (USA)"
+	rom ( name "Ghost Manor (USA).a26" size 8192 crc 6fc46219 md5 2bee7f226d506c217163bad4ab1768c0 sha1 4b533776dcd9d538f9206ad1e28b30116d08df1e )
 )
 
 game (
-	name "Boggle (08-07-1978) (Atari, David Crane) (Prototype) ~"
-	description "Boggle (08-07-1978) (Atari, David Crane) (Prototype) ~"
-	rom ( name "Boggle (08-07-1978) (Atari, David Crane) (Prototype) ~.bin" size 2048 crc 26b6bfef md5 undefined sha1 4accd4cc4f8f3a935ca178449a4ac62283639c53 )
+	name "Ghostbusters (USA)"
+	description "Ghostbusters (USA)"
+	rom ( name "Ghostbusters (USA).a26" size 8192 crc 45443d13 md5 e314b42761cd13c03def744b4afc7b1b sha1 5ed0b2cb346d20720e3c526da331551aa16a23a4 )
 )
 
 game (
-	name "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) (PAL)"
-	description "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) (PAL)"
-	rom ( name "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) (PAL).bin" size 4096 crc d2f06299 md5 undefined sha1 d7a079a8874dcf059d10dc49831d6d9e2db68917 )
+	name "Ghostbusters II (Europe)"
+	description "Ghostbusters II (Europe)"
+	rom ( name "Ghostbusters II (Europe).a26" size 16384 crc a3c342b8 md5 c2b5c50ccb59816867036d7cf730bf75 sha1 e032876305647a95b622e5c4971f7096ef72acdb )
 )
 
 game (
-	name "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) ~"
-	description "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) ~"
-	rom ( name "Boing! (Bubbles, Soap Suds, The Emphysema Game) (1983) (First Star Software, Alex Leavens, Shirley Ann Russell) ~.bin" size 4096 crc ad380487 md5 undefined sha1 d106bb41a38ed222dead608d839e8a3f0d0ecc18 )
+	name "Gigolo (USA)"
+	description "Gigolo (USA)"
+	rom ( name "Gigolo (USA).a26" size 4096 crc 4E16A8DC md5 1C8C42D1AEE5010B30E7F1992D69216E sha1 B64ED2D5A2F8FDAC4FF0CE56939BA72E343FEC33 )
 )
 
 game (
-	name "Boom Bang (AKA Crackpots) (1983) (CCE) (C-849)"
-	description "Boom Bang (AKA Crackpots) (1983) (CCE) (C-849)"
-	rom ( name "Boom Bang (AKA Crackpots) (1983) (CCE) (C-849).bin" size 4096 crc bb713c1c md5 undefined sha1 57e0c1db47cd8c4c671f705c74fa53bedf134fd1 )
+	name "Glacier Patrol (USA)"
+	description "Glacier Patrol (USA)"
+	rom ( name "Glacier Patrol (USA).a26" size 4096 crc 44e77fd6 md5 5e0c37f534ab5ccc4661768e2ddf0162 sha1 3a3d7206afee36786026d6287fe956c2ebc80ea7 )
 )
 
 game (
-	name "Boom Bang (AKA Crackpots) (HES) (PAL)"
-	description "Boom Bang (AKA Crackpots) (HES) (PAL)"
-	rom ( name "Boom Bang (AKA Crackpots) (HES) (PAL).bin" size 8192 crc 5979b0f8 md5 undefined sha1 29547a5b632060fbbc935267b709811a77fff127 )
+	name "Glib - Video Word Game (USA)"
+	description "Glib - Video Word Game (USA)"
+	rom ( name "Glib - Video Word Game (USA).a26" size 4096 crc 50bb03a4 md5 2d9e5d8d083b6367eda880e80dfdfaeb sha1 7bca0f7a0f992782e4e4c90772bac976ca963a6d )
 )
 
 game (
-	name "Boom Bang (AKA Crackpots) (Unknown)"
-	description "Boom Bang (AKA Crackpots) (Unknown)"
-	rom ( name "Boom Bang (AKA Crackpots) (Unknown).bin" size 4096 crc c6ec156c md5 undefined sha1 c367396281bad3fe5ef8cd9d990c3d2994d32bf1 )
+	name "Go Go Home Monster (Europe)"
+	description "Go Go Home Monster (Europe)"
+	rom ( name "Go Go Home Monster (Europe).a26" size 4096 crc c161f53b md5 103f1756d9dc0dd2b16b53ad0f0f1859 sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
 )
 
 game (
-	name "Boom Bang (AKA Crackpots) (Unknown) (PAL)"
-	description "Boom Bang (AKA Crackpots) (Unknown) (PAL)"
-	rom ( name "Boom Bang (AKA Crackpots) (Unknown) (PAL).bin" size 4096 crc 27b848d6 md5 undefined sha1 bae50a1939f11ebcb808f1f8b978c4e2586d65ee )
+	name "Golf (USA)"
+	description "Golf (USA)"
+	rom ( name "Golf (USA).a26" size 2048 crc 46a9f200 md5 2e663eaa0d6b723b645e643750b942fd sha1 a25d52770408314dec6f41aaf5f9f0a2a3e2c18f )
 )
 
 game (
-	name "Boom Bang (Rainbow Vision - Suntek) (SS-016) (PAL)"
-	description "Boom Bang (Rainbow Vision - Suntek) (SS-016) (PAL)"
-	rom ( name "Boom Bang (Rainbow Vision - Suntek) (SS-016) (PAL).bin" size 4096 crc 3beda93b md5 undefined sha1 dd3494a1e3ffa063803b1f02716e87e89dc3c574 )
+	name "Gopher (USA)"
+	description "Gopher (USA)"
+	rom ( name "Gopher (USA).a26" size 4096 crc ac8321d8 md5 c16c79aad6272baffb8aae9a7fff0864 sha1 97fb489ba4ce0f8a306563063563617321352cfb )
 )
 
 game (
-	name "Bowling (1979) (Atari, Larry Kaplan - Sears) (CX2628 - 6-99842, 49-75117) ~"
-	description "Bowling (1979) (Atari, Larry Kaplan - Sears) (CX2628 - 6-99842, 49-75117) ~"
-	rom ( name "Bowling (1979) (Atari, Larry Kaplan - Sears) (CX2628 - 6-99842, 49-75117) ~.bin" size 2048 crc fea0d6d5 md5 undefined sha1 cf6ce244b3edaad7ad5e9ca5f01668135c2f93d0 )
+	name "Gorf (USA)"
+	description "Gorf (USA)"
+	rom ( name "Gorf (USA).a26" size 4096 crc 9bd137aa md5 81b3bf17cf01039d311b4cd738ae608e sha1 35f8341c73c7e6e896cb065977427b3f98ae9f08 )
 )
 
 game (
-	name "Bowling (1979) (Atari, Larry Kaplan) (CX2628, CX2628P) (PAL)"
-	description "Bowling (1979) (Atari, Larry Kaplan) (CX2628, CX2628P) (PAL)"
-	rom ( name "Bowling (1979) (Atari, Larry Kaplan) (CX2628, CX2628P) (PAL).bin" size 2048 crc c7bc1bca md5 undefined sha1 da5ed7a4a100fa4830b635981774a11ba4b0a60d )
+	name "Grand Prix (USA)"
+	description "Grand Prix (USA)"
+	rom ( name "Grand Prix (USA).a26" size 4096 crc e855273d md5 2903896d88a341511586d69fcfc20f7d sha1 24fab817728216582b6d95558c361ace66abf96f )
 )
 
 game (
-	name "Bowling (208 in 1) (Unknown) (PAL)"
-	description "Bowling (208 in 1) (Unknown) (PAL)"
-	rom ( name "Bowling (208 in 1) (Unknown) (PAL).bin" size 2048 crc 6c6a32da md5 undefined sha1 e7ff9ded67c599586a533a3c6fb9684afd9e26bd )
+	name "Gravitar (USA)"
+	description "Gravitar (USA)"
+	rom ( name "Gravitar (USA).a26" size 8192 crc c87fccbe md5 8ac18076d01a6b63acf6e2cab4968940 sha1 a372d4dd3d95b3866553cae2336e4565e00cc25b )
 )
 
 game (
-	name "Bowling (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL)"
-	description "Bowling (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL)"
-	rom ( name "Bowling (32 in 1) (1988) (Atari, Larry Kaplan) (CX26163P) (PAL).bin" size 2048 crc ec82aaff md5 undefined sha1 68ea43ea0e678cb5419a437a9bdab5c84f5ee1b9 )
+	name "Great Escape (USA)"
+	description "Great Escape (USA)"
+	rom ( name "Great Escape (USA).a26" size 4096 crc 58010be3 md5 18f299edb5ba709a64c80c8c9cec24f2 sha1 8f4a00cb4ab6a6f809be0e055d97e8fe17f19e7d )
 )
 
 game (
-	name "Bowling (Dactar - Milmar)"
-	description "Bowling (Dactar - Milmar)"
-	rom ( name "Bowling (Dactar - Milmar).bin" size 2048 crc 18f65da8 md5 undefined sha1 4c6189fc465cc0353bec82de7cddde7aad269e93 )
+	name "Gremlins (USA)"
+	description "Gremlins (USA)"
+	rom ( name "Gremlins (USA).a26" size 8192 crc 48d5991f md5 01cb3e8dfab7203a9c62ba3b94b4e59f sha1 7a027329309e018b0d51adcb6ae13c9d13e54f4a )
 )
 
 game (
-	name "Boxen (AKA Boxing) (Videospielkassette - Ariola) (PGP234) (PAL)"
-	description "Boxen (AKA Boxing) (Videospielkassette - Ariola) (PGP234) (PAL)"
-	rom ( name "Boxen (AKA Boxing) (Videospielkassette - Ariola) (PGP234) (PAL).bin" size 2048 crc 7931c845 md5 undefined sha1 de7137596223f0e8d0f4e6cd675ea5344892c6f4 )
+	name "Grover's Music Maker (USA) (Proto)"
+	description "Grover's Music Maker (USA) (Proto)"
+	rom ( name "Grover's Music Maker (USA) (Proto).a26" size 8192 crc e1372b28 md5 66b89ba44e7ae0b51f9ef000ebba1eb7 sha1 b9760ffba05139bca0fac3f7d3dc1e5d57600eda )
 )
 
 game (
-	name "Boxing - Box-Champion (1980) (Activision, Bob Whitehead - Ariola) (EAG-002, EAG-002-04I, PAG-002 - 711 002-715) (PAL)"
-	description "Boxing - Box-Champion (1980) (Activision, Bob Whitehead - Ariola) (EAG-002, EAG-002-04I, PAG-002 - 711 002-715) (PAL)"
-	rom ( name "Boxing - Box-Champion (1980) (Activision, Bob Whitehead - Ariola) (EAG-002, EAG-002-04I, PAG-002 - 711 002-715) (PAL).bin" size 2048 crc 515036f1 md5 undefined sha1 4f75780608148f51eddb30ce2da0c1a40be7d37f )
+	name "Guardian (USA)"
+	description "Guardian (USA)"
+	rom ( name "Guardian (USA).a26" size 4096 crc 121738f5 md5 7ab2f190d4e59e8742e76a6e870b567e sha1 7d30ff565ad7b2a3143d049c5b39e4a6ac3f9cd5 )
 )
 
 game (
-	name "Boxing - La Boxe (1980) (Activision, Bob Whitehead) (AG-002, CAG-002, AG-002-04) ~"
-	description "Boxing - La Boxe (1980) (Activision, Bob Whitehead) (AG-002, CAG-002, AG-002-04) ~"
-	rom ( name "Boxing - La Boxe (1980) (Activision, Bob Whitehead) (AG-002, CAG-002, AG-002-04) ~.bin" size 2048 crc 9ece0021 md5 undefined sha1 14b9cd91188c7fb0d4566442d639870f8d6f174d )
+	name "Gyruss (USA)"
+	description "Gyruss (USA)"
+	rom ( name "Gyruss (USA).a26" size 8192 crc 0d78e8a9 md5 b311ab95e85bc0162308390728a7361d sha1 4bd87ba8b3b6d7850e3ea41b4d494c3b12659f27 )
 )
 
 game (
-	name "Boxing (1983) (CCE) (C-861)"
-	description "Boxing (1983) (CCE) (C-861)"
-	rom ( name "Boxing (1983) (CCE) (C-861).bin" size 2048 crc 0411ae6b md5 undefined sha1 a7716af544f0813ce7657bb8a1a55ff6088f09c3 )
+	name "H.E.R.O. (USA)"
+	description "H.E.R.O. (USA)"
+	rom ( name "H.E.R.O. (USA).a26" size 8192 crc 721e95b7 md5 fca4a5be1251927027f2c24774a02160 sha1 282f94817401e3725c622b73a0c05685ce761783 )
 )
 
 game (
-	name "Boxing (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Boxing (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Boxing (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc fdb0aa75 md5 undefined sha1 559d46d1f9dfe6ba2ed8f2001db8dbe7bcd207ef )
+	name "Halloween (USA)"
+	description "Halloween (USA)"
+	rom ( name "Halloween (USA).a26" size 4096 crc b1b11806 md5 30516cfbaa1bc3b5335ee53ad811f17a sha1 4c72cec151f219866bf870fa7ac749a19ca501c9 )
 )
 
 game (
-	name "Boxing (Dactari - Milmar)"
-	description "Boxing (Dactari - Milmar)"
-	rom ( name "Boxing (Dactari - Milmar).bin" size 2048 crc 6afbbc0c md5 undefined sha1 b67a8146b64f27f9bb8975da6a659f3be83d284b )
+	name "Hangman - Spelling (USA)"
+	description "Hangman - Spelling (USA)"
+	rom ( name "Hangman - Spelling (USA).a26" size 4096 crc c2bcc789 md5 f16c709df0a6c52f47ff52b9d95b7d8d sha1 561bccf508e162bc70c42d85c170cf0d1d4691a3 )
 )
 
 game (
-	name "Boxing (Unknown) (PAL)"
-	description "Boxing (Unknown) (PAL)"
-	rom ( name "Boxing (Unknown) (PAL).bin" size 2048 crc 7fdb4553 md5 undefined sha1 a74ab3e955d8f7656e977282636686632ba79648 )
+	name "Haunted House (USA)"
+	description "Haunted House (USA)"
+	rom ( name "Haunted House (USA).a26" size 4096 crc aa62d961 md5 f0a6e99f5875891246c3dbecbf2d2cea sha1 1476c869619075b551b20f2c7f95b11e0d16aec1 )
 )
 
 game (
-	name "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2664 - 6-99818) ~"
-	description "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2664 - 6-99818) ~"
-	rom ( name "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2664 - 6-99818) ~.bin" size 2048 crc 150709c2 md5 undefined sha1 238915cafd26f69bc8a3b9aa7d880dde59f6f12d )
+	name "Hell Driver (USA)"
+	description "Hell Driver (USA)"
+	rom ( name "Hell Driver (USA).a26" size 4096 crc 18954066 md5 aab840db22075aa0f6a6b83a597f8890 sha1 65bd036bffd90ae34baa3817fee6ea70c76478ac )
 )
 
 game (
-	name "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2664, CX2664P) (PAL)"
-	description "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2664, CX2664P) (PAL)"
-	rom ( name "Brain Games (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2664, CX2664P) (PAL).bin" size 2048 crc ea630e68 md5 undefined sha1 7b9d9ac288ea1fda8e8cbbde75e84b4e2ed37a5e )
+	name "Hole Hunter (USA)"
+	description "Hole Hunter (USA)"
+	rom ( name "Hole Hunter (USA).a26" size 4096 crc 66d5ce67 md5 3d48b8b586a09bdbf49f1a016bf4d29a sha1 f275c7ca9a76fb758f52548b8597bc13245263b6 )
 )
 
 game (
-	name "Break-Down (AKA Wall Break) (1983) (Dynamics) (DY-192004) (PAL)"
-	description "Break-Down (AKA Wall Break) (1983) (Dynamics) (DY-192004) (PAL)"
-	rom ( name "Break-Down (AKA Wall Break) (1983) (Dynamics) (DY-192004) (PAL).bin" size 4096 crc 727408cd md5 undefined sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
+	name "Holey Moley (USA) (Proto)"
+	description "Holey Moley (USA) (Proto)"
+	rom ( name "Holey Moley (USA) (Proto).a26" size 8192 crc 3bb2e71d md5 c52d9bbdc5530e1ef8e8ba7be692b01e sha1 8196209ef7048c5494dbdc932adbf1c7abf79f4e )
 )
 
 game (
-	name "Breakout - Breakaway IV (Paddle) (1978) (Atari, Brad Stewart - Sears) (CX2622 - 6-99813, 49-75107) ~"
-	description "Breakout - Breakaway IV (Paddle) (1978) (Atari, Brad Stewart - Sears) (CX2622 - 6-99813, 49-75107) ~"
-	rom ( name "Breakout - Breakaway IV (Paddle) (1978) (Atari, Brad Stewart - Sears) (CX2622 - 6-99813, 49-75107) ~.bin" size 2048 crc 3037638c md5 undefined sha1 8d473b87b70e26890268e6c417c0bb7f01e402eb )
+	name "Home Run - Baseball (USA)"
+	description "Home Run - Baseball (USA)"
+	rom ( name "Home Run - Baseball (USA).a26" size 2048 crc 45ace998 md5 0bfabf1e98bdb180643f35f2165995d0 sha1 f362d2b3a50e5ae3c2b412b6c08ecdcfee47a688 )
 )
 
 game (
-	name "Breakout (Paddle) (1978) (Atari, Brad Stewart) (CX2622, CX2622P) (PAL)"
-	description "Breakout (Paddle) (1978) (Atari, Brad Stewart) (CX2622, CX2622P) (PAL)"
-	rom ( name "Breakout (Paddle) (1978) (Atari, Brad Stewart) (CX2622, CX2622P) (PAL).bin" size 2048 crc 33717471 md5 undefined sha1 4d37ccf1d983917ff59659b78573d1430ad4f273 )
+	name "Human Cannonball - Cannon Man (USA)"
+	description "Human Cannonball - Cannon Man (USA)"
+	rom ( name "Human Cannonball - Cannon Man (USA).a26" size 2048 crc f05a41e1 md5 7972e5101fa548b952d852db24ad6060 sha1 d4b0b2aa379893356c72414ee0065a3a91cf9f97 )
 )
 
 game (
-	name "Bridge (1980) (Activision, Larry Kaplan) (AX-006) [fixed] ~"
-	description "Bridge (1980) (Activision, Larry Kaplan) (AX-006) [fixed] ~"
-	rom ( name "Bridge (1980) (Activision, Larry Kaplan) (AX-006) [fixed] ~.bin" size 4096 crc 8db95d1e md5 undefined sha1 6df43b75ae080240d97754ab69c39c32370800a7 )
+	name "Hunt & Score - Memory Match (USA)"
+	description "Hunt & Score - Memory Match (USA)"
+	rom ( name "Hunt & Score - Memory Match (USA).a26" size 2048 crc 17de8070 md5 102672bbd7e25cd79f4384dd7214c32b sha1 a6e42c63138a2fd527cdbe9b7e60f5feabdd55c8 )
 )
 
 game (
-	name "Bridge (1980) (Activision, Larry Kaplan) (AX-006) ~"
-	description "Bridge (1980) (Activision, Larry Kaplan) (AX-006) ~"
-	rom ( name "Bridge (1980) (Activision, Larry Kaplan) (AX-006) ~.bin" size 4096 crc 9c71d175 md5 undefined sha1 2873eb6effd35003d13e2f8f997b76dbc85d0f64 )
+	name "I.Q. 180 (USA)"
+	description "I.Q. 180 (USA)"
+	rom ( name "I.Q. 180 (USA).a26" size 4096 crc 4dc2a674 md5 4b9581c3100a1ef05eac1535d25385aa sha1 8483fd18dddafbdfbcbd1c43bc7de2cc05a1894d )
 )
 
 game (
-	name "Bridge (208 in 1) (Unknown) (PAL)"
-	description "Bridge (208 in 1) (Unknown) (PAL)"
-	rom ( name "Bridge (208 in 1) (Unknown) (PAL).bin" size 4096 crc 946d56a2 md5 undefined sha1 2ec31813906d4fcb1160ba756d0f93db8f93089a )
+	name "I.Q. Memory Teaser (Europe)"
+	description "I.Q. Memory Teaser (Europe)"
+	rom ( name "I.Q. Memory Teaser (Europe).a26" size 4096 crc 75ab6ba8 md5 dc33479d66615a3b09670775de4c2a38 sha1 fa05a35de4c401704538cc256f46440f42de3ddb )
 )
 
 game (
-	name "Buck Rogers - Planet of Zoom (1983) (Sega - Teldec) (005-10) (PAL)"
-	description "Buck Rogers - Planet of Zoom (1983) (Sega - Teldec) (005-10) (PAL)"
-	rom ( name "Buck Rogers - Planet of Zoom (1983) (Sega - Teldec) (005-10) (PAL).bin" size 8192 crc f8b140fa md5 undefined sha1 70f6310a522da76c18f3dedc050ef44217efb771 )
+	name "Ice Hockey (USA)"
+	description "Ice Hockey (USA)"
+	rom ( name "Ice Hockey (USA).a26" size 4096 crc adab8cdf md5 a4c08c4994eb9d24fb78be1793e82e26 sha1 21de0f034e5dad03fa91eb7ae6cc081c142be35c )
 )
 
 game (
-	name "Buck Rogers - Planet of Zoom (1983) (Sega) (005-01) ~"
-	description "Buck Rogers - Planet of Zoom (1983) (Sega) (005-01) ~"
-	rom ( name "Buck Rogers - Planet of Zoom (1983) (Sega) (005-01) ~.bin" size 8192 crc 2030f686 md5 undefined sha1 a65dea2d9790f3eb308c048a01566e35e8c24549 )
+	name "Ikari Warriors (USA)"
+	description "Ikari Warriors (USA)"
+	rom ( name "Ikari Warriors (USA).a26" size 16384 crc 5b7ce555 md5 9a21fba9ee9794e0fadd7c7eb6be4e12 sha1 d8f7b908f60fe49667c7c55d48ce15a05ad95a28 )
 )
 
 game (
-	name "Bugs (Paddle) (1982) (Data Age) (DA1005) ~"
-	description "Bugs (Paddle) (1982) (Data Age) (DA1005) ~"
-	rom ( name "Bugs (Paddle) (1982) (Data Age) (DA1005) ~.bin" size 4096 crc 1202427c md5 undefined sha1 67387d0d3d48a44800c44860bf15339a81f41aa9 )
+	name "Immies & Aggies (USA) (Proto)"
+	description "Immies & Aggies (USA) (Proto)"
+	rom ( name "Immies & Aggies (USA) (Proto).a26" size 4096 crc 86244c24 md5 75a303fd46ad12457ed8e853016815a0 sha1 603b4ecc797972d32f2f3b8e66ebdde5aaf51a07 )
 )
 
 game (
-	name "Bugs (Paddle) (1983) (Gameworld) (133-005) (PAL)"
-	description "Bugs (Paddle) (1983) (Gameworld) (133-005) (PAL)"
-	rom ( name "Bugs (Paddle) (1983) (Gameworld) (133-005) (PAL).bin" size 4096 crc d1ddb571 md5 undefined sha1 a8aedea627c67c38032cdde441fb98dad226916a )
+	name "Indy 500 - Race (USA)"
+	description "Indy 500 - Race (USA)"
+	rom ( name "Indy 500 - Race (USA).a26" size 2048 crc b43da2a3 md5 c5301f549d0722049bb0add6b10d1e09 sha1 620ab88d63cdd3f8ce67deac00a22257c7205c8b )
 )
 
 game (
-	name "Bugs Bunny (08-04-1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype) ~"
-	description "Bugs Bunny (08-04-1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype) ~"
-	rom ( name "Bugs Bunny (08-04-1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype) ~.bin" size 8192 crc bd164019 md5 undefined sha1 b3ff124891de0fb3d44c35115d838fd7e135ca04 )
+	name "Infiltrate (USA)"
+	description "Infiltrate (USA)"
+	rom ( name "Infiltrate (USA).a26" size 4096 crc 612bd4da md5 afe88aae81d99e0947c0cfb687b16251 sha1 922cd171ef132bf6c5bed00ad01410ada4b20729 )
 )
 
 game (
-	name "Bugs Bunny (1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype)"
-	description "Bugs Bunny (1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype)"
-	rom ( name "Bugs Bunny (1983) (Atari, Alan J. Murphy, Robert C. Polaro) (CX26100) (Prototype).bin" size 8192 crc 272b8856 md5 undefined sha1 9c0e13af336a986c271fe828fafdca250afba647 )
+	name "International Soccer (USA)"
+	description "International Soccer (USA)"
+	rom ( name "International Soccer (USA).a26" size 4096 crc b9d549a2 md5 b4030c38a720dd84b84178b6ce1fc749 sha1 fa5bf10d9058eeb2e32ab65a25a906c17b445903 )
 )
 
 game (
-	name "Bump 'n' Jump (1983) (M Network, David Akers, Joe 'Ferreira' King, Patricia Lewis Du Long, Jeff Ratcliff - INTV) (MT7045) ~"
-	description "Bump 'n' Jump (1983) (M Network, David Akers, Joe 'Ferreira' King, Patricia Lewis Du Long, Jeff Ratcliff - INTV) (MT7045) ~"
-	rom ( name "Bump 'n' Jump (1983) (M Network, David Akers, Joe 'Ferreira' King, Patricia Lewis Du Long, Jeff Ratcliff - INTV) (MT7045) ~.bin" size 16384 crc df2bc303 md5 undefined sha1 1819ef408c1216c83dcfeceec28d13f6ea5ca477 )
+	name "Ixion (USA) (Proto)"
+	description "Ixion (USA) (Proto)"
+	rom ( name "Ixion (USA) (Proto).a26" size 8192 crc b311e13f md5 2f0546c4d238551c7d64d884b618100c sha1 a11538157529b42a2840f518b95af5c59143cced )
 )
 
 game (
-	name "Bump 'n' Jump (1989) (Telegames) (7045 A015) (PAL)"
-	description "Bump 'n' Jump (1989) (Telegames) (7045 A015) (PAL)"
-	rom ( name "Bump 'n' Jump (1989) (Telegames) (7045 A015) (PAL).bin" size 8192 crc 194f3576 md5 undefined sha1 35bc4048f58bb170313872a0bce44fb1ca3217cc )
+	name "James Bond 007 (USA)"
+	description "James Bond 007 (USA)"
+	rom ( name "James Bond 007 (USA).a26" size 8192 crc 34d3ffc8 md5 e51030251e440cffaab1ac63438b44ae sha1 2bbc124cead9aa49b364268735dad8cb1eb6594f )
 )
 
 game (
-	name "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218, SA-218C) (PAL)"
-	description "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218, SA-218C) (PAL)"
-	rom ( name "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218, SA-218C) (PAL).bin" size 4096 crc 863248fc md5 undefined sha1 79c008568167bec1426280690c45e7ba5bd71b3e )
+	name "Jawbreaker (USA)"
+	description "Jawbreaker (USA)"
+	rom ( name "Jawbreaker (USA).a26" size 4096 crc fc11bf67 md5 58a82e1da64a692fd727c25faef2ecc9 sha1 af4d6867a8bc4818fc6bb701a765a3c907feb628 )
 )
 
 game (
-	name "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218) ~"
-	description "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218) ~"
-	rom ( name "Bumper Bash (Paddle) (1983) (Spectravideo, David Lubar) (SA-218) ~.bin" size 4096 crc b1a6a23e md5 undefined sha1 6c199782c79686dc0cbce6d5fe805f276a86a3f5 )
+	name "Journey Escape (USA)"
+	description "Journey Escape (USA)"
+	rom ( name "Journey Escape (USA).a26" size 4096 crc 52ff8027 md5 718ae62c70af4e5fd8e932fee216948a sha1 928eaa424b36d98078f9251d67fb13a8fddfafbd )
 )
 
 game (
-	name "Bumper Bash (Unknown) (PAL)"
-	description "Bumper Bash (Unknown) (PAL)"
-	rom ( name "Bumper Bash (Unknown) (PAL).bin" size 4096 crc 5d1798c2 md5 undefined sha1 ad48f4952e867a2b97900d965b69f50fddf8ba2d )
+	name "Joust (USA)"
+	description "Joust (USA)"
+	rom ( name "Joust (USA).a26" size 8192 crc a07b3304 md5 3276c777cbe97cdd2b4a63ffc16b7151 sha1 cb94dc316cba282a0036871db2417257e960786b )
 )
 
 game (
-	name "BurgerTime (1983) (M Network, Patricia Lewis Du Long, Ron Surratt - INTV) (MT4518) ~"
-	description "BurgerTime (1983) (M Network, Patricia Lewis Du Long, Ron Surratt - INTV) (MT4518) ~"
-	rom ( name "BurgerTime (1983) (M Network, Patricia Lewis Du Long, Ron Surratt - INTV) (MT4518) ~.bin" size 16384 crc c183fbbc md5 undefined sha1 49e01b8048ae344cb65838f6b1c1de0e1f416f29 )
+	name "Jr. Pac-Man (USA)"
+	description "Jr. Pac-Man (USA)"
+	rom ( name "Jr. Pac-Man (USA).a26" size 16384 crc 5c345bac md5 36c29ceee2c151b23a1ad7aa04bd529d sha1 cd2cf245d6e924ff2100cc93d20223c4a231e160 )
 )
 
 game (
-	name "Burning Desire (1982) (Mystique - American Multiple Industries) (1003) (PAL) ~"
-	description "Burning Desire (1982) (Mystique - American Multiple Industries) (1003) (PAL) ~"
-	rom ( name "Burning Desire (1982) (Mystique - American Multiple Industries) (1003) (PAL) ~.bin" size 4096 crc f2593d9b md5 undefined sha1 fcf8eeac23e146d20f93812ab5a9872045f95b52 )
+	name "Jungle Hunt (USA)"
+	description "Jungle Hunt (USA)"
+	rom ( name "Jungle Hunt (USA).a26" size 8192 crc 9c3e8734 md5 2bb9f4686f7e08c5fcc69ec1a1c66fe7 sha1 83a32a2d686355438c915540cfe0bb13b76c1113 )
 )
 
 game (
-	name "Burning Desire (1982) (PlayAround - J.H.M.) (202)"
-	description "Burning Desire (1982) (PlayAround - J.H.M.) (202)"
-	rom ( name "Burning Desire (1982) (PlayAround - J.H.M.) (202).bin" size 4096 crc 92f91d36 md5 undefined sha1 b233c37aa5164a54e2e7cc3dc621b331ddc6e55b )
+	name "Jungle Fever (USA)"
+	description "Jungle Fever (USA)"
+	rom ( name "Jungle Fever (USA).a26" size 4096 crc 0123617B md5 2CCCC079C15E9AF94246F867FFC7E9BF sha1 9A0EE845D9928D4DB003B07B927BB2C1F628E725 )
 )
 
 game (
-	name "Busy Police (AKA Keystone Kapers) (Funvision - Fund. International Co.)"
-	description "Busy Police (AKA Keystone Kapers) (Funvision - Fund. International Co.)"
-	rom ( name "Busy Police (AKA Keystone Kapers) (Funvision - Fund. International Co.).bin" size 4096 crc db1122e6 md5 undefined sha1 a663f13ce7f31e3451e944e9f03c9aac2c3e8f21 )
+	name "Kabobber (USA) (Proto)"
+	description "Kabobber (USA) (Proto)"
+	rom ( name "Kabobber (USA) (Proto).a26" size 4096 crc 9517ee0e md5 b9d1e3be30b131324482345959aed5e5 sha1 ce8ac88b799c282567495ce509402a5a4c2c4d82 )
 )
 
 game (
-	name "Busy Police (AKA Keystone Kapers) (Zellers)"
-	description "Busy Police (AKA Keystone Kapers) (Zellers)"
-	rom ( name "Busy Police (AKA Keystone Kapers) (Zellers).bin" size 4096 crc db1122e6 md5 undefined sha1 a663f13ce7f31e3451e944e9f03c9aac2c3e8f21 )
+	name "Kaboom! (USA)"
+	description "Kaboom! (USA)"
+	rom ( name "Kaboom! (USA).a26" size 2048 crc 813f00f6 md5 5428cdfada281c569c74c7308c7f2c26 sha1 40d4df4f8e4a69a299ae7678c17e72bedeb70105 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (05-24-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (05-24-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (05-24-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc 2545ff14 md5 undefined sha1 9b922b590f1ae041f1473336068cdca765a62e6e )
+	name "Kamikaze Saucers (USA) (Proto)"
+	description "Kamikaze Saucers (USA) (Proto)"
+	rom ( name "Kamikaze Saucers (USA) (Proto).a26" size 4096 crc 85cb187c md5 7b43c32e3d4ff5932f39afcb4c551627 sha1 a82aaeef44ad88de605c50d23fb4f6cec73f3ab4 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (06-14-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (06-14-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (06-14-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc e6c20f74 md5 undefined sha1 33ee9f36608e9e8bb879a27235d04226121c5f6b )
+	name "Kangaroo (USA)"
+	description "Kangaroo (USA)"
+	rom ( name "Kangaroo (USA).a26" size 8192 crc b9ab57e6 md5 4326edb70ff20d0ee5ba58fa5cb09d60 sha1 01fd30311e028944eafb6d14bb001035f816ced7 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (06-XX-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (06-XX-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (06-XX-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc 0958f84e md5 undefined sha1 a4ecf3757b78282dac1d16668f3820ca9da41ad9 )
+	name "Karate (USA)"
+	description "Karate (USA)"
+	rom ( name "Karate (USA).a26" size 4096 crc ac0a9ce0 md5 cedbd67d1ff321c996051eec843f8716 sha1 c0db7d295e2ce5e00e00b8a83075b1103688ea15 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (07-03-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (07-03-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (07-03-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc ea375b62 md5 undefined sha1 cd7f18bf865501e7b918522e00ddbe434fd57e21 )
+	name "Keystone Kapers (USA)"
+	description "Keystone Kapers (USA)"
+	rom ( name "Keystone Kapers (USA).a26" size 4096 crc 3e55f3a1 md5 be929419902e21bd7830a7a7d746195d sha1 3eefc193dec3b242bcfd43f5a4d9f023e55378a4 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (07-27-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (07-27-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (07-27-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc 3d5f4684 md5 undefined sha1 159b2ead2e5455c87264565c628396cca997a7f3 )
+	name "Killer Satellites (USA)"
+	description "Killer Satellites (USA)"
+	rom ( name "Killer Satellites (USA).a26" size 8448 crc bdd932dc md5 7a7f6ab9215a3a6b5940b8737f116359 sha1 64125e796f96aa472bb2191367c6501c657712d9 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (08-21-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (08-21-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (08-21-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc bc0462a8 md5 undefined sha1 63ce3795f48a2b1f5988f01d8bf7cc10f311223e )
+	name "King Kong (USA)"
+	description "King Kong (USA)"
+	rom ( name "King Kong (USA).a26" size 4096 crc cb6f5617 md5 e21ee3541ebd2c23e817ffb449939c37 sha1 59f485ea345cf1b9e3663b45b246f13936a32972 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (09-04-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (09-04-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (09-04-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc 19658587 md5 undefined sha1 8c7e04c6ed084d8dedc1e8eae12b72161c04f536 )
+	name "Klax (Europe)"
+	description "Klax (Europe)"
+	rom ( name "Klax (Europe).a26" size 16384 crc a8aaf68b md5 eed9eaf1a0b6a2b9bc4c8032cb43e3fb sha1 45623a1c8fb5074de98c37f005edd5b1d0937dae )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (09-07-1984) (Coleco, Ed Temple) (Prototype)"
-	description "Cabbage Patch Kids - Adventures in the Park (09-07-1984) (Coleco, Ed Temple) (Prototype)"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (09-07-1984) (Coleco, Ed Temple) (Prototype).bin" size 8192 crc 1aab5dc9 md5 undefined sha1 2a12324f04e22c86fd4f9933a223936c1117bba2 )
+	name "Knight on the Town (USA)"
+	description "Knight on the Town (USA)"
+	rom ( name "Knight on the Town (USA).a26" size 4096 crc ACEA70A6 md5 7FCD1766DE75C614A3CCC31B25DD5B7A sha1 759597D1D779CFDFD7AA30FD28A59ACC58CA2533 )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) [a]"
-	description "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) [a]"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) [a].bin" size 8192 crc dd46ed32 md5 undefined sha1 521035afc427e4be5c85a5c1a4b84126c49bd10f )
+	name "Kool-Aid Man (USA)"
+	description "Kool-Aid Man (USA)"
+	rom ( name "Kool-Aid Man (USA).a26" size 4096 crc d9bd009b md5 534e23210dd1993c828d944c6ac4d9fb sha1 2f550743e237f6dc8c75c389a01b02e9a396fdad )
 )
 
 game (
-	name "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) ~"
-	description "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) ~"
-	rom ( name "Cabbage Patch Kids - Adventures in the Park (09-13-1984) (Coleco, Ed Temple) (Prototype) ~.bin" size 8192 crc 7025d30d md5 undefined sha1 ffdba8ae22784ccc81a5a2e81a236ace09e5b7f4 )
+	name "Krull (USA)"
+	description "Krull (USA)"
+	rom ( name "Krull (USA).a26" size 8192 crc 1a67e6ed md5 4baada22435320d185c95b7dd2bcdb24 sha1 4bdf1cf73316bdb0002606facf11b6ddcb287207 )
 )
 
 game (
-	name "Cakewalk - Alarm in der Backstube (Bakery) (1983) (CommaVid, Irwin Gaines - Ariola) (CM-008 - 712 008-720) (PAL)"
-	description "Cakewalk - Alarm in der Backstube (Bakery) (1983) (CommaVid, Irwin Gaines - Ariola) (CM-008 - 712 008-720) (PAL)"
-	rom ( name "Cakewalk - Alarm in der Backstube (Bakery) (1983) (CommaVid, Irwin Gaines - Ariola) (CM-008 - 712 008-720) (PAL).bin" size 4096 crc 26c5b6bd md5 undefined sha1 392a3216ffbb616b8f123eaab3cd3938a63e1191 )
+	name "Kung-Fu Master (USA)"
+	description "Kung-Fu Master (USA)"
+	rom ( name "Kung-Fu Master (USA).a26" size 8192 crc 5fea6e51 md5 5b92a93b23523ff16e2789b820e2a4c5 sha1 3b93a34ba2a6b7db387ea588c48d939eee5d71a1 )
 )
 
 game (
-	name "Cakewalk (Bakery) (1983) (CommaVid, Irwin Gaines) (CM-008) ~"
-	description "Cakewalk (Bakery) (1983) (CommaVid, Irwin Gaines) (CM-008) ~"
-	rom ( name "Cakewalk (Bakery) (1983) (CommaVid, Irwin Gaines) (CM-008) ~.bin" size 4096 crc 73494211 md5 undefined sha1 3f1f17cf620f462355009f5302cddffa730fa2fa )
+	name "Kyphus (USA) (Proto)"
+	description "Kyphus (USA) (Proto)"
+	rom ( name "Kyphus (USA) (Proto).a26" size 4096 crc 79bd22e2 md5 b86552198f52cfce721bafb496363099 sha1 b4b55e0b6b5d7490565b00c03361199f05fb70b8 )
 )
 
 game (
-	name "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) (PAL)"
-	description "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) (PAL)"
-	rom ( name "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) (PAL).bin" size 16384 crc c53d0352 md5 undefined sha1 def9502c5a37700ae03461b2d7cf2f73e91b4cec )
+	name "Lady In Wading (USA)"
+	description "Lady In Wading (USA)"
+	rom ( name "Lady In Wading (USA).a26" size 4096 crc f197bbcc md5 95a89d1bf767d7cc9d0d5093d579ba61 sha1 6d59dfea26b7a06545a817f03f62a59be8993587 )
 )
 
 game (
-	name "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) ~"
-	description "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) ~"
-	rom ( name "California Games (1988) (Epyx, Steven A. Baker, Peter Engelbrite) (80561-00286) ~.bin" size 16384 crc e9a3fdc3 md5 undefined sha1 609c20365c3a71ce45cb277c66ec3ce6b2c50980 )
+	name "Laser Blast (USA)"
+	description "Laser Blast (USA)"
+	rom ( name "Laser Blast (USA).a26" size 2048 crc 99365f26 md5 931b91a8ea2d39fe4dca1a23832b591a sha1 ea8ecc2f6818e1c9479f55c0a3356edcf7a4d657 )
 )
 
 game (
-	name "Canyon Bomber (208 in 1) (Unknown) (PAL)"
-	description "Canyon Bomber (208 in 1) (Unknown) (PAL)"
-	rom ( name "Canyon Bomber (208 in 1) (Unknown) (PAL).bin" size 2048 crc b2a6306d md5 undefined sha1 5d27b7e9c492112734160abbb44570f02e2aec67 )
+	name "Laser Gates (USA)"
+	description "Laser Gates (USA)"
+	rom ( name "Laser Gates (USA).a26" size 4096 crc 4b7865af md5 1fa58679d4a39052bd9db059e8cda4ad sha1 cdf55b73b4322428a001e545019eaa591d3479cf )
 )
 
 game (
-	name "Canyon Bomber (Paddle) (1979) (Atari, David Crane - Sears) (CX2607 - 6-99828, 49-75115) ~"
-	description "Canyon Bomber (Paddle) (1979) (Atari, David Crane - Sears) (CX2607 - 6-99828, 49-75115) ~"
-	rom ( name "Canyon Bomber (Paddle) (1979) (Atari, David Crane - Sears) (CX2607 - 6-99828, 49-75115) ~.bin" size 2048 crc e914b8ca md5 undefined sha1 b89443a0029e765c2716774fe2582be37650115c )
+	name "Lilly Adventure (Europe)"
+	description "Lilly Adventure (Europe)"
+	rom ( name "Lilly Adventure (Europe).a26" size 4096 crc 3544c6d6 md5 ab10f2974dee73dab4579f0cab35fca6 sha1 63f4776aa4c35d124001918b733cdb4d46dfbe9b )
 )
 
 game (
-	name "Capture (AKA Wall Break) (1983) (Goliath - Hot Shot) (83-314) (PAL)"
-	description "Capture (AKA Wall Break) (1983) (Goliath - Hot Shot) (83-314) (PAL)"
-	rom ( name "Capture (AKA Wall Break) (1983) (Goliath - Hot Shot) (83-314) (PAL).bin" size 4096 crc 727408cd md5 undefined sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
+	name "Lochjaw (USA)"
+	description "Lochjaw (USA)"
+	rom ( name "Lochjaw (USA).a26" size 4096 crc b2a2ff31 md5 86128001e69ab049937f265911ce7e8a sha1 fe208ad775cbf9523e7a99632b9f10f2c9c7aa87 )
 )
 
 game (
-	name "Care Bears (1983) (Parker Brothers, Laura Nikolich) (Prototype) ~"
-	description "Care Bears (1983) (Parker Brothers, Laura Nikolich) (Prototype) ~"
-	rom ( name "Care Bears (1983) (Parker Brothers, Laura Nikolich) (Prototype) ~.bin" size 4096 crc a14a81d1 md5 undefined sha1 48576a24a40482151f6b3c9687be442db27115a8 )
+	name "Lock 'n' Chase (USA)"
+	description "Lock 'n' Chase (USA)"
+	rom ( name "Lock 'n' Chase (USA).a26" size 4096 crc 7994bf16 md5 71464c54da46adae9447926fdbfc1abe sha1 fc3d75d46d917457aa1701bf47844817d0ba96c3 )
 )
 
 game (
-	name "Carnival (1982) (CBS Electronics, Steve 'Jessica' Kitchen) (4L1717, 4L1718, 4L1719, 4L2277) (PAL)"
-	description "Carnival (1982) (CBS Electronics, Steve 'Jessica' Kitchen) (4L1717, 4L1718, 4L1719, 4L2277) (PAL)"
-	rom ( name "Carnival (1982) (CBS Electronics, Steve 'Jessica' Kitchen) (4L1717, 4L1718, 4L1719, 4L2277) (PAL).bin" size 4096 crc fb7e75a1 md5 undefined sha1 0c7ba0272ac8684105daa28843875017644dcdf9 )
+	name "London Blitz (USA)"
+	description "London Blitz (USA)"
+	rom ( name "London Blitz (USA).a26" size 4096 crc d23cd66c md5 b4e2fd27d3180f0f4eb1065afc0d7fc9 sha1 f92b0b83db3cd840d16ee2726011f5f0144103d5 )
 )
 
 game (
-	name "Carnival (1982) (Coleco, Steve 'Jessica' Kitchen) (2468) ~"
-	description "Carnival (1982) (Coleco, Steve 'Jessica' Kitchen) (2468) ~"
-	rom ( name "Carnival (1982) (Coleco, Steve 'Jessica' Kitchen) (2468) ~.bin" size 4096 crc 7ac3c700 md5 undefined sha1 e1acf7a845b56e4b3d18192a75a81c7afa6f341a )
+	name "Looping (USA) (Proto)"
+	description "Looping (USA) (Proto)"
+	rom ( name "Looping (USA) (Proto).a26" size 8192 crc f9b23f09 md5 5babe0cad3ec99d76b0aa1d36a695d2f sha1 5e04fa0320167434dab932f6b73183daf1a50ec7 )
 )
 
 game (
-	name "Carnival (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Carnival (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Carnival (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc e6246d84 md5 undefined sha1 eca46938b98ce7d908e14c4a126560a9b453f69c )
+	name "Lord of the Rings, The - Journey to Rivendell (USA) (Proto)"
+	description "Lord of the Rings, The - Journey to Rivendell (USA) (Proto)"
+	rom ( name "Lord of the Rings, The - Journey to Rivendell (USA) (Proto).a26" size 8192 crc 59b96db3 md5 e24d7d879281ffec0641e9c3f52e505a sha1 ef02fdb94ac092247bfcd5f556e01a68c06a4832 )
 )
 
 game (
-	name "Casino - Poker Plus (Paddle) (1979) (Atari, Bob Whitehead - Sears) (CX2652 - 6-99816, 49-75151) ~"
-	description "Casino - Poker Plus (Paddle) (1979) (Atari, Bob Whitehead - Sears) (CX2652 - 6-99816, 49-75151) ~"
-	rom ( name "Casino - Poker Plus (Paddle) (1979) (Atari, Bob Whitehead - Sears) (CX2652 - 6-99816, 49-75151) ~.bin" size 4096 crc 420b8248 md5 undefined sha1 08598101e38756916613f37581ef1b61c719016f )
+	name "Lost Luggage (USA)"
+	description "Lost Luggage (USA)"
+	rom ( name "Lost Luggage (USA).a26" size 4096 crc 551bdd37 md5 7c00e7a205d3fda98eb20da7c9c50a55 sha1 e8492fe9d62750df682358fe59a4d4272655eb96 )
 )
 
 game (
-	name "Casino (Paddle) (1979) (Atari, Bob Whitehead) (CX2652, CX2652P) (PAL)"
-	description "Casino (Paddle) (1979) (Atari, Bob Whitehead) (CX2652, CX2652P) (PAL)"
-	rom ( name "Casino (Paddle) (1979) (Atari, Bob Whitehead) (CX2652, CX2652P) (PAL).bin" size 4096 crc 675c7f84 md5 undefined sha1 0a7c41b4215f792e499d20ff86fd6da9c2648d17 )
+	name "M.A.D. (USA)"
+	description "M.A.D. (USA)"
+	rom ( name "M.A.D. (USA).a26" size 4096 crc 5cb68fe5 md5 393e41ca8bdd35b52bf6256a968a9b89 sha1 d6e2b7765a9d30f91c9b2b8d0adf61ec5dc2b30a )
 )
 
 game (
-	name "Cat Trax (1983) (UA Limited) (1) [a]"
-	description "Cat Trax (1983) (UA Limited) (1) [a]"
-	rom ( name "Cat Trax (1983) (UA Limited) (1) [a].bin" size 4096 crc 78726cc2 md5 undefined sha1 ccd34827a8d960d4d9062220bfca848d762912f7 )
+	name "M.A.S.H (USA)"
+	description "M.A.S.H (USA)"
+	rom ( name "M.A.S.H (USA).a26" size 4096 crc 13e1c83d md5 835759ff95c2cdc2324d7c1e7c5fa237 sha1 dcd96913a1c840c8b57848986242eeb928bfd2ff )
 )
 
 game (
-	name "Cat Trax (1983) (UA Limited) (1) ~"
-	description "Cat Trax (1983) (UA Limited) (1) ~"
-	rom ( name "Cat Trax (1983) (UA Limited) (1) ~.bin" size 4096 crc c847e5ec md5 undefined sha1 e979de719cecab2115affd9c0552c6c596b1999a )
+	name "MagiCard (USA)"
+	description "MagiCard (USA)"
+	rom ( name "MagiCard (USA).a26" size 2048 crc 14f126c0 md5 cddabfd68363a76cd30bee4e8094c646 sha1 4c66b84ab0d25e46729bbcf23f985d59ca8520ad )
 )
 
 game (
-	name "Catch Time (AKA Plaque Attack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Catch Time (AKA Plaque Attack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Catch Time (AKA Plaque Attack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc d657269f md5 undefined sha1 37722688d27b5338d941a7a7f034a5efa7cf47c4 )
+	name "Malagai (USA)"
+	description "Malagai (USA)"
+	rom ( name "Malagai (USA).a26" size 4096 crc 65790ef9 md5 ccb5fa954fb76f09caae9a8c66462190 sha1 cdc7e65d965a7a00adda1e8bedfbe6200e349497 )
 )
 
 game (
-	name "Catch Time (AKA Plaque Attack) (Rainbow Vision - Suntek) (SS-015) (PAL)"
-	description "Catch Time (AKA Plaque Attack) (Rainbow Vision - Suntek) (SS-015) (PAL)"
-	rom ( name "Catch Time (AKA Plaque Attack) (Rainbow Vision - Suntek) (SS-015) (PAL).bin" size 4096 crc 775d3dd9 md5 undefined sha1 45119e2840eb573ca5b058b690d3980524b218c5 )
+	name "Mangia' (USA)"
+	description "Mangia' (USA)"
+	rom ( name "Mangia' (USA).a26" size 4096 crc b807b775 md5 54a1c1255ed45eb8f71414dadb1cf669 sha1 ee8f9bf7cdb55f25f4d99e1a23f4c90106fadc39 )
 )
 
 game (
-	name "Catch Time (AKA Plaque Attack) (Video Game Cartridge - Ariola) (TP-602) (PAL)"
-	description "Catch Time (AKA Plaque Attack) (Video Game Cartridge - Ariola) (TP-602) (PAL)"
-	rom ( name "Catch Time (AKA Plaque Attack) (Video Game Cartridge - Ariola) (TP-602) (PAL).bin" size 4096 crc 775d3dd9 md5 undefined sha1 45119e2840eb573ca5b058b690d3980524b218c5 )
+	name "Marauder (USA)"
+	description "Marauder (USA)"
+	rom ( name "Marauder (USA).a26" size 4096 crc f8a8b470 md5 13895ef15610af0d0f89d588f376b3fe sha1 249a11bb4872a24f22dff1027ff256c1408140c2 )
 )
 
 game (
-	name "Cathouse Blues (1982) (PlayAround - J.H.M.) (201)"
-	description "Cathouse Blues (1982) (PlayAround - J.H.M.) (201)"
-	rom ( name "Cathouse Blues (1982) (PlayAround - J.H.M.) (201).bin" size 4096 crc 3c4e3f41 md5 undefined sha1 6adf70e0b7b5dab74cf4778f56000de7605e8713 )
+	name "Marine Wars (USA)"
+	description "Marine Wars (USA)"
+	rom ( name "Marine Wars (USA).a26" size 4096 crc 4d281ee3 md5 b00e8217633e870bf39d948662a52aac sha1 dd9e94ca96c75a212f1414aa511fd99ecdadaf44 )
 )
 
 game (
-	name "Centipede (1982) (Atari - GCC) (CX2676) (PAL)"
-	description "Centipede (1982) (Atari - GCC) (CX2676) (PAL)"
-	rom ( name "Centipede (1982) (Atari - GCC) (CX2676) (PAL).bin" size 8192 crc 44d16280 md5 undefined sha1 1841ce27fc14cc2aa741d67e91f64f7924e3bf3e )
+	name "Mario Bros. (USA)"
+	description "Mario Bros. (USA)"
+	rom ( name "Mario Bros. (USA).a26" size 8192 crc 8fbf7e90 md5 e908611d99890733be31733a979c62d8 sha1 49425ff154b92ca048abb4ce5e8d485c24935035 )
 )
 
 game (
-	name "Centipede (1982) (Atari - GCC) (CX2676) (Prototype) (PAL)"
-	description "Centipede (1982) (Atari - GCC) (CX2676) (Prototype) (PAL)"
-	rom ( name "Centipede (1982) (Atari - GCC) (CX2676) (Prototype) (PAL).bin" size 8192 crc aae78b7f md5 undefined sha1 c5ff64d7593f0d0103d6bb50a150e8a87d222ef3 )
+	name "Master Builder (USA)"
+	description "Master Builder (USA)"
+	rom ( name "Master Builder (USA).a26" size 4096 crc dd196d6c md5 ae4be3a36b285c1a1dff202157e2155d sha1 fbe7a78764407743b43a91136903ede65306f4e7 )
 )
 
 game (
-	name "Centipede (1982) (Atari - GCC) (CX2676) ~"
-	description "Centipede (1982) (Atari - GCC) (CX2676) ~"
-	rom ( name "Centipede (1982) (Atari - GCC) (CX2676) ~.bin" size 8192 crc 77396102 md5 undefined sha1 0b5914bc1526a9beaf54d7fd11408175cd8fcc72 )
+	name "Masters of the Universe - The Power of He-Man (USA)"
+	description "Masters of the Universe - The Power of He-Man (USA)"
+	rom ( name "Masters of the Universe - The Power of He-Man (USA).a26" size 16384 crc 0603e177 md5 3b76242691730b2dd22ec0ceab351bc6 sha1 6db8fa65755db86438ada3d90f4c39cc288dcf84 )
 )
 
 game (
-	name "Challenge (208 in 1) (Unknown) (PAL)"
-	description "Challenge (208 in 1) (Unknown) (PAL)"
-	rom ( name "Challenge (208 in 1) (Unknown) (PAL).bin" size 4096 crc 96b4c8b1 md5 undefined sha1 bc783303f5b05fd71c418e2cb4cf07e0ba2fd00f )
+	name "Math Gran Prix (USA)"
+	description "Math Gran Prix (USA)"
+	rom ( name "Math Gran Prix (USA).a26" size 4096 crc ccc90c98 md5 470878b9917ea0348d64b5750af149aa sha1 18fac606400c08a0469aebd9b071ae3aec2a3cf2 )
 )
 
 game (
-	name "Challenge (HES) (PAL)"
-	description "Challenge (HES) (PAL)"
-	rom ( name "Challenge (HES) (PAL).bin" size 8192 crc 38902fbc md5 undefined sha1 1191ed3cac491bab487ab3c3b52ecf56bd817b58 )
+	name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA)"
+	description "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA)"
+	rom ( name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA).a26" size 4096 crc 0098e428 md5 f825c538481f9a7a46d1e9bc06200aaf sha1 aba25089d87cd6fee8d206b880baa5d938aae255 )
 )
 
 game (
-	name "Challenge (Unknown)"
-	description "Challenge (Unknown)"
-	rom ( name "Challenge (Unknown).bin" size 4096 crc 086a0cb2 md5 undefined sha1 e81b5e49cfbb283edba2c8f21f31a8148d8645a1 )
+	name "McDonald's - Golden Arches Adventure (USA) (Proto)"
+	description "McDonald's - Golden Arches Adventure (USA) (Proto)"
+	rom ( name "McDonald's - Golden Arches Adventure (USA) (Proto).a26" size 4096 crc add0115d md5 35b43b54e83403bb3d71f519739a9549 sha1 0103b35b1aef6b10c1c0a44b213ebf30af708df6 )
 )
 
 game (
-	name "Challenge (Zellers) ~"
-	description "Challenge (Zellers) ~"
-	rom ( name "Challenge (Zellers) ~.bin" size 4096 crc 1f19aa5d md5 undefined sha1 b2b1bd165b3c10cde5316ed0f9f05a509aac828d )
+	name "Mega Force (USA)"
+	description "Mega Force (USA)"
+	rom ( name "Mega Force (USA).a26" size 4096 crc 9e6ae8c2 md5 daeb54957875c50198a7e616f9cc8144 sha1 0ae118373c7bda97da2f8d9c113e1e09ea7e49e1 )
 )
 
 game (
-	name "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) (PAL)"
-	description "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) (PAL)"
-	rom ( name "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) (PAL).bin" size 4096 crc 44ef0404 md5 undefined sha1 15ed5f1533256816980e0f315d1d1a5a43b3d5aa )
+	name "MegaBoy (USA)"
+	description "MegaBoy (USA)"
+	rom ( name "MegaBoy (USA).a26" size 65536 crc 26914ce0 md5 b65d4a38d6047735824ee99684f3515e sha1 46977baf0e1ee6124b524258879c46f80d624fae )
 )
 
 game (
-	name "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) ~"
-	description "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) ~"
-	rom ( name "Challenge of.... Nexar, The (1982) (Spectravision, Spectravideo, David Lubar) (SA-206) ~.bin" size 4096 crc 74cc37d4 md5 undefined sha1 ac9b0c62ba0ca7a975d08fabbbc7c7448ecdf18d )
+	name "MegaMania - A Space Nightmare (USA)"
+	description "MegaMania - A Space Nightmare (USA)"
+	rom ( name "MegaMania - A Space Nightmare (USA).a26" size 4096 crc 33edc33e md5 318a9d6dda791268df92d72679914ac3 sha1 9c5748b38661dbadcbc9cd1ec6a6b0c550b0e3da )
 )
 
 game (
-	name "Challenge of.... Nexar, The (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Challenge of.... Nexar, The (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Challenge of.... Nexar, The (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 57b3d123 md5 undefined sha1 4a6bbd96f2c805cda13238486c828379257c5a44 )
+	name "Meltdown (USA) (Proto)"
+	description "Meltdown (USA) (Proto)"
+	rom ( name "Meltdown (USA) (Proto).a26" size 4096 crc 7955b3be md5 96e798995af6ed9d8601166d4350f276 sha1 debb1572eadb20beb0e4cd2df8396def8eb02098 )
 )
 
 game (
-	name "Challenge of.... Nexar, The (Unknown) (PAL)"
-	description "Challenge of.... Nexar, The (Unknown) (PAL)"
-	rom ( name "Challenge of.... Nexar, The (Unknown) (PAL).bin" size 4096 crc ef3c90e2 md5 undefined sha1 c7c9ca986e76b5222ee976a7603d4ccf870014fc )
+	name "Midnight Magic (USA)"
+	description "Midnight Magic (USA)"
+	rom ( name "Midnight Magic (USA).a26" size 16384 crc 5c5447b9 md5 f1554569321dc933c87981cf5c239c43 sha1 7fcf95459ea597a332bf5b6f56c8f891307b45b4 )
 )
 
 game (
-	name "Championship Soccer - Soccer (1980) (Atari, Steve Wright - Sears) (CX2616 - 49-75155) ~"
-	description "Championship Soccer - Soccer (1980) (Atari, Steve Wright - Sears) (CX2616 - 49-75155) ~"
-	rom ( name "Championship Soccer - Soccer (1980) (Atari, Steve Wright - Sears) (CX2616 - 49-75155) ~.bin" size 4096 crc 3f59bb60 md5 undefined sha1 832283530f5dee332f29cf8c4854dd554f2030a0 )
+	name "Millipede (USA)"
+	description "Millipede (USA)"
+	rom ( name "Millipede (USA).a26" size 16384 crc ccc82dd0 md5 3c57748c8286cf9e821ecd064f21aaa9 sha1 0616f0dde6d697816dda92ed9e5a4c3d77a39408 )
 )
 
 game (
-	name "Championship Soccer (1980) (Atari, Steve Wright) (CX2616P) (PAL)"
-	description "Championship Soccer (1980) (Atari, Steve Wright) (CX2616P) (PAL)"
-	rom ( name "Championship Soccer (1980) (Atari, Steve Wright) (CX2616P) (PAL).bin" size 4096 crc be28f033 md5 undefined sha1 c887ceedc2216f1b403df8c449c89b08334ff2f6 )
+	name "Mind Maze (USA)"
+	description "Mind Maze (USA)"
+	rom ( name "Mind Maze (USA).a26" size 8192 crc 7cc6c991 md5 0e224ea74310da4e7e2103400eb1b4bf sha1 3844b79dbec5ffc99eaa2c9f5fa4f0a26c08c06d )
 )
 
 game (
-	name "Chase the Chuckwagon (1983) (Spectravideo - Video Games Industries Corporation, Mike Schwartz - Ralston Purina) ~"
-	description "Chase the Chuckwagon (1983) (Spectravideo - Video Games Industries Corporation, Mike Schwartz - Ralston Purina) ~"
-	rom ( name "Chase the Chuckwagon (1983) (Spectravideo - Video Games Industries Corporation, Mike Schwartz - Ralston Purina) ~.bin" size 4096 crc 63e4fc7f md5 undefined sha1 872b2f9aa7edbcbb2368de0db3696c90998ff016 )
+	name "Mind Maze (USA) (Proto)"
+	description "Mind Maze (USA) (Proto)"
+	rom ( name "Mind Maze (USA) (Proto).a26" size 8192 crc 7cc6c991 md5 0e224ea74310da4e7e2103400eb1b4bf sha1 3844b79dbec5ffc99eaa2c9f5fa4f0a26c08c06d )
 )
 
 game (
-	name "Checkers (1980) (Activision, Alan Miller) (AG-003) ~"
-	description "Checkers (1980) (Activision, Alan Miller) (AG-003) ~"
-	rom ( name "Checkers (1980) (Activision, Alan Miller) (AG-003) ~.bin" size 2048 crc e74f1b59 md5 undefined sha1 39b5bb27a6c4cb6532bd9d4cc520415c59dac653 )
+	name "Miner 2049er - Starring Bounty Bob (USA)"
+	description "Miner 2049er - Starring Bounty Bob (USA)"
+	rom ( name "Miner 2049er - Starring Bounty Bob (USA).a26" size 8192 crc 19f9ef1c md5 3b040ed7d1ef8acb4efdeebebdaa2052 sha1 5470afe5961f9fdd2f6388f53f682f3264a95ce9 )
 )
 
 game (
-	name "Checkers (208 in 1) (Unknown) (PAL)"
-	description "Checkers (208 in 1) (Unknown) (PAL)"
-	rom ( name "Checkers (208 in 1) (Unknown) (PAL).bin" size 2048 crc d3f3caeb md5 undefined sha1 d099cbbc72a9ccc4f084ece09fabf2071804fe0f )
+	name "Miner 2049er Volume II (USA)"
+	description "Miner 2049er Volume II (USA)"
+	rom ( name "Miner 2049er Volume II (USA).a26" size 8192 crc 71e814e9 md5 2a1b454a5c3832b0240111e7fd73de8a sha1 575faad92cb38944b9882ffb69073e0af9460aba )
 )
 
 game (
-	name "Checkers (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Checkers (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Checkers (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc ca3d8c74 md5 undefined sha1 9b9a9b6b6d3461485c31d80a830948ce70ea7ff1 )
+	name "Mines of Minos (USA)"
+	description "Mines of Minos (USA)"
+	rom ( name "Mines of Minos (USA).a26" size 4096 crc c799e944 md5 4543b7691914dfd69c3755a5287a95e1 sha1 34773998d7740e1e8c206b3b22a19e282ca132e1 )
 )
 
 game (
-	name "Checkers (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL)"
-	description "Checkers (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL)"
-	rom ( name "Checkers (32 in 1) (1988) (Atari, Carol Shaw) (CX26163P) (PAL).bin" size 2048 crc 6701264d md5 undefined sha1 0c0cd0f0f768afcef0e7ce32a8640c6914d9ff99 )
+	name "Miniature Golf - Arcade Golf (USA)"
+	description "Miniature Golf - Arcade Golf (USA)"
+	rom ( name "Miniature Golf - Arcade Golf (USA).a26" size 2048 crc 28562315 md5 df62a658496ac98a3aa4a6ee5719c251 sha1 be24b42e3744a81fb217c86c4ed5ce51bff28e65 )
 )
 
 game (
-	name "Cheese (Dragonfire Beta) (05-21-1982) (Imagic, Bob Smith) (720020-1A, IA3611) (Prototype)"
-	description "Cheese (Dragonfire Beta) (05-21-1982) (Imagic, Bob Smith) (720020-1A, IA3611) (Prototype)"
-	rom ( name "Cheese (Dragonfire Beta) (05-21-1982) (Imagic, Bob Smith) (720020-1A, IA3611) (Prototype).bin" size 4096 crc 6bf197c0 md5 undefined sha1 1bdd2d9cd673def75afdeb5aee2838c4351b8e8b )
+	name "Miss Piggy's Wedding (USA) (Proto)"
+	description "Miss Piggy's Wedding (USA) (Proto)"
+	rom ( name "Miss Piggy's Wedding (USA) (Proto).a26" size 8192 crc b1497e10 md5 4181087389a79c7f59611fb51c263137 sha1 f721d1f750e19b9e1788eed5e3872923ab46a91d )
 )
 
 game (
-	name "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) (PAL)"
-	description "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) (PAL)"
-	rom ( name "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) (PAL).bin" size 4096 crc 7690b0c3 md5 undefined sha1 faac85c0c61269660237978964a4cf57887cccfc )
+	name "Missile Command (USA)"
+	description "Missile Command (USA)"
+	rom ( name "Missile Command (USA).a26" size 4096 crc cff14904 md5 3a2e2d0c6892aa14544083dfb7762782 sha1 faa06bb0643dbf556b13591c31917d277a83110b )
 )
 
 game (
-	name "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) ~"
-	description "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) ~"
-	rom ( name "China Syndrome (1982) (Spectravision, Spectravideo) (SA-205) ~.bin" size 4096 crc a714e79c md5 undefined sha1 0b1bb76769ae3f8b4936f0f95f4941d276791bde )
+	name "Missile Control (Europe)"
+	description "Missile Control (Europe)"
+	rom ( name "Missile Control (Europe).a26" size 4096 crc ac80976b md5 cb24210dc86d92df97b38cf2a51782da sha1 224e7a310afdb91c6915743e72b7b53b38eb5754 )
 )
 
 game (
-	name "Chopper Command - Captain Helicopter (1982) (Activision, Bob Whitehead - Ariola) (EAX-015, EAX-015-04I - 711 015-725) (PAL)"
-	description "Chopper Command - Captain Helicopter (1982) (Activision, Bob Whitehead - Ariola) (EAX-015, EAX-015-04I - 711 015-725) (PAL)"
-	rom ( name "Chopper Command - Captain Helicopter (1982) (Activision, Bob Whitehead - Ariola) (EAX-015, EAX-015-04I - 711 015-725) (PAL).bin" size 4096 crc 6be865a5 md5 undefined sha1 a47bf3c35b47729330d3e1b0a1e0b5deec6ba213 )
+	name "Mission 3,000 A.D. (Europe)"
+	description "Mission 3,000 A.D. (Europe)"
+	rom ( name "Mission 3,000 A.D. (Europe).a26" size 4096 crc 55b140fe md5 6efe876168e2d45d4719b6a61355e5fe sha1 999dc390a7a3f7be7c88022506c70bd4208b26d8 )
 )
 
 game (
-	name "Chopper Command (1982) (Activision, Bob Whitehead) (AX-015, AX-015-04) ~"
-	description "Chopper Command (1982) (Activision, Bob Whitehead) (AX-015, AX-015-04) ~"
-	rom ( name "Chopper Command (1982) (Activision, Bob Whitehead) (AX-015, AX-015-04) ~.bin" size 4096 crc 1dfa64df md5 undefined sha1 51a53bbfdbcc22925515ae0af79df434df6ee68a )
+	name "Mission Survive (Europe)"
+	description "Mission Survive (Europe)"
+	rom ( name "Mission Survive (Europe).a26" size 4096 crc b70f52dc md5 cf9069f92a43f719974ee712c50cd932 sha1 93520821ce406a7aa6cc30472f76bca543805fd4 )
 )
 
 game (
-	name "Chopper Command (1983) (CCE) (C-827)"
-	description "Chopper Command (1983) (CCE) (C-827)"
-	rom ( name "Chopper Command (1983) (CCE) (C-827).bin" size 4096 crc ad1cad42 md5 undefined sha1 8407a8be1f95c55399457604cae2fc11a525d947 )
+	name "Mogul Maniac (USA)"
+	description "Mogul Maniac (USA)"
+	rom ( name "Mogul Maniac (USA).a26" size 4096 crc 50afe04b md5 7af40c1485ce9f29b1a7b069a2eb04a7 sha1 0b74a90a22a7a16f9c2131fabd76b7742de0473e )
 )
 
 game (
-	name "Chopper Command (1983) (CCE) (C-827) [a]"
-	description "Chopper Command (1983) (CCE) (C-827) [a]"
-	rom ( name "Chopper Command (1983) (CCE) (C-827) [a].bin" size 4096 crc e0437d1f md5 undefined sha1 804e3acaec15650b6ca8d2966c5bfd7a655a272e )
+	name "Monster Cise (USA) (Proto)"
+	description "Monster Cise (USA) (Proto)"
+	rom ( name "Monster Cise (USA) (Proto).a26" size 8192 crc ab0f6091 md5 6913c90002636c1487538d4004f7cac2 sha1 81a4d56820b1e00130e368a3532c409929aff5fb )
 )
 
 game (
-	name "Chopper Command (1983) (Digitel)"
-	description "Chopper Command (1983) (Digitel)"
-	rom ( name "Chopper Command (1983) (Digitel).bin" size 4096 crc e065820a md5 undefined sha1 fc97643a90447adc904da5e794c3614683f9fc52 )
+	name "Montezuma's Revenge - Featuring Panama Joe (USA)"
+	description "Montezuma's Revenge - Featuring Panama Joe (USA)"
+	rom ( name "Montezuma's Revenge - Featuring Panama Joe (USA).a26" size 8192 crc e680a1c9 md5 3347a6dd59049b15a38394aa2dafa585 sha1 7dfeb1a8ec863c1e0f297113a1cc4185c215e81c )
 )
 
 game (
-	name "Chopper Command (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Chopper Command (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Chopper Command (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 102f3178 md5 undefined sha1 529634d1eaf0e13c3e807f052a0f117e6d8306dc )
+	name "Moon Patrol (USA)"
+	description "Moon Patrol (USA)"
+	rom ( name "Moon Patrol (USA).a26" size 8192 crc d641ef2d md5 515046e3061b7b18aa3a551c3ae12673 sha1 dce778f397a325113f035722b7769492645d69eb )
 )
 
 game (
-	name "Chopper Command (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Chopper Command (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Chopper Command (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc 9d6a504a md5 undefined sha1 738fb28bc043aa1b4786de022f30ccd7f8bcafc6 )
+	name "Moonsweeper (USA)"
+	description "Moonsweeper (USA)"
+	rom ( name "Moonsweeper (USA).a26" size 8192 crc 450b5c57 md5 203abb713c00b0884206dcc656caa48f sha1 05ab04dc30eae31b98ebf6f43fec6793a53e0a23 )
 )
 
 game (
-	name "Chopper Command (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Chopper Command (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Chopper Command (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc a75d1930 md5 undefined sha1 676b8e9991a0998cba856cdbd8b3caf360a0522c )
+	name "Motocross (USA)"
+	description "Motocross (USA)"
+	rom ( name "Motocross (USA).a26" size 4096 crc 36feb44c md5 a20b7abbcdf90fbc29ac0fafa195bd12 sha1 bcafaa60338cf55ac72a940d04a5ad72003f7cf0 )
 )
 
 game (
-	name "Chopper Command (SuperVision) (405, 427, 806, 808, 813, 816) (PAL)"
-	description "Chopper Command (SuperVision) (405, 427, 806, 808, 813, 816) (PAL)"
-	rom ( name "Chopper Command (SuperVision) (405, 427, 806, 808, 813, 816) (PAL).bin" size 4096 crc cdeaf039 md5 undefined sha1 0a1ca082277c4849f5f3dee39254c0d71973213f )
+	name "Motocross Racer (USA)"
+	description "Motocross Racer (USA)"
+	rom ( name "Motocross Racer (USA).a26" size 8192 crc 0d1bc1cb md5 de0173ed6be9de6fd049803811e5f1a8 sha1 c4d495d42ea5bd354af04e1f2b68cce0fb43175d )
 )
 
 game (
-	name "Chuck Norris Superkicks (1983) (Xonox - K-Tel Software, Robert Weatherby) (6230, 06002, 06003, 99003) ~"
-	description "Chuck Norris Superkicks (1983) (Xonox - K-Tel Software, Robert Weatherby) (6230, 06002, 06003, 99003) ~"
-	rom ( name "Chuck Norris Superkicks (1983) (Xonox - K-Tel Software, Robert Weatherby) (6230, 06002, 06003, 99003) ~.bin" size 8192 crc 96210c6c md5 undefined sha1 1637b6b9cd1a918339ec054cf95b924e7ce4789a )
+	name "MotoRodeo (USA)"
+	description "MotoRodeo (USA)"
+	rom ( name "MotoRodeo (USA).a26" size 16384 crc 89998e29 md5 378a62af6e9c12a760795ff4fc939656 sha1 dea1506ba107b9544cd9b179f83bc61ced9101ac )
 )
 
 game (
-	name "Circus (AKA Circus Atari) (Zellers)"
-	description "Circus (AKA Circus Atari) (Zellers)"
-	rom ( name "Circus (AKA Circus Atari) (Zellers).bin" size 4096 crc a4b9a830 md5 undefined sha1 6821c334d9cb85da17fa2a960636620966b91f96 )
+	name "Mountain King (USA)"
+	description "Mountain King (USA)"
+	rom ( name "Mountain King (USA).a26" size 12288 crc ed778991 md5 db4eb44bc5d652d9192451383d3249fc sha1 0a84b0a6bd0e79f5fa0b1bb9112160cb564ab836 )
 )
 
 game (
-	name "Circus Atari - Circus (Paddle) (1980) (Atari, Mike Lorenzen - Sears) (CX2630 - 49-75122) ~"
-	description "Circus Atari - Circus (Paddle) (1980) (Atari, Mike Lorenzen - Sears) (CX2630 - 49-75122) ~"
-	rom ( name "Circus Atari - Circus (Paddle) (1980) (Atari, Mike Lorenzen - Sears) (CX2630 - 49-75122) ~.bin" size 4096 crc d2a330a3 md5 undefined sha1 8a91ecdbd8bf9d412da051c3422abb004eab8603 )
+	name "Mouse Trap (USA)"
+	description "Mouse Trap (USA)"
+	rom ( name "Mouse Trap (USA).a26" size 4096 crc 9ddd45d3 md5 5678ebaa09ca3b699516dba4671643ed sha1 cf6347dedcfec213c28dd92111ec6f41e74b6f64 )
 )
 
 game (
-	name "Circus Atari (Paddle) (1980) (Atari, Mike Lorenzen) (CX2630, CX2630P) (PAL)"
-	description "Circus Atari (Paddle) (1980) (Atari, Mike Lorenzen) (CX2630, CX2630P) (PAL)"
-	rom ( name "Circus Atari (Paddle) (1980) (Atari, Mike Lorenzen) (CX2630, CX2630P) (PAL).bin" size 4096 crc 95c9fe2b md5 undefined sha1 342cabe30592db8dcf692994666e40fb176c8d86 )
+	name "Mr. Do! (USA)"
+	description "Mr. Do! (USA)"
+	rom ( name "Mr. Do! (USA).a26" size 8192 crc 860a47a1 md5 0164f26f6b38a34208cd4a2d0212afc3 sha1 e4c912199779bba25f1b9950007f14dca3d19c84 )
 )
 
 game (
-	name "Circus Atari (Unknown)"
-	description "Circus Atari (Unknown)"
-	rom ( name "Circus Atari (Unknown).bin" size 4096 crc a280a451 md5 undefined sha1 0461f11aec13c0610612be9337fc2d2d4cbe6cab )
+	name "Mr. Do!'s Castle (USA)"
+	description "Mr. Do!'s Castle (USA)"
+	rom ( name "Mr. Do!'s Castle (USA).a26" size 8192 crc 2cbbf3fe md5 97184b263722748757cfdc41107ca5c0 sha1 2d1c99a0159f9bf5fe727d34f46b07d93bc8341c )
 )
 
 game (
-	name "Circus Atari (Unknown) (PAL)"
-	description "Circus Atari (Unknown) (PAL)"
-	rom ( name "Circus Atari (Unknown) (PAL).bin" size 4096 crc 9dc94535 md5 undefined sha1 2883df530b0832e9d84ade740ab95fbc7e3a7bac )
+	name "Mr. Postman (Europe)"
+	description "Mr. Postman (Europe)"
+	rom ( name "Mr. Postman (Europe).a26" size 4096 crc 16980cb8 md5 603c7a0d12c935df5810f400f3971b67 sha1 f9e1491d4cfea97822949349559a41d87a235d27 )
 )
 
 game (
-	name "Coco Nuts (1982) (Telesys, Jim Rupp, Jack Woodman) (1001) ~"
-	description "Coco Nuts (1982) (Telesys, Jim Rupp, Jack Woodman) (1001) ~"
-	rom ( name "Coco Nuts (1982) (Telesys, Jim Rupp, Jack Woodman) (1001) ~.bin" size 4096 crc b3e44e5c md5 undefined sha1 3f56d1a376702b64b3992b2d5652a3842c56ffad )
+	name "Ms. Pac-Man (USA)"
+	description "Ms. Pac-Man (USA)"
+	rom ( name "Ms. Pac-Man (USA).a26" size 8192 crc b2d08fc9 md5 87e79cd41ce136fd4f72cc6e2c161bee sha1 62b933cdd8844bb1816ce57889203954fe782603 )
 )
 
 game (
-	name "Codebreaker - Code Breaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2643 - 6-99815) ~"
-	description "Codebreaker - Code Breaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2643 - 6-99815) ~"
-	rom ( name "Codebreaker - Code Breaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan - Sears) (CX2643 - 6-99815) ~.bin" size 2048 crc 947edb18 md5 undefined sha1 137bd3d3f36e2549c6e1cc3a60f2a7574f767775 )
+	name "Music Machine (USA)"
+	description "Music Machine (USA)"
+	rom ( name "Music Machine (USA).a26" size 4096 crc bd133d59 md5 65b106eba3e45f3dab72ea907f39f8b4 sha1 5a641caa2ab3c7c0cd5deb027acbc58efccf8d6a )
 )
 
 game (
-	name "Codebreaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2643) (PAL)"
-	description "Codebreaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2643) (PAL)"
-	rom ( name "Codebreaker (Numbers) (Keyboard Controller) (1978) (Atari, Larry Kaplan) (CX2643) (PAL).bin" size 2048 crc b1cb7cdc md5 undefined sha1 0252bb61f8ca0462cc57a273d575c4bcdb5a95f2 )
+	name "Music Machine, The (USA)"
+	description "Music Machine, The (USA)"
+	rom ( name "Music Machine, The (USA).a26" size 4096 crc bd133d59 md5 65b106eba3e45f3dab72ea907f39f8b4 sha1 5a641caa2ab3c7c0cd5deb027acbc58efccf8d6a )
 )
 
 game (
-	name "Color Bar Generator (1984) (Video Soft, Jerry Lawson, Dan McElroy) (VS1008) ~"
-	description "Color Bar Generator (1984) (Video Soft, Jerry Lawson, Dan McElroy) (VS1008) ~"
-	rom ( name "Color Bar Generator (1984) (Video Soft, Jerry Lawson, Dan McElroy) (VS1008) ~.bin" size 4096 crc 19b52142 md5 undefined sha1 53c324ae736afa92a83d619b04e4fe72182281a6 )
+	name "My Golf (Europe)"
+	description "My Golf (Europe)"
+	rom ( name "My Golf (Europe).a26" size 8192 crc 0d2cbd53 md5 dfad86dd85a11c80259f3ddb6151f48f sha1 b2df23b1bf6df9d253ad0705592d3fce352a837b )
 )
 
 game (
-	name "Colors (1980) (Atari) (Prototype) (PAL) ~"
-	description "Colors (1980) (Atari) (Prototype) (PAL) ~"
-	rom ( name "Colors (1980) (Atari) (Prototype) (PAL) ~.bin" size 2048 crc 4d8a1f6b md5 undefined sha1 33db3151c8ad794eeb7bdf23c415b923f9839a93 )
+	name "Mysterious Thief, A (USA) (Proto)"
+	description "Mysterious Thief, A (USA) (Proto)"
+	rom ( name "Mysterious Thief, A (USA) (Proto).a26" size 4096 crc 8755c57c md5 fcbbd0a407d3ff7bf857b8a399280ea1 sha1 0d1c963ea040c60b296a26c46faaad472890499f )
 )
 
 game (
-	name "Comando Suicida (AKA Chopper Command) (Dismac)"
-	description "Comando Suicida (AKA Chopper Command) (Dismac)"
-	rom ( name "Comando Suicida (AKA Chopper Command) (Dismac).bin" size 4096 crc a56d1a00 md5 undefined sha1 f45fd00e9dde592e3729aef288ab72bca0958c24 )
+	name "Name This Game (USA)"
+	description "Name This Game (USA)"
+	rom ( name "Name This Game (USA).a26" size 4096 crc a86e1ad8 md5 36306070f0c90a72461551a7a4f3a209 sha1 2b4a0535ca83b963906eb0a5d60ce0e21f07905d )
 )
 
 game (
-	name "Combat - Tank-Plus (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner - Sears) (CX2601 - 99801, 6-99801, 49-75101, 49-75124) ~"
-	description "Combat - Tank-Plus (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner - Sears) (CX2601 - 99801, 6-99801, 49-75101, 49-75124) ~"
-	rom ( name "Combat - Tank-Plus (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner - Sears) (CX2601 - 99801, 6-99801, 49-75101, 49-75124) ~.bin" size 2048 crc 9c326a97 md5 undefined sha1 ce7580059e8b41cb4a1e734c9b35ce3774bf777a )
+	name "Night Driver (USA)"
+	description "Night Driver (USA)"
+	rom ( name "Night Driver (USA).a26" size 2048 crc 600d8a96 md5 392f00fd1a074a3c15bc96b0a57d52a1 sha1 372771aeb4e2fb2cd1dead5497e3821e4236d5fc )
 )
 
 game (
-	name "Combat (32 in 1) (1988) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX26163P) (PAL)"
-	description "Combat (32 in 1) (1988) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX26163P) (PAL)"
-	rom ( name "Combat (32 in 1) (1988) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX26163P) (PAL).bin" size 2048 crc a52139a8 md5 undefined sha1 5a078ce2087a07bc3c35f8479f0570bfb4ed9c8d )
+	name "Nightmare (Europe)"
+	description "Nightmare (Europe)"
+	rom ( name "Nightmare (Europe).a26" size 4096 crc b733f921 md5 ead60451c28635b55ca8fea198444e16 sha1 2a1ee3584c3df131a97d6291c93de46b3160af54 )
 )
 
 game (
-	name "Combat (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX2601, CX2601P) (PAL)"
-	description "Combat (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX2601, CX2601P) (PAL)"
-	rom ( name "Combat (Tank) (1977) (Atari, Joe Decuir, Steve Mayer, Larry Wagner) (CX2601, CX2601P) (PAL).bin" size 2048 crc 7bee5800 md5 undefined sha1 61c8a4b011b2cc31d1faa304a6b76acbd4cad25c )
+	name "No Escape! (USA)"
+	description "No Escape! (USA)"
+	rom ( name "No Escape! (USA).a26" size 4096 crc 8941caea md5 b6d52a0cf53ad4216feb04147301f87d sha1 e2e8750b8856dd44d914c43a7d277188cc148e5c )
 )
 
 game (
-	name "Combat Two (Super Combat) (1982) (Atari - GCC) (CX2663) (Prototype) ~"
-	description "Combat Two (Super Combat) (1982) (Atari - GCC) (CX2663) (Prototype) ~"
-	rom ( name "Combat Two (Super Combat) (1982) (Atari - GCC) (CX2663) (Prototype) ~.bin" size 8192 crc 8cabe1fd md5 undefined sha1 66014de1f8e9f39483ee3f97ca0d97d026ffc3bb )
+	name "Nuts (Europe)"
+	description "Nuts (Europe)"
+	rom ( name "Nuts (Europe).a26" size 4096 crc d76d5f14 md5 e3c35eac234537396a865d23bafb1c84 sha1 d3c0f973f2b31c14dc3ad2d91fe8bbbb42bce269 )
 )
 
 game (
-	name "Commando (1988) (Activision, Mike Riedel) (AK-043-04) [different logo] ~"
-	description "Commando (1988) (Activision, Mike Riedel) (AK-043-04) [different logo] ~"
-	rom ( name "Commando (1988) (Activision, Mike Riedel) (AK-043-04) [different logo] ~.bin" size 16384 crc 2c698b31 md5 undefined sha1 e47de0536a874a500bd6586eb6ec819e14b47f12 )
+	name "Obelix (USA)"
+	description "Obelix (USA)"
+	rom ( name "Obelix (USA).a26" size 8192 crc 29a51ea4 md5 133a4234512e8c4e9e8c5651469d4a09 sha1 9155f7fa57480a12a03c6a84213cc5dc7be739b5 )
 )
 
 game (
-	name "Commando (1988) (Activision, Mike Riedel) (AK-043-04) ~"
-	description "Commando (1988) (Activision, Mike Riedel) (AK-043-04) ~"
-	rom ( name "Commando (1988) (Activision, Mike Riedel) (AK-043-04) ~.bin" size 16384 crc 8d3025dc md5 undefined sha1 68a7cb3ff847cd987a551f3dd9cda5f90ce0a3bf )
+	name "Off the Wall (USA)"
+	description "Off the Wall (USA)"
+	rom ( name "Off the Wall (USA).a26" size 16384 crc a09779ea md5 98f63949e656ff309cefa672146dc1b8 sha1 3dcfe93399044148561586056288c6f8e5c96e2b )
 )
 
 game (
-	name "Commando (1988) (Activision, Mike Riedel) (EAK-043-04I) (PAL)"
-	description "Commando (1988) (Activision, Mike Riedel) (EAK-043-04I) (PAL)"
-	rom ( name "Commando (1988) (Activision, Mike Riedel) (EAK-043-04I) (PAL).bin" size 16384 crc b898762d md5 undefined sha1 de4a12036650577b544c2fc091b981f18f771e34 )
+	name "Off Your Rocker (USA) (Proto)"
+	description "Off Your Rocker (USA) (Proto)"
+	rom ( name "Off Your Rocker (USA) (Proto).a26" size 4096 crc 066ec995 md5 b6166f15720fdf192932f1f76df5b65d sha1 7ad74a7c36318f1304f5dc454401cf257fa60d7a )
 )
 
 game (
-	name "Commando Raid (1982) (U.S. Games Corporation, Wes Trager, Henry Will IV) (VC1004) ~"
-	description "Commando Raid (1982) (U.S. Games Corporation, Wes Trager, Henry Will IV) (VC1004) ~"
-	rom ( name "Commando Raid (1982) (U.S. Games Corporation, Wes Trager, Henry Will IV) (VC1004) ~.bin" size 4096 crc e46583e6 md5 undefined sha1 8dad05085657e95e567f47836502be515b42f66b )
+	name "Official Frogger, The (USA)"
+	description "Official Frogger, The (USA)"
+	rom ( name "Official Frogger, The (USA).a26" size 8448 crc 1228e48c md5 c73ae5ba5a0a3f3ac77f0a9e14770e73 sha1 f84c15579d22f2536e94f1679642b9dc73b6f2fe )
 )
 
 game (
-	name "Commando Raid (208 in 1) (Unknown) (PAL)"
-	description "Commando Raid (208 in 1) (Unknown) (PAL)"
-	rom ( name "Commando Raid (208 in 1) (Unknown) (PAL).bin" size 4096 crc 405779b8 md5 undefined sha1 8f63c5010008551f8e5fe5ada414f0c2bc44e5e5 )
+	name "Oink! (USA)"
+	description "Oink! (USA)"
+	rom ( name "Oink! (USA).a26" size 4096 crc 86f99b5e md5 c9c25fc536de9a7cdc5b9a916c459110 sha1 ea674cf2c90d407b8f8b96eac692690b602b73f9 )
 )
 
 game (
-	name "Commando Raid (Unknown) (PAL)"
-	description "Commando Raid (Unknown) (PAL)"
-	rom ( name "Commando Raid (Unknown) (PAL).bin" size 4096 crc ec85ec9d md5 undefined sha1 af7fa7741183a43f6aebb033c35b8be51f214409 )
+	name "Omega Race (USA)"
+	description "Omega Race (USA)"
+	rom ( name "Omega Race (USA).a26" size 12288 crc e9876116 md5 9947f1ebabb56fd075a96c6d37351efa sha1 dcaab259e7617c7ac7d349893451896a9ca0e292 )
 )
 
 game (
-	name "Communist Mutants from Space (Galactic Egg) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101) ~"
-	description "Communist Mutants from Space (Galactic Egg) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101) ~"
-	rom ( name "Communist Mutants from Space (Galactic Egg) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101) ~.bin" size 8448 crc d64ec816 md5 undefined sha1 9a113bacc576d1d1f80a26622359c49df97b16bc )
+	name "Open Sesame (Europe)"
+	description "Open Sesame (Europe)"
+	rom ( name "Open Sesame (Europe).a26" size 4096 crc d01b5a1f md5 8786f4609a66fbea2cd9aa48ca7aa11c sha1 cc4d66da0182819a8067dbc6b73ff1bc33fc165b )
 )
 
 game (
-	name "Communist Mutants from Space (Galactic Egg) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL)"
-	description "Communist Mutants from Space (Galactic Egg) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL)"
-	rom ( name "Communist Mutants from Space (Galactic Egg) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL).bin" size 8448 crc e8c4dc94 md5 undefined sha1 9ab6e90c2a41684f46592b8e2b71fd19e540b055 )
+	name "Oscar's Trash Race (USA)"
+	description "Oscar's Trash Race (USA)"
+	rom ( name "Oscar's Trash Race (USA).a26" size 8192 crc 34721d7b md5 fa1b060fd8e0bca0c2a097dcffce93d3 sha1 7905709fcc85cbcfc28ca2ed543ffa737a5483ae )
 )
 
 game (
-	name "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101)"
-	description "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101)"
-	rom ( name "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Arcadia Corporation, Stephen Harland Landrum) (2) (AR-4101).bin" size 8448 crc ca6bb788 md5 undefined sha1 ad18885ed38516c3e136293ae565c113f299d223 )
+	name "Othello (USA)"
+	description "Othello (USA)"
+	rom ( name "Othello (USA).a26" size 2048 crc 171ae72f md5 55949cb7884f9db0f8dfcf8707c7e5cb sha1 cbecf1a32d9366a3dd4ad643916cd59cdc820a8b )
 )
 
 game (
-	name "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL)"
-	description "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL)"
-	rom ( name "Communist Mutants from Space (Galactic Egg) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (2) (AR-4101) (PAL).bin" size 8448 crc d1a5b3bb md5 undefined sha1 b0483e5de99833d630433281953a670dd72a0df4 )
+	name "Out of Control (USA)"
+	description "Out of Control (USA)"
+	rom ( name "Out of Control (USA).a26" size 4096 crc ca4d03fb md5 f97dee1aa2629911f30f225ca31789d4 sha1 344d6942723513c376a7a844779804e10f357b85 )
 )
 
 game (
-	name "CompuMate (1983) (Spectravideo - Universum) (SV-010) (PAL)"
-	description "CompuMate (1983) (Spectravideo - Universum) (SV-010) (PAL)"
-	rom ( name "CompuMate (1983) (Spectravideo - Universum) (SV-010) (PAL).bin" size 16384 crc bed37e4f md5 undefined sha1 d85daed1b5397a779e8832628979f5396650090d )
+	name "Outlaw - Gunslinger (USA)"
+	description "Outlaw - Gunslinger (USA)"
+	rom ( name "Outlaw - Gunslinger (USA).a26" size 2048 crc 68dd7acd md5 890c13590e0d8d5d6149737d930e4d95 sha1 f8eeaaf4635ac39b4bdf7ded1348bce46313ef9f )
 )
 
 game (
-	name "CompuMate (1983) (Spectravideo) (SV-010) ~"
-	description "CompuMate (1983) (Spectravideo) (SV-010) ~"
-	rom ( name "CompuMate (1983) (Spectravideo) (SV-010) ~.bin" size 16384 crc bbe1f661 md5 undefined sha1 1947b26419fadfc6b2c9b5d552fd3d2bd220bc61 )
+	name "Pac-Man (USA)"
+	description "Pac-Man (USA)"
+	rom ( name "Pac-Man (USA).a26" size 4096 crc ddc9a881 md5 6e372f076fb9586aff416144f5cfe1cb sha1 0940fea7f04cdb6d4b90c5ad1a7e344e68f6dbb1 )
 )
 
 game (
-	name "Computer Chess (07-07-1978) (Atari, Larry Wagner, Bob Whitehead) (Prototype) ~"
-	description "Computer Chess (07-07-1978) (Atari, Larry Wagner, Bob Whitehead) (Prototype) ~"
-	rom ( name "Computer Chess (07-07-1978) (Atari, Larry Wagner, Bob Whitehead) (Prototype) ~.bin" size 4096 crc 0c44d49a md5 undefined sha1 dbc0c0451dee44425810e04df8f1d26d1c2d3993 )
+	name "Panda Chase (Europe)"
+	description "Panda Chase (Europe)"
+	rom ( name "Panda Chase (Europe).a26" size 4096 crc af417a00 md5 0e713d4e272ea7322c5b27d645f56dd0 sha1 f07b47cd6f3362eb051eab3eca564183d0d46c0c )
 )
 
 game (
-	name "Condor Attack (1982) (Ultravision) (1043) (PAL)"
-	description "Condor Attack (1982) (Ultravision) (1043) (PAL)"
-	rom ( name "Condor Attack (1982) (Ultravision) (1043) (PAL).bin" size 4096 crc 5c13b1ef md5 undefined sha1 c1930d130bdf668f3c0b4f026a980328eeb00482 )
+	name "Parachute (Europe)"
+	description "Parachute (Europe)"
+	rom ( name "Parachute (Europe).a26" size 4096 crc 40e4bc6a md5 714e13c08508ee9a7785ceac908ae831 sha1 385036ac98d44f2fa33a3ab11e35ca9f0151d6d2 )
 )
 
 game (
-	name "Condor Attack (1982) (Ultravision) (1043) ~"
-	description "Condor Attack (1982) (Ultravision) (1043) ~"
-	rom ( name "Condor Attack (1982) (Ultravision) (1043) ~.bin" size 4096 crc b6c582eb md5 undefined sha1 2ebd0f43ee76833f75759ac1bbb45a8e0c3b86e9 )
+	name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA)"
+	description "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA)"
+	rom ( name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA).a26" size 25344 crc 8b8ae545 md5 012b8e6ef3b5fd5aabc94075c527709d sha1 600e3a32b19b3b164aaafb538b4399eda669845a )
 )
 
 game (
-	name "Condor Attack (1983) (CCE) (C-851)"
-	description "Condor Attack (1983) (CCE) (C-851)"
-	rom ( name "Condor Attack (1983) (CCE) (C-851).bin" size 4096 crc b6c582eb md5 undefined sha1 2ebd0f43ee76833f75759ac1bbb45a8e0c3b86e9 )
+	name "Peek-A-Boo (USA) (Proto)"
+	description "Peek-A-Boo (USA) (Proto)"
+	rom ( name "Peek-A-Boo (USA) (Proto).a26" size 4096 crc 07594314 md5 e40a818dac4dd851f3b4aafbe2f1e0c1 sha1 b529c1664ed1abc8f5f962a1fed65c0e4440219c )
 )
 
 game (
-	name "Condor Attack (1983) (Goliath) (4) (PAL)"
-	description "Condor Attack (1983) (Goliath) (4) (PAL)"
-	rom ( name "Condor Attack (1983) (Goliath) (4) (PAL).bin" size 4096 crc e506bdb2 md5 undefined sha1 05dede1debc04fb1c81a8d940e32ac08e85af29b )
+	name "Pengo (USA)"
+	description "Pengo (USA)"
+	rom ( name "Pengo (USA).a26" size 8192 crc 7667e739 md5 04014d563b094e79ac8974366f616308 sha1 89b991a7a251f78f422bcdf9cf7d4475fdf33e97 )
 )
 
 game (
-	name "Condor Attack (Action Hi-Tech - Hi-Score) (PAL)"
-	description "Condor Attack (Action Hi-Tech - Hi-Score) (PAL)"
-	rom ( name "Condor Attack (Action Hi-Tech - Hi-Score) (PAL).bin" size 4096 crc 5c13b1ef md5 undefined sha1 c1930d130bdf668f3c0b4f026a980328eeb00482 )
+	name "Pete Rose Baseball (USA)"
+	description "Pete Rose Baseball (USA)"
+	rom ( name "Pete Rose Baseball (USA).a26" size 16384 crc d0c6fc32 md5 09388bf390cd9a86dc0849697b96c7dc sha1 19c3ad034466c0433501a415a996ed7155d6063a )
 )
 
 game (
-	name "Condor Attack (Unknown) (PAL)"
-	description "Condor Attack (Unknown) (PAL)"
-	rom ( name "Condor Attack (Unknown) (PAL).bin" size 4096 crc e72b11c7 md5 undefined sha1 e19de12bde02958dc57e254b0fe917b390f5f944 )
+	name "Peter Penguin (USA)"
+	description "Peter Penguin (USA)"
+	rom ( name "Peter Penguin (USA).a26" size 4096 crc 5b47448c md5 cb4a7b507372c24f8b9390d22d54a918 sha1 59cc30a376901462e43bc78586495c72bab81fce )
 )
 
 game (
-	name "Confrontation (1983) (Answer Software Corporation - TY Associates) (ASC2001) (Prototype) ~"
-	description "Confrontation (1983) (Answer Software Corporation - TY Associates) (ASC2001) (Prototype) ~"
-	rom ( name "Confrontation (1983) (Answer Software Corporation - TY Associates) (ASC2001) (Prototype) ~.bin" size 4096 crc c2dbcefe md5 undefined sha1 5512a0ed4306edc007a78bb52dbcf492adf798ec )
+	name "Phantom Tank (Europe)"
+	description "Phantom Tank (Europe)"
+	rom ( name "Phantom Tank (Europe).a26" size 4096 crc 9213493b md5 b29359f7de62fed6e6ad4c948f699df8 sha1 02a521354575d2270f75250e79bc18f69f666c7f )
 )
 
 game (
-	name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech - Teldec) (006-01 - 3.60105 VG) (PAL)"
-	description "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech - Teldec) (006-01 - 3.60105 VG) (PAL)"
-	rom ( name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech - Teldec) (006-01 - 3.60105 VG) (PAL).bin" size 8192 crc 015c0e40 md5 undefined sha1 5fec580e99c99380889c058ef49318e4518e6f7f )
+	name "Phantom UFO (USA)"
+	description "Phantom UFO (USA)"
+	rom ( name "Phantom UFO (USA).a26" size 4096 crc 69d3abc5 md5 4d38e1105c3a5f0b3119a805f261fcb5 sha1 39f96b96ee996ab4afd82c6dea35c8d86585b90c )
 )
 
 game (
-	name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) [a]"
-	description "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) [a]"
-	rom ( name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) [a].bin" size 8192 crc ff7ed640 md5 undefined sha1 3ec21fcdc14bdb6e9caee1f7d9b81107703da55b )
+	name "Pharaoh's Curse (Europe)"
+	description "Pharaoh's Curse (Europe)"
+	rom ( name "Pharaoh's Curse (Europe).a26" size 4096 crc c6b82fc6 md5 3577e19714921912685bb0e32ddf943c sha1 ecd9e93335ef6eda1531b0b5f03a5015054277b0 )
 )
 
 game (
-	name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) ~"
-	description "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) ~"
-	rom ( name "Congo Bongo (1983) (Sega, Steve Beck, Phat Ho - Beck-Tech) (006-01) ~.bin" size 8192 crc 3f6e7e0c md5 undefined sha1 3a77db43b6583e8689435f0f14aa04b9e57bdded )
+	name "Phaser Patrol (USA)"
+	description "Phaser Patrol (USA)"
+	rom ( name "Phaser Patrol (USA).a26" size 8448 crc eaf31bd7 md5 7dcbfd2acc013e817f011309c7504daa sha1 21c255e489d126475c3744cdd0d6e8a8e618e3eb )
 )
 
 game (
-	name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL)"
-	description "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL)"
-	rom ( name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL).bin" size 8192 crc 8ee4c319 md5 undefined sha1 fd47df700820295ead34a9d9cf5c73eccf1101bd )
+	name "Phoenix (USA)"
+	description "Phoenix (USA)"
+	rom ( name "Phoenix (USA).a26" size 8192 crc 6ae1b66c md5 7e52a95074a66640fcfde124fffd491a sha1 010d51e3f522ba60f021d56819437d7c85897cdd )
 )
 
 game (
-	name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL) [a]"
-	description "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL) [a]"
-	rom ( name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) (PAL) [a].bin" size 8192 crc cb377c19 md5 undefined sha1 3e03319ac9fdb095ace67ca1586be2cd1dbbbf64 )
+	name "Pick 'n' Pile (Europe)"
+	description "Pick 'n' Pile (Europe)"
+	rom ( name "Pick 'n' Pile (Europe).a26" size 16384 crc cb76a9d4 md5 da79aad11572c80a96e261e4ac6392d0 sha1 a5917537cf1093aa350903d85d9e271e8a11d2cf )
 )
 
 game (
-	name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) ~"
-	description "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) ~"
-	rom ( name "Cookie Monster Munch (Cokie Monster's Maze, Cookie Monster's Garden) (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Gary Stark) (CX26102) ~.bin" size 8192 crc 97ba488f md5 undefined sha1 f4a62ba0ff59803c5f40d59eeed1e126fe37979b )
+	name "Pick Up (USA) (Proto)"
+	description "Pick Up (USA) (Proto)"
+	rom ( name "Pick Up (USA) (Proto).a26" size 4096 crc 0cdd8475 md5 1d4e0a034ad1275bc4d75165ae236105 sha1 9784531d02200bb79a58987877c67a0fc658252e )
 )
 
 game (
-	name "Corrida da Matematica (AKA Math Gran Prix) (CCE)"
-	description "Corrida da Matematica (AKA Math Gran Prix) (CCE)"
-	rom ( name "Corrida da Matematica (AKA Math Gran Prix) (CCE).bin" size 4096 crc ff570220 md5 undefined sha1 3956dde26b2625fa3774e2bfc93e5e2c95bfa886 )
+	name "Picnic (USA)"
+	description "Picnic (USA)"
+	rom ( name "Picnic (USA).a26" size 4096 crc 1d507a61 md5 17c0a63f9a680e7a61beba81692d9297 sha1 483fc907471c5c358fb3e624097861a2fc9c1e45 )
 )
 
 game (
-	name "Cosmic Ark (1983) (CCE) (C-831)"
-	description "Cosmic Ark (1983) (CCE) (C-831)"
-	rom ( name "Cosmic Ark (1983) (CCE) (C-831).bin" size 4096 crc fe96d6cf md5 undefined sha1 a0eddf34fa4ab37ed95c2d1a1a306400b7066cc7 )
+	name "Piece o' Cake (USA)"
+	description "Piece o' Cake (USA)"
+	rom ( name "Piece o' Cake (USA).a26" size 4096 crc 40355166 md5 d3423d7600879174c038f53e5ebbf9d3 sha1 57774193081acea010bd935a0449bc8f53157128 )
 )
 
 game (
-	name "Cosmic Ark (1983) (CCE) (C-831) [a]"
-	description "Cosmic Ark (1983) (CCE) (C-831) [a]"
-	rom ( name "Cosmic Ark (1983) (CCE) (C-831) [a].bin" size 4096 crc f7d29a55 md5 undefined sha1 3b5d82ffcc7e9dd7966df9aeb53a8bb1f4998821 )
+	name "Pigs in Space - Starring Miss Piggy (USA)"
+	description "Pigs in Space - Starring Miss Piggy (USA)"
+	rom ( name "Pigs in Space - Starring Miss Piggy (USA).a26" size 8192 crc 27673d7c md5 8e4fa8c6ad8d8dce0db8c991c166cdaa sha1 d08b30ca2e5e351cac3bd3fb760b87a1a30aa300 )
 )
 
 game (
-	name "Cosmic Ark (Canal 3 - Intellivision)"
-	description "Cosmic Ark (Canal 3 - Intellivision)"
-	rom ( name "Cosmic Ark (Canal 3 - Intellivision).bin" size 4096 crc 625089d4 md5 undefined sha1 167cba5ead0671b80f42f4e9081c67a968ea3d6f )
+	name "Pitfall II - Lost Caverns (USA)"
+	description "Pitfall II - Lost Caverns (USA)"
+	rom ( name "Pitfall II - Lost Caverns (USA).a26" size 10495 crc 097ce7ad md5 6d842c96d5a01967be9680080dd5be54 sha1 920cfbd517764ad3fa6a7425c031bd72dc7d927c )
 )
 
 game (
-	name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) [selectable starfield] ~"
-	description "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) [selectable starfield] ~"
-	rom ( name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) [selectable starfield] ~.bin" size 4096 crc f1421b2f md5 undefined sha1 4340fdd768d66bcae7e5464c3149d427a32a848a )
+	name "Pitfall! - Pitfall Harry's Jungle Adventure (USA)"
+	description "Pitfall! - Pitfall Harry's Jungle Adventure (USA)"
+	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (USA).a26" size 4096 crc 42ad47bf md5 3e90cf23106f2e08b2781e41299de556 sha1 8d525480445d48cc48460dc666ebad78c8fb7b73 )
 )
 
 game (
-	name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) ~"
-	description "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) ~"
-	rom ( name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-1A, 720104-1B, IA3204) ~.bin" size 4096 crc cb374f0e md5 undefined sha1 187983fd14d37498437d0ef8f3fbd05675feb6ae )
+	name "Planet of the Apes (USA) (Proto)"
+	description "Planet of the Apes (USA) (Proto)"
+	rom ( name "Planet of the Apes (USA) (Proto).a26" size 4096 crc eea8b688 md5 9efb4e1a15a6cdd286e4bcd7cd94b7b8 sha1 dcca30e4ae58c85a070f0c6cfaa4d27be2970d61 )
 )
 
 game (
-	name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL)"
-	description "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL)"
-	rom ( name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL).bin" size 4096 crc c44c0965 md5 undefined sha1 99e35d9bebd3750e9ed5da4471910860311c2281 )
+	name "Planet Patrol (USA)"
+	description "Planet Patrol (USA)"
+	rom ( name "Planet Patrol (USA).a26" size 4096 crc 1e8ebb51 md5 043f165f384fbea3ea89393597951512 sha1 ccfcbf52815a441158977292b719f7c5ed80c515 )
 )
 
 game (
-	name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL) [selectable starfield]"
-	description "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL) [selectable starfield]"
-	rom ( name "Cosmic Ark (Reaction) (1982) (Imagic, Rob Fulop) (720104-2A, IA3204P, EIX-008-04I) (PAL) [selectable starfield].bin" size 4096 crc 3194a918 md5 undefined sha1 02ae141c7e22cc34cebd9b6cb36e39c7f9ce2145 )
+	name "Plaque Attack (USA)"
+	description "Plaque Attack (USA)"
+	rom ( name "Plaque Attack (USA).a26" size 4096 crc d5a5eb9e md5 da4e3396aa2db3bd667f83a1cb9e4a36 sha1 103398dd35ebd39450c5cac760fa332aac3f9458 )
 )
 
 game (
-	name "Cosmic Ark (Unknown) (PAL)"
-	description "Cosmic Ark (Unknown) (PAL)"
-	rom ( name "Cosmic Ark (Unknown) (PAL).bin" size 4096 crc 08fe413e md5 undefined sha1 42128e80e73baa287259bfe840a59f14993a1980 )
+	name "Pleiades (USA) (Proto)"
+	description "Pleiades (USA) (Proto)"
+	rom ( name "Pleiades (USA) (Proto).a26" size 8192 crc 35589cec md5 8bbfd951c89cc09c148bfabdefa08bec sha1 63c12146c183bccbf05c0044a961dc40790e3212 )
 )
 
 game (
-	name "Cosmic Avenger (AKA StarMaster) (4 Game in One) (1983) (Bit Corporation) (PGP214) (PAL)"
-	description "Cosmic Avenger (AKA StarMaster) (4 Game in One) (1983) (Bit Corporation) (PGP214) (PAL)"
-	rom ( name "Cosmic Avenger (AKA StarMaster) (4 Game in One) (1983) (Bit Corporation) (PGP214) (PAL).bin" size 4096 crc 1c5a1010 md5 undefined sha1 8276a9810f05658e1fb2c0c816457ad836612d85 )
+	name "Polaris (USA)"
+	description "Polaris (USA)"
+	rom ( name "Polaris (USA).a26" size 8192 crc 25b78f89 md5 44f71e70b89dcc7cf39dfd622cfb9a27 sha1 b76ab69118b579ca0acbbb8ebe8003eed5cbcb4a )
 )
 
 game (
-	name "Cosmic Commuter (1984) (Activision, John Van Ryzin) (AG-038-04) ~"
-	description "Cosmic Commuter (1984) (Activision, John Van Ryzin) (AG-038-04) ~"
-	rom ( name "Cosmic Commuter (1984) (Activision, John Van Ryzin) (AG-038-04) ~.bin" size 4096 crc 4939ba40 md5 undefined sha1 3717c97bbb0f547e4389db8fc954d1bad992444c )
+	name "Pole Position (USA)"
+	description "Pole Position (USA)"
+	rom ( name "Pole Position (USA).a26" size 8192 crc bd822518 md5 a4ff39d513b993159911efe01ac12eba sha1 b7122f478a343cffac17b765e9642893587e99a1 )
 )
 
 game (
-	name "Cosmic Commuter (CCE)"
-	description "Cosmic Commuter (CCE)"
-	rom ( name "Cosmic Commuter (CCE).bin" size 4096 crc f9d1144a md5 undefined sha1 4cbe082f2248ce8cc632a78636ce8d486e76522c )
+	name "Polo (USA) (Proto)"
+	description "Polo (USA) (Proto)"
+	rom ( name "Polo (USA) (Proto).a26" size 2048 crc 8c0b57d9 md5 ee28424af389a7f3672182009472500c sha1 c0af0188028cd899c49ba18f52bd1678e573bff2 )
 )
 
 game (
-	name "Cosmic Corridor (AKA Space Tunnel) (1983) (ZiMAG - Emag - Vidco) (708-111 - GN-040)"
-	description "Cosmic Corridor (AKA Space Tunnel) (1983) (ZiMAG - Emag - Vidco) (708-111 - GN-040)"
-	rom ( name "Cosmic Corridor (AKA Space Tunnel) (1983) (ZiMAG - Emag - Vidco) (708-111 - GN-040).bin" size 4096 crc 2511afc4 md5 undefined sha1 8b9dfef6c6757a6a59e01d783b751e4ab9541d9e )
+	name "Pompeii (USA) (Proto)"
+	description "Pompeii (USA) (Proto)"
+	rom ( name "Pompeii (USA) (Proto).a26" size 4096 crc 83d8a362 md5 a83b070b485cf1fb4d5a48da153fdf1a sha1 954d2980ea8f8d9a76921612c378889f24c35639 )
 )
 
 game (
-	name "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) (PAL)"
-	description "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) (PAL)"
-	rom ( name "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) (PAL).bin" size 4096 crc acfb4dba md5 undefined sha1 cd716ea236c6a73450f415131ac7ac8ee91a428d )
+	name "Pooyan (USA)"
+	description "Pooyan (USA)"
+	rom ( name "Pooyan (USA).a26" size 4096 crc fe24be60 md5 4799a40b6e889370b7ee55c17ba65141 sha1 b7a002025c24ab2ec4a03f62212db7b96c0e5ffd )
 )
 
 game (
-	name "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) ~"
-	description "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) ~"
-	rom ( name "Cosmic Creeps (Space Maze, Spaze Maze) (1982) (Telesys, Don 'Donyo' Ruffcorn) (1002) ~.bin" size 4096 crc 47aaa2dd md5 undefined sha1 22ff281b1e698e8a5d7a6f6173c86c46d3cd8561 )
+	name "Popeye (USA)"
+	description "Popeye (USA)"
+	rom ( name "Popeye (USA).a26" size 8192 crc 7d287f20 md5 c7f13ef38f61ee2367ada94fdcc6d206 sha1 1772a22df3e9a1f3842387ac63eeddff7f04b01c )
 )
 
 game (
-	name "Cosmic Creeps (Unknown) (PAL)"
-	description "Cosmic Creeps (Unknown) (PAL)"
-	rom ( name "Cosmic Creeps (Unknown) (PAL).bin" size 4096 crc 605c2233 md5 undefined sha1 eb992e41c626c223b7d422117196270ebd0a7070 )
+	name "Porky's (USA)"
+	description "Porky's (USA)"
+	rom ( name "Porky's (USA).a26" size 8192 crc add0b98a md5 f93d7fee92717e161e6763a88a293ffa sha1 70afc2cc870be546dc976fa0c6811f7e01ebc471 )
 )
 
 game (
-	name "Cosmic Swarm - Angriff der Termiten (Termite) (1982) (CommaVid, John Bronstein - Ariola) (CM-003 - 712 003-720) (PAL)"
-	description "Cosmic Swarm - Angriff der Termiten (Termite) (1982) (CommaVid, John Bronstein - Ariola) (CM-003 - 712 003-720) (PAL)"
-	rom ( name "Cosmic Swarm - Angriff der Termiten (Termite) (1982) (CommaVid, John Bronstein - Ariola) (CM-003 - 712 003-720) (PAL).bin" size 2048 crc e3406f38 md5 undefined sha1 d0b5e84ea3c82b372bd0b9d15b98f31ee552a45d )
+	name "Pressure Cooker (USA)"
+	description "Pressure Cooker (USA)"
+	rom ( name "Pressure Cooker (USA).a26" size 8192 crc ccf597d8 md5 97d079315c09796ff6d95a06e4b70171 sha1 8b001373be485060f88182e9a7afcf55b4d07a57 )
 )
 
 game (
-	name "Cosmic Swarm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Cosmic Swarm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Cosmic Swarm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 89845b00 md5 undefined sha1 4ce10f7f78febd29547239f36464ba4def80c06e )
+	name "Pressure Gauge (USA)"
+	description "Pressure Gauge (USA)"
+	rom ( name "Pressure Gauge (USA).a26" size 4096 crc d96bf85a md5 de1a636d098349be11bbc2d090f4e9cf sha1 0a171e8332d00534989104a51247b0e7a01bef5a )
 )
 
 game (
-	name "Cosmic Swarm (Termite) (1982) (CommaVid, John Bronstein) (CM-003) ~"
-	description "Cosmic Swarm (Termite) (1982) (CommaVid, John Bronstein) (CM-003) ~"
-	rom ( name "Cosmic Swarm (Termite) (1982) (CommaVid, John Bronstein) (CM-003) ~.bin" size 2048 crc 27f1ae48 md5 undefined sha1 c01354760f2ca8d6e4d01b230f31611973c6ae2d )
+	name "Private Eye (USA)"
+	description "Private Eye (USA)"
+	rom ( name "Private Eye (USA).a26" size 8192 crc ea3bff1c md5 ef3a4f64b6494ba770862768caf04b86 sha1 1ea6bea907a6b5607c76f222730f812a99cd1015 )
 )
 
 game (
-	name "Cosmic Town (AKA Base Attack) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 375) (PAL)"
-	description "Cosmic Town (AKA Base Attack) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 375) (PAL)"
-	rom ( name "Cosmic Town (AKA Base Attack) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 375) (PAL).bin" size 4096 crc 2b7d3498 md5 undefined sha1 b1e0672dc5cfd4d755c95af9abda4bb30889488a )
+	name "Q-bert (USA)"
+	description "Q-bert (USA)"
+	rom ( name "Q-bert (USA).a26" size 4096 crc 54142e3e md5 484b0076816a104875e00467d431c2d2 sha1 f3ef9787b4287a32e4d9ac7b9c3358edc16315b2 )
 )
 
 game (
-	name "Cosmic War (AKA Space Tunnel) (1983) (Home Vision - Gem International Corp.) (VCS83136) (PAL)"
-	description "Cosmic War (AKA Space Tunnel) (1983) (Home Vision - Gem International Corp.) (VCS83136) (PAL)"
-	rom ( name "Cosmic War (AKA Space Tunnel) (1983) (Home Vision - Gem International Corp.) (VCS83136) (PAL).bin" size 4096 crc 3806244e md5 undefined sha1 89b3389b8134fb9936b5e356e0bcef12e2bb4644 )
+	name "Q-bert's Qubes (USA)"
+	description "Q-bert's Qubes (USA)"
+	rom ( name "Q-bert's Qubes (USA).a26" size 8192 crc d9f499c5 md5 517592e6e0c71731019c0cebc2ce044f sha1 a61be3702437b5d16e19c0d2cd92393515d42f23 )
 )
 
 game (
-	name "Crack'ed (11-28-1988) (Atari, Randy Bowker) (CX26142) (Prototype) ~"
-	description "Crack'ed (11-28-1988) (Atari, Randy Bowker) (CX26142) (Prototype) ~"
-	rom ( name "Crack'ed (11-28-1988) (Atari, Randy Bowker) (CX26142) (Prototype) ~.bin" size 16384 crc 1b5e52a7 md5 undefined sha1 d226e8af4e38d1d4eb8bb69cdf6bccdad561c804 )
+	name "Quadrun (USA)"
+	description "Quadrun (USA)"
+	rom ( name "Quadrun (USA).a26" size 8192 crc 8d3c887b md5 024365007a87f213cbe8ef5f2e8e1333 sha1 b8d6f508edbf713e52f0cbf235d5e17add2fbf2e )
 )
 
 game (
-	name "Crackpots (1983) (Activision, Dan Kitchen) (AX-029) ~"
-	description "Crackpots (1983) (Activision, Dan Kitchen) (AX-029) ~"
-	rom ( name "Crackpots (1983) (Activision, Dan Kitchen) (AX-029) ~.bin" size 4096 crc ecd891b3 md5 undefined sha1 6ee0a26af4643ff250198dfc1c2b7c6568b4f207 )
+	name "Quest for Quintana Roo (USA)"
+	description "Quest for Quintana Roo (USA)"
+	rom ( name "Quest for Quintana Roo (USA).a26" size 8192 crc f9f58dd3 md5 a0675883f9b09a3595ddd66a6f5d3498 sha1 d83c740d2968343e6401828d62f58be6aea8e858 )
 )
 
 game (
-	name "Crackpots (1983) (CCE) (C-862)"
-	description "Crackpots (1983) (CCE) (C-862)"
-	rom ( name "Crackpots (1983) (CCE) (C-862).bin" size 4096 crc 1ed2c5f4 md5 undefined sha1 62b67cc0b7601b9662880aa39ead323aecd41c44 )
+	name "Quick Step! (USA)"
+	description "Quick Step! (USA)"
+	rom ( name "Quick Step! (USA).a26" size 4096 crc 057440fe md5 7eba20c2291a982214cc7cbe8d0b47cd sha1 33a47f79610c4525802c9881f67ad1f3f8c1b55d )
 )
 
 game (
-	name "Crackpots (1983) (CCE) (C-862) [a]"
-	description "Crackpots (1983) (CCE) (C-862) [a]"
-	rom ( name "Crackpots (1983) (CCE) (C-862) [a].bin" size 4096 crc 3375fca1 md5 undefined sha1 b186a2eb0f57c303c3191be026322b4e39cea801 )
+	name "Rabbit Transit (USA)"
+	description "Rabbit Transit (USA)"
+	rom ( name "Rabbit Transit (USA).a26" size 8448 crc 517e5561 md5 fb4ca865abc02d66e39651bd9ade140a sha1 81654cbd6a7262ce0f1abc385ed9adc323a9b6a6 )
 )
 
 game (
-	name "Crackpots (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Crackpots (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Crackpots (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc c53e243b md5 undefined sha1 20860ac787ea5874c74318e6f874183ab8011528 )
+	name "Racer (USA) (Proto)"
+	description "Racer (USA) (Proto)"
+	rom ( name "Racer (USA) (Proto).a26" size 8192 crc 794ed26d md5 3c7a7b3a0a7e6319b2fa0f923ef6c9af sha1 1df83e0e89a97511ee91a5a9f376dffcfbad06a9 )
 )
 
 game (
-	name "Crackpots (Digivision)"
-	description "Crackpots (Digivision)"
-	rom ( name "Crackpots (Digivision).bin" size 4096 crc 05ebe4d7 md5 undefined sha1 3c3370a2f842f219477e89842870e7ea23097f8b )
+	name "Racing Car (Europe)"
+	description "Racing Car (Europe)"
+	rom ( name "Racing Car (Europe).a26" size 4096 crc 18954066 md5 aab840db22075aa0f6a6b83a597f8890 sha1 65bd036bffd90ae34baa3817fee6ea70c76478ac )
 )
 
 game (
-	name "Crackpots (Unknown) (PAL)"
-	description "Crackpots (Unknown) (PAL)"
-	rom ( name "Crackpots (Unknown) (PAL).bin" size 4096 crc 8894f927 md5 undefined sha1 3ce4115bfeeb00da51b95d1161f831947b0e97f6 )
+	name "Racquetball (USA)"
+	description "Racquetball (USA)"
+	rom ( name "Racquetball (USA).a26" size 4096 crc 7eef9ac0 md5 a20d931a8fddcd6f6116ed21ff5c4832 sha1 4af6008152f1d38626d84016a7ef753406b48b46 )
 )
 
 game (
-	name "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11031) ~"
-	description "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11031) ~"
-	rom ( name "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11031) ~.bin" size 4096 crc 59fe4666 md5 undefined sha1 73d68f32d1fb73883ceb183d5150bff5f1065de4 )
+	name "Radar Lock (USA)"
+	description "Radar Lock (USA)"
+	rom ( name "Radar Lock (USA).a26" size 16384 crc c29f7285 md5 baf4ce885aa281fd31711da9b9795485 sha1 33f016c941fab01e1e2d0d7ba7930e3bcd8feaa3 )
 )
 
 game (
-	name "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11131) (PAL)"
-	description "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11131) (PAL)"
-	rom ( name "Crash Dive (Voyage to the Bottom of the Sea) (1983) (20th Century Fox Video Games, Bill Aspromonte) (11131) (PAL).bin" size 4096 crc b7d80520 md5 undefined sha1 878647d78f943f95e0aec5607ba640c011226f91 )
+	name "Raft Rider (USA)"
+	description "Raft Rider (USA)"
+	rom ( name "Raft Rider (USA).a26" size 4096 crc 3d1292f8 md5 92a1a605b7ad56d863a56373a866761b sha1 a79f6e0f4fd76878e5c3ba6b52d17e88acdbe9f6 )
 )
 
 game (
-	name "Crazy Climber (1982) (Atari, Joe Gaucher, Alex Leavens) (CX2683) ~"
-	description "Crazy Climber (1982) (Atari, Joe Gaucher, Alex Leavens) (CX2683) ~"
-	rom ( name "Crazy Climber (1982) (Atari, Joe Gaucher, Alex Leavens) (CX2683) ~.bin" size 8192 crc a3a3c009 md5 undefined sha1 70e723aa67d68f8549d9bd8f96d8b1262cbdac3c )
+	name "Raiders of the Lost Ark (USA)"
+	description "Raiders of the Lost Ark (USA)"
+	rom ( name "Raiders of the Lost Ark (USA).a26" size 8192 crc e05fe273 md5 f724d3dd2471ed4cf5f191dbb724b69f sha1 7ae70783969709318e56f189cf03da92320a6aba )
 )
 
 game (
-	name "Criminal Persuit (AKA A Mysterious Thief) (Suntek) (SS-036) (PAL)"
-	description "Criminal Persuit (AKA A Mysterious Thief) (Suntek) (SS-036) (PAL)"
-	rom ( name "Criminal Persuit (AKA A Mysterious Thief) (Suntek) (SS-036) (PAL).bin" size 4096 crc b93a7346 md5 undefined sha1 4e1ac830a8cd2ca27f92cb5d7e78c89c563e4c10 )
+	name "Ram It (USA)"
+	description "Ram It (USA)"
+	rom ( name "Ram It (USA).a26" size 4096 crc 582d5b62 md5 7096a198531d3f16a99d518ac0d7519a sha1 fd0a69c06eb3f7c9328951c890644f93c4bad6ad )
 )
 
 game (
-	name "Criminal Pursuit (AKA A Mysterious Thief) (Video Game Cartridge - Ariola) (TP-619) (PAL)"
-	description "Criminal Pursuit (AKA A Mysterious Thief) (Video Game Cartridge - Ariola) (TP-619) (PAL)"
-	rom ( name "Criminal Pursuit (AKA A Mysterious Thief) (Video Game Cartridge - Ariola) (TP-619) (PAL).bin" size 4096 crc b93a7346 md5 undefined sha1 4e1ac830a8cd2ca27f92cb5d7e78c89c563e4c10 )
+	name "Rampage! (USA)"
+	description "Rampage! (USA)"
+	rom ( name "Rampage! (USA).a26" size 16384 crc f0b446ac md5 5e1b4629426f4992cf3b2905a696e1a7 sha1 7bb7df255829d5fbbee0d944915e50f89a5e7075 )
 )
 
 game (
-	name "Cross Force - Kreuzfeuer (Cross Fire) (1982) (Spectravision, Spectravideo - Quelle) (SA-203 - 413.223 9) (PAL)"
-	description "Cross Force - Kreuzfeuer (Cross Fire) (1982) (Spectravision, Spectravideo - Quelle) (SA-203 - 413.223 9) (PAL)"
-	rom ( name "Cross Force - Kreuzfeuer (Cross Fire) (1982) (Spectravision, Spectravideo - Quelle) (SA-203 - 413.223 9) (PAL).bin" size 4096 crc 5c042596 md5 undefined sha1 8a7c67d83d8e5d0f9fc0a78c17153756aa043972 )
+	name "Raumpatrouille (USA)"
+	description "Raumpatrouille (USA)"
+	rom ( name "Raumpatrouille (USA).a26" size 4096 crc 3dfee54b md5 ca50cc4b21b0155255e066fcd6396331 sha1 d68d9ffcb6db02ea0e9299192f548e3d6594c0f3 )
 )
 
 game (
-	name "Cross Force (Cross Fire) (1982) (Spectravision, Spectravideo) (SA-203) ~"
-	description "Cross Force (Cross Fire) (1982) (Spectravision, Spectravideo) (SA-203) ~"
-	rom ( name "Cross Force (Cross Fire) (1982) (Spectravision, Spectravideo) (SA-203) ~.bin" size 4096 crc 41b0d615 md5 undefined sha1 b1b3d8d6afe94b73a43c36668cc756c5b6fdc1c3 )
+	name "Reactor (USA)"
+	description "Reactor (USA)"
+	rom ( name "Reactor (USA).a26" size 4096 crc 1619e222 md5 9f8fad4badcd7be61bbd2bcaeef3c58f sha1 5adf9b530321472380ebceb2539de2ffbb0310bc )
 )
 
 game (
-	name "Cross Force (Unknown) (PAL)"
-	description "Cross Force (Unknown) (PAL)"
-	rom ( name "Cross Force (Unknown) (PAL).bin" size 4096 crc 6a076f60 md5 undefined sha1 e1694ec252529d923b08797b7baa7030fb9ae79d )
+	name "RealSports Baseball (USA)"
+	description "RealSports Baseball (USA)"
+	rom ( name "RealSports Baseball (USA).a26" size 8192 crc 3c5a1b5f md5 eb634650c3912132092b7aee540bbce3 sha1 ace97b89b8b6ab947434dbfd263951c6c0b349ac )
 )
 
 game (
-	name "Cross Force (Unknown) (PAL) [a]"
-	description "Cross Force (Unknown) (PAL) [a]"
-	rom ( name "Cross Force (Unknown) (PAL) [a].bin" size 4096 crc a4f7d566 md5 undefined sha1 33033947a4f43586fa2cfa388c9b9e4240686058 )
+	name "RealSports Basketball (Europe) (Proto)"
+	description "RealSports Basketball (Europe) (Proto)"
+	rom ( name "RealSports Basketball (Europe) (Proto).a26" size 8192 crc 364feaa6 md5 8a183b6357987db5170c5cf9f4a113e5 sha1 bc2e6bdaa950bc06be040899dfeb9ad0938f4e98 )
 )
 
 game (
-	name "Crossbow (1987) (Atari) (CX26139) ~"
-	description "Crossbow (1987) (Atari) (CX26139) ~"
-	rom ( name "Crossbow (1987) (Atari) (CX26139) ~.bin" size 16384 crc 1f233140 md5 undefined sha1 5da3d089ccda960ce244adb855975877c670e615 )
+	name "RealSports Boxing (USA)"
+	description "RealSports Boxing (USA)"
+	rom ( name "RealSports Boxing (USA).a26" size 16384 crc 3398a1b2 md5 3177cc5c04c1a4080a927dfa4099482b sha1 22dedbfce6cc9055a6c4caec013ca80200e51971 )
 )
 
 game (
-	name "Crossbow (1987) (Atari) (CX26139P) (PAL)"
-	description "Crossbow (1987) (Atari) (CX26139P) (PAL)"
-	rom ( name "Crossbow (1987) (Atari) (CX26139P) (PAL).bin" size 16384 crc d40e0ffc md5 undefined sha1 1e3326143441f2e6f9709f81781978220555288f )
+	name "RealSports Football (USA)"
+	description "RealSports Football (USA)"
+	rom ( name "RealSports Football (USA).a26" size 8192 crc f89f64ef md5 7ad257833190bc60277c1ca475057051 sha1 200d04c1e7f41a5a3730287ed0c3f9293628f195 )
 )
 
 game (
-	name "Cruise Missile (AKA Exocet) (1987) (Froggo) (FG1007)"
-	description "Cruise Missile (AKA Exocet) (1987) (Froggo) (FG1007)"
-	rom ( name "Cruise Missile (AKA Exocet) (1987) (Froggo) (FG1007).bin" size 4096 crc 5161a246 md5 undefined sha1 5f1f2b5b407b0624b59409e02060a3a9e8eed8fc )
+	name "RealSports Soccer (USA)"
+	description "RealSports Soccer (USA)"
+	rom ( name "RealSports Soccer (USA).a26" size 8192 crc 02d89819 md5 08f853e8e01e711919e734d85349220d sha1 e3d964d918b7f2c420776acd3370ec1ee62744ea )
 )
 
 game (
-	name "Crypts of Chaos (1982) (20th Century Fox Video Games, John W.S. Marvin) (11009) ~"
-	description "Crypts of Chaos (1982) (20th Century Fox Video Games, John W.S. Marvin) (11009) ~"
-	rom ( name "Crypts of Chaos (1982) (20th Century Fox Video Games, John W.S. Marvin) (11009) ~.bin" size 4096 crc c5b29962 md5 undefined sha1 a57062f44e7ac793d4c39d1350521dc5bc2a665f )
+	name "RealSports Tennis (USA)"
+	description "RealSports Tennis (USA)"
+	rom ( name "RealSports Tennis (USA).a26" size 8192 crc 379001a0 md5 dac5c0fe74531f077c105b396874a9f1 sha1 702c1c7d985d0d22f935265bd284d1ed50df2527 )
 )
 
 game (
-	name "Crystal Castles (01-04-1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (Prototype)"
-	description "Crystal Castles (01-04-1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (Prototype)"
-	rom ( name "Crystal Castles (01-04-1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (Prototype).bin" size 16384 crc 16f88336 md5 undefined sha1 9d0b6e70de5ba3830f21fa477438be15eac484ed )
+	name "RealSports Volleyball (USA)"
+	description "RealSports Volleyball (USA)"
+	rom ( name "RealSports Volleyball (USA).a26" size 4096 crc 54fc9eb2 md5 aed0b7bd64cc384f85fdea33e28daf3b sha1 2025e1d868595fad36e5d9e7384ffd24c206208d )
 )
 
 game (
-	name "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (PAL)"
-	description "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (PAL)"
-	rom ( name "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) (PAL).bin" size 16384 crc d5622d0b md5 undefined sha1 3311ea53afc8901d665e487036e7da0ae1cdb276 )
+	name "Red Sea Crossing (USA)"
+	description "Red Sea Crossing (USA)"
+	rom ( name "Red Sea Crossing (USA).a26" size 4096 crc e81e232a md5 4eb4fd544805babafc375dcdb8c2a597 sha1 dd92f67873d928e98cc4a2b279b90d7db8d50f5d )
 )
 
 game (
-	name "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) ~"
-	description "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) ~"
-	rom ( name "Crystal Castles (1984) (Atari, Michael Kosaka, Peter C. Niday, Robert Vieira) (CX26110) ~.bin" size 16384 crc 9007b5ac md5 undefined sha1 2e4ee5ee040b08be1fe568602d1859664e607efb )
+	name "Rescue Terra I (USA)"
+	description "Rescue Terra I (USA)"
+	rom ( name "Rescue Terra I (USA).a26" size 4096 crc a509ad53 md5 60a61da9b2f43dd7e13a5093ec41a53d sha1 94e94810bf6c72eee49157f9218c3c170b65c836 )
 )
 
 game (
-	name "Cubicolor (1982) (Imagic, Rob Fulop) (Prototype) ~"
-	description "Cubicolor (1982) (Imagic, Rob Fulop) (Prototype) ~"
-	rom ( name "Cubicolor (1982) (Imagic, Rob Fulop) (Prototype) ~.bin" size 4096 crc d5d43a7a md5 undefined sha1 0dd72a3461b4167f2d68c93511ed4985d97e6adc )
+	name "Revenge of the Beefsteak Tomatoes (USA)"
+	description "Revenge of the Beefsteak Tomatoes (USA)"
+	rom ( name "Revenge of the Beefsteak Tomatoes (USA).a26" size 4096 crc 243a36df md5 4f64d6d0694d9b7a1ed7b0cb0b83e759 sha1 f8a9dd46f9bad232f74d1ee2671ccb26ea1b3029 )
 )
 
 game (
-	name "Cubo Magico (AKA Cubicolor) (CCE)"
-	description "Cubo Magico (AKA Cubicolor) (CCE)"
-	rom ( name "Cubo Magico (AKA Cubicolor) (CCE).bin" size 4096 crc b053bee5 md5 undefined sha1 f2af2fd5ac676fd6f3ce25976e35759de86535c4 )
+	name "Riddle of the Sphinx (USA)"
+	description "Riddle of the Sphinx (USA)"
+	rom ( name "Riddle of the Sphinx (USA).a26" size 4096 crc 183a87e3 md5 a995b6cbdb1f0433abc74050808590e6 sha1 acb2430b4e6c72ce13f321d9d3a38986dc4768ef )
 )
 
 game (
-	name "Curtiss (AKA Atlantis) (Rainbow Vision - Suntek) (SS-019) (PAL)"
-	description "Curtiss (AKA Atlantis) (Rainbow Vision - Suntek) (SS-019) (PAL)"
-	rom ( name "Curtiss (AKA Atlantis) (Rainbow Vision - Suntek) (SS-019) (PAL).bin" size 4096 crc 0eb1080c md5 undefined sha1 82e64366795b011c2a2f1755bf899cc2c0617fe8 )
+	name "River Patrol (USA)"
+	description "River Patrol (USA)"
+	rom ( name "River Patrol (USA).a26" size 8192 crc c820bd75 md5 31512cdfadfd82bfb6f196e3b0fd83cd sha1 6715493dce54b22362741229078815b3360988ae )
 )
 
 game (
-	name "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1001) ~"
-	description "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1001) ~"
-	rom ( name "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (1001) ~.bin" size 4096 crc 21283941 md5 undefined sha1 4b3d02b59e17520b4d60236568d5cb50a4e6aeb3 )
+	name "River Raid (USA)"
+	description "River Raid (USA)"
+	rom ( name "River Raid (USA).a26" size 4096 crc c3eb7e1e md5 393948436d1f4cc3192410bb918f9724 sha1 40329780402f8247f294fe884ffc56cc3da0c62d )
 )
 
 game (
-	name "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL)"
-	description "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL)"
-	rom ( name "Custer's Revenge (1982) (Mystique - American Multiple Industries, Joel H. Martin) (PAL).bin" size 4096 crc 931c45c2 md5 undefined sha1 30a076f1db53f85799f0ad9cfce96724c39887f7 )
+	name "River Raid II (USA)"
+	description "River Raid II (USA)"
+	rom ( name "River Raid II (USA).a26" size 16384 crc 27d2df2c md5 ab56f1b2542a05bebc4fbccfc4803a38 sha1 a08c3eae3368334c937a5e03329782e95f7b57c7 )
 )
 
 game (
-	name "Dancing Plate - Dancing Plates - Tanzende Teller (1982) (Bit Corporation) (PG205) (PAL)"
-	description "Dancing Plate - Dancing Plates - Tanzende Teller (1982) (Bit Corporation) (PG205) (PAL)"
-	rom ( name "Dancing Plate - Dancing Plates - Tanzende Teller (1982) (Bit Corporation) (PG205) (PAL).bin" size 4096 crc 7f55c2e9 md5 undefined sha1 07e94a7d357e859dcff77180981713ce8119324e )
+	name "Road Runner (USA)"
+	description "Road Runner (USA)"
+	rom ( name "Road Runner (USA).a26" size 16384 crc cb79c061 md5 ce5cc62608be2cd3ed8abd844efb8919 sha1 8be5f9c2a11f78ac536e598e3e3b7d37130154ec )
 )
 
 game (
-	name "Dancing Plate (1982) (Puzzy - Bit Corporation) (PG205) (PAL) ~"
-	description "Dancing Plate (1982) (Puzzy - Bit Corporation) (PG205) (PAL) ~"
-	rom ( name "Dancing Plate (1982) (Puzzy - Bit Corporation) (PG205) (PAL) ~.bin" size 4096 crc 250c4e3f md5 undefined sha1 85500dc5f7b083ce2d743c223c56163ff95b39e3 )
+	name "Robin Hood (USA)"
+	description "Robin Hood (USA)"
+	rom ( name "Robin Hood (USA).a26" size 8192 crc df96102b md5 72a46e0c21f825518b7261c267ab886e sha1 7f9c2321c9f22cf2cdbcf1b3f0e563a1c53f68ca )
 )
 
 game (
-	name "Dancing Plate (Unknown) (PAL)"
-	description "Dancing Plate (Unknown) (PAL)"
-	rom ( name "Dancing Plate (Unknown) (PAL).bin" size 4096 crc 7565c5c4 md5 undefined sha1 94a43b4aa6860315d9991bbaa144eb5b09a03081 )
+	name "Robot Tank (USA)"
+	description "Robot Tank (USA)"
+	rom ( name "Robot Tank (USA).a26" size 8192 crc e127c012 md5 4f618c2429138e0280969193ed6c107e sha1 21a3ee57cb622f410ffd51986ab80acadb8d44b7 )
 )
 
 game (
-	name "Dark Cavern (1982) (M Network, Hal Finney) (MT5667) ~"
-	description "Dark Cavern (1982) (M Network, Hal Finney) (MT5667) ~"
-	rom ( name "Dark Cavern (1982) (M Network, Hal Finney) (MT5667) ~.bin" size 4096 crc 0481078c md5 undefined sha1 0ae2fc87f87a5cc199c3b9a17444bf3c2f6a829b )
+	name "Roc 'n Rope (USA)"
+	description "Roc 'n Rope (USA)"
+	rom ( name "Roc 'n Rope (USA).a26" size 8192 crc 9d51c969 md5 65bd29e8ab1b847309775b0de6b2e4fe sha1 0abf0a292d4a24df5a5ebe19a9729f3a8f883c8b )
 )
 
 game (
-	name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (PAL)"
-	description "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (PAL)"
-	rom ( name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (PAL).bin" size 16384 crc 844ba468 md5 undefined sha1 0ea0dea570acedc806aae630a92f68b3e1d63868 )
+	name "Room of Doom (USA)"
+	description "Room of Doom (USA)"
+	rom ( name "Room of Doom (USA).a26" size 4096 crc f27fc3be md5 67931b0d37dc99af250dd06f1c095e8d sha1 fd243c480e769b20b7bf3e74bcd86e4ac99dab19 )
 )
 
 game (
-	name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (Prototype) (PAL)"
-	description "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (Prototype) (PAL)"
-	rom ( name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151, CX26151P) (Prototype) (PAL).bin" size 16384 crc 19e38e50 md5 undefined sha1 72563f872ebfd285ef51b9f2fe7d3a8f55f1b0fa )
+	name "Rubik's Cube 3-D (USA) (Proto)"
+	description "Rubik's Cube 3-D (USA) (Proto)"
+	rom ( name "Rubik's Cube 3-D (USA) (Proto).a26" size 4096 crc 47bfd42c md5 40b1832177c63ebf81e6c5b61aaffd3a sha1 cb3bb28bc4f08313ea8ed9ff395ca34271d3c499 )
 )
 
 game (
-	name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151) ~"
-	description "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151) ~"
-	rom ( name "Dark Chambers (Dungeon, Dungeon Masters) (1988) (Atari, Adam Clayton, John Howard Palevich) (CX26151) ~.bin" size 16384 crc 83900281 md5 undefined sha1 fbb4814973fcb4e101521515e04daa6424c45f5c )
+	name "S.A.C. Alert (USA) (Proto)"
+	description "S.A.C. Alert (USA) (Proto)"
+	rom ( name "S.A.C. Alert (USA) (Proto).a26" size 4096 crc 79d3b1e6 md5 715dbf2e39ba8a52c5fe5cdd927b37e0 sha1 7b829edffee303c6b796c71540b7636ca5685bcd )
 )
 
 game (
-	name "Deadly Discs (AKA TRON - Deadly Discs) (1989) (Telegames) (PAL)"
-	description "Deadly Discs (AKA TRON - Deadly Discs) (1989) (Telegames) (PAL)"
-	rom ( name "Deadly Discs (AKA TRON - Deadly Discs) (1989) (Telegames) (PAL).bin" size 4096 crc c127248e md5 undefined sha1 26de531ab1502a8dfb7b700c1db1024525dc410d )
+	name "Saboteur (USA) (Proto)"
+	description "Saboteur (USA) (Proto)"
+	rom ( name "Saboteur (USA) (Proto).a26" size 8192 crc 7efe0286 md5 a4ecb54f877cd94515527b11e698608c sha1 90cd987ccaffb428e53ffd98563dbbe3babd2e73 )
 )
 
 game (
-	name "Deadly Duck (1982) (20th Century Fox Video Games - Sirius Software, Ed Hodapp) (11004) ~"
-	description "Deadly Duck (1982) (20th Century Fox Video Games - Sirius Software, Ed Hodapp) (11004) ~"
-	rom ( name "Deadly Duck (1982) (20th Century Fox Video Games - Sirius Software, Ed Hodapp) (11004) ~.bin" size 4096 crc f33a9a2d md5 undefined sha1 68de291d5e9cbebfed72d2f9039e60581b6dbdc5 )
+	name "Save Mary! (USA) (Proto)"
+	description "Save Mary! (USA) (Proto)"
+	rom ( name "Save Mary! (USA) (Proto).a26" size 16384 crc 01e18f53 md5 4d502d6fb5b992ee0591569144128f99 sha1 ecd8ef49ae23ddd3e10ec60839b95c8e7764ea27 )
 )
 
 game (
-	name "Death Trap (1983) (Avalon Hill, Jean Baer, Jim Jacob) (5001002) ~"
-	description "Death Trap (1983) (Avalon Hill, Jean Baer, Jim Jacob) (5001002) ~"
-	rom ( name "Death Trap (1983) (Avalon Hill, Jean Baer, Jim Jacob) (5001002) ~.bin" size 4096 crc fdf79a60 md5 undefined sha1 5f710a1148740760b4ebcc42861a1f9c3384799e )
+	name "Save Our Ship (Europe)"
+	description "Save Our Ship (Europe)"
+	rom ( name "Save Our Ship (Europe).a26" size 4096 crc c422160a md5 01297d9b450455dd716db9658efb2fae sha1 8f06384fed607c5267d6f2c15a6f19cbe5c521d2 )
 )
 
 game (
-	name "Decathlon (AKA Activision Decathlon, The) (HES) (PAL) (16K)"
-	description "Decathlon (AKA Activision Decathlon, The) (HES) (PAL) (16K)"
-	rom ( name "Decathlon (AKA Activision Decathlon, The) (HES) (PAL) (16K).bin" size 16384 crc 71afa4d4 md5 undefined sha1 7a89163982d0b3c89ed87371334b6a10c56e1d2a )
+	name "Save the Whales (USA) (Proto)"
+	description "Save the Whales (USA) (Proto)"
+	rom ( name "Save the Whales (USA) (Proto).a26" size 4096 crc 9a346ce2 md5 e377c3af4f54a51b85efe37d4b7029e6 sha1 9f6c7295c3a82e0b2203d88715a6d9ac177b3ba9 )
 )
 
 game (
-	name "Defender (10-30-1981) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) (Prototype)"
-	description "Defender (10-30-1981) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) (Prototype)"
-	rom ( name "Defender (10-30-1981) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) (Prototype).bin" size 4096 crc 81d5c7e6 md5 undefined sha1 cee6f8e814b8d6499c1a2a892e33eb7b1745148b )
+	name "Schussel Der Polizistenschreck (Europe)"
+	description "Schussel Der Polizistenschreck (Europe)"
+	rom ( name "Schussel Der Polizistenschreck (Europe).a26" size 4096 crc da8e49fb md5 7ff53f6922708119e7bf478d7d618c86 sha1 25e2043775a08762e3fc98ecb96fbf46b20e860e )
 )
 
 game (
-	name "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) ~"
-	description "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) ~"
-	rom ( name "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy - Sears) (CX2609 - 49-75186) ~.bin" size 4096 crc 0df43d8e md5 undefined sha1 79facc1bf70e642685057999f5c2b8e94b102439 )
+	name "Sea Battle (USA)"
+	description "Sea Battle (USA)"
+	rom ( name "Sea Battle (USA).a26" size 4096 crc 83b4eb19 md5 1bc2427ac9b032a52fe527c7b26ce22c sha1 cfcc4f11ace2a7408b8122dbf80ab8ec6b56af76 )
 )
 
 game (
-	name "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy) (CX2609, CX2609P) (PAL)"
-	description "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy) (CX2609, CX2609P) (PAL)"
-	rom ( name "Defender (1982) (Atari, Robert C. Polaro, Alan J. Murphy) (CX2609, CX2609P) (PAL).bin" size 4096 crc b1722fb0 md5 undefined sha1 231f0a5441c4b910474f45d7dcf9802c90393649 )
+	name "Sea Hunt (USA)"
+	description "Sea Hunt (USA)"	
+	rom ( name "Sea Hunt (USA).a26" size 4096 crc f94a8aec md5 5dccf215fdb9bbf5d4a6d0139e5e8bcb sha1 e5558ae30acc1fa5b4ffe782ae480622586a32ca )
 )
 
 game (
-	name "Defender (CCE)"
-	description "Defender (CCE)"
-	rom ( name "Defender (CCE).bin" size 4096 crc 432e8658 md5 undefined sha1 eca356c4206fbfe6267f2c427ff57340d15ac737 )
+	name "Sea Monster (Europe)"
+	description "Sea Monster (Europe)"
+	rom ( name "Sea Monster (Europe).a26" size 4096 crc 3a1a392b md5 df6a46714960a3e39b57b3c3983801b5 sha1 c2f43f35d95797c06a581654406256c72e422ba4 )
 )
 
 game (
-	name "Defender (Dactari - Milmar)"
-	description "Defender (Dactari - Milmar)"
-	rom ( name "Defender (Dactari - Milmar).bin" size 4096 crc 56289967 md5 undefined sha1 7b10a71ebe079f66a61702d72e2df535ec07aab2 )
+	name "Seahawk (Europe)"
+	description "Seahawk (Europe)"
+	rom ( name "Seahawk (Europe).a26" size 4096 crc 5d3c699e md5 74d072e8a34560c36cacbc57b2462360 sha1 b4ead7656696a983dec3192c71cc4d63e9a67825 )
 )
 
 game (
-	name "Defender (Digivision)"
-	description "Defender (Digivision)"
-	rom ( name "Defender (Digivision).bin" size 4096 crc 08fb3589 md5 undefined sha1 3a0b4046088115ffd5b6df1a1e3abcc1003d45e1 )
+	name "Seaquest (USA)"
+	description "Seaquest (USA)"
+	rom ( name "Seaquest (USA).a26" size 4096 crc 8658e8d9 md5 240bfbac5163af4df5ae713985386f92 sha1 7324a1ebc695a477c8884718ffcad27732a98ab0 )
 )
 
 game (
-	name "Defender (Hack) (Unknown)"
-	description "Defender (Hack) (Unknown)"
-	rom ( name "Defender (Hack) (Unknown).bin" size 4096 crc f562a195 md5 undefined sha1 73056e3658f2ee46e6120e4150329cccd74771b0 )
+	name "Secret Agent (USA) (Proto)"
+	description "Secret Agent (USA) (Proto)"
+	rom ( name "Secret Agent (USA) (Proto).a26" size 4096 crc d16c45f9 md5 605fd59bfef88901c8c4794193a4cbad sha1 1914f57ab0a6f221f2ad344b244a3cdd7b1d991a )
 )
 
 game (
-	name "Defender (Unknown) (PAL)"
-	description "Defender (Unknown) (PAL)"
-	rom ( name "Defender (Unknown) (PAL).bin" size 4096 crc 6481d641 md5 undefined sha1 38790b824263bec292296644fe76036cd61aa748 )
+	name "Secret Quest (USA)"
+	description "Secret Quest (USA)"
+	rom ( name "Secret Quest (USA).a26" size 16384 crc 93c9eb47 md5 fc24a94d4371c69bc58f5245ada43c44 sha1 af11f1666d345267196a1c35223727e2ef93483a )
 )
 
 game (
-	name "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120)"
-	description "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120)"
-	rom ( name "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120).bin" size 8192 crc 93217704 md5 undefined sha1 d7b506b84f28e1b917a2978753d5a40eb197537a )
+	name "Sentinel (USA)"
+	description "Sentinel (USA)"
+	rom ( name "Sentinel (USA).a26" size 16384 crc d457b245 md5 8da51e0c4b6b46f7619425119c7d018e sha1 fcf5f8a7d6e59a339c2002e3d4084d87deb670fe )
 )
 
 game (
-	name "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL)"
-	description "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL)"
-	rom ( name "Defender II (AKA Stargate) (1988) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL).bin" size 8192 crc 8d348d62 md5 undefined sha1 aba4e94d01b10cdf9b882f25e620a126dd80df19 )
+	name "Shootin' Gallery (USA)"
+	description "Shootin' Gallery (USA)"
+	rom ( name "Shootin' Gallery (USA).a26" size 4096 crc b89aff8b md5 b5a1a189601a785bdb2f02a424080412 sha1 cfb4b41e318c7cd0070e75e412f67c973e124d8e )
 )
 
 game (
-	name "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) (PAL)"
-	description "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) (PAL)"
-	rom ( name "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) (PAL).bin" size 4096 crc 1d6088d8 md5 undefined sha1 c92324fc2a35e348ce3b008c4322771ab02a30c7 )
+	name "Shooting Arcade (USA) (Proto)"
+	description "Shooting Arcade (USA) (Proto)"
+	rom ( name "Shooting Arcade (USA) (Proto).a26" size 16384 crc 6f6fb3d6 md5 15c11ab6e4502b2010b18366133fc322 sha1 6e6daa34878d3e331c630359c7125a4ffba1b22d )
 )
 
 game (
-	name "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) ~"
-	description "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) ~"
-	rom ( name "Demolition Herby (1983) (Telesys, Don 'Donyo' Ruffcorn) (1006) ~.bin" size 4096 crc e9305ae2 md5 undefined sha1 5aae618292a728b55ad7f00242d870736b5356d3 )
+	name "Shuttle Orbiter (USA)"
+	description "Shuttle Orbiter (USA)"
+	rom ( name "Shuttle Orbiter (USA).a26" size 4096 crc 253d6396 md5 25b6dc012cdba63704ea9535c6987beb sha1 08952192ea6bf0ef94373520a7e855f58bae6179 )
 )
 
 game (
-	name "Demolition Herby (Unknown) (PAL)"
-	description "Demolition Herby (Unknown) (PAL)"
-	rom ( name "Demolition Herby (Unknown) (PAL).bin" size 4096 crc 677ef10a md5 undefined sha1 434e876226bea00ab19324804b18de14c93d096b )
+	name "Sinistar (USA) (Proto)"
+	description "Sinistar (USA) (Proto)"
+	rom ( name "Sinistar (USA) (Proto).a26" size 8192 crc 8e81a2a4 md5 1e85f8bccb4b866d4daa9fcf89306474 sha1 242fc23def80da96da22c2c7238d48635489abb0 )
 )
 
 game (
-	name "Demon Attack (1983) (CCE) (C-823)"
-	description "Demon Attack (1983) (CCE) (C-823)"
-	rom ( name "Demon Attack (1983) (CCE) (C-823).bin" size 4096 crc b962f803 md5 undefined sha1 82b2cc774a2d156c2a75d7409cc9a8bb861b59f8 )
+	name "Sir Lancelot (USA)"
+	description "Sir Lancelot (USA)"
+	rom ( name "Sir Lancelot (USA).a26" size 8192 crc eb792891 md5 4c8970f6c294a0a54c9c45e5e8445f93 sha1 fb4008b13cb9957ce5e2ce1555c7aecac9e773cc )
 )
 
 game (
-	name "Demon Attack (Canal 3 - Intellivision) (C 3016)"
-	description "Demon Attack (Canal 3 - Intellivision) (C 3016)"
-	rom ( name "Demon Attack (Canal 3 - Intellivision) (C 3016).bin" size 4096 crc 2ccafe0c md5 undefined sha1 72d431246bbccc5c1a6d6701a2a0294af6e81868 )
+	name "Skate Boardin' (USA)"
+	description "Skate Boardin' (USA)"
+	rom ( name "Skate Boardin' (USA).a26" size 8192 crc 6ee721f7 md5 f847fb8dba6c6d66d13724dbe5d95c4d sha1 a26fe0b5a43fe8116ab0ae6656d6b11644d871ec )
 )
 
 game (
-	name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) [fixed] ~"
-	description "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) [fixed] ~"
-	rom ( name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) [fixed] ~.bin" size 4096 crc 31c9df5e md5 undefined sha1 e5011b85a0e3c148087865bebd7e9b6608c32292 )
+	name "Skeet Shoot (USA)"
+	description "Skeet Shoot (USA)"
+	rom ( name "Skeet Shoot (USA).a26" size 2048 crc 57d69b13 md5 39c78d682516d79130b379fa9deb8d1c sha1 5ea6d2eb27c76e85f477ba6c799deb7c416ebbc3 )
 )
 
 game (
-	name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) ~"
-	description "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) ~"
-	rom ( name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720000-200, 720101-1B, 720101-1C, IA3200, IA3200C, IX-006-04) ~.bin" size 4096 crc 818927c1 md5 undefined sha1 a580d886c191a069f6b9036c3f879e83e09500c2 )
+	name "Ski Hunt (Europe)"
+	description "Ski Hunt (Europe)"
+	rom ( name "Ski Hunt (Europe).a26" size 4096 crc 5df00a09 md5 8654d7f0fb351960016e06646f639b02 sha1 936fce1ff68113fabf3f971592e98acddcab97b7 )
 )
 
 game (
-	name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720101-2B, IA3200P, EIX-006-04I) (PAL)"
-	description "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720101-2B, IA3200P, EIX-006-04I) (PAL)"
-	rom ( name "Demon Attack (Death from Above) (1982) (Imagic, Rob Fulop) (720101-2B, IA3200P, EIX-006-04I) (PAL).bin" size 4096 crc 42b2dfa9 md5 undefined sha1 91a78b32fe6229509008be3f2fa087049f16da3c )
+	name "Ski Run (Europe)"
+	description "Ski Run (Europe)"
+	rom ( name "Ski Run (Europe).a26" size 4096 crc e20a00b3 md5 f10e3f45fb01416c87e5835ab270b53a sha1 6ea10b4409225b2de0f130837e7d0e3b164a1652 )
 )
 
 game (
-	name "Demon Attack (Robby)"
-	description "Demon Attack (Robby)"
-	rom ( name "Demon Attack (Robby).bin" size 4096 crc 8bd0f9fd md5 undefined sha1 1270f2da04f46f86c1d8c4a41202480aa318c365 )
+	name "Skiing (USA)"
+	description "Skiing (USA)"
+	rom ( name "Skiing (USA).a26" size 2048 crc 35f80a22 md5 b76fbadc8ffb1f83e2ca08b6fb4d6c9f sha1 6581846f983b50cffb75d1c1b902238ba7dd4e92 )
 )
 
 game (
-	name "Demon Attack (Supergame)"
-	description "Demon Attack (Supergame)"
-	rom ( name "Demon Attack (Supergame).bin" size 4096 crc b6d6fa1d md5 undefined sha1 865c264310811111391bc81e32a17c57fdc6e3bf )
+	name "Skindiver (Europe)"
+	description "Skindiver (Europe)"
+	rom ( name "Skindiver (Europe).a26" size 4096 crc 9a98888c md5 340f546d59e72fb358c49ac2ca8482bb sha1 a86bf5762c4766c4de00b49b29d0df9a7ee417e0 )
 )
 
 game (
-	name "Demon Attack (Unknown) (PAL)"
-	description "Demon Attack (Unknown) (PAL)"
-	rom ( name "Demon Attack (Unknown) (PAL).bin" size 4096 crc b7ad372c md5 undefined sha1 03a9ea4191358ea65778b74b2f265089706a9a9a )
+	name "Sky Alien (Europe)"
+	description "Sky Alien (Europe)"
+	rom ( name "Sky Alien (Europe).a26" size 4096 crc a23eaac5 md5 c31a17942d162b80962cb1f7571cd1d5 sha1 12acae81097b752d2446c9456996bdccc3d625d5 )
 )
 
 game (
-	name "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner - Sears) (CX2615 - 49-75140) ~"
-	description "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner - Sears) (CX2615 - 49-75140) ~"
-	rom ( name "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner - Sears) (CX2615 - 49-75140) ~.bin" size 4096 crc 9b97c3da md5 undefined sha1 b45582de81c48b04c2bb758d69021e8088c70ce7 )
+	name "Sky Diver - Dare Diver (USA)"
+	description "Sky Diver - Dare Diver (USA)"
+	rom ( name "Sky Diver - Dare Diver (USA).a26" size 2048 crc 00312ea9 md5 46c021a3e9e2fd00919ca3dd1a6b76d8 sha1 4dde18d4abc139562fdd7a9d2fd49a1f00a9e64a )
 )
 
 game (
-	name "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner) (CX2615) (PAL)"
-	description "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner) (CX2615) (PAL)"
-	rom ( name "Demons to Diamonds (Hot Rox) (Paddle) (1982) (Atari, Alan J. Murphy, Nick 'Sandy Maiwald' Turner) (CX2615) (PAL).bin" size 4096 crc 9a61405c md5 undefined sha1 18c83930841b052b4339ccf054cd0fce6964facf )
+	name "Sky Jinks (USA)"
+	description "Sky Jinks (USA)"
+	rom ( name "Sky Jinks (USA).a26" size 2048 crc 96f8cf59 md5 2a0ba55e56e7a596146fa729acf0e109 sha1 105f722dcf9a89b683c10ddd7f684c5966c8e1db )
 )
 
 game (
-	name "Demons to Diamonds (Paddle) (CCE)"
-	description "Demons to Diamonds (Paddle) (CCE)"
-	rom ( name "Demons to Diamonds (Paddle) (CCE).bin" size 4096 crc 934aa0a2 md5 undefined sha1 38e24871d35c6c25b8fa9157244aaaff2b2b6e27 )
+	name "Sky Patrol (USA) (Proto)"
+	description "Sky Patrol (USA) (Proto)"
+	rom ( name "Sky Patrol (USA) (Proto).a26" size 8192 crc a1ecdf0e md5 4c9307de724c36fd487af6c99ca078f2 sha1 fc5f1e30db3b2469c9701dadfa95f3268fd1e4cb )
 )
 
 game (
-	name "Depth Charge (1983) (Amiga) (Prototype) ~"
-	description "Depth Charge (1983) (Amiga) (Prototype) ~"
-	rom ( name "Depth Charge (1983) (Amiga) (Prototype) ~.bin" size 4096 crc 442d6289 md5 undefined sha1 d72fd778313dca0d70202d2ff2c20213b0d3ed30 )
+	name "Sky Skipper (USA)"
+	description "Sky Skipper (USA)"
+	rom ( name "Sky Skipper (USA).a26" size 4096 crc cc6e0f22 md5 3b91c347d8e6427edbe942a7a405290d sha1 ef0a7ecfe8f3b5d1e67a736552a0cdc472803be9 )
 )
 
 game (
-	name "Der flinke Architekt (AKA Master Builder) (1983) (Quelle) (343.373 7) (PAL)"
-	description "Der flinke Architekt (AKA Master Builder) (1983) (Quelle) (343.373 7) (PAL)"
-	rom ( name "Der flinke Architekt (AKA Master Builder) (1983) (Quelle) (343.373 7) (PAL).bin" size 4096 crc c0b86ec7 md5 undefined sha1 a53f4d601c17aa146fdcbdd5d62107eca9821258 )
+	name "Slot Machine - Slots (USA)"
+	description "Slot Machine - Slots (USA)"
+	rom ( name "Slot Machine - Slots (USA).a26" size 2048 crc cb378d95 md5 f90b5da189f24d7e1a2117d8c8abc952 sha1 7239d1c64f3dfc2a1613be325cce13803dd2baa5 )
 )
 
 game (
-	name "Der Geheimkurier (AKA Mr. Postman) (1983) (Quelle) (802.744 3) (PAL)"
-	description "Der Geheimkurier (AKA Mr. Postman) (1983) (Quelle) (802.744 3) (PAL)"
-	rom ( name "Der Geheimkurier (AKA Mr. Postman) (1983) (Quelle) (802.744 3) (PAL).bin" size 4096 crc 8bf170ee md5 undefined sha1 18a105bf297ae1e7e9343747a002ffa97ec08ea9 )
+	name "Slot Racers - Maze (USA)"
+	description "Slot Racers - Maze (USA)"
+	rom ( name "Slot Racers - Maze (USA).a26" size 2048 crc 177dbdf8 md5 aed82052f7589df05a3f417bb4e45f0c sha1 a2b13017d759346174e3d8dd53b6347222d3b85d )
 )
 
 game (
-	name "Der hungrige Panda - Panda (Quest) (AKA Panda Chase) (1983) (Quelle) (731.662 3 - 550425) (PAL)"
-	description "Der hungrige Panda - Panda (Quest) (AKA Panda Chase) (1983) (Quelle) (731.662 3 - 550425) (PAL)"
-	rom ( name "Der hungrige Panda - Panda (Quest) (AKA Panda Chase) (1983) (Quelle) (731.662 3 - 550425) (PAL).bin" size 4096 crc d338860d md5 undefined sha1 2c108ad3fa80ed4302422edcd8f545e018881f36 )
+	name "Smurf - Rescue in Gargamel's Castle (USA)"
+	description "Smurf - Rescue in Gargamel's Castle (USA)"
+	rom ( name "Smurf - Rescue in Gargamel's Castle (USA).a26" size 8192 crc e0624a7f md5 3d1e83afdb4265fa2fb84819c9cfd39c sha1 530c7883fed4c5b9d78e35d48770b56e328999a3 )
 )
 
 game (
-	name "Der kleine Baer (AKA Frostbite) (1983) (Quelle) (685.640 5) (PAL)"
-	description "Der kleine Baer (AKA Frostbite) (1983) (Quelle) (685.640 5) (PAL)"
-	rom ( name "Der kleine Baer (AKA Frostbite) (1983) (Quelle) (685.640 5) (PAL).bin" size 4096 crc ab9db991 md5 undefined sha1 5d5f2d98c3731f78a7442415e0a39115aaaeca2c )
+	name "Smurfs Save the Day (USA)"
+	description "Smurfs Save the Day (USA)"
+	rom ( name "Smurfs Save the Day (USA).a26" size 8192 crc ad89c697 md5 a204cd4fb1944c86e800120706512a64 sha1 c0ae3965fcfab0294f770af0af57d7d1adc17750 )
 )
 
 game (
-	name "Der moderne Ritter - Mr. T (AKA Fast Eddie) (1983) (Quelle) (700.223 1 - 781627) (PAL)"
-	description "Der moderne Ritter - Mr. T (AKA Fast Eddie) (1983) (Quelle) (700.223 1 - 781627) (PAL)"
-	rom ( name "Der moderne Ritter - Mr. T (AKA Fast Eddie) (1983) (Quelle) (700.223 1 - 781627) (PAL).bin" size 4096 crc 5cd666c2 md5 undefined sha1 0a24059914ac078caee857219555ae25905447d4 )
+	name "Snail Against Squirrel (Europe)"
+	description "Snail Against Squirrel (Europe)"
+	rom ( name "Snail Against Squirrel (Europe).a26" size 4096 crc 5c5b9e1a md5 898b5467551d32af48a604802407b6e8 sha1 e7bf450cf3a3f40de9d24d89968a4bc89b53cb18 )
 )
 
 game (
-	name "Der Vielfrass (AKA Fast Food) (1983) (Quelle) (176.543 7) (PAL)"
-	description "Der Vielfrass (AKA Fast Food) (1983) (Quelle) (176.543 7) (PAL)"
-	rom ( name "Der Vielfrass (AKA Fast Food) (1983) (Quelle) (176.543 7) (PAL).bin" size 4096 crc 56ad3b5b md5 undefined sha1 03bc54eaa83872d4622513b23094c02b2b38a619 )
+	name "Sneak 'n Peek (USA)"
+	description "Sneak 'n Peek (USA)"
+	rom ( name "Sneak 'n Peek (USA).a26" size 4096 crc 93b17c39 md5 9c6faa4ff7f2ae549bbcb14f582b70e4 sha1 843e3c2fc71af2db3f2ae98eb350fde26334cfd1 )
 )
 
 game (
-	name "Desert Falcon (Nile Flyer, Sphinx) (05-27-1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (Prototype) (PAL)"
-	description "Desert Falcon (Nile Flyer, Sphinx) (05-27-1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (Prototype) (PAL)"
-	rom ( name "Desert Falcon (Nile Flyer, Sphinx) (05-27-1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (Prototype) (PAL).bin" size 8192 crc 85a0be98 md5 undefined sha1 5d9619410fd058ab8315f25910a38f4805c4b1c2 )
+	name "Snoopy and the Red Baron (USA)"
+	description "Snoopy and the Red Baron (USA)"
+	rom ( name "Snoopy and the Red Baron (USA).a26" size 8192 crc d1039967 md5 57939b326df86b74ca6404f64f89fce9 sha1 972bc0a77e76f3e4e1270ec1c2fc395e9826bc07 )
 )
 
 game (
-	name "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (PAL)"
-	description "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (PAL)"
-	rom ( name "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140, CX26140P) (PAL).bin" size 16384 crc 711d6648 md5 undefined sha1 b6ed9257bd542acfa8c4a3426094f46adbc6a93b )
+	name "Snow White and the Seven Dwarfs (USA) (Proto)"
+	description "Snow White and the Seven Dwarfs (USA) (Proto)"
+	rom ( name "Snow White and the Seven Dwarfs (USA) (Proto).a26" size 8192 crc 38598a9a md5 75ee371ccfc4f43e7d9b8f24e1266b55 sha1 5c968c6dc0db6564f4ea83a543c0bd7c3efd1032 )
 )
 
 game (
-	name "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140) ~"
-	description "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140) ~"
-	rom ( name "Desert Falcon (Nile Flyer, Sphinx) (1987) (Atari, Robert C. Polaro) (CX26140) ~.bin" size 16384 crc caa0054e md5 undefined sha1 ccea2d5095441d7e1b1468e3879a6ab556dc8b7a )
+	name "Solar Fox (USA)"
+	description "Solar Fox (USA)"
+	rom ( name "Solar Fox (USA).a26" size 8192 crc d2ca6ce8 md5 947317a89af38a49c4864d6bdd6a91fb sha1 09ea74f14db8d21ea785d0c8209ed670e4ce88be )
 )
 
 game (
-	name "Diagnostic Test Cartridge 2.0 (1980) (Atari) (50008) (Prototype) ~"
-	description "Diagnostic Test Cartridge 2.0 (1980) (Atari) (50008) (Prototype) ~"
-	rom ( name "Diagnostic Test Cartridge 2.0 (1980) (Atari) (50008) (Prototype) ~.bin" size 4096 crc e11e5726 md5 undefined sha1 7750238671b8ee1e41378adf46441adba324ea2c )
+	name "Solar Storm (USA)"
+	description "Solar Storm (USA)"
+	rom ( name "Solar Storm (USA).a26" size 4096 crc a970b3e3 md5 97842fe847e8eb71263d6f92f7e122bd sha1 ec65ef9e47239a7d15db9bca7e625b166e8ac242 )
 )
 
 game (
-	name "Diagnostic Test Cartridge 2.6 (1982) (Atari) (MA017600) ~"
-	description "Diagnostic Test Cartridge 2.6 (1982) (Atari) (MA017600) ~"
-	rom ( name "Diagnostic Test Cartridge 2.6 (1982) (Atari) (MA017600) ~.bin" size 2048 crc 38d9932d md5 undefined sha1 36d00dfc4a2fe1989da4c8acb819badfc28140d9 )
+	name "Solaris (USA)"
+	description "Solaris (USA)"
+	rom ( name "Solaris (USA).a26" size 16384 crc 2b87850e md5 e72eb8d4410152bdcb69e7fba327b420 sha1 33b16fbc95c2cdc52d84d98ca471f10dae3f9dbf )
 )
 
 game (
-	name "Diagnostic Test Cartridge 2.6P (1982) (Atari) (TE016643) (PAL) (4K)"
-	description "Diagnostic Test Cartridge 2.6P (1982) (Atari) (TE016643) (PAL) (4K)"
-	rom ( name "Diagnostic Test Cartridge 2.6P (1982) (Atari) (TE016643) (PAL) (4K).bin" size 4096 crc 24fdc482 md5 undefined sha1 d9a619e585cdf0d3f0edec1fd74abc1428498451 )
+	name "Sorcerer (USA)"
+	description "Sorcerer (USA)"
+	rom ( name "Sorcerer (USA).a26" size 4096 crc c7734be6 md5 d2c4f8a4a98a905a9deef3ba7380ed64 sha1 70e912379060d834aa9fb2baa2e6a438f3b5d3b6 )
 )
 
 game (
-	name "Dice Puzzle (1983) (Panda) (106)"
-	description "Dice Puzzle (1983) (Panda) (106)"
-	rom ( name "Dice Puzzle (1983) (Panda) (106).bin" size 4096 crc 8d05d61b md5 undefined sha1 81022ef30e682183d51b18bff145ce425c6f924e )
+	name "Sorcerer's Apprentice (USA)"
+	description "Sorcerer's Apprentice (USA)"
+	rom ( name "Sorcerer's Apprentice (USA).a26" size 8192 crc e5dbfed1 md5 5f7ae9a7f8d79a3b37e8fc841f65643a sha1 ae3009e921f23254bb71f67c8cb2d7d6de2845a5 )
 )
 
 game (
-	name "Dice Puzzle (1983) (Sancho - Tang's Electronic Co.) (TEC005) (PAL) ~"
-	description "Dice Puzzle (1983) (Sancho - Tang's Electronic Co.) (TEC005) (PAL) ~"
-	rom ( name "Dice Puzzle (1983) (Sancho - Tang's Electronic Co.) (TEC005) (PAL) ~.bin" size 4096 crc f691b853 md5 undefined sha1 509eeb7b113b09e7326618b74f90fa2eb1ddfc95 )
+	name "Space Attack (USA)"
+	description "Space Attack (USA)"
+	rom ( name "Space Attack (USA).a26" size 4096 crc b34a3e57 md5 17badbb3f54d1fc01ee68726882f26a6 sha1 560563613bc309a532d611f11a1cf2b9af1e2f16 )
 )
 
 game (
-	name "Die Ente und der Wolf (AKA Pooyan) (1983) (Quelle) (688.383 9) (PAL)"
-	description "Die Ente und der Wolf (AKA Pooyan) (1983) (Quelle) (688.383 9) (PAL)"
-	rom ( name "Die Ente und der Wolf (AKA Pooyan) (1983) (Quelle) (688.383 9) (PAL).bin" size 4096 crc d3e48afe md5 undefined sha1 61adf589c19f985928b593c69864ce4107a1f618 )
+	name "Space Cavern (USA)"
+	description "Space Cavern (USA)"
+	rom ( name "Space Cavern (USA).a26" size 4096 crc 3b0ffd89 md5 df6a28a89600affe36d94394ef597214 sha1 b757b883ee114054c650027f3b9a8f15548cbf32 )
 )
 
 game (
-	name "Die hungrigen Froesche (AKA Frogs and Flies) (1983) (Quelle) (043.151 0, 874.382 5) (PAL)"
-	description "Die hungrigen Froesche (AKA Frogs and Flies) (1983) (Quelle) (043.151 0, 874.382 5) (PAL)"
-	rom ( name "Die hungrigen Froesche (AKA Frogs and Flies) (1983) (Quelle) (043.151 0, 874.382 5) (PAL).bin" size 4096 crc c8e341b7 md5 undefined sha1 72be5b871d9bd4120c9bbf5203412dca56150191 )
+	name "Space Invaders (USA)"
+	description "Space Invaders (USA)"
+	rom ( name "Space Invaders (USA).a26" size 4096 crc a6e867b3 md5 72ffbef6504b75e69ee1045af9075f66 sha1 31d9668fe5812c3d2e076987ca327ac6b2e280bf )
 )
 
 game (
-	name "Die Ratte und die Karotten (AKA Gopher) (1983) (Quelle) (687.463 0) (PAL)"
-	description "Die Ratte und die Karotten (AKA Gopher) (1983) (Quelle) (687.463 0) (PAL)"
-	rom ( name "Die Ratte und die Karotten (AKA Gopher) (1983) (Quelle) (687.463 0) (PAL).bin" size 4096 crc 19bc29bb md5 undefined sha1 3e68cd29a1f850cb887d6f065d25f119b9a819ad )
+	name "Space Jockey (USA)"
+	description "Space Jockey (USA)"
+	rom ( name "Space Jockey (USA).a26" size 2048 crc ab24d73e md5 6f2aaffaaf53d23a28bf6677b86ac0e3 sha1 5bdd8af54020fa43065750bd4239a497695d403b )
 )
 
 game (
-	name "Die Springteufel (AKA Infiltrate) (1983) (Quelle) (176.654 2) (PAL)"
-	description "Die Springteufel (AKA Infiltrate) (1983) (Quelle) (176.654 2) (PAL)"
-	rom ( name "Die Springteufel (AKA Infiltrate) (1983) (Quelle) (176.654 2) (PAL).bin" size 4096 crc ed030be2 md5 undefined sha1 8a48eeebabd8d786ae78cde6b2cd7dc9cff89519 )
+	name "Space Shuttle - A Journey Into Space (USA)"
+	description "Space Shuttle - A Journey Into Space (USA)"
+	rom ( name "Space Shuttle - A Journey Into Space (USA).a26" size 8192 crc dd210cf3 md5 5894c9c0c1e7e29f3ab86c6d3f673361 sha1 bcec5a66f8dff1a751769626b0fce305fab44ca2 )
 )
 
 game (
-	name "Die Unterwasser Bestien - Mariana (AKA Seaquest) (1983) (Quelle) (463.734 4 - 550293) (PAL)"
-	description "Die Unterwasser Bestien - Mariana (AKA Seaquest) (1983) (Quelle) (463.734 4 - 550293) (PAL)"
-	rom ( name "Die Unterwasser Bestien - Mariana (AKA Seaquest) (1983) (Quelle) (463.734 4 - 550293) (PAL).bin" size 4096 crc d3c0b098 md5 undefined sha1 fa49ff282ab7c3c7b125d2d2ea7d1da1134e90d9 )
+	name "Space Tunnel (Europe)"
+	description "Space Tunnel (Europe)"
+	rom ( name "Space Tunnel (Europe).a26" size 4096 crc 28bc5a4d md5 d73ad614f1c2357997c88f37e75b18fe sha1 9a2c8ab7a3d0a4dfa18fc14f31a4082c3958db71 )
 )
 
 game (
-	name "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677, CX2677P) (PAL)"
-	description "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677, CX2677P) (PAL)"
-	rom ( name "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677, CX2677P) (PAL).bin" size 16384 crc de5c5553 md5 undefined sha1 816abcef9cc8fca5007cc400534e84d00285f199 )
+	name "Space War - Space Combat (USA)"
+	description "Space War - Space Combat (USA)"
+	rom ( name "Space War - Space Combat (USA).a26" size 2048 crc 65622f2a md5 a7ef44ccb5b9000caf02df3e6da71a92 sha1 23510ba617431097668eaf104aa1e36233173093 )
 )
 
 game (
-	name "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677) ~"
-	description "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677) ~"
-	rom ( name "Dig Dug (1983) (Atari - GCC, Douglas B. Macrae) (CX2677) ~.bin" size 16384 crc ee7b80d1 md5 undefined sha1 79e746524520da546249149c33614fc23a4f2a51 )
+	name "Spacechase (USA)"
+	description "Spacechase (USA)"
+	rom ( name "Spacechase (USA).a26" size 4096 crc 2954d22d md5 ec5c861b487a5075876ab01155e74c6c sha1 b356294e35827bf81add95fee5453b0ca0f497ad )
 )
 
 game (
-	name "Dishaster (AKA Dancing Plate) (1983) (ZiMAG - Emag - Vidco) (711-111 - GN-020)"
-	description "Dishaster (AKA Dancing Plate) (1983) (ZiMAG - Emag - Vidco) (711-111 - GN-020)"
-	rom ( name "Dishaster (AKA Dancing Plate) (1983) (ZiMAG - Emag - Vidco) (711-111 - GN-020).bin" size 4096 crc c8150316 md5 undefined sha1 7485cf55201ef98ded201aec73c4141f9f74f863 )
+	name "SpaceMaster X-7 (USA)"
+	description "SpaceMaster X-7 (USA)"
+	rom ( name "SpaceMaster X-7 (USA).a26" size 4096 crc e554d7d0 md5 45040679d72b101189c298a864a5b5ba sha1 983b1aff97ab1243e283ba62d3a6a75ad186d225 )
 )
 
 game (
-	name "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) [fixed] ~"
-	description "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) [fixed] ~"
-	rom ( name "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) [fixed] ~.bin" size 4096 crc 0c74479b md5 undefined sha1 157117df23cb5229386d06bbdb3af20a208722e0 )
+	name "Spider Fighter (USA)"
+	description "Spider Fighter (USA)"
+	rom ( name "Spider Fighter (USA).a26" size 4096 crc bf0941f6 md5 24d018c4a6de7e5bd19a36f2b879b335 sha1 06820ad3c957913847f9849d920bc8725f535f11 )
 )
 
 game (
-	name "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) ~"
-	description "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) ~"
-	rom ( name "Dodge 'Em - Dodger Cars (Head On) (1980) (Atari, Carla Meninsky - Sears) (CX2637 - 49-75158) ~.bin" size 4096 crc bc3602b5 md5 undefined sha1 0ffc02c54190e9dd51ac1e52c911d3d7d730a40a )
+	name "Spider Maze (USA)"
+	description "Spider Maze (USA)"
+	rom ( name "Spider Maze (USA).a26" size 4096 crc fbc1911d md5 21299c8c3ac1d54f8289d88702a738fd sha1 5d6f918bba4bd046e85b707da3b7d643cc2e1f1f )
 )
 
 game (
-	name "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL)"
-	description "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL)"
-	rom ( name "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL).bin" size 4096 crc 2fbc59cd md5 undefined sha1 cd91323991b4b64e5338a3f71e6f405222608452 )
+	name "Spider-Man (USA)"
+	description "Spider-Man (USA)"
+	rom ( name "Spider-Man (USA).a26" size 4096 crc 4dfea848 md5 199eb0b8dce1408f3f7d46411b715ca9 sha1 912c5f5571ac59a6782da412183cdd6277345816 )
 )
 
 game (
-	name "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL) [fixed]"
-	description "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL) [fixed]"
-	rom ( name "Dodge 'Em (Head On) (1980) (Atari, Carla Meninsky) (CX2637, CX2637P) (PAL) [fixed].bin" size 4096 crc 10cfc6c0 md5 undefined sha1 b26674d6e30d1a0bb2719b9bb1b3ccfa346260cf )
+	name "Spike's Peak (USA)"
+	description "Spike's Peak (USA)"
+	rom ( name "Spike's Peak (USA).a26" size 8192 crc 50efea8d md5 a4e885726af9d97b12bb5a36792eab63 sha1 205241a12778829981e9281d9c6fa137f11e1376 )
 )
 
 game (
-	name "Dodge 'Em (Unknown) (PAL)"
-	description "Dodge 'Em (Unknown) (PAL)"
-	rom ( name "Dodge 'Em (Unknown) (PAL).bin" size 4096 crc fa1ad9b8 md5 undefined sha1 e2418f72c144b0e6ced549cbb963849d53020ef4 )
+	name "Spitfire Attack (USA)"
+	description "Spitfire Attack (USA)"
+	rom ( name "Spitfire Attack (USA).a26" size 4096 crc 093507d8 md5 cef2287d5fd80216b2200fb2ef1adfa8 sha1 165de0ebca628eb1e9f564390c9eedfe289c7a1d )
 )
 
 game (
-	name "Dolphin (1983) (Activision, Matthew L. Hubbard, Bob Whitehead) (AX-024) ~"
-	description "Dolphin (1983) (Activision, Matthew L. Hubbard, Bob Whitehead) (AX-024) ~"
-	rom ( name "Dolphin (1983) (Activision, Matthew L. Hubbard, Bob Whitehead) (AX-024) ~.bin" size 4096 crc 9e38a7b9 md5 undefined sha1 e3985d759f8a8f4705f543ce7eb5e93bf63722b5 )
+	name "Springer (USA)"
+	description "Springer (USA)"
+	rom ( name "Springer (USA).a26" size 8192 crc dd183a4f md5 4cd796b5911ed3f1062e805a3df33d98 sha1 6da0aa8aa40cd9c78dc014deb9074529688d91d0 )
 )
 
 game (
-	name "Dolphin (CCE)"
-	description "Dolphin (CCE)"
-	rom ( name "Dolphin (CCE).bin" size 4096 crc 1eff90f1 md5 undefined sha1 7b34f31992da460e2c741245add5f7f19db60a04 )
+	name "Sprint Master (USA)"
+	description "Sprint Master (USA)"
+	rom ( name "Sprint Master (USA).a26" size 16384 crc c495904e md5 5a8afe5422abbfb0a342fb15afd7415f sha1 c0e29b86fc1cc41a1c8afa37572c3c5698ae70b2 )
 )
 
 game (
-	name "Donald Duck's Speedboat (Donald Duck's Regatta) (04-12-1983) (Atari) (CX26108) (Prototype) ~"
-	description "Donald Duck's Speedboat (Donald Duck's Regatta) (04-12-1983) (Atari) (CX26108) (Prototype) ~"
-	rom ( name "Donald Duck's Speedboat (Donald Duck's Regatta) (04-12-1983) (Atari) (CX26108) (Prototype) ~.bin" size 8192 crc 8db92c76 md5 undefined sha1 4606c0751f560200aede6598ec9c8e6249a105f5 )
+	name "Spy Hunter (USA)"
+	description "Spy Hunter (USA)"
+	rom ( name "Spy Hunter (USA).a26" size 8192 crc 4f804e49 md5 3105967f7222cc36a5ac6e5f6e89a0b4 sha1 1d0acf064d06a026a04b6028285db78c834e9854 )
 )
 
 game (
-	name "Donald Duck's Speedboat (Donald Duck's Regatta) (04-18-1983) (Atari) (CX26108) (Prototype) (PAL)"
-	description "Donald Duck's Speedboat (Donald Duck's Regatta) (04-18-1983) (Atari) (CX26108) (Prototype) (PAL)"
-	rom ( name "Donald Duck's Speedboat (Donald Duck's Regatta) (04-18-1983) (Atari) (CX26108) (Prototype) (PAL).bin" size 8192 crc 6f71547f md5 undefined sha1 b496e540dbc84b19185e2e597d559868cb1b10bc )
+	name "Squeeze Box (USA)"
+	description "Squeeze Box (USA)"
+	rom ( name "Squeeze Box (USA).a26" size 4096 crc d37f3fb3 md5 ba257438f8a78862a9e014d831143690 sha1 033148faebc97d4ed3a86c97fe0cdee21bd261f7 )
 )
 
 game (
-	name "Donkey Kong (1982) (CBS Electronics, Dan Kitchen, Garry Kitchen) (4L1700, 4L1701, 4L1702, 4L1802, 4L2274) (PAL)"
-	description "Donkey Kong (1982) (CBS Electronics, Dan Kitchen, Garry Kitchen) (4L1700, 4L1701, 4L1702, 4L1802, 4L2274) (PAL)"
-	rom ( name "Donkey Kong (1982) (CBS Electronics, Dan Kitchen, Garry Kitchen) (4L1700, 4L1701, 4L1702, 4L1802, 4L2274) (PAL).bin" size 4096 crc c7721daa md5 undefined sha1 48523b5e33aaa5ecda88fa0a7057512c658fcc03 )
+	name "Squoosh (USA) (Proto)"
+	description "Squoosh (USA) (Proto)"
+	rom ( name "Squoosh (USA) (Proto).a26" size 4096 crc b4212adb md5 34c808ad6577dbfa46169b73171585a3 sha1 7405d4b427cb278062fa44db918c0a702062e55c )
 )
 
 game (
-	name "Donkey Kong (1982) (Coleco, Dan Kitchen, Garry Kitchen) (2451) ~"
-	description "Donkey Kong (1982) (Coleco, Dan Kitchen, Garry Kitchen) (2451) ~"
-	rom ( name "Donkey Kong (1982) (Coleco, Dan Kitchen, Garry Kitchen) (2451) ~.bin" size 4096 crc f331b069 md5 undefined sha1 6e6e37ec8d66aea1c13ed444863e3db91497aa35 )
+	name "Sssnake (USA)"
+	description "Sssnake (USA)"
+	rom ( name "Sssnake (USA).a26" size 4096 crc 1b5b0212 md5 21a96301bb0df27fde2e7eefa49e0397 sha1 46aabde3074acded8890a2efa5586d6b8bd76b5d )
 )
 
 game (
-	name "Donkey Kong (1983) (Pet Boat) (PAL)"
-	description "Donkey Kong (1983) (Pet Boat) (PAL)"
-	rom ( name "Donkey Kong (1983) (Pet Boat) (PAL).bin" size 4096 crc 5e6527e9 md5 undefined sha1 44914e6b410837c42d5c45589527360ab0d367c2 )
+	name "Stampede (USA)"
+	description "Stampede (USA)"
+	rom ( name "Stampede (USA).a26" size 2048 crc 740800f3 md5 21d7334e406c2407e69dbddd7cec3583 sha1 277184c4e61ced14393049a21a304e941d05993f )
 )
 
 game (
-	name "Donkey Kong (1987) (Atari) (CX26143)"
-	description "Donkey Kong (1987) (Atari) (CX26143)"
-	rom ( name "Donkey Kong (1987) (Atari) (CX26143).bin" size 4096 crc f331b069 md5 undefined sha1 6e6e37ec8d66aea1c13ed444863e3db91497aa35 )
+	name "Star Fox (USA)"
+	description "Star Fox (USA)"
+	rom ( name "Star Fox (USA).a26" size 4096 crc 915ec040 md5 f526d0c519f5001adb1fc7948bfbb3ce sha1 1b95e07437ddc1523d7ec21c460273e91dbf36c7 )
 )
 
 game (
-	name "Donkey Kong (208 in 1) (Unknown) (PAL)"
-	description "Donkey Kong (208 in 1) (Unknown) (PAL)"
-	rom ( name "Donkey Kong (208 in 1) (Unknown) (PAL).bin" size 4096 crc e4b511ec md5 undefined sha1 58c4ddd4aa5466b6885c5410717e564d71ff29d8 )
+	name "Star Gunner (USA)"
+	description "Star Gunner (USA)"
+	rom ( name "Star Gunner (USA).a26" size 4096 crc fca9c17b md5 a3c1c70024d7aabb41381adbfb6d3b25 sha1 3359aa7a6a5fa25beaa3ae5868d0034d52de9882 )
 )
 
 game (
-	name "Donkey Kong (AKA Spider Kong) (Star Game) (001)"
-	description "Donkey Kong (AKA Spider Kong) (Star Game) (001)"
-	rom ( name "Donkey Kong (AKA Spider Kong) (Star Game) (001).bin" size 4096 crc 4ce700be md5 undefined sha1 01abbc2d630b9273555c7aaf1e9beba22aa0e48c )
+	name "Star Raiders (USA)"
+	description "Star Raiders (USA)"
+	rom ( name "Star Raiders (USA).a26" size 8192 crc 2ae193ee md5 cbd981a23c592fb9ab979223bb368cd5 sha1 e10cce1a438c82bd499e1eb31a3f07d7254198f5 )
 )
 
 game (
-	name "Donkey Kong Jr (AKA Donkey Kong Junior) (1983) (CCE) (C-1003)"
-	description "Donkey Kong Jr (AKA Donkey Kong Junior) (1983) (CCE) (C-1003)"
-	rom ( name "Donkey Kong Jr (AKA Donkey Kong Junior) (1983) (CCE) (C-1003).bin" size 8192 crc a1434a22 md5 undefined sha1 3bc35ae032f19f785706330c19ac117674787815 )
+	name "Star Ship - Outer Space (USA)"
+	description "Star Ship - Outer Space (USA)"
+	rom ( name "Star Ship - Outer Space (USA).a26" size 2048 crc 6609267e md5 e363e467f605537f3777ad33e74e113a sha1 878e78ed46e29c44949d0904a2198826e412ed81 )
 )
 
 game (
-	name "Donkey Kong Jr. (AKA Donkey Kong Junior) (Tron)"
-	description "Donkey Kong Jr. (AKA Donkey Kong Junior) (Tron)"
-	rom ( name "Donkey Kong Jr. (AKA Donkey Kong Junior) (Tron).bin" size 8192 crc 0404ea34 md5 undefined sha1 615c74880c48c99b8961642c4e5a96f6c63c6a31 )
+	name "Star Strike (USA)"
+	description "Star Strike (USA)"
+	rom ( name "Star Strike (USA).a26" size 4096 crc 936a596d md5 79e5338dbfa6b64008bb0d72a3179d3c sha1 de05d1ca8ad1e7a85df3faf25b1aa90b159afded )
 )
 
 game (
-	name "Donkey Kong Junior (1983) (CBS Electronics, Harley H. Puthuff Jr.) (4L1802) (PAL)"
-	description "Donkey Kong Junior (1983) (CBS Electronics, Harley H. Puthuff Jr.) (4L1802) (PAL)"
-	rom ( name "Donkey Kong Junior (1983) (CBS Electronics, Harley H. Puthuff Jr.) (4L1802) (PAL).bin" size 8192 crc ae444f76 md5 undefined sha1 f64d68964bc22b6a4217b779c1d58bc204a54307 )
+	name "Star Trek - Strategic Operations Simulator (USA)"
+	description "Star Trek - Strategic Operations Simulator (USA)"
+	rom ( name "Star Trek - Strategic Operations Simulator (USA).a26" size 8192 crc 820ea8a2 md5 03c3f7ba4585e349dd12bfa7b34b7729 sha1 61a3ebbffa0bfb761295c66e189b62915f4818d9 )
 )
 
 game (
-	name "Donkey Kong Junior (1983) (Coleco, Harley H. Puthuff Jr.) (2653) ~"
-	description "Donkey Kong Junior (1983) (Coleco, Harley H. Puthuff Jr.) (2653) ~"
-	rom ( name "Donkey Kong Junior (1983) (Coleco, Harley H. Puthuff Jr.) (2653) ~.bin" size 8192 crc 9ef649e5 md5 undefined sha1 98f98ac0728c68de66afda6500cafbdffe8ab50a )
+	name "Star Voyager (USA)"
+	description "Star Voyager (USA)"
+	rom ( name "Star Voyager (USA).a26" size 4096 crc 4fe8477f md5 813985a940aa739cc28df19e0edd4722 sha1 ccc5b829c4aa71acb7976e741fdbf59c8ef9eb55 )
 )
 
 game (
-	name "Donkey Kong Junior (1987) (Atari) (CX26144)"
-	description "Donkey Kong Junior (1987) (Atari) (CX26144)"
-	rom ( name "Donkey Kong Junior (1987) (Atari) (CX26144).bin" size 8192 crc 9ef649e5 md5 undefined sha1 98f98ac0728c68de66afda6500cafbdffe8ab50a )
+	name "Star Wars - Jedi Arena (USA)"
+	description "Star Wars - Jedi Arena (USA)"
+	rom ( name "Star Wars - Jedi Arena (USA).a26" size 4096 crc 9e36d347 md5 c9f6e521a49a2d15dac56b6ddb3fb4c7 sha1 36b9edc7150311203f375c1be10d0510efde6476 )
 )
 
 game (
-	name "Double Dragon (1989) (Activision, Dan Kitchen) (AK-050-04) ~"
-	description "Double Dragon (1989) (Activision, Dan Kitchen) (AK-050-04) ~"
-	rom ( name "Double Dragon (1989) (Activision, Dan Kitchen) (AK-050-04) ~.bin" size 16384 crc 8320bb37 md5 undefined sha1 cc99dba0a78fedd171387f492e9810f3037a5f05 )
+	name "Star Wars - Return of the Jedi - Death Star Battle (USA)"
+	description "Star Wars - Return of the Jedi - Death Star Battle (USA)"
+	rom ( name "Star Wars - Return of the Jedi - Death Star Battle (USA).a26" size 8192 crc 0886a55d md5 5336f86f6b982cc925532f2e80aa1e17 sha1 2ad9db4b5aec2da36ecc3178599b02619c3c462e )
 )
 
 game (
-	name "Double Dragon (1989) (Activision, Dan Kitchen) (EAK-050-04) (PAL)"
-	description "Double Dragon (1989) (Activision, Dan Kitchen) (EAK-050-04) (PAL)"
-	rom ( name "Double Dragon (1989) (Activision, Dan Kitchen) (EAK-050-04) (PAL).bin" size 16384 crc 5b3d8284 md5 undefined sha1 3f482acc1914c6bc92fd1fd823d6ed10c7ca65a8 )
+	name "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto)"
+	description "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto)"
+	rom ( name "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto).a26" size 8192 crc 939550e7 md5 d44d90e7c389165f5034b5844077777f sha1 b759eabf0dcb112c94b9fd66451a882130667860 )
 )
 
 game (
-	name "Double Dragon (CCE) (PAL)"
-	description "Double Dragon (CCE) (PAL)"
-	rom ( name "Double Dragon (CCE) (PAL).bin" size 16384 crc aa79a0e8 md5 undefined sha1 fc334fede2eb506a6c5b557e0109cd61f7a30919 )
+	name "Star Wars - The Arcade Game (USA)"
+	description "Star Wars - The Arcade Game (USA)"
+	rom ( name "Star Wars - The Arcade Game (USA).a26" size 8192 crc 65c31ca4 md5 6339d28c9a7f92054e70029eb0375837 sha1 8823fe3d8e3aeadc6b61ca51914e3b15aa13801c )
 )
 
 game (
-	name "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) (PAL)"
-	description "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) (PAL)"
-	rom ( name "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) (PAL).bin" size 16384 crc c22cd3bc md5 undefined sha1 78bba6d28b86f5ec080a6eae17d20ee5b25d63d7 )
+	name "Star Wars - The Empire Strikes Back (USA)"
+	description "Star Wars - The Empire Strikes Back (USA)"
+	rom ( name "Star Wars - The Empire Strikes Back (USA).a26" size 4096 crc ee8c9a89 md5 3c8e57a246742fa5d59e517134c0b4e6 sha1 ad5b2c9df558ab23ad2954fe49ed5b37a06009bf )
 )
 
 game (
-	name "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) ~"
-	description "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) ~"
-	rom ( name "Double Dunk (Super Basketball) (1989) (Atari, Matthew L. Hubbard) (CX26159) ~.bin" size 16384 crc 208f6c20 md5 undefined sha1 8e2ea320b23994dc87abe69d61249489f3a0fccc )
+	name "Stargate (USA)"
+	description "Stargate (USA)"
+	rom ( name "Stargate (USA).a26" size 8192 crc cde3530e md5 0c48e820301251fbb6bcdc89bd3555d9 sha1 4f87be0ef16a1d0389226d1fbda9b4c16b06e13e )
 )
 
 game (
-	name "Dragon Defender (Suntek) (SS-021) (PAL) ~"
-	description "Dragon Defender (Suntek) (SS-021) (PAL) ~"
-	rom ( name "Dragon Defender (Suntek) (SS-021) (PAL) ~.bin" size 4096 crc 0d57e23d md5 undefined sha1 794625475863c52259478ebd928ead829c1aaee3 )
+	name "Stargunner (USA)"
+	description "Stargunner (USA)"
+	rom ( name "Stargunner (USA).a26" size 4096 crc fca9c17b md5 a3c1c70024d7aabb41381adbfb6d3b25 sha1 3359aa7a6a5fa25beaa3ae5868d0034d52de9882 )
 )
 
 game (
-	name "Dragon Defender (Video Game Cartridge - Ariola) (TP-605) (PAL)"
-	description "Dragon Defender (Video Game Cartridge - Ariola) (TP-605) (PAL)"
-	rom ( name "Dragon Defender (Video Game Cartridge - Ariola) (TP-605) (PAL).bin" size 4096 crc 25c762c7 md5 undefined sha1 e474ad1864df56750ded71e9e457051eabfb03ee )
+	name "StarMaster (USA)"
+	description "StarMaster (USA)"
+	rom ( name "StarMaster (USA).a26" size 4096 crc 25248b4b md5 d69559f9c9dc6ef528d841bf9d91b275 sha1 814876ed270114912363e4718a84123dee213b6f )
 )
 
 game (
-	name "Dragon Treasure (AKA Dragonfire) (Funvision - Fund. International Co.)"
-	description "Dragon Treasure (AKA Dragonfire) (Funvision - Fund. International Co.)"
-	rom ( name "Dragon Treasure (AKA Dragonfire) (Funvision - Fund. International Co.).bin" size 4096 crc ba5dc02c md5 undefined sha1 b446381fe480156077b0b3c51747d156e5dde89f )
+	name "Steeplechase (Europe)"
+	description "Steeplechase (Europe)"
+	rom ( name "Steeplechase (Europe).a26" size 4096 crc 6aad3f22 md5 f1eeeccc4bba6999345a2575ae96508e sha1 bd7f0005fa018f13ed7e942c83c1751fb746a317 )
 )
 
 game (
-	name "Dragon Treasure (AKA Dragonfire) (Zellers)"
-	description "Dragon Treasure (AKA Dragonfire) (Zellers)"
-	rom ( name "Dragon Treasure (AKA Dragonfire) (Zellers).bin" size 4096 crc ba5dc02c md5 undefined sha1 b446381fe480156077b0b3c51747d156e5dde89f )
+	name "Steeplechase (USA)"
+	description "Steeplechase (USA)"
+	rom ( name "Steeplechase (USA).a26" size 2048 crc 5f6c32c3 md5 656dc247db2871766dffd978c71da80c sha1 e56ef1c0313d6d04e25446c4e34f9bb7eda8efac )
 )
 
 game (
-	name "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-1A, IA3611, IA3611C) ~"
-	description "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-1A, IA3611, IA3611C) ~"
-	rom ( name "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-1A, IA3611, IA3611C) ~.bin" size 4096 crc ba5dc02c md5 undefined sha1 b446381fe480156077b0b3c51747d156e5dde89f )
+	name "Stellar Track (USA)"
+	description "Stellar Track (USA)"
+	rom ( name "Stellar Track (USA).a26" size 4096 crc a76e93bf md5 0b8d3002d8f744a753ba434a4d39249a sha1 7d97d014c22a2ed3a5bc4b310f5a7be1b1d3520f )
 )
 
 game (
-	name "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-2A, IA3611P) (PAL)"
-	description "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-2A, IA3611P) (PAL)"
-	rom ( name "Dragonfire (Cheese) (1982) (Imagic, Bob Smith) (720020-2A, IA3611P) (PAL).bin" size 4096 crc 9b111eea md5 undefined sha1 7dffde1b8ccfd7af68645c4d74f5204b3c13c973 )
+	name "Stone Age (USA)"
+	description "Stone Age (USA)"
+	rom ( name "Stone Age (USA).a26" size 4096 crc 8bcdb222 md5 23fad5a125bcd4463701c8ad8a0043a9 sha1 45d37e37dea763956737110770e3d33de9c873a5 )
 )
 
 game (
-	name "Dragonfire (Unknown) (PAL)"
-	description "Dragonfire (Unknown) (PAL)"
-	rom ( name "Dragonfire (Unknown) (PAL).bin" size 4096 crc 4fcab711 md5 undefined sha1 de33eecf30e39c5a68db9afc3c866a35cc739ca1 )
+	name "Strategy X (USA)"
+	description "Strategy X (USA)"
+	rom ( name "Strategy X (USA).a26" size 4096 crc 2af91a81 md5 9333172e3c4992ecf548d3ac1f2553eb sha1 9d6decda6e8ab263f7380ff662c814b8cb8caf34 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	description "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	rom ( name "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400).bin" size 8448 crc ff942c31 md5 undefined sha1 9283e892dca1ad463443d347c99826bd623e0fdc )
+	name "Strawberry Shortcake - Musical Match-Ups (USA)"
+	description "Strawberry Shortcake - Musical Match-Ups (USA)"
+	rom ( name "Strawberry Shortcake - Musical Match-Ups (USA).a26" size 4096 crc fb29e31f md5 e10d2c785aadb42c06390fae0d92f282 sha1 7ca8f9cd74cfa505c493757ff37bf127ff467bb4 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	description "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	rom ( name "Dragonstomper (Excalibur) (1 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL).bin" size 8448 crc 87e14ffb md5 undefined sha1 0f4bed960092061a5e3a8a118118793b16b902b4 )
+	name "Street Racer - Speedway II (USA)"
+	description "Street Racer - Speedway II (USA)"
+	rom ( name "Street Racer - Speedway II (USA).a26" size 2048 crc 47592880 md5 396f7bc90ab4fa4975f8c74abe4e81f0 sha1 bffb3d41916c83398624151eb00aa2a3acd23ab8 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	description "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	rom ( name "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL).bin" size 25344 crc 1a50045d md5 undefined sha1 56944147fd494f8734460a89925cd945c1c7c5a5 )
+	name "Stronghold (USA)"
+	description "Stronghold (USA)"
+	rom ( name "Stronghold (USA).a26" size 4096 crc bb91ffa6 md5 7b3cf0256e1fa0fdc538caf3d5d86337 sha1 2cfe280fdbb6b5c8cda8a4620df12a5154e123be )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) ~"
-	description "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) ~"
-	rom ( name "Dragonstomper (Excalibur) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) ~.bin" size 25344 crc 291f7f92 md5 undefined sha1 d0777b4572903756c25559538ecde1a301a0b003 )
+	name "Stunt Cycle (USA) (Proto)"
+	description "Stunt Cycle (USA) (Proto)"
+	rom ( name "Stunt Cycle (USA) (Proto).a26" size 2048 crc 6354ff4c md5 c3bbc673acf2701b5275e85d9372facf sha1 2e19d7e16cf17682b043baaa30e345e6fa4540e5 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	description "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	rom ( name "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400).bin" size 8448 crc d9734371 md5 undefined sha1 1f00e06ae2f42e59637d73b37b9ccc3b130ede13 )
+	name "Sub-Scan (USA)"
+	description "Sub-Scan (USA)"
+	rom ( name "Sub-Scan (USA).a26" size 4096 crc 5069d7da md5 5af9cd346266a1f2515e1fbc86f5186a sha1 ccd75f0141b917656ef2b86c068fba3238d18a0c )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	description "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	rom ( name "Dragonstomper (Excalibur) (2 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL).bin" size 8448 crc 41301d7d md5 undefined sha1 6080703b9f16357e581be69a6154ac7186a91fac )
+	name "Submarine Commander (USA)"
+	description "Submarine Commander (USA)"
+	rom ( name "Submarine Commander (USA).a26" size 4096 crc 3262960a md5 f3f5f72bfdd67f3d0e45d097e11b8091 sha1 b22ba7cbde60a21ecbbe3953cc4a5c0bf007cc26 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	description "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	rom ( name "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400).bin" size 8448 crc fcd8c4ed md5 undefined sha1 b463d3da55cfa27c4f75550afcd07bcf28683d26 )
+	name "Subterranea (USA)"
+	description "Subterranea (USA)"
+	rom ( name "Subterranea (USA).a26" size 8192 crc 2ab951f7 md5 93c52141d3c4e1b5574d072f1afde6cd sha1 2abc6bbcab27985f19e42915530fd556b6b1ae23 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	description "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	rom ( name "Dragonstomper (Excalibur) (3 of 3) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL).bin" size 8448 crc a69d86eb md5 undefined sha1 0450f52c501c1018c7f2b8d6f18767daf17bdadc )
+	name "Suicide Mission (USA)"
+	description "Suicide Mission (USA)"
+	rom ( name "Suicide Mission (USA).a26" size 8448 crc b92c49e3 md5 e4c666ca0c36928b95b13d33474dbb44 sha1 d3919b4dbeedfabfba30126d351eab509b0c1536 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	description "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400)"
-	rom ( name "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400).bin" size 8448 crc c483f940 md5 undefined sha1 aa63009fb7dc4ece8cda3078d37f4e93b326c4df )
+	name "Summer Games (USA)"
+	description "Summer Games (USA)"
+	rom ( name "Summer Games (USA).a26" size 16384 crc b9cd3f86 md5 45027dde2be5bdd0cab522b80632717d sha1 65f4a708e6af565f1f75d0fbdc8942cb149cf299 )
 )
 
 game (
-	name "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	description "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL)"
-	rom ( name "Dragonstomper (Excalibur) (Preview) (1982) (Starpath Corporation, Stephen Harland Landrum) (6) (AR-4400) (PAL).bin" size 8448 crc d610fd7e md5 undefined sha1 7a893558f01e21b4708622cbc4b4db30c849acc6 )
+	name "Super Baseball (USA)"
+	description "Super Baseball (USA)"
+	rom ( name "Super Baseball (USA).a26" size 16384 crc c3704b73 md5 0751f342ee4cf28f2c9a6e8467c901be sha1 4c83731258126ecc7044155d17995601109a6f69 )
 )
 
 game (
-	name "Dragster - Dragster Rennen (1980) (Activision, David Crane - Ariola) (EAG-001, PAG-001, EAG-001-04B, EAG-001-04I - 711 001-715) (PAL)"
-	description "Dragster - Dragster Rennen (1980) (Activision, David Crane - Ariola) (EAG-001, PAG-001, EAG-001-04B, EAG-001-04I - 711 001-715) (PAL)"
-	rom ( name "Dragster - Dragster Rennen (1980) (Activision, David Crane - Ariola) (EAG-001, PAG-001, EAG-001-04B, EAG-001-04I - 711 001-715) (PAL).bin" size 2048 crc d26b820b md5 undefined sha1 2fdad16a60cd3a49d3bdfb301b3590f2aaa71da3 )
+	name "Super Breakout (USA)"
+	description "Super Breakout (USA)"
+	rom ( name "Super Breakout (USA).a26" size 4096 crc b0f20d31 md5 8885d0ce11c5b40c3a8a8d9ed28cefef sha1 ac2aad2196c155c1d87d6f42fa88891825f4fde6 )
 )
 
 game (
-	name "Dragster (1980) (Activision, David Crane) (AG-001) ~"
-	description "Dragster (1980) (Activision, David Crane) (AG-001) ~"
-	rom ( name "Dragster (1980) (Activision, David Crane) (AG-001) ~.bin" size 2048 crc 4042d3ab md5 undefined sha1 944c52de85464070a946813b050518977750e939 )
+	name "Super Challenge Baseball (USA)"
+	description "Super Challenge Baseball (USA)"
+	rom ( name "Super Challenge Baseball (USA).a26" size 4096 crc f7e88ec2 md5 9d37a1be4a6e898026414b8fee2fc826 sha1 dfce4d6436f91d8d385f8b01f0d8e3488400407b )
 )
 
 game (
-	name "Dragster (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Dragster (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Dragster (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 16f75f3a md5 undefined sha1 5a1113b39547954a8b2cf15258a5a52612fefb69 )
+	name "Super Challenge Football (USA)"
+	description "Super Challenge Football (USA)"
+	rom ( name "Super Challenge Football (USA).a26" size 4096 crc 55f02efe md5 e275cbe7d4e11e62c3bfcfb38fca3d49 sha1 5c1338ec76828cfa4a85b5bd8db1c00c8095c330 )
 )
 
 game (
-	name "Dream Flight (AKA Nightmare) (1983) (Goliath - Hot Shot) (83-215) (PAL)"
-	description "Dream Flight (AKA Nightmare) (1983) (Goliath - Hot Shot) (83-215) (PAL)"
-	rom ( name "Dream Flight (AKA Nightmare) (1983) (Goliath - Hot Shot) (83-215) (PAL).bin" size 4096 crc c38b5bbb md5 undefined sha1 fb1a08a3a8d3d4cd66276f5239e027db43bb06bc )
+	name "Super Cobra (USA)"
+	description "Super Cobra (USA)"
+	rom ( name "Super Cobra (USA).a26" size 8192 crc de97103d md5 c29f8db680990cb45ef7fef6ab57a2c2 sha1 bac0a0256509f8fd1feea93d74ba4c7d82c1edc6 )
 )
 
 game (
-	name "Dschungel Boy (AKA Pitfall!) (1983) (Quelle) (262.894 9) (PAL)"
-	description "Dschungel Boy (AKA Pitfall!) (1983) (Quelle) (262.894 9) (PAL)"
-	rom ( name "Dschungel Boy (AKA Pitfall!) (1983) (Quelle) (262.894 9) (PAL).bin" size 4096 crc aa168aaa md5 undefined sha1 f536dea39f64d1fd72e4ee0a98394eda39ddc3da )
+	name "Super Football (USA)"
+	description "Super Football (USA)"
+	rom ( name "Super Football (USA).a26" size 16384 crc c9b16f3c md5 09abfe9a312ce7c9f661582fdf12eab6 sha1 eaca6b474fd552ab4aaf75526618828165a91934 )
 )
 
 game (
-	name "Dukes of Hazzard (1983) (Atari, Mark R. Hahn) (CX2678) ~"
-	description "Dukes of Hazzard (1983) (Atari, Mark R. Hahn) (CX2678) ~"
-	rom ( name "Dukes of Hazzard (1983) (Atari, Mark R. Hahn) (CX2678) ~.bin" size 16384 crc 2db406dc md5 undefined sha1 c061d753435dcb7275a8764f4ad003b05fa100ed )
+	name "Superman (USA)"
+	description "Superman (USA)"
+	rom ( name "Superman (USA).a26" size 4096 crc afd7317b md5 5de8803a59c36725888346fdc6e7429d sha1 f00bcbda3d70c0c93026234fc775daf81db8569a )
 )
 
 game (
-	name "Dukes of Hazzard (AKA Stunt Cycle) (Paddle) (1980) (Atari, Robert C. Polaro) (Prototype)"
-	description "Dukes of Hazzard (AKA Stunt Cycle) (Paddle) (1980) (Atari, Robert C. Polaro) (Prototype)"
-	rom ( name "Dukes of Hazzard (AKA Stunt Cycle) (Paddle) (1980) (Atari, Robert C. Polaro) (Prototype).bin" size 2048 crc 2e09a905 md5 undefined sha1 5da98e39d2ce2dbf889e770e963e531ac9098df0 )
+	name "Surf's Up (USA) (Proto)"
+	description "Surf's Up (USA) (Proto)"
+	rom ( name "Surf's Up (USA) (Proto).a26" size 8192 crc 0cfd04d9 md5 aec9b885d0e8b24e871925630884095c sha1 cf84e21ada55730d689cfac7d26e2295317222bc )
 )
 
 game (
-	name "Dumbo's Flying Circus (05-05-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) ~"
-	description "Dumbo's Flying Circus (05-05-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) ~"
-	rom ( name "Dumbo's Flying Circus (05-05-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) ~.bin" size 8192 crc ae915725 md5 undefined sha1 fa8b32359035c51df9baca2881582bb09ab4a3d4 )
+	name "Surfer's Paradise - But Danger Below! (Europe)"
+	description "Surfer's Paradise - But Danger Below! (Europe)"
+	rom ( name "Surfer's Paradise - But Danger Below! (Europe).a26" size 4096 crc 8c68f2ae md5 c20f15282a1aa8724d70c117e5c9709e sha1 e754c8985ca7f5780c23a856656099b710e89919 )
 )
 
 game (
-	name "Dumbo's Flying Circus (07-11-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL)"
-	description "Dumbo's Flying Circus (07-11-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL)"
-	rom ( name "Dumbo's Flying Circus (07-11-1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL).bin" size 8192 crc 47a78fad md5 undefined sha1 d16eba13ab1313f375e86b488181567f846f1dc4 )
+	name "Surround - Chase (USA)"
+	description "Surround - Chase (USA)"
+	rom ( name "Surround - Chase (USA).a26" size 2048 crc dcb11f23 md5 4d7517ae69f95cfbc053be01312b7dba sha1 b7988373b81992d08056560d15d3e32d9d3888bc )
 )
 
 game (
-	name "Dumbo's Flying Circus (1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL)"
-	description "Dumbo's Flying Circus (1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL)"
-	rom ( name "Dumbo's Flying Circus (1983) (Atari, Jerome Domurat, Peter C. Niday) (CX26115) (Prototype) (PAL).bin" size 8192 crc 66b9100a md5 undefined sha1 97be2338afd40e9092de374ca86a754046dad556 )
+	name "Survival Island (USA)"
+	description "Survival Island (USA)"
+	rom ( name "Survival Island (USA).a26" size 25344 crc 8ab91d6b md5 045035f995272eb2deb8820111745a07 sha1 40808b7a653610359d38a0b5e84d3018edbd0f99 )
 )
 
 game (
-	name "Dune (07-10-1984) (Atari, Bruce Poehlman, Gary Stark) (Prototype) ~"
-	description "Dune (07-10-1984) (Atari, Bruce Poehlman, Gary Stark) (Prototype) ~"
-	rom ( name "Dune (07-10-1984) (Atari, Bruce Poehlman, Gary Stark) (Prototype) ~.bin" size 8192 crc f01f7c55 md5 undefined sha1 5e2b2d07dba3692db0ec0582b0a2cb4c2b6ad31f )
+	name "Survival Run (USA)"
+	description "Survival Run (USA)"
+	rom ( name "Survival Run (USA).a26" size 4096 crc 8c0eea30 md5 85e564dae5687e431955056fbda10978 sha1 6c993b4c70cfed390f1f436fdbaa1f81495be18e )
 )
 
 game (
-	name "Dungeon (Dark Chambers Beta) (11-22-1985) (Atari, John Howard Palevich) (CX26151, CX26151P) (Prototype)"
-	description "Dungeon (Dark Chambers Beta) (11-22-1985) (Atari, John Howard Palevich) (CX26151, CX26151P) (Prototype)"
-	rom ( name "Dungeon (Dark Chambers Beta) (11-22-1985) (Atari, John Howard Palevich) (CX26151, CX26151P) (Prototype).bin" size 4096 crc cf6efb4e md5 undefined sha1 9a8bf8d1400139636cfc1454373eeea089e74251 )
+	name "Survival Run (USA) (Proto)"
+	description "Survival Run (USA) (Proto)"
+	rom ( name "Survival Run (USA) (Proto).a26" size 4096 crc 8e888f3e md5 59e53894b3899ee164c91cfa7842da66 sha1 bcde63585092f84e437dd57f83bd67bd66b15646 )
 )
 
 game (
-	name "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) (PAL)"
-	description "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) (PAL)"
-	rom ( name "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) (PAL).bin" size 8192 crc 56cacf65 md5 undefined sha1 54828526fc7bb796bb42eb5413e049fcb34e21d7 )
+	name "Sweat! The Decathalon Game (USA)"
+	description "Sweat! The Decathalon Game (USA)"
+	rom ( name "Sweat! The Decathalon Game (USA).a26" size 16896 crc f24b44e3 md5 e51c23389e43ab328ccfb05be7d451da sha1 d786e27062623b1141806170187040a0280cc19d )
 )
 
 game (
-	name "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) ~"
-	description "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) ~"
-	rom ( name "E.T. - The Extra-Terrestrial (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2674) ~.bin" size 8192 crc 6d0a475f md5 undefined sha1 9e34f9ca51573c92918720f8a259b9449a0cd65e )
+	name "Sword of Saros (USA)"
+	description "Sword of Saros (USA)"
+	rom ( name "Sword of Saros (USA).a26" size 8448 crc d96a3632 md5 528400fad9a77fd5ad7fc5fdc2b7d69d sha1 45ab6ae206f86524e31815a736a90287cca94b70 )
 )
 
 game (
-	name "E.T. - The Extra-Terrestrial (CCE)"
-	description "E.T. - The Extra-Terrestrial (CCE)"
-	rom ( name "E.T. - The Extra-Terrestrial (CCE).bin" size 8192 crc 508767ff md5 undefined sha1 6d17f13a289dcc936a919a1dbd7d415e843c30eb )
+	name "Swordfight (USA)"
+	description "Swordfight (USA)"
+	rom ( name "Swordfight (USA).a26" size 4096 crc f1ad77be md5 87662815bc4f3c3c86071dc994e3f30e sha1 0d59545b22e15019a33de16999a57dae1f998283 )
 )
 
 game (
-	name "Earth Attack (AKA Defender) (Zellers)"
-	description "Earth Attack (AKA Defender) (Zellers)"
-	rom ( name "Earth Attack (AKA Defender) (Zellers).bin" size 4096 crc 82b2f050 md5 undefined sha1 67b660fc7a653626f5958cffb1f8a9c317d9aaa3 )
+	name "SwordQuest - EarthWorld (USA)"
+	description "SwordQuest - EarthWorld (USA)"
+	rom ( name "SwordQuest - EarthWorld (USA).a26" size 8192 crc 9031a479 md5 5aea9974b975a6a844e6df10d2b861c4 sha1 3deb650ae26b86e250aea8f7ca6d0674e6498ebb )
 )
 
 game (
-	name "Earth Dies Screaming, The (The Day the Earth Stood Still) (1983) (20th Century Fox Video Games, Dan Thompson) (11020) ~"
-	description "Earth Dies Screaming, The (The Day the Earth Stood Still) (1983) (20th Century Fox Video Games, Dan Thompson) (11020) ~"
-	rom ( name "Earth Dies Screaming, The (The Day the Earth Stood Still) (1983) (20th Century Fox Video Games, Dan Thompson) (11020) ~.bin" size 4096 crc 8a6c65f0 md5 undefined sha1 1f834923eac271bf04c18621ac2aada68d426917 )
+	name "SwordQuest - FireWorld (USA)"
+	description "SwordQuest - FireWorld (USA)"
+	rom ( name "SwordQuest - FireWorld (USA).a26" size 8192 crc 6ae46a0c md5 f9d51a4e5f8b48f68770c89ffd495ed1 sha1 5c3cf976edbea5ded66634a284787f965616d97e )
 )
 
 game (
-	name "Earth Dies Screaming, The (Unknown) (PAL)"
-	description "Earth Dies Screaming, The (Unknown) (PAL)"
-	rom ( name "Earth Dies Screaming, The (Unknown) (PAL).bin" size 4096 crc 1d131c84 md5 undefined sha1 e71071d99f5877a498d53df48c4065e7fd1e07aa )
+	name "SwordQuest - WaterWorld (USA)"
+	description "SwordQuest - WaterWorld (USA)"
+	rom ( name "SwordQuest - WaterWorld (USA).a26" size 8192 crc ca7b4685 md5 bc5389839857612cfabeb810ba7effdc sha1 569fcb67ca1674b48e2f3a2e7af7077a374402de )
 )
 
 game (
-	name "Eddy Langfinger, der Museumsdieb (AKA A Mysterious Thief) (1983) (Quelle) (732.052 6) (PAL)"
-	description "Eddy Langfinger, der Museumsdieb (AKA A Mysterious Thief) (1983) (Quelle) (732.052 6) (PAL)"
-	rom ( name "Eddy Langfinger, der Museumsdieb (AKA A Mysterious Thief) (1983) (Quelle) (732.052 6) (PAL).bin" size 4096 crc b93a7346 md5 undefined sha1 4e1ac830a8cd2ca27f92cb5d7e78c89c563e4c10 )
+	name "Tac-Scan (USA)"
+	description "Tac-Scan (USA)"
+	rom ( name "Tac-Scan (USA).a26" size 4096 crc a2a42bec md5 d45ebf130ed9070ea8ebd56176e48a38 sha1 55e98fe14b07460734781a6aa2f4f1646830c0af )
 )
 
 game (
-	name "Eggomania - Eierregen (Paddle) (1983) (Carrere Video, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC2003) (PAL)"
-	description "Eggomania - Eierregen (Paddle) (1983) (Carrere Video, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC2003) (PAL)"
-	rom ( name "Eggomania - Eierregen (Paddle) (1983) (Carrere Video, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC2003) (PAL).bin" size 4096 crc a0543f23 md5 undefined sha1 5b1a7dc9c5a6b7523f26a91ad9edb30467aff573 )
+	name "Tapeworm (USA)"
+	description "Tapeworm (USA)"
+	rom ( name "Tapeworm (USA).a26" size 4096 crc d63474b3 md5 de3d0e37729d85afcb25a8d052a6e236 sha1 ee8bc1710a67c33e9f95bb05cc3d8f841093fde2 )
 )
 
 game (
-	name "Eggomania (Canal 3 - Intellivision)"
-	description "Eggomania (Canal 3 - Intellivision)"
-	rom ( name "Eggomania (Canal 3 - Intellivision).bin" size 4096 crc 759d2baa md5 undefined sha1 71b9dfc436c4b6a218ab708115f0958cdd598121 )
+	name "Tapper (USA)"
+	description "Tapper (USA)"
+	rom ( name "Tapper (USA).a26" size 8192 crc d28afb2c md5 c0d2434348de72fa6edcc6d8e40f28d7 sha1 e986e1818e747beb9b33ce4dff1cdc6b55bdb620 )
 )
 
 game (
-	name "Eggomania (Weird Bird) (Paddle) (1982) (U.S. Games Corporation, Todd Marshall, Wes Trager, Henry Will IV) (VC2003) ~"
-	description "Eggomania (Weird Bird) (Paddle) (1982) (U.S. Games Corporation, Todd Marshall, Wes Trager, Henry Will IV) (VC2003) ~"
-	rom ( name "Eggomania (Weird Bird) (Paddle) (1982) (U.S. Games Corporation, Todd Marshall, Wes Trager, Henry Will IV) (VC2003) ~.bin" size 4096 crc c78ec927 md5 undefined sha1 68cbfadf097ae2d1e838f315c7cc7b70bbf2ccc8 )
+	name "Tax Avoiders (USA)"
+	description "Tax Avoiders (USA)"
+	rom ( name "Tax Avoiders (USA).a26" size 8192 crc 468d734c md5 a1ead9c181d67859aa93c44e40f1709c sha1 7aaf6be610ba6ea1205bdd5ed60838ccb8280d57 )
 )
 
 game (
-	name "Eishockey-Fieber (AKA Ice Hockey) (1983) (Quelle) (873.790 0) (PAL)"
-	description "Eishockey-Fieber (AKA Ice Hockey) (1983) (Quelle) (873.790 0) (PAL)"
-	rom ( name "Eishockey-Fieber (AKA Ice Hockey) (1983) (Quelle) (873.790 0) (PAL).bin" size 4096 crc 7db749d0 md5 undefined sha1 c08eda223d9bbd74d265f83dab25e1c5aed21d29 )
+	name "Taz (USA)"
+	description "Taz (USA)"
+	rom ( name "Taz (USA).a26" size 8192 crc c9d7ec9b md5 7574480ae2ab0d282c887e9015fdb54c sha1 fa4aee79487036656aabb432d7c6e13ec21e3a3c )
 )
 
 game (
-	name "Elevator Action (1983) (Atari, Dan Hitchens) (CX26126) (Prototype) ~"
-	description "Elevator Action (1983) (Atari, Dan Hitchens) (CX26126) (Prototype) ~"
-	rom ( name "Elevator Action (1983) (Atari, Dan Hitchens) (CX26126) (Prototype) ~.bin" size 8192 crc dc5a9d77 md5 undefined sha1 bab872ee41695cefe41d88e4932132eca6c4e69c )
+	name "Telepathy (USA) (Proto)"
+	description "Telepathy (USA) (Proto)"
+	rom ( name "Telepathy (USA) (Proto).a26" size 8192 crc a0996a0d md5 3d7aad37c55692814211c8b590a0334c sha1 7efc0ebe334dde84e25fa020ecde4fddcbea9e8f )
 )
 
 game (
-	name "Elf Adventure (04-22-83) (Atari, Warren Robinett) (Prototype)"
-	description "Elf Adventure (04-22-83) (Atari, Warren Robinett) (Prototype)"
-	rom ( name "Elf Adventure (04-22-83) (Atari, Warren Robinett) (Prototype).bin" size 4096 crc 3e2d9000 md5 undefined sha1 f1b3700fec94ef841935f02731dcc4b99169e67a )
+	name "Tempest (USA) (Proto)"
+	description "Tempest (USA) (Proto)"
+	rom ( name "Tempest (USA) (Proto).a26" size 8192 crc 711647f6 md5 c830f6ae7ee58bcc2a6712fb33e92d55 sha1 bf4d570c1c738a4d6d00237e25c62e9c3225f98f )
 )
 
 game (
-	name "Elf Adventure (05-02-83) (Atari, Warren Robinett) (Prototype)"
-	description "Elf Adventure (05-02-83) (Atari, Warren Robinett) (Prototype)"
-	rom ( name "Elf Adventure (05-02-83) (Atari, Warren Robinett) (Prototype).bin" size 4096 crc 0d6b598a md5 undefined sha1 c5d0f915ff6c67d36086bcb540b286cc7d0788ab )
+	name "Tennis (USA)"
+	description "Tennis (USA)"
+	rom ( name "Tennis (USA).a26" size 2048 crc 0a42515b md5 42cdd6a9e42a3639e190722b8ea3fc51 sha1 3d30e7ed617168d852923def2000c9c0a8b728c6 )
 )
 
 game (
-	name "Elf Adventure (05-25-83) (Atari, Warren Robinett) (Prototype) ~"
-	description "Elf Adventure (05-25-83) (Atari, Warren Robinett) (Prototype) ~"
-	rom ( name "Elf Adventure (05-25-83) (Atari, Warren Robinett) (Prototype) ~.bin" size 4096 crc 91647218 md5 undefined sha1 93cf13c16d995c69c78085effb555f17105f8b01 )
+	name "Texas Chainsaw Massacre, The (USA) (Proto)"
+	description "Texas Chainsaw Massacre, The (USA) (Proto)"
+	rom ( name "Texas Chainsaw Massacre, The (USA) (Proto).a26" size 4096 crc ec389caa md5 5eeb81292992e057b290a5cd196f155d sha1 717122a4184bc8db41e65ab7c369c40b21c048d9 )
 )
 
 game (
-	name "Eli's Ladder (1982) (Simage) ~"
-	description "Eli's Ladder (1982) (Simage) ~"
-	rom ( name "Eli's Ladder (1982) (Simage) ~.bin" size 4096 crc 2c5e6932 md5 undefined sha1 475fc2b23c0ee273388539a4eeafa34f8f8d3fd8 )
+	name "Threshold (USA)"
+	description "Threshold (USA)"
+	rom ( name "Threshold (USA).a26" size 4096 crc ce5097fd md5 e63a87c231ee9a506f9599aa4ef7dfb9 sha1 9a52fa88bd7455044f00548e9615452131d1c711 )
 )
 
 game (
-	name "Elk Attack (1987) (Atari, Mark R. Hahn) (Prototype) ~"
-	description "Elk Attack (1987) (Atari, Mark R. Hahn) (Prototype) ~"
-	rom ( name "Elk Attack (1987) (Atari, Mark R. Hahn) (Prototype) ~.bin" size 8192 crc 02ddde9f md5 undefined sha1 3983e109fc0b38c0b559a09a001f3e5f2bb1dc2a )
+	name "Thunderground (USA)"
+	description "Thunderground (USA)"
+	rom ( name "Thunderground (USA).a26" size 4096 crc 9e67c699 md5 cf507910d6e74568a68ac949537bccf9 sha1 3cc8bcc0ff5164303433f469aa4da2eb256d1ad0 )
 )
 
 game (
-	name "Encounter at L-5 (Megalon Invasion) (Paddle) (1982) (Data Age) (DA1001) ~"
-	description "Encounter at L-5 (Megalon Invasion) (Paddle) (1982) (Data Age) (DA1001) ~"
-	rom ( name "Encounter at L-5 (Megalon Invasion) (Paddle) (1982) (Data Age) (DA1001) ~.bin" size 4096 crc e78fe552 md5 undefined sha1 205af4051ea39fb5a038a8545c78bff91df321b7 )
+	name "Thwocker (USA) (Proto)"
+	description "Thwocker (USA) (Proto)"
+	rom ( name "Thwocker (USA) (Proto).a26" size 8192 crc b60ab310 md5 c032c2bd7017fdfbba9a105ec50f800e sha1 53ee70d4b35ee3df3ffb95fa360bddb4f2f56ab2 )
 )
 
 game (
-	name "Encounter at L-5 (Megalon Invasion) (Paddle) (1983) (Gameworld) (133-001) (PAL)"
-	description "Encounter at L-5 (Megalon Invasion) (Paddle) (1983) (Gameworld) (133-001) (PAL)"
-	rom ( name "Encounter at L-5 (Megalon Invasion) (Paddle) (1983) (Gameworld) (133-001) (PAL).bin" size 4096 crc e01a9dde md5 undefined sha1 6b1e0787ef595af5f85fef3bf780553b3fba4c7d )
+	name "Time Pilot (USA)"
+	description "Time Pilot (USA)"
+	rom ( name "Time Pilot (USA).a26" size 8192 crc 21ee7db4 md5 fc2104dd2dadf9a6176c1c1c8f87ced9 sha1 387358514964d0b6b55f9431576a59b55869f7ab )
 )
 
 game (
-	name "End of the World, The (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "End of the World, The (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "End of the World, The (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 9be88ada md5 undefined sha1 fcf34450bfd4a36a4a2a277eff0dbe5f1318e97f )
+	name "Time Warp (Europe)"
+	description "Time Warp (Europe)"
+	rom ( name "Time Warp (Europe).a26" size 4096 crc 551e2144 md5 d6d1ddd21e9d17ea5f325fa09305069c sha1 594db913e27509fe244c5c900b5dbf5991d19a3e )
 )
 
 game (
-	name "Enduro - Transamerika-Rennen (1983) (Activision, Larry Miller - Ariola) (EAX-026, EAX-026-04B, EAX-026-04I - 711 026-725) (PAL)"
-	description "Enduro - Transamerika-Rennen (1983) (Activision, Larry Miller - Ariola) (EAX-026, EAX-026-04B, EAX-026-04I - 711 026-725) (PAL)"
-	rom ( name "Enduro - Transamerika-Rennen (1983) (Activision, Larry Miller - Ariola) (EAX-026, EAX-026-04B, EAX-026-04I - 711 026-725) (PAL).bin" size 4096 crc fc2d83ac md5 undefined sha1 0a2fc2f048a9904799df26db1e17ffedad8ff302 )
+	name "Title Match Pro Wrestling (USA)"
+	description "Title Match Pro Wrestling (USA)"
+	rom ( name "Title Match Pro Wrestling (USA).a26" size 8192 crc ef708c03 md5 12123b534bdee79ed7563b9ad74f1cbd sha1 979d9b0b0f32b40c0a0568be65a0bc5ef36ca6d0 )
 )
 
 game (
-	name "Enduro (1983) (Activision, Larry Miller) (AX-026, AX-026-04) ~"
-	description "Enduro (1983) (Activision, Larry Miller) (AX-026, AX-026-04) ~"
-	rom ( name "Enduro (1983) (Activision, Larry Miller) (AX-026, AX-026-04) ~.bin" size 4096 crc 2ef17b2e md5 undefined sha1 82e9b2dd6d99f15381506a76ef958a1773a7ba21 )
+	name "Tomarc the Barbarian (USA)"
+	description "Tomarc the Barbarian (USA)"
+	rom ( name "Tomarc the Barbarian (USA).a26" size 8192 crc b5b5ac84 md5 32dcd1b535f564ee38143a70a8146efe sha1 489c9b572535721a0516a2b759e0b9c7f7a5b3cc )
 )
 
 game (
-	name "Enduro (1983) (CCE) (C-810)"
-	description "Enduro (1983) (CCE) (C-810)"
-	rom ( name "Enduro (1983) (CCE) (C-810).bin" size 4096 crc 896554db md5 undefined sha1 dd89676a38eeac903f326d2bc4022f7ceac35a4a )
+	name "Tomcat - The F-14 Fighter Simulator (USA)"
+	description "Tomcat - The F-14 Fighter Simulator (USA)"
+	rom ( name "Tomcat - The F-14 Fighter Simulator (USA).a26" size 16384 crc 8987c473 md5 3ac6c50a8e62d4ce71595134cbd8035e sha1 5b2742281fea96ab6a3a2f30e676352bcf424390 )
 )
 
 game (
-	name "Enduro (1983) (Digitel)"
-	description "Enduro (1983) (Digitel)"
-	rom ( name "Enduro (1983) (Digitel).bin" size 4096 crc 6b0123b9 md5 undefined sha1 8eb026df2ed0e07fe6af4d358ae9cfddff0d6b53 )
+	name "Tooth Protectors (USA)"
+	description "Tooth Protectors (USA)"
+	rom ( name "Tooth Protectors (USA).a26" size 8192 crc fd8c81e5 md5 fa2be8125c3c60ab83e1c0fe56922fcb sha1 d82ac7237df54cc8688e3074b58433a7dd6b7d11 )
 )
 
 game (
-	name "Enduro (1983) (Dynacom)"
-	description "Enduro (1983) (Dynacom)"
-	rom ( name "Enduro (1983) (Dynacom).bin" size 4096 crc fc2010ec md5 undefined sha1 1ed9ee32a5be8955be7b487d45838e331c5f73a5 )
+	name "Towering Inferno (USA)"
+	description "Towering Inferno (USA)"
+	rom ( name "Towering Inferno (USA).a26" size 4096 crc 2c7b86b8 md5 0aa208060d7c140f20571e3341f5a3f8 sha1 b344b3e042447afbb3e40292dc4ca063d5d1110d )
 )
 
 game (
-	name "Enduro (1984) (Supergame)"
-	description "Enduro (1984) (Supergame)"
-	rom ( name "Enduro (1984) (Supergame).bin" size 4096 crc 7db7aa4d md5 undefined sha1 ea9dfbda243dd7bccb148e3353797d5a764dca62 )
+	name "Track and Field (USA)"
+	description "Track and Field (USA)"
+	rom ( name "Track and Field (USA).a26" size 16384 crc 21827056 md5 6ae4dc6d7351dacd1012749ca82f9a56 sha1 005a6a53f5a856f0bdbca519af1ef236aaa1494d )
 )
 
 game (
-	name "Enduro (Canal 3 - Intellivision)"
-	description "Enduro (Canal 3 - Intellivision)"
-	rom ( name "Enduro (Canal 3 - Intellivision).bin" size 4096 crc ebf0378a md5 undefined sha1 c4ba92a7f2918f3f8e222091d6c47d03ccb7403b )
+	name "Treasure Below (Europe)"
+	description "Treasure Below (Europe)"
+	rom ( name "Treasure Below (Europe).a26" size 4096 crc d2cea797 md5 66706459e62514d0c39c3797cbf73ff1 sha1 9a9917d82362c77b4d396f56966219fc248edf47 )
 )
 
 game (
-	name "Enduro (Digivision)"
-	description "Enduro (Digivision)"
-	rom ( name "Enduro (Digivision).bin" size 4096 crc b1089352 md5 undefined sha1 7c931a1ab9548e02f55853ea369b68847c2d8d01 )
+	name "Treasure Island (Europe)"
+	description "Treasure Island (Europe)"
+	rom ( name "Treasure Island (Europe).a26" size 4096 crc 907f1d90 md5 1bb91bae919ddbd655fa25c54ea6f532 sha1 d1437e291fbc1927fcce14abc21a58a423e15368 )
 )
 
 game (
-	name "Enduro (Robby)"
-	description "Enduro (Robby)"
-	rom ( name "Enduro (Robby).bin" size 4096 crc 67e5e483 md5 undefined sha1 1594689eddcfcd1740e8084f29b3e37df4375f56 )
+	name "Trick Shot (USA)"
+	description "Trick Shot (USA)"
+	rom ( name "Trick Shot (USA).a26" size 4096 crc d1ce4634 md5 24df052902aa9de21c2b2525eb84a255 sha1 86c563db11db9afbffbd73c55e9fae9b2f69be4f )
 )
 
 game (
-	name "Enduro (Tron)"
-	description "Enduro (Tron)"
-	rom ( name "Enduro (Tron).bin" size 4096 crc f98649b8 md5 undefined sha1 5c327c4e8789f49d381f6c8ed3751e4d334efd91 )
+	name "TRON - Deadly Discs (USA)"
+	description "TRON - Deadly Discs (USA)"
+	rom ( name "TRON - Deadly Discs (USA).a26" size 4096 crc d35b22f9 md5 fb27afe896e7c928089307b32e5642ee sha1 0ec58a3a5a27d1b82a5f9aabab02f9a8387b6956 )
 )
 
 game (
-	name "Enduro (Unknown)"
-	description "Enduro (Unknown)"
-	rom ( name "Enduro (Unknown).bin" size 4096 crc e49ed673 md5 undefined sha1 9d51d6b8c45d04b684a215bd3f392762f7f2af8f )
+	name "Tunnel Runner (USA)"
+	description "Tunnel Runner (USA)"
+	rom ( name "Tunnel Runner (USA).a26" size 12288 crc a02745f8 md5 b2737034f974535f5c0c6431ab8caf73 sha1 fc1a0b58765a7dcbd8e33562e1074ddd9e0ac624 )
 )
 
 game (
-	name "Enduro (Unknown) (PAL)"
-	description "Enduro (Unknown) (PAL)"
-	rom ( name "Enduro (Unknown) (PAL).bin" size 4096 crc 9973b4b5 md5 undefined sha1 9b19202e3ba1f16d3261c2ce7f7106ab39c0ce19 )
+	name "Turmoil (USA)"
+	description "Turmoil (USA)"
+	rom ( name "Turmoil (USA).a26" size 4096 crc 8c65298a md5 7a5463545dfb2dcfdafa6074b2f2c15e sha1 1162fe46977f01b4d25efab813e0d05ec90aeadc )
 )
 
 game (
-	name "Entity, The (1983) (20th Century Fox Video Games, Mark Klein) (11036) (Prototype) ~"
-	description "Entity, The (1983) (20th Century Fox Video Games, Mark Klein) (11036) (Prototype) ~"
-	rom ( name "Entity, The (1983) (20th Century Fox Video Games, Mark Klein) (11036) (Prototype) ~.bin" size 4096 crc 3366ccb7 md5 undefined sha1 180d6aad4f5fe5dea553ef2e2ff233bd63592d00 )
+	name "Tutankham (USA)"
+	description "Tutankham (USA)"
+	rom ( name "Tutankham (USA).a26" size 8192 crc ec959bf2 md5 085322bae40d904f53bdcc56df0593fc sha1 a4d6bac854a70d2c55946932f1511cc62db7d4aa )
 )
 
 game (
-	name "Entombed (Maze Chase, Zombie) (1982) (U.S. Games Corporation, Paul Allen Newell, Steve Sidley, Tom Sloper) (VC2007) ~"
-	description "Entombed (Maze Chase, Zombie) (1982) (U.S. Games Corporation, Paul Allen Newell, Steve Sidley, Tom Sloper) (VC2007) ~"
-	rom ( name "Entombed (Maze Chase, Zombie) (1982) (U.S. Games Corporation, Paul Allen Newell, Steve Sidley, Tom Sloper) (VC2007) ~.bin" size 4096 crc e48ec9dc md5 undefined sha1 7905aee90a6dd64d9538e0b8e772f833ba9feb83 )
+	name "Universal Chaos (USA)"
+	description "Universal Chaos (USA)"
+	rom ( name "Universal Chaos (USA).a26" size 4096 crc 25efa169 md5 81a010abdba1a640f7adf7f84e13d307 sha1 286106fb973530bc3e2af13240f28c4bcb37e642 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	description "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200).bin" size 8448 crc 20817f5d md5 undefined sha1 aa7179ed05d6afb6ec8bcd06c589d4b137ec1bd6 )
+	name "Unknown 20th Century Fox Game (USA) (Proto)"
+	description "Unknown 20th Century Fox Game (USA) (Proto)"
+	rom ( name "Unknown 20th Century Fox Game (USA) (Proto).a26" size 8192 crc 0748817d md5 5f950a2d1eb331a1276819520705df94 sha1 3da6a2cc699945f708dac4e880ff6e085c635bbd )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (1 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 8448 crc 191c532a md5 undefined sha1 e870fbbc07213b1cc552872f3115f33c1f5b351c )
+	name "Unknown Activision Game #1 (USA) (Proto)"
+	description "Unknown Activision Game #1 (USA) (Proto)"
+	rom ( name "Unknown Activision Game #1 (USA) (Proto).a26" size 4096 crc 6b0672a6 md5 ee681f566aad6c07c61bbbfc66d74a27 sha1 d93c86970d3df29326acc35c0ce6679b83c2aff2 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 33792 crc aca1f8b3 md5 undefined sha1 4cda82176cabc3e532ebcad0f633179a6c403bae )
+	name "Unknown Activision Game #2 (USA) (Proto)"
+	description "Unknown Activision Game #2 (USA) (Proto)"
+	rom ( name "Unknown Activision Game #2 (USA) (Proto).a26" size 4096 crc 5c009ea0 md5 700a786471c8a91ec09e2f8e47f14a04 sha1 a25c4b33e1c86895cb63635bd6ca5b8379a206b3 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) ~"
-	description "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) ~"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) ~.bin" size 33792 crc fd0c8bfc md5 undefined sha1 adb24298457e15faacda532d50b7253bef0ef3b2 )
+	name "Unknown Datatech Game (USA)"
+	description "Unknown Datatech Game (USA)"
+	rom ( name "Unknown Datatech Game (USA).a26" size 4096 crc 95c37983 md5 73e66e82ac22b305eb4d9578e866236e sha1 5112edc18885b2fbde4adc2111176c87b41f0352 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	description "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200).bin" size 8448 crc f08aa960 md5 undefined sha1 7cc06554cea3030fc88b537c70f2adb33e4a3f59 )
+	name "Up 'n Down (USA)"
+	description "Up 'n Down (USA)"
+	rom ( name "Up 'n Down (USA).a26" size 8192 crc c04c2b58 md5 a499d720e7ee35c62424de882a3351b6 sha1 6bde671a50330af154ed15e73fdba3fa55f23d87 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (2 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 8448 crc 9a84b9e2 md5 undefined sha1 a72859502b9437e1e8ccf984f2e61aabc908ed28 )
+	name "Vanguard (USA)"
+	description "Vanguard (USA)"
+	rom ( name "Vanguard (USA).a26" size 8192 crc c4bec521 md5 c6556e082aac04260596b4045bc122de sha1 01475d037cb7a2a892be09d67083102fa9159216 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	description "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200).bin" size 8448 crc b9e64de8 md5 undefined sha1 b7e626c13bc53665a37e465d6beeb5a15e6e526c )
+	name "Vault Assault (USA)"
+	description "Vault Assault (USA)"
+	rom ( name "Vault Assault (USA).a26" size 4096 crc 856a6efb md5 787ebc2609a31eb5c57c4a18837d1aee sha1 dce98883e813d77e03a5de975d4c52bfb34e7f77 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (3 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 8448 crc 5b363d93 md5 undefined sha1 b4415af06ec8abf01c3127f17864b3d4c1e827db )
+	name "Venetian Blinds Demo (USA)"
+	description "Venetian Blinds Demo (USA)"
+	rom ( name "Venetian Blinds Demo (USA).a26" size 2048 crc 1f0d3562 md5 d08fccfbebaa531c4a4fa7359393a0a9 sha1 81f485b545445080e009adf0f2e93dd4f16b92ce )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	description "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200).bin" size 8448 crc abd4967d md5 undefined sha1 3db8d34567d9c27c41ce560b9eacc6148cd85163 )
+	name "Venture (USA)"
+	description "Venture (USA)"
+	rom ( name "Venture (USA).a26" size 4096 crc 85e0ca62 md5 3e899eba0ca8cd2972da1ae5479b4f0d sha1 0305dfc99bf192e53452a1e0408ccc148940afcd )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (4 of 4) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 8448 crc 7fbcc11f md5 undefined sha1 49bb0dfaadda7201787ca110b51ef3320963ca9f )
+	name "Video Checkers - Checkers (USA)"
+	description "Video Checkers - Checkers (USA)"
+	rom ( name "Video Checkers - Checkers (USA).a26" size 4096 crc 3df33335 md5 539d26b6e9df0da8e7465f0f5ad863b7 sha1 babae88a832b76d8c5af6ea63b8f10a0da5bb992 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	description "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200).bin" size 8448 crc 5a1deb25 md5 undefined sha1 7a32131911eb04957facc87b4333308b44e02c02 )
+	name "Video Chess (USA)"
+	description "Video Chess (USA)"
+	rom ( name "Video Chess (USA).a26" size 4096 crc b6226a54 md5 f0b7db930ca0e548c41a97160b9f6275 sha1 043ef523e4fcb9fc2fc2fda21f15671bf8620fc3 )
 )
 
 game (
-	name "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	description "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL)"
-	rom ( name "Escape from the Mindmaster (Labyrinth) (Preview) (1982) (Starpath Corporation, Dennis Caswell) (5) (AR-4200) (PAL).bin" size 8448 crc cd4bc0e0 md5 undefined sha1 65c7016bc60b7035645cdf1cb50bb396fce60aa0 )
+	name "Video Jogger (USA)"
+	description "Video Jogger (USA)"
+	rom ( name "Video Jogger (USA).a26" size 4096 crc 28fa8d77 md5 4191b671bcd8237fc8e297b4947f2990 sha1 1554b146d076b64776bf49136cea01f60eeba4c1 )
 )
 
 game (
-	name "Espial (1984) (Tigervision - Teldec) (7-012 - 3.60016 VC) (PAL)"
-	description "Espial (1984) (Tigervision - Teldec) (7-012 - 3.60016 VC) (PAL)"
-	rom ( name "Espial (1984) (Tigervision - Teldec) (7-012 - 3.60016 VC) (PAL).bin" size 8192 crc 34b80a97 md5 undefined sha1 27d925d482553deff23f0889b3051091977d6920 )
+	name "Video Life (USA)"
+	description "Video Life (USA)"
+	rom ( name "Video Life (USA).a26" size 2048 crc 34b0b5c2 md5 497f3d2970c43e5224be99f75e97cbbb sha1 3b18db73933747851eba9a0ffa3c12b9f602a95c )
 )
 
 game (
-	name "Espial (1984) (Tigervision) (7-012) ~"
-	description "Espial (1984) (Tigervision) (7-012) ~"
-	rom ( name "Espial (1984) (Tigervision) (7-012) ~.bin" size 8192 crc 1f95351a md5 undefined sha1 5db168bb450dc82f618dfa60b9f271ade3a057c7 )
+	name "Video Olympics - Pong Sports (USA)"
+	description "Video Olympics - Pong Sports (USA)"
+	rom ( name "Video Olympics - Pong Sports (USA).a26" size 2048 crc e4bc89c4 md5 60e0ea3cbe0913d39803477945e9e5ec sha1 1ffe89d79d55adabc0916b95cc37e18619ef7830 )
 )
 
 game (
-	name "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	description "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	rom ( name "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype).bin" size 8448 crc 73007594 md5 undefined sha1 eaea4c24280cf11e11d62bbbe5c0c74448f497e8 )
+	name "Video Pinball - Arcade Pinball (USA)"
+	description "Video Pinball - Arcade Pinball (USA)"
+	rom ( name "Video Pinball - Arcade Pinball (USA).a26" size 4096 crc 10d95426 md5 107cc025334211e6d29da0b6be46aec7 sha1 2c16c1a6374c8e22275d152d93dd31ffba26271f )
 )
 
 game (
-	name "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype) [a]"
-	description "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype) [a]"
-	rom ( name "Excalibur (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype) [a].bin" size 8448 crc 24885ec2 md5 undefined sha1 c6a8bb97d1891a45d9d5b6b799a3602ed7c83ef1 )
+	name "Video Reflex (USA)"
+	description "Video Reflex (USA)"
+	rom ( name "Video Reflex (USA).a26" size 4096 crc 77b8b0d1 md5 ee659ae50e9df886ac4f8d7ad10d046a sha1 dec2a3e9b366dce2b63dc1c13662d3f22420a22e )
 )
 
 game (
-	name "Excalibur Version 36 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	description "Excalibur Version 36 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	rom ( name "Excalibur Version 36 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype).bin" size 8448 crc 2a51cc8d md5 undefined sha1 9b89ba2b1481468994c6c93600053500912213f3 )
+	name "Wabbit (USA)"
+	description "Wabbit (USA)"
+	rom ( name "Wabbit (USA).a26" size 4096 crc 2d07ed77 md5 6041f400b45511aa3a69fab4b8fc8f41 sha1 73072295721453065d62d9136343b81310a4d225 )
 )
 
 game (
-	name "Excalibur Version 39 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	description "Excalibur Version 39 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype)"
-	rom ( name "Excalibur Version 39 (Dragonstomper Beta) (1982) (Arcadia Corporation, Stephen Harland Landrum) (6) (AR-4400) (Prototype).bin" size 8448 crc ba92957e md5 undefined sha1 9d515c70bb2498b44fd46f129f10be03b73c937c )
+	name "Walker (Europe)"
+	description "Walker (Europe)"
+	rom ( name "Walker (Europe).a26" size 4096 crc da8e49fb md5 7ff53f6922708119e7bf478d7d618c86 sha1 25e2043775a08762e3fc98ecb96fbf46b20e860e )
 )
 
 game (
-	name "Exocet (1982) (Sancho - Tang's Electronic Co.) (TEC001) (PAL) ~"
-	description "Exocet (1982) (Sancho - Tang's Electronic Co.) (TEC001) (PAL) ~"
-	rom ( name "Exocet (1982) (Sancho - Tang's Electronic Co.) (TEC001) (PAL) ~.bin" size 4096 crc 5cc39028 md5 undefined sha1 07b12357904ec3a4846d27b3790581f6eb5da2b7 )
+	name "Wall Ball (USA)"
+	description "Wall Ball (USA)"
+	rom ( name "Wall Ball (USA).a26" size 4096 crc 9ac6a295 md5 d3456b4cf1bd1a7b8fb907af1a80ee15 sha1 482bd349222b8c702e125c27fd516e73af13967b )
 )
 
 game (
-	name "Exocet (1983) (Panda) (109)"
-	description "Exocet (1983) (Panda) (109)"
-	rom ( name "Exocet (1983) (Panda) (109).bin" size 4096 crc fd424b96 md5 undefined sha1 c17801c0190ade27f438e2aa98dde81b3ae66267 )
+	name "Wall Break (Europe)"
+	description "Wall Break (Europe)"
+	rom ( name "Wall Break (Europe).a26" size 4096 crc 727408cd md5 372bddf113d088bc572f94e98d8249f5 sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
 )
 
 game (
-	name "Exoset Missile (AKA Exocet) (1982) (John Sands Electronics) (JS145B) (PAL)"
-	description "Exoset Missile (AKA Exocet) (1982) (John Sands Electronics) (JS145B) (PAL)"
-	rom ( name "Exoset Missile (AKA Exocet) (1982) (John Sands Electronics) (JS145B) (PAL).bin" size 4096 crc 5cc39028 md5 undefined sha1 07b12357904ec3a4846d27b3790581f6eb5da2b7 )
+	name "Warlords (USA)"
+	description "Warlords (USA)"
+	rom ( name "Warlords (USA).a26" size 4096 crc cf174b57 md5 cbe5a166550a8129a5e6d374901dffad sha1 2d7563d337cbc0cdf4fc14f69853ab6757697788 )
 )
 
 game (
-	name "Extra Terrestrials (1984) (Skill Screen Games, Herman Quast) ~"
-	description "Extra Terrestrials (1984) (Skill Screen Games, Herman Quast) ~"
-	rom ( name "Extra Terrestrials (1984) (Skill Screen Games, Herman Quast) ~.bin" size 4096 crc 3889d018 md5 undefined sha1 c7ba5912d40eb2992fda0f99eb7028d99edad72c )
+	name "Warplock (USA)"
+	description "Warplock (USA)"
+	rom ( name "Warplock (USA).a26" size 4096 crc 6531d4e1 md5 679e910b27406c6a2072f9569ae35fc8 sha1 232a370519a7fcce121e15f850d0d3671909f8b8 )
 )
 
 game (
-	name "F-14 Tomcat (1988) (Absolute Entertainment, Dan Kitchen) (PAL)"
-	description "F-14 Tomcat (1988) (Absolute Entertainment, Dan Kitchen) (PAL)"
-	rom ( name "F-14 Tomcat (1988) (Absolute Entertainment, Dan Kitchen) (PAL).bin" size 16384 crc 0966e8ed md5 undefined sha1 684275b22f2bac7d577cf48cf42fa14fa6f69678 )
+	name "Wing War (Europe)"
+	description "Wing War (Europe)"
+	rom ( name "Wing War (Europe).a26" size 8192 crc cfebef9e md5 4e02880beeb8dbd4da724a3f33f0971f sha1 1ce2426a1a71ebac81709c88eb30e461b29158e2 )
 )
 
 game (
-	name "Fantastic Voyage (1982) (20th Century Fox Video Games, David Lubar) (11008) ~"
-	description "Fantastic Voyage (1982) (20th Century Fox Video Games, David Lubar) (11008) ~"
-	rom ( name "Fantastic Voyage (1982) (20th Century Fox Video Games, David Lubar) (11008) ~.bin" size 4096 crc a60e153f md5 undefined sha1 6297dd336a6343f98cd142d1d3d76ce84770a488 )
+	name "Wings (USA) (Proto)"
+	description "Wings (USA) (Proto)"
+	rom ( name "Wings (USA) (Proto).a26" size 12288 crc 5e89b8af md5 8e48ea6ea53709b98e6f4bd8aa018908 sha1 419e7dd24c810afb8b8e555ed8489853b0bf05d8 )
 )
 
 game (
-	name "Fantastic Voyage (208 in 1) (Unknown) (PAL)"
-	description "Fantastic Voyage (208 in 1) (Unknown) (PAL)"
-	rom ( name "Fantastic Voyage (208 in 1) (Unknown) (PAL).bin" size 4096 crc be72caa9 md5 undefined sha1 5d84b54f672b92f870985277d6ea0ac9c1f6e9f5 )
+	name "Winter Games (USA)"
+	description "Winter Games (USA)"
+	rom ( name "Winter Games (USA).a26" size 16384 crc ddff6850 md5 83fafd7bd12e3335166c6314b3bde528 sha1 6850d329e8ab403bdae38850665a2eff91278e92 )
 )
 
 game (
-	name "Farmer Dan (AKA Gopher) (Zellers)"
-	description "Farmer Dan (AKA Gopher) (Zellers)"
-	rom ( name "Farmer Dan (AKA Gopher) (Zellers).bin" size 4096 crc 9aee6020 md5 undefined sha1 a19e8b53a09eb05b073fa759ff0258a60da7144d )
+	name "Wizard (USA) (Proto)"
+	description "Wizard (USA) (Proto)"
+	rom ( name "Wizard (USA) (Proto).a26" size 2048 crc a0bcc502 md5 7b24bfe1b61864e758ada1fe9adaa098 sha1 2499ce7c77536b2920753968135f9180bd9afe6e )
 )
 
 game (
-	name "Farmyard Fun (AKA Play Farm) (Suntek) (SS-034) (PAL)"
-	description "Farmyard Fun (AKA Play Farm) (Suntek) (SS-034) (PAL)"
-	rom ( name "Farmyard Fun (AKA Play Farm) (Suntek) (SS-034) (PAL).bin" size 4096 crc 38f28235 md5 undefined sha1 6f2cce0737f60310892801c42673ee27420f96dc )
+	name "Wizard of Wor (USA)"
+	description "Wizard of Wor (USA)"
+	rom ( name "Wizard of Wor (USA).a26" size 4096 crc 926f6f11 md5 7e8aa18bc9502eb57daaf5e7c1e94da7 sha1 326e5e63a54ec6a0231fd38e62e352004d4719fe )
 )
 
 game (
-	name "Farmyard Fun (AKA Play Farm) (Video Game Cartridge - Ariola) (TP-617)"
-	description "Farmyard Fun (AKA Play Farm) (Video Game Cartridge - Ariola) (TP-617)"
-	rom ( name "Farmyard Fun (AKA Play Farm) (Video Game Cartridge - Ariola) (TP-617).bin" size 4096 crc 73474b03 md5 undefined sha1 63a24d4f86529974ee38f0e3bd6602470835c993 )
+	name "Word Zapper (USA)"
+	description "Word Zapper (USA)"
+	rom ( name "Word Zapper (USA).a26" size 4096 crc a11eeeab md5 ec3beb6d8b5689e867bafb5d5f507491 sha1 806c5a8a7b042a1a3ada1b6f29451a3446f93da3 )
 )
 
 game (
-	name "Fast Eddie (1982) (20th Century Fox Video Games - Sirius Software, Mark Turmell) (11003) ~"
-	description "Fast Eddie (1982) (20th Century Fox Video Games - Sirius Software, Mark Turmell) (11003) ~"
-	rom ( name "Fast Eddie (1982) (20th Century Fox Video Games - Sirius Software, Mark Turmell) (11003) ~.bin" size 4096 crc 0c0a7a02 md5 undefined sha1 a5614c751f29118ddb3dec9794612b98a0f00b98 )
+	name "Words-Attack (Europe) (Proto)"
+	description "Words-Attack (Europe) (Proto)"
+	rom ( name "Words-Attack (Europe) (Proto).a26" size 4096 crc 77975baa md5 2facd460a6828e0e476d3ac4b8c5f4f7 sha1 84f4b60f351f23e664613ac3d155bb354b800cd5 )
 )
 
 game (
-	name "Fast Eddie (1983) (CCE) (C-834)"
-	description "Fast Eddie (1983) (CCE) (C-834)"
-	rom ( name "Fast Eddie (1983) (CCE) (C-834).bin" size 4096 crc 243c06bf md5 undefined sha1 b3b30de820b85e454a1510c60cadb30511b655f7 )
+	name "World End (Europe)"
+	description "World End (Europe)"
+	rom ( name "World End (Europe).a26" size 4096 crc dcc36508 md5 130c5742cd6cbe4877704d733d5b08ca sha1 0e981d6baa7e3e218608eb46ad51fb30675babac )
 )
 
 game (
-	name "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) (PAL)"
-	description "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) (PAL)"
-	rom ( name "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) (PAL).bin" size 4096 crc 2e3af4bc md5 undefined sha1 8191514af62e280cd2261f9f2403eab6aae1c098 )
+	name "Worm War I (USA)"
+	description "Worm War I (USA)"
+	rom ( name "Worm War I (USA).a26" size 4096 crc 97b83a54 md5 87f020daa98d0132e98e43db7d8fea7e sha1 36a1e73eb5aa5c3cd0b01af5117d19b8c36071e4 )
 )
 
 game (
-	name "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) ~"
-	description "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) ~"
-	rom ( name "Fast Food (1982) (Telesys, Don 'Donyo' Ruffcorn, Jack Woodman) (1003) ~.bin" size 4096 crc 62388455 md5 undefined sha1 c62a70645939480b184e3b2e378ec4bcbd484bc7 )
+	name "X-Man (USA)"
+	description "X-Man (USA)"
+	rom ( name "X-Man (USA).a26" size 4096 crc 91659af1 md5 5961d259115e99c30b64fe7058256bcf sha1 1c5d151e86c0a0bbdf3b33ef153888c6be78c36b )
 )
 
 game (
-	name "Fast Food (Unknown) (PAL)"
-	description "Fast Food (Unknown) (PAL)"
-	rom ( name "Fast Food (Unknown) (PAL).bin" size 4096 crc ef9f6781 md5 undefined sha1 3017342f592acc878f16ed41bdb2a9db5d554112 )
+	name "Xenophobe (USA)"
+	description "Xenophobe (USA)"
+	rom ( name "Xenophobe (USA).a26" size 16384 crc f875c406 md5 eaf744185d5e8def899950ba7c6e7bb5 sha1 160b6e36437ad6acbc2686fbde1002e2fa88c5fb )
 )
 
 game (
-	name "Fast Food (Zirok)"
-	description "Fast Food (Zirok)"
-	rom ( name "Fast Food (Zirok).bin" size 4096 crc defff649 md5 undefined sha1 ae26b181c68d179b6c193167776b95a663c3a54f )
+	name "Xevious (USA) (Proto)"
+	description "Xevious (USA) (Proto)"
+	rom ( name "Xevious (USA) (Proto).a26" size 8192 crc 2ef09f4a md5 c6688781f4ab844852f4e3352772289b sha1 73133b81196e5cbc1cec99eefc1223ddb8f4ca83 )
 )
 
 game (
-	name "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (PAL) ~"
-	description "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (PAL) ~"
-	rom ( name "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (PAL) ~.bin" size 32768 crc 991d2348 md5 undefined sha1 d0bb58ea1fc37e929e5f7cdead037bb14a166451 )
+	name "Yahtzee (USA)"
+	description "Yahtzee (USA)"
+	rom ( name "Yahtzee (USA).a26" size 4096 crc 5c93f4d0 md5 d090836f0a4ea8db9ac7abb7d6adf61e sha1 6a1e0142c6886a6589a58e029e5aec6b72f7d27f )
 )
 
 game (
-	name "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (Prototype)"
-	description "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (Prototype)"
-	rom ( name "Fatal Run (Ultimate Driving) (1989) (Atari - Sculptured Software, Steve Aguirre) (CX26162) (Prototype).bin" size 32768 crc 60b08497 md5 undefined sha1 59d004547e693aa05bb3333f055163ade2c9ea95 )
+	name "Yars' Revenge (USA)"
+	description "Yars' Revenge (USA)"
+	rom ( name "Yars' Revenge (USA).a26" size 4096 crc dfa1c825 md5 c5930d0e8cdae3e037349bfa08e871be sha1 e2cd8996c1cf929e29130690024d1ec23d3b0bde )
 )
 
 game (
-	name "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-1A, 03205) ~"
-	description "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-1A, 03205) ~"
-	rom ( name "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-1A, 03205) ~.bin" size 8192 crc 93da13cc md5 undefined sha1 686427cc47b69980d292d04597270347942773ff )
+	name "Zaxxon (USA)"
+	description "Zaxxon (USA)"
+	rom ( name "Zaxxon (USA).a26" size 8192 crc 265aa87f md5 eea0da9b987d661264cce69a7c13c3bd sha1 58c2f6abc5599cd35c0e722f24bcc128ac8f9a30 )
 )
 
 game (
-	name "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-2A, 13205) (PAL)"
-	description "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-2A, 13205) (PAL)"
-	rom ( name "Fathom (Scuba) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Rob Fulop) (720111-2A, 13205) (PAL).bin" size 8192 crc cd27a95c md5 undefined sha1 806e3eb977dffe86fb09ad2d8d4e1766fb7aa539 )
+	name "Zoo Fun (USA)"
+	description "Zoo Fun (USA)"
+	rom ( name "Zoo Fun (USA).a26" size 4096 crc c1da05f6 md5 fb833ed50c865a9a505a125fc9d79a7e sha1 feb6bd37e5d722bd080433587972b980afff5fa5 )
 )
 
 game (
-	name "Felix Return (AKA Bobby Is Going Home) (1983) (Goliath - Hot Shot) (83-116) (PAL)"
-	description "Felix Return (AKA Bobby Is Going Home) (1983) (Goliath - Hot Shot) (83-116) (PAL)"
-	rom ( name "Felix Return (AKA Bobby Is Going Home) (1983) (Goliath - Hot Shot) (83-116) (PAL).bin" size 4096 crc 31bc54ae md5 undefined sha1 5e48b5e98be4e8d2d8602b0039c3ea959d6a0731 )
-)
-
-game (
-	name "Festival (AKA Carnival) (4 Game in One) (1983) (Bit Corporation) (PGP230) (PAL)"
-	description "Festival (AKA Carnival) (4 Game in One) (1983) (Bit Corporation) (PGP230) (PAL)"
-	rom ( name "Festival (AKA Carnival) (4 Game in One) (1983) (Bit Corporation) (PGP230) (PAL).bin" size 4096 crc bc9b5415 md5 undefined sha1 6593f863256a31747b78eb8d02c56cb1811a84b4 )
-)
-
-game (
-	name "Feuerwehr im Einsatz (AKA Fire Fighter) (1983) (Quelle) (343.173 1) (PAL)"
-	description "Feuerwehr im Einsatz (AKA Fire Fighter) (1983) (Quelle) (343.173 1) (PAL)"
-	rom ( name "Feuerwehr im Einsatz (AKA Fire Fighter) (1983) (Quelle) (343.173 1) (PAL).bin" size 4096 crc c6b6bce5 md5 undefined sha1 22f6b8fc8467425bd199f3cbc9d69ce791820e25 )
-)
-
-game (
-	name "Fighter Pilot (AKA Tomcat - The F-14 Fighter Simulator) (1988) (Activision, Dan Kitchen) (EAK-046-04B) (PAL)"
-	description "Fighter Pilot (AKA Tomcat - The F-14 Fighter Simulator) (1988) (Activision, Dan Kitchen) (EAK-046-04B) (PAL)"
-	rom ( name "Fighter Pilot (AKA Tomcat - The F-14 Fighter Simulator) (1988) (Activision, Dan Kitchen) (EAK-046-04B) (PAL).bin" size 16384 crc 0966e8ed md5 undefined sha1 684275b22f2bac7d577cf48cf42fa14fa6f69678 )
-)
-
-game (
-	name "Final Approach (1982) (Apollo) (AP-2009) ~"
-	description "Final Approach (1982) (Apollo) (AP-2009) ~"
-	rom ( name "Final Approach (1982) (Apollo) (AP-2009) ~.bin" size 4096 crc ff23f469 md5 undefined sha1 ba9a8ccfeb552dd756c660ea843a39619d3c77e9 )
-)
-
-game (
-	name "Fire Bird (AKA Phoenix) (Video Game Program) (PAL)"
-	description "Fire Bird (AKA Phoenix) (Video Game Program) (PAL)"
-	rom ( name "Fire Bird (AKA Phoenix) (Video Game Program) (PAL).bin" size 8192 crc e6bec83c md5 undefined sha1 e2843b86da000d6e4a6fe683243a7b3e3e160c77 )
-)
-
-game (
-	name "Fire Birds (AKA Sky Alien) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 383) (PAL)"
-	description "Fire Birds (AKA Sky Alien) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 383) (PAL)"
-	rom ( name "Fire Birds (AKA Sky Alien) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 383) (PAL).bin" size 4096 crc aa4d1492 md5 undefined sha1 52e5067109b7e372952a7d0094cef8d16d32a939 )
-)
-
-game (
-	name "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-1A, IA3400) ~"
-	description "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-1A, IA3400) ~"
-	rom ( name "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-1A, IA3400) ~.bin" size 4096 crc e361fb42 md5 undefined sha1 f76cc14afd7aef367c5a5defbd84f3bbb2f98ba3 )
-)
-
-game (
-	name "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-2A, IA3400P, EIX-005-04I) (PAL)"
-	description "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-2A, IA3400P, EIX-005-04I) (PAL)"
-	rom ( name "Fire Fighter (Fire Fighters) (1982) (Imagic, Brad Stewart) (720105-2A, IA3400P, EIX-005-04I) (PAL).bin" size 4096 crc 1174cb1f md5 undefined sha1 cf152600adf945d741c421f21f510c8e77ae1ecb )
-)
-
-game (
-	name "Fire Fly (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1002) ~"
-	description "Fire Fly (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1002) ~"
-	rom ( name "Fire Fly (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1002) ~.bin" size 4096 crc 7a8e4ec7 md5 undefined sha1 df5420eb0f71e681e7222ede8e211a7601e7a327 )
-)
-
-game (
-	name "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) (Prototype)"
-	description "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) (Prototype)"
-	rom ( name "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) (Prototype).bin" size 8448 crc 10e4971e md5 undefined sha1 fd9ba06548a16067f1a3ab1ef48e3f32d6199191 )
-)
-
-game (
-	name "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) ~"
-	description "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) ~"
-	rom ( name "Fireball (Frantic) (Paddle) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300) ~.bin" size 8448 crc b32ae162 md5 undefined sha1 9fa9ed2622d29636f175b8745892dde48a871fd1 )
-)
-
-game (
-	name "Fireball (Frantic) (Paddle) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL)"
-	description "Fireball (Frantic) (Paddle) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL)"
-	rom ( name "Fireball (Frantic) (Paddle) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL).bin" size 8448 crc 1a382f65 md5 undefined sha1 f936c2ebc26c025e4904ae8d01be5f3e66249adb )
-)
-
-game (
-	name "Fireball (Frantic) (Preview) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300)"
-	description "Fireball (Frantic) (Preview) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300)"
-	rom ( name "Fireball (Frantic) (Preview) (1982) (Arcadia Corporation, Scott Nelson) (3) (AR-4300).bin" size 8448 crc 962c498f md5 undefined sha1 20322ad5eb2ad1c11b454d99126ce3b185351e99 )
-)
-
-game (
-	name "Fireball (Frantic) (Preview) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL)"
-	description "Fireball (Frantic) (Preview) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL)"
-	rom ( name "Fireball (Frantic) (Preview) (1982) (Starpath Corporation, Scott Nelson) (3) (AR-4300) (PAL).bin" size 8448 crc 138ccbd1 md5 undefined sha1 f7133999d072ac0560c5a9a4ec46fdd94b52dde6 )
-)
-
-game (
-	name "Firebug (AKA Spinning Fireball) (Suntek) (SS-028) (PAL)"
-	description "Firebug (AKA Spinning Fireball) (Suntek) (SS-028) (PAL)"
-	rom ( name "Firebug (AKA Spinning Fireball) (Suntek) (SS-028) (PAL).bin" size 4096 crc 533b59de md5 undefined sha1 b130a39c370be11c29bd774600352224956648e1 )
-)
-
-game (
-	name "Fisher Price (AKA Skindiver) (1983) (CCE) (C-863)"
-	description "Fisher Price (AKA Skindiver) (1983) (CCE) (C-863)"
-	rom ( name "Fisher Price (AKA Skindiver) (1983) (CCE) (C-863).bin" size 4096 crc e8295349 md5 undefined sha1 c131af4e459b4a68d4773cfd5ce9eeec70c52614 )
-)
-
-game (
-	name "Fishing (AKA Fishing Derby) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Fishing (AKA Fishing Derby) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Fishing (AKA Fishing Derby) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc f5187a3c md5 undefined sha1 162852d5d37d46daeaf824b710ddf203f9601ac9 )
-)
-
-game (
-	name "Fishing Derby - Schneller als der Hai (1980) (Activision, David Crane - Ariola) (EAG-004, PAG-004 - 711 004-715) (PAL)"
-	description "Fishing Derby - Schneller als der Hai (1980) (Activision, David Crane - Ariola) (EAG-004, PAG-004 - 711 004-715) (PAL)"
-	rom ( name "Fishing Derby - Schneller als der Hai (1980) (Activision, David Crane - Ariola) (EAG-004, PAG-004 - 711 004-715) (PAL).bin" size 2048 crc 1426e632 md5 undefined sha1 c10fb7962794f0e2270e81edadc1e1e073615f4f )
-)
-
-game (
-	name "Fishing Derby (1980) (Activision, David Crane) (AG-004) ~"
-	description "Fishing Derby (1980) (Activision, David Crane) (AG-004) ~"
-	rom ( name "Fishing Derby (1980) (Activision, David Crane) (AG-004) ~.bin" size 2048 crc 204c928f md5 undefined sha1 531e995aef6cd47b0efea72ae3e56aeee449d798 )
-)
-
-game (
-	name "Fishing Derby (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Fishing Derby (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Fishing Derby (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 9a59662d md5 undefined sha1 e77c837d07e5bb1e61fb22e2ff8d898df7346a59 )
-)
-
-game (
-	name "Fishing Derby (Canal 3 - Intellivision)"
-	description "Fishing Derby (Canal 3 - Intellivision)"
-	rom ( name "Fishing Derby (Canal 3 - Intellivision).bin" size 4096 crc 6f5cb383 md5 undefined sha1 6d77d45b0c7443d2d0eb071825b220b3a2befe0b )
-)
-
-game (
-	name "Fishing Derby (CCE)"
-	description "Fishing Derby (CCE)"
-	rom ( name "Fishing Derby (CCE).bin" size 2048 crc 489bb3d7 md5 undefined sha1 f1cf46f38370b02e12efaf925fa587968d72674e )
-)
-
-game (
-	name "Fishing Derby (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Fishing Derby (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Fishing Derby (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 7096f3f9 md5 undefined sha1 1677cc90ced43205e0397e09c30caedc4a71a345 )
-)
-
-game (
-	name "Fishing Derby (Hack) (Unknown) (PAL)"
-	description "Fishing Derby (Hack) (Unknown) (PAL)"
-	rom ( name "Fishing Derby (Hack) (Unknown) (PAL).bin" size 2048 crc 4e0e1c67 md5 undefined sha1 1f7235f831fe53f63f5a0342620771891c4c8005 )
-)
-
-game (
-	name "Flag Capture - Capture (1978) (Atari, Jim Huether - Sears) (CX2644 - 6-99824) ~"
-	description "Flag Capture - Capture (1978) (Atari, Jim Huether - Sears) (CX2644 - 6-99824) ~"
-	rom ( name "Flag Capture - Capture (1978) (Atari, Jim Huether - Sears) (CX2644 - 6-99824) ~.bin" size 2048 crc 8aa1c41e md5 undefined sha1 ac05f05f3365f5e348e1e618410065a1c2a88ee4 )
-)
-
-game (
-	name "Flag Capture (208 in 1) (Unknown) (PAL)"
-	description "Flag Capture (208 in 1) (Unknown) (PAL)"
-	rom ( name "Flag Capture (208 in 1) (Unknown) (PAL).bin" size 2048 crc 8f8caf99 md5 undefined sha1 5f4fa8c7a40f1ec62b03b8e86807c98c86a0819e )
-)
-
-game (
-	name "Flag Capture (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL)"
-	description "Flag Capture (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL)"
-	rom ( name "Flag Capture (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL).bin" size 2048 crc 4609d961 md5 undefined sha1 a519d25d60737605b9b83fc4d1cb7402bfed082d )
-)
-
-game (
-	name "Flash Gordon (1983) (20th Century Fox Video Games, David Lubar) (11015) ~"
-	description "Flash Gordon (1983) (20th Century Fox Video Games, David Lubar) (11015) ~"
-	rom ( name "Flash Gordon (1983) (20th Century Fox Video Games, David Lubar) (11015) ~.bin" size 4096 crc 0d61ce7d md5 undefined sha1 fb870ec3d51468fa4cf40e0efae9617e60c1c91c )
-)
-
-game (
-	name "Flash Gordon (Unknown) (PAL)"
-	description "Flash Gordon (Unknown) (PAL)"
-	rom ( name "Flash Gordon (Unknown) (PAL).bin" size 4096 crc 0b5c9815 md5 undefined sha1 9df3f13e143a8f36095d5b751867baf822d04dca )
-)
-
-game (
-	name "Flippern (AKA Video Pinball) (Double-Game Package) (1983) (Quelle) (781698) (PAL)"
-	description "Flippern (AKA Video Pinball) (Double-Game Package) (1983) (Quelle) (781698) (PAL)"
-	rom ( name "Flippern (AKA Video Pinball) (Double-Game Package) (1983) (Quelle) (781698) (PAL).bin" size 4096 crc c031467d md5 undefined sha1 86d4fede197afcd366a541981a173d9e74faad6e )
-)
-
-game (
-	name "Football (1979) (Atari, Bob Whitehead - Sears) (CX2625 - 6-99827, 49-75114) ~"
-	description "Football (1979) (Atari, Bob Whitehead - Sears) (CX2625 - 6-99827, 49-75114) ~"
-	rom ( name "Football (1979) (Atari, Bob Whitehead - Sears) (CX2625 - 6-99827, 49-75114) ~.bin" size 2048 crc 3b73ee02 md5 undefined sha1 c6fe4ce24bc1ebd538258d98cfe829963323acca )
-)
-
-game (
-	name "Football (208 in 1) (Unknown) (PAL)"
-	description "Football (208 in 1) (Unknown) (PAL)"
-	rom ( name "Football (208 in 1) (Unknown) (PAL).bin" size 2048 crc 1b826cb7 md5 undefined sha1 91575d27f4d8711c677bd528dcaeffee0df7e5b0 )
-)
-
-game (
-	name "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088)"
-	description "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088)"
-	rom ( name "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088).bin" size 4096 crc 55f02efe md5 undefined sha1 5c1338ec76828cfa4a85b5bd8db1c00c8095c330 )
-)
-
-game (
-	name "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088) (PAL)"
-	description "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088) (PAL)"
-	rom ( name "Football (AKA Super Challenge Football) (1989) (Telegames) (5658 A088) (PAL).bin" size 4096 crc 92f89aec md5 undefined sha1 9a26faddd1025c0fec88ab0e03bef931f37261ff )
-)
-
-game (
-	name "Forest (1983) (Sancho - Tang's Electronic Co.) (TEC006) (PAL) ~"
-	description "Forest (1983) (Sancho - Tang's Electronic Co.) (TEC006) (PAL) ~"
-	rom ( name "Forest (1983) (Sancho - Tang's Electronic Co.) (TEC006) (PAL) ~.bin" size 4096 crc 1aaab749 md5 undefined sha1 790e0a597270a5090110e3bfbdc3a076a47ced14 )
-)
-
-game (
-	name "Fox & Goat (AKA Nuts) (Double-Game Package) (1983) (Quelle) (311377) (PAL)"
-	description "Fox & Goat (AKA Nuts) (Double-Game Package) (1983) (Quelle) (311377) (PAL)"
-	rom ( name "Fox & Goat (AKA Nuts) (Double-Game Package) (1983) (Quelle) (311377) (PAL).bin" size 4096 crc 7e9152bc md5 undefined sha1 6ced6c763b9843c11af6c45ffa7ab9a295cc78bb )
-)
-
-game (
-	name "Frankenstein's Monster (1983) (Data Age) (112-008) ~"
-	description "Frankenstein's Monster (1983) (Data Age) (112-008) ~"
-	rom ( name "Frankenstein's Monster (1983) (Data Age) (112-008) ~.bin" size 4096 crc ad44dff9 md5 undefined sha1 c6023bf73818c78b2e477a9c6dac411cdbf9c0aa )
-)
-
-game (
-	name "Frankenstein's Monster (1983) (Gameworld) (133-008) (PAL)"
-	description "Frankenstein's Monster (1983) (Gameworld) (133-008) (PAL)"
-	rom ( name "Frankenstein's Monster (1983) (Gameworld) (133-008) (PAL).bin" size 4096 crc 0e6ce498 md5 undefined sha1 d3dfa61835b96aae6855f7caba0c456a2a9816a4 )
-)
-
-game (
-	name "Freeway - Das verrueckte Huhn (1981) (Activision, David Crane - Ariola) (EAG-009, PAG-009 - 711 009-720) (PAL)"
-	description "Freeway - Das verrueckte Huhn (1981) (Activision, David Crane - Ariola) (EAG-009, PAG-009 - 711 009-720) (PAL)"
-	rom ( name "Freeway - Das verrueckte Huhn (1981) (Activision, David Crane - Ariola) (EAG-009, PAG-009 - 711 009-720) (PAL).bin" size 2048 crc 152ee108 md5 undefined sha1 65192f51a271ecbdd0168c9d24ac3b8d64d63f49 )
-)
-
-game (
-	name "Freeway (1981) (Activision, David Crane) (AG-009, AG-009-04) ~"
-	description "Freeway (1981) (Activision, David Crane) (AG-009, AG-009-04) ~"
-	rom ( name "Freeway (1981) (Activision, David Crane) (AG-009, AG-009-04) ~.bin" size 2048 crc b13ec413 md5 undefined sha1 91cc7e5cd6c0d4a6f42ed66353b7ee7bb972fa3f )
-)
-
-game (
-	name "Freeway (Canal 3 - Intellivision)"
-	description "Freeway (Canal 3 - Intellivision)"
-	rom ( name "Freeway (Canal 3 - Intellivision).bin" size 4096 crc fee6c593 md5 undefined sha1 d9ca1a2f4b39c045a6c4f184d887668ed721936f )
-)
-
-game (
-	name "Freeway (CCE)"
-	description "Freeway (CCE)"
-	rom ( name "Freeway (CCE).bin" size 2048 crc bc9ef45a md5 undefined sha1 0a02e9b750b5da8ee28958a3831675db9b70e72e )
-)
-
-game (
-	name "Freeway (Dactari - Milmar)"
-	description "Freeway (Dactari - Milmar)"
-	rom ( name "Freeway (Dactari - Milmar).bin" size 2048 crc 8e92bfd1 md5 undefined sha1 30813c691bacc27b18bdeeeb9fd57cd858a267b6 )
-)
-
-game (
-	name "Freeway (Zellers)"
-	description "Freeway (Zellers)"
-	rom ( name "Freeway (Zellers).bin" size 2048 crc 1faf57c3 md5 undefined sha1 52eee69b08e7dc32e1732702a5fbf3ac8993f099 )
-)
-
-game (
-	name "Freeway Chicken (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Freeway Chicken (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Freeway Chicken (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 8ba61f5e md5 undefined sha1 37535b791a63c3e35d04ea0d14c0215680d71eda )
-)
-
-game (
-	name "Freeway Rabbit (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Freeway Rabbit (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Freeway Rabbit (AKA Freeway) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc e82e2475 md5 undefined sha1 292156b1ad05bbcb9749ded787801841d6beed0d )
-)
-
-game (
-	name "Frisco (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83104) (PAL) ~"
-	description "Frisco (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83104) (PAL) ~"
-	rom ( name "Frisco (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83104) (PAL) ~.bin" size 4096 crc 5b47448c md5 undefined sha1 59cc30a376901462e43bc78586495c72bab81fce )
-)
-
-game (
-	name "Frisco (Hack) (Unknown) (PAL)"
-	description "Frisco (Hack) (Unknown) (PAL)"
-	rom ( name "Frisco (Hack) (Unknown) (PAL).bin" size 4096 crc 096ae2a0 md5 undefined sha1 6e7a5a171a2bb70c8dee1df8480498a68ba36ce6 )
-)
-
-game (
-	name "Frisco (Unknown)"
-	description "Frisco (Unknown)"
-	rom ( name "Frisco (Unknown).bin" size 4096 crc c4f16d4d md5 undefined sha1 15d989e49c5f1af2a0fe114cdba8f6da39660e75 )
-)
-
-game (
-	name "Frog Demo (1983) (CommaVid, Joseph Biel) (PAL) ~"
-	description "Frog Demo (1983) (CommaVid, Joseph Biel) (PAL) ~"
-	rom ( name "Frog Demo (1983) (CommaVid, Joseph Biel) (PAL) ~.bin" size 2048 crc ec5ff220 md5 undefined sha1 ded4c64d60ffce5304d73e016be7deb5f2db45d4 )
-)
-
-game (
-	name "Frog Pond (08-27-1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype) ~"
-	description "Frog Pond (08-27-1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype) ~"
-	rom ( name "Frog Pond (08-27-1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype) ~.bin" size 8192 crc 5874385a md5 undefined sha1 0d6a96f857ae0e813b4d493866e2420cc5c4bad5 )
-)
-
-game (
-	name "Frog Pond (1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype)"
-	description "Frog Pond (1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype)"
-	rom ( name "Frog Pond (1982) (Atari, Nick 'Sandy Maiwald' Turner) (CX2665) (Prototype).bin" size 8192 crc 65a0380d md5 undefined sha1 de6fc1b51d41b34dcda92f579b2aa4df8eccf586 )
-)
-
-game (
-	name "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (931502) (PAL)"
-	description "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (931502) (PAL)"
-	rom ( name "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (931502) (PAL).bin" size 4096 crc 71527c5d md5 undefined sha1 b27aa85432f8704c4b3e14f6049e625cf9729aa8 )
-)
-
-game (
-	name "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (PB5300) ~"
-	description "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (PB5300) ~"
-	rom ( name "Frogger (1982) (Parker Brothers, Ed English, David Lamkins) (PB5300) ~.bin" size 4096 crc f5e1af92 md5 undefined sha1 e859b935a36494f3c4b4bf5547392600fb9c96f0 )
-)
-
-game (
-	name "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) (PAL)"
-	description "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) (PAL)"
-	rom ( name "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) (PAL).bin" size 8192 crc 09cdd3ea md5 undefined sha1 bce92de22fc8950f0eebb643d96fe9fa5dba2b72 )
-)
-
-game (
-	name "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) ~"
-	description "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) ~"
-	rom ( name "Frogger II - Threeedeep! (1984) (Parker Brothers, Mark Lesser) (PB5590) ~.bin" size 8192 crc 3ba0d9bf md5 undefined sha1 6b9e591cc53844795725fc66c564f0364d1fbe40 )
-)
-
-game (
-	name "Frogs and Flies - Frogs 'n' Flies (1982) (M Network, David Rolfe - INTV) (MT5664) ~"
-	description "Frogs and Flies - Frogs 'n' Flies (1982) (M Network, David Rolfe - INTV) (MT5664) ~"
-	rom ( name "Frogs and Flies - Frogs 'n' Flies (1982) (M Network, David Rolfe - INTV) (MT5664) ~.bin" size 4096 crc 6476c136 md5 undefined sha1 f344d5a8dc895c5a2ae0288f3c6cb66650e49167 )
-)
-
-game (
-	name "Frogs and Flies (1989) (Telegames) (PAL)"
-	description "Frogs and Flies (1989) (Telegames) (PAL)"
-	rom ( name "Frogs and Flies (1989) (Telegames) (PAL).bin" size 4096 crc 1d5cbb9f md5 undefined sha1 7682b4b6d45865b7eec1244e5d76f0f2efdb17e7 )
-)
-
-game (
-	name "Frogs and Flies (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Frogs and Flies (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Frogs and Flies (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc de5380bc md5 undefined sha1 b5a143cb046953a69f76cb2f903e61350f0de265 )
-)
-
-game (
-	name "Front Line (1984) (Coleco, Ed Temple) (2665) ~"
-	description "Front Line (1984) (Coleco, Ed Temple) (2665) ~"
-	rom ( name "Front Line (1984) (Coleco, Ed Temple) (2665) ~.bin" size 8192 crc c352f290 md5 undefined sha1 cf32bfcd7f2c3b7d2a6ad2f298aea2dfad8242e7 )
-)
-
-game (
-	name "Frontline (AKA Combat) (Zellers)"
-	description "Frontline (AKA Combat) (Zellers)"
-	rom ( name "Frontline (AKA Combat) (Zellers).bin" size 2048 crc 9c326a97 md5 undefined sha1 ce7580059e8b41cb4a1e734c9b35ce3774bf777a )
-)
-
-game (
-	name "Frostbite - Expedition ins Eis (1983) (Activision, Steve Cartwright - Ariola) (EAX-031, EAX-031-04B - 711 031-717) (PAL)"
-	description "Frostbite - Expedition ins Eis (1983) (Activision, Steve Cartwright - Ariola) (EAX-031, EAX-031-04B - 711 031-717) (PAL)"
-	rom ( name "Frostbite - Expedition ins Eis (1983) (Activision, Steve Cartwright - Ariola) (EAX-031, EAX-031-04B - 711 031-717) (PAL).bin" size 4096 crc 9d88d250 md5 undefined sha1 58a6f82434ccf49ca420596809ce9545373845a2 )
-)
-
-game (
-	name "Frostbite (1983) (Activision, Steve Cartwright) (AX-031) ~"
-	description "Frostbite (1983) (Activision, Steve Cartwright) (AX-031) ~"
-	rom ( name "Frostbite (1983) (Activision, Steve Cartwright) (AX-031) ~.bin" size 4096 crc b61be7a3 md5 undefined sha1 b9e60437e7691d5ef9002cfc7d15ae95f1c03a12 )
-)
-
-game (
-	name "Frostbite (1983) (Digitel)"
-	description "Frostbite (1983) (Digitel)"
-	rom ( name "Frostbite (1983) (Digitel).bin" size 4096 crc 5977cf64 md5 undefined sha1 3a5de073323a26fda9a6ad1590d26c74d7a42192 )
-)
-
-game (
-	name "Frostbite (1983) (Video Mania)"
-	description "Frostbite (1983) (Video Mania)"
-	rom ( name "Frostbite (1983) (Video Mania).bin" size 4096 crc 37e13033 md5 undefined sha1 7bab7c79d867c4fdbde8678fd2b5942e26d3ce02 )
-)
-
-game (
-	name "Frostbite (CCE)"
-	description "Frostbite (CCE)"
-	rom ( name "Frostbite (CCE).bin" size 4096 crc f240ac75 md5 undefined sha1 2f0ed5e015689a0cea33a95d990dedca2ab76142 )
-)
-
-game (
-	name "Frostbite (Digivision)"
-	description "Frostbite (Digivision)"
-	rom ( name "Frostbite (Digivision).bin" size 4096 crc 6b97c2a6 md5 undefined sha1 7fbf0d1f8aa9f9ff85b513143c9fce653e8b6569 )
-)
-
-game (
-	name "Frostbite (Hack) (Unknown) (PAL)"
-	description "Frostbite (Hack) (Unknown) (PAL)"
-	rom ( name "Frostbite (Hack) (Unknown) (PAL).bin" size 4096 crc 76588b34 md5 undefined sha1 8ad03667bbf73d3c7760cb82f2c4442f8745483c )
-)
-
-game (
-	name "Frostbite (Unknown) (PAL)"
-	description "Frostbite (Unknown) (PAL)"
-	rom ( name "Frostbite (Unknown) (PAL).bin" size 4096 crc b6b2361d md5 undefined sha1 1c529b13c1f77af1c9f4d2a74e7ad6ab2b44a1fd )
-)
-
-game (
-	name "Fuchs & Schweinchen Schlau (AKA Oink!) (1983) (Quelle) (806.174 9) (PAL)"
-	description "Fuchs & Schweinchen Schlau (AKA Oink!) (1983) (Quelle) (806.174 9) (PAL)"
-	rom ( name "Fuchs & Schweinchen Schlau (AKA Oink!) (1983) (Quelle) (806.174 9) (PAL).bin" size 4096 crc ff3f327b md5 undefined sha1 4de5d915b58402f5018173120f42be7a7dfabb8e )
-)
-
-game (
-	name "Fun with Numbers (32 in 1) (1988) (Atari, Gary Palmer) (CX26163P) (PAL)"
-	description "Fun with Numbers (32 in 1) (1988) (Atari, Gary Palmer) (CX26163P) (PAL)"
-	rom ( name "Fun with Numbers (32 in 1) (1988) (Atari, Gary Palmer) (CX26163P) (PAL).bin" size 2048 crc 6f13c49c md5 undefined sha1 51f477f37252b5c32469fc1f616c56ed7cad24bc )
-)
-
-game (
-	name "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661)"
-	description "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661)"
-	rom ( name "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661).bin" size 2048 crc d48ebac0 md5 undefined sha1 5cc4010eb2858afe8ce77f53a89d37c7584e15b4 )
-)
-
-game (
-	name "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661P) (PAL)"
-	description "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661P) (PAL)"
-	rom ( name "Fun with Numbers (AKA Basic Math) (1980) (Atari, Gary Palmer) (CX2661P) (PAL).bin" size 2048 crc 5456cdca md5 undefined sha1 ebdc9fc929a6ef47daea8ab539b769a244243a1a )
-)
-
-game (
-	name "Funky Fish (1983) (UA Limited) (Prototype) ~"
-	description "Funky Fish (1983) (UA Limited) (Prototype) ~"
-	rom ( name "Funky Fish (1983) (UA Limited) (Prototype) ~.bin" size 8192 crc b53b33f1 md5 undefined sha1 fba461d2a2d1395945806c883f4dca925712885e )
-)
-
-game (
-	name "Fussball (AKA International Soccer) (Videospielkassette - Ariola) (PGP235) (PAL)"
-	description "Fussball (AKA International Soccer) (Videospielkassette - Ariola) (PGP235) (PAL)"
-	rom ( name "Fussball (AKA International Soccer) (Videospielkassette - Ariola) (PGP235) (PAL).bin" size 4096 crc df3657f2 md5 undefined sha1 261b1cc497a2de5aa51483db4fd7d3c0e6fd99ef )
-)
-
-game (
-	name "G.I. Joe - Cobra Strike (Paddle) (1983) (Parker Brothers, John Emerson) (PB5920) ~"
-	description "G.I. Joe - Cobra Strike (Paddle) (1983) (Parker Brothers, John Emerson) (PB5920) ~"
-	rom ( name "G.I. Joe - Cobra Strike (Paddle) (1983) (Parker Brothers, John Emerson) (PB5920) ~.bin" size 4096 crc 6bcbcd37 md5 undefined sha1 9cfb6288a5c2dae63ee6f5e9325200ccd21a3055 )
-)
-
-game (
-	name "Galactic (AKA Condor Attack) (1983) (Goliath - Hot Shot) (83-416) (PAL)"
-	description "Galactic (AKA Condor Attack) (1983) (Goliath - Hot Shot) (83-416) (PAL)"
-	rom ( name "Galactic (AKA Condor Attack) (1983) (Goliath - Hot Shot) (83-416) (PAL).bin" size 4096 crc 8f67567c md5 undefined sha1 3eee4439082dc93f9e4d79c419faa432f280617f )
-)
-
-game (
-	name "Galactic (AKA Condor Attack) (Funvision - Fund. International Co.) (PAL)"
-	description "Galactic (AKA Condor Attack) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Galactic (AKA Condor Attack) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc 8f67567c md5 undefined sha1 3eee4439082dc93f9e4d79c419faa432f280617f )
-)
-
-game (
-	name "Galactic (AKA The Challenge of.... Nexar) (1983) (Quelle) (218.202 0) (PAL)"
-	description "Galactic (AKA The Challenge of.... Nexar) (1983) (Quelle) (218.202 0) (PAL)"
-	rom ( name "Galactic (AKA The Challenge of.... Nexar) (1983) (Quelle) (218.202 0) (PAL).bin" size 4096 crc 3da30744 md5 undefined sha1 5117b08e2709261b0eed41bdac65713a073b9048 )
-)
-
-game (
-	name "Galactic (AKA The Challenge of.... Nexar) (Rainbow Vision - Suntek) (SS-002) (PAL)"
-	description "Galactic (AKA The Challenge of.... Nexar) (Rainbow Vision - Suntek) (SS-002) (PAL)"
-	rom ( name "Galactic (AKA The Challenge of.... Nexar) (Rainbow Vision - Suntek) (SS-002) (PAL).bin" size 4096 crc 3da30744 md5 undefined sha1 5117b08e2709261b0eed41bdac65713a073b9048 )
-)
-
-game (
-	name "Galatic (AKA Challenge of.... Nexar, The) (208 in 1) (Unknown) (PAL)"
-	description "Galatic (AKA Challenge of.... Nexar, The) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Galatic (AKA Challenge of.... Nexar, The) (208 in 1) (Unknown) (PAL).bin" size 4096 crc b7cf92ec md5 undefined sha1 67797a55be73b373ad0afc67e428a6e8df56ce42 )
-)
-
-game (
-	name "Galaxian (01-05-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype)"
-	description "Galaxian (01-05-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype)"
-	rom ( name "Galaxian (01-05-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype).bin" size 8192 crc c209c7f9 md5 undefined sha1 6fa526da7173ae77f1d35f197bde5f21c9151fbf )
-)
-
-game (
-	name "Galaxian (02-04-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype)"
-	description "Galaxian (02-04-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype)"
-	rom ( name "Galaxian (02-04-1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) (Prototype).bin" size 8192 crc 6542cc75 md5 undefined sha1 a7c9c525632a8e5c3f7acc5c9b095138a8441f57 )
-)
-
-game (
-	name "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684, CX2684P) (PAL)"
-	description "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684, CX2684P) (PAL)"
-	rom ( name "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684, CX2684P) (PAL).bin" size 8192 crc a27cc28e md5 undefined sha1 fb3b3248d9705a883fcd79c23dc6075976c20646 )
-)
-
-game (
-	name "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) ~"
-	description "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) ~"
-	rom ( name "Galaxian (1983) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2684) ~.bin" size 8192 crc 4e9fe271 md5 undefined sha1 b081b327ac32d951c36cb4b3ff812be95685d52f )
-)
-
-game (
-	name "Galaxian (CCE)"
-	description "Galaxian (CCE)"
-	rom ( name "Galaxian (CCE).bin" size 8192 crc 7a63690f md5 undefined sha1 49e3fdc8e48605aa1fab37ce3ec0e26371822fa5 )
-)
-
-game (
-	name "Galaxian (Digivision)"
-	description "Galaxian (Digivision)"
-	rom ( name "Galaxian (Digivision).bin" size 8192 crc 563eeb0f md5 undefined sha1 ee0b91eec32bd737ac09e3ea1fea8434f0253114 )
-)
-
-game (
-	name "Game of Concentration, A - Concentration (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642)"
-	description "Game of Concentration, A - Concentration (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642)"
-	rom ( name "Game of Concentration, A - Concentration (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642).bin" size 2048 crc 17de8070 md5 undefined sha1 a6e42c63138a2fd527cdbe9b7e60f5feabdd55c8 )
-)
-
-game (
-	name "Game of Concentration, A (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642P) (PAL)"
-	description "Game of Concentration, A (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642P) (PAL)"
-	rom ( name "Game of Concentration, A (AKA Hunt & Score) (Keyboard Controller) (1980) (Atari, Alan Miller) (CX2642P) (PAL).bin" size 2048 crc 403b0d89 md5 undefined sha1 564ba5e3a70bd76dd7902fd9ee43b67429dea29c )
-)
-
-game (
-	name "Game Select (208 in 1) (Unknown) (PAL) ~"
-	description "Game Select (208 in 1) (Unknown) (PAL) ~"
-	rom ( name "Game Select (208 in 1) (Unknown) (PAL) ~.bin" size 2048 crc f72dd3f4 md5 undefined sha1 20d41e7c06004d64b9922dd1c3b49cbaffa70955 )
-)
-
-game (
-	name "GameLine Master Module ROM (1983) (Control Video Corporation)"
-	description "GameLine Master Module ROM (1983) (Control Video Corporation)"
-	rom ( name "GameLine Master Module ROM (1983) (Control Video Corporation).bin" size 4096 crc d2b39e30 md5 undefined sha1 78f7bd22152b6a66a086eca9300ae3cdbb7d97bf )
-)
-
-game (
-	name "Gamma-Attack (1983) (Gammation, Robert L. Esken Jr.) ~"
-	description "Gamma-Attack (1983) (Gammation, Robert L. Esken Jr.) ~"
-	rom ( name "Gamma-Attack (1983) (Gammation, Robert L. Esken Jr.) ~.bin" size 2048 crc d1efe8bb md5 undefined sha1 20abf6ba6a9685627220128babf74c303b7c8d30 )
-)
-
-game (
-	name "Gangster (AKA Outlaw) (Videospielkassette - Ariola) (PGP238) (PAL)"
-	description "Gangster (AKA Outlaw) (Videospielkassette - Ariola) (PGP238) (PAL)"
-	rom ( name "Gangster (AKA Outlaw) (Videospielkassette - Ariola) (PGP238) (PAL).bin" size 2048 crc 529debd9 md5 undefined sha1 ae403172bea0aca1f12e115d431c93fa76976560 )
-)
-
-game (
-	name "Gangster Alley - Gangster Ruine (1982) (Spectravision, Spectravideo - Quelle) (SA-201 - 412.783 3) (PAL)"
-	description "Gangster Alley - Gangster Ruine (1982) (Spectravision, Spectravideo - Quelle) (SA-201 - 412.783 3) (PAL)"
-	rom ( name "Gangster Alley - Gangster Ruine (1982) (Spectravision, Spectravideo - Quelle) (SA-201 - 412.783 3) (PAL).bin" size 4096 crc d485e58c md5 undefined sha1 09c5017cff09ebb400573742cc99abc6e1577371 )
-)
-
-game (
-	name "Gangster Alley (1982) (Spectravision, Spectravideo) (SA-201) ~"
-	description "Gangster Alley (1982) (Spectravision, Spectravideo) (SA-201) ~"
-	rom ( name "Gangster Alley (1982) (Spectravision, Spectravideo) (SA-201) ~.bin" size 4096 crc 03c2452c md5 undefined sha1 8cf49d43bd62308df788cfacbfcd80e9226c7590 )
-)
-
-game (
-	name "Garfield (Garfield on the Run) (06-21-1984) (Atari, Mimi Nyden, Steve Woita) (CX26132) (Prototype) ~"
-	description "Garfield (Garfield on the Run) (06-21-1984) (Atari, Mimi Nyden, Steve Woita) (CX26132) (Prototype) ~"
-	rom ( name "Garfield (Garfield on the Run) (06-21-1984) (Atari, Mimi Nyden, Steve Woita) (CX26132) (Prototype) ~.bin" size 16384 crc f20cadcf md5 undefined sha1 bc0d1edc251d8d4db3d5234ec83dee171642a547 )
-)
-
-game (
-	name "Gas Hog - Piraten Schiff (1983) (Spectravideo, Mark Turmell - Quelle) (SA-217, SA-217C - 413.723 8) (PAL)"
-	description "Gas Hog - Piraten Schiff (1983) (Spectravideo, Mark Turmell - Quelle) (SA-217, SA-217C - 413.723 8) (PAL)"
-	rom ( name "Gas Hog - Piraten Schiff (1983) (Spectravideo, Mark Turmell - Quelle) (SA-217, SA-217C - 413.723 8) (PAL).bin" size 4096 crc fdaa9d20 md5 undefined sha1 3696575988be6814b6c0eebab2285c471f94a127 )
-)
-
-game (
-	name "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) [fixed] ~"
-	description "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) [fixed] ~"
-	rom ( name "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) [fixed] ~.bin" size 4096 crc 40699ca5 md5 undefined sha1 e919ee03e8a17fd85be1e53b4d5ff76dae54d099 )
-)
-
-game (
-	name "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) ~"
-	description "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) ~"
-	rom ( name "Gas Hog (1983) (Spectravideo, Mark Turmell) (SA-217) ~.bin" size 4096 crc 89eec77e md5 undefined sha1 0da1f2de5a9b5a6604ccdb0f30b9da4e5f799b40 )
-)
-
-game (
-	name "Gauntlet (1983) (Answer Software Corporation - TY Associates) (ASC1002) ~"
-	description "Gauntlet (1983) (Answer Software Corporation - TY Associates) (ASC1002) ~"
-	rom ( name "Gauntlet (1983) (Answer Software Corporation - TY Associates) (ASC1002) ~.bin" size 4096 crc c7ac23c7 md5 undefined sha1 73adae38d86d50360b1a247244df05892e33da46 )
-)
-
-game (
-	name "Gefaehrliche Maeusejagd (AKA Topy) (1983) (Quelle) (719.551 4) (PAL)"
-	description "Gefaehrliche Maeusejagd (AKA Topy) (1983) (Quelle) (719.551 4) (PAL)"
-	rom ( name "Gefaehrliche Maeusejagd (AKA Topy) (1983) (Quelle) (719.551 4) (PAL).bin" size 4096 crc 0f45ee38 md5 undefined sha1 4dc2a1a78b1c237c4a7b9319494ad4d16383b1e4 )
-)
-
-game (
-	name "Gefecht im All (AKA Space Jockey) (1983) (Quelle) (147.443 6) (PAL)"
-	description "Gefecht im All (AKA Space Jockey) (1983) (Quelle) (147.443 6) (PAL)"
-	rom ( name "Gefecht im All (AKA Space Jockey) (1983) (Quelle) (147.443 6) (PAL).bin" size 4096 crc 3d6b2648 md5 undefined sha1 69a8b8a54377f5766722142c321dcfb04ab94920 )
-)
-
-game (
-	name "General Re-Treat (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL)"
-	description "General Re-Treat (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL)"
-	rom ( name "General Re-Treat (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL).bin" size 4096 crc 72a59be5 md5 undefined sha1 3b1fb93342c7f014a28dddf6f16895d11ac7d6f0 )
-)
-
-game (
-	name "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) (PAL)"
-	description "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) (PAL)"
-	rom ( name "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) (PAL).bin" size 8192 crc 71367efe md5 undefined sha1 12d2f7e75e9107093182dfcf3fb74370b0167c42 )
-)
-
-game (
-	name "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) ~"
-	description "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) ~"
-	rom ( name "Ghost Manor (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 06002, 06004, 99002) ~.bin" size 8192 crc 6fc46219 md5 undefined sha1 4b533776dcd9d538f9206ad1e28b30116d08df1e )
-)
-
-game (
-	name "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (AZ-108-04) ~"
-	description "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (AZ-108-04) ~"
-	rom ( name "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (AZ-108-04) ~.bin" size 8192 crc 45443d13 md5 undefined sha1 5ed0b2cb346d20720e3c526da331551aa16a23a4 )
-)
-
-game (
-	name "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (EAG-108-04, EAZ-108-04B) (PAL)"
-	description "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (EAG-108-04, EAZ-108-04B) (PAL)"
-	rom ( name "Ghostbusters (1985) (Activision, David Crane, Dan Kitchen) (EAG-108-04, EAZ-108-04B) (PAL).bin" size 8192 crc 439fade2 md5 undefined sha1 9a4f19b0eb7f3c76ea0646c6b8e098586369618c )
-)
-
-game (
-	name "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) [different tune] ~"
-	description "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) [different tune] ~"
-	rom ( name "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) [different tune] ~.bin" size 16384 crc 34375964 md5 undefined sha1 1bcf03e1129015a46ad7028e0e74253653944e86 )
-)
-
-game (
-	name "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) ~"
-	description "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) ~"
-	rom ( name "Ghostbusters II (1992) (Salu - Avantgarde Software, Michael Buetepage) (460741) (PAL) ~.bin" size 16384 crc a3c342b8 md5 undefined sha1 e032876305647a95b622e5c4971f7096ef72acdb )
-)
-
-game (
-	name "Gigolo (1982) (PlayAround - J.H.M.) (205)"
-	description "Gigolo (1982) (PlayAround - J.H.M.) (205)"
-	rom ( name "Gigolo (1982) (PlayAround - J.H.M.) (205).bin" size 4096 crc 4e16a8dc md5 undefined sha1 b64ed2d5a2f8fdac4ff0ce56939ba72e343fec33 )
-)
-
-game (
-	name "Glacier Patrol (1989) (Telegames, Ed Salvo) (5665 A016) (PAL)"
-	description "Glacier Patrol (1989) (Telegames, Ed Salvo) (5665 A016) (PAL)"
-	rom ( name "Glacier Patrol (1989) (Telegames, Ed Salvo) (5665 A016) (PAL).bin" size 4096 crc d37bcc05 md5 undefined sha1 3d867d49f3295324f214138640f0b2fd73ae89fb )
-)
-
-game (
-	name "Glacier Patrol (1989) (Telegames, Ed Salvo) (5667 A106) ~"
-	description "Glacier Patrol (1989) (Telegames, Ed Salvo) (5667 A106) ~"
-	rom ( name "Glacier Patrol (1989) (Telegames, Ed Salvo) (5667 A106) ~.bin" size 4096 crc 44e77fd6 md5 undefined sha1 3a3d7206afee36786026d6287fe956c2ebc80ea7 )
-)
-
-game (
-	name "Glib - Video Word Game (1983) (Selchow & Righter - QDI) (87) ~"
-	description "Glib - Video Word Game (1983) (Selchow & Righter - QDI) (87) ~"
-	rom ( name "Glib - Video Word Game (1983) (Selchow & Righter - QDI) (87) ~.bin" size 4096 crc 50bb03a4 md5 undefined sha1 7bca0f7a0f992782e4e4c90772bac976ca963a6d )
-)
-
-game (
-	name "Go Go Home (Unknown)"
-	description "Go Go Home (Unknown)"
-	rom ( name "Go Go Home (Unknown).bin" size 4096 crc 6e493f49 md5 undefined sha1 f78c478aacf6536522e8d37a3888a975e1a383cd )
-)
-
-game (
-	name "Go Go Home Monster (AKA Go Go Home) (1983) (Home Vision - Gem International Corp.) (PAL) ~"
-	description "Go Go Home Monster (AKA Go Go Home) (1983) (Home Vision - Gem International Corp.) (PAL) ~"
-	rom ( name "Go Go Home Monster (AKA Go Go Home) (1983) (Home Vision - Gem International Corp.) (PAL) ~.bin" size 4096 crc c161f53b md5 undefined sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
-)
-
-game (
-	name "Going-Up (1983) (Starpath Corporation) (Prototype) ~"
-	description "Going-Up (1983) (Starpath Corporation) (Prototype) ~"
-	rom ( name "Going-Up (1983) (Starpath Corporation) (Prototype) ~.bin" size 8448 crc cb864b21 md5 undefined sha1 7ab02d3fc90b036bd13631d60063c51998e9a325 )
-)
-
-game (
-	name "Golf (208 in 1) (Unknown) (PAL)"
-	description "Golf (208 in 1) (Unknown) (PAL)"
-	rom ( name "Golf (208 in 1) (Unknown) (PAL).bin" size 2048 crc f5613a4c md5 undefined sha1 3c39d2fdecec8b3fcf3603d9c663b84c682f637c )
-)
-
-game (
-	name "Golf (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Golf (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Golf (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc b6b24526 md5 undefined sha1 e728c46f6c1608b43a59229fb463f3f87f00e993 )
-)
-
-game (
-	name "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl - Sears) (CX2634 - 49-75121) ~"
-	description "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl - Sears) (CX2634 - 49-75121) ~"
-	rom ( name "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl - Sears) (CX2634 - 49-75121) ~.bin" size 2048 crc 46a9f200 md5 undefined sha1 a25d52770408314dec6f41aaf5f9f0a2a3e2c18f )
-)
-
-game (
-	name "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl) (CX2634, CX2634P) (PAL)"
-	description "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl) (CX2634, CX2634P) (PAL)"
-	rom ( name "Golf (Championship Golf) (1980) (Atari, Tom Rudadahl) (CX2634, CX2634P) (PAL).bin" size 2048 crc 36f106e7 md5 undefined sha1 b87fbeb369b21f733e0eeb28b9a19a8e24f30c9e )
-)
-
-game (
-	name "Golf Diagnostic (1983) (Video Soft, Jerry Lawson, Dan McElroy) (Prototype) ~"
-	description "Golf Diagnostic (1983) (Video Soft, Jerry Lawson, Dan McElroy) (Prototype) ~"
-	rom ( name "Golf Diagnostic (1983) (Video Soft, Jerry Lawson, Dan McElroy) (Prototype) ~.bin" size 4096 crc b11924c2 md5 undefined sha1 b0c2efefc8d80693565a64ee025be480aa3f1746 )
-)
-
-game (
-	name "Gopher - Vorsicht Wuehlmaus! (1983) (Carrere Video, Sylvia Day, Henry Will IV - Teldec - Prism Micro Products) (USC2001) (PAL)"
-	description "Gopher - Vorsicht Wuehlmaus! (1983) (Carrere Video, Sylvia Day, Henry Will IV - Teldec - Prism Micro Products) (USC2001) (PAL)"
-	rom ( name "Gopher - Vorsicht Wuehlmaus! (1983) (Carrere Video, Sylvia Day, Henry Will IV - Teldec - Prism Micro Products) (USC2001) (PAL).bin" size 4096 crc 61beb1a6 md5 undefined sha1 af635cf27e7b7a6f400f59d23b4b0129ac3e874c )
-)
-
-game (
-	name "Gopher (208 in 1) (Unknown) (PAL)"
-	description "Gopher (208 in 1) (Unknown) (PAL)"
-	rom ( name "Gopher (208 in 1) (Unknown) (PAL).bin" size 4096 crc ce950b34 md5 undefined sha1 599910eaeb65de07883280ba8d86e10bd382e9af )
-)
-
-game (
-	name "Gopher (Gopher Attack) (1982) (U.S. Games Corporation, Sylvia Day, Henry Will IV) (VC2001) ~"
-	description "Gopher (Gopher Attack) (1982) (U.S. Games Corporation, Sylvia Day, Henry Will IV) (VC2001) ~"
-	rom ( name "Gopher (Gopher Attack) (1982) (U.S. Games Corporation, Sylvia Day, Henry Will IV) (VC2001) ~.bin" size 4096 crc ac8321d8 md5 undefined sha1 97fb489ba4ce0f8a306563063563617321352cfb )
-)
-
-game (
-	name "Gopher (Unknown) (PAL)"
-	description "Gopher (Unknown) (PAL)"
-	rom ( name "Gopher (Unknown) (PAL).bin" size 4096 crc 6b13e88f md5 undefined sha1 0f15ee48cc68630ebbf3e43d37528c5088506245 )
-)
-
-game (
-	name "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (4L1751, 4L1752, 4L1753, 4L2275) (PAL)"
-	description "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (4L1751, 4L1752, 4L1753, 4L2275) (PAL)"
-	rom ( name "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (4L1751, 4L1752, 4L1753, 4L2275) (PAL).bin" size 4096 crc dee8e883 md5 undefined sha1 d530e73e3a44b91f0f2cf74c520edf1c258d07ce )
-)
-
-game (
-	name "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (M8776, M8793) ~"
-	description "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (M8776, M8793) ~"
-	rom ( name "Gorf (1982) (CBS Electronics, Joe Gaucher, Alex Leavens) (M8776, M8793) ~.bin" size 4096 crc 9bd137aa md5 undefined sha1 35f8341c73c7e6e896cb065977427b3f98ae9f08 )
-)
-
-game (
-	name "Grand Prix (1982) (Activision, David Crane - Ariola) (EAX-014, PAX-014, EAX-014-04B, EAX-014-04I - 711 014-720) (PAL)"
-	description "Grand Prix (1982) (Activision, David Crane - Ariola) (EAX-014, PAX-014, EAX-014-04B, EAX-014-04I - 711 014-720) (PAL)"
-	rom ( name "Grand Prix (1982) (Activision, David Crane - Ariola) (EAX-014, PAX-014, EAX-014-04B, EAX-014-04I - 711 014-720) (PAL).bin" size 4096 crc 5ab02ae6 md5 undefined sha1 32c9f57e79f07e56808cece24e503fbc325a60df )
-)
-
-game (
-	name "Grand Prix (1982) (Activision, David Crane) (AX-014, AX-014-04) ~"
-	description "Grand Prix (1982) (Activision, David Crane) (AX-014, AX-014-04) ~"
-	rom ( name "Grand Prix (1982) (Activision, David Crane) (AX-014, AX-014-04) ~.bin" size 4096 crc e855273d md5 undefined sha1 24fab817728216582b6d95558c361ace66abf96f )
-)
-
-game (
-	name "Grand Prix (1983) (CCE) (C-826)"
-	description "Grand Prix (1983) (CCE) (C-826)"
-	rom ( name "Grand Prix (1983) (CCE) (C-826).bin" size 4096 crc 4adb3f43 md5 undefined sha1 5c57d8954357651e11bfba492444f69a9c7443eb )
-)
-
-game (
-	name "Grand Prix (1983) (CCE) (C-826) [a]"
-	description "Grand Prix (1983) (CCE) (C-826) [a]"
-	rom ( name "Grand Prix (1983) (CCE) (C-826) [a].bin" size 4096 crc db4cca80 md5 undefined sha1 8701757011891e49b6df7b0dcb9016a25b1b0021 )
-)
-
-game (
-	name "Grand Prix (Robby)"
-	description "Grand Prix (Robby)"
-	rom ( name "Grand Prix (Robby).bin" size 4096 crc a7afdc5f md5 undefined sha1 c2da358a5eefb4a136fd678d03e8fe8879a3a6f1 )
-)
-
-game (
-	name "Grand Prix (Unknown) (PAL)"
-	description "Grand Prix (Unknown) (PAL)"
-	rom ( name "Grand Prix (Unknown) (PAL).bin" size 4096 crc 88def8da md5 undefined sha1 e3e4f49eb6f8e0e721fd0157ede88865b75de1b2 )
-)
-
-game (
-	name "Grand Prize (AKA Enduro) (Funvision - Fund. International Co.)"
-	description "Grand Prize (AKA Enduro) (Funvision - Fund. International Co.)"
-	rom ( name "Grand Prize (AKA Enduro) (Funvision - Fund. International Co.).bin" size 4096 crc 5108d36d md5 undefined sha1 50fcecb67884c683071091936b4ae33b50f609eb )
-)
-
-game (
-	name "Gravitar (04-12-1983) (Atari, Dan Hitchens) (CX2685) (Prototype)"
-	description "Gravitar (04-12-1983) (Atari, Dan Hitchens) (CX2685) (Prototype)"
-	rom ( name "Gravitar (04-12-1983) (Atari, Dan Hitchens) (CX2685) (Prototype).bin" size 8192 crc a4cac249 md5 undefined sha1 acf83fcd64b326d7e2f0cd397473e44b6168c10c )
-)
-
-game (
-	name "Gravitar (1983) (Atari, Dan Hitchens) (CX2685) ~"
-	description "Gravitar (1983) (Atari, Dan Hitchens) (CX2685) ~"
-	rom ( name "Gravitar (1983) (Atari, Dan Hitchens) (CX2685) ~.bin" size 8192 crc c87fccbe md5 undefined sha1 a372d4dd3d95b3866553cae2336e4565e00cc25b )
-)
-
-game (
-	name "Gravitar (CCE)"
-	description "Gravitar (CCE)"
-	rom ( name "Gravitar (CCE).bin" size 8192 crc 5a46d197 md5 undefined sha1 afddeef096b770f19c829c0153dc767ec6e274be )
-)
-
-game (
-	name "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282)"
-	description "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282)"
-	rom ( name "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282).bin" size 4096 crc 99c240c1 md5 undefined sha1 ef0843c0daa171bd6c7a2a1530bafb189b59da86 )
-)
-
-game (
-	name "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282) (PAL)"
-	description "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282) (PAL)"
-	rom ( name "Great Escape (AKA Asteroid Fire) (1983) (Bomb - Onbase) (CA282) (PAL).bin" size 4096 crc 70aebb22 md5 undefined sha1 429c3c21bf89dc08892d16c420b72b0c88c9e03c )
-)
-
-game (
-	name "Gremlins (Gargoyle) (03-12-1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) (Prototype)"
-	description "Gremlins (Gargoyle) (03-12-1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) (Prototype)"
-	rom ( name "Gremlins (Gargoyle) (03-12-1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) (Prototype).bin" size 8192 crc 1ff838aa md5 undefined sha1 df506a506eb333295e56cb9e4204e327ef63127d )
-)
-
-game (
-	name "Gremlins (Gargoyle) (1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) ~"
-	description "Gremlins (Gargoyle) (1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) ~"
-	rom ( name "Gremlins (Gargoyle) (1984) (Atari, Mimi Nyden, Scott Smith, Robert Vieira) (CX26127) ~.bin" size 8192 crc 48d5991f md5 undefined sha1 7a027329309e018b0d51adcb6ae13c9d13e54f4a )
-)
-
-game (
-	name "Ground Zero (AKA River Raid) (1983) (Goliath - Hot Shot) (83-113) (PAL)"
-	description "Ground Zero (AKA River Raid) (1983) (Goliath - Hot Shot) (83-113) (PAL)"
-	rom ( name "Ground Zero (AKA River Raid) (1983) (Goliath - Hot Shot) (83-113) (PAL).bin" size 4096 crc 1b8e7dbc md5 undefined sha1 0130f9d1334e106f2fbd9bbd5c01efae4f39cae1 )
-)
-
-game (
-	name "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (01-18-1983) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype) ~"
-	description "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (01-18-1983) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype) ~"
-	rom ( name "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (01-18-1983) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype) ~.bin" size 8192 crc e1372b28 md5 undefined sha1 b9760ffba05139bca0fac3f7d3dc1e5d57600eda )
-)
-
-game (
-	name "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (12-29-1982) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype)"
-	description "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (12-29-1982) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype)"
-	rom ( name "Grover's Music Maker (Monkey Music) (Kid's Controller) (Children's Computer Workshop) (12-29-1982) (Atari, Stephan R. Keith, Preston Stuart) (CX26106) (Prototype).bin" size 8192 crc f9e70731 md5 undefined sha1 c90acaee066f97efc6a520deb7fa3e5760a471fa )
-)
-
-game (
-	name "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) (Prototype)"
-	description "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) (Prototype)"
-	rom ( name "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) (Prototype).bin" size 4096 crc 23972366 md5 undefined sha1 a034090e4a72ac4006952a7f021ea0d08639f577 )
-)
-
-game (
-	name "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) ~"
-	description "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) ~"
-	rom ( name "Guardian (Cosmic Combat) (Paddle) (1982) (Apollo, Larry Martin) (AP-2008) ~.bin" size 4096 crc 121738f5 md5 undefined sha1 7d30ff565ad7b2a3143d049c5b39e4a6ac3f9cd5 )
-)
-
-game (
-	name "Gyruss (1984) (Parker Brothers) (PB5080) (PAL)"
-	description "Gyruss (1984) (Parker Brothers) (PB5080) (PAL)"
-	rom ( name "Gyruss (1984) (Parker Brothers) (PB5080) (PAL).bin" size 8192 crc ba14b37b md5 undefined sha1 598f710b7474ed6e4e7c13cc0294a4deba8faa87 )
-)
-
-game (
-	name "Gyruss (1984) (Parker Brothers) (PB5080) ~"
-	description "Gyruss (1984) (Parker Brothers) (PB5080) ~"
-	rom ( name "Gyruss (1984) (Parker Brothers) (PB5080) ~.bin" size 8192 crc 0d78e8a9 md5 undefined sha1 4bd87ba8b3b6d7850e3ea41b4d494c3b12659f27 )
-)
-
-game (
-	name "H.E.R.O. - Helicopter-Held (1984) (Activision, John Van Ryzin - Ariola) (EAZ-036-04, EAZ-036-04B, EAZ-036-04I - 711 036-720) (PAL)"
-	description "H.E.R.O. - Helicopter-Held (1984) (Activision, John Van Ryzin - Ariola) (EAZ-036-04, EAZ-036-04B, EAZ-036-04I - 711 036-720) (PAL)"
-	rom ( name "H.E.R.O. - Helicopter-Held (1984) (Activision, John Van Ryzin - Ariola) (EAZ-036-04, EAZ-036-04B, EAZ-036-04I - 711 036-720) (PAL).bin" size 8192 crc 4a5f82ba md5 undefined sha1 5e4f98210ef5a6682581b60a9fc939fce6b22d97 )
-)
-
-game (
-	name "H.E.R.O. (1984) (Activision, John Van Ryzin) (AZ-036-04) ~"
-	description "H.E.R.O. (1984) (Activision, John Van Ryzin) (AZ-036-04) ~"
-	rom ( name "H.E.R.O. (1984) (Activision, John Van Ryzin) (AZ-036-04) ~.bin" size 8192 crc 721e95b7 md5 undefined sha1 282f94817401e3725c622b73a0c05685ce761783 )
-)
-
-game (
-	name "H.E.R.O. (1984) (Activision, John Van Ryzin) (EAZ-036-04) (SECAM)"
-	description "H.E.R.O. (1984) (Activision, John Van Ryzin) (EAZ-036-04) (SECAM)"
-	rom ( name "H.E.R.O. (1984) (Activision, John Van Ryzin) (EAZ-036-04) (SECAM).bin" size 8192 crc 0642f2f1 md5 undefined sha1 04e9462254ae9db4804b3d331f2ad22c61901311 )
-)
-
-game (
-	name "H.E.R.O. (CCE)"
-	description "H.E.R.O. (CCE)"
-	rom ( name "H.E.R.O. (CCE).bin" size 8192 crc 272d3860 md5 undefined sha1 9e599284cdc8ad4aa803210a19c0485f1412b35f )
-)
-
-game (
-	name "H.E.R.O. (Tron)"
-	description "H.E.R.O. (Tron)"
-	rom ( name "H.E.R.O. (Tron).bin" size 8192 crc 9785fe8b md5 undefined sha1 9d1f48fd30026f84f6c1c08fe69d423fa437f40f )
-)
-
-game (
-	name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype)"
-	description "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype)"
-	rom ( name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype).bin" size 4096 crc 0c36f4b9 md5 undefined sha1 2322e3acfd02b12098ff50ee745613f3bdc346ad )
-)
-
-game (
-	name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype) [a]"
-	description "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype) [a]"
-	rom ( name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) (Prototype) [a].bin" size 4096 crc 53fe178e md5 undefined sha1 ecc609203c2e26ab20fbd92d13943fc1faed5ecb )
-)
-
-game (
-	name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) ~"
-	description "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) ~"
-	rom ( name "Halloween (1983) (Wizard Video Games, Robert Barber, Tim Martin) (007) ~.bin" size 4096 crc b1b11806 md5 undefined sha1 4c72cec151f219866bf870fa7ac749a19ca501c9 )
-)
-
-game (
-	name "Hangman - Spelling (1978) (Atari, Alan Miller - Sears) (CX2662 - 6-99811) ~"
-	description "Hangman - Spelling (1978) (Atari, Alan Miller - Sears) (CX2662 - 6-99811) ~"
-	rom ( name "Hangman - Spelling (1978) (Atari, Alan Miller - Sears) (CX2662 - 6-99811) ~.bin" size 4096 crc c2bcc789 md5 undefined sha1 561bccf508e162bc70c42d85c170cf0d1d4691a3 )
-)
-
-game (
-	name "Hangman (1978) (Atari, Alan Miller) (CX2662P) (PAL)"
-	description "Hangman (1978) (Atari, Alan Miller) (CX2662P) (PAL)"
-	rom ( name "Hangman (1978) (Atari, Alan Miller) (CX2662P) (PAL).bin" size 4096 crc bfb57767 md5 undefined sha1 74477cfa790e64b4c4fd1674c68261c0e187352b )
-)
-
-game (
-	name "Harbor Escape (AKA River Raid) (1983) (Panda) (110)"
-	description "Harbor Escape (AKA River Raid) (1983) (Panda) (110)"
-	rom ( name "Harbor Escape (AKA River Raid) (1983) (Panda) (110).bin" size 4096 crc 85998ae2 md5 undefined sha1 d6db71da02ae194140bf812be34d6e8a6785d138 )
-)
-
-game (
-	name "Harem (1982) (Multivision, Michael Case) ~"
-	description "Harem (1982) (Multivision, Michael Case) ~"
-	rom ( name "Harem (1982) (Multivision, Michael Case) ~.bin" size 4096 crc e4466537 md5 undefined sha1 90495bea80158430ff63bd3db97724cf3ce22736 )
-)
-
-game (
-	name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (09-28-81) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) (Prototype)"
-	description "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (09-28-81) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) (Prototype)"
-	rom ( name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (09-28-81) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) (Prototype).bin" size 4096 crc 2667b2ab md5 undefined sha1 b841411b2c719a4a89498e8cac06c1c1986c794d )
-)
-
-game (
-	name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) ~"
-	description "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) ~"
-	rom ( name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen - Sears) (CX2654 - 49-75141) ~.bin" size 4096 crc aa62d961 md5 undefined sha1 1476c869619075b551b20f2c7f95b11e0d16aec1 )
-)
-
-game (
-	name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen) (CX2654) (PAL)"
-	description "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen) (CX2654) (PAL)"
-	rom ( name "Haunted House (Mystery Mansion, Graves' Manor, Nightmare Manor) (1982) (Atari, James Andreasen) (CX2654) (PAL).bin" size 4096 crc 95e14db7 md5 undefined sha1 78f0894ab9386ff1dfb6f3e936e2473c5fa1a720 )
-)
-
-game (
-	name "Hell Driver (AKA Racing Car) (1983) (ITT Family Games) (554-37 729) (PAL)"
-	description "Hell Driver (AKA Racing Car) (1983) (ITT Family Games) (554-37 729) (PAL)"
-	rom ( name "Hell Driver (AKA Racing Car) (1983) (ITT Family Games) (554-37 729) (PAL).bin" size 4096 crc 18954066 md5 undefined sha1 65bd036bffd90ae34baa3817fee6ea70c76478ac )
-)
-
-game (
-	name "Hey! Stop! (AKA Keystone Kapers) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Hey! Stop! (AKA Keystone Kapers) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Hey! Stop! (AKA Keystone Kapers) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 293e06bf md5 undefined sha1 207826657b948ab15ea379592c28d74aa6ef8552 )
-)
-
-game (
-	name "Hey! Stop! (AKA Keystone Kapers) (Rainbow Vision - Suntek) (SS-012) (PAL)"
-	description "Hey! Stop! (AKA Keystone Kapers) (Rainbow Vision - Suntek) (SS-012) (PAL)"
-	rom ( name "Hey! Stop! (AKA Keystone Kapers) (Rainbow Vision - Suntek) (SS-012) (PAL).bin" size 4096 crc 6f3a278e md5 undefined sha1 4b808c975f8a8345c72d0f6281ea5ba93963d7fb )
-)
-
-game (
-	name "Hili Ball (AKA Racquetball) (1983) (Quelle) (689.302 8) (PAL)"
-	description "Hili Ball (AKA Racquetball) (1983) (Quelle) (689.302 8) (PAL)"
-	rom ( name "Hili Ball (AKA Racquetball) (1983) (Quelle) (689.302 8) (PAL).bin" size 4096 crc 2063844b md5 undefined sha1 4d2ab41b7818bf7156cfda93986f54d0bc505cbf )
-)
-
-game (
-	name "Hole Hunter (AKA Topy) (Video Game Cartridge - Ariola) (TP-606)"
-	description "Hole Hunter (AKA Topy) (Video Game Cartridge - Ariola) (TP-606)"
-	rom ( name "Hole Hunter (AKA Topy) (Video Game Cartridge - Ariola) (TP-606).bin" size 4096 crc 66d5ce67 md5 undefined sha1 f275c7ca9a76fb758f52548b8597bc13245263b6 )
-)
-
-game (
-	name "Holey Moley (Kid's Controller) (02-29-1984) (Atari, Robert C. Polaro) (CX26130) (Prototype) ~"
-	description "Holey Moley (Kid's Controller) (02-29-1984) (Atari, Robert C. Polaro) (CX26130) (Prototype) ~"
-	rom ( name "Holey Moley (Kid's Controller) (02-29-1984) (Atari, Robert C. Polaro) (CX26130) (Prototype) ~.bin" size 8192 crc 3bb2e71d md5 undefined sha1 8196209ef7048c5494dbdc932adbf1c7abf79f4e )
-)
-
-game (
-	name "Home Run - Baseball (1978) (Atari, Bob Whitehead - Sears) (CX2623 - 6-99819, 49-75108, 49-75125) ~"
-	description "Home Run - Baseball (1978) (Atari, Bob Whitehead - Sears) (CX2623 - 6-99819, 49-75108, 49-75125) ~"
-	rom ( name "Home Run - Baseball (1978) (Atari, Bob Whitehead - Sears) (CX2623 - 6-99819, 49-75108, 49-75125) ~.bin" size 2048 crc 45ace998 md5 undefined sha1 f362d2b3a50e5ae3c2b412b6c08ecdcfee47a688 )
-)
-
-game (
-	name "Home Run (Unknown) (PAL)"
-	description "Home Run (Unknown) (PAL)"
-	rom ( name "Home Run (Unknown) (PAL).bin" size 2048 crc ebc26875 md5 undefined sha1 7bdab234762d498b7c6517eed8a2f292f5fdd129 )
-)
-
-game (
-	name "Homerun - Horrorrun (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Homerun - Horrorrun (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Homerun - Horrorrun (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 6d479c89 md5 undefined sha1 4ef32864a59cef6e1daafb809a44a588fbeb354c )
-)
-
-game (
-	name "Hot Action Pak - Ghostbusters, Tennis, Plaque Attack (1990) (HES - Activision) (542) (PAL)"
-	description "Hot Action Pak - Ghostbusters, Tennis, Plaque Attack (1990) (HES - Activision) (542) (PAL)"
-	rom ( name "Hot Action Pak - Ghostbusters, Tennis, Plaque Attack (1990) (HES - Activision) (542) (PAL).bin" size 16384 crc e6862972 md5 undefined sha1 1f369c7676e33a11596fac07620980b9747122d2 )
-)
-
-game (
-	name "Hot Wave (AKA Ram It) (Double-Game Package) (1983) (Quelle) (746422) (PAL)"
-	description "Hot Wave (AKA Ram It) (Double-Game Package) (1983) (Quelle) (746422) (PAL)"
-	rom ( name "Hot Wave (AKA Ram It) (Double-Game Package) (1983) (Quelle) (746422) (PAL).bin" size 4096 crc fac18ec4 md5 undefined sha1 f630b95442054bda5259af5c68287af574dd185c )
-)
-
-game (
-	name "Human Cannonball - Cannon Man (1979) (Atari - Sears) (CX2627 - 6-99841) ~"
-	description "Human Cannonball - Cannon Man (1979) (Atari - Sears) (CX2627 - 6-99841) ~"
-	rom ( name "Human Cannonball - Cannon Man (1979) (Atari - Sears) (CX2627 - 6-99841) ~.bin" size 2048 crc f05a41e1 md5 undefined sha1 d4b0b2aa379893356c72414ee0065a3a91cf9f97 )
-)
-
-game (
-	name "Human Cannonball (128-in-1 Junior Console) (PAL)"
-	description "Human Cannonball (128-in-1 Junior Console) (PAL)"
-	rom ( name "Human Cannonball (128-in-1 Junior Console) (PAL).bin" size 2048 crc cc4d8910 md5 undefined sha1 59e8efa3eaad0829915bcffe9b2ae2487e6636be )
-)
-
-game (
-	name "Human Cannonball (1979) (Atari) (CX2627, CX2627P) (PAL)"
-	description "Human Cannonball (1979) (Atari) (CX2627, CX2627P) (PAL)"
-	rom ( name "Human Cannonball (1979) (Atari) (CX2627, CX2627P) (PAL).bin" size 2048 crc 3ed1c0d3 md5 undefined sha1 adc8c6ec2c5b0d0f495d088b5e015d4a351e1c24 )
-)
-
-game (
-	name "Human Cannonball (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Human Cannonball (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Human Cannonball (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 8743162a md5 undefined sha1 c5df16d4ea935fc88460c42028cfa1ee6fd54182 )
-)
-
-game (
-	name "Hunt & Score - Memory Match (Keyboard Controller) (1978) (Atari, Alan Miller - Sears) (CX2642 - 6-99814) ~"
-	description "Hunt & Score - Memory Match (Keyboard Controller) (1978) (Atari, Alan Miller - Sears) (CX2642 - 6-99814) ~"
-	rom ( name "Hunt & Score - Memory Match (Keyboard Controller) (1978) (Atari, Alan Miller - Sears) (CX2642 - 6-99814) ~.bin" size 2048 crc 17de8070 md5 undefined sha1 a6e42c63138a2fd527cdbe9b7e60f5feabdd55c8 )
-)
-
-game (
-	name "Hunt & Score (Keyboard Controller) (1978) (Atari, Alan Miller) (CX2642) (PAL)"
-	description "Hunt & Score (Keyboard Controller) (1978) (Atari, Alan Miller) (CX2642) (PAL)"
-	rom ( name "Hunt & Score (Keyboard Controller) (1978) (Atari, Alan Miller) (CX2642) (PAL).bin" size 2048 crc 403b0d89 md5 undefined sha1 564ba5e3a70bd76dd7902fd9ee43b67429dea29c )
-)
-
-game (
-	name "I Want My Mommy (AKA Open Sesame) (KidStuff) (1983) (ZiMAG - Emag - Vidco) (710-111 - GN-010)"
-	description "I Want My Mommy (AKA Open Sesame) (KidStuff) (1983) (ZiMAG - Emag - Vidco) (710-111 - GN-010)"
-	rom ( name "I Want My Mommy (AKA Open Sesame) (KidStuff) (1983) (ZiMAG - Emag - Vidco) (710-111 - GN-010).bin" size 4096 crc 57908550 md5 undefined sha1 f7e782214b5f9227e34c00f590be50534f1fda91 )
-)
-
-game (
-	name "I.Q. Memory Teaser (AKA IQ 180) (Suntek) (SS-033) (PAL) ~"
-	description "I.Q. Memory Teaser (AKA IQ 180) (Suntek) (SS-033) (PAL) ~"
-	rom ( name "I.Q. Memory Teaser (AKA IQ 180) (Suntek) (SS-033) (PAL) ~.bin" size 4096 crc 75ab6ba8 md5 undefined sha1 fa05a35de4c401704538cc256f46440f42de3ddb )
-)
-
-game (
-	name "Ice Hockey - Eishockey (1981) (Activision, Alan Miller - Ariola) (EAG-012-04I, EAX-012, EAX-012-04B - 711 012-720) (PAL)"
-	description "Ice Hockey - Eishockey (1981) (Activision, Alan Miller - Ariola) (EAG-012-04I, EAX-012, EAX-012-04B - 711 012-720) (PAL)"
-	rom ( name "Ice Hockey - Eishockey (1981) (Activision, Alan Miller - Ariola) (EAG-012-04I, EAX-012, EAX-012-04B - 711 012-720) (PAL).bin" size 4096 crc fc3fd6a5 md5 undefined sha1 5bd34ba7e260bd69f1756ef7cbd95b91be8d911b )
-)
-
-game (
-	name "Ice Hockey - Hockey, Hockey (4 Game in One) (1983) (Bit Corporation) (PGP210) (PAL)"
-	description "Ice Hockey - Hockey, Hockey (4 Game in One) (1983) (Bit Corporation) (PGP210) (PAL)"
-	rom ( name "Ice Hockey - Hockey, Hockey (4 Game in One) (1983) (Bit Corporation) (PGP210) (PAL).bin" size 4096 crc d3bf1b30 md5 undefined sha1 b3635f88c71e21e02a80655f2a76a278652bb1d3 )
-)
-
-game (
-	name "Ice Hockey - Le Hockey Sur Glace (1981) (Activision, Alan Miller) (AX-012, CAX-012, AX-012-04) ~"
-	description "Ice Hockey - Le Hockey Sur Glace (1981) (Activision, Alan Miller) (AX-012, CAX-012, AX-012-04) ~"
-	rom ( name "Ice Hockey - Le Hockey Sur Glace (1981) (Activision, Alan Miller) (AX-012, CAX-012, AX-012-04) ~.bin" size 4096 crc adab8cdf md5 undefined sha1 21de0f034e5dad03fa91eb7ae6cc081c142be35c )
-)
-
-game (
-	name "Ice Hockey (Canal 3 - Intellivision)"
-	description "Ice Hockey (Canal 3 - Intellivision)"
-	rom ( name "Ice Hockey (Canal 3 - Intellivision).bin" size 4096 crc b868ad9c md5 undefined sha1 5ebcc5938bb8b23bb438efa21d388a85fc9b7fe9 )
-)
-
-game (
-	name "Ice Hockey (CCE)"
-	description "Ice Hockey (CCE)"
-	rom ( name "Ice Hockey (CCE).bin" size 4096 crc 34a4d793 md5 undefined sha1 4c02f0d3a830d9745733d384002915a95279c9d5 )
-)
-
-game (
-	name "Ikari Warriors (1989) (Atari) (CX26177) (PAL)"
-	description "Ikari Warriors (1989) (Atari) (CX26177) (PAL)"
-	rom ( name "Ikari Warriors (1989) (Atari) (CX26177) (PAL).bin" size 16384 crc f80684a9 md5 undefined sha1 5ced92d13f8becd96d175b38d179e353f8c33660 )
-)
-
-game (
-	name "Ikari Warriors (1989) (Atari) (CX26177) ~"
-	description "Ikari Warriors (1989) (Atari) (CX26177) ~"
-	rom ( name "Ikari Warriors (1989) (Atari) (CX26177) ~.bin" size 16384 crc 5b7ce555 md5 undefined sha1 d8f7b908f60fe49667c7c55d48ce15a05ad95a28 )
-)
-
-game (
-	name "Im Reich der Spinne (AKA Amidar) (1983) (Quelle) (322.773 3) (PAL)"
-	description "Im Reich der Spinne (AKA Amidar) (1983) (Quelle) (322.773 3) (PAL)"
-	rom ( name "Im Reich der Spinne (AKA Amidar) (1983) (Quelle) (322.773 3) (PAL).bin" size 4096 crc 67fe1f3e md5 undefined sha1 b3374e03eac5b69e50e0c9574c567821e59da32e )
-)
-
-game (
-	name "Im Schutz der Drachen (AKA Dragon Defender) (1983) (Quelle) (719.252 9) (PAL)"
-	description "Im Schutz der Drachen (AKA Dragon Defender) (1983) (Quelle) (719.252 9) (PAL)"
-	rom ( name "Im Schutz der Drachen (AKA Dragon Defender) (1983) (Quelle) (719.252 9) (PAL).bin" size 4096 crc 0d57e23d md5 undefined sha1 794625475863c52259478ebd928ead829c1aaee3 )
-)
-
-game (
-	name "Imagic Selector ROM (1982) (Imagic) (PAL)"
-	description "Imagic Selector ROM (1982) (Imagic) (PAL)"
-	rom ( name "Imagic Selector ROM (1982) (Imagic) (PAL).bin" size 2048 crc dfefe82e md5 undefined sha1 5a9b9cc73fd367d02986e8692f42caaa602d4762 )
-)
-
-game (
-	name "Imagic Selector ROM (1982) (Imagic) [a]"
-	description "Imagic Selector ROM (1982) (Imagic) [a]"
-	rom ( name "Imagic Selector ROM (1982) (Imagic) [a].bin" size 4096 crc 552e3b21 md5 undefined sha1 0f18347ede9338f4aa85450667d164a7dea41101 )
-)
-
-game (
-	name "Imagic Selector ROM (1982) (Imagic) ~"
-	description "Imagic Selector ROM (1982) (Imagic) ~"
-	rom ( name "Imagic Selector ROM (1982) (Imagic) ~.bin" size 2048 crc b2e52f0f md5 undefined sha1 ceb3c722234633b39a57093e62cd11ae47639fa1 )
-)
-
-game (
-	name "Immies & Aggies - Immies and Aggies (1983) (ZiMAG - Emag - Vidco) (715-111 - GN-060) (Prototype) ~"
-	description "Immies & Aggies - Immies and Aggies (1983) (ZiMAG - Emag - Vidco) (715-111 - GN-060) (Prototype) ~"
-	rom ( name "Immies & Aggies - Immies and Aggies (1983) (ZiMAG - Emag - Vidco) (715-111 - GN-060) (Prototype) ~.bin" size 4096 crc 86244c24 md5 undefined sha1 603b4ecc797972d32f2f3b8e66ebdde5aaf51a07 )
-)
-
-game (
-	name "Immies & Aggies (1983) (CCE) (C-838)"
-	description "Immies & Aggies (1983) (CCE) (C-838)"
-	rom ( name "Immies & Aggies (1983) (CCE) (C-838).bin" size 4096 crc f58611f5 md5 undefined sha1 5e09a8ac303f701ccac483755d1a29dfcd21681f )
-)
-
-game (
-	name "Immies & Aggies (Unknown)"
-	description "Immies & Aggies (Unknown)"
-	rom ( name "Immies & Aggies (Unknown).bin" size 4096 crc bfd8c8f9 md5 undefined sha1 c43ab196ecbb32b71d2bd0ac5c86ed866286415d )
-)
-
-game (
-	name "Inca Gold (AKA Spider Kong) (Zellers)"
-	description "Inca Gold (AKA Spider Kong) (Zellers)"
-	rom ( name "Inca Gold (AKA Spider Kong) (Zellers).bin" size 4096 crc f06e8235 md5 undefined sha1 1fe79aa4821d7e172ec7d69ea34bd12403442297 )
-)
-
-game (
-	name "Indy 500 - Race (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle - Sears) (CX2611 - 99821, 49-75149) ~"
-	description "Indy 500 - Race (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle - Sears) (CX2611 - 99821, 49-75149) ~"
-	rom ( name "Indy 500 - Race (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle - Sears) (CX2611 - 99821, 49-75149) ~.bin" size 2048 crc b43da2a3 md5 undefined sha1 620ab88d63cdd3f8ce67deac00a22257c7205c8b )
-)
-
-game (
-	name "Indy 500 (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle) (CX2611, CX2611P) (PAL)"
-	description "Indy 500 (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle) (CX2611, CX2611P) (PAL)"
-	rom ( name "Indy 500 (Race Car) (Driving Controller) (1977) (Atari, Carla Meninsky, Ed Riddle) (CX2611, CX2611P) (PAL).bin" size 2048 crc 7f77afc9 md5 undefined sha1 f6ca3ca4af6d9ac5a539f1bc4c7a3a04837c2e44 )
-)
-
-game (
-	name "Infernal Tower (AKA Towering Inferno) (1983) (Carrere Video, Jeff Corsiglia, Paul Allen Newell - Teldec - Prism Micro Products) (USC1009) (PAL)"
-	description "Infernal Tower (AKA Towering Inferno) (1983) (Carrere Video, Jeff Corsiglia, Paul Allen Newell - Teldec - Prism Micro Products) (USC1009) (PAL)"
-	rom ( name "Infernal Tower (AKA Towering Inferno) (1983) (Carrere Video, Jeff Corsiglia, Paul Allen Newell - Teldec - Prism Micro Products) (USC1009) (PAL).bin" size 4096 crc 4f502c88 md5 undefined sha1 933ea6fa612fbbb3d5249641df16b800d3777f71 )
-)
-
-game (
-	name "Infiltrate - Nid d'espions (1981) (Apollo - Games by Apollo - RCA Video Jeux) (AP-2006) (PAL)"
-	description "Infiltrate - Nid d'espions (1981) (Apollo - Games by Apollo - RCA Video Jeux) (AP-2006) (PAL)"
-	rom ( name "Infiltrate - Nid d'espions (1981) (Apollo - Games by Apollo - RCA Video Jeux) (AP-2006) (PAL).bin" size 4096 crc ed030be2 md5 undefined sha1 8a48eeebabd8d786ae78cde6b2cd7dc9cff89519 )
-)
-
-game (
-	name "Infiltrate (1981) (Apollo - Games by Apollo) (AP-2006) ~"
-	description "Infiltrate (1981) (Apollo - Games by Apollo) (AP-2006) ~"
-	rom ( name "Infiltrate (1981) (Apollo - Games by Apollo) (AP-2006) ~.bin" size 4096 crc 612bd4da md5 undefined sha1 922cd171ef132bf6c5bed00ad01410ada4b20729 )
-)
-
-game (
-	name "Innerspace (1983) (VentureVision, Dan Oliver) (Prototype)"
-	description "Innerspace (1983) (VentureVision, Dan Oliver) (Prototype)"
-	rom ( name "Innerspace (1983) (VentureVision, Dan Oliver) (Prototype).bin" size 4096 crc 02d00dad md5 undefined sha1 943c7bb926c71e94f3a53185ac3bec1c27ffbee0 )
-)
-
-game (
-	name "International Soccer (1982) (M Network, Kevin Miller) (MT5687) ~"
-	description "International Soccer (1982) (M Network, Kevin Miller) (MT5687) ~"
-	rom ( name "International Soccer (1982) (M Network, Kevin Miller) (MT5687) ~.bin" size 4096 crc b9d549a2 md5 undefined sha1 fa5bf10d9058eeb2e32ab65a25a906c17b445903 )
-)
-
-game (
-	name "International Soccer (1989) (Telegames) (5687 A279) (PAL)"
-	description "International Soccer (1989) (Telegames) (5687 A279) (PAL)"
-	rom ( name "International Soccer (1989) (Telegames) (5687 A279) (PAL).bin" size 4096 crc 5cf82c0a md5 undefined sha1 059c0b5a3568f13ace63e5c61208beea9e924ffd )
-)
-
-game (
-	name "International Soccer (Unknown)"
-	description "International Soccer (Unknown)"
-	rom ( name "International Soccer (Unknown).bin" size 4096 crc ebc723c0 md5 undefined sha1 9d725002e94b04e29d8cbce3c71d3bb2a84352fa )
-)
-
-game (
-	name "International Soccer (Unknown) (PAL)"
-	description "International Soccer (Unknown) (PAL)"
-	rom ( name "International Soccer (Unknown) (PAL).bin" size 4096 crc 5cf0902b md5 undefined sha1 3046f6e7ad1d5bb9ff7178929cb3127f94e0143f )
-)
-
-game (
-	name "IQ 180 (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "IQ 180 (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "IQ 180 (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 5ea5d7e3 md5 undefined sha1 f157de7adac8d14231d3f8e6f35df8c39bb1b75f )
-)
-
-game (
-	name "IQ 180 (Unknown)"
-	description "IQ 180 (Unknown)"
-	rom ( name "IQ 180 (Unknown).bin" size 4096 crc 4dc2a674 md5 undefined sha1 8483fd18dddafbdfbcbd1c43bc7de2cc05a1894d )
-)
-
-game (
-	name "Ixion (1984) (Sega, Jeff Lorenz) (Prototype) ~"
-	description "Ixion (1984) (Sega, Jeff Lorenz) (Prototype) ~"
-	rom ( name "Ixion (1984) (Sega, Jeff Lorenz) (Prototype) ~.bin" size 8192 crc b311e13f md5 undefined sha1 a11538157529b42a2840f518b95af5c59143cced )
-)
-
-game (
-	name "Jacky Jump (AKA Bobby Is Going Home) (1983) (Home Vision - Gem International Corp.) (PAL)"
-	description "Jacky Jump (AKA Bobby Is Going Home) (1983) (Home Vision - Gem International Corp.) (PAL)"
-	rom ( name "Jacky Jump (AKA Bobby Is Going Home) (1983) (Home Vision - Gem International Corp.) (PAL).bin" size 4096 crc 31bc54ae md5 undefined sha1 5e48b5e98be4e8d2d8602b0039c3ea959d6a0731 )
-)
-
-game (
-	name "Jagd auf Diamanten-Frisco (AKA Frisco) (1983) (Quelle) (875.413 7) (PAL)"
-	description "Jagd auf Diamanten-Frisco (AKA Frisco) (1983) (Quelle) (875.413 7) (PAL)"
-	rom ( name "Jagd auf Diamanten-Frisco (AKA Frisco) (1983) (Quelle) (875.413 7) (PAL).bin" size 4096 crc 5b47448c md5 undefined sha1 59cc30a376901462e43bc78586495c72bab81fce )
-)
-
-game (
-	name "James Bond 007 (James Bond Agent 007) (1983) (Parker Brothers, Joe Gaucher, Louis Marbel) (PB5110) ~"
-	description "James Bond 007 (James Bond Agent 007) (1983) (Parker Brothers, Joe Gaucher, Louis Marbel) (PB5110) ~"
-	rom ( name "James Bond 007 (James Bond Agent 007) (1983) (Parker Brothers, Joe Gaucher, Louis Marbel) (PB5110) ~.bin" size 8192 crc 34d3ffc8 md5 undefined sha1 2bbc124cead9aa49b364268735dad8cb1eb6594f )
-)
-
-game (
-	name "Jaw Breaker (1983) (CCE) (C-824)"
-	description "Jaw Breaker (1983) (CCE) (C-824)"
-	rom ( name "Jaw Breaker (1983) (CCE) (C-824).bin" size 4096 crc fc11bf67 md5 undefined sha1 af4d6867a8bc4818fc6bb701a765a3c907feb628 )
-)
-
-game (
-	name "Jawbreaker (1982) (Tigervision, John Harris - Teldec) (7-002) (PAL)"
-	description "Jawbreaker (1982) (Tigervision, John Harris - Teldec) (7-002) (PAL)"
-	rom ( name "Jawbreaker (1982) (Tigervision, John Harris - Teldec) (7-002) (PAL).bin" size 4096 crc 68d10eb0 md5 undefined sha1 98ac19f7b445687b72af4c1dabbce8e269f41e91 )
-)
-
-game (
-	name "Jawbreaker (1982) (Tigervision, John Harris) (7-002) ~"
-	description "Jawbreaker (1982) (Tigervision, John Harris) (7-002) ~"
-	rom ( name "Jawbreaker (1982) (Tigervision, John Harris) (7-002) ~.bin" size 4096 crc fc11bf67 md5 undefined sha1 af4d6867a8bc4818fc6bb701a765a3c907feb628 )
-)
-
-game (
-	name "Jawbreaker (Unknown) (PAL)"
-	description "Jawbreaker (Unknown) (PAL)"
-	rom ( name "Jawbreaker (Unknown) (PAL).bin" size 4096 crc c6f2134c md5 undefined sha1 8bd8620346dd08b4be17dad75ae24aabefb4f6e8 )
-)
-
-game (
-	name "Jawbreaker (Unknown) (PAL) [a]"
-	description "Jawbreaker (Unknown) (PAL) [a]"
-	rom ( name "Jawbreaker (Unknown) (PAL) [a].bin" size 4096 crc d56cfcac md5 undefined sha1 a6e5c519ca8ae36ca25a20663475abe7416fa24e )
-)
-
-game (
-	name "Journey Escape - Rock 'n' Roll Escape (1983) (Gameworld) (133-006) (PAL)"
-	description "Journey Escape - Rock 'n' Roll Escape (1983) (Gameworld) (133-006) (PAL)"
-	rom ( name "Journey Escape - Rock 'n' Roll Escape (1983) (Gameworld) (133-006) (PAL).bin" size 4096 crc cf1144ba md5 undefined sha1 2367830a13361dc070ac961009e4450d6191dccd )
-)
-
-game (
-	name "Journey Escape (1982) (Data Age) (112-006) ~"
-	description "Journey Escape (1982) (Data Age) (112-006) ~"
-	rom ( name "Journey Escape (1982) (Data Age) (112-006) ~.bin" size 4096 crc 52ff8027 md5 undefined sha1 928eaa424b36d98078f9251d67fb13a8fddfafbd )
-)
-
-game (
-	name "Joust (08-09-1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) (Prototype)"
-	description "Joust (08-09-1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) (Prototype)"
-	rom ( name "Joust (08-09-1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) (Prototype).bin" size 8192 crc 78a4d4f4 md5 undefined sha1 51881d226c33cad7d429d3a56b7ee644ad053e57 )
-)
-
-game (
-	name "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691, CX2691P) (PAL)"
-	description "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691, CX2691P) (PAL)"
-	rom ( name "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691, CX2691P) (PAL).bin" size 8192 crc d27a003f md5 undefined sha1 033fa9ecad9eb4d5cfebf6505cb76a2126de6567 )
-)
-
-game (
-	name "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) ~"
-	description "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) ~"
-	rom ( name "Joust (1983) (Atari - GCC, Mike Feinstein, Kevin Osborn) (CX2691) ~.bin" size 8192 crc a07b3304 md5 undefined sha1 cb94dc316cba282a0036871db2417257e960786b )
-)
-
-game (
-	name "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123, CX26123P) (PAL)"
-	description "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123, CX26123P) (PAL)"
-	rom ( name "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123, CX26123P) (PAL).bin" size 16384 crc a1aa87dd md5 undefined sha1 a343d6553fa0367f49752ff8389116cee3605451 )
-)
-
-game (
-	name "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123) ~"
-	description "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123) ~"
-	rom ( name "Jr. Pac-Man (1984) (Atari - GCC, Ava-Robin Cohen) (CX26123) ~.bin" size 16384 crc 5c345bac md5 undefined sha1 cd2cf245d6e924ff2100cc93d20223c4a231e160 )
-)
-
-game (
-	name "Jumping Jack (AKA Bobby Is Going Home) (1983) (Dynamics) (DY-293005) (PAL)"
-	description "Jumping Jack (AKA Bobby Is Going Home) (1983) (Dynamics) (DY-293005) (PAL)"
-	rom ( name "Jumping Jack (AKA Bobby Is Going Home) (1983) (Dynamics) (DY-293005) (PAL).bin" size 4096 crc 4cd2b0f0 md5 undefined sha1 70f6a52f4d4b29a50b7f99074f8f81602ebe30cd )
-)
-
-game (
-	name "Jungle Fever (1982) (PlayAround - J.H.M.) (203)"
-	description "Jungle Fever (1982) (PlayAround - J.H.M.) (203)"
-	rom ( name "Jungle Fever (1982) (PlayAround - J.H.M.) (203).bin" size 4096 crc 0123617b md5 undefined sha1 9a0ee845d9928d4db003b07b927bb2c1f628e725 )
-)
-
-game (
-	name "Jungle Hunt (02-03-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype)"
-	description "Jungle Hunt (02-03-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype)"
-	rom ( name "Jungle Hunt (02-03-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype).bin" size 8192 crc 35804e38 md5 undefined sha1 304b22919ce4a278fa5560a70901f0af08114e8d )
-)
-
-game (
-	name "Jungle Hunt (02-25-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype)"
-	description "Jungle Hunt (02-25-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype)"
-	rom ( name "Jungle Hunt (02-25-1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) (Prototype).bin" size 8192 crc a26630cf md5 undefined sha1 1a911b08c48721e9280e0df07d7df4f7bfecb724 )
-)
-
-game (
-	name "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688, CX2688P) (PAL)"
-	description "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688, CX2688P) (PAL)"
-	rom ( name "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688, CX2688P) (PAL).bin" size 8192 crc cce0a94a md5 undefined sha1 b3ab5b0c1c4929dcca777fe2441f0c8aba03944f )
-)
-
-game (
-	name "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) ~"
-	description "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) ~"
-	rom ( name "Jungle Hunt (1983) (Atari - GCC, Mike Feinstein, John Allred) (CX2688) ~.bin" size 8192 crc 9c3e8734 md5 undefined sha1 83a32a2d686355438c915540cfe0bb13b76c1113 )
-)
-
-game (
-	name "Jungle Hunt (1983) (CCE) (C-1007)"
-	description "Jungle Hunt (1983) (CCE) (C-1007)"
-	rom ( name "Jungle Hunt (1983) (CCE) (C-1007).bin" size 8192 crc dcf3dd69 md5 undefined sha1 fe52af1b54e146be187e425fef229751212eeee1 )
-)
-
-game (
-	name "Jungle Hunt (1983) (CCE) (C-1007) [a]"
-	description "Jungle Hunt (1983) (CCE) (C-1007) [a]"
-	rom ( name "Jungle Hunt (1983) (CCE) (C-1007) [a].bin" size 8192 crc 86ae30bb md5 undefined sha1 8903aada563b4f5735274092d4e1b246f3d0f76d )
-)
-
-game (
-	name "Kabobber (07-25-1983) (Activision, Rex Bradford) (Prototype) ~"
-	description "Kabobber (07-25-1983) (Activision, Rex Bradford) (Prototype) ~"
-	rom ( name "Kabobber (07-25-1983) (Activision, Rex Bradford) (Prototype) ~.bin" size 4096 crc 9517ee0e md5 undefined sha1 ce8ac88b799c282567495ce509402a5a4c2c4d82 )
-)
-
-game (
-	name "Kaboom! - Schneller als der Knall (Paddle) (1981) (Activision, Larry Kaplan, David Crane - Ariola) (EAG-010, PAG-010 - 711 010-720) (PAL)"
-	description "Kaboom! - Schneller als der Knall (Paddle) (1981) (Activision, Larry Kaplan, David Crane - Ariola) (EAG-010, PAG-010 - 711 010-720) (PAL)"
-	rom ( name "Kaboom! - Schneller als der Knall (Paddle) (1981) (Activision, Larry Kaplan, David Crane - Ariola) (EAG-010, PAG-010 - 711 010-720) (PAL).bin" size 2048 crc 63f8f529 md5 undefined sha1 a257546271b33d7e3b9e7ea0ec4606ec47cfbc94 )
-)
-
-game (
-	name "Kaboom! (Paddle) (1981) (Activision, Larry Kaplan, David Crane) (AG-010, AG-010-04) ~"
-	description "Kaboom! (Paddle) (1981) (Activision, Larry Kaplan, David Crane) (AG-010, AG-010-04) ~"
-	rom ( name "Kaboom! (Paddle) (1981) (Activision, Larry Kaplan, David Crane) (AG-010, AG-010-04) ~.bin" size 2048 crc 813f00f6 md5 undefined sha1 40d4df4f8e4a69a299ae7678c17e72bedeb70105 )
-)
-
-game (
-	name "Kaboom! (Paddle) (CCE)"
-	description "Kaboom! (Paddle) (CCE)"
-	rom ( name "Kaboom! (Paddle) (CCE).bin" size 2048 crc b4901d54 md5 undefined sha1 ae5af59b3503858bd847c07fea8033139890ff34 )
-)
-
-game (
-	name "Kamikaze Saucers (1983) (Syncro, Dan Wolf) (Prototype) ~"
-	description "Kamikaze Saucers (1983) (Syncro, Dan Wolf) (Prototype) ~"
-	rom ( name "Kamikaze Saucers (1983) (Syncro, Dan Wolf) (Prototype) ~.bin" size 4096 crc 85cb187c md5 undefined sha1 a82aaeef44ad88de605c50d23fb4f6cec73f3ab4 )
-)
-
-game (
-	name "Kampf dem Steinfresser - Boom Bang (AKA Crackpots) (1983) (Quelle) (463.574 4 - 781393, 986153) (PAL)"
-	description "Kampf dem Steinfresser - Boom Bang (AKA Crackpots) (1983) (Quelle) (463.574 4 - 781393, 986153) (PAL)"
-	rom ( name "Kampf dem Steinfresser - Boom Bang (AKA Crackpots) (1983) (Quelle) (463.574 4 - 781393, 986153) (PAL).bin" size 4096 crc 3beda93b md5 undefined sha1 dd3494a1e3ffa063803b1f02716e87e89dc3c574 )
-)
-
-game (
-	name "Kampf im Asteroiden-Guertel - Astrowar (1983) (Quelle) (719.302 2 - 311388) (PAL)"
-	description "Kampf im Asteroiden-Guertel - Astrowar (1983) (Quelle) (719.302 2 - 311388) (PAL)"
-	rom ( name "Kampf im Asteroiden-Guertel - Astrowar (1983) (Quelle) (719.302 2 - 311388) (PAL).bin" size 4096 crc bb47d5af md5 undefined sha1 5cc122f10eb1a814d047404b462b325f51f35d2c )
-)
-
-game (
-	name "Kampf um die Schatzinsel (AKA Treasure Island) (1983) (Quelle) (719.163 8) (PAL)"
-	description "Kampf um die Schatzinsel (AKA Treasure Island) (1983) (Quelle) (719.163 8) (PAL)"
-	rom ( name "Kampf um die Schatzinsel (AKA Treasure Island) (1983) (Quelle) (719.163 8) (PAL).bin" size 4096 crc 907f1d90 md5 undefined sha1 d1437e291fbc1927fcce14abc21a58a423e15368 )
-)
-
-game (
-	name "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689, CX2689P) (PAL)"
-	description "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689, CX2689P) (PAL)"
-	rom ( name "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689, CX2689P) (PAL).bin" size 8192 crc b3b2a251 md5 undefined sha1 dac53b95626b68d3686430ccfda8c1a10946bad2 )
-)
-
-game (
-	name "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689) ~"
-	description "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689) ~"
-	rom ( name "Kangaroo (1983) (Atari - GCC, Kevin Osborn) (CX2689) ~.bin" size 8192 crc b9ab57e6 md5 undefined sha1 01fd30311e028944eafb6d14bb001035f816ced7 )
-)
-
-game (
-	name "Kanguru (AKA Kangaroo) (1983) (Zirok)"
-	description "Kanguru (AKA Kangaroo) (1983) (Zirok)"
-	rom ( name "Kanguru (AKA Kangaroo) (1983) (Zirok).bin" size 8192 crc e81eafe8 md5 undefined sha1 166902bf07013ad2983c11547226d33d72740236 )
-)
-
-game (
-	name "Karate (1982) (Funvision - Fund. International Co.) (PAL)"
-	description "Karate (1982) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Karate (1982) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc 86c21e13 md5 undefined sha1 c78feaec45604cda85eb5809e8814c3e49e8c73c )
-)
-
-game (
-	name "Karate (1982) (Ultravision, Joseph Amelio) (1044) ~"
-	description "Karate (1982) (Ultravision, Joseph Amelio) (1044) ~"
-	rom ( name "Karate (1982) (Ultravision, Joseph Amelio) (1044) ~.bin" size 4096 crc ac0a9ce0 md5 undefined sha1 c0db7d295e2ce5e00e00b8a83075b1103688ea15 )
-)
-
-game (
-	name "Karate (1987) (Froggo) (FG1001)"
-	description "Karate (1987) (Froggo) (FG1001)"
-	rom ( name "Karate (1987) (Froggo) (FG1001).bin" size 4096 crc ac0a9ce0 md5 undefined sha1 c0db7d295e2ce5e00e00b8a83075b1103688ea15 )
-)
-
-game (
-	name "Karate (Unknown) (PAL)"
-	description "Karate (Unknown) (PAL)"
-	rom ( name "Karate (Unknown) (PAL).bin" size 4096 crc 48e8b59d md5 undefined sha1 c8cd0a04edea449151e6349db2455d48f23dc213 )
-)
-
-game (
-	name "Katastrophen-Einsatz (AKA M.A.S.H.) (1983) (Quelle) (876.013 4) (PAL)"
-	description "Katastrophen-Einsatz (AKA M.A.S.H.) (1983) (Quelle) (876.013 4) (PAL)"
-	rom ( name "Katastrophen-Einsatz (AKA M.A.S.H.) (1983) (Quelle) (876.013 4) (PAL).bin" size 4096 crc 6c87e640 md5 undefined sha1 d5ce6dae728700ef24a7cddc95e1e42d0e2d20f9 )
-)
-
-game (
-	name "Kaystone Kapers (AKA Keystone Kapers) (1983) (Digitel)"
-	description "Kaystone Kapers (AKA Keystone Kapers) (1983) (Digitel)"
-	rom ( name "Kaystone Kapers (AKA Keystone Kapers) (1983) (Digitel).bin" size 4096 crc a963b50e md5 undefined sha1 54cd3848704563399784426e7d00eccd7f96836b )
-)
-
-game (
-	name "Keystone (AKA Keystone Kapers) (Tiger Vision - Eram)"
-	description "Keystone (AKA Keystone Kapers) (Tiger Vision - Eram)"
-	rom ( name "Keystone (AKA Keystone Kapers) (Tiger Vision - Eram).bin" size 4096 crc 6f872ffc md5 undefined sha1 2836a67954f3d94c27e09642e123a2b0c1d4ab39 )
-)
-
-game (
-	name "Keystone Kapers - Raueber und Gendarm (1983) (Activision, Garry Kitchen - Ariola) (EAX-025, EAX-025-04I - 711 025-725) (PAL)"
-	description "Keystone Kapers - Raueber und Gendarm (1983) (Activision, Garry Kitchen - Ariola) (EAX-025, EAX-025-04I - 711 025-725) (PAL)"
-	rom ( name "Keystone Kapers - Raueber und Gendarm (1983) (Activision, Garry Kitchen - Ariola) (EAX-025, EAX-025-04I - 711 025-725) (PAL).bin" size 4096 crc 5d27f7fb md5 undefined sha1 525e9054343916e2a7271278cf3610e0ed1efb71 )
-)
-
-game (
-	name "Keystone Kapers (1983) (Activision, Garry Kitchen) (AX-025, AX-025-04) ~"
-	description "Keystone Kapers (1983) (Activision, Garry Kitchen) (AX-025, AX-025-04) ~"
-	rom ( name "Keystone Kapers (1983) (Activision, Garry Kitchen) (AX-025, AX-025-04) ~.bin" size 4096 crc 3e55f3a1 md5 undefined sha1 3eefc193dec3b242bcfd43f5a4d9f023e55378a4 )
-)
-
-game (
-	name "Keystone Kapers (1983) (Activision, Garry Kitchen) (EAX-025) (SECAM)"
-	description "Keystone Kapers (1983) (Activision, Garry Kitchen) (EAX-025) (SECAM)"
-	rom ( name "Keystone Kapers (1983) (Activision, Garry Kitchen) (EAX-025) (SECAM).bin" size 4096 crc 19d50092 md5 undefined sha1 b3df50f1df780a8f7cbcdf15d803d2b85bb586ff )
-)
-
-game (
-	name "Keystone Kapers (Canal 3 - Intellivision) (C 3014)"
-	description "Keystone Kapers (Canal 3 - Intellivision) (C 3014)"
-	rom ( name "Keystone Kapers (Canal 3 - Intellivision) (C 3014).bin" size 4096 crc 481a8661 md5 undefined sha1 7e722f1184d5291ca53b0aca619915d3ec272926 )
-)
-
-game (
-	name "Keystone Kapers (Digivision)"
-	description "Keystone Kapers (Digivision)"
-	rom ( name "Keystone Kapers (Digivision).bin" size 4096 crc 39a5ba90 md5 undefined sha1 c05d225766dfde9aaeab25c975aadaf4e8b9c556 )
-)
-
-game (
-	name "Keystone Kapers (Robby)"
-	description "Keystone Kapers (Robby)"
-	rom ( name "Keystone Kapers (Robby).bin" size 4096 crc 33510e05 md5 undefined sha1 74fccedb3554a411f15e0d7f173cc18a1505f60f )
-)
-
-game (
-	name "Keystone Kapers (Shock Vision)"
-	description "Keystone Kapers (Shock Vision)"
-	rom ( name "Keystone Kapers (Shock Vision).bin" size 4096 crc 98e8678f md5 undefined sha1 4ae6b64f9a93cf4e7cb3ddd495aa0ca088ba6569 )
-)
-
-game (
-	name "Keystone Kapers (Unknown)"
-	description "Keystone Kapers (Unknown)"
-	rom ( name "Keystone Kapers (Unknown).bin" size 4096 crc f519067b md5 undefined sha1 4b397d7165825ebfe8f8dd6dddba7051b07185eb )
-)
-
-game (
-	name "Keystone Kapers (Unknown) (PAL)"
-	description "Keystone Kapers (Unknown) (PAL)"
-	rom ( name "Keystone Kapers (Unknown) (PAL).bin" size 4096 crc 966b0221 md5 undefined sha1 146e520febeb9a4d5df3ab5c374da60684eb3548 )
-)
-
-game (
-	name "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816)"
-	description "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816)"
-	rom ( name "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816).bin" size 4096 crc c9a64ff8 md5 undefined sha1 de2a47710287f5052bfe123b4a356f5b6bc122dc )
-)
-
-game (
-	name "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816) [a]"
-	description "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816) [a]"
-	rom ( name "Keystone Kappers (AKA Keystone Kapers) (1983) (CCE) (C-816) [a].bin" size 4096 crc ec9199da md5 undefined sha1 137ad103f74c0fa4f5ec0df3f56c726b63c13361 )
-)
-
-game (
-	name "Keystone Keypers (AKA Keystone Kapers) (1983) (Zirok)"
-	description "Keystone Keypers (AKA Keystone Kapers) (1983) (Zirok)"
-	rom ( name "Keystone Keypers (AKA Keystone Kapers) (1983) (Zirok).bin" size 4096 crc bf13ce6e md5 undefined sha1 401b811cc01c3370f5e0d18dc16a18b0bbf3bf87 )
-)
-
-game (
-	name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (PAL)"
-	description "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (PAL)"
-	rom ( name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (PAL).bin" size 8448 crc 0b60d857 md5 undefined sha1 7ab5597ca336d3eebd21a7ad82989af366f2dcd3 )
-)
-
-game (
-	name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (Prototype)"
-	description "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (Prototype)"
-	rom ( name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) (Prototype).bin" size 8448 crc c989064c md5 undefined sha1 dd0a82dac03298a8ce945c4b612cf8944927f5e8 )
-)
-
-game (
-	name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) ~"
-	description "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) ~"
-	rom ( name "Killer Satellites (1983) (Starpath Corporation, Kevin Norman) (7) (AR-4103) ~.bin" size 8448 crc bdd932dc md5 undefined sha1 64125e796f96aa472bb2191367c6501c657712d9 )
-)
-
-game (
-	name "King Arthur (AKA Dragonfire) (Double-Game Package) (1983) (Quelle) (600273) (PAL)"
-	description "King Arthur (AKA Dragonfire) (Double-Game Package) (1983) (Quelle) (600273) (PAL)"
-	rom ( name "King Arthur (AKA Dragonfire) (Double-Game Package) (1983) (Quelle) (600273) (PAL).bin" size 4096 crc f21bec5e md5 undefined sha1 3a6a045b5426a6090ff21db13aff1b7dde675990 )
-)
-
-game (
-	name "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL)"
-	description "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL)"
-	rom ( name "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL).bin" size 4096 crc e793edaf md5 undefined sha1 af679eb19d7e4ac0ea620332edbb7081567a55db )
-)
-
-game (
-	name "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL) [a]"
-	description "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL) [a]"
-	rom ( name "King Kong (1982) (Tigervision, Karl T. Olinger - Teldec) (7-001 - 3.60001 VE) (PAL) [a].bin" size 4096 crc ea99089a md5 undefined sha1 839e13ffedcbed22d51a24c001900c3474a078f2 )
-)
-
-game (
-	name "King Kong (1982) (Tigervision, Karl T. Olinger) (7-001) ~"
-	description "King Kong (1982) (Tigervision, Karl T. Olinger) (7-001) ~"
-	rom ( name "King Kong (1982) (Tigervision, Karl T. Olinger) (7-001) ~.bin" size 4096 crc cb6f5617 md5 undefined sha1 59f485ea345cf1b9e3663b45b246f13936a32972 )
-)
-
-game (
-	name "Klax (06-14-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype)"
-	description "Klax (06-14-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype)"
-	rom ( name "Klax (06-14-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype).bin" size 16384 crc ce778afd md5 undefined sha1 991089a63734a859c89eb465f3fc074e57c3ee4d )
-)
-
-game (
-	name "Klax (08-18-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype)"
-	description "Klax (08-18-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype)"
-	rom ( name "Klax (08-18-1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (Prototype).bin" size 16384 crc 6bc47721 md5 undefined sha1 3162259c6dbfbb57a2ea41d849155702151ee39b )
-)
-
-game (
-	name "Klax (1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (PAL) ~"
-	description "Klax (1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (PAL) ~"
-	rom ( name "Klax (1990) (Atari - Axlon, Steve DeFrisco) (CX26192) (PAL) ~.bin" size 16384 crc a8aaf68b md5 undefined sha1 45623a1c8fb5074de98c37f005edd5b1d0937dae )
-)
-
-game (
-	name "Knight on the Town (1982) (PlayAround - J.H.M.) (203)"
-	description "Knight on the Town (1982) (PlayAround - J.H.M.) (203)"
-	rom ( name "Knight on the Town (1982) (PlayAround - J.H.M.) (203).bin" size 4096 crc acea70a6 md5 undefined sha1 759597d1d779cfdfd7aa30fd28a59acc58ca2533 )
-)
-
-game (
-	name "Knight on the Town (1982) (PlayAround - J.H.M.) (203) (PAL)"
-	description "Knight on the Town (1982) (PlayAround - J.H.M.) (203) (PAL)"
-	rom ( name "Knight on the Town (1982) (PlayAround - J.H.M.) (203) (PAL).bin" size 4096 crc 8998b0ef md5 undefined sha1 d8033e1ba6efcac9d198757b41423b6963b6ffd7 )
-)
-
-game (
-	name "Kool-Aid Man (Kool Aid Pitcher Man) (1983) (M Network, Stephen Tatsumi, Jane Terjung - Kool Aid) (MT4648) ~"
-	description "Kool-Aid Man (Kool Aid Pitcher Man) (1983) (M Network, Stephen Tatsumi, Jane Terjung - Kool Aid) (MT4648) ~"
-	rom ( name "Kool-Aid Man (Kool Aid Pitcher Man) (1983) (M Network, Stephen Tatsumi, Jane Terjung - Kool Aid) (MT4648) ~.bin" size 4096 crc d9bd009b md5 undefined sha1 2f550743e237f6dc8c75c389a01b02e9a396fdad )
-)
-
-game (
-	name "Krieg der Sterne (AKA Atlantis) (Videospielkassette - Ariola) (PGP233) (PAL)"
-	description "Krieg der Sterne (AKA Atlantis) (Videospielkassette - Ariola) (PGP233) (PAL)"
-	rom ( name "Krieg der Sterne (AKA Atlantis) (Videospielkassette - Ariola) (PGP233) (PAL).bin" size 4096 crc 0eb1080c md5 undefined sha1 82e64366795b011c2a2f1755bf899cc2c0617fe8 )
-)
-
-game (
-	name "Krull (05-27-1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) (Prototype)"
-	description "Krull (05-27-1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) (Prototype)"
-	rom ( name "Krull (05-27-1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) (Prototype).bin" size 8192 crc 8dcff2e8 md5 undefined sha1 fb7402ff554d32441ea93066288a465a1cc694b9 )
-)
-
-game (
-	name "Krull (1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) ~"
-	description "Krull (1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) ~"
-	rom ( name "Krull (1983) (Atari, Jerome Domurat, Dave Staugas) (CX2682) ~.bin" size 8192 crc 1a67e6ed md5 undefined sha1 4bdf1cf73316bdb0002606facf11b6ddcb287207 )
-)
-
-game (
-	name "Krull (CCE)"
-	description "Krull (CCE)"
-	rom ( name "Krull (CCE).bin" size 8192 crc 632e5244 md5 undefined sha1 07a1c1b1a2297c4edde0e16f610b5ec23c775217 )
-)
-
-game (
-	name "Kung Fu (AKA Karate) (4 Game in One) (1983) (Bit Corporation) (PGP229) (PAL)"
-	description "Kung Fu (AKA Karate) (4 Game in One) (1983) (Bit Corporation) (PGP229) (PAL)"
-	rom ( name "Kung Fu (AKA Karate) (4 Game in One) (1983) (Bit Corporation) (PGP229) (PAL).bin" size 4096 crc d77552e9 md5 undefined sha1 b5fad0b608095c7ea3c11b77ade460aec50614a6 )
-)
-
-game (
-	name "Kung Fu Master (CCE)"
-	description "Kung Fu Master (CCE)"
-	rom ( name "Kung Fu Master (CCE).bin" size 8192 crc b9215ec6 md5 undefined sha1 13240d0decd944f7d5d7a87a7d1b47578f489711 )
-)
-
-game (
-	name "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145)"
-	description "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145)"
-	rom ( name "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145).bin" size 8192 crc 96210c6c md5 undefined sha1 1637b6b9cd1a918339ec054cf95b924e7ce4789a )
-)
-
-game (
-	name "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145) (PAL)"
-	description "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145) (PAL)"
-	rom ( name "Kung Fu Superkicks - Pursuit of the Ninja (AKA Chuck Norris Superkicks) (1989) (Telegames) (6082 A145) (PAL).bin" size 8192 crc b3091531 md5 undefined sha1 061e5196af3b559766d4158a13faef04f7365cd5 )
-)
-
-game (
-	name "Kung-Fu Master (1987) (Activision, Dan Kitchen) (AG-039-04) ~"
-	description "Kung-Fu Master (1987) (Activision, Dan Kitchen) (AG-039-04) ~"
-	rom ( name "Kung-Fu Master (1987) (Activision, Dan Kitchen) (AG-039-04) ~.bin" size 8192 crc 5fea6e51 md5 undefined sha1 3b93a34ba2a6b7db387ea588c48d939eee5d71a1 )
-)
-
-game (
-	name "Kung-Fu Master (1987) (Activision, Dan Kitchen) (EAX-039-04B, EAX-039-04I) (PAL)"
-	description "Kung-Fu Master (1987) (Activision, Dan Kitchen) (EAX-039-04B, EAX-039-04I) (PAL)"
-	rom ( name "Kung-Fu Master (1987) (Activision, Dan Kitchen) (EAX-039-04B, EAX-039-04I) (PAL).bin" size 8192 crc 7bb76266 md5 undefined sha1 81abed650600ede00a00e23491b79d46a9b4f173 )
-)
-
-game (
-	name "Kwibble (Quick Step! Beta) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) (Prototype)"
-	description "Kwibble (Quick Step! Beta) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) (Prototype)"
-	rom ( name "Kwibble (Quick Step! Beta) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) (Prototype).bin" size 4096 crc 45628bd3 md5 undefined sha1 696cc5c94de107940e0b22feb3089aaf62e96996 )
-)
-
-game (
-	name "Kyphus (1982) (Apollo, Tim Martin) (AP-2007) (Prototype) ~"
-	description "Kyphus (1982) (Apollo, Tim Martin) (AP-2007) (Prototype) ~"
-	rom ( name "Kyphus (1982) (Apollo, Tim Martin) (AP-2007) (Prototype) ~.bin" size 4096 crc 79bd22e2 md5 undefined sha1 b4b55e0b6b5d7490565b00c03361199f05fb70b8 )
-)
-
-game (
-	name "Labyrint (AKA Phantom Tank) (1983) (Goliath - Hot Shot) (83-411) (PAL)"
-	description "Labyrint (AKA Phantom Tank) (1983) (Goliath - Hot Shot) (83-411) (PAL)"
-	rom ( name "Labyrint (AKA Phantom Tank) (1983) (Goliath - Hot Shot) (83-411) (PAL).bin" size 4096 crc 9213493b md5 undefined sha1 02a521354575d2270f75250e79bc18f69f666c7f )
-)
-
-game (
-	name "Labyrinth (AKA Maze Craze) (1983) (Quelle) (805.784 6) (PAL)"
-	description "Labyrinth (AKA Maze Craze) (1983) (Quelle) (805.784 6) (PAL)"
-	rom ( name "Labyrinth (AKA Maze Craze) (1983) (Quelle) (805.784 6) (PAL).bin" size 4096 crc 4f2bc502 md5 undefined sha1 adbc884601016ebf1b3bca03dce56d95b7a90a22 )
-)
-
-game (
-	name "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell)"
-	description "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell)"
-	rom ( name "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell).bin" size 8448 crc 30ebc4a2 md5 undefined sha1 3ce35421bfa26c69eaced246909956a7e484f1fd )
-)
-
-game (
-	name "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell) [a]"
-	description "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell) [a]"
-	rom ( name "Labyrinth (Escape from the Mindmaster Beta) (1982) (5) (AR-4200) (Arcadia Corporation, Dennis Caswell) [a].bin" size 8448 crc 9dc34fb0 md5 undefined sha1 1df4b18ce0187eea5b4d3dd7d150f552d97a08fa )
-)
-
-game (
-	name "Lady in Wading (1982) (PlayAround - J.H.M.) (204)"
-	description "Lady in Wading (1982) (PlayAround - J.H.M.) (204)"
-	rom ( name "Lady in Wading (1982) (PlayAround - J.H.M.) (204).bin" size 4096 crc f197bbcc md5 undefined sha1 6d59dfea26b7a06545a817f03f62a59be8993587 )
-)
-
-game (
-	name "Landung in der Normandie (AKA Commando Raid) (1983) (Quelle) (876.482 1) (PAL)"
-	description "Landung in der Normandie (AKA Commando Raid) (1983) (Quelle) (876.482 1) (PAL)"
-	rom ( name "Landung in der Normandie (AKA Commando Raid) (1983) (Quelle) (876.482 1) (PAL).bin" size 4096 crc 3717886e md5 undefined sha1 e8baae84ff05b280b7123e940ac229142e0bdb2e )
-)
-
-game (
-	name "Landungskommando (AKA Strategy X) (1983) (Quelle) (176.433 1) (PAL)"
-	description "Landungskommando (AKA Strategy X) (1983) (Quelle) (176.433 1) (PAL)"
-	rom ( name "Landungskommando (AKA Strategy X) (1983) (Quelle) (176.433 1) (PAL).bin" size 4096 crc 5ee1f4dd md5 undefined sha1 f08f89b54455a68a5bc161ec781a5ca0a8ddbdd3 )
-)
-
-game (
-	name "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL)"
-	description "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL)"
-	rom ( name "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL).bin" size 4096 crc dcc36508 md5 undefined sha1 0e981d6baa7e3e218608eb46ad51fb30675babac )
-)
-
-game (
-	name "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL) [a]"
-	description "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL) [a]"
-	rom ( name "Laser Base (AKA The End of the World) (Perry Rhodan-Serie) (1983) (ITT Family Games) (554-33 367) (PAL) [a].bin" size 4096 crc bb71be44 md5 undefined sha1 e1f37a85fe118bcee656a82e9cc0e3798f3f9a31 )
-)
-
-game (
-	name "Laser Blast - Duell im Weltall (Lazer) (1981) (Activision, David Crane - Ariola) (EAG-008, PAG-008, EAG-008-04I - 711 008-720) (PAL)"
-	description "Laser Blast - Duell im Weltall (Lazer) (1981) (Activision, David Crane - Ariola) (EAG-008, PAG-008, EAG-008-04I - 711 008-720) (PAL)"
-	rom ( name "Laser Blast - Duell im Weltall (Lazer) (1981) (Activision, David Crane - Ariola) (EAG-008, PAG-008, EAG-008-04I - 711 008-720) (PAL).bin" size 2048 crc de02eab3 md5 undefined sha1 f43046e44100f123e04432dfed61a487c10e36d9 )
-)
-
-game (
-	name "Laser Blast (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Laser Blast (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Laser Blast (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 0e780c3f md5 undefined sha1 c7df5904cdc6a1658cad89b83e3e523b42a2b45d )
-)
-
-game (
-	name "Laser Blast (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Laser Blast (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Laser Blast (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 5c32a0f0 md5 undefined sha1 7c01dc0bc9f87c01dc93f68b3cc9bfabeda77f83 )
-)
-
-game (
-	name "Laser Blast (CCE)"
-	description "Laser Blast (CCE)"
-	rom ( name "Laser Blast (CCE).bin" size 2048 crc f1e17e7e md5 undefined sha1 4c68497b35cc0254738bf9bffee6eed672c7cea3 )
-)
-
-game (
-	name "Laser Blast (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Laser Blast (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Laser Blast (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 1db9fdb1 md5 undefined sha1 cc45af0a45a6e5d0581683c3589476c0da4b5600 )
-)
-
-game (
-	name "Laser Blast (Lazer) (08-08-1980) (Activision, David Crane) (AG-008) (Prototype)"
-	description "Laser Blast (Lazer) (08-08-1980) (Activision, David Crane) (AG-008) (Prototype)"
-	rom ( name "Laser Blast (Lazer) (08-08-1980) (Activision, David Crane) (AG-008) (Prototype).bin" size 2048 crc 4f2d6eae md5 undefined sha1 ab5a841caaf0d5ab506eebd2b13d62a56f812f98 )
-)
-
-game (
-	name "Laser Blast (Lazer) (1981) (Activision, David Crane) (AG-008) ~"
-	description "Laser Blast (Lazer) (1981) (Activision, David Crane) (AG-008) ~"
-	rom ( name "Laser Blast (Lazer) (1981) (Activision, David Crane) (AG-008) ~.bin" size 2048 crc 99365f26 md5 undefined sha1 ea8ecc2f6818e1c9479f55c0a3356edcf7a4d657 )
-)
-
-game (
-	name "Laser Gate (AKA Innerspace) (1983) (CCE) (C-860)"
-	description "Laser Gate (AKA Innerspace) (1983) (CCE) (C-860)"
-	rom ( name "Laser Gate (AKA Innerspace) (1983) (CCE) (C-860).bin" size 4096 crc 81c413a4 md5 undefined sha1 c768f44235766bdebdb7c2c6b61cfa84b40b04bb )
-)
-
-game (
-	name "Laser Gate (AKA Innerspace) (Future Video Games) (PAL)"
-	description "Laser Gate (AKA Innerspace) (Future Video Games) (PAL)"
-	rom ( name "Laser Gate (AKA Innerspace) (Future Video Games) (PAL).bin" size 4096 crc 834bd825 md5 undefined sha1 56d3d4ab75a646a473da043ae7e3dd13916c8a91 )
-)
-
-game (
-	name "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-1A, 03208) ~"
-	description "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-1A, 03208) ~"
-	rom ( name "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-1A, 03208) ~.bin" size 4096 crc 4b7865af md5 undefined sha1 cdf55b73b4322428a001e545019eaa591d3479cf )
-)
-
-game (
-	name "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-2A, 13208, EIX-007-04I) (PAL)"
-	description "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-2A, 13208, EIX-007-04I) (PAL)"
-	rom ( name "Laser Gates (AKA Innerspace) (1983) (Imagic, Dan Oliver) (720118-2A, 13208, EIX-007-04I) (PAL).bin" size 4096 crc 1785047a md5 undefined sha1 759eccf0cc8134a2ff787ba39087da045ddface1 )
-)
-
-game (
-	name "Laser Volley (AKA Innerspace) (Zellers)"
-	description "Laser Volley (AKA Innerspace) (Zellers)"
-	rom ( name "Laser Volley (AKA Innerspace) (Zellers).bin" size 4096 crc d5840593 md5 undefined sha1 afab795719386a776b5fb2165fc84f4858e16e05 )
-)
-
-game (
-	name "Laser-Loop (AKA Base Attack) (1983) (Dynamics) (PAL)"
-	description "Laser-Loop (AKA Base Attack) (1983) (Dynamics) (PAL)"
-	rom ( name "Laser-Loop (AKA Base Attack) (1983) (Dynamics) (PAL).bin" size 4096 crc 81f1e5dd md5 undefined sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
-)
-
-game (
-	name "Lasercade (1983) (20th Century Fox Video Games - Videa, Lee Actor) (Prototype) ~"
-	description "Lasercade (1983) (20th Century Fox Video Games - Videa, Lee Actor) (Prototype) ~"
-	rom ( name "Lasercade (1983) (20th Century Fox Video Games - Videa, Lee Actor) (Prototype) ~.bin" size 4096 crc ef4ff656 md5 undefined sha1 b6d40f1bdb1e2660254d88ff3089f2afc578cffe )
-)
-
-game (
-	name "Last Starfighter, The (Universe) (Solaris Beta) (1984) (Atari, Douglas 'Solaris' Neubauer) (CX26134) (Prototype)"
-	description "Last Starfighter, The (Universe) (Solaris Beta) (1984) (Atari, Douglas 'Solaris' Neubauer) (CX26134) (Prototype)"
-	rom ( name "Last Starfighter, The (Universe) (Solaris Beta) (1984) (Atari, Douglas 'Solaris' Neubauer) (CX26134) (Prototype).bin" size 16384 crc 7e30ddc0 md5 undefined sha1 1ae05ee1954db2a1a586a5922b210622d8063d12 )
-)
-
-game (
-	name "Lilly Adventure (1983) (Home Vision - Gem International Corp.) (VCS83117) (PAL) ~"
-	description "Lilly Adventure (1983) (Home Vision - Gem International Corp.) (VCS83117) (PAL) ~"
-	rom ( name "Lilly Adventure (1983) (Home Vision - Gem International Corp.) (VCS83117) (PAL) ~.bin" size 4096 crc 3544c6d6 md5 undefined sha1 63f4776aa4c35d124001918b733cdb4d46dfbe9b )
-)
-
-game (
-	name "Lilly Adventure (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Lilly Adventure (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Lilly Adventure (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc c6d30567 md5 undefined sha1 8ff6b530c0208defac18c96a51de95fda7228be8 )
-)
-
-game (
-	name "Lochjaw (1981) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) ~"
-	description "Lochjaw (1981) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) ~"
-	rom ( name "Lochjaw (1981) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) ~.bin" size 4096 crc b2a2ff31 md5 undefined sha1 fe208ad775cbf9523e7a99632b9f10f2c9c7aa87 )
-)
-
-game (
-	name "Lock 'n' Chase (1982) (M Network, Bruce Pedersen - INTV) (MT5663) ~"
-	description "Lock 'n' Chase (1982) (M Network, Bruce Pedersen - INTV) (MT5663) ~"
-	rom ( name "Lock 'n' Chase (1982) (M Network, Bruce Pedersen - INTV) (MT5663) ~.bin" size 4096 crc 7994bf16 md5 undefined sha1 fc3d75d46d917457aa1701bf47844817d0ba96c3 )
-)
-
-game (
-	name "Lock 'n' Chase (1989) (Telegames) (PAL)"
-	description "Lock 'n' Chase (1989) (Telegames) (PAL)"
-	rom ( name "Lock 'n' Chase (1989) (Telegames) (PAL).bin" size 4096 crc eea98b1a md5 undefined sha1 075ec3678ceabbee46a7d576fdd199a4ab908cc0 )
-)
-
-game (
-	name "Lock 'n' Chase (Unknown) (PAL)"
-	description "Lock 'n' Chase (Unknown) (PAL)"
-	rom ( name "Lock 'n' Chase (Unknown) (PAL).bin" size 4096 crc c1c0dc32 md5 undefined sha1 119171935ed9ea877de4f2a68aee31cd55bc697d )
-)
-
-game (
-	name "London Blitz (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, William O. Sheppard) (5002002) ~"
-	description "London Blitz (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, William O. Sheppard) (5002002) ~"
-	rom ( name "London Blitz (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, William O. Sheppard) (5002002) ~.bin" size 4096 crc d23cd66c md5 undefined sha1 f92b0b83db3cd840d16ee2726011f5f0144103d5 )
-)
-
-game (
-	name "Looping (1983) (Coleco, Ed Temple) (2654) (Prototype) ~"
-	description "Looping (1983) (Coleco, Ed Temple) (2654) (Prototype) ~"
-	rom ( name "Looping (1983) (Coleco, Ed Temple) (2654) (Prototype) ~.bin" size 8192 crc f9b23f09 md5 undefined sha1 5e04fa0320167434dab932f6b73183daf1a50ec7 )
-)
-
-game (
-	name "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) [a]"
-	description "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) [a]"
-	rom ( name "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) [a].bin" size 8192 crc e735bb54 md5 undefined sha1 9010530904f78ad10a6164174cb657d1f4717337 )
-)
-
-game (
-	name "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) ~"
-	description "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) ~"
-	rom ( name "Lord of the Rings, The - Journey to Rivendell (The Lord of the Rings I) (1983) (Parker Brothers, Mark Lesser) (PB5950) (Prototype) ~.bin" size 8192 crc 59b96db3 md5 undefined sha1 ef02fdb94ac092247bfcd5f556e01a68c06a4832 )
-)
-
-game (
-	name "Los Angeles 1984 Games (AKA Track and Field) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125) (Prototype) (PAL)"
-	description "Los Angeles 1984 Games (AKA Track and Field) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125) (Prototype) (PAL)"
-	rom ( name "Los Angeles 1984 Games (AKA Track and Field) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125) (Prototype) (PAL).bin" size 16384 crc 73ccb918 md5 undefined sha1 3200610dabfc6bbe3929e179d52b0e9379b04475 )
-)
-
-game (
-	name "Lost Luggage - La valise piegee (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo - RCA Video Jeux) (AP-2004) (PAL)"
-	description "Lost Luggage - La valise piegee (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo - RCA Video Jeux) (AP-2004) (PAL)"
-	rom ( name "Lost Luggage - La valise piegee (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo - RCA Video Jeux) (AP-2004) (PAL).bin" size 4096 crc 6069bdd5 md5 undefined sha1 e83024e007e103b84f83d31233627daf741df609 )
-)
-
-game (
-	name "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) [no opening scene] ~"
-	description "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) [no opening scene] ~"
-	rom ( name "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) [no opening scene] ~.bin" size 4096 crc 7ed4c019 md5 undefined sha1 7f03162fa0a3b08145e17d1de01208314ebf441f )
-)
-
-game (
-	name "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) ~"
-	description "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) ~"
-	rom ( name "Lost Luggage (Airport Mayhem) (1981) (Apollo - Games by Apollo, Larry Minor, Ernie Runyon, Ed Salvo) (AP-2004) ~.bin" size 4096 crc 551bdd37 md5 undefined sha1 e8492fe9d62750df682358fe59a4d4272655eb96 )
-)
-
-game (
-	name "M.A.D. (1983) (Carrere Video - Teldec - Prism Micro Products) (USC1012) (PAL)"
-	description "M.A.D. (1983) (Carrere Video - Teldec - Prism Micro Products) (USC1012) (PAL)"
-	rom ( name "M.A.D. (1983) (Carrere Video - Teldec - Prism Micro Products) (USC1012) (PAL).bin" size 4096 crc a3ef9032 md5 undefined sha1 86df578e913485089d9b3b3e7384076b53a98450 )
-)
-
-game (
-	name "M.A.D. (Missile Intercept) (1982) (U.S. Games Corporation) (VC1012) ~"
-	description "M.A.D. (Missile Intercept) (1982) (U.S. Games Corporation) (VC1012) ~"
-	rom ( name "M.A.D. (Missile Intercept) (1982) (U.S. Games Corporation) (VC1012) ~.bin" size 4096 crc 5cb68fe5 md5 undefined sha1 d6e2b7765a9d30f91c9b2b8d0adf61ec5dc2b30a )
-)
-
-game (
-	name "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11011) ~"
-	description "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11011) ~"
-	rom ( name "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11011) ~.bin" size 4096 crc 13e1c83d md5 undefined sha1 dcd96913a1c840c8b57848986242eeb928bfd2ff )
-)
-
-game (
-	name "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11111) (PAL)"
-	description "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11111) (PAL)"
-	rom ( name "M.A.S.H (1983) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11111) (PAL).bin" size 4096 crc ae6bf13f md5 undefined sha1 5873ae0768dfdcc85c0b031992921ae4badc3ac8 )
-)
-
-game (
-	name "M.A.S.H (208 in 1) (Unknown) (PAL)"
-	description "M.A.S.H (208 in 1) (Unknown) (PAL)"
-	rom ( name "M.A.S.H (208 in 1) (Unknown) (PAL).bin" size 4096 crc ae318b16 md5 undefined sha1 a2ef13317712f56685355b648ca9358efadacb3c )
-)
-
-game (
-	name "M.A.S.H (Hack) (Unknown) (PAL)"
-	description "M.A.S.H (Hack) (Unknown) (PAL)"
-	rom ( name "M.A.S.H (Hack) (Unknown) (PAL).bin" size 4096 crc 1a74e7dd md5 undefined sha1 9894f8cbab6acfdccf2231329f9fbe2a948f92c5 )
-)
-
-game (
-	name "Mafia (AKA Gangster Alley) (Rainbow Vision - Suntek) (SS-010) (PAL)"
-	description "Mafia (AKA Gangster Alley) (Rainbow Vision - Suntek) (SS-010) (PAL)"
-	rom ( name "Mafia (AKA Gangster Alley) (Rainbow Vision - Suntek) (SS-010) (PAL).bin" size 4096 crc ffd8dbe4 md5 undefined sha1 9e8b417a090f8418f63decaacdd4d818a23b4bea )
-)
-
-game (
-	name "MagiCard (Keyboard Controller) (1981) (Computer Magic - CommaVid, John Bronstein) (CM-001) ~"
-	description "MagiCard (Keyboard Controller) (1981) (Computer Magic - CommaVid, John Bronstein) (CM-001) ~"
-	rom ( name "MagiCard (Keyboard Controller) (1981) (Computer Magic - CommaVid, John Bronstein) (CM-001) ~.bin" size 2048 crc 14f126c0 md5 undefined sha1 4c66b84ab0d25e46729bbcf23f985d59ca8520ad )
-)
-
-game (
-	name "Malagai (1983) (Answer Software Corporation - TY Associates) (ASC1001) ~"
-	description "Malagai (1983) (Answer Software Corporation - TY Associates) (ASC1001) ~"
-	rom ( name "Malagai (1983) (Answer Software Corporation - TY Associates) (ASC1001) ~.bin" size 4096 crc 65790ef9 md5 undefined sha1 cdc7e65d965a7a00adda1e8bedfbe6200e349497 )
-)
-
-game (
-	name "Mangia' (1983) (Spectravideo) (SA-212) (PAL)"
-	description "Mangia' (1983) (Spectravideo) (SA-212) (PAL)"
-	rom ( name "Mangia' (1983) (Spectravideo) (SA-212) (PAL).bin" size 4096 crc 4a2982a5 md5 undefined sha1 311bf43a479e9981c70f38573dbf614429d0a5b5 )
-)
-
-game (
-	name "Mangia' (1983) (Spectravideo) (SA-212) ~"
-	description "Mangia' (1983) (Spectravideo) (SA-212) ~"
-	rom ( name "Mangia' (1983) (Spectravideo) (SA-212) ~.bin" size 4096 crc b807b775 md5 undefined sha1 ee8f9bf7cdb55f25f4d99e1a23f4c90106fadc39 )
-)
-
-game (
-	name "Marauder (1982) (Tigervision, Rorke Weigandt - Teldec) (7-005) (PAL)"
-	description "Marauder (1982) (Tigervision, Rorke Weigandt - Teldec) (7-005) (PAL)"
-	rom ( name "Marauder (1982) (Tigervision, Rorke Weigandt - Teldec) (7-005) (PAL).bin" size 4096 crc 5c008825 md5 undefined sha1 df02bb5418722fa5b8c1f112f717652a7f087d8c )
-)
-
-game (
-	name "Marauder (1982) (Tigervision, Rorke Weigandt) (7-005) ~"
-	description "Marauder (1982) (Tigervision, Rorke Weigandt) (7-005) ~"
-	rom ( name "Marauder (1982) (Tigervision, Rorke Weigandt) (7-005) ~.bin" size 4096 crc f8a8b470 md5 undefined sha1 249a11bb4872a24f22dff1027ff256c1408140c2 )
-)
-
-game (
-	name "Marauder (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Marauder (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Marauder (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc a10f7fba md5 undefined sha1 010add7c360052198a4f81b2be96350f4178da2e )
-)
-
-game (
-	name "Mariana (AKA Seaquest) (Rainbow Vision - Suntek) (SS-017) (PAL)"
-	description "Mariana (AKA Seaquest) (Rainbow Vision - Suntek) (SS-017) (PAL)"
-	rom ( name "Mariana (AKA Seaquest) (Rainbow Vision - Suntek) (SS-017) (PAL).bin" size 4096 crc d3c0b098 md5 undefined sha1 fa49ff282ab7c3c7b125d2d2ea7d1da1134e90d9 )
-)
-
-game (
-	name "Marine Wars (1983) (Gakken) (011) (PAL)"
-	description "Marine Wars (1983) (Gakken) (011) (PAL)"
-	rom ( name "Marine Wars (1983) (Gakken) (011) (PAL).bin" size 4096 crc 005183fa md5 undefined sha1 ad733f7bb62ce9275f348a5aea076d9df6107085 )
-)
-
-game (
-	name "Marine Wars (1983) (Konami) (RC 102-X 02) ~"
-	description "Marine Wars (1983) (Konami) (RC 102-X 02) ~"
-	rom ( name "Marine Wars (1983) (Konami) (RC 102-X 02) ~.bin" size 4096 crc 4d281ee3 md5 undefined sha1 dd9e94ca96c75a212f1414aa511fd99ecdadaf44 )
-)
-
-game (
-	name "Marineflieger - River Raid II (AKA Seahawk) (1983) (Quelle) (176.764 9 - 781644) (PAL)"
-	description "Marineflieger - River Raid II (AKA Seahawk) (1983) (Quelle) (176.764 9 - 781644) (PAL)"
-	rom ( name "Marineflieger - River Raid II (AKA Seahawk) (1983) (Quelle) (176.764 9 - 781644) (PAL).bin" size 4096 crc 229512e4 md5 undefined sha1 919fb7d1531aa6b181e96f8648168491be7a2f20 )
-)
-
-game (
-	name "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697, CX2697P) (PAL)"
-	description "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697, CX2697P) (PAL)"
-	rom ( name "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697, CX2697P) (PAL).bin" size 8192 crc 26442d60 md5 undefined sha1 a83f5f9a075ccfee1e7b74c8082ec2ff3d7e1f78 )
-)
-
-game (
-	name "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697) ~"
-	description "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697) ~"
-	rom ( name "Mario Bros. (1983) (Atari, Dan Hitchens) (CX2697) ~.bin" size 8192 crc 8fbf7e90 md5 undefined sha1 49425ff154b92ca048abb4ce5e8d485c24935035 )
-)
-
-game (
-	name "Mario Bros. (Zirok)"
-	description "Mario Bros. (Zirok)"
-	rom ( name "Mario Bros. (Zirok).bin" size 8192 crc 99c20f2d md5 undefined sha1 6282da81472c2c95f8efc1e20e0eebade7be8cc1 )
-)
-
-game (
-	name "Mario's Bros. (AKA Mario Bros.) (1983) (CCE) (C-1004)"
-	description "Mario's Bros. (AKA Mario Bros.) (1983) (CCE) (C-1004)"
-	rom ( name "Mario's Bros. (AKA Mario Bros.) (1983) (CCE) (C-1004).bin" size 8192 crc a88ccfa1 md5 undefined sha1 6ae41e84534dbe0c8cffdbf013d136754f239e9f )
-)
-
-game (
-	name "Marspatrouille (AKA Gas Hog) (1983) (Quelle) (292.542 8) (PAL)"
-	description "Marspatrouille (AKA Gas Hog) (1983) (Quelle) (292.542 8) (PAL)"
-	rom ( name "Marspatrouille (AKA Gas Hog) (1983) (Quelle) (292.542 8) (PAL).bin" size 4096 crc fdaa9d20 md5 undefined sha1 3696575988be6814b6c0eebab2285c471f94a127 )
-)
-
-game (
-	name "MASH (AKA M.A.S.H) (1983) (CCE) (C-859)"
-	description "MASH (AKA M.A.S.H) (1983) (CCE) (C-859)"
-	rom ( name "MASH (AKA M.A.S.H) (1983) (CCE) (C-859).bin" size 4096 crc bf20d0b7 md5 undefined sha1 fbc075766313f04a808236189daa2bf49f584f44 )
-)
-
-game (
-	name "MASH (AKA M.A.S.H) (1983) (CCE) (C-859) [a]"
-	description "MASH (AKA M.A.S.H) (1983) (CCE) (C-859) [a]"
-	rom ( name "MASH (AKA M.A.S.H) (1983) (CCE) (C-859) [a].bin" size 4096 crc 3cfe9e4a md5 undefined sha1 55ae319f11584f997b7b52000a1d98cdfaa07d5d )
-)
-
-game (
-	name "Master Builder - Super Baumeister (1983) (Spectravideo - Quelle) (SA-210 - 413.582 8) (PAL)"
-	description "Master Builder - Super Baumeister (1983) (Spectravideo - Quelle) (SA-210 - 413.582 8) (PAL)"
-	rom ( name "Master Builder - Super Baumeister (1983) (Spectravideo - Quelle) (SA-210 - 413.582 8) (PAL).bin" size 4096 crc c0b86ec7 md5 undefined sha1 a53f4d601c17aa146fdcbdd5d62107eca9821258 )
-)
-
-game (
-	name "Master Builder (1983) (Spectravideo) (SA-210) ~"
-	description "Master Builder (1983) (Spectravideo) (SA-210) ~"
-	rom ( name "Master Builder (1983) (Spectravideo) (SA-210) ~.bin" size 4096 crc dd196d6c md5 undefined sha1 fbe7a78764407743b43a91136903ede65306f4e7 )
-)
-
-game (
-	name "Masters of the Universe - The Power of He-Man (1983) (M Network, Connie Goldman, Joe King, Patricia Lewis Du Long, Gerald Moore, Mike Sanders, Jossef Wagner - INTV) (MT4319) ~"
-	description "Masters of the Universe - The Power of He-Man (1983) (M Network, Connie Goldman, Joe King, Patricia Lewis Du Long, Gerald Moore, Mike Sanders, Jossef Wagner - INTV) (MT4319) ~"
-	rom ( name "Masters of the Universe - The Power of He-Man (1983) (M Network, Connie Goldman, Joe King, Patricia Lewis Du Long, Gerald Moore, Mike Sanders, Jossef Wagner - INTV) (MT4319) ~.bin" size 16384 crc 0603e177 md5 undefined sha1 6db8fa65755db86438ada3d90f4c39cc288dcf84 )
-)
-
-game (
-	name "Math Gran Prix (208 in 1) (Unknown) (PAL)"
-	description "Math Gran Prix (208 in 1) (Unknown) (PAL)"
-	rom ( name "Math Gran Prix (208 in 1) (Unknown) (PAL).bin" size 4096 crc 1db195c8 md5 undefined sha1 3132590354ba0ec6922ef064bbecd41a3323ab58 )
-)
-
-game (
-	name "Math Gran Prix (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Math Gran Prix (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Math Gran Prix (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc a40534d3 md5 undefined sha1 13c4fd4bd1b6205c4ee868d28ee41693a1683f09 )
-)
-
-game (
-	name "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee - Sears) (CX2658 - 49-75128) ~"
-	description "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee - Sears) (CX2658 - 49-75128) ~"
-	rom ( name "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee - Sears) (CX2658 - 49-75128) ~.bin" size 4096 crc ccc90c98 md5 undefined sha1 18fac606400c08a0469aebd9b071ae3aec2a3cf2 )
-)
-
-game (
-	name "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee) (CX2658) (PAL)"
-	description "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee) (CX2658) (PAL)"
-	rom ( name "Math Gran Prix (Math Game) (1982) (Atari, Suki Lee) (CX2658) (PAL).bin" size 4096 crc 4eefe843 md5 undefined sha1 3ac92529e4c146eb15365486778052e6892bab32 )
-)
-
-game (
-	name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer - Sears) (CX2635 - 49-75157) ~"
-	description "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer - Sears) (CX2635 - 49-75157) ~"
-	rom ( name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer - Sears) (CX2635 - 49-75157) ~.bin" size 4096 crc 0098e428 md5 undefined sha1 aba25089d87cd6fee8d206b880baa5d938aae255 )
-)
-
-game (
-	name "Maze Craze - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer) (CX2635, CX2635P) (PAL)"
-	description "Maze Craze - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer) (CX2635, CX2635P) (PAL)"
-	rom ( name "Maze Craze - A Game of Cops 'n Robbers (1980) (Atari, Richard Maurer) (CX2635, CX2635P) (PAL).bin" size 4096 crc 328075b8 md5 undefined sha1 4a255c1d277f9ceb98dfe61ec2c6f7537ca4e7bf )
-)
-
-game (
-	name "Maze Craze (Unknown)"
-	description "Maze Craze (Unknown)"
-	rom ( name "Maze Craze (Unknown).bin" size 4096 crc 1ddccc7d md5 undefined sha1 b7b9e65159af23307da54cf371aac8536c5d227c )
-)
-
-game (
-	name "McDonald's - Golden Arches Adventure (Big Mac) (06-06-1983) (Parker Brothers, Dave Engman, Isabel Garret) (Prototype) ~"
-	description "McDonald's - Golden Arches Adventure (Big Mac) (06-06-1983) (Parker Brothers, Dave Engman, Isabel Garret) (Prototype) ~"
-	rom ( name "McDonald's - Golden Arches Adventure (Big Mac) (06-06-1983) (Parker Brothers, Dave Engman, Isabel Garret) (Prototype) ~.bin" size 4096 crc add0115d md5 undefined sha1 0103b35b1aef6b10c1c0a44b213ebf30af708df6 )
-)
-
-game (
-	name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11005) ~"
-	description "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11005) ~"
-	rom ( name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11005) ~.bin" size 4096 crc 9e6ae8c2 md5 undefined sha1 0ae118373c7bda97da2f8d9c113e1e09ea7e49e1 )
-)
-
-game (
-	name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL)"
-	description "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL)"
-	rom ( name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL).bin" size 4096 crc 42a22f23 md5 undefined sha1 da60cc4597681bf955eed5d03f7323ad3fa5c525 )
-)
-
-game (
-	name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL) [a]"
-	description "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL) [a]"
-	rom ( name "Mega Force (1982) (20th Century Fox Video Games, Douglas 'Dallas North' Neubauer) (11105) (PAL) [a].bin" size 4096 crc f82ee4cb md5 undefined sha1 542d45c4b4873e58b4da63fa2fa9dfc389aa4bf6 )
-)
-
-game (
-	name "Mega Funpak - Gorf, P. Patrol, Pacman, Skeet Shoot (HES) (PAL)"
-	description "Mega Funpak - Gorf, P. Patrol, Pacman, Skeet Shoot (HES) (PAL)"
-	rom ( name "Mega Funpak - Gorf, P. Patrol, Pacman, Skeet Shoot (HES) (PAL).bin" size 16384 crc b35af763 md5 undefined sha1 864f5c82f055c3d21c3f10b6ee892493b36b835a )
-)
-
-game (
-	name "MegaBoy (Dynacom) ~"
-	description "MegaBoy (Dynacom) ~"
-	rom ( name "MegaBoy (Dynacom) ~.bin" size 65536 crc 26914ce0 md5 undefined sha1 46977baf0e1ee6124b524258879c46f80d624fae )
-)
-
-game (
-	name "MegaMania - A Space Nightmare - Ein Alptraum im Weltall (1982) (Activision, Steve Cartwright - Ariola) (EAX-017, EAX-017-04I - 711 017-720) (PAL)"
-	description "MegaMania - A Space Nightmare - Ein Alptraum im Weltall (1982) (Activision, Steve Cartwright - Ariola) (EAX-017, EAX-017-04I - 711 017-720) (PAL)"
-	rom ( name "MegaMania - A Space Nightmare - Ein Alptraum im Weltall (1982) (Activision, Steve Cartwright - Ariola) (EAX-017, EAX-017-04I - 711 017-720) (PAL).bin" size 4096 crc 797e148e md5 undefined sha1 756396b5d89831909d3d55cba143f5d1a101e366 )
-)
-
-game (
-	name "MegaMania - A Space Nightmare (1982) (Activision, Steve Cartwright) (AX-017, AX-017-04) ~"
-	description "MegaMania - A Space Nightmare (1982) (Activision, Steve Cartwright) (AX-017, AX-017-04) ~"
-	rom ( name "MegaMania - A Space Nightmare (1982) (Activision, Steve Cartwright) (AX-017, AX-017-04) ~.bin" size 4096 crc 33edc33e md5 undefined sha1 9c5748b38661dbadcbc9cd1ec6a6b0c550b0e3da )
-)
-
-game (
-	name "Megamania (1982) (Dynacom)"
-	description "Megamania (1982) (Dynacom)"
-	rom ( name "Megamania (1982) (Dynacom).bin" size 4096 crc 7e879511 md5 undefined sha1 d0bf768b5e9434d9aefadd43db42b75a28c3363f )
-)
-
-game (
-	name "Megamania (1983) (CCE) (C-829)"
-	description "Megamania (1983) (CCE) (C-829)"
-	rom ( name "Megamania (1983) (CCE) (C-829).bin" size 4096 crc 56bd0b16 md5 undefined sha1 987e245e83ecd455196750f55873d80e75fe3941 )
-)
-
-game (
-	name "Megamania (1983) (Digitel)"
-	description "Megamania (1983) (Digitel)"
-	rom ( name "Megamania (1983) (Digitel).bin" size 4096 crc 436e6ec9 md5 undefined sha1 029fac354ceb2d3a8d8cc4d400b377c0cb0eddea )
-)
-
-game (
-	name "MegaMania (208 in 1) (Unknown) (PAL)"
-	description "MegaMania (208 in 1) (Unknown) (PAL)"
-	rom ( name "MegaMania (208 in 1) (Unknown) (PAL).bin" size 4096 crc d2642b73 md5 undefined sha1 e2313c328ef85b455666e061bd474a207852e786 )
-)
-
-game (
-	name "MegaMania (Unknown) (PAL)"
-	description "MegaMania (Unknown) (PAL)"
-	rom ( name "MegaMania (Unknown) (PAL).bin" size 4096 crc 89b8a859 md5 undefined sha1 2b6a826064295220502e1cee1df8c32bf1cd7189 )
-)
-
-game (
-	name "Mein Weg - My Way (AKA Challenge) (1983) (Quelle) (686.561 2 - 781627) (PAL)"
-	description "Mein Weg - My Way (AKA Challenge) (1983) (Quelle) (686.561 2 - 781627) (PAL)"
-	rom ( name "Mein Weg - My Way (AKA Challenge) (1983) (Quelle) (686.561 2 - 781627) (PAL).bin" size 4096 crc 420ff853 md5 undefined sha1 683fa09578bcdd129500c51fdc5dd059ff2f7c68 )
-)
-
-game (
-	name "Meltdown (Atom Smasher) (1983) (20th Century Fox Video Games - Videa, David Ross) (11029) (Prototype) ~"
-	description "Meltdown (Atom Smasher) (1983) (20th Century Fox Video Games - Videa, David Ross) (11029) (Prototype) ~"
-	rom ( name "Meltdown (Atom Smasher) (1983) (20th Century Fox Video Games - Videa, David Ross) (11029) (Prototype) ~.bin" size 4096 crc 7955b3be md5 undefined sha1 debb1572eadb20beb0e4cd2df8396def8eb02098 )
-)
-
-game (
-	name "Meteor Defense (AKA Astrowar) (1983) (ITT Family Games) (554-33 391) (PAL)"
-	description "Meteor Defense (AKA Astrowar) (1983) (ITT Family Games) (554-33 391) (PAL)"
-	rom ( name "Meteor Defense (AKA Astrowar) (1983) (ITT Family Games) (554-33 391) (PAL).bin" size 4096 crc bb47d5af md5 undefined sha1 5cc122f10eb1a814d047404b462b325f51f35d2c )
-)
-
-game (
-	name "Meteoroids (Suicide Mission Beta) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype)"
-	description "Meteoroids (Suicide Mission Beta) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype)"
-	rom ( name "Meteoroids (Suicide Mission Beta) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype).bin" size 8448 crc 40d6bbb2 md5 undefined sha1 11c3bd2b9327987e83b34e65e1bbee5fd62e6f60 )
-)
-
-game (
-	name "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) (PAL)"
-	description "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) (PAL)"
-	rom ( name "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) (PAL).bin" size 16384 crc 6cf038fa md5 undefined sha1 dfdcbba166396faeab1ffc40f167189498dfc113 )
-)
-
-game (
-	name "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) ~"
-	description "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) ~"
-	rom ( name "Midnight Magic (Pinball Wizard) (1984) (Atari, Glenn Axworthy) (CX26129) ~.bin" size 16384 crc 5c5447b9 md5 undefined sha1 7fcf95459ea597a332bf5b6f56c8f891307b45b4 )
-)
-
-game (
-	name "Mighty Mouse (AKA Gopher) (Funvision - Fund. International Co.)"
-	description "Mighty Mouse (AKA Gopher) (Funvision - Fund. International Co.)"
-	rom ( name "Mighty Mouse (AKA Gopher) (Funvision - Fund. International Co.).bin" size 4096 crc 9aee6020 md5 undefined sha1 a19e8b53a09eb05b073fa759ff0258a60da7144d )
-)
-
-game (
-	name "Millipede (01-04-1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype)"
-	description "Millipede (01-04-1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype)"
-	rom ( name "Millipede (01-04-1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype).bin" size 16384 crc 82d88744 md5 undefined sha1 6be6c8c8193e43e9fd0fd37e5344848d5a42bb4f )
-)
-
-game (
-	name "Millipede (1984) (Atari - GCC) (CX26118) (Prototype) (PAL)"
-	description "Millipede (1984) (Atari - GCC) (CX26118) (Prototype) (PAL)"
-	rom ( name "Millipede (1984) (Atari - GCC) (CX26118) (Prototype) (PAL).bin" size 16384 crc dcb13020 md5 undefined sha1 06092998a30e816a97fe9e4d3f27085b913ec9f9 )
-)
-
-game (
-	name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118, CX26118P) (PAL)"
-	description "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118, CX26118P) (PAL)"
-	rom ( name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118, CX26118P) (PAL).bin" size 16384 crc eea33418 md5 undefined sha1 7ba2e2c0b3b66a50692f4dece817368527e29180 )
-)
-
-game (
-	name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype)"
-	description "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype)"
-	rom ( name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) (Prototype).bin" size 16384 crc 41332631 md5 undefined sha1 42e97d1ba19781187e605430fd70049f0450ef75 )
-)
-
-game (
-	name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) ~"
-	description "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) ~"
-	rom ( name "Millipede (1984) (Atari, Jerome Domurat, Andrew Fuchs, Dave Staugas, Robert Vieira) (CX26118) ~.bin" size 16384 crc ccc82dd0 md5 undefined sha1 0616f0dde6d697816dda92ed9e5a4c3d77a39408 )
-)
-
-game (
-	name "Mind Maze (Mind Race) (Mindlink Controller) (10-10-1984) (Atari, Gary Shannon, Howard Scott Warshaw) (Prototype) ~"
-	description "Mind Maze (Mind Race) (Mindlink Controller) (10-10-1984) (Atari, Gary Shannon, Howard Scott Warshaw) (Prototype) ~"
-	rom ( name "Mind Maze (Mind Race) (Mindlink Controller) (10-10-1984) (Atari, Gary Shannon, Howard Scott Warshaw) (Prototype) ~.bin" size 8192 crc 7cc6c991 md5 undefined sha1 3844b79dbec5ffc99eaa2c9f5fa4f0a26c08c06d )
-)
-
-game (
-	name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision - Teldec) (7-008 - 3.60006 VG) (PAL)"
-	description "Miner 2049er - Starring Bounty Bob (1982) (Tigervision - Teldec) (7-008 - 3.60006 VG) (PAL)"
-	rom ( name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision - Teldec) (7-008 - 3.60006 VG) (PAL).bin" size 8192 crc f9851d21 md5 undefined sha1 c44b2f87695440828d6844ae630d3f975b582385 )
-)
-
-game (
-	name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) (Prototype)"
-	description "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) (Prototype)"
-	rom ( name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) (Prototype).bin" size 8192 crc 67d2837b md5 undefined sha1 78606c2f3dd418e903a0760746d11714e74a55a6 )
-)
-
-game (
-	name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) [fixed] ~"
-	description "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) [fixed] ~"
-	rom ( name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) [fixed] ~.bin" size 8192 crc 19f9ef1c md5 undefined sha1 5470afe5961f9fdd2f6388f53f682f3264a95ce9 )
-)
-
-game (
-	name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) ~"
-	description "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) ~"
-	rom ( name "Miner 2049er - Starring Bounty Bob (1982) (Tigervision) (7-008) ~.bin" size 8192 crc bd08d915 md5 undefined sha1 0e56b48e88f69d405eabf544e57663bd180b3b1e )
-)
-
-game (
-	name "Miner 2049er Volume II (1983) (Tigervision - Teldec) (7-011 - 3.60015 VG) (PAL)"
-	description "Miner 2049er Volume II (1983) (Tigervision - Teldec) (7-011 - 3.60015 VG) (PAL)"
-	rom ( name "Miner 2049er Volume II (1983) (Tigervision - Teldec) (7-011 - 3.60015 VG) (PAL).bin" size 8192 crc bfa477cd md5 undefined sha1 5edbf8a24fcba9763983befe20e2311f61b986d4 )
-)
-
-game (
-	name "Miner 2049er Volume II (1983) (Tigervision) (7-011) ~"
-	description "Miner 2049er Volume II (1983) (Tigervision) (7-011) ~"
-	rom ( name "Miner 2049er Volume II (1983) (Tigervision) (7-011) ~.bin" size 8192 crc 71e814e9 md5 undefined sha1 575faad92cb38944b9882ffb69073e0af9460aba )
-)
-
-game (
-	name "Mines of Minos - Im Labyrinth des Roboters (1982) (CommaVid, Irwin Gaines - Ariola) (CM-005 - 712 005-720) (PAL)"
-	description "Mines of Minos - Im Labyrinth des Roboters (1982) (CommaVid, Irwin Gaines - Ariola) (CM-005 - 712 005-720) (PAL)"
-	rom ( name "Mines of Minos - Im Labyrinth des Roboters (1982) (CommaVid, Irwin Gaines - Ariola) (CM-005 - 712 005-720) (PAL).bin" size 4096 crc b8a0c9b3 md5 undefined sha1 7d71ca3e9d3a81fb50d76f9983a1c0f61335e211 )
-)
-
-game (
-	name "Mines of Minos (1982) (CommaVid, Irwin Gaines) (CM-005) ~"
-	description "Mines of Minos (1982) (CommaVid, Irwin Gaines) (CM-005) ~"
-	rom ( name "Mines of Minos (1982) (CommaVid, Irwin Gaines) (CM-005) ~.bin" size 4096 crc c799e944 md5 undefined sha1 34773998d7740e1e8c206b3b22a19e282ca132e1 )
-)
-
-game (
-	name "Mines of Minos (Unknown) (PAL)"
-	description "Mines of Minos (Unknown) (PAL)"
-	rom ( name "Mines of Minos (Unknown) (PAL).bin" size 4096 crc d591299b md5 undefined sha1 24b9463d3e8da102a4156ac7e28d9a5afa453395 )
-)
-
-game (
-	name "Miniature Golf - Arcade Golf (1979) (Atari - Sears) (CX2626 - 6-99829, 49-75116) ~"
-	description "Miniature Golf - Arcade Golf (1979) (Atari - Sears) (CX2626 - 6-99829, 49-75116) ~"
-	rom ( name "Miniature Golf - Arcade Golf (1979) (Atari - Sears) (CX2626 - 6-99829, 49-75116) ~.bin" size 2048 crc 28562315 md5 undefined sha1 be24b42e3744a81fb217c86c4ed5ce51bff28e65 )
-)
-
-game (
-	name "Miniature Golf (1979) (Atari) (CX2626, CX2626P) (PAL)"
-	description "Miniature Golf (1979) (Atari) (CX2626, CX2626P) (PAL)"
-	rom ( name "Miniature Golf (1979) (Atari) (CX2626, CX2626P) (PAL).bin" size 2048 crc 9c18c7b6 md5 undefined sha1 9feebc2f41d0013e387275be2d5d525dd81ed8df )
-)
-
-game (
-	name "Miniaturer Golf (AKA Miniature Golf) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Miniaturer Golf (AKA Miniature Golf) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Miniaturer Golf (AKA Miniature Golf) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc fcc7a662 md5 undefined sha1 277396e0d4fe82512d994c77e539bf06310bd8f1 )
-)
-
-game (
-	name "Miss Pack Man (AKA Ms. Pac-Man) (Video Game Program) (PAL)"
-	description "Miss Pack Man (AKA Ms. Pac-Man) (Video Game Program) (PAL)"
-	rom ( name "Miss Pack Man (AKA Ms. Pac-Man) (Video Game Program) (PAL).bin" size 8192 crc b649c1dc md5 undefined sha1 1e9443c7e6517f649b47e0081aaa635e271e0aef )
-)
-
-game (
-	name "Miss Piggy's Wedding (06-24-1983) (Atari, Suki Lee) (CX26113) (Prototype) (8K) ~"
-	description "Miss Piggy's Wedding (06-24-1983) (Atari, Suki Lee) (CX26113) (Prototype) (8K) ~"
-	rom ( name "Miss Piggy's Wedding (06-24-1983) (Atari, Suki Lee) (CX26113) (Prototype) (8K) ~.bin" size 8192 crc b1497e10 md5 undefined sha1 f721d1f750e19b9e1788eed5e3872923ab46a91d )
-)
-
-game (
-	name "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype)"
-	description "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype)"
-	rom ( name "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype).bin" size 4096 crc 4b0b2db6 md5 undefined sha1 60da8b019f985a5aea64f50691a52424a6755586 )
-)
-
-game (
-	name "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype) [a]"
-	description "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype) [a]"
-	rom ( name "Miss Piggy's Wedding (1983) (Atari, Suki Lee) (CX26113) (Prototype) [a].bin" size 4096 crc 20936741 md5 undefined sha1 c6475034ad40189fbc868aab39ddc95ae62eaeaa )
-)
-
-game (
-	name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) (Prototype)"
-	description "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) (Prototype)"
-	rom ( name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) (Prototype).bin" size 4096 crc c7c0b5c6 md5 undefined sha1 405a67638f1fe80b2334fee1d3dfe8906586dc1a )
-)
-
-game (
-	name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) [no initials] ~"
-	description "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) [no initials] ~"
-	rom ( name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) [no initials] ~.bin" size 4096 crc db910d47 md5 undefined sha1 81ffac1f1051a4c99e82e53ae604f0b8ec95ad8e )
-)
-
-game (
-	name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) ~"
-	description "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) ~"
-	rom ( name "Missile Command (1981) (Atari, Rob Fulop - Sears) (CX2638 - 49-75166) ~.bin" size 4096 crc cff14904 md5 undefined sha1 faa06bb0643dbf556b13591c31917d277a83110b )
-)
-
-game (
-	name "Missile Command (1981) (Atari, Rob Fulop) (CX2638) (PAL)"
-	description "Missile Command (1981) (Atari, Rob Fulop) (CX2638) (PAL)"
-	rom ( name "Missile Command (1981) (Atari, Rob Fulop) (CX2638) (PAL).bin" size 4096 crc dbdfefb7 md5 undefined sha1 56e0637c29b9cfcbd9e7b025193a80ddaeb7e0b6 )
-)
-
-game (
-	name "Missile Command (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Missile Command (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Missile Command (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc be2708ff md5 undefined sha1 8498caaa85d2fb85cff4ad6591b34d9ccc0f7f41 )
-)
-
-game (
-	name "Missile Command (Unknown) (PAL)"
-	description "Missile Command (Unknown) (PAL)"
-	rom ( name "Missile Command (Unknown) (PAL).bin" size 4096 crc b9155596 md5 undefined sha1 91688716d32dbcd7c6b2c224bd56a3443f535cf5 )
-)
-
-game (
-	name "Missile Control (1983) (Video Gems) (VG-01) (PAL) ~"
-	description "Missile Control (1983) (Video Gems) (VG-01) (PAL) ~"
-	rom ( name "Missile Control (1983) (Video Gems) (VG-01) (PAL) ~.bin" size 4096 crc ac80976b md5 undefined sha1 224e7a310afdb91c6915743e72b7b53b38eb5754 )
-)
-
-game (
-	name "Missile War (AKA Astrowar) (1983) (Goliath - Hot Shot) (83-312) (PAL)"
-	description "Missile War (AKA Astrowar) (1983) (Goliath - Hot Shot) (83-312) (PAL)"
-	rom ( name "Missile War (AKA Astrowar) (1983) (Goliath - Hot Shot) (83-312) (PAL).bin" size 4096 crc e83f5848 md5 undefined sha1 eca0764f26168424633b620a9ff9b274b236135f )
-)
-
-game (
-	name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207)"
-	description "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207)"
-	rom ( name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207).bin" size 4096 crc b959a92f md5 undefined sha1 652bb092e9ba2958e242b1440acdd6c08a884ec5 )
-)
-
-game (
-	name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) [demonstration cartridge]"
-	description "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) [demonstration cartridge]"
-	rom ( name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) [demonstration cartridge].bin" size 4096 crc a567da14 md5 undefined sha1 dafa65780ebb5bc63e48a6cfd0f78ea3b11a7a1b )
-)
-
-game (
-	name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) ~"
-	description "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) ~"
-	rom ( name "Mission 3,000 A.D. - Mission 3000 (1983) (Bit Corporation) (PG207) (PAL) ~.bin" size 4096 crc 55b140fe md5 undefined sha1 999dc390a7a3f7be7c88022506c70bd4208b26d8 )
-)
-
-game (
-	name "Mission 3,000 A.D. (208 in 1) (Unknown) (PAL)"
-	description "Mission 3,000 A.D. (208 in 1) (Unknown) (PAL)"
-	rom ( name "Mission 3,000 A.D. (208 in 1) (Unknown) (PAL).bin" size 4096 crc 781b13bc md5 undefined sha1 d897b90ae92d338664e02c6ca70ff60d5921b9a0 )
-)
-
-game (
-	name "Mission 3,000 A.D. (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Mission 3,000 A.D. (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Mission 3,000 A.D. (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc b959a92f md5 undefined sha1 652bb092e9ba2958e242b1440acdd6c08a884ec5 )
-)
-
-game (
-	name "Mission 3000 A.D. - Missao 3000 A.D. (AKA Mission 3,000 AD) (1983) (CCE) (C-806)"
-	description "Mission 3000 A.D. - Missao 3000 A.D. (AKA Mission 3,000 AD) (1983) (CCE) (C-806)"
-	rom ( name "Mission 3000 A.D. - Missao 3000 A.D. (AKA Mission 3,000 AD) (1983) (CCE) (C-806).bin" size 4096 crc b959a92f md5 undefined sha1 652bb092e9ba2958e242b1440acdd6c08a884ec5 )
-)
-
-game (
-	name "Mission Survive (1983) (Video Gems) (VG-04) (PAL) [a]"
-	description "Mission Survive (1983) (Video Gems) (VG-04) (PAL) [a]"
-	rom ( name "Mission Survive (1983) (Video Gems) (VG-04) (PAL) [a].bin" size 4096 crc 4a37b4a7 md5 undefined sha1 209b54546bf9bfab0daf3aaad46d8a53167a5d0c )
-)
-
-game (
-	name "Mission Survive (1983) (Video Gems) (VG-04) (PAL) ~"
-	description "Mission Survive (1983) (Video Gems) (VG-04) (PAL) ~"
-	rom ( name "Mission Survive (1983) (Video Gems) (VG-04) (PAL) ~.bin" size 4096 crc b70f52dc md5 undefined sha1 93520821ce406a7aa6cc30472f76bca543805fd4 )
-)
-
-game (
-	name "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839)"
-	description "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839)"
-	rom ( name "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839).bin" size 4096 crc def78b09 md5 undefined sha1 21366d1608c008a8fb7e8859caf3a35a61176702 )
-)
-
-game (
-	name "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839) [a]"
-	description "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839) [a]"
-	rom ( name "Misterious Thief, A (AKA A Mysterious Thief) (1983) (CCE) (C-839) [a].bin" size 4096 crc 33a176e8 md5 undefined sha1 b21d17ae131e93aa8ca3fd4e4caf9f6d5ac2f86e )
-)
-
-game (
-	name "Mogul Maniac (Joyboard) (1983) (Amiga) (3120) ~"
-	description "Mogul Maniac (Joyboard) (1983) (Amiga) (3120) ~"
-	rom ( name "Mogul Maniac (Joyboard) (1983) (Amiga) (3120) ~.bin" size 4096 crc 50afe04b md5 undefined sha1 0b74a90a22a7a16f9c2131fabd76b7742de0473e )
-)
-
-game (
-	name "Mole Hunter (AKA Topy) (Suntek) (SS-023) (PAL)"
-	description "Mole Hunter (AKA Topy) (Suntek) (SS-023) (PAL)"
-	rom ( name "Mole Hunter (AKA Topy) (Suntek) (SS-023) (PAL).bin" size 4096 crc 0f45ee38 md5 undefined sha1 4dc2a1a78b1c237c4a7b9319494ad4d16383b1e4 )
-)
-
-game (
-	name "Monster aus dem All (AKA Sky Alien) (1983) (Video Game - Ariola) (SP-206) (PAL)"
-	description "Monster aus dem All (AKA Sky Alien) (1983) (Video Game - Ariola) (SP-206) (PAL)"
-	rom ( name "Monster aus dem All (AKA Sky Alien) (1983) (Video Game - Ariola) (SP-206) (PAL).bin" size 4096 crc a23eaac5 md5 undefined sha1 12acae81097b752d2446c9456996bdccc3d625d5 )
-)
-
-game (
-	name "Monster Cise (Kid's Controller) (1984) (Atari) (CX26131) (Prototype) ~"
-	description "Monster Cise (Kid's Controller) (1984) (Atari) (CX26131) (Prototype) ~"
-	rom ( name "Monster Cise (Kid's Controller) (1984) (Atari) (CX26131) (Prototype) ~.bin" size 8192 crc ab0f6091 md5 undefined sha1 81a4d56820b1e00130e368a3532c409929aff5fb )
-)
-
-game (
-	name "Montezuma's Revenge - Featuring Panama Joe (1984) (Parker Brothers, Robert Jaeger) (PB5760) ~"
-	description "Montezuma's Revenge - Featuring Panama Joe (1984) (Parker Brothers, Robert Jaeger) (PB5760) ~"
-	rom ( name "Montezuma's Revenge - Featuring Panama Joe (1984) (Parker Brothers, Robert Jaeger) (PB5760) ~.bin" size 8192 crc e680a1c9 md5 undefined sha1 7dfeb1a8ec863c1e0f297113a1cc4185c215e81c )
-)
-
-game (
-	name "Moon Patrol (05-16-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	description "Moon Patrol (05-16-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	rom ( name "Moon Patrol (05-16-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype).bin" size 8192 crc 28467ee2 md5 undefined sha1 e082923c89418ce7c49a770369a73a39d2bb1583 )
-)
-
-game (
-	name "Moon Patrol (06-15-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	description "Moon Patrol (06-15-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	rom ( name "Moon Patrol (06-15-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype).bin" size 8192 crc 85361ff8 md5 undefined sha1 1499f3b78756e0728b9cf66df147d4263a8b61fa )
-)
-
-game (
-	name "Moon Patrol (07-04-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	description "Moon Patrol (07-04-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	rom ( name "Moon Patrol (07-04-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype).bin" size 8192 crc 4b2ad69d md5 undefined sha1 57e1f0989f8a045267b4d1cb9e599b2c155611cd )
-)
-
-game (
-	name "Moon Patrol (07-26-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	description "Moon Patrol (07-26-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	rom ( name "Moon Patrol (07-26-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype).bin" size 8192 crc f6536071 md5 undefined sha1 2286929461dc07bbdc709245011663ba65db9f14 )
-)
-
-game (
-	name "Moon Patrol (07-31-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	description "Moon Patrol (07-31-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype)"
-	rom ( name "Moon Patrol (07-31-1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) (Prototype).bin" size 8192 crc c9d631a0 md5 undefined sha1 7c0b22e8dc7a0b85ff6e67b7493684dc652d0e27 )
-)
-
-game (
-	name "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692, CX2692P) (PAL)"
-	description "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692, CX2692P) (PAL)"
-	rom ( name "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692, CX2692P) (PAL).bin" size 8192 crc 373c3a82 md5 undefined sha1 723ef7da21660fe75d14d0f84eba5901aadbc4c2 )
-)
-
-game (
-	name "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) ~"
-	description "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) ~"
-	rom ( name "Moon Patrol (1983) (Atari - GCC, Mark Ackerman, Noellie Alito) (CX2692) ~.bin" size 8192 crc d641ef2d md5 undefined sha1 dce778f397a325113f035722b7769492645d69eb )
-)
-
-game (
-	name "Moon Patrol (1983) (CCE) (C-1006)"
-	description "Moon Patrol (1983) (CCE) (C-1006)"
-	rom ( name "Moon Patrol (1983) (CCE) (C-1006).bin" size 8192 crc 82600233 md5 undefined sha1 ab799fcf48946d41f071fc7e2ed2512ef23b07be )
-)
-
-game (
-	name "Moon Patrol (Canal 3 - Intellivision) (C 3004)"
-	description "Moon Patrol (Canal 3 - Intellivision) (C 3004)"
-	rom ( name "Moon Patrol (Canal 3 - Intellivision) (C 3004).bin" size 8192 crc 2fbab601 md5 undefined sha1 cc6054ffef91ab98fbef24b450a4470b598ec17e )
-)
-
-game (
-	name "Moon Patrol (Tron)"
-	description "Moon Patrol (Tron)"
-	rom ( name "Moon Patrol (Tron).bin" size 8192 crc 5f774d1d md5 undefined sha1 7c14ae45ed08c59af7c1c3ee4629d4ed02f6a187 )
-)
-
-game (
-	name "Moonsweeper (1983) (Imagic, Bob Smith) (720114-1A, 03207, IZ-001-04) ~"
-	description "Moonsweeper (1983) (Imagic, Bob Smith) (720114-1A, 03207, IZ-001-04) ~"
-	rom ( name "Moonsweeper (1983) (Imagic, Bob Smith) (720114-1A, 03207, IZ-001-04) ~.bin" size 8192 crc 450b5c57 md5 undefined sha1 05ab04dc30eae31b98ebf6f43fec6793a53e0a23 )
-)
-
-game (
-	name "Moonsweeper (1983) (Imagic, Bob Smith) (720114-2A, 13207, EIZ-001-04I) (PAL)"
-	description "Moonsweeper (1983) (Imagic, Bob Smith) (720114-2A, 13207, EIZ-001-04I) (PAL)"
-	rom ( name "Moonsweeper (1983) (Imagic, Bob Smith) (720114-2A, 13207, EIZ-001-04I) (PAL).bin" size 8192 crc b72fc86a md5 undefined sha1 173d7427d6ab024cc9ef75a0281a85fd4ee013dd )
-)
-
-game (
-	name "Moonsweeper (1988) (Activision) (AIZ-001)"
-	description "Moonsweeper (1988) (Activision) (AIZ-001)"
-	rom ( name "Moonsweeper (1988) (Activision) (AIZ-001).bin" size 8192 crc bb513282 md5 undefined sha1 2bb48d52aa43b10cdd29a1ceb2bd0c83aefbf96a )
-)
-
-game (
-	name "Morse Code Tutor (1979) (Atari, Brad Stewart)"
-	description "Morse Code Tutor (1979) (Atari, Brad Stewart)"
-	rom ( name "Morse Code Tutor (1979) (Atari, Brad Stewart).bin" size 2048 crc 022cbe5f md5 undefined sha1 585b9f35298b0dfb45525ea2e60c137eb378d4c3 )
-)
-
-game (
-	name "Moto Laser (AKA Mega Force) (Star Game) (043)"
-	description "Moto Laser (AKA Mega Force) (Star Game) (043)"
-	rom ( name "Moto Laser (AKA Mega Force) (Star Game) (043).bin" size 4096 crc c71bc0d3 md5 undefined sha1 c5df27376689b4a605069568218e61c0379532fc )
-)
-
-game (
-	name "Motocross - Motorcross - Motocross (1983) (Quelle) (719.383 2 - 649635, 781393, 781784, 986404) (PAL)"
-	description "Motocross - Motorcross - Motocross (1983) (Quelle) (719.383 2 - 649635, 781393, 781784, 986404) (PAL)"
-	rom ( name "Motocross - Motorcross - Motocross (1983) (Quelle) (719.383 2 - 649635, 781393, 781784, 986404) (PAL).bin" size 4096 crc 36feb44c md5 undefined sha1 bcafaa60338cf55ac72a940d04a5ad72003f7cf0 )
-)
-
-game (
-	name "Motocross (AKA Motocross Racer) (Joystik)"
-	description "Motocross (AKA Motocross Racer) (Joystik)"
-	rom ( name "Motocross (AKA Motocross Racer) (Joystik).bin" size 8192 crc 1bd58e61 md5 undefined sha1 d8a1eb094851ff067e0775fd39da5c0b790d8273 )
-)
-
-game (
-	name "Motocross (Suntek) (SS-022) (PAL)"
-	description "Motocross (Suntek) (SS-022) (PAL)"
-	rom ( name "Motocross (Suntek) (SS-022) (PAL).bin" size 4096 crc b0ae97ec md5 undefined sha1 0ec67ffe60ed91c682e0149a9e68e3a27e12de2d )
-)
-
-game (
-	name "Motocross Racer (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99008, 6240) ~"
-	description "Motocross Racer (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99008, 6240) ~"
-	rom ( name "Motocross Racer (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99008, 6240) ~.bin" size 8192 crc 0d1bc1cb md5 undefined sha1 c4d495d42ea5bd354af04e1f2b68cce0fb43175d )
-)
-
-game (
-	name "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) (PAL)"
-	description "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) (PAL)"
-	rom ( name "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) (PAL).bin" size 16384 crc 9260f839 md5 undefined sha1 ece97bda734faffcf847a8bcdfa474789c377d8d )
-)
-
-game (
-	name "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) ~"
-	description "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) ~"
-	rom ( name "MotoRodeo (Motor Olympics, Motor Rodeo) (1990) (Atari - Axlon, Steve DeFrisco) (CX26171) ~.bin" size 16384 crc 89998e29 md5 undefined sha1 dea1506ba107b9544cd9b179f83bc61ced9101ac )
-)
-
-game (
-	name "Mountain King (1983) (CBS Electronics, E.F. Dreyer, Ed Salvo) (4L 2738 0000) ~"
-	description "Mountain King (1983) (CBS Electronics, E.F. Dreyer, Ed Salvo) (4L 2738 0000) ~"
-	rom ( name "Mountain King (1983) (CBS Electronics, E.F. Dreyer, Ed Salvo) (4L 2738 0000) ~.bin" size 12288 crc ed778991 md5 undefined sha1 0a84b0a6bd0e79f5fa0b1bb9112160cb564ab836 )
-)
-
-game (
-	name "Mountain Man (AKA Ski Hunt) (1983) (ITT Family Games) (554-37 737) (PAL)"
-	description "Mountain Man (AKA Ski Hunt) (1983) (ITT Family Games) (554-37 737) (PAL)"
-	rom ( name "Mountain Man (AKA Ski Hunt) (1983) (ITT Family Games) (554-37 737) (PAL).bin" size 4096 crc 5f6c51c5 md5 undefined sha1 07d954ebe8a639249b2185d2b45bc9216cae14e6 )
-)
-
-game (
-	name "Mouse Trap (1982) (CBS Electronics, Sylvia Day, Henry Will IV) (4L1818, 4L1819, 4L1820, 4L1821) (PAL)"
-	description "Mouse Trap (1982) (CBS Electronics, Sylvia Day, Henry Will IV) (4L1818, 4L1819, 4L1820, 4L1821) (PAL)"
-	rom ( name "Mouse Trap (1982) (CBS Electronics, Sylvia Day, Henry Will IV) (4L1818, 4L1819, 4L1820, 4L1821) (PAL).bin" size 4096 crc 18b3c907 md5 undefined sha1 48b5cbfd0016961711777036148fa7d1b038fd18 )
-)
-
-game (
-	name "Mouse Trap (1982) (Coleco, Sylvia Day, Henry Will IV) (2459) ~"
-	description "Mouse Trap (1982) (Coleco, Sylvia Day, Henry Will IV) (2459) ~"
-	rom ( name "Mouse Trap (1982) (Coleco, Sylvia Day, Henry Will IV) (2459) ~.bin" size 4096 crc 9ddd45d3 md5 undefined sha1 cf6347dedcfec213c28dd92111ec6f41e74b6f64 )
-)
-
-game (
-	name "Mouse Trap (Mouse Attack) (1987) (Atari) (CX26146)"
-	description "Mouse Trap (Mouse Attack) (1987) (Atari) (CX26146)"
-	rom ( name "Mouse Trap (Mouse Attack) (1987) (Atari) (CX26146).bin" size 4096 crc 9ddd45d3 md5 undefined sha1 cf6347dedcfec213c28dd92111ec6f41e74b6f64 )
-)
-
-game (
-	name "Mr. Do! (1983) (CBS Electronics, Ed English) (4L4478) (PAL)"
-	description "Mr. Do! (1983) (CBS Electronics, Ed English) (4L4478) (PAL)"
-	rom ( name "Mr. Do! (1983) (CBS Electronics, Ed English) (4L4478) (PAL).bin" size 8192 crc 9fedc6ae md5 undefined sha1 85c693ef75fb62f26f9977acf63790a00cc0cb5e )
-)
-
-game (
-	name "Mr. Do! (1983) (Coleco, Ed English) (2656) ~"
-	description "Mr. Do! (1983) (Coleco, Ed English) (2656) ~"
-	rom ( name "Mr. Do! (1983) (Coleco, Ed English) (2656) ~.bin" size 8192 crc 860a47a1 md5 undefined sha1 e4c912199779bba25f1b9950007f14dca3d19c84 )
-)
-
-game (
-	name "Mr. Do!'s Castle (1984) (Parker Brothers) (PB5820) ~"
-	description "Mr. Do!'s Castle (1984) (Parker Brothers) (PB5820) ~"
-	rom ( name "Mr. Do!'s Castle (1984) (Parker Brothers) (PB5820) ~.bin" size 8192 crc 2cbbf3fe md5 undefined sha1 2d1c99a0159f9bf5fe727d34f46b07d93bc8341c )
-)
-
-game (
-	name "Mr. Postman - Der Postmann (1983) (Bit Corporation) (PG209) (PAL) ~"
-	description "Mr. Postman - Der Postmann (1983) (Bit Corporation) (PG209) (PAL) ~"
-	rom ( name "Mr. Postman - Der Postmann (1983) (Bit Corporation) (PG209) (PAL) ~.bin" size 4096 crc 16980cb8 md5 undefined sha1 f9e1491d4cfea97822949349559a41d87a235d27 )
-)
-
-game (
-	name "Mr. Postman - O Carteiro (1983) (CCE) (C-801)"
-	description "Mr. Postman - O Carteiro (1983) (CCE) (C-801)"
-	rom ( name "Mr. Postman - O Carteiro (1983) (CCE) (C-801).bin" size 4096 crc eabfc547 md5 undefined sha1 304622be85501fd7f5c7ea51b96516d685b8edaa )
-)
-
-game (
-	name "Mr. Postman (Digitel)"
-	description "Mr. Postman (Digitel)"
-	rom ( name "Mr. Postman (Digitel).bin" size 4096 crc 0d3eba3a md5 undefined sha1 e3b167951ae5084262aea3253711083359e2441b )
-)
-
-game (
-	name "Mr. Postman (Unknown)"
-	description "Mr. Postman (Unknown)"
-	rom ( name "Mr. Postman (Unknown).bin" size 4096 crc a7b03aa5 md5 undefined sha1 4a48548012bc977a4a51e4b1865f8c3e8029d8ac )
-)
-
-game (
-	name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675, CX2675P) (PAL)"
-	description "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675, CX2675P) (PAL)"
-	rom ( name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675, CX2675P) (PAL).bin" size 8192 crc 24cbf34c md5 undefined sha1 fab9f82ac3f039f787095a915ac7914af04ce7d4 )
-)
-
-game (
-	name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) (Prototype)"
-	description "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) (Prototype)"
-	rom ( name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) (Prototype).bin" size 8192 crc f0834d11 md5 undefined sha1 ccd4313a8643008581d303185d601ad2fdad3d51 )
-)
-
-game (
-	name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) ~"
-	description "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) ~"
-	rom ( name "Ms. Pac-Man (1982) (Atari - GCC, Mark Ackerman, Glenn Parker) (CX2675) ~.bin" size 8192 crc b2d08fc9 md5 undefined sha1 62b933cdd8844bb1816ce57889203954fe782603 )
-)
-
-game (
-	name "Ms. Pac-Man (CCE)"
-	description "Ms. Pac-Man (CCE)"
-	rom ( name "Ms. Pac-Man (CCE).bin" size 8192 crc 215b16b1 md5 undefined sha1 63b79bd237a4f4883320c6726518f6140491cdbd )
-)
-
-game (
-	name "Music Machine, The (Paddle) (1983) (Sparrow - HomeComputer Software Co., Dan Schafer, Glenn Stohel, Jon Tedesco) (GCG 1001T) ~"
-	description "Music Machine, The (Paddle) (1983) (Sparrow - HomeComputer Software Co., Dan Schafer, Glenn Stohel, Jon Tedesco) (GCG 1001T) ~"
-	rom ( name "Music Machine, The (Paddle) (1983) (Sparrow - HomeComputer Software Co., Dan Schafer, Glenn Stohel, Jon Tedesco) (GCG 1001T) ~.bin" size 4096 crc bd133d59 md5 undefined sha1 5a641caa2ab3c7c0cd5deb027acbc58efccf8d6a )
-)
-
-game (
-	name "My Golf (1990) (HES, David Lubar) (535) (PAL) [fixed] ~"
-	description "My Golf (1990) (HES, David Lubar) (535) (PAL) [fixed] ~"
-	rom ( name "My Golf (1990) (HES, David Lubar) (535) (PAL) [fixed] ~.bin" size 8192 crc 0d2cbd53 md5 undefined sha1 b2df23b1bf6df9d253ad0705592d3fce352a837b )
-)
-
-game (
-	name "My Golf (1990) (HES, David Lubar) (535) (PAL) ~"
-	description "My Golf (1990) (HES, David Lubar) (535) (PAL) ~"
-	rom ( name "My Golf (1990) (HES, David Lubar) (535) (PAL) ~.bin" size 8192 crc 5f5da13b md5 undefined sha1 250fbd63a80f2ddc034b73de7ce60a5ad49a09c7 )
-)
-
-game (
-	name "My Golf (CCE) (PAL)"
-	description "My Golf (CCE) (PAL)"
-	rom ( name "My Golf (CCE) (PAL).bin" size 8192 crc e9e0c511 md5 undefined sha1 2c2ceb9f279c8c70db43e6512bc78c6d6342c725 )
-)
-
-game (
-	name "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) [a]"
-	description "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) [a]"
-	rom ( name "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) [a].bin" size 4096 crc ef34a713 md5 undefined sha1 19c2880dba08b56ce10494131d468c39921a0d34 )
-)
-
-game (
-	name "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) ~"
-	description "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) ~"
-	rom ( name "Mysterious Thief, A (1983) (ZiMAG - Emag - Vidco) (GN-070) (Prototype) ~.bin" size 4096 crc 8755c57c md5 undefined sha1 0d1c963ea040c60b296a26c46faaad472890499f )
-)
-
-game (
-	name "Name This Game (1983) (Digitel)"
-	description "Name This Game (1983) (Digitel)"
-	rom ( name "Name This Game (1983) (Digitel).bin" size 4096 crc 5ebb5cbb md5 undefined sha1 85b48f5ff877e68928abebff6deba1fa972320ae )
-)
-
-game (
-	name "Name This Game (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Name This Game (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Name This Game (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc 5917f640 md5 undefined sha1 a150ef56f80242b0fa10873967e49afd79b6d6a9 )
-)
-
-game (
-	name "Name This Game (Octopussy) (1982) (U.S. Games Corporation, Roger Booth, Sylvia Day, Ron Dubren, Todd Marshall, Wes Trager, Henry Will IV) (VC1007) ~"
-	description "Name This Game (Octopussy) (1982) (U.S. Games Corporation, Roger Booth, Sylvia Day, Ron Dubren, Todd Marshall, Wes Trager, Henry Will IV) (VC1007) ~"
-	rom ( name "Name This Game (Octopussy) (1982) (U.S. Games Corporation, Roger Booth, Sylvia Day, Ron Dubren, Todd Marshall, Wes Trager, Henry Will IV) (VC1007) ~.bin" size 4096 crc a86e1ad8 md5 undefined sha1 2b4a0535ca83b963906eb0a5d60ce0e21f07905d )
-)
-
-game (
-	name "Name This Game (Unknown) (PAL)"
-	description "Name This Game (Unknown) (PAL)"
-	rom ( name "Name This Game (Unknown) (PAL).bin" size 4096 crc 3b7e600c md5 undefined sha1 6f8cbfcdb827045559ad2301e0071a61567f524b )
-)
-
-game (
-	name "Netmaker (AKA Amidar) (Rainbow Vision - Suntek) (SS-006) (PAL)"
-	description "Netmaker (AKA Amidar) (Rainbow Vision - Suntek) (SS-006) (PAL)"
-	rom ( name "Netmaker (AKA Amidar) (Rainbow Vision - Suntek) (SS-006) (PAL).bin" size 4096 crc 67fe1f3e md5 undefined sha1 b3374e03eac5b69e50e0c9574c567821e59da32e )
-)
-
-game (
-	name "NFL Football (AKA Football) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "NFL Football (AKA Football) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "NFL Football (AKA Football) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc e6a734dc md5 undefined sha1 bd3c477c1e962c2957daad0cf858220710841eb7 )
-)
-
-game (
-	name "Night Driver (Paddle) (1980) (Atari, Rob Fulop - Sears) (CX2633 - 49-75119) ~"
-	description "Night Driver (Paddle) (1980) (Atari, Rob Fulop - Sears) (CX2633 - 49-75119) ~"
-	rom ( name "Night Driver (Paddle) (1980) (Atari, Rob Fulop - Sears) (CX2633 - 49-75119) ~.bin" size 2048 crc 600d8a96 md5 undefined sha1 372771aeb4e2fb2cd1dead5497e3821e4236d5fc )
-)
-
-game (
-	name "Night Driver (Paddle) (1980) (Atari, Rob Fulop) (CX2633, CX2633P) (PAL)"
-	description "Night Driver (Paddle) (1980) (Atari, Rob Fulop) (CX2633, CX2633P) (PAL)"
-	rom ( name "Night Driver (Paddle) (1980) (Atari, Rob Fulop) (CX2633, CX2633P) (PAL).bin" size 2048 crc b028e338 md5 undefined sha1 b0f04e4592fb9c55faaa69a1a465049c2a9c7cac )
-)
-
-game (
-	name "Night Stalker (AKA Dark Cavern) (1989) (Telegames) (PAL)"
-	description "Night Stalker (AKA Dark Cavern) (1989) (Telegames) (PAL)"
-	rom ( name "Night Stalker (AKA Dark Cavern) (1989) (Telegames) (PAL).bin" size 4096 crc 5bca5c2d md5 undefined sha1 281ff7e55c27656522b144b84cba08eb148e2f0a )
-)
-
-game (
-	name "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004)"
-	description "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004)"
-	rom ( name "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004).bin" size 4096 crc ea30cdd5 md5 undefined sha1 3aec7ea8af72bbe105b9d2903a92f5ad2b37bddb )
-)
-
-game (
-	name "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004) (PAL) ~"
-	description "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004) (PAL) ~"
-	rom ( name "Nightmare (1983) (Sancho - Tang's Electronic Co.) (TEC004) (PAL) ~.bin" size 4096 crc b733f921 md5 undefined sha1 2a1ee3584c3df131a97d6291c93de46b3160af54 )
-)
-
-game (
-	name "Nightmare (CCE)"
-	description "Nightmare (CCE)"
-	rom ( name "Nightmare (CCE).bin" size 4096 crc 16885278 md5 undefined sha1 466a033efd763ab7b1f6e12be042bc929243837a )
-)
-
-game (
-	name "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-1A, IA3312) ~"
-	description "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-1A, IA3312) ~"
-	rom ( name "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-1A, IA3312) ~.bin" size 4096 crc 8941caea md5 undefined sha1 e2e8750b8856dd44d914c43a7d277188cc148e5c )
-)
-
-game (
-	name "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-2A, IA3312P) (PAL)"
-	description "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-2A, IA3312P) (PAL)"
-	rom ( name "No Escape! (Escape from Argos) (1982) (Imagic, Michael Greene) (720055-2A, IA3312P) (PAL).bin" size 4096 crc ae03d1b3 md5 undefined sha1 fb9fc3e2b2e391952bfb090ec6e189dcc40aa0fa )
-)
-
-game (
-	name "Nuts (1983) (TechnoVision) (TVS1001) (PAL) ~"
-	description "Nuts (1983) (TechnoVision) (TVS1001) (PAL) ~"
-	rom ( name "Nuts (1983) (TechnoVision) (TVS1001) (PAL) ~.bin" size 4096 crc d76d5f14 md5 undefined sha1 d3c0f973f2b31c14dc3ad2d91fe8bbbb42bce269 )
-)
-
-game (
-	name "Nuts (Unknown)"
-	description "Nuts (Unknown)"
-	rom ( name "Nuts (Unknown).bin" size 4096 crc 9b443896 md5 undefined sha1 ec79943f9bb42174d9adb15335ee08af5f58759b )
-)
-
-game (
-	name "Nuts (Unknown) (PAL)"
-	description "Nuts (Unknown) (PAL)"
-	rom ( name "Nuts (Unknown) (PAL).bin" size 4096 crc 8cd715c1 md5 undefined sha1 9b6421326fd8434277ec88e0cec307be700be99d )
-)
-
-game (
-	name "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) (PAL)"
-	description "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) (PAL)"
-	rom ( name "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) (PAL).bin" size 8192 crc a835d5c2 md5 undefined sha1 f5f8619035c73ef35a6fa197b39bc504e1a09b88 )
-)
-
-game (
-	name "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) ~"
-	description "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) ~"
-	rom ( name "Obelix (1983) (Atari, Andrew Fuchs, Jeffrey Gusman, Dave Jolly, Suki Lee) (CX26117) ~.bin" size 8192 crc 29a51ea4 md5 undefined sha1 9155f7fa57480a12a03c6a84213cc5dc7be739b5 )
-)
-
-game (
-	name "Ocean City (AKA Atlantis) (Funvision - Fund. International Co.)"
-	description "Ocean City (AKA Atlantis) (Funvision - Fund. International Co.)"
-	rom ( name "Ocean City (AKA Atlantis) (Funvision - Fund. International Co.).bin" size 4096 crc c6617840 md5 undefined sha1 1f8d06b99db94b0aa8ca320c7cb212639ac9591f )
-)
-
-game (
-	name "Ocean City Defender (AKA Atlantis) (Zellers)"
-	description "Ocean City Defender (AKA Atlantis) (Zellers)"
-	rom ( name "Ocean City Defender (AKA Atlantis) (Zellers).bin" size 4096 crc c6617840 md5 undefined sha1 1f8d06b99db94b0aa8ca320c7cb212639ac9591f )
-)
-
-game (
-	name "Octopus (AKA Name This Game) (1983) (Carrere Video, Roger Booth, Sylvia Day, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC1007) (PAL)"
-	description "Octopus (AKA Name This Game) (1983) (Carrere Video, Roger Booth, Sylvia Day, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC1007) (PAL)"
-	rom ( name "Octopus (AKA Name This Game) (1983) (Carrere Video, Roger Booth, Sylvia Day, Todd Marshall, Wes Trager, Henry Will IV - Teldec - Prism Micro Products) (USC1007) (PAL).bin" size 4096 crc 8df953c1 md5 undefined sha1 21e319d2856dbc207fd4029a626e1b60afb44691 )
-)
-
-game (
-	name "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) (PAL)"
-	description "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) (PAL)"
-	rom ( name "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) (PAL).bin" size 16384 crc 182af080 md5 undefined sha1 9ebc01bd86faceef87432597f1fc5fb6ce088ef5 )
-)
-
-game (
-	name "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) ~"
-	description "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) ~"
-	rom ( name "Off the Wall (Bizarre Breakout, Peasant King, Zip 'n' Zap) (1989) (Atari - Axlon, John Vifian) (CX26168) ~.bin" size 16384 crc a09779ea md5 undefined sha1 3dcfe93399044148561586056288c6f8e5c96e2b )
-)
-
-game (
-	name "Off Your Rocker (Joyboard) (1983) (Amiga) (3130) (Prototype) ~"
-	description "Off Your Rocker (Joyboard) (1983) (Amiga) (3130) (Prototype) ~"
-	rom ( name "Off Your Rocker (Joyboard) (1983) (Amiga) (3130) (Prototype) ~.bin" size 4096 crc 066ec995 md5 undefined sha1 7ad74a7c36318f1304f5dc454401cf257fa60d7a )
-)
-
-game (
-	name "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) (PAL)"
-	description "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) (PAL)"
-	rom ( name "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) (PAL).bin" size 8448 crc e374b94b md5 undefined sha1 2295b1eb5d30698e0a3a49e959f2a65ae60b4154 )
-)
-
-game (
-	name "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) ~"
-	description "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) ~"
-	rom ( name "Official Frogger, The (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105) ~.bin" size 8448 crc 1228e48c md5 undefined sha1 f84c15579d22f2536e94f1679642b9dc73b6f2fe )
-)
-
-game (
-	name "Official Frogger, The (Preview) (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105)"
-	description "Official Frogger, The (Preview) (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105)"
-	rom ( name "Official Frogger, The (Preview) (1983) (Starpath Corporation, Stephen Harland Landrum) (9) (AR-4105).bin" size 8448 crc 5f0181f9 md5 undefined sha1 2edb64be1bb6f4215f520ec2f487b19f29724b8d )
-)
-
-game (
-	name "Oink! - Das Schweinchen und der Wolf (1982) (Activision, Mike Lorenzen - Ariola) (EAX-023 - 711 023-720) (PAL)"
-	description "Oink! - Das Schweinchen und der Wolf (1982) (Activision, Mike Lorenzen - Ariola) (EAX-023 - 711 023-720) (PAL)"
-	rom ( name "Oink! - Das Schweinchen und der Wolf (1982) (Activision, Mike Lorenzen - Ariola) (EAX-023 - 711 023-720) (PAL).bin" size 4096 crc 7eb46148 md5 undefined sha1 96f71b08725ab78cac3d0ebb9dcffcf1d4895fba )
-)
-
-game (
-	name "Oink! (1982) (Activision, Mike Lorenzen) (AX-023) ~"
-	description "Oink! (1982) (Activision, Mike Lorenzen) (AX-023) ~"
-	rom ( name "Oink! (1982) (Activision, Mike Lorenzen) (AX-023) ~.bin" size 4096 crc 86f99b5e md5 undefined sha1 ea674cf2c90d407b8f8b96eac692690b602b73f9 )
-)
-
-game (
-	name "Oink! (CCE)"
-	description "Oink! (CCE)"
-	rom ( name "Oink! (CCE).bin" size 4096 crc d63bbf34 md5 undefined sha1 03eb4a3b3db04c1782e1a91d27ea515163d258fb )
-)
-
-game (
-	name "Oink! (Unknown) (PAL)"
-	description "Oink! (Unknown) (PAL)"
-	rom ( name "Oink! (Unknown) (PAL).bin" size 4096 crc 95121f77 md5 undefined sha1 f8c9e7d65b9924da6fac0ce7dc9eec8c0040057d )
-)
-
-game (
-	name "Omega Race (Booster Grip) (1983) (CBS Electronics) (4L 2737 0000) ~"
-	description "Omega Race (Booster Grip) (1983) (CBS Electronics) (4L 2737 0000) ~"
-	rom ( name "Omega Race (Booster Grip) (1983) (CBS Electronics) (4L 2737 0000) ~.bin" size 12288 crc e9876116 md5 undefined sha1 dcaab259e7617c7ac7d349893451896a9ca0e292 )
-)
-
-game (
-	name "Open Sesame (1982) (Puzzy - Bit Corporation) (PG204) (PAL) ~"
-	description "Open Sesame (1982) (Puzzy - Bit Corporation) (PG204) (PAL) ~"
-	rom ( name "Open Sesame (1982) (Puzzy - Bit Corporation) (PG204) (PAL) ~.bin" size 4096 crc d01b5a1f md5 undefined sha1 cc4d66da0182819a8067dbc6b73ff1bc33fc165b )
-)
-
-game (
-	name "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL)"
-	description "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL)"
-	rom ( name "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL).bin" size 4096 crc d01b5a1f md5 undefined sha1 cc4d66da0182819a8067dbc6b73ff1bc33fc165b )
-)
-
-game (
-	name "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL) [a]"
-	description "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL) [a]"
-	rom ( name "Open Sesame (AKA Open Sesame) (1983) (Goliath) (5) (PAL) [a].bin" size 4096 crc 0d12fd9b md5 undefined sha1 cd968c2a983f9adf4d8d8d56823923b31c33980f )
-)
-
-game (
-	name "Open Sesame (AKA Open Sesame) (4 Game in One) (1983) (Bit Corporation) (PGP204) (PAL)"
-	description "Open Sesame (AKA Open Sesame) (4 Game in One) (1983) (Bit Corporation) (PGP204) (PAL)"
-	rom ( name "Open Sesame (AKA Open Sesame) (4 Game in One) (1983) (Bit Corporation) (PGP204) (PAL).bin" size 4096 crc 23a8d1af md5 undefined sha1 3fcff056232bb7dca13e84ebe9bb2dc6bb5cd5fd )
-)
-
-game (
-	name "Open, Sesame! - Abre-te, Sesamo! (1983) (CCE) (C-804)"
-	description "Open, Sesame! - Abre-te, Sesamo! (1983) (CCE) (C-804)"
-	rom ( name "Open, Sesame! - Abre-te, Sesamo! (1983) (CCE) (C-804).bin" size 4096 crc 8cf511a4 md5 undefined sha1 cc00c5138fd1a3b723c5f1acc90ff8e6e87942c1 )
-)
-
-game (
-	name "Open, Sesame! - Sesam, Oeffne Dich (1982) (Bit Corporation) (PG204) (PAL)"
-	description "Open, Sesame! - Sesam, Oeffne Dich (1982) (Bit Corporation) (PG204) (PAL)"
-	rom ( name "Open, Sesame! - Sesam, Oeffne Dich (1982) (Bit Corporation) (PG204) (PAL).bin" size 4096 crc 0d12fd9b md5 undefined sha1 cd968c2a983f9adf4d8d8d56823923b31c33980f )
-)
-
-game (
-	name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (03-30-1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	description "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (03-30-1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	rom ( name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (03-30-1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype).bin" size 8192 crc 3b06e5b1 md5 undefined sha1 52028232f4f30800a2131d53fca49b05f6148868 )
-)
-
-game (
-	name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (10-20-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	description "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (10-20-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	rom ( name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (10-20-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype).bin" size 8192 crc 0396b971 md5 undefined sha1 993e998c5f85d153c9a1462240e47b06c297ca85 )
-)
-
-game (
-	name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (12-03-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	description "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (12-03-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype)"
-	rom ( name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (12-03-1982) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (Prototype).bin" size 8192 crc 06191c30 md5 undefined sha1 de79ef324d63b2bcadfc845f36b6535793a3b260 )
-)
-
-game (
-	name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (PAL)"
-	description "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (PAL)"
-	rom ( name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) (PAL).bin" size 8192 crc 4cc88058 md5 undefined sha1 98007f26356b4032a2ae4e9fddea5a38a988eb13 )
-)
-
-game (
-	name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) ~"
-	description "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) ~"
-	rom ( name "Oscar's Trash Race (Kid's Controller) (Children's Computer Workshop) (1983) (Atari, Christopher H. Omarzu, Preston Stuart, Bruce Williams) (CX26101) ~.bin" size 8192 crc 34721d7b md5 undefined sha1 7905709fcc85cbcfc28ca2ed543ffa737a5483ae )
-)
-
-game (
-	name "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) [no grid markers] ~"
-	description "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) [no grid markers] ~"
-	rom ( name "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) [no grid markers] ~.bin" size 2048 crc 8b932a9e md5 undefined sha1 5b3bbefe037951307317555a79981c7a7c8fb240 )
-)
-
-game (
-	name "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) ~"
-	description "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) ~"
-	rom ( name "Othello (1981) (Atari, Ed Logg, Carol Shaw - Sears) (CX2639 - 49-75162) ~.bin" size 2048 crc 171ae72f md5 undefined sha1 cbecf1a32d9366a3dd4ad643916cd59cdc820a8b )
-)
-
-game (
-	name "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL)"
-	description "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL)"
-	rom ( name "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL).bin" size 2048 crc ab337a10 md5 undefined sha1 7a253ac3a4769c0dbd3fff462b0069351f862be9 )
-)
-
-game (
-	name "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL) [no grid markers]"
-	description "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL) [no grid markers]"
-	rom ( name "Othello (1981) (Atari, Ed Logg, Carol Shaw) (CX2639, CX2639P) (PAL) [no grid markers].bin" size 2048 crc 5c341787 md5 undefined sha1 bf340ef27cbc436c6f7d6fa908977830e8d17675 )
-)
-
-game (
-	name "Out of Control (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, Jim Jacob) (5005002) ~"
-	description "Out of Control (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, Jim Jacob) (5005002) ~"
-	rom ( name "Out of Control (1983) (Avalon Hill, Jean Baer, Bill 'Rebecca Ann' Heineman, Jim Jacob) (5005002) ~.bin" size 4096 crc ca4d03fb md5 undefined sha1 344d6942723513c376a7a844779804e10f357b85 )
-)
-
-game (
-	name "Outlaw - Gunslinger (1978) (Atari, David Crane - Sears) (CX2605 - 6-99822, 49-75109) ~"
-	description "Outlaw - Gunslinger (1978) (Atari, David Crane - Sears) (CX2605 - 6-99822, 49-75109) ~"
-	rom ( name "Outlaw - Gunslinger (1978) (Atari, David Crane - Sears) (CX2605 - 6-99822, 49-75109) ~.bin" size 2048 crc 68dd7acd md5 undefined sha1 f8eeaaf4635ac39b4bdf7ded1348bce46313ef9f )
-)
-
-game (
-	name "Outlaw (1978) (Atari, David Crane) (CX2605, CX2605P) (PAL)"
-	description "Outlaw (1978) (Atari, David Crane) (CX2605, CX2605P) (PAL)"
-	rom ( name "Outlaw (1978) (Atari, David Crane) (CX2605, CX2605P) (PAL).bin" size 2048 crc 64f136d2 md5 undefined sha1 4a1514a7cf4279fded1b0db6f5b31818b9ff011c )
-)
-
-game (
-	name "Outlaw (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL)"
-	description "Outlaw (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL)"
-	rom ( name "Outlaw (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL).bin" size 2048 crc b6b28725 md5 undefined sha1 b61073bc30a9285d4fa21e66d06f525361ce05d9 )
-)
-
-game (
-	name "Overkill (AKA Seahawk) (1983) (Goliath - Hot Shot) (83-114) (PAL)"
-	description "Overkill (AKA Seahawk) (1983) (Goliath - Hot Shot) (83-114) (PAL)"
-	rom ( name "Overkill (AKA Seahawk) (1983) (Goliath - Hot Shot) (83-114) (PAL).bin" size 4096 crc 5d3c699e md5 undefined sha1 b4ead7656696a983dec3192c71cc4d63e9a67825 )
-)
-
-game (
-	name "Pac Kong (AKA Spider Kong) (1983) (Goliath - Hot Shot) (83-414) (PAL)"
-	description "Pac Kong (AKA Spider Kong) (1983) (Goliath - Hot Shot) (83-414) (PAL)"
-	rom ( name "Pac Kong (AKA Spider Kong) (1983) (Goliath - Hot Shot) (83-414) (PAL).bin" size 4096 crc 14f8f820 md5 undefined sha1 1a14a508f0565cdcf6d99431d4e49b8e9e0a1caa )
-)
-
-game (
-	name "Pac Kong (AKA Spider Kong) (Funvision - Fund. International Co.) (PAL)"
-	description "Pac Kong (AKA Spider Kong) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Pac Kong (AKA Spider Kong) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc b3f7cf8a md5 undefined sha1 cadf9109e97523d53525c2f921ccc083d8d83cf5 )
-)
-
-game (
-	name "Pac Kong (AKA Spider Kong) (Unknown)"
-	description "Pac Kong (AKA Spider Kong) (Unknown)"
-	rom ( name "Pac Kong (AKA Spider Kong) (Unknown).bin" size 4096 crc d3d0cc39 md5 undefined sha1 59f8b3b9be4bf5230ca26bb21e264abe2b154705 )
-)
-
-game (
-	name "Pac Man (1983) (CCE) (C-812)"
-	description "Pac Man (1983) (CCE) (C-812)"
-	rom ( name "Pac Man (1983) (CCE) (C-812).bin" size 4096 crc d8808375 md5 undefined sha1 ad375e303ef498b78e5dd1a29e9bfd77eaea5b1a )
-)
-
-game (
-	name "Pac Man (1983) (CCE) (C-812) [a]"
-	description "Pac Man (1983) (CCE) (C-812) [a]"
-	rom ( name "Pac Man (1983) (CCE) (C-812) [a].bin" size 4096 crc a626ef9f md5 undefined sha1 22b5905abc7298227acc841515472dd7464338fc )
-)
-
-game (
-	name "Pac Man (1983) (Digitel)"
-	description "Pac Man (1983) (Digitel)"
-	rom ( name "Pac Man (1983) (Digitel).bin" size 4096 crc 80cbd5d8 md5 undefined sha1 00fa1afc97c55a51f5dee9f0560e8059d6819d04 )
-)
-
-game (
-	name "Pac-Kong (AKA Spider Kong) (1983) (Quelle) (219.292 0) (PAL)"
-	description "Pac-Kong (AKA Spider Kong) (1983) (Quelle) (219.292 0) (PAL)"
-	rom ( name "Pac-Kong (AKA Spider Kong) (1983) (Quelle) (219.292 0) (PAL).bin" size 4096 crc 14f8f820 md5 undefined sha1 1a14a508f0565cdcf6d99431d4e49b8e9e0a1caa )
-)
-
-game (
-	name "Pac-Kong (AKA Spider Kong) (Rainbow Vision - Suntek) (SS-003) (PAL)"
-	description "Pac-Kong (AKA Spider Kong) (Rainbow Vision - Suntek) (SS-003) (PAL)"
-	rom ( name "Pac-Kong (AKA Spider Kong) (Rainbow Vision - Suntek) (SS-003) (PAL).bin" size 4096 crc db66a04d md5 undefined sha1 923c969d31cef450075932436f03f1404e1cab0e )
-)
-
-game (
-	name "Pac-Man (1982) (Atari, Tod Frye - Sears) (CX2646 - 49-75185) ~"
-	description "Pac-Man (1982) (Atari, Tod Frye - Sears) (CX2646 - 49-75185) ~"
-	rom ( name "Pac-Man (1982) (Atari, Tod Frye - Sears) (CX2646 - 49-75185) ~.bin" size 4096 crc ddc9a881 md5 undefined sha1 0940fea7f04cdb6d4b90c5ad1a7e344e68f6dbb1 )
-)
-
-game (
-	name "Pac-Man (1982) (Atari, Tod Frye) (CX2646) (PAL)"
-	description "Pac-Man (1982) (Atari, Tod Frye) (CX2646) (PAL)"
-	rom ( name "Pac-Man (1982) (Atari, Tod Frye) (CX2646) (PAL).bin" size 4096 crc 4947ef99 md5 undefined sha1 3e7ba1347755bdb313e06a54aaeca9e611eaa2b8 )
-)
-
-game (
-	name "Pac-Man (Hack) (Unknown) (PAL)"
-	description "Pac-Man (Hack) (Unknown) (PAL)"
-	rom ( name "Pac-Man (Hack) (Unknown) (PAL).bin" size 4096 crc a7ef0f13 md5 undefined sha1 7abca7ace04fb690324cc36802489414b49a708e )
-)
-
-game (
-	name "Panda (Quest) (AKA Panda Chase) (Suntek) (SS-035) (PAL)"
-	description "Panda (Quest) (AKA Panda Chase) (Suntek) (SS-035) (PAL)"
-	rom ( name "Panda (Quest) (AKA Panda Chase) (Suntek) (SS-035) (PAL).bin" size 4096 crc d338860d md5 undefined sha1 2c108ad3fa80ed4302422edcd8f545e018881f36 )
-)
-
-game (
-	name "Panda Chase (Penda Chase) (1983) (Home Vision - Gem International Corp.) (VCS83105) (PAL) ~"
-	description "Panda Chase (Penda Chase) (1983) (Home Vision - Gem International Corp.) (VCS83105) (PAL) ~"
-	rom ( name "Panda Chase (Penda Chase) (1983) (Home Vision - Gem International Corp.) (VCS83105) (PAL) ~.bin" size 4096 crc af417a00 md5 undefined sha1 f07b47cd6f3362eb051eab3eca564183d0d46c0c )
-)
-
-game (
-	name "Panda Chase (Unknown) (PAL)"
-	description "Panda Chase (Unknown) (PAL)"
-	rom ( name "Panda Chase (Unknown) (PAL).bin" size 4096 crc 90d50d65 md5 undefined sha1 6fa70cd79c3e18cd47d027b234c4ff4b14603327 )
-)
-
-game (
-	name "Parachute (1983) (Home Vision - Gem International Corp.) (VCS83123) (PAL) ~"
-	description "Parachute (1983) (Home Vision - Gem International Corp.) (VCS83123) (PAL) ~"
-	rom ( name "Parachute (1983) (Home Vision - Gem International Corp.) (VCS83123) (PAL) ~.bin" size 4096 crc 40e4bc6a md5 undefined sha1 385036ac98d44f2fa33a3ab11e35ca9f0151d6d2 )
-)
-
-game (
-	name "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	description "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	rom ( name "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302).bin" size 8448 crc 4724f396 md5 undefined sha1 1b1bcc35bd1120ded54318e63bce05d9c8603a82 )
-)
-
-game (
-	name "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	description "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	rom ( name "Party Mix - Bop a Buggy (1 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL).bin" size 8448 crc d20d4821 md5 undefined sha1 b92aaae1f94f9c2d9957dfaf1941b7f12c5c7679 )
-)
-
-game (
-	name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	description "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	rom ( name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL).bin" size 25344 crc b7af284a md5 undefined sha1 bd37bf6d8c2900bc68b383bd1edbf5a7fd6a8710 )
-)
-
-game (
-	name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) ~"
-	description "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) ~"
-	rom ( name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) ~.bin" size 25344 crc 8b8ae545 md5 undefined sha1 600e3a32b19b3b164aaafb538b4399eda669845a )
-)
-
-game (
-	name "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	description "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	rom ( name "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302).bin" size 8448 crc c1aa60ce md5 undefined sha1 261c9d149e7908558fb1a5a5898f568ac823dbb1 )
-)
-
-game (
-	name "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	description "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	rom ( name "Party Mix - Down on the Line, Handcar (3 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL).bin" size 8448 crc d619142f md5 undefined sha1 00c90aea85bd8272cb34ce23fd0e5f0d36a1ea48 )
-)
-
-game (
-	name "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	description "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	rom ( name "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302).bin" size 8448 crc bf14c002 md5 undefined sha1 13e8f09014dd4bebdb782833028504ff8577b035 )
-)
-
-game (
-	name "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	description "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	rom ( name "Party Mix - Tug of War, Wizard's Keep (2 of 3) (Paddle) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL).bin" size 8448 crc e50a3d5c md5 undefined sha1 d668e291131fc01b1286f7cbf5f0de10d15de7f1 )
-)
-
-game (
-	name "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	description "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302)"
-	rom ( name "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302).bin" size 8448 crc fb3fe9b1 md5 undefined sha1 035bad1d6142dbe932eb2f2a4e34bbb64692fa9f )
-)
-
-game (
-	name "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	description "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL)"
-	rom ( name "Party Mix (Preview) (1983) (Starpath Corporation, Dennis Caswell) (10) (AR-4302) (PAL).bin" size 8448 crc 57536159 md5 undefined sha1 55e51e131235123d2ab9f8a0209bcb16a7734622 )
-)
-
-game (
-	name "Peek-A-Boo (Dr. Salk) (Kid's Controller) (1984) (Atari, Dr. Lee Salk) (CX26135) (Prototype) ~"
-	description "Peek-A-Boo (Dr. Salk) (Kid's Controller) (1984) (Atari, Dr. Lee Salk) (CX26135) (Prototype) ~"
-	rom ( name "Peek-A-Boo (Dr. Salk) (Kid's Controller) (1984) (Atari, Dr. Lee Salk) (CX26135) (Prototype) ~.bin" size 4096 crc 07594314 md5 undefined sha1 b529c1664ed1abc8f5f962a1fed65c0e4440219c )
-)
-
-game (
-	name "Pega Ladrao (AKA Keystone Kapers) (Dismac)"
-	description "Pega Ladrao (AKA Keystone Kapers) (Dismac)"
-	rom ( name "Pega Ladrao (AKA Keystone Kapers) (Dismac).bin" size 4096 crc 33c7f94f md5 undefined sha1 7d154f99027418a7717d101cd7ad69cbe1c484b9 )
-)
-
-game (
-	name "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616)"
-	description "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616)"
-	rom ( name "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616).bin" size 4096 crc 3f59bb60 md5 undefined sha1 832283530f5dee332f29cf8c4854dd554f2030a0 )
-)
-
-game (
-	name "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616) (PAL)"
-	description "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616) (PAL)"
-	rom ( name "Pele's Soccer - Pele's Championship Soccer (AKA Championship Soccer) (1981) (Atari, Steve Wright) (CX2616) (PAL).bin" size 4096 crc be28f033 md5 undefined sha1 c887ceedc2216f1b403df8c449c89b08334ff2f6 )
-)
-
-game (
-	name "Pengo (1983) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (Prototype)"
-	description "Pengo (1983) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (Prototype)"
-	rom ( name "Pengo (1983) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (Prototype).bin" size 8192 crc 46b53f35 md5 undefined sha1 461c2ea3e4d24f86ec02215c1f4743d250796c11 )
-)
-
-game (
-	name "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (PAL)"
-	description "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (PAL)"
-	rom ( name "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) (PAL).bin" size 8192 crc f99f2cfb md5 undefined sha1 5e2a8ae2545091227b024e478c138b341211298b )
-)
-
-game (
-	name "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) ~"
-	description "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) ~"
-	rom ( name "Pengo (1984) (Atari, Andrew Fuchs, Courtney Granner, Jeffrey Gusman, Mark R. Hahn) (CX2690) ~.bin" size 8192 crc 7667e739 md5 undefined sha1 89b991a7a251f78f422bcdf9cf7d4475fdf33e97 )
-)
-
-game (
-	name "Pepsi Invaders - Coke Wins (Coca-Cola, Coke & Pepsi) (1983) (Atari, Richard Maurer, Christopher H. Omarzu - Coca Cola)"
-	description "Pepsi Invaders - Coke Wins (Coca-Cola, Coke & Pepsi) (1983) (Atari, Richard Maurer, Christopher H. Omarzu - Coca Cola)"
-	rom ( name "Pepsi Invaders - Coke Wins (Coca-Cola, Coke & Pepsi) (1983) (Atari, Richard Maurer, Christopher H. Omarzu - Coca Cola).bin" size 4096 crc 7ac99b5c md5 undefined sha1 c5317035e73f60e959c123d89600c81b7c45701f )
-)
-
-game (
-	name "Persian Gulf War (AKA River Raid) (Funvision - Fund. International Co.)"
-	description "Persian Gulf War (AKA River Raid) (Funvision - Fund. International Co.)"
-	rom ( name "Persian Gulf War (AKA River Raid) (Funvision - Fund. International Co.).bin" size 4096 crc 9aee6e8e md5 undefined sha1 2cc6c98442069bf32b00cc98b2ea156a4edfecb4 )
-)
-
-game (
-	name "Pete Rose Baseball (1988) (Absolute Entertainment, Alex DeMeo) (AG-045-04, AK-045-04) ~"
-	description "Pete Rose Baseball (1988) (Absolute Entertainment, Alex DeMeo) (AG-045-04, AK-045-04) ~"
-	rom ( name "Pete Rose Baseball (1988) (Absolute Entertainment, Alex DeMeo) (AG-045-04, AK-045-04) ~.bin" size 16384 crc d0c6fc32 md5 undefined sha1 19c3ad034466c0433501a415a996ed7155d6063a )
-)
-
-game (
-	name "Peter Penguin (AKA Frisco) (Pumuckl-Serie) (1983) (ITT Family Games) (554-37 338) (PAL)"
-	description "Peter Penguin (AKA Frisco) (Pumuckl-Serie) (1983) (ITT Family Games) (554-37 338) (PAL)"
-	rom ( name "Peter Penguin (AKA Frisco) (Pumuckl-Serie) (1983) (ITT Family Games) (554-37 338) (PAL).bin" size 4096 crc 5b47448c md5 undefined sha1 59cc30a376901462e43bc78586495c72bab81fce )
-)
-
-game (
-	name "Phantom Tank - Phantom-Panzer (1982) (Bit Corporation) (PG203) (PAL)"
-	description "Phantom Tank - Phantom-Panzer (1982) (Bit Corporation) (PG203) (PAL)"
-	rom ( name "Phantom Tank - Phantom-Panzer (1982) (Bit Corporation) (PG203) (PAL).bin" size 4096 crc 8a51b854 md5 undefined sha1 959aca4b44269b1e5ac58791fc3c7c461a6a4a17 )
-)
-
-game (
-	name "Phantom Tank - Tanque Fantasma (1983) (CCE) (C-808) (PAL)"
-	description "Phantom Tank - Tanque Fantasma (1983) (CCE) (C-808) (PAL)"
-	rom ( name "Phantom Tank - Tanque Fantasma (1983) (CCE) (C-808) (PAL).bin" size 4096 crc d3cc4d5c md5 undefined sha1 432c1264dc2d24d76e25c8750dfc387cccb2bc2f )
-)
-
-game (
-	name "Phantom Tank (1982) (Puzzy - Bit Corporation) (PG203) (PAL) ~"
-	description "Phantom Tank (1982) (Puzzy - Bit Corporation) (PG203) (PAL) ~"
-	rom ( name "Phantom Tank (1982) (Puzzy - Bit Corporation) (PG203) (PAL) ~.bin" size 4096 crc 9213493b md5 undefined sha1 02a521354575d2270f75250e79bc18f69f666c7f )
-)
-
-game (
-	name "Phantom Tank (1983) (Goliath) (3) (PAL)"
-	description "Phantom Tank (1983) (Goliath) (3) (PAL)"
-	rom ( name "Phantom Tank (1983) (Goliath) (3) (PAL).bin" size 4096 crc 9213493b md5 undefined sha1 02a521354575d2270f75250e79bc18f69f666c7f )
-)
-
-game (
-	name "Phantom Tank (Unknown) (PAL)"
-	description "Phantom Tank (Unknown) (PAL)"
-	rom ( name "Phantom Tank (Unknown) (PAL).bin" size 4096 crc 5ce11537 md5 undefined sha1 ac10193bd786ca3c2a735809c95d130898e6c784 )
-)
-
-game (
-	name "Phantom UFO (AKA Spider Fighter) (4 Game in One) (1983) (Bit Corporation) (PGP212) (PAL)"
-	description "Phantom UFO (AKA Spider Fighter) (4 Game in One) (1983) (Bit Corporation) (PGP212) (PAL)"
-	rom ( name "Phantom UFO (AKA Spider Fighter) (4 Game in One) (1983) (Bit Corporation) (PGP212) (PAL).bin" size 4096 crc 69d3abc5 md5 undefined sha1 39f96b96ee996ab4afd82c6dea35c8d86585b90c )
-)
-
-game (
-	name "Phantompanzer II (AKA Thunderground) (1983) (Quelle) (343.273 9) (PAL)"
-	description "Phantompanzer II (AKA Thunderground) (1983) (Quelle) (343.273 9) (PAL)"
-	rom ( name "Phantompanzer II (AKA Thunderground) (1983) (Quelle) (343.273 9) (PAL).bin" size 4096 crc b12b175a md5 undefined sha1 1a04ff325dc3ebb2382428c6cd44dae7bc76ff71 )
-)
-
-game (
-	name "Phanton Tank (AKA Phantom Tank) (Digivision)"
-	description "Phanton Tank (AKA Phantom Tank) (Digivision)"
-	rom ( name "Phanton Tank (AKA Phantom Tank) (Digivision).bin" size 4096 crc a99dce32 md5 undefined sha1 ac1c3c7429d1d44585b88905bbc8a81d3cb2c7df )
-)
-
-game (
-	name "Pharaoh's Curse (1983) (TechnoVision) (TVS1003) (PAL) ~"
-	description "Pharaoh's Curse (1983) (TechnoVision) (TVS1003) (PAL) ~"
-	rom ( name "Pharaoh's Curse (1983) (TechnoVision) (TVS1003) (PAL) ~.bin" size 4096 crc c6b82fc6 md5 undefined sha1 ecd9e93335ef6eda1531b0b5f03a5015054277b0 )
-)
-
-game (
-	name "Pharaoh's Curse (Unknown)"
-	description "Pharaoh's Curse (Unknown)"
-	rom ( name "Pharaoh's Curse (Unknown).bin" size 4096 crc c17c5f64 md5 undefined sha1 970963978d86f9b6cf6dfe0aae0c4d44a0327395 )
-)
-
-game (
-	name "Pharaoh's Curse (Unknown) (PAL)"
-	description "Pharaoh's Curse (Unknown) (PAL)"
-	rom ( name "Pharaoh's Curse (Unknown) (PAL).bin" size 4096 crc 4f9277c9 md5 undefined sha1 5dd853548b6bf1abffaf28fa01708fea20d346fd )
-)
-
-game (
-	name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype)"
-	description "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype)"
-	rom ( name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype).bin" size 8448 crc 4fd200db md5 undefined sha1 1ff4e3101275555ff014d981ff7f9006c93942ee )
-)
-
-game (
-	name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype) [a]"
-	description "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype) [a]"
-	rom ( name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (Prototype) [a].bin" size 8448 crc 61a05bf2 md5 undefined sha1 abfd85e6973ab55d12f039cb0a4f4df8a62c0330 )
-)
-
-game (
-	name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) ~"
-	description "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) ~"
-	rom ( name "Phaser Patrol (1982) (Arcadia Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) ~.bin" size 8448 crc eaf31bd7 md5 undefined sha1 21c255e489d126475c3744cdd0d6e8a8e618e3eb )
-)
-
-game (
-	name "Phaser Patrol (1982) (Starpath Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (PAL)"
-	description "Phaser Patrol (1982) (Starpath Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (PAL)"
-	rom ( name "Phaser Patrol (1982) (Starpath Corporation, Dennis Caswell) (1) (AR-4000, AR-4100) (PAL).bin" size 8448 crc 15550fed md5 undefined sha1 9734cde5019fad40aef45fe5271f245995027009 )
-)
-
-game (
-	name "Philly Flasher (AKA Beat 'Em & Eat 'Em) (Paddle) (1982) (PlayAround - J.H.M.) (201)"
-	description "Philly Flasher (AKA Beat 'Em & Eat 'Em) (Paddle) (1982) (PlayAround - J.H.M.) (201)"
-	rom ( name "Philly Flasher (AKA Beat 'Em & Eat 'Em) (Paddle) (1982) (PlayAround - J.H.M.) (201).bin" size 4096 crc 6ac647a1 md5 undefined sha1 b299df2792c5cca73118925dff85695b73a16228 )
-)
-
-game (
-	name "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673, CX2673P) (PAL)"
-	description "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673, CX2673P) (PAL)"
-	rom ( name "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673, CX2673P) (PAL).bin" size 8192 crc 743cfaac md5 undefined sha1 837a0f07c4ece7e64bbd088605859f7b6dade57d )
-)
-
-game (
-	name "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673) ~"
-	description "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673) ~"
-	rom ( name "Phoenix (1982) (Atari - GCC, Mike Feinstein, John Mracek) (CX2673) ~.bin" size 8192 crc 6ae1b66c md5 undefined sha1 010d51e3f522ba60f021d56819437d7c85897cdd )
-)
-
-game (
-	name "Phoenix (1983) (CCE) (C-1012)"
-	description "Phoenix (1983) (CCE) (C-1012)"
-	rom ( name "Phoenix (1983) (CCE) (C-1012).bin" size 8192 crc f43e6ab4 md5 undefined sha1 d14b17841fd2bcbf69140a9978b24820d1e0579a )
-)
-
-game (
-	name "Phoenix (Unknown)"
-	description "Phoenix (Unknown)"
-	rom ( name "Phoenix (Unknown).bin" size 8192 crc d76a8618 md5 undefined sha1 99d3fed58047aa61b49ef0e069f4fa76bc1be18f )
-)
-
-game (
-	name "Phoenix (Zirok)"
-	description "Phoenix (Zirok)"
-	rom ( name "Phoenix (Zirok).bin" size 8192 crc 99d5b4bf md5 undefined sha1 20830d1748ad3f880eb6a4d6b307dc73fec7a01c )
-)
-
-game (
-	name "Pick 'n' Pile (1990) (Salu - Ubi Soft, Dennis M. Kiss) (460673) (PAL) ~"
-	description "Pick 'n' Pile (1990) (Salu - Ubi Soft, Dennis M. Kiss) (460673) (PAL) ~"
-	rom ( name "Pick 'n' Pile (1990) (Salu - Ubi Soft, Dennis M. Kiss) (460673) (PAL) ~.bin" size 16384 crc cb76a9d4 md5 undefined sha1 a5917537cf1093aa350903d85d9e271e8a11d2cf )
-)
-
-game (
-	name "Pick Up (1983) (20th Century Fox Video Games, Mark Klein) (11034) (Prototype) ~"
-	description "Pick Up (1983) (20th Century Fox Video Games, Mark Klein) (11034) (Prototype) ~"
-	rom ( name "Pick Up (1983) (20th Century Fox Video Games, Mark Klein) (11034) (Prototype) ~.bin" size 4096 crc 0cdd8475 md5 undefined sha1 9784531d02200bb79a58987877c67a0fc658252e )
-)
-
-game (
-	name "Picnic (Catch the Fly) (Paddle) (1982) (U.S. Games Corporation, Tom Sloper) (VC2004) ~"
-	description "Picnic (Catch the Fly) (Paddle) (1982) (U.S. Games Corporation, Tom Sloper) (VC2004) ~"
-	rom ( name "Picnic (Catch the Fly) (Paddle) (1982) (U.S. Games Corporation, Tom Sloper) (VC2004) ~.bin" size 4096 crc 1d507a61 md5 undefined sha1 483fc907471c5c358fb3e624097861a2fc9c1e45 )
-)
-
-game (
-	name "Picnic (Paddle) (1983) (Carrere Video, Tom Sloper - Teldec - Prism Micro Products) (USC2004) (PAL)"
-	description "Picnic (Paddle) (1983) (Carrere Video, Tom Sloper - Teldec - Prism Micro Products) (USC2004) (PAL)"
-	rom ( name "Picnic (Paddle) (1983) (Carrere Video, Tom Sloper - Teldec - Prism Micro Products) (USC2004) (PAL).bin" size 4096 crc c8bc1076 md5 undefined sha1 70f4e4b38d9d6b21824341386e71eb1c4a7e30f4 )
-)
-
-game (
-	name "Piece o' Cake (Bakery) (Paddle) (1982) (U.S. Games Corporation) (VC2005) ~"
-	description "Piece o' Cake (Bakery) (Paddle) (1982) (U.S. Games Corporation) (VC2005) ~"
-	rom ( name "Piece o' Cake (Bakery) (Paddle) (1982) (U.S. Games Corporation) (VC2005) ~.bin" size 4096 crc 40355166 md5 undefined sha1 57774193081acea010bd935a0449bc8f53157128 )
-)
-
-game (
-	name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (PAL)"
-	description "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (PAL)"
-	rom ( name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (PAL).bin" size 8192 crc 2adb9a1f md5 undefined sha1 aee08324bc209f39c14658980fee06343d0d8b63 )
-)
-
-game (
-	name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (Prototype)"
-	description "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (Prototype)"
-	rom ( name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) (Prototype).bin" size 8192 crc 86a5b934 md5 undefined sha1 21a614365d63ff101af2f9cc9cb5f819229ec8db )
-)
-
-game (
-	name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) ~"
-	description "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) ~"
-	rom ( name "Pigs in Space - Starring Miss Piggy (1983) (Atari, Bill Aspromonte, John Russell, Michael Sierchio, Robert Zdybel) (CX26114) ~.bin" size 8192 crc 27673d7c md5 undefined sha1 d08b30ca2e5e351cac3bd3fb760b87a1a30aa300 )
-)
-
-game (
-	name "Pimball (AKA Video Pinball) (1983) (CCE) (C-856)"
-	description "Pimball (AKA Video Pinball) (1983) (CCE) (C-856)"
-	rom ( name "Pimball (AKA Video Pinball) (1983) (CCE) (C-856).bin" size 4096 crc 65e077f1 md5 undefined sha1 cc14c61b6ab0877b1dd6a239cabff944f7f97755 )
-)
-
-game (
-	name "Pinball (AKA Video Pinball) (Zellers)"
-	description "Pinball (AKA Video Pinball) (Zellers)"
-	rom ( name "Pinball (AKA Video Pinball) (Zellers).bin" size 4096 crc 10d95426 md5 undefined sha1 2c16c1a6374c8e22275d152d93dd31ffba26271f )
-)
-
-game (
-	name "Pitfall (1983) (CCE) (C-813)"
-	description "Pitfall (1983) (CCE) (C-813)"
-	rom ( name "Pitfall (1983) (CCE) (C-813).bin" size 4096 crc 03cf3b2f md5 undefined sha1 936693951383eaaa710f938debd0f7701a909c6d )
-)
-
-game (
-	name "Pitfall (AKA Pitfall!) (1984) (Supergame) (32)"
-	description "Pitfall (AKA Pitfall!) (1984) (Supergame) (32)"
-	rom ( name "Pitfall (AKA Pitfall!) (1984) (Supergame) (32).bin" size 4096 crc ad2224e6 md5 undefined sha1 861196f2425b9374c1aba5703bc15b88241e066b )
-)
-
-game (
-	name "Pitfall (AKA Pitfall!) (Genus)"
-	description "Pitfall (AKA Pitfall!) (Genus)"
-	rom ( name "Pitfall (AKA Pitfall!) (Genus).bin" size 4096 crc 1fc7038f md5 undefined sha1 a0a548bc6cc9e6af1401c37d43783590b670ae1d )
-)
-
-game (
-	name "Pitfall (AKA Pitfall!) (Star Game) (012)"
-	description "Pitfall (AKA Pitfall!) (Star Game) (012)"
-	rom ( name "Pitfall (AKA Pitfall!) (Star Game) (012).bin" size 4096 crc 4e11f28d md5 undefined sha1 fd68866b59bc9ff2fdeba0cb92012bfcc044de32 )
-)
-
-game (
-	name "Pitfall II - Lost Caverns (1983) (Activision, David Crane - Ariola) (EAB-035-04 - 711 035-721) (PAL)"
-	description "Pitfall II - Lost Caverns (1983) (Activision, David Crane - Ariola) (EAB-035-04 - 711 035-721) (PAL)"
-	rom ( name "Pitfall II - Lost Caverns (1983) (Activision, David Crane - Ariola) (EAB-035-04 - 711 035-721) (PAL).bin" size 10495 crc f29cf61d md5 undefined sha1 3ee18a1be7155900c2a01a104563657254d3a9a9 )
-)
-
-game (
-	name "Pitfall II - Lost Caverns (1983) (Activision, David Crane) (AB-035-04) ~"
-	description "Pitfall II - Lost Caverns (1983) (Activision, David Crane) (AB-035-04) ~"
-	rom ( name "Pitfall II - Lost Caverns (1983) (Activision, David Crane) (AB-035-04) ~.bin" size 10495 crc 097ce7ad md5 undefined sha1 920cfbd517764ad3fa6a7425c031bd72dc7d927c )
-)
-
-game (
-	name "Pitfall II - Lost Caverns (1984) (Activision, David Crane) (AB-035-04) [a]"
-	description "Pitfall II - Lost Caverns (1984) (Activision, David Crane) (AB-035-04) [a]"
-	rom ( name "Pitfall II - Lost Caverns (1984) (Activision, David Crane) (AB-035-04) [a].bin" size 10495 crc 39918cae md5 undefined sha1 b307c24c4002a4a1138e44212095ba53e9463aab )
-)
-
-game (
-	name "Pitfall! - Abenteuer im Urwald (Jungle Runner) (1982) (Activision, David Crane - Ariola) (EAX-018, EAX-018-04B, EAX-018-04I - 711 018-725) (PAL)"
-	description "Pitfall! - Abenteuer im Urwald (Jungle Runner) (1982) (Activision, David Crane - Ariola) (EAX-018, EAX-018-04B, EAX-018-04I - 711 018-725) (PAL)"
-	rom ( name "Pitfall! - Abenteuer im Urwald (Jungle Runner) (1982) (Activision, David Crane - Ariola) (EAX-018, EAX-018-04B, EAX-018-04I - 711 018-725) (PAL).bin" size 4096 crc ff7841d2 md5 undefined sha1 d0ec08b88d032627701ad72337524d91b26c656b )
-)
-
-game (
-	name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1981) (Activision, David Crane) (AX-018, AX-018-04) (Prototype)"
-	description "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1981) (Activision, David Crane) (AX-018, AX-018-04) (Prototype)"
-	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1981) (Activision, David Crane) (AX-018, AX-018-04) (Prototype).bin" size 4096 crc 79c93300 md5 undefined sha1 fd79516f3db60978dc2645625ee028f5af76b637 )
-)
-
-game (
-	name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) (Prototype)"
-	description "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) (Prototype)"
-	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) (Prototype).bin" size 4096 crc 61e6f17a md5 undefined sha1 c084539ef888ef0ac8bde9e81cd497697ba2b42a )
-)
-
-game (
-	name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) ~"
-	description "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) ~"
-	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (Jungle Runner) (1982) (Activision, David Crane) (AX-018, AX-018-04) ~.bin" size 4096 crc 42ad47bf md5 undefined sha1 8d525480445d48cc48460dc666ebad78c8fb7b73 )
-)
-
-game (
-	name "Pitfall! - Pitfall Harry's Jungle Adventure (Unknown) (PAL)"
-	description "Pitfall! - Pitfall Harry's Jungle Adventure (Unknown) (PAL)"
-	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (Unknown) (PAL).bin" size 4096 crc 38630571 md5 undefined sha1 f1b5fd9eefd04eec2df9aca6d7ca514f9495ba4e )
-)
-
-game (
-	name "Pizza Chef - Pizza Time (1983) (ZiMAG - Emag - Vidco) (713-111 - GN-050) (Prototype) ~"
-	description "Pizza Chef - Pizza Time (1983) (ZiMAG - Emag - Vidco) (713-111 - GN-050) (Prototype) ~"
-	rom ( name "Pizza Chef - Pizza Time (1983) (ZiMAG - Emag - Vidco) (713-111 - GN-050) (Prototype) ~.bin" size 4096 crc a240f751 md5 undefined sha1 f8db484d454f518b21d9ff2f72ed188734d56ff6 )
-)
-
-game (
-	name "Pizza Chef (1983) (CCE) (C-837)"
-	description "Pizza Chef (1983) (CCE) (C-837)"
-	rom ( name "Pizza Chef (1983) (CCE) (C-837).bin" size 4096 crc b9a9264e md5 undefined sha1 dde913e815fce66f06883d9eb2bb75426e3cc448 )
-)
-
-game (
-	name "Planet of the Apes (1983) (20th Century Fox Video Games, John W.S. Marvin) (Prototype) ~"
-	description "Planet of the Apes (1983) (20th Century Fox Video Games, John W.S. Marvin) (Prototype) ~"
-	rom ( name "Planet of the Apes (1983) (20th Century Fox Video Games, John W.S. Marvin) (Prototype) ~.bin" size 4096 crc eea8b688 md5 undefined sha1 dcca30e4ae58c85a070f0c6cfaa4d27be2970d61 )
-)
-
-game (
-	name "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL)"
-	description "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL)"
-	rom ( name "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL).bin" size 4096 crc 86756f84 md5 undefined sha1 7f8d12b4b028eeba387516ad2fa14bf39114d58f )
-)
-
-game (
-	name "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL) [different spaceship]"
-	description "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL) [different spaceship]"
-	rom ( name "Planet Patrol - Planeten Patrouilie (1982) (Spectravision, Spectravideo - Quelle) (SA-202 - 412.851 8) (PAL) [different spaceship].bin" size 4096 crc 92cf5728 md5 undefined sha1 9f2bdc53ef1b9242270059f990448a3b8ddd1826 )
-)
-
-game (
-	name "Planet Patrol (1982) (Play Video) (PAL)"
-	description "Planet Patrol (1982) (Play Video) (PAL)"
-	rom ( name "Planet Patrol (1982) (Play Video) (PAL).bin" size 4096 crc 9f20eeca md5 undefined sha1 71cc0b3055cb59cb37c9865e24eceb34998f44b2 )
-)
-
-game (
-	name "Planet Patrol (1982) (Spectravision, Spectravideo) (SA-202) ~"
-	description "Planet Patrol (1982) (Spectravision, Spectravideo) (SA-202) ~"
-	rom ( name "Planet Patrol (1982) (Spectravision, Spectravideo) (SA-202) ~.bin" size 4096 crc 1e8ebb51 md5 undefined sha1 ccfcbf52815a441158977292b719f7c5ed80c515 )
-)
-
-game (
-	name "Planet Patrol (1983) (CCE) (C-830)"
-	description "Planet Patrol (1983) (CCE) (C-830)"
-	rom ( name "Planet Patrol (1983) (CCE) (C-830).bin" size 4096 crc 367e9416 md5 undefined sha1 9b36e9aa76285238ba76fa6cce8aacc52b5ebcc9 )
-)
-
-game (
-	name "Planet Patrol (1983) (CCE) (C-830) [a]"
-	description "Planet Patrol (1983) (CCE) (C-830) [a]"
-	rom ( name "Planet Patrol (1983) (CCE) (C-830) [a].bin" size 4096 crc 06cb648f md5 undefined sha1 8cc96916d62bc5fd72d127d91b953bb6f3aa1359 )
-)
-
-game (
-	name "Planet Patrol (Unknown) (PAL)"
-	description "Planet Patrol (Unknown) (PAL)"
-	rom ( name "Planet Patrol (Unknown) (PAL).bin" size 4096 crc 6fb4dff1 md5 undefined sha1 21fd64e570fc555e9660754f1322a1e8e1e092ca )
-)
-
-game (
-	name "Plaque Attack - Schutzt Eure Zaehne (1983) (Activision, Steve Cartwright - Ariola) (EAX-027 - 711 027-722) (PAL)"
-	description "Plaque Attack - Schutzt Eure Zaehne (1983) (Activision, Steve Cartwright - Ariola) (EAX-027 - 711 027-722) (PAL)"
-	rom ( name "Plaque Attack - Schutzt Eure Zaehne (1983) (Activision, Steve Cartwright - Ariola) (EAX-027 - 711 027-722) (PAL).bin" size 4096 crc 1575f38d md5 undefined sha1 1654024a417d1e8286d6e8aa5d4f85c1e6a54779 )
-)
-
-game (
-	name "Plaque Attack (1983) (Activision, Steve Cartwright) (AX-027) ~"
-	description "Plaque Attack (1983) (Activision, Steve Cartwright) (AX-027) ~"
-	rom ( name "Plaque Attack (1983) (Activision, Steve Cartwright) (AX-027) ~.bin" size 4096 crc d5a5eb9e md5 undefined sha1 103398dd35ebd39450c5cac760fa332aac3f9458 )
-)
-
-game (
-	name "Plaque Attack (1983) (Dynacom)"
-	description "Plaque Attack (1983) (Dynacom)"
-	rom ( name "Plaque Attack (1983) (Dynacom).bin" size 4096 crc 67b613a1 md5 undefined sha1 dbcdad8d400a14f05e66a9d75cd3414fc80cc357 )
-)
-
-game (
-	name "Plaque Attack (CCE)"
-	description "Plaque Attack (CCE)"
-	rom ( name "Plaque Attack (CCE).bin" size 4096 crc 10e1dee7 md5 undefined sha1 5948e4171eeaba36081ddcc048ed7450889b991b )
-)
-
-game (
-	name "Plaque Attack (Digivision)"
-	description "Plaque Attack (Digivision)"
-	rom ( name "Plaque Attack (Digivision).bin" size 4096 crc e66adf82 md5 undefined sha1 5095718c7abac1021f51912ffef2488657685040 )
-)
-
-game (
-	name "Plaque Attack (Unknown) (PAL)"
-	description "Plaque Attack (Unknown) (PAL)"
-	rom ( name "Plaque Attack (Unknown) (PAL).bin" size 4096 crc bc9ab994 md5 undefined sha1 d826a15e2e35702c0dc3dffea06f1bee4605cdbf )
-)
-
-game (
-	name "PlayAround Demo (1982) (PlayAround - J.H.M.)"
-	description "PlayAround Demo (1982) (PlayAround - J.H.M.)"
-	rom ( name "PlayAround Demo (1982) (PlayAround - J.H.M.).bin" size 4096 crc d6def82d md5 undefined sha1 02104ffafb6d37dc60833ba42ff48d787cee550f )
-)
-
-game (
-	name "Pleiades (1983) (UA Limited) (Prototype) ~"
-	description "Pleiades (1983) (UA Limited) (Prototype) ~"
-	rom ( name "Pleiades (1983) (UA Limited) (Prototype) ~.bin" size 8192 crc 35589cec md5 undefined sha1 63c12146c183bccbf05c0044a961dc40790e3212 )
-)
-
-game (
-	name "Plug Attack (AKA Plaque Attack) (Funvision - Fund. International Co.)"
-	description "Plug Attack (AKA Plaque Attack) (Funvision - Fund. International Co.)"
-	rom ( name "Plug Attack (AKA Plaque Attack) (Funvision - Fund. International Co.).bin" size 4096 crc 7b9d4c75 md5 undefined sha1 aa9fcb52cda74e69bf2b990e256c54c426c5e216 )
-)
-
-game (
-	name "Polaris (02-17-1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype) (4K)"
-	description "Polaris (02-17-1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype) (4K)"
-	rom ( name "Polaris (02-17-1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype) (4K).bin" size 4096 crc a3caf6e3 md5 undefined sha1 f17f83aa4141daa4bc0c0150469a7982871c0ebb )
-)
-
-game (
-	name "Polaris (1983) (Tigervision, Robert H. O'Neil - Teldec) (7-007 - 3.60005 VG) (PAL)"
-	description "Polaris (1983) (Tigervision, Robert H. O'Neil - Teldec) (7-007 - 3.60005 VG) (PAL)"
-	rom ( name "Polaris (1983) (Tigervision, Robert H. O'Neil - Teldec) (7-007 - 3.60005 VG) (PAL).bin" size 8192 crc db376663 md5 undefined sha1 2410931a8a18b915993b6982fbabab0f437967a4 )
-)
-
-game (
-	name "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype)"
-	description "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype)"
-	rom ( name "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) (Prototype).bin" size 8192 crc acf49e9b md5 undefined sha1 8727630ca840dd7643bfc5762a6f597194ecdda3 )
-)
-
-game (
-	name "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) ~"
-	description "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) ~"
-	rom ( name "Polaris (1983) (Tigervision, Robert H. O'Neil) (7-007) ~.bin" size 8192 crc 25b78f89 md5 undefined sha1 b76ab69118b579ca0acbbb8ebe8003eed5cbcb4a )
-)
-
-game (
-	name "Pole Position (1983) (CCE) (C-1002)"
-	description "Pole Position (1983) (CCE) (C-1002)"
-	rom ( name "Pole Position (1983) (CCE) (C-1002).bin" size 8192 crc 7852d5b4 md5 undefined sha1 9afdc3b6756aaf60e4949f414037239c7a4f7fd1 )
-)
-
-game (
-	name "Pole Position (RealSports Driving) (05-15-1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) (Prototype)"
-	description "Pole Position (RealSports Driving) (05-15-1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) (Prototype)"
-	rom ( name "Pole Position (RealSports Driving) (05-15-1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) (Prototype).bin" size 8192 crc d16f2a66 md5 undefined sha1 4665c45c83bb64289b35782c3b59afed5ec2150c )
-)
-
-game (
-	name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694, CX2694P) (PAL)"
-	description "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694, CX2694P) (PAL)"
-	rom ( name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694, CX2694P) (PAL).bin" size 8192 crc a2a5b071 md5 undefined sha1 bf89876abac4fa300ed6862a0ae87a6c5fe84c13 )
-)
-
-game (
-	name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) [a]"
-	description "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) [a]"
-	rom ( name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) [a].bin" size 8192 crc a0eb1b3b md5 undefined sha1 9d334da07352a9399cbbd9b41c6923232d0cdcd3 )
-)
-
-game (
-	name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) ~"
-	description "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) ~"
-	rom ( name "Pole Position (RealSports Driving) (1983) (Atari - GCC, Betty Ryan Tylko, Douglas B. Macrae) (CX2694) ~.bin" size 8192 crc bd822518 md5 undefined sha1 b7122f478a343cffac17b765e9642893587e99a1 )
-)
-
-game (
-	name "Pole Position (Tron)"
-	description "Pole Position (Tron)"
-	rom ( name "Pole Position (Tron).bin" size 8192 crc 44567b43 md5 undefined sha1 e981b07a3bbce3ea187c7fd21bf4b8bea0630785 )
-)
-
-game (
-	name "Polo (1978) (Atari, Carol Shaw - Ralph Lauren) (Prototype) ~"
-	description "Polo (1978) (Atari, Carol Shaw - Ralph Lauren) (Prototype) ~"
-	rom ( name "Polo (1978) (Atari, Carol Shaw - Ralph Lauren) (Prototype) ~.bin" size 2048 crc 8c0b57d9 md5 undefined sha1 c0af0188028cd899c49ba18f52bd1678e573bff2 )
-)
-
-game (
-	name "Pompeii (Labyrinth, Lavarinth) (1983) (Apollo) (AP-2011) (Prototype) ~"
-	description "Pompeii (Labyrinth, Lavarinth) (1983) (Apollo) (AP-2011) (Prototype) ~"
-	rom ( name "Pompeii (Labyrinth, Lavarinth) (1983) (Apollo) (AP-2011) (Prototype) ~.bin" size 4096 crc 83d8a362 md5 undefined sha1 954d2980ea8f8d9a76921612c378889f24c35639 )
-)
-
-game (
-	name "Pooyan (1983) (Gakken) (001) (PAL)"
-	description "Pooyan (1983) (Gakken) (001) (PAL)"
-	rom ( name "Pooyan (1983) (Gakken) (001) (PAL).bin" size 4096 crc fc141c20 md5 undefined sha1 9885ca8f3b5612cbbc7749a32194425ba47b7ccf )
-)
-
-game (
-	name "Pooyan (1983) (Konami) (RC 100-X 02) ~"
-	description "Pooyan (1983) (Konami) (RC 100-X 02) ~"
-	rom ( name "Pooyan (1983) (Konami) (RC 100-X 02) ~.bin" size 4096 crc fe24be60 md5 undefined sha1 b7a002025c24ab2ec4a03f62212db7b96c0e5ffd )
-)
-
-game (
-	name "Pooyan (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Pooyan (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Pooyan (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 81a8b4b8 md5 undefined sha1 76009fdfc681a04cb98f6bf021cdfee23f7319ae )
-)
-
-game (
-	name "Pooyan (Unknown) (PAL)"
-	description "Pooyan (Unknown) (PAL)"
-	rom ( name "Pooyan (Unknown) (PAL).bin" size 4096 crc 1b0f5ba3 md5 undefined sha1 ff12127cdfef5ce33f6f5593c3df8201ebecd2e4 )
-)
-
-game (
-	name "Popeye (1983) (Parker Brothers, Joe Gaucher) (931519) (PAL)"
-	description "Popeye (1983) (Parker Brothers, Joe Gaucher) (931519) (PAL)"
-	rom ( name "Popeye (1983) (Parker Brothers, Joe Gaucher) (931519) (PAL).bin" size 8192 crc 742ac749 md5 undefined sha1 fbfca822962b623c3ac5a4585c8d0404b61d8ccf )
-)
-
-game (
-	name "Popeye (1983) (Parker Brothers, Joe Gaucher) (PB5370) ~"
-	description "Popeye (1983) (Parker Brothers, Joe Gaucher) (PB5370) ~"
-	rom ( name "Popeye (1983) (Parker Brothers, Joe Gaucher) (PB5370) ~.bin" size 8192 crc 7d287f20 md5 undefined sha1 1772a22df3e9a1f3842387ac63eeddff7f04b01c )
-)
-
-game (
-	name "Porky's (1983) (20th Century Fox - Lazer Micro Systems - Dunhill Electronic Media Corp., B. Winston Hendrickson, Randall Hyde, Mark V. Rhoads, John Simonds) (11013) ~"
-	description "Porky's (1983) (20th Century Fox - Lazer Micro Systems - Dunhill Electronic Media Corp., B. Winston Hendrickson, Randall Hyde, Mark V. Rhoads, John Simonds) (11013) ~"
-	rom ( name "Porky's (1983) (20th Century Fox - Lazer Micro Systems - Dunhill Electronic Media Corp., B. Winston Hendrickson, Randall Hyde, Mark V. Rhoads, John Simonds) (11013) ~.bin" size 8192 crc add0b98a md5 undefined sha1 70afc2cc870be546dc976fa0c6811f7e01ebc471 )
-)
-
-game (
-	name "Power Play Arcade Video Game Album IV - Atlantis, Cosmic Ark, Dragonfire (1984) (Amiga) (1125) (Prototype)"
-	description "Power Play Arcade Video Game Album IV - Atlantis, Cosmic Ark, Dragonfire (1984) (Amiga) (1125) (Prototype)"
-	rom ( name "Power Play Arcade Video Game Album IV - Atlantis, Cosmic Ark, Dragonfire (1984) (Amiga) (1125) (Prototype).bin" size 4096 crc b1b8f394 md5 undefined sha1 1e29c850687eb5cd84cbab366608bd9a8016526f )
-)
-
-game (
-	name "Power Play Arcade Video Game Album V - Mogul Maniac, Surf's Up, Off Your Rocker, S.A.C. Alert (1984) (Amiga) (1130) (Prototype)"
-	description "Power Play Arcade Video Game Album V - Mogul Maniac, Surf's Up, Off Your Rocker, S.A.C. Alert (1984) (Amiga) (1130) (Prototype)"
-	rom ( name "Power Play Arcade Video Game Album V - Mogul Maniac, Surf's Up, Off Your Rocker, S.A.C. Alert (1984) (Amiga) (1130) (Prototype).bin" size 4096 crc 52e80388 md5 undefined sha1 4e7b436b3a6ceae7f968f3534147b315a8d3cd9d )
-)
-
-game (
-	name "Power Play Arcade Video Game Album, The - Ghost Attack, Genesis, Havoc (1983) (Amiga) (1110) (Prototype)"
-	description "Power Play Arcade Video Game Album, The - Ghost Attack, Genesis, Havoc (1983) (Amiga) (1110) (Prototype)"
-	rom ( name "Power Play Arcade Video Game Album, The - Ghost Attack, Genesis, Havoc (1983) (Amiga) (1110) (Prototype).bin" size 16384 crc fbbb6c71 md5 undefined sha1 aabbbc5583e2878bf11177978b07c232368f3b32 )
-)
-
-game (
-	name "Pressure Cooker (1983) (Activision, Garry Kitchen - Ariola) (EAZ-032 - 771 032-712) (PAL)"
-	description "Pressure Cooker (1983) (Activision, Garry Kitchen - Ariola) (EAZ-032 - 771 032-712) (PAL)"
-	rom ( name "Pressure Cooker (1983) (Activision, Garry Kitchen - Ariola) (EAZ-032 - 771 032-712) (PAL).bin" size 8192 crc 50aad095 md5 undefined sha1 8116d0ab3585caf1da042907c2a555112d033f49 )
-)
-
-game (
-	name "Pressure Cooker (1983) (Activision, Garry Kitchen) (AZ-032) ~"
-	description "Pressure Cooker (1983) (Activision, Garry Kitchen) (AZ-032) ~"
-	rom ( name "Pressure Cooker (1983) (Activision, Garry Kitchen) (AZ-032) ~.bin" size 8192 crc ccf597d8 md5 undefined sha1 8b001373be485060f88182e9a7afcf55b4d07a57 )
-)
-
-game (
-	name "Pressure Cooker (CCE)"
-	description "Pressure Cooker (CCE)"
-	rom ( name "Pressure Cooker (CCE).bin" size 8192 crc a0a671d9 md5 undefined sha1 bb4ebcb7a2528c5bebf7a9570cf3c20705307c43 )
-)
-
-game (
-	name "Private Eye (1983) (Activision, Bob Whitehead) (AG-034-04) ~"
-	description "Private Eye (1983) (Activision, Bob Whitehead) (AG-034-04) ~"
-	rom ( name "Private Eye (1983) (Activision, Bob Whitehead) (AG-034-04) ~.bin" size 8192 crc ea3bff1c md5 undefined sha1 1ea6bea907a6b5607c76f222730f812a99cd1015 )
-)
-
-game (
-	name "Private Eye (1983) (Activision, Bob Whitehead) (EAZ-034-04, EAZ-034-04I) (PAL)"
-	description "Private Eye (1983) (Activision, Bob Whitehead) (EAZ-034-04, EAZ-034-04I) (PAL)"
-	rom ( name "Private Eye (1983) (Activision, Bob Whitehead) (EAZ-034-04, EAZ-034-04I) (PAL).bin" size 8192 crc 7bdd9912 md5 undefined sha1 24ab03a51bdd113a9845132476045b73532224dd )
-)
-
-game (
-	name "Private Eye (CCE)"
-	description "Private Eye (CCE)"
-	rom ( name "Private Eye (CCE).bin" size 8192 crc a21ceceb md5 undefined sha1 c4de1af8468a8110894f4b080c66dcb452eb4deb )
-)
-
-game (
-	name "Pumuckl I (AKA Panda Chase) (1983) (ITT Family Games) (PAL)"
-	description "Pumuckl I (AKA Panda Chase) (1983) (ITT Family Games) (PAL)"
-	rom ( name "Pumuckl I (AKA Panda Chase) (1983) (ITT Family Games) (PAL).bin" size 4096 crc c1da05f6 md5 undefined sha1 feb6bd37e5d722bd080433587972b980afff5fa5 )
-)
-
-game (
-	name "Pygmy (AKA Lock 'n' Chase) (Double-Game Package) (1983) (Quelle) (311377) (PAL)"
-	description "Pygmy (AKA Lock 'n' Chase) (Double-Game Package) (1983) (Quelle) (311377) (PAL)"
-	rom ( name "Pygmy (AKA Lock 'n' Chase) (Double-Game Package) (1983) (Quelle) (311377) (PAL).bin" size 4096 crc 6f22448d md5 undefined sha1 fb0eee2a5c0b74eeaacbf4c714b20881c2f4d747 )
-)
-
-game (
-	name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL)"
-	description "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL)"
-	rom ( name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL).bin" size 4096 crc cd8a1463 md5 undefined sha1 863be051c1c55f611555d228b6e35fd24509b6a0 )
-)
-
-game (
-	name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a1]"
-	description "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a1]"
-	rom ( name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a1].bin" size 4096 crc 43a24f04 md5 undefined sha1 bc483097f94f2bf9c4d3366b3bd25200f2e2f22a )
-)
-
-game (
-	name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a2]"
-	description "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a2]"
-	rom ( name "Pyramid War (AKA Chopper Command) (Rainbow Vision - Suntek) (SS-004) (PAL) [a2].bin" size 4096 crc ce63ff9b md5 undefined sha1 962c9d8ff3a9a0e6607f159a926f6ef68125a28c )
-)
-
-game (
-	name "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (931517) (PAL)"
-	description "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (931517) (PAL)"
-	rom ( name "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (931517) (PAL).bin" size 4096 crc 541fbe98 md5 undefined sha1 e5d0f615fed46efca3cc931a1e5f7ebcce73d586 )
-)
-
-game (
-	name "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (PB5360) ~"
-	description "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (PB5360) ~"
-	rom ( name "Q-bert (1983) (Parker Brothers, Dave Hampton, Tom Sloper) (PB5360) ~.bin" size 4096 crc 54142e3e md5 undefined sha1 f3ef9787b4287a32e4d9ac7b9c3358edc16315b2 )
-)
-
-game (
-	name "Q-bert (1987) (Atari) (CX26150)"
-	description "Q-bert (1987) (Atari) (CX26150)"
-	rom ( name "Q-bert (1987) (Atari) (CX26150).bin" size 4096 crc 54142e3e md5 undefined sha1 f3ef9787b4287a32e4d9ac7b9c3358edc16315b2 )
-)
-
-game (
-	name "Q-bert (1987) (Atari) (CX26150P) (PAL)"
-	description "Q-bert (1987) (Atari) (CX26150P) (PAL)"
-	rom ( name "Q-bert (1987) (Atari) (CX26150P) (PAL).bin" size 4096 crc d605bb61 md5 undefined sha1 8bf36ec012a46f8f7b17cc41ea0afdf2fe00d191 )
-)
-
-game (
-	name "Q-bert (208 in 1) (Unknown) (PAL)"
-	description "Q-bert (208 in 1) (Unknown) (PAL)"
-	rom ( name "Q-bert (208 in 1) (Unknown) (PAL).bin" size 4096 crc 7d34c0dc md5 undefined sha1 91966f4ffd0004b12ba50b990c93b25b7ae95457 )
-)
-
-game (
-	name "Q-bert's Qubes (1984) (Parker Brothers, Todd Marshall) (PB5550) ~"
-	description "Q-bert's Qubes (1984) (Parker Brothers, Todd Marshall) (PB5550) ~"
-	rom ( name "Q-bert's Qubes (1984) (Parker Brothers, Todd Marshall) (PB5550) ~.bin" size 8192 crc d9f499c5 md5 undefined sha1 a61be3702437b5d16e19c0d2cd92393515d42f23 )
-)
-
-game (
-	name "Quadrun (12-06-1982) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype)"
-	description "Quadrun (12-06-1982) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype)"
-	rom ( name "Quadrun (12-06-1982) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype).bin" size 4096 crc 13f7be48 md5 undefined sha1 16ac573c825a22095930f49a29e0157a7e4bc90a )
-)
-
-game (
-	name "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype)"
-	description "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype)"
-	rom ( name "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) (Prototype).bin" size 8192 crc 35592d43 md5 undefined sha1 1e634a8733cbc50462d363562b80013343d2fac3 )
-)
-
-game (
-	name "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) ~"
-	description "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) ~"
-	rom ( name "Quadrun (1983) (Atari, Frank Hausman, Steve Woita) (CX2686) ~.bin" size 8192 crc 8d3c887b md5 undefined sha1 b8d6f508edbf713e52f0cbf235d5e17add2fbf2e )
-)
-
-game (
-	name "Quest for Quintana Roo (1984) (Sunrise Software) (1603) ~"
-	description "Quest for Quintana Roo (1984) (Sunrise Software) (1603) ~"
-	rom ( name "Quest for Quintana Roo (1984) (Sunrise Software) (1603) ~.bin" size 8192 crc f9f58dd3 md5 undefined sha1 d83c740d2968343e6401828d62f58be6aea8e858 )
-)
-
-game (
-	name "Quest for Quintana Roo (1989) (Telegames) (6057 A227)"
-	description "Quest for Quintana Roo (1989) (Telegames) (6057 A227)"
-	rom ( name "Quest for Quintana Roo (1989) (Telegames) (6057 A227).bin" size 8192 crc f9f58dd3 md5 undefined sha1 d83c740d2968343e6401828d62f58be6aea8e858 )
-)
-
-game (
-	name "Quest for Quintana Roo (1989) (Telegames) (6057 A227) (PAL)"
-	description "Quest for Quintana Roo (1989) (Telegames) (6057 A227) (PAL)"
-	rom ( name "Quest for Quintana Roo (1989) (Telegames) (6057 A227) (PAL).bin" size 8192 crc 929c8065 md5 undefined sha1 6c0b91852314b293f675c889e4cf547eb9497452 )
-)
-
-game (
-	name "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) ~"
-	description "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) ~"
-	rom ( name "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-1A, 03211) ~.bin" size 4096 crc 057440fe md5 undefined sha1 33a47f79610c4525802c9881f67ad1f3f8c1b55d )
-)
-
-game (
-	name "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-2A, 13211, EIX-004-04I) (PAL)"
-	description "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-2A, 13211, EIX-004-04I) (PAL)"
-	rom ( name "Quick Step! (Hop To It, Kwibble) (1983) (Imagic, Dave Johnson) (720119-2A, 13211, EIX-004-04I) (PAL).bin" size 4096 crc a8ebe2dc md5 undefined sha1 80875ea38c58c64e787fbf1c4b9948ad6625f2c9 )
-)
-
-game (
-	name "Rabbit Transit (08-29-1983) (Atari) (Prototype)"
-	description "Rabbit Transit (08-29-1983) (Atari) (Prototype)"
-	rom ( name "Rabbit Transit (08-29-1983) (Atari) (Prototype).bin" size 8192 crc dd1e5638 md5 undefined sha1 7bf945ea667e683ec24a4ed779e88bbe55dc4b26 )
-)
-
-game (
-	name "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) (PAL)"
-	description "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) (PAL)"
-	rom ( name "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) (PAL).bin" size 8448 crc ea7f9afd md5 undefined sha1 a55851ead48c5033a45fb3f1672341146e5b47d9 )
-)
-
-game (
-	name "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) ~"
-	description "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) ~"
-	rom ( name "Rabbit Transit (Hopalong Catastrophe) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104) ~.bin" size 8448 crc 517e5561 md5 undefined sha1 81654cbd6a7262ce0f1abc385ed9adc323a9b6a6 )
-)
-
-game (
-	name "Rabbit Transit (Hopalong Catastrophe) (Preview) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104)"
-	description "Rabbit Transit (Hopalong Catastrophe) (Preview) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104)"
-	rom ( name "Rabbit Transit (Hopalong Catastrophe) (Preview) (1983) (Starpath Corporation, Brian McGhie) (8) (AR-4104).bin" size 8448 crc ba955bb1 md5 undefined sha1 2271944cd9284b499a590cf9fca938560a741990 )
-)
-
-game (
-	name "Racer (1982) (Atari, Joe Gaucher) (Prototype) ~"
-	description "Racer (1982) (Atari, Joe Gaucher) (Prototype) ~"
-	rom ( name "Racer (1982) (Atari, Joe Gaucher) (Prototype) ~.bin" size 8192 crc 794ed26d md5 undefined sha1 1df83e0e89a97511ee91a5a9f376dffcfbad06a9 )
-)
-
-game (
-	name "Racing Car (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83124) (PAL) ~"
-	description "Racing Car (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83124) (PAL) ~"
-	rom ( name "Racing Car (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83124) (PAL) ~.bin" size 4096 crc 18954066 md5 undefined sha1 65bd036bffd90ae34baa3817fee6ea70c76478ac )
-)
-
-game (
-	name "Racing Car (Unknown)"
-	description "Racing Car (Unknown)"
-	rom ( name "Racing Car (Unknown).bin" size 4096 crc f78489b0 md5 undefined sha1 54aa264254d8dd6e237f3f62b6e9c9a21fcb4eb1 )
-)
-
-game (
-	name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) (PAL)"
-	description "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) (PAL)"
-	rom ( name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) (PAL).bin" size 4096 crc b93f52ba md5 undefined sha1 469556ff9efd24a6668fc0641fec3c2bad5855ae )
-)
-
-game (
-	name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) [a]"
-	description "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) [a]"
-	rom ( name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) [a].bin" size 4096 crc c685edd4 md5 undefined sha1 c3c85788124425c5ced7812e4812e3e34b5ee3d6 )
-)
-
-game (
-	name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) ~"
-	description "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) ~"
-	rom ( name "Racquetball (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2003) ~.bin" size 4096 crc 7eef9ac0 md5 undefined sha1 4af6008152f1d38626d84016a7ef753406b48b46 )
-)
-
-game (
-	name "Racquetball (Unknown)"
-	description "Racquetball (Unknown)"
-	rom ( name "Racquetball (Unknown).bin" size 4096 crc 35247351 md5 undefined sha1 020c1ec75358b86dea92e61e7ed75e343d68188a )
-)
-
-game (
-	name "Racquetball (Unknown) (PAL)"
-	description "Racquetball (Unknown) (PAL)"
-	rom ( name "Racquetball (Unknown) (PAL).bin" size 4096 crc 5c071f26 md5 undefined sha1 52a9331b04e47ee8d9ccc4653955a1b631dc4a15 )
-)
-
-game (
-	name "Rad Action Pak - Kung-Fu Master, Freeway, Frostbite (1990) (HES - Activision) (559) (PAL)"
-	description "Rad Action Pak - Kung-Fu Master, Freeway, Frostbite (1990) (HES - Activision) (559) (PAL)"
-	rom ( name "Rad Action Pak - Kung-Fu Master, Freeway, Frostbite (1990) (HES - Activision) (559) (PAL).bin" size 16384 crc 47c8c308 md5 undefined sha1 f00d108e7f1c7716e8ebee9201599f82103b52ff )
-)
-
-game (
-	name "Radar (AKA Exocet) (1983) (CCE) (C-867)"
-	description "Radar (AKA Exocet) (1983) (CCE) (C-867)"
-	rom ( name "Radar (AKA Exocet) (1983) (CCE) (C-867).bin" size 4096 crc 7efdcaf1 md5 undefined sha1 ff77ba2cee629de526fc9a0cc6d5cbcb5eedbf34 )
-)
-
-game (
-	name "Radar (AKA Exocet) (Zellers)"
-	description "Radar (AKA Exocet) (Zellers)"
-	rom ( name "Radar (AKA Exocet) (Zellers).bin" size 4096 crc 5161a246 md5 undefined sha1 5f1f2b5b407b0624b59409e02060a3a9e8eed8fc )
-)
-
-game (
-	name "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) (PAL)"
-	description "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) (PAL)"
-	rom ( name "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) (PAL).bin" size 16384 crc d7c72da0 md5 undefined sha1 cb36828a2a23eaf8d736af4790ffd7e948ebbf1e )
-)
-
-game (
-	name "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) ~"
-	description "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) ~"
-	rom ( name "Radar Lock (Dog Fight) (1989) (Atari, Douglas Neubauer) (CX26176) ~.bin" size 16384 crc c29f7285 md5 undefined sha1 33f016c941fab01e1e2d0d7ba7930e3bcd8feaa3 )
-)
-
-game (
-	name "Raft Rider (1982) (U.S. Games Corporation, Dave Hampton) (VC2006) ~"
-	description "Raft Rider (1982) (U.S. Games Corporation, Dave Hampton) (VC2006) ~"
-	rom ( name "Raft Rider (1982) (U.S. Games Corporation, Dave Hampton) (VC2006) ~.bin" size 4096 crc 3d1292f8 md5 undefined sha1 a79f6e0f4fd76878e5c3ba6b52d17e88acdbe9f6 )
-)
-
-game (
-	name "Raft Rider (208 in 1) (Unknown) (PAL)"
-	description "Raft Rider (208 in 1) (Unknown) (PAL)"
-	rom ( name "Raft Rider (208 in 1) (Unknown) (PAL).bin" size 4096 crc da081db8 md5 undefined sha1 113c174166edc2e942f56975a1187ee7e417910f )
-)
-
-game (
-	name "Raft Rider (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Raft Rider (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Raft Rider (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 9910496c md5 undefined sha1 0f3fe01728da33f177c447e3b5462eb5c72de3a8 )
-)
-
-game (
-	name "Raiders of the Lost Ark (06-14-82) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (Prototype)"
-	description "Raiders of the Lost Ark (06-14-82) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (Prototype)"
-	rom ( name "Raiders of the Lost Ark (06-14-82) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (Prototype).bin" size 8192 crc 39af5048 md5 undefined sha1 e432cd6cf106ec686a661e80380ffc8bf1380871 )
-)
-
-game (
-	name "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (PAL)"
-	description "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (PAL)"
-	rom ( name "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) (PAL).bin" size 8192 crc 61110158 md5 undefined sha1 66803476a70a527741a35637b99bae3b7d20d00b )
-)
-
-game (
-	name "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) ~"
-	description "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) ~"
-	rom ( name "Raiders of the Lost Ark (1982) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX2659) ~.bin" size 8192 crc e05fe273 md5 undefined sha1 7ae70783969709318e56f189cf03da92320a6aba )
-)
-
-game (
-	name "Raketen-Angriff (AKA Missile Control) (Videospielkassette - Ariola) (PGP236) (PAL)"
-	description "Raketen-Angriff (AKA Missile Control) (Videospielkassette - Ariola) (PGP236) (PAL)"
-	rom ( name "Raketen-Angriff (AKA Missile Control) (Videospielkassette - Ariola) (PGP236) (PAL).bin" size 4096 crc 3d0720d0 md5 undefined sha1 55dba8cf66d8e63f95f8be68981feba832bdc0eb )
-)
-
-game (
-	name "Ram It (1982) (Telesys, Jim Rupp) (1004) (PAL)"
-	description "Ram It (1982) (Telesys, Jim Rupp) (1004) (PAL)"
-	rom ( name "Ram It (1982) (Telesys, Jim Rupp) (1004) (PAL).bin" size 4096 crc dacd41f7 md5 undefined sha1 55bdd45c7dbb956e549d192bd4df383bdadef49b )
-)
-
-game (
-	name "Ram It (1982) (Telesys, Jim Rupp) (1004) ~"
-	description "Ram It (1982) (Telesys, Jim Rupp) (1004) ~"
-	rom ( name "Ram It (1982) (Telesys, Jim Rupp) (1004) ~.bin" size 4096 crc 582d5b62 md5 undefined sha1 fd0a69c06eb3f7c9328951c890644f93c4bad6ad )
-)
-
-game (
-	name "Ram It (Unknown) (PAL)"
-	description "Ram It (Unknown) (PAL)"
-	rom ( name "Ram It (Unknown) (PAL).bin" size 4096 crc 4a4dee43 md5 undefined sha1 82671f284684e570bd8ce18ef7271df77c475652 )
-)
-
-game (
-	name "Rampage! (1989) (Activision, Robert C. Polaro) (AK-049-04) ~"
-	description "Rampage! (1989) (Activision, Robert C. Polaro) (AK-049-04) ~"
-	rom ( name "Rampage! (1989) (Activision, Robert C. Polaro) (AK-049-04) ~.bin" size 16384 crc f0b446ac md5 undefined sha1 7bb7df255829d5fbbee0d944915e50f89a5e7075 )
-)
-
-game (
-	name "Rampage! (1989) (Activision, Robert C. Polaro) (EAK-049-04B) (PAL)"
-	description "Rampage! (1989) (Activision, Robert C. Polaro) (EAK-049-04B) (PAL)"
-	rom ( name "Rampage! (1989) (Activision, Robert C. Polaro) (EAK-049-04B) (PAL).bin" size 16384 crc 5b2c2f22 md5 undefined sha1 c42f6da3aa0c8b5db68dd25ac5d6aa56d59baf48 )
-)
-
-game (
-	name "Raumbasen-Attacke - Base Attack (1983) (Quelle) (732.074 0 - 781778) (PAL)"
-	description "Raumbasen-Attacke - Base Attack (1983) (Quelle) (732.074 0 - 781778) (PAL)"
-	rom ( name "Raumbasen-Attacke - Base Attack (1983) (Quelle) (732.074 0 - 781778) (PAL).bin" size 4096 crc 81f1e5dd md5 undefined sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
-)
-
-game (
-	name "Raumpatrouille (AKA X'Mission) (1983) (Quelle) (731.064 2) (PAL)"
-	description "Raumpatrouille (AKA X'Mission) (1983) (Quelle) (731.064 2) (PAL)"
-	rom ( name "Raumpatrouille (AKA X'Mission) (1983) (Quelle) (731.064 2) (PAL).bin" size 4096 crc 3dfee54b md5 undefined sha1 d68d9ffcb6db02ea0e9299192f548e3d6594c0f3 )
-)
-
-game (
-	name "Reactor (1982) (Parker Brothers, Charlie Heath) (931506) (PAL)"
-	description "Reactor (1982) (Parker Brothers, Charlie Heath) (931506) (PAL)"
-	rom ( name "Reactor (1982) (Parker Brothers, Charlie Heath) (931506) (PAL).bin" size 4096 crc d4f33bc9 md5 undefined sha1 14ae88f28293aa4e6325b414f6b6d3d9c96cf062 )
-)
-
-game (
-	name "Reactor (1982) (Parker Brothers, Charlie Heath) (PB5330) ~"
-	description "Reactor (1982) (Parker Brothers, Charlie Heath) (PB5330) ~"
-	rom ( name "Reactor (1982) (Parker Brothers, Charlie Heath) (PB5330) ~.bin" size 4096 crc 1619e222 md5 undefined sha1 5adf9b530321472380ebceb2539de2ffbb0310bc )
-)
-
-game (
-	name "RealSports Baseball (07-09-1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype)"
-	description "RealSports Baseball (07-09-1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype)"
-	rom ( name "RealSports Baseball (07-09-1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype).bin" size 8192 crc 1257afde md5 undefined sha1 3a43e03969b01559d424a5d4a7f78dc96799c037 )
-)
-
-game (
-	name "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype)"
-	description "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype)"
-	rom ( name "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) (Prototype).bin" size 8192 crc 2e585d2f md5 undefined sha1 e9b06b567ddf802306d5c83b89d3da802ef2e16f )
-)
-
-game (
-	name "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) ~"
-	description "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) ~"
-	rom ( name "RealSports Baseball (1982) (Atari, Eric Manghise, Joseph Tung) (CX2640) ~.bin" size 8192 crc 3c5a1b5f md5 undefined sha1 ace97b89b8b6ab947434dbfd263951c6c0b349ac )
-)
-
-game (
-	name "RealSports Basketball (1983) (Atari, Joe Gaucher) (CX2679) (Prototype) (PAL) ~"
-	description "RealSports Basketball (1983) (Atari, Joe Gaucher) (CX2679) (Prototype) (PAL) ~"
-	rom ( name "RealSports Basketball (1983) (Atari, Joe Gaucher) (CX2679) (Prototype) (PAL) ~.bin" size 8192 crc 364feaa6 md5 undefined sha1 bc2e6bdaa950bc06be040899dfeb9ad0938f4e98 )
-)
-
-game (
-	name "RealSports Boxing (1987) (Atari) (CX26135, CX26135P) (PAL)"
-	description "RealSports Boxing (1987) (Atari) (CX26135, CX26135P) (PAL)"
-	rom ( name "RealSports Boxing (1987) (Atari) (CX26135, CX26135P) (PAL).bin" size 16384 crc 36f5b4bb md5 undefined sha1 6b940d543284c6837a31eaa328ca458cc77c1a73 )
-)
-
-game (
-	name "RealSports Boxing (1987) (Atari) (CX26135) ~"
-	description "RealSports Boxing (1987) (Atari) (CX26135) ~"
-	rom ( name "RealSports Boxing (1987) (Atari) (CX26135) ~.bin" size 16384 crc 3398a1b2 md5 undefined sha1 22dedbfce6cc9055a6c4caec013ca80200e51971 )
-)
-
-game (
-	name "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) (Prototype)"
-	description "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) (Prototype)"
-	rom ( name "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) (Prototype).bin" size 8192 crc d5e2141d md5 undefined sha1 0028d8cf46c4205f665ca05ad115c1a54a85aa9f )
-)
-
-game (
-	name "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) ~"
-	description "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) ~"
-	rom ( name "RealSports Football (Football II) (1982) (Atari, Alan J. Murphy, Robert Zdybel) (CX2668) ~.bin" size 8192 crc f89f64ef md5 undefined sha1 200d04c1e7f41a5a3730287ed0c3f9293628f195 )
-)
-
-game (
-	name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667, CX2667P) (PAL)"
-	description "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667, CX2667P) (PAL)"
-	rom ( name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667, CX2667P) (PAL).bin" size 8192 crc eb790199 md5 undefined sha1 f7d34f0278a7500d43252067adae529a751aed9d )
-)
-
-game (
-	name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) (Prototype)"
-	description "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) (Prototype)"
-	rom ( name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) (Prototype).bin" size 8192 crc 94ecfbe7 md5 undefined sha1 d7f2e53deb3fc4d2f8d819ccf0fbfd7f510fdbee )
-)
-
-game (
-	name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) [no opening tune] ~"
-	description "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) [no opening tune] ~"
-	rom ( name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) [no opening tune] ~.bin" size 8192 crc 0cbaa09c md5 undefined sha1 9c88e0dbb287d27c0e2c32f6e85d829133bbe8a3 )
-)
-
-game (
-	name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) ~"
-	description "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) ~"
-	rom ( name "RealSports Soccer - Football - RealSports Soccer (1983) (Atari, Jerome Domurat, Michael Sierchio) (CX2667) ~.bin" size 8192 crc 02d89819 md5 undefined sha1 e3d964d918b7f2c420776acd3370ec1ee62744ea )
-)
-
-game (
-	name "RealSports Tennis (1982) (Atari - GCC) (CX2680) (Prototype)"
-	description "RealSports Tennis (1982) (Atari - GCC) (CX2680) (Prototype)"
-	rom ( name "RealSports Tennis (1982) (Atari - GCC) (CX2680) (Prototype).bin" size 8192 crc 6e65c077 md5 undefined sha1 ddb414770376332bb96bdd8b70e5ba68c3128aa7 )
-)
-
-game (
-	name "RealSports Tennis (1983) (Atari - GCC) (CX2680, CX2680P) (PAL)"
-	description "RealSports Tennis (1983) (Atari - GCC) (CX2680, CX2680P) (PAL)"
-	rom ( name "RealSports Tennis (1983) (Atari - GCC) (CX2680, CX2680P) (PAL).bin" size 8192 crc e4731615 md5 undefined sha1 0467559378cfba949be579cadaf2dead6e25a55c )
-)
-
-game (
-	name "RealSports Tennis (1983) (Atari - GCC) (CX2680) ~"
-	description "RealSports Tennis (1983) (Atari - GCC) (CX2680) ~"
-	rom ( name "RealSports Tennis (1983) (Atari - GCC) (CX2680) ~.bin" size 8192 crc 379001a0 md5 undefined sha1 702c1c7d985d0d22f935265bd284d1ed50df2527 )
-)
-
-game (
-	name "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666, CX2666P) (PAL)"
-	description "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666, CX2666P) (PAL)"
-	rom ( name "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666, CX2666P) (PAL).bin" size 4096 crc bcc23410 md5 undefined sha1 54417214ea1b885cfff771378373b9e7f92c81e2 )
-)
-
-game (
-	name "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666) ~"
-	description "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666) ~"
-	rom ( name "RealSports Volleyball (1982) (Atari, Jim Huether, Alan J. Murphy, Robert C. Polaro) (CX2666) ~.bin" size 4096 crc 54fc9eb2 md5 undefined sha1 2025e1d868595fad36e5d9e7384ffd24c206208d )
-)
-
-game (
-	name "Red Sea Crossing (1983) (Inspirational Video Concepts, Steve Shustack) (321430) ~"
-	description "Red Sea Crossing (1983) (Inspirational Video Concepts, Steve Shustack) (321430) ~"
-	rom ( name "Red Sea Crossing (1983) (Inspirational Video Concepts, Steve Shustack) (321430) ~.bin" size 4096 crc e81e232a md5 undefined sha1 dd92f67873d928e98cc4a2b279b90d7db8d50f5d )
-)
-
-game (
-	name "Red Vs. Blue - Football (RealSports Football Beta) (1981) (Atari, Tod Frye) (Prototype)"
-	description "Red Vs. Blue - Football (RealSports Football Beta) (1981) (Atari, Tod Frye) (Prototype)"
-	rom ( name "Red Vs. Blue - Football (RealSports Football Beta) (1981) (Atari, Tod Frye) (Prototype).bin" size 4096 crc 20b41fc2 md5 undefined sha1 76d2117698bc90cd5277fdc058a1abc2b37bd767 )
-)
-
-game (
-	name "Rescue Terra I (1982) (VentureVision, Dan Oliver) (VV2001) ~"
-	description "Rescue Terra I (1982) (VentureVision, Dan Oliver) (VV2001) ~"
-	rom ( name "Rescue Terra I (1982) (VentureVision, Dan Oliver) (VV2001) ~.bin" size 4096 crc a509ad53 md5 undefined sha1 94e94810bf6c72eee49157f9218c3c170b65c836 )
-)
-
-game (
-	name "Resgate Espacial (AKA Moonsweeper) (CCE)"
-	description "Resgate Espacial (AKA Moonsweeper) (CCE)"
-	rom ( name "Resgate Espacial (AKA Moonsweeper) (CCE).bin" size 8192 crc 0c139bb8 md5 undefined sha1 c29a06c2950c79ede34905de5dea27b12ef1f8bf )
-)
-
-game (
-	name "Revenge of the Beefsteak Tomatoes (Revenge of the Cherry Tomatoes) (1982) (20th Century Fox Video Games, John Russell) (11016) ~"
-	description "Revenge of the Beefsteak Tomatoes (Revenge of the Cherry Tomatoes) (1982) (20th Century Fox Video Games, John Russell) (11016) ~"
-	rom ( name "Revenge of the Beefsteak Tomatoes (Revenge of the Cherry Tomatoes) (1982) (20th Century Fox Video Games, John Russell) (11016) ~.bin" size 4096 crc 243a36df md5 undefined sha1 f8a9dd46f9bad232f74d1ee2671ccb26ea1b3029 )
-)
-
-game (
-	name "Reversi (AKA Othello) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Reversi (AKA Othello) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Reversi (AKA Othello) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 58e1f930 md5 undefined sha1 3073c74a375635946482f657d36719df1164444d )
-)
-
-game (
-	name "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-1A, IA3600) ~"
-	description "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-1A, IA3600) ~"
-	rom ( name "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-1A, IA3600) ~.bin" size 4096 crc 183a87e3 md5 undefined sha1 acb2430b4e6c72ce13f321d9d3a38986dc4768ef )
-)
-
-game (
-	name "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-2A, IA3600P, EIX-009-04I) (PAL)"
-	description "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-2A, IA3600P, EIX-009-04I) (PAL)"
-	rom ( name "Riddle of the Sphinx (1982) (Imagic, Rob Fulop, Bob Smith) (720106-2A, IA3600P, EIX-009-04I) (PAL).bin" size 4096 crc e9e19a63 md5 undefined sha1 c2bea678daa236d3f0e79b5176607cc00a83c655 )
-)
-
-game (
-	name "River Patrol (1984) (Tigervision) (7-004) ~"
-	description "River Patrol (1984) (Tigervision) (7-004) ~"
-	rom ( name "River Patrol (1984) (Tigervision) (7-004) ~.bin" size 8192 crc c820bd75 md5 undefined sha1 6715493dce54b22362741229078815b3360988ae )
-)
-
-game (
-	name "River Raid - Jagdflieger (1982) (Activision, Carol Shaw - Ariola) (EAX-020, EAX-020-04B, EAX-020-04I - 711 020-720) (PAL)"
-	description "River Raid - Jagdflieger (1982) (Activision, Carol Shaw - Ariola) (EAX-020, EAX-020-04B, EAX-020-04I - 711 020-720) (PAL)"
-	rom ( name "River Raid - Jagdflieger (1982) (Activision, Carol Shaw - Ariola) (EAX-020, EAX-020-04B, EAX-020-04I - 711 020-720) (PAL).bin" size 4096 crc 6efb4ac1 md5 undefined sha1 c52435a42ab03ee2bf9474face24516707d29153 )
-)
-
-game (
-	name "River Raid (1982) (Activision, Carol Shaw) (AX-020, AX-020-04) ~"
-	description "River Raid (1982) (Activision, Carol Shaw) (AX-020, AX-020-04) ~"
-	rom ( name "River Raid (1982) (Activision, Carol Shaw) (AX-020, AX-020-04) ~.bin" size 4096 crc c3eb7e1e md5 undefined sha1 40329780402f8247f294fe884ffc56cc3da0c62d )
-)
-
-game (
-	name "River Raid (1983) (CCE) (C-811)"
-	description "River Raid (1983) (CCE) (C-811)"
-	rom ( name "River Raid (1983) (CCE) (C-811).bin" size 4096 crc 1c52f71c md5 undefined sha1 bfa069c5ad45990c70abf81dfb43e692d1414b59 )
-)
-
-game (
-	name "River Raid (1983) (CCE) (C-811) [a]"
-	description "River Raid (1983) (CCE) (C-811) [a]"
-	rom ( name "River Raid (1983) (CCE) (C-811) [a].bin" size 4096 crc b5a828c1 md5 undefined sha1 c1099ca7465ff617c6aa0e7ce4b0f5058bcaf1fb )
-)
-
-game (
-	name "River Raid (1983) (Digitel)"
-	description "River Raid (1983) (Digitel)"
-	rom ( name "River Raid (1983) (Digitel).bin" size 4096 crc 09e99415 md5 undefined sha1 0d73d308c8227ec46e43ad5b078a5a27abce2d66 )
-)
-
-game (
-	name "River Raid (1984) (Galaga Games)"
-	description "River Raid (1984) (Galaga Games)"
-	rom ( name "River Raid (1984) (Galaga Games).bin" size 4096 crc 32c189d5 md5 undefined sha1 325a2374800b2cb78ab7ff9e4017759865109d7d )
-)
-
-game (
-	name "River Raid (1984) (Galaga Games) (PAL)"
-	description "River Raid (1984) (Galaga Games) (PAL)"
-	rom ( name "River Raid (1984) (Galaga Games) (PAL).bin" size 4096 crc 760d3095 md5 undefined sha1 8ba7177acde6ab99c0c62e231700e1a7495eaac2 )
-)
-
-game (
-	name "River Raid (1984) (Supergame) (71)"
-	description "River Raid (1984) (Supergame) (71)"
-	rom ( name "River Raid (1984) (Supergame) (71).bin" size 4096 crc 64955e0d md5 undefined sha1 98b946bf70280f71910127d238643ee8c567f204 )
-)
-
-game (
-	name "River Raid (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "River Raid (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "River Raid (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc abab7375 md5 undefined sha1 491e994a89570be641f5bd80a6e578273d090367 )
-)
-
-game (
-	name "River Raid (Canal 3 - Intellivision)"
-	description "River Raid (Canal 3 - Intellivision)"
-	rom ( name "River Raid (Canal 3 - Intellivision).bin" size 4096 crc c3488de2 md5 undefined sha1 0ddf0ed5cc817d899c3a80f1f7ea428494c1e996 )
-)
-
-game (
-	name "River Raid (Digivision)"
-	description "River Raid (Digivision)"
-	rom ( name "River Raid (Digivision).bin" size 4096 crc 7596cd51 md5 undefined sha1 1b6983d1973438705597fb1068aa72867faa4693 )
-)
-
-game (
-	name "River Raid (Genus)"
-	description "River Raid (Genus)"
-	rom ( name "River Raid (Genus).bin" size 4096 crc e5ef464c md5 undefined sha1 23e0a668ffdac0329bb60800d9593a0a35621930 )
-)
-
-game (
-	name "River Raid (Hack) (208 in 1) (Unknown) (PAL)"
-	description "River Raid (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "River Raid (Hack) (208 in 1) (Unknown) (PAL).bin" size 4096 crc 8ff1a5f1 md5 undefined sha1 96ae39e103fd46457b0da53074bdf16fee3704fc )
-)
-
-game (
-	name "River Raid (Hack) (208 in 1) (Unknown) (PAL) [a]"
-	description "River Raid (Hack) (208 in 1) (Unknown) (PAL) [a]"
-	rom ( name "River Raid (Hack) (208 in 1) (Unknown) (PAL) [a].bin" size 4096 crc b798275e md5 undefined sha1 776a306788e1aeb5496454f493db15c2018feba9 )
-)
-
-game (
-	name "River Raid (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "River Raid (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "River Raid (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc e7529cb9 md5 undefined sha1 d3355b6ebc0885494cd6e6a1d9b67be9eaf34f26 )
-)
-
-game (
-	name "River Raid (Polyvox)"
-	description "River Raid (Polyvox)"
-	rom ( name "River Raid (Polyvox).bin" size 4096 crc 9aee6e8e md5 undefined sha1 2cc6c98442069bf32b00cc98b2ea156a4edfecb4 )
-)
-
-game (
-	name "River Raid (Robby) (18)"
-	description "River Raid (Robby) (18)"
-	rom ( name "River Raid (Robby) (18).bin" size 4096 crc 9a8c8ab7 md5 undefined sha1 b8f194cfa925624ab7fcaffd98bb7d724dca1dcf )
-)
-
-game (
-	name "River Raid (Star Game) (003)"
-	description "River Raid (Star Game) (003)"
-	rom ( name "River Raid (Star Game) (003).bin" size 4096 crc 818df711 md5 undefined sha1 1dc450ba42393a53f7d2ee30e359d20963ba12ca )
-)
-
-game (
-	name "River Raid (Unknown) (PAL)"
-	description "River Raid (Unknown) (PAL)"
-	rom ( name "River Raid (Unknown) (PAL).bin" size 4096 crc 8fba2025 md5 undefined sha1 e64002394de321ad03abc46e66f89725978ff72f )
-)
-
-game (
-	name "River Raid II (1988) (Activision, David Lubar) (AK-048-04) ~"
-	description "River Raid II (1988) (Activision, David Lubar) (AK-048-04) ~"
-	rom ( name "River Raid II (1988) (Activision, David Lubar) (AK-048-04) ~.bin" size 16384 crc 27d2df2c md5 undefined sha1 a08c3eae3368334c937a5e03329782e95f7b57c7 )
-)
-
-game (
-	name "River Raid II (1988) (Activision, David Lubar) (EAK-048-04, EAK-048-04B) (PAL)"
-	description "River Raid II (1988) (Activision, David Lubar) (EAK-048-04, EAK-048-04B) (PAL)"
-	rom ( name "River Raid II (1988) (Activision, David Lubar) (EAK-048-04, EAK-048-04B) (PAL).bin" size 16384 crc d9759ebc md5 undefined sha1 3b838681fc05276170c60e38fec1dec629cb0687 )
-)
-
-game (
-	name "River Raid II (AKA River Raid) (1985) (Digitel)"
-	description "River Raid II (AKA River Raid) (1985) (Digitel)"
-	rom ( name "River Raid II (AKA River Raid) (1985) (Digitel).bin" size 4096 crc 55682880 md5 undefined sha1 ba4c810f433e5a272e87c151b31a801cddcbf7c1 )
-)
-
-game (
-	name "River Raid II (AKA River Raid) (Digimax)"
-	description "River Raid II (AKA River Raid) (Digimax)"
-	rom ( name "River Raid II (AKA River Raid) (Digimax).bin" size 4096 crc 56763fff md5 undefined sha1 3ad6f465a192a7e693759c8da3379b2def530324 )
-)
-
-game (
-	name "River Raid II (AKA River Raid) (Supergame)"
-	description "River Raid II (AKA River Raid) (Supergame)"
-	rom ( name "River Raid II (AKA River Raid) (Supergame).bin" size 4096 crc 8c2ecc8c md5 undefined sha1 0aa80c4a8ff68b0c2d69b2dc85a0f13622d3209f )
-)
-
-game (
-	name "River Raid III (AKA River Raid) (1985) (Digitel)"
-	description "River Raid III (AKA River Raid) (1985) (Digitel)"
-	rom ( name "River Raid III (AKA River Raid) (1985) (Digitel).bin" size 4096 crc a8ff0490 md5 undefined sha1 cb1955c5552ce765b251b4c3ffbdec18d4c81ebb )
-)
-
-game (
-	name "River Raid III (AKA River Raid) (Supergame)"
-	description "River Raid III (AKA River Raid) (Supergame)"
-	rom ( name "River Raid III (AKA River Raid) (Supergame).bin" size 4096 crc 227dcda9 md5 undefined sha1 4e30a9996b9bf7580f86be2741209883676acaaf )
-)
-
-game (
-	name "Road Runner (06-25-1984) (Atari, Robert C. Polaro) (CX2663) (Prototype)"
-	description "Road Runner (06-25-1984) (Atari, Robert C. Polaro) (CX2663) (Prototype)"
-	rom ( name "Road Runner (06-25-1984) (Atari, Robert C. Polaro) (CX2663) (Prototype).bin" size 8192 crc 2fd86554 md5 undefined sha1 ee6940c018b34877e172576234d3d7b408c0203a )
-)
-
-game (
-	name "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) (PAL)"
-	description "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) (PAL)"
-	rom ( name "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) (PAL).bin" size 16384 crc 7a423931 md5 undefined sha1 eea478ef7ff8f579dd4d9077d325b9b6cb865470 )
-)
-
-game (
-	name "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) ~"
-	description "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) ~"
-	rom ( name "Road Runner (1989) (Atari, Robert C. Polaro) (CX2663) ~.bin" size 16384 crc cb79c061 md5 undefined sha1 8be5f9c2a11f78ac536e598e3e3b7d37130154ec )
-)
-
-game (
-	name "Road Runner (CCE)"
-	description "Road Runner (CCE)"
-	rom ( name "Road Runner (CCE).bin" size 16384 crc ea58c541 md5 undefined sha1 e3bb8dcb02e1fca0771e6d5009d27e3a62fa0256 )
-)
-
-game (
-	name "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) (PAL)"
-	description "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) (PAL)"
-	rom ( name "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) (PAL).bin" size 8192 crc c04d402b md5 undefined sha1 9807027508bb36937e14cdce10376ab087017cc0 )
-)
-
-game (
-	name "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) ~"
-	description "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) ~"
-	rom ( name "Robin Hood (1983) (Xonox - K-Tel Software) (99005, 6220, 6250) ~.bin" size 8192 crc df96102b md5 undefined sha1 7f9c2321c9f22cf2cdbcf1b3f0e563a1c53f68ca )
-)
-
-game (
-	name "Robin Hood (AKA Save Our Ship) (1983) (Quelle) (684.733 9) (PAL)"
-	description "Robin Hood (AKA Save Our Ship) (1983) (Quelle) (684.733 9) (PAL)"
-	rom ( name "Robin Hood (AKA Save Our Ship) (1983) (Quelle) (684.733 9) (PAL).bin" size 4096 crc e442d8ae md5 undefined sha1 738e64694e8c6e4122bf024c2e09474f21ebc4b0 )
-)
-
-game (
-	name "Robot Fight (AKA Space Robot) (1983) (Home Vision - Gem International Corp.) (VCS83101) (PAL)"
-	description "Robot Fight (AKA Space Robot) (1983) (Home Vision - Gem International Corp.) (VCS83101) (PAL)"
-	rom ( name "Robot Fight (AKA Space Robot) (1983) (Home Vision - Gem International Corp.) (VCS83101) (PAL).bin" size 4096 crc 15496008 md5 undefined sha1 53c897f724feba0e7b46463daf858bc9caa4dba4 )
-)
-
-game (
-	name "Robot Tank - Rebellion der Roboter (Robotank) (1983) (Activision, Alan Miller - Ariola) (EAZ-028 - 711 028-725) (PAL)"
-	description "Robot Tank - Rebellion der Roboter (Robotank) (1983) (Activision, Alan Miller - Ariola) (EAZ-028 - 711 028-725) (PAL)"
-	rom ( name "Robot Tank - Rebellion der Roboter (Robotank) (1983) (Activision, Alan Miller - Ariola) (EAZ-028 - 711 028-725) (PAL).bin" size 8192 crc cded5569 md5 undefined sha1 413341c947157197ad4c9dd3cef7d0da7b2e9361 )
-)
-
-game (
-	name "Robot Tank (Robotank) (1983) (Activision, Alan Miller) (AZ-028, AG-028-04) ~"
-	description "Robot Tank (Robotank) (1983) (Activision, Alan Miller) (AZ-028, AG-028-04) ~"
-	rom ( name "Robot Tank (Robotank) (1983) (Activision, Alan Miller) (AZ-028, AG-028-04) ~.bin" size 8192 crc e127c012 md5 undefined sha1 21a3ee57cb622f410ffd51986ab80acadb8d44b7 )
-)
-
-game (
-	name "Roc 'n Rope (1984) (CBS Electronics, Ed English) (4L1751) (PAL)"
-	description "Roc 'n Rope (1984) (CBS Electronics, Ed English) (4L1751) (PAL)"
-	rom ( name "Roc 'n Rope (1984) (CBS Electronics, Ed English) (4L1751) (PAL).bin" size 8192 crc 505890ab md5 undefined sha1 ec030ffa9ff574b2ad10e0cecff9af2b1f0ca254 )
-)
-
-game (
-	name "Roc 'n Rope (1984) (Coleco, Ed English) (2667) ~"
-	description "Roc 'n Rope (1984) (Coleco, Ed English) (2667) ~"
-	rom ( name "Roc 'n Rope (1984) (Coleco, Ed English) (2667) ~.bin" size 8192 crc 9d51c969 md5 undefined sha1 0abf0a292d4a24df5a5ebe19a9729f3a8f883c8b )
-)
-
-game (
-	name "Rocky & Bullwinkle (04-20-1983) (M Network, Steve Crandall, Patricia Lewis Du Long) (MT4646) (Prototype) ~"
-	description "Rocky & Bullwinkle (04-20-1983) (M Network, Steve Crandall, Patricia Lewis Du Long) (MT4646) (Prototype) ~"
-	rom ( name "Rocky & Bullwinkle (04-20-1983) (M Network, Steve Crandall, Patricia Lewis Du Long) (MT4646) (Prototype) ~.bin" size 4096 crc 91434dc6 md5 undefined sha1 b27f519052bcf8fa772b0769235acd54db6fca1a )
-)
-
-game (
-	name "Rodeo Champ (AKA Stampede) (4 Game in One) (1983) (Bit Corporation) (PGP218) (PAL)"
-	description "Rodeo Champ (AKA Stampede) (4 Game in One) (1983) (Bit Corporation) (PGP218) (PAL)"
-	rom ( name "Rodeo Champ (AKA Stampede) (4 Game in One) (1983) (Bit Corporation) (PGP218) (PAL).bin" size 4096 crc f2104e7b md5 undefined sha1 a02282e5b3deeb80a16c7dde99375da8c39bac2c )
-)
-
-game (
-	name "Room of Doom - Raum ohne Ausweg (1982) (CommaVid, Irwin Gaines - Ariola) (CM-004 - 712 004-720) (PAL)"
-	description "Room of Doom - Raum ohne Ausweg (1982) (CommaVid, Irwin Gaines - Ariola) (CM-004 - 712 004-720) (PAL)"
-	rom ( name "Room of Doom - Raum ohne Ausweg (1982) (CommaVid, Irwin Gaines - Ariola) (CM-004 - 712 004-720) (PAL).bin" size 4096 crc 63a5edd5 md5 undefined sha1 4be140b4e53387d280e5bf336a19d374ff314965 )
-)
-
-game (
-	name "Room of Doom (1982) (CommaVid, Irwin Gaines) (CM-004) ~"
-	description "Room of Doom (1982) (CommaVid, Irwin Gaines) (CM-004) ~"
-	rom ( name "Room of Doom (1982) (CommaVid, Irwin Gaines) (CM-004) ~.bin" size 4096 crc f27fc3be md5 undefined sha1 fd243c480e769b20b7bf3e74bcd86e4ac99dab19 )
-)
-
-game (
-	name "Room of Doom (208 in 1) (Unknown) (PAL)"
-	description "Room of Doom (208 in 1) (Unknown) (PAL)"
-	rom ( name "Room of Doom (208 in 1) (Unknown) (PAL).bin" size 4096 crc a96b6539 md5 undefined sha1 b07fa120135082b8d23e7bbcabf1da6ee8eb2df1 )
-)
-
-game (
-	name "Rubik's Cube (AKA Atari Video Cube) (1984) (Atari - GCC) (CX2698)"
-	description "Rubik's Cube (AKA Atari Video Cube) (1984) (Atari - GCC) (CX2698)"
-	rom ( name "Rubik's Cube (AKA Atari Video Cube) (1984) (Atari - GCC) (CX2698).bin" size 4096 crc 37f23cb8 md5 undefined sha1 ad2310ff6548d2972e2104f1095792b10a58f606 )
-)
-
-game (
-	name "Rubik's Cube 3-D (1982) (Atari, Peter C. Niday) (Prototype) ~"
-	description "Rubik's Cube 3-D (1982) (Atari, Peter C. Niday) (Prototype) ~"
-	rom ( name "Rubik's Cube 3-D (1982) (Atari, Peter C. Niday) (Prototype) ~.bin" size 4096 crc 47bfd42c md5 undefined sha1 cb3bb28bc4f08313ea8ed9ff395ca34271d3c499 )
-)
-
-game (
-	name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a1]"
-	description "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a1]"
-	rom ( name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a1].bin" size 4096 crc 1ace870b md5 undefined sha1 113d39db5d220bc9da64fa32b0b636ae41244727 )
-)
-
-game (
-	name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a2]"
-	description "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a2]"
-	rom ( name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) [a2].bin" size 4096 crc 8b2396d9 md5 undefined sha1 f2724911503c022fc4153b5e461a1d7dba5b6402 )
-)
-
-game (
-	name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) ~"
-	description "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) ~"
-	rom ( name "Rush Hour (1983) (Commavid, Ben Burch) (CM-010) (Prototype) ~.bin" size 4096 crc e681f62e md5 undefined sha1 c11df5dda52b667485b7cd44522ac75d5e0fe24e )
-)
-
-game (
-	name "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) (PAL)"
-	description "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) (PAL)"
-	rom ( name "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) (PAL).bin" size 4096 crc f2e2e0fc md5 undefined sha1 27e99e47fe4e1b5efa493b54b0e53d2a2997b4a1 )
-)
-
-game (
-	name "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) ~"
-	description "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) ~"
-	rom ( name "S.A.C. Alert (Joyboard) (1983) (Amiga) (3135) (Prototype) ~.bin" size 4096 crc 79d3b1e6 md5 undefined sha1 7b829edffee303c6b796c71540b7636ca5685bcd )
-)
-
-game (
-	name "Saboteur (Sabotage) (05-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	description "Saboteur (Sabotage) (05-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	rom ( name "Saboteur (Sabotage) (05-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype).bin" size 8192 crc 7403592b md5 undefined sha1 2d5419bfed2ccabb09fa2522edb3a84a8ceabae2 )
-)
-
-game (
-	name "Saboteur (Sabotage) (06-09-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	description "Saboteur (Sabotage) (06-09-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	rom ( name "Saboteur (Sabotage) (06-09-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype).bin" size 8192 crc 6ca12211 md5 undefined sha1 c20d42ee01bc1aef24c14b84f9b00e33b7c1bae3 )
-)
-
-game (
-	name "Saboteur (Sabotage) (06-15-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	description "Saboteur (Sabotage) (06-15-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	rom ( name "Saboteur (Sabotage) (06-15-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype).bin" size 8192 crc 2e43af7b md5 undefined sha1 3394ea0e9bd79cb6ea4f0642bd07250ecb587160 )
-)
-
-game (
-	name "Saboteur (Sabotage) (09-02-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	description "Saboteur (Sabotage) (09-02-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype)"
-	rom ( name "Saboteur (Sabotage) (09-02-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype).bin" size 8192 crc c359c13d md5 undefined sha1 85752ac6eb7045a9083425cd166609882a1c2c58 )
-)
-
-game (
-	name "Saboteur (Sabotage) (12-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype) ~"
-	description "Saboteur (Sabotage) (12-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype) ~"
-	rom ( name "Saboteur (Sabotage) (12-20-1983) (Atari, Jerome Domurat, Howard Scott Warshaw) (CX26119) (Prototype) ~.bin" size 8192 crc 7efe0286 md5 undefined sha1 90cd987ccaffb428e53ffd98563dbbe3babd2e73 )
-)
-
-game (
-	name "Save Mary! (Saving Mary) (04-03-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype)"
-	description "Save Mary! (Saving Mary) (04-03-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype)"
-	rom ( name "Save Mary! (Saving Mary) (04-03-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype).bin" size 16384 crc ef858ab2 md5 undefined sha1 1ddedcf4ffe4fc96a2870e11d9cca5fc73e93f59 )
-)
-
-game (
-	name "Save Mary! (Saving Mary) (10-24-1991) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) (PAL)"
-	description "Save Mary! (Saving Mary) (10-24-1991) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) (PAL)"
-	rom ( name "Save Mary! (Saving Mary) (10-24-1991) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) (PAL).bin" size 16384 crc eb2e801d md5 undefined sha1 44357b828b3214441d702d4912a1949951d80472 )
-)
-
-game (
-	name "Save Mary! (Saving Mary) (11-21-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) ~"
-	description "Save Mary! (Saving Mary) (11-21-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) ~"
-	rom ( name "Save Mary! (Saving Mary) (11-21-1989) (Atari - Axlon, Tod Frye) (CX26178) (Prototype) ~.bin" size 16384 crc 01e18f53 md5 undefined sha1 ecd8ef49ae23ddd3e10ec60839b95c8e7764ea27 )
-)
-
-game (
-	name "Save Our Ship (1983) (TechnoVision) (TVS1002) (PAL) ~"
-	description "Save Our Ship (1983) (TechnoVision) (TVS1002) (PAL) ~"
-	rom ( name "Save Our Ship (1983) (TechnoVision) (TVS1002) (PAL) ~.bin" size 4096 crc c422160a md5 undefined sha1 8f06384fed607c5267d6f2c15a6f19cbe5c521d2 )
-)
-
-game (
-	name "Save Our Ship (Hack) (Unknown)"
-	description "Save Our Ship (Hack) (Unknown)"
-	rom ( name "Save Our Ship (Hack) (Unknown).bin" size 4096 crc 830f1e04 md5 undefined sha1 8e9b4163cee3643bf8fe0c5a44396ddcf3c4017d )
-)
-
-game (
-	name "Save Our Ship (Unknown)"
-	description "Save Our Ship (Unknown)"
-	rom ( name "Save Our Ship (Unknown).bin" size 4096 crc c15a66e7 md5 undefined sha1 b9ddb41a5b44af67a6cb38a76d12905c807c0f93 )
-)
-
-game (
-	name "Save the Whales (1983) (20th Century Fox Video Games, Steve Beck) (11035) (Prototype) ~"
-	description "Save the Whales (1983) (20th Century Fox Video Games, Steve Beck) (11035) (Prototype) ~"
-	rom ( name "Save the Whales (1983) (20th Century Fox Video Games, Steve Beck) (11035) (Prototype) ~.bin" size 4096 crc 9a346ce2 md5 undefined sha1 9f6c7295c3a82e0b2203d88715a6d9ac177b3ba9 )
-)
-
-game (
-	name "Schiessbude (AKA Carnival) (1983) (Quelle) (701.134 9) (PAL)"
-	description "Schiessbude (AKA Carnival) (1983) (Quelle) (701.134 9) (PAL)"
-	rom ( name "Schiessbude (AKA Carnival) (1983) (Quelle) (701.134 9) (PAL).bin" size 4096 crc 498e98bb md5 undefined sha1 29b64257d4793125dfa4c6cf05c2f76a11235b48 )
-)
-
-game (
-	name "Schnapp die Apfeldiebe (AKA Plaque Attack) (1983) (Quelle) (429.663 8) (PAL)"
-	description "Schnapp die Apfeldiebe (AKA Plaque Attack) (1983) (Quelle) (429.663 8) (PAL)"
-	rom ( name "Schnapp die Apfeldiebe (AKA Plaque Attack) (1983) (Quelle) (429.663 8) (PAL).bin" size 4096 crc 775d3dd9 md5 undefined sha1 45119e2840eb573ca5b058b690d3980524b218c5 )
-)
-
-game (
-	name "Schussel, der Polizistenschreck (AKA Clown Down Town) (1983) (Quelle) (731.273 9) (PAL)"
-	description "Schussel, der Polizistenschreck (AKA Clown Down Town) (1983) (Quelle) (731.273 9) (PAL)"
-	rom ( name "Schussel, der Polizistenschreck (AKA Clown Down Town) (1983) (Quelle) (731.273 9) (PAL).bin" size 4096 crc da8e49fb md5 undefined sha1 25e2043775a08762e3fc98ecb96fbf46b20e860e )
-)
-
-game (
-	name "Scuba Diver (AKA Skindiver) (1983) (Panda) (104)"
-	description "Scuba Diver (AKA Skindiver) (1983) (Panda) (104)"
-	rom ( name "Scuba Diver (AKA Skindiver) (1983) (Panda) (104).bin" size 4096 crc 3869182c md5 undefined sha1 e8f5ae861ca1f410c6a9af116a96ed65d9a3abb2 )
-)
-
-game (
-	name "Scuba Diver (AKA Skindiver) (Zellers)"
-	description "Scuba Diver (AKA Skindiver) (Zellers)"
-	rom ( name "Scuba Diver (AKA Skindiver) (Zellers).bin" size 4096 crc f94a8aec md5 undefined sha1 e5558ae30acc1fa5b4ffe782ae480622586a32ca )
-)
-
-game (
-	name "Sea Battle (High Seas) (1983) (Intellivision Productions - M Network, Bruce Pedersen, Larry Zwick) (MT5860) ~"
-	description "Sea Battle (High Seas) (1983) (Intellivision Productions - M Network, Bruce Pedersen, Larry Zwick) (MT5860) ~"
-	rom ( name "Sea Battle (High Seas) (1983) (Intellivision Productions - M Network, Bruce Pedersen, Larry Zwick) (MT5860) ~.bin" size 4096 crc 83b4eb19 md5 undefined sha1 cfcc4f11ace2a7408b8122dbf80ab8ec6b56af76 )
-)
-
-game (
-	name "Sea Hawk (AKA Seahawk) (1983) (Panda) (108)"
-	description "Sea Hawk (AKA Seahawk) (1983) (Panda) (108)"
-	rom ( name "Sea Hawk (AKA Seahawk) (1983) (Panda) (108).bin" size 4096 crc 5cc76c35 md5 undefined sha1 4ec6982b2da25b29840428fd993a391e63f53730 )
-)
-
-game (
-	name "Sea Hawk (AKA Seahawk) (1987) (Froggo) (FG1008)"
-	description "Sea Hawk (AKA Seahawk) (1987) (Froggo) (FG1008)"
-	rom ( name "Sea Hawk (AKA Seahawk) (1987) (Froggo) (FG1008).bin" size 4096 crc 5224dc7b md5 undefined sha1 87cb2eb01f8e82fddb3a66e468fab68ae55778da )
-)
-
-game (
-	name "Sea Hawk (AKA Seahawk) (CCE)"
-	description "Sea Hawk (AKA Seahawk) (CCE)"
-	rom ( name "Sea Hawk (AKA Seahawk) (CCE).bin" size 4096 crc 5c7035a5 md5 undefined sha1 dc722409e833496b7cc8159dae35cdd47c5d6b5c )
-)
-
-game (
-	name "Sea Hawk (AKA Seahawk) (Zellers)"
-	description "Sea Hawk (AKA Seahawk) (Zellers)"
-	rom ( name "Sea Hawk (AKA Seahawk) (Zellers).bin" size 4096 crc 5224dc7b md5 undefined sha1 87cb2eb01f8e82fddb3a66e468fab68ae55778da )
-)
-
-game (
-	name "Sea Hunt (AKA Skindiver) (1987) (Froggo) (FG1009)"
-	description "Sea Hunt (AKA Skindiver) (1987) (Froggo) (FG1009)"
-	rom ( name "Sea Hunt (AKA Skindiver) (1987) (Froggo) (FG1009).bin" size 4096 crc f94a8aec md5 undefined sha1 e5558ae30acc1fa5b4ffe782ae480622586a32ca )
-)
-
-game (
-	name "Sea Hunt (AKA Skindiver) (CCE)"
-	description "Sea Hunt (AKA Skindiver) (CCE)"
-	rom ( name "Sea Hunt (AKA Skindiver) (CCE).bin" size 4096 crc c4d18781 md5 undefined sha1 762524b1ca50ee937164a6f52ceafb8d3fc624c8 )
-)
-
-game (
-	name "Sea Monster - O Monstro Marinho (1983) (CCE) (C-805)"
-	description "Sea Monster - O Monstro Marinho (1983) (CCE) (C-805)"
-	rom ( name "Sea Monster - O Monstro Marinho (1983) (CCE) (C-805).bin" size 4096 crc d6490bf3 md5 undefined sha1 0fac0c8611fbe2803b2a95d0328260d1c03a4c8b )
-)
-
-game (
-	name "Sea Monster - See-Monster (1982) (Bit Corporation) (PG201) (PAL)"
-	description "Sea Monster - See-Monster (1982) (Bit Corporation) (PG201) (PAL)"
-	rom ( name "Sea Monster - See-Monster (1982) (Bit Corporation) (PG201) (PAL).bin" size 4096 crc 7a8c2d7c md5 undefined sha1 5faf2e37d86ebd84ff069df20be0e6258edf0f0c )
-)
-
-game (
-	name "Sea Monster (1982) (Puzzy - Bit Corporation) (PG201) (PAL) ~"
-	description "Sea Monster (1982) (Puzzy - Bit Corporation) (PG201) (PAL) ~"
-	rom ( name "Sea Monster (1982) (Puzzy - Bit Corporation) (PG201) (PAL) ~.bin" size 4096 crc 3a1a392b md5 undefined sha1 c2f43f35d95797c06a581654406256c72e422ba4 )
-)
-
-game (
-	name "Sea Monster (1983) (Goliath) (8) (PAL)"
-	description "Sea Monster (1983) (Goliath) (8) (PAL)"
-	rom ( name "Sea Monster (1983) (Goliath) (8) (PAL).bin" size 4096 crc 3a1a392b md5 undefined sha1 c2f43f35d95797c06a581654406256c72e422ba4 )
-)
-
-game (
-	name "Sea Monster (Unknown) (PAL)"
-	description "Sea Monster (Unknown) (PAL)"
-	rom ( name "Sea Monster (Unknown) (PAL).bin" size 4096 crc 8df3a809 md5 undefined sha1 eebbf7052cda551e5612845037cf0f21a40f2265 )
-)
-
-game (
-	name "Seahawk (1982) (John Sands Electronics) (JS145A) (PAL)"
-	description "Seahawk (1982) (John Sands Electronics) (JS145A) (PAL)"
-	rom ( name "Seahawk (1982) (John Sands Electronics) (JS145A) (PAL).bin" size 4096 crc 5d3c699e md5 undefined sha1 b4ead7656696a983dec3192c71cc4d63e9a67825 )
-)
-
-game (
-	name "Seahawk (1982) (Sancho - Tang's Electronic Co.) (TEC002) (PAL) ~"
-	description "Seahawk (1982) (Sancho - Tang's Electronic Co.) (TEC002) (PAL) ~"
-	rom ( name "Seahawk (1982) (Sancho - Tang's Electronic Co.) (TEC002) (PAL) ~.bin" size 4096 crc 5d3c699e md5 undefined sha1 b4ead7656696a983dec3192c71cc4d63e9a67825 )
-)
-
-game (
-	name "Seamonster - Monstre des Mers (1982) (Puzzy - Bit Corporation) (PG201)"
-	description "Seamonster - Monstre des Mers (1982) (Puzzy - Bit Corporation) (PG201)"
-	rom ( name "Seamonster - Monstre des Mers (1982) (Puzzy - Bit Corporation) (PG201).bin" size 4096 crc e913a209 md5 undefined sha1 5b5ae563630beb11f51ee5a244f132481bf84573 )
-)
-
-game (
-	name "Seaquest - Rettung aus der Tiefe (1983) (Activision, Steve Cartwright - Ariola) (EAX-022, EAX-022-04I - 711 022-720) (PAL)"
-	description "Seaquest - Rettung aus der Tiefe (1983) (Activision, Steve Cartwright - Ariola) (EAX-022, EAX-022-04I - 711 022-720) (PAL)"
-	rom ( name "Seaquest - Rettung aus der Tiefe (1983) (Activision, Steve Cartwright - Ariola) (EAX-022, EAX-022-04I - 711 022-720) (PAL).bin" size 4096 crc 01fb2a60 md5 undefined sha1 2abcd573750dd228ec7714a70ce500866beecc65 )
-)
-
-game (
-	name "Seaquest (1983) (Activision, Steve Cartwright) (AX-022) ~"
-	description "Seaquest (1983) (Activision, Steve Cartwright) (AX-022) ~"
-	rom ( name "Seaquest (1983) (Activision, Steve Cartwright) (AX-022) ~.bin" size 4096 crc 8658e8d9 md5 undefined sha1 7324a1ebc695a477c8884718ffcad27732a98ab0 )
-)
-
-game (
-	name "Seaquest (1983) (CCE) (C-815)"
-	description "Seaquest (1983) (CCE) (C-815)"
-	rom ( name "Seaquest (1983) (CCE) (C-815).bin" size 4096 crc b78844f1 md5 undefined sha1 e093ed74edb7e40b009caba3ef313ca6646c5574 )
-)
-
-game (
-	name "Seaquest (1983) (CCE) (C-815) [a]"
-	description "Seaquest (1983) (CCE) (C-815) [a]"
-	rom ( name "Seaquest (1983) (CCE) (C-815) [a].bin" size 4096 crc 18d0ffd0 md5 undefined sha1 2b434940d28cf8fe001e287c447e41e24d433ee4 )
-)
-
-game (
-	name "Seaquest (1983) (Dynacom)"
-	description "Seaquest (1983) (Dynacom)"
-	rom ( name "Seaquest (1983) (Dynacom).bin" size 4096 crc 90a325e8 md5 undefined sha1 b3b3ac08ebfbf8cab322ee548d9e1aec0f1c1f7f )
-)
-
-game (
-	name "Seaquest (Digivision)"
-	description "Seaquest (Digivision)"
-	rom ( name "Seaquest (Digivision).bin" size 4096 crc f246f1b4 md5 undefined sha1 ed0dd424cd9d0008f456e2a353671bb8fbb9c61b )
-)
-
-game (
-	name "Seaquest (Dinatronic)"
-	description "Seaquest (Dinatronic)"
-	rom ( name "Seaquest (Dinatronic).bin" size 4096 crc c439f336 md5 undefined sha1 c26e1dacf3dde23c45a08bfe10bf11c135fe4570 )
-)
-
-game (
-	name "Seawolf 3 (Submarine Commander Beta) (03-23-1981) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) (Prototype) (PAL)"
-	description "Seawolf 3 (Submarine Commander Beta) (03-23-1981) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) (Prototype) (PAL)"
-	rom ( name "Seawolf 3 (Submarine Commander Beta) (03-23-1981) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) (Prototype) (PAL).bin" size 4096 crc e4ddefca md5 undefined sha1 b743d4d11a01d0253c14b1234a2205952a2a0ecf )
-)
-
-game (
-	name "Secret Agent (Paddle) (1983) (Data Age) (Prototype) ~"
-	description "Secret Agent (Paddle) (1983) (Data Age) (Prototype) ~"
-	rom ( name "Secret Agent (Paddle) (1983) (Data Age) (Prototype) ~.bin" size 4096 crc d16c45f9 md5 undefined sha1 1914f57ab0a6f221f2ad344b244a3cdd7b1d991a )
-)
-
-game (
-	name "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170, CX26170P) (PAL)"
-	description "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170, CX26170P) (PAL)"
-	rom ( name "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170, CX26170P) (PAL).bin" size 16384 crc f4337a77 md5 undefined sha1 8439f2f829152a4bac27736102ae131eac376d0e )
-)
-
-game (
-	name "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170) ~"
-	description "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170) ~"
-	rom ( name "Secret Quest (1989) (Atari - Axlon, Steve DeFrisco) (CX26170) ~.bin" size 16384 crc 93c9eb47 md5 undefined sha1 af11f1666d345267196a1c35223727e2ef93483a )
-)
-
-game (
-	name "See Saw (AKA Circus Atari) (Double-Game Package) (1983) (Quelle) (649635) (PAL)"
-	description "See Saw (AKA Circus Atari) (Double-Game Package) (1983) (Quelle) (649635) (PAL)"
-	rom ( name "See Saw (AKA Circus Atari) (Double-Game Package) (1983) (Quelle) (649635) (PAL).bin" size 4096 crc 6c6c3249 md5 undefined sha1 16987b160771e68f69464ea9540f1213c9360741 )
-)
-
-game (
-	name "Sentinel (Light Gun) (1990) (Atari, David Lubar) (CX26183) ~"
-	description "Sentinel (Light Gun) (1990) (Atari, David Lubar) (CX26183) ~"
-	rom ( name "Sentinel (Light Gun) (1990) (Atari, David Lubar) (CX26183) ~.bin" size 16384 crc d457b245 md5 undefined sha1 fcf5f8a7d6e59a339c2002e3d4084d87deb670fe )
-)
-
-game (
-	name "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005)"
-	description "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005)"
-	rom ( name "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005).bin" size 4096 crc f86448f5 md5 undefined sha1 6e91759756c34f40a2c26936df6c0ca1a3850e80 )
-)
-
-game (
-	name "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) (PAL)"
-	description "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) (PAL)"
-	rom ( name "Shark Attack (AKA Lochjaw) (1982) (Apollo - Games by Apollo, Steve Stringfellow) (AP-2005) (PAL).bin" size 4096 crc 510c750d md5 undefined sha1 5d667cbbeebec5f18a513e045704e5cc7ecc0301 )
-)
-
-game (
-	name "Shootin' Gallery (1982) (Imagic, Dennis Koble) (720021-1A, IA3410) ~"
-	description "Shootin' Gallery (1982) (Imagic, Dennis Koble) (720021-1A, IA3410) ~"
-	rom ( name "Shootin' Gallery (1982) (Imagic, Dennis Koble) (720021-1A, IA3410) ~.bin" size 4096 crc b89aff8b md5 undefined sha1 cfb4b41e318c7cd0070e75e412f67c973e124d8e )
-)
-
-game (
-	name "Shooting Arcade (Light Gun) (01-16-1990) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) (PAL)"
-	description "Shooting Arcade (Light Gun) (01-16-1990) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) (PAL)"
-	rom ( name "Shooting Arcade (Light Gun) (01-16-1990) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) (PAL).bin" size 16384 crc 1aee6f09 md5 undefined sha1 f20ab57ad7ca60c566376409c8f94c9f1b4003bd )
-)
-
-game (
-	name "Shooting Arcade (Light Gun) (09-19-1989) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) ~"
-	description "Shooting Arcade (Light Gun) (09-19-1989) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) ~"
-	rom ( name "Shooting Arcade (Light Gun) (09-19-1989) (Atari - Axlon, Tod Frye) (CX26169) (Prototype) ~.bin" size 16384 crc 6f6fb3d6 md5 undefined sha1 6e6daa34878d3e331c630359c7125a4ffba1b22d )
-)
-
-game (
-	name "Shuttle Orbiter (1983) (Avalon Hill, Jean Baer, Bill Hood) (5004002) ~"
-	description "Shuttle Orbiter (1983) (Avalon Hill, Jean Baer, Bill Hood) (5004002) ~"
-	rom ( name "Shuttle Orbiter (1983) (Avalon Hill, Jean Baer, Bill Hood) (5004002) ~.bin" size 4096 crc 253d6396 md5 undefined sha1 08952192ea6bf0ef94373520a7e855f58bae6179 )
-)
-
-game (
-	name "Sinistar (01-04-1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	description "Sinistar (01-04-1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	rom ( name "Sinistar (01-04-1984) (Atari, Lou Harp) (CX26122) (Prototype).bin" size 8192 crc 81e73728 md5 undefined sha1 9c01b7577ff3d4e74b91705db8d8c97ada331087 )
-)
-
-game (
-	name "Sinistar (01-23-1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	description "Sinistar (01-23-1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	rom ( name "Sinistar (01-23-1984) (Atari, Lou Harp) (CX26122) (Prototype).bin" size 8192 crc da33fda7 md5 undefined sha1 ccd50f0e4ddfae2142e4d06bee70e6084fbc4cde )
-)
-
-game (
-	name "Sinistar (02-13-1984) (Atari, Lou Harp) (CX26122) (Prototype) ~"
-	description "Sinistar (02-13-1984) (Atari, Lou Harp) (CX26122) (Prototype) ~"
-	rom ( name "Sinistar (02-13-1984) (Atari, Lou Harp) (CX26122) (Prototype) ~.bin" size 8192 crc 8e81a2a4 md5 undefined sha1 242fc23def80da96da22c2c7238d48635489abb0 )
-)
-
-game (
-	name "Sinistar (1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	description "Sinistar (1984) (Atari, Lou Harp) (CX26122) (Prototype)"
-	rom ( name "Sinistar (1984) (Atari, Lou Harp) (CX26122) (Prototype).bin" size 8192 crc 9721c332 md5 undefined sha1 9d342c3fb5449f887fc4e452e31ffcb0c99e83cf )
-)
-
-game (
-	name "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) (PAL)"
-	description "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) (PAL)"
-	rom ( name "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) (PAL).bin" size 8192 crc bb4d1430 md5 undefined sha1 cfac3bbe45af5f2027abe32c3a59d2fad29ef9b4 )
-)
-
-game (
-	name "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) ~"
-	description "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) ~"
-	rom ( name "Sir Lancelot (1983) (Xonox - K-Tel Software, Anthony R. Henderson) (99006, 6220) ~.bin" size 8192 crc eb792891 md5 undefined sha1 fb4008b13cb9957ce5e2ce1555c7aecac9e773cc )
-)
-
-game (
-	name "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (AG-042-02, AG-042-04) ~"
-	description "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (AG-042-02, AG-042-04) ~"
-	rom ( name "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (AG-042-02, AG-042-04) ~.bin" size 8192 crc 6ee721f7 md5 undefined sha1 a26fe0b5a43fe8116ab0ae6656d6b11644d871ec )
-)
-
-game (
-	name "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (EAZ-042-04B, EAZ-042-04I) (PAL)"
-	description "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (EAZ-042-04B, EAZ-042-04I) (PAL)"
-	rom ( name "Skate Boardin' (1987) (Absolute Entertainment, David Crane) (EAZ-042-04B, EAZ-042-04I) (PAL).bin" size 8192 crc 28180111 md5 undefined sha1 24a0eb23dedc8ecc4e3b6cef642d3704824fd1ec )
-)
-
-game (
-	name "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) (PAL)"
-	description "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) (PAL)"
-	rom ( name "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) (PAL).bin" size 4096 crc ebc576a0 md5 undefined sha1 9c5714f5809fae2b246c989fc5d8fcaeca9ece74 )
-)
-
-game (
-	name "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) ~"
-	description "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) ~"
-	rom ( name "Skeet Shoot (1981) (Apollo - Games by Apollo, Ed Salvo) (AP-1001) ~.bin" size 2048 crc 57d69b13 md5 undefined sha1 5ea6d2eb27c76e85f477ba6c799deb7c416ebbc3 )
-)
-
-game (
-	name "Ski Hunt (Skiing Hunt) (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83106) (PAL) ~"
-	description "Ski Hunt (Skiing Hunt) (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83106) (PAL) ~"
-	rom ( name "Ski Hunt (Skiing Hunt) (1983) (Home Vision - Gem International Corp. - R.J.P.G.) (VCS83106) (PAL) ~.bin" size 4096 crc 5df00a09 md5 undefined sha1 936fce1ff68113fabf3f971592e98acddcab97b7 )
-)
-
-game (
-	name "Ski Run (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Ski Run (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Ski Run (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc d6634a09 md5 undefined sha1 798f59199118674cec2155c1832d797334b16904 )
-)
-
-game (
-	name "Ski Run (Suntek) (SS-024) (PAL) ~"
-	description "Ski Run (Suntek) (SS-024) (PAL) ~"
-	rom ( name "Ski Run (Suntek) (SS-024) (PAL) ~.bin" size 4096 crc e20a00b3 md5 undefined sha1 6ea10b4409225b2de0f130837e7d0e3b164a1652 )
-)
-
-game (
-	name "Ski Run (Video Game Cartridge - Ariola) (TP-607) (PAL)"
-	description "Ski Run (Video Game Cartridge - Ariola) (TP-607) (PAL)"
-	rom ( name "Ski Run (Video Game Cartridge - Ariola) (TP-607) (PAL).bin" size 4096 crc e20a00b3 md5 undefined sha1 6ea10b4409225b2de0f130837e7d0e3b164a1652 )
-)
-
-game (
-	name "Skiing - Le Ski (1980) (Activision, Bob Whitehead) (AG-005, CAG-005, AG-005-04) ~"
-	description "Skiing - Le Ski (1980) (Activision, Bob Whitehead) (AG-005, CAG-005, AG-005-04) ~"
-	rom ( name "Skiing - Le Ski (1980) (Activision, Bob Whitehead) (AG-005, CAG-005, AG-005-04) ~.bin" size 2048 crc 35f80a22 md5 undefined sha1 6581846f983b50cffb75d1c1b902238ba7dd4e92 )
-)
-
-game (
-	name "Skiing - Ski Weltcup (1980) (Activision, Bob Whitehead - Ariola) (EAG-005, PAG-005, EAG-005-04B - 711 005-715) (PAL)"
-	description "Skiing - Ski Weltcup (1980) (Activision, Bob Whitehead - Ariola) (EAG-005, PAG-005, EAG-005-04B - 711 005-715) (PAL)"
-	rom ( name "Skiing - Ski Weltcup (1980) (Activision, Bob Whitehead - Ariola) (EAG-005, PAG-005, EAG-005-04B - 711 005-715) (PAL).bin" size 2048 crc 6c2033f6 md5 undefined sha1 43acd1ff15a696bb004d5dbd5d35a905c575d4e1 )
-)
-
-game (
-	name "Skiing (208 in 1) (Unknown) (PAL)"
-	description "Skiing (208 in 1) (Unknown) (PAL)"
-	rom ( name "Skiing (208 in 1) (Unknown) (PAL).bin" size 2048 crc c3ee322f md5 undefined sha1 6a08a5c9d983ff294b57abb8ee25246722c88a59 )
-)
-
-game (
-	name "Skiing (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Skiing (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Skiing (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 15dc4087 md5 undefined sha1 c870e45626c25ca02fa95994c6bb875c01717ac2 )
-)
-
-game (
-	name "Skiing (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Skiing (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Skiing (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 01fae566 md5 undefined sha1 5f927899d1086f0b721085b04a135f54d5c27d9b )
-)
-
-game (
-	name "Skiing (Dactari - Milmar)"
-	description "Skiing (Dactari - Milmar)"
-	rom ( name "Skiing (Dactari - Milmar).bin" size 2048 crc 6aa48f37 md5 undefined sha1 25b8ee69c73e6d030fe1192895e7c53411d85475 )
-)
-
-game (
-	name "Skindiver (1983) (Sancho - Tang's Electronic Co.) (TEC003) (PAL) ~"
-	description "Skindiver (1983) (Sancho - Tang's Electronic Co.) (TEC003) (PAL) ~"
-	rom ( name "Skindiver (1983) (Sancho - Tang's Electronic Co.) (TEC003) (PAL) ~.bin" size 4096 crc 9a98888c md5 undefined sha1 a86bf5762c4766c4de00b49b29d0df9a7ee417e0 )
-)
-
-game (
-	name "Sky Alien (Sky Aliem) (1983) (Home Vision - Gem International Corp.) (VCS83112) (PAL) ~"
-	description "Sky Alien (Sky Aliem) (1983) (Home Vision - Gem International Corp.) (VCS83112) (PAL) ~"
-	rom ( name "Sky Alien (Sky Aliem) (1983) (Home Vision - Gem International Corp.) (VCS83112) (PAL) ~.bin" size 4096 crc a23eaac5 md5 undefined sha1 12acae81097b752d2446c9456996bdccc3d625d5 )
-)
-
-game (
-	name "Sky Diver - Dare Diver (1979) (Atari, Jim Huether - Sears) (CX2629 - 6-99843, 49-75118) ~"
-	description "Sky Diver - Dare Diver (1979) (Atari, Jim Huether - Sears) (CX2629 - 6-99843, 49-75118) ~"
-	rom ( name "Sky Diver - Dare Diver (1979) (Atari, Jim Huether - Sears) (CX2629 - 6-99843, 49-75118) ~.bin" size 2048 crc 00312ea9 md5 undefined sha1 4dde18d4abc139562fdd7a9d2fd49a1f00a9e64a )
-)
-
-game (
-	name "Sky Diver (1979) (Atari, Jim Huether) (CX2629, CX2629P) (PAL)"
-	description "Sky Diver (1979) (Atari, Jim Huether) (CX2629, CX2629P) (PAL)"
-	rom ( name "Sky Diver (1979) (Atari, Jim Huether) (CX2629, CX2629P) (PAL).bin" size 2048 crc 6a84ec3f md5 undefined sha1 0856dd930db32843b25f33459abe7e7c4895646e )
-)
-
-game (
-	name "Sky Diver (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL)"
-	description "Sky Diver (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL)"
-	rom ( name "Sky Diver (32 in 1) (1988) (Atari, Jim Huether) (CX26163P) (PAL).bin" size 2048 crc cdefbf81 md5 undefined sha1 aa319a4c39b785b2e256ed1bb36d4eb4c8f7c55d )
-)
-
-game (
-	name "Sky Diver (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Sky Diver (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Sky Diver (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc a9eb2c17 md5 undefined sha1 9d9797f8e73381cbdd2e755174196587891b9628 )
-)
-
-game (
-	name "Sky Diver (Hack) (Unknown) (PAL)"
-	description "Sky Diver (Hack) (Unknown) (PAL)"
-	rom ( name "Sky Diver (Hack) (Unknown) (PAL).bin" size 2048 crc b49d16f2 md5 undefined sha1 81a4e5a335ba90184fa884813914e797d0a6a8d5 )
-)
-
-game (
-	name "Sky Jinks - Wettflug gegen die Zeit (1982) (Activision, Bob Whitehead - Ariola) (EAG-019, EAG-019-04I - 711 019-715) (PAL)"
-	description "Sky Jinks - Wettflug gegen die Zeit (1982) (Activision, Bob Whitehead - Ariola) (EAG-019, EAG-019-04I - 711 019-715) (PAL)"
-	rom ( name "Sky Jinks - Wettflug gegen die Zeit (1982) (Activision, Bob Whitehead - Ariola) (EAG-019, EAG-019-04I - 711 019-715) (PAL).bin" size 2048 crc 12b0056d md5 undefined sha1 dccde9899bdc063e77a99105131e3914181d72ad )
-)
-
-game (
-	name "Sky Jinks (1982) (Activision, Bob Whitehead) (AG-019) ~"
-	description "Sky Jinks (1982) (Activision, Bob Whitehead) (AG-019) ~"
-	rom ( name "Sky Jinks (1982) (Activision, Bob Whitehead) (AG-019) ~.bin" size 2048 crc 96f8cf59 md5 undefined sha1 105f722dcf9a89b683c10ddd7f684c5966c8e1db )
-)
-
-game (
-	name "Sky Jinks (CCE)"
-	description "Sky Jinks (CCE)"
-	rom ( name "Sky Jinks (CCE).bin" size 2048 crc fe6a0630 md5 undefined sha1 8e16d60d700fc7a2a021ae2b0e26438e61c3dd0c )
-)
-
-game (
-	name "Sky Jinks (Hack) (Unknown) (PAL)"
-	description "Sky Jinks (Hack) (Unknown) (PAL)"
-	rom ( name "Sky Jinks (Hack) (Unknown) (PAL).bin" size 2048 crc 01b9b1cb md5 undefined sha1 c3342fcd4ebe5c77b75b7b946fcd0717d83f49f7 )
-)
-
-game (
-	name "Sky Patrol (Aerial Ace) (1982) (Imagic, Brad Stewart) (720106-1A, IA3409) (Prototype) ~"
-	description "Sky Patrol (Aerial Ace) (1982) (Imagic, Brad Stewart) (720106-1A, IA3409) (Prototype) ~"
-	rom ( name "Sky Patrol (Aerial Ace) (1982) (Imagic, Brad Stewart) (720106-1A, IA3409) (Prototype) ~.bin" size 8192 crc a1ecdf0e md5 undefined sha1 fc5f1e30db3b2469c9701dadfa95f3268fd1e4cb )
-)
-
-game (
-	name "Sky Scraper (AKA Base Attack) (1983) (Goliath - Hot Shot) (83-415) (PAL)"
-	description "Sky Scraper (AKA Base Attack) (1983) (Goliath - Hot Shot) (83-415) (PAL)"
-	rom ( name "Sky Scraper (AKA Base Attack) (1983) (Goliath - Hot Shot) (83-415) (PAL).bin" size 4096 crc 81f1e5dd md5 undefined sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
-)
-
-game (
-	name "Sky Skipper (1983) (Parker Brothers) (931510) (PAL)"
-	description "Sky Skipper (1983) (Parker Brothers) (931510) (PAL)"
-	rom ( name "Sky Skipper (1983) (Parker Brothers) (931510) (PAL).bin" size 4096 crc 21e1a9c7 md5 undefined sha1 ce8f0ecf27919425c4c3fa686c4569fddaa9ce26 )
-)
-
-game (
-	name "Sky Skipper (1983) (Parker Brothers) (PB5350) ~"
-	description "Sky Skipper (1983) (Parker Brothers) (PB5350) ~"
-	rom ( name "Sky Skipper (1983) (Parker Brothers) (PB5350) ~.bin" size 4096 crc cc6e0f22 md5 undefined sha1 ef0a7ecfe8f3b5d1e67a736552a0cdc472803be9 )
-)
-
-game (
-	name "Skydiver (AKA Parachute) (Suntek) (SS-030) (PAL)"
-	description "Skydiver (AKA Parachute) (Suntek) (SS-030) (PAL)"
-	rom ( name "Skydiver (AKA Parachute) (Suntek) (SS-030) (PAL).bin" size 4096 crc d32ef4ac md5 undefined sha1 ceaa6868ad25ad4c06b89ef6fa4e5411ad1fcc6b )
-)
-
-game (
-	name "Slot Machine - Slots (1979) (Atari, David Crane - Sears) (CX2653 - 6-99823, 49-75111) ~"
-	description "Slot Machine - Slots (1979) (Atari, David Crane - Sears) (CX2653 - 6-99823, 49-75111) ~"
-	rom ( name "Slot Machine - Slots (1979) (Atari, David Crane - Sears) (CX2653 - 6-99823, 49-75111) ~.bin" size 2048 crc cb378d95 md5 undefined sha1 7239d1c64f3dfc2a1613be325cce13803dd2baa5 )
-)
-
-game (
-	name "Slot Machine (1979) (Atari, David Crane) (CX2653P) (PAL)"
-	description "Slot Machine (1979) (Atari, David Crane) (CX2653P) (PAL)"
-	rom ( name "Slot Machine (1979) (Atari, David Crane) (CX2653P) (PAL).bin" size 2048 crc 6463efcf md5 undefined sha1 8e11f980fc0ab133e8096fd1d4eb73da152f82e5 )
-)
-
-game (
-	name "Slot Machine (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL)"
-	description "Slot Machine (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL)"
-	rom ( name "Slot Machine (32 in 1) (1988) (Atari, David Crane) (CX26163P) (PAL).bin" size 2048 crc bcccf02f md5 undefined sha1 2f7af671265b4d8406b98c69154306b58e2bd488 )
-)
-
-game (
-	name "Slot Racers - Maze (1978) (Atari, Warren Robinett - Sears) (CX2606 - 6-99825, 49-75112) ~"
-	description "Slot Racers - Maze (1978) (Atari, Warren Robinett - Sears) (CX2606 - 6-99825, 49-75112) ~"
-	rom ( name "Slot Racers - Maze (1978) (Atari, Warren Robinett - Sears) (CX2606 - 6-99825, 49-75112) ~.bin" size 2048 crc 177dbdf8 md5 undefined sha1 a2b13017d759346174e3d8dd53b6347222d3b85d )
-)
-
-game (
-	name "Slot Racers (1978) (Atari, Warren Robinett) (CX2606, CX2606P) (PAL)"
-	description "Slot Racers (1978) (Atari, Warren Robinett) (CX2606, CX2606P) (PAL)"
-	rom ( name "Slot Racers (1978) (Atari, Warren Robinett) (CX2606, CX2606P) (PAL).bin" size 2048 crc cbc87a48 md5 undefined sha1 8af04974a997a7eb72c489e69f8131d65de03b1d )
-)
-
-game (
-	name "Slot Racers (32 in 1) (1988) (Atari, Warren Robinett) (CX26163P) (PAL)"
-	description "Slot Racers (32 in 1) (1988) (Atari, Warren Robinett) (CX26163P) (PAL)"
-	rom ( name "Slot Racers (32 in 1) (1988) (Atari, Warren Robinett) (CX26163P) (PAL).bin" size 2048 crc 3260084e md5 undefined sha1 db1eccfe1601f9c2a5cd7a1df8147872008b8d1d )
-)
-
-game (
-	name "Smash Hit Pak - Frogger, Boxing, Seaquest, Skiing, Stampede (HES) (498) (PAL)"
-	description "Smash Hit Pak - Frogger, Boxing, Seaquest, Skiing, Stampede (HES) (498) (PAL)"
-	rom ( name "Smash Hit Pak - Frogger, Boxing, Seaquest, Skiing, Stampede (HES) (498) (PAL).bin" size 16384 crc 8d3417f5 md5 undefined sha1 d5f7da871d8e2af6f474f05700bd62826b01d8cd )
-)
-
-game (
-	name "Smurf - Rescue in Gargamel's Castle (Smurf, Smurf Action) (1982) (Coleco, Henry Will IV) (2465) ~"
-	description "Smurf - Rescue in Gargamel's Castle (Smurf, Smurf Action) (1982) (Coleco, Henry Will IV) (2465) ~"
-	rom ( name "Smurf - Rescue in Gargamel's Castle (Smurf, Smurf Action) (1982) (Coleco, Henry Will IV) (2465) ~.bin" size 8192 crc e0624a7f md5 undefined sha1 530c7883fed4c5b9d78e35d48770b56e328999a3 )
-)
-
-game (
-	name "Smurf - Schtroumpfs - Pitufo (1982) (CBS Electronics, Henry Will IV) (4L1767, 4L1768, 4L1769, 4L1770) (PAL)"
-	description "Smurf - Schtroumpfs - Pitufo (1982) (CBS Electronics, Henry Will IV) (4L1767, 4L1768, 4L1769, 4L1770) (PAL)"
-	rom ( name "Smurf - Schtroumpfs - Pitufo (1982) (CBS Electronics, Henry Will IV) (4L1767, 4L1768, 4L1769, 4L1770) (PAL).bin" size 8192 crc d8666b94 md5 undefined sha1 716ac30bf2fc998851d3ad1d69bcd8c1ca2b3a5b )
-)
-
-game (
-	name "Smurfs Save the Day (Kid Vid Voice Module) (1983) (Coleco) (2511) ~"
-	description "Smurfs Save the Day (Kid Vid Voice Module) (1983) (Coleco) (2511) ~"
-	rom ( name "Smurfs Save the Day (Kid Vid Voice Module) (1983) (Coleco) (2511) ~.bin" size 8192 crc ad89c697 md5 undefined sha1 c0ae3965fcfab0294f770af0af57d7d1adc17750 )
-)
-
-game (
-	name "Snail Against Squirrel - Schnecke gegen Eichhoernchen (1983) (Bit Corporation) (PG208) (PAL) ~"
-	description "Snail Against Squirrel - Schnecke gegen Eichhoernchen (1983) (Bit Corporation) (PG208) (PAL) ~"
-	rom ( name "Snail Against Squirrel - Schnecke gegen Eichhoernchen (1983) (Bit Corporation) (PG208) (PAL) ~.bin" size 4096 crc 5c5b9e1a md5 undefined sha1 e7bf450cf3a3f40de9d24d89968a4bc89b53cb18 )
-)
-
-game (
-	name "Snail Against Squirrel (Unknown) (PAL)"
-	description "Snail Against Squirrel (Unknown) (PAL)"
-	rom ( name "Snail Against Squirrel (Unknown) (PAL).bin" size 4096 crc 3b6c9c63 md5 undefined sha1 3061b7aa4d010f67057b1cc606a18e6f1ae7e1ee )
-)
-
-game (
-	name "Sneak 'n Peek (Hide 'n Seek) (1982) (U.S. Games Corporation, Garry Kitchen, Paul Willson - Vidtec) (VC1002) ~"
-	description "Sneak 'n Peek (Hide 'n Seek) (1982) (U.S. Games Corporation, Garry Kitchen, Paul Willson - Vidtec) (VC1002) ~"
-	rom ( name "Sneak 'n Peek (Hide 'n Seek) (1982) (U.S. Games Corporation, Garry Kitchen, Paul Willson - Vidtec) (VC1002) ~.bin" size 4096 crc 93b17c39 md5 undefined sha1 843e3c2fc71af2db3f2ae98eb350fde26334cfd1 )
-)
-
-game (
-	name "Sneak 'n Peek (Unknown) (PAL)"
-	description "Sneak 'n Peek (Unknown) (PAL)"
-	rom ( name "Sneak 'n Peek (Unknown) (PAL).bin" size 4096 crc 52a5cd2a md5 undefined sha1 40fd75379734b75518d875a70231fa64db4afb5b )
-)
-
-game (
-	name "Sneak'n Peak (AKA Sneak 'n Peek) (1983) (CCE) (C-848)"
-	description "Sneak'n Peak (AKA Sneak 'n Peek) (1983) (CCE) (C-848)"
-	rom ( name "Sneak'n Peak (AKA Sneak 'n Peek) (1983) (CCE) (C-848).bin" size 4096 crc 93b17c39 md5 undefined sha1 843e3c2fc71af2db3f2ae98eb350fde26334cfd1 )
-)
-
-game (
-	name "Snoopy (AKA Snoopy and the Red Baron) (1983) (Century) (PAL)"
-	description "Snoopy (AKA Snoopy and the Red Baron) (1983) (Century) (PAL)"
-	rom ( name "Snoopy (AKA Snoopy and the Red Baron) (1983) (Century) (PAL).bin" size 8192 crc 35310cbd md5 undefined sha1 85d72072bfe2219fef912b7e2cf36d851e5efe86 )
-)
-
-game (
-	name "Snoopy (AKA Snoopy and the Red Baron) (Digivision)"
-	description "Snoopy (AKA Snoopy and the Red Baron) (Digivision)"
-	rom ( name "Snoopy (AKA Snoopy and the Red Baron) (Digivision).bin" size 8192 crc 0ecf6fc4 md5 undefined sha1 8b016e23faaebb6d096abd7a6436b6d5ce9fb0bc )
-)
-
-game (
-	name "Snoopy and the Red Baron (05-27-1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (Prototype)"
-	description "Snoopy and the Red Baron (05-27-1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (Prototype)"
-	rom ( name "Snoopy and the Red Baron (05-27-1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (Prototype).bin" size 8192 crc ca0fedaa md5 undefined sha1 a44b8d17b64a53d60aaca21324b540d3d11d2833 )
-)
-
-game (
-	name "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (PAL)"
-	description "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (PAL)"
-	rom ( name "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) (PAL).bin" size 8192 crc 82947a46 md5 undefined sha1 0dabf54ff855418fbce2a70badf7161d985e4fe5 )
-)
-
-game (
-	name "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) ~"
-	description "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) ~"
-	rom ( name "Snoopy and the Red Baron (1983) (Atari, Richard Dobbis, Nick 'Sandy Maiwald' Turner) (CX26111) ~.bin" size 8192 crc d1039967 md5 undefined sha1 972bc0a77e76f3e4e1270ec1c2fc395e9826bc07 )
-)
-
-game (
-	name "Snoopy and the Red Baron (Canal 3 - Intellivision) (C 3007)"
-	description "Snoopy and the Red Baron (Canal 3 - Intellivision) (C 3007)"
-	rom ( name "Snoopy and the Red Baron (Canal 3 - Intellivision) (C 3007).bin" size 8192 crc 5cd16af5 md5 undefined sha1 6163d36632a5e313bf4439ed2d3b9bf9b372da23 )
-)
-
-game (
-	name "Snoopy and the Red Baron (CCE)"
-	description "Snoopy and the Red Baron (CCE)"
-	rom ( name "Snoopy and the Red Baron (CCE).bin" size 8192 crc 576c6c44 md5 undefined sha1 687a0c9b90bd47d9e0562ac95636af09705198a4 )
-)
-
-game (
-	name "Snow White and the Seven Dwarfs (02-09-1983) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype)"
-	description "Snow White and the Seven Dwarfs (02-09-1983) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype)"
-	rom ( name "Snow White and the Seven Dwarfs (02-09-1983) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype).bin" size 8192 crc 4736c654 md5 undefined sha1 2c35fd54cd18e1a8b4eb26126875cb0cf8a58b19 )
-)
-
-game (
-	name "Snow White and the Seven Dwarfs (11-09-1982) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype) ~"
-	description "Snow White and the Seven Dwarfs (11-09-1982) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype) ~"
-	rom ( name "Snow White and the Seven Dwarfs (11-09-1982) (Atari, Greg Easter, Mimi Nyden) (CX26107) (Prototype) ~.bin" size 8192 crc 38598a9a md5 undefined sha1 5c968c6dc0db6564f4ea83a543c0bd7c3efd1032 )
-)
-
-game (
-	name "Soccer (AKA International Soccer) (1989) (Telegames) (5687 A279)"
-	description "Soccer (AKA International Soccer) (1989) (Telegames) (5687 A279)"
-	rom ( name "Soccer (AKA International Soccer) (1989) (Telegames) (5687 A279).bin" size 4096 crc ebc723c0 md5 undefined sha1 9d725002e94b04e29d8cbce3c71d3bb2a84352fa )
-)
-
-game (
-	name "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L 2487 5000) ~"
-	description "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L 2487 5000) ~"
-	rom ( name "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L 2487 5000) ~.bin" size 8192 crc d2ca6ce8 md5 undefined sha1 09ea74f14db8d21ea785d0c8209ed670e4ce88be )
-)
-
-game (
-	name "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L1845, 4L1852, 4L1853, 4L1854, 4L1855) (PAL)"
-	description "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L1845, 4L1852, 4L1853, 4L1854, 4L1855) (PAL)"
-	rom ( name "Solar Fox (1983) (CBS Electronics, Bob Curtiss) (4L1845, 4L1852, 4L1853, 4L1854, 4L1855) (PAL).bin" size 8192 crc 990046f2 md5 undefined sha1 83c45b60ba4d175cad6d6559ecfc62f92fdd3c22 )
-)
-
-game (
-	name "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-1A, 03206) ~"
-	description "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-1A, 03206) ~"
-	rom ( name "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-1A, 03206) ~.bin" size 4096 crc a970b3e3 md5 undefined sha1 ec65ef9e47239a7d15db9bca7e625b166e8ac242 )
-)
-
-game (
-	name "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-2A, 13206) (PAL)"
-	description "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-2A, 13206) (PAL)"
-	rom ( name "Solar Storm (Paddle) (1983) (Imagic, Wilfredo 'Willy' Aguilar, Michael Becker, Dennis Koble) (720113-2A, 13206) (PAL).bin" size 4096 crc dd8efc87 md5 undefined sha1 f0a9822ab9c109f6e4f3e757199594dc2e4655f0 )
-)
-
-game (
-	name "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) (PAL)"
-	description "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) (PAL)"
-	rom ( name "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) (PAL).bin" size 16384 crc b1e6acb6 md5 undefined sha1 260aac37ff3d6152209c24efe82669fe871a1342 )
-)
-
-game (
-	name "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) ~"
-	description "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) ~"
-	rom ( name "Solaris (Universe, Star Raiders II, The Last Starfighter) (1986) (Atari, Douglas Neubauer) (CX26136) ~.bin" size 16384 crc 2b87850e md5 undefined sha1 33b16fbc95c2cdc52d84d98ca471f10dae3f9dbf )
-)
-
-game (
-	name "Sorcerer (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1001) ~"
-	description "Sorcerer (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1001) ~"
-	rom ( name "Sorcerer (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1001) ~.bin" size 4096 crc c7734be6 md5 undefined sha1 70e912379060d834aa9fb2baa2e6a438f3b5d3b6 )
-)
-
-game (
-	name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (PAL)"
-	description "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (PAL)"
-	rom ( name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (PAL).bin" size 8192 crc b8892afc md5 undefined sha1 33f2c1454f28974d0e1f67ef2ce216c9cf8202c8 )
-)
-
-game (
-	name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype)"
-	description "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype)"
-	rom ( name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype).bin" size 8192 crc efc5943f md5 undefined sha1 73335561c65984d722d77b424221da7d302b241d )
-)
-
-game (
-	name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype) [a]"
-	description "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype) [a]"
-	rom ( name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) (Prototype) [a].bin" size 8192 crc 22682f1e md5 undefined sha1 5df004890ce6d8af1986d3c7c2934f7aa85159b9 )
-)
-
-game (
-	name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) ~"
-	description "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) ~"
-	rom ( name "Sorcerer's Apprentice (1983) (Atari, Jerome Domurat, Peter C. Niday, Robert Vieira) (CX26109) ~.bin" size 8192 crc e5dbfed1 md5 undefined sha1 ae3009e921f23254bb71f67c8cb2d7d6de2845a5 )
-)
-
-game (
-	name "Space Adventure (AKA Flash Gordon) (Zellers)"
-	description "Space Adventure (AKA Flash Gordon) (Zellers)"
-	rom ( name "Space Adventure (AKA Flash Gordon) (Zellers).bin" size 4096 crc 0d61ce7d md5 undefined sha1 fb870ec3d51468fa4cf40e0efae9617e60c1c91c )
-)
-
-game (
-	name "Space Attack (1982) (M Network, Hal Finney, Bruce Pedersen - INTV) (MT5659) ~"
-	description "Space Attack (1982) (M Network, Hal Finney, Bruce Pedersen - INTV) (MT5659) ~"
-	rom ( name "Space Attack (1982) (M Network, Hal Finney, Bruce Pedersen - INTV) (MT5659) ~.bin" size 4096 crc b34a3e57 md5 undefined sha1 560563613bc309a532d611f11a1cf2b9af1e2f16 )
-)
-
-game (
-	name "Space Attack (1989) (Telegames) (PAL)"
-	description "Space Attack (1989) (Telegames) (PAL)"
-	rom ( name "Space Attack (1989) (Telegames) (PAL).bin" size 4096 crc 98ff8d2f md5 undefined sha1 6105b1859ff6b5492aa2f21481224ac5e59cd2ee )
-)
-
-game (
-	name "Space Canyon (AKA Space Cavern) (1983) (Panda) (100)"
-	description "Space Canyon (AKA Space Cavern) (1983) (Panda) (100)"
-	rom ( name "Space Canyon (AKA Space Cavern) (1983) (Panda) (100).bin" size 4096 crc ce7268b3 md5 undefined sha1 26c6c47e9b654e81f47875c5fcb4e6212125f329 )
-)
-
-game (
-	name "Space Cavern - Les guerriers de l'espace (1981) (Apollo - Games by Apollo, Dan Oliver - RCA Video Jeux) (AP-2002) (PAL)"
-	description "Space Cavern - Les guerriers de l'espace (1981) (Apollo - Games by Apollo, Dan Oliver - RCA Video Jeux) (AP-2002) (PAL)"
-	rom ( name "Space Cavern - Les guerriers de l'espace (1981) (Apollo - Games by Apollo, Dan Oliver - RCA Video Jeux) (AP-2002) (PAL).bin" size 4096 crc 72876779 md5 undefined sha1 a46a611f1b445c9444aafa9c24c1ec291c9ed1a7 )
-)
-
-game (
-	name "Space Cavern (1981) (Apollo - Games by Apollo, Dan Oliver) (AP-2002) ~"
-	description "Space Cavern (1981) (Apollo - Games by Apollo, Dan Oliver) (AP-2002) ~"
-	rom ( name "Space Cavern (1981) (Apollo - Games by Apollo, Dan Oliver) (AP-2002) ~.bin" size 4096 crc 3b0ffd89 md5 undefined sha1 b757b883ee114054c650027f3b9a8f15548cbf32 )
-)
-
-game (
-	name "Space Eagle (AKA Exocet) (1983) (Goliath - Hot Shot) (83-213) (PAL)"
-	description "Space Eagle (AKA Exocet) (1983) (Goliath - Hot Shot) (83-213) (PAL)"
-	rom ( name "Space Eagle (AKA Exocet) (1983) (Goliath - Hot Shot) (83-213) (PAL).bin" size 4096 crc 5cc39028 md5 undefined sha1 07b12357904ec3a4846d27b3790581f6eb5da2b7 )
-)
-
-game (
-	name "Space Invaders (1980) (Atari, Richard Maurer - Sears) (CX2632 - 49-75153) ~"
-	description "Space Invaders (1980) (Atari, Richard Maurer - Sears) (CX2632 - 49-75153) ~"
-	rom ( name "Space Invaders (1980) (Atari, Richard Maurer - Sears) (CX2632 - 49-75153) ~.bin" size 4096 crc a6e867b3 md5 undefined sha1 31d9668fe5812c3d2e076987ca327ac6b2e280bf )
-)
-
-game (
-	name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL)"
-	description "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL)"
-	rom ( name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL).bin" size 4096 crc a8f04cb1 md5 undefined sha1 8fed31490b107194cfbf3cd93f714b018606eb9e )
-)
-
-game (
-	name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [different speed and colors]"
-	description "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [different speed and colors]"
-	rom ( name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [different speed and colors].bin" size 4096 crc 71627b6d md5 undefined sha1 82798cf199a8f4730a9305fab261d929a5780d9b )
-)
-
-game (
-	name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [fixed]"
-	description "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [fixed]"
-	rom ( name "Space Invaders (1980) (Atari, Richard Maurer) (CX2632, CX2632P) (PAL) [fixed].bin" size 4096 crc 4840d2b7 md5 undefined sha1 43a855d5af6e35aa77a52b03a4ecd325d7dbbb9b )
-)
-
-game (
-	name "Space Invaders (1983) (CCE) (C-820)"
-	description "Space Invaders (1983) (CCE) (C-820)"
-	rom ( name "Space Invaders (1983) (CCE) (C-820).bin" size 4096 crc d1ef5725 md5 undefined sha1 71e8e73541b08ea66fb465786f7db672eb64b2c9 )
-)
-
-game (
-	name "Space Jockey (1982) (U.S. Games Corporation, Garry Kitchen - Vidtec) (VC1001) ~"
-	description "Space Jockey (1982) (U.S. Games Corporation, Garry Kitchen - Vidtec) (VC1001) ~"
-	rom ( name "Space Jockey (1982) (U.S. Games Corporation, Garry Kitchen - Vidtec) (VC1001) ~.bin" size 2048 crc ab24d73e md5 undefined sha1 5bdd8af54020fa43065750bd4239a497695d403b )
-)
-
-game (
-	name "Space Jockey (1983) (Carrere Video, Garry Kitchen - Teldec - Prism Micro Products) (USC1001) (PAL)"
-	description "Space Jockey (1983) (Carrere Video, Garry Kitchen - Teldec - Prism Micro Products) (USC1001) (PAL)"
-	rom ( name "Space Jockey (1983) (Carrere Video, Garry Kitchen - Teldec - Prism Micro Products) (USC1001) (PAL).bin" size 2048 crc d74f40ff md5 undefined sha1 431ca59a34ce7e977d69f4263cf28579517f45ad )
-)
-
-game (
-	name "Space Jockey (208 in 1) (Unknown) (PAL)"
-	description "Space Jockey (208 in 1) (Unknown) (PAL)"
-	rom ( name "Space Jockey (208 in 1) (Unknown) (PAL).bin" size 2048 crc 4d76fac2 md5 undefined sha1 caef22bc0ea07040bb16e9c300ca74c287f96660 )
-)
-
-game (
-	name "Space Jockey (Unknown) (PAL)"
-	description "Space Jockey (Unknown) (PAL)"
-	rom ( name "Space Jockey (Unknown) (PAL).bin" size 2048 crc d796dacb md5 undefined sha1 dcdf2fe2e363267181fb37688cd78fa8bcb9b0d3 )
-)
-
-game (
-	name "Space Monster (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (F2001) (PAL)"
-	description "Space Monster (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (F2001) (PAL)"
-	rom ( name "Space Monster (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (F2001) (PAL).bin" size 4096 crc e506bdb2 md5 undefined sha1 05dede1debc04fb1c81a8d940e32ac08e85af29b )
-)
-
-game (
-	name "Space Raid (AKA Challenge of.... Nexar, The) (King Tripod Enterprise Co.) (SS - 007) (PAL)"
-	description "Space Raid (AKA Challenge of.... Nexar, The) (King Tripod Enterprise Co.) (SS - 007) (PAL)"
-	rom ( name "Space Raid (AKA Challenge of.... Nexar, The) (King Tripod Enterprise Co.) (SS - 007) (PAL).bin" size 4096 crc 30ec1efc md5 undefined sha1 c24551fcc2cff769c122fe0f4089e8bb4a77eaa2 )
-)
-
-game (
-	name "Space Raid (AKA MegaMania) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Space Raid (AKA MegaMania) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Space Raid (AKA MegaMania) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 6143ba57 md5 undefined sha1 22c06cc06a929052e8c3b4ec444113f5385bc35d )
-)
-
-game (
-	name "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL)"
-	description "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL)"
-	rom ( name "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL).bin" size 4096 crc 404f0a9f md5 undefined sha1 bc9b418f900505965e0b6e53a6c430f100ae56fa )
-)
-
-game (
-	name "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL) [a]"
-	description "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL) [a]"
-	rom ( name "Space Raid (AKA MegaMania) (Rainbow Vision - Suntek) (SS-007) (PAL) [a].bin" size 4096 crc 0df11d0d md5 undefined sha1 fadae2e987429faaa8552ea7409ac780b86efe01 )
-)
-
-game (
-	name "Space Robot (1983) (Goliath) (1) (PAL)"
-	description "Space Robot (1983) (Goliath) (1) (PAL)"
-	rom ( name "Space Robot (1983) (Goliath) (1) (PAL).bin" size 4096 crc 15496008 md5 undefined sha1 53c897f724feba0e7b46463daf858bc9caa4dba4 )
-)
-
-game (
-	name "Space Robot (Dimax - Sinmax) (SM8001)"
-	description "Space Robot (Dimax - Sinmax) (SM8001)"
-	rom ( name "Space Robot (Dimax - Sinmax) (SM8001).bin" size 4096 crc 8fffc351 md5 undefined sha1 3d6a433bc93dd005a578cd3b745896a76708542d )
-)
-
-game (
-	name "Space Robot (Dimax - Sinmax) (SM8001) (PAL)"
-	description "Space Robot (Dimax - Sinmax) (SM8001) (PAL)"
-	rom ( name "Space Robot (Dimax - Sinmax) (SM8001) (PAL).bin" size 4096 crc 15496008 md5 undefined sha1 53c897f724feba0e7b46463daf858bc9caa4dba4 )
-)
-
-game (
-	name "Space Robot (Unknown)"
-	description "Space Robot (Unknown)"
-	rom ( name "Space Robot (Unknown).bin" size 4096 crc 1778a4ae md5 undefined sha1 5cf1373c89dc15e61ee1c3e3f5423545f1bf8007 )
-)
-
-game (
-	name "Space Robot (Unknown) (PAL)"
-	description "Space Robot (Unknown) (PAL)"
-	rom ( name "Space Robot (Unknown) (PAL).bin" size 4096 crc 3749a0fe md5 undefined sha1 534c0a09ae60c0d9a2a2ea9e2a602f07b695f4c5 )
-)
-
-game (
-	name "Space Shuttle - A Journey Into Space - Eine Reise ins All (1983) (Activision, Steve 'Jessica' Kitchen - Ariola) (EAZ-033 - 711 033-725) (PAL)"
-	description "Space Shuttle - A Journey Into Space - Eine Reise ins All (1983) (Activision, Steve 'Jessica' Kitchen - Ariola) (EAZ-033 - 711 033-725) (PAL)"
-	rom ( name "Space Shuttle - A Journey Into Space - Eine Reise ins All (1983) (Activision, Steve 'Jessica' Kitchen - Ariola) (EAZ-033 - 711 033-725) (PAL).bin" size 8192 crc 600e7c77 md5 undefined sha1 3e9cd06cba4d79a9bc04faf79977b01d4947f935 )
-)
-
-game (
-	name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) [FE bankswitching] ~"
-	description "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) [FE bankswitching] ~"
-	rom ( name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) [FE bankswitching] ~.bin" size 8192 crc 123f2a0b md5 undefined sha1 8c905ec69e8831c18addc5f72a47323cd24c17bd )
-)
-
-game (
-	name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) ~"
-	description "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) ~"
-	rom ( name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (AZ-033, AZ-033-04) ~.bin" size 8192 crc dd210cf3 md5 undefined sha1 bcec5a66f8dff1a751769626b0fce305fab44ca2 )
-)
-
-game (
-	name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (EAZ-033) (SECAM)"
-	description "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (EAZ-033) (SECAM)"
-	rom ( name "Space Shuttle - A Journey Into Space (1983) (Activision, Steve 'Jessica' Kitchen) (EAZ-033) (SECAM).bin" size 8192 crc fc90b426 md5 undefined sha1 2e1510eaa9b58d7e0f3b58b26267c8ccd1614e3c )
-)
-
-game (
-	name "Space Tunnel - Le Tunnel de L'Estace (1982) (Puzzy - Bit Corporation) (PG202)"
-	description "Space Tunnel - Le Tunnel de L'Estace (1982) (Puzzy - Bit Corporation) (PG202)"
-	rom ( name "Space Tunnel - Le Tunnel de L'Estace (1982) (Puzzy - Bit Corporation) (PG202).bin" size 4096 crc 1b62e1b8 md5 undefined sha1 a49bf74e006867b4bdd6c0e1a7af76cdad8b76ee )
-)
-
-game (
-	name "Space Tunnel - O Tunel Espacial (1983) (CCE) (C-807)"
-	description "Space Tunnel - O Tunel Espacial (1983) (CCE) (C-807)"
-	rom ( name "Space Tunnel - O Tunel Espacial (1983) (CCE) (C-807).bin" size 4096 crc 295d0ded md5 undefined sha1 9d97e48baf0f1674ab872f17ccb3a1585a2ac177 )
-)
-
-game (
-	name "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202)"
-	description "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202)"
-	rom ( name "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202).bin" size 4096 crc f09f489f md5 undefined sha1 52c425fc220208d08cb0b1f2909cf79fb5b3f322 )
-)
-
-game (
-	name "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202) (PAL)"
-	description "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202) (PAL)"
-	rom ( name "Space Tunnel - Weltraum-Tunnel (1982) (Bit Corporation) (PG202) (PAL).bin" size 4096 crc 0596c056 md5 undefined sha1 c660247ee128bebe02ae0b0ba6478e48f572469f )
-)
-
-game (
-	name "Space Tunnel (1982) (Puzzy - Bit Corporation) (PG202) (PAL) ~"
-	description "Space Tunnel (1982) (Puzzy - Bit Corporation) (PG202) (PAL) ~"
-	rom ( name "Space Tunnel (1982) (Puzzy - Bit Corporation) (PG202) (PAL) ~.bin" size 4096 crc 28bc5a4d md5 undefined sha1 9a2c8ab7a3d0a4dfa18fc14f31a4082c3958db71 )
-)
-
-game (
-	name "Space Tunnel (1983) (Goliath) (7) (PAL)"
-	description "Space Tunnel (1983) (Goliath) (7) (PAL)"
-	rom ( name "Space Tunnel (1983) (Goliath) (7) (PAL).bin" size 4096 crc 28bc5a4d md5 undefined sha1 9a2c8ab7a3d0a4dfa18fc14f31a4082c3958db71 )
-)
-
-game (
-	name "Space War - Space Combat (1978) (Atari, Ian Shepard - Sears) (CX2604 - 6-99812, 49-75106) ~"
-	description "Space War - Space Combat (1978) (Atari, Ian Shepard - Sears) (CX2604 - 6-99812, 49-75106) ~"
-	rom ( name "Space War - Space Combat (1978) (Atari, Ian Shepard - Sears) (CX2604 - 6-99812, 49-75106) ~.bin" size 2048 crc 65622f2a md5 undefined sha1 23510ba617431097668eaf104aa1e36233173093 )
-)
-
-game (
-	name "Space War - Space Star (32 in 1) (1988) (Atari, Ian Shepard) (CX26163P) (PAL)"
-	description "Space War - Space Star (32 in 1) (1988) (Atari, Ian Shepard) (CX26163P) (PAL)"
-	rom ( name "Space War - Space Star (32 in 1) (1988) (Atari, Ian Shepard) (CX26163P) (PAL).bin" size 2048 crc 6f2528fa md5 undefined sha1 9db15e10cea799b69e0a7d890924c7391fd2ca45 )
-)
-
-game (
-	name "Space War (1978) (Atari, Ian Shepard) (CX2604, CX2604P) (PAL)"
-	description "Space War (1978) (Atari, Ian Shepard) (CX2604, CX2604P) (PAL)"
-	rom ( name "Space War (1978) (Atari, Ian Shepard) (CX2604, CX2604P) (PAL).bin" size 2048 crc 0c84be58 md5 undefined sha1 9a3210df35866f81eb2cbe8a4d677d70e755924a )
-)
-
-game (
-	name "Space War (208 in 1) (Unknown) (PAL)"
-	description "Space War (208 in 1) (Unknown) (PAL)"
-	rom ( name "Space War (208 in 1) (Unknown) (PAL).bin" size 2048 crc 1e2e7d3e md5 undefined sha1 f8573a9782adc2f170eb8ad6a50c36bba7795a5b )
-)
-
-game (
-	name "Space War (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (PAL)"
-	description "Space War (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Space War (AKA Condor Attack) (1982) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc 5c13b1ef md5 undefined sha1 c1930d130bdf668f3c0b4f026a980328eeb00482 )
-)
-
-game (
-	name "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Bryson Park) (AP-2001) (PAL)"
-	description "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Bryson Park) (AP-2001) (PAL)"
-	rom ( name "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Bryson Park) (AP-2001) (PAL).bin" size 4096 crc cfacb2ef md5 undefined sha1 90ad496340ff00b245412872e06259234984707a )
-)
-
-game (
-	name "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2001) ~"
-	description "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2001) ~"
-	rom ( name "Spacechase (1981) (Apollo - Games by Apollo, Ed Salvo, Byron Parks) (AP-2001) ~.bin" size 4096 crc 2954d22d md5 undefined sha1 b356294e35827bf81add95fee5453b0ca0f497ad )
-)
-
-game (
-	name "SpaceMaster X-7 (1983) (20th Century Fox Video Games, David Lubar) (11022) ~"
-	description "SpaceMaster X-7 (1983) (20th Century Fox Video Games, David Lubar) (11022) ~"
-	rom ( name "SpaceMaster X-7 (1983) (20th Century Fox Video Games, David Lubar) (11022) ~.bin" size 4096 crc e554d7d0 md5 undefined sha1 983b1aff97ab1243e283ba62d3a6a75ad186d225 )
-)
-
-game (
-	name "SpaceMaster X-7 (208 in 1) (Unknown) (PAL)"
-	description "SpaceMaster X-7 (208 in 1) (Unknown) (PAL)"
-	rom ( name "SpaceMaster X-7 (208 in 1) (Unknown) (PAL).bin" size 4096 crc e0496373 md5 undefined sha1 a278f142b4fcae227ef9147f12fcb894829d1a39 )
-)
-
-game (
-	name "Spectracube Invasion (AKA Immies & Aggies) (Suntek) (SS-025) (PAL)"
-	description "Spectracube Invasion (AKA Immies & Aggies) (Suntek) (SS-025) (PAL)"
-	rom ( name "Spectracube Invasion (AKA Immies & Aggies) (Suntek) (SS-025) (PAL).bin" size 4096 crc 6d842f66 md5 undefined sha1 1e5b6049ce75441937b6af878c22db1c689de678 )
-)
-
-game (
-	name "Spider Fighter - Monster greifen an (1982) (Activision, Larry Miller - Ariola) (EAX-021, EAX-021-04I - 711 021-720) (PAL)"
-	description "Spider Fighter - Monster greifen an (1982) (Activision, Larry Miller - Ariola) (EAX-021, EAX-021-04I - 711 021-720) (PAL)"
-	rom ( name "Spider Fighter - Monster greifen an (1982) (Activision, Larry Miller - Ariola) (EAX-021, EAX-021-04I - 711 021-720) (PAL).bin" size 4096 crc 8cde157e md5 undefined sha1 b8b8ea8ba9e1a3b8031e6ff2d9bfcfdee9b5236e )
-)
-
-game (
-	name "Spider Fighter (1982) (Activision, Larry Miller) (AX-021) ~"
-	description "Spider Fighter (1982) (Activision, Larry Miller) (AX-021) ~"
-	rom ( name "Spider Fighter (1982) (Activision, Larry Miller) (AX-021) ~.bin" size 4096 crc bf0941f6 md5 undefined sha1 06820ad3c957913847f9849d920bc8725f535f11 )
-)
-
-game (
-	name "Spider Fighter (1983) (CCE) (C-853)"
-	description "Spider Fighter (1983) (CCE) (C-853)"
-	rom ( name "Spider Fighter (1983) (CCE) (C-853).bin" size 4096 crc 17765bb7 md5 undefined sha1 80ec8e630c11384016f35239b38f6a0fcf97317c )
-)
-
-game (
-	name "Spider Fighter (1983) (Dynacom)"
-	description "Spider Fighter (1983) (Dynacom)"
-	rom ( name "Spider Fighter (1983) (Dynacom).bin" size 4096 crc 9a9f7a1f md5 undefined sha1 13750a9c7851ece82402118857a3f5d820660af6 )
-)
-
-game (
-	name "Spider Fighter (Canal 3 - Intellivision)"
-	description "Spider Fighter (Canal 3 - Intellivision)"
-	rom ( name "Spider Fighter (Canal 3 - Intellivision).bin" size 4096 crc b2fbce50 md5 undefined sha1 3285352f8f7342d9f5ef11d86b6c5b61c2870342 )
-)
-
-game (
-	name "Spider Fighter (Digivision)"
-	description "Spider Fighter (Digivision)"
-	rom ( name "Spider Fighter (Digivision).bin" size 4096 crc 6811f606 md5 undefined sha1 335fda185f5bbd7e060da7b1494aafbe05449114 )
-)
-
-game (
-	name "Spider Fighter (Unknown) (PAL)"
-	description "Spider Fighter (Unknown) (PAL)"
-	rom ( name "Spider Fighter (Unknown) (PAL).bin" size 4096 crc 13da48fa md5 undefined sha1 2908005895025a78302ea2840493b8e4809ea208 )
-)
-
-game (
-	name "Spider Kong (1983) (Goliath) (6) (PAL)"
-	description "Spider Kong (1983) (Goliath) (6) (PAL)"
-	rom ( name "Spider Kong (1983) (Goliath) (6) (PAL).bin" size 4096 crc 59b9fff1 md5 undefined sha1 ed12b50bed5ad013372d88100d2138f19eeaf74c )
-)
-
-game (
-	name "Spider Kong (1983) (Goliath) (6) (PAL) [a]"
-	description "Spider Kong (1983) (Goliath) (6) (PAL) [a]"
-	rom ( name "Spider Kong (1983) (Goliath) (6) (PAL) [a].bin" size 4096 crc 14f8f820 md5 undefined sha1 1a14a508f0565cdcf6d99431d4e49b8e9e0a1caa )
-)
-
-game (
-	name "Spider Kong (208 in 1) (Unknown) (PAL)"
-	description "Spider Kong (208 in 1) (Unknown) (PAL)"
-	rom ( name "Spider Kong (208 in 1) (Unknown) (PAL).bin" size 4096 crc 5216ecd9 md5 undefined sha1 5c36d0bbe3fcb896877b93cb0ee6955b78cc97ff )
-)
-
-game (
-	name "Spider Kong (Unknown) (PAL)"
-	description "Spider Kong (Unknown) (PAL)"
-	rom ( name "Spider Kong (Unknown) (PAL).bin" size 4096 crc a7fcc520 md5 undefined sha1 03a9f73814e066be5edb541ddb7f17a9d17b56f2 )
-)
-
-game (
-	name "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision)"
-	description "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision)"
-	rom ( name "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision).bin" size 4096 crc fbc1911d md5 undefined sha1 5d6f918bba4bd046e85b707da3b7d643cc2e1f1f )
-)
-
-game (
-	name "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision) (PAL)"
-	description "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision) (PAL)"
-	rom ( name "Spider Maze (AKA Spider Kong) (1982) (K-Tel Vision) (PAL).bin" size 4096 crc 59b9fff1 md5 undefined sha1 ed12b50bed5ad013372d88100d2138f19eeaf74c )
-)
-
-game (
-	name "Spider Monster - Inca Gold (AKA Spider Kong) (1982) (Funvision - Fund. International Co.) (PAL)"
-	description "Spider Monster - Inca Gold (AKA Spider Kong) (1982) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Spider Monster - Inca Gold (AKA Spider Kong) (1982) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc ac53d608 md5 undefined sha1 60af23a860b33e1a85081b8de779d2ddfe36b19a )
-)
-
-game (
-	name "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (931503) (PAL)"
-	description "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (931503) (PAL)"
-	rom ( name "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (931503) (PAL).bin" size 4096 crc 8feaaa0d md5 undefined sha1 6445fb2f6bbcc84468af78405570628dde97365c )
-)
-
-game (
-	name "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (PB5900) ~"
-	description "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (PB5900) ~"
-	rom ( name "Spider-Man (1982) (Parker Brothers, David Lamkins, Laura Nikolich) (PB5900) ~.bin" size 4096 crc 4dfea848 md5 undefined sha1 912c5f5571ac59a6782da412183cdd6277345816 )
-)
-
-game (
-	name "Spiderdroid (AKA Amidar) (1987) (Froggo) (FG1002)"
-	description "Spiderdroid (AKA Amidar) (1987) (Froggo) (FG1002)"
-	rom ( name "Spiderdroid (AKA Amidar) (1987) (Froggo) (FG1002).bin" size 4096 crc 4347ae8e md5 undefined sha1 904118b0c1be484782ec2a60a24436059608b36d )
-)
-
-game (
-	name "Spiderman (AKA Spider-Man) (1983) (Quelle) (495.663 7) (PAL)"
-	description "Spiderman (AKA Spider-Man) (1983) (Quelle) (495.663 7) (PAL)"
-	rom ( name "Spiderman (AKA Spider-Man) (1983) (Quelle) (495.663 7) (PAL).bin" size 4096 crc f873f7f9 md5 undefined sha1 fd0b244869f9521a8ff621d59e220f33f0526536 )
-)
-
-game (
-	name "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) (PAL)"
-	description "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) (PAL)"
-	rom ( name "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) (PAL).bin" size 8192 crc 13537536 md5 undefined sha1 3b9868cf925a5e5ee5ddee5f2582d5e1899dade2 )
-)
-
-game (
-	name "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) ~"
-	description "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) ~"
-	rom ( name "Spike's Peak (1983) (Xonox - K-Tel Software - Beck-Tech) (6210, 7210, 06003. 99001) ~.bin" size 8192 crc 50efea8d md5 undefined sha1 205241a12778829981e9281d9c6fa137f11e1376 )
-)
-
-game (
-	name "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) [a]"
-	description "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) [a]"
-	rom ( name "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) [a].bin" size 4096 crc f497456e md5 undefined sha1 e30e6195642884954bc98df2e82c3e972db49a57 )
-)
-
-game (
-	name "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) ~"
-	description "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) ~"
-	rom ( name "Spinning Fireball - Fire Spinner - Fireball Spinner (1983) (ZiMAG - Emag - Vidco) (GN-080) (Prototype) ~.bin" size 4096 crc fa40c6d3 md5 undefined sha1 2b184acdf908328a1c134c918d16a68cc2e57f94 )
-)
-
-game (
-	name "Spinning Fireball (Unknown) (PAL)"
-	description "Spinning Fireball (Unknown) (PAL)"
-	rom ( name "Spinning Fireball (Unknown) (PAL).bin" size 4096 crc f058455d md5 undefined sha1 a979bb0bc94dcb74d67ca1591e75d42318766767 )
-)
-
-game (
-	name "Spitfire Attack (Flight Commander) (1983) (Milton Bradley Company) (4363) ~"
-	description "Spitfire Attack (Flight Commander) (1983) (Milton Bradley Company) (4363) ~"
-	rom ( name "Spitfire Attack (Flight Commander) (1983) (Milton Bradley Company) (4363) ~.bin" size 4096 crc 093507d8 md5 undefined sha1 165de0ebca628eb1e9f564390c9eedfe289c7a1d )
-)
-
-game (
-	name "Sports Action Pak - Enduro, Ice Hockey, Fishing Derby, Dragster (1988) (HES - Activision) (PAL)"
-	description "Sports Action Pak - Enduro, Ice Hockey, Fishing Derby, Dragster (1988) (HES - Activision) (PAL)"
-	rom ( name "Sports Action Pak - Enduro, Ice Hockey, Fishing Derby, Dragster (1988) (HES - Activision) (PAL).bin" size 16384 crc cf886fa5 md5 undefined sha1 2988421b5d6121bce71469b8e4f37b0c4b970974 )
-)
-
-game (
-	name "Springer (1982) (Tigervision - Teldec) (7-006 - 3.60008 VG) (PAL)"
-	description "Springer (1982) (Tigervision - Teldec) (7-006 - 3.60008 VG) (PAL)"
-	rom ( name "Springer (1982) (Tigervision - Teldec) (7-006 - 3.60008 VG) (PAL).bin" size 8192 crc 3025541e md5 undefined sha1 ca0dcbd92e9dbfebc5bc211d7ace0e5c7c238331 )
-)
-
-game (
-	name "Springer (1982) (Tigervision) (7-006) ~"
-	description "Springer (1982) (Tigervision) (7-006) ~"
-	rom ( name "Springer (1982) (Tigervision) (7-006) ~.bin" size 8192 crc dd183a4f md5 undefined sha1 6da0aa8aa40cd9c78dc014deb9074529688d91d0 )
-)
-
-game (
-	name "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155) ~"
-	description "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155) ~"
-	rom ( name "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155) ~.bin" size 16384 crc c495904e md5 undefined sha1 c0e29b86fc1cc41a1c8afa37572c3c5698ae70b2 )
-)
-
-game (
-	name "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155P) (PAL)"
-	description "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155P) (PAL)"
-	rom ( name "Sprint Master (Sprint 88, Sprint 2600) (1988) (Atari, Robert C. Polaro) (CX26155P) (PAL).bin" size 16384 crc 040f0b14 md5 undefined sha1 dcaac1fac0fe15aaa4553c2fa02b923a6dfb6880 )
-)
-
-game (
-	name "Spy Hunter (Dual Control Module) (1984) (Sega, Jeff Lorenz - Bally Midway) (011-01, 011-02) ~"
-	description "Spy Hunter (Dual Control Module) (1984) (Sega, Jeff Lorenz - Bally Midway) (011-01, 011-02) ~"
-	rom ( name "Spy Hunter (Dual Control Module) (1984) (Sega, Jeff Lorenz - Bally Midway) (011-01, 011-02) ~.bin" size 8192 crc 4f804e49 md5 undefined sha1 1d0acf064d06a026a04b6028285db78c834e9854 )
-)
-
-game (
-	name "Spy Vs. Spy (AKA Chopper Command) (4 Game in One) (1983) (Bit Corporation) (PGP213) (PAL)"
-	description "Spy Vs. Spy (AKA Chopper Command) (4 Game in One) (1983) (Bit Corporation) (PGP213) (PAL)"
-	rom ( name "Spy Vs. Spy (AKA Chopper Command) (4 Game in One) (1983) (Bit Corporation) (PGP213) (PAL).bin" size 4096 crc 09756e40 md5 undefined sha1 85bfd2aaada3eeea1eb09cb8d7a23944c1ea7225 )
-)
-
-game (
-	name "Squeeze Box (1982) (U.S. Games Corporation, Henry Will IV) (VC2002) ~"
-	description "Squeeze Box (1982) (U.S. Games Corporation, Henry Will IV) (VC2002) ~"
-	rom ( name "Squeeze Box (1982) (U.S. Games Corporation, Henry Will IV) (VC2002) ~.bin" size 4096 crc d37f3fb3 md5 undefined sha1 033148faebc97d4ed3a86c97fe0cdee21bd261f7 )
-)
-
-game (
-	name "Squirrel - O Esquilo (AKA Snail Against Squirrel) (1983) (CCE) (C-809)"
-	description "Squirrel - O Esquilo (AKA Snail Against Squirrel) (1983) (CCE) (C-809)"
-	rom ( name "Squirrel - O Esquilo (AKA Snail Against Squirrel) (1983) (CCE) (C-809).bin" size 4096 crc ac2920ef md5 undefined sha1 87abe4ab10c9a7ca5c55d7a34a3181bbde0b0a90 )
-)
-
-game (
-	name "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) [a]"
-	description "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) [a]"
-	rom ( name "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) [a].bin" size 4096 crc fe44446e md5 undefined sha1 11a9dd44787f011ec540159248377cb27fb8f7bb )
-)
-
-game (
-	name "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) ~"
-	description "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) ~"
-	rom ( name "Squoosh (Vat's Incredible!, The Grape Escape) (1983) (Apollo) (AP-2012) (Prototype) ~.bin" size 4096 crc b4212adb md5 undefined sha1 7405d4b427cb278062fa44db918c0a702062e55c )
-)
-
-game (
-	name "Sssnake (1982) (Data Age) (DA1003) ~"
-	description "Sssnake (1982) (Data Age) (DA1003) ~"
-	rom ( name "Sssnake (1982) (Data Age) (DA1003) ~.bin" size 4096 crc 1b5b0212 md5 undefined sha1 46aabde3074acded8890a2efa5586d6b8bd76b5d )
-)
-
-game (
-	name "Sssnake (1983) (Gameworld) (133-003) (PAL)"
-	description "Sssnake (1983) (Gameworld) (133-003) (PAL)"
-	rom ( name "Sssnake (1983) (Gameworld) (133-003) (PAL).bin" size 4096 crc 9365d8d3 md5 undefined sha1 56557c04e0adfd00cb47842f44b14159ad93c625 )
-)
-
-game (
-	name "Stampede - Lasso-Helden (1981) (Activision, Bob Whitehead - Ariola) (EAG-011, PAG-011 - 711 011-715) (PAL)"
-	description "Stampede - Lasso-Helden (1981) (Activision, Bob Whitehead - Ariola) (EAG-011, PAG-011 - 711 011-715) (PAL)"
-	rom ( name "Stampede - Lasso-Helden (1981) (Activision, Bob Whitehead - Ariola) (EAG-011, PAG-011 - 711 011-715) (PAL).bin" size 2048 crc 4585c22a md5 undefined sha1 0f50a4bb0aaa4508d7654bac7a460c54ce7c5afe )
-)
-
-game (
-	name "Stampede (1981) (Activision, Bob Whitehead) (AG-011) ~"
-	description "Stampede (1981) (Activision, Bob Whitehead) (AG-011) ~"
-	rom ( name "Stampede (1981) (Activision, Bob Whitehead) (AG-011) ~.bin" size 2048 crc 740800f3 md5 undefined sha1 277184c4e61ced14393049a21a304e941d05993f )
-)
-
-game (
-	name "Stampede (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Stampede (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Stampede (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 0c90bcf8 md5 undefined sha1 9b8dff2cc1f7212285bebf5e529ec3c7ec971017 )
-)
-
-game (
-	name "Stampede (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Stampede (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Stampede (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 8780b26e md5 undefined sha1 e013dec038bdb0e2b57c4730e964e54999d6425a )
-)
-
-game (
-	name "Stampede (Canal 3 - Intellivision)"
-	description "Stampede (Canal 3 - Intellivision)"
-	rom ( name "Stampede (Canal 3 - Intellivision).bin" size 2048 crc 16ef428e md5 undefined sha1 24bdc921959e5d3e9db8e14f17a47bf005f6b2ba )
-)
-
-game (
-	name "Stampede (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Stampede (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Stampede (Hack) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 143ecd4d md5 undefined sha1 d665b6bc31c370b7ebb15bca44f35168262de81e )
-)
-
-game (
-	name "Stampede (Unknown) (PAL)"
-	description "Stampede (Unknown) (PAL)"
-	rom ( name "Stampede (Unknown) (PAL).bin" size 2048 crc 0732e6de md5 undefined sha1 4d7f86ac4a82f66d6657bfb50d2e07b349812429 )
-)
-
-game (
-	name "Star Fox (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1003) ~"
-	description "Star Fox (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1003) ~"
-	rom ( name "Star Fox (1983) (Mythicon, Bill Bryner, Bruce de Graaf) (MA1003) ~.bin" size 4096 crc 915ec040 md5 undefined sha1 1b95e07437ddc1523d7ec21c460273e91dbf36c7 )
-)
-
-game (
-	name "Star Raiders (1981) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) (Prototype)"
-	description "Star Raiders (1981) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) (Prototype)"
-	rom ( name "Star Raiders (1981) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) (Prototype).bin" size 4096 crc 497a41b8 md5 undefined sha1 b8f4128f8e44fb93d2b11135a46eab42cd65b9f0 )
-)
-
-game (
-	name "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) ~"
-	description "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) ~"
-	rom ( name "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky - Sears) (CX2660 - 49-75187) ~.bin" size 8192 crc 2ae193ee md5 undefined sha1 e10cce1a438c82bd499e1eb31a3f07d7254198f5 )
-)
-
-game (
-	name "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky) (CX2660) (PAL)"
-	description "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky) (CX2660) (PAL)"
-	rom ( name "Star Raiders (Video Touch Pad) (1982) (Atari, Carla Meninsky) (CX2660) (PAL).bin" size 8192 crc ff59b8e2 md5 undefined sha1 7c2a2ddbdef639ed2985ce66ae717b2285a94ae0 )
-)
-
-game (
-	name "Star Ship - Outer Space (Star Trek, Space, Space Mission) (1977) (Atari, Bob Whitehead - Sears) (CX2603 - 99803, 49-75601) ~"
-	description "Star Ship - Outer Space (Star Trek, Space, Space Mission) (1977) (Atari, Bob Whitehead - Sears) (CX2603 - 99803, 49-75601) ~"
-	rom ( name "Star Ship - Outer Space (Star Trek, Space, Space Mission) (1977) (Atari, Bob Whitehead - Sears) (CX2603 - 99803, 49-75601) ~.bin" size 2048 crc 6609267e md5 undefined sha1 878e78ed46e29c44949d0904a2198826e412ed81 )
-)
-
-game (
-	name "Star Strike (1983) (M Network, David Akers, Patricia Lewis Du Long - INTV) (MT4313) ~"
-	description "Star Strike (1983) (M Network, David Akers, Patricia Lewis Du Long - INTV) (MT4313) ~"
-	rom ( name "Star Strike (1983) (M Network, David Akers, Patricia Lewis Du Long - INTV) (MT4313) ~.bin" size 4096 crc 936a596d md5 undefined sha1 de05d1ca8ad1e7a85df3faf25b1aa90b159afded )
-)
-
-game (
-	name "Star Strike (1989) (Telegames) (PAL)"
-	description "Star Strike (1989) (Telegames) (PAL)"
-	rom ( name "Star Strike (1989) (Telegames) (PAL).bin" size 4096 crc 9c76e9ce md5 undefined sha1 a0e29405a92773bf3baa2845788a8add8f3bc0b1 )
-)
-
-game (
-	name "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz - Teldec) (004-01) (PAL)"
-	description "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz - Teldec) (004-01) (PAL)"
-	rom ( name "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz - Teldec) (004-01) (PAL).bin" size 8192 crc 031e509f md5 undefined sha1 667a528e8cf3fd7f533cf67993f48bcc3c100e0d )
-)
-
-game (
-	name "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz) (004-01) ~"
-	description "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz) (004-01) ~"
-	rom ( name "Star Trek - Strategic Operations Simulator (1983) (Sega, Jeff Lorenz) (004-01) ~.bin" size 8192 crc 820ea8a2 md5 undefined sha1 61a3ebbffa0bfb761295c66e189b62915f4818d9 )
-)
-
-game (
-	name "Star Voyager (1982) (Imagic, Bob Smith) (720000-201, 720102-1B, IA3201) ~"
-	description "Star Voyager (1982) (Imagic, Bob Smith) (720000-201, 720102-1B, IA3201) ~"
-	rom ( name "Star Voyager (1982) (Imagic, Bob Smith) (720000-201, 720102-1B, IA3201) ~.bin" size 4096 crc 4fe8477f md5 undefined sha1 ccc5b829c4aa71acb7976e741fdbf59c8ef9eb55 )
-)
-
-game (
-	name "Star Voyager (1982) (Imagic, Bob Smith) (720102-2B, IA3201P, EIX-011-04I) (PAL)"
-	description "Star Voyager (1982) (Imagic, Bob Smith) (720102-2B, IA3201P, EIX-011-04I) (PAL)"
-	rom ( name "Star Voyager (1982) (Imagic, Bob Smith) (720102-2B, IA3201P, EIX-011-04I) (PAL).bin" size 4096 crc aff3b46e md5 undefined sha1 422c6544998ac6c5239083a85ce94f50f9a12a00 )
-)
-
-game (
-	name "Star Voyager (1983) (CCE) (C-818)"
-	description "Star Voyager (1983) (CCE) (C-818)"
-	rom ( name "Star Voyager (1983) (CCE) (C-818).bin" size 4096 crc ed585369 md5 undefined sha1 effd8864585efc7efabf11962c15d3a6b0626b69 )
-)
-
-game (
-	name "Star Voyager (1983) (CCE) (C-818) [a]"
-	description "Star Voyager (1983) (CCE) (C-818) [a]"
-	rom ( name "Star Voyager (1983) (CCE) (C-818) [a].bin" size 4096 crc c76530e1 md5 undefined sha1 417bb89e1117413321ffba48a17e005b2687680b )
-)
-
-game (
-	name "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (931507) (PAL)"
-	description "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (931507) (PAL)"
-	rom ( name "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (931507) (PAL).bin" size 4096 crc 3bd1cda3 md5 undefined sha1 ac51aa0192cc41bc08329776c1b02ae388a9c558 )
-)
-
-game (
-	name "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (PB5000) ~"
-	description "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (PB5000) ~"
-	rom ( name "Star Wars - Jedi Arena (Paddle) (1983) (Parker Brothers, Rex Bradford) (PB5000) ~.bin" size 4096 crc 9e36d347 md5 undefined sha1 36b9edc7150311203f375c1be10d0510efde6476 )
-)
-
-game (
-	name "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (931513) (PAL)"
-	description "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (931513) (PAL)"
-	rom ( name "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (931513) (PAL).bin" size 8192 crc 2a2bd248 md5 undefined sha1 19447d7eabdecd9984be1a2ad500ba34251c458a )
-)
-
-game (
-	name "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (PB5060) ~"
-	description "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (PB5060) ~"
-	rom ( name "Star Wars - Return of the Jedi - Death Star Battle (Revenge of the Jedi - Game II) (1983) (Parker Brothers, Ray Miller, Todd Marshall) (PB5060) ~.bin" size 8192 crc 0886a55d md5 undefined sha1 2ad9db4b5aec2da36ecc3178599b02619c3c462e )
-)
-
-game (
-	name "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) (PAL)"
-	description "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) (PAL)"
-	rom ( name "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) (PAL).bin" size 8192 crc d113f5fe md5 undefined sha1 c9d201935bbe6373793241ba9c03cc02f1df31c9 )
-)
-
-game (
-	name "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) ~"
-	description "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) ~"
-	rom ( name "Star Wars - Return of the Jedi - Ewok Adventure (Revenge of the Jedi - Game I) (1983) (Parker Brothers, Larry Gelberg, Gary Goltz) (PB5065) (Prototype) ~.bin" size 8192 crc 939550e7 md5 undefined sha1 b759eabf0dcb112c94b9fd66451a882130667860 )
-)
-
-game (
-	name "Star Wars - The Arcade Game (01-03-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	description "Star Wars - The Arcade Game (01-03-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	rom ( name "Star Wars - The Arcade Game (01-03-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype).bin" size 4096 crc fa4a0e53 md5 undefined sha1 9657f1e445d6e406a48115846352f4f9bc815ec8 )
-)
-
-game (
-	name "Star Wars - The Arcade Game (04-05-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype) (8K)"
-	description "Star Wars - The Arcade Game (04-05-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype) (8K)"
-	rom ( name "Star Wars - The Arcade Game (04-05-1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype) (8K).bin" size 8192 crc 47efd61d md5 undefined sha1 e3c6f3dd4390fb60d88a05ef084947574d313ba5 )
-)
-
-game (
-	name "Star Wars - The Arcade Game (12-05-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	description "Star Wars - The Arcade Game (12-05-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	rom ( name "Star Wars - The Arcade Game (12-05-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype).bin" size 4096 crc 665077d0 md5 undefined sha1 e5122f75129085d803997244246d45eb007ede9a )
-)
-
-game (
-	name "Star Wars - The Arcade Game (12-15-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	description "Star Wars - The Arcade Game (12-15-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	rom ( name "Star Wars - The Arcade Game (12-15-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype).bin" size 4096 crc 04b83443 md5 undefined sha1 dc0741b28cdf29558b0c5ee376b4dc90984b92d7 )
-)
-
-game (
-	name "Star Wars - The Arcade Game (12-23-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	description "Star Wars - The Arcade Game (12-23-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype)"
-	rom ( name "Star Wars - The Arcade Game (12-23-1983) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (Prototype).bin" size 4096 crc 39bc1d6c md5 undefined sha1 58baf6739e6128048cb6d59971e93700a9de6f2f )
-)
-
-game (
-	name "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (PAL)"
-	description "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (PAL)"
-	rom ( name "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) (PAL).bin" size 8192 crc 273bda48 md5 undefined sha1 914eb4529f5fa044516ba2cf5a606e847cbf0d15 )
-)
-
-game (
-	name "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) ~"
-	description "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) ~"
-	rom ( name "Star Wars - The Arcade Game (1984) (Parker Brothers, Wilfredo 'Willy' Aguilar, Michael Becker, Neil McKenzie, Bob Smith, Brad Stewart) (PB5540) ~.bin" size 8192 crc 65c31ca4 md5 undefined sha1 8823fe3d8e3aeadc6b61ca51914e3b15aa13801c )
-)
-
-game (
-	name "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (931501) (PAL)"
-	description "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (931501) (PAL)"
-	rom ( name "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (931501) (PAL).bin" size 4096 crc b1ddc9a6 md5 undefined sha1 7276ae9e8a99618378868d8de2cf7de6ae6c1dc0 )
-)
-
-game (
-	name "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (PB5050) ~"
-	description "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (PB5050) ~"
-	rom ( name "Star Wars - The Empire Strikes Back (1982) (Parker Brothers, Rex Bradford, Sam Kjellman) (PB5050) ~.bin" size 4096 crc ee8c9a89 md5 undefined sha1 ad5b2c9df558ab23ad2954fe49ed5b37a06009bf )
-)
-
-game (
-	name "Stargate (1984) (Atari, Andrew Fuchs) (CX26120) ~"
-	description "Stargate (1984) (Atari, Andrew Fuchs) (CX26120) ~"
-	rom ( name "Stargate (1984) (Atari, Andrew Fuchs) (CX26120) ~.bin" size 8192 crc cde3530e md5 undefined sha1 4f87be0ef16a1d0389226d1fbda9b4c16b06e13e )
-)
-
-game (
-	name "Stargate (1984) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL)"
-	description "Stargate (1984) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL)"
-	rom ( name "Stargate (1984) (Atari, Bill Aspromonte, Andrew Fuchs) (CX26120) (PAL).bin" size 8192 crc d3f6a968 md5 undefined sha1 07920046ed55519797274117f2f8c8c7e530f623 )
-)
-
-game (
-	name "Stargunner (1982) (Telesys, Alex Leavens) (1005) ~"
-	description "Stargunner (1982) (Telesys, Alex Leavens) (1005) ~"
-	rom ( name "Stargunner (1982) (Telesys, Alex Leavens) (1005) ~.bin" size 4096 crc fca9c17b md5 undefined sha1 3359aa7a6a5fa25beaa3ae5868d0034d52de9882 )
-)
-
-game (
-	name "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL)"
-	description "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL)"
-	rom ( name "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL).bin" size 4096 crc 058c7dac md5 undefined sha1 1b15da84a0e50a91ededde6ff2ef4781d0eef481 )
-)
-
-game (
-	name "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL) [fixed]"
-	description "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL) [fixed]"
-	rom ( name "StarMaster - Kommando Galaxis (1982) (Activision, Alan Miller - Ariola) (EAX-016, PAX-016 - 711 016-725) (PAL) [fixed].bin" size 4096 crc 04b684fe md5 undefined sha1 49d9c811992e6f900a3ef795a792e48dd45187ae )
-)
-
-game (
-	name "StarMaster (1982) (Activision, Alan Miller) (AX-016) ~"
-	description "StarMaster (1982) (Activision, Alan Miller) (AX-016) ~"
-	rom ( name "StarMaster (1982) (Activision, Alan Miller) (AX-016) ~.bin" size 4096 crc 25248b4b md5 undefined sha1 814876ed270114912363e4718a84123dee213b6f )
-)
-
-game (
-	name "StarMaster (Unknown) (PAL)"
-	description "StarMaster (Unknown) (PAL)"
-	rom ( name "StarMaster (Unknown) (PAL).bin" size 4096 crc 8f3449ce md5 undefined sha1 bc2ea6e663d679ad2e5cf8efbf85a55808e7d564 )
-)
-
-game (
-	name "Steeplechase (1983) (Video Gems) (VG-03) (PAL) ~"
-	description "Steeplechase (1983) (Video Gems) (VG-03) (PAL) ~"
-	rom ( name "Steeplechase (1983) (Video Gems) (VG-03) (PAL) ~.bin" size 4096 crc 6aad3f22 md5 undefined sha1 bd7f0005fa018f13ed7e942c83c1751fb746a317 )
-)
-
-game (
-	name "Steeplechase (Paddle) (04-15-1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) (Prototype)"
-	description "Steeplechase (Paddle) (04-15-1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) (Prototype)"
-	rom ( name "Steeplechase (Paddle) (04-15-1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) (Prototype).bin" size 2048 crc 9ba7be18 md5 undefined sha1 c09cc17f53630b07f5ab672316f58b2dfedf4197 )
-)
-
-game (
-	name "Steeplechase (Paddle) (1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) ~"
-	description "Steeplechase (Paddle) (1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) ~"
-	rom ( name "Steeplechase (Paddle) (1980) (Sears Tele-Games, Jim Huether) (CX2614 - 49-75126) ~.bin" size 2048 crc 5f6c32c3 md5 undefined sha1 e56ef1c0313d6d04e25446c4e34f9bb7eda8efac )
-)
-
-game (
-	name "Stellar Track (Stella Trek) (1980) (Sears Tele-Games, Robert Zdybel) (CX2619 - 49-75159) ~"
-	description "Stellar Track (Stella Trek) (1980) (Sears Tele-Games, Robert Zdybel) (CX2619 - 49-75159) ~"
-	rom ( name "Stellar Track (Stella Trek) (1980) (Sears Tele-Games, Robert Zdybel) (CX2619 - 49-75159) ~.bin" size 4096 crc a76e93bf md5 undefined sha1 7d97d014c22a2ed3a5bc4b310f5a7be1b1d3520f )
-)
-
-game (
-	name "Stone Age (1983) (CCE) (C-840) ~"
-	description "Stone Age (1983) (CCE) (C-840) ~"
-	rom ( name "Stone Age (1983) (CCE) (C-840) ~.bin" size 4096 crc 8bcdb222 md5 undefined sha1 45d37e37dea763956737110770e3d33de9c873a5 )
-)
-
-game (
-	name "Stopp die Gangster (AKA Gangster Alley) (1983) (Quelle) (377.943 6) (PAL)"
-	description "Stopp die Gangster (AKA Gangster Alley) (1983) (Quelle) (377.943 6) (PAL)"
-	rom ( name "Stopp die Gangster (AKA Gangster Alley) (1983) (Quelle) (377.943 6) (PAL).bin" size 4096 crc 04725fa5 md5 undefined sha1 637f3729bd3994239d1ef5e868e8fc3f57f3b26b )
-)
-
-game (
-	name "Strahlen der Teufelsvoegel (AKA Atlantis) (1983) (Quelle) (463.860 7) (PAL)"
-	description "Strahlen der Teufelsvoegel (AKA Atlantis) (1983) (Quelle) (463.860 7) (PAL)"
-	rom ( name "Strahlen der Teufelsvoegel (AKA Atlantis) (1983) (Quelle) (463.860 7) (PAL).bin" size 4096 crc 02cfe4a3 md5 undefined sha1 af7cc065a40b214770bf597c7da85de9d37eb341 )
-)
-
-game (
-	name "Strategy X (1983) (Gakken) (010) (PAL)"
-	description "Strategy X (1983) (Gakken) (010) (PAL)"
-	rom ( name "Strategy X (1983) (Gakken) (010) (PAL).bin" size 4096 crc 14ce4c53 md5 undefined sha1 96dbd3a9cb981c42540eac99b5869163a6fb81c4 )
-)
-
-game (
-	name "Strategy X (1983) (Konami) (RC 101-X 02) ~"
-	description "Strategy X (1983) (Konami) (RC 101-X 02) ~"
-	rom ( name "Strategy X (1983) (Konami) (RC 101-X 02) ~.bin" size 4096 crc 2af91a81 md5 undefined sha1 9d6decda6e8ab263f7380ff662c814b8cb8caf34 )
-)
-
-game (
-	name "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) (PAL)"
-	description "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) (PAL)"
-	rom ( name "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) (PAL).bin" size 4096 crc 193579b0 md5 undefined sha1 8df406604191aabe43d623d482ff5f38e6674634 )
-)
-
-game (
-	name "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) ~"
-	description "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) ~"
-	rom ( name "Strawberry Shortcake - Musical Match-Ups (1983) (Parker Brothers, Dawn Stockbridge) (PB5910) ~.bin" size 4096 crc fb29e31f md5 undefined sha1 7ca8f9cd74cfa505c493757ff37bf127ff467bb4 )
-)
-
-game (
-	name "Street Racer - Speedway II (Wheels) (Paddle) (1977) (Atari, Larry Kaplan - Sears) (CX2612 - 99804, 49-75103) ~"
-	description "Street Racer - Speedway II (Wheels) (Paddle) (1977) (Atari, Larry Kaplan - Sears) (CX2612 - 99804, 49-75103) ~"
-	rom ( name "Street Racer - Speedway II (Wheels) (Paddle) (1977) (Atari, Larry Kaplan - Sears) (CX2612 - 99804, 49-75103) ~.bin" size 2048 crc 47592880 md5 undefined sha1 bffb3d41916c83398624151eb00aa2a3acd23ab8 )
-)
-
-game (
-	name "Street Racer (Wheels) (Paddle) (1977) (Atari, Larry Kaplan) (CX2612, CX2612P) (PAL)"
-	description "Street Racer (Wheels) (Paddle) (1977) (Atari, Larry Kaplan) (CX2612, CX2612P) (PAL)"
-	rom ( name "Street Racer (Wheels) (Paddle) (1977) (Atari, Larry Kaplan) (CX2612, CX2612P) (PAL).bin" size 2048 crc c39ab46a md5 undefined sha1 10f66b516eae5bb96193fdea46aafb36213ab3be )
-)
-
-game (
-	name "Stronghold (1983) (CommaVid, Joseph Biel) (CM-009) ~"
-	description "Stronghold (1983) (CommaVid, Joseph Biel) (CM-009) ~"
-	rom ( name "Stronghold (1983) (CommaVid, Joseph Biel) (CM-009) ~.bin" size 4096 crc bb91ffa6 md5 undefined sha1 2cfe280fdbb6b5c8cda8a4620df12a5154e123be )
-)
-
-game (
-	name "Stunt Cycle (Paddle) (07-21-1980) (Atari, Robert C. Polaro) (CX26157) (Prototype) ~"
-	description "Stunt Cycle (Paddle) (07-21-1980) (Atari, Robert C. Polaro) (CX26157) (Prototype) ~"
-	rom ( name "Stunt Cycle (Paddle) (07-21-1980) (Atari, Robert C. Polaro) (CX26157) (Prototype) ~.bin" size 2048 crc 6354ff4c md5 undefined sha1 2e19d7e16cf17682b043baaa30e345e6fa4540e5 )
-)
-
-game (
-	name "Stunt Man (AKA Nightmare) (1983) (Panda) (105)"
-	description "Stunt Man (AKA Nightmare) (1983) (Panda) (105)"
-	rom ( name "Stunt Man (AKA Nightmare) (1983) (Panda) (105).bin" size 4096 crc ea30cdd5 md5 undefined sha1 3aec7ea8af72bbe105b9d2903a92f5ad2b37bddb )
-)
-
-game (
-	name "Sub-Scan (Subterfuge) (1982) (Sega) (002-01) ~"
-	description "Sub-Scan (Subterfuge) (1982) (Sega) (002-01) ~"
-	rom ( name "Sub-Scan (Subterfuge) (1982) (Sega) (002-01) ~.bin" size 4096 crc 5069d7da md5 undefined sha1 ccd75f0141b917656ef2b86c068fba3238d18a0c )
-)
-
-game (
-	name "Sub-Scan (Unknown) (PAL)"
-	description "Sub-Scan (Unknown) (PAL)"
-	rom ( name "Sub-Scan (Unknown) (PAL).bin" size 4096 crc c3105d0b md5 undefined sha1 35cce03eec2660593881bb775ac907aedff07393 )
-)
-
-game (
-	name "Submarine Commander (Seawolf 3) (1982) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) ~"
-	description "Submarine Commander (Seawolf 3) (1982) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) ~"
-	rom ( name "Submarine Commander (Seawolf 3) (1982) (Sears Tele-Games, Marilyn Churchill, Matthew L. Hubbard) (CX2647 - 49-75142) ~.bin" size 4096 crc 3262960a md5 undefined sha1 b22ba7cbde60a21ecbbe3953cc4a5c0bf007cc26 )
-)
-
-game (
-	name "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (720112-1A, 03213) ~"
-	description "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (720112-1A, 03213) ~"
-	rom ( name "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (720112-1A, 03213) ~.bin" size 8192 crc 2ab951f7 md5 undefined sha1 2abc6bbcab27985f19e42915530fd556b6b1ae23 )
-)
-
-game (
-	name "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (EIZ-003-04I) (PAL)"
-	description "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (EIZ-003-04I) (PAL)"
-	rom ( name "Subterranea (Tarantula) (1983) (Imagic, Mark Klein) (EIZ-003-04I) (PAL).bin" size 8192 crc 6c74afed md5 undefined sha1 47a846bce53f739ec2cf5774fe09d70e755111af )
-)
-
-game (
-	name "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype)"
-	description "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype)"
-	rom ( name "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (Prototype).bin" size 8448 crc 54efd148 md5 undefined sha1 c3a79f8dbd4af3628ff91fa0f99f995a8756f4fa )
-)
-
-game (
-	name "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) ~"
-	description "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) ~"
-	rom ( name "Suicide Mission (Meteoroids) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) ~.bin" size 8448 crc b92c49e3 md5 undefined sha1 d3919b4dbeedfabfba30126d351eab509b0c1536 )
-)
-
-game (
-	name "Suicide Mission (Meteoroids) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL)"
-	description "Suicide Mission (Meteoroids) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL)"
-	rom ( name "Suicide Mission (Meteoroids) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL).bin" size 8448 crc 3b2a9c8a md5 undefined sha1 3b6d664440442f5f1d0220ef01d967a6004bbbdd )
-)
-
-game (
-	name "Suicide Mission (Meteoroids) (Preview) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102)"
-	description "Suicide Mission (Meteoroids) (Preview) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102)"
-	rom ( name "Suicide Mission (Meteoroids) (Preview) (1982) (Arcadia Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102).bin" size 8448 crc 4705b9c4 md5 undefined sha1 35061334cd1d26345e2459dfd663d240759eb5f4 )
-)
-
-game (
-	name "Suicide Mission (Meteoroids) (Preview) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL)"
-	description "Suicide Mission (Meteoroids) (Preview) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL)"
-	rom ( name "Suicide Mission (Meteoroids) (Preview) (1982) (Starpath Corporation, Steve Hales, Stephen Harland Landrum) (4) (AR-4102) (PAL).bin" size 8448 crc 67e4a405 md5 undefined sha1 c15c986f92bd068ec844c9cc3da73ff410ec002a )
-)
-
-game (
-	name "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) (PAL)"
-	description "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) (PAL)"
-	rom ( name "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) (PAL).bin" size 16384 crc 0c3c5ba9 md5 undefined sha1 3b5345fa194e449b27d014cc9934b662493dc9ba )
-)
-
-game (
-	name "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) ~"
-	description "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) ~"
-	rom ( name "Summer Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00250) ~.bin" size 16384 crc b9cd3f86 md5 undefined sha1 65f4a708e6af565f1f75d0fbdc8942cb149cf299 )
-)
-
-game (
-	name "Super Action Pak - Pitfall, Barnstorming, Grand Prix, Laser Blast (1988) (HES - Activision) (223) (PAL)"
-	description "Super Action Pak - Pitfall, Barnstorming, Grand Prix, Laser Blast (1988) (HES - Activision) (223) (PAL)"
-	rom ( name "Super Action Pak - Pitfall, Barnstorming, Grand Prix, Laser Blast (1988) (HES - Activision) (223) (PAL).bin" size 16384 crc f305ba47 md5 undefined sha1 0fd7b46d7e1c5eeea68108d0bb92ec3872ab3d56 )
-)
-
-game (
-	name "Super Baseball (1988) (Atari, Joseph Tung) (CX26152)"
-	description "Super Baseball (1988) (Atari, Joseph Tung) (CX26152)"
-	rom ( name "Super Baseball (1988) (Atari, Joseph Tung) (CX26152).bin" size 16384 crc 2245f170 md5 undefined sha1 b066a60ea1df1db0a55271c7608b0e19e4d18a1e )
-)
-
-game (
-	name "Super Baseball (1988) (Atari, Joseph Tung) (CX26152) (PAL)"
-	description "Super Baseball (1988) (Atari, Joseph Tung) (CX26152) (PAL)"
-	rom ( name "Super Baseball (1988) (Atari, Joseph Tung) (CX26152) (PAL).bin" size 16384 crc c3704b73 md5 undefined sha1 4c83731258126ecc7044155d17995601109a6f69 )
-)
-
-game (
-	name "Super Baseball (AKA RealSports Baseball) (CCE)"
-	description "Super Baseball (AKA RealSports Baseball) (CCE)"
-	rom ( name "Super Baseball (AKA RealSports Baseball) (CCE).bin" size 8192 crc bff44c80 md5 undefined sha1 8c8738fabdc3b42046e3c9c219f38dd5b7051952 )
-)
-
-game (
-	name "Super Box (AKA RealSports Boxing) (CCE)"
-	description "Super Box (AKA RealSports Boxing) (CCE)"
-	rom ( name "Super Box (AKA RealSports Boxing) (CCE).bin" size 16384 crc 0b629d9b md5 undefined sha1 bdc2b5517072a15f65683c662ea5344bcba8a092 )
-)
-
-game (
-	name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) [a]"
-	description "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) [a]"
-	rom ( name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) [a].bin" size 4096 crc 171dbe92 md5 undefined sha1 e380e243c671e954e86aa1a3a0bfeb36d5e0c3e2 )
-)
-
-game (
-	name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) ~"
-	description "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) ~"
-	rom ( name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner - Sears) (CX2608 - 49-75165) ~.bin" size 4096 crc b0f20d31 md5 undefined sha1 ac2aad2196c155c1d87d6f42fa88891825f4fde6 )
-)
-
-game (
-	name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner) (CX2608) (PAL)"
-	description "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner) (CX2608) (PAL)"
-	rom ( name "Super Breakout (Paddle) (1982 - 1981) (Atari, Carol Shaw, Nick 'Sandy Maiwald' Turner) (CX2608) (PAL).bin" size 4096 crc 79ec7688 md5 undefined sha1 3a9e296950aa8e93e75218b971b8614516292f86 )
-)
-
-game (
-	name "Super Challenge Baseball - Baseball (Big League Baseball) (1982) (M Network, David Rolfe - INTV) (MT5665) ~"
-	description "Super Challenge Baseball - Baseball (Big League Baseball) (1982) (M Network, David Rolfe - INTV) (MT5665) ~"
-	rom ( name "Super Challenge Baseball - Baseball (Big League Baseball) (1982) (M Network, David Rolfe - INTV) (MT5665) ~.bin" size 4096 crc f7e88ec2 md5 undefined sha1 dfce4d6436f91d8d385f8b01f0d8e3488400407b )
-)
-
-game (
-	name "Super Challenge Baseball (208 in 1) (Unknown) (PAL)"
-	description "Super Challenge Baseball (208 in 1) (Unknown) (PAL)"
-	rom ( name "Super Challenge Baseball (208 in 1) (Unknown) (PAL).bin" size 4096 crc e3ecb275 md5 undefined sha1 5b7799e1c98ca86965fa8b73b8750042edb70952 )
-)
-
-game (
-	name "Super Challenge Baseball (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Super Challenge Baseball (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Super Challenge Baseball (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 4c3a91f1 md5 undefined sha1 68b31e9cf626f0291dbcf038447fbf878bb7b37e )
-)
-
-game (
-	name "Super Challenge Football - Football (Pro Football) (1982) (M Network, Ken Smith - INTV) (MT5658) ~"
-	description "Super Challenge Football - Football (Pro Football) (1982) (M Network, Ken Smith - INTV) (MT5658) ~"
-	rom ( name "Super Challenge Football - Football (Pro Football) (1982) (M Network, Ken Smith - INTV) (MT5658) ~.bin" size 4096 crc 55f02efe md5 undefined sha1 5c1338ec76828cfa4a85b5bd8db1c00c8095c330 )
-)
-
-game (
-	name "Super Cobra (1982) (Parker Brothers, Paul Crowley) (931505) (PAL)"
-	description "Super Cobra (1982) (Parker Brothers, Paul Crowley) (931505) (PAL)"
-	rom ( name "Super Cobra (1982) (Parker Brothers, Paul Crowley) (931505) (PAL).bin" size 8192 crc 380d78b3 md5 undefined sha1 3ea967933740da36f47c04b269587da134a93c34 )
-)
-
-game (
-	name "Super Cobra (1982) (Parker Brothers, Paul Crowley) (PB5320) ~"
-	description "Super Cobra (1982) (Parker Brothers, Paul Crowley) (PB5320) ~"
-	rom ( name "Super Cobra (1982) (Parker Brothers, Paul Crowley) (PB5320) ~.bin" size 8192 crc de97103d md5 undefined sha1 bac0a0256509f8fd1feea93d74ba4c7d82c1edc6 )
-)
-
-game (
-	name "Super Ferrari (AKA Enduro) (Rainbow Vision - Suntek) (SS-011) (PAL)"
-	description "Super Ferrari (AKA Enduro) (Rainbow Vision - Suntek) (SS-011) (PAL)"
-	rom ( name "Super Ferrari (AKA Enduro) (Rainbow Vision - Suntek) (SS-011) (PAL).bin" size 4096 crc 935ff66a md5 undefined sha1 7453f744e250bda7601e1e28b30b7dbcba8b5df1 )
-)
-
-game (
-	name "Super Football (1988) (Atari, Douglas Neubauer) (CX26154, CX26154P) (PAL)"
-	description "Super Football (1988) (Atari, Douglas Neubauer) (CX26154, CX26154P) (PAL)"
-	rom ( name "Super Football (1988) (Atari, Douglas Neubauer) (CX26154, CX26154P) (PAL).bin" size 16384 crc d3004956 md5 undefined sha1 fa8db954eff4302ec518aaf7a477a073c1967a08 )
-)
-
-game (
-	name "Super Football (1988) (Atari, Douglas Neubauer) (CX26154) ~"
-	description "Super Football (1988) (Atari, Douglas Neubauer) (CX26154) ~"
-	rom ( name "Super Football (1988) (Atari, Douglas Neubauer) (CX26154) ~.bin" size 16384 crc c9b16f3c md5 undefined sha1 eaca6b474fd552ab4aaf75526618828165a91934 )
-)
-
-game (
-	name "Super Futebol (AKA RealSports Football) (CCE)"
-	description "Super Futebol (AKA RealSports Football) (CCE)"
-	rom ( name "Super Futebol (AKA RealSports Football) (CCE).bin" size 8192 crc 676a7a8f md5 undefined sha1 c80d497a99b2fe1e3ce6ea635f71a2337e67c3d5 )
-)
-
-game (
-	name "Super Futebol (AKA RealSports Soccer) (CCE)"
-	description "Super Futebol (AKA RealSports Soccer) (CCE)"
-	rom ( name "Super Futebol (AKA RealSports Soccer) (CCE).bin" size 8192 crc dd18b531 md5 undefined sha1 484d97e78ff832edca5382f31e084497e591cc72 )
-)
-
-game (
-	name "Super Hit Pak - River Raid, Sky Jinks, Grand Prix, Fishing Derby, Checkers (HES - Activision) (PAL)"
-	description "Super Hit Pak - River Raid, Sky Jinks, Grand Prix, Fishing Derby, Checkers (HES - Activision) (PAL)"
-	rom ( name "Super Hit Pak - River Raid, Sky Jinks, Grand Prix, Fishing Derby, Checkers (HES - Activision) (PAL).bin" size 16384 crc c82fec7c md5 undefined sha1 c078eb24cc8c9a504089147e80586a4edb303e0e )
-)
-
-game (
-	name "Super Kung-Fu (1983) (Xonox - K-Tel Software) (6230, 6250) (PAL)"
-	description "Super Kung-Fu (1983) (Xonox - K-Tel Software) (6230, 6250) (PAL)"
-	rom ( name "Super Kung-Fu (1983) (Xonox - K-Tel Software) (6230, 6250) (PAL).bin" size 8192 crc 2c94f6e8 md5 undefined sha1 50164dddbae3172bfa3a6ed2aaf3d5387ed7314d )
-)
-
-game (
-	name "Super Soccer (AKA RealSports Soccer) (Digivision)"
-	description "Super Soccer (AKA RealSports Soccer) (Digivision)"
-	rom ( name "Super Soccer (AKA RealSports Soccer) (Digivision).bin" size 8192 crc c1f30e80 md5 undefined sha1 b7df23296af495bb453cefb8e92ed84e4bc45c14 )
-)
-
-game (
-	name "Super Tenis (AKA RealSports Tennis) (VGS)"
-	description "Super Tenis (AKA RealSports Tennis) (VGS)"
-	rom ( name "Super Tenis (AKA RealSports Tennis) (VGS).bin" size 8192 crc 107de061 md5 undefined sha1 2541d87fa902f04ef373823561f4973ffaa34940 )
-)
-
-game (
-	name "Super Tennis (AKA RealSports Tennis) (1983) (CCE) (C-1005)"
-	description "Super Tennis (AKA RealSports Tennis) (1983) (CCE) (C-1005)"
-	rom ( name "Super Tennis (AKA RealSports Tennis) (1983) (CCE) (C-1005).bin" size 8192 crc 7070af33 md5 undefined sha1 bab9297ee2baf770f4649b8555e52edf579d6191 )
-)
-
-game (
-	name "Super Tennis (AKA RealSports Tennis) (Tron)"
-	description "Super Tennis (AKA RealSports Tennis) (Tron)"
-	rom ( name "Super Tennis (AKA RealSports Tennis) (Tron).bin" size 8192 crc 8203b40e md5 undefined sha1 ed90365800db9467fda66462b9ac83eb04a40eab )
-)
-
-game (
-	name "Super Voleyball (AKA RealSports Volleyball) (CCE)"
-	description "Super Voleyball (AKA RealSports Volleyball) (CCE)"
-	rom ( name "Super Voleyball (AKA RealSports Volleyball) (CCE).bin" size 4096 crc 5423dc84 md5 undefined sha1 b79c4f51d48009e42e8dec26a91305acfe7f43a8 )
-)
-
-game (
-	name "Super-Cowboy beim Rodeo (AKA Stampede) (1983) (Quelle) (874.254 6) (PAL)"
-	description "Super-Cowboy beim Rodeo (AKA Stampede) (1983) (Quelle) (874.254 6) (PAL)"
-	rom ( name "Super-Cowboy beim Rodeo (AKA Stampede) (1983) (Quelle) (874.254 6) (PAL).bin" size 2048 crc a4f590f7 md5 undefined sha1 3954fe67731402ad72815d819bb1fc1f3c7bbf33 )
-)
-
-game (
-	name "Super-Ferrari (AKA Enduro) (1983) (Quelle) (402.272 9) (PAL)"
-	description "Super-Ferrari (AKA Enduro) (1983) (Quelle) (402.272 9) (PAL)"
-	rom ( name "Super-Ferrari (AKA Enduro) (1983) (Quelle) (402.272 9) (PAL).bin" size 4096 crc d6888bc7 md5 undefined sha1 82a7044533f9556a9cd065881ccb9ed31f14dfd0 )
-)
-
-game (
-	name "Super-Ferrari (AKA Enduro) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Super-Ferrari (AKA Enduro) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Super-Ferrari (AKA Enduro) (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 513823e4 md5 undefined sha1 22a61238c218a83fdf0cce5986248d97577eb467 )
-)
-
-game (
-	name "Super-Ferrari (AKA Enduro) (Unknown)"
-	description "Super-Ferrari (AKA Enduro) (Unknown)"
-	rom ( name "Super-Ferrari (AKA Enduro) (Unknown).bin" size 4096 crc 4d07b643 md5 undefined sha1 fb848665f7fe8029f80b1c0aae5972f262852bf7 )
-)
-
-game (
-	name "Supercharger BIOS (1982) (Arcadia Corporation)"
-	description "Supercharger BIOS (1982) (Arcadia Corporation)"
-	rom ( name "Supercharger BIOS (1982) (Arcadia Corporation).bin" size 2048 crc c3a3f073 md5 undefined sha1 cd9d030a59f5bdcc88f1f80a6cc9fc2cd932f7db )
-)
-
-game (
-	name "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) [fixed] ~"
-	description "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) [fixed] ~"
-	rom ( name "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) [fixed] ~.bin" size 4096 crc afd7317b md5 undefined sha1 f00bcbda3d70c0c93026234fc775daf81db8569a )
-)
-
-game (
-	name "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) ~"
-	description "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) ~"
-	rom ( name "Superman (1979) (Atari, John Dunn - Sears) (CX2631 - 49-75152) ~.bin" size 4096 crc 39562bd7 md5 undefined sha1 b9dee027c8d7dd2a46be111ab0b8363c1becc081 )
-)
-
-game (
-	name "Superman (1979) (Atari, John Dunn) (CX2631, CX2631P) (PAL)"
-	description "Superman (1979) (Atari, John Dunn) (CX2631, CX2631P) (PAL)"
-	rom ( name "Superman (1979) (Atari, John Dunn) (CX2631, CX2631P) (PAL).bin" size 4096 crc 2c509a65 md5 undefined sha1 84968517da879f307e1f6d2de3462b2b0bdb95f2 )
-)
-
-game (
-	name "Superman (1983) (CCE) (C-857)"
-	description "Superman (1983) (CCE) (C-857)"
-	rom ( name "Superman (1983) (CCE) (C-857).bin" size 4096 crc 1454c45a md5 undefined sha1 7c4b3cce50ed1b5f1817c8fbf9ebc42e2f8855e8 )
-)
-
-game (
-	name "Superman (Unknown) (PAL)"
-	description "Superman (Unknown) (PAL)"
-	rom ( name "Superman (Unknown) (PAL).bin" size 4096 crc 50972ecd md5 undefined sha1 a974673dccfb786da6150df8d4584a559508a6de )
-)
-
-game (
-	name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) (4K)"
-	description "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) (4K)"
-	rom ( name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) (4K).bin" size 4096 crc bdb0858e md5 undefined sha1 bb56b41c69ad3ffb17f0d7c27361982a326e0469 )
-)
-
-game (
-	name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a1]"
-	description "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a1]"
-	rom ( name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a1].bin" size 8192 crc f5030c8c md5 undefined sha1 9c11b5b0f75b11eea116cc80f60d49e20289637b )
-)
-
-game (
-	name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a2]"
-	description "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a2]"
-	rom ( name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) [a2].bin" size 8192 crc f34de261 md5 undefined sha1 f903a3e5ed454356da7d27d3c6bd1e15f1d637a6 )
-)
-
-game (
-	name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) ~"
-	description "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) ~"
-	rom ( name "Surf's Up (Joyboard) (1983) (Amiga) (3125) (Prototype) ~.bin" size 8192 crc 0cfd04d9 md5 undefined sha1 cf84e21ada55730d689cfac7d26e2295317222bc )
-)
-
-game (
-	name "Surfer's Paradise - But Danger Below! (1983) (Video Gems) (VG-02) (PAL) ~"
-	description "Surfer's Paradise - But Danger Below! (1983) (Video Gems) (VG-02) (PAL) ~"
-	rom ( name "Surfer's Paradise - But Danger Below! (1983) (Video Gems) (VG-02) (PAL) ~.bin" size 4096 crc 8c68f2ae md5 undefined sha1 e754c8985ca7f5780c23a856656099b710e89919 )
-)
-
-game (
-	name "Surround - Chase (Blockade) (1977) (Atari, Alan Miller - Sears) (CX2641 - 99807, 49-75105) ~"
-	description "Surround - Chase (Blockade) (1977) (Atari, Alan Miller - Sears) (CX2641 - 99807, 49-75105) ~"
-	rom ( name "Surround - Chase (Blockade) (1977) (Atari, Alan Miller - Sears) (CX2641 - 99807, 49-75105) ~.bin" size 2048 crc dcb11f23 md5 undefined sha1 b7988373b81992d08056560d15d3e32d9d3888bc )
-)
-
-game (
-	name "Surround (1977) (Blockade) (Atari, Alan Miller) (CX2641, CX2641P) (PAL)"
-	description "Surround (1977) (Blockade) (Atari, Alan Miller) (CX2641, CX2641P) (PAL)"
-	rom ( name "Surround (1977) (Blockade) (Atari, Alan Miller) (CX2641, CX2641P) (PAL).bin" size 2048 crc 876d3bb5 md5 undefined sha1 944d4e2a3edd3120b8595a7c6aad857cff044534 )
-)
-
-game (
-	name "Surround (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL)"
-	description "Surround (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL)"
-	rom ( name "Surround (32 in 1) (1988) (Atari, Alan Miller) (CX26163P) (PAL).bin" size 2048 crc 45d3d533 md5 undefined sha1 62cc0bc432c81e9fcbc8a19bbcb68559b548ffdf )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	description "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	rom ( name "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401).bin" size 8448 crc ea4f2765 md5 undefined sha1 cba1c7d15cc3c7b6164652866f958297de9d7eef )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	description "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	rom ( name "Survival Island (Jungle Raid) (1 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL).bin" size 8448 crc 2ee59279 md5 undefined sha1 b1344b694ed1408ef50a6c9b1fe162c5b850cd1e )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	description "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	rom ( name "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL).bin" size 25344 crc fc7693c2 md5 undefined sha1 4b9015c96507e32d18876cb7fe9ef3471998bf1b )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) ~"
-	description "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) ~"
-	rom ( name "Survival Island (Jungle Raid) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) ~.bin" size 25344 crc 8ab91d6b md5 undefined sha1 40808b7a653610359d38a0b5e84d3018edbd0f99 )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	description "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	rom ( name "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401).bin" size 8448 crc ae02fdb4 md5 undefined sha1 bac319deee30cc6fb4f8e12605df2b69a9a249aa )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	description "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	rom ( name "Survival Island (Jungle Raid) (2 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL).bin" size 8448 crc c7dd5f7f md5 undefined sha1 9fecc4ea4fbcba8c0ecaabfe6dc77ea97826cc32 )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	description "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401)"
-	rom ( name "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401).bin" size 8448 crc d23dcfec md5 undefined sha1 34de46efc38be5c870faf11bc878e74519f7aac4 )
-)
-
-game (
-	name "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	description "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL)"
-	rom ( name "Survival Island (Jungle Raid) (3 of 3) (1983) (Starpath Corporation, Steve Mundry, Scott Nelson) (12) (AR-4401) (PAL).bin" size 8448 crc d1f68f7a md5 undefined sha1 e32c7604f84a3a22f455c6900fce28b33ddcf8cc )
-)
-
-game (
-	name "Survival Run (1983) (Data Age) (Prototype) ~"
-	description "Survival Run (1983) (Data Age) (Prototype) ~"
-	rom ( name "Survival Run (1983) (Data Age) (Prototype) ~.bin" size 4096 crc 8e888f3e md5 undefined sha1 bcde63585092f84e437dd57f83bd67bd66b15646 )
-)
-
-game (
-	name "Survival Run (Cosmic Commander) (1983) (Milton Bradley Company) (4362) ~"
-	description "Survival Run (Cosmic Commander) (1983) (Milton Bradley Company) (4362) ~"
-	rom ( name "Survival Run (Cosmic Commander) (1983) (Milton Bradley Company) (4362) ~.bin" size 4096 crc 8c0eea30 md5 undefined sha1 6c993b4c70cfed390f1f436fdbaa1f81495be18e )
-)
-
-game (
-	name "Sweat! - The Decathlon Game (1 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype) ~"
-	description "Sweat! - The Decathlon Game (1 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype) ~"
-	rom ( name "Sweat! - The Decathlon Game (1 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype) ~.bin" size 8448 crc 32297adf md5 undefined sha1 709a413f7d83176c5e6a6a753308752aecd16923 )
-)
-
-game (
-	name "Sweat! - The Decathlon Game (2 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype)"
-	description "Sweat! - The Decathlon Game (2 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype)"
-	rom ( name "Sweat! - The Decathlon Game (2 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype).bin" size 8448 crc bc58243a md5 undefined sha1 e84a3f964098c435d361aba9a2948f7ddc58dc60 )
-)
-
-game (
-	name "Sweat! - The Decathlon Game (3 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype)"
-	description "Sweat! - The Decathlon Game (3 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype)"
-	rom ( name "Sweat! - The Decathlon Game (3 of 3) (Paddle) (1983) (Starpath Corporation, Scott Nelson) (13) (Prototype).bin" size 8448 crc ba1f666b md5 undefined sha1 bea35df3bbcdc7b0a52e5b09716ab6f49719d9b1 )
-)
-
-game (
-	name "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) (PAL)"
-	description "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) (PAL)"
-	rom ( name "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) (PAL).bin" size 8448 crc 670ff870 md5 undefined sha1 f81877de942e4c424db201e80cee3af38e3c105d )
-)
-
-game (
-	name "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) ~"
-	description "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) ~"
-	rom ( name "Sword of Saros (1983) (Starpath Corporation, Stephen Harland Landrum, Jon Leupp) (11) (AR-4201) ~.bin" size 8448 crc d96a3632 md5 undefined sha1 45ab6ae206f86524e31815a736a90287cca94b70 )
-)
-
-game (
-	name "Swordfight (Sword, Swordfighting) (1983) (Intellivision Productions - M Network, Patricia Lewis Du Long, Stephen Tatsumi) ~"
-	description "Swordfight (Sword, Swordfighting) (1983) (Intellivision Productions - M Network, Patricia Lewis Du Long, Stephen Tatsumi) ~"
-	rom ( name "Swordfight (Sword, Swordfighting) (1983) (Intellivision Productions - M Network, Patricia Lewis Du Long, Stephen Tatsumi) ~.bin" size 4096 crc f1ad77be md5 undefined sha1 0d59545b22e15019a33de16999a57dae1f998283 )
-)
-
-game (
-	name "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) (PAL)"
-	description "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) (PAL)"
-	rom ( name "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) (PAL).bin" size 8192 crc 425a9e41 md5 undefined sha1 d89ff9b3f548fa496c215cde4c18bc2f3ccef3ef )
-)
-
-game (
-	name "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) ~"
-	description "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) ~"
-	rom ( name "SwordQuest - EarthWorld (Adventure I, SwordQuest I - EarthWorld) (1982) (Atari, Dan Hitchens) (CX2656) ~.bin" size 8192 crc 9031a479 md5 undefined sha1 3deb650ae26b86e250aea8f7ca6d0674e6498ebb )
-)
-
-game (
-	name "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) (PAL)"
-	description "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) (PAL)"
-	rom ( name "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) (PAL).bin" size 8192 crc 78aba21c md5 undefined sha1 a6fa78edff6b7b61c7b527fe7b6978eb371081ed )
-)
-
-game (
-	name "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) ~"
-	description "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) ~"
-	rom ( name "SwordQuest - FireWorld (Adventure II, SwordQuest II - FireWorld) (1982) (Atari, Tod Frye) (CX2657) ~.bin" size 8192 crc 6ae46a0c md5 undefined sha1 5c3cf976edbea5ded66634a284787f965616d97e )
-)
-
-game (
-	name "SwordQuest - WaterWorld (1983) (Atari, Tod Frye) (CX2671) ~"
-	description "SwordQuest - WaterWorld (1983) (Atari, Tod Frye) (CX2671) ~"
-	rom ( name "SwordQuest - WaterWorld (1983) (Atari, Tod Frye) (CX2671) ~.bin" size 8192 crc ca7b4685 md5 undefined sha1 569fcb67ca1674b48e2f3a2e7af7077a374402de )
-)
-
-game (
-	name "Tac-Scan (Canal 3 - Intellivision)"
-	description "Tac-Scan (Canal 3 - Intellivision)"
-	rom ( name "Tac-Scan (Canal 3 - Intellivision).bin" size 4096 crc 084c366a md5 undefined sha1 2b0aa1c098dc1f78c040528079d213fa7f6f30ea )
-)
-
-game (
-	name "Tac-Scan (Paddle) (1982) (Sega) (001-01) ~"
-	description "Tac-Scan (Paddle) (1982) (Sega) (001-01) ~"
-	rom ( name "Tac-Scan (Paddle) (1982) (Sega) (001-01) ~.bin" size 4096 crc a2a42bec md5 undefined sha1 55e98fe14b07460734781a6aa2f4f1646830c0af )
-)
-
-game (
-	name "Tac-Scan (Unknown) (PAL)"
-	description "Tac-Scan (Unknown) (PAL)"
-	rom ( name "Tac-Scan (Unknown) (PAL).bin" size 4096 crc 8884bf8d md5 undefined sha1 43438f5d7f038a9bf14e7b63228d2e694809e0fe )
-)
-
-game (
-	name "Tank Brigade (AKA Phantom Tank) (1983) (Panda) (101)"
-	description "Tank Brigade (AKA Phantom Tank) (1983) (Panda) (101)"
-	rom ( name "Tank Brigade (AKA Phantom Tank) (1983) (Panda) (101).bin" size 4096 crc 84e9e475 md5 undefined sha1 4bfa4427f823433e628e7fd04200f99ab4262336 )
-)
-
-game (
-	name "Tank City (AKA Thunderground) (Funvision - Fund. International Co.)"
-	description "Tank City (AKA Thunderground) (Funvision - Fund. International Co.)"
-	rom ( name "Tank City (AKA Thunderground) (Funvision - Fund. International Co.).bin" size 4096 crc 524822ef md5 undefined sha1 65a0d7892c799e60a201b1b1b5ca156a28af0ee9 )
-)
-
-game (
-	name "Tanks But No Tanks (AKA Phantom Tank) (1983) (ZiMAG - Emag - Vidco) (707-111 - GN-030)"
-	description "Tanks But No Tanks (AKA Phantom Tank) (1983) (ZiMAG - Emag - Vidco) (707-111 - GN-030)"
-	rom ( name "Tanks But No Tanks (AKA Phantom Tank) (1983) (ZiMAG - Emag - Vidco) (707-111 - GN-030).bin" size 4096 crc 4adbb1f9 md5 undefined sha1 13a9d86cbde32a1478ef0c7ef412427b13bd6222 )
-)
-
-game (
-	name "Tanks War (AKA Phantom Tank) (1983) (Home Vision - Gem International Corp.) (VCS83135) (PAL)"
-	description "Tanks War (AKA Phantom Tank) (1983) (Home Vision - Gem International Corp.) (VCS83135) (PAL)"
-	rom ( name "Tanks War (AKA Phantom Tank) (1983) (Home Vision - Gem International Corp.) (VCS83135) (PAL).bin" size 4096 crc faa839c6 md5 undefined sha1 3e3c466cd12a86aeb03c199d833102a072f33f96 )
-)
-
-game (
-	name "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) (PAL)"
-	description "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) (PAL)"
-	rom ( name "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) (PAL).bin" size 4096 crc 16786d69 md5 undefined sha1 bf495197fd4d9c84e035b6be397a58238bffe51b )
-)
-
-game (
-	name "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) ~"
-	description "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) ~"
-	rom ( name "Tapeworm (1982) (Spectravision, Spectravideo) (SA-204) ~.bin" size 4096 crc d63474b3 md5 undefined sha1 ee8bc1710a67c33e9f95bb05cc3d8f841093fde2 )
-)
-
-game (
-	name "Tapeworm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Tapeworm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Tapeworm (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc e8a5a2db md5 undefined sha1 633ef6359656abe9627b9d5b97eccb9858a4dc8c )
-)
-
-game (
-	name "Tapper (1984) (Sega - Bally Midway - Beck-Tech) (010-01) ~"
-	description "Tapper (1984) (Sega - Bally Midway - Beck-Tech) (010-01) ~"
-	rom ( name "Tapper (1984) (Sega - Bally Midway - Beck-Tech) (010-01) ~.bin" size 8192 crc d28afb2c md5 undefined sha1 e986e1818e747beb9b33ce4dff1cdc6b55bdb620 )
-)
-
-game (
-	name "Targ (1983) (CBS Electronics) (80110) (Prototype)"
-	description "Targ (1983) (CBS Electronics) (80110) (Prototype)"
-	rom ( name "Targ (1983) (CBS Electronics) (80110) (Prototype).bin" size 4096 crc 676cc394 md5 undefined sha1 36139502d3b43fc35874af8b3f06c69d5dc4fa97 )
-)
-
-game (
-	name "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833)"
-	description "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833)"
-	rom ( name "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833).bin" size 4096 crc 54f602eb md5 undefined sha1 ceefabdfd97d2d783cb3d14604f9c059a95eea52 )
-)
-
-game (
-	name "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833) [a]"
-	description "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833) [a]"
-	rom ( name "Target Practice (Carnival) (AKA Carnival) (1983) (CCE) (C-833) [a].bin" size 4096 crc 5436d567 md5 undefined sha1 2f6114e022bf57ff58450d765e60d2f3e3910432 )
-)
-
-game (
-	name "Task Force (AKA Gangster Alley) (1987) (Froggo) (FG1003)"
-	description "Task Force (AKA Gangster Alley) (1987) (Froggo) (FG1003)"
-	rom ( name "Task Force (AKA Gangster Alley) (1987) (Froggo) (FG1003).bin" size 4096 crc 779b87e3 md5 undefined sha1 bae73700ba6532e9e6415b6471d115bdb7805464 )
-)
-
-game (
-	name "Tax Avoiders (1982) (American Videogame - Dunhill Electronics, Darrell Wagner, Todd Clark Holm, John Simonds) ~"
-	description "Tax Avoiders (1982) (American Videogame - Dunhill Electronics, Darrell Wagner, Todd Clark Holm, John Simonds) ~"
-	rom ( name "Tax Avoiders (1982) (American Videogame - Dunhill Electronics, Darrell Wagner, Todd Clark Holm, John Simonds) ~.bin" size 8192 crc 468d734c md5 undefined sha1 7aaf6be610ba6ea1205bdd5ed60838ccb8280d57 )
-)
-
-game (
-	name "Taz (Tazz) (06-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) (PAL)"
-	description "Taz (Tazz) (06-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) (PAL)"
-	rom ( name "Taz (Tazz) (06-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) (PAL).bin" size 8192 crc 144b44eb md5 undefined sha1 2725ee79a5574243302e7a3d32de433696f597e5 )
-)
-
-game (
-	name "Taz (Tazz) (07-13-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	description "Taz (Tazz) (07-13-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	rom ( name "Taz (Tazz) (07-13-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype).bin" size 8192 crc abbdc217 md5 undefined sha1 ffa79f03bb93d51ce6801d675a6221dcd0df4d61 )
-)
-
-game (
-	name "Taz (Tazz) (07-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	description "Taz (Tazz) (07-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	rom ( name "Taz (Tazz) (07-15-1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype).bin" size 8192 crc 8e4df9d5 md5 undefined sha1 670b3dede2702c96494636b6d7f4ae8112501cb4 )
-)
-
-game (
-	name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	description "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype)"
-	rom ( name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype).bin" size 8192 crc dcd3e0de md5 undefined sha1 0bcfd8aa6c33d601c2240850f1188407e2f47331 )
-)
-
-game (
-	name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) [a]"
-	description "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) [a]"
-	rom ( name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) (Prototype) [a].bin" size 8192 crc e6862a1c md5 undefined sha1 c85ef597d56ee08d291597ecf6808427d93059c9 )
-)
-
-game (
-	name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) ~"
-	description "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) ~"
-	rom ( name "Taz (Tazz) (1983) (Atari, Jerome Domurat, Steve Woita) (CX2699) ~.bin" size 8192 crc c9d7ec9b md5 undefined sha1 fa4aee79487036656aabb432d7c6e13ec21e3a3c )
-)
-
-game (
-	name "Teddy Apple (AKA Open Sesame) (1983) (Home Vision - Gem International Corp.) (VCS83137) (PAL)"
-	description "Teddy Apple (AKA Open Sesame) (1983) (Home Vision - Gem International Corp.) (VCS83137) (PAL)"
-	rom ( name "Teddy Apple (AKA Open Sesame) (1983) (Home Vision - Gem International Corp.) (VCS83137) (PAL).bin" size 4096 crc 5f13a336 md5 undefined sha1 45b18efd5761c6138950511f580ebe1047419e4b )
-)
-
-game (
-	name "Telepathy (Mindlink Controller) (1983) (Atari, Dan Oliver) (Prototype) ~"
-	description "Telepathy (Mindlink Controller) (1983) (Atari, Dan Oliver) (Prototype) ~"
-	rom ( name "Telepathy (Mindlink Controller) (1983) (Atari, Dan Oliver) (Prototype) ~.bin" size 8192 crc a0996a0d md5 undefined sha1 7efc0ebe334dde84e25fa020ecde4fddcbea9e8f )
-)
-
-game (
-	name "Teller-Jonglieren! (AKA Dancing Plate) (1983) (Quelle) (685.996 1) (PAL)"
-	description "Teller-Jonglieren! (AKA Dancing Plate) (1983) (Quelle) (685.996 1) (PAL)"
-	rom ( name "Teller-Jonglieren! (AKA Dancing Plate) (1983) (Quelle) (685.996 1) (PAL).bin" size 4096 crc 3e039461 md5 undefined sha1 d144243c0afc541df0400654ae37f38f0bdb5967 )
-)
-
-game (
-	name "Tempest (01-05-1984) (Atari, Carla Meninsky) (CX2687) (Prototype) ~"
-	description "Tempest (01-05-1984) (Atari, Carla Meninsky) (CX2687) (Prototype) ~"
-	rom ( name "Tempest (01-05-1984) (Atari, Carla Meninsky) (CX2687) (Prototype) ~.bin" size 8192 crc 711647f6 md5 undefined sha1 bf4d570c1c738a4d6d00237e25c62e9c3225f98f )
-)
-
-game (
-	name "Tennis - Le Tennis (1981) (Activision, Alan Miller) (AG-007, CAG-007) ~"
-	description "Tennis - Le Tennis (1981) (Activision, Alan Miller) (AG-007, CAG-007) ~"
-	rom ( name "Tennis - Le Tennis (1981) (Activision, Alan Miller) (AG-007, CAG-007) ~.bin" size 2048 crc 0a42515b md5 undefined sha1 3d30e7ed617168d852923def2000c9c0a8b728c6 )
-)
-
-game (
-	name "Tennis (1981) (Activision, Alan Miller - Ariola) (EAG-007, EAG-007-04I, PAG-007 - 711 007-720) (PAL)"
-	description "Tennis (1981) (Activision, Alan Miller - Ariola) (EAG-007, EAG-007-04I, PAG-007 - 711 007-720) (PAL)"
-	rom ( name "Tennis (1981) (Activision, Alan Miller - Ariola) (EAG-007, EAG-007-04I, PAG-007 - 711 007-720) (PAL).bin" size 2048 crc 009e3166 md5 undefined sha1 5c8ab191ca378d9ed777e9a57da54a08caae3ea5 )
-)
-
-game (
-	name "Tennis (1983) (CCE) (C-858) (4K)"
-	description "Tennis (1983) (CCE) (C-858) (4K)"
-	rom ( name "Tennis (1983) (CCE) (C-858) (4K).bin" size 4096 crc f18534de md5 undefined sha1 f6cd324903f63719b8dbbcad3d3e2a4058634fd5 )
-)
-
-game (
-	name "Tennis (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Tennis (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Tennis (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 2048 crc 3e4bde89 md5 undefined sha1 577d9b36f7d5e4fe8f856a3acaedb2dbe3cb0464 )
-)
-
-game (
-	name "Tennis (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "Tennis (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "Tennis (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 311439e5 md5 undefined sha1 247015261d3b66d31a0b6526e27271abc8112851 )
-)
-
-game (
-	name "Tennis (Canal 3 - Intellivision)"
-	description "Tennis (Canal 3 - Intellivision)"
-	rom ( name "Tennis (Canal 3 - Intellivision).bin" size 4096 crc 9f8eab1c md5 undefined sha1 062ed7db6229ca942e83e689e4379ef1d102469d )
-)
-
-game (
-	name "Tennis (Dactari - Milmar)"
-	description "Tennis (Dactari - Milmar)"
-	rom ( name "Tennis (Dactari - Milmar).bin" size 2048 crc 5bb6bf55 md5 undefined sha1 edc206b9cba5485fa8998c87ac05e09444f4d3e0 )
-)
-
-game (
-	name "Tennis (Hack) (208 in 1) (Unknown) (PAL)"
-	description "Tennis (Hack) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Tennis (Hack) (208 in 1) (Unknown) (PAL).bin" size 2048 crc 9f84fe24 md5 undefined sha1 f61572b5745eeefe4ba9496f0e5d0a1bfe4565a1 )
-)
-
-game (
-	name "Tennis (Pet Boat) (PAL)"
-	description "Tennis (Pet Boat) (PAL)"
-	rom ( name "Tennis (Pet Boat) (PAL).bin" size 2048 crc 3497beb4 md5 undefined sha1 56ac5b5a63c82bfc11a77c9064f06f8d9aa8794c )
-)
-
-game (
-	name "Tennis (Star Game) (007)"
-	description "Tennis (Star Game) (007)"
-	rom ( name "Tennis (Star Game) (007).bin" size 2048 crc f61ea421 md5 undefined sha1 783d81f41076988dacd8de9ab4779b55a1ce9497 )
-)
-
-game (
-	name "Tennis (Tennis Game) (AKA Tennis) (1983) (Home Vision - Gem International Corp.) (VCS83107) (PAL) (4K)"
-	description "Tennis (Tennis Game) (AKA Tennis) (1983) (Home Vision - Gem International Corp.) (VCS83107) (PAL) (4K)"
-	rom ( name "Tennis (Tennis Game) (AKA Tennis) (1983) (Home Vision - Gem International Corp.) (VCS83107) (PAL) (4K).bin" size 4096 crc fc65047c md5 undefined sha1 7cb76949b085008e9e86279bff9803c04c55d039 )
-)
-
-game (
-	name "Tennis (Unknown)"
-	description "Tennis (Unknown)"
-	rom ( name "Tennis (Unknown).bin" size 2048 crc 3e4bde89 md5 undefined sha1 577d9b36f7d5e4fe8f856a3acaedb2dbe3cb0464 )
-)
-
-game (
-	name "Tennis (Zirok)"
-	description "Tennis (Zirok)"
-	rom ( name "Tennis (Zirok).bin" size 2048 crc 903fe56b md5 undefined sha1 bfdc2004be735f2555fe9375088684e351869c59 )
-)
-
-game (
-	name "Texas Chainsaw Massacre, The (1982) (Wizard Video Games, Bob Davis, Robert H. O'Neil) (Prototype) ~"
-	description "Texas Chainsaw Massacre, The (1982) (Wizard Video Games, Bob Davis, Robert H. O'Neil) (Prototype) ~"
-	rom ( name "Texas Chainsaw Massacre, The (1982) (Wizard Video Games, Bob Davis, Robert H. O'Neil) (Prototype) ~.bin" size 4096 crc ea9a4268 md5 undefined sha1 1f1660223abeee3113c3f75bf4d9cbb3b1cf49e4 )
-)
-
-game (
-	name "Texas Chainsaw Massacre, The (1983) (Wizard Video Games, Ed Salvo) (008) ~"
-	description "Texas Chainsaw Massacre, The (1983) (Wizard Video Games, Ed Salvo) (008) ~"
-	rom ( name "Texas Chainsaw Massacre, The (1983) (Wizard Video Games, Ed Salvo) (008) ~.bin" size 4096 crc ec389caa md5 undefined sha1 717122a4184bc8db41e65ab7c369c40b21c048d9 )
-)
-
-game (
-	name "Threshold (1982) (Tigervision, Warren Schwader - Teldec) (7-003) (PAL)"
-	description "Threshold (1982) (Tigervision, Warren Schwader - Teldec) (7-003) (PAL)"
-	rom ( name "Threshold (1982) (Tigervision, Warren Schwader - Teldec) (7-003) (PAL).bin" size 4096 crc b9c25858 md5 undefined sha1 318c403d3582ed0a90b551bc1816998cf99e66e7 )
-)
-
-game (
-	name "Threshold (1982) (Tigervision, Warren Schwader) (7-003) ~"
-	description "Threshold (1982) (Tigervision, Warren Schwader) (7-003) ~"
-	rom ( name "Threshold (1982) (Tigervision, Warren Schwader) (7-003) ~.bin" size 4096 crc ce5097fd md5 undefined sha1 9a52fa88bd7455044f00548e9615452131d1c711 )
-)
-
-game (
-	name "Thunderground (Canal 3 - Intellivision)"
-	description "Thunderground (Canal 3 - Intellivision)"
-	rom ( name "Thunderground (Canal 3 - Intellivision).bin" size 4096 crc 4b63ebfc md5 undefined sha1 2f12c76d74232055b7676b1be42e90cfcb1e4d4b )
-)
-
-game (
-	name "Thunderground (Underground) (1983) (Sega, Jeff Lorenz) (003-01) ~"
-	description "Thunderground (Underground) (1983) (Sega, Jeff Lorenz) (003-01) ~"
-	rom ( name "Thunderground (Underground) (1983) (Sega, Jeff Lorenz) (003-01) ~.bin" size 4096 crc 9e67c699 md5 undefined sha1 3cc8bcc0ff5164303433f469aa4da2eb256d1ad0 )
-)
-
-game (
-	name "Thunderground (Unknown) (PAL)"
-	description "Thunderground (Unknown) (PAL)"
-	rom ( name "Thunderground (Unknown) (PAL).bin" size 4096 crc 0d894018 md5 undefined sha1 34c316869e8749e334ea69892748b281ce36f7fc )
-)
-
-game (
-	name "Thwocker (04-09-1984) (Activision, Charlie Heath) (Prototype) ~"
-	description "Thwocker (04-09-1984) (Activision, Charlie Heath) (Prototype) ~"
-	rom ( name "Thwocker (04-09-1984) (Activision, Charlie Heath) (Prototype) ~.bin" size 8192 crc b60ab310 md5 undefined sha1 53ee70d4b35ee3df3ffb95fa360bddb4f2f56ab2 )
-)
-
-game (
-	name "Time Machine (AKA Asteroid Fire) (1983) (Goliath - Hot Shot) (83-112) (PAL)"
-	description "Time Machine (AKA Asteroid Fire) (1983) (Goliath - Hot Shot) (83-112) (PAL)"
-	rom ( name "Time Machine (AKA Asteroid Fire) (1983) (Goliath - Hot Shot) (83-112) (PAL).bin" size 4096 crc 70aebb22 md5 undefined sha1 429c3c21bf89dc08892d16c420b72b0c88c9e03c )
-)
-
-game (
-	name "Time Pilot (1983) (Coleco, Harley H. Puthuff Jr.) (2663) ~"
-	description "Time Pilot (1983) (Coleco, Harley H. Puthuff Jr.) (2663) ~"
-	rom ( name "Time Pilot (1983) (Coleco, Harley H. Puthuff Jr.) (2663) ~.bin" size 8192 crc 21ee7db4 md5 undefined sha1 387358514964d0b6b55f9431576a59b55869f7ab )
-)
-
-game (
-	name "Time Race (AKA Space Jockey) (1983) (Goliath - Hot Shot) (83-212) (PAL)"
-	description "Time Race (AKA Space Jockey) (1983) (Goliath - Hot Shot) (83-212) (PAL)"
-	rom ( name "Time Race (AKA Space Jockey) (1983) (Goliath - Hot Shot) (83-212) (PAL).bin" size 4096 crc 1f67afb5 md5 undefined sha1 7a05a77d648e356c71ad6d3c329aab48d7d88e6e )
-)
-
-game (
-	name "Time Race (AKA Space Jockey) (Rainbow Vision - Suntek - Sunteck Corporation) (SS-001) (PAL)"
-	description "Time Race (AKA Space Jockey) (Rainbow Vision - Suntek - Sunteck Corporation) (SS-001) (PAL)"
-	rom ( name "Time Race (AKA Space Jockey) (Rainbow Vision - Suntek - Sunteck Corporation) (SS-001) (PAL).bin" size 4096 crc c6c9a76f md5 undefined sha1 dee8afa624c716b7145f3b9237a21169d89b1a1a )
-)
-
-game (
-	name "Time Race (AKA Time Warp) (Funvision - Fund. International Co.) (PAL)"
-	description "Time Race (AKA Time Warp) (Funvision - Fund. International Co.) (PAL)"
-	rom ( name "Time Race (AKA Time Warp) (Funvision - Fund. International Co.) (PAL).bin" size 4096 crc 32f16d22 md5 undefined sha1 90041b76b873d214276a567cca3af53bfa3222ac )
-)
-
-game (
-	name "Time Warp (1982) (Funvision - Fund. International Co.)"
-	description "Time Warp (1982) (Funvision - Fund. International Co.)"
-	rom ( name "Time Warp (1982) (Funvision - Fund. International Co.).bin" size 4096 crc e5bc054d md5 undefined sha1 7258e8da5177f37583efca1bf43e5987c9845d4c )
-)
-
-game (
-	name "Time Warp (1982) (Funvision - Fund. International Co.) (PAL) ~"
-	description "Time Warp (1982) (Funvision - Fund. International Co.) (PAL) ~"
-	rom ( name "Time Warp (1982) (Funvision - Fund. International Co.) (PAL) ~.bin" size 4096 crc 551e2144 md5 undefined sha1 594db913e27509fe244c5c900b5dbf5991d19a3e )
-)
-
-game (
-	name "Time Warp (1983) (CCE) (C-845)"
-	description "Time Warp (1983) (CCE) (C-845)"
-	rom ( name "Time Warp (1983) (CCE) (C-845).bin" size 4096 crc 60163f9e md5 undefined sha1 57f4e0ea1c81ea263340be666b715316adfff491 )
-)
-
-game (
-	name "Time Warp (Unknown)"
-	description "Time Warp (Unknown)"
-	rom ( name "Time Warp (Unknown).bin" size 4096 crc 97dd6227 md5 undefined sha1 12340988852ad725c2acee5752a97beee8e62081 )
-)
-
-game (
-	name "Time Warp (Unknown) (PAL)"
-	description "Time Warp (Unknown) (PAL)"
-	rom ( name "Time Warp (Unknown) (PAL).bin" size 4096 crc 328e3312 md5 undefined sha1 2e8e62a5dc45c780617576ad8acaf5cbf8d36d2d )
-)
-
-game (
-	name "Time Warp (Zellers)"
-	description "Time Warp (Zellers)"
-	rom ( name "Time Warp (Zellers).bin" size 4096 crc e5bc054d md5 undefined sha1 7258e8da5177f37583efca1bf43e5987c9845d4c )
-)
-
-game (
-	name "Title Match Pro Wrestling - Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (EAZ-041-04I) (PAL)"
-	description "Title Match Pro Wrestling - Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (EAZ-041-04I) (PAL)"
-	rom ( name "Title Match Pro Wrestling - Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (EAZ-041-04I) (PAL).bin" size 8192 crc a2943d1b md5 undefined sha1 b5e9e207d02456e7eccf3ae9b7df60777bb3fb67 )
-)
-
-game (
-	name "Title Match Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (AG-041-04) ~"
-	description "Title Match Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (AG-041-04) ~"
-	rom ( name "Title Match Pro Wrestling (1987) (Absolute Entertainment, Alex DeMeo) (AG-041-04) ~.bin" size 8192 crc ef708c03 md5 undefined sha1 979d9b0b0f32b40c0a0568be65a0bc5ef36ca6d0 )
-)
-
-game (
-	name "Tom Boy (AKA Pitfall!) (Rainbow Vision - Suntek) (SS-005) (PAL)"
-	description "Tom Boy (AKA Pitfall!) (Rainbow Vision - Suntek) (SS-005) (PAL)"
-	rom ( name "Tom Boy (AKA Pitfall!) (Rainbow Vision - Suntek) (SS-005) (PAL).bin" size 4096 crc aa168aaa md5 undefined sha1 f536dea39f64d1fd72e4ee0a98394eda39ddc3da )
-)
-
-game (
-	name "Tom Boy (AKA Pitfall!) (Unknown)"
-	description "Tom Boy (AKA Pitfall!) (Unknown)"
-	rom ( name "Tom Boy (AKA Pitfall!) (Unknown).bin" size 4096 crc 5d6580fc md5 undefined sha1 396a96c91c0992f8726933766099a3f2c0669b31 )
-)
-
-game (
-	name "Tom's Eierjagd (AKA Play Farm) (1983) (Quelle) (731.503 9) (PAL)"
-	description "Tom's Eierjagd (AKA Play Farm) (1983) (Quelle) (731.503 9) (PAL)"
-	rom ( name "Tom's Eierjagd (AKA Play Farm) (1983) (Quelle) (731.503 9) (PAL).bin" size 4096 crc 38f28235 md5 undefined sha1 6f2cce0737f60310892801c42673ee27420f96dc )
-)
-
-game (
-	name "Tomarc the Barbarian (Thundarr the Barbarian) (1983) (99007, 6240) (Xonox - K-Tel Software, Anthony R. Henderson) ~"
-	description "Tomarc the Barbarian (Thundarr the Barbarian) (1983) (99007, 6240) (Xonox - K-Tel Software, Anthony R. Henderson) ~"
-	rom ( name "Tomarc the Barbarian (Thundarr the Barbarian) (1983) (99007, 6240) (Xonox - K-Tel Software, Anthony R. Henderson) ~.bin" size 8192 crc b5b5ac84 md5 undefined sha1 489c9b572535721a0516a2b759e0b9c7f7a5b3cc )
-)
-
-game (
-	name "Tomcat - The F-14 Fighter Simulator (1988) (Absolute Entertainment, Dan Kitchen) (AK-046-04) ~"
-	description "Tomcat - The F-14 Fighter Simulator (1988) (Absolute Entertainment, Dan Kitchen) (AK-046-04) ~"
-	rom ( name "Tomcat - The F-14 Fighter Simulator (1988) (Absolute Entertainment, Dan Kitchen) (AK-046-04) ~.bin" size 16384 crc 8987c473 md5 undefined sha1 5b2742281fea96ab6a3a2f30e676352bcf424390 )
-)
-
-game (
-	name "Tooth Protectors (1983) (DSD-Camelot - Johnson & Johnson, Michael Doherty, Clyde Hager) ~"
-	description "Tooth Protectors (1983) (DSD-Camelot - Johnson & Johnson, Michael Doherty, Clyde Hager) ~"
-	rom ( name "Tooth Protectors (1983) (DSD-Camelot - Johnson & Johnson, Michael Doherty, Clyde Hager) ~.bin" size 8192 crc fd8c81e5 md5 undefined sha1 d82ac7237df54cc8688e3074b58433a7dd6b7d11 )
-)
-
-game (
-	name "Top Gun - Air Patrol (AKA Air Raiders) (1983) (Quelle) (626.502 9 - 746381) (PAL)"
-	description "Top Gun - Air Patrol (AKA Air Raiders) (1983) (Quelle) (626.502 9 - 746381) (PAL)"
-	rom ( name "Top Gun - Air Patrol (AKA Air Raiders) (1983) (Quelle) (626.502 9 - 746381) (PAL).bin" size 4096 crc 8f78ee32 md5 undefined sha1 e853954eae7d0b7839787f0569888a739e56cfaf )
-)
-
-game (
-	name "Topy (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	description "Topy (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co)"
-	rom ( name "Topy (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co).bin" size 4096 crc 90eff841 md5 undefined sha1 59b5f61a8a6009a2ac9903fb3d72ee817fd849bb )
-)
-
-game (
-	name "Towering Inferno (1982) (U.S. Games Corporation,  Jeff Corsiglia, Paul Allen Newell) (VC1009) ~"
-	description "Towering Inferno (1982) (U.S. Games Corporation,  Jeff Corsiglia, Paul Allen Newell) (VC1009) ~"
-	rom ( name "Towering Inferno (1982) (U.S. Games Corporation,  Jeff Corsiglia, Paul Allen Newell) (VC1009) ~.bin" size 4096 crc 2c7b86b8 md5 undefined sha1 b344b3e042447afbb3e40292dc4ca063d5d1110d )
-)
-
-game (
-	name "Towering Inferno (208 in 1) (Unknown) (PAL)"
-	description "Towering Inferno (208 in 1) (Unknown) (PAL)"
-	rom ( name "Towering Inferno (208 in 1) (Unknown) (PAL).bin" size 4096 crc 861e0a51 md5 undefined sha1 dab9124de3c1d7760c979650d4d83b1c0e6c142d )
-)
-
-game (
-	name "Track and Field (Los Angeles 1984 Games) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125, CX26127) ~"
-	description "Track and Field (Los Angeles 1984 Games) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125, CX26127) ~"
-	rom ( name "Track and Field (Los Angeles 1984 Games) (Track & Field Controller) (1984) (Atari - GCC, Jaques Hugon, Seth Lipkin) (CX26125, CX26127) ~.bin" size 16384 crc 21827056 md5 undefined sha1 005a6a53f5a856f0bdbca519af1ef236aaa1494d )
-)
-
-game (
-	name "Treasure Below (1983) (Video Gems) (VG-05) (PAL) ~"
-	description "Treasure Below (1983) (Video Gems) (VG-05) (PAL) ~"
-	rom ( name "Treasure Below (1983) (Video Gems) (VG-05) (PAL) ~.bin" size 4096 crc d2cea797 md5 undefined sha1 9a9917d82362c77b4d396f56966219fc248edf47 )
-)
-
-game (
-	name "Treasure Hunting (AKA Pitfall!) (Funvision - Fund. International Co.)"
-	description "Treasure Hunting (AKA Pitfall!) (Funvision - Fund. International Co.)"
-	rom ( name "Treasure Hunting (AKA Pitfall!) (Funvision - Fund. International Co.).bin" size 4096 crc b1600d79 md5 undefined sha1 461d91dee959958f9107f1d72e716a17af3c1c92 )
-)
-
-game (
-	name "Treasure Island (AKA Treasure Discovery) (Suntek) (SS-026) (PAL) ~"
-	description "Treasure Island (AKA Treasure Discovery) (Suntek) (SS-026) (PAL) ~"
-	rom ( name "Treasure Island (AKA Treasure Discovery) (Suntek) (SS-026) (PAL) ~.bin" size 4096 crc 907f1d90 md5 undefined sha1 d1437e291fbc1927fcce14abc21a58a423e15368 )
-)
-
-game (
-	name "Trick Shot (1982) (Imagic, Dennis Koble) (720000-100, 720100-1B, IA3000, IA3000C) ~"
-	description "Trick Shot (1982) (Imagic, Dennis Koble) (720000-100, 720100-1B, IA3000, IA3000C) ~"
-	rom ( name "Trick Shot (1982) (Imagic, Dennis Koble) (720000-100, 720100-1B, IA3000, IA3000C) ~.bin" size 4096 crc d1ce4634 md5 undefined sha1 86c563db11db9afbffbd73c55e9fae9b2f69be4f )
-)
-
-game (
-	name "Trick Shot (1982) (Imagic, Dennis Koble) (720100-2B, IA3000P) (PAL)"
-	description "Trick Shot (1982) (Imagic, Dennis Koble) (720100-2B, IA3000P) (PAL)"
-	rom ( name "Trick Shot (1982) (Imagic, Dennis Koble) (720100-2B, IA3000P) (PAL).bin" size 4096 crc 4d84e90b md5 undefined sha1 799e24a0cf4c0695e34e94847f223706a40fccac )
-)
-
-game (
-	name "TRON - Deadly Discs (TRON Joystick) (1982) (M Network, Jeff Ronne, Brett Stutz - INTV) (MT5662) ~"
-	description "TRON - Deadly Discs (TRON Joystick) (1982) (M Network, Jeff Ronne, Brett Stutz - INTV) (MT5662) ~"
-	rom ( name "TRON - Deadly Discs (TRON Joystick) (1982) (M Network, Jeff Ronne, Brett Stutz - INTV) (MT5662) ~.bin" size 4096 crc d35b22f9 md5 undefined sha1 0ec58a3a5a27d1b82a5f9aabab02f9a8387b6956 )
-)
-
-game (
-	name "Tuby Bird (AKA Dolphin) (208 in 1) (Unknown) (PAL)"
-	description "Tuby Bird (AKA Dolphin) (208 in 1) (Unknown) (PAL)"
-	rom ( name "Tuby Bird (AKA Dolphin) (208 in 1) (Unknown) (PAL).bin" size 4096 crc 716a249d md5 undefined sha1 7ffec0eeb2608578238ef98ea287d7b487e9d4ff )
-)
-
-game (
-	name "Tuby Bird (AKA Dolphin) (Rainbow Vision - Suntek) (SS-020) (PAL)"
-	description "Tuby Bird (AKA Dolphin) (Rainbow Vision - Suntek) (SS-020) (PAL)"
-	rom ( name "Tuby Bird (AKA Dolphin) (Rainbow Vision - Suntek) (SS-020) (PAL).bin" size 4096 crc 1ca034ca md5 undefined sha1 f4f941b779bcb7902df0eb7cf6b985f56e751183 )
-)
-
-game (
-	name "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) (Prototype)"
-	description "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) (Prototype)"
-	rom ( name "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) (Prototype).bin" size 12288 crc bd2d975a md5 undefined sha1 af202ee515b41113660bdf4500802108b12f85a3 )
-)
-
-game (
-	name "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) ~"
-	description "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) ~"
-	rom ( name "Tunnel Runner (Black Box) (1983) (CBS Electronics, Richard K. Balaska Jr., Andy Frank, Stuart Ross) (4L 2520 5000) ~.bin" size 12288 crc a02745f8 md5 undefined sha1 fc1a0b58765a7dcbd8e33562e1074ddd9e0ac624 )
-)
-
-game (
-	name "Turbo (1982) (Coleco, Michael Green, Anthony R. Henderson, Gary Littleton) (2455) (Prototype) ~"
-	description "Turbo (1982) (Coleco, Michael Green, Anthony R. Henderson, Gary Littleton) (2455) (Prototype) ~"
-	rom ( name "Turbo (1982) (Coleco, Michael Green, Anthony R. Henderson, Gary Littleton) (2455) (Prototype) ~.bin" size 8192 crc 50eb43d3 md5 undefined sha1 8ab35bc17214df3b2bae6a32b96e5f1d4a28ca17 )
-)
-
-game (
-	name "Turmoil (1982) (20th Century Fox Video Games, Mark Turmell) (11007) ~"
-	description "Turmoil (1982) (20th Century Fox Video Games, Mark Turmell) (11007) ~"
-	rom ( name "Turmoil (1982) (20th Century Fox Video Games, Mark Turmell) (11007) ~.bin" size 4096 crc 8c65298a md5 undefined sha1 1162fe46977f01b4d25efab813e0d05ec90aeadc )
-)
-
-game (
-	name "Turmoil (Unknown) (PAL)"
-	description "Turmoil (Unknown) (PAL)"
-	rom ( name "Turmoil (Unknown) (PAL).bin" size 4096 crc 849563e7 md5 undefined sha1 b68a455e7ec4abfaf1beb9056cafd52ac59e54c0 )
-)
-
-game (
-	name "Turmoil (Zellers)"
-	description "Turmoil (Zellers)"
-	rom ( name "Turmoil (Zellers).bin" size 4096 crc 30bc25cf md5 undefined sha1 d80da540bb1fbbe5271e0742cf2f6aa60d71bd97 )
-)
-
-game (
-	name "Turmoill (AKA Turmoil) (1983) (CCE) (C-850)"
-	description "Turmoill (AKA Turmoil) (1983) (CCE) (C-850)"
-	rom ( name "Turmoill (AKA Turmoil) (1983) (CCE) (C-850).bin" size 4096 crc 30bc25cf md5 undefined sha1 d80da540bb1fbbe5271e0742cf2f6aa60d71bd97 )
-)
-
-game (
-	name "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (931509) (PAL)"
-	description "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (931509) (PAL)"
-	rom ( name "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (931509) (PAL).bin" size 8192 crc 8fbe2b84 md5 undefined sha1 d205e4c73c64335e1878b78f970c5fb52060c7db )
-)
-
-game (
-	name "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (PB5340) ~"
-	description "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (PB5340) ~"
-	rom ( name "Tutankham (1983) (Parker Brothers, Dave Engman, Dawn Stockbridge) (PB5340) ~.bin" size 8192 crc ec959bf2 md5 undefined sha1 a4d6bac854a70d2c55946932f1511cc62db7d4aa )
-)
-
-game (
-	name "UFI und sein gefaehrlicher Einsatz (AKA Go Go Home) (1983) (Quelle) (732.174 8) (PAL)"
-	description "UFI und sein gefaehrlicher Einsatz (AKA Go Go Home) (1983) (Quelle) (732.174 8) (PAL)"
-	rom ( name "UFI und sein gefaehrlicher Einsatz (AKA Go Go Home) (1983) (Quelle) (732.174 8) (PAL).bin" size 4096 crc c161f53b md5 undefined sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
-)
-
-game (
-	name "UFO (AKA Space Jockey) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	description "UFO (AKA Space Jockey) (32 in 1) (1988) (Atari) (CX26163P) (PAL)"
-	rom ( name "UFO (AKA Space Jockey) (32 in 1) (1988) (Atari) (CX26163P) (PAL).bin" size 2048 crc 092c05fd md5 undefined sha1 04e132f901f82c89eb1a1f2a4ba79e97e8b9d786 )
-)
-
-game (
-	name "UFO Patrol (AKA X'Mission) (Suntek) (SS-031) (PAL)"
-	description "UFO Patrol (AKA X'Mission) (Suntek) (SS-031) (PAL)"
-	rom ( name "UFO Patrol (AKA X'Mission) (Suntek) (SS-031) (PAL).bin" size 4096 crc 3dfee54b md5 undefined sha1 d68d9ffcb6db02ea0e9299192f548e3d6594c0f3 )
-)
-
-game (
-	name "Ungeheuer der Tiefe (AKA Skindiver) (1983) (Quelle) (719.013 5) (PAL)"
-	description "Ungeheuer der Tiefe (AKA Skindiver) (1983) (Quelle) (719.013 5) (PAL)"
-	rom ( name "Ungeheuer der Tiefe (AKA Skindiver) (1983) (Quelle) (719.013 5) (PAL).bin" size 4096 crc 9c3a516b md5 undefined sha1 d2bcc767b170b0fc0a2a0903f4337a821623abb4 )
-)
-
-game (
-	name "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) (PAL)"
-	description "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) (PAL)"
-	rom ( name "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) (PAL).bin" size 4096 crc 2f10950c md5 undefined sha1 50fb0e27ee994a9e51b63f84434a25a0036eea62 )
-)
-
-game (
-	name "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) ~"
-	description "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) ~"
-	rom ( name "Universal Chaos (AKA Targ) (1989) (Telegames) (7062 A305) ~.bin" size 4096 crc 25efa169 md5 undefined sha1 286106fb973530bc3e2af13240f28c4bcb37e642 )
-)
-
-game (
-	name "Unknown 20th Century Fox Game (1983) (20th Century Fox Video Games) (Prototype) ~"
-	description "Unknown 20th Century Fox Game (1983) (20th Century Fox Video Games) (Prototype) ~"
-	rom ( name "Unknown 20th Century Fox Game (1983) (20th Century Fox Video Games) (Prototype) ~.bin" size 8192 crc 0748817d md5 undefined sha1 3da6a2cc699945f708dac4e880ff6e085c635bbd )
-)
-
-game (
-	name "Unknown Activision Game #1 (10-22-1982) (Activision) (Prototype)"
-	description "Unknown Activision Game #1 (10-22-1982) (Activision) (Prototype)"
-	rom ( name "Unknown Activision Game #1 (10-22-1982) (Activision) (Prototype).bin" size 4096 crc 156e8ade md5 undefined sha1 8f0c2be512d239f25ee471d33ecbe2e5896999bd )
-)
-
-game (
-	name "Unknown Activision Game #1 (10-29-1982) (Activision) (Prototype) ~"
-	description "Unknown Activision Game #1 (10-29-1982) (Activision) (Prototype) ~"
-	rom ( name "Unknown Activision Game #1 (10-29-1982) (Activision) (Prototype) ~.bin" size 4096 crc 6b0672a6 md5 undefined sha1 d93c86970d3df29326acc35c0ce6679b83c2aff2 )
-)
-
-game (
-	name "Unknown Activision Game #2 (1983) (Activision) (Prototype) ~"
-	description "Unknown Activision Game #2 (1983) (Activision) (Prototype) ~"
-	rom ( name "Unknown Activision Game #2 (1983) (Activision) (Prototype) ~.bin" size 4096 crc 5c009ea0 md5 undefined sha1 a25c4b33e1c86895cb63635bd6ca5b8379a206b3 )
-)
-
-game (
-	name "Unknown Datatech Game (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) ~"
-	description "Unknown Datatech Game (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) ~"
-	rom ( name "Unknown Datatech Game (2600 Screen Search Console) (Jone Yuan Telephonic Enterprise Co) ~.bin" size 4096 crc 95c37983 md5 undefined sha1 5112edc18885b2fbde4adc2111176c87b41f0352 )
-)
-
-game (
-	name "Up 'n Down (1984) (Sega, Phat Ho - Bally Midway - Beck-Tech) (009-01) ~"
-	description "Up 'n Down (1984) (Sega, Phat Ho - Bally Midway - Beck-Tech) (009-01) ~"
-	rom ( name "Up 'n Down (1984) (Sega, Phat Ho - Bally Midway - Beck-Tech) (009-01) ~.bin" size 8192 crc c04c2b58 md5 undefined sha1 6bde671a50330af154ed15e73fdba3fa55f23d87 )
-)
-
-game (
-	name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669, CX2669P) (PAL)"
-	description "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669, CX2669P) (PAL)"
-	rom ( name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669, CX2669P) (PAL).bin" size 8192 crc f8ca90ae md5 undefined sha1 1a44918fa764da8dde97a7543a181ccf6756868b )
-)
-
-game (
-	name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) (Prototype)"
-	description "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) (Prototype)"
-	rom ( name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) (Prototype).bin" size 8192 crc 434b17db md5 undefined sha1 e41c37d2f5cca3c788f9d47a9fa642e01d35a827 )
-)
-
-game (
-	name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) ~"
-	description "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) ~"
-	rom ( name "Vanguard (1982) (Atari - GCC, Dave Payne) (CX2669) ~.bin" size 8192 crc c4bec521 md5 undefined sha1 01475d037cb7a2a892be09d67083102fa9159216 )
-)
-
-game (
-	name "Vanguard (CCE)"
-	description "Vanguard (CCE)"
-	rom ( name "Vanguard (CCE).bin" size 8192 crc df029ac5 md5 undefined sha1 5e01dba1f423bb3b32b51b15fc31827d25d4f8df )
-)
-
-game (
-	name "Vanguard (VGS)"
-	description "Vanguard (VGS)"
-	rom ( name "Vanguard (VGS).bin" size 8192 crc 40f2636c md5 undefined sha1 44920bd0599873c77ab17f36ff49e215cbf92917 )
-)
-
-game (
-	name "Venetian Blinds Demo (1982) (Activision, David Crane) ~"
-	description "Venetian Blinds Demo (1982) (Activision, David Crane) ~"
-	rom ( name "Venetian Blinds Demo (1982) (Activision, David Crane) ~.bin" size 2048 crc 1f0d3562 md5 undefined sha1 81f485b545445080e009adf0f2e93dd4f16b92ce )
-)
-
-game (
-	name "Venture (1982) (CBS Electronics, Joseph Biel) (4L1802, 4L1803, 4L1804, 4L2278) (PAL)"
-	description "Venture (1982) (CBS Electronics, Joseph Biel) (4L1802, 4L1803, 4L1804, 4L2278) (PAL)"
-	rom ( name "Venture (1982) (CBS Electronics, Joseph Biel) (4L1802, 4L1803, 4L1804, 4L2278) (PAL).bin" size 4096 crc 67d41ca8 md5 undefined sha1 7752360375ac7f35c649eb81424897db56616e3d )
-)
-
-game (
-	name "Venture (1982) (Coleco, Joseph Biel) (2457) (Prototype) (2K)"
-	description "Venture (1982) (Coleco, Joseph Biel) (2457) (Prototype) (2K)"
-	rom ( name "Venture (1982) (Coleco, Joseph Biel) (2457) (Prototype) (2K).bin" size 2048 crc a2ba9f0a md5 undefined sha1 71fc0cf5caad1ceac6c3923cfeb450b28a29a828 )
-)
-
-game (
-	name "Venture (1982) (Coleco, Joseph Biel) (2457) ~"
-	description "Venture (1982) (Coleco, Joseph Biel) (2457) ~"
-	rom ( name "Venture (1982) (Coleco, Joseph Biel) (2457) ~.bin" size 4096 crc 85e0ca62 md5 undefined sha1 0305dfc99bf192e53452a1e0408ccc148940afcd )
-)
-
-game (
-	name "Venture (1987) (Atari) (CX26145)"
-	description "Venture (1987) (Atari) (CX26145)"
-	rom ( name "Venture (1987) (Atari) (CX26145).bin" size 4096 crc 7a121b8e md5 undefined sha1 63afb1b75114d7080d9738ea1d90282af5d1fade )
-)
-
-game (
-	name "Viagem Espacial (AKA Star Voyager) (Dismac)"
-	description "Viagem Espacial (AKA Star Voyager) (Dismac)"
-	rom ( name "Viagem Espacial (AKA Star Voyager) (Dismac).bin" size 4096 crc 606d65d5 md5 undefined sha1 dc347bd605d8d0a0ca3a47e707a0d58ade822fd3 )
-)
-
-game (
-	name "Video Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw) (CX2636, CX2636P) (PAL)"
-	description "Video Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw) (CX2636, CX2636P) (PAL)"
-	rom ( name "Video Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw) (CX2636, CX2636P) (PAL).bin" size 4096 crc b8176485 md5 undefined sha1 24c1c6e1a495137bec53818c2cd8bd83c8336d21 )
-)
-
-game (
-	name "Video Checkers - Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw - Sears) (CX2636 - 49-75156) ~"
-	description "Video Checkers - Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw - Sears) (CX2636 - 49-75156) ~"
-	rom ( name "Video Checkers - Checkers - Atari Video Checkers (1980) (Atari, Carol Shaw - Sears) (CX2636 - 49-75156) ~.bin" size 4096 crc 3df33335 md5 undefined sha1 babae88a832b76d8c5af6ea63b8f10a0da5bb992 )
-)
-
-game (
-	name "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead - Sears) (CX2645 - 49-75181) ~"
-	description "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead - Sears) (CX2645 - 49-75181) ~"
-	rom ( name "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead - Sears) (CX2645 - 49-75181) ~.bin" size 4096 crc b6226a54 md5 undefined sha1 043ef523e4fcb9fc2fc2fda21f15671bf8620fc3 )
-)
-
-game (
-	name "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead) (CX2645, CX2645P) (PAL)"
-	description "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead) (CX2645, CX2645P) (PAL)"
-	rom ( name "Video Chess (1979) (Atari, Larry Wagner, Bob Whitehead) (CX2645, CX2645P) (PAL).bin" size 4096 crc 6b71b32d md5 undefined sha1 c7c792c91f9fa7c3e291d0e0f0dd71a7181369a5 )
-)
-
-game (
-	name "Video Chess (Unknown) (PAL)"
-	description "Video Chess (Unknown) (PAL)"
-	rom ( name "Video Chess (Unknown) (PAL).bin" size 4096 crc 4a6ea71c md5 undefined sha1 9dd387b0ea2b96de89699ae66f54adf9d67367b8 )
-)
-
-game (
-	name "Video Cube (AKA Atari Video Cube) (CCE)"
-	description "Video Cube (AKA Atari Video Cube) (CCE)"
-	rom ( name "Video Cube (AKA Atari Video Cube) (CCE).bin" size 4096 crc 1bc8b7af md5 undefined sha1 3f2ad3666eb713b20484e3677d8e1cac8fbd323e )
-)
-
-game (
-	name "Video Jogger (Foot Craz) (1983) (Exus Corporation) ~"
-	description "Video Jogger (Foot Craz) (1983) (Exus Corporation) ~"
-	rom ( name "Video Jogger (Foot Craz) (1983) (Exus Corporation) ~.bin" size 4096 crc 28fa8d77 md5 undefined sha1 1554b146d076b64776bf49136cea01f60eeba4c1 )
-)
-
-game (
-	name "Video Life (1981) (CommaVid, John Bronstein) (CM-002) [higher sounds] ~"
-	description "Video Life (1981) (CommaVid, John Bronstein) (CM-002) [higher sounds] ~"
-	rom ( name "Video Life (1981) (CommaVid, John Bronstein) (CM-002) [higher sounds] ~.bin" size 2048 crc bb1249a9 md5 undefined sha1 08c7c4ab5b25c008cc8a87fb1406b7d12df56124 )
-)
-
-game (
-	name "Video Life (1981) (CommaVid, John Bronstein) (CM-002) ~"
-	description "Video Life (1981) (CommaVid, John Bronstein) (CM-002) ~"
-	rom ( name "Video Life (1981) (CommaVid, John Bronstein) (CM-002) ~.bin" size 2048 crc 34b0b5c2 md5 undefined sha1 3b18db73933747851eba9a0ffa3c12b9f602a95c )
-)
-
-game (
-	name "Video Olympics - Pong Sports (Paddle) (1977) (Atari, Joe Decuir - Sears) (CX2621 - 99806, 6-99806, 49-75104) ~"
-	description "Video Olympics - Pong Sports (Paddle) (1977) (Atari, Joe Decuir - Sears) (CX2621 - 99806, 6-99806, 49-75104) ~"
-	rom ( name "Video Olympics - Pong Sports (Paddle) (1977) (Atari, Joe Decuir - Sears) (CX2621 - 99806, 6-99806, 49-75104) ~.bin" size 2048 crc e4bc89c4 md5 undefined sha1 1ffe89d79d55adabc0916b95cc37e18619ef7830 )
-)
-
-game (
-	name "Video Olympics (Paddle) (1977) (Atari, Joe Decuir) (CX2621, CX2621P) (PAL)"
-	description "Video Olympics (Paddle) (1977) (Atari, Joe Decuir) (CX2621, CX2621P) (PAL)"
-	rom ( name "Video Olympics (Paddle) (1977) (Atari, Joe Decuir) (CX2621, CX2621P) (PAL).bin" size 2048 crc cc6a454a md5 undefined sha1 a91cf3f977d9ae0c505ef4e7b353ccdcb0bde56e )
-)
-
-game (
-	name "Video Pinball - Arcade Pinball (1981) (Atari, Bob Smith - Sears) (CX2648 - 49-75161) ~"
-	description "Video Pinball - Arcade Pinball (1981) (Atari, Bob Smith - Sears) (CX2648 - 49-75161) ~"
-	rom ( name "Video Pinball - Arcade Pinball (1981) (Atari, Bob Smith - Sears) (CX2648 - 49-75161) ~.bin" size 4096 crc 10d95426 md5 undefined sha1 2c16c1a6374c8e22275d152d93dd31ffba26271f )
-)
-
-game (
-	name "Video Pinball (1981) (Atari, Bob Smith) (CX2648) (PAL)"
-	description "Video Pinball (1981) (Atari, Bob Smith) (CX2648) (PAL)"
-	rom ( name "Video Pinball (1981) (Atari, Bob Smith) (CX2648) (PAL).bin" size 4096 crc 49249eb3 md5 undefined sha1 324d67f2b56517c2293e9351c713b97d3c982b0b )
-)
-
-game (
-	name "Video Pinball (Unknown) (PAL)"
-	description "Video Pinball (Unknown) (PAL)"
-	rom ( name "Video Pinball (Unknown) (PAL).bin" size 4096 crc 09904bbe md5 undefined sha1 2129a72f30dc09987112bece2b1c0d3348187031 )
-)
-
-game (
-	name "Video Reflex (Foot Craz) (1983) (Exus Corporation) [no roman numbers] ~"
-	description "Video Reflex (Foot Craz) (1983) (Exus Corporation) [no roman numbers] ~"
-	rom ( name "Video Reflex (Foot Craz) (1983) (Exus Corporation) [no roman numbers] ~.bin" size 4096 crc 617a6cb6 md5 undefined sha1 fcde759bf4a2ff6360259c23aaef4739a49ddf34 )
-)
-
-game (
-	name "Video Reflex (Foot Craz) (1983) (Exus Corporation) ~"
-	description "Video Reflex (Foot Craz) (1983) (Exus Corporation) ~"
-	rom ( name "Video Reflex (Foot Craz) (1983) (Exus Corporation) ~.bin" size 4096 crc 77b8b0d1 md5 undefined sha1 dec2a3e9b366dce2b63dc1c13662d3f22420a22e )
-)
-
-game (
-	name "Vogel Flieh (AKA Dolphin) (1983) (Quelle) (465.302 8) (PAL)"
-	description "Vogel Flieh (AKA Dolphin) (1983) (Quelle) (465.302 8) (PAL)"
-	rom ( name "Vogel Flieh (AKA Dolphin) (1983) (Quelle) (465.302 8) (PAL).bin" size 4096 crc 1ca034ca md5 undefined sha1 f4f941b779bcb7902df0eb7cf6b985f56e751183 )
-)
-
-game (
-	name "Volleyball (AKA RealSports Volleyball) (1983) (Digitel)"
-	description "Volleyball (AKA RealSports Volleyball) (1983) (Digitel)"
-	rom ( name "Volleyball (AKA RealSports Volleyball) (1983) (Digitel).bin" size 4096 crc 06fa6eaf md5 undefined sha1 17181c8fa8a28d84f783c1a38e1e3d296789bfc5 )
-)
-
-game (
-	name "Volleyball (AKA RealSports Volleyball) (Dactari - Milmar)"
-	description "Volleyball (AKA RealSports Volleyball) (Dactari - Milmar)"
-	rom ( name "Volleyball (AKA RealSports Volleyball) (Dactari - Milmar).bin" size 4096 crc 71c5e30c md5 undefined sha1 b61af807d57f25ae10ae1355a287db6a8f0518a0 )
-)
-
-game (
-	name "Volleyball (AKA RealSports Volleyball) (Double-Game Package) (1983) (Quelle) (781698) (PAL)"
-	description "Volleyball (AKA RealSports Volleyball) (Double-Game Package) (1983) (Quelle) (781698) (PAL)"
-	rom ( name "Volleyball (AKA RealSports Volleyball) (Double-Game Package) (1983) (Quelle) (781698) (PAL).bin" size 4096 crc 95f8cbed md5 undefined sha1 fdbf74d726b4857a8799445341088f2a4ad8320c )
-)
-
-game (
-	name "Volleyball (AKA RealSports Volleyball) (Robby)"
-	description "Volleyball (AKA RealSports Volleyball) (Robby)"
-	rom ( name "Volleyball (AKA RealSports Volleyball) (Robby).bin" size 4096 crc 428ccf6f md5 undefined sha1 d07a746ade990a9930b3f5455c1f3b91a4f89187 )
-)
-
-game (
-	name "Vom Himmel durch die Hoelle (AKA Parachute) (1983) (Quelle) (719.941 7) (PAL)"
-	description "Vom Himmel durch die Hoelle (AKA Parachute) (1983) (Quelle) (719.941 7) (PAL)"
-	rom ( name "Vom Himmel durch die Hoelle (AKA Parachute) (1983) (Quelle) (719.941 7) (PAL).bin" size 4096 crc d32ef4ac md5 undefined sha1 ceaa6868ad25ad4c06b89ef6fa4e5411ad1fcc6b )
-)
-
-game (
-	name "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision)"
-	description "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision)"
-	rom ( name "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision).bin" size 4096 crc b6c582eb md5 undefined sha1 2ebd0f43ee76833f75759ac1bbb45a8e0c3b86e9 )
-)
-
-game (
-	name "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision) (PAL)"
-	description "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision) (PAL)"
-	rom ( name "Vulture Attack (AKA Condor Attack) (1982) (K-Tel Vision) (PAL).bin" size 4096 crc e506bdb2 md5 undefined sha1 05dede1debc04fb1c81a8d940e32ac08e85af29b )
-)
-
-game (
-	name "Wabbit (1982) (Apollo, Ban Tran) (AP-2010) ~"
-	description "Wabbit (1982) (Apollo, Ban Tran) (AP-2010) ~"
-	rom ( name "Wabbit (1982) (Apollo, Ban Tran) (AP-2010) ~.bin" size 4096 crc 2d07ed77 md5 undefined sha1 73072295721453065d62d9136343b81310a4d225 )
-)
-
-game (
-	name "Wachroboter jagt Jupy (AKA Keystone Kapers) (1983) (Quelle) (715.853 5) (PAL)"
-	description "Wachroboter jagt Jupy (AKA Keystone Kapers) (1983) (Quelle) (715.853 5) (PAL)"
-	rom ( name "Wachroboter jagt Jupy (AKA Keystone Kapers) (1983) (Quelle) (715.853 5) (PAL).bin" size 4096 crc 6f3a278e md5 undefined sha1 4b808c975f8a8345c72d0f6281ea5ba93963d7fb )
-)
-
-game (
-	name "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) [a]"
-	description "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) [a]"
-	rom ( name "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) [a].bin" size 4096 crc d5e7f8d8 md5 undefined sha1 0d98698133066588349a8084f9bdd13b80232ed3 )
-)
-
-game (
-	name "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) ~"
-	description "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) ~"
-	rom ( name "Walker (AKA Clown Down Town) (Suntek) (SS-032) (PAL) ~.bin" size 4096 crc da8e49fb md5 undefined sha1 25e2043775a08762e3fc98ecb96fbf46b20e860e )
-)
-
-game (
-	name "Wall Ball (1983) (Avalon Hill, Duncan Scott) (5003002) ~"
-	description "Wall Ball (1983) (Avalon Hill, Duncan Scott) (5003002) ~"
-	rom ( name "Wall Ball (1983) (Avalon Hill, Duncan Scott) (5003002) ~.bin" size 4096 crc 9ac6a295 md5 undefined sha1 482bd349222b8c702e125c27fd516e73af13967b )
-)
-
-game (
-	name "Wall Break (1983) (Home Vision - Gem International Corp.) (VCS83114) (PAL) ~"
-	description "Wall Break (1983) (Home Vision - Gem International Corp.) (VCS83114) (PAL) ~"
-	rom ( name "Wall Break (1983) (Home Vision - Gem International Corp.) (VCS83114) (PAL) ~.bin" size 4096 crc 727408cd md5 undefined sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
-)
-
-game (
-	name "Wall Break (Unknown)"
-	description "Wall Break (Unknown)"
-	rom ( name "Wall Break (Unknown).bin" size 4096 crc 3855dad6 md5 undefined sha1 6de42bbc4766b26301e291ba00f7f7a9ac748639 )
-)
-
-game (
-	name "Wall Defender (AKA Wall Break) (HES) (PAL)"
-	description "Wall Defender (AKA Wall Break) (HES) (PAL)"
-	rom ( name "Wall Defender (AKA Wall Break) (HES) (PAL).bin" size 8192 crc 0427d55e md5 undefined sha1 009a42d71262d3267ae315a392519664cc2f24b4 )
-)
-
-game (
-	name "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285)"
-	description "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285)"
-	rom ( name "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285).bin" size 4096 crc 6841d2a7 md5 undefined sha1 bc427ff64dd0b6e8c5f12fb8b1841d3edda0295f )
-)
-
-game (
-	name "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285) (PAL)"
-	description "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285) (PAL)"
-	rom ( name "Wall-Defender (AKA Wall Break) (1983) (Bomb - Onbase) (CA285) (PAL).bin" size 4096 crc 727408cd md5 undefined sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
-)
-
-game (
-	name "War 2000 (AKA Astrowar) (1983) (Home Vision - Gem International Corp.) (VCS83102) (PAL)"
-	description "War 2000 (AKA Astrowar) (1983) (Home Vision - Gem International Corp.) (VCS83102) (PAL)"
-	rom ( name "War 2000 (AKA Astrowar) (1983) (Home Vision - Gem International Corp.) (VCS83102) (PAL).bin" size 4096 crc bb47d5af md5 undefined sha1 5cc122f10eb1a814d047404b462b325f51f35d2c )
-)
-
-game (
-	name "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky - Sears) (CX2610 - 49-75127) ~"
-	description "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky - Sears) (CX2610 - 49-75127) ~"
-	rom ( name "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky - Sears) (CX2610 - 49-75127) ~.bin" size 4096 crc cf174b57 md5 undefined sha1 2d7563d337cbc0cdf4fc14f69853ab6757697788 )
-)
-
-game (
-	name "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky) (CX2610) (PAL)"
-	description "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky) (CX2610) (PAL)"
-	rom ( name "Warlords (Kings in the Corner) (Paddle) (1981) (Atari, Carla Meninsky) (CX2610) (PAL).bin" size 4096 crc 1d35687b md5 undefined sha1 c3fba4bebc2dda8436126433e1f4c15e51ef1bd4 )
-)
-
-game (
-	name "Warplock (Paddle) (1982) (Data Age) (DA1002) ~"
-	description "Warplock (Paddle) (1982) (Data Age) (DA1002) ~"
-	rom ( name "Warplock (Paddle) (1982) (Data Age) (DA1002) ~.bin" size 4096 crc 6531d4e1 md5 undefined sha1 232a370519a7fcce121e15f850d0d3671909f8b8 )
-)
-
-game (
-	name "Warplock (Paddle) (1983) (Gameworld) (133-002) (PAL)"
-	description "Warplock (Paddle) (1983) (Gameworld) (133-002) (PAL)"
-	rom ( name "Warplock (Paddle) (1983) (Gameworld) (133-002) (PAL).bin" size 4096 crc faf0700d md5 undefined sha1 3cfdd92952dc4a019a7c9b050f6e4cc6656a0149 )
-)
-
-game (
-	name "Weltraumtunnel (AKA Innerspace) (1983) (Quelle) (292.651 7) (PAL)"
-	description "Weltraumtunnel (AKA Innerspace) (1983) (Quelle) (292.651 7) (PAL)"
-	rom ( name "Weltraumtunnel (AKA Innerspace) (1983) (Quelle) (292.651 7) (PAL).bin" size 4096 crc dc1d3627 md5 undefined sha1 c513703d638c01b0c26922d5e3e7bfb65ea597da )
-)
-
-game (
-	name "Westward Ho (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL)"
-	description "Westward Ho (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL)"
-	rom ( name "Westward Ho (AKA Custer's Revenge) (1982) (PlayAround - J.H.M.) (206) (PAL).bin" size 4096 crc f7729f85 md5 undefined sha1 472215fcb46cec905576d539efc8043488efc4ed )
-)
-
-game (
-	name "Wilma Wanderer (AKA Lilly Adventure) (1983) (ITT Family Games) (PAL)"
-	description "Wilma Wanderer (AKA Lilly Adventure) (1983) (ITT Family Games) (PAL)"
-	rom ( name "Wilma Wanderer (AKA Lilly Adventure) (1983) (ITT Family Games) (PAL).bin" size 4096 crc 3544c6d6 md5 undefined sha1 63f4776aa4c35d124001918b733cdb4d46dfbe9b )
-)
-
-game (
-	name "Wing War (Flap) (1983) (Imagic, Michael Greene) (EIZ-002-04I) (PAL) ~"
-	description "Wing War (Flap) (1983) (Imagic, Michael Greene) (EIZ-002-04I) (PAL) ~"
-	rom ( name "Wing War (Flap) (1983) (Imagic, Michael Greene) (EIZ-002-04I) (PAL) ~.bin" size 8192 crc cfebef9e md5 undefined sha1 1ce2426a1a71ebac81709c88eb30e461b29158e2 )
-)
-
-game (
-	name "Wings (06-03-1983) (CBS Electronics, Stuart Ross) (Prototype) ~"
-	description "Wings (06-03-1983) (CBS Electronics, Stuart Ross) (Prototype) ~"
-	rom ( name "Wings (06-03-1983) (CBS Electronics, Stuart Ross) (Prototype) ~.bin" size 12288 crc 5e89b8af md5 undefined sha1 419e7dd24c810afb8b8e555ed8489853b0bf05d8 )
-)
-
-game (
-	name "Wings (10-10-1983) (CBS Electronics, Stuart Ross) (Prototype) (PAL)"
-	description "Wings (10-10-1983) (CBS Electronics, Stuart Ross) (Prototype) (PAL)"
-	rom ( name "Wings (10-10-1983) (CBS Electronics, Stuart Ross) (Prototype) (PAL).bin" size 12288 crc dd0aa66f md5 undefined sha1 3e63feca31fb98cc46fdfe90ec69e4937f9defa6 )
-)
-
-game (
-	name "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) (PAL)"
-	description "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) (PAL)"
-	rom ( name "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) (PAL).bin" size 16384 crc 964ff099 md5 undefined sha1 b5d3d0c0841697b940fe80eae249a884d6a889c8 )
-)
-
-game (
-	name "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) ~"
-	description "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) ~"
-	rom ( name "Winter Games (1987) (Epyx, Steven A. Baker, Tod Frye, Peter Engelbrite) (80561-00251) ~.bin" size 16384 crc ddff6850 md5 undefined sha1 6850d329e8ab403bdae38850665a2eff91278e92 )
-)
-
-game (
-	name "Winterjagd (AKA Ski Hunt) (1983) (Quelle) (343.073 3) (PAL)"
-	description "Winterjagd (AKA Ski Hunt) (1983) (Quelle) (343.073 3) (PAL)"
-	rom ( name "Winterjagd (AKA Ski Hunt) (1983) (Quelle) (343.073 3) (PAL).bin" size 4096 crc 5f6c51c5 md5 undefined sha1 07d954ebe8a639249b2185d2b45bc9216cae14e6 )
-)
-
-game (
-	name "Wizard (1980) (Atari, Chris Crawford) (Prototype) [a]"
-	description "Wizard (1980) (Atari, Chris Crawford) (Prototype) [a]"
-	rom ( name "Wizard (1980) (Atari, Chris Crawford) (Prototype) [a].bin" size 2048 crc c1538490 md5 undefined sha1 bbc484403a23dbb4eacb85fe5b685c939c93cd08 )
-)
-
-game (
-	name "Wizard (1980) (Atari, Chris Crawford) (Prototype) ~"
-	description "Wizard (1980) (Atari, Chris Crawford) (Prototype) ~"
-	rom ( name "Wizard (1980) (Atari, Chris Crawford) (Prototype) ~.bin" size 2048 crc a0bcc502 md5 undefined sha1 2499ce7c77536b2920753968135f9180bd9afe6e )
-)
-
-game (
-	name "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (4L1720, 4L1721, 4L1722, 4L2276) (PAL)"
-	description "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (4L1720, 4L1721, 4L1722, 4L2276) (PAL)"
-	rom ( name "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (4L1720, 4L1721, 4L1722, 4L2276) (PAL).bin" size 4096 crc 087afe6e md5 undefined sha1 088dc33fad4fd90da71e21b6f19c565ff62def1f )
-)
-
-game (
-	name "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (M8774, M8794) ~"
-	description "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (M8774, M8794) ~"
-	rom ( name "Wizard of Wor (1982) (CBS Electronics, Joe Hellesen) (M8774, M8794) ~.bin" size 4096 crc 926f6f11 md5 undefined sha1 326e5e63a54ec6a0231fd38e62e352004d4719fe )
-)
-
-game (
-	name "Word Zapper (208 in 1) (Unknown) (PAL)"
-	description "Word Zapper (208 in 1) (Unknown) (PAL)"
-	rom ( name "Word Zapper (208 in 1) (Unknown) (PAL).bin" size 4096 crc 14af1a17 md5 undefined sha1 253788380f6f7757cda39d7256c796a95800c909 )
-)
-
-game (
-	name "Word Zapper (Unknown)"
-	description "Word Zapper (Unknown)"
-	rom ( name "Word Zapper (Unknown).bin" size 4096 crc d57fe17f md5 undefined sha1 9820cebfbdb8b7ff8870b07008381516feb22537 )
-)
-
-game (
-	name "Word Zapper (Unknown) (PAL)"
-	description "Word Zapper (Unknown) (PAL)"
-	rom ( name "Word Zapper (Unknown) (PAL).bin" size 4096 crc 90adf7fa md5 undefined sha1 e35e773a895ab7d121611fcd507e575c5bab4413 )
-)
-
-game (
-	name "Word Zapper (Word Grabber) (1982) (U.S. Games Corporation, Henry Will IV - Vidtec) (VC1003) ~"
-	description "Word Zapper (Word Grabber) (1982) (U.S. Games Corporation, Henry Will IV - Vidtec) (VC1003) ~"
-	rom ( name "Word Zapper (Word Grabber) (1982) (U.S. Games Corporation, Henry Will IV - Vidtec) (VC1003) ~.bin" size 4096 crc a11eeeab md5 undefined sha1 806c5a8a7b042a1a3ada1b6f29451a3446f93da3 )
-)
-
-game (
-	name "Words-Attack (1983) (Sancho - Tang's Electronic Co.) (Prototype) (PAL) ~"
-	description "Words-Attack (1983) (Sancho - Tang's Electronic Co.) (Prototype) (PAL) ~"
-	rom ( name "Words-Attack (1983) (Sancho - Tang's Electronic Co.) (Prototype) (PAL) ~.bin" size 4096 crc 77975baa md5 undefined sha1 84f4b60f351f23e664613ac3d155bb354b800cd5 )
-)
-
-game (
-	name "World End (1983) (Home Vision - Gem International Corp.) (VCS83109) (PAL) ~"
-	description "World End (1983) (Home Vision - Gem International Corp.) (VCS83109) (PAL) ~"
-	rom ( name "World End (1983) (Home Vision - Gem International Corp.) (VCS83109) (PAL) ~.bin" size 4096 crc dcc36508 md5 undefined sha1 0e981d6baa7e3e218608eb46ad51fb30675babac )
-)
-
-game (
-	name "Worm War I (1982) (20th Century Fox Video Games - Sirius Software, David Lubar) (11001) ~"
-	description "Worm War I (1982) (20th Century Fox Video Games - Sirius Software, David Lubar) (11001) ~"
-	rom ( name "Worm War I (1982) (20th Century Fox Video Games - Sirius Software, David Lubar) (11001) ~.bin" size 4096 crc 97b83a54 md5 undefined sha1 36a1e73eb5aa5c3cd0b01af5117d19b8c36071e4 )
-)
-
-game (
-	name "Worm War I (1983) (CCE) (C-843)"
-	description "Worm War I (1983) (CCE) (C-843)"
-	rom ( name "Worm War I (1983) (CCE) (C-843).bin" size 4096 crc dcb61a59 md5 undefined sha1 3c3b4968dd3ab0e4cfecc5ac0c850567cf3f6443 )
-)
-
-game (
-	name "Worm War I (208 in 1) (Unknown) (PAL)"
-	description "Worm War I (208 in 1) (Unknown) (PAL)"
-	rom ( name "Worm War I (208 in 1) (Unknown) (PAL).bin" size 4096 crc 4a61b478 md5 undefined sha1 4e72aa7032e382a792b0f483cde9986f12598018 )
-)
-
-game (
-	name "Worm War I (Unknown) (PAL)"
-	description "Worm War I (Unknown) (PAL)"
-	rom ( name "Worm War I (Unknown) (PAL).bin" size 4096 crc a68a5f1f md5 undefined sha1 e42820d46677a55026726a0e17570cf6dc8b048b )
-)
-
-game (
-	name "Wuestenschlacht (AKA Chopper Command) (1983) (Quelle) (262.794 1) (PAL)"
-	description "Wuestenschlacht (AKA Chopper Command) (1983) (Quelle) (262.794 1) (PAL)"
-	rom ( name "Wuestenschlacht (AKA Chopper Command) (1983) (Quelle) (262.794 1) (PAL).bin" size 4096 crc 43a24f04 md5 undefined sha1 bc483097f94f2bf9c4d3366b3bd25200f2e2f22a )
-)
-
-game (
-	name "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) (PAL)"
-	description "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) (PAL)"
-	rom ( name "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) (PAL).bin" size 4096 crc 6c23c60b md5 undefined sha1 a5c2a3978ebd8e6a1e7aeee7281904983516f69e )
-)
-
-game (
-	name "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) ~"
-	description "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) ~"
-	rom ( name "X-Man (1983) (Universal Gamex Corporation, Alan Roberts, H.K. Poon) (GX-001) ~.bin" size 4096 crc 91659af1 md5 undefined sha1 1c5d151e86c0a0bbdf3b33ef153888c6be78c36b )
-)
-
-game (
-	name "X'Mission (Unknown) (PAL)"
-	description "X'Mission (Unknown) (PAL)"
-	rom ( name "X'Mission (Unknown) (PAL).bin" size 4096 crc eef374c2 md5 undefined sha1 9967a76efb68017f793188f691159f04e6bb4447 )
-)
-
-game (
-	name "Xenophobe (1990) (Atari) (CX26172) (PAL)"
-	description "Xenophobe (1990) (Atari) (CX26172) (PAL)"
-	rom ( name "Xenophobe (1990) (Atari) (CX26172) (PAL).bin" size 16384 crc 3835c5c1 md5 undefined sha1 75039127cb7c53fa09d1c223729a4c5a521aedef )
-)
-
-game (
-	name "Xenophobe (1990) (Atari) (CX26172) ~"
-	description "Xenophobe (1990) (Atari) (CX26172) ~"
-	rom ( name "Xenophobe (1990) (Atari) (CX26172) ~.bin" size 16384 crc f875c406 md5 undefined sha1 160b6e36437ad6acbc2686fbde1002e2fa88c5fb )
-)
-
-game (
-	name "Xevious (05-25-1983) (Atari, Tod Frye) (CX2695) (Prototype)"
-	description "Xevious (05-25-1983) (Atari, Tod Frye) (CX2695) (Prototype)"
-	rom ( name "Xevious (05-25-1983) (Atari, Tod Frye) (CX2695) (Prototype).bin" size 8192 crc d6867b22 md5 undefined sha1 fac29f21b711d31e3ffc21dfdcafef05aafabf02 )
-)
-
-game (
-	name "Xevious (08-02-1983) (Atari, Tod Frye) (CX2695) (Prototype) ~"
-	description "Xevious (08-02-1983) (Atari, Tod Frye) (CX2695) (Prototype) ~"
-	rom ( name "Xevious (08-02-1983) (Atari, Tod Frye) (CX2695) (Prototype) ~.bin" size 8192 crc 2ef09f4a md5 undefined sha1 73133b81196e5cbc1cec99eefc1223ddb8f4ca83 )
-)
-
-game (
-	name "Xevious (11-08-1984) (Atari, Tod Frye) (CX2695) (Prototype)"
-	description "Xevious (11-08-1984) (Atari, Tod Frye) (CX2695) (Prototype)"
-	rom ( name "Xevious (11-08-1984) (Atari, Tod Frye) (CX2695) (Prototype).bin" size 8192 crc f5802a6c md5 undefined sha1 53f941cabf661a9ce763142b070571f6fd4c8820 )
-)
-
-game (
-	name "Xevious (CCE)"
-	description "Xevious (CCE)"
-	rom ( name "Xevious (CCE).bin" size 8192 crc 8bd51ecc md5 undefined sha1 c4f956cc6a78f3d7b5c2fb16de58ed7cdb6c82a8 )
-)
-
-game (
-	name "Yars' Revenge (Canal 3 - Intellivision)"
-	description "Yars' Revenge (Canal 3 - Intellivision)"
-	rom ( name "Yars' Revenge (Canal 3 - Intellivision).bin" size 4096 crc aea86244 md5 undefined sha1 5febb9f56a989ee6a672d498464744c622147869 )
-)
-
-game (
-	name "Yars' Revenge (Time Freeze) (09-01-81) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) (Prototype)"
-	description "Yars' Revenge (Time Freeze) (09-01-81) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) (Prototype)"
-	rom ( name "Yars' Revenge (Time Freeze) (09-01-81) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) (Prototype).bin" size 4096 crc ce11177a md5 undefined sha1 884647ebc15df7d9388b2cba0318c240e593dbc0 )
-)
-
-game (
-	name "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) ~"
-	description "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) ~"
-	rom ( name "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw - Sears) (CX2655 - 49-75167) ~.bin" size 4096 crc dfa1c825 md5 undefined sha1 e2cd8996c1cf929e29130690024d1ec23d3b0bde )
-)
-
-game (
-	name "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw) (CX2655, CX2655P) (PAL)"
-	description "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw) (CX2655, CX2655P) (PAL)"
-	rom ( name "Yars' Revenge (Time Freeze) (1982) (Atari, Howard Scott Warshaw) (CX2655, CX2655P) (PAL).bin" size 4096 crc 317f7d0c md5 undefined sha1 aaeb19d1e5b3164659b3f18cbf32f3db924e500c )
-)
-
-game (
-	name "Year 1999, The (AKA Condor Attack) (Rainbow Vision - Suntek) (SS-008) (PAL)"
-	description "Year 1999, The (AKA Condor Attack) (Rainbow Vision - Suntek) (SS-008) (PAL)"
-	rom ( name "Year 1999, The (AKA Condor Attack) (Rainbow Vision - Suntek) (SS-008) (PAL).bin" size 4096 crc 4e19ab22 md5 undefined sha1 a80ea7083615fc7560beecfc0e99fa78fa7eeef7 )
-)
-
-game (
-	name "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283)"
-	description "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283)"
-	rom ( name "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283).bin" size 4096 crc 42a76f54 md5 undefined sha1 552e2bd37601da4961b0346353c93cce223e429e )
-)
-
-game (
-	name "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283) (PAL)"
-	description "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283) (PAL)"
-	rom ( name "Z-Tack (AKA Base Attack) (1983) (Bomb - Onbase) (CA283) (PAL).bin" size 4096 crc 81f1e5dd md5 undefined sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
-)
-
-game (
-	name "Zaxxon (1982) (CBS Electronics) (4L1784, 4L1786, 4L1787, 4L2277) (PAL)"
-	description "Zaxxon (1982) (CBS Electronics) (4L1784, 4L1786, 4L1787, 4L2277) (PAL)"
-	rom ( name "Zaxxon (1982) (CBS Electronics) (4L1784, 4L1786, 4L1787, 4L2277) (PAL).bin" size 8192 crc e8785b76 md5 undefined sha1 fe5e7f026b3154a222244fe595cfebbf8a080fcb )
-)
-
-game (
-	name "Zaxxon (1982) (Coleco) (2454) ~"
-	description "Zaxxon (1982) (Coleco) (2454) ~"
-	rom ( name "Zaxxon (1982) (Coleco) (2454) ~.bin" size 8192 crc 265aa87f md5 undefined sha1 58c2f6abc5599cd35c0e722f24bcc128ac8f9a30 )
-)
-
-game (
-	name "Zoo Fun (Suntek) (SS-027) (PAL)"
-	description "Zoo Fun (Suntek) (SS-027) (PAL)"
-	rom ( name "Zoo Fun (Suntek) (SS-027) (PAL).bin" size 4096 crc 99ce60e6 md5 undefined sha1 f14d270d429fc3ecf5dd04d71e87e79daf52fd5f )
-)
-
-game (
-	name "Zoo Keeper Sounds (1984) (Atari, Christopher H. Omarzu, Robert Vieira) (CX26121) (Prototype) ~"
-	description "Zoo Keeper Sounds (1984) (Atari, Christopher H. Omarzu, Robert Vieira) (CX26121) (Prototype) ~"
-	rom ( name "Zoo Keeper Sounds (1984) (Atari, Christopher H. Omarzu, Robert Vieira) (CX26121) (Prototype) ~.bin" size 2048 crc ae15c45d md5 undefined sha1 7f115cb41fc70889b933fd2c808044a2b6367261 )
+	name "Zoo Keeper Sounds (USA) (Proto)"
+	description "Zoo Keeper Sounds (USA) (Proto)"
+	rom ( name "Zoo Keeper Sounds (USA) (Proto).a26" size 2048 crc ae15c45d md5 a336beac1f0a835614200ecd9c41fd70 sha1 7f115cb41fc70889b933fd2c808044a2b6367261 )
 )


### PR DESCRIPTION
This is based on Rom Hunter V11 rom pack from AtariMania but updated to follow No-Intro standards.  It isn't perfect yet but it does make 2600 appear much more like the other No-Intro systems.