### PR TITLE
Add No-Intro Atari 2600

### DIFF
--- a/metadat/no-intro/Atari - 2600.dat
+++ b/metadat/no-intro/Atari - 2600.dat
@@ -1,0 +1,3294 @@
+clrmamepro (
+	name "Atari - 2600"
+	description "Atari - 2600"
+	version 20161212-103245
+	comment "no-intro | www.no-intro.org"
+)
+
+game (
+	name "3-D Tic-Tac-Toe (USA)"
+	description "3-D Tic-Tac-Toe (USA)"
+	rom ( name "3-D Tic-Tac-Toe (USA).a26" size 2048 crc 58805709 md5 0db4f4150fecf77e4ce72ca4d04c052f sha1 21d983f2f52b84c22ecae84b0943678ae2c31c10 )
+)
+
+game (
+	name "Acid Drop (USA)"
+	description "Acid Drop (USA)"
+	rom ( name "Acid Drop (USA).a26" size 16384 crc 14cddac7 md5 17ee23e5da931be82f733917adcb6386 sha1 d7c62df8300a68b21ce672cfaa4d0f2f4b3d0ce1 )
+)
+
+game (
+	name "Action Force (USA)"
+	description "Action Force (USA)"
+	rom ( name "Action Force (USA).a26" size 4096 crc 896446cf md5 b9f6fa399b8cd386c235983ec45e4355 sha1 9e6fb047ee9fa0a454ca23673ed9693430032dc6 )
+)
+
+game (
+	name "Activision Decathlon, The (USA)"
+	description "Activision Decathlon, The (USA)"
+	rom ( name "Activision Decathlon, The (USA).a26" size 8192 crc 3feb39b1 md5 525f2dfc8b21b0186cff2568e0509bfc sha1 e0d47565df935c064bc4055636f37a0432ab3727 )
+)
+
+game (
+	name "Adventure (USA)"
+	description "Adventure (USA)"
+	rom ( name "Adventure (USA).a26" size 4096 crc a6db4b3a md5 157bddb7192754a45372be196797f284 sha1 e07e48d463d30321239a8acc00c490f27f1f7422 )
+)
+
+game (
+	name "Adventures of TRON (USA)"
+	description "Adventures of TRON (USA)"
+	rom ( name "Adventures of TRON (USA).a26" size 4096 crc 1b8019d6 md5 ca4f8c5b4d6fb9d608bb96bc7ebd26c7 sha1 03a495c7bfa0671e24aa4d9460d232731f68cb43 )
+)
+
+game (
+	name "Air Raid (USA)"
+	description "Air Raid (USA)"
+	rom ( name "Air Raid (USA).a26" size 4096 crc b0e53814 md5 35be55426c1fec32dfb503b4f0651572 sha1 3b02e7dacb418c44d0d3dc77d60a9663b90b0fbc )
+)
+
+game (
+	name "Air Raiders (USA)"
+	description "Air Raiders (USA)"
+	rom ( name "Air Raiders (USA).a26" size 4096 crc bb16539d md5 a9cb638cd2cb2e8e0643d7a67db4281c sha1 29f5c73d1fe806a4284547274dd73f9972a7ed70 )
+)
+
+game (
+	name "Air-Sea Battle ~ Target Fun (USA)"
+	description "Air-Sea Battle ~ Target Fun (USA)"
+	rom ( name "Air-Sea Battle ~ Target Fun (USA).a26" size 2048 crc 1fc6c0f1 md5 16cb43492987d2f32b423817cdaaf7c4 sha1 a746fdc82b336a9d499bf17f50b41e0193ba595e )
+)
+
+game (
+	name "Airlock (USA)"
+	description "Airlock (USA)"
+	rom ( name "Airlock (USA).a26" size 4096 crc 25c90ce7 md5 4d77f291dca1518d7d8e47838695f54b sha1 0376c242819b785310b8af43c03b1d1156bd5f02 )
+)
+
+game (
+	name "Alien (USA)"
+	description "Alien (USA)"
+	rom ( name "Alien (USA).a26" size 4096 crc 6d61059f md5 f1a0a23e6464d954e3a9579c4ccd01c8 sha1 01d99bf307262825db58631e8002dd008a42cb1e )
+)
+
+game (
+	name "Aliens Return (Europe)"
+	description "Aliens Return (Europe)"
+	rom ( name "Aliens Return (Europe).a26" size 4096 crc c161f53b md5 103f1756d9dc0dd2b16b53ad0f0f1859 sha1 4c41379f0dd9880384fcbb46bad9fbaaf109a477 )
+)
+
+game (
+	name "Alligator People (USA) (Proto)"
+	description "Alligator People (USA) (Proto)"
+	rom ( name "Alligator People (USA) (Proto).a26" size 4096 crc b3f6d395 md5 e1a51690792838c5c687da80cd764d78 sha1 a1795d6371ddb0bc93ba6df70299cc548dc88b99 )
+)
+
+game (
+	name "Alpha Beam with Ernie (USA)"
+	description "Alpha Beam with Ernie (USA)"
+	rom ( name "Alpha Beam with Ernie (USA).a26" size 8192 crc 27c6b897 md5 9e01f7f95cb8596765e03b9a36e8e33c sha1 a1f660827ce291f19719a5672f2c5d277d903b03 )
+)
+
+game (
+	name "Amidar (USA)"
+	description "Amidar (USA)"
+	rom ( name "Amidar (USA).a26" size 4096 crc 8eb5bd72 md5 acb7750b4d0c4bd34969802a7deb2990 sha1 b89a5ac6593e83fbebee1fe7d4cec81a7032c544 )
+)
+
+game (
+	name "Apples And Dolls (USA)"
+	description "Apples And Dolls (USA)"
+	rom ( name "Apples And Dolls (USA).a26" size 4096 crc e7514705 md5 e73838c43040bcbc83e4204a3e72eef4 sha1 62e92508cf43acc28bff8b03a197137d56a5df79 )
+)
+
+game (
+	name "Aquaventure (USA) (Proto)"
+	description "Aquaventure (USA) (Proto)"
+	rom ( name "Aquaventure (USA) (Proto).a26" size 8192 crc 87a8cb8b md5 038e1e79c3d4410defde4bfe0b99cc32 sha1 7d132ab776ff755b86bf4f204165aa54e9e1f1cf )
+)
+
+game (
+	name "Armor Ambush (USA)"
+	description "Armor Ambush (USA)"
+	rom ( name "Armor Ambush (USA).a26" size 4096 crc fc35704b md5 a7b584937911d60c120677fe0d47f36f sha1 9b6a54969240baf64928118741c3affee148d721 )
+)
+
+game (
+	name "Artillery Duel (USA)"
+	description "Artillery Duel (USA)"
+	rom ( name "Artillery Duel (USA).a26" size 8192 crc 1d0f7e8d md5 c77c35a6fc3c0f12bf9e8bae48cba54b sha1 8c249e9eaa83fc6be16039f05ec304efdf987beb )
+)
+
+game (
+	name "Assault (USA)"
+	description "Assault (USA)"
+	rom ( name "Assault (USA).a26" size 4096 crc ab3a2b77 md5 de78b3a064d374390ac0710f95edde92 sha1 0c03eba97df5178eec5d4d0aea4a6fe2f961c88f )
+)
+
+game (
+	name "Asteroids (USA)"
+	description "Asteroids (USA)"
+	rom ( name "Asteroids (USA).a26" size 8192 crc c7d64c94 md5 dd7884b4f93cab423ac471aa1935e3df sha1 d68937e57a367e61eaa4b44550ae8b9d69456661 )
+)
+
+game (
+	name "Astroblast (USA)"
+	description "Astroblast (USA)"
+	rom ( name "Astroblast (USA).a26" size 4096 crc 1de25331 md5 170e7589a48739cfb9cc782cbb0fe25a sha1 8e83fd77e198b27eb5b02a6dc02a5ab37b5a76bd )
+)
+
+game (
+	name "Astrowar (Europe)"
+	description "Astrowar (Europe)"
+	rom ( name "Astrowar (Europe).a26" size 4096 crc e83f5848 md5 317a4cdbab090dcc996833d07cb40165 sha1 eca0764f26168424633b620a9ff9b274b236135f )
+)
+
+game (
+	name "Atari Video Cube (USA)"
+	description "Atari Video Cube (USA)"
+	rom ( name "Atari Video Cube (USA).a26" size 4096 crc 272ae37f md5 3f540a30fdee0b20aed7288e4a5ea528 sha1 d1563c24208766cf8d28de7af995021a9f89d7e1 )
+)
+
+game (
+	name "Atlantis (USA)"
+	description "Atlantis (USA)"
+	rom ( name "Atlantis (USA).a26" size 4096 crc 92560498 md5 9ad36e699ef6f45d9eb6c4cf90475c9f sha1 c6b1dcdb2f024ab682316db45763bacc6949c33c )
+)
+
+game (
+	name "Bachelor Party ~ Gigolo (USA)"
+	description "Bachelor Party ~ Gigolo (USA)"
+	rom ( name "Bachelor Party ~ Gigolo (USA).a26" size 4096 crc d9cd6c95 md5 5b124850de9eea66781a50b2e9837000 sha1 75e7efa861f7e7d8e367c09bf7c0cc351b472f03 )
+)
+
+game (
+	name "Bachelorette Party ~ Burning Desire (USA)"
+	description "Bachelorette Party ~ Burning Desire (USA)"
+	rom ( name "Bachelorette Party ~ Burning Desire (USA).a26" size 4096 crc 92f91d36 md5 19d6956ff17a959c48fcd8f4706a848d sha1 b233c37aa5164a54e2e7cc3dc621b331ddc6e55b )
+)
+
+game (
+	name "Backgammon (USA)"
+	description "Backgammon (USA)"
+	rom ( name "Backgammon (USA).a26" size 4096 crc e2a7ffa6 md5 8556b42aa05f94bc29ff39c39b11bff4 sha1 9b1da7fbd0bf6fcadf1b60c11eeb31b6a61a03c3 )
+)
+
+game (
+	name "Bank Heist (USA)"
+	description "Bank Heist (USA)"
+	rom ( name "Bank Heist (USA).a26" size 4096 crc 7aa79d1e md5 00ce0bdd43aed84a983bef38fe7f5ee3 sha1 80d4020575b14e130f28146bf45921e001f9f649 )
+)
+
+game (
+	name "Barnstorming (USA)"
+	description "Barnstorming (USA)"
+	rom ( name "Barnstorming (USA).a26" size 4096 crc 4a005181 md5 f8240e62d8c0a64a61e19388414e3104 sha1 372663097b419ced64f44ef743fe8d0af4317f46 )
+)
+
+game (
+	name "Base Attack (USA)"
+	description "Base Attack (USA)"
+	rom ( name "Base Attack (USA).a26" size 4096 crc 81f1e5dd md5 d6dc9b4508da407e2437bfa4de53d1b2 sha1 4e2ccb0afe236a76193ad500bab57abb82632a5a )
+)
+
+game (
+	name "Basic Math ~ Math (USA)"
+	description "Basic Math ~ Math (USA)"
+	rom ( name "Basic Math ~ Math (USA).a26" size 2048 crc d48ebac0 md5 819aeeb9a2e11deb54e6de334f843894 sha1 5cc4010eb2858afe8ce77f53a89d37c7584e15b4 )
+)
+
+game (
+	name "BASIC Programming (USA)"
+	description "BASIC Programming (USA)"
+	rom ( name "BASIC Programming (USA).a26" size 4096 crc 26a3c844 md5 9f48eeb47836cf145a15771775f0767a sha1 6c56fad688b2e9bb783f8a5a2360c80ad2338e47 )
+)
+
+game (
+	name "Basketball (USA)"
+	description "Basketball (USA)"
+	rom ( name "Basketball (USA).a26" size 2048 crc b31d49f0 md5 ab4ac994865fb16ebb85738316309457 sha1 bffe99454cb055552e5d612f0dba25470137328d )
+)
+
+game (
+	name "Battlezone (USA)"
+	description "Battlezone (USA)"
+	rom ( name "Battlezone (USA).a26" size 8192 crc 9155dd1d md5 41f252a66c6301f1e8ab3612c19bc5d4 sha1 e4134a3b4a065c856802bc935c12fa7e9868110a )
+)
+
+game (
+	name "Beamrider (USA)"
+	description "Beamrider (USA)"
+	rom ( name "Beamrider (USA).a26" size 8192 crc 1618565b md5 79ab4123a83dc11d468fb2108ea09e2e sha1 47619edb352f7f955f811cbb03a00746c8e099b1 )
+)
+
+game (
+	name "Beany Bopper (USA)"
+	description "Beany Bopper (USA)"
+	rom ( name "Beany Bopper (USA).a26" size 4096 crc b722bc8f md5 d0b9df57bfea66378c0418ec68cfe37f sha1 fad0c97331a525a4aeba67987552ba324629a7a0 )
+)
+
+game (
+	name "Beat 'Em & Eat 'Em (USA)"
+	description "Beat 'Em & Eat 'Em (USA)"
+	rom ( name "Beat 'Em & Eat 'Em (USA).a26" size 4096 crc c90d4f84 md5 59e96de9628e8373d1c685f5e57dcf10 sha1 e2c29d0a73a4575028b62dca745476a17f07c8f0 )
+)
+
+game (
+	name "Berenstain Bears (USA)"
+	description "Berenstain Bears (USA)"
+	rom ( name "Berenstain Bears (USA).a26" size 8192 crc 29d28baf md5 ee6665683ebdb539e89ba620981cb0f6 sha1 c3afd7909b72b49ca7d4485465b622d5e55f8913 )
+)
+
+game (
+	name "Bermuda Triangle (USA)"
+	description "Bermuda Triangle (USA)"
+	rom ( name "Bermuda Triangle (USA).a26" size 4096 crc 0fcb5b94 md5 b8ed78afdb1e6cfe44ef6e3428789d5f sha1 fcad0e5130de24f06b98fb86a7c3214841ca42e2 )
+)
+
+game (
+	name "Berzerk (USA)"
+	description "Berzerk (USA)"
+	rom ( name "Berzerk (USA).a26" size 4096 crc 2e8b4b5f md5 136f75c4dd02c29283752b7e5799f978 sha1 08bcbc8954473e8f0242b881315b0af4466998ae )
+)
+
+game (
+	name "Big Bird's Egg Catch (USA)"
+	description "Big Bird's Egg Catch (USA)"
+	rom ( name "Big Bird's Egg Catch (USA).a26" size 8192 crc 96dc9a9c md5 1802cc46b879b229272501998c5de04f sha1 5e4517db83c061926130ab65975e3b83d9401cc9 )
+)
+
+game (
+	name "Bionic Breakthrough (USA) (Proto)"
+	description "Bionic Breakthrough (USA) (Proto)"
+	rom ( name "Bionic Breakthrough (USA) (Proto).a26" size 8192 crc 928e4b47 md5 f0541d2f7cda5ec7bab6d62b6128b823 sha1 f6a41507b8cf890ab7c59bb1424f0500534385ce )
+)
+
+game (
+	name "Blackjack (USA)"
+	description "Blackjack (USA)"
+	rom ( name "Blackjack (USA).a26" size 2048 crc 4b0ee010 md5 0a981c03204ac2b278ba392674682560 sha1 edfd905a34870196f8acb2a9cd41f79f4326f88d )
+)
+
+game (
+	name "Blueprint (USA)"
+	description "Blueprint (USA)"
+	rom ( name "Blueprint (USA).a26" size 8192 crc da7b9dfa md5 33d68c3cd74e5bc4cf0df3716c5848bc sha1 0fadef01ce28192880f745b23a5fbb64c5a96efe )
+)
+
+game (
+	name "BMX Air Master (USA)"
+	description "BMX Air Master (USA)"
+	rom ( name "BMX Air Master (USA).a26" size 16384 crc b4017ee3 md5 968efc79d500dce52a906870a97358ab sha1 ff25ed062dcc430448b358d2ac745787410e1169 )
+)
+
+game (
+	name "Bobby geht Heim (Europe)"
+	description "Bobby geht Heim (Europe)"
+	rom ( name "Bobby geht Heim (Europe).a26" size 4096 crc f061e27f md5 2823364702595feea24a3fbee138a243 sha1 50e26688fdd3eadcfa83240616267a8f60216c25 )
+)
+
+game (
+	name "Boggle (USA) (Proto)"
+	description "Boggle (USA) (Proto)"
+	rom ( name "Boggle (USA) (Proto).a26" size 2048 crc 26b6bfef md5 a5855d73d304d83ef07dde03e379619f sha1 4accd4cc4f8f3a935ca178449a4ac62283639c53 )
+)
+
+game (
+	name "Boing! (USA)"
+	description "Boing! (USA)"
+	rom ( name "Boing! (USA).a26" size 4096 crc ad380487 md5 14c2548712099c220964d7f044c59fd9 sha1 d106bb41a38ed222dead608d839e8a3f0d0ecc18 )
+)
+
+game (
+	name "Bowling (USA)"
+	description "Bowling (USA)"
+	rom ( name "Bowling (USA).a26" size 2048 crc fea0d6d5 md5 c9b7afad3bfd922e006a6bfc1d4f3fe7 sha1 cf6ce244b3edaad7ad5e9ca5f01668135c2f93d0 )
+)
+
+game (
+	name "Boxing (USA)"
+	description "Boxing (USA)"
+	rom ( name "Boxing (USA).a26" size 2048 crc 9ece0021 md5 c3ef5c4653212088eda54dc91d787870 sha1 14b9cd91188c7fb0d4566442d639870f8d6f174d )
+)
+
+game (
+	name "Brain Games (USA)"
+	description "Brain Games (USA)"
+	rom ( name "Brain Games (USA).a26" size 2048 crc 150709c2 md5 1cca2197d95c5a41f2add49a13738055 sha1 238915cafd26f69bc8a3b9aa7d880dde59f6f12d )
+)
+
+game (
+	name "Breakout ~ Breakaway IV (USA)"
+	description "Breakout ~ Breakaway IV (USA)"
+	rom ( name "Breakout ~ Breakaway IV (USA).a26" size 2048 crc 3037638c md5 f34f08e5eb96e500e851a80be3277a56 sha1 8d473b87b70e26890268e6c417c0bb7f01e402eb )
+)
+
+game (
+	name "Bridge (USA)"
+	description "Bridge (USA)"
+	rom ( name "Bridge (USA).a26" size 4096 crc 8db95d1e md5 413c925c5fdcea62842a63a4c671a5f2 sha1 6df43b75ae080240d97754ab69c39c32370800a7 )
+)
+
+game (
+	name "Buck Rogers - Planet of Zoom (USA)"
+	description "Buck Rogers - Planet of Zoom (USA)"
+	rom ( name "Buck Rogers - Planet of Zoom (USA).a26" size 8192 crc 2030f686 md5 1cf59fc7b11cdbcefe931e41641772f6 sha1 a65dea2d9790f3eb308c048a01566e35e8c24549 )
+)
+
+game (
+	name "Bugs (USA)"
+	description "Bugs (USA)"
+	rom ( name "Bugs (USA).a26" size 4096 crc 1202427c md5 68597264c8e57ada93be3a5be4565096 sha1 67387d0d3d48a44800c44860bf15339a81f41aa9 )
+)
+
+game (
+	name "Bugs Bunny (USA) (Proto)"
+	description "Bugs Bunny (USA) (Proto)"
+	rom ( name "Bugs Bunny (USA) (Proto).a26" size 8192 crc bd164019 md5 a3486c0b8110d9d4b1db5d8a280723c6 sha1 b3ff124891de0fb3d44c35115d838fd7e135ca04 )
+)
+
+game (
+	name "Bump 'n' Jump (USA)"
+	description "Bump 'n' Jump (USA)"
+	rom ( name "Bump 'n' Jump (USA).a26" size 16384 crc df2bc303 md5 76f53abbbf39a0063f24036d6ee0968a sha1 1819ef408c1216c83dcfeceec28d13f6ea5ca477 )
+)
+
+game (
+	name "Bumper Bash (USA)"
+	description "Bumper Bash (USA)"
+	rom ( name "Bumper Bash (USA).a26" size 4096 crc b1a6a23e md5 aa1c41f86ec44c0a44eb64c332ce08af sha1 6c199782c79686dc0cbce6d5fe805f276a86a3f5 )
+)
+
+game (
+	name "BurgerTime (USA)"
+	description "BurgerTime (USA)"
+	rom ( name "BurgerTime (USA).a26" size 16384 crc c183fbbc md5 0443cfa9872cdb49069186413275fa21 sha1 49e01b8048ae344cb65838f6b1c1de0e1f416f29 )
+)
+
+game (
+	name "Cabbage Patch Kids - Adventures in the Park (USA) (Proto)"
+	description "Cabbage Patch Kids - Adventures in the Park (USA) (Proto)"
+	rom ( name "Cabbage Patch Kids - Adventures in the Park (USA) (Proto).a26" size 8192 crc 7025d30d md5 66fcf7643d554f5e15d4d06bab59fe70 sha1 ffdba8ae22784ccc81a5a2e81a236ace09e5b7f4 )
+)
+
+game (
+	name "Cakewalk (USA)"
+	description "Cakewalk (USA)"
+	rom ( name "Cakewalk (USA).a26" size 4096 crc 73494211 md5 7f6533386644c7d6358f871666c86e79 sha1 3f1f17cf620f462355009f5302cddffa730fa2fa )
+)
+
+game (
+	name "California Games (USA)"
+	description "California Games (USA)"
+	rom ( name "California Games (USA).a26" size 16384 crc e9a3fdc3 md5 9ab72d3fd2cc1a0c9adb504502579037 sha1 609c20365c3a71ce45cb277c66ec3ce6b2c50980 )
+)
+
+game (
+	name "Canyon Bomber (USA)"
+	description "Canyon Bomber (USA)"
+	rom ( name "Canyon Bomber (USA).a26" size 2048 crc e914b8ca md5 feedcc20bc3ca34851cd5d9e38aa2ca6 sha1 b89443a0029e765c2716774fe2582be37650115c )
+)
+
+game (
+	name "Care Bears (USA) (Proto)"
+	description "Care Bears (USA) (Proto)"
+	rom ( name "Care Bears (USA) (Proto).a26" size 4096 crc a14a81d1 md5 151c33a71b99e6bcffb34b43c6f0ec23 sha1 48576a24a40482151f6b3c9687be442db27115a8 )
+)
+
+game (
+	name "Carnival (USA)"
+	description "Carnival (USA)"
+	rom ( name "Carnival (USA).a26" size 4096 crc 7ac3c700 md5 028024fb8e5e5f18ea586652f9799c96 sha1 e1acf7a845b56e4b3d18192a75a81c7afa6f341a )
+)
+
+game (
+	name "Casino ~ Poker Plus (USA)"
+	description "Casino ~ Poker Plus (USA)"
+	rom ( name "Casino ~ Poker Plus (USA).a26" size 4096 crc 420b8248 md5 b816296311019ab69a21cb9e9e235d12 sha1 08598101e38756916613f37581ef1b61c719016f )
+)
+
+game (
+	name "Cat Trax (USA)"
+	description "Cat Trax (USA)"
+	rom ( name "Cat Trax (USA).a26" size 4096 crc c847e5ec md5 76f66ce3b83d7a104a899b4b3354a2f2 sha1 e979de719cecab2115affd9c0552c6c596b1999a )
+)
+
+game (
+	name "Cathouse Blues (USA)"
+	description "Cathouse Blues (USA)"
+	rom ( name "Cathouse Blues (USA).a26" size 4096 crc 3c4e3f41 md5 9e192601829f5f5c2d3b51f8ae25dbe5 sha1 6adf70e0b7b5dab74cf4778f56000de7605e8713 )
+)
+
+game (
+	name "Centipede (USA)"
+	description "Centipede (USA)"
+	rom ( name "Centipede (USA).a26" size 8192 crc 77396102 md5 91c2098e88a6b13f977af8c003e0bca5 sha1 0b5914bc1526a9beaf54d7fd11408175cd8fcc72 )
+)
+
+game (
+	name "Challenge (USA)"
+	description "Challenge (USA)"
+	rom ( name "Challenge (USA).a26" size 4096 crc 1f19aa5d md5 73158ea51d77bf521e1369311d26c27b sha1 b2b1bd165b3c10cde5316ed0f9f05a509aac828d )
+)
+
+game (
+	name "Challenge of.... Nexar, The (USA)"
+	description "Challenge of.... Nexar, The (USA)"
+	rom ( name "Challenge of.... Nexar, The (USA).a26" size 4096 crc 74cc37d4 md5 5d799bfa9e1e7b6224877162accada0d sha1 ac9b0c62ba0ca7a975d08fabbbc7c7448ecdf18d )
+)
+
+game (
+	name "Championship Soccer ~ Soccer (USA)"
+	description "Championship Soccer ~ Soccer (USA)"
+	rom ( name "Championship Soccer ~ Soccer (USA).a26" size 4096 crc 3f59bb60 md5 ace319dc4f76548659876741a6690d57 sha1 832283530f5dee332f29cf8c4854dd554f2030a0 )
+)
+
+game (
+	name "Chase the Chuckwagon (USA)"
+	description "Chase the Chuckwagon (USA)"
+	rom ( name "Chase the Chuckwagon (USA).a26" size 4096 crc 63e4fc7f md5 3e33ac10dcf2dff014bc1decf8a9aea4 sha1 872b2f9aa7edbcbb2368de0db3696c90998ff016 )
+)
+
+game (
+	name "Checkers (USA)"
+	description "Checkers (USA)"
+	rom ( name "Checkers (USA).a26" size 2048 crc e74f1b59 md5 3f5a43602f960ede330cd2f43a25139e sha1 39b5bb27a6c4cb6532bd9d4cc520415c59dac653 )
+)
+
+game (
+	name "China Syndrome (USA)"
+	description "China Syndrome (USA)"
+	rom ( name "China Syndrome (USA).a26" size 4096 crc a714e79c md5 749fec9918160921576f850b2375b516 sha1 0b1bb76769ae3f8b4936f0f95f4941d276791bde )
+)
+
+game (
+	name "Chopper Command (USA)"
+	description "Chopper Command (USA)"
+	rom ( name "Chopper Command (USA).a26" size 4096 crc 1dfa64df md5 c1cb228470a87beb5f36e90ac745da26 sha1 51a53bbfdbcc22925515ae0af79df434df6ee68a )
+)
+
+game (
+	name "Chuck Norris Superkicks (USA)"
+	description "Chuck Norris Superkicks (USA)"
+	rom ( name "Chuck Norris Superkicks (USA).a26" size 8192 crc 96210c6c md5 3f58f972276d1e4e0e09582521ed7a5b sha1 1637b6b9cd1a918339ec054cf95b924e7ce4789a )
+)
+
+game (
+	name "Circus Atari (USA)"
+	description "Circus Atari (USA)"
+	rom ( name "Circus Atari (USA).a26" size 4096 crc d2a330a3 md5 a7b96a8150600b3e800a4689c3ec60a2 sha1 8a91ecdbd8bf9d412da051c3422abb004eab8603 )
+)
+
+game (
+	name "Coco Nuts (USA)"
+	description "Coco Nuts (USA)"
+	rom ( name "Coco Nuts (USA).a26" size 4096 crc b3e44e5c md5 1e587ca91518a47753a28217cd4fd586 sha1 3f56d1a376702b64b3992b2d5652a3842c56ffad )
+)
+
+game (
+	name "Codebreaker (USA)"
+	description "Codebreaker (USA)"
+	rom ( name "Codebreaker (USA).a26" size 2048 crc 947edb18 md5 5846b1d34c296bf7afc2fa05bbc16e98 sha1 137bd3d3f36e2549c6e1cc3a60f2a7574f767775 )
+)
+
+game (
+	name "Color Bar Generator (USA)"
+	description "Color Bar Generator (USA)"
+	rom ( name "Color Bar Generator (USA).a26" size 4096 crc 19b52142 md5 76a9bf05a6de8418a3ebc7fc254b71b4 sha1 53c324ae736afa92a83d619b04e4fe72182281a6 )
+)
+
+game (
+	name "Combat Two (USA) (Proto)"
+	description "Combat Two (USA) (Proto)"
+	rom ( name "Combat Two (USA) (Proto).a26" size 8192 crc 8cabe1fd md5 b0c9cf89a6d4e612524f4fd48b5bb562 sha1 66014de1f8e9f39483ee3f97ca0d97d026ffc3bb )
+)
+
+game (
+	name "Combat ~ Tank-Plus (USA)"
+	description "Combat ~ Tank-Plus (USA)"
+	rom ( name "Combat ~ Tank-Plus (USA).a26" size 2048 crc 9c326a97 md5 4c8832ed387bbafc055320c05205bc08 sha1 ce7580059e8b41cb4a1e734c9b35ce3774bf777a )
+)
+
+game (
+	name "Commando (USA)"
+	description "Commando (USA)"
+	rom ( name "Commando (USA).a26" size 16384 crc 8d3025dc md5 5d2cc33ca798783dee435eb29debf6d6 sha1 68a7cb3ff847cd987a551f3dd9cda5f90ce0a3bf )
+)
+
+game (
+	name "Commando Raid (USA)"
+	description "Commando Raid (USA)"
+	rom ( name "Commando Raid (USA).a26" size 4096 crc e46583e6 md5 f457674cef449cfd85f21db2b4f631a7 sha1 8dad05085657e95e567f47836502be515b42f66b )
+)
+
+game (
+	name "Communist Mutants from Space (USA)"
+	description "Communist Mutants from Space (USA)"
+	rom ( name "Communist Mutants from Space (USA).a26" size 8448 crc d64ec816 md5 2c8835aed7f52a0da9ade5226ee5aa75 sha1 9a113bacc576d1d1f80a26622359c49df97b16bc )
+)
+
+game (
+	name "Computer Chess (USA) (Proto)"
+	description "Computer Chess (USA) (Proto)"
+	rom ( name "Computer Chess (USA) (Proto).a26" size 4096 crc 0c44d49a md5 6a2c68f7a77736ba02c0f21a6ba0985b sha1 dbc0c0451dee44425810e04df8f1d26d1c2d3993 )
+)
+
+game (
+	name "Condor Attack (USA)"
+	description "Condor Attack (USA)"
+	rom ( name "Condor Attack (USA).a26" size 4096 crc b6c582eb md5 1f21666b8f78b65051b7a609f1d48608 sha1 2ebd0f43ee76833f75759ac1bbb45a8e0c3b86e9 )
+)
+
+game (
+	name "Confrontation (USA) (Proto)"
+	description "Confrontation (USA) (Proto)"
+	rom ( name "Confrontation (USA) (Proto).a26" size 4096 crc c2dbcefe md5 f965cc981cbb0822f955641f8d84e774 sha1 5512a0ed4306edc007a78bb52dbcf492adf798ec )
+)
+
+game (
+	name "Congo Bongo (USA)"
+	description "Congo Bongo (USA)"
+	rom ( name "Congo Bongo (USA).a26" size 8192 crc 3f6e7e0c md5 00b7b4cbec81570642283e7fc1ef17af sha1 3a77db43b6583e8689435f0f14aa04b9e57bdded )
+)
+
+game (
+	name "Cookie Monster Munch (USA)"
+	description "Cookie Monster Munch (USA)"
+	rom ( name "Cookie Monster Munch (USA).a26" size 8192 crc 97ba488f md5 57c5b351d4de021785cf8ed8191a195c sha1 f4a62ba0ff59803c5f40d59eeed1e126fe37979b )
+)
+
+game (
+	name "Cosmic Ark (USA)"
+	description "Cosmic Ark (USA)"
+	rom ( name "Cosmic Ark (USA).a26" size 4096 crc cb374f0e md5 ab5bf1ef5e463ad1cbb11b6a33797228 sha1 187983fd14d37498437d0ef8f3fbd05675feb6ae )
+)
+
+game (
+	name "Cosmic Commuter (USA)"
+	description "Cosmic Commuter (USA)"
+	rom ( name "Cosmic Commuter (USA).a26" size 4096 crc 4939ba40 md5 133b56de011d562cbab665968bde352b sha1 3717c97bbb0f547e4389db8fc954d1bad992444c )
+)
+
+game (
+	name "Cosmic Creeps (USA)"
+	description "Cosmic Creeps (USA)"
+	rom ( name "Cosmic Creeps (USA).a26" size 4096 crc 47aaa2dd md5 3c853d864a1d5534ed0d4b325347f131 sha1 22ff281b1e698e8a5d7a6f6173c86c46d3cd8561 )
+)
+
+game (
+	name "Cosmic Swarm (USA)"
+	description "Cosmic Swarm (USA)"
+	rom ( name "Cosmic Swarm (USA).a26" size 2048 crc 27f1ae48 md5 e5f17b3e62a21d0df1ca9aee1aa8c7c5 sha1 c01354760f2ca8d6e4d01b230f31611973c6ae2d )
+)
+
+game (
+	name "Crack'ed (USA) (Proto)"
+	description "Crack'ed (USA) (Proto)"
+	rom ( name "Crack'ed (USA) (Proto).a26" size 16384 crc 1b5e52a7 md5 fe67087f9c22655ce519616fc6c6ef4d sha1 d226e8af4e38d1d4eb8bb69cdf6bccdad561c804 )
+)
+
+game (
+	name "Crackpots (USA)"
+	description "Crackpots (USA)"
+	rom ( name "Crackpots (USA).a26" size 4096 crc ecd891b3 md5 a184846d8904396830951217b47d13d9 sha1 6ee0a26af4643ff250198dfc1c2b7c6568b4f207 )
+)
+
+game (
+	name "Crash Dive (USA)"
+	description "Crash Dive (USA)"
+	rom ( name "Crash Dive (USA).a26" size 4096 crc 59fe4666 md5 fb88c400d602fe759ae74ef1716ee84e sha1 73d68f32d1fb73883ceb183d5150bff5f1065de4 )
+)
+
+game (
+	name "Crazy Climber (USA)"
+	description "Crazy Climber (USA)"
+	rom ( name "Crazy Climber (USA).a26" size 8192 crc a3a3c009 md5 55ef7b65066428367844342ed59f956c sha1 70e723aa67d68f8549d9bd8f96d8b1262cbdac3c )
+)
+
+game (
+	name "Cross Force (USA)"
+	description "Cross Force (USA)"
+	rom ( name "Cross Force (USA).a26" size 4096 crc 41b0d615 md5 c17bdc7d14a36e10837d039f43ee5fa3 sha1 b1b3d8d6afe94b73a43c36668cc756c5b6fdc1c3 )
+)
+
+game (
+	name "Crossbow (USA)"
+	description "Crossbow (USA)"
+	rom ( name "Crossbow (USA).a26" size 16384 crc 1f233140 md5 8cd26dcf249456fe4aeb8db42d49df74 sha1 5da3d089ccda960ce244adb855975877c670e615 )
+)
+
+game (
+	name "Crypts of Chaos (USA)"
+	description "Crypts of Chaos (USA)"
+	rom ( name "Crypts of Chaos (USA).a26" size 4096 crc c5b29962 md5 384f5fbf57b5e92ed708935ebf8a8610 sha1 a57062f44e7ac793d4c39d1350521dc5bc2a665f )
+)
+
+game (
+	name "Crystal Castles (USA)"
+	description "Crystal Castles (USA)"
+	rom ( name "Crystal Castles (USA).a26" size 16384 crc 9007b5ac md5 1c6eb740d3c485766cade566abab8208 sha1 2e4ee5ee040b08be1fe568602d1859664e607efb )
+)
+
+game (
+	name "Cubicolor (USA) (Proto)"
+	description "Cubicolor (USA) (Proto)"
+	rom ( name "Cubicolor (USA) (Proto).a26" size 4096 crc d5d43a7a md5 6fa0ac6943e33637d8e77df14962fbfc sha1 0dd72a3461b4167f2d68c93511ed4985d97e6adc )
+)
+
+game (
+	name "Custer's Revenge (USA)"
+	description "Custer's Revenge (USA)"
+	rom ( name "Custer's Revenge (USA).a26" size 4096 crc 21283941 md5 58513bae774360b96866a07ca0e8fd8e sha1 4b3d02b59e17520b4d60236568d5cb50a4e6aeb3 )
+)
+
+game (
+	name "Dancing Plate (USA)"
+	description "Dancing Plate (USA)"
+	rom ( name "Dancing Plate (USA).a26" size 4096 crc 250c4e3f md5 ece463abde92e8b89bcd867ec71751b8 sha1 85500dc5f7b083ce2d743c223c56163ff95b39e3 )
+)
+
+game (
+	name "Dark Cavern (USA)"
+	description "Dark Cavern (USA)"
+	rom ( name "Dark Cavern (USA).a26" size 4096 crc 0481078c md5 a422194290c64ef9d444da9d6a207807 sha1 0ae2fc87f87a5cc199c3b9a17444bf3c2f6a829b )
+)
+
+game (
+	name "Dark Chambers (USA)"
+	description "Dark Chambers (USA)"
+	rom ( name "Dark Chambers (USA).a26" size 16384 crc 83900281 md5 106855474c69d08c8ffa308d47337269 sha1 fbb4814973fcb4e101521515e04daa6424c45f5c )
+)
+
+game (
+	name "Deadly Duck (USA)"
+	description "Deadly Duck (USA)"
+	rom ( name "Deadly Duck (USA).a26" size 4096 crc f33a9a2d md5 e4c00beb17fdc5881757855f2838c816 sha1 68de291d5e9cbebfed72d2f9039e60581b6dbdc5 )
+)
+
+game (
+	name "Death Trap (USA)"
+	description "Death Trap (USA)"
+	rom ( name "Death Trap (USA).a26" size 4096 crc fdf79a60 md5 4e15ddfd48bca4f0bf999240c47b49f5 sha1 5f710a1148740760b4ebcc42861a1f9c3384799e )
+)
+
+game (
+	name "Defender (USA)"
+	description "Defender (USA)"
+	rom ( name "Defender (USA).a26" size 4096 crc 0df43d8e md5 0f643c34e40e3f1daafd9c524d3ffe64 sha1 79facc1bf70e642685057999f5c2b8e94b102439 )
+)
+
+game (
+	name "Demolition Herby (USA)"
+	description "Demolition Herby (USA)"
+	rom ( name "Demolition Herby (USA).a26" size 4096 crc e9305ae2 md5 d09935802d6760ae58253685ff649268 sha1 5aae618292a728b55ad7f00242d870736b5356d3 )
+)
+
+game (
+	name "Demon Attack (USA) (Rev 1)"
+	description "Demon Attack (USA) (Rev 1)"
+	rom ( name "Demon Attack (USA) (Rev 1).a26" size 4096 crc 31c9df5e md5 b12a7f63787a6bb08e683837a8ed3f18 sha1 e5011b85a0e3c148087865bebd7e9b6608c32292 )
+)
+
+game (
+	name "Demons to Diamonds (USA)"
+	description "Demons to Diamonds (USA)"
+	rom ( name "Demons to Diamonds (USA).a26" size 4096 crc 9b97c3da md5 f91fb8da3223b79f1c9a07b77ebfa0b2 sha1 b45582de81c48b04c2bb758d69021e8088c70ce7 )
+)
+
+game (
+	name "Depth Charge (USA) (Proto)"
+	description "Depth Charge (USA) (Proto)"
+	rom ( name "Depth Charge (USA) (Proto).a26" size 4096 crc 442d6289 md5 519f007c0e14fb90208dbb5199dfb604 sha1 d72fd778313dca0d70202d2ff2c20213b0d3ed30 )
+)
+
+game (
+	name "Desert Falcon (USA)"
+	description "Desert Falcon (USA)"
+	rom ( name "Desert Falcon (USA).a26" size 16384 crc caa0054e md5 fd4f5536fd80f35c64d365df85873418 sha1 ccea2d5095441d7e1b1468e3879a6ab556dc8b7a )
+)
+
+game (
+	name "Dice Puzzle (Europe)"
+	description "Dice Puzzle (Europe)"
+	rom ( name "Dice Puzzle (Europe).a26" size 4096 crc f691b853 md5 e02156294393818ff872d4314fc2f38e sha1 509eeb7b113b09e7326618b74f90fa2eb1ddfc95 )
+)
+
+game (
+	name "Dig Dug (USA)"
+	description "Dig Dug (USA)"
+	rom ( name "Dig Dug (USA).a26" size 16384 crc ee7b80d1 md5 6dda84fb8e442ecf34241ac0d1d91d69 sha1 79e746524520da546249149c33614fc23a4f2a51 )
+)
+
+game (
+	name "Dodge 'Em ~ Dodger Cars (USA)"
+	description "Dodge 'Em ~ Dodger Cars (USA)"
+	rom ( name "Dodge 'Em ~ Dodger Cars (USA).a26" size 4096 crc 0c74479b md5 83bdc819980db99bf89a7f2ed6a2de59 sha1 157117df23cb5229386d06bbdb3af20a208722e0 )
+)
+
+game (
+	name "Dolphin (USA)"
+	description "Dolphin (USA)"
+	rom ( name "Dolphin (USA).a26" size 4096 crc 9e38a7b9 md5 ca09fa7406b7d2aea10d969b6fc90195 sha1 e3985d759f8a8f4705f543ce7eb5e93bf63722b5 )
+)
+
+game (
+	name "Donald Duck's Speedboat (USA) (Proto)"
+	description "Donald Duck's Speedboat (USA) (Proto)"
+	rom ( name "Donald Duck's Speedboat (USA) (Proto).a26" size 8192 crc 8db92c76 md5 937736d899337036de818391a87271e0 sha1 4606c0751f560200aede6598ec9c8e6249a105f5 )
+)
+
+game (
+	name "Donkey Kong (USA)"
+	description "Donkey Kong (USA)"
+	rom ( name "Donkey Kong (USA).a26" size 4096 crc f331b069 md5 36b20c427975760cb9cf4a47e41369e4 sha1 6e6e37ec8d66aea1c13ed444863e3db91497aa35 )
+)
+
+game (
+	name "Donkey Kong Junior (USA)"
+	description "Donkey Kong Junior (USA)"
+	rom ( name "Donkey Kong Junior (USA).a26" size 8192 crc 9ef649e5 md5 c8fa5d69d9e555eb16068ef87b1c9c45 sha1 98f98ac0728c68de66afda6500cafbdffe8ab50a )
+)
+
+game (
+	name "Double Dragon (USA)"
+	description "Double Dragon (USA)"
+	rom ( name "Double Dragon (USA).a26" size 16384 crc 8320bb37 md5 7e2fe40a788e56765fe56a3576019968 sha1 cc99dba0a78fedd171387f492e9810f3037a5f05 )
+)
+
+game (
+	name "Double Dunk (USA)"
+	description "Double Dunk (USA)"
+	rom ( name "Double Dunk (USA).a26" size 16384 crc 208f6c20 md5 368d88a6c071caba60b4f778615aae94 sha1 8e2ea320b23994dc87abe69d61249489f3a0fccc )
+)
+
+game (
+	name "Dragon Defender (Europe)"
+	description "Dragon Defender (Europe)"
+	rom ( name "Dragon Defender (Europe).a26" size 4096 crc 0d57e23d md5 95e542a7467c94b1e4ab24a3ebe907f1 sha1 794625475863c52259478ebd928ead829c1aaee3 )
+)
+
+game (
+	name "Dragonfire (USA)"
+	description "Dragonfire (USA)"
+	rom ( name "Dragonfire (USA).a26" size 4096 crc ba5dc02c md5 41810dd94bd0de1110bedc5092bef5b0 sha1 b446381fe480156077b0b3c51747d156e5dde89f )
+)
+
+game (
+	name "Dragonstomper (USA)"
+	description "Dragonstomper (USA)"
+	rom ( name "Dragonstomper (USA).a26" size 25344 crc 291f7f92 md5 90ccf4f30a5ad8c801090b388ddd5613 sha1 d0777b4572903756c25559538ecde1a301a0b003 )
+)
+
+game (
+	name "Dragster (USA)"
+	description "Dragster (USA)"
+	rom ( name "Dragster (USA).a26" size 2048 crc 4042d3ab md5 77057d9d14b99e465ea9e29783af0ae3 sha1 944c52de85464070a946813b050518977750e939 )
+)
+
+game (
+	name "Dukes of Hazzard (USA)"
+	description "Dukes of Hazzard (USA)"
+	rom ( name "Dukes of Hazzard (USA).a26" size 16384 crc 2db406dc md5 51de328e79d919d7234cf19c1cd77fbc sha1 c061d753435dcb7275a8764f4ad003b05fa100ed )
+)
+
+game (
+	name "Dumbo's Flying Circus (USA) (Proto)"
+	description "Dumbo's Flying Circus (USA) (Proto)"
+	rom ( name "Dumbo's Flying Circus (USA) (Proto).a26" size 8192 crc ae915725 md5 3897744dd3c756ea4b1542e5e181e02a sha1 fa8b32359035c51df9baca2881582bb09ab4a3d4 )
+)
+
+game (
+	name "Dune (USA) (Proto)"
+	description "Dune (USA) (Proto)"
+	rom ( name "Dune (USA) (Proto).a26" size 8192 crc f01f7c55 md5 469473ff6fed8cc8d65f3c334f963aab sha1 5e2b2d07dba3692db0ec0582b0a2cb4c2b6ad31f )
+)
+
+game (
+	name "E.T. - The Extra-Terrestrial (USA)"
+	description "E.T. - The Extra-Terrestrial (USA)"
+	rom ( name "E.T. - The Extra-Terrestrial (USA).a26" size 8192 crc 6d0a475f md5 615a3bf251a38eb6638cdc7ffbde5480 sha1 9e34f9ca51573c92918720f8a259b9449a0cd65e )
+)
+
+game (
+	name "Earth Dies Screaming, The (USA)"
+	description "Earth Dies Screaming, The (USA)"
+	rom ( name "Earth Dies Screaming, The (USA).a26" size 4096 crc 8a6c65f0 md5 033e21521e0bf4e54e8816873943406d sha1 1f834923eac271bf04c18621ac2aada68d426917 )
+)
+
+game (
+	name "Eggomania (USA)"
+	description "Eggomania (USA)"
+	rom ( name "Eggomania (USA).a26" size 4096 crc c78ec927 md5 42b2c3b4545f1499a083cfbc4a3b7640 sha1 68cbfadf097ae2d1e838f315c7cc7b70bbf2ccc8 )
+)
+
+game (
+	name "Elevator Action (USA) (Proto)"
+	description "Elevator Action (USA) (Proto)"
+	rom ( name "Elevator Action (USA) (Proto).a26" size 8192 crc dc5a9d77 md5 71f8bacfbdca019113f3f0801849057e sha1 bab872ee41695cefe41d88e4932132eca6c4e69c )
+)
+
+game (
+	name "Eli's Ladder (USA)"
+	description "Eli's Ladder (USA)"
+	rom ( name "Eli's Ladder (USA).a26" size 4096 crc 2c5e6932 md5 b6812eaf87127f043e78f91f2028f9f4 sha1 475fc2b23c0ee273388539a4eeafa34f8f8d3fd8 )
+)
+
+game (
+	name "Elk Attack (USA) (Proto)"
+	description "Elk Attack (USA) (Proto)"
+	rom ( name "Elk Attack (USA) (Proto).a26" size 8192 crc 02ddde9f md5 7eafc9827e8d5b1336905939e097aae7 sha1 3983e109fc0b38c0b559a09a001f3e5f2bb1dc2a )
+)
+
+game (
+	name "Encounter at L-5 (USA)"
+	description "Encounter at L-5 (USA)"
+	rom ( name "Encounter at L-5 (USA).a26" size 4096 crc e78fe552 md5 dbc8829ef6f12db8f463e30f60af209f sha1 205af4051ea39fb5a038a8545c78bff91df321b7 )
+)
+
+game (
+	name "Enduro (USA)"
+	description "Enduro (USA)"
+	rom ( name "Enduro (USA).a26" size 4096 crc 2ef17b2e md5 94b92a882f6dbaa6993a46e2dcc58402 sha1 82e9b2dd6d99f15381506a76ef958a1773a7ba21 )
+)
+
+game (
+	name "Entity, The (USA) (Proto)"
+	description "Entity, The (USA) (Proto)"
+	rom ( name "Entity, The (USA) (Proto).a26" size 4096 crc 3366ccb7 md5 9f5096a6f1a5049df87798eb59707583 sha1 180d6aad4f5fe5dea553ef2e2ff233bd63592d00 )
+)
+
+game (
+	name "Entombed (USA)"
+	description "Entombed (USA)"
+	rom ( name "Entombed (USA).a26" size 4096 crc e48ec9dc md5 6b683be69f92958abe0e2a9945157ad5 sha1 7905aee90a6dd64d9538e0b8e772f833ba9feb83 )
+)
+
+game (
+	name "Escape from the Mindmaster (USA)"
+	description "Escape from the Mindmaster (USA)"
+	rom ( name "Escape from the Mindmaster (USA).a26" size 33792 crc fd0c8bfc md5 81f4f0285f651399a12ff2e2f35bab77 sha1 adb24298457e15faacda532d50b7253bef0ef3b2 )
+)
+
+game (
+	name "Espial (USA)"
+	description "Espial (USA)"
+	rom ( name "Espial (USA).a26" size 8192 crc 1f95351a md5 f344ac1279152157d63e64aa39479599 sha1 5db168bb450dc82f618dfa60b9f271ade3a057c7 )
+)
+
+game (
+	name "Exocet (Europe)"
+	description "Exocet (Europe)"
+	rom ( name "Exocet (Europe).a26" size 4096 crc 5cc39028 md5 7ac4f4fb425db38288fa07fb8ff4b21d sha1 07b12357904ec3a4846d27b3790581f6eb5da2b7 )
+)
+
+game (
+	name "Fantastic Voyage (USA)"
+	description "Fantastic Voyage (USA)"
+	rom ( name "Fantastic Voyage (USA).a26" size 4096 crc a60e153f md5 b80d50ecee73919a507498d0a4d922ae sha1 6297dd336a6343f98cd142d1d3d76ce84770a488 )
+)
+
+game (
+	name "Farmyard Fun (USA)"
+	description "Farmyard Fun (USA)"
+	rom ( name "Farmyard Fun (USA).a26" size 4096 crc 73474b03 md5 f7e07080ed8396b68f2e5788a5c245e2 sha1 63a24d4f86529974ee38f0e3bd6602470835c993 )
+)
+
+game (
+	name "Fast Eddie (USA)"
+	description "Fast Eddie (USA)"
+	rom ( name "Fast Eddie (USA).a26" size 4096 crc 0c0a7a02 md5 9de0d45731f90a0a922ab09228510393 sha1 a5614c751f29118ddb3dec9794612b98a0f00b98 )
+)
+
+game (
+	name "Fast Food (USA)"
+	description "Fast Food (USA)"
+	rom ( name "Fast Food (USA).a26" size 4096 crc 62388455 md5 665b8f8ead0eef220ed53886fbd61ec9 sha1 c62a70645939480b184e3b2e378ec4bcbd484bc7 )
+)
+
+game (
+	name "Fatal Run (Europe)"
+	description "Fatal Run (Europe)"
+	rom ( name "Fatal Run (Europe).a26" size 32768 crc 991d2348 md5 074ec425ec20579e64a7ded592155d48 sha1 d0bb58ea1fc37e929e5f7cdead037bb14a166451 )
+)
+
+game (
+	name "Fathom (USA)"
+	description "Fathom (USA)"
+	rom ( name "Fathom (USA).a26" size 8192 crc 93da13cc md5 0b55399cf640a2a00ba72dd155a0c140 sha1 686427cc47b69980d292d04597270347942773ff )
+)
+
+game (
+	name "Final Approach (USA)"
+	description "Final Approach (USA)"
+	rom ( name "Final Approach (USA).a26" size 4096 crc ff23f469 md5 211fbbdbbca1102dc5b43dc8157c09b3 sha1 ba9a8ccfeb552dd756c660ea843a39619d3c77e9 )
+)
+
+game (
+	name "Fire Fighter (USA)"
+	description "Fire Fighter (USA)"
+	rom ( name "Fire Fighter (USA).a26" size 4096 crc e361fb42 md5 d09f1830fb316515b90694c45728d702 sha1 f76cc14afd7aef367c5a5defbd84f3bbb2f98ba3 )
+)
+
+game (
+	name "Fire Fly (USA)"
+	description "Fire Fly (USA)"
+	rom ( name "Fire Fly (USA).a26" size 4096 crc 7a8e4ec7 md5 20dca534b997bf607d658e77fbb3c0ee sha1 df5420eb0f71e681e7222ede8e211a7601e7a327 )
+)
+
+game (
+	name "Fire Spinner (USA)"
+	description "Fire Spinner (USA)"
+	rom ( name "Fire Spinner (USA).a26" size 4096 crc f497456e md5 d3171407c3a8bb401a3a62eb578f48fb sha1 e30e6195642884954bc98df2e82c3e972db49a57 )
+)
+
+game (
+	name "Fireball (USA)"
+	description "Fireball (USA)"
+	rom ( name "Fireball (USA).a26" size 8448 crc b32ae162 md5 386ff28ac5e254ba1b1bac6916bcc93a sha1 9fa9ed2622d29636f175b8745892dde48a871fd1 )
+)
+
+game (
+	name "Fishing Derby (USA)"
+	description "Fishing Derby (USA)"
+	rom ( name "Fishing Derby (USA).a26" size 2048 crc 204c928f md5 b8865f05676e64f3bec72b9defdacfa7 sha1 531e995aef6cd47b0efea72ae3e56aeee449d798 )
+)
+
+game (
+	name "Flag Capture ~ Capture (USA)"
+	description "Flag Capture ~ Capture (USA)"
+	rom ( name "Flag Capture ~ Capture (USA).a26" size 2048 crc 8aa1c41e md5 30512e0e83903fc05541d2f6a6a62654 sha1 ac05f05f3365f5e348e1e618410065a1c2a88ee4 )
+)
+
+game (
+	name "Flash Gordon (USA)"
+	description "Flash Gordon (USA)"
+	rom ( name "Flash Gordon (USA).a26" size 4096 crc 0d61ce7d md5 8786c1e56ef221d946c64f6b65b697e9 sha1 fb870ec3d51468fa4cf40e0efae9617e60c1c91c )
+)
+
+game (
+	name "Football (USA)"
+	description "Football (USA)"
+	rom ( name "Football (USA).a26" size 2048 crc 3b73ee02 md5 e549f1178e038fa88dc6d657dc441146 sha1 c6fe4ce24bc1ebd538258d98cfe829963323acca )
+)
+
+game (
+	name "Forest (Europe)"
+	description "Forest (Europe)"
+	rom ( name "Forest (Europe).a26" size 4096 crc 1aaab749 md5 213e5e82ecb42af237cfed8612c128ac sha1 790e0a597270a5090110e3bfbdc3a076a47ced14 )
+)
+
+game (
+	name "Frankenstein's Monster (USA)"
+	description "Frankenstein's Monster (USA)"
+	rom ( name "Frankenstein's Monster (USA).a26" size 4096 crc ad44dff9 md5 15dd21c2608e0d7d9f54c0d3f08cca1f sha1 c6023bf73818c78b2e477a9c6dac411cdbf9c0aa )
+)
+
+game (
+	name "Freeway (USA)"
+	description "Freeway (USA)"
+	rom ( name "Freeway (USA).a26" size 2048 crc b13ec413 md5 8e0ab801b1705a740b476b7f588c6d16 sha1 91cc7e5cd6c0d4a6f42ed66353b7ee7bb972fa3f )
+)
+
+game (
+	name "Frog Demo (Europe)"
+	description "Frog Demo (Europe)"
+	rom ( name "Frog Demo (Europe).a26" size 2048 crc ec5ff220 md5 45a4f55bb9a5083d470ad479afd8bca2 sha1 ded4c64d60ffce5304d73e016be7deb5f2db45d4 )
+)
+
+game (
+	name "Frog Pond (USA) (Proto)"
+	description "Frog Pond (USA) (Proto)"
+	rom ( name "Frog Pond (USA) (Proto).a26" size 8192 crc 5874385a md5 f67181b3a01b9c9159840b15449b87b0 sha1 0d6a96f857ae0e813b4d493866e2420cc5c4bad5 )
+)
+
+game (
+	name "Frogger (USA)"
+	description "Frogger (USA)"
+	rom ( name "Frogger (USA).a26" size 4096 crc f5e1af92 md5 081e2c114c9c20b61acf25fc95c71bf4 sha1 e859b935a36494f3c4b4bf5547392600fb9c96f0 )
+)
+
+game (
+	name "Frogger II - Threeedeep! (USA)"
+	description "Frogger II - Threeedeep! (USA)"
+	rom ( name "Frogger II - Threeedeep! (USA).a26" size 8192 crc 3ba0d9bf md5 27c6a2ca16ad7d814626ceea62fa8fb4 sha1 6b9e591cc53844795725fc66c564f0364d1fbe40 )
+)
+
+game (
+	name "Frogs and Flies (USA)"
+	description "Frogs and Flies (USA)"
+	rom ( name "Frogs and Flies (USA).a26" size 4096 crc 6476c136 md5 dcc2956c7a39fdbf1e861fc5c595da0d sha1 f344d5a8dc895c5a2ae0288f3c6cb66650e49167 )
+)
+
+game (
+	name "Front Line (USA)"
+	description "Front Line (USA)"
+	rom ( name "Front Line (USA).a26" size 8192 crc c352f290 md5 e556e07cc06c803f2955986f53ef63ed sha1 cf32bfcd7f2c3b7d2a6ad2f298aea2dfad8242e7 )
+)
+
+game (
+	name "Frostbite (USA)"
+	description "Frostbite (USA)"
+	rom ( name "Frostbite (USA).a26" size 4096 crc b61be7a3 md5 4ca73eb959299471788f0b685c3ba0b5 sha1 b9e60437e7691d5ef9002cfc7d15ae95f1c03a12 )
+)
+
+game (
+	name "Funky Fish (USA) (Proto)"
+	description "Funky Fish (USA) (Proto)"
+	rom ( name "Funky Fish (USA) (Proto).a26" size 8192 crc b53b33f1 md5 d3bb42228a6cd452c111c1932503cc03 sha1 fba461d2a2d1395945806c883f4dca925712885e )
+)
+
+game (
+	name "G.I. Joe - Cobra Strike (USA)"
+	description "G.I. Joe - Cobra Strike (USA)"
+	rom ( name "G.I. Joe - Cobra Strike (USA).a26" size 4096 crc 6bcbcd37 md5 c1fdd44efda916414be3527a47752c75 sha1 9cfb6288a5c2dae63ee6f5e9325200ccd21a3055 )
+)
+
+game (
+	name "Galaxian (USA)"
+	description "Galaxian (USA)"
+	rom ( name "Galaxian (USA).a26" size 8192 crc 4e9fe271 md5 211774f4c5739042618be8ff67351177 sha1 b081b327ac32d951c36cb4b3ff812be95685d52f )
+)
+
+game (
+	name "Gangster Alley (USA)"
+	description "Gangster Alley (USA)"
+	rom ( name "Gangster Alley (USA).a26" size 4096 crc 03c2452c md5 20edcc3aa6c189259fa7e2f044a99c49 sha1 8cf49d43bd62308df788cfacbfcd80e9226c7590 )
+)
+
+game (
+	name "Garfield (USA) (Proto)"
+	description "Garfield (USA) (Proto)"
+	rom ( name "Garfield (USA) (Proto).a26" size 16384 crc f20cadcf md5 dc13df8420ec69841a7c51e41b9fbba5 sha1 bc0d1edc251d8d4db3d5234ec83dee171642a547 )
+)
+
+game (
+	name "Gas Hog (USA)"
+	description "Gas Hog (USA)"
+	rom ( name "Gas Hog (USA).a26" size 4096 crc 40699ca5 md5 5cbd7c31443fb9c308e9f0b54d94a395 sha1 e919ee03e8a17fd85be1e53b4d5ff76dae54d099 )
+)
+
+game (
+	name "Gauntlet (USA)"
+	description "Gauntlet (USA)"
+	rom ( name "Gauntlet (USA).a26" size 4096 crc c7ac23c7 md5 e64a8008812327853877a37befeb6465 sha1 73adae38d86d50360b1a247244df05892e33da46 )
+)
+
+game (
+	name "Ghost Manor (USA)"
+	description "Ghost Manor (USA)"
+	rom ( name "Ghost Manor (USA).a26" size 8192 crc 6fc46219 md5 2bee7f226d506c217163bad4ab1768c0 sha1 4b533776dcd9d538f9206ad1e28b30116d08df1e )
+)
+
+game (
+	name "Ghostbusters (USA)"
+	description "Ghostbusters (USA)"
+	rom ( name "Ghostbusters (USA).a26" size 8192 crc 45443d13 md5 e314b42761cd13c03def744b4afc7b1b sha1 5ed0b2cb346d20720e3c526da331551aa16a23a4 )
+)
+
+game (
+	name "Ghostbusters II (Europe)"
+	description "Ghostbusters II (Europe)"
+	rom ( name "Ghostbusters II (Europe).a26" size 16384 crc a3c342b8 md5 c2b5c50ccb59816867036d7cf730bf75 sha1 e032876305647a95b622e5c4971f7096ef72acdb )
+)
+
+game (
+	name "Glacier Patrol (USA)"
+	description "Glacier Patrol (USA)"
+	rom ( name "Glacier Patrol (USA).a26" size 4096 crc 44e77fd6 md5 5e0c37f534ab5ccc4661768e2ddf0162 sha1 3a3d7206afee36786026d6287fe956c2ebc80ea7 )
+)
+
+game (
+	name "Glib - Video Word Game (USA)"
+	description "Glib - Video Word Game (USA)"
+	rom ( name "Glib - Video Word Game (USA).a26" size 4096 crc 50bb03a4 md5 2d9e5d8d083b6367eda880e80dfdfaeb sha1 7bca0f7a0f992782e4e4c90772bac976ca963a6d )
+)
+
+game (
+	name "Golf (USA)"
+	description "Golf (USA)"
+	rom ( name "Golf (USA).a26" size 2048 crc 46a9f200 md5 2e663eaa0d6b723b645e643750b942fd sha1 a25d52770408314dec6f41aaf5f9f0a2a3e2c18f )
+)
+
+game (
+	name "Gopher (USA)"
+	description "Gopher (USA)"
+	rom ( name "Gopher (USA).a26" size 4096 crc ac8321d8 md5 c16c79aad6272baffb8aae9a7fff0864 sha1 97fb489ba4ce0f8a306563063563617321352cfb )
+)
+
+game (
+	name "Gorf (USA)"
+	description "Gorf (USA)"
+	rom ( name "Gorf (USA).a26" size 4096 crc 9bd137aa md5 81b3bf17cf01039d311b4cd738ae608e sha1 35f8341c73c7e6e896cb065977427b3f98ae9f08 )
+)
+
+game (
+	name "Grand Prix (USA)"
+	description "Grand Prix (USA)"
+	rom ( name "Grand Prix (USA).a26" size 4096 crc e855273d md5 2903896d88a341511586d69fcfc20f7d sha1 24fab817728216582b6d95558c361ace66abf96f )
+)
+
+game (
+	name "Gravitar (USA)"
+	description "Gravitar (USA)"
+	rom ( name "Gravitar (USA).a26" size 8192 crc c87fccbe md5 8ac18076d01a6b63acf6e2cab4968940 sha1 a372d4dd3d95b3866553cae2336e4565e00cc25b )
+)
+
+game (
+	name "Great Escape (Europe)"
+	description "Great Escape (Europe)"
+	rom ( name "Great Escape (Europe).a26" size 4096 crc 58010be3 md5 18f299edb5ba709a64c80c8c9cec24f2 sha1 8f4a00cb4ab6a6f809be0e055d97e8fe17f19e7d )
+)
+
+game (
+	name "Gremlins (USA)"
+	description "Gremlins (USA)"
+	rom ( name "Gremlins (USA).a26" size 8192 crc 48d5991f md5 01cb3e8dfab7203a9c62ba3b94b4e59f sha1 7a027329309e018b0d51adcb6ae13c9d13e54f4a )
+)
+
+game (
+	name "Grover's Music Maker (USA) (Proto)"
+	description "Grover's Music Maker (USA) (Proto)"
+	rom ( name "Grover's Music Maker (USA) (Proto).a26" size 8192 crc e1372b28 md5 66b89ba44e7ae0b51f9ef000ebba1eb7 sha1 b9760ffba05139bca0fac3f7d3dc1e5d57600eda )
+)
+
+game (
+	name "Guardian (USA)"
+	description "Guardian (USA)"
+	rom ( name "Guardian (USA).a26" size 4096 crc 121738f5 md5 7ab2f190d4e59e8742e76a6e870b567e sha1 7d30ff565ad7b2a3143d049c5b39e4a6ac3f9cd5 )
+)
+
+game (
+	name "Gyruss (USA)"
+	description "Gyruss (USA)"
+	rom ( name "Gyruss (USA).a26" size 8192 crc 0d78e8a9 md5 b311ab95e85bc0162308390728a7361d sha1 4bd87ba8b3b6d7850e3ea41b4d494c3b12659f27 )
+)
+
+game (
+	name "H.E.R.O. (USA)"
+	description "H.E.R.O. (USA)"
+	rom ( name "H.E.R.O. (USA).a26" size 8192 crc 721e95b7 md5 fca4a5be1251927027f2c24774a02160 sha1 282f94817401e3725c622b73a0c05685ce761783 )
+)
+
+game (
+	name "Halloween (USA)"
+	description "Halloween (USA)"
+	rom ( name "Halloween (USA).a26" size 4096 crc b1b11806 md5 30516cfbaa1bc3b5335ee53ad811f17a sha1 4c72cec151f219866bf870fa7ac749a19ca501c9 )
+)
+
+game (
+	name "Hangman - Spelling (USA)"
+	description "Hangman - Spelling (USA)"
+	rom ( name "Hangman - Spelling (USA).a26" size 4096 crc c2bcc789 md5 f16c709df0a6c52f47ff52b9d95b7d8d sha1 561bccf508e162bc70c42d85c170cf0d1d4691a3 )
+)
+
+game (
+	name "Haunted House (USA)"
+	description "Haunted House (USA)"
+	rom ( name "Haunted House (USA).a26" size 4096 crc aa62d961 md5 f0a6e99f5875891246c3dbecbf2d2cea sha1 1476c869619075b551b20f2c7f95b11e0d16aec1 )
+)
+
+game (
+	name "Hell Driver (Europe)"
+	description "Hell Driver (Europe)"
+	rom ( name "Hell Driver (Europe).a26" size 4096 crc 18954066 md5 aab840db22075aa0f6a6b83a597f8890 sha1 65bd036bffd90ae34baa3817fee6ea70c76478ac )
+)
+
+game (
+	name "Hole Hunter (USA)"
+	description "Hole Hunter (USA)"
+	rom ( name "Hole Hunter (USA).a26" size 4096 crc 66d5ce67 md5 3d48b8b586a09bdbf49f1a016bf4d29a sha1 f275c7ca9a76fb758f52548b8597bc13245263b6 )
+)
+
+game (
+	name "Holey Moley (USA) (Proto)"
+	description "Holey Moley (USA) (Proto)"
+	rom ( name "Holey Moley (USA) (Proto).a26" size 8192 crc 3bb2e71d md5 c52d9bbdc5530e1ef8e8ba7be692b01e sha1 8196209ef7048c5494dbdc932adbf1c7abf79f4e )
+)
+
+game (
+	name "Home Run - Baseball (USA)"
+	description "Home Run - Baseball (USA)"
+	rom ( name "Home Run - Baseball (USA).a26" size 2048 crc 45ace998 md5 0bfabf1e98bdb180643f35f2165995d0 sha1 f362d2b3a50e5ae3c2b412b6c08ecdcfee47a688 )
+)
+
+game (
+	name "Human Cannonball - Cannon Man (USA)"
+	description "Human Cannonball - Cannon Man (USA)"
+	rom ( name "Human Cannonball - Cannon Man (USA).a26" size 2048 crc f05a41e1 md5 7972e5101fa548b952d852db24ad6060 sha1 d4b0b2aa379893356c72414ee0065a3a91cf9f97 )
+)
+
+game (
+	name "Hunt & Score - Memory Match (USA)"
+	description "Hunt & Score - Memory Match (USA)"
+	rom ( name "Hunt & Score - Memory Match (USA).a26" size 2048 crc 17de8070 md5 102672bbd7e25cd79f4384dd7214c32b sha1 a6e42c63138a2fd527cdbe9b7e60f5feabdd55c8 )
+)
+
+game (
+	name "I.Q. 180 (USA)"
+	description "I.Q. 180 (USA)"
+	rom ( name "I.Q. 180 (USA).a26" size 4096 crc 4dc2a674 md5 4b9581c3100a1ef05eac1535d25385aa sha1 8483fd18dddafbdfbcbd1c43bc7de2cc05a1894d )
+)
+
+game (
+	name "I.Q. Memory Teaser (Europe)"
+	description "I.Q. Memory Teaser (Europe)"
+	rom ( name "I.Q. Memory Teaser (Europe).a26" size 4096 crc 75ab6ba8 md5 dc33479d66615a3b09670775de4c2a38 sha1 fa05a35de4c401704538cc256f46440f42de3ddb )
+)
+
+game (
+	name "Ice Hockey (USA)"
+	description "Ice Hockey (USA)"
+	rom ( name "Ice Hockey (USA).a26" size 4096 crc adab8cdf md5 a4c08c4994eb9d24fb78be1793e82e26 sha1 21de0f034e5dad03fa91eb7ae6cc081c142be35c )
+)
+
+game (
+	name "Ikari Warriors (USA)"
+	description "Ikari Warriors (USA)"
+	rom ( name "Ikari Warriors (USA).a26" size 16384 crc 5b7ce555 md5 9a21fba9ee9794e0fadd7c7eb6be4e12 sha1 d8f7b908f60fe49667c7c55d48ce15a05ad95a28 )
+)
+
+game (
+	name "Immies & Aggies (USA) (Proto)"
+	description "Immies & Aggies (USA) (Proto)"
+	rom ( name "Immies & Aggies (USA) (Proto).a26" size 4096 crc 86244c24 md5 75a303fd46ad12457ed8e853016815a0 sha1 603b4ecc797972d32f2f3b8e66ebdde5aaf51a07 )
+)
+
+game (
+	name "Indy 500 - Race (USA)"
+	description "Indy 500 - Race (USA)"
+	rom ( name "Indy 500 - Race (USA).a26" size 2048 crc b43da2a3 md5 c5301f549d0722049bb0add6b10d1e09 sha1 620ab88d63cdd3f8ce67deac00a22257c7205c8b )
+)
+
+game (
+	name "Infiltrate (USA)"
+	description "Infiltrate (USA)"
+	rom ( name "Infiltrate (USA).a26" size 4096 crc 612bd4da md5 afe88aae81d99e0947c0cfb687b16251 sha1 922cd171ef132bf6c5bed00ad01410ada4b20729 )
+)
+
+game (
+	name "International Soccer (USA)"
+	description "International Soccer (USA)"
+	rom ( name "International Soccer (USA).a26" size 4096 crc b9d549a2 md5 b4030c38a720dd84b84178b6ce1fc749 sha1 fa5bf10d9058eeb2e32ab65a25a906c17b445903 )
+)
+
+game (
+	name "Ixion (USA) (Proto)"
+	description "Ixion (USA) (Proto)"
+	rom ( name "Ixion (USA) (Proto).a26" size 8192 crc b311e13f md5 2f0546c4d238551c7d64d884b618100c sha1 a11538157529b42a2840f518b95af5c59143cced )
+)
+
+game (
+	name "James Bond 007 (USA)"
+	description "James Bond 007 (USA)"
+	rom ( name "James Bond 007 (USA).a26" size 8192 crc 34d3ffc8 md5 e51030251e440cffaab1ac63438b44ae sha1 2bbc124cead9aa49b364268735dad8cb1eb6594f )
+)
+
+game (
+	name "Jawbreaker (USA)"
+	description "Jawbreaker (USA)"
+	rom ( name "Jawbreaker (USA).a26" size 4096 crc fc11bf67 md5 58a82e1da64a692fd727c25faef2ecc9 sha1 af4d6867a8bc4818fc6bb701a765a3c907feb628 )
+)
+
+game (
+	name "Journey Escape (USA)"
+	description "Journey Escape (USA)"
+	rom ( name "Journey Escape (USA).a26" size 4096 crc 52ff8027 md5 718ae62c70af4e5fd8e932fee216948a sha1 928eaa424b36d98078f9251d67fb13a8fddfafbd )
+)
+
+game (
+	name "Joust (USA)"
+	description "Joust (USA)"
+	rom ( name "Joust (USA).a26" size 8192 crc a07b3304 md5 3276c777cbe97cdd2b4a63ffc16b7151 sha1 cb94dc316cba282a0036871db2417257e960786b )
+)
+
+game (
+	name "Jr. Pac-Man (USA)"
+	description "Jr. Pac-Man (USA)"
+	rom ( name "Jr. Pac-Man (USA).a26" size 16384 crc 5c345bac md5 36c29ceee2c151b23a1ad7aa04bd529d sha1 cd2cf245d6e924ff2100cc93d20223c4a231e160 )
+)
+
+game (
+	name "Jungle Hunt (USA)"
+	description "Jungle Hunt (USA)"
+	rom ( name "Jungle Hunt (USA).a26" size 8192 crc 9c3e8734 md5 2bb9f4686f7e08c5fcc69ec1a1c66fe7 sha1 83a32a2d686355438c915540cfe0bb13b76c1113 )
+)
+
+game (
+	name "Kabobber (USA) (Proto)"
+	description "Kabobber (USA) (Proto)"
+	rom ( name "Kabobber (USA) (Proto).a26" size 4096 crc 9517ee0e md5 b9d1e3be30b131324482345959aed5e5 sha1 ce8ac88b799c282567495ce509402a5a4c2c4d82 )
+)
+
+game (
+	name "Kaboom! (USA)"
+	description "Kaboom! (USA)"
+	rom ( name "Kaboom! (USA).a26" size 2048 crc 813f00f6 md5 5428cdfada281c569c74c7308c7f2c26 sha1 40d4df4f8e4a69a299ae7678c17e72bedeb70105 )
+)
+
+game (
+	name "Kamikaze Saucers (USA) (Proto)"
+	description "Kamikaze Saucers (USA) (Proto)"
+	rom ( name "Kamikaze Saucers (USA) (Proto).a26" size 4096 crc 85cb187c md5 7b43c32e3d4ff5932f39afcb4c551627 sha1 a82aaeef44ad88de605c50d23fb4f6cec73f3ab4 )
+)
+
+game (
+	name "Kangaroo (USA)"
+	description "Kangaroo (USA)"
+	rom ( name "Kangaroo (USA).a26" size 8192 crc b9ab57e6 md5 4326edb70ff20d0ee5ba58fa5cb09d60 sha1 01fd30311e028944eafb6d14bb001035f816ced7 )
+)
+
+game (
+	name "Karate (USA)"
+	description "Karate (USA)"
+	rom ( name "Karate (USA).a26" size 4096 crc ac0a9ce0 md5 cedbd67d1ff321c996051eec843f8716 sha1 c0db7d295e2ce5e00e00b8a83075b1103688ea15 )
+)
+
+game (
+	name "Keystone Kapers (USA)"
+	description "Keystone Kapers (USA)"
+	rom ( name "Keystone Kapers (USA).a26" size 4096 crc 3e55f3a1 md5 be929419902e21bd7830a7a7d746195d sha1 3eefc193dec3b242bcfd43f5a4d9f023e55378a4 )
+)
+
+game (
+	name "Killer Satellites (USA)"
+	description "Killer Satellites (USA)"
+	rom ( name "Killer Satellites (USA).a26" size 8448 crc bdd932dc md5 7a7f6ab9215a3a6b5940b8737f116359 sha1 64125e796f96aa472bb2191367c6501c657712d9 )
+)
+
+game (
+	name "King Kong (USA)"
+	description "King Kong (USA)"
+	rom ( name "King Kong (USA).a26" size 4096 crc cb6f5617 md5 e21ee3541ebd2c23e817ffb449939c37 sha1 59f485ea345cf1b9e3663b45b246f13936a32972 )
+)
+
+game (
+	name "Klax (Europe)"
+	description "Klax (Europe)"
+	rom ( name "Klax (Europe).a26" size 16384 crc a8aaf68b md5 eed9eaf1a0b6a2b9bc4c8032cb43e3fb sha1 45623a1c8fb5074de98c37f005edd5b1d0937dae )
+)
+
+game (
+	name "Kool-Aid Man (USA)"
+	description "Kool-Aid Man (USA)"
+	rom ( name "Kool-Aid Man (USA).a26" size 4096 crc d9bd009b md5 534e23210dd1993c828d944c6ac4d9fb sha1 2f550743e237f6dc8c75c389a01b02e9a396fdad )
+)
+
+game (
+	name "Krull (USA)"
+	description "Krull (USA)"
+	rom ( name "Krull (USA).a26" size 8192 crc 1a67e6ed md5 4baada22435320d185c95b7dd2bcdb24 sha1 4bdf1cf73316bdb0002606facf11b6ddcb287207 )
+)
+
+game (
+	name "Kung-Fu Master (USA)"
+	description "Kung-Fu Master (USA)"
+	rom ( name "Kung-Fu Master (USA).a26" size 8192 crc 5fea6e51 md5 5b92a93b23523ff16e2789b820e2a4c5 sha1 3b93a34ba2a6b7db387ea588c48d939eee5d71a1 )
+)
+
+game (
+	name "Kyphus (USA) (Proto)"
+	description "Kyphus (USA) (Proto)"
+	rom ( name "Kyphus (USA) (Proto).a26" size 4096 crc 79bd22e2 md5 b86552198f52cfce721bafb496363099 sha1 b4b55e0b6b5d7490565b00c03361199f05fb70b8 )
+)
+
+game (
+	name "Lady In Wading (USA)"
+	description "Lady In Wading (USA)"
+	rom ( name "Lady In Wading (USA).a26" size 4096 crc f197bbcc md5 95a89d1bf767d7cc9d0d5093d579ba61 sha1 6d59dfea26b7a06545a817f03f62a59be8993587 )
+)
+
+game (
+	name "Laser Blast (USA)"
+	description "Laser Blast (USA)"
+	rom ( name "Laser Blast (USA).a26" size 2048 crc 99365f26 md5 931b91a8ea2d39fe4dca1a23832b591a sha1 ea8ecc2f6818e1c9479f55c0a3356edcf7a4d657 )
+)
+
+game (
+	name "Laser Gates (USA)"
+	description "Laser Gates (USA)"
+	rom ( name "Laser Gates (USA).a26" size 4096 crc 4b7865af md5 1fa58679d4a39052bd9db059e8cda4ad sha1 cdf55b73b4322428a001e545019eaa591d3479cf )
+)
+
+game (
+	name "Lilly Adventure (Europe)"
+	description "Lilly Adventure (Europe)"
+	rom ( name "Lilly Adventure (Europe).a26" size 4096 crc 3544c6d6 md5 ab10f2974dee73dab4579f0cab35fca6 sha1 63f4776aa4c35d124001918b733cdb4d46dfbe9b )
+)
+
+game (
+	name "Lochjaw (USA)"
+	description "Lochjaw (USA)"
+	rom ( name "Lochjaw (USA).a26" size 4096 crc b2a2ff31 md5 86128001e69ab049937f265911ce7e8a sha1 fe208ad775cbf9523e7a99632b9f10f2c9c7aa87 )
+)
+
+game (
+	name "Lock 'n' Chase (USA)"
+	description "Lock 'n' Chase (USA)"
+	rom ( name "Lock 'n' Chase (USA).a26" size 4096 crc 7994bf16 md5 71464c54da46adae9447926fdbfc1abe sha1 fc3d75d46d917457aa1701bf47844817d0ba96c3 )
+)
+
+game (
+	name "London Blitz (USA)"
+	description "London Blitz (USA)"
+	rom ( name "London Blitz (USA).a26" size 4096 crc d23cd66c md5 b4e2fd27d3180f0f4eb1065afc0d7fc9 sha1 f92b0b83db3cd840d16ee2726011f5f0144103d5 )
+)
+
+game (
+	name "Looping (USA) (Proto)"
+	description "Looping (USA) (Proto)"
+	rom ( name "Looping (USA) (Proto).a26" size 8192 crc f9b23f09 md5 5babe0cad3ec99d76b0aa1d36a695d2f sha1 5e04fa0320167434dab932f6b73183daf1a50ec7 )
+)
+
+game (
+	name "Lord of the Rings, The - Journey to Rivendell (USA) (Proto)"
+	description "Lord of the Rings, The - Journey to Rivendell (USA) (Proto)"
+	rom ( name "Lord of the Rings, The - Journey to Rivendell (USA) (Proto).a26" size 8192 crc 59b96db3 md5 e24d7d879281ffec0641e9c3f52e505a sha1 ef02fdb94ac092247bfcd5f556e01a68c06a4832 )
+)
+
+game (
+	name "Lost Luggage (USA)"
+	description "Lost Luggage (USA)"
+	rom ( name "Lost Luggage (USA).a26" size 4096 crc 551bdd37 md5 7c00e7a205d3fda98eb20da7c9c50a55 sha1 e8492fe9d62750df682358fe59a4d4272655eb96 )
+)
+
+game (
+	name "M.A.D. (USA)"
+	description "M.A.D. (USA)"
+	rom ( name "M.A.D. (USA).a26" size 4096 crc 5cb68fe5 md5 393e41ca8bdd35b52bf6256a968a9b89 sha1 d6e2b7765a9d30f91c9b2b8d0adf61ec5dc2b30a )
+)
+
+game (
+	name "M.A.S.H (USA)"
+	description "M.A.S.H (USA)"
+	rom ( name "M.A.S.H (USA).a26" size 4096 crc 13e1c83d md5 835759ff95c2cdc2324d7c1e7c5fa237 sha1 dcd96913a1c840c8b57848986242eeb928bfd2ff )
+)
+
+game (
+	name "MagiCard (USA)"
+	description "MagiCard (USA)"
+	rom ( name "MagiCard (USA).a26" size 2048 crc 14f126c0 md5 cddabfd68363a76cd30bee4e8094c646 sha1 4c66b84ab0d25e46729bbcf23f985d59ca8520ad )
+)
+
+game (
+	name "Malagai (USA)"
+	description "Malagai (USA)"
+	rom ( name "Malagai (USA).a26" size 4096 crc 65790ef9 md5 ccb5fa954fb76f09caae9a8c66462190 sha1 cdc7e65d965a7a00adda1e8bedfbe6200e349497 )
+)
+
+game (
+	name "Mangia' (USA)"
+	description "Mangia' (USA)"
+	rom ( name "Mangia' (USA).a26" size 4096 crc b807b775 md5 54a1c1255ed45eb8f71414dadb1cf669 sha1 ee8f9bf7cdb55f25f4d99e1a23f4c90106fadc39 )
+)
+
+game (
+	name "Marauder (USA)"
+	description "Marauder (USA)"
+	rom ( name "Marauder (USA).a26" size 4096 crc f8a8b470 md5 13895ef15610af0d0f89d588f376b3fe sha1 249a11bb4872a24f22dff1027ff256c1408140c2 )
+)
+
+game (
+	name "Marine Wars (USA)"
+	description "Marine Wars (USA)"
+	rom ( name "Marine Wars (USA).a26" size 4096 crc 4d281ee3 md5 b00e8217633e870bf39d948662a52aac sha1 dd9e94ca96c75a212f1414aa511fd99ecdadaf44 )
+)
+
+game (
+	name "Mario Bros. (USA)"
+	description "Mario Bros. (USA)"
+	rom ( name "Mario Bros. (USA).a26" size 8192 crc 8fbf7e90 md5 e908611d99890733be31733a979c62d8 sha1 49425ff154b92ca048abb4ce5e8d485c24935035 )
+)
+
+game (
+	name "Master Builder (USA)"
+	description "Master Builder (USA)"
+	rom ( name "Master Builder (USA).a26" size 4096 crc dd196d6c md5 ae4be3a36b285c1a1dff202157e2155d sha1 fbe7a78764407743b43a91136903ede65306f4e7 )
+)
+
+game (
+	name "Masters of the Universe - The Power of He-Man (USA)"
+	description "Masters of the Universe - The Power of He-Man (USA)"
+	rom ( name "Masters of the Universe - The Power of He-Man (USA).a26" size 16384 crc 0603e177 md5 3b76242691730b2dd22ec0ceab351bc6 sha1 6db8fa65755db86438ada3d90f4c39cc288dcf84 )
+)
+
+game (
+	name "Math Gran Prix (USA)"
+	description "Math Gran Prix (USA)"
+	rom ( name "Math Gran Prix (USA).a26" size 4096 crc ccc90c98 md5 470878b9917ea0348d64b5750af149aa sha1 18fac606400c08a0469aebd9b071ae3aec2a3cf2 )
+)
+
+game (
+	name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA)"
+	description "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA)"
+	rom ( name "Maze Craze - A Game of Cops 'n Robbers - Maze Mania - A Game of Cops 'n Robbers (USA).a26" size 4096 crc 0098e428 md5 f825c538481f9a7a46d1e9bc06200aaf sha1 aba25089d87cd6fee8d206b880baa5d938aae255 )
+)
+
+game (
+	name "McDonald's - Golden Arches Adventure (USA) (Proto)"
+	description "McDonald's - Golden Arches Adventure (USA) (Proto)"
+	rom ( name "McDonald's - Golden Arches Adventure (USA) (Proto).a26" size 4096 crc add0115d md5 35b43b54e83403bb3d71f519739a9549 sha1 0103b35b1aef6b10c1c0a44b213ebf30af708df6 )
+)
+
+game (
+	name "Mega Force (USA)"
+	description "Mega Force (USA)"
+	rom ( name "Mega Force (USA).a26" size 4096 crc 9e6ae8c2 md5 daeb54957875c50198a7e616f9cc8144 sha1 0ae118373c7bda97da2f8d9c113e1e09ea7e49e1 )
+)
+
+game (
+	name "MegaBoy (USA)"
+	description "MegaBoy (USA)"
+	rom ( name "MegaBoy (USA).a26" size 65536 crc 26914ce0 md5 b65d4a38d6047735824ee99684f3515e sha1 46977baf0e1ee6124b524258879c46f80d624fae )
+)
+
+game (
+	name "MegaMania - A Space Nightmare (USA)"
+	description "MegaMania - A Space Nightmare (USA)"
+	rom ( name "MegaMania - A Space Nightmare (USA).a26" size 4096 crc 33edc33e md5 318a9d6dda791268df92d72679914ac3 sha1 9c5748b38661dbadcbc9cd1ec6a6b0c550b0e3da )
+)
+
+game (
+	name "Meltdown (USA) (Proto)"
+	description "Meltdown (USA) (Proto)"
+	rom ( name "Meltdown (USA) (Proto).a26" size 4096 crc 7955b3be md5 96e798995af6ed9d8601166d4350f276 sha1 debb1572eadb20beb0e4cd2df8396def8eb02098 )
+)
+
+game (
+	name "Midnight Magic (USA)"
+	description "Midnight Magic (USA)"
+	rom ( name "Midnight Magic (USA).a26" size 16384 crc 5c5447b9 md5 f1554569321dc933c87981cf5c239c43 sha1 7fcf95459ea597a332bf5b6f56c8f891307b45b4 )
+)
+
+game (
+	name "Millipede (USA)"
+	description "Millipede (USA)"
+	rom ( name "Millipede (USA).a26" size 16384 crc ccc82dd0 md5 3c57748c8286cf9e821ecd064f21aaa9 sha1 0616f0dde6d697816dda92ed9e5a4c3d77a39408 )
+)
+
+game (
+	name "Mind Maze (USA)"
+	description "Mind Maze (USA)"
+	rom ( name "Mind Maze (USA).a26" size 8192 crc 7cc6c991 md5 0e224ea74310da4e7e2103400eb1b4bf sha1 3844b79dbec5ffc99eaa2c9f5fa4f0a26c08c06d )
+)
+
+game (
+	name "Miner 2049er - Starring Bounty Bob (USA)"
+	description "Miner 2049er - Starring Bounty Bob (USA)"
+	rom ( name "Miner 2049er - Starring Bounty Bob (USA).a26" size 8192 crc 19f9ef1c md5 3b040ed7d1ef8acb4efdeebebdaa2052 sha1 5470afe5961f9fdd2f6388f53f682f3264a95ce9 )
+)
+
+game (
+	name "Miner 2049er Volume II (USA)"
+	description "Miner 2049er Volume II (USA)"
+	rom ( name "Miner 2049er Volume II (USA).a26" size 8192 crc 71e814e9 md5 2a1b454a5c3832b0240111e7fd73de8a sha1 575faad92cb38944b9882ffb69073e0af9460aba )
+)
+
+game (
+	name "Mines of Minos (USA)"
+	description "Mines of Minos (USA)"
+	rom ( name "Mines of Minos (USA).a26" size 4096 crc c799e944 md5 4543b7691914dfd69c3755a5287a95e1 sha1 34773998d7740e1e8c206b3b22a19e282ca132e1 )
+)
+
+game (
+	name "Miniature Golf - Arcade Golf (USA)"
+	description "Miniature Golf - Arcade Golf (USA)"
+	rom ( name "Miniature Golf - Arcade Golf (USA).a26" size 2048 crc 28562315 md5 df62a658496ac98a3aa4a6ee5719c251 sha1 be24b42e3744a81fb217c86c4ed5ce51bff28e65 )
+)
+
+game (
+	name "Miss Piggy's Wedding (USA) (Proto)"
+	description "Miss Piggy's Wedding (USA) (Proto)"
+	rom ( name "Miss Piggy's Wedding (USA) (Proto).a26" size 8192 crc b1497e10 md5 4181087389a79c7f59611fb51c263137 sha1 f721d1f750e19b9e1788eed5e3872923ab46a91d )
+)
+
+game (
+	name "Missile Command (USA)"
+	description "Missile Command (USA)"
+	rom ( name "Missile Command (USA).a26" size 4096 crc cff14904 md5 3a2e2d0c6892aa14544083dfb7762782 sha1 faa06bb0643dbf556b13591c31917d277a83110b )
+)
+
+game (
+	name "Missile Control (Europe)"
+	description "Missile Control (Europe)"
+	rom ( name "Missile Control (Europe).a26" size 4096 crc ac80976b md5 cb24210dc86d92df97b38cf2a51782da sha1 224e7a310afdb91c6915743e72b7b53b38eb5754 )
+)
+
+game (
+	name "Mission 3,000 A.D. (Europe)"
+	description "Mission 3,000 A.D. (Europe)"
+	rom ( name "Mission 3,000 A.D. (Europe).a26" size 4096 crc 55b140fe md5 6efe876168e2d45d4719b6a61355e5fe sha1 999dc390a7a3f7be7c88022506c70bd4208b26d8 )
+)
+
+game (
+	name "Mission Survive (Europe)"
+	description "Mission Survive (Europe)"
+	rom ( name "Mission Survive (Europe).a26" size 4096 crc b70f52dc md5 cf9069f92a43f719974ee712c50cd932 sha1 93520821ce406a7aa6cc30472f76bca543805fd4 )
+)
+
+game (
+	name "Mogul Maniac (USA)"
+	description "Mogul Maniac (USA)"
+	rom ( name "Mogul Maniac (USA).a26" size 4096 crc 50afe04b md5 7af40c1485ce9f29b1a7b069a2eb04a7 sha1 0b74a90a22a7a16f9c2131fabd76b7742de0473e )
+)
+
+game (
+	name "Monster Cise (USA) (Proto)"
+	description "Monster Cise (USA) (Proto)"
+	rom ( name "Monster Cise (USA) (Proto).a26" size 8192 crc ab0f6091 md5 6913c90002636c1487538d4004f7cac2 sha1 81a4d56820b1e00130e368a3532c409929aff5fb )
+)
+
+game (
+	name "Montezuma's Revenge - Featuring Panama Joe (USA)"
+	description "Montezuma's Revenge - Featuring Panama Joe (USA)"
+	rom ( name "Montezuma's Revenge - Featuring Panama Joe (USA).a26" size 8192 crc e680a1c9 md5 3347a6dd59049b15a38394aa2dafa585 sha1 7dfeb1a8ec863c1e0f297113a1cc4185c215e81c )
+)
+
+game (
+	name "Moon Patrol (USA)"
+	description "Moon Patrol (USA)"
+	rom ( name "Moon Patrol (USA).a26" size 8192 crc d641ef2d md5 515046e3061b7b18aa3a551c3ae12673 sha1 dce778f397a325113f035722b7769492645d69eb )
+)
+
+game (
+	name "Moonsweeper (USA)"
+	description "Moonsweeper (USA)"
+	rom ( name "Moonsweeper (USA).a26" size 8192 crc 450b5c57 md5 203abb713c00b0884206dcc656caa48f sha1 05ab04dc30eae31b98ebf6f43fec6793a53e0a23 )
+)
+
+game (
+	name "Motocross (USA)"
+	description "Motocross (USA)"
+	rom ( name "Motocross (USA).a26" size 4096 crc 36feb44c md5 a20b7abbcdf90fbc29ac0fafa195bd12 sha1 bcafaa60338cf55ac72a940d04a5ad72003f7cf0 )
+)
+
+game (
+	name "Motocross Racer (USA)"
+	description "Motocross Racer (USA)"
+	rom ( name "Motocross Racer (USA).a26" size 8192 crc 0d1bc1cb md5 de0173ed6be9de6fd049803811e5f1a8 sha1 c4d495d42ea5bd354af04e1f2b68cce0fb43175d )
+)
+
+game (
+	name "MotoRodeo (USA)"
+	description "MotoRodeo (USA)"
+	rom ( name "MotoRodeo (USA).a26" size 16384 crc 89998e29 md5 378a62af6e9c12a760795ff4fc939656 sha1 dea1506ba107b9544cd9b179f83bc61ced9101ac )
+)
+
+game (
+	name "Mountain King (USA)"
+	description "Mountain King (USA)"
+	rom ( name "Mountain King (USA).a26" size 12288 crc ed778991 md5 db4eb44bc5d652d9192451383d3249fc sha1 0a84b0a6bd0e79f5fa0b1bb9112160cb564ab836 )
+)
+
+game (
+	name "Mouse Trap (USA)"
+	description "Mouse Trap (USA)"
+	rom ( name "Mouse Trap (USA).a26" size 4096 crc 9ddd45d3 md5 5678ebaa09ca3b699516dba4671643ed sha1 cf6347dedcfec213c28dd92111ec6f41e74b6f64 )
+)
+
+game (
+	name "Mr. Do! (USA)"
+	description "Mr. Do! (USA)"
+	rom ( name "Mr. Do! (USA).a26" size 8192 crc 860a47a1 md5 0164f26f6b38a34208cd4a2d0212afc3 sha1 e4c912199779bba25f1b9950007f14dca3d19c84 )
+)
+
+game (
+	name "Mr. Do!'s Castle (USA)"
+	description "Mr. Do!'s Castle (USA)"
+	rom ( name "Mr. Do!'s Castle (USA).a26" size 8192 crc 2cbbf3fe md5 97184b263722748757cfdc41107ca5c0 sha1 2d1c99a0159f9bf5fe727d34f46b07d93bc8341c )
+)
+
+game (
+	name "Mr. Postman (Europe)"
+	description "Mr. Postman (Europe)"
+	rom ( name "Mr. Postman (Europe).a26" size 4096 crc 16980cb8 md5 603c7a0d12c935df5810f400f3971b67 sha1 f9e1491d4cfea97822949349559a41d87a235d27 )
+)
+
+game (
+	name "Ms. Pac-Man (USA)"
+	description "Ms. Pac-Man (USA)"
+	rom ( name "Ms. Pac-Man (USA).a26" size 8192 crc b2d08fc9 md5 87e79cd41ce136fd4f72cc6e2c161bee sha1 62b933cdd8844bb1816ce57889203954fe782603 )
+)
+
+game (
+	name "Music Machine, The (USA)"
+	description "Music Machine, The (USA)"
+	rom ( name "Music Machine, The (USA).a26" size 4096 crc bd133d59 md5 65b106eba3e45f3dab72ea907f39f8b4 sha1 5a641caa2ab3c7c0cd5deb027acbc58efccf8d6a )
+)
+
+game (
+	name "My Golf (Europe)"
+	description "My Golf (Europe)"
+	rom ( name "My Golf (Europe).a26" size 8192 crc 0d2cbd53 md5 dfad86dd85a11c80259f3ddb6151f48f sha1 b2df23b1bf6df9d253ad0705592d3fce352a837b )
+)
+
+game (
+	name "Mysterious Thief, A (USA) (Proto)"
+	description "Mysterious Thief, A (USA) (Proto)"
+	rom ( name "Mysterious Thief, A (USA) (Proto).a26" size 4096 crc 8755c57c md5 fcbbd0a407d3ff7bf857b8a399280ea1 sha1 0d1c963ea040c60b296a26c46faaad472890499f )
+)
+
+game (
+	name "Name This Game (USA)"
+	description "Name This Game (USA)"
+	rom ( name "Name This Game (USA).a26" size 4096 crc a86e1ad8 md5 36306070f0c90a72461551a7a4f3a209 sha1 2b4a0535ca83b963906eb0a5d60ce0e21f07905d )
+)
+
+game (
+	name "Night Driver (USA)"
+	description "Night Driver (USA)"
+	rom ( name "Night Driver (USA).a26" size 2048 crc 600d8a96 md5 392f00fd1a074a3c15bc96b0a57d52a1 sha1 372771aeb4e2fb2cd1dead5497e3821e4236d5fc )
+)
+
+game (
+	name "Nightmare (Europe)"
+	description "Nightmare (Europe)"
+	rom ( name "Nightmare (Europe).a26" size 4096 crc b733f921 md5 ead60451c28635b55ca8fea198444e16 sha1 2a1ee3584c3df131a97d6291c93de46b3160af54 )
+)
+
+game (
+	name "No Escape! (USA)"
+	description "No Escape! (USA)"
+	rom ( name "No Escape! (USA).a26" size 4096 crc 8941caea md5 b6d52a0cf53ad4216feb04147301f87d sha1 e2e8750b8856dd44d914c43a7d277188cc148e5c )
+)
+
+game (
+	name "Nuts (Europe)"
+	description "Nuts (Europe)"
+	rom ( name "Nuts (Europe).a26" size 4096 crc d76d5f14 md5 e3c35eac234537396a865d23bafb1c84 sha1 d3c0f973f2b31c14dc3ad2d91fe8bbbb42bce269 )
+)
+
+game (
+	name "O Monstro Marinho (Europe)"
+	description "O Monstro Marinho (Europe)"
+	rom ( name "O Monstro Marinho (Europe).a26" size 4096 crc 3a1a392b md5 df6a46714960a3e39b57b3c3983801b5 sha1 c2f43f35d95797c06a581654406256c72e422ba4 )
+)
+
+game (
+	name "Obelix (USA)"
+	description "Obelix (USA)"
+	rom ( name "Obelix (USA).a26" size 8192 crc 29a51ea4 md5 133a4234512e8c4e9e8c5651469d4a09 sha1 9155f7fa57480a12a03c6a84213cc5dc7be739b5 )
+)
+
+game (
+	name "Off the Wall (USA)"
+	description "Off the Wall (USA)"
+	rom ( name "Off the Wall (USA).a26" size 16384 crc a09779ea md5 98f63949e656ff309cefa672146dc1b8 sha1 3dcfe93399044148561586056288c6f8e5c96e2b )
+)
+
+game (
+	name "Off Your Rocker (USA) (Proto)"
+	description "Off Your Rocker (USA) (Proto)"
+	rom ( name "Off Your Rocker (USA) (Proto).a26" size 4096 crc 066ec995 md5 b6166f15720fdf192932f1f76df5b65d sha1 7ad74a7c36318f1304f5dc454401cf257fa60d7a )
+)
+
+game (
+	name "Official Frogger, The (USA)"
+	description "Official Frogger, The (USA)"
+	rom ( name "Official Frogger, The (USA).a26" size 8448 crc 1228e48c md5 c73ae5ba5a0a3f3ac77f0a9e14770e73 sha1 f84c15579d22f2536e94f1679642b9dc73b6f2fe )
+)
+
+game (
+	name "Oink! (USA)"
+	description "Oink! (USA)"
+	rom ( name "Oink! (USA).a26" size 4096 crc 86f99b5e md5 c9c25fc536de9a7cdc5b9a916c459110 sha1 ea674cf2c90d407b8f8b96eac692690b602b73f9 )
+)
+
+game (
+	name "Omega Race (USA)"
+	description "Omega Race (USA)"
+	rom ( name "Omega Race (USA).a26" size 12288 crc e9876116 md5 9947f1ebabb56fd075a96c6d37351efa sha1 dcaab259e7617c7ac7d349893451896a9ca0e292 )
+)
+
+game (
+	name "Open Sesame (Europe)"
+	description "Open Sesame (Europe)"
+	rom ( name "Open Sesame (Europe).a26" size 4096 crc d01b5a1f md5 8786f4609a66fbea2cd9aa48ca7aa11c sha1 cc4d66da0182819a8067dbc6b73ff1bc33fc165b )
+)
+
+game (
+	name "Oscar's Trash Race (USA)"
+	description "Oscar's Trash Race (USA)"
+	rom ( name "Oscar's Trash Race (USA).a26" size 8192 crc 34721d7b md5 fa1b060fd8e0bca0c2a097dcffce93d3 sha1 7905709fcc85cbcfc28ca2ed543ffa737a5483ae )
+)
+
+game (
+	name "Othello (USA)"
+	description "Othello (USA)"
+	rom ( name "Othello (USA).a26" size 2048 crc 171ae72f md5 55949cb7884f9db0f8dfcf8707c7e5cb sha1 cbecf1a32d9366a3dd4ad643916cd59cdc820a8b )
+)
+
+game (
+	name "Out of Control (USA)"
+	description "Out of Control (USA)"
+	rom ( name "Out of Control (USA).a26" size 4096 crc ca4d03fb md5 f97dee1aa2629911f30f225ca31789d4 sha1 344d6942723513c376a7a844779804e10f357b85 )
+)
+
+game (
+	name "Outlaw - Gunslinger (USA)"
+	description "Outlaw - Gunslinger (USA)"
+	rom ( name "Outlaw - Gunslinger (USA).a26" size 2048 crc 68dd7acd md5 890c13590e0d8d5d6149737d930e4d95 sha1 f8eeaaf4635ac39b4bdf7ded1348bce46313ef9f )
+)
+
+game (
+	name "Pac-Man (USA)"
+	description "Pac-Man (USA)"
+	rom ( name "Pac-Man (USA).a26" size 4096 crc ddc9a881 md5 6e372f076fb9586aff416144f5cfe1cb sha1 0940fea7f04cdb6d4b90c5ad1a7e344e68f6dbb1 )
+)
+
+game (
+	name "Panda Chase (Europe)"
+	description "Panda Chase (Europe)"
+	rom ( name "Panda Chase (Europe).a26" size 4096 crc af417a00 md5 0e713d4e272ea7322c5b27d645f56dd0 sha1 f07b47cd6f3362eb051eab3eca564183d0d46c0c )
+)
+
+game (
+	name "Parachute (Europe)"
+	description "Parachute (Europe)"
+	rom ( name "Parachute (Europe).a26" size 4096 crc 40e4bc6a md5 714e13c08508ee9a7785ceac908ae831 sha1 385036ac98d44f2fa33a3ab11e35ca9f0151d6d2 )
+)
+
+game (
+	name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA)"
+	description "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA)"
+	rom ( name "Party Mix - Bop a Buggy, Tug of War, Wizard's Keep, Down on the Line, Handcar (USA).a26" size 25344 crc 8b8ae545 md5 012b8e6ef3b5fd5aabc94075c527709d sha1 600e3a32b19b3b164aaafb538b4399eda669845a )
+)
+
+game (
+	name "Peek-A-Boo (USA) (Proto)"
+	description "Peek-A-Boo (USA) (Proto)"
+	rom ( name "Peek-A-Boo (USA) (Proto).a26" size 4096 crc 07594314 md5 e40a818dac4dd851f3b4aafbe2f1e0c1 sha1 b529c1664ed1abc8f5f962a1fed65c0e4440219c )
+)
+
+game (
+	name "Pengo (USA)"
+	description "Pengo (USA)"
+	rom ( name "Pengo (USA).a26" size 8192 crc 7667e739 md5 04014d563b094e79ac8974366f616308 sha1 89b991a7a251f78f422bcdf9cf7d4475fdf33e97 )
+)
+
+game (
+	name "Pete Rose Baseball (USA)"
+	description "Pete Rose Baseball (USA)"
+	rom ( name "Pete Rose Baseball (USA).a26" size 16384 crc d0c6fc32 md5 09388bf390cd9a86dc0849697b96c7dc sha1 19c3ad034466c0433501a415a996ed7155d6063a )
+)
+
+game (
+	name "Peter Penguin (Europe)"
+	description "Peter Penguin (Europe)"
+	rom ( name "Peter Penguin (Europe).a26" size 4096 crc 5b47448c md5 cb4a7b507372c24f8b9390d22d54a918 sha1 59cc30a376901462e43bc78586495c72bab81fce )
+)
+
+game (
+	name "Phantom Tank (Europe)"
+	description "Phantom Tank (Europe)"
+	rom ( name "Phantom Tank (Europe).a26" size 4096 crc 9213493b md5 b29359f7de62fed6e6ad4c948f699df8 sha1 02a521354575d2270f75250e79bc18f69f666c7f )
+)
+
+game (
+	name "Phantom UFO (USA)"
+	description "Phantom UFO (USA)"
+	rom ( name "Phantom UFO (USA).a26" size 4096 crc 69d3abc5 md5 4d38e1105c3a5f0b3119a805f261fcb5 sha1 39f96b96ee996ab4afd82c6dea35c8d86585b90c )
+)
+
+game (
+	name "Pharaoh's Curse (Europe)"
+	description "Pharaoh's Curse (Europe)"
+	rom ( name "Pharaoh's Curse (Europe).a26" size 4096 crc c6b82fc6 md5 3577e19714921912685bb0e32ddf943c sha1 ecd9e93335ef6eda1531b0b5f03a5015054277b0 )
+)
+
+game (
+	name "Phaser Patrol (USA)"
+	description "Phaser Patrol (USA)"
+	rom ( name "Phaser Patrol (USA).a26" size 8448 crc eaf31bd7 md5 7dcbfd2acc013e817f011309c7504daa sha1 21c255e489d126475c3744cdd0d6e8a8e618e3eb )
+)
+
+game (
+	name "Phoenix (USA)"
+	description "Phoenix (USA)"
+	rom ( name "Phoenix (USA).a26" size 8192 crc 6ae1b66c md5 7e52a95074a66640fcfde124fffd491a sha1 010d51e3f522ba60f021d56819437d7c85897cdd )
+)
+
+game (
+	name "Pick 'n' Pile (Europe)"
+	description "Pick 'n' Pile (Europe)"
+	rom ( name "Pick 'n' Pile (Europe).a26" size 16384 crc cb76a9d4 md5 da79aad11572c80a96e261e4ac6392d0 sha1 a5917537cf1093aa350903d85d9e271e8a11d2cf )
+)
+
+game (
+	name "Pick Up (USA) (Proto)"
+	description "Pick Up (USA) (Proto)"
+	rom ( name "Pick Up (USA) (Proto).a26" size 4096 crc 0cdd8475 md5 1d4e0a034ad1275bc4d75165ae236105 sha1 9784531d02200bb79a58987877c67a0fc658252e )
+)
+
+game (
+	name "Picnic (USA)"
+	description "Picnic (USA)"
+	rom ( name "Picnic (USA).a26" size 4096 crc 1d507a61 md5 17c0a63f9a680e7a61beba81692d9297 sha1 483fc907471c5c358fb3e624097861a2fc9c1e45 )
+)
+
+game (
+	name "Piece o' Cake (USA)"
+	description "Piece o' Cake (USA)"
+	rom ( name "Piece o' Cake (USA).a26" size 4096 crc 40355166 md5 d3423d7600879174c038f53e5ebbf9d3 sha1 57774193081acea010bd935a0449bc8f53157128 )
+)
+
+game (
+	name "Pigs in Space - Starring Miss Piggy (USA)"
+	description "Pigs in Space - Starring Miss Piggy (USA)"
+	rom ( name "Pigs in Space - Starring Miss Piggy (USA).a26" size 8192 crc 27673d7c md5 8e4fa8c6ad8d8dce0db8c991c166cdaa sha1 d08b30ca2e5e351cac3bd3fb760b87a1a30aa300 )
+)
+
+game (
+	name "Pitfall II - Lost Caverns (USA)"
+	description "Pitfall II - Lost Caverns (USA)"
+	rom ( name "Pitfall II - Lost Caverns (USA).a26" size 10495 crc 097ce7ad md5 6d842c96d5a01967be9680080dd5be54 sha1 920cfbd517764ad3fa6a7425c031bd72dc7d927c )
+)
+
+game (
+	name "Pitfall! - Pitfall Harry's Jungle Adventure (USA)"
+	description "Pitfall! - Pitfall Harry's Jungle Adventure (USA)"
+	rom ( name "Pitfall! - Pitfall Harry's Jungle Adventure (USA).a26" size 4096 crc 42ad47bf md5 3e90cf23106f2e08b2781e41299de556 sha1 8d525480445d48cc48460dc666ebad78c8fb7b73 )
+)
+
+game (
+	name "Planet of the Apes (USA) (Proto)"
+	description "Planet of the Apes (USA) (Proto)"
+	rom ( name "Planet of the Apes (USA) (Proto).a26" size 4096 crc eea8b688 md5 9efb4e1a15a6cdd286e4bcd7cd94b7b8 sha1 dcca30e4ae58c85a070f0c6cfaa4d27be2970d61 )
+)
+
+game (
+	name "Planet Patrol (USA)"
+	description "Planet Patrol (USA)"
+	rom ( name "Planet Patrol (USA).a26" size 4096 crc 1e8ebb51 md5 043f165f384fbea3ea89393597951512 sha1 ccfcbf52815a441158977292b719f7c5ed80c515 )
+)
+
+game (
+	name "Plaque Attack (USA)"
+	description "Plaque Attack (USA)"
+	rom ( name "Plaque Attack (USA).a26" size 4096 crc d5a5eb9e md5 da4e3396aa2db3bd667f83a1cb9e4a36 sha1 103398dd35ebd39450c5cac760fa332aac3f9458 )
+)
+
+game (
+	name "Pleiades (USA) (Proto)"
+	description "Pleiades (USA) (Proto)"
+	rom ( name "Pleiades (USA) (Proto).a26" size 8192 crc 35589cec md5 8bbfd951c89cc09c148bfabdefa08bec sha1 63c12146c183bccbf05c0044a961dc40790e3212 )
+)
+
+game (
+	name "Polaris (USA)"
+	description "Polaris (USA)"
+	rom ( name "Polaris (USA).a26" size 8192 crc 25b78f89 md5 44f71e70b89dcc7cf39dfd622cfb9a27 sha1 b76ab69118b579ca0acbbb8ebe8003eed5cbcb4a )
+)
+
+game (
+	name "Pole Position (USA)"
+	description "Pole Position (USA)"
+	rom ( name "Pole Position (USA).a26" size 8192 crc bd822518 md5 a4ff39d513b993159911efe01ac12eba sha1 b7122f478a343cffac17b765e9642893587e99a1 )
+)
+
+game (
+	name "Polo (USA) (Proto)"
+	description "Polo (USA) (Proto)"
+	rom ( name "Polo (USA) (Proto).a26" size 2048 crc 8c0b57d9 md5 ee28424af389a7f3672182009472500c sha1 c0af0188028cd899c49ba18f52bd1678e573bff2 )
+)
+
+game (
+	name "Pompeii (USA) (Proto)"
+	description "Pompeii (USA) (Proto)"
+	rom ( name "Pompeii (USA) (Proto).a26" size 4096 crc 83d8a362 md5 a83b070b485cf1fb4d5a48da153fdf1a sha1 954d2980ea8f8d9a76921612c378889f24c35639 )
+)
+
+game (
+	name "Pooyan (USA)"
+	description "Pooyan (USA)"
+	rom ( name "Pooyan (USA).a26" size 4096 crc fe24be60 md5 4799a40b6e889370b7ee55c17ba65141 sha1 b7a002025c24ab2ec4a03f62212db7b96c0e5ffd )
+)
+
+game (
+	name "Popeye (USA)"
+	description "Popeye (USA)"
+	rom ( name "Popeye (USA).a26" size 8192 crc 7d287f20 md5 c7f13ef38f61ee2367ada94fdcc6d206 sha1 1772a22df3e9a1f3842387ac63eeddff7f04b01c )
+)
+
+game (
+	name "Porky's (USA)"
+	description "Porky's (USA)"
+	rom ( name "Porky's (USA).a26" size 8192 crc add0b98a md5 f93d7fee92717e161e6763a88a293ffa sha1 70afc2cc870be546dc976fa0c6811f7e01ebc471 )
+)
+
+game (
+	name "Pressure Cooker (USA)"
+	description "Pressure Cooker (USA)"
+	rom ( name "Pressure Cooker (USA).a26" size 8192 crc ccf597d8 md5 97d079315c09796ff6d95a06e4b70171 sha1 8b001373be485060f88182e9a7afcf55b4d07a57 )
+)
+
+game (
+	name "Private Eye (USA)"
+	description "Private Eye (USA)"
+	rom ( name "Private Eye (USA).a26" size 8192 crc ea3bff1c md5 ef3a4f64b6494ba770862768caf04b86 sha1 1ea6bea907a6b5607c76f222730f812a99cd1015 )
+)
+
+game (
+	name "Q-bert (USA)"
+	description "Q-bert (USA)"
+	rom ( name "Q-bert (USA).a26" size 4096 crc 54142e3e md5 484b0076816a104875e00467d431c2d2 sha1 f3ef9787b4287a32e4d9ac7b9c3358edc16315b2 )
+)
+
+game (
+	name "Q-bert's Qubes (USA)"
+	description "Q-bert's Qubes (USA)"
+	rom ( name "Q-bert's Qubes (USA).a26" size 8192 crc d9f499c5 md5 517592e6e0c71731019c0cebc2ce044f sha1 a61be3702437b5d16e19c0d2cd92393515d42f23 )
+)
+
+game (
+	name "Quadrun (USA)"
+	description "Quadrun (USA)"
+	rom ( name "Quadrun (USA).a26" size 8192 crc 8d3c887b md5 024365007a87f213cbe8ef5f2e8e1333 sha1 b8d6f508edbf713e52f0cbf235d5e17add2fbf2e )
+)
+
+game (
+	name "Quest for Quintana Roo (USA)"
+	description "Quest for Quintana Roo (USA)"
+	rom ( name "Quest for Quintana Roo (USA).a26" size 8192 crc f9f58dd3 md5 a0675883f9b09a3595ddd66a6f5d3498 sha1 d83c740d2968343e6401828d62f58be6aea8e858 )
+)
+
+game (
+	name "Quick Step! (USA)"
+	description "Quick Step! (USA)"
+	rom ( name "Quick Step! (USA).a26" size 4096 crc 057440fe md5 7eba20c2291a982214cc7cbe8d0b47cd sha1 33a47f79610c4525802c9881f67ad1f3f8c1b55d )
+)
+
+game (
+	name "Rabbit Transit (USA)"
+	description "Rabbit Transit (USA)"
+	rom ( name "Rabbit Transit (USA).a26" size 8448 crc 517e5561 md5 fb4ca865abc02d66e39651bd9ade140a sha1 81654cbd6a7262ce0f1abc385ed9adc323a9b6a6 )
+)
+
+game (
+	name "Racer (USA) (Proto)"
+	description "Racer (USA) (Proto)"
+	rom ( name "Racer (USA) (Proto).a26" size 8192 crc 794ed26d md5 3c7a7b3a0a7e6319b2fa0f923ef6c9af sha1 1df83e0e89a97511ee91a5a9f376dffcfbad06a9 )
+)
+
+game (
+	name "Racquetball (USA)"
+	description "Racquetball (USA)"
+	rom ( name "Racquetball (USA).a26" size 4096 crc 7eef9ac0 md5 a20d931a8fddcd6f6116ed21ff5c4832 sha1 4af6008152f1d38626d84016a7ef753406b48b46 )
+)
+
+game (
+	name "Radar Lock (USA)"
+	description "Radar Lock (USA)"
+	rom ( name "Radar Lock (USA).a26" size 16384 crc c29f7285 md5 baf4ce885aa281fd31711da9b9795485 sha1 33f016c941fab01e1e2d0d7ba7930e3bcd8feaa3 )
+)
+
+game (
+	name "Raft Rider (USA)"
+	description "Raft Rider (USA)"
+	rom ( name "Raft Rider (USA).a26" size 4096 crc 3d1292f8 md5 92a1a605b7ad56d863a56373a866761b sha1 a79f6e0f4fd76878e5c3ba6b52d17e88acdbe9f6 )
+)
+
+game (
+	name "Raiders of the Lost Ark (USA)"
+	description "Raiders of the Lost Ark (USA)"
+	rom ( name "Raiders of the Lost Ark (USA).a26" size 8192 crc e05fe273 md5 f724d3dd2471ed4cf5f191dbb724b69f sha1 7ae70783969709318e56f189cf03da92320a6aba )
+)
+
+game (
+	name "Ram It (USA)"
+	description "Ram It (USA)"
+	rom ( name "Ram It (USA).a26" size 4096 crc 582d5b62 md5 7096a198531d3f16a99d518ac0d7519a sha1 fd0a69c06eb3f7c9328951c890644f93c4bad6ad )
+)
+
+game (
+	name "Rampage! (USA)"
+	description "Rampage! (USA)"
+	rom ( name "Rampage! (USA).a26" size 16384 crc f0b446ac md5 5e1b4629426f4992cf3b2905a696e1a7 sha1 7bb7df255829d5fbbee0d944915e50f89a5e7075 )
+)
+
+game (
+	name "Raumpatrouille (USA)"
+	description "Raumpatrouille (USA)"
+	rom ( name "Raumpatrouille (USA).a26" size 4096 crc 3dfee54b md5 ca50cc4b21b0155255e066fcd6396331 sha1 d68d9ffcb6db02ea0e9299192f548e3d6594c0f3 )
+)
+
+game (
+	name "Reactor (USA)"
+	description "Reactor (USA)"
+	rom ( name "Reactor (USA).a26" size 4096 crc 1619e222 md5 9f8fad4badcd7be61bbd2bcaeef3c58f sha1 5adf9b530321472380ebceb2539de2ffbb0310bc )
+)
+
+game (
+	name "RealSports Baseball (USA)"
+	description "RealSports Baseball (USA)"
+	rom ( name "RealSports Baseball (USA).a26" size 8192 crc 3c5a1b5f md5 eb634650c3912132092b7aee540bbce3 sha1 ace97b89b8b6ab947434dbfd263951c6c0b349ac )
+)
+
+game (
+	name "RealSports Basketball (Europe) (Proto)"
+	description "RealSports Basketball (Europe) (Proto)"
+	rom ( name "RealSports Basketball (Europe) (Proto).a26" size 8192 crc 364feaa6 md5 8a183b6357987db5170c5cf9f4a113e5 sha1 bc2e6bdaa950bc06be040899dfeb9ad0938f4e98 )
+)
+
+game (
+	name "RealSports Boxing (USA)"
+	description "RealSports Boxing (USA)"
+	rom ( name "RealSports Boxing (USA).a26" size 16384 crc 3398a1b2 md5 3177cc5c04c1a4080a927dfa4099482b sha1 22dedbfce6cc9055a6c4caec013ca80200e51971 )
+)
+
+game (
+	name "RealSports Football (USA)"
+	description "RealSports Football (USA)"
+	rom ( name "RealSports Football (USA).a26" size 8192 crc f89f64ef md5 7ad257833190bc60277c1ca475057051 sha1 200d04c1e7f41a5a3730287ed0c3f9293628f195 )
+)
+
+game (
+	name "RealSports Soccer (USA)"
+	description "RealSports Soccer (USA)"
+	rom ( name "RealSports Soccer (USA).a26" size 8192 crc 02d89819 md5 08f853e8e01e711919e734d85349220d sha1 e3d964d918b7f2c420776acd3370ec1ee62744ea )
+)
+
+game (
+	name "RealSports Tennis (USA)"
+	description "RealSports Tennis (USA)"
+	rom ( name "RealSports Tennis (USA).a26" size 8192 crc 379001a0 md5 dac5c0fe74531f077c105b396874a9f1 sha1 702c1c7d985d0d22f935265bd284d1ed50df2527 )
+)
+
+game (
+	name "RealSports Volleyball (USA)"
+	description "RealSports Volleyball (USA)"
+	rom ( name "RealSports Volleyball (USA).a26" size 4096 crc 54fc9eb2 md5 aed0b7bd64cc384f85fdea33e28daf3b sha1 2025e1d868595fad36e5d9e7384ffd24c206208d )
+)
+
+game (
+	name "Red Sea Crossing (USA)"
+	description "Red Sea Crossing (USA)"
+	rom ( name "Red Sea Crossing (USA).a26" size 4096 crc e81e232a md5 4eb4fd544805babafc375dcdb8c2a597 sha1 dd92f67873d928e98cc4a2b279b90d7db8d50f5d )
+)
+
+game (
+	name "Rescue Terra I (USA)"
+	description "Rescue Terra I (USA)"
+	rom ( name "Rescue Terra I (USA).a26" size 4096 crc a509ad53 md5 60a61da9b2f43dd7e13a5093ec41a53d sha1 94e94810bf6c72eee49157f9218c3c170b65c836 )
+)
+
+game (
+	name "Revenge of the Beefsteak Tomatoes (USA)"
+	description "Revenge of the Beefsteak Tomatoes (USA)"
+	rom ( name "Revenge of the Beefsteak Tomatoes (USA).a26" size 4096 crc 243a36df md5 4f64d6d0694d9b7a1ed7b0cb0b83e759 sha1 f8a9dd46f9bad232f74d1ee2671ccb26ea1b3029 )
+)
+
+game (
+	name "Riddle of the Sphinx (USA)"
+	description "Riddle of the Sphinx (USA)"
+	rom ( name "Riddle of the Sphinx (USA).a26" size 4096 crc 183a87e3 md5 a995b6cbdb1f0433abc74050808590e6 sha1 acb2430b4e6c72ce13f321d9d3a38986dc4768ef )
+)
+
+game (
+	name "River Patrol (USA)"
+	description "River Patrol (USA)"
+	rom ( name "River Patrol (USA).a26" size 8192 crc c820bd75 md5 31512cdfadfd82bfb6f196e3b0fd83cd sha1 6715493dce54b22362741229078815b3360988ae )
+)
+
+game (
+	name "River Raid (USA)"
+	description "River Raid (USA)"
+	rom ( name "River Raid (USA).a26" size 4096 crc c3eb7e1e md5 393948436d1f4cc3192410bb918f9724 sha1 40329780402f8247f294fe884ffc56cc3da0c62d )
+)
+
+game (
+	name "River Raid II (USA)"
+	description "River Raid II (USA)"
+	rom ( name "River Raid II (USA).a26" size 16384 crc 27d2df2c md5 ab56f1b2542a05bebc4fbccfc4803a38 sha1 a08c3eae3368334c937a5e03329782e95f7b57c7 )
+)
+
+game (
+	name "Road Runner (USA)"
+	description "Road Runner (USA)"
+	rom ( name "Road Runner (USA).a26" size 16384 crc cb79c061 md5 ce5cc62608be2cd3ed8abd844efb8919 sha1 8be5f9c2a11f78ac536e598e3e3b7d37130154ec )
+)
+
+game (
+	name "Robin Hood (USA)"
+	description "Robin Hood (USA)"
+	rom ( name "Robin Hood (USA).a26" size 8192 crc df96102b md5 72a46e0c21f825518b7261c267ab886e sha1 7f9c2321c9f22cf2cdbcf1b3f0e563a1c53f68ca )
+)
+
+game (
+	name "Robot Tank (USA)"
+	description "Robot Tank (USA)"
+	rom ( name "Robot Tank (USA).a26" size 8192 crc e127c012 md5 4f618c2429138e0280969193ed6c107e sha1 21a3ee57cb622f410ffd51986ab80acadb8d44b7 )
+)
+
+game (
+	name "Roc 'n Rope (USA)"
+	description "Roc 'n Rope (USA)"
+	rom ( name "Roc 'n Rope (USA).a26" size 8192 crc 9d51c969 md5 65bd29e8ab1b847309775b0de6b2e4fe sha1 0abf0a292d4a24df5a5ebe19a9729f3a8f883c8b )
+)
+
+game (
+	name "Room of Doom (USA)"
+	description "Room of Doom (USA)"
+	rom ( name "Room of Doom (USA).a26" size 4096 crc f27fc3be md5 67931b0d37dc99af250dd06f1c095e8d sha1 fd243c480e769b20b7bf3e74bcd86e4ac99dab19 )
+)
+
+game (
+	name "Rubik's Cube 3-D (USA) (Proto)"
+	description "Rubik's Cube 3-D (USA) (Proto)"
+	rom ( name "Rubik's Cube 3-D (USA) (Proto).a26" size 4096 crc 47bfd42c md5 40b1832177c63ebf81e6c5b61aaffd3a sha1 cb3bb28bc4f08313ea8ed9ff395ca34271d3c499 )
+)
+
+game (
+	name "S.A.C. Alert (USA) (Proto)"
+	description "S.A.C. Alert (USA) (Proto)"
+	rom ( name "S.A.C. Alert (USA) (Proto).a26" size 4096 crc 79d3b1e6 md5 715dbf2e39ba8a52c5fe5cdd927b37e0 sha1 7b829edffee303c6b796c71540b7636ca5685bcd )
+)
+
+game (
+	name "Saboteur (USA) (Proto)"
+	description "Saboteur (USA) (Proto)"
+	rom ( name "Saboteur (USA) (Proto).a26" size 8192 crc 7efe0286 md5 a4ecb54f877cd94515527b11e698608c sha1 90cd987ccaffb428e53ffd98563dbbe3babd2e73 )
+)
+
+game (
+	name "Save Mary! (USA) (Proto)"
+	description "Save Mary! (USA) (Proto)"
+	rom ( name "Save Mary! (USA) (Proto).a26" size 16384 crc 01e18f53 md5 4d502d6fb5b992ee0591569144128f99 sha1 ecd8ef49ae23ddd3e10ec60839b95c8e7764ea27 )
+)
+
+game (
+	name "Save Our Ship (Europe)"
+	description "Save Our Ship (Europe)"
+	rom ( name "Save Our Ship (Europe).a26" size 4096 crc c422160a md5 01297d9b450455dd716db9658efb2fae sha1 8f06384fed607c5267d6f2c15a6f19cbe5c521d2 )
+)
+
+game (
+	name "Save the Whales (USA) (Proto)"
+	description "Save the Whales (USA) (Proto)"
+	rom ( name "Save the Whales (USA) (Proto).a26" size 4096 crc 9a346ce2 md5 e377c3af4f54a51b85efe37d4b7029e6 sha1 9f6c7295c3a82e0b2203d88715a6d9ac177b3ba9 )
+)
+
+game (
+	name "Sea Battle (USA)"
+	description "Sea Battle (USA)"
+	rom ( name "Sea Battle (USA).a26" size 4096 crc 83b4eb19 md5 1bc2427ac9b032a52fe527c7b26ce22c sha1 cfcc4f11ace2a7408b8122dbf80ab8ec6b56af76 )
+)
+
+game (
+	name "Sea Hunt ~ Scuba Diver (USA)"
+	description "Sea Hunt ~ Scuba Diver (USA)"
+	rom ( name "Sea Hunt ~ Scuba Diver (USA).a26" size 4096 crc f94a8aec md5 5dccf215fdb9bbf5d4a6d0139e5e8bcb sha1 e5558ae30acc1fa5b4ffe782ae480622586a32ca )
+)
+
+game (
+	name "Seahawk (Europe)"
+	description "Seahawk (Europe)"
+	rom ( name "Seahawk (Europe).a26" size 4096 crc 5d3c699e md5 74d072e8a34560c36cacbc57b2462360 sha1 b4ead7656696a983dec3192c71cc4d63e9a67825 )
+)
+
+game (
+	name "Seaquest (USA)"
+	description "Seaquest (USA)"
+	rom ( name "Seaquest (USA).a26" size 4096 crc 8658e8d9 md5 240bfbac5163af4df5ae713985386f92 sha1 7324a1ebc695a477c8884718ffcad27732a98ab0 )
+)
+
+game (
+	name "Secret Agent (USA) (Proto)"
+	description "Secret Agent (USA) (Proto)"
+	rom ( name "Secret Agent (USA) (Proto).a26" size 4096 crc d16c45f9 md5 605fd59bfef88901c8c4794193a4cbad sha1 1914f57ab0a6f221f2ad344b244a3cdd7b1d991a )
+)
+
+game (
+	name "Secret Quest (USA)"
+	description "Secret Quest (USA)"
+	rom ( name "Secret Quest (USA).a26" size 16384 crc 93c9eb47 md5 fc24a94d4371c69bc58f5245ada43c44 sha1 af11f1666d345267196a1c35223727e2ef93483a )
+)
+
+game (
+	name "Sentinel (USA)"
+	description "Sentinel (USA)"
+	rom ( name "Sentinel (USA).a26" size 16384 crc d457b245 md5 8da51e0c4b6b46f7619425119c7d018e sha1 fcf5f8a7d6e59a339c2002e3d4084d87deb670fe )
+)
+
+game (
+	name "Shootin' Gallery (USA)"
+	description "Shootin' Gallery (USA)"
+	rom ( name "Shootin' Gallery (USA).a26" size 4096 crc b89aff8b md5 b5a1a189601a785bdb2f02a424080412 sha1 cfb4b41e318c7cd0070e75e412f67c973e124d8e )
+)
+
+game (
+	name "Shooting Arcade (USA) (Proto)"
+	description "Shooting Arcade (USA) (Proto)"
+	rom ( name "Shooting Arcade (USA) (Proto).a26" size 16384 crc 6f6fb3d6 md5 15c11ab6e4502b2010b18366133fc322 sha1 6e6daa34878d3e331c630359c7125a4ffba1b22d )
+)
+
+game (
+	name "Shuttle Orbiter (USA)"
+	description "Shuttle Orbiter (USA)"
+	rom ( name "Shuttle Orbiter (USA).a26" size 4096 crc 253d6396 md5 25b6dc012cdba63704ea9535c6987beb sha1 08952192ea6bf0ef94373520a7e855f58bae6179 )
+)
+
+game (
+	name "Sinistar (USA) (Proto)"
+	description "Sinistar (USA) (Proto)"
+	rom ( name "Sinistar (USA) (Proto).a26" size 8192 crc 8e81a2a4 md5 1e85f8bccb4b866d4daa9fcf89306474 sha1 242fc23def80da96da22c2c7238d48635489abb0 )
+)
+
+game (
+	name "Sir Lancelot (USA)"
+	description "Sir Lancelot (USA)"
+	rom ( name "Sir Lancelot (USA).a26" size 8192 crc eb792891 md5 4c8970f6c294a0a54c9c45e5e8445f93 sha1 fb4008b13cb9957ce5e2ce1555c7aecac9e773cc )
+)
+
+game (
+	name "Skate Boardin' (USA)"
+	description "Skate Boardin' (USA)"
+	rom ( name "Skate Boardin' (USA).a26" size 8192 crc 6ee721f7 md5 f847fb8dba6c6d66d13724dbe5d95c4d sha1 a26fe0b5a43fe8116ab0ae6656d6b11644d871ec )
+)
+
+game (
+	name "Skeet Shoot (USA)"
+	description "Skeet Shoot (USA)"
+	rom ( name "Skeet Shoot (USA).a26" size 2048 crc 57d69b13 md5 39c78d682516d79130b379fa9deb8d1c sha1 5ea6d2eb27c76e85f477ba6c799deb7c416ebbc3 )
+)
+
+game (
+	name "Ski Hunt (Europe)"
+	description "Ski Hunt (Europe)"
+	rom ( name "Ski Hunt (Europe).a26" size 4096 crc 5df00a09 md5 8654d7f0fb351960016e06646f639b02 sha1 936fce1ff68113fabf3f971592e98acddcab97b7 )
+)
+
+game (
+	name "Ski Run (Europe)"
+	description "Ski Run (Europe)"
+	rom ( name "Ski Run (Europe).a26" size 4096 crc e20a00b3 md5 f10e3f45fb01416c87e5835ab270b53a sha1 6ea10b4409225b2de0f130837e7d0e3b164a1652 )
+)
+
+game (
+	name "Skiing (USA)"
+	description "Skiing (USA)"
+	rom ( name "Skiing (USA).a26" size 2048 crc 35f80a22 md5 b76fbadc8ffb1f83e2ca08b6fb4d6c9f sha1 6581846f983b50cffb75d1c1b902238ba7dd4e92 )
+)
+
+game (
+	name "Skindiver (Europe)"
+	description "Skindiver (Europe)"
+	rom ( name "Skindiver (Europe).a26" size 4096 crc 9a98888c md5 340f546d59e72fb358c49ac2ca8482bb sha1 a86bf5762c4766c4de00b49b29d0df9a7ee417e0 )
+)
+
+game (
+	name "Sky Alien (Europe)"
+	description "Sky Alien (Europe)"
+	rom ( name "Sky Alien (Europe).a26" size 4096 crc a23eaac5 md5 c31a17942d162b80962cb1f7571cd1d5 sha1 12acae81097b752d2446c9456996bdccc3d625d5 )
+)
+
+game (
+	name "Sky Diver - Dare Diver (USA)"
+	description "Sky Diver - Dare Diver (USA)"
+	rom ( name "Sky Diver - Dare Diver (USA).a26" size 2048 crc 00312ea9 md5 46c021a3e9e2fd00919ca3dd1a6b76d8 sha1 4dde18d4abc139562fdd7a9d2fd49a1f00a9e64a )
+)
+
+game (
+	name "Sky Jinks (USA)"
+	description "Sky Jinks (USA)"
+	rom ( name "Sky Jinks (USA).a26" size 2048 crc 96f8cf59 md5 2a0ba55e56e7a596146fa729acf0e109 sha1 105f722dcf9a89b683c10ddd7f684c5966c8e1db )
+)
+
+game (
+	name "Sky Patrol (USA) (Proto)"
+	description "Sky Patrol (USA) (Proto)"
+	rom ( name "Sky Patrol (USA) (Proto).a26" size 8192 crc a1ecdf0e md5 4c9307de724c36fd487af6c99ca078f2 sha1 fc5f1e30db3b2469c9701dadfa95f3268fd1e4cb )
+)
+
+game (
+	name "Sky Skipper (USA)"
+	description "Sky Skipper (USA)"
+	rom ( name "Sky Skipper (USA).a26" size 4096 crc cc6e0f22 md5 3b91c347d8e6427edbe942a7a405290d sha1 ef0a7ecfe8f3b5d1e67a736552a0cdc472803be9 )
+)
+
+game (
+	name "Slot Machine - Slots (USA)"
+	description "Slot Machine - Slots (USA)"
+	rom ( name "Slot Machine - Slots (USA).a26" size 2048 crc cb378d95 md5 f90b5da189f24d7e1a2117d8c8abc952 sha1 7239d1c64f3dfc2a1613be325cce13803dd2baa5 )
+)
+
+game (
+	name "Slot Racers - Maze (USA)"
+	description "Slot Racers - Maze (USA)"
+	rom ( name "Slot Racers - Maze (USA).a26" size 2048 crc 177dbdf8 md5 aed82052f7589df05a3f417bb4e45f0c sha1 a2b13017d759346174e3d8dd53b6347222d3b85d )
+)
+
+game (
+	name "Smurf - Rescue in Gargamel's Castle (USA)"
+	description "Smurf - Rescue in Gargamel's Castle (USA)"
+	rom ( name "Smurf - Rescue in Gargamel's Castle (USA).a26" size 8192 crc e0624a7f md5 3d1e83afdb4265fa2fb84819c9cfd39c sha1 530c7883fed4c5b9d78e35d48770b56e328999a3 )
+)
+
+game (
+	name "Smurfs Save the Day (USA)"
+	description "Smurfs Save the Day (USA)"
+	rom ( name "Smurfs Save the Day (USA).a26" size 8192 crc ad89c697 md5 a204cd4fb1944c86e800120706512a64 sha1 c0ae3965fcfab0294f770af0af57d7d1adc17750 )
+)
+
+game (
+	name "Snail Against Squirrel (Europe)"
+	description "Snail Against Squirrel (Europe)"
+	rom ( name "Snail Against Squirrel (Europe).a26" size 4096 crc 5c5b9e1a md5 898b5467551d32af48a604802407b6e8 sha1 e7bf450cf3a3f40de9d24d89968a4bc89b53cb18 )
+)
+
+game (
+	name "Sneak 'n Peek (USA)"
+	description "Sneak 'n Peek (USA)"
+	rom ( name "Sneak 'n Peek (USA).a26" size 4096 crc 93b17c39 md5 9c6faa4ff7f2ae549bbcb14f582b70e4 sha1 843e3c2fc71af2db3f2ae98eb350fde26334cfd1 )
+)
+
+game (
+	name "Snoopy and the Red Baron (USA)"
+	description "Snoopy and the Red Baron (USA)"
+	rom ( name "Snoopy and the Red Baron (USA).a26" size 8192 crc d1039967 md5 57939b326df86b74ca6404f64f89fce9 sha1 972bc0a77e76f3e4e1270ec1c2fc395e9826bc07 )
+)
+
+game (
+	name "Snow White and the Seven Dwarfs (USA) (Proto)"
+	description "Snow White and the Seven Dwarfs (USA) (Proto)"
+	rom ( name "Snow White and the Seven Dwarfs (USA) (Proto).a26" size 8192 crc 38598a9a md5 75ee371ccfc4f43e7d9b8f24e1266b55 sha1 5c968c6dc0db6564f4ea83a543c0bd7c3efd1032 )
+)
+
+game (
+	name "Solar Fox (USA)"
+	description "Solar Fox (USA)"
+	rom ( name "Solar Fox (USA).a26" size 8192 crc d2ca6ce8 md5 947317a89af38a49c4864d6bdd6a91fb sha1 09ea74f14db8d21ea785d0c8209ed670e4ce88be )
+)
+
+game (
+	name "Solar Storm (USA)"
+	description "Solar Storm (USA)"
+	rom ( name "Solar Storm (USA).a26" size 4096 crc a970b3e3 md5 97842fe847e8eb71263d6f92f7e122bd sha1 ec65ef9e47239a7d15db9bca7e625b166e8ac242 )
+)
+
+game (
+	name "Solaris (USA)"
+	description "Solaris (USA)"
+	rom ( name "Solaris (USA).a26" size 16384 crc 2b87850e md5 e72eb8d4410152bdcb69e7fba327b420 sha1 33b16fbc95c2cdc52d84d98ca471f10dae3f9dbf )
+)
+
+game (
+	name "Sorcerer (USA)"
+	description "Sorcerer (USA)"
+	rom ( name "Sorcerer (USA).a26" size 4096 crc c7734be6 md5 d2c4f8a4a98a905a9deef3ba7380ed64 sha1 70e912379060d834aa9fb2baa2e6a438f3b5d3b6 )
+)
+
+game (
+	name "Sorcerer's Apprentice (USA)"
+	description "Sorcerer's Apprentice (USA)"
+	rom ( name "Sorcerer's Apprentice (USA).a26" size 8192 crc e5dbfed1 md5 5f7ae9a7f8d79a3b37e8fc841f65643a sha1 ae3009e921f23254bb71f67c8cb2d7d6de2845a5 )
+)
+
+game (
+	name "Space Attack (USA)"
+	description "Space Attack (USA)"
+	rom ( name "Space Attack (USA).a26" size 4096 crc b34a3e57 md5 17badbb3f54d1fc01ee68726882f26a6 sha1 560563613bc309a532d611f11a1cf2b9af1e2f16 )
+)
+
+game (
+	name "Space Cavern (USA)"
+	description "Space Cavern (USA)"
+	rom ( name "Space Cavern (USA).a26" size 4096 crc 3b0ffd89 md5 df6a28a89600affe36d94394ef597214 sha1 b757b883ee114054c650027f3b9a8f15548cbf32 )
+)
+
+game (
+	name "Space Invaders (USA)"
+	description "Space Invaders (USA)"
+	rom ( name "Space Invaders (USA).a26" size 4096 crc a6e867b3 md5 72ffbef6504b75e69ee1045af9075f66 sha1 31d9668fe5812c3d2e076987ca327ac6b2e280bf )
+)
+
+game (
+	name "Space Jockey (USA)"
+	description "Space Jockey (USA)"
+	rom ( name "Space Jockey (USA).a26" size 2048 crc ab24d73e md5 6f2aaffaaf53d23a28bf6677b86ac0e3 sha1 5bdd8af54020fa43065750bd4239a497695d403b )
+)
+
+game (
+	name "Space Shuttle - A Journey Into Space (USA)"
+	description "Space Shuttle - A Journey Into Space (USA)"
+	rom ( name "Space Shuttle - A Journey Into Space (USA).a26" size 8192 crc dd210cf3 md5 5894c9c0c1e7e29f3ab86c6d3f673361 sha1 bcec5a66f8dff1a751769626b0fce305fab44ca2 )
+)
+
+game (
+	name "Space War - Space Combat (USA)"
+	description "Space War - Space Combat (USA)"
+	rom ( name "Space War - Space Combat (USA).a26" size 2048 crc 65622f2a md5 a7ef44ccb5b9000caf02df3e6da71a92 sha1 23510ba617431097668eaf104aa1e36233173093 )
+)
+
+game (
+	name "Spacechase (USA)"
+	description "Spacechase (USA)"
+	rom ( name "Spacechase (USA).a26" size 4096 crc 2954d22d md5 ec5c861b487a5075876ab01155e74c6c sha1 b356294e35827bf81add95fee5453b0ca0f497ad )
+)
+
+game (
+	name "SpaceMaster X-7 (USA)"
+	description "SpaceMaster X-7 (USA)"
+	rom ( name "SpaceMaster X-7 (USA).a26" size 4096 crc e554d7d0 md5 45040679d72b101189c298a864a5b5ba sha1 983b1aff97ab1243e283ba62d3a6a75ad186d225 )
+)
+
+game (
+	name "Spider Fighter (USA)"
+	description "Spider Fighter (USA)"
+	rom ( name "Spider Fighter (USA).a26" size 4096 crc bf0941f6 md5 24d018c4a6de7e5bd19a36f2b879b335 sha1 06820ad3c957913847f9849d920bc8725f535f11 )
+)
+
+game (
+	name "Spider Maze (USA)"
+	description "Spider Maze (USA)"
+	rom ( name "Spider Maze (USA).a26" size 4096 crc fbc1911d md5 21299c8c3ac1d54f8289d88702a738fd sha1 5d6f918bba4bd046e85b707da3b7d643cc2e1f1f )
+)
+
+game (
+	name "Spider-Man (USA)"
+	description "Spider-Man (USA)"
+	rom ( name "Spider-Man (USA).a26" size 4096 crc 4dfea848 md5 199eb0b8dce1408f3f7d46411b715ca9 sha1 912c5f5571ac59a6782da412183cdd6277345816 )
+)
+
+game (
+	name "Spike's Peak (USA)"
+	description "Spike's Peak (USA)"
+	rom ( name "Spike's Peak (USA).a26" size 8192 crc 50efea8d md5 a4e885726af9d97b12bb5a36792eab63 sha1 205241a12778829981e9281d9c6fa137f11e1376 )
+)
+
+game (
+	name "Spitfire Attack (USA)"
+	description "Spitfire Attack (USA)"
+	rom ( name "Spitfire Attack (USA).a26" size 4096 crc 093507d8 md5 cef2287d5fd80216b2200fb2ef1adfa8 sha1 165de0ebca628eb1e9f564390c9eedfe289c7a1d )
+)
+
+game (
+	name "Springer (USA)"
+	description "Springer (USA)"
+	rom ( name "Springer (USA).a26" size 8192 crc dd183a4f md5 4cd796b5911ed3f1062e805a3df33d98 sha1 6da0aa8aa40cd9c78dc014deb9074529688d91d0 )
+)
+
+game (
+	name "Sprint Master (USA)"
+	description "Sprint Master (USA)"
+	rom ( name "Sprint Master (USA).a26" size 16384 crc c495904e md5 5a8afe5422abbfb0a342fb15afd7415f sha1 c0e29b86fc1cc41a1c8afa37572c3c5698ae70b2 )
+)
+
+game (
+	name "Spy Hunter (USA)"
+	description "Spy Hunter (USA)"
+	rom ( name "Spy Hunter (USA).a26" size 8192 crc 4f804e49 md5 3105967f7222cc36a5ac6e5f6e89a0b4 sha1 1d0acf064d06a026a04b6028285db78c834e9854 )
+)
+
+game (
+	name "Squeeze Box (USA)"
+	description "Squeeze Box (USA)"
+	rom ( name "Squeeze Box (USA).a26" size 4096 crc d37f3fb3 md5 ba257438f8a78862a9e014d831143690 sha1 033148faebc97d4ed3a86c97fe0cdee21bd261f7 )
+)
+
+game (
+	name "Squoosh (USA) (Proto)"
+	description "Squoosh (USA) (Proto)"
+	rom ( name "Squoosh (USA) (Proto).a26" size 4096 crc b4212adb md5 34c808ad6577dbfa46169b73171585a3 sha1 7405d4b427cb278062fa44db918c0a702062e55c )
+)
+
+game (
+	name "Sssnake (USA)"
+	description "Sssnake (USA)"
+	rom ( name "Sssnake (USA).a26" size 4096 crc 1b5b0212 md5 21a96301bb0df27fde2e7eefa49e0397 sha1 46aabde3074acded8890a2efa5586d6b8bd76b5d )
+)
+
+game (
+	name "Stampede (USA)"
+	description "Stampede (USA)"
+	rom ( name "Stampede (USA).a26" size 2048 crc 740800f3 md5 21d7334e406c2407e69dbddd7cec3583 sha1 277184c4e61ced14393049a21a304e941d05993f )
+)
+
+game (
+	name "Star Fox (USA)"
+	description "Star Fox (USA)"
+	rom ( name "Star Fox (USA).a26" size 4096 crc 915ec040 md5 f526d0c519f5001adb1fc7948bfbb3ce sha1 1b95e07437ddc1523d7ec21c460273e91dbf36c7 )
+)
+
+game (
+	name "Star Raiders (USA)"
+	description "Star Raiders (USA)"
+	rom ( name "Star Raiders (USA).a26" size 8192 crc 2ae193ee md5 cbd981a23c592fb9ab979223bb368cd5 sha1 e10cce1a438c82bd499e1eb31a3f07d7254198f5 )
+)
+
+game (
+	name "Star Ship - Outer Space (USA)"
+	description "Star Ship - Outer Space (USA)"
+	rom ( name "Star Ship - Outer Space (USA).a26" size 2048 crc 6609267e md5 e363e467f605537f3777ad33e74e113a sha1 878e78ed46e29c44949d0904a2198826e412ed81 )
+)
+
+game (
+	name "Star Strike (USA)"
+	description "Star Strike (USA)"
+	rom ( name "Star Strike (USA).a26" size 4096 crc 936a596d md5 79e5338dbfa6b64008bb0d72a3179d3c sha1 de05d1ca8ad1e7a85df3faf25b1aa90b159afded )
+)
+
+game (
+	name "Star Trek - Strategic Operations Simulator (USA)"
+	description "Star Trek - Strategic Operations Simulator (USA)"
+	rom ( name "Star Trek - Strategic Operations Simulator (USA).a26" size 8192 crc 820ea8a2 md5 03c3f7ba4585e349dd12bfa7b34b7729 sha1 61a3ebbffa0bfb761295c66e189b62915f4818d9 )
+)
+
+game (
+	name "Star Voyager (USA)"
+	description "Star Voyager (USA)"
+	rom ( name "Star Voyager (USA).a26" size 4096 crc 4fe8477f md5 813985a940aa739cc28df19e0edd4722 sha1 ccc5b829c4aa71acb7976e741fdbf59c8ef9eb55 )
+)
+
+game (
+	name "Star Wars - Jedi Arena (USA)"
+	description "Star Wars - Jedi Arena (USA)"
+	rom ( name "Star Wars - Jedi Arena (USA).a26" size 4096 crc 9e36d347 md5 c9f6e521a49a2d15dac56b6ddb3fb4c7 sha1 36b9edc7150311203f375c1be10d0510efde6476 )
+)
+
+game (
+	name "Star Wars - Return of the Jedi - Death Star Battle (USA)"
+	description "Star Wars - Return of the Jedi - Death Star Battle (USA)"
+	rom ( name "Star Wars - Return of the Jedi - Death Star Battle (USA).a26" size 8192 crc 0886a55d md5 5336f86f6b982cc925532f2e80aa1e17 sha1 2ad9db4b5aec2da36ecc3178599b02619c3c462e )
+)
+
+game (
+	name "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto)"
+	description "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto)"
+	rom ( name "Star Wars - Return of the Jedi - Ewok Adventure (USA) (Proto).a26" size 8192 crc 939550e7 md5 d44d90e7c389165f5034b5844077777f sha1 b759eabf0dcb112c94b9fd66451a882130667860 )
+)
+
+game (
+	name "Star Wars - The Arcade Game (USA)"
+	description "Star Wars - The Arcade Game (USA)"
+	rom ( name "Star Wars - The Arcade Game (USA).a26" size 8192 crc 65c31ca4 md5 6339d28c9a7f92054e70029eb0375837 sha1 8823fe3d8e3aeadc6b61ca51914e3b15aa13801c )
+)
+
+game (
+	name "Star Wars - The Empire Strikes Back (USA)"
+	description "Star Wars - The Empire Strikes Back (USA)"
+	rom ( name "Star Wars - The Empire Strikes Back (USA).a26" size 4096 crc ee8c9a89 md5 3c8e57a246742fa5d59e517134c0b4e6 sha1 ad5b2c9df558ab23ad2954fe49ed5b37a06009bf )
+)
+
+game (
+	name "Stargate (USA)"
+	description "Stargate (USA)"
+	rom ( name "Stargate (USA).a26" size 8192 crc cde3530e md5 0c48e820301251fbb6bcdc89bd3555d9 sha1 4f87be0ef16a1d0389226d1fbda9b4c16b06e13e )
+)
+
+game (
+	name "Stargunner (USA)"
+	description "Stargunner (USA)"
+	rom ( name "Stargunner (USA).a26" size 4096 crc fca9c17b md5 a3c1c70024d7aabb41381adbfb6d3b25 sha1 3359aa7a6a5fa25beaa3ae5868d0034d52de9882 )
+)
+
+game (
+	name "StarMaster (USA)"
+	description "StarMaster (USA)"
+	rom ( name "StarMaster (USA).a26" size 4096 crc 25248b4b md5 d69559f9c9dc6ef528d841bf9d91b275 sha1 814876ed270114912363e4718a84123dee213b6f )
+)
+
+game (
+	name "Steeplechase (Europe)"
+	description "Steeplechase (Europe)"
+	rom ( name "Steeplechase (Europe).a26" size 4096 crc 6aad3f22 md5 f1eeeccc4bba6999345a2575ae96508e sha1 bd7f0005fa018f13ed7e942c83c1751fb746a317 )
+)
+
+game (
+	name "Steeplechase (USA)"
+	description "Steeplechase (USA)"
+	rom ( name "Steeplechase (USA).a26" size 2048 crc 5f6c32c3 md5 656dc247db2871766dffd978c71da80c sha1 e56ef1c0313d6d04e25446c4e34f9bb7eda8efac )
+)
+
+game (
+	name "Stellar Track (USA)"
+	description "Stellar Track (USA)"
+	rom ( name "Stellar Track (USA).a26" size 4096 crc a76e93bf md5 0b8d3002d8f744a753ba434a4d39249a sha1 7d97d014c22a2ed3a5bc4b310f5a7be1b1d3520f )
+)
+
+game (
+	name "Stone Age (USA)"
+	description "Stone Age (USA)"
+	rom ( name "Stone Age (USA).a26" size 4096 crc 8bcdb222 md5 23fad5a125bcd4463701c8ad8a0043a9 sha1 45d37e37dea763956737110770e3d33de9c873a5 )
+)
+
+game (
+	name "Strategy X (USA)"
+	description "Strategy X (USA)"
+	rom ( name "Strategy X (USA).a26" size 4096 crc 2af91a81 md5 9333172e3c4992ecf548d3ac1f2553eb sha1 9d6decda6e8ab263f7380ff662c814b8cb8caf34 )
+)
+
+game (
+	name "Strawberry Shortcake - Musical Match-Ups (USA)"
+	description "Strawberry Shortcake - Musical Match-Ups (USA)"
+	rom ( name "Strawberry Shortcake - Musical Match-Ups (USA).a26" size 4096 crc fb29e31f md5 e10d2c785aadb42c06390fae0d92f282 sha1 7ca8f9cd74cfa505c493757ff37bf127ff467bb4 )
+)
+
+game (
+	name "Street Racer - Speedway II (USA)"
+	description "Street Racer - Speedway II (USA)"
+	rom ( name "Street Racer - Speedway II (USA).a26" size 2048 crc 47592880 md5 396f7bc90ab4fa4975f8c74abe4e81f0 sha1 bffb3d41916c83398624151eb00aa2a3acd23ab8 )
+)
+
+game (
+	name "Stronghold (USA)"
+	description "Stronghold (USA)"
+	rom ( name "Stronghold (USA).a26" size 4096 crc bb91ffa6 md5 7b3cf0256e1fa0fdc538caf3d5d86337 sha1 2cfe280fdbb6b5c8cda8a4620df12a5154e123be )
+)
+
+game (
+	name "Stunt Cycle (USA) (Proto)"
+	description "Stunt Cycle (USA) (Proto)"
+	rom ( name "Stunt Cycle (USA) (Proto).a26" size 2048 crc 6354ff4c md5 c3bbc673acf2701b5275e85d9372facf sha1 2e19d7e16cf17682b043baaa30e345e6fa4540e5 )
+)
+
+game (
+	name "Sub-Scan (USA)"
+	description "Sub-Scan (USA)"
+	rom ( name "Sub-Scan (USA).a26" size 4096 crc 5069d7da md5 5af9cd346266a1f2515e1fbc86f5186a sha1 ccd75f0141b917656ef2b86c068fba3238d18a0c )
+)
+
+game (
+	name "Submarine Commander (USA)"
+	description "Submarine Commander (USA)"
+	rom ( name "Submarine Commander (USA).a26" size 4096 crc 3262960a md5 f3f5f72bfdd67f3d0e45d097e11b8091 sha1 b22ba7cbde60a21ecbbe3953cc4a5c0bf007cc26 )
+)
+
+game (
+	name "Subterranea (USA)"
+	description "Subterranea (USA)"
+	rom ( name "Subterranea (USA).a26" size 8192 crc 2ab951f7 md5 93c52141d3c4e1b5574d072f1afde6cd sha1 2abc6bbcab27985f19e42915530fd556b6b1ae23 )
+)
+
+game (
+	name "Suicide Mission (USA)"
+	description "Suicide Mission (USA)"
+	rom ( name "Suicide Mission (USA).a26" size 8448 crc b92c49e3 md5 e4c666ca0c36928b95b13d33474dbb44 sha1 d3919b4dbeedfabfba30126d351eab509b0c1536 )
+)
+
+game (
+	name "Summer Games (USA)"
+	description "Summer Games (USA)"
+	rom ( name "Summer Games (USA).a26" size 16384 crc b9cd3f86 md5 45027dde2be5bdd0cab522b80632717d sha1 65f4a708e6af565f1f75d0fbdc8942cb149cf299 )
+)
+
+game (
+	name "Super Baseball (USA)"
+	description "Super Baseball (USA)"
+	rom ( name "Super Baseball (USA).a26" size 16384 crc c3704b73 md5 0751f342ee4cf28f2c9a6e8467c901be sha1 4c83731258126ecc7044155d17995601109a6f69 )
+)
+
+game (
+	name "Super Breakout (USA)"
+	description "Super Breakout (USA)"
+	rom ( name "Super Breakout (USA).a26" size 4096 crc b0f20d31 md5 8885d0ce11c5b40c3a8a8d9ed28cefef sha1 ac2aad2196c155c1d87d6f42fa88891825f4fde6 )
+)
+
+game (
+	name "Super Challenge Baseball (USA)"
+	description "Super Challenge Baseball (USA)"
+	rom ( name "Super Challenge Baseball (USA).a26" size 4096 crc f7e88ec2 md5 9d37a1be4a6e898026414b8fee2fc826 sha1 dfce4d6436f91d8d385f8b01f0d8e3488400407b )
+)
+
+game (
+	name "Super Challenge Football (USA)"
+	description "Super Challenge Football (USA)"
+	rom ( name "Super Challenge Football (USA).a26" size 4096 crc 55f02efe md5 e275cbe7d4e11e62c3bfcfb38fca3d49 sha1 5c1338ec76828cfa4a85b5bd8db1c00c8095c330 )
+)
+
+game (
+	name "Super Cobra (USA)"
+	description "Super Cobra (USA)"
+	rom ( name "Super Cobra (USA).a26" size 8192 crc de97103d md5 c29f8db680990cb45ef7fef6ab57a2c2 sha1 bac0a0256509f8fd1feea93d74ba4c7d82c1edc6 )
+)
+
+game (
+	name "Super Football (USA)"
+	description "Super Football (USA)"
+	rom ( name "Super Football (USA).a26" size 16384 crc c9b16f3c md5 09abfe9a312ce7c9f661582fdf12eab6 sha1 eaca6b474fd552ab4aaf75526618828165a91934 )
+)
+
+game (
+	name "Superman (USA)"
+	description "Superman (USA)"
+	rom ( name "Superman (USA).a26" size 4096 crc afd7317b md5 5de8803a59c36725888346fdc6e7429d sha1 f00bcbda3d70c0c93026234fc775daf81db8569a )
+)
+
+game (
+	name "Surf's Up (USA) (Proto)"
+	description "Surf's Up (USA) (Proto)"
+	rom ( name "Surf's Up (USA) (Proto).a26" size 8192 crc 0cfd04d9 md5 aec9b885d0e8b24e871925630884095c sha1 cf84e21ada55730d689cfac7d26e2295317222bc )
+)
+
+game (
+	name "Surfer's Paradise - But Danger Below! (Europe)"
+	description "Surfer's Paradise - But Danger Below! (Europe)"
+	rom ( name "Surfer's Paradise - But Danger Below! (Europe).a26" size 4096 crc 8c68f2ae md5 c20f15282a1aa8724d70c117e5c9709e sha1 e754c8985ca7f5780c23a856656099b710e89919 )
+)
+
+game (
+	name "Surround - Chase (USA)"
+	description "Surround - Chase (USA)"
+	rom ( name "Surround - Chase (USA).a26" size 2048 crc dcb11f23 md5 4d7517ae69f95cfbc053be01312b7dba sha1 b7988373b81992d08056560d15d3e32d9d3888bc )
+)
+
+game (
+	name "Survival Island (USA)"
+	description "Survival Island (USA)"
+	rom ( name "Survival Island (USA).a26" size 25344 crc 8ab91d6b md5 045035f995272eb2deb8820111745a07 sha1 40808b7a653610359d38a0b5e84d3018edbd0f99 )
+)
+
+game (
+	name "Survival Run (USA) (Proto)"
+	description "Survival Run (USA) (Proto)"
+	rom ( name "Survival Run (USA) (Proto).a26" size 4096 crc 8e888f3e md5 59e53894b3899ee164c91cfa7842da66 sha1 bcde63585092f84e437dd57f83bd67bd66b15646 )
+)
+
+game (
+	name "Survival Run (USA)"
+	description "Survival Run (USA)"
+	rom ( name "Survival Run (USA).a26" size 4096 crc 8c0eea30 md5 85e564dae5687e431955056fbda10978 sha1 6c993b4c70cfed390f1f436fdbaa1f81495be18e )
+)
+
+game (
+	name "Sweat! The Decathalon Game (USA)"
+	description "Sweat! The Decathalon Game (USA)"
+	rom ( name "Sweat! The Decathalon Game (USA).a26" size 16896 crc f24b44e3 md5 e51c23389e43ab328ccfb05be7d451da sha1 d786e27062623b1141806170187040a0280cc19d )
+)
+
+game (
+	name "Sword of Saros (USA)"
+	description "Sword of Saros (USA)"
+	rom ( name "Sword of Saros (USA).a26" size 8448 crc d96a3632 md5 528400fad9a77fd5ad7fc5fdc2b7d69d sha1 45ab6ae206f86524e31815a736a90287cca94b70 )
+)
+
+game (
+	name "Swordfight (USA)"
+	description "Swordfight (USA)"
+	rom ( name "Swordfight (USA).a26" size 4096 crc f1ad77be md5 87662815bc4f3c3c86071dc994e3f30e sha1 0d59545b22e15019a33de16999a57dae1f998283 )
+)
+
+game (
+	name "SwordQuest - EarthWorld (USA)"
+	description "SwordQuest - EarthWorld (USA)"
+	rom ( name "SwordQuest - EarthWorld (USA).a26" size 8192 crc 9031a479 md5 5aea9974b975a6a844e6df10d2b861c4 sha1 3deb650ae26b86e250aea8f7ca6d0674e6498ebb )
+)
+
+game (
+	name "SwordQuest - FireWorld (USA)"
+	description "SwordQuest - FireWorld (USA)"
+	rom ( name "SwordQuest - FireWorld (USA).a26" size 8192 crc 6ae46a0c md5 f9d51a4e5f8b48f68770c89ffd495ed1 sha1 5c3cf976edbea5ded66634a284787f965616d97e )
+)
+
+game (
+	name "SwordQuest - WaterWorld (USA)"
+	description "SwordQuest - WaterWorld (USA)"
+	rom ( name "SwordQuest - WaterWorld (USA).a26" size 8192 crc ca7b4685 md5 bc5389839857612cfabeb810ba7effdc sha1 569fcb67ca1674b48e2f3a2e7af7077a374402de )
+)
+
+game (
+	name "Tac-Scan (USA)"
+	description "Tac-Scan (USA)"
+	rom ( name "Tac-Scan (USA).a26" size 4096 crc a2a42bec md5 d45ebf130ed9070ea8ebd56176e48a38 sha1 55e98fe14b07460734781a6aa2f4f1646830c0af )
+)
+
+game (
+	name "Tapeworm (USA)"
+	description "Tapeworm (USA)"
+	rom ( name "Tapeworm (USA).a26" size 4096 crc d63474b3 md5 de3d0e37729d85afcb25a8d052a6e236 sha1 ee8bc1710a67c33e9f95bb05cc3d8f841093fde2 )
+)
+
+game (
+	name "Tapper (USA)"
+	description "Tapper (USA)"
+	rom ( name "Tapper (USA).a26" size 8192 crc d28afb2c md5 c0d2434348de72fa6edcc6d8e40f28d7 sha1 e986e1818e747beb9b33ce4dff1cdc6b55bdb620 )
+)
+
+game (
+	name "Tax Avoiders (USA)"
+	description "Tax Avoiders (USA)"
+	rom ( name "Tax Avoiders (USA).a26" size 8192 crc 468d734c md5 a1ead9c181d67859aa93c44e40f1709c sha1 7aaf6be610ba6ea1205bdd5ed60838ccb8280d57 )
+)
+
+game (
+	name "Taz (USA)"
+	description "Taz (USA)"
+	rom ( name "Taz (USA).a26" size 8192 crc c9d7ec9b md5 7574480ae2ab0d282c887e9015fdb54c sha1 fa4aee79487036656aabb432d7c6e13ec21e3a3c )
+)
+
+game (
+	name "Telepathy (USA) (Proto)"
+	description "Telepathy (USA) (Proto)"
+	rom ( name "Telepathy (USA) (Proto).a26" size 8192 crc a0996a0d md5 3d7aad37c55692814211c8b590a0334c sha1 7efc0ebe334dde84e25fa020ecde4fddcbea9e8f )
+)
+
+game (
+	name "Tempest (USA) (Proto)"
+	description "Tempest (USA) (Proto)"
+	rom ( name "Tempest (USA) (Proto).a26" size 8192 crc 711647f6 md5 c830f6ae7ee58bcc2a6712fb33e92d55 sha1 bf4d570c1c738a4d6d00237e25c62e9c3225f98f )
+)
+
+game (
+	name "Tennis (USA)"
+	description "Tennis (USA)"
+	rom ( name "Tennis (USA).a26" size 2048 crc 0a42515b md5 42cdd6a9e42a3639e190722b8ea3fc51 sha1 3d30e7ed617168d852923def2000c9c0a8b728c6 )
+)
+
+game (
+	name "Texas Chainsaw Massacre, The (USA) (Proto)"
+	description "Texas Chainsaw Massacre, The (USA) (Proto)"
+	rom ( name "Texas Chainsaw Massacre, The (USA) (Proto).a26" size 4096 crc ec389caa md5 5eeb81292992e057b290a5cd196f155d sha1 717122a4184bc8db41e65ab7c369c40b21c048d9 )
+)
+
+game (
+	name "Threshold (USA)"
+	description "Threshold (USA)"
+	rom ( name "Threshold (USA).a26" size 4096 crc ce5097fd md5 e63a87c231ee9a506f9599aa4ef7dfb9 sha1 9a52fa88bd7455044f00548e9615452131d1c711 )
+)
+
+game (
+	name "Thunderground (USA)"
+	description "Thunderground (USA)"
+	rom ( name "Thunderground (USA).a26" size 4096 crc 9e67c699 md5 cf507910d6e74568a68ac949537bccf9 sha1 3cc8bcc0ff5164303433f469aa4da2eb256d1ad0 )
+)
+
+game (
+	name "Thwocker (USA) (Proto)"
+	description "Thwocker (USA) (Proto)"
+	rom ( name "Thwocker (USA) (Proto).a26" size 8192 crc b60ab310 md5 c032c2bd7017fdfbba9a105ec50f800e sha1 53ee70d4b35ee3df3ffb95fa360bddb4f2f56ab2 )
+)
+
+game (
+	name "Time Pilot (USA)"
+	description "Time Pilot (USA)"
+	rom ( name "Time Pilot (USA).a26" size 8192 crc 21ee7db4 md5 fc2104dd2dadf9a6176c1c1c8f87ced9 sha1 387358514964d0b6b55f9431576a59b55869f7ab )
+)
+
+game (
+	name "Time Warp (Europe)"
+	description "Time Warp (Europe)"
+	rom ( name "Time Warp (Europe).a26" size 4096 crc 551e2144 md5 d6d1ddd21e9d17ea5f325fa09305069c sha1 594db913e27509fe244c5c900b5dbf5991d19a3e )
+)
+
+game (
+	name "Title Match Pro Wrestling (USA)"
+	description "Title Match Pro Wrestling (USA)"
+	rom ( name "Title Match Pro Wrestling (USA).a26" size 8192 crc ef708c03 md5 12123b534bdee79ed7563b9ad74f1cbd sha1 979d9b0b0f32b40c0a0568be65a0bc5ef36ca6d0 )
+)
+
+game (
+	name "Tomarc the Barbarian (USA)"
+	description "Tomarc the Barbarian (USA)"
+	rom ( name "Tomarc the Barbarian (USA).a26" size 8192 crc b5b5ac84 md5 32dcd1b535f564ee38143a70a8146efe sha1 489c9b572535721a0516a2b759e0b9c7f7a5b3cc )
+)
+
+game (
+	name "Tomcat - The F-14 Fighter Simulator (USA)"
+	description "Tomcat - The F-14 Fighter Simulator (USA)"
+	rom ( name "Tomcat - The F-14 Fighter Simulator (USA).a26" size 16384 crc 8987c473 md5 3ac6c50a8e62d4ce71595134cbd8035e sha1 5b2742281fea96ab6a3a2f30e676352bcf424390 )
+)
+
+game (
+	name "Tooth Protectors (USA)"
+	description "Tooth Protectors (USA)"
+	rom ( name "Tooth Protectors (USA).a26" size 8192 crc fd8c81e5 md5 fa2be8125c3c60ab83e1c0fe56922fcb sha1 d82ac7237df54cc8688e3074b58433a7dd6b7d11 )
+)
+
+game (
+	name "Towering Inferno (USA)"
+	description "Towering Inferno (USA)"
+	rom ( name "Towering Inferno (USA).a26" size 4096 crc 2c7b86b8 md5 0aa208060d7c140f20571e3341f5a3f8 sha1 b344b3e042447afbb3e40292dc4ca063d5d1110d )
+)
+
+game (
+	name "Track and Field (USA)"
+	description "Track and Field (USA)"
+	rom ( name "Track and Field (USA).a26" size 16384 crc 21827056 md5 6ae4dc6d7351dacd1012749ca82f9a56 sha1 005a6a53f5a856f0bdbca519af1ef236aaa1494d )
+)
+
+game (
+	name "Treasure Below (Europe)"
+	description "Treasure Below (Europe)"
+	rom ( name "Treasure Below (Europe).a26" size 4096 crc d2cea797 md5 66706459e62514d0c39c3797cbf73ff1 sha1 9a9917d82362c77b4d396f56966219fc248edf47 )
+)
+
+game (
+	name "Treasure Island ~ Duck Shoot (Europe)"
+	description "Treasure Island ~ Duck Shoot (Europe)"
+	rom ( name "Treasure Island ~ Duck Shoot (Europe).a26" size 4096 crc 907f1d90 md5 1bb91bae919ddbd655fa25c54ea6f532 sha1 d1437e291fbc1927fcce14abc21a58a423e15368 )
+)
+
+game (
+	name "Trick Shot (USA)"
+	description "Trick Shot (USA)"
+	rom ( name "Trick Shot (USA).a26" size 4096 crc d1ce4634 md5 24df052902aa9de21c2b2525eb84a255 sha1 86c563db11db9afbffbd73c55e9fae9b2f69be4f )
+)
+
+game (
+	name "TRON - Deadly Discs (USA)"
+	description "TRON - Deadly Discs (USA)"
+	rom ( name "TRON - Deadly Discs (USA).a26" size 4096 crc d35b22f9 md5 fb27afe896e7c928089307b32e5642ee sha1 0ec58a3a5a27d1b82a5f9aabab02f9a8387b6956 )
+)
+
+game (
+	name "Tunnel de L'Estace, Le (Europe)"
+	description "Tunnel de L'Estace, Le (Europe)"
+	rom ( name "Tunnel de L'Estace, Le (Europe).a26" size 4096 crc 28bc5a4d md5 d73ad614f1c2357997c88f37e75b18fe sha1 9a2c8ab7a3d0a4dfa18fc14f31a4082c3958db71 )
+)
+
+game (
+	name "Tunnel Runner (USA)"
+	description "Tunnel Runner (USA)"
+	rom ( name "Tunnel Runner (USA).a26" size 12288 crc a02745f8 md5 b2737034f974535f5c0c6431ab8caf73 sha1 fc1a0b58765a7dcbd8e33562e1074ddd9e0ac624 )
+)
+
+game (
+	name "Turmoil (USA)"
+	description "Turmoil (USA)"
+	rom ( name "Turmoil (USA).a26" size 4096 crc 8c65298a md5 7a5463545dfb2dcfdafa6074b2f2c15e sha1 1162fe46977f01b4d25efab813e0d05ec90aeadc )
+)
+
+game (
+	name "Tutankham (USA)"
+	description "Tutankham (USA)"
+	rom ( name "Tutankham (USA).a26" size 8192 crc ec959bf2 md5 085322bae40d904f53bdcc56df0593fc sha1 a4d6bac854a70d2c55946932f1511cc62db7d4aa )
+)
+
+game (
+	name "Universal Chaos (USA)"
+	description "Universal Chaos (USA)"
+	rom ( name "Universal Chaos (USA).a26" size 4096 crc 25efa169 md5 81a010abdba1a640f7adf7f84e13d307 sha1 286106fb973530bc3e2af13240f28c4bcb37e642 )
+)
+
+game (
+	name "Unknown 20th Century Fox Game (USA) (Proto)"
+	description "Unknown 20th Century Fox Game (USA) (Proto)"
+	rom ( name "Unknown 20th Century Fox Game (USA) (Proto).a26" size 8192 crc 0748817d md5 5f950a2d1eb331a1276819520705df94 sha1 3da6a2cc699945f708dac4e880ff6e085c635bbd )
+)
+
+game (
+	name "Unknown Activision Game #1 (USA) (Proto)"
+	description "Unknown Activision Game #1 (USA) (Proto)"
+	rom ( name "Unknown Activision Game #1 (USA) (Proto).a26" size 4096 crc 6b0672a6 md5 ee681f566aad6c07c61bbbfc66d74a27 sha1 d93c86970d3df29326acc35c0ce6679b83c2aff2 )
+)
+
+game (
+	name "Unknown Activision Game #2 (USA) (Proto)"
+	description "Unknown Activision Game #2 (USA) (Proto)"
+	rom ( name "Unknown Activision Game #2 (USA) (Proto).a26" size 4096 crc 5c009ea0 md5 700a786471c8a91ec09e2f8e47f14a04 sha1 a25c4b33e1c86895cb63635bd6ca5b8379a206b3 )
+)
+
+game (
+	name "Unknown Datatech Game (USA)"
+	description "Unknown Datatech Game (USA)"
+	rom ( name "Unknown Datatech Game (USA).a26" size 4096 crc 95c37983 md5 73e66e82ac22b305eb4d9578e866236e sha1 5112edc18885b2fbde4adc2111176c87b41f0352 )
+)
+
+game (
+	name "Up 'n Down (USA)"
+	description "Up 'n Down (USA)"
+	rom ( name "Up 'n Down (USA).a26" size 8192 crc c04c2b58 md5 a499d720e7ee35c62424de882a3351b6 sha1 6bde671a50330af154ed15e73fdba3fa55f23d87 )
+)
+
+game (
+	name "Vanguard (USA)"
+	description "Vanguard (USA)"
+	rom ( name "Vanguard (USA).a26" size 8192 crc c4bec521 md5 c6556e082aac04260596b4045bc122de sha1 01475d037cb7a2a892be09d67083102fa9159216 )
+)
+
+game (
+	name "Vault Assault (USA) (Unl)"
+	description "Vault Assault (USA) (Unl)"
+	rom ( name "Vault Assault (USA) (Unl).a26" size 4096 crc 856a6efb md5 787ebc2609a31eb5c57c4a18837d1aee sha1 dce98883e813d77e03a5de975d4c52bfb34e7f77 )
+)
+
+game (
+	name "Venetian Blinds Demo (USA)"
+	description "Venetian Blinds Demo (USA)"
+	rom ( name "Venetian Blinds Demo (USA).a26" size 2048 crc 1f0d3562 md5 d08fccfbebaa531c4a4fa7359393a0a9 sha1 81f485b545445080e009adf0f2e93dd4f16b92ce )
+)
+
+game (
+	name "Venture (USA)"
+	description "Venture (USA)"
+	rom ( name "Venture (USA).a26" size 4096 crc 85e0ca62 md5 3e899eba0ca8cd2972da1ae5479b4f0d sha1 0305dfc99bf192e53452a1e0408ccc148940afcd )
+)
+
+game (
+	name "Video Checkers - Checkers (USA)"
+	description "Video Checkers - Checkers (USA)"
+	rom ( name "Video Checkers - Checkers (USA).a26" size 4096 crc 3df33335 md5 539d26b6e9df0da8e7465f0f5ad863b7 sha1 babae88a832b76d8c5af6ea63b8f10a0da5bb992 )
+)
+
+game (
+	name "Video Chess (USA)"
+	description "Video Chess (USA)"
+	rom ( name "Video Chess (USA).a26" size 4096 crc b6226a54 md5 f0b7db930ca0e548c41a97160b9f6275 sha1 043ef523e4fcb9fc2fc2fda21f15671bf8620fc3 )
+)
+
+game (
+	name "Video Jogger (USA)"
+	description "Video Jogger (USA)"
+	rom ( name "Video Jogger (USA).a26" size 4096 crc 28fa8d77 md5 4191b671bcd8237fc8e297b4947f2990 sha1 1554b146d076b64776bf49136cea01f60eeba4c1 )
+)
+
+game (
+	name "Video Life (USA)"
+	description "Video Life (USA)"
+	rom ( name "Video Life (USA).a26" size 2048 crc 34b0b5c2 md5 497f3d2970c43e5224be99f75e97cbbb sha1 3b18db73933747851eba9a0ffa3c12b9f602a95c )
+)
+
+game (
+	name "Video Olympics - Pong Sports (USA)"
+	description "Video Olympics - Pong Sports (USA)"
+	rom ( name "Video Olympics - Pong Sports (USA).a26" size 2048 crc e4bc89c4 md5 60e0ea3cbe0913d39803477945e9e5ec sha1 1ffe89d79d55adabc0916b95cc37e18619ef7830 )
+)
+
+game (
+	name "Video Pinball - Arcade Pinball (USA)"
+	description "Video Pinball - Arcade Pinball (USA)"
+	rom ( name "Video Pinball - Arcade Pinball (USA).a26" size 4096 crc 10d95426 md5 107cc025334211e6d29da0b6be46aec7 sha1 2c16c1a6374c8e22275d152d93dd31ffba26271f )
+)
+
+game (
+	name "Video Reflex (USA)"
+	description "Video Reflex (USA)"
+	rom ( name "Video Reflex (USA).a26" size 4096 crc 77b8b0d1 md5 ee659ae50e9df886ac4f8d7ad10d046a sha1 dec2a3e9b366dce2b63dc1c13662d3f22420a22e )
+)
+
+game (
+	name "Wabbit (USA)"
+	description "Wabbit (USA)"
+	rom ( name "Wabbit (USA).a26" size 4096 crc 2d07ed77 md5 6041f400b45511aa3a69fab4b8fc8f41 sha1 73072295721453065d62d9136343b81310a4d225 )
+)
+
+game (
+	name "Walker ~ Schussel Der Polizistenschreck (Europe)"
+	description "Walker ~ Schussel Der Polizistenschreck (Europe)"
+	rom ( name "Walker ~ Schussel Der Polizistenschreck (Europe).a26" size 4096 crc da8e49fb md5 7ff53f6922708119e7bf478d7d618c86 sha1 25e2043775a08762e3fc98ecb96fbf46b20e860e )
+)
+
+game (
+	name "Wall Ball (USA)"
+	description "Wall Ball (USA)"
+	rom ( name "Wall Ball (USA).a26" size 4096 crc 9ac6a295 md5 d3456b4cf1bd1a7b8fb907af1a80ee15 sha1 482bd349222b8c702e125c27fd516e73af13967b )
+)
+
+game (
+	name "Wall Break (Europe)"
+	description "Wall Break (Europe)"
+	rom ( name "Wall Break (Europe).a26" size 4096 crc 727408cd md5 372bddf113d088bc572f94e98d8249f5 sha1 6ef3c2e8bb0d361d5a99afd95f4e29a69b61bc4a )
+)
+
+game (
+	name "Warlords (USA)"
+	description "Warlords (USA)"
+	rom ( name "Warlords (USA).a26" size 4096 crc cf174b57 md5 cbe5a166550a8129a5e6d374901dffad sha1 2d7563d337cbc0cdf4fc14f69853ab6757697788 )
+)
+
+game (
+	name "Warplock (USA)"
+	description "Warplock (USA)"
+	rom ( name "Warplock (USA).a26" size 4096 crc 6531d4e1 md5 679e910b27406c6a2072f9569ae35fc8 sha1 232a370519a7fcce121e15f850d0d3671909f8b8 )
+)
+
+game (
+	name "Wing War (Europe)"
+	description "Wing War (Europe)"
+	rom ( name "Wing War (Europe).a26" size 8192 crc cfebef9e md5 4e02880beeb8dbd4da724a3f33f0971f sha1 1ce2426a1a71ebac81709c88eb30e461b29158e2 )
+)
+
+game (
+	name "Wings (USA) (Proto)"
+	description "Wings (USA) (Proto)"
+	rom ( name "Wings (USA) (Proto).a26" size 12288 crc 5e89b8af md5 8e48ea6ea53709b98e6f4bd8aa018908 sha1 419e7dd24c810afb8b8e555ed8489853b0bf05d8 )
+)
+
+game (
+	name "Winter Games (USA)"
+	description "Winter Games (USA)"
+	rom ( name "Winter Games (USA).a26" size 16384 crc ddff6850 md5 83fafd7bd12e3335166c6314b3bde528 sha1 6850d329e8ab403bdae38850665a2eff91278e92 )
+)
+
+game (
+	name "Wizard (USA) (Proto)"
+	description "Wizard (USA) (Proto)"
+	rom ( name "Wizard (USA) (Proto).a26" size 2048 crc a0bcc502 md5 7b24bfe1b61864e758ada1fe9adaa098 sha1 2499ce7c77536b2920753968135f9180bd9afe6e )
+)
+
+game (
+	name "Wizard of Wor (USA)"
+	description "Wizard of Wor (USA)"
+	rom ( name "Wizard of Wor (USA).a26" size 4096 crc 926f6f11 md5 7e8aa18bc9502eb57daaf5e7c1e94da7 sha1 326e5e63a54ec6a0231fd38e62e352004d4719fe )
+)
+
+game (
+	name "Word Zapper (USA)"
+	description "Word Zapper (USA)"
+	rom ( name "Word Zapper (USA).a26" size 4096 crc a11eeeab md5 ec3beb6d8b5689e867bafb5d5f507491 sha1 806c5a8a7b042a1a3ada1b6f29451a3446f93da3 )
+)
+
+game (
+	name "Words-Attack (Europe) (Proto)"
+	description "Words-Attack (Europe) (Proto)"
+	rom ( name "Words-Attack (Europe) (Proto).a26" size 4096 crc 77975baa md5 2facd460a6828e0e476d3ac4b8c5f4f7 sha1 84f4b60f351f23e664613ac3d155bb354b800cd5 )
+)
+
+game (
+	name "World End (Europe)"
+	description "World End (Europe)"
+	rom ( name "World End (Europe).a26" size 4096 crc dcc36508 md5 130c5742cd6cbe4877704d733d5b08ca sha1 0e981d6baa7e3e218608eb46ad51fb30675babac )
+)
+
+game (
+	name "Worm War I (USA)"
+	description "Worm War I (USA)"
+	rom ( name "Worm War I (USA).a26" size 4096 crc 97b83a54 md5 87f020daa98d0132e98e43db7d8fea7e sha1 36a1e73eb5aa5c3cd0b01af5117d19b8c36071e4 )
+)
+
+game (
+	name "X-Man (USA)"
+	description "X-Man (USA)"
+	rom ( name "X-Man (USA).a26" size 4096 crc 91659af1 md5 5961d259115e99c30b64fe7058256bcf sha1 1c5d151e86c0a0bbdf3b33ef153888c6be78c36b )
+)
+
+game (
+	name "Xenophobe (USA)"
+	description "Xenophobe (USA)"
+	rom ( name "Xenophobe (USA).a26" size 16384 crc f875c406 md5 eaf744185d5e8def899950ba7c6e7bb5 sha1 160b6e36437ad6acbc2686fbde1002e2fa88c5fb )
+)
+
+game (
+	name "Xevious (USA) (Proto)"
+	description "Xevious (USA) (Proto)"
+	rom ( name "Xevious (USA) (Proto).a26" size 8192 crc 2ef09f4a md5 c6688781f4ab844852f4e3352772289b sha1 73133b81196e5cbc1cec99eefc1223ddb8f4ca83 )
+)
+
+game (
+	name "Yahtzee (USA)"
+	description "Yahtzee (USA)"
+	rom ( name "Yahtzee (USA).a26" size 4096 crc 5c93f4d0 md5 d090836f0a4ea8db9ac7abb7d6adf61e sha1 6a1e0142c6886a6589a58e029e5aec6b72f7d27f )
+)
+
+game (
+	name "Yars' Revenge (USA)"
+	description "Yars' Revenge (USA)"
+	rom ( name "Yars' Revenge (USA).a26" size 4096 crc dfa1c825 md5 c5930d0e8cdae3e037349bfa08e871be sha1 e2cd8996c1cf929e29130690024d1ec23d3b0bde )
+)
+
+game (
+	name "Zaxxon (USA)"
+	description "Zaxxon (USA)"
+	rom ( name "Zaxxon (USA).a26" size 8192 crc 265aa87f md5 eea0da9b987d661264cce69a7c13c3bd sha1 58c2f6abc5599cd35c0e722f24bcc128ac8f9a30 )
+)
+
+game (
+	name "Zoo Fun (USA)"
+	description "Zoo Fun (USA)"
+	rom ( name "Zoo Fun (USA).a26" size 4096 crc c1da05f6 md5 fb833ed50c865a9a505a125fc9d79a7e sha1 feb6bd37e5d722bd080433587972b980afff5fa5 )
+)
+
+game (
+	name "Zoo Keeper Sounds (USA) (Proto)"
+	description "Zoo Keeper Sounds (USA) (Proto)"
+	rom ( name "Zoo Keeper Sounds (USA) (Proto).a26" size 2048 crc ae15c45d md5 a336beac1f0a835614200ecd9c41fd70 sha1 7f115cb41fc70889b933fd2c808044a2b6367261 )
+)


### PR DESCRIPTION
[No-Intro](http://datomatic.no-intro.org/) now ships a Atari 2600 DAT. It's still young, and they're still adding entries, but it's a good start. Has a few extra from ours, and a few less. We can keep both for now.