### PR TITLE
tab and empty line removal

### DIFF
--- a/metadat/hacks/Bandai - WonderSwan Color.dat
+++ b/metadat/hacks/Bandai - WonderSwan Color.dat
@@ -1,22 +1,19 @@
 clrmamepro (
-	name "WonderSwan Color hacks"
-	description "Romhacks of Bandai WonderSwan Color games"
+    name "WonderSwan Color hacks"
+    description "Romhacks of Bandai WonderSwan Color games"
 )
-
 game (
     name "Makai Toushi Sa-Ga (Japan) [T-En by Tower Reversed]"
     description "English translation by Tower Reversed version (1.2)"
     rom ( name "Makai Toushi Sa-Ga (Japan).wsc" size 4194304 crc a4308378 md5 f1d130f871a4440be635322c73662049 sha1 f800e5305292a81be738f15426269329a8d139b1 )
     comment "http://www.romhacking.net/translations/1614/"
 )
-
 game (
     name "Dicing Knight. (Japan) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (1.00)"
     rom ( name "Dicing Knight. (Japan).wsc" size 2097152 crc 56f4e554 md5 6e8848993a51e0226ba4be18e7bb6b73 sha1 106dca0fd84ba59dd98f13ee5ab6e4832105b8b3 )
     comment "http://www.romhacking.net/translations/1073/"
 )
-
 game (
     name "Mr. Driller (Japan) [T-En by PmHacks]"
     description "English translation by PmHacks version (0.70)"

--- a/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
+++ b/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
@@ -1,15 +1,13 @@
 clrmamepro (
-	name "PC Engine hacks"
-	description "Romhacks of NEC PC Engine / NEC TurboGrafx 16 games"
+    name "PC Engine hacks"
+    description "Romhacks of NEC PC Engine / NEC TurboGrafx 16 games"
 )
-
 game (
     name "Gaia no Monshou (Japan) [T-En by D]"
     description "English translation by D version (1.3)"
     rom ( name "Gaia no Monshou (Japan).pce" size 262144 crc f93670ff md5 a2b1c24c8701e930ae9cf0b48d0873ce sha1 71e1f4f647e094e8758f0bc35409e1d31583b63a )
     comment "http://www.romhacking.net/translations/813/"
 )
-
 game (
     name "Final Match Tennis Ladies [T-En by tAz-07 + 2 hacks]"
     description "Final Match Tennis Ladies hack by MooZ version (1.0) + Final Match Tennis Ladies hack by tAz-07 version (1.0) + English translation by tAz-07 version (1.0)"
@@ -18,133 +16,114 @@ game (
     comment "http://www.romhacking.net/hacks/3297/"
     comment "http://www.romhacking.net/translations/2801/"
 )
-
 game (
     name "Die Hard (Japan) [T-En by Spinner 8 and friends]"
     description "English translation by Spinner 8 and friends version (1.0)"
     rom ( name "Die Hard (Japan).pce" size 524288 crc 91be0dec md5 45195abbbdaff8dd8d8c521b84f1698d sha1 ae01c948903cca1c849d77f68bffb3e533efcf50 )
     comment "http://www.romhacking.net/translations/1712/"
 )
-
 game (
     name "Bikkuriman World (Japan) [T-En by Demiforce]"
     description "English translation by Demiforce version (1.00)"
     rom ( name "Bikkuriman World (Japan).pce" size 262144 crc 02db6fe5 md5 7a13bd257402efafff3c33d9ba7d4ae4 sha1 9209ae070ef6a4ca6dad6fb20054b1ac3c265ccf )
     comment "http://www.romhacking.net/translations/511/"
 )
-
 game (
     name "Shiryou Sensen - War of the Dead (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.0)"
     rom ( name "Shiryou Sensen - War of the Dead (Japan).pce" size 278528 crc 9ccfbb7a md5 5fb0ef737dcea6a7cb8df0fbcd2670b6 sha1 b030c8f11d35002a3c8e95edc1a5aa4048151c97 )
     comment "http://www.romhacking.net/translations/3328/"
 )
-
 game (
     name "Lady Sword (Japan) [T-En by EsperKnight, filler, Grant Laughlin and Tomaitheous]"
     description "English translation by EsperKnight, filler, Grant Laughlin and Tomaitheous version (1.0)"
     rom ( name "Lady Sword (Japan).pce" size 1048576 crc ff461dcd md5 6b56d548b740cdbbc2993b5a8f03ffd4 sha1 7e6cf9b1c8ef96147129d297e0b39a2217d499f1 )
     comment "http://www.romhacking.net/translations/1574/"
 )
-
 game (
     name "Bubblegum Crash! - Knight Sabers 2034 (Japan) [T-En by Dave Shadoff, filler and Tomaitheous]"
     description "English translation by Dave Shadoff, filler and Tomaitheous version (1.0)"
     rom ( name "Bubblegum Crash! - Knight Sabers 2034 (Japan).pce" size 786432 crc 704b6916 md5 4675116aa55dcf17f6311142d43808ec sha1 83ab5db31cd669787bbfaeaaa691a0f59e4d167c )
     comment "http://www.romhacking.net/translations/1234/"
 )
-
 game (
     name "Aoi Blink (Japan) [T-En by Gaijin Productions and Zatos Hacks]"
     description "English translation by Gaijin Productions and Zatos Hacks version (0.99b)"
     rom ( name "Aoi Blink (Japan).pce" size 393216 crc 25d34a20 md5 6fd7e17d01fc93b9be9f89fa8359a579 sha1 781e6eda1f2e9be35d71b9853f97b8f26cce0631 )
     comment "http://www.romhacking.net/translations/504/"
 )
-
 game (
     name "Energy (Japan) [T-En by cabbage and onionzoo]"
     description "English translation by cabbage and onionzoo version (1.01)"
     rom ( name "Energy (Japan).pce" size 262144 crc 370fa62c md5 7fc06f2e3131c1cfcddff6c69d54b8b9 sha1 d237dff176ef5193885fdc4abb469f6435dd2aac )
     comment "http://www.romhacking.net/translations/2936/"
 )
-
 game (
     name "Knight Rider Special (Japan) [T-En by Psyklax]"
     description "English translation by Psyklax version (2.0)"
     rom ( name "Knight Rider Special (Japan).pce" size 262144 crc 1109d8e3 md5 79216bf0956d23b58331b98af6da6c4a sha1 1da7d890ff87cf48ba214f6a246892006c5d70d6 )
     comment "http://www.romhacking.net/translations/2156/"
 )
-
 game (
     name "Valkyrie no Densetsu (Japan) [T-En by cabbage and Shawn Cox]"
     description "English translation by cabbage and Shawn Cox version (1.0)"
     rom ( name "Valkyrie no Densetsu (Japan).pce" size 524288 crc 97a62bd1 md5 c8e415bf9bf74284e51f8d96a22caff5 sha1 aaa4b32bc980f04b54932bd6792955fa25ebc22c )
     comment "http://www.romhacking.net/translations/2637/"
 )
-
 game (
     name "Gekisha Boy (Japan) [T-En by Zatos Hacks]"
     description "English translation by Zatos Hacks version (0.99)"
     rom ( name "Gekisha Boy (Japan).pce" size 524288 crc 9cfe7e17 md5 4293b1c07f9de4c32075cfa00963379c sha1 a1083636dcc8d24c02454a4fb04256319d57f1ea )
     comment "http://www.romhacking.net/translations/507/"
 )
-
 game (
     name "Maison Ikkoku (Japan) [T-En by Dave Shadoff and filler]"
     description "English translation by Dave Shadoff and filler version (1.01)"
     rom ( name "Maison Ikkoku (Japan).pce" size 524288 crc 73c5adf1 md5 0e4dfb8449b2f825af396f0c577b6ef2 sha1 47655a5c5445cc4d69cd32825e84c70ed4a14d26 )
     comment "http://www.romhacking.net/translations/724/"
 )
-
 game (
     name "Formation Soccer Human Cup '92 [Hack by MooZ]"
     description "Formation Soccer Human Cup '92 hack by MooZ version (1.0)"
     rom ( name "Formation Soccer Human Cup 92.pce" size 262144 crc b3096880 md5 6334a124d072e53aab36c80c38253b1c sha1 9cd0a907d0795b0dc2eb5875aaddc686ce1caea0 )
     comment "https://www.romhacking.net/hacks/3181/"
 )
-
 game (
     name "Son Son II (Japan) [T-En by someitalian123]"
     description "English translation by someitalian123 version (1.0)"
     rom ( name "Son Son II (Japan).pce" size 262144 crc 1a0599b4 md5 471b66578757b269a682e75ba810b1b7 sha1 3a53ed2ff692e277c55fa287b1d8281a50b0df3e )
     comment "http://www.romhacking.net/translations/3146/"
 )
-
 game (
     name "Hisou Kihei - Xserd (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.0)"
     rom ( name "Hisou Kihei - Xserd (Japan).pce" size 786944 crc 3e5ce025 md5 3616bf19f2beb256d13ed4bd77533b6a sha1 8cefcf036b6eda0f120d6363a8c0c020f49f9d5d )
     comment "http://www.romhacking.net/translations/2780/"
 )
-
 game (
     name "Maerchen Maze (Japan) [T-En by MooZ and Shubibiman]"
     description "English translation by MooZ and Shubibiman version (1.1)"
     rom ( name "Maerchen Maze (Japan).pce" size 262144 crc b7166358 md5 f34299acd4a789ad51e7b10be3a8947d sha1 caf03a4bd2b8e74746b98c0b8be312231e447064 )
     comment "http://www.romhacking.net/translations/1637/"
 )
-
 game (
     name "Out Live (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.1)"
     rom ( name "Out Live (Japan).pce" size 303104 crc 2f1cee20 md5 0df6ed290544d42a6d06dcd781037bf7 sha1 4e78f64e3030cce13de7100b6b4dd248d199fa36 )
     comment "http://www.romhacking.net/translations/2814/"
 )
-
 game (
     name "Final Match Tennis (Japan) [T-En by tAz-07]"
     description "English translation by tAz-07 version (1.2)"
     rom ( name "Final Match Tennis (Japan).pce" size 262144 crc 8c4f4941 md5 e161b34d6bcdbcfe582f943b2eef5715 sha1 6d14d4ac286b70cd7b689a8d4576da4e27a330dd )
     comment "http://www.romhacking.net/translations/2778/"
 )
-
 game (
     name "Makai Hakkenden Shada (Japan) [T-En by cabbage and Shubibiman]"
     description "English translation by cabbage and Shubibiman version (1.0)"
     rom ( name "Makai Hakkenden Shada (Japan).pce" size 262144 crc 017de16d md5 6b33184f381d3bfc9870f5ad55b8c78a sha1 448991d34538c40cb8d7738ed1093b86c4dd1cfd )
     comment "http://www.romhacking.net/translations/2636/"
 )
-
 game (
     name "Druaga no Tou (Japan) [T-En by Procyon]"
     description "English translation by Procyon version (1.1)"

--- a/metadat/hacks/Nintendo - Game Boy Advance.dat
+++ b/metadat/hacks/Nintendo - Game Boy Advance.dat
@@ -1,92 +1,79 @@
 clrmamepro (
-	name "Game Boy Advance hacks"
-	description "Hacks of Game Boy Advance games"
+    name "Game Boy Advance hacks"
+    description "Hacks of Game Boy Advance games"
 )
-
 game (
     name "Magical Vacation (Japan) [T-En by magicalpatcher]"
     description "English translation by magicalpatcher version (1.0)"
     rom ( name "Magical Vacation (Japan).gba" size 9043968 crc 98fbbd9a md5 7bc82e72f6b9f734766f6cd9faf43e66 sha1 f928f9ca70ce76c19abbe50077f2c0d06efe6cfe )
     comment "http://www.romhacking.net/translations/2662/"
 )
-
 game (
     name "Metroid Other ZM [Hack by Luce Seyfarth]"
     description "Metroid Other ZM hack by Luce Seyfarth version (3.8)"
     rom ( name "Metroid Other ZM.gba" size 16777216 crc fc850cc5 md5 4fdb05cdb7bcd66e6fec1af992e7c310 sha1 26327eb06fda34c3f1fffa512c08b804623185f8 )
     comment "http://www.romhacking.net/hacks/2565/"
 )
-
 game (
     name "Oriental Blue - Ao no Tengai (Japan) [T-En by Kingcom and Tom]"
     description "English translation by Kingcom and Tom version (1.0)"
     rom ( name "Oriental Blue - Ao no Tengai (Japan).gba" size 16777216 crc 8a850da7 md5 0fe6daf45e3460cc865ee50029988f3a sha1 95c4e8b78d7e66e28451e4f6780d3f0fd9e687d2 )
     comment "http://www.romhacking.net/translations/2035/"
 )
-
 game (
     name "Gensou Suikoden - Card Stories (Japan) [T-En by Pokeytax]"
     description "English translation by Pokeytax version (1.00)"
     rom ( name "Gensou Suikoden - Card Stories (Japan).gba" size 4194304 crc dafac900 md5 1e2ed077d1db255c44cd6c653067750c sha1 343b4dc9e897133f26dc8f04a70c1ea752d26cdd )
     comment "http://www.romhacking.net/translations/1720/"
 )
-
 game (
     name "Super Robot Taisen J (Japan) [T-En by Kingcom]"
     description "English translation by Kingcom version (1.0)"
     rom ( name "Super Robot Taisen J (Japan).gba" size 16777216 crc 3b3cd715 md5 6caff32286c768d3bf9f7986d535ef7b sha1 0ef65670fec4f655536d15b7a954a1deda192855 )
     comment "http://www.romhacking.net/translations/1577/"
 )
-
 game (
     name "Mother 3 (Japan) [T-En by Chewy, Jeffman and Tomato]"
     description "English translation by Chewy, Jeffman and Tomato version (1.2)"
     rom ( name "Mother 3 (Japan).gba" size 33554432 crc a323c029 md5 31321db87c763bba42a2fdedf1706386 sha1 a2f2d9d1ca8281563683c89a05826ea0b91b2892 )
     comment "http://www.romhacking.net/translations/1333/"
 )
-
 game (
     name "Fire Emblem - Fuuin no Tsurugi (Japan) [T-En by Gringe]"
     description "English translation by Gringe version (1.0)"
     rom ( name "Fire Emblem - Fuuin no Tsurugi (Japan).gba" size 16777532 crc 99b8b6d7 md5 9fc134a926a9f2fe84a141aba2ba25a9 sha1 32605fd456677ef740f8d521e9a3894ace4bc59c )
     comment "http://www.romhacking.net/translations/2511/"
 )
-
 game (
     name "Hagane no Renkinjutsushi - Meisou no Rondo (Japan) [T-En by mz]"
     description "English translation by mz version (0.02)"
     rom ( name "Hagane no Renkinjutsushi - Meisou no Rondo (Japan).gba" size 16777216 crc bc3f79b5 md5 70dd13d5d0cb840ecdee29ea78e5e013 sha1 0e53d1b7c6a413f18e13f0b87e302b7838f8dbe1 )
     comment "http://www.romhacking.net/translations/2882/"
 )
-
 game (
     name "Hajime no Ippo - The Fighting! (Japan) [T-En by Markliujy]"
     description "English translation by Markliujy version (1.0)"
     rom ( name "Hajime no Ippo - The Fighting! (Japan).gba" size 8388608 crc 5130a355 md5 e33de4139d69d016394a26119cdeba32 sha1 106301fecaf19f026385e281f9da881b6c38d058 )
     comment "http://www.romhacking.net/translations/1319/"
 )
-
 game (
     name "Mother 1+2 (Japan) [T-En by Jeffman and Tomato]"
     description "English translation by Jeffman and Tomato version (1.01)"
     rom ( name "Mother 1+2 (Japan).gba" size 16777216 crc 7b1ff152 md5 68806f7e40e1f082b21a8b920e8982db sha1 e377a23de3411fd47b0d1ad3923d731ab0c127ac )
     comment "http://www.romhacking.net/translations/1609/"
 )
-
 game (
     name "Famicom Mini - Dai-2-ji Super Robot Taisen (Japan) (Promo) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (0.99)"
     rom ( name "Famicom Mini - Dai-2-ji Super Robot Taisen (Japan) (Promo).gba" size 4194304 crc cc4fda84 md5 778cbe0cd0d270cf7d436e4a85121fe6 sha1 0a05eaf5ca16bd9dd9490e83b20a330afc2a240f )
     comment "http://www.romhacking.net/translations/2091/"
 )
-
 game (
     name "Super Mario Advance 4 - All 38 e-Reader Levels [Hack by ShadowOne333]"
     description "Super Mario Advance 4 - All 38 e-Reader Levels hack by ShadowOne333 version (1.0)"
     rom ( name "Super Mario Advance 4 - Super Mario Bros. 3 (USA).gba" size 8388608 crc d4c13ac3 md5 e7a2792c5913a8420a419f2d01358487 sha1 dd2879329ec52bd5372f26b75297a67f1a81215a )
     comment "http://www.romhacking.net/hacks/2714/"
 )
-
 game (
     name "Dragon Quest Monsters - Caravan Heart (Japan) [T-En by KaioShin]"
     description "English translation by KaioShin version (1.0)"

--- a/metadat/hacks/Nintendo - Game Boy Color.dat
+++ b/metadat/hacks/Nintendo - Game Boy Color.dat
@@ -1,64 +1,55 @@
 clrmamepro (
-	name "Game Boy Color hacks"
-	description "Hacks of Game Boy Color games"
+    name "Game Boy Color hacks"
+    description "Hacks of Game Boy Color games"
 )
-
 game (
     name "Arle no Bouken - Mahou no Jewel (Japan) (SGB Enhanced) (GB Compatible) [T-En by Jazz]"
     description "English translation by Jazz version (2.1)"
     rom ( name "Arle no Bouken - Mahou no Jewel (Japan) (SGB Enhanced).gbc" size 1048576 crc 9a14a37a md5 d2bb101d6b203d8b29cc0db5944eb244 sha1 9238f6f5419eed2b65b8e362f9d4c76429283665 )
     comment "http://www.romhacking.net/translations/3468/"
 )
-
 game (
     name "Wizardry Empire (Japan) (Rev A) [T-En by AgentOrange, Helly and MrRichard999]"
     description "English translation by AgentOrange, Helly and MrRichard999 version (1.02)"
     rom ( name "Wizardry Empire (Japan) (Rev A).gbc" size 1048619 crc c10ddd2f md5 300edb5260429731848bcd99b413db5d sha1 831b23543967ba160ad7fe1d439b04f4abc68cad )
     comment "http://www.romhacking.net/translations/2316/"
 )
-
 game (
     name "Wizardry Empire - Fukkatsu no Tsue (Japan) [T-En by Helly and MrRichard999]"
     description "English translation by Helly and MrRichard999 version (1.16)"
     rom ( name "Wizardry Empire - Fukkatsu no Tsue (Japan).gbc" size 1048576 crc 8b209f47 md5 e8fe54e3483adee2019996a4cc1545ac sha1 f094d4afaf3a209d6422ff718045f93a5ae0c4fa )
     comment "http://www.romhacking.net/translations/2322/"
 )
-
 game (
     name "Megami Tensei Gaiden - Last Bible II (Japan) (SGB Enhanced) (GB Compatible) [T-En by EsperKnight]"
     description "English translation by EsperKnight version (1.0)"
     rom ( name "Megami Tensei Gaiden - Last Bible II (Japan) (SGB Enhanced).gbc" size 1048576 crc 007b4804 md5 5c426fda8368066cf7e30587876af631 sha1 6f2ba0de137cfc3be136f6477dd84873663745a0 )
     comment "http://www.romhacking.net/translations/1392/"
 )
-
 game (
     name "Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan) (SGB Enhanced) (GB Compatible) [T-En by Psyklax]"
     description "English translation by Psyklax version (1.0)"
     rom ( name "Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan) (SGB Enhanced).gbc" size 1048576 crc 4a586ad3 md5 1689c2205cc7b3bd020e85d2ea73fdf7 sha1 27185599dd6f0da93464a729306db1ac10818ae0 )
     comment "http://www.romhacking.net/translations/2151/"
 )
-
 game (
     name "Lufia: The Legend Returns Text Cleanup [Hack by vivify93]"
     description "Lufia: The Legend Returns Text Cleanup hack by vivify93 version (1.7)"
     rom ( name "Lufia - The Legend Returns (USA).gbc" size 2097152 crc 910ae902 md5 e873d89e9727e8aa2e505a091639e6cd sha1 b5e75b6ed36329d2eb1bb7d560a21e32131d737e )
     comment "http://www.romhacking.net/hacks/813/"
 )
-
 game (
     name "Little Magic (Japan) [T-En by Some Good Shit Translations]"
     description "English translation by Some Good Shit Translations version (1.0)"
     rom ( name "Little Magic (Japan).gbc" size 1048576 crc f1ea3f69 md5 5b1fc7b09dd78a0a6a4c87cf9c86ab1c sha1 9339c8770bab5650a60f05c4fb69bf75acc9a399 )
     comment "http://www.romhacking.net/translations/29/"
 )
-
 game (
     name "Shantae - Force GBA Enhanced Mode [Hack by Polar-Star]"
     description "Shantae - Force GBA Enhanced Mode hack by Polar-Star version (1.0)"
     rom ( name "Shantae (USA).gbc" size 4194304 crc a52782ba md5 f687ce08f80c8f6ecb7722c90dde4b5c sha1 4295fcae05cb90b1564f3bb4e92cc2b2eec40f0e )
     comment "http://www.romhacking.net/hacks/3462/"
 )
-
 game (
     name "Meitantei Conan - Kigantou Hihou Densetsu (Japan) (SGB Enhanced) (GB Compatible) [T-En by mz]"
     description "English translation by mz version (0.04)"

--- a/metadat/hacks/Nintendo - Game Boy.dat
+++ b/metadat/hacks/Nintendo - Game Boy.dat
@@ -1,57 +1,49 @@
 clrmamepro (
-	name "Game Boy hacks"
-	description "Hacks of Game Boy games"
+    name "Game Boy hacks"
+    description "Hacks of Game Boy games"
 )
-
 game (
     name "Heracles no Eikou - Ugokidashita Kamigami (Japan) [T-En by aishsha and Stardust Crusaders]"
     description "English translation by aishsha and Stardust Crusaders version (1.0)"
     rom ( name "Heracles no Eikou - Ugokidashita Kamigami (Japan).gb" size 262144 crc d51370ef md5 5f513ff116181531c0e99fa1e8ba91f8 sha1 dc2df7aa292c0982a953b897cd77d26719243e47 )
     comment "http://www.romhacking.net/translations/3365/"
 )
-
 game (
     name "Wizardry Gaiden 2 - Kodai Koutei no Noroi (Japan) [T-En by MrRichard999 and Tangyi_Chang]"
     description "English translation by MrRichard999 and Tangyi_Chang version (1.1)"
     rom ( name "Wizardry Gaiden 2 - Kodai Koutei no Noroi (Japan).gb" size 262144 crc 0f094fa6 md5 1919c1597fa158092c159230df1f6349 sha1 c9c50a9311b73e2b1e86c67f2a90cc3def28a5da )
     comment "http://www.romhacking.net/translations/2150/"
 )
-
 game (
     name "Kaeru no Tame ni Kane wa Naru (Japan) [T-En by ryanbgstl]"
     description "English translation by ryanbgstl version (1.0)"
     rom ( name "Kaeru no Tame ni Kane wa Naru (Japan).gb" size 524288 crc 630193e8 md5 5e477cdea0b3266b505ac5938ddc5e5c sha1 90bddff5d48eedad6ec5157946f602ae4170e0c6 )
     comment "http://www.romhacking.net/translations/1623/"
 )
-
 game (
     name "Nangoku Shounen Papuwa-kun - Ganmadan no Yabou (Japan) [T-En by Adventurous Translations]"
     description "English translation by Adventurous Translations version (1.00)"
     rom ( name "Nangoku Shounen Papuwa-kun - Ganmadan no Yabou (Japan).gb" size 131072 crc 366869bc md5 686abad72092adccabc6db3687b1075e sha1 daa16493e46de4bb3c2c24914c8ab5d13c12fa84 )
     comment "http://www.romhacking.net/translations/2946/"
 )
-
 game (
     name "Wizardry Gaiden 3 - Yami no Seiten (Japan) [T-En by Tangyi_Chang]"
     description "English translation by Tangyi_Chang version (1.03)"
     rom ( name "Wizardry Gaiden 3 - Yami no Seiten (Japan).gb" size 524288 crc a77df9cb md5 e1f712b4d9d4496e679c736c15895772 sha1 1f3586e46edc80e9f0602ba82ba3bba43d56c9f4 )
     comment "http://www.romhacking.net/translations/2252/"
 )
-
 game (
     name "Magic Knight Rayearth 2nd. - The Missing Colors (Japan) (SGB Enhanced) [T-En by Pearse Hillock]"
     description "English translation by Pearse Hillock version (0.99)"
     rom ( name "Magic Knight Rayearth 2nd. - The Missing Colors (Japan) (SGB Enhanced).gb" size 262144 crc 02209889 md5 8a0bd22a1e8c1c4259d12df1f1136b57 sha1 ff5606f210adc3f4bd14ddad91ec626bbf4cc89b )
     comment "http://www.romhacking.net/translations/2170/"
 )
-
 game (
     name "Wizardry Gaiden 1 - Joou no Junan (Japan) [T-En by Tangyi_Chang]"
     description "English translation by Tangyi_Chang version (1.1)"
     rom ( name "Wizardry Gaiden 1 - Joou no Junan (Japan).gb" size 262144 crc d97cfa52 md5 cb2ab3952aebf23b1c3dae2f453849d4 sha1 c544c0beeae3d4ec0e935126aecbd87a6bfb55aa )
     comment "http://www.romhacking.net/translations/2095/"
 )
-
 game (
     name "Super Mario Land 2 DX [Hack by toruzz]"
     description "Super Mario Land 2 DX hack by toruzz version (1.7)"

--- a/metadat/hacks/Nintendo - Nintendo 64.dat
+++ b/metadat/hacks/Nintendo - Nintendo 64.dat
@@ -1,135 +1,116 @@
 clrmamepro (
-	name "N64 hacks"
-	description "Hacks of Nintendo 64 games"
+    name "N64 hacks"
+    description "Hacks of Nintendo 64 games"
 )
-
 game (
-	name "SM64 Last Impact (USA)"
-	description "'Super Mario 64' hack by kaze version 1.1"
-	rom ( name "SM64 Last Impact V1.1.z64" size 67108864 crc 4ce7fa2a md5 836667a37dce62414064b62f5dafe9f6 sha1 78e3e86f679330a40a0480372f65c362179042ff )
+    name "SM64 Last Impact (USA)"
+    description "'Super Mario 64' hack by kaze version 1.1"
+    rom ( name "SM64 Last Impact V1.1.z64" size 67108864 crc 4ce7fa2a md5 836667a37dce62414064b62f5dafe9f6 sha1 78e3e86f679330a40a0480372f65c362179042ff )
 )
-
 game (
-	name "Custom Robo (Japan) [T-En by Star Trinket]"
-	description "'Custom Robo' translation by Star Trinket version 1.0"
-	rom ( name "Custom Robo (Japan).v64" size 16777216 crc 004e7c90 md5 93144df5a66c66f6c243471beb40b90b sha1 fde8e692c0aa4c3d34264319ab00601f83a7bd17 )
+    name "Custom Robo (Japan) [T-En by Star Trinket]"
+    description "'Custom Robo' translation by Star Trinket version 1.0"
+    rom ( name "Custom Robo (Japan).v64" size 16777216 crc 004e7c90 md5 93144df5a66c66f6c243471beb40b90b sha1 fde8e692c0aa4c3d34264319ab00601f83a7bd17 )
     comment "https://www.romhacking.net/translations/3237/"
 )
-
 game (
-	name "Custom Robo (Japan) [T-En by Star Trinket]"
-	description "'Custom Robo' translation by Star Trinket version 1.0"
-	rom ( name "Custom Robo (Japan).z64" size 16777216 crc fce6cdbc md5 f4a534469f81f493ffcfe4fcd6c4908a sha1 f8744703579f6ac2ee427ac50fbce5b95f11a918 )
+    name "Custom Robo (Japan) [T-En by Star Trinket]"
+    description "'Custom Robo' translation by Star Trinket version 1.0"
+    rom ( name "Custom Robo (Japan).z64" size 16777216 crc fce6cdbc md5 f4a534469f81f493ffcfe4fcd6c4908a sha1 f8744703579f6ac2ee427ac50fbce5b95f11a918 )
     comment "https://www.romhacking.net/translations/3237/"
 )
-
 game (
-	name "Custom Robo (Japan) [T-En by Star Trinket]"
-	description "'Custom Robo' translation by Star Trinket version 1.0"
-	rom ( name "Custom Robo (Japan).n64" size 16777216 crc 889b5295 md5 23860193df1bc9978a79a24122e5a64c sha1 6d545d26c910f31794c71b59b08fef54eab9ef3b )
+    name "Custom Robo (Japan) [T-En by Star Trinket]"
+    description "'Custom Robo' translation by Star Trinket version 1.0"
+    rom ( name "Custom Robo (Japan).n64" size 16777216 crc 889b5295 md5 23860193df1bc9978a79a24122e5a64c sha1 6d545d26c910f31794c71b59b08fef54eab9ef3b )
     comment "https://www.romhacking.net/translations/3237/"
 )
-
 game (
-	name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
-	description "'Wonder Project J2' translation by Ryu version 1.0"
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).v64" size 8912896 crc 38401ddb md5 9389cea162a3bbff3bf6f81284cc7786 sha1 cae4915a67d952f37a78e004d97d630bccc155a6 )
+    name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
+    description "'Wonder Project J2' translation by Ryu version 1.0"
+    rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).v64" size 8912896 crc 38401ddb md5 9389cea162a3bbff3bf6f81284cc7786 sha1 cae4915a67d952f37a78e004d97d630bccc155a6 )
     comment "tool64 can't convert to other byte orders after patching" 
     comment "https://www.romhacking.net/translations/1074/"
 )
-
 game (
-	name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
-	description "'Wonder Project J2' translation by Ryu version 1.0"
-	rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size 8912896 crc e1094e29 md5 3c02f56dd7b1a06be83a7a288755612f sha1 27c4c8f199d1045c697c5d79d216d33e1c715760 )
+    name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
+    description "'Wonder Project J2' translation by Ryu version 1.0"
+    rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size 8912896 crc e1094e29 md5 3c02f56dd7b1a06be83a7a288755612f sha1 27c4c8f199d1045c697c5d79d216d33e1c715760 )
     comment "tool64 can't convert to other byte orders after patching" 
     comment "https://www.romhacking.net/translations/1074/"
 )
-
 game (
-	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
-	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
-	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).v64" size 33554432 crc 0d17a138 md5 925a95b382faba3cc1aa7c8bd9f80dea sha1 e1721d90f49c2bef201b70416c2db78f21f1fd36 )
+    name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+    description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+    rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).v64" size 33554432 crc 0d17a138 md5 925a95b382faba3cc1aa7c8bd9f80dea sha1 e1721d90f49c2bef201b70416c2db78f21f1fd36 )
     comment "No reputable source"
 )
-
 game (
-	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
-	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
-	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).z64" size 33554432 crc 6a19ae94 md5 6e51b140a9b0c30d6f55ca7942a969fc sha1 e3906c919236dac6eba020b4b8c1df91fd725c5d )
+    name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+    description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+    rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).z64" size 33554432 crc 6a19ae94 md5 6e51b140a9b0c30d6f55ca7942a969fc sha1 e3906c919236dac6eba020b4b8c1df91fd725c5d )
     comment "No reputable source"
 )
-
 game (
-	name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
-	description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
-	rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).n64" size 33554432 crc 3fe26cce md5 352fe619ab9b4d29ae167c724fc41482 sha1 35d20ea6f9e52b21de80e25633bed45f4a2c13ae )
+    name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
+    description "'Tsumi to Batsu - Hoshi no Keishousha' english version extracted from Virtual Console"
+    rom ( name "Sin and Punishment - Successor of the Earth (USA) (Wii U Virtual Console).n64" size 33554432 crc 3fe26cce md5 352fe619ab9b4d29ae167c724fc41482 sha1 35d20ea6f9e52b21de80e25633bed45f4a2c13ae )
     comment "No reputable source"
 )
-
 game (
-	name "Super Mario Star Road (USA)"
-	description "'Super Mario 64' hack by Skelux Core final version"
-	rom ( name "Super Mario 64 (USA).v64" size 50331648 crc 646e8fff md5 caf803c77c9223b28b663af0b7e49a00 sha1 45e75bd3a1380bfeb874721c29581b47cfafa8d1 )
+    name "Super Mario Star Road (USA)"
+    description "'Super Mario 64' hack by Skelux Core final version"
+    rom ( name "Super Mario 64 (USA).v64" size 50331648 crc 646e8fff md5 caf803c77c9223b28b663af0b7e49a00 sha1 45e75bd3a1380bfeb874721c29581b47cfafa8d1 )
     comment "https://www.romhacking.net/hacks/873/"
 )
-
 game (
-	name "Super Mario Star Road (USA)"
-	description "'Super Mario 64' hack by Skelux Core final version"
-	rom ( name "Super Mario 64 (USA).z64" size 50331648 crc 2bd94dd7 md5 80e5019c9dd12648f909b3a5715ed580 sha1 469c6555a078dd831fa51ce601a653e44b3ce071 )
+    name "Super Mario Star Road (USA)"
+    description "'Super Mario 64' hack by Skelux Core final version"
+    rom ( name "Super Mario 64 (USA).z64" size 50331648 crc 2bd94dd7 md5 80e5019c9dd12648f909b3a5715ed580 sha1 469c6555a078dd831fa51ce601a653e44b3ce071 )
     comment "https://www.romhacking.net/hacks/873/"
 )
-
 game (
-	name "Super Mario Star Road (USA)"
-	description "'Super Mario 64' hack by Skelux Core final version"
-	rom ( name "Super Mario 64 (USA).n64" size 50331648 crc e40c674e md5 00f5bcdd597dbc575b8811d5430bb353 sha1 176bd6a50aee06fcc917c123f412fdc0c02dd922 )
+    name "Super Mario Star Road (USA)"
+    description "'Super Mario 64' hack by Skelux Core final version"
+    rom ( name "Super Mario 64 (USA).n64" size 50331648 crc e40c674e md5 00f5bcdd597dbc575b8811d5430bb353 sha1 176bd6a50aee06fcc917c123f412fdc0c02dd922 )
     comment "https://www.romhacking.net/hacks/873/"
 )
-
 game (
-	name "Zelda's Birthday (USA)"
-	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).v64" size 67108864 crc 65fceb4b md5 12fd4f2ac3ffe761be42e9fa63f75bc7 sha1 b001eec2adb2d80e9088909a417388c91dc8b545 )
+    name "Zelda's Birthday (USA)"
+    description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+    rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).v64" size 67108864 crc 65fceb4b md5 12fd4f2ac3ffe761be42e9fa63f75bc7 sha1 b001eec2adb2d80e9088909a417388c91dc8b545 )
     comment "https://www.romhacking.net/hacks/676/"
 )
-
 game (
-	name "Zelda's Birthday (USA)"
-	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).z64" size 67108864 crc 9dcde00e md5 9dc5ed87adf6e859391751ae124b44f5 sha1 881bbf199e24d37a291f95adc0000a89573bec70 )
+    name "Zelda's Birthday (USA)"
+    description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+    rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).z64" size 67108864 crc 9dcde00e md5 9dc5ed87adf6e859391751ae124b44f5 sha1 881bbf199e24d37a291f95adc0000a89573bec70 )
     comment "https://www.romhacking.net/hacks/676/"
 )
-
 game (
-	name "Zelda's Birthday (USA)"
-	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).n64" size 67108864 crc 4ed0632f md5 4d28941a4799a099d32f79f7ebca83f1 sha1 7095b2e825517b77a62f42198212565bd2a259c9 )
+    name "Zelda's Birthday (USA)"
+    description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition)' hack by jsa version 1.5"
+    rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug Edition).n64" size 67108864 crc 4ed0632f md5 4d28941a4799a099d32f79f7ebca83f1 sha1 7095b2e825517b77a62f42198212565bd2a259c9 )
     comment "https://www.romhacking.net/hacks/676/"
 )
-
 game (
-	name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
-	description "'Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
-	rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition).z64" size 33554432 crc 48124886 md5 7fc61f232811cd779d4789f71d55562c sha1 24207202d44e2a7fa5e4297187082945310bae0c )
+    name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+    description "'Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+    rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition).z64" size 33554432 crc 48124886 md5 7fc61f232811cd779d4789f71d55562c sha1 24207202d44e2a7fa5e4297187082945310bae0c )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )
-
 game (
-	name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
-	description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
-	rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition).z64" size 33554432 crc 339fc360 md5 6d79c2e17eb78ab9d6b40b49c6939949 sha1 800c27d8231a17c4321e801108893015b9ee22b2 )
+    name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+    description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+    rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition).z64" size 33554432 crc 339fc360 md5 6d79c2e17eb78ab9d6b40b49c6939949 sha1 800c27d8231a17c4321e801108893015b9ee22b2 )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )
-
 game (
-	name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
-	description "'Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
-	rom ( name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition).z64" size 33554432 crc 3d034499 md5 7f8386e3816db3ede468a4669fe7c978 sha1 f0fb78384331edf36e4daccd99571d4c8c605405 )
+    name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
+    description "'Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
+    rom ( name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition).z64" size 33554432 crc 3d034499 md5 7f8386e3816db3ede468a4669fe7c978 sha1 f0fb78384331edf36e4daccd99571d4c8c605405 )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )
-

--- a/metadat/hacks/Nintendo - Nintendo DS.dat
+++ b/metadat/hacks/Nintendo - Nintendo DS.dat
@@ -1,71 +1,61 @@
 clrmamepro (
-	name "Nintendo DS hacks"
-	description "Hacks of Nintendo DS games"
+    name "Nintendo DS hacks"
+    description "Hacks of Nintendo DS games"
 )
-
 game (
     name "Blood of Bahamut (Japan) [T-En by Aaron Tokunaga-Chmielowiec]"
     description "English translation by Aaron Tokunaga-Chmielowiec version (1.07)"
     rom ( name "Blood of Bahamut (Japan).nds" size 67108864 crc 6df95de4 md5 f951a883d307ea7e0a12aff54971a7a9 sha1 7d77c4f200d2942c78386896ab4855c543a19783 )
     comment "http://www.romhacking.net/translations/2560/"
 )
-
 game (
     name "Trauma Center Under the Knife 2 Wii Controls Hack [Hack by Greiga Master]"
     description "Trauma Center Under the Knife 2 Wii Controls Hack hack by Greiga Master version (1.01)"
     rom ( name "Trauma Center - Under the Knife 2 (USA).nds" size 57189404 crc c658f891 md5 2fbb88aa538bdf0de5f156dced62ead0 sha1 709dcb2f8da742cec229f83c9f1771cd0aec941d )
     comment "http://www.romhacking.net/hacks/1807/"
 )
-
 game (
     name "SaGa 3: Rulers of Time and Space - Shadow or Light [T-En by Cain and Easton West]"
     description "English translation by Cain and Easton West version (Beta 2.0.830)"
     rom ( name "SaGa 3 - Jikuu no Hasha - Shadow or Light (Japan) [b].nds" size 123213056 crc 2af5af5a md5 9c7a8a8865f74b1790c8f0aea3198f1c sha1 781a73bb0d75c0ded12edadcf9fca858c6e0c400 )
     comment "http://www.romhacking.net/translations/1705/"
 )
-
 game (
     name "Irozuki Tingle no Koi no Balloon Trip (Japan) [T-En by Team Tingle]"
     description "English translation by Team Tingle version (1.1)"
     rom ( name "Irozuki Tingle no Koi no Balloon Trip (Japan).nds" size 76248200 crc ce27be97 md5 9eeba755e421dc27b208c5f0b67b39fe sha1 8d7cbf9bb3006a215e6f8aba7615bee5f413227e )
     comment "http://www.romhacking.net/translations/3376/"
 )
-
 game (
     name "7th Dragon [T-En by Pokeytax]"
     description "English translation by Pokeytax version (1.01)"
     rom ( name "7th Dragon (Japan) [b].nds" size 134217728 crc 9dd36d0f md5 181ffe7d92d9b0e1e8f852317a0c1737 sha1 2e380c2b21f22d88454d1488095dbf016ba6b572 )
     comment "http://www.romhacking.net/translations/2176/"
 )
-
 game (
     name "SaGa 2 - Hihou Densetsu - Goddess of Destiny (Japan) [T-En by Crimson Nocturnal]"
     description "English translation by Crimson Nocturnal version (2.11)"
     rom ( name "SaGa 2 - Hihou Densetsu - Goddess of Destiny (Japan).nds" size 125207004 crc ba0f9202 md5 1523f3f334c9b37ff69756e329a6c483 sha1 b13750effc86369649b8aa999bba59ddaa56b758 )
     comment "http://www.romhacking.net/translations/1610/"
 )
-
 game (
     name "Tales of Innocence (Japan) [T-En by Kingcom and throughhim413]"
     description "English translation by Kingcom and throughhim413 version (1.0)"
     rom ( name "Tales of Innocence (Japan).nds" size 134217728 crc 186d0370 md5 0cde783d226ad82ddb8bffd98af4f0a3 sha1 750ebfc067e0d3147361c0e752fb2951212ed52b )
     comment "http://www.romhacking.net/translations/1594/"
 )
-
 game (
     name "Fire Emblem - Shin Monshou no Nazo - Hikari to Kage no Eiyuu (Japan) (Rev 1) (NDSi Enhanced) [b] [T-En by The Heroes of Shadow]"
     description "English translation by The Heroes of Shadow version (3.01)"
     rom ( name "Fire Emblem - Shin Monshou no Nazo - Hikari to Kage no Eiyuu (Japan) (Rev 1) (NDSi Enhanced) [b].nds" size 134217728 crc 889be26f md5 f3765a64b0c70d14ad10067c83505443 sha1 7f62fc579ab46133846126c114234ee8b4bd3b68 )
     comment "http://www.romhacking.net/translations/1764/"
 )
-
 game (
     name "Legend of Zelda Spirit Tracks D-Pad Controls [Hack by Greiga Master]"
     description "Legend of Zelda Spirit Tracks D-Pad Controls hack by Greiga Master version (1.01)"
     rom ( name "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es).nds" size 94096060 crc f846f7f3 md5 4b0882022b1d66f55cfbe68078b3cd83 sha1 7dd2f09473a2d049e01cc08491dd69f6ac71cc2b )
     comment "http://www.romhacking.net/hacks/2235/"
 )
-
 game (
     name "Castlevania: Dawn of Dignity (New Portraits Hack) [Hack by ShadowOne333 + 2 hacks]"
     description "Castlevania: Dawn of Dignity (New Portraits Hack) hack by ShadowOne333 version (1.1) + Castlevania: Dawn of Sorrow Fixed Luck hack by LagoLunatic version (1.0) + Castlevania: Dawn of Sorrow No Required Touch Screen hack by LagoLunatic version (1.1)"
@@ -74,14 +64,12 @@ game (
     comment "http://www.romhacking.net/hacks/3407/"
     comment "http://www.romhacking.net/hacks/3408/"
 )
-
 game (
     name "Gyakuten Kenji 2 (Japan) [T-En by Auryn]"
     description "English translation by Auryn version (Final V2)"
     rom ( name "Gyakuten Kenji 2 (Japan).nds" size 45165392 crc a1b255cf md5 3cf7bcf088149601d5a38742dd3da9ac sha1 2456f96e7d5f47f05479bc743fd235765a8e8668 )
     comment "http://www.romhacking.net/translations/2260/"
 )
-
 game (
     name "Legend of Zelda Phantom Hourglass D-Pad Patch [Hack by Greiga Master]"
     description "Legend of Zelda Phantom Hourglass D-Pad Patch hack by Greiga Master version (1.0)"

--- a/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
@@ -1,35 +1,29 @@
 clrmamepro (
-	name "NES hacks"
-	description "Romhacks of NES/Famicom games"
+    name "NES hacks"
+    description "Romhacks of NES/Famicom games"
 )
-
 game (
-	name "BattleCity (Japan) 4 Players Hack"
-	description "4 players hack by Ti version 1.3"
-	rom ( name "Battle_City_-_4_Players_Hack_(v1.3).nes" size 40976 crc 974a5902 md5 b9fd5c27bf82200b3a6827cf3bc1bc2b sha1 5a2a37462fce65d83fdcae20c5e49aaa34025645 )
+    name "BattleCity (Japan) 4 Players Hack"
+    description "4 players hack by Ti version 1.3"
+    rom ( name "Battle_City_-_4_Players_Hack_(v1.3).nes" size 40976 crc 974a5902 md5 b9fd5c27bf82200b3a6827cf3bc1bc2b sha1 5a2a37462fce65d83fdcae20c5e49aaa34025645 )
 )
-
 game (
-	name "Battletoads & Double Dragon - On Ragnarok (USA)"
-	description "'Battletoads' hack by Corpse Grinder version 1.2"
-	rom ( name "Battletoads_Double_Dragon_-_On_Ragnarok.nes" size 524304 crc aa42045e md5 fe1e4900fa16b0b0ba4f21ec9f632cad sha1 db810ed0b5ab7585ff82c8de2e9dad8e25a007db )
+    name "Battletoads & Double Dragon - On Ragnarok (USA)"
+    description "'Battletoads' hack by Corpse Grinder version 1.2"
+    rom ( name "Battletoads_Double_Dragon_-_On_Ragnarok.nes" size 524304 crc aa42045e md5 fe1e4900fa16b0b0ba4f21ec9f632cad sha1 db810ed0b5ab7585ff82c8de2e9dad8e25a007db )
 )
-
 game (
-	name "DuckTales 2 (USA) Two Players Hack"
-	description "2 players hack by Ti version 1.2"
-	rom ( name "Duck_Tales_2_Two_Players_Hack_(v1.2).nes" size 262160 crc 910ab4c7 md5 21f9353652fb32c8cf4abe5023bbb2ff sha1 8f182a0f324b8294957766b88e57c7eab73f789d )
+    name "DuckTales 2 (USA) Two Players Hack"
+    description "2 players hack by Ti version 1.2"
+    rom ( name "Duck_Tales_2_Two_Players_Hack_(v1.2).nes" size 262160 crc 910ab4c7 md5 21f9353652fb32c8cf4abe5023bbb2ff sha1 8f182a0f324b8294957766b88e57c7eab73f789d )
 )
-
 game (
-	name "Metroid - Rogue Dawn (USA)"
-	description "'Metroid' hack by snarfblam, Optomon and Grimlock version 1.10"
-	rom ( name "Metroid_Rogue_Dawn_V1.10.nes" size 786448 crc a24fd9e7 md5 6fc5e68df69d5c91366427113a8ef414 sha1 6c458f25521a985ea0b87db280eadf1297e798de )
+    name "Metroid - Rogue Dawn (USA)"
+    description "'Metroid' hack by snarfblam, Optomon and Grimlock version 1.10"
+    rom ( name "Metroid_Rogue_Dawn_V1.10.nes" size 786448 crc a24fd9e7 md5 6fc5e68df69d5c91366427113a8ef414 sha1 6c458f25521a985ea0b87db280eadf1297e798de )
 )
-
 game (
-	name "Sonic The Hedgehog (USA) Improvement"
-	description "'Somari The Adventurer' hack by the jabu, Ti and Sics"
-	rom ( name "Sonic_NES_Improvement_plus_Music_plus_Graphics.nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
+    name "Sonic The Hedgehog (USA) Improvement"
+    description "'Somari The Adventurer' hack by the jabu, Ti and Sics"
+    rom ( name "Sonic_NES_Improvement_plus_Music_plus_Graphics.nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
 )
-

--- a/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
@@ -1,40 +1,34 @@
 clrmamepro (
-	name "SNES hacks"
-	description "Romhacks of Super Nintendo / Super Famicom games"
+    name "SNES hacks"
+    description "Romhacks of Super Nintendo / Super Famicom games"
 )
-
 game (
-	name "Banzai Mario World (USA)"
-	description "'Super Mario World' hack by GbreezeSunset"
-	rom ( name "Banzai Mario World.sfc" size 2097152 crc 922d3660 md5 1daa2333725eec3e0f0ec077c2395755 sha1 ddc5df0b72a3a7b8e4904649087991ad3ab694d8 )
+    name "Banzai Mario World (USA)"
+    description "'Super Mario World' hack by GbreezeSunset"
+    rom ( name "Banzai Mario World.sfc" size 2097152 crc 922d3660 md5 1daa2333725eec3e0f0ec077c2395755 sha1 ddc5df0b72a3a7b8e4904649087991ad3ab694d8 )
 )
-
 game (
-	name "Chrono Trigger - Crimson Echoes (USA)"
-	description "'Chrono Trigger' hack by Kajam Laboratories"
-	rom ( name "ChronoTrigger - Crimson Echoes.smc" size 6291968 crc 2ebceb79 md5 24955542c1ea9c5bbd21a07479e64047 sha1 a43632026948df3d288f0bb03f6c83ee8e76bdd5 )
+    name "Chrono Trigger - Crimson Echoes (USA)"
+    description "'Chrono Trigger' hack by Kajam Laboratories"
+    rom ( name "ChronoTrigger - Crimson Echoes.smc" size 6291968 crc 2ebceb79 md5 24955542c1ea9c5bbd21a07479e64047 sha1 a43632026948df3d288f0bb03f6c83ee8e76bdd5 )
 )
-
 game (
-	name "Mario & Luigi - Kola Kingdom Quest (USA)"
-	description "'Super Mario World' hack by GammaV"
-	rom ( name "KKQFinalFixed.sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )
+    name "Mario & Luigi - Kola Kingdom Quest (USA)"
+    description "'Super Mario World' hack by GammaV"
+    rom ( name "KKQFinalFixed.sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )
 )
-
 game (
-	name "NBA Jam 2K17 (USA)"
-	description "'NBA Jam - Tournament Edition' hack by Ethan Miller"
-	rom ( name "NBA Jam 2k17.SMC" size 3145728 crc 5bd9eb28 md5 4675c4f100784f83ada83b74bb24a50a sha1 932d4fe315f06001de82ab2dc82d755363bb343a )
+    name "NBA Jam 2K17 (USA)"
+    description "'NBA Jam - Tournament Edition' hack by Ethan Miller"
+    rom ( name "NBA Jam 2k17.SMC" size 3145728 crc 5bd9eb28 md5 4675c4f100784f83ada83b74bb24a50a sha1 932d4fe315f06001de82ab2dc82d755363bb343a )
 )
-
 game (
-	name "Oh No! More Zombies Ate My Neighbors! (USA)"
-	description "'Zombies Ate My Neighbors' hack by Stanley_Decker and sloat version 1.0"
-	rom ( name "Oh No! More Zombies Ate My Neighbors!.sfc" size 4194304 crc d218147c md5 7f44a65cf20b213502314fc118b5a6f4 sha1 917b2c381e0ed77b8c3f196171d7285fce21a090 )
+    name "Oh No! More Zombies Ate My Neighbors! (USA)"
+    description "'Zombies Ate My Neighbors' hack by Stanley_Decker and sloat version 1.0"
+    rom ( name "Oh No! More Zombies Ate My Neighbors!.sfc" size 4194304 crc d218147c md5 7f44a65cf20b213502314fc118b5a6f4 sha1 917b2c381e0ed77b8c3f196171d7285fce21a090 )
 )
-
 game (
-	name  "Super Boss Gaiden (J)"
-	description "Super Boss Gaiden (J)"
-	rom ( name "Super Boss Gaiden (J).sfc" size 524288 crc 188f152b md5 73abcd4808657a6d546652cfac4683b5 sha1 65b22d721b148c7863d315cd7bb78a851342d009 )
+    name  "Super Boss Gaiden (J)"
+    description "Super Boss Gaiden (J)"
+    rom ( name "Super Boss Gaiden (J).sfc" size 524288 crc 188f152b md5 73abcd4808657a6d546652cfac4683b5 sha1 65b22d721b148c7863d315cd7bb78a851342d009 )
 )

--- a/metadat/hacks/Sega - Game Gear.dat
+++ b/metadat/hacks/Sega - Game Gear.dat
@@ -1,9 +1,7 @@
 clrmamepro (
-	name "Game Gear hacks"
-	description "Romhacks of Sega Game Gear games"
+    name "Game Gear hacks"
+    description "Romhacks of Sega Game Gear games"
 )
-
-
 game (
     name "Phantasy Star Gaiden (Japan) [T-En by Dynamic-Designs and Taskforce]"
     description "English translation by Dynamic-Designs and Taskforce version (1.012)"

--- a/metadat/hacks/Sega - Master System - Mark III.dat
+++ b/metadat/hacks/Sega - Master System - Mark III.dat
@@ -1,8 +1,7 @@
 clrmamepro (
-	name "Master System hacks"
-	description "Romhacks of Sega Master System / Sega Mark III games"
+    name "Master System hacks"
+    description "Romhacks of Sega Master System / Sega Mark III games"
 )
-
 game (
     name "Golvellius - SRAM save [Hack by Ichigobankai]"
     description "Golvellius - SRAM save hack by Ichigobankai version (1.0)"

--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -1,63 +1,52 @@
 clrmamepro (
-	name "Mega Drive hacks"
-	description "Romhacks of Sega Mega Drive / Sega Genesis games"
+    name "Mega Drive hacks"
+    description "Romhacks of Sega Mega Drive / Sega Genesis games"
 )
-
 game (
-	name "Mega Man - The Wily Wars (Europe) Move-Shoot Hack"
-	description "Hacks for 60FPS, SRAM support and NES-like movement/shooting"
-	rom ( name "Mega Man - The Wily Wars (move-shoot hack).bin" size 2097152 crc 1d9b9c91 md5 c13a4784a8bce87bb514d6f24a05d2f1 sha1 99cb17c2b141c21b5661049d3811ebf90fde40b2 )
+    name "Mega Man - The Wily Wars (Europe) Move-Shoot Hack"
+    description "Hacks for 60FPS, SRAM support and NES-like movement/shooting"
+    rom ( name "Mega Man - The Wily Wars (move-shoot hack).bin" size 2097152 crc 1d9b9c91 md5 c13a4784a8bce87bb514d6f24a05d2f1 sha1 99cb17c2b141c21b5661049d3811ebf90fde40b2 )
 )
-
 game (
-	name "Mortal Kombat II Unlimited - Enhanced Colors (USA)"
-	description "'Mortal Kombat II' hack by Smoke and Pyron"
-	rom ( name "MK2U_EC_Pyron.bin" size 4136840 crc 1867b4d9 md5 3f1aa570edddc5c5e2879a94d6f62e11 sha1 13de727bacf8c644e3df7a96cf212b5a1a899455 )
+    name "Mortal Kombat II Unlimited - Enhanced Colors (USA)"
+    description "'Mortal Kombat II' hack by Smoke and Pyron"
+    rom ( name "MK2U_EC_Pyron.bin" size 4136840 crc 1867b4d9 md5 3f1aa570edddc5c5e2879a94d6f62e11 sha1 13de727bacf8c644e3df7a96cf212b5a1a899455 )
 )
-
 game (
-	name "Rock n' Roll Racing (USA) Hack"
-	description "Hack by Ti version 15"
-	rom ( name "Rock_n'_Roll_Racing_Hack_v15.bin" size 2097152 crc 205f4afc md5 bd4bae13a6fed5d2801face18572fab2 sha1 bedfa111535fbeea0b75999b799317415bc4bab3 )
+    name "Rock n' Roll Racing (USA) Hack"
+    description "Hack by Ti version 15"
+    rom ( name "Rock_n'_Roll_Racing_Hack_v15.bin" size 2097152 crc 205f4afc md5 bd4bae13a6fed5d2801face18572fab2 sha1 bedfa111535fbeea0b75999b799317415bc4bab3 )
 )
-
 game (
-	name "Sonic 3 Complete (USA)"
-	description "'Sonic 3 & Knuckles 3' hack version 130810"
-	rom ( name "Sonic3C.gen" size 3932160 crc 2bd564b1 md5 153b6d32026993569b16ff89c53197a3 sha1 4461ed4a94b93653905c08e201f7c11a128e5a47 )
+    name "Sonic 3 Complete (USA)"
+    description "'Sonic 3 & Knuckles 3' hack version 130810"
+    rom ( name "Sonic3C.gen" size 3932160 crc 2bd564b1 md5 153b6d32026993569b16ff89c53197a3 sha1 4461ed4a94b93653905c08e201f7c11a128e5a47 )
 )
-
 game (
-	name "Street Fighter II' - Champion Edition Arcade (USA)"
-	description "'Street Fighter II' - Special Champion Edition' hack by Lord Hiryu"
-	rom ( name "Street Fighter II' - Arcade Champion Edition.bin" size 3145728 crc 6de3eea9 md5 4d808b2dc08eafee0f88a1ddb2fe9c28 sha1 dcaeba1b980ddab6cd51447b4f075ba63960fe34 )
+    name "Street Fighter II' - Champion Edition Arcade (USA)"
+    description "'Street Fighter II' - Special Champion Edition' hack by Lord Hiryu"
+    rom ( name "Street Fighter II' - Arcade Champion Edition.bin" size 3145728 crc 6de3eea9 md5 4d808b2dc08eafee0f88a1ddb2fe9c28 sha1 dcaeba1b980ddab6cd51447b4f075ba63960fe34 )
 )
-
 game (
-	name "Street Fighter II' - Special Champion Edition (USA) PCM Driver Fix"
-	description "Rewritten Z80 PCM driver by Stef"
-	rom ( name "sf2_mod_v7.bin" size 3145728 crc 92b46306 md5 9b4529a4f713c733e5a187bc7b673eca sha1 1d6e640007edbec5e4e7a7d37d48e12a9029fa00 )
+    name "Street Fighter II' - Special Champion Edition (USA) PCM Driver Fix"
+    description "Rewritten Z80 PCM driver by Stef"
+    rom ( name "sf2_mod_v7.bin" size 3145728 crc 92b46306 md5 9b4529a4f713c733e5a187bc7b673eca sha1 1d6e640007edbec5e4e7a7d37d48e12a9029fa00 )
 )
-
 game (
-	name "Super Street Fighter II (USA) PCM Driver Fix"
-	description "Rewritten Z80 PCM driver by Stef"
-	rom ( name "SSF2_mod.bin" size 5242880 crc e8612c91 md5 3ed52bd4b63f0438ea41306aec08afcc sha1 479223c0efd45a1c88298dcd231af1c6f347f9f1 )
+    name "Super Street Fighter II (USA) PCM Driver Fix"
+    description "Rewritten Z80 PCM driver by Stef"
+    rom ( name "SSF2_mod.bin" size 5242880 crc e8612c91 md5 3ed52bd4b63f0438ea41306aec08afcc sha1 479223c0efd45a1c88298dcd231af1c6f347f9f1 )
 )
-
 game (
-	name "Ultimate Mortal Kombat 3 (USA) Hack"
-	description "Hack by Nemesis_c, r57shell and Smoke version 0.6"
-	rom ( name "Ultimate_Mortal_Kombat_3_Hack_v0-6.bin" size 6248922 crc d8c152ff md5 3ef38ef9ec6fe16526762dff2966cd05 sha1 072c891f23e3e1f960a712fde08b01a9af75c9cb )
+    name "Ultimate Mortal Kombat 3 (USA) Hack"
+    description "Hack by Nemesis_c, r57shell and Smoke version 0.6"
+    rom ( name "Ultimate_Mortal_Kombat_3_Hack_v0-6.bin" size 6248922 crc d8c152ff md5 3ef38ef9ec6fe16526762dff2966cd05 sha1 072c891f23e3e1f960a712fde08b01a9af75c9cb )
 )
-
-
 game (
-	name "Ultimate Mortal Kombat Trilogy (USA)"
-	description "'Ultimate Mortal Kombat 3' hack by KABAL_MK version 5125"
-	rom ( name "(5125)UMKT(HACK_23)_fixed.bin" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
+    name "Ultimate Mortal Kombat Trilogy (USA)"
+    description "'Ultimate Mortal Kombat 3' hack by KABAL_MK version 5125"
+    rom ( name "(5125)UMKT(HACK_23)_fixed.bin" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
 )
-
 game (
     name "El Viento Enhancement [Hack by M.I.J.E.T.]"
     description "El Viento Enhancement hack by M.I.J.E.T. version (101010)"

--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -1,38 +1,33 @@
 clrmamepro (
-	name "Saturn hacks"
-	description "Romhacks of Saturn games"
+    name "Saturn hacks"
+    description "Romhacks of Saturn games"
 )
-
 game (
-	name "Shining Force III Collection Deluxe Volume 1 (Japan) [T-En by Shining Force Central]"
-	description "Shining Force III compilation by paul_met and translation Shining Force Central version (1.9)"
-	rom ( name "Shining Force III Collection Deluxe Volume 1.bin" size 735379456 crc 827967f3 md5 d7ff366c67fc9e431ba76da7b4b15c09 sha1 62749a78740f6ca4b909bf008c2787304d9bbda0 )
+    name "Shining Force III Collection Deluxe Volume 1 (Japan) [T-En by Shining Force Central]"
+    description "Shining Force III compilation by paul_met and translation Shining Force Central version (1.9)"
+    rom ( name "Shining Force III Collection Deluxe Volume 1.bin" size 735379456 crc 827967f3 md5 d7ff366c67fc9e431ba76da7b4b15c09 sha1 62749a78740f6ca4b909bf008c2787304d9bbda0 )
     comment "No reputable source"
     comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
 )
-
 game (
-	name "Shining Force III Collection Deluxe Volume 2 (Japan) [T-En by Shining Force Central]"
-	description "Shining Force III compilation by paul_met and translation by Shining Force Central version (1.9)"
-	rom ( name "Shining Force III Collection Deluxe Volume 2.bin" size 733184000 crc 58b07ef5 md5 8130bfedacfa032395a7095d3799289e sha1 3fc0605781f8462344b3262207755b8074213ddd )
+    name "Shining Force III Collection Deluxe Volume 2 (Japan) [T-En by Shining Force Central]"
+    description "Shining Force III compilation by paul_met and translation by Shining Force Central version (1.9)"
+    rom ( name "Shining Force III Collection Deluxe Volume 2.bin" size 733184000 crc 58b07ef5 md5 8130bfedacfa032395a7095d3799289e sha1 3fc0605781f8462344b3262207755b8074213ddd )
     comment "No reputable source"
     comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
 )
-
 game (
     name "Asuka 120% Limit Over - easy patch [Hack by SCO]"
     description "Asuka 120% Limit Over - easy patch hack by SCO version (1.0)"
     rom ( name "Asuka 120% Limited - Burning Fest. Limited (Japan) (Track 01).bin" size 62095152 crc bd23db54 md5 4bcce0bfcc29cb358f7c2e2c8682f1a9 sha1 b9723e2277933df5fba915bcf160253952ba5fdd )
     comment "http://www.romhacking.net/hacks/3983/"
 )
-
 game (
     name "Dragon Force II - Kami Sarishi Daichi ni (Japan) [T-En by Verve Fanworks]"
     description "English translation by Verve Fanworks version (1.04)"
     rom ( name "Dragon Force II - Kami Sarishi Daichi ni (Japan) (Track 1).bin" size 528943104 crc 6feb6044 md5 4b99223f62098f37a5a6cfa69653b684 sha1 62f553003bb9fbd9d16897334678fdf289114efe )
     comment "http://www.romhacking.net/translations/1622/"
 )
-
 game (
     name "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) [Hack by paul_met]"
     description "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) hack by paul_met version (1.0)"

--- a/metadat/hacks/Sony - PlayStation Portable.dat
+++ b/metadat/hacks/Sony - PlayStation Portable.dat
@@ -1,92 +1,79 @@
 clrmamepro (
-	name "PlayStation Portable hacks"
-	description "Romhacks of Sony PlayStation Portable games"
+    name "PlayStation Portable hacks"
+    description "Romhacks of Sony PlayStation Portable games"
 )
-
 game (
     name "SD Gundam - G Generation Over World (Japan) (v1.01) [T-En by Izzul95]"
     description "English translation by Izzul95 version (1.0.1)"
     rom ( name "SD Gundam - G Generation Over World (Japan) (v1.01).iso" size 2095632384 crc 7e662ae7 md5 cfc229a78b1afbfc935e9769ccd8a062 sha1 a1040bc899cdd552ced158e2a12e112693cbde57 )
     comment "http://www.romhacking.net/translations/3029/"
 )
-
 game (
     name "War of the Lions Tweak [Hack by Tzepish]"
     description "War of the Lions Tweak hack by Tzepish version (1.06)"
     rom ( name "Final Fantasy Tactics - The War of the Lions (USA).iso" size 418873344 crc 53d278e6 md5 00cb18f7d384e0e562f9bc8d322fb743 sha1 0e4d0aaf884459641b4bc77216badb1d5167d036 )
     comment "http://www.romhacking.net/hacks/916/"
 )
-
 game (
     name "R-Type Tactics II - Operation Bitter Chocolate (Japan) (v1.05) [T-En by Isourou-san]"
     description "English translation by Isourou-san version (1.1)"
     rom ( name "R-Type Tactics II - Operation Bitter Chocolate (Japan) (v1.05).iso" size 1213214720 crc 854a2766 md5 e107c8c27336205276c5a084c62713c1 sha1 ccc66bea9d729bea6195151631bfb0cd4a410b76 )
     comment "http://www.romhacking.net/translations/3136/"
 )
-
 game (
     name "Pucelle, La - Ragnarok (Japan) (v1.01) [T-En by ChepChep]"
     description "English translation by ChepChep version (1.0.1)"
     rom ( name "Pucelle, La - Ragnarok (Japan) (v1.01).iso" size 858937344 crc b6c71667 md5 891cdb7e51c78e0241cff5e8b3db3097 sha1 705cf33da482a2d5fd74ce113ac58909c828a140 )
     comment "http://www.romhacking.net/translations/2130/"
 )
-
 game (
     name "Ys vs. Sora no Kiseki - Alternative Saga (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (2)"
     rom ( name "Ys vs. Sora no Kiseki - Alternative Saga (Japan) (v1.01).iso" size 1344208896 crc efd03f80 md5 30432759501c18a0a583eb8e563add1b sha1 f49521655fa1657e7231a46956104c517dd21d6a )
     comment "http://www.romhacking.net/translations/2841/"
 )
-
 game (
     name "Phantom Kingdom Portable (Japan) (v1.03) [T-En by ChepChep]"
     description "English translation by ChepChep version (0.9.3)"
     rom ( name "Phantom Kingdom Portable (Japan) (v1.03).iso" size 712542208 crc 34745d2d md5 fa42bdca4b4afafd17cff002f023758d sha1 85fd472badfebd9fbd93b6cf2dff681288583cde )
     comment "http://www.romhacking.net/translations/2328/"
 )
-
 game (
     name "Monster Hunter Portable 3rd (Japan) (v1.02) [T-En by Team Maverick ONE]"
     description "English translation by Team Maverick ONE version (5.0)"
     rom ( name "Monster Hunter Portable 3rd (Japan) (v1.02).iso" size 1207140352 crc a2e67cf4 md5 fcc3518fca48ff5bcf0aa31f18885615 sha1 cac2408a7a2dc08d330171136382ee266a2c78a4 )
     comment "http://www.romhacking.net/translations/2043/"
 )
-
 game (
     name "Final Fantasy Reishiki (Japan) (v1.01) [T-En by Skybladecloud]"
     description "English translation by Skybladecloud version (1.0)"
     rom ( name "Final Fantasy Reishiki (Japan) (v1.01) (Disc 1).iso" size 3158917120 crc 4b1b2a06 md5 1e0775832f2364bd30bb952d880341d3 sha1 286699cc680006dfa0982c51fcc35741f18d1399 )
     comment "http://www.romhacking.net/translations/1966/"
 )
-
 game (
     name "Samuraidou Portable (Japan) (v1.02) [T-En by aka translations]"
     description "English translation by aka translations version (0.02)"
     rom ( name "Samuraidou Portable (Japan) (v1.02).iso" size 323092480 crc bd789229 md5 6a980505e015ff7629a8699b7cd21e8b sha1 72f9d631756c886e9d0673ba34a4edfc3d4d1e7a )
     comment "http://www.romhacking.net/translations/2014/"
 )
-
 game (
     name "Yuusha 30 Second (Japan) (v1.02) [T-En by ChepChep]"
     description "English translation by ChepChep version (1.0.2)"
     rom ( name "Yuusha 30 Second (Japan) (v1.02).iso" size 396761088 crc 7abae927 md5 44efc8a601b385a221a07fb6d6ef838f sha1 2be0a73b8951254beb2d5f06bbfb1215b761d1b4 )
     comment "http://www.romhacking.net/translations/2635/"
 )
-
 game (
     name "Nayuta no Kiseki (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (4.15)"
     rom ( name "Nayuta no Kiseki (Japan) (v1.01).iso" size 831373312 crc 88c08fc1 md5 6cc975153b7998db4242baa17eb8d276 sha1 01e02d60dc7a05683d29c45a10cce41083cd809b )
     comment "http://www.romhacking.net/translations/3560/"
 )
-
 game (
     name "Senjou no Valkyria 3 - Extra Edition (Japan) [T-En by Valkyria Chronicles 3 Translation Project]"
     description "English translation by Valkyria Chronicles 3 Translation Project version (Patch 2)"
     rom ( name "Senjou no Valkyria 3 - Extra Edition (Japan).iso" size 1771300864 crc 190394de md5 dd0e198cb5414fc11601f20bec1f48fa sha1 1a69eec680c186efdb0225e27302aaa1104a0ee3 )
     comment "http://www.romhacking.net/translations/3562/"
 )
-
 game (
     name "Last Ranker (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (1)"

--- a/metadat/hacks/Sony - PlayStation.dat
+++ b/metadat/hacks/Sony - PlayStation.dat
@@ -1,148 +1,127 @@
 clrmamepro (
-	name "PlayStation hacks"
-	description "Romhacks of Sony PlayStation games"
+    name "PlayStation hacks"
+    description "Romhacks of Sony PlayStation games"
 )
-
 game (
     name "Front Mission 2 (Japan) (v1.1) [T-En by pedr0]"
     description "English translation by pedr0 version (1.1)"
     rom ( name "Front Mission 2 (Japan) (v1.1).bin" size 426215328 crc 3da0bff7 md5 6f50e2380738863e9d6fcadb6fac6b63 sha1 702767d63d81f614c6d5cd912f015c786d86ce96 )
     comment "No reputable source"
 )
-
 game (
     name "Persona 2 - Tsumi (Japan) (v1.0) [T-En by Gemini]"
     description "English translation by Gemini version (1.0a)"
     rom ( name "Persona 2 - Tsumi (Japan) (v1.0).bin" size 691925472 crc 870ceff9 md5 11b188975894f2e4062ac773a9e9c153 sha1 cd3521fab99346ada2f09391b1c415429fde2b1c )
     comment "http://www.romhacking.net/translations/1249/"
 )
-
 game (
     name "iS - Internal Section (Japan) [T-En by GameHacking.org]"
     description "English translation by GameHacking.org version (1.02)"
     rom ( name "iS - Internal Section (Japan).bin" size 248107776 crc 1ec73120 md5 58785f169abf5b14bfffff8716bcb7ad sha1 a787c7f0118d07879d3e50908947e7e8c035b7de )
     comment "http://www.romhacking.net/translations/1265/"
 )
-
 game (
     name "Asuncia - Majou no Jubaku (Japan) [T-En by John Osborne]"
     description "English translation by John Osborne version (1)"
     rom ( name "Asuncia - Majou no Jubaku (Japan) (Track 01).bin" size 122529792 crc 871fd606 md5 584fc0933909ae1636255bc9649cb719 sha1 de7d3ac31150f0112d633d3a763ffb9c8aa6c818 )
     comment "http://www.romhacking.net/translations/3393/"
 )
-
 game (
     name "Fantastic Night Dreams - Cotton Original (Japan) [T-En by RIP Translations]"
     description "English translation by RIP Translations version (1.10)"
     rom ( name "Fantastic Night Dreams - Cotton Original (Japan).bin" size 39273696 crc 3082745a md5 0b84dff9eb045321f3c1e60bf861280a sha1 9252d11b1487756c8a37877f90655ded285be9da )
     comment "http://www.romhacking.net/translations/265/"
 )
-
 game (
     name "King's Field (Japan) [T-En by John Osborne]"
     description "English translation by John Osborne version (1.0)"
     rom ( name "King's Field (Japan).bin" size 30378432 crc 5f9be6e1 md5 c56cfb36f19f2608d3c180c104ace9dd sha1 c667b5b2dfba697c338783fe3d351f7910882152 )
     comment "https://www.romhacking.net/translations/1067/"
 )
-
 game (
     name "Policenauts (Japan) (Disc 1) [T-En by JunkerHQ]"
     description "English translation by JunkerHQ version (1.0)"
     rom ( name "Policenauts (Japan) (Disc 1).bin" size 748928544 crc 0db7d7e8 md5 65977ae8b63042475730e6efb6a5a8a6 sha1 3aa1fe0f2175dee26f66175de2a1ffe6d385ee95 )
     comment "http://www.romhacking.net/translations/1422/"
 )
-
 game (
     name "Policenauts (Japan) (Disc 2) [T-En by JunkerHQ]"
     description "English translation by JunkerHQ version (1.0)"
     rom ( name "Policenauts (Japan) (Disc 2).bin" size 613822608 crc 272ca545 md5 3b6bf3ce8230da37b8a717b6e892b457 sha1 e23d6395e0761e170bce24686c4eda289c159319 )
     comment "http://www.romhacking.net/translations/1422/"
 )
-
 game (
     name "Echo Night #2 - Nemuri no Shihaisha (Japan) [T-En by Gemini and Tom]"
     description "English translation by Gemini and Tom version (1.0a)"
     rom ( name "Echo Night 2 (Japan).bin" size 346863552 crc 3f73164a md5 68d101c1650952a49d66d66eb9b772ec sha1 e87ec671a337bcd9b7da537b8901a500e6ed5ee5 )
     comment "http://www.romhacking.net/translations/2380/"
 )
-
 game (
     name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) [T-En by Gemini]"
     description "English translation by Gemini version (1.0)"
     rom ( name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) (Track 1).bin" size 545440560 crc d42bc703 md5 a79f24c94d9843ef903564a9e9c56356 sha1 3ef656b04d490b66f2babfbf601e1cc6b73b30e2 )
     comment "http://www.romhacking.net/translations/1427/"
 )
-
 game (
     name "Super Robot Taisen Alpha Gaiden (Japan) (Shokai Genteiban) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (0.95b)"
     rom ( name "Super Robot Taisen Alpha Gaiden (Japan) (v1.1).bin" size 718394880 crc 52df8488 md5 bb73db766fbd2d7d2ad089104ca5b956 sha1 64198b5ce52c117b30ce044ffdbad19419a622b3 )
     comment "http://www.romhacking.net/translations/859/"
 )
-
 game (
     name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1) [T-En by Team NEMO]"
     description "English translation by Team NEMO version (2.0)"
     rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1).bin" size 732224640 crc f0fc5ae7 md5 b075b732f61371efe680323c21390204 sha1 c69975892d0a19f952018d375be52adf38fe1e2c )
     comment "http://www.romhacking.net/translations/2307/"
 )
-
 game (
     name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1) [T-En by Team NEMO]"
     description "English translation by Team NEMO version (2.0)"
     rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1).bin" size 724512432 crc 0b2f796b md5 15f7580eebae2fab6381a4c65450a75f sha1 cfc3e5e96ae93dafce3fbde46ebd4bb4310f0d4b )
     comment "http://www.romhacking.net/translations/2307/"
 )
-
 game (
     name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1) [T-En by NoOneee]"
     description "English translation by NoOneee version (1.0)"
     rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1).bin" size 477180816 crc 51a2c51b md5 934ef37fb41fd3acad685e4e1bffde05 sha1 7e69656048f01a36f46b40b239257ebee4d089e6 )
     comment "http://www.romhacking.net/translations/2927/"
 )
-
 game (
     name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2) [T-En by NoOneee]"
     description "English translation by NoOneee version (1.0)"
     rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2).bin" size 455354256 crc 131f8b49 md5 c8f81e55451ec07c90414cba0a45a471 sha1 f1a79dc3db9ef90c152bfeb51f2fcc0b46cb0277 )
     comment "http://www.romhacking.net/translations/2927/"
 )
-
 game (
     name "Brigandine - Grand Edition (Japan) (Disc 2) [T-En by John Osborne]"
     description "English translation by John Osborne version (8)"
     rom ( name "Brigandine - Grand Edition (Japan) (Disc 2).bin" size 751746240 crc 11fa0e02 md5 e497d63caf18b8387d43022ef2c6c103 sha1 bfddf6904d8d0827e63ff51b23ddc2dbcd265192 )
     comment "https://www.romhacking.net/translations/3236/"
 )
-
 game (
     name "Brigandine - Grand Edition (Japan) (Disc 1) [T-En by John Osborne]"
     description "English translation by John Osborne version (8)"
     rom ( name "Brigandine - Grand Edition (Japan) (Disc 1).bin" size 751720368 crc 4d719816 md5 fc3eb17e3451a2fa9f8494842f1a0290 sha1 8d494e8d3616b285fd453d78e7f945970e1c3268 )
     comment "https://www.romhacking.net/translations/3236/"
 )
-
 game (
     name "Clock Tower - The First Fear (Japan) [T-En by arcraith]"
     description "English translation by arcraith version (1.1)"
     rom ( name "Clock Tower - The First Fear (Japan) (Track 1).bin" size 75750864 crc f3ced589 md5 83adf3cdb6c46b3e084dec6dfb213295 sha1 f20aaf6d52ba2acee483445a8039b85e6f1492d4 )
     comment "https://www.romhacking.net/translations/2337/"
 )
-
 game (
     name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) [T-En by Kil]"
     description "English translation by Kil version (1.3)"
     rom ( name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) (Track 1).bin" size 576338784 crc 946999e1 md5 1740cc952d6f29a682dbc218e061d081 sha1 77b0d822adb68ebbdd5a98a97894d55f340f5b79 )
     comment "http://www.romhacking.net/translations/1711/"
 )
-
 game (
     name "Castlevania: Symphony of the Night - Quality hack [Hack by paul_met]"
     description "Castlevania: Symphony of the Night - Quality hack hack by paul_met version (1.2)"
     rom ( name "Castlevania - Symphony of the Night (USA) (Track 1).bin" size 538655040 crc 0431c247 md5 6674f4a75ea11fd9422669f247ec27fd sha1 1fa7cd542e15f9ce281e83320eedd24daace79e8 )
     comment "http://www.romhacking.net/hacks/3606/"
 )
-
 game (
     name "Yutona Eiyuu Senki - TearRingSaga (Japan) [T-En by Aethin]"
     description "English translation by Aethin version (1.04)"


### PR DESCRIPTION
tl; dir: this PR is for being able to use a tool later without  extra whitespace changes and has no functional modifications. It only affects the metadata/hacks directory, not any of the others.


I'm doing this commit for a simple reason; i updated [my update checker script ](https://github.com/i30817/rhdndat) to allow 'merging' the calculated updates to a ra hack dat file. This makes it much easier to update and to see the changes, and doesn't nuke the hacks added by hand in most cases¹ 

The merge mode simply reads and parses with pyparsing the 'merge file', reads all the hack info off the filesystem and romhacking.net, compares each set of urls on the discovered hacks to the urls (if any) on the merge-file and removes duplicates or updates (and warns about updates with a color diff). Then it writes to temp file first the crlmamepro header, then the 'by hand' hacks remaining from the merge file, then the discovered hacks and finally moves the file to the new location (in case the write  file and the merge dat are one and the same).

I can use [a script like this](https://gist.github.com/dfe468fff13f2a0f0a8a42b81e7b2fc7) to check for updates in all the systems and write them out to the dat file without hand editing.
Or for a single system too.

¹ it may nuke those that refer to same hack urls - which is a problem in the N64 dat which has many versions of the same hack because of multiple source formats