### PR TITLE
Add Chrono Cross (PSX) US Cheats

### DIFF
--- a/cht/Sony - PlayStation/Chrono Cross (USA).cht
+++ b/cht/Sony - PlayStation/Chrono Cross (USA).cht
@@ -1,0 +1,72 @@
+cheats = 16 
+
+cheat0_desc = "Infinite Money"
+cheat0_code = "800719A8:FFFF"
+cheat0_enable = false 
+
+cheat1_desc = "Easy Win Dragon Feed 1"
+cheat1_code = "D00E5BEA:0001"
+cheat1_enable = false 
+
+cheat2_desc = "Easy Win Dragon Feed 2"
+cheat2_code = "800E5BEA:000A"
+cheat2_enable = false 
+
+cheat3_desc = "Easy Win Dragon Feed 3"
+cheat3_code = "D00E5BEA:000B"
+cheat3_enable = false 
+
+cheat4_desc = "Easy Win Dragon Feed 4"
+cheat4_code = "800E5BEA:0014"
+cheat4_enable = false 
+
+cheat5_desc = "Easy Win Dragon Feed 5"
+cheat5_code = "D00E5BEA:0015"
+cheat5_enable = false 
+
+cheat6_desc = "Easy Win Dragon Feed 6"
+cheat6_code = "800E5BEA:001E"
+cheat6_enable = false 
+
+cheat7_desc = "Easy Win Dragon Feed 7"
+cheat7_code = "D00E5BEA:001F"
+cheat7_enable = false 
+
+cheat8_desc = "Easy Win Dragon Feed 8"
+cheat8_code = "800E5BEA:0028"
+cheat8_enable = false 
+
+cheat9_desc = "Easy Win Dragon Feed 9"
+cheat9_code = "D00E5BEA:0029"
+cheat9_enable = false
+
+cheat10_desc = "Easy Win Dragon Feed 10"
+cheat10_code = "800E5BEA:0064"
+cheat10_enable = false 
+
+cheat11_desc = "Inf Elements Battle 1"
+cheat11_code = "D00CB574:0001"
+cheat11_enable = false 
+
+cheat12_desc = "Inf Elements Battle 2"
+cheat12_code = "800CB574:0000"
+cheat12_enable = false 
+
+cheat13_desc = "Inf Elements Battle 3"
+cheat13_code = "D00CB682:A083"
+cheat13_enable = false
+
+cheat14_desc = "Inf Elements Battle 4"
+cheat14_code = "800CB682:2400"
+cheat14_enable = false 
+
+cheat15_desc = "Anywhere Teleport/Smith 1"
+cheat15_code = "D00E57DC:0000"
+cheat15_enable = false 
+
+cheat16_desc = "Anywhere Teleport/Smith 2"
+cheat16_code = "800E57DC:0001"
+cheat16_enable = false 
+
+
+


### PR DESCRIPTION
Added Beetle compatible cheat file for the US version of Chrono Cross

Note the long-hand formatting where I did not combine related codes: This is currently required by Beetle for cheats to work properly.