### PR TITLE
Add `Final Fantasy VI - Ted Woolsey Uncensored Edition` to `SNES` rom hacks database

### DIFF
--- a/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
@@ -13,6 +13,162 @@ game (
     rom ( name "ChronoTrigger - Crimson Echoes.smc" size 6291968 crc 2ebceb79 md5 24955542c1ea9c5bbd21a07479e64047 sha1 a43632026948df3d288f0bb03f6c83ee8e76bdd5 )
 )
 game (
+    name "Final Fantasy VI [TWUE v2.01]"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01]"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01].sfc" size 4194304 crc 496a732d md5 d20b087e43b21782bbf7104f34fa710d sha1 6ffa84a357b0eef904e9ee14c89b44fe1681dad0 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Config 1).sfc" size 4194304 crc 017c1b14 md5 59301dc161a9ac99f9b5812e54fecfaa sha1 41fca01e18ae6d22b22895078ecb1031f32e1f4e )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Config 2).sfc" size 4194304 crc d45668f6 md5 5e4ff42da754ef2f21ce69d342629d68 sha1 1e3b409bda7e9d7a53474da7bfa97cdfd8e1f8fb )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu A).sfc" size 4194304 crc 0146e2c2 md5 bbeb63146c138681fbaf8c095f4283f6 sha1 941c4ade4ece4129e40702c68548299dafef0c19 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu B)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Main Menu B)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu B).sfc" size 4194304 crc fa72d7c7 md5 1149ff4cc5ffb73400f87146e25969f7 sha1 a7ea8603dd680ada19ff83c0f6aa708f0d99d17e )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes).sfc" size 4194304 crc 72f6c8b9 md5 4595980aaff9a8fdf4352b090de6c978 sha1 192dfac806c5eb0555230f7e300357f6084ec42b )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 1).sfc" size 4194304 crc 3ae0a080 md5 ce219609adbbd4f01aca3c09a6c9120f sha1 2def721c63912a7e587084a775a20d37bf3a2b9b )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 2).sfc" size 4194304 crc efcad362 md5 d9f839b85fd59daae1f4459cddafafaf sha1 411b6f4f1d7d735e7555f61fb89c1637dabb4a79 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Main Menu A).sfc" size 4194304 crc 891acc1c md5 44e284c085959d397d3c7d2be2465445 sha1 937a153f469545cd3d99db379c1f9cc0cb614fb2 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons).sfc" size 4194304 crc f5f4a492 md5 b5282e5c781eed3cfb25ed89a24f18bf sha1 9a9deb3fb033dec62e696849d97d37f6c5183fbd )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1).sfc" size 4194304 crc bde2ccab md5 0b0f7a6cb545b7ed39e059be47164e8d sha1 d454f7357871d89c151560b77b1b2e61eeb8685b )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2).sfc" size 4194304 crc 68c8bf49 md5 3b27b255a91602706b9ec59a060e77b5 sha1 70c3ce1627d0f1a22fd9c70e31c9fb5ae60a7e83 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A).sfc" size 4194304 crc 0e18a037 md5 58b0e8a7c4cf1b4334aa851c95fe68ed sha1 d5abbaa0718326971193651b0d5551eb0947baac )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera).sfc" size 4194304 crc 9a555238 md5 470b038a57a2527771e1130e1d78d663 sha1 87563f8cec80f9983d0d61e815125619dd4833cf )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1).sfc" size 4194304 crc d2433a01 md5 fd2f5ffebbf06f043e2ecf001e5ba724 sha1 582089cc4aef1d2ac30ff95452d7337ef79bafb2 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2).sfc" size 4194304 crc 076949e3 md5 078e24dc0e88da06c54febd7b00f0d77 sha1 29cedb11c8ca643c8e532bc33eb639973fbc5b44 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A).sfc" size 4194304 crc 61b9569d md5 2aa2be40e461065fe8c6ef817fb24be8 sha1 c8dea3c804bdae50bdb538ab15b1db0bf99acaa7 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons).sfc" size 4194304 crc 747c2038 md5 cecc23d950153dd9c8af8d446cc32f21 sha1 1cd19ef28d58912bd7679583c8915f401a16d0de )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1).sfc" size 4194304 crc 3c6a4801 md5 0f02218bef725649cb025c777bf82ebb sha1 42b269a86de5c19fa60fdece81825466f9fd1f92 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2).sfc" size 4194304 crc e9403be3 md5 bd8464371c86e0ec5a2c887041920af8 sha1 00dc8d2947acc5e0f2b02103dfc71078bf9fd881 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A).sfc" size 4194304 crc 8f90249d md5 b042767cabb3e75827c78346d31d6952 sha1 d6a5455b59cf0dc4dff8f7bc4602e599cc0c6680 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Updated Opera)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera).sfc" size 4194304 crc ea50cd89 md5 b589d6d0d78c07f422efbdce96a84a44 sha1 3d5b3e64b31036b5b30ce1a2e1db364c99a114c0 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 1)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Config 1)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 1).sfc" size 4194304 crc a246a5b0 md5 b914e85efaa6ba88c824bf53f54212a0 sha1 c484d67324bb0493525ed9da239de7ea5b1b9aa0 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 2)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Config 2)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 2).sfc" size 4194304 crc 776cd652 md5 316902d08bb213e8a408f7eaaca44d8b sha1 e03758566ceaec22ecdad36742e9c2d2b114c11e )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu A)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Main Menu A)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu A).sfc" size 4194304 crc a27c5c66 md5 ec8a6b57af4ebdde472d044c82bbf462 sha1 d4dca9df543346a55f5069ae5a22a807a12f9f76 )
+)
+game (
+    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu B)"
+    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Main Menu B)"
+    homepage "https://www.romhacking.net/hacks/1386/"
+    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu B).sfc" size 4194304 crc 59486963 md5 003b119e354c70022d4e8ce67e5ddba3 sha1 750bf9dec0e428c1a164691a67c22147752955ab )
+)
+game (
     name "Mario & Luigi - Kola Kingdom Quest (USA)"
     description "'Super Mario World' hack by GammaV"
     rom ( name "KKQFinalFixed.sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )


### PR DESCRIPTION
Hi @RobLoach,

I noticed you were quite conservative regarding the addition of ROM hacks to the database, but this one is a quite well known translation/edit of Final Fantasy VI. I added all of the available signatures (based on the different combinations of patches) for the latest version ([`v2.01`](https://www.romhacking.net/hacks/1386/)).

