### PR TITLE
Update PC-FX BIOS info in Non-Merged DAT

### DIFF
--- a/dat/BIOS - Non-Merged.dat
+++ b/dat/BIOS - Non-Merged.dat
@@ -44,9 +44,9 @@ game (
 	name "Magnavox - Odyssey2"
 	rom ( name o2rom.bin size 1024 crc 8016a315 md5 562d5ebf9e030a40d6fabfc2f33139fd sha1 b2e1955d957a475de2411770452eff4ea19f4cee )
 	comment "Phillips - Videopac+"
-	rom (name c52.bin size 1024 crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
-	rom (name g7400.bin size 1024 crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
-	rom (name jopac.bin size 1024 crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )	
+	rom ( name c52.bin size 1024 crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
+	rom ( name g7400.bin size 1024 crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
+	rom ( name jopac.bin size 1024 crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )	
 )
 
 game (
@@ -70,11 +70,10 @@ game (
 
 game (
 	name "NEC - PC-FX"
+	rom ( name pcfx.rom size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name fx-scsi.rom size 524288 crc f3e60e5e md5 430e9745f9235c515bc8e652d6ca3004 sha1 65482a23ac5c10a6095aee1db5824cca54ead6e5 )
-	rom ( name pcfx.bios size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name pcfxbios.bin size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name pcfxv101.bin size 1048576 crc 236102c9 md5 e2fb7c7220e3a7838c2dd7e401a7f3d8 sha1 8b662f7548078be52a871565e19511ccca28c5c8 )
-	comment "NEC - PC-FX (incomplete)"
 	rom ( name pcfxga.rom size 1048576 crc 41c3776b sha1 a9372202a5db302064c994fcda9b24d29bb1b41c )
 )
 


### PR DESCRIPTION
This update reflects the PR earlier today that corrects the BIOS filename that the Beetle PC-FX core will search for: https://github.com/libretro/beetle-pcfx-libretro/pull/15

Also there is a whitespace tweak.