### PR TITLE
Add Saturn hacks file

### DIFF
--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -1,0 +1,47 @@
+clrmamepro (
+	name "Saturn hacks"
+	description "Romhacks of Saturn games"
+)
+
+game (
+	name "Dragon Force II: The Godforsaken Land"
+	description "Translation by Verve Fanworks version 1.04"
+	rom ( name "Dragon Force II - Kami Sarishi Daichi ni (Japan) (Track 1).bin" size 528943104 crc 6feb6044 md5 4b99223f62098f37a5a6cfa69653b684 sha1 62f553003bb9fbd9d16897334678fdf289114efe )
+    comment "Redump (Japan) source"
+    comment "Needs conversion of track 1 to MODE1/2048 before patch and cue file edit 'TRACK 01 MODE1/2352' to 'TRACK 01 MODE1/2048'"
+    comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
+    comment "http://www.romhacking.net/translations/1622/"
+)
+
+game (
+	name "The Story of Thor 2 (4 in 1 hack)"
+	description "Hacks for larger resolution, bug fixes, tweaks and anti-scaling by paul_met version 1.0"
+	rom ( name "Story of Thor 2, The (Europe) (Track 1).bin" size 81995424 crc 8ae4c201 md5 f438779e54965c3e923d1aa934a6a13c sha1 0c551e311ae0c5ad59199017d67c6582429a5922 )
+    comment "Redump (Europe) source"
+    comment "http://www.romhacking.net/hacks/3403/"
+)
+
+game (
+	name "Asuka 120% Limit Over (menu translation)"
+	description "Asuka 120% Limit Over by CafeBreak Project version 12/31 + Menu Translation by Ms. Tea version 1.0"
+	rom ( name "Asuka 120% Limited - Burning Fest. Limited (Japan) (Track 01).bin" size 62095152 crc bd23db54 md5 4bcce0bfcc29cb358f7c2e2c8682f1a9 sha1 b9723e2277933df5fba915bcf160253952ba5fdd )
+    comment "Redump (Japan) source"
+    comment "https://github.com/i30817/asuka_over_limit"
+)
+
+game (
+	name "Shining Force III Collection Deluxe Volume 1"
+	description "Shining Force III Scenario 1 + Premium Disc by paul_met and Shining Force Central version 1.8"
+	rom ( name "Shining Force III Collection Deluxe Volume 1.bin" size 735379456 crc 3d13459e md5 a2295b8a6668ca209d7659b04435eae5 sha1 9170b2a28da8142b79561a46b5e1f9ab13a1690c )
+    comment "No reputable source"
+    comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
+)
+
+game (
+	name "Shining Force III Collection Deluxe Volume 2"
+	description "Shining Force III Scenario 2 + Scenario 3 by paul_met and Shining Force Central version 1.8"
+	rom ( name "Shining Force III Collection Deluxe Volume 2.bin" size 733184000 crc 773e9b2b md5 a8e46b8559f36f97552f12ebbf368b88 sha1 84cc72ac874f30b2d7808c805a7d0b22fc2fcca9 )
+    comment "No reputable source"
+    comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
+)
+


### PR DESCRIPTION
RFC about this i guess. Before trying something heavier like the psx1 hacks i have i decided to limit myself to the few Saturn hacks.


Things i don't understand:

The 'rom name', how does it behave when the rom is multifile and the file with the right CRC is not the 'index' file (that honor would go to cues).

Because Mednafen for one will not load games that don't have a cue (even bare isos in MODE1/2048 mode) but will load them fine if passed the right cue.

So my hope is that the Scanner finds cues, finds the first track, tries to check for serial, fails, tries to check for crc, finds it and then adds the cue to the playlist.

Not  Scanner finds cues, finds the first track, tries to check for serial, fails, tries to check for crc, finds it and then adds the *track* to the playlist.

Even if it works like i expect, if a serial method is created for saturn suddenly these hacks wouldn't get scanned because the Scanner would think it had 'found' the game, in spite of it being a hack. So how is this supposed to work,?

Also, can i use comments like this?

