### PR TITLE
changed rhdndat output

### DIFF
--- a/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
+++ b/metadat/hacks/NEC - PC Engine - TurboGrafx 16.dat
@@ -10,7 +10,7 @@ game (
 )
 game (
     name "Final Match Tennis Ladies [T-En by tAz-07 + 2 hacks]"
-    description "Final Match Tennis Ladies hack by MooZ version (1.0) + Final Match Tennis Ladies hack by tAz-07 version (1.0) + English translation by tAz-07 version (1.0)"
+    description "Final Match Tennis Ladies by MooZ version (1.0) + Final Match Tennis Ladies by tAz-07 version (1.0) + English translation by tAz-07 version (1.0)"
     rom ( name "Final Match Tennis Ladies.pce" size 262144 crc e92d1290 md5 4975b6669f0a47c201d16fa3fc7ec392 sha1 d186a4fd933ab12dd3c2024093241660c0dae1bf )
     patch "http://www.romhacking.net/hacks/3174/"
     patch "http://www.romhacking.net/hacks/3297/"
@@ -84,7 +84,7 @@ game (
 )
 game (
     name "Formation Soccer Human Cup '92 [Hack by MooZ]"
-    description "Formation Soccer Human Cup '92 hack by MooZ version (1.0)"
+    description "Formation Soccer Human Cup '92 by MooZ version (1.0)"
     rom ( name "Formation Soccer Human Cup 92.pce" size 262144 crc b3096880 md5 6334a124d072e53aab36c80c38253b1c sha1 9cd0a907d0795b0dc2eb5875aaddc686ce1caea0 )
     patch "http://www.romhacking.net/hacks/3181/"
 )

--- a/metadat/hacks/Nintendo - Game Boy Advance.dat
+++ b/metadat/hacks/Nintendo - Game Boy Advance.dat
@@ -10,7 +10,7 @@ game (
 )
 game (
     name "Metroid Other ZM [Hack by Luce Seyfarth]"
-    description "Metroid Other ZM hack by Luce Seyfarth version (3.8)"
+    description "Metroid Other ZM by Luce Seyfarth version (3.8)"
     rom ( name "Metroid Other ZM.gba" size 16777216 crc fc850cc5 md5 4fdb05cdb7bcd66e6fec1af992e7c310 sha1 26327eb06fda34c3f1fffa512c08b804623185f8 )
     patch "http://www.romhacking.net/hacks/2565/"
 )
@@ -70,7 +70,7 @@ game (
 )
 game (
     name "Super Mario Advance 4 - All 38 e-Reader Levels [Hack by ShadowOne333]"
-    description "Super Mario Advance 4 - All 38 e-Reader Levels hack by ShadowOne333 version (1.0)"
+    description "Super Mario Advance 4 - All 38 e-Reader Levels by ShadowOne333 version (1.0)"
     rom ( name "Super Mario Advance 4 - Super Mario Bros. 3 (USA).gba" size 8388608 crc d4c13ac3 md5 e7a2792c5913a8420a419f2d01358487 sha1 dd2879329ec52bd5372f26b75297a67f1a81215a )
     patch "http://www.romhacking.net/hacks/2714/"
 )
@@ -82,19 +82,19 @@ game (
 )
 game (
     name "Castlevania Aria of Sorrow Gebel Hack [Hack by caminopreacher]"
-    description "Castlevania Aria of Sorrow Gebel Hack hack by caminopreacher version (1.0)"
+    description "Castlevania Aria of Sorrow Gebel Hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Gebel Hack.gba" size 8388608 crc 317f5c4f md5 8df41935661e22ddc70e216bd6249216 sha1 48fbd3c3a0b0477160f82c19149841b6de271c75 )
     patch "http://www.romhacking.net/hacks/4136/"
 )
 game (
     name "Castlevania Aria of Sorrow Zangetsu Hack [Hack by caminopreacher]"
-    description "Castlevania Aria of Sorrow Zangetsu Hack hack by caminopreacher version (1.0)"
+    description "Castlevania Aria of Sorrow Zangetsu Hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Zangetsu Hack.gba" size 8388608 crc 027d4b31 md5 fd0fa411a7c7722c752116beca243f27 sha1 7112dd9c55fd2d33cd5274dfdb71202e162cc1e2 )
     patch "http://www.romhacking.net/hacks/4130/"
 )
 game (
     name "Castlevania Aria of Sorrow Alfred Hack [Hack by caminopreacher]"
-    description "Castlevania Aria of Sorrow Alfred Hack hack by caminopreacher version (1.0)"
+    description "Castlevania Aria of Sorrow Alfred Hack by caminopreacher version (1.0)"
     rom ( name "Castlevania - Aria of Sorrow Alfred Hack.gba" size 8388608 crc 9f88961f md5 7c5c06345e69eec96b13668e969177f8 sha1 4191b6d131e5307ccbd210df5fb39d7824e59355 )
     patch "http://www.romhacking.net/hacks/4131/"
 )

--- a/metadat/hacks/Nintendo - Game Boy Color.dat
+++ b/metadat/hacks/Nintendo - Game Boy Color.dat
@@ -34,7 +34,7 @@ game (
 )
 game (
     name "Lufia: The Legend Returns Text Cleanup [Hack by vivify93]"
-    description "Lufia: The Legend Returns Text Cleanup hack by vivify93 version (2.0)"
+    description "Lufia: The Legend Returns Text Cleanup by vivify93 version (2.0)"
     rom ( name "Lufia - The Legend Returns (USA).gbc" size 2097152 crc 0146f07f md5 daa61ef232971c454d7766663f03ceb2 sha1 0446d2d3b3df41d449f4de22b82f09bab5be55c7 )
     patch "http://www.romhacking.net/hacks/813/"
 )
@@ -46,7 +46,7 @@ game (
 )
 game (
     name "Shantae - Force GBA Enhanced Mode [Hack by Polar-Star]"
-    description "Shantae - Force GBA Enhanced Mode hack by Polar-Star version (1.0)"
+    description "Shantae - Force GBA Enhanced Mode by Polar-Star version (1.0)"
     rom ( name "Shantae (USA).gbc" size 4194304 crc a52782ba md5 f687ce08f80c8f6ecb7722c90dde4b5c sha1 4295fcae05cb90b1564f3bb4e92cc2b2eec40f0e )
     patch "http://www.romhacking.net/hacks/3462/"
 )
@@ -58,19 +58,19 @@ game (
 )
 game (
     name "Oracle of Seasons Force GBA Enhanced Mode [Hack by DuoDreamer]"
-    description "Oracle of Seasons Force GBA Enhanced Mode hack by DuoDreamer version (0.3)"
+    description "Oracle of Seasons Force GBA Enhanced Mode by DuoDreamer version (0.3)"
     rom ( name "Legend of Zelda, The - Oracle of Seasons (USA).gbc" size 1048576 crc c26879a0 md5 a2ecf20f04b3be46e9ed3feaac96a7cf sha1 a0fec9d9c51c5d117910192d820539e6455fe8cf )
     patch "http://www.romhacking.net/hacks/3583/"
 )
 game (
     name "Oracle of Ages Force GBA Enhanced Mode [Hack by DuoDreamer]"
-    description "Oracle of Ages Force GBA Enhanced Mode hack by DuoDreamer version (0.3)"
+    description "Oracle of Ages Force GBA Enhanced Mode by DuoDreamer version (0.3)"
     rom ( name "Legend of Zelda, The - Oracle of Ages (USA).gbc" size 1048576 crc 2d812ff0 md5 a9d5b7b5ccedb6a7785b404d224c42ee sha1 d7fb2fec5a445b77d0d9e1c1f147b9397186038d )
     patch "http://www.romhacking.net/hacks/3580/"
 )
 game (
     name "Wendy: Every Witch Way - Force GBA Enhanced Mode [Hack by celebi23]"
-    description "Wendy: Every Witch Way - Force GBA Enhanced Mode hack by celebi23 version (1.0)"
+    description "Wendy: Every Witch Way - Force GBA Enhanced Mode by celebi23 version (1.0)"
     rom ( name "Wendy - Every Witch Way (USA, Europe).gbc" size 1048576 crc 2c0c9cb3 md5 067b1ff18d9ee9f939d79a55f47d850e sha1 e5d2a32613d179a93482fca11138171c17340672 )
     patch "http://www.romhacking.net/hacks/4039/"
 )

--- a/metadat/hacks/Nintendo - Game Boy.dat
+++ b/metadat/hacks/Nintendo - Game Boy.dat
@@ -46,7 +46,7 @@ game (
 )
 game (
     name "Super Mario Land 2 DX [Hack by toruzz]"
-    description "Super Mario Land 2 DX hack by toruzz version (1.8.1)"
+    description "Super Mario Land 2 DX by toruzz version (1.8.1)"
     rom ( name "Super Mario Land 2 - 6 Golden Coins (USA, Europe).gb" size 1048576 crc f0799017 md5 946a4a60bbd5328ca2250d5f9f0606c7 sha1 b9ed5789c9f481e25a64dad1c5e8e93e4ddc1b80 )
     patch "http://www.romhacking.net/hacks/3784/"
 )

--- a/metadat/hacks/Nintendo - Nintendo 64.dat
+++ b/metadat/hacks/Nintendo - Nintendo 64.dat
@@ -29,15 +29,15 @@ game (
     name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
     description "'Wonder Project J2' translation by Ryu version 1.0"
     rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).v64" size 8912896 crc 38401ddb md5 9389cea162a3bbff3bf6f81284cc7786 sha1 cae4915a67d952f37a78e004d97d630bccc155a6 )
-    comment "tool64 can't convert to other byte orders after patching"
     patch "http://www.romhacking.net/translations/1074/"
+    comment "tool64 can't convert rom to other byte orders after patching"
 )
 game (
     name "Wonder Project J2: Josette of the Corlo Forest (Japan) [T-En by Ryu]"
     description "'Wonder Project J2' translation by Ryu version 1.0"
     rom ( name "Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size 8912896 crc e1094e29 md5 3c02f56dd7b1a06be83a7a288755612f sha1 27c4c8f199d1045c697c5d79d216d33e1c715760 )
-    comment "tool64 can't convert to other byte orders after patching"
     patch "http://www.romhacking.net/translations/1074/"
+    comment "tool64 can't convert rom to other byte orders after patching"
 )
 game (
     name "Sin and Punishment: Successor of the Earth (USA) (Wii U Virtual Console)"
@@ -59,37 +59,37 @@ game (
 )
 game (
     name "Super Mario Star Road [Hack by Skelux Core]"
-    description "Super Mario Star Road hack by Skelux Core version (Final)"
+    description "Super Mario Star Road by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.v64" size 50331648 crc 646e8fff md5 caf803c77c9223b28b663af0b7e49a00 sha1 45e75bd3a1380bfeb874721c29581b47cfafa8d1 )
     patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Super Mario Star Road [Hack by Skelux Core]"
-    description "Super Mario Star Road hack by Skelux Core version (Final)"
+    description "Super Mario Star Road by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.z64" size 50331648 crc 2bd94dd7 md5 80e5019c9dd12648f909b3a5715ed580 sha1 469c6555a078dd831fa51ce601a653e44b3ce071 )
     patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Super Mario Star Road [Hack by Skelux Core]"
-    description "Super Mario Star Road hack by Skelux Core version (Final)"
+    description "Super Mario Star Road by Skelux Core version (Final)"
     rom ( name "Super Mario Star Road.n64" size 50331648 crc e40c674e md5 00f5bcdd597dbc575b8811d5430bb353 sha1 176bd6a50aee06fcc917c123f412fdc0c02dd922 )
     patch "http://www.romhacking.net/hacks/873/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
-    description "Zelda's Birthday hack by jsa version (1.5)"
+    description "Zelda's Birthday by jsa version (1.5)"
     rom ( name "Zelda's Birthday.v64" size 67108864 crc 65fceb4b md5 12fd4f2ac3ffe761be42e9fa63f75bc7 sha1 b001eec2adb2d80e9088909a417388c91dc8b545 )
     patch "http://www.romhacking.net/hacks/676/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
-    description "Zelda's Birthday hack by jsa version (1.5)"
+    description "Zelda's Birthday by jsa version (1.5)"
     rom ( name "Zelda's Birthday.z64" size 67108864 crc 9dcde00e md5 9dc5ed87adf6e859391751ae124b44f5 sha1 881bbf199e24d37a291f95adc0000a89573bec70 )
     patch "http://www.romhacking.net/hacks/676/"
 )
 game (
     name "Zelda's Birthday [Hack by jsa]"
-    description "Zelda's Birthday hack by jsa version (1.5)"
+    description "Zelda's Birthday by jsa version (1.5)"
     rom ( name "Zelda's Birthday.n64" size 67108864 crc 4ed0632f md5 4d28941a4799a099d32f79f7ebca83f1 sha1 7095b2e825517b77a62f42198212565bd2a259c9 )
     patch "http://www.romhacking.net/hacks/676/"
 )
@@ -97,20 +97,20 @@ game (
     name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Ocarina of Time (USA) (GameCube Edition).z64" size 33554432 crc 48124886 md5 7fc61f232811cd779d4789f71d55562c sha1 24207202d44e2a7fa5e4297187082945310bae0c )
-    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
 )
 game (
     name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube Edition).z64" size 33554432 crc 339fc360 md5 6d79c2e17eb78ab9d6b40b49c6939949 sha1 800c27d8231a17c4321e801108893015b9ee22b2 )
-    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
 )
 game (
     name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition) [GameCube to N64 hack by Aroenai]"
     description "'Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition)' disable anti-aliasing, combine versions features and bugfix hack by Aroenai version 4/9/18"
     rom ( name "Legend of Zelda, The - Majora's Mask (USA) (GameCube Edition).z64" size 33554432 crc 3d034499 md5 7f8386e3816db3ede468a4669fe7c978 sha1 f0fb78384331edf36e4daccd99571d4c8c605405 )
-    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
     patch "http://krikzz.com/forum/index.php?PHPSESSID=2g5pms1o3rsofsrci9gb7o2th7&topic=5161.0"
+    comment "Patch requires big endian rom, no-intro rom can be changed to big endian with tool64 and match the required crc for the patch"
 )

--- a/metadat/hacks/Nintendo - Nintendo DS.dat
+++ b/metadat/hacks/Nintendo - Nintendo DS.dat
@@ -10,7 +10,7 @@ game (
 )
 game (
     name "Trauma Center Under the Knife 2 Wii Controls Hack [Hack by Greiga Master]"
-    description "Trauma Center Under the Knife 2 Wii Controls Hack hack by Greiga Master version (1.01)"
+    description "Trauma Center Under the Knife 2 Wii Controls Hack by Greiga Master version (1.01)"
     rom ( name "Trauma Center - Under the Knife 2 (USA).nds" size 57189404 crc c658f891 md5 2fbb88aa538bdf0de5f156dced62ead0 sha1 709dcb2f8da742cec229f83c9f1771cd0aec941d )
     patch "http://www.romhacking.net/hacks/1807/"
 )
@@ -52,13 +52,13 @@ game (
 )
 game (
     name "Legend of Zelda Spirit Tracks D-Pad Controls [Hack by Greiga Master]"
-    description "Legend of Zelda Spirit Tracks D-Pad Controls hack by Greiga Master version (1.01)"
+    description "Legend of Zelda Spirit Tracks D-Pad Controls by Greiga Master version (1.01)"
     rom ( name "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es).nds" size 94096060 crc f846f7f3 md5 4b0882022b1d66f55cfbe68078b3cd83 sha1 7dd2f09473a2d049e01cc08491dd69f6ac71cc2b )
     patch "http://www.romhacking.net/hacks/2235/"
 )
 game (
     name "Castlevania: Dawn of Dignity (New Portraits Hack) [Hack by ShadowOne333 + 2 hacks]"
-    description "Castlevania: Dawn of Dignity (New Portraits Hack) hack by ShadowOne333 version (1.1) + Castlevania: Dawn of Sorrow Fixed Luck hack by LagoLunatic version (1.0) + Castlevania: Dawn of Sorrow No Required Touch Screen hack by LagoLunatic version (1.1)"
+    description "Castlevania: Dawn of Dignity (New Portraits Hack) by ShadowOne333 version (1.1) + Castlevania: Dawn of Sorrow Fixed Luck by LagoLunatic version (1.0) + Castlevania: Dawn of Sorrow No Required Touch Screen by LagoLunatic version (1.1)"
     rom ( name "Castlevania - Dawn of Sorrow (USA).nds" size 67108864 crc f6c7192b md5 4161086eedebafdbacc1678bb7349577 sha1 2f23dc3c148556f4ba2ad845fd172bb223693535 )
     patch "http://www.romhacking.net/hacks/3356/"
     patch "http://www.romhacking.net/hacks/3407/"
@@ -72,7 +72,7 @@ game (
 )
 game (
     name "Legend of Zelda Phantom Hourglass D-Pad Patch [Hack by Greiga Master]"
-    description "Legend of Zelda Phantom Hourglass D-Pad Patch hack by Greiga Master version (1.0)"
+    description "Legend of Zelda Phantom Hourglass D-Pad Patch by Greiga Master version (1.0)"
     rom ( name "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es).nds" size 65327204 crc 404e6312 md5 ac87bd6dd589586c37d533f1541c0de3 sha1 7e0d26d143992f1eee182b24f1abb9e7f038eacf )
     patch "http://www.romhacking.net/hacks/2248/"
 )

--- a/metadat/hacks/Sega - Master System - Mark III.dat
+++ b/metadat/hacks/Sega - Master System - Mark III.dat
@@ -4,7 +4,7 @@ clrmamepro (
 )
 game (
     name "Golvellius - SRAM save [Hack by Ichigobankai]"
-    description "Golvellius - SRAM save hack by Ichigobankai version (1.0)"
+    description "Golvellius - SRAM save by Ichigobankai version (1.0)"
     rom ( name "Golvellius (USA, Europe).sms" size 262144 crc a465cd07 md5 ecae9027839fc25797037d8cf424ffb3 sha1 291df4df5a07749b7106bc53657fef5aa1f3909f )
     patch "http://www.romhacking.net/hacks/3631/"
 )
@@ -16,7 +16,7 @@ game (
 )
 game (
     name "Zillion Slight Improvement [Hack by Johnny]"
-    description "Zillion Slight Improvement hack by Johnny version (1.0)"
+    description "Zillion Slight Improvement by Johnny version (1.0)"
     rom ( name "Zillion (USA) (Rev 1).sms" size 131072 crc 3a9f4c9e md5 9cbe687e43bad149d54e169aff8dc0cd sha1 6f04dcf1647b682d7a29b13625310b0bef50804c )
     patch "http://www.romhacking.net/hacks/879/"
 )
@@ -34,13 +34,13 @@ game (
 )
 game (
     name "Spellcaster - SRAM save [Hack by Ichigobankai]"
-    description "Spellcaster - SRAM save hack by Ichigobankai version (1.0)"
+    description "Spellcaster - SRAM save by Ichigobankai version (1.0)"
     rom ( name "SpellCaster (USA, Europe).sms" size 524288 crc 13a0838a md5 67b6ff0d6427c37645455edf75b69b93 sha1 89aa2072268d4577e31db26a6865f3d5ba5fc09f )
     patch "http://www.romhacking.net/hacks/3632/"
 )
 game (
     name "Ys US Master System FM sound patch [Hack by SSTranslations]"
-    description "Ys US Master System FM sound patch hack by SSTranslations version (1.2)"
+    description "Ys US Master System FM sound patch by SSTranslations version (1.2)"
     rom ( name "Ys - The Vanished Omens (USA, Europe).sms" size 262144 crc 7ed5dca2 md5 dd5d01d4e1fe7d275f95ac95dc63b04f sha1 c61f4302a6ca6ccd1e79c5174bcefaf0c94f6c41 )
     patch "http://www.romhacking.net/hacks/572/"
 )
@@ -52,7 +52,7 @@ game (
 )
 game (
     name "Miracle Warriors Improvement [Hack by Penta Penguin]"
-    description "Miracle Warriors Improvement hack by Penta Penguin version (1.0)"
+    description "Miracle Warriors Improvement by Penta Penguin version (1.0)"
     rom ( name "Miracle Warriors - Seal of the Dark Lord (USA, Europe).sms" size 262144 crc 4f50b42a md5 f75318912bf0bb45b9b9a16e2ecb3502 sha1 8536cf7ac553612ecf2db2d8d423d5c2221d73a3 )
     patch "http://www.romhacking.net/hacks/2127/"
 )
@@ -64,13 +64,13 @@ game (
 )
 game (
     name "Sonic 1 Improvement [Hack by Penta Penguin]"
-    description "Sonic 1 Improvement hack by Penta Penguin version (1.2)"
+    description "Sonic 1 Improvement by Penta Penguin version (1.2)"
     rom ( name "Sonic The Hedgehog (USA, Europe).sms" size 262144 crc a291032c md5 1f34c34c95c9b294b056c1648b22c00d sha1 3719bb613ca6dab1e2d18295a0c688393c2109e0 )
     patch "http://www.romhacking.net/hacks/983/"
 )
 game (
     name "Wonder Boy III - SRAM Save [Hack by Ichigobankai]"
-    description "Wonder Boy III - SRAM Save hack by Ichigobankai version (1.2)"
+    description "Wonder Boy III - SRAM Save by Ichigobankai version (1.2)"
     rom ( name "Wonder Boy III - The Dragon's Trap (USA, Europe).sms" size 262144 crc 725132ae md5 c7e1464e9ac0805f08ae7151796f69da sha1 d27fd069a244d2496e156c41d5b3fca4fe27649e )
     patch "http://www.romhacking.net/hacks/3628/"
 )

--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -9,7 +9,7 @@ game (
 )
 game (
     name "El Viento Enhancement [Hack by M.I.J.E.T.]"
-    description "El Viento Enhancement hack by M.I.J.E.T. version (101010)"
+    description "El Viento Enhancement by M.I.J.E.T. version (101010)"
     rom ( name "El. Viento (USA).md" size 1048576 crc 363946b2 md5 ca18abf6ccede48681f013db3c43f108 sha1 83c55f390ce33cfbfcd8c913e8a34a0c3bc304ae )
     patch "http://www.romhacking.net/hacks/678/"
 )
@@ -21,7 +21,7 @@ game (
 )
 game (
     name "Sonic 3D Blast: Director's Cut [Hack by GameHut]"
-    description "Sonic 3D Blast: Director's Cut hack by GameHut version (1.0)"
+    description "Sonic 3D Blast: Director's Cut by GameHut version (1.0)"
     rom ( name "Sonic 3D Blast ~ Sonic 3D Flickies' Island (USA, Europe).md" size 4191682 crc 9767e840 md5 742dd5c98d143ff6716800dee6a25dc5 sha1 4072d34e119e199131b839d338f1fc38e472203a )
     patch "http://www.romhacking.net/hacks/3810/"
 )
@@ -39,13 +39,13 @@ game (
 )
 game (
     name "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors [Hack by fusaru]"
-    description "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors hack by fusaru version (2.00)"
+    description "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors by fusaru version (2.00)"
     rom ( name "Twin Cobra (USA).md" size 704120 crc 88ea1e4e md5 d1c82b81594f80a1868a141275e16bba sha1 1bae39be93427bddfd7fff1db2a47954abb9d8a1 )
     patch "http://www.romhacking.net/hacks/2920/"
 )
 game (
     name "Sally Acorn in Sonic the Hedgehog [Hack by E-122-Psi]"
-    description "Sally Acorn in Sonic the Hedgehog hack by E-122-Psi version (2.2)"
+    description "Sally Acorn in Sonic the Hedgehog by E-122-Psi version (2.2)"
     rom ( name "Sally Acorn In Sonic The Hedgehog.md" size 1048576 crc 96f971f6 md5 80d3491eca8580494a87186ca9f40abd sha1 1bb88d7f4dfcea94d3f47e79b9c1fddf364b2d59 )
     patch "http://www.romhacking.net/hacks/1020/"
 )
@@ -69,7 +69,7 @@ game (
 )
 game (
     name "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors [Hack by fusaru]"
-    description "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors hack by fusaru version (1.0)"
+    description "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors by fusaru version (1.0)"
     rom ( name "Daisenpuu ~ Twin Hawk (Japan, Europe).md" size 524288 crc abd8ce33 md5 1100938e017a56ee30c8e368ba06dc18 sha1 51e3b19d3652d5bcb45165ab6838c77455a39a28 )
     patch "http://www.romhacking.net/hacks/3310/"
 )
@@ -93,7 +93,7 @@ game (
 )
 game (
     name "Streets of Rage 3 (Roo, Ash, Shiva Unlocked) [Hack by Evgeny]"
-    description "Streets of Rage 3 (Roo, Ash, Shiva Unlocked) hack by Evgeny version (1.0)"
+    description "Streets of Rage 3 (Roo, Ash, Shiva Unlocked) by Evgeny version (1.0)"
     rom ( name "Streets of Rage 3 (USA).md" size 4194304 crc 396e2937 md5 18e4790c9a797a1085bd452d3c0d46de sha1 8cf55d57e34602c1b454bb37b17b2431a1f8e771 )
     patch "http://www.romhacking.net/hacks/2253/"
 )
@@ -147,31 +147,31 @@ game (
 )
 game (
     name "Prince of Persia 2 - Horse Level Fixed [Hack by Linkuei]"
-    description "Prince of Persia 2 - Horse Level Fixed hack by Linkuei version (1.0)"
+    description "Prince of Persia 2 - Horse Level Fixed by Linkuei version (1.0)"
     rom ( name "Prince of Persia 2 - The Shadow and the Flame (Europe) (Proto).md" size 2097152 crc f5e625c9 md5 f2078ee86d5a614925c51a5be81bc3cc sha1 1bfca72bcd6aeb7ad762edb6e114f75bd0bee4b6 )
     patch "http://www.romhacking.net/hacks/3755/"
 )
 game (
     name "Mega Man the Wily Wars SRAM+ [Hack by Ar8temis008]"
-    description "Mega Man the Wily Wars SRAM+ hack by Ar8temis008 version (0.5)"
+    description "Mega Man the Wily Wars SRAM+ by Ar8temis008 version (0.5)"
     rom ( name "Mega Man - The Wily Wars (Europe).md" size 2097152 crc d5d47d23 md5 1b0d5de7be13517ca2a7249aab5d2152 sha1 cf8c4cb323c7b167ebd52c3f0486e4261f0da2d5 )
     patch "http://www.romhacking.net/hacks/3837/"
 )
 game (
     name "The Chaos Engine Amiga colors & music speed fix [Hack by fusaru]"
-    description "The Chaos Engine Amiga colors & music speed fix hack by fusaru version (1.01)"
+    description "The Chaos Engine Amiga colors & music speed fix by fusaru version (1.01)"
     rom ( name "Chaos Engine, The (Europe).md" size 1572864 crc 65887f32 md5 43fdebcd2edc168f5fb9439eed68820b sha1 7d70a839f9ca5b49f937b54377c16c58fe2fea41 )
     patch "http://www.romhacking.net/hacks/2754/"
 )
 game (
     name "Contra: Hard Corps Enhancement Hack [Hack by M.I.J.E.T.]"
-    description "Contra: Hard Corps Enhancement Hack hack by M.I.J.E.T. version (Super Cham)"
+    description "Contra: Hard Corps Enhancement Hack by M.I.J.E.T. version (Super Cham)"
     rom ( name "Contra - Hard Corps (USA, Korea).md" size 2097152 crc 41b49317 md5 f055fce2a6ab82a96a65290465e0c97e sha1 475a1c99713df4f7f8e66d4f75664559a3dac851 )
     patch "http://www.romhacking.net/hacks/450/"
 )
 game (
     name "Sonic the Hedgehog Classic Heroes [Hack by flamewing]"
-    description "Sonic the Hedgehog Classic Heroes hack by flamewing version (0.10.008a)"
+    description "Sonic the Hedgehog Classic Heroes by flamewing version (0.10.008a)"
     rom ( name "Sonic Classic Heroes.md" size 4194304 crc c27093da md5 4634c397a507053b0e04fc3ce6c49d9a sha1 a39b4a7c2d69f7d0bc8b40de7757e3be13acea0b )
     patch "http://www.romhacking.net/hacks/1038/"
 )
@@ -183,7 +183,7 @@ game (
 )
 game (
     name "Sonic 3 Complete [Hack by Tiddles]"
-    description "Sonic 3 Complete hack by Tiddles version (130810)"
+    description "Sonic 3 Complete by Tiddles version (130810)"
     rom ( name "Sonic & Knuckles + Sonic The Hedgehog 3 (USA).md" size 3932160 crc 2bd564b1 md5 153b6d32026993569b16ff89c53197a3 sha1 4461ed4a94b93653905c08e201f7c11a128e5a47 )
     patch "http://www.romhacking.net/hacks/1056/"
 )
@@ -207,13 +207,13 @@ game (
 )
 game (
     name "Phantasy Star II Bugfix [Hack by lory1990]"
-    description "Phantasy Star II Bugfix hack by lory1990 version (4.1)"
+    description "Phantasy Star II Bugfix by lory1990 version (4.1)"
     rom ( name "Phantasy Star II (USA, Europe) (Rev A).md" size 784378 crc 54b60daf md5 6cb1775bc35af4680fc1f0f98b5274b2 sha1 3b4698d1d872582de4ce4a65bf0ae24bdf6f0377 )
     patch "http://www.romhacking.net/hacks/2132/"
 )
 game (
     name "Shinobi III Enhancement Hack [Hack by M.I.J.E.T.]"
-    description "Shinobi III Enhancement Hack hack by M.I.J.E.T. version (111009)"
+    description "Shinobi III Enhancement Hack by M.I.J.E.T. version (111009)"
     rom ( name "Shinobi III - Return of the Ninja Master (USA).md" size 1048576 crc aaea518f md5 7d72722a02c7c0057171ae150683337f sha1 ca27d5445533a31f46ea5db058a1ef56ef093a28 )
     patch "http://www.romhacking.net/hacks/827/"
 )
@@ -237,55 +237,55 @@ game (
 )
 game (
     name "Shadowrun 2050 [Hack by Vikfield]"
-    description "Shadowrun 2050 hack by Vikfield version (1.1)"
+    description "Shadowrun 2050 by Vikfield version (1.1)"
     rom ( name "Shadowrun (USA).md" size 2097152 crc 8bdf25f0 md5 ffb080691848b24d28cdf1b7c1d1fc18 sha1 03c0f0e67a65feae01349b90f6e679f6e1090f07 )
     patch "http://www.romhacking.net/hacks/4116/"
 )
 game (
     name "Phantasy Star Generation: 4 - A Relocalization [Hack by GhaleonUnlimited]"
-    description "Phantasy Star Generation: 4 - A Relocalization hack by GhaleonUnlimited version (1.30)"
+    description "Phantasy Star Generation: 4 - A Relocalization by GhaleonUnlimited version (1.30)"
     rom ( name "Phantasy Star IV (USA).md" size 3193364 crc 016662d2 md5 b1de437701a520399a9c9602b980751d sha1 e24fdd2f75661bf7688aff06831e3caf9dfa6808 )
     patch "http://www.romhacking.net/hacks/4171/"
 )
 game (
-    name "Ultimate Mortal Kombat 3 Hack [Hack by Nemesis_c]"
-    description "Ultimate Mortal Kombat 3 Hack hack by Nemesis_c version (0.6)"
+    name "Ultimate Mortal Kombat 3 - Arcade Hack [Hack by Nemesis_c]"
+    description "Ultimate Mortal Kombat 3 - Arcade Hack by Nemesis_c version (0.6)"
     rom ( name "Ultimate Mortal Kombat 3 (USA).md" size 6248922 crc d8c152ff md5 3ef38ef9ec6fe16526762dff2966cd05 sha1 072c891f23e3e1f960a712fde08b01a9af75c9cb )
     patch "http://www.romhacking.net/hacks/3158/"
 )
 game (
     name "Ultimate Mortal Kombat Trilogy [Hack by KABAL_MK]"
-    description "Ultimate Mortal Kombat Trilogy hack by KABAL_MK version (Hack 23 (5125))"
+    description "Ultimate Mortal Kombat Trilogy by KABAL_MK version (Hack 23 (5125))"
     rom ( name "Ultimate Mortal Kombat Trilogy.md" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
     patch "http://www.romhacking.net/hacks/1059/"
 )
 game (
     name "Sonic 2 Improvement [Hack by lory1990]"
-    description "Sonic 2 Improvement hack by lory1990 version (5.0)"
+    description "Sonic 2 Improvement by lory1990 version (5.0)"
     rom ( name "Sonic The Hedgehog 2 (World) (Rev A).md" size 1114102 crc f5d4c7cd md5 b3c8945b1d1aa1f6ef867eb3bfb8c26d sha1 7c0e01ed089fa56d52141b5be0a9064eb96fb255 )
     patch "http://www.romhacking.net/hacks/2137/"
 )
 game (
     name "Street Fighter II PCM driver fix [Hack by Stephane Dallongeville]"
-    description "Street Fighter II PCM driver fix hack by Stephane Dallongeville version (7)"
+    description "Street Fighter II PCM driver fix by Stephane Dallongeville version (7)"
     rom ( name "Street Fighter II' - Special Champion Edition (USA).md" size 3145728 crc 92b46306 md5 9b4529a4f713c733e5a187bc7b673eca sha1 1d6e640007edbec5e4e7a7d37d48e12a9029fa00 )
     patch "http://www.romhacking.net/hacks/2133/"
 )
 game (
     name "Street Fighter 2 Champion Edition Arcade Hack [Hack by Lord Hiryu]"
-    description "Street Fighter 2 Champion Edition Arcade Hack hack by Lord Hiryu version (2.0)"
+    description "Street Fighter 2 Champion Edition Arcade Hack by Lord Hiryu version (2.0)"
     rom ( name "Street Fighter 2 Champion Edition Arcade Hack.md" size 3145728 crc 518a850e md5 262131e441fadd75d31e3bcf0dd9cccd sha1 4f8167ce31d90ccc95315e32ddb36b7b108bc9ca )
     patch "http://www.romhacking.net/hacks/3212/"
 )
 game (
     name "Mortal Kombat II Unlimited - Enhanced Colors [Hack by Pyron]"
-    description "Mortal Kombat II Unlimited - Enhanced Colors hack by Pyron version (1.0)"
+    description "Mortal Kombat II Unlimited - Enhanced Colors by Pyron version (1.0)"
     rom ( name "Mortal Kombat II (World).md" size 4136840 crc 1867b4d9 md5 3f1aa570edddc5c5e2879a94d6f62e11 sha1 13de727bacf8c644e3df7a96cf212b5a1a899455 )
     patch "http://www.romhacking.net/hacks/2310/"
 )
 game (
     name "Super Street Fighter II PCM driver fix [Hack by Stephane Dallongeville]"
-    description "Super Street Fighter II PCM driver fix hack by Stephane Dallongeville version (1.0)"
+    description "Super Street Fighter II PCM driver fix by Stephane Dallongeville version (1.0)"
     rom ( name "Super Street Fighter II (USA).md" size 5242880 crc e8612c91 md5 3ed52bd4b63f0438ea41306aec08afcc sha1 479223c0efd45a1c88298dcd231af1c6f347f9f1 )
     patch "http://www.romhacking.net/hacks/2134/"
 )

--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -18,7 +18,7 @@ game (
 )
 game (
     name "Asuka 120% Limit Over - easy patch [Hack by SCO]"
-    description "Asuka 120% Limit Over - easy patch hack by SCO version (1.0)"
+    description "Asuka 120% Limit Over - easy patch by SCO version (1.0)"
     rom ( name "Asuka 120% Limited - Burning Fest. Limited (Japan) (Track 01).bin" size 62095152 crc bd23db54 md5 4bcce0bfcc29cb358f7c2e2c8682f1a9 sha1 b9723e2277933df5fba915bcf160253952ba5fdd )
     patch "http://www.romhacking.net/hacks/3983/"
 )
@@ -30,7 +30,7 @@ game (
 )
 game (
     name "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) [Hack by paul_met]"
-    description "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) hack by paul_met version (1.0)"
+    description "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) by paul_met version (1.0)"
     rom ( name "Story of Thor 2, The (Europe) (Track 1).bin" size 81995424 crc 8ae4c201 md5 f438779e54965c3e923d1aa934a6a13c sha1 0c551e311ae0c5ad59199017d67c6582429a5922 )
     patch "http://www.romhacking.net/hacks/3403/"
 )

--- a/metadat/hacks/Sony - PlayStation Portable.dat
+++ b/metadat/hacks/Sony - PlayStation Portable.dat
@@ -10,7 +10,7 @@ game (
 )
 game (
     name "War of the Lions Tweak [Hack by Tzepish]"
-    description "War of the Lions Tweak hack by Tzepish version (1.06)"
+    description "War of the Lions Tweak by Tzepish version (1.06)"
     rom ( name "Final Fantasy Tactics - The War of the Lions (USA).iso" size 418873344 crc 53d278e6 md5 00cb18f7d384e0e562f9bc8d322fb743 sha1 0e4d0aaf884459641b4bc77216badb1d5167d036 )
     patch "http://www.romhacking.net/hacks/916/"
 )

--- a/metadat/hacks/Sony - PlayStation.dat
+++ b/metadat/hacks/Sony - PlayStation.dat
@@ -118,7 +118,7 @@ game (
 )
 game (
     name "Castlevania: Symphony of the Night - Quality hack [Hack by paul_met]"
-    description "Castlevania: Symphony of the Night - Quality hack hack by paul_met version (1.2)"
+    description "Castlevania: Symphony of the Night - Quality hack by paul_met version (1.2)"
     rom ( name "Castlevania - Symphony of the Night (USA) (Track 1).bin" size 538655040 crc 0431c247 md5 6674f4a75ea11fd9422669f247ec27fd sha1 1fa7cd542e15f9ce281e83320eedd24daace79e8 )
     patch "http://www.romhacking.net/hacks/3606/"
 )


### PR DESCRIPTION
This is a big commit but there is nothing interesting there - it's because rhdndat output changed to remove a 'hack' after the hackname and before the 'by author' because many hacks already had a hack suffix on their name.

I also need to change the order of a few 'comments' in these files for rhdndat pyparsing parser to parse them correctly prior to a merge and not blow up if there is a 'comment followed by patch followed by comment'. Basically all 'comment' tags are to be put after the 'patch' tags at the bottom.