### PR TITLE
add many N64 hacks and translations

### DIFF
--- a/metadat/hacks/Nintendo - Nintendo 64.dat
+++ b/metadat/hacks/Nintendo - Nintendo 64.dat
@@ -9,3 +9,127 @@ game (
 	rom ( name "SM64 Last Impact V1.1.z64" size 67108864 crc 4ce7fa2a md5 836667a37dce62414064b62f5dafe9f6 sha1 78e3e86f679330a40a0480372f65c362179042ff )
 )
 
+game (
+	name "Custom Robo (Japan) [T-En by Star Trinket]"
+	description "'Custom Robo' translation by Star Trinket version 1.0"
+	rom ( name "Custom Robo (Japan).v64" size 16777216 crc 004e7c90 md5 93144df5a66c66f6c243471beb40b90b sha1 fde8e692c0aa4c3d34264319ab00601f83a7bd17 )
+    comment "https://www.romhacking.net/translations/3237/"
+)
+
+game (
+	name "Custom Robo (Japan) [T-En by Star Trinket]"
+	description "'Custom Robo' translation by Star Trinket version 1.0"
+	rom ( name "Custom Robo (Japan).z64" size 16777216 crc fce6cdbc md5 f4a534469f81f493ffcfe4fcd6c4908a sha1 f8744703579f6ac2ee427ac50fbce5b95f11a918 )
+    comment "https://www.romhacking.net/translations/3237/"
+)
+
+game (
+	name "Custom Robo (Japan) [T-En by Star Trinket]"
+	description "'Custom Robo' translation by Star Trinket version 1.0"
+	rom ( name "Custom Robo (Japan).n64" size 16777216 crc 889b5295 md5 23860193df1bc9978a79a24122e5a64c sha1 6d545d26c910f31794c71b59b08fef54eab9ef3b )
+    comment "https://www.romhacking.net/translations/3237/"
+)
+
+game (
+	name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
+	description "'Wonder Project J2' translation by Ryu version 1.0"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).v64" size 8912896 crc 38401ddb md5 9389cea162a3bbff3bf6f81284cc7786 sha1 cae4915a67d952f37a78e004d97d630bccc155a6 )
+    comment "tool64 can't convert to other byte orders after patching" 
+    comment "https://www.romhacking.net/translations/1074/"
+)
+
+game (
+	name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
+	description "'Wonder Project J2' translation by Ryu version 1.0"
+	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size 8912896 crc e1094e29 md5 3c02f56dd7b1a06be83a7a288755612f sha1 27c4c8f199d1045c697c5d79d216d33e1c715760 )
+    comment "tool64 can't convert to other byte orders after patching" 
+    comment "https://www.romhacking.net/translations/1074/"
+)
+
+game (
+	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).v64" size 33554432 crc 0d17a138 md5 925a95b382faba3cc1aa7c8bd9f80dea sha1 e1721d90f49c2bef201b70416c2db78f21f1fd36 )
+    comment "No reputable source"
+)
+
+game (
+	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).z64" size 33554432 crc 6a19ae94 md5 6e51b140a9b0c30d6f55ca7942a969fc sha1 e3906c919236dac6eba020b4b8c1df91fd725c5d )
+    comment "No reputable source"
+)
+
+game (
+	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).n64" size 33554432 crc 3fe26cce md5 352fe619ab9b4d29ae167c724fc41482 sha1 35d20ea6f9e52b21de80e25633bed45f4a2c13ae )
+    comment "No reputable source"
+)
+
+game (
+	name "Super Mario Star Road (USA)"
+	description "'Super Mario 64' hack by Skelux Core final version"
+	rom ( name "Super Mario 64 (USA).v64" size 50331648 crc 646e8fff md5 caf803c77c9223b28b663af0b7e49a00 sha1 45e75bd3a1380bfeb874721c29581b47cfafa8d1 )
+    comment "https://www.romhacking.net/hacks/873/"
+)
+
+game (
+	name "Super Mario Star Road (USA)"
+	description "'Super Mario 64' hack by Skelux Core final version"
+	rom ( name "Super Mario 64 (USA).z64" size 50331648 crc 2bd94dd7 md5 80e5019c9dd12648f909b3a5715ed580 sha1 469c6555a078dd831fa51ce601a653e44b3ce071 )
+    comment "https://www.romhacking.net/hacks/873/"
+)
+
+game (
+	name "Super Mario Star Road (USA)"
+	description "'Super Mario 64' hack by Skelux Core final version"
+	rom ( name "Super Mario 64 (USA).n64" size 50331648 crc e40c674e md5 00f5bcdd597dbc575b8811d5430bb353 sha1 176bd6a50aee06fcc917c123f412fdc0c02dd922 )
+    comment "https://www.romhacking.net/hacks/873/"
+)
+
+game (
+	name "Zelda's Birthday (USA)"
+	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).v64" size 67108864 crc 65fceb4b md5 12fd4f2ac3ffe761be42e9fa63f75bc7 sha1 b001eec2adb2d80e9088909a417388c91dc8b545 )
+    comment "https://www.romhacking.net/hacks/676/"
+)
+
+game (
+	name "Zelda's Birthday (USA)"
+	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).z64" size 67108864 crc 9dcde00e md5 9dc5ed87adf6e859391751ae124b44f5 sha1 881bbf199e24d37a291f95adc0000a89573bec70 )
+    comment "https://www.romhacking.net/hacks/676/"
+)
+
+game (
+	name "Zelda's Birthday (USA)"
+	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).n64" size 67108864 crc 4ed0632f md5 4d28941a4799a099d32f79f7ebca83f1 sha1 7095b2e825517b77a62f42198212565bd2a259c9 )
+    comment "https://www.romhacking.net/hacks/676/"
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+	description "'Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition).z64" size 33554432 crc 48124886 md5 7fc61f232811cd779d4789f71d55562c sha1 24207202d44e2a7fa5e4297187082945310bae0c )
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
+    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+)
+
+game (
+	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition).z64" size 33554432 crc 339fc360 md5 6d79c2e17eb78ab9d6b40b49c6939949 sha1 800c27d8231a17c4321e801108893015b9ee22b2 )
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
+    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+)
+
+game (
+	name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+	description "'Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition).z64" size 33554432 crc 3d034499 md5 7f8386e3816db3ede468a4669fe7c978 sha1 f0fb78384331edf36e4daccd99571d4c8c605405 )
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
+    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+)
+


### PR DESCRIPTION
Many of these are because N64 emulators unfortunately accept byteswapped, little endian and big endian byte orders, and no-intro and goodn64 (and gamecube iirc) use different byte orders (or worse, many).

Even with this this is severely incomplete on some things. For instance, hack patches versions of the 'GameCube to N64' series of which the last 3 games added here are part have patches for

3 zelda games (OoT, OoTMQ, MJ) * 3 regions * 2 (with aliasing or not) * 3 (bytes orders) = 54

All things considered i decided to only add the main 3 games on the USA with the anti-aliasing disable patch (my preference) and in the byte order the patch expects (big endian). Which is not btw, the order of no-intro, so to make a small soft-patch to no-intro, you'd have to patch the big-endian rom, convert it back to no-intro byte-swapped and make the bps patch finally.

Of special notice is `Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)` which is a rom that needs to be extracted from a Wii U wad to work on n64 emulators but i still provided all the byte orders because i created a softpatch for the original N64 Japan release using that method. If RA ever gets VFS softpatch support those different byte orders might allow me to scan softpatches and get the hack definition, not the 'original game' like currently.

In fact this is kind of pointless to me, because i created softpatches for everything but cds so everything doesn't get picked up until VFS soft-patch happens, but ....