### PR TITLE
Update Sega - Mega Drive - Genesis.dat

### DIFF
--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -3,11 +3,6 @@ clrmamepro (
     description "Romhacks of Sega Mega Drive / Sega Genesis games"
 )
 game (
-    name "Mega Man - The Wily Wars (Europe) Move-Shoot Hack"
-    description "Hacks for 60FPS, SRAM support and NES-like movement/shooting"
-    rom ( name "Mega Man - The Wily Wars (move-shoot hack).bin" size 2097152 crc 1d9b9c91 md5 c13a4784a8bce87bb514d6f24a05d2f1 sha1 99cb17c2b141c21b5661049d3811ebf90fde40b2 )
-)
-game (
     name "Mortal Kombat II Unlimited - Enhanced Colors (USA)"
     description "'Mortal Kombat II' hack by Smoke and Pyron"
     rom ( name "MK2U_EC_Pyron.bin" size 4136840 crc 1867b4d9 md5 3f1aa570edddc5c5e2879a94d6f62e11 sha1 13de727bacf8c644e3df7a96cf212b5a1a899455 )
@@ -16,11 +11,6 @@ game (
     name "Rock n' Roll Racing (USA) Hack"
     description "Hack by Ti version 15"
     rom ( name "Rock_n'_Roll_Racing_Hack_v15.bin" size 2097152 crc 205f4afc md5 bd4bae13a6fed5d2801face18572fab2 sha1 bedfa111535fbeea0b75999b799317415bc4bab3 )
-)
-game (
-    name "Sonic 3 Complete (USA)"
-    description "'Sonic 3 & Knuckles 3' hack version 130810"
-    rom ( name "Sonic3C.gen" size 3932160 crc 2bd564b1 md5 153b6d32026993569b16ff89c53197a3 sha1 4461ed4a94b93653905c08e201f7c11a128e5a47 )
 )
 game (
     name "Street Fighter II' - Champion Edition Arcade (USA)"


### PR DESCRIPTION
Removal of duplicate 'Sonic 3 Complete' hack entry, leaving the more consistent one for automatic updates and tracking authors (though romhacking.net url and names).

Removal of Willy move-shoot hack both because it has a equivalent modern replacement in ["Mega Man the Wily Wars SRAM+ [Hack by Ar8temis008]"](http://www.romhacking.net/hacks/3837/) and because it crashes the game, see the link for the reason it was removed on romhacking.net

http://www.romhacking.net/?page=submissions&action=itemhistory&section=Hacks&sectionid=6&id=3322