### PR TITLE
Add cheats for ChaiLove Floppy Bird

### DIFF
--- a/cht/ChaiLove/Floppy Bird.cht
+++ b/cht/ChaiLove/Floppy Bird.cht
@@ -1,0 +1,12 @@
+# Floppy Bird
+# https://github.com/robloach/chailove-floppybird
+
+cheats = 2
+
+cheat0_desc = "No Clip"
+cheat0_code = "noclip"
+cheat0_enable = false
+
+cheat1_desc = "Fly Mode"
+cheat1_code = "fly"
+cheat1_enable = false


### PR DESCRIPTION
In Floppy Bird, you can now use the `noclip` and `fly` cheat codes.

https://github.com/robloach/chailove-floppybird

Need to have Floppy Bird 0.20.1