### PR TITLE
changed 'comment' tag for 'patch' on the metadata/hacks dir

### DIFF
--- a/metadat/hacks/Bandai - WonderSwan Color.dat
+++ b/metadat/hacks/Bandai - WonderSwan Color.dat
@@ -6,17 +6,17 @@ game (
     name "Makai Toushi Sa-Ga (Japan) [T-En by Tower Reversed]"
     description "English translation by Tower Reversed version (1.2)"
     rom ( name "Makai Toushi Sa-Ga (Japan).wsc" size 4194304 crc a4308378 md5 f1d130f871a4440be635322c73662049 sha1 f800e5305292a81be738f15426269329a8d139b1 )
-    comment "http://www.romhacking.net/translations/1614/"
+    patch "http://www.romhacking.net/translations/1614/"
 )
 game (
     name "Dicing Knight. (Japan) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (1.00)"
     rom ( name "Dicing Knight. (Japan).wsc" size 2097152 crc 56f4e554 md5 6e8848993a51e0226ba4be18e7bb6b73 sha1 106dca0fd84ba59dd98f13ee5ab6e4832105b8b3 )
-    comment "http://www.romhacking.net/translations/1073/"
+    patch "http://www.romhacking.net/translations/1073/"
 )
 game (
     name "Mr. Driller (Japan) [T-En by PmHacks]"
     description "English translation by PmHacks version (0.70)"
     rom ( name "Mr. Driller (Japan).wsc" size 2097152 crc 61e7ed03 md5 1f5539c33ae54234511af2cc8f3c811b sha1 a6e40a8aac557c443a241c3cbc83a104e9ce7032 )
-    comment "http://www.romhacking.net/translations/748/"
+    patch "http://www.romhacking.net/translations/748/"
 )

--- a/metadat/hacks/Bandai - WonderSwan.dat
+++ b/metadat/hacks/Bandai - WonderSwan.dat
@@ -6,5 +6,5 @@ game (
     name "Kaze no Klonoa - Moonlight Museum (Japan) [T-En by PowerStone05]"
     description "English translation by PowerStone05 version (0.511)"
     rom ( name "Kaze no Klonoa - Moonlight Museum (Japan).ws" size 1048576 crc d4e0cb07 md5 a33445feef853e11fb75f255e1460be5 sha1 0690e73285e0587e93b1f4c813b3484467d2eaca )
-    comment "http://www.romhacking.net/translations/3681/"
+    patch "http://www.romhacking.net/translations/3681/"
 )

--- a/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
+++ b/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
@@ -6,133 +6,133 @@ game (
     name "Gaia no Monshou (Japan) [T-En by D]"
     description "English translation by D version (1.3)"
     rom ( name "Gaia no Monshou (Japan).pce" size 262144 crc f93670ff md5 a2b1c24c8701e930ae9cf0b48d0873ce sha1 71e1f4f647e094e8758f0bc35409e1d31583b63a )
-    comment "http://www.romhacking.net/translations/813/"
+    patch "http://www.romhacking.net/translations/813/"
 )
 game (
     name "Final Match Tennis Ladies [T-En by tAz-07 + 2 hacks]"
     description "Final Match Tennis Ladies hack by MooZ version (1.0) + Final Match Tennis Ladies hack by tAz-07 version (1.0) + English translation by tAz-07 version (1.0)"
     rom ( name "Final Match Tennis Ladies.pce" size 262144 crc e92d1290 md5 4975b6669f0a47c201d16fa3fc7ec392 sha1 d186a4fd933ab12dd3c2024093241660c0dae1bf )
-    comment "http://www.romhacking.net/hacks/3174/"
-    comment "http://www.romhacking.net/hacks/3297/"
-    comment "http://www.romhacking.net/translations/2801/"
+    patch "http://www.romhacking.net/hacks/3174/"
+    patch "http://www.romhacking.net/hacks/3297/"
+    patch "http://www.romhacking.net/translations/2801/"
 )
 game (
     name "Die Hard (Japan) [T-En by Spinner 8 and friends]"
     description "English translation by Spinner 8 and friends version (1.0)"
     rom ( name "Die Hard (Japan).pce" size 524288 crc 91be0dec md5 45195abbbdaff8dd8d8c521b84f1698d sha1 ae01c948903cca1c849d77f68bffb3e533efcf50 )
-    comment "http://www.romhacking.net/translations/1712/"
+    patch "http://www.romhacking.net/translations/1712/"
 )
 game (
     name "Bikkuriman World (Japan) [T-En by Demiforce]"
     description "English translation by Demiforce version (1.00)"
     rom ( name "Bikkuriman World (Japan).pce" size 262144 crc 02db6fe5 md5 7a13bd257402efafff3c33d9ba7d4ae4 sha1 9209ae070ef6a4ca6dad6fb20054b1ac3c265ccf )
-    comment "http://www.romhacking.net/translations/511/"
+    patch "http://www.romhacking.net/translations/511/"
 )
 game (
     name "Shiryou Sensen - War of the Dead (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.0)"
     rom ( name "Shiryou Sensen - War of the Dead (Japan).pce" size 278528 crc 9ccfbb7a md5 5fb0ef737dcea6a7cb8df0fbcd2670b6 sha1 b030c8f11d35002a3c8e95edc1a5aa4048151c97 )
-    comment "http://www.romhacking.net/translations/3328/"
+    patch "http://www.romhacking.net/translations/3328/"
 )
 game (
     name "Lady Sword (Japan) [T-En by EsperKnight, filler, Grant Laughlin and Tomaitheous]"
     description "English translation by EsperKnight, filler, Grant Laughlin and Tomaitheous version (1.0)"
     rom ( name "Lady Sword (Japan).pce" size 1048576 crc ff461dcd md5 6b56d548b740cdbbc2993b5a8f03ffd4 sha1 7e6cf9b1c8ef96147129d297e0b39a2217d499f1 )
-    comment "http://www.romhacking.net/translations/1574/"
+    patch "http://www.romhacking.net/translations/1574/"
 )
 game (
     name "Bubblegum Crash! - Knight Sabers 2034 (Japan) [T-En by Dave Shadoff, filler and Tomaitheous]"
     description "English translation by Dave Shadoff, filler and Tomaitheous version (1.0)"
     rom ( name "Bubblegum Crash! - Knight Sabers 2034 (Japan).pce" size 786432 crc 704b6916 md5 4675116aa55dcf17f6311142d43808ec sha1 83ab5db31cd669787bbfaeaaa691a0f59e4d167c )
-    comment "http://www.romhacking.net/translations/1234/"
+    patch "http://www.romhacking.net/translations/1234/"
 )
 game (
     name "Aoi Blink (Japan) [T-En by Gaijin Productions and Zatos Hacks]"
     description "English translation by Gaijin Productions and Zatos Hacks version (0.99b)"
     rom ( name "Aoi Blink (Japan).pce" size 393216 crc 25d34a20 md5 6fd7e17d01fc93b9be9f89fa8359a579 sha1 781e6eda1f2e9be35d71b9853f97b8f26cce0631 )
-    comment "http://www.romhacking.net/translations/504/"
+    patch "http://www.romhacking.net/translations/504/"
 )
 game (
     name "Energy (Japan) [T-En by cabbage and onionzoo]"
     description "English translation by cabbage and onionzoo version (1.01)"
     rom ( name "Energy (Japan).pce" size 262144 crc 370fa62c md5 7fc06f2e3131c1cfcddff6c69d54b8b9 sha1 d237dff176ef5193885fdc4abb469f6435dd2aac )
-    comment "http://www.romhacking.net/translations/2936/"
+    patch "http://www.romhacking.net/translations/2936/"
 )
 game (
     name "Knight Rider Special (Japan) [T-En by Psyklax]"
     description "English translation by Psyklax version (2.0)"
     rom ( name "Knight Rider Special (Japan).pce" size 262144 crc 1109d8e3 md5 79216bf0956d23b58331b98af6da6c4a sha1 1da7d890ff87cf48ba214f6a246892006c5d70d6 )
-    comment "http://www.romhacking.net/translations/2156/"
+    patch "http://www.romhacking.net/translations/2156/"
 )
 game (
     name "Valkyrie no Densetsu (Japan) [T-En by cabbage and Shawn Cox]"
     description "English translation by cabbage and Shawn Cox version (1.0)"
     rom ( name "Valkyrie no Densetsu (Japan).pce" size 524288 crc 97a62bd1 md5 c8e415bf9bf74284e51f8d96a22caff5 sha1 aaa4b32bc980f04b54932bd6792955fa25ebc22c )
-    comment "http://www.romhacking.net/translations/2637/"
+    patch "http://www.romhacking.net/translations/2637/"
 )
 game (
     name "Gekisha Boy (Japan) [T-En by Zatos Hacks]"
     description "English translation by Zatos Hacks version (0.99)"
     rom ( name "Gekisha Boy (Japan).pce" size 524288 crc 9cfe7e17 md5 4293b1c07f9de4c32075cfa00963379c sha1 a1083636dcc8d24c02454a4fb04256319d57f1ea )
-    comment "http://www.romhacking.net/translations/507/"
+    patch "http://www.romhacking.net/translations/507/"
 )
 game (
     name "Maison Ikkoku (Japan) [T-En by Dave Shadoff and filler]"
     description "English translation by Dave Shadoff and filler version (1.01)"
     rom ( name "Maison Ikkoku (Japan).pce" size 524288 crc 73c5adf1 md5 0e4dfb8449b2f825af396f0c577b6ef2 sha1 47655a5c5445cc4d69cd32825e84c70ed4a14d26 )
-    comment "http://www.romhacking.net/translations/724/"
+    patch "http://www.romhacking.net/translations/724/"
 )
 game (
     name "Formation Soccer Human Cup '92 [Hack by MooZ]"
     description "Formation Soccer Human Cup '92 hack by MooZ version (1.0)"
     rom ( name "Formation Soccer Human Cup 92.pce" size 262144 crc b3096880 md5 6334a124d072e53aab36c80c38253b1c sha1 9cd0a907d0795b0dc2eb5875aaddc686ce1caea0 )
-    comment "http://www.romhacking.net/hacks/3181/"
+    patch "http://www.romhacking.net/hacks/3181/"
 )
 game (
     name "Son Son II (Japan) [T-En by someitalian123]"
     description "English translation by someitalian123 version (1.0)"
     rom ( name "Son Son II (Japan).pce" size 262144 crc 1a0599b4 md5 471b66578757b269a682e75ba810b1b7 sha1 3a53ed2ff692e277c55fa287b1d8281a50b0df3e )
-    comment "http://www.romhacking.net/translations/3146/"
+    patch "http://www.romhacking.net/translations/3146/"
 )
 game (
     name "Hisou Kihei - Xserd (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.0)"
     rom ( name "Hisou Kihei - Xserd (Japan).pce" size 786944 crc 3e5ce025 md5 3616bf19f2beb256d13ed4bd77533b6a sha1 8cefcf036b6eda0f120d6363a8c0c020f49f9d5d )
-    comment "http://www.romhacking.net/translations/2780/"
+    patch "http://www.romhacking.net/translations/2780/"
 )
 game (
     name "Maerchen Maze (Japan) [T-En by MooZ and Shubibiman]"
     description "English translation by MooZ and Shubibiman version (1.1)"
     rom ( name "Maerchen Maze (Japan).pce" size 262144 crc b7166358 md5 f34299acd4a789ad51e7b10be3a8947d sha1 caf03a4bd2b8e74746b98c0b8be312231e447064 )
-    comment "http://www.romhacking.net/translations/1637/"
+    patch "http://www.romhacking.net/translations/1637/"
 )
 game (
     name "Out Live (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.1)"
     rom ( name "Out Live (Japan).pce" size 303104 crc 2f1cee20 md5 0df6ed290544d42a6d06dcd781037bf7 sha1 4e78f64e3030cce13de7100b6b4dd248d199fa36 )
-    comment "http://www.romhacking.net/translations/2814/"
+    patch "http://www.romhacking.net/translations/2814/"
 )
 game (
     name "Final Match Tennis (Japan) [T-En by tAz-07]"
     description "English translation by tAz-07 version (1.2)"
     rom ( name "Final Match Tennis (Japan).pce" size 262144 crc 8c4f4941 md5 e161b34d6bcdbcfe582f943b2eef5715 sha1 6d14d4ac286b70cd7b689a8d4576da4e27a330dd )
-    comment "http://www.romhacking.net/translations/2778/"
+    patch "http://www.romhacking.net/translations/2778/"
 )
 game (
     name "Makai Hakkenden Shada (Japan) [T-En by cabbage and Shubibiman]"
     description "English translation by cabbage and Shubibiman version (1.0)"
     rom ( name "Makai Hakkenden Shada (Japan).pce" size 262144 crc 017de16d md5 6b33184f381d3bfc9870f5ad55b8c78a sha1 448991d34538c40cb8d7738ed1093b86c4dd1cfd )
-    comment "http://www.romhacking.net/translations/2636/"
+    patch "http://www.romhacking.net/translations/2636/"
 )
 game (
     name "Druaga no Tou (Japan) [T-En by Procyon]"
     description "English translation by Procyon version (1.1)"
     rom ( name "Druaga no Tou (Japan).pce" size 524288 crc b9032dc3 md5 8da3885d9c6674f33cf9bac28905d249 sha1 7a36b6b64596a04a4a3fc6ffeacae44989504271 )
-    comment "http://www.romhacking.net/translations/1104/"
+    patch "http://www.romhacking.net/translations/1104/"
 )
 game (
     name "Youkai Douchuuki (Japan) [T-En by cabbage]"
     description "English translation by cabbage version (1.0)"
     rom ( name "Youkai Douchuuki (Japan).pce" size 270336 crc fe2c2c5e md5 212884e64a1c968b0ebe355575589844 sha1 1a9ea3239986ac4de1a196e813984416b6e28e19 )
-    comment "http://www.romhacking.net/translations/3607/"
+    patch "http://www.romhacking.net/translations/3607/"
 )

--- a/metadat/hacks/Nintendo - Game Boy Advance.dat
+++ b/metadat/hacks/Nintendo - Game Boy Advance.dat
@@ -6,95 +6,95 @@ game (
     name "Magical Vacation (Japan) [T-En by magicalpatcher]"
     description "English translation by magicalpatcher version (1.0)"
     rom ( name "Magical Vacation (Japan).gba" size 9043968 crc 98fbbd9a md5 7bc82e72f6b9f734766f6cd9faf43e66 sha1 f928f9ca70ce76c19abbe50077f2c0d06efe6cfe )
-    comment "http://www.romhacking.net/translations/2662/"
+    patch "http://www.romhacking.net/translations/2662/"
 )
 game (
     name "Metroid Other ZM [Hack by Luce Seyfarth]"
     description "Metroid Other ZM hack by Luce Seyfarth version (3.8)"
     rom ( name "Metroid Other ZM.gba" size 16777216 crc fc850cc5 md5 4fdb05cdb7bcd66e6fec1af992e7c310 sha1 26327eb06fda34c3f1fffa512c08b804623185f8 )
-    comment "http://www.romhacking.net/hacks/2565/"
+    patch "http://www.romhacking.net/hacks/2565/"
 )
 game (
     name "Oriental Blue - Ao no Tengai (Japan) [T-En by Kingcom and Tom]"
     description "English translation by Kingcom and Tom version (1.0)"
     rom ( name "Oriental Blue - Ao no Tengai (Japan).gba" size 16777216 crc 8a850da7 md5 0fe6daf45e3460cc865ee50029988f3a sha1 95c4e8b78d7e66e28451e4f6780d3f0fd9e687d2 )
-    comment "http://www.romhacking.net/translations/2035/"
+    patch "http://www.romhacking.net/translations/2035/"
 )
 game (
     name "Gensou Suikoden - Card Stories (Japan) [T-En by Pokeytax]"
     description "English translation by Pokeytax version (1.00)"
     rom ( name "Gensou Suikoden - Card Stories (Japan).gba" size 4194304 crc dafac900 md5 1e2ed077d1db255c44cd6c653067750c sha1 343b4dc9e897133f26dc8f04a70c1ea752d26cdd )
-    comment "http://www.romhacking.net/translations/1720/"
+    patch "http://www.romhacking.net/translations/1720/"
 )
 game (
     name "Super Robot Taisen J (Japan) [T-En by Kingcom]"
     description "English translation by Kingcom version (1.0)"
     rom ( name "Super Robot Taisen J (Japan).gba" size 16777216 crc 3b3cd715 md5 6caff32286c768d3bf9f7986d535ef7b sha1 0ef65670fec4f655536d15b7a954a1deda192855 )
-    comment "http://www.romhacking.net/translations/1577/"
+    patch "http://www.romhacking.net/translations/1577/"
 )
 game (
     name "Mother 3 (Japan) [T-En by Chewy, Jeffman and Tomato]"
     description "English translation by Chewy, Jeffman and Tomato version (1.2)"
     rom ( name "Mother 3 (Japan).gba" size 33554432 crc a323c029 md5 31321db87c763bba42a2fdedf1706386 sha1 a2f2d9d1ca8281563683c89a05826ea0b91b2892 )
-    comment "http://www.romhacking.net/translations/1333/"
+    patch "http://www.romhacking.net/translations/1333/"
 )
 game (
     name "Fire Emblem - Fuuin no Tsurugi (Japan) [T-En by Gringe]"
     description "English translation by Gringe version (1.0)"
     rom ( name "Fire Emblem - Fuuin no Tsurugi (Japan).gba" size 16777532 crc 99b8b6d7 md5 9fc134a926a9f2fe84a141aba2ba25a9 sha1 32605fd456677ef740f8d521e9a3894ace4bc59c )
-    comment "http://www.romhacking.net/translations/2511/"
+    patch "http://www.romhacking.net/translations/2511/"
 )
 game (
     name "Hagane no Renkinjutsushi - Meisou no Rondo (Japan) [T-En by mz]"
     description "English translation by mz version (0.02)"
     rom ( name "Hagane no Renkinjutsushi - Meisou no Rondo (Japan).gba" size 16777216 crc bc3f79b5 md5 70dd13d5d0cb840ecdee29ea78e5e013 sha1 0e53d1b7c6a413f18e13f0b87e302b7838f8dbe1 )
-    comment "http://www.romhacking.net/translations/2882/"
+    patch "http://www.romhacking.net/translations/2882/"
 )
 game (
     name "Hajime no Ippo - The Fighting! (Japan) [T-En by Markliujy]"
     description "English translation by Markliujy version (1.0)"
     rom ( name "Hajime no Ippo - The Fighting! (Japan).gba" size 8388608 crc 5130a355 md5 e33de4139d69d016394a26119cdeba32 sha1 106301fecaf19f026385e281f9da881b6c38d058 )
-    comment "http://www.romhacking.net/translations/1319/"
+    patch "http://www.romhacking.net/translations/1319/"
 )
 game (
     name "Mother 1+2 (Japan) [T-En by Jeffman and Tomato]"
     description "English translation by Jeffman and Tomato version (1.01)"
     rom ( name "Mother 1+2 (Japan).gba" size 16777216 crc 7b1ff152 md5 68806f7e40e1f082b21a8b920e8982db sha1 e377a23de3411fd47b0d1ad3923d731ab0c127ac )
-    comment "http://www.romhacking.net/translations/1609/"
+    patch "http://www.romhacking.net/translations/1609/"
 )
 game (
     name "Famicom Mini - Dai-2-ji Super Robot Taisen (Japan) (Promo) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (0.99)"
     rom ( name "Famicom Mini - Dai-2-ji Super Robot Taisen (Japan) (Promo).gba" size 4194304 crc cc4fda84 md5 778cbe0cd0d270cf7d436e4a85121fe6 sha1 0a05eaf5ca16bd9dd9490e83b20a330afc2a240f )
-    comment "http://www.romhacking.net/translations/2091/"
+    patch "http://www.romhacking.net/translations/2091/"
 )
 game (
     name "Super Mario Advance 4 - All 38 e-Reader Levels [Hack by ShadowOne333]"
     description "Super Mario Advance 4 - All 38 e-Reader Levels hack by ShadowOne333 version (1.0)"
     rom ( name "Super Mario Advance 4 - Super Mario Bros. 3 (USA).gba" size 8388608 crc d4c13ac3 md5 e7a2792c5913a8420a419f2d01358487 sha1 dd2879329ec52bd5372f26b75297a67f1a81215a )
-    comment "http://www.romhacking.net/hacks/2714/"
+    patch "http://www.romhacking.net/hacks/2714/"
 )
 game (
     name "Dragon Quest Monsters - Caravan Heart (Japan) [T-En by KaioShin]"
     description "English translation by KaioShin version (1.0)"
     rom ( name "Dragon Quest Monsters - Caravan Heart (Japan).gba" size 8388608 crc 5b925fc9 md5 a57a5ea8c43957ee5974dd02ae305d1f sha1 0aa4fd4808260af2c8a7531b07ed301eee1bb50a )
-    comment "http://www.romhacking.net/translations/1252/"
+    patch "http://www.romhacking.net/translations/1252/"
 )
 game (
     name "Castlevania Aria of Sorrow Gebel Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Gebel Hack hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Gebel Hack.gba" size 8388608 crc 317f5c4f md5 8df41935661e22ddc70e216bd6249216 sha1 48fbd3c3a0b0477160f82c19149841b6de271c75 )
-    comment "http://www.romhacking.net/hacks/4136/"
+    patch "http://www.romhacking.net/hacks/4136/"
 )
 game (
     name "Castlevania Aria of Sorrow Zangetsu Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Zangetsu Hack hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Zangetsu Hack.gba" size 8388608 crc 027d4b31 md5 fd0fa411a7c7722c752116beca243f27 sha1 7112dd9c55fd2d33cd5274dfdb71202e162cc1e2 )
-    comment "http://www.romhacking.net/hacks/4130/"
+    patch "http://www.romhacking.net/hacks/4130/"
 )
 game (
     name "Castlevania Aria of Sorrow Alfred Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Alfred Hack hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Alfred Hack.gba" size 8388608 crc 9f88961f md5 7c5c06345e69eec96b13668e969177f8 sha1 4191b6d131e5307ccbd210df5fb39d7824e59355 )
-    comment "http://www.romhacking.net/hacks/4131/"
+    patch "http://www.romhacking.net/hacks/4131/"
 )

--- a/metadat/hacks/Nintendo - Game Boy Color.dat
+++ b/metadat/hacks/Nintendo - Game Boy Color.dat
@@ -6,71 +6,71 @@ game (
     name "Arle no Bouken - Mahou no Jewel (Japan) (SGB Enhanced) (GB Compatible) [T-En by Jazz]"
     description "English translation by Jazz version (2.1)"
     rom ( name "Arle no Bouken - Mahou no Jewel (Japan) (SGB Enhanced).gbc" size 1048576 crc 9a14a37a md5 d2bb101d6b203d8b29cc0db5944eb244 sha1 9238f6f5419eed2b65b8e362f9d4c76429283665 )
-    comment "http://www.romhacking.net/translations/3468/"
+    patch "http://www.romhacking.net/translations/3468/"
 )
 game (
     name "Wizardry Empire (Japan) (Rev A) [T-En by AgentOrange, Helly and MrRichard999]"
     description "English translation by AgentOrange, Helly and MrRichard999 version (1.02)"
     rom ( name "Wizardry Empire (Japan) (Rev A).gbc" size 1048619 crc c10ddd2f md5 300edb5260429731848bcd99b413db5d sha1 831b23543967ba160ad7fe1d439b04f4abc68cad )
-    comment "http://www.romhacking.net/translations/2316/"
+    patch "http://www.romhacking.net/translations/2316/"
 )
 game (
     name "Wizardry Empire - Fukkatsu no Tsue (Japan) [T-En by Helly and MrRichard999]"
     description "English translation by Helly and MrRichard999 version (1.16)"
     rom ( name "Wizardry Empire - Fukkatsu no Tsue (Japan).gbc" size 1048576 crc 8b209f47 md5 e8fe54e3483adee2019996a4cc1545ac sha1 f094d4afaf3a209d6422ff718045f93a5ae0c4fa )
-    comment "http://www.romhacking.net/translations/2322/"
+    patch "http://www.romhacking.net/translations/2322/"
 )
 game (
     name "Megami Tensei Gaiden - Last Bible II (Japan) (SGB Enhanced) (GB Compatible) [T-En by EsperKnight]"
     description "English translation by EsperKnight version (1.0)"
     rom ( name "Megami Tensei Gaiden - Last Bible II (Japan) (SGB Enhanced).gbc" size 1048576 crc 007b4804 md5 5c426fda8368066cf7e30587876af631 sha1 6f2ba0de137cfc3be136f6477dd84873663745a0 )
-    comment "http://www.romhacking.net/translations/1392/"
+    patch "http://www.romhacking.net/translations/1392/"
 )
 game (
     name "Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan) (SGB Enhanced) (GB Compatible) [T-En by Psyklax]"
     description "English translation by Psyklax version (1.0)"
     rom ( name "Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan) (SGB Enhanced).gbc" size 1048576 crc 4a586ad3 md5 1689c2205cc7b3bd020e85d2ea73fdf7 sha1 27185599dd6f0da93464a729306db1ac10818ae0 )
-    comment "http://www.romhacking.net/translations/2151/"
+    patch "http://www.romhacking.net/translations/2151/"
 )
 game (
     name "Lufia: The Legend Returns Text Cleanup [Hack by vivify93]"
     description "Lufia: The Legend Returns Text Cleanup hack by vivify93 version (2.0)"
     rom ( name "Lufia - The Legend Returns (USA).gbc" size 2097152 crc 0146f07f md5 daa61ef232971c454d7766663f03ceb2 sha1 0446d2d3b3df41d449f4de22b82f09bab5be55c7 )
-    comment "http://www.romhacking.net/hacks/813/"
+    patch "http://www.romhacking.net/hacks/813/"
 )
 game (
     name "Little Magic (Japan) [T-En by Some Good Shit Translations]"
     description "English translation by Some Good Shit Translations version (1.0)"
     rom ( name "Little Magic (Japan).gbc" size 1048576 crc f1ea3f69 md5 5b1fc7b09dd78a0a6a4c87cf9c86ab1c sha1 9339c8770bab5650a60f05c4fb69bf75acc9a399 )
-    comment "http://www.romhacking.net/translations/29/"
+    patch "http://www.romhacking.net/translations/29/"
 )
 game (
     name "Shantae - Force GBA Enhanced Mode [Hack by Polar-Star]"
     description "Shantae - Force GBA Enhanced Mode hack by Polar-Star version (1.0)"
     rom ( name "Shantae (USA).gbc" size 4194304 crc a52782ba md5 f687ce08f80c8f6ecb7722c90dde4b5c sha1 4295fcae05cb90b1564f3bb4e92cc2b2eec40f0e )
-    comment "http://www.romhacking.net/hacks/3462/"
+    patch "http://www.romhacking.net/hacks/3462/"
 )
 game (
     name "Meitantei Conan - Kigantou Hihou Densetsu (Japan) (SGB Enhanced) (GB Compatible) [T-En by mz]"
     description "English translation by mz version (0.04)"
     rom ( name "Meitantei Conan - Kigantou Hihou Densetsu (Japan) (SGB Enhanced).gbc" size 1048576 crc 194921e5 md5 09f6430f0847ec793ff95057fdacac1d sha1 7ca15cd02a440b9bb9435ae443ffee578f9a5a2e )
-    comment "http://www.romhacking.net/translations/2880/"
+    patch "http://www.romhacking.net/translations/2880/"
 )
 game (
     name "Oracle of Seasons Force GBA Enhanced Mode [Hack by DuoDreamer]"
     description "Oracle of Seasons Force GBA Enhanced Mode hack by DuoDreamer version (0.3)"
     rom ( name "Legend of Zelda, The - Oracle of Seasons (USA).gbc" size 1048576 crc c26879a0 md5 a2ecf20f04b3be46e9ed3feaac96a7cf sha1 a0fec9d9c51c5d117910192d820539e6455fe8cf )
-    comment "http://www.romhacking.net/hacks/3583/"
+    patch "http://www.romhacking.net/hacks/3583/"
 )
 game (
     name "Oracle of Ages Force GBA Enhanced Mode [Hack by DuoDreamer]"
     description "Oracle of Ages Force GBA Enhanced Mode hack by DuoDreamer version (0.3)"
     rom ( name "Legend of Zelda, The - Oracle of Ages (USA).gbc" size 1048576 crc 2d812ff0 md5 a9d5b7b5ccedb6a7785b404d224c42ee sha1 d7fb2fec5a445b77d0d9e1c1f147b9397186038d )
-    comment "http://www.romhacking.net/hacks/3580/"
+    patch "http://www.romhacking.net/hacks/3580/"
 )
 game (
     name "Wendy: Every Witch Way - Force GBA Enhanced Mode [Hack by celebi23]"
     description "Wendy: Every Witch Way - Force GBA Enhanced Mode hack by celebi23 version (1.0)"
     rom ( name "Wendy - Every Witch Way (USA, Europe).gbc" size 1048576 crc 2c0c9cb3 md5 067b1ff18d9ee9f939d79a55f47d850e sha1 e5d2a32613d179a93482fca11138171c17340672 )
-    comment "http://www.romhacking.net/hacks/4039/"
+    patch "http://www.romhacking.net/hacks/4039/"
 )

--- a/metadat/hacks/Nintendo - Game Boy.dat
+++ b/metadat/hacks/Nintendo - Game Boy.dat
@@ -6,65 +6,65 @@ game (
     name "Heracles no Eikou - Ugokidashita Kamigami (Japan) [T-En by aishsha and Stardust Crusaders]"
     description "English translation by aishsha and Stardust Crusaders version (1.0)"
     rom ( name "Heracles no Eikou - Ugokidashita Kamigami (Japan).gb" size 262144 crc d51370ef md5 5f513ff116181531c0e99fa1e8ba91f8 sha1 dc2df7aa292c0982a953b897cd77d26719243e47 )
-    comment "http://www.romhacking.net/translations/3365/"
+    patch "http://www.romhacking.net/translations/3365/"
 )
 game (
     name "Wizardry Gaiden 2 - Kodai Koutei no Noroi (Japan) [T-En by MrRichard999 and Tangyi_Chang]"
     description "English translation by MrRichard999 and Tangyi_Chang version (1.1)"
     rom ( name "Wizardry Gaiden 2 - Kodai Koutei no Noroi (Japan).gb" size 262144 crc 0f094fa6 md5 1919c1597fa158092c159230df1f6349 sha1 c9c50a9311b73e2b1e86c67f2a90cc3def28a5da )
-    comment "http://www.romhacking.net/translations/2150/"
+    patch "http://www.romhacking.net/translations/2150/"
 )
 game (
     name "Kaeru no Tame ni Kane wa Naru (Japan) [T-En by ryanbgstl]"
     description "English translation by ryanbgstl version (1.0)"
     rom ( name "Kaeru no Tame ni Kane wa Naru (Japan).gb" size 524288 crc 630193e8 md5 5e477cdea0b3266b505ac5938ddc5e5c sha1 90bddff5d48eedad6ec5157946f602ae4170e0c6 )
-    comment "http://www.romhacking.net/translations/1623/"
+    patch "http://www.romhacking.net/translations/1623/"
 )
 game (
     name "Nangoku Shounen Papuwa-kun - Ganmadan no Yabou (Japan) [T-En by Adventurous Translations]"
     description "English translation by Adventurous Translations version (1.00)"
     rom ( name "Nangoku Shounen Papuwa-kun - Ganmadan no Yabou (Japan).gb" size 131072 crc 366869bc md5 686abad72092adccabc6db3687b1075e sha1 daa16493e46de4bb3c2c24914c8ab5d13c12fa84 )
-    comment "http://www.romhacking.net/translations/2946/"
+    patch "http://www.romhacking.net/translations/2946/"
 )
 game (
     name "Wizardry Gaiden 3 - Yami no Seiten (Japan) [T-En by Tangyi_Chang]"
     description "English translation by Tangyi_Chang version (1.03)"
     rom ( name "Wizardry Gaiden 3 - Yami no Seiten (Japan).gb" size 524288 crc a77df9cb md5 e1f712b4d9d4496e679c736c15895772 sha1 1f3586e46edc80e9f0602ba82ba3bba43d56c9f4 )
-    comment "http://www.romhacking.net/translations/2252/"
+    patch "http://www.romhacking.net/translations/2252/"
 )
 game (
     name "Magic Knight Rayearth 2nd. - The Missing Colors (Japan) (SGB Enhanced) [T-En by Pearse Hillock]"
     description "English translation by Pearse Hillock version (0.99)"
     rom ( name "Magic Knight Rayearth 2nd. - The Missing Colors (Japan) (SGB Enhanced).gb" size 262144 crc 02209889 md5 8a0bd22a1e8c1c4259d12df1f1136b57 sha1 ff5606f210adc3f4bd14ddad91ec626bbf4cc89b )
-    comment "http://www.romhacking.net/translations/2170/"
+    patch "http://www.romhacking.net/translations/2170/"
 )
 game (
     name "Wizardry Gaiden 1 - Joou no Junan (Japan) [T-En by Tangyi_Chang]"
     description "English translation by Tangyi_Chang version (1.1)"
     rom ( name "Wizardry Gaiden 1 - Joou no Junan (Japan).gb" size 262144 crc d97cfa52 md5 cb2ab3952aebf23b1c3dae2f453849d4 sha1 c544c0beeae3d4ec0e935126aecbd87a6bfb55aa )
-    comment "http://www.romhacking.net/translations/2095/"
+    patch "http://www.romhacking.net/translations/2095/"
 )
 game (
     name "Super Mario Land 2 DX [Hack by toruzz]"
     description "Super Mario Land 2 DX hack by toruzz version (1.8.1)"
     rom ( name "Super Mario Land 2 - 6 Golden Coins (USA, Europe).gb" size 1048576 crc f0799017 md5 946a4a60bbd5328ca2250d5f9f0606c7 sha1 b9ed5789c9f481e25a64dad1c5e8e93e4ddc1b80 )
-    comment "http://www.romhacking.net/hacks/3784/"
+    patch "http://www.romhacking.net/hacks/3784/"
 )
 game (
     name "Little Master - Raikuban no Densetsu (Japan) [T-En by Zatos Hacks]"
     description "English translation by Zatos Hacks version (1.0)"
     rom ( name "Little Master - Raikuban no Densetsu (Japan).gb" size 131072 crc eff41b9c md5 6ee73d60e4d5a2984edea054082b15bf sha1 91758d27956372c7d134c744a55a9e89a0edb808 )
-    comment "http://www.romhacking.net/translations/3647/"
+    patch "http://www.romhacking.net/translations/3647/"
 )
 game (
     name "Noobow (Japan) [T-En by Stardust Crusaders]"
     description "English translation by Stardust Crusaders version (1.0)"
     rom ( name "Noobow (Japan).gb" size 262144 crc da0224e3 md5 15449adf4a457462d59c92ed0ac49d5a sha1 735015e38e636583c8a433966e09511447f907cb )
-    comment "http://www.romhacking.net/translations/3618/"
+    patch "http://www.romhacking.net/translations/3618/"
 )
 game (
     name "Tenjin Kaisen (Japan) [T-En by Stardust Crusaders]"
     description "English translation by Stardust Crusaders version (1.0)"
     rom ( name "Tenjin Kaisen (Japan).gb" size 131072 crc 959d2241 md5 ec48db74c5daefb14646ac2413e1f0af sha1 8cbd89b7931461ccd959a3a5e658c19fdcc3508f )
-    comment "http://www.romhacking.net/translations/3754/"
+    patch "http://www.romhacking.net/translations/3754/"
 )

--- a/metadat/hacks/Nintendo - Nintendo 64.dat
+++ b/metadat/hacks/Nintendo - Nintendo 64.dat
@@ -11,33 +11,33 @@ game (
     name "Custom Robo (Japan) [T-En by Star Trinket]"
     description "English translation by Star Trinket version (1.0)"
     rom ( name "Custom Robo (Japan).v64" size 16777216 crc 004e7c90 md5 93144df5a66c66f6c243471beb40b90b sha1 fde8e692c0aa4c3d34264319ab00601f83a7bd17 )
-    comment "http://www.romhacking.net/translations/3237/"
+    patch "http://www.romhacking.net/translations/3237/"
 )
 game (
     name "Custom Robo (Japan) [T-En by Star Trinket]"
     description "English translation by Star Trinket version (1.0)"
     rom ( name "Custom Robo (Japan).z64" size 16777216 crc fce6cdbc md5 f4a534469f81f493ffcfe4fcd6c4908a sha1 f8744703579f6ac2ee427ac50fbce5b95f11a918 )
-    comment "http://www.romhacking.net/translations/3237/"
+    patch "http://www.romhacking.net/translations/3237/"
 )
 game (
     name "Custom Robo (Japan) [T-En by Star Trinket]"
     description "English translation by Star Trinket version (1.0)"
     rom ( name "Custom Robo (Japan).n64" size 16777216 crc 889b5295 md5 23860193df1bc9978a79a24122e5a64c sha1 6d545d26c910f31794c71b59b08fef54eab9ef3b )
-    comment "http://www.romhacking.net/translations/3237/"
+    patch "http://www.romhacking.net/translations/3237/"
 )
 game (
     name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
     description "'Wonder Project J2' translation by Ryu version 1.0"
     rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).v64" size 8912896 crc 38401ddb md5 9389cea162a3bbff3bf6f81284cc7786 sha1 cae4915a67d952f37a78e004d97d630bccc155a6 )
     comment "tool64 can't convert to other byte orders after patching"
-    comment "http://www.romhacking.net/translations/1074/"
+    patch "http://www.romhacking.net/translations/1074/"
 )
 game (
     name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
     description "'Wonder Project J2' translation by Ryu version 1.0"
     rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size 8912896 crc e1094e29 md5 3c02f56dd7b1a06be83a7a288755612f sha1 27c4c8f199d1045c697c5d79d216d33e1c715760 )
     comment "tool64 can't convert to other byte orders after patching"
-    comment "http://www.romhacking.net/translations/1074/"
+    patch "http://www.romhacking.net/translations/1074/"
 )
 game (
     name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
@@ -61,56 +61,56 @@ game (
     name "Super Mario Star Road [Hack by Skelux Core]"
     description "Super Mario Star Road hack by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.v64" size 50331648 crc 646e8fff md5 caf803c77c9223b28b663af0b7e49a00 sha1 45e75bd3a1380bfeb874721c29581b47cfafa8d1 )
-    comment "http://www.romhacking.net/hacks/873/"
+    patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Super Mario Star Road [Hack by Skelux Core]"
     description "Super Mario Star Road hack by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.z64" size 50331648 crc 2bd94dd7 md5 80e5019c9dd12648f909b3a5715ed580 sha1 469c6555a078dd831fa51ce601a653e44b3ce071 )
-    comment "http://www.romhacking.net/hacks/873/"
+    patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Super Mario Star Road [Hack by Skelux Core]"
     description "Super Mario Star Road hack by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.n64" size 50331648 crc e40c674e md5 00f5bcdd597dbc575b8811d5430bb353 sha1 176bd6a50aee06fcc917c123f412fdc0c02dd922 )
-    comment "http://www.romhacking.net/hacks/873/"
+    patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
     description "Zelda's Birthday hack by jsa version (1.5)"
     rom ( name "Zelda's Birthday.v64" size 67108864 crc 65fceb4b md5 12fd4f2ac3ffe761be42e9fa63f75bc7 sha1 b001eec2adb2d80e9088909a417388c91dc8b545 )
-    comment "http://www.romhacking.net/hacks/676/"
+    patch "http://www.romhacking.net/hacks/676/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
     description "Zelda's Birthday hack by jsa version (1.5)"
     rom ( name "Zelda's Birthday.z64" size 67108864 crc 9dcde00e md5 9dc5ed87adf6e859391751ae124b44f5 sha1 881bbf199e24d37a291f95adc0000a89573bec70 )
-    comment "http://www.romhacking.net/hacks/676/"
+    patch "http://www.romhacking.net/hacks/676/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
     description "Zelda's Birthday hack by jsa version (1.5)"
     rom ( name "Zelda's Birthday.n64" size 67108864 crc 4ed0632f md5 4d28941a4799a099d32f79f7ebca83f1 sha1 7095b2e825517b77a62f42198212565bd2a259c9 )
-    comment "http://www.romhacking.net/hacks/676/"
+    patch "http://www.romhacking.net/hacks/676/"
 )
 game (
     name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition).z64" size 33554432 crc 48124886 md5 7fc61f232811cd779d4789f71d55562c sha1 24207202d44e2a7fa5e4297187082945310bae0c )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
-    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )
 game (
     name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition).z64" size 33554432 crc 339fc360 md5 6d79c2e17eb78ab9d6b40b49c6939949 sha1 800c27d8231a17c4321e801108893015b9ee22b2 )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
-    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )
 game (
     name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition).z64" size 33554432 crc 3d034499 md5 7f8386e3816db3ede468a4669fe7c978 sha1 f0fb78384331edf36e4daccd99571d4c8c605405 )
     comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
-    comment "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
 )

--- a/metadat/hacks/Nintendo - Nintendo DS.dat
+++ b/metadat/hacks/Nintendo - Nintendo DS.dat
@@ -6,85 +6,85 @@ game (
     name "Blood of Bahamut (Japan) [T-En by Aaron Tokunaga-Chmielowiec]"
     description "English translation by Aaron Tokunaga-Chmielowiec version (1.07)"
     rom ( name "Blood of Bahamut (Japan).nds" size 67108864 crc 6df95de4 md5 f951a883d307ea7e0a12aff54971a7a9 sha1 7d77c4f200d2942c78386896ab4855c543a19783 )
-    comment "http://www.romhacking.net/translations/2560/"
+    patch "http://www.romhacking.net/translations/2560/"
 )
 game (
     name "Trauma Center Under the Knife 2 Wii Controls Hack [Hack by Greiga Master]"
     description "Trauma Center Under the Knife 2 Wii Controls Hack hack by Greiga Master version (1.01)"
     rom ( name "Trauma Center - Under the Knife 2 (USA).nds" size 57189404 crc c658f891 md5 2fbb88aa538bdf0de5f156dced62ead0 sha1 709dcb2f8da742cec229f83c9f1771cd0aec941d )
-    comment "http://www.romhacking.net/hacks/1807/"
+    patch "http://www.romhacking.net/hacks/1807/"
 )
 game (
     name "SaGa 3: Rulers of Time and Space - Shadow or Light [T-En by Cain and Easton West]"
     description "English translation by Cain and Easton West version (Beta 2.0.830)"
     rom ( name "SaGa 3 - Jikuu no Hasha - Shadow or Light (Japan) [b].nds" size 123213056 crc 2af5af5a md5 9c7a8a8865f74b1790c8f0aea3198f1c sha1 781a73bb0d75c0ded12edadcf9fca858c6e0c400 )
-    comment "http://www.romhacking.net/translations/1705/"
+    patch "http://www.romhacking.net/translations/1705/"
 )
 game (
     name "Irozuki Tingle no Koi no Balloon Trip (Japan) [T-En by Team Tingle]"
     description "English translation by Team Tingle version (1.1)"
     rom ( name "Irozuki Tingle no Koi no Balloon Trip (Japan).nds" size 76248200 crc ce27be97 md5 9eeba755e421dc27b208c5f0b67b39fe sha1 8d7cbf9bb3006a215e6f8aba7615bee5f413227e )
-    comment "http://www.romhacking.net/translations/3376/"
+    patch "http://www.romhacking.net/translations/3376/"
 )
 game (
     name "7th Dragon [T-En by Pokeytax]"
     description "English translation by Pokeytax version (1.01)"
     rom ( name "7th Dragon (Japan) [b].nds" size 134217728 crc 9dd36d0f md5 181ffe7d92d9b0e1e8f852317a0c1737 sha1 2e380c2b21f22d88454d1488095dbf016ba6b572 )
-    comment "http://www.romhacking.net/translations/2176/"
+    patch "http://www.romhacking.net/translations/2176/"
 )
 game (
     name "SaGa 2 - Hihou Densetsu - Goddess of Destiny (Japan) [T-En by Crimson Nocturnal]"
     description "English translation by Crimson Nocturnal version (2.11)"
     rom ( name "SaGa 2 - Hihou Densetsu - Goddess of Destiny (Japan).nds" size 125207004 crc ba0f9202 md5 1523f3f334c9b37ff69756e329a6c483 sha1 b13750effc86369649b8aa999bba59ddaa56b758 )
-    comment "http://www.romhacking.net/translations/1610/"
+    patch "http://www.romhacking.net/translations/1610/"
 )
 game (
     name "Tales of Innocence (Japan) [T-En by Kingcom and throughhim413]"
     description "English translation by Kingcom and throughhim413 version (1.0)"
     rom ( name "Tales of Innocence (Japan).nds" size 134217728 crc 186d0370 md5 0cde783d226ad82ddb8bffd98af4f0a3 sha1 750ebfc067e0d3147361c0e752fb2951212ed52b )
-    comment "http://www.romhacking.net/translations/1594/"
+    patch "http://www.romhacking.net/translations/1594/"
 )
 game (
     name "Fire Emblem - Shin Monshou no Nazo - Hikari to Kage no Eiyuu (Japan) (Rev 1) (NDSi Enhanced) [b] [T-En by The Heroes of Shadow]"
     description "English translation by The Heroes of Shadow version (3.01)"
     rom ( name "Fire Emblem - Shin Monshou no Nazo - Hikari to Kage no Eiyuu (Japan) (Rev 1) (NDSi Enhanced) [b].nds" size 134217728 crc 889be26f md5 f3765a64b0c70d14ad10067c83505443 sha1 7f62fc579ab46133846126c114234ee8b4bd3b68 )
-    comment "http://www.romhacking.net/translations/1764/"
+    patch "http://www.romhacking.net/translations/1764/"
 )
 game (
     name "Legend of Zelda Spirit Tracks D-Pad Controls [Hack by Greiga Master]"
     description "Legend of Zelda Spirit Tracks D-Pad Controls hack by Greiga Master version (1.01)"
     rom ( name "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es).nds" size 94096060 crc f846f7f3 md5 4b0882022b1d66f55cfbe68078b3cd83 sha1 7dd2f09473a2d049e01cc08491dd69f6ac71cc2b )
-    comment "http://www.romhacking.net/hacks/2235/"
+    patch "http://www.romhacking.net/hacks/2235/"
 )
 game (
     name "Castlevania: Dawn of Dignity (New Portraits Hack) [Hack by ShadowOne333 + 2 hacks]"
     description "Castlevania: Dawn of Dignity (New Portraits Hack) hack by ShadowOne333 version (1.1) + Castlevania: Dawn of Sorrow Fixed Luck hack by LagoLunatic version (1.0) + Castlevania: Dawn of Sorrow No Required Touch Screen hack by LagoLunatic version (1.1)"
     rom ( name "Castlevania - Dawn of Sorrow (USA).nds" size 67108864 crc f6c7192b md5 4161086eedebafdbacc1678bb7349577 sha1 2f23dc3c148556f4ba2ad845fd172bb223693535 )
-    comment "http://www.romhacking.net/hacks/3356/"
-    comment "http://www.romhacking.net/hacks/3407/"
-    comment "http://www.romhacking.net/hacks/3408/"
+    patch "http://www.romhacking.net/hacks/3356/"
+    patch "http://www.romhacking.net/hacks/3407/"
+    patch "http://www.romhacking.net/hacks/3408/"
 )
 game (
     name "Gyakuten Kenji 2 (Japan) [T-En by Auryn]"
     description "English translation by Auryn version (Final V2)"
     rom ( name "Gyakuten Kenji 2 (Japan).nds" size 45165392 crc a1b255cf md5 3cf7bcf088149601d5a38742dd3da9ac sha1 2456f96e7d5f47f05479bc743fd235765a8e8668 )
-    comment "http://www.romhacking.net/translations/2260/"
+    patch "http://www.romhacking.net/translations/2260/"
 )
 game (
     name "Legend of Zelda Phantom Hourglass D-Pad Patch [Hack by Greiga Master]"
     description "Legend of Zelda Phantom Hourglass D-Pad Patch hack by Greiga Master version (1.0)"
     rom ( name "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es).nds" size 65327204 crc 404e6312 md5 ac87bd6dd589586c37d533f1541c0de3 sha1 7e0d26d143992f1eee182b24f1abb9e7f038eacf )
-    comment "http://www.romhacking.net/hacks/2248/"
+    patch "http://www.romhacking.net/hacks/2248/"
 )
 game (
     name "Nanashi no Geemu (Japan) [T-En by Nagato, Ryusui and summvs]"
     description "English translation by Nagato, Ryusui and summvs version (1.2)"
     rom ( name "Nanashi no Geemu (Japan).nds" size 68743360 crc 90a04d40 md5 b8fcd6501c37c755b7c366c3ff19965e sha1 7392e2d25354f77bbd6c3b0a16f3b40eb061b1a1 )
-    comment "http://www.romhacking.net/translations/1654/"
+    patch "http://www.romhacking.net/translations/1654/"
 )
 game (
     name "Nanashi no Geemu Me (Japan) [b] [T-En by Nagato]"
     description "English translation by Nagato version (1.13)"
     rom ( name "Nanashi no Geemu Me (Japan) [b].nds" size 63459956 crc 8321a8ca md5 2c8fd83c44860b27fdc8b4c991962e37 sha1 2eb2eba44d54fb0e0091e57311bf49231dabf817 )
-    comment "http://www.romhacking.net/translations/2456/"
+    patch "http://www.romhacking.net/translations/2456/"
 )

--- a/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
@@ -37,11 +37,11 @@ game (
     name "Mario Adventure"
     description "'Super Mario Bros. 3' hack by DahrkDaiz"
     rom ( name "Mario_Adventure.nes" size 426000 crc 26a8de2c md5 ceb3261eaf10e464842bce5072b6abf0 sha1 069be38823c366777268c49da6e19b84c5667622 )
-    comment "https://www.romhacking.net/hacks/70/"
+    patch "http://www.romhacking.net/hacks/70/"
 )
 game (
     name "Mother: 25th Anniversary Edition"
     description "'Mother' hack by DragonDePlatino, Dr. Floppy, Tomato, vince94, and Jonesy47 version 1.11"
     rom ( name "Mother_25th_Anniversary_Edition.nes" size 524304 crc 6e24f190 md5 88cfab9094665bff0849079999dcf681 sha1 00ae39f447bc787edf01f3515977bea689cd5c54 )
-    comment "https://www.romhacking.net/hacks/2211/"
+    patch "http://www.romhacking.net/hacks/2211/"
 )

--- a/metadat/hacks/Sega - Game Gear.dat
+++ b/metadat/hacks/Sega - Game Gear.dat
@@ -6,71 +6,71 @@ game (
     name "Phantasy Star Gaiden (Japan) [T-En by Dynamic-Designs and Taskforce]"
     description "English translation by Dynamic-Designs and Taskforce version (1.012)"
     rom ( name "Phantasy Star Gaiden (Japan).gg" size 262144 crc 1c98154a md5 ba091114cbc5a4b3482e6887094070bb sha1 4a53a203af8ed7542a86d6fa0db0314b047afef5 )
-    comment "http://www.romhacking.net/translations/63/"
+    patch "http://www.romhacking.net/translations/63/"
 )
 game (
     name "Head Buster (Japan) [T-En by Chris M. Covell]"
     description "English translation by Chris M. Covell version (0.99)"
     rom ( name "Head Buster (Japan).gg" size 131072 crc 8ed94c2b md5 6848f595b71795a64322255c60fdb39b sha1 2d8d587f6a5341d6665de5d9ee1906889344d1ed )
-    comment "http://www.romhacking.net/translations/903/"
+    patch "http://www.romhacking.net/translations/903/"
 )
 game (
     name "Madou Monogatari I - 3-Tsu no Madoukyuu (Japan) [T-En by filler and SSTranslations]"
     description "English translation by filler and SSTranslations version (1.0)"
     rom ( name "Madou Monogatari I - 3-Tsu no Madoukyuu (Japan).gg" size 524288 crc b289011d md5 81c3447b356a808a8e8e7b7c6a815c32 sha1 fba3a3126dfef2b9192c9f4e26252d656dccf1fd )
-    comment "http://www.romhacking.net/translations/1502/"
+    patch "http://www.romhacking.net/translations/1502/"
 )
 game (
     name "Lunar - Sanposuru Gakuen (Japan) [T-En by Aeon Genesis and Some Good Shit Translations]"
     description "English translation by Aeon Genesis and Some Good Shit Translations version (1.0)"
     rom ( name "Lunar - Sanposuru Gakuen (Japan).gg" size 1048576 crc 19f3f168 md5 3dccee17f3f355413e5ade333b2f70a0 sha1 a9e9e990ab5d19471c9d6d0fcadf8949f42ff3e9 )
-    comment "http://www.romhacking.net/translations/1454/"
+    patch "http://www.romhacking.net/translations/1454/"
 )
 game (
     name "SD Gundam - Winner's History (Japan) [T-En by Gaijin Productions]"
     description "English translation by Gaijin Productions version (0.99)"
     rom ( name "SD Gundam - Winner's History (Japan).gg" size 524288 crc d9a69e9e md5 408809d2f922e90154c5a5213ce2a39a sha1 121bb17a137d68d8f74c4d34a5b8ecb1892c2256 )
-    comment "http://www.romhacking.net/translations/64/"
+    patch "http://www.romhacking.net/translations/64/"
 )
 game (
     name "Shining Force Gaiden - Final Conflict (Japan) [T-En by Shining Force Central]"
     description "English translation by Shining Force Central version (070706 final)"
     rom ( name "Shining Force Gaiden - Final Conflict (Japan).gg" size 524288 crc 23bac434 md5 abdef9e89d2963c70c5573d37edd9d9d sha1 9a7370301e16488aab205c8595169044f90677ba )
-    comment "http://www.romhacking.net/translations/876/"
+    patch "http://www.romhacking.net/translations/876/"
 )
 game (
     name "Megami Tensei Gaiden - Last Bible S (Japan) [T-En by MrRichard999, SSTranslations and Tom]"
     description "English translation by MrRichard999, SSTranslations and Tom version (1.02)"
     rom ( name "Megami Tensei Gaiden - Last Bible S (Japan).gg" size 524288 crc 1a1cb7f8 md5 d918c05bad2910779c3892b376d33054 sha1 87028e86fe22ac0cd3d4e06d64e1319617d42cb1 )
-    comment "http://www.romhacking.net/translations/3160/"
+    patch "http://www.romhacking.net/translations/3160/"
 )
 game (
     name "Royal Stone - Hirakareshi Toki no Tobira (Japan) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (1.00)"
     rom ( name "Royal Stone - Hirakareshi Toki no Tobira (Japan).gg" size 524288 crc e4677b07 md5 0e3fecf6ebb236531743fcef29ed7f64 sha1 1aca8d57407d821976b9dc58fd7ab22064bdd146 )
-    comment "http://www.romhacking.net/translations/2076/"
+    patch "http://www.romhacking.net/translations/2076/"
 )
 game (
     name "Sylvan Tale (Japan) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (1.01)"
     rom ( name "Sylvan Tale (Japan).gg" size 524288 crc 5d803486 md5 56de378aaba52d3473852e7539a79e15 sha1 22a516bf4dc27c0c9c94ac950c5eb5f45d809077 )
-    comment "http://www.romhacking.net/translations/67/"
+    patch "http://www.romhacking.net/translations/67/"
 )
 game (
     name "Phantasy Star Adventure (Japan) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (1.0)"
     rom ( name "Phantasy Star Adventure (Japan).gg" size 131072 crc 42c98a68 md5 c069464b6a0f9fa547c22133f143b75c sha1 642a485e31d004a569ff6dd71a458338fdbf19a0 )
-    comment "http://www.romhacking.net/translations/62/"
+    patch "http://www.romhacking.net/translations/62/"
 )
 game (
     name "Magic Knight Rayearth (Japan) [T-En by filler]"
     description "English translation by filler version (1.0)"
     rom ( name "Magic Knight Rayearth (Japan).gg" size 524288 crc 6c9b8b15 md5 b9b1a0f7d84c6d01fa53c56d87d23d53 sha1 451d5ff041ea7051e39af026f9a4ee897509cd32 )
-    comment "http://www.romhacking.net/translations/3726/"
+    patch "http://www.romhacking.net/translations/3726/"
 )
 game (
     name "Kishin Douji Zenki (Japan) [T-En by cccmar]"
     description "English translation by cccmar version (1.0)"
     rom ( name "Kishin Douji Zenki (Japan).gg" size 1048576 crc dcd63e4c md5 b0f8f7a3b573468f1d65b660c173dc82 sha1 048e3bddc01f4079d0a6a54efbeca1254d10d1f2 )
-    comment "http://www.romhacking.net/translations/3767/"
+    patch "http://www.romhacking.net/translations/3767/"
 )

--- a/metadat/hacks/Sega - Master System - Mark III.dat
+++ b/metadat/hacks/Sega - Master System - Mark III.dat
@@ -6,71 +6,71 @@ game (
     name "Golvellius - SRAM save [Hack by Ichigobankai]"
     description "Golvellius - SRAM save hack by Ichigobankai version (1.0)"
     rom ( name "Golvellius (USA, Europe).sms" size 262144 crc a465cd07 md5 ecae9027839fc25797037d8cf424ffb3 sha1 291df4df5a07749b7106bc53657fef5aa1f3909f )
-    comment "http://www.romhacking.net/hacks/3631/"
+    patch "http://www.romhacking.net/hacks/3631/"
 )
 game (
     name "Hoshi wo Sagasite... (Japan) [T-En by filler and SSTranslations]"
     description "English translation by filler and SSTranslations version (1.0)"
     rom ( name "Hoshi wo Sagasite... (Japan).sms" size 262144 crc b5ce862f md5 87357229d77a4c796b57f45c243456d1 sha1 641ae3eb1cb476359a0a0ade2f45437d47e24361 )
-    comment "http://www.romhacking.net/translations/1447/"
+    patch "http://www.romhacking.net/translations/1447/"
 )
 game (
     name "Zillion Slight Improvement [Hack by Johnny]"
     description "Zillion Slight Improvement hack by Johnny version (1.0)"
     rom ( name "Zillion (USA) (Rev 1).sms" size 131072 crc 3a9f4c9e md5 9cbe687e43bad149d54e169aff8dc0cd sha1 6f04dcf1647b682d7a29b13625310b0bef50804c )
-    comment "http://www.romhacking.net/hacks/879/"
+    patch "http://www.romhacking.net/hacks/879/"
 )
 game (
     name "Sukeban Deka II - Shoujo Tekkamen Densetsu (Japan) [T-En by enigmaopoeia and SSTranslations]"
     description "English translation by enigmaopoeia and SSTranslations version (1.0)"
     rom ( name "Sukeban Deka II - Shoujo Tekkamen Densetsu (Japan).sms" size 262144 crc 0950a312 md5 5aab1adbbb642daa2ecbf6333e68807d sha1 79590e6232c14c2577e346391d7c1db481c824c2 )
-    comment "http://www.romhacking.net/translations/1488/"
+    patch "http://www.romhacking.net/translations/1488/"
 )
 game (
     name "Phantasy Star (Japan) [T-En by SMS Power!]"
     description "English translation by SMS Power! version (1.02)"
     rom ( name "Phantasy Star (Japan).sms" size 524288 crc 70e89681 md5 a0f614f26e99633493e3a3339bc85586 sha1 82067c389b26f65f5a1106a9894a0b19dd3c54f9 )
-    comment "http://www.romhacking.net/translations/1069/"
+    patch "http://www.romhacking.net/translations/1069/"
 )
 game (
     name "Spellcaster - SRAM save [Hack by Ichigobankai]"
     description "Spellcaster - SRAM save hack by Ichigobankai version (1.0)"
     rom ( name "SpellCaster (USA, Europe).sms" size 524288 crc 13a0838a md5 67b6ff0d6427c37645455edf75b69b93 sha1 89aa2072268d4577e31db26a6865f3d5ba5fc09f )
-    comment "http://www.romhacking.net/hacks/3632/"
+    patch "http://www.romhacking.net/hacks/3632/"
 )
 game (
     name "Ys US Master System FM sound patch [Hack by SSTranslations]"
     description "Ys US Master System FM sound patch hack by SSTranslations version (1.2)"
     rom ( name "Ys - The Vanished Omens (USA, Europe).sms" size 262144 crc 7ed5dca2 md5 dd5d01d4e1fe7d275f95ac95dc63b04f sha1 c61f4302a6ca6ccd1e79c5174bcefaf0c94f6c41 )
-    comment "http://www.romhacking.net/hacks/572/"
+    patch "http://www.romhacking.net/hacks/572/"
 )
 game (
     name "High School! Kimengumi (Japan) [T-En by SMS Power!]"
     description "English translation by SMS Power! version (1.0)"
     rom ( name "High School! Kimengumi (Japan).sms" size 131072 crc 8a296a3e md5 471e80fed601261667b1fc6242396239 sha1 f4350a41ec6cd685e21b09ce471c3456646d6904 )
-    comment "http://www.romhacking.net/translations/883/"
+    patch "http://www.romhacking.net/translations/883/"
 )
 game (
     name "Miracle Warriors Improvement [Hack by Penta Penguin]"
     description "Miracle Warriors Improvement hack by Penta Penguin version (1.0)"
     rom ( name "Miracle Warriors - Seal of the Dark Lord (USA, Europe).sms" size 262144 crc 4f50b42a md5 f75318912bf0bb45b9b9a16e2ecb3502 sha1 8536cf7ac553612ecf2db2d8d423d5c2221d73a3 )
-    comment "http://www.romhacking.net/hacks/2127/"
+    patch "http://www.romhacking.net/hacks/2127/"
 )
 game (
     name "Hokuto no Ken (Japan) [T-En by phalanX]"
     description "English translation by phalanX version (1.0)"
     rom ( name "Hokuto no Ken (Japan).sms" size 131072 crc d3c17b48 md5 f0b348ca5d23fcfde830dc7a1ade3c3b sha1 259d0d031c5c3a2609a8f0e5b9b87a5752d5c9f4 )
-    comment "http://www.romhacking.net/translations/3381/"
+    patch "http://www.romhacking.net/translations/3381/"
 )
 game (
     name "Sonic 1 Improvement [Hack by Penta Penguin]"
     description "Sonic 1 Improvement hack by Penta Penguin version (1.2)"
     rom ( name "Sonic The Hedgehog (USA, Europe).sms" size 262144 crc a291032c md5 1f34c34c95c9b294b056c1648b22c00d sha1 3719bb613ca6dab1e2d18295a0c688393c2109e0 )
-    comment "http://www.romhacking.net/hacks/983/"
+    patch "http://www.romhacking.net/hacks/983/"
 )
 game (
     name "Wonder Boy III - SRAM Save [Hack by Ichigobankai]"
     description "Wonder Boy III - SRAM Save hack by Ichigobankai version (1.2)"
     rom ( name "Wonder Boy III - The Dragon's Trap (USA, Europe).sms" size 262144 crc 725132ae md5 c7e1464e9ac0805f08ae7151796f69da sha1 d27fd069a244d2496e156c41d5b3fca4fe27649e )
-    comment "http://www.romhacking.net/hacks/3628/"
+    patch "http://www.romhacking.net/hacks/3628/"
 )

--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -11,281 +11,281 @@ game (
     name "El Viento Enhancement [Hack by M.I.J.E.T.]"
     description "El Viento Enhancement hack by M.I.J.E.T. version (101010)"
     rom ( name "El. Viento (USA).md" size 1048576 crc 363946b2 md5 ca18abf6ccede48681f013db3c43f108 sha1 83c55f390ce33cfbfcd8c913e8a34a0c3bc304ae )
-    comment "http://www.romhacking.net/hacks/678/"
+    patch "http://www.romhacking.net/hacks/678/"
 )
 game (
     name "Rent a Hero (Japan) [T-En by NikcDC]"
     description "English translation by NikcDC version (0.97)"
     rom ( name "Rent a Hero (Japan).md" size 1271970 crc efe3483b md5 ce0affb925c93c4ad8342ac874af87cd sha1 0b2f5da12190cd9ecf1dfd374781b2ff3931635d )
-    comment "http://www.romhacking.net/translations/2309/"
+    patch "http://www.romhacking.net/translations/2309/"
 )
 game (
     name "Sonic 3D Blast: Director's Cut [Hack by GameHut]"
     description "Sonic 3D Blast: Director's Cut hack by GameHut version (1.0)"
     rom ( name "Sonic 3D Blast ~ Sonic 3D Flickies' Island (USA, Europe).md" size 4191682 crc 9767e840 md5 742dd5c98d143ff6716800dee6a25dc5 sha1 4072d34e119e199131b839d338f1fc38e472203a )
-    comment "http://www.romhacking.net/hacks/3810/"
+    patch "http://www.romhacking.net/hacks/3810/"
 )
 game (
     name "Phantasy Star II - Amia's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Amia's Adventure (Japan) (SegaNet).md" size 262144 crc 7fdb5fe9 md5 cbdf6fe34574675dbd9da1cfccd6b9f5 sha1 f33e5744f94dc0364bd548bf937e194e4c630666 )
-    comment "http://www.romhacking.net/translations/1530/"
+    patch "http://www.romhacking.net/translations/1530/"
 )
 game (
     name "Monster World IV (Japan) [T-En by Di Somma Michele]"
     description "English translation by Di Somma Michele version (2.2)"
     rom ( name "Monster World IV (Japan).md" size 2097152 crc c94a35bf md5 7fb7c9c2d737e8d65298e039262e68a8 sha1 91bb0c1f54ce68287233e3b36f0ba3c96cc574c6 )
-    comment "http://www.romhacking.net/translations/1276/"
+    patch "http://www.romhacking.net/translations/1276/"
 )
 game (
     name "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors [Hack by fusaru]"
     description "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors hack by fusaru version (2.00)"
     rom ( name "Twin Cobra (USA).md" size 704120 crc 88ea1e4e md5 d1c82b81594f80a1868a141275e16bba sha1 1bae39be93427bddfd7fff1db2a47954abb9d8a1 )
-    comment "http://www.romhacking.net/hacks/2920/"
+    patch "http://www.romhacking.net/hacks/2920/"
 )
 game (
     name "Sally Acorn in Sonic the Hedgehog [Hack by E-122-Psi]"
     description "Sally Acorn in Sonic the Hedgehog hack by E-122-Psi version (2.2)"
     rom ( name "Sally Acorn In Sonic The Hedgehog.md" size 1048576 crc 96f971f6 md5 80d3491eca8580494a87186ca9f40abd sha1 1bb88d7f4dfcea94d3f47e79b9c1fddf364b2d59 )
-    comment "http://www.romhacking.net/hacks/1020/"
+    patch "http://www.romhacking.net/hacks/1020/"
 )
 game (
     name "Battle Golfer Yui (Japan) [T-En by filler]"
     description "English translation by filler version (0.9)"
     rom ( name "Battle Golfer Yui (Japan).md" size 1048576 crc 2d7e868c md5 70ca38f7dc03560fa770a298ecef438a sha1 2c6f17f0c212bb51b6ef629b123bae4bd2359816 )
-    comment "http://www.romhacking.net/translations/3364/"
+    patch "http://www.romhacking.net/translations/3364/"
 )
 game (
     name "Tougiou King Colossus (Japan) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (061030)"
     rom ( name "Tougiou King Colossus (Japan).md" size 1048576 crc 016afd40 md5 7c932a29d9943944cda4b37241b17b22 sha1 7c397fe46acba156cc428bbe428c6d5cb8121ff4 )
-    comment "http://www.romhacking.net/translations/914/"
+    patch "http://www.romhacking.net/translations/914/"
 )
 game (
     name "Phantasy Star II - Rudger's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Rudger's Adventure (Japan) (SegaNet).md" size 262144 crc 3cd3bc1c md5 dbc8487b78b63efc151b80ea89de17ff sha1 3462b67944fa467a616106cf6be3ed2bb282f51e )
-    comment "http://www.romhacking.net/translations/1533/"
+    patch "http://www.romhacking.net/translations/1533/"
 )
 game (
     name "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors [Hack by fusaru]"
     description "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors hack by fusaru version (1.0)"
     rom ( name "Daisenpuu ~ Twin Hawk (Japan, Europe).md" size 524288 crc abd8ce33 md5 1100938e017a56ee30c8e368ba06dc18 sha1 51e3b19d3652d5bcb45165ab6838c77455a39a28 )
-    comment "http://www.romhacking.net/hacks/3310/"
+    patch "http://www.romhacking.net/hacks/3310/"
 )
 game (
     name "Phantasy Star III - Generations of Doom (USA, Europe, Korea) [T-En by Peaches]"
     description "English translation by Peaches version (1.0)"
     rom ( name "Phantasy Star III - Generations of Doom (USA, Europe, Korea).md" size 828012 crc ca89dbe5 md5 4d8baa33ac18e4625142c4b0c3c4af37 sha1 7913d984460d6117d57d5762b9cf43af932baa96 )
-    comment "http://www.romhacking.net/translations/3549/"
+    patch "http://www.romhacking.net/translations/3549/"
 )
 game (
     name "Phantasy Star II - Anne's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Anne's Adventure (Japan) (SegaNet).md" size 262144 crc 355fad11 md5 cee72632b13d435674b2ddac637c5f8e sha1 46a0e249b9564ed0d3d2df2435e42f0d7bdf3d97 )
-    comment "http://www.romhacking.net/translations/1221/"
+    patch "http://www.romhacking.net/translations/1221/"
 )
 game (
     name "Langrisser II (Japan) (Rev B) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (110701)"
     rom ( name "Langrisser II (Japan) (v1.2).md" size 2097152 crc e8f28522 md5 3da68d7ef336d2ea7fa2cc9c1481c9fe sha1 fe43c51314ed902c65ce967f3b181dcefad2d59c )
-    comment "http://www.romhacking.net/translations/1314/"
+    patch "http://www.romhacking.net/translations/1314/"
 )
 game (
     name "Streets of Rage 3 (Roo, Ash, Shiva Unlocked) [Hack by Evgeny]"
     description "Streets of Rage 3 (Roo, Ash, Shiva Unlocked) hack by Evgeny version (1.0)"
     rom ( name "Streets of Rage 3 (USA).md" size 4194304 crc 396e2937 md5 18e4790c9a797a1085bd452d3c0d46de sha1 8cf55d57e34602c1b454bb37b17b2431a1f8e771 )
-    comment "http://www.romhacking.net/hacks/2253/"
+    patch "http://www.romhacking.net/hacks/2253/"
 )
 game (
     name "Vixen 357 (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (1.2)"
     rom ( name "Vixen 357 (Japan).md" size 1310720 crc f8ce2e43 md5 a7144ee7bc7ec52c63116734b1dcdc4f sha1 b32b1af7c2be5709f0822b636fd2bc73fca80540 )
-    comment "http://www.romhacking.net/translations/2738/"
+    patch "http://www.romhacking.net/translations/2738/"
 )
 game (
     name "Advanced Busterhawk Gleylancer (Japan) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (061023)"
     rom ( name "Advanced Busterhawk Gleylancer (Japan).md" size 1048576 crc 1b744d15 md5 a13ab653a20fb383337fab1e52ddb0df sha1 80bd2c7c06d45040399418980fae6a557f0574c8 )
-    comment "http://www.romhacking.net/translations/1173/"
+    patch "http://www.romhacking.net/translations/1173/"
 )
 game (
     name "Phantasy Star II - Kinds's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Kinds's Adventure (Japan) (SegaNet).md" size 262144 crc e91051e3 md5 ca9c437ccf387fb581f9ee00cfb14f34 sha1 731576ebdc8999417859ca440901d6c521d91477 )
-    comment "http://www.romhacking.net/translations/1150/"
+    patch "http://www.romhacking.net/translations/1150/"
 )
 game (
     name "Phantasy Star II - Nei's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Nei's Adventure (Japan) (SegaNet).md" size 262144 crc b0ce897c md5 30fb373aa2d47af800712f6897823309 sha1 759ca49ca18a5e1a9f6d55770a50f5bcf3d3fcce )
-    comment "http://www.romhacking.net/translations/1532/"
+    patch "http://www.romhacking.net/translations/1532/"
 )
 game (
     name "Star Cruiser (Japan) [T-En by Nebulous Translations]"
     description "English translation by Nebulous Translations version (0.99)"
     rom ( name "Star Cruiser (Japan).md" size 786432 crc 53d8b33e md5 2d3ead69178e0c0ccbf0d80102a3faed sha1 8404b0008fc1796706b06a3a709bd5c631e31fc4 )
-    comment "http://www.romhacking.net/translations/2776/"
+    patch "http://www.romhacking.net/translations/2776/"
 )
 game (
     name "Phantasy Star II - Yushis's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Yushis's Adventure (Japan) (SegaNet).md" size 262144 crc 5395a7e2 md5 3c1ce24f8d84735d67fc6e0380c5e4c5 sha1 437a2d2899f18544af981be64de23583aaaf352b )
-    comment "http://www.romhacking.net/translations/1531/"
+    patch "http://www.romhacking.net/translations/1531/"
 )
 game (
     name "Phantasy Star II - Shilka's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Shilka's Adventure (Japan) (SegaNet).md" size 262144 crc 76e56009 md5 35d2cd35f238c59b645f77be6e64ab81 sha1 b3ea1a8b0e749ad5889a414dd4cf99aee83d63fb )
-    comment "http://www.romhacking.net/translations/1159/"
+    patch "http://www.romhacking.net/translations/1159/"
 )
 game (
     name "Dahna - Megami Tanjou (Japan) [T-En by cccmar]"
     description "English translation by cccmar version (1.0)"
     rom ( name "Dahna Megami Tanjou (Japan).md" size 1048576 crc d04d2df7 md5 0f1b62e1b8b651409cf3dbae9a6a4c81 sha1 24310b49b02abce85d8270c95871451206785408 )
-    comment "http://www.romhacking.net/translations/2713/"
+    patch "http://www.romhacking.net/translations/2713/"
 )
 game (
     name "Prince of Persia 2 - Horse Level Fixed [Hack by Linkuei]"
     description "Prince of Persia 2 - Horse Level Fixed hack by Linkuei version (1.0)"
     rom ( name "Prince of Persia 2 - The Shadow and the Flame (Europe) (Proto).md" size 2097152 crc f5e625c9 md5 f2078ee86d5a614925c51a5be81bc3cc sha1 1bfca72bcd6aeb7ad762edb6e114f75bd0bee4b6 )
-    comment "http://www.romhacking.net/hacks/3755/"
+    patch "http://www.romhacking.net/hacks/3755/"
 )
 game (
     name "Mega Man the Wily Wars SRAM+ [Hack by Ar8temis008]"
     description "Mega Man the Wily Wars SRAM+ hack by Ar8temis008 version (0.5)"
     rom ( name "Mega Man - The Wily Wars (Europe).md" size 2097152 crc d5d47d23 md5 1b0d5de7be13517ca2a7249aab5d2152 sha1 cf8c4cb323c7b167ebd52c3f0486e4261f0da2d5 )
-    comment "http://www.romhacking.net/hacks/3837/"
+    patch "http://www.romhacking.net/hacks/3837/"
 )
 game (
     name "The Chaos Engine Amiga colors & music speed fix [Hack by fusaru]"
     description "The Chaos Engine Amiga colors & music speed fix hack by fusaru version (1.01)"
     rom ( name "Chaos Engine, The (Europe).md" size 1572864 crc 65887f32 md5 43fdebcd2edc168f5fb9439eed68820b sha1 7d70a839f9ca5b49f937b54377c16c58fe2fea41 )
-    comment "http://www.romhacking.net/hacks/2754/"
+    patch "http://www.romhacking.net/hacks/2754/"
 )
 game (
     name "Contra: Hard Corps Enhancement Hack [Hack by M.I.J.E.T.]"
     description "Contra: Hard Corps Enhancement Hack hack by M.I.J.E.T. version (Super Cham)"
     rom ( name "Contra - Hard Corps (USA, Korea).md" size 2097152 crc 41b49317 md5 f055fce2a6ab82a96a65290465e0c97e sha1 475a1c99713df4f7f8e66d4f75664559a3dac851 )
-    comment "http://www.romhacking.net/hacks/450/"
+    patch "http://www.romhacking.net/hacks/450/"
 )
 game (
     name "Sonic the Hedgehog Classic Heroes [Hack by flamewing]"
     description "Sonic the Hedgehog Classic Heroes hack by flamewing version (0.10.008a)"
     rom ( name "Sonic Classic Heroes.md" size 4194304 crc c27093da md5 4634c397a507053b0e04fc3ce6c49d9a sha1 a39b4a7c2d69f7d0bc8b40de7757e3be13acea0b )
-    comment "http://www.romhacking.net/hacks/1038/"
+    patch "http://www.romhacking.net/hacks/1038/"
 )
 game (
     name "Undead Line (Japan) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (070903)"
     rom ( name "Undead Line (Japan).md" size 1048576 crc 53b9e72f md5 254741822f6966eafcf924d2f798e8aa sha1 734a2aea93109a20b805f9255ace5f179adc972e )
-    comment "http://www.romhacking.net/translations/1223/"
+    patch "http://www.romhacking.net/translations/1223/"
 )
 game (
     name "Sonic 3 Complete [Hack by Tiddles]"
     description "Sonic 3 Complete hack by Tiddles version (130810)"
     rom ( name "Sonic & Knuckles + Sonic The Hedgehog 3 (USA).md" size 3932160 crc 2bd564b1 md5 153b6d32026993569b16ff89c53197a3 sha1 4461ed4a94b93653905c08e201f7c11a128e5a47 )
-    comment "http://www.romhacking.net/hacks/1056/"
+    patch "http://www.romhacking.net/hacks/1056/"
 )
 game (
     name "Battle Mania Daiginjou (Japan, Korea) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (061029)"
     rom ( name "Battle Mania Daiginjou (Japan, Korea).md" size 1048576 crc 07ba38f6 md5 cb9521fe83d848f65a226d947020ecfa sha1 f425db086a2fa2c21ebf0e54fff5a06adc4b48e9 )
-    comment "http://www.romhacking.net/translations/1075/"
+    patch "http://www.romhacking.net/translations/1075/"
 )
 game (
     name "Phantasy Star II - Huey's Adventure (Japan) (SegaNet) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (100710)"
     rom ( name "Phantasy Star II - Huey's Adventure (Japan) (SegaNet).md" size 262144 crc db2cce50 md5 12260bf5b7863f4489d627865dba1eec sha1 21b06f683d7bc34be61740c0986867f7748ca18e )
-    comment "http://www.romhacking.net/translations/1337/"
+    patch "http://www.romhacking.net/translations/1337/"
 )
 game (
     name "Twinkle Tale (Japan) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (070328)"
     rom ( name "Twinkle Tale (Japan).md" size 1048576 crc 0c43b66b md5 3d2a638bdf18b42621e95788fa9fde9c sha1 e22217a0bdf460c7376fac3d5bed37da00f529a1 )
-    comment "http://www.romhacking.net/translations/1103/"
+    patch "http://www.romhacking.net/translations/1103/"
 )
 game (
     name "Phantasy Star II Bugfix [Hack by lory1990]"
     description "Phantasy Star II Bugfix hack by lory1990 version (4.1)"
     rom ( name "Phantasy Star II (USA, Europe) (Rev A).md" size 784378 crc 54b60daf md5 6cb1775bc35af4680fc1f0f98b5274b2 sha1 3b4698d1d872582de4ce4a65bf0ae24bdf6f0377 )
-    comment "http://www.romhacking.net/hacks/2132/"
+    patch "http://www.romhacking.net/hacks/2132/"
 )
 game (
     name "Shinobi III Enhancement Hack [Hack by M.I.J.E.T.]"
     description "Shinobi III Enhancement Hack hack by M.I.J.E.T. version (111009)"
     rom ( name "Shinobi III - Return of the Ninja Master (USA).md" size 1048576 crc aaea518f md5 7d72722a02c7c0057171ae150683337f sha1 ca27d5445533a31f46ea5db058a1ef56ef093a28 )
-    comment "http://www.romhacking.net/hacks/827/"
+    patch "http://www.romhacking.net/hacks/827/"
 )
 game (
     name "Yu Yu Hakusho - Makyou Toitsusen (Japan) [T-En by M.I.J.E.T.]"
     description "English translation by M.I.J.E.T. version (071113)"
     rom ( name "Yu Yu Hakusho - Makyou Toitsusen (Japan).md" size 3145728 crc 0f041d2e md5 0178d80a25f00b84f1bf15ae365beae0 sha1 d881629af139edb6acf36498654401508501ff69 )
-    comment "http://www.romhacking.net/translations/1222/"
+    patch "http://www.romhacking.net/translations/1222/"
 )
 game (
     name "Bishoujo Senshi Sailor Moon (Japan) [T-En by Supper]"
     description "English translation by Supper version (1.0)"
     rom ( name "Bishoujo Senshi Sailor Moon (Japan).md" size 4194304 crc 48778add md5 54a7dbc8748695a90d95d2728f946b9e sha1 4a89848f9442cb47be6d78c8ca66baa535c3f015 )
-    comment "http://www.romhacking.net/translations/3544/"
+    patch "http://www.romhacking.net/translations/3544/"
 )
 game (
     name "Fushigi no Umi no Nadia (Japan) [T-En by Eien Ni Hen and KingMike's Translations]"
     description "English translation by Eien Ni Hen and KingMike's Translations version (1.1)"
     rom ( name "Fushigi no Umi no Nadia (Japan).md" size 1572864 crc 8dec9c35 md5 b05a6f58495fab4968bce589da8e7dba sha1 2b14aebf4510f02c6fe220a32a2f709db91f60c3 )
-    comment "http://www.romhacking.net/translations/1630/"
+    patch "http://www.romhacking.net/translations/1630/"
 )
 game (
     name "Shadowrun 2050 [Hack by Vikfield]"
     description "Shadowrun 2050 hack by Vikfield version (1.1)"
     rom ( name "Shadowrun (USA).md" size 2097152 crc 8bdf25f0 md5 ffb080691848b24d28cdf1b7c1d1fc18 sha1 03c0f0e67a65feae01349b90f6e679f6e1090f07 )
-    comment "http://www.romhacking.net/hacks/4116/"
+    patch "http://www.romhacking.net/hacks/4116/"
 )
 game (
     name "Phantasy Star Generation: 4 - A Relocalization [Hack by GhaleonUnlimited]"
     description "Phantasy Star Generation: 4 - A Relocalization hack by GhaleonUnlimited version (1.30)"
     rom ( name "Phantasy Star IV (USA).md" size 3193364 crc 016662d2 md5 b1de437701a520399a9c9602b980751d sha1 e24fdd2f75661bf7688aff06831e3caf9dfa6808 )
-    comment "http://www.romhacking.net/hacks/4171/"
+    patch "http://www.romhacking.net/hacks/4171/"
 )
 game (
     name "Ultimate Mortal Kombat 3 Hack [Hack by Nemesis_c]"
     description "Ultimate Mortal Kombat 3 Hack hack by Nemesis_c version (0.6)"
     rom ( name "Ultimate Mortal Kombat 3 (USA).md" size 6248922 crc d8c152ff md5 3ef38ef9ec6fe16526762dff2966cd05 sha1 072c891f23e3e1f960a712fde08b01a9af75c9cb )
-    comment "http://www.romhacking.net/hacks/3158/"
+    patch "http://www.romhacking.net/hacks/3158/"
 )
 game (
     name "Ultimate Mortal Kombat Trilogy [Hack by KABAL_MK]"
     description "Ultimate Mortal Kombat Trilogy hack by KABAL_MK version (Hack 23 (5125))"
     rom ( name "Ultimate Mortal Kombat Trilogy.md" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
-    comment "http://www.romhacking.net/hacks/1059/"
+    patch "http://www.romhacking.net/hacks/1059/"
 )
 game (
     name "Sonic 2 Improvement [Hack by lory1990]"
     description "Sonic 2 Improvement hack by lory1990 version (5.0)"
     rom ( name "Sonic The Hedgehog 2 (World) (Rev A).md" size 1114102 crc f5d4c7cd md5 b3c8945b1d1aa1f6ef867eb3bfb8c26d sha1 7c0e01ed089fa56d52141b5be0a9064eb96fb255 )
-    comment "http://www.romhacking.net/hacks/2137/"
+    patch "http://www.romhacking.net/hacks/2137/"
 )
 game (
     name "Street Fighter II PCM driver fix [Hack by Stephane Dallongeville]"
     description "Street Fighter II PCM driver fix hack by Stephane Dallongeville version (7)"
     rom ( name "Street Fighter II' - Special Champion Edition (USA).md" size 3145728 crc 92b46306 md5 9b4529a4f713c733e5a187bc7b673eca sha1 1d6e640007edbec5e4e7a7d37d48e12a9029fa00 )
-    comment "http://www.romhacking.net/hacks/2133/"
+    patch "http://www.romhacking.net/hacks/2133/"
 )
 game (
     name "Street Fighter 2 Champion Edition Arcade Hack [Hack by Lord Hiryu]"
     description "Street Fighter 2 Champion Edition Arcade Hack hack by Lord Hiryu version (2.0)"
     rom ( name "Street Fighter 2 Champion Edition Arcade Hack.md" size 3145728 crc 518a850e md5 262131e441fadd75d31e3bcf0dd9cccd sha1 4f8167ce31d90ccc95315e32ddb36b7b108bc9ca )
-    comment "http://www.romhacking.net/hacks/3212/"
+    patch "http://www.romhacking.net/hacks/3212/"
 )
 game (
     name "Mortal Kombat II Unlimited - Enhanced Colors [Hack by Pyron]"
     description "Mortal Kombat II Unlimited - Enhanced Colors hack by Pyron version (1.0)"
     rom ( name "Mortal Kombat II (World).md" size 4136840 crc 1867b4d9 md5 3f1aa570edddc5c5e2879a94d6f62e11 sha1 13de727bacf8c644e3df7a96cf212b5a1a899455 )
-    comment "http://www.romhacking.net/hacks/2310/"
+    patch "http://www.romhacking.net/hacks/2310/"
 )
 game (
     name "Super Street Fighter II PCM driver fix [Hack by Stephane Dallongeville]"
     description "Super Street Fighter II PCM driver fix hack by Stephane Dallongeville version (1.0)"
     rom ( name "Super Street Fighter II (USA).md" size 5242880 crc e8612c91 md5 3ed52bd4b63f0438ea41306aec08afcc sha1 479223c0efd45a1c88298dcd231af1c6f347f9f1 )
-    comment "http://www.romhacking.net/hacks/2134/"
+    patch "http://www.romhacking.net/hacks/2134/"
 )

--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -7,30 +7,30 @@ game (
     description "Shining Force III compilation by paul_met and translation Shining Force Central version (1.9)"
     rom ( name "Shining Force III Collection Deluxe Volume 1.bin" size 735379456 crc 827967f3 md5 d7ff366c67fc9e431ba76da7b4b15c09 sha1 62749a78740f6ca4b909bf008c2787304d9bbda0 )
     comment "No reputable source"
-    comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
+    comment "Beetle Saturn requires a cue file to read MODE1/2048 iso/bin files"
 )
 game (
     name "Shining Force III Collection Deluxe Volume 2 (Japan) [T-En by Shining Force Central]"
     description "Shining Force III compilation by paul_met and translation by Shining Force Central version (1.9)"
     rom ( name "Shining Force III Collection Deluxe Volume 2.bin" size 733184000 crc 58b07ef5 md5 8130bfedacfa032395a7095d3799289e sha1 3fc0605781f8462344b3262207755b8074213ddd )
     comment "No reputable source"
-    comment "Mednafen requires a cue file to read MODE1/2048 iso/bin files"
+    comment "Beetle Saturn requires a cue file to read MODE1/2048 iso/bin files"
 )
 game (
     name "Asuka 120% Limit Over - easy patch [Hack by SCO]"
     description "Asuka 120% Limit Over - easy patch hack by SCO version (1.0)"
     rom ( name "Asuka 120% Limited - Burning Fest. Limited (Japan) (Track 01).bin" size 62095152 crc bd23db54 md5 4bcce0bfcc29cb358f7c2e2c8682f1a9 sha1 b9723e2277933df5fba915bcf160253952ba5fdd )
-    comment "http://www.romhacking.net/hacks/3983/"
+    patch "http://www.romhacking.net/hacks/3983/"
 )
 game (
     name "Dragon Force II - Kami Sarishi Daichi ni (Japan) [T-En by Verve Fanworks]"
     description "English translation by Verve Fanworks version (1.04)"
     rom ( name "Dragon Force II - Kami Sarishi Daichi ni (Japan) (Track 1).bin" size 528943104 crc 6feb6044 md5 4b99223f62098f37a5a6cfa69653b684 sha1 62f553003bb9fbd9d16897334678fdf289114efe )
-    comment "http://www.romhacking.net/translations/1622/"
+    patch "http://www.romhacking.net/translations/1622/"
 )
 game (
     name "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) [Hack by paul_met]"
     description "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) hack by paul_met version (1.0)"
     rom ( name "Story of Thor 2, The (Europe) (Track 1).bin" size 81995424 crc 8ae4c201 md5 f438779e54965c3e923d1aa934a6a13c sha1 0c551e311ae0c5ad59199017d67c6582429a5922 )
-    comment "http://www.romhacking.net/hacks/3403/"
+    patch "http://www.romhacking.net/hacks/3403/"
 )

--- a/metadat/hacks/Sony - PlayStation 2.dat
+++ b/metadat/hacks/Sony - PlayStation 2.dat
@@ -6,35 +6,35 @@ game (
     name "Ar tonelico II: Melody of Metafalica [T-En by Project Metafalica]"
     description "English translation by Project Metafalica version (1.0)"
     rom ( name "Ar tonelico II - Melody of Metafalica (USA).iso" size 4421877760 crc 027a757f md5 d3a3f8cc08d3e6277aa72fc16f994e4d sha1 418d1c70a77c3ffaa4f453b3cfb4422a2dd5eff2 )
-    comment "http://www.romhacking.net/translations/2833/"
+    patch "http://www.romhacking.net/translations/2833/"
 )
 game (
     name "Front Mission 5: Scars of the War [T-En by Front Mission 5 Team]"
     description "English translation by Front Mission 5 Team version (Patch 4 Complete)"
     rom ( name "Front Mission 5 - Scars of the War (Japan).iso" size 3918495744 crc f5a947c2 md5 2d8235b1670ab9d53ff08dc4d2ab95df sha1 1bf2e1169ab2aaa7330cd93a5430e91e0b6dab80 )
-    comment "http://www.romhacking.net/translations/1297/"
+    patch "http://www.romhacking.net/translations/1297/"
 )
 game (
     name "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2 (Japan) [T-En by RyleFury]"
     description "English translation by RyleFury version (1.01)"
     rom ( name "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2 (Japan).iso" size 1551040512 crc ded23029 md5 2bbe14b0851b7eff48cb8d9969343460 sha1 34048d18ebc554d1caf5e7b614cf1c06817a51f9 )
-    comment "http://www.romhacking.net/translations/3494/"
+    patch "http://www.romhacking.net/translations/3494/"
 )
 game (
     name "Final Fantasy XII International: Zodiac Job System [T-En by ffgriever]"
     description "English translation by ffgriever version (023)"
     rom ( name "Final Fantasy XII International - Zodiac Job System (Japan).iso" size 4182384640 crc 23e944e2 md5 9e078f38041fc6ea1c1967c66f6340e9 sha1 5c57c9eeca8f746bf2a32addf5ae11446698c961 )
-    comment "http://www.romhacking.net/translations/2723/"
+    patch "http://www.romhacking.net/translations/2723/"
 )
 game (
     name "Shin Megami Tensei III - Nocturne Maniax - Chronicle Edition (Japan) [T-En by Krisan Thyme]"
     description "English translation by Krisan Thyme version (1.1.2)"
     rom ( name "Shin Megami Tensei III - Nocturne Maniax - Chronicle Edition (Japan).iso" size 3431956480 crc 418e72cf md5 a42f5203a8da715e10ab06c2efbfa81f sha1 77624e7bc3aed49c70475419afd28ed137fb2a8a )
-    comment "http://www.romhacking.net/translations/3283/"
+    patch "http://www.romhacking.net/translations/3283/"
 )
 game (
     name "Shadow Tower: Abyss [T-En by Mord of Swoonlight]"
     description "English translation by Mord of Swoonlight version (1.0)"
     rom ( name "Shadow Tower Abyss (Japan).iso" size 1561624576 crc 8c3dffb9 md5 a47d844a2aa33906f30d56e7c08d8817 sha1 31f9bec779b50e29c6392bd4c5470fe7563d5d56 )
-    comment "http://www.romhacking.net/translations/2042/"
+    patch "http://www.romhacking.net/translations/2042/"
 )

--- a/metadat/hacks/Sony - PlayStation Portable.dat
+++ b/metadat/hacks/Sony - PlayStation Portable.dat
@@ -6,89 +6,89 @@ game (
     name "SD Gundam - G Generation Over World (Japan) (v1.01) [T-En by Izzul95]"
     description "English translation by Izzul95 version (1.0.1)"
     rom ( name "SD Gundam - G Generation Over World (Japan) (v1.01).iso" size 2095632384 crc 7e662ae7 md5 cfc229a78b1afbfc935e9769ccd8a062 sha1 a1040bc899cdd552ced158e2a12e112693cbde57 )
-    comment "http://www.romhacking.net/translations/3029/"
+    patch "http://www.romhacking.net/translations/3029/"
 )
 game (
     name "War of the Lions Tweak [Hack by Tzepish]"
     description "War of the Lions Tweak hack by Tzepish version (1.06)"
     rom ( name "Final Fantasy Tactics - The War of the Lions (USA).iso" size 418873344 crc 53d278e6 md5 00cb18f7d384e0e562f9bc8d322fb743 sha1 0e4d0aaf884459641b4bc77216badb1d5167d036 )
-    comment "http://www.romhacking.net/hacks/916/"
+    patch "http://www.romhacking.net/hacks/916/"
 )
 game (
     name "R-Type Tactics II - Operation Bitter Chocolate (Japan) (v1.05) [T-En by Isourou-san]"
     description "English translation by Isourou-san version (1.1)"
     rom ( name "R-Type Tactics II - Operation Bitter Chocolate (Japan) (v1.05).iso" size 1213214720 crc 854a2766 md5 e107c8c27336205276c5a084c62713c1 sha1 ccc66bea9d729bea6195151631bfb0cd4a410b76 )
-    comment "http://www.romhacking.net/translations/3136/"
+    patch "http://www.romhacking.net/translations/3136/"
 )
 game (
     name "Pucelle, La - Ragnarok (Japan) (v1.01) [T-En by ChepChep]"
     description "English translation by ChepChep version (1.0.1)"
     rom ( name "Pucelle, La - Ragnarok (Japan) (v1.01).iso" size 858937344 crc b6c71667 md5 891cdb7e51c78e0241cff5e8b3db3097 sha1 705cf33da482a2d5fd74ce113ac58909c828a140 )
-    comment "http://www.romhacking.net/translations/2130/"
+    patch "http://www.romhacking.net/translations/2130/"
 )
 game (
     name "Ys vs. Sora no Kiseki - Alternative Saga (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (2)"
     rom ( name "Ys vs. Sora no Kiseki - Alternative Saga (Japan) (v1.01).iso" size 1344208896 crc efd03f80 md5 30432759501c18a0a583eb8e563add1b sha1 f49521655fa1657e7231a46956104c517dd21d6a )
-    comment "http://www.romhacking.net/translations/2841/"
+    patch "http://www.romhacking.net/translations/2841/"
 )
 game (
     name "Phantom Kingdom Portable (Japan) (v1.03) [T-En by ChepChep]"
     description "English translation by ChepChep version (0.9.3)"
     rom ( name "Phantom Kingdom Portable (Japan) (v1.03).iso" size 712542208 crc 34745d2d md5 fa42bdca4b4afafd17cff002f023758d sha1 85fd472badfebd9fbd93b6cf2dff681288583cde )
-    comment "http://www.romhacking.net/translations/2328/"
+    patch "http://www.romhacking.net/translations/2328/"
 )
 game (
     name "Monster Hunter Portable 3rd (Japan) (v1.02) [T-En by Team Maverick ONE]"
     description "English translation by Team Maverick ONE version (5.0)"
     rom ( name "Monster Hunter Portable 3rd (Japan) (v1.02).iso" size 1207140352 crc a2e67cf4 md5 fcc3518fca48ff5bcf0aa31f18885615 sha1 cac2408a7a2dc08d330171136382ee266a2c78a4 )
-    comment "http://www.romhacking.net/translations/2043/"
+    patch "http://www.romhacking.net/translations/2043/"
 )
 game (
     name "Final Fantasy Reishiki (Japan) (v1.01) [T-En by Skybladecloud]"
     description "English translation by Skybladecloud version (1.0)"
     rom ( name "Final Fantasy Reishiki (Japan) (v1.01) (Disc 1).iso" size 3158917120 crc 4b1b2a06 md5 1e0775832f2364bd30bb952d880341d3 sha1 286699cc680006dfa0982c51fcc35741f18d1399 )
-    comment "http://www.romhacking.net/translations/1966/"
+    patch "http://www.romhacking.net/translations/1966/"
 )
 game (
     name "Samuraidou Portable (Japan) (v1.02) [T-En by aka translations]"
     description "English translation by aka translations version (0.02)"
     rom ( name "Samuraidou Portable (Japan) (v1.02).iso" size 323092480 crc bd789229 md5 6a980505e015ff7629a8699b7cd21e8b sha1 72f9d631756c886e9d0673ba34a4edfc3d4d1e7a )
-    comment "http://www.romhacking.net/translations/2014/"
+    patch "http://www.romhacking.net/translations/2014/"
 )
 game (
     name "Yuusha 30 Second (Japan) (v1.02) [T-En by ChepChep]"
     description "English translation by ChepChep version (1.0.2)"
     rom ( name "Yuusha 30 Second (Japan) (v1.02).iso" size 396761088 crc 7abae927 md5 44efc8a601b385a221a07fb6d6ef838f sha1 2be0a73b8951254beb2d5f06bbfb1215b761d1b4 )
-    comment "http://www.romhacking.net/translations/2635/"
+    patch "http://www.romhacking.net/translations/2635/"
 )
 game (
     name "Nayuta no Kiseki (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (4.15)"
     rom ( name "Nayuta no Kiseki (Japan) (v1.01).iso" size 831373312 crc 88c08fc1 md5 6cc975153b7998db4242baa17eb8d276 sha1 01e02d60dc7a05683d29c45a10cce41083cd809b )
-    comment "http://www.romhacking.net/translations/3560/"
+    patch "http://www.romhacking.net/translations/3560/"
 )
 game (
     name "Senjou no Valkyria 3 - Extra Edition (Japan) [T-En by Valkyria Chronicles 3 Translation Project]"
     description "English translation by Valkyria Chronicles 3 Translation Project version (Patch 2)"
     rom ( name "Senjou no Valkyria 3 - Extra Edition (Japan).iso" size 1771300864 crc 190394de md5 dd0e198cb5414fc11601f20bec1f48fa sha1 1a69eec680c186efdb0225e27302aaa1104a0ee3 )
-    comment "http://www.romhacking.net/translations/3562/"
+    patch "http://www.romhacking.net/translations/3562/"
 )
 game (
     name "Last Ranker (Japan) (v1.01) [T-En by Flame]"
     description "English translation by Flame version (1)"
     rom ( name "Last Ranker (Japan) (v1.01).iso" size 950337536 crc 80f08f9a md5 4133cc0a5e2ff00f37be3a860781b6e9 sha1 ba7f410bdfe98ee81816573fa64c60634f3dda4f )
-    comment "http://www.romhacking.net/translations/2747/"
+    patch "http://www.romhacking.net/translations/2747/"
 )
 game (
     name "Super Robot Taisen A Portable (Japan) (v1.02) [T-En by Steel Soul]"
     description "English translation by Steel Soul version (1.01)"
     rom ( name "Super Robot Taisen A Portable (Japan) (v1.02).iso" size 1143351296 crc 2cdca6c1 md5 83bb7560a12d7032ed7ca9388d7fe97a sha1 6351237a247291ba5bcb46c314055e49d7b1bb6a )
-    comment "http://www.romhacking.net/translations/3658/"
+    patch "http://www.romhacking.net/translations/3658/"
 )
 game (
     name "Eiyuu Densetsu - Ao no Kiseki (Japan) (v1.01) [T-En by Flame and Guren]"
     description "English translation by Flame and Guren version (15)"
     rom ( name "Eiyuu Densetsu - Ao no Kiseki (Japan) (v1.01).iso" size 1437401088 crc f765c9ae md5 a41e9f6a888f009ed3b37b0de335057b sha1 e7098ab39dac341073d4d9c2c3d737dbbc2cd81f )
-    comment "http://www.romhacking.net/translations/3679/"
+    patch "http://www.romhacking.net/translations/3679/"
 )

--- a/metadat/hacks/Sony - PlayStation.dat
+++ b/metadat/hacks/Sony - PlayStation.dat
@@ -12,119 +12,119 @@ game (
     name "Persona 2 - Tsumi (Japan) (v1.0) [T-En by Gemini]"
     description "English translation by Gemini version (1.0a)"
     rom ( name "Persona 2 - Tsumi (Japan) (v1.0).bin" size 691925472 crc 870ceff9 md5 11b188975894f2e4062ac773a9e9c153 sha1 cd3521fab99346ada2f09391b1c415429fde2b1c )
-    comment "http://www.romhacking.net/translations/1249/"
+    patch "http://www.romhacking.net/translations/1249/"
 )
 game (
     name "iS - Internal Section (Japan) [T-En by GameHacking.org]"
     description "English translation by GameHacking.org version (1.02)"
     rom ( name "iS - Internal Section (Japan).bin" size 248107776 crc 1ec73120 md5 58785f169abf5b14bfffff8716bcb7ad sha1 a787c7f0118d07879d3e50908947e7e8c035b7de )
-    comment "http://www.romhacking.net/translations/1265/"
+    patch "http://www.romhacking.net/translations/1265/"
 )
 game (
     name "Asuncia - Majou no Jubaku (Japan) [T-En by John Osborne]"
     description "English translation by John Osborne version (1)"
     rom ( name "Asuncia - Majou no Jubaku (Japan) (Track 01).bin" size 122529792 crc 871fd606 md5 584fc0933909ae1636255bc9649cb719 sha1 de7d3ac31150f0112d633d3a763ffb9c8aa6c818 )
-    comment "http://www.romhacking.net/translations/3393/"
+    patch "http://www.romhacking.net/translations/3393/"
 )
 game (
     name "Fantastic Night Dreams - Cotton Original (Japan) [T-En by RIP Translations]"
     description "English translation by RIP Translations version (1.10)"
     rom ( name "Fantastic Night Dreams - Cotton Original (Japan).bin" size 39273696 crc 3082745a md5 0b84dff9eb045321f3c1e60bf861280a sha1 9252d11b1487756c8a37877f90655ded285be9da )
-    comment "http://www.romhacking.net/translations/265/"
+    patch "http://www.romhacking.net/translations/265/"
 )
 game (
     name "King's Field (Japan) [T-En by John Osborne]"
     description "English translation by John Osborne version (1.0)"
     rom ( name "King's Field (Japan).bin" size 30378432 crc 5f9be6e1 md5 c56cfb36f19f2608d3c180c104ace9dd sha1 c667b5b2dfba697c338783fe3d351f7910882152 )
-    comment "http://www.romhacking.net/translations/1067/"
+    patch "http://www.romhacking.net/translations/1067/"
 )
 game (
     name "Policenauts (Japan) (Disc 1) [T-En by JunkerHQ]"
     description "English translation by JunkerHQ version (1.0)"
     rom ( name "Policenauts (Japan) (Disc 1).bin" size 748928544 crc 0db7d7e8 md5 65977ae8b63042475730e6efb6a5a8a6 sha1 3aa1fe0f2175dee26f66175de2a1ffe6d385ee95 )
-    comment "http://www.romhacking.net/translations/1422/"
+    patch "http://www.romhacking.net/translations/1422/"
 )
 game (
     name "Policenauts (Japan) (Disc 2) [T-En by JunkerHQ]"
     description "English translation by JunkerHQ version (1.0)"
     rom ( name "Policenauts (Japan) (Disc 2).bin" size 613822608 crc 272ca545 md5 3b6bf3ce8230da37b8a717b6e892b457 sha1 e23d6395e0761e170bce24686c4eda289c159319 )
-    comment "http://www.romhacking.net/translations/1422/"
+    patch "http://www.romhacking.net/translations/1422/"
 )
 game (
     name "Echo Night #2 - Nemuri no Shihaisha (Japan) [T-En by Gemini and Tom]"
     description "English translation by Gemini and Tom version (1.0a)"
     rom ( name "Echo Night 2 (Japan).bin" size 346863552 crc 3f73164a md5 68d101c1650952a49d66d66eb9b772ec sha1 e87ec671a337bcd9b7da537b8901a500e6ed5ee5 )
-    comment "http://www.romhacking.net/translations/2380/"
+    patch "http://www.romhacking.net/translations/2380/"
 )
 game (
     name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) [T-En by Gemini]"
     description "English translation by Gemini version (1.0)"
     rom ( name "Akumajou Dracula X - Gekka no Yasoukyoku (Japan) (v1.2) (Track 1).bin" size 545440560 crc d42bc703 md5 a79f24c94d9843ef903564a9e9c56356 sha1 3ef656b04d490b66f2babfbf601e1cc6b73b30e2 )
-    comment "http://www.romhacking.net/translations/1427/"
+    patch "http://www.romhacking.net/translations/1427/"
 )
 game (
     name "Super Robot Taisen Alpha Gaiden (Japan) (Shokai Genteiban) [T-En by Aeon Genesis]"
     description "English translation by Aeon Genesis version (0.95b)"
     rom ( name "Super Robot Taisen Alpha Gaiden (Japan) (v1.1).bin" size 718394880 crc 52df8488 md5 bb73db766fbd2d7d2ad089104ca5b956 sha1 64198b5ce52c117b30ce044ffdbad19419a622b3 )
-    comment "http://www.romhacking.net/translations/859/"
+    patch "http://www.romhacking.net/translations/859/"
 )
 game (
     name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1) [T-En by Team NEMO]"
     description "English translation by Team NEMO version (2.0)"
     rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 2) (v1.1).bin" size 732224640 crc f0fc5ae7 md5 b075b732f61371efe680323c21390204 sha1 c69975892d0a19f952018d375be52adf38fe1e2c )
-    comment "http://www.romhacking.net/translations/2307/"
+    patch "http://www.romhacking.net/translations/2307/"
 )
 game (
     name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1) [T-En by Team NEMO]"
     description "English translation by Team NEMO version (2.0)"
     rom ( name "Ace Combat 3 - Electrosphere (Japan) (Disc 1) (v1.1).bin" size 724512432 crc 0b2f796b md5 15f7580eebae2fab6381a4c65450a75f sha1 cfc3e5e96ae93dafce3fbde46ebd4bb4310f0d4b )
-    comment "http://www.romhacking.net/translations/2307/"
+    patch "http://www.romhacking.net/translations/2307/"
 )
 game (
     name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1) [T-En by NoOneee]"
     description "English translation by NoOneee version (1.0)"
     rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 1).bin" size 477180816 crc 51a2c51b md5 934ef37fb41fd3acad685e4e1bffde05 sha1 7e69656048f01a36f46b40b239257ebee4d089e6 )
-    comment "http://www.romhacking.net/translations/2927/"
+    patch "http://www.romhacking.net/translations/2927/"
 )
 game (
     name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2) [T-En by NoOneee]"
     description "English translation by NoOneee version (1.0)"
     rom ( name "Animetic Story Game 1 - Card Captor Sakura (Japan) (Disc 2).bin" size 455354256 crc 131f8b49 md5 c8f81e55451ec07c90414cba0a45a471 sha1 f1a79dc3db9ef90c152bfeb51f2fcc0b46cb0277 )
-    comment "http://www.romhacking.net/translations/2927/"
+    patch "http://www.romhacking.net/translations/2927/"
 )
 game (
     name "Brigandine - Grand Edition (Japan) (Disc 2) [T-En by John Osborne]"
     description "English translation by John Osborne version (8)"
     rom ( name "Brigandine - Grand Edition (Japan) (Disc 2).bin" size 751746240 crc 11fa0e02 md5 e497d63caf18b8387d43022ef2c6c103 sha1 bfddf6904d8d0827e63ff51b23ddc2dbcd265192 )
-    comment "http://www.romhacking.net/translations/3236/"
+    patch "http://www.romhacking.net/translations/3236/"
 )
 game (
     name "Brigandine - Grand Edition (Japan) (Disc 1) [T-En by John Osborne]"
     description "English translation by John Osborne version (8)"
     rom ( name "Brigandine - Grand Edition (Japan) (Disc 1).bin" size 751720368 crc 4d719816 md5 fc3eb17e3451a2fa9f8494842f1a0290 sha1 8d494e8d3616b285fd453d78e7f945970e1c3268 )
-    comment "http://www.romhacking.net/translations/3236/"
+    patch "http://www.romhacking.net/translations/3236/"
 )
 game (
     name "Clock Tower - The First Fear (Japan) [T-En by arcraith]"
     description "English translation by arcraith version (1.1)"
     rom ( name "Clock Tower - The First Fear (Japan) (Track 1).bin" size 75750864 crc f3ced589 md5 83adf3cdb6c46b3e084dec6dfb213295 sha1 f20aaf6d52ba2acee483445a8039b85e6f1492d4 )
-    comment "http://www.romhacking.net/translations/2337/"
+    patch "http://www.romhacking.net/translations/2337/"
 )
 game (
     name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) [T-En by Kil]"
     description "English translation by Kil version (1.3)"
     rom ( name "Langrisser IV & V - Final Edition (Japan) (Disc 1) (Langrisser IV Disc) (Track 1).bin" size 576338784 crc 946999e1 md5 1740cc952d6f29a682dbc218e061d081 sha1 77b0d822adb68ebbdd5a98a97894d55f340f5b79 )
-    comment "http://www.romhacking.net/translations/1711/"
+    patch "http://www.romhacking.net/translations/1711/"
 )
 game (
     name "Castlevania: Symphony of the Night - Quality hack [Hack by paul_met]"
     description "Castlevania: Symphony of the Night - Quality hack hack by paul_met version (1.2)"
     rom ( name "Castlevania - Symphony of the Night (USA) (Track 1).bin" size 538655040 crc 0431c247 md5 6674f4a75ea11fd9422669f247ec27fd sha1 1fa7cd542e15f9ce281e83320eedd24daace79e8 )
-    comment "http://www.romhacking.net/hacks/3606/"
+    patch "http://www.romhacking.net/hacks/3606/"
 )
 game (
     name "Yutona Eiyuu Senki - TearRingSaga (Japan) [T-En by Aethin]"
     description "English translation by Aethin version (1.04)"
     rom ( name "Tear Ring Saga (Japan).bin" size 594054048 crc ca9bf988 md5 7f67daa021705a01ce322aa47edd1695 sha1 17066296885b81dc7511597c002fa867b4f178d3 )
-    comment "http://www.romhacking.net/translations/2812/"
+    patch "http://www.romhacking.net/translations/2812/"
 )


### PR DESCRIPTION
Skipped actual comments.

This is to make the RA frontend be able to treat 'patch' (which contains a url to the page where the patch can be downloaded and 99% of the time has a description - always on romhacking.net urls) especially and be able to load on the system browser all 'patches' if the user wants more information on what the game is.

Previously, 'comment' could be anything and often was. Logs from cowering tools, hints that a hack has special requirements etc. This way a special button in the info page can be created to open all 'patch pages' on the browser, which i'm going to ask for right after this is merged.