### PR TITLE
Fix serials in Sony - PlayStation Portable

### DIFF
--- a/metadat/serial/Sony - PlayStation Portable.dat
+++ b/metadat/serial/Sony - PlayStation Portable.dat
@@ -5,16579 +5,13606 @@ clrmamepro (
 
 game (
 	name "007 - From Russia with Love (Asia)"
-	serial "ULAS-42043"
-	serial "ULAS-42043"
+	rom ( serial "ULAS-42043" )
 )
 
 game (
 	name "007 - From Russia with Love (Australia) (En,Fr,De,Es,It)"
-	serial "ULES-00288"
-	serial "ULES-00288"
+	rom ( serial "ULES-00288" )
 )
 
 game (
 	name "007 - From Russia with Love (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00290"
-	serial "ULES-00290"
+	rom ( serial "ULES-00290" )
 )
 
 game (
 	name "007 - From Russia with Love (USA)"
-	serial "ULUS-10080"
-	serial "ULUS-10080"
+	rom ( serial "ULUS-10080" )
 )
 
 game (
 	name "100-Man Ton no Barabara (Japan)"
-	serial "UCJS-10108"
-	serial "UCJS-10108"
+	rom ( serial "UCJS-10108" )
 )
 
 game (
 	name "11 Eyes Crossover (Japan)"
-	serial "ULJM-05574"
-	serial "ULJM-05574"
+	rom ( serial "ULJM-05574" )
 )
 
 game (
 	name "12-Ji no Kane to Cinderella - Halloween Wedding (Japan) (v1.02)"
-	serial "ULJM-06023"
-	serial "ULJM-06023"
+	rom ( serial "ULJM-06023" )
 )
 
 game (
 	name "12Riven - The Psi-Climinal of Integral (Japan) (v1.02)"
-	serial "ULJM-05445"
-	serial "ULJM-05445"
+	rom ( serial "ULJM-05445" )
 )
 
 game (
 	name "2 Games in 1! - Archer Maclean's Mercury & Mercury Meltdown (USA) (En,Fr,Es)"
-	serial "ULUS-10568"
-	serial "ULUS-10568"
+	rom ( serial "ULUS-10568" )
 )
 
 game (
 	name "2010 FIFA World Cup - South Africa (Europe) (En,Nl) (v1.01)"
-	serial "ULES-01412"
-	serial "ULES-01412"
+	rom ( serial "ULES-01412" )
 )
 
 game (
 	name "2010 FIFA World Cup - South Africa (Europe) (Es,It) (v1.01)"
-	serial "ULES-01414"
-	serial "ULES-01414"
+	rom ( serial "ULES-01414" )
 )
 
 game (
 	name "2010 FIFA World Cup - South Africa (Europe) (Fr,De) (v1.01)"
-	serial "ULES-01413"
-	serial "ULES-01413"
+	rom ( serial "ULES-01413" )
 )
 
 game (
 	name "2010 FIFA World Cup - South Africa (USA) (En,Es) (v1.01)"
-	serial "ULUS-10504"
-	serial "ULUS-10504"
+	rom ( serial "ULUS-10504" )
 )
 
 game (
 	name "24-Ji no Kane to Cinderella - Halloween Wedding (Japan) (v1.02)"
-	serial "ULJM-06168"
-	serial "ULJM-06168"
+	rom ( serial "ULJM-06168" )
 )
 
 game (
 	name "300 - March to Glory (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00766"
-	serial "ULES-00766"
+	rom ( serial "ULES-00766" )
 )
 
 game (
 	name "300 - March to Glory (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10241"
-	serial "ULUS-10241"
+	rom ( serial "ULUS-10241" )
 )
 
 game (
 	name "3rd Birthday, The (Europe)"
-	serial "ULES-01513"
-	serial "ULES-01513"
+	rom ( serial "ULES-01513" )
 )
 
 game (
 	name "3rd Birthday, The (Japan) (v1.01)"
-	serial "ULJM-05798"
-	serial "ULJM-05798"
+	rom ( serial "ULJM-05798" )
 )
 
 game (
 	name "3rd Birthday, The (USA)"
-	serial "ULUS-10567"
-	serial "ULUS-10567"
+	rom ( serial "ULUS-10567" )
 )
 
 game (
 	name "428 - Fuusa Sareta Shibuya de (Japan) (v1.01)"
-	serial "ULJS-00219"
-	serial "ULJS-00219"
+	rom ( serial "ULJS-00219" )
 )
 
 game (
 	name "50 Cent - Bulletproof - G-Unit Edition (Australia) (v1.01)"
-	serial "ULES-00452"
-	serial "ULES-00452"
+	rom ( serial "ULES-00452" )
 )
 
 game (
 	name "50 Cent - Bulletproof - G-Unit Edition (Europe) (v1.03)"
-	serial "ULES-00451"
-	serial "ULES-00451"
+	rom ( serial "ULES-00451" )
 )
 
 game (
 	name "50 Cent - Bulletproof - G-Unit Edition (USA) (v1.02)"
-	serial "ULUS-10128"
-	serial "ULUS-10128"
+	rom ( serial "ULUS-10128" )
 )
 
 game (
 	name "7 Wonders of the Ancient World (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01037"
-	serial "ULES-01037"
+	rom ( serial "ULES-01037" )
 )
 
 game (
 	name "7 Wonders of the Ancient World (USA) (v1.01)"
-	serial "ULUS-10227"
-	serial "ULUS-10227"
+	rom ( serial "ULUS-10227" )
 )
 
 game (
 	name "77 - Beyond the Milky Way (Japan) (v1.01)"
-	serial "ULJM-05877"
-	serial "ULJM-05877"
+	rom ( serial "ULJM-05877" )
 )
 
 game (
 	name "7th Dragon 2020 (Japan) (v1.01)"
-	serial "NPJH-50459"
-	serial "NPJH-50459"
+	rom ( serial "NPJH-50459" )
 )
 
 game (
 	name "AFL Challenge (Europe) (v1.03)"
-	serial "ULES-01299"
-	serial "ULES-01299"
+	rom ( serial "ULES-01299" )
 )
 
 game (
 	name "AI Igo (Japan) (v1.02)"
-	serial "ULJS-00008"
-	serial "ULJS-00008"
+	rom ( serial "ULJS-00008" )
 )
 
 game (
 	name "AI Mahjong (Japan)"
-	serial "ULJS-00007"
-	serial "ULJS-00007"
+	rom ( serial "ULJS-00007" )
 )
 
 game (
 	name "AI Shogi (Japan) (v1.04)"
-	serial "ULJS-00009"
-	serial "ULJS-00009"
+	rom ( serial "ULJS-00009" )
 )
 
 game (
 	name "AI Shogi (Japan) (v2.00)"
-	serial "ULJS-00009"
-	serial "ULJS-00009"
+	rom ( serial "ULJS-00101" )
 )
 
 game (
 	name "AIR (Japan) (v1.02)"
-	serial "ULJM-05282"
-	serial "ULJM-05282"
+	rom ( serial "ULJM-05282" )
 )
 
 game (
 	name "ATV Offroad Fury - Blazin' Trails (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00155"
-	serial "ULES-00155"
+	rom ( serial "ULES-00155" )
 )
 
 game (
 	name "ATV Offroad Fury - Blazin' Trails (USA) (v1.01)"
-	serial "UCUS-98603"
-	serial "UCUS-98603"
+	rom ( serial "UCUS-98603" )
 )
 
 game (
 	name "ATV Offroad Fury Pro (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,Da,Ru)"
-	serial "UCES-00786"
-	serial "UCES-00786"
+	rom ( serial "UCES-00786" )
 )
 
 game (
 	name "ATV Offroad Fury Pro (USA)"
-	serial "UCUS-98648"
-	serial "UCUS-98648"
+	rom ( serial "UCUS-98648" )
 )
 
 game (
 	name "ATV Offroad Fury Pro (USA) (Demo)"
-	serial "UCUS-98681"
-	serial "UCUS-98681"
+	rom ( serial "UCUS-98681" )
 )
 
 game (
 	name "Abunai - Koi no Sousa Shitsu (Japan) (v1.03)"
-	serial "ULJM-06050"
-	serial "ULJM-06050"
+	rom ( serial "ULJM-06050" )
 )
 
 game (
 	name "Accel World - Ginyoku no Kakusei (Japan) (v1.01)"
-	serial "NPJH-50606"
-	serial "NPJH-50606"
+	rom ( serial "NPJH-50606" )
 )
 
 game (
 	name "Ace Combat - Joint Assault (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01408"
-	serial "ULES-01408"
+	rom ( serial "ULES-01408" )
 )
 
 game (
 	name "Ace Combat - Joint Assault (USA)"
-	serial "ULUS-10511"
-	serial "ULUS-10511"
+	rom ( serial "ULUS-10511" )
 )
 
 game (
 	name "Ace Combat X - Skies of Deception (Europe) (En,Ja,Fr,De,Es,It,Ko)"
-	serial "UCES-00423"
-	serial "UCES-00423"
+	rom ( serial "UCES-00423" )
 )
 
 game (
 	name "Ace Combat X - Skies of Deception (Japan) (En,Ja,Fr,De,Es,It,Ko) (v1.01)"
-	serial "ULJS-00086"
-	serial "ULJS-00086"
+	rom ( serial "ULJS-00086" )
 )
 
 game (
 	name "Ace Combat X - Skies of Deception (Japan) (En,Ja,Fr,De,Es,It,Ko) (v2.00)"
-	serial "ULJS-00086"
-	serial "ULJS-00086"
 )
 
 game (
 	name "Ace Combat X - Skies of Deception (USA)"
-	serial "ULUS-10176"
-	serial "ULUS-10176"
+	rom ( serial "ULUS-10176" )
 )
 
 game (
 	name "Aces of War (Europe) (v1.01)"
-	serial "ULES-00590"
-	serial "ULES-00590"
+	rom ( serial "ULES-00590" )
 )
 
 game (
 	name "Activision Hits Remixed (Europe)"
-	serial "ULES-00640"
-	serial "ULES-00640"
+	rom ( serial "ULES-00640" )
 )
 
 game (
 	name "Activision Hits Remixed (USA) (v1.01)"
-	serial "ULUS-10186"
-	serial "ULUS-10186"
+	rom ( serial "ULUS-10186" )
 )
 
 game (
 	name "Adventure Player (Japan) (v1.05)"
-	serial "ULJS-00011"
-	serial "ULJS-00011"
+	rom ( serial "ULJS-00011" )
 )
 
 game (
 	name "Adventures to Go! (Europe) (En,Fr,De) (v1.02)"
-	serial "ULES-01383"
-	serial "ULES-01383"
+	rom ( serial "ULES-01383" )
 )
 
 game (
 	name "Adventures to Go! (USA) (v1.02)"
-	serial "ULUS-10417"
-	serial "ULUS-10417"
+	rom ( serial "ULUS-10417" )
 )
 
 game (
 	name "Aedis Eclipse - Generation of Chaos (USA)"
-	serial "ULUS-10242"
-	serial "ULUS-10242"
+	rom ( serial "ULUS-10242" )
 )
 
 game (
 	name "After Burner - Black Falcon (Australia) (En,Fr,De,Es,It)"
-	serial "ULES-00753"
-	serial "ULES-00753"
+	rom ( serial "ULES-00753" )
 )
 
 game (
 	name "After Burner - Black Falcon (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00785"
-	serial "ULES-00785"
+	rom ( serial "ULES-00785" )
 )
 
 game (
 	name "After Burner - Black Falcon (USA) (En,Fr,Es,It,Nl)"
-	serial "ULUS-10244"
-	serial "ULUS-10244"
+	rom ( serial "ULUS-10244" )
 )
 
 game (
 	name "Agarest Senki Mariage (Japan) (v1.01)"
-	serial "NPJH-50639"
-	serial "NPJH-50639"
+	rom ( serial "NPJH-50639" )
 )
 
 game (
 	name "Air Conflicts - Aces of World War II (USA)"
-	serial "ULUS-10404"
-	serial "ULUS-10404"
+	rom ( serial "ULUS-10404" )
 )
 
 game (
 	name "Airou de Puzzle (Japan)"
-	serial "NPJH-50614"
-	serial "NPJH-50614"
+	rom ( serial "NPJH-50614" )
 )
 
 game (
 	name "Akane Iro ni Somaru Saka Portable (Japan) (v1.01)"
-	serial "ULJM-05589"
-	serial "ULJM-05589"
+	rom ( serial "ULJM-05589" )
 )
 
 game (
 	name "Akatsuki no Amaneka to Aoi Kyojin (Japan) (v1.02)"
-	serial "ULJM-05582"
-	serial "ULJM-05582"
+	rom ( serial "ULJM-05582" )
 )
 
 game (
 	name "Akatsuki no Goei Trinity (Japan) (v1.01)"
-	serial "ULJM-06174"
-	serial "ULJM-06174"
-)
-
-game (
-	name "Akatsuki no Goei Trinity (Japan) (v1.01)"
-	serial "ULJM-06174"
-	serial "ULJM-06174"
+	rom ( serial "ULJM-06174" )
 )
 
 game (
 	name "Akiba's Trip (Japan) (v1.07)"
-	serial "NPJH-50412"
-	serial "NPJH-50412"
+	rom ( serial "NPJH-50412" )
 )
 
 game (
 	name "Akiba's Trip Plus (Japan) (v1.02)"
-	serial "NPJH-50563"
-	serial "NPJH-50563"
+	rom ( serial "NPJH-50563" )
 )
 
 game (
 	name "Akudaikan Manyuuki (Japan) (v1.03)"
-	serial "ULJM-05185"
-	serial "ULJM-05185"
+	rom ( serial "ULJM-05185" )
 )
 
 game (
 	name "Akudaikan Manyuuki - Seigi no Yaiba (Japan) (v1.01)"
-	serial "ULJM-05229"
-	serial "ULJM-05229"
+	rom ( serial "ULJM-05229" )
 )
 
 game (
 	name "Alien Syndrome (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00772"
-	serial "ULES-00772"
+	rom ( serial "ULES-00772" )
 )
 
 game (
 	name "Alien Syndrome (USA)"
-	serial "ULUS-10245"
-	serial "ULUS-10245"
+	rom ( serial "ULUS-10245" )
 )
 
 game (
 	name "Aliens vs. Predator - Requiem (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-00972"
-	serial "ULES-00972"
+	rom ( serial "ULES-00972" )
 )
 
 game (
 	name "Aliens vs. Predator - Requiem (USA)"
-	serial "ULUS-10327"
-	serial "ULUS-10327"
+	rom ( serial "ULUS-10327" )
 )
 
 game (
 	name "All Kamen Rider - Rider Generation 2 (Japan) (v1.02)"
-	serial "NPJH-50617"
-	serial "NPJH-50617"
+	rom ( serial "NPJH-50617" )
 )
 
 game (
 	name "Amagoushi no Yakata Portable - Ichiyanagi Nagomu, Saisho no Junan (Japan)"
-	serial "ULJS-00216"
-	serial "ULJS-00216"
+	rom ( serial "ULJS-00216" )
 )
 
 game (
 	name "Amatsumi Sora ni! Kumo no Hatate ni (Japan) (v1.01)"
-	serial "ULJM-05992"
-	serial "ULJM-05992"
-)
-
-game (
-	name "Amatsumi Sora ni! Kumo no Hatate ni (Japan) (v1.01)"
-	serial "ULJM-05992"
-	serial "ULJM-05992"
+	rom ( serial "ULJM-05992" )
 )
 
 game (
 	name "Amnesia (Japan) (v1.01)"
-	serial "ULJM-05931"
-	serial "ULJM-05931"
+	rom ( serial "ULJM-05931" )
 )
 
 game (
 	name "Amnesia Later (Japan) (v1.01)"
-	serial "ULJM-06044"
-	serial "ULJM-06044"
+	rom ( serial "ULJM-06044" )
 )
 
 game (
 	name "Anata o Yurusanai (Japan) (v1.01)"
-	serial "ULJM-05279"
-	serial "ULJM-05279"
+	rom ( serial "ULJM-05279" )
 )
 
 game (
 	name "Angelique - Maren no Rokukishi (Japan) (v1.01)"
-	serial "ULJM-05986"
-	serial "ULJM-05986"
+	rom ( serial "ULJM-05986" )
 )
 
 game (
 	name "Ano Hi Mita Hana no Namae o Bokutachi wa Mada Shiranai (Japan) (v1.01)"
-	serial "ULJM-06115"
-	serial "ULJM-06115"
+	rom ( serial "ULJM-06115" )
 )
 
 game (
 	name "Another Century's Episode Portable (Japan) (v1.01)"
-	serial "ULJS-00322"
-	serial "ULJS-00322"
+	rom ( serial "ULJS-00322" )
 )
 
 game (
 	name "Antiphona no Seikahime - Tenshi no Score Op.A (Japan) (v1.01)"
-	serial "ULJS-00229"
-	serial "ULJS-00229"
+	rom ( serial "ULJS-00229" )
 )
 
 game (
 	name "Ao no Exorcist - Genkoku no Labyrinth (Japan)"
-	serial "NPJH-50489"
-	serial "NPJH-50489"
+	rom ( serial "NPJH-50489" )
 )
 
 game (
 	name "Aoi Sora no Neosphere Portable - Nanoca Flanka Hatsumei Koubouki 2 (Japan) (v1.01)"
-	serial "ULJM-06137"
-	serial "ULJM-06137"
+	rom ( serial "ULJM-06137" )
 )
 
 game (
 	name "Aoi Umi no Tristia Portable - Nanoca Flanka Hatsumei Koubouki (Japan) (v1.01)"
-	serial "ULJM-06136"
-	serial "ULJM-06136"
+	rom ( serial "ULJM-06136" )
 )
 
 game (
 	name "Ape Academy (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00010"
-	serial "UCES-00010"
+	rom ( serial "UCES-00010" )
 )
 
 game (
 	name "Ape Academy 2 (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru)"
-	serial "UCES-00302"
-	serial "UCES-00302"
+	rom ( serial "UCES-00302" )
 )
 
 game (
 	name "Ape Escape P (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00045"
-	serial "UCES-00045"
+	rom ( serial "UCES-00045" )
 )
 
 game (
 	name "Arabians Lost - The Engagement on Desert (Japan) (v1.02)"
-	serial "ULJM-06104"
-	serial "ULJM-06104"
+	rom ( serial "ULJM-06104" )
 )
 
 game (
 	name "Arcana Famiglia - La Storia della Aracana Famiglia (Japan) (v1.02)"
-	serial "ULJM-05956"
-	serial "ULJM-05956"
+	rom ( serial "ULJM-05956" )
 )
 
 game (
 	name "Arcana Famiglia - Vascello Phantasma no Majutsushi (Japan) (v1.02)"
-	serial "ULJM-06032"
-	serial "ULJM-06032"
+	rom ( serial "ULJM-06032" )
 )
 
 game (
 	name "Archer Maclean's Mercury (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00011"
-	serial "ULES-00011"
+	rom ( serial "ULES-00011" )
 )
 
 game (
 	name "Archer Maclean's Mercury (USA)"
-	serial "ULUS-10017"
-	serial "ULUS-10017"
+	rom ( serial "ULUS-10017" )
 )
 
 game (
 	name "Arcobaleno! Portable (Japan) (v1.02)"
-	serial "ULJM-05609"
-	serial "ULJM-05609"
+	rom ( serial "ULJM-05609" )
 )
 
 game (
 	name "Are You Alice (Japan) (v1.02)"
-	serial "ULJM-05848"
-	serial "ULJM-05848"
+	rom ( serial "ULJM-05848" )
 )
 
 game (
 	name "Armen Noir Portable (Japan) (v1.01)"
-	serial "ULJM-06064"
-	serial "ULJM-06064"
+	rom ( serial "ULJM-06064" )
 )
 
 game (
 	name "Armored Core - Formula Front - Extreme Battle (Europe) (v1.02)"
-	serial "ULES-00219"
-	serial "ULES-00219"
+	rom ( serial "ULES-00219" )
 )
 
 game (
 	name "Armored Core - Formula Front - Extreme Battle (USA) (v1.02)"
-	serial "ULUS-10034"
-	serial "ULUS-10034"
+	rom ( serial "ULUS-10034" )
 )
 
 game (
 	name "Armored Core - Last Raven Portable (Japan) (v1.02)"
-	serial "ULJM-05611"
-	serial "ULJM-05611"
+	rom ( serial "ULJM-05611" )
 )
 
 game (
 	name "Armored Core - Silent Line Portable (Japan) (v1.01)"
-	serial "ULJM-05552"
-	serial "ULJM-05552"
+	rom ( serial "ULJM-05552" )
 )
 
 game (
 	name "Armored Core 3 Portable (Japan) (v1.02)"
-	serial "ULJM-05492"
-	serial "ULJM-05492"
+	rom ( serial "ULJM-05492" )
 )
 
 game (
 	name "Arms' Heart (Japan) (v1.02)"
-	serial "ULJM-05786"
-	serial "ULJM-05786"
+	rom ( serial "ULJM-05786" )
 )
 
 game (
 	name "Army of Two - The 40th Day (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01381"
-	serial "ULES-01381"
+	rom ( serial "ULES-01381" )
 )
 
 game (
 	name "Army of Two - The 40th Day (Japan)"
-	serial "ULJM-05643"
-	serial "ULJM-05643"
+	rom ( serial "ULJM-05643" )
 )
 
 game (
 	name "Army of Two - The 40th Day (USA)"
-	serial "ULUS-10472"
-	serial "ULUS-10472"
+	rom ( serial "ULUS-10472" )
 )
 
 game (
 	name "Arthur and the Invisibles (Europe) (De,It)"
-	serial "ULES-00669"
-	serial "ULES-00669"
+	rom ( serial "ULES-00669" )
 )
 
 game (
 	name "Arthur and the Invisibles (Europe) (En,Es,Nl,Sv,Fi)"
-	serial "ULES-00668"
-	serial "ULES-00668"
+	rom ( serial "ULES-00668" )
 )
 
 game (
 	name "Asaki, Yumemishi (Japan) (v1.01)"
-	serial "ULJM-05870"
-	serial "ULJM-05870"
+	rom ( serial "ULJM-05870" )
 )
 
 game (
 	name "Asphalt - Urban GT 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00719"
-	serial "ULES-00719"
+	rom ( serial "ULES-00719" )
 )
 
 game (
 	name "Assassin's Creed - Bloodlines (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01367"
-	serial "ULES-01367"
+	rom ( serial "ULES-01367" )
 )
 
 game (
 	name "Assassin's Creed - Bloodlines (Japan) (v1.01)"
-	serial "ULJM-05571"
-	serial "ULJM-05571"
+	rom ( serial "ULJM-05571" )
 )
 
 game (
 	name "Assassin's Creed - Bloodlines (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10455"
-	serial "ULUS-10455"
+	rom ( serial "ULUS-10455" )
 )
 
 game (
 	name "Asterix & Obelix XXL 2 - Mission WiFix (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-00527"
-	serial "ULES-00527"
+	rom ( serial "ULES-00527" )
 )
 
 game (
 	name "Astonishia Story (Europe) (v1.01)"
-	serial "ULES-00363"
-	serial "ULES-00363"
+	rom ( serial "ULES-00363" )
 )
 
 game (
 	name "Astonishia Story (Japan) (v1.02)"
-	serial "ULJM-05176"
-	serial "ULJM-05176"
+	rom ( serial "ULJM-05176" )
 )
 
 game (
 	name "Astonishia Story (Korea) (v1.02)"
-	serial "ULKS-46021"
-	serial "ULKS-46021"
+	rom ( serial "ULKS-46021" )
 )
 
 game (
 	name "Astonishia Story (USA) (v1.02)"
-	serial "ULUS-10083"
-	serial "ULUS-10083"
+	rom ( serial "ULUS-10083" )
 )
 
 game (
 	name "Astro Boy - The Video Game (Europe) (v1.01)"
-	serial "ULES-01345"
-	serial "ULES-01345"
+	rom ( serial "ULES-01345" )
 )
 
 game (
 	name "Astro Boy - The Video Game (USA) (En,Fr,Es,It,Nl)"
-	serial "ULUS-10454"
-	serial "ULUS-10454"
+	rom ( serial "ULUS-10454" )
 )
 
 game (
 	name "Atari Classics Evolved (USA) (v1.02)"
-	serial "ULUS-10325"
-	serial "ULUS-10325"
+	rom ( serial "ULUS-10325" )
 )
 
 game (
 	name "Audition Portable (Korea) (v1.02)"
-	serial "ULKS-46122"
-	serial "ULKS-46122"
+	rom ( serial "ULKS-46122" )
 )
 
 game (
 	name "Autoescuela Aprueba Conmigo (Spain) (v1.02)"
-	serial "ULES-01366"
-	serial "ULES-01366"
+	rom ( serial "ULES-01366" )
 )
 
 game (
 	name "Avatar - The Legend of Aang (Europe) (En,Fr,De,Nl)"
-	serial "ULES-00633"
-	serial "ULES-00633"
+	rom ( serial "ULES-00633" )
 )
 
 game (
 	name "Ayakashibito - Genyou Ibunroku Portable (Japan) (v1.03)"
-	serial "ULJM-05426"
-	serial "ULJM-05426"
+	rom ( serial "ULJM-05426" )
 )
 
 game (
 	name "B-Boy (Europe) (Demo)"
-	serial "UCED-00432"
-	serial "UCED-00432"
+	rom ( serial "UCED-00432" )
 )
 
 game (
 	name "B-Boy (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00249"
-	serial "UCES-00249"
+	rom ( serial "UCES-00249" )
 )
 
 game (
 	name "B-Boy (USA) (v1.01)"
-	serial "ULUS-10363"
-	serial "ULUS-10363"
+	rom ( serial "ULUS-10363" )
 )
 
 game (
 	name "Bakemonogatari Portable (Japan) (v1.03)"
-	serial "NPJH-50605"
-	serial "NPJH-50605"
+	rom ( serial "NPJH-50605" )
 )
 
 game (
 	name "Bakugan Battle Brawlers - Defenders of the Core (Europe) (En,Fr,De,Es,It,Nl,Sv)"
-	serial "ULES-01466"
-	serial "ULES-01466"
+	rom ( serial "ULES-01466" )
 )
 
 game (
 	name "Bakugan Battle Brawlers - Defenders of the Core (USA) (En,Fr)"
-	serial "ULUS-10536"
-	serial "ULUS-10536"
+	rom ( serial "ULUS-10536" )
 )
 
 game (
 	name "Bamboo Blade - Sorekara no Chousen (Japan) (v1.04)"
-	serial "ULJM-05463"
-	serial "ULJM-05463"
+	rom ( serial "ULJM-05463" )
 )
 
 game (
 	name "Bara no Ki ni Bara no Hanasaku (Japan) (v1.01)"
-	serial "ULJM-05802"
-	serial "ULJM-05802"
+	rom ( serial "ULJM-05802" )
 )
 
 game (
 	name "Battle Dodgeball 3 (Japan) (v1.01)"
-	serial "ULJS-00468"
-	serial "ULJS-00468"
+	rom ( serial "ULJS-00468" )
 )
 
 game (
 	name "Battle Spirits - Heroes Soul (Japan) (v1.01)"
-	serial "ULJS-00280"
-	serial "ULJS-00280"
+	rom ( serial "ULJS-00280" )
 )
 
 game (
 	name "Battle Spirits - Kiseki no Hasha (Japan) (v1.01)"
-	serial "ULJS-00238"
-	serial "ULJS-00238"
+	rom ( serial "ULJS-00238" )
 )
 
 game (
 	name "BattleZone (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00522"
-	serial "ULES-00522"
+	rom ( serial "ULES-00522" )
 )
 
 game (
 	name "BattleZone (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10156"
-	serial "ULUS-10156"
+	rom ( serial "ULUS-10156" )
 )
 
 game (
 	name "Beaterator (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01023"
-	serial "ULES-01023"
+	rom ( serial "ULES-01023" )
 )
 
 game (
 	name "Beaterator (USA) (v1.01)"
-	serial "ULUS-10405"
-	serial "ULUS-10405"
+	rom ( serial "ULUS-10405" )
 )
 
 game (
 	name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01189"
-	serial "ULES-01189"
+	rom ( serial "ULES-01189" )
 )
 
 game (
 	name "Ben 10 - Alien Force (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10387"
-	serial "ULUS-10387"
+	rom ( serial "ULUS-10387" )
 )
 
 game (
 	name "Ben 10 - Alien Force - Vilgax Attacks (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01358"
-	serial "ULES-01358"
+	rom ( serial "ULES-01358" )
 )
 
 game (
 	name "Ben 10 - Alien Force - Vilgax Attacks (USA)"
-	serial "ULUS-10488"
-	serial "ULUS-10488"
+	rom ( serial "ULUS-10488" )
 )
 
 game (
 	name "Ben 10 - Protector of Earth (Europe)"
-	serial "ULES-00905"
-	serial "ULES-00905"
+	rom ( serial "ULES-00905" )
 )
 
 game (
 	name "Ben 10 - Protector of Earth (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00906"
-	serial "ULES-00906"
+	rom ( serial "ULES-00906" )
 )
 
 game (
 	name "Ben 10 - Protector of Earth (USA) (v1.01)"
-	serial "ULUS-10307"
-	serial "ULUS-10307"
+	rom ( serial "ULUS-10307" )
 )
 
 game (
 	name "Ben 10 - Ultimate Alien - Cosmic Destruction (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01471"
-	serial "ULES-01471"
+	rom ( serial "ULES-01471" )
 )
 
 game (
 	name "Ben 10 - Ultimate Alien - Cosmic Destruction (USA)"
-	serial "ULUS-10542"
-	serial "ULUS-10542"
+	rom ( serial "ULUS-10542" )
 )
 
 game (
 	name "Beowulf - The Game (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00992"
-	serial "ULES-00992"
+	rom ( serial "ULES-00992" )
 )
 
 game (
 	name "Beowulf - The Game (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10329"
-	serial "ULUS-10329"
+	rom ( serial "ULUS-10329" )
 )
 
 game (
 	name "Beta Bloc (Europe)"
-	serial "ULES-00792"
-	serial "ULES-00792"
+	rom ( serial "ULES-00792" )
 )
 
 game (
 	name "Beyond the Future - Fix the Time Arrows (Japan) (v1.01)"
-	serial "ULJM-05988"
-	serial "ULJM-05988"
+	rom ( serial "ULJM-05988" )
 )
 
 game (
 	name "Bigs 2, The (USA)"
-	serial "ULUS-10448"
-	serial "ULUS-10448"
+	rom ( serial "ULUS-10448" )
 )
 
 game (
 	name "Bigs, The (USA) (v1.01)"
-	serial "ULUS-10284"
-	serial "ULUS-10284"
+	rom ( serial "ULUS-10284" )
 )
 
 game (
 	name "Biz Taiken Series - Kigyodo (Japan) (v1.02)"
-	serial "ULJS-00050"
-	serial "ULJS-00050"
+	rom ( serial "ULJS-00050" )
 )
 
 game (
 	name "Black Robinia (Japan) (v1.01)"
-	serial "NPJH-50394"
-	serial "NPJH-50394"
+	rom ( serial "NPJH-50394" )
 )
 
 game (
 	name "Black Rock Shooter - The Game (Japan) (v1.01)"
-	serial "NPJH-50448"
-	serial "NPJH-50448"
+	rom ( serial "NPJH-50448" )
 )
 
 game (
 	name "Blade Dancer - Lineage of Light (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00541"
-	serial "ULES-00541"
+	rom ( serial "ULES-00541" )
 )
 
 game (
 	name "Blade Dancer - Lineage of Light (USA) (v1.01)"
-	serial "ULUS-10124"
-	serial "ULUS-10124"
+	rom ( serial "ULUS-10124" )
 )
 
 game (
 	name "BlazBlue - Calamity Trigger Portable (Europe) (En,Ja,Fr,De,Es,It,Zh,Ko)"
-	serial "ULES-01497"
-	serial "ULES-01497"
+	rom ( serial "ULES-01497" )
 )
 
 game (
 	name "BlazBlue - Calamity Trigger Portable (Japan) (v1.01)"
-	serial "NPJH-50180"
-	serial "NPJH-50180"
+	rom ( serial "NPJH-50180" )
 )
 
 game (
 	name "BlazBlue - Calamity Trigger Portable (USA) (En,Ja,Zh,Ko)"
-	serial "ULUS-10519"
-	serial "ULUS-10519"
+	rom ( serial "ULUS-10519" )
 )
 
 game (
 	name "BlazBlue - Continuum Shift Extend (Japan) (v1.03)"
-	serial "NPJH-50582"
-	serial "NPJH-50582"
+	rom ( serial "NPJH-50582" )
 )
 
 game (
 	name "BlazBlue - Continuum Shift II (Asia) (En,Ja,Zh,Ko) (v1.01)"
-	serial "ULUS-10579"
-	serial "ULUS-10579"
+	rom ( serial "ULUS-10579" )
 )
 
 game (
 	name "BlazBlue - Continuum Shift II (Europe) (En,Ja,Zh,Ko) (v1.01)"
-	serial "ULES-01526"
-	serial "ULES-01526"
+	rom ( serial "ULES-01526" )
 )
 
 game (
 	name "BlazBlue - Continuum Shift II (Japan) (v1.01)"
-	serial "NPJH-50401"
-	serial "NPJH-50401"
+	rom ( serial "NPJH-50401" )
 )
 
 game (
 	name "BlazBlue - Continuum Shift II (USA) (En,Ja,Zh,Ko) (v1.01)"
-	serial "ULUS-10579"
-	serial "ULUS-10579"
 )
 
 game (
 	name "Blaze Union - Story to Reach the Future (Japan)"
-	serial "ULJM-05503"
-	serial "ULJM-05503"
+	rom ( serial "ULJM-05503" )
 )
 
 game (
 	name "Blazing Souls - Accelate (Europe) (v1.02)"
-	serial "ULES-01562"
-	serial "ULES-01562"
+	rom ( serial "ULES-01562" )
 )
 
 game (
 	name "Blazing Souls - Accelate (Japan) (v1.02)"
-	serial "ULJM-05490"
-	serial "ULJM-05490"
+	rom ( serial "ULJM-05490" )
 )
 
 game (
 	name "Blazing Souls - Accelate (USA)"
-	serial "ULUS-10527"
-	serial "ULUS-10527"
+	rom ( serial "ULUS-10527" )
 )
 
 game (
 	name "Bleach - Heat the Soul (Japan)"
-	serial "UCJS-10008"
-	serial "UCJS-10008"
+	rom ( serial "UCJS-10008" )
 )
 
 game (
 	name "Bleach - Heat the Soul 2 (Japan) (v1.01)"
-	serial "UCJS-10017"
-	serial "UCJS-10017"
+	rom ( serial "UCJS-10017" )
 )
 
 game (
 	name "Bleach - Heat the Soul 3 (Japan)"
-	serial "UCJS-10042"
-	serial "UCJS-10042"
+	rom ( serial "UCJS-10042" )
 )
 
 game (
 	name "Bleach - Heat the Soul 4 (Japan) (v2.00)"
-	serial "UCJS-10057"
-	serial "UCJS-10057"
+	rom ( serial "UCJS-10057" )
 )
 
 game (
 	name "Bleach - Heat the Soul 5 (Japan) (v1.01)"
-	serial "UCJS-10082"
-	serial "UCJS-10082"
+	rom ( serial "UCJS-10082" )
 )
 
 game (
 	name "Bleach - Heat the Soul 6 (Asia)"
-	serial "UCAS-40258"
-	serial "UCAS-40258"
+	rom ( serial "UCAS-40258" )
 )
 
 game (
 	name "Bleach - Heat the Soul 6 (Japan) (v1.01)"
-	serial "UCJS-10093"
-	serial "UCJS-10093"
+	rom ( serial "UCJS-10093" )
 )
 
 game (
 	name "Bleach - Heat the Soul 7 (Asia)"
-	serial "NPHG-00087"
-	serial "NPHG-00087"
+	rom ( serial "NPHG-00087" )
 )
 
 game (
 	name "Bleach - Heat the Soul 7 (Japan) (v1.01)"
-	serial "UCJS-10110"
-	serial "UCJS-10110"
+	rom ( serial "UCJS-10110" )
 )
 
 game (
 	name "Bleach - Soul Carnival (Asia)"
-	serial "UCAS-40234"
-	serial "UCAS-40234"
+	rom ( serial "UCAS-40234" )
 )
 
 game (
 	name "Bleach - Soul Carnival (Japan) (v1.02)"
-	serial "UCJS-10085"
-	serial "UCJS-10085"
+	rom ( serial "UCJS-10085" )
 )
 
 game (
 	name "Bleach - Soul Carnival 2 (Asia)"
-	serial "UCAS-40297"
-	serial "UCAS-40297"
+	rom ( serial "UCAS-40297" )
 )
 
 game (
 	name "Bleach - Soul Carnival 2 (Japan)"
-	serial "UCJS-10106"
-	serial "UCJS-10106"
+	rom ( serial "UCJS-10106" )
 )
 
 game (
 	name "Bliss Island (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00616"
-	serial "ULES-00616"
+	rom ( serial "ULES-00616" )
 )
 
 game (
 	name "Blitz - Overtime (USA) (v1.01)"
-	serial "ULUS-10200"
-	serial "ULUS-10200"
+	rom ( serial "ULUS-10200" )
 )
 
 game (
 	name "Blokus Portable - Steambot Championship (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01016"
-	serial "ULES-01016"
+	rom ( serial "ULES-01016" )
 )
 
 game (
 	name "Blokus Portable - Steambot Championship (USA)"
-	serial "ULUS-10332"
-	serial "ULUS-10332"
+	rom ( serial "ULUS-10332" )
 )
 
 game (
 	name "Blood Bowl (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01230"
-	serial "ULES-01230"
+	rom ( serial "ULES-01230" )
 )
 
 game (
 	name "Blood Bowl (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10516"
-	serial "ULUS-10516"
+	rom ( serial "ULUS-10516" )
 )
 
 game (
 	name "Blood+ Final Piece (Japan)"
-	serial "UCJS-10044"
-	serial "UCJS-10044"
+	rom ( serial "UCJS-10044" )
 )
 
 game (
 	name "Blue Roses - Yousei to Aoi Hitomi no Senshitachi (Japan) (v1.01)"
-	serial "NPJH-50280"
-	serial "NPJH-50280"
+	rom ( serial "NPJH-50280" )
 )
 
 game (
 	name "Boku no Natsuyasumi 4 - Setouchi Shounen Tanteidan, Boku to Himitsu no Chizu (Japan) (v1.02)"
-	serial "UCJS-10095"
-	serial "UCJS-10095"
+	rom ( serial "UCJS-10095" )
 )
 
 game (
 	name "Boku no Natsuyasumi Portable - Mushi Mushi Hakase to Teppen-yama no Himitsu!! (Japan)"
-	serial "UCJS-10038"
-	serial "UCJS-10038"
+	rom ( serial "UCJS-10038" )
 )
 
 game (
 	name "Boku no Natsuyasumi Portable 2 - Nazo Nazo Shimai to Chinbotsusen no Himitsu! (Japan) (v1.01)"
-	serial "UCJS-10111"
-	serial "UCJS-10111"
+	rom ( serial "UCJS-10111" )
 )
 
 game (
 	name "Boku wa Koukuu Kanseikan - Airport Hero Haneda (Japan) (v1.01)"
-	serial "ULJM-05769"
-	serial "ULJM-05769"
+	rom ( serial "ULJM-05769" )
 )
 
 game (
 	name "Boku wa Koukuu Kanseikan - Airport Hero Kankuu (Japan) (v1.01)"
-	serial "ULJM-05803"
-	serial "ULJM-05803"
+	rom ( serial "ULJM-05803" )
 )
 
 game (
 	name "Boku wa Koukuu Kanseikan - Airport Hero Naha (Japan) (v1.03)"
-	serial "ULJM-05171"
-	serial "ULJM-05171"
+	rom ( serial "ULJM-05171" )
 )
 
 game (
 	name "Boku wa Koukuu Kanseikan - Airport Hero Narita (Japan) (v1.02)"
-	serial "ULJM-05128"
-	serial "ULJM-05128"
+	rom ( serial "ULJM-05128" )
 )
 
 game (
 	name "Boku wa Koukuu Kanseikan - Airport Hero Shinchitose (Japan) (v1.02)"
-	serial "ULJM-05231"
-	serial "ULJM-05231"
+	rom ( serial "ULJM-05231" )
 )
 
 game (
 	name "Boku wa Tomodachi ga Sukunai Portable (Japan) (v1.03)"
-	serial "ULJS-00459"
-	serial "ULJS-00459"
+	rom ( serial "ULJS-00459" )
 )
 
 game (
 	name "Bomberman (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00469"
-	serial "ULES-00469"
+	rom ( serial "ULES-00469" )
 )
 
 game (
 	name "Bomberman (USA)"
-	serial "ULUS-10121"
-	serial "ULUS-10121"
+	rom ( serial "ULUS-10121" )
 )
 
 game (
 	name "Bomberman - Bakufuu Sentai Bombermen (Japan) (v1.01)"
-	serial "UCJS-10030"
-	serial "UCJS-10030"
+	rom ( serial "UCJS-10030" )
 )
 
 game (
 	name "Bomberman - Panic Bomber (Japan)"
-	serial "ULJM-05023"
-	serial "ULJM-05023"
+	rom ( serial "ULJM-05023" )
 )
 
 game (
 	name "Bomberman Land (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00959"
-	serial "ULES-00959"
+	rom ( serial "ULES-00959" )
 )
 
 game (
 	name "Bomberman Land (USA) (v1.02)"
-	serial "ULUS-10319"
-	serial "ULUS-10319"
+	rom ( serial "ULUS-10319" )
 )
 
 game (
 	name "Bounty Hounds (Asia) (v1.01)"
-	serial "UCAS-40037"
-	serial "UCAS-40037"
+	rom ( serial "UCAS-40037" )
 )
 
 game (
 	name "Bounty Hounds (Japan) (v1.02)"
-	serial "ULJS-00021"
-	serial "ULJS-00021"
+	rom ( serial "ULJS-00021" )
 )
 
 game (
 	name "Bounty Hounds (USA)"
-	serial "ULUS-10161"
-	serial "ULUS-10161"
+	rom ( serial "ULUS-10161" )
 )
 
 game (
 	name "Boxer's Road 2 - The Real (Japan) (v1.10)"
-	serial "ULJM-05125"
-	serial "ULJM-05125"
+	rom ( serial "ULJM-05125" )
 )
 
 game (
 	name "Brandish - The Dark Revenant (Japan)"
-	serial "ULJM-05424"
-	serial "ULJM-05424"
+	rom ( serial "ULJM-05424" )
 )
 
 game (
 	name "Brave Story - New Traveler (USA) (v1.01)"
-	serial "ULUS-10279"
-	serial "ULUS-10279"
+	rom ( serial "ULUS-10279" )
 )
 
 game (
 	name "Breath of Fire III (Europe)"
-	serial "ULES-00193"
-	serial "ULES-00193"
+	rom ( serial "ULES-00193" )
 )
 
 game (
 	name "Breath of Fire III (Japan) (v1.02)"
-	serial "ULJM-05029"
-	serial "ULJM-05029"
+	rom ( serial "ULJM-05029" )
 )
 
 game (
 	name "Brian Lara 2007 - Pressure Play (Europe) (En,Fr) (v1.01)"
-	serial "ULES-00814"
-	serial "ULES-00814"
+	rom ( serial "ULES-00814" )
 )
 
 game (
 	name "Brooktown High (USA)"
-	serial "ULUS-10257"
-	serial "ULUS-10257"
+	rom ( serial "ULUS-10257" )
 )
 
 game (
 	name "Brothers Conflict - Passion Pink (Japan) (v1.02)"
-	serial "ULJM-06066"
-	serial "ULJM-06066"
+	rom ( serial "ULJM-06066" )
 )
 
 game (
 	name "Brothers in Arms - D-Day (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00608"
-	serial "ULES-00608"
+	rom ( serial "ULES-00608" )
 )
 
 game (
 	name "Brothers in Arms - D-Day (USA) (v1.01)"
-	serial "ULUS-10193"
-	serial "ULUS-10193"
+	rom ( serial "ULUS-10193" )
 )
 
 game (
 	name "Brunswick Pro Bowling (Europe)"
-	serial "ULES-00848"
-	serial "ULES-00848"
+	rom ( serial "ULES-00848" )
 )
 
 game (
 	name "Brunswick Pro Bowling (USA) (v1.01)"
-	serial "ULUS-10283"
-	serial "ULUS-10283"
+	rom ( serial "ULUS-10283" )
 )
 
 game (
 	name "Bubble Bobble - Evolution (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00303"
-	serial "ULES-00303"
+	rom ( serial "ULES-00303" )
 )
 
 game (
 	name "Bubble Bobble - Evolution (USA) (v1.01)"
-	serial "ULUS-10143"
-	serial "ULUS-10143"
+	rom ( serial "ULUS-10143" )
 )
 
 game (
 	name "Bullet Butlers - Juudan no Kanata (Japan) (v1.05)"
-	serial "ULJM-05941"
-	serial "ULJM-05941"
+	rom ( serial "ULJM-05941" )
 )
 
 game (
 	name "Bunmei Kaika - Aoiza Ibunroku (Japan) (v1.01)"
-	serial "ULJM-05824"
-	serial "ULJM-05824"
+	rom ( serial "ULJM-05824" )
 )
 
 game (
 	name "Bunmei Kaika - Aoiza Ibunroku Saien (Japan) (v1.01)"
-	serial "NPJH-50560"
-	serial "NPJH-50560"
+	rom ( serial "NPJH-50560" )
 )
 
 game (
 	name "Burnout Dominator (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00703"
-	serial "ULES-00703"
+	rom ( serial "ULES-00703" )
 )
 
 game (
 	name "Burnout Dominator (Europe) (v1.01)"
-	serial "ULES-00750"
-	serial "ULES-00750"
+	rom ( serial "ULES-00750" )
 )
 
 game (
 	name "Burnout Dominator (Japan)"
-	serial "ULJM-05242"
-	serial "ULJM-05242"
+	rom ( serial "ULJM-05242" )
 )
 
 game (
 	name "Burnout Dominator (USA)"
-	serial "ULUS-10236"
-	serial "ULUS-10236"
+	rom ( serial "ULUS-10236" )
 )
 
 game (
 	name "Burnout Legends (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00125"
-	serial "ULES-00125"
+	rom ( serial "ULES-00125" )
 )
 
 game (
 	name "Burnout Legends (Europe) (En,Fr,De,Es,It,Nl) (v2.00) (Platinum)"
-	serial "ULES-00125"
-	serial "ULES-00125"
 )
 
 game (
 	name "Burnout Legends (Japan) (v1.01)"
-	serial "ULJM-05049"
-	serial "ULJM-05049"
+	rom ( serial "ULJM-05049" )
 )
 
 game (
 	name "Burnout Legends (Japan) (v1.01) (EA Best Hits)"
-	serial "ULJM-05228"
-	serial "ULJM-05228"
+	rom ( serial "ULJM-05228" )
 )
 
 game (
 	name "Burnout Legends (Korea) (v1.01) [b]"
-	serial "ULKS-46027"
-	serial "ULKS-46027"
+	rom ( serial "ULKS-46027" )
 )
 
 game (
 	name "Burnout Legends (USA) (En,Fr,De,Es,It,Nl)"
-	serial "ULUS-10025"
-	serial "ULUS-10025"
+	rom ( serial "ULUS-10025" )
 )
 
 game (
 	name "Burnout Legends (USA) (En,Fr,De,Es,It,Nl) (v2.00) (Greatest Hits)"
-	serial "ULUS-10025"
-	serial "ULUS-10025"
 )
 
 game (
 	name "Burst Error - Eve the First (Japan) (v1.02)"
-	serial "ULJM-05615"
-	serial "ULJM-05615"
+	rom ( serial "ULJM-05615" )
 )
 
 game (
 	name "Busou Shinki - Battle Masters (Japan) (v1.03)"
-	serial "ULJM-05538"
-	serial "ULJM-05538"
+	rom ( serial "ULJM-05538" )
 )
 
 game (
 	name "Busou Shinki - Battle Masters Mk. 2 (Japan) (v2.01)"
-	serial "NPJH-50453"
-	serial "NPJH-50453"
+	rom ( serial "NPJH-50453" )
 )
 
 game (
 	name "Bust-A-Move Ghost (Europe) (v1.01)"
-	serial "ULES-00233"
-	serial "ULES-00233"
+	rom ( serial "ULES-00233" )
 )
 
 game (
 	name "Buzz! Brain Bender (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-01157"
-	serial "UCES-01157"
+	rom ( serial "UCES-01157" )
 )
 
 game (
 	name "Buzz! Brain Bender (Europe) (Sv,No,Da,Fi) (v1.01)"
-	serial "UCES-01158"
-	serial "UCES-01158"
+	rom ( serial "UCES-01158" )
 )
 
 game (
 	name "Buzz! Brain of the UK (Europe) (v1.01)"
-	serial "UCES-01196"
-	serial "UCES-01196"
+	rom ( serial "UCES-01196" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe)"
-	serial "UCES-01042"
-	serial "UCES-01042"
+	rom ( serial "UCES-01042" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (De,It)"
-	serial "UCES-01031"
-	serial "UCES-01031"
+	rom ( serial "UCES-01031" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (En,Pl)"
-	serial "UCES-01130"
-	serial "UCES-01130"
+	rom ( serial "UCES-01130" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (Es,Pt)"
-	serial "UCES-01032"
-	serial "UCES-01032"
+	rom ( serial "UCES-01032" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (Fr,Nl)"
-	serial "UCES-01033"
-	serial "UCES-01033"
+	rom ( serial "UCES-01033" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (No,Da) [b]"
-	serial "UCES-01034"
-	serial "UCES-01034"
+	rom ( serial "UCES-01034" )
 )
 
 game (
 	name "Buzz! Master Quiz (Europe) (Sv,Fi)"
-	serial "UCES-01041"
-	serial "UCES-01041"
+	rom ( serial "UCES-01041" )
 )
 
 game (
 	name "Buzz! Master Quiz (USA)"
-	serial "UCUS-98729"
-	serial "UCUS-98729"
+	rom ( serial "UCUS-98729" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe)"
-	serial "UCES-01293"
-	serial "UCES-01293"
+	rom ( serial "UCES-01293" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (De,It)"
-	serial "UCES-01290"
-	serial "UCES-01290"
+	rom ( serial "UCES-01290" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (El,Cs)"
-	serial "UCES-01297"
-	serial "UCES-01297"
+	rom ( serial "UCES-01297" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (En,Pl)"
-	serial "UCES-01289"
-	serial "UCES-01289"
+	rom ( serial "UCES-01289" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (Es,Pt)"
-	serial "UCES-01292"
-	serial "UCES-01292"
+	rom ( serial "UCES-01292" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (Fr,Nl)"
-	serial "UCES-01291"
-	serial "UCES-01291"
+	rom ( serial "UCES-01291" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (No,Da)"
-	serial "UCES-01294"
-	serial "UCES-01294"
+	rom ( serial "UCES-01294" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (Ru,Hr)"
-	serial "UCES-01296"
-	serial "UCES-01296"
+	rom ( serial "UCES-01296" )
 )
 
 game (
 	name "Buzz! Quiz World (Europe) (Sv,Fi)"
-	serial "UCES-01295"
-	serial "UCES-01295"
+	rom ( serial "UCES-01295" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe) (De,It) (v1.02)"
-	serial "UCES-01449"
-	serial "UCES-01449"
+	rom ( serial "UCES-01449" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe) (Es,Pt)"
-	serial "UCES-01451"
-	serial "UCES-01451"
+	rom ( serial "UCES-01451" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe) (Fr,Nl) (v1.02)"
-	serial "UCES-01450"
-	serial "UCES-01450"
+	rom ( serial "UCES-01450" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe) (Sv,Fi) (v1.02)"
-	serial "UCES-01454"
-	serial "UCES-01454"
+	rom ( serial "UCES-01454" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe) (v1.02)"
-	serial "UCES-01445"
-	serial "UCES-01445"
+	rom ( serial "UCES-01445" )
 )
 
 game (
 	name "Buzz! The Ultimate Music Quiz (Europe, Australia) (v1.02)"
-	serial "UCES-01452"
-	serial "UCES-01452"
+	rom ( serial "UCES-01452" )
 )
 
 game (
 	name "CID The Dummy (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01024"
-	serial "ULES-01024"
+	rom ( serial "ULES-01024" )
 )
 
 game (
 	name "CID The Dummy (USA) (v1.02)"
-	serial "ULUS-10356"
-	serial "ULUS-10356"
+	rom ( serial "ULUS-10356" )
 )
 
 game (
 	name "Cabela's African Safari (USA) (v1.01)"
-	serial "ULUS-10175"
-	serial "ULUS-10175"
+	rom ( serial "ULUS-10175" )
 )
 
 game (
 	name "Cabela's Dangerous Hunts - Ultimate Challenge (Europe)"
-	serial "ULES-00550"
-	serial "ULES-00550"
+	rom ( serial "ULES-00550" )
 )
 
 game (
 	name "Cabela's Dangerous Hunts - Ultimate Challenge (USA) (v1.01)"
-	serial "ULUS-10106"
-	serial "ULUS-10106"
+	rom ( serial "ULUS-10106" )
 )
 
 game (
 	name "Cabela's Legendary Adventures (USA)"
-	serial "ULUS-10385"
-	serial "ULUS-10385"
+	rom ( serial "ULUS-10385" )
 )
 
 game (
 	name "Cabela's North American Adventures (USA)"
-	serial "ULUS-10533"
-	serial "ULUS-10533"
+	rom ( serial "ULUS-10533" )
 )
 
 game (
 	name "Cake Mania - Baker's Challenge (USA) (v1.02)"
-	serial "ULUS-10362"
-	serial "ULUS-10362"
+	rom ( serial "ULUS-10362" )
 )
 
 game (
 	name "Call of Duty - Roads to Victory (Europe) (En,Fr,Es,It) (v1.02)"
-	serial "ULES-00643"
-	serial "ULES-00643"
+	rom ( serial "ULES-00643" )
 )
 
 game (
 	name "Call of Duty - Roads to Victory (Germany) (v1.01) [b]"
-	serial "ULES-00644"
-	serial "ULES-00644"
+	rom ( serial "ULES-00644" )
 )
 
 game (
 	name "Call of Duty - Roads to Victory (USA) (En,Ja,Fr,De,Es,It) (v1.03)"
-	serial "ULUS-10218"
-	serial "ULUS-10218"
+	rom ( serial "ULUS-10218" )
 )
 
 game (
 	name "Canvas 3 - Nanairo no Kiseki (Japan) (v1.03)"
-	serial "ULJM-05659"
-	serial "ULJM-05659"
+	rom ( serial "ULJM-05659" )
 )
 
 game (
 	name "Capcom Classics Collection Reloaded (Europe) (v1.01)"
-	serial "ULES-00377"
-	serial "ULES-00377"
+	rom ( serial "ULES-00377" )
 )
 
 game (
 	name "Capcom Classics Collection Reloaded (USA)"
-	serial "ULUS-10134"
-	serial "ULUS-10134"
+	rom ( serial "ULUS-10134" )
 )
 
 game (
 	name "Capcom Classics Collection Remixed (Asia)"
-	serial "ULAS-42053"
-	serial "ULAS-42053"
+	rom ( serial "ULAS-42053" )
 )
 
 game (
 	name "Capcom Classics Collection Remixed (Europe) (v1.01)"
-	serial "ULES-00347"
-	serial "ULES-00347"
+	rom ( serial "ULES-00347" )
 )
 
 game (
 	name "Capcom Classics Collection Remixed (USA)"
-	serial "ULUS-10097"
-	serial "ULUS-10097"
+	rom ( serial "ULUS-10097" )
 )
 
 game (
 	name "Capcom Puzzle World (Europe) (v1.04)"
-	serial "ULES-00647"
-	serial "ULES-00647"
+	rom ( serial "ULES-00647" )
 )
 
 game (
 	name "Capcom Puzzle World (USA) (v1.02)"
-	serial "ULUS-10217"
-	serial "ULUS-10217"
+	rom ( serial "ULUS-10217" )
 )
 
 game (
 	name "Carnage Heart EXA (Japan) (v1.01)"
-	serial "ULJM-05698"
-	serial "ULJM-05698"
+	rom ( serial "ULJM-05698" )
 )
 
 game (
 	name "Carnage Heart Portable (Japan) (v1.02)"
-	serial "ULJM-05138"
-	serial "ULJM-05138"
+	rom ( serial "ULJM-05138" )
 )
 
 game (
 	name "Carol Vorderman's Sudoku (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-00388"
-	serial "ULES-00388"
+	rom ( serial "ULES-00388" )
 )
 
 game (
 	name "Carol Vorderman's Sudoku (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10126"
-	serial "ULUS-10126"
+	rom ( serial "ULUS-10126" )
 )
 
 game (
 	name "Cars (Europe) (v1.01)"
-	serial "ULES-00319"
-	serial "ULES-00319"
+	rom ( serial "ULES-00319" )
 )
 
 game (
 	name "Cars (France) (v1.01)"
-	serial "ULES-00321"
-	serial "ULES-00321"
+	rom ( serial "ULES-00321" )
 )
 
 game (
 	name "Cars (Germany)"
-	serial "ULES-00323"
-	serial "ULES-00323"
+	rom ( serial "ULES-00323" )
 )
 
 game (
 	name "Cars (Italy)"
-	serial "ULES-00325"
-	serial "ULES-00325"
+	rom ( serial "ULES-00325" )
 )
 
 game (
 	name "Cars (Japan) (v1.01)"
-	serial "ULJM-05149"
-	serial "ULJM-05149"
+	rom ( serial "ULJM-05149" )
 )
 
 game (
 	name "Cars (Korea) (En,Ko)"
-	serial "UCKS-45018"
-	serial "UCKS-45018"
+	rom ( serial "UCKS-45018" )
 )
 
 game (
 	name "Cars (Netherlands)"
-	serial "ULES-00322"
-	serial "ULES-00322"
+	rom ( serial "ULES-00322" )
 )
 
 game (
 	name "Cars (Spain) (v1.01)"
-	serial "ULES-00324"
-	serial "ULES-00324"
+	rom ( serial "ULES-00324" )
 )
 
 game (
 	name "Cars (USA) (v1.02)"
-	serial "ULUS-10073"
-	serial "ULUS-10073"
+	rom ( serial "ULUS-10073" )
 )
 
 game (
 	name "Cars - Race-O-Rama (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01333"
-	serial "ULES-01333"
+	rom ( serial "ULES-01333" )
 )
 
 game (
 	name "Cars - Race-O-Rama (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10428"
-	serial "ULUS-10428"
+	rom ( serial "ULUS-10428" )
 )
 
 game (
 	name "Cars 2 (Europe) (En,Fr,De,Es,It,Nl,Pt,Pl,Ru)"
-	serial "UCES-01534"
-	serial "UCES-01534"
+	rom ( serial "UCES-01534" )
 )
 
 game (
 	name "Cars 2 (USA) (En,Fr,De,Es,It)"
-	serial "UCUS-98766"
-	serial "UCUS-98766"
+	rom ( serial "UCUS-98766" )
 )
 
 game (
 	name "Castlevania - The Dracula X Chronicles (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00841"
-	serial "ULES-00841"
+	rom ( serial "ULES-00841" )
 )
 
 game (
 	name "Castlevania - The Dracula X Chronicles (USA) (v1.02)"
-	serial "ULUS-10277"
-	serial "ULUS-10277"
+	rom ( serial "ULUS-10277" )
 )
 
 game (
 	name "Championship Manager (Europe) (v1.02)"
-	serial "ULES-00174"
-	serial "ULES-00174"
+	rom ( serial "ULES-00174" )
 )
 
 game (
 	name "Championship Manager 2006 (Europe)"
-	serial "ULES-00330"
-	serial "ULES-00330"
+	rom ( serial "ULES-00330" )
 )
 
 game (
 	name "Championship Manager 2007 (Europe) (En,Fr,Es,It)"
-	serial "ULES-00636"
-	serial "ULES-00636"
+	rom ( serial "ULES-00636" )
 )
 
 game (
 	name "Chaos;Head Love Chu-Chu! (Japan)"
-	serial "ULJM-05821"
-	serial "ULJM-05821"
+	rom ( serial "ULJM-05821" )
 )
 
 game (
 	name "Chaos;Head Noah (Japan) (v1.01)"
-	serial "ULJM-05692"
-	serial "ULJM-05692"
+	rom ( serial "ULJM-05692" )
 )
 
 game (
 	name "Cherry Blossom Portable (Japan) (v1.01)"
-	serial "ULJS-00174"
-	serial "ULJS-00174"
+	rom ( serial "ULJS-00174" )
 )
 
 game (
 	name "Chessmaster - The Art of Learning (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-01013"
-	serial "ULES-01013"
+	rom ( serial "ULES-01013" )
 )
 
 game (
 	name "Chessmaster - The Art of Learning (USA) (En,Fr,Es)"
-	serial "ULUS-10335"
-	serial "ULUS-10335"
+	rom ( serial "ULUS-10335" )
 )
 
 game (
 	name "Chikyuu Boueigun 2 Portable (Japan) (v1.02)"
-	serial "ULJS-00374"
-	serial "ULJS-00374"
+	rom ( serial "ULJS-00374" )
 )
 
 game (
 	name "Chili Con Carnage (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00629"
-	serial "ULES-00629"
+	rom ( serial "ULES-00629" )
 )
 
 game (
 	name "Chili Con Carnage (USA) (v1.02)"
-	serial "ULUS-10216"
-	serial "ULUS-10216"
+	rom ( serial "ULUS-10216" )
 )
 
 game (
 	name "Chotto Shot (Japan) (v1.01)"
-	serial "UCJB-98012"
-	serial "UCJB-98012"
+	rom ( serial "UCJB-98012" )
 )
 
 game (
 	name "Chronobelt - SchwarzOath (Japan) (v1.01)"
-	serial "ULJM-06013"
-	serial "ULJM-06013"
+	rom ( serial "ULJM-06013" )
 )
 
 game (
 	name "Chuugen no Hasha - Sangoku Shouseiden (Japan) (v1.02)"
-	serial "ULJS-00036"
-	serial "ULJS-00036"
+	rom ( serial "ULJS-00036" )
 )
 
 game (
 	name "Chuukana Janshi Tenhoo Painyan Remix (Japan) (v1.01)"
-	serial "ULJM-05244"
-	serial "ULJM-05244"
+	rom ( serial "ULJM-05244" )
 )
 
 game (
 	name "Clannad (Japan)"
-	serial "ULJM-05338"
-	serial "ULJM-05338"
-)
-
-game (
-	name "Clannad (Japan)"
-	serial "ULJM-05338"
-	serial "ULJM-05338"
+	rom ( serial "ULJM-05338" )
 )
 
 game (
 	name "Clannad - Hikari Mimamoru Sakamichi de Gekan (Japan) (v1.01)"
-	serial "NPJH-50273"
-	serial "NPJH-50273"
+	rom ( serial "NPJH-50273" )
 )
 
 game (
 	name "Clannad - Hikari Mimamoru Sakamichi de Joukan (Japan) (v1.02)"
-	serial "NPJH-50266"
-	serial "NPJH-50266"
+	rom ( serial "NPJH-50266" )
 )
 
 game (
 	name "Class of Heroes (USA) (v1.01)"
-	serial "ULUS-10396"
-	serial "ULUS-10396"
+	rom ( serial "ULUS-10396" )
 )
 
 game (
 	name "Class of Heroes 2 (USA) (v1.01)"
-	serial "ULUS-10653"
-	serial "ULUS-10653"
+	rom ( serial "ULUS-10653" )
 )
 
 game (
 	name "Classic Dungeon - Fuyoku no Masoujin (Japan) (v1.01)"
-	serial "NPJH-50185"
-	serial "NPJH-50185"
+	rom ( serial "NPJH-50185" )
 )
 
 game (
 	name "Classic Dungeon X2 (Japan) (v1.02)"
-	serial "NPJH-50388"
-	serial "NPJH-50388"
+	rom ( serial "NPJH-50388" )
 )
 
 game (
 	name "Clock Zero - Shuuen no Ichibyou Portable (Japan) (v1.02)"
-	serial "ULJM-05945"
-	serial "ULJM-05945"
+	rom ( serial "ULJM-05945" )
 )
 
 game (
 	name "Cloudy with a Chance of Meatballs (Europe)"
-	serial "ULES-01319"
-	serial "ULES-01319"
+	rom ( serial "ULES-01319" )
 )
 
 game (
 	name "Cloudy with a Chance of Meatballs (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01318"
-	serial "ULES-01318"
+	rom ( serial "ULES-01318" )
 )
 
 game (
 	name "Cloudy with a Chance of Meatballs (Russia)"
-	serial "ULES-01361"
-	serial "ULES-01361"
+	rom ( serial "ULES-01361" )
 )
 
 game (
 	name "Cloudy with a Chance of Meatballs (USA) (En,Fr,Es)"
-	serial "ULUS-10444"
-	serial "ULUS-10444"
+	rom ( serial "ULUS-10444" )
 )
 
 game (
 	name "Clover no Kuni no Alice - Wonderful Wonder World (Japan) (v1.01)"
-	serial "ULJM-05856"
-	serial "ULJM-05856"
+	rom ( serial "ULJM-05856" )
 )
 
 game (
 	name "Code Geass - Hangyaku no Lelouch - Lost Colors (Japan) (v1.01)"
-	serial "ULJS-00135"
-	serial "ULJS-00135"
+	rom ( serial "ULJS-00135" )
 )
 
 game (
 	name "Code Geass - Hangyaku no Lelouch - Lost Colors (Japan) (v2.00)"
-	serial "ULJS-00135"
-	serial "ULJS-00135"
 )
 
 game (
 	name "Code Lyoko - Quest for Infinity (Europe) (En,Fr,Es,It) (v1.01)"
-	serial "ULES-01095"
-	serial "ULES-01095"
+	rom ( serial "ULES-01095" )
 )
 
 game (
 	name "Code Lyoko - Quest for Infinity (USA) (En,Fr,Es) (v1.03)"
-	serial "ULUS-10351"
-	serial "ULUS-10351"
+	rom ( serial "ULUS-10351" )
 )
 
 game (
 	name "Coded Arms (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00124"
-	serial "ULES-00124"
+	rom ( serial "ULES-00124" )
 )
 
 game (
 	name "Coded Arms (Japan) (v1.03)"
-	serial "ULJM-05024"
-	serial "ULJM-05024"
+	rom ( serial "ULJM-05024" )
 )
 
 game (
 	name "Coded Arms (USA) (v1.01)"
-	serial "ULUS-10019"
-	serial "ULUS-10019"
+	rom ( serial "ULUS-10019" )
 )
 
 game (
 	name "Coded Arms - Contagion (Asia) (v1.04)"
-	serial "ULUS-10184"
-	serial "ULUS-10184"
+	rom ( serial "ULUS-10184" )
 )
 
 game (
 	name "Coded Arms - Contagion (Europe) (En,Fr,De,Es,It) (v1.06)"
-	serial "ULES-00718"
-	serial "ULES-00718"
+	rom ( serial "ULES-00718" )
 )
 
 game (
 	name "Coded Arms - Contagion (Japan) (v1.02)"
-	serial "ULJM-05243"
-	serial "ULJM-05243"
+	rom ( serial "ULJM-05243" )
 )
 
 game (
 	name "Coded Arms - Contagion (USA) (v1.04)"
-	serial "ULUS-10184"
-	serial "ULUS-10184"
 )
 
 game (
 	name "Coded Soul - Uke Tsugareshi Idea (Japan)"
-	serial "UCJS-10061"
-	serial "UCJS-10061"
+	rom ( serial "UCJS-10061" )
 )
 
 game (
 	name "Colin McRae - DiRT 2 (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01301"
-	serial "ULES-01301"
+	rom ( serial "ULES-01301" )
 )
 
 game (
 	name "Colin McRae - DiRT 2 (Japan) (v1.01)"
-	serial "NPJH-50006"
-	serial "NPJH-50006"
+	rom ( serial "NPJH-50006" )
 )
 
 game (
 	name "Colin McRae - DiRT 2 (USA) (v1.02)"
-	serial "ULUS-10471"
-	serial "ULUS-10471"
+	rom ( serial "ULUS-10471" )
 )
 
 game (
 	name "Colin McRae Rally 2005 Plus (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00111"
-	serial "ULES-00111"
+	rom ( serial "ULES-00111" )
 )
 
 game (
 	name "Comic Party Portable (Japan) (v1.08)"
-	serial "ULJS-00028"
-	serial "ULJS-00028"
+	rom ( serial "ULJS-00028" )
 )
 
 game (
 	name "Comic Party Portable (Japan) (v1.08) (Shokai Genteiban)"
-	serial "ULJS-00027"
-	serial "ULJS-00027"
+	rom ( serial "ULJS-00027" )
 )
 
 game (
 	name "Con, The (Europe) (v1.02)"
-	serial "ULES-00516"
-	serial "ULES-00516"
+	rom ( serial "ULES-00516" )
 )
 
 game (
 	name "Con, The (Germany) (v1.02) [b]"
-	serial "ULES-00511"
-	serial "ULES-00511"
+	rom ( serial "ULES-00511" )
 )
 
 game (
 	name "Con, The (Italy) (v1.03)"
-	serial "ULES-00512"
-	serial "ULES-00512"
+	rom ( serial "ULES-00512" )
 )
 
 game (
 	name "Con, The (USA)"
-	serial "UCUS-98621"
-	serial "UCUS-98621"
+	rom ( serial "UCUS-98621" )
 )
 
 game (
 	name "Conception - Ore no Kodomo o Unde Kure!! (Japan) (v1.01)"
-	serial "NPJH-50583"
-	serial "NPJH-50583"
+	rom ( serial "NPJH-50583" )
 )
 
 game (
 	name "Confidential Money - 300-Nichi de 3000-Man Dol Kasegu Houhou (Japan) (v1.02)"
-	serial "ULJM-06143"
-	serial "ULJM-06143"
+	rom ( serial "ULJM-06143" )
 )
 
 game (
 	name "Conveni Portable, The (Japan) (v1.02)"
-	serial "ULJM-05702"
-	serial "ULJM-05702"
+	rom ( serial "ULJM-05702" )
 )
 
 game (
 	name "Corpse Party - Blood Covered - Repeated Fear (Japan) (v1.03)"
-	serial "ULJM-05704"
-	serial "ULJM-05704"
+	rom ( serial "ULJM-05704" )
 )
 
 game (
 	name "Corpse Party - Book of Shadows (Japan)"
-	serial "ULJM-05909"
-	serial "ULJM-05909"
+	rom ( serial "ULJM-05909" )
 )
 
 game (
 	name "Corpse Party - The Anthology - Sachiko no Renai Yuugi - Hysteric Birthday 2U (Japan) (v1.01)"
-	serial "ULJM-06114"
-	serial "ULJM-06114"
+	rom ( serial "ULJM-06114" )
 )
 
 game (
 	name "Cover Girl (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01302"
-	serial "ULES-01302"
+	rom ( serial "ULES-01302" )
 )
 
 game (
 	name "Crash - Mind Over Mutant (Europe)"
-	serial "ULES-01170"
-	serial "ULES-01170"
+	rom ( serial "ULES-01170" )
 )
 
 game (
 	name "Crash - Mind Over Mutant (Europe) (De,Ru) (v1.03)"
-	serial "ULES-01171"
-	serial "ULES-01171"
+	rom ( serial "ULES-01171" )
 )
 
 game (
 	name "Crash - Mind Over Mutant (Europe) (Es,It)"
-	serial "ULES-01172"
-	serial "ULES-01172"
+	rom ( serial "ULES-01172" )
 )
 
 game (
 	name "Crash - Mind Over Mutant (Europe) (Fr,Nl)"
-	serial "ULES-01173"
-	serial "ULES-01173"
+	rom ( serial "ULES-01173" )
 )
 
 game (
 	name "Crash - Mind Over Mutant (USA) (En,Fr) (v1.01)"
-	serial "ULUS-10377"
-	serial "ULUS-10377"
+	rom ( serial "ULUS-10377" )
 )
 
 game (
 	name "Crash Tag Team Racing (Europe)"
-	serial "ULES-00168"
-	serial "ULES-00168"
+	rom ( serial "ULES-00168" )
 )
 
 game (
 	name "Crash Tag Team Racing (France)"
-	serial "ULES-00169"
-	serial "ULES-00169"
+	rom ( serial "ULES-00169" )
 )
 
 game (
 	name "Crash Tag Team Racing (Germany)"
-	serial "ULES-00170"
-	serial "ULES-00170"
+	rom ( serial "ULES-00170" )
 )
 
 game (
 	name "Crash Tag Team Racing (Italy)"
-	serial "ULES-00172"
-	serial "ULES-00172"
+	rom ( serial "ULES-00172" )
 )
 
 game (
 	name "Crash Tag Team Racing (Netherlands)"
-	serial "ULES-00173"
-	serial "ULES-00173"
+	rom ( serial "ULES-00173" )
 )
 
 game (
 	name "Crash Tag Team Racing (Spain)"
-	serial "ULES-00171"
-	serial "ULES-00171"
+	rom ( serial "ULES-00171" )
 )
 
 game (
 	name "Crash Tag Team Racing (USA) (v1.01)"
-	serial "ULUS-10044"
-	serial "ULUS-10044"
+	rom ( serial "ULUS-10044" )
 )
 
 game (
 	name "Crash of the Titans (Europe) (De,Ru) (v1.01)"
-	serial "ULES-00917"
-	serial "ULES-00917"
+	rom ( serial "ULES-00917" )
 )
 
 game (
 	name "Crash of the Titans (Europe) (Es,It) (v1.01)"
-	serial "ULES-00915"
-	serial "ULES-00915"
+	rom ( serial "ULES-00915" )
 )
 
 game (
 	name "Crash of the Titans (Europe) (v1.01)"
-	serial "ULES-00918"
-	serial "ULES-00918"
+	rom ( serial "ULES-00918" )
 )
 
 game (
 	name "Crash of the Titans (France) (v1.01)"
-	serial "ULES-00916"
-	serial "ULES-00916"
+	rom ( serial "ULES-00916" )
 )
 
 game (
 	name "Crash of the Titans (USA) (v1.01)"
-	serial "ULUS-10304"
-	serial "ULUS-10304"
+	rom ( serial "ULUS-10304" )
 )
 
 game (
 	name "Crazy Taxi - Fare Wars (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00811"
-	serial "ULES-00811"
+	rom ( serial "ULES-00811" )
 )
 
 game (
 	name "Crazy Taxi - Fare Wars (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10273"
-	serial "ULUS-10273"
+	rom ( serial "ULUS-10273" )
 )
 
 game (
 	name "Crazy Taxi - Fare Wars (USA) (En,Fr,De,Es,It) (v2.01)"
-	serial "ULUS-10273"
-	serial "ULUS-10273"
 )
 
 game (
 	name "Cream Stew mo Minagara Iroiro Gochagocha Ittemasukedomo - Warai no Tamago L Size - Ohitorisama Nankai demo (Japan)"
-	serial "ULJM-05052"
-	serial "ULJM-05052"
+	rom ( serial "ULJM-05052" )
 )
 
 game (
 	name "Criminal Girls (Japan) (v1.03)"
-	serial "NPJH-50316"
-	serial "NPJH-50316"
+	rom ( serial "NPJH-50316" )
 )
 
 game (
 	name "Crimson Empire (Japan) (v1.01)"
-	serial "ULJM-05932"
-	serial "ULJM-05932"
+	rom ( serial "ULJM-05932" )
 )
 
 game (
 	name "Crimson Gem Saga (USA)"
-	serial "ULUS-10400"
-	serial "ULUS-10400"
+	rom ( serial "ULUS-10400" )
 )
 
 game (
 	name "Crimson Room Reverse (Japan) (v1.01)"
-	serial "ULJM-05408"
-	serial "ULJM-05408"
+	rom ( serial "ULJM-05408" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Asia)"
-	serial "ULUS-10336"
-	serial "ULUS-10336"
+	rom ( serial "ULUS-10336" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Europe)"
-	serial "ULES-01044"
-	serial "ULES-01044"
+	rom ( serial "ULES-01044" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (France)"
-	serial "ULES-01045"
-	serial "ULES-01045"
+	rom ( serial "ULES-01045" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Germany)"
-	serial "ULES-01046"
-	serial "ULES-01046"
+	rom ( serial "ULES-01046" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Italy)"
-	serial "ULES-01047"
-	serial "ULES-01047"
+	rom ( serial "ULES-01047" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Japan) (v1.01)"
-	serial "ULJM-05275"
-	serial "ULJM-05275"
+	rom ( serial "ULJM-05275" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Japan) (v1.01) (10th Anniversary Limited Edition)"
-	serial "ULJM-05254"
-	serial "ULJM-05254"
+	rom ( serial "ULJM-05254" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (Spain)"
-	serial "ULES-01048"
-	serial "ULES-01048"
+	rom ( serial "ULES-01048" )
 )
 
 game (
 	name "Crisis Core - Final Fantasy VII (USA)"
-	serial "ULUS-10336"
-	serial "ULUS-10336"
 )
 
 game (
 	name "Cross Channel - To All People (Japan)"
-	serial "ULJM-05623"
-	serial "ULJM-05623"
+	rom ( serial "ULJM-05623" )
 )
 
 game (
 	name "Crush (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00765"
-	serial "ULES-00765"
+	rom ( serial "ULES-00765" )
 )
 
 game (
 	name "Crush (USA) (En,Fr,Es)"
-	serial "ULUS-10238"
-	serial "ULUS-10238"
+	rom ( serial "ULUS-10238" )
 )
 
 game (
 	name "Cube - 3D Puzzle Mayhem (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00722"
-	serial "ULES-00722"
+	rom ( serial "ULES-00722" )
 )
 
 game (
 	name "Custom Drive (Japan) (v1.03)"
-	serial "NPJH-50649"
-	serial "NPJH-50649"
+	rom ( serial "NPJH-50649" )
 )
 
 game (
 	name "D.C. Girls Symphony Pocket (Japan) (v1.01)"
-	serial "ULJM-05690"
-	serial "ULJM-05690"
+	rom ( serial "ULJM-05690" )
 )
 
 game (
 	name "D.C.I&II P.S.P. -Da Capo I&II- Plus Situation Portable (Japan)"
-	serial "ULJM-05718"
-	serial "ULJM-05718"
-)
-
-game (
-	name "D.C.I&II P.S.P. -Da Capo I&II- Plus Situation Portable (Japan)"
-	serial "ULJM-05718"
-	serial "ULJM-05718"
+	rom ( serial "ULJM-05718" )
 )
 
 game (
 	name "DJ Max Emotional Sense P 2 - Sound Miracle (Korea) (En,Ja,Ko) (v1.09)"
-	serial "ULKS-46116"
-	serial "ULKS-46116"
+	rom ( serial "ULKS-46116" )
 )
 
 game (
 	name "DJ Max Fever (USA) (v1.03)"
-	serial "ULUS-10403"
-	serial "ULUS-10403"
+	rom ( serial "ULUS-10403" )
 )
 
 game (
 	name "DJ Max Portable (Korea) (v1.02) (International)"
-	serial "ULKS-46059"
-	serial "ULKS-46059"
+	rom ( serial "ULKS-46059" )
 )
 
 game (
 	name "DJ Max Portable - Hottunes (Korea) (En,Ja,Ko) (v1.02) [b]"
-	serial "ULKS-46240"
-	serial "ULKS-46240"
+	rom ( serial "ULKS-46240" )
 )
 
 game (
 	name "DJ Max Portable 3 (Japan) (v1.01)"
-	serial "ULJM-05836"
-	serial "ULJM-05836"
+	rom ( serial "ULJM-05836" )
 )
 
 game (
 	name "DJ Max Portable 3 (Korea) (En,Ja,Ko) (v1.08) [b]"
-	serial "ULKS-46236"
-	serial "ULKS-46236"
+	rom ( serial "ULKS-46236" )
 )
 
 game (
 	name "DJ Max Portable 3 (USA) (v1.01)"
-	serial "ULUS-10538"
-	serial "ULUS-10538"
+	rom ( serial "ULUS-10538" )
 )
 
 game (
 	name "DJ Max Portable Emotional Sense - Black Square (Japan) (v1.01)"
-	serial "ULJM-06034"
-	serial "ULJM-06034"
+	rom ( serial "ULJM-06034" )
 )
 
 game (
 	name "DJ Max Portable Emotional Sense - Clazziquai Edition (Korea) (En,Ja,Ko) (v1.04)"
-	serial "ULKS-46190"
-	serial "ULKS-46190"
+	rom ( serial "ULKS-46190" )
 )
 
 game (
 	name "DT Carnage (USA) (v1.01)"
-	serial "ULUS-10406"
-	serial "ULUS-10406"
+	rom ( serial "ULUS-10406" )
 )
 
 game (
 	name "Dai-2-Ji Super Robot Taisen Z Hakai-hen (Japan) (v1.01)"
-	serial "ULJS-00379"
-	serial "ULJS-00379"
+	rom ( serial "ULJS-00379" )
 )
 
 game (
 	name "Dai-2-Ji Super Robot Taisen Z Saisei-hen (Japan) (v1.01)"
-	serial "ULJS-00460"
-	serial "ULJS-00460"
+	rom ( serial "ULJS-00460" )
 )
 
 game (
 	name "Daikoukai Jidai IV - Rota Nova (Japan) (v1.03)"
-	serial "ULJM-05096"
-	serial "ULJM-05096"
+	rom ( serial "ULJM-05096" )
 )
 
 game (
 	name "Daikuugun (Japan) (v1.03)"
-	serial "ULJM-05572"
-	serial "ULJM-05572"
+	rom ( serial "ULJM-05572" )
 )
 
 game (
 	name "Daisenryaku - Daitoua Kouboushi - Tora Tora Tora Ware Kishuu ni Seikou Seri (Japan) (v1.01)"
-	serial "ULJS-00147"
-	serial "ULJS-00147"
+	rom ( serial "ULJS-00147" )
 )
 
 game (
 	name "Daisenryaku Perfect - Senjou no Hasha (Japan) (v1.02)"
-	serial "ULJS-00289"
-	serial "ULJS-00289"
+	rom ( serial "ULJS-00289" )
 )
 
 game (
 	name "Daisenryaku Portable (Japan) (v1.03)"
-	serial "ULJM-05068"
-	serial "ULJM-05068"
+	rom ( serial "ULJM-05068" )
 )
 
 game (
 	name "Daisenryaku Portable 2 (Japan) (v1.01)"
-	serial "ULJM-05205"
-	serial "ULJM-05205"
+	rom ( serial "ULJM-05205" )
 )
 
 game (
 	name "Daisenryaku VII Exceed (Japan) (v1.01)"
-	serial "ULJS-00126"
-	serial "ULJS-00126"
+	rom ( serial "ULJS-00126" )
 )
 
 game (
 	name "Daito Giken Koushiki Pachi-Slot Simulator - Hihouden - Fuujirareta Megami Portable (Japan) (v1.01)"
-	serial "NPJH-50405"
-	serial "NPJH-50405"
+	rom ( serial "NPJH-50405" )
 )
 
 game (
 	name "Daito Giken Koushiki Pachi-Slot Simulator - Ossu! Banchou Portable (Japan) (v1.01)"
-	serial "ULJS-00052"
-	serial "ULJS-00052"
+	rom ( serial "ULJS-00052" )
 )
 
 game (
 	name "Daito Giken Koushiki Pachi-Slot Simulator - Ossu! Misao + Maguro Densetsu Portable (Japan) (v1.02)"
-	serial "NPJH-50271"
-	serial "NPJH-50271"
+	rom ( serial "NPJH-50271" )
 )
 
 game (
 	name "Daito Giken Koushiki Pachi-Slot Simulator - Yoshimune Portable (Japan) (v1.02)"
-	serial "ULJS-00060"
-	serial "ULJS-00060"
+	rom ( serial "ULJS-00060" )
 )
 
 game (
 	name "Danball Senki (Japan) (v1.04)"
-	serial "ULJS-00361"
-	serial "ULJS-00361"
+	rom ( serial "ULJS-00361" )
 )
 
 game (
 	name "Danball Senki Boost (Japan) (v1.03)"
-	serial "ULJM-05990"
-	serial "ULJM-05990"
+	rom ( serial "ULJM-05990" )
 )
 
 game (
 	name "Dangan-Ronpa - Kibou no Gakuen to Zetsubou no Koukousei (Japan) (PSP The Best)"
-	serial "NPJH-50515"
-	serial "NPJH-50515"
+	rom ( serial "NPJH-50515" )
 )
 
 game (
 	name "Dangan-Ronpa - Kibou no Gakuen to Zetsubou no Koukousei (Japan) (v1.03)"
-	serial "NPJH-50372"
-	serial "NPJH-50372"
+	rom ( serial "NPJH-50372" )
 )
 
 game (
 	name "Dante's Inferno (Asia) (v1.01)"
-	serial "ULUS-10469"
-	serial "ULUS-10469"
+	rom ( serial "ULUS-10469" )
 )
 
 game (
 	name "Dante's Inferno (Europe)"
-	serial "ULES-01384"
-	serial "ULES-01384"
+	rom ( serial "ULES-01384" )
 )
 
 game (
 	name "Dante's Inferno (France)"
-	serial "ULES-01385"
-	serial "ULES-01385"
+	rom ( serial "ULES-01385" )
 )
 
 game (
 	name "Dante's Inferno (Germany)"
-	serial "ULES-01387"
-	serial "ULES-01387"
+	rom ( serial "ULES-01387" )
 )
 
 game (
 	name "Dante's Inferno (Italy)"
-	serial "ULES-01386"
-	serial "ULES-01386"
+	rom ( serial "ULES-01386" )
 )
 
 game (
 	name "Dante's Inferno (Spain)"
-	serial "ULES-01388"
-	serial "ULES-01388"
+	rom ( serial "ULES-01388" )
 )
 
 game (
 	name "Dante's Inferno (USA) (v1.01)"
-	serial "ULUS-10469"
-	serial "ULUS-10469"
 )
 
 game (
 	name "Danzai no Maria - La Campanella (Japan) (v1.04)"
-	serial "ULJM-06078"
-	serial "ULJM-06078"
+	rom ( serial "ULJM-06078" )
 )
 
 game (
 	name "Darius Burst (Japan) (v1.01)"
-	serial "ULJM-05558"
-	serial "ULJM-05558"
+	rom ( serial "ULJM-05558" )
 )
 
 game (
 	name "Darkstalkers Chronicle - The Chaos Tower (Europe)"
-	serial "ULES-00016"
-	serial "ULES-00016"
+	rom ( serial "ULES-00016" )
 )
 
 game (
 	name "Darkstalkers Chronicle - The Chaos Tower (USA)"
-	serial "ULUS-10005"
-	serial "ULUS-10005"
+	rom ( serial "ULUS-10005" )
 )
 
 game (
 	name "Dave Mirra BMX Challenge (Europe) (v1.01)"
-	serial "ULES-00773"
-	serial "ULES-00773"
+	rom ( serial "ULES-00773" )
 )
 
 game (
 	name "Dave Mirra BMX Challenge (USA)"
-	serial "ULUS-10204"
-	serial "ULUS-10204"
+	rom ( serial "ULUS-10204" )
 )
 
 game (
 	name "Daxter (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00044"
-	serial "UCES-00044"
+	rom ( serial "UCES-00044" )
 )
 
 game (
 	name "Daxter (Korea) (En,Fr,De,Es,It,Ko)"
-	serial "UCKS-45025"
-	serial "UCKS-45025"
+	rom ( serial "UCKS-45025" )
 )
 
 game (
 	name "Daxter (USA)"
-	serial "UCUS-98618"
-	serial "UCUS-98618"
+	rom ( serial "UCUS-98618" )
 )
 
 game (
 	name "Daxter (USA) (v1.01) (Demo)"
-	serial "UCUS-98654"
-	serial "UCUS-98654"
+	rom ( serial "UCUS-98654" )
 )
 
 game (
 	name "Dead End - Orchestral Manoeuvres in the Dead End (Japan) (v1.04)"
-	serial "ULJM-05907"
-	serial "ULJM-05907"
+	rom ( serial "ULJM-05907" )
 )
 
 game (
 	name "Dead Head Fred (Asia)"
-	serial "ULUS-10288"
-	serial "ULUS-10288"
+	rom ( serial "ULUS-10288" )
 )
 
 game (
 	name "Dead Head Fred (Europe)"
-	serial "ULES-00902"
-	serial "ULES-00902"
+	rom ( serial "ULES-00902" )
 )
 
 game (
 	name "Dead Head Fred (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00903"
-	serial "ULES-00903"
+	rom ( serial "ULES-00903" )
 )
 
 game (
 	name "Dead Head Fred (USA) (Demo)"
-	serial "ULUS-90002"
-	serial "ULUS-90002"
+	rom ( serial "ULUS-90002" )
 )
 
 game (
 	name "Dead Head Fred (USA) (v1.02)"
-	serial "ULUS-10288"
-	serial "ULUS-10288"
 )
 
 game (
 	name "Dead or Alive - Paradise (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-01431"
-	serial "ULES-01431"
+	rom ( serial "ULES-01431" )
 )
 
 game (
 	name "Dead or Alive - Paradise (Europe) (En,Fr,De) (v1.02)"
-	serial "ULES-01416"
-	serial "ULES-01416"
+	rom ( serial "ULES-01416" )
 )
 
 game (
 	name "Dead or Alive - Paradise (Japan) (v1.02)"
-	serial "NPJH-50239"
-	serial "NPJH-50239"
+	rom ( serial "NPJH-50239" )
 )
 
 game (
 	name "Dead or Alive - Paradise (USA) (v1.01)"
-	serial "ULUS-10521"
-	serial "ULUS-10521"
+	rom ( serial "ULUS-10521" )
 )
 
 game (
 	name "Dead to Rights - Reckoning (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00195"
-	serial "ULES-00195"
+	rom ( serial "ULES-00195" )
 )
 
 game (
 	name "Dead to Rights - Reckoning (USA)"
-	serial "ULUS-10023"
-	serial "ULUS-10023"
+	rom ( serial "ULUS-10023" )
 )
 
 game (
 	name "Deardrops Distortion (Japan) (v1.03)"
-	serial "ULJM-05819"
-	serial "ULJM-05819"
+	rom ( serial "ULJM-05819" )
 )
 
 game (
 	name "Death Connection Portable (Japan) (v1.01)"
-	serial "ULJM-05823"
-	serial "ULJM-05823"
+	rom ( serial "ULJM-05823" )
 )
 
 game (
 	name "Death Jr. (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00144"
-	serial "ULES-00144"
+	rom ( serial "ULES-00144" )
 )
 
 game (
 	name "Death Jr. (USA) (v1.01)"
-	serial "ULUS-10027"
-	serial "ULUS-10027"
+	rom ( serial "ULUS-10027" )
 )
 
 game (
 	name "Death Jr. II - Root of Evil (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00582"
-	serial "ULES-00582"
+	rom ( serial "ULES-00582" )
 )
 
 game (
 	name "Death Jr. II - Root of Evil (USA) (v1.01)"
-	serial "ULUS-10157"
-	serial "ULUS-10157"
+	rom ( serial "ULUS-10157" )
 )
 
 game (
 	name "Def Jam - Fight for NY - The Takeover (Europe)"
-	serial "ULES-00390"
-	serial "ULES-00390"
+	rom ( serial "ULES-00390" )
 )
 
 game (
 	name "Def Jam - Fight for NY - The Takeover (USA) (v1.01)"
-	serial "ULUS-10100"
-	serial "ULUS-10100"
+	rom ( serial "ULUS-10100" )
 )
 
 game (
 	name "Dengeki no Piroto - Tenkuu no Kizuna (Japan) (v1.02)"
-	serial "ULJS-00248"
-	serial "ULJS-00248"
+	rom ( serial "ULJS-00248" )
 )
 
 game (
 	name "Densetsu no Yuusha no Densetsu - Legendary Saga (Japan) (v1.01)"
-	serial "ULJM-05588"
-	serial "ULJM-05588"
+	rom ( serial "ULJM-05588" )
 )
 
 game (
 	name "Densha de Go! Pocket - Chuuousen Hen (Japan) (v1.01)"
-	serial "ULJM-05084"
-	serial "ULJM-05084"
+	rom ( serial "ULJM-05084" )
 )
 
 game (
 	name "Densha de Go! Pocket - Osaka Kanjousen Hen (Japan)"
-	serial "ULJM-05120"
-	serial "ULJM-05120"
+	rom ( serial "ULJM-05120" )
 )
 
 game (
 	name "Densha de Go! Pocket - Tokaidosen Hen (Japan)"
-	serial "ULJM-05152"
-	serial "ULJM-05152"
+	rom ( serial "ULJM-05152" )
 )
 
 game (
 	name "Densha de Go! Pocket - Yamanotesen Hen (Japan) (v1.03)"
-	serial "ULJM-05039"
-	serial "ULJM-05039"
+	rom ( serial "ULJM-05039" )
 )
 
 game (
 	name "Derby Stallion P (Japan) (v1.03)"
-	serial "ULJS-00045"
-	serial "ULJS-00045"
+	rom ( serial "ULJS-00045" )
 )
 
 game (
 	name "Derby Time (Japan) (v1.06)"
-	serial "UCJS-10006"
-	serial "UCJS-10006"
+	rom ( serial "UCJS-10006" )
 )
 
 game (
 	name "Derby Time 2006 (Japan) (v1.03)"
-	serial "UCJS-10027"
-	serial "UCJS-10027"
+	rom ( serial "UCJS-10027" )
 )
 
 game (
 	name "Despicable Me (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
-	serial "ULES-01447"
-	serial "ULES-01447"
+	rom ( serial "ULES-01447" )
 )
 
 game (
 	name "Diabolik - The Original Sin (Europe) (En,Fr,De,Es,It) (v1.05)"
-	serial "ULES-01248"
-	serial "ULES-01248"
+	rom ( serial "ULES-01248" )
 )
 
 game (
 	name "Diabolik Lovers - Haunted Dark Bridal (Japan) (v1.02)"
-	serial "ULJM-06163"
-	serial "ULJM-06163"
+	rom ( serial "ULJM-06163" )
 )
 
 game (
 	name "Dice Dice Fantasia (Japan) (v1.01)"
-	serial "ULJM-05568"
-	serial "ULJM-05568"
+	rom ( serial "ULJM-05568" )
 )
 
 game (
 	name "Dies Irae - Amantes Amentes (Japan) (v1.02)"
-	serial "ULJM-06107"
-	serial "ULJM-06107"
-)
-
-game (
-	name "Dies Irae - Amantes Amentes (Japan) (v1.02)"
-	serial "ULJM-06107"
-	serial "ULJM-06107"
+	rom ( serial "ULJM-06107" )
 )
 
 game (
 	name "Diner Dash (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00755"
-	serial "ULES-00755"
+	rom ( serial "ULES-00755" )
 )
 
 game (
 	name "Disgaea - Afternoon of Darkness (Asia)"
-	serial "ULUS-10308"
-	serial "ULUS-10308"
+	rom ( serial "ULUS-10308" )
 )
 
 game (
 	name "Disgaea - Afternoon of Darkness (Europe)"
-	serial "ULES-00999"
-	serial "ULES-00999"
+	rom ( serial "ULES-00999" )
 )
 
 game (
 	name "Disgaea - Afternoon of Darkness (USA)"
-	serial "ULUS-10308"
-	serial "ULUS-10308"
 )
 
 game (
 	name "Disgaea 2 - Dark Hero Days (Europe) (v1.01)"
-	serial "ULES-01392"
-	serial "ULES-01392"
+	rom ( serial "ULES-01392" )
 )
 
 game (
 	name "Disgaea 2 - Dark Hero Days (USA) (v1.02)"
-	serial "ULUS-10461"
-	serial "ULUS-10461"
+	rom ( serial "ULUS-10461" )
 )
 
 game (
 	name "Disgaea Infinite (Japan)"
-	serial "ULJS-00286"
-	serial "ULJS-00286"
+	rom ( serial "ULJS-00286" )
 )
 
 game (
 	name "Disgaea Infinite (USA) (v1.01)"
-	serial "ULUS-10522"
-	serial "ULUS-10522"
+	rom ( serial "ULUS-10522" )
 )
 
 game (
 	name "Dissidia - Final Fantasy (Asia)"
-	serial "ULUS-10437"
-	serial "ULUS-10437"
+	rom ( serial "ULUS-10437" )
 )
 
 game (
 	name "Dissidia - Final Fantasy (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01270"
-	serial "ULES-01270"
+	rom ( serial "ULES-01270" )
 )
 
 game (
 	name "Dissidia - Final Fantasy (Japan) (v1.03)"
-	serial "ULJM-05262"
-	serial "ULJM-05262"
+	rom ( serial "ULJM-05262" )
 )
 
 game (
 	name "Dissidia - Final Fantasy (Russia)"
-	serial "UCES-01229"
-	serial "UCES-01229"
+	rom ( serial "UCES-01229" )
 )
 
 game (
 	name "Dissidia - Final Fantasy (USA)"
-	serial "ULUS-10437"
-	serial "ULUS-10437"
 )
 
 game (
 	name "Dissidia - Final Fantasy (USA) (Demo)"
-	serial "NPUH-90029"
-	serial "NPUH-90029"
+	rom ( serial "NPUH-90029" )
 )
 
 game (
 	name "Dissidia 012 - Duodecim Final Fantasy (Asia) (En,Zh,Ko)"
-	serial "NPHH-00293"
-	serial "NPHH-00293"
+	rom ( serial "NPHH-00293" )
 )
 
 game (
 	name "Dissidia 012 - Duodecim Final Fantasy (Europe)"
-	serial "ULES-01505"
-	serial "ULES-01505"
+	rom ( serial "ULES-01505" )
 )
 
 game (
 	name "Dissidia 012 - Duodecim Final Fantasy (Japan)"
-	serial "NPJH-50377"
-	serial "NPJH-50377"
+	rom ( serial "NPJH-50377" )
 )
 
 game (
 	name "Dissidia 012 - Duodecim Final Fantasy (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10566"
-	serial "ULUS-10566"
+	rom ( serial "ULUS-10566" )
 )
 
 game (
 	name "Dog, The - Happy Life - Shiawase Wanko Seikatsu Dai Ichidan (Japan) (v1.01) (Promo) (McDonald's Ver.)"
-	serial "ULJM-95002"
-	serial "ULJM-95002"
+	rom ( serial "ULJM-95002" )
 )
 
 game (
 	name "Dog, The - Happy Life - Shiawase Wanko Seikatsu Dai Ichidan (Japan) (v1.02)"
-	serial "ULJM-05122"
-	serial "ULJM-05122"
+	rom ( serial "ULJM-05122" )
 )
 
 game (
 	name "Doki Doki Suikoden (Japan) (v1.02)"
-	serial "ULJS-00380"
-	serial "ULJS-00380"
+	rom ( serial "ULJS-00380" )
 )
 
 game (
 	name "Dokodemo Issho (Japan) (v1.01)"
-	serial "UCJS-10002"
-	serial "UCJS-10002"
+	rom ( serial "UCJS-10002" )
 )
 
 game (
 	name "Dokodemo Issho - Let's Gakkou! (Japan) (v1.01)"
-	serial "UCJS-10039"
-	serial "UCJS-10039"
+	rom ( serial "UCJS-10039" )
 )
 
 game (
 	name "Dokodemo Issho - Let's Gakkou! (Japan) (v1.01) (Obenkyou Pack)"
-	serial "UCJB-98010"
-	serial "UCJB-98010"
+	rom ( serial "UCJB-98010" )
 )
 
 game (
 	name "Donkey Xote (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00836"
-	serial "ULES-00836"
+	rom ( serial "ULES-00836" )
 )
 
 game (
 	name "Dora-Slot - Hana Hana Matsuri Da!! (Japan) (v1.01)"
-	serial "ULJM-05478"
-	serial "ULJM-05478"
+	rom ( serial "ULJM-05478" )
 )
 
 game (
 	name "Dora-Slot - Kyojin no Hoshi II (Japan) (v1.01)"
-	serial "ULJM-05027"
-	serial "ULJM-05027"
+	rom ( serial "ULJM-05027" )
 )
 
 game (
 	name "Dora-Slot - Kyojin no Hoshi II (Japan) (v2.02)"
-	serial "ULJM-05027"
-	serial "ULJM-05027"
 )
 
 game (
 	name "Dora-Slot - Oki-Slot-Ou! Pioneer 12 (Japan) (v1.04)"
-	serial "ULJM-05069"
-	serial "ULJM-05069"
+	rom ( serial "ULJM-05069" )
 )
 
 game (
 	name "Dora-Slot - Shuyaku wa Zenigata (Japan) (v1.03)"
-	serial "ULJM-05014"
-	serial "ULJM-05014"
+	rom ( serial "ULJM-05014" )
 )
 
 game (
 	name "DotHack-Link (Japan) (v1.01)"
-	serial "ULJS-00266"
-	serial "ULJS-00266"
+	rom ( serial "ULJS-00266" )
 )
 
 game (
 	name "Downstream Panic! (USA)"
-	serial "ULUS-10322"
-	serial "ULUS-10322"
+	rom ( serial "ULUS-10322" )
 )
 
 game (
 	name "Dragon Ball Evolution (Asia)"
-	serial "ULUS-10415"
-	serial "ULUS-10415"
+	rom ( serial "ULUS-10415" )
 )
 
 game (
 	name "Dragon Ball Evolution (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01227"
-	serial "ULES-01227"
+	rom ( serial "ULES-01227" )
 )
 
 game (
 	name "Dragon Ball Evolution (Japan)"
-	serial "ULJS-00184"
-	serial "ULJS-00184"
+	rom ( serial "ULJS-00184" )
 )
 
 game (
 	name "Dragon Ball Evolution (USA)"
-	serial "ULUS-10415"
-	serial "ULUS-10415"
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00309"
-	serial "ULES-00309"
+	rom ( serial "ULES-00309" )
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai (Japan) (v1.02)"
-	serial "ULJS-00049"
-	serial "ULJS-00049"
+	rom ( serial "ULJS-00049" )
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai (USA)"
-	serial "ULUS-10081"
-	serial "ULUS-10081"
+	rom ( serial "ULUS-10081" )
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai 2 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00789"
-	serial "ULES-00789"
+	rom ( serial "ULES-00789" )
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai 2 (Japan) (Kiosk Demo)"
-	serial "ULJM-91010"
-	serial "ULJM-91010"
+	rom ( serial "ULJM-91010" )
 )
 
 game (
 	name "Dragon Ball Z - Shin Budokai 2 (Japan) (v1.02)"
-	serial "ULJS-00107"
-	serial "ULJS-00107"
+	rom ( serial "ULJS-00107" )
 )
 
 game (
 	name "Dragon Ball Z - Tenkaichi Tag Team (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01456"
-	serial "ULES-01456"
+	rom ( serial "ULES-01456" )
 )
 
 game (
 	name "Dragon Ball Z - Tenkaichi Tag Team (USA) (En,Fr,Es)"
-	serial "ULUS-10537"
-	serial "ULUS-10537"
+	rom ( serial "ULUS-10537" )
 )
 
 game (
 	name "Dragon Dance (Japan)"
-	serial "ULJM-05407"
-	serial "ULJM-05407"
+	rom ( serial "ULJM-05407" )
 )
 
 game (
 	name "Dragon Quest & Final Fantasy in Itadaki Street Portable (Japan) (v1.02)"
-	serial "ULJM-05127"
-	serial "ULJM-05127"
+	rom ( serial "ULJM-05127" )
 )
 
 game (
 	name "Dragoneer's Aria (Asia)"
-	serial "ULUS-10291"
-	serial "ULUS-10291"
+	rom ( serial "ULUS-10291" )
 )
 
 game (
 	name "Dragoneer's Aria (Europe)"
-	serial "ULES-01004"
-	serial "ULES-01004"
+	rom ( serial "ULES-01004" )
 )
 
 game (
 	name "Dragoneer's Aria (USA)"
-	serial "ULUS-10291"
-	serial "ULUS-10291"
 )
 
 game (
 	name "Dream C Club Portable (Japan) (v1.01)"
-	serial "ULJS-00333"
-	serial "ULJS-00333"
+	rom ( serial "ULJS-00333" )
 )
 
 game (
 	name "Driver 76 (Europe) (v1.01)"
-	serial "ULES-00740"
-	serial "ULES-00740"
+	rom ( serial "ULES-00740" )
 )
 
 game (
 	name "Driver 76 (USA)"
-	serial "ULUS-10235"
-	serial "ULUS-10235"
+	rom ( serial "ULUS-10235" )
 )
 
 game (
 	name "Dunamis15 (Japan) (v1.01)"
-	serial "ULJM-06119"
-	serial "ULJM-06119"
+	rom ( serial "ULJM-06119" )
 )
 
 game (
 	name "Dungeon Explorer (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00847"
-	serial "ULES-00847"
+	rom ( serial "ULES-00847" )
 )
 
 game (
 	name "Dungeon Maker - Hunting Ground (USA) (v1.01)"
-	serial "ULUS-10282"
-	serial "ULUS-10282"
+	rom ( serial "ULUS-10282" )
 )
 
 game (
 	name "Dungeon Maker II - The Hidden War (USA) (v1.01)"
-	serial "ULUS-10393"
-	serial "ULUS-10393"
+	rom ( serial "ULUS-10393" )
 )
 
 game (
 	name "Dungeon Siege - Throne of Agony (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00569"
-	serial "ULES-00569"
+	rom ( serial "ULES-00569" )
 )
 
 game (
 	name "Dungeon Siege - Throne of Agony (USA) (v1.02)"
-	serial "ULUS-10177"
-	serial "ULUS-10177"
+	rom ( serial "ULUS-10177" )
 )
 
 game (
 	name "Dungeons & Dragons Tactics (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00721"
-	serial "ULES-00721"
+	rom ( serial "ULES-00721" )
 )
 
 game (
 	name "Dungeons & Dragons Tactics (USA) (v1.01)"
-	serial "ULUS-10232"
-	serial "ULUS-10232"
+	rom ( serial "ULUS-10232" )
 )
 
 game (
 	name "Durarara!! 3way Standoff (Japan) (v1.01)"
-	serial "ULJS-00318"
-	serial "ULJS-00318"
+	rom ( serial "ULJS-00318" )
 )
 
 game (
 	name "Durarara!! 3way Standoff - Alley (Japan) (v1.01)"
-	serial "NPJH-50484"
-	serial "NPJH-50484"
+	rom ( serial "NPJH-50484" )
 )
 
 game (
 	name "Dynasty Warriors (Europe)"
-	serial "ULES-00026"
-	serial "ULES-00026"
+	rom ( serial "ULES-00026" )
 )
 
 game (
 	name "Dynasty Warriors (France) (v1.01)"
-	serial "ULES-00118"
-	serial "ULES-00118"
+	rom ( serial "ULES-00118" )
 )
 
 game (
 	name "Dynasty Warriors (Germany) (v1.01)"
-	serial "ULES-00119"
-	serial "ULES-00119"
+	rom ( serial "ULES-00119" )
 )
 
 game (
 	name "Dynasty Warriors (Korea) (v1.02)"
-	serial "ULKS-46012"
-	serial "ULKS-46012"
+	rom ( serial "ULKS-46012" )
 )
 
 game (
 	name "Dynasty Warriors (USA)"
-	serial "ULUS-10004"
-	serial "ULUS-10004"
+	rom ( serial "ULUS-10004" )
 )
 
 game (
 	name "Dynasty Warriors - Strikeforce (Europe) (En,Fr,De)"
-	serial "ULES-01221"
-	serial "ULES-01221"
+	rom ( serial "ULES-01221" )
 )
 
 game (
 	name "Dynasty Warriors - Strikeforce (USA)"
-	serial "ULUS-10416"
-	serial "ULUS-10416"
+	rom ( serial "ULUS-10416" )
 )
 
 game (
 	name "Dynasty Warriors Vol. 2 (Europe)"
-	serial "ULES-00604"
-	serial "ULES-00604"
+	rom ( serial "ULES-00604" )
 )
 
 game (
 	name "Dynasty Warriors Vol. 2 (France)"
-	serial "ULES-00605"
-	serial "ULES-00605"
+	rom ( serial "ULES-00605" )
 )
 
 game (
 	name "Dynasty Warriors Vol. 2 (Germany)"
-	serial "ULES-00606"
-	serial "ULES-00606"
+	rom ( serial "ULES-00606" )
 )
 
 game (
 	name "Dynasty Warriors Vol. 2 (USA)"
-	serial "ULUS-10170"
-	serial "ULUS-10170"
+	rom ( serial "ULUS-10170" )
 )
 
 game (
 	name "E'tude Prologue - Yureugoku Kokoro no Katachi Portable (Japan) (v1.02)"
-	serial "ULJM-05252"
-	serial "ULJM-05252"
+	rom ( serial "ULJM-05252" )
 )
 
 game (
 	name "EA Replay (Europe) (En,De,Es,It,Nl) (v1.02)"
-	serial "ULES-00592"
-	serial "ULES-00592"
+	rom ( serial "ULES-00592" )
 )
 
 game (
 	name "EA Replay (USA) (v1.01)"
-	serial "ULUS-10140"
-	serial "ULUS-10140"
+	rom ( serial "ULUS-10140" )
 )
 
 game (
 	name "Echochrome (Europe) (En,Fr,De,Es,It) (Demo)"
-	serial "UCED-01060"
-	serial "UCED-01060"
+	rom ( serial "UCED-01060" )
 )
 
 game (
 	name "Echochrome (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru)"
-	serial "UCES-01011"
-	serial "UCES-01011"
+	rom ( serial "UCES-01011" )
 )
 
 game (
 	name "Echoshift (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru)"
-	serial "UCES-01313"
-	serial "UCES-01313"
+	rom ( serial "UCES-01313" )
 )
 
 game (
 	name "Echoshift (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru) (v2.00)"
-	serial "UCES-01313"
-	serial "UCES-01313"
 )
 
 game (
 	name "Eien no Aseria - Kono Daichi no Hate de (Japan) (v1.02)"
-	serial "ULJM-06017"
-	serial "ULJM-06017"
+	rom ( serial "ULJM-06017" )
 )
 
 game (
 	name "Eiyuu Densetsu - Ao no Kiseki (Japan) (v1.01)"
-	serial "NPJH-50473"
-	serial "NPJH-50473"
+	rom ( serial "NPJH-50473" )
 )
 
 game (
 	name "Eiyuu Densetsu - Sora no Kiseki SC (Japan)"
-	serial "ULJM-05278"
-	serial "ULJM-05278"
-)
-
-game (
-	name "Eiyuu Densetsu - Sora no Kiseki SC (Japan)"
-	serial "ULJM-05278"
-	serial "ULJM-05278"
+	rom ( serial "ULJM-05278" )
 )
 
 game (
 	name "Eiyuu Densetsu - Sora no Kiseki the 3rd (Japan) (v1.01)"
-	serial "ULJM-05353"
-	serial "ULJM-05353"
+	rom ( serial "ULJM-05353" )
 )
 
 game (
 	name "Eiyuu Densetsu - Zero no Kiseki (Japan) (v1.01)"
-	serial "NPJH-50311"
-	serial "NPJH-50311"
+	rom ( serial "NPJH-50311" )
 )
 
 game (
 	name "Elder Scrolls Travels, The - Oblivion (USA) (Beta) (01-02-2007)"
-	serial "ABCD-01234561"
-	serial "ABCD-01234561"
+	rom ( serial "ABCD-01234561" )
 )
 
 game (
 	name "Elder Scrolls Travels, The - Oblivion (USA) (Beta) (09-06-2006)"
-	serial "UCUS-12345"
-	serial "UCUS-12345"
+	rom ( serial "UCUS-12345" )
 )
 
 game (
 	name "Elder Scrolls Travels, The - Oblivion (USA) (Beta) (21-11-2006)"
-	serial "ABCD-01234561"
-	serial "ABCD-01234561"
 )
 
 game (
 	name "Elder Scrolls Travels, The - Oblivion (USA) (Beta) (27-04-2007)"
-	serial "ABCD-01234561"
-	serial "ABCD-01234561"
 )
 
 game (
 	name "Elder Scrolls Travels, The - Oblivion (USA) (Beta) (31-01-2007)"
-	serial "ABCD-01234561"
-	serial "ABCD-01234561"
 )
 
 game (
 	name "Elkrone no Atelier - Dear for Otomate (Japan) (v1.01)"
-	serial "ULJM-06046"
-	serial "ULJM-06046"
+	rom ( serial "ULJM-06046" )
 )
 
 game (
 	name "Elminage Gothic - Ulm Zakir to Yami no Gishiki (Japan) (v1.01)"
-	serial "ULJM-06091"
-	serial "ULJM-06091"
+	rom ( serial "ULJM-06091" )
 )
 
 game (
 	name "Elminage II - Sousei no Megami to Unmei no Daichi (Japan) (v1.01)"
-	serial "ULJM-05488"
-	serial "ULJM-05488"
+	rom ( serial "ULJM-05488" )
 )
 
 game (
 	name "Elminage III - Ankoku no Shito to Taiyou no Kyuuden (Japan) (v1.03)"
-	serial "ULJM-05883"
-	serial "ULJM-05883"
+	rom ( serial "ULJM-05883" )
 )
 
 game (
 	name "Elminage Ibun - Ame no Mihashira (Japan) (v1.02)"
-	serial "ULJM-06141"
-	serial "ULJM-06141"
+	rom ( serial "ULJM-06141" )
 )
 
 game (
 	name "Enkaku Sousa - Shinjitsu eno 23nichikan (Japan)"
-	serial "UCJS-10088"
-	serial "UCJS-10088"
+	rom ( serial "UCJS-10088" )
 )
 
 game (
 	name "Entaku no Seito - The Eternal Legend (Japan)"
-	serial "ULJS-00548"
-	serial "ULJS-00548"
+	rom ( serial "ULJS-00548" )
 )
 
 game (
 	name "Eragon (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00474"
-	serial "ULES-00474"
+	rom ( serial "ULES-00474" )
 )
 
 game (
 	name "Eragon (Russia)"
-	serial "ULES-00475"
-	serial "ULES-00475"
+	rom ( serial "ULES-00475" )
 )
 
 game (
 	name "Eragon (USA) (v1.03)"
-	serial "ULUS-10146"
-	serial "ULUS-10146"
+	rom ( serial "ULUS-10146" )
 )
 
 game (
 	name "Eternal Etude - Canvas 4 (Japan) (v1.01)"
-	serial "ULJM-05980"
-	serial "ULJM-05980"
+	rom ( serial "ULJM-05980" )
 )
 
 game (
 	name "Evangelion - Jo (Japan) (v1.02)"
-	serial "ULJS-00201"
-	serial "ULJS-00201"
+	rom ( serial "ULJS-00201" )
 )
 
 game (
 	name "Evangelion Shin Gekijouban - 3nd Impact (Japan)"
-	serial "NPJH-50457"
-	serial "NPJH-50457"
+	rom ( serial "NPJH-50457" )
 )
 
 game (
 	name "Ever17 - The Out of Infinity Premium Edition (Japan)"
-	serial "ULJM-05437"
-	serial "ULJM-05437"
+	rom ( serial "ULJM-05437" )
 )
 
 game (
 	name "Every Extend Extra (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00468"
-	serial "ULES-00468"
+	rom ( serial "ULES-00468" )
 )
 
 game (
 	name "Every Extend Extra (Japan) (v1.02)"
-	serial "ULJS-00054"
-	serial "ULJS-00054"
+	rom ( serial "ULJS-00054" )
 )
 
 game (
 	name "Every Extend Extra (USA)"
-	serial "ULUS-10147"
-	serial "ULUS-10147"
+	rom ( serial "ULUS-10147" )
 )
 
 game (
 	name "Everybody's Golf (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00012"
-	serial "UCES-00012"
+	rom ( serial "UCES-00012" )
 )
 
 game (
 	name "Everybody's Golf 2 (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00767"
-	serial "UCES-00767"
+	rom ( serial "UCES-00767" )
 )
 
 game (
 	name "Everybody's Tennis (Asia) (En,Zh) (v1.01)"
-	serial "UCAS-40307"
-	serial "UCAS-40307"
+	rom ( serial "UCAS-40307" )
 )
 
 game (
 	name "Everybody's Tennis (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-01420"
-	serial "UCES-01420"
+	rom ( serial "UCES-01420" )
 )
 
 game (
 	name "Exit (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00285"
-	serial "ULES-00285"
+	rom ( serial "ULES-00285" )
 )
 
 game (
 	name "Exit (Japan)"
-	serial "ULJM-05062"
-	serial "ULJM-05062"
+	rom ( serial "ULJM-05062" )
 )
 
 game (
 	name "Exit (Korea)"
-	serial "ULKS-46054"
-	serial "ULKS-46054"
+	rom ( serial "ULKS-46054" )
 )
 
 game (
 	name "Exit (USA)"
-	serial "ULUS-10074"
-	serial "ULUS-10074"
+	rom ( serial "ULUS-10074" )
 )
 
 game (
 	name "Exit 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00620"
-	serial "ULES-00620"
+	rom ( serial "ULES-00620" )
 )
 
 game (
 	name "Eye of Judgment, The - Legends (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-01334"
-	serial "UCES-01334"
+	rom ( serial "UCES-01334" )
 )
 
 game (
 	name "EyePet (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru) (v1.01)"
-	serial "UCES-01462"
-	serial "UCES-01462"
+	rom ( serial "UCES-01462" )
 )
 
 game (
 	name "EyePet (USA) (En,Fr,Es,Pt)"
-	serial "UCUS-98759"
-	serial "UCUS-98759"
+	rom ( serial "UCUS-98759" )
 )
 
 game (
 	name "EyePet Adventures (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru)"
-	serial "UCES-01531"
-	serial "UCES-01531"
+	rom ( serial "UCES-01531" )
 )
 
 game (
 	name "Eyeshield 21 - Portable Edition (Japan) (v1.01)"
-	serial "ULJM-05108"
-	serial "ULJM-05108"
+	rom ( serial "ULJM-05108" )
 )
 
 game (
 	name "F1 2009 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01355"
-	serial "ULES-01355"
+	rom ( serial "ULES-01355" )
 )
 
 game (
 	name "F1 2009 (Japan) (v1.02)"
-	serial "NPJH-50007"
-	serial "NPJH-50007"
+	rom ( serial "NPJH-50007" )
 )
 
 game (
 	name "F1 Grand Prix (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00004"
-	serial "UCES-00004"
+	rom ( serial "UCES-00004" )
 )
 
 game (
 	name "F1 Grand Prix (Europe) (En,Fr,De,Es,It) (v2.00) (Platinum)"
-	serial "UCES-00004"
-	serial "UCES-00004"
 )
 
 game (
 	name "FIFA 06 (Europe)"
-	serial "ULES-00161"
-	serial "ULES-00161"
+	rom ( serial "ULES-00161" )
 )
 
 game (
 	name "FIFA 06 (France)"
-	serial "ULES-00162"
-	serial "ULES-00162"
+	rom ( serial "ULES-00162" )
 )
 
 game (
 	name "FIFA 06 (Germany)"
-	serial "ULES-00163"
-	serial "ULES-00163"
+	rom ( serial "ULES-00163" )
 )
 
 game (
 	name "FIFA 06 (Italy)"
-	serial "ULES-00164"
-	serial "ULES-00164"
+	rom ( serial "ULES-00164" )
 )
 
 game (
 	name "FIFA 06 (Japan) (v1.02)"
-	serial "ULJM-05061"
-	serial "ULJM-05061"
+	rom ( serial "ULJM-05061" )
 )
 
 game (
 	name "FIFA 06 (Korea) (v1.01)"
-	serial "ULKS-46031"
-	serial "ULKS-46031"
+	rom ( serial "ULKS-46031" )
 )
 
 game (
 	name "FIFA 06 (Spain)"
-	serial "ULES-00165"
-	serial "ULES-00165"
+	rom ( serial "ULES-00165" )
 )
 
 game (
 	name "FIFA 07 (Europe) (v1.02)"
-	serial "ULES-00440"
-	serial "ULES-00440"
+	rom ( serial "ULES-00440" )
 )
 
 game (
 	name "FIFA 07 (France) (v1.02)"
-	serial "ULES-00441"
-	serial "ULES-00441"
+	rom ( serial "ULES-00441" )
 )
 
 game (
 	name "FIFA 07 (Germany) (v1.02)"
-	serial "ULES-00443"
-	serial "ULES-00443"
+	rom ( serial "ULES-00443" )
 )
 
 game (
 	name "FIFA 07 (Italy) (v1.02)"
-	serial "ULES-00442"
-	serial "ULES-00442"
+	rom ( serial "ULES-00442" )
 )
 
 game (
 	name "FIFA 07 (Japan) (v1.02)"
-	serial "ULJM-05191"
-	serial "ULJM-05191"
+	rom ( serial "ULJM-05191" )
 )
 
 game (
 	name "FIFA 07 (Korea) (v1.01)"
-	serial "ULKS-46113"
-	serial "ULKS-46113"
+	rom ( serial "ULKS-46113" )
 )
 
 game (
 	name "FIFA 07 (Netherlands) (v1.02)"
-	serial "ULES-00459"
-	serial "ULES-00459"
+	rom ( serial "ULES-00459" )
 )
 
 game (
 	name "FIFA 07 (Spain) (v1.02)"
-	serial "ULES-00444"
-	serial "ULES-00444"
+	rom ( serial "ULES-00444" )
 )
 
 game (
 	name "FIFA 08 (Asia)"
-	serial "ULAS-42114"
-	serial "ULAS-42114"
+	rom ( serial "ULAS-42114" )
 )
 
 game (
 	name "FIFA 08 (Europe) (v1.01)"
-	serial "ULES-00891"
-	serial "ULES-00891"
+	rom ( serial "ULES-00891" )
 )
 
 game (
 	name "FIFA 08 (France)"
-	serial "ULES-00892"
-	serial "ULES-00892"
+	rom ( serial "ULES-00892" )
 )
 
 game (
 	name "FIFA 08 (Germany)"
-	serial "ULES-00894"
-	serial "ULES-00894"
+	rom ( serial "ULES-00894" )
 )
 
 game (
 	name "FIFA 08 (Portugal)"
-	serial "ULES-00896"
-	serial "ULES-00896"
+	rom ( serial "ULES-00896" )
 )
 
 game (
 	name "FIFA 08 (Spain)"
-	serial "ULES-00895"
-	serial "ULES-00895"
+	rom ( serial "ULES-00895" )
 )
 
 game (
 	name "FIFA 09 (Asia) (En,Es)"
-	serial "ULUS-10369"
-	serial "ULUS-10369"
+	rom ( serial "ULUS-10369" )
 )
 
 game (
 	name "FIFA 09 (Europe) (Pl,Cs,Hu)"
-	serial "ULES-01142"
-	serial "ULES-01142"
+	rom ( serial "ULES-01142" )
 )
 
 game (
 	name "FIFA 09 (Europe) (v1.01)"
-	serial "ULES-01135"
-	serial "ULES-01135"
+	rom ( serial "ULES-01135" )
 )
 
 game (
 	name "FIFA 09 (France)"
-	serial "ULES-01136"
-	serial "ULES-01136"
+	rom ( serial "ULES-01136" )
 )
 
 game (
 	name "FIFA 09 (Germany)"
-	serial "ULES-01137"
-	serial "ULES-01137"
+	rom ( serial "ULES-01137" )
 )
 
 game (
 	name "FIFA 09 (Italy)"
-	serial "ULES-01138"
-	serial "ULES-01138"
+	rom ( serial "ULES-01138" )
 )
 
 game (
 	name "FIFA 09 (Netherlands)"
-	serial "ULES-01141"
-	serial "ULES-01141"
+	rom ( serial "ULES-01141" )
 )
 
 game (
 	name "FIFA 09 (Portugal)"
-	serial "ULES-01143"
-	serial "ULES-01143"
+	rom ( serial "ULES-01143" )
 )
 
 game (
 	name "FIFA 09 (Russia)"
-	serial "ULES-01140"
-	serial "ULES-01140"
+	rom ( serial "ULES-01140" )
 )
 
 game (
 	name "FIFA 09 (Spain)"
-	serial "ULES-01139"
-	serial "ULES-01139"
+	rom ( serial "ULES-01139" )
 )
 
 game (
 	name "FIFA 10 (Asia)"
-	serial "ULES-01322"
-	serial "ULES-01322"
+	rom ( serial "ULES-01322" )
 )
 
 game (
 	name "FIFA 10 (Europe) (Pl,Cs,Hu)"
-	serial "ULES-01328"
-	serial "ULES-01328"
+	rom ( serial "ULES-01328" )
 )
 
 game (
 	name "FIFA 10 (Europe) (v1.01)"
-	serial "ULES-01322"
-	serial "ULES-01322"
 )
 
 game (
 	name "FIFA 10 (France)"
-	serial "ULES-01326"
-	serial "ULES-01326"
+	rom ( serial "ULES-01326" )
 )
 
 game (
 	name "FIFA 10 (Germany)"
-	serial "ULES-01330"
-	serial "ULES-01330"
+	rom ( serial "ULES-01330" )
 )
 
 game (
 	name "FIFA 10 (Italy)"
-	serial "ULES-01325"
-	serial "ULES-01325"
+	rom ( serial "ULES-01325" )
 )
 
 game (
 	name "FIFA 10 (Korea) [b]"
-	serial "NPHH-00061"
-	serial "NPHH-00061"
+	rom ( serial "NPHH-00061" )
 )
 
 game (
 	name "FIFA 10 (Netherlands)"
-	serial "ULES-01324"
-	serial "ULES-01324"
+	rom ( serial "ULES-01324" )
 )
 
 game (
 	name "FIFA 10 (Russia)"
-	serial "ULES-01329"
-	serial "ULES-01329"
+	rom ( serial "ULES-01329" )
 )
 
 game (
 	name "FIFA 10 (Spain) [b]"
-	serial "ULES-01323"
-	serial "ULES-01323"
+	rom ( serial "ULES-01323" )
 )
 
 game (
 	name "FIFA 11 (Europe) (v1.01)"
-	serial "ULES-01475"
-	serial "ULES-01475"
+	rom ( serial "ULES-01475" )
 )
 
 game (
 	name "FIFA 11 (France)"
-	serial "ULES-01476"
-	serial "ULES-01476"
+	rom ( serial "ULES-01476" )
 )
 
 game (
 	name "FIFA 11 (Germany)"
-	serial "ULES-01478"
-	serial "ULES-01478"
+	rom ( serial "ULES-01478" )
 )
 
 game (
 	name "FIFA 11 (Italy)"
-	serial "ULES-01477"
-	serial "ULES-01477"
+	rom ( serial "ULES-01477" )
 )
 
 game (
 	name "FIFA 11 (Italy) (v2.00)"
-	serial "ULES-01477"
-	serial "ULES-01477"
 )
 
 game (
 	name "FIFA 11 (Netherlands)"
-	serial "ULES-01482"
-	serial "ULES-01482"
+	rom ( serial "ULES-01482" )
 )
 
 game (
 	name "FIFA 11 (Poland)"
-	serial "ULES-01483"
-	serial "ULES-01483"
+	rom ( serial "ULES-01483" )
 )
 
 game (
 	name "FIFA 11 (Russia)"
-	serial "ULES-01480"
-	serial "ULES-01480"
+	rom ( serial "ULES-01480" )
 )
 
 game (
 	name "FIFA 11 (Spain) [b]"
-	serial "ULES-01479"
-	serial "ULES-01479"
+	rom ( serial "ULES-01479" )
 )
 
 game (
 	name "FIFA 12 (Europe)"
-	serial "ULES-01543"
-	serial "ULES-01543"
+	rom ( serial "ULES-01543" )
 )
 
 game (
 	name "FIFA 12 (France)"
-	serial "ULES-01546"
-	serial "ULES-01546"
+	rom ( serial "ULES-01546" )
 )
 
 game (
 	name "FIFA 12 (Germany)"
-	serial "ULES-01547"
-	serial "ULES-01547"
+	rom ( serial "ULES-01547" )
 )
 
 game (
 	name "FIFA 12 (Italy)"
-	serial "ULES-01551"
-	serial "ULES-01551"
+	rom ( serial "ULES-01551" )
 )
 
 game (
 	name "FIFA 12 (Netherlands)"
-	serial "ULES-01544"
-	serial "ULES-01544"
+	rom ( serial "ULES-01544" )
 )
 
 game (
 	name "FIFA 12 (Poland)"
-	serial "ULES-01545"
-	serial "ULES-01545"
+	rom ( serial "ULES-01545" )
 )
 
 game (
 	name "FIFA 12 (Portugal)"
-	serial "ULES-01550"
-	serial "ULES-01550"
+	rom ( serial "ULES-01550" )
 )
 
 game (
 	name "FIFA 12 (Russia)"
-	serial "ULES-01548"
-	serial "ULES-01548"
+	rom ( serial "ULES-01548" )
 )
 
 game (
 	name "FIFA 12 (Spain)"
-	serial "ULES-01549"
-	serial "ULES-01549"
+	rom ( serial "ULES-01549" )
 )
 
 game (
 	name "FIFA 13 (Europe)"
-	serial "ULES-01565"
-	serial "ULES-01565"
+	rom ( serial "ULES-01565" )
 )
 
 game (
 	name "FIFA 13 (Europe) (En,Es)"
-	serial "ULES-01565"
-	serial "ULES-01565"
 )
 
 game (
 	name "FIFA 13 (France)"
-	serial "ULES-01569"
-	serial "ULES-01569"
+	rom ( serial "ULES-01569" )
 )
 
 game (
 	name "FIFA 13 (Germany)"
-	serial "ULES-01574"
-	serial "ULES-01574"
+	rom ( serial "ULES-01574" )
 )
 
 game (
 	name "FIFA 13 (Italy)"
-	serial "ULES-01573"
-	serial "ULES-01573"
+	rom ( serial "ULES-01573" )
 )
 
 game (
 	name "FIFA 13 (Netherlands)"
-	serial "ULES-01567"
-	serial "ULES-01567"
+	rom ( serial "ULES-01567" )
 )
 
 game (
 	name "FIFA 13 (Poland)"
-	serial "ULES-01568"
-	serial "ULES-01568"
+	rom ( serial "ULES-01568" )
 )
 
 game (
 	name "FIFA 13 (Portugal)"
-	serial "ULES-01571"
-	serial "ULES-01571"
+	rom ( serial "ULES-01571" )
 )
 
 game (
 	name "FIFA 13 (Russia)"
-	serial "ULES-01570"
-	serial "ULES-01570"
+	rom ( serial "ULES-01570" )
 )
 
 game (
 	name "FIFA 13 (Spain)"
-	serial "ULES-01572"
-	serial "ULES-01572"
+	rom ( serial "ULES-01572" )
 )
 
 game (
 	name "FIFA 14 (Europe)"
-	serial "ULES-01586"
-	serial "ULES-01586"
+	rom ( serial "ULES-01586" )
 )
 
 game (
 	name "FIFA 14 (Germany)"
-	serial "ULES-01589"
-	serial "ULES-01589"
+	rom ( serial "ULES-01589" )
 )
 
 game (
 	name "FIFA 14 (Italy)"
-	serial "ULES-01588"
-	serial "ULES-01588"
+	rom ( serial "ULES-01588" )
 )
 
 game (
 	name "FIFA 14 (Netherlands)"
-	serial "ULES-01594"
-	serial "ULES-01594"
+	rom ( serial "ULES-01594" )
 )
 
 game (
 	name "FIFA 14 (Poland)"
-	serial "ULES-01593"
-	serial "ULES-01593"
+	rom ( serial "ULES-01593" )
 )
 
 game (
 	name "FIFA 14 (Russia)"
-	serial "ULES-01591"
-	serial "ULES-01591"
+	rom ( serial "ULES-01591" )
 )
 
 game (
 	name "FIFA 14 (Spain)"
-	serial "ULES-01590"
-	serial "ULES-01590"
+	rom ( serial "ULES-01590" )
 )
 
 game (
 	name "FIFA Soccer (Korea)"
-	serial "ULKS-46011"
-	serial "ULKS-46011"
+	rom ( serial "ULKS-46011" )
 )
 
 game (
 	name "FIFA Soccer (USA) (v1.02)"
-	serial "ULUS-10011"
-	serial "ULUS-10011"
+	rom ( serial "ULUS-10011" )
 )
 
 game (
 	name "FIFA Street 2 (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-00264"
-	serial "ULES-00264"
+	rom ( serial "ULES-00264" )
 )
 
 game (
 	name "FIFA Street 2 (Japan) (v1.02)"
-	serial "ULJM-05141"
-	serial "ULJM-05141"
+	rom ( serial "ULJM-05141" )
 )
 
 game (
 	name "FIFA Street 2 (USA) (v1.01)"
-	serial "ULUS-10067"
-	serial "ULUS-10067"
+	rom ( serial "ULUS-10067" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Asia)"
-	serial "ULAS-42058"
-	serial "ULAS-42058"
+	rom ( serial "ULAS-42058" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Europe) (v1.02)"
-	serial "ULES-00340"
-	serial "ULES-00340"
+	rom ( serial "ULES-00340" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (France) (v1.02)"
-	serial "ULES-00341"
-	serial "ULES-00341"
+	rom ( serial "ULES-00341" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Germany) (v1.02)"
-	serial "ULES-00342"
-	serial "ULES-00342"
+	rom ( serial "ULES-00342" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Italy) (v1.02)"
-	serial "ULES-00343"
-	serial "ULES-00343"
+	rom ( serial "ULES-00343" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Japan) (v1.02)"
-	serial "ULJM-05133"
-	serial "ULJM-05133"
+	rom ( serial "ULJM-05133" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Korea) (v1.01)"
-	serial "ULKS-46088"
-	serial "ULKS-46088"
+	rom ( serial "ULKS-46088" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (Spain) (v1.02)"
-	serial "ULES-00344"
-	serial "ULES-00344"
+	rom ( serial "ULES-00344" )
 )
 
 game (
 	name "FIFA World Cup - Germany 2006 (USA) (v1.01)"
-	serial "ULUS-10082"
-	serial "ULUS-10082"
+	rom ( serial "ULUS-10082" )
 )
 
 game (
 	name "Fading Shadows (Europe) (En,Fr,De,Es,It,Nl,Ru) (v1.02)"
-	serial "ULES-00858"
-	serial "ULES-00858"
+	rom ( serial "ULES-00858" )
 )
 
 game (
 	name "Fading Shadows (USA) (En,Fr,De,Es,It,Nl,Ru) (v1.03)"
-	serial "ULUS-10344"
-	serial "ULUS-10344"
+	rom ( serial "ULUS-10344" )
 )
 
 game (
 	name "FairlyLife - MiracleDays (Japan) (v1.01)"
-	serial "ULJM-05618"
-	serial "ULJM-05618"
+	rom ( serial "ULJM-05618" )
 )
 
 game (
 	name "Fairy Tail - Portable Guild (Japan) (v1.03)"
-	serial "ULJM-05608"
-	serial "ULJM-05608"
+	rom ( serial "ULJM-05608" )
 )
 
 game (
 	name "Fairy Tail - Portable Guild 2 (Japan) (v1.01)"
-	serial "NPJH-50411"
-	serial "NPJH-50411"
+	rom ( serial "NPJH-50411" )
 )
 
 game (
 	name "Fairy Tail - Zelef Kakusei (Japan) (v1.01)"
-	serial "NPJH-50486"
-	serial "NPJH-50486"
+	rom ( serial "NPJH-50486" )
 )
 
 game (
 	name "FamiTsu PSP Vol.12 Tokubetsu Furoku - Irem Taikenban Shuu 2008 Shunki Tokubetsugou (Japan) (v1.01) (Demo)"
-	serial "ULJM-91013"
-	serial "ULJM-91013"
+	rom ( serial "ULJM-91013" )
 )
 
 game (
 	name "FamiTsu PSP Vol.5 Tokubetsu Furoku - Capcom Special Taikenban 3in1 (Japan) (Demo)"
-	serial "ULJM-91004"
-	serial "ULJM-91004"
+	rom ( serial "ULJM-91004" )
 )
 
 game (
 	name "FamiTsu PSP Vol.8 Tokubetsu Furoku - Irem Taikenban Shuu 2007 Kaki Tokubetsugou (Japan) (Demo)"
-	serial "ULJM-91011"
-	serial "ULJM-91011"
+	rom ( serial "ULJM-91011" )
 )
 
 game (
 	name "Family Guy (Europe)"
-	serial "ULES-00567"
-	serial "ULES-00567"
+	rom ( serial "ULES-00567" )
 )
 
 game (
 	name "Family Guy (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00601"
-	serial "ULES-00601"
+	rom ( serial "ULES-00601" )
 )
 
 game (
 	name "Family Guy (USA)"
-	serial "ULUS-10185"
-	serial "ULUS-10185"
+	rom ( serial "ULUS-10185" )
 )
 
 game (
 	name "Fast and The Furious, The - Tokyo Drift (Europe)"
-	serial "ULES-00973"
-	serial "ULES-00973"
+	rom ( serial "ULES-00973" )
 )
 
 game (
 	name "Fat Princess - Fistful of Cake (Asia) (En,Zh)"
-	serial "NPHG-00025"
-	serial "NPHG-00025"
+	rom ( serial "NPHG-00025" )
 )
 
 game (
 	name "Fat Princess - Fistful of Cake (Europe) (En,Fr,De,Es,It,Pt,Ru,El)"
-	serial "UCES-01312"
-	serial "UCES-01312"
+	rom ( serial "UCES-01312" )
 )
 
 game (
 	name "Fat Princess - Fistful of Cake (USA) (En,Fr,Es)"
-	serial "UCUS-98740"
-	serial "UCUS-98740"
+	rom ( serial "UCUS-98740" )
 )
 
 game (
 	name "Fate-Extra (Europe)"
-	serial "ULES-01561"
-	serial "ULES-01561"
+	rom ( serial "ULES-01561" )
 )
 
 game (
 	name "Fate-Extra (Japan) (v1.01)"
-	serial "NPJH-50247"
-	serial "NPJH-50247"
+	rom ( serial "NPJH-50247" )
 )
 
 game (
 	name "Fate-Extra (USA)"
-	serial "ULUS-10576"
-	serial "ULUS-10576"
+	rom ( serial "ULUS-10576" )
 )
 
 game (
 	name "Fate-Tiger Colosseum (Japan) (v1.01)"
-	serial "ULJM-05266"
-	serial "ULJM-05266"
+	rom ( serial "ULJM-05266" )
 )
 
 game (
 	name "Fate-Tiger Colosseum Upper (Japan) (v1.01)"
-	serial "ULJM-05360"
-	serial "ULJM-05360"
+	rom ( serial "ULJM-05360" )
 )
 
 game (
 	name "Fate-Unlimited Codes Portable (Japan)"
-	serial "ULJM-05451"
-	serial "ULJM-05451"
+	rom ( serial "ULJM-05451" )
 )
 
 game (
 	name "Field Commander (Europe) (En,Fr,De,Es) (v1.01)"
-	serial "ULES-00335"
-	serial "ULES-00335"
+	rom ( serial "ULES-00335" )
 )
 
 game (
 	name "Field Commander (USA)"
-	serial "ULUS-10088"
-	serial "ULUS-10088"
+	rom ( serial "ULUS-10088" )
 )
 
 game (
 	name "Fight Ippatsu! Juden-Chan!! CC (Japan) (v1.01)"
-	serial "ULJM-05668"
-	serial "ULJM-05668"
+	rom ( serial "ULJM-05668" )
 )
 
 game (
 	name "Fight Night Round 3 (Asia)"
-	serial "ULAS-42044"
-	serial "ULAS-42044"
+	rom ( serial "ULAS-42044" )
 )
 
 game (
 	name "Fight Night Round 3 (Europe)"
-	serial "ULES-00270"
-	serial "ULES-00270"
+	rom ( serial "ULES-00270" )
 )
 
 game (
 	name "Fight Night Round 3 (USA)"
-	serial "ULUS-10066"
-	serial "ULUS-10066"
+	rom ( serial "ULUS-10066" )
 )
 
 game (
 	name "Final Armada (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00661"
-	serial "ULES-00661"
+	rom ( serial "ULES-00661" )
 )
 
 game (
 	name "Final Fantasy - 20th Anniversary Edition (Europe) (En,Ja)"
-	serial "ULES-00986"
-	serial "ULES-00986"
+	rom ( serial "ULES-00986" )
 )
 
 game (
 	name "Final Fantasy - 20th Anniversary Edition (USA) (En,Ja) (System 3.03)"
-	serial "ULUS-10251"
-	serial "ULUS-10251"
+	rom ( serial "ULUS-10251" )
 )
 
 game (
 	name "Final Fantasy - 20th Anniversary Edition (USA) (En,Ja) (System 6.00)"
-	serial "ULUS-10251"
-	serial "ULUS-10251"
 )
 
 game (
 	name "Final Fantasy II - 20th Anniversary Edition (Europe) (En,Ja)"
-	serial "ULES-00987"
-	serial "ULES-00987"
+	rom ( serial "ULES-00987" )
 )
 
 game (
 	name "Final Fantasy II - 20th Anniversary Edition (USA) (En,Ja)"
-	serial "ULUS-10263"
-	serial "ULUS-10263"
+	rom ( serial "ULUS-10263" )
 )
 
 game (
 	name "Final Fantasy III (Japan) (En,Ja) (v1.01)"
-	serial "NPJH-50626"
-	serial "NPJH-50626"
+	rom ( serial "NPJH-50626" )
 )
 
 game (
 	name "Final Fantasy IV - The Complete Collection (Europe) (En,Ja,Fr)"
-	serial "ULES-01521"
-	serial "ULES-01521"
+	rom ( serial "ULES-01521" )
 )
 
 game (
 	name "Final Fantasy IV - The Complete Collection (Japan) (En,Ja,Fr) (v1.01)"
-	serial "NPJH-50414"
-	serial "NPJH-50414"
+	rom ( serial "NPJH-50414" )
 )
 
 game (
 	name "Final Fantasy IV - The Complete Collection (USA) (En,Ja,Fr)"
-	serial "ULUS-10560"
-	serial "ULUS-10560"
+	rom ( serial "ULUS-10560" )
 )
 
 game (
 	name "Final Fantasy Reishiki (Japan) (v1.01)"
-	serial "NPJH-50443"
-	serial "NPJH-50443"
-)
-
-game (
-	name "Final Fantasy Reishiki (Japan) (v1.01)"
-	serial "NPJH-50443"
-	serial "NPJH-50443"
+	rom ( serial "NPJH-50443" )
 )
 
 game (
 	name "Final Fantasy Tactics - The War of the Lions (Europe)"
-	serial "ULES-00850"
-	serial "ULES-00850"
+	rom ( serial "ULES-00850" )
 )
 
 game (
 	name "Final Fantasy Tactics - The War of the Lions (USA)"
-	serial "ULUS-10297"
-	serial "ULUS-10297"
+	rom ( serial "ULUS-10297" )
 )
 
 game (
 	name "Finder Love - Hara Fumina - Futari no Futari de (Japan) (v1.02)"
-	serial "ULJM-05143"
-	serial "ULJM-05143"
+	rom ( serial "ULJM-05143" )
 )
 
 game (
 	name "Finder Love - Hoshino Aki - Nangoku Trouble Rendezvous (Japan) (v1.01)"
-	serial "ULJM-05145"
-	serial "ULJM-05145"
+	rom ( serial "ULJM-05145" )
 )
 
 game (
 	name "Finder Love - Kudo Risa - First Shoot wa Kimi to (Japan) (v1.01)"
-	serial "ULJM-05144"
-	serial "ULJM-05144"
+	rom ( serial "ULJM-05144" )
 )
 
 game (
 	name "Fired Up (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "UCES-00015"
-	serial "UCES-00015"
+	rom ( serial "UCES-00015" )
 )
 
 game (
 	name "Fired Up (Korea) (v1.02)"
-	serial "UCKS-45013"
-	serial "UCKS-45013"
+	rom ( serial "UCKS-45013" )
 )
 
 game (
 	name "Fired Up (USA) (Demo)"
-	serial "ZZZ_NOT_VALID"
-	serial "ZZZ_NOT_VALID"
+	rom ( serial "ZZZ_NOT_VALID" )
 )
 
 game (
 	name "FlatOut - Head On (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00968"
-	serial "ULES-00968"
+	rom ( serial "ULES-00968" )
 )
 
 game (
 	name "FlatOut - Head On (Germany)"
-	serial "ULES-00969"
-	serial "ULES-00969"
+	rom ( serial "ULES-00969" )
 )
 
 game (
 	name "FlatOut - Head On (USA) (v1.01)"
-	serial "ULUS-10328"
-	serial "ULUS-10328"
+	rom ( serial "ULUS-10328" )
 )
 
 game (
 	name "Football Manager Handheld (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00248"
-	serial "ULES-00248"
+	rom ( serial "ULES-00248" )
 )
 
 game (
 	name "Football Manager Handheld 2007 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00549"
-	serial "ULES-00549"
+	rom ( serial "ULES-00549" )
 )
 
 game (
 	name "Football Manager Handheld 2008 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00934"
-	serial "ULES-00934"
+	rom ( serial "ULES-00934" )
 )
 
 game (
 	name "Football Manager Handheld 2009 (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01152"
-	serial "ULES-01152"
+	rom ( serial "ULES-01152" )
 )
 
 game (
 	name "Football Manager Handheld 2010 (Europe) (En,Fr,De,Es,It) (v1.04)"
-	serial "ULES-01338"
-	serial "ULES-01338"
+	rom ( serial "ULES-01338" )
 )
 
 game (
 	name "Football Manager Handheld 2011 (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01455"
-	serial "ULES-01455"
+	rom ( serial "ULES-01455" )
 )
 
 game (
 	name "Football Manager Handheld 2012 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01555"
-	serial "ULES-01555"
+	rom ( serial "ULES-01555" )
 )
 
 game (
 	name "For Symphony - With All One's Heart Portable (Japan) (v1.01)"
-	serial "ULJM-05258"
-	serial "ULJM-05258"
+	rom ( serial "ULJM-05258" )
 )
 
 game (
 	name "Ford Street Racing - L.A. Duel (Europe)"
-	serial "ULES-00564"
-	serial "ULES-00564"
+	rom ( serial "ULES-00564" )
 )
 
 game (
 	name "Formula One 2006 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00238"
-	serial "UCES-00238"
+	rom ( serial "UCES-00238" )
 )
 
 game (
 	name "Frantix (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00175"
-	serial "ULES-00175"
+	rom ( serial "ULES-00175" )
 )
 
 game (
 	name "Freak Out - Extreme Freeride (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00783"
-	serial "ULES-00783"
+	rom ( serial "ULES-00783" )
 )
 
 game (
 	name "Free Running (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00704"
-	serial "ULES-00704"
+	rom ( serial "ULES-00704" )
 )
 
 game (
 	name "Frogger - Helmet Chaos (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00207"
-	serial "ULES-00207"
+	rom ( serial "ULES-00207" )
 )
 
 game (
 	name "Frogger - Helmet Chaos (USA)"
-	serial "ULUS-10026"
-	serial "ULUS-10026"
+	rom ( serial "ULUS-10026" )
 )
 
 game (
 	name "Frontier Gate (Japan) (v1.01)"
-	serial "NPJH-50468"
-	serial "NPJH-50468"
+	rom ( serial "NPJH-50468" )
 )
 
 game (
 	name "Fukufuku no Shima (Japan) (v3.01)"
-	serial "UCJS-10016"
-	serial "UCJS-10016"
+	rom ( serial "UCJS-10016" )
 )
 
 game (
 	name "Full Auto 2 - Battlelines (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00754"
-	serial "ULES-00754"
+	rom ( serial "ULES-00754" )
 )
 
 game (
 	name "Full Auto 2 - Battlelines (USA) (v1.01)"
-	serial "ULUS-10220"
-	serial "ULUS-10220"
+	rom ( serial "ULUS-10220" )
 )
 
 game (
 	name "Fullmetal Alchemist - Brotherhood (Europe) (En,De)"
-	serial "ULES-01432"
-	serial "ULES-01432"
+	rom ( serial "ULES-01432" )
 )
 
 game (
 	name "Fullmetal Alchemist - Brotherhood (France)"
-	serial "ULES-01433"
-	serial "ULES-01433"
+	rom ( serial "ULES-01433" )
 )
 
 game (
 	name "Fushigi Yuugi - Genbu Kaiden Gaiden - Kagami no Miko (Japan) (v1.02)"
-	serial "ULJM-05175"
-	serial "ULJM-05175"
+	rom ( serial "ULJM-05175" )
 )
 
 game (
 	name "Fushigi no Dungeon - Fuurai no Shiren 3 Portable (Japan) (v1.01)"
-	serial "ULJS-00239"
-	serial "ULJS-00239"
+	rom ( serial "ULJS-00239" )
 )
 
 game (
 	name "Fushigi no Dungeon - Fuurai no Shiren 4 Plus - Kami no Me to Akuma no Heso (Japan) (v1.01)"
-	serial "NPJH-50698"
-	serial "NPJH-50698"
+	rom ( serial "NPJH-50698" )
 )
 
 game (
 	name "Fuuun Shinsengumi Bakumatsuden Portable (Japan) (v1.02)"
-	serial "ULJM-05561"
-	serial "ULJM-05561"
+	rom ( serial "ULJM-05561" )
 )
 
 game (
 	name "G-Force (Europe) (De,It)"
-	serial "ULES-01239"
-	serial "ULES-01239"
+	rom ( serial "ULES-01239" )
 )
 
 game (
 	name "G-Force (Europe) (En,Fr,Es)"
-	serial "ULES-01238"
-	serial "ULES-01238"
+	rom ( serial "ULES-01238" )
 )
 
 game (
 	name "G-Force (Russia)"
-	serial "ULES-01240"
-	serial "ULES-01240"
+	rom ( serial "ULES-01240" )
 )
 
 game (
 	name "G-Force (USA) (En,Fr,Es)"
-	serial "ULUS-10439"
-	serial "ULUS-10439"
+	rom ( serial "ULUS-10439" )
 )
 
 game (
 	name "G.I. Joe - The Rise of Cobra (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01277"
-	serial "ULES-01277"
+	rom ( serial "ULES-01277" )
 )
 
 game (
 	name "G.I. Joe - The Rise of Cobra (USA) (v1.01)"
-	serial "ULUS-10435"
-	serial "ULUS-10435"
+	rom ( serial "ULUS-10435" )
 )
 
 game (
 	name "GA - Geijutsuka Art Design Class - Slapstick Wonder Land (Japan) (v1.01)"
-	serial "ULJM-05672"
-	serial "ULJM-05672"
+	rom ( serial "ULJM-05672" )
 )
 
 game (
 	name "GUN Showdown (Europe)"
-	serial "ULES-00484"
-	serial "ULES-00484"
+	rom ( serial "ULES-00484" )
 )
 
 game (
 	name "GUN Showdown (Germany)"
-	serial "ULES-00485"
-	serial "ULES-00485"
+	rom ( serial "ULES-00485" )
 )
 
 game (
 	name "GUN Showdown (USA) (v1.01)"
-	serial "ULUS-10158"
-	serial "ULUS-10158"
+	rom ( serial "ULUS-10158" )
 )
 
 game (
 	name "GachiTora! Abarenbou Kyoushi in High School (Japan) (v1.02)"
-	serial "NPJH-50409"
-	serial "NPJH-50409"
+	rom ( serial "NPJH-50409" )
 )
 
 game (
 	name "Gakuen Heaven - Okawari! (Japan) (v1.01)"
-	serial "ULJM-05729"
-	serial "ULJM-05729"
+	rom ( serial "ULJM-05729" )
 )
 
 game (
 	name "Gakuen Heaven Boys Love Scramble (Japan)"
-	serial "ULJM-05562"
-	serial "ULJM-05562"
-)
-
-game (
-	name "Gakuen Heaven Boys Love Scramble (Japan)"
-	serial "ULJM-05562"
-	serial "ULJM-05562"
+	rom ( serial "ULJM-05562" )
 )
 
 game (
 	name "Gakuen Hetalia Portable (Japan) (v1.01)"
-	serial "ULJM-05840"
-	serial "ULJM-05840"
+	rom ( serial "ULJM-05840" )
 )
 
 game (
 	name "Gallery Fake (Japan) (v1.01)"
-	serial "ULJS-00024"
-	serial "ULJS-00024"
+	rom ( serial "ULJS-00024" )
 )
 
 game (
 	name "Game demo, Papa no Iukoto o Kikinasai! (Japan) (v1.01)"
-	serial "NPJH-50575"
-	serial "NPJH-50575"
+	rom ( serial "NPJH-50575" )
 )
 
 game (
 	name "Gangs of London (Europe) (En,Fr,De,Es,It,Pt)"
-	serial "UCES-00113"
-	serial "UCES-00113"
+	rom ( serial "UCES-00113" )
 )
 
 game (
 	name "Gangs of London (Germany) (v1.01)"
-	serial "UCES-00523"
-	serial "UCES-00523"
+	rom ( serial "UCES-00523" )
 )
 
 game (
 	name "Gangs of London (USA) (En,Fr,Es) (Demo)"
-	serial "UCUS-98689"
-	serial "UCUS-98689"
+	rom ( serial "UCUS-98689" )
 )
 
 game (
 	name "Gangs of London (USA) (v1.01)"
-	serial "UCUS-98617"
-	serial "UCUS-98617"
+	rom ( serial "UCUS-98617" )
 )
 
 game (
 	name "Garnet Cradle Portable - Kagi no Himemiko (Japan) (v1.01)"
-	serial "ULJM-05858"
-	serial "ULJM-05858"
+	rom ( serial "ULJM-05858" )
 )
 
 game (
 	name "Gekiatsu!! PachiGe-Damashi Portable Vol.1 - Evangelion - Shinjitsu no Tsubasa (Japan) (v1.01)"
-	serial "ULJM-05906"
-	serial "ULJM-05906"
+	rom ( serial "ULJM-05906" )
 )
 
 game (
 	name "Gekka Ryouran Romance (Japan) (v1.01)"
-	serial "ULJM-05943"
-	serial "ULJM-05943"
+	rom ( serial "ULJM-05943" )
 )
 
 game (
 	name "Gendai Daisenryaku - Isshoku Sokuhatsu Gunji Balance Houkai (Japan) (v1.02)"
-	serial "ULJS-00213"
-	serial "ULJS-00213"
+	rom ( serial "ULJS-00213" )
 )
 
 game (
 	name "Generation of Chaos (Europe) (v1.01)"
-	serial "ULES-00820"
-	serial "ULES-00820"
+	rom ( serial "ULES-00820" )
 )
 
 game (
 	name "Generation of Chaos (USA) (v1.02)"
-	serial "ULUS-10075"
-	serial "ULUS-10075"
+	rom ( serial "ULUS-10075" )
 )
 
 game (
 	name "Generation of Chaos 6 (Japan)"
-	serial "ULJM-06103"
-	serial "ULJM-06103"
+	rom ( serial "ULJM-06103" )
 )
 
 game (
 	name "Genroh (Japan) (v1.02)"
-	serial "ULJM-06145"
-	serial "ULJM-06145"
+	rom ( serial "ULJM-06145" )
 )
 
 game (
 	name "Gensan (Europe) (En,Fr,De,Es,It) (v1.05)"
-	serial "ULES-01360"
-	serial "ULES-01360"
+	rom ( serial "ULES-01360" )
 )
 
 game (
 	name "Genso Suikoden - Tsumugareshi Hyakunen no Toki (Japan)"
-	serial "NPJH-50535"
-	serial "NPJH-50535"
+	rom ( serial "NPJH-50535" )
 )
 
 game (
 	name "Genso Suikoden I & II (Japan) (v1.03)"
-	serial "ULJM-05086"
-	serial "ULJM-05086"
+	rom ( serial "ULJM-05086" )
 )
 
 game (
 	name "Genso Suikoden I & II (Japan) (v2.00)"
-	serial "ULJM-05086"
-	serial "ULJM-05086"
 )
 
 game (
 	name "Geronimo Stilton in the Kingdom of Fantasy - The Videogame (Europe) (En,Fr,De,Es,It,Nl,Pt)"
-	serial "UCES-01535"
-	serial "UCES-01535"
+	rom ( serial "UCES-01535" )
 )
 
 game (
 	name "Ghost Rider (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00630"
-	serial "ULES-00630"
+	rom ( serial "ULES-00630" )
 )
 
 game (
 	name "Ghost Rider (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10210"
-	serial "ULUS-10210"
+	rom ( serial "ULUS-10210" )
 )
 
 game (
 	name "Ghost in the Shell - Stand Alone Complex (Europe)"
-	serial "ULES-00135"
-	serial "ULES-00135"
+	rom ( serial "ULES-00135" )
 )
 
 game (
 	name "Ghost in the Shell - Stand Alone Complex (USA) (v1.01)"
-	serial "ULUS-10020"
-	serial "ULUS-10020"
+	rom ( serial "ULUS-10020" )
 )
 
 game (
 	name "Ghostbusters - The Video Game (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
-	serial "UCES-01276"
-	serial "UCES-01276"
+	rom ( serial "UCES-01276" )
 )
 
 game (
 	name "Ghostbusters - The Video Game (Europe) (Fr,De,It) (v1.02)"
-	serial "UCES-01321"
-	serial "UCES-01321"
+	rom ( serial "UCES-01321" )
 )
 
 game (
 	name "Ghostbusters - The Video Game (USA)"
-	serial "ULUS-10486"
-	serial "ULUS-10486"
+	rom ( serial "ULUS-10486" )
 )
 
 game (
 	name "Gift - Prism (Japan) (v1.01)"
-	serial "ULJM-06016"
-	serial "ULJM-06016"
+	rom ( serial "ULJM-06016" )
 )
 
 game (
 	name "Ginsei Shogi Portable (Japan)"
-	serial "ULJS-00269"
-	serial "ULJS-00269"
+	rom ( serial "ULJS-00269" )
 )
 
 game (
 	name "Ginsei Shogi Portable - Fuuun Ryuuko Raiden (Japan)"
-	serial "ULJS-00405"
-	serial "ULJS-00405"
+	rom ( serial "ULJS-00405" )
 )
 
 game (
 	name "Gitaroo Man Lives! (Europe) (En,Fr,De) (v1.02)"
-	serial "ULES-00383"
-	serial "ULES-00383"
+	rom ( serial "ULES-00383" )
 )
 
 game (
 	name "Gitaroo Man Lives! (Japan) (v1.03)"
-	serial "ULJM-05130"
-	serial "ULJM-05130"
+	rom ( serial "ULJM-05130" )
 )
 
 game (
 	name "Gitaroo Man Lives! (Korea) (v1.01)"
-	serial "ULKS-46071"
-	serial "ULKS-46071"
+	rom ( serial "ULKS-46071" )
 )
 
 game (
 	name "Gitaroo Man Lives! (USA)"
-	serial "ULUS-10207"
-	serial "ULUS-10207"
+	rom ( serial "ULUS-10207" )
 )
 
 game (
 	name "Gladiator Begins (Europe) (v1.01)"
-	serial "ULES-01515"
-	serial "ULES-01515"
+	rom ( serial "ULES-01515" )
 )
 
 game (
 	name "Gladiator Begins (USA)"
-	serial "ULUS-10528"
-	serial "ULUS-10528"
+	rom ( serial "ULUS-10528" )
 )
 
 game (
 	name "Glorace - Phantastic Carnival (Korea) (v1.02)"
-	serial "UCKS-45001"
-	serial "UCKS-45001"
+	rom ( serial "UCKS-45001" )
 )
 
 game (
 	name "Gloria Union - Twin Fates in Blue Ocean (Japan) (v1.01)"
-	serial "ULJM-05813"
-	serial "ULJM-05813"
+	rom ( serial "ULJM-05813" )
 )
 
 game (
 	name "Go! Sudoku (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00152"
-	serial "UCES-00152"
+	rom ( serial "UCES-00152" )
 )
 
 game (
 	name "Go! Sudoku (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10095"
-	serial "ULUS-10095"
+	rom ( serial "ULUS-10095" )
 )
 
 game (
 	name "Go!Explore (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (v0.08) (Beta)"
-	serial "UCET-00860"
-	serial "UCET-00860"
+	rom ( serial "UCET-00860" )
 )
 
 game (
 	name "Go!Explore (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (v0.09) (Beta)"
-	serial "UCET-00860"
-	serial "UCET-00860"
 )
 
 game (
 	name "Go!Explore (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (v1.01)"
-	serial "UCES-00881"
-	serial "UCES-00881"
+	rom ( serial "UCES-00881" )
 )
 
 game (
 	name "God Eater (Japan) (Demo)"
-	serial "ULJM-91019"
-	serial "ULJM-91019"
+	rom ( serial "ULJM-91019" )
 )
 
 game (
 	name "God Eater (Japan) (v1.01)"
-	serial "ULJS-00237"
-	serial "ULJS-00237"
+	rom ( serial "ULJS-00237" )
 )
 
 game (
 	name "God of War - Chains of Olympus (Asia) (En,Zh)"
-	serial "UCAS-40198"
-	serial "UCAS-40198"
+	rom ( serial "UCAS-40198" )
 )
 
 game (
 	name "God of War - Chains of Olympus (Europe) (Demo)"
-	serial "UCED-00970"
-	serial "UCED-00970"
+	rom ( serial "UCED-00970" )
 )
 
 game (
 	name "God of War - Chains of Olympus (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00842"
-	serial "UCES-00842"
+	rom ( serial "UCES-00842" )
 )
 
 game (
 	name "God of War - Chains of Olympus (Europe) (Promo) [b]"
-	serial "UCET-00844"
-	serial "UCET-00844"
+	rom ( serial "UCET-00844" )
 )
 
 game (
 	name "God of War - Chains of Olympus (Korea)"
-	serial "UCKS-45084"
-	serial "UCKS-45084"
+	rom ( serial "UCKS-45084" )
 )
 
 game (
 	name "God of War - Chains of Olympus (USA)"
-	serial "UCUS-98653"
-	serial "UCUS-98653"
+	rom ( serial "UCUS-98653" )
 )
 
 game (
 	name "God of War - Chains of Olympus - Special Edition - Battle of Attica (USA) (v1.01) (Demo)"
-	serial "UCUS-98705"
-	serial "UCUS-98705"
+	rom ( serial "UCUS-98705" )
 )
 
 game (
 	name "God of War - Ghost of Sparta (Asia) (En,Zh)"
-	serial "NPHG-00092"
-	serial "NPHG-00092"
+	rom ( serial "NPHG-00092" )
 )
 
 game (
 	name "God of War - Ghost of Sparta (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-01401"
-	serial "UCES-01401"
+	rom ( serial "UCES-01401" )
 )
 
 game (
 	name "God of War - Ghost of Sparta (Europe) (En,Pl,Ru) (v1.01)"
-	serial "UCES-01473"
-	serial "UCES-01473"
+	rom ( serial "UCES-01473" )
 )
 
 game (
 	name "God of War - Ghost of Sparta (USA) (En,Fr,Es) (v2.00)"
-	serial "UCUS-98737"
-	serial "UCUS-98737"
+	rom ( serial "UCUS-98737" )
 )
 
 game (
 	name "Godfather, The (Europe) (En,Nl,Pl)"
-	serial "ULES-00394"
-	serial "ULES-00394"
+	rom ( serial "ULES-00394" )
 )
 
 game (
 	name "Gods Eater Burst (Europe)"
-	serial "ULES-01519"
-	serial "ULES-01519"
+	rom ( serial "ULES-01519" )
 )
 
 game (
 	name "Gods Eater Burst (USA)"
-	serial "ULUS-10563"
-	serial "ULUS-10563"
+	rom ( serial "ULUS-10563" )
 )
 
 game (
 	name "Goku Makaimura Kai (Japan)"
-	serial "ULJM-05265"
-	serial "ULJM-05265"
+	rom ( serial "ULJM-05265" )
 )
 
 game (
 	name "Golden Compass, The (Europe) (En,Nl,Sv,No,Da)"
-	serial "ULES-00950"
-	serial "ULES-00950"
+	rom ( serial "ULES-00950" )
 )
 
 game (
 	name "Golden Compass, The (USA)"
-	serial "ULUS-10315"
-	serial "ULUS-10315"
+	rom ( serial "ULUS-10315" )
 )
 
 game (
 	name "Gottlieb Pinball Classics (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00213"
-	serial "ULES-00213"
+	rom ( serial "ULES-00213" )
 )
 
 game (
 	name "Gottlieb Pinball Classics (Europe) (v1.02)"
-	serial "ULES-00212"
-	serial "ULES-00212"
+	rom ( serial "ULES-00212" )
 )
 
 game (
 	name "Gradius Portable (Europe)"
-	serial "ULES-00381"
-	serial "ULES-00381"
+	rom ( serial "ULES-00381" )
 )
 
 game (
 	name "Gradius Portable (Japan) (v1.03)"
-	serial "ULJM-05091"
-	serial "ULJM-05091"
+	rom ( serial "ULJM-05091" )
 )
 
 game (
 	name "Gran Turismo (Asia) (En,Zh,Ko)"
-	serial "UCAS-40265"
-	serial "UCAS-40265"
+	rom ( serial "UCAS-40265" )
 )
 
 game (
 	name "Gran Turismo (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru) (v1.01)"
-	serial "UCES-01245"
-	serial "UCES-01245"
+	rom ( serial "UCES-01245" )
 )
 
 game (
 	name "Gran Turismo (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru) (v2.00)"
-	serial "UCES-01245"
-	serial "UCES-01245"
 )
 
 game (
 	name "Gran Turismo (Japan) (v1.01)"
-	serial "UCJS-10100"
-	serial "UCJS-10100"
+	rom ( serial "UCJS-10100" )
 )
 
 game (
 	name "Gran Turismo (USA) (En,Fr,Es)"
-	serial "UCUS-98632"
-	serial "UCUS-98632"
+	rom ( serial "UCUS-98632" )
 )
 
 game (
 	name "Grand Knights History (Japan) (v1.01)"
-	serial "ULJS-00394"
-	serial "ULJS-00394"
+	rom ( serial "ULJS-00394" )
 )
 
 game (
 	name "Grand Theft Auto - Chinatown Wars (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01347"
-	serial "ULES-01347"
+	rom ( serial "ULES-01347" )
 )
 
 game (
 	name "Grand Theft Auto - Chinatown Wars (Japan) (v1.01)"
-	serial "ULJM-05604"
-	serial "ULJM-05604"
+	rom ( serial "ULJM-05604" )
 )
 
 game (
 	name "Grand Theft Auto - Chinatown Wars (USA) (v1.01)"
-	serial "ULUS-10490"
-	serial "ULUS-10490"
+	rom ( serial "ULUS-10490" )
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Europe) (En,Fr,De,Es,It) (v1.05)"
-	serial "ULES-00151"
-	serial "ULES-00151"
+	rom ( serial "ULES-00151" )
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "ULES-00151"
-	serial "ULES-00151"
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Europe) (En,Fr,De,Es,It) (v3.00)"
-	serial "ULES-00151"
-	serial "ULES-00151"
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Germany)"
-	serial "ULES-00182"
-	serial "ULES-00182"
+	rom ( serial "ULES-00182" )
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Germany) (v2.00)"
-	serial "ULES-00182"
-	serial "ULES-00182"
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (Japan) (v1.01)"
-	serial "ULJM-05255"
-	serial "ULJM-05255"
+	rom ( serial "ULJM-05255" )
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (USA) (En,Fr,De,Es,It) (v1.05)"
-	serial "ULUS-10041"
-	serial "ULUS-10041"
+	rom ( serial "ULUS-10041" )
 )
 
 game (
 	name "Grand Theft Auto - Liberty City Stories (USA) (En,Fr,De,Es,It) (v3.00)"
-	serial "ULUS-10041"
-	serial "ULUS-10041"
 )
 
 game (
 	name "Grand Theft Auto - Vice City Stories (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00502"
-	serial "ULES-00502"
+	rom ( serial "ULES-00502" )
 )
 
 game (
 	name "Grand Theft Auto - Vice City Stories (Germany) (v1.02)"
-	serial "ULES-00503"
-	serial "ULES-00503"
+	rom ( serial "ULES-00503" )
 )
 
 game (
 	name "Grand Theft Auto - Vice City Stories (Japan) (v1.01)"
-	serial "ULJM-05297"
-	serial "ULJM-05297"
+	rom ( serial "ULJM-05297" )
 )
 
 game (
 	name "Grand Theft Auto - Vice City Stories (USA) (v1.03)"
-	serial "ULUS-10160"
-	serial "ULUS-10160"
+	rom ( serial "ULUS-10160" )
 )
 
 game (
 	name "Great Battle Fullblast (Japan) (v1.02)"
-	serial "NPJH-50561"
-	serial "NPJH-50561"
+	rom ( serial "NPJH-50561" )
 )
 
 game (
 	name "Gretzky NHL (USA)"
-	serial "UCUS-98604"
-	serial "UCUS-98604"
+	rom ( serial "UCUS-98604" )
 )
 
 game (
 	name "Gretzky NHL 06 (USA) (v1.02)"
-	serial "UCUS-98627"
-	serial "UCUS-98627"
+	rom ( serial "UCUS-98627" )
 )
 
 game (
 	name "Grim the Bounty Hunter (Japan) (v1.02)"
-	serial "ULJM-06116"
-	serial "ULJM-06116"
+	rom ( serial "ULJM-06116" )
 )
 
 game (
 	name "Gripshift (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00177"
-	serial "ULES-00177"
+	rom ( serial "ULES-00177" )
 )
 
 game (
 	name "Gripshift (Japan) (v1.01)"
-	serial "ULJM-05089"
-	serial "ULJM-05089"
+	rom ( serial "ULJM-05089" )
 )
 
 game (
 	name "Gripshift (USA)"
-	serial "ULUS-10040"
-	serial "ULUS-10040"
+	rom ( serial "ULUS-10040" )
 )
 
 game (
 	name "Growlanser (Japan)"
-	serial "ULJM-05423"
-	serial "ULJM-05423"
+	rom ( serial "ULJM-05423" )
 )
 
 game (
 	name "Growlanser - Wayfarer of Time (USA)"
-	serial "ULUS-10593"
-	serial "ULUS-10593"
+	rom ( serial "ULUS-10593" )
 )
 
 game (
 	name "Guilty Gear Judgment (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00574"
-	serial "ULES-00574"
+	rom ( serial "ULES-00574" )
 )
 
 game (
 	name "Guilty Gear Judgment (Japan) (v1.04)"
-	serial "ULJM-05158"
-	serial "ULJM-05158"
+	rom ( serial "ULJM-05158" )
 )
 
 game (
 	name "Guilty Gear Judgment (USA) (v1.01)"
-	serial "ULUS-10104"
-	serial "ULUS-10104"
+	rom ( serial "ULUS-10104" )
 )
 
 game (
 	name "Guilty Gear XX Accent Core Plus (Europe) (v1.01)"
-	serial "ULES-01394"
-	serial "ULES-01394"
+	rom ( serial "ULES-01394" )
 )
 
 game (
 	name "Guilty Gear XX Accent Core Plus (Japan)"
-	serial "ULJM-05355"
-	serial "ULJM-05355"
+	rom ( serial "ULJM-05355" )
 )
 
 game (
 	name "Guilty Gear XX Accent Core Plus (USA)"
-	serial "ULUS-10409"
-	serial "ULUS-10409"
+	rom ( serial "ULUS-10409" )
 )
 
 game (
 	name "Guilty Gear XX Reload (Japan) (v1.01)"
-	serial "ULJM-05042"
-	serial "ULJM-05042"
+	rom ( serial "ULJM-05042" )
 )
 
 game (
 	name "Gundam Assault Survive (Japan) (v1.02)"
-	serial "ULJS-00281"
-	serial "ULJS-00281"
+	rom ( serial "ULJS-00281" )
 )
 
 game (
 	name "Gundam Battle Chronicle (Japan) (v1.02)"
-	serial "ULJS-00122"
-	serial "ULJS-00122"
+	rom ( serial "ULJS-00122" )
 )
 
 game (
 	name "Gundam Battle Chronicle (Korea) (v1.02)"
-	serial "ULJS-00122"
-	serial "ULJS-00122"
 )
 
 game (
 	name "Gundam Battle Royale (Japan) (v1.02)"
-	serial "ULJS-00083"
-	serial "ULJS-00083"
+	rom ( serial "ULJS-00083" )
 )
 
 game (
 	name "Gundam Battle Tactics (Japan) (v1.02)"
-	serial "ULJS-00025"
-	serial "ULJS-00025"
+	rom ( serial "ULJS-00025" )
 )
 
 game (
 	name "Gundam Battle Universe (Japan) (v1.03)"
-	serial "ULJS-00145"
-	serial "ULJS-00145"
+	rom ( serial "ULJS-00145" )
 )
 
 game (
 	name "Gundam Memories - Tatakai no Kioku (Japan) (v1.01)"
-	serial "NPJH-50437"
-	serial "NPJH-50437"
+	rom ( serial "NPJH-50437" )
 )
 
 game (
 	name "Gungnir (USA)"
-	serial "ULUS-10592"
-	serial "ULUS-10592"
+	rom ( serial "ULUS-10592" )
 )
 
 game (
 	name "Gunpey (Europe) (En,De,Es,It,Nl)"
-	serial "ULES-00648"
-	serial "ULES-00648"
+	rom ( serial "ULES-00648" )
 )
 
 game (
 	name "Gunpey (USA)"
-	serial "ULUS-10182"
-	serial "ULUS-10182"
+	rom ( serial "ULUS-10182" )
 )
 
 game (
 	name "Gurumin - A Monstrous Adventure (Europe)"
-	serial "ULES-00627"
-	serial "ULES-00627"
+	rom ( serial "ULES-00627" )
 )
 
 game (
 	name "Gurumin - A Monstrous Adventure (USA)"
-	serial "ULUS-10228"
-	serial "ULUS-10228"
+	rom ( serial "ULUS-10228" )
 )
 
 game (
 	name "Hagane no Renkinjutsushi - Fullmetal Alchemist - Yakusoku no Hi e (Japan)"
-	serial "ULJS-00292"
-	serial "ULJS-00292"
+	rom ( serial "ULJS-00292" )
 )
 
 game (
 	name "Hajime no Ippo Portable - Victorious Spirits (Japan) (v1.03)"
-	serial "ULJS-00125"
-	serial "ULJS-00125"
+	rom ( serial "ULJS-00125" )
 )
 
 game (
 	name "Hakuisei Renai Shoukougun (Japan) (v1.01)"
-	serial "ULJM-05935"
-	serial "ULJM-05935"
+	rom ( serial "ULJM-05935" )
 )
 
 game (
 	name "Hakuisei Renai Shoukougun RE-Therapy (Japan)"
-	serial "ULJM-06106"
-	serial "ULJM-06106"
+	rom ( serial "ULJM-06106" )
 )
 
 game (
 	name "Hakuoki - Demon of the Fleeting Blossom (USA)"
-	serial "ULUS-10577"
-	serial "ULUS-10577"
+	rom ( serial "ULUS-10577" )
 )
 
 game (
 	name "Hakuoki - Reimeiroku Portable (Japan) (v1.02)"
-	serial "ULJM-05917"
-	serial "ULJM-05917"
+	rom ( serial "ULJM-05917" )
 )
 
 game (
 	name "Hakuoki - Yuugi Roku (Japan) (v1.02)"
-	serial "ULJM-05663"
-	serial "ULJM-05663"
+	rom ( serial "ULJM-05663" )
 )
 
 game (
 	name "Hakuoki - Yuugi Roku Ni - Matsuri Bayashi to Taishitachi (Japan) (v1.02)"
-	serial "ULJM-06165"
-	serial "ULJM-06165"
+	rom ( serial "ULJM-06165" )
 )
 
 game (
 	name "Half-Minute Hero (Europe) (v1.01)"
-	serial "ULES-01359"
-	serial "ULES-01359"
+	rom ( serial "ULES-01359" )
 )
 
 game (
 	name "Half-Minute Hero (USA)"
-	serial "ULUS-10491"
-	serial "ULUS-10491"
+	rom ( serial "ULUS-10491" )
 )
 
 game (
 	name "Hana to Otome ni Shukufuku o - Harukaze no Okurimono - Portable (Japan) (v1.01)"
-	serial "ULJM-05962"
-	serial "ULJM-05962"
+	rom ( serial "ULJM-05962" )
 )
 
 game (
 	name "Hanakisou (Japan)"
-	serial "ULJM-05701"
-	serial "ULJM-05701"
+	rom ( serial "ULJM-05701" )
 )
 
 game (
 	name "Hanaoni - Koi Someru Toki Towa no Shirushi (Japan)"
-	serial "ULJM-05847"
-	serial "ULJM-05847"
+	rom ( serial "ULJM-05847" )
 )
 
 game (
 	name "Hanaoni - Yume no Tsudzuki (Japan) (v1.01)"
-	serial "ULJM-06048"
-	serial "ULJM-06048"
+	rom ( serial "ULJM-06048" )
 )
 
 game (
 	name "Hanayaka Nari, Wa ga Ichizoku (Japan) (v1.01)"
-	serial "ULJM-05691"
-	serial "ULJM-05691"
+	rom ( serial "ULJM-05691" )
 )
 
 game (
 	name "Hanayaka Nari, Wa ga Ichizoku - Kinema Mosaic (Japan) (v1.01)"
-	serial "ULJM-05998"
-	serial "ULJM-05998"
+	rom ( serial "ULJM-05998" )
 )
 
 game (
 	name "Handdic (Korea)"
-	serial "UCKS-45017"
-	serial "UCKS-45017"
+	rom ( serial "UCKS-45017" )
 )
 
 game (
 	name "Hannah Montana - Rock Out the Show (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-01303"
-	serial "ULES-01303"
+	rom ( serial "ULES-01303" )
 )
 
 game (
 	name "Hannah Montana - Rock Out the Show (Europe) (En,Sv,No,Da,Ru) [b]"
-	serial "ULES-01304"
-	serial "ULES-01304"
+	rom ( serial "ULES-01304" )
 )
 
 game (
 	name "Hannah Montana - Rock Out the Show (USA) (En,Fr)"
-	serial "ULUS-10431"
-	serial "ULUS-10431"
+	rom ( serial "ULUS-10431" )
 )
 
 game (
 	name "Harajuku Tantei Gakuen - Steel Wood (Japan) (v1.02)"
-	serial "ULJM-05655"
-	serial "ULJM-05655"
+	rom ( serial "ULJM-05655" )
 )
 
 game (
 	name "Hard Rock Casino (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00638"
-	serial "ULES-00638"
+	rom ( serial "ULES-00638" )
 )
 
 game (
 	name "Hard Rock Casino (USA) (v1.02)"
-	serial "ULUS-10181"
-	serial "ULUS-10181"
+	rom ( serial "ULUS-10181" )
 )
 
 game (
 	name "Harry Potter and the Goblet of Fire (Europe) (Es,It) [b]"
-	serial "ULES-00216"
-	serial "ULES-00216"
+	rom ( serial "ULES-00216" )
 )
 
 game (
 	name "Harry Potter and the Goblet of Fire (Europe) (v1.01)"
-	serial "ULES-00210"
-	serial "ULES-00210"
+	rom ( serial "ULES-00210" )
 )
 
 game (
 	name "Harry Potter and the Goblet of Fire (Korea) [b]"
-	serial "ULKS-46047"
-	serial "ULKS-46047"
+	rom ( serial "ULKS-46047" )
 )
 
 game (
 	name "Harry Potter and the Goblet of Fire (USA)"
-	serial "ULUS-10032"
-	serial "ULUS-10032"
+	rom ( serial "ULUS-10032" )
 )
 
 game (
 	name "Harry Potter and the Half-Blood Prince (Europe) (En,Fr,De,Es,It,Nl,Pt,Ru)"
-	serial "ULES-01180"
-	serial "ULES-01180"
+	rom ( serial "ULES-01180" )
 )
 
 game (
 	name "Harry Potter and the Half-Blood Prince (USA)"
-	serial "ULUS-10381"
-	serial "ULUS-10381"
+	rom ( serial "ULUS-10381" )
 )
 
 game (
 	name "Harry Potter and the Order of the Phoenix (Asia)"
-	serial "ULUS-10261"
-	serial "ULUS-10261"
+	rom ( serial "ULUS-10261" )
 )
 
 game (
 	name "Harry Potter and the Order of the Phoenix (Europe)"
-	serial "ULES-00829"
-	serial "ULES-00829"
+	rom ( serial "ULES-00829" )
 )
 
 game (
 	name "Harry Potter and the Order of the Phoenix (Europe) (Es,Nl,Pt)"
-	serial "ULES-00831"
-	serial "ULES-00831"
+	rom ( serial "ULES-00831" )
 )
 
 game (
 	name "Harry Potter and the Order of the Phoenix (Europe) (Fr,De,It)"
-	serial "ULES-00830"
-	serial "ULES-00830"
+	rom ( serial "ULES-00830" )
 )
 
 game (
 	name "Harry Potter and the Order of the Phoenix (USA)"
-	serial "ULUS-10261"
-	serial "ULUS-10261"
 )
 
 game (
 	name "Harukanaru Toki no Naka de - Iroetebako (Japan) (v1.02)"
-	serial "ULJM-05018"
-	serial "ULJM-05018"
+	rom ( serial "ULJM-05018" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 2 (Japan) (v1.02)"
-	serial "ULJM-05019"
-	serial "ULJM-05019"
+	rom ( serial "ULJM-05019" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 3 - Unmei no Labyrinth Aizouban (Japan) (v1.01)"
-	serial "ULJM-05547"
-	serial "ULJM-05547"
+	rom ( serial "ULJM-05547" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 3 with Izayoiki Aizouban (Japan) (v1.02)"
-	serial "ULJM-05441"
-	serial "ULJM-05441"
+	rom ( serial "ULJM-05441" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 4 Aizouban (Japan) (v1.01)"
-	serial "ULJM-05810"
-	serial "ULJM-05810"
+	rom ( serial "ULJM-05810" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 5 (Japan) (v1.01)"
-	serial "ULJM-05843"
-	serial "ULJM-05843"
+	rom ( serial "ULJM-05843" )
 )
 
 game (
 	name "Harukanaru Toki no Naka de 5 Kazahanaki (Japan) (v1.01)"
-	serial "ULJM-06025"
-	serial "ULJM-06025"
+	rom ( serial "ULJM-06025" )
 )
 
 game (
 	name "Harvest Moon - Boy & Girl (USA)"
-	serial "ULUS-10142"
-	serial "ULUS-10142"
+	rom ( serial "ULUS-10142" )
 )
 
 game (
 	name "Harvest Moon - Hero of Leaf Valley (Europe)"
-	serial "ULES-01489"
-	serial "ULES-01489"
+	rom ( serial "ULES-01489" )
 )
 
 game (
 	name "Harvest Moon - Hero of Leaf Valley (USA)"
-	serial "ULUS-10458"
-	serial "ULUS-10458"
+	rom ( serial "ULUS-10458" )
 )
 
 game (
 	name "Harvey Birdman - Attorney at Law (USA)"
-	serial "ULUS-10324"
-	serial "ULUS-10324"
+	rom ( serial "ULUS-10324" )
 )
 
 game (
 	name "Hatsune Miku - Project Diva (Japan) (v1.01)"
-	serial "ULJM-05472"
-	serial "ULJM-05472"
+	rom ( serial "ULJM-05472" )
 )
 
 game (
 	name "Hatsune Miku - Project Diva 2nd (Japan)"
-	serial "ULJM-05681"
-	serial "ULJM-05681"
+	rom ( serial "ULJM-05681" )
 )
 
 game (
 	name "Hatsune Miku - Project Diva 2nd (Japan) (Okaidokuban)"
-	serial "NPJH-50475"
-	serial "NPJH-50475"
+	rom ( serial "NPJH-50475" )
 )
 
 game (
 	name "Hatsune Miku - Project Diva Extend (Japan) (v1.01)"
-	serial "NPJH-50465"
-	serial "NPJH-50465"
+	rom ( serial "NPJH-50465" )
 )
 
 game (
 	name "Hayarigami 2 Portable - Keishichou Kaii Jiken File (Japan) (v1.02)"
-	serial "ULJS-00149"
-	serial "ULJS-00149"
+	rom ( serial "ULJS-00149" )
 )
 
 game (
 	name "Hayarigami 3 - Keishichou Kaii Jiken File (Japan) (v1.01)"
-	serial "ULJS-00204"
-	serial "ULJS-00204"
+	rom ( serial "ULJS-00204" )
 )
 
 game (
 	name "Hayarigami Portable - Keishichou Kaii Jiken File (Japan) (v1.01)"
-	serial "ULJS-00035"
-	serial "ULJS-00035"
+	rom ( serial "ULJS-00035" )
 )
 
 game (
 	name "Hayate no Gotoku!! - Nightmare Paradise (Japan) (v1.02)"
-	serial "ULJM-05416"
-	serial "ULJM-05416"
+	rom ( serial "ULJM-05416" )
 )
 
 game (
 	name "Heart no Kuni no Alice Anniversary Ver. - Wonderful Wonder World (Japan) (v1.03)"
-	serial "ULJM-05919"
-	serial "ULJM-05919"
+	rom ( serial "ULJM-05919" )
 )
 
 game (
 	name "Heatseeker (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00760"
-	serial "ULES-00760"
+	rom ( serial "ULES-00760" )
 )
 
 game (
 	name "Heatseeker (USA) (v1.01)"
-	serial "ULUS-10259"
-	serial "ULUS-10259"
+	rom ( serial "ULUS-10259" )
 )
 
 game (
 	name "Heaven's Will (Japan) (v1.01)"
-	serial "ULJM-05186"
-	serial "ULJM-05186"
+	rom ( serial "ULJM-05186" )
 )
 
 game (
 	name "Hellboy - The Science of Evil (Asia)"
-	serial "ULUS-10301"
-	serial "ULUS-10301"
+	rom ( serial "ULUS-10301" )
 )
 
 game (
 	name "Hellboy - The Science of Evil (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00827"
-	serial "ULES-00827"
+	rom ( serial "ULES-00827" )
 )
 
 game (
 	name "Hellboy - The Science of Evil (USA)"
-	serial "ULUS-10301"
-	serial "ULUS-10301"
 )
 
 game (
 	name "Hello Kitty - Puzzle Party (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01397"
-	serial "ULES-01397"
+	rom ( serial "ULES-01397" )
 )
 
 game (
 	name "Hello Kitty to Issho! Block Crash 123!! (Japan) (v1.01)"
-	serial "ULJM-05707"
-	serial "ULJM-05707"
+	rom ( serial "ULJM-05707" )
 )
 
 game (
 	name "Heroes Phantasia (Japan) (v1.02)"
-	serial "NPJH-50558"
-	serial "NPJH-50558"
+	rom ( serial "NPJH-50558" )
 )
 
 game (
 	name "Heroes Phantasia (Japan) (v1.02) (Limited Edition Disc)"
-	serial "ULJS-00455"
-	serial "ULJS-00455"
+	rom ( serial "ULJS-00455" )
 )
 
 game (
 	name "Hexyz Force (Japan)"
-	serial "ULJM-05501"
-	serial "ULJM-05501"
+	rom ( serial "ULJM-05501" )
 )
 
 game (
 	name "Hexyz Force (USA)"
-	serial "ULUS-10506"
-	serial "ULUS-10506"
+	rom ( serial "ULUS-10506" )
 )
 
 game (
 	name "Higanjima (Japan) (v1.02)"
-	serial "ULJS-00013"
-	serial "ULJS-00013"
+	rom ( serial "ULJS-00013" )
 )
 
 game (
 	name "Higurashi Daybreak Portable (Japan)"
-	serial "ULJM-05388"
-	serial "ULJM-05388"
+	rom ( serial "ULJM-05388" )
 )
 
 game (
 	name "Higurashi Daybreak Portable Mega Edition (Japan) (v1.01)"
-	serial "ULJM-05557"
-	serial "ULJM-05557"
+	rom ( serial "ULJM-05557" )
 )
 
 game (
 	name "Higurashi no Naku Koro ni - Jan (Japan) (v1.01)"
-	serial "ULJM-05554"
-	serial "ULJM-05554"
+	rom ( serial "ULJM-05554" )
 )
 
 game (
 	name "Hiiro no Kakera - Shin Tamayori-hime Denshou - Piece of Future (Japan) (1.01)"
-	serial "ULJM-05913"
-	serial "ULJM-05913"
+	rom ( serial "ULJM-05913" )
 )
 
 game (
 	name "Hiiro no Kakera Portable (Japan) (v1.02)"
-	serial "ULJM-05399"
-	serial "ULJM-05399"
+	rom ( serial "ULJM-05399" )
 )
 
 game (
 	name "Himawari - Pebble in the Sky Portable (Japan) (v1.01)"
-	serial "ULJM-05614"
-	serial "ULJM-05614"
+	rom ( serial "ULJM-05614" )
 )
 
 game (
 	name "HimeHibi - New Princess Days!! Zoku! Ni-Gakki Portable (Japan) (v1.02)"
-	serial "ULJS-00271"
-	serial "ULJS-00271"
+	rom ( serial "ULJS-00271" )
 )
 
 game (
 	name "HimeHibi - Princess Days Portable (Japan) (v1.01)"
-	serial "ULJM-05354"
-	serial "ULJM-05354"
+	rom ( serial "ULJM-05354" )
 )
 
 game (
 	name "Hisshou Pachinko - Pachi-Slot Kouryaku Series Portable Vol.1 - Shinseiki Evangelion - Tamashii no Kiseki (Japan) (v1.01)"
-	serial "ULJS-00295"
-	serial "ULJS-00295"
+	rom ( serial "ULJS-00295" )
 )
 
 game (
 	name "Hisshou Pachinko - Pachi-Slot Kouryaku Series Portable Vol.2 - CR Evangelion - Hajimari no Fukuin (Japan) (v1.01)"
-	serial "ULJS-00340"
-	serial "ULJS-00340"
+	rom ( serial "ULJS-00340" )
 )
 
 game (
 	name "History Channel - Great Battles of Rome (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00798"
-	serial "ULES-00798"
+	rom ( serial "ULES-00798" )
 )
 
 game (
 	name "Hitsuji-kun nara Kiss Shite Ageru (Japan) (v1.01)"
-	serial "ULJM-05431"
-	serial "ULJM-05431"
+	rom ( serial "ULJM-05431" )
 )
 
 game (
 	name "Hokuto no Ken - Raoh Gaiden - Ten no Haoh (Japan) (v1.02)"
-	serial "ULJM-05404"
-	serial "ULJM-05404"
+	rom ( serial "ULJM-05404" )
 )
 
 game (
 	name "Holy Invasion of Privacy, Badman! What Did I Do to Deserve This (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-01332"
-	serial "ULES-01332"
+	rom ( serial "ULES-01332" )
 )
 
 game (
 	name "Honkaku Yonin uchi Pro Mahjong - Mahjong-Ou Portable (Japan) (v1.01)"
-	serial "ULJM-05115"
-	serial "ULJM-05115"
+	rom ( serial "ULJM-05115" )
 )
 
 game (
 	name "Hoshigari Empusa Portable (Japan) (v1.01)"
-	serial "ULJS-00172"
-	serial "ULJS-00172"
+	rom ( serial "ULJS-00172" )
 )
 
 game (
 	name "Hoshiiro no Okurimono Portable (Japan) (v1.02)"
-	serial "ULJS-00164"
-	serial "ULJS-00164"
+	rom ( serial "ULJS-00164" )
 )
 
 game (
 	name "Hoshizora Planet - One Small Step For (Japan) (v1.01)"
-	serial "ULJM-05845"
-	serial "ULJM-05845"
+	rom ( serial "ULJM-05845" )
 )
 
 game (
 	name "Hot Brain (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00834"
-	serial "ULES-00834"
+	rom ( serial "ULES-00834" )
 )
 
 game (
 	name "Hot Brain (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10268"
-	serial "ULUS-10268"
+	rom ( serial "ULUS-10268" )
 )
 
 game (
 	name "Hot Pixel (Europe)"
-	serial "ULES-00642"
-	serial "ULES-00642"
+	rom ( serial "ULES-00642" )
 )
 
 game (
 	name "Hot Pixel (USA) (v1.02)"
-	serial "ULUS-10298"
-	serial "ULUS-10298"
+	rom ( serial "ULUS-10298" )
 )
 
 game (
 	name "Hot Wheels Ultimate Racing (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00828"
-	serial "ULES-00828"
+	rom ( serial "ULES-00828" )
 )
 
 game (
 	name "Hot Wheels Ultimate Racing (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10239"
-	serial "ULUS-10239"
+	rom ( serial "ULUS-10239" )
 )
 
 game (
 	name "Hunter x Hunter - Wonder Adventure (Japan)"
-	serial "NPJH-50624"
-	serial "NPJH-50624"
+	rom ( serial "NPJH-50624" )
 )
 
 game (
 	name "Hustle, The - Detroit Streets (Europe) (En,Fr,De) (v1.02)"
-	serial "ULES-00603"
-	serial "ULES-00603"
+	rom ( serial "ULES-00603" )
 )
 
 game (
 	name "Hustle, The - Detroit Streets (USA) (v1.01)"
-	serial "ULUS-10048"
-	serial "ULUS-10048"
+	rom ( serial "ULUS-10048" )
 )
 
 game (
 	name "Hyakki Yakou - Kaidan Romance (Japan) (v1.02)"
-	serial "ULJM-06184"
-	serial "ULJM-06184"
+	rom ( serial "ULJM-06184" )
 )
 
 game (
 	name "I.Q Mania (Asia) (En,Zh) (v1.01)"
-	serial "UCAS-40065"
-	serial "UCAS-40065"
+	rom ( serial "UCAS-40065" )
 )
 
 game (
 	name "I.Q Mania (Japan) (Beta) [b]"
-	serial "ZZZ_NOT_VALID"
-	serial "ZZZ_NOT_VALID"
 )
 
 game (
 	name "I.Q Mania (Japan) (v1.01)"
-	serial "UCJS-10029"
-	serial "UCJS-10029"
+	rom ( serial "UCJS-10029" )
 )
 
 game (
 	name "IL-2 Sturmovik - Birds of Prey (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01316"
-	serial "ULES-01316"
+	rom ( serial "ULES-01316" )
 )
 
 game (
 	name "IL-2 Sturmovik - Birds of Prey (Russia) (v1.01)"
-	serial "ULES-01317"
-	serial "ULES-01317"
+	rom ( serial "ULES-01317" )
 )
 
 game (
 	name "IL-2 Sturmovik - Birds of Prey (USA) (En,Fr) (v1.02)"
-	serial "ULUS-10476"
-	serial "ULUS-10476"
+	rom ( serial "ULUS-10476" )
 )
 
 game (
 	name "Idol Janshi Suchie-Pai III Remix (Japan) (v1.01)"
-	serial "ULJM-05253"
-	serial "ULJM-05253"
+	rom ( serial "ULJM-05253" )
 )
 
 game (
 	name "Idol Janshi Suchie-Pai IV Portable (Japan) (v1.01)"
-	serial "ULJM-05722"
-	serial "ULJM-05722"
+	rom ( serial "ULJM-05722" )
 )
 
 game (
 	name "Idolmaster SP, The - Missing Moon (Japan) (v1.01)"
-	serial "ULJS-00169"
-	serial "ULJS-00169"
+	rom ( serial "ULJS-00169" )
 )
 
 game (
 	name "Idolmaster SP, The - Perfect Sun (Japan) (v1.01)"
-	serial "ULJS-00167"
-	serial "ULJS-00167"
+	rom ( serial "ULJS-00167" )
 )
 
 game (
 	name "Idolmaster SP, The - Wandering Star (Japan) (v1.01)"
-	serial "ULJS-00168"
-	serial "ULJS-00168"
+	rom ( serial "ULJS-00168" )
 )
 
 game (
 	name "Ikki Tousen - Eloquent Fist (Japan) (v1.01)"
-	serial "ULJS-00152"
-	serial "ULJS-00152"
+	rom ( serial "ULJS-00152" )
 )
 
 game (
 	name "Ikki Tousen - Xross Impact (Japan) (v1.03)"
-	serial "NPJH-50222"
-	serial "NPJH-50222"
+	rom ( serial "NPJH-50222" )
 )
 
 game (
 	name "Imagine - Champion Rider (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
-	serial "ULES-01161"
-	serial "ULES-01161"
+	rom ( serial "ULES-01161" )
 )
 
 game (
 	name "Impossible Mission (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00764"
-	serial "ULES-00764"
+	rom ( serial "ULES-00764" )
 )
 
 game (
 	name "Indiana Jones and the Staff of Kings (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00939"
-	serial "ULES-00939"
+	rom ( serial "ULES-00939" )
 )
 
 game (
 	name "Indiana Jones and the Staff of Kings (USA)"
-	serial "ULUS-10316"
-	serial "ULUS-10316"
+	rom ( serial "ULUS-10316" )
 )
 
 game (
 	name "Infected (Europe) (En,Fr,Es) (v1.01)"
-	serial "ULES-00338"
-	serial "ULES-00338"
+	rom ( serial "ULES-00338" )
 )
 
 game (
 	name "Infected (USA) (v1.02)"
-	serial "ULUS-10054"
-	serial "ULUS-10054"
+	rom ( serial "ULUS-10054" )
 )
 
 game (
 	name "Infinite Loop - Kojou ga Miseta Yume (Japan) (v1.01)"
-	serial "ULJS-00144"
-	serial "ULJS-00144"
+	rom ( serial "ULJS-00144" )
 )
 
 game (
 	name "Initial D - Street Stage (Japan) (v1.01)"
-	serial "ULJM-05093"
-	serial "ULJM-05093"
+	rom ( serial "ULJM-05093" )
 )
 
 game (
 	name "Initial D - Street Stage (Korea) (v1.01)"
-	serial "ULKS-46068"
-	serial "ULKS-46068"
+	rom ( serial "ULKS-46068" )
 )
 
 game (
 	name "Innocent Life - A Futuristic Harvest Moon (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00658"
-	serial "ULES-00658"
+	rom ( serial "ULES-00658" )
 )
 
 game (
 	name "Innocent Life - A Futuristic Harvest Moon (USA)"
-	serial "ULUS-10219"
-	serial "ULUS-10219"
+	rom ( serial "ULUS-10219" )
 )
 
 game (
 	name "International Athletics (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01090"
-	serial "ULES-01090"
+	rom ( serial "ULES-01090" )
 )
 
 game (
 	name "International Cricket Captain III (Europe) (v1.01)"
-	serial "ULES-00835"
-	serial "ULES-00835"
+	rom ( serial "ULES-00835" )
 )
 
 game (
 	name "Invizimals (Asia) (En,Zh)"
-	serial "UCAS-40280"
-	serial "UCAS-40280"
+	rom ( serial "UCAS-40280" )
 )
 
 game (
 	name "Invizimals (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru)"
-	serial "UCES-01241"
-	serial "UCES-01241"
+	rom ( serial "UCES-01241" )
 )
 
 game (
 	name "Invizimals (Korea) (En,Ko)"
-	serial "UCKS-45129"
-	serial "UCKS-45129"
+	rom ( serial "UCKS-45129" )
 )
 
 game (
 	name "Invizimals (USA) (En,Fr,Es) (v1.02)"
-	serial "UCUS-98746"
-	serial "UCUS-98746"
+	rom ( serial "UCUS-98746" )
 )
 
 game (
 	name "Invizimals - Shadow Zone (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru)"
-	serial "UCES-01411"
-	serial "UCES-01411"
+	rom ( serial "UCES-01411" )
 )
 
 game (
 	name "Invizimals - Shadow Zone (USA) (En,Fr,Es,Pt)"
-	serial "UCUS-98760"
-	serial "UCUS-98760"
+	rom ( serial "UCUS-98760" )
 )
 
 game (
 	name "Invizimals - The Lost Tribes (Europe) (En,Fr,De,Es,It,Nl,Pl,Ru) (v1.01)"
-	serial "UCES-01525"
-	serial "UCES-01525"
+	rom ( serial "UCES-01525" )
 )
 
 game (
 	name "Iron Man (Europe) (En,De,It)"
-	serial "ULES-01071"
-	serial "ULES-01071"
+	rom ( serial "ULES-01071" )
 )
 
 game (
 	name "Iron Man (Europe) (En,Fr,Es)"
-	serial "ULES-01070"
-	serial "ULES-01070"
+	rom ( serial "ULES-01070" )
 )
 
 game (
 	name "Iron Man (USA) (En,Fr,Es)"
-	serial "ULUS-10347"
-	serial "ULUS-10347"
+	rom ( serial "ULUS-10347" )
 )
 
 game (
 	name "Iron Man 2 - The Video Game (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01422"
-	serial "ULES-01422"
+	rom ( serial "ULES-01422" )
 )
 
 game (
 	name "Iron Man 2 - The Video Game (USA)"
-	serial "ULUS-10497"
-	serial "ULUS-10497"
+	rom ( serial "ULUS-10497" )
 )
 
 game (
 	name "Ishin Renka Ryoma Gaiden (Japan) (Shokai Seisanban)"
-	serial "ULJS-00334"
-	serial "ULJS-00334"
+	rom ( serial "ULJS-00334" )
 )
 
 game (
 	name "Isle of Minno (Europe) (0.01) (Beta)"
-	serial "UCET-00372"
-	serial "UCET-00372"
+	rom ( serial "UCET-00372" )
 )
 
 game (
 	name "Isshou Asoberu Toudai Shogi - Tsumeshogi Dojo (Japan) (v1.01)"
-	serial "ULJM-05239"
-	serial "ULJM-05239"
+	rom ( serial "ULJM-05239" )
 )
 
 game (
 	name "Itsuka Kono Te ga Kegareru Toki ni - Spectral Force Legacy (Japan) (v1.04)"
-	serial "ULJM-05523"
-	serial "ULJM-05523"
+	rom ( serial "ULJM-05523" )
 )
 
 game (
 	name "Itsuka Tenma no Kuro Usagi Portable (Japan) (v1.01)"
-	serial "ULJM-05961"
-	serial "ULJM-05961"
+	rom ( serial "ULJM-05961" )
 )
 
 game (
 	name "Iza, Shutsujin! Koiikusa (Japan)"
-	serial "ULJM-05876"
-	serial "ULJM-05876"
+	rom ( serial "ULJM-05876" )
 )
 
 game (
 	name "J.League Pro Soccer Club o Tsukurou! 6 - Pride of J (Japan) (v1.01)"
-	serial "NPJH-50076"
-	serial "NPJH-50076"
+	rom ( serial "NPJH-50076" )
 )
 
 game (
 	name "J.League Pro Soccer Club o Tsukurou! 7 Euro Plus (Japan) (v1.02)"
-	serial "NPJH-50464"
-	serial "NPJH-50464"
+	rom ( serial "NPJH-50464" )
 )
 
 game (
 	name "Jackass - The Game (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00897"
-	serial "ULES-00897"
+	rom ( serial "ULES-00897" )
 )
 
 game (
 	name "Jackass - The Game (USA) (v1.02)"
-	serial "ULUS-10303"
-	serial "ULUS-10303"
+	rom ( serial "ULUS-10303" )
 )
 
 game (
 	name "Jak and Daxter - The Lost Frontier (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl)"
-	serial "UCES-01225"
-	serial "UCES-01225"
+	rom ( serial "UCES-01225" )
 )
 
 game (
 	name "Jak and Daxter - The Lost Frontier (USA) (En,Fr,Es)"
-	serial "UCUS-98634"
-	serial "UCUS-98634"
+	rom ( serial "UCUS-98634" )
 )
 
 game (
 	name "James Cameron's Avatar - The Game (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01357"
-	serial "ULES-01357"
+	rom ( serial "ULES-01357" )
 )
 
 game (
 	name "James Cameron's Avatar - The Game (USA) (En,Fr,Es)"
-	serial "ULUS-10451"
-	serial "ULUS-10451"
+	rom ( serial "ULUS-10451" )
 )
 
 game (
 	name "Jan Sangoku Musou (Japan) (v1.02)"
-	serial "ULJM-05136"
-	serial "ULJM-05136"
+	rom ( serial "ULJM-05136" )
 )
 
 game (
 	name "Jeanne d'Arc (Japan)"
-	serial "UCJS-10048"
-	serial "UCJS-10048"
+	rom ( serial "UCJS-10048" )
 )
 
 game (
 	name "Jeanne d'Arc (USA)"
-	serial "UCUS-98700"
-	serial "UCUS-98700"
+	rom ( serial "UCUS-98700" )
 )
 
 game (
 	name "Jeanne d'Arc (USA) (Demo)"
-	serial "UCUS-98706"
-	serial "UCUS-98706"
+	rom ( serial "UCUS-98706" )
 )
 
 game (
 	name "Jet de Go! Pocket - Let's Go By Airliner (Japan) (v1.02)"
-	serial "ULJM-05074"
-	serial "ULJM-05074"
+	rom ( serial "ULJM-05074" )
 )
 
 game (
 	name "Jikandia - The Timeless Land (USA)"
-	serial "ULUS-10562"
-	serial "ULUS-10562"
+	rom ( serial "ULUS-10562" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2010 (Japan) (v1.02)"
-	serial "ULJM-05678"
-	serial "ULJM-05678"
+	rom ( serial "ULJM-05678" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2011 (Japan) (v1.01)"
-	serial "ULJM-05871"
-	serial "ULJM-05871"
+	rom ( serial "ULJM-05871" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2011 Ketteiban (Japan) (v1.01)"
-	serial "ULJM-05991"
-	serial "ULJM-05991"
+	rom ( serial "ULJM-05991" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu 2012 (Japan) (v1.01)"
-	serial "NPJH-50594"
-	serial "NPJH-50594"
+	rom ( serial "NPJH-50594" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu Portable (Japan) (v1.02)"
-	serial "ULJM-05077"
-	serial "ULJM-05077"
+	rom ( serial "ULJM-05077" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu Portable 2 (Japan) (v1.03)"
-	serial "ULJM-05195"
-	serial "ULJM-05195"
+	rom ( serial "ULJM-05195" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu Portable 3 (Japan) (v1.04)"
-	serial "ULJM-05300"
-	serial "ULJM-05300"
+	rom ( serial "ULJM-05300" )
 )
 
 game (
 	name "Jikkyou Powerful Pro Yakyuu Portable 4 (Japan) (v1.01)"
-	serial "ULJM-05421"
-	serial "ULJM-05421"
+	rom ( serial "ULJM-05421" )
 )
 
 game (
 	name "Jissen Pachi-Slot Hisshouhou! Aladdin 2 Evolution Portable (Japan) (v1.02)"
-	serial "ULJM-05112"
-	serial "ULJM-05112"
+	rom ( serial "ULJM-05112" )
 )
 
 game (
 	name "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Portable (Japan) (v1.03)"
-	serial "ULJM-05020"
-	serial "ULJM-05020"
+	rom ( serial "ULJM-05020" )
 )
 
 game (
 	name "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken SE Portable (Japan) (v1.01)"
-	serial "ULJM-05153"
-	serial "ULJM-05153"
+	rom ( serial "ULJM-05153" )
 )
 
 game (
 	name "Jitsuroku Oniyome Nikki - Shiuchi ni Taeru Otto no Rifujin Taiken Adventure (Japan) (v1.02)"
-	serial "ULJM-05100"
-	serial "ULJM-05100"
+	rom ( serial "ULJM-05100" )
 )
 
 game (
 	name "Jitsuwa Kaidan - Shinmimi Bukuro - Ichi no Shou (Japan) (v1.03)"
-	serial "ULJM-05028"
-	serial "ULJM-05028"
+	rom ( serial "ULJM-05028" )
 )
 
 game (
 	name "Joker no Kuni no Alice - Wonderful Wonder World (Japan) (v1.01)"
-	serial "ULJM-05973"
-	serial "ULJM-05973"
+	rom ( serial "ULJM-05973" )
 )
 
 game (
 	name "Ju and Ryu Toeic LC (Korea)"
-	serial "ULKS-46098"
-	serial "ULKS-46098"
-)
-
-game (
-	name "Ju and Ryu Toeic LC (Korea)"
-	serial "ULKS-46098"
-	serial "ULKS-46098"
+	rom ( serial "ULKS-46098" )
 )
 
 game (
 	name "Judie no Atelier - Gramnad no Renkinjutsushi - Toraware no Moribito (Japan) (v1.02)"
-	serial "ULJM-05607"
-	serial "ULJM-05607"
+	rom ( serial "ULJM-05607" )
 )
 
 game (
 	name "Jui - Dr. Toma Jotaro (Japan) (v1.02)"
-	serial "ULJM-05098"
-	serial "ULJM-05098"
+	rom ( serial "ULJM-05098" )
 )
 
 game (
 	name "Juiced 2 - Hot Import Nights (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00928"
-	serial "ULES-00928"
+	rom ( serial "ULES-00928" )
 )
 
 game (
 	name "Juiced 2 - Hot Import Nights (USA) (v1.02)"
-	serial "ULUS-10312"
-	serial "ULUS-10312"
+	rom ( serial "ULUS-10312" )
 )
 
 game (
 	name "Juiced Eliminator (Europe) (v1.01)"
-	serial "ULES-00379"
-	serial "ULES-00379"
+	rom ( serial "ULES-00379" )
 )
 
 game (
 	name "Juiced Eliminator (Japan) (v1.02)"
-	serial "ULJM-05154"
-	serial "ULJM-05154"
+	rom ( serial "ULJM-05154" )
 )
 
 game (
 	name "Juiced Eliminator (USA)"
-	serial "ULUS-10090"
-	serial "ULUS-10090"
+	rom ( serial "ULUS-10090" )
 )
 
 game (
 	name "Jukugon (Japan)"
-	serial "ULJM-05139"
-	serial "ULJM-05139"
+	rom ( serial "ULJM-05139" )
 )
 
 game (
 	name "Jungle Party (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru,El) (v1.01)"
-	serial "UCES-01459"
-	serial "UCES-01459"
+	rom ( serial "UCES-01459" )
 )
 
 game (
 	name "Just English (Korea) (v1.03)"
-	serial "ULKS-46090"
-	serial "ULKS-46090"
+	rom ( serial "ULKS-46090" )
 )
 
 game (
 	name "Justice League Heroes (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00609"
-	serial "ULES-00609"
+	rom ( serial "ULES-00609" )
 )
 
 game (
 	name "Justice League Heroes (USA) (v1.01)"
-	serial "ULUS-10214"
-	serial "ULUS-10214"
+	rom ( serial "ULUS-10214" )
 )
 
 game (
 	name "Juujigen Rippoutai Cipher Portable (Japan) (v1.02)"
-	serial "ULJM-05491"
-	serial "ULJM-05491"
+	rom ( serial "ULJM-05491" )
 )
 
 game (
 	name "Juusei to Diamond (Japan)"
-	serial "UCJS-10092"
-	serial "UCJS-10092"
+	rom ( serial "UCJS-10092" )
 )
 
 game (
 	name "Juuza Engi - Engetsu Sangokuden (Japan) (v1.01)"
-	serial "ULJM-06090"
-	serial "ULJM-06090"
+	rom ( serial "ULJM-06090" )
 )
 
 game (
 	name "K-ON! Houkago Live!! (Japan) (v1.01)"
-	serial "ULJM-05709"
-	serial "ULJM-05709"
+	rom ( serial "ULJM-05709" )
 )
 
 game (
 	name "KAZooK! (Europe) (En,Fr,De,It) (v1.01)"
-	serial "ULES-00517"
-	serial "ULES-00517"
+	rom ( serial "ULES-00517" )
 )
 
 game (
 	name "Kaeru Batake de Tsukamaete - Natsu Chigira Sansen! Portable (Japan)"
-	serial "ULJS-00388"
-	serial "ULJS-00388"
+	rom ( serial "ULJS-00388" )
 )
 
 game (
 	name "Kaeru Batake de Tsukamaete Portable (Japan) (v1.02)"
-	serial "ULJS-00341"
-	serial "ULJS-00341"
+	rom ( serial "ULJS-00341" )
 )
 
 game (
 	name "Kaitou Apricot Portable (Japan) (v1.04)"
-	serial "ULJM-05276"
-	serial "ULJM-05276"
+	rom ( serial "ULJM-05276" )
 )
 
 game (
 	name "Kaitou Tenshi Twin Angel - Toki to Sekai no Meikyuu (Japan) (v1.01)"
-	serial "ULJM-05908"
-	serial "ULJM-05908"
+	rom ( serial "ULJM-05908" )
 )
 
 game (
 	name "Kamaitachi no Yoru 2 - Tokubetsuhen (Japan) (v2.00)"
-	serial "ULJM-05110"
-	serial "ULJM-05110"
+	rom ( serial "ULJM-05110" )
 )
 
 game (
 	name "Kameleon (Europe) (v1.01)"
-	serial "ULES-00369"
-	serial "ULES-00369"
+	rom ( serial "ULES-00369" )
 )
 
 game (
 	name "Kamen Rider Climax Heroes Fourze (Japan)"
-	serial "NPJH-50502"
-	serial "NPJH-50502"
+	rom ( serial "NPJH-50502" )
 )
 
 game (
 	name "Kamen Rider Climax Heroes OOO (Japan) (v1.02)"
-	serial "ULJS-00331"
-	serial "ULJS-00331"
+	rom ( serial "ULJS-00331" )
 )
 
 game (
 	name "Kamen no Maid Guy - Boyoyon Battle Royale (Japan)"
-	serial "ULJM-05418"
-	serial "ULJM-05418"
+	rom ( serial "ULJM-05418" )
 )
 
 game (
 	name "Kami Naru Kimi to (Japan) (v1.02)"
-	serial "ULJM-05975"
-	serial "ULJM-05975"
+	rom ( serial "ULJM-05975" )
 )
 
 game (
 	name "Kamigami no Asobi InFinite (Japan)"
-	serial "NPJH-50909"
-	serial "NPJH-50909"
+	rom ( serial "NPJH-50909" )
 )
 
 game (
 	name "Kamisama to Koi Gokoro (Japan) (v1.02)"
-	serial "ULJS-00509"
-	serial "ULJS-00509"
+	rom ( serial "ULJS-00509" )
 )
 
 game (
 	name "Kana - Imouto (Japan) (v1.01)"
-	serial "ULJM-05768"
-	serial "ULJM-05768"
+	rom ( serial "ULJM-05768" )
 )
 
 game (
 	name "Kannou Mukashi Banashi Portable (Japan) (v1.01)"
-	serial "ULJM-06015"
-	serial "ULJM-06015"
+	rom ( serial "ULJM-06015" )
 )
 
 game (
 	name "Kanon (Japan) (v1.02)"
-	serial "ULJM-05203"
-	serial "ULJM-05203"
+	rom ( serial "ULJM-05203" )
 )
 
 game (
 	name "Kanuchi - Futatsu no Tsubasa (Japan)"
-	serial "ULJM-05797"
-	serial "ULJM-05797"
-)
-
-game (
-	name "Kanuchi - Futatsu no Tsubasa (Japan)"
-	serial "ULJM-05797"
-	serial "ULJM-05797"
+	rom ( serial "ULJM-05797" )
 )
 
 game (
 	name "Kao Challengers (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00146"
-	serial "ULES-00146"
+	rom ( serial "ULES-00146" )
 )
 
 game (
 	name "Kao Challengers (USA) (v1.01)"
-	serial "ULUS-10085"
-	serial "ULUS-10085"
+	rom ( serial "ULUS-10085" )
 )
 
 game (
 	name "Katekyoo Hitman Reborn! Battle Arena (Japan) (v1.01)"
-	serial "ULJS-00157"
-	serial "ULJS-00157"
+	rom ( serial "ULJS-00157" )
 )
 
 game (
 	name "Katekyoo Hitman Reborn! Battle Arena 2 - Spirits Burst (Japan) (v1.03)"
-	serial "ULJS-00218"
-	serial "ULJS-00218"
+	rom ( serial "ULJS-00218" )
 )
 
 game (
 	name "Katekyoo Hitman Reborn! Kizuna no Tag Battle (Japan) (v1.01)"
-	serial "NPJH-50221"
-	serial "NPJH-50221"
+	rom ( serial "NPJH-50221" )
 )
 
 game (
 	name "Kazoku Keikaku (Japan) (v1.01)"
-	serial "ULJM-05721"
-	serial "ULJM-05721"
+	rom ( serial "ULJM-05721" )
 )
 
 game (
 	name "Keibatsuu Portable (Japan) (v1.02)"
-	serial "ULJM-05326"
-	serial "ULJM-05326"
+	rom ( serial "ULJM-05326" )
 )
 
 game (
 	name "Keibatsuu Portable 2 - JRA Koushiki Data 23 Nenbun Shuuroku (Japan) (v1.02)"
-	serial "ULJM-05455"
-	serial "ULJM-05455"
+	rom ( serial "ULJM-05455" )
 )
 
 game (
 	name "Ken to Mahou to Gakuen Mono. 3 (Japan) (v1.01)"
-	serial "ULJM-05735"
-	serial "ULJM-05735"
+	rom ( serial "ULJM-05735" )
 )
 
 game (
 	name "Ken to Mahou to Gakuen Mono. Final - Shinnyusei wa Ohimesama (Japan) (v1.01)"
-	serial "ULJM-05965"
-	serial "ULJM-05965"
+	rom ( serial "ULJM-05965" )
 )
 
 game (
 	name "Kenka Bancho - Badass Rumble (USA)"
-	serial "ULUS-10442"
-	serial "ULUS-10442"
+	rom ( serial "ULUS-10442" )
 )
 
 game (
 	name "Kenka Banchou 4 - One Year War (Japan) (v1.01)"
-	serial "ULJS-00268"
-	serial "ULJS-00268"
+	rom ( serial "ULJS-00268" )
 )
 
 game (
 	name "Kenka Banchou 5 - Otoko no Rule (Japan) (v1.02)"
-	serial "ULJS-00359"
-	serial "ULJS-00359"
+	rom ( serial "ULJS-00359" )
 )
 
 game (
 	name "Kenka Banchou Bros. Tokyo Battle Royale (Japan) (v1.02)"
-	serial "ULJS-00517"
-	serial "ULJS-00517"
+	rom ( serial "ULJS-00517" )
 )
 
 game (
 	name "Kenka Banchou Portable (Japan) (v1.02)"
-	serial "ULJS-00235"
-	serial "ULJS-00235"
+	rom ( serial "ULJS-00235" )
 )
 
 game (
 	name "Key of Heaven (Europe) (Beta)"
-	serial "UCET-00247"
-	serial "UCET-00247"
+	rom ( serial "UCET-00247" )
 )
 
 game (
 	name "Key of Heaven (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00178"
-	serial "UCES-00178"
+	rom ( serial "UCES-00178" )
 )
 
 game (
 	name "Kidou Keisatsu Patlabor - Kamubakku MiniPato (Japan)"
-	serial "ULJS-00026"
-	serial "ULJS-00026"
+	rom ( serial "ULJS-00026" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Gihren no Yabou - Axis no Kyoui (Japan) (v1.03)"
-	serial "ULJS-00131"
-	serial "ULJS-00131"
+	rom ( serial "ULJS-00131" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Gihren no Yabou - Axis no Kyoui V (Japan) (v1.01)"
-	serial "ULJS-00178"
-	serial "ULJS-00178"
+	rom ( serial "ULJS-00178" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Gihren no Yabou - Zeon no Keifu (Japan) (v1.02)"
-	serial "ULJS-00022"
-	serial "ULJS-00022"
+	rom ( serial "ULJS-00022" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Gundam vs. Gundam (Japan)"
-	serial "ULJS-00165"
-	serial "ULJS-00165"
+	rom ( serial "ULJS-00165" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Gundam vs. Gundam NEXT PLUS (Japan)"
-	serial "NPJH-50107"
-	serial "NPJH-50107"
+	rom ( serial "NPJH-50107" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Mokuba no Kiseki (Japan) (v1.01)"
-	serial "NPJH-50442"
-	serial "NPJH-50442"
+	rom ( serial "NPJH-50442" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Senjou no Kizuna Portable (Japan) (v1.02)"
-	serial "ULJS-00181"
-	serial "ULJS-00181"
+	rom ( serial "ULJS-00181" )
 )
 
 game (
 	name "Kidou Senshi Gundam - Senjou no Kizuna Portable (Korea) (v1.02)"
-	serial "ULJS-00181"
-	serial "ULJS-00181"
 )
 
 game (
 	name "Kidou Senshi Gundam - Shin Gihren no Yabou (Japan) (v1.01)"
-	serial "NPJH-50441"
-	serial "NPJH-50441"
+	rom ( serial "NPJH-50441" )
 )
 
 game (
 	name "Kidou Senshi Gundam AGE - Cosmic Drive (Japan) (v1.02)"
-	serial "NPJH-50567"
-	serial "NPJH-50567"
+	rom ( serial "NPJH-50567" )
 )
 
 game (
 	name "Kidou Senshi Gundam AGE - Universe Accel (Japan) (v1.03)"
-	serial "NPJH-50566"
-	serial "NPJH-50566"
+	rom ( serial "NPJH-50566" )
 )
 
 game (
 	name "Kidou Senshi Gundam Seed - Rengou vs. Z.A.F.T. Portable (Japan) (Demo)"
-	serial "ULJM-91009"
-	serial "ULJM-91009"
+	rom ( serial "ULJM-91009" )
 )
 
 game (
 	name "Kidou Senshi Gundam Seed - Rengou vs. Z.A.F.T. Portable (Japan) (v1.01)"
-	serial "ULJM-05238"
-	serial "ULJM-05238"
+	rom ( serial "ULJM-05238" )
 )
 
 game (
 	name "Kiite Oboeru Eitango - Alc no Kikutan Advanced (Japan)"
-	serial "ULJM-05461"
-	serial "ULJM-05461"
+	rom ( serial "ULJM-05461" )
 )
 
 game (
 	name "Kiite Oboeru Eitango - Alc no Kikutan Basic (Japan)"
-	serial "ULJM-05460"
-	serial "ULJM-05460"
+	rom ( serial "ULJM-05460" )
 )
 
 game (
 	name "Kiite Oboeru Eitango - Alc no Kikutan Entry (Japan)"
-	serial "ULJM-05459"
-	serial "ULJM-05459"
+	rom ( serial "ULJM-05459" )
 )
 
 game (
 	name "Killzone - Liberation (Europe) (En,Fr,De,Es,It,Nl,Pl,Ru)"
-	serial "UCES-00279"
-	serial "UCES-00279"
+	rom ( serial "UCES-00279" )
 )
 
 game (
 	name "Killzone - Liberation (Korea)"
-	serial "UCKS-45041"
-	serial "UCKS-45041"
+	rom ( serial "UCKS-45041" )
 )
 
 game (
 	name "Killzone - Liberation (USA) (Beta)"
-	serial "UCUS-98646"
-	serial "UCUS-98646"
+	rom ( serial "UCUS-98646" )
 )
 
 game (
 	name "Killzone - Liberation (USA) (Demo)"
-	serial "UCUS-98670"
-	serial "UCUS-98670"
+	rom ( serial "UCUS-98670" )
 )
 
 game (
 	name "Killzone - Liberation (USA) (En,Fr,De,Es,It,Nl,Pl,Ru)"
-	serial "UCUS-98646"
-	serial "UCUS-98646"
 )
 
 game (
 	name "Kimi ga Aruji de Shitsuji ga Ore de - Otsukae Nikki Portable (Japan)"
-	serial "ULJM-06183"
-	serial "ULJM-06183"
+	rom ( serial "ULJM-06183" )
 )
 
 game (
 	name "Kimikare - Shingakki (Japan) (v1.01)"
-	serial "ULJM-06127"
-	serial "ULJM-06127"
+	rom ( serial "ULJM-06127" )
 )
 
 game (
 	name "King of Clubs (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-00914"
-	serial "ULES-00914"
+	rom ( serial "ULES-00914" )
 )
 
 game (
 	name "King of Fighters Collection, The - The Orochi Saga (Asia)"
-	serial "ULUS-10360"
-	serial "ULUS-10360"
+	rom ( serial "ULUS-10360" )
 )
 
 game (
 	name "King of Fighters Collection, The - The Orochi Saga (Europe) (v1.01)"
-	serial "ULES-01191"
-	serial "ULES-01191"
+	rom ( serial "ULES-01191" )
 )
 
 game (
 	name "King of Fighters Collection, The - The Orochi Saga (USA)"
-	serial "ULUS-10360"
-	serial "ULUS-10360"
 )
 
 game (
 	name "King of Pool (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01164"
-	serial "ULES-01164"
+	rom ( serial "ULES-01164" )
 )
 
 game (
 	name "King's Field - Additional I (Japan) (v1.02)"
-	serial "ULJS-00070"
-	serial "ULJS-00070"
+	rom ( serial "ULJS-00070" )
 )
 
 game (
 	name "King's Field - Additional II (Japan) (v1.01)"
-	serial "ULJS-00076"
-	serial "ULJS-00076"
+	rom ( serial "ULJS-00076" )
 )
 
 game (
 	name "Kingdom - Ikkitousen no Ken (Japan) (v1.01)"
-	serial "ULJM-05784"
-	serial "ULJM-05784"
+	rom ( serial "ULJM-05784" )
 )
 
 game (
 	name "Kingdom Hearts - Birth by Sleep (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01441"
-	serial "ULES-01441"
+	rom ( serial "ULES-01441" )
 )
 
 game (
 	name "Kingdom Hearts - Birth by Sleep (Japan) (Final Mix)"
-	serial "ULJM-05775"
-	serial "ULJM-05775"
+	rom ( serial "ULJM-05775" )
 )
 
 game (
 	name "Kingdom Hearts - Birth by Sleep (Japan) (v1.02)"
-	serial "ULJM-05600"
-	serial "ULJM-05600"
+	rom ( serial "ULJM-05600" )
 )
 
 game (
 	name "Kingdom Hearts - Birth by Sleep (USA) (En,Fr,Es)"
-	serial "ULUS-10505"
-	serial "ULUS-10505"
+	rom ( serial "ULUS-10505" )
 )
 
 game (
 	name "Kiniro no Corda (Japan) (v1.01)"
-	serial "ULJM-05054"
-	serial "ULJM-05054"
+	rom ( serial "ULJM-05054" )
 )
 
 game (
 	name "Kiniro no Corda 2 Forte (Japan) (v1.01)"
-	serial "ULJM-05428"
-	serial "ULJM-05428"
+	rom ( serial "ULJM-05428" )
 )
 
 game (
 	name "Kiniro no Corda 2 Forte Encore (Japan) (v1.01)"
-	serial "ULJM-05508"
-	serial "ULJM-05508"
+	rom ( serial "ULJM-05508" )
 )
 
 game (
 	name "Kiniro no Corda 3 (Japan) (v1.01)"
-	serial "ULJM-05624"
-	serial "ULJM-05624"
+	rom ( serial "ULJM-05624" )
 )
 
 game (
 	name "Kinnikuman - Muscle Generations (Japan) (v1.02)"
-	serial "ULJS-00046"
-	serial "ULJS-00046"
+	rom ( serial "ULJS-00046" )
 )
 
 game (
 	name "Kirameki School Life SP - The Wonder Years (Japan) (v1.03)"
-	serial "ULJS-00458"
-	serial "ULJS-00458"
+	rom ( serial "ULJS-00458" )
 )
 
 game (
 	name "Knights in the Nightmare (Japan)"
-	serial "ULJM-05502"
-	serial "ULJM-05502"
+	rom ( serial "ULJM-05502" )
 )
 
 game (
 	name "Knights in the Nightmare (USA)"
-	serial "ULUS-10539"
-	serial "ULUS-10539"
+	rom ( serial "ULUS-10539" )
 )
 
 game (
 	name "Koi Sentai Love & Peace the P.S.P. - Power Zenkai! Special Youso Tenkomori de Portable Ka Daisakusen de Aru! (Japan) (v1.01)"
-	serial "ULJM-06073"
-	serial "ULJM-06073"
+	rom ( serial "ULJM-06073" )
 )
 
 game (
 	name "Koi to Senkyo to Chocolate Portable (Japan) (v1.01)"
-	serial "ULJS-00526"
-	serial "ULJS-00526"
+	rom ( serial "ULJS-00526" )
 )
 
 game (
 	name "Koi wa Rule ni Shibararenai! (Japan)"
-	serial "NPJH-50704"
-	serial "NPJH-50704"
+	rom ( serial "NPJH-50704" )
 )
 
 game (
 	name "Koisuru Otome to Shugo no Tate Portable (Japan) (v1.01)"
-	serial "ULJM-05635"
-	serial "ULJM-05635"
+	rom ( serial "ULJM-05635" )
 )
 
 game (
 	name "Koloomn (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00143"
-	serial "ULES-00143"
+	rom ( serial "ULES-00143" )
 )
 
 game (
 	name "Konneko - Keep a Memory Green (Japan)"
-	serial "ULJM-05996"
-	serial "ULJM-05996"
+	rom ( serial "ULJM-05996" )
 )
 
 game (
 	name "Kono Aozora ni Yakusoku o - Tenohira no Rakuen (Japan) (v1.04)"
-	serial "ULJM-05442"
-	serial "ULJM-05442"
+	rom ( serial "ULJM-05442" )
 )
 
 game (
 	name "Kono Bushitsu wa Kitaku Shinai Bu ga Senkyo Shimashita. Portable - Gakuen Dog Ear Hen (Japan)"
-	serial "ULJM-06110"
-	serial "ULJM-06110"
+	rom ( serial "ULJM-06110" )
 )
 
 game (
 	name "Kono Bushitsu wa Kitaku Shinai Bu ga Senkyo Shimashita. Portable - Gakuen Summer Wars Hen (Japan) (v1.03)"
-	serial "ULJM-06109"
-	serial "ULJM-06109"
+	rom ( serial "ULJM-06109" )
 )
 
 game (
 	name "Koori no Haka - Ichiyanagi Nagomu, 3-dome no Junan (Japan) (v1.03)"
-	serial "NPJH-50186"
-	serial "NPJH-50186"
+	rom ( serial "NPJH-50186" )
 )
 
 game (
 	name "Kotoba no Puzzle - Mojipittan Daijiten (Japan)"
-	serial "ULJS-00002"
-	serial "ULJS-00002"
+	rom ( serial "ULJS-00002" )
 )
 
 game (
 	name "Koukyou Shihen Eureka Seven (Japan) (v1.02)"
-	serial "ULJS-00056"
-	serial "ULJS-00056"
+	rom ( serial "ULJS-00056" )
 )
 
 game (
 	name "Kuon no Kizuna - Sairin Mikotonori Portable (Japan) (v1.02)"
-	serial "ULJM-05981"
-	serial "ULJM-05981"
+	rom ( serial "ULJM-05981" )
 )
 
 game (
 	name "Kurogane no Linebarrels (Japan) (v1.01)"
-	serial "ULJM-05495"
-	serial "ULJM-05495"
+	rom ( serial "ULJM-05495" )
 )
 
 game (
 	name "Kurohyou - Ryu ga Gotoku Shinshou (Japan) (v1.02)"
-	serial "NPJH-50333"
-	serial "NPJH-50333"
+	rom ( serial "NPJH-50333" )
 )
 
 game (
 	name "Kurohyou 2 - Ryu ga Gotoku Ashura Hen (Japan) (v1.01)"
-	serial "NPJH-50562"
-	serial "NPJH-50562"
+	rom ( serial "NPJH-50562" )
 )
 
 game (
 	name "Kuroko no Basuke - Kiseki no Game (Japan) (v1.01)"
-	serial "NPJH-50635"
-	serial "NPJH-50635"
+	rom ( serial "NPJH-50635" )
 )
 
 game (
 	name "Kyoto Daigaku Atsuji Tetsuji Kyouju Kanshuu - Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Kyouryoku - Kanji Trainer Portable (Japan) (v1.01)"
-	serial "ULJM-05201"
-	serial "ULJM-05201"
+	rom ( serial "ULJM-05201" )
 )
 
 game (
 	name "L no Kisetsu - Double Pocket (Japan) (v1.01)"
-	serial "ULJM-05555"
-	serial "ULJM-05555"
+	rom ( serial "ULJM-05555" )
 )
 
 game (
 	name "L.A. Rush (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00554"
-	serial "ULES-00554"
+	rom ( serial "ULES-00554" )
 )
 
 game (
 	name "L.G.S Shinsetsu Houshinengi (Japan) (v1.02)"
-	serial "ULJM-06131"
-	serial "ULJM-06131"
+	rom ( serial "ULJM-06131" )
 )
 
 game (
 	name "LEGO Batman - The Video Game (Europe) (En,Fr,De,Es,It,Da)"
-	serial "ULES-01151"
-	serial "ULES-01151"
+	rom ( serial "ULES-01151" )
 )
 
 game (
 	name "LEGO Batman - The Video Game (USA)"
-	serial "ULUS-10380"
-	serial "ULUS-10380"
+	rom ( serial "ULUS-10380" )
 )
 
 game (
 	name "LEGO Harry Potter - Years 1-4 (Europe) (En,Fr,De,Es,It,Da) (v2.01)"
-	serial "ULES-01351"
-	serial "ULES-01351"
+	rom ( serial "ULES-01351" )
 )
 
 game (
 	name "LEGO Harry Potter - Years 1-4 (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-01351"
-	serial "ULES-01351"
 )
 
 game (
 	name "LEGO Harry Potter - Years 1-4 (USA)"
-	serial "ULUS-10500"
-	serial "ULUS-10500"
+	rom ( serial "ULUS-10500" )
 )
 
 game (
 	name "LEGO Harry Potter - Years 5-7 (Europe) (En,Fr,De,Es,It,Da)"
-	serial "ULES-01532"
-	serial "ULES-01532"
+	rom ( serial "ULES-01532" )
 )
 
 game (
 	name "LEGO Harry Potter - Years 5-7 (Europe) (En,Pl,Ru)"
-	serial "ULES-01558"
-	serial "ULES-01558"
+	rom ( serial "ULES-01558" )
 )
 
 game (
 	name "LEGO Harry Potter - Years 5-7 (USA) (En,Fr,Es,Pt)"
-	serial "ULUS-10580"
-	serial "ULUS-10580"
+	rom ( serial "ULUS-10580" )
 )
 
 game (
 	name "LEGO Indiana Jones - The Original Adventures (Europe) (En,Fr,De,Es,It,Da) (v1.01)"
-	serial "ULES-01086"
-	serial "ULES-01086"
+	rom ( serial "ULES-01086" )
 )
 
 game (
 	name "LEGO Indiana Jones - The Original Adventures (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10365"
-	serial "ULUS-10365"
+	rom ( serial "ULUS-10365" )
 )
 
 game (
 	name "LEGO Indiana Jones 2 - The Adventure Continues (Europe) (En,Fr,De,Es,It,Pt) (v1.01)"
-	serial "ULES-01370"
-	serial "ULES-01370"
+	rom ( serial "ULES-01370" )
 )
 
 game (
 	name "LEGO Indiana Jones 2 - The Adventure Continues (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10487"
-	serial "ULUS-10487"
+	rom ( serial "ULUS-10487" )
 )
 
 game (
 	name "LEGO Pirates of the Caribbean - The Video Game (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da)"
-	serial "ULES-01528"
-	serial "ULES-01528"
+	rom ( serial "ULES-01528" )
 )
 
 game (
 	name "LEGO Pirates of the Caribbean - The Video Game (Russia)"
-	serial "ULES-01529"
-	serial "ULES-01529"
+	rom ( serial "ULES-01529" )
 )
 
 game (
 	name "LEGO Pirates of the Caribbean - The Video Game (USA) (En,Fr,Es)"
-	serial "ULUS-10575"
-	serial "ULUS-10575"
+	rom ( serial "ULUS-10575" )
 )
 
 game (
 	name "LEGO Star Wars II - The Original Trilogy (Europe) (En,Fr,De,Es,It,Da) (v1.02)"
-	serial "ULES-00479"
-	serial "ULES-00479"
+	rom ( serial "ULES-00479" )
 )
 
 game (
 	name "LEGO Star Wars II - The Original Trilogy (USA) (v1.01)"
-	serial "ULUS-10155"
-	serial "ULUS-10155"
+	rom ( serial "ULUS-10155" )
 )
 
 game (
 	name "LEGO Star Wars III - The Clone Wars (Europe) (En,Fr,De,Es,It,Da) (v1.01)"
-	serial "ULES-01446"
-	serial "ULES-01446"
+	rom ( serial "ULES-01446" )
 )
 
 game (
 	name "LEGO Star Wars III - The Clone Wars (USA) (En,Fr,Es)"
-	serial "ULUS-10531"
-	serial "ULUS-10531"
+	rom ( serial "ULUS-10531" )
 )
 
 game (
 	name "LairLand Story - Shoujo no Yakujou (Japan)"
-	serial "ULJM-05387"
-	serial "ULJM-05387"
+	rom ( serial "ULJM-05387" )
 )
 
 game (
 	name "Lanfeust of Troy (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01022"
-	serial "ULES-01022"
+	rom ( serial "ULES-01022" )
 )
 
 game (
 	name "Last Escort - Club Katze (Japan) (v1.02)"
-	serial "ULJS-00256"
-	serial "ULJS-00256"
+	rom ( serial "ULJS-00256" )
 )
 
 game (
 	name "Last Ranker (Japan) (v1.01)"
-	serial "ULJM-05676"
-	serial "ULJM-05676"
+	rom ( serial "ULJM-05676" )
 )
 
 game (
 	name "Legend of Heroes II, The - Prophecy of the Moonlight Witch (USA)"
-	serial "ULUS-10125"
-	serial "ULUS-10125"
+	rom ( serial "ULUS-10125" )
 )
 
 game (
 	name "Legend of Heroes III, The - Song of the Ocean (USA) (v1.01)"
-	serial "ULUS-10144"
-	serial "ULUS-10144"
+	rom ( serial "ULUS-10144" )
 )
 
 game (
 	name "Legend of Heroes, The - A Tear of Vermillion (USA) (v1.01)"
-	serial "ULUS-10022"
-	serial "ULUS-10022"
+	rom ( serial "ULUS-10022" )
 )
 
 game (
 	name "Legend of Heroes, The - Trails in the Sky (Europe)"
-	serial "ULES-01556"
-	serial "ULES-01556"
+	rom ( serial "ULES-01556" )
 )
 
 game (
 	name "Legend of Heroes, The - Trails in the Sky (USA)"
-	serial "ULUS-10540"
-	serial "ULUS-10540"
+	rom ( serial "ULUS-10540" )
 )
 
 game (
 	name "Legend of the Dragon (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00695"
-	serial "ULES-00695"
+	rom ( serial "ULES-00695" )
 )
 
 game (
 	name "Legend of the Dragon (USA) (v1.03)"
-	serial "ULUS-10250"
-	serial "ULUS-10250"
+	rom ( serial "ULUS-10250" )
 )
 
 game (
 	name "Lemmings (Europe) (Beta)"
-	serial "UCET-00179"
-	serial "UCET-00179"
+	rom ( serial "UCET-00179" )
 )
 
 game (
 	name "Lemmings (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00109"
-	serial "UCES-00109"
+	rom ( serial "UCES-00109" )
 )
 
 game (
 	name "Lemmings (Japan)"
-	serial "UCJS-10028"
-	serial "UCJS-10028"
+	rom ( serial "UCJS-10028" )
 )
 
 game (
 	name "Lemmings (USA) (Demo)"
-	serial "UCUS-98671"
-	serial "UCUS-98671"
+	rom ( serial "UCUS-98671" )
 )
 
 game (
 	name "Lemmings (USA) (v1.01)"
-	serial "UCUS-98647"
-	serial "UCUS-98647"
+	rom ( serial "UCUS-98647" )
 )
 
 game (
 	name "Like Life Every Hour (Japan) (v1.03)"
-	serial "ULJM-05507"
-	serial "ULJM-05507"
+	rom ( serial "ULJM-05507" )
 )
 
 game (
 	name "Lisa to Issho ni Tairiku Oudan - A-Ressha de Ikou (Japan) (v1.01)"
-	serial "ULJM-05137"
-	serial "ULJM-05137"
+	rom ( serial "ULJM-05137" )
 )
 
 game (
 	name "Little Aid Portable (Japan) (v1.02)"
-	serial "ULJM-05249"
-	serial "ULJM-05249"
+	rom ( serial "ULJM-05249" )
 )
 
 game (
 	name "Little Busters - Converted Edition (Japan)"
-	serial "ULJM-05789"
-	serial "ULJM-05789"
-)
-
-game (
-	name "Little Busters - Converted Edition (Japan)"
-	serial "ULJM-05789"
-	serial "ULJM-05789"
+	rom ( serial "ULJM-05789" )
 )
 
 game (
 	name "Little Witch Parfait - Kuroneko Mahouten Monogatari (Japan) (v1.03)"
-	serial "ULJM-06019"
-	serial "ULJM-06019"
+	rom ( serial "ULJM-06019" )
 )
 
 game (
 	name "LittleBigPlanet (Asia) (En,Zh,Ko)"
-	serial "UCAS-40262"
-	serial "UCAS-40262"
+	rom ( serial "UCAS-40262" )
 )
 
 game (
 	name "LittleBigPlanet (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru) (v1.01)"
-	serial "UCES-01264"
-	serial "UCES-01264"
+	rom ( serial "UCES-01264" )
 )
 
 game (
 	name "LittleBigPlanet (Japan) (v1.01)"
-	serial "UCJS-10107"
-	serial "UCJS-10107"
+	rom ( serial "UCJS-10107" )
 )
 
 game (
 	name "LittleBigPlanet (USA) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl)"
-	serial "UCUS-98744"
-	serial "UCUS-98744"
+	rom ( serial "UCUS-98744" )
 )
 
 game (
 	name "LocoRoco (Asia) (En,Zh)"
-	serial "UCAS-40063"
-	serial "UCAS-40063"
+	rom ( serial "UCAS-40063" )
 )
 
 game (
 	name "LocoRoco (Europe) (Demo)"
-	serial "UCED-00365"
-	serial "UCED-00365"
+	rom ( serial "UCED-00365" )
 )
 
 game (
 	name "LocoRoco (Europe) (En,Fr,De,Es,It,Nl,Pt,No,Da,Fi,Ru) (Beta) [b]"
-	serial "UCET-00357"
-	serial "UCET-00357"
+	rom ( serial "UCET-00357" )
 )
 
 game (
 	name "LocoRoco (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Ru) (v1.01)"
-	serial "UCES-00304"
-	serial "UCES-00304"
+	rom ( serial "UCES-00304" )
 )
 
 game (
 	name "LocoRoco (Japan) (v1.01)"
-	serial "UCJS-10041"
-	serial "UCJS-10041"
+	rom ( serial "UCJS-10041" )
 )
 
 game (
 	name "LocoRoco (Japan) (v1.01) (Toku Toku Pack)"
-	serial "UCJB-98011"
-	serial "UCJB-98011"
+	rom ( serial "UCJB-98011" )
 )
 
 game (
 	name "LocoRoco (Korea)"
-	serial "UCKS-45020"
-	serial "UCKS-45020"
+	rom ( serial "UCKS-45020" )
 )
 
 game (
 	name "LocoRoco (USA)"
-	serial "UCUS-98662"
-	serial "UCUS-98662"
+	rom ( serial "UCUS-98662" )
 )
 
 game (
 	name "LocoRoco (USA) (Demo)"
-	serial "UCUS-98685"
-	serial "UCUS-98685"
+	rom ( serial "UCUS-98685" )
 )
 
 game (
 	name "LocoRoco (USA) (En,Ja,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Zh,Ko,Ru) (v0.10) (Beta) (Test Sample)"
-	serial "UCUS-98662"
-	serial "UCUS-98662"
 )
 
 game (
 	name "LocoRoco 2 (Asia) (En,Zh,Ko) (v1.02)"
-	serial "UCAS-40222"
-	serial "UCAS-40222"
+	rom ( serial "UCAS-40222" )
 )
 
 game (
 	name "LocoRoco 2 (Europe) (En,Fr,De,Es,It) (Beta)"
-	serial "UCET-01181"
-	serial "UCET-01181"
+	rom ( serial "UCET-01181" )
 )
 
 game (
 	name "LocoRoco 2 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Ru)"
-	serial "UCES-01059"
-	serial "UCES-01059"
+	rom ( serial "UCES-01059" )
 )
 
 game (
 	name "LocoRoco 2 (Japan) (v1.02)"
-	serial "UCJS-10087"
-	serial "UCJS-10087"
+	rom ( serial "UCJS-10087" )
 )
 
 game (
 	name "LocoRoco 2 (USA)"
-	serial "UCUS-98731"
-	serial "UCUS-98731"
+	rom ( serial "UCUS-98731" )
 )
 
 game (
 	name "Lord of Apocalypse (Japan) (v1.01)"
-	serial "NPJH-50503"
-	serial "NPJH-50503"
+	rom ( serial "NPJH-50503" )
 )
 
 game (
 	name "Lord of Arcana (Europe) (En,Fr,De,Es)"
-	serial "ULES-01507"
-	serial "ULES-01507"
+	rom ( serial "ULES-01507" )
 )
 
 game (
 	name "Lord of Arcana (Japan)"
-	serial "NPJH-50335"
-	serial "NPJH-50335"
+	rom ( serial "NPJH-50335" )
 )
 
 game (
 	name "Lord of Arcana (USA) (En,Fr)"
-	serial "ULUS-10479"
-	serial "ULUS-10479"
+	rom ( serial "ULUS-10479" )
 )
 
 game (
 	name "Lord of the Rings, The - Aragorn's Quest (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-01395"
-	serial "ULES-01395"
+	rom ( serial "ULES-01395" )
 )
 
 game (
 	name "Lord of the Rings, The - Aragorn's Quest (USA)"
-	serial "ULUS-10475"
-	serial "ULUS-10475"
+	rom ( serial "ULUS-10475" )
 )
 
 game (
 	name "Lord of the Rings, The - Tactics (Europe)"
-	serial "ULES-00198"
-	serial "ULES-00198"
+	rom ( serial "ULES-00198" )
 )
 
 game (
 	name "Lord of the Rings, The - Tactics (USA)"
-	serial "ULUS-10038"
-	serial "ULUS-10038"
+	rom ( serial "ULUS-10038" )
 )
 
 game (
 	name "Lost Heroes (Japan) (v1.01)"
-	serial "NPJH-50647"
-	serial "NPJH-50647"
+	rom ( serial "NPJH-50647" )
 )
 
 game (
 	name "Love at Once (Japan) (v1.01)"
-	serial "ULJM-05746"
-	serial "ULJM-05746"
+	rom ( serial "ULJM-05746" )
 )
 
 game (
 	name "Lucian Bee's Evil Violet (Japan)"
-	serial "ULJM-05748"
-	serial "ULJM-05748"
+	rom ( serial "ULJM-05748" )
 )
 
 game (
 	name "Lucian Bee's Justice Yellow (Japan) (v1.01)"
-	serial "ULJM-05749"
-	serial "ULJM-05749"
+	rom ( serial "ULJM-05749" )
 )
 
 game (
 	name "Lucian Bee's Resurrection Supernova (Japan)"
-	serial "ULJM-05680"
-	serial "ULJM-05680"
+	rom ( serial "ULJM-05680" )
 )
 
 game (
 	name "Lucky Star - Net Idol Meister (Japan) (v1.01)"
-	serial "ULJM-05542"
-	serial "ULJM-05542"
+	rom ( serial "ULJM-05542" )
 )
 
 game (
 	name "Lucky Star - Ryouou Gakuen Outousai Portable (Japan)"
-	serial "ULJM-05752"
-	serial "ULJM-05752"
+	rom ( serial "ULJM-05752" )
 )
 
 game (
 	name "Lumines (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00043"
-	serial "ULES-00043"
+	rom ( serial "ULES-00043" )
 )
 
 game (
 	name "Lumines (Japan) (v1.02)"
-	serial "ULJS-00005"
-	serial "ULJS-00005"
+	rom ( serial "ULJS-00005" )
 )
 
 game (
 	name "Lumines (Japan) (v1.02) (PSP The Best)"
-	serial "ULJS-00005"
-	serial "ULJS-00005"
 )
 
 game (
 	name "Lumines (USA) (v1.01)"
-	serial "ULUS-10002"
-	serial "ULUS-10002"
+	rom ( serial "ULUS-10002" )
 )
 
 game (
 	name "Lumines II (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00553"
-	serial "ULES-00553"
+	rom ( serial "ULES-00553" )
 )
 
 game (
 	name "Lumines II (Japan) (v1.01)"
-	serial "ULJM-05232"
-	serial "ULJM-05232"
+	rom ( serial "ULJM-05232" )
 )
 
 game (
 	name "Lumines II (USA)"
-	serial "ULUS-10183"
-	serial "ULUS-10183"
+	rom ( serial "ULUS-10183" )
 )
 
 game (
 	name "Lunar - Silver Star Harmony (USA)"
-	serial "ULUS-10482"
-	serial "ULUS-10482"
+	rom ( serial "ULUS-10482" )
 )
 
 game (
 	name "Luxor - Pharaoh's Challenge (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01028"
-	serial "ULES-01028"
+	rom ( serial "ULES-01028" )
 )
 
 game (
 	name "Luxor - Pharaoh's Challenge (USA) (v1.01)"
-	serial "ULUS-10333"
-	serial "ULUS-10333"
+	rom ( serial "ULUS-10333" )
 )
 
 game (
 	name "Luxor - The Wrath of Set (USA)"
-	serial "ULUS-10201"
-	serial "ULUS-10201"
+	rom ( serial "ULUS-10201" )
 )
 
 game (
 	name "M.A.C.H. - Modified Air Combat Heroes (Europe) (v1.02)"
-	serial "ULES-00565"
-	serial "ULES-00565"
+	rom ( serial "ULES-00565" )
 )
 
 game (
 	name "M.A.C.H. - Modified Air Combat Heroes (Japan) (v1.03)"
-	serial "ULJM-05202"
-	serial "ULJM-05202"
+	rom ( serial "ULJM-05202" )
 )
 
 game (
 	name "M.A.C.H. - Modified Air Combat Heroes (Russia) (v1.02)"
-	serial "ULES-00566"
-	serial "ULES-00566"
+	rom ( serial "ULES-00566" )
 )
 
 game (
 	name "M.A.C.H. - Modified Air Combat Heroes (USA) (v1.01)"
-	serial "ULUS-10180"
-	serial "ULUS-10180"
+	rom ( serial "ULUS-10180" )
 )
 
 game (
 	name "MLB (Korea)"
-	serial "UCKS-45010"
-	serial "UCKS-45010"
+	rom ( serial "UCKS-45010" )
 )
 
 game (
 	name "MLB (USA)"
-	serial "UCUS-98605"
-	serial "UCUS-98605"
+	rom ( serial "UCUS-98605" )
 )
 
 game (
 	name "MLB 06 - The Show (USA) (v1.01)"
-	serial "UCUS-98624"
-	serial "UCUS-98624"
+	rom ( serial "UCUS-98624" )
 )
 
 game (
 	name "MLB 07 - The Show (USA) (Demo)"
-	serial "UCUS-98680"
-	serial "UCUS-98680"
+	rom ( serial "UCUS-98680" )
 )
 
 game (
 	name "MLB 07 - The Show (USA) (v1.01)"
-	serial "UCUS-98667"
-	serial "UCUS-98667"
+	rom ( serial "UCUS-98667" )
 )
 
 game (
 	name "MLB 08 - The Show (Asia)"
-	serial "UCUS-98696"
-	serial "UCUS-98696"
+	rom ( serial "UCUS-98696" )
 )
 
 game (
 	name "MLB 08 - The Show (USA)"
-	serial "UCUS-98696"
-	serial "UCUS-98696"
 )
 
 game (
 	name "MLB 09 - The Show (USA) (v1.01)"
-	serial "UCUS-98730"
-	serial "UCUS-98730"
+	rom ( serial "UCUS-98730" )
 )
 
 game (
 	name "MLB 10 - The Show (USA)"
-	serial "UCUS-98742"
-	serial "UCUS-98742"
+	rom ( serial "UCUS-98742" )
 )
 
 game (
 	name "MLB 11 - The Show (USA)"
-	serial "UCUS-98758"
-	serial "UCUS-98758"
+	rom ( serial "UCUS-98758" )
 )
 
 game (
 	name "MTX Mototrax (Europe) (v1.01)"
-	serial "ULES-00581"
-	serial "ULES-00581"
+	rom ( serial "ULES-00581" )
 )
 
 game (
 	name "MTX Mototrax (USA)"
-	serial "ULUS-10138"
-	serial "ULUS-10138"
+	rom ( serial "ULUS-10138" )
 )
 
 game (
 	name "MVP Baseball (Korea)"
-	serial "ULKS-46006"
-	serial "ULKS-46006"
+	rom ( serial "ULKS-46006" )
 )
 
 game (
 	name "MVP Baseball (USA) (v1.02)"
-	serial "ULUS-10012"
-	serial "ULUS-10012"
+	rom ( serial "ULUS-10012" )
 )
 
 game (
 	name "MX vs. ATV On the Edge (Europe)"
-	serial "ULES-00274"
-	serial "ULES-00274"
+	rom ( serial "ULES-00274" )
 )
 
 game (
 	name "MX vs. ATV On the Edge (USA) (v1.01)"
-	serial "ULUS-10071"
-	serial "ULUS-10071"
+	rom ( serial "ULUS-10071" )
 )
 
 game (
 	name "MX vs. ATV Reflex (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01375"
-	serial "ULES-01375"
+	rom ( serial "ULES-01375" )
 )
 
 game (
 	name "MX vs. ATV Reflex (USA) (En,Fr) (v1.02)"
-	serial "ULUS-10429"
-	serial "ULUS-10429"
+	rom ( serial "ULUS-10429" )
 )
 
 game (
 	name "MX vs. ATV Untamed (Europe)"
-	serial "ULES-00993"
-	serial "ULES-00993"
+	rom ( serial "ULES-00993" )
 )
 
 game (
 	name "MX vs. ATV Untamed (USA)"
-	serial "ULUS-10330"
-	serial "ULUS-10330"
+	rom ( serial "ULUS-10330" )
 )
 
 game (
 	name "Machi-Ing Maker 3 x Tousouchuu (Japan) (v1.03)"
-	serial "ULJS-00242"
-	serial "ULJS-00242"
+	rom ( serial "ULJS-00242" )
 )
 
 game (
 	name "Macross Ace Frontier (Japan) (v1.02)"
-	serial "ULJS-00158"
-	serial "ULJS-00158"
+	rom ( serial "ULJS-00158" )
 )
 
 game (
 	name "Macross Triangle Frontier (Japan) (v1.01)"
-	serial "ULJS-00321"
-	serial "ULJS-00321"
+	rom ( serial "ULJS-00321" )
 )
 
 game (
 	name "Macross Ultimate Frontier (Japan) (v1.02)"
-	serial "NPJH-50050"
-	serial "NPJH-50050"
+	rom ( serial "NPJH-50050" )
 )
 
 game (
 	name "Madden NFL 06 (Europe) (v1.01)"
-	serial "ULES-00147"
-	serial "ULES-00147"
+	rom ( serial "ULES-00147" )
 )
 
 game (
 	name "Madden NFL 06 (USA)"
-	serial "ULUS-10024"
-	serial "ULUS-10024"
+	rom ( serial "ULUS-10024" )
 )
 
 game (
 	name "Madden NFL 07 (USA)"
-	serial "ULUS-10117"
-	serial "ULUS-10117"
+	rom ( serial "ULUS-10117" )
 )
 
 game (
 	name "Madden NFL 08 (Europe) (v1.01)"
-	serial "ULES-00867"
-	serial "ULES-00867"
+	rom ( serial "ULES-00867" )
 )
 
 game (
 	name "Madden NFL 08 (USA)"
-	serial "ULUS-10275"
-	serial "ULUS-10275"
+	rom ( serial "ULUS-10275" )
 )
 
 game (
 	name "Madden NFL 09 (Europe)"
-	serial "ULES-01093"
-	serial "ULES-01093"
+	rom ( serial "ULES-01093" )
 )
 
 game (
 	name "Madden NFL 09 (USA)"
-	serial "ULUS-10352"
-	serial "ULUS-10352"
+	rom ( serial "ULUS-10352" )
 )
 
 game (
 	name "Madden NFL 10 (USA)"
-	serial "ULUS-10441"
-	serial "ULUS-10441"
+	rom ( serial "ULUS-10441" )
 )
 
 game (
 	name "Madden NFL 11 (Japan)"
-	serial "ULJM-05757"
-	serial "ULJM-05757"
+	rom ( serial "ULJM-05757" )
 )
 
 game (
 	name "Madden NFL 11 (USA) (v1.01)"
-	serial "ULUS-10541"
-	serial "ULUS-10541"
+	rom ( serial "ULUS-10541" )
 )
 
 game (
 	name "Madden NFL 12 (USA)"
-	serial "ULUS-10581"
-	serial "ULUS-10581"
+	rom ( serial "ULUS-10581" )
 )
 
 game (
 	name "Magic Sudoku (Asia) (v1.01)"
-	serial "UCAS-40139"
-	serial "UCAS-40139"
+	rom ( serial "UCAS-40139" )
 )
 
 game (
 	name "Magic Sudoku (Europe) (v1.03)"
-	serial "ULES-00621"
-	serial "ULES-00621"
+	rom ( serial "ULES-00621" )
 )
 
 game (
 	name "Magna Carta Portable (Japan) (v1.03)"
-	serial "ULJS-00042"
-	serial "ULJS-00042"
+	rom ( serial "ULJS-00042" )
 )
 
 game (
 	name "MagusTale Eternity - Sekaiju to Koisuru Mahou Tsukai (Japan) (v1.02)"
-	serial "ULJM-05577"
-	serial "ULJM-05577"
+	rom ( serial "ULJM-05577" )
 )
 
 game (
 	name "Mahjong Fight Club (Japan) (v1.01)"
-	serial "ULJM-05002"
-	serial "ULJM-05002"
+	rom ( serial "ULJM-05002" )
 )
 
 game (
 	name "Mahjong Fight Club - Zenkoku Taisenban (Japan) (v1.05)"
-	serial "ULJM-05163"
-	serial "ULJM-05163"
+	rom ( serial "ULJM-05163" )
 )
 
 game (
 	name "Mahjong Haoh Battle Royale II (Japan) (v1.02)"
-	serial "ULJM-05606"
-	serial "ULJM-05606"
+	rom ( serial "ULJM-05606" )
 )
 
 game (
 	name "Mahjong Haoh Portable - Dankyuu Battle (Japan) (v1.01)"
-	serial "ULJM-05288"
-	serial "ULJM-05288"
+	rom ( serial "ULJM-05288" )
 )
 
 game (
 	name "Mahjong Haoh Portable - Dankyuu Battle Special (Japan) (v1.02)"
-	serial "ULJM-05841"
-	serial "ULJM-05841"
+	rom ( serial "ULJM-05841" )
 )
 
 game (
 	name "Mahjong Haoh Portable - Jansou Battle (Japan) (v1.04)"
-	serial "ULJM-05173"
-	serial "ULJM-05173"
+	rom ( serial "ULJM-05173" )
 )
 
 game (
 	name "Mahjong Taikai (Japan)"
-	serial "ULJM-05004"
-	serial "ULJM-05004"
+	rom ( serial "ULJM-05004" )
 )
 
 game (
 	name "Mahou Shoujo Lyrical Nanoha A's Portable - The Battle of Aces (Japan) (v1.01)"
-	serial "ULJS-00241"
-	serial "ULJS-00241"
+	rom ( serial "ULJS-00241" )
 )
 
 game (
 	name "Mahou Shoujo Lyrical Nanoha A's Portable - The Gears of Destiny (Japan) (v1.01)"
-	serial "ULJS-00385"
-	serial "ULJS-00385"
+	rom ( serial "ULJS-00385" )
 )
 
 game (
 	name "Mahou Shoujo Madoka Magica Portable (Japan) (v1.03)"
-	serial "ULJS-00430"
-	serial "ULJS-00430"
+	rom ( serial "ULJS-00430" )
 )
 
 game (
 	name "Mahou Tsukai to Goshujin-sama - New Ground (Japan) (v1.02)"
-	serial "ULJM-05951"
-	serial "ULJM-05951"
+	rom ( serial "ULJM-05951" )
 )
 
 game (
 	name "Mai-Hime Bakuretsu! Fuuka Gakuen Gekitoushi! (Japan) (v1.04)"
-	serial "ULJS-00040"
-	serial "ULJS-00040"
+	rom ( serial "ULJS-00040" )
 )
 
 game (
 	name "Mai-Hime Senretsu! Shin Fuuka Gakuen Gekitoushi!! (Japan) (v1.01)"
-	serial "ULJS-00062"
-	serial "ULJS-00062"
+	rom ( serial "ULJS-00062" )
 )
 
 game (
 	name "Maji de Manabu LEC de Ukaru - Nisshou Boki 3-Kyuu Portable (Japan)"
-	serial "NPJH-50146"
-	serial "NPJH-50146"
+	rom ( serial "NPJH-50146" )
 )
 
 game (
 	name "Maji de Manabu LEC de Ukaru - Takuchi Tatemono Torihiki Shuninsha Portable (Japan) (v1.01)"
-	serial "NPJH-50147"
-	serial "NPJH-50147"
+	rom ( serial "NPJH-50147" )
 )
 
 game (
 	name "Major League Baseball 2K10 (Japan) (En) (v1.01)"
-	serial "ULJS-00330"
-	serial "ULJS-00330"
+	rom ( serial "ULJS-00330" )
 )
 
 game (
 	name "Major League Baseball 2K10 (USA) (v1.01)"
-	serial "ULUS-10503"
-	serial "ULUS-10503"
+	rom ( serial "ULUS-10503" )
 )
 
 game (
 	name "Major League Baseball 2K11 (Japan)"
-	serial "ULJS-00387"
-	serial "ULJS-00387"
+	rom ( serial "ULJS-00387" )
 )
 
 game (
 	name "Major League Baseball 2K11 (USA)"
-	serial "ULUS-10573"
-	serial "ULUS-10573"
+	rom ( serial "ULUS-10573" )
 )
 
 game (
 	name "Major League Baseball 2K12 (Japan) (v1.01)"
-	serial "ULJS-00473"
-	serial "ULJS-00473"
+	rom ( serial "ULJS-00473" )
 )
 
 game (
 	name "Major League Baseball 2K12 (USA)"
-	serial "ULUS-10591"
-	serial "ULUS-10591"
+	rom ( serial "ULUS-10591" )
 )
 
 game (
 	name "Major League Baseball 2K6 (USA) (v1.01)"
-	serial "ULUS-10099"
-	serial "ULUS-10099"
+	rom ( serial "ULUS-10099" )
 )
 
 game (
 	name "Major League Baseball 2K7 (USA) (v1.01)"
-	serial "ULUS-10229"
-	serial "ULUS-10229"
+	rom ( serial "ULUS-10229" )
 )
 
 game (
 	name "Major League Baseball 2K8 (USA) (v1.02)"
-	serial "ULUS-10342"
-	serial "ULUS-10342"
+	rom ( serial "ULUS-10342" )
 )
 
 game (
 	name "Major League Baseball 2K9 (Japan) (En)"
-	serial "ULJS-00200"
-	serial "ULJS-00200"
+	rom ( serial "ULJS-00200" )
 )
 
 game (
 	name "Major League Baseball 2K9 (USA) (v1.02)"
-	serial "ULUS-10413"
-	serial "ULUS-10413"
+	rom ( serial "ULUS-10413" )
 )
 
 game (
 	name "Mana Khemia - Student Alliance (Europe) (v1.01)"
-	serial "ULES-01215"
-	serial "ULES-01215"
+	rom ( serial "ULES-01215" )
 )
 
 game (
 	name "Mana Khemia - Student Alliance (USA)"
-	serial "ULUS-10408"
-	serial "ULUS-10408"
+	rom ( serial "ULUS-10408" )
 )
 
 game (
 	name "Mana Khemia 2 Ochita Gakuen to Renkinjutsushi Tachi Portable (Japan) (v1.01)"
-	serial "ULJM-05519"
-	serial "ULJM-05519"
+	rom ( serial "ULJM-05519" )
 )
 
 game (
 	name "Manhunt 2 (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00756"
-	serial "ULES-00756"
+	rom ( serial "ULES-00756" )
 )
 
 game (
 	name "Manhunt 2 (USA) (v1.03)"
-	serial "ULUS-10280"
-	serial "ULUS-10280"
+	rom ( serial "ULUS-10280" )
 )
 
 game (
 	name "Maplus - Portable Navi (Japan) (v1.03)"
-	serial "ULJS-00092"
-	serial "ULJS-00092"
+	rom ( serial "ULJS-00092" )
 )
 
 game (
 	name "Maplus - Portable Navi (Japan) (v1.03) (GPS Receiver Doukonban)"
-	serial "ULJS-00091"
-	serial "ULJS-00091"
+	rom ( serial "ULJS-00091" )
 )
 
 game (
 	name "Maplus - Portable Navi 2 (Japan) (v1.02)"
-	serial "ULJS-00128"
-	serial "ULJS-00128"
+	rom ( serial "ULJS-00128" )
 )
 
 game (
 	name "Maplus - Portable Navi 3 (Japan) (v1.07)"
-	serial "ULJS-00199"
-	serial "ULJS-00199"
+	rom ( serial "ULJS-00199" )
 )
 
 game (
 	name "Marriage Royale - Prism Story (Japan) (v1.04)"
-	serial "ULJS-00273"
-	serial "ULJS-00273"
+	rom ( serial "ULJS-00273" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Care Manager Shiken Portable (Japan) (v1.02)"
-	serial "NPJH-50604"
-	serial "NPJH-50604"
+	rom ( serial "NPJH-50604" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Chuushoukigyou Shindanshi Shiken 1 Portable (Japan) (v1.02)"
-	serial "NPJH-50534"
-	serial "NPJH-50534"
+	rom ( serial "NPJH-50534" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Chuushoukigyou Shindanshi Shiken 2 Portable (Japan) (v1.02)"
-	serial "NPJH-50533"
-	serial "NPJH-50533"
+	rom ( serial "NPJH-50533" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! FP Financial Planning Ginou Kentei Shiken 2-Kyuu Portable (Japan) (v1.02)"
-	serial "NPJH-50506"
-	serial "NPJH-50506"
+	rom ( serial "NPJH-50506" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! FP Financial Planning Ginou Kentei Shiken 3-Kyuu Portable (Japan) (v1.02)"
-	serial "NPJH-50507"
-	serial "NPJH-50507"
+	rom ( serial "NPJH-50507" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! IT Passport Shiken Portable (Japan) (v1.03)"
-	serial "NPJH-50482"
-	serial "NPJH-50482"
+	rom ( serial "NPJH-50482" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Kihon Jouhou Gijutsusha Shiken Portable (Japan) (v1.03)"
-	serial "NPJH-50480"
-	serial "NPJH-50480"
+	rom ( serial "NPJH-50480" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Ouyou Jouhou Gijutsusha Shiken Portable (Japan) (v1.03)"
-	serial "NPJH-50481"
-	serial "NPJH-50481"
+	rom ( serial "NPJH-50481" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Sharoushi Shiken Portable (Japan)"
-	serial "NPJH-50516"
-	serial "NPJH-50516"
+	rom ( serial "NPJH-50516" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Shouken Gaimuin Shiken Portable (Japan) (v1.02)"
-	serial "NPJH-50587"
-	serial "NPJH-50587"
+	rom ( serial "NPJH-50587" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! TOEIC Test Portable (Japan) (v1.01)"
-	serial "NPJH-50574"
-	serial "NPJH-50574"
+	rom ( serial "NPJH-50574" )
 )
 
 game (
 	name "Maru Goukaku - Shikaku Dasshu! Takken Shiken Portable (Japan)"
-	serial "NPJH-50548"
-	serial "NPJH-50548"
+	rom ( serial "NPJH-50548" )
 )
 
 game (
 	name "Marvel - Ultimate Alliance (Europe) (v1.01)"
-	serial "ULES-00542"
-	serial "ULES-00542"
+	rom ( serial "ULES-00542" )
 )
 
 game (
 	name "Marvel - Ultimate Alliance (USA) (v1.02)"
-	serial "ULUS-10167"
-	serial "ULUS-10167"
+	rom ( serial "ULUS-10167" )
 )
 
 game (
 	name "Marvel - Ultimate Alliance (USA) (v2.00)"
-	serial "ULUS-10167"
-	serial "ULUS-10167"
 )
 
 game (
 	name "Marvel - Ultimate Alliance 2 (Europe) (v1.02)"
-	serial "ULES-01343"
-	serial "ULES-01343"
+	rom ( serial "ULES-01343" )
 )
 
 game (
 	name "Marvel - Ultimate Alliance 2 (USA) (v1.02)"
-	serial "ULUS-10421"
-	serial "ULUS-10421"
+	rom ( serial "ULUS-10421" )
 )
 
 game (
 	name "Marvel Nemesis - Rise of the Imperfects (Europe) (En,Fr,De,It)"
-	serial "ULES-00159"
-	serial "ULES-00159"
+	rom ( serial "ULES-00159" )
 )
 
 game (
 	name "Marvel Nemesis - Rise of the Imperfects (USA)"
-	serial "ULUS-10033"
-	serial "ULUS-10033"
+	rom ( serial "ULUS-10033" )
 )
 
 game (
 	name "Marvel Super Hero Squad (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01368"
-	serial "ULES-01368"
+	rom ( serial "ULES-01368" )
 )
 
 game (
 	name "Marvel Super Hero Squad (USA)"
-	serial "ULUS-10485"
-	serial "ULUS-10485"
+	rom ( serial "ULUS-10485" )
 )
 
 game (
 	name "Marvel Trading Card Game (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00683"
-	serial "ULES-00683"
+	rom ( serial "ULES-00683" )
 )
 
 game (
 	name "Marvel Trading Card Game (USA) (v1.02)"
-	serial "ULUS-10196"
-	serial "ULUS-10196"
+	rom ( serial "ULUS-10196" )
 )
 
 game (
 	name "Mashiro Iro Symphony - Mutsu-no-hana (Japan)"
-	serial "ULJM-05889"
-	serial "ULJM-05889"
+	rom ( serial "ULJM-05889" )
 )
 
 game (
 	name "Mawaskes Puzzle (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-01104"
-	serial "ULES-01104"
+	rom ( serial "ULES-01104" )
 )
 
 game (
 	name "Me & My Katamari (Europe)"
-	serial "ULES-00339"
-	serial "ULES-00339"
+	rom ( serial "ULES-00339" )
 )
 
 game (
 	name "Me & My Katamari (USA)"
-	serial "ULUS-10094"
-	serial "ULUS-10094"
+	rom ( serial "ULUS-10094" )
 )
 
 game (
 	name "Me de Unou o Kitaeru - Sokudoku Jutsu Portable (Japan) (v1.01)"
-	serial "ULJM-05250"
-	serial "ULJM-05250"
+	rom ( serial "ULJM-05250" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Europe)"
-	serial "ULES-00557"
-	serial "ULES-00557"
+	rom ( serial "ULES-00557" )
 )
 
 game (
 	name "Medal of Honor - Heroes (France)"
-	serial "ULES-00558"
-	serial "ULES-00558"
+	rom ( serial "ULES-00558" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Germany)"
-	serial "ULES-00559"
-	serial "ULES-00559"
+	rom ( serial "ULES-00559" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Italy)"
-	serial "ULES-00560"
-	serial "ULES-00560"
+	rom ( serial "ULES-00560" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Japan)"
-	serial "ULJM-05213"
-	serial "ULJM-05213"
+	rom ( serial "ULJM-05213" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Netherlands)"
-	serial "ULES-00562"
-	serial "ULES-00562"
+	rom ( serial "ULES-00562" )
 )
 
 game (
 	name "Medal of Honor - Heroes (Spain)"
-	serial "ULES-00561"
-	serial "ULES-00561"
+	rom ( serial "ULES-00561" )
 )
 
 game (
 	name "Medal of Honor - Heroes (USA)"
-	serial "ULUS-10141"
-	serial "ULUS-10141"
+	rom ( serial "ULUS-10141" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (Asia)"
-	serial "ULUS-10310"
-	serial "ULUS-10310"
+	rom ( serial "ULUS-10310" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (Australia)"
-	serial "ULES-00988"
-	serial "ULES-00988"
+	rom ( serial "ULES-00988" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (Europe)"
-	serial "ULES-00955"
-	serial "ULES-00955"
+	rom ( serial "ULES-00955" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (Europe) (Fr,De,Es,It)"
-	serial "ULES-00956"
-	serial "ULES-00956"
+	rom ( serial "ULES-00956" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (Japan)"
-	serial "ULJM-05301"
-	serial "ULJM-05301"
+	rom ( serial "ULJM-05301" )
 )
 
 game (
 	name "Medal of Honor - Heroes 2 (USA)"
-	serial "ULUS-10310"
-	serial "ULUS-10310"
 )
 
 game (
 	name "MediEvil - Resurrection (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "UCES-00006"
-	serial "UCES-00006"
+	rom ( serial "UCES-00006" )
 )
 
 game (
 	name "MediEvil - Resurrection (USA)"
-	serial "UCUS-98620"
-	serial "UCUS-98620"
+	rom ( serial "UCUS-98620" )
 )
 
 game (
 	name "Medical91 for Portable (Japan) (v1.01)"
-	serial "ULJM-05336"
-	serial "ULJM-05336"
+	rom ( serial "ULJM-05336" )
 )
 
 game (
 	name "Mega Man - Maverick Hunter X (Europe) (v1.01)"
-	serial "ULES-00251"
-	serial "ULES-00251"
+	rom ( serial "ULES-00251" )
 )
 
 game (
 	name "Mega Man - Maverick Hunter X (USA) (v1.01)"
-	serial "ULUS-10068"
-	serial "ULUS-10068"
+	rom ( serial "ULUS-10068" )
 )
 
 game (
 	name "Mega Man - Powered Up (Europe)"
-	serial "ULES-00307"
-	serial "ULES-00307"
+	rom ( serial "ULES-00307" )
 )
 
 game (
 	name "Mega Man - Powered Up (USA)"
-	serial "ULUS-10091"
-	serial "ULUS-10091"
+	rom ( serial "ULUS-10091" )
 )
 
 game (
 	name "Mega Minis Volume 1 (Europe)"
-	serial "UCES-01502"
-	serial "UCES-01502"
+	rom ( serial "UCES-01502" )
 )
 
 game (
 	name "Mega Minis Volume 2 (Europe)"
-	serial "UCES-01503"
-	serial "UCES-01503"
+	rom ( serial "UCES-01503" )
 )
 
 game (
 	name "Mega Minis Volume 3 (Europe)"
-	serial "UCES-01504"
-	serial "UCES-01504"
+	rom ( serial "UCES-01504" )
 )
 
 game (
 	name "Megami no Etsubo (Japan) (v1.01)"
-	serial "ULJM-05107"
-	serial "ULJM-05107"
+	rom ( serial "ULJM-05107" )
 )
 
 game (
 	name "Megamind - The Blue Defender (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-01415"
-	serial "ULES-01415"
+	rom ( serial "ULES-01415" )
 )
 
 game (
 	name "Megamind - The Blue Defender (Russia)"
-	serial "ULES-01465"
-	serial "ULES-01465"
+	rom ( serial "ULES-01465" )
 )
 
 game (
 	name "Megamind - The Blue Defender (USA) (En,Fr)"
-	serial "ULUS-10520"
-	serial "ULUS-10520"
+	rom ( serial "ULUS-10520" )
 )
 
 game (
 	name "Meitantei Conan - Kakokara no Prelude (Japan) (v1.02)"
-	serial "NPJH-50565"
-	serial "NPJH-50565"
+	rom ( serial "NPJH-50565" )
 )
 
 game (
 	name "Melodie (Europe) (Beta)"
-	serial "PETR-00010"
-	serial "PETR-00010"
+	rom ( serial "PETR-00010" )
 )
 
 game (
 	name "Memories Off (Japan) (v1.02)"
-	serial "ULJM-05334"
-	serial "ULJM-05334"
+	rom ( serial "ULJM-05334" )
 )
 
 game (
 	name "Memories Off - After Rain (Japan) (v1.01)"
-	serial "ULJM-05473"
-	serial "ULJM-05473"
+	rom ( serial "ULJM-05473" )
 )
 
 game (
 	name "Memories Off - Sorekara (Japan) (v1.01)"
-	serial "ULJM-05350"
-	serial "ULJM-05350"
+	rom ( serial "ULJM-05350" )
 )
 
 game (
 	name "Memories Off - Sorekara Again (Japan)"
-	serial "ULJM-05526"
-	serial "ULJM-05526"
+	rom ( serial "ULJM-05526" )
 )
 
 game (
 	name "Memories Off - Yubikiri no Kioku (Japan)"
-	serial "ULJM-05875"
-	serial "ULJM-05875"
+	rom ( serial "ULJM-05875" )
 )
 
 game (
 	name "Memories Off - Yubikiri no Kioku - Futari no Fuuryuuan (Japan)"
-	serial "ULJM-05874"
-	serial "ULJM-05874"
+	rom ( serial "ULJM-05874" )
 )
 
 game (
 	name "Memories Off 2nd (Japan) (v1.02)"
-	serial "ULJM-05335"
-	serial "ULJM-05335"
+	rom ( serial "ULJM-05335" )
 )
 
 game (
 	name "Memories Off 5 - Encore (Japan)"
-	serial "ULJM-05527"
-	serial "ULJM-05527"
+	rom ( serial "ULJM-05527" )
 )
 
 game (
 	name "Memories Off 5 - Togireta Film (Japan) (v1.01)"
-	serial "ULJM-05394"
-	serial "ULJM-05394"
+	rom ( serial "ULJM-05394" )
 )
 
 game (
 	name "Memories Off 6 - Next Relation (Japan) (v1.01)"
-	serial "ULJM-05762"
-	serial "ULJM-05762"
+	rom ( serial "ULJM-05762" )
 )
 
 game (
 	name "Memories Off 6 - T-Wave (Japan) (v1.01)"
-	serial "ULJM-05467"
-	serial "ULJM-05467"
+	rom ( serial "ULJM-05467" )
 )
 
 game (
 	name "Mercury Meltdown (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00466"
-	serial "ULES-00466"
+	rom ( serial "ULES-00466" )
 )
 
 game (
 	name "Mercury Meltdown (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10133"
-	serial "ULUS-10133"
+	rom ( serial "ULUS-10133" )
 )
 
 game (
 	name "Metal Fight Beyblade Portable - Chouzetsu Tensei! Vulcan Horuseus (Japan) (v1.01)"
-	serial "ULJM-05731"
-	serial "ULJM-05731"
+	rom ( serial "ULJM-05731" )
 )
 
 game (
 	name "Metal Gear Ac!d (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00008"
-	serial "ULES-00008"
+	rom ( serial "ULES-00008" )
 )
 
 game (
 	name "Metal Gear Ac!d (Japan) (v1.02)"
-	serial "ULJM-05001"
-	serial "ULJM-05001"
+	rom ( serial "ULJM-05001" )
 )
 
 game (
 	name "Metal Gear Ac!d (USA)"
-	serial "ULUS-10006"
-	serial "ULUS-10006"
+	rom ( serial "ULUS-10006" )
 )
 
 game (
 	name "Metal Gear Ac!d 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00284"
-	serial "ULES-00284"
+	rom ( serial "ULES-00284" )
 )
 
 game (
 	name "Metal Gear Ac!d 2 (Japan) (v1.05)"
-	serial "ULJM-05047"
-	serial "ULJM-05047"
+	rom ( serial "ULJM-05047" )
 )
 
 game (
 	name "Metal Gear Ac!d 2 (Korea) (v1.02)"
-	serial "ULKS-46065"
-	serial "ULKS-46065"
+	rom ( serial "ULKS-46065" )
 )
 
 game (
 	name "Metal Gear Ac!d 2 (USA)"
-	serial "ULUS-10077"
-	serial "ULUS-10077"
+	rom ( serial "ULUS-10077" )
 )
 
 game (
 	name "Metal Gear Solid - Digital Graphic Novel (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00382"
-	serial "ULES-00382"
+	rom ( serial "ULES-00382" )
 )
 
 game (
 	name "Metal Gear Solid - Digital Graphic Novel (USA) (v1.01)"
-	serial "ULUS-10108"
-	serial "ULUS-10108"
+	rom ( serial "ULUS-10108" )
 )
 
 game (
 	name "Metal Gear Solid - Peace Walker (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01372"
-	serial "ULES-01372"
+	rom ( serial "ULES-01372" )
 )
 
 game (
 	name "Metal Gear Solid - Peace Walker (Japan) (v1.02)"
-	serial "NPJH-50045"
-	serial "NPJH-50045"
+	rom ( serial "NPJH-50045" )
 )
 
 game (
 	name "Metal Gear Solid - Peace Walker (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10509"
-	serial "ULUS-10509"
+	rom ( serial "ULUS-10509" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00645"
-	serial "ULES-00645"
+	rom ( serial "ULES-00645" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops (Japan) (Deluxe Pack)"
-	serial "ULJM-05284"
-	serial "ULJM-05284"
+	rom ( serial "ULJM-05284" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops (Japan) (v1.02)"
-	serial "ULJM-05193"
-	serial "ULJM-05193"
+	rom ( serial "ULJM-05193" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops (Japan) (v1.02) (Premium Pack)"
-	serial "ULJM-05227"
-	serial "ULJM-05227"
+	rom ( serial "ULJM-05227" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops (USA) (v1.02)"
-	serial "ULUS-10202"
-	serial "ULUS-10202"
+	rom ( serial "ULUS-10202" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops Plus (Asia) (v1.01)"
-	serial "ULUS-10290"
-	serial "ULUS-10290"
+	rom ( serial "ULUS-10290" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops Plus (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01003"
-	serial "ULES-01003"
+	rom ( serial "ULES-01003" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops Plus (Japan) (v1.03)"
-	serial "ULJM-05261"
-	serial "ULJM-05261"
+	rom ( serial "ULJM-05261" )
 )
 
 game (
 	name "Metal Gear Solid - Portable Ops Plus (USA) (v1.01)"
-	serial "ULUS-10290"
-	serial "ULUS-10290"
 )
 
 game (
 	name "Metal Slug Anthology (Europe) (v1.01)"
-	serial "ULES-00530"
-	serial "ULES-00530"
+	rom ( serial "ULES-00530" )
 )
 
 game (
 	name "Metal Slug Anthology (USA) (v1.03)"
-	serial "ULUS-10154"
-	serial "ULUS-10154"
+	rom ( serial "ULUS-10154" )
 )
 
 game (
 	name "Metal Slug XX (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01429"
-	serial "ULES-01429"
+	rom ( serial "ULES-01429" )
 )
 
 game (
 	name "Metal Slug XX (Japan) (v1.01)"
-	serial "NPJH-50044"
-	serial "NPJH-50044"
+	rom ( serial "NPJH-50044" )
 )
 
 game (
 	name "Metal Slug XX (USA) (v1.01)"
-	serial "ULUS-10495"
-	serial "ULUS-10495"
+	rom ( serial "ULUS-10495" )
 )
 
 game (
 	name "Miami Vice - The Game (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00375"
-	serial "ULES-00375"
+	rom ( serial "ULES-00375" )
 )
 
 game (
 	name "Miami Vice - The Game (Japan) (v1.01)"
-	serial "ULJM-05165"
-	serial "ULJM-05165"
+	rom ( serial "ULJM-05165" )
 )
 
 game (
 	name "Miami Vice - The Game (Russia) (v1.01)"
-	serial "ULES-00376"
-	serial "ULES-00376"
+	rom ( serial "ULES-00376" )
 )
 
 game (
 	name "Miami Vice - The Game (USA) (v1.01)"
-	serial "ULUS-10109"
-	serial "ULUS-10109"
+	rom ( serial "ULUS-10109" )
 )
 
 game (
 	name "Michael Jackson - The Experience (Europe) (En,Fr,De,Es,It,Pl,Ru)"
-	serial "ULES-01512"
-	serial "ULES-01512"
+	rom ( serial "ULES-01512" )
 )
 
 game (
 	name "Michael Jackson - The Experience (USA) (En,Fr,De,Es,It,Pl,Ru)"
-	serial "ULUS-10564"
-	serial "ULUS-10564"
+	rom ( serial "ULUS-10564" )
 )
 
 game (
 	name "Micro Machines V4 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00368"
-	serial "ULES-00368"
+	rom ( serial "ULES-00368" )
 )
 
 game (
 	name "Micro Machines V4 (USA) (v1.01)"
-	serial "ULUS-10129"
-	serial "ULUS-10129"
+	rom ( serial "ULUS-10129" )
 )
 
 game (
 	name "Midnight Club - L.A. Remix (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-01144"
-	serial "ULES-01144"
+	rom ( serial "ULES-01144" )
 )
 
 game (
 	name "Midnight Club - L.A. Remix (Japan) (v1.04)"
-	serial "ULJS-00180"
-	serial "ULJS-00180"
+	rom ( serial "ULJS-00180" )
 )
 
 game (
 	name "Midnight Club - L.A. Remix (USA) (v2.02)"
-	serial "ULUS-10383"
-	serial "ULUS-10383"
+	rom ( serial "ULUS-10383" )
 )
 
 game (
 	name "Midnight Club 3 - DUB Edition (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00108"
-	serial "ULES-00108"
+	rom ( serial "ULES-00108" )
 )
 
 game (
 	name "Midnight Club 3 - DUB Edition (USA)"
-	serial "ULUS-10021"
-	serial "ULUS-10021"
+	rom ( serial "ULUS-10021" )
 )
 
 game (
 	name "Midnight Club 3 - DUB Edition (USA) (v2.02)"
-	serial "ULUS-10021"
-	serial "ULUS-10021"
 )
 
 game (
 	name "Midway Arcade Treasures - Extended Play (Europe) (v1.02)"
-	serial "ULES-00180"
-	serial "ULES-00180"
+	rom ( serial "ULES-00180" )
 )
 
 game (
 	name "Midway Arcade Treasures - Extended Play (USA)"
-	serial "ULUS-10059"
-	serial "ULUS-10059"
+	rom ( serial "ULUS-10059" )
 )
 
 game (
 	name "Mimana - Iyar Chronicle (Japan)"
-	serial "ULJM-05379"
-	serial "ULJM-05379"
+	rom ( serial "ULJM-05379" )
 )
 
 game (
 	name "Mimana - Iyar Chronicle (USA) (v1.01)"
-	serial "ULUS-10492"
-	serial "ULUS-10492"
+	rom ( serial "ULUS-10492" )
 )
 
 game (
 	name "Mind Quiz (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-00555"
-	serial "ULES-00555"
+	rom ( serial "ULES-00555" )
 )
 
 game (
 	name "Mind Quiz (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00701"
-	serial "ULES-00701"
+	rom ( serial "ULES-00701" )
 )
 
 game (
 	name "Mind Quiz (USA)"
-	serial "ULUS-10178"
-	serial "ULUS-10178"
+	rom ( serial "ULUS-10178" )
 )
 
 game (
 	name "Minna de Dokusho - Keitai Shousetsu Desuu (Japan) (v1.01)"
-	serial "ULJM-05393"
-	serial "ULJM-05393"
+	rom ( serial "ULJM-05393" )
 )
 
 game (
 	name "Minna de Dokusho - Meisaku & Suiri & Kaidan & Bungaku (Japan) (v1.02)"
-	serial "ULJM-05352"
-	serial "ULJM-05352"
+	rom ( serial "ULJM-05352" )
 )
 
 game (
 	name "Minna no Chizu (Japan) (v1.01)"
-	serial "ULJS-00051"
-	serial "ULJS-00051"
+	rom ( serial "ULJS-00051" )
 )
 
 game (
 	name "Minna no Chizu 2 (Japan) (v1.01)"
-	serial "ULJS-00104"
-	serial "ULJS-00104"
+	rom ( serial "ULJS-00104" )
 )
 
 game (
 	name "Minna no Chizu 2 (Japan) (v1.01) (GPS Receiver Doukonban)"
-	serial "ULJS-00103"
-	serial "ULJS-00103"
+	rom ( serial "ULJS-00103" )
 )
 
 game (
 	name "Minna no Chizu 2 Chiikiban - Higashi Nihon hen (Japan)"
-	serial "ULJS-00116"
-	serial "ULJS-00116"
+	rom ( serial "ULJS-00116" )
 )
 
 game (
 	name "Minna no Chizu 2 Chiikiban - Naka Nihon hen (Japan)"
-	serial "ULJS-00117"
-	serial "ULJS-00117"
+	rom ( serial "ULJS-00117" )
 )
 
 game (
 	name "Minna no Chizu 2 Chiikiban - Nishi Nihon hen (Japan)"
-	serial "ULJS-00118"
-	serial "ULJS-00118"
+	rom ( serial "ULJS-00118" )
 )
 
 game (
 	name "Minna no Chizu 3 (Japan)"
-	serial "ULJS-00140"
-	serial "ULJS-00140"
-)
-
-game (
-	name "Minna no Chizu 3 (Japan)"
-	serial "ULJS-00140"
-	serial "ULJS-00140"
+	rom ( serial "ULJS-00140" )
 )
 
 game (
 	name "Minna no Golf Jou Vol.1 (Japan)"
-	serial "UCJS-10058"
-	serial "UCJS-10058"
-)
-
-game (
-	name "Minna no Golf Jou Vol.1 (Japan)"
-	serial "UCJS-10058"
-	serial "UCJS-10058"
+	rom ( serial "UCJS-10058" )
 )
 
 game (
 	name "Minna no Golf Jou Vol.1 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10055"
-	serial "UCJS-10055"
-)
-
-game (
-	name "Minna no Golf Jou Vol.1 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10055"
-	serial "UCJS-10055"
+	rom ( serial "UCJS-10055" )
 )
 
 game (
 	name "Minna no Golf Jou Vol.2 (Japan)"
-	serial "UCJS-10064"
-	serial "UCJS-10064"
-)
-
-game (
-	name "Minna no Golf Jou Vol.2 (Japan)"
-	serial "UCJS-10064"
-	serial "UCJS-10064"
+	rom ( serial "UCJS-10064" )
 )
 
 game (
 	name "Minna no Golf Jou Vol.3 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10068"
-	serial "UCJS-10068"
-)
-
-game (
-	name "Minna no Golf Jou Vol.3 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10068"
-	serial "UCJS-10068"
+	rom ( serial "UCJS-10068" )
 )
 
 game (
 	name "Minna no Golf Jou Vol.4 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10071"
-	serial "UCJS-10071"
-)
-
-game (
-	name "Minna no Golf Jou Vol.4 (Japan) (GPS Receiver Doukonban)"
-	serial "UCJS-10071"
-	serial "UCJS-10071"
+	rom ( serial "UCJS-10071" )
 )
 
 game (
 	name "Minna no Navi (Japan)"
-	serial "ULJS-00211"
-	serial "ULJS-00211"
-)
-
-game (
-	name "Minna no Navi (Japan)"
-	serial "ULJS-00211"
-	serial "ULJS-00211"
+	rom ( serial "ULJS-00211" )
 )
 
 game (
 	name "Minna no Shiatsu - Itami mo Tsukare mo Sukirii! (Japan) (v1.01)"
-	serial "ULJM-05619"
-	serial "ULJM-05619"
+	rom ( serial "ULJM-05619" )
 )
 
 game (
 	name "Minna no Sukkiri (Japan)"
-	serial "UCJS-10094"
-	serial "UCJS-10094"
+	rom ( serial "UCJS-10094" )
 )
 
 game (
 	name "Mirai Nikki - 13-ninme no Nikki Shoyuusha (Japan)"
-	serial "ULJM-05565"
-	serial "ULJM-05565"
+	rom ( serial "ULJM-05565" )
 )
 
 game (
 	name "Mirai Nikki - 13-ninme no Nikki Shoyuusha Re-Write (Japan) (v1.02)"
-	serial "ULJM-06052"
-	serial "ULJM-06052"
+	rom ( serial "ULJM-06052" )
 )
 
 game (
 	name "Misshitsu no Sacrifice (Japan) (v1.01)"
-	serial "ULJS-00251"
-	serial "ULJS-00251"
+	rom ( serial "ULJS-00251" )
 )
 
 game (
 	name "Mite Kiite Nou de Kanjite Crossword Tengoku (Japan) (v1.01)"
-	serial "ULJM-05168"
-	serial "ULJM-05168"
+	rom ( serial "ULJM-05168" )
 )
 
 game (
 	name "Miyako (Japan) (v1.02)"
-	serial "ULJM-05770"
-	serial "ULJM-05770"
+	rom ( serial "ULJM-05770" )
 )
 
 game (
 	name "Miyako - Awayuki no Utage (Japan) (v1.01)"
-	serial "ULJM-06070"
-	serial "ULJM-06070"
+	rom ( serial "ULJM-06070" )
 )
 
 game (
 	name "Mizu no Senritsu (Japan)"
-	serial "ULJM-05583"
-	serial "ULJM-05583"
+	rom ( serial "ULJM-05583" )
 )
 
 game (
 	name "Mizu no Senritsu 2 - Hi no Kioku (Japan) (v1.01)"
-	serial "ULJM-05622"
-	serial "ULJM-05622"
+	rom ( serial "ULJM-05622" )
 )
 
 game (
 	name "Mobile Train Simulator + Densha de Go! Tokyo Kyuukou Hen (Japan) (v1.04)"
-	serial "ULJM-05012"
-	serial "ULJM-05012"
+	rom ( serial "ULJM-05012" )
 )
 
 game (
 	name "Mobile Train Simulator - Keisei - Toei Asakusa - Keikyuusen (Japan) (v1.02)"
-	serial "ULJM-05085"
-	serial "ULJM-05085"
+	rom ( serial "ULJM-05085" )
 )
 
 game (
 	name "ModNation Racers (Asia) (En,Zh)"
-	serial "NPHG-00080"
-	serial "NPHG-00080"
+	rom ( serial "NPHG-00080" )
 )
 
 game (
 	name "ModNation Racers (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru) (v1.01)"
-	serial "UCES-01327"
-	serial "UCES-01327"
+	rom ( serial "UCES-01327" )
 )
 
 game (
 	name "ModNation Racers (USA) (En,Fr,Es)"
-	serial "UCUS-98741"
-	serial "UCUS-98741"
+	rom ( serial "UCUS-98741" )
 )
 
 game (
 	name "Moe Moe 2-Ji Taisen-Ryaku 2 (Japan) (v1.02)"
-	serial "ULJS-00252"
-	serial "ULJS-00252"
+	rom ( serial "ULJS-00252" )
 )
 
 game (
 	name "Moe Moe 2-Ji Taisen-Ryaku Deluxe (Japan)"
-	serial "ULJS-00160"
-	serial "ULJS-00160"
+	rom ( serial "ULJS-00160" )
 )
 
 game (
 	name "Moe Moe Daisensou - Gendaiban+ (Japan) (v1.01)"
-	serial "ULJS-00411"
-	serial "ULJS-00411"
+	rom ( serial "ULJS-00411" )
 )
 
 game (
 	name "Moegaku Portable (Japan) (v1.02)"
-	serial "ULJM-05174"
-	serial "ULJM-05174"
+	rom ( serial "ULJM-05174" )
 )
 
 game (
 	name "Momotaro Dentetsu Tag Match - Yuujou Doryoku Shouri no Maki! (Japan) (v1.01)"
-	serial "ULJM-05677"
-	serial "ULJM-05677"
+	rom ( serial "ULJM-05677" )
 )
 
 game (
 	name "MonHun Nikki - Poka Poka Airou Mura (Japan) (v1.02)"
-	serial "ULJM-05710"
-	serial "ULJM-05710"
+	rom ( serial "ULJM-05710" )
 )
 
 game (
 	name "MonHun Nikki - Poka Poka Airou Mura G (Japan) (1.01)"
-	serial "ULJM-05881"
-	serial "ULJM-05881"
+	rom ( serial "ULJM-05881" )
 )
 
 game (
 	name "Mondo di Patty, Il - Il Gioco Piu' Bello (Europe) (Es,It,Pt) (v1.02)"
-	serial "ULES-01493"
-	serial "ULES-01493"
+	rom ( serial "ULES-01493" )
 )
 
 game (
 	name "Monochrome (Japan)"
-	serial "ULJM-05642"
-	serial "ULJM-05642"
+	rom ( serial "ULJM-05642" )
 )
 
 game (
 	name "Monster Hunter Freedom (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00318"
-	serial "ULES-00318"
+	rom ( serial "ULES-00318" )
 )
 
 game (
 	name "Monster Hunter Freedom (USA) (v1.01)"
-	serial "ULUS-10084"
-	serial "ULUS-10084"
+	rom ( serial "ULUS-10084" )
 )
 
 game (
 	name "Monster Hunter Freedom 2 (Asia) (v1.01)"
-	serial "ULAS-42110"
-	serial "ULAS-42110"
+	rom ( serial "ULAS-42110" )
 )
 
 game (
 	name "Monster Hunter Freedom 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00851"
-	serial "ULES-00851"
+	rom ( serial "ULES-00851" )
 )
 
 game (
 	name "Monster Hunter Freedom 2 (Korea)"
-	serial "ULUS-10266"
-	serial "ULUS-10266"
+	rom ( serial "ULUS-10266" )
 )
 
 game (
 	name "Monster Hunter Freedom 2 (USA) (v1.01)"
-	serial "ULUS-10266"
-	serial "ULUS-10266"
 )
 
 game (
 	name "Monster Hunter Freedom Unite (Europe) (En,Fr,De,Es,It) (Demo)"
-	serial "ULED-01244"
-	serial "ULED-01244"
+	rom ( serial "ULED-01244" )
 )
 
 game (
 	name "Monster Hunter Freedom Unite (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01213"
-	serial "ULES-01213"
+	rom ( serial "ULES-01213" )
 )
 
 game (
 	name "Monster Hunter Freedom Unite (USA) (Demo)"
-	serial "ULUS-90003"
-	serial "ULUS-90003"
+	rom ( serial "ULUS-90003" )
 )
 
 game (
 	name "Monster Hunter Freedom Unite (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10391"
-	serial "ULUS-10391"
+	rom ( serial "ULUS-10391" )
 )
 
 game (
 	name "Monster Hunter Portable 3rd (Japan) (v1.02)"
-	serial "ULJM-05800"
-	serial "ULJM-05800"
+	rom ( serial "ULJM-05800" )
 )
 
 game (
 	name "Monster Jam - Path of Destruction (USA) (v1.01)"
-	serial "ULUS-10530"
-	serial "ULUS-10530"
+	rom ( serial "ULUS-10530" )
 )
 
 game (
 	name "Monster Jam - Urban Assault (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01169"
-	serial "ULES-01169"
+	rom ( serial "ULES-01169" )
 )
 
 game (
 	name "Monster Jam - Urban Assault (USA)"
-	serial "ULUS-10379"
-	serial "ULUS-10379"
+	rom ( serial "ULUS-10379" )
 )
 
 game (
 	name "Monster Kingdom - Jewel Summoner (Japan) (v1.01)"
-	serial "UCJS-10026"
-	serial "UCJS-10026"
+	rom ( serial "UCJS-10026" )
 )
 
 game (
 	name "Monster Kingdom - Jewel Summoner (USA)"
-	serial "ULUS-10211"
-	serial "ULUS-10211"
+	rom ( serial "ULUS-10211" )
 )
 
 game (
 	name "Mortal Kombat - Unchained (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00353"
-	serial "ULES-00353"
+	rom ( serial "ULES-00353" )
 )
 
 game (
 	name "Mortal Kombat - Unchained (USA) (v1.03)"
-	serial "ULUS-10102"
-	serial "ULUS-10102"
+	rom ( serial "ULUS-10102" )
 )
 
 game (
 	name "Mother Goose no Himitsu no Yakata (Japan) (v1.02)"
-	serial "ULJM-05892"
-	serial "ULJM-05892"
+	rom ( serial "ULJM-05892" )
 )
 
 game (
 	name "Mother Goose no Himitsu no Yakata - Blue Label (Japan) (v1.01)"
-	serial "ULJM-05950"
-	serial "ULJM-05950"
+	rom ( serial "ULJM-05950" )
 )
 
 game (
 	name "Moto GP (Europe) (En,Fr,De,It,Nl)"
-	serial "UCES-00373"
-	serial "UCES-00373"
+	rom ( serial "UCES-00373" )
 )
 
 game (
 	name "Moto GP (Japan) (v1.02)"
-	serial "ULJS-00078"
-	serial "ULJS-00078"
+	rom ( serial "ULJS-00078" )
 )
 
 game (
 	name "Moto GP (USA) (v1.02)"
-	serial "ULUS-10153"
-	serial "ULUS-10153"
+	rom ( serial "ULUS-10153" )
 )
 
 game (
 	name "MotorStorm - Arctic Edge (Asia) (En,Ko)"
-	serial "UCAS-40266"
-	serial "UCAS-40266"
+	rom ( serial "UCAS-40266" )
 )
 
 game (
 	name "MotorStorm - Arctic Edge (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru,El) (v1.01)"
-	serial "UCES-01250"
-	serial "UCES-01250"
+	rom ( serial "UCES-01250" )
 )
 
 game (
 	name "MotorStorm - Arctic Edge (Korea)"
-	serial "UCKS-45124"
-	serial "UCKS-45124"
+	rom ( serial "UCKS-45124" )
 )
 
 game (
 	name "MotorStorm - Arctic Edge (USA) (En,Fr,De,Es,It,Nl,Pt,Ru)"
-	serial "UCUS-98743"
-	serial "UCUS-98743"
+	rom ( serial "UCUS-98743" )
 )
 
 game (
 	name "Motto Nuga-Cel! (Japan) (v1.01)"
-	serial "ULJM-05654"
-	serial "ULJM-05654"
+	rom ( serial "ULJM-05654" )
 )
 
 game (
 	name "Moujuutsukai to Oujisama - Snow Bride Portable (Japan) (v1.02)"
-	serial "ULJM-06030"
-	serial "ULJM-06030"
+	rom ( serial "ULJM-06030" )
 )
 
 game (
 	name "Moujuutsukai to Oujisama Portable (Japan) (v1.01)"
-	serial "ULJM-05895"
-	serial "ULJM-05895"
+	rom ( serial "ULJM-05895" )
 )
 
 game (
 	name "Musketeer (Japan) (v1.01)"
-	serial "ULJM-05882"
-	serial "ULJM-05882"
+	rom ( serial "ULJM-05882" )
 )
 
 game (
 	name "Musou Orochi 2 Special (Japan) (v1.01)"
-	serial "ULJM-06097"
-	serial "ULJM-06097"
+	rom ( serial "ULJM-06097" )
 )
 
 game (
 	name "Musou Tourou (Japan)"
-	serial "ULJS-00163"
-	serial "ULJS-00163"
+	rom ( serial "ULJS-00163" )
 )
 
 game (
 	name "MutaJuice (Korea) (v1.04)"
-	serial "ULKS-46061"
-	serial "ULKS-46061"
+	rom ( serial "ULKS-46061" )
 )
 
 game (
 	name "My Merry May with be (Japan) (v1.01)"
-	serial "ULJM-05603"
-	serial "ULJM-05603"
+	rom ( serial "ULJM-05603" )
 )
 
 game (
 	name "My Spanish Coach (USA) (v1.01)"
-	serial "ULUS-10378"
-	serial "ULUS-10378"
+	rom ( serial "ULUS-10378" )
 )
 
 game (
 	name "MyStylist (Asia) (v1.01) [b]"
-	serial "UCAS-40192"
-	serial "UCAS-40192"
+	rom ( serial "UCAS-40192" )
 )
 
 game (
 	name "MyStylist (Japan)"
-	serial "UCJS-10078"
-	serial "UCJS-10078"
+	rom ( serial "UCJS-10078" )
 )
 
 game (
 	name "Myst (Europe)"
-	serial "ULES-00659"
-	serial "ULES-00659"
+	rom ( serial "ULES-00659" )
 )
 
 game (
 	name "Myst (Europe) (En,Fr,De) (v1.02)"
-	serial "ULES-00412"
-	serial "ULES-00412"
+	rom ( serial "ULES-00412" )
 )
 
 game (
 	name "Myst (Japan) (v1.03)"
-	serial "ULJM-05094"
-	serial "ULJM-05094"
+	rom ( serial "ULJM-05094" )
 )
 
 game (
 	name "Mystereet Portable - Yasogami Kaoru no Chousen (Japan) (v1.01)"
-	serial "ULJM-05328"
-	serial "ULJM-05328"
+	rom ( serial "ULJM-05328" )
 )
 
 game (
 	name "Mystery Team, The (Europe) (En,Fr,De,Es,It,Nl,Pt)"
-	serial "UCES-01536"
-	serial "UCES-01536"
+	rom ( serial "UCES-01536" )
 )
 
 game (
 	name "Mytran Wars (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01098"
-	serial "ULES-01098"
+	rom ( serial "ULES-01098" )
 )
 
 game (
 	name "Mytran Wars (USA) (En,Fr,De,Es,It) (v1.04)"
-	serial "ULUS-10398"
-	serial "ULUS-10398"
+	rom ( serial "ULUS-10398" )
 )
 
 game (
 	name "N+ (Europe)"
-	serial "ULES-01026"
-	serial "ULES-01026"
+	rom ( serial "ULES-01026" )
 )
 
 game (
 	name "N+ (USA) (v1.02)"
-	serial "ULUS-10340"
-	serial "ULUS-10340"
+	rom ( serial "ULUS-10340" )
 )
 
 game (
 	name "NASCAR (USA) (v1.01)"
-	serial "ULUS-10122"
-	serial "ULUS-10122"
+	rom ( serial "ULUS-10122" )
 )
 
 game (
 	name "NBA (USA)"
-	serial "UCUS-98607"
-	serial "UCUS-98607"
+	rom ( serial "UCUS-98607" )
 )
 
 game (
 	name "NBA 06 (USA)"
-	serial "UCUS-98626"
-	serial "UCUS-98626"
+	rom ( serial "UCUS-98626" )
 )
 
 game (
 	name "NBA 07 (USA)"
-	serial "UCUS-98644"
-	serial "UCUS-98644"
+	rom ( serial "UCUS-98644" )
 )
 
 game (
 	name "NBA 07 (USA) (Demo)"
-	serial "UCUS-98694"
-	serial "UCUS-98694"
+	rom ( serial "UCUS-98694" )
 )
 
 game (
 	name "NBA 08 (USA)"
-	serial "UCUS-98699"
-	serial "UCUS-98699"
+	rom ( serial "UCUS-98699" )
 )
 
 game (
 	name "NBA 09 - The Inside (USA)"
-	serial "UCUS-98715"
-	serial "UCUS-98715"
+	rom ( serial "UCUS-98715" )
 )
 
 game (
 	name "NBA 10 - The Inside (USA)"
-	serial "UCUS-98738"
-	serial "UCUS-98738"
+	rom ( serial "UCUS-98738" )
 )
 
 game (
 	name "NBA 2K10 (Europe) (v1.01)"
-	serial "ULES-01342"
-	serial "ULES-01342"
+	rom ( serial "ULES-01342" )
 )
 
 game (
 	name "NBA 2K10 (Japan) (En) (v1.01)"
-	serial "ULUS-10474"
-	serial "ULUS-10474"
+	rom ( serial "ULUS-10474" )
 )
 
 game (
 	name "NBA 2K10 (USA)"
-	serial "ULUS-10474"
-	serial "ULUS-10474"
 )
 
 game (
 	name "NBA 2K11 (Europe)"
-	serial "ULES-01488"
-	serial "ULES-01488"
+	rom ( serial "ULES-01488" )
 )
 
 game (
 	name "NBA 2K11 (Japan)"
-	serial "ULJM-05778"
-	serial "ULJM-05778"
+	rom ( serial "ULJM-05778" )
 )
 
 game (
 	name "NBA 2K11 (USA) (v1.01)"
-	serial "ULUS-10552"
-	serial "ULUS-10552"
+	rom ( serial "ULUS-10552" )
 )
 
 game (
 	name "NBA 2K12 (Asia)"
-	serial "ULUS-10585"
-	serial "ULUS-10585"
+	rom ( serial "ULUS-10585" )
 )
 
 game (
 	name "NBA 2K12 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01554"
-	serial "ULES-01554"
+	rom ( serial "ULES-01554" )
 )
 
 game (
 	name "NBA 2K12 (Japan)"
-	serial "ULJS-00426"
-	serial "ULJS-00426"
+	rom ( serial "ULJS-00426" )
 )
 
 game (
 	name "NBA 2K12 (USA)"
-	serial "ULUS-10585"
-	serial "ULUS-10585"
 )
 
 game (
 	name "NBA 2K13 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01578"
-	serial "ULES-01578"
+	rom ( serial "ULES-01578" )
 )
 
 game (
 	name "NBA 2K13 (Japan)"
-	serial "ULJS-00551"
-	serial "ULJS-00551"
+	rom ( serial "ULJS-00551" )
 )
 
 game (
 	name "NBA 2K13 (USA)"
-	serial "ULUS-10598"
-	serial "ULUS-10598"
+	rom ( serial "ULUS-10598" )
 )
 
 game (
 	name "NBA Ballers Rebound (USA) (v1.05)"
-	serial "ULUS-10078"
-	serial "ULUS-10078"
+	rom ( serial "ULUS-10078" )
 )
 
 game (
 	name "NBA Live 06 (Europe) (En,De,It)"
-	serial "ULES-00156"
-	serial "ULES-00156"
+	rom ( serial "ULES-00156" )
 )
 
 game (
 	name "NBA Live 06 (France)"
-	serial "ULES-00157"
-	serial "ULES-00157"
+	rom ( serial "ULES-00157" )
 )
 
 game (
 	name "NBA Live 06 (Japan) (v1.03)"
-	serial "ULJM-05064"
-	serial "ULJM-05064"
+	rom ( serial "ULJM-05064" )
 )
 
 game (
 	name "NBA Live 06 (Korea)"
-	serial "ULKS-46032"
-	serial "ULKS-46032"
+	rom ( serial "ULKS-46032" )
 )
 
 game (
 	name "NBA Live 06 (Spain)"
-	serial "ULES-00158"
-	serial "ULES-00158"
+	rom ( serial "ULES-00158" )
 )
 
 game (
 	name "NBA Live 06 (USA)"
-	serial "ULUS-10030"
-	serial "ULUS-10030"
+	rom ( serial "ULUS-10030" )
 )
 
 game (
 	name "NBA Live 07 (Europe) (En,De,It)"
-	serial "ULES-00462"
-	serial "ULES-00462"
+	rom ( serial "ULES-00462" )
 )
 
 game (
 	name "NBA Live 07 (France)"
-	serial "ULES-00463"
-	serial "ULES-00463"
+	rom ( serial "ULES-00463" )
 )
 
 game (
 	name "NBA Live 07 (Japan) (v1.01)"
-	serial "ULJM-05190"
-	serial "ULJM-05190"
+	rom ( serial "ULJM-05190" )
 )
 
 game (
 	name "NBA Live 07 (Spain)"
-	serial "ULES-00464"
-	serial "ULES-00464"
+	rom ( serial "ULES-00464" )
 )
 
 game (
 	name "NBA Live 07 (USA) (v1.01)"
-	serial "ULUS-10113"
-	serial "ULUS-10113"
+	rom ( serial "ULUS-10113" )
 )
 
 game (
 	name "NBA Live 08 (Asia)"
-	serial "ULAS-42113"
-	serial "ULAS-42113"
+	rom ( serial "ULAS-42113" )
 )
 
 game (
 	name "NBA Live 08 (Europe) (En,Fr,Es,It) (v1.01)"
-	serial "ULES-00921"
-	serial "ULES-00921"
+	rom ( serial "ULES-00921" )
 )
 
 game (
 	name "NBA Live 08 (Europe) (v1.01)"
-	serial "ULES-00920"
-	serial "ULES-00920"
+	rom ( serial "ULES-00920" )
 )
 
 game (
 	name "NBA Live 08 (Japan) (v1.01)"
-	serial "ULJM-05289"
-	serial "ULJM-05289"
+	rom ( serial "ULJM-05289" )
 )
 
 game (
 	name "NBA Live 08 (USA)"
-	serial "ULUS-10294"
-	serial "ULUS-10294"
+	rom ( serial "ULUS-10294" )
 )
 
 game (
 	name "NBA Live 09 (Europe) (En,De,It)"
-	serial "ULES-01147"
-	serial "ULES-01147"
+	rom ( serial "ULES-01147" )
 )
 
 game (
 	name "NBA Live 09 (France)"
-	serial "ULES-01148"
-	serial "ULES-01148"
+	rom ( serial "ULES-01148" )
 )
 
 game (
 	name "NBA Live 09 (Japan) (v1.01)"
-	serial "ULJM-05386"
-	serial "ULJM-05386"
+	rom ( serial "ULJM-05386" )
 )
 
 game (
 	name "NBA Live 09 (Spain)"
-	serial "ULES-01149"
-	serial "ULES-01149"
+	rom ( serial "ULES-01149" )
 )
 
 game (
 	name "NBA Live 09 (USA) (En,Fr) (v1.01)"
-	serial "ULUS-10370"
-	serial "ULUS-10370"
+	rom ( serial "ULUS-10370" )
 )
 
 game (
 	name "NBA Live 10 (Asia) (v1.01)"
-	serial "ULUS-10465"
-	serial "ULUS-10465"
+	rom ( serial "ULUS-10465" )
 )
 
 game (
 	name "NBA Live 10 (Europe) (En,De,It) (v1.06)"
-	serial "ULES-01308"
-	serial "ULES-01308"
+	rom ( serial "ULES-01308" )
 )
 
 game (
 	name "NBA Live 10 (France) (v1.06)"
-	serial "ULES-01309"
-	serial "ULES-01309"
+	rom ( serial "ULES-01309" )
 )
 
 game (
 	name "NBA Live 10 (Japan)"
-	serial "NPJH-50084"
-	serial "NPJH-50084"
+	rom ( serial "NPJH-50084" )
 )
 
 game (
 	name "NBA Live 10 (Spain) (v1.06)"
-	serial "ULES-01310"
-	serial "ULES-01310"
+	rom ( serial "ULES-01310" )
 )
 
 game (
 	name "NBA Live 10 (USA) (v1.01)"
-	serial "ULUS-10465"
-	serial "ULUS-10465"
 )
 
 game (
 	name "NBA Street Showdown (Asia)"
-	serial "ULAS-42003"
-	serial "ULAS-42003"
+	rom ( serial "ULAS-42003" )
 )
 
 game (
 	name "NBA Street Showdown (Europe) (En,Fr,De)"
-	serial "ULES-00037"
-	serial "ULES-00037"
+	rom ( serial "ULES-00037" )
 )
 
 game (
 	name "NBA Street Showdown (Japan) (v1.01)"
-	serial "ULJM-05046"
-	serial "ULJM-05046"
+	rom ( serial "ULJM-05046" )
 )
 
 game (
 	name "NBA Street Showdown (USA)"
-	serial "ULUS-10010"
-	serial "ULUS-10010"
+	rom ( serial "ULUS-10010" )
 )
 
 game (
 	name "NCAA Football 07 (USA)"
-	serial "ULUS-10116"
-	serial "ULUS-10116"
+	rom ( serial "ULUS-10116" )
 )
 
 game (
 	name "NCAA Football 07 (USA) (v2.00)"
-	serial "ULUS-10116"
-	serial "ULUS-10116"
 )
 
 game (
 	name "NCAA Football 2009 (USA)"
-	serial "ULUS-10355"
-	serial "ULUS-10355"
+	rom ( serial "ULUS-10355" )
 )
 
 game (
 	name "NFL Street 2 Unleashed (Europe)"
-	serial "ULES-00036"
-	serial "ULES-00036"
+	rom ( serial "ULES-00036" )
 )
 
 game (
 	name "NFL Street 2 Unleashed (USA) (v1.02)"
-	serial "ULUS-10008"
-	serial "ULUS-10008"
+	rom ( serial "ULUS-10008" )
 )
 
 game (
 	name "NFL Street 3 (Europe)"
-	serial "ULES-00641"
-	serial "ULES-00641"
+	rom ( serial "ULES-00641" )
 )
 
 game (
 	name "NFL Street 3 (USA)"
-	serial "ULUS-10135"
-	serial "ULUS-10135"
+	rom ( serial "ULUS-10135" )
 )
 
 game (
 	name "NHL 07 (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-00477"
-	serial "ULES-00477"
+	rom ( serial "ULES-00477" )
 )
 
 game (
 	name "NHL 07 (USA) (v1.01)"
-	serial "ULUS-10131"
-	serial "ULUS-10131"
+	rom ( serial "ULUS-10131" )
 )
 
 game (
 	name "NHRA Drag Racing - Countdown to the Championship (USA) (v1.01)"
-	serial "ULUS-10278"
-	serial "ULUS-10278"
+	rom ( serial "ULUS-10278" )
 )
 
 game (
 	name "Namco Museum (Japan) (v1.02)"
-	serial "ULJS-00012"
-	serial "ULJS-00012"
+	rom ( serial "ULJS-00012" )
 )
 
 game (
 	name "Namco Museum (Korea)"
-	serial "UCKS-45005"
-	serial "UCKS-45005"
+	rom ( serial "UCKS-45005" )
 )
 
 game (
 	name "Namco Museum Vol.2 (Japan) (v1.01)"
-	serial "ULJS-00047"
-	serial "ULJS-00047"
+	rom ( serial "ULJS-00047" )
 )
 
 game (
 	name "Nana - Subete wa Daimaou no Omichibiki (Japan)"
-	serial "ULJM-05142"
-	serial "ULJM-05142"
+	rom ( serial "ULJM-05142" )
 )
 
 game (
 	name "Nanatama - Chronicle of Dungeon Maker (Japan) (v1.02)"
-	serial "ULJM-05434"
-	serial "ULJM-05434"
+	rom ( serial "ULJM-05434" )
 )
 
 game (
 	name "Nano Diver (Japan) (v1.03)"
-	serial "NPJH-50375"
-	serial "NPJH-50375"
+	rom ( serial "NPJH-50375" )
 )
 
 game (
 	name "Napoleon Dynamite - The Game (USA) (v1.03)"
-	serial "ULUS-10305"
-	serial "ULUS-10305"
+	rom ( serial "ULUS-10305" )
 )
 
 game (
 	name "Naraku no Shiro Portable - Ichiyanagi Nagomu, 2-dome no Junan (Japan) (v1.03)"
-	serial "ULJS-00230"
-	serial "ULJS-00230"
+	rom ( serial "ULJS-00230" )
 )
 
 game (
 	name "Narcissu - Moshimo Ashita ga Arunara (Japan) (v1.02)"
-	serial "ULJM-05674"
-	serial "ULJM-05674"
+	rom ( serial "ULJM-05674" )
 )
 
 game (
 	name "Narisokonai Eiyuutan - Taiyou to Tsuki no Monogatari (Japan) (v1.03)"
-	serial "ULJS-00177"
-	serial "ULJS-00177"
+	rom ( serial "ULJS-00177" )
 )
 
 game (
 	name "Naruto - Ultimate Ninja Heroes (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00865"
-	serial "ULES-00865"
+	rom ( serial "ULES-00865" )
 )
 
 game (
 	name "Naruto - Ultimate Ninja Heroes (USA)"
-	serial "ULUS-10299"
-	serial "ULUS-10299"
+	rom ( serial "ULUS-10299" )
 )
 
 game (
 	name "Naruto - Ultimate Ninja Heroes 2 - The Phantom Fortress (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01088"
-	serial "ULES-01088"
+	rom ( serial "ULES-01088" )
 )
 
 game (
 	name "Naruto - Ultimate Ninja Heroes 2 - The Phantom Fortress (USA)"
-	serial "ULUS-10349"
-	serial "ULUS-10349"
+	rom ( serial "ULUS-10349" )
 )
 
 game (
 	name "Naruto Shippuden - Kizuna Drive (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01516"
-	serial "ULES-01516"
+	rom ( serial "ULES-01516" )
 )
 
 game (
 	name "Naruto Shippuden - Kizuna Drive (Japan) (v1.01)"
-	serial "ULJS-00291"
-	serial "ULJS-00291"
+	rom ( serial "ULJS-00291" )
 )
 
 game (
 	name "Naruto Shippuden - Kizuna Drive (USA) (En,Fr,Es)"
-	serial "ULUS-10571"
-	serial "ULUS-10571"
+	rom ( serial "ULUS-10571" )
 )
 
 game (
 	name "Naruto Shippuden - Legends - Akatsuki Rising (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01306"
-	serial "ULES-01306"
+	rom ( serial "ULES-01306" )
 )
 
 game (
 	name "Naruto Shippuden - Legends - Akatsuki Rising (USA)"
-	serial "ULUS-10447"
-	serial "ULUS-10447"
+	rom ( serial "ULUS-10447" )
 )
 
 game (
 	name "Naruto Shippuden - Ultimate Ninja Heroes 3 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01407"
-	serial "ULES-01407"
+	rom ( serial "ULES-01407" )
 )
 
 game (
 	name "Naruto Shippuden - Ultimate Ninja Heroes 3 (USA)"
-	serial "ULUS-10518"
-	serial "ULUS-10518"
+	rom ( serial "ULUS-10518" )
 )
 
 game (
 	name "Naruto Shippuden - Ultimate Ninja Impact (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01537"
-	serial "ULES-01537"
+	rom ( serial "ULES-01537" )
 )
 
 game (
 	name "Naruto Shippuden - Ultimate Ninja Impact (USA) (En,Fr,Es)"
-	serial "ULUS-10582"
-	serial "ULUS-10582"
+	rom ( serial "ULUS-10582" )
 )
 
 game (
 	name "Nayuta no Kiseki (Japan) (v1.01)"
-	serial "NPJH-50625"
-	serial "NPJH-50625"
+	rom ( serial "NPJH-50625" )
 )
 
 game (
 	name "Need for Speed - Most Wanted 5-1-0 (Asia)"
-	serial "ULAS-42031"
-	serial "ULAS-42031"
+	rom ( serial "ULAS-42031" )
 )
 
 game (
 	name "Need for Speed - Most Wanted 5-1-0 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00196"
-	serial "ULES-00196"
+	rom ( serial "ULES-00196" )
 )
 
 game (
 	name "Need for Speed - Most Wanted 5-1-0 (Japan)"
-	serial "ULJM-05073"
-	serial "ULJM-05073"
+	rom ( serial "ULJM-05073" )
 )
 
 game (
 	name "Need for Speed - Most Wanted 5-1-0 (Korea) (v1.01)"
-	serial "ULKS-46044"
-	serial "ULKS-46044"
+	rom ( serial "ULKS-46044" )
 )
 
 game (
 	name "Need for Speed - Most Wanted 5-1-0 (USA)"
-	serial "ULUS-10036"
-	serial "ULUS-10036"
+	rom ( serial "ULUS-10036" )
 )
 
 game (
 	name "Need for Speed - ProStreet (Asia)"
-	serial "ULAS-42129"
-	serial "ULAS-42129"
+	rom ( serial "ULAS-42129" )
 )
 
 game (
 	name "Need for Speed - ProStreet (Europe)"
-	serial "ULES-01019"
-	serial "ULES-01019"
+	rom ( serial "ULES-01019" )
 )
 
 game (
 	name "Need for Speed - ProStreet (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-01020"
-	serial "ULES-01020"
+	rom ( serial "ULES-01020" )
 )
 
 game (
 	name "Need for Speed - ProStreet (Japan) (v1.01)"
-	serial "ULJM-05308"
-	serial "ULJM-05308"
+	rom ( serial "ULJM-05308" )
 )
 
 game (
 	name "Need for Speed - ProStreet (USA)"
-	serial "ULUS-10331"
-	serial "ULUS-10331"
+	rom ( serial "ULUS-10331" )
 )
 
 game (
 	name "Need for Speed - Shift (Asia) (En,Fr,Es)"
-	serial "ULUS-10462"
-	serial "ULUS-10462"
+	rom ( serial "ULUS-10462" )
 )
 
 game (
 	name "Need for Speed - Shift (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01275"
-	serial "ULES-01275"
+	rom ( serial "ULES-01275" )
 )
 
 game (
 	name "Need for Speed - Shift (Japan)"
-	serial "ULJM-05494"
-	serial "ULJM-05494"
+	rom ( serial "ULJM-05494" )
 )
 
 game (
 	name "Need for Speed - Shift (USA) (En,Fr,Es)"
-	serial "ULUS-10462"
-	serial "ULUS-10462"
 )
 
 game (
 	name "Need for Speed - Undercover (Asia)"
-	serial "ULUS-10376"
-	serial "ULUS-10376"
+	rom ( serial "ULUS-10376" )
 )
 
 game (
 	name "Need for Speed - Undercover (Europe) (En,Fr,De,Es,It,Nl,Pl,Ru,Cs,Hu)"
-	serial "ULES-01145"
-	serial "ULES-01145"
+	rom ( serial "ULES-01145" )
 )
 
 game (
 	name "Need for Speed - Undercover (Japan) (v1.01)"
-	serial "ULJM-05403"
-	serial "ULJM-05403"
+	rom ( serial "ULJM-05403" )
 )
 
 game (
 	name "Need for Speed - Undercover (USA)"
-	serial "ULUS-10376"
-	serial "ULUS-10376"
 )
 
 game (
 	name "Need for Speed - Underground Rivals (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00025"
-	serial "ULES-00025"
+	rom ( serial "ULES-00025" )
 )
 
 game (
 	name "Need for Speed - Underground Rivals (Japan)"
-	serial "ULJM-05008"
-	serial "ULJM-05008"
+	rom ( serial "ULJM-05008" )
 )
 
 game (
 	name "Need for Speed - Underground Rivals (Korea)"
-	serial "ULKS-46004"
-	serial "ULKS-46004"
+	rom ( serial "ULKS-46004" )
 )
 
 game (
 	name "Need for Speed - Underground Rivals (USA)"
-	serial "ULUS-10007"
-	serial "ULUS-10007"
+	rom ( serial "ULUS-10007" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (Asia)"
-	serial "ULAS-42080"
-	serial "ULAS-42080"
+	rom ( serial "ULAS-42080" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (Europe)"
-	serial "ULES-00576"
-	serial "ULES-00576"
+	rom ( serial "ULES-00576" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-00577"
-	serial "ULES-00577"
+	rom ( serial "ULES-00577" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (Japan) (v1.02)"
-	serial "ULJM-05204"
-	serial "ULJM-05204"
+	rom ( serial "ULJM-05204" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (Korea)"
-	serial "ULKS-46034"
-	serial "ULKS-46034"
+	rom ( serial "ULKS-46034" )
 )
 
 game (
 	name "Need for Speed Carbon - Own the City (USA)"
-	serial "ULUS-10114"
-	serial "ULUS-10114"
+	rom ( serial "ULUS-10114" )
 )
 
 game (
 	name "Nendoroid Generation (Japan) (v1.02)"
-	serial "ULJS-00441"
-	serial "ULJS-00441"
+	rom ( serial "ULJS-00441" )
 )
 
 game (
 	name "Neo Angelique Special (Japan) (v1.01)"
-	serial "ULJM-05374"
-	serial "ULJM-05374"
+	rom ( serial "ULJM-05374" )
 )
 
 game (
 	name "Neopets - Petpet Adventures - The Wand of Wishing (USA)"
-	serial "UCUS-98622"
-	serial "UCUS-98622"
+	rom ( serial "UCUS-98622" )
 )
 
 game (
 	name "Never7 - The End of Infinity (Japan) (v1.01)"
-	serial "ULJM-05433"
-	serial "ULJM-05433"
+	rom ( serial "ULJM-05433" )
 )
 
 game (
 	name "Neverland Card Battles (USA)"
-	serial "ULUS-10382"
-	serial "ULUS-10382"
+	rom ( serial "ULUS-10382" )
 )
 
 game (
 	name "Nichijou - Uchuujin (Japan) (v1.01)"
-	serial "ULJM-05893"
-	serial "ULJM-05893"
+	rom ( serial "ULJM-05893" )
 )
 
 game (
 	name "Nikoli no Sudoku +2 Daiisshuu - Sudoku Nurikabe Heyawake (Japan) (v1.01)"
-	serial "ULJM-05787"
-	serial "ULJM-05787"
+	rom ( serial "ULJM-05787" )
 )
 
 game (
 	name "Nikoli no Sudoku +3 Dainishuu - Sudoku Kakuro Bijutsukan Hitori-ni-Shitekure (Japan) (v1.01)"
-	serial "NPJH-50387"
-	serial "NPJH-50387"
+	rom ( serial "NPJH-50387" )
 )
 
 game (
 	name "Nikoli no Sudoku +3 Daisanshuu - Sudoku Slitherlink Masyu Yajilin (Japan)"
-	serial "NPJH-50413"
-	serial "NPJH-50413"
+	rom ( serial "NPJH-50413" )
 )
 
 game (
 	name "Nikoli no Sudoku +3 Daiyonshuu - Sudoku Numberlink Shikaku-ni-Kire Hashi-o-Kakero (Japan)"
-	serial "NPJH-50419"
-	serial "NPJH-50419"
+	rom ( serial "NPJH-50419" )
 )
 
 game (
 	name "Ninja Katsugeki - Tenchu Kurenai Portable (Japan) (v1.01)"
-	serial "ULJM-05598"
-	serial "ULJM-05598"
+	rom ( serial "ULJM-05598" )
 )
 
 game (
 	name "Ninja Katsugeki - Tenchu San Portable (Japan) (v1.01)"
-	serial "ULJM-05505"
-	serial "ULJM-05505"
+	rom ( serial "ULJM-05505" )
 )
 
 game (
 	name "Nippon no Asoko de (Japan) (v1.01)"
-	serial "UCJS-10080"
-	serial "UCJS-10080"
+	rom ( serial "UCJS-10080" )
 )
 
 game (
 	name "Nise no Chigiri - Omoide no Saki e (Japan) (v1.02)"
-	serial "ULJM-05915"
-	serial "ULJM-05915"
+	rom ( serial "ULJM-05915" )
 )
 
 game (
 	name "Nishimura Kyotaro Travel Mystery - Akugyaku no Kisetsu - Tokyo Nanki-Shirahama Renzoku Satsujin Jiken (Japan)"
-	serial "ULJS-00197"
-	serial "ULJS-00197"
+	rom ( serial "ULJS-00197" )
 )
 
 game (
 	name "No Fate! Only the Power of Will (Japan) (v1.01)"
-	serial "ULJM-05610"
-	serial "ULJM-05610"
+	rom ( serial "ULJM-05610" )
 )
 
 game (
 	name "Nobunaga no Yabou - Reppuuden with Power Up Kit (Japan) (v1.02)"
-	serial "ULJM-05022"
-	serial "ULJM-05022"
+	rom ( serial "ULJM-05022" )
 )
 
 game (
 	name "Nobunaga no Yabou - Shouseiroku (Japan) (v1.01)"
-	serial "ULJM-05072"
-	serial "ULJM-05072"
+	rom ( serial "ULJM-05072" )
 )
 
 game (
 	name "Nobunaga no Yabou - Soutenroku with Power Up Kit (Japan) (v1.02)"
-	serial "ULJM-05902"
-	serial "ULJM-05902"
+	rom ( serial "ULJM-05902" )
 )
 
 game (
 	name "Nobunaga no Yabou - Tenshouki (Japan) (v1.03)"
-	serial "ULJM-05032"
-	serial "ULJM-05032"
+	rom ( serial "ULJM-05032" )
 )
 
 game (
 	name "Nogizaka Haruka no Himistu - Doujinshi Hajimemashita (Japan)"
-	serial "NPJH-50339"
-	serial "NPJH-50339"
+	rom ( serial "NPJH-50339" )
 )
 
 game (
 	name "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita - Himitsu no Radio (Japan)"
-	serial "ULJS-00161"
-	serial "ULJS-00161"
+	rom ( serial "ULJS-00161" )
 )
 
 game (
 	name "Nouryoku Trainer Portable (Japan)"
-	serial "ULJM-05050"
-	serial "ULJM-05050"
+	rom ( serial "ULJM-05050" )
 )
 
 game (
 	name "Numpla 10000-Mon (Japan)"
-	serial "ULJM-05331"
-	serial "ULJM-05331"
+	rom ( serial "ULJM-05331" )
 )
 
 game (
 	name "Obscure - The Aftermath (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01340"
-	serial "ULES-01340"
+	rom ( serial "ULES-01340" )
 )
 
 game (
 	name "Obscure - The Aftermath (USA) (En,Fr,Es)"
-	serial "ULUS-10484"
-	serial "ULUS-10484"
+	rom ( serial "ULUS-10484" )
 )
 
 game (
 	name "Off Road (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00963"
-	serial "ULES-00963"
+	rom ( serial "ULES-00963" )
 )
 
 game (
 	name "Okashi na Shima no Peter Pan - Sweet Never Land (Japan) (v1.03)"
-	serial "ULJM-05949"
-	serial "ULJM-05949"
+	rom ( serial "ULJM-05949" )
 )
 
 game (
 	name "Omochabako no Kuni no Alice - Wonderful Wonder World (Japan) (v1.03)"
-	serial "ULJM-05995"
-	serial "ULJM-05995"
+	rom ( serial "ULJM-05995" )
 )
 
 game (
 	name "Omoi no Kakera - Close to (Japan)"
-	serial "ULJM-06002"
-	serial "ULJM-06002"
+	rom ( serial "ULJM-06002" )
 )
 
 game (
 	name "Omoide ni Kawaru Kimi - Memories Off (Japan) (v1.01)"
-	serial "ULJM-05349"
-	serial "ULJM-05349"
+	rom ( serial "ULJM-05349" )
 )
 
 game (
 	name "OneChanbara Special (Japan) (v1.03)"
-	serial "ULJS-00367"
-	serial "ULJS-00367"
+	rom ( serial "ULJS-00367" )
 )
 
 game (
 	name "Online Chess Kingdoms (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00570"
-	serial "ULES-00570"
+	rom ( serial "ULES-00570" )
 )
 
 game (
 	name "Online Chess Kingdoms (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10179"
-	serial "ULUS-10179"
+	rom ( serial "ULUS-10179" )
 )
 
 game (
 	name "Onore no Shinzuru Michi o Yuke (Japan) (v1.01)"
-	serial "ULJM-05465"
-	serial "ULJM-05465"
+	rom ( serial "ULJM-05465" )
 )
 
 game (
 	name "Ooedo Senryoubako (Japan) (v1.01)"
-	serial "ULJM-05099"
-	serial "ULJM-05099"
+	rom ( serial "ULJM-05099" )
 )
 
 game (
 	name "Ookami Kakushi (Japan) (v1.04)"
-	serial "ULJM-05413"
-	serial "ULJM-05413"
+	rom ( serial "ULJM-05413" )
 )
 
 game (
 	name "Open Season (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
-	serial "ULES-00508"
-	serial "ULES-00508"
+	rom ( serial "ULES-00508" )
 )
 
 game (
 	name "Open Season (Europe) (En,Fr,Es,Nl) (v1.01)"
-	serial "ULES-00507"
-	serial "ULES-00507"
+	rom ( serial "ULES-00507" )
 )
 
 game (
 	name "Open Season (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10152"
-	serial "ULUS-10152"
+	rom ( serial "ULUS-10152" )
 )
 
 game (
 	name "Ore no Dungeon - Desire and Adventurous Spirit (Japan) (v1.01)"
-	serial "ULJM-05167"
-	serial "ULJM-05167"
+	rom ( serial "ULJM-05167" )
 )
 
 game (
 	name "Ore no Imouto Maker EX - Imouto to Koishiyo Portable (Japan) (v1.01)"
-	serial "ULJS-00357"
-	serial "ULJS-00357"
+	rom ( serial "ULJS-00357" )
 )
 
 game (
 	name "Ore no Imouto ga Konna ni Kawaii Wake ga Nai - Portable ga Tsuzuku Wake ga Nai (Japan)"
-	serial "NPJH-50568"
-	serial "NPJH-50568"
-)
-
-game (
-	name "Ore no Imouto ga Konna ni Kawaii Wake ga Nai - Portable ga Tsuzuku Wake ga Nai (Japan)"
-	serial "NPJH-50568"
-	serial "NPJH-50568"
+	rom ( serial "NPJH-50568" )
 )
 
 game (
 	name "Ore no Imouto ga Konna ni Kawaii Wake ga Nai Portable (Japan) (v1.01)"
-	serial "ULJS-00358"
-	serial "ULJS-00358"
+	rom ( serial "ULJS-00358" )
 )
 
 game (
 	name "Ore wa Shoujo Mangaka (Japan) (v1.03)"
-	serial "ULJM-06018"
-	serial "ULJM-06018"
+	rom ( serial "ULJM-06018" )
 )
 
 game (
 	name "Oretachi no Sabage Portable (Japan) (v1.03)"
-	serial "ULJS-00170"
-	serial "ULJS-00170"
+	rom ( serial "ULJS-00170" )
 )
 
 game (
 	name "Oretachi no Sabage Versus (Japan) (v1.02)"
-	serial "ULJS-00319"
-	serial "ULJS-00319"
+	rom ( serial "ULJS-00319" )
 )
 
 game (
 	name "Otome wa Boku ni Koishiteru Portable (Japan) (v1.02)"
-	serial "ULJM-05647"
-	serial "ULJM-05647"
+	rom ( serial "ULJM-05647" )
 )
 
 game (
 	name "Otome wa Boku ni Koishiteru Portable - Futari no Elder (Japan)"
-	serial "ULJM-05862"
-	serial "ULJM-05862"
-)
-
-game (
-	name "Otome wa Boku ni Koishiteru Portable - Futari no Elder (Japan)"
-	serial "ULJM-05862"
-	serial "ULJM-05862"
+	rom ( serial "ULJM-05862" )
 )
 
 game (
 	name "Otometeki Koi Kakumei - Love Revo!! Portable (Japan) (v1.02)"
-	serial "ULJM-05656"
-	serial "ULJM-05656"
+	rom ( serial "ULJM-05656" )
 )
 
 game (
 	name "Otsuge Uranainandesu. (Japan) (v1.01)"
-	serial "ULJM-05409"
-	serial "ULJM-05409"
+	rom ( serial "ULJM-05409" )
 )
 
 game (
 	name "Ouka Sengoku Portable (Japan) (v1.02)"
-	serial "NPJH-50627"
-	serial "NPJH-50627"
+	rom ( serial "NPJH-50627" )
 )
 
 game (
 	name "Oumagatoki - Kaidan Romance (Japan) (v1.02)"
-	serial "ULJM-06039"
-	serial "ULJM-06039"
+	rom ( serial "ULJM-06039" )
 )
 
 game (
 	name "OutRun 2006 - Coast 2 Coast (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00262"
-	serial "ULES-00262"
+	rom ( serial "ULES-00262" )
 )
 
 game (
 	name "OutRun 2006 - Coast 2 Coast (USA) (v1.03)"
-	serial "ULUS-10064"
-	serial "ULUS-10064"
+	rom ( serial "ULUS-10064" )
 )
 
 game (
 	name "Over the Hedge - Hammy Goes Nuts! (Europe)"
-	serial "ULES-00663"
-	serial "ULES-00663"
+	rom ( serial "ULES-00663" )
 )
 
 game (
 	name "Over the Hedge - Hammy Goes Nuts! (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00665"
-	serial "ULES-00665"
+	rom ( serial "ULES-00665" )
 )
 
 game (
 	name "Over the Hedge - Hammy Goes Nuts! (USA) (v1.01)"
-	serial "ULUS-10187"
-	serial "ULUS-10187"
+	rom ( serial "ULUS-10187" )
 )
 
 game (
 	name "P-Kara (Japan)"
-	serial "UCJS-10040"
-	serial "UCJS-10040"
+	rom ( serial "UCJS-10040" )
 )
 
 game (
 	name "PC Engine Best Collection - Ginga Ojousama Densetsu Collection (Japan) (v1.02)"
-	serial "ULJM-05358"
-	serial "ULJM-05358"
+	rom ( serial "ULJM-05358" )
 )
 
 game (
 	name "PC Engine Best Collection - Soldier Collection (Japan)"
-	serial "ULJM-05377"
-	serial "ULJM-05377"
+	rom ( serial "ULJM-05377" )
 )
 
 game (
 	name "PC Engine Best Collection - Tengai Makyou Collection (Japan) (v1.01)"
-	serial "ULJM-05357"
-	serial "ULJM-05357"
+	rom ( serial "ULJM-05357" )
 )
 
 game (
 	name "PDC World Championship Darts 2008 (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-01096"
-	serial "ULES-01096"
+	rom ( serial "ULES-01096" )
 )
 
 game (
 	name "PQ - Practical Intelligence Quotient (Europe) (v1.01)"
-	serial "ULES-00358"
-	serial "ULES-00358"
+	rom ( serial "ULES-00358" )
 )
 
 game (
 	name "PQ - Practical Intelligence Quotient (USA) (v1.01)"
-	serial "ULUS-10046"
-	serial "ULUS-10046"
+	rom ( serial "ULUS-10046" )
 )
 
 game (
 	name "PSP System Kiosk Disc #4 (USA) (Demo)"
-	serial "UCUS-98665"
-	serial "UCUS-98665"
+	rom ( serial "UCUS-98665" )
 )
 
 game (
 	name "PW - Project Witch (Japan) (v1.02)"
-	serial "ULJM-05470"
-	serial "ULJM-05470"
+	rom ( serial "ULJM-05470" )
 )
 
 game (
 	name "PaRappa the Rapper (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00775"
-	serial "UCES-00775"
+	rom ( serial "UCES-00775" )
 )
 
 game (
 	name "PaRappa the Rapper (Japan) (En,Ja)"
-	serial "UCJS-10046"
-	serial "UCJS-10046"
+	rom ( serial "UCJS-10046" )
 )
 
 game (
 	name "PaRappa the Rapper (USA)"
-	serial "UCUS-98702"
-	serial "UCUS-98702"
+	rom ( serial "UCUS-98702" )
 )
 
 game (
 	name "Pac Man World 3 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00260"
-	serial "ULES-00260"
+	rom ( serial "ULES-00260" )
 )
 
 game (
 	name "Pac Man World 3 (USA) (v1.01)"
-	serial "ULUS-10055"
-	serial "ULUS-10055"
+	rom ( serial "ULUS-10055" )
 )
 
 game (
 	name "Pac-Man World Rally (USA) (v1.02)"
-	serial "ULUS-10149"
-	serial "ULUS-10149"
+	rom ( serial "ULUS-10149" )
 )
 
 game (
 	name "PachiPara Slot - Pachi-Slot Super Umi Monogatari in Okinawa (Japan)"
-	serial "ULJS-00382"
-	serial "ULJS-00382"
+	rom ( serial "ULJS-00382" )
 )
 
 game (
 	name "Pachinka Mania P - CR Tekkenden Tough (Japan) (v1.01)"
-	serial "ULJM-05670"
-	serial "ULJM-05670"
+	rom ( serial "ULJM-05670" )
 )
 
 game (
 	name "Pangya - Fantasy Golf (USA)"
-	serial "ULUS-10438"
-	serial "ULUS-10438"
+	rom ( serial "ULUS-10438" )
 )
 
 game (
 	name "Panic Palette Portable (Japan) (v1.01)"
-	serial "ULJM-05344"
-	serial "ULJM-05344"
+	rom ( serial "ULJM-05344" )
 )
 
 game (
 	name "Parodius Portable (Japan) (v1.02)"
-	serial "ULJM-05220"
-	serial "ULJM-05220"
+	rom ( serial "ULJM-05220" )
 )
 
 game (
 	name "Passport to Amsterdam (Europe) (En,Fr,De,Es,It) (Map Software)"
-	serial "UCES-00243"
-	serial "UCES-00243"
+	rom ( serial "UCES-00243" )
 )
 
 game (
 	name "Passport to London (Europe) (v1.01) (Map Software)"
-	serial "UCES-00240"
-	serial "UCES-00240"
+	rom ( serial "UCES-00240" )
 )
 
 game (
 	name "Passport to Paris (Europe) (En,Fr,De,Es,It) (v1.01) (Map Software)"
-	serial "UCES-00241"
-	serial "UCES-00241"
+	rom ( serial "UCES-00241" )
 )
 
 game (
 	name "Passport to Prague (Europe) (En,Fr,De,Es,It) (Map Software)"
-	serial "UCES-00244"
-	serial "UCES-00244"
+	rom ( serial "UCES-00244" )
 )
 
 game (
 	name "Passport to Rome (Europe) (En,Fr,De,Es,It) (Map Software)"
-	serial "UCES-00246"
-	serial "UCES-00246"
+	rom ( serial "UCES-00246" )
 )
 
 game (
 	name "Pastel Chime Continue (Japan) (v1.02)"
-	serial "ULJM-05788"
-	serial "ULJM-05788"
+	rom ( serial "ULJM-05788" )
 )
 
 game (
 	name "Patapon (Asia) (v1.01) [b]"
-	serial "UCAS-40193"
-	serial "UCAS-40193"
+	rom ( serial "UCAS-40193" )
 )
 
 game (
 	name "Patapon (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00995"
-	serial "UCES-00995"
+	rom ( serial "UCES-00995" )
 )
 
 game (
 	name "Patapon (Japan)"
-	serial "UCJS-10077"
-	serial "UCJS-10077"
+	rom ( serial "UCJS-10077" )
 )
 
 game (
 	name "Patapon (Korea) (v1.01)"
-	serial "UCKS-45076"
-	serial "UCKS-45076"
+	rom ( serial "UCKS-45076" )
 )
 
 game (
 	name "Patapon (USA)"
-	serial "UCUS-98711"
-	serial "UCUS-98711"
+	rom ( serial "UCUS-98711" )
 )
 
 game (
 	name "Patapon (USA) (Demo)"
-	serial "UCUS-98721"
-	serial "UCUS-98721"
+	rom ( serial "UCUS-98721" )
 )
 
 game (
 	name "Patapon 2 (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-01177"
-	serial "UCES-01177"
+	rom ( serial "UCES-01177" )
 )
 
 game (
 	name "Patapon 2 (USA) (En,Fr,Es)"
-	serial "UCUS-98732"
-	serial "UCUS-98732"
+	rom ( serial "UCUS-98732" )
 )
 
 game (
 	name "Patapon 2 (USA) (En,Fr,Es) (PSN & Store)"
-	serial "UCUS-98732"
-	serial "UCUS-98732"
 )
 
 game (
 	name "Patapon 3 (Asia) (En,Zh,Ko)"
-	serial "UCAS-40318"
-	serial "UCAS-40318"
+	rom ( serial "UCAS-40318" )
 )
 
 game (
 	name "Patapon 3 (Europe) (En,Fr,De,Es,It,Nl,Pt,Pl,Ru) (v1.01)"
-	serial "UCES-01421"
-	serial "UCES-01421"
+	rom ( serial "UCES-01421" )
 )
 
 game (
 	name "Patapon 3 (Japan)"
-	serial "NPJG-00122"
-	serial "NPJG-00122"
+	rom ( serial "NPJG-00122" )
 )
 
 game (
 	name "Patapon 3 (USA) (En,Fr,Es,Pt)"
-	serial "UCUS-98751"
-	serial "UCUS-98751"
+	rom ( serial "UCUS-98751" )
 )
 
 game (
 	name "Payout Poker & Casino (USA) (v1.02)"
-	serial "ULUS-10118"
-	serial "ULUS-10118"
+	rom ( serial "ULUS-10118" )
 )
 
 game (
 	name "Persona 2 - Batsu (Japan)"
-	serial "ULJM-06081"
-	serial "ULJM-06081"
+	rom ( serial "ULJM-06081" )
 )
 
 game (
 	name "Peter Jackson's King Kong (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi) (v1.01)"
-	serial "ULES-00225"
-	serial "ULES-00225"
+	rom ( serial "ULES-00225" )
 )
 
 game (
 	name "Peter Jackson's King Kong (USA) (v1.02)"
-	serial "ULUS-10072"
-	serial "ULUS-10072"
+	rom ( serial "ULUS-10072" )
 )
 
 game (
 	name "Petz - My Baby Hamster (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01266"
-	serial "ULES-01266"
+	rom ( serial "ULES-01266" )
 )
 
 game (
 	name "Petz - My Puppy Family (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01267"
-	serial "ULES-01267"
+	rom ( serial "ULES-01267" )
 )
 
 game (
 	name "Phantasy Star Portable (Europe)"
-	serial "ULES-01218"
-	serial "ULES-01218"
+	rom ( serial "ULES-01218" )
 )
 
 game (
 	name "Phantasy Star Portable (Japan) (Demo)"
-	serial "ULJM-91014"
-	serial "ULJM-91014"
+	rom ( serial "ULJM-91014" )
 )
 
 game (
 	name "Phantasy Star Portable (Japan) (v1.01)"
-	serial "ULJM-05309"
-	serial "ULJM-05309"
+	rom ( serial "ULJM-05309" )
 )
 
 game (
 	name "Phantasy Star Portable (USA)"
-	serial "ULUS-10410"
-	serial "ULUS-10410"
+	rom ( serial "ULUS-10410" )
 )
 
 game (
 	name "Phantasy Star Portable 2 (Europe)"
-	serial "ULES-01439"
-	serial "ULES-01439"
+	rom ( serial "ULES-01439" )
 )
 
 game (
 	name "Phantasy Star Portable 2 (Japan)"
-	serial "NPJH-50043"
-	serial "NPJH-50043"
+	rom ( serial "NPJH-50043" )
 )
 
 game (
 	name "Phantasy Star Portable 2 (USA)"
-	serial "ULUS-10529"
-	serial "ULUS-10529"
+	rom ( serial "ULUS-10529" )
 )
 
 game (
 	name "Phantasy Star Portable 2 Infinity (Japan) (v1.02)"
-	serial "NPJH-50332"
-	serial "NPJH-50332"
+	rom ( serial "NPJH-50332" )
 )
 
 game (
 	name "Phantom Brave - The Hermuda Triangle (USA)"
-	serial "ULUS-10572"
-	serial "ULUS-10572"
+	rom ( serial "ULUS-10572" )
 )
 
 game (
 	name "Phantom Kingdom Portable (Japan) (v1.03)"
-	serial "NPJH-50451"
-	serial "NPJH-50451"
+	rom ( serial "NPJH-50451" )
 )
 
 game (
 	name "Phase-D - Hakuei no Shou (Japan)"
-	serial "ULJM-05994"
-	serial "ULJM-05994"
+	rom ( serial "ULJM-05994" )
 )
 
 game (
 	name "Phase-D - Kokusei no Shou (Japan) (v1.01)"
-	serial "ULJM-06026"
-	serial "ULJM-06026"
+	rom ( serial "ULJM-06026" )
 )
 
 game (
 	name "Phase-D - Shuki no Shou (Japan)"
-	serial "ULJM-06031"
-	serial "ULJM-06031"
+	rom ( serial "ULJM-06031" )
 )
 
 game (
 	name "Phase-D - Souka no Shou (Japan) (v1.01)"
-	serial "ULJM-05983"
-	serial "ULJM-05983"
+	rom ( serial "ULJM-05983" )
 )
 
 game (
 	name "Phi Brain - Kizuna no Puzzle (Japan) (v1.01)"
-	serial "ULJM-06037"
-	serial "ULJM-06037"
+	rom ( serial "ULJM-06037" )
 )
 
 game (
 	name "PhotoKano (Japan) (v1.03)"
-	serial "ULJS-00378"
-	serial "ULJS-00378"
+	rom ( serial "ULJS-00378" )
 )
 
 game (
 	name "Pia Carrot e Youkoso!! 4 - Natsu no Kioku (Japan) (v1.01)"
-	serial "ULJM-06182"
-	serial "ULJM-06182"
+	rom ( serial "ULJM-06182" )
 )
 
 game (
 	name "Pia Carrot e Youkoso!! G.P. - Gakuen Princess - Portable (Japan)"
-	serial "ULJM-05464"
-	serial "ULJM-05464"
+	rom ( serial "ULJM-05464" )
 )
 
 game (
 	name "Pilot Academy (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00374"
-	serial "ULES-00374"
+	rom ( serial "ULES-00374" )
 )
 
 game (
 	name "Pimp My Ride (Europe)"
-	serial "ULES-00960"
-	serial "ULES-00960"
+	rom ( serial "ULES-00960" )
 )
 
 game (
 	name "Pimp My Ride (USA)"
-	serial "ULUS-10256"
-	serial "ULUS-10256"
+	rom ( serial "ULUS-10256" )
 )
 
 game (
 	name "Pinball (Japan) (v1.02)"
-	serial "ULJM-05025"
-	serial "ULJM-05025"
+	rom ( serial "ULJM-05025" )
 )
 
 game (
 	name "Pipe Mania (Asia) (En,Fr) (FW4.01)"
-	serial "ULUS-10359"
-	serial "ULUS-10359"
+	rom ( serial "ULUS-10359" )
 )
 
 game (
 	name "Pipe Mania (Europe) (En,De,Es,It,Nl) (v1.01)"
-	serial "ULES-01094"
-	serial "ULES-01094"
+	rom ( serial "ULES-01094" )
 )
 
 game (
 	name "Pipe Mania (USA) (En,Fr) (FW3.95)"
-	serial "ULUS-10359"
-	serial "ULUS-10359"
 )
 
 game (
 	name "Pirates of the Caribbean - At World's End (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00727"
-	serial "ULES-00727"
+	rom ( serial "ULES-00727" )
 )
 
 game (
 	name "Pirates of the Caribbean - At World's End (Russia)"
-	serial "ULES-00728"
-	serial "ULES-00728"
+	rom ( serial "ULES-00728" )
 )
 
 game (
 	name "Pirates of the Caribbean - At World's End (USA) (v1.01)"
-	serial "ULUS-10252"
-	serial "ULUS-10252"
+	rom ( serial "ULUS-10252" )
 )
 
 game (
 	name "Pirates of the Caribbean - Dead Man's Chest (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00366"
-	serial "ULES-00366"
+	rom ( serial "ULES-00366" )
 )
 
 game (
 	name "Pirates of the Caribbean - Dead Man's Chest (Japan) (v1.03)"
-	serial "ULJS-00071"
-	serial "ULJS-00071"
+	rom ( serial "ULJS-00071" )
 )
 
 game (
 	name "Pirates of the Caribbean - Dead Man's Chest (USA) (v1.01)"
-	serial "ULUS-10111"
-	serial "ULUS-10111"
+	rom ( serial "ULUS-10111" )
 )
 
 game (
 	name "Planetarian - Chiisana Hoshi no Yume (Japan) (v1.02)"
-	serial "ULJM-05383"
-	serial "ULJM-05383"
+	rom ( serial "ULJM-05383" )
 )
 
 game (
 	name "Planetarian - Chiisana Hoshi no Yume (Japan) (v2.00) (Touhoku-Chihou Taiheiyou-Oki Jishin Hisaichi Charity Ban)"
-	serial "ULJM-05383"
-	serial "ULJM-05383"
 )
 
 game (
 	name "Planetarium Creator Ohira Takayuki Kanshuu - Homestar Portable (Japan)"
-	serial "ULJM-05184"
-	serial "ULJM-05184"
+	rom ( serial "ULJM-05184" )
 )
 
 game (
 	name "Platypus (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01029"
-	serial "ULES-01029"
+	rom ( serial "ULES-01029" )
 )
 
 game (
 	name "Platypus (USA) (v1.01)"
-	serial "ULUS-10203"
-	serial "ULUS-10203"
+	rom ( serial "ULUS-10203" )
 )
 
 game (
 	name "Play Chapas - Football Edition (Spain) (v1.02)"
-	serial "UCES-01134"
-	serial "UCES-01134"
+	rom ( serial "UCES-01134" )
 )
 
 game (
 	name "Play English (Portugal)"
-	serial "ULES-01509"
-	serial "ULES-01509"
+	rom ( serial "ULES-01509" )
 )
 
 game (
 	name "Play English (Spain) (v1.03)"
-	serial "ULES-01440"
-	serial "ULES-01440"
+	rom ( serial "ULES-01440" )
 )
 
 game (
 	name "PlayStation Spot Senyou UMD Vol.5 (Japan) (Kiosk Demo)"
-	serial "UCJX-90021"
-	serial "UCJX-90021"
+	rom ( serial "UCJX-90021" )
 )
 
 game (
 	name "PlayStation Spot Senyou UMD Vol.6 (Japan) (Kiosk Demo)"
-	serial "UCJX-90023"
-	serial "UCJX-90023"
+	rom ( serial "UCJX-90023" )
 )
 
 game (
 	name "PlayStation Spot Senyou UMD Vol.7 (Japan) (Kiosk Demo)"
-	serial "UCJX-90024"
-	serial "UCJX-90024"
+	rom ( serial "UCJX-90024" )
 )
 
 game (
 	name "Playstation Network Collection, The - Power Pack (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "UCES-01160"
-	serial "UCES-01160"
+	rom ( serial "UCES-01160" )
 )
 
 game (
 	name "Playstation Network Collection, The - Puzzle Pack, The (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "UCES-01159"
-	serial "UCES-01159"
+	rom ( serial "UCES-01159" )
 )
 
 game (
 	name "Plus Plum 2 Again Portable (Japan) (v1.03)"
-	serial "ULJS-00066"
-	serial "ULJS-00066"
+	rom ( serial "ULJS-00066" )
 )
 
 game (
 	name "PoPoLoCrois (Europe) (v1.01)"
-	serial "ULES-00291"
-	serial "ULES-00291"
+	rom ( serial "ULES-00291" )
 )
 
 game (
 	name "PoPoLoCrois (USA)"
-	serial "ULUS-10018"
-	serial "ULUS-10018"
+	rom ( serial "ULUS-10018" )
 )
 
 game (
 	name "Pocket Pool (USA) (v1.01)"
-	serial "ULUS-10151"
-	serial "ULUS-10151"
+	rom ( serial "ULUS-10151" )
 )
 
 game (
 	name "Pocket Racers (Europe) (v1.02)"
-	serial "ULES-00275"
-	serial "ULES-00275"
+	rom ( serial "ULES-00275" )
 )
 
 game (
 	name "Pocket Racers (USA) (v1.01)"
-	serial "ULUS-10163"
-	serial "ULUS-10163"
+	rom ( serial "ULUS-10163" )
 )
 
 game (
 	name "Pop'n Music Portable (Japan) (v1.01)"
-	serial "ULJM-05605"
-	serial "ULJM-05605"
+	rom ( serial "ULJM-05605" )
 )
 
 game (
 	name "Pop'n Music Portable 2 (Japan)"
-	serial "ULJM-05959"
-	serial "ULJM-05959"
+	rom ( serial "ULJM-05959" )
 )
 
 game (
 	name "Portable Island - Tenohira no Resort (Japan) (v1.02)"
-	serial "ULJS-00031"
-	serial "ULJS-00031"
+	rom ( serial "ULJS-00031" )
 )
 
 game (
 	name "Power Pro Success Legends (Japan) (v1.01)"
-	serial "ULJM-05537"
-	serial "ULJM-05537"
+	rom ( serial "ULJM-05537" )
 )
 
 game (
 	name "Power Stone Collection (Europe)"
-	serial "ULES-00496"
-	serial "ULES-00496"
+	rom ( serial "ULES-00496" )
 )
 
 game (
 	name "Power Stone Collection (USA)"
-	serial "ULUS-10171"
-	serial "ULUS-10171"
+	rom ( serial "ULUS-10171" )
 )
 
 game (
 	name "Practical IQ - Test Your Intelligence (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00806"
-	serial "ULES-00806"
+	rom ( serial "ULES-00806" )
 )
 
 game (
 	name "Pri-Saga! Portable (Japan) (v1.01)"
-	serial "ULJM-05521"
-	serial "ULJM-05521"
+	rom ( serial "ULJM-05521" )
 )
 
 game (
 	name "Prince of Persia - Revelations (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00223"
-	serial "ULES-00223"
+	rom ( serial "ULES-00223" )
 )
 
 game (
 	name "Prince of Persia - Revelations (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10063"
-	serial "ULUS-10063"
+	rom ( serial "ULUS-10063" )
 )
 
 game (
 	name "Prince of Persia - Rival Swords (Europe) (En,Fr,De,Es,It) (v1.06)"
-	serial "ULES-00579"
-	serial "ULES-00579"
+	rom ( serial "ULES-00579" )
 )
 
 game (
 	name "Prince of Persia - Rival Swords (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10240"
-	serial "ULUS-10240"
+	rom ( serial "ULUS-10240" )
 )
 
 game (
 	name "Prince of Persia - The Forgotten Sands (Asia) (v1.01)"
-	serial "ULUS-10480"
-	serial "ULUS-10480"
+	rom ( serial "ULUS-10480" )
 )
 
 game (
 	name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-01409"
-	serial "ULES-01409"
+	rom ( serial "ULES-01409" )
 )
 
 game (
 	name "Prince of Persia - The Forgotten Sands (Russia)"
-	serial "ULES-01438"
-	serial "ULES-01438"
+	rom ( serial "ULES-01438" )
 )
 
 game (
 	name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10480"
-	serial "ULUS-10480"
 )
 
 game (
 	name "Princess Crown (Japan) (v1.03)"
-	serial "ULJM-05040"
-	serial "ULJM-05040"
+	rom ( serial "ULJM-05040" )
 )
 
 game (
 	name "Princess Evangile Portable (Japan) (v1.02)"
-	serial "ULJM-06036"
-	serial "ULJM-06036"
+	rom ( serial "ULJM-06036" )
 )
 
 game (
 	name "Princess Frontier Portable (Japan) (v1.02)"
-	serial "ULJM-05852"
-	serial "ULJM-05852"
+	rom ( serial "ULJM-05852" )
 )
 
 game (
 	name "Princess Maker 4 Portable (Japan) (v1.01)"
-	serial "ULJM-05169"
-	serial "ULJM-05169"
+	rom ( serial "ULJM-05169" )
 )
 
 game (
 	name "Princess Maker 5 Portable (Japan) (v1.02)"
-	serial "ULJM-05337"
-	serial "ULJM-05337"
+	rom ( serial "ULJM-05337" )
 )
 
 game (
 	name "Princess Maker 5 Portable (Korea) (v1.02)"
-	serial "ULKS-46187"
-	serial "ULKS-46187"
+	rom ( serial "ULKS-46187" )
 )
 
 game (
 	name "Princess Maker 5 Portable (Korea) (v2.00)"
-	serial "ULKS-46187"
-	serial "ULKS-46187"
 )
 
 game (
 	name "Prinny - Can I Really Be the Hero (Europe) (En,Fr)"
-	serial "ULES-01278"
-	serial "ULES-01278"
+	rom ( serial "ULES-01278" )
 )
 
 game (
 	name "Prinny - Can I Really Be the Hero (USA)"
-	serial "ULUS-10407"
-	serial "ULUS-10407"
+	rom ( serial "ULUS-10407" )
 )
 
 game (
 	name "Prinny 2 - Dawn of Operation Panties, Dood! (USA)"
-	serial "ULUS-10561"
-	serial "ULUS-10561"
+	rom ( serial "ULUS-10561" )
 )
 
 game (
 	name "Pro Atlas Travel Guide (Japan) (v1.01)"
-	serial "ULJS-00115"
-	serial "ULJS-00115"
+	rom ( serial "ULJS-00115" )
 )
 
 game (
 	name "Pro Cycling Season 2007 - Le Tour de France (Europe) (En,Fr,Es,It,Nl) (v1.06)"
-	serial "ULES-00849"
-	serial "ULES-00849"
+	rom ( serial "ULES-00849" )
 )
 
 game (
 	name "Pro Cycling Season 2008 - Le Tour de France (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
-	serial "ULES-01100"
-	serial "ULES-01100"
+	rom ( serial "ULES-01100" )
 )
 
 game (
 	name "Pro Cycling Season 2009 - Le Tour de France (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-01274"
-	serial "ULES-01274"
+	rom ( serial "ULES-01274" )
 )
 
 game (
 	name "Pro Cycling Season 2010 - Le Tour de France (Europe) (En,Fr,De,Es,It,Nl,Da) (v1.01)"
-	serial "ULES-01448"
-	serial "ULES-01448"
+	rom ( serial "ULES-01448" )
 )
 
 game (
 	name "Pro Evolution Soccer 2008 (Europe) (En,Fr,De,Es,It,Pt) (v1.02)"
-	serial "ULES-00880"
-	serial "ULES-00880"
+	rom ( serial "ULES-00880" )
 )
 
 game (
 	name "Pro Evolution Soccer 2008 (USA) (En,Fr,Es)"
-	serial "ULUS-10320"
-	serial "ULUS-10320"
+	rom ( serial "ULUS-10320" )
 )
 
 game (
 	name "Pro Evolution Soccer 2009 (Europe) (En,Fr,De,Es,It,Pt) (v1.01)"
-	serial "ULES-01176"
-	serial "ULES-01176"
+	rom ( serial "ULES-01176" )
 )
 
 game (
 	name "Pro Evolution Soccer 2009 (USA) (En,Fr,Es,Pt) (v1.01)"
-	serial "ULUS-10388"
-	serial "ULUS-10388"
+	rom ( serial "ULUS-10388" )
 )
 
 game (
 	name "Pro Evolution Soccer 2010 (Europe) (En,Nl,Sv,Ru) (v1.01)"
-	serial "ULES-01353"
-	serial "ULES-01353"
+	rom ( serial "ULES-01353" )
 )
 
 game (
 	name "Pro Evolution Soccer 2010 (Europe) (Fr,De,Es,It,Pt) (v1.01)"
-	serial "ULES-01354"
-	serial "ULES-01354"
+	rom ( serial "ULES-01354" )
 )
 
 game (
 	name "Pro Evolution Soccer 2010 (USA) (En,Fr,Es,Pt)"
-	serial "ULUS-10483"
-	serial "ULUS-10483"
+	rom ( serial "ULUS-10483" )
 )
 
 game (
 	name "Pro Evolution Soccer 2011 (Europe) (En,Nl,Sv,Ru) (v1.01)"
-	serial "ULES-01467"
-	serial "ULES-01467"
+	rom ( serial "ULES-01467" )
 )
 
 game (
 	name "Pro Evolution Soccer 2011 (Europe) (Es,Pt)"
-	serial "ULES-01470"
-	serial "ULES-01470"
+	rom ( serial "ULES-01470" )
 )
 
 game (
 	name "Pro Evolution Soccer 2011 (Europe) (Fr,De)"
-	serial "ULES-01468"
-	serial "ULES-01468"
+	rom ( serial "ULES-01468" )
 )
 
 game (
 	name "Pro Evolution Soccer 2011 (Europe) (It,El)"
-	serial "ULES-01469"
-	serial "ULES-01469"
+	rom ( serial "ULES-01469" )
 )
 
 game (
 	name "Pro Evolution Soccer 2011 (USA) (En,Es)"
-	serial "ULUS-10554"
-	serial "ULUS-10554"
+	rom ( serial "ULUS-10554" )
 )
 
 game (
 	name "Pro Evolution Soccer 2012 (Europe) (En,Nl,Sv,Ru,Tr) (v1.01)"
-	serial "ULES-01540"
-	serial "ULES-01540"
+	rom ( serial "ULES-01540" )
 )
 
 game (
 	name "Pro Evolution Soccer 2012 (Europe) (Es,It,Pt,El)"
-	serial "ULES-01542"
-	serial "ULES-01542"
+	rom ( serial "ULES-01542" )
 )
 
 game (
 	name "Pro Evolution Soccer 2012 (Europe) (Fr,De)"
-	serial "ULES-01541"
-	serial "ULES-01541"
+	rom ( serial "ULES-01541" )
 )
 
 game (
 	name "Pro Evolution Soccer 2012 (USA) (En,Fr,Es,Pt) (v1.01)"
-	serial "ULUS-10586"
-	serial "ULUS-10586"
+	rom ( serial "ULUS-10586" )
 )
 
 game (
 	name "Pro Evolution Soccer 2013 (Europe) (En,Nl,Sv,Ru,Tr)"
-	serial "ULES-01575"
-	serial "ULES-01575"
+	rom ( serial "ULES-01575" )
 )
 
 game (
 	name "Pro Evolution Soccer 2013 (Europe) (Es,Pt)"
-	serial "ULES-01580"
-	serial "ULES-01580"
+	rom ( serial "ULES-01580" )
 )
 
 game (
 	name "Pro Evolution Soccer 2013 (Europe) (Fr,De)"
-	serial "ULES-01576"
-	serial "ULES-01576"
+	rom ( serial "ULES-01576" )
 )
 
 game (
 	name "Pro Evolution Soccer 2013 (Europe) (It,El)"
-	serial "ULES-01577"
-	serial "ULES-01577"
+	rom ( serial "ULES-01577" )
 )
 
 game (
 	name "Pro Evolution Soccer 2013 (USA) (En,Fr,Es,Pt)"
-	serial "ULUS-10597"
-	serial "ULUS-10597"
+	rom ( serial "ULUS-10597" )
 )
 
 game (
 	name "Pro Evolution Soccer 2014 (Europe) (En,Nl,Sv,Ru,Tr) (v1.01)"
-	serial "ULES-01595"
-	serial "ULES-01595"
+	rom ( serial "ULES-01595" )
 )
 
 game (
 	name "Pro Evolution Soccer 2014 (Europe) (Es,Pt)"
-	serial "ULES-01598"
-	serial "ULES-01598"
+	rom ( serial "ULES-01598" )
 )
 
 game (
 	name "Pro Evolution Soccer 2014 (Europe) (Fr,De)"
-	serial "ULES-01596"
-	serial "ULES-01596"
+	rom ( serial "ULES-01596" )
 )
 
 game (
 	name "Pro Evolution Soccer 2014 (Europe) (It,El)"
-	serial "ULES-01597"
-	serial "ULES-01597"
+	rom ( serial "ULES-01597" )
 )
 
 game (
 	name "Pro Evolution Soccer 5 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00160"
-	serial "ULES-00160"
+	rom ( serial "ULES-00160" )
 )
 
 game (
 	name "Pro Evolution Soccer 6 (Europe) (En,Ja,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00476"
-	serial "ULES-00476"
+	rom ( serial "ULES-00476" )
 )
 
 game (
 	name "Pro Stroke Golf - World Tour 2007 (Europe)"
-	serial "ULES-00472"
-	serial "ULES-00472"
+	rom ( serial "ULES-00472" )
 )
 
 game (
 	name "Pro Stroke Golf - World Tour 2007 (USA) (v1.01)"
-	serial "ULUS-10209"
-	serial "ULUS-10209"
+	rom ( serial "ULUS-10209" )
 )
 
 game (
 	name "Pro Yakyuu Spirits 2010 (Japan) (v1.03)"
-	serial "NPJH-50234"
-	serial "NPJH-50234"
+	rom ( serial "NPJH-50234" )
 )
 
 game (
 	name "Pro Yakyuu Spirits 2011 (Japan) (v1.02)"
-	serial "NPJH-50336"
-	serial "NPJH-50336"
+	rom ( serial "NPJH-50336" )
 )
 
 game (
 	name "Pro Yakyuu Spirits 2012 (Japan)"
-	serial "NPJH-50520"
-	serial "NPJH-50520"
+	rom ( serial "NPJH-50520" )
 )
 
 game (
 	name "Pro Yakyuu Spirits 2014 (Japan)"
-	serial "NPJH-50838"
-	serial "NPJH-50838"
+	rom ( serial "NPJH-50838" )
 )
 
 game (
 	name "Pro Yakyuu Spirits 2014 (Japan) (v2.00)"
-	serial "NPJH-50838"
-	serial "NPJH-50838"
 )
 
 game (
 	name "Project Cerberus (Japan) (v1.03)"
-	serial "ULJM-05636"
-	serial "ULJM-05636"
+	rom ( serial "ULJM-05636" )
 )
 
 game (
 	name "Pucelle, La - Ragnarok (Japan) (v1.01)"
-	serial "ULJS-00244"
-	serial "ULJS-00244"
+	rom ( serial "ULJS-00244" )
 )
 
 game (
 	name "Pump It Up - Exceed Portable (Korea) (En,Ko) (v1.02)"
-	serial "ULKS-46042"
-	serial "ULKS-46042"
+	rom ( serial "ULKS-46042" )
 )
 
 game (
 	name "Pump It Up - Zero Portable (Korea) (v1.04)"
-	serial "ULKS-46146"
-	serial "ULKS-46146"
+	rom ( serial "ULKS-46146" )
 )
 
 game (
 	name "Pursuit Force (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00019"
-	serial "UCES-00019"
+	rom ( serial "UCES-00019" )
 )
 
 game (
 	name "Pursuit Force (Europe) (En,Fr,De,Es,It) (Beta)"
-	serial "UCET-00007"
-	serial "UCET-00007"
+	rom ( serial "UCET-00007" )
 )
 
 game (
 	name "Pursuit Force (Europe) (En,Fr,De,Es,It) (Demo)"
-	serial "UCED-00150"
-	serial "UCED-00150"
+	rom ( serial "UCED-00150" )
 )
 
 game (
 	name "Pursuit Force (Korea)"
-	serial "UCKS-45016"
-	serial "UCKS-45016"
+	rom ( serial "UCKS-45016" )
 )
 
 game (
 	name "Pursuit Force (USA)"
-	serial "UCUS-98640"
-	serial "UCUS-98640"
+	rom ( serial "UCUS-98640" )
 )
 
 game (
 	name "Pursuit Force (USA) (Demo)"
-	serial "UCUS-98655"
-	serial "UCUS-98655"
+	rom ( serial "UCUS-98655" )
 )
 
 game (
 	name "Pursuit Force - Extreme Justice (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (v1.03)"
-	serial "UCES-00694"
-	serial "UCES-00694"
+	rom ( serial "UCES-00694" )
 )
 
 game (
 	name "Pursuit Force - Extreme Justice (Europe) (En,Pl,Ru,Cs,Hu)"
-	serial "UCES-00890"
-	serial "UCES-00890"
+	rom ( serial "UCES-00890" )
 )
 
 game (
 	name "Pursuit Force - Extreme Justice (USA) (Demo)"
-	serial "UCUS-98718"
-	serial "UCUS-98718"
+	rom ( serial "UCUS-98718" )
 )
 
 game (
 	name "Pursuit Force - Extreme Justice (USA) (En,Fr,Es)"
-	serial "UCUS-98703"
-	serial "UCUS-98703"
+	rom ( serial "UCUS-98703" )
 )
 
 game (
 	name "Puyo Pop Fever (Europe) (v1.01)"
-	serial "ULES-00294"
-	serial "ULES-00294"
+	rom ( serial "ULES-00294" )
 )
 
 game (
 	name "Puyo Puyo 7 (Japan) (v1.01)"
-	serial "NPJH-50075"
-	serial "NPJH-50075"
+	rom ( serial "NPJH-50075" )
 )
 
 game (
 	name "Puyo Puyo Fever 2 (Japan) (v1.01)"
-	serial "ULJM-05058"
-	serial "ULJM-05058"
+	rom ( serial "ULJM-05058" )
 )
 
 game (
 	name "Puyo Puyo! 15th Anniversary (Japan)"
-	serial "ULJM-05177"
-	serial "ULJM-05177"
+	rom ( serial "ULJM-05177" )
 )
 
 game (
 	name "Puyo Puyo!! 20th Anniversary (Japan)"
-	serial "NPJH-50492"
-	serial "NPJH-50492"
+	rom ( serial "NPJH-50492" )
 )
 
 game (
 	name "Puzzle - Bokura no 48 Jikan Sensou (Japan)"
-	serial "ULJM-05543"
-	serial "ULJM-05543"
+	rom ( serial "ULJM-05543" )
 )
 
 game (
 	name "Puzzle Bobble Pocket (Japan) (v1.01)"
-	serial "ULJM-05011"
-	serial "ULJM-05011"
+	rom ( serial "ULJM-05011" )
 )
 
 game (
 	name "Puzzle Challenge - Crosswords and More! (USA)"
-	serial "ULUS-10120"
-	serial "ULUS-10120"
+	rom ( serial "ULUS-10120" )
 )
 
 game (
 	name "Puzzle Chronicles (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01356"
-	serial "ULES-01356"
+	rom ( serial "ULES-01356" )
 )
 
 game (
 	name "Puzzle Chronicles (USA)"
-	serial "ULUS-10468"
-	serial "ULUS-10468"
+	rom ( serial "ULUS-10468" )
 )
 
 game (
 	name "Puzzle Quest - Challenge of the Warlords (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00909"
-	serial "ULES-00909"
+	rom ( serial "ULES-00909" )
 )
 
 game (
 	name "Puzzle Quest - Challenge of the Warlords (Europe) (v1.01)"
-	serial "ULES-00720"
-	serial "ULES-00720"
+	rom ( serial "ULES-00720" )
 )
 
 game (
 	name "Puzzle Quest - Challenge of the Warlords (USA)"
-	serial "ULUS-10225"
-	serial "ULUS-10225"
+	rom ( serial "ULUS-10225" )
 )
 
 game (
 	name "Puzzle Quest - Challenge of the Warlords (USA) (Demo)"
-	serial "ULUS-90001"
-	serial "ULUS-90001"
+	rom ( serial "ULUS-90001" )
 )
 
 game (
 	name "Puzzle Scape (USA) (v1.04)"
-	serial "ULUS-10190"
-	serial "ULUS-10190"
+	rom ( serial "ULUS-10190" )
 )
 
 game (
 	name "Puzzler Collection (Europe)"
-	serial "ULES-01066"
-	serial "ULES-01066"
+	rom ( serial "ULES-01066" )
 )
 
 game (
 	name "Puzzler Collection (Europe) (Fr,De,Es,It,Nl)"
-	serial "ULES-01175"
-	serial "ULES-01175"
+	rom ( serial "ULES-01175" )
 )
 
 game (
 	name "Qix++ (Japan) (v1.02)"
-	serial "NPJH-50199"
-	serial "NPJH-50199"
+	rom ( serial "NPJH-50199" )
 )
 
 game (
 	name "Queen's Blade - Spiral Chaos (Japan)"
-	serial "ULJS-00190"
-	serial "ULJS-00190"
+	rom ( serial "ULJS-00190" )
 )
 
 game (
 	name "Queen's Gate - Spiral Chaos (Japan) (v1.01)"
-	serial "ULJS-00377"
-	serial "ULJS-00377"
+	rom ( serial "ULJS-00377" )
 )
 
 game (
 	name "Quiz Kidou Senshi Gundam - Toisenshi DX (Japan) (v1.01)"
-	serial "ULJS-00074"
-	serial "ULJS-00074"
+	rom ( serial "ULJS-00074" )
 )
 
 game (
 	name "R-15 Portable (Japan) (v1.01)"
-	serial "ULJM-05960"
-	serial "ULJM-05960"
+	rom ( serial "ULJM-05960" )
 )
 
 game (
 	name "R-Type Tactics (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01121"
-	serial "ULES-01121"
+	rom ( serial "ULES-01121" )
 )
 
 game (
 	name "R-Type Tactics (Japan) (v1.02)"
-	serial "ULJS-00111"
-	serial "ULJS-00111"
+	rom ( serial "ULJS-00111" )
 )
 
 game (
 	name "R-Type Tactics (Korea)"
-	serial "UCKS-45065"
-	serial "UCKS-45065"
+	rom ( serial "UCKS-45065" )
 )
 
 game (
 	name "R-Type Tactics II - Operation Bitter Chocolate (Japan) (v1.05)"
-	serial "NPJH-50119"
-	serial "NPJH-50119"
+	rom ( serial "NPJH-50119" )
 )
 
 game (
 	name "R.U.R.U.R - Petit Prince (Japan) (v1.06)"
-	serial "ULJM-05532"
-	serial "ULJM-05532"
+	rom ( serial "ULJM-05532" )
 )
 
 game (
 	name "Race Driver 2006 (USA) (v1.01)"
-	serial "ULUS-10096"
-	serial "ULUS-10096"
+	rom ( serial "ULUS-10096" )
 )
 
 game (
 	name "Ragnarok Tactics (USA)"
-	serial "ULUS-10594"
-	serial "ULUS-10594"
+	rom ( serial "ULUS-10594" )
 )
 
 game (
 	name "Rain Wonder Trip (Japan) (En,Ja,Ko) (v1.03) (Genteiban)"
-	serial "ULJS-00072"
-	serial "ULJS-00072"
+	rom ( serial "ULJS-00072" )
 )
 
 game (
 	name "Rain Wonder Trip (Japan) (v1.03)"
-	serial "ULJS-00073"
-	serial "ULJS-00073"
+	rom ( serial "ULJS-00073" )
 )
 
 game (
 	name "Rain Wonder Trip (Korea) (v1.01)"
-	serial "ULKS-46091"
-	serial "ULKS-46091"
+	rom ( serial "ULKS-46091" )
 )
 
 game (
 	name "Rainbow Islands Evolution (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00594"
-	serial "ULES-00594"
+	rom ( serial "ULES-00594" )
 )
 
 game (
 	name "Rainbow Islands Evolution (USA) (En,Fr,Es)"
-	serial "ULUS-10205"
-	serial "ULUS-10205"
+	rom ( serial "ULUS-10205" )
 )
 
 game (
 	name "Rapala Pro Bass Fishing (USA) (v1.01)"
-	serial "ULUS-10532"
-	serial "ULUS-10532"
+	rom ( serial "ULUS-10532" )
 )
 
 game (
 	name "Rapala Trophies (USA)"
-	serial "ULUS-10137"
-	serial "ULUS-10137"
+	rom ( serial "ULUS-10137" )
 )
 
 game (
 	name "Ratatouille (Europe) (v2.00)"
-	serial "ULES-00741"
-	serial "ULES-00741"
+	rom ( serial "ULES-00741" )
 )
 
 game (
 	name "Ratatouille (France) (v1.01)"
-	serial "ULES-00734"
-	serial "ULES-00734"
+	rom ( serial "ULES-00734" )
 )
 
 game (
 	name "Ratatouille (Germany) (v1.01)"
-	serial "ULES-00736"
-	serial "ULES-00736"
+	rom ( serial "ULES-00736" )
 )
 
 game (
 	name "Ratatouille (Greece) (v1.01)"
-	serial "ULES-00743"
-	serial "ULES-00743"
+	rom ( serial "ULES-00743" )
 )
 
 game (
 	name "Ratatouille (Italy)"
-	serial "ULES-00744"
-	serial "ULES-00744"
+	rom ( serial "ULES-00744" )
 )
 
 game (
 	name "Ratatouille (Netherlands)"
-	serial "ULES-00735"
-	serial "ULES-00735"
+	rom ( serial "ULES-00735" )
 )
 
 game (
 	name "Ratatouille (Russia)"
-	serial "ULES-00748"
-	serial "ULES-00748"
+	rom ( serial "ULES-00748" )
 )
 
 game (
 	name "Ratatouille (Spain)"
-	serial "ULES-00737"
-	serial "ULES-00737"
+	rom ( serial "ULES-00737" )
 )
 
 game (
 	name "Ratatouille (Sweden)"
-	serial "ULES-00746"
-	serial "ULES-00746"
+	rom ( serial "ULES-00746" )
 )
 
 game (
 	name "Ratatouille (USA) (v1.02)"
-	serial "ULUS-10247"
-	serial "ULUS-10247"
+	rom ( serial "ULUS-10247" )
 )
 
 game (
 	name "Ratchet & Clank - Size Matters (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi)"
-	serial "UCES-00420"
-	serial "UCES-00420"
+	rom ( serial "UCES-00420" )
 )
 
 game (
 	name "Ratchet & Clank - Size Matters (Korea)"
-	serial "UCKS-45048"
-	serial "UCKS-45048"
+	rom ( serial "UCKS-45048" )
 )
 
 game (
 	name "Ratchet & Clank - Size Matters (USA) (Beta)"
-	serial "UCUS-98695"
-	serial "UCUS-98695"
+	rom ( serial "UCUS-98695" )
 )
 
 game (
 	name "Ratchet & Clank - Size Matters (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCUS-98633"
-	serial "UCUS-98633"
+	rom ( serial "UCUS-98633" )
 )
 
 game (
 	name "Ratchet & Clank - Size Matters (USA) (v0.10) (Demo)"
-	serial "UCUS-98684"
-	serial "UCUS-98684"
+	rom ( serial "UCUS-98684" )
 )
 
 game (
 	name "Real Madrid - The Game (Europe) (En,Fr,Es,It,Pt)"
-	serial "ULES-01219"
-	serial "ULES-01219"
+	rom ( serial "ULES-01219" )
 )
 
 game (
 	name "Real Rode Portable (Japan) (v1.01)"
-	serial "ULJM-05657"
-	serial "ULJM-05657"
+	rom ( serial "ULJM-05657" )
 )
 
 game (
 	name "Reel Fishing - The Great Outdoors (Europe) (v1.01)"
-	serial "ULES-00612"
-	serial "ULES-00612"
+	rom ( serial "ULES-00612" )
 )
 
 game (
 	name "Reel Fishing - The Great Outdoors (USA) (v1.01)"
-	serial "ULUS-10166"
-	serial "ULUS-10166"
+	rom ( serial "ULUS-10166" )
 )
 
 game (
 	name "Reishiki Kanjou Sentouki Ni (Japan) (v1.01)"
-	serial "ULJM-05296"
-	serial "ULJM-05296"
+	rom ( serial "ULJM-05296" )
 )
 
 game (
 	name "Remember11 - The Age of Infinity (Japan) (v1.01)"
-	serial "ULJM-05444"
-	serial "ULJM-05444"
+	rom ( serial "ULJM-05444" )
 )
 
 game (
 	name "Renai Banchou 2 - Midnight Lesson!!! (Japan) (v1.03)"
-	serial "ULJM-06001"
-	serial "ULJM-06001"
+	rom ( serial "ULJM-06001" )
 )
 
 game (
 	name "Rengoku - The Tower of Purgatory (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00123"
-	serial "ULES-00123"
+	rom ( serial "ULES-00123" )
 )
 
 game (
 	name "Rengoku - The Tower of Purgatory (Japan) (v1.01)"
-	serial "ULJM-05006"
-	serial "ULJM-05006"
+	rom ( serial "ULJM-05006" )
 )
 
 game (
 	name "Rengoku - The Tower of Purgatory (USA) (v1.01)"
-	serial "ULUS-10013"
-	serial "ULUS-10013"
+	rom ( serial "ULUS-10013" )
 )
 
 game (
 	name "Rengoku II - The Stairway to H.E.A.V.E.N. (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00437"
-	serial "ULES-00437"
+	rom ( serial "ULES-00437" )
 )
 
 game (
 	name "Rengoku II - The Stairway to H.E.A.V.E.N. (Japan) (v1.02)"
-	serial "ULJM-05055"
-	serial "ULJM-05055"
+	rom ( serial "ULJM-05055" )
 )
 
 game (
 	name "Rengoku II - The Stairway to H.E.A.V.E.N. (USA) (v1.02)"
-	serial "ULUS-10127"
-	serial "ULUS-10127"
+	rom ( serial "ULUS-10127" )
 )
 
 game (
 	name "Resistance - Retribution (Asia) (En,Ja,Fr,Es)"
-	serial "UCAS-40233"
-	serial "UCAS-40233"
+	rom ( serial "UCAS-40233" )
 )
 
 game (
 	name "Resistance - Retribution (Europe) (En,Ja,Fr,De,Es,It)"
-	serial "UCES-01184"
-	serial "UCES-01184"
+	rom ( serial "UCES-01184" )
 )
 
 game (
 	name "Resistance - Retribution (USA) (En,Ja,Fr,Es)"
-	serial "UCUS-98668"
-	serial "UCUS-98668"
+	rom ( serial "UCUS-98668" )
 )
 
 game (
 	name "Rezel Cross (Asia)"
-	serial "UCAS-40140"
-	serial "UCAS-40140"
+	rom ( serial "UCAS-40140" )
 )
 
 game (
 	name "Rezel Cross (Japan)"
-	serial "UCJS-10023"
-	serial "UCJS-10023"
+	rom ( serial "UCJS-10023" )
 )
 
 game (
 	name "Ridge Racer (Asia) (En,Fr,De,Es,It)"
-	serial "UCAS-40015"
-	serial "UCAS-40015"
+	rom ( serial "UCAS-40015" )
 )
 
 game (
 	name "Ridge Racer (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00002"
-	serial "UCES-00002"
+	rom ( serial "UCES-00002" )
 )
 
 game (
 	name "Ridge Racer (Korea)"
-	serial "UCKS-45002"
-	serial "UCKS-45002"
+	rom ( serial "UCKS-45002" )
 )
 
 game (
 	name "Ridge Racer (USA)"
-	serial "ULUS-10001"
-	serial "ULUS-10001"
+	rom ( serial "ULUS-10001" )
 )
 
 game (
 	name "Ridge Racer 2 (Asia) (En,Fr,De,Es,It)"
-	serial "UCAS-40119"
-	serial "UCAS-40119"
+	rom ( serial "UCAS-40119" )
 )
 
 game (
 	name "Ridge Racer 2 (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00422"
-	serial "UCES-00422"
+	rom ( serial "UCES-00422" )
 )
 
 game (
 	name "Riviera - The Promised Land (Europe) (En,Fr,It)"
-	serial "ULES-00818"
-	serial "ULES-00818"
+	rom ( serial "ULES-00818" )
 )
 
 game (
 	name "Riviera - The Promised Land (USA)"
-	serial "ULUS-10286"
-	serial "ULUS-10286"
+	rom ( serial "ULUS-10286" )
 )
 
 game (
 	name "Ro-Kyu-Bu! (Japan)"
-	serial "NPJH-50508"
-	serial "NPJH-50508"
+	rom ( serial "NPJH-50508" )
 )
 
 game (
 	name "Rock Band Unplugged (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01243"
-	serial "ULES-01243"
+	rom ( serial "ULES-01243" )
 )
 
 game (
 	name "Rock Band Unplugged (USA)"
-	serial "ULUS-10418"
-	serial "ULUS-10418"
+	rom ( serial "ULUS-10418" )
 )
 
 game (
 	name "Rockman Dash - Hagane no Boukenshin (Japan) (v1.01)"
-	serial "ULJM-05030"
-	serial "ULJM-05030"
+	rom ( serial "ULJM-05030" )
 )
 
 game (
 	name "Rockman Dash 2 - Episode 2 Ooinaru Isan (Japan) (v1.04)"
-	serial "ULJM-05037"
-	serial "ULJM-05037"
+	rom ( serial "ULJM-05037" )
 )
 
 game (
 	name "Rocky Balboa (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00670"
-	serial "ULES-00670"
+	rom ( serial "ULES-00670" )
 )
 
 game (
 	name "Rocky Balboa (USA) (v1.02)"
-	serial "ULUS-10233"
-	serial "ULUS-10233"
+	rom ( serial "ULUS-10233" )
 )
 
 game (
 	name "Routes Portable (Japan) (v1.03)"
-	serial "ULJS-00095"
-	serial "ULJS-00095"
+	rom ( serial "ULJS-00095" )
 )
 
 game (
 	name "Routes Portable (Japan) (v1.03) (Kinou Genteiban)"
-	serial "ULJS-00094"
-	serial "ULJS-00094"
+	rom ( serial "ULJS-00094" )
 )
 
 game (
 	name "Rugby League Challenge (Europe)"
-	serial "ULES-01283"
-	serial "ULES-01283"
+	rom ( serial "ULES-01283" )
 )
 
 game (
 	name "Rupupu Cube - Lup Salad Portable - Matatabi (Japan) (v1.01)"
-	serial "NPJH-50103"
-	serial "NPJH-50103"
+	rom ( serial "NPJH-50103" )
 )
 
 game (
 	name "Rurouni Kenshin - Meiji Kenkaku Romantan Saisen (Japan) (v1.01)"
-	serial "ULJS-00360"
-	serial "ULJS-00360"
+	rom ( serial "ULJS-00360" )
 )
 
 game (
 	name "Ryu-koku (Japan) (v1.01)"
-	serial "ULJM-05958"
-	serial "ULJM-05958"
+	rom ( serial "ULJM-05958" )
 )
 
 game (
 	name "S.Y.K - Renshouden Portable (Japan) (v1.01)"
-	serial "ULJM-05867"
-	serial "ULJM-05867"
+	rom ( serial "ULJM-05867" )
 )
 
 game (
 	name "S.Y.K - Shinsetsu Saiyuuki Portable (Japan) (v1.03)"
-	serial "ULJM-05697"
-	serial "ULJM-05697"
+	rom ( serial "ULJM-05697" )
 )
 
 game (
 	name "SBK 07 - Superbike World Championship (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00800"
-	serial "ULES-00800"
+	rom ( serial "ULES-00800" )
 )
 
 game (
 	name "SBK 08 - Superbike World Championship (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01063"
-	serial "ULES-01063"
+	rom ( serial "ULES-01063" )
 )
 
 game (
 	name "SBK 09 - Superbike World Championship (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-01247"
-	serial "ULES-01247"
+	rom ( serial "ULES-01247" )
 )
 
 game (
 	name "SD Gundam - G Generation Over World (Japan) (v1.01)"
-	serial "NPJH-50681"
-	serial "NPJH-50681"
+	rom ( serial "NPJH-50681" )
 )
 
 game (
 	name "SD Gundam - G Generation Portable (Japan) (v1.02)"
-	serial "ULJS-00065"
-	serial "ULJS-00065"
+	rom ( serial "ULJS-00065" )
 )
 
 game (
 	name "SD Gundam - G Generation World (Japan) (v1.02)"
-	serial "ULJS-00363"
-	serial "ULJS-00363"
+	rom ( serial "ULJS-00363" )
 )
 
 game (
 	name "SNK Arcade Classics 0 (Japan) (v1.01)"
-	serial "NPJH-50430"
-	serial "NPJH-50430"
+	rom ( serial "NPJH-50430" )
 )
 
 game (
 	name "SNK Arcade Classics Vol. 1 (Europe) (v1.01)"
-	serial "ULES-01105"
-	serial "ULES-01105"
+	rom ( serial "ULES-01105" )
 )
 
 game (
 	name "SNK Arcade Classics Vol. 1 (Japan)"
-	serial "ULJS-00193"
-	serial "ULJS-00193"
+	rom ( serial "ULJS-00193" )
 )
 
 game (
 	name "SNK Arcade Classics Vol. 1 (USA) (v1.02)"
-	serial "ULUS-10338"
-	serial "ULUS-10338"
+	rom ( serial "ULUS-10338" )
 )
 
 game (
 	name "SOCOM - Fireteam Bravo 3 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl,Ru)"
-	serial "UCES-01242"
-	serial "UCES-01242"
+	rom ( serial "UCES-01242" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00038"
-	serial "UCES-00038"
+	rom ( serial "UCES-00038" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo (Korea)"
-	serial "UCKS-45021"
-	serial "UCKS-45021"
+	rom ( serial "UCKS-45021" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo (USA) (Beta)"
-	serial "UCUS-98637"
-	serial "UCUS-98637"
+	rom ( serial "UCUS-98637" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo (USA) (Demo)"
-	serial "UCUS-98638"
-	serial "UCUS-98638"
+	rom ( serial "UCUS-98638" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo (USA) (v1.01)"
-	serial "UCUS-98615"
-	serial "UCUS-98615"
+	rom ( serial "UCUS-98615" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00543"
-	serial "UCES-00543"
+	rom ( serial "UCES-00543" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo 2 (USA)"
-	serial "UCUS-98645"
-	serial "UCUS-98645"
+	rom ( serial "UCUS-98645" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Fireteam Bravo 2 (USA) (Demo)"
-	serial "UCUS-98691"
-	serial "UCUS-98691"
+	rom ( serial "UCUS-98691" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Tactical Strike (Europe) (En,Fr,De,Es,It,Nl,Ko)"
-	serial "UCES-00855"
-	serial "UCES-00855"
+	rom ( serial "UCES-00855" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Tactical Strike (USA)"
-	serial "UCUS-98649"
-	serial "UCUS-98649"
+	rom ( serial "UCUS-98649" )
 )
 
 game (
 	name "SOCOM - U.S. Navy SEALs - Tactical Strike (USA) (Demo)"
-	serial "UCUS-98714"
-	serial "UCUS-98714"
+	rom ( serial "UCUS-98714" )
 )
 
 game (
 	name "SSX - On Tour (Europe) (En,Fr,De)"
-	serial "ULES-00192"
-	serial "ULES-00192"
+	rom ( serial "ULES-00192" )
 )
 
 game (
 	name "SSX - On Tour (Korea) (v1.01)"
-	serial "ULKS-46038"
-	serial "ULKS-46038"
+	rom ( serial "ULKS-46038" )
 )
 
 game (
 	name "SSX - On Tour (USA) (En,Fr,De)"
-	serial "ULUS-10042"
-	serial "ULUS-10042"
+	rom ( serial "ULUS-10042" )
 )
 
 game (
 	name "SWAT - Target Liberty (Europe)"
-	serial "ULES-00927"
-	serial "ULES-00927"
+	rom ( serial "ULES-00927" )
 )
 
 game (
 	name "SWAT - Target Liberty (USA) (v1.01)"
-	serial "ULUS-10314"
-	serial "ULUS-10314"
+	rom ( serial "ULUS-10314" )
 )
 
 game (
 	name "Saigo no Yakusoku no Monogatari (Japan) (v1.01)"
-	serial "NPJH-50416"
-	serial "NPJH-50416"
+	rom ( serial "NPJH-50416" )
 )
 
 game (
 	name "Saihate no Ima Portable (Japan) (v1.01)"
-	serial "ULJM-06132"
-	serial "ULJM-06132"
+	rom ( serial "ULJM-06132" )
 )
 
 game (
 	name "Saikyou Shogi Bonanza (Japan) (v1.01)"
-	serial "ULJM-05406"
-	serial "ULJM-05406"
+	rom ( serial "ULJM-05406" )
 )
 
 game (
 	name "Saikyou Toudai Shogi Deluxe (Japan) (v1.01)"
-	serial "ULJM-05506"
-	serial "ULJM-05506"
+	rom ( serial "ULJM-05506" )
 )
 
 game (
 	name "Saikyou Toudai Shogi Portable (Japan) (v1.02)"
-	serial "ULJM-05070"
-	serial "ULJM-05070"
+	rom ( serial "ULJM-05070" )
 )
 
 game (
 	name "Saints Row - Undercover (USA) (Proto)"
-	serial "ULUS-12345"
-	serial "ULUS-12345"
+	rom ( serial "ULUS-12345" )
 )
 
 game (
 	name "Saka Agari Hurricane Portable (Japan) (v1.01)"
-	serial "ULJM-05891"
-	serial "ULJM-05891"
+	rom ( serial "ULJM-05891" )
 )
 
 game (
 	name "Saki Portable (Japan) (v1.01)"
-	serial "ULJM-05556"
-	serial "ULJM-05556"
+	rom ( serial "ULJM-05556" )
 )
 
 game (
 	name "Sakura Sakura - Haru Urara (Japan) (v1.02)"
-	serial "ULJM-05758"
-	serial "ULJM-05758"
+	rom ( serial "ULJM-05758" )
 )
 
 game (
 	name "Sakura Taisen 1 & 2 (Japan) (v1.01)"
-	serial "ULJM-05109"
-	serial "ULJM-05109"
+	rom ( serial "ULJM-05109" )
 )
 
 game (
 	name "Salamander Portable (Japan) (v1.01)"
-	serial "ULJM-05219"
-	serial "ULJM-05219"
+	rom ( serial "ULJM-05219" )
 )
 
 game (
 	name "Sampler Disc for PSP Vol. 1 (Europe) (Demo)"
-	serial "UCJB-98302"
-	serial "UCJB-98302"
+	rom ( serial "UCJB-98302" )
 )
 
 game (
 	name "Sampler Disc for PSP Vol. 1 (USA)"
-	serial "UCJB-98301"
-	serial "UCJB-98301"
+	rom ( serial "UCJB-98301" )
 )
 
 game (
 	name "Samurai Shodown Anthology (Europe) (v1.01)"
-	serial "ULES-01211"
-	serial "ULES-01211"
+	rom ( serial "ULES-01211" )
 )
 
 game (
 	name "Samurai Shodown Anthology (USA)"
-	serial "ULUS-10401"
-	serial "ULUS-10401"
+	rom ( serial "ULUS-10401" )
 )
 
 game (
 	name "Samurai Shodown Anthology (USA, Asia) (v1.02)"
-	serial "ULUS-10401"
-	serial "ULUS-10401"
 )
 
 game (
 	name "Samurai Warriors - State of War (Europe)"
-	serial "ULES-00297"
-	serial "ULES-00297"
+	rom ( serial "ULES-00297" )
 )
 
 game (
 	name "Samurai Warriors - State of War (France)"
-	serial "ULES-00298"
-	serial "ULES-00298"
+	rom ( serial "ULES-00298" )
 )
 
 game (
 	name "Samurai Warriors - State of War (Germany)"
-	serial "ULES-00299"
-	serial "ULES-00299"
+	rom ( serial "ULES-00299" )
 )
 
 game (
 	name "Samurai Warriors - State of War (USA) (v1.01)"
-	serial "ULUS-10089"
-	serial "ULUS-10089"
+	rom ( serial "ULUS-10089" )
 )
 
 game (
 	name "Samuraidou 2 Portable (Japan) (v1.03)"
-	serial "ULJS-00217"
-	serial "ULJS-00217"
+	rom ( serial "ULJS-00217" )
 )
 
 game (
 	name "Samuraidou Portable (Japan) (v1.02)"
-	serial "ULJS-00155"
-	serial "ULJS-00155"
+	rom ( serial "ULJS-00155" )
 )
 
 game (
 	name "Sangoku Hime - Sangoku Ranse - Haten no Saihai (Japan)"
-	serial "ULJS-00435"
-	serial "ULJS-00435"
+	rom ( serial "ULJS-00435" )
 )
 
 game (
 	name "Sangoku Koi Senki - Otome no Heihou! (Japan) (v1.03)"
-	serial "ULJM-06123"
-	serial "ULJM-06123"
-)
-
-game (
-	name "Sangoku Koi Senki - Otome no Heihou! (Japan) (v1.03)"
-	serial "ULJM-06123"
-	serial "ULJM-06123"
+	rom ( serial "ULJM-06123" )
 )
 
 game (
 	name "Sangokushi IX with Power-Up Kit (Japan) (v1.01)"
-	serial "ULJM-05842"
-	serial "ULJM-05842"
+	rom ( serial "ULJM-05842" )
 )
 
 game (
 	name "Sangokushi V (Asia) (v1.02)"
-	serial "ULAS-42014"
-	serial "ULAS-42014"
+	rom ( serial "ULAS-42014" )
 )
 
 game (
 	name "Sangokushi V (Japan) (v1.03)"
-	serial "ULJM-05016"
-	serial "ULJM-05016"
+	rom ( serial "ULJM-05016" )
 )
 
 game (
 	name "Sangokushi VI (Asia) (v1.01)"
-	serial "ULAS-42032"
-	serial "ULAS-42032"
+	rom ( serial "ULAS-42032" )
 )
 
 game (
 	name "Sangokushi VI (Japan) (v1.02)"
-	serial "ULJM-05038"
-	serial "ULJM-05038"
+	rom ( serial "ULJM-05038" )
 )
 
 game (
 	name "Sangokushi VII (Japan) (v1.03)"
-	serial "ULJM-05083"
-	serial "ULJM-05083"
+	rom ( serial "ULJM-05083" )
 )
 
 game (
 	name "Sangokushi VIII (Japan) (v1.01)"
-	serial "ULJM-05240"
-	serial "ULJM-05240"
+	rom ( serial "ULJM-05240" )
 )
 
 game (
 	name "SaruGetYou - Piposaru Racer (Japan)"
-	serial "UCJS-10032"
-	serial "UCJS-10032"
+	rom ( serial "UCJS-10032" )
 )
 
 game (
 	name "Scared Rider Xechs I+FD Portable (Japan)"
-	serial "ULJM-06006"
-	serial "ULJM-06006"
-)
-
-game (
-	name "Scared Rider Xechs I+FD Portable (Japan)"
-	serial "ULJM-06006"
-	serial "ULJM-06006"
+	rom ( serial "ULJM-06006" )
 )
 
 game (
 	name "Scarface - Money. Power. Respect. (Europe) (En,Fr,Es,It) (v1.02)"
-	serial "ULES-00546"
-	serial "ULES-00546"
+	rom ( serial "ULES-00546" )
 )
 
 game (
 	name "Scarface - Money. Power. Respect. (Europe) (v1.02)"
-	serial "ULES-00545"
-	serial "ULES-00545"
+	rom ( serial "ULES-00545" )
 )
 
 game (
 	name "Scarface - Money. Power. Respect. (Germany) (v1.02)"
-	serial "ULES-00547"
-	serial "ULES-00547"
+	rom ( serial "ULES-00547" )
 )
 
 game (
 	name "Scarface - Money. Power. Respect. (USA) (v1.01)"
-	serial "ULUS-10148"
-	serial "ULUS-10148"
+	rom ( serial "ULUS-10148" )
 )
 
 game (
 	name "School Rumble - Neesan Jiken Desu! (Japan)"
-	serial "ULJS-00019"
-	serial "ULJS-00019"
+	rom ( serial "ULJS-00019" )
 )
 
 game (
 	name "School Wars (Japan)"
-	serial "ULJM-06191"
-	serial "ULJM-06191"
+	rom ( serial "ULJM-06191" )
 )
 
 game (
 	name "Scooby-Doo! - Who's Watching Who (Australia)"
-	serial "ULES-00571"
-	serial "ULES-00571"
+	rom ( serial "ULES-00571" )
 )
 
 game (
 	name "Scooby-Doo! - Who's Watching Who (Europe)"
-	serial "ULES-00572"
-	serial "ULES-00572"
+	rom ( serial "ULES-00572" )
 )
 
 game (
 	name "Scooby-Doo! - Who's Watching Who (Europe) (Es,It)"
-	serial "ULES-00573"
-	serial "ULES-00573"
+	rom ( serial "ULES-00573" )
 )
 
 game (
 	name "Scooby-Doo! - Who's Watching Who (USA) (v1.01)"
-	serial "ULUS-10168"
-	serial "ULUS-10168"
+	rom ( serial "ULUS-10168" )
 )
 
 game (
 	name "Scrabble - Crossword Game (USA)"
-	serial "ULUS-10412"
-	serial "ULUS-10412"
+	rom ( serial "ULUS-10412" )
 )
 
 game (
 	name "Second Novel - Kanojo no Natsu, 15fun no Kioku (Japan) (v1.01)"
-	serial "NPJH-50279"
-	serial "NPJH-50279"
+	rom ( serial "NPJH-50279" )
 )
 
 game (
 	name "Secret Agent Clank (Asia) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCAS-40218"
-	serial "UCAS-40218"
+	rom ( serial "UCAS-40218" )
 )
 
 game (
 	name "Secret Agent Clank (Europe) (En,Fr,De,Es,It) (Beta) [b]"
-	serial "UCET-01101"
-	serial "UCET-01101"
+	rom ( serial "UCET-01101" )
 )
 
 game (
 	name "Secret Agent Clank (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,Pl) (v1.01)"
-	serial "UCES-00942"
-	serial "UCES-00942"
+	rom ( serial "UCES-00942" )
 )
 
 game (
 	name "Secret Agent Clank (Korea)"
-	serial "UCKS-45096"
-	serial "UCKS-45096"
+	rom ( serial "UCKS-45096" )
 )
 
 game (
 	name "Secret Agent Clank (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCUS-98697"
-	serial "UCUS-98697"
+	rom ( serial "UCUS-98697" )
 )
 
 game (
 	name "Secret Game - Killer Queen Portable (Japan) (v1.01)"
-	serial "ULJM-05675"
-	serial "ULJM-05675"
+	rom ( serial "ULJM-05675" )
 )
 
 game (
 	name "Secret Saturdays, The - Beasts of the 5th Sun (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01363"
-	serial "ULES-01363"
+	rom ( serial "ULES-01363" )
 )
 
 game (
 	name "Secret Saturdays, The - Beasts of the 5th Sun (USA)"
-	serial "ULUS-10443"
-	serial "ULUS-10443"
+	rom ( serial "ULUS-10443" )
 )
 
 game (
 	name "Secret of Evangelion Portable (Japan) (v1.01)"
-	serial "ULJM-05251"
-	serial "ULJM-05251"
+	rom ( serial "ULJM-05251" )
 )
 
 game (
 	name "Sega Mega Drive Collection (Europe) (v1.01)"
-	serial "ULES-00556"
-	serial "ULES-00556"
+	rom ( serial "ULES-00556" )
 )
 
 game (
 	name "Sega Rally (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00910"
-	serial "ULES-00910"
+	rom ( serial "ULES-00910" )
 )
 
 game (
 	name "Sega Rally (Europe) (En,Fr,De,Es,It) (v2)"
-	serial "ULES-00910"
-	serial "ULES-00910"
 )
 
 game (
 	name "Sega Rally (Russia)"
-	serial "ULES-00911"
-	serial "ULES-00911"
+	rom ( serial "ULES-00911" )
 )
 
 game (
 	name "Seinaru Kana - Orichalcum no Na no Motoni (Japan) (v1.03)"
-	serial "ULJM-06035"
-	serial "ULJM-06035"
+	rom ( serial "ULJM-06035" )
 )
 
 game (
 	name "Sekai de Ichiban Dame na Koi - Full House (Japan)"
-	serial "ULJM-05878"
-	serial "ULJM-05878"
+	rom ( serial "ULJM-05878" )
 )
 
 game (
 	name "Sekai wa Atashi de Mawatteru - Hikari to Yami no Princess (Japan)"
-	serial "ULJM-05468"
-	serial "ULJM-05468"
+	rom ( serial "ULJM-05468" )
 )
 
 game (
 	name "Sen Goku Hime - Senran ni Mau Otometachi (Japan) (v1.02)"
-	serial "ULJM-05540"
-	serial "ULJM-05540"
+	rom ( serial "ULJM-05540" )
 )
 
 game (
 	name "Sen Goku Hime 2 Ran - Hyakka, Senran Tatsukaze no Gotoku (Japan) (v1.03)"
-	serial "ULJM-05774"
-	serial "ULJM-05774"
+	rom ( serial "ULJM-05774" )
 )
 
 game (
 	name "Sen Goku Hime 3 - Tenka o Kirisaku Hikari to Kage (Japan) (v1.02)"
-	serial "ULJM-06004"
-	serial "ULJM-06004"
+	rom ( serial "ULJM-06004" )
 )
 
 game (
 	name "Sengoku Basara - Battle Heroes (Japan) (v1.01)"
-	serial "ULJM-05436"
-	serial "ULJM-05436"
+	rom ( serial "ULJM-05436" )
 )
 
 game (
 	name "Sengoku Basara - Chronicle Heroes (Japan) (v1.01)"
-	serial "NPJH-50460"
-	serial "NPJH-50460"
+	rom ( serial "NPJH-50460" )
 )
 
 game (
 	name "Sengoku Cannon - Sengoku Ace Episode III (Japan) (v1.03)"
-	serial "ULJM-05021"
-	serial "ULJM-05021"
+	rom ( serial "ULJM-05021" )
 )
 
 game (
 	name "Sengoku Efuda Yuugi - Hototogisu Ran (Japan)"
-	serial "ULJS-00159"
-	serial "ULJS-00159"
+	rom ( serial "ULJS-00159" )
 )
 
 game (
 	name "Sengoku Efuda Yuugi - Hototogisu Tairan (Japan) (v1.02)"
-	serial "NPJH-50321"
-	serial "NPJH-50321"
+	rom ( serial "NPJH-50321" )
 )
 
 game (
 	name "Sengoku Musou 3Z Special (Japan) (v1.01)"
-	serial "ULJM-06024"
-	serial "ULJM-06024"
+	rom ( serial "ULJM-06024" )
 )
 
 game (
 	name "Sengoku Tenka Touitsu (Japan) (v1.01)"
-	serial "ULJS-00187"
-	serial "ULJS-00187"
+	rom ( serial "ULJS-00187" )
 )
 
 game (
 	name "Senjou no Valkyria 3 (Japan) (v1.01)"
-	serial "ULJM-05781"
-	serial "ULJM-05781"
+	rom ( serial "ULJM-05781" )
 )
 
 game (
 	name "Senjou no Valkyria 3 - Extra Edition (Japan)"
-	serial "ULJM-05957"
-	serial "ULJM-05957"
+	rom ( serial "ULJM-05957" )
 )
 
 game (
 	name "Senritsu no Stratus (Japan) (v1.01)"
-	serial "NPJH-50467"
-	serial "NPJH-50467"
+	rom ( serial "NPJH-50467" )
 )
 
 game (
 	name "Shadow of Destiny (USA)"
-	serial "ULUS-10459"
-	serial "ULUS-10459"
+	rom ( serial "ULUS-10459" )
 )
 
 game (
 	name "Shanghai (Japan) (v1.01)"
-	serial "ULJM-05057"
-	serial "ULJM-05057"
+	rom ( serial "ULJM-05057" )
 )
 
 game (
 	name "Sharin no Kuni, Himawari no Shoujo (Japan)"
-	serial "ULJM-06022"
-	serial "ULJM-06022"
+	rom ( serial "ULJM-06022" )
 )
 
 game (
 	name "Shaun White Snowboarding (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01185"
-	serial "ULES-01185"
+	rom ( serial "ULES-01185" )
 )
 
 game (
 	name "Shaun White Snowboarding (Japan) (v1.01)"
-	serial "ULJM-05412"
-	serial "ULJM-05412"
+	rom ( serial "ULJM-05412" )
 )
 
 game (
 	name "Shaun White Snowboarding (USA) (v1.01)"
-	serial "ULUS-10399"
-	serial "ULUS-10399"
+	rom ( serial "ULUS-10399" )
 )
 
 game (
 	name "Shepherd's Crossing (USA)"
-	serial "ULUS-10499"
-	serial "ULUS-10499"
+	rom ( serial "ULUS-10499" )
 )
 
 game (
 	name "Shichida Shiki Training - Unou Tanren Portable (Japan)"
-	serial "ULJM-05157"
-	serial "ULJM-05157"
+	rom ( serial "ULJM-05157" )
 )
 
 game (
 	name "Shin Hisui no Shizuku - Hiiro no Kakera 2 Portable (Japan) (v1.01)"
-	serial "ULJM-05725"
-	serial "ULJM-05725"
+	rom ( serial "ULJM-05725" )
 )
 
 game (
 	name "Shin Ken to Mahou to Gakuen Mono. - Toki no Gakuen (Japan) (v1.01)"
-	serial "ULJM-06117"
-	serial "ULJM-06117"
+	rom ( serial "ULJM-06117" )
 )
 
 game (
 	name "Shin Koihime Musou Ryouran Gihen (Japan)"
-	serial "ULJM-05705"
-	serial "ULJM-05705"
-)
-
-game (
-	name "Shin Koihime Musou Ryouran Gihen (Japan)"
-	serial "ULJM-05705"
-	serial "ULJM-05705"
+	rom ( serial "ULJM-05705" )
 )
 
 game (
 	name "Shin Koihime Musou Ryouran Gohen (Japan)"
-	serial "ULJM-05699"
-	serial "ULJM-05699"
-)
-
-game (
-	name "Shin Koihime Musou Ryouran Gohen (Japan)"
-	serial "ULJM-05699"
-	serial "ULJM-05699"
+	rom ( serial "ULJM-05699" )
 )
 
 game (
 	name "Shin Koihime Musou Ryouran Shokuhen (Japan)"
-	serial "ULJM-05694"
-	serial "ULJM-05694"
-)
-
-game (
-	name "Shin Koihime Musou Ryouran Shokuhen (Japan)"
-	serial "ULJM-05694"
-	serial "ULJM-05694"
+	rom ( serial "ULJM-05694" )
 )
 
 game (
 	name "Shin Master of Monsters Final EX - Mukunaru Nageki, Tenmei no Saika (Japan) (v1.01)"
-	serial "ULJS-00282"
-	serial "ULJS-00282"
+	rom ( serial "ULJS-00282" )
 )
 
 game (
 	name "Shin Megami Tensei - Devil Summoner (Japan) (v1.02)"
-	serial "ULJM-05053"
-	serial "ULJM-05053"
+	rom ( serial "ULJM-05053" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona (USA)"
-	serial "ULUS-10432"
-	serial "ULUS-10432"
+	rom ( serial "ULUS-10432" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona 2 - Innocent Sin (Europe)"
-	serial "ULES-01557"
-	serial "ULES-01557"
+	rom ( serial "ULES-01557" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona 2 - Innocent Sin (USA)"
-	serial "ULUS-10584"
-	serial "ULUS-10584"
+	rom ( serial "ULUS-10584" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona 3 Portable (Europe) (v1.01)"
-	serial "ULES-01523"
-	serial "ULES-01523"
+	rom ( serial "ULES-01523" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona 3 Portable (Korea)"
-	serial "UCKS-45140"
-	serial "UCKS-45140"
+	rom ( serial "UCKS-45140" )
 )
 
 game (
 	name "Shin Megami Tensei - Persona 3 Portable (USA)"
-	serial "ULUS-10512"
-	serial "ULUS-10512"
+	rom ( serial "ULUS-10512" )
 )
 
 game (
 	name "Shin Sangoku Musou - Multi Raid 2 (Asia) (v1.01)"
-	serial "ULAS-42230"
-	serial "ULAS-42230"
+	rom ( serial "ULAS-42230" )
 )
 
 game (
 	name "Shin Sangoku Musou - Multi Raid 2 (Japan) (v1.01)"
-	serial "ULJM-05637"
-	serial "ULJM-05637"
+	rom ( serial "ULJM-05637" )
 )
 
 game (
 	name "Shin Sangoku Musou 5 Empires (Japan) (v1.02)"
-	serial "ULJM-05584"
-	serial "ULJM-05584"
+	rom ( serial "ULJM-05584" )
 )
 
 game (
 	name "Shin Sangoku Musou 5 Special (Asia)"
-	serial "ULAS-42202"
-	serial "ULAS-42202"
+	rom ( serial "ULAS-42202" )
 )
 
 game (
 	name "Shin Sangoku Musou 5 Special (Japan) (v1.02)"
-	serial "ULJM-05524"
-	serial "ULJM-05524"
+	rom ( serial "ULJM-05524" )
 )
 
 game (
 	name "Shin Sangoku Musou 5 Special (Korea) [b]"
-	serial "ULKS-46222"
-	serial "ULKS-46222"
+	rom ( serial "ULKS-46222" )
 )
 
 game (
 	name "Shin Sangoku Musou 6 Special (Japan) (v1.02)"
-	serial "ULJM-05938"
-	serial "ULJM-05938"
-)
-
-game (
-	name "Shin Sangoku Musou 6 Special (Japan) (v1.02)"
-	serial "ULJM-05938"
-	serial "ULJM-05938"
+	rom ( serial "ULJM-05938" )
 )
 
 game (
 	name "Shinigami to Shoujo (Japan) (v1.01)"
-	serial "ULJS-00403"
-	serial "ULJS-00403"
+	rom ( serial "ULJS-00403" )
 )
 
 game (
 	name "Shining Blade (Japan)"
-	serial "NPJH-50530"
-	serial "NPJH-50530"
+	rom ( serial "NPJH-50530" )
 )
 
 game (
 	name "Shining Hearts (Japan)"
-	serial "NPJH-50342"
-	serial "NPJH-50342"
+	rom ( serial "NPJH-50342" )
 )
 
 game (
 	name "Shinkyoku Soukai Polyphonica - 0-4 Wa Full Pack (Japan) (v1.02)"
-	serial "ULJM-05347"
-	serial "ULJM-05347"
+	rom ( serial "ULJM-05347" )
 )
 
 game (
 	name "Shinkyoku Soukai Polyphonica - After School (Japan) (v1.01)"
-	serial "ULJM-05832"
-	serial "ULJM-05832"
+	rom ( serial "ULJM-05832" )
 )
 
 game (
 	name "Shinobido - Tales of the Ninja (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00421"
-	serial "UCES-00421"
+	rom ( serial "UCES-00421" )
 )
 
 game (
 	name "Shinseiki Evangelion - Battle Orchestra Portable (Japan) (v1.03)"
-	serial "ULJM-05480"
-	serial "ULJM-05480"
+	rom ( serial "ULJM-05480" )
 )
 
 game (
 	name "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd Portable (Japan) (v1.01)"
-	serial "ULJM-05477"
-	serial "ULJM-05477"
+	rom ( serial "ULJM-05477" )
 )
 
 game (
 	name "Shinseiki Evangelion - Koutetsu no Girlfriend Tokubetsu-Hen Portable (Japan) (v1.01)"
-	serial "ULJM-05456"
-	serial "ULJM-05456"
+	rom ( serial "ULJM-05456" )
 )
 
 game (
 	name "Shinseiki Evangelion 2 - Tsukurareshi Sekai - Another Cases (Japan) (v1.01)"
-	serial "ULJS-00064"
-	serial "ULJS-00064"
+	rom ( serial "ULJS-00064" )
 )
 
 game (
 	name "Shinseiki Evangelion 2 - Tsukurareshi Sekai - Another Cases (Japan) (v1.01) (10 Shuunen Kinen Memorial Box)"
-	serial "ULJS-00061"
-	serial "ULJS-00061"
+	rom ( serial "ULJS-00061" )
 )
 
 game (
 	name "Shinseiki GPX Cyber Formula VS (Japan) (v1.02)"
-	serial "ULJS-00142"
-	serial "ULJS-00142"
+	rom ( serial "ULJS-00142" )
 )
 
 game (
 	name "Shirahana no Ori - Hiiro no Kakera 4 (Japan) (v1.01)"
-	serial "ULJM-06167"
-	serial "ULJM-06167"
+	rom ( serial "ULJM-06167" )
 )
 
 game (
 	name "Shirogane no Cal to Soukuu no Joou (Japan)"
-	serial "ULJM-05954"
-	serial "ULJM-05954"
+	rom ( serial "ULJM-05954" )
 )
 
 game (
 	name "Shirokuma Belles Stars - Happy Holidays! (Japan) (v1.01)"
-	serial "ULJM-06111"
-	serial "ULJM-06111"
+	rom ( serial "ULJM-06111" )
 )
 
 game (
 	name "Shogi World Champion - Gekisashi Portable (Japan)"
-	serial "ULJM-05652"
-	serial "ULJM-05652"
+	rom ( serial "ULJM-05652" )
 )
 
 game (
 	name "Shogi ga Tsuyokunaru - Gekishi - Jouseki Dojo (Japan) (v1.02)"
-	serial "ULJM-05263"
-	serial "ULJM-05263"
+	rom ( serial "ULJM-05263" )
 )
 
 game (
 	name "Shrek - Smash n' Crash Racing (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00618"
-	serial "ULES-00618"
+	rom ( serial "ULES-00618" )
 )
 
 game (
 	name "Shrek - Smash n' Crash Racing (USA) (v1.01)"
-	serial "ULUS-10194"
-	serial "ULUS-10194"
+	rom ( serial "ULUS-10194" )
 )
 
 game (
 	name "Shrek the Third (Europe) (En,Fr,De,Es,It,Nl) (v1.01)"
-	serial "ULES-00813"
-	serial "ULES-00813"
+	rom ( serial "ULES-00813" )
 )
 
 game (
 	name "Shrek the Third (Europe) (v1.01)"
-	serial "ULES-00812"
-	serial "ULES-00812"
+	rom ( serial "ULES-00812" )
 )
 
 game (
 	name "Shrek the Third (USA) (v1.01)"
-	serial "ULUS-10248"
-	serial "ULUS-10248"
+	rom ( serial "ULUS-10248" )
 )
 
 game (
 	name "Shukufuku no Campanella Portable (Japan) (v1.02)"
-	serial "ULJM-05715"
-	serial "ULJM-05715"
+	rom ( serial "ULJM-05715" )
 )
 
 game (
 	name "Shutsugeki!! Otometachi no Senjou 2 - Amakakeru Shougeki no Kizuna (Japan) (v1.03)"
-	serial "ULJS-00392"
-	serial "ULJS-00392"
+	rom ( serial "ULJS-00392" )
 )
 
 game (
 	name "Sid Meier's Pirates! (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00688"
-	serial "ULES-00688"
+	rom ( serial "ULES-00688" )
 )
 
 game (
 	name "Sid Meier's Pirates! (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10224"
-	serial "ULUS-10224"
+	rom ( serial "ULUS-10224" )
 )
 
 game (
 	name "Silent Hill - Shattered Memories (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01352"
-	serial "ULES-01352"
+	rom ( serial "ULES-01352" )
 )
 
 game (
 	name "Silent Hill - Shattered Memories (Japan)"
-	serial "NPJH-50148"
-	serial "NPJH-50148"
+	rom ( serial "NPJH-50148" )
 )
 
 game (
 	name "Silent Hill - Shattered Memories (USA)"
-	serial "ULUS-10450"
-	serial "ULUS-10450"
+	rom ( serial "ULUS-10450" )
 )
 
 game (
 	name "Silent Hill Origins (Asia) (En,Fr,De,Es,It) [b]"
-	serial "ULUS-10285"
-	serial "ULUS-10285"
+	rom ( serial "ULUS-10285" )
 )
 
 game (
 	name "Silent Hill Origins (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00869"
-	serial "ULES-00869"
+	rom ( serial "ULES-00869" )
 )
 
 game (
 	name "Silent Hill Origins (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10285"
-	serial "ULUS-10285"
 )
 
 game (
 	name "Silverfall (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00808"
-	serial "ULES-00808"
+	rom ( serial "ULES-00808" )
 )
 
 game (
 	name "Simple 2000 Series Portable!! Vol. 1 - The Mahjong (Japan) (v1.04)"
-	serial "ULJS-00301"
-	serial "ULJS-00301"
+	rom ( serial "ULJS-00301" )
 )
 
 game (
 	name "Simple 2000 Series Portable!! Vol. 2 - The Shogi (Japan) (v1.04)"
-	serial "ULJS-00302"
-	serial "ULJS-00302"
+	rom ( serial "ULJS-00302" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 1 - The Table Game (Japan) (v1.03)"
-	serial "ULJS-00037"
-	serial "ULJS-00037"
+	rom ( serial "ULJS-00037" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 12 - The Hohei 2 - Senyuu yo, Sakini Yuke (Japan) (v1.02)"
-	serial "ULJS-00207"
-	serial "ULJS-00207"
+	rom ( serial "ULJS-00207" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 13 - The Akuma Hunters - Exorsister (Japan) (v1.03)"
-	serial "ULJS-00265"
-	serial "ULJS-00265"
+	rom ( serial "ULJS-00265" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 3 - The Dokodemo Suiri (Japan) (v1.07)"
-	serial "ULJS-00053"
-	serial "ULJS-00053"
+	rom ( serial "ULJS-00053" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 4 - The Unou Drill (Japan) (v1.01)"
-	serial "ULJS-00039"
-	serial "ULJS-00039"
+	rom ( serial "ULJS-00039" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 6 - The Sensha (Japan)"
-	serial "ULJS-00058"
-	serial "ULJS-00058"
+	rom ( serial "ULJS-00058" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 7 - The Doko Demo Kanji Quiz 2006 (Japan)"
-	serial "ULJS-00077"
-	serial "ULJS-00077"
+	rom ( serial "ULJS-00077" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 8 - The Dokodemo Girl Mahjong (Japan) (v1.02)"
-	serial "ULJS-00084"
-	serial "ULJS-00084"
+	rom ( serial "ULJS-00084" )
 )
 
 game (
 	name "Simple 2500 Series Portable!! Vol. 9 - The My Taxi (Japan) (v1.01)"
-	serial "ULJS-00096"
-	serial "ULJS-00096"
+	rom ( serial "ULJS-00096" )
 )
 
 game (
 	name "Simpsons Game, The (Europe)"
-	serial "ULES-00975"
-	serial "ULES-00975"
+	rom ( serial "ULES-00975" )
 )
 
 game (
 	name "Simpsons Game, The (USA)"
-	serial "ULUS-10295"
-	serial "ULUS-10295"
+	rom ( serial "ULUS-10295" )
 )
 
 game (
 	name "Sims 2, The (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00211"
-	serial "ULES-00211"
+	rom ( serial "ULES-00211" )
 )
 
 game (
 	name "Sims 2, The (Korea)"
-	serial "ULKS-46045"
-	serial "ULKS-46045"
+	rom ( serial "ULKS-46045" )
 )
 
 game (
 	name "Sims 2, The (USA)"
-	serial "ULUS-10031"
-	serial "ULUS-10031"
+	rom ( serial "ULUS-10031" )
 )
 
 game (
 	name "Sims 2, The - Castaway (Europe) (En,Fr,De,Es,It,Nl,Pt)"
-	serial "ULES-00945"
-	serial "ULES-00945"
+	rom ( serial "ULES-00945" )
 )
 
 game (
 	name "Sims 2, The - Castaway (USA) (En,Fr,De,Es,It,Nl,Pt)"
-	serial "ULUS-10296"
-	serial "ULUS-10296"
+	rom ( serial "ULUS-10296" )
 )
 
 game (
 	name "Sims 2, The - Pets (Asia) (En,Fr,De,Es,It,Nl,Zh)"
-	serial "ULAS-42085"
-	serial "ULAS-42085"
+	rom ( serial "ULAS-42085" )
 )
 
 game (
 	name "Sims 2, The - Pets (Europe)"
-	serial "ULES-00595"
-	serial "ULES-00595"
+	rom ( serial "ULES-00595" )
 )
 
 game (
 	name "Sims 2, The - Pets (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-00596"
-	serial "ULES-00596"
+	rom ( serial "ULES-00596" )
 )
 
 game (
 	name "Sims 2, The - Pets (USA)"
-	serial "ULUS-10130"
-	serial "ULUS-10130"
+	rom ( serial "ULUS-10130" )
 )
 
 game (
 	name "Skate Park City (Europe) (v1.02)"
-	serial "ULES-00957"
-	serial "ULES-00957"
+	rom ( serial "ULES-00957" )
 )
 
 game (
 	name "Slotter Mania P - Mach Go Go Go III (Japan) (v1.01)"
-	serial "ULJM-05822"
-	serial "ULJM-05822"
+	rom ( serial "ULJM-05822" )
 )
 
 game (
 	name "Slotter Mania P - SanSan HanaHana & SanSan Oasis (Japan) (v1.01)"
-	serial "ULJM-05764"
-	serial "ULJM-05764"
+	rom ( serial "ULJM-05764" )
 )
 
 game (
 	name "Slotter Mania P - Tetsuya - Shinjuku vs Ueno - Jansei to Yobareta Otoko (Japan) (v1.02)"
-	serial "ULJM-05620"
-	serial "ULJM-05620"
+	rom ( serial "ULJM-05620" )
 )
 
 game (
 	name "Smart Bomb (USA) (v1.03)"
-	serial "ULUS-10016"
-	serial "ULUS-10016"
+	rom ( serial "ULUS-10016" )
 )
 
 game (
 	name "Smash Court Tennis 3 (Europe) (En,Ja,Fr,De,Es,It)"
-	serial "UCES-00758"
-	serial "UCES-00758"
+	rom ( serial "UCES-00758" )
 )
 
 game (
 	name "Smash Court Tennis 3 (Japan)"
-	serial "ULJS-00098"
-	serial "ULJS-00098"
+	rom ( serial "ULJS-00098" )
 )
 
 game (
 	name "Smash Court Tennis 3 (USA)"
-	serial "ULUS-10269"
-	serial "ULUS-10269"
+	rom ( serial "ULUS-10269" )
 )
 
 game (
 	name "Snoopy vs the Red Baron (USA)"
-	serial "ULUS-10189"
-	serial "ULUS-10189"
+	rom ( serial "ULUS-10189" )
 )
 
 game (
 	name "Snow Portable (Japan) (v1.03)"
-	serial "ULJM-05214"
-	serial "ULJM-05214"
+	rom ( serial "ULJM-05214" )
 )
 
 game (
 	name "So-Ra-No-Wo-To - Otome no Quintet (Japan) (v1.03)"
-	serial "ULJM-05673"
-	serial "ULJM-05673"
+	rom ( serial "ULJM-05673" )
 )
 
 game (
 	name "Sol Trigger (Japan) (v1.01)"
-	serial "NPJH-50619"
-	serial "NPJH-50619"
+	rom ( serial "NPJH-50619" )
 )
 
 game (
 	name "Solfege - Sweet Harmony (Japan) (v1.03)"
-	serial "ULJM-05367"
-	serial "ULJM-05367"
+	rom ( serial "ULJM-05367" )
 )
 
 game (
 	name "Sonic Rivals (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00622"
-	serial "ULES-00622"
+	rom ( serial "ULES-00622" )
 )
 
 game (
 	name "Sonic Rivals (USA)"
-	serial "ULUS-10195"
-	serial "ULUS-10195"
+	rom ( serial "ULUS-10195" )
 )
 
 game (
 	name "Sonic Rivals 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00940"
-	serial "ULES-00940"
+	rom ( serial "ULES-00940" )
 )
 
 game (
 	name "Sonic Rivals 2 (USA) (v1.01)"
-	serial "ULUS-10323"
-	serial "ULUS-10323"
+	rom ( serial "ULUS-10323" )
 )
 
 game (
 	name "Sony Computer Science Kenkyuusho Mogi Kenichiro Hakase Kanshuu - Nou ni Kaikan Aha Taiken! (Japan)"
-	serial "ULJM-05135"
-	serial "ULJM-05135"
+	rom ( serial "ULJM-05135" )
 )
 
 game (
 	name "Sony Computer Science Kenkyuusho Mogi Kenichiro Hakase Kanshuu - Nou ni Kaikan Aha Taiken! (Japan) (v2.01)"
-	serial "ULJM-05135"
-	serial "ULJM-05135"
 )
 
 game (
 	name "Sony Computer Science Kenkyuusho Mogi Kenichiro Hakase Kanshuu - Nou ni Kaikan Minna de Aha Taiken! (Japan) (v1.01)"
-	serial "ULJM-05189"
-	serial "ULJM-05189"
+	rom ( serial "ULJM-05189" )
 )
 
 game (
 	name "Sora no Kiseki - Material Collection Portable (Japan)"
-	serial "ULJM-05307"
-	serial "ULJM-05307"
+	rom ( serial "ULJM-05307" )
 )
 
 game (
 	name "Sora no Otoshimono - DokiDoki Summer Vacation (Japan) (v1.02)"
-	serial "ULJM-05639"
-	serial "ULJM-05639"
+	rom ( serial "ULJM-05639" )
 )
 
 game (
 	name "Sorairo Portable (Japan) (v1.01)"
-	serial "ULJM-06138"
-	serial "ULJM-06138"
+	rom ( serial "ULJM-06138" )
 )
 
 game (
 	name "Sorayume Portable (Japan) (v1.02)"
-	serial "ULJS-00203"
-	serial "ULJS-00203"
+	rom ( serial "ULJS-00203" )
 )
 
 game (
 	name "Soreyuke! Burunyan-Man Portable - Torimodose! Ai to Seigi to Kibou no Tsunyakan (Japan) (v1.03)"
-	serial "NPJH-50656"
-	serial "NPJH-50656"
+	rom ( serial "NPJH-50656" )
 )
 
 game (
 	name "Soukoku no Kusabi - Hiiro no Kakera 3 - Ashita e no Tobira (Japan) (v1.04)"
-	serial "ULJM-06072"
-	serial "ULJM-06072"
+	rom ( serial "ULJM-06072" )
 )
 
 game (
 	name "Soukyuu no Fafner (Japan)"
-	serial "ULJS-00006"
-	serial "ULJS-00006"
+	rom ( serial "ULJS-00006" )
 )
 
 game (
 	name "Soul Eater - Battle Resonance (Japan) (v1.02)"
-	serial "ULJS-00176"
-	serial "ULJS-00176"
+	rom ( serial "ULJS-00176" )
 )
 
 game (
 	name "Soulcalibur - Broken Destiny (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01298"
-	serial "ULES-01298"
+	rom ( serial "ULES-01298" )
 )
 
 game (
 	name "Soulcalibur - Broken Destiny (Japan) (En,Ja,Fr,De,Es,It,Ru) (v1.01)"
-	serial "ULJS-00202"
-	serial "ULJS-00202"
+	rom ( serial "ULJS-00202" )
 )
 
 game (
 	name "Soulcalibur - Broken Destiny (USA) (En,Ja,Fr,De,Es,It,Ru)"
-	serial "ULUS-10457"
-	serial "ULUS-10457"
+	rom ( serial "ULUS-10457" )
 )
 
 game (
 	name "Sound Novel Portable Machi - Unmei no Kosaten Tokubetsu Hen (Japan) (v1.01)"
-	serial "ULJM-05111"
-	serial "ULJM-05111"
+	rom ( serial "ULJM-05111" )
 )
 
 game (
 	name "Space Invaders Evolution (Europe) (En,Fr,De,Es,It,Nl) (v1.02)"
-	serial "ULES-00348"
-	serial "ULES-00348"
+	rom ( serial "ULES-00348" )
 )
 
 game (
 	name "Space Invaders Extreme (Europe) (En,Ja,Fr,De,Es,It)"
-	serial "ULES-01078"
-	serial "ULES-01078"
+	rom ( serial "ULES-01078" )
 )
 
 game (
 	name "Space Invaders Extreme (Japan) (v1.01)"
-	serial "ULJM-05315"
-	serial "ULJM-05315"
+	rom ( serial "ULJM-05315" )
 )
 
 game (
 	name "Space Invaders Extreme (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10346"
-	serial "ULUS-10346"
+	rom ( serial "ULUS-10346" )
 )
 
 game (
 	name "Space Invaders Pocket (Japan) (v1.04)"
-	serial "ULJM-05015"
-	serial "ULJM-05015"
+	rom ( serial "ULJM-05015" )
 )
 
 game (
 	name "Space Invaders Pocket (Korea)"
-	serial "ULKS-46020"
-	serial "ULKS-46020"
+	rom ( serial "ULKS-46020" )
 )
 
 game (
 	name "Spectral Souls - Resurrection of the Ethereal Empires (USA)"
-	serial "ULUS-10076"
-	serial "ULUS-10076"
+	rom ( serial "ULUS-10076" )
 )
 
 game (
 	name "Spectral vs Generation (Europe) (v1.02)"
-	serial "ULES-00757"
-	serial "ULES-00757"
+	rom ( serial "ULES-00757" )
 )
 
 game (
 	name "Spectral vs Generation (Japan) (v1.06)"
-	serial "ULJM-05162"
-	serial "ULJM-05162"
+	rom ( serial "ULJM-05162" )
 )
 
 game (
 	name "Spelling Challenges and More! (USA)"
-	serial "ULUS-10255"
-	serial "ULUS-10255"
+	rom ( serial "ULUS-10255" )
 )
 
 game (
 	name "Spider-Man - Friend or Foe (Europe) (En,It) (v1.01)"
-	serial "ULES-00899"
-	serial "ULES-00899"
+	rom ( serial "ULES-00899" )
 )
 
 game (
 	name "Spider-Man - Friend or Foe (Europe) (Fr,Es) (v1.01)"
-	serial "ULES-00900"
-	serial "ULES-00900"
+	rom ( serial "ULES-00900" )
 )
 
 game (
 	name "Spider-Man - Friend or Foe (USA)"
-	serial "ULUS-10318"
-	serial "ULUS-10318"
+	rom ( serial "ULUS-10318" )
 )
 
 game (
 	name "Spider-Man - Web of Shadows (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "ULES-01174"
-	serial "ULES-01174"
+	rom ( serial "ULES-01174" )
 )
 
 game (
 	name "Spider-Man - Web of Shadows (USA) (En,Fr) (v1.01)"
-	serial "ULUS-10389"
-	serial "ULUS-10389"
+	rom ( serial "ULUS-10389" )
 )
 
 game (
 	name "Spider-Man 2 (Europe) (Fr,De,Es,It)"
-	serial "ULES-00023"
-	serial "ULES-00023"
+	rom ( serial "ULES-00023" )
 )
 
 game (
 	name "Spider-Man 2 (Europe) (v1.01)"
-	serial "ULES-00022"
-	serial "ULES-00022"
+	rom ( serial "ULES-00022" )
 )
 
 game (
 	name "Spider-Man 2 (Japan) (v1.02)"
-	serial "ULJM-05102"
-	serial "ULJM-05102"
+	rom ( serial "ULJM-05102" )
 )
 
 game (
 	name "Spider-Man 2 (USA) (v1.01)"
-	serial "ULUS-10015"
-	serial "ULUS-10015"
+	rom ( serial "ULUS-10015" )
 )
 
 game (
 	name "Spider-Man 3 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00938"
-	serial "ULES-00938"
+	rom ( serial "ULES-00938" )
 )
 
 game (
 	name "Spider-Man 3 (USA) (v1.02)"
-	serial "ULUS-10317"
-	serial "ULUS-10317"
+	rom ( serial "ULUS-10317" )
 )
 
 game (
 	name "Spinout (Europe) (v1.02)"
-	serial "ULES-00693"
-	serial "ULES-00693"
+	rom ( serial "ULES-00693" )
 )
 
 game (
 	name "Split-Second - Velocity (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01402"
-	serial "ULES-01402"
+	rom ( serial "ULES-01402" )
 )
 
 game (
 	name "SpongeBob SquarePants - The Yellow Avenger (Europe) (v1.01)"
-	serial "ULES-00280"
-	serial "ULES-00280"
+	rom ( serial "ULES-00280" )
 )
 
 game (
 	name "SpongeBob SquarePants - The Yellow Avenger (USA) (v1.01)"
-	serial "ULUS-10092"
-	serial "ULUS-10092"
+	rom ( serial "ULUS-10092" )
 )
 
 game (
 	name "SpongeBob's Truth or Square (Europe) (En,De,It,Nl) (v1.01)"
-	serial "ULES-01365"
-	serial "ULES-01365"
+	rom ( serial "ULES-01365" )
 )
 
 game (
 	name "SpongeBob's Truth or Square (USA)"
-	serial "ULUS-10478"
-	serial "ULUS-10478"
+	rom ( serial "ULUS-10478" )
 )
 
 game (
 	name "Stacked with Daniel Negreanu (USA) (v1.02)"
-	serial "ULUS-10101"
-	serial "ULUS-10101"
+	rom ( serial "ULUS-10101" )
 )
 
 game (
 	name "Star Driver - Kagayaki no Takuto - Ginga Bishounen Densetsu (Japan) (v1.01)"
-	serial "ULJS-00368"
-	serial "ULJS-00368"
+	rom ( serial "ULJS-00368" )
 )
 
 game (
 	name "Star Ocean - First Departure (Europe)"
-	serial "ULES-01154"
-	serial "ULES-01154"
+	rom ( serial "ULES-01154" )
 )
 
 game (
 	name "Star Ocean - First Departure (Japan) (v1.01)"
-	serial "ULJM-05290"
-	serial "ULJM-05290"
+	rom ( serial "ULJM-05290" )
 )
 
 game (
 	name "Star Ocean - First Departure (USA)"
-	serial "ULUS-10374"
-	serial "ULUS-10374"
+	rom ( serial "ULUS-10374" )
 )
 
 game (
 	name "Star Ocean - Second Evolution (Europe)"
-	serial "ULES-01187"
-	serial "ULES-01187"
+	rom ( serial "ULES-01187" )
 )
 
 game (
 	name "Star Ocean - Second Evolution (Japan) (v1.01)"
-	serial "ULJM-05325"
-	serial "ULJM-05325"
+	rom ( serial "ULJM-05325" )
 )
 
 game (
 	name "Star Ocean - Second Evolution (USA)"
-	serial "ULUS-10375"
-	serial "ULUS-10375"
+	rom ( serial "ULUS-10375" )
 )
 
 game (
 	name "Star Soldier (Japan) (v1.01)"
-	serial "ULJM-05026"
-	serial "ULJM-05026"
+	rom ( serial "ULJM-05026" )
 )
 
 game (
 	name "Star Trek - Tactical Assault (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00623"
-	serial "ULES-00623"
+	rom ( serial "ULES-00623" )
 )
 
 game (
 	name "Star Trek - Tactical Assault (USA) (v1.01)"
-	serial "ULUS-10150"
-	serial "ULUS-10150"
+	rom ( serial "ULUS-10150" )
 )
 
 game (
 	name "Star Wars - Battlefront II (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00183"
-	serial "ULES-00183"
+	rom ( serial "ULES-00183" )
 )
 
 game (
 	name "Star Wars - Battlefront II (Japan) (v1.02)"
-	serial "ULJM-05060"
-	serial "ULJM-05060"
+	rom ( serial "ULJM-05060" )
 )
 
 game (
 	name "Star Wars - Battlefront II (USA) (v1.01)"
-	serial "ULUS-10053"
-	serial "ULUS-10053"
+	rom ( serial "ULUS-10053" )
 )
 
 game (
 	name "Star Wars - Lethal Alliance (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00599"
-	serial "ULES-00599"
+	rom ( serial "ULES-00599" )
 )
 
 game (
 	name "Star Wars - Lethal Alliance (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10188"
-	serial "ULUS-10188"
+	rom ( serial "ULUS-10188" )
 )
 
 game (
 	name "Star Wars - The Clone Wars - Republic Heroes (Europe) (De,It) (v1.01)"
-	serial "ULES-01285"
-	serial "ULES-01285"
+	rom ( serial "ULES-01285" )
 )
 
 game (
 	name "Star Wars - The Clone Wars - Republic Heroes (Europe) (En,Fr,Es)"
-	serial "ULES-01284"
-	serial "ULES-01284"
+	rom ( serial "ULES-01284" )
 )
 
 game (
 	name "Star Wars - The Clone Wars - Republic Heroes (USA)"
-	serial "ULUS-10477"
-	serial "ULUS-10477"
+	rom ( serial "ULUS-10477" )
 )
 
 game (
 	name "Star Wars - The Force Unleashed (Europe) (En,Es,It)"
-	serial "ULES-00981"
-	serial "ULES-00981"
+	rom ( serial "ULES-00981" )
 )
 
 game (
 	name "Star Wars - The Force Unleashed (Europe) (Fr,De)"
-	serial "ULES-00982"
-	serial "ULES-00982"
+	rom ( serial "ULES-00982" )
 )
 
 game (
 	name "Star Wars - The Force Unleashed (USA) (v1.01)"
-	serial "ULUS-10345"
-	serial "ULUS-10345"
+	rom ( serial "ULUS-10345" )
 )
 
 game (
 	name "Star Wars Battlefront - Elite Squadron (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01214"
-	serial "ULES-01214"
+	rom ( serial "ULES-01214" )
 )
 
 game (
 	name "Star Wars Battlefront - Elite Squadron (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10390"
-	serial "ULUS-10390"
+	rom ( serial "ULUS-10390" )
 )
 
 game (
 	name "Star Wars Battlefront - Renegade Squadron (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00861"
-	serial "ULES-00861"
+	rom ( serial "ULES-00861" )
 )
 
 game (
 	name "Star Wars Battlefront - Renegade Squadron (USA) (v1.02)"
-	serial "ULUS-10292"
-	serial "ULUS-10292"
+	rom ( serial "ULUS-10292" )
 )
 
 game (
 	name "Starry Sky in Autumn Portable (Japan) (v1.01)"
-	serial "ULJM-05809"
-	serial "ULJM-05809"
+	rom ( serial "ULJM-05809" )
 )
 
 game (
 	name "Starry Sky in Spring Portable (Japan) (v1.02)"
-	serial "ULJM-05683"
-	serial "ULJM-05683"
+	rom ( serial "ULJM-05683" )
 )
 
 game (
 	name "Starry Sky in Winter Portable (Japan) (v1.01)"
-	serial "ULJM-05861"
-	serial "ULJM-05861"
+	rom ( serial "ULJM-05861" )
 )
 
 game (
 	name "State Shift (Europe) (v1.03)"
-	serial "ULES-00776"
-	serial "ULES-00776"
+	rom ( serial "ULES-00776" )
 )
 
 game (
 	name "Steambot Chronicles - Battle Tournament (USA)"
-	serial "ULUS-10470"
-	serial "ULUS-10470"
+	rom ( serial "ULUS-10470" )
 )
 
 game (
 	name "Steel Horizon (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00739"
-	serial "ULES-00739"
+	rom ( serial "ULES-00739" )
 )
 
 game (
 	name "Steel Horizon (USA) (v1.03)"
-	serial "ULUS-10215"
-	serial "ULUS-10215"
+	rom ( serial "ULUS-10215" )
 )
 
 game (
 	name "Steins;Gate (Japan) (v1.01)"
-	serial "ULJM-05887"
-	serial "ULJM-05887"
+	rom ( serial "ULJM-05887" )
 )
 
 game (
 	name "Steins;Gate - Hiyoku Renri no Darling (Japan) (v1.02)"
-	serial "ULJM-06040"
-	serial "ULJM-06040"
+	rom ( serial "ULJM-06040" )
 )
 
 game (
 	name "StormLover (Japan) (v1.02) (Shokai Seisanban)"
-	serial "ULJS-00299"
-	serial "ULJS-00299"
+	rom ( serial "ULJS-00299" )
 )
 
 game (
 	name "StormLover Kai!! (Japan) (v1.03) (Shokai Seisanban)"
-	serial "ULJS-00504"
-	serial "ULJS-00504"
+	rom ( serial "ULJS-00504" )
 )
 
 game (
 	name "Street Cricket Champions (Europe)"
-	serial "UCES-01320"
-	serial "UCES-01320"
+	rom ( serial "UCES-01320" )
 )
 
 game (
 	name "Street Fighter Alpha 3 Max (Europe) (v1.01)"
-	serial "ULES-00235"
-	serial "ULES-00235"
+	rom ( serial "ULES-00235" )
 )
 
 game (
 	name "Street Fighter Alpha 3 Max (USA)"
-	serial "ULUS-10062"
-	serial "ULUS-10062"
+	rom ( serial "ULUS-10062" )
 )
 
 game (
 	name "Street Riders (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00276"
-	serial "ULES-00276"
+	rom ( serial "ULES-00276" )
 )
 
 game (
 	name "Street Supremacy (Europe) (v1.02)"
-	serial "ULES-00239"
-	serial "ULES-00239"
+	rom ( serial "ULES-00239" )
 )
 
 game (
 	name "Street Supremacy (USA)"
-	serial "ULUS-10069"
-	serial "ULUS-10069"
+	rom ( serial "ULUS-10069" )
 )
 
 game (
 	name "Strike Witches - Hakugin no Tsubasa (Japan)"
-	serial "NPJH-50622"
-	serial "NPJH-50622"
+	rom ( serial "NPJH-50622" )
 )
 
 game (
 	name "Strikers 1945 Plus Portable (Japan)"
-	serial "ULJM-05511"
-	serial "ULJM-05511"
+	rom ( serial "ULJM-05511" )
 )
 
 game (
 	name "Sucre Portable (Japan) (v1.01)"
-	serial "ULJM-06134"
-	serial "ULJM-06134"
+	rom ( serial "ULJM-06134" )
 )
 
 game (
 	name "Sudoku (Japan)"
-	serial "ULJM-05146"
-	serial "ULJM-05146"
+	rom ( serial "ULJM-05146" )
 )
 
 game (
 	name "Suigetsu Ni Portable (Japan) (v1.01)"
-	serial "ULJM-06062"
-	serial "ULJM-06062"
+	rom ( serial "ULJM-06062" )
 )
 
 game (
 	name "Suigetsu Portable (Japan)"
-	serial "ULJM-05346"
-	serial "ULJM-05346"
+	rom ( serial "ULJM-05346" )
 )
 
 game (
 	name "Summon Night 3 (Japan) (v2.0)"
-	serial "NPJH-50380"
-	serial "NPJH-50380"
+	rom ( serial "NPJH-50380" )
 )
 
 game (
 	name "Summon Night 5 (Japan) (v1.01)"
-	serial "NPJH-50696"
-	serial "NPJH-50696"
+	rom ( serial "NPJH-50696" )
 )
 
 game (
 	name "Summon Night 5 (USA)"
-	serial "ULUS-10656"
-	serial "ULUS-10656"
+	rom ( serial "ULUS-10656" )
 )
 
 game (
 	name "Sunday Vs Magazine Shuuketsu! Choujou Daikessen (Japan) (v1.05)"
-	serial "ULJM-05450"
-	serial "ULJM-05450"
+	rom ( serial "ULJM-05450" )
 )
 
 game (
 	name "Super Collapse! 3 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01027"
-	serial "ULES-01027"
+	rom ( serial "ULES-01027" )
 )
 
 game (
 	name "Super Collapse! 3 (USA) (v1.01)"
-	serial "ULUS-10287"
-	serial "ULUS-10287"
+	rom ( serial "ULUS-10287" )
 )
 
 game (
 	name "Super Dangan-Ronpa 2 - Sayonara Zetsubou Gakuen (Japan) (v1.02)"
-	serial "NPJH-50631"
-	serial "NPJH-50631"
+	rom ( serial "NPJH-50631" )
 )
 
 game (
 	name "Super Fruit Fall Deluxe Edition (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00639"
-	serial "ULES-00639"
+	rom ( serial "ULES-00639" )
 )
 
 game (
 	name "Super Hind (Europe) (En,Fr,De,Es,It,Fi) (v1.01)"
-	serial "ULES-01091"
-	serial "ULES-01091"
+	rom ( serial "ULES-01091" )
 )
 
 game (
 	name "Super Monkey Ball Adventure (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00364"
-	serial "ULES-00364"
+	rom ( serial "ULES-00364" )
 )
 
 game (
 	name "Super Monkey Ball Adventure (USA) (v1.02)"
-	serial "ULUS-10132"
-	serial "ULUS-10132"
+	rom ( serial "ULUS-10132" )
 )
 
 game (
 	name "Super Pocket Tennis (Europe) (v1.01)"
-	serial "ULES-00619"
-	serial "ULES-00619"
+	rom ( serial "ULES-00619" )
 )
 
 game (
 	name "Super Robot Taisen A Portable (Japan) (v1.02)"
-	serial "ULJS-00143"
-	serial "ULJS-00143"
+	rom ( serial "ULJS-00143" )
 )
 
 game (
 	name "Super Robot Taisen MX Portable (Japan) (v1.04)"
-	serial "ULJS-00041"
-	serial "ULJS-00041"
+	rom ( serial "ULJS-00041" )
 )
 
 game (
 	name "Super Robot Taisen OG Saga - Masou Kishin - The Lord of Elemental (Japan) (v1.01)"
-	serial "ULJS-00445"
-	serial "ULJS-00445"
+	rom ( serial "ULJS-00445" )
 )
 
 game (
 	name "Super Robot Taisen OG Saga - Masou Kishin II - Revelation of Evil God (Japan) (v1.02)"
-	serial "ULJS-00446"
-	serial "ULJS-00446"
+	rom ( serial "ULJS-00446" )
 )
 
 game (
 	name "Surf's Up (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00817"
-	serial "ULES-00817"
+	rom ( serial "ULES-00817" )
 )
 
 game (
 	name "Surf's Up (Europe) (En,Fr,Es)"
-	serial "ULES-00816"
-	serial "ULES-00816"
+	rom ( serial "ULES-00816" )
 )
 
 game (
 	name "Surf's Up (USA) (En,Fr,Es) (v1.01)"
-	serial "ULUS-10262"
-	serial "ULUS-10262"
+	rom ( serial "ULUS-10262" )
 )
 
 game (
 	name "Suto-Mani - Strobe-Mania (Japan) (v1.01)"
-	serial "ULJS-00439"
-	serial "ULJS-00439"
+	rom ( serial "ULJS-00439" )
 )
 
 game (
 	name "Suzukaze no Melt - Days in the Sanctuary (Japan) (v1.01)"
-	serial "ULJM-06053"
-	serial "ULJM-06053"
+	rom ( serial "ULJM-06053" )
 )
 
 game (
 	name "Suzumiya Haruhi no Tsuisou (Japan) (v1.02)"
-	serial "ULJS-00371"
-	serial "ULJS-00371"
+	rom ( serial "ULJS-00371" )
 )
 
 game (
 	name "Suzumiya Haruhi no Yakusoku (Japan) (v1.06)"
-	serial "ULJS-00124"
-	serial "ULJS-00124"
+	rom ( serial "ULJS-00124" )
 )
 
 game (
 	name "Suzumiya Haruhi no Yakusoku (Japan) (v1.06) (Super Premium Box)"
-	serial "ULJS-00123"
-	serial "ULJS-00123"
+	rom ( serial "ULJS-00123" )
 )
 
 game (
 	name "Suzumiya Haruhi-Chan no Mahjong (Japan) (v1.02)"
-	serial "ULJM-05751"
-	serial "ULJM-05751"
+	rom ( serial "ULJM-05751" )
 )
 
 game (
 	name "Sweet Fuse - At Your Side (USA)"
-	serial "ULUS-10652"
-	serial "ULUS-10652"
+	rom ( serial "ULUS-10652" )
 )
 
 game (
 	name "Syphon Filter - Dark Mirror (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00310"
-	serial "UCES-00310"
+	rom ( serial "UCES-00310" )
 )
 
 game (
 	name "Syphon Filter - Dark Mirror (USA) (Demo)"
-	serial "UCUS-98656"
-	serial "UCUS-98656"
+	rom ( serial "UCUS-98656" )
 )
 
 game (
 	name "Syphon Filter - Dark Mirror (USA) (v1.01)"
-	serial "UCUS-98641"
-	serial "UCUS-98641"
+	rom ( serial "UCUS-98641" )
 )
 
 game (
 	name "Syphon Filter - Logan's Shadow (Europe) (En,Fr,De,Es,It,Pl,Ru)"
-	serial "UCES-00710"
-	serial "UCES-00710"
+	rom ( serial "UCES-00710" )
 )
 
 game (
 	name "Syphon Filter - Logan's Shadow (USA)"
-	serial "UCUS-98606"
-	serial "UCUS-98606"
+	rom ( serial "UCUS-98606" )
 )
 
 game (
 	name "Syphon Filter - Logan's Shadow (USA) (Demo)"
-	serial "UCUS-98704"
-	serial "UCUS-98704"
+	rom ( serial "UCUS-98704" )
 )
 
 game (
 	name "TMNT - Teenage Mutant Ninja Turtles (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00759"
-	serial "ULES-00759"
+	rom ( serial "ULES-00759" )
 )
 
 game (
 	name "TNA Impact - Cross the Line (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01305"
-	serial "ULES-01305"
+	rom ( serial "ULES-01305" )
 )
 
 game (
 	name "TRON - Evolution (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "ULES-01494"
-	serial "ULES-01494"
+	rom ( serial "ULES-01494" )
 )
 
 game (
 	name "TRON - Evolution (Russia)"
-	serial "ULES-01495"
-	serial "ULES-01495"
+	rom ( serial "ULES-01495" )
 )
 
 game (
 	name "TRON - Evolution (USA) (En,Fr,Es)"
-	serial "ULUS-10548"
-	serial "ULUS-10548"
+	rom ( serial "ULUS-10548" )
 )
 
 game (
 	name "Tactics Ogre - Let Us Cling Together (Europe)"
-	serial "ULES-01500"
-	serial "ULES-01500"
+	rom ( serial "ULES-01500" )
 )
 
 game (
 	name "Tactics Ogre - Let Us Cling Together (USA)"
-	serial "ULUS-10565"
-	serial "ULUS-10565"
+	rom ( serial "ULUS-10565" )
 )
 
 game (
 	name "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugekisu (Japan) (v1.02)"
-	serial "ULJS-00127"
-	serial "ULJS-00127"
+	rom ( serial "ULJS-00127" )
 )
 
 game (
 	name "Taiko no Tatsujin Portable (Japan) (v1.01)"
-	serial "ULJS-00020"
-	serial "ULJS-00020"
+	rom ( serial "ULJS-00020" )
 )
 
 game (
 	name "Taiko no Tatsujin Portable (Japan) (v2.00)"
-	serial "ULJS-00020"
-	serial "ULJS-00020"
 )
 
 game (
 	name "Taiko no Tatsujin Portable 2 (Japan)"
-	serial "ULJS-00081"
-	serial "ULJS-00081"
+	rom ( serial "ULJS-00081" )
 )
 
 game (
 	name "Taiko no Tatsujin Portable DX (Japan) (v1.02)"
-	serial "NPJH-50426"
-	serial "NPJH-50426"
+	rom ( serial "NPJH-50426" )
 )
 
 game (
 	name "Taikou Risshiden IV (Japan) (v1.02)"
-	serial "ULJM-05159"
-	serial "ULJM-05159"
+	rom ( serial "ULJM-05159" )
 )
 
 game (
 	name "Taikou Risshiden V (Japan) (v1.01)"
-	serial "ULJM-05525"
-	serial "ULJM-05525"
+	rom ( serial "ULJM-05525" )
 )
 
 game (
 	name "Taishou Yakyuu Musume - Otometachi no Seishun Nikki (Japan) (v1.01)"
-	serial "ULJM-05528"
-	serial "ULJM-05528"
+	rom ( serial "ULJM-05528" )
 )
 
 game (
 	name "Taito Legends Power-Up (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00473"
-	serial "ULES-00473"
+	rom ( serial "ULES-00473" )
 )
 
 game (
 	name "Taito Legends Power-Up (USA) (v1.01)"
-	serial "ULUS-10208"
-	serial "ULUS-10208"
+	rom ( serial "ULUS-10208" )
 )
 
 game (
 	name "Takuyo Mix Box - First Anniversary (Japan) (v1.01)"
-	serial "ULJS-00305"
-	serial "ULJS-00305"
+	rom ( serial "ULJS-00305" )
 )
 
 game (
 	name "Tales of Destiny 2 (Japan)"
-	serial "ULJS-00097"
-	serial "ULJS-00097"
+	rom ( serial "ULJS-00097" )
 )
 
 game (
 	name "Tales of Eternia (Europe) (v2.02)"
-	serial "ULES-00176"
-	serial "ULES-00176"
+	rom ( serial "ULES-00176" )
 )
 
 game (
 	name "Tales of Eternia (Japan)"
-	serial "ULJS-00015"
-	serial "ULJS-00015"
+	rom ( serial "ULJS-00015" )
 )
 
 game (
 	name "Tales of Phantasia - Full Voice Edition (Japan) (v1.02)"
-	serial "ULJS-00079"
-	serial "ULJS-00079"
+	rom ( serial "ULJS-00079" )
 )
 
 game (
 	name "Tales of Phantasia - Narikiri Dungeon X (Japan) (v1.01)"
-	serial "ULJS-00293"
-	serial "ULJS-00293"
+	rom ( serial "ULJS-00293" )
 )
 
 game (
 	name "Tales of Rebirth (Japan) (v1.02)"
-	serial "ULJS-00132"
-	serial "ULJS-00132"
+	rom ( serial "ULJS-00132" )
 )
 
 game (
 	name "Tales of VS. (Japan) (v1.02)"
-	serial "ULJS-00209"
-	serial "ULJS-00209"
+	rom ( serial "ULJS-00209" )
 )
 
 game (
 	name "Tales of the Heroes - Twin Brave (Japan) (v1.02)"
-	serial "NPJH-50501"
-	serial "NPJH-50501"
+	rom ( serial "NPJH-50501" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology (Europe)"
-	serial "ULES-00837"
-	serial "ULES-00837"
+	rom ( serial "ULES-00837" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology (Japan) (v1.01)"
-	serial "ULJS-00093"
-	serial "ULJS-00093"
+	rom ( serial "ULJS-00093" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology (Japan) (v1.01) (PSP Bundle Edition)"
-	serial "ULJM-95004"
-	serial "ULJM-95004"
+	rom ( serial "ULJM-95004" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology (USA)"
-	serial "ULUS-10271"
-	serial "ULUS-10271"
+	rom ( serial "ULUS-10271" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology 2 (Japan) (v1.01)"
-	serial "ULJS-00175"
-	serial "ULJS-00175"
+	rom ( serial "ULJS-00175" )
 )
 
 game (
 	name "Tales of the World - Radiant Mythology 3 (Japan)"
-	serial "NPJH-50353"
-	serial "NPJH-50353"
+	rom ( serial "NPJH-50353" )
 )
 
 game (
 	name "TalkMan (Asia) (En,Ja,Zh,Ko) (v1.03)"
-	serial "UCAS-40045"
-	serial "UCAS-40045"
+	rom ( serial "UCAS-40045" )
 )
 
 game (
 	name "TalkMan (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00254"
-	serial "UCES-00254"
+	rom ( serial "UCES-00254" )
 )
 
 game (
 	name "TalkMan (Japan) (En,Ja,Zh,Ko) (Software Tantaiban)"
-	serial "UCJS-10035"
-	serial "UCJS-10035"
+	rom ( serial "UCJS-10035" )
 )
 
 game (
 	name "TalkMan (Japan) (En,Ja,Zh,Ko) (v1.02) (Microphone Doukonban)"
-	serial "UCJS-10009"
-	serial "UCJS-10009"
+	rom ( serial "UCJS-10009" )
 )
 
 game (
 	name "TalkMan (Korea) (En,Ja,Zh,Ko) (v1.02) [b]"
-	serial "UCKS-45012"
-	serial "UCKS-45012"
+	rom ( serial "UCKS-45012" )
 )
 
 game (
 	name "TalkMan Shiki Shabelingual Eikaiwa (Japan) (En,Ja) (Microphone Doukonban)"
-	serial "UCJS-10050"
-	serial "UCJS-10050"
+	rom ( serial "UCJS-10050" )
 )
 
 game (
 	name "TalkMan Shiki Shabelingual Eikaiwa (Japan) (En,Ja) (Software Tantaiban)"
-	serial "UCJS-10051"
-	serial "UCJS-10051"
+	rom ( serial "UCJS-10051" )
 )
 
 game (
 	name "TalkMan Shiki Shabelingual Eikaiwa for Kids! (Japan) (En,Ja) (Microphone Doukonban)"
-	serial "UCJS-10053"
-	serial "UCJS-10053"
+	rom ( serial "UCJS-10053" )
 )
 
 game (
 	name "TalkMan Shiki Shabelingual Eikaiwa for Kids! (Japan) (En,Ja) (Software Tantaiban)"
-	serial "UCJS-10054"
-	serial "UCJS-10054"
+	rom ( serial "UCJS-10054" )
 )
 
 game (
 	name "TalkMan Travel (Japan)"
-	serial "UCJS-10066"
-	serial "UCJS-10066"
+	rom ( serial "UCJS-10066" )
 )
 
 game (
 	name "Tamayura - Mitamaokuri no Uta (Japan) (v1.01)"
-	serial "ULJM-05999"
-	serial "ULJM-05999"
+	rom ( serial "ULJM-05999" )
 )
 
 game (
 	name "Tantei Jinguji Saburo - Hai to Diamond (Japan) (v1.01)"
-	serial "ULJM-05529"
-	serial "ULJM-05529"
+	rom ( serial "ULJM-05529" )
 )
 
 game (
 	name "Tantei Opera Milky Holmes (Japan) (v1.01)"
-	serial "ULJS-00343"
-	serial "ULJS-00343"
+	rom ( serial "ULJS-00343" )
 )
 
 game (
 	name "Tantei Opera Milky Holmes 1.5 (Japan) (v1.01)"
-	serial "ULJS-00485"
-	serial "ULJS-00485"
+	rom ( serial "ULJS-00485" )
 )
 
 game (
 	name "Tantei Opera Milky Holmes 2 (Japan) (v1.01)"
-	serial "ULJS-00520"
-	serial "ULJS-00520"
+	rom ( serial "ULJS-00520" )
 )
 
 game (
 	name "Tanteibu - The Detective Club - Angou to Misshitsu to Kaijin to (Japan) (v1.01)"
-	serial "ULJM-05926"
-	serial "ULJM-05926"
+	rom ( serial "ULJM-05926" )
 )
 
 game (
 	name "Tanteibu - The Detective Club - Haibu to Kaiga to Bakudan to (Japan) (v1.02)"
-	serial "ULJM-05927"
-	serial "ULJM-05927"
+	rom ( serial "ULJM-05927" )
 )
 
 game (
 	name "Tanteibu - The Detective Club - Shissou to Hangeki to Daidanen (Japan)"
-	serial "ULJM-05928"
-	serial "ULJM-05928"
+	rom ( serial "ULJM-05928" )
 )
 
 game (
 	name "Tanteibu - The Detective Club - Tantei to Yuurei to Kaitou to (Japan) (v1.01)"
-	serial "ULJM-05925"
-	serial "ULJM-05925"
+	rom ( serial "ULJM-05925" )
 )
 
 game (
 	name "Te to Te Try On! - Tropical (Japan) (v1.01)"
-	serial "ULJM-05963"
-	serial "ULJM-05963"
+	rom ( serial "ULJM-05963" )
 )
 
 game (
 	name "Tears to Tiara - Kakan no Daichi Portable (Japan) (v1.04)"
-	serial "NPJH-50242"
-	serial "NPJH-50242"
+	rom ( serial "NPJH-50242" )
 )
 
 game (
 	name "Tears to Tiara Gaiden - Avalon no Nazo Portable (Japan) (v1.01)"
-	serial "NPJH-50243"
-	serial "NPJH-50243"
+	rom ( serial "NPJH-50243" )
 )
 
 game (
 	name "Tegami Bachi - Kokoro Tsumugu Mono e (Japan) (v1.01)"
-	serial "ULJM-05587"
-	serial "ULJM-05587"
+	rom ( serial "ULJM-05587" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Asia) (v1.02) [b]"
-	serial "UCAS-40099"
-	serial "UCAS-40099"
+	rom ( serial "UCAS-40099" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Europe) (Demo)"
-	serial "UCED-00448"
-	serial "UCED-00448"
+	rom ( serial "UCED-00448" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00356"
-	serial "UCES-00356"
+	rom ( serial "UCES-00356" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Europe) (En,Fr,De,Es,It) (Beta)"
-	serial "UCET-00424"
-	serial "UCET-00424"
+	rom ( serial "UCET-00424" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "UCES-00356"
-	serial "UCES-00356"
 )
 
 game (
 	name "Tekken - Dark Resurrection (Japan) (v1.06)"
-	serial "ULJS-00048"
-	serial "ULJS-00048"
+	rom ( serial "ULJS-00048" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (Korea) (v1.02)"
-	serial "UCKS-45027"
-	serial "UCKS-45027"
+	rom ( serial "UCKS-45027" )
 )
 
 game (
 	name "Tekken - Dark Resurrection (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10139"
-	serial "ULUS-10139"
+	rom ( serial "ULUS-10139" )
 )
 
 game (
 	name "Tekken 6 (Europe) (En,Fr,De,Es,It,Ru)"
-	serial "ULES-01376"
-	serial "ULES-01376"
+	rom ( serial "ULES-01376" )
 )
 
 game (
 	name "Tekken 6 (Japan) (En,Ja)"
-	serial "NPJH-50184"
-	serial "NPJH-50184"
+	rom ( serial "NPJH-50184" )
 )
 
 game (
 	name "Tekken 6 (USA) (En,Fr,De,Es,It,Ru)"
-	serial "ULUS-10466"
-	serial "ULUS-10466"
+	rom ( serial "ULUS-10466" )
 )
 
 game (
 	name "Telly Addicts (Europe) (v1.01)"
-	serial "ULES-00983"
-	serial "ULES-00983"
+	rom ( serial "ULES-00983" )
 )
 
 game (
 	name "Tenchi no Mon 2 Busouden (Asia) (v1.01)"
-	serial "UCAS-40116"
-	serial "UCAS-40116"
+	rom ( serial "UCAS-40116" )
 )
 
 game (
 	name "Tenchi no Mon 2 Busouden (Japan)"
-	serial "UCJS-10047"
-	serial "UCJS-10047"
+	rom ( serial "UCJS-10047" )
 )
 
 game (
 	name "Tenchi no Mon 2 Busouden (Korea)"
-	serial "UCKS-45034"
-	serial "UCKS-45034"
+	rom ( serial "UCKS-45034" )
 )
 
 game (
 	name "Tenchou no Igo (Japan) (v1.01)"
-	serial "ULJM-05766"
-	serial "ULJM-05766"
+	rom ( serial "ULJM-05766" )
 )
 
 game (
 	name "Tenchu - Shadow Assassins (Europe)"
-	serial "ULES-01237"
-	serial "ULES-01237"
+	rom ( serial "ULES-01237" )
 )
 
 game (
 	name "Tenchu - Shadow Assassins (USA) (v1.01)"
-	serial "ULUS-10419"
-	serial "ULUS-10419"
+	rom ( serial "ULUS-10419" )
 )
 
 game (
 	name "Tenchu - Time of the Assassins (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00277"
-	serial "ULES-00277"
+	rom ( serial "ULES-00277" )
 )
 
 game (
 	name "Tengai Makyou - Daiyon no Mokushiroku (Japan) (v1.02)"
-	serial "ULJM-05106"
-	serial "ULJM-05106"
+	rom ( serial "ULJM-05106" )
 )
 
 game (
 	name "Tenshin Ranman - Happy GO Lucky!! (Japan) (v1.01)"
-	serial "ULJM-05634"
-	serial "ULJM-05634"
+	rom ( serial "ULJM-05634" )
 )
 
 game (
 	name "Tenshin Ranman - Happy GO Lucky!! (Japan) (v1.01) (Shokai Genteiban)"
-	serial "ULJM-05634"
-	serial "ULJM-05634"
 )
 
 game (
 	name "Test Drive Unlimited (Europe) (En,Fr,De,Es,It) (Promo)"
-	serial "ULET-00386"
-	serial "ULET-00386"
+	rom ( serial "ULET-00386" )
 )
 
 game (
 	name "Test Drive Unlimited (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00637"
-	serial "ULES-00637"
+	rom ( serial "ULES-00637" )
 )
 
 game (
 	name "Test Drive Unlimited (USA)"
-	serial "ULUS-10249"
-	serial "ULUS-10249"
+	rom ( serial "ULUS-10249" )
 )
 
 game (
 	name "Thrillville (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00646"
-	serial "ULES-00646"
+	rom ( serial "ULES-00646" )
 )
 
 game (
 	name "Thrillville (USA) (v1.01)"
-	serial "ULUS-10191"
-	serial "ULUS-10191"
+	rom ( serial "ULUS-10191" )
 )
 
 game (
 	name "Thrillville - Off the Rails (Europe) (Es,It)"
-	serial "ULES-00888"
-	serial "ULES-00888"
+	rom ( serial "ULES-00888" )
 )
 
 game (
 	name "Thrillville - Off the Rails (Europe) (Fr,De)"
-	serial "ULES-00887"
-	serial "ULES-00887"
+	rom ( serial "ULES-00887" )
 )
 
 game (
 	name "Thrillville - Off the Rails (Europe) (v1.01)"
-	serial "ULES-00889"
-	serial "ULES-00889"
+	rom ( serial "ULES-00889" )
 )
 
 game (
 	name "Thrillville - Off the Rails (Korea)"
-	serial "ULKS-46115"
-	serial "ULKS-46115"
+	rom ( serial "ULKS-46115" )
 )
 
 game (
 	name "Thrillville - Off the Rails (USA) (v1.01)"
-	serial "ULUS-10306"
-	serial "ULUS-10306"
+	rom ( serial "ULUS-10306" )
 )
 
 game (
 	name "Tiger & Bunny - On-Air Jack! (Japan) (v1.01)"
-	serial "NPJH-50589"
-	serial "NPJH-50589"
+	rom ( serial "NPJH-50589" )
 )
 
 game (
 	name "Tiger Woods PGA Tour (Asia)"
-	serial "ULAS-42002"
-	serial "ULAS-42002"
+	rom ( serial "ULAS-42002" )
 )
 
 game (
 	name "Tiger Woods PGA Tour (Japan) (v1.03)"
-	serial "ULJM-05010"
-	serial "ULJM-05010"
+	rom ( serial "ULJM-05010" )
 )
 
 game (
 	name "Tiger Woods PGA Tour (USA)"
-	serial "ULUS-10009"
-	serial "ULUS-10009"
+	rom ( serial "ULUS-10009" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 06 (Asia)"
-	serial "ULAS-42020"
-	serial "ULAS-42020"
+	rom ( serial "ULAS-42020" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 06 (Europe)"
-	serial "ULES-00153"
-	serial "ULES-00153"
+	rom ( serial "ULES-00153" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 06 (Europe) (En,Fr,De)"
-	serial "ULES-00154"
-	serial "ULES-00154"
+	rom ( serial "ULES-00154" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 06 (Japan) (v1.03)"
-	serial "ULJM-05059"
-	serial "ULJM-05059"
+	rom ( serial "ULJM-05059" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 06 (USA) (v1.01)"
-	serial "ULUS-10028"
-	serial "ULUS-10028"
+	rom ( serial "ULUS-10028" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 07 (Europe)"
-	serial "ULES-00455"
-	serial "ULES-00455"
+	rom ( serial "ULES-00455" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 07 (France)"
-	serial "ULES-00456"
-	serial "ULES-00456"
+	rom ( serial "ULES-00456" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 07 (Japan)"
-	serial "ULJM-05192"
-	serial "ULJM-05192"
+	rom ( serial "ULJM-05192" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 07 (USA)"
-	serial "ULUS-10115"
-	serial "ULUS-10115"
+	rom ( serial "ULUS-10115" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 08 (Europe) (v1.02)"
-	serial "ULES-00845"
-	serial "ULES-00845"
+	rom ( serial "ULES-00845" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 08 (USA)"
-	serial "ULUS-10276"
-	serial "ULUS-10276"
+	rom ( serial "ULUS-10276" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 09 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01120"
-	serial "ULES-01120"
+	rom ( serial "ULES-01120" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 09 (USA)"
-	serial "ULUS-10367"
-	serial "ULUS-10367"
+	rom ( serial "ULUS-10367" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 10 (Europe)"
-	serial "ULES-01260"
-	serial "ULES-01260"
+	rom ( serial "ULES-01260" )
 )
 
 game (
 	name "Tiger Woods PGA Tour 10 (USA)"
-	serial "ULUS-10420"
-	serial "ULUS-10420"
+	rom ( serial "ULUS-10420" )
 )
 
 game (
 	name "Time Travelers (Japan) (v1.04)"
-	serial "NPJH-50597"
-	serial "NPJH-50597"
+	rom ( serial "NPJH-50597" )
 )
 
 game (
 	name "Tir-Na-Nog - Yuukyuu no Jin (Japan) (v1.01)"
-	serial "ULJS-00129"
-	serial "ULJS-00129"
+	rom ( serial "ULJS-00129" )
 )
 
 game (
 	name "To Heart 2 - Dungeon Travelers (Japan) (v1.04)"
-	serial "ULJM-05873"
-	serial "ULJM-05873"
+	rom ( serial "ULJM-05873" )
 )
 
 game (
 	name "To Heart 2 Portable (Japan)"
-	serial "ULJM-05487"
-	serial "ULJM-05487"
+	rom ( serial "ULJM-05487" )
 )
 
 game (
 	name "To Heart Portable (Japan)"
-	serial "ULJM-05486"
-	serial "ULJM-05486"
+	rom ( serial "ULJM-05486" )
 )
 
 game (
 	name "To Love Ru - Doki Doki Rinkai Gakkou Hen (Japan) (v1.02)"
-	serial "ULJS-00154"
-	serial "ULJS-00154"
+	rom ( serial "ULJS-00154" )
 )
 
 game (
 	name "ToCA Race Driver 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00040"
-	serial "ULES-00040"
+	rom ( serial "ULES-00040" )
 )
 
 game (
 	name "ToCA Race Driver 3 Challenge (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00613"
-	serial "ULES-00613"
+	rom ( serial "ULES-00613" )
 )
 
 game (
 	name "Toaru Kagaku no Railgun (Japan) (v1.02)"
-	serial "ULJS-00354"
-	serial "ULJS-00354"
+	rom ( serial "ULJS-00354" )
 )
 
 game (
 	name "Toaru Majutsu no Index (Japan) (v1.02)"
-	serial "ULJS-00329"
-	serial "ULJS-00329"
+	rom ( serial "ULJS-00329" )
 )
 
 game (
 	name "Tobidase! Trouble Hanafuda Douchuuki (Japan) (v1.02)"
-	serial "ULJM-05207"
-	serial "ULJM-05207"
+	rom ( serial "ULJM-05207" )
 )
 
 game (
 	name "Togainu no Chi - True Blood Portable (Japan) (v1.03)"
-	serial "ULJM-05795"
-	serial "ULJM-05795"
+	rom ( serial "ULJM-05795" )
 )
 
 game (
 	name "Tokimeki Memorial - Forever With You (Japan) (v1.02)"
-	serial "ULJM-05078"
-	serial "ULJM-05078"
+	rom ( serial "ULJM-05078" )
 )
 
 game (
 	name "Tokimeki Memorial 4 (Japan) (v1.01)"
-	serial "NPJH-50127"
-	serial "NPJH-50127"
+	rom ( serial "NPJH-50127" )
 )
 
 game (
 	name "Tokimeki Memorial Girl's Side Premium - 3rd Story (Japan) (v1.01)"
-	serial "ULJM-05976"
-	serial "ULJM-05976"
+	rom ( serial "ULJM-05976" )
 )
 
 game (
 	name "Tokobot (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00312"
-	serial "ULES-00312"
+	rom ( serial "ULES-00312" )
 )
 
 game (
 	name "Tokobot (USA) (v1.02)"
-	serial "ULUS-10061"
-	serial "ULUS-10061"
+	rom ( serial "ULUS-10061" )
 )
 
 game (
 	name "Tokyo Mono Harashi - Karasu no Mori Gakuen Kitan (Japan) (v1.04)"
-	serial "NPJH-50215"
-	serial "NPJH-50215"
+	rom ( serial "NPJH-50215" )
 )
 
 game (
 	name "Tom Clancy's EndWar (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "ULES-01068"
-	serial "ULES-01068"
+	rom ( serial "ULES-01068" )
 )
 
 game (
 	name "Tom Clancy's EndWar (USA) (v1.01)"
-	serial "ULUS-10358"
-	serial "ULUS-10358"
+	rom ( serial "ULUS-10358" )
 )
 
 game (
 	name "Tom Clancy's Ghost Recon - Advanced Warfighter 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00770"
-	serial "ULES-00770"
+	rom ( serial "ULES-00770" )
 )
 
 game (
 	name "Tom Clancy's Ghost Recon - Advanced Warfighter 2 (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10237"
-	serial "ULUS-10237"
+	rom ( serial "ULUS-10237" )
 )
 
 game (
 	name "Tom Clancy's Ghost Recon - Predator (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01350"
-	serial "ULES-01350"
+	rom ( serial "ULES-01350" )
 )
 
 game (
 	name "Tom Clancy's Ghost Recon - Predator (USA) (En,Fr,Es)"
-	serial "ULUS-10445"
-	serial "ULUS-10445"
+	rom ( serial "ULUS-10445" )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six - Vegas (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00584"
-	serial "ULES-00584"
+	rom ( serial "ULES-00584" )
 )
 
 game (
 	name "Tom Clancy's Rainbow Six - Vegas (USA) (En,Fr,Es) (v1.02)"
-	serial "ULUS-10206"
-	serial "ULUS-10206"
+	rom ( serial "ULUS-10206" )
 )
 
 game (
 	name "Tom Clancy's Splinter Cell - Essentials (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00281"
-	serial "ULES-00281"
+	rom ( serial "ULES-00281" )
 )
 
 game (
 	name "Tom Clancy's Splinter Cell - Essentials (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "ULES-00281"
-	serial "ULES-00281"
 )
 
 game (
 	name "Tom Clancy's Splinter Cell - Essentials (USA) (v1.02)"
-	serial "ULUS-10070"
-	serial "ULUS-10070"
+	rom ( serial "ULUS-10070" )
 )
 
 game (
 	name "Tomb Raider - Anniversary (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00826"
-	serial "ULES-00826"
+	rom ( serial "ULES-00826" )
 )
 
 game (
 	name "Tomb Raider - Anniversary (Japan)"
-	serial "ULJS-00133"
-	serial "ULJS-00133"
+	rom ( serial "ULJS-00133" )
 )
 
 game (
 	name "Tomb Raider - Anniversary (USA) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10253"
-	serial "ULUS-10253"
+	rom ( serial "ULUS-10253" )
 )
 
 game (
 	name "Tomb Raider - Legend (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00283"
-	serial "ULES-00283"
+	rom ( serial "ULES-00283" )
 )
 
 game (
 	name "Tomb Raider - Legend (Japan) (v1.01)"
-	serial "ULJM-05180"
-	serial "ULJM-05180"
+	rom ( serial "ULJM-05180" )
 )
 
 game (
 	name "Tomb Raider - Legend (USA) (v1.02)"
-	serial "ULUS-10110"
-	serial "ULUS-10110"
+	rom ( serial "ULUS-10110" )
 )
 
 game (
 	name "Tomoyo After - It's a Wonderful Life - CS Edition (Japan)"
-	serial "ULJM-05411"
-	serial "ULJM-05411"
+	rom ( serial "ULJM-05411" )
 )
 
 game (
 	name "Tony Hawk's Underground 2 Remix (Europe) (v1.03)"
-	serial "ULES-00033"
-	serial "ULES-00033"
+	rom ( serial "ULES-00033" )
 )
 
 game (
 	name "Tony Hawk's Underground 2 Remix (France) (v1.03)"
-	serial "ULES-00034"
-	serial "ULES-00034"
+	rom ( serial "ULES-00034" )
 )
 
 game (
 	name "Tony Hawk's Underground 2 Remix (Germany) (v1.03)"
-	serial "ULES-00035"
-	serial "ULES-00035"
+	rom ( serial "ULES-00035" )
 )
 
 game (
 	name "Tony Hawk's Underground 2 Remix (USA) (v1.01)"
-	serial "ULUS-10014"
-	serial "ULUS-10014"
+	rom ( serial "ULUS-10014" )
 )
 
 game (
 	name "Tora Dora Portable! (Japan)"
-	serial "ULJS-00186"
-	serial "ULJS-00186"
+	rom ( serial "ULJS-00186" )
 )
 
 game (
 	name "Toriko - Gourmet Survival (Japan) (v1.01)"
-	serial "NPJH-50470"
-	serial "NPJH-50470"
+	rom ( serial "NPJH-50470" )
 )
 
 game (
 	name "Toriko - Gourmet Survival 2 (Japan) (v1.01)"
-	serial "NPJH-50564"
-	serial "NPJH-50564"
+	rom ( serial "NPJH-50564" )
 )
 
 game (
 	name "Toudai Shogi - Mejinsen Dojo (Japan) (v1.01)"
-	serial "ULJM-05747"
-	serial "ULJM-05747"
+	rom ( serial "ULJM-05747" )
 )
 
 game (
 	name "Toy Story 3 (Europe) (En,Es) (v1.01)"
-	serial "ULES-01406"
-	serial "ULES-01406"
+	rom ( serial "ULES-01406" )
 )
 
 game (
 	name "Toy Story 3 (Europe) (Fr,De,It,Nl)"
-	serial "ULES-01405"
-	serial "ULES-01405"
+	rom ( serial "ULES-01405" )
 )
 
 game (
 	name "Toy Story 3 (USA) (En,Fr,Es)"
-	serial "ULUS-10507"
-	serial "ULUS-10507"
+	rom ( serial "ULUS-10507" )
 )
 
 game (
 	name "Transformers - Revenge of the Fallen (Asia)"
-	serial "ULUS-10433"
-	serial "ULUS-10433"
+	rom ( serial "ULUS-10433" )
 )
 
 game (
 	name "Transformers - Revenge of the Fallen (Europe) (En,Fr)"
-	serial "ULES-01286"
-	serial "ULES-01286"
+	rom ( serial "ULES-01286" )
 )
 
 game (
 	name "Transformers - Revenge of the Fallen (Europe) (Es,It)"
-	serial "ULES-01287"
-	serial "ULES-01287"
+	rom ( serial "ULES-01287" )
 )
 
 game (
 	name "Transformers - Revenge of the Fallen (USA)"
-	serial "ULUS-10433"
-	serial "ULUS-10433"
 )
 
 game (
 	name "Transformers - The Game (Europe) (De,It) (v1.02)"
-	serial "ULES-00824"
-	serial "ULES-00824"
+	rom ( serial "ULES-00824" )
 )
 
 game (
 	name "Transformers - The Game (Europe) (Fr,Es) (v1.02)"
-	serial "ULES-00825"
-	serial "ULES-00825"
+	rom ( serial "ULES-00825" )
 )
 
 game (
 	name "Transformers - The Game (Europe) (v1.02)"
-	serial "ULES-00823"
-	serial "ULES-00823"
+	rom ( serial "ULES-00823" )
 )
 
 game (
 	name "Transformers - The Game (USA) (v1.02)"
-	serial "ULUS-10274"
-	serial "ULUS-10274"
+	rom ( serial "ULUS-10274" )
 )
 
 game (
 	name "Traxxpad - Portable Studio (USA) (v1.02)"
-	serial "ULUS-10272"
-	serial "ULUS-10272"
+	rom ( serial "ULUS-10272" )
 )
 
 game (
 	name "Trick x Logic - Season 1 (Japan)"
-	serial "UCJS-10097"
-	serial "UCJS-10097"
+	rom ( serial "UCJS-10097" )
 )
 
 game (
 	name "Trick x Logic - Season 2 (Japan)"
-	serial "UCJS-10105"
-	serial "UCJS-10105"
+	rom ( serial "UCJS-10105" )
 )
 
 game (
 	name "Tsugi no Giseisha o Oshirase Shimasu - Houkaisuru Sekai ni Shinigami to (Japan)"
-	serial "ULJM-05948"
-	serial "ULJM-05948"
+	rom ( serial "ULJM-05948" )
 )
 
 game (
 	name "Tsugi no Giseisha o Oshirase Shimasu - Kimi to Ko no Hateru Kotonai Kurayami o (Japan) (v1.01)"
-	serial "ULJM-05946"
-	serial "ULJM-05946"
+	rom ( serial "ULJM-05946" )
 )
 
 game (
 	name "Tsugi no Giseisha o Oshirase Shimasu - Shi to Zetsubou o Nori Koete (Japan) (v1.01)"
-	serial "ULJM-05947"
-	serial "ULJM-05947"
+	rom ( serial "ULJM-05947" )
 )
 
 game (
 	name "Tsukumonogatari (Japan) (v1.01)"
-	serial "ULJM-05755"
-	serial "ULJM-05755"
+	rom ( serial "ULJM-05755" )
 )
 
 game (
 	name "Tsuyo Kiss 2-Gakki Portable (Japan) (v1.03)"
-	serial "ULJM-05750"
-	serial "ULJM-05750"
+	rom ( serial "ULJM-05750" )
 )
 
 game (
 	name "Tsuyo Kiss 3-Gakki Portable (Japan)"
-	serial "ULJM-05910"
-	serial "ULJM-05910"
+	rom ( serial "ULJM-05910" )
 )
 
 game (
 	name "Twelve - Sengoku Fuushinden (Japan) (v1.01)"
-	serial "ULJM-05031"
-	serial "ULJM-05031"
+	rom ( serial "ULJM-05031" )
 )
 
 game (
 	name "TwinBee Portable (Japan) (v1.01)"
-	serial "ULJM-05221"
-	serial "ULJM-05221"
+	rom ( serial "ULJM-05221" )
 )
 
 game (
 	name "Twinkle Crusaders GoGo! (Japan) (v1.01)"
-	serial "ULJS-00316"
-	serial "ULJS-00316"
+	rom ( serial "ULJS-00316" )
 )
 
 game (
 	name "Twinkle Crusaders Starlit Brave (Japan) (v1.01)"
-	serial "ULJS-00315"
-	serial "ULJS-00315"
+	rom ( serial "ULJS-00315" )
 )
 
 game (
 	name "Twisted Metal - Head On (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-00018"
-	serial "UCES-00018"
+	rom ( serial "UCES-00018" )
 )
 
 game (
 	name "Twisted Metal - Head On (USA) (v2.00)"
-	serial "UCUS-98601"
-	serial "UCUS-98601"
+	rom ( serial "UCUS-98601" )
 )
 
 game (
 	name "UEFA Champions League 2006-2007 (Europe)"
-	serial "ULES-00699"
-	serial "ULES-00699"
+	rom ( serial "ULES-00699" )
 )
 
 game (
 	name "UEFA Champions League 2006-2007 (Germany)"
-	serial "ULES-00708"
-	serial "ULES-00708"
+	rom ( serial "ULES-00708" )
 )
 
 game (
 	name "UEFA Champions League 2006-2007 (Italy) [b]"
-	serial "ULES-00707"
-	serial "ULES-00707"
+	rom ( serial "ULES-00707" )
 )
 
 game (
 	name "UEFA Champions League 2006-2007 (USA) (v1.01)"
-	serial "ULUS-10221"
-	serial "ULUS-10221"
+	rom ( serial "ULUS-10221" )
 )
 
 game (
 	name "UEFA Euro 2008 (Europe) (En,Fr,De)"
-	serial "ULES-01025"
-	serial "ULES-01025"
+	rom ( serial "ULES-01025" )
 )
 
 game (
 	name "UEFA Euro 2008 (Europe) (Es,It)"
-	serial "ULES-01038"
-	serial "ULES-01038"
+	rom ( serial "ULES-01038" )
 )
 
 game (
 	name "UEFA Euro 2008 (USA) (v1.01)"
-	serial "ULUS-10337"
-	serial "ULUS-10337"
+	rom ( serial "ULUS-10337" )
 )
 
 game (
 	name "UFC Undisputed 2010 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01410"
-	serial "ULES-01410"
+	rom ( serial "ULES-01410" )
 )
 
 game (
 	name "Ultimate Board Game Collection (Asia) (En,Fr,De,Es,It)"
-	serial "ULES-01017"
-	serial "ULES-01017"
+	rom ( serial "ULES-01017" )
 )
 
 game (
 	name "Ultimate Board Game Collection (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01017"
-	serial "ULES-01017"
 )
 
 game (
 	name "Ultimate Board Game Collection (USA) (v1.02)"
-	serial "ULUS-10254"
-	serial "ULUS-10254"
+	rom ( serial "ULUS-10254" )
 )
 
 game (
 	name "Ultimate Ghosts 'n Goblins (Asia)"
-	serial "ULAS-42073"
-	serial "ULAS-42073"
+	rom ( serial "ULAS-42073" )
 )
 
 game (
 	name "Ultimate Ghosts 'n Goblins (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00419"
-	serial "ULES-00419"
+	rom ( serial "ULES-00419" )
 )
 
 game (
 	name "Ultimate Ghosts 'n Goblins (USA)"
-	serial "ULUS-10105"
-	serial "ULUS-10105"
+	rom ( serial "ULUS-10105" )
 )
 
 game (
 	name "Ultraman - Fighting Evolution 0 (Japan) (v1.02)"
-	serial "ULJS-00069"
-	serial "ULJS-00069"
+	rom ( serial "ULJS-00069" )
 )
 
 game (
 	name "Umezawa Yukari no Yasashii Igo (Japan) (v1.01)"
-	serial "ULJM-05384"
-	serial "ULJM-05384"
+	rom ( serial "ULJM-05384" )
 )
 
 game (
 	name "Umihara Kawase Portable (Japan) (v1.02)"
-	serial "ULJS-00137"
-	serial "ULJS-00137"
+	rom ( serial "ULJS-00137" )
 )
 
 game (
 	name "Umineko no Naku Koro ni Portable 1 (Japan)"
-	serial "ULJM-05968"
-	serial "ULJM-05968"
+	rom ( serial "ULJM-05968" )
 )
 
 game (
 	name "Umineko no Naku Koro ni Portable 2 (Japan) (v1.01)"
-	serial "ULJM-05969"
-	serial "ULJM-05969"
+	rom ( serial "ULJM-05969" )
 )
 
 game (
 	name "UnENDing BloodyCall (Japan) (v1.01)"
-	serial "ULJM-06079"
-	serial "ULJM-06079"
+	rom ( serial "ULJM-06079" )
 )
 
 game (
 	name "UnchainBlades ReXX (Japan) (v1.03)"
-	serial "ULJM-05756"
-	serial "ULJM-05756"
+	rom ( serial "ULJM-05756" )
 )
 
 game (
 	name "Undead Knights (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01390"
-	serial "ULES-01390"
+	rom ( serial "ULES-01390" )
 )
 
 game (
 	name "Undead Knights (Japan) (v1.01)"
-	serial "ULJM-05530"
-	serial "ULJM-05530"
+	rom ( serial "ULJM-05530" )
 )
 
 game (
 	name "Undead Knights (USA) (v1.04)"
-	serial "ULUS-10453"
-	serial "ULUS-10453"
+	rom ( serial "ULUS-10453" )
 )
 
 game (
 	name "Untold Legends - Brotherhood of the Blade (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00046"
-	serial "ULES-00046"
+	rom ( serial "ULES-00046" )
 )
 
 game (
 	name "Untold Legends - Brotherhood of the Blade (USA) (v1.02)"
-	serial "ULUS-10003"
-	serial "ULUS-10003"
+	rom ( serial "ULUS-10003" )
 )
 
 game (
 	name "Untold Legends - The Warrior's Code (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00301"
-	serial "ULES-00301"
+	rom ( serial "ULES-00301" )
 )
 
 game (
 	name "Untold Legends - The Warrior's Code (Japan) (v1.03)"
-	serial "ULJM-05179"
-	serial "ULJM-05179"
+	rom ( serial "ULJM-05179" )
 )
 
 game (
 	name "Untold Legends - The Warrior's Code (USA) (v1.02)"
-	serial "ULUS-10086"
-	serial "ULUS-10086"
+	rom ( serial "ULUS-10086" )
 )
 
 game (
 	name "Up (Europe) (En,Fr) (v1.01)"
-	serial "ULES-01253"
-	serial "ULES-01253"
+	rom ( serial "ULES-01253" )
 )
 
 game (
 	name "Up (Italy)"
-	serial "ULES-01257"
-	serial "ULES-01257"
+	rom ( serial "ULES-01257" )
 )
 
 game (
 	name "Up (Netherlands)"
-	serial "ULES-01263"
-	serial "ULES-01263"
+	rom ( serial "ULES-01263" )
 )
 
 game (
 	name "Up (Russia) (v1.01)"
-	serial "ULES-01255"
-	serial "ULES-01255"
+	rom ( serial "ULES-01255" )
 )
 
 game (
 	name "Up (Spain) [b]"
-	serial "ULES-01256"
-	serial "ULES-01256"
+	rom ( serial "ULES-01256" )
 )
 
 game (
 	name "Up (USA)"
-	serial "ULUS-10430"
-	serial "ULUS-10430"
+	rom ( serial "ULUS-10430" )
 )
 
 game (
 	name "Uta no Prince Sama (Japan) (v2.00)"
-	serial "NPJH-50269"
-	serial "NPJH-50269"
+	rom ( serial "NPJH-50269" )
 )
 
 game (
 	name "Uta no Prince Sama - Amazing Aria (Japan) (v1.02)"
-	serial "NPJH-50381"
-	serial "NPJH-50381"
+	rom ( serial "NPJH-50381" )
 )
 
 game (
 	name "Uta no Prince Sama - Debut (Japan) (v1.02)"
-	serial "NPJH-50500"
-	serial "NPJH-50500"
+	rom ( serial "NPJH-50500" )
 )
 
 game (
 	name "Uta no Prince Sama - Music (Japan) (v1.01)"
-	serial "NPJH-50499"
-	serial "NPJH-50499"
+	rom ( serial "NPJH-50499" )
 )
 
 game (
 	name "Uta no Prince Sama - Repeat (Japan) (v1.01)"
-	serial "NPJH-50446"
-	serial "NPJH-50446"
+	rom ( serial "NPJH-50446" )
 )
 
 game (
 	name "Uta no Prince Sama - Sweet Serenade (Japan) (v1.01)"
-	serial "NPJH-50393"
-	serial "NPJH-50393"
+	rom ( serial "NPJH-50393" )
 )
 
 game (
 	name "Utawarerumono Portable (Japan) (v1.01)"
-	serial "ULJM-05458"
-	serial "ULJM-05458"
+	rom ( serial "ULJM-05458" )
 )
 
 game (
 	name "Valhalla Knights (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00657"
-	serial "ULES-00657"
+	rom ( serial "ULES-00657" )
 )
 
 game (
 	name "Valhalla Knights (Japan) (v1.03)"
-	serial "ULJS-00075"
-	serial "ULJS-00075"
+	rom ( serial "ULJS-00075" )
 )
 
 game (
 	name "Valhalla Knights (Korea)"
-	serial "ULKS-46133"
-	serial "ULKS-46133"
+	rom ( serial "ULKS-46133" )
 )
 
 game (
 	name "Valhalla Knights (USA) (v1.01)"
-	serial "ULUS-10230"
-	serial "ULUS-10230"
+	rom ( serial "ULUS-10230" )
 )
 
 game (
 	name "Valhalla Knights 2 (Europe)"
-	serial "ULES-01265"
-	serial "ULES-01265"
+	rom ( serial "ULES-01265" )
 )
 
 game (
 	name "Valhalla Knights 2 (Japan) (v1.03)"
-	serial "ULJS-00138"
-	serial "ULJS-00138"
+	rom ( serial "ULJS-00138" )
 )
 
 game (
 	name "Valhalla Knights 2 (USA)"
-	serial "ULUS-10366"
-	serial "ULUS-10366"
+	rom ( serial "ULUS-10366" )
 )
 
 game (
 	name "Valhalla Knights 2 - Battle Stance (Japan) (v1.01)"
-	serial "ULJS-00196"
-	serial "ULJS-00196"
+	rom ( serial "ULJS-00196" )
 )
 
 game (
 	name "Valkyria Chronicles II (Europe)"
-	serial "ULES-01417"
-	serial "ULES-01417"
+	rom ( serial "ULES-01417" )
 )
 
 game (
 	name "Valkyria Chronicles II (USA)"
-	serial "ULUS-10515"
-	serial "ULUS-10515"
+	rom ( serial "ULUS-10515" )
 )
 
 game (
 	name "Valkyrie Profile - Lenneth (Europe)"
-	serial "ULES-00724"
-	serial "ULES-00724"
+	rom ( serial "ULES-00724" )
 )
 
 game (
 	name "Valkyrie Profile - Lenneth (Japan) (v1.04)"
-	serial "ULJM-05101"
-	serial "ULJM-05101"
+	rom ( serial "ULJM-05101" )
 )
 
 game (
 	name "Valkyrie Profile - Lenneth (USA)"
-	serial "ULUS-10107"
-	serial "ULUS-10107"
+	rom ( serial "ULUS-10107" )
 )
 
 game (
 	name "Vantage Master Portable (Japan) (v1.01)"
-	serial "ULJM-05332"
-	serial "ULJM-05332"
+	rom ( serial "ULJM-05332" )
 )
 
 game (
 	name "Venus & Braves - Majo to Megami to Horobi no Yogen (Japan)"
-	serial "NPJH-50376"
-	serial "NPJH-50376"
+	rom ( serial "NPJH-50376" )
 )
 
 game (
 	name "Viewtiful Joe - Red Hot Rumble (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00256"
-	serial "ULES-00256"
+	rom ( serial "ULES-00256" )
 )
 
 game (
 	name "Viewtiful Joe - Red Hot Rumble (USA)"
-	serial "ULUS-10087"
-	serial "ULUS-10087"
+	rom ( serial "ULUS-10087" )
 )
 
 game (
 	name "Viorate no Atelier - Gramnad no Renkinjutsushi 2 - Gunjou no Omoide (Japan) (v1.01)"
-	serial "ULJM-05835"
-	serial "ULJM-05835"
+	rom ( serial "ULJM-05835" )
 )
 
 game (
 	name "Virtua Tennis - World Tour (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00126"
-	serial "ULES-00126"
+	rom ( serial "ULES-00126" )
 )
 
 game (
 	name "Virtua Tennis - World Tour (Korea) (v1.02)"
-	serial "ULKS-46023"
-	serial "ULKS-46023"
+	rom ( serial "ULKS-46023" )
 )
 
 game (
 	name "Virtua Tennis - World Tour (USA) (v1.02)"
-	serial "ULUS-10037"
-	serial "ULUS-10037"
+	rom ( serial "ULUS-10037" )
 )
 
 game (
 	name "Virtua Tennis 3 (Europe) (En,Ja,Fr,De,Es,It)"
-	serial "ULES-00763"
-	serial "ULES-00763"
+	rom ( serial "ULES-00763" )
 )
 
 game (
 	name "Virtua Tennis 3 (USA) (En,Ja,Fr,De,Es,It) (v1.02)"
-	serial "ULUS-10246"
-	serial "ULUS-10246"
+	rom ( serial "ULUS-10246" )
 )
 
 game (
 	name "VitaminX Detective B6 (Japan) (v1.01)"
-	serial "ULJS-00471"
-	serial "ULJS-00471"
+	rom ( serial "ULJS-00471" )
 )
 
 game (
 	name "VitaminX Evolution Plus (Japan) (v1.01)"
-	serial "ULJS-00325"
-	serial "ULJS-00325"
+	rom ( serial "ULJS-00325" )
 )
 
 game (
 	name "VitaminXtoZ (Japan) (v1.01)"
-	serial "ULJS-00347"
-	serial "ULJS-00347"
+	rom ( serial "ULJS-00347" )
 )
 
 game (
 	name "VitaminZ Revolution (Japan) (v1.02)"
-	serial "ULJS-00278"
-	serial "ULJS-00278"
+	rom ( serial "ULJS-00278" )
 )
 
 game (
 	name "Vulcanus (Japan) (v1.01)"
-	serial "ULJM-05187"
-	serial "ULJM-05187"
+	rom ( serial "ULJM-05187" )
 )
 
 game (
 	name "Vulcanus (Korea)"
-	serial "UCKS-45006"
-	serial "UCKS-45006"
+	rom ( serial "UCKS-45006" )
 )
 
 game (
 	name "WALL-E (Europe)"
-	serial "ULES-01072"
-	serial "ULES-01072"
+	rom ( serial "ULES-01072" )
 )
 
 game (
 	name "WALL-E (Europe) (En,Sv)"
-	serial "ULES-01074"
-	serial "ULES-01074"
+	rom ( serial "ULES-01074" )
 )
 
 game (
 	name "WALL-E (Europe) (Es,Pt) [b]"
-	serial "ULES-01075"
-	serial "ULES-01075"
+	rom ( serial "ULES-01075" )
 )
 
 game (
 	name "WALL-E (Europe) (Fr,Nl)"
-	serial "ULES-01076"
-	serial "ULES-01076"
+	rom ( serial "ULES-01076" )
 )
 
 game (
 	name "WALL-E (Europe) (No,Da) [b]"
-	serial "ULES-01073"
-	serial "ULES-01073"
+	rom ( serial "ULES-01073" )
 )
 
 game (
 	name "WALL-E (Germany)"
-	serial "ULES-01082"
-	serial "ULES-01082"
+	rom ( serial "ULES-01082" )
 )
 
 game (
 	name "WALL-E (Italy)"
-	serial "ULES-01080"
-	serial "ULES-01080"
+	rom ( serial "ULES-01080" )
 )
 
 game (
 	name "WALL-E (Russia) [b]"
-	serial "ULES-01081"
-	serial "ULES-01081"
+	rom ( serial "ULES-01081" )
 )
 
 game (
 	name "WALL-E (USA) (En,Fr)"
-	serial "ULUS-10350"
-	serial "ULUS-10350"
+	rom ( serial "ULUS-10350" )
 )
 
 game (
 	name "WRC - FIA World Rally Championship (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "UCES-00005"
-	serial "UCES-00005"
+	rom ( serial "UCES-00005" )
 )
 
 game (
 	name "WRC - FIA World Rally Championship (Japan) (v1.02)"
-	serial "ULJM-05114"
-	serial "ULJM-05114"
+	rom ( serial "ULJM-05114" )
 )
 
 game (
 	name "WRC - FIA World Rally Championship (USA) (v1.01)"
-	serial "ULUS-10093"
-	serial "ULUS-10093"
+	rom ( serial "ULUS-10093" )
 )
 
 game (
 	name "WTF - Work Time Fun (USA) (Beta) [b]"
-	serial "ULUX-80234"
-	serial "ULUX-80234"
+	rom ( serial "ULUX-80234" )
 )
 
 game (
 	name "WTF - Work Time Fun (USA) (v1.01)"
-	serial "ULUS-10172"
-	serial "ULUS-10172"
+	rom ( serial "ULUS-10172" )
 )
 
 game (
 	name "WWE All-Stars (Europe)"
-	serial "ULES-01510"
-	serial "ULES-01510"
+	rom ( serial "ULES-01510" )
 )
 
 game (
 	name "WWE All-Stars (USA)"
-	serial "ULUS-10544"
-	serial "ULUS-10544"
+	rom ( serial "ULUS-10544" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2006 (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-00227"
-	serial "ULES-00227"
+	rom ( serial "ULES-00227" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2006 (Korea) (v1.02)"
-	serial "ULKS-46057"
-	serial "ULKS-46057"
+	rom ( serial "ULKS-46057" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2006 (USA) (v1.02)"
-	serial "ULUS-10050"
-	serial "ULUS-10050"
+	rom ( serial "ULUS-10050" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2007 (Europe) (v1.02)"
-	serial "ULES-00631"
-	serial "ULES-00631"
+	rom ( serial "ULES-00631" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2007 (Japan) (v1.01)"
-	serial "ULJM-05233"
-	serial "ULJM-05233"
+	rom ( serial "ULJM-05233" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2007 (Korea) (v1.01)"
-	serial "ULKS-46125"
-	serial "ULKS-46125"
+	rom ( serial "ULKS-46125" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2007 (USA) (v1.03)"
-	serial "ULUS-10199"
-	serial "ULUS-10199"
+	rom ( serial "ULUS-10199" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2008 featuring ECW (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00932"
-	serial "ULES-00932"
+	rom ( serial "ULES-00932" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2008 featuring ECW (Europe) (v1.01)"
-	serial "ULES-00931"
-	serial "ULES-00931"
+	rom ( serial "ULES-00931" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2008 featuring ECW (USA)"
-	serial "ULUS-10281"
-	serial "ULUS-10281"
+	rom ( serial "ULUS-10281" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2009 featuring ECW (Europe)"
-	serial "ULES-01165"
-	serial "ULES-01165"
+	rom ( serial "ULES-01165" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2009 featuring ECW (Europe) (En,Fr,De,Es,It)"
-	serial "ULES-01166"
-	serial "ULES-01166"
+	rom ( serial "ULES-01166" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2009 featuring ECW (USA)"
-	serial "ULUS-10384"
-	serial "ULUS-10384"
+	rom ( serial "ULUS-10384" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2010 featuring ECW (Europe) (v1.01)"
-	serial "ULES-01339"
-	serial "ULES-01339"
+	rom ( serial "ULES-01339" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2010 featuring ECW (USA)"
-	serial "ULUS-10452"
-	serial "ULUS-10452"
+	rom ( serial "ULUS-10452" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2011 (Europe) (v1.01)"
-	serial "ULES-01472"
-	serial "ULES-01472"
+	rom ( serial "ULES-01472" )
 )
 
 game (
 	name "WWE SmackDown! vs. RAW 2011 (USA)"
-	serial "ULUS-10543"
-	serial "ULUS-10543"
+	rom ( serial "ULUS-10543" )
 )
 
 game (
 	name "WWII - Battle Over the Pacific (Europe) (v1.01)"
-	serial "ULES-00974"
-	serial "ULES-00974"
+	rom ( serial "ULES-00974" )
 )
 
 game (
 	name "Wand of Fortune - Mirai e no Prologue Portable (Japan) (v1.01)"
-	serial "ULJM-05783"
-	serial "ULJM-05783"
+	rom ( serial "ULJM-05783" )
 )
 
 game (
 	name "Wand of Fortune 2 - Jikuu ni Shizumu Mokushiroku (Japan) (v1.02)"
-	serial "ULJM-05834"
-	serial "ULJM-05834"
+	rom ( serial "ULJM-05834" )
 )
 
 game (
 	name "Wand of Fortune 2 FD - Kimi ni Sasageru Epilogue (Japan) (v1.01)"
-	serial "ULJM-06194"
-	serial "ULJM-06194"
+	rom ( serial "ULJM-06194" )
 )
 
 game (
 	name "Wand of Fortune Portable (Japan)"
-	serial "ULJM-05689"
-	serial "ULJM-05689"
+	rom ( serial "ULJM-05689" )
 )
 
 game (
 	name "Wangan Midnight Portable (Japan) (v1.02)"
-	serial "ULJM-05264"
-	serial "ULJM-05264"
+	rom ( serial "ULJM-05264" )
 )
 
 game (
 	name "Warhammer - Battle for Atluma (USA) (v1.03)"
-	serial "ULUS-10123"
-	serial "ULUS-10123"
+	rom ( serial "ULUS-10123" )
 )
 
 game (
 	name "Warhammer 40,000 - Squad Command (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00873"
-	serial "ULES-00873"
+	rom ( serial "ULES-00873" )
 )
 
 game (
 	name "Warhammer 40,000 - Squad Command (USA) (En,Fr) (v1.01)"
-	serial "ULUS-10313"
-	serial "ULUS-10313"
+	rom ( serial "ULUS-10313" )
 )
 
 game (
 	name "Warning - Code de La Route (France)"
-	serial "ULES-01103"
-	serial "ULES-01103"
+	rom ( serial "ULES-01103" )
 )
 
 game (
 	name "Warriors Orochi (Europe)"
-	serial "ULES-01054"
-	serial "ULES-01054"
+	rom ( serial "ULES-01054" )
 )
 
 game (
 	name "Warriors Orochi (France)"
-	serial "ULES-01055"
-	serial "ULES-01055"
+	rom ( serial "ULES-01055" )
 )
 
 game (
 	name "Warriors Orochi (Germany)"
-	serial "ULES-01056"
-	serial "ULES-01056"
+	rom ( serial "ULES-01056" )
 )
 
 game (
 	name "Warriors Orochi (USA)"
-	serial "ULUS-10341"
-	serial "ULUS-10341"
+	rom ( serial "ULUS-10341" )
 )
 
 game (
 	name "Warriors Orochi 2 (Europe) (En,Fr) (v1.01)"
-	serial "ULES-01261"
-	serial "ULES-01261"
+	rom ( serial "ULES-01261" )
 )
 
 game (
 	name "Warriors Orochi 2 (Germany) (v1.01)"
-	serial "ULES-01262"
-	serial "ULES-01262"
+	rom ( serial "ULES-01262" )
 )
 
 game (
 	name "Warriors Orochi 2 (USA) (En,Fr) (v1.02)"
-	serial "ULUS-10423"
-	serial "ULUS-10423"
+	rom ( serial "ULUS-10423" )
 )
 
 game (
 	name "Warriors of the Lost Empire (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00924"
-	serial "ULES-00924"
+	rom ( serial "ULES-00924" )
 )
 
 game (
 	name "Warriors of the Lost Empire (USA) (En,Fr,Es) (v1.03)"
-	serial "ULUS-10309"
-	serial "ULUS-10309"
+	rom ( serial "ULUS-10309" )
 )
 
 game (
 	name "Warriors, The (Europe) (v1.02)"
-	serial "ULES-00483"
-	serial "ULES-00483"
+	rom ( serial "ULES-00483" )
 )
 
 game (
 	name "Warriors, The (USA) (v1.02)"
-	serial "ULUS-10213"
-	serial "ULUS-10213"
+	rom ( serial "ULUS-10213" )
 )
 
 game (
 	name "Warship Gunner 2 Portable (Japan) (v1.01)"
-	serial "ULJM-05553"
-	serial "ULJM-05553"
+	rom ( serial "ULJM-05553" )
 )
 
 game (
 	name "We Love Juggler (Japan) (v1.01)"
-	serial "ULJS-00283"
-	serial "ULJS-00283"
+	rom ( serial "ULJS-00283" )
 )
 
 game (
 	name "Weiss Schwarz Portable - Boost Schwarz (Japan) (v1.02)"
-	serial "ULJS-00420"
-	serial "ULJS-00420"
+	rom ( serial "ULJS-00420" )
 )
 
 game (
 	name "Weiss Schwarz Portable - Boost Weiss (Japan) (v1.02)"
-	serial "ULJS-00422"
-	serial "ULJS-00422"
+	rom ( serial "ULJS-00422" )
 )
 
 game (
 	name "White Breath - Perfect Edition (Japan) (v1.04)"
-	serial "ULJM-05730"
-	serial "ULJM-05730"
+	rom ( serial "ULJM-05730" )
 )
 
 game (
 	name "White Knight Chronicles - Origins (Europe) (En,Fr,De,Es,It)"
-	serial "UCES-01511"
-	serial "UCES-01511"
+	rom ( serial "UCES-01511" )
 )
 
 game (
 	name "Who Wants to Be a Millionaire - Party Edition (Europe) (v1.02)"
-	serial "ULES-00540"
-	serial "ULES-00540"
+	rom ( serial "ULES-00540" )
 )
 
 game (
 	name "Wild Arms XF (Europe)"
-	serial "ULES-01085"
-	serial "ULES-01085"
+	rom ( serial "ULES-01085" )
 )
 
 game (
 	name "Wild Arms XF (Japan)"
-	serial "UCJS-10049"
-	serial "UCJS-10049"
+	rom ( serial "UCJS-10049" )
 )
 
 game (
 	name "Wild Arms XF (USA)"
-	serial "ULUS-10339"
-	serial "ULUS-10339"
+	rom ( serial "ULUS-10339" )
 )
 
 game (
 	name "Will O' Wisp Portable (Japan) (v1.02)"
-	serial "ULJM-05447"
-	serial "ULJM-05447"
+	rom ( serial "ULJM-05447" )
 )
 
 game (
 	name "Williams Pinball Classics (Europe) (En,Fr,De,Es) (v2.01)"
-	serial "ULES-01014"
-	serial "ULES-01014"
+	rom ( serial "ULES-01014" )
 )
 
 game (
 	name "Win-JPT - Primary (Korea) (v1.02)"
-	serial "ULKS-46033"
-	serial "ULKS-46033"
+	rom ( serial "ULKS-46033" )
 )
 
 game (
 	name "Win-TOEIC Beginners' LC (Korea) (v1.02)"
-	serial "ULKS-46018"
-	serial "ULKS-46018"
+	rom ( serial "ULKS-46018" )
 )
 
 game (
 	name "Win-TOEIC Beginners' RC (Korea) (v1.02)"
-	serial "ULKS-46019"
-	serial "ULKS-46019"
+	rom ( serial "ULKS-46019" )
 )
 
 game (
 	name "Winglish - Oh's Talk English (Korea)"
-	serial "ULKS-46082"
-	serial "ULKS-46082"
-)
-
-game (
-	name "Winglish - Oh's Talk English (Korea)"
-	serial "ULKS-46082"
-	serial "ULKS-46082"
+	rom ( serial "ULKS-46082" )
 )
 
 game (
 	name "Winning Post 6 2006 (Japan) (v1.05)"
-	serial "ULJM-05095"
-	serial "ULJM-05095"
+	rom ( serial "ULJM-05095" )
 )
 
 game (
 	name "Winning Post 6 2008 (Japan) (v1.01)"
-	serial "ULJM-05341"
-	serial "ULJM-05341"
+	rom ( serial "ULJM-05341" )
 )
 
 game (
 	name "Winning Post 7 2009 (Japan) (v1.01)"
-	serial "ULJM-05546"
-	serial "ULJM-05546"
+	rom ( serial "ULJM-05546" )
 )
 
 game (
 	name "Winning Post 7 2010 (Japan) (v1.01)"
-	serial "ULJM-05739"
-	serial "ULJM-05739"
+	rom ( serial "ULJM-05739" )
 )
 
 game (
 	name "Winning Post 7 2012 (Japan) (v1.02)"
-	serial "ULJM-06038"
-	serial "ULJM-06038"
+	rom ( serial "ULJM-06038" )
 )
 
 game (
 	name "Winx Club - Join the Club (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00611"
-	serial "ULES-00611"
+	rom ( serial "ULES-00611" )
 )
 
 game (
 	name "Winx Club - Join the Club (USA) (v1.05)"
-	serial "ULUS-10212"
-	serial "ULUS-10212"
+	rom ( serial "ULUS-10212" )
 )
 
 game (
 	name "WipEout Pulse (Asia) (En,Fr,De,Es,It)"
-	serial "UCAS-40179"
-	serial "UCAS-40179"
+	rom ( serial "UCAS-40179" )
 )
 
 game (
 	name "WipEout Pulse (Europe) (En,Fr,De,Es,It) (Promo)"
-	serial "UCET-00713"
-	serial "UCET-00713"
+	rom ( serial "UCET-00713" )
 )
 
 game (
 	name "WipEout Pulse (Europe) (En,Fr,De,Es,It) (v0.07) (Demo)"
-	serial "UCET-00713"
-	serial "UCET-00713"
 )
 
 game (
 	name "WipEout Pulse (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00465"
-	serial "UCES-00465"
+	rom ( serial "UCES-00465" )
 )
 
 game (
 	name "WipEout Pulse (USA) (En,Fr,De,Es,It)"
-	serial "UCUS-98712"
-	serial "UCUS-98712"
+	rom ( serial "UCUS-98712" )
 )
 
 game (
 	name "WipEout Pulse (USA) (En,Fr,De,Es,It) (Promo)"
-	serial "UCUS-98712"
-	serial "UCUS-98712"
 )
 
 game (
 	name "WipEout Pure (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00001"
-	serial "UCES-00001"
+	rom ( serial "UCES-00001" )
 )
 
 game (
 	name "WipEout Pure (Japan) (En,Ja) (v1.02)"
-	serial "UCJS-10007"
-	serial "UCJS-10007"
+	rom ( serial "UCJS-10007" )
 )
 
 game (
 	name "WipEout Pure (Korea) (v1.01)"
-	serial "UCKS-45008"
-	serial "UCKS-45008"
+	rom ( serial "UCKS-45008" )
 )
 
 game (
 	name "WipEout Pure (USA) (En,Fr,Es) (v1.04)"
-	serial "UCUS-98612"
-	serial "UCUS-98612"
+	rom ( serial "UCUS-98612" )
 )
 
 game (
 	name "WipEout Pure (USA) (En,Fr,Es) (v2.00)"
-	serial "UCUS-98612"
-	serial "UCUS-98612"
 )
 
 game (
 	name "Wizardry Empire III - Haou no Keifu (Japan) (v1.01)"
-	serial "ULJM-05218"
-	serial "ULJM-05218"
+	rom ( serial "ULJM-05218" )
 )
 
 game (
 	name "World Championship Cards (USA) (v1.05)"
-	serial "ULUS-10226"
-	serial "ULUS-10226"
+	rom ( serial "ULUS-10226" )
 )
 
 game (
 	name "World Championship Poker 2 (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00635"
-	serial "ULES-00635"
+	rom ( serial "ULES-00635" )
 )
 
 game (
 	name "World Championship Poker featuring Howard Lederer - All In (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00681"
-	serial "ULES-00681"
+	rom ( serial "ULES-00681" )
 )
 
 game (
 	name "World Championship Poker featuring Howard Lederer - All In (USA) (v1.01)"
-	serial "ULUS-10145"
-	serial "ULUS-10145"
+	rom ( serial "ULUS-10145" )
 )
 
 game (
 	name "World Neverland - The Nalulu Kingdom Stories (Japan)"
-	serial "NPJH-00054"
-	serial "NPJH-00054"
+	rom ( serial "NPJH-00054" )
 )
 
 game (
 	name "World Neverland 2 in 1 Portable - Olerud Oukoku Monogatari & Pluto Kyouwakoku Monogatari (Japan) (v1.01)"
-	serial "ULJS-00044"
-	serial "ULJS-00044"
+	rom ( serial "ULJS-00044" )
 )
 
 game (
 	name "World Poker Tour (Europe) (En,Fr,De) (v1.01)"
-	serial "ULES-00296"
-	serial "ULES-00296"
+	rom ( serial "ULES-00296" )
 )
 
 game (
 	name "World Poker Tour (USA) (v1.06)"
-	serial "ULUS-10079"
-	serial "ULUS-10079"
+	rom ( serial "ULUS-10079" )
 )
 
 game (
 	name "World Series of Poker (Europe)"
-	serial "ULES-00224"
-	serial "ULES-00224"
+	rom ( serial "ULES-00224" )
 )
 
 game (
 	name "World Series of Poker (USA)"
-	serial "ULUS-10047"
-	serial "ULUS-10047"
+	rom ( serial "ULUS-10047" )
 )
 
 game (
 	name "World Series of Poker - Tournament of Champions - 2007 Edition (Europe) (v1.01)"
-	serial "ULES-00591"
-	serial "ULES-00591"
+	rom ( serial "ULES-00591" )
 )
 
 game (
 	name "World Series of Poker - Tournament of Champions - 2007 Edition (USA)"
-	serial "ULUS-10162"
-	serial "ULUS-10162"
+	rom ( serial "ULUS-10162" )
 )
 
 game (
 	name "World Series of Poker 2008 - Battle for the Bracelets (Europe)"
-	serial "ULES-00991"
-	serial "ULES-00991"
+	rom ( serial "ULES-00991" )
 )
 
 game (
 	name "World Series of Poker 2008 - Battle for the Bracelets (USA)"
-	serial "ULUS-10321"
-	serial "ULUS-10321"
+	rom ( serial "ULUS-10321" )
 )
 
 game (
 	name "World Snooker Challenge 2005 (Europe)"
-	serial "ULES-00021"
-	serial "ULES-00021"
+	rom ( serial "ULES-00021" )
 )
 
 game (
 	name "World Snooker Challenge 2007 (Europe) (v1.01)"
-	serial "ULES-00453"
-	serial "ULES-00453"
+	rom ( serial "ULES-00453" )
 )
 
 game (
 	name "World Soccer Winning Eleven 2010 - Aoki Samurai no Chousen (Japan) (v1.01)"
-	serial "ULJM-05648"
-	serial "ULJM-05648"
+	rom ( serial "ULJM-05648" )
 )
 
 game (
 	name "World Tour Soccer (Europe) (En,Fr,De,Es,It) (v2.00)"
-	serial "UCES-00003"
-	serial "UCES-00003"
+	rom ( serial "UCES-00003" )
 )
 
 game (
 	name "World Tour Soccer (USA) (En,Fr,Es,It) (v1.01)"
-	serial "UCUS-98613"
-	serial "UCUS-98613"
+	rom ( serial "UCUS-98613" )
 )
 
 game (
 	name "World Tour Soccer 2 (Europe) (En,Fr,De,Es,It) (Demo)"
-	serial "UCED-00350"
-	serial "UCED-00350"
+	rom ( serial "UCED-00350" )
 )
 
 game (
 	name "World Tour Soccer 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "UCES-00206"
-	serial "UCES-00206"
+	rom ( serial "UCES-00206" )
 )
 
 game (
 	name "World of Pool (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00821"
-	serial "ULES-00821"
+	rom ( serial "ULES-00821" )
 )
 
 game (
 	name "Worms - Open Warfare (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00268"
-	serial "ULES-00268"
+	rom ( serial "ULES-00268" )
 )
 
 game (
 	name "Worms - Open Warfare (USA) (v1.02)"
-	serial "ULUS-10065"
-	serial "ULUS-10065"
+	rom ( serial "ULUS-10065" )
 )
 
 game (
 	name "Worms - Open Warfare 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00819"
-	serial "ULES-00819"
+	rom ( serial "ULES-00819" )
 )
 
 game (
 	name "Worms - Open Warfare 2 (USA) (v1.02)"
-	serial "ULUS-10260"
-	serial "ULUS-10260"
+	rom ( serial "ULUS-10260" )
 )
 
 game (
 	name "X-Men Legends II - Rise of Apocalypse (Europe) (v1.01)"
-	serial "ULES-00189"
-	serial "ULES-00189"
+	rom ( serial "ULES-00189" )
 )
 
 game (
 	name "X-Men Legends II - Rise of Apocalypse (Germany) (v1.01)"
-	serial "ULES-00190"
-	serial "ULES-00190"
+	rom ( serial "ULES-00190" )
 )
 
 game (
 	name "X-Men Legends II - Rise of Apocalypse (USA) (v1.01)"
-	serial "ULUS-10045"
-	serial "ULUS-10045"
+	rom ( serial "ULUS-10045" )
 )
 
 game (
 	name "X-Men Origins - Wolverine (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01226"
-	serial "ULES-01226"
+	rom ( serial "ULES-01226" )
 )
 
 game (
 	name "X-Men Origins - Wolverine (USA) (v1.01)"
-	serial "ULUS-10411"
-	serial "ULUS-10411"
+	rom ( serial "ULUS-10411" )
 )
 
 game (
 	name "XI Coliseum (Japan) (v1.01)"
-	serial "UCJS-10031"
-	serial "UCJS-10031"
+	rom ( serial "UCJS-10031" )
 )
 
 game (
 	name "Xiaolin Showdown (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00711"
-	serial "ULES-00711"
+	rom ( serial "ULES-00711" )
 )
 
 game (
 	name "Xiaolin Showdown (USA) (v1.02)"
-	serial "ULUS-10164"
-	serial "ULUS-10164"
+	rom ( serial "ULUS-10164" )
 )
 
 game (
 	name "Xyanide - Resurrection (Asia) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00634"
-	serial "ULES-00634"
+	rom ( serial "ULES-00634" )
 )
 
 game (
 	name "Xyanide - Resurrection (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00634"
-	serial "ULES-00634"
 )
 
 game (
 	name "Yamamura Misa Suspense - Kyoto Kurama Sansou Satsujin Jiken (Japan) (v1.01)"
-	serial "ULJS-00225"
-	serial "ULJS-00225"
+	rom ( serial "ULJS-00225" )
 )
 
 game (
 	name "Yamasa Digi Portable - Matsuri no Tatsujin - Win-Chan no Natsumatsuri (Japan) (v1.02)"
-	serial "ULJS-00067"
-	serial "ULJS-00067"
+	rom ( serial "ULJS-00067" )
 )
 
 game (
 	name "Yami Kara no Izanai - Tenebrae I (Japan)"
-	serial "ULJM-06147"
-	serial "ULJM-06147"
+	rom ( serial "ULJM-06147" )
 )
 
 game (
 	name "Yarudora Portable - Blood the Last Vampire (Asia)"
-	serial "UCAS-40055"
-	serial "UCAS-40055"
+	rom ( serial "UCAS-40055" )
 )
 
 game (
 	name "Yarudora Portable - Blood the Last Vampire (Japan)"
-	serial "UCJS-10025"
-	serial "UCJS-10025"
+	rom ( serial "UCJS-10025" )
 )
 
 game (
 	name "Yarudora Portable - Double Cast (Asia) (v1.03)"
-	serial "UCAS-40032"
-	serial "UCAS-40032"
+	rom ( serial "UCAS-40032" )
 )
 
 game (
 	name "Yarudora Portable - Double Cast (Japan) (v1.05)"
-	serial "UCJS-10012"
-	serial "UCJS-10012"
+	rom ( serial "UCJS-10012" )
 )
 
 game (
 	name "Yarudora Portable - Kisetsu o Dakishimete (Asia) (v1.03)"
-	serial "UCAS-40033"
-	serial "UCAS-40033"
+	rom ( serial "UCAS-40033" )
 )
 
 game (
 	name "Yarudora Portable - Kisetsu o Dakishimete (Japan) (v1.05)"
-	serial "UCJS-10013"
-	serial "UCJS-10013"
+	rom ( serial "UCJS-10013" )
 )
 
 game (
 	name "Yarudora Portable - Sampaguita (Asia) (v1.03)"
-	serial "UCAS-40034"
-	serial "UCAS-40034"
+	rom ( serial "UCAS-40034" )
 )
 
 game (
 	name "Yarudora Portable - Sampaguita (Japan) (v1.05)"
-	serial "UCJS-10014"
-	serial "UCJS-10014"
+	rom ( serial "UCJS-10014" )
 )
 
 game (
 	name "Yarudora Portable - Yukiwari no Hana (Asia) (v1.03)"
-	serial "UCAS-40035"
-	serial "UCAS-40035"
+	rom ( serial "UCAS-40035" )
 )
 
 game (
 	name "Yarudora Portable - Yukiwari no Hana (Japan) (v1.05)"
-	serial "UCJS-10015"
-	serial "UCJS-10015"
+	rom ( serial "UCJS-10015" )
 )
 
 game (
 	name "Yggdra Union - We'll Never Fight Alone (Japan) (Demo)"
-	serial "ULJM-91012"
-	serial "ULJM-91012"
+	rom ( serial "ULJM-91012" )
 )
 
 game (
 	name "Yggdra Union - We'll Never Fight Alone (Japan) (v1.01)"
-	serial "ULJM-05299"
-	serial "ULJM-05299"
+	rom ( serial "ULJM-05299" )
 )
 
 game (
 	name "Yggdra Union - We'll Never Fight Alone (USA)"
-	serial "ULUS-10368"
-	serial "ULUS-10368"
+	rom ( serial "ULUS-10368" )
 )
 
 game (
 	name "Yoake Mae Yori Ruriiro na Portable (Japan) (v1.02)"
-	serial "ULJM-05625"
-	serial "ULJM-05625"
+	rom ( serial "ULJM-05625" )
 )
 
 game (
 	name "Your Memories Off - Girls Style (Japan)"
-	serial "ULJM-05435"
-	serial "ULJM-05435"
+	rom ( serial "ULJM-05435" )
 )
 
 game (
 	name "Ys - The Ark of Napishtim (Europe) (En,Fr,De,Es,It) (v1.03)"
-	serial "ULES-00267"
-	serial "ULES-00267"
+	rom ( serial "ULES-00267" )
 )
 
 game (
 	name "Ys - The Ark of Napishtim (USA)"
-	serial "ULUS-10051"
-	serial "ULUS-10051"
+	rom ( serial "ULUS-10051" )
 )
 
 game (
 	name "Ys - The Oath in Felghana (USA)"
-	serial "ULUS-10558"
-	serial "ULUS-10558"
+	rom ( serial "ULUS-10558" )
 )
 
 game (
 	name "Ys I & II Chronicles (Japan) (v1.01)"
-	serial "ULJM-05474"
-	serial "ULJM-05474"
+	rom ( serial "ULJM-05474" )
 )
 
 game (
 	name "Ys I & II Chronicles (USA)"
-	serial "ULUS-10547"
-	serial "ULUS-10547"
+	rom ( serial "ULUS-10547" )
 )
 
 game (
 	name "Ys Seven (Japan) (v1.01)"
-	serial "ULJM-05475"
-	serial "ULJM-05475"
+	rom ( serial "ULJM-05475" )
 )
 
 game (
 	name "Ys Seven (USA)"
-	serial "ULUS-10551"
-	serial "ULUS-10551"
+	rom ( serial "ULUS-10551" )
 )
 
 game (
 	name "Ys vs. Sora no Kiseki - Alternative Saga (Japan) (v1.01)"
-	serial "NPJH-50276"
-	serial "NPJH-50276"
+	rom ( serial "NPJH-50276" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 4 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01362"
-	serial "ULES-01362"
+	rom ( serial "ULES-01362" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 4 (Japan) (v1.01)"
-	serial "ULJM-05479"
-	serial "ULJM-05479"
+	rom ( serial "ULJM-05479" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 4 (USA) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULUS-10481"
-	serial "ULUS-10481"
+	rom ( serial "ULUS-10481" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 5 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-01474"
-	serial "ULES-01474"
+	rom ( serial "ULES-01474" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 5 (Japan) (v1.02)"
-	serial "ULJM-05734"
-	serial "ULJM-05734"
+	rom ( serial "ULJM-05734" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 5 (USA) (En,Fr,De,Es,It)"
-	serial "ULUS-10555"
-	serial "ULUS-10555"
+	rom ( serial "ULUS-10555" )
 )
 
 game (
 	name "Yu-Gi-Oh! 5D's - Tag Force 6 (Japan) (v1.01)"
-	serial "ULJM-05940"
-	serial "ULJM-05940"
+	rom ( serial "ULJM-05940" )
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force (Europe) (En,Ja,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00600"
-	serial "ULES-00600"
+	rom ( serial "ULES-00600" )
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force (USA) (v1.03)"
-	serial "ULUS-10136"
-	serial "ULUS-10136"
+	rom ( serial "ULUS-10136" )
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force 2 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "ULES-00925"
-	serial "ULES-00925"
+	rom ( serial "ULES-00925" )
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force 2 (Europe) (En,Fr,De,Es,It) (v2.0)"
-	serial "ULES-00925"
-	serial "ULES-00925"
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force 2 (USA) (v1.02)"
-	serial "ULUS-10302"
-	serial "ULUS-10302"
+	rom ( serial "ULUS-10302" )
 )
 
 game (
 	name "Yu-Gi-Oh! GX - Tag Force 3 (Europe) (En,Fr,De,Es,It,Nl,Pt,Pl) (v1.02)"
-	serial "ULES-01183"
-	serial "ULES-01183"
+	rom ( serial "ULES-01183" )
 )
 
 game (
 	name "Yuusha 30 Second (Japan) (v1.02)"
-	serial "ULJS-00332"
-	serial "ULJS-00332"
+	rom ( serial "ULJS-00332" )
 )
 
 game (
 	name "Yuusha no Kuse ni Namaikida 3D (Japan) (v1.01)"
-	serial "UCJS-10109"
-	serial "UCJS-10109"
+	rom ( serial "UCJS-10109" )
 )
 
 game (
 	name "Z.H.P. - Unlosing Ranger vs. Darkdeath Evilman (USA) (En,Ja)"
-	serial "ULUS-10559"
-	serial "ULUS-10559"
+	rom ( serial "ULUS-10559" )
 )
 
 game (
 	name "Zendoku (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "ULES-00692"
-	serial "ULES-00692"
+	rom ( serial "ULES-00692" )
 )
 
 game (
 	name "Zero Chou Aniki (Japan)"
-	serial "ULJM-05390"
-	serial "ULJM-05390"
+	rom ( serial "ULJM-05390" )
 )
 
 game (
 	name "Zero Pilot - Daisanji Sekai Taisen 1946 (Japan)"
-	serial "ULJM-05382"
-	serial "ULJM-05382"
+	rom ( serial "ULJM-05382" )
 )
 
 game (
 	name "Zettai Meikyuu Grimm - Nanatsu no Kagi to Rakuen no Otome (Japan) (v1.01)"
-	serial "ULJM-05632"
-	serial "ULJM-05632"
+	rom ( serial "ULJM-05632" )
 )
 
 game (
 	name "Zettai Zetsumei Toshi 3 - Kowareyuku Machi to Kanojo no Uta (Japan) (v1.02)"
-	serial "ULJS-00191"
-	serial "ULJS-00191"
+	rom ( serial "ULJS-00191" )
 )
 
 game (
 	name "Zill O'll Infinite Plus (Japan) (v1.03)"
-	serial "ULJM-05410"
-	serial "ULJM-05410"
+	rom ( serial "ULJM-05410" )
 )
 
 game (
 	name "Zwei!! (Japan) (v1.01)"
-	serial "ULJM-05392"
-	serial "ULJM-05392"
+	rom ( serial "ULJM-05392" )
 )
 
 game (
 	name "code_18 (Japan) (v1.02)"
-	serial "ULJM-05936"
-	serial "ULJM-05936"
+	rom ( serial "ULJM-05936" )
 )
 
 game (
 	name "ebKore+ Amagami (Japan) (v1.02)"
-	serial "ULJS-00339"
-	serial "ULJS-00339"
+	rom ( serial "ULJS-00339" )
 )
-


### PR DESCRIPTION
Sticks the serial numbers into `rom` entries.