### PR TITLE
Add Nintendo Wii serial information

### DIFF
--- a/metadat/redump/Nintendo - Wii.dat
+++ b/metadat/redump/Nintendo - Wii.dat
@@ -1009,9 +1009,8 @@ game (
 
 game (
 	name "Cabela's Big Game Hunter (USA)"
-	serial "GG5E52"
 	description "Cabela's Big Game Hunter (USA)"
-	rom ( name "Cabela's Big Game Hunter (USA).iso" size 4699979776 crc 1bfa8a42 md5 680e67cc24127ec54cca1cc1c079a175 sha1 01bd17c0b4f760b57edfbb21db8bb1748726ff6e serial "GG5E52" )
+	rom ( name "Cabela's Big Game Hunter (USA).iso" size 4699979776 crc 1bfa8a42 md5 680e67cc24127ec54cca1cc1c079a175 sha1 01bd17c0b4f760b57edfbb21db8bb1748726ff6e )
 )
 
 game (
@@ -1385,9 +1384,8 @@ game (
 
 game (
 	name "Crazy Climber Wii (Japan)"
-	serial "E6BJ"
 	description "Crazy Climber Wii (Japan)"
-	rom ( name "Crazy Climber Wii (Japan).iso" size 4699979776 crc e8236bbd md5 3eedfda972f6d2adeffb93dee94b8895 sha1 f98d1688eda4eb43c1985811a87c9b7a06a0fc8a serial "E6BJ" )
+	rom ( name "Crazy Climber Wii (Japan).iso" size 4699979776 crc e8236bbd md5 3eedfda972f6d2adeffb93dee94b8895 sha1 f98d1688eda4eb43c1985811a87c9b7a06a0fc8a )
 )
 
 game (
@@ -2103,23 +2101,23 @@ game (
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
-	serial "GD7E70"
+	serial "GZ3E70"
 	description "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja).iso" size 4699979776 crc 0c713740 md5 41abf80c95fde8a90ae831c8ee1f7777 sha1 9de2efd8cc7517e5a464d6810a142c60317b731b serial "GD7E70" )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja).iso" size 4699979776 crc 0c713740 md5 41abf80c95fde8a90ae831c8ee1f7777 sha1 9de2efd8cc7517e5a464d6810a142c60317b731b serial "GZ3E70" )
 )
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
-	serial "GD7PB2"
+	serial "GD7P70"
 	description "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a5e94186 md5 656723af3267f554f5be2c166f0fbc92 sha1 7ff74ddaf87a63940dc6115c0dc52a87c4ed9370 serial "GD7PB2" )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a5e94186 md5 656723af3267f554f5be2c166f0fbc92 sha1 7ff74ddaf87a63940dc6115c0dc52a87c4ed9370 serial "GD7P70" )
 )
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
-	serial "GD7P70"
+	serial "GD7E70"
 	description "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja).iso" size 4699979776 crc 8f4a3b7b md5 691421036ae73128691634d20f50ce8a sha1 97ed07738895c863db0f6012e0b36eee7bdffa2c serial "GD7P70" )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja).iso" size 4699979776 crc 8f4a3b7b md5 691421036ae73128691634d20f50ce8a sha1 97ed07738895c863db0f6012e0b36eee7bdffa2c serial "GD7E70" )
 )
 
 game (
@@ -2678,16 +2676,16 @@ game (
 
 game (
 	name "FIFA 13 (Europe) (De,Es,It)"
-	serial "S3FP69"
+	serial "S3FX69"
 	description "FIFA 13 (Europe) (De,Es,It)"
-	rom ( name "FIFA 13 (Europe) (De,Es,It).iso" size 4699979776 crc fa3069bc md5 08f4bbeaa0fd32e23ea83458cd220c80 sha1 f4c6fca46cda7401ee9eb292cf6ec3d938cbc31b serial "S3FP69" )
+	rom ( name "FIFA 13 (Europe) (De,Es,It).iso" size 4699979776 crc fa3069bc md5 08f4bbeaa0fd32e23ea83458cd220c80 sha1 f4c6fca46cda7401ee9eb292cf6ec3d938cbc31b serial "S3FX69" )
 )
 
 game (
 	name "FIFA 13 (Europe) (En,Fr,Nl)"
-	serial "S3FX69"
+	serial "S3FP69"
 	description "FIFA 13 (Europe) (En,Fr,Nl)"
-	rom ( name "FIFA 13 (Europe) (En,Fr,Nl).iso" size 4699979776 crc 745bc776 md5 55465079499c7c72aeadd5166ba54772 sha1 ef1f2aeea81c782cd28a260539589c56876c50a6 serial "S3FX69" )
+	rom ( name "FIFA 13 (Europe) (En,Fr,Nl).iso" size 4699979776 crc 745bc776 md5 55465079499c7c72aeadd5166ba54772 sha1 ef1f2aeea81c782cd28a260539589c56876c50a6 serial "S3FP69" )
 )
 
 game (
@@ -3824,37 +3822,36 @@ game (
 
 game (
 	name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl)"
-	serial "SZ7E41"
 	description "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl)"
-	rom ( name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 771ccc25 md5 08aa014afa180e3d5474f29a2de7b904 sha1 beff7b469ac9c3878359c7206a0e924a44002253 serial "SZ7E41" )
+	rom ( name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 771ccc25 md5 08aa014afa180e3d5474f29a2de7b904 sha1 beff7b469ac9c3878359c7206a0e924a44002253 )
 )
 
 game (
 	name "Just Dance 2014 (USA)"
-	serial "SE3P41"
+	serial "SJOE41"
 	description "Just Dance 2014 (USA)"
-	rom ( name "Just Dance 2014 (USA).iso" size 4699979776 crc 1fe94c32 md5 64d469178d925d5b79ae26f7289d165b sha1 5200b41d771c3f5f71fdf45752e27d44d3cffb64 serial "SE3P41" )
+	rom ( name "Just Dance 2014 (USA).iso" size 4699979776 crc 1fe94c32 md5 64d469178d925d5b79ae26f7289d165b sha1 5200b41d771c3f5f71fdf45752e27d44d3cffb64 serial "SJOE41" )
 )
 
 game (
 	name "Just Dance 2015 (USA)"
-	serial "SJNE41"
+	serial "SE3P41"
 	description "Just Dance 2015 (USA)"
-	rom ( name "Just Dance 2015 (USA).iso" size 4699979776 crc ada3ce0e md5 6142795d6f0700963b9754ca59c92d90 sha1 af98bcd15d31a7a1b8ac1982b0d490e422b455dc serial "SJNE41" )
+	rom ( name "Just Dance 2015 (USA).iso" size 4699979776 crc ada3ce0e md5 6142795d6f0700963b9754ca59c92d90 sha1 af98bcd15d31a7a1b8ac1982b0d490e422b455dc serial "SE3P41" )
 )
 
 game (
 	name "Just Dance 2016 (USA)"
-	serial "SJNP41"
+	serial "SJNE41"
 	description "Just Dance 2016 (USA)"
-	rom ( name "Just Dance 2016 (USA).iso" size 4699979776 crc 350cdaca md5 8041c2a5ad9465cb5fac6657514e3ea2 sha1 881ae88bda44a71835b8817eba70fd268345063c serial "SJNP41" )
+	rom ( name "Just Dance 2016 (USA).iso" size 4699979776 crc 350cdaca md5 8041c2a5ad9465cb5fac6657514e3ea2 sha1 881ae88bda44a71835b8817eba70fd268345063c serial "SJNE41" )
 )
 
 game (
 	name "Just Dance 2017 (USA)"
-	serial "SJOE41"
+	serial "SZ7E41"
 	description "Just Dance 2017 (USA)"
-	rom ( name "Just Dance 2017 (USA).iso" size 4699979776 crc b8516e2b md5 31e872f305d4355416a4ce345fdd9c4c sha1 04f808d78379a3266c64940aeb6ceb69740dc369 serial "SJOE41" )
+	rom ( name "Just Dance 2017 (USA).iso" size 4699979776 crc b8516e2b md5 31e872f305d4355416a4ce345fdd9c4c sha1 04f808d78379a3266c64940aeb6ceb69740dc369 serial "SZ7E41" )
 )
 
 game (
@@ -3938,16 +3935,15 @@ game (
 
 game (
 	name "Karaoke Joysound Wii (Japan)"
-	serial "SOKEA4"
+	serial "WOKJ"
 	description "Karaoke Joysound Wii (Japan)"
-	rom ( name "Karaoke Joysound Wii (Japan).iso" size 4699979776 crc 728ad2fa md5 d89ae93539eaed363fc61c1238d4f22c sha1 e8669048eb88c8c213c5c29e6c1ed28351352513 serial "SOKEA4" )
+	rom ( name "Karaoke Joysound Wii (Japan).iso" size 4699979776 crc 728ad2fa md5 d89ae93539eaed363fc61c1238d4f22c sha1 e8669048eb88c8c213c5c29e6c1ed28351352513 serial "WOKJ" )
 )
 
 game (
 	name "Karaoke Joysound Wii DX (Japan)"
-	serial "WOKJ"
 	description "Karaoke Joysound Wii DX (Japan)"
-	rom ( name "Karaoke Joysound Wii DX (Japan).iso" size 4699979776 crc 6c7c56c7 md5 f17ee412ea30a0064cd1dd11568a1e13 sha1 4078132e9b3d7669eac3c10d81c57ced052a3fb4 serial "WOKJ" )
+	rom ( name "Karaoke Joysound Wii DX (Japan).iso" size 4699979776 crc 6c7c56c7 md5 f17ee412ea30a0064cd1dd11568a1e13 sha1 4078132e9b3d7669eac3c10d81c57ced052a3fb4 )
 )
 
 game (
@@ -4712,9 +4708,9 @@ game (
 
 game (
 	name "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
-	serial "RMCE79"
+	serial "MK7P41"
 	description "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Mario Kart Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a70d78b md5 e7b1ff1fabb0789482ce2cb0661d986e sha1 4fde5ce38d68f632d92c5b0d52bbab0b1d355a95 serial "RMCE79" )
+	rom ( name "Mario Kart Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a70d78b md5 e7b1ff1fabb0789482ce2cb0661d986e sha1 4fde5ce38d68f632d92c5b0d52bbab0b1d355a95 serial "MK7P41" )
 )
 
 game (
@@ -4726,9 +4722,9 @@ game (
 
 game (
 	name "Mario Kart Wii (USA) (En,Fr,Es)"
-	serial "MK7P41"
+	serial "RMCE79"
 	description "Mario Kart Wii (USA) (En,Fr,Es)"
-	rom ( name "Mario Kart Wii (USA) (En,Fr,Es).iso" size 4699979776 crc 0cc7b4d5 md5 bb7f2c926cbcdee65e2a48b7002a52ea sha1 9faca97115fb267c1b8a4d8a05fb22f42a904733 serial "MK7P41" )
+	rom ( name "Mario Kart Wii (USA) (En,Fr,Es).iso" size 4699979776 crc 0cc7b4d5 md5 bb7f2c926cbcdee65e2a48b7002a52ea sha1 9faca97115fb267c1b8a4d8a05fb22f42a904733 serial "RMCE79" )
 )
 
 game (
@@ -5403,9 +5399,8 @@ game (
 
 game (
 	name "Mystery Case Files - The Malgrave Incident (USA)"
-	serial "DAVE01"
 	description "Mystery Case Files - The Malgrave Incident (USA)"
-	rom ( name "Mystery Case Files - The Malgrave Incident (USA).iso" size 4699979776 crc 1f0ed55d md5 2d516390efa9bab69f62aca10742d963 sha1 332082ee374791bee2fbff10c6bffc68ff426207 serial "DAVE01" )
+	rom ( name "Mystery Case Files - The Malgrave Incident (USA).iso" size 4699979776 crc 1f0ed55d md5 2d516390efa9bab69f62aca10742d963 sha1 332082ee374791bee2fbff10c6bffc68ff426207 )
 )
 
 game (
@@ -5621,37 +5616,37 @@ game (
 
 game (
 	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
-	serial "KMNE03"
+	serial "NSMB02"
 	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
-	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc e71b9bc7 md5 fc335c3187c6940a290f7c971fbdc576 sha1 8c0408ae7ed6539fccc9b002d50eecb994000af7 serial "KMNE03" )
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc e71b9bc7 md5 fc335c3187c6940a290f7c971fbdc576 sha1 8c0408ae7ed6539fccc9b002d50eecb994000af7 serial "NSMB02" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
-	serial "NMNP01"
+	serial "SMNJ11"
 	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
-	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 2a9344fb md5 ea2698f30aef31182d1c506d9ae5cbd2 sha1 91ff55875b0e0401e6246d5bc2a52d7a80517860 serial "NMNP01" )
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 2a9344fb md5 ea2698f30aef31182d1c506d9ae5cbd2 sha1 91ff55875b0e0401e6246d5bc2a52d7a80517860 serial "SMNJ11" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (Japan)"
-	serial "NSMB02"
+	serial "SMNP11"
 	description "New Super Mario Bros. Wii (Japan)"
-	rom ( name "New Super Mario Bros. Wii (Japan).iso" size 4699979776 crc 1a1e2e29 md5 3e3337ea0fab653aa50807c839ceeec4 sha1 019b9a7abfcf9f2429b2d106d884a72d17fb922d serial "NSMB02" )
+	rom ( name "New Super Mario Bros. Wii (Japan).iso" size 4699979776 crc 1a1e2e29 md5 3e3337ea0fab653aa50807c839ceeec4 sha1 019b9a7abfcf9f2429b2d106d884a72d17fb922d serial "SMNP11" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
-	serial "KMNJ03"
+	serial "SMNE11"
 	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
-	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 1cc03c30 md5 05022377c66dcc13dd8308b333c202db sha1 aa7b134a7606435ddcd735f2964ebdecde38c2ef serial "KMNJ03" )
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 1cc03c30 md5 05022377c66dcc13dd8308b333c202db sha1 aa7b134a7606435ddcd735f2964ebdecde38c2ef serial "SMNE11" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
-	serial "KMNP03"
+	serial "SMNESN"
 	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
-	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 8c30d1d7 md5 b31a7da0d493ec1f558b4e1899406a14 sha1 9ac7242a5feebe1d0a6e2775c21f482c471b2240 serial "KMNP03" )
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 8c30d1d7 md5 b31a7da0d493ec1f558b4e1899406a14 sha1 9ac7242a5feebe1d0a6e2775c21f482c471b2240 serial "SMNESN" )
 )
 
 game (
@@ -6133,9 +6128,8 @@ game (
 
 game (
 	name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
-	serial "S3IEA4"
 	description "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
-	rom ( name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc f9a8040b md5 9de67539e64b3544bbedd137a59d401f sha1 c56632c087b14356d82ff3042be8baee69167e1c serial "S3IEA4" )
+	rom ( name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc f9a8040b md5 9de67539e64b3544bbedd137a59d401f sha1 c56632c087b14356d82ff3042be8baee69167e1c )
 )
 
 game (
@@ -7992,9 +7986,8 @@ game (
 
 game (
 	name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
-	serial "RSBEBP"
 	description "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
-	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 8511160320 crc 6757c5f2 md5 549c19aefd56c3651571c32e3c32e5b3 sha1 42ab0684b9601405b2cb349ea64550a7807173cf serial "RSBEBP" )
+	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 8511160320 crc 6757c5f2 md5 549c19aefd56c3651571c32e3c32e5b3 sha1 42ab0684b9601405b2cb349ea64550a7807173cf )
 )
 
 game (
@@ -8005,16 +7998,16 @@ game (
 
 game (
 	name "Super Smash Bros. Brawl (USA) (v1.01)"
-	serial "RSBE24"
+	serial "RSBE01"
 	description "Super Smash Bros. Brawl (USA) (v1.01)"
-	rom ( name "Super Smash Bros. Brawl (USA) (v1.01).iso" size 8511160320 crc 7d5228c6 md5 d18726e6dfdc8bdbdad540b561051087 sha1 0e95949ac585f357e79fcd34b20670b5dca97ac2 serial "RSBE24" )
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.01).iso" size 8511160320 crc 7d5228c6 md5 d18726e6dfdc8bdbdad540b561051087 sha1 0e95949ac585f357e79fcd34b20670b5dca97ac2 serial "RSBE01" )
 )
 
 game (
 	name "Super Smash Bros. Brawl (USA) (v1.02)"
-	serial "RSBE03"
+	serial "RSBP01"
 	description "Super Smash Bros. Brawl (USA) (v1.02)"
-	rom ( name "Super Smash Bros. Brawl (USA) (v1.02).iso" size 8511160320 crc 854b2889 md5 52ce7160ced2505ad5e397477d0ea4fe sha1 59432f150bf6b871ab378bb5b28e92005e0862f6 serial "RSBE03" )
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.02).iso" size 8511160320 crc 854b2889 md5 52ce7160ced2505ad5e397477d0ea4fe sha1 59432f150bf6b871ab378bb5b28e92005e0862f6 serial "RSBP01" )
 )
 
 game (
@@ -8164,9 +8157,9 @@ game (
 
 game (
 	name "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
-	serial "FBKP"
+	serial "GTFEA4"
 	description "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
-	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (Europe).iso" size 4699979776 crc a732c637 md5 e9fc3a03595a4869988baf5883717fbe sha1 51b1e95793583f2985e889ae35e83650b3a10e61 serial "FBKP" )
+	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (Europe).iso" size 4699979776 crc a732c637 md5 e9fc3a03595a4869988baf5883717fbe sha1 51b1e95793583f2985e889ae35e83650b3a10e61 serial "GTFEA4" )
 )
 
 game (
@@ -8178,9 +8171,9 @@ game (
 
 game (
 	name "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
-	serial "GTFEA4"
+	serial "GTFPA4"
 	description "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
-	rom ( name "Teenage Mutant Ninja Turtles (USA) (En,Fr).iso" size 4699979776 crc 46ce2ad6 md5 53636e5efe2042d540962cdec58626c0 sha1 11ef981c246bece78c713eefdf45e3632c840363 serial "GTFEA4" )
+	rom ( name "Teenage Mutant Ninja Turtles (USA) (En,Fr).iso" size 4699979776 crc 46ce2ad6 md5 53636e5efe2042d540962cdec58626c0 sha1 11ef981c246bece78c713eefdf45e3632c840363 serial "GTFPA4" )
 )
 
 game (
@@ -8209,8 +8202,9 @@ game (
 
 game (
 	name "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl)"
+	serial "WTPJ"
 	description "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl)"
-	rom ( name "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 68094068 md5 7fdfd25a87ed18f7320e64bc040186ea sha1 a0d2f903b15a4b968fdb197da08ec8901524e7fc )
+	rom ( name "Tetris Party Deluxe (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 68094068 md5 7fdfd25a87ed18f7320e64bc040186ea sha1 a0d2f903b15a4b968fdb197da08ec8901524e7fc serial "WTPJ" )
 )
 
 game (

--- a/metadat/redump/Nintendo - Wii.dat
+++ b/metadat/redump/Nintendo - Wii.dat
@@ -13,8 +13,9 @@ game (
 
 game (
 	name "2010 FIFA World Cup South Africa (Europe) (En,Nl)"
+	serial "SFWK13"
 	description "2010 FIFA World Cup South Africa (Europe) (En,Nl)"
-	rom ( name "2010 FIFA World Cup South Africa (Europe) (En,Nl).iso" size 4699979776 crc 6de8366c md5 9639b04484c3524ddb12563a322a873f sha1 764da0cc19bd5534c2471ebe6dd74e2123007577 )
+	rom ( name "2010 FIFA World Cup South Africa (Europe) (En,Nl).iso" size 4699979776 crc 6de8366c md5 9639b04484c3524ddb12563a322a873f sha1 764da0cc19bd5534c2471ebe6dd74e2123007577 serial "SFWK13" )
 )
 
 game (
@@ -27,12 +28,6 @@ game (
 	name "2010 FIFA World Cup South Africa (Europe) (Fr,De)"
 	description "2010 FIFA World Cup South Africa (Europe) (Fr,De)"
 	rom ( name "2010 FIFA World Cup South Africa (Europe) (Fr,De).iso" size 4699979776 crc a1f92eac md5 55633171adeb2dbd8f2cc74f35cd2210 sha1 b075d6503fbf0b8ca5e60a44417f76abb5ca31eb )
-)
-
-game (
-	name "250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan)"
-	description "250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan)"
-	rom ( name "250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan).iso" size 4699979776 crc 01064656 md5 62bf94914850f0e269e0e4e98916da51 sha1 8f9ffaafe94947354404ffa9830a2f8dcf11f903 )
 )
 
 game (
@@ -181,8 +176,9 @@ game (
 
 game (
 	name "Amazing Spider-Man, The (USA) (En,Fr,Es)"
+	serial "SA8P52"
 	description "Amazing Spider-Man, The (USA) (En,Fr,Es)"
-	rom ( name "Amazing Spider-Man, The (USA) (En,Fr,Es).iso" size 4699979776 crc f94f8240 md5 a0727cf1a369150e58a487a51d8e4cef sha1 5e881d99b29cb17169e4ebf73f9ebca4b671e148 )
+	rom ( name "Amazing Spider-Man, The (USA) (En,Fr,Es).iso" size 4699979776 crc f94f8240 md5 a0727cf1a369150e58a487a51d8e4cef sha1 5e881d99b29cb17169e4ebf73f9ebca4b671e148 serial "SA8P52" )
 )
 
 game (
@@ -211,8 +207,9 @@ game (
 
 game (
 	name "Angry Birds Star Wars (USA) (En,Fr,Es,Pt)"
+	serial "S7DP52"
 	description "Angry Birds Star Wars (USA) (En,Fr,Es,Pt)"
-	rom ( name "Angry Birds Star Wars (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 002b6c6e md5 6964897a2faff6b1787a7f41c43c0851 sha1 3e3706518ea6d2f3950c9a672249688c77f32021 )
+	rom ( name "Angry Birds Star Wars (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 002b6c6e md5 6964897a2faff6b1787a7f41c43c0851 sha1 3e3706518ea6d2f3950c9a672249688c77f32021 serial "S7DP52" )
 )
 
 game (
@@ -223,8 +220,9 @@ game (
 
 game (
 	name "Animal Crossing - City Folk (USA) (En,Fr,Es)"
+	serial "GAFE01"
 	description "Animal Crossing - City Folk (USA) (En,Fr,Es)"
-	rom ( name "Animal Crossing - City Folk (USA) (En,Fr,Es).iso" size 4699979776 crc 2f468135 md5 732d7cddfd2f958d30b98ffeb72eeac4 sha1 a75c7389877b331a520803529798f909b0dd0122 )
+	rom ( name "Animal Crossing - City Folk (USA) (En,Fr,Es).iso" size 4699979776 crc 2f468135 md5 732d7cddfd2f958d30b98ffeb72eeac4 sha1 a75c7389877b331a520803529798f909b0dd0122 serial "GAFE01" )
 )
 
 game (
@@ -265,8 +263,9 @@ game (
 
 game (
 	name "Ant Bully, The (Europe) (En,Fr,De,Es,It)"
+	serial "GAXE5D"
 	description "Ant Bully, The (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Ant Bully, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7478438f md5 4ea2c9d47cfcfc944895b030e46a545c sha1 8930dc444d07bc59768cf1fa015d774db61a0bfd )
+	rom ( name "Ant Bully, The (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 7478438f md5 4ea2c9d47cfcfc944895b030e46a545c sha1 8930dc444d07bc59768cf1fa015d774db61a0bfd serial "GAXE5D" )
 )
 
 game (
@@ -283,8 +282,9 @@ game (
 
 game (
 	name "Arc Rise Fantasia (Japan)"
+	serial "RPJEUD"
 	description "Arc Rise Fantasia (Japan)"
-	rom ( name "Arc Rise Fantasia (Japan).iso" size 4699979776 crc f92834dc md5 31aebda4cb726a80763bb6c4e76211e2 sha1 383599d38df8105da21a32d7a18fb4a30514878e )
+	rom ( name "Arc Rise Fantasia (Japan).iso" size 4699979776 crc f92834dc md5 31aebda4cb726a80763bb6c4e76211e2 sha1 383599d38df8105da21a32d7a18fb4a30514878e serial "RPJEUD" )
 )
 
 game (
@@ -343,8 +343,9 @@ game (
 
 game (
 	name "Avatar - The Last Airbender - Into the Inferno (USA)"
+	serial "GAVE78"
 	description "Avatar - The Last Airbender - Into the Inferno (USA)"
-	rom ( name "Avatar - The Last Airbender - Into the Inferno (USA).iso" size 4699979776 crc c27c2445 md5 9e2ee27118a5b46643aecd75562f70aa sha1 6ccb950fb2f32ba027d9ad070eed6742fe5b76f8 )
+	rom ( name "Avatar - The Last Airbender - Into the Inferno (USA).iso" size 4699979776 crc c27c2445 md5 9e2ee27118a5b46643aecd75562f70aa sha1 6ccb950fb2f32ba027d9ad070eed6742fe5b76f8 serial "GAVE78" )
 )
 
 game (
@@ -379,8 +380,9 @@ game (
 
 game (
 	name "Backyard Baseball '10 (USA)"
+	serial "GBKE70"
 	description "Backyard Baseball '10 (USA)"
-	rom ( name "Backyard Baseball '10 (USA).iso" size 4699979776 crc 7c148b74 md5 1e8ad2e1854eb9ded2b95301d6f3237a sha1 e88f5f763b96bbb4780bdb2e0c1f64ba6ee1b75f )
+	rom ( name "Backyard Baseball '10 (USA).iso" size 4699979776 crc 7c148b74 md5 1e8ad2e1854eb9ded2b95301d6f3237a sha1 e88f5f763b96bbb4780bdb2e0c1f64ba6ee1b75f serial "GBKE70" )
 )
 
 game (
@@ -414,6 +416,12 @@ game (
 )
 
 game (
+	name "Balls of Fury (USA)"
+	description "Balls of Fury (USA)"
+	rom ( name "Balls of Fury (USA).iso" size 4699979776 crc 18e0aec1 md5 3db5b0e906a5b30a5270c83267747b9f sha1 674dba760f89e303feab957e86d3f74ec50765aa )
+)
+
+game (
 	name "Band Hero (Europe) (En,Fr,De,Es,It)"
 	description "Band Hero (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Band Hero (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15b8bbca md5 800295c82835dbd1bc8210b295da8770 sha1 2a4f756375887eb9d7ebcbdc2555f5bdefead439 )
@@ -427,8 +435,9 @@ game (
 
 game (
 	name "Barbie & Her Sisters - Puppy Rescue (USA)"
+	serial "SVQEVZ"
 	description "Barbie & Her Sisters - Puppy Rescue (USA)"
-	rom ( name "Barbie & Her Sisters - Puppy Rescue (USA).iso" size 4699979776 crc 7b76d773 md5 0e2e65e0ef9ac1a400f4c52c646537d8 sha1 1b076cab4654a50fbdc1df79f84244b3f4264547 )
+	rom ( name "Barbie & Her Sisters - Puppy Rescue (USA).iso" size 4699979776 crc 7b76d773 md5 0e2e65e0ef9ac1a400f4c52c646537d8 sha1 1b076cab4654a50fbdc1df79f84244b3f4264547 serial "SVQEVZ" )
 )
 
 game (
@@ -475,14 +484,16 @@ game (
 
 game (
 	name "Battalion Wars 2 (Europe) (En,Fr,De,Es,It)"
+	serial "G8WP01"
 	description "Battalion Wars 2 (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Battalion Wars 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 24f09ee6 md5 7c56dd60937035438c6c5479689e7c3a sha1 531d3396aa7323aba3f2d379e0f2fae524ac8299 )
+	rom ( name "Battalion Wars 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 24f09ee6 md5 7c56dd60937035438c6c5479689e7c3a sha1 531d3396aa7323aba3f2d379e0f2fae524ac8299 serial "G8WP01" )
 )
 
 game (
 	name "Battalion Wars 2 (USA)"
+	serial "G8WE01"
 	description "Battalion Wars 2 (USA)"
-	rom ( name "Battalion Wars 2 (USA).iso" size 4699979776 crc b8e6d7bd md5 b2f5a32adbba7f7edaa8990d8f19edd9 sha1 c1c9f8336e7e04786dbee8c575181ebaa4979655 )
+	rom ( name "Battalion Wars 2 (USA).iso" size 4699979776 crc b8e6d7bd md5 b2f5a32adbba7f7edaa8990d8f19edd9 sha1 c1c9f8336e7e04786dbee8c575181ebaa4979655 serial "G8WE01" )
 )
 
 game (
@@ -499,8 +510,9 @@ game (
 
 game (
 	name "Battleship (USA) (En,Fr)"
+	serial "SVBP52"
 	description "Battleship (USA) (En,Fr)"
-	rom ( name "Battleship (USA) (En,Fr).iso" size 4699979776 crc f33d7532 md5 d33114fea5b2bfd2fc9966f9b8bfb8c0 sha1 f003e5b94ed8cc6e5f86bc6919fee8f24e94bc27 )
+	rom ( name "Battleship (USA) (En,Fr).iso" size 4699979776 crc f33d7532 md5 d33114fea5b2bfd2fc9966f9b8bfb8c0 sha1 f003e5b94ed8cc6e5f86bc6919fee8f24e94bc27 serial "SVBP52" )
 )
 
 game (
@@ -535,20 +547,23 @@ game (
 
 game (
 	name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It)"
+	serial "WXBP"
 	description "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 92333fdf md5 ad8eae8f2a9ca025f716f8be9d741303 sha1 297d78ebafcfc8e6913fa8361edd9a6fcc0a6f6f )
+	rom ( name "Ben 10 - Alien Force (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 92333fdf md5 ad8eae8f2a9ca025f716f8be9d741303 sha1 297d78ebafcfc8e6913fa8361edd9a6fcc0a6f6f serial "WXBP" )
 )
 
 game (
 	name "Ben 10 - Alien Force (USA) (En,Fr,Es)"
+	serial "WXBE"
 	description "Ben 10 - Alien Force (USA) (En,Fr,Es)"
-	rom ( name "Ben 10 - Alien Force (USA) (En,Fr,Es).iso" size 4699979776 crc d4bd5ff9 md5 28852ed1110f601a7bba5dc2cfef9d56 sha1 36938b1245faf43528355e625eb2bb575d5c5e43 )
+	rom ( name "Ben 10 - Alien Force (USA) (En,Fr,Es).iso" size 4699979776 crc d4bd5ff9 md5 28852ed1110f601a7bba5dc2cfef9d56 sha1 36938b1245faf43528355e625eb2bb575d5c5e43 serial "WXBE" )
 )
 
 game (
 	name "Ben 10 - Omniverse (USA)"
+	serial "S5TPAF"
 	description "Ben 10 - Omniverse (USA)"
-	rom ( name "Ben 10 - Omniverse (USA).iso" size 4699979776 crc 51ca3a63 md5 d269ccae43f10b1fde5a53134287b1b0 sha1 eb8e5b0faee7c8b26fd43a4d23559c8a4c73aaf6 )
+	rom ( name "Ben 10 - Omniverse (USA).iso" size 4699979776 crc 51ca3a63 md5 d269ccae43f10b1fde5a53134287b1b0 sha1 eb8e5b0faee7c8b26fd43a4d23559c8a4c73aaf6 serial "S5TPAF" )
 )
 
 game (
@@ -601,8 +616,9 @@ game (
 
 game (
 	name "Big Family Games (Europe) (En,Fr,De,Es,It)"
+	serial "WFYP"
 	description "Big Family Games (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Big Family Games (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 481093e8 md5 d44bc385442fed7b3da0c0b825814b44 sha1 85180cc73df13118e613401e4492095dfc567f96 )
+	rom ( name "Big Family Games (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 481093e8 md5 d44bc385442fed7b3da0c0b825814b44 sha1 85180cc73df13118e613401e4492095dfc567f96 serial "WFYP" )
 )
 
 game (
@@ -703,8 +719,9 @@ game (
 
 game (
 	name "Bit.Trip Complete (Europe)"
+	serial "SVTP99"
 	description "Bit.Trip Complete (Europe)"
-	rom ( name "Bit.Trip Complete (Europe).iso" size 4699979776 crc 964e4df5 md5 e21fc6f26958f5d49738b83b6366c48e sha1 de1f4ec683791193290846998672bc837f97ed12 )
+	rom ( name "Bit.Trip Complete (Europe).iso" size 4699979776 crc 964e4df5 md5 e21fc6f26958f5d49738b83b6366c48e sha1 de1f4ec683791193290846998672bc837f97ed12 serial "SVTP99" )
 )
 
 game (
@@ -985,20 +1002,23 @@ game (
 
 game (
 	name "Cabela's African Adventures (USA)"
+	serial "SQAE52"
 	description "Cabela's African Adventures (USA)"
-	rom ( name "Cabela's African Adventures (USA).iso" size 4699979776 crc 15639044 md5 712c990397972cc2b2237debd9e53dec sha1 a48bb251f2b24f50470859310d359204f2555813 )
+	rom ( name "Cabela's African Adventures (USA).iso" size 4699979776 crc 15639044 md5 712c990397972cc2b2237debd9e53dec sha1 a48bb251f2b24f50470859310d359204f2555813 serial "SQAE52" )
 )
 
 game (
 	name "Cabela's Big Game Hunter (USA)"
+	serial "GG5E52"
 	description "Cabela's Big Game Hunter (USA)"
-	rom ( name "Cabela's Big Game Hunter (USA).iso" size 4699979776 crc 1bfa8a42 md5 680e67cc24127ec54cca1cc1c079a175 sha1 01bd17c0b4f760b57edfbb21db8bb1748726ff6e )
+	rom ( name "Cabela's Big Game Hunter (USA).iso" size 4699979776 crc 1bfa8a42 md5 680e67cc24127ec54cca1cc1c079a175 sha1 01bd17c0b4f760b57edfbb21db8bb1748726ff6e serial "GG5E52" )
 )
 
 game (
 	name "Cabela's Big Game Hunter 2010 (USA)"
+	serial "SH6P52"
 	description "Cabela's Big Game Hunter 2010 (USA)"
-	rom ( name "Cabela's Big Game Hunter 2010 (USA).iso" size 4699979776 crc a9bd6b44 md5 55f0bc19d1a1a37d7a307d5c985e163b sha1 244785ee493106a475737ec9975eeec0eaf9368b )
+	rom ( name "Cabela's Big Game Hunter 2010 (USA).iso" size 4699979776 crc a9bd6b44 md5 55f0bc19d1a1a37d7a307d5c985e163b sha1 244785ee493106a475737ec9975eeec0eaf9368b serial "SH6P52" )
 )
 
 game (
@@ -1015,8 +1035,9 @@ game (
 
 game (
 	name "Cabela's Outdoor Adventures 2010 (USA)"
+	serial "GOAE52"
 	description "Cabela's Outdoor Adventures 2010 (USA)"
-	rom ( name "Cabela's Outdoor Adventures 2010 (USA).iso" size 4699979776 crc b98b9102 md5 4c40eb044dda7d78497e1b2c6c592404 sha1 dc89a88457624dfbfe9c76567416f7117c6e92eb )
+	rom ( name "Cabela's Outdoor Adventures 2010 (USA).iso" size 4699979776 crc b98b9102 md5 4c40eb044dda7d78497e1b2c6c592404 sha1 dc89a88457624dfbfe9c76567416f7117c6e92eb serial "GOAE52" )
 )
 
 game (
@@ -1135,8 +1156,9 @@ game (
 
 game (
 	name "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It)"
+	serial "SKKPHY"
 	description "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fc5e7494 md5 40bc90b7ba88a1c852823bd5bc6d7089 sha1 824973f53fe723ee5743c0df2e4d9b04b6edac26 )
+	rom ( name "Captain Morgane and the Golden Turtle (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc fc5e7494 md5 40bc90b7ba88a1c852823bd5bc6d7089 sha1 824973f53fe723ee5743c0df2e4d9b04b6edac26 serial "SKKPHY" )
 )
 
 game (
@@ -1239,6 +1261,12 @@ game (
 	name "Chronicles of Narnia, The - Prince Caspian (USA)"
 	description "Chronicles of Narnia, The - Prince Caspian (USA)"
 	rom ( name "Chronicles of Narnia, The - Prince Caspian (USA).iso" size 4699979776 crc e302b317 md5 8567b56a77daab8606f9fa0fe62b4b50 sha1 be694ec96803382accab75823d31a1cc803c9a54 )
+)
+
+game (
+	name "Chrysler Classic Racing (USA) (En,Fr,De,Es,It)"
+	description "Chrysler Classic Racing (USA) (En,Fr,De,Es,It)"
+	rom ( name "Chrysler Classic Racing (USA) (En,Fr,De,Es,It).iso" size 4699979776 crc 5067c969 md5 9ac4ad82fcbbeede91ee5a694875651d sha1 513053e4c4bc08cbf52150c453a91f36c4ab2831 )
 )
 
 game (
@@ -1357,8 +1385,9 @@ game (
 
 game (
 	name "Crazy Climber Wii (Japan)"
+	serial "E6BJ"
 	description "Crazy Climber Wii (Japan)"
-	rom ( name "Crazy Climber Wii (Japan).iso" size 4699979776 crc e8236bbd md5 3eedfda972f6d2adeffb93dee94b8895 sha1 f98d1688eda4eb43c1985811a87c9b7a06a0fc8a )
+	rom ( name "Crazy Climber Wii (Japan).iso" size 4699979776 crc e8236bbd md5 3eedfda972f6d2adeffb93dee94b8895 sha1 f98d1688eda4eb43c1985811a87c9b7a06a0fc8a serial "E6BJ" )
 )
 
 game (
@@ -1395,6 +1424,12 @@ game (
 	name "Cursed Mountain (Europe)"
 	description "Cursed Mountain (Europe)"
 	rom ( name "Cursed Mountain (Europe).iso" size 4699979776 crc ec4146e1 md5 36a204c54e923bbc4696a129028e146e sha1 c62ab5142872bf56c9827ef6dd86bf371e74ea20 )
+)
+
+game (
+	name "Daikaijuu Battle - Ultra Coliseum (Japan)"
+	description "Daikaijuu Battle - Ultra Coliseum (Japan)"
+	rom ( name "Daikaijuu Battle - Ultra Coliseum (Japan).iso" size 4699979776 crc 01799c5e md5 018fff4f2999ab7508f43317149bf5ba sha1 ff03a9a7de174065bcf0ac060e6398ae989ea92f )
 )
 
 game (
@@ -1518,6 +1553,12 @@ game (
 )
 
 game (
+	name "Deca Sporta 2 - Wii de Sports 10 Shumoku! (Japan)"
+	description "Deca Sporta 2 - Wii de Sports 10 Shumoku! (Japan)"
+	rom ( name "Deca Sporta 2 - Wii de Sports 10 Shumoku! (Japan).iso" size 4699979776 crc ab648379 md5 6e3dc9864d693c572d10b3b0d0b3ca9d sha1 4fc148dc5afb595730d823a5e498e056a64e41e7 )
+)
+
+game (
 	name "Deca Sporta 3 - Wii de Sports 10 Shumoku! (Japan)"
 	description "Deca Sporta 3 - Wii de Sports 10 Shumoku! (Japan)"
 	rom ( name "Deca Sporta 3 - Wii de Sports 10 Shumoku! (Japan).iso" size 4699979776 crc 839b494b md5 e4f8b5b9ff513090323131b334b1f1e3 sha1 f89c5f7288d66dbb854d9774d781ce69f84f6b5e )
@@ -1638,9 +1679,10 @@ game (
 )
 
 game (
-	name "Disney Epic Mickey 2 - The Power of Two (USA)"
-	description "Disney Epic Mickey 2 - The Power of Two (USA)"
-	rom ( name "Disney Epic Mickey 2 - The Power of Two (USA).iso" size 4699979776 crc 55509501 md5 4df38d3d74f2db971470ac708e80091a sha1 abd5e464fbc6b28e124fade89b495dab1df123b8 )
+	name "Disney Epic Mickey 2 - The Power of Two (USA) (En,Fr,Es,Pt)"
+	serial "SERK4Q"
+	description "Disney Epic Mickey 2 - The Power of Two (USA) (En,Fr,Es,Pt)"
+	rom ( name "Disney Epic Mickey 2 - The Power of Two (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 55509501 md5 4df38d3d74f2db971470ac708e80091a sha1 abd5e464fbc6b28e124fade89b495dab1df123b8 serial "SERK4Q" )
 )
 
 game (
@@ -1675,8 +1717,9 @@ game (
 
 game (
 	name "Disney Infinity (USA) (En,Fr,Es,Pt)"
+	serial "SQIP4Q"
 	description "Disney Infinity (USA) (En,Fr,Es,Pt)"
-	rom ( name "Disney Infinity (USA) (En,Fr,Es,Pt).iso" size 8511160320 crc 17e6c6b1 md5 99452cffce11c53e727477fd93947e3e sha1 8cb941a5a10e9ab4ee14679112e24fa7ac836957 )
+	rom ( name "Disney Infinity (USA) (En,Fr,Es,Pt).iso" size 8511160320 crc 17e6c6b1 md5 99452cffce11c53e727477fd93947e3e sha1 8cb941a5a10e9ab4ee14679112e24fa7ac836957 serial "SQIP4Q" )
 )
 
 game (
@@ -1711,14 +1754,16 @@ game (
 
 game (
 	name "Disney Planes - Fire & Rescue (Europe) (En,Fr,De,Es,It)"
+	serial "SQQEVZ"
 	description "Disney Planes - Fire & Rescue (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Disney Planes - Fire & Rescue (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 32c6dbd8 md5 dbb735bded5471196a258b761137982c sha1 28cacd91980546eae94fbdd9f6e5dd299b99ac80 )
+	rom ( name "Disney Planes - Fire & Rescue (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 32c6dbd8 md5 dbb735bded5471196a258b761137982c sha1 28cacd91980546eae94fbdd9f6e5dd299b99ac80 serial "SQQEVZ" )
 )
 
 game (
 	name "Disney Planes (USA)"
+	serial "SU9X4Q"
 	description "Disney Planes (USA)"
-	rom ( name "Disney Planes (USA).iso" size 4699979776 crc 8c67b82f md5 4bbd4525b19b104ec9ca83e6cf37f6f3 sha1 ebe161289ab2e19d5995a3377fca6802bef7e374 )
+	rom ( name "Disney Planes (USA).iso" size 4699979776 crc 8c67b82f md5 4bbd4525b19b104ec9ca83e6cf37f6f3 sha1 ebe161289ab2e19d5995a3377fca6802bef7e374 serial "SU9X4Q" )
 )
 
 game (
@@ -1815,6 +1860,12 @@ game (
 	name "Disney-Pixar Ratatouille (USA)"
 	description "Disney-Pixar Ratatouille (USA)"
 	rom ( name "Disney-Pixar Ratatouille (USA).iso" size 4699979776 crc 77796b8e md5 dd43c13d2f7ba81eb19ff2ba8b94564a sha1 d529f31c4fad79bdb73c0d02995c85c2c089998c )
+)
+
+game (
+	name "Disney-Pixar Remy no Oishii Restaurant (Japan)"
+	description "Disney-Pixar Remy no Oishii Restaurant (Japan)"
+	rom ( name "Disney-Pixar Remy no Oishii Restaurant (Japan).iso" size 4699979776 crc e8b83de4 md5 c30cf6de934ba5242e68da51c30606fe sha1 7510d56474bf7fcfc0b6f51ec2fdfd988d1bc4bd )
 )
 
 game (
@@ -1963,20 +2014,23 @@ game (
 
 game (
 	name "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It)"
+	serial "JAEE"
 	description "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a1c33316 md5 8ecfcd59ed3fa9241af62f694ebcb343 sha1 9c957bb34e46c3c6fd9e48acb09dfcb9933301cf )
+	rom ( name "Donkey Kong Country Returns (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a1c33316 md5 8ecfcd59ed3fa9241af62f694ebcb343 sha1 9c957bb34e46c3c6fd9e48acb09dfcb9933301cf serial "JAEE" )
 )
 
 game (
 	name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00)"
+	serial "JAEP"
 	description "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00)"
-	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 9737a7a7 md5 d88b8280ecfd89f40b77925dfba15f9c sha1 9f2185ca3220249d056783757e85704ca787fe43 )
+	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.00).iso" size 4699979776 crc 9737a7a7 md5 d88b8280ecfd89f40b77925dfba15f9c sha1 9f2185ca3220249d056783757e85704ca787fe43 serial "JAEP" )
 )
 
 game (
 	name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01)"
+	serial "JAEK"
 	description "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01)"
-	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 063ded8d md5 09ab792ad383280a0b5fba8f5d34ff97 sha1 bfd468160eff04622f70d845ac539b042e55e7b2 )
+	rom ( name "Donkey Kong Country Returns (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 063ded8d md5 09ab792ad383280a0b5fba8f5d34ff97 sha1 bfd468160eff04622f70d845ac539b042e55e7b2 serial "JAEK" )
 )
 
 game (
@@ -1987,14 +2041,16 @@ game (
 
 game (
 	name "Donkey Kong Jungle Beat (Japan)"
+	serial "GYBP01"
 	description "Donkey Kong Jungle Beat (Japan)"
-	rom ( name "Donkey Kong Jungle Beat (Japan).iso" size 4699979776 crc 077a63e8 md5 0679a018133cb64ff7823c87b0451f28 sha1 ece3736d8e7000cc8b2af751e1f85bf873f1408f )
+	rom ( name "Donkey Kong Jungle Beat (Japan).iso" size 4699979776 crc 077a63e8 md5 0679a018133cb64ff7823c87b0451f28 sha1 ece3736d8e7000cc8b2af751e1f85bf873f1408f serial "GYBP01" )
 )
 
 game (
 	name "Donkey Kong Jungle Beat (USA) (En,Fr,Es)"
+	serial "GYBE01"
 	description "Donkey Kong Jungle Beat (USA) (En,Fr,Es)"
-	rom ( name "Donkey Kong Jungle Beat (USA) (En,Fr,Es).iso" size 4699979776 crc b88f74ea md5 aefb59ac51ecc07b3d057b3d568a1ea1 sha1 2060d010f303d37ad25ecda8c6d7ab97aaf2fd72 )
+	rom ( name "Donkey Kong Jungle Beat (USA) (En,Fr,Es).iso" size 4699979776 crc b88f74ea md5 aefb59ac51ecc07b3d057b3d568a1ea1 sha1 2060d010f303d37ad25ecda8c6d7ab97aaf2fd72 serial "GYBE01" )
 )
 
 game (
@@ -2047,20 +2103,23 @@ game (
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
+	serial "GD7E70"
 	description "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja).iso" size 4699979776 crc 0c713740 md5 41abf80c95fde8a90ae831c8ee1f7777 sha1 9de2efd8cc7517e5a464d6810a142c60317b731b )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 2 (USA) (En,Ja).iso" size 4699979776 crc 0c713740 md5 41abf80c95fde8a90ae831c8ee1f7777 sha1 9de2efd8cc7517e5a464d6810a142c60317b731b serial "GD7E70" )
 )
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
+	serial "GD7PB2"
 	description "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a5e94186 md5 656723af3267f554f5be2c166f0fbc92 sha1 7ff74ddaf87a63940dc6115c0dc52a87c4ed9370 )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc a5e94186 md5 656723af3267f554f5be2c166f0fbc92 sha1 7ff74ddaf87a63940dc6115c0dc52a87c4ed9370 serial "GD7PB2" )
 )
 
 game (
 	name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
+	serial "GD7P70"
 	description "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja)"
-	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja).iso" size 4699979776 crc 8f4a3b7b md5 691421036ae73128691634d20f50ce8a sha1 97ed07738895c863db0f6012e0b36eee7bdffa2c )
+	rom ( name "Dragon Ball Z - Budokai Tenkaichi 3 (USA) (En,Ja).iso" size 4699979776 crc 8f4a3b7b md5 691421036ae73128691634d20f50ce8a sha1 97ed07738895c863db0f6012e0b36eee7bdffa2c serial "GD7P70" )
 )
 
 game (
@@ -2131,8 +2190,9 @@ game (
 
 game (
 	name "Dragon Quest X - Nemureru Yuusha to Michibiki no Meiyuu Online (Japan)"
+	serial "S4SJGD"
 	description "Dragon Quest X - Nemureru Yuusha to Michibiki no Meiyuu Online (Japan)"
-	rom ( name "Dragon Quest X - Nemureru Yuusha to Michibiki no Meiyuu Online (Japan).iso" size 4699979776 crc 478460f4 md5 ff9f51a842f4c40509f601f88a026715 sha1 21f3b537535dd1c4b131af699719669e326d2696 )
+	rom ( name "Dragon Quest X - Nemureru Yuusha to Michibiki no Meiyuu Online (Japan).iso" size 4699979776 crc 478460f4 md5 ff9f51a842f4c40509f601f88a026715 sha1 21f3b537535dd1c4b131af699719669e326d2696 serial "S4SJGD" )
 )
 
 game (
@@ -2163,6 +2223,12 @@ game (
 	name "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr)"
 	description "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr)"
 	rom ( name "DreamWorks Kung Fu Panda - Legendary Warriors (USA) (En,Fr).iso" size 4699979776 crc 307c955c md5 4b5b9bce046c9c51cd8dbba0444f552c sha1 0f0126f580202c33f71f515bb45369765d2774b8 )
+)
+
+game (
+	name "DreamWorks Kung Fu Panda (Japan)"
+	description "DreamWorks Kung Fu Panda (Japan)"
+	rom ( name "DreamWorks Kung Fu Panda (Japan).iso" size 4699979776 crc 2c342e8c md5 43400b6c17adfc407d135adec120af09 sha1 9d68e061771314640a6ade599befc03d578da551 )
 )
 
 game (
@@ -2449,8 +2515,9 @@ game (
 
 game (
 	name "Family Fishing (Japan)"
+	serial "S22K01"
 	description "Family Fishing (Japan)"
-	rom ( name "Family Fishing (Japan).iso" size 4699979776 crc d13dbb86 md5 87a34c784fc01e58e70c47ac1db9f4c4 sha1 47a88d6052066422a6e7b6890ce12c108015b67b )
+	rom ( name "Family Fishing (Japan).iso" size 4699979776 crc d13dbb86 md5 87a34c784fc01e58e70c47ac1db9f4c4 sha1 47a88d6052066422a6e7b6890ce12c108015b67b serial "S22K01" )
 )
 
 game (
@@ -2611,14 +2678,16 @@ game (
 
 game (
 	name "FIFA 13 (Europe) (De,Es,It)"
+	serial "S3FP69"
 	description "FIFA 13 (Europe) (De,Es,It)"
-	rom ( name "FIFA 13 (Europe) (De,Es,It).iso" size 4699979776 crc fa3069bc md5 08f4bbeaa0fd32e23ea83458cd220c80 sha1 f4c6fca46cda7401ee9eb292cf6ec3d938cbc31b )
+	rom ( name "FIFA 13 (Europe) (De,Es,It).iso" size 4699979776 crc fa3069bc md5 08f4bbeaa0fd32e23ea83458cd220c80 sha1 f4c6fca46cda7401ee9eb292cf6ec3d938cbc31b serial "S3FP69" )
 )
 
 game (
 	name "FIFA 13 (Europe) (En,Fr,Nl)"
+	serial "S3FX69"
 	description "FIFA 13 (Europe) (En,Fr,Nl)"
-	rom ( name "FIFA 13 (Europe) (En,Fr,Nl).iso" size 4699979776 crc 745bc776 md5 55465079499c7c72aeadd5166ba54772 sha1 ef1f2aeea81c782cd28a260539589c56876c50a6 )
+	rom ( name "FIFA 13 (Europe) (En,Fr,Nl).iso" size 4699979776 crc 745bc776 md5 55465079499c7c72aeadd5166ba54772 sha1 ef1f2aeea81c782cd28a260539589c56876c50a6 serial "S3FX69" )
 )
 
 game (
@@ -2635,8 +2704,9 @@ game (
 
 game (
 	name "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es)"
+	serial "GCCE01"
 	description "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es)"
-	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es).iso" size 4699979776 crc e8663b8b md5 80e60fa6e8802e3773606a05c99980c0 sha1 7bcca1d5e94c7e0b67486c33ed9e44a216ea69ae )
+	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (Europe) (En,Fr,De,Es).iso" size 4699979776 crc e8663b8b md5 80e60fa6e8802e3773606a05c99980c0 sha1 7bcca1d5e94c7e0b67486c33ed9e44a216ea69ae serial "GCCE01" )
 )
 
 game (
@@ -2647,8 +2717,9 @@ game (
 
 game (
 	name "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es)"
+	serial "GCCP01"
 	description "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es)"
-	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es).iso" size 4699979776 crc 0bc95379 md5 ea2b120e323d5259d7871ec465e4dab6 sha1 0c7ac30cc373c9876879080ba2758a50cdcc3fb5 )
+	rom ( name "Final Fantasy Crystal Chronicles - Echoes of Time (USA) (En,Fr,Es).iso" size 4699979776 crc 0bc95379 md5 ea2b120e323d5259d7871ec465e4dab6 sha1 0c7ac30cc373c9876879080ba2758a50cdcc3fb5 serial "GCCP01" )
 )
 
 game (
@@ -2677,8 +2748,9 @@ game (
 
 game (
 	name "Final Fantasy Fables - Chocobo's Dungeon (USA)"
+	serial "R7FEUD"
 	description "Final Fantasy Fables - Chocobo's Dungeon (USA)"
-	rom ( name "Final Fantasy Fables - Chocobo's Dungeon (USA).iso" size 4699979776 crc 589cc931 md5 f926f9f719034d7bb07300ef1495d5d7 sha1 b59d7f6fcabcd11477577ee0184c23c34449a97f )
+	rom ( name "Final Fantasy Fables - Chocobo's Dungeon (USA).iso" size 4699979776 crc 589cc931 md5 f926f9f719034d7bb07300ef1495d5d7 sha1 b59d7f6fcabcd11477577ee0184c23c34449a97f serial "R7FEUD" )
 )
 
 game (
@@ -2689,8 +2761,9 @@ game (
 
 game (
 	name "Fire Emblem - Radiant Dawn (USA) (v1.00)"
+	serial "RFEPUD"
 	description "Fire Emblem - Radiant Dawn (USA) (v1.00)"
-	rom ( name "Fire Emblem - Radiant Dawn (USA) (v1.00).iso" size 4699979776 crc 5843dd9b md5 f23bc9391f2e5075d05bd08dd50cdf0e sha1 7b8f509ee847b906a4a7eea97a6d67f832964ce4 )
+	rom ( name "Fire Emblem - Radiant Dawn (USA) (v1.00).iso" size 4699979776 crc 5843dd9b md5 f23bc9391f2e5075d05bd08dd50cdf0e sha1 7b8f509ee847b906a4a7eea97a6d67f832964ce4 serial "RFEPUD" )
 )
 
 game (
@@ -2779,8 +2852,9 @@ game (
 
 game (
 	name "Furu Furu Park (USA)"
+	serial "FFPJ"
 	description "Furu Furu Park (USA)"
-	rom ( name "Furu Furu Park (USA).iso" size 4699979776 crc 8739edc6 md5 e819c803415f5bde6409f4cd17c7f3ee sha1 508593505516c15ece814f14f26a68ad20887eaf )
+	rom ( name "Furu Furu Park (USA).iso" size 4699979776 crc 8739edc6 md5 e819c803415f5bde6409f4cd17c7f3ee sha1 508593505516c15ece814f14f26a68ad20887eaf serial "FFPJ" )
 )
 
 game (
@@ -2857,8 +2931,9 @@ game (
 
 game (
 	name "Get Up and Dance (USA)"
+	serial "SLCEGN"
 	description "Get Up and Dance (USA)"
-	rom ( name "Get Up and Dance (USA).iso" size 4699979776 crc d68f8a38 md5 6fcd738e83714c4041ebf4d6ddfc590b sha1 30d12fb9aa72917cf9ba429c1f5a274f964c7a5f )
+	rom ( name "Get Up and Dance (USA).iso" size 4699979776 crc d68f8a38 md5 6fcd738e83714c4041ebf4d6ddfc590b sha1 30d12fb9aa72917cf9ba429c1f5a274f964c7a5f serial "SLCEGN" )
 )
 
 game (
@@ -2923,8 +2998,9 @@ game (
 
 game (
 	name "Go Play - Lumberjacks (USA)"
+	serial "RJXXFR"
 	description "Go Play - Lumberjacks (USA)"
-	rom ( name "Go Play - Lumberjacks (USA).iso" size 4699979776 crc c512a853 md5 430d5858d7f3f51fc37595b51fb79183 sha1 07488b786b73d5e23bc49180b197f73bcb620809 )
+	rom ( name "Go Play - Lumberjacks (USA).iso" size 4699979776 crc c512a853 md5 430d5858d7f3f51fc37595b51fb79183 sha1 07488b786b73d5e23bc49180b197f73bcb620809 serial "RJXXFR" )
 )
 
 game (
@@ -3057,6 +3133,12 @@ game (
 	name "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It)"
 	description "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Guitar Hero - Aerosmith (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1d182535 md5 d3be83f8c8f031a2d7e4dfabc0bc2f6c sha1 cc26205e1c6b9d088e930c84369433fa9f74e734 )
+)
+
+game (
+	name "Guitar Hero - Aerosmith (Japan)"
+	description "Guitar Hero - Aerosmith (Japan)"
+	rom ( name "Guitar Hero - Aerosmith (Japan).iso" size 4699979776 crc 40be81a8 md5 f581af810828bb80f8f42b77f549dc79 sha1 3ea72d7321152996f541820195a176dec80eea29 )
 )
 
 game (
@@ -3295,8 +3377,9 @@ game (
 
 game (
 	name "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It)"
+	serial "G4AEE9"
 	description "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 407fedf2 md5 22d8bacaa8227ea2e1fc2ac830a48738 sha1 b9b5d710848a282f2ecaf4db83e876ff4cfb7125 )
+	rom ( name "Harvest Moon - Magical Melody (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 407fedf2 md5 22d8bacaa8227ea2e1fc2ac830a48738 sha1 b9b5d710848a282f2ecaf4db83e876ff4cfb7125 serial "G4AEE9" )
 )
 
 game (
@@ -3373,8 +3456,9 @@ game (
 
 game (
 	name "Heavy Fire - Afghanistan (USA)"
+	serial "SH4PNK"
 	description "Heavy Fire - Afghanistan (USA)"
-	rom ( name "Heavy Fire - Afghanistan (USA).iso" size 4699979776 crc b1e9ca94 md5 91021311aea10f97a28c2f0d901376af sha1 37e2fc6296bd0172cbb125ae5d780d3e82bd9208 )
+	rom ( name "Heavy Fire - Afghanistan (USA).iso" size 4699979776 crc b1e9ca94 md5 91021311aea10f97a28c2f0d901376af sha1 37e2fc6296bd0172cbb125ae5d780d3e82bd9208 serial "SH4PNK" )
 )
 
 game (
@@ -3481,8 +3565,9 @@ game (
 
 game (
 	name "Ice Age 2 - The Meltdown (USA)"
+	serial "GIAE7D"
 	description "Ice Age 2 - The Meltdown (USA)"
-	rom ( name "Ice Age 2 - The Meltdown (USA).iso" size 4699979776 crc f04df98f md5 82872679fd1592663bd041aa4b29e116 sha1 902d71c95fa87d429e00b401dceb53c2637d8396 )
+	rom ( name "Ice Age 2 - The Meltdown (USA).iso" size 4699979776 crc f04df98f md5 82872679fd1592663bd041aa4b29e116 sha1 902d71c95fa87d429e00b401dceb53c2637d8396 serial "GIAE7D" )
 )
 
 game (
@@ -3505,14 +3590,16 @@ game (
 
 game (
 	name "Inazuma Eleven Strikers (Europe) (En,Es,It)"
+	serial "STQP01"
 	description "Inazuma Eleven Strikers (Europe) (En,Es,It)"
-	rom ( name "Inazuma Eleven Strikers (Europe) (En,Es,It).iso" size 4699979776 crc b29f2046 md5 15debf05a1bee86b1f05483b6ff79426 sha1 0bfffffe90eaa7f086f0d18fd10409ec83c2dc01 )
+	rom ( name "Inazuma Eleven Strikers (Europe) (En,Es,It).iso" size 4699979776 crc b29f2046 md5 15debf05a1bee86b1f05483b6ff79426 sha1 0bfffffe90eaa7f086f0d18fd10409ec83c2dc01 serial "STQP01" )
 )
 
 game (
 	name "Inazuma Eleven Strikers (Japan)"
+	serial "STQX01"
 	description "Inazuma Eleven Strikers (Japan)"
-	rom ( name "Inazuma Eleven Strikers (Japan).iso" size 4699979776 crc 45606dee md5 d63f5fb95b6629c7c074eee1e61c6a45 sha1 0c7bd44017553816551828f9c28882fa6a984645 )
+	rom ( name "Inazuma Eleven Strikers (Japan).iso" size 4699979776 crc 45606dee md5 d63f5fb95b6629c7c074eee1e61c6a45 sha1 0c7bd44017553816551828f9c28882fa6a984645 serial "STQX01" )
 )
 
 game (
@@ -3589,8 +3676,9 @@ game (
 
 game (
 	name "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
+	serial "SJ3PNL"
 	description "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi)"
-	rom ( name "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi).iso" size 4699979776 crc 528d7a25 md5 a1be405079f67faf7b8799a857c897d0 sha1 8a0ea595460e4e06829e23064db01cb5a6511269 )
+	rom ( name "Jakers! Kart Racing (Europe) (En,Fr,De,Es,It,Sv,No,Da,Fi).iso" size 4699979776 crc 528d7a25 md5 a1be405079f67faf7b8799a857c897d0 sha1 8a0ea595460e4e06829e23064db01cb5a6511269 serial "SJ3PNL" )
 )
 
 game (
@@ -3619,8 +3707,9 @@ game (
 
 game (
 	name "Jerry Rice & Nitus' Dog Football (USA)"
+	serial "SJCEZW"
 	description "Jerry Rice & Nitus' Dog Football (USA)"
-	rom ( name "Jerry Rice & Nitus' Dog Football (USA).iso" size 4699979776 crc 21c89063 md5 ef389123bb90c39352a0d66d960f4ad2 sha1 f94087201c3af6f98b09af333d3ad88ea6633f3c )
+	rom ( name "Jerry Rice & Nitus' Dog Football (USA).iso" size 4699979776 crc 21c89063 md5 ef389123bb90c39352a0d66d960f4ad2 sha1 f94087201c3af6f98b09af333d3ad88ea6633f3c serial "SJCEZW" )
 )
 
 game (
@@ -3636,9 +3725,21 @@ game (
 )
 
 game (
+	name "Jikkyou Powerful Major League 3 (Japan)"
+	description "Jikkyou Powerful Major League 3 (Japan)"
+	rom ( name "Jikkyou Powerful Major League 3 (Japan).iso" size 4699979776 crc a4f89bad md5 4437538422d869db640880d4a62a5300 sha1 412c34857e4b3d4ac88a87e7030683b7da17d55e )
+)
+
+game (
 	name "Jillian Michaels Fitness Ultimatum 2010 (USA) (En,Es)"
 	description "Jillian Michaels Fitness Ultimatum 2010 (USA) (En,Es)"
 	rom ( name "Jillian Michaels Fitness Ultimatum 2010 (USA) (En,Es).iso" size 4699979776 crc 84171fd9 md5 6051bc3a8000ac6d9a41351d57eece5d sha1 0c93532b31ffdcf32fac6c01a49b745db99fe996 )
+)
+
+game (
+	name "Jillian Michaels' Fitness Ultimatum 2009 (USA)"
+	description "Jillian Michaels' Fitness Ultimatum 2009 (USA)"
+	rom ( name "Jillian Michaels' Fitness Ultimatum 2009 (USA).iso" size 4699979776 crc c984d4ea md5 d929b2bf998e6a50d5ffa9b791552b3a sha1 a9a75cea16e13e16089b479afeeda4722788bd30 )
 )
 
 game (
@@ -3679,14 +3780,16 @@ game (
 
 game (
 	name "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl)"
+	serial "S5DE41"
 	description "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl)"
-	rom ( name "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl).iso" size 4699979776 crc 28562a9a md5 2a90121a4a9ae51f0ad8675c86b096a4 sha1 9e4e25b44795d50bde0e38a5eafbbec0f1046824 )
+	rom ( name "Just Dance - Disney Party (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi,Pl).iso" size 4699979776 crc 28562a9a md5 2a90121a4a9ae51f0ad8675c86b096a4 sha1 9e4e25b44795d50bde0e38a5eafbbec0f1046824 serial "S5DE41" )
 )
 
 game (
 	name "Just Dance - Disney Party (USA)"
+	serial "S5DP41"
 	description "Just Dance - Disney Party (USA)"
-	rom ( name "Just Dance - Disney Party (USA).iso" size 4699979776 crc 070a8981 md5 85190ce9f873b0f8c9f49213679fdd2e sha1 2ec288be30f38f8d66bd824948c27cb99e24935c )
+	rom ( name "Just Dance - Disney Party (USA).iso" size 4699979776 crc 070a8981 md5 85190ce9f873b0f8c9f49213679fdd2e sha1 2ec288be30f38f8d66bd824948c27cb99e24935c serial "S5DP41" )
 )
 
 game (
@@ -3699,6 +3802,12 @@ game (
 	name "Just Dance - Summer Party (USA)"
 	description "Just Dance - Summer Party (USA)"
 	rom ( name "Just Dance - Summer Party (USA).iso" size 4699979776 crc 4d000679 md5 0bc9096371d9ba3850ffa59cd5198190 sha1 c96bc7ced56e3e4bbb7866c21ac489505a5e5357 )
+)
+
+game (
+	name "Just Dance (USA) (En,Fr,Es)"
+	description "Just Dance (USA) (En,Fr,Es)"
+	rom ( name "Just Dance (USA) (En,Fr,Es).iso" size 4699979776 crc 7b0c095d md5 f2dcb14491dd49d63835b58b4dc17509 sha1 e791898a21b9cbbce6289b1e4524ff29a5018823 )
 )
 
 game (
@@ -3715,32 +3824,37 @@ game (
 
 game (
 	name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl)"
+	serial "SZ7E41"
 	description "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl)"
-	rom ( name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 771ccc25 md5 08aa014afa180e3d5474f29a2de7b904 sha1 beff7b469ac9c3878359c7206a0e924a44002253 )
+	rom ( name "Just Dance 2014 (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 771ccc25 md5 08aa014afa180e3d5474f29a2de7b904 sha1 beff7b469ac9c3878359c7206a0e924a44002253 serial "SZ7E41" )
 )
 
 game (
 	name "Just Dance 2014 (USA)"
+	serial "SE3P41"
 	description "Just Dance 2014 (USA)"
-	rom ( name "Just Dance 2014 (USA).iso" size 4699979776 crc 1fe94c32 md5 64d469178d925d5b79ae26f7289d165b sha1 5200b41d771c3f5f71fdf45752e27d44d3cffb64 )
+	rom ( name "Just Dance 2014 (USA).iso" size 4699979776 crc 1fe94c32 md5 64d469178d925d5b79ae26f7289d165b sha1 5200b41d771c3f5f71fdf45752e27d44d3cffb64 serial "SE3P41" )
 )
 
 game (
 	name "Just Dance 2015 (USA)"
+	serial "SJNE41"
 	description "Just Dance 2015 (USA)"
-	rom ( name "Just Dance 2015 (USA).iso" size 4699979776 crc ada3ce0e md5 6142795d6f0700963b9754ca59c92d90 sha1 af98bcd15d31a7a1b8ac1982b0d490e422b455dc )
+	rom ( name "Just Dance 2015 (USA).iso" size 4699979776 crc ada3ce0e md5 6142795d6f0700963b9754ca59c92d90 sha1 af98bcd15d31a7a1b8ac1982b0d490e422b455dc serial "SJNE41" )
 )
 
 game (
 	name "Just Dance 2016 (USA)"
+	serial "SJNP41"
 	description "Just Dance 2016 (USA)"
-	rom ( name "Just Dance 2016 (USA).iso" size 4699979776 crc 350cdaca md5 8041c2a5ad9465cb5fac6657514e3ea2 sha1 881ae88bda44a71835b8817eba70fd268345063c )
+	rom ( name "Just Dance 2016 (USA).iso" size 4699979776 crc 350cdaca md5 8041c2a5ad9465cb5fac6657514e3ea2 sha1 881ae88bda44a71835b8817eba70fd268345063c serial "SJNP41" )
 )
 
 game (
 	name "Just Dance 2017 (USA)"
+	serial "SJOE41"
 	description "Just Dance 2017 (USA)"
-	rom ( name "Just Dance 2017 (USA).iso" size 4699979776 crc b8516e2b md5 31e872f305d4355416a4ce345fdd9c4c sha1 04f808d78379a3266c64940aeb6ceb69740dc369 )
+	rom ( name "Just Dance 2017 (USA).iso" size 4699979776 crc b8516e2b md5 31e872f305d4355416a4ce345fdd9c4c sha1 04f808d78379a3266c64940aeb6ceb69740dc369 serial "SJOE41" )
 )
 
 game (
@@ -3787,8 +3901,9 @@ game (
 
 game (
 	name "Just Dance Kids 2014 (USA)"
+	serial "SJ7E41"
 	description "Just Dance Kids 2014 (USA)"
-	rom ( name "Just Dance Kids 2014 (USA).iso" size 4699979776 crc 5989f37e md5 249c90b8e91bfef3a51785f804911592 sha1 ad1b32fe34211ae715aaade1ddbd507f26295534 )
+	rom ( name "Just Dance Kids 2014 (USA).iso" size 4699979776 crc 5989f37e md5 249c90b8e91bfef3a51785f804911592 sha1 ad1b32fe34211ae715aaade1ddbd507f26295534 serial "SJ7E41" )
 )
 
 game (
@@ -3823,20 +3938,28 @@ game (
 
 game (
 	name "Karaoke Joysound Wii (Japan)"
+	serial "SOKEA4"
 	description "Karaoke Joysound Wii (Japan)"
-	rom ( name "Karaoke Joysound Wii (Japan).iso" size 4699979776 crc 728ad2fa md5 d89ae93539eaed363fc61c1238d4f22c sha1 e8669048eb88c8c213c5c29e6c1ed28351352513 )
+	rom ( name "Karaoke Joysound Wii (Japan).iso" size 4699979776 crc 728ad2fa md5 d89ae93539eaed363fc61c1238d4f22c sha1 e8669048eb88c8c213c5c29e6c1ed28351352513 serial "SOKEA4" )
 )
 
 game (
 	name "Karaoke Joysound Wii DX (Japan)"
+	serial "WOKJ"
 	description "Karaoke Joysound Wii DX (Japan)"
-	rom ( name "Karaoke Joysound Wii DX (Japan).iso" size 4699979776 crc 6c7c56c7 md5 f17ee412ea30a0064cd1dd11568a1e13 sha1 4078132e9b3d7669eac3c10d81c57ced052a3fb4 )
+	rom ( name "Karaoke Joysound Wii DX (Japan).iso" size 4699979776 crc 6c7c56c7 md5 f17ee412ea30a0064cd1dd11568a1e13 sha1 4078132e9b3d7669eac3c10d81c57ced052a3fb4 serial "WOKJ" )
 )
 
 game (
 	name "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan)"
 	description "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan)"
 	rom ( name "Karaoke Joysound Wii Super DX - Hitori de Minna de Utai Houdai! (Japan).iso" size 4699979776 crc f3c968e5 md5 c206d934c5898eee1d034fb70821d1a2 sha1 24158d2a812bc8e4052bd7e4bd1c9d8fc4628e24 )
+)
+
+game (
+	name "Kaseki Monster - Spectrobes (Japan)"
+	description "Kaseki Monster - Spectrobes (Japan)"
+	rom ( name "Kaseki Monster - Spectrobes (Japan).iso" size 4699979776 crc be0a2016 md5 72457808da2faf3b394d8d9f69025461 sha1 31036c3f03714521742eeedeb15ad670f49610a6 )
 )
 
 game (
@@ -3853,8 +3976,9 @@ game (
 
 game (
 	name "Kawasaki Jet Ski (USA)"
+	serial "NAIJ"
 	description "Kawasaki Jet Ski (USA)"
-	rom ( name "Kawasaki Jet Ski (USA).iso" size 4699979776 crc b5b1eea2 md5 2c29beea005ce08a697757c6c787a930 sha1 2899dab60c01cf4ef0b264c1cf837abf93452212 )
+	rom ( name "Kawasaki Jet Ski (USA).iso" size 4699979776 crc b5b1eea2 md5 2c29beea005ce08a697757c6c787a930 sha1 2899dab60c01cf4ef0b264c1cf837abf93452212 serial "NAIJ" )
 )
 
 game (
@@ -3931,14 +4055,16 @@ game (
 
 game (
 	name "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It)"
+	serial "FA8E"
 	description "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ed20d6cd md5 3e7e59cf9507ff5f7fb1fe536a730459 sha1 e09cf8cd58a05f0f7c0d6f0b8e4917c73f8f8021 )
+	rom ( name "Kirby's Adventure Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc ed20d6cd md5 3e7e59cf9507ff5f7fb1fe536a730459 sha1 e09cf8cd58a05f0f7c0d6f0b8e4917c73f8f8021 serial "FA8E" )
 )
 
 game (
 	name "Kirby's Dream Collection - Special Edition (USA)"
+	serial "S72E01"
 	description "Kirby's Dream Collection - Special Edition (USA)"
-	rom ( name "Kirby's Dream Collection - Special Edition (USA).iso" size 4699979776 crc 780fdad9 md5 2f584b2a7ea6b20ebd0c61a811db8248 sha1 598ec9e2a29ae82ed04a4a4c0c261fb80c3f82e5 )
+	rom ( name "Kirby's Dream Collection - Special Edition (USA).iso" size 4699979776 crc 780fdad9 md5 2f584b2a7ea6b20ebd0c61a811db8248 sha1 598ec9e2a29ae82ed04a4a4c0c261fb80c3f82e5 serial "S72E01" )
 )
 
 game (
@@ -4123,14 +4249,16 @@ game (
 
 game (
 	name "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02)"
+	serial "GZ2P01"
 	description "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02)"
-	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc b5825844 md5 70946e09da8f0bb218bb3b3542953d63 sha1 e9f9b22fee0d1e3be46fa01b7189d390f51c7f87 )
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc b5825844 md5 70946e09da8f0bb218bb3b3542953d63 sha1 e9f9b22fee0d1e3be46fa01b7189d390f51c7f87 serial "GZ2P01" )
 )
 
 game (
 	name "Legend of Zelda, The - Twilight Princess (USA) (v1.00)"
+	serial "GZ2E01"
 	description "Legend of Zelda, The - Twilight Princess (USA) (v1.00)"
-	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (v1.00).iso" size 4699979776 crc a1bc9066 md5 25003a3e3666edf79c99080be9083b34 sha1 e45f35bef5a5949539ac3cabfc231e97ee9343cf )
+	rom ( name "Legend of Zelda, The - Twilight Princess (USA) (v1.00).iso" size 4699979776 crc a1bc9066 md5 25003a3e3666edf79c99080be9083b34 sha1 e45f35bef5a5949539ac3cabfc231e97ee9343cf serial "GZ2E01" )
 )
 
 game (
@@ -4147,8 +4275,9 @@ game (
 
 game (
 	name "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt)"
+	serial "S7AKWR"
 	description "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt)"
-	rom ( name "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 855a352f md5 3ffc5c4f2fd821be9a68df20efc10478 sha1 7e32f47ad712ed3ff413318e4457aaa1787dcd99 )
+	rom ( name "LEGO Batman 2 - DC Super Heroes (USA) (En,Fr,Es,Pt).iso" size 4699979776 crc 855a352f md5 3ffc5c4f2fd821be9a68df20efc10478 sha1 7e32f47ad712ed3ff413318e4457aaa1787dcd99 serial "S7AKWR" )
 )
 
 game (
@@ -4242,9 +4371,9 @@ game (
 )
 
 game (
-	name "LEGO Star Wars - The Complete Saga (Europe) (En,Da)"
-	description "LEGO Star Wars - The Complete Saga (Europe) (En,Da)"
-	rom ( name "LEGO Star Wars - The Complete Saga (Europe) (En,Da).iso" size 4699979776 crc a9aa9858 md5 1e8b4d81c119628f22fa7bd70767b74d sha1 10f4bc81b7c262abe8c9020d7ef62e66e1a8cb6d )
+	name "LEGO Star Wars - The Complete Saga (Europe) (En,Fr,De,Es,It,Da)"
+	description "LEGO Star Wars - The Complete Saga (Europe) (En,Fr,De,Es,It,Da)"
+	rom ( name "LEGO Star Wars - The Complete Saga (Europe) (En,Fr,De,Es,It,Da).iso" size 4699979776 crc a9aa9858 md5 1e8b4d81c119628f22fa7bd70767b74d sha1 10f4bc81b7c262abe8c9020d7ef62e66e1a8cb6d )
 )
 
 game (
@@ -4291,8 +4420,9 @@ game (
 
 game (
 	name "Let's Dance (USA)"
+	serial "SLDEYG"
 	description "Let's Dance (USA)"
-	rom ( name "Let's Dance (USA).iso" size 4699979776 crc f50c3b40 md5 83bef5c6936551149f2008a0ac84bbe0 sha1 df87f144217e9540f9b401719b76105ee24611d1 )
+	rom ( name "Let's Dance (USA).iso" size 4699979776 crc f50c3b40 md5 83bef5c6936551149f2008a0ac84bbe0 sha1 df87f144217e9540f9b401719b76105ee24611d1 serial "SLDEYG" )
 )
 
 game (
@@ -4423,8 +4553,9 @@ game (
 
 game (
 	name "Madden NFL 07 (USA)"
+	serial "G7ME69"
 	description "Madden NFL 07 (USA)"
-	rom ( name "Madden NFL 07 (USA).iso" size 4699979776 crc 7f213889 md5 5e21ad948ad418c6bdffcbfd455fd374 sha1 5be8d3562719be0f176e16bb421e2b8ce18003a0 )
+	rom ( name "Madden NFL 07 (USA).iso" size 4699979776 crc 7f213889 md5 5e21ad948ad418c6bdffcbfd455fd374 sha1 5be8d3562719be0f176e16bb421e2b8ce18003a0 serial "G7ME69" )
 )
 
 game (
@@ -4435,8 +4566,9 @@ game (
 
 game (
 	name "Madden NFL 08 (USA)"
+	serial "GQ8E69"
 	description "Madden NFL 08 (USA)"
-	rom ( name "Madden NFL 08 (USA).iso" size 4699979776 crc 736f640e md5 714656cece1167ebdf8b66e70eb5445b sha1 6639131c05bb34304fb00e85f6eb82ac7aa62954 )
+	rom ( name "Madden NFL 08 (USA).iso" size 4699979776 crc 736f640e md5 714656cece1167ebdf8b66e70eb5445b sha1 6639131c05bb34304fb00e85f6eb82ac7aa62954 serial "GQ8E69" )
 )
 
 game (
@@ -4495,8 +4627,9 @@ game (
 
 game (
 	name "Major League Baseball 2K9 (USA)"
+	serial "G62E54"
 	description "Major League Baseball 2K9 (USA)"
-	rom ( name "Major League Baseball 2K9 (USA).iso" size 4699979776 crc 394cd872 md5 d4f9284dd5853a62f80c2078db5f45ec sha1 a4fe7d7b79dbd76aa0851f8ac178a0486a271e43 )
+	rom ( name "Major League Baseball 2K9 (USA).iso" size 4699979776 crc 394cd872 md5 d4f9284dd5853a62f80c2078db5f45ec sha1 a4fe7d7b79dbd76aa0851f8ac178a0486a271e43 serial "G62E54" )
 )
 
 game (
@@ -4533,6 +4666,12 @@ game (
 	name "Marines - Modern Urban Combat (USA)"
 	description "Marines - Modern Urban Combat (USA)"
 	rom ( name "Marines - Modern Urban Combat (USA).iso" size 4699979776 crc 4cf0030c md5 c5a0b6168e8d7e0c5a9dc47658e47591 sha1 e97198378323c2e7df88d6233b338799985a29fe )
+)
+
+game (
+	name "Mario & Sonic at Bejing Olympic (Japan)"
+	description "Mario & Sonic at Bejing Olympic (Japan)"
+	rom ( name "Mario & Sonic at Bejing Olympic (Japan).iso" size 4699979776 crc 814a63dc md5 1b2695ab00fd8d5af28b87d94d19dbe0 sha1 f3425b33bfaf1358599ea4f1d2b315ded0760527 )
 )
 
 game (
@@ -4573,80 +4712,98 @@ game (
 
 game (
 	name "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
+	serial "RMCE79"
 	description "Mario Kart Wii (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Mario Kart Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a70d78b md5 e7b1ff1fabb0789482ce2cb0661d986e sha1 4fde5ce38d68f632d92c5b0d52bbab0b1d355a95 )
+	rom ( name "Mario Kart Wii (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3a70d78b md5 e7b1ff1fabb0789482ce2cb0661d986e sha1 4fde5ce38d68f632d92c5b0d52bbab0b1d355a95 serial "RMCE79" )
 )
 
 game (
 	name "Mario Kart Wii (Japan)"
+	serial "RMCE80"
 	description "Mario Kart Wii (Japan)"
-	rom ( name "Mario Kart Wii (Japan).iso" size 4699979776 crc 36b9a6b2 md5 1942f9c144af686cb99557ee6a1a120d sha1 6539bada98dd48aed072082eba9e6049b53959bb )
+	rom ( name "Mario Kart Wii (Japan).iso" size 4699979776 crc 36b9a6b2 md5 1942f9c144af686cb99557ee6a1a120d sha1 6539bada98dd48aed072082eba9e6049b53959bb serial "RMCE80" )
 )
 
 game (
 	name "Mario Kart Wii (USA) (En,Fr,Es)"
+	serial "MK7P41"
 	description "Mario Kart Wii (USA) (En,Fr,Es)"
-	rom ( name "Mario Kart Wii (USA) (En,Fr,Es).iso" size 4699979776 crc 0cc7b4d5 md5 bb7f2c926cbcdee65e2a48b7002a52ea sha1 9faca97115fb267c1b8a4d8a05fb22f42a904733 )
+	rom ( name "Mario Kart Wii (USA) (En,Fr,Es).iso" size 4699979776 crc 0cc7b4d5 md5 bb7f2c926cbcdee65e2a48b7002a52ea sha1 9faca97115fb267c1b8a4d8a05fb22f42a904733 serial "MK7P41" )
 )
 
 game (
 	name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00)"
+	serial "GP5E01"
 	description "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00)"
-	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc c0621009 md5 5030e8dfbc5e0c71a70898cb648f5d3c sha1 902286817d0fd5cd63f5d6ff253dd78c839b12f2 )
+	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc c0621009 md5 5030e8dfbc5e0c71a70898cb648f5d3c sha1 902286817d0fd5cd63f5d6ff253dd78c839b12f2 serial "GP5E01" )
 )
 
 game (
 	name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01)"
+	serial "GMPE01"
 	description "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01)"
-	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc dfe8361a md5 a80fe065339638c73b260af7409ada57 sha1 fe4688283c9d2b7d76fda13ed991afdcacf182cd )
+	rom ( name "Mario Party 8 (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc dfe8361a md5 a80fe065339638c73b260af7409ada57 sha1 fe4688283c9d2b7d76fda13ed991afdcacf182cd serial "GMPE01" )
 )
 
 game (
 	name "Mario Party 8 (USA) (v1.01)"
+	serial "GP5P01"
 	description "Mario Party 8 (USA) (v1.01)"
-	rom ( name "Mario Party 8 (USA) (v1.01).iso" size 4699979776 crc 4d63d260 md5 a2feb2d57ec670615ac9f1d13e1db49b sha1 2252edd39961d3de9cf8ce529b721856960b8715 )
+	rom ( name "Mario Party 8 (USA) (v1.01).iso" size 4699979776 crc 4d63d260 md5 a2feb2d57ec670615ac9f1d13e1db49b sha1 2252edd39961d3de9cf8ce529b721856960b8715 serial "GP5P01" )
 )
 
 game (
 	name "Mario Party 8 (USA) (v1.02)"
+	serial "GMPP01"
 	description "Mario Party 8 (USA) (v1.02)"
-	rom ( name "Mario Party 8 (USA) (v1.02).iso" size 4699979776 crc 50829c66 md5 944c3f7db81170c9d86fc73dab1da24b sha1 f00bfeead8de26504571d30e83a0b84ea8c38c21 )
+	rom ( name "Mario Party 8 (USA) (v1.02).iso" size 4699979776 crc 50829c66 md5 944c3f7db81170c9d86fc73dab1da24b sha1 f00bfeead8de26504571d30e83a0b84ea8c38c21 serial "GMPP01" )
 )
 
 game (
 	name "Mario Party 9 (Europe) (En,Fr,De,Es,It)"
+	serial "GP6E01"
 	description "Mario Party 9 (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Mario Party 9 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15f44aaf md5 48722e664aecee14b181ee0ff56a7ec8 sha1 c0b62c218118c77494cab0feb41be69f6ea84c73 )
+	rom ( name "Mario Party 9 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15f44aaf md5 48722e664aecee14b181ee0ff56a7ec8 sha1 c0b62c218118c77494cab0feb41be69f6ea84c73 serial "GP6E01" )
 )
 
 game (
 	name "Mario Party 9 (Japan)"
+	serial "GP6P01"
 	description "Mario Party 9 (Japan)"
-	rom ( name "Mario Party 9 (Japan).iso" size 4699979776 crc 21c8d345 md5 02245d8da3a7b57bdc14ff1c55301fa1 sha1 06bee0298050d966f3de41ea540fd2a064958ebc )
+	rom ( name "Mario Party 9 (Japan).iso" size 4699979776 crc 21c8d345 md5 02245d8da3a7b57bdc14ff1c55301fa1 sha1 06bee0298050d966f3de41ea540fd2a064958ebc serial "GP6P01" )
 )
 
 game (
 	name "Mario Party 9 (USA) (En,Fr,Es)"
+	serial "GP7E01"
 	description "Mario Party 9 (USA) (En,Fr,Es)"
-	rom ( name "Mario Party 9 (USA) (En,Fr,Es).iso" size 4699979776 crc 3caea203 md5 a9aa140b48e67ccdba9c7c9afc9884bc sha1 bf3048189e0195fe4e230d2989db9f7d69ffd559 )
+	rom ( name "Mario Party 9 (USA) (En,Fr,Es).iso" size 4699979776 crc 3caea203 md5 a9aa140b48e67ccdba9c7c9afc9884bc sha1 bf3048189e0195fe4e230d2989db9f7d69ffd559 serial "GP7E01" )
 )
 
 game (
 	name "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
+	serial "GOMP01"
 	description "Mario Power Tennis (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Mario Power Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5532686d md5 0f29a21513495a096d68a7fb5c88e5fd sha1 f7dcfc46030ac305e76d13c5509690e5644103c6 )
+	rom ( name "Mario Power Tennis (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5532686d md5 0f29a21513495a096d68a7fb5c88e5fd sha1 f7dcfc46030ac305e76d13c5509690e5644103c6 serial "GOMP01" )
 )
 
 game (
 	name "Mario Power Tennis (USA) (En,Fr,Es)"
+	serial "GOME01"
 	description "Mario Power Tennis (USA) (En,Fr,Es)"
-	rom ( name "Mario Power Tennis (USA) (En,Fr,Es).iso" size 4699979776 crc 8e838298 md5 3bc8110b208074e4b39193145d3a8e78 sha1 b3a03ef79f942cb95c5dff8bdb00393fb355da6c )
+	rom ( name "Mario Power Tennis (USA) (En,Fr,Es).iso" size 4699979776 crc 8e838298 md5 3bc8110b208074e4b39193145d3a8e78 sha1 b3a03ef79f942cb95c5dff8bdb00393fb355da6c serial "GOME01" )
 )
 
 game (
 	name "Mario Sports Mix (Europe) (En,Fr,De,Es,It)"
 	description "Mario Sports Mix (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Mario Sports Mix (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 5c6fc758 md5 a63c794fca194c7ccbb57a82a857d821 sha1 06db56218697cff5089402167246d6556674cddd )
+)
+
+game (
+	name "Mario Sports Mix (Japan)"
+	description "Mario Sports Mix (Japan)"
+	rom ( name "Mario Sports Mix (Japan).iso" size 4699979776 crc 4ed29967 md5 255bd780dccc252dac60d429289ebe05 sha1 ee790bc25092ad7a62397f84222225c45c1a02c9 )
 )
 
 game (
@@ -4813,8 +4970,9 @@ game (
 
 game (
 	name "Metroid - Other M (Europe) (En,Fr,De,Es,It)"
+	serial "FBZP"
 	description "Metroid - Other M (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Metroid - Other M (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 582dea6c md5 c188f8704b96e40e3f86b4f698599b3c sha1 e169caa7ac194f779cbc3c3c014f86fb90d96e11 )
+	rom ( name "Metroid - Other M (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 582dea6c md5 c188f8704b96e40e3f86b4f698599b3c sha1 e169caa7ac194f779cbc3c3c014f86fb90d96e11 serial "FBZP" )
 )
 
 game (
@@ -4825,14 +4983,16 @@ game (
 
 game (
 	name "Metroid - Other M (USA) (En,Fr,Es) (v1.00)"
+	serial "FBZJ"
 	description "Metroid - Other M (USA) (En,Fr,Es) (v1.00)"
-	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.00).iso" size 8511160320 crc 29da327a md5 8c66027b1023fe8e64645611fadd2a95 sha1 a22962468be3f137633275c05505cdc2b50ecc3b )
+	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.00).iso" size 8511160320 crc 29da327a md5 8c66027b1023fe8e64645611fadd2a95 sha1 a22962468be3f137633275c05505cdc2b50ecc3b serial "FBZJ" )
 )
 
 game (
 	name "Metroid - Other M (USA) (En,Fr,Es) (v1.01)"
+	serial "FBZE"
 	description "Metroid - Other M (USA) (En,Fr,Es) (v1.01)"
-	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.01).iso" size 8511160320 crc 62515755 md5 3e6170d5deb86ccf11a90aedea35097e sha1 afca5b8f0a9d6c632c81471e04a4f96c209f91f0 )
+	rom ( name "Metroid - Other M (USA) (En,Fr,Es) (v1.01).iso" size 8511160320 crc 62515755 md5 3e6170d5deb86ccf11a90aedea35097e sha1 afca5b8f0a9d6c632c81471e04a4f96c209f91f0 serial "FBZE" )
 )
 
 game (
@@ -4855,14 +5015,16 @@ game (
 
 game (
 	name "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It)"
+	serial "GM8E01"
 	description "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 7506b685 md5 735c0d0c16177e3294f5e0faf7a69571 sha1 0c80815eedca8f597f01d5a380489766c56acf88 )
+	rom ( name "Metroid Prime Trilogy (Europe) (En,Fr,De,Es,It).iso" size 8511160320 crc 7506b685 md5 735c0d0c16177e3294f5e0faf7a69571 sha1 0c80815eedca8f597f01d5a380489766c56acf88 serial "GM8E01" )
 )
 
 game (
 	name "Metroid Prime Trilogy (USA)"
+	serial "GM8P01"
 	description "Metroid Prime Trilogy (USA)"
-	rom ( name "Metroid Prime Trilogy (USA).iso" size 8511160320 crc 8a4b439d md5 823df1c3c425f1383529f368f6479359 sha1 2204e5b19039d44b2379ab2065fd548c800ba680 )
+	rom ( name "Metroid Prime Trilogy (USA).iso" size 8511160320 crc 8a4b439d md5 823df1c3c425f1383529f368f6479359 sha1 2204e5b19039d44b2379ab2065fd548c800ba680 serial "GM8P01" )
 )
 
 game (
@@ -4926,6 +5088,12 @@ game (
 )
 
 game (
+	name "Mini Desktop Racing (USA)"
+	description "Mini Desktop Racing (USA)"
+	rom ( name "Mini Desktop Racing (USA).iso" size 4699979776 crc 2d369b9b md5 e70c8bc0bcf62fd3624ca46b5a3ba250 sha1 bb2de1d33d40525a5b6693d70472f4ecc934598c )
+)
+
+game (
 	name "Mini Ninjas (USA) (En,Fr,Es)"
 	description "Mini Ninjas (USA) (En,Fr,Es)"
 	rom ( name "Mini Ninjas (USA) (En,Fr,Es).iso" size 4699979776 crc 5e9240cc md5 fefb0aa57b1aa3ea9c0c92d764f1c00b sha1 a91564914eb22c5f917cff726aacda42768ab66a )
@@ -4962,6 +5130,12 @@ game (
 )
 
 game (
+	name "Monkey Mischief! Party Time (USA) (En,Fr)"
+	description "Monkey Mischief! Party Time (USA) (En,Fr)"
+	rom ( name "Monkey Mischief! Party Time (USA) (En,Fr).iso" size 4699979776 crc de0b1bfd md5 be38e0ee01cf8b218996c70f9cea8514 sha1 78a8894218f6244aba880cd73f3f9972b6d1fcb6 )
+)
+
+game (
 	name "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi)"
 	description "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi)"
 	rom ( name "Monopoly (Europe) (En,Fr,De,Es,Nl,Sv,Fi).iso" size 4699979776 crc df1a3655 md5 d3f9e3db53cd27272e8f3a36d6cd9531 sha1 4fc41d05c54958c374f19e8f113617ce3db048a0 )
@@ -4993,14 +5167,16 @@ game (
 
 game (
 	name "Monster High - Ghoul Spirit (Europe) (En,Fr,De,Es,It,Nl)"
+	serial "SAOE78"
 	description "Monster High - Ghoul Spirit (Europe) (En,Fr,De,Es,It,Nl)"
-	rom ( name "Monster High - Ghoul Spirit (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 584556f2 md5 04dc4465a75aad037eb16b49eb73049b sha1 f994d98aca252b3a1211ad98579e8cdf8527c8f9 )
+	rom ( name "Monster High - Ghoul Spirit (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 584556f2 md5 04dc4465a75aad037eb16b49eb73049b sha1 f994d98aca252b3a1211ad98579e8cdf8527c8f9 serial "SAOE78" )
 )
 
 game (
 	name "Monster High - New Ghoul in School (USA)"
+	serial "S5MEVZ"
 	description "Monster High - New Ghoul in School (USA)"
-	rom ( name "Monster High - New Ghoul in School (USA).iso" size 4699979776 crc ee8c5672 md5 fc728d69815fdc6bea5f855ca5fc5583 sha1 6af83fb6a1cb9b5ce2acea0f66d96aba0fb42046 )
+	rom ( name "Monster High - New Ghoul in School (USA).iso" size 4699979776 crc ee8c5672 md5 fc728d69815fdc6bea5f855ca5fc5583 sha1 6af83fb6a1cb9b5ce2acea0f66d96aba0fb42046 serial "S5MEVZ" )
 )
 
 game (
@@ -5031,6 +5207,12 @@ game (
 	name "Monster Hunter Tri (USA)"
 	description "Monster Hunter Tri (USA)"
 	rom ( name "Monster Hunter Tri (USA).iso" size 4699979776 crc 46848f76 md5 a56b231600a6a084eb91514e124194eb sha1 ea0e5098509c241b5ec1997c14deace08dd95280 )
+)
+
+game (
+	name "Monster Jam - Urban Assault (USA) (En,Fr)"
+	description "Monster Jam - Urban Assault (USA) (En,Fr)"
+	rom ( name "Monster Jam - Urban Assault (USA) (En,Fr).iso" size 4699979776 crc e368223d md5 1cdf5d66fe7baaa49c209f2781abbc76 sha1 80a57a3d3a1aefced7456a60a8c5ebdfe942f3a8 )
 )
 
 game (
@@ -5221,8 +5403,9 @@ game (
 
 game (
 	name "Mystery Case Files - The Malgrave Incident (USA)"
+	serial "DAVE01"
 	description "Mystery Case Files - The Malgrave Incident (USA)"
-	rom ( name "Mystery Case Files - The Malgrave Incident (USA).iso" size 4699979776 crc 1f0ed55d md5 2d516390efa9bab69f62aca10742d963 sha1 332082ee374791bee2fbff10c6bffc68ff426207 )
+	rom ( name "Mystery Case Files - The Malgrave Incident (USA).iso" size 4699979776 crc 1f0ed55d md5 2d516390efa9bab69f62aca10742d963 sha1 332082ee374791bee2fbff10c6bffc68ff426207 serial "DAVE01" )
 )
 
 game (
@@ -5239,8 +5422,9 @@ game (
 
 game (
 	name "Namco Museum Remix (Europe) (En,Fr,De,Es,It)"
+	serial "RN2K70"
 	description "Namco Museum Remix (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Namco Museum Remix (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d3173f05 md5 ee5fdf64d27dd4e5b67aa945b2970abc sha1 360889e4a356a529225cae4facd24de577ed4046 )
+	rom ( name "Namco Museum Remix (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc d3173f05 md5 ee5fdf64d27dd4e5b67aa945b2970abc sha1 360889e4a356a529225cae4facd24de577ed4046 serial "RN2K70" )
 )
 
 game (
@@ -5269,14 +5453,16 @@ game (
 
 game (
 	name "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es)"
+	serial "GNUEDA"
 	description "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es)"
-	rom ( name "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es).iso" size 4699979776 crc eb279052 md5 b959d02591c33c9cc3e8f3df1692f0f4 sha1 0e1acc214f10c76c2f5cfe654dacc137eb4b0ba2 )
+	rom ( name "Naruto - Clash of Ninja Revolution 2 (USA) (En,Fr,Es).iso" size 4699979776 crc eb279052 md5 b959d02591c33c9cc3e8f3df1692f0f4 sha1 0e1acc214f10c76c2f5cfe654dacc137eb4b0ba2 serial "GNUEDA" )
 )
 
 game (
 	name "Naruto Shippuden - Clash of Ninja Revolution III (USA)"
+	serial "RNEEUD"
 	description "Naruto Shippuden - Clash of Ninja Revolution III (USA)"
-	rom ( name "Naruto Shippuden - Clash of Ninja Revolution III (USA).iso" size 4699979776 crc e9931cd0 md5 a4d5c9c9aa2b285c8fecf5c700a0bb10 sha1 a92de4e3397a0f40348b890ed86392ab646b3306 )
+	rom ( name "Naruto Shippuden - Clash of Ninja Revolution III (USA).iso" size 4699979776 crc e9931cd0 md5 a4d5c9c9aa2b285c8fecf5c700a0bb10 sha1 a92de4e3397a0f40348b890ed86392ab646b3306 serial "RNEEUD" )
 )
 
 game (
@@ -5353,14 +5539,16 @@ game (
 
 game (
 	name "Need for Speed - Carbon (Japan)"
+	serial "GUGE69"
 	description "Need for Speed - Carbon (Japan)"
-	rom ( name "Need for Speed - Carbon (Japan).iso" size 4699979776 crc 876fbc70 md5 abe513ff6432fd46a3327ef9a7b96244 sha1 52c08d525548b1bc6d053b914cc584c6c9f7e3ce )
+	rom ( name "Need for Speed - Carbon (Japan).iso" size 4699979776 crc 876fbc70 md5 abe513ff6432fd46a3327ef9a7b96244 sha1 52c08d525548b1bc6d053b914cc584c6c9f7e3ce serial "GUGE69" )
 )
 
 game (
 	name "Need for Speed - Carbon (USA)"
+	serial "GUGD69"
 	description "Need for Speed - Carbon (USA)"
-	rom ( name "Need for Speed - Carbon (USA).iso" size 4699979776 crc 3ac65cad md5 b5edd42a6ed6b1ca25c6e16c1c468f81 sha1 7432d23b9bf926016b86ebfcdf34f7009c0ea179 )
+	rom ( name "Need for Speed - Carbon (USA).iso" size 4699979776 crc 3ac65cad md5 b5edd42a6ed6b1ca25c6e16c1c468f81 sha1 7432d23b9bf926016b86ebfcdf34f7009c0ea179 serial "GUGD69" )
 )
 
 game (
@@ -5389,8 +5577,9 @@ game (
 
 game (
 	name "Need for Speed - Undercover (Europe) (En,Nl)"
+	serial "GNDD69"
 	description "Need for Speed - Undercover (Europe) (En,Nl)"
-	rom ( name "Need for Speed - Undercover (Europe) (En,Nl).iso" size 4699979776 crc f035f9ed md5 ce4ab3d9ad9e0e112c075836eabc9a1b sha1 96bcaaab517b861a688ca23fe0d82cf2f6c0eecf )
+	rom ( name "Need for Speed - Undercover (Europe) (En,Nl).iso" size 4699979776 crc f035f9ed md5 ce4ab3d9ad9e0e112c075836eabc9a1b sha1 96bcaaab517b861a688ca23fe0d82cf2f6c0eecf serial "GNDD69" )
 )
 
 game (
@@ -5425,38 +5614,44 @@ game (
 
 game (
 	name "Netflix (USA)"
+	serial "HCLP"
 	description "Netflix (USA)"
-	rom ( name "Netflix (USA).iso" size 4699979776 crc c69a7acd md5 e9016c841434bcaa7824ecb6d97f8310 sha1 82a23ba1b32d1c99e8150af1266bb66148ab1146 )
+	rom ( name "Netflix (USA).iso" size 4699979776 crc c69a7acd md5 e9016c841434bcaa7824ecb6d97f8310 sha1 82a23ba1b32d1c99e8150af1266bb66148ab1146 serial "HCLP" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
+	serial "KMNE03"
 	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01)"
-	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc e71b9bc7 md5 fc335c3187c6940a290f7c971fbdc576 sha1 8c0408ae7ed6539fccc9b002d50eecb994000af7 )
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.01).iso" size 4699979776 crc e71b9bc7 md5 fc335c3187c6940a290f7c971fbdc576 sha1 8c0408ae7ed6539fccc9b002d50eecb994000af7 serial "KMNE03" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
+	serial "NMNP01"
 	description "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02)"
-	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 2a9344fb md5 ea2698f30aef31182d1c506d9ae5cbd2 sha1 91ff55875b0e0401e6246d5bc2a52d7a80517860 )
+	rom ( name "New Super Mario Bros. Wii (Europe) (En,Fr,De,Es,It) (v1.02).iso" size 4699979776 crc 2a9344fb md5 ea2698f30aef31182d1c506d9ae5cbd2 sha1 91ff55875b0e0401e6246d5bc2a52d7a80517860 serial "NMNP01" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (Japan)"
+	serial "NSMB02"
 	description "New Super Mario Bros. Wii (Japan)"
-	rom ( name "New Super Mario Bros. Wii (Japan).iso" size 4699979776 crc 1a1e2e29 md5 3e3337ea0fab653aa50807c839ceeec4 sha1 019b9a7abfcf9f2429b2d106d884a72d17fb922d )
+	rom ( name "New Super Mario Bros. Wii (Japan).iso" size 4699979776 crc 1a1e2e29 md5 3e3337ea0fab653aa50807c839ceeec4 sha1 019b9a7abfcf9f2429b2d106d884a72d17fb922d serial "NSMB02" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
+	serial "KMNJ03"
 	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01)"
-	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 1cc03c30 md5 05022377c66dcc13dd8308b333c202db sha1 aa7b134a7606435ddcd735f2964ebdecde38c2ef )
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc 1cc03c30 md5 05022377c66dcc13dd8308b333c202db sha1 aa7b134a7606435ddcd735f2964ebdecde38c2ef serial "KMNJ03" )
 )
 
 game (
 	name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
+	serial "KMNP03"
 	description "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02)"
-	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 8c30d1d7 md5 b31a7da0d493ec1f558b4e1899406a14 sha1 9ac7242a5feebe1d0a6e2775c21f482c471b2240 )
+	rom ( name "New Super Mario Bros. Wii (USA) (En,Fr,Es) (v1.02).iso" size 4699979776 crc 8c30d1d7 md5 b31a7da0d493ec1f558b4e1899406a14 sha1 9ac7242a5feebe1d0a6e2775c21f482c471b2240 serial "KMNP03" )
 )
 
 game (
@@ -5538,9 +5733,9 @@ game (
 )
 
 game (
-	name "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe)"
-	description "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe)"
-	rom ( name "Nickelodeon Rock University - The Naked Brothers - The Videogame (Europe).iso" size 4699979776 crc 9f305f02 md5 9615cd69ca692a5acea7a1a0cec63b25 sha1 3f8146e8732d34df2866aaf33ee512dd363708bb )
+	name "Nickelodeon Rock University - The Naked Brothers Band - The Videogame (Europe)"
+	description "Nickelodeon Rock University - The Naked Brothers Band - The Videogame (Europe)"
+	rom ( name "Nickelodeon Rock University - The Naked Brothers Band - The Videogame (Europe).iso" size 4699979776 crc 9f305f02 md5 9615cd69ca692a5acea7a1a0cec63b25 sha1 3f8146e8732d34df2866aaf33ee512dd363708bb )
 )
 
 game (
@@ -5622,9 +5817,9 @@ game (
 )
 
 game (
-	name "Ninja Reflex (USA) (En,Ja,Fr,De,Es,It)"
-	description "Ninja Reflex (USA) (En,Ja,Fr,De,Es,It)"
-	rom ( name "Ninja Reflex (USA) (En,Ja,Fr,De,Es,It).iso" size 4699979776 crc 5808f3e0 md5 31d5b31992f677fea41cb4296bb37b5f sha1 6dbc49da21ea969d791488889541e1cdd27b4ad9 )
+	name "Ninja Reflex (USA) (En,Fr,Es)"
+	description "Ninja Reflex (USA) (En,Fr,Es)"
+	rom ( name "Ninja Reflex (USA) (En,Fr,Es).iso" size 4699979776 crc 5808f3e0 md5 31d5b31992f677fea41cb4296bb37b5f sha1 6dbc49da21ea969d791488889541e1cdd27b4ad9 )
 )
 
 game (
@@ -5700,6 +5895,12 @@ game (
 )
 
 game (
+	name "Nyanko to Mahou no Boushi (Japan)"
+	description "Nyanko to Mahou no Boushi (Japan)"
+	rom ( name "Nyanko to Mahou no Boushi (Japan).iso" size 4699979776 crc aa29aa99 md5 01b77590e7cc1d8f70fff8036bf44b8d sha1 b308995a722030d5145d37bcccd0f0ebc766396b )
+)
+
+game (
 	name "Oboro Muramasa (Japan)"
 	description "Oboro Muramasa (Japan)"
 	rom ( name "Oboro Muramasa (Japan).iso" size 4699979776 crc 1de890ba md5 0ff33af4ef84752c5ecfa21b62960cb5 sha1 2d06e72dfd2f190a0d286b058b23bbd89830e020 )
@@ -5760,9 +5961,16 @@ game (
 )
 
 game (
+	name "Oneechanbara Revolution (Japan)"
+	description "Oneechanbara Revolution (Japan)"
+	rom ( name "Oneechanbara Revolution (Japan).iso" size 4699979776 crc 7a4b0673 md5 8938f535e9bcf4ecab8c1b4160e8142d sha1 94410a27cfe0e1380ebd00c5db5d1fe83e29d984 )
+)
+
+game (
 	name "Open Season (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
+	serial "GOSE41"
 	description "Open Season (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)"
-	rom ( name "Open Season (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).iso" size 4699979776 crc b3769c88 md5 09ce4583b60000aa8917732e0cd954e2 sha1 54331c5fc28ec7c224e1c39d3640296eab5c95e3 )
+	rom ( name "Open Season (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).iso" size 4699979776 crc b3769c88 md5 09ce4583b60000aa8917732e0cd954e2 sha1 54331c5fc28ec7c224e1c39d3640296eab5c95e3 serial "GOSE41" )
 )
 
 game (
@@ -5845,14 +6053,16 @@ game (
 
 game (
 	name "Pandora's Tower (Europe) (En,Fr,De,Es,It)"
+	serial "SX3PUD"
 	description "Pandora's Tower (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Pandora's Tower (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4acb6d26 md5 518bfc0cb7e374f85568ca88975c7ef6 sha1 ff425322460a98aa8f56335372ba0d696450ee28 )
+	rom ( name "Pandora's Tower (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 4acb6d26 md5 518bfc0cb7e374f85568ca88975c7ef6 sha1 ff425322460a98aa8f56335372ba0d696450ee28 serial "SX3PUD" )
 )
 
 game (
 	name "Pandora's Tower (USA) (En,Fr,Es)"
+	serial "SX3EXJ"
 	description "Pandora's Tower (USA) (En,Fr,Es)"
-	rom ( name "Pandora's Tower (USA) (En,Fr,Es).iso" size 4699979776 crc 8398c943 md5 5bf999114d6741c04fe2e84d1b7b0509 sha1 66284691913ed85029b394eef194024f4a99c614 )
+	rom ( name "Pandora's Tower (USA) (En,Fr,Es).iso" size 4699979776 crc 8398c943 md5 5bf999114d6741c04fe2e84d1b7b0509 sha1 66284691913ed85029b394eef194024f4a99c614 serial "SX3EXJ" )
 )
 
 game (
@@ -5923,14 +6133,27 @@ game (
 
 game (
 	name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
+	serial "S3IEA4"
 	description "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El)"
-	rom ( name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc f9a8040b md5 9de67539e64b3544bbedd137a59d401f sha1 c56632c087b14356d82ff3042be8baee69167e1c )
+	rom ( name "PES 2013 - Pro Evolution Soccer (Europe) (Fr,De,El).iso" size 4699979776 crc f9a8040b md5 9de67539e64b3544bbedd137a59d401f sha1 c56632c087b14356d82ff3042be8baee69167e1c serial "S3IEA4" )
+)
+
+game (
+	name "Petz - Dogz 2 (USA) (En,Fr,Es)"
+	description "Petz - Dogz 2 (USA) (En,Fr,Es)"
+	rom ( name "Petz - Dogz 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 6bd41076 md5 7e3cafa3f9c482e867c7997a74e67a05 sha1 3f1a085cdab3c35781c6f1157fb35aba50744378 )
 )
 
 game (
 	name "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl)"
 	description "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "Petz Sports - Dog Playground (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc fde9f955 md5 3ca050ac702df96ae53d0cb1763a1831 sha1 b44623b9763feabe2e24d18e24001cb596e3a3e9 )
+)
+
+game (
+	name "Petz Sports (USA) (En,Fr,Es)"
+	description "Petz Sports (USA) (En,Fr,Es)"
+	rom ( name "Petz Sports (USA) (En,Fr,Es).iso" size 4699979776 crc 33acb08f md5 78267b46a2d15bb7e293cd45c5e6d980 sha1 e10497aef584dd96e5e58c8a7e97a4f7844d19a6 )
 )
 
 game (
@@ -5947,32 +6170,37 @@ game (
 
 game (
 	name "Pikmin (Europe) (En,Fr,De,Es,It)"
+	serial "GPIP01"
 	description "Pikmin (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Pikmin (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b999d726 md5 eded803e145c760bad2983caf19ff504 sha1 7aa500b30b242edeabaf340c26242c9b36b24b23 )
+	rom ( name "Pikmin (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc b999d726 md5 eded803e145c760bad2983caf19ff504 sha1 7aa500b30b242edeabaf340c26242c9b36b24b23 serial "GPIP01" )
 )
 
 game (
 	name "Pikmin (USA) (En,Fr,Es)"
+	serial "GPIE01"
 	description "Pikmin (USA) (En,Fr,Es)"
-	rom ( name "Pikmin (USA) (En,Fr,Es).iso" size 4699979776 crc 4f34ddc2 md5 092f509fdd7370903ab2c3e993e1ae3c sha1 abdef200f685aa5f38d14633a837a01ca3b9e8c1 )
+	rom ( name "Pikmin (USA) (En,Fr,Es).iso" size 4699979776 crc 4f34ddc2 md5 092f509fdd7370903ab2c3e993e1ae3c sha1 abdef200f685aa5f38d14633a837a01ca3b9e8c1 serial "GPIE01" )
 )
 
 game (
 	name "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
+	serial "GPVE01"
 	description "Pikmin 2 (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Pikmin 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c3f982e7 md5 2cf3a242c243652e9d174e155e91bef6 sha1 779b63380319d419f8e1e65f59da66311748c43b )
+	rom ( name "Pikmin 2 (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc c3f982e7 md5 2cf3a242c243652e9d174e155e91bef6 sha1 779b63380319d419f8e1e65f59da66311748c43b serial "GPVE01" )
 )
 
 game (
 	name "Pikmin 2 (USA) (En,Fr,Es)"
+	serial "GPVP01"
 	description "Pikmin 2 (USA) (En,Fr,Es)"
-	rom ( name "Pikmin 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 5ecfe4cc md5 bbc83bf55728c0a3ec689579f2eb795e sha1 77c7e815fbf3e83b71c398a70369d674bf413caa )
+	rom ( name "Pikmin 2 (USA) (En,Fr,Es).iso" size 4699979776 crc 5ecfe4cc md5 bbc83bf55728c0a3ec689579f2eb795e sha1 77c7e815fbf3e83b71c398a70369d674bf413caa serial "GPVP01" )
 )
 
 game (
 	name "Pinball Hall of Fame - The Williams Collection (USA)"
+	serial "GHFE4Z"
 	description "Pinball Hall of Fame - The Williams Collection (USA)"
-	rom ( name "Pinball Hall of Fame - The Williams Collection (USA).iso" size 4699979776 crc 5171889f md5 3aa36fd2e39e6bb9564fdd78482fac70 sha1 d0abca98a0e89a5979d6a270e3ee3bd0a32ada45 )
+	rom ( name "Pinball Hall of Fame - The Williams Collection (USA).iso" size 4699979776 crc 5171889f md5 3aa36fd2e39e6bb9564fdd78482fac70 sha1 d0abca98a0e89a5979d6a270e3ee3bd0a32ada45 serial "GHFE4Z" )
 )
 
 game (
@@ -5995,14 +6223,16 @@ game (
 
 game (
 	name "Pitfall - The Big Adventure (Europe) (En,Fr,De,Es,It)"
+	serial "MCVJ"
 	description "Pitfall - The Big Adventure (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Pitfall - The Big Adventure (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 554cfc18 md5 6e80425b8e617b9aa9ecec17c8bb5b17 sha1 9b567eda629ae2765ac5a3d2d5537cc4c67d754d )
+	rom ( name "Pitfall - The Big Adventure (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 554cfc18 md5 6e80425b8e617b9aa9ecec17c8bb5b17 sha1 9b567eda629ae2765ac5a3d2d5537cc4c67d754d serial "MCVJ" )
 )
 
 game (
 	name "Pitfall - The Big Adventure (USA) (En,Fr)"
+	serial "MCVE"
 	description "Pitfall - The Big Adventure (USA) (En,Fr)"
-	rom ( name "Pitfall - The Big Adventure (USA) (En,Fr).iso" size 4699979776 crc cdb1742a md5 dd28800c6fae72ee502afd87bc687294 sha1 4e2f635902ccb221af6b3ebde6e25f1b9ef50471 )
+	rom ( name "Pitfall - The Big Adventure (USA) (En,Fr).iso" size 4699979776 crc cdb1742a md5 dd28800c6fae72ee502afd87bc687294 sha1 4e2f635902ccb221af6b3ebde6e25f1b9ef50471 serial "MCVE" )
 )
 
 game (
@@ -6121,14 +6351,16 @@ game (
 
 game (
 	name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl)"
+	serial "GPTP41"
 	description "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl)"
-	rom ( name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc d0b4fa69 md5 aaaf8d9226365969db23460c1ffda396 sha1 ac8415e87ee45a6457b60294892758f877d8d7e3 )
+	rom ( name "Prince of Persia - The Forgotten Sands (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc d0b4fa69 md5 aaaf8d9226365969db23460c1ffda396 sha1 ac8415e87ee45a6457b60294892758f877d8d7e3 serial "GPTP41" )
 )
 
 game (
 	name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es)"
+	serial "GPTE41"
 	description "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es)"
-	rom ( name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es).iso" size 4699979776 crc f91314fd md5 7048c2caad084bd96bbf812a87c29ba5 sha1 bc7d035a71e11cc4a70bc985bf5f3b2f612bf3b2 )
+	rom ( name "Prince of Persia - The Forgotten Sands (USA) (En,Fr,Es).iso" size 4699979776 crc f91314fd md5 7048c2caad084bd96bbf812a87c29ba5 sha1 bc7d035a71e11cc4a70bc985bf5f3b2f612bf3b2 serial "GPTE41" )
 )
 
 game (
@@ -6157,14 +6389,16 @@ game (
 
 game (
 	name "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It)"
+	serial "SL2PUD"
 	description "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 04deedb6 md5 7ddbcbff22ab64b3e99604d402bfa3d8 sha1 a6e647f0218a2a1aed7be6c85f3d6422414e163a )
+	rom ( name "Project Zero 2 - Wii Edition (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 04deedb6 md5 7ddbcbff22ab64b3e99604d402bfa3d8 sha1 a6e647f0218a2a1aed7be6c85f3d6422414e163a serial "SL2PUD" )
 )
 
 game (
 	name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00)"
+	serial "FBIP"
 	description "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00)"
-	rom ( name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc fa85b484 md5 41e6916519d67f457298fd988b7e9f65 sha1 f3d09de0b94a09f7ae8c4c92cdd477d21fa7bf90 )
+	rom ( name "Punch-Out!! (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 4699979776 crc fa85b484 md5 41e6916519d67f457298fd988b7e9f65 sha1 f3d09de0b94a09f7ae8c4c92cdd477d21fa7bf90 serial "FBIP" )
 )
 
 game (
@@ -6181,14 +6415,16 @@ game (
 
 game (
 	name "Punch-Out!! (USA) (En,Fr,Es)"
+	serial "FBIJ"
 	description "Punch-Out!! (USA) (En,Fr,Es)"
-	rom ( name "Punch-Out!! (USA) (En,Fr,Es).iso" size 4699979776 crc c1f5f0e4 md5 6d0e5884cac674ac50d132cb1f3aa762 sha1 0232f0c61285e9e810847f504b1c626f6a6d472a )
+	rom ( name "Punch-Out!! (USA) (En,Fr,Es).iso" size 4699979776 crc c1f5f0e4 md5 6d0e5884cac674ac50d132cb1f3aa762 sha1 0232f0c61285e9e810847f504b1c626f6a6d472a serial "FBIJ" )
 )
 
 game (
 	name "Puyo Puyo 7 (Japan)"
+	serial "E5YJ"
 	description "Puyo Puyo 7 (Japan)"
-	rom ( name "Puyo Puyo 7 (Japan).iso" size 4699979776 crc 001c87e9 md5 752091f983d5a310eb3759600641947c sha1 c6b710bb63aefed0bc5907d7da7fa635101a68b5 )
+	rom ( name "Puyo Puyo 7 (Japan).iso" size 4699979776 crc 001c87e9 md5 752091f983d5a310eb3759600641947c sha1 c6b710bb63aefed0bc5907d7da7fa635101a68b5 serial "E5YJ" )
 )
 
 game (
@@ -6282,6 +6518,12 @@ game (
 )
 
 game (
+	name "Rainbow Pop (Japan)"
+	description "Rainbow Pop (Japan)"
+	rom ( name "Rainbow Pop (Japan).iso" size 4699979776 crc 079b8665 md5 103c1daf88995ecb3ea89acfcfa4091e sha1 85bef4feffb76be0fa5d16b059c594c9a05c1b07 )
+)
+
+game (
 	name "Rally Racer (Europe) (En,Fr,De,Es,It)"
 	description "Rally Racer (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Rally Racer (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 3691417a md5 9e3e36e98a41daadc340426ed2876375 sha1 c5e116d38a0e61510b60f9b1866c974b753c61b7 )
@@ -6295,8 +6537,9 @@ game (
 
 game (
 	name "Rampage - Total Destruction (USA)"
+	serial "GXNE5D"
 	description "Rampage - Total Destruction (USA)"
-	rom ( name "Rampage - Total Destruction (USA).iso" size 4699979776 crc 5512f6f6 md5 a489cf68ec7541aed8f7bc3a44b13b52 sha1 f1485f19bd590c90afec80916a913f8dc6446ba3 )
+	rom ( name "Rampage - Total Destruction (USA).iso" size 4699979776 crc 5512f6f6 md5 a489cf68ec7541aed8f7bc3a44b13b52 sha1 f1485f19bd590c90afec80916a913f8dc6446ba3 serial "GXNE5D" )
 )
 
 game (
@@ -6384,9 +6627,9 @@ game (
 )
 
 game (
-	name "Rayman - Raving Rabbids 2 (USA) (v1.01)"
-	description "Rayman - Raving Rabbids 2 (USA) (v1.01)"
-	rom ( name "Rayman - Raving Rabbids 2 (USA) (v1.01).iso" size 4699979776 crc e55a3ba2 md5 75dec3dbcd7da58031746f46efff37d7 sha1 4c1c263e41164e9a4be055763fa723f983cf890b )
+	name "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.01)"
+	description "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.01)"
+	rom ( name "Rayman - Raving Rabbids 2 (USA) (En,Fr,Es) (v1.01).iso" size 4699979776 crc e55a3ba2 md5 75dec3dbcd7da58031746f46efff37d7 sha1 4c1c263e41164e9a4be055763fa723f983cf890b )
 )
 
 game (
@@ -6403,26 +6646,30 @@ game (
 
 game (
 	name "Reader Rabbit - 1st Grade (USA)"
+	serial "SRTXNL"
 	description "Reader Rabbit - 1st Grade (USA)"
-	rom ( name "Reader Rabbit - 1st Grade (USA).iso" size 4699979776 crc d624f530 md5 fae0710a8ffc0336dc07977e574081df sha1 e8c05099e7cc3809fa30f9f4ef471be4a61bdbd1 )
+	rom ( name "Reader Rabbit - 1st Grade (USA).iso" size 4699979776 crc d624f530 md5 fae0710a8ffc0336dc07977e574081df sha1 e8c05099e7cc3809fa30f9f4ef471be4a61bdbd1 serial "SRTXNL" )
 )
 
 game (
 	name "Reader Rabbit - 2nd Grade (USA)"
+	serial "SRWXNL"
 	description "Reader Rabbit - 2nd Grade (USA)"
-	rom ( name "Reader Rabbit - 2nd Grade (USA).iso" size 4699979776 crc 37149261 md5 0f3b6e21985d30d9ead55c9ee6cab336 sha1 29e0de92ef68f1402984b6c30bbe8f324502a5d0 )
+	rom ( name "Reader Rabbit - 2nd Grade (USA).iso" size 4699979776 crc 37149261 md5 0f3b6e21985d30d9ead55c9ee6cab336 sha1 29e0de92ef68f1402984b6c30bbe8f324502a5d0 serial "SRWXNL" )
 )
 
 game (
 	name "Reader Rabbit - Kindergarten (USA)"
+	serial "SREXNL"
 	description "Reader Rabbit - Kindergarten (USA)"
-	rom ( name "Reader Rabbit - Kindergarten (USA).iso" size 4699979776 crc 8b03b88b md5 59487395e44baa24e82bcbaa3dd502b3 sha1 67292fa2c4bc8b0dcb919a4e4f5875ad1f0adb1b )
+	rom ( name "Reader Rabbit - Kindergarten (USA).iso" size 4699979776 crc 8b03b88b md5 59487395e44baa24e82bcbaa3dd502b3 sha1 67292fa2c4bc8b0dcb919a4e4f5875ad1f0adb1b serial "SREXNL" )
 )
 
 game (
 	name "Reader Rabbit - Preschool (USA)"
+	serial "SRLXNL"
 	description "Reader Rabbit - Preschool (USA)"
-	rom ( name "Reader Rabbit - Preschool (USA).iso" size 4699979776 crc 209c734c md5 42ee45b5997e8836fda6d3d0998e8313 sha1 b15b4e1766b6efcbb89fbeec30b9bc1953cbde2c )
+	rom ( name "Reader Rabbit - Preschool (USA).iso" size 4699979776 crc 209c734c md5 42ee45b5997e8836fda6d3d0998e8313 sha1 b15b4e1766b6efcbb89fbeec30b9bc1953cbde2c serial "SRLXNL" )
 )
 
 game (
@@ -6511,8 +6758,9 @@ game (
 
 game (
 	name "Resident Evil 4 - Wii Edition (USA)"
+	serial "G4BP08"
 	description "Resident Evil 4 - Wii Edition (USA)"
-	rom ( name "Resident Evil 4 - Wii Edition (USA).iso" size 4699979776 crc 19016866 md5 1235cb29693d7b52b63d60103a7d4f47 sha1 62218f84ac3ca545992fb34c537e4fd01efb9c46 )
+	rom ( name "Resident Evil 4 - Wii Edition (USA).iso" size 4699979776 crc 19016866 md5 1235cb29693d7b52b63d60103a7d4f47 sha1 62218f84ac3ca545992fb34c537e4fd01efb9c46 serial "G4BP08" )
 )
 
 game (
@@ -6631,14 +6879,16 @@ game (
 
 game (
 	name "Rodea the Sky Soldier (Europe) (En,Ja,Fr,De)"
+	serial "SROPNS"
 	description "Rodea the Sky Soldier (Europe) (En,Ja,Fr,De)"
-	rom ( name "Rodea the Sky Soldier (Europe) (En,Ja,Fr,De).iso" size 4699979776 crc f617527f md5 6038de894120d5a8eb9d646bb7b581ee sha1 3d0a12b978b70a665cfa8f22838f6a0a1669e281 )
+	rom ( name "Rodea the Sky Soldier (Europe) (En,Ja,Fr,De).iso" size 4699979776 crc f617527f md5 6038de894120d5a8eb9d646bb7b581ee sha1 3d0a12b978b70a665cfa8f22838f6a0a1669e281 serial "SROPNS" )
 )
 
 game (
 	name "Rodea the Sky Soldier (USA) (En,Ja,Fr,De)"
+	serial "SROENS"
 	description "Rodea the Sky Soldier (USA) (En,Ja,Fr,De)"
-	rom ( name "Rodea the Sky Soldier (USA) (En,Ja,Fr,De).iso" size 4699979776 crc ac68bc6a md5 cb89f1778801a77f5c0764105d32c5cd sha1 b5cb04d912b163f7d1fa5700a747e698439dca5f )
+	rom ( name "Rodea the Sky Soldier (USA) (En,Ja,Fr,De).iso" size 4699979776 crc ac68bc6a md5 cb89f1778801a77f5c0764105d32c5cd sha1 b5cb04d912b163f7d1fa5700a747e698439dca5f serial "SROENS" )
 )
 
 game (
@@ -6685,8 +6935,9 @@ game (
 
 game (
 	name "Rune Factory - Tides of Destiny (USA)"
+	serial "SO3EUD"
 	description "Rune Factory - Tides of Destiny (USA)"
-	rom ( name "Rune Factory - Tides of Destiny (USA).iso" size 4699979776 crc f4b7b417 md5 404672b23263c77a281cd1bd84692cfd sha1 d52b0027c21d7f9910aa1f7024452e81487c2fbd )
+	rom ( name "Rune Factory - Tides of Destiny (USA).iso" size 4699979776 crc f4b7b417 md5 404672b23263c77a281cd1bd84692cfd sha1 d52b0027c21d7f9910aa1f7024452e81487c2fbd serial "SO3EUD" )
 )
 
 game (
@@ -6877,8 +7128,27 @@ game (
 
 game (
 	name "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es)"
+	serial "SB3EUD"
 	description "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es)"
-	rom ( name "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es).iso" size 4699979776 crc cdb50439 md5 8a807910e8eb6c0e96182a5e788dc6b0 sha1 93493a4ad597f734933d3bb5158f5abeda9cc600 )
+	rom ( name "Sengoku Basara - Samurai Heroes (USA) (En,Fr,Es).iso" size 4699979776 crc cdb50439 md5 8a807910e8eb6c0e96182a5e788dc6b0 sha1 93493a4ad597f734933d3bb5158f5abeda9cc600 serial "SB3EUD" )
+)
+
+game (
+	name "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2 - Heroes)"
+	description "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2 - Heroes)"
+	rom ( name "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2 - Heroes).iso" size 4699979776 crc 64bec0c5 md5 d1424093e34c85620dd53153304107e8 sha1 819b180e1df65dc942a5d8d06990369d77a7af69 )
+)
+
+game (
+	name "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2)"
+	description "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2)"
+	rom ( name "Sengoku Basara 2 - Heroes - Double Pack (Japan) (Sengoku Basara 2).iso" size 4699979776 crc 8aa47a01 md5 88a3d5cc846fe66109c3d4791645b381 sha1 9506a00f21b31ec256c64dce2fa7daf776ec076b )
+)
+
+game (
+	name "Sengoku Basara 3 - Utage (Japan)"
+	description "Sengoku Basara 3 - Utage (Japan)"
+	rom ( name "Sengoku Basara 3 - Utage (Japan).iso" size 4699979776 crc fc95a06f md5 62de78dbf1b8e7b6d85fb6ebdbf6c5a6 sha1 8f0e1a1b6d5336f6f527a27ab9cc4c9e7608f3ff )
 )
 
 game (
@@ -6891,6 +7161,12 @@ game (
 	name "Sengoku Musou - Katana (Japan)"
 	description "Sengoku Musou - Katana (Japan)"
 	rom ( name "Sengoku Musou - Katana (Japan).iso" size 4699979776 crc d4a21fde md5 8a40ea7f8b044d26402f50f53bdaf709 sha1 68ae41e7ab1b543d56853be629a119ae9a66feb7 )
+)
+
+game (
+	name "Sengoku Musou 3 - Moushouden (Japan)"
+	description "Sengoku Musou 3 - Moushouden (Japan)"
+	rom ( name "Sengoku Musou 3 - Moushouden (Japan).iso" size 8511160320 crc 2a35cf1a md5 1b6d1c1875715ae093c9d09ad1f86268 sha1 19f4a69fe624ce174148cb43009d9ba37bc622e2 )
 )
 
 game (
@@ -6913,8 +7189,9 @@ game (
 
 game (
 	name "Sesame Street - Ready, Set, Grover! (Australia)"
+	serial "SESEWR"
 	description "Sesame Street - Ready, Set, Grover! (Australia)"
-	rom ( name "Sesame Street - Ready, Set, Grover! (Australia).iso" size 4699979776 crc a475703f md5 ef2bd3c6d34b2e5dadc7ee456cbc5258 sha1 f48707aa3ef122bd9364e8183bdee4dcdcb0e268 )
+	rom ( name "Sesame Street - Ready, Set, Grover! (Australia).iso" size 4699979776 crc a475703f md5 ef2bd3c6d34b2e5dadc7ee456cbc5258 sha1 f48707aa3ef122bd9364e8183bdee4dcdcb0e268 serial "SESEWR" )
 )
 
 game (
@@ -7051,8 +7328,9 @@ game (
 
 game (
 	name "Simple Wii Series Vol. 5 - The Block Kuzushi (Japan)"
+	serial "WDIJ"
 	description "Simple Wii Series Vol. 5 - The Block Kuzushi (Japan)"
-	rom ( name "Simple Wii Series Vol. 5 - The Block Kuzushi (Japan).iso" size 4699979776 crc 71c08e98 md5 9a8e8f94a18d3fdf99764f2f2ce73b7d sha1 af0e1ed6672d8cbc1ba28f954b7e0d04b22ad509 )
+	rom ( name "Simple Wii Series Vol. 5 - The Block Kuzushi (Japan).iso" size 4699979776 crc 71c08e98 md5 9a8e8f94a18d3fdf99764f2f2ce73b7d sha1 af0e1ed6672d8cbc1ba28f954b7e0d04b22ad509 serial "WDIJ" )
 )
 
 game (
@@ -7081,8 +7359,9 @@ game (
 
 game (
 	name "Sims 2, The - Pets (USA)"
+	serial "G4OP69"
 	description "Sims 2, The - Pets (USA)"
-	rom ( name "Sims 2, The - Pets (USA).iso" size 4699979776 crc 300143e6 md5 f2c09d0bd528ea507001747152f769b6 sha1 b63346da51eab874c862825658dfb4a46e56ecd9 )
+	rom ( name "Sims 2, The - Pets (USA).iso" size 4699979776 crc 300143e6 md5 f2c09d0bd528ea507001747152f769b6 sha1 b63346da51eab874c862825658dfb4a46e56ecd9 serial "G4OP69" )
 )
 
 game (
@@ -7159,26 +7438,30 @@ game (
 
 game (
 	name "Skylanders - Spyro's Adventure (USA)"
+	serial "SSPE52"
 	description "Skylanders - Spyro's Adventure (USA)"
-	rom ( name "Skylanders - Spyro's Adventure (USA).iso" size 4699979776 crc a558b2db md5 bbf93219cc63efd88cb3600485f22e55 sha1 7df3a483241cf3f7e80868ef56ab88478c8792ff )
+	rom ( name "Skylanders - Spyro's Adventure (USA).iso" size 4699979776 crc a558b2db md5 bbf93219cc63efd88cb3600485f22e55 sha1 7df3a483241cf3f7e80868ef56ab88478c8792ff serial "SSPE52" )
 )
 
 game (
 	name "Skylanders - Swap Force (Europe) (Es,It)"
+	serial "SVXE52"
 	description "Skylanders - Swap Force (Europe) (Es,It)"
-	rom ( name "Skylanders - Swap Force (Europe) (Es,It).iso" size 4699979776 crc ccb3a774 md5 32d4e91c03e84ba70ecd188a8c795c84 sha1 676852e28f9d9c1f03464bac39cc02047ba55f7d )
+	rom ( name "Skylanders - Swap Force (Europe) (Es,It).iso" size 4699979776 crc ccb3a774 md5 32d4e91c03e84ba70ecd188a8c795c84 sha1 676852e28f9d9c1f03464bac39cc02047ba55f7d serial "SVXE52" )
 )
 
 game (
 	name "Skylanders - Swap Force (Europe) (Fr,Nl)"
+	serial "SVXF52"
 	description "Skylanders - Swap Force (Europe) (Fr,Nl)"
-	rom ( name "Skylanders - Swap Force (Europe) (Fr,Nl).iso" size 4699979776 crc d84d9f69 md5 8ce650bacd913c87729c0d0e4959ebf2 sha1 fa934ba321e60c773b1d3f7da829cd1e02cd4589 )
+	rom ( name "Skylanders - Swap Force (Europe) (Fr,Nl).iso" size 4699979776 crc d84d9f69 md5 8ce650bacd913c87729c0d0e4959ebf2 sha1 fa934ba321e60c773b1d3f7da829cd1e02cd4589 serial "SVXF52" )
 )
 
 game (
 	name "Skylanders - Trap Team (Europe) (Es,It)"
+	serial "SK8D52"
 	description "Skylanders - Trap Team (Europe) (Es,It)"
-	rom ( name "Skylanders - Trap Team (Europe) (Es,It).iso" size 4699979776 crc 2a14281c md5 04e467e76327d1459a665709d7962349 sha1 4a10b413c2e86f78ceec72588dfd6297cf3c91a4 )
+	rom ( name "Skylanders - Trap Team (Europe) (Es,It).iso" size 4699979776 crc 2a14281c md5 04e467e76327d1459a665709d7962349 sha1 4a10b413c2e86f78ceec72588dfd6297cf3c91a4 serial "SK8D52" )
 )
 
 game (
@@ -7333,14 +7616,16 @@ game (
 
 game (
 	name "Soulcalibur Legends (Japan)"
+	serial "GRSPAF"
 	description "Soulcalibur Legends (Japan)"
-	rom ( name "Soulcalibur Legends (Japan).iso" size 4699979776 crc 514021ef md5 7a7701b96302e53d2cf5a0b6d6f3da63 sha1 71e044de7de6372be13736b2f50acd662785d537 )
+	rom ( name "Soulcalibur Legends (Japan).iso" size 4699979776 crc 514021ef md5 7a7701b96302e53d2cf5a0b6d6f3da63 sha1 71e044de7de6372be13736b2f50acd662785d537 serial "GRSPAF" )
 )
 
 game (
 	name "Soulcalibur Legends (USA)"
+	serial "GRSEAF"
 	description "Soulcalibur Legends (USA)"
-	rom ( name "Soulcalibur Legends (USA).iso" size 4699979776 crc c61d7423 md5 d5167f28453f55b532b14e6c40fa2def sha1 a17c5b250695128263e7c5c844eefb91ec448b30 )
+	rom ( name "Soulcalibur Legends (USA).iso" size 4699979776 crc c61d7423 md5 d5167f28453f55b532b14e6c40fa2def sha1 a17c5b250695128263e7c5c844eefb91ec448b30 serial "GRSEAF" )
 )
 
 game (
@@ -7393,8 +7678,9 @@ game (
 
 game (
 	name "Spider-Man 3 (USA)"
+	serial "GK2D52"
 	description "Spider-Man 3 (USA)"
-	rom ( name "Spider-Man 3 (USA).iso" size 4699979776 crc edc80639 md5 df761e58b4bd556519d9e5f2a9b5fce4 sha1 5c099250561a38d766e2cebb197f7960739c9bd3 )
+	rom ( name "Spider-Man 3 (USA).iso" size 4699979776 crc edc80639 md5 df761e58b4bd556519d9e5f2a9b5fce4 sha1 5c099250561a38d766e2cebb197f7960739c9bd3 serial "GK2D52" )
 )
 
 game (
@@ -7483,14 +7769,16 @@ game (
 
 game (
 	name "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It)"
+	serial "GSXE64"
 	description "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1ed5d26c md5 4fe0b71f051fa087cc699a73200f30d5 sha1 ef155d2b0a1955aafab58d0fb0f45e68d0d78a57 )
+	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 1ed5d26c md5 4fe0b71f051fa087cc699a73200f30d5 sha1 ef155d2b0a1955aafab58d0fb0f45e68d0d78a57 serial "GSXE64" )
 )
 
 game (
 	name "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr)"
+	serial "GSXD64"
 	description "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr)"
-	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr).iso" size 4699979776 crc 118d8520 md5 b6a8fdc0e72e49ad6a5406bd9d4c0480 sha1 174dee8c37c73cc2efb4a3a24038989e150c7859 )
+	rom ( name "Star Wars - The Clone Wars - Lightsaber Duels (USA) (En,Fr).iso" size 4699979776 crc 118d8520 md5 b6a8fdc0e72e49ad6a5406bd9d4c0480 sha1 174dee8c37c73cc2efb4a3a24038989e150c7859 serial "GSXD64" )
 )
 
 game (
@@ -7521,6 +7809,12 @@ game (
 	name "Star Wars - The Force Unleashed II (USA) (En,Fr,Es)"
 	description "Star Wars - The Force Unleashed II (USA) (En,Fr,Es)"
 	rom ( name "Star Wars - The Force Unleashed II (USA) (En,Fr,Es).iso" size 4699979776 crc 6eb87435 md5 b8f85efe0152d83aaae0ec0a0087a6f3 sha1 659f6f6d3ae8941bd9ff41647e7502e1985ae75e )
+)
+
+game (
+	name "Story Hour - Fairy Tales (USA) (En,Fr,Es)"
+	description "Story Hour - Fairy Tales (USA) (En,Fr,Es)"
+	rom ( name "Story Hour - Fairy Tales (USA) (En,Fr,Es).iso" size 4699979776 crc 9a2aa782 md5 4556630af086a8c790249ed97e42354a sha1 cc5ef7630028aa26c7b5a8549538489f1667f854 )
 )
 
 game (
@@ -7579,8 +7873,9 @@ game (
 
 game (
 	name "Super Mario Galaxy (Japan)"
+	serial "SB4E25"
 	description "Super Mario Galaxy (Japan)"
-	rom ( name "Super Mario Galaxy (Japan).iso" size 4699979776 crc 9cdb7505 md5 de205dd5e379f5bd2e0fcea8cae9497b sha1 ebbeb06a222efd78846254bc829f411d0987db99 )
+	rom ( name "Super Mario Galaxy (Japan).iso" size 4699979776 crc 9cdb7505 md5 de205dd5e379f5bd2e0fcea8cae9497b sha1 ebbeb06a222efd78846254bc829f411d0987db99 serial "SB4E25" )
 )
 
 game (
@@ -7615,26 +7910,30 @@ game (
 
 game (
 	name "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It)"
+	serial "GMBP8P"
 	description "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc af64c370 md5 eb4c7bc397f78f9f48778d289c7d5f09 sha1 17b840a49273b48d512df15c7b937e4fd3c4f44b )
+	rom ( name "Super Monkey Ball - Banana Blitz (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc af64c370 md5 eb4c7bc397f78f9f48778d289c7d5f09 sha1 17b840a49273b48d512df15c7b937e4fd3c4f44b serial "GMBP8P" )
 )
 
 game (
 	name "Super Monkey Ball - Banana Blitz (USA)"
+	serial "GMBE8P"
 	description "Super Monkey Ball - Banana Blitz (USA)"
-	rom ( name "Super Monkey Ball - Banana Blitz (USA).iso" size 4699979776 crc ad99f707 md5 0043d80c3d70f90787522adb7cb6fdf1 sha1 8489e61fc7af5c42478649371ff0eb9d94120b68 )
+	rom ( name "Super Monkey Ball - Banana Blitz (USA).iso" size 4699979776 crc ad99f707 md5 0043d80c3d70f90787522adb7cb6fdf1 sha1 8489e61fc7af5c42478649371ff0eb9d94120b68 serial "GMBE8P" )
 )
 
 game (
 	name "Super Monkey Ball - Step & Roll (Europe)"
+	serial "GM2P8P"
 	description "Super Monkey Ball - Step & Roll (Europe)"
-	rom ( name "Super Monkey Ball - Step & Roll (Europe).iso" size 4699979776 crc 9733b44e md5 f9bcf8383e6ca8237941a24e6488ec29 sha1 a3f8718d4ac00fa72c6294c7cbb9607ea60b6cc1 )
+	rom ( name "Super Monkey Ball - Step & Roll (Europe).iso" size 4699979776 crc 9733b44e md5 f9bcf8383e6ca8237941a24e6488ec29 sha1 a3f8718d4ac00fa72c6294c7cbb9607ea60b6cc1 serial "GM2P8P" )
 )
 
 game (
 	name "Super Monkey Ball - Step & Roll (USA)"
+	serial "GM2E8P"
 	description "Super Monkey Ball - Step & Roll (USA)"
-	rom ( name "Super Monkey Ball - Step & Roll (USA).iso" size 4699979776 crc c64e229e md5 6b1ed46bc3506331014cd49be3e05d03 sha1 965a9066f7f8503a344fbc0c994d41841018c99c )
+	rom ( name "Super Monkey Ball - Step & Roll (USA).iso" size 4699979776 crc c64e229e md5 6b1ed46bc3506331014cd49be3e05d03 sha1 965a9066f7f8503a344fbc0c994d41841018c99c serial "GM2E8P" )
 )
 
 game (
@@ -7693,8 +7992,9 @@ game (
 
 game (
 	name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
+	serial "RSBEBP"
 	description "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00)"
-	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 8511160320 crc 6757c5f2 md5 549c19aefd56c3651571c32e3c32e5b3 sha1 42ab0684b9601405b2cb349ea64550a7807173cf )
+	rom ( name "Super Smash Bros. Brawl (Europe) (En,Fr,De,Es,It) (v1.00).iso" size 8511160320 crc 6757c5f2 md5 549c19aefd56c3651571c32e3c32e5b3 sha1 42ab0684b9601405b2cb349ea64550a7807173cf serial "RSBEBP" )
 )
 
 game (
@@ -7705,14 +8005,16 @@ game (
 
 game (
 	name "Super Smash Bros. Brawl (USA) (v1.01)"
+	serial "RSBE24"
 	description "Super Smash Bros. Brawl (USA) (v1.01)"
-	rom ( name "Super Smash Bros. Brawl (USA) (v1.01).iso" size 8511160320 crc 7d5228c6 md5 d18726e6dfdc8bdbdad540b561051087 sha1 0e95949ac585f357e79fcd34b20670b5dca97ac2 )
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.01).iso" size 8511160320 crc 7d5228c6 md5 d18726e6dfdc8bdbdad540b561051087 sha1 0e95949ac585f357e79fcd34b20670b5dca97ac2 serial "RSBE24" )
 )
 
 game (
 	name "Super Smash Bros. Brawl (USA) (v1.02)"
+	serial "RSBE03"
 	description "Super Smash Bros. Brawl (USA) (v1.02)"
-	rom ( name "Super Smash Bros. Brawl (USA) (v1.02).iso" size 8511160320 crc 854b2889 md5 52ce7160ced2505ad5e397477d0ea4fe sha1 59432f150bf6b871ab378bb5b28e92005e0862f6 )
+	rom ( name "Super Smash Bros. Brawl (USA) (v1.02).iso" size 8511160320 crc 854b2889 md5 52ce7160ced2505ad5e397477d0ea4fe sha1 59432f150bf6b871ab378bb5b28e92005e0862f6 serial "RSBE03" )
 )
 
 game (
@@ -7801,8 +8103,9 @@ game (
 
 game (
 	name "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It)"
+	serial "RT4EUD"
 	description "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15abeb61 md5 462ca4153007c8f2bea2236cf5fdb0dd sha1 7e2f2a788e4e587385dda51ca0f1adc84fd73b03 )
+	rom ( name "Tales of Symphonia - Dawn of the New World (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 15abeb61 md5 462ca4153007c8f2bea2236cf5fdb0dd sha1 7e2f2a788e4e587385dda51ca0f1adc84fd73b03 serial "RT4EUD" )
 )
 
 game (
@@ -7861,20 +8164,23 @@ game (
 
 game (
 	name "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
+	serial "FBKP"
 	description "Teenage Mutant Ninja Turtles - Smash-Up (Europe)"
-	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (Europe).iso" size 4699979776 crc a732c637 md5 e9fc3a03595a4869988baf5883717fbe sha1 51b1e95793583f2985e889ae35e83650b3a10e61 )
+	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (Europe).iso" size 4699979776 crc a732c637 md5 e9fc3a03595a4869988baf5883717fbe sha1 51b1e95793583f2985e889ae35e83650b3a10e61 serial "FBKP" )
 )
 
 game (
 	name "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It)"
+	serial "FBKE"
 	description "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It)"
-	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It).iso" size 4699979776 crc 2f59d424 md5 29237aee3325787cab85595f82f13ab6 sha1 f059293fb15c319b378d860d95f5d1fd5c6cd4c9 )
+	rom ( name "Teenage Mutant Ninja Turtles - Smash-Up (USA) (En,Fr,De,Es,It).iso" size 4699979776 crc 2f59d424 md5 29237aee3325787cab85595f82f13ab6 sha1 f059293fb15c319b378d860d95f5d1fd5c6cd4c9 serial "FBKE" )
 )
 
 game (
 	name "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
+	serial "GTFEA4"
 	description "Teenage Mutant Ninja Turtles (USA) (En,Fr)"
-	rom ( name "Teenage Mutant Ninja Turtles (USA) (En,Fr).iso" size 4699979776 crc 46ce2ad6 md5 53636e5efe2042d540962cdec58626c0 sha1 11ef981c246bece78c713eefdf45e3632c840363 )
+	rom ( name "Teenage Mutant Ninja Turtles (USA) (En,Fr).iso" size 4699979776 crc 46ce2ad6 md5 53636e5efe2042d540962cdec58626c0 sha1 11ef981c246bece78c713eefdf45e3632c840363 serial "GTFEA4" )
 )
 
 game (
@@ -7939,8 +8245,9 @@ game (
 
 game (
 	name "Tiger Woods PGA Tour 07 (USA)"
+	serial "G6WP69"
 	description "Tiger Woods PGA Tour 07 (USA)"
-	rom ( name "Tiger Woods PGA Tour 07 (USA).iso" size 4699979776 crc d475a248 md5 00aa570a9ead9e6eaf6156e82b2004e6 sha1 7f3b6341ebf52c69a02b29540797252fc4bb594d )
+	rom ( name "Tiger Woods PGA Tour 07 (USA).iso" size 4699979776 crc d475a248 md5 00aa570a9ead9e6eaf6156e82b2004e6 sha1 7f3b6341ebf52c69a02b29540797252fc4bb594d serial "G6WP69" )
 )
 
 game (
@@ -7957,8 +8264,9 @@ game (
 
 game (
 	name "Tiger Woods PGA Tour 08 (USA) (En,Fr)"
+	serial "G6WE69"
 	description "Tiger Woods PGA Tour 08 (USA) (En,Fr)"
-	rom ( name "Tiger Woods PGA Tour 08 (USA) (En,Fr).iso" size 4699979776 crc ccde0cee md5 108aa2b0e5c91931486e92061d9debbc sha1 7e093628c957cacb4205d614a678dd5f49fa2139 )
+	rom ( name "Tiger Woods PGA Tour 08 (USA) (En,Fr).iso" size 4699979776 crc ccde0cee md5 108aa2b0e5c91931486e92061d9debbc sha1 7e093628c957cacb4205d614a678dd5f49fa2139 serial "G6WE69" )
 )
 
 game (
@@ -7992,6 +8300,12 @@ game (
 )
 
 game (
+	name "Tiger Woods PGA Tour 11 (USA)"
+	description "Tiger Woods PGA Tour 11 (USA)"
+	rom ( name "Tiger Woods PGA Tour 11 (USA).iso" size 4699979776 crc d43e553b md5 5a768fe294e6738a6b3eb29a35b708fa sha1 0735ff84804e3acd4909772ba91e6f2974ca29a0 )
+)
+
+game (
 	name "Tiger Woods PGA Tour 12 (USA)"
 	description "Tiger Woods PGA Tour 12 (USA)"
 	rom ( name "Tiger Woods PGA Tour 12 (USA).iso" size 4699979776 crc 1cd3f947 md5 1f5fc413808447edef99eebcfde0323a sha1 12709b7de72d76823f92144cf8f2a7019b581c39 )
@@ -7999,8 +8313,9 @@ game (
 
 game (
 	name "TMNT (USA) (En,Fr,Es)"
+	serial "GYRE41"
 	description "TMNT (USA) (En,Fr,Es)"
-	rom ( name "TMNT (USA) (En,Fr,Es).iso" size 4699979776 crc 194636cc md5 4c9aa8e2ae4bceb3dd0e6b87de776a50 sha1 f9f75e3050a0fb0392ed03e7dc12362e0ffdd9a3 )
+	rom ( name "TMNT (USA) (En,Fr,Es).iso" size 4699979776 crc 194636cc md5 4c9aa8e2ae4bceb3dd0e6b87de776a50 sha1 f9f75e3050a0fb0392ed03e7dc12362e0ffdd9a3 serial "GYRE41" )
 )
 
 game (
@@ -8017,8 +8332,9 @@ game (
 
 game (
 	name "Tom Clancy's Ghost Recon (USA)"
+	serial "GGRD41"
 	description "Tom Clancy's Ghost Recon (USA)"
-	rom ( name "Tom Clancy's Ghost Recon (USA).iso" size 4699979776 crc 3c81cdc8 md5 a6dec9dc0b0bfdcda1327fc9cc450895 sha1 afc33db8b169d56d36f993ab410748c2f70ed718 )
+	rom ( name "Tom Clancy's Ghost Recon (USA).iso" size 4699979776 crc 3c81cdc8 md5 a6dec9dc0b0bfdcda1327fc9cc450895 sha1 afc33db8b169d56d36f993ab410748c2f70ed718 serial "GGRD41" )
 )
 
 game (
@@ -8029,14 +8345,16 @@ game (
 
 game (
 	name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It)"
+	serial "GWYX41"
 	description "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 683ec80b md5 3645c0906155cf0adf5d875b22c84424 sha1 9e8dfaf35c8479bf00034bd767353e469d3c47d2 )
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 683ec80b md5 3645c0906155cf0adf5d875b22c84424 sha1 9e8dfaf35c8479bf00034bd767353e469d3c47d2 serial "GWYX41" )
 )
 
 game (
 	name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es)"
+	serial "GWYE41"
 	description "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es)"
-	rom ( name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es).iso" size 4699979776 crc b7a08b7c md5 494fb46106ba8820e21b227bcbdb68cf sha1 429c74820c6cea4b462c2bfaf24743ac4b7861e0 )
+	rom ( name "Tom Clancy's Splinter Cell - Double Agent (USA) (En,Fr,Es).iso" size 4699979776 crc b7a08b7c md5 494fb46106ba8820e21b227bcbdb68cf sha1 429c74820c6cea4b462c2bfaf24743ac4b7861e0 serial "GWYE41" )
 )
 
 game (
@@ -8185,14 +8503,16 @@ game (
 
 game (
 	name "Trauma Center - New Blood (USA)"
+	serial "RK2EUD"
 	description "Trauma Center - New Blood (USA)"
-	rom ( name "Trauma Center - New Blood (USA).iso" size 4699979776 crc 1b9fc0a4 md5 4ece4485e318a2fa2aab5cbf5aab1b18 sha1 3778e0c4d0b74be925c894813c9f6e2c6078dda5 )
+	rom ( name "Trauma Center - New Blood (USA).iso" size 4699979776 crc 1b9fc0a4 md5 4ece4485e318a2fa2aab5cbf5aab1b18 sha1 3778e0c4d0b74be925c894813c9f6e2c6078dda5 serial "RK2EUD" )
 )
 
 game (
 	name "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It)"
+	serial "RKDEUD"
 	description "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc cba4c93f md5 16119b96d5c60500d5e49b1dda79009e sha1 dd1ac732543918dcd7e9e66a97c8ab57ec4da7f3 )
+	rom ( name "Trauma Center - Second Opinion (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc cba4c93f md5 16119b96d5c60500d5e49b1dda79009e sha1 dd1ac732543918dcd7e9e66a97c8ab57ec4da7f3 serial "RKDEUD" )
 )
 
 game (
@@ -8203,8 +8523,9 @@ game (
 
 game (
 	name "Trauma Team (USA)"
+	serial "SK3EUD"
 	description "Trauma Team (USA)"
-	rom ( name "Trauma Team (USA).iso" size 4699979776 crc f989bb8d md5 dfc0f957956eebc614a01e4fe60d20cb sha1 2f1c6efb312447170de75c5da013a8f7558f1256 )
+	rom ( name "Trauma Team (USA).iso" size 4699979776 crc f989bb8d md5 dfc0f957956eebc614a01e4fe60d20cb sha1 2f1c6efb312447170de75c5da013a8f7558f1256 serial "SK3EUD" )
 )
 
 game (
@@ -8226,9 +8547,21 @@ game (
 )
 
 game (
+	name "Tsumi to Batsu - Sora no Koukeisha (Japan)"
+	description "Tsumi to Batsu - Sora no Koukeisha (Japan)"
+	rom ( name "Tsumi to Batsu - Sora no Koukeisha (Japan).iso" size 4699979776 crc 4780998f md5 fd9f83599cb9962e3ba8137b19454c1f sha1 cf4225060f76f3d8842a63bcdbe00313bb5cc155 )
+)
+
+game (
 	name "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl)"
 	description "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl)"
 	rom ( name "TV Show King Party (Europe) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 9e32bc1c md5 08c9ab501b089079d79d332cfabfbcf9 sha1 d138caadd87426a22f63b54f2d4180fcb29b4187 )
+)
+
+game (
+	name "Twinkle Queen (Japan)"
+	description "Twinkle Queen (Japan)"
+	rom ( name "Twinkle Queen (Japan).iso" size 4699979776 crc b039b985 md5 b9ee0777d05c327556c8aac9409fe7c1 sha1 7fc4c01541398274a67d80458d40092e80583ca4 )
 )
 
 game (
@@ -8250,9 +8583,9 @@ game (
 )
 
 game (
-	name "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,De,Es,It,Nl)"
-	description "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,De,Es,It,Nl)"
-	rom ( name "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,De,Es,It,Nl).iso" size 4699979776 crc 388fe4b9 md5 1f6162c5946abf14bbccb8d1a5e1317e sha1 43dc8b138a31b46f40fcdb71dc6c52bec55d8752 )
+	name "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,Es)"
+	description "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,Es)"
+	rom ( name "uDraw Nickelodeon SpongeBob SquigglePants (USA) (En,Fr,Es).iso" size 4699979776 crc 388fe4b9 md5 1f6162c5946abf14bbccb8d1a5e1317e sha1 43dc8b138a31b46f40fcdb71dc6c52bec55d8752 )
 )
 
 game (
@@ -8331,6 +8664,12 @@ game (
 	name "Valhalla Knights - Eldar Saga (USA)"
 	description "Valhalla Knights - Eldar Saga (USA)"
 	rom ( name "Valhalla Knights - Eldar Saga (USA).iso" size 4699979776 crc b9eba063 md5 5af258375691b6b7c6d2d70646ef6475 sha1 212da0c425255d64c715fdc27701cafd643c1752 )
+)
+
+game (
+	name "Vertigo (USA) (En,Fr,Es)"
+	description "Vertigo (USA) (En,Fr,Es)"
+	rom ( name "Vertigo (USA) (En,Fr,Es).iso" size 4699979776 crc fd9eec7d md5 ead7ee516ba2dfc118c528d66db55891 sha1 9429d66c2c0e8755f245c9db84f1641d5b4256c0 )
 )
 
 game (
@@ -8443,8 +8782,9 @@ game (
 
 game (
 	name "We Sing - Rock! (Europe) (En,Fr,De,Es,It)"
+	serial "SQRPNG"
 	description "We Sing - Rock! (Europe) (En,Fr,De,Es,It)"
-	rom ( name "We Sing - Rock! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 73d23897 md5 a9d15705795403124dc8ecea8cca716c sha1 675405b0709150bd5b7ed200425541ea2363e5bc )
+	rom ( name "We Sing - Rock! (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 73d23897 md5 a9d15705795403124dc8ecea8cca716c sha1 675405b0709150bd5b7ed200425541ea2363e5bc serial "SQRPNG" )
 )
 
 game (
@@ -8653,8 +8993,9 @@ game (
 
 game (
 	name "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
+	serial "SL8K01"
 	description "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It)"
-	rom ( name "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 199014df md5 f9d6a6c2600a54f72c8fe9cb61321fe7 sha1 1310aeba93aaccfb9e9a614d3e4850f5199bc1d9 )
+	rom ( name "Wii Sports & Wii Sports Resort (Europe) (En,Fr,De,Es,It).iso" size 4699979776 crc 199014df md5 f9d6a6c2600a54f72c8fe9cb61321fe7 sha1 1310aeba93aaccfb9e9a614d3e4850f5199bc1d9 serial "SL8K01" )
 )
 
 game (
@@ -8757,6 +9098,12 @@ game (
 	name "Winning Eleven Play Maker 2012 (Japan)"
 	description "Winning Eleven Play Maker 2012 (Japan)"
 	rom ( name "Winning Eleven Play Maker 2012 (Japan).iso" size 4699979776 crc 69fca407 md5 9be6177861ae517d22c37c0d6cd82847 sha1 e1d569f78084b8af294e2e3f8fb3db9513679d49 )
+)
+
+game (
+	name "Winning Post World (Japan)"
+	description "Winning Post World (Japan)"
+	rom ( name "Winning Post World (Japan).iso" size 4699979776 crc a6bf66e8 md5 12be73954957313fc794166538058dbd sha1 ab683b1d0bcf6c54d42612a4b3e559bd2324db5b )
 )
 
 game (
@@ -8967,6 +9314,18 @@ game (
 	name "Zack & Wiki - Quest for Barbaros' Treasure (USA)"
 	description "Zack & Wiki - Quest for Barbaros' Treasure (USA)"
 	rom ( name "Zack & Wiki - Quest for Barbaros' Treasure (USA).iso" size 4699979776 crc f751b21f md5 35c196aafdb90640169b696939c4d97a sha1 f588c59cd239ce5f052c63a935a07916d4a0926e )
+)
+
+game (
+	name "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Kounin - Kanken Wii - Kanji-ou Ketteisen (Japan)"
+	description "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Kounin - Kanken Wii - Kanji-ou Ketteisen (Japan)"
+	rom ( name "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Kounin - Kanken Wii - Kanji-ou Ketteisen (Japan).iso" size 4699979776 crc 402169bf md5 a63e99896ba2985223c07ce20f3146ba sha1 75a97e4ac645ef08b216660f0c43bfb58615fcd5 )
+)
+
+game (
+	name "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Koushiki Soft - 250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan)"
+	description "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Koushiki Soft - 250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan)"
+	rom ( name "Zaidan Houjin Nihon Kanji Nouryoku Kentei Kyoukai Koushiki Soft - 250 Mannin no Kanken - Wii de Tokoton Kanji Nou (Japan).iso" size 4699979776 crc 01064656 md5 62bf94914850f0e269e0e4e98916da51 sha1 8f9ffaafe94947354404ffa9830a2f8dcf11f903 )
 )
 
 game (


### PR DESCRIPTION
This adds the Wii serial data through this PR: https://github.com/RobLoach/libretro-dats/pull/14

Likely some mismatches in the titles, but we end up with ~350 serials. The title matching is over at:
https://github.com/RobLoach/libretro-dats/blob/wii-serials/src/inject-wii.js#L27