### PR TITLE
Add Blastem BIOS rom.db

### DIFF
--- a/dat/BIOS - Non-Merged.dat
+++ b/dat/BIOS - Non-Merged.dat
@@ -173,6 +173,7 @@ game (
 	rom ( name ggenie.bin size 32768 crc 5f293e4c md5 b5d5ff1147036b06944b4d2cac2dd1e1 sha1 ea4b0418d90bc47996f6788ad455391d07cad6cc )
 	rom ( name sk.bin size 2097152 crc 0658f691 md5 4ea493ea4e9f6c9ebfccbdb15110367e sha1 88d6499d874dcb5721ff58d76fe1b9af811192e3 )
 	rom ( name sk2chip.bin size 262144 crc 4dcfd55c md5 b4e76e416b887f4e7413ba76fa735f16 sha1 70429f1d80503a0632f603bf762fe0bbaa881d22 )
+	rom ( name rom.db size 16623 crc 591c75f2 md5 2ef2ca2b9aad717de5baf10c9e42e179 sha1 6142390c739c752eaf9214214915bf6f54aa2125 )
 )
 
 game (

--- a/dat/BIOS.dat
+++ b/dat/BIOS.dat
@@ -134,6 +134,7 @@ game (
 	rom ( name ggenie.bin size 32768 crc 5f293e4c md5 b5d5ff1147036b06944b4d2cac2dd1e1 sha1 ea4b0418d90bc47996f6788ad455391d07cad6cc )
 	rom ( name sk.bin size 2097152 crc 0658f691 md5 4ea493ea4e9f6c9ebfccbdb15110367e sha1 88d6499d874dcb5721ff58d76fe1b9af811192e3 )
 	rom ( name sk2chip.bin size 262144 crc 4dcfd55c md5 b4e76e416b887f4e7413ba76fa735f16 sha1 70429f1d80503a0632f603bf762fe0bbaa881d22 )
+	rom ( name rom.db size 16623 crc 591c75f2 md5 2ef2ca2b9aad717de5baf10c9e42e179 sha1 6142390c739c752eaf9214214915bf6f54aa2125 )
 
 	comment "Sega - Saturn"
 	rom ( name mpr-17933.bin size 524288 crc 4afcf0fa md5 3240872c70984b6cbfda1586cab68dbe sha1 faa8ea183a6d7bbe5d4e03bb1332519800d3fbc3 )


### PR DESCRIPTION
`rom.db` is available directly from [Blastem](https://www.retrodev.com/blastem/).