### PR TITLE
Update NEC - PC Engine SuperGrafx

### DIFF
--- a/dat/NEC - PC Engine SuperGrafx.dat
+++ b/dat/NEC - PC Engine SuperGrafx.dat
@@ -1,1 +1,0 @@
-../metadat/no-intro/NEC - SuperGrafx.dat

--- a/metadat/no-intro/NEC - PC Engine SuperGrafx.dat
+++ b/metadat/no-intro/NEC - PC Engine SuperGrafx.dat
@@ -1,6 +1,6 @@
 clrmamepro (
-	name "NEC - SuperGrafx"
-	description "NEC - SuperGrafx"
+	name "NEC - PC Engine SuperGrafx"
+	description "NEC - PC Engine SuperGrafx"
 	version 20161023-001148
 	comment "no-intro | www.no-intro.org"
 )


### PR DESCRIPTION
No-Intro now uses the correct naming for "NEC - PC Engine SuperGrafx".