### PR TITLE
add playstation hacks

### DIFF
--- a/metadat/hacks/Sony - PlayStation.dat
+++ b/metadat/hacks/Sony - PlayStation.dat
@@ -1,0 +1,151 @@
+clrmamepro (
+	name "PlayStation hacks"
+	description "Romhacks of Sony PlayStation games"
+)
+
+game(
+    name "Front Mission 2 (Japan) (v1.1) [T-En by pedr0]"
+    description "English translation by pedr0 version (1.1)"
+    rom ( name "Front Mission 2 (Japan) (v1.1).bin" size 426215328 crc 3da0bff7 md5 6f50e2380738863e9d6fcadb6fac6b63 sha1 702767d63d81f614c6d5cd912f015c786d86ce96 )
+    comment "No reputable source"
+)
+
+game(
+    name "Persona 2 - Tsumi (Japan) (v1.0) [T-En by Gemini]"
+    description "English translation by Gemini version (1.0a)"
+    rom ( name "Persona 2 - Tsumi (Japan) (v1.0).bin" size 691925472 crc 870ceff9 md5 11b188975894f2e4062ac773a9e9c153 sha1 cd3521fab99346ada2f09391b1c415429fde2b1c )
+    comment "http://www.romhacking.net/translations/1249/"
+)
+
+game(
+    name "iS - Internal Section (Japan) [T-En by GameHacking.org]"
+    description "English translation by GameHacking.org version (1.02)"
+    rom ( name "iS - Internal Section (Japan).bin" size 248107776 crc 1ec73120 md5 58785f169abf5b14bfffff8716bcb7ad sha1 a787c7f0118d07879d3e50908947e7e8c035b7de )
+    comment "http://www.romhacking.net/translations/1265/"
+)
+
+game(
+    name "Asuncia - Majou no Jubaku (Japan) [T-En by John Osborne]"
+    description "English translation by John Osborne version (1)"
+    rom ( name "Asuncia - Majou no Jubaku (Japan) (Track 01).bin" size 122529792 crc 871fd606 md5 584fc0933909ae1636255bc9649cb719 sha1 de7d3ac31150f0112d633d3a763ffb9c8aa6c818 )
+    comment "http://www.romhacking.net/translations/3393/"
+)
+
+game(
+    name "Fantastic Night Dreams - Cotton Original (Japan) [T-En by RIP Translations]"
+    description "English translation by RIP Translations version (1.10)"
+    rom ( name "Fantastic Night Dreams - Cotton Original (Japan).bin" size 39273696 crc 3082745a md5 0b84dff9eb045321f3c1e60bf861280a sha1 9252d11b1487756c8a37877f90655ded285be9da )
+    comment "http://www.romhacking.net/translations/265/"
+)
+
+game(
+    name "King's Field (Japan) [T-En by John Osborne]"
+    description "English translation by John Osborne version (1.0)"
+    rom ( name "King's Field (Japan).bin" size 30378432 crc 5f9be6e1 md5 c56cfb36f19f2608d3c180c104ace9dd sha1 c667b5b2dfba697c338783fe3d351f7910882152 )
+    comment "https://www.romhacking.net/translations/1067/"
+)
+
+game(
+    name "Policenauts (Japan) (Disc 1) [T-En by JunkerHQ]"
+    description "English translation by JunkerHQ version (1.0)"
+    rom ( name "Policenauts (Japan) (Disc 1).bin" size 748928544 crc 0db7d7e8 md5 65977ae8b63042475730e6efb6a5a8a6 sha1 3aa1fe0f2175dee26f66175de2a1ffe6d385ee95 )
+    comment "http://www.romhacking.net/translations/1422/"
+)
+
+game(
+    name "Policenauts (Japan) (Disc 2) [T-En by JunkerHQ]"
+    description "English translation by JunkerHQ version (1.0)"
+    rom ( name "Policenauts (Japan) (Disc 2).bin" size 613822608 crc 272ca545 md5 3b6bf3ce8230da37b8a717b6e892b457 sha1 e23d6395e0761e170bce24686c4eda289c159319 )
+    comment "http://www.romhacking.net/translations/1422/"
+)
+
+game(
+    name "Echo Night #2 - Nemuri no Shihaisha (Japan) [T-En by Gemini and Tom]"
+    description "English translation by Gemini and Tom version (1.0a)"
+    rom ( name "Echo Night 2 (Japan).bin" size 346863552 crc 3f73164a md5 68d101c1650952a49d66d66eb9b772ec sha1 e87ec671a337bcd9b7da537b8901a500e6ed5ee5 )
+    comment "http://www.romhacking.net/translations/2380/"
+)
+
+game(
+    name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) [T-En by Gemini]"
+    description "English translation by Gemini version (1.0)"
+    rom ( name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) (Track 1).bin" size 545440560 crc d42bc703 md5 a79f24c94d9843ef903564a9e9c56356 sha1 3ef656b04d490b66f2babfbf601e1cc6b73b30e2 )
+    comment "http://www.romhacking.net/translations/1427/"
+)
+
+game(
+    name "Super Robot Taisen Alpha Gaiden (Japan) (Shokai Genteiban) [T-En by Aeon Genesis]"
+    description "English translation by Aeon Genesis version (0.95b)"
+    rom ( name "Super Robot Taisen Alpha Gaiden (Japan) (v1.1).bin" size 718394880 crc 52df8488 md5 bb73db766fbd2d7d2ad089104ca5b956 sha1 64198b5ce52c117b30ce044ffdbad19419a622b3 )
+    comment "http://www.romhacking.net/translations/859/"
+)
+
+game(
+    name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1) [T-En by Team NEMO]"
+    description "English translation by Team NEMO version (2.0)"
+    rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1).bin" size 732224640 crc f0fc5ae7 md5 b075b732f61371efe680323c21390204 sha1 c69975892d0a19f952018d375be52adf38fe1e2c )
+    comment "http://www.romhacking.net/translations/2307/"
+)
+
+game(
+    name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1) [T-En by Team NEMO]"
+    description "English translation by Team NEMO version (2.0)"
+    rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1).bin" size 724512432 crc 0b2f796b md5 15f7580eebae2fab6381a4c65450a75f sha1 cfc3e5e96ae93dafce3fbde46ebd4bb4310f0d4b )
+    comment "http://www.romhacking.net/translations/2307/"
+)
+
+game(
+    name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1) [T-En by NoOneee]"
+    description "English translation by NoOneee version (1.0)"
+    rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1).bin" size 477180816 crc 51a2c51b md5 934ef37fb41fd3acad685e4e1bffde05 sha1 7e69656048f01a36f46b40b239257ebee4d089e6 )
+    comment "http://www.romhacking.net/translations/2927/"
+)
+
+game(
+    name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2) [T-En by NoOneee]"
+    description "English translation by NoOneee version (1.0)"
+    rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2).bin" size 455354256 crc 131f8b49 md5 c8f81e55451ec07c90414cba0a45a471 sha1 f1a79dc3db9ef90c152bfeb51f2fcc0b46cb0277 )
+    comment "http://www.romhacking.net/translations/2927/"
+)
+
+game(
+    name "Brigandine - Grand Edition (Japan) (Disc 2) [T-En by John Osborne]"
+    description "English translation by John Osborne version (8)"
+    rom ( name "Brigandine - Grand Edition (Japan) (Disc 2).bin" size 751746240 crc 11fa0e02 md5 e497d63caf18b8387d43022ef2c6c103 sha1 bfddf6904d8d0827e63ff51b23ddc2dbcd265192 )
+    comment "https://www.romhacking.net/translations/3236/"
+)
+
+game(
+    name "Brigandine - Grand Edition (Japan) (Disc 1) [T-En by John Osborne]"
+    description "English translation by John Osborne version (8)"
+    rom ( name "Brigandine - Grand Edition (Japan) (Disc 1).bin" size 751720368 crc 4d719816 md5 fc3eb17e3451a2fa9f8494842f1a0290 sha1 8d494e8d3616b285fd453d78e7f945970e1c3268 )
+    comment "https://www.romhacking.net/translations/3236/"
+)
+
+game(
+    name "Clock Tower - The First Fear (Japan) [T-En by arcraith]"
+    description "English translation by arcraith version (1.1)"
+    rom ( name "Clock Tower - The First Fear (Japan) (Track 1).bin" size 75750864 crc f3ced589 md5 83adf3cdb6c46b3e084dec6dfb213295 sha1 f20aaf6d52ba2acee483445a8039b85e6f1492d4 )
+    comment "https://www.romhacking.net/translations/2337/"
+)
+
+game(
+    name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) [T-En by Kil]"
+    description "English translation by Kil version (1.3)"
+    rom ( name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) (Track 1).bin" size 576338784 crc 946999e1 md5 1740cc952d6f29a682dbc218e061d081 sha1 77b0d822adb68ebbdd5a98a97894d55f340f5b79 )
+    comment "http://www.romhacking.net/translations/1711/"
+)
+
+game(
+    name "Castlevania: Symphony of the Night - Quality hack [Hack by paul_met]"
+    description "Castlevania: Symphony of the Night - Quality hack hack by paul_met version (1.2)"
+    rom ( name "Castlevania - Symphony of the Night (USA) (Track 1).bin" size 538655040 crc 0431c247 md5 6674f4a75ea11fd9422669f247ec27fd sha1 1fa7cd542e15f9ce281e83320eedd24daace79e8 )
+    comment "http://www.romhacking.net/hacks/3606/"
+)
+
+game(
+    name "Yutona Eiyuu Senki - TearRingSaga (Japan) [T-En by Aethin]"
+    description "English translation by Aethin version (1.04)"
+    rom ( name "Tear Ring Saga (Japan).bin" size 594054048 crc ca9bf988 md5 7f67daa021705a01ce322aa47edd1695 sha1 17066296885b81dc7511597c002fa867b4f178d3 )
+    comment "http://www.romhacking.net/translations/2812/"
+)


### PR DESCRIPTION
All the ps1 hacks i have. There aren't so many, but there is some gotchas here.

First, 3 translations here had to be modified by [error_recalc](https://www.romhacking.net/utilities/1264/) to work on the mednafen core. This is because the upstream has a 'bad' translation that nukes the error correction codes and mednafen objects. I thought it more 'reasonable' to include the working checksums not the broken ones.

The translations are Brigandine - Grand Edition, iS - Internal Section and Fantastic Night Dreams - Cotton Original.

Then there is the first game translation entry for front mission 2. This is a 'better' working version of the normal one on www.romhacking.net which actually has sound on videos among other things. Since i could never make the other one work without downloading the whole iso, and it was buggier and this one works with the redump iso, i thought i'd include this one instead. It has no romhacking page and the Mega link in which it was distributed is gone though, so it has to be maintained manually, unless i upload it to romhacking.net and it is accepted.

After this only the psp and ps2 games hacks are left for me. PSP i'm waiting for romhacking to review and accept two translations (one not so important `Last Ranker` and another quite important `Valkyria Chronicles 3`). For ps2 i know you don't have a core (yet) but it's only 6 of them.
 