### PR TITLE
add pc engine hacks

### DIFF
--- a/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
+++ b/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
@@ -1,0 +1,153 @@
+clrmamepro (
+	name "PC Engine hacks"
+	description "Romhacks of NEC PC Engine / NEC TurboGrafx 16 games"
+)
+
+game(
+    name "Gaia no Monshou (Japan) [T-En by D]"
+    description "English translation by D version (1.3)"
+    rom ( name "Gaia no Monshou (Japan).pce" size 262144 crc f93670ff md5 a2b1c24c8701e930ae9cf0b48d0873ce sha1 71e1f4f647e094e8758f0bc35409e1d31583b63a )
+    comment "http://www.romhacking.net/translations/813/"
+)
+
+game(
+    name "Final Match Tennis Ladies [T-En by tAz-07 + 2 hacks]"
+    description "Final Match Tennis Ladies hack by MooZ version (1.0) + Final Match Tennis Ladies hack by tAz-07 version (1.0) + English translation by tAz-07 version (1.0)"
+    rom ( name "Final Match Tennis Ladies.pce" size 262144 crc e92d1290 md5 4975b6669f0a47c201d16fa3fc7ec392 sha1 d186a4fd933ab12dd3c2024093241660c0dae1bf )
+    comment "http://www.romhacking.net/hacks/3174/"
+    comment "http://www.romhacking.net/hacks/3297/"
+    comment "http://www.romhacking.net/translations/2801/"
+)
+
+game(
+    name "Die Hard (Japan) [T-En by Spinner 8 and friends]"
+    description "English translation by Spinner 8 and friends version (1.0)"
+    rom ( name "Die Hard (Japan).pce" size 524288 crc 91be0dec md5 45195abbbdaff8dd8d8c521b84f1698d sha1 ae01c948903cca1c849d77f68bffb3e533efcf50 )
+    comment "http://www.romhacking.net/translations/1712/"
+)
+
+game(
+    name "Bikkuriman World (Japan) [T-En by Demiforce]"
+    description "English translation by Demiforce version (1.00)"
+    rom ( name "Bikkuriman World (Japan).pce" size 262144 crc 02db6fe5 md5 7a13bd257402efafff3c33d9ba7d4ae4 sha1 9209ae070ef6a4ca6dad6fb20054b1ac3c265ccf )
+    comment "http://www.romhacking.net/translations/511/"
+)
+
+game(
+    name "Shiryou Sensen - War of the Dead (Japan) [T-En by Nebulous Translations]"
+    description "English translation by Nebulous Translations version (1.0)"
+    rom ( name "Shiryou Sensen - War of the Dead (Japan).pce" size 278528 crc 9ccfbb7a md5 5fb0ef737dcea6a7cb8df0fbcd2670b6 sha1 b030c8f11d35002a3c8e95edc1a5aa4048151c97 )
+    comment "http://www.romhacking.net/translations/3328/"
+)
+
+game(
+    name "Lady Sword (Japan) [T-En by EsperKnight, filler, Grant Laughlin and Tomaitheous]"
+    description "English translation by EsperKnight, filler, Grant Laughlin and Tomaitheous version (1.0)"
+    rom ( name "Lady Sword (Japan).pce" size 1048576 crc ff461dcd md5 6b56d548b740cdbbc2993b5a8f03ffd4 sha1 7e6cf9b1c8ef96147129d297e0b39a2217d499f1 )
+    comment "http://www.romhacking.net/translations/1574/"
+)
+
+game(
+    name "Bubblegum Crash! - Knight Sabers 2034 (Japan) [T-En by Dave Shadoff, filler and Tomaitheous]"
+    description "English translation by Dave Shadoff, filler and Tomaitheous version (1.0)"
+    rom ( name "Bubblegum Crash! - Knight Sabers 2034 (Japan).pce" size 786432 crc 704b6916 md5 4675116aa55dcf17f6311142d43808ec sha1 83ab5db31cd669787bbfaeaaa691a0f59e4d167c )
+    comment "http://www.romhacking.net/translations/1234/"
+)
+
+game(
+    name "Aoi Blink (Japan) [T-En by Gaijin Productions and Zatos Hacks]"
+    description "English translation by Gaijin Productions and Zatos Hacks version (0.99b)"
+    rom ( name "Aoi Blink (Japan).pce" size 393216 crc 25d34a20 md5 6fd7e17d01fc93b9be9f89fa8359a579 sha1 781e6eda1f2e9be35d71b9853f97b8f26cce0631 )
+    comment "http://www.romhacking.net/translations/504/"
+)
+
+game(
+    name "Energy (Japan) [T-En by cabbage and onionzoo]"
+    description "English translation by cabbage and onionzoo version (1.01)"
+    rom ( name "Energy (Japan).pce" size 262144 crc 370fa62c md5 7fc06f2e3131c1cfcddff6c69d54b8b9 sha1 d237dff176ef5193885fdc4abb469f6435dd2aac )
+    comment "http://www.romhacking.net/translations/2936/"
+)
+
+game(
+    name "Knight Rider Special (Japan) [T-En by Psyklax]"
+    description "English translation by Psyklax version (2.0)"
+    rom ( name "Knight Rider Special (Japan).pce" size 262144 crc 1109d8e3 md5 79216bf0956d23b58331b98af6da6c4a sha1 1da7d890ff87cf48ba214f6a246892006c5d70d6 )
+    comment "http://www.romhacking.net/translations/2156/"
+)
+
+game(
+    name "Valkyrie no Densetsu (Japan) [T-En by cabbage and Shawn Cox]"
+    description "English translation by cabbage and Shawn Cox version (1.0)"
+    rom ( name "Valkyrie no Densetsu (Japan).pce" size 524288 crc 97a62bd1 md5 c8e415bf9bf74284e51f8d96a22caff5 sha1 aaa4b32bc980f04b54932bd6792955fa25ebc22c )
+    comment "http://www.romhacking.net/translations/2637/"
+)
+
+game(
+    name "Gekisha Boy (Japan) [T-En by Zatos Hacks]"
+    description "English translation by Zatos Hacks version (0.99)"
+    rom ( name "Gekisha Boy (Japan).pce" size 524288 crc 9cfe7e17 md5 4293b1c07f9de4c32075cfa00963379c sha1 a1083636dcc8d24c02454a4fb04256319d57f1ea )
+    comment "http://www.romhacking.net/translations/507/"
+)
+
+game(
+    name "Maison Ikkoku (Japan) [T-En by Dave Shadoff and filler]"
+    description "English translation by Dave Shadoff and filler version (1.01)"
+    rom ( name "Maison Ikkoku (Japan).pce" size 524288 crc 73c5adf1 md5 0e4dfb8449b2f825af396f0c577b6ef2 sha1 47655a5c5445cc4d69cd32825e84c70ed4a14d26 )
+    comment "http://www.romhacking.net/translations/724/"
+)
+
+game(
+    name "Formation Soccer Human Cup '92 [Hack by MooZ]"
+    description "Formation Soccer Human Cup '92 hack by MooZ version (1.0)"
+    rom ( name "Formation Soccer Human Cup 92.pce" size 262144 crc b3096880 md5 6334a124d072e53aab36c80c38253b1c sha1 9cd0a907d0795b0dc2eb5875aaddc686ce1caea0 )
+    comment "https://www.romhacking.net/hacks/3181/"
+)
+
+game(
+    name "Son Son II (Japan) [T-En by someitalian123]"
+    description "English translation by someitalian123 version (1.0)"
+    rom ( name "Son Son II (Japan).pce" size 262144 crc 1a0599b4 md5 471b66578757b269a682e75ba810b1b7 sha1 3a53ed2ff692e277c55fa287b1d8281a50b0df3e )
+    comment "http://www.romhacking.net/translations/3146/"
+)
+
+game(
+    name "Hisou Kihei - Xserd (Japan) [T-En by Nebulous Translations]"
+    description "English translation by Nebulous Translations version (1.0)"
+    rom ( name "Hisou Kihei - Xserd (Japan).pce" size 786944 crc 3e5ce025 md5 3616bf19f2beb256d13ed4bd77533b6a sha1 8cefcf036b6eda0f120d6363a8c0c020f49f9d5d )
+    comment "http://www.romhacking.net/translations/2780/"
+)
+
+game(
+    name "Maerchen Maze (Japan) [T-En by MooZ and Shubibiman]"
+    description "English translation by MooZ and Shubibiman version (1.1)"
+    rom ( name "Maerchen Maze (Japan).pce" size 262144 crc b7166358 md5 f34299acd4a789ad51e7b10be3a8947d sha1 caf03a4bd2b8e74746b98c0b8be312231e447064 )
+    comment "http://www.romhacking.net/translations/1637/"
+)
+
+game(
+    name "Out Live (Japan) [T-En by Nebulous Translations]"
+    description "English translation by Nebulous Translations version (1.1)"
+    rom ( name "Out Live (Japan).pce" size 303104 crc 2f1cee20 md5 0df6ed290544d42a6d06dcd781037bf7 sha1 4e78f64e3030cce13de7100b6b4dd248d199fa36 )
+    comment "http://www.romhacking.net/translations/2814/"
+)
+
+game(
+    name "Final Match Tennis (Japan) [T-En by tAz-07]"
+    description "English translation by tAz-07 version (1.2)"
+    rom ( name "Final Match Tennis (Japan).pce" size 262144 crc 8c4f4941 md5 e161b34d6bcdbcfe582f943b2eef5715 sha1 6d14d4ac286b70cd7b689a8d4576da4e27a330dd )
+    comment "http://www.romhacking.net/translations/2778/"
+)
+
+game(
+    name "Makai Hakkenden Shada (Japan) [T-En by cabbage and Shubibiman]"
+    description "English translation by cabbage and Shubibiman version (1.0)"
+    rom ( name "Makai Hakkenden Shada (Japan).pce" size 262144 crc 017de16d md5 6b33184f381d3bfc9870f5ad55b8c78a sha1 448991d34538c40cb8d7738ed1093b86c4dd1cfd )
+    comment "http://www.romhacking.net/translations/2636/"
+)
+
+game(
+    name "Druaga no Tou (Japan) [T-En by Procyon]"
+    description "English translation by Procyon version (1.1)"
+    rom ( name "Druaga no Tou (Japan).pce" size 524288 crc b9032dc3 md5 8da3885d9c6674f33cf9bac28905d249 sha1 7a36b6b64596a04a4a3fc6ffeacae44989504271 )
+    comment "http://www.romhacking.net/translations/1104/"
+)


### PR DESCRIPTION
pc engine hacks. As in the SNES all of these source ips that could had their 'required headers' removed by ipsbehead so that they would match what would be end result if the patch applied to the no-intro ROM. It's the same hack, sans header.

Of special interest are `Final Match Tennis Ladies` and `Formation Soccer Human Cup '92`. The source roms of these hacks aren't actually from no-intro because they're roms extracted from a cd `Human Sports Festival (NTSC-J) (HMCD2002)` and never were released on cartridge form. This is also the reason i had to rename `Final Match Tennis Ladies` from `Human Sports Festival` because it isn't on the no-intro dat and the romhacking page lists the 'original game' for translations. 

Just something to keep in mind when updating.