### PR TITLE
Fix to use .scummvm launcher files

### DIFF
--- a/dat/ScummVM.dat
+++ b/dat/ScummVM.dat
@@ -2,16886 +2,3921 @@ clrmamepro (
 	name "ScummVM"
 	description "ScummVM"
 	comment "DAT file containing game files to launch ScummVM games from RetroArch."
-	category "ScummVM"
-	version "0.0.1"
-	author "Gruby"
-	homepage "http://github.com/RobLoach/libretro-scummvm.dat"
+	version 1.9.0
+	date "2017-01-14"
+	author "Rob Loach"
+	homepage https://github.com/libretro/scummvm
+	url https://github.com/RobLoach/libretro-scummvm.dat#readme
 )
 
 game (
-	name "1 1/2 Ritter (Demo/Windows/German)[Unk]"
-	description "1 1/2 Ritter (Demo/Windows/German)[Unk]"
-	rom ( name "data.dcp" size 99975952 crc d849b1f9 md5 408474b813553978880cf4f36cc38793 )
+	name "3 Skulls of the Toltecs"
+	description "3 Skulls of the Toltecs"
+	rom ( name "3 Skulls of the Toltecs.scummvm" size 7 crc db62a67 )
 )
 
 game (
-	name "11th Hour, The: The sequel to The 7th Guest (Demo/DOS)"
-	description "11th Hour, The: The sequel to The 7th Guest (Demo/DOS)"
-	rom ( name "BACK.RAW" size 25687 crc 31012dc8 md5 c336eafb982ceba8662571d42403c449 )
+	name "3 Skulls of the Toltecs"
+	description "3 Skulls of the Toltecs"
+	rom ( name "3 Skulls of the Toltecs CRLF.scummvm" size 9 crc e5a5bcac )
 )
 
 game (
-	name "11th Hour, The: The sequel to The 7th Guest (DOS)[!]"
-	description "11th Hour, The: The sequel to The 7th Guest (DOS)[!]"
-	rom ( name "DISK.1" size 227 crc dd0398ea md5 5c0428cd3659fc7bbcd0aa16485ed5da )
+	name "3 Skulls of the Toltecs"
+	description "3 Skulls of the Toltecs"
+	rom ( name "3 Skulls of the Toltecs LF.scummvm" size 8 crc e10c4442 )
 )
 
 game (
-	name "120 Degrees Below Zero (DOS/Fanmade)"
-	description "120 Degrees Below Zero (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 320749 crc 2556a73b md5 a4a8759a0a8694a6563450e89765b4ba )
+	name "3 Skulls of the Toltecs"
+	description "3 Skulls of the Toltecs"
+	rom ( name "3 Skulls of the Toltecs CR.scummvm" size 8 crc 7f68d1e1 )
 )
 
 game (
-	name "13th Disciple, The (DOS/Fanmade v1.00)"
-	description "13th Disciple, The (DOS/Fanmade v1.00)"
-	rom ( name "LOGDIR" size 615 crc 4e398f15 md5 887719ad59afce9a41ec057dbb73ad73 )
+	name "Access"
+	description "Access"
+	rom ( name "Access.scummvm" size 6 crc 1c52e62 )
 )
 
 game (
-	name "13th Disciple, The (DOS/Fanmade v1.01)"
-	description "13th Disciple, The (DOS/Fanmade v1.01)"
-	rom ( name "LOGDIR" size 615 crc 0c186a8c md5 undefined )
+	name "Access"
+	description "Access"
+	rom ( name "Access CRLF.scummvm" size 8 crc 9fbf8083 )
 )
 
 game (
-	name "2 Player Demo (DOS/Fanmade)"
-	description "2 Player Demo (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc a697cc8a md5 4279f46b3cebd855132496476b1d2cca )
+	name "Access"
+	description "Access"
+	rom ( name "Access LF.scummvm" size 7 crc 916ac3c9 )
 )
 
 game (
-	name "3 Skulls of the Toltecs (Demo/DOS)"
-	description "3 Skulls of the Toltecs (Demo/DOS)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 904b04063ff4e04c8fc33576e41c68a9 )
+	name "Access"
+	description "Access"
+	rom ( name "Access CR.scummvm" size 7 crc f0e566a )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS)"
-	description "3 Skulls of the Toltecs (DOS)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 904b04063ff4e04c8fc33576e41c68a9 )
+	name "Amazon Guardians of Eden"
+	description "Amazon Guardians of Eden"
+	rom ( name "Amazon Guardians of Eden.scummvm" size 6 crc 815b8877 )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS/French)"
-	description "3 Skulls of the Toltecs (DOS/French)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 904b04063ff4e04c8fc33576e41c68a9 )
+	name "Amazon Guardians of Eden"
+	description "Amazon Guardians of Eden"
+	rom ( name "Amazon Guardians of Eden CRLF.scummvm" size 8 crc 97bfe0d4 )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS/German)"
-	description "3 Skulls of the Toltecs (DOS/German)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 undefined )
+	name "Amazon Guardians of Eden"
+	description "Amazon Guardians of Eden"
+	rom ( name "Amazon Guardians of Eden LF.scummvm" size 7 crc fc37b984 )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS/Hungarian)"
-	description "3 Skulls of the Toltecs (DOS/Hungarian)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 undefined )
+	name "Amazon Guardians of Eden"
+	description "Amazon Guardians of Eden"
+	rom ( name "Amazon Guardians of Eden CR.scummvm" size 7 crc 62532c27 )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS/Russian)"
-	description "3 Skulls of the Toltecs (DOS/Russian)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 904b04063ff4e04c8fc33576e41c68a9 )
+	name "Backyard Baseball"
+	description "Backyard Baseball"
+	rom ( name "Backyard Baseball.scummvm" size 8 crc 533f2feb )
 )
 
 game (
-	name "3 Skulls of the Toltecs (DOS/Spanish)"
-	description "3 Skulls of the Toltecs (DOS/Spanish)"
-	rom ( name "SAMPLE.AD" size 3242 crc 11cde28d md5 undefined )
+	name "Backyard Baseball"
+	description "Backyard Baseball"
+	rom ( name "Backyard Baseball CRLF.scummvm" size 10 crc 2f9c1ed )
 )
 
 game (
-	name "3rd Floor (Macintosh)"
-	description "3rd Floor (Macintosh)"
-	rom ( name "._3rd Floor" size 285319 crc d703a54f md5 ffd69b567bbda9018340d84343135a7e )
+	name "Backyard Baseball"
+	description "Backyard Baseball"
+	rom ( name "Backyard Baseball LF.scummvm" size 9 crc 55c024c )
 )
 
 game (
-	name "7th Guest, The (DOS)[GOG][!]"
-	description "7th Guest, The (DOS)[GOG][!]"
-	rom ( name "AT.GJD" size 45171574 crc 125816a4 md5 a24e6c5e22cfcf6d7653039e7256012a )
+	name "Backyard Baseball"
+	description "Backyard Baseball"
+	rom ( name "Backyard Baseball CR.scummvm" size 9 crc 9b3897ef )
 )
 
 game (
-	name "7th Guest, The (DOS/Russian)"
-	description "7th Guest, The (DOS/Russian)"
-	rom ( name "AT.GJD" size 46711897 crc undefined md5 undefined )
+	name "Backyard Baseball 2001"
+	description "Backyard Baseball 2001"
+	rom ( name "Backyard Baseball 2001.scummvm" size 12 crc 4946d1f9 )
 )
 
 game (
-	name "7th Guest, The (Macintosh)"
-	description "7th Guest, The (Macintosh)"
-	rom ( name "._T7GMac" size 1830912 crc 35889d61 md5 09a7c0d4938f9a416b0b45c1efce392d )
+	name "Backyard Baseball 2001"
+	description "Backyard Baseball 2001"
+	rom ( name "Backyard Baseball 2001 CRLF.scummvm" size 14 crc 2008745c )
 )
 
 game (
-	name "A Mess O' Trouble (Macintosh/v1.8)"
-	description "A Mess O' Trouble (Macintosh/v1.8)"
-	rom ( name "._A Mess O' Trouble 1.8" size 1895841 crc 1731c603 md5 4524ff8cfd0ad981e6b32b863ff0c298 )
+	name "Backyard Baseball 2001"
+	description "Backyard Baseball 2001"
+	rom ( name "Backyard Baseball 2001 LF.scummvm" size 13 crc f6ff0afa )
 )
 
 game (
-	name "A.J.'s World of Discovery (DOS)"
-	description "A.J.'s World of Discovery (DOS)"
-	rom ( name "INTRO.STK" size 3913628 crc 1d1c63d2 md5 undefined )
+	name "Backyard Baseball 2001"
+	description "Backyard Baseball 2001"
+	rom ( name "Backyard Baseball 2001 CR.scummvm" size 13 crc 689b9f59 )
 )
 
 game (
-	name "A.J.'s World of Discovery (DOS/Hebrew)"
-	description "A.J.'s World of Discovery (DOS/Hebrew)"
-	rom ( name "ADIBOU.IMD" size 191964 crc 4426f35e md5 f60881c9aef09b821a1d4d7e167595fc )
+	name "Backyard Baseball 2003"
+	description "Backyard Baseball 2003"
+	rom ( name "Backyard Baseball 2003.scummvm" size 12 crc bf796b2d )
 )
 
 game (
-	name "Abrah: L'orphelin de l'espace (DOS/Fanmade/French v1.2)"
-	description "Abrah: L'orphelin de l'espace (DOS/Fanmade/French v1.2)"
-	rom ( name "LOGDIR" size 756 crc ba1f2378 md5 undefined )
+	name "Backyard Baseball 2003"
+	description "Backyard Baseball 2003"
+	rom ( name "Backyard Baseball 2003 CRLF.scummvm" size 14 crc eee8d8ea )
 )
 
 game (
-	name "Acidopolis (DOS/Fanmade)"
-	description "Acidopolis (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc a621dd41 md5 7017db1a4b726d0d59e65e9020f7d9f7 )
+	name "Backyard Baseball 2003"
+	description "Backyard Baseball 2003"
+	rom ( name "Backyard Baseball 2003 LF.scummvm" size 13 crc 77b7238d )
 )
 
 game (
-	name "Actual Destination (Windows)"
-	description "Actual Destination (Windows)"
-	rom ( name "data.dcp" size 9081740 crc 0cdcbbbe md5 undefined )
+	name "Backyard Baseball 2003"
+	description "Backyard Baseball 2003"
+	rom ( name "Backyard Baseball 2003 CR.scummvm" size 13 crc e9d3b62e )
 )
 
 game (
-	name "ADI 2 (Demo/Non-Interactive/DOS/French)"
-	description "ADI 2 (Demo/Non-Interactive/DOS/French)"
-	rom ( name "DEMADI2T.VMD" size 7250723 crc 95b4b052 md5 undefined )
+	name "Backyard Basketball"
+	description "Backyard Basketball"
+	rom ( name "Backyard Basketball.scummvm" size 10 crc d7f3e811 )
 )
 
 game (
-	name "ADI 4 (Demo/Adi 4.0-Adibou 2/DOS/French)"
-	description "ADI 4 (Demo/Adi 4.0-Adibou 2/DOS/French)"
-	rom ( name "ACCUEIL.TGA" size 614418 crc 26d42086 md5 undefined )
+	name "Backyard Basketball"
+	description "Backyard Basketball"
+	rom ( name "Backyard Basketball CRLF.scummvm" size 12 crc e9aa1b05 )
 )
 
 game (
-	name "ADI 4 (Demo/Interactive Adi 4.0/DOS/French)"
-	description "ADI 4 (Demo/Interactive Adi 4.0/DOS/French)"
-	rom ( name "A_PARCHE.TGA" size 21944 crc undefined md5 undefined )
+	name "Backyard Basketball"
+	description "Backyard Basketball"
+	rom ( name "Backyard Basketball LF.scummvm" size 11 crc 58b0d589 )
 )
 
 game (
-	name "Adibou 2 (ADIBOU 2/DOS/German)"
-	description "Adibou 2 (ADIBOU 2/DOS/German)"
-	rom ( name "ADI1.TTF" size 57184 crc 7a29024d md5 e65eaf4a42749a1c6048c9b0770f856e )
+	name "Backyard Basketball"
+	description "Backyard Basketball"
+	rom ( name "Backyard Basketball CR.scummvm" size 11 crc c6d4402a )
 )
 
 game (
-	name "Adibou 2 (Demo/Non-Interactive/DOS/French)"
-	description "Adibou 2 (Demo/Non-Interactive/DOS/French)"
-	rom ( name "DEMOFRA.EXE" size 240656 crc d7d6db93 md5 undefined )
+	name "Backyard Football"
+	description "Backyard Football"
+	rom ( name "Backyard Football.scummvm" size 8 crc aede269e )
 )
 
 game (
-	name "Adibou 2 (Demo/Non-Interactive/DOS/German)"
-	description "Adibou 2 (Demo/Non-Interactive/DOS/German)"
-	rom ( name "DEMOALL.EXE" size 240656 crc d7d6db93 md5 undefined )
+	name "Backyard Football"
+	description "Backyard Football"
+	rom ( name "Backyard Football CRLF.scummvm" size 10 crc 296d091b )
 )
 
 game (
-	name "Adibou 2 (Demo/Non-Interactive/DOS/UK)"
-	description "Adibou 2 (Demo/Non-Interactive/DOS/UK)"
-	rom ( name "DEMOGB.EXE" size 240656 crc d7d6db93 md5 undefined )
+	name "Backyard Football"
+	description "Backyard Football"
+	rom ( name "Backyard Football LF.scummvm" size 9 crc 25ce66f6 )
 )
 
 game (
-	name "Adventure Game Interpreter Combat (DOS/Fanmade)"
-	description "Adventure Game Interpreter Combat (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 366 crc 0ca8d786 md5 0be6a8a9e19203dcca0067d280798871 )
+	name "Backyard Football"
+	description "Backyard Football"
+	rom ( name "Backyard Football CR.scummvm" size 9 crc bbaaf355 )
 )
 
 game (
-	name "Adventures of a Crazed Hermit, The (DOS/Fanmade)"
-	description "Adventures of a Crazed Hermit, The (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc bfe8be36 md5 6e3086cbb794d3299a9c5a9792295511 )
+	name "Backyard Football 2002"
+	description "Backyard Football 2002"
+	rom ( name "Backyard Football 2002.scummvm" size 12 crc 716a76e )
 )
 
 game (
-	name "Agent 0055 (DOS/Fanmade v1.0)"
-	description "Agent 0055 (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 603 crc 7f72d678 md5 undefined )
+	name "Backyard Football 2002"
+	description "Backyard Football 2002"
+	rom ( name "Backyard Football 2002 CRLF.scummvm" size 14 crc a76ef2d8 )
 )
 
 game (
-	name "Agent 06 vs. The Super Nazi (DOS/Fanmade)"
-	description "Agent 06 vs. The Super Nazi (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 212086fa md5 136f89ca9f117c617e88a85119777529 )
+	name "Backyard Football 2002"
+	description "Backyard Football 2002"
+	rom ( name "Backyard Football 2002 LF.scummvm" size 13 crc 98da5c6b )
 )
 
 game (
-	name "Agent Quest (DOS/Fanmade)"
-	description "Agent Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 71e6b024 md5 undefined )
+	name "Backyard Football 2002"
+	description "Backyard Football 2002"
+	rom ( name "Backyard Football 2002 CR.scummvm" size 13 crc 6bec9c8 )
 )
 
 game (
-	name "AGI Contest 1 Template (DOS/Fanmade)"
-	description "AGI Contest 1 Template (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc b8db2b8e md5 d879aed25da6fc655564b29567358ae2 )
+	name "Backyard Soccer"
+	description "Backyard Soccer"
+	rom ( name "Backyard Soccer.scummvm" size 6 crc e2959c36 )
 )
 
 game (
-	name "AGI Contest 2 Template (DOS/Fanmade)"
-	description "AGI Contest 2 Template (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc d67ea729 md5 5a2fb2894207eff36c72f5c1b08bcc07 )
+	name "Backyard Soccer"
+	description "Backyard Soccer"
+	rom ( name "Backyard Soccer CRLF.scummvm" size 8 crc 64072923 )
 )
 
 game (
-	name "AGI Demo - Kings Quest III & Space Quest I (DOS)"
-	description "AGI Demo - Kings Quest III & Space Quest I (DOS)"
-	rom ( name "LOGDIR" size 300 crc 7dc7b02d md5 undefined )
+	name "Backyard Soccer"
+	description "Backyard Soccer"
+	rom ( name "Backyard Soccer LF.scummvm" size 7 crc fd8f0696 )
 )
 
 game (
-	name "AGI Demo (Demo 1/DOS)"
-	description "AGI Demo (Demo 1/DOS)"
-	rom ( name "LOGDIR" size 300 crc ff09c352 md5 9c4a5b09cc3564bc48b4766e679ea332 )
+	name "Backyard Soccer"
+	description "Backyard Soccer"
+	rom ( name "Backyard Soccer CR.scummvm" size 7 crc 63eb9335 )
 )
 
 game (
-	name "AGI Demo (Demo 2/Apple IIgs)(Censored)"
-	description "AGI Demo (Demo 2/Apple IIgs)(Censored)"
-	rom ( name "DEMO.SYS" size 141884 crc 5f3828e9 md5 53f395aa2fd6f9146438bbbca68d697b )
+	name "Backyard Soccer 2004"
+	description "Backyard Soccer 2004"
+	rom ( name "Backyard Soccer 2004.scummvm" size 10 crc 8dd9d0d2 )
 )
 
 game (
-	name "AGI Demo (Demo 2/DOS)"
-	description "AGI Demo (Demo 2/DOS)"
-	rom ( name "LOGDIR" size 666 crc 85e73dfe md5 e8ebeb0bbe978172fe166f91f51598c7 )
+	name "Backyard Soccer 2004"
+	description "Backyard Soccer 2004"
+	rom ( name "Backyard Soccer 2004 CRLF.scummvm" size 12 crc 217f7d3c )
 )
 
 game (
-	name "AGI Demo (Demo 2/version 1/DOS)"
-	description "AGI Demo (Demo 2/version 1/DOS)"
-	rom ( name "LOGDIR" size 666 crc 1d38ad82 md5 undefined )
+	name "Backyard Soccer 2004"
+	description "Backyard Soccer 2004"
+	rom ( name "Backyard Soccer 2004 LF.scummvm" size 11 crc 5a876cbb )
 )
 
 game (
-	name "AGI Demo (Demo 2/version 2/DOS)"
-	description "AGI Demo (Demo 2/version 2/DOS)"
-	rom ( name "LOGDIR" size 606 crc a124de2b md5 1503f02086ea9f388e7e041c039eaa69 )
+	name "Backyard Soccer 2004"
+	description "Backyard Soccer 2004"
+	rom ( name "Backyard Soccer 2004 CR.scummvm" size 11 crc c4e3f918 )
 )
 
 game (
-	name "AGI Demo (Demo 3/DOS)"
-	description "AGI Demo (Demo 3/DOS)"
-	rom ( name "DMDIR" size 2552 crc d43258d5 md5 289c7a2c881f1d973661e961ced77d74 )
+	name "Backyard Soccer MLS Edition"
+	description "Backyard Soccer MLS Edition"
+	rom ( name "Backyard Soccer MLS Edition.scummvm" size 9 crc d62b7e78 )
 )
 
 game (
-	name "AGI Mouse Demo 0.60 (Demo 1/DOS/Fanmade)"
-	description "AGI Mouse Demo 0.60 (Demo 1/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 5a15f539 md5 undefined )
+	name "Backyard Soccer MLS Edition"
+	description "Backyard Soccer MLS Edition"
+	rom ( name "Backyard Soccer MLS Edition CRLF.scummvm" size 11 crc 44f9fc42 )
 )
 
 game (
-	name "AGI Mouse Demo 0.60 (Demo 2/DOS/Fanmade)"
-	description "AGI Mouse Demo 0.60 (Demo 2/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 2e8dae88 md5 undefined )
+	name "Backyard Soccer MLS Edition"
+	description "Backyard Soccer MLS Edition"
+	rom ( name "Backyard Soccer MLS Edition LF.scummvm" size 10 crc 6cdfd4e3 )
 )
 
 game (
-	name "AGI Mouse Demo 0.70 (DOS/Fanmade)"
-	description "AGI Mouse Demo 0.70 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 7306b124 md5 undefined )
+	name "Backyard Soccer MLS Edition"
+	description "Backyard Soccer MLS Edition"
+	rom ( name "Backyard Soccer MLS Edition CR.scummvm" size 10 crc f2bb4140 )
 )
 
 game (
-	name "AGI Mouse Demo 1.00 (DOS/Fanmade)"
-	description "AGI Mouse Demo 1.00 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 0d6d638c md5 undefined )
+	name "Bear Stormin'"
+	description "Bear Stormin'"
+	rom ( name "Bear Stormin'.scummvm" size 7 crc f0010920 )
 )
 
 game (
-	name "AGI Mouse Demo 1.10 (DOS/Fanmade)"
-	description "AGI Mouse Demo 1.10 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc d7ed7f98 md5 undefined )
+	name "Bear Stormin'"
+	description "Bear Stormin'"
+	rom ( name "Bear Stormin' CRLF.scummvm" size 9 crc f8fae9ab )
 )
 
 game (
-	name "AGI Piano (DOS/Fanmade v1.0)"
-	description "AGI Piano (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 39817b7d md5 8778b3d89eb93c1d50a70ef06ef10310 )
+	name "Bear Stormin'"
+	description "Bear Stormin'"
+	rom ( name "Bear Stormin' LF.scummvm" size 8 crc 9492752 )
 )
 
 game (
-	name "AGI Quest (DOS/Fanmade v1.46-TJ0)"
-	description "AGI Quest (DOS/Fanmade v1.46-TJ0)"
-	rom ( name "LOGDIR" size 768 crc 0def87d2 md5 1cf1a5307c1a0a405f5039354f679814 )
+	name "Bear Stormin'"
+	description "Bear Stormin'"
+	rom ( name "Bear Stormin' CR.scummvm" size 8 crc 972db2f1 )
 )
 
 game (
-	name "AGI Tetris (DOS)"
-	description "AGI Tetris (DOS)"
-	rom ( name "LOGDIR" size 300 crc 046677a2 md5 undefined )
+	name "Beavis and Butt-head in Virtual Stupidity"
+	description "Beavis and Butt-head in Virtual Stupidity"
+	rom ( name "Beavis and Butt-head in Virtual Stupidity.scummvm" size 4 crc 4b51012c )
 )
 
 game (
-	name "AGI Tetris (DOS/Fanmade 1998)"
-	description "AGI Tetris (DOS/Fanmade 1998)"
-	rom ( name "LOGDIR" size 297 crc ccf6d2f2 md5 undefined )
+	name "Beavis and Butt-head in Virtual Stupidity"
+	description "Beavis and Butt-head in Virtual Stupidity"
+	rom ( name "Beavis and Butt-head in Virtual Stupidity CRLF.scummvm" size 6 crc 5a9495c5 )
 )
 
 game (
-	name "AGI Trek (Demo/DOS/Fanmade)"
-	description "AGI Trek (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 2a827d30 md5 undefined )
+	name "Beavis and Butt-head in Virtual Stupidity"
+	description "Beavis and Butt-head in Virtual Stupidity"
+	rom ( name "Beavis and Butt-head in Virtual Stupidity LF.scummvm" size 5 crc 443b71 )
 )
 
 game (
-	name "AGI256 Demo (DOS/Fanmade)"
-	description "AGI256 Demo (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc bc66d77d md5 undefined )
+	name "Beavis and Butt-head in Virtual Stupidity"
+	description "Beavis and Butt-head in Virtual Stupidity"
+	rom ( name "Beavis and Butt-head in Virtual Stupidity CR.scummvm" size 5 crc 9e20aed2 )
 )
 
 game (
-	name "AGI256-2 Demo (DOS/Fanmade)"
-	description "AGI256-2 Demo (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 0ba446ec md5 3cad9b3aff1467cebf0c5c5b110985c5 )
+	name "Beneath a Steel Sky"
+	description "Beneath a Steel Sky"
+	rom ( name "Beneath a Steel Sky.scummvm" size 3 crc 62674ef )
 )
 
 game (
-	name "Al Pond 1: Al Lives Forever (DOS/Fanmade v1.0)"
-	description "Al Pond 1: Al Lives Forever (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 603 crc d758b7bf md5 e8921c3043b749b056ff51f56d1b451b )
+	name "Beneath a Steel Sky"
+	description "Beneath a Steel Sky"
+	rom ( name "Beneath a Steel Sky CRLF.scummvm" size 5 crc 9a2cd98c )
 )
 
 game (
-	name "Al Pond 1: Al Lives Forever (DOS/Fanmade v1.3)"
-	description "Al Pond 1: Al Lives Forever (DOS/Fanmade v1.3)"
-	rom ( name "LOGDIR" size 603 crc 4280c1cc md5 undefined )
+	name "Beneath a Steel Sky"
+	description "Beneath a Steel Sky"
+	rom ( name "Beneath a Steel Sky LF.scummvm" size 4 crc 264df0e )
 )
 
 game (
-	name "Al Pond 2: Island Quest (DOS/Fanmade)"
-	description "Al Pond 2: Island Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 889843 crc 90a3a563 md5 358155b78c402f67450d2bc6910a570d )
+	name "Beneath a Steel Sky"
+	description "Beneath a Steel Sky"
+	rom ( name "Beneath a Steel Sky CR.scummvm" size 4 crc 9c004aad )
 )
 
 game (
-	name "Al Pond 2: Island Quest (DOS/Fanmade/Updated)"
-	description "Al Pond 2: Island Quest (DOS/Fanmade/Updated)"
-	rom ( name "resource.001" size 885241 crc b64bcd27 md5 undefined )
+	name "Big Thinkers First Grade"
+	description "Big Thinkers First Grade"
+	rom ( name "Big Thinkers First Grade.scummvm" size 8 crc 1274b7b8 )
 )
 
 game (
-	name "Al Pond: Island Quest 2 (DOS/Fanmade)"
-	description "Al Pond: Island Quest 2 (DOS/Fanmade)"
-	rom ( name "resource.001" size 613769 crc e528bda5 md5 undefined )
+	name "Big Thinkers First Grade"
+	description "Big Thinkers First Grade"
+	rom ( name "Big Thinkers First Grade CRLF.scummvm" size 10 crc 6dbb9547 )
 )
 
 game (
-	name "Al Pond: On Holiday (DOS/Fanmade v1.0)"
-	description "Al Pond: On Holiday (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 11557eba md5 undefined )
+	name "Big Thinkers First Grade"
+	description "Big Thinkers First Grade"
+	rom ( name "Big Thinkers First Grade LF.scummvm" size 9 crc f77f499a )
 )
 
 game (
-	name "Al Pond: On Holiday (DOS/Fanmade v1.1)"
-	description "Al Pond: On Holiday (DOS/Fanmade v1.1)"
-	rom ( name "LOGDIR" size 300 crc 272642be md5 7c95ac4689d0c3bfec61e935f3093634 )
+	name "Big Thinkers First Grade"
+	description "Big Thinkers First Grade"
+	rom ( name "Big Thinkers First Grade CR.scummvm" size 9 crc 691bdc39 )
 )
 
 game (
-	name "Al Pond: On Holiday (DOS/Fanmade v1.3)"
-	description "Al Pond: On Holiday (DOS/Fanmade v1.3)"
-	rom ( name "LOGDIR" size 300 crc 0e99f3c2 md5 undefined )
+	name "Big Thinkers Kindergarten"
+	description "Big Thinkers Kindergarten"
+	rom ( name "Big Thinkers Kindergarten.scummvm" size 8 crc 99ca0f52 )
 )
 
 game (
-	name "Amazon: Guardians of Eden (CD/DOS)"
-	description "Amazon: Guardians of Eden (CD/DOS)"
-	rom ( name "DATA02.MAP" size 2360 crc 8bbdddbe md5 undefined )
+	name "Big Thinkers Kindergarten"
+	description "Big Thinkers Kindergarten"
+	rom ( name "Big Thinkers Kindergarten CRLF.scummvm" size 10 crc c903e21 )
 )
 
 game (
-	name "Amazon: Guardians of Eden (Demo/DOS)"
-	description "Amazon: Guardians of Eden (Demo/DOS)"
-	rom ( name "C25.AP" size 65458 crc 74ff68cb md5 91950289c23024ae3b171e77d5909aff )
+	name "Big Thinkers Kindergarten"
+	description "Big Thinkers Kindergarten"
+	rom ( name "Big Thinkers Kindergarten LF.scummvm" size 9 crc b72bfc44 )
 )
 
 game (
-	name "Amazon: Guardians of Eden (DOS)"
-	description "Amazon: Guardians of Eden (DOS)"
-	rom ( name "C00.AP" size 331481 crc 02174fbc md5 3828e94a484c1dbf492398ef64c6dd84 )
+	name "Big Thinkers Kindergarten"
+	description "Big Thinkers Kindergarten"
+	rom ( name "Big Thinkers Kindergarten CR.scummvm" size 9 crc 294f69e7 )
 )
 
 game (
-	name "Amazon: Guardians of Eden (DOS/Spanish)"
-	description "Amazon: Guardians of Eden (DOS/Spanish)"
-	rom ( name "C00.AP" size 303753 crc 6eed7fc8 md5 undefined )
+	name "Blue's 123 Time Activities"
+	description "Blue's 123 Time Activities"
+	rom ( name "Blue's 123 Time Activities.scummvm" size 12 crc 96cdd5ca )
 )
 
 game (
-	name "Ancient Mark, The: Episode 1 (Windows)"
-	description "Ancient Mark, The: Episode 1 (Windows)"
-	rom ( name "data.dcp" size 364664692 crc 73259e67 md5 16816b7664a1c2d92a8140932482646f )
+	name "Blue's 123 Time Activities"
+	description "Blue's 123 Time Activities"
+	rom ( name "Blue's 123 Time Activities CRLF.scummvm" size 14 crc d30e0afe )
 )
 
 game (
-	name "Another DG Game: I Want My C64 Back (DOS/Fanmade)"
-	description "Another DG Game: I Want My C64 Back (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 150513 crc 74783b03 md5 0f9d747a14c52e221cf1c8ce70c40eed )
+	name "Blue's 123 Time Activities"
+	description "Blue's 123 Time Activities"
+	rom ( name "Blue's 123 Time Activities LF.scummvm" size 13 crc 49f0e0e8 )
 )
 
 game (
-	name "Another DG Game: I Want My C64 Back (DOS/Fanmade/French)"
-	description "Another DG Game: I Want My C64 Back (DOS/Fanmade/French)"
-	rom ( name "RESOURCE.001" size 141697 crc 223efe21 md5 undefined )
+	name "Blue's 123 Time Activities"
+	description "Blue's 123 Time Activities"
+	rom ( name "Blue's 123 Time Activities CR.scummvm" size 13 crc d794754b )
 )
 
 game (
-	name "Another Fine Mess (Macintosh/v1.8)"
-	description "Another Fine Mess (Macintosh/v1.8)"
-	rom ( name "._AFM SOUNDS" size 744193 crc undefined md5 undefined )
+	name "Blue's ABC Time Activities"
+	description "Blue's ABC Time Activities"
+	rom ( name "Blue's ABC Time Activities.scummvm" size 12 crc 8855e8ef )
 )
 
 game (
-	name "Apocalyptic Quest (Demo/DOS/Fanmade v4.00 Alpha)[Unl]"
-	description "Apocalyptic Quest (Demo/DOS/Fanmade v4.00 Alpha)[Unl]"
-	rom ( name "LOGDIR" size 300 crc f48f5047 md5 986a3c6d2ef74fce6082d37a71f24aae )
+	name "Blue's ABC Time Activities"
+	description "Blue's ABC Time Activities"
+	rom ( name "Blue's ABC Time Activities CRLF.scummvm" size 14 crc 63958890 )
 )
 
 game (
-	name "Apocalyptic Quest (DOS/Fanmade v4.00 Alpha 1)"
-	description "Apocalyptic Quest (DOS/Fanmade v4.00 Alpha 1)"
-	rom ( name "LOGDIR" size 297 crc 51933a7b md5 e15581628d84949b8d352d224ec3184b )
+	name "Blue's ABC Time Activities"
+	description "Blue's ABC Time Activities"
+	rom ( name "Blue's ABC Time Activities LF.scummvm" size 13 crc 2eaac92 )
 )
 
 game (
-	name "Apocalyptic Quest (DOS/Fanmade v4.00 Alpha 2)"
-	description "Apocalyptic Quest (DOS/Fanmade v4.00 Alpha 2)"
-	rom ( name "LOGDIR" size 306 crc 36aee0a7 md5 undefined )
+	name "Blue's ABC Time Activities"
+	description "Blue's ABC Time Activities"
+	rom ( name "Blue's ABC Time Activities CR.scummvm" size 13 crc 9c8e3931 )
 )
 
 game (
-	name "Apocalyptic Quest (Teaser/DOS/Fanmade v0.03)"
-	description "Apocalyptic Quest (Teaser/DOS/Fanmade v0.03)"
-	rom ( name "LOGDIR" size 300 crc 10ff7e5d md5 42ced528b67965d3bc3b52c635f94a57 )
+	name "Blue's Art Time Activities"
+	description "Blue's Art Time Activities"
+	rom ( name "Blue's Art Time Activities.scummvm" size 7 crc b4c535b3 )
 )
 
 game (
-	name "Aquarius: An Aquatic Experience (DOS/Fanmade)"
-	description "Aquarius: An Aquatic Experience (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 272372 crc c2cedb4d md5 undefined )
+	name "Blue's Art Time Activities"
+	description "Blue's Art Time Activities"
+	rom ( name "Blue's Art Time Activities CRLF.scummvm" size 9 crc 8df90831 )
 )
 
 game (
-	name "Astro Chicken (DOS)"
-	description "Astro Chicken (DOS)"
-	rom ( name "RESOURCE.001" size 126895 crc a1e3a114 md5 4b312cc932e3637f54aceb70edf9d6e1 )
+	name "Blue's Art Time Activities"
+	description "Blue's Art Time Activities"
+	rom ( name "Blue's Art Time Activities LF.scummvm" size 8 crc 600b2190 )
 )
 
 game (
-	name "Backyard Baseball (ALL)"
-	description "Backyard Baseball (ALL)"
-	rom ( name "BASEBALL.HE0" size 43338 crc 75cc3c46 md5 undefined )
+	name "Blue's Art Time Activities"
+	description "Blue's Art Time Activities"
+	rom ( name "Blue's Art Time Activities CR.scummvm" size 8 crc fe6fb433 )
 )
 
 game (
-	name "Backyard Baseball (Preview)[!]"
-	description "Backyard Baseball (Preview)[!]"
-	rom ( name "BASEDEMO.CUP" size 10044774 crc 06366f7e md5 8078e221cad7e8a70c58ad4845fc220a )
+	name "Blue's Birthday Adventure"
+	description "Blue's Birthday Adventure"
+	rom ( name "Blue's Birthday Adventure.scummvm" size 13 crc 55358473 )
 )
 
 game (
-	name "Backyard Baseball (Preview/Updated)[!]"
-	description "Backyard Baseball (Preview/Updated)[!]"
-	rom ( name "BaseDemo.cup" size 12876596 crc b9eb9e03 md5 undefined )
+	name "Blue's Birthday Adventure"
+	description "Blue's Birthday Adventure"
+	rom ( name "Blue's Birthday Adventure CRLF.scummvm" size 15 crc fa65bd95 )
 )
 
 game (
-	name "Backyard Baseball 2001 (ALL)"
-	description "Backyard Baseball 2001 (ALL)"
-	rom ( name "baseball 2001.(a)" size 141563292 crc 95a359c3 md5 26c7ad3f08c11979585aab09cc19f1a9 )
+	name "Blue's Birthday Adventure"
+	description "Blue's Birthday Adventure"
+	rom ( name "Blue's Birthday Adventure LF.scummvm" size 14 crc fb8e1391 )
 )
 
 game (
-	name "Backyard Baseball 2001 (Demo/ALL)"
-	description "Backyard Baseball 2001 (Demo/ALL)"
-	rom ( name "BB2DEMO.(A)" size 28444929 crc 53382844 md5 0b38fda342fdaa5e206b2a82c8ab6b9b )
+	name "Blue's Birthday Adventure"
+	description "Blue's Birthday Adventure"
+	rom ( name "Blue's Birthday Adventure CR.scummvm" size 14 crc 65ea8632 )
 )
 
 game (
-	name "Backyard Baseball 2003 (ALL)"
-	description "Backyard Baseball 2003 (ALL)"
-	rom ( name "baseball2003.(a)" size 196067172 crc 3e5987f6 md5 undefined )
+	name "Blue's Reading Time Activities"
+	description "Blue's Reading Time Activities"
+	rom ( name "Blue's Reading Time Activities.scummvm" size 8 crc b31360ed )
 )
 
 game (
-	name "Backyard Basketball (ALL)[!]"
-	description "Backyard Basketball (ALL)[!]"
-	rom ( name "Basketball.(a)" size 212421604 crc b7eefbb2 md5 f204ba0418828d352e77f193403b766c )
+	name "Blue's Reading Time Activities"
+	description "Blue's Reading Time Activities"
+	rom ( name "Blue's Reading Time Activities CRLF.scummvm" size 10 crc b2c0da46 )
 )
 
 game (
-	name "Backyard Football (ALL)"
-	description "Backyard Football (ALL)"
-	rom ( name "FOOTBALL.(A)" size 197867294 crc ad4cb08c md5 undefined )
+	name "Blue's Reading Time Activities"
+	description "Blue's Reading Time Activities"
+	rom ( name "Blue's Reading Time Activities LF.scummvm" size 9 crc ecdf8b36 )
 )
 
 game (
-	name "Backyard Football (Demo/ALL)[!]"
-	description "Backyard Football (Demo/ALL)[!]"
-	rom ( name "FOOTDEMO.(A)" size 28052915 crc 9ff25dae md5 bb6ec9a3a2a016b239367c2b26d9ee3b )
+	name "Blue's Reading Time Activities"
+	description "Blue's Reading Time Activities"
+	rom ( name "Blue's Reading Time Activities CR.scummvm" size 9 crc 72bb1e95 )
 )
 
 game (
-	name "Backyard Football 2002 (ALL)"
-	description "Backyard Football 2002 (ALL)"
-	rom ( name "Football2002.(b)" size 2205188 crc 3dda7313 md5 1e45c754359ca021d50cc6776f3240a6 )
+	name "Blue's Treasure Hunt"
+	description "Blue's Treasure Hunt"
+	rom ( name "Blue's Treasure Hunt.scummvm" size 17 crc 2ab30b17 )
 )
 
 game (
-	name "Backyard Football 2002 (ALL)[a][!]"
-	description "Backyard Football 2002 (ALL)[a][!]"
-	rom ( name "Football2002.(b)" size 2205593 crc d1b2c3e1 md5 undefined )
+	name "Blue's Treasure Hunt"
+	description "Blue's Treasure Hunt"
+	rom ( name "Blue's Treasure Hunt CRLF.scummvm" size 19 crc 86f3f201 )
 )
 
 game (
-	name "Backyard Soccer (ALL)[!]"
-	description "Backyard Soccer (ALL)[!]"
-	rom ( name "SOCCER.(A)" size 154576946 crc f9c21907 md5 undefined )
+	name "Blue's Treasure Hunt"
+	description "Blue's Treasure Hunt"
+	rom ( name "Blue's Treasure Hunt LF.scummvm" size 18 crc b12e305f )
 )
 
 game (
-	name "Backyard Soccer 2004 (ALL)"
-	description "Backyard Soccer 2004 (ALL)"
-	rom ( name "Soccer2004.(a)" size 287393325 crc f6c1387f md5 2808c81e388743998b3c7331501cc4dd )
+	name "Blue's Treasure Hunt"
+	description "Blue's Treasure Hunt"
+	rom ( name "Blue's Treasure Hunt CR.scummvm" size 18 crc 2f4aa5fc )
 )
 
 game (
-	name "Backyard Soccer 2004 (ALL/Russian)"
-	description "Backyard Soccer 2004 (ALL/Russian)"
-	rom ( name "Soccer2004.(a)" size 287393325 crc e433e754 md5 e10cb34c774852175134fe166a602012 )
+	name "Broken Sword 2.5"
+	description "Broken Sword 2.5"
+	rom ( name "Broken Sword 2.5.scummvm" size 7 crc 78825394 )
 )
 
 game (
-	name "Backyard Soccer MLS Edition (ALL)[!]"
-	description "Backyard Soccer MLS Edition (ALL)[!]"
-	rom ( name "SoccerMLS.(a)" size 203784670 crc 18014648 md5 undefined )
+	name "Broken Sword 2.5"
+	description "Broken Sword 2.5"
+	rom ( name "Broken Sword 2.5 CRLF.scummvm" size 9 crc f3edb27e )
 )
 
 game (
-	name "Backyard Soccer MLS Edition (Windows)"
-	description "Backyard Soccer MLS Edition (Windows)"
-	rom ( name "SoccerMLS.(a)" size 203771068 crc 626bd348 md5 bda62f35e0ce1f910d63f0713b3426cb )
+	name "Broken Sword 2.5"
+	description "Broken Sword 2.5"
+	rom ( name "Broken Sword 2.5 LF.scummvm" size 8 crc c5cdd39d )
 )
 
 game (
-	name "Band Quest (Demo/DOS/Fanmade)"
-	description "Band Quest (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 1d4dd806 md5 7326abefd793571cc17ed0db647bdf34 )
+	name "Broken Sword 2.5"
+	description "Broken Sword 2.5"
+	rom ( name "Broken Sword 2.5 CR.scummvm" size 8 crc 5ba9463e )
 )
 
 game (
-	name "Band Quest (Demo/Early/DOS/Fanmade)"
-	description "Band Quest (Demo/Early/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 31d3e373 md5 undefined )
+	name "Broken Sword II The Smoking Mirror"
+	description "Broken Sword II The Smoking Mirror"
+	rom ( name "Broken Sword II The Smoking Mirror.scummvm" size 6 crc 8af0465b )
 )
 
 game (
-	name "Bargon Attack (Amiga)"
-	description "Bargon Attack (Amiga)"
-	rom ( name "DISK1.STK" size 236114 crc df7353ef md5 undefined )
+	name "Broken Sword II The Smoking Mirror"
+	description "Broken Sword II The Smoking Mirror"
+	rom ( name "Broken Sword II The Smoking Mirror CRLF.scummvm" size 8 crc d2526f66 )
 )
 
 game (
-	name "Bargon Attack (Atari ST/French)"
-	description "Bargon Attack (Atari ST/French)"
-	rom ( name "DISK1.STK" size 237921 crc df923def md5 c1431eb29c322b10041671b485c3d383 )
+	name "Broken Sword II The Smoking Mirror"
+	description "Broken Sword II The Smoking Mirror"
+	rom ( name "Broken Sword II The Smoking Mirror LF.scummvm" size 7 crc cee47ea9 )
 )
 
 game (
-	name "Bargon Attack (DOS)"
-	description "Bargon Attack (DOS)"
-	rom ( name "1INTRO3.SND" size 48390 crc 022b07ff md5 undefined )
+	name "Broken Sword II The Smoking Mirror"
+	description "Broken Sword II The Smoking Mirror"
+	rom ( name "Broken Sword II The Smoking Mirror CR.scummvm" size 7 crc 5080eb0a )
 )
 
 game (
-	name "Bargon Attack (DOS/Fanmade Italian)"
-	description "Bargon Attack (DOS/Fanmade Italian)"
-	rom ( name "1INTRO3.SND" size 48390 crc 022b07ff md5 c42e3541c0455776b31a68d859fce475 )
+	name "Broken Sword II The Smoking Mirror (Demo)"
+	description "Broken Sword II The Smoking Mirror (Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (Demo).scummvm" size 10 crc a7882df2 )
 )
 
 game (
-	name "Bargon Attack (DOS/French)"
-	description "Bargon Attack (DOS/French)"
-	rom ( name "1INTRO3.SND" size 48390 crc 022b07ff md5 undefined )
+	name "Broken Sword II The Smoking Mirror (Demo)"
+	description "Broken Sword II The Smoking Mirror (Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (Demo) CRLF.scummvm" size 12 crc 77f7fd6e )
 )
 
 game (
-	name "Bargon Attack (DOS/German)"
-	description "Bargon Attack (DOS/German)"
-	rom ( name "1INTRO3.SND" size 48390 crc 022b07ff md5 undefined )
+	name "Broken Sword II The Smoking Mirror (Demo)"
+	description "Broken Sword II The Smoking Mirror (Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (Demo) LF.scummvm" size 11 crc 61c31d8e )
 )
 
 game (
-	name "Bargon Attack (DOS/Spanish)"
-	description "Bargon Attack (DOS/Spanish)"
-	rom ( name "1INTRO3.SND" size 36102 crc 17dca3c8 md5 5831fac88125df07abb60f1adb5e2a9b )
+	name "Broken Sword II The Smoking Mirror (Demo)"
+	description "Broken Sword II The Smoking Mirror (Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (Demo) CR.scummvm" size 11 crc ffa7882d )
 )
 
 game (
-	name "Bear Stormin' (ALL)"
-	description "Bear Stormin' (ALL)"
-	rom ( name "BRSTORM.BRS" size 45690 crc ab2774db md5 undefined )
+	name "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	description "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo).scummvm" size 13 crc f01589b6 )
 )
 
 game (
-	name "Beast Within, The: A Gabriel Knight Mystery (Demo/Windows)"
-	description "Beast Within, The: A Gabriel Knight Mystery (Demo/Windows)"
-	rom ( name "300.AUD" size 1624685 crc 9650a21e md5 undefined )
+	name "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	description "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo) CRLF.scummvm" size 15 crc 32594703 )
 )
 
 game (
-	name "Beast Within, The: A Gabriel Knight Mystery (DOS)[!]"
-	description "Beast Within, The: A Gabriel Knight Mystery (DOS)[!]"
-	rom ( name "1020.HEP" size 562 crc 62cb383d md5 undefined )
+	name "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	description "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo) LF.scummvm" size 14 crc 102505a3 )
 )
 
 game (
-	name "Beast Within, The: A Gabriel Knight Mystery (DOS/French)[!]"
-	description "Beast Within, The: A Gabriel Knight Mystery (DOS/French)[!]"
-	rom ( name "11853.HEP" size 716 crc 471a65bf md5 d4b7a8db1081bd2ca965938fd9a1412f )
+	name "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	description "Broken Sword II The Smoking Mirror (PlayStation - Demo)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation - Demo) CR.scummvm" size 14 crc 8e419000 )
 )
 
 game (
-	name "Beavis and Butt-head in Virtual Stupidity (Windows)[!]"
-	description "Beavis and Butt-head in Virtual Stupidity (Windows)[!]"
-	rom ( name "BBAIRG\AUDIO\BURP\A#.AIF" size 18314 crc 1f90da41 md5 62d1e1f1cdd4fb1bd7efe6a80671cfe7 )
+	name "Broken Sword II The Smoking Mirror (PlayStation)"
+	description "Broken Sword II The Smoking Mirror (PlayStation)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation).scummvm" size 9 crc 8a0bb93d )
 )
 
 game (
-	name "Beavis and Butt-head in Virtual Stupidity (Windows/Russian)"
-	description "Beavis and Butt-head in Virtual Stupidity (Windows/Russian)"
-	rom ( name "BBAIRG\AUDIO\BURP\A#.AIF" size 18314 crc 1f90da41 md5 undefined )
+	name "Broken Sword II The Smoking Mirror (PlayStation)"
+	description "Broken Sword II The Smoking Mirror (PlayStation)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation) CRLF.scummvm" size 11 crc ccf74c31 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0109 PC Gamer Demo)"
-	description "Beneath a Steel Sky (v0.0109 PC Gamer Demo)"
-	rom ( name "SKY.DNR" size 1948 crc 0e2ee7e0 md5 57db203259f0b57ab766c3b198048039 )
+	name "Broken Sword II The Smoking Mirror (PlayStation)"
+	description "Broken Sword II The Smoking Mirror (PlayStation)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation) LF.scummvm" size 10 crc 6a35413b )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0267 Floppy Demo)"
-	description "Beneath a Steel Sky (v0.0267 Floppy Demo)"
-	rom ( name "SKY.DNR" size 1980 crc eef0d3ca md5 22c52b311fba2458b7849f5e3df3a19c )
+	name "Broken Sword II The Smoking Mirror (PlayStation)"
+	description "Broken Sword II The Smoking Mirror (PlayStation)"
+	rom ( name "Broken Sword II The Smoking Mirror (PlayStation) CR.scummvm" size 10 crc f451d498 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0272 Floppy Demo/German)"
-	description "Beneath a Steel Sky (v0.0272 Floppy Demo/German)"
-	rom ( name "SKY.DNR" size 1860 crc 4444a861 md5 9b901d20069fdb255e8f91e5a7822267 )
+	name "Broken Sword II The Smoking Mirror (alt)"
+	description "Broken Sword II The Smoking Mirror (alt)"
+	rom ( name "Broken Sword II The Smoking Mirror (alt).scummvm" size 9 crc 530332cf )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0288 Floppy)"
-	description "Beneath a Steel Sky (v0.0288 Floppy)"
-	rom ( name "SKY.DNR" size 11236 crc 93df7892 md5 51f0588cc5ea0d2ad6f6d7b0bb5384be )
+	name "Broken Sword II The Smoking Mirror (alt)"
+	description "Broken Sword II The Smoking Mirror (alt)"
+	rom ( name "Broken Sword II The Smoking Mirror (alt) CRLF.scummvm" size 11 crc 90174cae )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0288 Floppy/French)"
-	description "Beneath a Steel Sky (v0.0288 Floppy/French)"
-	rom ( name "FRENCH.ROM" size 43 crc a2ea017b md5 undefined )
+	name "Broken Sword II The Smoking Mirror (alt)"
+	description "Broken Sword II The Smoking Mirror (alt)"
+	rom ( name "Broken Sword II The Smoking Mirror (alt) LF.scummvm" size 10 crc 395fda80 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0288 Floppy/German)"
-	description "Beneath a Steel Sky (v0.0288 Floppy/German)"
-	rom ( name "GERMAN.ROM" size 43 crc 8fe5af78 md5 54fc3739c56de5668c6ccab4571ae210 )
+	name "Broken Sword II The Smoking Mirror (alt)"
+	description "Broken Sword II The Smoking Mirror (alt)"
+	rom ( name "Broken Sword II The Smoking Mirror (alt) CR.scummvm" size 10 crc a73b4f23 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0303 Floppy)"
-	description "Beneath a Steel Sky (v0.0303 Floppy)"
-	rom ( name "SKY.DNR" size 11308 crc e1bb5c4f md5 7f54987bf84eacd3a4502cf5f8a283b9 )
+	name "Broken Sword The Shadow of the Templars"
+	description "Broken Sword The Shadow of the Templars"
+	rom ( name "Broken Sword The Shadow of the Templars.scummvm" size 6 crc 13f917e1 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0303 Floppy/French)"
-	description "Beneath a Steel Sky (v0.0303 Floppy/French)"
-	rom ( name "FRENCH.ROM" size 43 crc f173d3b9 md5 undefined )
+	name "Broken Sword The Shadow of the Templars"
+	description "Broken Sword The Shadow of the Templars"
+	rom ( name "Broken Sword The Shadow of the Templars CRLF.scummvm" size 8 crc d014d13f )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0303 Floppy/German)"
-	description "Beneath a Steel Sky (v0.0303 Floppy/German)"
-	rom ( name "GERMAN.ROM" size 43 crc dc7c7dba md5 9b01e5a9501712ea4ea4cd72a23c0615 )
+	name "Broken Sword The Shadow of the Templars"
+	description "Broken Sword The Shadow of the Templars"
+	rom ( name "Broken Sword The Shadow of the Templars LF.scummvm" size 7 crc e5c92d6a )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy)"
-	description "Beneath a Steel Sky (v0.0331 Floppy)"
-	rom ( name "SKY.DNR" size 11564 crc 2383f297 md5 5192318ca6f033132bf5132098476d5b )
+	name "Broken Sword The Shadow of the Templars"
+	description "Broken Sword The Shadow of the Templars"
+	rom ( name "Broken Sword The Shadow of the Templars CR.scummvm" size 7 crc 7badb8c9 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/French)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/French)"
-	rom ( name "FRENCH.ROM" size 43 crc 2549ad5e md5 597222c93dce92b69b9ba241b5bf45a7 )
+	name "Broken Sword The Shadow of the Templars (Demo)"
+	description "Broken Sword The Shadow of the Templars (Demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Demo).scummvm" size 10 crc e0285722 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/German)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/German)"
-	rom ( name "GERMAN.ROM" size 43 crc 0846035d md5 31b7f751fa4698e911cefd774583ec47 )
+	name "Broken Sword The Shadow of the Templars (Demo)"
+	description "Broken Sword The Shadow of the Templars (Demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Demo) CRLF.scummvm" size 12 crc 461fe7f3 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/Italian)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/Italian)"
-	rom ( name "ITALIAN.ROM" size 44 crc 98b37676 md5 undefined )
+	name "Broken Sword The Shadow of the Templars (Demo)"
+	description "Broken Sword The Shadow of the Templars (Demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Demo) LF.scummvm" size 11 crc e7576f20 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/Portuguese)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/Portuguese)"
-	rom ( name "PORTUGUESE.ROM" size 47 crc 088ca063 md5 f38c6bfc7ffb68c62001554190d09ba6 )
+	name "Broken Sword The Shadow of the Templars (Demo)"
+	description "Broken Sword The Shadow of the Templars (Demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Demo) CR.scummvm" size 11 crc 7933fa83 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/Spanish)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/Spanish)"
-	rom ( name "SPANISH.ROM" size 44 crc b2bffc7e md5 undefined )
+	name "Broken Sword The Shadow of the Templars (Mac demo)"
+	description "Broken Sword The Shadow of the Templars (Mac demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo).scummvm" size 13 crc 21bd7658 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0331 Floppy/Swedish)"
-	description "Beneath a Steel Sky (v0.0331 Floppy/Swedish)"
-	rom ( name "SWEDISH.ROM" size 44 crc a6399847 md5 undefined )
+	name "Broken Sword The Shadow of the Templars (Mac demo)"
+	description "Broken Sword The Shadow of the Templars (Mac demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo) CRLF.scummvm" size 15 crc dfa6a744 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy)[!]"
-	description "Beneath a Steel Sky (v0.0348 Floppy)[!]"
-	rom ( name "SKY.DNR" size 11564 crc d4db73a3 md5 22d9956b990881f84ed38757661b7561 )
+	name "Broken Sword The Shadow of the Templars (Mac demo)"
+	description "Broken Sword The Shadow of the Templars (Mac demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo) LF.scummvm" size 14 crc 57466223 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/French)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/French)"
-	rom ( name "FRENCH.ROM" size 43 crc d8a0dfcb md5 3b85d955d53d80c2e0ddd9faa321048b )
+	name "Broken Sword The Shadow of the Templars (Mac demo)"
+	description "Broken Sword The Shadow of the Templars (Mac demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac demo) CR.scummvm" size 14 crc c922f780 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/German)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/German)"
-	rom ( name "GERMAN.ROM" size 43 crc f5af71c8 md5 17be9ba29a47e261e7afef24d2ce43cc )
+	name "Broken Sword The Shadow of the Templars (Mac)"
+	description "Broken Sword The Shadow of the Templars (Mac)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac).scummvm" size 9 crc 7ed19fcf )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/Italian)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/Italian)"
-	rom ( name "ITALIAN.ROM" size 44 crc 182bf8cf md5 undefined )
+	name "Broken Sword The Shadow of the Templars (Mac)"
+	description "Broken Sword The Shadow of the Templars (Mac)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac) CRLF.scummvm" size 11 crc 3870be29 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/Portuguese)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/Portuguese)"
-	rom ( name "PORTUGUESE.ROM" size 47 crc 99d7cbcf md5 570750972a0846a4f7b880ff322559e0 )
+	name "Broken Sword The Shadow of the Templars (Mac)"
+	description "Broken Sword The Shadow of the Templars (Mac)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac) LF.scummvm" size 10 crc 3972082d )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/Spanish)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/Spanish)"
-	rom ( name "SPANISH.ROM" size 44 crc 322772c7 md5 undefined )
+	name "Broken Sword The Shadow of the Templars (Mac)"
+	description "Broken Sword The Shadow of the Templars (Mac)"
+	rom ( name "Broken Sword The Shadow of the Templars (Mac) CR.scummvm" size 10 crc a7169d8e )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0348 Floppy/Swedish)"
-	description "Beneath a Steel Sky (v0.0348 Floppy/Swedish)"
-	rom ( name "SWEDISH.ROM" size 44 crc 26a116fe md5 undefined )
+	name "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	description "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo).scummvm" size 13 crc 7e9a8e55 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo)"
-	rom ( name "SKY.DNR" size 13692 crc 002dfaf2 md5 53151a6b9d2090b29469e7c94c027735 )
+	name "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	description "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo) CRLF.scummvm" size 15 crc d96efc00 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/French)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/French)"
-	rom ( name "FRENCH.ROM" size 74 crc f7949985 md5 32844ac635118ab1a3fb8659e93bb649 )
+	name "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	description "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo) LF.scummvm" size 14 crc 29a83966 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/German)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/German)"
-	rom ( name "GERMAN.ROM" size 74 crc 6d9bf532 md5 20489649774a0aa7f70f487114c0e33f )
+	name "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	description "Broken Sword The Shadow of the Templars (PlayStation demo)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation demo) CR.scummvm" size 14 crc b7ccacc5 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/Italian)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/Italian)"
-	rom ( name "ITALIAN.ROM" size 75 crc 0b73098a md5 undefined )
+	name "Broken Sword The Shadow of the Templars (PlayStation)"
+	description "Broken Sword The Shadow of the Templars (PlayStation)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation).scummvm" size 9 crc 98be16d3 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/Portuguese)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/Portuguese)"
-	rom ( name "PORTUGUESE.ROM" size 78 crc 083599d1 md5 bb82027fd2303fc587aa4bbbddff3b9f )
+	name "Broken Sword The Shadow of the Templars (PlayStation)"
+	description "Broken Sword The Shadow of the Templars (PlayStation)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation) CRLF.scummvm" size 11 crc 4a633e9f )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/Spanish)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/Spanish)"
-	rom ( name "SPANISH.ROM" size 75 crc 36164341 md5 undefined )
+	name "Broken Sword The Shadow of the Templars (PlayStation)"
+	description "Broken Sword The Shadow of the Templars (PlayStation)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation) LF.scummvm" size 10 crc 2d953beb )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0365 CD Demo/Swedish)"
-	description "Beneath a Steel Sky (v0.0365 CD Demo/Swedish)"
-	rom ( name "SWEDISH.ROM" size 75 crc 81d07cf7 md5 undefined )
+	name "Broken Sword The Shadow of the Templars (PlayStation)"
+	description "Broken Sword The Shadow of the Templars (PlayStation)"
+	rom ( name "Broken Sword The Shadow of the Templars (PlayStation) CR.scummvm" size 10 crc b3f1ae48 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD)[!]"
-	rom ( name "SKY.DNR" size 40796 crc a3206462 md5 f05a0ae79722022b31cfbaf3b7c92578 )
+	name "Bud Tucker in Double Trouble"
+	description "Bud Tucker in Double Trouble"
+	rom ( name "Bud Tucker in Double Trouble.scummvm" size 6 crc dbd37215 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU)[!]"
-	rom ( name "SKY.DNR" size 40796 crc a3206462 md5 f05a0ae79722022b31cfbaf3b7c92578 )
+	name "Bud Tucker in Double Trouble"
+	description "Bud Tucker in Double Trouble"
+	rom ( name "Bud Tucker in Double Trouble CRLF.scummvm" size 8 crc 9d1ca87b )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/French)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/French)[!]"
-	rom ( name "FRENCH.ROM" size 52 crc 544fce3d md5 056707d0c5ebad96db97d7233acbadf6 )
+	name "Bud Tucker in Double Trouble"
+	description "Bud Tucker in Double Trouble"
+	rom ( name "Bud Tucker in Double Trouble LF.scummvm" size 7 crc 5fd1310a )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/German)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/German)[!]"
-	rom ( name "GERMAN.ROM" size 52 crc c9f9822a md5 undefined )
+	name "Bud Tucker in Double Trouble"
+	description "Bud Tucker in Double Trouble"
+	rom ( name "Bud Tucker in Double Trouble CR.scummvm" size 7 crc c1b5a4a9 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/Italian)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/Italian)[!]"
-	rom ( name "ITALIAN.ROM" size 53 crc 932e1d79 md5 f1923c3afc34c50470a1e1b4b238461f )
+	name "Cinematique evo.1 engine game"
+	description "Cinematique evo.1 engine game"
+	rom ( name "Cinematique evo.1 engine game.scummvm" size 4 crc 8977a4a0 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/Portuguese)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/Portuguese)[!]"
-	rom ( name "PORTUGUESE.ROM" size 56 crc 51ff58cc md5 ecb392c326ea7ab869fe272b9354f941 )
+	name "Cinematique evo.1 engine game"
+	description "Cinematique evo.1 engine game"
+	rom ( name "Cinematique evo.1 engine game CRLF.scummvm" size 6 crc 6b1ed7c3 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/Spanish)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/Spanish)[!]"
-	rom ( name "SPANISH.ROM" size 53 crc f1eab4b9 md5 undefined )
+	name "Cinematique evo.1 engine game"
+	description "Cinematique evo.1 engine game"
+	rom ( name "Cinematique evo.1 engine game LF.scummvm" size 5 crc e488d2df )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/EU/Swedish)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/EU/Swedish)[!]"
-	rom ( name "SWEDISH.ROM" size 53 crc 2089d522 md5 undefined )
+	name "Cinematique evo.1 engine game"
+	description "Cinematique evo.1 engine game"
+	rom ( name "Cinematique evo.1 engine game CR.scummvm" size 5 crc 7aec477c )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/French)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/French)[!]"
-	rom ( name "FRENCH.ROM" size 39 crc e745a323 md5 deba4ce3b03cd536cacce57418d89059 )
+	name "Cinematique evo.2 engine game"
+	description "Cinematique evo.2 engine game"
+	rom ( name "Cinematique evo.2 engine game.scummvm" size 6 crc 9e9d701b )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/German)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/German)[!]"
-	rom ( name "GERMAN.ROM" size 39 crc ca4a0d20 md5 b1d764572b370eee73fe1d5fe1a2875e )
+	name "Cinematique evo.2 engine game"
+	description "Cinematique evo.2 engine game"
+	rom ( name "Cinematique evo.2 engine game CRLF.scummvm" size 8 crc ed91a197 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/Hungarian)"
-	description "Beneath a Steel Sky (v0.0368 CD/Hungarian)"
-	rom ( name "SKY.DNR" size 40796 crc 777df536 md5 13e49ab86dafea375c02aa9079382a8f )
+	name "Cinematique evo.2 engine game"
+	description "Cinematique evo.2 engine game"
+	rom ( name "Cinematique evo.2 engine game LF.scummvm" size 7 crc b82c520f )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/Italian)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/Italian)[!]"
-	rom ( name "ITALIAN.ROM" size 40 crc b6c577f9 md5 undefined )
+	name "Cinematique evo.2 engine game"
+	description "Cinematique evo.2 engine game"
+	rom ( name "Cinematique evo.2 engine game CR.scummvm" size 7 crc 2648c7ac )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/Spanish)[!]"
-	description "Beneath a Steel Sky (v0.0368 CD/Spanish)[!]"
-	rom ( name "SPANISH.ROM" size 40 crc 9cc9fdf1 md5 undefined )
+	name "Composer Game"
+	description "Composer Game"
+	rom ( name "Composer Game.scummvm" size 8 crc 987306d8 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US)"
-	description "Beneath a Steel Sky (v0.0368 CD/US)"
-	rom ( name "SKY.DNR" size 40796 crc a3206462 md5 f05a0ae79722022b31cfbaf3b7c92578 )
+	name "Composer Game"
+	description "Composer Game"
+	rom ( name "Composer Game CRLF.scummvm" size 10 crc b420f7fd )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/French)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/French)"
-	rom ( name "FRENCH.ROM" size 64 crc bd0c2ed7 md5 undefined )
+	name "Composer Game"
+	description "Composer Game"
+	rom ( name "Composer Game LF.scummvm" size 9 crc ba472f73 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/German)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/German)"
-	rom ( name "GERMAN.ROM" size 64 crc 34cca5a4 md5 b1c30717d38e2a59fbe33abc974adedb )
+	name "Composer Game"
+	description "Composer Game"
+	rom ( name "Composer Game CR.scummvm" size 9 crc 2423bad0 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/Italian)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/Italian)"
-	rom ( name "ITALIAN.ROM" size 65 crc f92082f5 md5 484e256eb99d83a36e8f8262db28091d )
+	name "Day of the Tentacle"
+	description "Day of the Tentacle"
+	rom ( name "Day of the Tentacle.scummvm" size 8 crc 97815f07 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/Portuguese)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/Portuguese)"
-	rom ( name "PORTUGUESE.ROM" size 68 crc 9bc0d1fc md5 undefined )
+	name "Day of the Tentacle"
+	description "Day of the Tentacle"
+	rom ( name "Day of the Tentacle CRLF.scummvm" size 10 crc a037c88f )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/Spanish)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/Spanish)"
-	rom ( name "SPANISH.ROM" size 65 crc 658c0bc2 md5 3e5cbd9620c31d874486d3baa8b0df3a )
+	name "Day of the Tentacle"
+	description "Day of the Tentacle"
+	rom ( name "Day of the Tentacle LF.scummvm" size 9 crc ac24126f )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0368 CD/US/Swedish)"
-	description "Beneath a Steel Sky (v0.0368 CD/US/Swedish)"
-	rom ( name "SWEDISH.ROM" size 65 crc 51eb18d2 md5 undefined )
+	name "Day of the Tentacle"
+	description "Day of the Tentacle"
+	rom ( name "Day of the Tentacle CR.scummvm" size 9 crc 324087cc )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD)[!]"
-	rom ( name "SKY.DNR" size 40780 crc 3d09639f md5 2484982a89dec770c7e283fb0081eba2 )
+	name "Demon in my Pocket"
+	description "Demon in my Pocket"
+	rom ( name "Demon in my Pocket.scummvm" size 4 crc 52502b31 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/French)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/French)[!]"
-	rom ( name "FRENCH.ROM" size 39 crc d0e492c7 md5 c77734d224d05cd6f0cbda9d20368df9 )
+	name "Demon in my Pocket"
+	description "Demon in my Pocket"
+	rom ( name "Demon in my Pocket CRLF.scummvm" size 6 crc 7e43290e )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/German)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/German)[!]"
-	rom ( name "GERMAN.ROM" size 39 crc fdeb3cc4 md5 7bfa1487dc65b367fb0004fcf8bbcf5b )
+	name "Demon in my Pocket"
+	description "Demon in my Pocket"
+	rom ( name "Demon in my Pocket LF.scummvm" size 5 crc 635b5682 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/Italian)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/Italian)[!]"
-	rom ( name "ITALIAN.ROM" size 40 crc 1195f0a9 md5 undefined )
+	name "Demon in my Pocket"
+	description "Demon in my Pocket"
+	rom ( name "Demon in my Pocket CR.scummvm" size 5 crc fd3fc321 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/Polish)"
-	description "Beneath a Steel Sky (v0.0372 CD/Polish)"
-	rom ( name "sky.dnr" size 40780 crc 8a653afe md5 db305aaf1d80990557ea3d5bb2a823b8 )
+	name "Draci Historie"
+	description "Draci Historie"
+	rom ( name "Draci Historie.scummvm" size 5 crc 580d0e08 )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/Portuguese)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/Portuguese)[!]"
-	rom ( name "PORTUGUESE.ROM" size 43 crc 318d68d7 md5 56b1e465c270c00627fa84bdbaeeb0eb )
+	name "Draci Historie"
+	description "Draci Historie"
+	rom ( name "Draci Historie CRLF.scummvm" size 7 crc 3bc37aae )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/Spanish)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/Spanish)[!]"
-	rom ( name "SPANISH.ROM" size 40 crc 3b997aa1 md5 undefined )
+	name "Draci Historie"
+	description "Draci Historie"
+	rom ( name "Draci Historie LF.scummvm" size 6 crc 3c5483af )
 )
 
 game (
-	name "Beneath a Steel Sky (v0.0372 CD/Swedish)[!]"
-	description "Beneath a Steel Sky (v0.0372 CD/Swedish)[!]"
-	rom ( name "SWEDISH.ROM" size 40 crc 2f1f1e98 md5 undefined )
+	name "Draci Historie"
+	description "Draci Historie"
+	rom ( name "Draci Historie CR.scummvm" size 6 crc a230160c )
 )
 
 game (
-	name "Betrayed Alliance (DOS/Fanmade)"
-	description "Betrayed Alliance (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 2367197 crc 5ebad0d7 md5 8cad6967653d9619fc52201c4474a510 )
+	name "Dragonsphere"
+	description "Dragonsphere"
+	rom ( name "Dragonsphere.scummvm" size 12 crc c691bb82 )
 )
 
 game (
-	name "Beyond the Threshold (Windows)"
-	description "Beyond the Threshold (Windows)"
-	rom ( name "data.dcp" size 12773712 crc fc1222e9 md5 undefined )
+	name "Dragonsphere"
+	description "Dragonsphere"
+	rom ( name "Dragonsphere CRLF.scummvm" size 14 crc 41a4d3f0 )
 )
 
 game (
-	name "Beyond the Titanic 2 (DOS/Fanmade)"
-	description "Beyond the Titanic 2 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 41990f02 md5 undefined )
+	name "Dragonsphere"
+	description "Dragonsphere"
+	rom ( name "Dragonsphere LF.scummvm" size 13 crc 31a77524 )
 )
 
 game (
-	name "Bickadoodle (v1.2/Windows)"
-	description "Bickadoodle (v1.2/Windows)"
-	rom ( name "Bickadoodle.exe" size 1994752 crc 69f3666a md5 undefined )
+	name "Dragonsphere"
+	description "Dragonsphere"
+	rom ( name "Dragonsphere CR.scummvm" size 13 crc afc3e087 )
 )
 
 game (
-	name "Big Red Adventure, The (Demo/Amiga)"
-	description "Big Red Adventure, The (Demo/Amiga)"
-	rom ( name "onoff.win" size 1251 crc dd8ebe18 md5 undefined )
+	name "Drascula The Vampire Strikes Back"
+	description "Drascula The Vampire Strikes Back"
+	rom ( name "Drascula The Vampire Strikes Back.scummvm" size 8 crc bffa71f9 )
 )
 
 game (
-	name "Big Red Adventure, The (Demo/DOS)"
-	description "Big Red Adventure, The (Demo/DOS)"
-	rom ( name "COMIC.FNT" size 7567 crc bd7da0bf md5 undefined )
+	name "Drascula The Vampire Strikes Back"
+	description "Drascula The Vampire Strikes Back"
+	rom ( name "Drascula The Vampire Strikes Back CRLF.scummvm" size 10 crc f6de2108 )
 )
 
 game (
-	name "Big Red Adventure, The (Multi-lingual/Amiga)[En,Fr,De,It]"
-	description "Big Red Adventure, The (Multi-lingual/Amiga)[En,Fr,De,It]"
-	rom ( name "onoff.win" size 1251 crc dd8ebe18 md5 undefined )
+	name "Drascula The Vampire Strikes Back"
+	description "Drascula The Vampire Strikes Back"
+	rom ( name "Drascula The Vampire Strikes Back LF.scummvm" size 9 crc f609b65a )
 )
 
 game (
-	name "Big Red Adventure, The (Multi-Lingual/DOS)[En,Fr,De,It]"
-	description "Big Red Adventure, The (Multi-Lingual/DOS)[En,Fr,De,It]"
-	rom ( name "COMIC.FNT" size 9879 crc eae76558 md5 7d1afb35e0f92585180c5febe9ab8900 )
+	name "Drascula The Vampire Strikes Back"
+	description "Drascula The Vampire Strikes Back"
+	rom ( name "Drascula The Vampire Strikes Back CR.scummvm" size 9 crc 686d23f9 )
 )
 
 game (
-	name "Big Thinkers First Grade (ALL/US)"
-	description "Big Thinkers First Grade (ALL/US)"
-	rom ( name "THINKER1.HE0" size 33270 crc 7fc5dda2 md5 5c21fc49aee8f46e58fef21579e614a1 )
+	name "DreamWeb"
+	description "DreamWeb"
+	rom ( name "DreamWeb.scummvm" size 8 crc 95dbbea3 )
 )
 
 game (
-	name "Big Thinkers First Grade (Demo/Windows/US)"
-	description "Big Thinkers First Grade (Demo/Windows/US)"
-	rom ( name "1GRADEMO.HE0" size 30919 crc 307e965d md5 0f5935bd5e88ba6f09e558d64459746d )
+	name "DreamWeb"
+	description "DreamWeb"
+	rom ( name "DreamWeb CRLF.scummvm" size 10 crc bd5161d6 )
 )
 
 game (
-	name "Big Thinkers First Grade (Windows)"
-	description "Big Thinkers First Grade (Windows)"
-	rom ( name "THINKER1.HE0" size 33270 crc de214045 md5 632d2fddb8ba97723fa15334763ae857 )
+	name "DreamWeb"
+	description "DreamWeb"
+	rom ( name "DreamWeb LF.scummvm" size 9 crc 7d9d2f7f )
 )
 
 game (
-	name "Big Thinkers Kindergarten (ALL)"
-	description "Big Thinkers Kindergarten (ALL)"
-	rom ( name "THINKERK.HE0" size 30560 crc 801d5cb5 md5 92fc0073a4cf259ff36070ecb8628ba8 )
+	name "DreamWeb"
+	description "DreamWeb"
+	rom ( name "DreamWeb CR.scummvm" size 9 crc e3f9badc )
 )
 
 game (
-	name "Big Thinkers Kindergarten (Demo/ALL/US)[!]"
-	description "Big Thinkers Kindergarten (Demo/ALL/US)[!]"
-	rom ( name "KINDDEMO.HE0" size 29789 crc 708522a0 md5 695fe0b3963333b7e15b37514db3c745 )
+	name "Elvira - Mistress of the Dark"
+	description "Elvira - Mistress of the Dark"
+	rom ( name "Elvira - Mistress of the Dark.scummvm" size 7 crc 71253819 )
 )
 
 game (
-	name "Biru Quest 1 (DOS/Fanmade)"
-	description "Biru Quest 1 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 8f12f04b md5 1b08f34f2c43e626c775c9d6649e2f17 )
+	name "Elvira - Mistress of the Dark"
+	description "Elvira - Mistress of the Dark"
+	rom ( name "Elvira - Mistress of the Dark CRLF.scummvm" size 9 crc a7a0e50f )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (Demo/Non-Interactive/DOS)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (Demo/Non-Interactive/DOS)"
-	rom ( name "DEMO.SCN" size 89 crc b7e675f7 md5 undefined )
+	name "Elvira - Mistress of the Dark"
+	description "Elvira - Mistress of the Dark"
+	rom ( name "Elvira - Mistress of the Dark LF.scummvm" size 8 crc 56cd8b6b )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/French)[!]"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/French)[!]"
-	rom ( name "INTRO.STK" size 20296390 crc 651ad418 md5 undefined )
+	name "Elvira - Mistress of the Dark"
+	description "Elvira - Mistress of the Dark"
+	rom ( name "Elvira - Mistress of the Dark CR.scummvm" size 8 crc c8a91ec8 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/German)[!]"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/German)[!]"
-	rom ( name "INTRO.STK" size 20296422 crc 9a2da0b8 md5 undefined )
+	name "Elvira II - The Jaws of Cerberus"
+	description "Elvira II - The Jaws of Cerberus"
+	rom ( name "Elvira II - The Jaws of Cerberus.scummvm" size 7 crc e82c69a3 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/German)[Best of Sierra Nr. 5][!]"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/German)[Best of Sierra Nr. 5][!]"
-	rom ( name "INTRO.STK" size 20296422 crc 9a2da0b8 md5 undefined )
+	name "Elvira II - The Jaws of Cerberus"
+	description "Elvira II - The Jaws of Cerberus"
+	rom ( name "Elvira II - The Jaws of Cerberus CRLF.scummvm" size 9 crc a5e65b56 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Hungarian)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Hungarian)"
-	rom ( name "INTRO.STK" size 19744691 crc 8d211b5a md5 undefined )
+	name "Elvira II - The Jaws of Cerberus"
+	description "Elvira II - The Jaws of Cerberus"
+	rom ( name "Elvira II - The Jaws of Cerberus LF.scummvm" size 8 crc 7de0d8a8 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Italian)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Italian)"
-	rom ( name "INTRO.STK" size 7069736 crc 6c108e6f md5 undefined )
+	name "Elvira II - The Jaws of Cerberus"
+	description "Elvira II - The Jaws of Cerberus"
+	rom ( name "Elvira II - The Jaws of Cerberus CR.scummvm" size 8 crc e3844d0b )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Polish)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Polish)"
-	rom ( name "2BOUZ1A.VMD" size 21167 crc 3884d850 md5 undefined )
+	name "Eye of the Beholder"
+	description "Eye of the Beholder"
+	rom ( name "Eye of the Beholder.scummvm" size 3 crc f084a7c5 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Russian)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Russian)"
-	rom ( name "INTRO.STK" size 20296390 crc 58d70635 md5 undefined )
+	name "Eye of the Beholder"
+	description "Eye of the Beholder"
+	rom ( name "Eye of the Beholder CRLF.scummvm" size 5 crc ea9d6068 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Spanish)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/Spanish)"
-	rom ( name "INTRO.STK" size 20296452 crc 7244b755 md5 undefined )
+	name "Eye of the Beholder"
+	description "Eye of the Beholder"
+	rom ( name "Eye of the Beholder LF.scummvm" size 4 crc d929b40b )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/UK)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/UK)"
-	rom ( name "INTRO.STK" size 20296390 crc 651ad418 md5 undefined )
+	name "Eye of the Beholder"
+	description "Eye of the Beholder"
+	rom ( name "Eye of the Beholder CR.scummvm" size 4 crc 474d21a8 )
 )
 
 game (
-	name "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/US)"
-	description "Bizarre Adventures of Woodruff and the Schnibble, The (DOS/US)"
-	rom ( name "INTRO.STK" size 20298108 crc 3d83d332 md5 undefined )
+	name "Eye of the Beholder II The Legend of Darkmoon"
+	description "Eye of the Beholder II The Legend of Darkmoon"
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon.scummvm" size 4 crc f12b0c95 )
 )
 
 game (
-	name "Black Cauldron, The (Amiga/2.00 1987-06-14)"
-	description "Black Cauldron, The (Amiga/2.00 1987-06-14)"
-	rom ( name "LOGDIR" size 357 crc 5d4dd7a0 md5 7b01694af21213b4727bb94476f64eb5 )
+	name "Eye of the Beholder II The Legend of Darkmoon"
+	description "Eye of the Beholder II The Legend of Darkmoon"
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon CRLF.scummvm" size 6 crc 112246f3 )
 )
 
 game (
-	name "Black Cauldron, The (Apple IIgs/1.0O 1989-02-24)"
-	description "Black Cauldron, The (Apple IIgs/1.0O 1989-02-24)"
-	rom ( name "BC.SYS16" size 148192 crc b5e19ab3 md5 610b16ff027928592e3b0862486c6490 )
+	name "Eye of the Beholder II The Legend of Darkmoon"
+	description "Eye of the Beholder II The Legend of Darkmoon"
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon LF.scummvm" size 5 crc b2434a54 )
 )
 
 game (
-	name "Black Cauldron, The (CoCo3/Updated)"
-	description "Black Cauldron, The (CoCo3/Updated)"
-	rom ( name "logDir" size 357 crc 68596f31 md5 undefined )
+	name "Eye of the Beholder II The Legend of Darkmoon"
+	description "Eye of the Beholder II The Legend of Darkmoon"
+	rom ( name "Eye of the Beholder II The Legend of Darkmoon CR.scummvm" size 5 crc 2c27dff7 )
 )
 
 game (
-	name "Black Cauldron, The (Demo/DOS/Fanmade)"
-	description "Black Cauldron, The (Demo/DOS/Fanmade)"
-	rom ( name "resource.001" size 1881839 crc 15a9b542 md5 undefined )
+	name "Fatty Bear's Birthday Surprise"
+	description "Fatty Bear's Birthday Surprise"
+	rom ( name "Fatty Bear's Birthday Surprise.scummvm" size 5 crc cd8e0945 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/2.00 1987-06-14)"
-	description "Black Cauldron, The (DOS/2.00 1987-06-14)"
-	rom ( name "LOGDIR" size 357 crc 783a63a1 md5 7f598d4712319b09d7bd5b3be10a2e4a )
+	name "Fatty Bear's Birthday Surprise"
+	description "Fatty Bear's Birthday Surprise"
+	rom ( name "Fatty Bear's Birthday Surprise CRLF.scummvm" size 7 crc e0704bc6 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/2.10 1988-11-10 5.25')"
-	description "Black Cauldron, The (DOS/2.10 1988-11-10 5.25')"
-	rom ( name "BCDIR" size 1217 crc 2691d449 md5 undefined )
+	name "Fatty Bear's Birthday Surprise"
+	description "Fatty Bear's Birthday Surprise"
+	rom ( name "Fatty Bear's Birthday Surprise LF.scummvm" size 6 crc 34ac3d85 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/2.10)"
-	description "Black Cauldron, The (DOS/2.10)"
-	rom ( name "BCDIR" size 1217 crc b3af0f26 md5 undefined )
+	name "Fatty Bear's Birthday Surprise"
+	description "Fatty Bear's Birthday Surprise"
+	rom ( name "Fatty Bear's Birthday Surprise CR.scummvm" size 6 crc aac8a826 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Booter 1.1J)"
-	description "Black Cauldron, The (DOS/Booter 1.1J)"
-	rom ( name "bc-d1.img" size 368640 crc 34c07147 md5 9667f77040409777eb8b80555475f35e )
+	name "Fatty Bear's Fun Pack"
+	description "Fatty Bear's Fun Pack"
+	rom ( name "Fatty Bear's Fun Pack.scummvm" size 6 crc 3a07e8f6 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Booter 1.1K)"
-	description "Black Cauldron, The (DOS/Booter 1.1K)"
-	rom ( name "bc-d1.img" size 368640 crc cd86430a md5 6ffa36eb7685265c52ab4487ccfe0b0b )
+	name "Fatty Bear's Fun Pack"
+	description "Fatty Bear's Fun Pack"
+	rom ( name "Fatty Bear's Fun Pack CRLF.scummvm" size 8 crc f89593da )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Booter 1.1M)"
-	description "Black Cauldron, The (DOS/Booter 1.1M)"
-	rom ( name "bc-d1.img" size 368640 crc fa24b4eb md5 58dbc3256c00981d435502c464620963 )
+	name "Fatty Bear's Fun Pack"
+	description "Fatty Bear's Fun Pack"
+	rom ( name "Fatty Bear's Fun Pack LF.scummvm" size 7 crc 66335652 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Fanmade/Final)"
-	description "Black Cauldron, The (DOS/Fanmade/Final)"
-	rom ( name "RESOURCE.001" size 1677293 crc b4e0c29c md5 undefined )
+	name "Fatty Bear's Fun Pack"
+	description "Fatty Bear's Fun Pack"
+	rom ( name "Fatty Bear's Fun Pack CR.scummvm" size 7 crc f857c3f1 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Italian)[unl]"
-	description "Black Cauldron, The (DOS/Italian)[unl]"
-	rom ( name "LOGDIR" size 357 crc 3d7970db md5 undefined )
+	name "Flight of the Amazon Queen"
+	description "Flight of the Amazon Queen"
+	rom ( name "Flight of the Amazon Queen.scummvm" size 5 crc a2edb4ba )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Russian)"
-	description "Black Cauldron, The (DOS/Russian)"
-	rom ( name "LOGDIR" size 357 crc f76581dd md5 b7de782dfdf8ea7dde8064f09804bcf5 )
+	name "Flight of the Amazon Queen"
+	description "Flight of the Amazon Queen"
+	rom ( name "Flight of the Amazon Queen CRLF.scummvm" size 7 crc c68416e6 )
 )
 
 game (
-	name "Black Cauldron, The (DOS/Spanish)[Unl]"
-	description "Black Cauldron, The (DOS/Spanish)[Unl]"
-	rom ( name "LOGDIR" size 357 crc 1ff79454 md5 38a79b6a1708b28a8aee084795ae2aed )
+	name "Flight of the Amazon Queen"
+	description "Flight of the Amazon Queen"
+	rom ( name "Flight of the Amazon Queen LF.scummvm" size 6 crc 19c1b1b5 )
 )
 
 game (
-	name "Blue Force (CD/DOS)"
-	description "Blue Force (CD/DOS)"
-	rom ( name "BLUE.RLB" size 63863322 crc 507412da md5 ac29f38184cb3b874ea18523059872ba )
+	name "Flight of the Amazon Queen"
+	description "Flight of the Amazon Queen"
+	rom ( name "Flight of the Amazon Queen CR.scummvm" size 6 crc 87a52416 )
 )
 
 game (
-	name "Blue Force (DOS)"
-	description "Blue Force (DOS)"
-	rom ( name "BLUE.RLB" size 10032614 crc 5077a6b0 md5 467da43c848cc0e800b547c59d84ccb1 )
+	name "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	description "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds.scummvm" size 6 crc 9aa4edd9 )
 )
 
 game (
-	name "Blue Force (DOS)[v1.10]"
-	description "Blue Force (DOS)[v1.10]"
-	rom ( name "BLUE.RLB" size 10032614 crc 5077a6b0 md5 undefined )
+	name "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	description "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds CRLF.scummvm" size 8 crc 9ae3ff9b )
 )
 
 game (
-	name "Blue's 123 Time Activities (ALL)"
-	description "Blue's 123 Time Activities (ALL)"
-	rom ( name "Blues123time.(a)" size 27916510 crc f43e4657 md5 e212859b7ada9db715a4fd21d95ab11e )
+	name "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	description "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds LF.scummvm" size 7 crc cd42c80e )
 )
 
 game (
-	name "Blue's ABC Time Activities (ALL)"
-	description "Blue's ABC Time Activities (ALL)"
-	rom ( name "BluesABCTime.(a)" size 35597984 crc 54eb6891 md5 16ccacafed9f0296e4c1517e17b537e6 )
+	name "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	description "Freddi Fish 1 The Case of the Missing Kelp Seeds"
+	rom ( name "Freddi Fish 1 The Case of the Missing Kelp Seeds CR.scummvm" size 7 crc 53265dad )
 )
 
 game (
-	name "Blue's ABC Time Activities (Demo/ALL)[!]"
-	description "Blue's ABC Time Activities (Demo/ALL)[!]"
-	rom ( name "BluesABCTimeDemo.(a)" size 4147245 crc 9b14cd5a md5 undefined )
+	name "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	description "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse.scummvm" size 7 crc e5407090 )
 )
 
 game (
-	name "Blue's ABC Time Activities (Demo/ALL)[a][!]"
-	description "Blue's ABC Time Activities (Demo/ALL)[a][!]"
-	rom ( name "BluesABCTimeDemo.(a)" size 3892429 crc eefac7b7 md5 undefined )
+	name "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	description "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse CRLF.scummvm" size 9 crc 35e69bca )
 )
 
 game (
-	name "Blue's ABC Time Activities (Preview)[!]"
-	description "Blue's ABC Time Activities (Preview)[!]"
-	rom ( name "abc-slideshow.cup" size 4133436 crc ab2b9fc2 md5 d281f9c081ba95fa7c2e122a857658b2 )
+	name "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	description "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse LF.scummvm" size 8 crc c23dd5a7 )
 )
 
 game (
-	name "Blue's Art Time Activities (ALL)"
-	description "Blue's Art Time Activities (ALL)"
-	rom ( name "ArtTime.(a)" size 92921235 crc ef7f0c7a md5 undefined )
+	name "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	description "Freddi Fish 2 The Case of the Haunted Schoolhouse"
+	rom ( name "Freddi Fish 2 The Case of the Haunted Schoolhouse CR.scummvm" size 8 crc 5c594004 )
 )
 
 game (
-	name "Blue's Art Time Activities (Demo/ALL)[!]"
-	description "Blue's Art Time Activities (Demo/ALL)[!]"
-	rom ( name "artdemo.(a)" size 34541983 crc e3ec83b3 md5 548fcedaa9cee84443a5a9acfff4cb04 )
+	name "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	description "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell.scummvm" size 7 crc 92474006 )
 )
 
 game (
-	name "Blue's Birthday Adventure (Demo/ALL)[!]"
-	description "Blue's Birthday Adventure (Demo/ALL)[!]"
-	rom ( name "BluesBirthdayDemo.(a)" size 14266316 crc 17225f69 md5 18ee74255c93da057c92effbd39ebd9a )
+	name "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	description "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell CRLF.scummvm" size 9 crc 3424f1fd )
 )
 
 game (
-	name "Blue's Birthday Adventure (Demo/ALL)[a1][!]"
-	description "Blue's Birthday Adventure (Demo/ALL)[a1][!]"
-	rom ( name "BluesBirthdayDemo.(a)" size 14376827 crc eb349de0 md5 undefined )
+	name "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	description "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell LF.scummvm" size 8 crc db26e4e6 )
 )
 
 game (
-	name "Blue's Birthday Adventure (Demo/ALL)[a2]"
-	description "Blue's Birthday Adventure (Demo/ALL)[a2]"
-	rom ( name "BluesBirthdayDemo.(a)" size 14266316 crc 17225f69 md5 18ee74255c93da057c92effbd39ebd9a )
+	name "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	description "Freddi Fish 3 The Case of the Stolen Conch Shell"
+	rom ( name "Freddi Fish 3 The Case of the Stolen Conch Shell CR.scummvm" size 8 crc 45427145 )
 )
 
 game (
-	name "Blue's Birthday Adventure (Preview)[!]"
-	description "Blue's Birthday Adventure (Preview)[!]"
-	rom ( name "bda-slideshow.cup" size 7819264 crc 1c7d96c7 md5 undefined )
+	name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	description "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch.scummvm" size 7 crc c23d5a5 )
 )
 
 game (
-	name "Blue's Birthday Adventure (Red/Windows)"
-	description "Blue's Birthday Adventure (Red/Windows)"
-	rom ( name "Blue'sBirthday-Red.(a)" size 73101517 crc e43868a1 md5 undefined )
+	name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	description "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch CRLF.scummvm" size 9 crc 316be778 )
 )
 
 game (
-	name "Blue's Birthday Adventure (Yellow/ALL)"
-	description "Blue's Birthday Adventure (Yellow/ALL)"
-	rom ( name "Blue'sBirthday-Yellow.(a)" size 72047281 crc b408a6a4 md5 undefined )
+	name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	description "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch LF.scummvm" size 8 crc 94677221 )
 )
 
 game (
-	name "Blue's Reading Time Activities (ALL)"
-	description "Blue's Reading Time Activities (ALL)"
-	rom ( name "Blue's Reading Time.(a)" size 96102205 crc 9941116c md5 9609ff30d13ad2ebbbaff312be4a9715 )
+	name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	description "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch"
+	rom ( name "Freddi Fish 4 The Case of the Hogfish Rustlers of Briny Gulch CR.scummvm" size 8 crc a03e782 )
 )
 
 game (
-	name "Blue's Reading Time Activities (Demo/ALL)[!]"
-	description "Blue's Reading Time Activities (Demo/ALL)[!]"
-	rom ( name "readdemo.(a)" size 16413478 crc 920a0911 md5 undefined )
+	name "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	description "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove.scummvm" size 10 crc 2f36f61c )
 )
 
 game (
-	name "Blue's Treasure Hunt (Windows/Disc 1)"
-	description "Blue's Treasure Hunt (Windows/Disc 1)"
-	rom ( name "Blue'sTreasureHunt-Disc1.(a)" size 80873647 crc b22a1848 md5 undefined )
+	name "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	description "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove CRLF.scummvm" size 12 crc a60ba0ee )
 )
 
 game (
-	name "Blue's Treasure Hunt (Windows/Disc 2)"
-	description "Blue's Treasure Hunt (Windows/Disc 2)"
-	rom ( name "Blue'sTreasureHunt-Disc2.(a)" size 86266545 crc 4412b331 md5 undefined )
+	name "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	description "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove LF.scummvm" size 11 crc 26f96c2a )
 )
 
 game (
-	name "Bluntman and Chronic P.C. version (DOS/Fanmade)"
-	description "Bluntman and Chronic P.C. version (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 596688 crc 48440bb1 md5 undefined )
+	name "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	description "Freddi Fish 5 The Case of the Creature of Coral Cove"
+	rom ( name "Freddi Fish 5 The Case of the Creature of Coral Cove CR.scummvm" size 11 crc b89df989 )
 )
 
 game (
-	name "Bob The Farmboy (DOS/Fanmade)"
-	description "Bob The Farmboy (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 294460e5 md5 e4b7df9d0830addee5af946d380e66d7 )
+	name "Freddi Fish and Luther's Maze Madness"
+	description "Freddi Fish and Luther's Maze Madness"
+	rom ( name "Freddi Fish and Luther's Maze Madness.scummvm" size 4 crc 4915557e )
 )
 
 game (
-	name "Book of Gron Part One (Windows/Russian)"
-	description "Book of Gron Part One (Windows/Russian)"
-	rom ( name "data.dcp" size 83129531 crc 296174b1 md5 undefined )
+	name "Freddi Fish and Luther's Maze Madness"
+	description "Freddi Fish and Luther's Maze Madness"
+	rom ( name "Freddi Fish and Luther's Maze Madness CRLF.scummvm" size 6 crc be1f3dba )
 )
 
 game (
-	name "Boredom of Agustin Cordes (Windows)"
-	description "Boredom of Agustin Cordes (Windows)"
-	rom ( name "data.dcp" size 2461949 crc 596d1605 md5 59d02a63af810662374e15bd01249dc1 )
+	name "Freddi Fish and Luther's Maze Madness"
+	description "Freddi Fish and Luther's Maze Madness"
+	rom ( name "Freddi Fish and Luther's Maze Madness LF.scummvm" size 5 crc 85234ffd )
 )
 
 game (
-	name "Boring Man 1: The Toad to Robinland (DOS/Fanmade)"
-	description "Boring Man 1: The Toad to Robinland (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc eca525ab md5 undefined )
+	name "Freddi Fish and Luther's Maze Madness"
+	description "Freddi Fish and Luther's Maze Madness"
+	rom ( name "Freddi Fish and Luther's Maze Madness CR.scummvm" size 5 crc 1b47da5e )
 )
 
 game (
-	name "Boring Man 2: Ho Man! This Game Sucks! (DOS/Fanmade)"
-	description "Boring Man 2: Ho Man! This Game Sucks! (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc 5bc2e08c md5 250032ba105bdf7c1bc4fed767c2d37e )
+	name "Freddi Fish and Luther's Water Worries"
+	description "Freddi Fish and Luther's Water Worries"
+	rom ( name "Freddi Fish and Luther's Water Worries.scummvm" size 5 crc fb3314da )
 )
 
 game (
-	name "Botz (DOS/Fanmade)"
-	description "Botz (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc e129c3b8 md5 undefined )
+	name "Freddi Fish and Luther's Water Worries"
+	description "Freddi Fish and Luther's Water Worries"
+	rom ( name "Freddi Fish and Luther's Water Worries CRLF.scummvm" size 7 crc 75af8777 )
 )
 
 game (
-	name "Box, The (Windows)"
-	description "Box, The (Windows)"
-	rom ( name "data.dcp" size 108372483 crc d69fca97 md5 undefined )
+	name "Freddi Fish and Luther's Water Worries"
+	description "Freddi Fish and Luther's Water Worries"
+	rom ( name "Freddi Fish and Luther's Water Worries LF.scummvm" size 6 crc 542a0e4d )
 )
 
 game (
-	name "Brian's Quest (DOS/Fanmade v1.0)"
-	description "Brian's Quest (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc ac4fb9ad md5 0964aa79b9cdcff7f33a12b1d7e04b9c )
+	name "Freddi Fish and Luther's Water Worries"
+	description "Freddi Fish and Luther's Water Worries"
+	rom ( name "Freddi Fish and Luther's Water Worries CR.scummvm" size 6 crc ca4e9bee )
 )
 
 game (
-	name "Broken Sword 2.5 (Croatian)"
-	description "Broken Sword 2.5 (Croatian)"
-	rom ( name "lang_hr.b25c" size 1273217 crc c56a8f16 md5 5720ef33039ed8d2ed3c9b66a056c217 )
+	name "Freddi Fish's One-Stop Fun Shop"
+	description "Freddi Fish's One-Stop Fun Shop"
+	rom ( name "Freddi Fish's One-Stop Fun Shop.scummvm" size 14 crc 9faddef6 )
 )
 
 game (
-	name "Broken Sword 2.5 (English)"
-	description "Broken Sword 2.5 (English)"
-	rom ( name "lang_en.b25c" size 170856736 crc d659b8e0 md5 f603644ab24a54bbea0ca86484adf42f )
+	name "Freddi Fish's One-Stop Fun Shop"
+	description "Freddi Fish's One-Stop Fun Shop"
+	rom ( name "Freddi Fish's One-Stop Fun Shop CRLF.scummvm" size 16 crc 372fa3e9 )
 )
 
 game (
-	name "Broken Sword 2.5 (French)"
-	description "Broken Sword 2.5 (French)"
-	rom ( name "lang_fr.b25c" size 1006043 crc 47275cb6 md5 undefined )
+	name "Freddi Fish's One-Stop Fun Shop"
+	description "Freddi Fish's One-Stop Fun Shop"
+	rom ( name "Freddi Fish's One-Stop Fun Shop LF.scummvm" size 15 crc 6696fc64 )
 )
 
 game (
-	name "Broken Sword 2.5 (German)"
-	description "Broken Sword 2.5 (German)"
-	rom ( name "data.b25c" size 654310588 crc eda6196f md5 undefined )
+	name "Freddi Fish's One-Stop Fun Shop"
+	description "Freddi Fish's One-Stop Fun Shop"
+	rom ( name "Freddi Fish's One-Stop Fun Shop CR.scummvm" size 15 crc f8f269c7 )
 )
 
 game (
-	name "Broken Sword 2.5 (Hungarian)[Psylog]"
-	description "Broken Sword 2.5 (Hungarian)[Psylog]"
-	rom ( name "lang_hu.b25c" size 1864915 crc 494ec580 md5 undefined )
+	name "Full Throttle"
+	description "Full Throttle"
+	rom ( name "Full Throttle.scummvm" size 2 crc 25166bfb )
 )
 
 game (
-	name "Broken Sword 2.5 (Italian)"
-	description "Broken Sword 2.5 (Italian)"
-	rom ( name "lang_it.b25c" size 996197 crc d101f416 md5 8582d73e046265da447af52890d11cd0 )
+	name "Full Throttle"
+	description "Full Throttle"
+	rom ( name "Full Throttle CRLF.scummvm" size 4 crc 398a201c )
 )
 
 game (
-	name "Broken Sword 2.5 (Multi-Language)[!]"
-	description "Broken Sword 2.5 (Multi-Language)[!]"
-	rom ( name "data.b25c" size 827397764 crc 1659e20f md5 1f89a63e3509aa64626cc90cd2561032 )
+	name "Full Throttle"
+	description "Full Throttle"
+	rom ( name "Full Throttle LF.scummvm" size 3 crc 189d3b6c )
 )
 
 game (
-	name "Broken Sword 2.5 (Polish)"
-	description "Broken Sword 2.5 (Polish)"
-	rom ( name "lang_pl.b25c" size 1281799 crc 9e21baf9 md5 undefined )
+	name "Full Throttle"
+	description "Full Throttle"
+	rom ( name "Full Throttle CR.scummvm" size 3 crc 86f9aecf )
 )
 
 game (
-	name "Broken Sword 2.5 (Portuguese)"
-	description "Broken Sword 2.5 (Portuguese)"
-	rom ( name "lang_pt.b25c" size 993812 crc 9806539c md5 undefined )
+	name "Gnap"
+	description "Gnap"
+	rom ( name "Gnap.scummvm" size 4 crc e91fdd56 )
 )
 
 game (
-	name "Broken Sword 2.5 (Russian)"
-	description "Broken Sword 2.5 (Russian)"
-	rom ( name "lang_ru.b25c" size 1235378 crc 65b09953 md5 288e1455b9e6083b394c8928b3c4bd0b )
+	name "Gnap"
+	description "Gnap"
+	rom ( name "Gnap CRLF.scummvm" size 6 crc 213808 )
 )
 
 game (
-	name "Broken Sword 2.5 (Spanish)"
-	description "Broken Sword 2.5 (Spanish)"
-	rom ( name "lang_es.b25c" size 987965 crc 15d8b938 md5 2ee44a258b1e8cc882bd712633625908 )
+	name "Gnap"
+	description "Gnap"
+	rom ( name "Gnap LF.scummvm" size 5 crc b036ed8f )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (Demo/PC)"
-	description "Broken Sword II: The Smoking Mirror (Demo/PC)"
-	rom ( name "CD.INF" size 294 crc ca2f2eea md5 undefined )
+	name "Gnap"
+	description "Gnap"
+	rom ( name "Gnap CR.scummvm" size 5 crc 2e52782c )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (Demo/PlayStation)"
-	description "Broken Sword II: The Smoking Mirror (Demo/PlayStation)"
-	rom ( name "DOCKS.CLU" size 5818340 crc eb7a2ec0 md5 d1caaca15b76221c63d4d00543bb63b2 )
+	name "Gob engine game"
+	description "Gob engine game"
+	rom ( name "Gob engine game.scummvm" size 3 crc f30073ab )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC)[!]"
-	description "Broken Sword II: The Smoking Mirror (PC)[!]"
-	rom ( name "CREDITS.CLU" size 4747 crc fef18f18 md5 bd5868013e558ff69debe299ed7ffe1c )
+	name "Gob engine game"
+	description "Gob engine game"
+	rom ( name "Gob engine game CRLF.scummvm" size 5 crc 905d3308 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/1cd version)[!]"
-	description "Broken Sword II: The Smoking Mirror (PC/1cd version)[!]"
-	rom ( name "CARIB1.CLU" size 29537932 crc 071045d3 md5 undefined )
+	name "Gob engine game"
+	description "Gob engine game"
+	rom ( name "Gob engine game LF.scummvm" size 4 crc 73207c80 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/French)[!]"
-	description "Broken Sword II: The Smoking Mirror (PC/French)[!]"
-	rom ( name "CREDITS.CLU" size 3731 crc 785a1a42 md5 undefined )
+	name "Gob engine game"
+	description "Gob engine game"
+	rom ( name "Gob engine game CR.scummvm" size 4 crc ed44e923 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/German)"
-	description "Broken Sword II: The Smoking Mirror (PC/German)"
-	rom ( name "CREDITS.CLU" size 6043 crc 7ce1f77e md5 undefined )
+	name "Groovie engine game"
+	description "Groovie engine game"
+	rom ( name "Groovie engine game.scummvm" size 7 crc 342b57cd )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/GOG version)[!]"
-	description "Broken Sword II: The Smoking Mirror (PC/GOG version)[!]"
-	rom ( name "CREDITS.CLU" size 4747 crc fef18f18 md5 bd5868013e558ff69debe299ed7ffe1c )
+	name "Groovie engine game"
+	description "Groovie engine game"
+	rom ( name "Groovie engine game CRLF.scummvm" size 9 crc 9ff9dcd3 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/Hungarian)"
-	description "Broken Sword II: The Smoking Mirror (PC/Hungarian)"
-	rom ( name "CREDITS.CLU" size 4747 crc fef18f18 md5 bd5868013e558ff69debe299ed7ffe1c )
+	name "Groovie engine game"
+	description "Groovie engine game"
+	rom ( name "Groovie engine game LF.scummvm" size 8 crc d73693c9 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/Italian)"
-	description "Broken Sword II: The Smoking Mirror (PC/Italian)"
-	rom ( name "CREDITS.CLU" size 4629 crc 3ef48fd0 md5 undefined )
+	name "Groovie engine game"
+	description "Groovie engine game"
+	rom ( name "Groovie engine game CR.scummvm" size 8 crc 4952066a )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/Portuguese)"
-	description "Broken Sword II: The Smoking Mirror (PC/Portuguese)"
-	rom ( name "CREDITS.CLU" size 4747 crc fef18f18 md5 bd5868013e558ff69debe299ed7ffe1c )
+	name "Hi-Res Adventure #0 Mission Asteroid"
+	description "Hi-Res Adventure #0 Mission Asteroid"
+	rom ( name "Hi-Res Adventure #0 Mission Asteroid.scummvm" size 6 crc 6ca642ed )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/Russian)"
-	description "Broken Sword II: The Smoking Mirror (PC/Russian)"
-	rom ( name "CREDITS.CLU" size 4042 crc 0efe9fa2 md5 9df5c88f1c7bb4bf89fcb074d80b3efa )
+	name "Hi-Res Adventure #0 Mission Asteroid"
+	description "Hi-Res Adventure #0 Mission Asteroid"
+	rom ( name "Hi-Res Adventure #0 Mission Asteroid CRLF.scummvm" size 8 crc 67a04417 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PC/Spanish)"
-	description "Broken Sword II: The Smoking Mirror (PC/Spanish)"
-	rom ( name "CREDITS.CLU" size 5196 crc a8576020 md5 90ff523386ed271527ec0cd695210ad2 )
+	name "Hi-Res Adventure #0 Mission Asteroid"
+	description "Hi-Res Adventure #0 Mission Asteroid"
+	rom ( name "Hi-Res Adventure #0 Mission Asteroid LF.scummvm" size 7 crc ec003e14 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/EU)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/EU)[!]"
-	rom ( name "CREDITS.TXT" size 4253 crc 7ff46981 md5 a22d0ec16793ef4be9fb289295726736 )
+	name "Hi-Res Adventure #0 Mission Asteroid"
+	description "Hi-Res Adventure #0 Mission Asteroid"
+	rom ( name "Hi-Res Adventure #0 Mission Asteroid CR.scummvm" size 7 crc 7264abb7 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/French)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/French)[!]"
-	rom ( name "CREDITS.TXT" size 3269 crc c0a370a1 md5 undefined )
+	name "Hi-Res Adventure #1 Mystery House"
+	description "Hi-Res Adventure #1 Mystery House"
+	rom ( name "Hi-Res Adventure #1 Mystery House.scummvm" size 6 crc 1ba1727b )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/German)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/German)[!]"
-	rom ( name "CREDITS.TXT" size 3982 crc 581c6b09 md5 undefined )
+	name "Hi-Res Adventure #1 Mystery House"
+	description "Hi-Res Adventure #1 Mystery House"
+	rom ( name "Hi-Res Adventure #1 Mystery House CRLF.scummvm" size 8 crc 66622e20 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/Italian)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/Italian)[!]"
-	rom ( name "CREDITS.TXT" size 4269 crc b8892501 md5 a7de18b465596d3a93665cf48e4024dc )
+	name "Hi-Res Adventure #1 Mystery House"
+	description "Hi-Res Adventure #1 Mystery House"
+	rom ( name "Hi-Res Adventure #1 Mystery House LF.scummvm" size 7 crc f51b0f55 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/Spanish)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/Spanish)[!]"
-	rom ( name "CREDITS.TXT" size 4624 crc 4aa2f9e4 md5 728530292cdcc914a13ee520de2812b9 )
+	name "Hi-Res Adventure #1 Mystery House"
+	description "Hi-Res Adventure #1 Mystery House"
+	rom ( name "Hi-Res Adventure #1 Mystery House CR.scummvm" size 7 crc 6b7f9af6 )
 )
 
 game (
-	name "Broken Sword II: The Smoking Mirror (PlayStation/US)[!]"
-	description "Broken Sword II: The Smoking Mirror (PlayStation/US)[!]"
-	rom ( name "CREDITS.TXT" size 4213 crc e409b6b8 md5 undefined )
+	name "Hi-Res Adventure #2 Wizard and the Princess"
+	description "Hi-Res Adventure #2 Wizard and the Princess"
+	rom ( name "Hi-Res Adventure #2 Wizard and the Princess.scummvm" size 6 crc 82a823c1 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Demo/Macintosh)"
-	description "Broken Sword: The Shadow of the Templars (Demo/Macintosh)"
-	rom ( name "CLUSTERS\COMPACTS.CLM" size 200852 crc 6bffd0c1 md5 1bd345eda284611be3d4ba1483d0ab6c )
+	name "Hi-Res Adventure #2 Wizard and the Princess"
+	description "Hi-Res Adventure #2 Wizard and the Princess"
+	rom ( name "Hi-Res Adventure #2 Wizard and the Princess CRLF.scummvm" size 8 crc 64249079 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Demo/PC)"
-	description "Broken Sword: The Shadow of the Templars (Demo/PC)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200156 crc 02c60cc2 md5 undefined )
+	name "Hi-Res Adventure #2 Wizard and the Princess"
+	description "Hi-Res Adventure #2 Wizard and the Princess"
+	rom ( name "Hi-Res Adventure #2 Wizard and the Princess LF.scummvm" size 7 crc de365c96 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Demo/PC/Portuguese)"
-	description "Broken Sword: The Shadow of the Templars (Demo/PC/Portuguese)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200156 crc 02c60cc2 md5 undefined )
+	name "Hi-Res Adventure #2 Wizard and the Princess"
+	description "Hi-Res Adventure #2 Wizard and the Princess"
+	rom ( name "Hi-Res Adventure #2 Wizard and the Princess CR.scummvm" size 7 crc 4052c935 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Demo/PlayStation)"
-	description "Broken Sword: The Shadow of the Templars (Demo/PlayStation)"
-	rom ( name "COMPACTS.CLU" size 200852 crc 87b1374a md5 undefined )
+	name "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	description "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	rom ( name "Hi-Res Adventure #4 Ulysses and the Golden Fleece.scummvm" size 6 crc 6bcb86f4 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Demo/PlayStation/Italian)"
-	description "Broken Sword: The Shadow of the Templars (Demo/PlayStation/Italian)"
-	rom ( name "COMPACTS.CLU" size 200852 crc 87b1374a md5 undefined )
+	name "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	description "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	rom ( name "Hi-Res Adventure #4 Ulysses and the Golden Fleece CRLF.scummvm" size 8 crc 60a9eccb )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (Macintosh)"
-	description "Broken Sword: The Shadow of the Templars (Macintosh)"
-	rom ( name "CLUSTERS\compacts.CLm" size 200852 crc 6bffd0c1 md5 undefined )
+	name "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	description "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	rom ( name "Hi-Res Adventure #4 Ulysses and the Golden Fleece LF.scummvm" size 7 crc 886cfb10 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC)[GOG][!]"
-	description "Broken Sword: The Shadow of the Templars (PC)[GOG][!]"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 87b1374a md5 7072952037a5e240c868d441ca4a6da9 )
+	name "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	description "Hi-Res Adventure #4 Ulysses and the Golden Fleece"
+	rom ( name "Hi-Res Adventure #4 Ulysses and the Golden Fleece CR.scummvm" size 7 crc 16086eb3 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Czech)"
-	description "Broken Sword: The Shadow of the Templars (PC/Czech)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 87b1374a md5 7072952037a5e240c868d441ca4a6da9 )
+	name "Hi-Res Adventure #6 The Dark Crystal"
+	description "Hi-Res Adventure #6 The Dark Crystal"
+	rom ( name "Hi-Res Adventure #6 The Dark Crystal.scummvm" size 6 crc 85c5e7d8 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/EU)[!]"
-	description "Broken Sword: The Shadow of the Templars (PC/EU)[!]"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 87b1374a md5 7072952037a5e240c868d441ca4a6da9 )
+	name "Hi-Res Adventure #6 The Dark Crystal"
+	description "Hi-Res Adventure #6 The Dark Crystal"
+	rom ( name "Hi-Res Adventure #6 The Dark Crystal CRLF.scummvm" size 8 crc 632d38a5 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/French)[!]"
-	description "Broken Sword: The Shadow of the Templars (PC/French)[!]"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 undefined )
+	name "Hi-Res Adventure #6 The Dark Crystal"
+	description "Hi-Res Adventure #6 The Dark Crystal"
+	rom ( name "Hi-Res Adventure #6 The Dark Crystal LF.scummvm" size 7 crc ba5a9992 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/German)"
-	description "Broken Sword: The Shadow of the Templars (PC/German)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 undefined )
+	name "Hi-Res Adventure #6 The Dark Crystal"
+	description "Hi-Res Adventure #6 The Dark Crystal"
+	rom ( name "Hi-Res Adventure #6 The Dark Crystal CR.scummvm" size 7 crc 243e0c31 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Hungarian)"
-	description "Broken Sword: The Shadow of the Templars (PC/Hungarian)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 undefined )
+	name "Hopkins FBI"
+	description "Hopkins FBI"
+	rom ( name "Hopkins FBI.scummvm" size 7 crc bc1666be )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Italian)"
-	description "Broken Sword: The Shadow of the Templars (PC/Italian)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 87b1374a md5 7072952037a5e240c868d441ca4a6da9 )
+	name "Hopkins FBI"
+	description "Hopkins FBI"
+	rom ( name "Hopkins FBI CRLF.scummvm" size 9 crc ca357ee1 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Portuguese)"
-	description "Broken Sword: The Shadow of the Templars (PC/Portuguese)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 undefined )
+	name "Hopkins FBI"
+	description "Hopkins FBI"
+	rom ( name "Hopkins FBI LF.scummvm" size 8 crc 1eb28e7e )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Russian)[Akella]"
-	description "Broken Sword: The Shadow of the Templars (PC/Russian)[Akella]"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 0502c541a978785aac089d0b04bd0db9 )
+	name "Hopkins FBI"
+	description "Hopkins FBI"
+	rom ( name "Hopkins FBI CR.scummvm" size 8 crc 80d61bdd )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/Spanish)"
-	description "Broken Sword: The Shadow of the Templars (PC/Spanish)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 87b1374a md5 undefined )
+	name "Hugo 1 Hugo's House of Horrors"
+	description "Hugo 1 Hugo's House of Horrors"
+	rom ( name "Hugo 1 Hugo's House of Horrors.scummvm" size 5 crc cda231c8 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PC/US)"
-	description "Broken Sword: The Shadow of the Templars (PC/US)"
-	rom ( name "CLUSTERS\COMPACTS.CLU" size 200852 crc 3d8406bc md5 0502c541a978785aac089d0b04bd0db9 )
+	name "Hugo 1 Hugo's House of Horrors"
+	description "Hugo 1 Hugo's House of Horrors"
+	rom ( name "Hugo 1 Hugo's House of Horrors CRLF.scummvm" size 7 crc 465f1572 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/EU)[!]"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/EU)[!]"
-	rom ( name "CREDITS.DAT" size 2799 crc 073c25d9 md5 69349710eef6b653ed2c02643ed6c4a0 )
+	name "Hugo 1 Hugo's House of Horrors"
+	description "Hugo 1 Hugo's House of Horrors"
+	rom ( name "Hugo 1 Hugo's House of Horrors LF.scummvm" size 6 crc a7a5ee20 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/French)[!]"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/French)[!]"
-	rom ( name "CREDITS.DAT" size 2382 crc c77c1307 md5 undefined )
+	name "Hugo 1 Hugo's House of Horrors"
+	description "Hugo 1 Hugo's House of Horrors"
+	rom ( name "Hugo 1 Hugo's House of Horrors CR.scummvm" size 6 crc 39c17b83 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/German)[!]"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/German)[!]"
-	rom ( name "CREDITS.DAT" size 2382 crc 6a01d331 md5 c4f84aaa17f80fb549a5c8a867a9836a )
+	name "Hugo 2 Whodunit"
+	description "Hugo 2 Whodunit"
+	rom ( name "Hugo 2 Whodunit.scummvm" size 5 crc 54ab6072 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/Italian)"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/Italian)"
-	rom ( name "CREDITS.DAT" size 2823 crc 8a945091 md5 undefined )
+	name "Hugo 2 Whodunit"
+	description "Hugo 2 Whodunit"
+	rom ( name "Hugo 2 Whodunit CRLF.scummvm" size 7 crc 4419ab2b )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/Spanish)[!]"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/Spanish)[!]"
-	rom ( name "CREDITS.DAT" size 2412 crc 03ad648b md5 cd97e8f5006d91914904b3bfdb0ff588 )
+	name "Hugo 2 Whodunit"
+	description "Hugo 2 Whodunit"
+	rom ( name "Hugo 2 Whodunit LF.scummvm" size 6 crc 8c88bde3 )
 )
 
 game (
-	name "Broken Sword: The Shadow of the Templars (PlayStation/US)[!]"
-	description "Broken Sword: The Shadow of the Templars (PlayStation/US)[!]"
-	rom ( name "CREDITS.DAT" size 3312 crc f38d0f0b md5 undefined )
+	name "Hugo 2 Whodunit"
+	description "Hugo 2 Whodunit"
+	rom ( name "Hugo 2 Whodunit CR.scummvm" size 6 crc 12ec2840 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (Demo/DOS)"
-	description "Bud Tucker in Double Trouble (Demo/DOS)"
-	rom ( name "A10_01.SPR" size 35680 crc 6dd358d8 md5 undefined )
+	name "Hugo 3 Jungle of Doom"
+	description "Hugo 3 Jungle of Doom"
+	rom ( name "Hugo 3 Jungle of Doom.scummvm" size 5 crc 23ac50e4 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (Demo/Non-Interactive/DOS)"
-	description "Bud Tucker in Double Trouble (Demo/Non-Interactive/DOS)"
-	rom ( name "SAMPLE.AD" size 3622 crc 1db21bed md5 4df3a9a0b994aa77725a93aa752fd681 )
+	name "Hugo 3 Jungle of Doom"
+	description "Hugo 3 Jungle of Doom"
+	rom ( name "Hugo 3 Jungle of Doom CRLF.scummvm" size 7 crc 45dbc11c )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (DOS)"
-	description "Bud Tucker in Double Trouble (DOS)"
-	rom ( name "_BACKUP_.PCX" size 27381 crc dc8044f0 md5 e54eeb5f03597c0a04459ebb64eca331 )
+	name "Hugo 3 Jungle of Doom"
+	description "Hugo 3 Jungle of Doom"
+	rom ( name "Hugo 3 Jungle of Doom LF.scummvm" size 6 crc 95938ca2 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (DOS/French)"
-	description "Bud Tucker in Double Trouble (DOS/French)"
-	rom ( name "_BACKUP_.PCX" size 27381 crc dc8044f0 md5 e54eeb5f03597c0a04459ebb64eca331 )
+	name "Hugo 3 Jungle of Doom"
+	description "Hugo 3 Jungle of Doom"
+	rom ( name "Hugo 3 Jungle of Doom CR.scummvm" size 6 crc bf71901 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (DOS/German)"
-	description "Bud Tucker in Double Trouble (DOS/German)"
-	rom ( name "_BACKUP_.PCX" size 27381 crc dc8044f0 md5 e54eeb5f03597c0a04459ebb64eca331 )
+	name "Humongous Interactive Catalog"
+	description "Humongous Interactive Catalog"
+	rom ( name "Humongous Interactive Catalog.scummvm" size 7 crc 1b2c3247 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (DOS/Polish)"
-	description "Bud Tucker in Double Trouble (DOS/Polish)"
-	rom ( name "_BACKUP_.PCX" size 27381 crc dc8044f0 md5 e54eeb5f03597c0a04459ebb64eca331 )
+	name "Humongous Interactive Catalog"
+	description "Humongous Interactive Catalog"
+	rom ( name "Humongous Interactive Catalog CRLF.scummvm" size 9 crc 634d16c2 )
 )
 
 game (
-	name "Bud Tucker in Double Trouble (DOS/Spanish)"
-	description "Bud Tucker in Double Trouble (DOS/Spanish)"
-	rom ( name "_BACKUP_.PCX" size 27381 crc dc8044f0 md5 e54eeb5f03597c0a04459ebb64eca331 )
+	name "Humongous Interactive Catalog"
+	description "Humongous Interactive Catalog"
+	rom ( name "Humongous Interactive Catalog LF.scummvm" size 8 crc da74fe92 )
 )
 
 game (
-	name "Bug Hunt (Macintosh)"
-	description "Bug Hunt (Macintosh)"
-	rom ( name "._Bug Hunt" size 200365 crc 165a1504 md5 e30a2cb496ee29f2dc8808fabc333381 )
+	name "Humongous Interactive Catalog"
+	description "Humongous Interactive Catalog"
+	rom ( name "Humongous Interactive Catalog CR.scummvm" size 8 crc 44106b31 )
 )
 
 game (
-	name "Bug Hunt (Macintosh)[a]"
-	description "Bug Hunt (Macintosh)[a]"
-	rom ( name "._Bug Hunt" size 200704 crc 15c344b4 md5 e9cfde14c26a9798e99840482e9d1597 )
+	name "Indiana Jones and the Fate of Atlantis"
+	description "Indiana Jones and the Fate of Atlantis"
+	rom ( name "Indiana Jones and the Fate of Atlantis.scummvm" size 8 crc 4f12aa7c )
 )
 
 game (
-	name "Caitlyn's Destiny (Demo/DOS/Fanmade)"
-	description "Caitlyn's Destiny (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 321 crc fd1d576e md5 5b8a3cdb2fc05469f8119d49f50fbe98 )
+	name "Indiana Jones and the Fate of Atlantis"
+	description "Indiana Jones and the Fate of Atlantis"
+	rom ( name "Indiana Jones and the Fate of Atlantis CRLF.scummvm" size 10 crc a12bb6b2 )
 )
 
 game (
-	name "Caitlyn's Destiny (DOS/Fanmade)"
-	description "Caitlyn's Destiny (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 354 crc 195c525c md5 undefined )
+	name "Indiana Jones and the Fate of Atlantis"
+	description "Indiana Jones and the Fate of Atlantis"
+	rom ( name "Indiana Jones and the Fate of Atlantis LF.scummvm" size 9 crc 6b2b292e )
 )
 
 game (
-	name "Camp Cantitoe (Macintosh)"
-	description "Camp Cantitoe (Macintosh)"
-	rom ( name "._Camp Cantitoe" size 621354 crc 34d32278 md5 7cc4d89dd0273623847153757747cc31 )
+	name "Indiana Jones and the Fate of Atlantis"
+	description "Indiana Jones and the Fate of Atlantis"
+	rom ( name "Indiana Jones and the Fate of Atlantis CR.scummvm" size 9 crc f54fbc8d )
 )
 
 game (
-	name "Canal District (Macintosh)"
-	description "Canal District (Macintosh)"
-	rom ( name "._Canal District" size 658024 crc b37f0728 md5 f21fd69f8e2d27c06aa7c1291a5ce3e5 )
+	name "Indiana Jones and the Last Crusade"
+	description "Indiana Jones and the Last Crusade"
+	rom ( name "Indiana Jones and the Last Crusade.scummvm" size 5 crc 870aa244 )
 )
 
 game (
-	name "Car Driver (DOS/Fanmade v1.1)"
-	description "Car Driver (DOS/Fanmade v1.1)"
-	rom ( name "LOGDIR" size 300 crc 29ab65df md5 undefined )
+	name "Indiana Jones and the Last Crusade"
+	description "Indiana Jones and the Last Crusade"
+	rom ( name "Indiana Jones and the Last Crusade CRLF.scummvm" size 7 crc b86f4a63 )
 )
 
 game (
-	name "Carbon Copy (Macintosh)"
-	description "Carbon Copy (Macintosh)"
-	rom ( name "._Carbon Copy" size 528081 crc undefined md5 undefined )
+	name "Indiana Jones and the Last Crusade"
+	description "Indiana Jones and the Last Crusade"
+	rom ( name "Indiana Jones and the Last Crusade LF.scummvm" size 6 crc 43e189b8 )
 )
 
 game (
-	name "Carmen Sandiego's ThinkQuick Challenge (Windows)[!]"
-	description "Carmen Sandiego's ThinkQuick Challenge (Windows)[!]"
-	rom ( name "CarmenTQ.exe" size 643072 crc c9baba90 md5 1cac1d7b2c274e8a0540d54499e29510 )
+	name "Indiana Jones and the Last Crusade"
+	description "Indiana Jones and the Last Crusade"
+	rom ( name "Indiana Jones and the Last Crusade CR.scummvm" size 6 crc dd851c1b )
 )
 
 game (
-	name "Carmen Sandiego's ThinkQuick Challenge Custom Question Creator (Windows)[!]"
-	description "Carmen Sandiego's ThinkQuick Challenge Custom Question Creator (Windows)[!]"
-	rom ( name "CQCreate.exe" size 643072 crc c9baba90 md5 1cac1d7b2c274e8a0540d54499e29510 )
+	name "Indiana Jones and the Last Crusade & Loom"
+	description "Indiana Jones and the Last Crusade & Loom"
+	rom ( name "Indiana Jones and the Last Crusade & Loom.scummvm" size 8 crc f5b53298 )
 )
 
 game (
-	name "Carol Reed 04: East Side Story (Demo/Windows)"
-	description "Carol Reed 04: East Side Story (Demo/Windows)"
-	rom ( name "data.dcp" size 59296246 crc a127279c md5 f081a5250838cb02ee26a878da5f1b82 )
+	name "Indiana Jones and the Last Crusade & Loom"
+	description "Indiana Jones and the Last Crusade & Loom"
+	rom ( name "Indiana Jones and the Last Crusade & Loom CRLF.scummvm" size 10 crc 65ed218b )
 )
 
 game (
-	name "Carol Reed 04: East Side Story (Windows)"
-	description "Carol Reed 04: East Side Story (Windows)"
-	rom ( name "data.dcp" size 529320536 crc 40b41a04 md5 undefined )
+	name "Indiana Jones and the Last Crusade & Loom"
+	description "Indiana Jones and the Last Crusade & Loom"
+	rom ( name "Indiana Jones and the Last Crusade & Loom LF.scummvm" size 9 crc ccf6a8d7 )
 )
 
 game (
-	name "Carol Reed 05: The Colour of Murder (Demo/Windows)"
-	description "Carol Reed 05: The Colour of Murder (Demo/Windows)"
-	rom ( name "data.dcp" size 92019500 crc 0ab3df86 md5 undefined )
+	name "Indiana Jones and the Last Crusade & Loom"
+	description "Indiana Jones and the Last Crusade & Loom"
+	rom ( name "Indiana Jones and the Last Crusade & Loom CR.scummvm" size 9 crc 52923d74 )
 )
 
 game (
-	name "Carol Reed 05: The Colour of Murder (Windows)"
-	description "Carol Reed 05: The Colour of Murder (Windows)"
-	rom ( name "data.dcp" size 603660415 crc 1b76216d md5 5a0200e69a7d9cf4aa83fb713af0edfd )
+	name "Indiana Jones and the Last Crusade & Zak McKracken"
+	description "Indiana Jones and the Last Crusade & Zak McKracken"
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken.scummvm" size 7 crc 34d98949 )
 )
 
 game (
-	name "Carol Reed 06: Black Circle (Demo/Windows)[Unk]"
-	description "Carol Reed 06: Black Circle (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 94399373 crc f05e9ccc md5 undefined )
+	name "Indiana Jones and the Last Crusade & Zak McKracken"
+	description "Indiana Jones and the Last Crusade & Zak McKracken"
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken CRLF.scummvm" size 9 crc a17d7ebd )
 )
 
 game (
-	name "Carol Reed 06: Black Circle (Windows)[Unk]"
-	description "Carol Reed 06: Black Circle (Windows)[Unk]"
-	rom ( name "data.dcp" size 456465173 crc aafa11a0 md5 d6501582210282ee244bf3c9ee55c002 )
+	name "Indiana Jones and the Last Crusade & Zak McKracken"
+	description "Indiana Jones and the Last Crusade & Zak McKracken"
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken LF.scummvm" size 8 crc 3de3262e )
 )
 
 game (
-	name "Carol Reed 07: Blue Madonna (Demo/Windows)"
-	description "Carol Reed 07: Blue Madonna (Demo/Windows)"
-	rom ( name "data.dcp" size 103719442 crc 982a9439 md5 a00be7a096f0df247a18fde6137735c8 )
+	name "Indiana Jones and the Last Crusade & Zak McKracken"
+	description "Indiana Jones and the Last Crusade & Zak McKracken"
+	rom ( name "Indiana Jones and the Last Crusade & Zak McKracken CR.scummvm" size 8 crc a387b38d )
 )
 
 game (
-	name "Carol Reed 07: Blue Madonna (Windows)[Unk]"
-	description "Carol Reed 07: Blue Madonna (Windows)[Unk]"
-	rom ( name "data.dcp" size 495185438 crc 59810115 md5 undefined )
+	name "Jumble"
+	description "Jumble"
+	rom ( name "Jumble.scummvm" size 6 crc 5f1063cc )
 )
 
 game (
-	name "Carol Reed 08: Amber's Blood (Demo/Windows)[Unk]"
-	description "Carol Reed 08: Amber's Blood (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 110106328 crc ba62dec4 md5 6b30383b74963c4b2286bda4b5cbc1e0 )
+	name "Jumble"
+	description "Jumble"
+	rom ( name "Jumble CRLF.scummvm" size 8 crc a756721c )
 )
 
 game (
-	name "Carol Reed 08: Amber's Blood (Windows)"
-	description "Carol Reed 08: Amber's Blood (Windows)"
-	rom ( name "data.dcp" size 502714557 crc 0eda4275 md5 undefined )
+	name "Jumble"
+	description "Jumble"
+	rom ( name "Jumble LF.scummvm" size 7 crc a05a986b )
 )
 
 game (
-	name "Carol Reed 09: Cold Case Summer (Demo/Windows)[Unk]"
-	description "Carol Reed 09: Cold Case Summer (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 86362217 crc 33de315b md5 undefined )
+	name "Jumble"
+	description "Jumble"
+	rom ( name "Jumble CR.scummvm" size 7 crc 3e3e0dc8 )
 )
 
 game (
-	name "Carol Reed 09: Cold Case Summer (Windows)"
-	description "Carol Reed 09: Cold Case Summer (Windows)"
-	rom ( name "data.dcp" size 620005266 crc 051a8c5e md5 790d14ddbd2d0f4b6961a571998f1034 )
+	name "Labyrinth of Time"
+	description "Labyrinth of Time"
+	rom ( name "Labyrinth of Time.scummvm" size 3 crc 61d6b1c4 )
 )
 
 game (
-	name "Carol Reed 10: Bosch's Damnation (Demo/Windows)[Unk]"
-	description "Carol Reed 10: Bosch's Damnation (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 79971080 crc 653233e1 md5 8515861b5b3329c38ba67a0c1bee4e4a )
+	name "Labyrinth of Time"
+	description "Labyrinth of Time"
+	rom ( name "Labyrinth of Time CRLF.scummvm" size 5 crc 752752a )
 )
 
 game (
-	name "Carol Reed 11: Shades of Black (Demo/HD/Windows)[Unk]"
-	description "Carol Reed 11: Shades of Black (Demo/HD/Windows)[Unk]"
-	rom ( name "data.dcp" size 77909344 crc 88d1fe40 md5 6682a333eea0ae130126a00359aaf5de )
+	name "Labyrinth of Time"
+	description "Labyrinth of Time"
+	rom ( name "Labyrinth of Time LF.scummvm" size 4 crc aebfd68b )
 )
 
 game (
-	name "Carol Reed 11: Shades of Black (Demo/Windows)[Unk]"
-	description "Carol Reed 11: Shades of Black (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 52692061 crc 54e5c205 md5 undefined )
+	name "Labyrinth of Time"
+	description "Labyrinth of Time"
+	rom ( name "Labyrinth of Time CR.scummvm" size 4 crc 30db4328 )
 )
 
 game (
-	name "Cascade Quest (DOS/Fanmade)"
-	description "Cascade Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 1432195 crc cdf4fd01 md5 undefined )
+	name "Lands of Lore The Throne of Chaos"
+	description "Lands of Lore The Throne of Chaos"
+	rom ( name "Lands of Lore The Throne of Chaos.scummvm" size 3 crc 18edb14d )
 )
 
 game (
-	name "Case of the Rose Tattoo, The (CD/DOS)"
-	description "Case of the Rose Tattoo, The (CD/DOS)"
-	rom ( name "ADLIB.MDI" size 15003 crc 18786810 md5 29ca710cbca2bcb487e9faae781df3ab )
+	name "Lands of Lore The Throne of Chaos"
+	description "Lands of Lore The Throne of Chaos"
+	rom ( name "Lands of Lore The Throne of Chaos CRLF.scummvm" size 5 crc ed132f13 )
 )
 
 game (
-	name "Case of the Rose Tattoo, The (CD/DOS/French)"
-	description "Case of the Rose Tattoo, The (CD/DOS/French)"
-	rom ( name "ADLIB.MDI" size 15003 crc 18786810 md5 29ca710cbca2bcb487e9faae781df3ab )
+	name "Lands of Lore The Throne of Chaos"
+	description "Lands of Lore The Throne of Chaos"
+	rom ( name "Lands of Lore The Throne of Chaos LF.scummvm" size 4 crc 3aa2d60f )
 )
 
 game (
-	name "Case of the Rose Tattoo, The (CD/DOS/German)"
-	description "Case of the Rose Tattoo, The (CD/DOS/German)"
-	rom ( name "ADLIB.MDI" size 15003 crc 18786810 md5 undefined )
+	name "Lands of Lore The Throne of Chaos"
+	description "Lands of Lore The Throne of Chaos"
+	rom ( name "Lands of Lore The Throne of Chaos CR.scummvm" size 4 crc a4c643ac )
 )
 
 game (
-	name "Case of the Rose Tattoo, The (CD/DOS/Spanish)"
-	description "Case of the Rose Tattoo, The (CD/DOS/Spanish)"
-	rom ( name "ADLIB.MDI" size 15003 crc 18786810 md5 undefined )
+	name "Let's Explore the Airport with Buzzy"
+	description "Let's Explore the Airport with Buzzy"
+	rom ( name "Let's Explore the Airport with Buzzy.scummvm" size 7 crc 7e91f7c2 )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (3DO)[!]"
-	description "Case of the Serrated Scalpel, The (3DO)[!]"
-	rom ( name "3doSplash.CEL" size 153736 crc e82ba174 md5 undefined )
+	name "Let's Explore the Airport with Buzzy"
+	description "Let's Explore the Airport with Buzzy"
+	rom ( name "Let's Explore the Airport with Buzzy CRLF.scummvm" size 9 crc ceb7294e )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (Demo/Interactive/DOS)"
-	description "Case of the Serrated Scalpel, The (Demo/Interactive/DOS)"
-	rom ( name "BLASTER.SP" size 1889 crc ccef2ae5 md5 84cc0698212c7de6acc970dea8fcad6e )
+	name "Let's Explore the Airport with Buzzy"
+	description "Let's Explore the Airport with Buzzy"
+	rom ( name "Let's Explore the Airport with Buzzy LF.scummvm" size 8 crc 47c334f8 )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (Demo/Non-Interactive/DOS)"
-	description "Case of the Serrated Scalpel, The (Demo/Non-Interactive/DOS)"
-	rom ( name "1.RLB" size 6 crc 94a9fe7f md5 6a5697ee375948f505f61d4365dbf5d2 )
+	name "Let's Explore the Airport with Buzzy"
+	description "Let's Explore the Airport with Buzzy"
+	rom ( name "Let's Explore the Airport with Buzzy CR.scummvm" size 8 crc d9a7a15b )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (DOS)"
-	description "Case of the Serrated Scalpel, The (DOS)"
-	rom ( name "1.RLB" size 6 crc 94a9fe7f md5 6a5697ee375948f505f61d4365dbf5d2 )
+	name "Let's Explore the Farm with Buzzy"
+	description "Let's Explore the Farm with Buzzy"
+	rom ( name "Let's Explore the Farm with Buzzy.scummvm" size 4 crc 5816d045 )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (DOS/German)"
-	description "Case of the Serrated Scalpel, The (DOS/German)"
-	rom ( name "1.RLB" size 6 crc 94a9fe7f md5 undefined )
+	name "Let's Explore the Farm with Buzzy"
+	description "Let's Explore the Farm with Buzzy"
+	rom ( name "Let's Explore the Farm with Buzzy CRLF.scummvm" size 6 crc 1f7fb42e )
 )
 
 game (
-	name "Case of the Serrated Scalpel, The (DOS/Spanish)"
-	description "Case of the Serrated Scalpel, The (DOS/Spanish)"
-	rom ( name "1.RLB" size 6 crc 94a9fe7f md5 6a5697ee375948f505f61d4365dbf5d2 )
+	name "Let's Explore the Farm with Buzzy"
+	description "Let's Explore the Farm with Buzzy"
+	rom ( name "Let's Explore the Farm with Buzzy LF.scummvm" size 5 crc 3439a55c )
 )
 
 game (
-	name "Castle of Dr. Brain (Amiga)"
-	description "Castle of Dr. Brain (Amiga)"
-	rom ( name "180.SCR" size 15382 crc 7f1ec8aa md5 c8c9eee9cd1ab63436ee848603ce45b6 )
+	name "Let's Explore the Farm with Buzzy"
+	description "Let's Explore the Farm with Buzzy"
+	rom ( name "Let's Explore the Farm with Buzzy CR.scummvm" size 5 crc aa5d30ff )
 )
 
 game (
-	name "Castle of Dr. Brain (Amiga/German)"
-	description "Castle of Dr. Brain (Amiga/German)"
-	rom ( name "0.SCR" size 11244 crc b78e70b2 md5 undefined )
+	name "Let's Explore the Jungle with Buzzy"
+	description "Let's Explore the Jungle with Buzzy"
+	rom ( name "Let's Explore the Jungle with Buzzy.scummvm" size 6 crc 4b6e0ec9 )
 )
 
 game (
-	name "Castle of Dr. Brain (Demo/DOS)"
-	description "Castle of Dr. Brain (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 67367 crc 3c55141a md5 94c2f5aed92870f6de22726ac153d45b )
+	name "Let's Explore the Jungle with Buzzy"
+	description "Let's Explore the Jungle with Buzzy"
+	rom ( name "Let's Explore the Jungle with Buzzy CRLF.scummvm" size 8 crc e9228fc2 )
 )
 
 game (
-	name "Castle of Dr. Brain (DOS)[a]"
-	description "Castle of Dr. Brain (DOS)[a]"
-	rom ( name "440.SCR" size 14634 crc 0cff14ca md5 f3320e215f0079db371069af83726977 )
+	name "Let's Explore the Jungle with Buzzy"
+	description "Let's Explore the Jungle with Buzzy"
+	rom ( name "Let's Explore the Jungle with Buzzy LF.scummvm" size 7 crc d0241289 )
 )
 
 game (
-	name "Castle of Dr. Brain (DOS)[v1.000]"
-	description "Castle of Dr. Brain (DOS)[v1.000]"
-	rom ( name "440.SCR" size 14634 crc 0cff14ca md5 f3320e215f0079db371069af83726977 )
+	name "Let's Explore the Jungle with Buzzy"
+	description "Let's Explore the Jungle with Buzzy"
+	rom ( name "Let's Explore the Jungle with Buzzy CR.scummvm" size 7 crc 4e40872a )
 )
 
 game (
-	name "Castle of Dr. Brain (DOS)[v1.1][!]"
-	description "Castle of Dr. Brain (DOS)[v1.1][!]"
-	rom ( name "120.SCR" size 19952 crc 604c6637 md5 d7104c31c7d23864f248782231f29ffe )
+	name "Loom"
+	description "Loom"
+	rom ( name "Loom.scummvm" size 4 crc c2597137 )
 )
 
 game (
-	name "Castle of Dr. Brain (DOS/EGA)"
-	description "Castle of Dr. Brain (DOS/EGA)"
-	rom ( name "RESOURCE.000" size 25325 crc 9bd35952 md5 abe3595bf40db3d5a0f9ef916870c032 )
+	name "Loom"
+	description "Loom"
+	rom ( name "Loom CRLF.scummvm" size 6 crc a3a7a66b )
 )
 
 game (
-	name "Castle of Dr. Brain (DOS/Spanish)[v1.004]"
-	description "Castle of Dr. Brain (DOS/Spanish)[v1.004]"
-	rom ( name "RESOURCE.000" size 1197694 crc 0b3ea525 md5 undefined )
+	name "Loom"
+	description "Loom"
+	rom ( name "Loom LF.scummvm" size 5 crc 8aa8faed )
 )
 
 game (
-	name "Castle of Dr. Brain (Macintosh)"
-	description "Castle of Dr. Brain (Macintosh)"
-	rom ( name "0.TEX" size 2302 crc 75047853 md5 undefined )
+	name "Loom"
+	description "Loom"
+	rom ( name "Loom CR.scummvm" size 5 crc 14cc6f4e )
 )
 
 game (
-	name "Castle of Dr. Brain (PC-98/Japanese)"
-	description "Castle of Dr. Brain (PC-98/Japanese)"
-	rom ( name "20.SCR" size 366 crc 1614787d md5 undefined )
+	name "Lost in Time"
+	description "Lost in Time"
+	rom ( name "Lost in Time.scummvm" size 3 crc 5ddb8e9d )
 )
 
 game (
-	name "Castle of Ert (Macintosh)"
-	description "Castle of Ert (Macintosh)"
-	rom ( name "._Castle of Ert" size 208896 crc 0cf06369 md5 99451cbca4a2b5e2f8e5b2097a1a7f1c )
+	name "Lost in Time"
+	description "Lost in Time"
+	rom ( name "Lost in Time CRLF.scummvm" size 5 crc da4d8207 )
 )
 
 game (
-	name "Castle of Ert (Macintosh)[a]"
-	description "Castle of Ert (Macintosh)[a]"
-	rom ( name "._Castle of Ert.1" size 208896 crc 41655bb4 md5 a0c0028833f943b5f24b97d5a5128675 )
+	name "Lost in Time"
+	description "Lost in Time"
+	rom ( name "Lost in Time LF.scummvm" size 4 crc bc3432e4 )
 )
 
 game (
-	name "Chivalry is Not Dead (Windows)"
-	description "Chivalry is Not Dead (Windows)"
-	rom ( name "arial.ttf" size 773852 crc 8c72f2c8 md5 undefined )
+	name "Lost in Time"
+	description "Lost in Time"
+	rom ( name "Lost in Time CR.scummvm" size 4 crc 2250a747 )
 )
 
 game (
-	name "Chivalry is Not Dead (Windows)[a]"
-	description "Chivalry is Not Dead (Windows)[a]"
-	rom ( name "arial.ttf" size 773852 crc 8c72f2c8 md5 096b6677fc4a0a2ab430cd3d28b6fd52 )
+	name "Lure of the Temptress"
+	description "Lure of the Temptress"
+	rom ( name "Lure of the Temptress.scummvm" size 4 crc 225fb3bf )
 )
 
 game (
-	name "Christmas Card 1988 (DOS)"
-	description "Christmas Card 1988 (DOS)"
-	rom ( name "ADL.DRV" size 5720 crc b67d927d md5 undefined )
+	name "Lure of the Temptress"
+	description "Lure of the Temptress"
+	rom ( name "Lure of the Temptress CRLF.scummvm" size 6 crc 2597f7b2 )
 )
 
 game (
-	name "Christmas Card 1990: The Seasoned Professional (DOS/16 Colors)"
-	description "Christmas Card 1990: The Seasoned Professional (DOS/16 Colors)"
-	rom ( name "RESOURCE.001" size 272629 crc 85ca2250 md5 317ef25e032b39f3568931913578c046 )
+	name "Lure of the Temptress"
+	description "Lure of the Temptress"
+	rom ( name "Lure of the Temptress LF.scummvm" size 5 crc 692bf73d )
 )
 
 game (
-	name "Christmas Card 1990: The Seasoned Professional (DOS/256 Colors)"
-	description "Christmas Card 1990: The Seasoned Professional (DOS/256 Colors)"
-	rom ( name "RESOURCE.001" size 335362 crc 957cc5cd md5 c2792b1b53aa67276f12673d1f3d7c1d )
+	name "Lure of the Temptress"
+	description "Lure of the Temptress"
+	rom ( name "Lure of the Temptress CR.scummvm" size 5 crc f74f629e )
 )
 
 game (
-	name "Christmas Card 1992 (DOS)"
-	description "Christmas Card 1992 (DOS)"
-	rom ( name "65535.MAP" size 20 crc 71915187 md5 5e198fc563a9dbb1c8d9aa681625042d )
+	name "MADE engine game"
+	description "MADE engine game"
+	rom ( name "MADE engine game.scummvm" size 4 crc 9d546aa1 )
 )
 
 game (
-	name "Circus Quest (DOS/Fanmade)"
-	description "Circus Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 279627 crc 00412bb0 md5 00b3020c57b3605634b2810fd5f0238d )
+	name "MADE engine game"
+	description "MADE engine game"
+	rom ( name "MADE engine game CRLF.scummvm" size 6 crc ed91d16 )
 )
 
 game (
-	name "Clandestiny (DOS)[!]"
-	description "Clandestiny (DOS)[!]"
-	rom ( name "02_RACK.GRV" size 1918 crc 6644ea4d md5 e25cc170f900f1698693471cac4e6c66 )
+	name "MADE engine game"
+	description "MADE engine game"
+	rom ( name "MADE engine game LF.scummvm" size 5 crc 939bc187 )
 )
 
 game (
-	name "Cloak of Darkness (DOS/Fanmade v1.0)"
-	description "Cloak of Darkness (DOS/Fanmade v1.0)"
-	rom ( name "logdir" size 300 crc 60902249 md5 undefined )
+	name "MADE engine game"
+	description "MADE engine game"
+	rom ( name "MADE engine game CR.scummvm" size 5 crc dff5424 )
 )
 
 game (
-	name "Coco Coq Dans la Base de Grostesteing (DOS/Fanmade/French v1.0.2)"
-	description "Coco Coq Dans la Base de Grostesteing (DOS/Fanmade/French v1.0.2)"
-	rom ( name "LOGDIR" size 672 crc d907cbd7 md5 ef579ebccfe5e356f9a557eb3b2d8649 )
+	name "MADS"
+	description "MADS"
+	rom ( name "MADS.scummvm" size 4 crc 5f153244 )
 )
 
 game (
-	name "Coco Coq In Grostesteing's Base (DOS/Fanmade v1.0.3)"
-	description "Coco Coq In Grostesteing's Base (DOS/Fanmade v1.0.3)"
-	rom ( name "LOGDIR" size 672 crc 5e4baeea md5 undefined )
+	name "MADS"
+	description "MADS"
+	rom ( name "MADS CRLF.scummvm" size 6 crc 48600138 )
 )
 
 game (
-	name "Codename: Iceman (Amiga)"
-	description "Codename: Iceman (Amiga)"
-	rom ( name "BANK.001" size 271283 crc 31766325 md5 53abb8a4ca3bee2b9570270736ffc515 )
+	name "MADS"
+	description "MADS"
+	rom ( name "MADS LF.scummvm" size 5 crc 43399628 )
 )
 
 game (
-	name "Codename: Iceman (Atari ST)[!]"
-	description "Codename: Iceman (Atari ST)[!]"
-	rom ( name "RESOURCE.000" size 26987 crc 4b3a89a4 md5 92f28465662fe0f674ed02065c6f1be2 )
+	name "MADS"
+	description "MADS"
+	rom ( name "MADS CR.scummvm" size 5 crc dd5d038b )
 )
 
 game (
-	name "Codename: Iceman (Demo/DOS)"
-	description "Codename: Iceman (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 573647 crc 28fc2616 md5 0208b1d66bf32dbae397b2077ac32218 )
+	name "Magic Tales: Liam Finds a Story"
+	description "Magic Tales: Liam Finds a Story"
+	rom ( name "Magic Tales: Liam Finds a Story.scummvm" size 4 crc 5857200b )
 )
 
 game (
-	name "Codename: Iceman (DOS)"
-	description "Codename: Iceman (DOS)"
-	rom ( name "RESOURCE.000" size 26989 crc 714742ed md5 dbe227f481b5dfce0ec5dffc3c9b2d91 )
+	name "Magic Tales: Liam Finds a Story"
+	description "Magic Tales: Liam Finds a Story"
+	rom ( name "Magic Tales: Liam Finds a Story CRLF.scummvm" size 6 crc cc3824f8 )
 )
 
 game (
-	name "Codename: Iceman (DOS)[a]"
-	description "Codename: Iceman (DOS)[a]"
-	rom ( name "RESOURCE.000" size 26974 crc e2eb7b35 md5 d008c0ab07143aa4ab3141326c05ba69 )
+	name "Magic Tales: Liam Finds a Story"
+	description "Magic Tales: Liam Finds a Story"
+	rom ( name "Magic Tales: Liam Finds a Story LF.scummvm" size 5 crc a55d883b )
 )
 
 game (
-	name "Codename: Iceman (DOS/EGA)"
-	description "Codename: Iceman (DOS/EGA)"
-	rom ( name "RESOURCE.000" size 26974 crc e2eb7b35 md5 undefined )
+	name "Magic Tales: Liam Finds a Story"
+	description "Magic Tales: Liam Finds a Story"
+	rom ( name "Magic Tales: Liam Finds a Story CR.scummvm" size 5 crc 3b391d98 )
 )
 
 game (
-	name "Conquests of Camelot: King Arthur, Quest for the Grail (Amiga)"
-	description "Conquests of Camelot: King Arthur, Quest for the Grail (Amiga)"
-	rom ( name "BANK.001" size 217180 crc abdd17a3 md5 25b4b65a3fb4b639c6cdcbb79d0aca69 )
+	name "Maniac Mansion"
+	description "Maniac Mansion"
+	rom ( name "Maniac Mansion.scummvm" size 6 crc 9558f941 )
 )
 
 game (
-	name "Conquests of Camelot: King Arthur, Quest for the Grail (Atari ST)"
-	description "Conquests of Camelot: King Arthur, Quest for the Grail (Atari ST)"
-	rom ( name "RESOURCE.001" size 596773 crc 94f2b0b3 md5 7ea1e1722c2b2c1e01f8c0eed6092cd0 )
+	name "Maniac Mansion"
+	description "Maniac Mansion"
+	rom ( name "Maniac Mansion CRLF.scummvm" size 8 crc 39a12408 )
 )
 
 game (
-	name "Conquests of Camelot: King Arthur, Quest for the Grail (Demo/DOS)"
-	description "Conquests of Camelot: King Arthur, Quest for the Grail (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 232523 crc 1e3dede2 md5 undefined )
+	name "Maniac Mansion"
+	description "Maniac Mansion"
+	rom ( name "Maniac Mansion LF.scummvm" size 7 crc 33992f6c )
 )
 
 game (
-	name "Conquests of Camelot: King Arthur, Quest for the Grail (DOS)[10x360KB]"
-	description "Conquests of Camelot: King Arthur, Quest for the Grail (DOS)[10x360KB]"
-	rom ( name "RESOURCE.001" size 212461 crc 59cadbee md5 1552a72986d3d473149b33a98b3a4d15 )
+	name "Maniac Mansion"
+	description "Maniac Mansion"
+	rom ( name "Maniac Mansion CR.scummvm" size 7 crc adfdbacf )
 )
 
 game (
-	name "Conquests of Camelot: King Arthur, Quest for the Grail (DOS)[4x720KB]"
-	description "Conquests of Camelot: King Arthur, Quest for the Grail (DOS)[4x720KB]"
-	rom ( name "RESOURCE.001" size 596774 crc 6dbc7908 md5 2f21c992da30741065e891db1a80a7cb )
+	name "Martian Memorandum"
+	description "Martian Memorandum"
+	rom ( name "Martian Memorandum.scummvm" size 7 crc 42004cd6 )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (Amiga)"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (Amiga)"
-	rom ( name "101.PAT" size 556 crc 598c5897 md5 undefined )
+	name "Martian Memorandum"
+	description "Martian Memorandum"
+	rom ( name "Martian Memorandum CRLF.scummvm" size 9 crc bcaaa88e )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (Demo/DOS)"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 869916 crc fc3fa292 md5 2ee97c8511fe1917033add3c9937a98c )
+	name "Martian Memorandum"
+	description "Martian Memorandum"
+	rom ( name "Martian Memorandum LF.scummvm" size 8 crc 5d25713e )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (DOS)"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (DOS)"
-	rom ( name "100.SCR" size 3970 crc 272496f7 md5 undefined )
+	name "Martian Memorandum"
+	description "Martian Memorandum"
+	rom ( name "Martian Memorandum CR.scummvm" size 8 crc c341e49d )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (DOS)[a]"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (DOS)[a]"
-	rom ( name "140.SCR" size 14102 crc 157ddb8f md5 41bab5f46ad5451efe8c6e9f4d1bc5d9 )
+	name "Mohawk Game"
+	description "Mohawk Game"
+	rom ( name "Mohawk Game.scummvm" size 6 crc 135374a1 )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (DOS)[a2]"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (DOS)[a2]"
-	rom ( name "100.SCR" size 3970 crc 272496f7 md5 undefined )
+	name "Mohawk Game"
+	description "Mohawk Game"
+	rom ( name "Mohawk Game CRLF.scummvm" size 8 crc f4d6ae72 )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (DOS/EGA)"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (DOS/EGA)"
-	rom ( name "180.SCR" size 12408 crc 9c8a5136 md5 undefined )
+	name "Mohawk Game"
+	description "Mohawk Game"
+	rom ( name "Mohawk Game LF.scummvm" size 7 crc 9315c699 )
 )
 
 game (
-	name "Conquests of the Longbow: The Adventures of Robin Hood (DOS/German)"
-	description "Conquests of the Longbow: The Adventures of Robin Hood (DOS/German)"
-	rom ( name "621.SCR" size 6280 crc ba401939 md5 undefined )
+	name "Mohawk Game"
+	description "Mohawk Game"
+	rom ( name "Mohawk Game CR.scummvm" size 7 crc d71533a )
 )
 
 game (
-	name "Corby's Murder Mystery (DOS/Fanmade v1.0)"
-	description "Corby's Murder Mystery (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 172e854d md5 4ebe62ac24c5a8c7b7898c8eb070efe5 )
+	name "Monkey Island 2 LeChuck's Revenge"
+	description "Monkey Island 2 LeChuck's Revenge"
+	rom ( name "Monkey Island 2 LeChuck's Revenge.scummvm" size 7 crc 3cbc6c0e )
 )
 
 game (
-	name "Corrosion: Cold Winter Waiting - Enhanced Edition (Windows)[Unk]"
-	description "Corrosion: Cold Winter Waiting - Enhanced Edition (Windows)[Unk]"
-	rom ( name "data.dcp" size 643363379 crc 405f2e74 md5 undefined )
+	name "Monkey Island 2 LeChuck's Revenge"
+	description "Monkey Island 2 LeChuck's Revenge"
+	rom ( name "Monkey Island 2 LeChuck's Revenge CRLF.scummvm" size 9 crc ce25b9ed )
 )
 
 game (
-	name "Corrosion: Cold Winter Waiting (Windows)"
-	description "Corrosion: Cold Winter Waiting (Windows)"
-	rom ( name "data.dcp" size 525931618 crc bcb0b1ce md5 fb6717c2fbb6a5d762b7e269f4f7672c )
+	name "Monkey Island 2 LeChuck's Revenge"
+	description "Monkey Island 2 LeChuck's Revenge"
+	rom ( name "Monkey Island 2 LeChuck's Revenge LF.scummvm" size 8 crc d55397f8 )
 )
 
 game (
-	name "CPU-21 (DOS/Fanmade v1.0)"
-	description "CPU-21 (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 55b1f469 md5 35b7cdb4d17e890e4c52018d96e9cbf4 )
+	name "Monkey Island 2 LeChuck's Revenge"
+	description "Monkey Island 2 LeChuck's Revenge"
+	rom ( name "Monkey Island 2 LeChuck's Revenge CR.scummvm" size 8 crc 4b37025b )
 )
 
 game (
-	name "Crazy Nick's Software Picks: King Graham's Board Game Challenge (DOS)"
-	description "Crazy Nick's Software Picks: King Graham's Board Game Challenge (DOS)"
-	rom ( name "98.TEX" size 3068 crc 85ab438c md5 undefined )
+	name "Moonbase Commander"
+	description "Moonbase Commander"
+	rom ( name "Moonbase Commander.scummvm" size 8 crc 6d6203d1 )
 )
 
 game (
-	name "Crazy Nick's Software Picks: Leisure Suit Larry's Casino (DOS)"
-	description "Crazy Nick's Software Picks: Leisure Suit Larry's Casino (DOS)"
-	rom ( name "RESOURCE.001" size 344830 crc d3ab06fd md5 a3da199359e649054903363c6b3e38cf )
+	name "Moonbase Commander"
+	description "Moonbase Commander"
+	rom ( name "Moonbase Commander CRLF.scummvm" size 10 crc 15884d2a )
 )
 
 game (
-	name "Crazy Nick's Software Picks: Parlor Games with Laura Bow (DOS)"
-	description "Crazy Nick's Software Picks: Parlor Games with Laura Bow (DOS)"
-	rom ( name "98.TEX" size 3068 crc 85ab438c md5 undefined )
+	name "Moonbase Commander"
+	description "Moonbase Commander"
+	rom ( name "Moonbase Commander LF.scummvm" size 9 crc c36e86d2 )
 )
 
 game (
-	name "Crazy Nick's Software Picks: Robin Hood's Game of Skill and Chance (DOS)"
-	description "Crazy Nick's Software Picks: Robin Hood's Game of Skill and Chance (DOS)"
-	rom ( name "RESOURCE.001" size 571466 crc d18800e1 md5 undefined )
+	name "Moonbase Commander"
+	description "Moonbase Commander"
+	rom ( name "Moonbase Commander CR.scummvm" size 9 crc 5d0a1371 )
 )
 
 game (
-	name "Crazy Nick's Software Picks: Roger Wilco's Spaced Out Game Pack (DOS)"
-	description "Crazy Nick's Software Picks: Roger Wilco's Spaced Out Game Pack (DOS)"
-	rom ( name "RESOURCE.001" size 364921 crc 0cb787bb md5 undefined )
+	name "Mortville Manor"
+	description "Mortville Manor"
+	rom ( name "Mortville Manor.scummvm" size 11 crc f165dbc )
 )
 
 game (
-	name "Croustibat (DOS/Portuguese)"
-	description "Croustibat (DOS/Portuguese)"
-	rom ( name "ALL.ASK" size 12768 crc 41a9bbf1 md5 f027e465fb074a3a2244251bac7ee3de )
+	name "Mortville Manor"
+	description "Mortville Manor"
+	rom ( name "Mortville Manor CRLF.scummvm" size 13 crc 49084647 )
 )
 
 game (
-	name "Cruise for a Corpse (Amiga/German)"
-	description "Cruise for a Corpse (Amiga/German)"
-	rom ( name "D1" size 700963 crc 1c44fcd2 md5 0b14210a569ae76345449a5816ce7881 )
+	name "Mortville Manor"
+	description "Mortville Manor"
+	rom ( name "Mortville Manor LF.scummvm" size 12 crc f00fef69 )
 )
 
 game (
-	name "Cruise for a Corpse (Amiga/Italian)"
-	description "Cruise for a Corpse (Amiga/Italian)"
-	rom ( name "D1" size 700668 crc d0bc53eb md5 undefined )
+	name "Mortville Manor"
+	description "Mortville Manor"
+	rom ( name "Mortville Manor CR.scummvm" size 12 crc 6e6b7aca )
 )
 
 game (
-	name "Cruise for a Corpse (Atari ST)"
-	description "Cruise for a Corpse (Atari ST)"
-	rom ( name "D1" size 536473 crc 96fad26b md5 undefined )
+	name "Myst"
+	description "Myst"
+	rom ( name "Myst.scummvm" size 4 crc e0523c0d )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/16 colors)"
-	description "Cruise for a Corpse (DOS/16 colors)"
-	rom ( name "D1" size 540087 crc 6b4984e0 md5 undefined )
+	name "Myst"
+	description "Myst"
+	rom ( name "Myst CRLF.scummvm" size 6 crc 8e636734 )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/256 colors)"
-	description "Cruise for a Corpse (DOS/256 colors)"
-	rom ( name "D1" size 612731 crc 23c6bd31 md5 330cb6c19ee4feaed1023413bfb710a5 )
+	name "Myst"
+	description "Myst"
+	rom ( name "Myst LF.scummvm" size 5 crc 4c862812 )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/French 16 colors)"
-	description "Cruise for a Corpse (DOS/French 16 colors)"
-	rom ( name "D1" size 541225 crc f9facd79 md5 undefined )
+	name "Myst"
+	description "Myst"
+	rom ( name "Myst CR.scummvm" size 5 crc d2e2bdb1 )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/French 256 colors)"
-	description "Cruise for a Corpse (DOS/French 256 colors)"
-	rom ( name "D1" size 611387 crc 426e40f6 md5 undefined )
+	name "Nippon Safes Inc."
+	description "Nippon Safes Inc."
+	rom ( name "Nippon Safes Inc..scummvm" size 6 crc 60bf294e )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/German 256 colors)"
-	description "Cruise for a Corpse (DOS/German 256 colors)"
-	rom ( name "D1" size 612990 crc d99b539d md5 undefined )
+	name "Nippon Safes Inc."
+	description "Nippon Safes Inc."
+	rom ( name "Nippon Safes Inc. CRLF.scummvm" size 8 crc 38ea1ff4 )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/Italian 256 colors)"
-	description "Cruise for a Corpse (DOS/Italian 256 colors)"
-	rom ( name "D1" size 612715 crc 9cc553e5 md5 undefined )
+	name "Nippon Safes Inc."
+	description "Nippon Safes Inc."
+	rom ( name "Nippon Safes Inc. LF.scummvm" size 7 crc a3d3d52d )
 )
 
 game (
-	name "Cruise for a Corpse (DOS/Spanish 256 colors)"
-	description "Cruise for a Corpse (DOS/Spanish 256 colors)"
-	rom ( name "D1" size 612631 crc 75218765 md5 undefined )
+	name "Nippon Safes Inc."
+	description "Nippon Safes Inc."
+	rom ( name "Nippon Safes Inc. CR.scummvm" size 7 crc 3db7408e )
 )
 
 game (
-	name "Curse of Monkey Island, The (Demo/Large/Windows)[!]"
-	description "Curse of Monkey Island, The (Demo/Large/Windows)[!]"
-	rom ( name "COMI.LA0" size 18041 crc 2f43bb49 md5 undefined )
+	name "NoPatience"
+	description "NoPatience"
+	rom ( name "NoPatience.scummvm" size 6 crc 22a6dfdf )
 )
 
 game (
-	name "Curse of Monkey Island, The (Demo/Small/Windows)"
-	description "Curse of Monkey Island, The (Demo/Small/Windows)"
-	rom ( name "COMI.LA0" size 18041 crc 2f43bb49 md5 undefined )
+	name "NoPatience"
+	description "NoPatience"
+	rom ( name "NoPatience CRLF.scummvm" size 8 crc 46eb19f )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows)[!]"
-	description "Curse of Monkey Island, The (Windows)[!]"
-	rom ( name "RESOURCE\BBSAN.SAN" size 14973880 crc f42b1561 md5 undefined )
+	name "NoPatience"
+	description "NoPatience"
+	rom ( name "NoPatience LF.scummvm" size 7 crc 24996f09 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Hungarian)[v1.2]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Hungarian)[v1.2]"
-	rom ( name "RESOURCE\FONT0.NUT" size 94240 crc a3f9ddc6 md5 8b9f2180203fad6fbe22db9a48b6a839 )
+	name "NoPatience"
+	description "NoPatience"
+	rom ( name "NoPatience CR.scummvm" size 7 crc bafdfaaa )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Polish)"
-	description "Curse of Monkey Island, The (Windows/Fanmade Polish)"
-	rom ( name "RESOURCE\FONT0.NUT" size 94240 crc a3f9ddc6 md5 8b9f2180203fad6fbe22db9a48b6a839 )
+	name "Once Upon A Time: Little Red Riding Hood"
+	description "Once Upon A Time: Little Red Riding Hood"
+	rom ( name "Once Upon A Time: Little Red Riding Hood.scummvm" size 9 crc 4e747d81 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Portuguese)"
-	description "Curse of Monkey Island, The (Windows/Fanmade Portuguese)"
-	rom ( name "RESOURCE\FONT0.NUT" size 94240 crc a3f9ddc6 md5 undefined )
+	name "Once Upon A Time: Little Red Riding Hood"
+	description "Once Upon A Time: Little Red Riding Hood"
+	rom ( name "Once Upon A Time: Little Red Riding Hood CRLF.scummvm" size 11 crc 188e6f53 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Russian)[ENPY Soft v1.0]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Russian)[ENPY Soft v1.0]"
-	rom ( name "RESOURCE\FONT0.NUT" size 111966 crc 8fd91332 md5 842d64de369cc7486b94d4751ee35615 )
+	name "Once Upon A Time: Little Red Riding Hood"
+	description "Once Upon A Time: Little Red Riding Hood"
+	rom ( name "Once Upon A Time: Little Red Riding Hood LF.scummvm" size 10 crc a826c158 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.0 rc1]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.0 rc1]"
-	rom ( name "RESOURCE\FONT0.NUT" size 92077 crc 322224cc md5 2873d0caec6aff5539a0b5147c31fafa )
+	name "Once Upon A Time: Little Red Riding Hood"
+	description "Once Upon A Time: Little Red Riding Hood"
+	rom ( name "Once Upon A Time: Little Red Riding Hood CR.scummvm" size 10 crc 364254fb )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.0.4]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.0.4]"
-	rom ( name "RESOURCE\FONT0.NUT" size 92083 crc 8013b296 md5 42e6503761c866fa6d170ab21de3a918 )
+	name "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	description "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside.scummvm" size 6 crc e9da00cb )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.1b]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Russian)[v1.1b]"
-	rom ( name "RESOURCE\FONT0.NUT" size 92077 crc 322224cc md5 2873d0caec6aff5539a0b5147c31fafa )
+	name "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	description "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside CRLF.scummvm" size 8 crc 3cac62f3 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Fanmade Russian)[v2.0]"
-	description "Curse of Monkey Island, The (Windows/Fanmade Russian)[v2.0]"
-	rom ( name "RESOURCE\FONT0.NUT" size 92077 crc 322224cc md5 2873d0caec6aff5539a0b5147c31fafa )
+	name "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	description "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside LF.scummvm" size 7 crc 3e88c7ab )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/French)"
-	description "Curse of Monkey Island, The (Windows/French)"
-	rom ( name "RESOURCE\BBSAN.SAN" size 14973666 crc 050056e3 md5 5a213cabc56e4e5509293df2125da45d )
+	name "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	description "Pajama Sam 1 No Need to Hide When It's Dark Outside"
+	rom ( name "Pajama Sam 1 No Need to Hide When It's Dark Outside CR.scummvm" size 7 crc a0ec5208 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/German)"
-	description "Curse of Monkey Island, The (Windows/German)"
-	rom ( name "RESOURCE\BBSAN.SAN" size 14973826 crc 8d02e3ae md5 undefined )
+	name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	description "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening.scummvm" size 7 crc 168a7f35 )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Italian)"
-	description "Curse of Monkey Island, The (Windows/Italian)"
-	rom ( name "RESOURCE\BBSAN.SAN" size 14973516 crc 76cbbece md5 533209dec649ddbc514a576d183a4799 )
+	name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	description "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening CRLF.scummvm" size 9 crc 76293d3d )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Russian)"
-	description "Curse of Monkey Island, The (Windows/Russian)"
-	rom ( name "RESOURCE\FONT0.NUT" size 86946 crc e0b7808c md5 277ddf3168e83beafed1aba8b65f9e85 )
+	name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	description "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening LF.scummvm" size 8 crc 647248cf )
 )
 
 game (
-	name "Curse of Monkey Island, The (Windows/Spanish)"
-	description "Curse of Monkey Island, The (Windows/Spanish)"
-	rom ( name "RESOURCE\BBSAN.SAN" size 14973678 crc 44ef9541 md5 338b4f71de5fc8447f067abe27566fd7 )
+	name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	description "Pajama Sam 2 Thunder and Lightning Aren't so Frightening"
+	rom ( name "Pajama Sam 2 Thunder and Lightning Aren't so Frightening CR.scummvm" size 8 crc fa16dd6c )
 )
 
 game (
-	name "Curt's Quest (DOS/Fanmade/1.0)"
-	description "Curt's Quest (DOS/Fanmade/1.0)"
-	rom ( name "RESOURCE.001" size 307165 crc 3487bf5a md5 7ad0ca1cb0de3da977136a384200a016 )
+	name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	description "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet.scummvm" size 7 crc 618d4fa3 )
 )
 
 game (
-	name "Curt's Quest (DOS/Fanmade/1.1)"
-	description "Curt's Quest (DOS/Fanmade/1.1)"
-	rom ( name "RESOURCE.001" size 302000 crc 5c537be2 md5 15720b1d305b2cca5bbdebbbfbdad492 )
+	name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	description "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet CRLF.scummvm" size 9 crc 77eb570a )
 )
 
 game (
-	name "Darby the Dragon (Macintosh)"
-	description "Darby the Dragon (Macintosh)"
-	rom ( name "Darby the Dragon" size 57728 crc 10bd22d6 md5 undefined )
+	name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	description "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet LF.scummvm" size 8 crc 7d69798e )
 )
 
 game (
-	name "Darby the Dragon (Windows)"
-	description "Darby the Dragon (Windows)"
-	rom ( name "BOOK.INI" size 2545 crc b4e187ea md5 undefined )
+	name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	description "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet"
+	rom ( name "Pajama Sam 3 You Are What You Eat From Your Head to Your Feet CR.scummvm" size 8 crc e30dec2d )
 )
 
 game (
-	name "Darby the Dragon (Windows/German)"
-	description "Darby the Dragon (Windows/German)"
-	rom ( name "BOOK.INI" size 2545 crc cc61adb2 md5 undefined )
+	name "Pajama Sam Games to Play on Any Day"
+	description "Pajama Sam Games to Play on Any Day"
+	rom ( name "Pajama Sam Games to Play on Any Day.scummvm" size 7 crc e16aff45 )
 )
 
 game (
-	name "Darby the Dragon (Windows/Hebrew)"
-	description "Darby the Dragon (Windows/Hebrew)"
-	rom ( name "Book.ini" size 2545 crc b4e187ea md5 undefined )
+	name "Pajama Sam Games to Play on Any Day"
+	description "Pajama Sam Games to Play on Any Day"
+	rom ( name "Pajama Sam Games to Play on Any Day CRLF.scummvm" size 9 crc b4ae300b )
 )
 
 game (
-	name "Dashiki (DOS/Fanmade 16 Colors)"
-	description "Dashiki (DOS/Fanmade 16 Colors)"
-	rom ( name "LOGDIR" size 609 crc 0bbc00c7 md5 undefined )
+	name "Pajama Sam Games to Play on Any Day"
+	description "Pajama Sam Games to Play on Any Day"
+	rom ( name "Pajama Sam Games to Play on Any Day LF.scummvm" size 8 crc 3480d973 )
 )
 
 game (
-	name "Dashiki (DOS/Fanmade 256 Colors)"
-	description "Dashiki (DOS/Fanmade 256 Colors)"
-	rom ( name "LOGDIR" size 300 crc bc31654e md5 c68052bb209e23b39b55ff3d759958e6 )
+	name "Pajama Sam Games to Play on Any Day"
+	description "Pajama Sam Games to Play on Any Day"
+	rom ( name "Pajama Sam Games to Play on Any Day CR.scummvm" size 8 crc aae44cd0 )
 )
 
 game (
-	name "Date Quest 1 (DOS/Fanmade v1.0)"
-	description "Date Quest 1 (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 768 crc 3e154e1e md5 ba3dcb2600645be53a13170aa1a12e69 )
+	name "Pajama Sam's Lost & Found"
+	description "Pajama Sam's Lost & Found"
+	rom ( name "Pajama Sam's Lost & Found.scummvm" size 4 crc 404584aa )
 )
 
 game (
-	name "Date Quest 2 (Demo/DOS/Fanmade v1.0)"
-	description "Date Quest 2 (Demo/DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 603 crc 877d1020 md5 undefined )
+	name "Pajama Sam's Lost & Found"
+	description "Pajama Sam's Lost & Found"
+	rom ( name "Pajama Sam's Lost & Found CRLF.scummvm" size 6 crc aa9fd6b3 )
 )
 
 game (
-	name "Date Quest 2 (DOS/Fanmade v1.0)"
-	description "Date Quest 2 (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 603 crc 4872ef1f md5 f13f6fc85aa3e6e02b0c20408fb63b47 )
+	name "Pajama Sam's Lost & Found"
+	description "Pajama Sam's Lost & Found"
+	rom ( name "Pajama Sam's Lost & Found LF.scummvm" size 5 crc 49409e1 )
 )
 
 game (
-	name "Dave's Quest (DOS/Fanmade v0.07)"
-	description "Dave's Quest (DOS/Fanmade v0.07)"
-	rom ( name "LOGDIR" size 603 crc c98563eb md5 undefined )
+	name "Pajama Sam's Lost & Found"
+	description "Pajama Sam's Lost & Found"
+	rom ( name "Pajama Sam's Lost & Found CR.scummvm" size 5 crc 9af09c42 )
 )
 
 game (
-	name "Dave's Quest (DOS/Fanmade v0.17)"
-	description "Dave's Quest (DOS/Fanmade v0.17)"
-	rom ( name "LOGDIR" size 603 crc 4c87ce03 md5 da3772624cc4a86f7137db812f6d7c39 )
+	name "Pajama Sam's One-Stop Fun Shop"
+	description "Pajama Sam's One-Stop Fun Shop"
+	rom ( name "Pajama Sam's One-Stop Fun Shop.scummvm" size 11 crc 4c27bc9a )
 )
 
 game (
-	name "Day of the Tentacle (CD)[!]"
-	description "Day of the Tentacle (CD)[!]"
-	rom ( name "TENTACLE.000" size 7932 crc a354dcfe md5 undefined )
+	name "Pajama Sam's One-Stop Fun Shop"
+	description "Pajama Sam's One-Stop Fun Shop"
+	rom ( name "Pajama Sam's One-Stop Fun Shop CRLF.scummvm" size 13 crc 5ddb54bc )
 )
 
 game (
-	name "Day of the Tentacle (CD/Fanmade Hungarian)"
-	description "Day of the Tentacle (CD/Fanmade Hungarian)"
-	rom ( name "TENTACLE.000" size 7932 crc e8bbfedb md5 undefined )
+	name "Pajama Sam's One-Stop Fun Shop"
+	description "Pajama Sam's One-Stop Fun Shop"
+	rom ( name "Pajama Sam's One-Stop Fun Shop LF.scummvm" size 12 crc 22415b75 )
 )
 
 game (
-	name "Day of the Tentacle (CD/French)"
-	description "Day of the Tentacle (CD/French)"
-	rom ( name "TENTACLE.000" size 7932 crc 90925500 md5 8aa05d3cdb0e795436043f0546af2da2 )
+	name "Pajama Sam's One-Stop Fun Shop"
+	description "Pajama Sam's One-Stop Fun Shop"
+	rom ( name "Pajama Sam's One-Stop Fun Shop CR.scummvm" size 12 crc bc25ced6 )
 )
 
 game (
-	name "Day of the Tentacle (CD/German)"
-	description "Day of the Tentacle (CD/German)"
-	rom ( name "MONSTER.SOU" size 238267139 crc ba6467a2 md5 8ea07a3e13af00f0a6e594820df1a9af )
+	name "Pajama Sam's Sock Works"
+	description "Pajama Sam's Sock Works"
+	rom ( name "Pajama Sam's Sock Works.scummvm" size 5 crc 1e816dc4 )
 )
 
 game (
-	name "Day of the Tentacle (CD/Italian)"
-	description "Day of the Tentacle (CD/Italian)"
-	rom ( name "TENTACLE.000" size 7932 crc 34f89a97 md5 undefined )
+	name "Pajama Sam's Sock Works"
+	description "Pajama Sam's Sock Works"
+	rom ( name "Pajama Sam's Sock Works CRLF.scummvm" size 7 crc 88379482 )
 )
 
 game (
-	name "Day of the Tentacle (CD/Macintosh)[mac bundle]"
-	description "Day of the Tentacle (CD/Macintosh)[mac bundle]"
-	rom ( name "Day of the Tentacle Data" size 282467632 crc 477e4dad md5 undefined )
+	name "Pajama Sam's Sock Works"
+	description "Pajama Sam's Sock Works"
+	rom ( name "Pajama Sam's Sock Works LF.scummvm" size 6 crc aec08157 )
 )
 
 game (
-	name "Day of the Tentacle (CD/Macintosh/French)[mac bundle]"
-	description "Day of the Tentacle (CD/Macintosh/French)[mac bundle]"
-	rom ( name "Day of the Tentacle Data" size 282830409 crc 3452390b md5 undefined )
+	name "Pajama Sam's Sock Works"
+	description "Pajama Sam's Sock Works"
+	rom ( name "Pajama Sam's Sock Works CR.scummvm" size 6 crc 30a414f4 )
 )
 
 game (
-	name "Day of the Tentacle (CD/Macintosh/German)[mac bundle][v1.1]"
-	description "Day of the Tentacle (CD/Macintosh/German)[mac bundle][v1.1]"
-	rom ( name "Day of the Tentacle Data" size 252138634 crc e82eea83 md5 ad1b2891f2cca5938d5ecd39453b43e7 )
+	name "Parallaction engine game"
+	description "Parallaction engine game"
+	rom ( name "Parallaction engine game.scummvm" size 12 crc 4a3d7075 )
 )
 
 game (
-	name "Day of the Tentacle (CD/Polish)"
-	description "Day of the Tentacle (CD/Polish)"
-	rom ( name "tentacle.000" size 7932 crc 579786e6 md5 d19eef805645c3ae5a0e368a65f0df5b )
+	name "Parallaction engine game"
+	description "Parallaction engine game"
+	rom ( name "Parallaction engine game CRLF.scummvm" size 14 crc 16ef331e )
 )
 
 game (
-	name "Day of the Tentacle (CD/Spanish)"
-	description "Day of the Tentacle (CD/Spanish)"
-	rom ( name "TENTACLE.000" size 7932 crc 50fc6a82 md5 undefined )
+	name "Parallaction engine game"
+	description "Parallaction engine game"
+	rom ( name "Parallaction engine game LF.scummvm" size 13 crc 12f2be50 )
 )
 
 game (
-	name "Day of the Tentacle (Demo)[!]"
-	description "Day of the Tentacle (Demo)[!]"
-	rom ( name "DOTTDEMO.000" size 7477 crc cec8754e md5 undefined )
+	name "Parallaction engine game"
+	description "Parallaction engine game"
+	rom ( name "Parallaction engine game CR.scummvm" size 13 crc 8c962bf3 )
 )
 
 game (
-	name "Day of the Tentacle (Demo/DOS/French)"
-	description "Day of the Tentacle (Demo/DOS/French)"
-	rom ( name "DOTTDEMO.000" size 7477 crc 44c6509e md5 undefined )
+	name "Passport to Adventure"
+	description "Passport to Adventure"
+	rom ( name "Passport to Adventure.scummvm" size 4 crc ce70d424 )
 )
 
 game (
-	name "Day of the Tentacle (Demo/DOS/German)"
-	description "Day of the Tentacle (Demo/DOS/German)"
-	rom ( name "DOTTDEMO.000" size 7477 crc bf6f4d2b md5 ac1642b6edfb8521ca03760126f1c250 )
+	name "Passport to Adventure"
+	description "Passport to Adventure"
+	rom ( name "Passport to Adventure CRLF.scummvm" size 6 crc 64f4bcb7 )
 )
 
 game (
-	name "Day of the Tentacle (Demo/Macintosh)[mac bundle]"
-	description "Day of the Tentacle (Demo/Macintosh)[mac bundle]"
-	rom ( name "Day of the Tentacle Demo Data" size 2439158 crc 4b341613 md5 53aa3be3e7a15fc29941695e3d588713 )
+	name "Passport to Adventure"
+	description "Passport to Adventure"
+	rom ( name "Passport to Adventure LF.scummvm" size 5 crc e1a9296 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy)[version a]"
-	description "Day of the Tentacle (Floppy)[version a]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Passport to Adventure"
+	description "Passport to Adventure"
+	rom ( name "Passport to Adventure CR.scummvm" size 5 crc 907e0735 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS)[version b]"
-	description "Day of the Tentacle (Floppy/DOS)[version b]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Personal Nightmare"
+	description "Personal Nightmare"
+	rom ( name "Personal Nightmare.scummvm" size 2 crc c4ec2756 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS)[version b][a]"
-	description "Day of the Tentacle (Floppy/DOS)[version b][a]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 ec46c029ec58596485b221dac0c55d7a )
+	name "Personal Nightmare"
+	description "Personal Nightmare"
+	rom ( name "Personal Nightmare CRLF.scummvm" size 4 crc 5d490ef9 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS)[version b][a2]"
-	description "Day of the Tentacle (Floppy/DOS)[version b][a2]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Personal Nightmare"
+	description "Personal Nightmare"
+	rom ( name "Personal Nightmare LF.scummvm" size 3 crc b01b1e75 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/French)"
-	description "Day of the Tentacle (Floppy/DOS/French)"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 ec46c029ec58596485b221dac0c55d7a )
+	name "Personal Nightmare"
+	description "Personal Nightmare"
+	rom ( name "Personal Nightmare CR.scummvm" size 3 crc 2e7f8bd6 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/French)[a]"
-	description "Day of the Tentacle (Floppy/DOS/French)[a]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Putt-Putt & Fatty Bear's Activity Pack"
+	description "Putt-Putt & Fatty Bear's Activity Pack"
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack.scummvm" size 8 crc ac74095a )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/French)[a2]"
-	description "Day of the Tentacle (Floppy/DOS/French)[a2]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 ec46c029ec58596485b221dac0c55d7a )
+	name "Putt-Putt & Fatty Bear's Activity Pack"
+	description "Putt-Putt & Fatty Bear's Activity Pack"
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack CRLF.scummvm" size 10 crc 2d2a24a2 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/German)"
-	description "Day of the Tentacle (Floppy/DOS/German)"
-	rom ( name "MONSTER.SOU" size 4808781 crc d09efae8 md5 undefined )
+	name "Putt-Putt & Fatty Bear's Activity Pack"
+	description "Putt-Putt & Fatty Bear's Activity Pack"
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack LF.scummvm" size 9 crc b9c5ca70 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/German)[a]"
-	description "Day of the Tentacle (Floppy/DOS/German)[a]"
-	rom ( name "MONSTER.SOU" size 4808781 crc d09efae8 md5 8dfb1236c4a03ee0614a7ad8ace2a1c7 )
+	name "Putt-Putt & Fatty Bear's Activity Pack"
+	description "Putt-Putt & Fatty Bear's Activity Pack"
+	rom ( name "Putt-Putt & Fatty Bear's Activity Pack CR.scummvm" size 9 crc 27a15fd3 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/Italian)"
-	description "Day of the Tentacle (Floppy/DOS/Italian)"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Putt-Putt Enters the Race"
+	description "Putt-Putt Enters the Race"
+	rom ( name "Putt-Putt Enters the Race.scummvm" size 8 crc 10e8dc1e )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/Italian)[a]"
-	description "Day of the Tentacle (Floppy/DOS/Italian)[a]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 ec46c029ec58596485b221dac0c55d7a )
+	name "Putt-Putt Enters the Race"
+	description "Putt-Putt Enters the Race"
+	rom ( name "Putt-Putt Enters the Race CRLF.scummvm" size 10 crc 4f863464 )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/Spanish)"
-	description "Day of the Tentacle (Floppy/DOS/Spanish)"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 undefined )
+	name "Putt-Putt Enters the Race"
+	description "Putt-Putt Enters the Race"
+	rom ( name "Putt-Putt Enters the Race LF.scummvm" size 9 crc c8c8d32c )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/Spanish)[a]"
-	description "Day of the Tentacle (Floppy/DOS/Spanish)[a]"
-	rom ( name "MONSTER.SOU" size 3830653 crc 607ef52a md5 ec46c029ec58596485b221dac0c55d7a )
+	name "Putt-Putt Enters the Race"
+	description "Putt-Putt Enters the Race"
+	rom ( name "Putt-Putt Enters the Race CR.scummvm" size 9 crc 56ac468f )
 )
 
 game (
-	name "Day of the Tentacle (Floppy/DOS/Spanish)[a2]"
-	description "Day of the Tentacle (Floppy/DOS/Spanish)[a2]"
-	rom ( name "MONSTER.SOU" size 3830653 crc ab4ba33a md5 undefined )
+	name "Putt-Putt Goes to the Moon"
+	description "Putt-Putt Goes to the Moon"
+	rom ( name "Putt-Putt Goes to the Moon.scummvm" size 8 crc 296b2059 )
 )
 
 game (
-	name "Dead City (Windows)"
-	description "Dead City (Windows)"
-	rom ( name "english.dcp" size 415935 crc e253c827 md5 05c3b14408b951181157ac297bffd96f )
+	name "Putt-Putt Goes to the Moon"
+	description "Putt-Putt Goes to the Moon"
+	rom ( name "Putt-Putt Goes to the Moon CRLF.scummvm" size 10 crc 44b56a12 )
 )
 
 game (
-	name "Dead City (Windows/Czech)"
-	description "Dead City (Windows/Czech)"
-	rom ( name "CZECH.ROM" size 30 crc c46020ab md5 undefined )
+	name "Putt-Putt Goes to the Moon"
+	description "Putt-Putt Goes to the Moon"
+	rom ( name "Putt-Putt Goes to the Moon LF.scummvm" size 9 crc 204984e3 )
 )
 
 game (
-	name "Dead City (Windows/Italian)"
-	description "Dead City (Windows/Italian)"
-	rom ( name "italian.dcp" size 454037 crc aecffce5 md5 undefined )
+	name "Putt-Putt Goes to the Moon"
+	description "Putt-Putt Goes to the Moon"
+	rom ( name "Putt-Putt Goes to the Moon CR.scummvm" size 9 crc be2d1140 )
 )
 
 game (
-	name "Dead City (Windows/Russian)"
-	description "Dead City (Windows/Russian)"
-	rom ( name "russian.dcp" size 653317 crc 12cfb9cc md5 0b5b37c7d57f1b0da165e3f71c677742 )
+	name "Putt-Putt Joins the Circus"
+	description "Putt-Putt Joins the Circus"
+	rom ( name "Putt-Putt Joins the Circus.scummvm" size 10 crc 956bd8b5 )
 )
 
 game (
-	name "Deep Angst (Macintosh)"
-	description "Deep Angst (Macintosh)"
-	rom ( name "._Deep Angst" size 335872 crc undefined md5 undefined )
+	name "Putt-Putt Joins the Circus"
+	description "Putt-Putt Joins the Circus"
+	rom ( name "Putt-Putt Joins the Circus CRLF.scummvm" size 12 crc 51810dc )
 )
 
 game (
-	name "Demo Quest (DOS/Fanmade)"
-	description "Demo Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 160098 crc fef0f0cb md5 61eedf686573229e217156ea6aae29ee )
+	name "Putt-Putt Joins the Circus"
+	description "Putt-Putt Joins the Circus"
+	rom ( name "Putt-Putt Joins the Circus LF.scummvm" size 11 crc 89492a48 )
 )
 
 game (
-	name "Des Reves Elastiques Avec Mille Insectes Nommes Georges (Windows)"
-	description "Des Reves Elastiques Avec Mille Insectes Nommes Georges (Windows)"
-	rom ( name "data.dcp" size 8804073 crc b936b4b5 md5 undefined )
+	name "Putt-Putt Joins the Circus"
+	description "Putt-Putt Joins the Circus"
+	rom ( name "Putt-Putt Joins the Circus CR.scummvm" size 11 crc 172dbfeb )
 )
 
 game (
-	name "DG: The Adventure Game (DOS/Fanmade v1.1)"
-	description "DG: The Adventure Game (DOS/Fanmade v1.1)"
-	rom ( name "LOGDIR" size 300 crc 8fc2a998 md5 undefined )
+	name "Putt-Putt Joins the Parade"
+	description "Putt-Putt Joins the Parade"
+	rom ( name "Putt-Putt Joins the Parade.scummvm" size 8 crc cefdbb5d )
 )
 
 game (
-	name "DG: The Adventure Game (DOS/Fanmade/French v1.1)"
-	description "DG: The Adventure Game (DOS/Fanmade/French v1.1)"
-	rom ( name "LOGDIR" size 300 crc 8839de41 md5 undefined )
+	name "Putt-Putt Joins the Parade"
+	description "Putt-Putt Joins the Parade"
+	rom ( name "Putt-Putt Joins the Parade CRLF.scummvm" size 10 crc 4704024c )
 )
 
 game (
-	name "DG: The AGIMouse Adventure (DOS/Fanmade v1.1)"
-	description "DG: The AGIMouse Adventure (DOS/Fanmade v1.1)"
-	rom ( name "LOGDIR" size 300 crc 496d4cc4 md5 undefined )
+	name "Putt-Putt Joins the Parade"
+	description "Putt-Putt Joins the Parade"
+	rom ( name "Putt-Putt Joins the Parade LF.scummvm" size 9 crc 27c3d661 )
 )
 
 game (
-	name "DG: The AGIMouse Adventure (DOS/Fanmade/French v1.1)"
-	description "DG: The AGIMouse Adventure (DOS/Fanmade/French v1.1)"
-	rom ( name "LOGDIR" size 300 crc c7373152 md5 undefined )
+	name "Putt-Putt Joins the Parade"
+	description "Putt-Putt Joins the Parade"
+	rom ( name "Putt-Putt Joins the Parade CR.scummvm" size 9 crc b9a743c2 )
 )
 
 game (
-	name "Dig, The (Demo)"
-	description "Dig, The (Demo)"
-	rom ( name "DEMOEND.SAN" size 9972014 crc 1bff07d1 md5 undefined )
+	name "Putt-Putt Saves the Zoo"
+	description "Putt-Putt Saves the Zoo"
+	rom ( name "Putt-Putt Saves the Zoo.scummvm" size 7 crc a4ea04c4 )
 )
 
 game (
-	name "Dig, The (Demo/Macintosh)[mac bundle]"
-	description "Dig, The (Demo/Macintosh)[mac bundle]"
-	rom ( name "The Dig Demo Data" size 45156007 crc bf2ea10c md5 undefined )
+	name "Putt-Putt Saves the Zoo"
+	description "Putt-Putt Saves the Zoo"
+	rom ( name "Putt-Putt Saves the Zoo CRLF.scummvm" size 9 crc bc59f715 )
 )
 
 game (
-	name "Dig, The (English)[!]"
-	description "Dig, The (English)[!]"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 d8323015ecb8b10bf53474f6e6b0ae33 )
+	name "Putt-Putt Saves the Zoo"
+	description "Putt-Putt Saves the Zoo"
+	rom ( name "Putt-Putt Saves the Zoo LF.scummvm" size 8 crc ae7aea3e )
 )
 
 game (
-	name "Dig, The (English)[v2]"
-	description "Dig, The (English)[v2]"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 d8323015ecb8b10bf53474f6e6b0ae33 )
+	name "Putt-Putt Saves the Zoo"
+	description "Putt-Putt Saves the Zoo"
+	rom ( name "Putt-Putt Saves the Zoo CR.scummvm" size 8 crc 301e7f9d )
 )
 
 game (
-	name "Dig, The (French)"
-	description "Dig, The (French)"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 undefined )
+	name "Putt-Putt Travels Through Time"
+	description "Putt-Putt Travels Through Time"
+	rom ( name "Putt-Putt Travels Through Time.scummvm" size 8 crc a513fff4 )
 )
 
 game (
-	name "Dig, The (German)[!]"
-	description "Dig, The (German)[!]"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 d8323015ecb8b10bf53474f6e6b0ae33 )
+	name "Putt-Putt Travels Through Time"
+	description "Putt-Putt Travels Through Time"
+	rom ( name "Putt-Putt Travels Through Time CRLF.scummvm" size 10 crc 4970eb8b )
 )
 
 game (
-	name "Dig, The (Hungarian)"
-	description "Dig, The (Hungarian)"
-	rom ( name "DIG.LA0" size 16304 crc 26e77e8f md5 5c3b3add7eaebcf6d5bb95e0e0c83229 )
+	name "Putt-Putt Travels Through Time"
+	description "Putt-Putt Travels Through Time"
+	rom ( name "Putt-Putt Travels Through Time LF.scummvm" size 9 crc 88a22369 )
 )
 
 game (
-	name "Dig, The (Italian)"
-	description "Dig, The (Italian)"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 d8323015ecb8b10bf53474f6e6b0ae33 )
+	name "Putt-Putt Travels Through Time"
+	description "Putt-Putt Travels Through Time"
+	rom ( name "Putt-Putt Travels Through Time CR.scummvm" size 9 crc 16c6b6ca )
 )
 
 game (
-	name "Dig, The (Macintosh)[mac bundle]"
-	description "Dig, The (Macintosh)[mac bundle]"
-	rom ( name "The Dig Data" size 659335495 crc 8d98a8d3 md5 undefined )
+	name "Putt-Putt and Pep's Balloon-O-Rama"
+	description "Putt-Putt and Pep's Balloon-O-Rama"
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama.scummvm" size 7 crc 643b3b90 )
 )
 
 game (
-	name "Dig, The (Macintosh/French)[mac bundle]"
-	description "Dig, The (Macintosh/French)[mac bundle]"
-	rom ( name "The Dig Data" size 661316652 crc 13ce04ba md5 15de69eb6984a728eb9ef84321a16eaa )
+	name "Putt-Putt and Pep's Balloon-O-Rama"
+	description "Putt-Putt and Pep's Balloon-O-Rama"
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama CRLF.scummvm" size 9 crc d4e882a9 )
 )
 
 game (
-	name "Dig, The (Polish)"
-	description "Dig, The (Polish)"
-	rom ( name "DIG.LA0" size 16304 crc 326d9f61 md5 undefined )
+	name "Putt-Putt and Pep's Balloon-O-Rama"
+	description "Putt-Putt and Pep's Balloon-O-Rama"
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama LF.scummvm" size 8 crc c2bcaeec )
 )
 
 game (
-	name "Dig, The (Portuguese)"
-	description "Dig, The (Portuguese)"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 undefined )
+	name "Putt-Putt and Pep's Balloon-O-Rama"
+	description "Putt-Putt and Pep's Balloon-O-Rama"
+	rom ( name "Putt-Putt and Pep's Balloon-O-Rama CR.scummvm" size 8 crc 5cd83b4f )
 )
 
 game (
-	name "Dig, The (Russian)"
-	description "Dig, The (Russian)"
-	rom ( name "DIG.LA0" size 16304 crc 803edd4e md5 undefined )
+	name "Putt-Putt and Pep's Dog on a Stick"
+	description "Putt-Putt and Pep's Dog on a Stick"
+	rom ( name "Putt-Putt and Pep's Dog on a Stick.scummvm" size 3 crc 812c397d )
 )
 
 game (
-	name "Dig, The (Russian/With Subtitles)"
-	description "Dig, The (Russian/With Subtitles)"
-	rom ( name "DIG.LA0" size 16304 crc ec470b1e md5 ebdd2fbc995a321605375dc57766db79 )
+	name "Putt-Putt and Pep's Dog on a Stick"
+	description "Putt-Putt and Pep's Dog on a Stick"
+	rom ( name "Putt-Putt and Pep's Dog on a Stick CRLF.scummvm" size 5 crc d1368b33 )
 )
 
 game (
-	name "Dig, The (Spanish)"
-	description "Dig, The (Spanish)"
-	rom ( name "DIG.LA0" size 16304 crc 95af95ad md5 d8323015ecb8b10bf53474f6e6b0ae33 )
+	name "Putt-Putt and Pep's Dog on a Stick"
+	description "Putt-Putt and Pep's Dog on a Stick"
+	rom ( name "Putt-Putt and Pep's Dog on a Stick LF.scummvm" size 4 crc 1ce2272b )
 )
 
 game (
-	name "Dig, The (Steam/Macintosh)[!]"
-	description "Dig, The (Steam/Macintosh)[!]"
-	rom ( name "DIG.LA1" size 88673344 crc 38c765be md5 undefined )
+	name "Putt-Putt and Pep's Dog on a Stick"
+	description "Putt-Putt and Pep's Dog on a Stick"
+	rom ( name "Putt-Putt and Pep's Dog on a Stick CR.scummvm" size 4 crc 8286b288 )
 )
 
 game (
-	name "Dig, The (Steam/Windows)[!]"
-	description "Dig, The (Steam/Windows)[!]"
-	rom ( name "DIG.LA1" size 88673344 crc 38c765be md5 3f0c5483b0786391fa82231c51732448 )
+	name "Putt-Putt's Fun Pack"
+	description "Putt-Putt's Fun Pack"
+	rom ( name "Putt-Putt's Fun Pack.scummvm" size 7 crc be7d72c0 )
 )
 
 game (
-	name "Dinotopia (DOS)"
-	description "Dinotopia (DOS)"
-	rom ( name "DINO.HRS" size 66018 crc 0e94e6bb md5 4c453329ff1fa2a47f4ead90d9c478ee )
+	name "Putt-Putt's Fun Pack"
+	description "Putt-Putt's Fun Pack"
+	rom ( name "Putt-Putt's Fun Pack CRLF.scummvm" size 9 crc 6153fc8f )
 )
 
 game (
-	name "Dirty Split (Windows)"
-	description "Dirty Split (Windows)"
-	rom ( name "data.dcp" size 88577621 crc 759e859e md5 undefined )
+	name "Putt-Putt's Fun Pack"
+	description "Putt-Putt's Fun Pack"
+	rom ( name "Putt-Putt's Fun Pack LF.scummvm" size 8 crc a90db951 )
 )
 
 game (
-	name "Dirty Split (Windows/Czech)"
-	description "Dirty Split (Windows/Czech)"
-	rom ( name "czech.dcp" size 127697934 crc e507e051 md5 undefined )
+	name "Putt-Putt's Fun Pack"
+	description "Putt-Putt's Fun Pack"
+	rom ( name "Putt-Putt's Fun Pack CR.scummvm" size 8 crc 37692cf2 )
 )
 
 game (
-	name "Dirty Split (Windows/French)"
-	description "Dirty Split (Windows/French)"
-	rom ( name "data.dcp" size 88577623 crc 213ca473 md5 undefined )
+	name "Putt-Putt's One-Stop Fun Shop"
+	description "Putt-Putt's One-Stop Fun Shop"
+	rom ( name "Putt-Putt's One-Stop Fun Shop.scummvm" size 12 crc cfc36a07 )
 )
 
 game (
-	name "Dirty Split (Windows/German)"
-	description "Dirty Split (Windows/German)"
-	rom ( name "data.dcp" size 92668291 crc 4bc1e479 md5 undefined )
+	name "Putt-Putt's One-Stop Fun Shop"
+	description "Putt-Putt's One-Stop Fun Shop"
+	rom ( name "Putt-Putt's One-Stop Fun Shop CRLF.scummvm" size 14 crc f68454ee )
 )
 
 game (
-	name "Dirty Split (Windows/Italian)"
-	description "Dirty Split (Windows/Italian)"
-	rom ( name "data.dcp" size 88577623 crc c358eee9 md5 undefined )
+	name "Putt-Putt's One-Stop Fun Shop"
+	description "Putt-Putt's One-Stop Fun Shop"
+	rom ( name "Putt-Putt's One-Stop Fun Shop LF.scummvm" size 13 crc ac7c505a )
 )
 
 game (
-	name "Dirty Split (Windows/Spanish)"
-	description "Dirty Split (Windows/Spanish)"
-	rom ( name "data.dcp" size 88577621 crc c4f340a1 md5 undefined )
+	name "Putt-Putt's One-Stop Fun Shop"
+	description "Putt-Putt's One-Stop Fun Shop"
+	rom ( name "Putt-Putt's One-Stop Fun Shop CR.scummvm" size 13 crc 3218c5f9 )
 )
 
 game (
-	name "Disco Nights (Demo/DOS/Fanmade)"
-	description "Disco Nights (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc fc26a44b md5 undefined )
+	name "Return of the Phantom"
+	description "Return of the Phantom"
+	rom ( name "Return of the Phantom.scummvm" size 7 crc 6896f6ae )
 )
 
 game (
-	name "Discworld (CD/DOS)[v1]"
-	description "Discworld (CD/DOS)[v1]"
-	rom ( name "ENGLISH.SMP" size 343755891 crc 196e4eb7 md5 b9973da5c04aa7407f0efe621406d296 )
+	name "Return of the Phantom"
+	description "Return of the Phantom"
+	rom ( name "Return of the Phantom CRLF.scummvm" size 9 crc 70f82b74 )
 )
 
 game (
-	name "Discworld (CD/DOS)[v2][!]"
-	description "Discworld (CD/DOS)[v2][!]"
-	rom ( name "ACT1.SCN" size 134528 crc 38776cac md5 6568c47d70a7ab898ef101ce9b74109f )
+	name "Return of the Phantom"
+	description "Return of the Phantom"
+	rom ( name "Return of the Phantom LF.scummvm" size 8 crc 3d11e8a )
 )
 
 game (
-	name "Discworld (CD/DOS/Enhanced Music)[v2][!]"
-	description "Discworld (CD/DOS/Enhanced Music)[v2][!]"
-	rom ( name "track01.ogg" size 850532 crc 18907c94 md5 c5bebebbf6bbe2dc76c6df4165ac851d )
+	name "Return of the Phantom"
+	description "Return of the Phantom"
+	rom ( name "Return of the Phantom CR.scummvm" size 8 crc 9db58b29 )
 )
 
 game (
-	name "Discworld (CD/DOS/French)[subtitle]"
-	description "Discworld (CD/DOS/French)[subtitle]"
-	rom ( name "FRENCH.ROM" size 35 crc 6d3791b2 md5 undefined )
+	name "Rex Nebular and the Cosmic Gender Bender"
+	description "Rex Nebular and the Cosmic Gender Bender"
+	rom ( name "Rex Nebular and the Cosmic Gender Bender.scummvm" size 7 crc 22ef7a1e )
 )
 
 game (
-	name "Discworld (CD/DOS/German)[subtitle]"
-	description "Discworld (CD/DOS/German)[subtitle]"
-	rom ( name "GERMAN.ROM" size 35 crc dd2c393f md5 undefined )
+	name "Rex Nebular and the Cosmic Gender Bender"
+	description "Rex Nebular and the Cosmic Gender Bender"
+	rom ( name "Rex Nebular and the Cosmic Gender Bender CRLF.scummvm" size 9 crc 703300be )
 )
 
 game (
-	name "Discworld (CD/DOS/German)[v2][!]"
-	description "Discworld (CD/DOS/German)[v2][!]"
-	rom ( name "ACT1.SCN" size 134528 crc e4427611 md5 undefined )
+	name "Rex Nebular and the Cosmic Gender Bender"
+	description "Rex Nebular and the Cosmic Gender Bender"
+	rom ( name "Rex Nebular and the Cosmic Gender Bender LF.scummvm" size 8 crc c8fad48a )
 )
 
 game (
-	name "Discworld (CD/DOS/Hebrew)"
-	description "Discworld (CD/DOS/Hebrew)"
-	rom ( name "ACT1.SCN" size 134528 crc 103d812f md5 835197be4fc15beb29740b3cd97d08c3 )
+	name "Rex Nebular and the Cosmic Gender Bender"
+	description "Rex Nebular and the Cosmic Gender Bender"
+	rom ( name "Rex Nebular and the Cosmic Gender Bender CR.scummvm" size 8 crc 569e4129 )
 )
 
 game (
-	name "Discworld (CD/DOS/Italian)[subtitle]"
-	description "Discworld (CD/DOS/Italian)[subtitle]"
-	rom ( name "ITALIAN.ROM" size 36 crc 8f0abda7 md5 a88231f863d5ab22bfa607cbc280baa0 )
+	name "SAGA Engine game"
+	description "SAGA Engine game"
+	rom ( name "SAGA Engine game.scummvm" size 4 crc 1d2ddd7 )
 )
 
 game (
-	name "Discworld (CD/DOS/Polish)"
-	description "Discworld (CD/DOS/Polish)"
-	rom ( name "ACT1.SCN" size 134576 crc 9c333c05 md5 ae41733a56a55580b4aa339037a5cd35 )
+	name "SAGA Engine game"
+	description "SAGA Engine game"
+	rom ( name "SAGA Engine game CRLF.scummvm" size 6 crc 22b979cf )
 )
 
 game (
-	name "Discworld (CD/DOS/Russian)"
-	description "Discworld (CD/DOS/Russian)"
-	rom ( name "ACT1.SCN" size 134576 crc 9c333c05 md5 undefined )
+	name "SAGA Engine game"
+	description "SAGA Engine game"
+	rom ( name "SAGA Engine game LF.scummvm" size 5 crc 2a619339 )
 )
 
 game (
-	name "Discworld (CD/DOS/Russian)[v1.1]"
-	description "Discworld (CD/DOS/Russian)[v1.1]"
-	rom ( name "ACT1.SCN" size 134608 crc 2f65ecd3 md5 undefined )
+	name "SAGA Engine game"
+	description "SAGA Engine game"
+	rom ( name "SAGA Engine game CR.scummvm" size 5 crc b405069a )
 )
 
 game (
-	name "Discworld (CD/DOS/Spanish)[subtitle]"
-	description "Discworld (CD/DOS/Spanish)[subtitle]"
-	rom ( name "SPANISH.ROM" size 36 crc 53c4041f md5 cc929dd690a5dc5b9f4be8f7a533f15f )
+	name "SPY Fox 1 Dry Cereal"
+	description "SPY Fox 1 Dry Cereal"
+	rom ( name "SPY Fox 1 Dry Cereal.scummvm" size 6 crc 2370e8e1 )
 )
 
 game (
-	name "Discworld (CD/Macintosh)"
-	description "Discworld (CD/Macintosh)"
-	rom ( name "ACT1.SCN" size 270416 crc 81defa98 md5 undefined )
+	name "SPY Fox 1 Dry Cereal"
+	description "SPY Fox 1 Dry Cereal"
+	rom ( name "SPY Fox 1 Dry Cereal CRLF.scummvm" size 8 crc fd160e3b )
 )
 
 game (
-	name "Discworld (CD/Sony PlayStation/English, French, German, Italian, Spanish)[!]"
-	description "Discworld (CD/Sony PlayStation/English, French, German, Italian, Spanish)[!]"
-	rom ( name "ENGLISH.TXT" size 230326 crc 648032be md5 49422e6301e57088478246b6c680496d )
+	name "SPY Fox 1 Dry Cereal"
+	description "SPY Fox 1 Dry Cereal"
+	rom ( name "SPY Fox 1 Dry Cereal LF.scummvm" size 7 crc e5f9a495 )
 )
 
 game (
-	name "Discworld (Demo/CD/DOS)"
-	description "Discworld (Demo/CD/DOS)"
-	rom ( name "ACT1.GRA" size 142532 crc 166ef534 md5 undefined )
+	name "SPY Fox 1 Dry Cereal"
+	description "SPY Fox 1 Dry Cereal"
+	rom ( name "SPY Fox 1 Dry Cereal CR.scummvm" size 7 crc 7b9d3136 )
 )
 
 game (
-	name "Discworld (Demo/CD/Macintosh)"
-	description "Discworld (Demo/CD/Macintosh)"
-	rom ( name "ACT1.SCN" size 270416 crc 5c716dde md5 0010e70a2f3c4b5d8266a7b6375f4c3f )
+	name "SPY Fox 2 Some Assembly Required"
+	description "SPY Fox 2 Some Assembly Required"
+	rom ( name "SPY Fox 2 Some Assembly Required.scummvm" size 7 crc cdfb1c0b )
 )
 
 game (
-	name "Discworld (Demo/CD/Sony PlayStation)"
-	description "Discworld (Demo/CD/Sony PlayStation)"
-	rom ( name "ENGLISH.TXT" size 230326 crc e565f21c md5 b54974ecb5bc73137a00b888d29a66fc )
+	name "SPY Fox 2 Some Assembly Required"
+	description "SPY Fox 2 Some Assembly Required"
+	rom ( name "SPY Fox 2 Some Assembly Required CRLF.scummvm" size 9 crc e357cdd3 )
 )
 
 game (
-	name "Discworld (Demo/Floppy/DOS)"
-	description "Discworld (Demo/Floppy/DOS)"
-	rom ( name "DW.GRA" size 441192 crc a6418dcd md5 undefined )
+	name "SPY Fox 2 Some Assembly Required"
+	description "SPY Fox 2 Some Assembly Required"
+	rom ( name "SPY Fox 2 Some Assembly Required LF.scummvm" size 8 crc a5c82407 )
 )
 
 game (
-	name "Discworld (Floppy/DOS)"
-	description "Discworld (Floppy/DOS)"
-	rom ( name "DW.GRA" size 781656 crc f8df863d md5 ac505b9087f8a8d5b9df2f9b8515b0f6 )
+	name "SPY Fox 2 Some Assembly Required"
+	description "SPY Fox 2 Some Assembly Required"
+	rom ( name "SPY Fox 2 Some Assembly Required CR.scummvm" size 8 crc 3bacb1a4 )
 )
 
 game (
-	name "Discworld (Floppy/DOS/Czech)"
-	description "Discworld (Floppy/DOS/Czech)"
-	rom ( name "DW.GRA" size 781656 crc f8df863d md5 ac505b9087f8a8d5b9df2f9b8515b0f6 )
+	name "SPY Fox 3 Operation Ozone"
+	description "SPY Fox 3 Operation Ozone"
+	rom ( name "SPY Fox 3 Operation Ozone.scummvm" size 7 crc cd40ab53 )
 )
 
 game (
-	name "Discworld (Floppy/DOS/French)"
-	description "Discworld (Floppy/DOS/French)"
-	rom ( name "ACT1.GRA" size 142532 crc 51a816d2 md5 010f82a29ca12c141d01caccf6878bf9 )
+	name "SPY Fox 3 Operation Ozone"
+	description "SPY Fox 3 Operation Ozone"
+	rom ( name "SPY Fox 3 Operation Ozone CRLF.scummvm" size 9 crc c4303c1b )
 )
 
 game (
-	name "Discworld (Floppy/DOS/German)"
-	description "Discworld (Floppy/DOS/German)"
-	rom ( name "GERMAN.ROM" size 69 crc 1241f4af md5 d102db82bd1a2221d7a8435efd64528e )
+	name "SPY Fox 3 Operation Ozone"
+	description "SPY Fox 3 Operation Ozone"
+	rom ( name "SPY Fox 3 Operation Ozone LF.scummvm" size 8 crc c0784676 )
 )
 
 game (
-	name "Discworld (Floppy/DOS/Italian)"
-	description "Discworld (Floppy/DOS/Italian)"
-	rom ( name "ITALIAN.ROM" size 70 crc 97ba8a39 md5 5aab1ba8e75d1ef1363edf82d4f27601 )
+	name "SPY Fox 3 Operation Ozone"
+	description "SPY Fox 3 Operation Ozone"
+	rom ( name "SPY Fox 3 Operation Ozone CR.scummvm" size 8 crc 5e1cd3d5 )
 )
 
 game (
-	name "Discworld (Floppy/DOS/Polish)"
-	description "Discworld (Floppy/DOS/Polish)"
-	rom ( name "DW.GRA" size 781864 crc 4755a976 md5 undefined )
+	name "SPY Fox in Cheese Chase"
+	description "SPY Fox in Cheese Chase"
+	rom ( name "SPY Fox in Cheese Chase.scummvm" size 5 crc 96fd3b99 )
 )
 
 game (
-	name "Discworld (Floppy/DOS/Spanish)"
-	description "Discworld (Floppy/DOS/Spanish)"
-	rom ( name "SPANISH.ROM" size 70 crc 3f055f7f md5 undefined )
+	name "SPY Fox in Cheese Chase"
+	description "SPY Fox in Cheese Chase"
+	rom ( name "SPY Fox in Cheese Chase CRLF.scummvm" size 7 crc 52acb26 )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/French)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/French)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 f14bdc331bf6d61965ac6795677d4b4b )
+	name "SPY Fox in Cheese Chase"
+	description "SPY Fox in Cheese Chase"
+	rom ( name "SPY Fox in Cheese Chase LF.scummvm" size 6 crc bb92d048 )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/German)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/German)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 undefined )
+	name "SPY Fox in Cheese Chase"
+	description "SPY Fox in Cheese Chase"
+	rom ( name "SPY Fox in Cheese Chase CR.scummvm" size 6 crc 25f645eb )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/Italian)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/Italian)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 f14bdc331bf6d61965ac6795677d4b4b )
+	name "SPY Fox in Hold the Mustard"
+	description "SPY Fox in Hold the Mustard"
+	rom ( name "SPY Fox in Hold the Mustard.scummvm" size 7 crc 680edcdf )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/Russian)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/Russian)"
-	rom ( name "ACT1.SCN" size 121017 crc c0e08759 md5 ab69c9da386550efb3b84809563fad9d )
+	name "SPY Fox in Hold the Mustard"
+	description "SPY Fox in Hold the Mustard"
+	rom ( name "SPY Fox in Hold the Mustard CRLF.scummvm" size 9 crc 9d67aa8d )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/Spanish)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/Spanish)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 f14bdc331bf6d61965ac6795677d4b4b )
+	name "SPY Fox in Hold the Mustard"
+	description "SPY Fox in Hold the Mustard"
+	rom ( name "SPY Fox in Hold the Mustard LF.scummvm" size 8 crc 24d3c70a )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/UK)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/UK)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 f14bdc331bf6d61965ac6795677d4b4b )
+	name "SPY Fox in Hold the Mustard"
+	description "SPY Fox in Hold the Mustard"
+	rom ( name "SPY Fox in Hold the Mustard CR.scummvm" size 8 crc bab752a9 )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (CD/DOS/US)"
-	description "Discworld 2: Missing Presumed ...!? (CD/DOS/US)"
-	rom ( name "ACT1.SCN" size 121017 crc ff5840c3 md5 f14bdc331bf6d61965ac6795677d4b4b )
+	name "Sam & Max Hit the Road"
+	description "Sam & Max Hit the Road"
+	rom ( name "Sam & Max Hit the Road.scummvm" size 7 crc 5b280160 )
 )
 
 game (
-	name "Discworld 2: Missing Presumed ...!? (Demo/DOS)"
-	description "Discworld 2: Missing Presumed ...!? (Demo/DOS)"
-	rom ( name "DEMOCRED.SCN" size 278097 crc d0cb293d md5 undefined )
+	name "Sam & Max Hit the Road"
+	description "Sam & Max Hit the Road"
+	rom ( name "Sam & Max Hit the Road CRLF.scummvm" size 9 crc 65885b5 )
 )
 
 game (
-	name "Dogs Quest: The Quest for the Golden Bone (DOS/Fanmade v1.0)"
-	description "Dogs Quest: The Quest for the Golden Bone (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc f7547b1e md5 f197357edaaea0ff70880602d2f09b3e )
+	name "Sam & Max Hit the Road"
+	description "Sam & Max Hit the Road"
+	rom ( name "Sam & Max Hit the Road LF.scummvm" size 8 crc 7f3e4fca )
 )
 
 game (
-	name "Donald Duck's Playground (Amiga/DOS)"
-	description "Donald Duck's Playground (Amiga/DOS)"
-	rom ( name "LOGDIR" size 132 crc 6d0d4e18 md5 undefined )
+	name "Sam & Max Hit the Road"
+	description "Sam & Max Hit the Road"
+	rom ( name "Sam & Max Hit the Road CR.scummvm" size 8 crc e15ada69 )
 )
 
 game (
-	name "Donald Duck's Playground (Atari ST/DOS)"
-	description "Donald Duck's Playground (Atari ST/DOS)"
-	rom ( name "LOGDIR" size 132 crc 084a8014 md5 undefined )
+	name "Sfinx"
+	description "Sfinx"
+	rom ( name "Sfinx.scummvm" size 5 crc 84bb8a55 )
 )
 
 game (
-	name "Donald Duck's Playground (Booter/DOS)"
-	description "Donald Duck's Playground (Booter/DOS)"
-	rom ( name "ddp.img" size 368640 crc 88a1bd70 md5 908e57b0ee97c3691407436e51476204 )
+	name "Sfinx"
+	description "Sfinx"
+	rom ( name "Sfinx CRLF.scummvm" size 7 crc de03c238 )
 )
 
 game (
-	name "Double Trouble (Macintosh)"
-	description "Double Trouble (Macintosh)"
-	rom ( name "._Double Trouble" size 557074 crc 69547c51 md5 b31da6278ee50f856a55e2ca01ccca9c )
+	name "Sfinx"
+	description "Sfinx"
+	rom ( name "Sfinx LF.scummvm" size 6 crc 29521862 )
 )
 
 game (
-	name "Dr. Jummybummy's Space Adventure (DOS/Fanmade)"
-	description "Dr. Jummybummy's Space Adventure (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc dcfc9bf3 md5 undefined )
+	name "Sfinx"
+	description "Sfinx"
+	rom ( name "Sfinx CR.scummvm" size 6 crc b7368dc1 )
 )
 
 game (
-	name "Dr. Jummybummy's Space Adventure 2 (DOS/Fanmade)"
-	description "Dr. Jummybummy's Space Adventure 2 (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 394670 crc be27ab2c md5 28f30d533d05c1bc2cb79ff7b7f58c6c )
+	name "Sierra AGI game"
+	description "Sierra AGI game"
+	rom ( name "Sierra AGI game.scummvm" size 3 crc a8865c99 )
 )
 
 game (
-	name "Draci Historie (DOS/German)"
-	description "Draci Historie (DOS/German)"
-	rom ( name "BIG.FON" size 21392 crc a4a49c91 md5 undefined )
+	name "Sierra AGI game"
+	description "Sierra AGI game"
+	rom ( name "Sierra AGI game CRLF.scummvm" size 5 crc d6fc01a6 )
 )
 
 game (
-	name "Dragon History (DOS)"
-	description "Dragon History (DOS)"
-	rom ( name "BIG.FON" size 21392 crc 18ff5a26 md5 e80f22efad64761ac52fcb68935eb64b )
+	name "Sierra AGI game"
+	description "Sierra AGI game"
+	rom ( name "Sierra AGI game LF.scummvm" size 4 crc bbacab2f )
 )
 
 game (
-	name "Dragon History (DOS/Czech)[!]"
-	description "Dragon History (DOS/Czech)[!]"
-	rom ( name "BIG.FON" size 21392 crc 18ff5a26 md5 undefined )
+	name "Sierra AGI game"
+	description "Sierra AGI game"
+	rom ( name "Sierra AGI game CR.scummvm" size 4 crc 25c83e8c )
 )
 
 game (
-	name "Dragon History (DOS/Polish)"
-	description "Dragon History (DOS/Polish)"
-	rom ( name "BIG.FON" size 21392 crc ffb28901 md5 undefined )
+	name "Sierra SCI Game"
+	description "Sierra SCI Game"
+	rom ( name "Sierra SCI Game.scummvm" size 3 crc d348ee83 )
 )
 
 game (
-	name "Dragonsphere (DOS)"
-	description "Dragonsphere (DOS)"
-	rom ( name "ANIMVIEW.EXE" size 109569 crc eb070529 md5 d24af0ca64829c2ea277dbdbdc838ebe )
+	name "Sierra SCI Game"
+	description "Sierra SCI Game"
+	rom ( name "Sierra SCI Game CRLF.scummvm" size 5 crc 43be5213 )
 )
 
 game (
-	name "Drakmyth Castle (Macintosh/disk I)"
-	description "Drakmyth Castle (Macintosh/disk I)"
-	rom ( name "._Drakmyth Castle disk I of II" size 798720 crc c7b9d9de md5 e6ab2a6b9ffe94d85830a33604a9fd0b )
+	name "Sierra SCI Game"
+	description "Sierra SCI Game"
+	rom ( name "Sierra SCI Game LF.scummvm" size 4 crc 46b59ce7 )
 )
 
 game (
-	name "Drakmyth Castle (Macintosh/disk II)"
-	description "Drakmyth Castle (Macintosh/disk II)"
-	rom ( name "._Drakmyth Castle II" size 1695744 crc undefined md5 undefined )
+	name "Sierra SCI Game"
+	description "Sierra SCI Game"
+	rom ( name "Sierra SCI Game CR.scummvm" size 4 crc d8d10944 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS)"
-	description "Drascula: The Vampire Strikes Back (DOS)"
-	rom ( name "1.ALD" size 261 crc 39daf931 md5 undefined )
+	name "Simon the Sorcerer 1"
+	description "Simon the Sorcerer 1"
+	rom ( name "Simon the Sorcerer 1.scummvm" size 6 crc 88312e20 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Italian)"
-	description "Drascula: The Vampire Strikes Back (DOS/Italian)"
-	rom ( name "1.ALD" size 266 crc 360626c8 md5 c3bb7eaff961e64120c8718a13133392 )
+	name "Simon the Sorcerer 1"
+	description "Simon the Sorcerer 1"
+	rom ( name "Simon the Sorcerer 1 CRLF.scummvm" size 8 crc 5df024f0 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Packed)"
-	description "Drascula: The Vampire Strikes Back (DOS/Packed)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 fac946707f07d51696a02c00cc182078 )
+	name "Simon the Sorcerer 1"
+	description "Simon the Sorcerer 1"
+	rom ( name "Simon the Sorcerer 1 LF.scummvm" size 7 crc 9311775 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Packed/French)"
-	description "Drascula: The Vampire Strikes Back (DOS/Packed/French)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 undefined )
+	name "Simon the Sorcerer 1"
+	description "Simon the Sorcerer 1"
+	rom ( name "Simon the Sorcerer 1 CR.scummvm" size 7 crc 975582d6 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Packed/German)"
-	description "Drascula: The Vampire Strikes Back (DOS/Packed/German)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 undefined )
+	name "Simon the Sorcerer 2"
+	description "Simon the Sorcerer 2"
+	rom ( name "Simon the Sorcerer 2.scummvm" size 6 crc 11387f9a )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Packed/Italian)"
-	description "Drascula: The Vampire Strikes Back (DOS/Packed/Italian)"
-	rom ( name "PACKET.001" size 32564209 crc d8730d7d md5 undefined )
+	name "Simon the Sorcerer 2"
+	description "Simon the Sorcerer 2"
+	rom ( name "Simon the Sorcerer 2 CRLF.scummvm" size 8 crc 5fb69aa9 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Packed/Spanish)"
-	description "Drascula: The Vampire Strikes Back (DOS/Packed/Spanish)"
-	rom ( name "PACKET.001" size 31702652 crc 3cc4ed44 md5 d52719c813ee5363f8e8057851a582c9 )
+	name "Simon the Sorcerer 2"
+	description "Simon the Sorcerer 2"
+	rom ( name "Simon the Sorcerer 2 LF.scummvm" size 7 crc 221c44b6 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Repacked/French)"
-	description "Drascula: The Vampire Strikes Back (DOS/Repacked/French)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 undefined )
+	name "Simon the Sorcerer 2"
+	description "Simon the Sorcerer 2"
+	rom ( name "Simon the Sorcerer 2 CR.scummvm" size 7 crc bc78d115 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Repacked/Italian)"
-	description "Drascula: The Vampire Strikes Back (DOS/Repacked/Italian)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 undefined )
+	name "Soltys"
+	description "Soltys"
+	rom ( name "Soltys.scummvm" size 6 crc 32ef545e )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Repacked/Spanish)"
-	description "Drascula: The Vampire Strikes Back (DOS/Repacked/Spanish)"
-	rom ( name "PACKET.001" size 32847563 crc 3e79eec3 md5 undefined )
+	name "Soltys"
+	description "Soltys"
+	rom ( name "Soltys CRLF.scummvm" size 8 crc 5c9c5274 )
 )
 
 game (
-	name "Drascula: The Vampire Strikes Back (DOS/Spanish)"
-	description "Drascula: The Vampire Strikes Back (DOS/Spanish)"
-	rom ( name "1.ALD" size 790 crc 66229b95 md5 undefined )
+	name "Soltys"
+	description "Soltys"
+	rom ( name "Soltys LF.scummvm" size 7 crc be369534 )
 )
 
 game (
-	name "Dreamscape (Windows)"
-	description "Dreamscape (Windows)"
-	rom ( name "data.dcp" size 17034377 crc c54f0d42 md5 8c6d10e14963de9557ec7e7f624474b6 )
+	name "Soltys"
+	description "Soltys"
+	rom ( name "Soltys CR.scummvm" size 7 crc 20520097 )
 )
 
 game (
-	name "DreamWeb (CD/DOS/Czech)"
-	description "DreamWeb (CD/DOS/Czech)"
-	rom ( name "DREAMWEB.C00" size 14378 crc f1307c31 md5 undefined )
+	name "Swampy Adventures"
+	description "Swampy Adventures"
+	rom ( name "Swampy Adventures.scummvm" size 6 crc b2f59a68 )
 )
 
 game (
-	name "DreamWeb (CD/DOS/French)"
-	description "DreamWeb (CD/DOS/French)"
-	rom ( name "DREAMWFR.C00" size 20522 crc 749ceac8 md5 undefined )
+	name "Swampy Adventures"
+	description "Swampy Adventures"
+	rom ( name "Swampy Adventures CRLF.scummvm" size 8 crc a95cacac )
 )
 
 game (
-	name "DreamWeb (CD/DOS/German)"
-	description "DreamWeb (CD/DOS/German)"
-	rom ( name "DREAMWEB.C00" size 19645 crc aa8b4839 md5 undefined )
+	name "Swampy Adventures"
+	description "Swampy Adventures"
+	rom ( name "Swampy Adventures LF.scummvm" size 7 crc 710c1a63 )
 )
 
 game (
-	name "DreamWeb (CD/DOS/Italian)"
-	description "DreamWeb (CD/DOS/Italian)"
-	rom ( name "DREAMWEB.C00" size 20407 crc 8ef86022 md5 64786bc089bbf650a2e5a2a713032f14 )
+	name "Swampy Adventures"
+	description "Swampy Adventures"
+	rom ( name "Swampy Adventures CR.scummvm" size 7 crc ef688fc0 )
 )
 
 game (
-	name "DreamWeb (CD/DOS/Spanish)"
-	description "DreamWeb (CD/DOS/Spanish)"
-	rom ( name "DREAMWSP.C00" size 20248 crc 42da6883 md5 e8d5c7414fd2245d77f8aea575298def )
+	name "Teen Agent"
+	description "Teen Agent"
+	rom ( name "Teen Agent.scummvm" size 9 crc d8944e40 )
 )
 
 game (
-	name "DreamWeb (CD/DOS/UK)"
-	description "DreamWeb (CD/DOS/UK)"
-	rom ( name "DREAMWEB.C00" size 14378 crc f1307c31 md5 undefined )
+	name "Teen Agent"
+	description "Teen Agent"
+	rom ( name "Teen Agent CRLF.scummvm" size 11 crc 75bf7eaa )
 )
 
 game (
-	name "DreamWeb (CD/DOS/US)"
-	description "DreamWeb (CD/DOS/US)"
-	rom ( name "DREAMWEB.C00" size 14378 crc f1307c31 md5 f603e68793cec0df96520b071720184c )
+	name "Teen Agent"
+	description "Teen Agent"
+	rom ( name "Teen Agent LF.scummvm" size 10 crc 44d3d34d )
 )
 
 game (
-	name "DreamWeb (DOS)"
-	description "DreamWeb (DOS)"
-	rom ( name "DREAMWEB.C00" size 14378 crc f1307c31 md5 f603e68793cec0df96520b071720184c )
+	name "Teen Agent"
+	description "Teen Agent"
+	rom ( name "Teen Agent CR.scummvm" size 10 crc dab746ee )
 )
 
 game (
-	name "DreamWeb (DOS/German)"
-	description "DreamWeb (DOS/German)"
-	rom ( name "DREAMWEB.C00" size 19645 crc aa8b4839 md5 7be311c4963cbeeefa308eaa817a6c52 )
+	name "The Big Red Adventure"
+	description "The Big Red Adventure"
+	rom ( name "The Big Red Adventure.scummvm" size 3 crc 93ae8ce6 )
 )
 
 game (
-	name "DreamWeb (DOS/Italian)"
-	description "DreamWeb (DOS/Italian)"
-	rom ( name "DREAMWEB.C00" size 20522 crc 749ceac8 md5 undefined )
+	name "The Big Red Adventure"
+	description "The Big Red Adventure"
+	rom ( name "The Big Red Adventure CRLF.scummvm" size 5 crc f8888d63 )
 )
 
 game (
-	name "DreamWeb (DOS/Spanish)"
-	description "DreamWeb (DOS/Spanish)"
-	rom ( name "DREAMWEB.C00" size 20248 crc 42da6883 md5 e8d5c7414fd2245d77f8aea575298def )
+	name "The Big Red Adventure"
+	description "The Big Red Adventure"
+	rom ( name "The Big Red Adventure LF.scummvm" size 4 crc 7b2def52 )
 )
 
 game (
-	name "Dune Eternity (Macintosh)"
-	description "Dune Eternity (Macintosh)"
-	rom ( name "._Dune Eternity" size 292940 crc 3260402d md5 81e81fdadf45b244b631ff9a833d1e5c )
+	name "The Big Red Adventure"
+	description "The Big Red Adventure"
+	rom ( name "The Big Red Adventure CR.scummvm" size 4 crc e5497af1 )
 )
 
 game (
-	name "Dungeon World II (Macintosh)"
-	description "Dungeon World II (Macintosh)"
-	rom ( name "._DungeonWorld2" size 237568 crc e5f1d897 md5 91b89b336a6e0c3e7a30ed3335df7c16 )
+	name "The Bizarre Adventures of Woodruff and the Schnibble"
+	description "The Bizarre Adventures of Woodruff and the Schnibble"
+	rom ( name "The Bizarre Adventures of Woodruff and the Schnibble.scummvm" size 8 crc 2f23dd0e )
 )
 
 game (
-	name "Dynasty of Dar (Macintosh)"
-	description "Dynasty of Dar (Macintosh)"
-	rom ( name "._Dynasty of Dar" size 282624 crc undefined md5 undefined )
+	name "The Bizarre Adventures of Woodruff and the Schnibble"
+	description "The Bizarre Adventures of Woodruff and the Schnibble"
+	rom ( name "The Bizarre Adventures of Woodruff and the Schnibble CRLF.scummvm" size 10 crc 72432968 )
 )
 
 game (
-	name "EcoQuest II: Lost Secret of the Rainforest (Demo/DOS)"
-	description "EcoQuest II: Lost Secret of the Rainforest (Demo/DOS)"
-	rom ( name "150.HEP" size 802 crc c5908ed2 md5 92e9a08da08bc1747beb449737cd312b )
+	name "The Bizarre Adventures of Woodruff and the Schnibble"
+	description "The Bizarre Adventures of Woodruff and the Schnibble"
+	rom ( name "The Bizarre Adventures of Woodruff and the Schnibble LF.scummvm" size 9 crc d5400849 )
 )
 
 game (
-	name "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS)"
-	description "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS)"
-	rom ( name "5.HEP" size 980 crc 8ac500dc md5 undefined )
+	name "The Bizarre Adventures of Woodruff and the Schnibble"
+	description "The Bizarre Adventures of Woodruff and the Schnibble"
+	rom ( name "The Bizarre Adventures of Woodruff and the Schnibble CR.scummvm" size 9 crc 4b249dea )
 )
 
 game (
-	name "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/French)"
-	description "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/French)"
-	rom ( name "100.MSG" size 15477 crc 6646ce3e md5 undefined )
+	name "The Black Cauldron"
+	description "The Black Cauldron"
+	rom ( name "The Black Cauldron.scummvm" size 2 crc c2a92b38 )
 )
 
 game (
-	name "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/German)"
-	description "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/German)"
-	rom ( name "65535.MAP" size 632 crc 51387af3 md5 26e3887baba644f119d8674bbb5f4406 )
+	name "The Black Cauldron"
+	description "The Black Cauldron"
+	rom ( name "The Black Cauldron CRLF.scummvm" size 4 crc af8102be )
 )
 
 game (
-	name "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/Spanish)"
-	description "EcoQuest II: Lost Secret of the Rainforest (Floppy/DOS/Spanish)"
-	rom ( name "65535.MAP" size 590 crc 2c7f75dd md5 8de87b6ccce895b195188f9a650dcced )
+	name "The Black Cauldron"
+	description "The Black Cauldron"
+	rom ( name "The Black Cauldron LF.scummvm" size 3 crc 1a171726 )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (CD/DOS)[v1.1][!]"
-	description "EcoQuest: The Search for Cetus (CD/DOS)[v1.1][!]"
-	rom ( name "140.HEP" size 5594 crc 5a3fc6db md5 5e5e1a9e208151eaf718d319520cee69 )
+	name "The Black Cauldron"
+	description "The Black Cauldron"
+	rom ( name "The Black Cauldron CR.scummvm" size 3 crc 84738285 )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Demo/DOS)"
-	description "EcoQuest: The Search for Cetus (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 657518 crc f20c4377 md5 undefined )
+	name "The Case of the Rose Tattoo"
+	description "The Case of the Rose Tattoo"
+	rom ( name "The Case of the Rose Tattoo.scummvm" size 10 crc d5916b5b )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (DOS)"
-	description "EcoQuest: The Search for Cetus (DOS)"
-	rom ( name "140.HEP" size 5368 crc a35880d0 md5 4c327a3d4860ce4d5b28a884ac9703e9 )
+	name "The Case of the Rose Tattoo"
+	description "The Case of the Rose Tattoo"
+	rom ( name "The Case of the Rose Tattoo CRLF.scummvm" size 12 crc 978d6c72 )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Floppy/DOS)"
-	description "EcoQuest: The Search for Cetus (Floppy/DOS)"
-	rom ( name "0.SCR" size 18762 crc bbfd7872 md5 undefined )
+	name "The Case of the Rose Tattoo"
+	description "The Case of the Rose Tattoo"
+	rom ( name "The Case of the Rose Tattoo LF.scummvm" size 11 crc cebb1f84 )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Floppy/DOS)[a]"
-	description "EcoQuest: The Search for Cetus (Floppy/DOS)[a]"
-	rom ( name "0.SCR" size 18762 crc bbfd7872 md5 undefined )
+	name "The Case of the Rose Tattoo"
+	description "The Case of the Rose Tattoo"
+	rom ( name "The Case of the Rose Tattoo CR.scummvm" size 11 crc 50df8a27 )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Floppy/DOS/French)"
-	description "EcoQuest: The Search for Cetus (Floppy/DOS/French)"
-	rom ( name "1180.MSG" size 16134 crc d6448fa4 md5 undefined )
+	name "The Case of the Serrated Scalpel"
+	description "The Case of the Serrated Scalpel"
+	rom ( name "The Case of the Serrated Scalpel.scummvm" size 7 crc 1351a4bb )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Floppy/DOS/German)"
-	description "EcoQuest: The Search for Cetus (Floppy/DOS/German)"
-	rom ( name "480.SCR" size 17408 crc 1af20e4b md5 undefined )
+	name "The Case of the Serrated Scalpel"
+	description "The Case of the Serrated Scalpel"
+	rom ( name "The Case of the Serrated Scalpel CRLF.scummvm" size 9 crc c228867f )
 )
 
 game (
-	name "EcoQuest: The Search for Cetus (Floppy/DOS/Spanish)"
-	description "EcoQuest: The Search for Cetus (Floppy/DOS/Spanish)"
-	rom ( name "226.SCR" size 5844 crc b27697c9 md5 51cdc0514b31fb5a3c2a209406d9e82d )
+	name "The Case of the Serrated Scalpel"
+	description "The Case of the Serrated Scalpel"
+	rom ( name "The Case of the Serrated Scalpel LF.scummvm" size 8 crc 6e773d33 )
 )
 
 game (
-	name "Ed Ward (DOS/Fanmade)"
-	description "Ed Ward (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 74726e2c md5 undefined )
+	name "The Case of the Serrated Scalpel"
+	description "The Case of the Serrated Scalpel"
+	rom ( name "The Case of the Serrated Scalpel CR.scummvm" size 8 crc f013a890 )
 )
 
 game (
-	name "Edg's World (Macintosh)"
-	description "Edg's World (Macintosh)"
-	rom ( name "._Edg's World" size 114688 crc 3c74cf18 md5 1fad6a23467d4ccecca32f16b31bc7e6 )
+	name "The Curse of Monkey Island"
+	description "The Curse of Monkey Island"
+	rom ( name "The Curse of Monkey Island.scummvm" size 4 crc af61c7fa )
 )
 
 game (
-	name "Edy Oliver into the Cave of Whistling Skulls Demo (DOS/Fanmade)"
-	description "Edy Oliver into the Cave of Whistling Skulls Demo (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 2601551 crc b54ca2af md5 400686a4f508a220db1a6a6f6fcb001b )
+	name "The Curse of Monkey Island"
+	description "The Curse of Monkey Island"
+	rom ( name "The Curse of Monkey Island CRLF.scummvm" size 6 crc fff174e9 )
 )
 
 game (
-	name "Eidisi I (Macintosh)"
-	description "Eidisi I (Macintosh)"
-	rom ( name "._Eidisi I" size 180818 crc cf0f45c0 md5 23f975c99d3fc85506b1f9b77a405d27 )
+	name "The Curse of Monkey Island"
+	description "The Curse of Monkey Island"
+	rom ( name "The Curse of Monkey Island LF.scummvm" size 5 crc 6f107c56 )
 )
 
 game (
-	name "Elfintard (DOS/Fanmade)"
-	description "Elfintard (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 78629595 md5 c3b847e9e9e978af9708df76a0751dc2 )
+	name "The Curse of Monkey Island"
+	description "The Curse of Monkey Island"
+	rom ( name "The Curse of Monkey Island CR.scummvm" size 5 crc f174e9f5 )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Amiga)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Amiga)"
-	rom ( name "001.PKD" size 280 crc f257e717 md5 f85dc1c000f9796a76c991a9283f79a6 )
+	name "The Dig"
+	description "The Dig"
+	rom ( name "The Dig.scummvm" size 3 crc d7769efb )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Amiga/French)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Amiga/French)"
-	rom ( name "001.PKD" size 280 crc f257e717 md5 undefined )
+	name "The Dig"
+	description "The Dig"
+	rom ( name "The Dig CRLF.scummvm" size 5 crc f45dd4ef )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Amiga/German)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Amiga/German)"
-	rom ( name "001.PKD" size 280 crc f257e717 md5 undefined )
+	name "The Dig"
+	description "The Dig"
+	rom ( name "The Dig LF.scummvm" size 4 crc 186f5b99 )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Amiga/Italian)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Amiga/Italian)"
-	rom ( name "001.PKD" size 280 crc f257e717 md5 undefined )
+	name "The Dig"
+	description "The Dig"
+	rom ( name "The Dig CR.scummvm" size 4 crc 860bce3a )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Amiga/Spanish)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Amiga/Spanish)"
-	rom ( name "001.PKD" size 280 crc f257e717 md5 f85dc1c000f9796a76c991a9283f79a6 )
+	name "The Feeble Files"
+	description "The Feeble Files"
+	rom ( name "The Feeble Files.scummvm" size 6 crc 8d861cda )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/Atari ST)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/Atari ST)"
-	rom ( name "001.PKD" size 144 crc ec1d75d4 md5 undefined )
+	name "The Feeble Files"
+	description "The Feeble Files"
+	rom ( name "The Feeble Files CRLF.scummvm" size 8 crc 7b7479f0 )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/DOS)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/DOS)"
-	rom ( name "001.VGA" size 438 crc 56887a22 md5 undefined )
+	name "The Feeble Files"
+	description "The Feeble Files"
+	rom ( name "The Feeble Files LF.scummvm" size 7 crc 545cbb45 )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/DOS/French)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/DOS/French)"
-	rom ( name "001.VGA" size 438 crc 3ce1f47b md5 undefined )
+	name "The Feeble Files"
+	description "The Feeble Files"
+	rom ( name "The Feeble Files CR.scummvm" size 7 crc ca382ee6 )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/DOS/German)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/DOS/German)"
-	rom ( name "001.VGA" size 438 crc 3ce1f47b md5 undefined )
+	name "The Journeyman Project Pegasus Prime"
+	description "The Journeyman Project Pegasus Prime"
+	rom ( name "The Journeyman Project Pegasus Prime.scummvm" size 7 crc 4c46d1bb )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/DOS/Italian)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/DOS/Italian)"
-	rom ( name "001.VGA" size 438 crc 3ce1f47b md5 293daf2bfb3fa269a15911f64fa59806 )
+	name "The Journeyman Project Pegasus Prime"
+	description "The Journeyman Project Pegasus Prime"
+	rom ( name "The Journeyman Project Pegasus Prime CRLF.scummvm" size 9 crc e2475cdb )
 )
 
 game (
-	name "Elvira II: The Jaws of Cerberus (Floppy/DOS/Spanish)"
-	description "Elvira II: The Jaws of Cerberus (Floppy/DOS/Spanish)"
-	rom ( name "001.VGA" size 438 crc 3ce1f47b md5 293daf2bfb3fa269a15911f64fa59806 )
+	name "The Journeyman Project Pegasus Prime"
+	description "The Journeyman Project Pegasus Prime"
+	rom ( name "The Journeyman Project Pegasus Prime LF.scummvm" size 8 crc 6e282a46 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Demo/Non-Interactive/Amiga)"
-	description "Elvira: Mistress of the Dark (Demo/Non-Interactive/Amiga)"
-	rom ( name "21.OUT" size 888 crc 62a1e381 md5 c550d6c2f5eef44e5912e5ab04e3dcd4 )
+	name "The Journeyman Project Pegasus Prime"
+	description "The Journeyman Project Pegasus Prime"
+	rom ( name "The Journeyman Project Pegasus Prime CR.scummvm" size 8 crc f04cbfe5 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Demo/Non-Interactive/Amiga)[a]"
-	description "Elvira: Mistress of the Dark (Demo/Non-Interactive/Amiga)[a]"
-	rom ( name "21.OUT" size 888 crc 62a1e381 md5 undefined )
+	name "The Legend of Kyrandia"
+	description "The Legend of Kyrandia"
+	rom ( name "The Legend of Kyrandia.scummvm" size 5 crc 44bab8b5 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Demo/Non-Interactive/Atari ST)"
-	description "Elvira: Mistress of the Dark (Demo/Non-Interactive/Atari ST)"
-	rom ( name "991.OUT" size 1822 crc 0fd2fad2 md5 9238242d3274bb770cb4925d2b268f83 )
+	name "The Legend of Kyrandia"
+	description "The Legend of Kyrandia"
+	rom ( name "The Legend of Kyrandia CRLF.scummvm" size 7 crc 48aaa055 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Demo/Non-Interactive/DOS)"
-	description "Elvira: Mistress of the Dark (Demo/Non-Interactive/DOS)"
-	rom ( name "701.VGA" size 2396 crc bd1fd1da md5 8181496e16134bdc6f951e862a3cc2b4 )
+	name "The Legend of Kyrandia"
+	description "The Legend of Kyrandia"
+	rom ( name "The Legend of Kyrandia LF.scummvm" size 6 crc 8998fb28 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/Amiga)"
-	description "Elvira: Mistress of the Dark (Floppy/Amiga)"
-	rom ( name "011.PKD" size 676 crc 8636991f md5 undefined )
+	name "The Legend of Kyrandia"
+	description "The Legend of Kyrandia"
+	rom ( name "The Legend of Kyrandia CR.scummvm" size 6 crc 17fc6e8b )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/Amiga/French)"
-	description "Elvira: Mistress of the Dark (Floppy/Amiga/French)"
-	rom ( name "011.PKD" size 676 crc 8636991f md5 undefined )
+	name "The Legend of Kyrandia Malcolm's Revenge"
+	description "The Legend of Kyrandia Malcolm's Revenge"
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge.scummvm" size 5 crc aab4d999 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/Amiga/German)"
-	description "Elvira: Mistress of the Dark (Floppy/Amiga/German)"
-	rom ( name "011.PKD" size 676 crc 8636991f md5 ea1a210f8823a7b5526b4f00b9ce87d2 )
+	name "The Legend of Kyrandia Malcolm's Revenge"
+	description "The Legend of Kyrandia Malcolm's Revenge"
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge CRLF.scummvm" size 7 crc 4b2e743b )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/Atari ST)"
-	description "Elvira: Mistress of the Dark (Floppy/Atari ST)"
-	rom ( name "011.PKD" size 676 crc 8636991f md5 undefined )
+	name "The Legend of Kyrandia Malcolm's Revenge"
+	description "The Legend of Kyrandia Malcolm's Revenge"
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge LF.scummvm" size 6 crc bbae99aa )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/Atari ST)[a]"
-	description "Elvira: Mistress of the Dark (Floppy/Atari ST)[a]"
-	rom ( name "011.PKD" size 676 crc 8636991f md5 undefined )
+	name "The Legend of Kyrandia Malcolm's Revenge"
+	description "The Legend of Kyrandia Malcolm's Revenge"
+	rom ( name "The Legend of Kyrandia Malcolm's Revenge CR.scummvm" size 6 crc 25ca0c09 )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/DOS)"
-	description "Elvira: Mistress of the Dark (Floppy/DOS)"
-	rom ( name "01.SND" size 16783 crc 8df8f476 md5 undefined )
+	name "The Legend of Kyrandia The Hand of Fate"
+	description "The Legend of Kyrandia The Hand of Fate"
+	rom ( name "The Legend of Kyrandia The Hand of Fate.scummvm" size 5 crc ddb3e90f )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/DOS/French)"
-	description "Elvira: Mistress of the Dark (Floppy/DOS/French)"
-	rom ( name "01.SND" size 16783 crc 8df8f476 md5 undefined )
+	name "The Legend of Kyrandia The Hand of Fate"
+	description "The Legend of Kyrandia The Hand of Fate"
+	rom ( name "The Legend of Kyrandia The Hand of Fate CRLF.scummvm" size 7 crc 4aec1e0c )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/DOS/German)"
-	description "Elvira: Mistress of the Dark (Floppy/DOS/German)"
-	rom ( name "01.SND" size 16783 crc 8df8f476 md5 e0a473bd0eafe3904b66daa060d48cde )
+	name "The Legend of Kyrandia The Hand of Fate"
+	description "The Legend of Kyrandia The Hand of Fate"
+	rom ( name "The Legend of Kyrandia The Hand of Fate LF.scummvm" size 6 crc a2b5a8eb )
 )
 
 game (
-	name "Elvira: Mistress of the Dark (Floppy/DOS/Spanish)"
-	description "Elvira: Mistress of the Dark (Floppy/DOS/Spanish)"
-	rom ( name "01.SND" size 16783 crc undefined md5 undefined )
+	name "The Legend of Kyrandia The Hand of Fate"
+	description "The Legend of Kyrandia The Hand of Fate"
+	rom ( name "The Legend of Kyrandia The Hand of Fate CR.scummvm" size 6 crc 3cd13d48 )
 )
 
 game (
-	name "Enchanted Pencils (Macintosh)"
-	description "Enchanted Pencils (Macintosh)"
-	rom ( name "Enchanted Pencils 0.99 (PG)" size 414464 crc undefined md5 undefined )
+	name "The Neverhood Chronicles"
+	description "The Neverhood Chronicles"
+	rom ( name "The Neverhood Chronicles.scummvm" size 9 crc ab93a9c8 )
 )
 
 game (
-	name "Enchanted Scepters (Macintosh)"
-	description "Enchanted Scepters (Macintosh)"
-	rom ( name "._Scepters" size 364544 crc 5565d2aa md5 7d1450a40b7dc3ad15af100d4086f32a )
+	name "The Neverhood Chronicles"
+	description "The Neverhood Chronicles"
+	rom ( name "The Neverhood Chronicles CRLF.scummvm" size 11 crc b88b6835 )
 )
 
 game (
-	name "Enclosure (CoCo3/Fanmade)"
-	description "Enclosure (CoCo3/Fanmade)"
-	rom ( name "logDir" size 345 crc 49984bee md5 undefined )
+	name "The Neverhood Chronicles"
+	description "The Neverhood Chronicles"
+	rom ( name "The Neverhood Chronicles LF.scummvm" size 10 crc a7c3dfb8 )
 )
 
 game (
-	name "Enclosure (DOS/Fanmade v1.01)"
-	description "Enclosure (DOS/Fanmade v1.01)"
-	rom ( name "LOGDIR" size 330 crc 37f0003b md5 f08e66fee9ecdde77db7ee9a10c96ba2 )
+	name "The Neverhood Chronicles"
+	description "The Neverhood Chronicles"
+	rom ( name "The Neverhood Chronicles CR.scummvm" size 10 crc 39a74a1b )
 )
 
 game (
-	name "Enclosure (DOS/Fanmade v1.03)"
-	description "Enclosure (DOS/Fanmade v1.03)"
-	rom ( name "LOGDIR" size 330 crc ae29fcab md5 undefined )
+	name "The Secret of Monkey Island"
+	description "The Secret of Monkey Island"
+	rom ( name "The Secret of Monkey Island.scummvm" size 6 crc b0e2af30 )
 )
 
 game (
-	name "Epic Fighting (DOS/Fanmade v0.1)"
-	description "Epic Fighting (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 768 crc 67230f37 md5 aff24a1b3bdd676187685c4d95ba4294 )
+	name "The Secret of Monkey Island"
+	description "The Secret of Monkey Island"
+	rom ( name "The Secret of Monkey Island CRLF.scummvm" size 8 crc 8d8dbdc4 )
 )
 
 game (
-	name "Escape from School! (Macintosh)"
-	description "Escape from School! (Macintosh)"
-	rom ( name "._Escape from School!" size 51745 crc 68e1c233 md5 dc7e544b5e6818c33dee09ea3c06d0f6 )
+	name "The Secret of Monkey Island"
+	description "The Secret of Monkey Island"
+	rom ( name "The Secret of Monkey Island LF.scummvm" size 7 crc 14bed490 )
 )
 
 game (
-	name "Escape from the Desert (DOS/Fanmade beta 1)"
-	description "Escape from the Desert (DOS/Fanmade beta 1)"
-	rom ( name "LOGDIR" size 300 crc 3fa0c5c4 md5 undefined )
+	name "The Secret of Monkey Island"
+	description "The Secret of Monkey Island"
+	rom ( name "The Secret of Monkey Island CR.scummvm" size 7 crc 8ada4133 )
 )
 
 game (
-	name "Escape from the Mansion (v1.3/Windows)"
-	description "Escape from the Mansion (v1.3/Windows)"
-	rom ( name "data.dcp" size 29261972 crc 5c0ffd49 md5 undefined )
+	name "Tinsel engine game"
+	description "Tinsel engine game"
+	rom ( name "Tinsel engine game.scummvm" size 6 crc 64931fe0 )
 )
 
 game (
-	name "Escape from the Salesman (DOS/Fanmade)"
-	description "Escape from the Salesman (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc b08f2bba md5 undefined )
+	name "Tinsel engine game"
+	description "Tinsel engine game"
+	rom ( name "Tinsel engine game CRLF.scummvm" size 8 crc c7d41f26 )
 )
 
 game (
-	name "Escape Quest (DOS/Fanmade v0.0.3)"
-	description "Escape Quest (DOS/Fanmade v0.0.3)"
-	rom ( name "LOGDIR" size 300 crc 49f847f9 md5 2346b65619b1da0298b715b06d1a45a1 )
+	name "Tinsel engine game"
+	description "Tinsel engine game"
+	rom ( name "Tinsel engine game LF.scummvm" size 7 crc 92b977f4 )
 )
 
 game (
-	name "Eye of the Beholder (DOS)"
-	description "Eye of the Beholder (DOS)"
-	rom ( name "EOBDATA.SAV" size 33101 crc e8adb270 md5 0f423953de8b07e985c97d611c8af070 )
+	name "Tinsel engine game"
+	description "Tinsel engine game"
+	rom ( name "Tinsel engine game CR.scummvm" size 7 crc cdde257 )
 )
 
 game (
-	name "Eye of the Beholder (DOS/Fanmade Italianan)[v1.0b]"
-	description "Eye of the Beholder (DOS/Fanmade Italianan)[v1.0b]"
-	rom ( name "EOBDATA.SAV" size 33101 crc e8adb270 md5 undefined )
+	name "Tony Tough and the Night of Roasted Moths"
+	description "Tony Tough and the Night of Roasted Moths"
+	rom ( name "Tony Tough and the Night of Roasted Moths.scummvm" size 4 crc 5435eb7b )
 )
 
 game (
-	name "Eye of the Beholder (DOS/German)"
-	description "Eye of the Beholder (DOS/German)"
-	rom ( name "ADLIB.DAT" size 7489 crc a36ec04c md5 undefined )
+	name "Tony Tough and the Night of Roasted Moths"
+	description "Tony Tough and the Night of Roasted Moths"
+	rom ( name "Tony Tough and the Night of Roasted Moths CRLF.scummvm" size 6 crc efb14a54 )
 )
 
 game (
-	name "Eye of the Beholder II: The Legend of Darkmoon (DOS)"
-	description "Eye of the Beholder II: The Legend of Darkmoon (DOS)"
-	rom ( name "AIRSEAL.CPS" size 21530 crc 933112e9 md5 806cb1776e784cfc2af65a942faab4d3 )
+	name "Tony Tough and the Night of Roasted Moths"
+	description "Tony Tough and the Night of Roasted Moths"
+	rom ( name "Tony Tough and the Night of Roasted Moths LF.scummvm" size 5 crc f5549bcc )
 )
 
 game (
-	name "Eye of the Beholder II: The Legend of Darkmoon (DOS/German)"
-	description "Eye of the Beholder II: The Legend of Darkmoon (DOS/German)"
-	rom ( name "AIRSEAL.CPS" size 21530 crc 933112e9 md5 806cb1776e784cfc2af65a942faab4d3 )
+	name "Tony Tough and the Night of Roasted Moths"
+	description "Tony Tough and the Night of Roasted Moths"
+	rom ( name "Tony Tough and the Night of Roasted Moths CR.scummvm" size 5 crc 6b300e6f )
 )
 
 game (
-	name "Faery Tale Adventure II: Halls of the Dead (DOS)"
-	description "Faery Tale Adventure II: Halls of the Dead (DOS)"
-	rom ( name "FTA.HRS" size 213376 crc 2f0f7f14 md5 eeb15d016d26346a60923ba000c930fd )
+	name "Toonstruck"
+	description "Toonstruck"
+	rom ( name "Toonstruck.scummvm" size 4 crc cefd5ffd )
 )
 
 game (
-	name "Fairy Tales About Toshechka and Boshechka (Windows/Russian)"
-	description "Fairy Tales About Toshechka and Boshechka (Windows/Russian)"
-	rom ( name "data.dcp" size 340264526 crc 23bbadcc md5 f9634cb58767f1300619f16d94ec353f )
+	name "Toonstruck"
+	description "Toonstruck"
+	rom ( name "Toonstruck CRLF.scummvm" size 6 crc 4e6498c4 )
 )
 
 game (
-	name "Fantasy Quest (Macintosh)"
-	description "Fantasy Quest (Macintosh)"
-	rom ( name "._Fant Quest Sounds" size 418118 crc undefined md5 undefined )
+	name "Toonstruck"
+	description "Toonstruck"
+	rom ( name "Toonstruck LF.scummvm" size 5 crc f115756d )
 )
 
 game (
-	name "Farm Nightmare, The (DOS/Fanmade)"
-	description "Farm Nightmare, The (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 338303 crc 9289100b md5 93212272644257724f4cc69849cec59e )
+	name "Toonstruck"
+	description "Toonstruck"
+	rom ( name "Toonstruck CR.scummvm" size 5 crc 6f71e0ce )
 )
 
 game (
-	name "Fascination (Amiga)"
-	description "Fascination (Amiga)"
-	rom ( name "DISK0.STK" size 189951 crc ee516f5d md5 undefined )
+	name "Touche The Adventures of the Fifth Musketeer"
+	description "Touche The Adventures of the Fifth Musketeer"
+	rom ( name "Touche The Adventures of the Fifth Musketeer.scummvm" size 6 crc bc9f5f47 )
 )
 
 game (
-	name "Fascination (Amiga/French)"
-	description "Fascination (Amiga/French)"
-	rom ( name "DISK0.STK" size 190005 crc 3d771f68 md5 undefined )
+	name "Touche The Adventures of the Fifth Musketeer"
+	description "Touche The Adventures of the Fifth Musketeer"
+	rom ( name "Touche The Adventures of the Fifth Musketeer CRLF.scummvm" size 8 crc 504eac94 )
 )
 
 game (
-	name "Fascination (Amiga/German)"
-	description "Fascination (Amiga/German)"
-	rom ( name "DISK0.STK" size 189968 crc 400164a7 md5 7e82071f73b8d2e6a81412439ad15301 )
+	name "Touche The Adventures of the Fifth Musketeer"
+	description "Touche The Adventures of the Fifth Musketeer"
+	rom ( name "Touche The Adventures of the Fifth Musketeer LF.scummvm" size 7 crc dad34dff )
 )
 
 game (
-	name "Fascination (Amiga/Italian)"
-	description "Fascination (Amiga/Italian)"
-	rom ( name "DISK0.STK" size 189931 crc 85a51781 md5 573139cc5442a1c56578103d2b5ae52d )
+	name "Touche The Adventures of the Fifth Musketeer"
+	description "Touche The Adventures of the Fifth Musketeer"
+	rom ( name "Touche The Adventures of the Fifth Musketeer CR.scummvm" size 7 crc 44b7d85c )
 )
 
 game (
-	name "Fascination (Atari ST)"
-	description "Fascination (Atari ST)"
-	rom ( name "ALL.ASK" size 2807 crc 6f0d39d6 md5 32df1391781c05f8714b562285d2d428 )
+	name "Tsunami TsAGE-based Game"
+	description "Tsunami TsAGE-based Game"
+	rom ( name "Tsunami TsAGE-based Game.scummvm" size 5 crc ed8b77c0 )
 )
 
 game (
-	name "Fascination (CD/DOS)[Censored]"
-	description "Fascination (CD/DOS)[Censored]"
-	rom ( name "DISK1.STK" size 479283 crc 5bd2a1ef md5 undefined )
+	name "Tsunami TsAGE-based Game"
+	description "Tsunami TsAGE-based Game"
+	rom ( name "Tsunami TsAGE-based Game CRLF.scummvm" size 7 crc 11395bf6 )
 )
 
 game (
-	name "Fascination (CD/DOS/French)[Censored]"
-	description "Fascination (CD/DOS/French)[Censored]"
-	rom ( name "FRENCH.ROM" size 64 crc 877889c9 md5 undefined )
+	name "Tsunami TsAGE-based Game"
+	description "Tsunami TsAGE-based Game"
+	rom ( name "Tsunami TsAGE-based Game LF.scummvm" size 6 crc a95e4f54 )
 )
 
 game (
-	name "Fascination (CD/DOS/German)[Censored]"
-	description "Fascination (CD/DOS/German)[Censored]"
-	rom ( name "GERMAN.ROM" size 64 crc b25f38fb md5 undefined )
+	name "Tsunami TsAGE-based Game"
+	description "Tsunami TsAGE-based Game"
+	rom ( name "Tsunami TsAGE-based Game CR.scummvm" size 6 crc 373adaf7 )
 )
 
 game (
-	name "Fascination (CD/DOS/Italian)[Censored]"
-	description "Fascination (CD/DOS/Italian)[Censored]"
-	rom ( name "ITALIAN.ROM" size 65 crc b3933406 md5 8b9839a87fabe7a6d4f7db5aa3cee905 )
+	name "Voyeur"
+	description "Voyeur"
+	rom ( name "Voyeur.scummvm" size 6 crc c3b3d49d )
 )
 
 game (
-	name "Fascination (CD/DOS/Spanish)[Censored]"
-	description "Fascination (CD/DOS/Spanish)[Censored]"
-	rom ( name "SPANISH.ROM" size 65 crc 040cc8fc md5 15a0d64aaafa9e94be3e3d89bf2001be )
+	name "Voyeur"
+	description "Voyeur"
+	rom ( name "Voyeur CRLF.scummvm" size 8 crc 51f3a485 )
 )
 
 game (
-	name "Fascination (VGA/DOS)"
-	description "Fascination (VGA/DOS)"
-	rom ( name "DISK0.STK" size 1061955 crc a02408c2 md5 undefined )
+	name "Voyeur"
+	description "Voyeur"
+	rom ( name "Voyeur LF.scummvm" size 7 crc bcaa5abe )
 )
 
 game (
-	name "Fascination (VGA/DOS/French)"
-	description "Fascination (VGA/DOS/French)"
-	rom ( name "DISK0.STK" size 183337 crc b7d974f5 md5 undefined )
+	name "Voyeur"
+	description "Voyeur"
+	rom ( name "Voyeur CR.scummvm" size 7 crc 22cecf1d )
 )
 
 game (
-	name "Fascination (VGA/DOS/French)[3 disks edition]"
-	description "Fascination (VGA/DOS/French)[3 disks edition]"
-	rom ( name "DISK0.STK" size 1064387 crc bfe6a1f6 md5 undefined )
+	name "Waxworks"
+	description "Waxworks"
+	rom ( name "Waxworks.scummvm" size 8 crc 39c07a43 )
 )
 
 game (
-	name "Fascination (VGA/DOS/Hebrew)[Censored]"
-	description "Fascination (VGA/DOS/Hebrew)[Censored]"
-	rom ( name "BAIN.ANG" size 10265 crc 87f5211f md5 undefined )
+	name "Waxworks"
+	description "Waxworks"
+	rom ( name "Waxworks CRLF.scummvm" size 10 crc 7f263888 )
 )
 
 game (
-	name "Fascination (VGA/DOS/Italian)[3 disks edition]"
-	description "Fascination (VGA/DOS/Italian)[3 disks edition]"
-	rom ( name "DISK0.STK" size 1061929 crc 41348c8d md5 608e6c75f83c47a5bf0892233324451b )
+	name "Waxworks"
+	description "Waxworks"
+	rom ( name "Waxworks LF.scummvm" size 9 crc dd3bd6c3 )
 )
 
 game (
-	name "Fascination (VGA/DOS/Spanish)"
-	description "Fascination (VGA/DOS/Spanish)"
-	rom ( name "ALL.ASK" size 2804 crc f746ff72 md5 undefined )
+	name "Waxworks"
+	description "Waxworks"
+	rom ( name "Waxworks CR.scummvm" size 9 crc 435f4360 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (3DO)[!]"
-	description "Fatty Bear's Birthday Surprise (3DO)[!]"
-	rom ( name "FBEAR.HE0" size 7722 crc 8dd97b40 md5 undefined )
+	name "Wintermute engine game"
+	description "Wintermute engine game"
+	rom ( name "Wintermute engine game.scummvm" size 10 crc ec4f06df )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (3DO)[HE 61]"
-	description "Fatty Bear's Birthday Surprise (3DO)[HE 61]"
-	rom ( name "FBEAR.HE0" size 7722 crc 348c748a md5 5b08000a9c47b2887df6506ac767ca68 )
+	name "Wintermute engine game"
+	description "Wintermute engine game"
+	rom ( name "Wintermute engine game CRLF.scummvm" size 12 crc fb611506 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (3DO/Japanese)[!]"
-	description "Fatty Bear's Birthday Surprise (3DO/Japanese)[!]"
-	rom ( name "FBEAR.SNG" size 1115 crc 52513973 md5 undefined )
+	name "Wintermute engine game"
+	description "Wintermute engine game"
+	rom ( name "Wintermute engine game LF.scummvm" size 11 crc 245786d0 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (Demo/DOS)"
-	description "Fatty Bear's Birthday Surprise (Demo/DOS)"
-	rom ( name "FBDEMO.HE0" size 6203 crc f02846cd md5 47e75b1bdcb44c78cb94883d1731ccf8 )
+	name "Wintermute engine game"
+	description "Wintermute engine game"
+	rom ( name "Wintermute engine game CR.scummvm" size 11 crc ba331373 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (Demo/Macintosh)"
-	description "Fatty Bear's Birthday Surprise (Demo/Macintosh)"
-	rom ( name "Fatty Bear Demo 0" size 6203 crc 5b0fcbef md5 undefined )
+	name "Z-Vision Game"
+	description "Z-Vision Game"
+	rom ( name "Z-Vision Game.scummvm" size 7 crc eace6f11 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (Demo/Windows)[!]"
-	description "Fatty Bear's Birthday Surprise (Demo/Windows)[!]"
-	rom ( name "FBDEMO.HE0" size 9593 crc a271aca3 md5 22c9eb04455440131ffc157aeb8d40a8 )
+	name "Z-Vision Game"
+	description "Z-Vision Game"
+	rom ( name "Z-Vision Game CRLF.scummvm" size 9 crc 9a7630bb )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS)"
-	description "Fatty Bear's Birthday Surprise (DOS)"
-	rom ( name "FBEAR.HE0" size 7717 crc b94237df md5 undefined )
+	name "Z-Vision Game"
+	description "Z-Vision Game"
+	rom ( name "Z-Vision Game LF.scummvm" size 8 crc 588de80e )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS)[a][!]"
-	description "Fatty Bear's Birthday Surprise (DOS)[a][!]"
-	rom ( name "FBEAR.HE0" size 7732 crc 7b99fa70 md5 undefined )
+	name "Z-Vision Game"
+	description "Z-Vision Game"
+	rom ( name "Z-Vision Game CR.scummvm" size 8 crc c6e97dad )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS)[a2]"
-	description "Fatty Bear's Birthday Surprise (DOS)[a2]"
-	rom ( name "FBEAR.HE0" size 7717 crc b94237df md5 undefined )
+	name "Zak McKracken & Loom"
+	description "Zak McKracken & Loom"
+	rom ( name "Zak McKracken & Loom.scummvm" size 7 crc 1b236493 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS)[a3]"
-	description "Fatty Bear's Birthday Surprise (DOS)[a3]"
-	rom ( name "FBEAR.HE0" size 7717 crc b94237df md5 undefined )
+	name "Zak McKracken & Loom"
+	description "Zak McKracken & Loom"
+	rom ( name "Zak McKracken & Loom CRLF.scummvm" size 9 crc 411e217 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS)[a4]"
-	description "Fatty Bear's Birthday Surprise (DOS)[a4]"
-	rom ( name "FBEAR.HE0" size 7717 crc b94237df md5 4f1d6f8b38343dba405472538b5037ed )
+	name "Zak McKracken & Loom"
+	description "Zak McKracken & Loom"
+	rom ( name "Zak McKracken & Loom LF.scummvm" size 8 crc 5bcae709 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS/Hebrew)"
-	description "Fatty Bear's Birthday Surprise (DOS/Hebrew)"
-	rom ( name "FBEAR.HE0" size 7722 crc 2c7a5ac9 md5 undefined )
+	name "Zak McKracken & Loom"
+	description "Zak McKracken & Loom"
+	rom ( name "Zak McKracken & Loom CR.scummvm" size 8 crc c5ae72aa )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (DOS/Hungarian)"
-	description "Fatty Bear's Birthday Surprise (DOS/Hungarian)"
-	rom ( name "FBEAR.HE0" size 7732 crc 54c2d8d6 md5 undefined )
+	name "Zak McKracken and the Alien Mindbenders"
+	description "Zak McKracken and the Alien Mindbenders"
+	rom ( name "Zak McKracken and the Alien Mindbenders.scummvm" size 3 crc a1d6a2 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (Macintosh)"
-	description "Fatty Bear's Birthday Surprise (Macintosh)"
-	rom ( name "Fatty Bear 0" size 7722 crc a4fd8a5e md5 undefined )
+	name "Zak McKracken and the Alien Mindbenders"
+	description "Zak McKracken and the Alien Mindbenders"
+	rom ( name "Zak McKracken and the Alien Mindbenders CRLF.scummvm" size 5 crc e7232c87 )
 )
 
 game (
-	name "Fatty Bear's Birthday Surprise (Windows)[!]"
-	description "Fatty Bear's Birthday Surprise (Windows)[!]"
-	rom ( name "FBEAR.HE0" size 13381 crc e8961d49 md5 undefined )
+	name "Zak McKracken and the Alien Mindbenders"
+	description "Zak McKracken and the Alien Mindbenders"
+	rom ( name "Zak McKracken and the Alien Mindbenders LF.scummvm" size 4 crc a0f6581 )
 )
 
 game (
-	name "Fatty Bear's Fun Pack (3DO)"
-	description "Fatty Bear's Fun Pack (3DO)"
-	rom ( name "FBEAR01.DMU" size 2572327 crc 94072907 md5 27d8bdd5e8f7ccf0d68e77947c9f243a )
-)
-
-game (
-	name "Fatty Bear's Fun Pack (3DO/Japanese)"
-	description "Fatty Bear's Fun Pack (3DO/Japanese)"
-	rom ( name "FBEAR.SNG" size 1115 crc 52513973 md5 undefined )
-)
-
-game (
-	name "Fatty Bear's Fun Pack (DOS)"
-	description "Fatty Bear's Fun Pack (DOS)"
-	rom ( name "FBPACK.C00" size 8380 crc 93c4684c md5 undefined )
-)
-
-game (
-	name "Fatty Bear's Fun Pack (DOS/Hebrew)"
-	description "Fatty Bear's Fun Pack (DOS/Hebrew)"
-	rom ( name "FBPACK.C00" size 8380 crc 93c4684c md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (2CD/Windows)"
-	description "Feeble Files, The (2CD/Windows)"
-	rom ( name "0011.VGA" size 824 crc ad2b228b md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (2CD/Windows)[cab]"
-	description "Feeble Files, The (2CD/Windows)[cab]"
-	rom ( name "DATA1.CAB" size 28845430 crc dc869f19 md5 f1710585e33b23b3cc0f3a881aad1c4e )
-)
-
-game (
-	name "Feeble Files, The (4CD/Windows)"
-	description "Feeble Files, The (4CD/Windows)"
-	rom ( name "0011.VGA" size 824 crc ad2b228b md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (4CD/Windows/French)"
-	description "Feeble Files, The (4CD/Windows/French)"
-	rom ( name "0011.VGA" size 824 crc 4aa6f3db md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (4CD/Windows/German)[!]"
-	description "Feeble Files, The (4CD/Windows/German)[!]"
-	rom ( name "0011.VGA" size 824 crc dec49d61 md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (4CD/Windows/Italian)"
-	description "Feeble Files, The (4CD/Windows/Italian)"
-	rom ( name "0011.VGA" size 824 crc ad2b228b md5 f77a2f7632408752c29e0beab0ee3d66 )
-)
-
-game (
-	name "Feeble Files, The (4CD/Windows/Spanish)"
-	description "Feeble Files, The (4CD/Windows/Spanish)"
-	rom ( name "0011.VGA" size 824 crc ad2b228b md5 f77a2f7632408752c29e0beab0ee3d66 )
-)
-
-game (
-	name "Feeble Files, The (CD/Amiga)"
-	description "Feeble Files, The (CD/Amiga)"
-	rom ( name "GAME22" size 259576 crc 85dac618 md5 4a6fc1b3c4f06a728da256709db8a65e )
-)
-
-game (
-	name "Feeble Files, The (CD/Amiga/German)"
-	description "Feeble Files, The (CD/Amiga/German)"
-	rom ( name "AUDIO.WAV" size 61774856 crc b1a2e3f5 md5 b1b58d46d4820fbb16352079f4e998ee )
-)
-
-game (
-	name "Feeble Files, The (CD/Macintosh)"
-	description "Feeble Files, The (CD/Macintosh)"
-	rom ( name "GAME22" size 259576 crc 85dac618 md5 4a6fc1b3c4f06a728da256709db8a65e )
-)
-
-game (
-	name "Feeble Files, The (CD/Macintosh/French)"
-	description "Feeble Files, The (CD/Macintosh/French)"
-	rom ( name "audio.wav" size 31731828 crc 488ec654 md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (CD/Macintosh/German)"
-	description "Feeble Files, The (CD/Macintosh/German)"
-	rom ( name "audio.wav" size 31943028 crc a55969ef md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (CD/Macintosh/Spanish)"
-	description "Feeble Files, The (CD/Macintosh/Spanish)"
-	rom ( name "audio.wav" size 31873396 crc 595c387c md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (Demo/DOS)"
-	description "Feeble Files, The (Demo/DOS)"
-	rom ( name "BIKEBUST.SMK" size 4933428 crc 75406677 md5 undefined )
-)
-
-game (
-	name "Feeble Files, The (Demo/DOS/German)"
-	description "Feeble Files, The (Demo/DOS/German)"
-	rom ( name "BIKEBUST.SMK" size 3238744 crc 3d7741d3 md5 30c209969e7c099cdebbc62ff0b85589 )
-)
-
-game (
-	name "Find the Heart (Macintosh)"
-	description "Find the Heart (Macintosh)"
-	rom ( name "._Find the Heart" size 108799 crc 53275731 md5 undefined )
-)
-
-game (
-	name "Five Lethal Demons (Windows)"
-	description "Five Lethal Demons (Windows)"
-	rom ( name "english.dcp" size 170340 crc fd8b7e25 md5 11c2e172e0488e6b16c58f3b96822a30 )
-)
-
-game (
-	name "Five Lethal Demons (Windows/Czech)"
-	description "Five Lethal Demons (Windows/Czech)"
-	rom ( name "czech.dcp" size 186 crc 6cf92b9c md5 undefined )
-)
-
-game (
-	name "Five Lethal Demons (Windows/Polish)"
-	description "Five Lethal Demons (Windows/Polish)"
-	rom ( name "polish.dcp" size 173792 crc aeb58022 md5 7938e6c6e64fd79d8004207d3da1c022 )
-)
-
-game (
-	name "Five Magical Amulets (Windows)"
-	description "Five Magical Amulets (Windows)"
-	rom ( name "english.dcp" size 893681 crc 0756ad27 md5 undefined )
-)
-
-game (
-	name "Five Magical Amulets (Windows/Czech)"
-	description "Five Magical Amulets (Windows/Czech)"
-	rom ( name "czech.dcp" size 184 crc c564b180 md5 7b2515a8ceb955c72bc14f0f1fca869e )
-)
-
-game (
-	name "Five Magical Amulets (Windows/German)[Unk]"
-	description "Five Magical Amulets (Windows/German)[Unk]"
-	rom ( name "german.dcp" size 885150 crc e90dd25a md5 undefined )
-)
-
-game (
-	name "Five Magical Amulets (Windows/Polish)"
-	description "Five Magical Amulets (Windows/Polish)"
-	rom ( name "polish.dcp" size 1132197 crc e5240fcc md5 87bb5ae0c4727669120418f0db251632 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Demo/Amiga)"
-	description "Flight of the Amazon Queen (Demo/Amiga)"
-	rom ( name "QUEEN.1" size 563335 crc 9165eadc md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Demo/DOS)"
-	description "Flight of the Amazon Queen (Demo/DOS)"
-	rom ( name "QUEEN.1" size 3732177 crc d168bde3 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Demo/DOS)[a]"
-	description "Flight of the Amazon Queen (Demo/DOS)[a]"
-	rom ( name "QUEEN.1" size 3735447 crc f42a6561 md5 4f73732e52e91c193fd2fc7b94763042 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Demo/PCGames/DOS)"
-	description "Flight of the Amazon Queen (Demo/PCGames/DOS)"
-	rom ( name "QUEEN.1" size 3724538 crc a3ff88d3 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Floppy/Amiga)"
-	description "Flight of the Amazon Queen (Floppy/Amiga)"
-	rom ( name "QUEEN.1" size 351775 crc ce0584a8 md5 6d56947b95a701a731e1c111ff947df5 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Floppy/DOS)"
-	description "Flight of the Amazon Queen (Floppy/DOS)"
-	rom ( name "QUEEN.1" size 22677657 crc 2038cd82 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Floppy/DOS/German)"
-	description "Flight of the Amazon Queen (Floppy/DOS/German)"
-	rom ( name "QUEEN.1" size 22240013 crc 5beaea01 md5 065cbb3a5d9e63c7f9186c82f86867be )
-)
-
-game (
-	name "Flight of the Amazon Queen (Floppy/DOS/Italian)"
-	description "Flight of the Amazon Queen (Floppy/DOS/Italian)"
-	rom ( name "QUEEN.1" size 22461366 crc f2e7c273 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Floppy/DOS/Russian)"
-	description "Flight of the Amazon Queen (Floppy/DOS/Russian)"
-	rom ( name "QUEEN.1" size 22677657 crc 3c266e5f md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Interview/Amiga)"
-	description "Flight of the Amazon Queen (Interview/Amiga)"
-	rom ( name "QUEEN.1" size 597032 crc fc7b52f9 md5 8ccfd33d82f699bb0460544f2972f7af )
-)
-
-game (
-	name "Flight of the Amazon Queen (Interview/DOS)"
-	description "Flight of the Amazon Queen (Interview/DOS)"
-	rom ( name "QUEEN.1" size 1915913 crc d72dcd56 md5 169b605598fd06d3a8c5b13b5c86d7f2 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS)"
-	description "Flight of the Amazon Queen (Talkie/DOS)"
-	rom ( name "QUEEN.1" size 190787021 crc 1de401e7 md5 258c0729d0d6701ab6f342531247740c )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS)[Compressed Freeware v1.0]"
-	description "Flight of the Amazon Queen (Talkie/DOS)[Compressed Freeware v1.0]"
-	rom ( name "QUEEN.1C" size 54108887 crc aa61d0f1 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS)[Compressed Freeware v1.1]"
-	description "Flight of the Amazon Queen (Talkie/DOS)[Compressed Freeware v1.1]"
-	rom ( name "QUEEN.1C" size 51222412 crc 681e1333 md5 945d2ffd74fbedcb45f84abac10ddd71 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/French)"
-	description "Flight of the Amazon Queen (Talkie/DOS/French)"
-	rom ( name "QUEEN.1" size 186689095 crc 0ab6d0ea md5 bd387ce20277350c566c0cced25afb4c )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/French)[Compressed Freeware v1.0]"
-	description "Flight of the Amazon Queen (Talkie/DOS/French)[Compressed Freeware v1.0]"
-	rom ( name "QUEEN.1C" size 97382620 crc c01bc85f md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/German)"
-	description "Flight of the Amazon Queen (Talkie/DOS/German)"
-	rom ( name "QUEEN.1" size 217648975 crc 61904719 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/German)[Compressed Freeware v1.0]"
-	description "Flight of the Amazon Queen (Talkie/DOS/German)[Compressed Freeware v1.0]"
-	rom ( name "QUEEN.1C" size 108738717 crc 767004ae md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/Hebrew)[Compressed Freeware v1.0]"
-	description "Flight of the Amazon Queen (Talkie/DOS/Hebrew)[Compressed Freeware v1.0]"
-	rom ( name "QUEEN.1C" size 99391805 crc 7d277448 md5 8419610f724d7a6e5d62eeba297ba0bc )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/Hungarian)[Compressed Freeware v1.02]"
-	description "Flight of the Amazon Queen (Talkie/DOS/Hungarian)[Compressed Freeware v1.02]"
-	rom ( name "QUEEN.1C" size 51329031 crc 05929065 md5 undefined )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/Italian)"
-	description "Flight of the Amazon Queen (Talkie/DOS/Italian)"
-	rom ( name "QUEEN.1" size 190795582 crc caa4791d md5 a9395b1858e0abed120a13fc64e9c01e )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/Italian)[Compressed Freeware v1.0]"
-	description "Flight of the Amazon Queen (Talkie/DOS/Italian)[Compressed Freeware v1.0]"
-	rom ( name "QUEEN.1C" size 98327801 crc 2b5378f6 md5 e8b06af43f6eb3bcfbf2a0d0f40eff46 )
-)
-
-game (
-	name "Flight of the Amazon Queen (Talkie/DOS/Spanish)"
-	description "Flight of the Amazon Queen (Talkie/DOS/Spanish)"
-	rom ( name "QUEEN.1" size 190730602 crc b9ab432a md5 undefined )
-)
-
-game (
-	name "Footsteps Sound Demo (DOS/Fanmade)"
-	description "Footsteps Sound Demo (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 114212 crc 9b1fbdd1 md5 40a5b7fdab190af6d79c66f7b1be7c09 )
-)
-
-game (
-	name "Four (Windows)"
-	description "Four (Windows)"
-	rom ( name "data.dcp" size 62599855 crc dcfb2d21 md5 bf07a7f0b135c6bca391323bdb60db81 )
-)
-
-game (
-	name "Framed (Windows)"
-	description "Framed (Windows)"
-	rom ( name "data.dcp" size 34690568 crc 11831aa8 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (ALL/US/Updated)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (ALL/US/Updated)[!]"
-	rom ( name "FREDDI.HE0" size 34674 crc 9f8e1aa1 md5 df047cc4792150f601290357566d36a6 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Macintosh)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Macintosh)"
-	rom ( name "Freddi Demo" size 403362 crc d03e91c2 md5 0d4f935ad5ac0e9bb200ca70f29d54be )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows)[!]"
-	rom ( name "FREDDEMO.HE0" size 9800 crc 487824ec md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows)[HE 71]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows)[HE 71]"
-	rom ( name "FREDDEMO.HE0" size 9779 crc 8a41a6f6 md5 084ed0fa98a6d1e9368d67fe9cfbd417 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/Dutch)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/Dutch)[!]"
-	rom ( name "FREDDEMO.HE0" size 9779 crc 65223858 md5 c7c492a107ec520d7a7943037d0ca54a )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/French)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/French)"
-	rom ( name "MM-DEMO.HE0" size 9800 crc 503ec041 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/German)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/German)"
-	rom ( name "FREDDEMO.HE0" size 9800 crc 16498a64 md5 cf4ef315214c7d8cdab6302cdb7e50db )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/US)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Demo/Windows/US)[!]"
-	rom ( name "FREDDEMO.HE0" size 9800 crc db486ff5 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh)[!]"
-	rom ( name "._Freddi Fish" size 475136 crc 2f16beb3 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh/Dutch)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh/Dutch)[!]"
-	rom ( name "._Freddi" size 479232 crc 3ed6b169 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh/Swedish)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Macintosh/Swedish)"
-	rom ( name "._Freddi Fisk" size 376832 crc ea50ff65 md5 6d6ce6e93b3adc6b9c1e60dd98b11dc9 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii)"
-	rom ( name "FREDDI.(a)" size 57756427 crc 0f8657b8 md5 ee51388cc51bd699dd3d569fcc14290c )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Dutch)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Dutch)"
-	rom ( name "FREDDI.(a)" size 57734694 crc be3c88e3 md5 a804c1a2698622f480a77a8699fee824 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/French)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/French)"
-	rom ( name "FREDDI.(a)" size 57449285 crc e566e2f5 md5 b3187a011e4cd8b43603fa8c648b2273 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/German)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/German)"
-	rom ( name "FREDDI.(a)" size 57491091 crc e00eb547 md5 46bdd555465bd3ca4bb1fa566b3d628b )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Norwegian)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Norwegian)"
-	rom ( name "FREDDI.(a)" size 57593367 crc f4ce25d3 md5 86d305cb78f0df0b6c86f11d361505c0 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Swedish)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/Swedish)"
-	rom ( name "FREDDI.(a)" size 57562811 crc 5f561adf md5 9a38c2d0b9b02c010363516592dd96dc )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/UK)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Nintendo Wii/UK)"
-	rom ( name "FREDDI.(a)" size 57754184 crc 60855e22 md5 3a1ba51b0609633706e1fa064abe1891 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows)[!]"
-	rom ( name "FREDDI.HE0" size 26078 crc 0980beea md5 d4cccb5af88f3e77f370896e9ba8c5f9 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows)[Unk]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows)[Unk]"
-	rom ( name "FREDDI.HE0" size 16385 crc 9628be0d md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Dutch)[!]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Dutch)[!]"
-	rom ( name "FREDDID.HE0" size 26159 crc b597e070 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/French)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/French)"
-	rom ( name "FREDDI.HE0" size 26654 crc c3096025 md5 5ebb57234b2fe5c5dff641e00184ad81 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/German)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/German)"
-	rom ( name "FREDDI.HE0" size 26618 crc 890fcebf md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Hebrew)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Hebrew)"
-	rom ( name "FREDDI.HE0" size 26483 crc ba9bd78c md5 undefined )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Japanese)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Japanese)"
-	rom ( name "FREDDI.HE0" size 26375 crc c8d25ca4 md5 64a22be96d679018696e5c8d3ca8b71d )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian)[Arus]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian)[Arus]"
-	rom ( name "FREDDI.HE0" size 26078 crc 0980beea md5 d4cccb5af88f3e77f370896e9ba8c5f9 )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian/Updated)[Akella]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian/Updated)[Akella]"
-	rom ( name "FREDDI.HE0" size 34674 crc fd9139a4 md5 746e88c172a5b7a1ae89ac0ee3ee681a )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian/Updated)[Russobit-M]"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Russian/Updated)[Russobit-M]"
-	rom ( name "FREDDI.HE0" size 34674 crc fd9139a4 md5 746e88c172a5b7a1ae89ac0ee3ee681a )
-)
-
-game (
-	name "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Swedish)"
-	description "Freddi Fish 1: The Case of the Missing Kelp Seeds (Windows/Swedish)"
-	rom ( name "FREDDI.HE0" size 26402 crc a0833a03 md5 507bb360688dc4180fdf0d7597352a69 )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL)[!]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL)[!]"
-	rom ( name "FREDDI2.HE0" size 65305 crc d02314ed md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/French)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/French)"
-	rom ( name "FREDDI2.HE0" size 65305 crc 7077a269 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/German)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/German)"
-	rom ( name "FREDDI2.HE0" size 65305 crc 5d38baf2 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/Russian/Updated)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/Russian/Updated)"
-	rom ( name "FreddiCHSH.he2" size 34564440 crc 58062139 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/Russian/Updated)[a]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/Russian/Updated)[a]"
-	rom ( name "FreddiCHSH.he2" size 34564440 crc 8458b463 md5 1d3dbb50a339ea358a65471b121a0788 )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/US/Updated)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (ALL/US/Updated)"
-	rom ( name "FreddiCHSH.he2" size 34564440 crc 5822202a md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/ALL)[!]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/ALL)[!]"
-	rom ( name "FF2-DEMO.HE0" size 27298 crc 59cb3e93 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/ALL/Updated)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/ALL/Updated)"
-	rom ( name "FFHSDemo.(a)" size 35075095 crc d571b51e md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/Windows/Dutch)[!]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Demo/Windows/Dutch)[!]"
-	rom ( name "FF2-DEMO.HE0" size 27298 crc f3d192bb md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows)"
-	rom ( name "Freddi2.he0" size 65305 crc 9d8313f8 md5 151071053a1d0021198216713939521d )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Dutch)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Dutch)"
-	rom ( name "FREDDI2.HE0" size 65305 crc c4ad195d md5 ac62d50e39492ee3738b4e83a5ac780f )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/German/Updated)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/German/Updated)"
-	rom ( name "FRITZI2.(A)" size 115379504 crc a4449a98 md5 d68916166bf7da33c64a29b4d9a0e6fc )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian)"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian)"
-	rom ( name "FREDDI2.HE0" size 65305 crc d02314ed md5 5057fb0e99e5aa29df1836329232f101 )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian/Updated)[Akella]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian/Updated)[Akella]"
-	rom ( name "FreddiCHSH.(a)" size 135380546 crc d75cd9cd md5 undefined )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian/Updated)[Russobit-M]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/Russian/Updated)[Russobit-M]"
-	rom ( name "FreddiCHSH.(a)" size 135380546 crc 492b32d0 md5 c40f2b3cf5b82d34afc222779b3f0a7c )
-)
-
-game (
-	name "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/US)[!]"
-	description "Freddi Fish 2: The Case of the Haunted Schoolhouse (Windows/US)[!]"
-	rom ( name "FREDDI2.HE0" size 65305 crc 9d8313f8 md5 151071053a1d0021198216713939521d )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL)[!]"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL)[!]"
-	rom ( name "FREDDI3.HE0" size 55959 crc 2444137b md5 8368f552b1e3eba559f8d559bcc4cadb )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/Dutch)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/Dutch)"
-	rom ( name "FREDDI3.HE0" size 55959 crc 08c14d07 md5 0cccfa5223099a60e76cfcca57a1a141 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/French)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/French)"
-	rom ( name "MaliceMCV.(a)" size 74650500 crc 3eb6afcc md5 8c24f97d63df5df16f86832beaefc164 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/German)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/German)"
-	rom ( name "FreddiFGT.(a)" size 74617807 crc cb9f5a73 md5 1c17cedc8593e0caebbae3ca61a8a78d )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/Russian)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (ALL/Russian)"
-	rom ( name "FREDDI3.HE0" size 55959 crc 2444137b md5 8368f552b1e3eba559f8d559bcc4cadb )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL)[!]"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL)[!]"
-	rom ( name "F3-MDEMO.HE0" size 22718 crc dce3912d md5 cb1559e8405d17a5a278a6b5ad9338d1 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL/Dutch)[!]"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL/Dutch)[!]"
-	rom ( name "FF3-DEMO.HE0" size 22718 crc dee1a736 md5 754feb59d3bf86b8a00840df74fd7b26 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL/French)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/ALL/French)"
-	rom ( name "MM3-DEMO.HE0" size 22718 crc 414a3419 md5 bbadf7309c4a2c2763e4bbba3c3be634 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/Windows/Hebrew)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Demo/Windows/Hebrew)"
-	rom ( name "FF3DEMO.(A)" size 5557057 crc 7ea20a98 md5 822063d180f099fa5a465ee71cef0376 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/German)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/German)"
-	rom ( name "FRITZI3.(A)" size 74334409 crc fe455fda md5 104f997b0b7c9f43230b6e23b9f85e7b )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/Russian)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/Russian)"
-	rom ( name "FREDDI3.HE0" size 55959 crc c6c5362d md5 898ce8eb1234a955ef75e87141902bb3 )
-)
-
-game (
-	name "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/Russian/Updated)"
-	description "Freddi Fish 3: The Case of the Stolen Conch Shell (Windows/Russian/Updated)"
-	rom ( name "FreddiSCS.(a)" size 74908581 crc e3f4cdcc md5 b2b8622d2a1d954fedf526043fc185eb )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL)[!]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL)[!]"
-	rom ( name "FREDDI4.(A)" size 117440938 crc c1b90819 md5 d3cb0cbdd52b7684d321a3630bdf8abc )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL/Dutch)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL/Dutch)"
-	rom ( name "FREDDI4.(A)" size 117639735 crc 8025c3cc md5 14d15f520f3f55fdf7fccb668aa97ed8 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL/German)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (ALL/German)"
-	rom ( name "FreddiGS.(a)" size 117399294 crc a1440ce8 md5 25da2483b1d36a35c371393e907f57bf )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL)[!]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL)[!]"
-	rom ( name "f4-demo.(a)" size 6245090 crc 7dd71da1 md5 53b0e5c820bd264684df59231dbdc031 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/German)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/German)"
-	rom ( name "Ff4demo.(a)" size 6061386 crc 4861034d md5 0eef3e0fca1f1ab0204982234be943a0 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/US)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/US)"
-	rom ( name "F4-DEMO.(A)" size 6243174 crc fd4dadc4 md5 bd6a0ac7c15562250349dd5b64709e92 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/US)[HE 99][!]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/ALL/US)[HE 99][!]"
-	rom ( name "f4-demo.(a)" size 6243281 crc 2796eb11 md5 0a5e8a6eb824c9e006dea982adf72d1e )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[!]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[!]"
-	rom ( name "F4-DEMO.(A)" size 6198643 crc b3fd139b md5 05eccda036ff5337295659b9b258b408 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[a1][!]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[a1][!]"
-	rom ( name "FF4DEMO.(A)" size 6511799 crc c967cf68 md5 5ce60cae4b396838c5fc752b8d11973d )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[a2]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Dutch)[a2]"
-	rom ( name "FF4DEMO.(A)" size 6320006 crc 25d2723b md5 cc95b64e9a6ff671224acd498d90c62e )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/French)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/French)"
-	rom ( name "Mm4demo.(a)" size 6542432 crc 5be64d83 md5 22e3dd7c96108efe2d6bcb0e8ff13e02 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/French)[a]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/French)[a]"
-	rom ( name "Mm4demo.(a)" size 6083430 crc 3b3a0c00 md5 140e5cb94eefd26cb3bee559b350dd69 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/German)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/German)"
-	rom ( name "Ff4demo.(a)" size 6451799 crc 79b302a7 md5 b0b0010a4c8852bc6ee181e7154378a4 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Italian)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/Italian)"
-	rom ( name "FF4DEMO.(A)" size 6877546 crc dce3b27c md5 bd4d31438098ff530dd6fb1f9fedbe32 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/UK)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Demo/Windows/UK)"
-	rom ( name "FF4DEMO.(A)" size 6322129 crc d064630a md5 a2bb4dbf44dbf26587c2c213064853a8 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/French)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/French)"
-	rom ( name "MaliceMRC.(a)" size 117689819 crc 2a3f81c7 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)"
-	rom ( name "FREDDI4.(A)" size 117440938 crc 1d824453 md5 0fb24aa2d37a8a6cbf90066c2f792596 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[a]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[a]"
-	rom ( name "Freddi4.(a)" size 117852838 crc 73bf7428 md5 e94f3f560ec3dce8cb3a6b510ae457b7 )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[Akella]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[Akella]"
-	rom ( name "FreddiHRBG.(a)" size 117729511 crc 3cee5cfa md5 ac896b0c10011dd2a0494acbc23186dd )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[Russobit-M]"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian)[Russobit-M]"
-	rom ( name "FreddiHRBG.(a)" size 117729511 crc 3086080e md5 undefined )
-)
-
-game (
-	name "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian/Unencrypted)"
-	description "Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch (Windows/Russian/Unencrypted)"
-	rom ( name "FREDDI4.(A)" size 117440938 crc 7264cad0 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL)[!]"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL)[!]"
-	rom ( name "freddicove.(a)" size 123791021 crc 622834d3 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL/Dutch)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL/Dutch)"
-	rom ( name "FreddiDZZ.(a)" size 123380154 crc d4b1cb63 md5 undefined )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL/French)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (ALL/French)"
-	rom ( name "FreddiMML.(a)" size 123485049 crc 2adfe452 md5 6d025be59c569f9eb3c1e244ee35e889 )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (Demo/ALL)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (Demo/ALL)"
-	rom ( name "FFCoveDemo.(a)" size 27382107 crc e49f0c68 md5 f1b5cd6bceb50f8296d7a8db6efb69ec )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (Demo/ALL/Dutch)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (Demo/ALL/Dutch)"
-	rom ( name "FF5Demo.(a)" size 27815973 crc 91990750 md5 ebd4a5b0322a8342bb5eada346846afc )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cave (Windows/Russian/Unencrypted)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cave (Windows/Russian/Unencrypted)"
-	rom ( name "FREDDICOVE.(A)" size 123791021 crc 041eb6d0 md5 2cac27c79aebf9db05ed516783d950a6 )
-)
-
-game (
-	name "Freddi Fish 5: The Case of the Creature of Coral Cove (Windows/Russian)"
-	description "Freddi Fish 5: The Case of the Creature of Coral Cove (Windows/Russian)"
-	rom ( name "FreddiCCC.(a)" size 124701077 crc 37156d0e md5 undefined )
-)
-
-game (
-	name "Freddi Fish and Luther's Maze Madness (ALL/Dutch)[!]"
-	description "Freddi Fish and Luther's Maze Madness (ALL/Dutch)[!]"
-	rom ( name "DOOLHOF.(A)" size 11706702 crc ea4cc3d8 md5 undefined )
-)
-
-game (
-	name "Freddi Fish and Luther's Maze Madness (ALL/US)"
-	description "Freddi Fish and Luther's Maze Madness (ALL/US)"
-	rom ( name "MAZE.HE0" size 23479 crc 367f943a md5 4f04b321a95d4315ce6d65f8e1dd0368 )
-)
-
-game (
-	name "Freddi Fish and Luther's Maze Madness (ALL/US)[a]"
-	description "Freddi Fish and Luther's Maze Madness (ALL/US)[a]"
-	rom ( name "MAZE.HE0" size 23479 crc 367f943a md5 undefined )
-)
-
-game (
-	name "Freddi Fish and Luther's Maze Madness (ALL/US/Updated)"
-	description "Freddi Fish and Luther's Maze Madness (ALL/US/Updated)"
-	rom ( name "Maze.(a)" size 29610570 crc 13f36f76 md5 undefined )
-)
-
-game (
-	name "Freddi Fish and Luther's Maze Madness (Windows/US)[!]"
-	description "Freddi Fish and Luther's Maze Madness (Windows/US)[!]"
-	rom ( name "Maze.(a)" size 11771922 crc a9f1f095 md5 a48c156d8c03bf53096ec881329a9432 )
-)
-
-game (
-	name "Freddi Fish and Luther's Water Worries (ALL/Dutch)"
-	description "Freddi Fish and Luther's Water Worries (ALL/Dutch)"
-	rom ( name "WATER.(A)" size 11709214 crc aa2ac93c md5 111bc14ec657f127d12fc3b830ef90a5 )
-)
-
-game (
-	name "Freddi Fish and Luther's Water Worries (ALL/US)[!]"
-	description "Freddi Fish and Luther's Water Worries (ALL/US)[!]"
-	rom ( name "WATER.HE0" size 12699 crc 1bd08e6b md5 undefined )
-)
-
-game (
-	name "Freddi Fish and Luther's Water Worries (Windows/Russian)"
-	description "Freddi Fish and Luther's Water Worries (Windows/Russian)"
-	rom ( name "WATER.HE0" size 12699 crc fa7f20b9 md5 2012f854d83d9cc6f73b2b544cd8bbf8 )
-)
-
-game (
-	name "Freddi Fish and Luther's Water Worries (Windows/Russian)[a]"
-	description "Freddi Fish and Luther's Water Worries (Windows/Russian)[a]"
-	rom ( name "WATER.HE0" size 12699 crc d5054e5c md5 undefined )
-)
-
-game (
-	name "Freddi Fish's One-Stop Fun Shop (ALL/US)[!]"
-	description "Freddi Fish's One-Stop Fun Shop (ALL/US)[!]"
-	rom ( name "FreddisFunShop.(a)" size 21591833 crc 81bf3f06 md5 895b6746ab176b3ba3e70afa3ce6588b )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (CD/DOS)[!]"
-	description "Freddy Pharkas: Frontier Pharmacist (CD/DOS)[!]"
-	rom ( name "2998.SYN" size 4568 crc f53d3f34 md5 undefined )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (CD/DOS/Spanish)"
-	description "Freddy Pharkas: Frontier Pharmacist (CD/DOS/Spanish)"
-	rom ( name "253.V56" size 39672 crc cba2125b md5 03306bcf20324c4088f7260b303ef749 )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Demo/CD/DOS)"
-	description "Freddy Pharkas: Frontier Pharmacist (Demo/CD/DOS)"
-	rom ( name "RESOURCE.000" size 957382 crc 6f0fb5a1 md5 undefined )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)"
-	description "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)"
-	rom ( name "220.HEP" size 1684 crc 2e97e1e3 md5 undefined )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)[a1]"
-	description "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)[a1]"
-	rom ( name "220.HEP" size 1684 crc 2e97e1e3 md5 dee236337efde928cddf87f233bdc108 )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)[a2]"
-	description "Freddy Pharkas: Frontier Pharmacist (Demo/DOS)[a2]"
-	rom ( name "220.HEP" size 1684 crc 2e97e1e3 md5 undefined )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS)"
-	description "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS)"
-	rom ( name "15.MSG" size 21743 crc 8e47f64c md5 266e1c623e61bad056aa2b06b0fa0d39 )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/French)"
-	description "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/French)"
-	rom ( name "15.MSG" size 25059 crc ce917054 md5 12860c3a5775fdc6cfdf89e6bbee2916 )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/German)"
-	description "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/German)"
-	rom ( name "0.MSG" size 5647 crc b739327b md5 undefined )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/Spanish)"
-	description "Freddy Pharkas: Frontier Pharmacist (Floppy/DOS/Spanish)"
-	rom ( name "253.V56" size 39672 crc cba2125b md5 03306bcf20324c4088f7260b303ef749 )
-)
-
-game (
-	name "Freddy Pharkas: Frontier Pharmacist (Macintosh)"
-	description "Freddy Pharkas: Frontier Pharmacist (Macintosh)"
-	rom ( name "._Data1" size 3052692 crc a49953b6 md5 37120deb748f0cd0961d410412960c75 )
-)
-
-game (
-	name "Fu$k Quest 1 (DOS/Fanmade Final)"
-	description "Fu$k Quest 1 (DOS/Fanmade Final)"
-	rom ( name "LOGDIR" size 300 crc 502884d2 md5 undefined )
-)
-
-game (
-	name "Fu$k Quest 1 (DOS/Fanmade)"
-	description "Fu$k Quest 1 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 502884d2 md5 1cd0587422313f6ca77d6a95988e88ed )
-)
-
-game (
-	name "Fu$k Quest 2: Romancing the Bone (DOS/Fanmade)"
-	description "Fu$k Quest 2: Romancing the Bone (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 762 crc 4839c96e md5 294beeb7765c7ea6b05ed7b9bf7bff4f )
-)
-
-game (
-	name "Fu$k Quest 2: Romancing the Bone (Teaser/DOS/Fanmade)"
-	description "Fu$k Quest 2: Romancing the Bone (Teaser/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 762 crc 64beed55 md5 undefined )
-)
-
-game (
-	name "Full Pipe (Windows/German)"
-	description "Full Pipe (Windows/German)"
-	rom ( name "00170301.nl" size 3146576 crc c44dc91a md5 293842dc7f10b8868cdc499fdd019621 )
-)
-
-game (
-	name "Full Pipe (Windows/Russian)"
-	description "Full Pipe (Windows/Russian)"
-	rom ( name "00170301.nl" size 3146576 crc c44dc91a md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/French)"
-	description "Full Throttle (ALL/French)"
-	rom ( name "FT.LA0" size 19752 crc 8591fe6f md5 4bedb49943df95a9c900a5a82ccbe9de )
-)
-
-game (
-	name "Full Throttle (ALL/German)"
-	description "Full Throttle (ALL/German)"
-	rom ( name "FT.LA0" size 19762 crc f8d3d2b7 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Italian)"
-	description "Full Throttle (ALL/Italian)"
-	rom ( name "FT.LA0" size 19707 crc 4d08a3e4 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Portuguese)"
-	description "Full Throttle (ALL/Portuguese)"
-	rom ( name "FT.LA0" size 19727 crc 1958694d md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Russian/7-Wolf)"
-	description "Full Throttle (ALL/Russian/7-Wolf)"
-	rom ( name "FT.LA0" size 19697 crc dc4fe586 md5 291fb06071e65897f755846611f5ad40 )
-)
-
-game (
-	name "Full Throttle (ALL/Russian/Akella)"
-	description "Full Throttle (ALL/Russian/Akella)"
-	rom ( name "FT.LA0" size 19697 crc 1f37e6c9 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Spanish)"
-	description "Full Throttle (ALL/Spanish)"
-	rom ( name "FT.LA0" size 19727 crc 73dffffb md5 e72bb4c2b613db2cf50f89ff6350e70a )
-)
-
-game (
-	name "Full Throttle (ALL/Version A)[v1.01][!]"
-	description "Full Throttle (ALL/Version A)[v1.01][!]"
-	rom ( name "FT.LA0" size 19697 crc ac464377 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Version A/Hungarian)"
-	description "Full Throttle (ALL/Version A/Hungarian)"
-	rom ( name "FT.LA0" size 19697 crc aad16812 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Version B)[v1.00][!]"
-	description "Full Throttle (ALL/Version B)[v1.00][!]"
-	rom ( name "FT.LA0" size 19697 crc e2c63024 md5 undefined )
-)
-
-game (
-	name "Full Throttle (ALL/Version B/Hungarian)"
-	description "Full Throttle (ALL/Version B/Hungarian)"
-	rom ( name "FT.LA0" size 19697 crc 40ae69d2 md5 undefined )
-)
-
-game (
-	name "Full Throttle (Demo/DOS)"
-	description "Full Throttle (Demo/DOS)"
-	rom ( name "FT.000" size 7885 crc 5a4b7e9a md5 undefined )
-)
-
-game (
-	name "Full Throttle (Demo/Macintosh)"
-	description "Full Throttle (Demo/Macintosh)"
-	rom ( name "BENBIKE.NUT" size 160544 crc a560ef10 md5 undefined )
-)
-
-game (
-	name "Full Throttle (Demo/Macintosh)[mac bundle]"
-	description "Full Throttle (Demo/Macintosh)[mac bundle]"
-	rom ( name "Full Throttle Demo Data" size 116463537 crc ccaec7d1 md5 undefined )
-)
-
-game (
-	name "Full Throttle (Macintosh)[mac bundle][!]"
-	description "Full Throttle (Macintosh)[mac bundle][!]"
-	rom ( name "Full Throttle Data" size 513243679 crc 259fed8d md5 5bde23f2b23bb7b27e523df9df2afe40 )
-)
-
-game (
-	name "Full Throttle (Macintosh/French)[mac bundle]"
-	description "Full Throttle (Macintosh/French)[mac bundle]"
-	rom ( name "Full Throttle Data" size 489436643 crc cf061416 md5 e71a0e605e70d2a2634b1fd4e20fa85f )
-)
-
-game (
-	name "Full Throttle (Macintosh/German)[mac bundle]"
-	description "Full Throttle (Macintosh/German)[mac bundle]"
-	rom ( name "Vollgas Data" size 535405461 crc 3c8e5b7d md5 undefined )
-)
-
-game (
-	name "Fun Seeker's Guide (DOS)"
-	description "Fun Seeker's Guide (DOS)"
-	rom ( name "RESOURCE.001" size 40692 crc undefined md5 undefined )
-)
-
-game (
-	name "Future Wars (Amiga)"
-	description "Future Wars (Amiga)"
-	rom ( name "ALIENS" size 51640 crc 747a31eb md5 42588fd22ea3d1539c53f6fd477934d8 )
-)
-
-game (
-	name "Future Wars (Amiga/French)"
-	description "Future Wars (Amiga/French)"
-	rom ( name "ADD21K" size 1836 crc bf296d4a md5 undefined )
-)
-
-game (
-	name "Future Wars (Amiga/German)"
-	description "Future Wars (Amiga/German)"
-	rom ( name "ALIENS" size 51640 crc 747a31eb md5 undefined )
-)
-
-game (
-	name "Future Wars (Amiga/Italian)"
-	description "Future Wars (Amiga/Italian)"
-	rom ( name "ALIENS" size 51640 crc 747a31eb md5 undefined )
-)
-
-game (
-	name "Future Wars (Amiga/Spanish)"
-	description "Future Wars (Amiga/Spanish)"
-	rom ( name "ALIENS" size 51640 crc 747a31eb md5 42588fd22ea3d1539c53f6fd477934d8 )
-)
-
-game (
-	name "Future Wars (Atari ST)"
-	description "Future Wars (Atari ST)"
-	rom ( name "ALIENS" size 6496 crc 87544a84 md5 c277593df73ddd857d0d3b856908282c )
-)
-
-game (
-	name "Future Wars (Atari ST/French)"
-	description "Future Wars (Atari ST/French)"
-	rom ( name "ALIENS" size 6496 crc 87544a84 md5 c277593df73ddd857d0d3b856908282c )
-)
-
-game (
-	name "Future Wars (CD/DOS/US)"
-	description "Future Wars (CD/DOS/US)"
-	rom ( name "AUTO00.PRC" size 253 crc efcbe7fe md5 4fe1e7930b38e3c63f0f2474d471bf8f )
-)
-
-game (
-	name "Future Wars (Demo/Amiga)"
-	description "Future Wars (Demo/Amiga)"
-	rom ( name "AUTO00.PRC" size 136 crc be0ed25f md5 undefined )
-)
-
-game (
-	name "Future Wars (DOS)"
-	description "Future Wars (DOS)"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 52e064ffa0cd191ea32781efd5cd4761 )
-)
-
-game (
-	name "Future Wars (DOS)[UK Classic]"
-	description "Future Wars (DOS)[UK Classic]"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 undefined )
-)
-
-game (
-	name "Future Wars (DOS/French)"
-	description "Future Wars (DOS/French)"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 undefined )
-)
-
-game (
-	name "Future Wars (DOS/German)"
-	description "Future Wars (DOS/German)"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 undefined )
-)
-
-game (
-	name "Future Wars (DOS/Hungarian)"
-	description "Future Wars (DOS/Hungarian)"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 undefined )
-)
-
-game (
-	name "Future Wars (DOS/Spanish)"
-	description "Future Wars (DOS/Spanish)"
-	rom ( name "AUTO00.PRC" size 128 crc 27190770 md5 52e064ffa0cd191ea32781efd5cd4761 )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/DOS)[!]"
-	description "Gabriel Knight: Sins of the Fathers (CD/DOS)[!]"
-	rom ( name "ALT.MAP" size 364 crc a772d755 md5 undefined )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/DOS/French)[!]"
-	description "Gabriel Knight: Sins of the Fathers (CD/DOS/French)[!]"
-	rom ( name "ALT.MAP" size 364 crc 71a462d3 md5 undefined )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/DOS/German)"
-	description "Gabriel Knight: Sins of the Fathers (CD/DOS/German)"
-	rom ( name "ALT.MAP" size 364 crc f35d90be md5 undefined )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/DOS/Hungarian)"
-	description "Gabriel Knight: Sins of the Fathers (CD/DOS/Hungarian)"
-	rom ( name "0.MSG" size 17129 crc 854f50a0 md5 a7f229895ed4708f9e7601b21706dd50 )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/DOS/Spanish)"
-	description "Gabriel Knight: Sins of the Fathers (CD/DOS/Spanish)"
-	rom ( name "ALT.MAP" size 364 crc a6b1e514 md5 8a3a887b373453d8439ae4c756c1653e )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (CD/Windows)[!]"
-	description "Gabriel Knight: Sins of the Fathers (CD/Windows)[!]"
-	rom ( name "ALT.MAP" size 364 crc a772d755 md5 edd20299dc96776eaa45e9d193dcc711 )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (Demo/DOS)"
-	description "Gabriel Knight: Sins of the Fathers (Demo/DOS)"
-	rom ( name "1.SEQ" size 473370 crc 315b40b5 md5 1d2548a973ad91e09ac0b02564958a7c )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (DOS)"
-	description "Gabriel Knight: Sins of the Fathers (DOS)"
-	rom ( name "0.MSG" size 17660 crc 33d394d8 md5 undefined )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (DOS)[a]"
-	description "Gabriel Knight: Sins of the Fathers (DOS)[a]"
-	rom ( name "0.MSG" size 17660 crc 33d394d8 md5 6ed6f0ee6e8c33482a38039256e9740b )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (DOS/French)"
-	description "Gabriel Knight: Sins of the Fathers (DOS/French)"
-	rom ( name "3024.V56" size 10399 crc 3282b2e4 md5 undefined )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (DOS/German)"
-	description "Gabriel Knight: Sins of the Fathers (DOS/German)"
-	rom ( name "250.MSG" size 22718 crc 28661be8 md5 4498c30bd00625660def20145e6226a1 )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (DOS/Spanish)"
-	description "Gabriel Knight: Sins of the Fathers (DOS/Spanish)"
-	rom ( name "65535.MAP" size 252 crc d5f24394 md5 5874709872a2c01a23ea9e8552d592ef )
-)
-
-game (
-	name "Gabriel Knight: Sins of the Fathers (Macintosh)"
-	description "Gabriel Knight: Sins of the Fathers (Macintosh)"
-	rom ( name "._Data1" size 5831874 crc b7c483f2 md5 undefined )
-)
-
-game (
-	name "Geisha (Amiga)"
-	description "Geisha (Amiga)"
-	rom ( name "DISK1.STK" size 208120 crc 701c81c0 md5 ae02b759a57b03b7be6a06bf6460ea4f )
-)
-
-game (
-	name "Geisha (DOS)"
-	description "Geisha (DOS)"
-	rom ( name "DISK1.STK" size 212153 crc 6f0ba963 md5 undefined )
-)
-
-game (
-	name "Geisha (DOS/French)"
-	description "Geisha (DOS/French)"
-	rom ( name "DISK1.STK" size 211889 crc e55a307c md5 undefined )
-)
-
-game (
-	name "Geisha (DOS/German)"
-	description "Geisha (DOS/German)"
-	rom ( name "ALL.ASK" size 2690 crc 365d106d md5 b63174c77bfb6a5fdd72a8dd83449c6a )
-)
-
-game (
-	name "Geisha (DOS/Italian)"
-	description "Geisha (DOS/Italian)"
-	rom ( name "DISK1.STK" size 212169 crc 924e33b3 md5 cbc21c7cf03ea98881b904a133c3d238 )
-)
-
-game (
-	name "Geisha (DOS/Spanish)"
-	description "Geisha (DOS/Spanish)"
-	rom ( name "DISK1.STK" size 212169 crc 924e33b3 md5 cbc21c7cf03ea98881b904a133c3d238 )
-)
-
-game (
-	name "Geisha (DOS/Spanish)[a]"
-	description "Geisha (DOS/Spanish)[a]"
-	rom ( name "DISK1.STK" size 212164 crc 92347305 md5 undefined )
-)
-
-game (
-	name "Gem Scenario, The (DOS/Fanmade)"
-	description "Gem Scenario, The (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 244794 crc 90a12a54 md5 c2e20ceba64e1a7eb7952462960d6373 )
-)
-
-game (
-	name "Gennadi Tahab Autot: Mission Pack 1: Kuressaare (DOS/Fanmade)"
-	description "Gennadi Tahab Autot: Mission Pack 1: Kuressaare (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc 3d959f84 md5 undefined )
-)
-
-game (
-	name "Get Outta Space Quest (DOS/Fanmade)"
-	description "Get Outta Space Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 841c1787 md5 aaea5b4a348acb669d13b0e6f22d4dc9 )
-)
-
-game (
-	name "Ghost in the Sheet (Demo/Windows)"
-	description "Ghost in the Sheet (Demo/Windows)"
-	rom ( name "audio.dcp" size 22721390 crc 6749b839 md5 undefined )
-)
-
-game (
-	name "Ghost in the Sheet (Demo/Windows/Italian)"
-	description "Ghost in the Sheet (Demo/Windows/Italian)"
-	rom ( name "audio.dcp" size 22721390 crc 9b8ae406 md5 undefined )
-)
-
-game (
-	name "Ghost in the Sheet (Windows)"
-	description "Ghost in the Sheet (Windows)"
-	rom ( name "audio.dcp" size 54347822 crc c6f9368a md5 3fb028dfe45d7eebaa2d58972fe0af0a )
-)
-
-game (
-	name "Ghost in the Sheet (Windows)[Unk]"
-	description "Ghost in the Sheet (Windows)[Unk]"
-	rom ( name "audio.dcp" size 54347822 crc e240a9b4 md5 78f415f20d28575df6e46c2090a3d42c )
-)
-
-game (
-	name "Gnap (Windows)"
-	description "Gnap (Windows)"
-	rom ( name "BAR_N.DAT" size 4004001 crc d1a9282c md5 96083f09ada26f1b265f9f2765f4c8ef )
-)
-
-game (
-	name "Gnap (Windows/Russian)"
-	description "Gnap (Windows/Russian)"
-	rom ( name "BAR_N.DAT" size 4897165 crc 17e551a4 md5 undefined )
-)
-
-game (
-	name "Go West, Young Hippie (DOS/Fanmade)"
-	description "Go West, Young Hippie (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 1f9b4bb5 md5 ff31484ea465441cb5f3a0f8e956b716 )
-)
-
-game (
-	name "Gobliiins (Demo/Amiga)[!]"
-	description "Gobliiins (Demo/Amiga)[!]"
-	rom ( name "DISK1.STK" size 300871 crc 19eb7e97 md5 undefined )
-)
-
-game (
-	name "Gobliiins (Demo/Interactive/DOS)[!]"
-	description "Gobliiins (Demo/Interactive/DOS)[!]"
-	rom ( name "DISK1.STK" size 662036 crc 27fb1369 md5 undefined )
-)
-
-game (
-	name "Gobliiins (Demo/Interactive/DOS)[a][!]"
-	description "Gobliiins (Demo/Interactive/DOS)[a][!]"
-	rom ( name "DISK1.STK" size 672348 crc 5f490a21 md5 undefined )
-)
-
-game (
-	name "Gobliiins (Demo/Interactive/DOS/French)[!]"
-	description "Gobliiins (Demo/Interactive/DOS/French)[!]"
-	rom ( name "DISK1.STK" size 588595 crc 61fbf3af md5 undefined )
-)
-
-game (
-	name "Gobliiins (EGA/DOS)"
-	description "Gobliiins (EGA/DOS)"
-	rom ( name "DISK1.STK" size 367110 crc a65958f4 md5 a42ca54c4f1e3bc3a9fee8fd301bf4e5 )
-)
-
-game (
-	name "Gobliiins (EGA/DOS)[a1]"
-	description "Gobliiins (EGA/DOS)[a1]"
-	rom ( name "DISK1.STK" size 367110 crc a65958f4 md5 undefined )
-)
-
-game (
-	name "Gobliiins (EGA/DOS)[a2]"
-	description "Gobliiins (EGA/DOS)[a2]"
-	rom ( name "DISK1.STK" size 367110 crc a65958f4 md5 a42ca54c4f1e3bc3a9fee8fd301bf4e5 )
-)
-
-game (
-	name "Gobliiins (EGA/DOS/Russian)"
-	description "Gobliiins (EGA/DOS/Russian)"
-	rom ( name "DISK1.STK" size 367188 crc accc0e65 md5 70829142bef578a98d8045dd76e0269e )
-)
-
-game (
-	name "Gobliiins (Macintosh)"
-	description "Gobliiins (Macintosh)"
-	rom ( name "COMMUN.EX1" size 113553 crc bf33961f md5 undefined )
-)
-
-game (
-	name "Gobliiins (Macintosh/French)"
-	description "Gobliiins (Macintosh/French)"
-	rom ( name "french.rom" size 28 crc 0f6a402d md5 9c29497676d6ff93a11772334d481b71 )
-)
-
-game (
-	name "Gobliiins (Macintosh/German)"
-	description "Gobliiins (Macintosh/German)"
-	rom ( name "german.rom" size 28 crc 2265ee2e md5 7ea5a84e98f6225f37093a631d7ff755 )
-)
-
-game (
-	name "Gobliiins (Macintosh/Italian)"
-	description "Gobliiins (Macintosh/Italian)"
-	rom ( name "italian.rom" size 29 crc 5195751d md5 undefined )
-)
-
-game (
-	name "Gobliiins (Macintosh/Spanish)"
-	description "Gobliiins (Macintosh/Spanish)"
-	rom ( name "spanish.rom" size 29 crc 7b99ff15 md5 undefined )
-)
-
-game (
-	name "Gobliiins (VGA/DOS)[GOG][!]"
-	description "Gobliiins (VGA/DOS)[GOG][!]"
-	rom ( name "DISK1.STK" size 496145 crc c209b551 md5 604cbe12f143cc841223d0670f6428eb )
-)
-
-game (
-	name "Gobliiins (VGA/DOS/UK)"
-	description "Gobliiins (VGA/DOS/UK)"
-	rom ( name "DISK1.STK" size 572700 crc bc099dec md5 undefined )
-)
-
-game (
-	name "Gobliiins (Windows/French)"
-	description "Gobliiins (Windows/French)"
-	rom ( name "DISK1.STK" size 572700 crc bc099dec md5 undefined )
-)
-
-game (
-	name "Gobliiins (Windows/German)[fr]"
-	description "Gobliiins (Windows/German)[fr]"
-	rom ( name "GERMAN.ROM" size 68 crc cc8a00ea md5 75de9a222789d8f4f405c10c1bf1580c )
-)
-
-game (
-	name "Gobliiins (Windows/Italian)[fr]"
-	description "Gobliiins (Windows/Italian)[fr]"
-	rom ( name "ITALIAN.ROM" size 69 crc 05651be2 md5 undefined )
-)
-
-game (
-	name "Gobliiins (Windows/Spanish)[fr]"
-	description "Gobliiins (Windows/Spanish)[fr]"
-	rom ( name "SPANISH.ROM" size 69 crc abe66baa md5 undefined )
-)
-
-game (
-	name "Gobliiins (Windows/UK)[fr]"
-	description "Gobliiins (Windows/UK)[fr]"
-	rom ( name "ENGLISH.ROM" size 64 crc 0d508f00 md5 ad30b4b793cd86227823f036469c16e5 )
-)
-
-game (
-	name "Gobliiins CD (Polish/DOS)"
-	description "Gobliiins CD (Polish/DOS)"
-	rom ( name "GOB.LIC" size 949 crc 21ac85cd md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.000/DOS/French)[!]"
-	description "Gobliiins CD (v1.000/DOS/French)[!]"
-	rom ( name "FRENCH.ROM" size 32 crc be2276e0 md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.000/DOS/German)[!]"
-	description "Gobliiins CD (v1.000/DOS/German)[!]"
-	rom ( name "GERMAN.ROM" size 32 crc 932dd8e3 md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.000/DOS/Italian)[!]"
-	description "Gobliiins CD (v1.000/DOS/Italian)[!]"
-	rom ( name "ITALIAN.ROM" size 33 crc b4f18326 md5 545be8396811e02f5a4dfcd5fbd560fb )
-)
-
-game (
-	name "Gobliiins CD (v1.000/DOS/Spanish)[!]"
-	description "Gobliiins CD (v1.000/DOS/Spanish)[!]"
-	rom ( name "SPANISH.ROM" size 33 crc 9efd092e md5 bae69da73af5ef90830ad5a79c35c6fe )
-)
-
-game (
-	name "Gobliiins CD (v1.000/DOS/US)[!]"
-	description "Gobliiins CD (v1.000/DOS/US)[!]"
-	rom ( name "GOB.LIC" size 949 crc 21ac85cd md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/French)[!]"
-	description "Gobliiins CD (v1.02/DOS/French)[!]"
-	rom ( name "French.rom" size 31 crc 6c31230a md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/French)[hu][!]"
-	description "Gobliiins CD (v1.02/DOS/French)[hu][!]"
-	rom ( name "FRENCH.ROM" size 62 crc b6b1234b md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/German)[!]"
-	description "Gobliiins CD (v1.02/DOS/German)[!]"
-	rom ( name "German.rom" size 31 crc 413e8d09 md5 undefined )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/Hungarian)[!]"
-	description "Gobliiins CD (v1.02/DOS/Hungarian)[!]"
-	rom ( name "GOB.LIC" size 949 crc 21ac85cd md5 3d53324939418df5815e613635ac1d8a )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/Italian)[!]"
-	description "Gobliiins CD (v1.02/DOS/Italian)[!]"
-	rom ( name "Italian.rom" size 32 crc f4fc9b15 md5 74ffda99c86edf01fc208ed4bffa68df )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/Italian)[hu][!]"
-	description "Gobliiins CD (v1.02/DOS/Italian)[hu][!]"
-	rom ( name "ITALIAN.ROM" size 63 crc 9bc6a2ea md5 ce1dd3cfddd8a5b91f75bd9d5dc235eb )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/Spanish)[!]"
-	description "Gobliiins CD (v1.02/DOS/Spanish)[!]"
-	rom ( name "Spanish.rom" size 32 crc def0111d md5 3e0dbb61b90b195a6aa784d02720e32e )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/Spanish)[hu][!]"
-	description "Gobliiins CD (v1.02/DOS/Spanish)[hu][!]"
-	rom ( name "SPANISH.ROM" size 63 crc 2cebfdf5 md5 45c564bc95d7028f7088ab8e3d7cb94f )
-)
-
-game (
-	name "Gobliiins CD (v1.02/DOS/UK)[GOG][!]"
-	description "Gobliiins CD (v1.02/DOS/UK)[GOG][!]"
-	rom ( name "GOB.LIC" size 949 crc 21ac85cd md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Amiga)"
-	description "Gobliins 2 (Amiga)"
-	rom ( name "DISK2.STK" size 723311 crc 7505781e md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Amiga/German)"
-	description "Gobliins 2 (Amiga/German)"
-	rom ( name "DISK2.STK" size 724889 crc 06c80d2e md5 72dab9a3c2216ba0bb75592db4ca65a3 )
-)
-
-game (
-	name "Gobliins 2 (Amiga/German)[a]"
-	description "Gobliins 2 (Amiga/German)[a]"
-	rom ( name "DISK2.STK" size 724889 crc 8d22e8c6 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Amiga/Italian)"
-	description "Gobliins 2 (Amiga/Italian)"
-	rom ( name "DISK2.STK" size 723970 crc 8e657b29 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Amiga/Spanish)"
-	description "Gobliins 2 (Amiga/Spanish)"
-	rom ( name "DISK2.STK" size 724130 crc 230cf639 md5 46d63871ac2d0227f7019dfbd7408b50 )
-)
-
-game (
-	name "Gobliins 2 (Atari ST/French)"
-	description "Gobliins 2 (Atari ST/French)"
-	rom ( name "DISK2.STK" size 724356 crc 3de8a987 md5 3100cdad47f6bcc43a4c50a5f65c081e )
-)
-
-game (
-	name "Gobliins 2 (Demo/Interactive/Amiga)[!]"
-	description "Gobliins 2 (Demo/Interactive/Amiga)[!]"
-	rom ( name "G0.DUM" size 2850 crc 115ebbab md5 5aafbf393ea67553fd5742b010ee333a )
-)
-
-game (
-	name "Gobliins 2 (Demo/Interactive/Amiga)[a][!]"
-	description "Gobliins 2 (Demo/Interactive/Amiga)[a][!]"
-	rom ( name "G0.DUM" size 2850 crc 115ebbab md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Demo/Interactive/DOS)[!]"
-	description "Gobliins 2 (Demo/Interactive/DOS)[!]"
-	rom ( name "INTRO.STK" size 492226 crc 93a2ae99 md5 48223d9343db7a849a0db61acd99ebd4 )
-)
-
-game (
-	name "Gobliins 2 (Demo/Non-Interactive/DOS)[!]"
-	description "Gobliins 2 (Demo/Non-Interactive/DOS)[!]"
-	rom ( name "INTRO.STK" size 907690 crc 91eace82 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (DOS/French)"
-	description "Gobliins 2 (DOS/French)"
-	rom ( name "DISK2.STK" size 997418 crc e12b56aa md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (DOS/German)"
-	description "Gobliins 2 (DOS/German)"
-	rom ( name "DISK2.STK" size 1002874 crc 691eb81a md5 ba7bfb6e518dc67b789e88a48ffef938 )
-)
-
-game (
-	name "Gobliins 2 (DOS/German)[a]"
-	description "Gobliins 2 (DOS/German)[a]"
-	rom ( name "DISK2.STK" size 1002874 crc 691eb81a md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (DOS/Italian)"
-	description "Gobliins 2 (DOS/Italian)"
-	rom ( name "DISK2.STK" size 1002359 crc e5cbb345 md5 047e46dc244d102d6ac4339f9bf148ac )
-)
-
-game (
-	name "Gobliins 2 (DOS/Russian)"
-	description "Gobliins 2 (DOS/Russian)"
-	rom ( name "DISK2.STK" size 1004849 crc 2053ab73 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (DOS/Spanish)"
-	description "Gobliins 2 (DOS/Spanish)"
-	rom ( name "DISK2.STK" size 1002332 crc 064fd1c3 md5 423e427c7dff0557263cd4d89ad3d037 )
-)
-
-game (
-	name "Gobliins 2 (DOS/UK)"
-	description "Gobliins 2 (DOS/UK)"
-	rom ( name "disk2.stk" size 1001893 crc 0e0ce8f7 md5 294624eb1103f1ce263ea182c1855331 )
-)
-
-game (
-	name "Gobliins 2 (DOS/UK)[GOG][!]"
-	description "Gobliins 2 (DOS/UK)[GOG][!]"
-	rom ( name "DISK2.STK" size 1001893 crc 627b7fec md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (DOS/US)"
-	description "Gobliins 2 (DOS/US)"
-	rom ( name "DISK2.STK" size 970686 crc 11549a07 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Macintosh)"
-	description "Gobliins 2 (Macintosh)"
-	rom ( name "DISK2.STK" size 1001893 crc 627b7fec md5 undefined )
-)
-
-game (
-	name "Gobliins 2 (Macintosh/French)"
-	description "Gobliins 2 (Macintosh/French)"
-	rom ( name "DISK2.STK" size 997418 crc e12b56aa md5 09ec79a93a0c1fcbc36414fa9abdbd20 )
-)
-
-game (
-	name "Gobliins 2 (Windows/French)"
-	description "Gobliins 2 (Windows/French)"
-	rom ( name "DISK2.STK" size 937200 crc 6cb7460b md5 3d8aabaf7b02afbd84c877ef37d63e1a )
-)
-
-game (
-	name "Gobliins 2 (Windows/French)[a]"
-	description "Gobliins 2 (Windows/French)[a]"
-	rom ( name "DISK2.STK" size 997418 crc e12b56aa md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.000/DOS/US)"
-	description "Gobliins 2 CD (v1.000/DOS/US)"
-	rom ( name "GOBNEW.LIC" size 4338 crc 3aaf9860 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS)[GOG][!]"
-	description "Gobliins 2 CD (v1.02/DOS)[GOG][!]"
-	rom ( name "GOB2.LIC" size 4338 crc 3aaf9860 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/French)[GOG][!]"
-	description "Gobliins 2 CD (v1.02/DOS/French)[GOG][!]"
-	rom ( name "french.rom" size 44 crc e18e8368 md5 1be1f9720daa44755f750ef80e0c9b6e )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/French)[hu][!]"
-	description "Gobliins 2 CD (v1.02/DOS/French)[hu][!]"
-	rom ( name "FRENCH.ROM" size 63 crc 76dede74 md5 e15eaecd574f2053be426aea03b89845 )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/German)[GOG][!]"
-	description "Gobliins 2 CD (v1.02/DOS/German)[GOG][!]"
-	rom ( name "german.rom" size 44 crc b7aefeaf md5 c74defec94cc2bfe272862bb20e081c0 )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/German)[hu][!]"
-	description "Gobliins 2 CD (v1.02/DOS/German)[hu][!]"
-	rom ( name "GERMAN.ROM" size 63 crc 7ff71b09 md5 7cb0e7e1d1331bbc4a883d2f23e22eca )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/Hungarian)[!]"
-	description "Gobliins 2 CD (v1.02/DOS/Hungarian)[!]"
-	rom ( name "GOB2.LIC" size 4338 crc 3aaf9860 md5 7dc7854378b42899f98c9bfb660bc3bf )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/Italian)[GOG][!]"
-	description "Gobliins 2 CD (v1.02/DOS/Italian)[GOG][!]"
-	rom ( name "italian.rom" size 45 crc 4f4fc7ad md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/Italian)[hu][!]"
-	description "Gobliins 2 CD (v1.02/DOS/Italian)[hu][!]"
-	rom ( name "ITALIAN.ROM" size 64 crc 21317647 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/Spanish)[GOG][!]"
-	description "Gobliins 2 CD (v1.02/DOS/Spanish)[GOG][!]"
-	rom ( name "spanish.rom" size 45 crc d1ee34fb md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v1.02/DOS/Spanish)[hu][!]"
-	description "Gobliins 2 CD (v1.02/DOS/Spanish)[hu][!]"
-	rom ( name "SPANISH.ROM" size 64 crc 15fc4059 md5 undefined )
-)
-
-game (
-	name "Gobliins 2 CD (v2.01 Polish/DOS)"
-	description "Gobliins 2 CD (v2.01 Polish/DOS)"
-	rom ( name "GOBNEW.LIC" size 4338 crc 3aaf9860 md5 7dc7854378b42899f98c9bfb660bc3bf )
-)
-
-game (
-	name "Goblins Quest 3 (Amiga/German)"
-	description "Goblins Quest 3 (Amiga/German)"
-	rom ( name "DEMO.ALL" size 1281 crc da88cf6e md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (Amiga/UK)"
-	description "Goblins Quest 3 (Amiga/UK)"
-	rom ( name "DEMO.ANG" size 1281 crc da88cf6e md5 6193ae185eec43c7e8d7058097dca02f )
-)
-
-game (
-	name "Goblins Quest 3 (Demo/Interactive 2/DOS/French)"
-	description "Goblins Quest 3 (Demo/Interactive 2/DOS/French)"
-	rom ( name "IMD.ITK" size 767505 crc ee37c186 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (Demo/Interactive 3/DOS)"
-	description "Goblins Quest 3 (Demo/Interactive 3/DOS)"
-	rom ( name "IMD.ITK" size 83129 crc 49c77750 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (Demo/Interactive/DOS/French)"
-	description "Goblins Quest 3 (Demo/Interactive/DOS/French)"
-	rom ( name "INTRO.STK" size 270737 crc 9b49440f md5 4986b44cec309589508d7904f924c217 )
-)
-
-game (
-	name "Goblins Quest 3 (Demo/Non-interactive/DOS)"
-	description "Goblins Quest 3 (Demo/Non-interactive/DOS)"
-	rom ( name "IMD.ITK" size 767505 crc ee37c186 md5 b0d30241ccdfddc2a8c815df6eab67e1 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/French)"
-	description "Goblins Quest 3 (DOS/French)"
-	rom ( name "EXT.STK" size 3922524 crc 7338cc3a md5 764e1ce536f734393461dd5505689fb9 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/German)"
-	description "Goblins Quest 3 (DOS/German)"
-	rom ( name "EXT.STK" size 3922524 crc b9a33db7 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/Hebrew)"
-	description "Goblins Quest 3 (DOS/Hebrew)"
-	rom ( name "EXT.STK" size 3922498 crc 820b0662 md5 0f131306adee95dc426167936d832711 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/Italian)"
-	description "Goblins Quest 3 (DOS/Italian)"
-	rom ( name "EXT.STK" size 3922524 crc 7338cc3a md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/Russian)"
-	description "Goblins Quest 3 (DOS/Russian)"
-	rom ( name "EXT.STK" size 3922524 crc 7338cc3a md5 764e1ce536f734393461dd5505689fb9 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/Spanish)"
-	description "Goblins Quest 3 (DOS/Spanish)"
-	rom ( name "EXT.STK" size 3922524 crc 7338cc3a md5 764e1ce536f734393461dd5505689fb9 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/UK)"
-	description "Goblins Quest 3 (DOS/UK)"
-	rom ( name "EXT.STK" size 3922524 crc 7338cc3a md5 764e1ce536f734393461dd5505689fb9 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/UK)[a2]"
-	description "Goblins Quest 3 (DOS/UK)[a2]"
-	rom ( name "EXT.STK" size 3922524 crc b9a33db7 md5 e50f38eb8a996702b84f6af6721aa985 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/UK)[GOG][!]"
-	description "Goblins Quest 3 (DOS/UK)[GOG][!]"
-	rom ( name "EXT.STK" size 3922524 crc 69593e26 md5 a9a7eaaed24e295bdca22e9f784ebfe6 )
-)
-
-game (
-	name "Goblins Quest 3 (DOS/US)"
-	description "Goblins Quest 3 (DOS/US)"
-	rom ( name "EXT.STK" size 3946534 crc 76aafabc md5 99f4cf07b06a8d718ef7c7b84ed81c4d )
-)
-
-game (
-	name "Goblins Quest 3 (Macintosh/UK)"
-	description "Goblins Quest 3 (Macintosh/UK)"
-	rom ( name "EXT.STK" size 3922524 crc b9a33db7 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 (Windows/French)"
-	description "Goblins Quest 3 (Windows/French)"
-	rom ( name "EXT.STK" size 3922524 crc fb2c55fd md5 06a00d341f9ba3786f616a173f96daec )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.000/DOS/US)"
-	description "Goblins Quest 3 CD (v1.000/DOS/US)"
-	rom ( name "COKTEL.IMD" size 835339 crc 38ef3aff md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS)"
-	description "Goblins Quest 3 CD (v1.02/DOS)"
-	rom ( name "COKTEL.IMD" size 835339 crc 38ef3aff md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS)[GOG][!]"
-	description "Goblins Quest 3 CD (v1.02/DOS)[GOG][!]"
-	rom ( name "EXT.STK" size 7224322 crc 1cf479e9 md5 08b694360f10661f86b8411f4caab7ce )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/French)"
-	description "Goblins Quest 3 CD (v1.02/DOS/French)"
-	rom ( name "FRGOB3.ITK" size 82759160 crc 5f8f1ad4 md5 c933eb7b961514f17e089348a902b5c2 )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/French)[hu][!]"
-	description "Goblins Quest 3 CD (v1.02/DOS/French)[hu][!]"
-	rom ( name "FRENCH.ROM" size 68 crc aff08d7a md5 69a77c97f1b99b14bca076344a709ab9 )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/German)"
-	description "Goblins Quest 3 CD (v1.02/DOS/German)"
-	rom ( name "DEGOB3.ITK" size 87863546 crc a5e812c9 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/German)[hu][!]"
-	description "Goblins Quest 3 CD (v1.02/DOS/German)[hu][!]"
-	rom ( name "DEGOB3.ITK" size 87863546 crc a5e812c9 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/Hungarian)[!]"
-	description "Goblins Quest 3 CD (v1.02/DOS/Hungarian)[!]"
-	rom ( name "COKTEL.IMD" size 835339 crc 38ef3aff md5 70fe82c7fd418f9a094bdff3609f1119 )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/Italian)"
-	description "Goblins Quest 3 CD (v1.02/DOS/Italian)"
-	rom ( name "ITGOB3.ITK" size 89931448 crc 39e1e6c4 md5 undefined )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/Polish)"
-	description "Goblins Quest 3 CD (v1.02/DOS/Polish)"
-	rom ( name "DEGOB3.ITK" size 87863546 crc a5e812c9 md5 360319b7cc63d4e05ba23d9b3b14abe4 )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/Spanish)"
-	description "Goblins Quest 3 CD (v1.02/DOS/Spanish)"
-	rom ( name "FRGOB3.ITK" size 82759160 crc 5f8f1ad4 md5 c933eb7b961514f17e089348a902b5c2 )
-)
-
-game (
-	name "Goblins Quest 3 CD (v1.02/DOS/Spanish)[hu][!]"
-	description "Goblins Quest 3 CD (v1.02/DOS/Spanish)[hu][!]"
-	rom ( name "SPANISH.ROM" size 69 crc d0ba46b2 md5 undefined )
-)
-
-game (
-	name "Gold Rush! (Amiga) "
-	description "Gold Rush! (Amiga) "
-	rom ( name "DIRS" size 2399 crc 07b8b5e0 md5 a1d4de3e75c2688c1e2ca2634ffc3bd8 )
-)
-
-game (
-	name "Gold Rush! (Apple IIgs) "
-	description "Gold Rush! (Apple IIgs) "
-	rom ( name "GR.SYS16" size 148268 crc 3062e482 md5 1050ee79e637059c7464284de058c5c6 )
-)
-
-game (
-	name "Gold Rush! (Atari ST)"
-	description "Gold Rush! (Atari ST)"
-	rom ( name "GRDIR" size 2399 crc 5fb7a690 md5 undefined )
-)
-
-game (
-	name "Gold Rush! (CoCo3/Updated)"
-	description "Gold Rush! (CoCo3/Updated)"
-	rom ( name "logDir" size 744 crc ea6856c4 md5 c49bf56bf91e31a4601a604e51ef8bfb )
-)
-
-game (
-	name "Gold Rush! (DOS/3.5')"
-	description "Gold Rush! (DOS/3.5')"
-	rom ( name "GRDIR" size 2399 crc f23766f7 md5 undefined )
-)
-
-game (
-	name "Gold Rush! (DOS/5.25')"
-	description "Gold Rush! (DOS/5.25')"
-	rom ( name "GRDIR" size 2399 crc 6dfff5b6 md5 undefined )
-)
-
-game (
-	name "Gold Rush! (Macintosh)"
-	description "Gold Rush! (Macintosh)"
-	rom ( name "GRDIR" size 2399 crc 6dfff5b6 md5 db733d199238d4009a9e95f11ece34e9 )
-)
-
-game (
-	name "Good Man (Demo/DOS/Fanmade v3.41)"
-	description "Good Man (Demo/DOS/Fanmade v3.41)"
-	rom ( name "LOGDIR" size 759 crc 1d6589e6 md5 undefined )
-)
-
-game (
-	name "Good Man (Demo/DOS/Fanmade v4.0)[Unl]"
-	description "Good Man (Demo/DOS/Fanmade v4.0)[Unl]"
-	rom ( name "LOGDIR" size 759 crc ce8d94c3 md5 undefined )
-)
-
-game (
-	name "Good Man (Demo/DOS/Fanmade v4.0T)[Unl]"
-	description "Good Man (Demo/DOS/Fanmade v4.0T)[Unl]"
-	rom ( name "LOGDIR" size 759 crc 974ec8dc md5 undefined )
-)
-
-game (
-	name "Gourd of the Beans, The (DOS/Fanmade Old version)"
-	description "Gourd of the Beans, The (DOS/Fanmade Old version)"
-	rom ( name "LOGDIR" size 768 crc 7809a792 md5 4a1c1ef3a7901baf0ab45fde0cfadd89 )
-)
-
-game (
-	name "Gourd of the Beans, The (DOS/Fanmade)[Unl]"
-	description "Gourd of the Beans, The (DOS/Fanmade)[Unl]"
-	rom ( name "LOGDIR" size 768 crc bf691535 md5 undefined )
-)
-
-game (
-	name "Grateful Dead, The (DOS/Fanmade)"
-	description "Grateful Dead, The (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 609 crc e7628245 md5 undefined )
-)
-
-game (
-	name "Gregory and the Hot Air Balloon (Macintosh)"
-	description "Gregory and the Hot Air Balloon (Macintosh)"
-	rom ( name "Gregory" size 57669 crc eb86657c md5 351eb37325f2240e78efced85efb2bc8 )
-)
-
-game (
-	name "Gregory and the Hot Air Balloon (Windows)"
-	description "Gregory and the Hot Air Balloon (Windows)"
-	rom ( name "BOOK.INI" size 2234 crc a2f73cb3 md5 14a562dcf361773445255af9f3e94790 )
-)
-
-game (
-	name "Gregory and the Hot Air Balloon (Windows/German)"
-	description "Gregory and the Hot Air Balloon (Windows/German)"
-	rom ( name "BOOK.INI" size 2234 crc 4203cf78 md5 undefined )
-)
-
-game (
-	name "Grostesteing: Plus Mechant que Jamais (DOS/Fanmade/French)"
-	description "Grostesteing: Plus Mechant que Jamais (DOS/Fanmade/French)"
-	rom ( name "RESOURCE.001" size 464657 crc 433b87f1 md5 undefined )
-)
-
-game (
-	name "Groza (DOS/Fanmade/Russian AGDS sample)"
-	description "Groza (DOS/Fanmade/Russian AGDS sample)"
-	rom ( name "LOGDIR" size 339 crc 6818b64c md5 421da3a18004122a966d64ab6bd86d2e )
-)
-
-game (
-	name "Half-Death: Terror at White-Mesa (DOS/Fanmade)"
-	description "Half-Death: Terror at White-Mesa (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc 9d1d189c md5 undefined )
-)
-
-game (
-	name "Hamlet or the last game without MMORPS features, shaders and product placement (Windows)"
-	description "Hamlet or the last game without MMORPS features, shaders and product placement (Windows)"
-	rom ( name "data.bin" size 8112 crc 53a476d4 md5 eced02e857906cba42b0f22d87e1c717 )
-)
-
-game (
-	name "Hank's Quest: Slachtoffer Van Het Gebeuren (DOS/Fanmade/Dutch v1.81)"
-	description "Hank's Quest: Slachtoffer Van Het Gebeuren (DOS/Fanmade/Dutch v1.81)"
-	rom ( name "LOGDIR" size 300 crc d4593e43 md5 undefined )
-)
-
-game (
-	name "Hank's Quest: Victim of Society (DOS/Fanmade v1.0)"
-	description "Hank's Quest: Victim of Society (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 94371e4f md5 64c15b3d0483d17888129100dc5af213 )
-)
-
-game (
-	name "Hank's Quest: Victim of Society (DOS/Fanmade v1.1)"
-	description "Hank's Quest: Victim of Society (DOS/Fanmade v1.1)"
-	rom ( name "LOGDIR" size 300 crc db12f6bc md5 undefined )
-)
-
-game (
-	name "Hank's Quest: Victim of Society (DOS/Fanmade v1.81)"
-	description "Hank's Quest: Victim of Society (DOS/Fanmade v1.81)"
-	rom ( name "LOGDIR" size 300 crc a8f27b7a md5 7a776383282f62a57c3a960dafca62d1 )
-)
-
-game (
-	name "Helga Deep In Trouble (Demo/Windows)"
-	description "Helga Deep In Trouble (Demo/Windows)"
-	rom ( name "data.dcp" size 154266028 crc 72c1f6a2 md5 8f8f854061b3902202b4bfe6504005eb )
-)
-
-game (
-	name "Helga Deep In Trouble (Windows)"
-	description "Helga Deep In Trouble (Windows)"
-	rom ( name "data.dcp" size 183251259 crc e7350e6f md5 6418d332384a0fb933968d2a0e705f7e )
-)
-
-game (
-	name "Herbao (DOS/Fanmade v0.2)"
-	description "Herbao (DOS/Fanmade v0.2)"
-	rom ( name "LOGDIR" size 300 crc 2f328127 md5 undefined )
-)
-
-game (
-	name "Hi-Res Adventure #0: Mission Asteroid (Apple IIgs)"
-	description "Hi-Res Adventure #0: Mission Asteroid (Apple IIgs)"
-	rom ( name "MISSION.NIB" size 232960 crc a8cc0865 md5 cedf4db0b9ba63a7644d2621235aaf3d )
-)
-
-game (
-	name "Hi-Res Adventure #1: Mystery House (Apple IIgs)"
-	description "Hi-Res Adventure #1: Mystery House (Apple IIgs)"
-	rom ( name "ADVENTURE" size 29952 crc 338bc7ac md5 undefined )
-)
-
-game (
-	name "Hi-Res Adventure #1: Mystery House (Apple IIgs)[DSK]"
-	description "Hi-Res Adventure #1: Mystery House (Apple IIgs)[DSK]"
-	rom ( name "MYSTHOUS.DSK" size 143360 crc 4b0017cc md5 undefined )
-)
-
-game (
-	name "Hi-Res Adventure #2: Wizard and the Princess (Apple IIgs)"
-	description "Hi-Res Adventure #2: Wizard and the Princess (Apple IIgs)"
-	rom ( name "WIZARD.DSK" size 143360 crc 035128ff md5 9d22d0788838fac08c219d5c00701b38 )
-)
-
-game (
-	name "Hi-Res Adventure #6: The Dark Crystal (Apple IIgs)"
-	description "Hi-Res Adventure #6: The Dark Crystal (Apple IIgs)"
-	rom ( name "DARK1A.DSK" size 143360 crc 75615733 md5 undefined )
-)
-
-game (
-	name "Hitler's Legacy (DOS/Fanmade v.0004q)"
-	description "Hitler's Legacy (DOS/Fanmade v.0004q)"
-	rom ( name "LOGDIR" size 768 crc 6bd63ab7 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Demo/Linux)"
-	description "Hopkins FBI (Demo/Linux)"
-	rom ( name "ANIM\.DIRECTORY" size 53 crc 1b18e4fa md5 e496129dff274a0bd42d429ef260bc8e )
-)
-
-game (
-	name "Hopkins FBI (Demo/Windows)"
-	description "Hopkins FBI (Demo/Windows)"
-	rom ( name "hopkins.exe" size 376897 crc 4e42000d md5 08aa5f9da1f62ed744a864e92e90373a )
-)
-
-game (
-	name "Hopkins FBI (Demo/Windows/Polish)"
-	description "Hopkins FBI (Demo/Windows/Polish)"
-	rom ( name "anim\ANDERS.SPR" size 129740 crc 2388338a md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Linux)"
-	description "Hopkins FBI (Linux)"
-	rom ( name "LINK\CREAN.TXT" size 2107 crc 4098b3de md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Linux/French)"
-	description "Hopkins FBI (Linux/French)"
-	rom ( name "LINK\CREFR.TXT" size 2081 crc a2422136 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (OS/2)"
-	description "Hopkins FBI (OS/2)"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Windows)[!]"
-	description "Hopkins FBI (Windows)[!]"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Windows/French)"
-	description "Hopkins FBI (Windows/French)"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Windows/Polish)"
-	description "Hopkins FBI (Windows/Polish)"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 undefined )
-)
-
-game (
-	name "Hopkins FBI (Windows/Russian)"
-	description "Hopkins FBI (Windows/Russian)"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 22e31c66ddf3a0becec803da407a10f7 )
-)
-
-game (
-	name "Hopkins FBI (Windows/Spanish)"
-	description "Hopkins FBI (Windows/Spanish)"
-	rom ( name "ANIM\AGENT1.PE2" size 3855 crc e3726da8 md5 22e31c66ddf3a0becec803da407a10f7 )
-)
-
-game (
-	name "Hotel Caper, The (Macintosh)"
-	description "Hotel Caper, The (Macintosh)"
-	rom ( name "._The Hotel Caper V1.0" size 236119 crc f522484d md5 0757f9abcdb95ced7102edc57dbb8e79 )
-)
-
-game (
-	name "Hoyle Children's Collection (Windows)"
-	description "Hoyle Children's Collection (Windows)"
-	rom ( name "1.MSG" size 32 crc 4433f771 md5 undefined )
-)
-
-game (
-	name "Hoyle Classic Card Games (Demo/DOS)"
-	description "Hoyle Classic Card Games (Demo/DOS)"
-	rom ( name "1000.MAP" size 22 crc e8e69ec3 md5 undefined )
-)
-
-game (
-	name "Hoyle Classic Card Games (Demo/DOS)[a][!]"
-	description "Hoyle Classic Card Games (Demo/DOS)[a][!]"
-	rom ( name "65535.MAP" size 68 crc eb0eeb7d md5 6a547779352bbbb789c809960ad6094a )
-)
-
-game (
-	name "Hoyle Classic Card Games (DOS)"
-	description "Hoyle Classic Card Games (DOS)"
-	rom ( name "600.HEP" size 4664 crc e9a371d6 md5 20b7406eb122b2ff59c19d6e3a0de0c5 )
-)
-
-game (
-	name "Hoyle Classic Card Games (Macintosh)"
-	description "Hoyle Classic Card Games (Macintosh)"
-	rom ( name "._1.Pat" size 578 crc e656f638 md5 910ab1580700292b9f4649df1ab29133 )
-)
-
-game (
-	name "Hoyle Classic Games (Demo/Windows)"
-	description "Hoyle Classic Games (Demo/Windows)"
-	rom ( name "975.HEP" size 1896 crc 7543e876 md5 undefined )
-)
-
-game (
-	name "Hoyle Classic Games (Windows)[!]"
-	description "Hoyle Classic Games (Windows)[!]"
-	rom ( name "100.CFG" size 488 crc 7f461a88 md5 d1b1f08ad3affc2b31fbe67c3180f9e1 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (Amiga)"
-	description "Hoyle Official Book of Games: Volume 1 (Amiga)"
-	rom ( name "BANK.001" size 133716 crc 1153161f md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (Atari ST)"
-	description "Hoyle Official Book of Games: Volume 1 (Atari ST)"
-	rom ( name "NAME.SET" size 10 crc 866c98a2 md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (Atari ST)[a]"
-	description "Hoyle Official Book of Games: Volume 1 (Atari ST)[a]"
-	rom ( name "HOYLE.SET" size 23 crc 0d8bcac2 md5 2f450a3656f0ca2dde2efb5d37b2da23 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (DOS)[1x720KB]"
-	description "Hoyle Official Book of Games: Volume 1 (DOS)[1x720KB]"
-	rom ( name "NAME.SET" size 10 crc e6c98e18 md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (DOS)[3x360KB]"
-	description "Hoyle Official Book of Games: Volume 1 (DOS)[3x360KB]"
-	rom ( name "NAME.SET" size 10 crc e6c98e18 md5 6f004743822869778d55f1562c55edf7 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (DOS)[a]"
-	description "Hoyle Official Book of Games: Volume 1 (DOS)[a]"
-	rom ( name "RESOURCE.001" size 162805 crc 83533133 md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 1 (DOS/EGA)[0.000.519]"
-	description "Hoyle Official Book of Games: Volume 1 (DOS/EGA)[0.000.519]"
-	rom ( name "HOYLE.SET" size 23 crc 2cb5e45b md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 2 (Amiga)"
-	description "Hoyle Official Book of Games: Volume 2 (Amiga)"
-	rom ( name "BANK.001" size 133716 crc 1153161f md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 2 (Atari ST)"
-	description "Hoyle Official Book of Games: Volume 2 (Atari ST)"
-	rom ( name "HOYLESOL.100" size 1856 crc 0fa1eb7d md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 2 (DOS)"
-	description "Hoyle Official Book of Games: Volume 2 (DOS)"
-	rom ( name "HOYLESOL.100" size 1856 crc 0fa1eb7d md5 72394b421419314aab5770f9572758a5 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 2 (DOS)[a]"
-	description "Hoyle Official Book of Games: Volume 2 (DOS)[a]"
-	rom ( name "HOYLESOL.100" size 1856 crc 0fa1eb7d md5 72394b421419314aab5770f9572758a5 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 2 (Macintosh)"
-	description "Hoyle Official Book of Games: Volume 2 (Macintosh)"
-	rom ( name "HOYLESOL.100" size 1856 crc 0fa1eb7d md5 72394b421419314aab5770f9572758a5 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 3 (Amiga)"
-	description "Hoyle Official Book of Games: Volume 3 (Amiga)"
-	rom ( name "101.PAT" size 556 crc 56a66909 md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 3 (Demo/DOS)"
-	description "Hoyle Official Book of Games: Volume 3 (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 797678 crc eb961f57 md5 undefined )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 3 (DOS)"
-	description "Hoyle Official Book of Games: Volume 3 (DOS)"
-	rom ( name "600.SCR" size 17412 crc c5831cb6 md5 2dd3c78f45494cbed7a92dae40ede5f0 )
-)
-
-game (
-	name "Hoyle Official Book of Games: Volume 3 (DOS/EGA)"
-	description "Hoyle Official Book of Games: Volume 3 (DOS/EGA)"
-	rom ( name "4.PAT" size 1301 crc c13a4742 md5 8c30ca28eaecf8ed48f94f2afe01fec8 )
-)
-
-game (
-	name "Hoyle Solitaire (CD/Windows)"
-	description "Hoyle Solitaire (CD/Windows)"
-	rom ( name "15.HEP" size 1674 crc d3789d95 md5 undefined )
-)
-
-game (
-	name "Hoyle Solitaire (Hard Drive/Windows)"
-	description "Hoyle Solitaire (Hard Drive/Windows)"
-	rom ( name "15.SCR" size 20696 crc a2aa3ca2 md5 undefined )
-)
-
-game (
-	name "Hugo 1: Hugo's House of Horrors (DOS)"
-	description "Hugo 1: Hugo's House of Horrors (DOS)"
-	rom ( name "ARC.PIX" size 582 crc b132b6b9 md5 699b1784944e644bdb747e2d3ceb71b9 )
-)
-
-game (
-	name "Hugo 2: Whodunit? (DOS)"
-	description "Hugo 2: Whodunit? (DOS)"
-	rom ( name "HELP.DAT" size 1920 crc ee8fa480 md5 086bc847a23b9b3cd7d8c83beb3ace5d )
-)
-
-game (
-	name "Hugo 3: Jungle of Doom (DOS)"
-	description "Hugo 3: Jungle of Doom (DOS)"
-	rom ( name "HELP.DAT" size 2092 crc ca4f01bf md5 0d5967cce09690e318474351126ddb6f )
-)
-
-game (
-	name "Humanoid Demo (DOS/Fanmade)"
-	description "Humanoid Demo (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 452320 crc 4806a921 md5 c0a61b66c1b8e5651d6fee74c3dba8db )
-)
-
-game (
-	name "Humongous Interactive Catalog (Demo/Windows)"
-	description "Humongous Interactive Catalog (Demo/Windows)"
-	rom ( name "CATALOG.HE0" size 28539 crc d15e5a9e md5 11e6e244078ff09b0f3832e35420e0a7 )
-)
-
-game (
-	name "Humongous Interactive Catalog (Demo/Windows/US)[!]"
-	description "Humongous Interactive Catalog (Demo/Windows/US)[!]"
-	rom ( name "CATALOG2.HE0" size 28491 crc 1f0bcc53 md5 037385a953789190298494d92b89b3d0 )
-)
-
-game (
-	name "Humongous Interactive Catalog (Preview)"
-	description "Humongous Interactive Catalog (Preview)"
-	rom ( name "PREVIEW.CUP" size 10978342 crc d901114e md5 a6a9d994a6ba4f44541499b36b828f04 )
-)
-
-game (
-	name "Humongous Interactive Catalog (Preview/French)"
-	description "Humongous Interactive Catalog (Preview/French)"
-	rom ( name "Preview.cup" size 10841544 crc 003aa8eb md5 ca7d371621c113c2c8b3df041bc0bebf )
-)
-
-game (
-	name "Humongous Interactive Catalog (Preview/German)"
-	description "Humongous Interactive Catalog (Preview/German)"
-	rom ( name "Preview.cup" size 10927456 crc 0967bb08 md5 undefined )
-)
-
-game (
-	name "Humongous Interactive Catalog (Preview/US)"
-	description "Humongous Interactive Catalog (Preview/US)"
-	rom ( name "preview.cup" size 10795148 crc feb9bbae md5 undefined )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (Demo/DOS)"
-	description "I Have No Mouth and I Must Scream (Demo/DOS)"
-	rom ( name "MUSIC.RES" size 33042 crc 7a7b8f50 md5 fac6e4fbfc845911ccdc4b5962f56cf9 )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS)[GOG][!]"
-	description "I Have No Mouth and I Must Scream (DOS)[GOG][!]"
-	rom ( name "SCREAM.RES" size 79211140 crc 9cb225a9 md5 undefined )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/Fanmade German)"
-	description "I Have No Mouth and I Must Scream (DOS/Fanmade German)"
-	rom ( name "SCREAM.RES" size 79219797 crc c51257e0 md5 ed824d6a4587de2a034b723190a43a0f )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/French)"
-	description "I Have No Mouth and I Must Scream (DOS/French)"
-	rom ( name "MUSICFM.RES" size 302676 crc 7f13e61a md5 fe63a88b8c49baa69a814fc15659b1df )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/German)"
-	description "I Have No Mouth and I Must Scream (DOS/German)"
-	rom ( name "MUSICFM.RES" size 302676 crc 7f13e61a md5 undefined )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/Italian)"
-	description "I Have No Mouth and I Must Scream (DOS/Italian)"
-	rom ( name "SCREAM.RES" size 79211498 crc af975602 md5 55e89ac27ea2eac4f21339f4bcf42edf )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/Russian)"
-	description "I Have No Mouth and I Must Scream (DOS/Russian)"
-	rom ( name "SCREAM.RES" size 79210049 crc 223a2fd4 md5 4dd67ba52406b099adc56fda3d93d0c4 )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (DOS/Spanish)"
-	description "I Have No Mouth and I Must Scream (DOS/Spanish)"
-	rom ( name "MUSICFM.RES" size 302676 crc 7f13e61a md5 undefined )
-)
-
-game (
-	name "I Have No Mouth and I Must Scream (Macintosh)"
-	description "I Have No Mouth and I Must Scream (Macintosh)"
-	rom ( name "PATCH.RES" size 5038599 crc 55a0883e md5 a88a9182abd95ed2af059ef28af9f470 )
-)
-
-game (
-	name "ImagiNation Network (INN) Demo (DOS)"
-	description "ImagiNation Network (INN) Demo (DOS)"
-	rom ( name "RESOURCE.000" size 514578 crc 44badcc0 md5 undefined )
-)
-
-game (
-	name "In the 1st Degree (Windows)"
-	description "In the 1st Degree (Windows)"
-	rom ( name "BROEMIDI.TMI" size 2644 crc 51cbaaa3 md5 05b32430cd470fbeccfd25f6ebe99f93 )
-)
-
-game (
-	name "In the 1st Degree (Windows/French)"
-	description "In the 1st Degree (Windows/French)"
-	rom ( name "BROEMIDI.EXE" size 211114 crc 88b18789 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (CD/DOS/French)[v1.30]"
-	description "Inca II: Wiracocha (CD/DOS/French)[v1.30]"
-	rom ( name "FROBLI.ITK" size 4250270 crc a7a6dea7 md5 81784ab6883e373f03a4c4a4e5269ab0 )
-)
-
-game (
-	name "Inca II: Wiracocha (CD/DOS/German)[v1.30]"
-	description "Inca II: Wiracocha (CD/DOS/German)[v1.30]"
-	rom ( name "DEOBLI.ITK" size 4546066 crc eb38449b md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (CD/DOS/Italian)[v1.30]"
-	description "Inca II: Wiracocha (CD/DOS/Italian)[v1.30]"
-	rom ( name "ITALIAN.ROM" size 54 crc 6eb34b66 md5 7e72b98fa254eb96736e81abaac2b426 )
-)
-
-game (
-	name "Inca II: Wiracocha (CD/DOS/Spanish)[v1.30]"
-	description "Inca II: Wiracocha (CD/DOS/Spanish)[v1.30]"
-	rom ( name "SPANISH.ROM" size 54 crc b9aa619b md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (CD/DOS/US)[v1.30]"
-	description "Inca II: Wiracocha (CD/DOS/US)[v1.30]"
-	rom ( name "SPEAK.INF" size 7 crc 41745f90 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (Demo/Non-Interactive/DOS)"
-	description "Inca II: Wiracocha (Demo/Non-Interactive/DOS)"
-	rom ( name "CONS.IMD" size 17804 crc e5fed4f0 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (DOS/French)[v1.000 hd]"
-	description "Inca II: Wiracocha (DOS/French)[v1.000 hd]"
-	rom ( name "FRENCH.ROM" size 43 crc 7d333993 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (DOS/German)[v1.000 hd]"
-	description "Inca II: Wiracocha (DOS/German)[v1.000 hd]"
-	rom ( name "GERMAN.ROM" size 43 crc ee8adda6 md5 8f584db4842b966773345dbbaf413fe1 )
-)
-
-game (
-	name "Inca II: Wiracocha (DOS/US)[v1.000 hd]"
-	description "Inca II: Wiracocha (DOS/US)[v1.000 hd]"
-	rom ( name "COKTEL.CLT" size 768 crc 9a56d39a md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (Windows)"
-	description "Inca II: Wiracocha (Windows)"
-	rom ( name "EXT.STK" size 5258646 crc 58af7645 md5 a3f06badf3f338409d64e662dd69db9c )
-)
-
-game (
-	name "Inca II: Wiracocha (Windows/French)"
-	description "Inca II: Wiracocha (Windows/French)"
-	rom ( name "FRENCH.ROM" size 75 crc fab54068 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (Windows/German)"
-	description "Inca II: Wiracocha (Windows/German)"
-	rom ( name "GERMAN.ROM" size 75 crc 77f3b927 md5 undefined )
-)
-
-game (
-	name "Inca II: Wiracocha (Windows/Italian)"
-	description "Inca II: Wiracocha (Windows/Italian)"
-	rom ( name "ITALIAN.ROM" size 76 crc 0dc190f7 md5 a450968ba992daf62801396c5e18a3d5 )
-)
-
-game (
-	name "Inca II: Wiracocha (Windows/Spanish)"
-	description "Inca II: Wiracocha (Windows/Spanish)"
-	rom ( name "SPANISH.ROM" size 76 crc f7126792 md5 9088e551a65c66954b0e81633cb2c9f6 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS)"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS)"
-	rom ( name "ATLANTIS.000" size 12035 crc 60e9988f md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade French)[v0.8]"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade French)[v0.8]"
-	rom ( name "ATLANTIS.000" size 12030 crc 3b23cb47 md5 de9be9be4e3fb4c05eaa55dfcd813233 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade German)[v1.12]"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade German)[v1.12]"
-	rom ( name "ATLANTIS.000" size 12035 crc 1d5a5dfa md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade German)[v1.13]"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade German)[v1.13]"
-	rom ( name "ATLANTIS.000" size 12035 crc c5a6e729 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Hungarian)"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Hungarian)"
-	rom ( name "ATLANTIS.000" size 12035 crc 6ce50d53 md5 007c9547e193f2d9a28a4c033d4492f5 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Italian)"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Italian)"
-	rom ( name "ATLANTIS.000" size 12035 crc 2357f368 md5 6a218dd9125ff15a1f840770a2c4a05d )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Russian)"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Russian)"
-	rom ( name "ATLANTIS.000" size 12035 crc 23cfa9bf md5 add05fa3f50d9264f47638516c9496dd )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Spanish)"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Spanish)"
-	rom ( name "ATLANTIS.000" size 12030 crc 3821b867 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Spanish)[a]"
-	description "Indiana Jones and the Fate of Atlantis (CD/DOS/Fanmade Spanish)[a]"
-	rom ( name "ATLANTIS.000" size 12035 crc 7a7c14a0 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/FM-Towns)"
-	description "Indiana Jones and the Fate of Atlantis (CD/FM-Towns)"
-	rom ( name "INDY4.000" size 12030 crc a49c0b7b md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/FM-Towns/Japanese)"
-	description "Indiana Jones and the Fate of Atlantis (CD/FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/Macintosh)"
-	description "Indiana Jones and the Fate of Atlantis (CD/Macintosh)"
-	rom ( name "._iMuse Setups" size 1097728 crc 7f3de2e5 md5 37c39007246e28431adf769e46f63c27 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (CD/Macintosh)[mac bundle]"
-	description "Indiana Jones and the Fate of Atlantis (CD/Macintosh)[mac bundle]"
-	rom ( name "Fate of Atlantis Data" size 161796385 crc 03e242b2 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/DOS)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/DOS)"
-	rom ( name "PLAYFATE.000" size 12030 crc dbef6cd3 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/DOS)[a]"
-	description "Indiana Jones and the Fate of Atlantis (Demo/DOS)[a]"
-	rom ( name "PLAYFATE.000" size 12030 crc ff19fa0b md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/FM-Towns/Fanmade German)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/FM-Towns/Fanmade German)"
-	rom ( name "ATLANTIS.000" size 11170 crc bb08a544 md5 83aa325609669c524630928d9a448b05 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/Interactive v2/DOS)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/Interactive v2/DOS)"
-	rom ( name "PLAYFATE.000" size 12030 crc 46cbbe4c md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/Interactive/DOS/Portuguese)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/Interactive/DOS/Portuguese)"
-	rom ( name "ATLANTIS.000" size 12030 crc 9bcf2701 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/Non-interactive/FM-Towns/Japanese)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/Non-interactive/FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/Talkie/DOS)[!]"
-	description "Indiana Jones and the Fate of Atlantis (Demo/Talkie/DOS)[!]"
-	rom ( name "FATE.000" size 11105 crc 8a19ca9e md5 99b6f822b0b2612415407865438697d6 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Demo/Talkie/DOS/Fanmade German)"
-	description "Indiana Jones and the Fate of Atlantis (Demo/Talkie/DOS/Fanmade German)"
-	rom ( name "FATE.000" size 11105 crc 5861e96b md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 5f00d17a449c833d48e24b93a36665b4 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)[a1]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)[a1]"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)[a2]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga)[a2]"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 5f00d17a449c833d48e24b93a36665b4 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/French)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/French)"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/German)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/German)"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/Italian)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/Italian)"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 5f00d17a449c833d48e24b93a36665b4 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/Spanish)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Amiga/Spanish)"
-	rom ( name "AMIGA1.IMS" size 72558 crc 377b7a12 md5 5f00d17a449c833d48e24b93a36665b4 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS)"
-	rom ( name "ATLANTIS.000" size 12030 crc 89ac8949 md5 c63ee46143ba65f9ce14cf539ca51bd7 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS)[a1]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS)[a1]"
-	rom ( name "ATLANTIS.000" size 12030 crc 89ac8949 md5 c63ee46143ba65f9ce14cf539ca51bd7 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS)[a2]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS)[a2]"
-	rom ( name "ATLANTIS.000" size 12030 crc 89ac8949 md5 c63ee46143ba65f9ce14cf539ca51bd7 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/French)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/French)"
-	rom ( name "ATLANTIS.000" size 12030 crc e2837671 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/French)[a]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/French)[a]"
-	rom ( name "ATLANTIS.000" size 12030 crc e2837671 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/German)[!]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/German)[!]"
-	rom ( name "ATLANTIS.000" size 12030 crc 22003c90 md5 1fbebd7b2b692df5297870447a80cfed )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/German)[a]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/German)[a]"
-	rom ( name "ATLANTIS.000" size 12030 crc 22003c90 md5 1fbebd7b2b692df5297870447a80cfed )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)"
-	rom ( name "ATLANTIS.000" size 12030 crc 3ebc7d99 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)[a1]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)[a1]"
-	rom ( name "ATLANTIS.000" size 12030 crc 88962043 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)[a2]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Hungarian)[a2]"
-	rom ( name "ATLANTIS.000" size 12030 crc 28126e26 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Italian)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Italian)"
-	rom ( name "ATLANTIS.000" size 12030 crc d33981b3 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Italian)[a]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Italian)[a]"
-	rom ( name "ATLANTIS.000" size 12030 crc d33981b3 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Russian)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Russian)"
-	rom ( name "ATLANTIS.000" size 12030 crc a8c3a929 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Spanish)"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Spanish)"
-	rom ( name "ATLANTIS.000" size 12030 crc 27270b36 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Spanish)[a]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/DOS/Spanish)[a]"
-	rom ( name "ATLANTIS.000" size 12030 crc 27270b36 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Macintosh)[a1]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Macintosh)[a1]"
-	rom ( name "._iMuse Setups" size 1097728 crc 7f3de2e5 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Floppy/Macintosh)[a2]"
-	description "Indiana Jones and the Fate of Atlantis (Floppy/Macintosh)[a2]"
-	rom ( name "._iMuse Setups" size 1097728 crc 7f3de2e5 md5 37c39007246e28431adf769e46f63c27 )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Steam/Macintosh)[!]"
-	description "Indiana Jones and the Fate of Atlantis (Steam/Macintosh)[!]"
-	rom ( name "ATLANTIS.001" size 9823920 crc 90db9c30 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Fate of Atlantis (Steam/Windows)[!]"
-	description "Indiana Jones and the Fate of Atlantis (Steam/Windows)[!]"
-	rom ( name "ATLANTIS.001" size 9823920 crc 90db9c30 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (Demo/Non-interactive/EGA/DOS)"
-	description "Indiana Jones and the Last Crusade (Demo/Non-interactive/EGA/DOS)"
-	rom ( name "00.LFL" size 5361 crc 586b53cc md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga)"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga)"
-	rom ( name "00.LFL" size 5361 crc 1145ddda md5 9c0fee288ad564a7d25ec3e841810d79 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga)[a]"
-	rom ( name "00.LFL" size 5361 crc 1145ddda md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/French)"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/French)"
-	rom ( name "00.LFL" size 5361 crc 1dc95b91 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/German)"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/German)"
-	rom ( name "00.LFL" size 5361 crc 35fa6cab md5 330f631502e381a4e199a3f7cb483c20 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/German)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/German)[a]"
-	rom ( name "00.LFL" size 5361 crc 35fa6cab md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/German)[a2]"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/German)[a2]"
-	rom ( name "00.LFL" size 5361 crc 35fa6cab md5 330f631502e381a4e199a3f7cb483c20 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/Italian)"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/Italian)"
-	rom ( name "00.LFL" size 5361 crc 62547fdd md5 df03ee021aa9b81d90cab9c26da07614 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/Italian)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/Italian)[a]"
-	rom ( name "00.LFL" size 5361 crc 62547fdd md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/Spanish)"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/Spanish)"
-	rom ( name "00.LFL" size 5361 crc 807285c2 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Amiga/Spanish)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/Amiga/Spanish)[a]"
-	rom ( name "00.LFL" size 5361 crc 807285c2 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Atari ST)[no adlib]"
-	description "Indiana Jones and the Last Crusade (EGA/Atari ST)[no adlib]"
-	rom ( name "00.LFL" size 5361 crc 54338f08 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Atari ST/French)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/Atari ST/French)[a]"
-	rom ( name "00.LFL" size 5361 crc b95456a5 md5 0f9c7a76657f0840b8f7ccb5bffeb9f4 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Atari ST/French)[no adlib]"
-	description "Indiana Jones and the Last Crusade (EGA/Atari ST/French)[no adlib]"
-	rom ( name "00.LFL" size 5361 crc b95456a5 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Atari ST/German)"
-	description "Indiana Jones and the Last Crusade (EGA/Atari ST/German)"
-	rom ( name "00.LFL" size 5361 crc 7e384c3e md5 aaa7f36a253f277dd29dd1c051b0e4b9 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS)[v1.0]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS)[v1.0]"
-	rom ( name "00.LFL" size 5361 crc daa62a5c md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS)[v1.3]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS)[v1.3]"
-	rom ( name "00.LFL" size 5361 crc e5266ff6 md5 6b3ec67da214f558dc5ceaa2acd47453 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS)[v1.3][a]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS)[v1.3][a]"
-	rom ( name "00.LFL" size 5361 crc 3d389296 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/French)"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/French)"
-	rom ( name "00.LFL" size 5361 crc ea5f3e03 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/French)[a]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/French)[a]"
-	rom ( name "00.LFL" size 5361 crc 0bd14926 md5 89cfc425566003ff74b7dc7b3e6fd469 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/German)[v1.4]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/German)[v1.4]"
-	rom ( name "00.LFL" size 5361 crc 411dbab7 md5 6f6ef668c608c7f534fea6e6d3878dde )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.4]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.4]"
-	rom ( name "00.LFL" size 5361 crc 4571c90d md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.4][a]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.4][a]"
-	rom ( name "00.LFL" size 5361 crc 4571c90d md5 d62d248c3df6ec177405e2cb23d923b2 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.5]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Italian)[v1.5]"
-	rom ( name "00.LFL" size 5361 crc e36c2738 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[a2]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[a2]"
-	rom ( name "00.LFL" size 5361 crc fca55967 md5 049b4229333e0db71b25b87e52747212 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[v1.4b]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[v1.4b]"
-	rom ( name "00.LFL" size 5361 crc 02d54864 md5 86be8ada36371d4fdc35659d0e912a26 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[v1.4b][a]"
-	description "Indiana Jones and the Last Crusade (EGA/DOS/Spanish)[v1.4b][a]"
-	rom ( name "00.LFL" size 5361 crc dacbb504 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (EGA/Macintosh)[no adlib v1.7]"
-	description "Indiana Jones and the Last Crusade (EGA/Macintosh)[no adlib v1.7]"
-	rom ( name "00.LFL" size 5361 crc 62fb16a0 md5 1dd7aa088e09f96d06818aa9a9deabe0 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns)"
-	description "Indiana Jones and the Last Crusade (FM-Towns)"
-	rom ( name "00.LFL" size 7552 crc 213b947c md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Fanmade French)[v0.9a]"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Fanmade French)[v0.9a]"
-	rom ( name "00.LFL" size 7552 crc 7eb932b4 md5 eac5a3c9b5cbe795d1be2f871f6d8cc8 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Fanmade German)[v1.01]"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Fanmade German)[v1.01]"
-	rom ( name "00.LFL" size 7552 crc c9de9849 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Fanmade German)[v1.14 - patch 2]"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Fanmade German)[v1.14 - patch 2]"
-	rom ( name "00.LFL" size 7552 crc fd09d6b9 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Fanmade Italian)"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Fanmade Italian)"
-	rom ( name "00.LFL" size 7552 crc 5308f83e md5 b27efc535df2bc2db998947c15ce57fb )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Fanmade Spanish)"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Fanmade Spanish)"
-	rom ( name "00.LFL" size 7552 crc 173258bc md5 a8725e57d3c808c56db46f5e63eb89ec )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (FM-Towns/Japanese)"
-	description "Indiana Jones and the Last Crusade (FM-Towns/Japanese)"
-	rom ( name "00.LFL" size 7552 crc 013c30d3 md5 3a0c35f3c147b98a2bdf8d400cfc4ab5 )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (Steam/Macintosh)[!]"
-	description "Indiana Jones and the Last Crusade (Steam/Macintosh)[!]"
-	rom ( name "01.LFL" size 93138 crc ddebc13c md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (Steam/Windows)[!]"
-	description "Indiana Jones and the Last Crusade (Steam/Windows)[!]"
-	rom ( name "01.LFL" size 93138 crc ddebc13c md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS)[a]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS)[a]"
-	rom ( name "00.LFL" size 6295 crc 4f179478 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS)[ibm 256 color v2.0]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS)[ibm 256 color v2.0]"
-	rom ( name "00.LFL" size 6295 crc 4f179478 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade French)[v0.9a]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade French)[v0.9a]"
-	rom ( name "00.LFL" size 6295 crc de45931b md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v0.8b uncut patch]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v0.8b uncut patch]"
-	rom ( name "00.LFL" size 6295 crc cd7ced36 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v1.02]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v1.02]"
-	rom ( name "00.LFL" size 6295 crc 946057ed md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v1.03]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade German)[v1.03]"
-	rom ( name "00.LFL" size 6295 crc 4103da9a md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Hungarian)"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Hungarian)"
-	rom ( name "00.LFL" size 6295 crc 4e59905d md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Italian)"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Italian)"
-	rom ( name "00.LFL" size 6295 crc e5ae336f md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Portuguese)"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Portuguese)"
-	rom ( name "00.LFL" size 6295 crc 1ab0d971 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Russian)[PRCA v1.0 Final][Unk]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Russian)[PRCA v1.0 Final][Unk]"
-	rom ( name "00.LFL" size 6295 crc b0c2a2f2 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Russian)[Unk]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Russian)[Unk]"
-	rom ( name "00.LFL" size 6295 crc c77cd4af md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Spanish)"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Fanmade Spanish)"
-	rom ( name "00.LFL" size 6295 crc 4f179478 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/German v1.02)[!]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/German v1.02)[!]"
-	rom ( name "00.LFL" size 6295 crc 3b27c4ec md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade (VGA/DOS/Italian)[ibm 256 color v2.1]"
-	description "Indiana Jones and the Last Crusade (VGA/DOS/Italian)[ibm 256 color v2.1]"
-	rom ( name "00.LFL" size 6295 crc 227ce0e3 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade & Loom (Demo/FM-Towns)"
-	description "Indiana Jones and the Last Crusade & Loom (Demo/FM-Towns)"
-	rom ( name "00.LFL" size 7520 crc 5b208b33 md5 undefined )
-)
-
-game (
-	name "Indiana Jones and the Last Crusade & Zak McKracken (Demo/FM-Towns)"
-	description "Indiana Jones and the Last Crusade & Zak McKracken (Demo/FM-Towns)"
-	rom ( name "00.LFL" size 7520 crc a5e8e756 md5 3938ee1aa4433fca9d9308c9891172b1 )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/DOS)"
-	description "Inherit the Earth: Quest for the Orb (CD/DOS)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/DOS/German)"
-	description "Inherit the Earth: Quest for the Orb (CD/DOS/German)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/Macintosh)"
-	description "Inherit the Earth: Quest for the Orb (CD/Macintosh)"
-	rom ( name "ITE Music.bin" size 3146112 crc f528f1b3 md5 fd917101d5f65ddac17cc0cf8898f592 )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/Multi-OS/Italian)"
-	description "Inherit the Earth: Quest for the Orb (CD/Multi-OS/Italian)"
-	rom ( name "Inherit the Earth Voices" size 434830787 crc 3c02df05 md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS)"
-	description "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS)"
-	rom ( name "ITE.RSC" size 8928678 crc dca7f42e md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS/Italian)"
-	description "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS/Italian)"
-	rom ( name "ITE.RSC" size 8929956 crc 0bf951bc md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS/Spanish)"
-	description "Inherit the Earth: Quest for the Orb (CD/Windows/Linux/DOS/Spanish)"
-	rom ( name "ITE.RSC" size 8928678 crc 37a444dc md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Demo 1/Windows)"
-	description "Inherit the Earth: Quest for the Orb (Demo 1/Windows)"
-	rom ( name "ited.rsc" size 1327323 crc 7bb08a16 md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Demo 2/3 Linux/Windows)"
-	description "Inherit the Earth: Quest for the Orb (Demo 2/3 Linux/Windows)"
-	rom ( name "ited.rsc" size 1951395 crc c61281f8 md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Demo 2/Macintosh)"
-	description "Inherit the Earth: Quest for the Orb (Demo 2/Macintosh)"
-	rom ( name "BOARHALL.BBM" size 25260 crc c7ee4de2 md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Floppy/DOS)"
-	description "Inherit the Earth: Quest for the Orb (Floppy/DOS)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 1dddf5c5ff20b026a90b555ba430f9c3 )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Floppy/DOS/German)"
-	description "Inherit the Earth: Quest for the Orb (Floppy/DOS/German)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 1dddf5c5ff20b026a90b555ba430f9c3 )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Floppy/DOS/Italian)"
-	description "Inherit the Earth: Quest for the Orb (Floppy/DOS/Italian)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 1dddf5c5ff20b026a90b555ba430f9c3 )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Floppy/DOS/Spanish)"
-	description "Inherit the Earth: Quest for the Orb (Floppy/DOS/Spanish)"
-	rom ( name "INSTR.AD" size 2982 crc 307deecb md5 undefined )
-)
-
-game (
-	name "Inherit the Earth: Quest for the Orb (Wyrmkeep CD/Macintosh)"
-	description "Inherit the Earth: Quest for the Orb (Wyrmkeep CD/Macintosh)"
-	rom ( name "crow.sound" size 21692 crc 96f8d597 md5 undefined )
-)
-
-game (
-	name "Inseparables, Les (Demo/DOS/Fanmade/French v0.2)[Unl]"
-	description "Inseparables, Les (Demo/DOS/Fanmade/French v0.2)[Unl]"
-	rom ( name "LOGDIR" size 669 crc 036d4ac0 md5 undefined )
-)
-
-game (
-	name "Inseparables, Les (DOS/Fanmade v1.0)"
-	description "Inseparables, Les (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 675 crc 5cce1daa md5 4b780887cab0ecabc5eca319acb3acf2 )
-)
-
-game (
-	name "Inside the Chest / Behind the Developer's Shield (DOS)"
-	description "Inside the Chest / Behind the Developer's Shield (DOS)"
-	rom ( name "1.HEP" size 1312 crc 45eb4de5 md5 ae906099cc559506391006be05f64c97 )
-)
-
-game (
-	name "Isabella Coq: A Present For My Dad (DOS/Fanmade)"
-	description "Isabella Coq: A Present For My Dad (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc 84e74e2f md5 undefined )
-)
-
-game (
-	name "Island of Dr. Brain, The (CD/DOS)[!]"
-	description "Island of Dr. Brain, The (CD/DOS)[!]"
-	rom ( name "130.HEP" size 1888 crc 60382630 md5 undefined )
-)
-
-game (
-	name "Island of Dr. Brain, The (Demo/DOS)"
-	description "Island of Dr. Brain, The (Demo/DOS)"
-	rom ( name "104.SND" size 38 crc 52d69bcb md5 b0571b7b3609eccc701a61b420ab742e )
-)
-
-game (
-	name "Island of Secrets Demo 0.3 (DOS/Fanmade)"
-	description "Island of Secrets Demo 0.3 (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 197790 crc ac9b9752 md5 a4db14a21b7b6ca48adb92e94f31d651 )
-)
-
-game (
-	name "J.U.L.I.A. (Demo/Greenlight/Windows)"
-	description "J.U.L.I.A. (Demo/Greenlight/Windows)"
-	rom ( name "audio.dcp" size 176965466 crc a48d7355 md5 29b58f7e887a24e7c44e6799286a9622 )
-)
-
-game (
-	name "J.U.L.I.A. (Demo/Windows)"
-	description "J.U.L.I.A. (Demo/Windows)"
-	rom ( name "audio.dcp" size 77700986 crc 1961d44f md5 undefined )
-)
-
-game (
-	name "J.U.L.I.A. (v1.2/Windows)"
-	description "J.U.L.I.A. (v1.2/Windows)"
-	rom ( name "audio.dcp" size 303351795 crc 33d7c4c8 md5 undefined )
-)
-
-game (
-	name "Jack & Julia: VAMPYR (DOS/Fanmade)"
-	description "Jack & Julia: VAMPYR (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc e30b1757 md5 8aa0b9a26f8d5a4421067ab8cc3706f6 )
-)
-
-game (
-	name "James Discovers/Explores Math (Windows)"
-	description "James Discovers/Explores Math (Windows)"
-	rom ( name "JAMES.BDF" size 1263 crc dea28191 md5 undefined )
-)
-
-game (
-	name "James Discovers/Explores Math (Windows)[a]"
-	description "James Discovers/Explores Math (Windows)[a]"
-	rom ( name "JAMES.BDF" size 1263 crc dea28191 md5 c324c763221462ebc069a23a7b4e8b34 )
-)
-
-game (
-	name "James Peris Sin Licencia ni Control (Windows/English, Spanish)[Unk]"
-	description "James Peris Sin Licencia ni Control (Windows/English, Spanish)[Unk]"
-	rom ( name "audio.dcp" size 149823811 crc d6c20b46 md5 dab79cc61b15aa4cb6abde6a3f2e6055 )
-)
-
-game (
-	name "James Peris: No License Nor Control (Demo/Windows)"
-	description "James Peris: No License Nor Control (Demo/Windows)"
-	rom ( name "audio.dcp" size 28953716 crc d3a87dfa md5 4f21835849ab0153e349b5297f646574 )
-)
-
-game (
-	name "James Peris: No License Nor Control (Demo/Windows/Spanish)"
-	description "James Peris: No License Nor Control (Demo/Windows/Spanish)"
-	rom ( name "SPANISH.ROM" size 57 crc d7c9b41b md5 undefined )
-)
-
-game (
-	name "Jeff's Quest (DOS/Fanmade v.5 alpha Jun 1)"
-	description "Jeff's Quest (DOS/Fanmade v.5 alpha Jun 1)"
-	rom ( name "LOGDIR" size 723 crc a34f6bd4 md5 undefined )
-)
-
-game (
-	name "Jeff's Quest (DOS/Fanmade v.5 alpha May 31)"
-	description "Jeff's Quest (DOS/Fanmade v.5 alpha May 31)"
-	rom ( name "LOGDIR" size 723 crc ee8f6ed8 md5 51ff71c0ed90db4e987a488ed3bf0551 )
-)
-
-game (
-	name "Jen's Quest (Demo 1/DOS/Fanmade)"
-	description "Jen's Quest (Demo 1/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 62c6eb6a md5 361afb5bdb6160213a1857245e711939 )
-)
-
-game (
-	name "Jen's Quest (Demo 2/DOS/Fanmade)"
-	description "Jen's Quest (Demo 2/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc fe07b9fc md5 3c321eee33013b289ab8775449df7df2 )
-)
-
-game (
-	name "Jiggy Jiggy Uh! Uh! (DOS/Fanmade)"
-	description "Jiggy Jiggy Uh! Uh! (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 297 crc f9f52c95 md5 undefined )
-)
-
-game (
-	name "Jim's Quest 1: The Phantom Thesis (DOS/Fanmade)"
-	description "Jim's Quest 1: The Phantom Thesis (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 496446 crc c2868b6d md5 018d82115b019fb3b74f3560f61039a7 )
-)
-
-game (
-	name "Jimmy In: The Alien Attack (DOS/Fanmade v0.1)"
-	description "Jimmy In: The Alien Attack (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 300 crc b9ac36f1 md5 undefined )
-)
-
-game (
-	name "Joe McMuffin In 'What's Cooking, Doc' (DOS/Fanmade v1.0)"
-	description "Joe McMuffin In 'What's Cooking, Doc' (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 0c313be8 md5 undefined )
-)
-
-game (
-	name "Jolimie, le Village Maudit (DOS/Fanmade/French v0.5)"
-	description "Jolimie, le Village Maudit (DOS/Fanmade/French v0.5)"
-	rom ( name "LOGDIR" size 669 crc e3fb1b38 md5 undefined )
-)
-
-game (
-	name "Jolimie, le Village Maudit (DOS/Fanmade/French v1.1)"
-	description "Jolimie, le Village Maudit (DOS/Fanmade/French v1.1)"
-	rom ( name "LOGDIR" size 669 crc 1b49859e md5 undefined )
-)
-
-game (
-	name "Jones in the Fast Lane (CD/DOS)"
-	description "Jones in the Fast Lane (CD/DOS)"
-	rom ( name "1001.SND" size 370 crc 2df7633f md5 undefined )
-)
-
-game (
-	name "Jones in the Fast Lane (CD/Windows)"
-	description "Jones in the Fast Lane (CD/Windows)"
-	rom ( name "AUDIO001.002" size 23126016 crc 420ab4b1 md5 0e7d1d15dcbcabd9ccfaf9eca1792df4 )
-)
-
-game (
-	name "Jones in the Fast Lane (DOS)[1x1.44MB]"
-	description "Jones in the Fast Lane (DOS)[1x1.44MB]"
-	rom ( name "RESOURCE.001" size 994487 crc 2545b160 md5 undefined )
-)
-
-game (
-	name "Jones in the Fast Lane (DOS)[2x720KB]"
-	description "Jones in the Fast Lane (DOS)[2x720KB]"
-	rom ( name "RESOURCE.001" size 313476 crc a0a2d94e md5 56166eb58bc48f072cfd77e4aa1418d7 )
-)
-
-game (
-	name "Jones in the Fast Lane (DOS/EGA)[2x360KB]"
-	description "Jones in the Fast Lane (DOS/EGA)[2x360KB]"
-	rom ( name "RESOURCE.001" size 202105 crc c0cf7df6 md5 fb0f52ef2ef417c3ef6789170f738774 )
-)
-
-game (
-	name "Jones in the Fast Lane (DOS/EGA)[a]"
-	description "Jones in the Fast Lane (DOS/EGA)[a]"
-	rom ( name "RESOURCE.001" size 511528 crc 3264b567 md5 365cda97ea2850e0c3fc8e2c816a25b7 )
-)
-
-game (
-	name "Joulumaa (DOS/Fanmade/Estonian v0.05)"
-	description "Joulumaa (DOS/Fanmade/Estonian v0.05)"
-	rom ( name "LOGDIR" size 300 crc 408e5de7 md5 undefined )
-)
-
-game (
-	name "Journey Of Chef (DOS/Fanmade)"
-	description "Journey Of Chef (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc d63e506c md5 undefined )
-)
-
-game (
-	name "Journeyman Project, The: Pegasus Prime (Demo/DVD/Windows)"
-	description "Journeyman Project, The: Pegasus Prime (Demo/DVD/Windows)"
-	rom ( name "._Images" size 82 crc 77238e0d md5 e86c11b3d51d7a3a7ee390bbe6092820 )
-)
-
-game (
-	name "Journeyman Project, The: Pegasus Prime (Demo/Macintosh)"
-	description "Journeyman Project, The: Pegasus Prime (Demo/Macintosh)"
-	rom ( name "._JMP PP Resources" size 365350 crc 6b8eea24 md5 071ee3bb6b8e238990b0f5adf7a9a179 )
-)
-
-game (
-	name "Journeyman Project, The: Pegasus Prime (Macintosh)"
-	description "Journeyman Project, The: Pegasus Prime (Macintosh)"
-	rom ( name "._JMP PP Resources" size 2019328 crc 76d8b17e md5 undefined )
-)
-
-game (
-	name "Jukebox (DOS/Fanmade v1.0)"
-	description "Jukebox (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 431ea038 md5 undefined )
-)
-
-game (
-	name "Jumble (Macintosh)"
-	description "Jumble (Macintosh)"
-	rom ( name "._LSJUMBLE" size 671744 crc af3ad4ad md5 665e012faccc47bd52d7df2d6cfb7c94 )
-)
-
-game (
-	name "Justin Quest (DOS/Fanmade v1.0 in development)"
-	description "Justin Quest (DOS/Fanmade v1.0 in development)"
-	rom ( name "LOGDIR" size 303 crc 183b7d2c md5 103050989da7e0ffdc1c5e1793a4e1ec )
-)
-
-game (
-	name "Karth of the Jungle (Macintosh)"
-	description "Karth of the Jungle (Macintosh)"
-	rom ( name "._Karth of the Jungle" size 99700 crc 7028617a md5 f3a25bdc9c25ab76470b98b596a77156 )
-)
-
-game (
-	name "Karth of the Jungle (Macintosh)[a]"
-	description "Karth of the Jungle (Macintosh)[a]"
-	rom ( name "._Karth of the Jungle" size 99365 crc fecb5295 md5 b5082becdc8537afd6a23f89700deced )
-)
-
-game (
-	name "Karth of the Jungle II (Macintosh)"
-	description "Karth of the Jungle II (Macintosh)"
-	rom ( name "._Karth of the Jungle II" size 204480 crc 39209dcb md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (Amiga)"
-	description "King's Quest I: Quest for the Crown (Amiga)"
-	rom ( name "LOGDIR" size 315 crc 986832ae md5 246c695324f1c514aee2b904fa352fad )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (Apple IIgs)"
-	description "King's Quest I: Quest for the Crown (Apple IIgs)"
-	rom ( name "KQ.SYS16" size 141894 crc 052faf4e md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (Atari ST)"
-	description "King's Quest I: Quest for the Crown (Atari ST)"
-	rom ( name "LOGDIR" size 315 crc 12ceb49f md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (CoCo3/Updated)"
-	description "King's Quest I: Quest for the Crown (CoCo3/Updated)"
-	rom ( name "logDir" size 315 crc 24bf85a7 md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (Demo/SCI/DOS)"
-	description "King's Quest I: Quest for the Crown (Demo/SCI/DOS)"
-	rom ( name "RESOURCE.001" size 296555 crc a87a1073 md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (DOS)"
-	description "King's Quest I: Quest for the Crown (DOS)"
-	rom ( name "LOGDIR" size 315 crc 4d098292 md5 10ad66e2ecbd66951534a50aedcd0128 )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (DOS/EGA)[9x360KB]"
-	description "King's Quest I: Quest for the Crown (DOS/EGA)[9x360KB]"
-	rom ( name "RESOURCE.001" size 196027 crc a465b63f md5 b1f6dda438728eefe5c8a0b75188ab23 )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (Macintosh)"
-	description "King's Quest I: Quest for the Crown (Macintosh)"
-	rom ( name "LOGDIR" size 384 crc c1c4ff27 md5 d4c4739d4ac63f7dbd29255425077d48 )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (SCI Remake-DOS)[3x720KB]"
-	description "King's Quest I: Quest for the Crown (SCI Remake-DOS)[3x720KB]"
-	rom ( name "RESOURCE.001" size 555439 crc 53cb0dcb md5 undefined )
-)
-
-game (
-	name "King's Quest I: Quest for the Crown (SCI/Amiga)"
-	description "King's Quest I: Quest for the Crown (SCI/Amiga)"
-	rom ( name "PATCH.005" size 243154 crc 1fd83967 md5 undefined )
-)
-
-game (
-	name "King's Quest II SCI Pre-Alpha Version (DOS/Fanmade)"
-	description "King's Quest II SCI Pre-Alpha Version (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 2310356 crc 470df20d md5 9a73a42b397cf9ba3e3730684105f340 )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (Amiga)"
-	description "King's Quest II: Romancing the Throne (Amiga)"
-	rom ( name "LOGDIR" size 543 crc d26e944b md5 undefined )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (Apple IIgs)"
-	description "King's Quest II: Romancing the Throne (Apple IIgs)"
-	rom ( name "KQ2.SYS16" size 143775 crc f5248e88 md5 b227bd9328fb6dbca404abcd05de56fe )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (CoCo3/Updated)"
-	description "King's Quest II: Romancing the Throne (CoCo3/Updated)"
-	rom ( name "logDir" size 543 crc fe7dbfb1 md5 f64a606de740a5348f3d125c03e989fe )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (DOS/2.1)"
-	description "King's Quest II: Romancing the Throne (DOS/2.1)"
-	rom ( name "LOGDIR" size 543 crc df28f8c8 md5 759e39f891a0e1d86dd29d7de485c6ac )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (DOS/2.2)"
-	description "King's Quest II: Romancing the Throne (DOS/2.2)"
-	rom ( name "LOGDIR" size 543 crc a9a679c2 md5 undefined )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (DOS/Russian)"
-	description "King's Quest II: Romancing the Throne (DOS/Russian)"
-	rom ( name "LOGDIR" size 543 crc d0bff53a md5 35211c574ececebdc723b23e35f99275 )
-)
-
-game (
-	name "King's Quest II: Romancing the Throne (Macintosh)"
-	description "King's Quest II: Romancing the Throne (Macintosh)"
-	rom ( name "LOGDIR" size 640 crc ac85beb5 md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Amiga/1.01)"
-	description "King's Quest III: To Heir is Human (Amiga/1.01)"
-	rom ( name "LOGDIR" size 390 crc 3e5f084b md5 8ab343306df0e2d98f136be4e8cfd0ef )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Amiga/2.15)"
-	description "King's Quest III: To Heir is Human (Amiga/2.15)"
-	rom ( name "DIRS" size 1805 crc 49051684 md5 8e35bded2bc5cf20f5eec2b15523b155 )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Apple IIgs/2.0A)"
-	description "King's Quest III: To Heir is Human (Apple IIgs/2.0A)"
-	rom ( name "KQ3.SYS16" size 144312 crc cdbc06c8 md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Atari ST/1.02)"
-	description "King's Quest III: To Heir is Human (Atari ST/1.02)"
-	rom ( name "LOGDIR" size 390 crc 9a7fe35c md5 8846df2654302b623217ba8bd6d657a9 )
-)
-
-game (
-	name "King's Quest III: To Heir Is Human (CoCo3)"
-	description "King's Quest III: To Heir Is Human (CoCo3)"
-	rom ( name "logDir" size 429 crc ee4d928b md5 5a6be7d16b1c742c369ef5cc64fefdd2 )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (DOS/1.01)"
-	description "King's Quest III: To Heir is Human (DOS/1.01)"
-	rom ( name "LOGDIR" size 390 crc f16aa84c md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (DOS/2.00)"
-	description "King's Quest III: To Heir is Human (DOS/2.00)"
-	rom ( name "LOGDIR" size 390 crc 89469be1 md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (DOS/2.14)"
-	description "King's Quest III: To Heir is Human (DOS/2.14)"
-	rom ( name "LOGDIR" size 390 crc 87e235be md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (DOS/Russian)"
-	description "King's Quest III: To Heir is Human (DOS/Russian)"
-	rom ( name "KQ3.OVR" size 21150 crc ef66f25e md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Macintosh/2.14 5.25')"
-	description "King's Quest III: To Heir is Human (Macintosh/2.14 5.25')"
-	rom ( name "LOGDIR" size 390 crc a8508d8c md5 undefined )
-)
-
-game (
-	name "King's Quest III: To Heir is Human (Macintosh/2.14)"
-	description "King's Quest III: To Heir is Human (Macintosh/2.14)"
-	rom ( name "LOGDIR" size 512 crc 288d0f9d md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (Apple IIgs/1.0K)"
-	description "King's Quest IV: The Perils of Rosella (Apple IIgs/1.0K)"
-	rom ( name "KQ4.SYS16" size 147652 crc ca5693a6 md5 409a222a483baaa5a6cdf3e253c83d05 )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (Demo/DOS)"
-	description "King's Quest IV: The Perils of Rosella (Demo/DOS)"
-	rom ( name "DMDIR" size 2711 crc 38040e0f md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (Demo/SCI/DOS)"
-	description "King's Quest IV: The Perils of Rosella (Demo/SCI/DOS)"
-	rom ( name "RESOURCE.001" size 205330 crc fd589eaa md5 aca24141ff9564001201150d22ec193b )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (DOS/2.0)"
-	description "King's Quest IV: The Perils of Rosella (DOS/2.0)"
-	rom ( name "KQ4DIR" size 2786 crc da8ed9b8 md5 fe44655c42f16c6f81046fdf169b6337 )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (DOS/2.3)"
-	description "King's Quest IV: The Perils of Rosella (DOS/2.3)"
-	rom ( name "KQ4DIR" size 2786 crc e7fbec15 md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/Amiga)[v1.023]"
-	description "King's Quest IV: The Perils of Rosella (SCI/Amiga)[v1.023]"
-	rom ( name "BANK.001" size 248163 crc c84bfe72 md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/Atari ST)[v1.003.006]"
-	description "King's Quest IV: The Perils of Rosella (SCI/Atari ST)[v1.003.006]"
-	rom ( name "QAFILE" size 155 crc 25f98d9e md5 b1a2eec545f7045c9b376c426c23f588 )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/DOS)"
-	description "King's Quest IV: The Perils of Rosella (SCI/DOS)"
-	rom ( name "08060219" size 1309 crc 99f9517f md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.000.106]"
-	description "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.000.106]"
-	rom ( name "ADL.DRV" size 5727 crc 8cfbf2db md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.000.111]"
-	description "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.000.111]"
-	rom ( name "ADL.DRV" size 5727 crc 8cfbf2db md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.006.004][4x720KB]"
-	description "King's Quest IV: The Perils of Rosella (SCI/DOS)[v1.006.004][4x720KB]"
-	rom ( name "RESOURCE.001" size 452523 crc 791aa1a3 md5 undefined )
-)
-
-game (
-	name "King's Quest IV: The Perils of Rosella (SCI/DOS/EGA)[v1.006.004]"
-	description "King's Quest IV: The Perils of Rosella (SCI/DOS/EGA)[v1.006.004]"
-	rom ( name "RESOURCE.001" size 174852 crc 235b9a11 md5 10a31bc36f57fe830f99d1b904e3be84 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (Amiga)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (Amiga)"
-	rom ( name "756.SCR" size 548 crc 0f119f93 md5 8337df5a5c1dc99b759d83c3c9a22f1b )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (Amiga/German)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (Amiga/German)"
-	rom ( name "9.PAT" size 202522 crc 1b9d0816 md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (Amiga/Italian)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (Amiga/Italian)"
-	rom ( name "109.SCR" size 8302 crc ffb23ce7 md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (CD/DOS)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (CD/DOS)"
-	rom ( name "0.SCR" size 9960 crc a4780234 md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[8x1.44MB]"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[8x1.44MB]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 4ff2dc339352972581da584cc0a8d2f1 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[9x1.44MB]"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[9x1.44MB]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 4ff2dc339352972581da584cc0a8d2f1 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[a]"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS)[a]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 4ff2dc339352972581da584cc0a8d2f1 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/EGA)[9x720KB]"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/EGA)[9x720KB]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/French)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/French)"
-	rom ( name "RESOURCE.000" size 332806 crc 8ce322f8 md5 c5a3b5c8c0908aeeeb1b015e6a6bbc08 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/German)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/German)"
-	rom ( name "RESOURCE.000" size 336826 crc 0a2ab8cb md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Italian)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Italian)"
-	rom ( name "RESOURCE.000" size 332246 crc 4352c151 md5 2483da36d360751eed198a804a54c710 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Russian)[Unk]"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Russian)[Unk]"
-	rom ( name "RESOURCE.000" size 12926878 crc 709fd949 md5 05b374f4ac1a704b04479411b4f6779a )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Spanish)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (DOS/Spanish)"
-	rom ( name "RESOURCE.000" size 335871 crc 698326e3 md5 undefined )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (FM-Towns)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (FM-Towns)"
-	rom ( name "AUDIO001.002" size 104992768 crc edfdca4d md5 50d33e4d1ff7ad2396ef20e64c4ad98c )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (FM-Towns/Japanese)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (FM-Towns/Japanese)"
-	rom ( name "AUDIO081.002" size 124477440 crc bd66a49c md5 09cb5e6ac4c295fe9d5b355fea750578 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (Macintosh)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (Macintosh)"
-	rom ( name "1.PAT" size 16902 crc 915659aa md5 d5deabbbe2ad59b37707ce9d82917970 )
-)
-
-game (
-	name "King's Quest V: Absence Makes the Heart Go Yonder (PC-98/Japanese)"
-	description "King's Quest V: Absence Makes the Heart Go Yonder (PC-98/Japanese)"
-	rom ( name "RESOURCE.000" size 493681 crc ee33379b md5 23e07b0d1d56fa2a061d9abc7c0ffd00 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (CD/DOS)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (CD/DOS)"
-	rom ( name "VERSION" size 45 crc f2472c07 md5 c1c0a978082b41ee8fdea67f34896cd8 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (CD/Windows)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (CD/Windows)"
-	rom ( name "HDLOGO.AVI" size 1204352 crc 61cec9ff md5 undefined )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (Demo/CD/DOS)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (Demo/CD/DOS)"
-	rom ( name "100.HEP" size 1396 crc 303158c4 md5 a71cc16aa2177be78eb2c09b4200df44 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (Demo/DOS)[!]"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (Demo/DOS)[!]"
-	rom ( name "1002.SYN" size 188 crc e149c8ff md5 d520e8270657f583a4fee39d6eab28d3 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (DOS)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (DOS)"
-	rom ( name "100.HEP" size 1272 crc c03d9f74 md5 undefined )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (DOS/French)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (DOS/French)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 75a70717e0b3b4efcbb692fe369060d3 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (DOS/German)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (DOS/German)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 75a70717e0b3b4efcbb692fe369060d3 )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (DOS/Italian)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (DOS/Italian)"
-	rom ( name "100.HEP" size 1392 crc 8469d894 md5 undefined )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (DOS/Spanish)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (DOS/Spanish)"
-	rom ( name "1002.SYN" size 188 crc e149c8ff md5 undefined )
-)
-
-game (
-	name "King's Quest VI: Heir Today, Gone Tomorrow (Macintosh)"
-	description "King's Quest VI: Heir Today, Gone Tomorrow (Macintosh)"
-	rom ( name "._AAA" size 70 crc ac20e34e md5 undefined )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (Demo/DOS)"
-	description "King's Quest VII: The Princeless Bride (Demo/DOS)"
-	rom ( name "65535.MAP" size 82 crc 64c15ada md5 undefined )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (Demo/Windows)"
-	description "King's Quest VII: The Princeless Bride (Demo/Windows)"
-	rom ( name "RESOURCE.000" size 84020382 crc 8112b402 md5 dbfdb47fcb200a56e09418b9416c4683 )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (DOS)[!]"
-	description "King's Quest VII: The Princeless Bride (DOS)[!]"
-	rom ( name "30.HEP" size 1174 crc 622a4365 md5 undefined )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (DOS/German)[!]"
-	description "King's Quest VII: The Princeless Bride (DOS/German)[!]"
-	rom ( name "0.CHK" size 138652 crc ef6cd919 md5 69f0051217b108b75d9f2d996f3aeba9 )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (DOS/Spanish)"
-	description "King's Quest VII: The Princeless Bride (DOS/Spanish)"
-	rom ( name "30.HEP" size 1422 crc 61df4a57 md5 e22d824db566a83ba2525a0bbf591283 )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (Windows)[!]"
-	description "King's Quest VII: The Princeless Bride (Windows)[!]"
-	rom ( name "ALTRES.MDT" size 466 crc 655d305a md5 undefined )
-)
-
-game (
-	name "King's Quest VII: The Princeless Bride (Windows)[a][!]"
-	description "King's Quest VII: The Princeless Bride (Windows)[a][!]"
-	rom ( name "0.CHK" size 142338 crc 73bd7d20 md5 5caa0146b19c3822d930a0108210f37b )
-)
-
-game (
-	name "King's Questions (DOS)"
-	description "King's Questions (DOS)"
-	rom ( name "RESOURCE.000" size 162697 crc 27d2391b md5 undefined )
-)
-
-game (
-	name "Kings Quest 2: Breast Intentions (DOS/Fanmade v2.0 Aug 16)"
-	description "Kings Quest 2: Breast Intentions (DOS/Fanmade v2.0 Aug 16)"
-	rom ( name "LOGDIR" size 471 crc 6dcc6f0d md5 6b4f796d0421d2e12e501b511962e03a )
-)
-
-game (
-	name "Kings Quest 2: Breast Intentions (DOS/Fanmade v2.0 Mar 26)"
-	description "Kings Quest 2: Breast Intentions (DOS/Fanmade v2.0 Mar 26)"
-	rom ( name "LOGDIR" size 471 crc f334b393 md5 undefined )
-)
-
-game (
-	name "Kite, The (v1.0/Windows/Russian)[Unk]"
-	description "Kite, The (v1.0/Windows/Russian)[Unk]"
-	rom ( name "data.dcp" size 47571404 crc a0bfc456 md5 undefined )
-)
-
-game (
-	name "Kite, The (v1.1/Windows)"
-	description "Kite, The (v1.1/Windows)"
-	rom ( name "data.dcp" size 47332296 crc 74452c37 md5 fbad6022ec1e2778c1aff57342fd6ae3 )
-)
-
-game (
-	name "Kite, The (v1.2.e/Windows)"
-	description "Kite, The (v1.2.e/Windows)"
-	rom ( name "data.dcp" size 47360539 crc a2cb68d2 md5 undefined )
-)
-
-game (
-	name "Kite, The (v1.2.i/Windows/Italian)"
-	description "Kite, The (v1.2.i/Windows/Italian)"
-	rom ( name "data.dcp" size 47509274 crc ee3ab7b0 md5 1b5ba0214cb37921042dac626e1f4c88 )
-)
-
-game (
-	name "Kite, The (v1.2.r/Windows/Russian)"
-	description "Kite, The (v1.2.r/Windows/Russian)"
-	rom ( name "data.dcp" size 47554582 crc efa782e4 md5 undefined )
-)
-
-game (
-	name "Kite, The (v1.3.e/Windows)"
-	description "Kite, The (v1.3.e/Windows)"
-	rom ( name "data.dcp" size 47382987 crc d9d33d49 md5 7787616da3ea58356e55399db05e5c99 )
-)
-
-game (
-	name "Knight's Quest Demo 1.0 (DOS/Fanmade)"
-	description "Knight's Quest Demo 1.0 (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 703836 crc 4deb2526 md5 95d6638920be149a517446b23ba7e895 )
-)
-
-game (
-	name "Kulivocko (Demo/Windows/Czech)"
-	description "Kulivocko (Demo/Windows/Czech)"
-	rom ( name "dabing.dcp" size 24277025 crc c035f6f0 md5 b94dc38402953f5a6ecc5ca3877e7b5e )
-)
-
-game (
-	name "Kulivocko (Windows/Czech)"
-	description "Kulivocko (Windows/Czech)"
-	rom ( name "dabing.dcp" size 27092957 crc 51262f5c md5 f5cba572f4cab47323386317f0ef6635 )
-)
-
-game (
-	name "Labyrinth of Time (Amiga)[!]"
-	description "Labyrinth of Time (Amiga)[!]"
-	rom ( name "Assign" size 3008 crc daede154 md5 undefined )
-)
-
-game (
-	name "Labyrinth of Time (DOS)"
-	description "Labyrinth of Time (DOS)"
-	rom ( name "FONTS\AVG13" size 5055 crc 48c7e276 md5 9fc7111acd455c1db9749bdac06eacec )
-)
-
-game (
-	name "Labyrinth of Time (Lowres/DOS)"
-	description "Labyrinth of Time (Lowres/DOS)"
-	rom ( name "FONTS\AVG13" size 5055 crc 48c7e276 md5 9fc7111acd455c1db9749bdac06eacec )
-)
-
-game (
-	name "Labyrinth of Time (Rerelease/Windows)[GOG][!]"
-	description "Labyrinth of Time (Rerelease/Windows)[GOG][!]"
-	rom ( name "FONTS\AVG13" size 5055 crc 48c7e276 md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS)[!]"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS)[!]"
-	rom ( name "L01.PAK" size 68733 crc aa0e9f3f md5 759a0ac26808d77ea968bd392355ba1d )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS)[RU]"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS)[RU]"
-	rom ( name "ENG\BLEND.TAB" size 65536 crc 61e897b8 md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS/Fanmade Italian)"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS/Fanmade Italian)"
-	rom ( name "L01.PAK" size 73317 crc 84877cc6 md5 898485c0eb7bb4403fdd63bf5191f37e )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS/French)[!]"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS/French)[!]"
-	rom ( name "L01.PAK" size 68733 crc aa0e9f3f md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS/French)[RU]"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS/French)[RU]"
-	rom ( name "FRE\BLEND.TAB" size 65536 crc 61e897b8 md5 a19778df81d895d2dc8fbd5bb29a5e5f )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS/German)[!]"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS/German)[!]"
-	rom ( name "L01.PAK" size 68733 crc aa0e9f3f md5 759a0ac26808d77ea968bd392355ba1d )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (CD/DOS/Russian)"
-	description "Lands of Lore: The Throne of Chaos (CD/DOS/Russian)"
-	rom ( name "GER\BLEND.TAB" size 65536 crc 61e897b8 md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Demo/DOS)"
-	description "Lands of Lore: The Throne of Chaos (Demo/DOS)"
-	rom ( name "GENERAL.PAK" size 1847363 crc 02dbc83c md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Demo/DOS)[a]"
-	description "Lands of Lore: The Throne of Chaos (Demo/DOS)[a]"
-	rom ( name "INTRO.PAK" size 872550 crc d9569a77 md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (DOS)[v1.05]"
-	description "Lands of Lore: The Throne of Chaos (DOS)[v1.05]"
-	rom ( name "WESTWOOD.1" size 1352193 crc 0db6905f md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (DOS/German)"
-	description "Lands of Lore: The Throne of Chaos (DOS/German)"
-	rom ( name "WESTWOOD.1" size 1352193 crc 7397b563 md5 1e3b28720045f5020a077804e794d5f3 )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Extracted/DOS)[v1.05]"
-	description "Lands of Lore: The Throne of Chaos (Extracted/DOS)[v1.05]"
-	rom ( name "CHAPTER1.PAK" size 2287611 crc d1d7899b md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Extracted/DOS)[v1.23]"
-	description "Lands of Lore: The Throne of Chaos (Extracted/DOS)[v1.23]"
-	rom ( name "CHAPTER1.PAK" size 2287524 crc 47e9057a md5 a1741ca1cf0f189f5c066372ddac8af7 )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Extracted/DOS/French)[v1.23]"
-	description "Lands of Lore: The Throne of Chaos (Extracted/DOS/French)[v1.23]"
-	rom ( name "CHAPTER1.PAK" size 2290368 crc 8c0f72a9 md5 undefined )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Extracted/DOS/German)[v1.20a]"
-	description "Lands of Lore: The Throne of Chaos (Extracted/DOS/German)[v1.20a]"
-	rom ( name "CHAPTER1.PAK" size 2290569 crc fd629a8c md5 57de18be610942594d42566451595589 )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (Extracted/DOS/Russian)[v1.05]"
-	description "Lands of Lore: The Throne of Chaos (Extracted/DOS/Russian)[v1.05]"
-	rom ( name "CHAPTER1.PAK" size 2288096 crc 2cebce63 md5 904e2c33ca64542691f0e8f19bb8815b )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (FM-Towns/Japanese)"
-	description "Lands of Lore: The Throne of Chaos (FM-Towns/Japanese)"
-	rom ( name "CHAPTER1.PAK" size 2114628 crc 05cd48f0 md5 f0bdede2e82774e26ee42064a24b48ea )
-)
-
-game (
-	name "Lands of Lore: The Throne of Chaos (PC-98/Japanese)"
-	description "Lands of Lore: The Throne of Chaos (PC-98/Japanese)"
-	rom ( name "CHAPTER1.PAK" size 1819609 crc f1d8c7cc md5 70605f0a8783ad8fc1c5182ec4c63001 )
-)
-
-game (
-	name "Lasse Holm: The Quest for Revenge (DOS/Fanmade v1.0)"
-	description "Lasse Holm: The Quest for Revenge (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 1ab3ef01 md5 f9fbcc8a4ef510bfbb92423296ff4abb )
-)
-
-game (
-	name "Last Dynasty, The (Demo/DOS/US)"
-	description "Last Dynasty, The (Demo/DOS/US)"
-	rom ( name "CD1.ITK" size 46491648 crc 95d6d305 md5 9ebf86d8b20c543921a7c581aa171506 )
-)
-
-game (
-	name "Last Dynasty, The (Demo/Windows/German)"
-	description "Last Dynasty, The (Demo/Windows/German)"
-	rom ( name "LDA1.ITK" size 7563264 crc 6da84d5c md5 b7041458b884017d32185ce4d1d5db64 )
-)
-
-game (
-	name "Last Dynasty, The (DOS/French)"
-	description "Last Dynasty, The (DOS/French)"
-	rom ( name "CD1.ITK" size 435189760 crc 62402128 md5 undefined )
-)
-
-game (
-	name "Last Dynasty, The (DOS/German)"
-	description "Last Dynasty, The (DOS/German)"
-	rom ( name "CD1.ITK" size 447031296 crc 0c07bf33 md5 ead31d41231b7507de5fd5f7abb8d123 )
-)
-
-game (
-	name "Last Dynasty, The (DOS/UK)[!]"
-	description "Last Dynasty, The (DOS/UK)[!]"
-	rom ( name "CD1.ITK" size 439568384 crc 802f3dd0 md5 undefined )
-)
-
-game (
-	name "Last Dynasty, The (DOS/US)"
-	description "Last Dynasty, The (DOS/US)"
-	rom ( name "CD1.ITK" size 438974464 crc d17d1cbd md5 199a71275b86014fd73637d85125a4d4 )
-)
-
-game (
-	name "Last Express, The (Demo)"
-	description "Last Express, The (Demo)"
-	rom ( name "BLUE.EGG" size 0 crc - md5 undefined )
-)
-
-game (
-	name "Last Express, The (French)"
-	description "Last Express, The (French)"
-	rom ( name "CD1.HPF" size 522924032 crc 879240cb md5 undefined )
-)
-
-game (
-	name "Last Express, The (German)"
-	description "Last Express, The (German)"
-	rom ( name "CD1.HPF" size 522971136 crc 4402772b md5 f5e5cb1f50b431e3203cc9977d87c8cd )
-)
-
-game (
-	name "Last Express, The (Italian)"
-	description "Last Express, The (Italian)"
-	rom ( name "CD1.HPF" size 522328064 crc 5d4af08d md5 undefined )
-)
-
-game (
-	name "Last Express, The (Russian)"
-	description "Last Express, The (Russian)"
-	rom ( name "CD1.HPF" size 525805568 crc 0b775991 md5 undefined )
-)
-
-game (
-	name "Last Express, The (Spanish)"
-	description "Last Express, The (Spanish)"
-	rom ( name "CD1.HPF" size 519927808 crc undefined md5 undefined )
-)
-
-game (
-	name "Last Express, The (UK/Interplay)"
-	description "Last Express, The (UK/Interplay)"
-	rom ( name "CD1.HPF" size 525522944 crc 9fda61d1 md5 cec8810125b050f41b7f34ab72371f81 )
-)
-
-game (
-	name "Last Express, The (US/Broderbund)[!]"
-	description "Last Express, The (US/Broderbund)[!]"
-	rom ( name "CD1.HPF" size 525522944 crc abd86705 md5 d70d8a5eb03de64f6b62acb4abf4411b )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (CD/DOS)[!]"
-	description "Laura Bow 2: The Dagger of Amon Ra (CD/DOS)[!]"
-	rom ( name "100.HEP" size 1408 crc 4b11d3d4 md5 undefined )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (CD/DOS/Spanish)"
-	description "Laura Bow 2: The Dagger of Amon Ra (CD/DOS/Spanish)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 undefined )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (Demo/DOS)"
-	description "Laura Bow 2: The Dagger of Amon Ra (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 781912 crc 79311d92 md5 5626ce0a06369013612fd9dfb33ca6f0 )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (DOS v1.0)"
-	description "Laura Bow 2: The Dagger of Amon Ra (DOS v1.0)"
-	rom ( name "0.HEP" size 2508 crc c14bbf55 md5 undefined )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (DOS v1.1)"
-	description "Laura Bow 2: The Dagger of Amon Ra (DOS v1.1)"
-	rom ( name "310.HEP" size 2486 crc ec4186c2 md5 ee999c9f9bfabba0557da4a3fc6b1c10 )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (DOS/French)"
-	description "Laura Bow 2: The Dagger of Amon Ra (DOS/French)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 undefined )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (DOS/German)"
-	description "Laura Bow 2: The Dagger of Amon Ra (DOS/German)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 75a70717e0b3b4efcbb692fe369060d3 )
-)
-
-game (
-	name "Laura Bow 2: The Dagger of Amon Ra (DOS/Spanish)"
-	description "Laura Bow 2: The Dagger of Amon Ra (DOS/Spanish)"
-	rom ( name "0.FON" size 2799 crc 34ac739d md5 undefined )
-)
-
-game (
-	name "Laura Bow: The Colonel's Bequest (Amiga)"
-	description "Laura Bow: The Colonel's Bequest (Amiga)"
-	rom ( name "BANK.001" size 242018 crc 1ea587eb md5 undefined )
-)
-
-game (
-	name "Laura Bow: The Colonel's Bequest (Atari ST)"
-	description "Laura Bow: The Colonel's Bequest (Atari ST)"
-	rom ( name "RESOURCE.001" size 515964 crc 8957605b md5 7e47fcdbc802a929d5c0ed0814746b7b )
-)
-
-game (
-	name "Laura Bow: The Colonel's Bequest (Demo/DOS)"
-	description "Laura Bow: The Colonel's Bequest (Demo/DOS)"
-	rom ( name "PATCH.101" size 800 crc 267b9c79 md5 undefined )
-)
-
-game (
-	name "Laura Bow: The Colonel's Bequest (DOS)"
-	description "Laura Bow: The Colonel's Bequest (DOS)"
-	rom ( name "RESOURCE.001" size 108032 crc 6c814ca3 md5 undefined )
-)
-
-game (
-	name "Laura Bow: The Colonel's Bequest (DOS)[a]"
-	description "Laura Bow: The Colonel's Bequest (DOS)[a]"
-	rom ( name "RESOURCE.001" size 515788 crc 8053a408 md5 7558c92c4bfbd5e17f0b73023a731f89 )
-)
-
-game (
-	name "Lawman for Hire (DOS/Fanmade)"
-	description "Lawman for Hire (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc 7ed113bc md5 undefined )
-)
-
-game (
-	name "Leather Goddesses of Phobos 2 (DOS)"
-	description "Leather Goddesses of Phobos 2 (DOS)"
-	rom ( name "LGOP2.DAT" size 280280 crc 28c0ef4b md5 abcf043701ec480898829091a9efccd6 )
-)
-
-game (
-	name "Leather Goddesses of Phobos 2 (DOS/French)"
-	description "Leather Goddesses of Phobos 2 (DOS/French)"
-	rom ( name "LGOP2.DAT" size 295366 crc 2c13f4c6 md5 72916dc8b7f3c66e6fb175407f44bade )
-)
-
-game (
-	name "Leather Goddesses of Phobos 2 (DOS/German)"
-	description "Leather Goddesses of Phobos 2 (DOS/German)"
-	rom ( name "LGOP2.DAT" size 299466 crc 8c9b6a0a md5 77e4343fe572200926a4148e7834ad4c )
-)
-
-game (
-	name "Leather Goddesses of Phobos 2 (DOS/Spanish)"
-	description "Leather Goddesses of Phobos 2 (DOS/Spanish)"
-	rom ( name "LGOP2.DAT" size 288984 crc e51cb965 md5 0a1ac397f2fe6b68961b0b89682d22db )
-)
-
-game (
-	name "Lefty Goes on Vacation (Not in The Right Place) (DOS/Fanmade)"
-	description "Lefty Goes on Vacation (Not in The Right Place) (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 603 crc 8574b081 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Amiga)"
-	description "Legend of Kyrandia, The (Amiga)"
-	rom ( name "8FAT.FNT" size 14706 crc e6dd51bf md5 47233fbc79fcf6beb5da9d7f5d5647c5 )
-)
-
-game (
-	name "Legend of Kyrandia, The (Amiga/German)"
-	description "Legend of Kyrandia, The (Amiga/German)"
-	rom ( name "8FAT.FNT" size 14706 crc e6dd51bf md5 47233fbc79fcf6beb5da9d7f5d5647c5 )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/DOS)[!]"
-	description "Legend of Kyrandia, The (CD/DOS)[!]"
-	rom ( name "ALCHEMY.PAK" size 20670 crc b117666a md5 5e20ffd2f9c3866396ca57f81af94ed8 )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/DOS/French)[!]"
-	description "Legend of Kyrandia, The (CD/DOS/French)[!]"
-	rom ( name "ALCHEMY.PAK" size 20696 crc 7af1cd1e md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/DOS/German)[!]"
-	description "Legend of Kyrandia, The (CD/DOS/German)[!]"
-	rom ( name "ALCHEMY.PAK" size 20700 crc f4513656 md5 f1f8e2aa641221064602412bb8e8ad99 )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/DOS/Italian)[!]"
-	description "Legend of Kyrandia, The (CD/DOS/Italian)[!]"
-	rom ( name "_KYRA000.SAV" size 1698 crc 139bc5c1 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/FM-Towns)"
-	description "Legend of Kyrandia, The (CD/FM-Towns)"
-	rom ( name "EMC.PAK" size 167021 crc 388c2112 md5 a046bb0b422061aab8e4c4689400343a )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/FM-Towns/Japanese)"
-	description "Legend of Kyrandia, The (CD/FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 b91300e55b70227ce98b59c5f02fa8dd )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/Macintosh)"
-	description "Legend of Kyrandia, The (CD/Macintosh)"
-	rom ( name "._LK" size 770048 crc 3a20350d md5 f58a2be3fbf01ca364b20b4f8b890b75 )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/Macintosh/French)"
-	description "Legend of Kyrandia, The (CD/Macintosh/French)"
-	rom ( name "._LK" size 770048 crc 5c2659c2 md5 cebee3d929d4238bd80f457e11ed5e9d )
-)
-
-game (
-	name "Legend of Kyrandia, The (CD/Macintosh/German)"
-	description "Legend of Kyrandia, The (CD/Macintosh/German)"
-	rom ( name "._LK" size 770048 crc 22969f9f md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Demo/CD/DOS)"
-	description "Legend of Kyrandia, The (Demo/CD/DOS)"
-	rom ( name "ADL.PAK" size 241255 crc e30798f2 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Demo/DOS)"
-	description "Legend of Kyrandia, The (Demo/DOS)"
-	rom ( name "8FAT.FNT" size 4299 crc 63e9c7e3 md5 ef4b28582d932ca26d1c1ecdd8454f4d )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS)"
-	description "Legend of Kyrandia, The (Extracted/DOS)"
-	rom ( name "6.FNT" size 2463 crc 58801bc5 md5 01de09f4641ca421fda054334d587e61 )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS)[a]"
-	description "Legend of Kyrandia, The (Extracted/DOS)[a]"
-	rom ( name "6.FNT" size 2463 crc 58801bc5 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/French)"
-	description "Legend of Kyrandia, The (Extracted/DOS/French)"
-	rom ( name "6.FNT" size 2419 crc 2623935b md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/German)"
-	description "Legend of Kyrandia, The (Extracted/DOS/German)"
-	rom ( name "6.FNT" size 2419 crc 2623935b md5 3bb9b67d773fca325edf0b4597518130 )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/Italian)"
-	description "Legend of Kyrandia, The (Extracted/DOS/Italian)"
-	rom ( name "6.FNT" size 2419 crc 2623935b md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/Russian)"
-	description "Legend of Kyrandia, The (Extracted/DOS/Russian)"
-	rom ( name "6.FNT" size 2463 crc 58801bc5 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/Spanish)"
-	description "Legend of Kyrandia, The (Extracted/DOS/Spanish)"
-	rom ( name "6.FNT" size 2419 crc 2623935b md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Extracted/DOS/Spanish)[a]"
-	description "Legend of Kyrandia, The (Extracted/DOS/Spanish)[a]"
-	rom ( name "6.FNT" size 2419 crc 2623935b md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (Macintosh)"
-	description "Legend of Kyrandia, The (Macintosh)"
-	rom ( name "6.FNT" size 2422 crc c81f832c md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The (PC-98/Japanese)"
-	description "Legend of Kyrandia, The (PC-98/Japanese)"
-	rom ( name "A_E.PAK" size 475079 crc 05be28db md5 43f6b0334a2e10ca38be1e2add2f7f55 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/English (in Italian CD))"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/English (in Italian CD))"
-	rom ( name "ENGLISH.ROM" size 94 crc 9aab4f9e md5 19ceca429363793ef94f87ebd2fbd001 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/French (in Spanish CD))"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/French (in Spanish CD))"
-	rom ( name "FRENCH.ROM" size 94 crc 56113bda md5 63d42d9f2f6d4a3e32d088e1e9b47cc7 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/German (in Italian CD))"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/German (in Italian CD))"
-	rom ( name "GERMAN.ROM" size 93 crc 45950818 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/German (in Spanish CD))"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/German (in Spanish CD))"
-	rom ( name "GERMAN.ROM" size 94 crc bd949a0c md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed)[!]"
-	rom ( name "ALBUM.PAK" size 266271 crc b68d50a0 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed/French)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed/French)[!]"
-	rom ( name "FRENCH.ROM" size 87 crc 083ab54e md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed/German)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Installed/German)[!]"
-	rom ( name "GERMAN.ROM" size 87 crc 60ad0153 md5 301290dc90b84c39cc3a96bd4f27c777 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Italian)"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Italian)"
-	rom ( name "ALBUM.PAK" size 266255 crc 7acb196e md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Installed/French)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Installed/French)[!]"
-	rom ( name "FRENCH.ROM" size 78 crc 0075c8c2 md5 1bf6c2fe5919b47593c383de94d01af0 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Installed/German)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Installed/German)[!]"
-	rom ( name "GERMAN.ROM" size 78 crc 0416943c md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Istalled)[!]"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Non Istalled)[!]"
-	rom ( name "ALBUM.PAK" size 266271 crc b68d50a0 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Spanish)"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (DOS/Spanish)"
-	rom ( name "ALBUM.PAK" size 266406 crc 8caaab14 md5 0f4274a2735b85e99b10ff7c477da261 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh)"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh)"
-	rom ( name "ALBUM.PAK" size 266271 crc b68d50a0 md5 03f98f45ca93aed90acf1f5db75379d8 )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh/French)"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh/French)"
-	rom ( name "FRENCH.ROM" size 75 crc dcc81be5 md5 a0bf22388dc9e493d4e46427b888ddeb )
-)
-
-game (
-	name "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh/German)"
-	description "Legend of Kyrandia, The: Malcolm's Revenge (Macintosh/German)"
-	rom ( name "GERMAN.ROM" size 75 crc ae642e1f md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS)[!]"
-	rom ( name "ALLEY.PAK" size 200696 crc 2083409b md5 fe35f12bac8257ffefec7297f32b84ed )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Italian)[v1.3]"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Italian)[v1.3]"
-	rom ( name "ALLEY.PAK" size 200944 crc 4f3ac092 md5 eb3a64b4ea67c79aee90612a9d2e05fd )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Italian)[v1.5]"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Italian)[v1.5]"
-	rom ( name "ALLEY.PAK" size 200934 crc 39d12dc3 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Russian)"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/Fanmade Russian)"
-	rom ( name "8FAT.FNT" size 10770 crc 67c7ced1 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/French)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/French)[!]"
-	rom ( name "TALKFRE.PAK" size 360225 crc 714a2f98 md5 2e2c595bf4b79e20649ead41406306b6 )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/German)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/DOS/German)[!]"
-	rom ( name "TALKGER.PAK" size 480856 crc e046d8cf md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/FM-Towns)"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/FM-Towns)"
-	rom ( name "AUDIO.PAK" size 204343 crc 06b732b4 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/FM-Towns/Japanese)"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/FM-Towns/Japanese)"
-	rom ( name "cdfmjp.rom" size 14 crc d3bf89da md5 66b404f2f9a9d42730b106372e23897a )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/PC98)"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/PC98)"
-	rom ( name "cdpc98.rom" size 13 crc b23093f5 md5 a150ca7f4891a253e8f0e69b12fd0521 )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (CD/PC98/Japanese)"
-	description "Legend of Kyrandia, The: The Hand of Fate (CD/PC98/Japanese)"
-	rom ( name "cdpc98jp.rom" size 16 crc cf79a64c md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS)[!]"
-	rom ( name "ANYTALK.TLK" size 12193192 crc dd77fe10 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS/French)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS/French)[!]"
-	rom ( name "SKY.FMC" size 3202 crc 6a2e835e md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS/German)[!]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Demo/CD/DOS/German)[!]"
-	rom ( name "SKY.GMC" size 3236 crc 71dd9dd3 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Demo/Non-Interactive/DOS)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Demo/Non-Interactive/DOS)"
-	rom ( name "GENERAL.PAK" size 908669 crc 34b4be23 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Demo/Non-Interactive/DOS)[a]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Demo/Non-Interactive/DOS)[a]"
-	rom ( name "GENERAL.PAK" size 908987 crc 457b1404 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (DOS)"
-	description "Legend of Kyrandia, The: The Hand of Fate (DOS)"
-	rom ( name "WESTWOOD.001" size 1353735 crc dd90d14a md5 059d149b0919f29fc533bb17ab894ca0 )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (DOS/German)"
-	description "Legend of Kyrandia, The: The Hand of Fate (DOS/German)"
-	rom ( name "WESTWOOD.001" size 1351175 crc d8b117be md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS)"
-	rom ( name "ALLEY.PAK" size 184872 crc ff867dd5 md5 6a867eac72dbfa086c0d79b593d1698b )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS)[a]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS)[a]"
-	rom ( name "ALLEY.PAK" size 184872 crc ff867dd5 md5 6a867eac72dbfa086c0d79b593d1698b )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/French)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/French)"
-	rom ( name "ALLEY.PAK" size 185068 crc b3be0295 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/German)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/German)"
-	rom ( name "ALLEY.PAK" size 185076 crc 5a0978ac md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Italian)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Italian)"
-	rom ( name "ALLEY.PAK" size 185212 crc c85fb773 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Russian)"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Russian)"
-	rom ( name "8FAT.FNT" size 5837 crc 33f5eb87 md5 undefined )
-)
-
-game (
-	name "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Russian)[a]"
-	description "Legend of Kyrandia, The: The Hand of Fate (Extracted/DOS/Russian)[a]"
-	rom ( name "8FAT.FNT" size 5837 crc 33f5eb87 md5 6307482da86d33d529cf4374f3052b7b )
-)
-
-game (
-	name "Legend of Shay-Larah 1, The: The Lost Prince (DOS/Fanmade)"
-	description "Legend of Shay-Larah 1, The: The Lost Prince (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 303 crc e55132b6 md5 04e720c8e30c9cf12db22ea14a24a3dd )
-)
-
-game (
-	name "Legend of the Lost Jewel, The (DOS/Fanmade)"
-	description "Legend of the Lost Jewel, The (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 300398 crc 2f0f6afe md5 179fb6e4f27703d6954e8bd9519dcb73 )
-)
-
-game (
-	name "Legend of Zelda, The: The Fungus of Time (Demo/DOS/Fanmade v1.00)"
-	description "Legend of Zelda, The: The Fungus of Time (Demo/DOS/Fanmade v1.00)"
-	rom ( name "LOGDIR" size 300 crc 19a77cef md5 undefined )
-)
-
-game (
-	name "Legendary Harry Soupsmith, The (Demo/DOS/Fanmade 1998 Apr 2)"
-	description "Legendary Harry Soupsmith, The (Demo/DOS/Fanmade 1998 Apr 2)"
-	rom ( name "LOGDIR" size 309 crc dcb29403 md5 64c46b0d6fc135c9835afa80980d2831 )
-)
-
-game (
-	name "Legendary Harry Soupsmith, The (Demo/DOS/Fanmade 1998 Aug 19)"
-	description "Legendary Harry Soupsmith, The (Demo/DOS/Fanmade 1998 Aug 19)"
-	rom ( name "LOGDIR" size 306 crc 95045d4f md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Amiga)"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Amiga)"
-	rom ( name "BANK.001" size 137922 crc 5708db03 md5 8d211deb490e64e2918aa90e3b650370 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Atari ST)"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Atari ST)"
-	rom ( name "RESOURCE.001" size 477342 crc 134866ae md5 c339740f29f8fd1f5018226712c19855 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Atari ST)[a]"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Atari ST)[a]"
-	rom ( name "LSL2.QA" size 266 crc 0998fbe6 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Demo/DOS)"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 127532 crc 04f228a6 md5 be8173fba0088890493af6e731ac0db4 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)"
-	rom ( name "ADL.DRV" size 5684 crc 2604f137 md5 ce0b096f0ed4ed366fbd635cd96de6e8 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)[v1.000.011]"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)[v1.000.011]"
-	rom ( name "ADL.DRV" size 5684 crc 2604f137 md5 ce0b096f0ed4ed366fbd635cd96de6e8 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)[v1.002.000]"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS)[v1.002.000]"
-	rom ( name "LSL2.QA" size 222 crc 65e0161f md5 4439494f0ef6339e81d416e1433c9816 )
-)
-
-game (
-	name "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS/EGA)"
-	description "Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places) (DOS/EGA)"
-	rom ( name "LSL2.QA" size 222 crc 65e0161f md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Amiga)[v1.039]"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Amiga)[v1.039]"
-	rom ( name "BANK.001" size 203620 crc 61af6dcc md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Atari ST)"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Atari ST)"
-	rom ( name "RESOURCE.001" size 456722 crc 7c1d841b md5 ad787a731bd98670c989aad2ac3b895f )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Demo/DOS)"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 76525 crc b268cac6 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS)[v1.003][8x360KB]"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS)[v1.003][8x360KB]"
-	rom ( name "LSL3.QA" size 185 crc 70e15f90 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS)[v1.021]"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS)[v1.021]"
-	rom ( name "RESOURCE.001" size 456722 crc 7fa5e23e md5 3437c56f0cb7f4a3df5f5bc21008a786 )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/EGA)[4x720KB]"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/EGA)[4x720KB]"
-	rom ( name "LSL3.QA" size 185 crc 70e15f90 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/French)"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/French)"
-	rom ( name "RESOURCE.001" size 457402 crc cb8c1976 md5 d754db5c586588fea6d1f43c01d6af51 )
-)
-
-game (
-	name "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/German)"
-	description "Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (DOS/German)"
-	rom ( name "PIC.455" size 3544 crc 4e8d773f md5 fd5cdc78cdeba2467f39074fb772a0a3 )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Amiga)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Amiga)"
-	rom ( name "467.SND" size 17984 crc cc82bf54 md5 ce22d3c56c5cd7211365e81c1f197466 )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Amiga/German)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Amiga/German)"
-	rom ( name "9.PAT" size 213616 crc b97017d2 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Demo/DOS)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 531380 crc ba36d522 md5 347cf87521effeca79acfdeebf1889f6 )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS)[!]"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS)[!]"
-	rom ( name "200.SCR" size 14270 crc c379aec7 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/EGA)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/EGA)"
-	rom ( name "RESOURCE.000" size 765747 crc 53e1a2ea md5 b6ebd3870df7ea9d903677a16ce5c1d6 )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/French)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/French)"
-	rom ( name "961.V56" size 2062 crc 63fd77b8 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/German)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/German)"
-	rom ( name "961.V56" size 2062 crc 63fd77b8 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/Italian)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/Italian)"
-	rom ( name "320.SCR" size 14066 crc d6f8e6fd md5 2f6bb8ec8f2205b377dc5d40ac2e5f4f )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/Spanish)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (DOS/Spanish)"
-	rom ( name "280.SCR" size 10902 crc 4ed2b5d9 md5 508d6ef95d368287684d5f1e282d35f2 )
-)
-
-game (
-	name "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Macintosh)"
-	description "Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work (Macintosh)"
-	rom ( name "1.PAT" size 16907 crc f82eec48 md5 c3318de0cd50b371c78cd115ca92a994 )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (CD-DOS)[!]"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (CD-DOS)[!]"
-	rom ( name "RESOURCE.000" size 5754790 crc e1b0ace7 md5 3434f03c74ae136ce8cb6b8f2ae87b78 )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (CD/DOS/French)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (CD/DOS/French)"
-	rom ( name "RESOURCE.000" size 5776092 crc f83ccbd5 md5 04bebdb3698fe7e9d9e942cade604b42 )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (CD/DOS/German)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (CD/DOS/German)"
-	rom ( name "RESOURCE.000" size 5773160 crc 6f19d651 md5 c6cb2315c2517734167e8e6f7c9c2ed5 )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS)"
-	rom ( name "1800.HEP" size 500 crc 69d64ada md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS/German)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS/German)"
-	rom ( name "0.HEP" size 2338 crc 5cc62050 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS/Spanish)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (DOS/Spanish)"
-	rom ( name "1242.HEP" size 526 crc f70b040a md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS)[!]"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS)[!]"
-	rom ( name "RESOURCE.000" size 18520872 crc f47952d7 md5 699958e370a81cdddb4ac8289f10398d )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS/French)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS/French)"
-	rom ( name "RESOURCE.000" size 18538987 crc 2261a6b7 md5 6ebe1bdee4e4fa9d6f4221ebc30379ae )
-)
-
-game (
-	name "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS/German)"
-	description "Leisure Suit Larry 6: Shape Up or Slip Out! (Hi-res/DOS/German)"
-	rom ( name "RESOURCE.000" size 18534274 crc c14354b7 md5 ce195173351cd9883614491f34828f4e )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (Demo/DOS)"
-	description "Leisure Suit Larry 7: Love for Sail! (Demo/DOS)"
-	rom ( name "CLASSES" size 6740 crc a6801c84 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (DOS)[!]"
-	description "Leisure Suit Larry 7: Love for Sail! (DOS)[!]"
-	rom ( name "RESMAP.000" size 8188 crc 9136f82e md5 682f820746f385ba3c63f1dbb974e32c )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (DOS/French)"
-	description "Leisure Suit Larry 7: Love for Sail! (DOS/French)"
-	rom ( name "RESMAP.000" size 8206 crc 639b5543 md5 60ec1ffa0cea2e1aab788cfb9448e6cf )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (DOS/German)"
-	description "Leisure Suit Larry 7: Love for Sail! (DOS/German)"
-	rom ( name "RESMAP.000" size 8188 crc 3515b254 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (DOS/Italian)"
-	description "Leisure Suit Larry 7: Love for Sail! (DOS/Italian)"
-	rom ( name "RESMAP.000" size 8212 crc 2acaf963 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry 7: Love for Sail! (DOS/Spanish)"
-	description "Leisure Suit Larry 7: Love for Sail! (DOS/Spanish)"
-	rom ( name "RESMAP.000" size 8188 crc 2aa67adc md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (CoCo3)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (CoCo3)"
-	rom ( name "logDir" size 198 crc 37341e7b md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (Demo/SCI/DOS)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (Demo/SCI/DOS)"
-	rom ( name "RESOURCE.001" size 359913 crc 50725eb2 md5 21496816c24d824427c027e25a1ce713 )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (DOS/Polish)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (DOS/Polish)"
-	rom ( name "LOGDIR" size 303 crc 37185d75 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/Amiga)[1.004.024]"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/Amiga)[1.004.024]"
-	rom ( name "355.SCR" size 3734 crc a0899a41 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS)[1.000.510]"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS)[1.000.510]"
-	rom ( name "RESOURCE.000" size 918242 crc 4a0463ae md5 142296b299e3fa2c016fc979a68ed0e7 )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS)[1.000.577]"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS)[1.000.577]"
-	rom ( name "RESOURCE.000" size 922406 crc 58964d3f md5 ad07679eb5680926850546d30191b7df )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/EGA)[1.000.575]"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/EGA)[1.000.575]"
-	rom ( name "4.PAT" size 1301 crc a28008a0 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Polish)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Polish)"
-	rom ( name "RESOURCE.000" size 4781210 crc ac9d37f5 md5 4de12ba27f6d93d76dea1c952aff1809 )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Russian)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Russian)"
-	rom ( name "RESOURCE.000" size 928566 crc baf9b5c7 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Spanish)[1.SQ4.057]"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/DOS/Spanish)[1.SQ4.057]"
-	rom ( name "300.SCR" size 7408 crc 00461338 md5 68932c8bbdfd4ad23f7043698bfb769f )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/Macintosh)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizards (SCI/Macintosh)"
-	rom ( name "110.SCR" size 14108 crc 825f74bb md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizzards (Amiga)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizzards (Amiga)"
-	rom ( name "LOGDIR" size 177 crc e394b64d md5 3f5d26d8834ca49c147fb60936869d56 )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizzards (Apple IIgs)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizzards (Apple IIgs)"
-	rom ( name "LL.SYS16" size 141003 crc b4fb6b98 md5 undefined )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizzards (Atari ST)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizzards (Atari ST)"
-	rom ( name "LOGDIR" size 177 crc edebf8c1 md5 8b579f8673fe9448c2538f5ed9887cf0 )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizzards (DOS/1.00)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizzards (DOS/1.00)"
-	rom ( name "LOGDIR" size 177 crc 2f82e0b1 md5 1fe764e66857e7f305a5f03ca3f4971d )
-)
-
-game (
-	name "Leisure Suit Larry in the Land of the Lounge Lizzards (Macintosh)"
-	description "Leisure Suit Larry in the Land of the Lounge Lizzards (Macintosh)"
-	rom ( name "LOGDIR" size 256 crc 537e7dba md5 8a0076429890531832f0dc113285e31e )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Demo/Macintosh)"
-	description "Let's Explore the Airport with Buzzy (Demo/Macintosh)"
-	rom ( name "Airport Demo" size 348426 crc c435b30e md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Demo/Windows)[a][!]"
-	description "Let's Explore the Airport with Buzzy (Demo/Windows)[a][!]"
-	rom ( name "AIRDEMO.HE0" size 51152 crc c2dbb2f1 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Demo/Windows)[HE 71]"
-	description "Let's Explore the Airport with Buzzy (Demo/Windows)[HE 71]"
-	rom ( name "AIRDEMO.HE0" size 51131 crc d3db6ca3 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Demo/Windows/US)[!]"
-	description "Let's Explore the Airport with Buzzy (Demo/Windows/US)[!]"
-	rom ( name "AIRDEMO.HE0" size 51152 crc 2be40601 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Macintosh)"
-	description "Let's Explore the Airport with Buzzy (Macintosh)"
-	rom ( name "._The AirPort" size 475136 crc ace7a068 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Windows)"
-	description "Let's Explore the Airport with Buzzy (Windows)"
-	rom ( name "AIRPORT.HE0" size 93231 crc 18b3bdf9 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Airport with Buzzy (Windows/Russian)"
-	description "Let's Explore the Airport with Buzzy (Windows/Russian)"
-	rom ( name "AIRPORT.HE0" size 93231 crc 0611c168 md5 3e861421f494711bc6f619d4aba60285 )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Demo/Macintosh)"
-	description "Let's Explore the Farm with Buzzy (Demo/Macintosh)"
-	rom ( name "Farm Demo" size 356352 crc 1ae279b5 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Demo/Windows)[HE 71]"
-	description "Let's Explore the Farm with Buzzy (Demo/Windows)[HE 71]"
-	rom ( name "FARMDEMO.HE0" size 18149 crc f2468823 md5 bf8b52fdd9a69c67f34e8e9fec72661c )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Demo/Windows/Dutch)[!]"
-	description "Let's Explore the Farm with Buzzy (Demo/Windows/Dutch)[!]"
-	rom ( name "FARMDEMO.HE0" size 34333 crc 49e8cc00 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Demo/Windows/US)[!]"
-	description "Let's Explore the Farm with Buzzy (Demo/Windows/US)[!]"
-	rom ( name "FARMDEMO.HE0" size 34333 crc 90b997c2 md5 8d479e36f35e80257dfc102cf4b8a912 )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Macintosh)"
-	description "Let's Explore the Farm with Buzzy (Macintosh)"
-	rom ( name "._Farm" size 425984 crc c280dcda md5 795e8b80b2e1f8658cac815172d466f0 )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Windows)"
-	description "Let's Explore the Farm with Buzzy (Windows)"
-	rom ( name "FARM.HE0" size 86962 crc 8c5fa403 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Windows)[a]"
-	description "Let's Explore the Farm with Buzzy (Windows)[a]"
-	rom ( name "FARM.HE0" size 87061 crc 23c691b2 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Windows/Dutch)"
-	description "Let's Explore the Farm with Buzzy (Windows/Dutch)"
-	rom ( name "FARM.HE0" size 87061 crc cb5595ac md5 undefined )
-)
-
-game (
-	name "Let's Explore the Farm with Buzzy (Windows/Russian)"
-	description "Let's Explore the Farm with Buzzy (Windows/Russian)"
-	rom ( name "FARM.HE0" size 87061 crc 02397f0f md5 undefined )
-)
-
-game (
-	name "Let's Explore the Jungle with Buzzy (Macintosh)"
-	description "Let's Explore the Jungle with Buzzy (Macintosh)"
-	rom ( name "._The Jungle" size 462848 crc 4de4ca97 md5 undefined )
-)
-
-game (
-	name "Let's Explore the Jungle with Buzzy (Windows)"
-	description "Let's Explore the Jungle with Buzzy (Windows)"
-	rom ( name "JUNGLE.HE0" size 108594 crc dda7f381 md5 8801fb4a1200b347f7a38523339526dd )
-)
-
-game (
-	name "Life In 3 Minutes (Windows)"
-	description "Life In 3 Minutes (Windows)"
-	rom ( name "data.dcp" size 141787214 crc cb909237 md5 undefined )
-)
-
-game (
-	name "Lighthouse: The Dark Being (Demo/DOS)"
-	description "Lighthouse: The Dark Being (Demo/DOS)"
-	rom ( name "16.RBT" size 224133 crc 16dcbf44 md5 f8b4d6b00b3f92af5aca7ae58eafc5a5 )
-)
-
-game (
-	name "Lighthouse: The Dark Being (Demo/Windows)"
-	description "Lighthouse: The Dark Being (Demo/Windows)"
-	rom ( name "2.VMD" size 26672792 crc 0b960df4 md5 e4322c979308f7c8ef379ae843665bf8 )
-)
-
-game (
-	name "Lighthouse: The Dark Being (DOS)[!]"
-	description "Lighthouse: The Dark Being (DOS)[!]"
-	rom ( name "11.CSC" size 3902 crc e2b81412 md5 e7613dc207a1e0522c2d24022662f624 )
-)
-
-game (
-	name "Lighthouse: The Dark Being (DOS/Spanish)"
-	description "Lighthouse: The Dark Being (DOS/Spanish)"
-	rom ( name "0.CSC" size 29818 crc f9547862 md5 undefined )
-)
-
-game (
-	name "Little Pirate (Demo 2/DOS/Fanmade v0.6)"
-	description "Little Pirate (Demo 2/DOS/Fanmade v0.6)"
-	rom ( name "LOGDIR" size 768 crc 29d60320 md5 undefined )
-)
-
-game (
-	name "Little Pythagoras (Macintosh)"
-	description "Little Pythagoras (Macintosh)"
-	rom ( name "._Little Pythagoras 1.1.1" size 634880 crc a57ffbb1 md5 bd45de774335a3f11b5c25dc15110f42 )
-)
-
-game (
-	name "Living Books Sampler (Macintosh/v1)"
-	description "Living Books Sampler (Macintosh/v1)"
-	rom ( name "BookOutline" size 847 crc 4a1740f5 md5 undefined )
-)
-
-game (
-	name "Living Books Sampler (Macintosh/v2)"
-	description "Living Books Sampler (Macintosh/v2)"
-	rom ( name "BookOutline" size 1133 crc 90959c2c md5 48985306013164b128981883045f2c43 )
-)
-
-game (
-	name "Living Books Sampler (Windows/v1)"
-	description "Living Books Sampler (Windows/v1)"
-	rom ( name "DEMO.512" size 1028 crc d1a06674 md5 undefined )
-)
-
-game (
-	name "Living Books Sampler (Windows/v2)"
-	description "Living Books Sampler (Windows/v2)"
-	rom ( name "BOOKOUTL.INE" size 1133 crc 90959c2c md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.0/Windows/English,Spanish)"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.0/Windows/English,Spanish)"
-	rom ( name "FILE.DLL" size 6144 crc 2786066b md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.1/Windows/English,Spanish)"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.1/Windows/English,Spanish)"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.1/Windows/English,Spanish)[a]"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Demo v1.1/Windows/English,Spanish)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/English,Spanish)[v1.0]"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/English,Spanish)[v1.0]"
-	rom ( name "TORTOISE.512" size 2120 crc 85e6ab4c md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/English,Spanish)[v1.1]"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/English,Spanish)[v1.1]"
-	rom ( name "TORTOISE.512" size 2167 crc c13b9c69 md5 undefined )
-)
-
-game (
-	name "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/Hebrew)"
-	description "Living Books: Aesop's Fables: The Tortoise and the Hare (Windows/Hebrew)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Demo/Macintosh)"
-	description "Living Books: Arthur's Birthday (Demo/Macintosh)"
-	rom ( name "Arthur's Birthday Demo" size 622 crc 50ae12ef md5 0d974ec635eea615475368e865f1b1c8 )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Demo/Windows)"
-	description "Living Books: Arthur's Birthday (Demo/Windows)"
-	rom ( name "BIRTHDAY.512" size 699 crc 97b354c0 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Demo/Windows/English,Spanish)"
-	description "Living Books: Arthur's Birthday (Demo/Windows/English,Spanish)"
-	rom ( name "BIRTHDAY.512" size 715 crc 7cfc822c md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Macintosh)"
-	description "Living Books: Arthur's Birthday (Macintosh)"
-	rom ( name "Arthur's Birthday" size 432058 crc 42142267 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Windows)"
-	description "Living Books: Arthur's Birthday (Windows)"
-	rom ( name "BDAY16.EXE" size 428560 crc b0206d92 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Birthday (Windows/English,Spanish)"
-	description "Living Books: Arthur's Birthday (Windows/English,Spanish)"
-	rom ( name "BIRTHDAY.512" size 2455 crc 9ab33098 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Computer Adventure (Macintosh)"
-	description "Living Books: Arthur's Computer Adventure (Macintosh)"
-	rom ( name "Arthur's Computer Adventure" size 714054 crc 90011696 md5 fb8feef6f4a2f20c20072f8befceecf7 )
-)
-
-game (
-	name "Living Books: Arthur's Computer Adventure (Windows)"
-	description "Living Books: Arthur's Computer Adventure (Windows)"
-	rom ( name "ACA16.EXE" size 586240 crc e5a575ca md5 2e7bb3083fb3434a468b49c50f1e6337 )
-)
-
-game (
-	name "Living Books: Arthur's Reading Race (Macintosh)"
-	description "Living Books: Arthur's Reading Race (Macintosh)"
-	rom ( name "._Arthur's Reading Race" size 413696 crc e2064dc1 md5 99df20b89ebfe3c98242251ce37714f5 )
-)
-
-game (
-	name "Living Books: Arthur's Reading Race (Windows/16bit)"
-	description "Living Books: Arthur's Reading Race (Windows/16bit)"
-	rom ( name "MOHAWK.WIN" size 1165 crc fad5af3e md5 84bf8e9082f1117901f3995752e43e36 )
-)
-
-game (
-	name "Living Books: Arthur's Reading Race (Windows/32bit)"
-	description "Living Books: Arthur's Reading Race (Windows/32bit)"
-	rom ( name "MOHAWK.W32" size 473 crc e5c8d096 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Demo v1.1/Windows)"
-	description "Living Books: Arthur's Teacher Trouble (Demo v1.1/Windows)"
-	rom ( name "ARTHUR.512" size 706 crc d77261e3 md5 f19e824e0a2f2745ed698e6aaf44f838 )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Demo v1.1/Windows/English,Spanish)"
-	description "Living Books: Arthur's Teacher Trouble (Demo v1.1/Windows/English,Spanish)"
-	rom ( name "ARTHUR.512" size 722 crc 60c81b0e md5 dabdd466dea26ab5ecb9415cf73f8601 )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Demo/Macintosh)"
-	description "Living Books: Arthur's Teacher Trouble (Demo/Macintosh)"
-	rom ( name "Bookoutline" size 645 crc 61bd0bda md5 7e2691611ff4c7b89c05221736628059 )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Demo/Macintosh)[a]"
-	description "Living Books: Arthur's Teacher Trouble (Demo/Macintosh)[a]"
-	rom ( name "Arthur's Teacher Trouble Demo" size 622 crc e6d3af29 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Demo/Windows)"
-	description "Living Books: Arthur's Teacher Trouble (Demo/Windows)"
-	rom ( name "ARTHUR.EXE" size 504082 crc 2e54540e md5 7de1c10ba27e4b26f6f8d01b20a9f576 )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Macintosh/English,Spanish)"
-	description "Living Books: Arthur's Teacher Trouble (Macintosh/English,Spanish)"
-	rom ( name "Arthur's Teacher Trouble" size 0 crc 00000000 md5 undefined )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Windows/English,Spanish)"
-	description "Living Books: Arthur's Teacher Trouble (Windows/English,Spanish)"
-	rom ( name "ARTHUR.EXE" size 504082 crc 2e54540e md5 7de1c10ba27e4b26f6f8d01b20a9f576 )
-)
-
-game (
-	name "Living Books: Arthur's Teacher Trouble (Windows/English,Spanish)[a]"
-	description "Living Books: Arthur's Teacher Trouble (Windows/English,Spanish)[a]"
-	rom ( name "ARTHUR.EXE" size 504082 crc 2e54540e md5 undefined )
-)
-
-game (
-	name "Living Books: Dr Seuss's ABC (Macintosh)"
-	description "Living Books: Dr Seuss's ABC (Macintosh)"
-	rom ( name "BookOutline" size 3698 crc 295deb9a md5 64fbc7a3519de7db3f8c7ff650921eea )
-)
-
-game (
-	name "Living Books: Dr Seuss's ABC (Windows/16bit)"
-	description "Living Books: Dr Seuss's ABC (Windows/16bit)"
-	rom ( name "ABC.EXE" size 296960 crc 149fbfc3 md5 d9f960b57dbcad68e4d4420a9a3421e1 )
-)
-
-game (
-	name "Living Books: Dr Seuss's ABC (Windows/32bit)"
-	description "Living Books: Dr Seuss's ABC (Windows/32bit)"
-	rom ( name "ABC32.EXE" size 215040 crc 79dc7439 md5 undefined )
-)
-
-game (
-	name "Living Books: Green Eggs and Ham (Demo/Windows)"
-	description "Living Books: Green Eggs and Ham (Demo/Windows)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 a286ce0ed37fd68ff01a0c7c6ea7400e )
-)
-
-game (
-	name "Living Books: Green Eggs and Ham (Macintosh)"
-	description "Living Books: Green Eggs and Ham (Macintosh)"
-	rom ( name "BookOutline" size 5814 crc 55ea4435 md5 8fdca02c7df4624e3bc318161b7ebf47 )
-)
-
-game (
-	name "Living Books: Green Eggs and Ham (Windows/16bit)"
-	description "Living Books: Green Eggs and Ham (Windows/16bit)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 a286ce0ed37fd68ff01a0c7c6ea7400e )
-)
-
-game (
-	name "Living Books: Green Eggs and Ham (Windows/32bit)"
-	description "Living Books: Green Eggs and Ham (Windows/32bit)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 a286ce0ed37fd68ff01a0c7c6ea7400e )
-)
-
-game (
-	name "Living Books: Harry and the Haunted House (Windows)"
-	description "Living Books: Harry and the Haunted House (Windows)"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Demo v1.0/Windows)"
-	description "Living Books: Just Grandma and Me (Demo v1.0/Windows)"
-	rom ( name "DIB.DRV" size 29536 crc 7a9772c0 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Demo v1.1/Windows/English,Spanish,Japanese)"
-	description "Living Books: Just Grandma and Me (Demo v1.1/Windows/English,Spanish,Japanese)"
-	rom ( name "FILE.DLL" size 6144 crc 2786066b md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Demo v1.1/Windows/English,Spanish,Japanese)[a]"
-	description "Living Books: Just Grandma and Me (Demo v1.1/Windows/English,Spanish,Japanese)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Demo/Macintosh)"
-	description "Living Books: Just Grandma and Me (Demo/Macintosh)"
-	rom ( name "Bookoutline" size 804 crc 09d9a117 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Demo/Macintosh)[a]"
-	description "Living Books: Just Grandma and Me (Demo/Macintosh)[a]"
-	rom ( name "Just Grandma and Me Demo" size 797 crc c6b69ed6 md5 552d8729fa77a4a83c88283c7d79bd31 )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Macintosh/English,Spanish,Japanese)[v1.0]"
-	description "Living Books: Just Grandma and Me (Macintosh/English,Spanish,Japanese)[v1.0]"
-	rom ( name "._Just Grandma and Me" size 81920 crc 6215a791 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Macintosh/English,Spanish,Japanese)[v1.1]"
-	description "Living Books: Just Grandma and Me (Macintosh/English,Spanish,Japanese)[v1.1]"
-	rom ( name "._Just Grandma and Me" size 81920 crc 87a0384a md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows)"
-	description "Living Books: Just Grandma and Me (Windows)"
-	rom ( name "JGMB.EXE" size 302592 crc 99a9ba8e md5 cb10b2585a8cac66dd14e432359c09a3 )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows/English,French,Spanish,German)[v2.0]"
-	description "Living Books: Just Grandma and Me (Windows/English,French,Spanish,German)[v2.0]"
-	rom ( name "OUTLINE" size 1528 crc 8ee93964 md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows/English,Spanish,Japanese)[v1.0]"
-	description "Living Books: Just Grandma and Me (Windows/English,Spanish,Japanese)[v1.0]"
-	rom ( name "PAGES.512" size 2437 crc 99689ceb md5 undefined )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows/English,Spanish,Japanese)[v1.1]"
-	description "Living Books: Just Grandma and Me (Windows/English,Spanish,Japanese)[v1.1]"
-	rom ( name "PAGES.512" size 2435 crc 48d42655 md5 613ca946bc8d91087fb7c10e9b84e88b )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows/French)"
-	description "Living Books: Just Grandma and Me (Windows/French)"
-	rom ( name "JGMF.EXE" size 302592 crc be76affd md5 9f5e738fa3affc71f395dac79be47f8a )
-)
-
-game (
-	name "Living Books: Just Grandma and Me (Windows/German)"
-	description "Living Books: Just Grandma and Me (Windows/German)"
-	rom ( name "JGMD.EXE" size 303104 crc d0576076 md5 c7bf1dd6c11fa294c0c2d6dd32c6ba8e )
-)
-
-game (
-	name "Living Books: Little Monster at School (Demo/Windows/English,Spanish)"
-	description "Living Books: Little Monster at School (Demo/Windows/English,Spanish)"
-	rom ( name "MONSTER.512" size 706 crc 241cd897 md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Demo/Windows/English,Spanish)[a]"
-	description "Living Books: Little Monster at School (Demo/Windows/English,Spanish)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Macintosh)"
-	description "Living Books: Little Monster at School (Macintosh)"
-	rom ( name "EnglishBO" size 4259 crc 5cab12f6 md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Macintosh/French)"
-	description "Living Books: Little Monster at School (Macintosh/French)"
-	rom ( name "FrenchBO" size 4258 crc e63cd561 md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Macintosh/German)"
-	description "Living Books: Little Monster at School (Macintosh/German)"
-	rom ( name "Das Kleine Monster" size 298194 crc 7cc38dfc md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Windows)"
-	description "Living Books: Little Monster at School (Windows)"
-	rom ( name "LMASB.EXE" size 353792 crc c6b5c2e2 md5 6e017089d54ca73b13e3b6453f495627 )
-)
-
-game (
-	name "Living Books: Little Monster at School (Windows)[a]"
-	description "Living Books: Little Monster at School (Windows)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 undefined )
-)
-
-game (
-	name "Living Books: Little Monster at School (Windows/French)"
-	description "Living Books: Little Monster at School (Windows/French)"
-	rom ( name "LMASF.EXE" size 353792 crc 370b3974 md5 2ad3132edeb84bf32e5058461bbdbe23 )
-)
-
-game (
-	name "Living Books: Little Monster at School (Windows/German)"
-	description "Living Books: Little Monster at School (Windows/German)"
-	rom ( name "LMASD.EXE" size 353792 crc 99b0d3f4 md5 8784a4c8ca7849f30c1f8056fb9bf94b )
-)
-
-game (
-	name "Living Books: Maggie's Farmyard Adventure (Windows)"
-	description "Living Books: Maggie's Farmyard Adventure (Windows)"
-	rom ( name "OUTLINE" size 1174 crc 356de1ab md5 undefined )
-)
-
-game (
-	name "Living Books: Ruff's Bone (Demo/Macintosh/English,Spanish)"
-	description "Living Books: Ruff's Bone (Demo/Macintosh/English,Spanish)"
-	rom ( name "Ruff's Bone Demo" size 622 crc 380fc4fc md5 undefined )
-)
-
-game (
-	name "Living Books: Ruff's Bone (Demo/Windows/English,Spanish)"
-	description "Living Books: Ruff's Bone (Demo/Windows/English,Spanish)"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 efa32c7924890c0625a88476e3c075c2 )
-)
-
-game (
-	name "Living Books: Ruff's Bone (Demo/Windows/English,Spanish)[a]"
-	description "Living Books: Ruff's Bone (Demo/Windows/English,Spanish)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 efa32c7924890c0625a88476e3c075c2 )
-)
-
-game (
-	name "Living Books: Ruff's Bone (Macintosh/English,Spanish)"
-	description "Living Books: Ruff's Bone (Macintosh/English,Spanish)"
-	rom ( name "._Ruff's Bone" size 90112 crc 92daa5df md5 536fd98ab4ed271f1756e96d1d9b72b1 )
-)
-
-game (
-	name "Living Books: Ruff's Bone (Windows/English,Spanish)"
-	description "Living Books: Ruff's Bone (Windows/English,Spanish)"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 efa32c7924890c0625a88476e3c075c2 )
-)
-
-game (
-	name "Living Books: Sheila Rae, the Brave (Windows)"
-	description "Living Books: Sheila Rae, the Brave (Windows)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 a286ce0ed37fd68ff01a0c7c6ea7400e )
-)
-
-game (
-	name "Living Books: Stellaluna (Macintosh)"
-	description "Living Books: Stellaluna (Macintosh)"
-	rom ( name "BookOutline" size 4133 crc fd4e23ea md5 undefined )
-)
-
-game (
-	name "Living Books: Stellaluna (Windows)"
-	description "Living Books: Stellaluna (Windows)"
-	rom ( name "DIB.DRV" size 30544 crc 68053e64 md5 undefined )
-)
-
-game (
-	name "Living Books: The Berenstain Bears Get in a Fight (Windows)"
-	description "Living Books: The Berenstain Bears Get in a Fight (Windows)"
-	rom ( name "AUTHORS.EXE" size 396816 crc 07f64f01 md5 0066e97f97af86e38d29b091458c1bce )
-)
-
-game (
-	name "Living Books: The Berenstain Bears in the Dark (Macintosh)"
-	description "Living Books: The Berenstain Bears in the Dark (Macintosh)"
-	rom ( name "BookOutline" size 3264 crc 318c6c76 md5 b56746b3b2c062c8588bfb6b28e137c1 )
-)
-
-game (
-	name "Living Books: The Berenstain Bears in the Dark (Windows/16bit)"
-	description "Living Books: The Berenstain Bears in the Dark (Windows/16bit)"
-	rom ( name "DARK.EXE" size 458240 crc 8cdff563 md5 undefined )
-)
-
-game (
-	name "Living Books: The Berenstain Bears in the Dark (Windows/32bit)"
-	description "Living Books: The Berenstain Bears in the Dark (Windows/32bit)"
-	rom ( name "DARK32.EXE" size 353792 crc db508f38 md5 b40ede0f09a840eafbebeaba15965495 )
-)
-
-game (
-	name "Living Books: The Cat in the Hat (Macintosh)"
-	description "Living Books: The Cat in the Hat (Macintosh)"
-	rom ( name "BookOutline" size 2331 crc fe18637a md5 e139903eee98f0b0c3f39247a23b8f10 )
-)
-
-game (
-	name "Living Books: The Cat in the Hat (Windows)"
-	description "Living Books: The Cat in the Hat (Windows)"
-	rom ( name "CAT16.EXE" size 436240 crc 67fec7e4 md5 c5f9f023bad17861feba59360501215a )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Demo v1.0/Windows)"
-	description "Living Books: The New Kid on the Block (Demo v1.0/Windows)"
-	rom ( name "FILE.DLL" size 6144 crc 2786066b md5 53a0f3cb0a55d184f901a6d0d563ccc8 )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Demo v1.1/Windows)"
-	description "Living Books: The New Kid on the Block (Demo v1.1/Windows)"
-	rom ( name "FILE.DLL" size 6144 crc 2786066b md5 53a0f3cb0a55d184f901a6d0d563ccc8 )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Demo v1.1/Windows)[a]"
-	description "Living Books: The New Kid on the Block (Demo v1.1/Windows)[a]"
-	rom ( name "FILE.DLL" size 6144 crc bdbb5a92 md5 efa32c7924890c0625a88476e3c075c2 )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Demo/Macintosh)"
-	description "Living Books: The New Kid on the Block (Demo/Macintosh)"
-	rom ( name "The New Kid on the Block Demo" size 450 crc 8a6d6b1a md5 7d33237e0ea452a97f2a3acdfb9e1286 )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Macintosh)"
-	description "Living Books: The New Kid on the Block (Macintosh)"
-	rom ( name "._The New Kid on the Block" size 86016 crc c2caaeb2 md5 c0e36c9dce425a8799cc77c832e0e325 )
-)
-
-game (
-	name "Living Books: The New Kid on the Block (Windows)"
-	description "Living Books: The New Kid on the Block (Windows)"
-	rom ( name "FILE.DLL" size 6144 crc 2786066b md5 53a0f3cb0a55d184f901a6d0d563ccc8 )
-)
-
-game (
-	name "LockerGnome Quest (DOS/Fanmade)"
-	description "LockerGnome Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 158906 crc add28f72 md5 9cc3d991e0f958f9b12772004a7ae372 )
-)
-
-game (
-	name "LockerGnome Quest Redux (DOS/Fanmade)"
-	description "LockerGnome Quest Redux (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 167383 crc a4fc6388 md5 9bb83022263af00d6786e3a034852cbb )
-)
-
-game (
-	name "LockerGnome Quest Redux (DOS/Fanmade)[a]"
-	description "LockerGnome Quest Redux (DOS/Fanmade)[a]"
-	rom ( name "resource.001" size 168069 crc 87fc63d4 md5 334aaef8232f27f1a96d1e9079405634 )
-)
-
-game (
-	name "Logical Journey of the Zoombinis (Windows)[a]"
-	description "Logical Journey of the Zoombinis (Windows)[a]"
-	rom ( name "BASECAMP.MHK" size 1162634 crc 0df7fb72 md5 undefined )
-)
-
-game (
-	name "Logical Journey of the Zoombinis (Windows)[v1.1][!]"
-	description "Logical Journey of the Zoombinis (Windows)[v1.1][!]"
-	rom ( name "CORNER.TTF" size 34176 crc c4136af2 md5 undefined )
-)
-
-game (
-	name "Logical Journey of the Zoombinis (Windows)[v2.0]"
-	description "Logical Journey of the Zoombinis (Windows)[v2.0]"
-	rom ( name "CORNER.TTF" size 34176 crc c4136af2 md5 d7d5be74bd96dfb06b4ea312e6ac2c87 )
-)
-
-game (
-	name "Logical Journey of the Zoombinis (Windows/French)"
-	description "Logical Journey of the Zoombinis (Windows/French)"
-	rom ( name "BASECAMP.MHK" size 1162634 crc 0df7fb72 md5 3e048d5affb0b5b093611641b0cdeb1c )
-)
-
-game (
-	name "Logical Journey of the Zoombinis (Windows/German)"
-	description "Logical Journey of the Zoombinis (Windows/German)"
-	rom ( name "BASECAMP.MHK" size 1162634 crc 0df7fb72 md5 undefined )
-)
-
-game (
-	name "Long Haired Dude, The: Encounter of the 18-th Kind (DOS/Fanmade)"
-	description "Long Haired Dude, The: Encounter of the 18-th Kind (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 57956f92 md5 86ea17b9fc2f3e537a7e40863d352c29 )
-)
-
-game (
-	name "Looky (Demo/Windows)"
-	description "Looky (Demo/Windows)"
-	rom ( name "English.dcp" size 1358442 crc 3094118e md5 6002171a02cb2280c7345f7863b6fa0f )
-)
-
-game (
-	name "Looky (Demo/Windows/German)"
-	description "Looky (Demo/Windows/German)"
-	rom ( name "German.dcp" size 14339496 crc 35e86594 md5 33147f7bde06c8044549cba0b049393d )
-)
-
-game (
-	name "Looky (Windows/German)"
-	description "Looky (Windows/German)"
-	rom ( name "data.dcp" size 1342214 crc 734ee740 md5 undefined )
-)
-
-game (
-	name "Loom (Demo/EGA/DOS)[january 1990 ces preview]"
-	description "Loom (Demo/EGA/DOS)[january 1990 ces preview]"
-	rom ( name "00.LFL" size 6108 crc db9d9722 md5 undefined )
-)
-
-game (
-	name "Loom (Demo/EGA/DOS)[self-running preview]"
-	description "Loom (Demo/EGA/DOS)[self-running preview]"
-	rom ( name "00.LFL" size 5748 crc f70a3334 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Amiga)"
-	description "Loom (EGA/Amiga)"
-	rom ( name "00.LFL" size 5748 crc 77aa56d2 md5 4dc780f1bc587a193ce8a97652791438 )
-)
-
-game (
-	name "Loom (EGA/Amiga)[a]"
-	description "Loom (EGA/Amiga)[a]"
-	rom ( name "00.LFL" size 5748 crc 77aa56d2 md5 4dc780f1bc587a193ce8a97652791438 )
-)
-
-game (
-	name "Loom (EGA/Amiga/French)"
-	description "Loom (EGA/Amiga/French)"
-	rom ( name "00.LFL" size 5748 crc adcb988d md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Amiga/German)"
-	description "Loom (EGA/Amiga/German)"
-	rom ( name "00.LFL" size 5748 crc c0cf6a7e md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Amiga/German)[a]"
-	description "Loom (EGA/Amiga/German)[a]"
-	rom ( name "00.LFL" size 5748 crc c0cf6a7e md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Amiga/Italian)"
-	description "Loom (EGA/Amiga/Italian)"
-	rom ( name "00.LFL" size 5748 crc adcb988d md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Amiga/Spanish)"
-	description "Loom (EGA/Amiga/Spanish)"
-	rom ( name "00.LFL" size 5748 crc 4faf0ff5 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Atari ST)[no adlib]"
-	description "Loom (EGA/Atari ST)[no adlib]"
-	rom ( name "00.LFL" size 5748 crc 7d34e303 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Atari ST/French)[no adlib]"
-	description "Loom (EGA/Atari ST/French)[no adlib]"
-	rom ( name "00.LFL" size 5748 crc 4f177846 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Atari ST/German)[no adlib]"
-	description "Loom (EGA/Atari ST/German)[no adlib]"
-	rom ( name "00.LFL" size 5748 crc f986cc69 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.0 from 8 mar 90]"
-	description "Loom (EGA/DOS)[v1.0 from 8 mar 90]"
-	rom ( name "00.LFL" size 5748 crc e504f353 md5 28ef68ee3ed76d7e2ee8ee13c15fbd5b )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.0]"
-	description "Loom (EGA/DOS)[v1.0]"
-	rom ( name "00.LFL" size 5748 crc 7c4ddc1b md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.0][a]"
-	description "Loom (EGA/DOS)[v1.0][a]"
-	rom ( name "00.LFL" size 5748 crc 7c4ddc1b md5 73e5ab7dbb9a8061cc6d25df02dbd1e7 )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.0][a2]"
-	description "Loom (EGA/DOS)[v1.0][a2]"
-	rom ( name "00.LFL" size 5748 crc e504f353 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.1 from 16 mar 90]"
-	description "Loom (EGA/DOS)[v1.1 from 16 mar 90]"
-	rom ( name "00.LFL" size 5748 crc 79c1d06c md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS)[v1.1][a]"
-	description "Loom (EGA/DOS)[v1.1][a]"
-	rom ( name "00.LFL" size 5748 crc 79c1d06c md5 37f56ceb13e401a7ac7d9e6b37fecaf7 )
-)
-
-game (
-	name "Loom (EGA/DOS/French)"
-	description "Loom (EGA/DOS/French)"
-	rom ( name "00.LFL" size 5748 crc 20122b69 md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS/German)[v1.2 from 7 jun 90][!]"
-	description "Loom (EGA/DOS/German)[v1.2 from 7 jun 90][!]"
-	rom ( name "00.LFL" size 5748 crc db2a0d3d md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS/German)[v1.2 from 7 Jun 90][a]"
-	description "Loom (EGA/DOS/German)[v1.2 from 7 Jun 90][a]"
-	rom ( name "00.LFL" size 5748 crc 8d32491a md5 470c45b636139bb40716daa1c7edaad0 )
-)
-
-game (
-	name "Loom (EGA/DOS/Hebrew)"
-	description "Loom (EGA/DOS/Hebrew)"
-	rom ( name "00.LFL" size 5748 crc 2c0c2b00 md5 187d315f6b5168f68680dfe8c3d76a3e )
-)
-
-game (
-	name "Loom (EGA/DOS/Italian)"
-	description "Loom (EGA/DOS/Italian)"
-	rom ( name "00.lfl" size 5752 crc 5dc9650c md5 undefined )
-)
-
-game (
-	name "Loom (EGA/DOS/Russian)[v1.0]"
-	description "Loom (EGA/DOS/Russian)[v1.0]"
-	rom ( name "00.LFL" size 5748 crc be9e58b9 md5 cd46c9f122272d02bbf79332ff521898 )
-)
-
-game (
-	name "Loom (EGA/DOS/Russian)[v1.1]"
-	description "Loom (EGA/DOS/Russian)[v1.1]"
-	rom ( name "00.LFL" size 5748 crc be9e58b9 md5 cd46c9f122272d02bbf79332ff521898 )
-)
-
-game (
-	name "Loom (EGA/DOS/Spanish)[05 sep 90]"
-	description "Loom (EGA/DOS/Spanish)[05 sep 90]"
-	rom ( name "00.LFL" size 5748 crc ea62824f md5 0be88565f734b1e9e77ccaaf3bb14b29 )
-)
-
-game (
-	name "Loom (EGA/DOS/Spanish)[v1.2]"
-	description "Loom (EGA/DOS/Spanish)[v1.2]"
-	rom ( name "00.LFL" size 5748 crc 349a8d6a md5 undefined )
-)
-
-game (
-	name "Loom (EGA/Macintosh)"
-	description "Loom (EGA/Macintosh)"
-	rom ( name "._Loom" size 209335 crc 6d6aaa12 md5 bcbfb463270c32577aada827548ade3d )
-)
-
-game (
-	name "Loom (FM-Towns)"
-	description "Loom (FM-Towns)"
-	rom ( name "00.LFL" size 7540 crc 72c0d02c md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade French)[v0.8]"
-	description "Loom (FM-Towns/Fanmade French)[v0.8]"
-	rom ( name "00.LFL" size 7540 crc 35c68146 md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade German)"
-	description "Loom (FM-Towns/Fanmade German)"
-	rom ( name "00.LFL" size 7540 crc a102d25c md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade German)[v1.1]"
-	description "Loom (FM-Towns/Fanmade German)[v1.1]"
-	rom ( name "00.LFL" size 7540 crc 626b9f66 md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade Polish)"
-	description "Loom (FM-Towns/Fanmade Polish)"
-	rom ( name "00.LFL" size 7540 crc 02385fd0 md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade Russian)"
-	description "Loom (FM-Towns/Fanmade Russian)"
-	rom ( name "00.LFL" size 7540 crc f0c68d62 md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Fanmade Spanish)"
-	description "Loom (FM-Towns/Fanmade Spanish)"
-	rom ( name "00.LFL" size 7540 crc dcd68631 md5 undefined )
-)
-
-game (
-	name "Loom (FM-Towns/Japanese)"
-	description "Loom (FM-Towns/Japanese)"
-	rom ( name "00.LFL" size 7540 crc d8dd533c md5 undefined )
-)
-
-game (
-	name "Loom (PC-Engine)"
-	description "Loom (PC-Engine)"
-	rom ( name "00.LFL" size 6532 crc 7c7201cd md5 undefined )
-)
-
-game (
-	name "Loom (PC-Engine/Japanese)"
-	description "Loom (PC-Engine/Japanese)"
-	rom ( name "00.LFL" size 6532 crc 710060c6 md5 79b05f628586837e7166e82b2279bb50 )
-)
-
-game (
-	name "Loom (Steam/Macintosh)[!]"
-	description "Loom (Steam/Macintosh)[!]"
-	rom ( name "Loom" size 393572 crc d7bc6e42 md5 undefined )
-)
-
-game (
-	name "Loom (Steam/Windows)[!]"
-	description "Loom (Steam/Windows)[!]"
-	rom ( name "Loom.exe" size 585728 crc f0bfcfb1 md5 0354ee0d14cde1264ec762261c04c14a )
-)
-
-game (
-	name "Loom (VGA/DOS)[!]"
-	description "Loom (VGA/DOS)[!]"
-	rom ( name "000.LFL" size 8307 crc 3ef3e225 md5 undefined )
-)
-
-game (
-	name "Loom (VGA/DOS/Fanmade German)[v1.1]"
-	description "Loom (VGA/DOS/Fanmade German)[v1.1]"
-	rom ( name "000.LFL" size 8307 crc b249d036 md5 undefined )
-)
-
-game (
-	name "Loom (VGA/DOS/Fanmade Hungarian)"
-	description "Loom (VGA/DOS/Fanmade Hungarian)"
-	rom ( name "000.LFL" size 8307 crc cddef5d6 md5 undefined )
-)
-
-game (
-	name "Loom (VGA/DOS/Fanmade Italian)"
-	description "Loom (VGA/DOS/Fanmade Italian)"
-	rom ( name "000.LFL" size 8307 crc 691fdd0d md5 undefined )
-)
-
-game (
-	name "Loom (VGA/DOS/Fanmade Spanish)"
-	description "Loom (VGA/DOS/Fanmade Spanish)"
-	rom ( name "000.LFL" size 8307 crc 3ef3e225 md5 undefined )
-)
-
-game (
-	name "Lord Avalot d'Argent (DOS)"
-	description "Lord Avalot d'Argent (DOS)"
-	rom ( name "ABOUT.AVD" size 8624 crc 98a640b0 md5 7fc98ab8d9591c76bd50ff1199ce1f01 )
-)
-
-game (
-	name "Lost Crystal (Macintosh)"
-	description "Lost Crystal (Macintosh)"
-	rom ( name "._LC Sounds 1" size 785940 crc undefined md5 undefined )
-)
-
-game (
-	name "Lost Eternity (DOS/Fanmade v1.0)"
-	description "Lost Eternity (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 541774e0 md5 undefined )
-)
-
-game (
-	name "Lost in Time (CD/DOS/French)"
-	description "Lost in Time (CD/DOS/French)"
-	rom ( name "FRENCH.ROM" size 42 crc 7886283d md5 8a89b646c701e54672b4ed1bfc42c6e6 )
-)
-
-game (
-	name "Lost in Time (CD/DOS/German)"
-	description "Lost in Time (CD/DOS/German)"
-	rom ( name "GERMAN.ROM" size 42 crc 8d88c2a6 md5 49f85482b408acbb5bb4ad380a89a10a )
-)
-
-game (
-	name "Lost in Time (CD/DOS/Italian)"
-	description "Lost in Time (CD/DOS/Italian)"
-	rom ( name "ITALIAN.ROM" size 43 crc 3184dd36 md5 087a2e4113369df132dac7d483004327 )
-)
-
-game (
-	name "Lost in Time (CD/DOS/Spanish)"
-	description "Lost in Time (CD/DOS/Spanish)"
-	rom ( name "SPANISH.ROM" size 43 crc a1a1e377 md5 undefined )
-)
-
-game (
-	name "Lost in Time (CD/DOS/UK)"
-	description "Lost in Time (CD/DOS/UK)"
-	rom ( name "ENGLISH.ROM" size 47 crc bac2ffe0 md5 undefined )
-)
-
-game (
-	name "Lost in Time (CD/DOS/US)"
-	description "Lost in Time (CD/DOS/US)"
-	rom ( name "BATCOM.ITK" size 5962538 crc c687d4fd md5 cbf7c612343fb03047a9b603d193388d )
-)
-
-game (
-	name "Lost in Time (Demo/DOS)"
-	description "Lost in Time (Demo/DOS)"
-	rom ( name "DEMO.ITK" size 2347518 crc 52754deb md5 1251cc7d11ce5b0816410bbcbed0b0c4 )
-)
-
-game (
-	name "Lost in Time (Demo/Non-interactive/DOS)"
-	description "Lost in Time (Demo/Non-interactive/DOS)"
-	rom ( name "DEMO.STK" size 3031494 crc addd87bd md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/Czech)[NotID]"
-	description "Lost in Time (DOS/Czech)[NotID]"
-	rom ( name "COMMUN.STK" size 454132 crc 394b8f6e md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/French)"
-	description "Lost in Time (DOS/French)"
-	rom ( name "COMMUN.STK" size 447694 crc 935b63a4 md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/German)"
-	description "Lost in Time (DOS/German)"
-	rom ( name "BATCOM.ITK" size 1874526 crc 07bc7033 md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/Hebrew)"
-	description "Lost in Time (DOS/Hebrew)"
-	rom ( name "BATCOM.ITK" size 1874526 crc 07bc7033 md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/Spanish)"
-	description "Lost in Time (DOS/Spanish)"
-	rom ( name "BATCOM.ITK" size 1874526 crc 07bc7033 md5 01729d5c31f748937b377303d224f94f )
-)
-
-game (
-	name "Lost in Time (DOS/US)"
-	description "Lost in Time (DOS/US)"
-	rom ( name "BATCOM.ITK" size 1874480 crc d5549bfc md5 undefined )
-)
-
-game (
-	name "Lost in Time (DOS/US)[a]"
-	description "Lost in Time (DOS/US)[a]"
-	rom ( name "BATCOM.ITK" size 1874480 crc d5549bfc md5 e00daea8a4b7c49ef852ccfe8c00707f )
-)
-
-game (
-	name "Lost in Time (Macintosh/French)"
-	description "Lost in Time (Macintosh/French)"
-	rom ( name "._MUSMAC1.MID" size 89145 crc 1476f19d md5 undefined )
-)
-
-game (
-	name "Lost in Time (Windows/French)"
-	description "Lost in Time (Windows/French)"
-	rom ( name "BATCOM.ITK" size 1980416 crc 27f2d964 md5 undefined )
-)
-
-game (
-	name "Lost Planet, The (DOS/Fanmade v0.9)"
-	description "Lost Planet, The (DOS/Fanmade v0.9)"
-	rom ( name "LOGDIR" size 768 crc 7fed8fe4 md5 590dffcbd932a9fbe554be13b769cac0 )
-)
-
-game (
-	name "Lost Planet, The (DOS/Fanmade v1.0)"
-	description "Lost Planet, The (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 768 crc 7d64843d md5 undefined )
-)
-
-game (
-	name "Lure of the Temptress (EGA/DOS)"
-	description "Lure of the Temptress (EGA/DOS)"
-	rom ( name "DISK1.EGA" size 599904 crc 8484f142 md5 9355d15a03ff5f43513ff7d743f685bc )
-)
-
-game (
-	name "Lure of the Temptress (EGA/DOS/Italian)"
-	description "Lure of the Temptress (EGA/DOS/Italian)"
-	rom ( name "DISK1.EGA" size 583392 crc 47d80235 md5 da86a49fe0fbb0ac16e0038d04fa2541 )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS)"
-	description "Lure of the Temptress (VGA/DOS)"
-	rom ( name "DISK1.VGA" size 618944 crc 354736ed md5 e45ea5d279a268c7d3c6524c2f63a2d2 )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS/French)"
-	description "Lure of the Temptress (VGA/DOS/French)"
-	rom ( name "DISK1.VGA" size 603648 crc 62dfb28b md5 2e6c42dbc76ba4f329261f1ff7013309 )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS/German)"
-	description "Lure of the Temptress (VGA/DOS/German)"
-	rom ( name "DISK1.VGA" size 610496 crc f85d34fb md5 00469bde05e79e634c3dd3931d3a708a )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS/Italian)"
-	description "Lure of the Temptress (VGA/DOS/Italian)"
-	rom ( name "DISK1.VGA" size 598944 crc 705e70b6 md5 13cc7c64de578e05e64857dbf123b1b8 )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS/Russian)"
-	description "Lure of the Temptress (VGA/DOS/Russian)"
-	rom ( name "DISK1.VGA" size 639552 crc 0a48987e md5 e7f052e4d49b0c81ab82752813a5d420 )
-)
-
-game (
-	name "Lure of the Temptress (VGA/DOS/Spanish)"
-	description "Lure of the Temptress (VGA/DOS/Spanish)"
-	rom ( name "DISK1.VGA" size 598816 crc 66bf8ed4 md5 8ffb491147a404428146dafc9d5baf8b )
-)
-
-game (
-	name "Maale Adummin Quest (DOS/Fanmade)"
-	description "Maale Adummin Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 333 crc 39a1d9c7 md5 ddfbeb33feb7cf78504fe4dba14ec63b )
-)
-
-game (
-	name "Magic Rings (Macintosh)"
-	description "Magic Rings (Macintosh)"
-	rom ( name "._Magic Rings" size 111843 crc 0c62f4ff md5 3a42991cb09f84c51a45f24eb10ef950 )
-)
-
-game (
-	name "Magic Tales Demo: Baby Yaga, Samurai, Imo (Windows)"
-	description "Magic Tales Demo: Baby Yaga, Samurai, Imo (Windows)"
-	rom ( name "BOOK.INI" size 759 crc a713e7c1 md5 dbc98c566f4ac61b544443524585dccb )
-)
-
-game (
-	name "Magic Tales Demo: Sleeping Cub, Princess & Crab (Windows)"
-	description "Magic Tales Demo: Sleeping Cub, Princess & Crab (Windows)"
-	rom ( name "BOOK.INI" size 353 crc aeb6e607 md5 3dede2522bb0886c95667b082987a87f )
-)
-
-game (
-	name "Magic Tales: Baba Yaga and the Magic Geese (Macintosh)"
-	description "Magic Tales: Baba Yaga and the Magic Geese (Macintosh)"
-	rom ( name "BABA YAGA" size 44321 crc 5317eae4 md5 7aca0820ac96ad954b59c9ab24af082e )
-)
-
-game (
-	name "Magic Tales: Baba Yaga and the Magic Geese (Windows)"
-	description "Magic Tales: Baba Yaga and the Magic Geese (Windows)"
-	rom ( name "BABAYAGA.ICO" size 1078 crc 0603cdcd md5 314a87428aeb52f32a6f18ed68fa3044 )
-)
-
-game (
-	name "Magic Tales: Imo and the King (Macintosh)"
-	description "Magic Tales: Imo and the King (Macintosh)"
-	rom ( name "BOOK.INI" size 2721 crc 9cb312d2 md5 d59b9d3981898ab7cb5f9f6ed22383de )
-)
-
-game (
-	name "Magic Tales: Imo and the King (Windows)"
-	description "Magic Tales: Imo and the King (Windows)"
-	rom ( name "BOOK.INI" size 3299 crc 4d621892 md5 62b52a1763cce7d7d6ccde9f9d32fd4b )
-)
-
-game (
-	name "Magic Tales: Liam Finds a Story (Macintosh)"
-	description "Magic Tales: Liam Finds a Story (Macintosh)"
-	rom ( name "BOOK.INI" size 747 crc 4b2b043a md5 85a1ca6002ded8572920bbdb73d35b0a )
-)
-
-game (
-	name "Magic Tales: Liam Finds a Story (Windows)"
-	description "Magic Tales: Liam Finds a Story (Windows)"
-	rom ( name "BOOK.INI" size 834 crc 03ee3a4a md5 undefined )
-)
-
-game (
-	name "Magic Tales: Sleeping Cub's Test of Courage (Macintosh)"
-	description "Magic Tales: Sleeping Cub's Test of Courage (Macintosh)"
-	rom ( name "BOOK.INI" size 877 crc dd0b2d60 md5 undefined )
-)
-
-game (
-	name "Magic Tales: Sleeping Cub's Test of Courage (Windows)"
-	description "Magic Tales: Sleeping Cub's Test of Courage (Windows)"
-	rom ( name "BOOK.INI" size 964 crc 4c1115e5 md5 0d329e592387009c6387a733a3ea2235 )
-)
-
-game (
-	name "Magic Tales: The Little Samurai (Macintosh)"
-	description "Magic Tales: The Little Samurai (Macintosh)"
-	rom ( name "BOOK.INI" size 3164 crc 3770e857 md5 undefined )
-)
-
-game (
-	name "Magic Tales: The Little Samurai (Windows)"
-	description "Magic Tales: The Little Samurai (Windows)"
-	rom ( name "BOOK.INI" size 3747 crc 55a4e510 md5 undefined )
-)
-
-game (
-	name "Magic Tales: The Princess and the Crab (Macintosh)"
-	description "Magic Tales: The Princess and the Crab (Macintosh)"
-	rom ( name "BOOK.INI" size 877 crc cdb139b1 md5 f6b551a7304643004bd5e4df7ac1e76e )
-)
-
-game (
-	name "Magic Tales: The Princess and the Crab (Windows)"
-	description "Magic Tales: The Princess and the Crab (Windows)"
-	rom ( name "BOOK.INI" size 966 crc 5b560a80 md5 undefined )
-)
-
-game (
-	name "Making of Myst, The (Windows)"
-	description "Making of Myst, The (Windows)"
-	rom ( name "MAKING.DAT" size 8377 crc 5b37460f md5 undefined )
-)
-
-game (
-	name "Manhole, The (EGA/DOS)"
-	description "Manhole, The (EGA/DOS)"
-	rom ( name "MANHOLE.DAT" size 127541 crc 2fc7b250 md5 735337cc5b44e58e5f7a0c35260f69db )
-)
-
-game (
-	name "Manhole, The: New and Enhanced (CD/DOS)"
-	description "Manhole, The: New and Enhanced (CD/DOS)"
-	rom ( name "MANHOLE.DAT" size 107028 crc 60fc59ea md5 b9b36c9e496bae7d9b08f2929b463eef )
-)
-
-game (
-	name "Manhunter 1: New York (Amiga)"
-	description "Manhunter 1: New York (Amiga)"
-	rom ( name "DIRS" size 2114 crc 1e2a71e9 md5 92c6183042d1c2bb76236236a7d7a847 )
-)
-
-game (
-	name "Manhunter 1: New York (Apple IIgs)"
-	description "Manhunter 1: New York (Apple IIgs)"
-	rom ( name "MH.SYS16" size 147678 crc 047883b3 md5 e7192a22eadceede702193866105f60e )
-)
-
-game (
-	name "Manhunter 1: New York (Atari ST)"
-	description "Manhunter 1: New York (Atari ST)"
-	rom ( name "MHDIR" size 2114 crc 88c80d7f md5 f2d58056ad802452d60776ee920a52a6 )
-)
-
-game (
-	name "Manhunter 1: New York (CoCo3/Updated)"
-	description "Manhunter 1: New York (CoCo3/Updated)"
-	rom ( name "logDir" size 495 crc 76b54ada md5 d47da950c62289f8d4ccf36af73365f2 )
-)
-
-game (
-	name "Manhunter 1: New York (DOS/3.5')"
-	description "Manhunter 1: New York (DOS/3.5')"
-	rom ( name "MHDIR" size 2141 crc 88c0354c md5 undefined )
-)
-
-game (
-	name "Manhunter 1: New York (DOS/5.25')"
-	description "Manhunter 1: New York (DOS/5.25')"
-	rom ( name "MHDIR" size 2123 crc 757d0fa4 md5 undefined )
-)
-
-game (
-	name "Manhunter 2: San Francisco (Amiga)"
-	description "Manhunter 2: San Francisco (Amiga)"
-	rom ( name "DIRS" size 2573 crc 9cab5d67 md5 b412e8a126368b76696696f7632d4c16 )
-)
-
-game (
-	name "Manhunter 2: San Francisco (Atari ST)"
-	description "Manhunter 2: San Francisco (Atari ST)"
-	rom ( name "MH2DIR" size 2573 crc c3a86545 md5 undefined )
-)
-
-game (
-	name "Manhunter 2: San Francisco (CoCo3/Updated)"
-	description "Manhunter 2: San Francisco (CoCo3/Updated)"
-	rom ( name "logDir" size 591 crc e250b108 md5 c64875766700196e72a92359f70f45a9 )
-)
-
-game (
-	name "Manhunter 2: San Francisco (DOS/3.5')"
-	description "Manhunter 2: San Francisco (DOS/3.5')"
-	rom ( name "MH2DIR" size 2588 crc 26060c01 md5 undefined )
-)
-
-game (
-	name "Manhunter 2: San Francisco (DOS/5.25')"
-	description "Manhunter 2: San Francisco (DOS/5.25')"
-	rom ( name "MH2DIR" size 2588 crc 96da55d8 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (Apple II/Apple IIgs)[image]"
-	description "Maniac Mansion (Apple II/Apple IIgs)[image]"
-	rom ( name "maniac1.dsk" size 143360 crc 6a61ff48 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (Apple IIgs/Extracted)"
-	description "Maniac Mansion (Apple IIgs/Extracted)"
-	rom ( name "00.LFL" size 1188 crc 98cfec5c md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (C64)[image]"
-	description "Maniac Mansion (C64)[image]"
-	rom ( name "maniac1.d64" size 174848 crc c80a5af0 md5 d831f7c048574dd9d5d85db2a1468099 )
-)
-
-game (
-	name "Maniac Mansion (C64/Extracted)"
-	description "Maniac Mansion (C64/Extracted)"
-	rom ( name "00.LFL" size 1188 crc e41e3a95 md5 eea4d9ac2fb6f145945a308e8866915b )
-)
-
-game (
-	name "Maniac Mansion (C64/German)[image]"
-	description "Maniac Mansion (C64/German)[image]"
-	rom ( name "maniac1.d64" size 174848 crc f446ebdd md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (C64/German/Extracted)"
-	description "Maniac Mansion (C64/German/Extracted)"
-	rom ( name "00.LFL" size 1188 crc 9b9417d2 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (Demo/Commodore 64)"
-	description "Maniac Mansion (Demo/Commodore 64)"
-	rom ( name "maniacdemo.d64" size 174848 crc 327c1a55 md5 942398bfac774bd3f0830ff614b46db9 )
-)
-
-game (
-	name "Maniac Mansion (Demo/V1/DOS)"
-	description "Maniac Mansion (Demo/V1/DOS)"
-	rom ( name "00.MAN" size 1972 crc 6d5aa540 md5 7f45ddd6dbfbf8f80c0c0efea4c295bc )
-)
-
-game (
-	name "Maniac Mansion (Demo/V2/DOS/Russian)"
-	description "Maniac Mansion (Demo/V2/DOS/Russian)"
-	rom ( name "00.LFL" size 1988 crc c8a90058 md5 3a988de37118873ad129246b452909c0 )
-)
-
-game (
-	name "Maniac Mansion (Demo/V2/Non-Interactive/DOS)"
-	description "Maniac Mansion (Demo/V2/Non-Interactive/DOS)"
-	rom ( name "00.LFL" size 1988 crc 56aa2be8 md5 40564ec47da48a67787d1f9bd043902a )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/French)"
-	description "Maniac Mansion (Extracted/NES/French)"
-	rom ( name "00.LFL" size 2082 crc 6145b4c9 md5 1c7e7db2cfab1ad62746ab680a634204 )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/German)"
-	description "Maniac Mansion (Extracted/NES/German)"
-	rom ( name "00.LFL" size 2082 crc 8bbd3712 md5 3a5ec90d556d4920976c5578bfbfaf79 )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/Italian)"
-	description "Maniac Mansion (Extracted/NES/Italian)"
-	rom ( name "00.LFL" size 2082 crc 148df79c md5 fa3cb1541f9d7cf99ccbae6249bc150c )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/Spanish)"
-	description "Maniac Mansion (Extracted/NES/Spanish)"
-	rom ( name "00.LFL" size 2082 crc db42ce82 md5 b7d37d6b786b5a22deea3b038eca96ca )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/Swedish)"
-	description "Maniac Mansion (Extracted/NES/Swedish)"
-	rom ( name "00.LFL" size 2082 crc 1d7eda57 md5 6b5a3fef241e90d4b2e77f1e222773ee )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/UK)"
-	description "Maniac Mansion (Extracted/NES/UK)"
-	rom ( name "00.LFL" size 2082 crc 969841ae md5 17f7296f63c78642724f057fd8e736a7 )
-)
-
-game (
-	name "Maniac Mansion (Extracted/NES/US)"
-	description "Maniac Mansion (Extracted/NES/US)"
-	rom ( name "00.LFL" size 2082 crc a830a830 md5 91d5db93187fab54d823f73bd6441cb6 )
-)
-
-game (
-	name "Maniac Mansion (NES/French)"
-	description "Maniac Mansion (NES/French)"
-	rom ( name "Maniac Mansion (F).prg" size 262144 crc f4b70bfe md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/German)"
-	description "Maniac Mansion (NES/German)"
-	rom ( name "Maniac Mansion (G).prg" size 262144 crc 60ea98a0 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/Italian)"
-	description "Maniac Mansion (NES/Italian)"
-	rom ( name "Maniac Mansion (I).prg" size 262144 crc dc529482 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/Spanish)"
-	description "Maniac Mansion (NES/Spanish)"
-	rom ( name "Maniac Mansion (Sp).prg" size 262144 crc f5b2afca md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/Swedish)"
-	description "Maniac Mansion (NES/Swedish)"
-	rom ( name "Maniac Mansion (SW).prg" size 262144 crc 3f2bda65 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/UK)"
-	description "Maniac Mansion (NES/UK)"
-	rom ( name "Maniac Mansion (U).prg" size 262144 crc f59cfc3d md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (NES/US)"
-	description "Maniac Mansion (NES/US)"
-	rom ( name "Maniac Mansion (E).prg" size 262144 crc 0d9f5bd1 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (V1/DOS)[from tentacle][!]"
-	description "Maniac Mansion (V1/DOS)[from tentacle][!]"
-	rom ( name "00.LFL" size 1972 crc 6d5aa540 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga)"
-	description "Maniac Mansion (V2/Amiga)"
-	rom ( name "00.LFL" size 1988 crc 770c4c19 md5 e781230da44a44e2f0770edb2b3b3633 )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga)[a]"
-	description "Maniac Mansion (V2/Amiga)[a]"
-	rom ( name "00.LFL" size 1988 crc 770c4c19 md5 e781230da44a44e2f0770edb2b3b3633 )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga)[a2]"
-	description "Maniac Mansion (V2/Amiga)[a2]"
-	rom ( name "00.LFL" size 1988 crc 770c4c19 md5 e781230da44a44e2f0770edb2b3b3633 )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga/Fanmade Italian)"
-	description "Maniac Mansion (V2/Amiga/Fanmade Italian)"
-	rom ( name "00.LFL" size 1988 crc 6b3680d1 md5 76b97854544d3596df15f3debfcac982 )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga/French)"
-	description "Maniac Mansion (V2/Amiga/French)"
-	rom ( name "00.LFL" size 1988 crc 4e6ef6fd md5 ce7733f185b838e248927c7ba1a04204 )
-)
-
-game (
-	name "Maniac Mansion (V2/Amiga/German)"
-	description "Maniac Mansion (V2/Amiga/German)"
-	rom ( name "00.LFL" size 1988 crc bf9994ec md5 9bc548e179cdb0767009401c094d0895 )
-)
-
-game (
-	name "Maniac Mansion (V2/Atari ST)"
-	description "Maniac Mansion (V2/Atari ST)"
-	rom ( name "00.LFL" size 1988 crc b8361018 md5 a570381b028972d891052ee1e51dc011 )
-)
-
-game (
-	name "Maniac Mansion (V2/Atari ST)[a]"
-	description "Maniac Mansion (V2/Atari ST)[a]"
-	rom ( name "00.LFL" size 1988 crc d9ae3664 md5 0c331637580950aea2346e012ef2a868 )
-)
-
-game (
-	name "Maniac Mansion (V2/Atari ST/French)"
-	description "Maniac Mansion (V2/Atari ST/French)"
-	rom ( name "00.LFL" size 1988 crc f3b3dfb7 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (V2/Atari ST/German)"
-	description "Maniac Mansion (V2/Atari ST/German)"
-	rom ( name "00.LFL" size 1988 crc a45291e2 md5 undefined )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS)"
-	description "Maniac Mansion (V2/DOS)"
-	rom ( name "00.LFL" size 1988 crc 9be3c79b md5 624cdb93654667c869d204a64af7e57f )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS)[a]"
-	description "Maniac Mansion (V2/DOS)[a]"
-	rom ( name "00.LFL" size 1988 crc 5af93fe4 md5 b250d0f9cc83f80ced56fe11a4fb057c )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/French)[from tentacle]"
-	description "Maniac Mansion (V2/DOS/French)[from tentacle]"
-	rom ( name "00.LFL" size 1988 crc 55447960 md5 99a3699f80b8f776efae592b44b9b991 )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/German)[!]"
-	description "Maniac Mansion (V2/DOS/German)[!]"
-	rom ( name "00.LFL" size 1988 crc 381f97e8 md5 183d7464902d40d00800e8ee1f04117c )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/German)[patch v1.0]"
-	description "Maniac Mansion (V2/DOS/German)[patch v1.0]"
-	rom ( name "00.LFL" size 1988 crc 3284f172 md5 d690506788445fbcd91ea34f697b0d58 )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/Italian)[from tentacle]"
-	description "Maniac Mansion (V2/DOS/Italian)[from tentacle]"
-	rom ( name "00.LFL" size 1988 crc 7b5a45fa md5 87f6e8037b7cc996e13474b491a7a98e )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/Russian)"
-	description "Maniac Mansion (V2/DOS/Russian)"
-	rom ( name "00.LFL" size 1988 crc 87378e77 md5 f0d294891b813d3dcc525b89bc318815 )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/Russian)[Unk]"
-	description "Maniac Mansion (V2/DOS/Russian)[Unk]"
-	rom ( name "00.LFL" size 1988 crc 181b5ba2 md5 06865ea0fae1aeef2d6b96d8ae7ecc41 )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/Spanish)"
-	description "Maniac Mansion (V2/DOS/Spanish)"
-	rom ( name "00.LFL" size 1988 crc 709c1e1a md5 0d1b69471605201ef2fa9cec1f5f02d2 )
-)
-
-game (
-	name "Maniac Mansion (V2/DOS/Spanish)[a]"
-	description "Maniac Mansion (V2/DOS/Spanish)[a]"
-	rom ( name "00.LFL" size 1988 crc 709c1e1a md5 0d1b69471605201ef2fa9cec1f5f02d2 )
-)
-
-game (
-	name "Martian Memorandum (Demo/DOS)"
-	description "Martian Memorandum (Demo/DOS)"
-	rom ( name "ADLIB.DRV" size 7349 crc c8b45d03 md5 1bc9edd3c948eb5be95241ac13e35d8e )
-)
-
-game (
-	name "Martian Memorandum (DOS)"
-	description "Martian Memorandum (DOS)"
-	rom ( name "ADLIB.DRV" size 7375 crc 56a878aa md5 undefined )
-)
-
-game (
-	name "MD Quest: The Search for Michiel (DOS/Fanmade v0.10)"
-	description "MD Quest: The Search for Michiel (DOS/Fanmade v0.10)"
-	rom ( name "LOGDIR" size 300 crc 9a1ea3ac md5 undefined )
-)
-
-game (
-	name "Mickey's Space Adventure (DOS)"
-	description "Mickey's Space Adventure (DOS)"
-	rom ( name "1.PIC" size 2489 crc 1462b25f md5 undefined )
-)
-
-game (
-	name "Midnight Snack (Macintosh)"
-	description "Midnight Snack (Macintosh)"
-	rom ( name "._Midnight Snack" size 69378 crc c486f757 md5 81c9746089f2de477c8321d13ab89676 )
-)
-
-game (
-	name "Mirage (Windows)"
-	description "Mirage (Windows)"
-	rom ( name "data.dcp" size 17844056 crc e536f46c md5 undefined )
-)
-
-game (
-	name "Mixed-Up Fairy Tales (Demo/DOS)"
-	description "Mixed-Up Fairy Tales (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 14643 crc 13c16f7c md5 8956ad2a6583b6c665bc1c433cbf0353 )
-)
-
-game (
-	name "Mixed-Up Fairy Tales (DOS)"
-	description "Mixed-Up Fairy Tales (DOS)"
-	rom ( name "190.SCR" size 3164 crc 1293e42e md5 undefined )
-)
-
-game (
-	name "Mixed-Up Fairy Tales (DOS)[a]"
-	description "Mixed-Up Fairy Tales (DOS)[a]"
-	rom ( name "190.SCR" size 3164 crc 1293e42e md5 undefined )
-)
-
-game (
-	name "Mixed-Up Fairy Tales (DOS/EGA)"
-	description "Mixed-Up Fairy Tales (DOS/EGA)"
-	rom ( name "230.SCR" size 15460 crc 5704cdfc md5 f19b604249d4361dd0e4acc4dc3a175a )
-)
-
-game (
-	name "Mixed-Up Mother Goose (Amiga)"
-	description "Mixed-Up Mother Goose (Amiga)"
-	rom ( name "PATCH.005" size 177398 crc c2587995 md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (Apple IIgs)"
-	description "Mixed-Up Mother Goose (Apple IIgs)"
-	rom ( name "LOGDIR" size 609 crc c3372953 md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (CD/DOS/English, French, German, Spanish, Japanese)[!]"
-	description "Mixed-Up Mother Goose (CD/DOS/English, French, German, Spanish, Japanese)[!]"
-	rom ( name "AUDIO001.002" size 26850049 crc 57a9b83e md5 9db68ed3ce2d742b2b548deb63428bc0 )
-)
-
-game (
-	name "Mixed-Up Mother Goose (CoCo3)"
-	description "Mixed-Up Mother Goose (CoCo3)"
-	rom ( name "logDir" size 606 crc 3805d435 md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (Demo/Windows)"
-	description "Mixed-Up Mother Goose (Demo/Windows)"
-	rom ( name "AUDIO001.002" size 7749632 crc a88ab4d3 md5 7b8f30e66a5fb12cfe2c290f6720e065 )
-)
-
-game (
-	name "Mixed-Up Mother Goose (DOS)"
-	description "Mixed-Up Mother Goose (DOS)"
-	rom ( name "0.MAP" size 506 crc d320a55c md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (DOS/EGA)"
-	description "Mixed-Up Mother Goose (DOS/EGA)"
-	rom ( name "RESOURCE.001" size 239906 crc 40d1a345 md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (DOS/EGA)[a]"
-	description "Mixed-Up Mother Goose (DOS/EGA)[a]"
-	rom ( name "RESOURCE.000" size 140375 crc c38d6841 md5 undefined )
-)
-
-game (
-	name "Mixed-Up Mother Goose (FM-Towns)"
-	description "Mixed-Up Mother Goose (FM-Towns)"
-	rom ( name "AUDIO001.002" size 26850049 crc 57a9b83e md5 9db68ed3ce2d742b2b548deb63428bc0 )
-)
-
-game (
-	name "Mixed-Up Mother Goose (FM-Towns/Japanese)"
-	description "Mixed-Up Mother Goose (FM-Towns/Japanese)"
-	rom ( name "AUDIO081.002" size 31414272 crc c587d76f md5 e9c649b66e11f6fcc4bd1f9b4ee1f896 )
-)
-
-game (
-	name "Mixed-Up Mother Goose Deluxe (DOS/English, French, German, Spanish)"
-	description "Mixed-Up Mother Goose Deluxe (DOS/English, French, German, Spanish)"
-	rom ( name "0.MAP" size 997 crc 7004da19 md5 ba083f70e216856d1d92d4439fc27411 )
-)
-
-game (
-	name "Mixed-Up Mother Goose Deluxe (DOS/English, Spanish)"
-	description "Mixed-Up Mother Goose Deluxe (DOS/English, Spanish)"
-	rom ( name "0.MAP" size 990 crc 7c86ab70 md5 0a1a324565503383cee7ae674bf40e93 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga)"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga)"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 092100ec06890d0c934d46a5179c8043 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/French)"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/French)"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/German)"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/German)"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/German)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/German)[a]"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 092100ec06890d0c934d46a5179c8043 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/German)[a2]"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/German)[a2]"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/Italian)"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/Italian)"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 092100ec06890d0c934d46a5179c8043 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Amiga/Spanish)"
-	description "Monkey Island 2: LeChuck's Revenge (Amiga/Spanish)"
-	rom ( name "AMIGA1.IMS" size 237776 crc 5b1c2ec4 md5 092100ec06890d0c934d46a5179c8043 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Demo/Non-interactive/DOS)"
-	description "Monkey Island 2: LeChuck's Revenge (Demo/Non-interactive/DOS)"
-	rom ( name "DEMO.REC" size 37940 crc 41de4654 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS)[!]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS)[!]"
-	rom ( name "MONKEY2.000" size 11135 crc c516b625 md5 3686cf8f89e102ececf4366e1d2c8126 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS)[a]"
-	rom ( name "MONKEY2.000" size 11135 crc c516b625 md5 3686cf8f89e102ececf4366e1d2c8126 )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Fanmade German)[v1.01]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Fanmade German)[v1.01]"
-	rom ( name "MONKEY2.000" size 11135 crc c0d25885 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Fanmade Hungarian)"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Fanmade Hungarian)"
-	rom ( name "MONKEY2.000" size 11135 crc 215d50ae md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/French)"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/French)"
-	rom ( name "MONKEY2.000" size 11135 crc 876218a1 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/French)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/French)[a]"
-	rom ( name "MONKEY2.000" size 11135 crc 272d8000 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/German)"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/German)"
-	rom ( name "MONKEY2.000" size 11135 crc 49d92aaa md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/German)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/German)[a]"
-	rom ( name "MONKEY2.000" size 11135 crc 49d92aaa md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Italian)"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Italian)"
-	rom ( name "MONKEY2.000" size 11135 crc 619e0eb4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Italian)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Italian)[a]"
-	rom ( name "MONKEY2.000" size 11135 crc 8b35e6f5 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Italian)[a2]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Italian)[a2]"
-	rom ( name "MONKEY2.000" size 11135 crc 619e0eb4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Spanish)"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Spanish)"
-	rom ( name "MONKEY2.000" size 11135 crc b29dc431 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (DOS/Spanish)[a]"
-	description "Monkey Island 2: LeChuck's Revenge (DOS/Spanish)[a]"
-	rom ( name "MONKEY2.000" size 11135 crc b29dc431 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (FM-Towns)"
-	description "Monkey Island 2: LeChuck's Revenge (FM-Towns)"
-	rom ( name "MONKEY2.000" size 11135 crc e1d02ee1 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (FM-Towns/Fanmade German)"
-	description "Monkey Island 2: LeChuck's Revenge (FM-Towns/Fanmade German)"
-	rom ( name "MONKEY2.000" size 11135 crc 4fe4e05d md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (FM-Towns/Fanmade German)[v1.1]"
-	description "Monkey Island 2: LeChuck's Revenge (FM-Towns/Fanmade German)[v1.1]"
-	rom ( name "MONKEY2.000" size 11135 crc 6f97acac md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (FM-Towns/Japanese)"
-	description "Monkey Island 2: LeChuck's Revenge (FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 b91300e55b70227ce98b59c5f02fa8dd )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Macintosh)[int 1.0]"
-	description "Monkey Island 2: LeChuck's Revenge (Macintosh)[int 1.0]"
-	rom ( name "MONKEY2.000" size 10740 crc 19a415c4 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Macintosh)[int 1.2]"
-	description "Monkey Island 2: LeChuck's Revenge (Macintosh)[int 1.2]"
-	rom ( name "._iMuse Setups" size 1191936 crc b28bc9e8 md5 undefined )
-)
-
-game (
-	name "Monkey Island 2: LeChuck's Revenge (Unofficial SE Talkie v0.2/DOS)"
-	description "Monkey Island 2: LeChuck's Revenge (Unofficial SE Talkie v0.2/DOS)"
-	rom ( name "monkey2.000" size 10835 crc 13cc30ba md5 f4d20ab4ce19743a646cb48bd93aee72 )
-)
-
-game (
-	name "Monkey Man (DOS/Fanmade)"
-	description "Monkey Man (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 14f16c05 md5 2322d03f997e8cc235d4578efff69cfa )
-)
-
-game (
-	name "Moonbase Commander (Demo/Windows)"
-	description "Moonbase Commander (Demo/Windows)"
-	rom ( name "moondemo.(a)" size 103472483 crc 1a23d62e md5 482c403041a21b61b77b831e14aefc85 )
-)
-
-game (
-	name "Moonbase Commander (Windows)[!]"
-	description "Moonbase Commander (Windows)[!]"
-	rom ( name "moonbase.(a)" size 417210836 crc e4ba1df6 md5 undefined )
-)
-
-game (
-	name "Moonbase Commander (Windows)[1.1]"
-	description "Moonbase Commander (Windows)[1.1]"
-	rom ( name "moonbase.(a)" size 417198849 crc ee224872 md5 undefined )
-)
-
-game (
-	name "Mortville Manor (DOS)"
-	description "Mortville Manor (DOS)"
-	rom ( name "AXX.MOR" size 15104 crc 84ed910a md5 1bdb13fe5a86193ec5ee0bb36473f2bb )
-)
-
-game (
-	name "Mortville Manor (DOS/French)"
-	description "Mortville Manor (DOS/French)"
-	rom ( name "AXX.MOR" size 15104 crc 84ed910a md5 1bdb13fe5a86193ec5ee0bb36473f2bb )
-)
-
-game (
-	name "Mortville Manor (DOS/French)[a]"
-	description "Mortville Manor (DOS/French)[a]"
-	rom ( name "AXX.MOR" size 15104 crc 84ed910a md5 undefined )
-)
-
-game (
-	name "Mortville Manor (DOS/German)"
-	description "Mortville Manor (DOS/German)"
-	rom ( name "ALCFIEC.MOR" size 108416 crc 42c54510 md5 undefined )
-)
-
-game (
-	name "Mountain of Mayhem (Macintosh)"
-	description "Mountain of Mayhem (Macintosh)"
-	rom ( name "._Mountain of Mayhem" size 761856 crc undefined md5 undefined )
-)
-
-game (
-	name "Ms. Astro Chicken (DOS)"
-	description "Ms. Astro Chicken (DOS)"
-	rom ( name "RESOURCE.001" size 229737 crc 4837dca5 md5 a88633f1423787fd0e69a4f406d49925 )
-)
-
-game (
-	name "Myst (Demo/Windows)"
-	description "Myst (Demo/Windows)"
-	rom ( name "CREDITS.DAT" size 1311270 crc 6862fd85 md5 undefined )
-)
-
-game (
-	name "Myst (Masterpiece Edition/Windows)"
-	description "Myst (Masterpiece Edition/Windows)"
-	rom ( name "CHANNEL.DAT" size 63780140 crc 4052e5ed md5 6e8e8bf36875eb11802305a9ca4d611e )
-)
-
-game (
-	name "Myst (Masterpiece Edition/Windows/German)"
-	description "Myst (Masterpiece Edition/Windows/German)"
-	rom ( name "CHANNEL.DAT" size 63783514 crc afc8ee2a md5 7360c96ad87909f93f636d1ee48137d1 )
-)
-
-game (
-	name "Myst (Windows)[!]"
-	description "Myst (Windows)[!]"
-	rom ( name "CHANNEL.DAT" size 84081235 crc 62afc783 md5 undefined )
-)
-
-game (
-	name "Myst (Windows/French)[!]"
-	description "Myst (Windows/French)[!]"
-	rom ( name "CHANNEL.DAT" size 84083181 crc 317f6200 md5 undefined )
-)
-
-game (
-	name "Myst (Windows/German)[!]"
-	description "Myst (Windows/German)[!]"
-	rom ( name "CHANNEL.DAT" size 84080530 crc 78d754f5 md5 0852ce0b4e66d81a4264546651232212 )
-)
-
-game (
-	name "Myst (Windows/Italian)"
-	description "Myst (Windows/Italian)"
-	rom ( name "CHANNEL.DAT" size 84079017 crc a1e0581f md5 undefined )
-)
-
-game (
-	name "Myst (Windows/Russian)[Unk]"
-	description "Myst (Windows/Russian)[Unk]"
-	rom ( name "CHANNEL.DAT" size 84099861 crc ceaf809a md5 0c160879f526d96471db9062bddfe3de )
-)
-
-game (
-	name "Myst (Windows/Spanish)"
-	description "Myst (Windows/Spanish)"
-	rom ( name "CHANNEL.DAT" size 84077230 crc e617b301 md5 21cb311252a5348e87e95f5ba04108d0 )
-)
-
-game (
-	name "Napalm Quest (DOS/Fanmade v0.5)"
-	description "Napalm Quest (DOS/Fanmade v0.5)"
-	rom ( name "LOGDIR" size 333 crc 9e3ac810 md5 b659afb491d967bb34810d1c6ce22093 )
-)
-
-game (
-	name "Naturette 1 (DOS/Fanmade v1.2)"
-	description "Naturette 1 (DOS/Fanmade v1.2)"
-	rom ( name "LOGDIR" size 741 crc 0b5776c1 md5 undefined )
-)
-
-game (
-	name "Naturette 1 (DOS/Fanmade v1.3)"
-	description "Naturette 1 (DOS/Fanmade v1.3)"
-	rom ( name "LOGDIR" size 741 crc 53f51c8c md5 undefined )
-)
-
-game (
-	name "Naturette 1 (DOS/Fanmade/French v1.2)"
-	description "Naturette 1 (DOS/Fanmade/French v1.2)"
-	rom ( name "LOGDIR" size 741 crc 0a3df6e5 md5 undefined )
-)
-
-game (
-	name "Naturette 2: Daughter of the Moon (DOS/Fanmade v1.0/English, French)"
-	description "Naturette 2: Daughter of the Moon (DOS/Fanmade v1.0/English, French)"
-	rom ( name "LOGDIR" size 768 crc 43b1eb22 md5 undefined )
-)
-
-game (
-	name "Naturette 3: Adventure in Treeworld (DOS/Fanmade v1.0a/English, French)"
-	description "Naturette 3: Adventure in Treeworld (DOS/Fanmade v1.0a/English, French)"
-	rom ( name "LOGDIR" size 768 crc f295563a md5 6dbb0e7fc75fec442e6d9e5a06f1530e )
-)
-
-game (
-	name "Naturette 4: From a Planet to Another Planet (DOS/Fanmade 2007-10-05/English, French)"
-	description "Naturette 4: From a Planet to Another Planet (DOS/Fanmade 2007-10-05/English, French)"
-	rom ( name "LOGDIR" size 768 crc f5918797 md5 undefined )
-)
-
-game (
-	name "Naturette 4: From a Planet to Another Planet (DOS/Fanmade Not Finished)"
-	description "Naturette 4: From a Planet to Another Planet (DOS/Fanmade Not Finished)"
-	rom ( name "LOGDIR" size 768 crc 978848b4 md5 undefined )
-)
-
-game (
-	name "Neverhood Chronicles, The (Demo/Windows)"
-	description "Neverhood Chronicles, The (Demo/Windows)"
-	rom ( name "A.BLB" size 11973 crc ab1de4b7 md5 b42c5692e6490f4ee4302d03284060af )
-)
-
-game (
-	name "Neverhood Chronicles, The (Demo/Windows)[a]"
-	description "Neverhood Chronicles, The (Demo/Windows)[a]"
-	rom ( name "A.BLB" size 11973 crc ab1de4b7 md5 undefined )
-)
-
-game (
-	name "Neverhood Chronicles, The (DR/Windows/Russian)"
-	description "Neverhood Chronicles, The (DR/Windows/Russian)"
-	rom ( name "A.BLB" size 50437664 crc effef236 md5 4c2ac649f53b863c2b601a73367fb5ac )
-)
-
-game (
-	name "Neverhood Chronicles, The (Windows)[!]"
-	description "Neverhood Chronicles, The (Windows)[!]"
-	rom ( name "a.blb" size 50571893 crc 49660ca0 md5 90e2b47a562df6d0df87e50247040330 )
-)
-
-game (
-	name "New Adventure of Roger Wilco, The (DOS/Fanmade 1.00)"
-	description "New Adventure of Roger Wilco, The (DOS/Fanmade 1.00)"
-	rom ( name "LOGDIR" size 753 crc bf71e155 md5 e5f0a7cb8d49f66b89114951888ca688 )
-)
-
-game (
-	name "New AGI Hangman Test (DOS/Fanmade)"
-	description "New AGI Hangman Test (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 1ce45ef0 md5 d69c0e9050ccc29fd662b74d9fc73a15 )
-)
-
-game (
-	name "New Year's Mystery (DOS/Fanmade)"
-	description "New Year's Mystery (DOS/Fanmade)"
-	rom ( name "resource.001" size 295425 crc d90290a1 md5 undefined )
-)
-
-game (
-	name "New Year's Mystery (DOS/Fanmade/Updated)"
-	description "New Year's Mystery (DOS/Fanmade/Updated)"
-	rom ( name "resource.001" size 305027 crc 9858c5de md5 ac73d6bb3772e45898b0f7b624c583c3 )
-)
-
-game (
-	name "Nick's Quest: In Pursuit of QuakeMovie (DOS/Fanmade v2.1 Gold)"
-	description "Nick's Quest: In Pursuit of QuakeMovie (DOS/Fanmade v2.1 Gold)"
-	rom ( name "LOGDIR" size 300 crc a477ad22 md5 e29cbf9222551aee40397fabc83eeca0 )
-)
-
-game (
-	name "Night Train (Demo/Windows)"
-	description "Night Train (Demo/Windows)"
-	rom ( name "data.dcp" size 131760816 crc 6c132eb8 md5 77dbb8831baaf304545aa530eafc9f66 )
-)
-
-game (
-	name "Night Train (Demo/Windows)[Unk]"
-	description "Night Train (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 124495883 crc ff35f171 md5 2674466fc420d8cf062ee98d37ce276f )
-)
-
-game (
-	name "Nippon Safes Inc. (Amiga/Italian)"
-	description "Nippon Safes Inc. (Amiga/Italian)"
-	rom ( name "ADVENTURE" size 116068 crc 1175f0fe md5 d77c74f4f290d22c32a7d5bb94dad3df )
-)
-
-game (
-	name "Nippon Safes Inc. (Demo/Amiga)"
-	description "Nippon Safes Inc. (Demo/Amiga)"
-	rom ( name "DISK0" size 624640 crc b7eb40c9 md5 513a27d65a15d0652b0995a727031e7e )
-)
-
-game (
-	name "Nippon Safes Inc. (Multi-Lingual/Amiga)[En,Fr,De]"
-	description "Nippon Safes Inc. (Multi-Lingual/Amiga)[En,Fr,De]"
-	rom ( name "DISK0" size 208437 crc f2e813fe md5 2e11e84e2f45f4e37a8c0ba9bac4b941 )
-)
-
-game (
-	name "Nippon Safes Inc. (Multi-Lingual/DOS)[En,Fr,De,It]"
-	description "Nippon Safes Inc. (Multi-Lingual/DOS)[En,Fr,De,It]"
-	rom ( name "BOOGIE2.MID" size 7507 crc d93fda9b md5 undefined )
-)
-
-game (
-	name "Ocean Battle (DOS/Fanmade)"
-	description "Ocean Battle (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 142234 crc 2770f865 md5 2eaa6c52866272f0247e05e4279bbdcf )
-)
-
-game (
-	name "Oknytt (v1.0/Windows)"
-	description "Oknytt (v1.0/Windows)"
-	rom ( name "d_actors.dcp" size 43897900 crc a06b72d5 md5 undefined )
-)
-
-game (
-	name "Oknytt (v1.13/Windows)"
-	description "Oknytt (v1.13/Windows)"
-	rom ( name "english.dcp" size 293274135 crc ab67e370 md5 1cc3d7e816a6274dc16e94324f67eaa4 )
-)
-
-game (
-	name "Oknytt (v1.13/Windows/German)"
-	description "Oknytt (v1.13/Windows/German)"
-	rom ( name "german.dcp" size 304292574 crc 80e371a1 md5 undefined )
-)
-
-game (
-	name "Oknytt (v1.13/Windows/Russian)"
-	description "Oknytt (v1.13/Windows/Russian)"
-	rom ( name "russian.dcp" size 362681669 crc aed268ae md5 undefined )
-)
-
-game (
-	name "Oknytt (v1.13/Windows/Spanish)"
-	description "Oknytt (v1.13/Windows/Spanish)"
-	rom ( name "spanish.dcp" size 319406572 crc ed39140b md5 7abe00102d5a0d7ba61473ec8b8876c0 )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Amiga)"
-	description "Once Upon A Time: Abracadabra (Amiga)"
-	rom ( name "mod.babayaga" size 60248 crc ed6a70dd md5 d34e33cfa2013fb1a6c9ea3b6c7be7b5 )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Amiga/French)"
-	description "Once Upon A Time: Abracadabra (Amiga/French)"
-	rom ( name "FRENCH.ROM" size 20 crc 2cfff93e md5 51b8f0378b0aa5979f9274f40052920a )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Amiga/German)"
-	description "Once Upon A Time: Abracadabra (Amiga/German)"
-	rom ( name "GERMAN.ROM" size 20 crc 9d1a1e7b md5 226cd9a57899e66ad459306c8664cdb5 )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Amiga/Italian)"
-	description "Once Upon A Time: Abracadabra (Amiga/Italian)"
-	rom ( name "ITALIAN.ROM" size 20 crc 420440c4 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Amiga/Spanish)"
-	description "Once Upon A Time: Abracadabra (Amiga/Spanish)"
-	rom ( name "SPANISH.ROM" size 20 crc 70d59a6b md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Atari ST)"
-	description "Once Upon A Time: Abracadabra (Atari ST)"
-	rom ( name "STK1.STK" size 209806 crc bcf35c98 md5 44671af4a411fedd4d477ef0ba61dfd4 )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Atari ST/French)"
-	description "Once Upon A Time: Abracadabra (Atari ST/French)"
-	rom ( name "FRENCH.ROM" size 17 crc 0fa61655 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Atari ST/German)"
-	description "Once Upon A Time: Abracadabra (Atari ST/German)"
-	rom ( name "GERMAN.ROM" size 17 crc be43f110 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Atari ST/Italian)"
-	description "Once Upon A Time: Abracadabra (Atari ST/Italian)"
-	rom ( name "ITALIAN.ROM" size 17 crc 615dafaf md5 7e82b60a9df212c26e5b3c079ab6ddbe )
-)
-
-game (
-	name "Once Upon A Time: Abracadabra (Atari ST/Spanish)"
-	description "Once Upon A Time: Abracadabra (Atari ST/Spanish)"
-	rom ( name "SPANISH.ROM" size 17 crc 538c7500 md5 980f4fdee53467459786e37da69da31c )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Amiga)"
-	description "Once Upon A Time: Baba Yaga (Amiga)"
-	rom ( name "mod.babayaga" size 60248 crc ed6a70dd md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Amiga/French)"
-	description "Once Upon A Time: Baba Yaga (Amiga/French)"
-	rom ( name "FRENCH.ROM" size 17 crc 74fd8e6e md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Amiga/German)"
-	description "Once Upon A Time: Baba Yaga (Amiga/German)"
-	rom ( name "GERMAN.ROM" size 17 crc c518692b md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Amiga/Italian)"
-	description "Once Upon A Time: Baba Yaga (Amiga/Italian)"
-	rom ( name "ITALIAN.ROM" size 17 crc 1a063794 md5 b4f3680f1d4f6917e80d172057f326d2 )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Amiga/Spanish)"
-	description "Once Upon A Time: Baba Yaga (Amiga/Spanish)"
-	rom ( name "SPANISH.ROM" size 17 crc 28d7ed3b md5 b9406468b89f802ac6633c3f1ec4b85d )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Atari ST)"
-	description "Once Upon A Time: Baba Yaga (Atari ST)"
-	rom ( name "STK1.STK" size 205095 crc 7a2097b6 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Atari ST/French)"
-	description "Once Upon A Time: Baba Yaga (Atari ST/French)"
-	rom ( name "FRENCH.ROM" size 14 crc d0d1ed0f md5 98348301305d9e25b0e778126796dc73 )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Atari ST/German)"
-	description "Once Upon A Time: Baba Yaga (Atari ST/German)"
-	rom ( name "GERMAN.ROM" size 14 crc 61340a4a md5 5cb53873c282d00fc25d86920e11b81e )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Atari ST/Italian)"
-	description "Once Upon A Time: Baba Yaga (Atari ST/Italian)"
-	rom ( name "ITALIAN.ROM" size 14 crc be2a54f5 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (Atari ST/Spanish)"
-	description "Once Upon A Time: Baba Yaga (Atari ST/Spanish)"
-	rom ( name "SPANISH.ROM" size 14 crc 8cfb8e5a md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (DOS)"
-	description "Once Upon A Time: Baba Yaga (DOS)"
-	rom ( name "STK1.STK" size 204813 crc be94e596 md5 17684270d01fa14f5796ef96b5034334 )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (DOS/French)"
-	description "Once Upon A Time: Baba Yaga (DOS/French)"
-	rom ( name "FRENCH.ROM" size 11 crc 9c2783e2 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (DOS/German)"
-	description "Once Upon A Time: Baba Yaga (DOS/German)"
-	rom ( name "GERMAN.ROM" size 11 crc 2dc264a7 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (DOS/Italian)"
-	description "Once Upon A Time: Baba Yaga (DOS/Italian)"
-	rom ( name "ITALIAN.ROM" size 11 crc f2dc3a18 md5 b0636798e2406e9f5ec83eb90536290f )
-)
-
-game (
-	name "Once Upon A Time: Baba Yaga (DOS/Spanish)"
-	description "Once Upon A Time: Baba Yaga (DOS/Spanish)"
-	rom ( name "SPANISH.ROM" size 11 crc c00de0b7 md5 28ca50bcea21e9ed64c3e61f863f8449 )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Amiga)"
-	description "Once Upon A Time: Little Red Riding Hood (Amiga)"
-	rom ( name "INTRO.STK" size 256490 crc 38f3d731 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (DOS)"
-	description "Once Upon A Time: Little Red Riding Hood (DOS)"
-	rom ( name "ALL.ASK" size 2878 crc e3a3c81a md5 50d3edaf27127f65bdae4aef2472b09b )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (DOS/French)"
-	description "Once Upon A Time: Little Red Riding Hood (DOS/French)"
-	rom ( name "FRENCH.ROM" size 71 crc fc3c686a md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (DOS/German)"
-	description "Once Upon A Time: Little Red Riding Hood (DOS/German)"
-	rom ( name "GERMAN.ROM" size 71 crc 9fb1ce78 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (DOS/Italian)"
-	description "Once Upon A Time: Little Red Riding Hood (DOS/Italian)"
-	rom ( name "ITALIAN.ROM" size 72 crc 59b0d773 md5 fba4d19a37ea1bec47ef49ed3f13970d )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (DOS/Spanish)"
-	description "Once Upon A Time: Little Red Riding Hood (DOS/Spanish)"
-	rom ( name "SPANISH.ROM" size 72 crc 5472b95a md5 2066382b5a22ece6cde3342c6dd44f95 )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Windows)"
-	description "Once Upon A Time: Little Red Riding Hood (Windows)"
-	rom ( name "INTRO.STK" size 1187522 crc 2437eaaf md5 b9e1e8c27c3eada253d9baddb08afad9 )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Windows/French)"
-	description "Once Upon A Time: Little Red Riding Hood (Windows/French)"
-	rom ( name "FRENCH.ROM" size 102 crc c1bbc0eb md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Windows/German)"
-	description "Once Upon A Time: Little Red Riding Hood (Windows/German)"
-	rom ( name "GERMAN.ROM" size 102 crc 648dfa02 md5 undefined )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Windows/Italian)"
-	description "Once Upon A Time: Little Red Riding Hood (Windows/Italian)"
-	rom ( name "ITALIAN.ROM" size 103 crc f44a3b03 md5 b5a23a11350025fd20578e9468f518ed )
-)
-
-game (
-	name "Once Upon A Time: Little Red Riding Hood (Windows/Spanish)"
-	description "Once Upon A Time: Little Red Riding Hood (Windows/Spanish)"
-	rom ( name "SPANISH.ROM" size 103 crc a692ba77 md5 dca0ee93ec6b4de01fb61554a32a4635 )
-)
-
-game (
-	name "Open Mic Night (DOS/Fanmade v0.1)"
-	description "Open Mic Night (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 300 crc b9ecfe91 md5 undefined )
-)
-
-game (
-	name "Open Quest (Fanmade/DOS)"
-	description "Open Quest (Fanmade/DOS)"
-	rom ( name "MONSTER.SOU" size 1060381 crc 0c165fc4 md5 5374d817c37b684e76f9c87a95524fba )
-)
-
-game (
-	name "Operation Stealth (Amiga/French)"
-	description "Operation Stealth (Amiga/French)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 8932f627148e6b7c9bc6d05a3d9f2dd3 )
-)
-
-game (
-	name "Operation Stealth (Amiga/German)"
-	description "Operation Stealth (Amiga/German)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 8932f627148e6b7c9bc6d05a3d9f2dd3 )
-)
-
-game (
-	name "Operation Stealth (Amiga/Spanish)"
-	description "Operation Stealth (Amiga/Spanish)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Amiga/UK)"
-	description "Operation Stealth (Amiga/UK)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Amiga/UK)[a]"
-	description "Operation Stealth (Amiga/UK)[a]"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Amiga/US)"
-	description "Operation Stealth (Amiga/US)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Atari ST/French)"
-	description "Operation Stealth (Atari ST/French)"
-	rom ( name "DELPHINE.PRG" size 21832 crc 5a2ce66d md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Atari ST/UK)"
-	description "Operation Stealth (Atari ST/UK)"
-	rom ( name "DELPHINE.CLG" size 101508 crc 2aec904a md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Atari ST/UK)[a]"
-	description "Operation Stealth (Atari ST/UK)[a]"
-	rom ( name "DELPHINE.CLG" size 101508 crc 22204e65 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Demo/Amiga/UK)"
-	description "Operation Stealth (Demo/Amiga/UK)"
-	rom ( name "DEMO" size 69636 crc 08d8578e md5 undefined )
-)
-
-game (
-	name "Operation Stealth (Demo/DOS/UK)"
-	description "Operation Stealth (Demo/DOS/UK)"
-	rom ( name "DEMO_OS" size 270592 crc c69314b5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (DOS/French 256 Colors)"
-	description "Operation Stealth (DOS/French 256 Colors)"
-	rom ( name "EGOUBASE" size 27198 crc 40503468 md5 8ced5079ff2bd37300e9194318d144f2 )
-)
-
-game (
-	name "Operation Stealth (DOS/German)"
-	description "Operation Stealth (DOS/German)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 8932f627148e6b7c9bc6d05a3d9f2dd3 )
-)
-
-game (
-	name "Operation Stealth (DOS/Italian)"
-	description "Operation Stealth (DOS/Italian)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 8932f627148e6b7c9bc6d05a3d9f2dd3 )
-)
-
-game (
-	name "Operation Stealth (DOS/Spanish 256 Colors)"
-	description "Operation Stealth (DOS/Spanish 256 Colors)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (DOS/Spanish)"
-	description "Operation Stealth (DOS/Spanish)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation Stealth (DOS/UK 256 Colors)"
-	description "Operation Stealth (DOS/UK 256 Colors)"
-	rom ( name "EGOUBASE" size 27198 crc 40503468 md5 8ced5079ff2bd37300e9194318d144f2 )
-)
-
-game (
-	name "Operation Stealth (DOS/US)"
-	description "Operation Stealth (DOS/US)"
-	rom ( name "EGOUBASE" size 17044 crc 95003ed5 md5 undefined )
-)
-
-game (
-	name "Operation: Recon (DOS/Fanmade)"
-	description "Operation: Recon (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 642 crc c2172abb md5 undefined )
-)
-
-game (
-	name "Osama Been Skatin' (DOS/Fanmade)"
-	description "Osama Been Skatin' (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 123827 crc bc221ee8 md5 3733e7d0276d4e521dc35c2f6debf004 )
-)
-
-game (
-	name "Paintaria (Windows)"
-	description "Paintaria (Windows)"
-	rom ( name "data.dcp" size 48326040 crc 304d664d md5 076d0bbeb69d912fda220e715887da34 )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/Dutch)[!]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/Dutch)[!]"
-	rom ( name "PAJAMA.HE0" size 66377 crc b8a621d2 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/French)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/French)"
-	rom ( name "SAMPYJAM.HE0" size 66377 crc 875da0fd md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/German)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/German)"
-	rom ( name "PYJAMA.(A)" size 124585072 crc 60ef8fdf md5 491d39fd399c5be930e3e79ea2b4530c )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/US)[GOG][!]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/US)[GOG][!]"
-	rom ( name "PAJAMA.HE0" size 66368 crc ca56aed6 md5 672dec94b82f7f0877ebb5b5cf7f4bc1 )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/US/Updated)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (ALL/US/Updated)"
-	rom ( name "PajamaNHD.(a)" size 141943944 crc cf0052ee md5 701339423881b1a6792c9dd3cb82c095 )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL)[!]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL)[!]"
-	rom ( name "PJS-DEMO.HE0" size 18354 crc f5d97968 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL)[HE 100]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL)[HE 100]"
-	rom ( name "PjSamDemo.(a)" size 31125965 crc 0e91296c md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL/French)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/ALL/French)"
-	rom ( name "SAMDEMO.HE0" size 18354 crc 17389123 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/Macintosh/Dutch)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/Macintosh/Dutch)"
-	rom ( name "PJS-Demo (0)" size 18354 crc 4b8322df md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/Windows/Dutch)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Demo/Windows/Dutch)"
-	rom ( name "PJS-DEMO.HE0" size 18354 crc d599d17f md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Nintendo Wii)"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Nintendo Wii)"
-	rom ( name "PAJAMA.(a)" size 142407336 crc c19ae5dc md5 d799ddc2f6a5698962d364ba8012e68f )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Windows/Russian)[a]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Windows/Russian)[a]"
-	rom ( name "PAJAMA.HE0" size 66368 crc ca56aed6 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 1: No Need to Hide When It's Dark Outside (Windows/Russian)[Russobit-M]"
-	description "Pajama Sam 1: No Need to Hide When It's Dark Outside (Windows/Russian)[Russobit-M]"
-	rom ( name "PajamaNHD.(a)" size 127337060 crc c5f582c4 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/Dutch)"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/Dutch)"
-	rom ( name "PAJAMA2.(A)" size 98122420 crc 246284e9 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/German)"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/German)"
-	rom ( name "PyjamaDBMN.(a)" size 97912612 crc 66c5e785 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/US)[GOG][!]"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (ALL/US)[GOG][!]"
-	rom ( name "PAJAMA2.HE0" size 60557 crc 6e2cd948 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/ALL)[!]"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/ALL)[!]"
-	rom ( name "PJ2DEMO.HE0" size 58749 crc 164df975 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/ALL/Dutch)[!]"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/ALL/Dutch)[!]"
-	rom ( name "Pjs2demo.(A)" size 6120392 crc 50b34291 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/Windows/Hebrew)"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Demo/Windows/Hebrew)"
-	rom ( name "PS2DEMO.(A)" size 6141228 crc e15a7563 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Windows/French)"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Windows/French)"
-	rom ( name "PYJAM2.(A)" size 98209987 crc 6d274252 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Windows/Russian)"
-	description "Pajama Sam 2: Thunder and Lightning Aren't so Frightening (Windows/Russian)"
-	rom ( name "PajamaTAL.(a)" size 115842524 crc be705c45 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (ALL/Dutch)[!]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (ALL/Dutch)[!]"
-	rom ( name "Pajama3.(a)" size 90362711 crc 94ded985 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (ALL/US)[GOG][!]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (ALL/US)[GOG][!]"
-	rom ( name "PAJAMA3.(A)" size 90301125 crc f52d70e1 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/German)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/German)"
-	rom ( name "Gpj3demo.(a)" size 5455857 crc e4bf46fe md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/US)[!]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/US)[!]"
-	rom ( name "pj3-demo.(a)" size 5513484 crc ecef9c8a md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/US)[a][!]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/ALL/US)[a][!]"
-	rom ( name "pj3-demo.(a)" size 5513492 crc 320c26fd md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Dutch)[!]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Dutch)[!]"
-	rom ( name "PJ3DEMO.(A)" size 5570075 crc 81047d23 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/French)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/French)"
-	rom ( name "Fpj3demo.(a)" size 5431202 crc 26f67858 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/French)[a]"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/French)[a]"
-	rom ( name "FPJ3Demo.(a)" size 5496475 crc 89906796 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/German)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/German)"
-	rom ( name "Gpj3demo.(a)" size 5521055 crc 0379565d md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/Italian)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/Italian)"
-	rom ( name "pj3demo.(a)" size 5500333 crc 39ba9de5 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/UK)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/UK)"
-	rom ( name "PJ3DEMO.(A)" size 5476892 crc 1ad9ca22 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/US)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Demo/Windows/US)"
-	rom ( name "pj3-demo.(a)" size 5517718 crc 47a8b307 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (German)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (German)"
-	rom ( name "PyjamaSKS.(a)" size 90508062 crc e2247598 md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Windows/French)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Windows/French)"
-	rom ( name "PyjamaHG.(a)" size 90532821 crc 88ad34de md5 undefined )
-)
-
-game (
-	name "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Windows/Russian)"
-	description "Pajama Sam 3: You Are What You Eat from Your Head to Your Feet (Windows/Russian)"
-	rom ( name "UKPajamaEAT.(a)" size 90477242 crc 2d68bf56 md5 undefined )
-)
-
-game (
-	name "Pajama Sam: Games to Play On Any Day (ALL/US)"
-	description "Pajama Sam: Games to Play On Any Day (ALL/US)"
-	rom ( name "PJGAMES.(A)" size 57737720 crc 19e9ea70 md5 undefined )
-)
-
-game (
-	name "Pajama Sam's Lost & Found (ALL/Dutch)[!]"
-	description "Pajama Sam's Lost & Found (ALL/Dutch)[!]"
-	rom ( name "Verloren.(a)" size 24330428 crc fbb9a02c md5 89aac7adf76895ddb0e0f878c64d04a1 )
-)
-
-game (
-	name "Pajama Sam's Lost & Found (ALL/US)[GOG][!]"
-	description "Pajama Sam's Lost & Found (ALL/US)[GOG][!]"
-	rom ( name "lost.(a)" size 24482447 crc 331146e7 md5 e0499c7a9aad75122c902934aaa98b62 )
-)
-
-game (
-	name "Pajama Sam's Lost & Found (Demo/Windows)"
-	description "Pajama Sam's Lost & Found (Demo/Windows)"
-	rom ( name "smaller.(a)" size 4730153 crc c5e4b9ca md5 070702d4a191580455acee3d38d5ca9e )
-)
-
-game (
-	name "Pajama Sam's Lost & Found (Windows/Russian)[Akella]"
-	description "Pajama Sam's Lost & Found (Windows/Russian)[Akella]"
-	rom ( name "lost.(a)" size 33125896 crc 26dce376 md5 undefined )
-)
-
-game (
-	name "Pajama Sam's Lost & Found (Windows/Russian)[Russobit-M]"
-	description "Pajama Sam's Lost & Found (Windows/Russian)[Russobit-M]"
-	rom ( name "lost.(a)" size 33125896 crc 255c2d13 md5 undefined )
-)
-
-game (
-	name "Pajama Sam's One-Stop Fun Shop (ALL/US)"
-	description "Pajama Sam's One-Stop Fun Shop (ALL/US)"
-	rom ( name "SAMSFUNSHOP.(A)" size 20199889 crc c3355a4f md5 35202bb9a0fa8fa23bbc3c9b606ad6b6 )
-)
-
-game (
-	name "Pajama Sam's Sock Works (ALL/Dutch)"
-	description "Pajama Sam's Sock Works (ALL/Dutch)"
-	rom ( name "SOKKENSOEP.(A)" size 13360737 crc f47ef08e md5 6aec2509e0e76caf6c96b9daa4077733 )
-)
-
-game (
-	name "Pajama Sam's Sock Works (ALL/US)"
-	description "Pajama Sam's Sock Works (ALL/US)"
-	rom ( name "SOCKS.HE0" size 13596 crc ace37482 md5 undefined )
-)
-
-game (
-	name "Pajama Sam's Sock Works (Widows/Russian)"
-	description "Pajama Sam's Sock Works (Widows/Russian)"
-	rom ( name "SOCKS.HE0" size 13596 crc e206baaa md5 undefined )
-)
-
-game (
-	name "Pajama Sam's Sock Works (Windows/Updated)[GOG][!]"
-	description "Pajama Sam's Sock Works (Windows/Updated)[GOG][!]"
-	rom ( name "Socks.(a)" size 13393968 crc e291ee22 md5 444a8ca9598d8960ea5cd5fc7005f9ff )
-)
-
-game (
-	name "Passport to Adventure (DOS)"
-	description "Passport to Adventure (DOS)"
-	rom ( name "000.LFL" size 7857 crc 9d9d5275 md5 undefined )
-)
-
-game (
-	name "Patrick's Quest (Demo/DOS/Fanmade v1.0)"
-	description "Patrick's Quest (Demo/DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 672 crc 04bbd8b5 md5 f254f5b894b98fec5f92acc07fb62841 )
-)
-
-game (
-	name "Pepper's Adventure in Time (Demo/DOS)"
-	description "Pepper's Adventure in Time (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 1713544 crc 7c626a49 md5 undefined )
-)
-
-game (
-	name "Pepper's Adventure in Time (Demo/DOS)[a]"
-	description "Pepper's Adventure in Time (Demo/DOS)[a]"
-	rom ( name "630.MAP" size 192 crc 61caaeb2 md5 undefined )
-)
-
-game (
-	name "Pepper's Adventure in Time (Demo/Windows)"
-	description "Pepper's Adventure in Time (Demo/Windows)"
-	rom ( name "RESOURCE.000" size 1698164 crc 8cf2ffea md5 81b7cb503bbb673f5b9d6611f945bc33 )
-)
-
-game (
-	name "Pepper's Adventure in Time (DOS)"
-	description "Pepper's Adventure in Time (DOS)"
-	rom ( name "120.HEP" size 3474 crc 84fcf10d md5 250e4df22da5594ceff99e449c4a8681 )
-)
-
-game (
-	name "Periapt (Macintosh)"
-	description "Periapt (Macintosh)"
-	rom ( name "._Periapt" size 417792 crc 2264dd5b md5 1d2499ab577cb4cf5eab7e14dc12bb75 )
-)
-
-game (
-	name "Personal Nightmare (Demo/Non-Interactive/Atari ST)"
-	description "Personal Nightmare (Demo/Non-Interactive/Atari ST)"
-	rom ( name "01.IN" size 756 crc 061562a8 md5 23a4c8c4c9ac460fee7281080b5274e3 )
-)
-
-game (
-	name "Personal Nightmare (EGA/Floppy/DOS/Packed)"
-	description "Personal Nightmare (EGA/Floppy/DOS/Packed)"
-	rom ( name "01.OUT" size 4252 crc 6106ee65 md5 3a2a4c3e07dfbc4b309deade0af37baf )
-)
-
-game (
-	name "Personal Nightmare (Floppy/Amiga)"
-	description "Personal Nightmare (Floppy/Amiga)"
-	rom ( name "01.IN" size 4252 crc 16849987 md5 undefined )
-)
-
-game (
-	name "Personal Nightmare (Floppy/Atari ST)"
-	description "Personal Nightmare (Floppy/Atari ST)"
-	rom ( name "01.IN" size 4252 crc 16849987 md5 undefined )
-)
-
-game (
-	name "Phantasmagoria (Demo/DOS)"
-	description "Phantasmagoria (Demo/DOS)"
-	rom ( name "37.MAP" size 1000 crc 3e9dca20 md5 undefined )
-)
-
-game (
-	name "Phantasmagoria (DOS)"
-	description "Phantasmagoria (DOS)"
-	rom ( name "37.MAP" size 1000 crc 3e9dca20 md5 7b77cb8c323bb4f14b15cd591beb3ca5 )
-)
-
-game (
-	name "Phantasmagoria (DOS)[GOG][!]"
-	description "Phantasmagoria (DOS)[GOG][!]"
-	rom ( name "0.HEP" size 4560 crc 775bf0d6 md5 undefined )
-)
-
-game (
-	name "Phantasmagoria (DOS/Fanmade)"
-	description "Phantasmagoria (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 366 crc 3ff90891 md5 undefined )
-)
-
-game (
-	name "Phantasmagoria (DOS/French)"
-	description "Phantasmagoria (DOS/French)"
-	rom ( name "37.MAP" size 798 crc b31477a9 md5 9222616947e59d5c86ab2223c5bb4b1d )
-)
-
-game (
-	name "Phantasmagoria (DOS/German)"
-	description "Phantasmagoria (DOS/German)"
-	rom ( name "37.MAP" size 798 crc ee42798c md5 1dd692660d0aaf8afb89059fbd269ff6 )
-)
-
-game (
-	name "Phantasmagoria II: A Puzzle of Flesh (DOS)[GOG][!]"
-	description "Phantasmagoria II: A Puzzle of Flesh (DOS)[GOG][!]"
-	rom ( name "RESMAP.000" size 2956 crc d2a0aac6 md5 undefined )
-)
-
-game (
-	name "Phantasmagoria II: A Puzzle of Flesh (Windows)"
-	description "Phantasmagoria II: A Puzzle of Flesh (Windows)"
-	rom ( name "RESDUK.PAT" size 13 crc 60663b8c md5 080f44fe5dde6c4dc789fc546ed4d255 )
-)
-
-game (
-	name "Pharaoh Quest (DOS/Fanmade v0.0)"
-	description "Pharaoh Quest (DOS/Fanmade v0.0)"
-	rom ( name "LOGDIR" size 300 crc f74bb376 md5 51c630899d076cf799e573dadaa2276d )
-)
-
-game (
-	name "Phil's Quest: The Search for Tolbaga (DOS/Fanmade)"
-	description "Phil's Quest: The Search for Tolbaga (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc abbd125c md5 undefined )
-)
-
-game (
-	name "Phoenix, The (Macintosh)"
-	description "Phoenix, The (Macintosh)"
-	rom ( name "._The Phoenix" size 438272 crc undefined md5 undefined )
-)
-
-game (
-	name "Phoenix, The (Macintosh/v1.2)"
-	description "Phoenix, The (Macintosh/v1.2)"
-	rom ( name "._HAL Files" size 573440 crc c40f632e md5 a1d10ea8c58a080a600ce1b5a6ca0a3b )
-)
-
-game (
-	name "Pigeons in the Park (Windows)"
-	description "Pigeons in the Park (Windows)"
-	rom ( name "data.dcp" size 2611100 crc fe147e0c md5 undefined )
-)
-
-game (
-	name "Pinkun Maze Quest (DOS/Fanmade v0.1)"
-	description "Pinkun Maze Quest (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 300 crc aa3ab156 md5 148ff0843af389928b3939f463bfd20d )
-)
-
-game (
-	name "Pirate Quest (DOS/Fanmade)"
-	description "Pirate Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 7f45f1a9 md5 bb612a919ed2b9ea23bbf03ce69fed42 )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS)"
-	description "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS)"
-	rom ( name "ARCHI.VMD" size 5617210 crc 97ad8b85 md5 undefined )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS)[a]"
-	description "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS)[a]"
-	rom ( name "DEMARCHG.VMD" size 5619415 crc 957403ba md5 c8ac14934051b9ddbf14f7a7984cd7f7 )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS/Italian)"
-	description "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS/Italian)"
-	rom ( name "DEMARITA.VMD" size 5742533 crc 8467fcb6 md5 undefined )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS/Spanish)"
-	description "Playtoons 1: Uncle Archibald (Demo/Non-Interactive/DOS/Spanish)"
-	rom ( name "DEMARESP.VMD" size 5720619 crc 5548df3d md5 9ff29325bbca1da528a0fde62e0a0f2b )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (DOS)"
-	description "Playtoons 1: Uncle Archibald (DOS)"
-	rom ( name "ARCHI.ITK" size 182163456 crc b9b1c83b md5 8861b8131c4b13499e6c4aa8d2a835ee )
-)
-
-game (
-	name "Playtoons 1: Uncle Archibald (DOS/French)"
-	description "Playtoons 1: Uncle Archibald (DOS/French)"
-	rom ( name "ARCHI.ITK" size 150165504 crc 5c63f79f md5 undefined )
-)
-
-game (
-	name "Playtoons 2: The Case of the Counterfeit Collaborator (DOS)"
-	description "Playtoons 2: The Case of the Counterfeit Collaborator (DOS)"
-	rom ( name "DEMO.ITK" size 18065408 crc d4ba5ace md5 08d76094a7dd969127c19edcdd9434ec )
-)
-
-game (
-	name "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/French)"
-	description "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/French)"
-	rom ( name "DEMO.ITK" size 13676544 crc fb5cda15 md5 undefined )
-)
-
-game (
-	name "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/French)[v1.002]"
-	description "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/French)[v1.002]"
-	rom ( name "DEMO.ITK" size 18567168 crc 613dbf4f md5 6e875097c549a8153b6ccd7785731066 )
-)
-
-game (
-	name "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/German)"
-	description "Playtoons 2: The Case of the Counterfeit Collaborator (DOS/German)"
-	rom ( name "DEMO.ITK" size 13715456 crc ec55791a md5 undefined )
-)
-
-game (
-	name "Playtoons 3: The Secret of the Castle (DOS)"
-	description "Playtoons 3: The Secret of the Castle (DOS)"
-	rom ( name "CHATO.ITK" size 197894144 crc 188e63cd md5 fb3e3b993146d6b93eb2b03e5b2a74a4 )
-)
-
-game (
-	name "Playtoons 3: The Secret of the Castle (DOS/French)"
-	description "Playtoons 3: The Secret of the Castle (DOS/French)"
-	rom ( name "CHATO.ITK" size 150163456 crc a3ecac5c md5 undefined )
-)
-
-game (
-	name "Playtoons 3: The Secret of the Castle (DOS/German)"
-	description "Playtoons 3: The Secret of the Castle (DOS/German)"
-	rom ( name "CHATO.ITK" size 196513792 crc f4e0fe79 md5 undefined )
-)
-
-game (
-	name "Playtoons 4: The Mandarine Prince (DOS)"
-	description "Playtoons 4: The Mandarine Prince (DOS)"
-	rom ( name "DEMO.ITK" size 18065408 crc d4ba5ace md5 08d76094a7dd969127c19edcdd9434ec )
-)
-
-game (
-	name "Playtoons 4: The Mandarine Prince (DOS/French)"
-	description "Playtoons 4: The Mandarine Prince (DOS/French)"
-	rom ( name "DEMO.ITK" size 13676544 crc fb5cda15 md5 undefined )
-)
-
-game (
-	name "Playtoons 5: The Stone of Wakan (DOS/French)"
-	description "Playtoons 5: The Stone of Wakan (DOS/French)"
-	rom ( name "DEMO.ITK" size 18567168 crc 613dbf4f md5 6e875097c549a8153b6ccd7785731066 )
-)
-
-game (
-	name "Playtoons Construction Kit 1: Monsters (DOS/French)"
-	description "Playtoons Construction Kit 1: Monsters (DOS/French)"
-	rom ( name "DAN.ITK" size 3000320 crc 7816b4ce md5 undefined )
-)
-
-game (
-	name "Playtoons Construction Kit 2: Knights (DOS/French)"
-	description "Playtoons Construction Kit 2: Knights (DOS/French)"
-	rom ( name "DAN.ITK" size 3213312 crc 2e408d88 md5 7801d681b049684f4c2539c7cd3703f4 )
-)
-
-game (
-	name "Playtoons Construction Kit 3: Far West (DOS/French)"
-	description "Playtoons Construction Kit 3: Far West (DOS/French)"
-	rom ( name "DAN.ITK" size 2861056 crc c8d1453c md5 undefined )
-)
-
-game (
-	name "Playtoons Limited Edition: Bambou le sauveur de la jungle (DOS/French)"
-	description "Playtoons Limited Edition: Bambou le sauveur de la jungle (DOS/French)"
-	rom ( name "BAMBOU.ITK" size 114440192 crc d3b22163 md5 a37ac50e843b3318e5bff672865c85b9 )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (Amiga)"
-	description "Police Quest I: In Pursuit of the Death Angel (Amiga)"
-	rom ( name "DIRS" size 1613 crc ac50e433 md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (Apple IIgs/2.0A)"
-	description "Police Quest I: In Pursuit of the Death Angel (Apple IIgs/2.0A)"
-	rom ( name "LOGDIR" size 363 crc d0fb7595 md5 8994e39d0901de3d07cecfb954075bb5 )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (Apple IIgs/2.0B)"
-	description "Police Quest I: In Pursuit of the Death Angel (Apple IIgs/2.0B)"
-	rom ( name "LOGDIR" size 363 crc 69592c03 md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (Atari ST)"
-	description "Police Quest I: In Pursuit of the Death Angel (Atari ST)"
-	rom ( name "LOGDIR" size 360 crc 1ccd8b67 md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (CoCo3/Updated)"
-	description "Police Quest I: In Pursuit of the Death Angel (CoCo3/Updated)"
-	rom ( name "logDir" size 768 crc 1132ff29 md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (DOS/2.0A)"
-	description "Police Quest I: In Pursuit of the Death Angel (DOS/2.0A)"
-	rom ( name "LOGDIR" size 360 crc ff9874aa md5 b9dbb305092851da5e34d6a9f00240b1 )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (DOS/2.0A)[a]"
-	description "Police Quest I: In Pursuit of the Death Angel (DOS/2.0A)[a]"
-	rom ( name "LOGDIR" size 360 crc ff9874aa md5 b9dbb305092851da5e34d6a9f00240b1 )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (DOS/2.0E)"
-	description "Police Quest I: In Pursuit of the Death Angel (DOS/2.0E)"
-	rom ( name "LOGDIR" size 360 crc eac6f3a7 md5 2fd992a92df6ab0461d5a2cd83c72139 )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (DOS/2.0G)[!]"
-	description "Police Quest I: In Pursuit of the Death Angel (DOS/2.0G)[!]"
-	rom ( name "LOGDIR" size 360 crc 0e851173 md5 d194e5d88363095f55d5096b8e32fbbb )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (DOS/Russian)"
-	description "Police Quest I: In Pursuit of the Death Angel (DOS/Russian)"
-	rom ( name "LOGDIR" size 360 crc 8a7bc8af md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (Macintosh)"
-	description "Police Quest I: In Pursuit of the Death Angel (Macintosh)"
-	rom ( name "LOGDIR" size 384 crc 3c9d1d0a md5 undefined )
-)
-
-game (
-	name "Police Quest I: In Pursuit of the Death Angel (SCI/DOS)[!]"
-	description "Police Quest I: In Pursuit of the Death Angel (SCI/DOS)[!]"
-	rom ( name "30.HEP" size 2404 crc 24cc5b74 md5 undefined )
-)
-
-game (
-	name "Police Quest II: The Vengeance (Amiga)"
-	description "Police Quest II: The Vengeance (Amiga)"
-	rom ( name "BANK.001" size 240089 crc cfb9d015 md5 undefined )
-)
-
-game (
-	name "Police Quest II: The Vengeance (Atari ST)"
-	description "Police Quest II: The Vengeance (Atari ST)"
-	rom ( name "PQ2DS.QA" size 234 crc 4db6bcd5 md5 undefined )
-)
-
-game (
-	name "Police Quest II: The Vengeance (Atari ST)[a]"
-	description "Police Quest II: The Vengeance (Atari ST)[a]"
-	rom ( name "RESOURCE.001" size 506563 crc 8d625eaa md5 9614dfa9f4611f71acd3e777c72cc486 )
-)
-
-game (
-	name "Police Quest II: The Vengeance (Demo/DOS)"
-	description "Police Quest II: The Vengeance (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 215398 crc adf81509 md5 undefined )
-)
-
-game (
-	name "Police Quest II: The Vengeance (DOS)"
-	description "Police Quest II: The Vengeance (DOS)"
-	rom ( name "RESOURCE.001" size 509760 crc ea649cf4 md5 3bc39082a79785b8cb9d5e8d63408cee )
-)
-
-game (
-	name "Police Quest II: The Vengeance (DOS)[a1]"
-	description "Police Quest II: The Vengeance (DOS)[a1]"
-	rom ( name "P2112688.QA" size 126 crc e8c68b64 md5 9fec5e379d8a32f02206dcc1f17bc4e0 )
-)
-
-game (
-	name "Police Quest II: The Vengeance (DOS)[a2]"
-	description "Police Quest II: The Vengeance (DOS)[a2]"
-	rom ( name "P2121488.QA" size 172 crc 3db4af74 md5 7b8c8ec610ca01261dcdc1d08201001b )
-)
-
-game (
-	name "Police Quest II: The Vengeance (DOS)[a3][!]"
-	description "Police Quest II: The Vengeance (DOS)[a3][!]"
-	rom ( name "PATCH.000" size 3504 crc 7afc4165 md5 undefined )
-)
-
-game (
-	name "Police Quest II: The Vengeance (PC-98/Japanese)"
-	description "Police Quest II: The Vengeance (PC-98/Japanese)"
-	rom ( name "RESOURCE.001" size 669319 crc 0ebe9f47 md5 undefined )
-)
-
-game (
-	name "Police Quest III: The Kindred (Amiga)"
-	description "Police Quest III: The Kindred (Amiga)"
-	rom ( name "101.PAT" size 556 crc 56a66909 md5 2340213201b686da921c8f1ca8328b53 )
-)
-
-game (
-	name "Police Quest III: The Kindred (Amiga/German)"
-	description "Police Quest III: The Kindred (Amiga/German)"
-	rom ( name "101.PAT" size 556 crc 56a66909 md5 undefined )
-)
-
-game (
-	name "Police Quest III: The Kindred (Demo/DOS)"
-	description "Police Quest III: The Kindred (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 65150 crc 4961958c md5 327be611a1ecf15ab19105ed13c66f09 )
-)
-
-game (
-	name "Police Quest III: The Kindred (DOS)[!]"
-	description "Police Quest III: The Kindred (DOS)[!]"
-	rom ( name "12.SCR" size 10012 crc 43d6b20c md5 9b5d97d1190d1b0dc0e5b436deb717ab )
-)
-
-game (
-	name "Police Quest III: The Kindred (DOS/EGA)"
-	description "Police Quest III: The Kindred (DOS/EGA)"
-	rom ( name "13.SCR" size 15536 crc 530adca5 md5 2906a12be2fdf02737f9d1d80db9fc8a )
-)
-
-game (
-	name "Police Quest III: The Kindred (DOS/German)"
-	description "Police Quest III: The Kindred (DOS/German)"
-	rom ( name "RESOURCE.000" size 865204 crc 4c6ba9b6 md5 undefined )
-)
-
-game (
-	name "Police Quest III: The Kindred (DOS/Spanish)"
-	description "Police Quest III: The Kindred (DOS/Spanish)"
-	rom ( name "RESOURCE.000" size 5410263 crc 08a25b9a md5 undefined )
-)
-
-game (
-	name "Police Quest IV: Open Season (CD/DOS)[!]"
-	description "Police Quest IV: Open Season (CD/DOS)[!]"
-	rom ( name "RESOURCE.000" size 18841068 crc b05416f5 md5 468f4d4b80cae7c88066a9937046dca7 )
-)
-
-game (
-	name "Police Quest IV: Open Season (Demo/DOS)"
-	description "Police Quest IV: Open Season (Demo/DOS)"
-	rom ( name "35.HEP" size 330 crc 6b32a2aa md5 04941d662996da4297776971cae5a7b4 )
-)
-
-game (
-	name "Police Quest IV: Open Season (DOS)"
-	description "Police Quest IV: Open Season (DOS)"
-	rom ( name "170.HEP" size 3716 crc 3dcab7e4 md5 6e2ea0fecc2581eb81dd3bacd98d8231 )
-)
-
-game (
-	name "Police Quest IV: Open Season (DOS/French)"
-	description "Police Quest IV: Open Season (DOS/French)"
-	rom ( name "240.MSG" size 4174 crc 9d75bdd0 md5 undefined )
-)
-
-game (
-	name "Police Quest IV: Open Season (DOS/German)"
-	description "Police Quest IV: Open Season (DOS/German)"
-	rom ( name "65535.MAP" size 262 crc fb118b78 md5 490a9363072acede084ea85efb3dcec8 )
-)
-
-game (
-	name "Police Quest: SWAT (Demo/DOS)"
-	description "Police Quest: SWAT (Demo/DOS)"
-	rom ( name "MIDITEST.MID" size 3714 crc 64492198 md5 undefined )
-)
-
-game (
-	name "Police Quest: SWAT (DOS)[GOG][!]"
-	description "Police Quest: SWAT (DOS)[GOG][!]"
-	rom ( name "RESMAP.000" size 12175 crc ad893afe md5 undefined )
-)
-
-game (
-	name "Police Quest: SWAT (Windows)[!]"
-	description "Police Quest: SWAT (Windows)[!]"
-	rom ( name "RESMAP.001" size 6937 crc ed648b77 md5 undefined )
-)
-
-game (
-	name "Pothead (DOS/Fanmade v0.1)"
-	description "Pothead (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 765 crc b43ce12c md5 d181101385d3a45082f418cd4b3c5b01 )
-)
-
-game (
-	name "President's Quest (DOS/Fanmade)"
-	description "President's Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 2c2b5d38 md5 undefined )
-)
-
-game (
-	name "Prince Game (Galador/Windows/German)[!]"
-	description "Prince Game (Galador/Windows/German)[!]"
-	rom ( name "GALADOR.EXE" size 36380 crc a7172f75 md5 22e019ef2d2de8e61b1742610e1d7db9 )
-)
-
-game (
-	name "Prince Game (Ksiaze i Tchorz/Windows/Polish)"
-	description "Prince Game (Ksiaze i Tchorz/Windows/Polish)"
-	rom ( name "CODE.EXE" size 114688 crc d6b213b6 md5 undefined )
-)
-
-game (
-	name "Prince Quest (DOS/Fanmade)"
-	description "Prince Quest (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 603 crc 9fab376f md5 266248d75c3130c8ccc9c9bf2ad30a0d )
-)
-
-game (
-	name "Professor: Le Professeur a Disparu (DOS/Fanmade/French)"
-	description "Professor: Le Professeur a Disparu (DOS/Fanmade/French)"
-	rom ( name "LOGDIR" size 666 crc 7e9e354b md5 undefined )
-)
-
-game (
-	name "Professor: The Professor is Missing (DOS/Fanmade Mar 17)"
-	description "Professor: The Professor is Missing (DOS/Fanmade Mar 17)"
-	rom ( name "LOGDIR" size 666 crc 59d7ac20 md5 undefined )
-)
-
-game (
-	name "Professor: The Professor is Missing (DOS/Fanmade Mar 22)"
-	description "Professor: The Professor is Missing (DOS/Fanmade Mar 22)"
-	rom ( name "LOGDIR" size 666 crc cbaa32da md5 undefined )
-)
-
-game (
-	name "Project Joe (Demo/Windows)"
-	description "Project Joe (Demo/Windows)"
-	rom ( name "data.dcp" size 160780037 crc ed71fbf2 md5 undefined )
-)
-
-game (
-	name "Project Lonely Robot (beta/Windows)"
-	description "Project Lonely Robot (beta/Windows)"
-	rom ( name "data.dcp" size 3420120 crc 216e6a51 md5 fe9d1878e3f9a96a43c7f20a0be5e977 )
-)
-
-game (
-	name "Project: Doom (Windows)"
-	description "Project: Doom (Windows)"
-	rom ( name "data.dcp" size 99223761 crc 7146b333 md5 e87977c44673c9c12f50b631b08961ed )
-)
-
-game (
-	name "Putt-Putt & Fatty Bear's Activity Pack (DOS)"
-	description "Putt-Putt & Fatty Bear's Activity Pack (DOS)"
-	rom ( name "ACTIVITY.BRS" size 159430 crc 40dbd412 md5 undefined )
-)
-
-game (
-	name "Putt-Putt & Fatty Bear's Activity Pack (Macintosh)"
-	description "Putt-Putt & Fatty Bear's Activity Pack (Macintosh)"
-	rom ( name "._Putt & Fatty's Actpack" size 249856 crc 9527f1da md5 0f6f30c45ebcbbbad7a54869babf185d )
-)
-
-game (
-	name "Putt-Putt & Fatty Bear's Activity Pack (Windows)"
-	description "Putt-Putt & Fatty Bear's Activity Pack (Windows)"
-	rom ( name "ACTIVITY.BRS" size 159430 crc 40dbd412 md5 8d062b2e86eb93d77f584ceed3d041a6 )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (ALL/Updated)[HE100]"
-	description "Putt-Putt and Pep's Balloon-O-Rama (ALL/Updated)[HE100]"
-	rom ( name "BALLOON.(A)" size 31483644 crc f278ecbc md5 5ca348a5f57bffb13960ebcd1d2c36cc )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (ALL/US)[!]"
-	description "Putt-Putt and Pep's Balloon-O-Rama (ALL/US)[!]"
-	rom ( name "BALLOON.HE0" size 12800 crc e074071a md5 undefined )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (Windows/Dutch)"
-	description "Putt-Putt and Pep's Balloon-O-Rama (Windows/Dutch)"
-	rom ( name "BALLOON.HE0" size 12800 crc 970e019c md5 2232b0b9411575b1f9961713ebc9de61 )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (Windows/German)"
-	description "Putt-Putt and Pep's Balloon-O-Rama (Windows/German)"
-	rom ( name "BALLOON.HE0" size 12800 crc 378b871d md5 bab0fb81dcb12b8930c5d850b8f2a7de )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (Windows/Russian)"
-	description "Putt-Putt and Pep's Balloon-O-Rama (Windows/Russian)"
-	rom ( name "BALLOON.HE0" size 12800 crc b5b490aa md5 undefined )
-)
-
-game (
-	name "Putt-Putt and Pep's Balloon-O-Rama (Windows/Russian)[a]"
-	description "Putt-Putt and Pep's Balloon-O-Rama (Windows/Russian)[a]"
-	rom ( name "BALLOON.HE0" size 12800 crc 2580b0ed md5 27b2ef1653089fe5b897d9cc89ce784f )
-)
-
-game (
-	name "Putt-Putt and Pep's Dog on a Stick (ALL)"
-	description "Putt-Putt and Pep's Dog on a Stick (ALL)"
-	rom ( name "DOG.HE0" size 19681 crc 8b37f537 md5 eae95b2b3546d8ba86ae1d397c383253 )
-)
-
-game (
-	name "Putt-Putt and Pep's Dog on a Stick (Windows)"
-	description "Putt-Putt and Pep's Dog on a Stick (Windows)"
-	rom ( name "dog.(a)" size 10120369 crc c70063b2 md5 43821dcacadd3340396dc9bdcf9fe455 )
-)
-
-game (
-	name "Putt-Putt and Pep's Dog on a Stick (Windows/Dutch)"
-	description "Putt-Putt and Pep's Dog on a Stick (Windows/Dutch)"
-	rom ( name "DOG.HE0" size 19681 crc beaff9cc md5 undefined )
-)
-
-game (
-	name "Putt-Putt and Pep's Dog on a Stick (Windows/German)"
-	description "Putt-Putt and Pep's Dog on a Stick (Windows/German)"
-	rom ( name "DOG.HE0" size 19681 crc 2282d79e md5 839a658f7d22de00787ebc945348cdb6 )
-)
-
-game (
-	name "Putt-Putt Enters the Race (ALL/Dutch)"
-	description "Putt-Putt Enters the Race (ALL/Dutch)"
-	rom ( name "PUTT500.(A)" size 74933960 crc de1bcb02 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (ALL/German)"
-	description "Putt-Putt Enters the Race (ALL/German)"
-	rom ( name "ToffRennen.(a)" size 75327182 crc 30d0ed21 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (ALL/US)"
-	description "Putt-Putt Enters the Race (ALL/US)"
-	rom ( name "puttrace.(a)" size 74410999 crc e3dab413 md5 ef68d6670cce33d4300468d0b76b3894 )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/ALL/Dutch)[!]"
-	description "Putt-Putt Enters the Race (Demo/ALL/Dutch)[!]"
-	rom ( name "500demo.(a)" size 6460376 crc f5c96ee4 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/ALL/German)"
-	description "Putt-Putt Enters the Race (Demo/ALL/German)"
-	rom ( name "Rennen.(a)" size 6424962 crc 0e08d7f0 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/ALL/US)[!]"
-	description "Putt-Putt Enters the Race (Demo/ALL/US)[!]"
-	rom ( name "RACEDEMO.(A)" size 6521828 crc 6e892984 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/Dutch)[!]"
-	description "Putt-Putt Enters the Race (Demo/Windows/Dutch)[!]"
-	rom ( name "racedemo.(a)" size 6387690 crc caf2bd3a md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/French)"
-	description "Putt-Putt Enters the Race (Demo/Windows/French)"
-	rom ( name "CourseDemo.(a)" size 6641935 crc 02a6bb40 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/French)[a1]"
-	description "Putt-Putt Enters the Race (Demo/Windows/French)[a1]"
-	rom ( name "coursedemo.(a)" size 6664112 crc 711b8c89 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/French)[a2]"
-	description "Putt-Putt Enters the Race (Demo/Windows/French)[a2]"
-	rom ( name "coursedemo.(a)" size 6664115 crc 53412417 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/German)"
-	description "Putt-Putt Enters the Race (Demo/Windows/German)"
-	rom ( name "Rennen.(a)" size 6404762 crc c73f001d md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/Italian)"
-	description "Putt-Putt Enters the Race (Demo/Windows/Italian)"
-	rom ( name "Racedemo.(a)" size 6550420 crc 4f81a0ad md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Demo/Windows/UK)"
-	description "Putt-Putt Enters the Race (Demo/Windows/UK)"
-	rom ( name "RACEDEMO.(A)" size 6406987 crc 3bde51d2 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Preview)"
-	description "Putt-Putt Enters the Race (Preview)"
-	rom ( name "RACEDEMO.CUP" size 3901484 crc ede85ce8 md5 525613eebe8913141271756f4c40f1ae )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Windows/French)"
-	description "Putt-Putt Enters the Race (Windows/French)"
-	rom ( name "COURSE.(A)" size 74935349 crc 053d866d md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Windows/Russian)"
-	description "Putt-Putt Enters the Race (Windows/Russian)"
-	rom ( name "PUTTRACE.(A)" size 74410999 crc 7948c784 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Windows/Russian)[Akella]"
-	description "Putt-Putt Enters the Race (Windows/Russian)[Akella]"
-	rom ( name "uKPuttRace.(a)" size 74814568 crc fef60c35 md5 9cfc747ddfbe84f9fc15085f744f8380 )
-)
-
-game (
-	name "Putt-Putt Enters the Race (Windows/Russian)[Russobit-M]"
-	description "Putt-Putt Enters the Race (Windows/Russian)[Russobit-M]"
-	rom ( name "UKPuttRace.(a)" size 74814568 crc 7596bc67 md5 cde08c76ce62dcb6081a3fb7dfd2bc89 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (3DO)"
-	description "Putt-Putt Goes to the Moon (3DO)"
-	rom ( name "PUTTM01.DMU" size 1484156 crc 561c69f8 md5 aeb2aa8877ceee35f5283ddf9e0d664a )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Demo/DOS)"
-	description "Putt-Putt Goes to the Moon (Demo/DOS)"
-	rom ( name "MOONDEMO.HE0" size 6233 crc 3e0a2758 md5 aa6a91b7f6f119d1b7b1f2a4c9e24d59 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Demo/Macintosh)"
-	description "Putt-Putt Goes to the Moon (Demo/Macintosh)"
-	rom ( name "Putt-Putt Moon Demo 0" size 6233 crc a85342d1 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Demo/Windows)[!]"
-	description "Putt-Putt Goes to the Moon (Demo/Windows)[!]"
-	rom ( name "MOONDEMO.HE0" size 8856 crc cdb8642b md5 9c143c5905055d5df7a0f014ab379aee )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (DOS)[!]"
-	description "Putt-Putt Goes to the Moon (DOS)[!]"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 19113cc2ecc1dc24c70c46ae015abd78 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (DOS)[a]"
-	description "Putt-Putt Goes to the Moon (DOS)[a]"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 19113cc2ecc1dc24c70c46ae015abd78 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (DOS/Hebrew)"
-	description "Putt-Putt Goes to the Moon (DOS/Hebrew)"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 undefined )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (DOS/Russian)"
-	description "Putt-Putt Goes to the Moon (DOS/Russian)"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 19113cc2ecc1dc24c70c46ae015abd78 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Macintosh)"
-	description "Putt-Putt Goes to the Moon (Macintosh)"
-	rom ( name "._Putt-Putt Moon" size 577536 crc 9008a19e md5 undefined )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Windows)[!]"
-	description "Putt-Putt Goes to the Moon (Windows)[!]"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 19113cc2ecc1dc24c70c46ae015abd78 )
-)
-
-game (
-	name "Putt-Putt Goes to the Moon (Windows/Russian)"
-	description "Putt-Putt Goes to the Moon (Windows/Russian)"
-	rom ( name "PUTTMOON.BRS" size 45564 crc d402deda md5 19113cc2ecc1dc24c70c46ae015abd78 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (ALL)"
-	description "Putt-Putt Joins the Circus (ALL)"
-	rom ( name "puttcircus.(a)" size 97411959 crc df916947 md5 2efc1faef85c78dbfe91d46fcc26a3ec )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (ALL/Dutch)"
-	description "Putt-Putt Joins the Circus (ALL/Dutch)"
-	rom ( name "PuttIHC.(a)" size 97421557 crc 85db4ff7 md5 439b286862ec6a863d6ef2fb2dffd0d0 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Demo/ALL)[!]"
-	description "Putt-Putt Joins the Circus (Demo/ALL)[!]"
-	rom ( name "circdemo.(a)" size 5953808 crc 52aa7da1 md5 d78d1eff392096c83687231fe2e78c6b )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Demo/Windows/French)"
-	description "Putt-Putt Joins the Circus (Demo/Windows/French)"
-	rom ( name "circusdemo.(a)" size 5986556 crc 3eb9f32e md5 056befcf0dce3942f3e23c9306b8c267 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Demo/Windows/Hebrew)"
-	description "Putt-Putt Joins the Circus (Demo/Windows/Hebrew)"
-	rom ( name "CIRCDEMO.(A)" size 5987610 crc f0f3adb9 md5 ed3ea79ec9582f863d3a2b514add28a0 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Russian)[Akella]"
-	description "Putt-Putt Joins the Circus (Russian)[Akella]"
-	rom ( name "puttcircus.(a)" size 97847773 crc d99441b7 md5 762a30bbddced3d653bcb4013d63b4b6 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Russian)[Russobit-M]"
-	description "Putt-Putt Joins the Circus (Russian)[Russobit-M]"
-	rom ( name "puttcircus.(a)" size 97847773 crc a210dceb md5 undefined )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Windows/French)"
-	description "Putt-Putt Joins the Circus (Windows/French)"
-	rom ( name "PouceDLC.(a)" size 97458862 crc f7ed7fc4 md5 e0caf8abe8e1fd7d9b44a8fb94cf8ae5 )
-)
-
-game (
-	name "Putt-Putt Joins the Circus (Windows/German)"
-	description "Putt-Putt Joins the Circus (Windows/German)"
-	rom ( name "ToffToffGZZ.(a)" size 97351039 crc 9498c4ae md5 7c5ecb6a31f5b91ca24e2bd2ecaae3c5 )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (3DO)"
-	description "Putt-Putt Joins the Parade (3DO)"
-	rom ( name "BREEZY.DMU" size 1145686 crc d62548b5 md5 c817613033ceb12eb4c31ea6c336808f )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (3DO)[a]"
-	description "Putt-Putt Joins the Parade (3DO)[a]"
-	rom ( name "BREEZY.DMU" size 1145686 crc d62548b5 md5 c817613033ceb12eb4c31ea6c336808f )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (3DO/Japanese)"
-	description "Putt-Putt Joins the Parade (3DO/Japanese)"
-	rom ( name "BREEZY.DMU" size 1145686 crc d62548b5 md5 c817613033ceb12eb4c31ea6c336808f )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (Demo/DOS)"
-	description "Putt-Putt Joins the Parade (Demo/DOS)"
-	rom ( name "PUTTDEMO.HE0" size 6150 crc 52d7a1f8 md5 31aa57f460a3d12429f0552a46a90b39 )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (Demo/Macintosh)"
-	description "Putt-Putt Joins the Parade (Demo/Macintosh)"
-	rom ( name "Putt-Putt's Demo 0" size 6160 crc 28a94dc5 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (Demo/Windows)[!]"
-	description "Putt-Putt Joins the Parade (Demo/Windows)[!]"
-	rom ( name "PUTTDEMO.HE0" size 8269 crc 36e7ad27 md5 37ff1b308999c4cca7319edfcc1280a0 )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (DOS)[!]"
-	description "Putt-Putt Joins the Parade (DOS)[!]"
-	rom ( name "PUTTPUTT.HE0" size 8117 crc 5eba3918 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (DOS)[HE 60]"
-	description "Putt-Putt Joins the Parade (DOS)[HE 60]"
-	rom ( name "PUTTPUTT.HE0" size 8022 crc 7f2e58bb md5 7766c9487f9d53a8cb0edabda5119c3d )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (DOS/Hebrew)"
-	description "Putt-Putt Joins the Parade (DOS/Hebrew)"
-	rom ( name "PUTTPUTT.HE0" size 8032 crc ee5b8e14 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (DOS/Russian)"
-	description "Putt-Putt Joins the Parade (DOS/Russian)"
-	rom ( name "PUTTPUTT.HE0" size 8107 crc cb488496 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (Macintosh)"
-	description "Putt-Putt Joins the Parade (Macintosh)"
-	rom ( name "Putt-Putt Parade 0" size 8122 crc 2f3d9931 md5 684732efb5799c0f78804c99d8de9aba )
-)
-
-game (
-	name "Putt-Putt Joins the Parade (Windows)[!]"
-	description "Putt-Putt Joins the Parade (Windows)[!]"
-	rom ( name "PUTTPUTT.HE0" size 12728 crc ece405b0 md5 6a30a07f353a75cdc602db27d73e1b42 )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (ALL/Updated)"
-	description "Putt-Putt Saves the Zoo (ALL/Updated)"
-	rom ( name "PUTTZOO.(A)" size 95810519 crc 48031138 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Macintosh)"
-	description "Putt-Putt Saves the Zoo (Demo/Macintosh)"
-	rom ( name "Puttzoo Demo" size 403411 crc cc4a6824 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Windows)"
-	description "Putt-Putt Saves the Zoo (Demo/Windows)"
-	rom ( name "Zoodemo.he0" size 14337 crc 178c7025 md5 f3d55aea441e260e9e9c7d2a187097e0 )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Windows/Dutch)"
-	description "Putt-Putt Saves the Zoo (Demo/Windows/Dutch)"
-	rom ( name "ZOODEMO.HE0" size 14337 crc b6272693 md5 aa81aa6d5545ce172fdba81f2e2f9d36 )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Windows/French)"
-	description "Putt-Putt Saves the Zoo (Demo/Windows/French)"
-	rom ( name "ZOODEMO.HE0" size 14337 crc 78961237 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Windows/German)"
-	description "Putt-Putt Saves the Zoo (Demo/Windows/German)"
-	rom ( name "ZOODEMO.HE0" size 14328 crc d59e9aec md5 2a446817ffcabfef8716e0c456ecaf81 )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Demo/Windows/US)[!]"
-	description "Putt-Putt Saves the Zoo (Demo/Windows/US)[!]"
-	rom ( name "ZOODEMO.HE0" size 14337 crc 73568f3f md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Macintosh)"
-	description "Putt-Putt Saves the Zoo (Macintosh)"
-	rom ( name "._Putt-Putt Saves the Zoo" size 479232 crc 84680009 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Macintosh/Dutch)[!]"
-	description "Putt-Putt Saves the Zoo (Macintosh/Dutch)[!]"
-	rom ( name "._Putt-Putt Redt De Zoo" size 352256 crc 6e3181fa md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Windows)[!]"
-	description "Putt-Putt Saves the Zoo (Windows)[!]"
-	rom ( name "PUTTZOO.HE0" size 41998 crc 73a91ded md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Windows/Dutch)[!]"
-	description "Putt-Putt Saves the Zoo (Windows/Dutch)[!]"
-	rom ( name "PUTTZOO.HE0" size 42079 crc ae559df5 md5 c3b22fa4654bb580b20325ebf4174841 )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Windows/French)"
-	description "Putt-Putt Saves the Zoo (Windows/French)"
-	rom ( name "PUTTZOO.HE0" size 42070 crc cea1f032 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Windows/German)"
-	description "Putt-Putt Saves the Zoo (Windows/German)"
-	rom ( name "PUTTZOO.HE0" size 42070 crc 055c69c4 md5 0f9d3317910ac7a9f449243118884ada )
-)
-
-game (
-	name "Putt-Putt Saves the Zoo (Windows/Russian)[Fargus]"
-	description "Putt-Putt Saves the Zoo (Windows/Russian)[Fargus]"
-	rom ( name "PUTTZOO.HE0" size 41998 crc 73a91ded md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL)"
-	description "Putt-Putt Travels Through Time (ALL)"
-	rom ( name "PUTTTIME.HE0" size 62582 crc 33136767 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL/Dutch)[!]"
-	description "Putt-Putt Travels Through Time (ALL/Dutch)[!]"
-	rom ( name "PUTTTIJD.HE0" size 62582 crc 896b49bd md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL/French)"
-	description "Putt-Putt Travels Through Time (ALL/French)"
-	rom ( name "POUCE.HE0" size 62582 crc ac9e76e4 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL/German/Updated)"
-	description "Putt-Putt Travels Through Time (ALL/German/Updated)"
-	rom ( name "ToffZeit.(a)" size 133927366 crc a12b3ad6 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL/US/Updated)"
-	description "Putt-Putt Travels Through Time (ALL/US/Updated)"
-	rom ( name "PuttTime.(a)" size 133791791 crc 6861b538 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (ALL/US/Updated)[HE 100]"
-	description "Putt-Putt Travels Through Time (ALL/US/Updated)[HE 100]"
-	rom ( name "PuttTTT.(a)" size 151414849 crc cd52ef60 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Demo/ALL/French)"
-	description "Putt-Putt Travels Through Time (Demo/ALL/French)"
-	rom ( name "TEMPDEMO.HE0" size 18394 crc 1ba6fafb md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Demo/ALL/US)[!]"
-	description "Putt-Putt Travels Through Time (Demo/ALL/US)[!]"
-	rom ( name "TIMEDEMO.HE0" size 18394 crc c7e61b3d md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Demo/German)"
-	description "Putt-Putt Travels Through Time (Demo/German)"
-	rom ( name "ZEITDEMO.HE0" size 18403 crc 2b709008 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Demo/US)"
-	description "Putt-Putt Travels Through Time (Demo/US)"
-	rom ( name "TimeDemo.(a)" size 28520383 crc b632ad4a md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Demo/Windows/Dutch)"
-	description "Putt-Putt Travels Through Time (Demo/Windows/Dutch)"
-	rom ( name "TIJDDEMO.HE0" size 18403 crc a8978ce6 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Windows/German)"
-	description "Putt-Putt Travels Through Time (Windows/German)"
-	rom ( name "TOFFZEIT.HE0" size 62582 crc 056debf5 md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Windows/Russian)[Akella]"
-	description "Putt-Putt Travels Through Time (Windows/Russian)[Akella]"
-	rom ( name "PuttPuttTTT.(a)" size 135107758 crc 8f43410b md5 undefined )
-)
-
-game (
-	name "Putt-Putt Travels Through Time (Windows/Russian)[Russobit-M]"
-	description "Putt-Putt Travels Through Time (Windows/Russian)[Russobit-M]"
-	rom ( name "PuttPuttTTT.(a)" size 135107758 crc a3935f19 md5 4a7452aabc69cdaf897ccc099ff0bafa )
-)
-
-game (
-	name "Putt-Putt's Fun Pack (3DO)"
-	description "Putt-Putt's Fun Pack (3DO)"
-	rom ( name "BREEZY.DMU" size 1145686 crc d62548b5 md5 c817613033ceb12eb4c31ea6c336808f )
-)
-
-game (
-	name "Putt-Putt's Fun Pack (3DO/Japanese)"
-	description "Putt-Putt's Fun Pack (3DO/Japanese)"
-	rom ( name "BREEZY.DMU" size 1145686 crc d62548b5 md5 c817613033ceb12eb4c31ea6c336808f )
-)
-
-game (
-	name "Putt-Putt's Fun Pack (DOS)"
-	description "Putt-Putt's Fun Pack (DOS)"
-	rom ( name "FUNPACK.HE0" size 5798 crc 4e7c3215 md5 3d219e7546039543307b55a91282bf18 )
-)
-
-game (
-	name "Putt-Putt's Fun Pack (DOS)[a]"
-	description "Putt-Putt's Fun Pack (DOS)[a]"
-	rom ( name "FUNPACK.HE0" size 5798 crc 8abc1051 md5 undefined )
-)
-
-game (
-	name "Putt-Putt's Fun Pack (DOS/Hebrew)"
-	description "Putt-Putt's Fun Pack (DOS/Hebrew)"
-	rom ( name "FUNPACK.HE0" size 5798 crc a117426a md5 90a329d8ad5b7ce0690429e98cfbb32f )
-)
-
-game (
-	name "Putt-Putt's One-Stop Fun Shop (ALL/US)"
-	description "Putt-Putt's One-Stop Fun Shop (ALL/US)"
-	rom ( name "PUTTSFUNSHOP.(A)" size 21042989 crc 30bedd4d md5 undefined )
-)
-
-game (
-	name "Puzzle Piece Search (Macintosh)"
-	description "Puzzle Piece Search (Macintosh)"
-	rom ( name "._Puzzle Piece Search" size 252852 crc 98835d9c md5 af179f437adfa8ca80437b3bcf4b5b39 )
-)
-
-game (
-	name "Pyramid of Ert (Macintosh)"
-	description "Pyramid of Ert (Macintosh)"
-	rom ( name "._Pyramid of Ert V1.2" size 323584 crc undefined md5 undefined )
-)
-
-game (
-	name "Pyramid of No Return (Macintosh)"
-	description "Pyramid of No Return (Macintosh)"
-	rom ( name "._Pyramid of No Return" size 392090 crc f3c1d1b3 md5 5040219648b0dd1c41ffe39a4f5dd038 )
-)
-
-game (
-	name "Quest for a Record Deal (DOS/Fanmade)"
-	description "Quest for a Record Deal (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc f42c5a07 md5 f4fbd7abf056d2d3204f790da5ac89ab )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (Amiga)"
-	description "Quest for Glory I: So You Want to Be a Hero (Amiga)"
-	rom ( name "BANK.001" size 228259 crc 9621d676 md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (Atari ST)"
-	description "Quest for Glory I: So You Want to Be a Hero (Atari ST)"
-	rom ( name "RESOURCE.000" size 79204 crc 5fe18f4e md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (Demo/DOS)"
-	description "Quest for Glory I: So You Want to Be a Hero (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 389884 crc ceadd6df md5 d0d0eef77db678099048ae2d7fff3336 )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (Demo/DOS/VGA)"
-	description "Quest for Glory I: So You Want to Be a Hero (Demo/DOS/VGA)"
-	rom ( name "RESOURCE.000" size 768218 crc 82e13c9e md5 2ca9beb033c1aaad0bd5c443b9408988 )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (DOS)[!]"
-	description "Quest for Glory I: So You Want to Be a Hero (DOS)[!]"
-	rom ( name "RESOURCE.000" size 79181 crc df8a1b9f md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (DOS)[a1]"
-	description "Quest for Glory I: So You Want to Be a Hero (DOS)[a1]"
-	rom ( name "RESOURCE.000" size 80334 crc 4d999fe6 md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (DOS)[a2]"
-	description "Quest for Glory I: So You Want to Be a Hero (DOS)[a2]"
-	rom ( name "RESOURCE.000" size 80334 crc 4d999fe6 md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (DOS)[a3]"
-	description "Quest for Glory I: So You Want to Be a Hero (DOS)[a3]"
-	rom ( name "RESOURCE.000" size 78800 crc 278fbe58 md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (DOS/VGA)[!]"
-	description "Quest for Glory I: So You Want to Be a Hero (DOS/VGA)[!]"
-	rom ( name "120.HEP" size 322 crc fa7a09c1 md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (Macintosh)"
-	description "Quest for Glory I: So You Want to Be a Hero (Macintosh)"
-	rom ( name "._Data1" size 1768667 crc 2526bfea md5 undefined )
-)
-
-game (
-	name "Quest for Glory I: So You Want to Be a Hero (PC-98/Japanese 8 Colors)"
-	description "Quest for Glory I: So You Want to Be a Hero (PC-98/Japanese 8 Colors)"
-	rom ( name "RESOURCE.001" size 859959 crc 6efe4620 md5 c9831363698a16a7263e5cf79006ffd6 )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (Amiga)"
-	description "Quest for Glory II: Trial by Fire (Amiga)"
-	rom ( name "PATCH.005" size 196714 crc 43fb9f8b md5 undefined )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (Demo/DOS)"
-	description "Quest for Glory II: Trial by Fire (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 362123 crc 78c2c9de md5 281b506764ed3e0728ce20cbecca2315 )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (DOS)[!]"
-	description "Quest for Glory II: Trial by Fire (DOS)[!]"
-	rom ( name "RESOURCE.000" size 212120 crc 3d60805e md5 undefined )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (DOS)[a1]"
-	description "Quest for Glory II: Trial by Fire (DOS)[a1]"
-	rom ( name "RESOURCE.000" size 212151 crc 5a26445d md5 1e7e6a82ef7f96375032ded513f9c465 )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (DOS)[a2]"
-	description "Quest for Glory II: Trial by Fire (DOS)[a2]"
-	rom ( name "RESOURCE.000" size 212119 crc 58dd3f24 md5 undefined )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (DOS)[a3]"
-	description "Quest for Glory II: Trial by Fire (DOS)[a3]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 undefined )
-)
-
-game (
-	name "Quest for Glory II: Trial by Fire (DOS)[a4]"
-	description "Quest for Glory II: Trial by Fire (DOS)[a4]"
-	rom ( name "FONT.000" size 1782 crc 69161c49 md5 4ff2dc339352972581da584cc0a8d2f1 )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (Demo/DOS)[!]"
-	description "Quest for Glory III: Wages of War (Demo/DOS)[!]"
-	rom ( name "0.MAP" size 32 crc 3ef0b381 md5 880b312d09e18ee6ad1c230ec9a2fecc )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS)[!]"
-	description "Quest for Glory III: Wages of War (DOS)[!]"
-	rom ( name "140.HEP" size 2390 crc 7ebd7543 md5 e09cdb5d1d0168971c6d16f83b25d084 )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS)[a]"
-	description "Quest for Glory III: Wages of War (DOS)[a]"
-	rom ( name "140.HEP" size 2390 crc 7ebd7543 md5 undefined )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS/French)[!]"
-	description "Quest for Glory III: Wages of War (DOS/French)[!]"
-	rom ( name "0.FON" size 2543 crc 7b388472 md5 40c7a644296284b7d638e8e8805d1171 )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS/German)[!]"
-	description "Quest for Glory III: Wages of War (DOS/German)[!]"
-	rom ( name "0.FON" size 2641 crc 34c84c20 md5 7a4b4bc460314444afc790b16a45668a )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS/Italian)[!]"
-	description "Quest for Glory III: Wages of War (DOS/Italian)[!]"
-	rom ( name "0.FON" size 2543 crc 7b388472 md5 undefined )
-)
-
-game (
-	name "Quest for Glory III: Wages of War (DOS/Spanish)[!]"
-	description "Quest for Glory III: Wages of War (DOS/Spanish)[!]"
-	rom ( name "510.HEP" size 2520 crc b05060f7 md5 undefined )
-)
-
-game (
-	name "Quest for Glory IV: Shadows of Darkness (CD/DOS)[!]"
-	description "Quest for Glory IV: Shadows of Darkness (CD/DOS)[!]"
-	rom ( name "65535.MAP" size 237 crc 70a0db36 md5 d0aac15865900fb59d989dc4b5a1e81f )
-)
-
-game (
-	name "Quest for Glory IV: Shadows of Darkness (Demo/DOS)"
-	description "Quest for Glory IV: Shadows of Darkness (Demo/DOS)"
-	rom ( name "610.SND" size 3882 crc 7c1043e4 md5 undefined )
-)
-
-game (
-	name "Quest for Glory IV: Shadows of Darkness (DOS)"
-	description "Quest for Glory IV: Shadows of Darkness (DOS)"
-	rom ( name "19.MSG" size 6045 crc 8641b2cc md5 da6e76e7a28fc3e518fe6e7ada29d4f0 )
-)
-
-game (
-	name "Quest for Glory IV: Shadows of Darkness (DOS)[a]"
-	description "Quest for Glory IV: Shadows of Darkness (DOS)[a]"
-	rom ( name "250.HEP" size 4088 crc 2ba3a5d8 md5 a081fb488a009f3539dfc1f3047723b8 )
-)
-
-game (
-	name "Quest for Glory IV: Shadows of Darkness (DOS/German)[!]"
-	description "Quest for Glory IV: Shadows of Darkness (DOS/German)[!]"
-	rom ( name "330.HEP" size 1998 crc 95ddb187 md5 e21294df0d9321e68c47a8e3e53969b5 )
-)
-
-game (
-	name "Quest for Glory VI: Hero's Adventure (DOS/Fanmade)"
-	description "Quest for Glory VI: Hero's Adventure (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc d728a9c8 md5 undefined )
-)
-
-game (
-	name "Quest for Home (DOS/Fanmade)"
-	description "Quest for Home (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc dba39c36 md5 d2895dc1cd3930f2489af0f843b144b3 )
-)
-
-game (
-	name "Quest for Ladies (Demo/DOS/Fanmade v1.1 Apr 1)"
-	description "Quest for Ladies (Demo/DOS/Fanmade v1.1 Apr 1)"
-	rom ( name "LOGDIR" size 300 crc 3386fcc1 md5 3f6e02f16e1154a0daf296c8895edd97 )
-)
-
-game (
-	name "Quest for Ladies (Demo/DOS/Fanmade v1.1 Apr 6)"
-	description "Quest for Ladies (Demo/DOS/Fanmade v1.1 Apr 6)"
-	rom ( name "LOGDIR" size 300 crc c42039f8 md5 f75e7b6a0769a3fa926eea0854711591 )
-)
-
-game (
-	name "Quest for Piracy 1: Enter the Silver Pirate (DOS/Fanmade v0.15)"
-	description "Quest for Piracy 1: Enter the Silver Pirate (DOS/Fanmade v0.15)"
-	rom ( name "LOGDIR" size 300 crc 68307f25 md5 d23f5c2a26f6dc60c686f8a2436ea4a6 )
-)
-
-game (
-	name "Quest for T-Rex (Macintosh)"
-	description "Quest for T-Rex (Macintosh)"
-	rom ( name "._Quest for T-Rex" size 604266 crc 5f5a405c md5 undefined )
-)
-
-game (
-	name "Quest for the Cheat (DOS/Fanmade)"
-	description "Quest for the Cheat (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 455209 crc b99232aa md5 5cdcd32f8b2bd02c5a20f2d12a1725eb )
-)
-
-game (
-	name "Quest for the Dark Sword (Macintosh)"
-	description "Quest for the Dark Sword (Macintosh)"
-	rom ( name "._Quest for the Dark Sword" size 590631 crc 37f6f825 md5 53aae52a35dcf939d7139270861c125b )
-)
-
-game (
-	name "Radical Castle 1.0 (Macintosh)"
-	description "Radical Castle 1.0 (Macintosh)"
-	rom ( name "._Radical Castle 1.0" size 356352 crc e3d0d63e md5 bf88e4dc198563fe2861be7e684fc1fa )
-)
-
-game (
-	name "Ralph's Quest (DOS/Fanmade v0.1)"
-	description "Ralph's Quest (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 300 crc 6263ed7c md5 5cf56378aa01a26ec30f25295f0750ca )
-)
-
-game (
-	name "RAMA (Demo/Windows)"
-	description "RAMA (Demo/Windows)"
-	rom ( name "DEMO.BAK" size 1550 crc 9be0844b md5 undefined )
-)
-
-game (
-	name "RAMA (Windows)"
-	description "RAMA (Windows)"
-	rom ( name "PROLOGUE.DAT" size 1457 crc 2d421d20 md5 undefined )
-)
-
-game (
-	name "RAMA (Windows/German)"
-	description "RAMA (Windows/German)"
-	rom ( name "PROLOGUE.DAT" size 1389 crc 8ef3aaba md5 432ecd4f1cf0b3a30cebba59d0f99db4 )
-)
-
-game (
-	name "RAMA (Windows/Italian)"
-	description "RAMA (Windows/Italian)"
-	rom ( name "PROLOGUE.DAT" size 1318 crc e14135a0 md5 9d050921dd0ef1f50463bc9c95b90bc1 )
-)
-
-game (
-	name "Ray's Maze (Macintosh/v1.5)"
-	description "Ray's Maze (Macintosh/v1.5)"
-	rom ( name "._Ray's Maze1.5" size 1437138 crc undefined md5 undefined )
-)
-
-game (
-	name "Ray's Maze (Macintosh/v1.5)[a]"
-	description "Ray's Maze (Macintosh/v1.5)[a]"
-	rom ( name "._Ray's Maze1.5" size 1437138 crc e8c4b6f3 md5 2917296cd9ad216e99ddb8661a30aada )
-)
-
-game (
-	name "Residence 44 Quest (DOS/Fanmade v0.99)"
-	description "Residence 44 Quest (DOS/Fanmade v0.99)"
-	rom ( name "LOGDIR" size 765 crc fe45d8d5 md5 undefined )
-)
-
-game (
-	name "Residence 44 Quest (DOS/Fanmade v1.0a)"
-	description "Residence 44 Quest (DOS/Fanmade v1.0a)"
-	rom ( name "LOGDIR" size 765 crc c30385d0 md5 f99e3f69dc8c77a45399da9472ef5801 )
-)
-
-game (
-	name "Residence 44 Quest (DOS/Fanmade/Dutch v0.99)"
-	description "Residence 44 Quest (DOS/Fanmade/Dutch v0.99)"
-	rom ( name "LOGDIR" size 765 crc 7a202271 md5 7c5cc64200660c70240053b33d379d7d )
-)
-
-game (
-	name "Return of the Phantom (DOS)"
-	description "Return of the Phantom (DOS)"
-	rom ( name "ANIMVIEW.EXE" size 108747 crc 4293a93e md5 f47ff8dcb013fcd6c277b0d376bef77a )
-)
-
-game (
-	name "Return to Ringworld (CD/DOS)"
-	description "Return to Ringworld (CD/DOS)"
-	rom ( name "R2RW.RLB" size 47586928 crc 07dad1ce md5 f5dd9ef0b5ceda876bb3d63ce06f7c13 )
-)
-
-game (
-	name "Return to Ringworld (Demo/CD/DOS)"
-	description "Return to Ringworld (Demo/CD/DOS)"
-	rom ( name "R2RW.RLB" size 32384464 crc 296e9f48 md5 fa86abd3d6590a5728910e740a6eb92b )
-)
-
-game (
-	name "Return to Zork (CD/DOS)(v1.0)"
-	description "Return to Zork (CD/DOS)(v1.0)"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS)(v1.0)(Installed)"
-	description "Return to Zork (CD/DOS)(v1.0)(Installed)"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS)[v1.1 installed]"
-	description "Return to Zork (CD/DOS)[v1.1 installed]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS)[v1.1]"
-	description "Return to Zork (CD/DOS)[v1.1]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS)[v1.2 installed]"
-	description "Return to Zork (CD/DOS)[v1.2 installed]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS)[v1.2]"
-	description "Return to Zork (CD/DOS)[v1.2]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS/French)[v1.2 installed]"
-	description "Return to Zork (CD/DOS/French)[v1.2 installed]"
-	rom ( name "FBFTKN01.PMV" size 1559635 crc 561599b3 md5 8f9edc1d7507ad6fcf621107c009bea0 )
-)
-
-game (
-	name "Return to Zork (CD/DOS/French)[v1.2]"
-	description "Return to Zork (CD/DOS/French)[v1.2]"
-	rom ( name "FBFTKN01.PMV" size 1559635 crc 561599b3 md5 8f9edc1d7507ad6fcf621107c009bea0 )
-)
-
-game (
-	name "Return to Zork (CD/DOS/German)[v1.2 installed]"
-	description "Return to Zork (CD/DOS/German)[v1.2 installed]"
-	rom ( name "FBFTKN01.PMV" size 1582387 crc 7eb78255 md5 650c83333424d7abcb2228c0506579d3 )
-)
-
-game (
-	name "Return to Zork (CD/DOS/German)[v1.2]"
-	description "Return to Zork (CD/DOS/German)[v1.2]"
-	rom ( name "FBFTKN01.PMV" size 1582387 crc 7eb78255 md5 650c83333424d7abcb2228c0506579d3 )
-)
-
-game (
-	name "Return to Zork (CD/DOS/Italian)[v1.2 installed]"
-	description "Return to Zork (CD/DOS/Italian)[v1.2 installed]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (CD/DOS/Italian)[v1.2]"
-	description "Return to Zork (CD/DOS/Italian)[v1.2]"
-	rom ( name "FBFTKN01.PMV" size 1570801 crc c2e23782 md5 3beb8982b8b1574058d42a5db3fbc89c )
-)
-
-game (
-	name "Return to Zork (Demo/DOS)"
-	description "Return to Zork (Demo/DOS)"
-	rom ( name "DEMO.DAT" size 34304 crc 789d1f10 md5 06daaeea8efc9382fd577919de4778eb )
-)
-
-game (
-	name "Return to Zork (DOS/Japanese)"
-	description "Return to Zork (DOS/Japanese)"
-	rom ( name "RTZCD.DAT" size 537088 crc c7413e86 md5 9df6e9f614f0ef2be79b94694e64b1bf )
-)
-
-game (
-	name "Return to Zork (Floppy/DOS)"
-	description "Return to Zork (Floppy/DOS)"
-	rom ( name "RTZ.DAT" size 508928 crc 8d0fb61f md5 eb9567c4dbdf8396e03034e2aa624c4c )
-)
-
-game (
-	name "Return to Zork (FM-Towns/Japanese)"
-	description "Return to Zork (FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 b91300e55b70227ce98b59c5f02fa8dd )
-)
-
-game (
-	name "Return to Zork (PC-98/Japanese)"
-	description "Return to Zork (PC-98/Japanese)"
-	rom ( name "RTZCD.DAT" size 537088 crc c5ecef3f md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows)"
-	description "Reversion: The Escape (v1.1/Windows)"
-	rom ( name "English.dcp" size 5702699 crc 7445bd07 md5 2f0735c61cafb76b0a2b385f36b020a5 )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows/Chinese)"
-	description "Reversion: The Escape (v1.1/Windows/Chinese)"
-	rom ( name "Chinese.dcp" size 6330561 crc 699595ba md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows/French)"
-	description "Reversion: The Escape (v1.1/Windows/French)"
-	rom ( name "French.dcp" size 6327400 crc 575cee9d md5 743b237c01806cb0f8b8632c72ba67cb )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows/German)"
-	description "Reversion: The Escape (v1.1/Windows/German)"
-	rom ( name "German.dcp" size 6340699 crc 9246a50d md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows/Italian)"
-	description "Reversion: The Escape (v1.1/Windows/Italian)"
-	rom ( name "Italian.dcp" size 6301836 crc b19d798f md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.1/Windows/Portuguese)"
-	description "Reversion: The Escape (v1.1/Windows/Portuguese)"
-	rom ( name "Portugues.dcp" size 5053303 crc 60312505 md5 b2d212643ac60451af7551d222d8385b )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows)"
-	description "Reversion: The Escape (v1.3.2369/Windows)"
-	rom ( name "xlanguage_en.dcp" size 11339619 crc 606ed2e9 md5 4cb82cfe0e8c9d57b0c76a4e60f7e3bc )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/Chinese)"
-	description "Reversion: The Escape (v1.3.2369/Windows/Chinese)"
-	rom ( name "xlanguage_nz.dcp" size 13722261 crc 02ae01b3 md5 ac4bc1481e18e49bca875a44ab09f292 )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/French)"
-	description "Reversion: The Escape (v1.3.2369/Windows/French)"
-	rom ( name "xlanguage_fr.dcp" size 11963210 crc b1adcbc1 md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/German)"
-	description "Reversion: The Escape (v1.3.2369/Windows/German)"
-	rom ( name "xlanguage_de.dcp" size 14040310 crc d12520d4 md5 4136613dcbd506917943d21629a744a1 )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/Italian)"
-	description "Reversion: The Escape (v1.3.2369/Windows/Italian)"
-	rom ( name "xlanguage_it.dcp" size 11913752 crc f8da2ca0 md5 4e0e403b18c7d36942586cb5fdf537bc )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/Latvian)"
-	description "Reversion: The Escape (v1.3.2369/Windows/Latvian)"
-	rom ( name "xlanguage_lv.dcp" size 11414925 crc 7f45a6c0 md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/Polish)"
-	description "Reversion: The Escape (v1.3.2369/Windows/Polish)"
-	rom ( name "xlanguage_pl.dcp" size 11532215 crc f9c1459b md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3.2369/Windows/Portuguese)"
-	description "Reversion: The Escape (v1.3.2369/Windows/Portuguese)"
-	rom ( name "xlanguage_pt.dcp" size 10620797 crc 9551baef md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows)"
-	description "Reversion: The Escape (v1.3/Windows)"
-	rom ( name "xlanguage_en.dcp" size 4818543 crc 91c3eb2b md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/Chinese)"
-	description "Reversion: The Escape (v1.3/Windows/Chinese)"
-	rom ( name "xlanguage_nz.dcp" size 5130600 crc 309452d3 md5 3275acb5818ebf0ff8197bfcea3a1723 )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/French)"
-	description "Reversion: The Escape (v1.3/Windows/French)"
-	rom ( name "xlanguage_fr.dcp" size 5425959 crc a4263c8c md5 undefined )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/German)"
-	description "Reversion: The Escape (v1.3/Windows/German)"
-	rom ( name "xlanguage_de.dcp" size 5423798 crc 5e95b4bb md5 16385bf1fb26e5afe236ac99c0840bb8 )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/Italian)"
-	description "Reversion: The Escape (v1.3/Windows/Italian)"
-	rom ( name "xlanguage_it.dcp" size 5386424 crc d87479f7 md5 c0bbc34e00b0f22554db5356287df572 )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/Latvian)[Unk]"
-	description "Reversion: The Escape (v1.3/Windows/Latvian)[Unk]"
-	rom ( name "xlanguage_lv.dcp" size 4959028 crc d5e17c2f md5 1557b5a00b3e35764a5f3c30ca9e940f )
-)
-
-game (
-	name "Reversion: The Escape (v1.3/Windows/Portuguese)"
-	description "Reversion: The Escape (v1.3/Windows/Portuguese)"
-	rom ( name "xlanguage_pt.dcp" size 4149165 crc c2fe6d3e md5 undefined )
-)
-
-game (
-	name "Reversion: The Meeting (Windows)"
-	description "Reversion: The Meeting (Windows)"
-	rom ( name "xlanguage_en.dcp" size 8414976 crc 1ca01bae md5 undefined )
-)
-
-game (
-	name "Reversion: The Meeting (Windows)[es][Unk]"
-	description "Reversion: The Meeting (Windows)[es][Unk]"
-	rom ( name "xlanguage_en.dcp" size 8414976 crc 1ca01bae md5 undefined )
-)
-
-game (
-	name "Reversion: The Meeting (Windows/Chinese)[es][Unk]"
-	description "Reversion: The Meeting (Windows/Chinese)[es][Unk]"
-	rom ( name "xlanguage_nz.dcp" size 8746015 crc e65014bf md5 eecd69083409d00224c34a22288697a5 )
-)
-
-game (
-	name "Reversion: The Meeting (Windows/Chinese)[Unk]"
-	description "Reversion: The Meeting (Windows/Chinese)[Unk]"
-	rom ( name "xlanguage_nz.dcp" size 8746015 crc e65014bf md5 undefined )
-)
-
-game (
-	name "Reversion: The Meeting (Windows/Spanish)"
-	description "Reversion: The Meeting (Windows/Spanish)"
-	rom ( name "data.dcp" size 255672016 crc ce1a63f5 md5 99813ac7c7b706ce071a44a4dc077c15 )
-)
-
-game (
-	name "Rex Nebular and the Cosmic Gender Bender (DOS)"
-	description "Rex Nebular and the Cosmic Gender Bender (DOS)"
-	rom ( name "ASOUND.001" size 11460 crc 3eb92383 md5 undefined )
-)
-
-game (
-	name "Rhiannon: Curse of the Four Branches (Windows)"
-	description "Rhiannon: Curse of the Four Branches (Windows)"
-	rom ( name "data.dcp" size 1046169851 crc 8a5e004d md5 e252e26c8954c8eec3159f3bd2a7dc36 )
-)
-
-game (
-	name "Rhiannon: Curse of the Four Branches: The Premium Edition (Windows)[Unk]"
-	description "Rhiannon: Curse of the Four Branches: The Premium Edition (Windows)[Unk]"
-	rom ( name "data.dcp" size 928484275 crc ad8bac6c md5 undefined )
-)
-
-game (
-	name "Ringworld: Revenge of the Patriarch (CD/DOS)"
-	description "Ringworld: Revenge of the Patriarch (CD/DOS)"
-	rom ( name "RING.RLB" size 37847618 crc d5ad6c75 md5 undefined )
-)
-
-game (
-	name "Ringworld: Revenge of the Patriarch (CD/DOS/Spanish)"
-	description "Ringworld: Revenge of the Patriarch (CD/DOS/Spanish)"
-	rom ( name "RING.RLB" size 7427980 crc dad890d5 md5 undefined )
-)
-
-game (
-	name "Ringworld: Revenge of the Patriarch (Demo/Floppy/DOS)"
-	description "Ringworld: Revenge of the Patriarch (Demo/Floppy/DOS)"
-	rom ( name "TSAGE.RLB" size 833453 crc d4580bc6 md5 undefined )
-)
-
-game (
-	name "Ringworld: Revenge of the Patriarch (Floppy/DOS)"
-	description "Ringworld: Revenge of the Patriarch (Floppy/DOS)"
-	rom ( name "RING.RLB" size 8438770 crc 1b6db576 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Demo/Windows)"
-	description "Riven: The Sequel to Myst (Demo/Windows)"
-	rom ( name "A_DATA.MHK" size 86703958 crc 8ad56c66 md5 045183adb068ae32520aa5744c1e63e2 )
-)
-
-game (
-	name "Riven: The Sequel to Myst (DVD/Windows)"
-	description "Riven: The Sequel to Myst (DVD/Windows)"
-	rom ( name "A_DATA.MHK" size 10218888 crc 7239f3a7 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (DVD/Windows/Russian)"
-	description "Riven: The Sequel to Myst (DVD/Windows/Russian)"
-	rom ( name "A_DATA.MHK" size 17126152 crc 768cd027 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/French)"
-	description "Riven: The Sequel to Myst (Windows/French)"
-	rom ( name "A_DATA.MHK" size 9865868 crc d42955fd md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/German)"
-	description "Riven: The Sequel to Myst (Windows/German)"
-	rom ( name "A_DATA.MHK" size 9875600 crc 555d86eb md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/Italian)"
-	description "Riven: The Sequel to Myst (Windows/Italian)"
-	rom ( name "A_DATA.MHK" size 9455028 crc e08b1c69 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/Russian/Fargus v1.0.0)"
-	description "Riven: The Sequel to Myst (Windows/Russian/Fargus v1.0.0)"
-	rom ( name "A_DATA.MHK" size 12024358 crc 19a70323 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/Russian/Fargus v1.1)"
-	description "Riven: The Sequel to Myst (Windows/Russian/Fargus v1.1)"
-	rom ( name "A_DATA.MHK" size 17126144 crc 9701cb85 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/Spanish)"
-	description "Riven: The Sequel to Myst (Windows/Spanish)"
-	rom ( name "A_DATA.MHK" size 10910242 crc 2a2c4424 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/v1.0)[!]"
-	description "Riven: The Sequel to Myst (Windows/v1.0)[!]"
-	rom ( name "A_DATA.MHK" size 10148976 crc 9a8d3529 md5 undefined )
-)
-
-game (
-	name "Riven: The Sequel to Myst (Windows/v1.03)"
-	description "Riven: The Sequel to Myst (Windows/v1.03)"
-	rom ( name "A_DATA.MHK" size 10149682 crc c88be810 md5 undefined )
-)
-
-game (
-	name "Road (DOS)"
-	description "Road (DOS)"
-	rom ( name "MONSTER.SOU" size 143493 crc eb609353 md5 undefined )
-)
-
-game (
-	name "Robust Parse Demo 1.2 (DOS/Fanmade)"
-	description "Robust Parse Demo 1.2 (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 229044 crc 119210e6 md5 cfecbc8c6e91aaece1138ba0f3e835fc )
-)
-
-game (
-	name "Rodney's Funscreen (DOS)"
-	description "Rodney's Funscreen (DOS)"
-	rom ( name "RODNEYS.DAT" size 92990 crc 4da2ddbf md5 7e1ab4f486cfb0f1ebb9e5d5c73f25fe )
-)
-
-game (
-	name "Rosemary (Windows)"
-	description "Rosemary (Windows)"
-	rom ( name "data.dcp" size 29483643 crc 7e29204f md5 2efc266ec2ca3e44e29f116188b2623b )
-)
-
-game (
-	name "Ruby Cast, The (DOS/Fanmade v0.02)"
-	description "Ruby Cast, The (DOS/Fanmade v0.02)"
-	rom ( name "LOGDIR" size 609 crc c790c8a4 md5 undefined )
-)
-
-game (
-	name "Rugrats Adventure Game (Demo/Windows)"
-	description "Rugrats Adventure Game (Demo/Windows)"
-	rom ( name "MOHAWK.W32" size 354 crc 0753c713 md5 undefined )
-)
-
-game (
-	name "Rugrats Adventure Game (Macintosh)"
-	description "Rugrats Adventure Game (Macintosh)"
-	rom ( name "BookOutline" size 7363 crc c340ba3c md5 undefined )
-)
-
-game (
-	name "Rugrats Adventure Game (Windows)"
-	description "Rugrats Adventure Game (Windows)"
-	rom ( name "GLOBALS" size 316 crc a3bf0ce2 md5 undefined )
-)
-
-game (
-	name "Rugrats Print Shop (Demo/Windows)"
-	description "Rugrats Print Shop (Demo/Windows)"
-	rom ( name "BOOKOUTL.INE" size 571 crc 4e5fba54 md5 ec0b27599bbff0235438b59af1cf54d8 )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD)"
-	description "Sam & Max Hit the Road (CD)"
-	rom ( name "SAMNMAX.000" size 9080 crc a277c40d md5 d917f311a448e3cc7239c31bddb00dd2 )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Fanmade Hungarian)"
-	description "Sam & Max Hit the Road (CD/Fanmade Hungarian)"
-	rom ( name "SAMNMAX.000" size 9080 crc 2bc97472 md5 f47dae9f314ff1fd8da57eaae3e4f54b )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Fanmade Portuguese)"
-	description "Sam & Max Hit the Road (CD/Fanmade Portuguese)"
-	rom ( name "SAMNMAX.000" size 9080 crc f1207ee8 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/French)"
-	description "Sam & Max Hit the Road (CD/French)"
-	rom ( name "SAMNMAX.000" size 9080 crc 3166b5c4 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/German)"
-	description "Sam & Max Hit the Road (CD/German)"
-	rom ( name "SAMNMAX.000" size 9080 crc 864111b2 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Italian)"
-	description "Sam & Max Hit the Road (CD/Italian)"
-	rom ( name "SAMNMAX.000" size 9080 crc b6a5395f md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Macintosh)[mac bundle]"
-	description "Sam & Max Hit the Road (CD/Macintosh)[mac bundle]"
-	rom ( name "Sam & Max Data" size 199195304 crc 8ffeb68b md5 e84d3a41b3015de79344f2c507639eed )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Macintosh/French)[mac bundle]"
-	description "Sam & Max Hit the Road (CD/Macintosh/French)[mac bundle]"
-	rom ( name "Sam & Max Data" size 228446581 crc c277bba9 md5 f91125935266899478a7d366e615011a )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Macintosh/German)[mac bundle]"
-	description "Sam & Max Hit the Road (CD/Macintosh/German)[mac bundle]"
-	rom ( name "Sam & Max Data" size 226899591 crc 1317b5b1 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Russian)"
-	description "Sam & Max Hit the Road (CD/Russian)"
-	rom ( name "RAMNMAX.000" size 9080 crc 6d25923a md5 d43352a805d78b5f4936c6d7779bf575 )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Spanish)"
-	description "Sam & Max Hit the Road (CD/Spanish)"
-	rom ( name "SAMNMAX.000" size 9080 crc 86499264 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (CD/Spanish)[fixed]"
-	description "Sam & Max Hit the Road (CD/Spanish)[fixed]"
-	rom ( name "SAMNMAX.000" size 9080 crc 86499264 md5 4ba7fb331296c283e73d8f5b2096e551 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Non-interactive)[!]"
-	description "Sam & Max Hit the Road (Demo/Non-interactive)[!]"
-	rom ( name "SAMDEMO.000" size 6478 crc 6b762342 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Preview)[v1.0]"
-	description "Sam & Max Hit the Road (Demo/Preview)[v1.0]"
-	rom ( name "MONSTER.SOU" size 374599 crc 31c02390 md5 aed9bedf8a7e14df1bfdce67df379d32 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Preview/German)"
-	description "Sam & Max Hit the Road (Demo/Preview/German)"
-	rom ( name "MONSTER.SOU" size 374599 crc 31c02390 md5 aed9bedf8a7e14df1bfdce67df379d32 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Preview/Macintosh)"
-	description "Sam & Max Hit the Road (Demo/Preview/Macintosh)"
-	rom ( name "INSTRUMENTS" size 2055076 crc 2432c2b6 md5 f96bc1d4530e5ac971cbc4aa1ec9ae9b )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Preview/Macintosh)[mac bundle]"
-	description "Sam & Max Hit the Road (Demo/Preview/Macintosh)[mac bundle]"
-	rom ( name "Sam & Max Demo Data" size 16556335 crc 46081a18 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Preview/Portuguese)"
-	description "Sam & Max Hit the Road (Demo/Preview/Portuguese)"
-	rom ( name "MONSTER.SOU" size 374599 crc 31c02390 md5 aed9bedf8a7e14df1bfdce67df379d32 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Demo/Wip)"
-	description "Sam & Max Hit the Road (Demo/Wip)"
-	rom ( name "MONSTER.SOU" size 974551 crc 2fa4e4af md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy)"
-	description "Sam & Max Hit the Road (Floppy)"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 6ae8753d md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy)[a1]"
-	description "Sam & Max Hit the Road (Floppy)[a1]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 358ac824 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy)[a2]"
-	description "Sam & Max Hit the Road (Floppy)[a2]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 358ac824 md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/French)"
-	description "Sam & Max Hit the Road (Floppy/French)"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 775aaf63 md5 ef347474f3c7be3b29584eaa133cca05 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/German)"
-	description "Sam & Max Hit the Road (Floppy/German)"
-	rom ( name "SAMNMAX.SM0" size 9040 crc ac8b1c3e md5 f27b1ba0eadaf2a6617b2b58192d1dbf )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/German)[a1]"
-	description "Sam & Max Hit the Road (Floppy/German)[a1]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc ac8b1c3e md5 f27b1ba0eadaf2a6617b2b58192d1dbf )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/German)[a2]"
-	description "Sam & Max Hit the Road (Floppy/German)[a2]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc ac8b1c3e md5 f27b1ba0eadaf2a6617b2b58192d1dbf )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/Italian)"
-	description "Sam & Max Hit the Road (Floppy/Italian)"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 1797d12c md5 b289a2a8cbedbf45786e0b4ad2f510f1 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/Italian)[a]"
-	description "Sam & Max Hit the Road (Floppy/Italian)[a]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 1797d12c md5 b289a2a8cbedbf45786e0b4ad2f510f1 )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/Spanish)"
-	description "Sam & Max Hit the Road (Floppy/Spanish)"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 477d867b md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/Spanish)[a1]"
-	description "Sam & Max Hit the Road (Floppy/Spanish)[a1]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 477d867b md5 undefined )
-)
-
-game (
-	name "Sam & Max Hit the Road (Floppy/Spanish)[a2]"
-	description "Sam & Max Hit the Road (Floppy/Spanish)[a2]"
-	rom ( name "SAMNMAX.SM0" size 9040 crc 477d867b md5 undefined )
-)
-
-game (
-	name "Satan and Son (Windows)"
-	description "Satan and Son (Windows)"
-	rom ( name "data.dcp" size 67539054 crc 01754546 md5 undefined )
-)
-
-game (
-	name "Save Santa (DOS/Fanmade v1.0)"
-	description "Save Santa (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 5eb0bb1b md5 undefined )
-)
-
-game (
-	name "Save Santa (DOS/Fanmade v1.3)"
-	description "Save Santa (DOS/Fanmade v1.3)"
-	rom ( name "LOGDIR" size 300 crc 4cf6d7a3 md5 undefined )
-)
-
-game (
-	name "Schiller (Preview 1/DOS/Fanmade)"
-	description "Schiller (Preview 1/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 297 crc 5de98bca md5 ade39dea968c959cfebe1cf935d653e9 )
-)
-
-game (
-	name "Schiller (Preview 2/DOS/Fanmade)"
-	description "Schiller (Preview 2/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 381 crc 65a290f5 md5 undefined )
-)
-
-game (
-	name "Schmoozer (Macintosh)"
-	description "Schmoozer (Macintosh)"
-	rom ( name "._Schmoozer" size 229376 crc f7496e77 md5 66cb2e82e01d8d33b0fd428405ae511d )
-)
-
-game (
-	name "SCI Capture the Flag (DOS/Fanmade)"
-	description "SCI Capture the Flag (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 147878 crc b6ad24b5 md5 cbcd95aff90e463e424fb4cc69aca30f )
-)
-
-game (
-	name "SCI Companion Template (DOS)"
-	description "SCI Companion Template (DOS)"
-	rom ( name "resource.001" size 113061 crc bb002ada md5 undefined )
-)
-
-game (
-	name "SCI Logging Demo (DOS/Fanmade)"
-	description "SCI Logging Demo (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 171012 crc 81f23a04 md5 216168758036566fee24edf7b0bcafb9 )
-)
-
-game (
-	name "SCI Programming April 2010 Competition Template (DOS)"
-	description "SCI Programming April 2010 Competition Template (DOS)"
-	rom ( name "resource.001" size 142221 crc a999102a md5 undefined )
-)
-
-game (
-	name "SCI Quest (DOS/Fanmade)"
-	description "SCI Quest (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 149634 crc 020b7179 md5 e4cff1aa343d8498ac1628d51ec1ea4d )
-)
-
-game (
-	name "SCI Studio Template 3.0 (DOS)"
-	description "SCI Studio Template 3.0 (DOS)"
-	rom ( name "resource.001" size 113097 crc ef1c1f90 md5 undefined )
-)
-
-game (
-	name "SCI-Man (DOS/Fanmade)"
-	description "SCI-Man (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 131810 crc 91a12bbe md5 6138bed172ba11897a116cade48f67fa )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS)[!]"
-	description "Secret of Monkey Island, The (CD/DOS)[!]"
-	rom ( name "MONKEY.000" size 8955 crc 5a1a5f3e md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Fanmade German)[v1.11]"
-	description "Secret of Monkey Island, The (CD/DOS/Fanmade German)[v1.11]"
-	rom ( name "MONKEY.000" size 8955 crc c2d75b75 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Fanmade German)[v1.12]"
-	description "Secret of Monkey Island, The (CD/DOS/Fanmade German)[v1.12]"
-	rom ( name "MONKEY.000" size 8955 crc 5ea44fde md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Fanmade Hungarian)[v1.2]"
-	description "Secret of Monkey Island, The (CD/DOS/Fanmade Hungarian)[v1.2]"
-	rom ( name "MONKEY.000" size 8955 crc f4b91c52 md5 eb3c2d01b5ac92db4687dc1a1231ea46 )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Fanmade Portuguese)"
-	description "Secret of Monkey Island, The (CD/DOS/Fanmade Portuguese)"
-	rom ( name "MONKEY.000" size 8955 crc c21bc9ff md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/French)[!]"
-	description "Secret of Monkey Island, The (CD/DOS/French)[!]"
-	rom ( name "MONKEY.000" size 8955 crc 0950886e md5 aa8a0cb65f3afbbe2c14c3f9f92775a3 )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/German)[!]"
-	description "Secret of Monkey Island, The (CD/DOS/German)[!]"
-	rom ( name "MONKEY.000" size 8955 crc 70b3e13b md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Italian)[!]"
-	description "Secret of Monkey Island, The (CD/DOS/Italian)[!]"
-	rom ( name "MONKEY.000" size 8955 crc 704f5922 md5 da6269b18fcb08189c0aa9c95533cce2 )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Spanish)[!]"
-	description "Secret of Monkey Island, The (CD/DOS/Spanish)[!]"
-	rom ( name "MONKEY.000" size 8955 crc 5092187f md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (CD/DOS/Spanish)[a]"
-	description "Secret of Monkey Island, The (CD/DOS/Spanish)[a]"
-	rom ( name "MONKEY.000" size 8955 crc 5092187f md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Demo/EGA/DOS)"
-	description "Secret of Monkey Island, The (Demo/EGA/DOS)"
-	rom ( name "000.LFL" size 7607 crc 719585d5 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Demo/EGA/DOS/German)"
-	description "Secret of Monkey Island, The (Demo/EGA/DOS/German)"
-	rom ( name "000.LFL" size 7607 crc ead371d6 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Demo/EGA/Fanmade Portuguese)"
-	description "Secret of Monkey Island, The (Demo/EGA/Fanmade Portuguese)"
-	rom ( name "000.LFL" size 7607 crc beeadeeb md5 d2fb8d59f561727ff027b98b7996e7fa )
-)
-
-game (
-	name "Secret of Monkey Island, The (Demo/VGA/Amiga)"
-	description "Secret of Monkey Island, The (Demo/VGA/Amiga)"
-	rom ( name "000.LFL" size 7617 crc b81908f3 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/Atari ST)[no adlib]"
-	description "Secret of Monkey Island, The (EGA/Atari ST)[no adlib]"
-	rom ( name "000.LFL" size 8347 crc 899d425f md5 c666a998af90d81db447eccba9f72c8d )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/Atari ST/French)[no adlib]"
-	description "Secret of Monkey Island, The (EGA/Atari ST/French)[no adlib]"
-	rom ( name "000.LFL" size 8347 crc b9dc0a5a md5 9e5e0fb43bd22f4628719b7501adb717 )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/Atari ST/German)[no adlib]"
-	description "Secret of Monkey Island, The (EGA/Atari ST/German)[no adlib]"
-	rom ( name "000.LFL" size 8357 crc 157467a9 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS)[4x720kb]"
-	description "Secret of Monkey Island, The (EGA/DOS)[4x720kb]"
-	rom ( name "000.LFL" size 8357 crc 3390ce86 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS)[4x720kb][a]"
-	description "Secret of Monkey Island, The (EGA/DOS)[4x720kb][a]"
-	rom ( name "000.LFL" size 8357 crc 3390ce86 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS)[8x360kb][a]"
-	description "Secret of Monkey Island, The (EGA/DOS)[8x360kb][a]"
-	rom ( name "000.LFL" size 8357 crc 18ec619b md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS)[8x360kb][v1.0]"
-	description "Secret of Monkey Island, The (EGA/DOS)[8x360kb][v1.0]"
-	rom ( name "000.LFL" size 8357 crc 18ec619b md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/French)[4x720kb]"
-	description "Secret of Monkey Island, The (EGA/DOS/French)[4x720kb]"
-	rom ( name "000.LFL" size 8357 crc ab70c963 md5 ce6a4cef315b20fef58a95bc40a2d8d3 )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/French)[8x360kb]"
-	description "Secret of Monkey Island, The (EGA/DOS/French)[8x360kb]"
-	rom ( name "000.LFL" size 8357 crc ef94b209 md5 1dd3c11ea4439adfe681e4e405b624e1 )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/German)[8x360kb]"
-	description "Secret of Monkey Island, The (EGA/DOS/German)[8x360kb]"
-	rom ( name "000.LFL" size 8367 crc 4092113a md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/Italian)[4x720kb]"
-	description "Secret of Monkey Island, The (EGA/DOS/Italian)[4x720kb]"
-	rom ( name "000.LFL" size 8357 crc 33de3871 md5 477dbafbd66a53c98416dc01aef019ad )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/Italian)[4x720kb][a]"
-	description "Secret of Monkey Island, The (EGA/DOS/Italian)[4x720kb][a]"
-	rom ( name "000.LFL" size 8357 crc 33de3871 md5 477dbafbd66a53c98416dc01aef019ad )
-)
-
-game (
-	name "Secret of Monkey Island, The (EGA/DOS/Spanish)[8x360kb]"
-	description "Secret of Monkey Island, The (EGA/DOS/Spanish)[8x360kb]"
-	rom ( name "000.LFL" size 8367 crc 7a0a62e9 md5 910e31cffb28226bd68c569668a0d6b4 )
-)
-
-game (
-	name "Secret of Monkey Island, The (FM-Towns)"
-	description "Secret of Monkey Island, The (FM-Towns)"
-	rom ( name "MONKEY.000" size 9925 crc a2e72949 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (FM-Towns/Fanmade German)[v1.1]"
-	description "Secret of Monkey Island, The (FM-Towns/Fanmade German)[v1.1]"
-	rom ( name "MONKEY.000" size 9925 crc 0a15cd5e md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (FM-Towns/Fanmade German)[v1.1][a]"
-	description "Secret of Monkey Island, The (FM-Towns/Fanmade German)[v1.1][a]"
-	rom ( name "MONKEY.000" size 9925 crc 7b395bee md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (FM-Towns/Japanese)"
-	description "Secret of Monkey Island, The (FM-Towns/Japanese)"
-	rom ( name "FMT_FNT.ROM" size 262144 crc dd6fd544 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Macintosh)[v2.4][a]"
-	description "Secret of Monkey Island, The (Macintosh)[v2.4][a]"
-	rom ( name "._Monkey Island" size 291327 crc d933d62c md5 d44fe769892b05ce6bdf6e84a1076d0f )
-)
-
-game (
-	name "Secret of Monkey Island, The (SegaCD)"
-	description "Secret of Monkey Island, The (SegaCD)"
-	rom ( name "GAME.000" size 9465 crc e998ad6d md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (SegaCD/Fanmade German)"
-	description "Secret of Monkey Island, The (SegaCD/Fanmade German)"
-	rom ( name "GAME.000" size 9465 crc 4909e3fc md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (SegaCD/Fanmade German)[v1.1]"
-	description "Secret of Monkey Island, The (SegaCD/Fanmade German)[v1.1]"
-	rom ( name "GAME.000" size 9465 crc 322e8612 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (SegaCD/Fanmade Spanish)"
-	description "Secret of Monkey Island, The (SegaCD/Fanmade Spanish)"
-	rom ( name "GAME.000" size 9465 crc e5dc80c5 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (SegaCD/Japanese)"
-	description "Secret of Monkey Island, The (SegaCD/Japanese)"
-	rom ( name "GAME.000" size 9465 crc f49d5307 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Unofficial SE Talkie v1.02/DOS)[CD Music]"
-	description "Secret of Monkey Island, The (Unofficial SE Talkie v1.02/DOS)[CD Music]"
-	rom ( name "track1.flac" size 8345033 crc 5c623239 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (Unofficial SE Talkie v1.02/DOS)[SE Music]"
-	description "Secret of Monkey Island, The (Unofficial SE Talkie v1.02/DOS)[SE Music]"
-	rom ( name "track1.flac" size 6969085 crc 05dd2071 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga)"
-	description "Secret of Monkey Island, The (VGA/Amiga)"
-	rom ( name "000.LFL" size 8347 crc 254074f3 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/French)"
-	description "Secret of Monkey Island, The (VGA/Amiga/French)"
-	rom ( name "000.LFL" size 8347 crc 65a205f0 md5 3433be9866ca4261b2d5d25374e3f243 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/German)"
-	description "Secret of Monkey Island, The (VGA/Amiga/German)"
-	rom ( name "000.LFL" size 8347 crc eedd0439 md5 0a212fa35fa8421f31c1f3961272caf0 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/German)[v1.1]"
-	description "Secret of Monkey Island, The (VGA/Amiga/German)[v1.1]"
-	rom ( name "000.LFL" size 8347 crc eedd0439 md5 0a212fa35fa8421f31c1f3961272caf0 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/German)[v1.2r]"
-	description "Secret of Monkey Island, The (VGA/Amiga/German)[v1.2r]"
-	rom ( name "000.LFL" size 8347 crc 7f2de28a md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/Italian)"
-	description "Secret of Monkey Island, The (VGA/Amiga/Italian)"
-	rom ( name "000.LFL" size 8347 crc c0a124a1 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/Amiga/Spanish)"
-	description "Secret of Monkey Island, The (VGA/Amiga/Spanish)"
-	rom ( name "000.LFL" size 8347 crc f1087047 md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS)[4x1.44mb]"
-	description "Secret of Monkey Island, The (VGA/DOS)[4x1.44mb]"
-	rom ( name "000.LFL" size 8357 crc da6aa41d md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS)[7x720kb][v1.1]"
-	description "Secret of Monkey Island, The (VGA/DOS)[7x720kb][v1.1]"
-	rom ( name "000.LFL" size 8357 crc 88872747 md5 08656dd9698ddf1023ba9bf8a195e37b )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS)[8x720kb]"
-	description "Secret of Monkey Island, The (VGA/DOS)[8x720kb]"
-	rom ( name "000.LFL" size 8357 crc b3ddfccd md5 c7890e038806df2bb5c0c8c6f1986ea2 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS/French)"
-	description "Secret of Monkey Island, The (VGA/DOS/French)"
-	rom ( name "000.LFL" size 8347 crc b08fb64c md5 a01fab4a64d47b96e2e58e6b0f825cc7 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS/German)[4x1.44mb][v1.1][!]"
-	description "Secret of Monkey Island, The (VGA/DOS/German)[4x1.44mb][v1.1][!]"
-	rom ( name "000.LFL" size 8357 crc 480d0e33 md5 d0b531227a27c6662018d2bd05aac52a )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS/Italian)[4x1.44mb]"
-	description "Secret of Monkey Island, The (VGA/DOS/Italian)[4x1.44mb]"
-	rom ( name "000.LFL" size 8357 crc 1dfd9a8b md5 undefined )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS/Spanish)[4x1.44mb]"
-	description "Secret of Monkey Island, The (VGA/DOS/Spanish)[4x1.44mb]"
-	rom ( name "000.LFL" size 8357 crc 79dcb5c8 md5 45152f7cf2ba8f43cf8a8ea2e740ae09 )
-)
-
-game (
-	name "Secret of Monkey Island, The (VGA/DOS/Spanish)[4x1.44mb][a]"
-	description "Secret of Monkey Island, The (VGA/DOS/Spanish)[4x1.44mb][a]"
-	rom ( name "000.LFL" size 8357 crc 79dcb5c8 md5 undefined )
-)
-
-game (
-	name "Serguei's Destiny 1 (DOS/Fanmade v1.0)"
-	description "Serguei's Destiny 1 (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 669 crc 9c547973 md5 b86725f067e456e10cdbdf5f58e01dec )
-)
-
-game (
-	name "Serguei's Destiny 1 (DOS/Fanmade v1.1 2002)"
-	description "Serguei's Destiny 1 (DOS/Fanmade v1.1 2002)"
-	rom ( name "LOGDIR" size 669 crc 4292ccb7 md5 91975c1fb4b13b0f9a8e9ff74731030d )
-)
-
-game (
-	name "Serguei's Destiny 1 (DOS/Fanmade v1.1 2003)"
-	description "Serguei's Destiny 1 (DOS/Fanmade v1.1 2003)"
-	rom ( name "LOGDIR" size 669 crc 4292ccb7 md5 91975c1fb4b13b0f9a8e9ff74731030d )
-)
-
-game (
-	name "Serguei's Destiny 2 (Demo/DOS/Fanmade v0.1.1)"
-	description "Serguei's Destiny 2 (Demo/DOS/Fanmade v0.1.1)"
-	rom ( name "LOGDIR" size 768 crc 90e4b92f md5 906ccbc2ddedb29b63141acc6d10cd28 )
-)
-
-game (
-	name "Serguei's Destiny 2 (Demo/DOS/Fanmade v1.3.1)"
-	description "Serguei's Destiny 2 (Demo/DOS/Fanmade v1.3.1)"
-	rom ( name "LOGDIR" size 768 crc 9f339790 md5 ad1308fcb8f48723cd388e012ebf5e20 )
-)
-
-game (
-	name "Sfinx (DOS/Freeware v0.3)"
-	description "Sfinx (DOS/Freeware v0.3)"
-	rom ( name "vol.cat" size 129024 crc 67d24312 md5 4c9a315120f871876b7be3ac2b149dd8 )
-)
-
-game (
-	name "Sfinx (DOS/Freeware v1.0)"
-	description "Sfinx (DOS/Freeware v1.0)"
-	rom ( name "vol.cat" size 129024 crc 3a681503 md5 6520e582444f4094b8d0677a3efb4f43 )
-)
-
-game (
-	name "Sfinx (DOS/Freeware v1.1)"
-	description "Sfinx (DOS/Freeware v1.1)"
-	rom ( name "vol.cat" size 129024 crc 38a6fe53 md5 23a8d6c2bc405f7faf47bf777723a70d )
-)
-
-game (
-	name "Sfinx (DOS/Polish Freeware v1.0)"
-	description "Sfinx (DOS/Polish Freeware v1.0)"
-	rom ( name "vol.cat" size 129024 crc 76ea3fa7 md5 cf954e62a02911ca1073b905d6678b3a )
-)
-
-game (
-	name "Sfinx (DOS/Polish Freeware)"
-	description "Sfinx (DOS/Polish Freeware)"
-	rom ( name "VOL.CAT" size 129024 crc 674c10f4 md5 f5f27cfbd12c736eb34fe1880c1aeaff )
-)
-
-game (
-	name "Sfinx (DOS/Polish Freeware)[cge]"
-	description "Sfinx (DOS/Polish Freeware)[cge]"
-	rom ( name "VOL.CAT" size 129024 crc 674c10f4 md5 f5f27cfbd12c736eb34fe1880c1aeaff )
-)
-
-game (
-	name "Shaban (Demo/Windows)[Unk]"
-	description "Shaban (Demo/Windows)[Unk]"
-	rom ( name "data.dcp" size 338067285 crc 99deae4a md5 c8a2296fd5a23df19c90a088aaa56e7c )
-)
-
-game (
-	name "Shadow Plan, The (DOS/Fanmade)"
-	description "Shadow Plan, The (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 83c3229b md5 c02cd10267e721f4e836b1431f504a0a )
-)
-
-game (
-	name "Shifty (DOS/Fanmade v1.0)"
-	description "Shifty (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 303 crc 9096367a md5 2a07984d27b938364bf6bd243ac75080 )
-)
-
-game (
-	name "Shine of a Star, The (Windows)"
-	description "Shine of a Star, The (Windows)"
-	rom ( name "data.dcp" size 94113060 crc 16f697a7 md5 undefined )
-)
-
-game (
-	name "Shivers (Demo/Windows)"
-	description "Shivers (Demo/Windows)"
-	rom ( name "15014.WAV" size 42924 crc 1c7cca41 md5 undefined )
-)
-
-game (
-	name "Shivers (Windows)[!]"
-	description "Shivers (Windows)[!]"
-	rom ( name "RESMAP.000" size 46525 crc 27e50c99 md5 undefined )
-)
-
-game (
-	name "Shivers (Windows/German)"
-	description "Shivers (Windows/German)"
-	rom ( name "65535.MAP" size 3672 crc e4a01e82 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Amiga CD32)[!]"
-	description "Simon the Sorcerer 1 (CD/Amiga CD32)[!]"
-	rom ( name "0001.OUT" size 1116 crc 6e0b6570 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS)"
-	description "Simon the Sorcerer 1 (CD/DOS)"
-	rom ( name "GAMEPC" size 29176 crc 524fb94c md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/French)"
-	description "Simon the Sorcerer 1 (CD/DOS/French)"
-	rom ( name "GAMEPC" size 39310 crc b06dfa0d md5 08bd7abefe9c44e43df396748640e531 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/German)[!]"
-	description "Simon the Sorcerer 1 (CD/DOS/German)[!]"
-	rom ( name "EFFECTS.VOC" size 3520684 crc 08d3f8db md5 4c15cdcff2b649e29512c3b544fcbe88 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/Hebrew)"
-	description "Simon the Sorcerer 1 (CD/DOS/Hebrew)"
-	rom ( name "GAMEPC" size 34348 crc 5027c5b6 md5 9d58f84988634d217c944cd4153a2a3b )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/Italian)"
-	description "Simon the Sorcerer 1 (CD/DOS/Italian)"
-	rom ( name "GAMEPC" size 37807 crc b5ec05bb md5 057eac98fc4d14dc7fd04341781b26b3 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/Russian)"
-	description "Simon the Sorcerer 1 (CD/DOS/Russian)"
-	rom ( name "EFFECTS.VOC" size 3520684 crc 08d3f8db md5 4c15cdcff2b649e29512c3b544fcbe88 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/DOS/Spanish)"
-	description "Simon the Sorcerer 1 (CD/DOS/Spanish)"
-	rom ( name "GAMEPC" size 37847 crc e1ab20de md5 e3712b3ed4429e736123a40276f533d7 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS)"
-	rom ( name "EFFECTS.OGG" size 1357833 crc c8ccd22a md5 d1d2d4fea2f9812467148725a19009ec )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/French)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/French)"
-	rom ( name "EFFECTS.OGG" size 1357833 crc c8ccd22a md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/German)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/German)"
-	rom ( name "EFFECTS.OGG" size 1358517 crc 3c735d19 md5 f9a62f3598f649fc3cc82009a1563102 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Hebrew)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Hebrew)"
-	rom ( name "EFFECTS.OGG" size 1357833 crc c8ccd22a md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Italian)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Italian)"
-	rom ( name "EFFECTS.OGG" size 1357833 crc c8ccd22a md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Russian)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Russian)"
-	rom ( name "EFFECTS.OGG" size 1358517 crc 3c735d19 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Spanish)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/DOS/Spanish)"
-	rom ( name "EFFECTS.OGG" size 1357833 crc c8ccd22a md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/Windows)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/Windows)"
-	rom ( name "GAMEPC" size 36152 crc 5fb4c04d md5 d22302abf44219f95d50f2faa807dd1a )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/Windows/German)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/Windows/German)"
-	rom ( name "GAMEPC" size 29671 crc 30f62ed0 md5 ecc01a02c9b97b49d0b4191a346b0940 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Enhanced Music/Windows/Italian)"
-	description "Simon the Sorcerer 1 (CD/Enhanced Music/Windows/Italian)"
-	rom ( name "GAMEPC" size 37807 crc 70dbf7d6 md5 5d0a9fe136ae53138d98364cad9d0377 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Windows)"
-	description "Simon the Sorcerer 1 (CD/Windows)"
-	rom ( name "GAMEPC" size 36152 crc 5fb4c04d md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Windows)[a]"
-	description "Simon the Sorcerer 1 (CD/Windows)[a]"
-	rom ( name "GAMEPC" size 36152 crc 5fb4c04d md5 d22302abf44219f95d50f2faa807dd1a )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Windows/German)[!]"
-	description "Simon the Sorcerer 1 (CD/Windows/German)[!]"
-	rom ( name "GAMEPC" size 29671 crc 30f62ed0 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (CD/Windows/Italian)"
-	description "Simon the Sorcerer 1 (CD/Windows/Italian)"
-	rom ( name "GAMEPC" size 37807 crc 70dbf7d6 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Demo/Amiga CD32)"
-	description "Simon the Sorcerer 1 (Demo/Amiga CD32)"
-	rom ( name "0001.OUT" size 1116 crc 6e0b6570 md5 8271253915454bf7502b693140677eeb )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Demo/CD/Acorn)"
-	description "Simon the Sorcerer 1 (Demo/CD/Acorn)"
-	rom ( name "DATA" size 1237886 crc be6dfae0 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Demo/CD/DOS)"
-	description "Simon the Sorcerer 1 (Demo/CD/DOS)"
-	rom ( name "EFFECTS.VOC" size 489177 crc 35d06982 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Demo/Floppy/Amiga/OCS)"
-	description "Simon the Sorcerer 1 (Demo/Floppy/Amiga/OCS)"
-	rom ( name "0001.PKD" size 296 crc 91e57e85 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Demo/Floppy/DOS)"
-	description "Simon the Sorcerer 1 (Demo/Floppy/DOS)"
-	rom ( name "0001.VGA" size 1026 crc c7ceeb7c md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Acorn)"
-	description "Simon the Sorcerer 1 (Floppy/Acorn)"
-	rom ( name "0001.DAT" size 532 crc 9c9884f9 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/AGA)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/AGA)"
-	rom ( name "0001.PKD" size 572 crc 4e1359b0 md5 2f07185c409fdba5d2758d88e04a43a3 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/AGA/French)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/AGA/French)"
-	rom ( name "0001.PKD" size 432 crc cb8bc0f7 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/AGA/German)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/AGA/German)"
-	rom ( name "0001.PKD" size 428 crc 6d1e0084 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/AGA/Italian)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/AGA/Italian)"
-	rom ( name "0001.pkd" size 432 crc eb1bc99d md5 fd51c7906558a89f58cde425e956dd50 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/OCS)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/OCS)"
-	rom ( name "0001.PKD" size 296 crc 91e57e85 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/Amiga/OCS/German)"
-	description "Simon the Sorcerer 1 (Floppy/Amiga/OCS/German)"
-	rom ( name "0001.pkd" size 292 crc 8a0c30cc md5 97b3bec8fe3ab31a3dccc82935c3b894 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS)"
-	description "Simon the Sorcerer 1 (Floppy/DOS)"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS)[infocom]"
-	description "Simon the Sorcerer 1 (Floppy/DOS)[infocom]"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 91dc8113a8052dfa5c9f0985579f25e1 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Czech)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Czech)"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 91dc8113a8052dfa5c9f0985579f25e1 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Czech)[infocom]"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Czech)[infocom]"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/French)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/French)"
-	rom ( name "0001.VGA" size 736 crc c5bf92ca md5 00f7df6ffc31e5304da1fe15d21dc803 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/German)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/German)"
-	rom ( name "0001.VGA" size 736 crc 08e27d0c md5 1b13b49f1bf2dd7537d6380a57355b1a )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Italian)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Italian)"
-	rom ( name "0001.VGA" size 736 crc 7aa6b748 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Russian)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Russian)"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Russian)[infocom]"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Russian)[infocom]"
-	rom ( name "0001.VGA" size 1000 crc b5d3c49c md5 91dc8113a8052dfa5c9f0985579f25e1 )
-)
-
-game (
-	name "Simon the Sorcerer 1 (Floppy/DOS/Spanish)"
-	description "Simon the Sorcerer 1 (Floppy/DOS/Spanish)"
-	rom ( name "0001.VGA" size 736 crc undefined md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Amiga)"
-	description "Simon the Sorcerer 2 (CD/Amiga)"
-	rom ( name "GSPTR30" size 58652 crc 0191a442 md5 bd85a8b5135592ada9cbeae49160f1d3 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS)[!]"
-	description "Simon the Sorcerer 2 (CD/DOS)[!]"
-	rom ( name "GSPTR30" size 58652 crc 37747799 md5 078b04da0974a40645b92baffdf2781e )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS)[a]"
-	description "Simon the Sorcerer 2 (CD/DOS)[a]"
-	rom ( name "GSPTR30" size 58646 crc 5c96e4fc md5 965270a515580b164db98d88f8526e08 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/French)"
-	description "Simon the Sorcerer 2 (CD/DOS/French)"
-	rom ( name "GSPTR30" size 60857 crc c5018fd0 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/German)[!]"
-	description "Simon the Sorcerer 2 (CD/DOS/German)[!]"
-	rom ( name "GSPTR30" size 62346 crc 0646856a md5 3bdf85dc57c1abff8f05416b4571198f )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/German)[a]"
-	description "Simon the Sorcerer 2 (CD/DOS/German)[a]"
-	rom ( name "GSPTR30" size 62346 crc b31ac6d7 md5 b60d4e794a5ade862a252b98c6165f64 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/Hebrew)"
-	description "Simon the Sorcerer 2 (CD/DOS/Hebrew)"
-	rom ( name "GSPTR30" size 53366 crc 5ddd74cd md5 a3cbdd3450f9fccb0a9d8d6dc28f66fe )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/Russian)"
-	description "Simon the Sorcerer 2 (CD/DOS/Russian)"
-	rom ( name "GSPTR30" size 58851 crc a7565726 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/DOS/Spanish)"
-	description "Simon the Sorcerer 2 (CD/DOS/Spanish)"
-	rom ( name "GSPTR30" size 59767 crc e884b67f md5 79a9d9357c15153c8c502dba73c3eac6 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Macintosh)"
-	description "Simon the Sorcerer 2 (CD/Macintosh)"
-	rom ( name "GSPTR30" size 58652 crc 0191a442 md5 bd85a8b5135592ada9cbeae49160f1d3 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Windows)[!]"
-	description "Simon the Sorcerer 2 (CD/Windows)[!]"
-	rom ( name "GSPTR30" size 58652 crc 0191a442 md5 bd85a8b5135592ada9cbeae49160f1d3 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Windows/German)[!]"
-	description "Simon the Sorcerer 2 (CD/Windows/German)[!]"
-	rom ( name "GSPTR30" size 62346 crc 48421a31 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Windows/Italian)"
-	description "Simon the Sorcerer 2 (CD/Windows/Italian)"
-	rom ( name "GSPTR30" size 58904 crc 24a01ade md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (CD/Windows/Polish)"
-	description "Simon the Sorcerer 2 (CD/Windows/Polish)"
-	rom ( name "GSPTR30" size 58652 crc 4f008835 md5 0ce41d8d7d0487f1ddb76244532eb219 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Demo/CD/DOS)"
-	description "Simon the Sorcerer 2 (Demo/CD/DOS)"
-	rom ( name "GSPTR30" size 58757 crc 87e6089f md5 1e11ddbad80c408031ae44a0cbce46bb )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Demo/CD/DOS/German)"
-	description "Simon the Sorcerer 2 (Demo/CD/DOS/German)"
-	rom ( name "GSPTR30" size 62738 crc 5593e1a7 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Demo/Non-Interactive/CD/DOS/German)"
-	description "Simon the Sorcerer 2 (Demo/Non-Interactive/CD/DOS/German)"
-	rom ( name "GSPTR30" size 63415 crc 09d7e60e md5 2d2ccea62cee0cc1ba0f666e9c0ba60f )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Floppy/DOS)"
-	description "Simon the Sorcerer 2 (Floppy/DOS)"
-	rom ( name "GAME32" size 59111 crc ff4130ed md5 27c8e7feada80c75b70b9c2f6088d519 )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Floppy/DOS/German)"
-	description "Simon the Sorcerer 2 (Floppy/DOS/German)"
-	rom ( name "GAME32" size 63146 crc acbda034 md5 f7cf125aef2dbf95737540f28e4dc44d )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Floppy/DOS/Italian)"
-	description "Simon the Sorcerer 2 (Floppy/DOS/Italian)"
-	rom ( name "GAME32" size 58534 crc 119e42e1 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer 2 (Floppy/DOS/Russian)"
-	description "Simon the Sorcerer 2 (Floppy/DOS/Russian)"
-	rom ( name "GAME32" size 59111 crc c88201e7 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Demon in my Pocket (CD/Windows CAB)"
-	description "Simon the Sorcerer's Puzzle Pack: Demon in my Pocket (CD/Windows CAB)"
-	rom ( name "dimp-win-1.add" size 102 crc 7bdd78f9 md5 176726b25b0e2d597a05ac8d11a75831 )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Demon in my Pocket (CD/Windows)"
-	description "Simon the Sorcerer's Puzzle Pack: Demon in my Pocket (CD/Windows)"
-	rom ( name "0102.VGA" size 1209924 crc 4dbae750 md5 090e5d82c327453a5214997b12616aaf )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Jumble (CD/Windows CAB)"
-	description "Simon the Sorcerer's Puzzle Pack: Jumble (CD/Windows CAB)"
-	rom ( name "jumble-win-1.add" size 92 crc f753b366 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Jumble (CD/Windows)"
-	description "Simon the Sorcerer's Puzzle Pack: Jumble (CD/Windows)"
-	rom ( name "0102.VGA" size 1209924 crc 4dbae750 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: NoPatience (CD/Windows CAB)"
-	description "Simon the Sorcerer's Puzzle Pack: NoPatience (CD/Windows CAB)"
-	rom ( name "puzzle-win-1.add" size 96 crc a6725e06 md5 c557bda94a8ade80e736182f677e6913 )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: NoPatience (CD/Windows)"
-	description "Simon the Sorcerer's Puzzle Pack: NoPatience (CD/Windows)"
-	rom ( name "0102.VGA" size 1209924 crc 4dbae750 md5 090e5d82c327453a5214997b12616aaf )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows CAB)"
-	description "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows CAB)"
-	rom ( name "0021.vga" size 1204 crc cd09a302 md5 702b790944582ddbb9755b7228e8f147 )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows)"
-	description "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows)"
-	rom ( name "0102.VGA" size 1209924 crc 4dbae750 md5 undefined )
-)
-
-game (
-	name "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows/German)"
-	description "Simon the Sorcerer's Puzzle Pack: Swampy Adventures (CD/Windows/German)"
-	rom ( name "0102.VGA" size 1758070 crc c15ded2f md5 undefined )
-)
-
-game (
-	name "Slater & Charlie Go Camping (Demo/DOS)"
-	description "Slater & Charlie Go Camping (Demo/DOS)"
-	rom ( name "116.V56" size 22268 crc 5132fad7 md5 1c23f87e49baa8daac43fcbbe34e087c )
-)
-
-game (
-	name "Slater & Charlie Go Camping (DOS)[!]"
-	description "Slater & Charlie Go Camping (DOS)[!]"
-	rom ( name "943.TEX" size 155 crc f1f4eed2 md5 1d08443371e9d0a56e55cefc5e66424f )
-)
-
-game (
-	name "Slater & Charlie Go Camping (DOS)[a]"
-	description "Slater & Charlie Go Camping (DOS)[a]"
-	rom ( name "943.TEX" size 155 crc f1f4eed2 md5 undefined )
-)
-
-game (
-	name "Sliding Tile Game (DOS/Fanmade v1.00)"
-	description "Sliding Tile Game (DOS/Fanmade v1.00)"
-	rom ( name "LOGDIR" size 306 crc 7d92fd08 md5 undefined )
-)
-
-game (
-	name "Snowboarding (Demo/DOS/Fanmade v1.0)"
-	description "Snowboarding (Demo/DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc 68222397 md5 24bb8f29f1eddb5c0a099705267c86e4 )
-)
-
-game (
-	name "Sofia's Debt (Windows)"
-	description "Sofia's Debt (Windows)"
-	rom ( name "SD.exe" size 9915047 crc d7a47a94 md5 de2a07751efa4f094e3dedc72ff6c772 )
-)
-
-game (
-	name "Solar System Tour (DOS/Fanmade)"
-	description "Solar System Tour (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 0b5f1639 md5 b5a3d0f392dfd76a6aa63f3d5f578403 )
-)
-
-game (
-	name "Soltys (DOS/Freeware v1.0)"
-	description "Soltys (DOS/Freeware v1.0)"
-	rom ( name "vol.cat" size 50176 crc 2523b152 md5 de93496e6973d8716f38e4d25b1985f3 )
-)
-
-game (
-	name "Soltys (DOS/Polish Freeware v1.0)"
-	description "Soltys (DOS/Polish Freeware v1.0)"
-	rom ( name "vol.cat" size 50176 crc 3bd4d296 md5 c49eba3fb2ffd22a43accceab43a2f98 )
-)
-
-game (
-	name "Soltys (DOS/Polish Freeware)"
-	description "Soltys (DOS/Polish Freeware)"
-	rom ( name "VOL.CAT" size 50176 crc 0c3d3021 md5 6855e614730910c74de7070e3dbd114b )
-)
-
-game (
-	name "Soltys (DOS/Spanish Freeware v1.0)"
-	description "Soltys (DOS/Spanish Freeware v1.0)"
-	rom ( name "vol.cat" size 50176 crc e86a7f2e md5 6699114f2c36ba7dfdd0ba6753d456b7 )
-)
-
-game (
-	name "Sorceror's Appraisal (DOS/Fanmade)"
-	description "Sorceror's Appraisal (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 303 crc 2aaaf160 md5 undefined )
-)
-
-game (
-	name "Space Adventure (Macintosh)"
-	description "Space Adventure (Macintosh)"
-	rom ( name "._SpaceAdventure" size 159744 crc 0557d263 md5 d3cc343526f0150cd01309be88bdb114 )
-)
-
-game (
-	name "Space Adventure (Macintosh)[a]"
-	description "Space Adventure (Macintosh)[a]"
-	rom ( name "._SpaceAdventure" size 159744 crc undefined md5 undefined )
-)
-
-game (
-	name "Space Invaders (Demo/Windows)"
-	description "Space Invaders (Demo/Windows)"
-	rom ( name "data.dcp" size 1308361 crc 37b9c76b md5 undefined )
-)
-
-game (
-	name "Space Madness (Demo/Windows)[Unk]"
-	description "Space Madness (Demo/Windows)[Unk]"
-	rom ( name "lang-english.dcp" size 586837 crc 6da9f023 md5 e1aa69e4bff97afe70706720dfdac616 )
-)
-
-game (
-	name "Space Madness (Demo/Windows/German)[Unk]"
-	description "Space Madness (Demo/Windows/German)[Unk]"
-	rom ( name "lang-german.dcp" size 1524330 crc 7339828d md5 undefined )
-)
-
-game (
-	name "Space Quest 0: Replicated (CoCo3/Fanmade)"
-	description "Space Quest 0: Replicated (CoCo3/Fanmade)"
-	rom ( name "logDir" size 762 crc 75a3d400 md5 undefined )
-)
-
-game (
-	name "Space Quest 0: Replicated (DOS/Fanmade v1.03)"
-	description "Space Quest 0: Replicated (DOS/Fanmade v1.03)"
-	rom ( name "LOGDIR" size 762 crc febae0b5 md5 undefined )
-)
-
-game (
-	name "Space Quest 0: Replicated (DOS/Fanmade v1.04)"
-	description "Space Quest 0: Replicated (DOS/Fanmade v1.04)"
-	rom ( name "LOGDIR" size 762 crc 1d3f7cbb md5 2ad9d1a4624a98571ee77dcc83f231b6 )
-)
-
-game (
-	name "Space Quest 3.5 (DOS/Fanmade)"
-	description "Space Quest 3.5 (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 618 crc cb354d78 md5 c077bc28d7b36213dd99dc9ecb0147fc )
-)
-
-game (
-	name "Space Quest 6: The Spinal Frontier (Demo/DOS)"
-	description "Space Quest 6: The Spinal Frontier (Demo/DOS)"
-	rom ( name "RESOURCE.000" size 2272050 crc c6339b9c md5 undefined )
-)
-
-game (
-	name "Space Quest 6: The Spinal Frontier (DOS)[!]"
-	description "Space Quest 6: The Spinal Frontier (DOS)[!]"
-	rom ( name "102.SND" size 42972 crc 2b4f7ece md5 undefined )
-)
-
-game (
-	name "Space Quest 6: The Spinal Frontier (DOS)[a]"
-	description "Space Quest 6: The Spinal Frontier (DOS)[a]"
-	rom ( name "102.SND" size 42972 crc 2b4f7ece md5 undefined )
-)
-
-game (
-	name "Space Quest 6: The Spinal Frontier (DOS/French)"
-	description "Space Quest 6: The Spinal Frontier (DOS/French)"
-	rom ( name "680.HEP" size 1204 crc ae90fd3e md5 be1a99c1f6a3447011e58fa67b34f782 )
-)
-
-game (
-	name "Space Quest 6: The Spinal Frontier (DOS/German)"
-	description "Space Quest 6: The Spinal Frontier (DOS/German)"
-	rom ( name "RESOURCE.000" size 40933685 crc b69b04a3 md5 0d63e5f38b547aa16e1bc033b6ec3447 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (Amiga)"
-	description "Space Quest I: The Sarien Encounter (Amiga)"
-	rom ( name "LOGDIR" size 372 crc a86408a7 md5 0b216d931e95750f1f4837d6a4b821e5 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (Apple IIgs)"
-	description "Space Quest I: The Sarien Encounter (Apple IIgs)"
-	rom ( name "LOGDIR" size 372 crc d210ef19 md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (Atari ST)"
-	description "Space Quest I: The Sarien Encounter (Atari ST)"
-	rom ( name "LOGDIR" size 372 crc 4e6a0c8b md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (CoCo3/Updated)"
-	description "Space Quest I: The Sarien Encounter (CoCo3/Updated)"
-	rom ( name "logDir" size 387 crc b6e05f5c md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (Demo/SCI/DOS)"
-	description "Space Quest I: The Sarien Encounter (Demo/SCI/DOS)"
-	rom ( name "433.V56" size 2703 crc e37de82a md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (DOS/1.0X)"
-	description "Space Quest I: The Sarien Encounter (DOS/1.0X)"
-	rom ( name "LOGDIR" size 372 crc 938a1123 md5 af93941b6c51460790a9efa0e8cb7122 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (DOS/1.1A)"
-	description "Space Quest I: The Sarien Encounter (DOS/1.1A)"
-	rom ( name "LOGDIR" size 372 crc d58b2035 md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (DOS/2.2)"
-	description "Space Quest I: The Sarien Encounter (DOS/2.2)"
-	rom ( name "LOGDIR" size 372 crc 36f49d8d md5 5d67630aba008ec5f7f9a6d0a00582f4 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (DOS/Russian)"
-	description "Space Quest I: The Sarien Encounter (DOS/Russian)"
-	rom ( name "LOGDIR" size 372 crc 5a4e8d82 md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (Macintosh)"
-	description "Space Quest I: The Sarien Encounter (Macintosh)"
-	rom ( name "LOGDIR" size 384 crc 9c202e66 md5 ce88419aadd073d1c6682d859b3d8aa2 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (SCI/Amiga)"
-	description "Space Quest I: The Sarien Encounter (SCI/Amiga)"
-	rom ( name "11.SCR" size 6178 crc dd36d6dc md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (SCI/DOS)"
-	description "Space Quest I: The Sarien Encounter (SCI/DOS)"
-	rom ( name "433.V56" size 2703 crc e37de82a md5 88014ca186f40b1a1cc7183adba3e234 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (SCI/DOS/EGA)"
-	description "Space Quest I: The Sarien Encounter (SCI/DOS/EGA)"
-	rom ( name "4.PAT" size 1301 crc b8d689c1 md5 undefined )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (SCI/DOS/Spanish)"
-	description "Space Quest I: The Sarien Encounter (SCI/DOS/Spanish)"
-	rom ( name "803.SCR" size 730 crc b79572ee md5 020dc5c02deeeba4fd0479f33098eda8 )
-)
-
-game (
-	name "Space Quest I: The Sarien Encounter (SCI/Macintosh)"
-	description "Space Quest I: The Sarien Encounter (SCI/Macintosh)"
-	rom ( name "1.PAT" size 13014 crc a781af6b md5 undefined )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (Amiga)[vol.2-picture.16 broken]"
-	description "Space Quest II: Vohaul's Revenge (Amiga)[vol.2-picture.16 broken]"
-	rom ( name "LOGDIR" size 426 crc 4af29aa5 md5 undefined )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (Apple IIgs)"
-	description "Space Quest II: Vohaul's Revenge (Apple IIgs)"
-	rom ( name "LOGDIR" size 426 crc c9fb0d1b md5 5dfdac98dd3c01fcfb166529f917e911 )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (CoCo3/Updated)"
-	description "Space Quest II: Vohaul's Revenge (CoCo3/Updated)"
-	rom ( name "logDir" size 768 crc c24230da md5 d24f19b047e65e1763eff4b46f3d50df )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/2.0A 3.5')"
-	description "Space Quest II: Vohaul's Revenge (DOS/2.0A 3.5')"
-	rom ( name "LOGDIR" size 423 crc 772e92b4 md5 6c25e33d23b8bed42a5c7fa63d588e5c )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/2.0A 5.25')"
-	description "Space Quest II: Vohaul's Revenge (DOS/2.0A 5.25')"
-	rom ( name "LOGDIR" size 423 crc 1a33142d md5 ad7ce8f800581ecc536f3e8021d7a74d )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/2.0D)"
-	description "Space Quest II: Vohaul's Revenge (DOS/2.0D)"
-	rom ( name "LOGDIR" size 426 crc 7beb7519 md5 undefined )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/2.0F)"
-	description "Space Quest II: Vohaul's Revenge (DOS/2.0F)"
-	rom ( name "LOGDIR" size 426 crc 4af29aa5 md5 undefined )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/Atari ST/2.0C)"
-	description "Space Quest II: Vohaul's Revenge (DOS/Atari ST/2.0C)"
-	rom ( name "LOGDIR" size 423 crc bb96128b md5 bd71fe54869e86945041700f1804a651 )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/Russian)"
-	description "Space Quest II: Vohaul's Revenge (DOS/Russian)"
-	rom ( name "LOGDIR" size 423 crc b0d5d0b7 md5 undefined )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (DOS/Spanish)"
-	description "Space Quest II: Vohaul's Revenge (DOS/Spanish)"
-	rom ( name "LOGDIR" size 426 crc d2645a28 md5 1ae7640dd4d253c3ac2d708d61a35379 )
-)
-
-game (
-	name "Space Quest II: Vohaul's Revenge (Macintosh)"
-	description "Space Quest II: Vohaul's Revenge (Macintosh)"
-	rom ( name "LOGDIR" size 512 crc 8384a13e md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Amiga)"
-	description "Space Quest III: The Pirates of Pestulon (Amiga)"
-	rom ( name "BANK.001" size 224552 crc e14340c4 md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Amiga/German)"
-	description "Space Quest III: The Pirates of Pestulon (Amiga/German)"
-	rom ( name "101.PAT" size 468 crc 27647c7e md5 e8bf57292ac413ee4344aef8c036e949 )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Atari ST)"
-	description "Space Quest III: The Pirates of Pestulon (Atari ST)"
-	rom ( name "RESOURCE.001" size 485146 crc 6ffa9f2e md5 46c23d9d74551c94dba5fd3854c79fb5 )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Demo/DOS)"
-	description "Space Quest III: The Pirates of Pestulon (Demo/DOS)"
-	rom ( name "RESOURCE.001" size 180245 crc cb9010ec md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (DOS)"
-	description "Space Quest III: The Pirates of Pestulon (DOS)"
-	rom ( name "RESOURCE.001" size 490247 crc eba62ad0 md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (DOS)[a1]"
-	description "Space Quest III: The Pirates of Pestulon (DOS)[a1]"
-	rom ( name "QAFILE" size 71 crc c670757f md5 6a9eb7ab4561163edddbc71362a62e70 )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (DOS)[a2]"
-	description "Space Quest III: The Pirates of Pestulon (DOS)[a2]"
-	rom ( name "RESOURCE.001" size 170494 crc f59693ed md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (DOS/German)"
-	description "Space Quest III: The Pirates of Pestulon (DOS/German)"
-	rom ( name "RESOURCE.001" size 567245 crc 4f7cb9d7 md5 9cf369a1e4fd6d4c9008758b60b8d458 )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (DOS/German)[a]"
-	description "Space Quest III: The Pirates of Pestulon (DOS/German)[a]"
-	rom ( name "RESOURCE.001" size 117869 crc af73160f md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Macintosh)"
-	description "Space Quest III: The Pirates of Pestulon (Macintosh)"
-	rom ( name "PATCH.001" size 16914 crc 338907bd md5 undefined )
-)
-
-game (
-	name "Space Quest III: The Pirates of Pestulon (Macintosh)[a]"
-	description "Space Quest III: The Pirates of Pestulon (Macintosh)[a]"
-	rom ( name "PATCH.001" size 16914 crc 338907bd md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (Amiga)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (Amiga)"
-	rom ( name "615.SCR" size 5210 crc cb55021c md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (Amiga/German)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (Amiga/German)"
-	rom ( name "395.SCR" size 8504 crc 75a3a267 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (CD/DOS)[!]"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (CD/DOS)[!]"
-	rom ( name "335.HEP" size 2846 crc bc2487b9 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS)"
-	rom ( name "RESOURCE.000" size 173330 crc 98a8b567 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS)[a1]"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS)[a1]"
-	rom ( name "RESOURCE.000" size 933928 crc caee1eeb md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS)[a2]"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS)[a2]"
-	rom ( name "ENGLISH.ROM" size 69 crc 3563ed48 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/EGA)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/EGA)"
-	rom ( name "377.V16" size 8069 crc 865c9892 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/EGA/Spanish)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/EGA/Spanish)"
-	rom ( name "RESOURCE.000" size 242470 crc 6a7ec48c md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/French)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/French)"
-	rom ( name "391.SCR" size 12518 crc 2ea35bf0 md5 71ce6270f0a3c09618f6be2ad55979c1 )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/German)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/German)"
-	rom ( name "RESOURCE.000" size 206032 crc 9703a0a2 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/German)[a]"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/German)[a]"
-	rom ( name "RESOURCE.000" size 206032 crc 9703a0a2 md5 f662bbfe7fccf02ab529768bdd9bd524 )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Italian)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Italian)"
-	rom ( name "0.SCR" size 16980 crc cc4e621b md5 97c74b38ec5940884a856fdf5eb4c6b1 )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Russian)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Russian)"
-	rom ( name "992.V56" size 5613 crc 90f1a065 md5 de92a199b251f9b9cd261cebbf1e1458 )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Spanish)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (DOS/Spanish)"
-	rom ( name "341.SCR" size 4226 crc f11451fa md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (Macintosh)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (Macintosh)"
-	rom ( name "1.PAT" size 16902 crc d3c9eef5 md5 undefined )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (PC-98)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (PC-98)"
-	rom ( name "RESOURCE.000" size 952909 crc bad31f5a md5 2ebb429f92243d460494161d8e197e9f )
-)
-
-game (
-	name "Space Quest IV: Roger Wilco and the Time Rippers (PC-98/Japanese)"
-	description "Space Quest IV: Roger Wilco and the Time Rippers (PC-98/Japanese)"
-	rom ( name "JAPANESE.ROM" size 73 crc 67c000ac md5 undefined )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS)"
-	description "Space Quest V: The Next Mutation (DOS)"
-	rom ( name "0.FON" size 1782 crc 69161c49 md5 undefined )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS/French)"
-	description "Space Quest V: The Next Mutation (DOS/French)"
-	rom ( name "0.FON" size 2791 crc 5fe84248 md5 undefined )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS/German)"
-	description "Space Quest V: The Next Mutation (DOS/German)"
-	rom ( name "0.FON" size 2791 crc 5fe84248 md5 ef62d5be51eaba4ee0d49fae99fd55e4 )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS/Italian)"
-	description "Space Quest V: The Next Mutation (DOS/Italian)"
-	rom ( name "65535.MAP" size 428 crc 2ca8baa5 md5 undefined )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS/Russian)"
-	description "Space Quest V: The Next Mutation (DOS/Russian)"
-	rom ( name "65535.MAP" size 422 crc b029f85e md5 ff6d8f0130406c0947fda636fd50fb32 )
-)
-
-game (
-	name "Space Quest V: The Next Mutation (DOS/Spanish)"
-	description "Space Quest V: The Next Mutation (DOS/Spanish)"
-	rom ( name "1041.MSG" size 2263 crc 004029a4 md5 7f4b0a90a04c71c50164b3e82f51137a )
-)
-
-game (
-	name "Space Quest X: The Lost Chapter (CoCo3/Fanmade)"
-	description "Space Quest X: The Lost Chapter (CoCo3/Fanmade)"
-	rom ( name "logDir" size 768 crc b08a36b2 md5 f0a59044475a5fa37c055d8c3eb4d1a7 )
-)
-
-game (
-	name "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Apr 10)[Unl]"
-	description "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Apr 10)[Unl]"
-	rom ( name "LOGDIR" size 768 crc cf04734c md5 b8688f77b74309bf082ec583b6a3beb8 )
-)
-
-game (
-	name "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Feb 05)"
-	description "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Feb 05)"
-	rom ( name "LOGDIR" size 768 crc 21873a6c md5 c992ae2f8ab18360404efdf16fa9edd1 )
-)
-
-game (
-	name "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Jul 18)"
-	description "Space Quest X: The Lost Chapter (DOS/Fanmade v10.0 Jul 18)"
-	rom ( name "LOGDIR" size 768 crc c055f242 md5 812edec45cefad559d190ffde2f9c910 )
-)
-
-game (
-	name "Space Trek (DOS/Fanmade v1.0)"
-	description "Space Trek (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 768 crc 3fb93532 md5 807a1aeadb2ace6968831d36ab5ea37a )
-)
-
-game (
-	name "Spear of Destiny (Macintosh)"
-	description "Spear of Destiny (Macintosh)"
-	rom ( name "._SpearOfDestiny" size 339968 crc a7f6bd3c md5 ce050e7fd1a7a1dce2a2c8eef7ddcbbc )
-)
-
-game (
-	name "Special Delivery (DOS/Fanmade)"
-	description "Special Delivery (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 26146983 md5 undefined )
-)
-
-game (
-	name "Speeder Bike Challenge (DOS/Fanmade v1.0)"
-	description "Speeder Bike Challenge (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 300 crc f65f9b1c md5 2deb25bab379285ca955df398d96c1e7 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (ALL/Dutch)"
-	description "SPY Fox 1: Dry Cereal (ALL/Dutch)"
-	rom ( name "SPYFox.(A)" size 69484569 crc 0adaac03 md5 bf36db36ec5717ac84a1774e3ea52530 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (ALL/German)"
-	description "SPY Fox 1: Dry Cereal (ALL/German)"
-	rom ( name "SPYFoxDMK.(a)" size 69294266 crc 076b6be5 md5 96da98152ccc2f0d9002c834f34d5cd0 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (ALL/Updated)"
-	description "SPY Fox 1: Dry Cereal (ALL/Updated)"
-	rom ( name "SPYFoxDC.(a)" size 69716465 crc 81a65b60 md5 1707a872046fef6538028adb59c3d172 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (ALL/US/Updated)"
-	description "SPY Fox 1: Dry Cereal (ALL/US/Updated)"
-	rom ( name "Spyfox.(a)" size 87359317 crc 3f3f6fdc md5 42bd881bb836d95f12031be8ee92053f )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/ALL)[!]"
-	description "SPY Fox 1: Dry Cereal (Demo/ALL)[!]"
-	rom ( name "FOXDEMO.HE0" size 20103 crc 5855a484 md5 53e94115b55dd51d4b8ff0871aa1df1e )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/ALL)[a][!]"
-	description "SPY Fox 1: Dry Cereal (Demo/ALL)[a][!]"
-	rom ( name "spydemo.HE0" size 15693 crc c1cae4cb md5 fbdd947d21e8f5bac6d6f7a316af1c5a )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/ALL)[HE 100]"
-	description "SPY Fox 1: Dry Cereal (Demo/ALL)[HE 100]"
-	rom ( name "Spydemo.(a)" size 23415607 crc e76ec39e md5 f5207b882c9015a4e4a9599460be6294 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/ALL/Dutch)[!]"
-	description "SPY Fox 1: Dry Cereal (Demo/ALL/Dutch)[!]"
-	rom ( name "Spydemo.(A)" size 14553711 crc d167a057 md5 76de1998b5cfc0e16cbf259bf2989cc2 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/ALL/French)"
-	description "SPY Fox 1: Dry Cereal (Demo/ALL/French)"
-	rom ( name "JAMESDEM.HE0" size 20103 crc 363cf4f8 md5 ba888e6831517597859e91aa173f945c )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/German)"
-	description "SPY Fox 1: Dry Cereal (Demo/German)"
-	rom ( name "FUCHSDEM.HE0" size 20103 crc d4aa45af md5 73b8197e236da4bf49adc99fe8f5fa1b )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Demo/Macintosh/Dutch)"
-	description "SPY Fox 1: Dry Cereal (Demo/Macintosh/Dutch)"
-	rom ( name "Spy Fox demo (0)" size 20141 crc c6ba73f7 md5 f2ec78e50bdc63b70044e9758be10914 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Nintendo Wii)"
-	description "SPY Fox 1: Dry Cereal (Nintendo Wii)"
-	rom ( name "SPYFOX.(a)" size 87393601 crc 81e4ec9e md5 a486f91b4ee1406a6b7c5a4a72a3402a )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Windows)[!]"
-	description "SPY Fox 1: Dry Cereal (Windows)[!]"
-	rom ( name "SPYFOX.HE0" size 49221 crc cb8aff06 md5 6bf70eee5de3d24d2403e0dd3d267e8a )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Windows/French)"
-	description "SPY Fox 1: Dry Cereal (Windows/French)"
-	rom ( name "RENARD.HE0" size 49221 crc 9d2979c0 md5 100b4c8403ad6a83d4bf7dbf83e44dc4 )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Windows/Russian)"
-	description "SPY Fox 1: Dry Cereal (Windows/Russian)"
-	rom ( name "SPYFOX.HE0" size 49221 crc cb8aff06 md5 6bf70eee5de3d24d2403e0dd3d267e8a )
-)
-
-game (
-	name "SPY Fox 1: Dry Cereal (Windows/Russian)[a]"
-	description "SPY Fox 1: Dry Cereal (Windows/Russian)[a]"
-	rom ( name "SPYFoxDC.(a)" size 69373367 crc 666e30a0 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (ALL)[!]"
-	description "SPY Fox 2: Some Assembly Required (ALL)[!]"
-	rom ( name "SPYFOX2.(A)" size 88105181 crc 0a103dca md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (ALL/French)"
-	description "SPY Fox 2: Some Assembly Required (ALL/French)"
-	rom ( name "SPYFoxORE.(a)" size 89647310 crc 2bf514fa md5 5b3e92b782e4143dccb9d17b1d5df750 )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (ALL/German)"
-	description "SPY Fox 2: Some Assembly Required (ALL/German)"
-	rom ( name "SPYFoxOR.(a)" size 89158743 crc bbb076fa md5 525010efe78d638c893a2a54f0e97a04 )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/ALL/German)"
-	description "SPY Fox 2: Some Assembly Required (Demo/ALL/German)"
-	rom ( name "SF2demo.(a)" size 6050609 crc 005d5b8a md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/ALL/US)[!]"
-	description "SPY Fox 2: Some Assembly Required (Demo/ALL/US)[!]"
-	rom ( name "sf2-demo.(a)" size 6162726 crc b7818a08 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/Dutch)[!]"
-	description "SPY Fox 2: Some Assembly Required (Demo/Dutch)[!]"
-	rom ( name "sf2demo.(a)" size 5990459 crc 650b4713 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/Windows/French)"
-	description "SPY Fox 2: Some Assembly Required (Demo/Windows/French)"
-	rom ( name "Sf2demo.(a)" size 6174151 crc c0853405 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/Windows/German)"
-	description "SPY Fox 2: Some Assembly Required (Demo/Windows/German)"
-	rom ( name "SF2demo.(a)" size 5964873 crc eb0a6f65 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/Windows/Italian)"
-	description "SPY Fox 2: Some Assembly Required (Demo/Windows/Italian)"
-	rom ( name "SF2demo.(a)" size 5958283 crc c10f8d3c md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Demo/Windows/UK)"
-	description "SPY Fox 2: Some Assembly Required (Demo/Windows/UK)"
-	rom ( name "SF2DEMO.(A)" size 5870072 crc c0c9f6f6 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Preview)[!]"
-	description "SPY Fox 2: Some Assembly Required (Preview)[!]"
-	rom ( name "spy2preview.cup" size 5756234 crc eb534ca2 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Russian)"
-	description "SPY Fox 2: Some Assembly Required (Russian)"
-	rom ( name "spyfoxsr.(a)" size 88872097 crc 5e281392 md5 4ecc3a54d961a23b80239e191309bb2a )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Russian)[a1]"
-	description "SPY Fox 2: Some Assembly Required (Russian)[a1]"
-	rom ( name "SPYFOX2.(A)" size 88105181 crc 830351bc md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Russian)[a2]"
-	description "SPY Fox 2: Some Assembly Required (Russian)[a2]"
-	rom ( name "SPYFoxSR.(a)" size 88111882 crc 718a3d14 md5 undefined )
-)
-
-game (
-	name "SPY Fox 2: Some Assembly Required (Windows/Dutch)"
-	description "SPY Fox 2: Some Assembly Required (Windows/Dutch)"
-	rom ( name "Spyfox2.(a)" size 88730276 crc 6f35a607 md5 undefined )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (ALL/French)"
-	description "SPY Fox 3: Operation Ozone (ALL/French)"
-	rom ( name "SPYFoxSOS.(a)" size 97390021 crc 1779aa8e md5 undefined )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (ALL/German)"
-	description "SPY Fox 3: Operation Ozone (ALL/German)"
-	rom ( name "SPYFoxAIW.(a)" size 97290221 crc da2f91eb md5 7752e47f72ee7e7cfc81586308aa6bfc )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (ALL/US)[!]"
-	description "SPY Fox 3: Operation Ozone (ALL/US)[!]"
-	rom ( name "SPYOZON.(A)" size 97283003 crc ae439d4d md5 undefined )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (Demo/ALL)[!]"
-	description "SPY Fox 3: Operation Ozone (Demo/ALL)[!]"
-	rom ( name "SF3-DEMO.(A)" size 7141191 crc 0394a58e md5 0b3dac19ac1107f3fcfa9b38c47b2dfb )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (Demo/Windows/French)"
-	description "SPY Fox 3: Operation Ozone (Demo/Windows/French)"
-	rom ( name "SF3Demo.(a)" size 7323207 crc 5b77e7da md5 aafe454e173d7612829aafb17b4865fe )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (Preview)[!]"
-	description "SPY Fox 3: Operation Ozone (Preview)[!]"
-	rom ( name "OZONEPRE.CUP" size 5235008 crc c88af260 md5 6466510675b2021204f951f8deecb348 )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (Russian)"
-	description "SPY Fox 3: Operation Ozone (Russian)"
-	rom ( name "SPYFoxOzu.(a)" size 121041055 crc 561da083 md5 eb03a8bd9e7654d5d06635d934f2059b )
-)
-
-game (
-	name "SPY Fox 3: Operation Ozone (Windows/UK)"
-	description "SPY Fox 3: Operation Ozone (Windows/UK)"
-	rom ( name "SPYFoxOzu.(a)" size 97113888 crc 955b2e30 md5 undefined )
-)
-
-game (
-	name "SPY Fox in Cheese Chase (ALL/US)[!]"
-	description "SPY Fox in Cheese Chase (ALL/US)[!]"
-	rom ( name "CHASE.HE0" size 39100 crc daab4a4a md5 589601b676c98b1c0c987bc031ab68b3 )
-)
-
-game (
-	name "SPY Fox in Cheese Chase (Windows/Russian)"
-	description "SPY Fox in Cheese Chase (Windows/Russian)"
-	rom ( name "CHASE.HE0" size 39100 crc c43af8c6 md5 9cdd327c1034c046cb595d251c44da2f )
-)
-
-game (
-	name "SPY Fox in Hold the Mustard (ALL/US)[!]"
-	description "SPY Fox in Hold the Mustard (ALL/US)[!]"
-	rom ( name "map.ini" size 28068 crc 675144a9 md5 70355a28ccece8d0e26cfc3623adc0d8 )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.3)"
-	description "SQ2Eye (DOS/Fanmade v0.3)"
-	rom ( name "LOGDIR" size 423 crc cac2ca47 md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.4)"
-	description "SQ2Eye (DOS/Fanmade v0.4)"
-	rom ( name "LOGDIR" size 423 crc cac2ca47 md5 2be2519401d38ad9ce8f43b948d093a3 )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.41)"
-	description "SQ2Eye (DOS/Fanmade v0.41)"
-	rom ( name "LOGDIR" size 423 crc 3e834473 md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.42)"
-	description "SQ2Eye (DOS/Fanmade v0.42)"
-	rom ( name "LOGDIR" size 423 crc 17fc772d md5 d7beae55f6328ef8b2da47b1aafea40c )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.43)"
-	description "SQ2Eye (DOS/Fanmade v0.43)"
-	rom ( name "LOGDIR" size 423 crc 7e77f8b0 md5 2a895f06e45de153bb4b77c982009e06 )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.44)"
-	description "SQ2Eye (DOS/Fanmade v0.44)"
-	rom ( name "LOGDIR" size 423 crc e38b05ab md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.45)"
-	description "SQ2Eye (DOS/Fanmade v0.45)"
-	rom ( name "LOGDIR" size 423 crc 479282b6 md5 6e06f8bb7b90ce6f6aabf1a0e620159c )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.46)"
-	description "SQ2Eye (DOS/Fanmade v0.46)"
-	rom ( name "LOGDIR" size 423 crc 6fe57f4f md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.47)"
-	description "SQ2Eye (DOS/Fanmade v0.47)"
-	rom ( name "LOGDIR" size 423 crc 412b7c7b md5 85dc3be1d33ff932c292b74f9037abaa )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.48)"
-	description "SQ2Eye (DOS/Fanmade v0.48)"
-	rom ( name "LOGDIR" size 423 crc d388e7f3 md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.481)"
-	description "SQ2Eye (DOS/Fanmade v0.481)"
-	rom ( name "LOGDIR" size 423 crc 007e4c17 md5 fc9234beb49804ae869696ce5af8ef30 )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.482)"
-	description "SQ2Eye (DOS/Fanmade v0.482)"
-	rom ( name "LOGDIR" size 423 crc 3a832c1b md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.483)"
-	description "SQ2Eye (DOS/Fanmade v0.483)"
-	rom ( name "LOGDIR" size 423 crc 8b90112e md5 647c31298d3f9cda641231b893e347c0 )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.484)"
-	description "SQ2Eye (DOS/Fanmade v0.484)"
-	rom ( name "LOGDIR" size 423 crc f1295f48 md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.485)"
-	description "SQ2Eye (DOS/Fanmade v0.485)"
-	rom ( name "LOGDIR" size 423 crc 7892008c md5 undefined )
-)
-
-game (
-	name "SQ2Eye (DOS/Fanmade v0.486)"
-	description "SQ2Eye (DOS/Fanmade v0.486)"
-	rom ( name "LOGDIR" size 423 crc 65873740 md5 3fd86436e93456770dbdd4593eded70a )
-)
-
-game (
-	name "Star Commander 1: The Escape (DOS/Fanmade v1.0)"
-	description "Star Commander 1: The Escape (DOS/Fanmade v1.0)"
-	rom ( name "LOGDIR" size 768 crc 4e0a170e md5 a7806f01e6fa14ebc029faa58f263750 )
-)
-
-game (
-	name "Star Pilot: Bigger Fish (DOS/Fanmade)"
-	description "Star Pilot: Bigger Fish (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 315 crc 6f66b422 md5 8cb26f8e1c045b75c6576c839d4a0172 )
-)
-
-game (
-	name "Star Trek (Macintosh)"
-	description "Star Trek (Macintosh)"
-	rom ( name "._Star Trek" size 55242 crc 5cdc89bb md5 2372b7ee033a4958cb63ad4b10cfb64e )
-)
-
-game (
-	name "Strange Disappearance (Macintosh)"
-	description "Strange Disappearance (Macintosh)"
-	rom ( name "._Strange Disappearance" size 781154 crc 372442d0 md5 95044c253a8506e414bda4a28552a4e9 )
-)
-
-game (
-	name "Street Quest (Demo/DOS/Fanmade)"
-	description "Street Quest (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc e97d31ed md5 undefined )
-)
-
-game (
-	name "Sultan's Palace, The (Macintosh)"
-	description "Sultan's Palace, The (Macintosh)"
-	rom ( name "._Sultan's Sounds" size 297958 crc 51b03b67 md5 d203c985d63e546f7a158617de72d8b5 )
-)
-
-game (
-	name "Swamp Witch (Macintosh)"
-	description "Swamp Witch (Macintosh)"
-	rom ( name "._Swamp Witch" size 753664 crc undefined md5 undefined )
-)
-
-game (
-	name "Sweetspace Now! (Macintosh)"
-	description "Sweetspace Now! (Macintosh)"
-	rom ( name "._Basic Sounds" size 184320 crc 347352e1 md5 794df937f895acd6cc5a7bf8d4991e40 )
-)
-
-game (
-	name "Tales of the Tiki (DOS/Fanmade)"
-	description "Tales of the Tiki (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 615 crc 3131d90b md5 8103c9c87e3964690a14a3d0d83f7ddc )
-)
-
-game (
-	name "Teen Agent (CD/DOS/Czech)"
-	description "Teen Agent (CD/DOS/Czech)"
-	rom ( name "CDLOGO.RES" size 64768 crc 43964e52 md5 f3053aa4674b698ec71628f139ea59e7 )
-)
-
-game (
-	name "Teen Agent (Demo/Union/DOS)"
-	description "Teen Agent (Demo/Union/DOS)"
-	rom ( name "LAN_000.RES" size 91729 crc 1f25acbf md5 undefined )
-)
-
-game (
-	name "Teen Agent (Demo/Wiztech/DOS)"
-	description "Teen Agent (Demo/Wiztech/DOS)"
-	rom ( name "ADVERT.RES" size 712500 crc 22631ba4 md5 undefined )
-)
-
-game (
-	name "Teen Agent (DOS)"
-	description "Teen Agent (DOS)"
-	rom ( name "LAN_000.RES" size 535599 crc f84ad35d md5 2b376797af05a8a021a82d3d5abf96d4 )
-)
-
-game (
-	name "Teen Agent (DOS/v1.0)[GOG][!]"
-	description "Teen Agent (DOS/v1.0)[GOG][!]"
-	rom ( name "ADVERT.RES" size 712500 crc 22631ba4 md5 undefined )
-)
-
-game (
-	name "Tender Loving Care (DOS)"
-	description "Tender Loving Care (DOS)"
-	rom ( name "DISK.1" size 84 crc b40f376b md5 undefined )
-)
-
-game (
-	name "Tex McPhilip 1: Quest for the Papacy (DOS/Fanmade)"
-	description "Tex McPhilip 1: Quest for the Papacy (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 3edaf9b3 md5 undefined )
-)
-
-game (
-	name "Tex McPhilip 2: Road to Divinity (DOS/Fanmade v1.5)"
-	description "Tex McPhilip 2: Road to Divinity (DOS/Fanmade v1.5)"
-	rom ( name "LOGDIR" size 762 crc a188638a md5 7387e8df854440bc26620ca0ea43af9a )
-)
-
-game (
-	name "Tex McPhilip 3: A Destiny of Sin (Demo/DOS/Fanmade v0.25)"
-	description "Tex McPhilip 3: A Destiny of Sin (Demo/DOS/Fanmade v0.25)"
-	rom ( name "LOGDIR" size 768 crc 9c261524 md5 undefined )
-)
-
-game (
-	name "Text Views Demo (DOS/Fanmade)"
-	description "Text Views Demo (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 115788 crc a992bc55 md5 b216cd40666ba1e9f002b85a8bc3d6a3 )
-)
-
-game (
-	name "Time Bomb (Macintosh)"
-	description "Time Bomb (Macintosh)"
-	rom ( name "._Time Bomb" size 66304 crc undefined md5 undefined )
-)
-
-game (
-	name "Time Quest (CoCo3/Fanmade)"
-	description "Time Quest (CoCo3/Fanmade)"
-	rom ( name "logDir" size 300 crc efc5b1cb md5 undefined )
-)
-
-game (
-	name "Time Quest (Demo/DOS/Fanmade v0.1)"
-	description "Time Quest (Demo/DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 300 crc 998984ce md5 12e1a6f03ea4b8c5531acd0400b4ed8d )
-)
-
-game (
-	name "Time Quest (Demo/DOS/Fanmade v0.2)"
-	description "Time Quest (Demo/DOS/Fanmade v0.2)"
-	rom ( name "LOGDIR" size 300 crc 7e1906d3 md5 7b710608abc99e0861ac59b967bf3f6d )
-)
-
-game (
-	name "Toby's World (Demo/DOS/Fanmade)"
-	description "Toby's World (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 768 crc d6537b56 md5 3f8ebea0eb32303e65e2a6e8341c6741 )
-)
-
-game (
-	name "Tonight The Shrieking Corpses Bleed (Demo/DOS/Fanmade v0.11)"
-	description "Tonight The Shrieking Corpses Bleed (Demo/DOS/Fanmade v0.11)"
-	rom ( name "LOGDIR" size 762 crc 70678154 md5 bcc57a7c8d563fa0c333107ae1c0a6e6 )
-)
-
-game (
-	name "Tonight The Shrieking Corpses Bleed (DOS/Fanmade v1.01)"
-	description "Tonight The Shrieking Corpses Bleed (DOS/Fanmade v1.01)"
-	rom ( name "LOGDIR" size 762 crc 8566ce8f md5 undefined )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Demo/Compressed/Windows)"
-	description "Tony Tough and the Night of Roasted Moths (Demo/Compressed/Windows)"
-	rom ( name "data1.cab" size 58660608 crc 18b7535c md5 b4471356313e85febdf960092a2bdcf2 )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Demo/Extracted/Windows)"
-	description "Tony Tough and the Night of Roasted Moths (Demo/Extracted/Windows)"
-	rom ( name "roasted.MPC" size 39211 crc d8890944 md5 6f7f61674392f58c00e5996189ff7eb3 )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Windows)"
-	description "Tony Tough and the Night of Roasted Moths (Windows)"
-	rom ( name "data1.cab" size 4350 crc 4223a02f md5 undefined )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Windows/French)"
-	description "Tony Tough and the Night of Roasted Moths (Windows/French)"
-	rom ( name "roasted.mpc" size 374135 crc 045e1a31 md5 40c7626863cd6b7ad23f88f46279a4d6 )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Windows/German)"
-	description "Tony Tough and the Night of Roasted Moths (Windows/German)"
-	rom ( name "roasted.mpc" size 389554 crc 8fa29b29 md5 undefined )
-)
-
-game (
-	name "Tony Tough and the Night of Roasted Moths (Windows/Italian)"
-	description "Tony Tough and the Night of Roasted Moths (Windows/Italian)"
-	rom ( name "roasted.mpc" size 380183 crc 81b5318a md5 undefined )
-)
-
-game (
-	name "Toonstruck (Demo/DOS)"
-	description "Toonstruck (Demo/DOS)"
-	rom ( name "ACT1\JIMEX\JIMEX.PAK" size 332034 crc 5addc12b md5 undefined )
-)
-
-game (
-	name "Toonstruck (Demo/DOS/German)"
-	description "Toonstruck (Demo/DOS/German)"
-	rom ( name "ACT1\JIMEX\CAR20471.MUS" size 656620 crc fc133e9f md5 undefined )
-)
-
-game (
-	name "Toonstruck (DOS)"
-	description "Toonstruck (DOS)"
-	rom ( name "ACT1\ARCADDBL\422M.SMK" size 6891136 crc 3de7a865 md5 718bfd7cadb63997757d10067b7a0b20 )
-)
-
-game (
-	name "Toonstruck (DOS/French)"
-	description "Toonstruck (DOS/French)"
-	rom ( name "ACT1\ARCADDBL\422M.SMK" size 7112452 crc 857652c7 md5 undefined )
-)
-
-game (
-	name "Toonstruck (DOS/German)"
-	description "Toonstruck (DOS/German)"
-	rom ( name "ACT1\ARCADDBL\422M.SMK" size 6882324 crc 3da49133 md5 4beecbe2fd5ae2662fea0e45511bb694 )
-)
-
-game (
-	name "Toonstruck (DOS/Russian)"
-	description "Toonstruck (DOS/Russian)"
-	rom ( name "ACT1\ARCADDBL\422M.SMK" size 6913164 crc dc473a18 md5 6110479db0f5f4413fe0c985e8b73adf )
-)
-
-game (
-	name "Toonstruck (DOS/Spanish)"
-	description "Toonstruck (DOS/Spanish)"
-	rom ( name "ACT1\ARCADDBL\422M.SMK" size 6594296 crc b2c85c11 md5 cc1a7e4b49b74111147d52b2f01eef00 )
-)
-
-game (
-	name "Torin's Passage (Demo/Windows)"
-	description "Torin's Passage (Demo/Windows)"
-	rom ( name "RESMAP.000" size 3403 crc b7d1436b md5 9a3e172cde9963d0a969f26469318cec )
-)
-
-game (
-	name "Torin's Passage (Macintosh)"
-	description "Torin's Passage (Macintosh)"
-	rom ( name "._1052.VMD" size 4096 crc d184ab9a md5 8c9d8902ba203e813a4f4953015f7a72 )
-)
-
-game (
-	name "Torin's Passage (Windows)"
-	description "Torin's Passage (Windows)"
-	rom ( name "0.MSG" size 5468 crc b91b445e md5 undefined )
-)
-
-game (
-	name "Torin's Passage (Windows/French)"
-	description "Torin's Passage (Windows/French)"
-	rom ( name "RESMAP.000" size 9787 crc 8325769b md5 0a30dabf38dcfa558b4ec69438573606 )
-)
-
-game (
-	name "Torin's Passage (Windows/French)[a]"
-	description "Torin's Passage (Windows/French)[a]"
-	rom ( name "0.MSG" size 5857 crc ec3d4038 md5 undefined )
-)
-
-game (
-	name "Torin's Passage (Windows/German)"
-	description "Torin's Passage (Windows/German)"
-	rom ( name "RESMAP.000" size 9787 crc 5bf098f4 md5 undefined )
-)
-
-game (
-	name "Torin's Passage (Windows/German)[a]"
-	description "Torin's Passage (Windows/German)[a]"
-	rom ( name "0.MSG" size 5993 crc 66c1b3f2 md5 faa339d6f66bd31d266e48a423bd4609 )
-)
-
-game (
-	name "Torin's Passage (Windows/Italian)"
-	description "Torin's Passage (Windows/Italian)"
-	rom ( name "0.FON" size 3120 crc e9b21d5b md5 undefined )
-)
-
-game (
-	name "Torin's Passage (Windows/Russian)"
-	description "Torin's Passage (Windows/Russian)"
-	rom ( name "RESMAP.000" size 9799 crc 4074810e md5 5e2be41f26e30d264e1d889bf5c227d8 )
-)
-
-game (
-	name "Torin's Passage (Windows/Spanish)"
-	description "Torin's Passage (Windows/Spanish)"
-	rom ( name "0.MSG" size 5681 crc 7f337d2a md5 ce2ed1b98659766122b57565e6110523 )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (Demo/DOS)"
-	description "Touche: The Adventures of the 5th Musketeer (Demo/DOS)"
-	rom ( name "OBJ" size 5503572 crc 7115ceff md5 d3c81cb2f8f7eb4a4852f30264bde7ec )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS)"
-	rom ( name "TOUCHE.DAT" size 26350211 crc be2d2a8e md5 6de2714bef18056f93fcf6e160be8a66 )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/French)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/French)"
-	rom ( name "TOUCHE.DAT" size 26558232 crc 62180ba3 md5 dabc88d12a7468e1e72185570efdac34 )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/German)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/German)"
-	rom ( name "TOUCHE.DAT" size 26625537 crc e656312e md5 undefined )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/Hungarian)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/Hungarian)"
-	rom ( name "TOUCHE.DAT" size 26475596 crc b9892561 md5 undefined )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/Italian)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/Italian)"
-	rom ( name "TOUCHE.DAT" size 26367792 crc db6344e1 md5 14fd5d73a5a26bde1897bc3529186431 )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/Polish)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/Polish)"
-	rom ( name "TOUCHE.DAT" size 26487370 crc 642fddb7 md5 undefined )
-)
-
-game (
-	name "Touche: The Adventures of the 5th Musketeer (DOS/Spanish)"
-	description "Touche: The Adventures of the 5th Musketeer (DOS/Spanish)"
-	rom ( name "TOUCHE.DAT" size 26529523 crc e39f7654 md5 undefined )
-)
-
-game (
-	name "Tower, The (Macintosh)"
-	description "Tower, The (Macintosh)"
-	rom ( name "._The Tower" size 568274 crc 622a0e81 md5 131a753b1879c46e0d09d936e8fe6b6e )
-)
-
-game (
-	name "Trader of Stories, The (Demo/Windows)"
-	description "Trader of Stories, The (Demo/Windows)"
-	rom ( name "data.dcp" size 40401902 crc 9d32122e md5 undefined )
-)
-
-game (
-	name "Troll's Tale (DOS)"
-	description "Troll's Tale (DOS)"
-	rom ( name "TROLL.IMG" size 184320 crc 30a61f05 md5 78bf623993b16a6dd84d08f62340d494 )
-)
-
-game (
-	name "Turks' Quest: Heir to the Planet (DOS/Fanmade)"
-	description "Turks' Quest: Heir to the Planet (DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 9d365a26 md5 3d19254b737c8b218e5bc4580542b79a )
-)
-
-game (
-	name "Twisted! (Macintosh)"
-	description "Twisted! (Macintosh)"
-	rom ( name "._Command Verbs" size 434 crc 01d8b470 md5 5db212dd72177dbdf340db7eef247765 )
-)
-
-game (
-	name "Ultimate AGI Fangame (Demo/DOS/Fanmade)"
-	description "Ultimate AGI Fangame (Demo/DOS/Fanmade)"
-	rom ( name "LOGDIR" size 300 crc 34730166 md5 undefined )
-)
-
-game (
-	name "Uncle Henry's Playhouse (DOS)"
-	description "Uncle Henry's Playhouse (DOS)"
-	rom ( name "CCC.GRV" size 2511 crc 2c2862a7 md5 cdb912b45fc875fb189ed6bd671d9be0 )
-)
-
-game (
-	name "Urban Runner (Demo/Non-Interactive/DOS)"
-	description "Urban Runner (Demo/Non-Interactive/DOS)"
-	rom ( name "DEMO.VMD" size 9091237 crc 7cb463db md5 undefined )
-)
-
-game (
-	name "Urban Runner (DOS/French)"
-	description "Urban Runner (DOS/French)"
-	rom ( name "CD1.ITK" size 510681088 crc 4d51b1cb md5 3742f2b4fac32cd3c0ad136aa4118e5b )
-)
-
-game (
-	name "Urban Runner (DOS/German)"
-	description "Urban Runner (DOS/German)"
-	rom ( name "CD1.ITK" size 507539456 crc 3f2d8187 md5 22432bfcd37037fff787abc5819ea055 )
-)
-
-game (
-	name "Urban Runner (DOS/Italian)"
-	description "Urban Runner (DOS/Italian)"
-	rom ( name "CD1.ITK" size 506869760 crc d396b8ea md5 undefined )
-)
-
-game (
-	name "Urban Runner (DOS/Spanish)"
-	description "Urban Runner (DOS/Spanish)"
-	rom ( name "CD1.ITK" size 510621696 crc f5f8cc55 md5 undefined )
-)
-
-game (
-	name "Urban Runner (DOS/UK)[!]"
-	description "Urban Runner (DOS/UK)[!]"
-	rom ( name "CD1.ITK" size 512555008 crc b3fd87f0 md5 63e3985897f370add4905e70ae540fa0 )
-)
-
-game (
-	name "URI Quest (DOS/Fanmade v0.173 Feb 27)"
-	description "URI Quest (DOS/Fanmade v0.173 Feb 27)"
-	rom ( name "LOGDIR" size 660 crc 1ea27085 md5 undefined )
-)
-
-game (
-	name "URI Quest (DOS/Fanmade v0.173 Jan 29)"
-	description "URI Quest (DOS/Fanmade v0.173 Jan 29)"
-	rom ( name "LOGDIR" size 660 crc 82da9b8d md5 494150940d34130605a4f2e67ee40b12 )
-)
-
-game (
-	name "V: The Graphical Adventure (CoCo3/Fanmade)"
-	description "V: The Graphical Adventure (CoCo3/Fanmade)"
-	rom ( name "logDir" size 768 crc 8c305170 md5 undefined )
-)
-
-game (
-	name "V: The Graphical Adventure (Demo 2/DOS/Fanmade)"
-	description "V: The Graphical Adventure (Demo 2/DOS/Fanmade)"
-	rom ( name "OBJECT" size 470 crc 442e73c7 md5 619ac462f2c19787d17b6fe213fed57c )
-)
-
-game (
-	name "Village, The (Macintosh)"
-	description "Village, The (Macintosh)"
-	rom ( name "._The Village" size 331776 crc 0792cabb md5 7ebc3d69e5f9a15651ba0a059a23fb03 )
-)
-
-game (
-	name "Voodoo Girl: Queen of the Darned (DOS/Fanmade v1.2 2002 Jan 1)"
-	description "Voodoo Girl: Queen of the Darned (DOS/Fanmade v1.2 2002 Jan 1)"
-	rom ( name "LOGDIR" size 618 crc c49f8838 md5 undefined )
-)
-
-game (
-	name "Voodoo Girl: Queen of the Darned (DOS/Fanmade v1.2 2002 Mar 29)"
-	description "Voodoo Girl: Queen of the Darned (DOS/Fanmade v1.2 2002 Mar 29)"
-	rom ( name "LOGDIR" size 303 crc eafec39d md5 11d0417b7b886f963d0b36789dac4c8f )
-)
-
-game (
-	name "Voyeur (DOS)[!]"
-	description "Voyeur (DOS)[!]"
-	rom ( name "A1100100.RL2" size 336361 crc ec202ee1 md5 de32223f6b7b9617f67fc186d9b97903 )
-)
-
-game (
-	name "Vsevolod (Prologue/Windows)"
-	description "Vsevolod (Prologue/Windows)"
-	rom ( name "data.dcp" size 388669493 crc d3b456eb md5 de8fe7fb822b9195cdb44448e46e653c )
-)
-
-game (
-	name "Waxworks (Demo/Non-Interactive/DOS)"
-	description "Waxworks (Demo/Non-Interactive/DOS)"
-	rom ( name "001.VGA" size 372 crc deaceccc md5 ba43de14718ef63bb3723d8389a95f9e )
-)
-
-game (
-	name "Waxworks (Floppy/Amiga)"
-	description "Waxworks (Floppy/Amiga)"
-	rom ( name "0001.PKD" size 232 crc 70029584 md5 undefined )
-)
-
-game (
-	name "Waxworks (Floppy/Amiga/German)"
-	description "Waxworks (Floppy/Amiga/German)"
-	rom ( name "0001.PKD" size 232 crc 70029584 md5 5905a954a0ca6e44f29aa943e9cf5df0 )
-)
-
-game (
-	name "Waxworks (Floppy/DOS)"
-	description "Waxworks (Floppy/DOS)"
-	rom ( name "001.VGA" size 372 crc deaceccc md5 ba43de14718ef63bb3723d8389a95f9e )
-)
-
-game (
-	name "Waxworks (Floppy/DOS/French)"
-	description "Waxworks (Floppy/DOS/French)"
-	rom ( name "001.VGA" size 372 crc deaceccc md5 ba43de14718ef63bb3723d8389a95f9e )
-)
-
-game (
-	name "Waxworks (Floppy/DOS/German)"
-	description "Waxworks (Floppy/DOS/German)"
-	rom ( name "001.VGA" size 372 crc deaceccc md5 undefined )
-)
-
-game (
-	name "Waxworks (Floppy/DOS/Spanish)"
-	description "Waxworks (Floppy/DOS/Spanish)"
-	rom ( name "001.VGA" size 372 crc deaceccc md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (Amiga/French)"
-	description "Ween: The Prophecy (Amiga/French)"
-	rom ( name "DISK2.STK" size 655389 crc 034c6a73 md5 a866a2f22373270c29419749fc96813a )
-)
-
-game (
-	name "Ween: The Prophecy (Amiga/German)"
-	description "Ween: The Prophecy (Amiga/German)"
-	rom ( name "DISK2.STK" size 646009 crc 1b2e8219 md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (Amiga/Italian)"
-	description "Ween: The Prophecy (Amiga/Italian)"
-	rom ( name "DISK2.STK" size 647386 crc 86e56832 md5 6671e2ad95e9414302f39c8a9e940bdb )
-)
-
-game (
-	name "Ween: The Prophecy (Amiga/UK)"
-	description "Ween: The Prophecy (Amiga/UK)"
-	rom ( name "DISK2.STK" size 644451 crc f1b0f325 md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (Atari ST/French)"
-	description "Ween: The Prophecy (Atari ST/French)"
-	rom ( name "DISK2.STK" size 646130 crc 53114231 md5 e6f89eca14019262e670499dfb6e4ecd )
-)
-
-game (
-	name "Ween: The Prophecy (Atari ST/UK)"
-	description "Ween: The Prophecy (Atari ST/UK)"
-	rom ( name "DISK2.STK" size 644451 crc f1b0f325 md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (Demo/DOS)"
-	description "Ween: The Prophecy (Demo/DOS)"
-	rom ( name "INTRO.STK" size 2435800 crc 5b13da68 md5 1ad9e4b072c859179cdeb2c78df53b06 )
-)
-
-game (
-	name "Ween: The Prophecy (Demo/DOS/US)"
-	description "Ween: The Prophecy (Demo/DOS/US)"
-	rom ( name "INTRO.STK" size 2340230 crc d2a38494 md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/French)"
-	description "Ween: The Prophecy (DOS/French)"
-	rom ( name "INTRO.STK" size 7029591 crc d225f4aa md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/French)[a]"
-	description "Ween: The Prophecy (DOS/French)[a]"
-	rom ( name "INTRO.STK" size 7029591 crc ffe3f808 md5 3ff06b7834918564f220f669c72de494 )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/German)"
-	description "Ween: The Prophecy (DOS/German)"
-	rom ( name "INTRO.STK" size 6962069 crc 0faeb1aa md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/Italian)"
-	description "Ween: The Prophecy (DOS/Italian)"
-	rom ( name "INTRO.STK" size 7018771 crc d3ac93dd md5 9eea1da6823b11968af290aff310f21a )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/Italian)[a]"
-	description "Ween: The Prophecy (DOS/Italian)[a]"
-	rom ( name "INTRO.STK" size 7018771 crc 92cd2f1d md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/Spanish)"
-	description "Ween: The Prophecy (DOS/Spanish)"
-	rom ( name "INTRO.STK" size 7014426 crc fdc2ec74 md5 a253bc7c62715c22fd59f64f5cec54ea )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/UK)"
-	description "Ween: The Prophecy (DOS/UK)"
-	rom ( name "INTRO.STK" size 6989902 crc ea510f53 md5 undefined )
-)
-
-game (
-	name "Ween: The Prophecy (DOS/US)"
-	description "Ween: The Prophecy (DOS/US)"
-	rom ( name "INTRO.STK" size 7117568 crc 7d0024cb md5 da3964bdce938419354357f6c193c034 )
-)
-
-game (
-	name "Where in the World is Carmen Sandiego (v3.5/Windows)"
-	description "Where in the World is Carmen Sandiego (v3.5/Windows)"
-	rom ( name "ARCHIVE.Z" size 10167082 crc 70447833 md5 ea6ead89f3aeedf3ab6f02b462b3f3aa )
-)
-
-game (
-	name "Where in Time is Carmen Sandiego (Windows)"
-	description "Where in Time is Carmen Sandiego (Windows)"
-	rom ( name "EVP14.FON" size 8192 crc 9aa18e64 md5 e45ca62e8a889e8028d70bf54b0fb9a5 )
-)
-
-game (
-	name "White Chamber, The (Windows/Multi-Language)"
-	description "White Chamber, The (Windows/Multi-Language)"
-	rom ( name "data.dcp" size 186451273 crc c2f5d8f3 md5 d3082e15e981681c7e93d22c2538b3b5 )
-)
-
-game (
-	name "White Chamber, The (Windows/Multi-Language)[Unk]"
-	description "White Chamber, The (Windows/Multi-Language)[Unk]"
-	rom ( name "data.dcp" size 186451273 crc 4bd2019e md5 undefined )
-)
-
-game (
-	name "Wilma Tetris (Windows)"
-	description "Wilma Tetris (Windows)"
-	rom ( name "data.dcp" size 2780093 crc 28435439 md5 undefined )
-)
-
-game (
-	name "Wilma Tetris (Windows)[Unk]"
-	description "Wilma Tetris (Windows)[Unk]"
-	rom ( name "data.dcp" size 2779976 crc e60c4b58 md5 432e5a627b02ed3acb20bcbc1d70ab17 )
-)
-
-game (
-	name "Winnie the Pooh in the Hundred Acre Wood (Amiga)"
-	description "Winnie the Pooh in the Hundred Acre Wood (Amiga)"
-	rom ( name "COMPASS" size 114 crc 5807da3e md5 0641e06c3db66a585015b4c8df69af6f )
-)
-
-game (
-	name "Winnie the Pooh in the Hundred Acre Wood (Apple IIgs)"
-	description "Winnie the Pooh in the Hundred Acre Wood (Apple IIgs)"
-	rom ( name "DE" size 122 crc e4ccffc6 md5 87d603bb10eb192a20e09f27b452cf43 )
-)
-
-game (
-	name "Winnie the Pooh in the Hundred Acre Wood (C64)"
-	description "Winnie the Pooh in the Hundred Acre Wood (C64)"
-	rom ( name "DISK" size 290 crc 20d2b653 md5 199503f1057207dfe4cc46ea6dae56d0 )
-)
-
-game (
-	name "Winnie the Pooh in the Hundred Acre Wood (C64)[a]"
-	description "Winnie the Pooh in the Hundred Acre Wood (C64)[a]"
-	rom ( name "GAME.OBJ" size 5492 crc 9baba2c5 md5 df45c0d0250727e73e5f819f8de4f97a )
-)
-
-game (
-	name "Winnie the Pooh in the Hundred Acre Wood (DOS)"
-	description "Winnie the Pooh in the Hundred Acre Wood (DOS)"
-	rom ( name "LOGO.PIC" size 1599 crc 4e48e5d0 md5 undefined )
-)
-
-game (
-	name "Winter Wonderland (DOS/Fanmade)"
-	description "Winter Wonderland (DOS/Fanmade)"
-	rom ( name "RESOURCE.001" size 305076 crc bca8dcfc md5 c6397195e2c018e683e2685709684ec5 )
-)
-
-game (
-	name "Wintermute Engine 3D Characters Technology Demo (Windows)[Unk]"
-	description "Wintermute Engine 3D Characters Technology Demo (Windows)[Unk]"
-	rom ( name "data.dcp" size 3224894 crc 4a4e15c1 md5 undefined )
-)
-
-game (
-	name "Wintermute Engine Technology Demo 1.2 (Windows)[Unk]"
-	description "Wintermute Engine Technology Demo 1.2 (Windows)[Unk]"
-	rom ( name "data.dcp" size 6031195 crc 570e3fb1 md5 18ff4369bf53fb7c2050fec8377a355f )
-)
-
-game (
-	name "Wishing Well (Macintosh)"
-	description "Wishing Well (Macintosh)"
-	rom ( name "._Wishing Well" size 105439 crc 7d16a8c9 md5 e5408023b3198c10240581245dc72a6e )
-)
-
-game (
-	name "Wizard's Warehouse (Macintosh)"
-	description "Wizard's Warehouse (Macintosh)"
-	rom ( name "._Wizard's Warehouse" size 163035 crc undefined md5 undefined )
-)
-
-game (
-	name "Wizard's Warehouse 2 (Macintosh)"
-	description "Wizard's Warehouse 2 (Macintosh)"
-	rom ( name "._WizWarehouse 2.0" size 237568 crc d9405817 md5 1678892faa55380e09d2f902b0464c54 )
-)
-
-game (
-	name "Wizaro (DOS/Fanmade v0.1)"
-	description "Wizaro (DOS/Fanmade v0.1)"
-	rom ( name "LOGDIR" size 768 crc 005b707e md5 abeec1eda6eaf8dbc52443ea97ff140c )
-)
-
-game (
-	name "Xmas Card (CoCo3)"
-	description "Xmas Card (CoCo3)"
-	rom ( name "logDir" size 768 crc 24656263 md5 25ad35e9628fc77e5e0dd35852a272b6 )
-)
-
-game (
-	name "Xmas Card (DOS/1986-11-13)[version 1]"
-	description "Xmas Card (DOS/1986-11-13)[version 1]"
-	rom ( name "LOGDIR" size 372 crc e7d94d15 md5 undefined )
-)
-
-game (
-	name "Zak McKracken & Loom (Demo/FM-Towns)"
-	description "Zak McKracken & Loom (Demo/FM-Towns)"
-	rom ( name "00.LFL" size 7520 crc 7c149b9c md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (Demo/Atari ST/German)"
-	description "Zak McKracken and the Alien Mindbenders (Demo/Atari ST/German)"
-	rom ( name "00.LFL" size 1916 crc efb4865e md5 3aa1bf6f2b6fac7739e1706079f34f55 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (Demo/Non-interactive/Atari ST)"
-	description "Zak McKracken and the Alien Mindbenders (Demo/Non-interactive/Atari ST)"
-	rom ( name "00.LFL" size 1916 crc f90900c6 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns)"
-	rom ( name "00.LFL" size 7520 crc 0b9ab822 md5 2d4536a56e01da4b02eb021e7770afa2 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns)[a]"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns)[a]"
-	rom ( name "00.LFL" size 7520 crc 0b9ab822 md5 2d4536a56e01da4b02eb021e7770afa2 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns)[a2]"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns)[a2]"
-	rom ( name "00.LFL" size 7520 crc 0b9ab822 md5 2d4536a56e01da4b02eb021e7770afa2 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/French)[v0.8b]"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/French)[v0.8b]"
-	rom ( name "00.LFL" size 7520 crc 1cbe3e9f md5 46583ec0ecc443db614fa465a12cc592 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/German)[v1.1]"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/German)[v1.1]"
-	rom ( name "00.LFL" size 7520 crc 414640d2 md5 543d36641b5c55d863e8ebbacda6ea03 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Hungarian)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Hungarian)"
-	rom ( name "00.LFL" size 7520 crc 00c0b723 md5 769c398d7abb4fa026e2411749ef0b64 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Italian)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Italian)"
-	rom ( name "00.LFL" size 7520 crc 166d105d md5 d7681f89ea70da03ad3717d34e24271f )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Japanese)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Japanese)"
-	rom ( name "00.LFL" size 7520 crc d8e99b74 md5 1ca86e2cf9aaa2068738a1e5ba477e60 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Polish)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Polish)"
-	rom ( name "00.LFL" size 7520 crc c1b8d62b md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Spanish)"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Spanish)"
-	rom ( name "00.lfl" size 7520 crc 0b9ab822 md5 2d4536a56e01da4b02eb021e7770afa2 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (FM-Towns/Spanish)[beta 5]"
-	description "Zak McKracken and the Alien Mindbenders (FM-Towns/Spanish)[beta 5]"
-	rom ( name "00.LFL" size 7520 crc 9385cc28 md5 ad403430a90a07569efe7a990d506b3c )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64)[image]"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64)[image]"
-	rom ( name "Zak1.d64" size 174848 crc 0efadb0a md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64/Extracted)"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64/Extracted)"
-	rom ( name "00.LFL" size 1914 crc 11c9f34d md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64/German)[image]"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64/German)[image]"
-	rom ( name "Zak1.d64" size 196608 crc 87cce278 md5 4973bbc3899e3826dbf316e1d7271ec7 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64/German/Extracted)"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64/German/Extracted)"
-	rom ( name "00.LFL" size 1914 crc 2395b846 md5 95be99181bd0f10fef4872c2d4a771cb )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64/Italian)[image]"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64/Italian)[image]"
-	rom ( name "Zak1.d64" size 174848 crc 85c46281 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/C64/Italian/Extracted)"
-	description "Zak McKracken and the Alien Mindbenders (V1/C64/Italian/Extracted)"
-	rom ( name "00.LFL" size 1914 crc c21a85ec md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/DOS)"
-	description "Zak McKracken and the Alien Mindbenders (V1/DOS)"
-	rom ( name "00.LFL" size 1896 crc 1ab8492b md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V1/DOS)[a]"
-	description "Zak McKracken and the Alien Mindbenders (V1/DOS)[a]"
-	rom ( name "00.LFL" size 1896 crc 5b5cae2c md5 b23f7cd7c304d7dff08e92a96120d5b4 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Amiga)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Amiga)"
-	rom ( name "00.LFL" size 1916 crc fb78ae5f md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Amiga/French)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Amiga/French)"
-	rom ( name "00.LFL" size 1916 crc 7fd32208 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Amiga/German)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Amiga/German)"
-	rom ( name "00.LFL" size 1916 crc 8b6896e1 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Amiga/German)[a]"
-	description "Zak McKracken and the Alien Mindbenders (V2/Amiga/German)[a]"
-	rom ( name "00.LFL" size 1916 crc 8b6896e1 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Amiga/Italian)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Amiga/Italian)"
-	rom ( name "00.LFL" size 1916 crc acb306b5 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Atari ST)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Atari ST)"
-	rom ( name "00.LFL" size 1916 crc 0548e2de md5 d55eff37c2100f5065cde9de428621fa )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Atari ST/French)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Atari ST/French)"
-	rom ( name "00.LFL" size 1916 crc 09b329aa md5 613f64f78ea26c7353b2a5940eb61d6a )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/Atari ST/German)"
-	description "Zak McKracken and the Alien Mindbenders (V2/Atari ST/German)"
-	rom ( name "00.LFL" size 1916 crc 90fd1723 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS)"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS)"
-	rom ( name "00.LFL" size 1916 crc 1d9303b3 md5 675d71151e9b5a968c8ce46d9fbf4cbf )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS)[a]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS)[a]"
-	rom ( name "00.LFL" size 1916 crc e93ede5a md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS)[a2]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS)[a2]"
-	rom ( name "00.LFL" size 1916 crc 1d9303b3 md5 675d71151e9b5a968c8ce46d9fbf4cbf )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/French)"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/French)"
-	rom ( name "00.LFL" size 1916 crc c749ac1b md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/German)[!]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/German)[!]"
-	rom ( name "00.LFL" size 1916 crc 6bb2f4ed md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/German)[from 5.25 floppies]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/German)[from 5.25 floppies]"
-	rom ( name "00.LFL" size 1916 crc 9f1f2904 md5 d06fbe28818fef7bfc45c2cdf0c0849d )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)"
-	rom ( name "00.LFL" size 1916 crc 38b0ed88 md5 1900e501a52fbf55bde6e4196f6d2aa6 )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)[a]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)[a]"
-	rom ( name "00.LFL" size 1916 crc cc1d3061 md5 undefined )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)[a2]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/Italian)[a2]"
-	rom ( name "00.LFL" size 1916 crc cc1d3061 md5 75ba23fff4fd63fa446c02864f2a5a4b )
-)
-
-game (
-	name "Zak McKracken and the Alien Mindbenders (V2/DOS/Russian)[v1.0]"
-	description "Zak McKracken and the Alien Mindbenders (V2/DOS/Russian)[v1.0]"
-	rom ( name "00.LFL" size 1916 crc cba30761 md5 undefined )
-)
-
-game (
-	name "ZikTuria (Macintosh)"
-	description "ZikTuria (Macintosh)"
-	rom ( name "._ZikTuria" size 54632 crc 517d3512 md5 689972a28e97f50dee188cea7325439e )
-)
-
-game (
-	name "Zork Nemesis: The Forbidden Lands (Demo/Windowsh)"
-	description "Zork Nemesis: The Forbidden Lands (Demo/Windowsh)"
-	rom ( name "CURSOR.ZFS" size 2094166 crc e46ae89a md5 undefined )
-)
-
-game (
-	name "Zork Nemesis: The Forbidden Lands (DOS)[!]"
-	description "Zork Nemesis: The Forbidden Lands (DOS)[!]"
-	rom ( name "NEMESIS.STR" size 8075 crc 2e1481c9 md5 undefined )
-)
-
-game (
-	name "Zork Nemesis: The Forbidden Lands (DOS/French)"
-	description "Zork Nemesis: The Forbidden Lands (DOS/French)"
-	rom ( name "NEMESIS.STR" size 9219 crc 82152196 md5 undefined )
-)
-
-game (
-	name "Zork Nemesis: The Forbidden Lands (DOS/German)"
-	description "Zork Nemesis: The Forbidden Lands (DOS/German)"
-	rom ( name "NEMESIS.STR" size 9505 crc 51422c92 md5 0f1b1429b338b4349c2d5175a6782d38 )
-)
-
-game (
-	name "Zork Nemesis: The Forbidden Lands (DOS/Italian)"
-	description "Zork Nemesis: The Forbidden Lands (DOS/Italian)"
-	rom ( name "NEMESIS.STR" size 9061 crc e82910f2 md5 edea8671bc21a2d5d1487638e6ac0211 )
-)
-
-game (
-	name "Zork: Grand Inquisitor (CD/Windows)"
-	description "Zork: Grand Inquisitor (CD/Windows)"
-	rom ( name "CURSOR.ZFS" size 4947211 crc 10b709ef md5 undefined )
-)
-
-game (
-	name "Zork: Grand Inquisitor (CD/Windows/French)"
-	description "Zork: Grand Inquisitor (CD/Windows/French)"
-	rom ( name "CURSOR.ZFS" size 4949329 crc 9ec2ab7c md5 20108098b2f269b5ef8c54bd4736454f )
-)
-
-game (
-	name "Zork: Grand Inquisitor (CD/Windows/German)"
-	description "Zork: Grand Inquisitor (CD/Windows/German)"
-	rom ( name "CURSOR.ZFS" size 4958887 crc f6f55a38 md5 undefined )
-)
-
-game (
-	name "Zork: Grand Inquisitor (CD/Windows/Spanish)"
-	description "Zork: Grand Inquisitor (CD/Windows/Spanish)"
-	rom ( name "CURSOR.ZFS" size 4947789 crc 8385e317 md5 undefined )
-)
-
-game (
-	name "Zork: Grand Inquisitor (Demo/Windows)"
-	description "Zork: Grand Inquisitor (Demo/Windows)"
-	rom ( name "CURSOR.ZFS" size 617889 crc 99214201 md5 29ce3c81c31da85ea2f99e5741a3fcbf )
-)
-
-game (
-	name "Zork: Grand Inquisitor (DVD/Windows)"
-	description "Zork: Grand Inquisitor (DVD/Windows)"
-	rom ( name "cursor.zfs" size 4959825 crc f68a421a md5 undefined )
+	name "Zak McKracken and the Alien Mindbenders"
+	description "Zak McKracken and the Alien Mindbenders"
+	rom ( name "Zak McKracken and the Alien Mindbenders CR.scummvm" size 4 crc 946bf022 )
 )


### PR DESCRIPTION
The automatic ScummVM game loading has been proven to be problematic:
https://github.com/libretro/scummvm/issues/53

This restores the use of the `.scummvm` file launchers.