### PR TITLE
Add Phillips - Videopac+ BIOSes to the Merged DAT

### DIFF
--- a/dat/BIOS - Merged.dat
+++ b/dat/BIOS - Merged.dat
@@ -94,9 +94,9 @@ game (
 	rom ( name st018.program.rom size 131072 crc f73d5e10 md5 dda40ccd57390c96e49d30a041f9a9e7 sha1 388e3721b94cd074d6ba0eca8616523d2118a6c3 )
 
 	comment "Phillips - Videopac+"
-	rom (name c52.bin crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
-	rom (name g7400.bin crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
-	rom (name jopac.bin crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )
+	rom (name c52.bin size 1024 crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
+	rom (name g7400.bin size 1024 crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
+	rom (name jopac.bin size 1024 crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )
 	
 	comment "Sega - Dreamcast"
 	rom ( name dc_boot.bin size 2097152 crc 89f2b1a1 md5 e10c53c2f8b90bab96ead2d368858623 sha1 8951d1bb219ab2ff8583033d2119c899cc81f18c )

--- a/dat/BIOS - Merged.dat
+++ b/dat/BIOS - Merged.dat
@@ -93,6 +93,11 @@ game (
 	rom ( name st018.data.rom size 32768 crc b5255459 md5 49c898b60d0f15e90d0ba780dd12f366 sha1 b19c0f8f207d62fdabf4bf71442826063bccc626 )
 	rom ( name st018.program.rom size 131072 crc f73d5e10 md5 dda40ccd57390c96e49d30a041f9a9e7 sha1 388e3721b94cd074d6ba0eca8616523d2118a6c3 )
 
+	comment "Phillips - Videopac+"
+	rom (name c52.bin crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
+	rom (name g7400.bin crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
+	rom (name jopac.bin crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )
+	
 	comment "Sega - Dreamcast"
 	rom ( name dc_boot.bin size 2097152 crc 89f2b1a1 md5 e10c53c2f8b90bab96ead2d368858623 sha1 8951d1bb219ab2ff8583033d2119c899cc81f18c )
 	rom ( name dc_flash.bin size 131072 crc c611b498 md5 0a93f7940c455905bea6e392dfde92a4 sha1 94d44d7f9529ec1642ba3771ed3c5f756d5bc872 )


### PR DESCRIPTION
Some discussion here: https://github.com/libretro/libretro-database/issues/383#issuecomment-271105374

There is a separate PR to add these to the Non-Merged DAT