### PR TITLE
Update PC-FX BIOS info in Merged DAT

### DIFF
--- a/dat/BIOS - Merged.dat
+++ b/dat/BIOS - Merged.dat
@@ -44,11 +44,10 @@ game (
 	rom ( name syscard3.pce size 262656 crc 64f78e3c md5 ff1a674273fe3540ccef576376407d1d sha1 1b4c260326d905bc718812dad0f68089977f427b )
 
 	comment "NEC - PC-FX"
+	rom ( name pcfx.rom size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name fx-scsi.rom size 524288 crc f3e60e5e md5 430e9745f9235c515bc8e652d6ca3004 sha1 65482a23ac5c10a6095aee1db5824cca54ead6e5 )
-	rom ( name pcfx.bios size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name pcfxbios.bin size 1048576 crc 76ffb97a md5 08e36edbea28a017f79f8d4f7ff9b6d7 sha1 1a77fd83e337f906aecab27a1604db064cf10074 )
 	rom ( name pcfxv101.bin size 1048576 crc 236102c9 md5 e2fb7c7220e3a7838c2dd7e401a7f3d8 sha1 8b662f7548078be52a871565e19511ccca28c5c8 )
-	comment "NEC - PC-FX (incomplete)"
 	rom ( name pcfxga.rom size 1048576 crc 41c3776b sha1 a9372202a5db302064c994fcda9b24d29bb1b41c )
 
 	comment "Nintendo - Famicom Disk System"
@@ -94,9 +93,9 @@ game (
 	rom ( name st018.program.rom size 131072 crc f73d5e10 md5 dda40ccd57390c96e49d30a041f9a9e7 sha1 388e3721b94cd074d6ba0eca8616523d2118a6c3 )
 
 	comment "Phillips - Videopac+"
-	rom (name c52.bin size 1024 crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
-	rom (name g7400.bin size 1024 crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
-	rom (name jopac.bin size 1024 crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )
+	rom ( name c52.bin size 1024 crc a318e8d6 md5 f1071cdb0b6b10dde94d3bc8a6146387 sha1 a6120aed50831c9c0d95dbdf707820f601d9452e )
+	rom ( name g7400.bin size 1024 crc e20a9f41 md5 c500ff71236068e0dc0d0603d265ae76 sha1 5130243429b40b01a14e1304d0394b8459a6fbae )
+	rom ( name jopac.bin size 1024 crc 11647ca5 md5 279008e4a0db2dc5f1c048853b033828 sha1 54b8d2c1317628de51a85fc1c424423a986775e4 )
 	
 	comment "Sega - Dreamcast"
 	rom ( name dc_boot.bin size 2097152 crc 89f2b1a1 md5 e10c53c2f8b90bab96ead2d368858623 sha1 8951d1bb219ab2ff8583033d2119c899cc81f18c )


### PR DESCRIPTION
This update reflects the PR earlier today that corrects the BIOS filename that the Beetle PC-FX core will search for: https://github.com/libretro/beetle-pcfx-libretro/pull/15

Also there is a whitespace tweak.