### PR TITLE
Update No-Intro Nintendo 64

### DIFF
--- a/metadat/no-intro/Nintendo - Nintendo 64.dat
+++ b/metadat/no-intro/Nintendo - Nintendo 64.dat
@@ -1,7 +1,7 @@
 clrmamepro (
-	name "Nintendo - Nintendo 64"
-	description "Nintendo - Nintendo 64"
-	version 20160812-141326
+	name "Nintendo - Nintendo 64 Byte Swapped"
+	description "Nintendo - Nintendo 64 Byte Swapped"
+	version 20161208-034823
 	comment "no-intro | www.no-intro.org"
 )
 
@@ -2826,9 +2826,9 @@ game (
 )
 
 game (
-	name "Mini Racers (USA) (Proto)"
-	description "Mini Racers (USA) (Proto)"
-	rom ( name "Mini Racers (USA) (Proto).n64" size 16777216 crc CF4C80B0 md5 036D9A9533C89CEFE1032BAE54A21B82 sha1 AC093F0BBEC0893E942DA322318F54268834C10B )
+	name "Mini Racers (USA) (Ja) (Proto)"
+	description "Mini Racers (USA) (Ja) (Proto)"
+	rom ( name "Mini Racers (USA) (Ja) (Proto).n64" size 16777216 crc CF4C80B0 md5 036D9A9533C89CEFE1032BAE54A21B82 sha1 AC093F0BBEC0893E942DA322318F54268834C10B )
 )
 
 game (
@@ -5699,4 +5699,3 @@ game (
 	description "Zool - Majuu Tsukai Densetsu (Japan)"
 	rom ( name "Zool - Majuu Tsukai Densetsu (Japan).n64" size 12582912 crc 84428431 md5 9795074EF3192F49ADE9ABC9F0BF71D0 sha1 DEF9F1D097CEF5857449827AE2B1291BA346C2A8 flags verified )
 )
-


### PR DESCRIPTION
Allows us to clarify that the DAT is the Byte-Swapped set.