### PR TITLE
add many nes hacks and translations

### DIFF
--- a/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
@@ -33,3 +33,2214 @@ game (
 	rom ( name "Sonic_NES_Improvement_plus_Music_plus_Graphics.nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
 )
 
+game (
+    name "Cosmo Police Galivan (Japan) [T-En by Jair]"
+    description "English translation by Jair version (1.00)"
+    rom ( name "Cosmo Police Galivan (Japan).nes" size 262160 crc 4f031cb0 md5 08ecfd17a791acde0bf63543c98115a6 sha1 fd3d9f8a6c862773194c3e23b420aabe9453d2d6 )
+    comment "https://www.romhacking.net/translations/109/"
+)
+
+game (
+    name "Kamen no Ninja - Hanamaru (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Kamen no Ninja - Hanamaru (Japan).nes" size 262160 crc c4924b42 md5 3858f554bb79f8522c45b57b997f80a5 sha1 93e5757e77bf6588a8723360e9396cd6292df412 )
+    comment "http://www.romhacking.net/translations/2331/"
+)
+
+game (
+    name "J.League Winning Goal (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "J.League Winning Goal (Japan).nes" size 262160 crc fbfa06f6 md5 c357a2367d3f13c448479731df3c54fe sha1 22aaa0c031b9db96684d5a37a81192986abd7b5d )
+    comment "http://www.romhacking.net/translations/1363/"
+)
+
+game (
+    name "StarTropics - No Movement Delay [Hack by Trisma + 1 hacks]"
+    description "StarTropics - No Movement Delay hack by Trisma version (1.0) + StarTropics (Music Fix) hack by rainwarrior version (1.0)"
+    rom ( name "StarTropics (USA).nes" size 524304 crc 64b8860f md5 0d13248466eea1dedb6131378780e51d sha1 447d8196162dd873b67c4cbe06db690078440a02 )
+    comment "http://www.romhacking.net/hacks/3307/"
+    comment "http://www.romhacking.net/hacks/2229/"
+)
+
+game (
+    name "Daisenryaku (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.0)"
+    rom ( name "Daisenryaku (Japan).nes" size 163856 crc 3ecbbd9c md5 33834c85a817cb3a26025e6f87e85839 sha1 4be526b28a0579774b23e3b5d32f9dc805c0bf68 )
+    comment "https://www.romhacking.net/translations/110/"
+)
+
+game (
+    name "Mickey Mouse III - Yume Fuusen (Japan) [T-En by NikcDC]"
+    description "English translation by NikcDC version (1.1)"
+    rom ( name "Mickey Mouse III - Yume Fuusen (Japan).nes" size 262160 crc 5cb55b23 md5 edc3bc5bcb230ff0f56c276ea6d7ad39 sha1 32a9c1321469793c6352474978f313cfabc62f7e )
+    comment "http://www.romhacking.net/translations/1640/"
+)
+
+game (
+    name "Spartan X 2 (Japan) [T-En by Abstract Crouton Productions]"
+    description "English translation by Abstract Crouton Productions version (1.0)"
+    rom ( name "Spartan X 2 (Japan).nes" size 262160 crc 30003fc6 md5 5c6980bc699ec60b43b9a40f732ed0de sha1 5e60dd0b6274d2007903b91b29ff62effe489b6b )
+    comment "http://www.romhacking.net/translations/659/"
+)
+
+game (
+    name "Devil Man (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Devil Man (Japan).nes" size 262160 crc 0be5f3e3 md5 af82c9e7145712608c25fc11998a42b0 sha1 a13abc649b4c56649cc29af12cd161831af8add9 )
+    comment "https://www.romhacking.net/translations/1386/"
+)
+
+game (
+    name "Ninja Hattori-kun - Ninja wa Syugyou de Gozaru (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Ninja Hattori-kun - Ninja wa Syugyou de Gozaru (Japan).nes" size 40976 crc 873c7478 md5 947aa35d0e4023ebf38a9f354cb06e67 sha1 88816abc7c22fce3be195f227d31ca8c330daec1 )
+    comment "http://www.romhacking.net/translations/2220/"
+)
+
+game (
+    name "Musashi no Ken - Tadaima Shugyou Chuu (Japan) [T-En by GAFF Translations]"
+    description "English translation by GAFF Translations version (1.00)"
+    rom ( name "Musashi no Ken - Tadaima Shugyou Chuu (Japan).nes" size 65552 crc f1f07c0e md5 5043515e63a08e06ecc10a33185a103f sha1 74d201690167d02427bd81cfadf146f86488972c )
+    comment "http://www.romhacking.net/translations/2492/"
+)
+
+game (
+    name "Mirai Shinwa Jarvas (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Mirai Shinwa Jarvas (Japan).nes" size 262160 crc 85f6d496 md5 c445e932abbd5f7fd25ced2fca2ae6e6 sha1 9ed6fb3c1e467b590eb807ae64f485618f8c8294 )
+    comment "http://www.romhacking.net/translations/1275/"
+)
+
+game (
+    name "Final Fantasy III (Japan) [T-En by Chaos Rush]"
+    description "English translation by Chaos Rush version (1.4)"
+    rom ( name "Final Fantasy III (Japan).nes" size 1048592 crc f6811104 md5 a36d31e22c3caefba4718f08f8cf709f sha1 6643da918b08597d7fd90dd68cafd1fa787f3646 )
+    comment "http://www.romhacking.net/translations/2701/"
+)
+
+game (
+    name "Cosmo Genesis (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.1)"
+    rom ( name "Cosmo Genesis (Japan).nes" size 65552 crc 390cfcb8 md5 edee6f341768da1c0913b8dd741f51ec sha1 908043950a8c8ad3e1a0811ab4a4fce3faacd690 )
+    comment "http://www.romhacking.net/translations/108/"
+)
+
+game (
+    name "Romancia (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev. A)"
+    rom ( name "Romancia (Japan).nes" size 131088 crc c0785ed4 md5 6acb386fa233dd2d8420ae1912d7bfab sha1 a397393ca833adc509ef3de3647b05d513911abe )
+    comment "http://www.romhacking.net/translations/1264/"
+)
+
+game (
+    name "Juuryoku Soukou Metal Storm (Japan) [T-En by Sliver X]"
+    description "English translation by Sliver X version (1.01)"
+    rom ( name "Juuryoku Soukou Metal Storm (Japan).nes" size 393232 crc d2729532 md5 9bbd91b33e576878571338076c6f4c03 sha1 33e96d8a55a2a06c6298cbce427334a95c0e0d26 )
+    comment "http://www.romhacking.net/translations/1466/"
+)
+
+game (
+    name "Zoids Mokushiroku (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.3)"
+    rom ( name "Zoids Mokushiroku (Japan).nes" size 262160 crc dac19d80 md5 cd3d8de761e54d128071ec22aa653d02 sha1 0040786e13d24723b13afad385feae6978055a01 )
+    comment "http://www.romhacking.net/translations/2096/"
+)
+
+game (
+    name "Exciting Rally - World Rally Championship (Japan) [T-En by Klepto Software]"
+    description "English translation by Klepto Software version (1.00)"
+    rom ( name "Exciting Rally - World Rally Championship (Japan).nes" size 262160 crc dc1b653d md5 7f4efa009e82ed6f9021ccdb2933f066 sha1 9a1ee8570ac59d5ba76f0e7f4d0b706fbfda393d )
+    comment "http://www.romhacking.net/translations/739/"
+)
+
+game (
+    name "Tetrastar - The Fighter (Japan) [T-En by Gaijin Productions]"
+    description "English translation by Gaijin Productions version (1.00beta)"
+    rom ( name "Tetrastar - The Fighter (Japan).nes" size 524304 crc 1eb0ab01 md5 ea9512bff5a0eb395763c56e9b44452b sha1 5d8aa17095f25ab7c4ded41f20474ba11f45e4a2 )
+    comment "http://www.romhacking.net/translations/227/"
+)
+
+game (
+    name "Splatter House - Wanpaku Graffiti (Japan) [T-En by Spinner 8 and friends]"
+    description "English translation by Spinner 8 and friends version (2.0)"
+    rom ( name "Splatter House - Wanpaku Graffiti (Japan).nes" size 262160 crc 21d6c3df md5 34cabbee8a412c131fce5268144cfc92 sha1 d416159014e1760729f4c5d2d0d835c78e0f1736 )
+    comment "http://www.romhacking.net/translations/212/"
+)
+
+game (
+    name "F1 Circus (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "F1 Circus (Japan).nes" size 393232 crc 67c75e53 md5 47f2348a31d91492cb0f56565ce12bb5 sha1 8cd80fcee2bd2bb2f703f0e4c218d4fafc28ccaf )
+    comment "https://www.romhacking.net/translations/2724/"
+)
+
+game (
+    name "Kamen no Ninja - Akakage (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Kamen no Ninja - Akakage (Japan).nes" size 131088 crc 775d6bdc md5 a43763b1453c94f3994ddccba2125835 sha1 08a1d7d21bb80f221c34509c05b05e0c5722a145 )
+    comment "http://www.romhacking.net/translations/2589/"
+)
+
+game (
+    name "SD Keiji - Blader (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.01)"
+    rom ( name "SD Keiji - Blader (Japan).nes" size 393232 crc d81d7085 md5 c0dd23e63c29e407e12cba287673c30f sha1 bd7900fc9b4d563baa84ae02983db4e43e89064f )
+    comment "https://www.romhacking.net/translations/1715/"
+)
+
+game (
+    name "Niji no Silk Road (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Niji no Silk Road (Japan).nes" size 655376 crc 982c3296 md5 396db1948646fbc754d9550ee48423f5 sha1 b37589dae46709a1c175ad99d9b221d7e87dae85 )
+    comment "https://www.romhacking.net/translations/2594/"
+)
+
+game (
+    name "Last Armageddon (Japan) [T-En by Chably]"
+    description "English translation by Chably version (1.1)"
+    rom ( name "Last Armageddon (Japan).nes" size 524304 crc 3c3aa31c md5 8790dc1fdf7c49a255e669dc31a0b365 sha1 78d30e561dbb6ec00dda0a3086619b03ce9438a8 )
+    comment "http://www.romhacking.net/translations/2783/"
+)
+
+game (
+    name "Shadow Brain (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Shadow Brain (Japan).nes" size 524304 crc 0e064fe8 md5 f60b36c6564f5d1276290f45cce6717d sha1 55c149701ba10143ab483d07c5d7a7bd2f4ff6d9 )
+    comment "http://www.romhacking.net/translations/2631/"
+)
+
+game (
+    name "Battle of Olympus - SRAM Saving Edition + Re-balanced [Hack by 8-bit fan]"
+    description "Battle of Olympus - SRAM Saving Edition + Re-balanced hack by 8-bit fan version (1.0)"
+    rom ( name "Battle of Olympus, The (USA).nes" size 131088 crc 5d7256b1 md5 83dddcfd11e81ce95be1ec70df0c2849 sha1 06968405b1ea3f65cc0263f93869b6f3b44a4199 )
+    comment "http://www.romhacking.net/hacks/3600/"
+)
+
+game (
+    name "Sukeban Deka III (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (0.95)"
+    rom ( name "Sukeban Deka III (Japan).nes" size 131088 crc fec242b9 md5 8799bbdc5c5d72b3fb7953032433ef9a sha1 da2b5ad83cd106307041909e8c1a21eb9282719f )
+    comment "http://www.romhacking.net/translations/2756/"
+)
+
+game (
+    name "Ninja Jajamaru - Ginga Daisakusen (Japan) [T-En by HTI]"
+    description "English translation by HTI version (1.00)"
+    rom ( name "Ninja Jajamaru - Ginga Daisakusen (Japan).nes" size 262160 crc 89ee0ed9 md5 b270656f360b8a4ef23719d36bfdf269 sha1 7e1eed32343a8f6cd21bd894d7775729368ba423 )
+    comment "http://www.romhacking.net/translations/615/"
+)
+
+game (
+    name "Parasol Henbee (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Parasol Henbee (Japan).nes" size 262160 crc 6e435769 md5 ec8dfb062afbdb4dd528ca749dfd06ba sha1 c7503bf45958119f4650dbfe5566c1c5898b1d10 )
+    comment "http://www.romhacking.net/translations/2582/"
+)
+
+game (
+    name "Nangoku Shirei!! - Spy vs Spy (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Nangoku Shirei!! - Spy vs Spy (Japan).nes" size 131088 crc f9e51c93 md5 c8f337aa2232f18c29cc926a28bebcf5 sha1 be72fa52dd5fb1ac3647a59d4583089d204ec324 )
+    comment "http://www.romhacking.net/translations/2387/"
+)
+
+game (
+    name "Jajamaru no Daibouken (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Jajamaru no Daibouken (Japan).nes" size 65552 crc 753b2f07 md5 962514129cb3c45a4bb51ad3ce406c58 sha1 cfb6977a4a9e8b7801593995c1b4995829e9199d )
+    comment "http://www.romhacking.net/translations/1474/"
+)
+
+game (
+    name "Akira (Japan) [T-En by Dank-Trans]"
+    description "English translation by Dank-Trans version (0.995)"
+    rom ( name "Akira (Japan).nes" size 524304 crc 1676ac87 md5 bde3b7c31837cef3c4dc3c9b6f978872 sha1 4615791a1b4d7edcebd5515ae550bb159d2e5eab )
+    comment "https://www.romhacking.net/translations/1725/"
+)
+
+game (
+    name "Dragon Ball Z - Kyoushuu! Saiya Jin (Japan) [T-En by Twilight Translations]"
+    description "English translation by Twilight Translations version (1.01)"
+    rom ( name "Dragon Ball Z - Kyoushuu! Saiya Jin (Japan).nes" size 524304 crc 84aeceb7 md5 1a3776b6ed1ee974ecbb39c8c673c300 sha1 1885026ab0b3dd1fe33e140df7699766368deb29 )
+    comment "http://www.romhacking.net/translations/647/"
+)
+
+game (
+    name "Kawa no Nushi Tsuri (Japan) [T-En by Pikachumanson]"
+    description "English translation by Pikachumanson version (0.91)"
+    rom ( name "Kawa no Nushi Tsuri (Japan).nes" size 262160 crc b2931d6a md5 64e28bbe26e2de014ee790d9343ce7aa sha1 770a4b80661c207e7bc5051aaa413028c763dd11 )
+    comment "http://www.romhacking.net/translations/2009/"
+)
+
+game (
+    name "Radia Senki - Reimei Hen (Japan) [T-En by dreamless, Jair and [cx]]"
+    description "English translation by dreamless, Jair and [cx] version (1.00)"
+    rom ( name "Radia Senki - Reimei Hen (Japan).nes" size 393232 crc 1d76af30 md5 6f800e38643c65a193ecc4215748a9d9 sha1 87e8ac608dde48dceccc52e96b247086cb76c032 )
+    comment "http://www.romhacking.net/translations/102/"
+)
+
+game (
+    name "Banana Prince 2 - The Adventure of Banana Goat [Hack by DANGER X]"
+    description "Banana Prince 2 - The Adventure of Banana Goat hack by DANGER X version (3.2)"
+    rom ( name "Banana Prince 2 - The Adventure of Banana Goat.nes" size 262160 crc da1aa878 md5 679f846c5f4a9acbd252b8cbef3e9a6b sha1 0852161b2fb128a3912420309d4b9e12e1b98285 )
+    comment "http://www.romhacking.net/hacks/3180/"
+)
+
+game (
+    name "Lost Word of Jenny - Ushinawareta Message (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Lost Word of Jenny - Ushinawareta Message (Japan).nes" size 131088 crc 577425b3 md5 dbb1964178f3aeb835eee7e708b63c94 sha1 906db79d5dbb767497a3c5cb2e64b1b8f3a89668 )
+    comment "http://www.romhacking.net/translations/2004/"
+)
+
+game (
+    name "Jigoku Gokuraku Maru (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Jigoku Gokuraku Maru (Japan).nes" size 262160 crc bb71e575 md5 4c81bb9b8e4e7eacafc80a17df89072d sha1 524cac353f4cb28e72bd5a17bcfcecb17d245162 )
+    comment "http://www.romhacking.net/translations/1539/"
+)
+
+game (
+    name "Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0)"
+    rom ( name "Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan).nes" size 49168 crc 566a2bb5 md5 836a4daf4adf78838395372822618b9c sha1 d3029f471e39d47d5b4eeed6fc18a723b62370bd )
+    comment "http://www.romhacking.net/translations/894/"
+)
+
+game (
+    name "Wit's (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Wit's (Japan).nes" size 131088 crc e8d26d93 md5 5b25e056c1a20a5e7bfe4490d3b290e7 sha1 37552844718a43a9c15f01d1e25b5be9c05a3cf6 )
+    comment "http://www.romhacking.net/translations/652/"
+)
+
+game (
+    name "Kiteretsu Daihyakka (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Kiteretsu Daihyakka (Japan).nes" size 262160 crc ac9a9381 md5 2892b0cba846e5379ed14caeac1bc598 sha1 f8e142c7689b198da07396353189a191b6f37472 )
+    comment "https://www.romhacking.net/translations/2581/"
+)
+
+game (
+    name "Samsara Naga (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.01)"
+    rom ( name "Samsara Naga (Japan).nes" size 655376 crc 84d7b375 md5 86ea7f22c0e5f1f1f3af8e9088e94b4f sha1 d220905a3a40b6efcaf787185295186cfac5bdb5 )
+    comment "http://www.romhacking.net/translations/2099/"
+)
+
+game (
+    name "Ninja-kun - Majou no Bouken (Japan) (Rev 1) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Ninja-kun - Majou no Bouken (Japan) (Rev 1).nes" size 24592 crc 8cfaa90e md5 443e11c1d2c546abf8aa51ea4fc68899 sha1 d4df3838f6671cbd6f53442851291999edb8cffa )
+    comment "http://www.romhacking.net/translations/2219/"
+)
+
+game (
+    name "Zelda II: New Adventure of Link [Hack by HollowShadow]"
+    description "Zelda II: New Adventure of Link hack by HollowShadow version (4.3)"
+    rom ( name "Zelda II - New Adventure of Link.nes" size 262160 crc e658deda md5 10dc0137c9ff558563a978e05771762b sha1 d09214c2d64c7e2782fb2c6b7e592923bcf0451d )
+    comment "http://www.romhacking.net/hacks/3474/"
+)
+
+game (
+    name "Ys (Japan) [T-En by David Mullen (MakoKnight)]"
+    description "English translation by David Mullen (MakoKnight) version (1.0)"
+    rom ( name "Ys (Japan).nes" size 262160 crc 9171e8b2 md5 aa3b6d8109ccacd77c64dc248d8d39ca sha1 f3da0184fb69f3b566f136f6977d4dce129acfd3 )
+    comment "http://www.romhacking.net/translations/238/"
+)
+
+game (
+    name "Valis++ [Hack by Sliver X]"
+    description "Valis++ hack by Sliver X version (1.01)"
+    rom ( name "Mugen Senshi Valis (Japan).nes" size 131088 crc 58f6b2f6 md5 23ca79401d7a87318d6dbedff6fcd213 sha1 c079934756ba2a3a3ec295fe125921dadcc1c040 )
+    comment "http://www.romhacking.net/hacks/248/"
+)
+
+game (
+    name "Juvei Quest (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.01)"
+    rom ( name "Juvei Quest (Japan).nes" size 786448 crc 00a5b4f2 md5 c8ca112a41accc4049ebed1b70b7b259 sha1 1839aa3671f0df084107e92ed8627f0b0388463f )
+    comment "http://www.romhacking.net/translations/1826/"
+)
+
+game (
+    name "Honoo no Toukyuuji - Dodge Danpei 2 (Japan) [T-En by TransGen]"
+    description "English translation by TransGen version (1.0a)"
+    rom ( name "Honoo no Toukyuuji - Dodge Danpei 2 (Japan).nes" size 524304 crc 95469699 md5 cc0951551fce79f66a519a23214b7bee sha1 61f198bc5f95dfa5a2e9fe567c37e586a54d9313 )
+    comment "http://www.romhacking.net/translations/1269/"
+)
+
+game (
+    name "Layla: The Iris Missions [Hack by Supper]"
+    description "Layla: The Iris Missions hack by Supper version (3.0)"
+    rom ( name "Layla (Japan).nes" size 262160 crc 3f4f9465 md5 30c8feeb4d35da3232aa57a07a5137e6 sha1 ec98ce4d292b078e08f06a35a68b077436e039c7 )
+    comment "https://www.romhacking.net/hacks/3311/"
+)
+
+game (
+    name "Saint Seiya - Ougon Densetsu Kanketsu Hen (Japan) [T-En by aishsha and Djinn]"
+    description "English translation by aishsha and Djinn version (1.01)"
+    rom ( name "Saint Seiya - Ougon Densetsu Kanketsu Hen (Japan).nes" size 262160 crc 912be32d md5 8e7bf5ab464287e46d631bbea9857a01 sha1 a1126cf59c0710b55d64873ac8c394138b7dbe10 )
+    comment "http://www.romhacking.net/translations/1487/"
+)
+
+game (
+    name "Tsuri Kichi Sanpei - Blue Marlin Hen (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (0.94b)"
+    rom ( name "Tsuri Kichi Sanpei - Blue Marlin Hen (Japan).nes" size 131088 crc a3479469 md5 f3000d1d87c2ca443f2980804f70e8eb sha1 087700340f3266c8e1acff1c454d7913f813cf98 )
+    comment "http://www.romhacking.net/translations/2533/"
+)
+
+game (
+    name "Nakayoshi to Issho (Japan) [T-En by HTI]"
+    description "English translation by HTI version (1.00)"
+    rom ( name "Nakayoshi to Issho (Japan).nes" size 393232 crc 1da8c393 md5 11d8137c6ad0679bdc4a286329501583 sha1 87ad659ebd755866d0bbf519ef44ba18cd6c425a )
+    comment "http://www.romhacking.net/translations/1723/"
+)
+
+game (
+    name "Mitsume ga Tooru (Japan) [T-En by The Spoony Bard]"
+    description "English translation by The Spoony Bard version (1.01)"
+    rom ( name "Mitsume ga Tooru (Japan).nes" size 262160 crc d1157a30 md5 232247d7bae7aa1a92cee06668abdd07 sha1 78f272a42ef8695ae91a4c0ed8fd154e67366167 )
+    comment "http://www.romhacking.net/translations/187/"
+)
+
+game (
+    name "King of Kings (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (0.99B)"
+    rom ( name "King of Kings (Japan).nes" size 262160 crc 89e7e83d md5 14ec77d9af2e2bc23884d5f4aabacfdf sha1 f7c9873d3f7a79257478afee6cb57e75186de6fc )
+    comment "http://www.romhacking.net/translations/2350/"
+)
+
+game (
+    name "Magical Kid's Doropie (Japan) [T-En by Video Smash Excellent]"
+    description "English translation by Video Smash Excellent version (1.00)"
+    rom ( name "Magical Kid's Doropie (Japan).nes" size 262160 crc 9978aa06 md5 5d99ff5b4a2fe341ebee2cb3ef8a369d sha1 e6e13fb9be8de11016efbaac9ad5655b8e43b180 )
+    comment "http://www.romhacking.net/translations/576/"
+)
+
+game (
+    name "Foton - The Ultimate Game on Planet Earth (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.00 beta)"
+    rom ( name "Foton - The Ultimate Game on Planet Earth (Japan).nes" size 131088 crc 351a3bf3 md5 133d8cdf71a111d1a5d2c605017863b6 sha1 560f25ad88f934c64c01ce3ad0086d9b9359b42c )
+    comment "http://www.romhacking.net/translations/634/"
+)
+
+game (
+    name "Jing Hua Yuan [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Jing Hua Yuan (China) (Unl).nes" size 524304 crc d56a5afa md5 2e1e80034f1b8fc6f9d64c02564d4a39 sha1 981484744e684e93583c636dd01ec6319a372258 )
+    comment "https://www.romhacking.net/translations/3113/"
+)
+
+game (
+    name "Shinsenden (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.0)"
+    rom ( name "Shinsenden (Japan).nes" size 524304 crc a0b8da25 md5 b51ee221653ebae5df47a40dcf8b9793 sha1 3d327d9d35568d70e7aa3a7ceacdb0e62db0f457 )
+    comment "http://www.romhacking.net/translations/1420/"
+)
+
+game (
+    name "Ki no Bouken - The Quest of Ki (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Ki no Bouken - The Quest of Ki (Japan).nes" size 196624 crc 35c90a4f md5 bc6fe7d4c53a2dd9948d6bbc28dd2111 sha1 d18fb2b1e49ddf5aaf33f49a107d617ea09448a7 )
+    comment "http://www.romhacking.net/translations/2029/"
+)
+
+game (
+    name "Home Alone - Improved Version [Hack by lancuster]"
+    description "Home Alone - Improved Version hack by lancuster version (1.0)"
+    rom ( name "Home Alone (USA).nes" size 262160 crc ccd63ff1 md5 cc764be1ae8915f7cb89438b59de9f14 sha1 14236fb78bdb48f41b29a440bddf6d281f0db6c6 )
+    comment "http://www.romhacking.net/hacks/3184/"
+)
+
+game (
+    name "Tokkyuu Shirei Solbrain (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.01)"
+    rom ( name "Tokkyuu Shirei Solbrain (Japan).nes" size 262160 crc 0fd5f1cc md5 c0ed463527c1dc4945d9c5aa3653a22c sha1 7c786558fdf9886a561478d6b559e2b57a0fedc3 )
+    comment "http://www.romhacking.net/translations/229/"
+)
+
+game (
+    name "Pachinko Daisakusen 2 (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "Pachinko Daisakusen 2 (Japan).nes" size 262160 crc bc54de02 md5 7de946560dd07ad510f46005958c2eb5 sha1 ed43c7475abea3b58c87000091e3ee00a63bcae8 )
+    comment "http://www.romhacking.net/translations/2438/"
+)
+
+game (
+    name "Robocco Wars (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Robocco Wars (Japan).nes" size 393232 crc 9ef74f16 md5 aa735c00b660cb51a1144a605373e496 sha1 0ac3565bc6d619b308918c595189506282b062a0 )
+    comment "http://www.romhacking.net/translations/1388/"
+)
+
+game (
+    name "Future Wars - Mirai Senshi Lios (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00)"
+    rom ( name "Future Wars - Mirai Senshi Lios (Japan).nes" size 262160 crc 932c263b md5 ddb5adcc4b6d45758f3eedfc68edcb0e sha1 1536ea1fc8d59d690c1096d2554e9cc340cf6c56 )
+    comment "http://www.romhacking.net/translations/186/"
+)
+
+game (
+    name "Metroid - Rogue Dawn [Hack by Grimlock, Optomon and snarfblam]"
+    description "Metroid - Rogue Dawn hack by Grimlock, Optomon and snarfblam version (1.21)"
+    rom ( name "Metroid Rogue Dawn.nes" size 786448 crc 2120dfea md5 0a92c8dc3e9a0e7d0d1a45b62912a285 sha1 45f7f44490067e5a439e580e103705f3b574366d )
+    comment "https://www.romhacking.net/hacks/3280/"
+)
+
+game (
+    name "Toukon Club (Japan) [T-En by Eric Engel]"
+    description "English translation by Eric Engel version (1.1)"
+    rom ( name "Toukon Club (Japan).nes" size 393232 crc e2891f5b md5 0df8ed0db3e2d68e9750285ad939fb9f sha1 bc0392376d490b9318817f9ba939857c153eb02b )
+    comment "http://www.romhacking.net/translations/1661/"
+)
+
+game (
+    name "Minna no Taabou no Nakayoshi Daisakusen (Japan) [T-En by hap]"
+    description "English translation by Suicidal Translations version (1.01) + English translation by hap version (1.01)"
+    rom ( name "Minna no Taabou no Nakayoshi Daisakusen (Japan).nes" size 65552 crc e944b830 md5 c89896399a163ebd629230608d339b75 sha1 2fedfc29a8eef15f71d4848c416801526753c075 )
+    comment "http://www.romhacking.net/translations/223/"
+    comment "http://www.romhacking.net/translations/1196/"
+)
+
+game (
+    name "Contra (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Contra (Japan).nes" size 262160 crc d93f2c45 md5 caa299d1a8ecb6dbf8b74ec5145747bf sha1 6ee3e9c59c282abf595d62063ebe5ad52146ee00 )
+    comment "http://www.romhacking.net/translations/1451/"
+)
+
+game (
+    name "Musashi no Bouken (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Musashi no Bouken (Japan).nes" size 393232 crc 0de705a6 md5 a4be4acd712dcee707a78ff00305e8f8 sha1 7dcdbea06774014f3de880f7e9773b8fd79b1bed )
+    comment "http://www.romhacking.net/translations/2749/"
+)
+
+game (
+    name "Fudou Myouou Den (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Fudou Myouou Den (Japan).nes" size 393232 crc 0439b8a6 md5 b0214e8a92d0312b84980ff90969fc8f sha1 0f52630ddc31027f17341a09c6d46b1793c69708 )
+    comment "http://www.romhacking.net/translations/1419/"
+)
+
+game (
+    name "Ikinari Musician (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Ikinari Musician (Japan).nes" size 49168 crc caeb2414 md5 f5ffc9f4ef271a7b589645829d3d4da4 sha1 dbd6bb522bc826f66662e603f1ad6501c393d1af )
+    comment "http://www.romhacking.net/translations/3162/"
+)
+
+game (
+    name "Fire Emblem - Ankoku Ryuu to Hikari no Tsurugi (Japan) [T-En by Megakoopax]"
+    description "English translation by Megakoopax version (Beta 4)"
+    rom ( name "Fire Emblem - Ankoku Ryuu to Hikari no Tsurugi (Japan).nes" size 393232 crc f374f4f6 md5 0ba1df43fd9b47f9ccc5a57d6599267f sha1 393b3e898dc8ada60dc9436b69c7f04df3433da8 )
+    comment "https://www.romhacking.net/translations/2800/"
+)
+
+game (
+    name "Aigina no Yogen - Balubalouk no Densetsu Yori (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.1)"
+    rom ( name "Aigina no Yogen - Balubalouk no Densetsu Yori (Japan).nes" size 131088 crc 661c0a1b md5 bbed95b5202b3c20e9dc2626ca3f38fd sha1 4d117b6348a0e2800104753831536a3966d15897 )
+    comment "http://www.romhacking.net/translations/3102/"
+)
+
+game (
+    name "Pocket Zaurus - Juu Ouken no Nazo (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev A)"
+    rom ( name "Pocket Zaurus - Juu Ouken no Nazo (Japan).nes" size 262160 crc 51548a77 md5 29ce51b4b37e242e7e6fbc13dab90e81 sha1 f3f23708d5154a55a6d08afda5f68faf8a9d1667 )
+    comment "http://www.romhacking.net/translations/2361/"
+)
+
+game (
+    name "Chevaliers du Zodiaque, Les - La Legende d'Or (France) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0)"
+    rom ( name "Chevaliers du Zodiaque, Les - La Legende d'Or (France).nes" size 262160 crc 0914dd20 md5 81f3a6b46dc1aede270e0c615ed36e50 sha1 1fad99244601a160fb0fc4f458b7df3d87053845 )
+    comment "http://www.romhacking.net/translations/172/"
+)
+
+game (
+    name "Mario Adventure [Hack by DahrkDaiz]"
+    description "Mario Adventure hack by DahrkDaiz version (1.0)"
+    rom ( name "Mario Adventure.nes" size 426000 crc 2e6d3fdc md5 326c66d832766021fcc054ae4cc4dddf sha1 4cb0416cb8f06430ec765e0de98b676e4183842d )
+    comment "https://www.romhacking.net/hacks/70"
+)
+
+game (
+    name "Jikuu Yuuden - Debias (Japan) [T-En by Gil Galad]"
+    description "English translation by Gil Galad version (1.0)"
+    rom ( name "Jikuu Yuuden - Debias (Japan).nes" size 327696 crc 0b38881d md5 edcd4f96d394e9a8e2192c39a6c7b3eb sha1 8fd98ee0be19e6d63aac97ed33ea70d02578a38c )
+    comment "http://www.romhacking.net/translations/1645/"
+)
+
+game (
+    name "The Hacker [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Hacker, The (China) (Unl).nes" size 524304 crc 51367325 md5 7cea16d718186025532f1d74680a1adc sha1 6cbbd1ba873408b325fa709a0b84bf5fed147549 )
+    comment "https://www.romhacking.net/translations/3085/"
+)
+
+game (
+    name "Nekketsu Kouha Kunio-kun (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.01)"
+    rom ( name "Nekketsu Kouha Kunio-kun (Japan).nes" size 131088 crc a34f60f9 md5 bedb2cd3158cdbbbfca908f9b5194343 sha1 493b3a4a0e2b003f555f1c427296bad14e58b1f6 )
+    comment "http://www.romhacking.net/translations/891/"
+)
+
+game (
+    name "Cocoron (Japan) [T-En by Akujin and Dynamic-Designs]"
+    description "English translation by Akujin and Dynamic-Designs version (1.0)"
+    rom ( name "Cocoron (Japan).nes" size 262160 crc e486f7d3 md5 6ba6ce8ef2198ad45fd14dae8499d74b sha1 475bf19a0933eb75b38fb9147e4feca4f7398674 )
+    comment "http://www.romhacking.net/translations/104/"
+)
+
+game (
+    name "Wizardry II - Llylgamyn no Isan (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.1)"
+    rom ( name "Wizardry II - Llylgamyn no Isan (Japan).nes" size 262160 crc d3131b58 md5 3f381ec791328613ff964211e85f5071 sha1 478afe45ff295ddca1d9ccaefaac66849191b4a8 )
+    comment "https://www.romhacking.net/translations/2327/"
+)
+
+game (
+    name "Wanpaku Kokkun no Gourmet World (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Wanpaku Kokkun no Gourmet World (Japan).nes" size 262160 crc 24c1e90a md5 73e6d07c28eae3e25b38baf7cdbba934 sha1 874f6d8811310823109d96480acfab7b1b622cad )
+    comment "http://www.romhacking.net/translations/1784/"
+)
+
+game (
+    name "Keroppi to Keroriinu no Splash Bomb! (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.0)"
+    rom ( name "Keroppi to Keroriinu no Splash Bomb! (Japan).nes" size 163856 crc d7039620 md5 0bf94c1e448caa364e7c3f58d99425e6 sha1 f34f9bb86c93f6db24581f62473c1ea924656da9 )
+    comment "http://www.romhacking.net/translations/167/"
+)
+
+game (
+    name "Dragon Ball - Daimaou Fukkatsu (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Dragon Ball - Daimaou Fukkatsu (Japan).nes" size 393232 crc 69beb7a5 md5 bcc2ef456525746ec6a07d5b5a1f2598 sha1 026d1c64338de1b7526e5b442a39a2bceaced2af )
+    comment "http://www.romhacking.net/translations/1604/"
+)
+
+game (
+    name "Ike Ike! Nekketsu Hockey-bu - Subette Koronde Dairantou (Japan) [T-En by GAFF Translations]"
+    description "English translation by Disconnected Translations version (0.99) + English translation by GAFF Translations version (1.00)"
+    rom ( name "Ike Ike! Nekketsu Hockey-bu - Subette Koronde Dairantou (Japan).nes" size 262160 crc 5ad1f8e8 md5 a1456c544b5c71e689ce6619180e59b4 sha1 5f1b28d17dcf4557f1b9ceed860d6c17b23430b5 )
+    comment "http://www.romhacking.net/translations/224/"
+    comment "http://www.romhacking.net/translations/2385/"
+)
+
+game (
+    name "Dragon Ball Z Gaiden - Saiya Jin Zetsumetsu Keikaku (Japan) [T-En by Twilight Translations]"
+    description "English translation by Twilight Translations version (1.00 IPS)"
+    rom ( name "Dragon Ball Z Gaiden - Saiya Jin Zetsumetsu Keikaku (Japan).nes" size 524304 crc 849012ed md5 dc2cb215f7d84bf46d28444805b486dd sha1 cbb2382d78724ee4c18d0d71ca557eb565364408 )
+    comment "http://www.romhacking.net/translations/899/"
+)
+
+game (
+    name "Gegege no Kitarou - Youkai Daimakyou (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.0)"
+    rom ( name "Gegege no Kitarou - Youkai Daimakyou (Japan).nes" size 65552 crc 4a7a99c4 md5 0c1f06ba8c5d0c13a4b524bd79ac311f sha1 e7f4a69971fbf422bd630bffd0a6e53e9d54bb89 )
+    comment "http://www.romhacking.net/translations/1421/"
+)
+
+game (
+    name "Super Star Force (Japan) [T-En by GAFF Translations]"
+    description "English translation by GAFF Translations version (1.00)"
+    rom ( name "Super Star Force (Japan).nes" size 131088 crc a40e552e md5 9c094dcb5d93b5f0673a75213ef977ce sha1 5ed50e40f0ecee4e9d599d7155be42b911dec292 )
+    comment "http://www.romhacking.net/translations/2499/"
+)
+
+game (
+    name "Gun Nac (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.1)"
+    rom ( name "Gun Nac (Japan).nes" size 262160 crc c5fc33f0 md5 0969e96bf893483adc2b360bed774ef7 sha1 9ee38364c5b946a9c4e5d3b69ad3f89cddf30830 )
+    comment "https://www.romhacking.net/translations/2892/"
+)
+
+game (
+    name "Dragon Warrior 2 DX [Hack by LastduaL]"
+    description "Dragon Warrior 2 DX hack by LastduaL version (1.0)"
+    rom ( name "Dragon Warrior II DX.nes" size 262160 crc 73913ca7 md5 7cdcf724aaf7d9393b8decf4f5cf8a32 sha1 d7effff2d998c1cff7259bd026346cd5609ec56c )
+    comment "http://www.romhacking.net/hacks/3964/"
+)
+
+game (
+    name "Spelunker II - Yuusha e no Chousen (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Spelunker II - Yuusha e no Chousen (Japan).nes" size 262160 crc e9aee0d8 md5 3f4b4616dd04f3058f7ab63e89f21552 sha1 5925716d0c5d2da34c2e3959f5c208f4cf24e738 )
+    comment "http://www.romhacking.net/translations/1591/"
+)
+
+game (
+    name "Nagagutsu o Haita Neko - Sekai Isshuu 80 Nichi Daibouken (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Nagagutsu o Haita Neko - Sekai Isshuu 80 Nichi Daibouken (Japan).nes" size 65552 crc 261e3178 md5 8b53eb56901755eb78cd0bd1b66bcc00 sha1 0d6a7fca473f95aece1e5309fcacbace34304361 )
+    comment "http://www.romhacking.net/translations/3114/"
+)
+
+game (
+    name "Sted - Iseki Wakusei no Yabou (Japan) [T-En by J2e Translations]"
+    description "English translation by J2e Translations version (1.0)"
+    rom ( name "Sted - Iseki Wakusei no Yabou (Japan).nes" size 262160 crc 5e63ec57 md5 9cae69bd569ceb05c388929c21fead2a sha1 6e67cedb3481037ddfe8237503bb8cd1ac4523d2 )
+    comment "http://www.romhacking.net/translations/217/"
+)
+
+game (
+    name "Sugoro Quest - Dice no Senshitachi (Japan) [T-En by KingMike's Translations]"
+    description "English translation by AlanMidas version (koogly.titivilus) + English translation by KingMike's Translations version (1.0)"
+    rom ( name "Sugoro Quest - Dice no Senshitachi (Japan).nes" size 262160 crc 98de03c5 md5 fa7c849984de92ac65eac906d0321ddf sha1 ad0b7d31c6ebe1b7e5ea17b93eb2461267e7882c )
+    comment "http://www.romhacking.net/translations/218/"
+    comment "http://www.romhacking.net/translations/1233/"
+)
+
+game (
+    name "Hydlide 3 - Yami kara no Houmonsha (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Hydlide 3 - Yami kara no Houmonsha (Japan).nes" size 393232 crc 3915a78b md5 6d16ebefce1bebe1d5527220aef489eb sha1 bc7c516f669861e46125a95d7f77da5683004bd7 )
+    comment "http://www.romhacking.net/translations/2903/"
+)
+
+game (
+    name "Insector X (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Insector X (Japan).nes" size 262160 crc cc856c42 md5 a65beccf1ed3656996802f31c9c086ec sha1 7580c5a72aa2a28350b34dc1bdc47b486882c44e )
+    comment "http://www.romhacking.net/translations/1542/"
+)
+
+game (
+    name "Kaguya Hime Densetsu (Japan) [T-En by snark]"
+    description "English translation by snark version (0.99)"
+    rom ( name "Kaguya Hime Densetsu (Japan).nes" size 262160 crc e3a1feff md5 2559a167acbf7882a9cfc824e51e76bf sha1 a1a23904d5a2266aac15ae857728b855b0726e3a )
+    comment "http://www.romhacking.net/translations/1449/"
+)
+
+game (
+    name "Oishinbo - Kyuukyoku no Menu Sanbon Shoubu (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Oishinbo - Kyuukyoku no Menu Sanbon Shoubu (Japan).nes" size 262160 crc cfae54f6 md5 50951fd255c256d44da0f9ea87af8973 sha1 c2dbb77abf9dabf7b982c212cb7e2a8c0639f6de )
+    comment "http://www.romhacking.net/translations/1280/"
+)
+
+game (
+    name "Ikki (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Ikki (Japan).nes" size 24592 crc ca514ce9 md5 f80a2e53106e869f7a5fa167841e6e3b sha1 78b56506cecf022066ce62c6e491a0febda06763 )
+    comment "http://www.romhacking.net/translations/3055/"
+)
+
+game (
+    name "Fighting Road (Japan) [T-En by Immutable]"
+    description "English translation by Immutable version (1.0)"
+    rom ( name "Fighting Road (Japan).nes" size 262160 crc 3b9e7aa1 md5 a21c22911f260b3a0c210ddced9b2512 sha1 7db376cfd33d722a5221d6144643072328668b06 )
+    comment "http://www.romhacking.net/translations/3480/"
+)
+
+game (
+    name "Ninjara Hoi! (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Ninjara Hoi! (Japan).nes" size 524304 crc 7a18ffdd md5 9ed3af4c6657b2a09e63ea8d4d3ccd19 sha1 77f29bb265f67d930c9e3c1a1040092ca4e0ec10 )
+    comment "http://www.romhacking.net/translations/2239/"
+)
+
+game (
+    name "Saiyuuki World 2 - Tenjoukai no Majin (Japan) [T-En by PentarouZero]"
+    description "English translation by PentarouZero version (1.0)"
+    rom ( name "Saiyuuki World 2 - Tenjoukai no Majin (Japan).nes" size 262160 crc 45a0a20d md5 802a135115cd4a031e187330da05ab6f sha1 fa30461d2f7a49185b3da7b616b1ac11496752bc )
+    comment "http://www.romhacking.net/translations/838/"
+)
+
+game (
+    name "Bio Miracle Bokutte Upa (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.00)"
+    rom ( name "Bio Miracle Bokutte Upa (Japan).nes" size 262160 crc 31a8ed51 md5 9fcf168547c9ad414e41fb5b709e6987 sha1 e99bd2b415de69531ec50936eb928c2bc3500cc2 )
+    comment "http://www.romhacking.net/translations/676/"
+)
+
+game (
+    name "Valkyrie no Bouken - Toki no Kagi Densetsu (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev A)"
+    rom ( name "Valkyrie no Bouken - Toki no Kagi Densetsu (Japan).nes" size 65552 crc 52ea15cf md5 8395ab6fcd0e04243d22c061ef915895 sha1 dc411d9dacc1bdc89cd894aad193686acf91a8f1 )
+    comment "http://www.romhacking.net/translations/1378/"
+)
+
+game (
+    name "Zombie Hunter (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.01)"
+    rom ( name "Zombie Hunter (Japan).nes" size 163856 crc 4095faba md5 abc8ee11efd585699df9555444f4e164 sha1 20af591a4643391973f430c521262601d5d9b73a )
+    comment "http://www.romhacking.net/translations/545/"
+)
+
+game (
+    name "Battle Storm (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "Battle Storm (Japan).nes" size 262160 crc 791bc52b md5 f7cb1ca47fd4127df7ee05066062719c sha1 43f59b8dca010ed5c6a6d8743cbd9fcbd73c520e )
+    comment "http://www.romhacking.net/translations/2497/"
+)
+
+game (
+    name "Kero Kero Keroppi no Daibouken (Japan) [T-En by Gaijin Productions]"
+    description "English translation by Gaijin Productions version (1.00)"
+    rom ( name "Kero Kero Keroppi no Daibouken (Japan).nes" size 65552 crc 0dfbda9c md5 7d8998d3bd5c1ac8f1c24077d4d702ba sha1 03d12d6e7dde05c261209934513e93e2297624ec )
+    comment "http://www.romhacking.net/translations/165/"
+)
+
+game (
+    name "Elnark no Zaihou (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "Elnark no Zaihou (Japan).nes" size 131088 crc 7e0856c5 md5 4c5e0f788789ec38b7767a7be93eb1d4 sha1 9d708f832e07eff06acdebded130d1d3425f6803 )
+    comment "http://www.romhacking.net/translations/2062/"
+)
+
+game (
+    name "Kart Fighter [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (1.0)"
+    rom ( name "Kart Fighter (China) (Unl).nes" size 393232 crc 290d76b7 md5 773cf1f35440cda3de19e5449cb89dbd sha1 9ac1cb6658664445941ae755520bbb1483da5efd )
+    comment "http://www.romhacking.net/translations/784/"
+)
+
+game (
+    name "Jajamaru Gekimaden - Maboroshi no Kinmajou (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Jajamaru Gekimaden - Maboroshi no Kinmajou (Japan).nes" size 262160 crc 367df135 md5 58768b5a0aaf99ccf305b610bb00f2ac sha1 528c0c3ab9a427f5272785df93f8403e35778a89 )
+    comment "http://www.romhacking.net/translations/1444/"
+)
+
+game (
+    name "Super Xevious - Gump no Nazo (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Super Xevious - Gump no Nazo (Japan).nes" size 163856 crc f18c30e7 md5 656c7c75ffdccd2306e763c3ee8dd86e sha1 f716f6feae0551b1fb380b82e95ac5213396b361 )
+    comment "http://www.romhacking.net/translations/3064/"
+)
+
+game (
+    name "Ganbare Goemon 2 (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.02)"
+    rom ( name "Ganbare Goemon 2 (Japan).nes" size 262160 crc b2fe26c7 md5 de660969cf51255ce30b951e0f71683d sha1 a5616607328daacfea7646bc0d476f8baad265c3 )
+    comment "http://www.romhacking.net/translations/1329/"
+)
+
+game (
+    name "Hyaku no Sekai no Monogatari - The Tales on a Watery Wilderness (Japan) [T-En by AlanMidas]"
+    description "English translation by AlanMidas version (BS.VQt)"
+    rom ( name "Hyaku no Sekai no Monogatari - The Tales on a Watery Wilderness (Japan).nes" size 262160 crc 1385e8a5 md5 45eb296391e9c22c4585bc4382cce72a sha1 30867b7d263da64ad63b3a11e93a473c0c002e30 )
+    comment "http://www.romhacking.net/translations/85/"
+)
+
+game (
+    name "Hello Kitty no Ohanabatake (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Hello Kitty no Ohanabatake (Japan).nes" size 65552 crc ed8c788c md5 6d787d2b1ede51f619c1693cb4e5bf96 sha1 57ca0c476f394a164e032427a57db9a0d1731d1a )
+    comment "http://www.romhacking.net/translations/158/"
+)
+
+game (
+    name "Youkai Club (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Youkai Club (Japan).nes" size 163856 crc 27937903 md5 9ddfd27dc2a6b08ed2b2c6b5a9e49508 sha1 6b9b28ee4fbfd77b601fc6081b607654385a3696 )
+    comment "https://www.romhacking.net/translations/1303/"
+)
+
+game (
+    name "Esper Dream 2 - Aratanaru Tatakai (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.0)"
+    rom ( name "Esper Dream 2 - Aratanaru Tatakai (Japan).nes" size 393232 crc 892b32eb md5 6dbfaf74836208dbce117a99fa388b04 sha1 1786eb08348d3c73e3fed66fe88ebda74e78ed0f )
+    comment "https://www.romhacking.net/translations/1045/"
+)
+
+game (
+    name "Holy Diver (Japan) [T-En by Monaco]"
+    description "English translation by Monaco version (1.0)"
+    rom ( name "Holy Diver (Japan).nes" size 262160 crc 28d1d380 md5 1a2c8fd89cdb0d7c978f38b9f2802891 sha1 fb7f078ccae66da934387bd80967e03b2e29747b )
+    comment "http://www.romhacking.net/translations/1110/"
+)
+
+game (
+    name "Sweet Home (Japan) [T-En by TheSiege]"
+    description "English translation by TheSiege version (1.0)"
+    rom ( name "Sweet Home (Japan).nes" size 262160 crc ef8f2af6 md5 23d54cc85c432ef5525932600b98ded2 sha1 f5896b057420dc2d4666bb4567dc319ddecdb020 )
+    comment "http://www.romhacking.net/translations/2853/"
+)
+
+game (
+    name "Mashin Eiyuuden Wataru Gaiden (Japan) [T-En by Hubz]"
+    description "English translation by Hubz version (1.0)"
+    rom ( name "Mashin Eiyuuden Wataru Gaiden (Japan).nes" size 262160 crc 806af261 md5 4f2ea17b8404013358f447c4af048c82 sha1 3ea2a72651c805acd7c3ea8d3e6496ebaa68eff0 )
+    comment "http://www.romhacking.net/translations/1816/"
+)
+
+game (
+    name "Captain Tsubasa Vol. II - Super Striker (Japan) [T-En by hayabusakun]"
+    description "English translation by hayabusakun version (1.0)"
+    rom ( name "Captain Tsubasa Vol. II - Super Striker (Japan).nes" size 393232 crc 465917f7 md5 602ddd825c74869a846658f7ced717f9 sha1 a081364d15aa651a3a30477b7f8b7115a1060c8b )
+    comment "http://www.romhacking.net/translations/1182/"
+)
+
+game (
+    name "Moai-kun (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Moai-kun (Japan).nes" size 65552 crc 95f8b436 md5 bda29672c8950de9fd83b031fa566c26 sha1 012f143c3343835b1426abdd2a0102b595a1793a )
+    comment "http://www.romhacking.net/translations/2098/"
+)
+
+game (
+    name "Tao (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Tao (Japan).nes" size 262160 crc 32fb06f5 md5 8cb4ca95467ca6596cddc2ed5c29622c sha1 b48d8740621c891208923ad37ba70d0bccd5e7d7 )
+    comment "http://www.romhacking.net/translations/1603/"
+)
+
+game (
+    name "Ultraman Club - Kaijuu Daikessen!! (Japan) [T-En by cccmar and Eric Engel]"
+    description "English translation by cccmar and Eric Engel version (1.0)"
+    rom ( name "Ultraman Club - Kaijuu Daikessen!! (Japan).nes" size 393232 crc f97911b7 md5 c419524dd3e1f8edff05647fc9064b75 sha1 7f67aba8c58cb332e0341e5fd4c83839cbe98cbc )
+    comment "https://www.romhacking.net/translations/3281/"
+)
+
+game (
+    name "Legend of Zelda: Awakening of Onyx [Hack by pacnsacdave and Trifindo]"
+    description "Legend of Zelda: Awakening of Onyx hack by pacnsacdave and Trifindo version (1.0)"
+    rom ( name "Legend of Zelda - Awakening of Onyx.nes" size 131088 crc 8baa6c5f md5 c12901c75c16ec4e1bb47ce6d860c5e7 sha1 d8dc3a7eac9b858ef82233d6fb21b33c2babb2c4 )
+    comment "https://www.romhacking.net/hacks/3261/"
+)
+
+game (
+    name "Fantasy Zone Neo Classic [Hack by High Level Challenge]"
+    description "Fantasy Zone Neo Classic hack by High Level Challenge version (1.0)"
+    rom ( name "Fantasy Zone (Japan).nes" size 131088 crc 38f00067 md5 8c9eeb843775216071b92e752292e165 sha1 965dc587897dcc1142f1ca2b1005def2c2076003 )
+    comment "http://www.romhacking.net/hacks/3935/"
+)
+
+game (
+    name "Super Mario All Stars NES [Hack by infidelity]"
+    description "Super Mario All Stars NES hack by infidelity version (10-15-2017)"
+    rom ( name "Super Mario All-Stars NES.nes" size 2097168 crc 379327ab md5 1bb981b0d632a5b84ba805adf8bdc755 sha1 94983938cbb6439e2c3931ce39dedc13917fd179 )
+    comment "https://www.romhacking.net/hacks/2422/"
+)
+
+game (
+    name "Silva Saga (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.01)"
+    rom ( name "Silva Saga (Japan).nes" size 786448 crc 75a9eb48 md5 93bdf2e534408ba25ea6213d03e1c7fc sha1 a32bd06092f129668736ad0a627e78575b52e0d7 )
+    comment "http://www.romhacking.net/translations/1394/"
+)
+
+game (
+    name "Yume Penguin Monogatari (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.021)"
+    rom ( name "Yume Penguin Monogatari (Japan).nes" size 262160 crc 280902ae md5 800c44062da7a2897dd33408ee90def0 sha1 6730403428b76a830ded0e1d3654957f8305c686 )
+    comment "http://www.romhacking.net/translations/678/"
+)
+
+game (
+    name "Power Blazer (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Power Blazer (Japan).nes" size 262160 crc a9bd2381 md5 012c6c03931bbabe3833e62fafd22494 sha1 852e622b1787b678fcf120260af7014ae069df31 )
+    comment "http://www.romhacking.net/translations/1402/"
+)
+
+game (
+    name "Banana Prince (Germany) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.1a)"
+    rom ( name "Banana Prince (Germany).nes" size 262160 crc 3a2e77a7 md5 335aebbb9c37398b4fc8858ffb5b87ff sha1 5c387229b6f734eec70236c5fd890af850408302 )
+    comment "https://www.romhacking.net/translations/685/"
+)
+
+game (
+    name "Crisis Force (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Crisis Force (Japan).nes" size 262160 crc 8a053054 md5 4c8415dd3bb071883753a7ed41ae4436 sha1 6c2458b515b39274ed684628e5189e6c4275dfa9 )
+    comment "http://www.romhacking.net/translations/1353/"
+)
+
+game (
+    name "Castlevania: The Holy Relics [Hack by Optomon]"
+    description "Castlevania: The Holy Relics hack by Optomon version (1.0)"
+    rom ( name "Castlevania - The Holy Relics.nes" size 131088 crc 8603cbbb md5 2b6244fbf1da0bd79a69e20700b767c3 sha1 80bc6e477d46260c4fbf19e1bb68c11cc208894a )
+    comment "http://www.romhacking.net/hacks/3759/"
+)
+
+game (
+    name "Bio Senshi Dan - Increaser Tono Tatakai (Japan) [T-En by Abstract Crouton Productions]"
+    description "English translation by Abstract Crouton Productions version (1.5)"
+    rom ( name "Bio Senshi Dan - Increaser Tono Tatakai (Japan).nes" size 262287 crc 172bd116 md5 435bbcc4c1628aeb9f9c97e4e2786134 sha1 9e353e4bdbae88354c6fafce55de33444b33435f )
+    comment "http://www.romhacking.net/translations/642/"
+)
+
+game (
+    name "Airwolf (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.0)"
+    rom ( name "Airwolf (Japan).nes" size 262160 crc deb8ef4a md5 bdb6c1b72c6cf039a748a2f6a354813b sha1 b76eb5b18b09bfc48f08533309cd03b8b24221fd )
+    comment "http://www.romhacking.net/translations/741/"
+)
+
+game (
+    name "Grand Master (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.01)"
+    rom ( name "Grand Master (Japan).nes" size 393232 crc 51cd513e md5 e058a867a6c4f16981fc7d7fa3e8616d sha1 454d7cab62c3d27b7c6210373a14d92d90ba1672 )
+    comment "http://www.romhacking.net/translations/1540/"
+)
+
+game (
+    name "Majou Densetsu II - Daimashikyou Galious (Japan) [T-En by Manipulate + 1 hacks]"
+    description "English translation by Manipulate version (0.31b) + Majou Densetsu II: Daimashikyou Galious SRAM save patch hack by RGBA_CRT version (1.0)"
+    rom ( name "Majou Densetsu II - Daimashikyou Galious (Japan).nes" size 131088 crc 4248f3b1 md5 005072477e1082bbd0899587398962f4 sha1 90467baecaeb722505468ce5a22ae027d44bd560 )
+    comment "http://www.romhacking.net/translations/182/"
+    comment "https://www.romhacking.net/hacks/3938/"
+)
+
+game (
+    name "Downtown - Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan) [T-En by Disconnected Translations]"
+    description "English translation by Disconnected Translations version (0.15)"
+    rom ( name "Downtown - Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan).nes" size 262160 crc d6b273d7 md5 0d3d4600589c465f408806f2a8e7322b sha1 33d2931d9cc0821eb34f10a0b8dd3f73b145c615 )
+    comment "https://www.romhacking.net/translations/596/"
+)
+
+game (
+    name "Star Wars (Japan) (Namco) [T-En by Gil Galad]"
+    description "English translation by Gil Galad version (1.10)"
+    rom ( name "Star Wars (Japan) (Namco).nes" size 262160 crc f3f48bc2 md5 22964f1a90234dac8758f7cc7c0f0158 sha1 a57747348e41198e47a7ebbc38dab2316dc27d88 )
+    comment "http://www.romhacking.net/translations/1369/"
+)
+
+game (
+    name "SWAT - Special Weapons and Tactics (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "SWAT - Special Weapons and Tactics (Japan).nes" size 262160 crc fdfc0116 md5 6c02ae106cd8e928ff6f4f89fd50dee0 sha1 d14684db61a357eaff4e8fa8d790a8424cb13af2 )
+    comment "https://www.romhacking.net/translations/3487/"
+)
+
+game (
+    name "Tashiro Masashi no Princess ga Ippai (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Tashiro Masashi no Princess ga Ippai (Japan).nes" size 262160 crc d85c0cc1 md5 9922564f9d2c666c6f5f8b9f834c0859 sha1 518cd8abe17d2620a7108d545e9ed7bf534303df )
+    comment "http://www.romhacking.net/translations/202/"
+)
+
+game (
+    name "Puyo Puyo (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.0)"
+    rom ( name "Puyo Puyo (Japan).nes" size 131088 crc e0784b94 md5 3e83a7e11ffb8974507ab87201e6f7e1 sha1 734fbe2bb54fdcdc9b5a8008c38abcbb370a2b45 )
+    comment "http://www.romhacking.net/translations/203/"
+)
+
+game (
+    name "Kujaku Ou (Japan) [T-En by snark]"
+    description "English translation by snark version (1.1)"
+    rom ( name "Kujaku Ou (Japan).nes" size 262160 crc 4b98ba2a md5 ab862997d635ea3fc8b1652564cf3161 sha1 2bd98e652019330f9d1e1ae0d51bfd3bfdf2615d )
+    comment "http://www.romhacking.net/translations/1341/"
+)
+
+game (
+    name "Maharaja (Japan) [T-En by snark]"
+    description "English translation by snark version (0.99)"
+    rom ( name "Maharaja (Japan).nes" size 262160 crc d6883037 md5 1b4fc2cad44412392e832d5b4ac44f84 sha1 21e641492a45e71480dd4bf98670ffb291c895f0 )
+    comment "http://www.romhacking.net/translations/1453/"
+)
+
+game (
+    name "Perman Part 2 - Himitsu Kessha Madoodan o Taose! (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0)"
+    rom ( name "Perman Part 2 - Himitsu Kessha Madoodan o Taose! (Japan).nes" size 393232 crc cc4d0d62 md5 01911c577115d93801c31ff69fd43554 sha1 402313b7c330e691c6782b7d82296d97c883750e )
+    comment "http://www.romhacking.net/translations/668/"
+)
+
+game (
+    name "Mouryou Senki Madara (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00)"
+    rom ( name "Mouryou Senki Madara (Japan).nes" size 524304 crc 572856c7 md5 cedce8967efda698fb37d08e6f1f37b1 sha1 539f81ee9dd662b0d2062e58b4bfcfb9e5220ab9 )
+    comment "http://www.romhacking.net/translations/1047/"
+)
+
+game (
+    name "Kujaku Ou II (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Kujaku Ou II (Japan).nes" size 262160 crc b478e8ab md5 043d4cdc35fd8c5830c7d2275eb463fb sha1 9b9db229f0c115c52e2c36963064e6a1364ae0f7 )
+    comment "http://www.romhacking.net/translations/1387/"
+)
+
+game (
+    name "Dark Gimmick! [Hack by Berion and Dizzy9]"
+    description "Dark Gimmick! hack by Berion and Dizzy9 version (1.1)"
+    rom ( name "Dark Gimmick!.nes" size 393232 crc 66a6b8d6 md5 e8cfd6d67003e64018213b48fb76fc87 sha1 4ee5b5c30ee7c102045c5c61e3fad6346d5b6645 )
+    comment "https://www.romhacking.net/hacks/2221/"
+)
+
+game (
+    name "Sanrio Cup - Pon Pon Volley (Japan) [T-En by Gaijin Productions]"
+    description "English translation by Gaijin Productions version (1.00)"
+    rom ( name "Sanrio Cup - Pon Pon Volley (Japan).nes" size 65552 crc 5a08b975 md5 632947c8dba6fdae54ecbfd998c4c16c sha1 23869662f501fbd4206f48e162d042c274437e87 )
+    comment "http://www.romhacking.net/translations/210/"
+)
+
+game (
+    name "Mississippi Satsujin Jiken (Japan) [T-En by GAFF Translations]"
+    description "English translation by GAFF Translations version (1.00)"
+    rom ( name "Mississippi Satsujin Jiken (Japan).nes" size 163856 crc f698e872 md5 72eec8c62890cbfcf29676c9a0cfed2f sha1 a490631370eef6ae4f0a2c979e365a0bb7f88f53 )
+    comment "http://www.romhacking.net/translations/3133/"
+)
+
+game (
+    name "Onyanko Town (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Onyanko Town (Japan).nes" size 40976 crc 8e819303 md5 523ee6d72b2464fd5f00f3075d815d21 sha1 5e7b49181b9fbafc20b3b093bd0b5c9544ded624 )
+    comment "http://www.romhacking.net/translations/2522/"
+)
+
+game (
+    name "Takahashi Meijin no Bugutte Honey (Japan) [T-En by FlashPV]"
+    description "English translation by FlashPV version (1.0)"
+    rom ( name "Takahashi Meijin no Bugutte Honey (Japan).nes" size 163856 crc 76e5fbcd md5 2c110f7e9d82a90ac28d313c32ebf86e sha1 7c09d5aa7c5b04a5eac99ac90fb73bf8a3997f33 )
+    comment "http://www.romhacking.net/translations/3373/"
+)
+
+game (
+    name "Final Fantasy II (Japan) [T-En by Chaos Rush]"
+    description "English translation by Chaos Rush version (1.6)"
+    rom ( name "Final Fantasy II (Japan).nes" size 262160 crc 5f9b56da md5 2ee374f3547656956a4770f66241c3df sha1 c11c84c028eb8c450f935c83d7e5a22d86c2b108 )
+    comment "http://www.romhacking.net/translations/2656/"
+)
+
+game (
+    name "Mottomo Abunai Deka (Japan) [T-En by Gil Galad]"
+    description "English translation by Gil Galad version (1.0)"
+    rom ( name "Mottomo Abunai Deka (Japan).nes" size 131088 crc c87069f7 md5 a64f74548d8d3956c100344511c69251 sha1 4ce5357d3ba645cc8e587f3e70b3d02afd47f921 )
+    comment "http://www.romhacking.net/translations/1364/"
+)
+
+game (
+    name "Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan) [T-En by Technos Samurai Translation Project]"
+    description "English translation by Technos Samurai Translation Project version (1.0)"
+    rom ( name "Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan).nes" size 262160 crc e7d3dc96 md5 63e1d902807981f524af97748cd99500 sha1 74a83909bb4a0786b5dec3b4411099ccf154ca27 )
+    comment "https://www.romhacking.net/translations/226/"
+)
+
+game (
+    name "City Adventure Touch - Mystery of Triangle (Japan) [T-En by filler]"
+    description "English translation by filler version (1.0)"
+    rom ( name "City Adventure Touch - Mystery of Triangle (Japan).nes" size 131088 crc 0e566e50 md5 937b12457c9666bfb42d86205cb39351 sha1 6ed859f0b25a5f64b2cecb2ee50ef10979239331 )
+    comment "http://www.romhacking.net/translations/3440/"
+)
+
+game (
+    name "Kaiketsu Yancha Maru 3 - Taiketsu! Zouringen (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Kaiketsu Yancha Maru 3 - Taiketsu! Zouringen (Japan).nes" size 262160 crc 2c8d479c md5 f922dbbce476ac9b8f3297c642f054b7 sha1 ba02bd54ffb60e3cf996f73d92c3728006db3cab )
+    comment "http://www.romhacking.net/translations/651/"
+)
+
+game (
+    name "Fushigi no Umi no Nadia (Japan) [T-En by J2e Translations]"
+    description "English translation by J2e Translations version (1.3)"
+    rom ( name "Fushigi no Umi no Nadia (Japan).nes" size 262160 crc 9e49b111 md5 bdaf3987b1a115c46566a708d449e484 sha1 3eacaa6b91880852cb480828a2f79aa1568eba15 )
+    comment "http://www.romhacking.net/translations/194/"
+)
+
+game (
+    name "P.O.W.: Prisoners of War - Two Players Hack [Hack by Ti]"
+    description "P.O.W.: Prisoners of War - Two Players Hack hack by Ti version (1.5a)"
+    rom ( name "P.O.W. - Prisoners of War (USA).nes" size 262160 crc ac35ae7b md5 0b82aff1ed97e178d10b2f67974986e2 sha1 b4ba5f3226c06a2eafaf32d70789eb289028c7fa )
+    comment "https://www.romhacking.net/hacks/2140/"
+)
+
+game (
+    name "Perman (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (2.0)"
+    rom ( name "Perman (Japan).nes" size 262160 crc 936089f7 md5 99d794a33d760c0668839fbef7ff8125 sha1 744a119bc201ea1b4b28d87c1f09f9d77b7d0535 )
+    comment "http://www.romhacking.net/translations/2588/"
+)
+
+game (
+    name "Castlevania: Improved Controls [Hack by NaOH]"
+    description "Castlevania: Improved Controls hack by NaOH version (1.0)"
+    rom ( name "Castlevania (USA) (Rev A).nes" size 131088 crc 693ee9fa md5 3e1cbed91aaa4508874110a5784434cb sha1 52f65d074007533b3e19678604dde31c7c459fbe )
+    comment "https://www.romhacking.net/hacks/3867/"
+)
+
+game (
+    name "Gojira (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Gojira (Japan).nes" size 262160 crc dd65d608 md5 b2dde7b884a4ac989932e02a596156ce sha1 bc678048ded90bfefe38172300279b616e6108c4 )
+    comment "https://www.romhacking.net/translations/2894/"
+)
+
+game (
+    name "Chuuka Taisen (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Chuuka Taisen (Japan).nes" size 262160 crc 8cdbc48f md5 4fcc8c1dc1bc05fe752d4fe4ee3b0e2a sha1 6173fcb1237128327f7234dbf34872fb4b355470 )
+    comment "http://www.romhacking.net/translations/1697/"
+)
+
+game (
+    name "Summer Carnival '92 - Recca (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00)"
+    rom ( name "Summer Carnival '92 - Recca (Japan).nes" size 262160 crc 834a79d8 md5 034fdc020a432a51828501d7aa4390ec sha1 d43ae67a64a563d8f7965b75291a83160e3392d7 )
+    comment "http://www.romhacking.net/translations/620/"
+)
+
+game (
+    name "The Legend of Zelda - Link's Shadow [Hack by The3Dude]"
+    description "The Legend of Zelda - Link's Shadow hack by The3Dude version (1.5)"
+    rom ( name "Legend of Zelda - Link's Shadow.nes" size 131099 crc bb9fddd7 md5 d94ce5ca4697dc3221433cb95c8fd8a4 sha1 83da36acc3df73795fcf763d603028a4f628dd65 )
+    comment "https://www.romhacking.net/hacks/3960/"
+)
+
+game (
+    name "Akumajou Special - Boku Dracula-kun (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.04)"
+    rom ( name "Akumajou Special - Boku Dracula-kun (Japan).nes" size 262160 crc f70dd01c md5 42274f44e77e1ec18f714a919d763124 sha1 ecf3c21144d2a1d9fc6d9ac924fcbdbade198ed6 )
+    comment "http://www.romhacking.net/translations/169/"
+)
+
+game (
+    name "Dragon Scroll - Yomigaerishi Maryuu (Japan) [T-En by Eien Ni Hen and KingMike's Translations]"
+    description "English translation by Eien Ni Hen and KingMike's Translations version (1.0)"
+    rom ( name "Dragon Scroll - Yomigaerishi Maryuu (Japan).nes" size 262160 crc 286dc20f md5 fe19f70cf024a7f072c2f86d4ba5346c sha1 2d1c5630e827b6d5a89993986eb7a714643ba637 )
+    comment "https://www.romhacking.net/translations/1267/"
+)
+
+game (
+    name "Motocross Champion (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Motocross Champion (Japan).nes" size 262160 crc c252e03a md5 b81fc746d90c3087dfac6d8cf5eb82c4 sha1 b838956eba2c4b456a11f71a984f5ffbcd892801 )
+    comment "http://www.romhacking.net/translations/191/"
+)
+
+game (
+    name "Namco Prism Zone - Dream Master (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.01)"
+    rom ( name "Namco Prism Zone - Dream Master (Japan).nes" size 786448 crc 5ca2de71 md5 32cbb6cdc9042c46d02405af6d80819d sha1 aff4b38aad368c0956b40099ebbddb53c337291e )
+    comment "http://www.romhacking.net/translations/1520/"
+)
+
+game (
+    name "Game Designer Yousei Soft - Dezaemon (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.1)"
+    rom ( name "Game Designer Yousei Soft - Dezaemon (Japan).nes" size 131088 crc a2a3f2a8 md5 e5e6155d68788ed4c92849142adda594 sha1 63e173c5b146795d41ead95bb668cb8791ae9edf )
+    comment "http://www.romhacking.net/translations/117/"
+)
+
+game (
+    name "SD Hero Soukessen - Taose! Aku no Gundan (Japan) [T-En by Corvo]"
+    description "English translation by Corvo version (1.0)"
+    rom ( name "SD Hero Soukessen - Taose! Aku no Gundan (Japan).nes" size 262160 crc b552854d md5 aa3080b051e69026370dfdd57a16f0b1 sha1 6fe108efb17839a834a367316cd44d69db6b1382 )
+    comment "http://www.romhacking.net/translations/2354/"
+)
+
+game (
+    name "Elysion (Japan) [T-En by Tenshigami]"
+    description "English translation by Tenshigami version (0.92)"
+    rom ( name "Elysion (Japan).nes" size 262160 crc 4839106c md5 e138b94753d94b99a48a71f10b4de6b5 sha1 bf2ce915e78ed761092fb387331ae3812cf95986 )
+    comment "http://www.romhacking.net/translations/1306/"
+)
+
+game (
+    name "River City Ransom Improvement [Hack by SpiderDave]"
+    description "River City Ransom Improvement hack by SpiderDave version (2017.06.1)"
+    rom ( name "River City Ransom (USA).nes" size 262160 crc fb9d3d82 md5 287f11a43a45150ce0376a0e00ecc6c7 sha1 2584d294db79e622ef7efb8e3331aed578685662 )
+    comment "http://www.romhacking.net/hacks/3453/"
+)
+
+game (
+    name "Don Doko Don 2 (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "Don Doko Don 2 (Japan).nes" size 393232 crc 560142bc md5 cafbbbc82ac7bfbc93bc84d7b9391677 sha1 a3342bc3bd0b98674e718ffe6ef937630f523524 )
+    comment "http://www.romhacking.net/translations/2198/"
+)
+
+game (
+    name "Final Fantasy Redux [Hack by Spindaboy]"
+    description "Final Fantasy Redux hack by Spindaboy version (1.0.0)"
+    rom ( name "Final Fantasy (USA).nes" size 262160 crc 033fd1ae md5 caf45a1922aed0db4d332886362da4c0 sha1 b7cd68101f0e1025a86eb93e3bcc483c9d19edac )
+    comment "https://www.romhacking.net/hacks/3424/"
+)
+
+game (
+    name "Digital Devil Story - Megami Tensei (Japan) [T-En by EsperKnight, Stardust Crusaders and Tom]"
+    description "English translation by EsperKnight, Stardust Crusaders and Tom version (1.0)"
+    rom ( name "Digital Devil Story - Megami Tensei (Japan).nes" size 393232 crc ac5acc89 md5 70e6725348fe617905d65059fb526ef1 sha1 0c4ff5eb16a0826a92b6196ee67d8aea2cb7572b )
+    comment "https://www.romhacking.net/translations/2287/"
+)
+
+game (
+    name "Cosmic Epsilon (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Cosmic Epsilon (Japan).nes" size 393232 crc 7479004e md5 e5934aa26652181c3e9a61e0c0111272 sha1 d0f1103acdf6f3057bfe45f6ba23f89a94bf33ed )
+    comment "http://www.romhacking.net/translations/1354/"
+)
+
+game (
+    name "Madoola no Tsubasa (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Madoola no Tsubasa (Japan).nes" size 65552 crc c583a427 md5 b81e143b4a5d13a525ddace091e477c7 sha1 f06d3a23dbb34081f2d7e2bd3d23e9867d636092 )
+    comment "http://www.romhacking.net/translations/3060/"
+)
+
+game (
+    name "Nekketsu Kakutou Densetsu (Japan) [T-En by oRdErEDchaos]"
+    description "English translation by oRdErEDchaos version (0.95)"
+    rom ( name "Nekketsu Kakutou Densetsu (Japan).nes" size 262288 crc 54454a52 md5 c541dfa9cb50a217ca3dc6021eb05553 sha1 6e677534d126af27d446c1941e6acfbad900eafc )
+    comment "http://www.romhacking.net/translations/205/"
+)
+
+game (
+    name "Meikyuu no Tatsujin - Daimeiro (Japan) [T-En by filler and KingMike's Translations]"
+    description "English translation by filler and KingMike's Translations version (1.0)"
+    rom ( name "Meikyuu no Tatsujin - Daimeiro (Japan).nes" size 262160 crc 6f193f6d md5 8ee4ddbd7e4e621f3aa20995709beaef sha1 3e17e6eae4bf3dc25d07ae15d6390f808ddd990f )
+    comment "http://www.romhacking.net/translations/970/"
+)
+
+game (
+    name "Tokoro-san no Mamoru mo Semeru mo (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Tokoro-san no Mamoru mo Semeru mo (Japan).nes" size 65552 crc 78e9a3c0 md5 64267e6d97ba186f8114d0b5f4bfc4dc sha1 a67089908a59f97660becd1ca6a94ff995d93a1a )
+    comment "http://www.romhacking.net/translations/3161/"
+)
+
+game (
+    name "Karnov (Japan) (Rev 1) [T-En by Eien Ni Hen and Vice Translations]"
+    description "English translation by Eien Ni Hen and Vice Translations version (1.10)"
+    rom ( name "Karnov (Japan) (Rev 1).nes" size 196624 crc c370e415 md5 c9a31dd3581d1100ef0f986136ab08df sha1 6efc92e189da4cb9816bce4dad501cc0cf560d75 )
+    comment "http://www.romhacking.net/translations/944/"
+)
+
+game (
+    name "Metroid + Saving [Hack by snarfblam]"
+    description "Metroid + Saving hack by snarfblam version (0.3)"
+    rom ( name "Metroid (USA).nes" size 393232 crc e0c003a2 md5 a96551237d03ea499143bd090394b628 sha1 a37e0aa67c2a476fe2f82fbf01f24ca544036f97 )
+    comment "https://www.romhacking.net/hacks/1186/"
+)
+
+game (
+    name "Taiyou no Yuusha - Fighbird (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.2)"
+    rom ( name "Taiyou no Yuusha - Fighbird (Japan).nes" size 262160 crc 5ff1a680 md5 ea44157312b5109cc1af6db84258c387 sha1 5a37c1415071c2cfafe0aaf255d36e15554201f8 )
+    comment "http://www.romhacking.net/translations/2563/"
+)
+
+game (
+    name "Captain Silver (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Captain Silver (Japan).nes" size 262160 crc 1019dae5 md5 8c9348f0cea3b8de82d46f6316c0a9cc sha1 ad6b392959fc6ac3ea44e5de4bf8e641cbae6994 )
+    comment "http://www.romhacking.net/translations/1461/"
+)
+
+game (
+    name "Gun-Dec (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Gun-Dec (Japan).nes" size 393232 crc 0b7c7e99 md5 78751a3ea0ea6b55c1a1ef5291a6bd34 sha1 57e58a9610b13a902d34de5b7512e3db30c14521 )
+    comment "http://www.romhacking.net/translations/2319/"
+)
+
+game (
+    name "Ganbare Goemon! - Karakuri Douchuu (Japan) [T-En by Spinner 8 and friends]"
+    description "English translation by Spinner 8 and friends version (1.01)"
+    rom ( name "Ganbare Goemon! - Karakuri Douchuu (Japan).nes" size 262160 crc 83fab5ff md5 d9e23be8aa47ee808efb9ae03855c16b sha1 188c02a798874bfcf38007044568ce0073704858 )
+    comment "https://www.romhacking.net/translations/1496/"
+)
+
+game (
+    name "Hana no Star Kaidou (Japan) [T-En by GAFF Translations]"
+    description "English translation by GAFF Translations version (1.00)"
+    rom ( name "Hana no Star Kaidou (Japan).nes" size 131088 crc c6034187 md5 a6984f873fb6667b7b8abe1cda1ad4e7 sha1 9eb040bd1aae27fff47dd0221bffd5dd691fad64 )
+    comment "http://www.romhacking.net/translations/2382/"
+)
+
+game (
+    name "Lu Ye Xian Zong [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Lu Ye Xian Zong (China) (Unl).nes" size 524304 crc ba97585f md5 6d46fc0741f693ae8e1bdcd9abf8386c sha1 134613d525682dc989772051b2fc01b512c934df )
+    comment "http://www.romhacking.net/translations/2808/"
+)
+
+game (
+    name "Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan).nes" size 131088 crc 1934ed15 md5 37bc52cf9909537970dc739f17fb0c78 sha1 0294ff7764f5d3ba8542d45115ecd6bdfd49f846 )
+    comment "https://www.romhacking.net/translations/1278/"
+)
+
+game (
+    name "Kero Kero Keroppi no Daibouken 2 - Donuts Ike wa Oosawagi! (Japan) [T-En by The Spoony Bard]"
+    description "English translation by The Spoony Bard version (1.0)"
+    rom ( name "Kero Kero Keroppi no Daibouken 2 - Donuts Ike wa Oosawagi! (Japan).nes" size 262160 crc 8b3c7d79 md5 24ec09db2b7ea2aeb998b0a0c4c89975 sha1 994ce240d11b2917bcca70c89b336b777751559b )
+    comment "http://www.romhacking.net/translations/166/"
+)
+
+game (
+    name "Sherlock Holmes - Hakushaku Reijou Yuukai Jiken (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Sherlock Holmes - Hakushaku Reijou Yuukai Jiken (Japan).nes" size 262160 crc 9b3313d4 md5 66b99f98d4d101f555cc5f917062a61f sha1 eb89e4c44bc1f20d7a6b7b2ba7132b2ce33458f1 )
+    comment "http://www.romhacking.net/translations/3474/"
+)
+
+game (
+    name "Super Pitfall 30th Anniversary Edition [Hack by Nesrocks]"
+    description "Super Pitfall 30th Anniversary Edition hack by Nesrocks version (1.0)"
+    rom ( name "Super Pitfall (USA).nes" size 131088 crc e55ba70d md5 d1c80bdaf2ffa9d87dbcb461aed13c2a sha1 b2198e1cbcc74ccfa1be610d16031d326f725049 )
+    comment "https://www.romhacking.net/hacks/3060/"
+)
+
+game (
+    name "Mappy Kids (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Mappy Kids (Japan).nes" size 262160 crc 3ab06c68 md5 1357fde43d873f9c967708f418a39f2c sha1 1b853558e4700ba1b5ad664f97651cb44c5386b4 )
+    comment "http://www.romhacking.net/translations/2052/"
+)
+
+game (
+    name "Urusei Yatsura - Lum no Wedding Bell (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Urusei Yatsura - Lum no Wedding Bell (Japan).nes" size 65552 crc 61350459 md5 dc9e3c89817b59641bf9bc8d8aed17a2 sha1 adf98f83b3745be3795d434663ddc85b0ceea886 )
+    comment "http://www.romhacking.net/translations/1389/"
+)
+
+game (
+    name "Wily & Right no Rockboard - That's Paradise (Japan) [T-En by Interordi Software]"
+    description "English translation by Interordi Software version (1.1)"
+    rom ( name "Wily & Right no Rockboard - That's Paradise (Japan).nes" size 262160 crc 7c9f47b7 md5 47ef8e3357c157b1187927e713451dca sha1 40bce9f07c099e021bc1a7c73e5cd81de026c630 )
+    comment "http://www.romhacking.net/translations/766/"
+)
+
+game (
+    name "Time Zone (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.3)"
+    rom ( name "Time Zone (Japan).nes" size 262160 crc 4ffe1ceb md5 a47ae20bb0497538f82123aad21ebe3d sha1 0382ca2341e0b99be099005444120b8835d1fa2e )
+    comment "http://www.romhacking.net/translations/228/"
+)
+
+game (
+    name "Chester Field - Ankoku Shin e no Chousen (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00b)"
+    rom ( name "Chester Field - Ankoku Shin e no Chousen (Japan).nes" size 131088 crc c67439e3 md5 dbabe5a1843f2c4eb96645e77922d9a7 sha1 f5faf608a5d815862ff77b3a9973972aaee8735a )
+    comment "https://www.romhacking.net/translations/100/"
+)
+
+game (
+    name "Columbus - Ougon no Yoake (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.02)"
+    rom ( name "Columbus - Ougon no Yoake (Japan).nes" size 262160 crc 2c3ca4bd md5 6735e804d6f92c4332005cc77894ac76 sha1 4583e426cce60e0f675e31d5b20ce82edc1fe40c )
+    comment "http://www.romhacking.net/translations/1285/"
+)
+
+game (
+    name "Ghostbusters - Proofreading Fix [Hack by HarvettFox96]"
+    description "Ghostbusters - Proofreading Fix hack by HarvettFox96 version (2017.06.03)"
+    rom ( name "Ghostbusters (USA).nes" size 65552 crc 9c08f461 md5 f05670a668a68a9dc4f4d11c010f46df sha1 10c038cf81ca3b888f729d0efe00e1f63dcf8775 )
+    comment "http://www.romhacking.net/hacks/1976/"
+)
+
+game (
+    name "Jesus - Kyoufu no Bio Monster (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (3 Days Later Edition Rev 2)"
+    rom ( name "Jesus - Kyoufu no Bio Monster (Japan).nes" size 524304 crc a8d642ea md5 cdb2326a5f90f22fa2902299e676f7f6 sha1 17288518b825b80385fb0f36b3b3333009be6b77 )
+    comment "http://www.romhacking.net/translations/1043/"
+)
+
+game (
+    name "Chaos World (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (0.98F)"
+    rom ( name "Chaos World (Japan).nes" size 393232 crc 4c8e1ffe md5 f4ef20dece92b6aea9269db3f1f9cdf3 sha1 9042e783b71eef666a48bd8077ad1e12f2e173d6 )
+    comment "https://www.romhacking.net/translations/99/"
+)
+
+game (
+    name "Doki!Doki! Yuuenchi - Crazy Land Daisakusen (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Doki!Doki! Yuuenchi - Crazy Land Daisakusen (Japan).nes" size 262160 crc 6d3658a7 md5 9e8786760de06945ef7d7c2d7bca3899 sha1 50966e6e92d63c67fdd10f2767424eaa572c3bfb )
+    comment "http://www.romhacking.net/translations/2598/"
+)
+
+game (
+    name "Kaiketsu Yancha Maru 2 - Karakuri Land (Japan) [T-En by D]"
+    description "English translation by D version (1.2)"
+    rom ( name "Kaiketsu Yancha Maru 2 - Karakuri Land (Japan).nes" size 262160 crc 7e876466 md5 96a96cdac8bc067df88ea2ea97e2fbe7 sha1 b6e869f862fb797805018a0f1171e28d6690a62a )
+    comment "http://www.romhacking.net/translations/640/"
+)
+
+game (
+    name "Kaijuu Monogatari (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0beta2)"
+    rom ( name "Kaijuu Monogatari (Japan).nes" size 393232 crc a9cb0e80 md5 7fcc957c61c980d833f31816698f5b8d sha1 b290a917f54399c125eb5a98e83feb4c24d9ec55 )
+    comment "http://www.romhacking.net/translations/619/"
+)
+
+game (
+    name "Moon Crystal (Japan) [T-En by Alex W. Jackson]"
+    description "English translation by Alex W. Jackson version (1.0)"
+    rom ( name "Moon Crystal (Japan).nes" size 524304 crc e05b0f24 md5 15bafb8ba3a49b61d013b7fc599d9e7d sha1 2c0e730ea3487f65084a91744593fc7fcf4336a5 )
+    comment "http://www.romhacking.net/translations/189/"
+)
+
+game (
+    name "Matendouji (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Matendouji (Japan).nes" size 393232 crc db38e26c md5 2824a8995b14036ddfd83828f6232312 sha1 d9564a98f3d7c40af29ac4d9f2207e7db1d2e1b3 )
+    comment "http://www.romhacking.net/translations/1646/"
+)
+
+game (
+    name "Black Bass, The (Japan) [T-En by GAFF Translations]"
+    description "English translation by GAFF Translations version (1.00)"
+    rom ( name "Black Bass, The (Japan).nes" size 131088 crc e27dd3b5 md5 585d893bacadfe01e77b976b6b69ccd8 sha1 0e88a500955e58190589f3baac62b0ebe9192b54 )
+    comment "http://www.romhacking.net/translations/3167/"
+)
+
+game (
+    name "Magic Candle, The (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Magic Candle, The (Japan).nes" size 655376 crc 75c420f0 md5 1e144b5d804a0af59e19cc1db0888204 sha1 c636543af86946fd5ab1960fd137e250b6ed6786 )
+    comment "http://www.romhacking.net/translations/2399/"
+)
+
+game (
+    name "Mother: 25th Anniversary Edition [Hack by DragonDePlatino]"
+    description "Mother: 25th Anniversary Edition hack by DragonDePlatino version (1.11)"
+    rom ( name "Mother 25th Anniversary Edition.nes" size 524304 crc 6e24f190 md5 88cfab9094665bff0849079999dcf681 sha1 00ae39f447bc787edf01f3515977bea689cd5c54 )
+    comment "https://www.romhacking.net/hacks/2211/"
+)
+
+game (
+    name "Getsu Fuuma Den (Japan) [T-En by Nebulous Translations]"
+    description "English translation by Nebulous Translations version (1.0)"
+    rom ( name "Getsu Fuuma Den (Japan).nes" size 393232 crc dad72cc9 md5 cef22723be6f366477c6b24f5a9fc30e sha1 5e74648bec226b0c41081bb5cc437d6b3463c15e )
+    comment "https://www.romhacking.net/translations/3482/"
+)
+
+game (
+    name "Wai Wai World 2 - SOS!! Paseri Jou (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.01)"
+    rom ( name "Wai Wai World 2 - SOS!! Paseri Jou (Japan).nes" size 393232 crc 191f0556 md5 298926674ddb1dd03a03eca586e362eb sha1 7f79e90e75e566a69d8da95df9cf023b9ee89a47 )
+    comment "http://www.romhacking.net/translations/235/"
+)
+
+game (
+    name "Shadowgate Classic [Hack by Magnus Nilsson]"
+    description "Shadowgate Classic hack by Magnus Nilsson version (1.0)"
+    rom ( name "Shadowgate (USA).nes" size 262160 crc 7d81dfb7 md5 6cf797aabb667f511fff94e1198ed0ba sha1 8229ddaa5a7c15bd1e44a44b85ad94022e12c370 )
+    comment "https://www.romhacking.net/hacks/2369/"
+)
+
+game (
+    name "Wagyan Land (Japan) [T-En by AlanMidas]"
+    description "English translation by AlanMidas version (wag.yan)"
+    rom ( name "Wagyan Land (Japan).nes" size 196624 crc 65a5b127 md5 49bf15e17a34297cdd107fbbdc07238e sha1 4538039db94e8975a133aeec7332a2e76e26ce13 )
+    comment "http://www.romhacking.net/translations/234/"
+)
+
+game (
+    name "Mini Putt (Japan) [T-En by Klarth Aileron]"
+    description "English translation by Klarth Aileron version (1.00)"
+    rom ( name "Mini Putt (Japan).nes" size 262160 crc 892c61be md5 6d8cf072754207f1abd33ddbafad7c5c sha1 e4795d7c5f04f994eb9f4bf109fd12c35afd2775 )
+    comment "http://www.romhacking.net/translations/185/"
+)
+
+game (
+    name "Fire Emblem Gaiden (Japan) [T-En by Gaiden Guy]"
+    description "English translation by Gaiden Guy version (0.9)"
+    rom ( name "Fire Emblem Gaiden (Japan).nes" size 393232 crc eb05d89f md5 5a04c4b39d6afd2de7cb2b542e6e7a09 sha1 c6b33952505bd26c7b20bdf88a27d3664dc12bf8 )
+    comment "https://www.romhacking.net/translations/2806/"
+)
+
+game (
+    name "Mad City (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Mad City (Japan).nes" size 262160 crc 52389803 md5 40660a3abafce67b385d5fda376fb34b sha1 328ba27c0aa5dc2655507459722f1e4ee286df49 )
+    comment "http://www.romhacking.net/translations/1554/"
+)
+
+game (
+    name "Double Moon Densetsu (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.01)"
+    rom ( name "Double Moon Densetsu (Japan).nes" size 524304 crc a360031b md5 0071b8321f1f4a784914b7b732ca5638 sha1 4b1f6e73e366730b8105282ad49b9d6253e67d94 )
+    comment "http://www.romhacking.net/translations/2336/"
+)
+
+game (
+    name "Dash Yarou (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Dash Yarou (Japan).nes" size 131088 crc 2369e22b md5 8c7934df1f8e341dd27690615e149e4d sha1 16dd2feb64366b5115d7a93e02e712b953a7d0a6 )
+    comment "http://www.romhacking.net/translations/2214/"
+)
+
+game (
+    name "Joy Mech Fight (Japan) [T-En by AlanMidas]"
+    description "English translation by AlanMidas version (joy.mech)"
+    rom ( name "Joy Mech Fight (Japan).nes" size 524304 crc 8bb8bc54 md5 60c05e99c61fd018287d7c63200a18a6 sha1 3ce0cda10d9fd2823bc1cb94f80122bfe9b82b5a )
+    comment "http://www.romhacking.net/translations/161/"
+)
+
+game (
+    name "Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan) [T-En by aishsha and Djinn]"
+    description "English translation by aishsha and Djinn version (1.01)"
+    rom ( name "Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan).nes" size 262160 crc 0dbc5869 md5 1e6c49a5e40479fc60fc32e3a1a5ba39 sha1 e6819d6b7810320d5c7ade72b1da722c732227a2 )
+    comment "http://www.romhacking.net/translations/1339/"
+)
+
+game (
+    name "Dragon Ninja (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Dragon Ninja (Japan).nes" size 262160 crc 5970cf2a md5 e6aa81e046bec9308392a4f0560980dd sha1 2893365d3de959a7cc713007abc717369ea600b8 )
+    comment "http://www.romhacking.net/translations/1544/"
+)
+
+game (
+    name "Castlevania II English Re-translation (+Map) [Hack by Bisqwit]"
+    description "Castlevania II English Re-translation (+Map) hack by Bisqwit version (2.9.8.19)"
+    rom ( name "Castlevania II - Simon's Quest (USA).nes" size 262160 crc aba65284 md5 0354954dcc6b65214b06c2bc8a673a7d sha1 5b770db5538ff268b1ae679c2d0fabdc75c0aff9 )
+    comment "https://www.romhacking.net/hacks/1032/"
+)
+
+game (
+    name "Parodius Da! (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Parodius Da! (Japan).nes" size 393232 crc 7012e75a md5 0720974376f7452191f60170a94766f2 sha1 c3ccbae7c12e4ef37b520175a61c5b06253045e7 )
+    comment "http://www.romhacking.net/translations/1621/"
+)
+
+game (
+    name "Magnum Kikiippatsu - Empire City - 1931 (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Magnum Kikiippatsu - Empire City - 1931 (Japan).nes" size 131088 crc fda99dd3 md5 6094ac114eeed98335b642977740203d sha1 b769ccabd52fa80580aa790f41d5507bb31c8918 )
+    comment "http://www.romhacking.net/translations/3166/"
+)
+
+game (
+    name "Magic John (Japan) [T-En by KingMike's Translations and Video Smash Excellent]"
+    description "English translation by KingMike's Translations and Video Smash Excellent version (1.0)"
+    rom ( name "Magic John (Japan).nes" size 262160 crc a64a436b md5 153ccc28362c3f7f157a1d115efb0f18 sha1 8ccd7e53da63104ef08ceafe3783564e15d13a6b )
+    comment "http://www.romhacking.net/translations/1582/"
+)
+
+game (
+    name "Superstar Pro Wrestling (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Superstar Pro Wrestling (Japan).nes" size 262160 crc cbef638b md5 8ccadc2a8fc73b793e53fed523f2c8c0 sha1 2cf9b75f60400d47e6815f59ea48fac287622b94 )
+    comment "http://www.romhacking.net/translations/2280/"
+)
+
+game (
+    name "Guardian Legend Secret Edition - SRAM Saving Edition [Hack by 8-bit fan]"
+    description "Guardian Legend Secret Edition - SRAM Saving Edition hack by 8-bit fan version (1.0)"
+    rom ( name "Guardian Legend Secret Edition.nes" size 262160 crc 23a9308f md5 e8c0769b386b7d43d71a17b399ead852 sha1 84245dfc577cfe78aaed32936ef34184b1210efd )
+    comment "http://www.romhacking.net/hacks/3742/"
+)
+
+game (
+    name "Saiyuuki World (Japan) [T-En by Nebulous Translations]"
+    description "English translation by Nebulous Translations version (0.95)"
+    rom ( name "Saiyuuki World (Japan).nes" size 262160 crc 9a2792b4 md5 84a27ed3100d24b80f6d730c72246976 sha1 59fcaf8b56fe9cc3ab6da151e02b725f9e65c656 )
+    comment "http://www.romhacking.net/translations/2799/"
+)
+
+game (
+    name "Parody World - Monster Party (Japan) (Proto) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Parody World - Monster Party (Japan) (Proto).nes" size 262160 crc 454ea273 md5 91cf2c6a1498f33271a343092f398033 sha1 a1e0b4d0f926549364c31eb8cab8562b1332623d )
+    comment "http://www.romhacking.net/translations/3115/"
+)
+
+game (
+    name "Rockman CX [Hack by Himajin Jichiku]"
+    description "Rockman CX hack by Himajin Jichiku version (1.1)"
+    rom ( name "Rockman CX.nes" size 524304 crc 74117d31 md5 5a6e5c804ab811516b2f92e89365427f sha1 becc50b50682cdab531b67228ecb4b8be43ffe21 )
+    comment "https://www.romhacking.net/hacks/3231/"
+)
+
+game (
+    name "Rampart (Japan) [T-En by Magnus Nilsson and MrRichard999]"
+    description "English translation by Magnus Nilsson and MrRichard999 version (1.0)"
+    rom ( name "Rampart (Japan).nes" size 131088 crc a29d5442 md5 7d1dfd21b736027bb659d660b17e42ed sha1 078ead20f08075dd98e54c255ec040bfbaed1885 )
+    comment "http://www.romhacking.net/translations/2661/"
+)
+
+game (
+    name "Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Japan) [T-En by Adventurous Translations]"
+    description "English translation by Adventurous Translations version (0.99c)"
+    rom ( name "Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Japan).nes" size 524304 crc a1c4c69e md5 88f9df55ad9ca502b943d9b4899f0510 sha1 21944f1df67a4fdaf67dd14d32309a3e4a2ff94a )
+    comment "http://www.romhacking.net/translations/3079/"
+)
+
+game (
+    name "Esper Bouken Tai (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.01)"
+    rom ( name "Esper Bouken Tai (Japan).nes" size 524304 crc de9f134b md5 738b0ef5e6ce3e79b50995ee03f480ca sha1 f35a0521e2c3020cf4bdd9ccbe5384bcc2d4bc20 )
+    comment "http://www.romhacking.net/translations/1580/"
+)
+
+game (
+    name "Paris-Dakar Rally Special (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.02)"
+    rom ( name "Paris-Dakar Rally Special (Japan).nes" size 163856 crc e2b9be12 md5 58aad675f2387b737ece4952836ebc74 sha1 73a5678fc5e8fd2fdabe720bf66aba98eee887bd )
+    comment "http://www.romhacking.net/translations/2231/"
+)
+
+game (
+    name "Castlevania 3: Improved Controls [Hack by NaOH + 1 hacks]"
+    description "Castlevania 3: Improved Controls hack by NaOH version (1.4) + Akumajou Densetsu - Localization / Title Screen Redone hack by ShadowOne333 version (7.1)"
+    rom ( name "Akumajou Densetsu (Japan).nes" size 393232 crc eac99920 md5 baa6dd0ea728043653222ebb2029ebaf sha1 88f7ff4c928894743eec3f4e43783b7c358c8b1e )
+    comment "https://www.romhacking.net/hacks/3596/"
+    comment "https://www.romhacking.net/hacks/1983/"
+)
+
+game (
+    name "Doraemon (Japan) (Rev A) [T-En by Sky Yoshi]"
+    description "English translation by Sky Yoshi version (1.0)"
+    rom ( name "Doraemon (Japan) (Rev A).nes" size 163856 crc 0192b04d md5 51440bfa6eb3830cf08bc8ca28d4df43 sha1 9870ea7d89dcc4003eceb58f2ae8e9abd841717d )
+    comment "http://www.romhacking.net/translations/2629/"
+)
+
+game (
+    name "Shufflepuck Cafe (Japan) [T-En by MadHacker]"
+    description "English translation by MadHacker version (1.0)"
+    rom ( name "Shufflepuck Cafe (Japan).nes" size 131088 crc 60253774 md5 ad1d68aaab7427d5cb7d6e1daabde217 sha1 cb95262dd7e71ea3cf0a7fa74fc6986bf380c5c0 )
+    comment "http://www.romhacking.net/translations/214/"
+)
+
+game (
+    name "Cat Ninden Teyandee (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.01)"
+    rom ( name "Cat Ninden Teyandee (Japan).nes" size 393232 crc 6becfce3 md5 d00fd3ffb1782b8fe83da920cec9518a sha1 6fc76a631505ab67759f963216072839d6b992ef )
+    comment "http://www.romhacking.net/translations/1741/"
+)
+
+game (
+    name "Shikinjou (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (1.00)"
+    rom ( name "Shikinjou (Japan).nes" size 131088 crc 0822d49f md5 042347af2db573114af6adf882efa491 sha1 c3f03140e9477aac8f185a7e3c5d43bfc1ecfbc1 )
+    comment "http://www.romhacking.net/translations/213/"
+)
+
+game (
+    name "TwinBee 3 - Poko Poko Daimaou (Japan) [T-En by Demiforce and Stardust Crusaders]"
+    description "English translation by Demiforce and Stardust Crusaders version (1.01)"
+    rom ( name "TwinBee 3 - Poko Poko Daimaou (Japan).nes" size 262160 crc 0d12c759 md5 3f0ec97d506d683940cb8a672cceaa7a sha1 d6d7c5425b85d02dd6531b99995071880cce86ed )
+    comment "http://www.romhacking.net/translations/1391/"
+)
+
+game (
+    name "Zelda Challenge: Outlands [Hack by GameMakr24]"
+    description "Zelda Challenge: Outlands hack by GameMakr24 version (1.0)"
+    rom ( name "Zelda Challenge - Outlands.nes" size 131088 crc 4f4d295e md5 135a00814899859dc90886c55dcdc4ac sha1 0b93d8f2e40e085a83571409fc9973c959783a4d )
+    comment "https://www.romhacking.net/hacks/10/"
+)
+
+game (
+    name "Daiva - Imperial of Nirsartia (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (1.0)"
+    rom ( name "Daiva - Imperial of Nirsartia (Japan).nes" size 131088 crc 8baf783d md5 cbbe4a83d094f6566d5eaa16fa5c7880 sha1 3c2b2283a173e9715018ea58028be3ef03456d86 )
+    comment "http://www.romhacking.net/translations/2253/"
+)
+
+game (
+    name "Totsuzen! Macchoman (Japan) (Beta) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Totsuzen! Macchoman (Japan) (Beta).nes" size 131088 crc 2198e611 md5 16960208870a0348466dc7e667352e5b sha1 fc0636cf6c7078b77209ce6c7755b1243601465e )
+    comment "http://www.romhacking.net/translations/2597/"
+)
+
+game (
+    name "Heracles no Eikou II - Titan no Metsubou (Japan) [T-En by The Spoony Bard]"
+    description "English translation by The Spoony Bard version (1.31)"
+    rom ( name "Heracles no Eikou II - Titan no Metsubou (Japan).nes" size 262160 crc ce222646 md5 fdcaee1dd6e766aa196eb448618d4bdc sha1 43ffaf7af10ed3fd5c1ef684348cb1408329d0fe )
+    comment "http://www.romhacking.net/translations/154/"
+)
+
+game (
+    name "Just Breed (Japan) [T-En by Stealth Translations]"
+    description "English translation by Stealth Translations version (1.00)"
+    rom ( name "Just Breed (Japan).nes" size 786448 crc a4863269 md5 f738400ef0ef622d48c4ece8cf15cf5c sha1 aa1111430bfad56bb4c3b467a78ba16a12261332 )
+    comment "http://www.romhacking.net/translations/566/"
+)
+
+game (
+    name "King Kong 2 - Ikari no Megaton Punch (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev A)"
+    rom ( name "King Kong 2 - Ikari no Megaton Punch (Japan).nes" size 262160 crc 9db6489a md5 d467ce6c8224aa31c4b0501f64ee2b18 sha1 03ae291c88e4f6e85a905e19ae01bf7254de531b )
+    comment "http://www.romhacking.net/translations/1290/"
+)
+
+game (
+    name "Final Mission (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Final Mission (Japan).nes" size 393232 crc 01c4633e md5 78ad5d7123cb05661870219eb986b728 sha1 115c336594ab12e7a627d5067bdad0561fd791d9 )
+    comment "http://www.romhacking.net/translations/1400/"
+)
+
+game (
+    name "Takahashi Meijin no Bouken-jima IV (Japan) [T-En by Demiforce]"
+    description "English translation by Demiforce version (1.00)"
+    rom ( name "Takahashi Meijin no Bouken-jima IV (Japan).nes" size 393232 crc 60e3d052 md5 c51cc11e75ee519abcf5e7197ab7cf1b sha1 d5a98779f11382e7bda7696c1f4d982461c8f774 )
+    comment "http://www.romhacking.net/translations/86/"
+)
+
+game (
+    name "Castle Quest (Japan) [T-En by Hubz and Stardust Crusaders]"
+    description "English translation by Hubz and Stardust Crusaders version (2.01)"
+    rom ( name "Castle Quest (Japan).nes" size 262160 crc faabff04 md5 bd42e3b8d5ee3380191f23b268c23ec4 sha1 0113ce89be837daa074455f867ba24f6ca9d42e5 )
+    comment "http://www.romhacking.net/translations/1500/"
+)
+
+game (
+    name "Nekketsu! Street Basket - Ganbare Dunk Heroes (Japan) [T-En by Farid]"
+    description "English translation by Farid version (1.2 (Final))"
+    rom ( name "Nekketsu! Street Basket - Ganbare Dunk Heroes (Japan).nes" size 262160 crc a4680ca5 md5 44ff327ffc85dd7a5169f3e791f99a06 sha1 61c2ce554334266f675e878624a5bbc2e6fbfc73 )
+    comment "http://www.romhacking.net/translations/1548/"
+)
+
+game (
+    name "Moero TwinBee - Cinnamon Hakase o Sukue! (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev A)"
+    rom ( name "Moero TwinBee - Cinnamon Hakase o Sukue! (Japan).nes" size 131088 crc 5aed2a67 md5 ba291cfc8ff8ed86b24d435c72df1c85 sha1 f33a5b4f76f70c4b71e9f05f72f13992b258e389 )
+    comment "http://www.romhacking.net/translations/3535/"
+)
+
+game (
+    name "Gorby no Pipeline Daisakusen (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (A)"
+    rom ( name "Gorby no Pipeline Daisakusen (Japan).nes" size 65552 crc d791067b md5 a8d17f7ceed372ed51f88459120063d6 sha1 53594716f5631e7572271bea927966f73ee640c1 )
+    comment "http://www.romhacking.net/translations/1077/"
+)
+
+game (
+    name "Metroid mOTHER [Hack by dACE]"
+    description "Metroid mOTHER hack by dACE version (1.0)"
+    rom ( name "Metroid [mOTHER].nes" size 393232 crc 04819e27 md5 88aac556e89c53d35f728623c07718ee sha1 607b429388c1652f3194dfe599e6355dd7d59967 )
+    comment "https://www.romhacking.net/hacks/1988/"
+)
+
+game (
+    name "Seirei Gari (Japan) [T-En by snark]"
+    description "English translation by snark version (1.0)"
+    rom ( name "Seirei Gari (Japan).nes" size 262160 crc d208968d md5 34dfa7b3bdf3a5514e7672216d3e58c8 sha1 1560196046a8c8dd99867e2ff68ec845060fa40d )
+    comment "http://www.romhacking.net/translations/1279/"
+)
+
+game (
+    name "Portopia Renzoku Satsujin Jiken (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev. B (Manual Rev. B2))"
+    rom ( name "Portopia Renzoku Satsujin Jiken (Japan).nes" size 73744 crc 88679d11 md5 b0e67aa8214af3a4a831ab2e3d569415 sha1 7bc0b7a13495a4aa50272d845c28b3531e8e45fe )
+    comment "http://www.romhacking.net/translations/764/"
+)
+
+game (
+    name "Sou Setsu Ryuu III - The Rosetta Stone (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Sou Setsu Ryuu III - The Rosetta Stone (Japan).nes" size 262160 crc 58d0c214 md5 8c4bb669ecd2f7fb786475806cbaf17d sha1 1149aec2a16ae5850638aa9d5fe5ce8f945553ac )
+    comment "http://www.romhacking.net/translations/2596/"
+)
+
+game (
+    name "Deep Dungeon III - Yuushi e no Tabi (Japan) [T-En by MrRichard999]"
+    description "English translation by KingMike's Translations version (1.0) + English translation by MrRichard999 version (1.1)"
+    rom ( name "Deep Dungeon III - Yuushi e no Tabi (Japan).nes" size 524304 crc b646f50f md5 3c97ee1c1a096ff51799a596d40d8a77 sha1 d0af41e87f4f58e55523f8730305730886dadef7 )
+    comment "http://www.romhacking.net/translations/1996/"
+    comment "http://www.romhacking.net/translations/3395/"
+)
+
+game (
+    name "Guardian Legend - SRAM Saving Edition [Hack by 8-bit fan]"
+    description "Guardian Legend - SRAM Saving Edition hack by 8-bit fan version (1.0)"
+    rom ( name "Guardian Legend, The (USA).nes" size 131088 crc 0f2a4c94 md5 27afeb5f4e24be1bd55591afa9af5eba sha1 95dfa7161781c9637613fe320bbe6f3afb94a1b1 )
+    comment "http://www.romhacking.net/hacks/3734/"
+)
+
+game (
+    name "Biohazard [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Bio Hazard (Ch) (Unl).nes" size 1048592 crc 4dffd969 md5 f424a5c641075c434cf8a5d2c8793fbb sha1 8a9578e0ac650f2655782618c1d7e33d2879f427 )
+    comment "https://www.romhacking.net/translations/3388/"
+)
+
+game (
+    name "Minelvaton Saga - Ragon no Fukkatsu (Japan) [T-En by aishsha]"
+    description "English translation by aishsha version (1.03)"
+    rom ( name "Minelvaton Saga - Ragon no Fukkatsu (Japan).nes" size 393232 crc 013050d3 md5 a456aa50d41652372d4a026e0d3de69f sha1 e935b9fb6f6a700c5c8323e6e8cc2bd3ee880d27 )
+    comment "http://www.romhacking.net/translations/1611/"
+)
+
+game (
+    name "Hello Kitty World (Japan) [T-En by Flake]"
+    description "English translation by Flake version (1.0)"
+    rom ( name "Hello Kitty World (Japan).nes" size 131088 crc bd54af4d md5 896f2e1eea756a412288cf2ef9e31c20 sha1 df7e273ce83e17f4e934a2b2428bf54b7e528c76 )
+    comment "https://www.romhacking.net/translations/1398/"
+)
+
+game (
+    name "Famicom Wars (Japan) (Rev 0B) [T-En by Spinner 8 and friends]"
+    description "English translation by Spinner 8 and friends version (1.0)"
+    rom ( name "Famicom Wars (Japan) (Rev 0B).nes" size 196624 crc d829c789 md5 40a956be333a0e1b62a122aa19be0939 sha1 29770421d64e168967d0cf102f820fbf8258a7b8 )
+    comment "https://www.romhacking.net/translations/2590/"
+)
+
+game (
+    name "Momotarou Densetsu (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0)"
+    rom ( name "Momotarou Densetsu (Japan).nes" size 524304 crc 9d3fa8a5 md5 cf8c0d5faabafc5e383075b49e4e8473 sha1 1240e5f127e842d7f8dc56336e20eea3355c07b8 )
+    comment "http://www.romhacking.net/translations/1779/"
+)
+
+game (
+    name "Tecmo World Cup Soccer NEXT [Hack by BZK]"
+    description "Tecmo World Cup Soccer NEXT hack by BZK version (162)"
+    rom ( name "Tecmo World Cup Soccer (Japan).nes" size 262160 crc ed902992 md5 3b22e5c5a05b8c357be68c0527a59fd6 sha1 70d2d7c4f5f745888ac966b5633b6b624a82734c )
+    comment "http://www.romhacking.net/hacks/2765/"
+)
+
+game (
+    name "Obake no Q Tarou - Wanwan Panic (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Obake no Q Tarou - Wanwan Panic (Japan).nes" size 40976 crc 452c7995 md5 b4e4c542f925f672c837067e5b882758 sha1 cc51bf3bed064a7a4eb2556ac170ffe1f3234140 )
+    comment "http://www.romhacking.net/translations/2224/"
+)
+
+game (
+    name "Dark Lord (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00)"
+    rom ( name "Dark Lord (Japan).nes" size 393232 crc 106ff0e3 md5 db339c7ac8b106e21eda2492a7d43944 sha1 5dd8b4df076fe0dfed9b67133aeab51008342ba4 )
+    comment "http://www.romhacking.net/translations/934/"
+)
+
+game (
+    name "Gomoku Narabe (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (1.0)"
+    rom ( name "Gomoku Narabe (Japan).nes" size 24592 crc 18513cfc md5 73ba1ad298b63d98565a7f8cef810c24 sha1 fb529abebc8805fb16e08b9b6e9157c0409ec7a1 )
+    comment "http://www.romhacking.net/translations/3073/"
+)
+
+game (
+    name "Parallel World (Japan) [T-En by PentarouZero]"
+    description "English translation by PentarouZero version (1.00)"
+    rom ( name "Parallel World (Japan).nes" size 262160 crc 1d92dd22 md5 61386d9c591c89e74cded4cc5608fbef sha1 dc13ea8330a53833aa4f9d1ac17d78598b2ced45 )
+    comment "http://www.romhacking.net/translations/839/"
+)
+
+game (
+    name "Hinotori - Houou Hen - Gaou no Bouken (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.01)"
+    rom ( name "Hinotori - Houou Hen - Gaou no Bouken (Japan).nes" size 262160 crc 5f228691 md5 829745963ebd52bb6dabc6c710473062 sha1 2c45b0e08ca230374f3e7db663c3c8ff183d2e85 )
+    comment "http://www.romhacking.net/translations/1486/"
+)
+
+game (
+    name "Karakuri Kengou Den Musashi Lord - Karakuribito Hashiru (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Karakuri Kengou Den Musashi Lord - Karakuribito Hashiru (Japan).nes" size 393232 crc 12fc6dbf md5 23d0ccc0462841b559438a17b70ea255 sha1 4adf30369416e14bc4d8295805d8f24d4ac0a0ec )
+    comment "http://www.romhacking.net/translations/2056/"
+)
+
+game (
+    name "DuckTales Restoration [Hack by SCD]"
+    description "DuckTales Restoration hack by SCD version (Final)"
+    rom ( name "DuckTales (USA).nes" size 131088 crc 04e2f130 md5 6c1a2dd42bdaa3f452280b3b06534b65 sha1 3111db6e05cc44b87985e015e57899f883a9ccbd )
+    comment "http://www.romhacking.net/hacks/1103/"
+)
+
+game (
+    name "Taito Chase H.Q. (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Taito Chase H.Q. (Japan).nes" size 262160 crc 8b13b5e3 md5 23623ae4537b4ed9075d94f1b826a68a sha1 5c292d0633c295ab080ab4cd0495ac67358f6119 )
+    comment "http://www.romhacking.net/translations/2516/"
+)
+
+game (
+    name "Hebereke (Japan) [T-En by BMF54123]"
+    description "English translation by BMF54123 version (1.0)"
+    rom ( name "Hebereke (Japan).nes" size 393232 crc ac2e16e9 md5 562e3813d0ccb795dacefa2458c3571d sha1 0af15831089f63eb54e751af460dce75357933ba )
+    comment "http://www.romhacking.net/translations/1798/"
+)
+
+game (
+    name "Janggun-ui Adeul (Korea) (Unl) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Janggun-ui Adeul (Korea) (Unl).nes" size 655376 crc a300d9ca md5 7605a0a951628e2c3f74e3ec325b1edf sha1 0e633213f1ebd18bcc8c35ce7e1838bf7617b439 )
+    comment "http://www.romhacking.net/translations/2379/"
+)
+
+game (
+    name "Dragon Warrior 3 DX [Hack by LastduaL]"
+    description "Dragon Warrior 3 DX hack by LastduaL version (1.0)"
+    rom ( name "Dragon Warrior III DX.nes" size 524304 crc d6eda94a md5 e1514cb5f40b2d9a25615b3cc0946534 sha1 b8be2eeab4e5d88b2ef3e3ec7a3a6cbade0fe6ac )
+    comment "http://www.romhacking.net/hacks/3965/"
+)
+
+game (
+    name "Ys III - Wanderers from Ys (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.00)"
+    rom ( name "Ys III - Wanderers from Ys (Japan).nes" size 393232 crc 93328bf1 md5 2cde2d5e79851460363561475d91bf83 sha1 a778f8aa755b3a9796e031d90443dc2c08512637 )
+    comment "http://www.romhacking.net/translations/240/"
+)
+
+game (
+    name "Friday the 13th [Hack by Harlemhero]"
+    description "Friday the 13th hack by Harlemhero version (1.0)"
+    rom ( name "Friday the 13th (USA).nes" size 65552 crc e692e705 md5 e62d3bf8b777890b1fe2b182c376c709 sha1 c788dbc93525b510032880c49f0f18c1b51a1b83 )
+    comment "http://www.romhacking.net/hacks/3289/"
+)
+
+game (
+    name "Dai-2-ji Super Robot Taisen (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.00)"
+    rom ( name "Dai-2-ji Super Robot Taisen (Japan).nes" size 524304 crc 473ddcc4 md5 897d66ba2580f220d2e2910587b0806e sha1 7c8910fecc5f473cf0ce923a3371e1768bfdb04a )
+    comment "https://www.romhacking.net/translations/221/"
+)
+
+game (
+    name "Honoo no Toukyuuji - Dodge Danpei (Japan) [T-En by TransGen]"
+    description "English translation by TransGen version (1.0.b)"
+    rom ( name "Honoo no Toukyuuji - Dodge Danpei (Japan).nes" size 393232 crc 47325872 md5 d7d3e3d27e64081b309981ff222400f7 sha1 9afab7cd56ef209e35833ff24bcef62bdf8abdf6 )
+    comment "http://www.romhacking.net/translations/1255/"
+)
+
+game (
+    name "Dragon Ball - Shen Long no Nazo (Mapper Fix) [Hack by Ice Man]"
+    description "Dragon Ball - Shen Long no Nazo (Mapper Fix) hack by Ice Man version (1.00)"
+    rom ( name "Dragon Ball - Shen Long no Nazo (Japan).nes" size 163856 crc b4e31bf4 md5 19993f3c35c0d0ed5f385028e25758d1 sha1 d4ed25dca49c07dd4df6de7b49313b3de0312455 )
+    comment "http://www.romhacking.net/hacks/3490/"
+)
+
+game (
+    name "Ys II - Ancient Ys Vanished - The Final Chapter (Japan) [T-En by David Mullen (MakoKnight)]"
+    description "English translation by David Mullen (MakoKnight) version (1.0)"
+    rom ( name "Ys II - Ancient Ys Vanished - The Final Chapter (Japan).nes" size 393232 crc ab6b7ac1 md5 32c68ef62498e88a32b6cfa3272ec677 sha1 bab7fb94a4c5fcd44c048e90f9de82c44629be5d )
+    comment "http://www.romhacking.net/translations/239/"
+)
+
+game (
+    name "Dragon Ball Z III - Ressen Jinzou Ningen (Japan) [T-En by Twilight Translations]"
+    description "English translation by Twilight Translations version (1.00 IPS)"
+    rom ( name "Dragon Ball Z III - Ressen Jinzou Ningen (Japan).nes" size 524304 crc 209955ea md5 8930a5fa54485cab7aac3efc2001d92d sha1 246a66ff3e961554fa1e56ed3334350104c53ca9 )
+    comment "http://www.romhacking.net/translations/898/"
+)
+
+game (
+    name "Wai Wai World (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (2.0)"
+    rom ( name "Wai Wai World (Japan).nes" size 262160 crc 9e87b5df md5 b4e7a0b2f117cf060ec85e4e1f96c5ae sha1 a34438e21053c945ac931766f1d53d708658b98e )
+    comment "http://www.romhacking.net/translations/1995/"
+)
+
+game (
+    name "Softball Tengoku (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Softball Tengoku (Japan).nes" size 262160 crc db4b277b md5 25ffc17f85e679d74955949cfe777b01 sha1 9b576f0979365755d0caf0e76d6963e98868f93d )
+    comment "http://www.romhacking.net/translations/2867/"
+)
+
+game (
+    name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) [T-En by Dark Force, Dynamic-Designs, Jair and Taskforce]"
+    description "English translation by Dark Force, Dynamic-Designs, Jair and Taskforce version (1.12)"
+    rom ( name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan).nes" size 524304 crc 6dcfda9e md5 04db3a53cd3bd635e9c82fec0893b4bc sha1 b35a8d24f148ea7ae97ef9a16eb2d482720bfdb0 )
+    comment "http://www.romhacking.net/translations/116/"
+)
+
+game (
+    name "Iron Tank - Re-Nazified [Hack by Psyklax]"
+    description "Iron Tank - Re-Nazified hack by Psyklax version (1.0)"
+    rom ( name "Iron Tank - The Invasion of Normandy (USA).nes" size 262160 crc becb7662 md5 7d809e97c695aff8023535b3ee2449bd sha1 8355759008ebafea30fe004b2b23d810c000dd49 )
+    comment "https://www.romhacking.net/hacks/3592/"
+)
+
+game (
+    name "Advanced Dungeons & Dragons - Dragons of Flame (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (1.03)"
+    rom ( name "Advanced Dungeons & Dragons - Dragons of Flame (Japan).nes" size 262160 crc b5d03883 md5 73902f0db4c43b651672173853977423 sha1 7f0741580ec2ab8df060a19767793c038c669472 )
+    comment "http://www.romhacking.net/translations/683/"
+)
+
+game (
+    name "Ninja Jajamaru-kun (Japan) [T-En by aishsha and Stardust Crusaders]"
+    description "English translation by aishsha and Stardust Crusaders version (1.0)"
+    rom ( name "Ninja Jajamaru-kun (Japan).nes" size 32784 crc 839fecf2 md5 050c73279ba4b25d16c1506f5e74c695 sha1 5f6227b519aa3d104a5d39ec26e31c42f10561ff )
+    comment "http://www.romhacking.net/translations/1448/"
+)
+
+game (
+    name "Revenge of the Red Falcon [Hack by Trax]"
+    description "Revenge of the Red Falcon hack by Trax version (1.0)"
+    rom ( name "Contra (USA).nes" size 262160 crc fa28193b md5 869fb19d2fd4781df4e17b8e53845768 sha1 17ef24121d2d4095dcdfab38f90aa021f9b58ebb )
+    comment "https://www.romhacking.net/hacks/2701/"
+)
+
+game (
+    name "JJ (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (1.00)"
+    rom ( name "JJ (Japan).nes" size 131088 crc 7e9b7411 md5 2309b11acb81d5dd01abe72d568590cd sha1 e54091563b9f39863a93f8c0260b3b5518628576 )
+    comment "http://www.romhacking.net/translations/744/"
+)
+
+game (
+    name "Titanic [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (2.1)"
+    rom ( name "Titanic (China) (Unl).nes" size 524304 crc 4f0bef8a md5 483792cec1d0814cd00a85ef6f32c7ac sha1 756656570e7cb21fb9f3f52f5fe25587bcc76336 )
+    comment "http://www.romhacking.net/translations/1605/"
+)
+
+game (
+    name "Ankoku Shinwa - Yamato Takeru Densetsu (Japan) [T-En by Proveaux]"
+    description "English translation by Proveaux version (1.0)"
+    rom ( name "Ankoku Shinwa - Yamato Takeru Densetsu (Japan).nes" size 262160 crc 1382cb5c md5 28cb1f5d72add33fb772fec5a20e9e9c sha1 951a2d3419270b7c5e5d644d0d56ee14ef887217 )
+    comment "http://www.romhacking.net/translations/2683/"
+)
+
+game (
+    name "Game Party (Japan) [T-En by Proveaux]"
+    description "English translation by Proveaux version (1.0)"
+    rom ( name "Game Party (Japan).nes" size 262160 crc e81e2062 md5 36519a9efa19521ac78b26ac017de242 sha1 3553ec226b9dd353ddefae815462728f4299a235 )
+    comment "http://www.romhacking.net/translations/2469/"
+)
+
+game (
+    name "Indora no Hikari (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0 Beta)"
+    rom ( name "Indora no Hikari (Japan).nes" size 262160 crc 3b5ccb05 md5 8dab0afefd940da8b0d96fbde66a8a79 sha1 6b4d7d7982b0f8a9eb8b9fae7ab4e28054252e90 )
+    comment "http://www.romhacking.net/translations/3153/"
+)
+
+game (
+    name "Sakigake!! Otoko Juku - Shippuu Ichi Gou Sei (Japan) [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Sakigake!! Otoko Juku - Shippuu Ichi Gou Sei (Japan).nes" size 262160 crc 09735a4b md5 076aeda52d38b4488935e1a95ff5be28 sha1 19885d7407ca88c3cbf0f2eaa307bd430a7e9f56 )
+    comment "http://www.romhacking.net/translations/2813/"
+)
+
+game (
+    name "Armadillo (Japan) [T-En by Vice Translations]"
+    description "English translation by Vice Translations version (1.01)"
+    rom ( name "Armadillo (Japan).nes" size 393232 crc 651c9916 md5 17df841e1ea1edcff82a3f74539529c1 sha1 ed5612028ad32c9c693dd4392e307998a58a0007 )
+    comment "http://www.romhacking.net/translations/774/"
+)
+
+game (
+    name "Hitler no Fukkatsu - Top Secret (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.04)"
+    rom ( name "Hitler no Fukkatsu - Top Secret (Japan).nes" size 262160 crc 519a3005 md5 dc2aff3dfb8266148e96663ff340c4a1 sha1 657c32ff90c1b8fb21fe088a42958e32b4704c79 )
+    comment "http://www.romhacking.net/translations/2031/"
+)
+
+game (
+    name "Pachinko Daisakusen (Japan) [T-En by MrRichard999]"
+    description "English translation by MrRichard999 version (0.97B)"
+    rom ( name "Pachinko Daisakusen (Japan).nes" size 262160 crc 95708287 md5 9fa3f0faec5eeed71642c825d39d2199 sha1 71fcd4e2ce5cf99286303a274ce7b688cafe062a )
+    comment "http://www.romhacking.net/translations/2417/"
+)
+
+game (
+    name "Heracles no Eikou - Toujin Makyou Den (Japan) [T-En by DvD Translations]"
+    description "English translation by DvD Translations version (Rev B)"
+    rom ( name "Heracles no Eikou - Toujin Makyou Den (Japan).nes" size 262160 crc 724489c8 md5 6267f8af6c135a90e24ff3939e03b2b5 sha1 961fdcf7f553c5c8399f3eaf8684ee5b9dea58f4 )
+    comment "http://www.romhacking.net/translations/1681/"
+)
+
+game (
+    name "Hottarman no Chitei Tanken (Japan) [T-En by Six Feet Under]"
+    description "English translation by Six Feet Under version (1.0)"
+    rom ( name "Hottarman no Chitei Tanken (Japan).nes" size 65552 crc 429701e2 md5 6066c29d403cc017b50942c8575d1478 sha1 55cd797479c436707b9dc03a9852a8f958f92fc9 )
+    comment "http://www.romhacking.net/translations/159/"
+)
+
+game (
+    name "Doraemon - Giga Zombie no Gyakushuu (Japan) [T-En by WakdHacks]"
+    description "English translation by WakdHacks version (1.0)"
+    rom ( name "Doraemon - Giga Zombie no Gyakushuu (Japan).nes" size 262160 crc a9c510ac md5 d12ad1cc9a99e1f6916dc9b86f457895 sha1 bf8980e0868f058aceb0cfdd4a00f29d82ab87bb )
+    comment "http://www.romhacking.net/translations/120/"
+)
+
+game (
+    name "Metroid Deluxe Reduxe [Hack by The Rooser]"
+    description "Metroid Deluxe Reduxe hack by The Rooser version (1.0)"
+    rom ( name "Metroid Deluxe Reduxe.nes" size 393232 crc f0c3e09a md5 0255a6670697a8e7c6318a6c1bd56bc0 sha1 43e1737250ce5f82b9458aa424f18e92d1946f1f )
+    comment "https://www.romhacking.net/hacks/3134/"
+)
+
+game (
+    name "Choujinrou Senki Warwolf (Japan) [T-En by Stardust Crusaders]"
+    description "English translation by Stardust Crusaders version (1.0)"
+    rom ( name "Choujinrou Senki Warwolf (Japan).nes" size 262160 crc 26d2c8fb md5 d84a3a366d24cb38047b4bc46d1dca64 sha1 c36b79e20646d6241f7b490482cf0bf5dcb36f84 )
+    comment "http://www.romhacking.net/translations/1656/"
+)
+
+game (
+    name "Makai Island Restoration [Hack by SCD]"
+    description "Makai Island Restoration hack by SCD version (Final)"
+    rom ( name "Makai Island (USA) (Proto).nes" size 262160 crc 8356d32a md5 131469d59219d6bcb242cf1f19dad0a6 sha1 4f046e81a8ab39a6b67a69268d495dd63ccaab28 )
+    comment "http://www.romhacking.net/hacks/1102/"
+)
+
+game (
+    name "Batsu & Terry - Makyou no Tetsujin Race (Japan) [T-En by Zynk Oxhyde]"
+    description "English translation by Zynk Oxhyde version (1.0)"
+    rom ( name "Batsu & Terry - Makyou no Tetsujin Race (Japan).nes" size 131088 crc 6e99c8ca md5 9d6f310ffb3040bf7da6fd795b466d4a sha1 756fddaab603ca567a5dcc91b6b0f8b5895efb75 )
+    comment "http://www.romhacking.net/translations/2092/"
+)
+
+game (
+    name "Bloody Warriors - Shan-Go no Gyakushuu (Japan) [T-En by ded302 and snark]"
+    description "English translation by ded302 and snark version (1.0)"
+    rom ( name "Bloody Warriors - Shan-Go no Gyakushuu (Japan).nes" size 262160 crc 8b489e9d md5 aea5d8fa234b02767892c5adafa48cb0 sha1 46a4ec2f6f2b62af6aed75b559a4e36f20e55cae )
+    comment "http://www.romhacking.net/translations/1679/"
+)
+
+game (
+    name "Wu Shi Hun [T-En by pacnsacdave]"
+    description "English translation by pacnsacdave version (1.0)"
+    rom ( name "Samurai Shodown (Japan) (Unl).nes" size 393232 crc d35a975c md5 bbda42f35da30518bb67b81e9637fc16 sha1 9b249b52d48f4a7f128b0e1ce440519522661bd8 )
+    comment "http://www.romhacking.net/translations/2524/"
+)
+
+game (
+    name "Kunio-kun no Nekketsu Soccer League (Japan) [T-En by PentarouZero]"
+    description "English translation by PentarouZero version (1.2)"
+    rom ( name "Kunio-kun no Nekketsu Soccer League (Japan).nes" size 262160 crc f41f1f4e md5 8e4b1972394600ec72ce3b034acd2631 sha1 a049f85a576f189e9bdfe892ef6fa3aee664d219 )
+    comment "http://www.romhacking.net/translations/569/"
+)
+
+game (
+    name "Labyrinth (Japan) [T-En by Suicidal Translations]"
+    description "English translation by Suicidal Translations version (Beta)"
+    rom ( name "Labyrinth (Japan).nes" size 131088 crc c7148047 md5 09c9a4e31f7af4b037603294bf3846c8 sha1 001e78b07f05d7be2a2f7867d8d3f09c0951c354 )
+    comment "http://www.romhacking.net/translations/663/"
+)
+
+game (
+    name "Lagrange Point (Japan) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (1.01)"
+    rom ( name "Lagrange Point (Japan).nes" size 524304 crc 9e13caa2 md5 c7953ee37e1b24d1d49ed132091b2745 sha1 599378e35f08292cec3cebfb9dbe8a0e732af1c9 )
+    comment "https://www.romhacking.net/translations/2294/"
+)
+
+game (
+    name "Palamedes II - Star Twinkle, Hoshi no Mabataki (Japan) [T-En by KingMike's Translations]"
+    description "English translation by KingMike's Translations version (1.0)"
+    rom ( name "Palamedes II - Star Twinkle, Hoshi no Mabataki (Japan).nes" size 65552 crc 65f96a77 md5 d5d2c61c6b59d80fb410addaa90a2fa4 sha1 4f26873c814d842895d64e0961772fed83247bfe )
+    comment "http://www.romhacking.net/translations/2003/"
+)
+
+game (
+    name "Deep Dungeon IV - Kuro no Youjutsushi (Japan) [T-En by KingMike's Translations and snark]"
+    description "English translation by KingMike's Translations and snark version (1.0)"
+    rom ( name "Deep Dungeon IV - Kuro no Youjutsushi (Japan).nes" size 262160 crc 663be07f md5 bae3298e49b3efbc046f3988ccbf0d36 sha1 04ba04a67b6e631fe0f734062ae494362bf01cb7 )
+    comment "http://www.romhacking.net/translations/1658/"
+)
+
+game (
+    name "Kyouryuu Sentai Zyuranger (Japan) [T-En by Dank-Trans]"
+    description "English translation by Dank-Trans version (0.99)"
+    rom ( name "Kyouryuu Sentai Zyuranger (Japan).nes" size 262160 crc afbc9dc4 md5 915db6a2335b7c3db680af86354f8bdc sha1 f147791c93684a0ddce5c2c14d2aacc2bdd0818d )
+    comment "http://www.romhacking.net/translations/1395/"
+)
+
+game (
+    name "Dragon Warrior DX [Hack by LastduaL]"
+    description "Dragon Warrior DX hack by LastduaL version (1.0)"
+    rom ( name "Dragon Warrior DX.nes" size 81936 crc 5fcb00d9 md5 efb73468065b8e6d8a9ce7656268bf84 sha1 10b9a73cc919e95280a4a27c73b76684e81ce458 )
+    comment "http://www.romhacking.net/hacks/3963/"
+)
+
+game (
+    name "Ninja-kun - Ashura no Shou (Japan) [T-En by The Spoony Bard]"
+    description "English translation by The Spoony Bard version (1.0)"
+    rom ( name "Ninja-kun - Ashura no Shou (Japan).nes" size 131088 crc bf4f77b3 md5 d6a602adea3f47b69154537a2b69c8ea sha1 c0cde20a837b83b8055d6bee7acf8f87c9382106 )
+    comment "http://www.romhacking.net/translations/197/"
+)


### PR DESCRIPTION
Same as the closed PR.

I verified that RA checksums don't skip the header like redump dats do so the output rom() entry checksums are of the whole patched file.

This was made by 
having a cli version of flips on the same dir as the script (built with `make CLI=1`)
having a no-intro (xml format) dat for nes to pass (to use the no-intro names when possible instead of the names on the romhacking page)
and using this script:
edit, script updated. edit: twice:
https://gist.github.com/i30817/c5332248f46113fcb4ca03081f7673f2



with the following arguments:
`./makedat.py NES/ nes -d no-intro-nes.dat`

This verifies the games against the no-intro dat and if it finds it, use that name, but if it doesn't, warn use the romhacking.net page name. In effect this only 'warned' on unlicensed games translations (since i had no hacks for unlicensed games).

Hacks that aren't translations use the name on the redump page always but its extended description might use the dat name if it's found because those are more likely to match the local rom name than the romhacking entry. But if not found still use romhacking 'secondary' title.  I haven't a example of this because i've not seen a hack that isn't a translation of unlicensed games on my collection.

A warning: although this calculates the right checksum values on the where you combined two hacks into a single softpatch file, you'll end up with 'only' the first hack link on the readme and the name of that hack. 
On these files, the only one that had that problem was `Castlevania 3: Improved Controls + Localization / Title Screen Redone [Hack by NaOH and ShadowOne333]` which i edited manually.

I also didn't allow to add romhacks that flips said failed the checksum when applying the rom so some hacks won't be here (besides the ones that i never downloaded anyway). One example of such is Castlevania: Chorus of Mysteries, which is supposed to apply to some janky rom that doesn't seem to be on the net anymore.