### PR TITLE
update MAME 2010 DATs and metadaat

### DIFF
--- a/metadat/mame-nonmerged/MAME 2010.dat
+++ b/metadat/mame-nonmerged/MAME 2010.dat
@@ -1,13 +1,6 @@
 clrmamepro (
-	name "MAME 0.139 Non-Merged TorrentZipped (No BIOS)"
-	version 2017-02-10
-)
-
-game (
-	name "005"
-	year "1981"
-	developer "Sega"
-	rom ( name 005.zip size 29769 crc d123fe67 md5 64ba2c1869a491bdae1384d3a95c2027 sha1 aeebfd4a3a6214e6efed19dd4d5716215e253b13 )
+  name "MAME 2010 Full Non-Merged Working"
+  version "2019-01-03"
 )
 
 game (
@@ -32,31 +25,10 @@ game (
 )
 
 game (
-	name "Eleven Beat"
-	year "1998"
-	developer "Hudson"
-	rom ( name 11beat.zip size 4787189 crc 5f254a6c md5 9acbaa0f01b5e2e988ed2c322f4962ea sha1 79f30a15c48ee8d625ae4376b56f764126c1579e )
-)
-
-game (
-	name "18 Wheeler (JPN)"
-	year "2000"
-	developer "Sega"
-	rom ( name 18wheelr.zip size 101133212 crc 093619ab md5 4d840a2b0a358ecc43c38b0f52a36bfd sha1 c133a08de797e3d74832d0d0866443003073f633 )
-)
-
-game (
 	name "1941: Counter Attack (World)"
 	year "1990"
 	developer "Capcom"
 	rom ( name 1941.zip size 1419821 crc de03fb24 md5 3a72d8463b47ce63dee199137a13ac64 sha1 d6ee54766d377d1136f6a5e17b772666a072e74e )
-)
-
-game (
-	name "1941: Counter Attack (Japan)"
-	year "1990"
-	developer "Capcom"
-	rom ( name 1941j.zip size 1419323 crc aefdd791 md5 b7ac353d4638406fb29cf8b13cf5f924 sha1 b953cc7fa4f727008afe7cbff3579c61e4fbfae5 )
 )
 
 game (
@@ -92,34 +64,6 @@ game (
 	year "1985"
 	developer "Capcom (Williams Electronics license)"
 	rom ( name 1942w.zip size 106956 crc 3ca92bd4 md5 c393fd70c115d8317e296b8f4b419a79 sha1 adda61865b029ac39296138abb5dd0a256e30605 )
-)
-
-game (
-	name "1943: The Battle of Midway (Euro)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943.zip size 305392 crc d0e80fef md5 905c7d99b594af7fe2ac31392835e9b8 sha1 a5acd39d166a43450b8f01cafe1a6e98e7122b4e )
-)
-
-game (
-	name "1943: Midway Kaisen (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943j.zip size 305250 crc b76b02f5 md5 2cf7f5363e7a648528770702b0227446 sha1 68a0ea3b855bbe0a24f81d632aab15d34bd57e95 )
-)
-
-game (
-	name "1943 Kai: Midway Kaisen (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943kai.zip size 313068 crc 992baef8 md5 763bf59dd41cfbf9540330b541d03f35 sha1 a4b53090206e4d7186a9615b6c3f3c7654b4d93e )
-)
-
-game (
-	name "1943: The Battle of Midway (US)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943u.zip size 305018 crc 66b05a68 md5 e82ccdf57ec8eecab6587d6901adc8ad sha1 90e72d1ecb739490f7e3bf122ca9575ec9b58664 )
 )
 
 game (
@@ -203,28 +147,28 @@ game (
 	name "1 on 1 Government (Japan)"
 	year "2000"
 	developer "Tecmo"
-	rom ( name 1on1gov.zip size 15003816 crc 87b82444 md5 14d001bf5709752cf9e89b56e86db868 sha1 0b36788fbeae0cfd854250ce929f0f3395fa43d4 )
+	rom ( name 1on1gov.zip size 15142268 crc ff1ad8e1 md5 2d180d12d9be06103247ba6afe32a066 sha1 11888530107f94f7b7e028910ab91e80157c3273 )
 )
 
 game (
 	name "2020 Super Baseball (set 1)"
 	year "1991"
 	developer "SNK / Pallas"
-	rom ( name 2020bb.zip size 2934349 crc 493c034c md5 e383b97137c353d51b3f4d26ccea968b sha1 bc5cac4d6d7fd4623ef0d9eafc9f8d0c789b9749 )
+	rom ( name 2020bb.zip size 4281036 crc 35fa62d8 md5 055805b41530a8465d584c0223154a73 sha1 0ef94d08b82219187acececd7c98d0fbcc784233 )
 )
 
 game (
 	name "2020 Super Baseball (set 2)"
 	year "1991"
 	developer "SNK / Pallas"
-	rom ( name 2020bba.zip size 2934591 crc 3c336986 md5 66c288cdaaa34b52b25278d9b265326b sha1 b316457042f11459ded41839ff9c38e3a458c759 )
+	rom ( name 2020bba.zip size 4281278 crc 48ba82a8 md5 b8d6dab1deebfd3dbaab496b10d61657 sha1 1710db7b6aef0a709d2042e418bd80a707a29ef3 )
 )
 
 game (
 	name "2020 Super Baseball (set 3)"
 	year "1991"
 	developer "SNK / Pallas"
-	rom ( name 2020bbh.zip size 2934367 crc 75653f34 md5 78c9d39f3c18ccaf3dc095e2df505ed2 sha1 9b73b0397c8a41d99b8ff97eefb2492a18b5d313 )
+	rom ( name 2020bbh.zip size 4281054 crc 5d5c5731 md5 b578671e04a572adafd6fec67b928759 sha1 622bfbf48701fb3967e808c1a63c4b1b85378390 )
 )
 
 game (
@@ -256,20 +200,6 @@ game (
 )
 
 game (
-	name "Datsun 280 Zzzap"
-	year "1976"
-	developer "Midway"
-	rom ( name 280zzzap.zip size 5229 crc c476b857 md5 6fda35567e29e62681add5de4c2d4f5b sha1 8dd2dc4e8abe83ab7ceb4c0fb553a3513652a44e )
-)
-
-game (
-	name "Two Minute Drill"
-	year "1993"
-	developer "Taito"
-	rom ( name 2mindril.zip size 5504856 crc f5588598 md5 3e78cb4f77323375f66e495bed6951b3 sha1 49e937b9f89bc1729171da44ad26cc98b1ad21e0 )
-)
-
-game (
 	name "39 in 1 MAME bootleg"
 	year "2004"
 	developer "bootleg"
@@ -277,17 +207,10 @@ game (
 )
 
 game (
-	name "3 Bags Full - 3VXFC5345 (New Zealand)"
-	year "1994"
-	developer "Aristocrat"
-	rom ( name 3bagflnz.zip size 53100 crc abe7d8ba md5 ae05bc562a050ac57d08bd3b2978de5e sha1 93b2902480c056be234514c6b2ecf7545fabe2d4 )
-)
-
-game (
 	name "3 Count Bout / Fire Suplex"
 	year "1993"
 	developer "SNK"
-	rom ( name 3countb.zip size 7632913 crc 7ba4e7b5 md5 d82c7dfe4311ee8f74c091232541d8f7 sha1 033602a1c49f2b2cfa5bdee9a0a2f09a7c9ad429 )
+	rom ( name 3countb.zip size 8979600 crc 1a088e4e md5 4026599fa83837ac6278619ee080a12a sha1 6760d76e28cdf6ef4fe26f7ae88ba15b7cb3599b )
 )
 
 game (
@@ -295,13 +218,6 @@ game (
 	year "1985"
 	developer "Nichibutsu"
 	rom ( name 3ds.zip size 93856 crc 28ae71bf md5 5ebb59f496cff93fe75c83344c2d4cf5 sha1 f7e5498b3fdc92ff34fcb5736047cf57cb36f2d0 )
-)
-
-game (
-	name "XESS - The New Revolution (SemiCom 3-in-1)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name 3in1semi.zip size 1187337 crc c8ce23a8 md5 37ab524977d28c1fee901ddfdf200a02 sha1 5655e9f337cf9ddb9451a3ecc2ba22b27fe46e82 )
 )
 
 game (
@@ -316,12 +232,6 @@ game (
 	year "1984"
 	developer "Mylstar"
 	rom ( name 3stooges.zip size 73365 crc 5fe01517 md5 716239c23bd55423ecb01bbaebadb870 sha1 36bb2c3c323eb31074f60bcfe5b11630232cba2c )
-)
-
-game (
-	name "3 Super 8 (Italy)"
-	developer "&lt;unknown&gt;"
-	rom ( name 3super8.zip size 403221 crc f14e771c md5 3135cb08fd8b92cb695e14046402e6a7 sha1 308f3f8ed4e5867143f5c337f1fe0a8716b89f9e )
 )
 
 game (
@@ -343,41 +253,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name 3wondersu.zip size 2476254 crc 2f41cfa6 md5 65251d86571756cd16031e01ac24b681 sha1 7d79508b95b2b06ccf34e85b3b9d48f3133129f4 )
-)
-
-game (
-	name "Forty-Love"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
-)
-
-game (
-	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
-	year "1994"
-	developer "Jaleco"
-	rom ( name 47pie2.zip size 10228866 crc 09321e19 md5 f9d67336316a83050a1be7d3e174990c sha1 158bf6e56bcfdc03d0a32f7d881a07351554c8fd )
-)
-
-game (
-	name "Idol Janshi Su-Chi-Pie 2 (v1.0)"
-	year "1994"
-	developer "Jaleco"
-	rom ( name 47pie2o.zip size 10229218 crc 7100955c md5 ecf6d7d7f4cf46c6927183872962db53 sha1 c83e4a41e2f628c48f871351a05cb85e462ffa16 )
-)
-
-game (
-	name "48 in 1 MAME bootleg (ver 3.09)"
-	year "2004"
-	developer "bootleg"
-	rom ( name 48in1.zip size 2509146 crc 85e10950 md5 5a9c00945eee945969df0621baf23b92 sha1 8c2068b5dd97fa01561c1a72cba6d2f3f3c0d78f )
-)
-
-game (
-	name "48 in 1 MAME bootleg (ver 3.02)"
-	year "2004"
-	developer "bootleg"
-	rom ( name 48in1a.zip size 2526328 crc 3d4bff41 md5 fd509e94150642bbb04bda26bea1166c sha1 0b0112441b98a6ee5bcbdc9aa0ad3e845ff40f57 )
 )
 
 game (
@@ -416,38 +291,10 @@ game (
 )
 
 game (
-	name "Four Roses (encrypted, set 1)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name 4roses.zip size 98411 crc 85e4951e md5 86cfb78de260094e1d7a322511c8a8fa sha1 b7549eb13876c5dd7bd16be3ff8c93419bb52cd8 )
-)
-
-game (
-	name "Four Roses (encrypted, set 2)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name 4rosesa.zip size 98383 crc 93bf05f7 md5 2746514c0bce86d5172c420125ad08cf sha1 a545cdad74f06bb9134abbd36bb200fff8344e5f )
-)
-
-game (
-	name "500 GP (5GP3 Ver. C)"
-	year "1998"
-	developer "Namco"
-	rom ( name 500gp.zip size 40299932 crc 9064fb08 md5 65e8098eed9cd9d2c7d7135b86677f94 sha1 046494e6a3f5dab02ada0eebe8f1906662705089 )
-)
-
-game (
 	name "Five Clown (English, set 1)"
 	year "1993"
 	developer "IGS"
 	rom ( name 5clown.zip size 63250 crc 97b36d3e md5 ada16ed9eb1ae6440babc982b8cdeb41 sha1 4b66f40192f075547d07e018c73ce57dc4e6bfb5 )
-)
-
-game (
-	name "Five Clown (English, set 2)"
-	year "1993"
-	developer "IGS"
-	rom ( name 5clowna.zip size 63943 crc 58041a43 md5 ef28648f12f5d56577372984937b9eb3 sha1 909c5613c546892e7e9f0dc362b0400d488d1887 )
 )
 
 game (
@@ -462,20 +309,6 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14459 crc e8e6b845 md5 6b249af98f7b27b35c55df083188d7a4 sha1 b40bd175b43a494a19d0b7e7b6021243027bb8df )
-)
-
-game (
-	name "64th. Street - A Detective Story (World)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
-)
-
-game (
-	name "64th. Street - A Detective Story (Japan)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name 64streetj.zip size 1294030 crc 38192b3d md5 72160ca1b1d25604d50e22c18f9eec4d sha1 f6992618cee1fceabcdacaa294e6f8ddbce49b82 )
 )
 
 game (
@@ -555,13 +388,6 @@ game (
 )
 
 game (
-	name "86 Lions"
-	year "1985"
-	developer "Aristocrat"
-	rom ( name 86lions.zip size 9957 crc 0ed6f606 md5 714d4ee21c6298a6ecf75c7f2bc12f03 sha1 8f35bf08a14c225c33b29da7675f56f35c97c66c )
-)
-
-game (
 	name "'88 Games"
 	year "1988"
 	developer "Konami"
@@ -583,31 +409,10 @@ game (
 )
 
 game (
-	name "Eight Ball Action (DK conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Magic Eletronics USA license)"
-	rom ( name 8ballact.zip size 16261 crc c7b9822e md5 81cc86d18b8604c5ba85de72830011b6 sha1 3024248c8c6f47b2ed4ac525b428236c43dafcd0 )
-)
-
-game (
-	name "Eight Ball Action (DKJr conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Magic Eletronics USA license)"
-	rom ( name 8ballact2.zip size 17183 crc 62e3f146 md5 c45ca3398de25eaedf86b66c32dc8926 sha1 b3e52e2825966a11ba98b0530dd846107794545d )
-)
-
-game (
 	name "Eight Ball Action (Pac-Man conversion)"
 	year "1985"
 	developer "Seatongrove Ltd (Magic Eletronics USA license)"
 	rom ( name 8bpm.zip size 12301 crc 1f39b634 md5 2c509ce7e2234e2a43c2b7b8005b64cf sha1 b685ca19a861607053aade8557ef9283e969544b )
-)
-
-game (
-	name "'98 NeoPri Best 44 (Neo Print)"
-	year "1998"
-	developer "SNK"
-	rom ( name 98best44.zip size 2135046 crc 75d47503 md5 76256e30153a2d37e5b28a46b5d2476f sha1 49ea078bb54fbe888355b1fc0e812579d18f500a )
 )
 
 game (
@@ -667,20 +472,6 @@ game (
 )
 
 game (
-	name "Area 51: Site 4"
-	year "1998"
-	developer "Atari Games"
-	rom ( name a51site4.zip size 90541 crc 3a259eba md5 f51c3a40f277deeccdf558928aba7508 sha1 09dcbbab7451775571c3d8c4fd82bfbd78ec37aa )
-)
-
-game (
-	name "All American Football (rev E)"
-	year "1989"
-	developer "Leland Corp."
-	rom ( name aafb.zip size 525577 crc 4535f25a md5 234ae3914d7eb81036e38beb0eca4d9b sha1 4e33bdea83ad2897e40855ed163ba0d06eb4e5de )
-)
-
-game (
 	name "All American Football (rev B)"
 	year "1989"
 	developer "Leland Corp."
@@ -699,12 +490,6 @@ game (
 	year "1989"
 	developer "Leland Corp."
 	rom ( name aafbd2p.zip size 550832 crc 76d4321d md5 b6744c51c1242db34e445a077c634507 sha1 054b8c0e18afff63eaadf82da55bbc9e193bd86e )
-)
-
-game (
-	name "Abacus (Ver 1.0)"
-	developer "&lt;unknown&gt;"
-	rom ( name abacus.zip size 496571 crc 638c65fb md5 9e0c86a40c53bf8f57eb1ecef83a22d6 sha1 432780165ad18f851818961e18dab2eb093c5976 )
 )
 
 game (
@@ -799,20 +584,6 @@ game (
 )
 
 game (
-	name "Ace"
-	year "1976"
-	developer "Allied Leisure"
-	rom ( name ace.zip size 2862 crc 3db2236f md5 83ca82ca99a83dfee572e8a0ce62d7a0 sha1 185e6ac2d1b76bcb4007e048fe2d325229173806 )
-)
-
-game (
-	name "Ace Attacker (FD1094 317-0059)"
-	year "1988"
-	developer "Sega"
-	rom ( name aceattac.zip size 469948 crc feef4f10 md5 184de2ebe9706e4ddbeb86a49cbdf9e8 sha1 bdd2ccf04d4ba8f9662413aba01e48bfc4158ec3 )
-)
-
-game (
 	name "Ace Attacker (Japan, System 16A, FD1094 317-0060)"
 	year "1988"
 	developer "Sega"
@@ -824,12 +595,6 @@ game (
 	year "1994"
 	developer "Namco"
 	rom ( name acedrvrw.zip size 7790956 crc ecc23531 md5 26343984ae1b62631f08252183c307c1 sha1 19961e0a7360028570448f5a2eae6af8c74bbac8 )
-)
-
-game (
-	name "unknown ACE fruits game"
-	developer "ACE"
-	rom ( name acefruit.zip size 12257 crc 73cf297e md5 c9e0a328229c76e9eb6182149e2ee0d2 sha1 7aa6eb7da57e61788a7fd127aa9c6349740a29c5 )
 )
 
 game (
@@ -851,13 +616,6 @@ game (
 	year "1979"
 	developer "bootleg"
 	rom ( name acombato.zip size 10567 crc 88abf5fd md5 0af568e72b7080cb2879088de6ae1ca2 sha1 586f954e28325080064bf459ee6d190412aa1105 )
-)
-
-game (
-	name "Alien Command"
-	year "1994"
-	developer "Jaleco"
-	rom ( name acommand.zip size 2788724 crc 91946a02 md5 12df5b1c39cac7f9fe8939fc50cb9b3f sha1 108742eb6144c0c1f072ace2688688dea72b907c )
 )
 
 game (
@@ -959,34 +717,6 @@ game (
 )
 
 game (
-	name "Action Hollywood"
-	year "1995"
-	developer "TCH"
-	rom ( name actionhw.zip size 1321130 crc 34e2ced3 md5 560b7326579a82c1f92de6949a84960b sha1 4078379bf8e45be863a1ce175841f213def23e10 )
-)
-
-game (
-	name "A. D. 2083"
-	year "1983"
-	developer "Midcoin"
-	rom ( name ad2083.zip size 37545 crc 3676a561 md5 0838dc3da631045ddf93611f0d32090f sha1 0d59e1987ce60306df165d307ef0c26e3677b38c )
-)
-
-game (
-	name "Adders and Ladders (v2.0)"
-	year "1989"
-	developer "Barcrest"
-	rom ( name adders.zip size 527319 crc 104980a2 md5 ae2ed9f9fa402faf594ba47fd32f5744 sha1 96a133a33b096c35ae3d7de2bf8d6f886c067188 )
-)
-
-game (
-	name "Adonis (A - 25-05-98, NSW/ACT)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name adonis.zip size 601302 crc 1c06fe91 md5 5fe7e1e60769331aadc65ed77f8b8992 sha1 8b14ee68c46175b59500192c52e1490fb168428c )
-)
-
-game (
 	name "Aero Fighters (bootleg set 2)"
 	year "1992"
 	developer "bootleg"
@@ -1032,7 +762,7 @@ game (
 	name "Aero Fighters Special (Taiwan)"
 	year "1996"
 	developer "Video System Co."
-	rom ( name aerofgts.zip size 8581134 crc 90c60c7d md5 057c775c9d592455e82337508162f561 sha1 e698f065fd78ea1b1d71147fab37ae66ff6d3787 )
+	rom ( name aerofgts.zip size 8707316 crc 8a9573be md5 855ee38f1910b30e28b16276f36f7cf5 sha1 86509735b8a56eeaa49a0db10807a3d53bf0ce5b )
 )
 
 game (
@@ -1134,13 +864,6 @@ game (
 )
 
 game (
-	name "Air Inferno (US)"
-	year "1990"
-	developer "Taito America Corporation"
-	rom ( name ainferno.zip size 1149947 crc c94d1c87 md5 c341009c791ed4e5668e528a3ba097e2 sha1 f1917a825c143682381ae1641ed1cf51f9d0bef5 )
-)
-
-game (
 	name "Air Attack (set 1)"
 	year "1996"
 	developer "Comad"
@@ -1155,80 +878,10 @@ game (
 )
 
 game (
-	name "Air Buster: Trouble Specialty Raid Unit (World)"
-	year "1990"
-	developer "Kaneko (Namco license)"
-	rom ( name airbustr.zip size 693968 crc d9e397ed md5 48fe2cda23a4ec913b254fcf67ca17b0 sha1 9f3d12511be5bc05d17c220d1a933a12698df5f1 )
-)
-
-game (
 	name "Air Buster: Trouble Specialty Raid Unit (bootleg)"
 	year "1990"
 	developer "bootleg"
 	rom ( name airbustrb.zip size 729359 crc 40b9c205 md5 8be3cb86a353516ca6edb61f95bad303 sha1 5685db462ef175fc317c81f58e3de5f291f21b35 )
-)
-
-game (
-	name "Air Buster: Trouble Specialty Raid Unit (Japan)"
-	year "1990"
-	developer "Kaneko (Namco license)"
-	rom ( name airbustrj.zip size 704896 crc 1dbd6225 md5 0e1a35246a73224a410eb5a81d8ad3f1 sha1 02f8644418305dde573a883b3a6022aa9a8b5d96 )
-)
-
-game (
-	name "Air Combat 22 (Rev. ACS1 Ver.B, Japan)"
-	year "1995"
-	developer "Namco"
-	rom ( name airco22b.zip size 17502906 crc 15b0e20a md5 bd693068dccc61ef457e8cb608dd2dc0 sha1 f014ce2b006df935a9d2213e9ee16566dcd5df09 )
-)
-
-game (
-	name "Air Combat (US)"
-	year "1992"
-	developer "Namco"
-	rom ( name aircomb.zip size 3285350 crc 435615cc md5 b61f229acfa736f82d1a8bff27225700 sha1 415c38f5fa1bd61bf76082882fbaf13b89c28036 )
-)
-
-game (
-	name "Air Combat (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name aircombj.zip size 3255746 crc 23c82e91 md5 d65b49243a154164dd7980ff8297acc4 sha1 2194ffd12bc4991acf15fe24e32ac39da1c4f804 )
-)
-
-game (
-	name "Air Duel (Japan)"
-	year "1990"
-	developer "Irem"
-	rom ( name airduel.zip size 1129917 crc 9d4f621c md5 f32170fdb460883767cdd30e3fec4def sha1 3a77c08f548679ff8f1d7e2a5722e7031e0ae797 )
-)
-
-game (
-	name "Air Raid (encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu"
-	rom ( name airraid.zip size 54989 crc 706d7fc6 md5 dee6ea84024c892fbb10ed9479cb6d8d sha1 b45761fab41231b5be8053144a0f4c1266d5b84e )
-)
-
-game (
-	name "Air Trix"
-	year "2000"
-	developer "Sega"
-	rom ( name airtrix.zip size 43740423 crc 112e51c1 md5 b86df32c6480ab682ac33eb37a4df1f9 sha1 49b8f405a59b9a222fb5df852468ca037c52e96c )
-)
-
-game (
-	name "Airwolf"
-	year "1987"
-	developer "Kyugo"
-	rom ( name airwolf.zip size 81889 crc 11104399 md5 962be6e1dcc6bff7861750416468419d sha1 6d139e060f781ee3a41618113aff13d0a9836942 )
-)
-
-game (
-	name "Airwolf (US)"
-	year "1987"
-	developer "Kyugo (UA Theatre license)"
-	rom ( name airwolfa.zip size 82048 crc 928c6ec9 md5 1379ca51c5b52917b7bcae35ec9f82f9 sha1 aeddf36a8ecfb527b303a242b7c52dd4b32f3f52 )
 )
 
 game (
@@ -1250,13 +903,6 @@ game (
 	year "1996"
 	developer "Dynax (Nakanihon license)"
 	rom ( name akamaru.zip size 5870697 crc 1f829dfd md5 6c2604e10553e30e4f2ce4aae7ccd7d8 sha1 60cc32f9eca177ef17f87edaf8c40939178446dc )
-)
-
-game (
-	name "Mahjong Angel Kiss"
-	year "1995"
-	developer "Jaleco"
-	rom ( name akiss.zip size 13222340 crc 63cbbff4 md5 6c26fe69eb301a68a489174881fb58ae sha1 834cbff5a4e90fb9fdeb10e550cf7090dbe3a6aa )
 )
 
 game (
@@ -1288,20 +934,6 @@ game (
 )
 
 game (
-	name "Alex Kidd: The Lost Stars (set 1, FD1089A 317-0021)"
-	year "1986"
-	developer "Sega"
-	rom ( name alexkidd1.zip size 384886 crc 46bd804c md5 8c5c694ef82dd97336a5a92c46321d96 sha1 dfe47c558225da42dfc7a25c9147f3eafc518bb6 )
-)
-
-game (
-	name "Ali Baba and 40 Thieves"
-	year "1982"
-	developer "Sega"
-	rom ( name alibaba.zip size 20184 crc a5edcb7a md5 fdb65ceadc7d9362bf56e5e2e4e40436 sha1 4bae12a1e21275f9093a4f9c7e52934da6d86895 )
-)
-
-game (
 	name "Alien3: The Gun (World)"
 	year "1993"
 	developer "Sega"
@@ -1327,20 +959,6 @@ game (
 	year "1985"
 	developer "Duncan Brown"
 	rom ( name alienaru.zip size 19887 crc 5362fb1d md5 bb87550ce3eba358fa61c66ec322b5dd sha1 18254bb058961a43b7a79d8508640c2492e0f45f )
-)
-
-game (
-	name "Alien Challenge (World)"
-	year "1994"
-	developer "IGS"
-	rom ( name aliencha.zip size 11413569 crc f66e5bd1 md5 d3cfdd25bf2d65da705afe9ea3ced31f sha1 3cd2e364de1ea7244f6fa24bca235b2cb3cd1123 )
-)
-
-game (
-	name "Alien Challenge (China)"
-	year "1994"
-	developer "IGS"
-	rom ( name alienchac.zip size 11097380 crc 46937c8a md5 5574745255dbbcc03c476eb60c4b8743 sha1 736ac237018c97baa0dbc73cf2de5e606c5946df )
 )
 
 game (
@@ -1454,13 +1072,6 @@ game (
 )
 
 game (
-	name "Alligator Hunt"
-	year "1994"
-	developer "Gaelco"
-	rom ( name aligator.zip size 8818059 crc 7013687a md5 17462eef86a896ca2b564e6f54aa1efa sha1 87865984a5566757b0971576dc3df25f05bd78da )
-)
-
-game (
 	name "Alligator Hunt (unprotected)"
 	year "1994"
 	developer "Gaelco"
@@ -1475,23 +1086,10 @@ game (
 )
 
 game (
-	name "Alpha One (Vision Electronics / Kyle Hodgetts)"
-	year "1988"
-	developer "Vision Electronics"
-	rom ( name alpha1v.zip size 25694 crc a653cde6 md5 ffa16bc2f8a9ca089c86e70009404ada sha1 f02041829776206270c084c84b7dc9a9fd0d4f90 )
-)
-
-game (
-	name "Alpha Fighter / Head On"
-	developer "Data East Corporation"
-	rom ( name alphaho.zip size 14445 crc 184c8caa md5 9a5f40b6be34059e7db8ba9678436939 sha1 63b322f199de66a9bdda6b919747520278d562bf )
-)
-
-game (
 	name "Alpha Mission II / ASO II - Last Guardian"
 	year "1991"
 	developer "SNK"
-	rom ( name alpham2.zip size 3223256 crc 2fce6df5 md5 36cea1e1311af9715201906ef988a61a sha1 90b1d2f066ab3d46bdaeb3ebccb2fe6ff5571b7f )
+	rom ( name alpham2.zip size 4569943 crc b6f3f7db md5 c10be5c9bca93961ef40bf1dc7c70bdd sha1 3ae5fc55cc145b701ae26a13b27124328020feca )
 )
 
 game (
@@ -1502,38 +1100,10 @@ game (
 )
 
 game (
-	name "Alpha One (prototype, 3 lives)"
-	year "1983"
-	developer "Atari"
-	rom ( name alphaone.zip size 53881 crc 3827642b md5 333f4d8063d134664e2b327aa40776c4 sha1 8f205ee2d70432b2c3932a7fb07eee0b3fa23449 )
-)
-
-game (
-	name "Alpha One (prototype, 5 lives)"
-	year "1983"
-	developer "Atari"
-	rom ( name alphaonea.zip size 53880 crc 82f61f1e md5 365e9b9d809fb35f218cae6049082e82 sha1 115344ad232d9089026418f771b44b9084ad5753 )
-)
-
-game (
 	name "The Alphax Z (Japan)"
 	year "1986"
 	developer "Ed Co. Ltd. (Wood Place Inc. license)"
 	rom ( name alphaxz.zip size 70044 crc bcf6b5f0 md5 aec73aadb67539282ef459904afb5a58 sha1 f810bfab36ad5867d961e190f4e159a9cd117ad1 )
-)
-
-game (
-	name "Airline Pilots (Rev A)"
-	year "1999"
-	developer "Sega"
-	rom ( name alpilota.zip size 42573934 crc e609885f md5 b49bb81d6ffdab60c4746944b898aa39 sha1 a7afa13ca0b3c2ad779f111deb2cf5eaf8df8c22 )
-)
-
-game (
-	name "Airline Pilots Deluxe (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name alpiltdx.zip size 42574169 crc 6e85c373 md5 0c0386125a39262de9bc6441462f9599 sha1 36b53082f4d315c8f0a4f6afd60269a824fcb474 )
 )
 
 game (
@@ -1572,13 +1142,6 @@ game (
 )
 
 game (
-	name "Alpine Racer 2 (Rev. ARS2 Ver.A)"
-	year "1996"
-	developer "Namco"
-	rom ( name alpinr2a.zip size 18081014 crc 7310913e md5 c91c8929dd9369ea22630ffdee4c5d99 sha1 8e20ee4f7de1e00be4c3be03286f8de21bc2d6bc )
-)
-
-game (
 	name "Alpine Racer 2 (Rev. ARS2 Ver.B)"
 	year "1996"
 	developer "Namco"
@@ -1590,13 +1153,6 @@ game (
 	year "1981"
 	developer "Cidelsa"
 	rom ( name altair.zip size 9758 crc 88e8c78f md5 969a24aff748af9049223096032cc7e0 sha1 c0ba33ad1af34707ed6ba863e3d5e4ac0471148c )
-)
-
-game (
-	name "Altered Beast (set 8, 8751 317-0078)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeast.zip size 848905 crc e431711b md5 64ae9698dd3816c123e464ef1df3f446 sha1 5d1431b186c2fe481bc7c2a84f565405e1ed1c9a )
 )
 
 game (
@@ -1614,59 +1170,10 @@ game (
 )
 
 game (
-	name "Altered Beast (set 6, 8751 317-0076)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeast5.zip size 848579 crc fac03d47 md5 a9b86a51947d53ce548235d588aa426f sha1 7b47092d0d1a4d0f23abdbb71d98c0938f79b1b7 )
-)
-
-game (
-	name "Juuouki (set 7, Japan, 8751 317-0077)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj.zip size 848385 crc 38d7e51f md5 1174a10ab5c833cc34f19ebbb1e32efd sha1 e1f0037c53ace5fcde9cf9b4b6b0019a479265e6 )
-)
-
-game (
-	name "Juuouki (set 1, Japan, FD1094 317-0065)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj1.zip size 882507 crc b2c03cbf md5 3a26893081ff107d01d4d601469fd161 sha1 9fc8cc2b7f8147169367cee30b0741c03f54522e )
-)
-
-game (
-	name "Juuouki (set 5, Japan, FD1094 317-0069)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj2.zip size 881251 crc ce64377f md5 203fc47d233cd5c8129537b671330fab sha1 e38cb8e7f50bae4eb68cb53f036ce7ecf709720e )
-)
-
-game (
 	name "Juuouki (set 3, Japan, FD1094 317-0068)"
 	year "1988"
 	developer "Sega"
 	rom ( name altbeastj3.zip size 888865 crc dfe33685 md5 6895d8311f0f0fa48fc53ff6ded47ebe sha1 af121840538d9eae24ab47bdc01376d626918aa2 )
-)
-
-game (
-	name "Multi Game I (V.Ger 2.4)"
-	year "2000"
-	developer "Amatic Trading GmbH"
-	rom ( name am_mg24.zip size 606363 crc e907f644 md5 1c44b9378af3ac34936bcc59e79b6554 sha1 af7c0ccac63bb51845ca13fa652df3ecf8e008eb )
-)
-
-game (
-	name "Multi Game III (V.Ger 3.5)"
-	year "2000"
-	developer "Amatic Trading GmbH"
-	rom ( name am_mg3.zip size 626214 crc 501c6844 md5 854e18a545d7dd0f3866040aabd69b3d sha1 9ef1d9d2995c93663020a136e8cc4342c675c001 )
-)
-
-game (
-	name "Amatic Unknown Slots Game"
-	year "1996"
-	developer "Amatic Trading GmbH"
-	rom ( name am_uslot.zip size 67278 crc 433189d5 md5 f1a7ffc98f48ce702c542b20903d7d61 sha1 e2a96462f91ba83b947d315765dff5b0be326981 )
 )
 
 game (
@@ -1702,12 +1209,6 @@ game (
 	year "1983"
 	developer "Tecfri (Volt Electronics license)"
 	rom ( name ambushv.zip size 30212 crc ee868cb2 md5 fc3a461de21a07387a473d25ee487236 sha1 6f5fd34f3257040e287adb25ea176e2b8d884068 )
-)
-
-game (
-	name "Amcoe Link Control Box (Version 2.2)"
-	developer "Amcoe"
-	rom ( name amclink.zip size 59340 crc 14d4a266 md5 fcb965547eff756cbbe69022b9d771c9 sha1 405eebe64f2ac8afecbe6a03858e5b1e341b630f )
 )
 
 game (
@@ -1854,14 +1355,7 @@ game (
 	name "Andro Dunos"
 	year "1992"
 	developer "Visco"
-	rom ( name androdun.zip size 1797572 crc f405b11b md5 2daddc07f4ae6d73d90f38b8e58621d3 sha1 58a7c1ca9297cc9025bd858125ea3e9ee88e6a0f )
-)
-
-game (
-	name "Andromeda (Japan?)"
-	year "1979"
-	developer "IPM"
-	rom ( name andromed.zip size 7933 crc 7b192acc md5 8dde2f27d822dbda1e86e19a365794d5 sha1 88e4fe7323b37647d30e249e2458532675fb5e92 )
+	rom ( name androdun.zip size 3144259 crc e31583f1 md5 bc6428eb47da6d207b8014b33f934546 sha1 9812aededb486ebeefbea647abb7aa7471eeee06 )
 )
 
 game (
@@ -1977,13 +1471,6 @@ game (
 )
 
 game (
-	name "Animalandia Jr. (Spanish)"
-	year "1993"
-	developer "Nakanihon / East Technology (Taito license)"
-	rom ( name animaljrs.zip size 1355937 crc ab7efa53 md5 25fce01079d3c6fa801e9ec62002b597 sha1 0b6b8a77b78537b033564ba3c1a34af5ce45f1db )
-)
-
-game (
 	name "Animal Treasure Hunt (Version 1.9R, set 1)"
 	year "2003"
 	developer "Amcoe"
@@ -2043,42 +1530,42 @@ game (
 	name "Aggressors of Dark Kombat / Tsuukai GANGAN Koushinkyoku"
 	year "1994"
 	developer "ADK / SNK"
-	rom ( name aodk.zip size 10054195 crc 8401f172 md5 1438bd3c2a374e23a4d3835bef3601cc sha1 832ceac3c461932866155a8545d11689d0320811 )
+	rom ( name aodk.zip size 11400882 crc 8a6c5ece md5 f08c386534d939578ec4146c552a17f7 sha1 39a5937cb1f5e4e11eceb6582cf5dfa715801371 )
 )
 
 game (
 	name "Art of Fighting / Ryuuko no Ken"
 	year "1992"
 	developer "SNK"
-	rom ( name aof.zip size 6610200 crc 79b1cfb8 md5 bd44a72ea9f73ea788eae52de053df0e sha1 1a168bf18daa79fac7e6b4deb5feae7f572d0541 )
+	rom ( name aof.zip size 7956887 crc 09b4b678 md5 feb8218414b42773d78543888e9ae1c8 sha1 5b756f61e42b4e9a91f8b1b59068491f68600a17 )
 )
 
 game (
 	name "Art of Fighting 2 / Ryuuko no Ken 2 (set 1)"
 	year "1994"
 	developer "SNK"
-	rom ( name aof2.zip size 12319800 crc 78105c6a md5 9a5b10488807a2d9e86a1c8208c70bce sha1 565d1e93eca327984b809ed8e5bab7c495c4ae50 )
+	rom ( name aof2.zip size 13666487 crc 03e73995 md5 05e1b020913d161a21c89cb006d22450 sha1 2f11587f7316caaabda0ac0b8f545abb107fe558 )
 )
 
 game (
 	name "Art of Fighting 2 / Ryuuko no Ken 2 (set 2)"
 	year "1994"
 	developer "SNK"
-	rom ( name aof2a.zip size 12551235 crc 96c4c1c6 md5 c3ae6ab5dee1087877fab2288e1f2944 sha1 eafa3fcee0efaca76f5e47b759587446bf608392 )
+	rom ( name aof2a.zip size 13897922 crc 0ccfb7a5 md5 ec012763ff2a0b443259de3851cf7713 sha1 b59090127925753d7e6992b5f9a89ce161107e91 )
 )
 
 game (
 	name "Art of Fighting 3 - The Path of the Warrior / Art of Fighting - Ryuuko no Ken Gaiden"
 	year "1996"
 	developer "SNK"
-	rom ( name aof3.zip size 17087186 crc 7a3d2778 md5 04f619d4a672aeda8817e36d262f58f1 sha1 8458ca66ac55f1f14394f07802d005388296d7c2 )
+	rom ( name aof3.zip size 18433873 crc b6473531 md5 397bbf0ebd1d10269ecf74f50e42825a sha1 1940a7f9a04470259764f89445e8439d198d59c2 )
 )
 
 game (
 	name "Art of Fighting 3 - The Path of the Warrior (Korean release)"
 	year "1996"
 	developer "SNK"
-	rom ( name aof3k.zip size 17086996 crc e1a51013 md5 3370254e229507b4cb2438772ce325d7 sha1 c35be73bf9c72b219a51e740c8c0e2fdcc58c8f5 )
+	rom ( name aof3k.zip size 18433683 crc 8ed38274 md5 015598af185d3354b9b7c615b2e1e009 sha1 3af56d74d0f38d7f91cd6645d17f1ef8337915ca )
 )
 
 game (
@@ -2166,12 +1653,6 @@ game (
 )
 
 game (
-	name "Platoon V.?.? US"
-	developer "Nova?"
-	rom ( name aplatoon.zip size 131361 crc a3a933ac md5 beb4ea5a5454e09639b2c5e5c71e4766 sha1 903982d84001dbd1c6d6999ddec412d3bbaba921 )
-)
-
-game (
 	name "Apocaljpse Now"
 	year "1982"
 	developer "bootleg"
@@ -2188,7 +1669,7 @@ game (
 game (
 	name "Apple 10 (Ver 1.21)"
 	year "1998"
-	developer "Sandii&apos;"
+	developer "Sandii'"
 	rom ( name apple10.zip size 144770 crc bb8f8b1c md5 3a628b009003222af70ad3b3d70a9290 sha1 bf8aced9d241cba0631b442060f1b19d8e189472 )
 )
 
@@ -2238,119 +1719,105 @@ game (
 	name "SportTime Table Hockey (Arcadia, set 1, V 2.1)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_airh.zip size 52141 crc 8ca86b2a md5 9186b7b61ee2a13900f1e284a4e89517 sha1 a485708478c680533206f979f7829b0803bfd4eb )
+	rom ( name ar_airh.zip size 433197 crc e80f8cea md5 b3714bb1442c16ee03533d8019a5e39a sha1 7e1b95dbebcda85aebb2a6c9d4ee9c093ba67b38 )
 )
 
 game (
 	name "SportTime Table Hockey (Arcadia, set 2)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_airh2.zip size 66984 crc 3f45a6bf md5 357ee361de15c1410189b8ad1c4106d0 sha1 313891a422bd35eb0d4fa3b77cb3e49f135a79b7 )
+	rom ( name ar_airh2.zip size 448040 crc 13073106 md5 c1f2fdb276c9d640a4a8722abb369fe9 sha1 caec10cb31981387e3952881ca6130c9b0de1fc2 )
 )
 
 game (
 	name "SportTime Bowling (Arcadia, V 2.1)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_bowl.zip size 118738 crc 79f63697 md5 a210e391d7b75fa6d4adb3bcb4d0749b sha1 ac23499249afdd534fb951fb62235965c46536d2 )
+	rom ( name ar_bowl.zip size 499794 crc a32695aa md5 c3ea79a5239360b969ff1a4f6fc81b6d sha1 32a95dd91ffea2ca502edf01ca94ff5c82b3353c )
 )
 
 game (
 	name "World Darts (Arcadia, set 1, V 2.1)"
 	year "1987"
 	developer "Arcadia Systems"
-	rom ( name ar_dart.zip size 326135 crc 8cbc717c md5 6df354d34bb00d6794ec8a5b092ccaf7 sha1 0031cfb122f07695c3ab395882d60274208cc218 )
-)
-
-game (
-	name "World Darts (Arcadia, set 2)"
-	year "1987"
-	developer "Arcadia Systems"
-	rom ( name ar_dart2.zip size 323979 crc 563706a3 md5 b5a74950786a0241d732a648889ea6f7 sha1 71040950ff16eefd3c056c41f8425cb8e39da25a )
-)
-
-game (
-	name "Magic Johnson's Fast Break (Arcadia, V 2.8)"
-	year "1988"
-	developer "Arcadia Systems"
-	rom ( name ar_fast.zip size 485048 crc 196c2e53 md5 259252446be16ccb76785cef691d4a7f sha1 527927ba7d8089a555566b7f452e30aa60cdaf3a )
+	rom ( name ar_dart.zip size 707191 crc 69834548 md5 80702e0215bf3d2fa9c7cc44a956097e sha1 d789fe187ee87df409980915f4f1cdf430403d81 )
 )
 
 game (
 	name "Leader Board (Arcadia, V 2.4?)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_ldrb.zip size 334357 crc 774c24f8 md5 9a8570a9baa9319eda55e49734271fc6 sha1 e04cf6c7f64eef02e79c128063b248f663c24e45 )
+	rom ( name ar_ldrb.zip size 715413 crc a7a9bdbf md5 484950f0cdb167255c10d93d17b54200 sha1 0e7f718afe745c00a450ffdb34c9352589fe2fad )
 )
 
 game (
 	name "Leader Board (Arcadia, V 2.5)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_ldrba.zip size 334457 crc 1c565fc8 md5 45a6facc78e22ea7c029661da3c84723 sha1 d1ed50de77deac4e9a912913e42a113b3d770a1d )
+	rom ( name ar_ldrba.zip size 715513 crc 82cfa3f2 md5 6c60e3e4453754d878040c7d94700e89 sha1 66fa4e09b0e5fca6f7eab7dd75a2d8d6893e562c )
 )
 
 game (
 	name "Ninja Mission (Arcadia, set 1, V 2.5)"
 	year "1987"
 	developer "Arcadia Systems"
-	rom ( name ar_ninj.zip size 399890 crc 5247193b md5 d7d58eb63ba5ef4fa531ed4158eff9d0 sha1 58c0266b8b14b6d2a7027c2c16120659d473eb95 )
+	rom ( name ar_ninj.zip size 780946 crc 19efd5e5 md5 a6b0cc71a663c0941e4b19c0a5fd4cae sha1 379f7f8785ff0ff5fb60e24e5ebc012d5845db42 )
 )
 
 game (
 	name "Ninja Mission (Arcadia, set 2)"
 	year "1987"
 	developer "Arcadia Systems"
-	rom ( name ar_ninj2.zip size 400008 crc 70d15f89 md5 4b4a09a8752284f37a9126e310724f6b sha1 5dc7fa2ee7c1f36f60a23b6852e9ad7345452d38 )
+	rom ( name ar_ninj2.zip size 781064 crc e1cb9e13 md5 3103abc28cd9403dbe7ab73c8a243541 sha1 56cc2eeb393ef64ceb59a28365df9ecd63793738 )
 )
 
 game (
 	name "RoadWars (Arcadia, V 2.3)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_rdwr.zip size 233074 crc d17da113 md5 4dc3629f0308eb4043fab1d436384683 sha1 4ffede0b76b52893ae4537036ad7e2bcfce65700 )
+	rom ( name ar_rdwr.zip size 614130 crc 5dd321e1 md5 8c714666e90ac39fc96877a51d6facf3 sha1 a305a7bc7a2a826bc2413be9a35bc2d4bffecc0a )
 )
 
 game (
 	name "Sidewinder (Arcadia, set 1, V 2.1)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_sdwr.zip size 354146 crc 756f35ea md5 d8a719d0350dd4623670e2bc22e8d134 sha1 5107486c4dcaf8946e24b50f9908f3d569652189 )
+	rom ( name ar_sdwr.zip size 735202 crc 81058901 md5 395519da19641db213c07372d992c2ed sha1 3e31e591003fbec18848501235564a980999dfd9 )
 )
 
 game (
 	name "Sidewinder (Arcadia, set 2)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_sdwr2.zip size 354233 crc c2d72276 md5 f2df5883ad464f07e0dd8f4a624a8ca9 sha1 048deb320a7201924a1bde51085366deb6cda45a )
+	rom ( name ar_sdwr2.zip size 735289 crc 82d1d41c md5 85f3ad9a0f0338cacec854e5490e589f sha1 2871630793047b26406d36240fa124bb7fa800ee )
 )
 
 game (
 	name "World Trophy Soccer (Arcadia, V 3.0)"
 	year "1989"
 	developer "Arcadia Systems"
-	rom ( name ar_socc.zip size 370059 crc 8131f682 md5 4f639677b31efdce456eb222002a6d0a sha1 d390d2734a265275dac2b2c1edcc77a5890c9fc5 )
+	rom ( name ar_socc.zip size 751115 crc 1d9c7dd9 md5 5e2035e64d21616aa59c6511d0f1eb13 sha1 72a40b008edb2f191b6452dd4a1e86e955c49869 )
 )
 
 game (
 	name "Spot (Arcadia)"
 	year "1990"
 	developer "Arcadia Systems"
-	rom ( name ar_spot.zip size 451301 crc 702f814e md5 03fa639866171c476ae871537091dad5 sha1 e6048a1b3243d16dede08a9e18fe0aa95bc87cfa )
+	rom ( name ar_spot.zip size 832357 crc 6cbdbac9 md5 996094b2fc63ba55c8a9a69573fc670e sha1 0d7bc184b89992cfcb9f1e904c3e4dfa699d07c3 )
 )
 
 game (
 	name "Space Ranger (Arcadia, V 2.0)"
 	year "1987"
 	developer "Arcadia Systems"
-	rom ( name ar_sprg.zip size 251388 crc e52a4a03 md5 5b81d7bbc02c5c9e8b222c973bf0ee67 sha1 450ab57fb8dd12fd4b81786aba603b4bcbce5bd1 )
+	rom ( name ar_sprg.zip size 632444 crc bc4d294f md5 d704e20db5e475a5a9c167a94b45d40b sha1 4da7fd096b0660bb0a725abe046be2a01bba4427 )
 )
 
 game (
 	name "Xenon (Arcadia, V 2.3)"
 	year "1988"
 	developer "Arcadia Systems"
-	rom ( name ar_xeon.zip size 263885 crc 7d10d683 md5 a9f4810af017770f548fec47a50b74cb sha1 585fe05d7847aa15853493f671f4ce3e9ad13f25 )
+	rom ( name ar_xeon.zip size 644941 crc e42d761f md5 16d6835bff19f0f75ae64c5942669643 sha1 4c46b1362d7b6f5fb24867524d3bce96ca75acaf )
 )
 
 game (
@@ -2437,20 +1904,6 @@ game (
 )
 
 game (
-	name "Arch Rivals (rev 4.0)"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name archrivl.zip size 360208 crc d8667efb md5 9152563491b6a5244b57c291b63cbd2c sha1 680e6b296fcc288dc90aa11ae571d6566fc73c80 )
-)
-
-game (
-	name "Arch Rivals (rev 2.0)"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name archrivl2.zip size 360062 crc 1b65c9f8 md5 5588e3ddeaac8e8e930f087c424aa7c2 sha1 ee6f0187d5a3274233fc1bcf05414bf8d448bcc2 )
-)
-
-game (
 	name "Area 51 (R3000)"
 	year "1996"
 	developer "Atari Games"
@@ -2514,13 +1967,6 @@ game (
 )
 
 game (
-	name "Arkanoid (bootleg with MCU, harder)"
-	year "1986"
-	developer "bootleg"
-	rom ( name ark1ball.zip size 69354 crc f432b025 md5 d9071aa347a71c080535068f5b871d60 sha1 c8f5ae6b090c8db27b6ac43f9ac63ee11a591ffd )
-)
-
-game (
 	name "Arkanoid (Game Corporation bootleg, set 1)"
 	year "1986"
 	developer "bootleg (Game Corporation)"
@@ -2542,20 +1988,6 @@ game (
 )
 
 game (
-	name "Arkanoid (Japan)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name arkanoidj.zip size 69529 crc 952d9c11 md5 68ab9e027e64e8adddd2acfd253350d2 sha1 116f876f59cb5f61e37a33323bcbfead79d69557 )
-)
-
-game (
-	name "Arkanoid (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arkanoidu.zip size 69426 crc 9529993e md5 70373c8aa3402ecd8a6cb10f9fb3cbf8 sha1 352094d1d88f7def9849089f40018c81917fcf78 )
-)
-
-game (
 	name "Arkanoid (US, older)"
 	year "1986"
 	developer "Taito America Corporation (Romstar license)"
@@ -2574,13 +2006,6 @@ game (
 	year "1986"
 	developer "bootleg (Tayto)"
 	rom ( name arkatayt.zip size 68793 crc 3e625c8d md5 a170ca2801532b1633546efb95c13bea sha1 d04529015c1569db7e3d2d276db6901dbfa672ec )
-)
-
-game (
-	name "Tournament Arkanoid (US)"
-	year "1987"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arkatour.zip size 68720 crc ae0fb022 md5 d31e4e5c2d9539d2e016837a24e87c07 sha1 01313a342b3aac403e2fbc357243ee6d7048e3f8 )
 )
 
 game (
@@ -2616,34 +2041,6 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name arkgcbla.zip size 69288 crc 63a8089a md5 2b49b44e80cdd6dc7bf9a7646bf36813 sha1 5743451abb588e938eaf6b31492231a3a6de9d6c )
-)
-
-game (
-	name "Arkanoid (bootleg with MCU)"
-	year "1986"
-	developer "bootleg"
-	rom ( name arkmcubl.zip size 70179 crc 997685eb md5 54f09ab5ba737417b6cbda529cab088b sha1 5b678f1b75f4a099fbd534d1dab41fcfec16946f )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (World)"
-	year "1987"
-	developer "Taito Corporation Japan"
-	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name arknoid2j.zip size 165315 crc e73cbb79 md5 3370138aca19dac0bec247c7f945af9a sha1 0f770962bc298e25f5fb89d6adf4cc18757878cb )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (US)"
-	year "1987"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arknoid2u.zip size 165246 crc 83c4dcdc md5 110c4a9fe87fd15696640aa8859dfa2e sha1 51192a5aa0b50e7e760ce0ef5bfd77bb5c018171 )
 )
 
 game (
@@ -2955,13 +2352,6 @@ game (
 )
 
 game (
-	name "Alien Storm (bootleg, set 2)"
-	year "1990"
-	developer "bootleg"
-	rom ( name astormb2.zip size 2187068 crc 8eeb013d md5 39a1a92ba84492fb630d61e1ab3d4890 sha1 a5145c95f8e97245dbbb562dface9ff6bdde01bd )
-)
-
-game (
 	name "Alien Storm (bootleg, set 1)"
 	year "1990"
 	developer "bootleg"
@@ -2983,24 +2373,10 @@ game (
 )
 
 game (
-	name "Astra SuperStars (J 980514 V1.002)"
-	year "1998"
-	developer "Sunsoft"
-	rom ( name astrass.zip size 17183446 crc ccb36035 md5 1e8fd5e2cc3905c31a7add667cb181b0 sha1 3872eb964ff84c652e465222c9d93f00bb749b71 )
-)
-
-game (
 	name "Astro Blaster (version 3)"
 	year "1981"
 	developer "Sega"
 	rom ( name astrob.zip size 34688 crc aa435f8b md5 bbec3c2b9eea2b3e628e599b407ec087 sha1 95abe377dfa5d531928584ba58cd57fc811210f2 )
-)
-
-game (
-	name "Astro Blaster (version 1)"
-	year "1981"
-	developer "Sega"
-	rom ( name astrob1.zip size 31744 crc 4492ab13 md5 cbebf90c641ce08449fab98e188e4201 sha1 87ac2f0f087847ec63020f4dd195cbca212e1389 )
 )
 
 game (
@@ -3053,37 +2429,9 @@ game (
 )
 
 game (
-	name "Astron Belt"
-	year "1983"
-	developer "Sega"
-	rom ( name astron.zip size 62658 crc bdb608d9 md5 4a85f633afcbde8d25d83d8de3ce092f sha1 6d3f6f922c934cee5ca6a3e01e3fda41587b9b8a )
-)
-
-game (
-	name "Astron Belt (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name astronp.zip size 62485 crc 28ea7e2f md5 fe2f4597faca4ba80d481beb84c266a7 sha1 ef1a38f78a03ea38201d8bbcd8665e080f26b087 )
-)
-
-game (
 	name "Astropal"
 	developer "Sidam?"
 	rom ( name astropal.zip size 7000 crc af301370 md5 fc7e7ed8a3c16ef410ef693bb8b85904 sha1 b326e28cbadfb85b67c5ca55fed394594e75ffd4 )
-)
-
-game (
-	name "Astro Wars"
-	year "1980"
-	developer "Zaccaria"
-	rom ( name astrowar.zip size 11367 crc 1cdd3f69 md5 8de1a73da08220fea25b603244b28e08 sha1 f110a254fcfdd243e701842723e4c53812f5886f )
-)
-
-game (
-	name "The Astyanax"
-	year "1989"
-	developer "Jaleco"
-	rom ( name astyanax.zip size 1101266 crc bcf42d2b md5 2f3aad524d08d3e64c0a0993a227a423 sha1 bdcc2b5eee0be493445729a53bb749206aa55adb )
 )
 
 game (
@@ -3119,13 +2467,6 @@ game (
 	year "1991"
 	developer "Leland Corp."
 	rom ( name asylum.zip size 2396177 crc a0136f4d md5 2962b861c8ef9156f8f46633c8674bc4 sha1 28f11ac38e1cb1d12cad85aa5837a694f1a8ccc4 )
-)
-
-game (
-	name "Computer Quiz Atama no Taisou (Japan)"
-	year "1983"
-	developer "Yachiyo Denki / Uni Enterprize"
-	rom ( name atamanot.zip size 111986 crc adf7a04e md5 a994705a32c4c6da8fd1a063ba77e1e4 sha1 712b6cdd6c0a2f199ad371cbaea986b669f0651a )
 )
 
 game (
@@ -3332,52 +2673,10 @@ game (
 )
 
 game (
-	name "Automat (bootleg of Robocop)"
-	year "1988"
-	developer "bootleg"
-	rom ( name automat.zip size 385778 crc 09ae667c md5 e49d5f0cfc43eb90581d625cf82d7c47 sha1 9adfa22a709852f53100b56c0e9e90b37746ba68 )
-)
-
-game (
-	name "AV2Mahjong No.1 Bay Bridge no Seijo (Japan)"
-	year "1991"
-	developer "Miki Syouji / AV Japan"
-	rom ( name av2mj1bb.zip size 280169 crc f50b0395 md5 6f3515819019cab7a132226212f9ecec sha1 955c46125885387c5cfbe2f555c8d4a52a5d3977 )
-)
-
-game (
-	name "AV2Mahjong No.2 Rouge no Kaori (Japan)"
-	year "1991"
-	developer "Miki Syouji / AV Japan"
-	rom ( name av2mj2rg.zip size 357844 crc c28d815e md5 8c779e441107a304eb446db66ca41a63 sha1 1f06c34b43fa49a07d31fd8add8fedd7930955f4 )
-)
-
-game (
 	name "Avalanche"
 	year "1978"
 	developer "Atari"
 	rom ( name avalnche.zip size 5012 crc 70e24341 md5 2df7eff0a72abbf89c57dd4cbb7c2a32 sha1 60ee8d4019e43f733d36819ea40dc307c327daa5 )
-)
-
-game (
-	name "The Key Of Avalon 1.3 - Chaotic Sabbat - Client (GDT-0010C) (V4.000)"
-	year "2004"
-	developer "Sega"
-	rom ( name avalon13.zip size 213 crc f8875e42 md5 2a31941e25d8780971d76be81dd0432f sha1 4d2fbe71a0b75f2335ea3790b0a1c6697323530d )
-)
-
-game (
-	name "The Key Of Avalon 2.0 - Eutaxy and Commandment - Client (GDT-0017B) (V3.001)"
-	year "2004"
-	developer "Sega"
-	rom ( name avalon20.zip size 213 crc d35c5df2 md5 2d46157b2570e06be8f293348ed93d8b sha1 a78f9cb8f6fa8f2336dfca8590161643a04de708 )
-)
-
-game (
-	name "The Key Of Avalon - The Wizard Master - Server (GDT-0005C) (V4.001)"
-	year "2003"
-	developer "Sega"
-	rom ( name avalons.zip size 211 crc c20b3755 md5 bd3e160f8a78b9e19b02421eeb48aed3 sha1 e8d98a549d016844182f33d524074aae1009c4de )
 )
 
 game (
@@ -3437,13 +2736,6 @@ game (
 )
 
 game (
-	name "Avenging Spirit"
-	year "1991"
-	developer "Jaleco"
-	rom ( name avspirit.zip size 1060778 crc 6707417d md5 cf4e3c32cdd6158b51585915ede39195 sha1 3cef5b36308d25e6612d72f83d6badb8d971268c )
-)
-
-game (
 	name "Alien vs. Predator (Japan 940520)"
 	year "1994"
 	developer "Capcom"
@@ -3462,13 +2754,6 @@ game (
 	year "1983"
 	developer "Centuri"
 	rom ( name aztarac.zip size 32536 crc ad36a737 md5 69fd96aa9ec408b6b5e49ff31c531458 sha1 79b3761d3b0d068c8250d0ca95b5459f2486c378 )
-)
-
-game (
-	name "Azumanga Daioh Puzzle Bobble (GDL-0018)"
-	year "2002"
-	developer "Moss (Taito license)"
-	rom ( name azumanga.zip size 219 crc 3da26a27 md5 bc9e0b6bc943159678dc70163dd03d12 sha1 f8f3884128c5d0951eb52c5752351441ce199432 )
 )
 
 game (
@@ -3493,13 +2778,6 @@ game (
 )
 
 game (
-	name "Backfire! (set 1)"
-	year "1995"
-	developer "Data East Corporation"
-	rom ( name backfire.zip size 9859906 crc 28fdb800 md5 3d338c08570acd51771f87677c72da36 sha1 3162de077c9e5196b5878b14689e9216eb0825ee )
-)
-
-game (
 	name "Backfire! (set 2)"
 	year "1995"
 	developer "Data East Corporation"
@@ -3514,20 +2792,6 @@ game (
 )
 
 game (
-	name "Backgammon"
-	year "1990"
-	developer "ADP"
-	rom ( name backgamn.zip size 39995 crc e352e16d md5 ff271b6250c73602b25ae120f521c4ab sha1 34cdfb5e9e0bc8aff3f1d9795a3f00639be55327 )
-)
-
-game (
-	name "Bad Dudes vs. Dragonninja (US)"
-	year "1988"
-	developer "Data East USA"
-	rom ( name baddudes.zip size 454673 crc 823dddde md5 9f61003dd6e361e91df4312a54187f74 sha1 5f5b1c66cb9998d369a15cd56b98f096ac8e21c2 )
-)
-
-game (
 	name "Bad Lands"
 	year "1989"
 	developer "Atari Games"
@@ -3535,31 +2799,10 @@ game (
 )
 
 game (
-	name "Bad Lands (bootleg)"
-	year "1989"
-	developer "bootleg (Playmark)"
-	rom ( name badlandsb.zip size 429336 crc 11713c52 md5 a7d10acd989478c14f7e256040f031b4 sha1 9e8c2c5348ebdf72175dd8447916bfdcf758927d )
-)
-
-game (
 	name "Bagman"
 	year "1982"
 	developer "Valadon Automation"
 	rom ( name bagman.zip size 23250 crc b2334187 md5 2450cea77840cd1a30b60de6a99a86e9 sha1 543ee9cd463fc9d63b643cba8ba842f323ea7e4a )
-)
-
-game (
-	name "Bagman (bootleg on Crazy Kong hardware)"
-	year "1981"
-	developer "bootleg"
-	rom ( name bagmanf.zip size 23586 crc 5edd6e68 md5 2530b7b6d08332d6bcbe96f64b0dc72f sha1 e422c14e60f50066e2a28758ee91cc212dee8c9e )
-)
-
-game (
-	name "Bagman (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name bagmanmc.zip size 21737 crc 4d143fe6 md5 ed839d556dd74d6491553813c6f042c5 sha1 b2f46e780ed18e9d4fc2837014075ed2fb76dfa0 )
 )
 
 game (
@@ -3594,14 +2837,7 @@ game (
 	name "Bakatonosama Mahjong Manyuuki"
 	year "1991"
 	developer "Monolith Corp."
-	rom ( name bakatono.zip size 2515537 crc b6e7a7ad md5 36698501c3f5d5751a1f7b261e6abad1 sha1 20dedee7c6cfdcc298311f11e9b14b2d3f5a828a )
-)
-
-game (
-	name "Baku Baku Animal (J 950407 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name bakubaku.zip size 5936271 crc 4d49e6f3 md5 de0359dd8eccee2dcf1f94851291bfda sha1 17b2df9858084e52c5efff899d02c19ffa2b1410 )
+	rom ( name bakatono.zip size 3862224 crc ce765b2c md5 1a2b15c47ccb779bd6db9ddadbe44883 sha1 b61bde1feba0fa4ec1056b3c2d9b1b27a9745780 )
 )
 
 game (
@@ -3633,13 +2869,6 @@ game (
 )
 
 game (
-	name "Balloon Bomber"
-	year "1980"
-	developer "Taito"
-	rom ( name ballbomb.zip size 6936 crc d8c9cbc6 md5 bd95aa39956fa02fdd5ecbd68f0437c2 sha1 46daff2917dbbb69b5081e904d182727fb4c83f0 )
-)
-
-game (
 	name "Balloon Brothers"
 	year "1992"
 	developer "East Technology"
@@ -3654,17 +2883,10 @@ game (
 )
 
 game (
-	name "Baluba-louk no Densetsu"
+	name "Baluba-louk no Densetsu (Japan)"
 	year "1986"
 	developer "Able Corp, Ltd."
 	rom ( name baluba.zip size 68148 crc 640d45af md5 c84daa05bf3bcd5faa3fac247068c7b0 sha1 de9bfd1291768f84ebf3f7fdaecb345a615882fe )
-)
-
-game (
-	name "Bust a Move 2 (Japanese ROM ver. 1999/07/17 10:00:00)"
-	year "1999"
-	developer "Metro / Enix / Namco"
-	rom ( name bam2.zip size 27357381 crc 0c24b882 md5 648be02a41d3bcd46210f001a5f51707 sha1 b9ede3c86829e3ee11f10fe048744fbd87d7cce0 )
 )
 
 game (
@@ -3672,13 +2894,6 @@ game (
 	year "1989"
 	developer "Digital Soft"
 	rom ( name bananadr.zip size 434150 crc d39f1488 md5 e2a838c811c721bfb134419619f64685 sha1 a6202201175275bf1157bb76481d632374d97a26 )
-)
-
-game (
-	name "BanBam"
-	year "1984"
-	developer "Sun Electronics"
-	rom ( name banbam.zip size 46036 crc a97f678a md5 d866593f9cc1ac2027b22877a3699b02 sha1 8af4251b677ab70309a7d9e3126a0c2980a69eb5 )
 )
 
 game (
@@ -3706,7 +2921,7 @@ game (
 	name "Bang Bead"
 	year "2000"
 	developer "Visco"
-	rom ( name bangbead.zip size 20562178 crc 44bedddb md5 e2207c6aab1abb9d9f42d7f5dfcc672d sha1 9b40c53401d069cc6bacd887ecd42b012c5f594f )
+	rom ( name bangbead.zip size 21908865 crc a1359131 md5 3516152a7a366dac8a551766339cc288 sha1 0542efba4ffdad258e2283ffbe4c2f044eb13b21 )
 )
 
 game (
@@ -3714,13 +2929,6 @@ game (
 	year "1998"
 	developer "Gaelco"
 	rom ( name bangj.zip size 2494627 crc f75b3e6c md5 2e6ed8fdd2249576b1488c1ad9906e0f sha1 ca8b8ea2bbd40f8e91d2ff28957f5c62e3f5dd96 )
-)
-
-game (
-	name "Bank Panic"
-	year "1984"
-	developer "Sanritsu / Sega"
-	rom ( name bankp.zip size 68081 crc c891b681 md5 b95e5c2016bf570c4438f9d742cce44e sha1 5cade8bfbac308caca5b4844dce525be5a134cb2 )
 )
 
 game (
@@ -3755,27 +2963,6 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name basebal2.zip size 132687 crc afab8769 md5 d938e769b6db97e280062b0d7e5d5d32 sha1 f2776d7d8717f6a760a9602d9a670ffb0c53d100 )
-)
-
-game (
-	name "Sega Bass Fishing"
-	year "1997"
-	developer "Sega"
-	rom ( name bass.zip size 43709726 crc 505c2bac md5 0a61a5f56742043a3c70de5c580f8e14 sha1 2a98b655c8e0b08a5b48abebae6ea99b2f2ea8dc )
-)
-
-game (
-	name "Bass Angler 2 (GE865 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name bassang2.zip size 182 crc 58103c23 md5 152227827baf38c778d50cff8dacdb75 sha1 3f1dffa8ffebb13844422b8d5c0f5d94f44880b3 )
-)
-
-game (
-	name "Bass Angler (GE765 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name bassangl.zip size 182 crc 786221d4 md5 481d0a427167a7175a00b6c5ef57bfa2 sha1 eb7902169ce094a0234cf165ca0f65d242d22525 )
 )
 
 game (
@@ -3835,20 +3022,6 @@ game (
 )
 
 game (
-	name "Battle Gear"
-	year "1999"
-	developer "Taito"
-	rom ( name batlgear.zip size 26289 crc 2734b16d md5 778fc5f630276d7324379e4db00c30a1 sha1 cdb2e1241be258eae829e8d6fd402dae47f8e78e )
-)
-
-game (
-	name "Battle Gear 2"
-	year "2000"
-	developer "Taito"
-	rom ( name batlgr2.zip size 26488 crc c97da0ce md5 2f0fac897e68892b40122506a13110a4 sha1 1fa012f02812eb1ee7a789552b51e26179578bea )
-)
-
-game (
 	name "Batman"
 	year "1991"
 	developer "Atari Games"
@@ -3860,13 +3033,6 @@ game (
 	year "1981"
 	developer "bootleg"
 	rom ( name batman2.zip size 16185 crc 1e53a1d4 md5 1796144ac5f4c9a7864d175cc6f87157 sha1 0bda3fd598ee4064d8f97012b069db8115ab8cf1 )
-)
-
-game (
-	name "Batman Forever (JUE 960507 V1.000)"
-	year "1996"
-	developer "Acclaim"
-	rom ( name batmanfr.zip size 24447417 crc 3f6dcfd3 md5 947d220e7d847e02dc6e9f16729cd80f sha1 3527513bb7385f1c81d075ec9a6278ed4f980804 )
 )
 
 game (
@@ -3916,27 +3082,6 @@ game (
 	year "1998"
 	developer "Raizing / Eighting"
 	rom ( name batridu.zip size 8265947 crc aa09511c md5 c3843c9a22d9d6c77e87ea6fc9ecc0ab sha1 8095ba6ff208a0bd6e1978adfbb7f64eece631c2 )
-)
-
-game (
-	name "Batsugun (set 1)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsugun.zip size 2409345 crc 22069212 md5 9b10f2234e03680ce7d211c1fb928d42 sha1 6b9e9624cc6d9d9f80039d0a4a34534016f67799 )
-)
-
-game (
-	name "Batsugun (set 2)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsuguna.zip size 2409803 crc 948adcd4 md5 2d72658936443f1d554040b4e510b447 sha1 e5c3ac8b1508fb14c0a367eb826394e8e5e3bb9c )
-)
-
-game (
-	name "Batsugun (Special Ver.)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsugunsp.zip size 2411034 crc 7ae306a5 md5 6fe0853fadd4fa0d14407d74e2a2ff5a sha1 65a95d3e20e702a091c895e96e6c0ad3ea6a60a4 )
 )
 
 game (
@@ -4017,52 +3162,10 @@ game (
 )
 
 game (
-	name "Bay Route (set 1, US, unprotected)"
-	year "1989"
-	developer "Sunsoft / Sega"
-	rom ( name bayroute1.zip size 431287 crc a7efe0f8 md5 508c1d8c8e904b7975a35353a01272e7 sha1 927eb31797c2b5545b905b0a5ab699e661ba65f1 )
-)
-
-game (
-	name "Bay Route (encrypted, protected bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name bayrouteb1.zip size 695068 crc d9892374 md5 5c2ea40474201d6caf3e9bea26cce05d sha1 db68375421ca03b20df6c2ecb5ef2544cf190641 )
-)
-
-game (
-	name "Bay Route (Datsu bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name bayrouteb2.zip size 533843 crc 3956d805 md5 b3f1acb8e460cb2582ec09e5c3f9cb8a sha1 3ce905a2c0a24135b0dbfdde44843ff41e01ed46 )
-)
-
-game (
 	name "Bay Route (set 2, Japan, FD1094 317-0115)"
 	year "1989"
 	developer "Sunsoft / Sega"
 	rom ( name bayroutej.zip size 705201 crc 8eafd6cf md5 d38ac2f6deda9048d1296fc460bec0d5 sha1 c0e52a2e9085bda565cd8860687e38af4dd9045f )
-)
-
-game (
-	name "Balloon _ Balloon"
-	year "2003"
-	developer "Eolith"
-	rom ( name bballoon.zip size 3881400 crc a67596bf md5 9769218a3f5ac3813b1d72fc6244eb39 sha1 96bb79f908ae6d737193e05fd223130bd3f07b37 )
-)
-
-game (
-	name "Bouncing Balls"
-	year "1991"
-	developer "Comad"
-	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
-)
-
-game (
-	name "Best Bout Boxing"
-	year "1994"
-	developer "Jaleco"
-	rom ( name bbbxing.zip size 10429515 crc 9b47d8ac md5 96986e1972839f0821aadd48b87dc13e sha1 53470be999ffa957d32e44d999dff936d8beb436 )
 )
 
 game (
@@ -4087,23 +3190,10 @@ game (
 )
 
 game (
-	name "unknown fighting game 'BB' (prototype)"
-	developer "&lt;unknown&gt;"
-	rom ( name bbprot.zip size 2485034 crc 39c604b7 md5 309a492e84cecc54675755d63ed4e33b sha1 6eeacb0b9a5c23fce8ad83f7510452a13acabc8a )
-)
-
-game (
 	name "Buster Bros. (US)"
 	year "1989"
 	developer "Mitchell (Capcom license)"
 	rom ( name bbros.zip size 421481 crc 7c98aba3 md5 bc50ac296665cbf5b7a65cee951d3f7f sha1 92f841e6cee96584ba563f2f875d5ce1758c7b3a )
-)
-
-game (
-	name "Beast Busters 2nd Nightmare"
-	year "1998"
-	developer "SNK"
-	rom ( name bbust2.zip size 21055444 crc ba9bee97 md5 36eb573856c6fffb403f8b4e9837c7b8 sha1 60e7760ea8922c3f3ef805aa42c8a93ff18975bf )
 )
 
 game (
@@ -4121,13 +3211,6 @@ game (
 )
 
 game (
-	name "Battle Chopper"
-	year "1987"
-	developer "Irem"
-	rom ( name bchopper.zip size 625484 crc bb2ba4e2 md5 b1c23702556a56b13ea7120566b6691e sha1 d640f7466fd4409a89b81c19bf7c1cf0446ca71b )
-)
-
-game (
 	name "Bone Crusher"
 	year "1985"
 	developer "bootleg"
@@ -4142,48 +3225,6 @@ game (
 )
 
 game (
-	name "B.C. Story (set 1)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name bcstry.zip size 1867429 crc 2790dc04 md5 af6c843f42e06c5a5ff56952afaba6ce sha1 b099fe0618c298d712f4e955e004602ee5849c19 )
-)
-
-game (
-	name "B.C. Story (set 2)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name bcstrya.zip size 1867473 crc 5e2b182f md5 6aeb49666e15739e5c72fcb0d0e31821 sha1 2685955e416af1a85f644983181a169dcbae74eb )
-)
-
-game (
-	name "Border Down (Rev A) (GDL-0023A)"
-	year "2004"
-	developer "G-Rev"
-	rom ( name bdrdown.zip size 1196 crc 9e7b60f5 md5 93142b1dbd4ca6c83b79f832ea0bda11 sha1 578f3f11be969702c1cb246cd2b75cd033bd3c98 )
-)
-
-game (
-	name "Beach Spikers (GDS-0014)"
-	year "2002"
-	developer "Sega"
-	rom ( name beachspi.zip size 1194 crc 9d5c8b2c md5 c114cc2701d7551bc3c1b9f1e3c8cbe3 sha1 1ad864c5ce47e05502094659c37df52380f32910 )
-)
-
-game (
-	name "Beam Invader (set 1)"
-	year "1979"
-	developer "Tekunon Kougyou"
-	rom ( name beaminv.zip size 5895 crc 51c74ff3 md5 82fc1d88fdbc2c3f05e14b4a02851ce9 sha1 2711c5c3fbc5f85d06efb203cce021bc649bbddb )
-)
-
-game (
-	name "Beam Invader (set 2)"
-	year "1979"
-	developer "Tekunon Kougyou"
-	rom ( name beaminva.zip size 5814 crc 9f651089 md5 de5dfb78c148efa8ae51a0428a074374 sha1 f728f42437b6d88f252f38e19fa2ece8c686b91c )
-)
-
-game (
 	name "Beastie Feastie"
 	year "1984"
 	developer "Epos Corporation"
@@ -4191,17 +3232,10 @@ game (
 )
 
 game (
-	name "Beastorizer (USA bootleg)"
-	year "1997"
-	developer "bootleg"
-	rom ( name beastrzb.zip size 6326204 crc 2d08f12e md5 ee525d47c0e223ad90e1ad1f2fdac251 sha1 9fb9cff912e736963f12737274175e450abcb1d6 )
-)
-
-game (
 	name "Beastorizer (USA)"
 	year "1997"
 	developer "Eighting / Raizing"
-	rom ( name beastrzr.zip size 8971873 crc 27c8ffee md5 bfe70a30ecae75120f71e23d106ad97f sha1 f4199eaa0565c3802ee3777494815caba67955f7 )
+	rom ( name beastrzr.zip size 9100361 crc a2df2dfa md5 3595c22cbe136d02ada50664f2d4b1f1 sha1 5e3197094a5b5adf3c43637e612c67d614533534 )
 )
 
 game (
@@ -4209,20 +3243,6 @@ game (
 	year "1993"
 	developer "Atari Games"
 	rom ( name beathead.zip size 3031107 crc fe798ebd md5 67f4b84dd409e1bb546665d141ee00d1 sha1 ee181dc5d9b27d06b5ef65427c23bc1eb488478c )
-)
-
-game (
-	name "Beauty Block"
-	year "1991"
-	developer "AMT"
-	rom ( name beautyb.zip size 90881 crc bff50aae md5 bfef3bae6459aea1d74ca579d01e26d7 sha1 ff2b658edfa8eb46015d779aab9e51c1a97ad48f )
-)
-
-game (
-	name "Beeline (39-360-075)"
-	year "1991"
-	developer "BFM"
-	rom ( name beeline.zip size 107525 crc 76d70440 md5 4b9246a359b847a106071dabac9e0a2a sha1 55975fc2ef505a2277a7c7c3521e1de1aaf17132 )
 )
 
 game (
@@ -4237,27 +3257,6 @@ game (
 	year "1982"
 	developer "Tong Electronic"
 	rom ( name beezer1.zip size 24167 crc d2e78447 md5 4cd9bc71f0fe89fe43feda41e700f488 sha1 d78e9d7718921978a6da117229c0114a609b09bc )
-)
-
-game (
-	name "Bega's Battle (Revision 3)"
-	year "1983"
-	developer "Data East"
-	rom ( name begas.zip size 54554 crc 35a6ae14 md5 455c76c39ead02e7ebc89a2bf43ecb46 sha1 b59df21c99b0523d36bb9c790ee8c4bbf47b61b0 )
-)
-
-game (
-	name "Bega's Battle (Revision 1)"
-	year "1983"
-	developer "Data East"
-	rom ( name begas1.zip size 54590 crc 53d22dae md5 421a65b6ce3968a0736c1e98c801b269 sha1 4bd13931978918c66ee6d83677a44284d4ac747d )
-)
-
-game (
-	name "Behind Enemy Lines"
-	year "1998"
-	developer "Sega / EPL Productions"
-	rom ( name bel.zip size 27328296 crc b2e85671 md5 eb1baf8fefad0d765d1a73f82a8a0678 sha1 2164da6c78742c3ef1af4024d684c598d5d337f1 )
 )
 
 game (
@@ -4359,13 +3358,6 @@ game (
 )
 
 game (
-	name "Best League (bootleg of Big Striker, World Cup)"
-	year "1993"
-	developer "bootleg"
-	rom ( name bestleaw.zip size 966967 crc 42fce0ce md5 db72a6f702b3d1c3616efabfde166196 sha1 4cfcd0b1b133c38bbfab7386c4311c970eed1091 )
-)
-
-game (
 	name "Bestri (Korea)"
 	year "1998"
 	developer "F2 System"
@@ -4442,27 +3434,6 @@ game (
 )
 
 game (
-	name "Big D2"
-	year "2000"
-	developer "IGS"
-	rom ( name bigd2.zip size 2217046 crc 506b3015 md5 531c3083ea1534db16ec1dcdcb643ece sha1 8fd17f83df412592bb35d95646a0edb44763fefc )
-)
-
-game (
-	name "Big Deal (Hungarian, set 1)"
-	year "1986"
-	developer "Funworld"
-	rom ( name bigdeal.zip size 31494 crc 11dc02dc md5 5c0a83f4f50b9d3f04ad053af2a41cd2 sha1 26149d8c6eab579cfad8077330388f0debd2dad7 )
-)
-
-game (
-	name "Big Deal (Hungarian, set 2)"
-	year "1986"
-	developer "Funworld"
-	rom ( name bigdealb.zip size 31499 crc 99229386 md5 824d5adf15c08054c5bec654e216bd2a sha1 a1c345a20be13daeab0d3c117cce06ad4dbaf77f )
-)
-
-game (
 	name "Big Event Golf (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -4474,13 +3445,6 @@ game (
 	year "1986"
 	developer "Taito Corporation"
 	rom ( name bigevglfj.zip size 209276 crc 3e312f1f md5 5057ca5dc000ced56185e505d99b0d88 sha1 691f76a5dbad17dbefd788e8d4bc1b2023a4634b )
-)
-
-game (
-	name "Tatakae! Big Fighter"
-	year "1989"
-	developer "Nichibutsu"
-	rom ( name bigfghtr.zip size 487894 crc 50a18563 md5 eb6ef47d116b88a61d7a2effdbd5c854 sha1 7a66892cb241b6c414d49f37bebd4d41ee3baac2 )
 )
 
 game (
@@ -4516,13 +3480,6 @@ game (
 	year "1989"
 	developer "Jaleco"
 	rom ( name bigrun.zip size 2462344 crc c1e11087 md5 2e6e4fcccbfbbf11748cedc28adda5e7 sha1 303b2e99c94e7d16026610edbee9e2a1ea97b933 )
-)
-
-game (
-	name "Big Striker"
-	year "1992"
-	developer "Jaleco"
-	rom ( name bigstrik.zip size 838155 crc 08b43cdd md5 a256c29d166eb5694001ef4138e7880d sha1 67c7e723947c8e76aa1c78be13aa854c45717af7 )
 )
 
 game (
@@ -4568,48 +3525,6 @@ game (
 )
 
 game (
-	name "Bingo Circus (Rev. A 891001)"
-	year "1989"
-	developer "Sega"
-	rom ( name bingoc.zip size 252105 crc aacd1796 md5 5d35b83cba1876258a05ff9a9e8103a7 sha1 09e200bc4d84342d49b040e45e19dd4557b04b6a )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 1)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor1.zip size 55112 crc edae3d70 md5 55c09726b360fbf9b36c7bdbbf858412 sha1 145030a397f8738774c7063ba789120221032c3b )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 2)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor2.zip size 85502 crc 5291dbed md5 20a0081e4c330f3beb083f0887329ed0 sha1 aa3e54bb13679a3f3aa2feb017f23438aae3d833 )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 3)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor3.zip size 46424 crc ec7ba36d md5 0739030fdef066626d20435fccff5a84 sha1 2947e815cd018f2004bedc4167c68a1067fc41f6 )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 4)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor4.zip size 60613 crc 946d6af9 md5 223c2ff5fefbfc24af653812d4b0c287 sha1 7497dba4412cbb9c2738b601616aab8101051757 )
-)
-
-game (
-	name "Bingo Roll / Bell Star V3? (set 5)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor5.zip size 46072 crc 98056045 md5 fa64bf4811fb11f73b0cd3014e2009a9 sha1 0fd7bf72d024fc51802c5086ddcce0b544ad69b6 )
-)
-
-game (
 	name "Bio Attack"
 	year "1983"
 	developer "Taito Corporation (Fox Video Games license)"
@@ -4631,27 +3546,6 @@ game (
 )
 
 game (
-	name "Bionic Commando (Euro)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc.zip size 341032 crc 4618814f md5 3edd644f35021365a73f65e166ca38eb sha1 9ab366c3635e1536cdd61d83dadd43e7f758e038 )
-)
-
-game (
-	name "Bionic Commando (US set 1)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc1.zip size 341057 crc 11e7248d md5 5f7349b3e9512de05eb5fef50c52432e sha1 d45161d816fa76486e8dbba479e4d0c5e9803582 )
-)
-
-game (
-	name "Bionic Commando (US set 2)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc2.zip size 341034 crc 650e68ba md5 0804d0a3b9ca4ea612c6581bf8f230d3 sha1 0e33ed5fd37e37920542d49bd93f62df804e2900 )
-)
-
-game (
 	name "Bio-ship Paladin"
 	year "1990"
 	developer "UPL (American Sammy license)"
@@ -4659,37 +3553,10 @@ game (
 )
 
 game (
-	name "Birdie Try (Japan)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name birdtry.zip size 405472 crc 45008a6a md5 b648f6d50ec138500a4c2f01c2804f55 sha1 19f033951fdfff2eaa124649573699c460b7179c )
-)
-
-game (
-	name "Bishi Bashi Championship Mini Game Senshuken (ver JAA, 3 Players)"
-	year "1996"
-	developer "Konami"
-	rom ( name bishi.zip size 2693368 crc 8e6d5bf6 md5 c1892ca48e05516f9744229b3807557e sha1 6f491d1def0a8ea1a7ef074b3ab47f92f04c653c )
-)
-
-game (
-	name "Bishou Jan (Japan 203)"
-	year "1999"
-	developer "Subsino"
-	rom ( name bishjan.zip size 2794769 crc 8c3fcf15 md5 02741fa4862560466659d146e7c7b4fb sha1 c6318a748de35d087cf1c876babb33a0f563f3f4 )
-)
-
-game (
 	name "Blue's Journey / Raguy"
 	year "1990"
 	developer "Alpha Denshi Co."
-	rom ( name bjourney.zip size 2929979 crc 9fc19733 md5 640af332280677aa05fcb965a56090e0 sha1 0ca5b299d321dd8ed2c269a1b063f7ebea6c7ee2 )
-)
-
-game (
-	name "Poker / Black Jack (Model 7521)"
-	developer "M.Kramer Manufacturing."
-	rom ( name bjpoker.zip size 21786 crc 84277ab7 md5 f5883d0bdfe8b1c77b00f2ec5d208fbb sha1 45dcfc65e95e3880eadd8ba327a2f3bd23fc393e )
+	rom ( name bjourney.zip size 4276666 crc ce12d0e3 md5 760497036830b2b400fd35f31d8c37d4 sha1 2c4cb2838d465f4d0881ab4fe393af1e81741e18 )
 )
 
 game (
@@ -4762,13 +3629,6 @@ game (
 )
 
 game (
-	name "Black Touch '96"
-	year "1996"
-	developer "D.G.R.M."
-	rom ( name blackt96.zip size 1764185 crc ed39ee22 md5 e00acd2b279ab3c682b2151ee68acc51 sha1 1960a1044b7982a8739638f4b8730847f26657c6 )
-)
-
-game (
 	name "Blades of Steel (version T)"
 	year "1987"
 	developer "Konami"
@@ -4801,13 +3661,6 @@ game (
 	year "1992"
 	developer "Allumer"
 	rom ( name blandiap.zip size 3668983 crc 7f1d8ef2 md5 adc947b0d849cd7752aee22959f9dd60 sha1 5d9f038f3631c81d0c1f00dcabd5ad2bfc6ab1dd )
-)
-
-game (
-	name "Blasted"
-	year "1988"
-	developer "Bally Midway"
-	rom ( name blasted.zip size 485570 crc 3c79c3b1 md5 f070f2b43a0739ee69fca9cb2cbb8b2b sha1 2dec7d45fab77121634c3a14a8a1b66251950afc )
 )
 
 game (
@@ -4870,7 +3723,7 @@ game (
 	name "Blazing Star"
 	year "1998"
 	developer "Yumekobo"
-	rom ( name blazstar.zip size 21596303 crc 70433864 md5 2c33658d351a7d4b7e63951a112edc7e sha1 55a6b6b30163c1f2882a75e6184e4046453b1534 )
+	rom ( name blazstar.zip size 22942990 crc 356782d2 md5 cd5624543178302c35ba81a2228223d7 sha1 9ebb867a7da1f319d9edbb390e62e54f3160a63b )
 )
 
 game (
@@ -4898,35 +3751,35 @@ game (
 	name "Bloody Roar (Japan)"
 	year "1997"
 	developer "Eighting / Raizing"
-	rom ( name bldyroar.zip size 8971817 crc 07a42d70 md5 05bfd16ed27b1471fb4e2c2833adb4a7 sha1 dfa7f90ff4a98f1c126834fe968d75a60409509c )
+	rom ( name bldyroar.zip size 9100305 crc b1ec59cd md5 05642e0a5dbfde42346a1846b816da1f sha1 7f72913352f1e2ab001b0ff5a6e998874775e6d0 )
 )
 
 game (
 	name "Bloody Roar 2 (World)"
 	year "1998"
 	developer "Eighting / Raizing"
-	rom ( name bldyror2.zip size 19393065 crc ede51edb md5 893d730a2d979629b2beea617540f456 sha1 94e47214e087a9326cc38f4851abe724380157b3 )
+	rom ( name bldyror2.zip size 19521553 crc e573ea00 md5 a707d3b133a863f9a1efd87e1ac5f5b4 sha1 7f2bcd937638c1d1a9fdefbfd6447eba3ced0b32 )
 )
 
 game (
 	name "Bloody Roar 2 (Asia)"
 	year "1998"
 	developer "Eighting / Raizing"
-	rom ( name bldyror2a.zip size 19393063 crc d572d030 md5 26ccd0c21e678a95979cca9d224002ba sha1 d2b93d21e5504a7d187dc7244ee1101516b7249f )
+	rom ( name bldyror2a.zip size 19521551 crc 9295255d md5 330f489c81e0d474a991c668b585e00d sha1 a00bff891c9c66ea831abbfd5a11594f2b2c4d9a )
 )
 
 game (
 	name "Bloody Roar 2 (Japan)"
 	year "1998"
 	developer "Eighting / Raizing"
-	rom ( name bldyror2j.zip size 19393064 crc 325d50de md5 0141ab207d0751807f25db768c820b47 sha1 5fde3efdbb5e433fcd9dc895027f84f414e4b9db )
+	rom ( name bldyror2j.zip size 19521552 crc d84ea085 md5 b03dcdd573714207f5474cce8b8b8b9f sha1 20712460eea28805bbaa134f1b035dad4b4aa87f )
 )
 
 game (
 	name "Bloody Roar 2 (USA)"
 	year "1998"
 	developer "Eighting / Raizing"
-	rom ( name bldyror2u.zip size 19393060 crc 8c37ce27 md5 3534ba0f863ff7d5b6e20984671f5060 sha1 99201913176311d81c243c98082600201d780047 )
+	rom ( name bldyror2u.zip size 19521548 crc d476722e md5 af5f379b2617dff03ff53991438ea3b5 sha1 66190e59cc5ffebb09b3150cf40512154e9ba3b8 )
 )
 
 game (
@@ -5209,18 +4062,6 @@ game (
 )
 
 game (
-	name "Blox (v2.0)"
-	developer "BwB"
-	rom ( name blox.zip size 88469 crc 717546fe md5 a5df1d22f0b72db4ac6a68e33a93d70b sha1 cb26375a521dcb556c4b9335c3aa4a99368b54f3 )
-)
-
-game (
-	name "Blox (v2.0, Datapak)"
-	developer "BwB"
-	rom ( name bloxd.zip size 88469 crc 835c4989 md5 7830f8df69cfd772dbfb1468c7f09784 sha1 fad207d41b5dc203d944e6c62757ae6829297315 )
-)
-
-game (
 	name "Bloxeed (Japan, FD1094 317-0139)"
 	year "1989"
 	developer "Sega"
@@ -5438,62 +4279,6 @@ game (
 )
 
 game (
-	name "beatmania IIDX 3th style (GC992 JA)"
-	year "2000"
-	developer "Konami"
-	rom ( name bmiidx3.zip size 146 crc 642dbfd0 md5 4adf21d9b53aa5e3ca4d405a1ded11bb sha1 9e7bdbd9097230628d3e8be98c3bb1cec46e4b6a )
-)
-
-game (
-	name "beatmania IIDX 4th style (GCA03 JA)"
-	year "2000"
-	developer "Konami"
-	rom ( name bmiidx4.zip size 150 crc e24f5af4 md5 a36ec3a1304434e01e3cdf09fbf62a84 sha1 cf5c1eb9e683adf9feedda88301fdb7c98290cd2 )
-)
-
-game (
-	name "beatmania IIDX 6th style (GCB4U JA)"
-	year "2001"
-	developer "Konami"
-	rom ( name bmiidx6.zip size 146 crc 93f5297c md5 7489fa3ddaa35027a8653f98afbd3522 sha1 c06d89b8dbcd48822eed3887a9371831bb697612 )
-)
-
-game (
-	name "beatmania IIDX 7th style (GCB44 JA)"
-	year "2002"
-	developer "Konami"
-	rom ( name bmiidx7.zip size 146 crc 0c37b6a5 md5 fb52eebeeaeddd4250be6e5e4f670465 sha1 51a09a86f213b590282a54140770e1e1f3a9fba0 )
-)
-
-game (
-	name "beatmania IIDX 8th style (GCC44 JA)"
-	year "2002"
-	developer "Konami"
-	rom ( name bmiidx8.zip size 146 crc 8971df25 md5 ed572f8e954647a21585c7b831228946 sha1 af2afdb036bbd388032e9d5e58115a8c8fc56195 )
-)
-
-game (
-	name "beatmania IIDX with DDR 2nd Club Version (896 JAB)"
-	year "1999"
-	developer "Konami"
-	rom ( name bmiidxc.zip size 146 crc 0d976b08 md5 b8f565a508b234d7a2f0cd5eb909ac83 sha1 85eeac47f26372594c89f95056ffe4f8d9bb7bb9 )
-)
-
-game (
-	name "beatmania IIDX Substream 2 with DDR 2nd Club Version (984 A01 BM)"
-	year "1999"
-	developer "Konami"
-	rom ( name bmiidxc2.zip size 146 crc 15f35ba7 md5 b38e7cf691d981aa3955ce07f814b5ed sha1 c86faa89081a8df209adbe9d4d343169df29e7bf )
-)
-
-game (
-	name "beatmania IIDX with DDR 2nd Club Version (896 JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name bmiidxca.zip size 146 crc 0d976b08 md5 b8f565a508b234d7a2f0cd5eb909ac83 sha1 85eeac47f26372594c89f95056ffe4f8d9bb7bb9 )
-)
-
-game (
 	name "Vs. Raid on Bungeling Bay (Japan)"
 	year "1985"
 	developer "Nintendo / Broderbund Software Inc."
@@ -5505,20 +4290,6 @@ game (
 	year "1982"
 	developer "Data East USA (Bally Midway license)"
 	rom ( name bnj.zip size 25112 crc 66fd2e3d md5 0add8ee9048b808825d2b7ce2ef60301 sha1 8c93b1d9d3d99d17993780076cc59ee881df31e1 )
-)
-
-game (
-	name "Vs. Janshi Brandnew Stars (MegaSystem32 Version)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name bnstars.zip size 14048911 crc c6411513 md5 f0243b0e9201cf1629aff0eb9fc32dda sha1 9ae665d20b5537327277ecfcb57c26ecd25d4694 )
-)
-
-game (
-	name "Vs. Janshi Brandnew Stars"
-	year "1997"
-	developer "Jaleco"
-	rom ( name bnstars1.zip size 17328000 crc 763772f2 md5 af9c8495c8a3363ba489837098ced956 sha1 88c3535a1b7305566bb39b26077b62d51caf4da2 )
 )
 
 game (
@@ -5566,7 +4337,7 @@ game (
 game (
 	name "Boggy '84 (bootleg)"
 	year "1983"
-	developer "bootleg (Eddie&apos;s Games)"
+	developer "bootleg (Eddie's Games)"
 	rom ( name boggy84b.zip size 26152 crc 851b5bf8 md5 b241b0041aa16dc9b182b23dfbd6ee3b sha1 e792f68b4a71afe9a9250c09ea20d8ff385b925b )
 )
 
@@ -5613,27 +4384,6 @@ game (
 )
 
 game (
-	name "Bombs Away"
-	year "1988"
-	developer "Jaleco"
-	rom ( name bombsa.zip size 153114 crc 9e7b85ae md5 d02c9d9a0f6d8cd1c24069db26eb5279 sha1 91c59588acb0e11e14c2d0f9a32a40d948a1a598 )
-)
-
-game (
-	name "Bonanza (Revision 3)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name bonanza.zip size 1460778 crc a0bb755f md5 e236cea2fbc5338cb2c33ad766f21c7f sha1 5ce06420bbb38587814279bdb728a77a28273ba4 )
-)
-
-game (
-	name "Bonanza (Revision 2)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name bonanzar2.zip size 1459061 crc 2aab3026 md5 cd7c3e8606e9a0488eeed3e80c404b6e sha1 74887c5dc2c9e3bb42cd70af8073a7f7fbf244be )
-)
-
-game (
 	name "Bongo"
 	year "1983"
 	developer "Jetsoft"
@@ -5669,13 +4419,6 @@ game (
 )
 
 game (
-	name "Booby Kids (Italian manufactured graphic hack / bootleg of Kid no Hore Hore Daisakusen (bootleg))"
-	year "1987"
-	developer "bootleg"
-	rom ( name boobhack.zip size 196432 crc f7f34d26 md5 189e329ec5f5f863f3f21119b3536c8e sha1 726af6b574029fa3a6e1081a684db24a3832113d )
-)
-
-game (
 	name "Boogie Wings (Euro v1.5, 92.12.07)"
 	year "1992"
 	developer "Data East Corporation"
@@ -5687,12 +4430,6 @@ game (
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name boogwinga.zip size 8306790 crc 4d0211e9 md5 0ea5e64a4e0aa38d7e1d0c8bc60e5417 sha1 76ec908de7c82b7ccc8ab981b68c3d167f076fe3 )
-)
-
-game (
-	name "Book Theatre (Ver 1.2)"
-	developer "&lt;unknown&gt;"
-	rom ( name bookthr.zip size 600947 crc f4e37363 md5 b533a38e50f820a9a5011a4f91423410 sha1 4d0cc5523d2295429cd388e385eebc698afc8791 )
 )
 
 game (
@@ -5744,20 +4481,6 @@ game (
 )
 
 game (
-	name "Bosconian (Midway, new version)"
-	year "1981"
-	developer "Namco (Midway license)"
-	rom ( name boscomd.zip size 38842 crc 147893c9 md5 edc202f3c2a6b9db0610cdfa79ed2e03 sha1 7ee2fe1b601d2230c83f848a8013f1333d1f5890 )
-)
-
-game (
-	name "Bosconian (Midway, old version)"
-	year "1981"
-	developer "Namco (Midway license)"
-	rom ( name boscomdo.zip size 38991 crc 4c39968d md5 fbcdb731aaddeb4ac620452210cffa66 sha1 c0d2b33ae9c68655f3aaf25756121c7636c23c66 )
-)
-
-game (
 	name "Bosconian (old version)"
 	year "1981"
 	developer "Namco"
@@ -5790,20 +4513,6 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name botssa.zip size 1549571 crc c3c77601 md5 9ebc3b927a9de824df62964b10a412c9 sha1 894e27844bfad8194a265dc5f556cd3b36dcac2e )
-)
-
-game (
-	name "Bottle 10 (Italian, set 2)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name bottl10b.zip size 19470 crc 795f9141 md5 703c1974037e82dfa4404a7b743ad03d sha1 fdfc81bf7655aadf5613a8e766f829c30341c566 )
-)
-
-game (
-	name "Bottle 10 (Italian, set 1)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name bottle10.zip size 19483 crc 8addc9ce md5 7a0334d3b023c3025f00e04ea53613ce sha1 81c0fa21548cd484d909e0114a3bdb09c19e1ae1 )
 )
 
 game (
@@ -5842,13 +4551,6 @@ game (
 )
 
 game (
-	name "3-D Bowling"
-	year "1978"
-	developer "Meadows"
-	rom ( name bowl3d.zip size 6423 crc c16a7c86 md5 e169b64161d4acedf432acd7deb7dd47 sha1 c2ba0f9c089ed9dba8649a53f33a8911c57bf91d )
-)
-
-game (
 	name "Bowling Alley"
 	year "1978"
 	developer "Midway"
@@ -5863,24 +4565,10 @@ game (
 )
 
 game (
-	name "Boxer (prototype)"
-	year "1978"
-	developer "Atari"
-	rom ( name boxer.zip size 5583 crc 5759a1c6 md5 17f37cbcb77aa140a127783009089268 sha1 a9c45ca8f981a4c71426cdad10f7a551ad272fd6 )
-)
-
-game (
 	name "Boxing Bugs"
 	year "1981"
 	developer "Cinematronics"
 	rom ( name boxingb.zip size 27123 crc 854dbfbe md5 cb9b0501ada8177ec918761cfd41d3b8 sha1 229dd4258194fa775f369b32ad6b271a42a39a7d )
-)
-
-game (
-	name "Boxing Mania (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name boxingm.zip size 802 crc 73585a4f md5 3e73210695f37eeaa251ebe21ea3aa8c sha1 316efb4c4f0fccd6e9fcb850ede98c9e72974575 )
 )
 
 game (
@@ -5895,13 +4583,6 @@ game (
 	year "1980"
 	developer "Atari"
 	rom ( name bradley.zip size 15479 crc d0b3b841 md5 ee761bd58196edc6b05036b73ed09924 sha1 3e63a80e3badf541c326c033c6bb3a947aaee353 )
-)
-
-game (
-	name "Brain"
-	year "1986"
-	developer "Coreland / Sega"
-	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
 )
 
 game (
@@ -5933,45 +4614,17 @@ game (
 )
 
 game (
-	name "Borderline (Karateco bootleg)"
-	year "1981"
-	developer "bootleg (Karateco)"
-	rom ( name brdrlinb.zip size 13716 crc 7c714b04 md5 ad748e1b248f6d6ba1c48fbf991904a0 sha1 6e85d4af5c2b0856304cb2c65142cc06d51b319b )
-)
-
-game (
-	name "Borderline"
-	year "1981"
-	developer "Sega"
-	rom ( name brdrline.zip size 15236 crc 9886f011 md5 e672205b32565e977ca919ca623c8681 sha1 f6019f3c99075de17f140fe9777d4e6a8ad18941 )
-)
-
-game (
-	name "Borderline (Sidam bootleg)"
-	year "1981"
-	developer "bootleg (Sidam)"
-	rom ( name brdrlins.zip size 15124 crc 946d2e49 md5 424cbf350b5a9bfdaacd1655b6f3e424 sha1 6c0b4b9b859745a3eeb026b4cd028c399dd44312 )
-)
-
-game (
 	name "Breakers"
 	year "1996"
 	developer "Visco"
-	rom ( name breakers.zip size 13849092 crc ef7cfb06 md5 15d2bcf4b4f2283fcd3695ed4c73b53a sha1 6fce927a41eadb9455dbdb35d0389e52891d402f )
+	rom ( name breakers.zip size 15195779 crc 951fa5d2 md5 a84ebfead2bbd9867af8d8332513d87b sha1 ef42130fbbb7396647a2b412be23bbc49227aabe )
 )
 
 game (
 	name "Breakers Revenge"
 	year "1998"
 	developer "Visco"
-	rom ( name breakrev.zip size 15821592 crc 76c4e4d4 md5 1f746d513a29bd7d9d3b686be73dcd3c sha1 7c87ec6fd944ffb27afdd3d8916610818c12c8b8 )
-)
-
-game (
-	name "Breywood (Japan revision 2)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name breywood.zip size 288503 crc ff6fee69 md5 1ceff7a2902aa5eb0d122bccf64c366d sha1 c23860d32ce21b3915f11e674b48c9eaa530d42e )
+	rom ( name breakrev.zip size 17168279 crc 36b50107 md5 afb110d595470ab76c33dd4d7e7abadd sha1 fb7c45bfc15c61609a0cfbad99a2be561113aaef )
 )
 
 game (
@@ -5979,20 +4632,6 @@ game (
 	year "1976"
 	developer "RamTek"
 	rom ( name brickyrd.zip size 2457 crc 9ae0468b md5 5830d81f8647688b7bb6cc052b193eb4 sha1 745ed7a271c3d8f24598f58a54c5b7179d5d0232 )
-)
-
-game (
-	name "Brick Zone (v5.0)"
-	year "1992"
-	developer "SunA"
-	rom ( name brickzn.zip size 531025 crc 8ac71e75 md5 7a22b365cbbe3e0b12229dcd89311e8a sha1 b792b38b4344df79a3a8ad3db57dd1b57c4f102c )
-)
-
-game (
-	name "Brick Zone (v4.0)"
-	year "1992"
-	developer "SunA"
-	rom ( name brickzn3.zip size 530620 crc 9554d917 md5 866325e157da2779ca2e0ccb6203e03b sha1 52a981f260d7261c76053d9b2eb0b19b97f45346 )
 )
 
 game (
@@ -6061,28 +4700,28 @@ game (
 	name "Brave Blade (World)"
 	year "2000"
 	developer "Eighting / Raizing"
-	rom ( name brvblade.zip size 7125643 crc 42b00f4e md5 12f80748ed746e4a910a6a0b7d11226b sha1 ad245f05e2d8568319f6b2a0d561169b80d0153c )
+	rom ( name brvblade.zip size 7264095 crc fbd44e68 md5 c7285c7f4c1de8bfc2d484bd9d27218c sha1 ec10fc98f9d07b2172d0656ec64760e3043c5095 )
 )
 
 game (
 	name "Brave Blade (Asia)"
 	year "2000"
 	developer "Eighting / Raizing"
-	rom ( name brvbladea.zip size 7125640 crc 1e4180eb md5 5b045569f12f6403a15c6b50cdcba58e sha1 feda0c42c9b2e2474c5263972f275128dbe52fc1 )
+	rom ( name brvbladea.zip size 7264092 crc 9ffdf502 md5 af7e5eb1cf8e8c1668e999451fb8b079 sha1 b8f1e46cc8a40ecb699e43d4c928f5689189d79f )
 )
 
 game (
 	name "Brave Blade (Japan)"
 	year "2000"
 	developer "Eighting / Raizing"
-	rom ( name brvbladej.zip size 7125642 crc 3c4a44e1 md5 35cc0ef24a9355721bfef1a7463f35b8 sha1 9c50eabd608fae1e06ddb507290abeb1f7b0290b )
+	rom ( name brvbladej.zip size 7264094 crc 60344a0f md5 ef29ceef1a909899db399bbceade9902 sha1 bdff3dc5da59531cdfb7f054fbf2473a5bd11b91 )
 )
 
 game (
 	name "Brave Blade (USA)"
 	year "2000"
 	developer "Eighting / Raizing"
-	rom ( name brvbladeu.zip size 7125639 crc 454da579 md5 d1a5f10b28ec43f20a59809ced12c93a sha1 ce072925f578a3c536cd7d4fba0846760875a167 )
+	rom ( name brvbladeu.zip size 7264091 crc dd346826 md5 9de8e5193bccc9849b12b544e694ac6c sha1 67512533736d1e5dff68af0408b090dd64ffbc13 )
 )
 
 game (
@@ -6124,21 +4763,21 @@ game (
 	name "Baseball Stars Professional (set 1)"
 	year "1990"
 	developer "SNK"
-	rom ( name bstars.zip size 3331984 crc fdd3f390 md5 b8d992c3b0891cae2bafbcd29b1fcf85 sha1 62afebdacbae770789115519bc1228208ec98d9f )
+	rom ( name bstars.zip size 4678671 crc b526e8d3 md5 850d199f70079aa4350dbe1480bb61f7 sha1 c24c6af7bcf03d089d2954333eb049085b2b6c39 )
 )
 
 game (
 	name "Baseball Stars 2"
 	year "1992"
 	developer "SNK"
-	rom ( name bstars2.zip size 3700600 crc bb561151 md5 1899726f31f846adea8ec05065a4bef6 sha1 2c48c060606714a22e4d3127f9811ac6ca97f135 )
+	rom ( name bstars2.zip size 5047287 crc f118c4eb md5 f4163a9c6cc0414b7d50b874b820b6f7 sha1 b99cf0946c42c7d02dda7e6ccad32b99a36e17b1 )
 )
 
 game (
 	name "Baseball Stars Professional (set 2)"
 	year "1990"
 	developer "SNK"
-	rom ( name bstarsh.zip size 3331986 crc 64a9ab88 md5 a336702126938d9c6ce93472096cfc71 sha1 215ef5164528c224237258baababebb81725de84 )
+	rom ( name bstarsh.zip size 4678673 crc 47385398 md5 620a7fca674ec80a05bc7be2b4ad3cac sha1 aa46db80db0db7f423292b854892146541ca9a20 )
 )
 
 game (
@@ -6296,13 +4935,6 @@ game (
 )
 
 game (
-	name "Beat the Champ (GV053 UAA01)"
-	year "1996"
-	developer "Konami"
-	rom ( name btchamp.zip size 151 crc ee2ffa6f md5 e5fe5528eed0fadbef614cc9cc8d9dee sha1 45cdcfe5992e58165c7bd172550821ad3218cf7e )
-)
-
-game (
 	name "Burger Time (Data East set 1)"
 	year "1982"
 	developer "Data East Corporation"
@@ -6342,20 +4974,6 @@ game (
 	year "1987"
 	developer "bootleg"
 	rom ( name btlfieldb.zip size 914076 crc fd0ce171 md5 6ef162978ef96cb298404a52ad3b19c2 sha1 62c0a082315f7e1a0194e7c9f1ba71896e526016 )
-)
-
-game (
-	name "Battle K-Road"
-	year "1994"
-	developer "Psikyo"
-	rom ( name btlkroad.zip size 4161327 crc 18ed9e21 md5 00603afe66310ebe8d340c6564c84cc2 sha1 cfcefd05c4fb1492741caf392c3938754bd89fd3 )
-)
-
-game (
-	name "Battle Tryst (ver JAC)"
-	year "1998"
-	developer "Konami"
-	rom ( name btltryst.zip size 630980 crc 8c9cca39 md5 3ff37c6fc6370ec3d2b547864577f919 sha1 b2c907f18e436311e76f030739fd37631f8b26f8 )
 )
 
 game (
@@ -6408,13 +5026,6 @@ game (
 )
 
 game (
-	name "Bubble Trouble (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name bubbletr.zip size 911433 crc 56650225 md5 48acc135eb5ccac7bfef02fe3fd7aa48 sha1 6f37ea115eae404632dd468db7a6ee10888692e3 )
-)
-
-game (
 	name "Bubble 2000"
 	year "1998"
 	developer "Tuning"
@@ -6426,41 +5037,6 @@ game (
 	year "1994"
 	developer "Taito Corporation Japan"
 	rom ( name bublbob2.zip size 4906715 crc 224c696e md5 9c746ee1f7aea62567477df58d46af56 sha1 0ba71f6aa86952b65aac20c9e01508f0fa43d7d8 )
-)
-
-game (
-	name "Bubble Bobble"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name bublbobl.zip size 183843 crc 4fea6af9 md5 7f7e392e6152e97737de4d54cc7b5108 sha1 829142c9ba2aec2372ba14371e8f5ec8893194f4 )
-)
-
-game (
-	name "Bubble Bobble (older)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name bublbobl1.zip size 183826 crc ea563bed md5 7ea60edc196566e5710e289695d2d3e3 sha1 9653e056a9bbebdc05c4bc86e74333aabc1f32a3 )
-)
-
-game (
-	name "Bubble Bobble (US with mode select)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name bublboblr.zip size 183843 crc 46a46e42 md5 3746508ab29446d3571147b149c8e095 sha1 76b8a9867ce493be0f848a2a077a42ad22987964 )
-)
-
-game (
-	name "Bubble Bobble (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name bublboblr1.zip size 183837 crc e55c6cd8 md5 ebd55c450c817327ce1ce8ed375499e4 sha1 024a4eb4dac0f9a1ac351e4dcb1b9fdfad322f56 )
-)
-
-game (
-	name "Bubble Symphony (bootleg with OKI6295)"
-	year "1994"
-	developer "bootleg"
-	rom ( name bubsymphb.zip size 2602910 crc 2ebae6f6 md5 2def73da00a343fad8589deb36e7b4a8 sha1 7e4d6529e265bfa3af7757712e261e23d5b35534 )
 )
 
 game (
@@ -6482,13 +5058,6 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name bubsymphu.zip size 4906715 crc b09cad05 md5 aa67b30f61db31b3e0743772a87da479 sha1 4785522896a7fcdcc54f3b735dd2aec6ac742ed4 )
-)
-
-game (
-	name "Buccaneers (set 1)"
-	year "1989"
-	developer "Duintronic"
-	rom ( name buccanrs.zip size 292256 crc ad4e7b3f md5 15e909f3f8557171f5b865eafbbba64a sha1 df84215553cf9bf265455fb54f8631d15666d886 )
 )
 
 game (
@@ -6576,13 +5145,6 @@ game (
 )
 
 game (
-	name "Buggy Boy Junior/Speed Buggy (upright)"
-	year "1986"
-	developer "Tatsumi"
-	rom ( name buggyboyjr.zip size 231963 crc 50643292 md5 7d6656d484f91864395333c19a9c4942 sha1 187c1c7abe51daedbd27de22703ea229a28746a9 )
-)
-
-game (
 	name "Buggy Challenge"
 	year "1984"
 	developer "Taito Corporation"
@@ -6594,13 +5156,6 @@ game (
 	year "1984"
 	developer "Taito Corporation (Tecfri license)"
 	rom ( name buggychlt.zip size 97010 crc 73451675 md5 ebcc9c984608a3bf070888099e8b32fb sha1 2719422be8e0141d4c510ceb4960f03344da70b1 )
-)
-
-game (
-	name "Bullet (FD1094 317-0041)"
-	year "1987"
-	developer "Sega"
-	rom ( name bullet.zip size 343072 crc 1c3ddb9c md5 3f0874a51fd3928ca403421e8d278440 sha1 988573070b9810b1b2a525198472b51cfd18ea1d )
 )
 
 game (
@@ -6625,13 +5180,6 @@ game (
 )
 
 game (
-	name "Bulls Eye Darts"
-	year "1985"
-	developer "Shinkai Inc. (Magic Eletronics Inc. license)"
-	rom ( name bullsdrt.zip size 18099 crc 0f7d4a14 md5 c50f036aae4c57d9cc296cdd229637a9 sha1 e018d0b8583962fdb42914a841f675ff82ff31d9 )
-)
-
-game (
 	name "Hissatsu Buraiken (Japan)"
 	year "1987"
 	developer "Capcom"
@@ -6643,13 +5191,6 @@ game (
 	year "1997"
 	developer "Unico"
 	rom ( name burglarx.zip size 4820018 crc d292786b md5 bf55727fdf7785eea80045abeec4b968 sha1 4e443f1eb3ddc53783f6b954a06da98542057c61 )
-)
-
-game (
-	name "Buriki One (rev.B)"
-	year "1999"
-	developer "SNK"
-	rom ( name buriki.zip size 54519633 crc 16435a4a md5 be5ac200fdb0922d9a21db4357217b37 sha1 14bb16aecb66a0a765e6f2b191146efb5a7e41c4 )
 )
 
 game (
@@ -6670,21 +5211,14 @@ game (
 	name "Burning Fight (set 1)"
 	year "1991"
 	developer "SNK"
-	rom ( name burningf.zip size 3386939 crc adbefcf5 md5 69eeb5aa24b48bde4c02da8213925e43 sha1 a429dbceabf1b1b79a76afd159b61f3f2c5b17c3 )
+	rom ( name burningf.zip size 4733626 crc 160a8aef md5 e3b785bb402b2f2844a99be591857444 sha1 01edb85eb138e4ef28ba230112ad3a8aaa537f70 )
 )
 
 game (
 	name "Burning Fight (set 2)"
 	year "1991"
 	developer "SNK"
-	rom ( name burningfh.zip size 3387332 crc 82979f42 md5 5cc4efff06a8295df3a8e085a163671b sha1 8a70eb0f7e682455f83bb9f2600ff378da022dc5 )
-)
-
-game (
-	name "Buster"
-	year "1987"
-	developer "Marian Electronics Ltd."
-	rom ( name buster.zip size 19323 crc 0daa1c09 md5 6d42ed32514a66a76473c6a42c41fc0f sha1 bbee41a4f7efcfebd2c98032659a945f0a0a4f01 )
+	rom ( name burningfh.zip size 4734019 crc 40477638 md5 9d2a523fb9645b2a0be8c329d318a8b0 sha1 4bb12ccf2e074be5625b11745825d5f5b0820e74 )
 )
 
 game (
@@ -6807,13 +5341,6 @@ game (
 )
 
 game (
-	name "Cabaret"
-	year "1992"
-	developer "AMT Co. Ltd."
-	rom ( name cabaret.zip size 233926 crc bb72cda8 md5 33eff9d0b8cabfd979693eff6a5dc4c2 sha1 7fd038b7249525675a723aa55eff6299dbb35744 )
-)
-
-game (
 	name "Cachat (Japan)"
 	year "1993"
 	developer "Taito Corporation"
@@ -6870,20 +5397,6 @@ game (
 )
 
 game (
-	name "Mahjong Cafe Break"
-	year "1999"
-	developer "Nakanihon / Dynax"
-	rom ( name cafebrk.zip size 1390142 crc c0bd5623 md5 7dab8bbebfbcda5e3ced2009c6bd5912 sha1 a6a722f6be44ebe359fa4ba9a5f64855c70eae7c )
-)
-
-game (
-	name "Mahjong Cafe Doll (Japan)"
-	year "1993"
-	developer "Dynax"
-	rom ( name cafedoll.zip size 559452 crc 16c3fdf4 md5 2f99903133f46ab4e8243d1863061f36 sha1 88d5a71c9092e18e37b66920df90197be687de1e )
-)
-
-game (
 	name "Mahjong Cafe Time"
 	year "1992"
 	developer "Dynax"
@@ -6895,13 +5408,6 @@ game (
 	year "1999"
 	developer "Sammy"
 	rom ( name cairblad.zip size 13533920 crc c8716878 md5 f6a7777922650c300c0a28ce8486c34b sha1 07bedb17e9ed6e19710272f1cd566dd0b59ec399 )
-)
-
-game (
-	name "California Chase"
-	year "1999"
-	developer "The Game Room"
-	rom ( name calchase.zip size 131969 crc 631e0743 md5 f8d14d38a98efc3c854b425e90770b44 sha1 2b95d667f22ccdb1fbafe1cae6430939af8bd87a )
 )
 
 game (
@@ -7017,12 +5523,6 @@ game (
 )
 
 game (
-	name "Cannon Ball (Pacman Hardware)"
-	developer "Novomatic"
-	rom ( name cannonbp.zip size 13520 crc 043cc321 md5 092062965a660cef9612dceb1346b67c sha1 1141eaf74a1cc7082be41395f350695a5a06680b )
-)
-
-game (
 	name "Canvas Croquis"
 	year "1985"
 	developer "SNK"
@@ -7072,31 +5572,10 @@ game (
 )
 
 game (
-	name "Capitani Coraggiosi (Ver 1.3)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name capcor.zip size 528091 crc 9f111251 md5 624d384180db423225fcab9ecde8e7a0 sha1 86fdc4cccb35668d535bc996ca063a3dbb017b76 )
-)
-
-game (
 	name "Capitol"
 	year "1981"
 	developer "bootleg? (Universal Video Spiel)"
 	rom ( name capitol.zip size 16530 crc cee20fd8 md5 6c1a0e23422ce768311dfb24db0b9856 sha1 d1759ef898e053404f0d82452ad5d56d6c9932a7 )
-)
-
-game (
-	name "Capcom Vs. SNK Millennium Fight 2000 (000904 JPN, USA, EXP, KOR, AUS) (Rev C)"
-	year "2000"
-	developer "Capcom / SNK"
-	rom ( name capsnk.zip size 90874201 crc ed476428 md5 509c16b5eced2f0849c5fd87c6c9a81f sha1 1c8cfbcd7f1c22ec3319e6974eefa17d52e6e2a8 )
-)
-
-game (
-	name "Capcom Vs. SNK Millennium Fight 2000 (000804 JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom / SNK"
-	rom ( name capsnka.zip size 90873135 crc 29f13054 md5 3e46878816d317f7720ebb476ae67406 sha1 781560d26c144cf6e469e3babf848a4008346842 )
 )
 
 game (
@@ -7111,13 +5590,6 @@ game (
 	year "1991"
 	developer "Data East Corporation"
 	rom ( name captavena.zip size 7448206 crc 0d5737c7 md5 3ec4a4343019bf5f978a9b6a2fcc5c19 sha1 822097e908131fc4a542a942964b74b554cd427d )
-)
-
-game (
-	name "Captain America and The Avengers (UK Rev 1.4)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name captavene.zip size 7448214 crc ca014fa6 md5 251d9d02677411a37d69f45e65ff2f78 sha1 794ffb413ecaf0961a4433a8f6f85553be3e9ff4 )
 )
 
 game (
@@ -7149,20 +5621,6 @@ game (
 )
 
 game (
-	name "Captain Commando (World 911202)"
-	year "1991"
-	developer "Capcom"
-	rom ( name captcomm.zip size 2541835 crc f0e6245b md5 abc7c7ee61319dd421c202c086f2c3b4 sha1 f46abadc44a2b1ec022dccc2dac3f26f4eff88aa )
-)
-
-game (
-	name "Captain Commando (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name captcommb.zip size 2648896 crc 8e3b5d37 md5 45bb2e193bbc8756f4e75f0b45cd490e sha1 e3d50d8c029c76d6dc677b814e29641351dbac04 )
-)
-
-game (
 	name "Captain Commando (Japan 911202)"
 	year "1991"
 	developer "Capcom"
@@ -7191,13 +5649,6 @@ game (
 )
 
 game (
-	name "Capitan Uncino (Ver 1.2)"
-	year "2000"
-	developer "Nazionale Elettronica"
-	rom ( name capunc.zip size 557181 crc e31977f7 md5 a9ad3a4ae09b56fb2dfb82fd407865dc sha1 430127ff1894c35295bf0c0629fc4fc1673cb20c )
-)
-
-game (
 	name "Car 2 (bootleg of Head On 2)"
 	year "1979"
 	developer "bootleg (RZ Bologna)"
@@ -7209,20 +5660,6 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name caractn.zip size 23452 crc daa9a0db md5 c558cddba0b65fa1aff63cde826a3679 sha1 149ae75b32110a8fdf4ec2602f3e8bebc4f79636 )
-)
-
-game (
-	name "Carriage Bonus 2002 (bootleg)"
-	year "2002"
-	developer "bootleg"
-	rom ( name carb2002.zip size 74268 crc a003d921 md5 e46e88573836511610d4581d57e4cef0 sha1 e62263db51bafbcb500da3b01617e3e2c58188f1 )
-)
-
-game (
-	name "Carriage Bonus 2003 (bootleg)"
-	year "2003"
-	developer "bootleg"
-	rom ( name carb2003.zip size 59430 crc f6d08c62 md5 955a8ef8450c75b98990cf91c16a19d3 sha1 60db397a2078a7e3e3e2ceafb7401706ca4723ec )
 )
 
 game (
@@ -7243,13 +5680,6 @@ game (
 	year "1998"
 	developer "Midway Games"
 	rom ( name carnevil.zip size 127977 crc 71494d59 md5 881db2dd46fa960b34f5bb4d56c86609 sha1 49596c05f99515356c9f5501780dc6574de11735 )
-)
-
-game (
-	name "CarnEvil (v1.0.1)"
-	year "1998"
-	developer "Midway Games"
-	rom ( name carnevil1.zip size 127977 crc 71494d59 md5 881db2dd46fa960b34f5bb4d56c86609 sha1 49596c05f99515356c9f5501780dc6574de11735 )
 )
 
 game (
@@ -7281,23 +5711,9 @@ game (
 )
 
 game (
-	name "Car Polo"
-	year "1977"
-	developer "Exidy"
-	rom ( name carpolo.zip size 5574 crc 92bcf55d md5 bde33e30020d209594ae065fae9c23dd sha1 7043a4bf4ff800dcc96477bbab113cdfa4ccce00 )
-)
-
-game (
 	name "Carrera (Version 6.7)"
 	developer "BS Electronics"
 	rom ( name carrera.zip size 46908 crc 70f6d233 md5 fc30dfd07b5e7a27ebc92b0afda74993 sha1 ca114e8b1dd9a6dfb665ce186a8795d560ecbecd )
-)
-
-game (
-	name "Cart Fury"
-	year "2000"
-	developer "Midway Games"
-	rom ( name cartfury.zip size 177931 crc 62d13f75 md5 62a4c8a8cda54f00b478be069fe89257 sha1 6cf7d0e33c6b1268f639fb544433f792dc76df18 )
 )
 
 game (
@@ -7305,13 +5721,6 @@ game (
 	year "1978"
 	developer "bootleg? (Sidam)"
 	rom ( name cascade.zip size 5037 crc 9cac9d3c md5 80687d98b1a35f782ca1c0653b1024f2 sha1 a47a221add6377f314a0a48b838b13ad40fcce2b )
-)
-
-game (
-	name "Cash Quiz (Type B, Version 5)"
-	year "1986"
-	developer "Zilec-Zenitone"
-	rom ( name cashquiz.zip size 163824 crc ae2baab7 md5 4116fc74601f7a21a643fbeb22e09369 sha1 d6a267423ae84929005a3c164fb885c5691badf4 )
 )
 
 game (
@@ -7325,7 +5734,7 @@ game (
 	name "Astro Fantasia (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name castfant.zip size 16626 crc 839348a1 md5 24c1a2f0d79042d3f6ae34193d046eb8 sha1 9fbee3c62da2f05fad6c75785631130a8fd6e0d6 )
+	rom ( name castfant.zip size 27027 crc f7b9296c md5 6b6f9cb3d5bc17059468b0385560b1cf sha1 9c2104e0062883dff14a2a1bbeb9e84c48210e2d )
 )
 
 game (
@@ -7333,20 +5742,6 @@ game (
 	year "1985"
 	developer "Aristocrat"
 	rom ( name caswin.zip size 19831 crc b8892e3f md5 924622bc0be6f21e90df38468f1670ab sha1 3394522a8c19de5b118fe714955af21e04d262a0 )
-)
-
-game (
-	name "Catacomb"
-	year "1982"
-	developer "MTM Games"
-	rom ( name catacomb.zip size 6934 crc 16cea5fc md5 e61554ef95709a6406fd3be2a477f265 sha1 78d01f133c5357a2592efaf3b6b731dd7e1bc126 )
-)
-
-game (
-	name "Catapult"
-	year "1982"
-	developer "Epos Corporation"
-	rom ( name catapult.zip size 19986 crc 2475400b md5 c5f75c3c7bd817d914d2df8f63b60532 sha1 ee10550734cbf5e68697656fec2c66626d3787e8 )
 )
 
 game (
@@ -7361,27 +5756,6 @@ game (
 	year "1980"
 	developer "bootleg"
 	rom ( name caterplr.zip size 8703 crc 9b89a703 md5 2f0684b0102dd8c7fc7af48b32205485 sha1 831d55a4dd01f6ae5bf2973342dc37c099200ae3 )
-)
-
-game (
-	name "Cat and Mouse (set 1)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name catnmous.zip size 29654 crc 185a9c66 md5 212e0a860a6ecf993d3ca3839bb6b892 sha1 1a65eeec5e12ebfe396de5fc0113a5d470c51af9 )
-)
-
-game (
-	name "Cat and Mouse (set 2)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name catnmousa.zip size 27555 crc 954e0b08 md5 01ad7da0320abc1aa4b2c0cccb4e2bdc sha1 9637e7864d2f7b19735fb39d894c0253773bbd28 )
-)
-
-game (
-	name "Catt (Japan)"
-	year "1993"
-	developer "Wintechno"
-	rom ( name catt.zip size 3023322 crc ceec2587 md5 f57677dbea4d9ca3396bd970c1c57c93 sha1 71319691c40ca3455ef4f23392724dc2214d4bf7 )
 )
 
 game (
@@ -7406,13 +5780,6 @@ game (
 )
 
 game (
-	name "U.S. Navy (Japan 901012)"
-	year "1990"
-	developer "Capcom"
-	rom ( name cawingj.zip size 1511162 crc 7d187d5f md5 bf4beda24a5302219ac903a832d2aacb sha1 df579aa9c396d150c7da99234a081540232cd2b2 )
-)
-
-game (
 	name "Carrier Air Wing (World 901009)"
 	year "1990"
 	developer "Capcom"
@@ -7427,48 +5794,10 @@ game (
 )
 
 game (
-	name "Cherry Bonus 2001"
-	year "2001"
-	developer "Dyna"
-	rom ( name cb2001.zip size 126365 crc 27a76a66 md5 11f70def8f339e52a9dd4283fa3880de sha1 9c9e8b40fdc0e4a046eb49f1f9d5a7b70f2bc733 )
-)
-
-game (
-	name "Cherry Bonus III (ver.1.40, encrypted)"
-	developer "Dyna"
-	rom ( name cb3.zip size 81529 crc d176dd38 md5 f54ec370fa5fa83b2a7b4f5b3d00dbcc sha1 9748d513a6f4655dd74919821d4aa020960e5f6a )
-)
-
-game (
-	name "Cherry Bonus III (ver.1.40, set 2)"
-	developer "Dyna"
-	rom ( name cb3a.zip size 76484 crc b8f4db84 md5 4c7eaf5da44efb6cd054b5d2bd6346f7 sha1 104b8e07cdf9efd9983323d6521355da4213933e )
-)
-
-game (
-	name "Cherry Bonus III (alt)"
-	developer "Dyna"
-	rom ( name cb3b.zip size 86027 crc 666d7e2c md5 b42847b91823c81702e74db6f797fb9e sha1 22e419f913277480a46d42089d807e09b7424af2 )
-)
-
-game (
-	name "Cherry Bonus III (alt, set 2)"
-	developer "bootleg"
-	rom ( name cb3c.zip size 73033 crc ae44c115 md5 cdee237c1c207f761d82e5278f4a1667 sha1 0e6ec5910c00c11c1085fc22cfa3e26678d76a54 )
-)
-
-game (
 	name "Cool Boarders Arcade Jam"
 	year "1998"
 	developer "Tecmo"
-	rom ( name cbaj.zip size 16030178 crc 7c2ad7a0 md5 d09b9c81cd44b3fbabd7be0468bdb420 sha1 9ff4bfb101b12be60141fb78040fca5a5cccd09a )
-)
-
-game (
-	name "Cannonball (Atari, prototype)"
-	year "1976"
-	developer "Atari"
-	rom ( name cball.zip size 4227 crc cf0b0beb md5 df833d6af13e68958f2ae1d75861bd03 sha1 d0e1145ef6396e2b30aba420822f44845cfd5fe6 )
+	rom ( name cbaj.zip size 16168630 crc a33884e4 md5 f01a47120896ba278864deb4cbe2e19b sha1 154dc1cb823854556b3cb6f9f517be491e3b002b )
 )
 
 game (
@@ -7482,14 +5811,14 @@ game (
 	name "Boulder Dash (Cassette)"
 	year "1985"
 	developer "Data East Corporation"
-	rom ( name cbdash.zip size 13862 crc 4e1432bb md5 da7ac31c6867a0f059739e1d6f4c7e83 sha1 0c0f7ff29cbe1caa5a22aa0cf291bf5560ddd358 )
+	rom ( name cbdash.zip size 24263 crc 959bf7d9 md5 791fa49997c995147f5bdf373d5bffb3 sha1 044d1d2d57468e2b3c6719bd4983e73aca1feab7 )
 )
 
 game (
 	name "Bump 'n' Jump (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cbnj.zip size 23678 crc 0c87d6f1 md5 da48e9d37950a1843b5d505cea8b691e sha1 aecc69b6f5f439f976403c7e051dda3867e0a532 )
+	rom ( name cbnj.zip size 34079 crc 011993d1 md5 211e79fc51d924fa4afea70f5ede433f sha1 05325502fda594bc7c8b146e95965ea51270659d )
 )
 
 game (
@@ -7503,21 +5832,21 @@ game (
 	name "Burger Time (Cassette)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cbtime.zip size 19505 crc 82a4321c md5 3000716c40bb1e3b92e0237003c78d61 sha1 22722b9599abd535ba22f2050510728e3706e44e )
+	rom ( name cbtime.zip size 29906 crc 8085d963 md5 d0fa47667f0d3a27e4c15d4e696baabb sha1 e6d808750faab0196b66c810a6514f4c326916b1 )
 )
 
 game (
 	name "Burnin' Rubber (Cassette, set 1)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cburnrub.zip size 23681 crc 01172c6d md5 7071eb35aa63023f5a7cb246583ae17c sha1 cc83ac92006f627b6608097df93c6bb20fa57ffe )
+	rom ( name cburnrub.zip size 34082 crc 73b36ebe md5 0db0fadcd007a51d87da6d535f4f1d4a sha1 e16c6c34b8a87f4f449bba0787a887295804a940 )
 )
 
 game (
 	name "Burnin' Rubber (Cassette, set 2)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cburnrub2.zip size 23628 crc d0c1a260 md5 a866785338743570f3fbd7e994ea8446 sha1 df06ee463f428910e44574c598a7d0c83482ef3e )
+	rom ( name cburnrub2.zip size 34029 crc a2457553 md5 0fc2e5f8464ea702a5a44d2728d1052d sha1 26fc8f137856773dbff98df0885b4038a93344b5 )
 )
 
 game (
@@ -7619,12 +5948,6 @@ game (
 )
 
 game (
-	name "Cherry Chance"
-	developer "&lt;unknown&gt;"
-	rom ( name cchance.zip size 37963 crc 798dee25 md5 0b52bc7329f84a89022c46e03db041c3 sha1 cd37b98a8783a4a0d82c08583ea6582a464a705c )
-)
-
-game (
 	name "Cosmic Chasm (set 1)"
 	year "1983"
 	developer "Cinematronics / GCE"
@@ -7677,7 +6000,7 @@ game (
 	name "Disco No.1 (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cdiscon1.zip size 18139 crc 4a5289f1 md5 83b1d34d3f3488d638c098c6936cb33a sha1 9c6dde04be51d938ae14835299e0a6bde81e4561 )
+	rom ( name cdiscon1.zip size 28540 crc a780bf86 md5 e00686af8ba6232ecc2b7d4b68237c6d sha1 2c06a0bce9bc18066793a1de31edf24477c37e94 )
 )
 
 game (
@@ -7730,13 +6053,6 @@ game (
 )
 
 game (
-	name "Explorer (Cassette)"
-	year "1982"
-	developer "Data East Corporation"
-	rom ( name cexplore.zip size 18374 crc db477e31 md5 07dafae4c4a0fae39006372851b4e6dd sha1 509d0fdfc285dfc8f301f1b3b67bec6f08d17e1d )
-)
-
-game (
 	name "Chicken Farm (Version 2.0)"
 	year "1999"
 	developer "LAI Games"
@@ -7782,21 +6098,14 @@ game (
 	name "Fighting Ice Hockey (Cassette)"
 	year "1984"
 	developer "Data East Corporation"
-	rom ( name cfghtice.zip size 27824 crc 5208666c md5 4e538006c61cf63fe075aefdb83af010 sha1 570dde5da5a9d0829a4ce1cd154011085dd91471 )
-)
-
-game (
-	name "Chaos Field (GDL-0025)"
-	year "2004"
-	developer "Able"
-	rom ( name cfield.zip size 1196 crc 2d510786 md5 78250a81d8daaa6248d0355d92469e40 sha1 384b6072448858d1017c0b16d1bdc8a4287a258b )
+	rom ( name cfghtice.zip size 38225 crc e2d61865 md5 aba20d31e7daf0d1daf52c573c700625 sha1 589a129913c3c4f05654a625214d479422f49bfb )
 )
 
 game (
 	name "Flying Ball (Cassette)"
 	year "1985"
 	developer "Data East Corporation"
-	rom ( name cflyball.zip size 18646 crc 64247716 md5 6f008506e1c2be954a686a172b684190 sha1 f43dcf3c9499c975baa2ae71937577268d7b7921 )
+	rom ( name cflyball.zip size 29047 crc d3961aef md5 04d5d01e0eaac76d165efcfd40af08a9 sha1 24d8830e81cf2eaa19e4aff782edabb26f66db21 )
 )
 
 game (
@@ -7824,14 +6133,7 @@ game (
 	name "Cluster Buster / Graplop (Cassette, set 1)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cgraplop.zip size 20458 crc 3adab3e0 md5 448400ab1001f7d452abbcdeeb16c78b sha1 2baa0df7d1887e0d0804a37cf544169699549358 )
-)
-
-game (
-	name "Cluster Buster / Graplop (Cassette, set 2)"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name cgraplop2.zip size 16835 crc 0e3dc75d md5 66a090f8b67127c6205a6b766f45fcc5 sha1 c90a67796529169678434d8a771da6bd686f6c1c )
+	rom ( name cgraplop.zip size 30859 crc 59721b64 md5 ac274f09e319f6c765cf18b1a4251bb5 sha1 7480149bed98d831a7d5606b4886717044ea2872 )
 )
 
 game (
@@ -7926,24 +6228,10 @@ game (
 )
 
 game (
-	name "Chack'n Pop"
-	year "1983"
-	developer "Taito Corporation"
-	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
-)
-
-game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
 	rom ( name challeng.zip size 14901 crc 61e8276b md5 0c53b4676e3335279a67da49517ca1c0 sha1 325323db1b927b14119571c06b1880fe124cacf6 )
-)
-
-game (
-	name "Chameleon 24"
-	year "2002"
-	developer "bootleg"
-	rom ( name cham24.zip size 942902 crc 07092d53 md5 a4cf2d24005af8343755fe339b1be1a5 sha1 066c36dc8ae05c3a2f798ac755f611617e17e440 )
 )
 
 game (
@@ -7979,20 +6267,6 @@ game (
 	year "1983"
 	developer "Alpha Denshi Co. (Sega license)"
 	rom ( name champbb2.zip size 52147 crc fddc6463 md5 30408ce846c510ca286f5050dac13152 sha1 7bac73045cac299ea58ac956a5f74406106cfd1b )
-)
-
-game (
-	name "Champion Baseball II (set 2)"
-	year "1983"
-	developer "Alpha Denshi Co."
-	rom ( name champbb2a.zip size 50816 crc 954a77ef md5 357e227c94f1514445dcdd0166b16556 sha1 5eb0ecc2cb6e2f7e2488af342f73bebe4e378d05 )
-)
-
-game (
-	name "Champion Baseball II (Japan)"
-	year "1983"
-	developer "Alpha Denshi Co."
-	rom ( name champbb2j.zip size 52131 crc 4c4aaaf2 md5 470c94bc25f9298efad5c3628f282306 sha1 28abbc6c332373e01dabd1f5cce07b585d2b16d1 )
 )
 
 game (
@@ -8052,31 +6326,24 @@ game (
 )
 
 game (
+	name "Chaos Heat (V2.09O)"
+	year "1998"
+	developer "Taito"
+	rom ( name chaoshea.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
+	name "Chaos Heat (V2.08J)"
+	year "1998"
+	developer "Taito"
+	rom ( name chaosheaj.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Charlie Ninja"
 	year "1995"
 	developer "Mitchell"
 	rom ( name charlien.zip size 3708127 crc bf36b3c3 md5 24e81fa3afa4591e86b6bd932fc88c52 sha1 212ebbf9a222381a1e0c8dee4d9cda59baa3089c )
-)
-
-game (
-	name "Chase H.Q. (World)"
-	year "1988"
-	developer "Taito Corporation Japan"
-	rom ( name chasehq.zip size 3728581 crc 28121659 md5 2331a078acf3f5915ac22da046eee5fb sha1 0a43f9fa46e07354242723241c30d2c3866c6905 )
-)
-
-game (
-	name "Chase H.Q. (Japan)"
-	year "1988"
-	developer "Taito Corporation"
-	rom ( name chasehqj.zip size 3681743 crc 681fa553 md5 3f521b9efeec02c4325979111eb442e2 sha1 1b84c7a9397875852f641e21faec49fc4a898433 )
-)
-
-game (
-	name "Chase H.Q. (US)"
-	year "1988"
-	developer "Taito America Corporation"
-	rom ( name chasehqu.zip size 3728824 crc 151577fe md5 a756a0ecfc599f6874c1fb7f2b686200 sha1 0df2fa3b8af5ec6a4aef9ad029836a6f5af39bc6 )
 )
 
 game (
@@ -8098,13 +6365,6 @@ game (
 	year "1982"
 	developer "Zilec-Zenitone (Jaleco license)"
 	rom ( name checkmanj.zip size 10972 crc be592c2d md5 8ab21575a212046d4a0064deb1b4217c sha1 7cdc082b7ec4bcb92cb7297b2e0812e4ac3fac43 )
-)
-
-game (
-	name "Checkmate"
-	year "1977"
-	developer "Midway"
-	rom ( name checkmat.zip size 3681 crc 07b85371 md5 704d93f7dc3334ad7a82db3773298f37 sha1 c6032d475c2a64f77d252c43ed96762772a35375 )
 )
 
 game (
@@ -8170,20 +6430,6 @@ game (
 )
 
 game (
-	name "Chimera Beast (prototype)"
-	year "1993"
-	developer "Jaleco"
-	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
-)
-
-game (
-	name "China Gate (US)"
-	year "1988"
-	developer "Technos Japan (Taito / Romstar license)"
-	rom ( name chinagat.zip size 570940 crc f69e5596 md5 b7879cc59c11d7c546958fed372ebfe4 sha1 3a60a36b5841b283e12ab61e7ba4c8c26f2f5673 )
-)
-
-game (
 	name "China Town (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -8226,13 +6472,6 @@ game (
 )
 
 game (
-	name "Chance Kun"
-	year "1982"
-	developer "&lt;unknown&gt;"
-	rom ( name chkun.zip size 126759 crc 5682a169 md5 42ec7597208bd35577ba83f89b528d5c sha1 efb159837defb39677b87baff77c72e3c1025292 )
-)
-
-game (
 	name "Champion League (Poker)"
 	year "2000"
 	developer "IGS"
@@ -8254,45 +6493,10 @@ game (
 )
 
 game (
-	name "Musapey's Choco Marker (Rev A) (GDL-0014A)"
-	year "2002"
-	developer "Ecole Software"
-	rom ( name chocomk.zip size 1197 crc 6a13106f md5 3d7c4a307eb51d5ae6ddba5f2bd35a30 sha1 3d4fbd9aa1292aa37caebee36ea808d614a854b5 )
-)
-
-game (
-	name "Choky! Choky!"
-	year "1995"
-	developer "SemiCom"
-	rom ( name chokchok.zip size 1105332 crc e49ff98c md5 10bdec45413daa6880abccf9ed8695b7 sha1 4bf77f1df9bf1e61b96b30ea7f176fd32976f53c )
-)
-
-game (
 	name "Janpai Puzzle Choukou (Japan 010820)"
 	year "2001"
 	developer "Mitchell (Capcom license)"
 	rom ( name choko.zip size 4923896 crc af3b9ce9 md5 6b916fdfe389946df5b293b4fc3d8532 sha1 138bd736202f8de1ee0a2c2a29da7e358c0d6c2c )
-)
-
-game (
-	name "Choplifter (8751 315-5151)"
-	year "1985"
-	developer "Sega"
-	rom ( name choplift.zip size 138193 crc 1c4bff6a md5 e2e71305b100c701a67b262220f04ca2 sha1 6affaa22ea10ca727dabdae41eb720a676f7de17 )
-)
-
-game (
-	name "Choplifter (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name chopliftbl.zip size 137535 crc b752694d md5 69daa4fb5d1f85c2e45d627bbfec5588 sha1 910806c5ff7190bf1fa50bd456d6afbd9a17310b )
-)
-
-game (
-	name "Choplifter (unprotected)"
-	year "1985"
-	developer "Sega"
-	rom ( name chopliftu.zip size 137757 crc 07f1511c md5 8190951fa98026933bbeeb41a3ca1210 sha1 90c242b12ddf6997d1fb92d8d1844a1338b7d5a8 )
 )
 
 game (
@@ -8314,32 +6518,6 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name chopperb.zip size 422267 crc e3643ccf md5 2b1a2094d140faacb4ec41d3ae7fb706 sha1 91a45d122846928923b9d9383e6cdc4729401f4f )
-)
-
-game (
-	name "Chequered Flag"
-	year "1988"
-	developer "Konami"
-	rom ( name chqflag.zip size 1325979 crc c170b656 md5 5728a509ae752d36577ea02bc348d6a0 sha1 976e1c7d2384752745b24dd94a105356909f175f )
-)
-
-game (
-	name "Chequered Flag (Japan)"
-	year "1988"
-	developer "Konami"
-	rom ( name chqflagj.zip size 1325970 crc 5f591e00 md5 8ee0deb0cea631e797c1eb2cc7530a02 sha1 58240a05b83c33551786ab0fa76b18cb74ec2980 )
-)
-
-game (
-	name "Cherry 10 (bootleg with PIC16F84)"
-	developer "bootleg"
-	rom ( name chry10.zip size 76925 crc dd0884ea md5 b33be0c1d8d7b7f1d498f769441dea6f sha1 db713de9f2fa66b637cc376e6b4e9f4f355b1e43 )
-)
-
-game (
-	name "Cherry Gold I"
-	developer "bootleg"
-	rom ( name chrygld.zip size 63347 crc 69866dac md5 55c4b8d72f9f99f2324cbef13b708201 sha1 a2400ea45f3fe5252c43757bed43b8b4450f2248 )
 )
 
 game (
@@ -8382,13 +6560,6 @@ game (
 	year "1985"
 	developer "Sega"
 	rom ( name chwrestl.zip size 35843 crc 9d88439c md5 d3ca349c776d55c7fd9fe30e65dc7321 sha1 91d6aaddc557759d21d6bbbc12c785ff91c9a810 )
-)
-
-game (
-	name "Highway Chase (Cassette)"
-	year "1980"
-	developer "Data East Corporation"
-	rom ( name chwy.zip size 15056 crc 10736c54 md5 d30b24fa6550e810bcd261353c420dc8 sha1 dd64977399b20dbac1db26cfb81f3cf3161d61dd )
 )
 
 game (
@@ -8576,70 +6747,14 @@ game (
 	name "Rootin' Tootin' / La-Pa-Pa (Cassette)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name clapapa.zip size 19143 crc 60e4d4e0 md5 940bca05be16523aa66035c101afd7a6 sha1 7c17e802dbc1be038fe46336127ebb2426876da4 )
+	rom ( name clapapa.zip size 29544 crc 0413d54a md5 f8b9998c7c6340435261c79ed95c2bad sha1 a67c82b09e883b0f041bb55f329b690157e267f3 )
 )
 
 game (
 	name "Rootin' Tootin' (Cassette)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name clapapa2.zip size 18804 crc 043317ef md5 bc6c62fa6bfd614bf944da0629992da0 sha1 8408bb64c89c2f13eb84b9648d1b7ddd6cfbad32 )
-)
-
-game (
-	name "Classic Edition (Version 1.6E)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice.zip size 715269 crc bcc46dbd md5 5e92a66015bccda25c622a6c364e3096 sha1 c0518f8aab24b0d7c986d88585248bdacb44307b )
-)
-
-game (
-	name "Classic Edition (Version 1.6R, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice1.zip size 716182 crc 027075d0 md5 3ebee978f86cefed209dbfe2ab6e69f0 sha1 bba880dd65c886d897cde7c6a60ac821ddc1cd77 )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice2.zip size 716445 crc 407bf78a md5 e27cc09e9f5fbc34f99aebee46b02b82 sha1 159d853c1fb7e174112d36d5e898728cb26e1dfb )
-)
-
-game (
-	name "Classic Edition (Version 1.6R, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classiced1.zip size 715130 crc 99afeb39 md5 87c082e9b5e1e8dabf9b7b74bb988a94 sha1 6d171f0ed2b00760c889f1bc070f43c890cde4f4 )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classiced2.zip size 715520 crc 7c25674c md5 209e675f866d79df10e908326f2bca9f sha1 a5be9015a4a85a139a6d6506c757c0da0b219d09 )
-)
-
-game (
-	name "Classic Edition (Version 1.6E Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev.zip size 716433 crc f24e2a74 md5 e26333e8c7032740799ee94a55e6090f sha1 be72f01eb5344afe048561d434fd67470416907d )
-)
-
-game (
-	name "Classic Edition (Version 1.6R Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev1.zip size 716153 crc c4d71dc3 md5 cad685f0df292c5e4649c77770ad723d sha1 32465f876e449ce0c2a660db983c4729b9368653 )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev2.zip size 716220 crc 233e50e6 md5 4f1848bd6dce69ea66904893f4f9c93a sha1 da85b652e1277a7151a17a7b63adca2cf62cc1fa )
+	rom ( name clapapa2.zip size 29205 crc deadf828 md5 79021b6b1416476369b2214c555224ce sha1 a6aec3da77dc70a6e91048c6c332e722c01bb0f9 )
 )
 
 game (
@@ -8650,24 +6765,10 @@ game (
 )
 
 game (
-	name "Clay Shoot"
-	year "1979"
-	developer "Allied Leisure"
-	rom ( name clayshoo.zip size 6453 crc d8b2cb3a md5 4401c797845344f5700935c25bd2d5db sha1 3a9402b6f03b31e8000c5c8a4e69bc10584eec3e )
-)
-
-game (
 	name "Coors Light Bowling"
 	year "1989"
 	developer "Incredible Technologies / Capcom"
 	rom ( name clbowl.zip size 100005 crc 3ce43928 md5 e2b2e97aad33555f91a3bc4c763ad943 sha1 3c45a76dc9f28bac1772701cb9cb5485739a523d )
-)
-
-game (
-	name "Cleopatra Fortune Plus (GDL-0012)"
-	year "2002"
-	developer "Altron"
-	rom ( name cleoftp.zip size 1195 crc 89b4f12b md5 2d29a06a8493b8b711a8c906cc948bef sha1 efe6831a6fe1448ccb158f700af02a5532d4d11b )
 )
 
 game (
@@ -8723,14 +6824,7 @@ game (
 	name "Lock'n'Chase (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name clocknch.zip size 15936 crc 263255a6 md5 a1f7ea74039b363b28b155c8ef3607c9 sha1 e15fb90995e6e41c97fc11f2b22846cae32890de )
-)
-
-game (
-	name "Cloud 9 (prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name cloud9.zip size 22630 crc 84caff0f md5 0868c27a4b6d65518e01d456ef766ac2 sha1 821c6bb14ea941e9d120e81648f9dc9a9f10fded )
+	rom ( name clocknch.zip size 26337 crc fc163091 md5 3874066b7ac760062a9ea934696ba30a sha1 cbb695adbed82083d52990d65ebf459799834b7d )
 )
 
 game (
@@ -8790,17 +6884,10 @@ game (
 )
 
 game (
-	name "Club Kart: European Session"
-	year "2002"
-	developer "Sega"
-	rom ( name clubkrte.zip size 139630974 crc 01a259ca md5 defbd9799019f24f3cb9a304b3cfcfe8 sha1 d0163dc27444a6aed52bde59db6e9c844fdef3ee )
-)
-
-game (
 	name "Lucky Poker (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name cluckypo.zip size 16875 crc d7b699e5 md5 f94c0331aae80cfe9c80f271c1ca99ad sha1 e3a5deb6bc4c4e4046b9230fff7ee1b94ea1b950 )
+	rom ( name cluckypo.zip size 27276 crc 83b1c9e9 md5 39ca024ce3245f10d731f6155bd6b5e5 sha1 a1c7fba558b1d3f3cfc13184dfb764bd323d9f0f )
 )
 
 game (
@@ -8832,26 +6919,6 @@ game (
 )
 
 game (
-	name "Carta Magica (Ver 1.8)"
-	developer "&lt;unknown&gt;"
-	rom ( name cmagica.zip size 425498 crc 256eb1f5 md5 2a91fac75a9ee5eadc967845e5dc9298 sha1 b9e25c0f6041dac1491ede2f5804bd3fed3c1b49 )
-)
-
-game (
-	name "Cherry Master '91 (ver.1.30)"
-	year "1991"
-	developer "Dyna"
-	rom ( name cmast91.zip size 124394 crc a1a6abb1 md5 c1dd7066427057dd054404822d20297b sha1 f7950ed9fd3d6cafcd657f1f870f94a877e87aaa )
-)
-
-game (
-	name "Cherry Master '92"
-	year "1992"
-	developer "Dyna"
-	rom ( name cmast92.zip size 17718 crc c73d9176 md5 1f7c1b45985e650f639b7e7c62eed7d4 sha1 2ab8357a28cc687666e26f0a1b37ea4753a6e09e )
-)
-
-game (
 	name "Cherry Master I (ver.1.01, set 1)"
 	year "1991"
 	developer "Dyna"
@@ -8863,13 +6930,6 @@ game (
 	year "1991"
 	developer "Dyna"
 	rom ( name cmasterb.zip size 57679 crc 8f1b89fd md5 aada9448283ddb3666f1585361809e32 sha1 e14e1cf2d0a10edb65830e2805c6c37414e80867 )
-)
-
-game (
-	name "Cherry Master I (ver.1.01, set 4, with Blitz Poker ROM?)"
-	year "1991"
-	developer "Dyna"
-	rom ( name cmasterbv.zip size 92332 crc 4cf315e2 md5 ebbae542ed8ec62a5e290a1f6e71187a sha1 a165877affffa74a74a72973fa900b78cc957977 )
 )
 
 game (
@@ -8925,34 +6985,7 @@ game (
 	name "Mission-X (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cmissnx.zip size 15902 crc 24c9869a md5 8dde52b4e5ea840752bfcb23286ca860 sha1 41c30bcf24043e7ae4d95ec8f44b730552e8e0d0 )
-)
-
-game (
-	name "Coinmaster Keno (Y2K, Spanish, 2000-12-14)"
-	year "2000"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmkenosp.zip size 5174964 crc fd03f3e4 md5 08531201d1783d09017783ac8fe508e5 sha1 820219816f85d803ca8308ff68b0580baee2ba84 )
-)
-
-game (
-	name "Coinmaster Keno (Y2K, Spanish, 2000-12-02)"
-	year "2000"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmkenospa.zip size 5174165 crc 709df135 md5 2ec951da4814a912f0f6e06c5fd056a2 sha1 c40915c93d4dfd31f610403f40e86fcb6c84479b )
-)
-
-game (
-	name "Multipede (V1.00)"
-	developer "Infogrames / Cosmodog"
-	rom ( name cmmb162.zip size 147152 crc 18f734b7 md5 85e998cd75efbd5413165aee0355a548 sha1 1cf3c46baff5e176517b3d882248d95432ade38e )
-)
-
-game (
-	name "Coinmaster Roulette V75 (Y2K, Spanish)"
-	year "2001"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmrltv75.zip size 6583014 crc 44558d84 md5 68e6c69ff3fb3ccd6a6410891a234c58 sha1 0ca8dcb24c6da97b1bb287247100a7bc77a9a1ac )
+	rom ( name cmissnx.zip size 26303 crc b3da06a5 md5 aa3f832a25b2e537d3737dcf8d4a54b0 sha1 e7defbd0033ab9df7261d8431b739bc5134b8c02 )
 )
 
 game (
@@ -8963,36 +6996,30 @@ game (
 )
 
 game (
-	name "Cherry Master (ver.4, set 2)"
-	year "1992"
-	developer "Dyna"
-	rom ( name cmv4a.zip size 98103 crc 6fe04512 md5 d49fa3694b3f31650366ff0b8ad3b8dd sha1 2b4bd8e1814d90b0d0ba0b19530378d437177ae8 )
-)
-
-game (
-	name "Cherry Master (Corsica, ver.8.01)"
-	developer "Corsica"
-	rom ( name cmv801.zip size 63718 crc 25c94c82 md5 d02d783854aaf79b018dc37777172454 sha1 3dc6691fba35614c033ea07f19456f83bd66a667 )
-)
-
-game (
 	name "Cherry Master (Watermelon bootleg / hack)"
 	developer "Dyna"
 	rom ( name cmwm.zip size 58408 crc ef1bcbaa md5 99fbce128393656d95bf18523d766419 sha1 2f06d5944b2528610585a9b1bfd8f1c33adee8d9 )
 )
 
 game (
+	name "Candy Puzzle (v1.0)"
+	year "1995"
+	developer "CD Express"
+	rom ( name cndypuzl.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
+)
+
+game (
 	name "Night Star (Cassette, set 1)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cnightst.zip size 21664 crc 34f25e3f md5 199289411990d55a8d7a460e86ddf2ce sha1 58e2b73efde610ec022182773c8081e55b544a40 )
+	rom ( name cnightst.zip size 32065 crc a03c804f md5 283e131bf0cd18f55676dd3a1f535015 sha1 7b080c3e4bb5bacf364d7a88d9a0d32ef9e31722 )
 )
 
 game (
 	name "Night Star (Cassette, set 2)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cnightst2.zip size 21664 crc 839d6424 md5 bbdced890aa56330d6b81e95a9bc1444 sha1 51632040433f819837bd0b6b3005b15c2759ce20 )
+	rom ( name cnightst2.zip size 32065 crc 5c0b567f md5 f2cb89455e9c61cd3f7105425d04e79b sha1 6b2511b30ab0566e06208f42970931ffb4ed25e8 )
 )
 
 game (
@@ -9007,13 +7034,6 @@ game (
 	year "1991"
 	developer "Data East Corporation"
 	rom ( name cninja1.zip size 2317672 crc a6acac18 md5 a3a42d5e675a1c9c4add2d260f7fd339 sha1 d83d07f79417785a9b4040189d082febecdfd6dc )
-)
-
-game (
-	name "Caveman Ninja (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name cninjabl.zip size 2217384 crc 7de87ee7 md5 538547c6100b04fe00a2e370415f2d42 sha1 23f5690c37ebf9ce48d495fa173003b7ce7f2df7 )
 )
 
 game (
@@ -9038,20 +7058,6 @@ game (
 )
 
 game (
-	name "Counter Steer (Japan)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name cntsteer.zip size 109874 crc 1f4377c2 md5 fb7183032add6b15dc6884730c125c7a sha1 e7a5aa04fea70529ed9a3378f41ca1a00d568266 )
-)
-
-game (
-	name "Cobra Command (Data East LD)"
-	year "1984"
-	developer "Data East"
-	rom ( name cobra.zip size 32085 crc 45c49d29 md5 fc1b65a61bb7f11d7615111acedbdf27 sha1 37f00714e60ea5ad92f8cb8607fc1ee22410945c )
-)
-
-game (
 	name "Cobra-Command (World revision 5)"
 	year "1988"
 	developer "Data East Corporation"
@@ -9073,17 +7079,10 @@ game (
 )
 
 game (
-	name "Cobra Command (Sega LaserDisc Hardware)"
-	year "1983"
-	developer "Sega"
-	rom ( name cobraseg.zip size 25880 crc ee5c0496 md5 63f073892c9b0b05768647e02a21c38c sha1 039631d92c67eef8a21c7048427874eb8e76f084 )
-)
-
-game (
 	name "Columns '97 (JET 961209 V1.000)"
 	year "1996"
 	developer "Sega"
-	rom ( name colmns97.zip size 2535930 crc 7b143312 md5 27868c75d0178a4c8db5ea4c622075e7 sha1 f3d3d2b0805eab4d9df2ed12360fc3c5b8748835 )
+	rom ( name colmns97.zip size 5235151 crc ea2412c7 md5 9ed676375f168ab4cca4d29956dfff77 sha1 6a9784240b8834c0ff363bbf0ca65a60365da318 )
 )
 
 game (
@@ -9098,20 +7097,6 @@ game (
 	year "1981"
 	developer "Taito"
 	rom ( name colony7a.zip size 15510 crc 2b0d549f md5 661dff8998106ed8ccf72bd840007ea5 sha1 26f812ca41aa8f8dbc7cd05264009c941060957d )
-)
-
-game (
-	name "Colorama (English)"
-	year "2001"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name colorama.zip size 1771751 crc 34ffa6ae md5 48e30ad9164fb790c351e501c29e8af3 sha1 a46bae5eff8ec3ca3eef5c59aaedd2c52a7ac287 )
-)
-
-game (
-	name "Colt"
-	year "1986"
-	developer "bootleg"
-	rom ( name colt.zip size 123749 crc 27386a24 md5 e1a7ff1bb1a42d0a124301291e4f8f2f sha1 f42e5e9598f8e978a6c3d0ae8c1122c7940c9e9a )
 )
 
 game (
@@ -9157,13 +7142,6 @@ game (
 )
 
 game (
-	name "Combat School (joystick)"
-	year "1988"
-	developer "Konami"
-	rom ( name combatsc.zip size 536697 crc 737e2796 md5 2fd1d3696d9aa56c5deb0bbcee20c01e sha1 86f39b054525498962424cf2af8c422443b42391 )
-)
-
-game (
 	name "Combat School (bootleg)"
 	year "1988"
 	developer "bootleg"
@@ -9185,73 +7163,10 @@ game (
 )
 
 game (
-	name "Combat Hawk"
-	year "1987"
-	developer "Sanritsu / Sega"
-	rom ( name combh.zip size 57206 crc 3b563a57 md5 5f50f040b72bb2eb8a8ce0e3930c3303 sha1 366a8b95d44e7fccdda45669dc2a27b01c26085e )
-)
-
-game (
-	name "Cal Omega - Game 7.4 (Gaming Poker, W.Export)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg074.zip size 11237 crc 0e7ba0ce md5 7e5b0549e0bae999d0a4b35039d720a4 sha1 c20835afe061f47306203ef0bbb401dcc8e40ccf )
-)
-
-game (
 	name "Cal Omega - Game 7.6 (Arcade Poker)"
 	year "1981"
 	developer "Cal Omega Inc."
 	rom ( name comg076.zip size 10767 crc 941f06ce md5 3fe80555c99a10b46af848f6b9097355 sha1 a879dc2ffa18c5fd9ea2cced7a093ba4db32374e )
-)
-
-game (
-	name "Cal Omega - Game 7.9 (Arcade Poker)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg079.zip size 12238 crc ba34d239 md5 a65116b1ff8c226e1be85f10c9ee1cde sha1 3e9c60cc3f0c70fa12eeb411f602af7edaee2622 )
-)
-
-game (
-	name "Cal Omega - Game 8.0 (Arcade Black Jack)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg080.zip size 9969 crc 339d118d md5 a29c2866dbc817e4383f2cca043f09ee sha1 e8fb045fe0b1a38e408a0eb167f8fcdef7fb0738 )
-)
-
-game (
-	name "Cal Omega - Game 9.4 (Keno)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg094.zip size 7032 crc ad655df6 md5 425a2ee9b038b9d6b639880356c30efa sha1 b624b2aea6e95e52ea191c12c7355f0cfc39022f )
-)
-
-game (
-	name "Cal Omega - Game 10.7c (Big Game)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg107.zip size 8937 crc 758e99cf md5 ad29f47b6057b0241b1048a30de1e1fe sha1 4d20239a83baeaab598e0998d8e48be829aad1c1 )
-)
-
-game (
-	name "Cal Omega - Game 12.3 (Ticket Poker)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg123.zip size 10703 crc 17855223 md5 d914ee1c49dbdb1ba12a4aff276ddad3 sha1 3ab0731c83ea81f645e5e75436ea0a35104dc9a8 )
-)
-
-game (
-	name "Cal Omega - Game 12.5 (Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg125.zip size 9725 crc 26bafb56 md5 947ad970c557e281b1aadf4c5a579050 sha1 aa4e5fde433abe10745dcc57fc02dc95f86e1dc6 )
-)
-
-game (
-	name "Cal Omega - Game 12.7 (Keno)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg127.zip size 7028 crc 04262b95 md5 155c89e6bbaf49b657864190b50545e3 sha1 cacf93fd315667b30a6293c6d3fd38d6f4cb59e2 )
 )
 
 game (
@@ -9262,136 +7177,10 @@ game (
 )
 
 game (
-	name "Cal Omega - Game 13.4 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg134.zip size 9707 crc 920b097e md5 d00886c7927ff1815c43942efebb2d63 sha1 8d514eba2112cc5e0adb74a719005808f6909979 )
-)
-
-game (
-	name "Cal Omega - Game 14.5 (Pixels)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg145.zip size 11909 crc c1aad10e md5 1f53404c06d1b5a4593b4e8f5ab67fd4 sha1 c3c7e885a2d048022693b03061b759d500cd8c1c )
-)
-
-game (
-	name "Cal Omega - Game 15.7 (Double-Draw Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg157.zip size 12671 crc 88ae08a9 md5 0ccdb436a8151eab4322b994b2441b01 sha1 2e78ddc3fe1cc804846059ad4b6933ed1a4e4f20 )
-)
-
-game (
-	name "Cal Omega - Game 15.9 (Wild Double-Up)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg159.zip size 12883 crc 1de913c6 md5 f02bcb9f305958a49206e0861f5da56e sha1 fa95755b9b04f4b9d5461535435c7075571e4867 )
-)
-
-game (
-	name "Cal Omega - Game 16.4 (Keno)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg164.zip size 7790 crc ec527c0f md5 8d5187fc9da53185fb1c370fe04f688d sha1 733db447c48d91bcbed5bd94843b326baa62b1f3 )
-)
-
-game (
-	name "Cal Omega - Game 16.8 (Keno)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg168.zip size 6979 crc 6d78036f md5 4a8814aefd245f011b74b996a4cf9227 sha1 2e3ff85226423a54503d0826e7dbde6e31252183 )
-)
-
-game (
-	name "Cal Omega - Game 17.2 (Double Double Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg172.zip size 13283 crc 9df1eb1d md5 b72d2dd25f5e84fc389e6a88acd8288e sha1 95c8dbb564c7ceb384b369c8e0c810fd2653685e )
-)
-
-game (
 	name "Cal Omega - Game 17.51 (Gaming Draw Poker)"
 	year "1984"
 	developer "Cal Omega / Casino Electronics Inc."
 	rom ( name comg175.zip size 12594 crc b44fdb21 md5 76e0d09cf85fd61e517ca1250213c7be sha1 c9cc0a338567e6f3fb1737f961d663dace56004e )
-)
-
-game (
-	name "Cal Omega - Game 17.6 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg176.zip size 9922 crc 6019ed01 md5 d663fc606f869961207370135f60d132 sha1 1fe135832d015d05349891c46c35f5ce493c983e )
-)
-
-game (
-	name "Cal Omega - Game 18.1 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg181.zip size 9770 crc 7cfb3b5d md5 fc1b11727f9d8ff9ec0bf8aff36d3110 sha1 3f85ec0f559218489c9ce6dc0da4a98ebdf87862 )
-)
-
-game (
-	name "Cal Omega - Game 18.3 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg183.zip size 13151 crc 19905488 md5 37a519af701656c6643546c5de491ffb sha1 bbe21f35b53cb9445a7591f50f7d27cbf3e0a757 )
-)
-
-game (
-	name "Cal Omega - Game 18.5 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg185.zip size 14952 crc f5036012 md5 3800805b2f8942a1cc9e3c388d892fb1 sha1 79a3a26442d4bf76366df09a889000e8318d98e3 )
-)
-
-game (
-	name "Cal Omega - Game 18.6 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg186.zip size 13271 crc eeea2740 md5 ae869f0f9577b0856f916d827977c442 sha1 9af9fa256625f160e523251a4b44ed787c6d5402 )
-)
-
-game (
-	name "Cal Omega - Game 18.7 (Amusement Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg187.zip size 13315 crc d985bbc7 md5 8978a4fb9ca30474c7293e13f1929c93 sha1 62fd6461579b486b93b4895fb9837bf2cbaf3fcb )
-)
-
-game (
-	name "Cal Omega - Game 20.4 (Super Blackjack)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg204.zip size 18499 crc 21e0e8c2 md5 44dc25e96f967633f3f5292314ce8edf sha1 4eb850119d37eac43469d3ba463e39b6e7f035f5 )
-)
-
-game (
-	name "Cal Omega - Game 20.8 (Winner's Choice)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg208.zip size 21871 crc f54403fb md5 f21973805a082af2a5e598e1e0822cfb sha1 f6c2197bbc8cf3d4f930b21ee36dbc5fec5f1829 )
-)
-
-game (
-	name "Cal Omega - Game 22.7 (Amusement Poker, d/d)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg227.zip size 12345 crc 8ffc9c9c md5 ccd5b89826ca98c555e6e45f7791bb83 sha1 47b886f521e3865e27cf1b3a2d37ec2fa7859ecd )
-)
-
-game (
-	name "Cal Omega - Game 23.0 (FC Bingo (4-card))"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg230.zip size 8114 crc 664631d7 md5 2231a329734d1255822a06e2ddf59ed2 sha1 881a33390b9df9d52cc784199bcd51470e04658d )
-)
-
-game (
-	name "Cal Omega - Game 23.6 (Hotline)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg236.zip size 14607 crc 3c60f5f9 md5 452b4ba3e2f5f18fc1afe9188fbf916c sha1 dbb12500e0fb9618843e7145a451e3ef4ec35bb0 )
 )
 
 game (
@@ -9402,50 +7191,10 @@ game (
 )
 
 game (
-	name "Cal Omega - Game 24.6 (Hotline)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg246.zip size 14998 crc 5aeac3ee md5 2e856b8fb5f3b8e1bea5e607634ffe1d sha1 a12f439bf777914080f6810ad1814abca166d0fc )
-)
-
-game (
-	name "Cal Omega - Game 27.2 (Keno, amusement)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg272a.zip size 7024 crc b0e49d89 md5 552231d7ebd498bc256a244f2e75a203 sha1 e225cc33506b21dab891d20268f939bee8d3b16b )
-)
-
-game (
-	name "Cal Omega - Game 27.2 (Keno, gaming)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg272b.zip size 7620 crc 52543873 md5 57c47eeed8e1a2e302445bc836ea85b9 sha1 1d3b314b2334e30a3eec0a3312d85f99d1f6fdb6 )
-)
-
-game (
-	name "Cal Omega - System 903 Diag.PROM"
-	developer "Cal Omega Inc."
-	rom ( name comg903d.zip size 2980 crc a01be3a2 md5 ff54feac3016b19eb845c54b65b53908 sha1 074da12a6a37cc4dce08a5a5b9b79febedbc0b7b )
-)
-
-game (
-	name "Cal Omega - System 905 Diag.PROM"
-	developer "Cal Omega Inc."
-	rom ( name comg905d.zip size 4725 crc b0c6223b md5 76cb56ae8a53629e954b280ad9edbe8a sha1 265f09e77067463c455766e0b8e2fb97f7c1ff2e )
-)
-
-game (
 	name "Commando (World)"
 	year "1985"
 	developer "Capcom"
 	rom ( name commando.zip size 135332 crc fa4bac04 md5 84b2cf3dd2393c8c6cc13caa6440f4c3 sha1 1af11df9f2ccdc33564f606db8cef4c586b03f2a )
-)
-
-game (
-	name "Commando (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name commandob.zip size 135368 crc 31907663 md5 5f40db47a810d2520b03094ff1d64aca sha1 849488c03726481a8f9c81a8b67d9b79e64230a2 )
 )
 
 game (
@@ -9512,13 +7261,6 @@ game (
 )
 
 game (
-	name "Confidential Mission (GDS-0001)"
-	year "2001"
-	developer "Sega"
-	rom ( name confmiss.zip size 1193 crc 98a3cadc md5 4a40598e228949a16cbac3326079c47c sha1 7f592dc72ca8f6b42f81e827f61d804ac52e2096 )
-)
-
-game (
 	name "Congo Bongo"
 	year "1983"
 	developer "Sega"
@@ -9529,13 +7271,6 @@ game (
 	name "Connect 4"
 	developer "Dolbeck Systems"
 	rom ( name connect4.zip size 17836 crc 5639ae8a md5 f8197ef2a86b6dd457c25630d12a84b4 sha1 53d5d4f13ea522c694fc4c349d7a3ea43dfe2ca1 )
-)
-
-game (
-	name "Conquer"
-	year "1982"
-	developer "&lt;unknown&gt;"
-	rom ( name conquer.zip size 15424 crc 7a19c643 md5 cb38dd56f8b0452c3ca8313d7b3e1666 sha1 91833d5a1e09a9b2b794388685a3092069390716 )
 )
 
 game (
@@ -9560,20 +7295,6 @@ game (
 )
 
 game (
-	name "Contra (US, Set 1)"
-	year "1987"
-	developer "Konami"
-	rom ( name contra.zip size 388410 crc 3d1478a8 md5 ee1ba16d382481b9158c4d85e23c4e47 sha1 20f9644b22773cc1e45f8bf18750faf54cd1884c )
-)
-
-game (
-	name "Contra (US, Set 2)"
-	year "1987"
-	developer "Konami"
-	rom ( name contra1.zip size 388400 crc b5e6223e md5 c0552568fceab7bb2b59f25aa992ac36 sha1 ce440f3aa7b22dc09f79de87096feae4aebbf749 )
-)
-
-game (
 	name "Contra (bootleg)"
 	year "1987"
 	developer "bootleg"
@@ -9581,38 +7302,10 @@ game (
 )
 
 game (
-	name "Contra (Japan)"
-	year "1987"
-	developer "Konami"
-	rom ( name contraj.zip size 388471 crc 83841d3e md5 9a0cbfc01ab0a41f200673f50659270b sha1 01742dd591f8e1c29bc62e710c7444ba47d6d268 )
-)
-
-game (
 	name "Contra (Japan bootleg)"
 	year "1987"
 	developer "bootleg"
 	rom ( name contrajb.zip size 373785 crc ce9e6fde md5 c69e1c60865d4822680802dbc80bbf14 sha1 84c23f8d25c5f7040b6e519af645368ec015e172 )
-)
-
-game (
-	name "Cookie _ Bibi"
-	year "1995"
-	developer "SemiCom"
-	rom ( name cookbib.zip size 342327 crc 97dea0ac md5 41965c465e6bbf17dd4742b1b4086f04 sha1 cfd3d80bdf61705dfc7039ae92e922935d991b64 )
-)
-
-game (
-	name "Cookie _ Bibi 2"
-	year "1996"
-	developer "SemiCom"
-	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
-)
-
-game (
-	name "Cookie _ Bibi 3"
-	year "1997"
-	developer "SemiCom"
-	rom ( name cookbib3.zip size 846012 crc b25ea726 md5 08d84864359d554308c0d542f2bba183 sha1 4793eb59e453b5e8d72eff74dfed1538fe467610 )
 )
 
 game (
@@ -9637,13 +7330,6 @@ game (
 )
 
 game (
-	name "Cool Riders (US)"
-	year "1995"
-	developer "Sega"
-	rom ( name coolridr.zip size 44572286 crc c4dec29e md5 b711067a5a95e62ed76903e8f098eafc sha1 51a824c71b13fabd038e3e6d33b69737cbed9dde )
-)
-
-game (
 	name "Cop 01 (set 1)"
 	year "1985"
 	developer "Nichibutsu"
@@ -9655,13 +7341,6 @@ game (
 	year "1985"
 	developer "Nichibutsu"
 	rom ( name cop01a.zip size 70085 crc e6c19028 md5 54f2ce4dd52c64bc17f3beedd768b56b sha1 b79b860c20e50ef9e6dd422f197e7c2c094bddf4 )
-)
-
-game (
-	name "Cops'n Robbers"
-	year "1976"
-	developer "Atari"
-	rom ( name copsnrob.zip size 5679 crc 6ac18272 md5 0199eebff107ffc27dfacb314b304f61 sha1 89b071ba7e243eb6e92c6be14cdb28ad2095adcb )
 )
 
 game (
@@ -9697,13 +7376,6 @@ game (
 	year "1979"
 	developer "Universal"
 	rom ( name cosmica1.zip size 11303 crc d420e7c9 md5 c60863df6532f04bc18860fbd1403bc1 sha1 7df16681f2539adb878a8fb0281ca6af1e648b68 )
-)
-
-game (
-	name "Cosmic Alien (early version II?)"
-	year "1979"
-	developer "Universal"
-	rom ( name cosmica2.zip size 12383 crc 8fb16d59 md5 6559277b0fe726f5c440d59f3cc19ddc sha1 5b27c049d877e082fb6aa7ee8667e32fa9e4b6b9 )
 )
 
 game (
@@ -9766,14 +7438,14 @@ game (
 	name "Cotton 2 (JUET 970902 V1.000)"
 	year "1997"
 	developer "Success"
-	rom ( name cotton2.zip size 15192373 crc 9e20eda6 md5 bf2c99ab9adef7f50449c3d04a57994b sha1 c6034038173fd0b506f80ec2a9502b8d8cd0bf16 )
+	rom ( name cotton2.zip size 17891594 crc 0b7bc16c md5 e42357bbd92f808d22d4420e6e7a721a sha1 9b678355d760786c92a60740ba3dce653e3c7f2e )
 )
 
 game (
 	name "Cotton Boomerang (JUET 980709 V1.000)"
 	year "1998"
 	developer "Success"
-	rom ( name cottonbm.zip size 13676832 crc f8addeee md5 39e54818f4ff09c8b6505debdd385d69 sha1 77a33222476f8d35b1644764b609df06a8c17ccc )
+	rom ( name cottonbm.zip size 16376053 crc 3b1858b4 md5 965ea7f5a6d625427cfb5f9840d10948 sha1 d9b4941ba2130d6d348cd594a6b2d188b48991bf )
 )
 
 game (
@@ -9798,13 +7470,6 @@ game (
 )
 
 game (
-	name "Counter Run"
-	year "1988"
-	developer "Nihon System (Sega license)"
-	rom ( name countrun.zip size 45649 crc 99365d7e md5 ed2c2b648bb2e154739ae8ab42f87d45 sha1 d4a7c3c0d581e6376ffae306a9621a189b8003e8 )
-)
-
-game (
 	name "Counter Run (bootleg set 1)"
 	year "1988"
 	developer "bootleg"
@@ -9812,45 +7477,10 @@ game (
 )
 
 game (
-	name "Counter Run (bootleg set 2)"
-	year "1988"
-	developer "bootleg"
-	rom ( name countrunb2.zip size 66867 crc 1a79919d md5 1663e286c776c0bdb8b705f2d873a864 sha1 6471fda8a1eab42aeb62b4f6153806b35a60a8a6 )
-)
-
-game (
 	name "Country Club"
 	year "1988"
 	developer "SNK"
 	rom ( name countryc.zip size 113057 crc f39a381d md5 3a4c86108e38acf091557a57619ea6ac sha1 c1dfe7c35a012c0321f90f4b132e35840d7d85b1 )
-)
-
-game (
-	name "The Couples (Set 1)"
-	year "1988"
-	developer "Merit"
-	rom ( name couple.zip size 53983 crc 128e4e73 md5 e2aaa5235207ccf22e771a1f8c69ff5b sha1 7aff661949da7f9e2d234f59fa550d42f5b0a013 )
-)
-
-game (
-	name "The Couples (Set 3)"
-	year "1988"
-	developer "Merit"
-	rom ( name couplei.zip size 53937 crc 2cd8999e md5 c25acf7c3e676d66c2f7a85a44eff6f6 sha1 86f5df7efadf327d98952de953111ed96e06a7a4 )
-)
-
-game (
-	name "The Couples (Set 2)"
-	year "1988"
-	developer "Merit"
-	rom ( name couplep.zip size 54054 crc e510ca33 md5 05072c4ed84b4b371c12bb9f98fd3c52 sha1 a57d0c6195e259dba4d9bfed0fb3a25b8125d9ff )
-)
-
-game (
-	name "Cow Race (1986 King Derby hack)"
-	year "2000"
-	developer "bootleg"
-	rom ( name cowrace.zip size 129620 crc eeb04708 md5 116f335fff20602581d08f3625ebfd37 sha1 d8ecbbdf10e75349478b0060f7b415786ced056f )
 )
 
 game (
@@ -9866,12 +7496,6 @@ game (
 )
 
 game (
-	name "Champion Italian PK (bootleg, green board)"
-	developer "bootleg (SGS)"
-	rom ( name cpokerpkg.zip size 336734 crc c5eb5d92 md5 7d85452305941d6d19caf63e36188041 sha1 442659a63810c2bd8c6eaa36b8ec0918adba0bd2 )
-)
-
-game (
 	name "Champion Poker (v200G)"
 	developer "IGS (Tuning license)"
 	rom ( name cpokert.zip size 154764 crc 03fa655a md5 3fbc9c04d44d9b2b606d6aebd726b6be sha1 4a5efd3d7f713775bc3cfdfc7686cf4c6cbefa4e )
@@ -9881,49 +7505,56 @@ game (
 	name "Peter Pepper's Ice Cream Factory (Cassette, set 1)"
 	year "1984"
 	developer "Data East Corporation"
-	rom ( name cppicf.zip size 21599 crc 65f88851 md5 4af2b959c3457b9cc658149f20d979e7 sha1 51829bc8c37e51be9b927de605f159eb69e9b896 )
+	rom ( name cppicf.zip size 32000 crc 97b6693c md5 8b5d3075838336d2b7a1c1506a7a3439 sha1 c93c50864504758db8163a0fb46b054b678d14b5 )
 )
 
 game (
 	name "Peter Pepper's Ice Cream Factory (Cassette, set 2)"
 	year "1984"
 	developer "Data East Corporation"
-	rom ( name cppicf2.zip size 21645 crc 6428cc09 md5 2ed97c90983fc4755ae65d8dc74dc55d sha1 419c712cd6543ccb199f0796d81ba7cc04f26ed2 )
+	rom ( name cppicf2.zip size 32046 crc 14cd9d26 md5 c783ae9dea237ab2a9987b44f58a72ee sha1 29953f385c16613036dad01ae40819aa1522f6de )
 )
 
 game (
 	name "Pro Bowling (Cassette)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cprobowl.zip size 17795 crc 0fd9cb6f md5 b6e8383466e74628e2e58de8124a8aca sha1 3cded2585fe6ffd83d667c0a2cdcca513ddd5ec3 )
+	rom ( name cprobowl.zip size 28196 crc c6af4438 md5 3d3c390fc25d7f9fb364b9d23372eae5 sha1 04edf35e70ef304b71b63b19a40f1d19796d9d69 )
 )
 
 game (
 	name "Tournament Pro Golf (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name cprogolf.zip size 15932 crc 89050266 md5 7cb5dfaf70c8216bd9a273fcc0b31c0e sha1 5c16252e4c3e104f1abd78e163f2a5ed5ab6608b )
+	rom ( name cprogolf.zip size 26333 crc 99a1c3a7 md5 127868e4b9459703b687a899315209d0 sha1 63cf0f043c5cf7bd8ae94993da8bcd752a1fa64e )
 )
 
 game (
 	name "Pro Soccer (Cassette)"
 	year "1983"
 	developer "Data East Corporation"
-	rom ( name cprosocc.zip size 23922 crc 8b6a307e md5 cd4f0797ea49a03b46a8e76921ebf8ef sha1 55956c4c791972c70be39e568364ad2cea44bf0c )
+	rom ( name cprosocc.zip size 34323 crc 69285ad6 md5 641c1ee10768c23b0b142a20bd142a3b sha1 d5f447d19dcd0958de2611c96c169702e95d41f4 )
 )
 
 game (
 	name "Pro Tennis (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name cptennis.zip size 13544 crc 93143b31 md5 9f37f91e3a96256621bd7cd0223f45f9 sha1 109aa2bce463d699405d0d0d32a9357e9bd4aa38 )
+	rom ( name cptennis.zip size 23945 crc 80901326 md5 619d9ea3b1892f2c448e17c799aa2171 sha1 ebe6f844f2e46e1a349b663e17b345962ea13b13 )
 )
 
 game (
-	name "Crackin' DJ"
-	year "2000"
-	developer "Sega"
-	rom ( name crackndj.zip size 103939119 crc fd8bc350 md5 80cbd085c54eac02454b8def3af4701a sha1 93572ea3c4712400a9a09a02a7765bae666ac2a5 )
+	name "CD-ROM Drive Updater 2.0 (700B04)"
+	year "1999"
+	developer "Konami"
+	rom ( name cr589fw.zip size 63328 crc 695dd76d md5 07fe45624cbf62d00e3cefb88770c6c4 sha1 9d2f6da3639a789a5ab53b6010670c39ed6941f7 )
+)
+
+game (
+	name "CD-ROM Drive Updater (700A04)"
+	year "1999"
+	developer "Konami"
+	rom ( name cr589fwa.zip size 63328 crc 695dd76d md5 07fe45624cbf62d00e3cefb88770c6c4 sha1 9d2f6da3639a789a5ab53b6010670c39ed6941f7 )
 )
 
 game (
@@ -9962,20 +7593,6 @@ game (
 )
 
 game (
-	name "Crazy Fight"
-	year "1996"
-	developer "Subsino"
-	rom ( name crazyfgt.zip size 1570605 crc ef867d42 md5 e1a5b5a71e72e7db8b340401b2ecb0aa sha1 3c3b9a8f54c9c9ee9c2aa3d4a6b833765aeb1105 )
-)
-
-game (
-	name "Crazy War"
-	year "2002"
-	developer "Eolith"
-	rom ( name crazywar.zip size 12682336 crc 0da6e2b1 md5 71fc6380adc8fc98186161af0f00ac56 sha1 525b44d4a69edbf9d787e95400fd91131f1342ea )
-)
-
-game (
 	name "Crazy Balloon (set 1)"
 	year "1980"
 	developer "Taito Corporation"
@@ -9987,20 +7604,6 @@ game (
 	year "1980"
 	developer "Taito Corporation"
 	rom ( name crbaloon2.zip size 11123 crc b2f99dff md5 79b852a64fa796dc2c90781deb04812c sha1 0e470447bc1d91d1357217fa70b0e21a6c75c1bc )
-)
-
-game (
-	name "Crowns Golf (834-5419-04)"
-	year "1984"
-	developer "Nasco Japan"
-	rom ( name crgolf.zip size 48587 crc 512e0094 md5 3a13536a8d6577c0beec45f831e4840f sha1 44ed1b8d429eed892b8143d61902e1f3de3426e4 )
-)
-
-game (
-	name "Crowns Golf (834-5419-03)"
-	year "1984"
-	developer "Nasco Japan"
-	rom ( name crgolfa.zip size 48446 crc d0539b73 md5 08439967c5e3b4aa50db540740789674 sha1 8ba14a3610238f4c150e6691a28bde1a78e64283 )
 )
 
 game (
@@ -10053,27 +7656,6 @@ game (
 )
 
 game (
-	name "Crime Patrol 2: Drug Wars v1.3"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimep2.zip size 62957 crc a04290c3 md5 37801632e64270838c0435d3018f2365 sha1 3fe0d794b6c241702a0df80035a0d83ca726408a )
-)
-
-game (
-	name "Crime Patrol 2: Drug Wars v1.1"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimep211.zip size 62227 crc 30e96206 md5 e3f00d6c7692232a27f09530e4a95bee sha1 32102a215216372eb4a9995f8b03e04343fbdd48 )
-)
-
-game (
-	name "Crime Patrol v1.4"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimepat.zip size 64047 crc 3d55fb8b md5 d74f79d25cd7bfdcb12bc9a975377990 sha1 ccaca1963b287dc986d80169c42a09c01566e8a7 )
-)
-
-game (
 	name "Crime Fighters (US 4 players)"
 	year "1989"
 	developer "Konami"
@@ -10095,17 +7677,10 @@ game (
 )
 
 game (
-	name "Criss Cross (Sweden)"
-	year "1986"
-	developer "JPM"
-	rom ( name crisscrs.zip size 18194 crc 563bf3b4 md5 4a8fdaca74d34421531843ca1539e064 sha1 ef5bf8f27a9daa1e69a44678276d250357a02b9c )
-)
-
-game (
 	name "Critter Crusher (EA 951204 V1.000)"
 	year "1995"
 	developer "Sega"
-	rom ( name critcrsh.zip size 5245622 crc 0eeda057 md5 da396476429a54e05c7d36be0774b588 sha1 79794c2e4afb312c11799fe47c8ed4b6f7b82617 )
+	rom ( name critcrsh.zip size 7944843 crc 3ab1c0b4 md5 4d1ff11859d1287f605841fb051245f9 sha1 b31719cb8bf58ac334d0d3730d55ec10167ef389 )
 )
 
 game (
@@ -10127,69 +7702,6 @@ game (
 	year "1989"
 	developer "Sega"
 	rom ( name crkdownu.zip size 945216 crc 37198b99 md5 133cd434cfd0447a613eb6579939451f sha1 1560d2462e46ace1e72dd3f689fe02ea9ae1963f )
-)
-
-game (
-	name "The Crystal Maze (v1.3)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze.zip size 2718918 crc 8d463d01 md5 a0b20e342941a2502aeaff32089d52ac sha1 8511c42b5b3b77ca63bcbc34ff759e6ece5f40fa )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v2.2)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2.zip size 1905063 crc cfa310b7 md5 77cd0f0c5252d73ae840eab69d02af6c sha1 a847eb5eece85207a3c7b0ed369e43c005cb3871 )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v0.1, AMLD)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2a.zip size 1895494 crc 3fcbe465 md5 5053f17077f4219ce6946878f473abd8 sha1 f6bd2f36cc0d0720620fa364014fa1a6b95358bf )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v2.2d)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2d.zip size 1905064 crc 82435c33 md5 6c14dda654d86e997fe36a16f015d0b8 sha1 ce6225b24240a695565636d86bfca676393f3422 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v0.9)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3.zip size 1911772 crc f7514bb1 md5 64f545b51a5004efe427b5b977000f60 sha1 25163b2d185a980a72094dc5c975379b4a888ab1 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v1.2, AMLD)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3a.zip size 1916171 crc e49f5f62 md5 0df35eff77fd3fbb435ff9a2c10e04b0 sha1 2638374c7e918529958a28be8519c63bb7734995 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v0.9, Datapak)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3d.zip size 1911775 crc 4f381b85 md5 c2fa0c71ad9328a2a4774107519bb44f sha1 5c27a5397a0c86945afcd4cef40b53564931237a )
-)
-
-game (
-	name "The Crystal Maze (v0.1, AMLD)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmazea.zip size 2674582 crc d501f548 md5 369463d6c75abcf15b1e14de2a81d8dd sha1 b0bd52d46dc73d2f5297a62d8796bbf93340670c )
-)
-
-game (
-	name "The Crystal Maze (v1.3, Datapak)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmazed.zip size 2718920 crc 3b6f0ae7 md5 80eade7cfae940846342a642e65ba58b sha1 82462dfd5e49850412d71fdb898190a0b55ca809 )
 )
 
 game (
@@ -10221,13 +7733,6 @@ game (
 )
 
 game (
-	name "Poker Carnival"
-	year "1991"
-	developer "Subsino"
-	rom ( name crsbingo.zip size 59323 crc bf514419 md5 8c9f8a769f852de3fff6b15842535833 sha1 cdac4d35379322cf6c1a9c4c01907e2791b67b70 )
-)
-
-game (
 	name "Lethal Crash Race (set 1)"
 	year "1993"
 	developer "Video System Co."
@@ -10245,14 +7750,7 @@ game (
 	name "Crossed Swords"
 	year "1991"
 	developer "Alpha Denshi Co."
-	rom ( name crsword.zip size 2724948 crc e157a16a md5 84bac100e9bb85fbacfe8c8505ea34db sha1 e867d2964d9bcc9eeb6483a943aa5acb85b7ba6d )
-)
-
-game (
-	name "Crisis Zone (CSZO3 Ver. B)"
-	year "2000"
-	developer "Namco"
-	rom ( name crszone.zip size 60082757 crc c1d966ab md5 c32841f242f48774665d2508414367f2 sha1 4c53868ce25fbf82fa56852f2cd16d9da08707d7 )
+	rom ( name crsword.zip size 4071635 crc ac279ddc md5 a53c3426bad6a1853f58b070679b6d82 sha1 4e94bd32fbf90f2ebc2533df8c3430197f7129b9 )
 )
 
 game (
@@ -10317,34 +7815,6 @@ game (
 )
 
 game (
-	name "Cruis'n Exotica (version 2.4)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexo.zip size 42826650 crc 6f7074c4 md5 09d225c9ed514752fb656e4d55372666 sha1 1dec5ad9162627347c213ec780aa9e8c0d3bd220 )
-)
-
-game (
-	name "Cruis'n Exotica (version 2.0)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexoa.zip size 42826506 crc 8ddc450b md5 b8fa24026bcb378bdc1ecb8739bf3590 sha1 eb961e0d01b8a0ef1747116e4f406f946f1d7fd4 )
-)
-
-game (
-	name "Cruis'n Exotica (version 1.6)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexob.zip size 42825205 crc 8a1ce399 md5 5dd0163bf2d29330b0a9f63407bf9653 sha1 bc495a0653d0c92fbbbf0d4f0ed1fc7ef6dc4edc )
-)
-
-game (
-	name "Cruis'n USA (rev L4.1)"
-	year "1994"
-	developer "Midway"
-	rom ( name crusnusa.zip size 11277901 crc dc92d005 md5 b60f7571b1c48d2c2a2ebee557d0c25c sha1 31a02b25028c17602de4e9e1a10a9a27244c47aa )
-)
-
-game (
 	name "Cruis'n USA (rev L2.1)"
 	year "1994"
 	developer "Midway"
@@ -10404,7 +7874,7 @@ game (
 	name "The Crystal of Kings"
 	year "2001"
 	developer "BrezzaSoft"
-	rom ( name crysking.zip size 38605431 crc 2dd41ed5 md5 697290638192db2fcb8d0e77c9dc8313 sha1 e94e5c439e6b9e6e9a80274daf8ab7313dd4ccf8 )
+	rom ( name crysking.zip size 38648889 crc 994c90a9 md5 c4be82779e400bd7c79d95920b9a9ba3 sha1 236eb7eb88a8e7fd36f28ee1158263a9867edb4d )
 )
 
 game (
@@ -10457,31 +7927,10 @@ game (
 )
 
 game (
-	name "Crazy Rally (set 1)"
-	year "1985"
-	developer "Tecfri"
-	rom ( name crzrally.zip size 58840 crc 393d1ceb md5 c7c6fe20f661faf0ec7a93009fc33edc sha1 26981eee4b60477f6d3647b8444a3043a6a3998a )
-)
-
-game (
-	name "Crazy Rally (set 2)"
-	year "1985"
-	developer "Tecfri"
-	rom ( name crzrallya.zip size 58894 crc e3676f47 md5 98c7ecbc53b527dd5224bfc292919641 sha1 23c58116adda135fa834cc23487efa36ae3428fc )
-)
-
-game (
 	name "Crazy Rally (Gecas license)"
 	year "1985"
 	developer "Tecfri (Gecas license)"
 	rom ( name crzrallyg.zip size 58759 crc 6f761cd3 md5 80b8ae7b656813590d2c81a661479c27 sha1 d76d259554621786d89b198cc10cfa58f2a890a3 )
-)
-
-game (
-	name "Crazy Taxi (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name crzytaxi.zip size 55999707 crc 724b1303 md5 cb12e129efc3005a76daeb18bc025dd2 sha1 d7836734b4e083f17f9fa06da6eec99cd70f7569 )
 )
 
 game (
@@ -10523,49 +7972,14 @@ game (
 	name "Scrum Try (Cassette, set 1)"
 	year "1984"
 	developer "Data East Corporation"
-	rom ( name cscrtry.zip size 28217 crc 203ddcf2 md5 0ff6a2835716e4368c1b980472f4ccfa sha1 f39c9d763b9014ac3bae29f10c720d80a35d390a )
+	rom ( name cscrtry.zip size 38618 crc 91cf322b md5 625aea5e155d601e4f59af695f3d703b sha1 93a36e447510f17247c6bd29cc63321994777467 )
 )
 
 game (
 	name "Scrum Try (Cassette, set 2)"
 	year "1984"
 	developer "Data East Corporation"
-	rom ( name cscrtry2.zip size 28087 crc 4cb8759b md5 a9d558ac152d4d983468586a70d6043d sha1 ba96d873f598cd284ebfee5c9dc4663660c7d356 )
-)
-
-game (
-	name "Chicken Shift"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name cshift.zip size 43315 crc 7c6abca8 md5 de1ee67a321e96e354c0618228bfe451 sha1 618c93be227f68390501e771d806d291cb271eb9 )
-)
-
-game (
-	name "Cross Shooter (not encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu (Taito license)"
-	rom ( name cshooter.zip size 43638 crc 480864cf md5 1f94c6bd5dd2b1075e92823fb12cee35 sha1 ca6e55c9d34531284497663d2fa8406f375e8d2b )
-)
-
-game (
-	name "Cross Shooter (encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu (J.K.H. license)"
-	rom ( name cshootere.zip size 50811 crc 71f79d75 md5 d8b5aa51b8729a7f9ad17f5ab6fc4dce sha1 c3ab0ae3345270aceb9f75cc7162e15e28206ddf )
-)
-
-game (
-	name "Captain Silver (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name csilver.zip size 403065 crc cdbcd8a3 md5 9396631f721ab08913e6c430857b331c sha1 e510c6c0c8c7755351b5c3d1d557c46ab504cf86 )
-)
-
-game (
-	name "Captain Silver (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name csilverj.zip size 400952 crc 5962214d md5 b697fb405697a8f8519e87e73fbe01f2 sha1 87c3b265298d68a3bb2246680ab83f8c2073f531 )
+	rom ( name cscrtry2.zip size 38488 crc 67d87185 md5 bbd57d14e1fbce475e917f890cbdb180 sha1 bc7e54b57c3023489579245fab836ba4c4439172 )
 )
 
 game (
@@ -10578,27 +7992,6 @@ game (
 	name "Champion Skill (Ability, Poker _ Symbols)"
 	developer "IGS"
 	rom ( name csk234it.zip size 155876 crc f53e290a md5 f43814c49bd2cf7fefb57d3b58817051 sha1 6d2f709920b79ef09a9e73fbf2194122b3c4e077 )
-)
-
-game (
-	name "Cosmic Smash (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2001"
-	developer "Sega"
-	rom ( name csmash.zip size 35525841 crc c8781b8f md5 e2c2127dc12c9ec331bfadfae90feea9 sha1 d75e9ad69de5f7c2723e8d52017e1335f9794956 )
-)
-
-game (
-	name "Cosmic Smash (JPN, USA, EXP, KOR, AUS) (original)"
-	year "2001"
-	developer "Sega"
-	rom ( name csmasho.zip size 35525804 crc 3072bc84 md5 ee38160967d6c2cb840ddcb3d4f1cc46 sha1 0b39dec5f7899e87145647eec2ffaebd2b51546a )
-)
-
-game (
-	name "Gun Spike (JPN) / Cannon Spike (USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Psikyo / Capcom"
-	rom ( name cspike.zip size 57347306 crc e11a5991 md5 f871cf616d61d1ddb983447cf2a6103c sha1 1fbfc2c9a057d768078df9d34604d965c0d89b11 )
 )
 
 game (
@@ -10665,87 +8058,73 @@ game (
 )
 
 game (
-	name "Casino Strip XI"
-	year "1990"
-	developer "Status Games"
-	rom ( name cstripxi.zip size 7814 crc baaa8f0e md5 8fcad99e334447163c2ac688dbd9d0c0 sha1 e2ad6fb1a468ca0d526d43464df0870b82f791af )
-)
-
-game (
 	name "Super Astro Fighter (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name csuperas.zip size 16405 crc b7fb3934 md5 4ed4b426189e5f38f127a999a2aa7908 sha1 0337b84b3f623efa234cd5fd346d8299a3e35eb5 )
+	rom ( name csuperas.zip size 26806 crc b86bbd0c md5 a26dfb1f0e06b0213bc909922052c8eb sha1 12fa36a8b812bc896c1ec0a00ae1e5ab1132a590 )
 )
 
 game (
 	name "Sweet Heart (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name csweetht.zip size 17865 crc 964407de md5 638bdb8349ad3581dc2c3036ab591ad2 sha1 6a293b26a210f627232c4e78d24b859d7e3f6e37 )
+	rom ( name csweetht.zip size 28266 crc 56552f80 md5 f7ed52f393cee9f334cf606e7993db3d sha1 ad93ee71e42780cc5f2d85467f82590eb6391ec0 )
 )
 
 game (
 	name "Crouching Tiger Hidden Dragon 2003 Super Plus alternate (The King of Fighters 2001 bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name ct2k3sa.zip size 40193722 crc 09906ea6 md5 a59d1b0b0004cbcec664e14d28c93b1e sha1 8b237837d2e2d8a8cdf3d8adb394c5f53eb27421 )
+	rom ( name ct2k3sa.zip size 41540409 crc 87595e20 md5 bf6537f0c1edebfd45d39d97034da294 sha1 2f222c99fd9354265b8eb461e22c0c9f87133e8d )
 )
 
 game (
 	name "Crouching Tiger Hidden Dragon 2003 Super Plus (The King of Fighters 2001 bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name ct2k3sp.zip size 40296288 crc 01ba1ad1 md5 c53a5fd1571c4ad0e4370b1aa92b763a sha1 596aef5fa48468ececde500db357a0ff9fe9c740 )
+	rom ( name ct2k3sp.zip size 41642975 crc abcc66b5 md5 f68b7fc71eb6809bec3a9df6ba015107 sha1 985419062a038cfd33942900b51e444432d88cb6 )
 )
 
 game (
 	name "Terranean (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name cterrani.zip size 17158 crc 5dd207b8 md5 390d5d200eb95c1ad46586b4a1a62f98 sha1 ab537fee294f4bade11a3cbc3cd75cadf87be7c1 )
+	rom ( name cterrani.zip size 27559 crc eb41be25 md5 f957d8273a37556501875e1f1e640fff sha1 d5f5ca1507c8b6a35e52c25de7b2db2349d81893 )
 )
 
 game (
 	name "Crouching Tiger Hidden Dragon 2003 (The King of Fighters 2001 bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name cthd2003.zip size 40188311 crc 64cfb07b md5 c390ae0e061c6a00238c8568559fca58 sha1 06292fa683fbf0b55338b78e7a41afb60053de9c )
+	rom ( name cthd2003.zip size 41534998 crc dd30f061 md5 11d08add835bf86660814487ad5ff870 sha1 eadec1a1a22368a7c2d30290c93df0a377ab2bd5 )
 )
 
 game (
 	name "Treasure Island (Cassette, set 1)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name ctisland.zip size 24063 crc e40ee96d md5 9b2243f94b043461ef83e6d7a6d75b34 sha1 c44e8b45234e63f707ef8db663d294ccc7cf214e )
+	rom ( name ctisland.zip size 34464 crc 56767fe5 md5 8ae466da0bad7ce05ba5a3d769d7b593 sha1 583e2ce6b667ad0e1b6f1a313f7cfe15959ffbc3 )
 )
 
 game (
 	name "Treasure Island (Cassette, set 2)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name ctisland2.zip size 24487 crc 7a30c2c9 md5 c3025c957a912831234e18b1aa402242 sha1 2bdee934424fec67595ee1a267ebd62ab29c0f52 )
-)
-
-game (
-	name "Treasure Island (Cassette, set 3)"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name ctisland3.zip size 24084 crc c061f2b6 md5 099e3180ad83153bde542ef1d09beb38 sha1 111ae34c8a7751b2b93ea25a0ae4c8ccfbb7dae6 )
+	rom ( name ctisland2.zip size 34888 crc 17fa21b1 md5 d6584c4e89b67da2cb7ce7bce1288b28 sha1 7a68bf620e44f0503b323cc207e89ff6a834d29b )
 )
 
 game (
 	name "Captain Tomaday"
 	year "1999"
 	developer "Visco"
-	rom ( name ctomaday.zip size 5796317 crc 34a90b14 md5 2d6d7c4535d900564562051e1a7c6937 sha1 3eb4c87f0c62f6d1b48ca095132af5a9219cb7f2 )
+	rom ( name ctomaday.zip size 7143004 crc 54bf6b84 md5 22862f8785ed20c2c810cd766dd990a6 sha1 062887ef5183e6e6530faefcfa3774c80ebee3c1 )
 )
 
 game (
 	name "Tornado (Cassette)"
 	year "1982"
 	developer "Data East Corporation"
-	rom ( name ctornado.zip size 15325 crc da108c0d md5 23075be9570bd206d064a473432eb834 sha1 aa3d618a88a989fe906af1e282713ac5d32817f9 )
+	rom ( name ctornado.zip size 25726 crc b2cae423 md5 a6e06c7f72509125caba0864f62a4785 sha1 18ac49f1cbc29b3b9210a2ed6879abbf2c2fde3a )
 )
 
 game (
@@ -10794,7 +8173,7 @@ game (
 	name "Test Tape (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
-	rom ( name ctsttape.zip size 4139 crc 15263a15 md5 b443174f5bed572944e304514d67b126 sha1 0291a9f24994d1b2bba6b0c60d14d12bc4fd41c1 )
+	rom ( name ctsttape.zip size 14540 crc f5c4f261 md5 dfa55d513c05a5e26b5684c09b0089fc sha1 6103a46b244abe81958bc80fb991d01071db1fe7 )
 )
 
 game (
@@ -10832,13 +8211,6 @@ game (
 )
 
 game (
-	name "Seimei-Kantei-Meimei-Ki Cult Name"
-	year "1996"
-	developer "I&apos;Max"
-	rom ( name cultname.zip size 2374339 crc 6e0d55d7 md5 46ef4d95ca1c98521648460136315d38 sha1 d30f4147c2fc9101ae4b103cee74afc10bef835d )
-)
-
-game (
 	name "Jibun wo Migaku Culture School Mahjong Hen"
 	year "1994"
 	developer "Face"
@@ -10846,59 +8218,10 @@ game (
 )
 
 game (
-	name "Cuore 1 (Italian)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name cuoreuno.zip size 19253 crc 94c0fea5 md5 24f2f15db3d20da4c4401fce4548585a sha1 b16af13650d2b114253773644601b2788ca1c7c1 )
-)
-
-game (
 	name "Taito Cup Finals (Ver 1.0O 1993/02/28)"
 	year "1993"
 	developer "Taito Corporation Japan"
 	rom ( name cupfinal.zip size 5437282 crc 7651ee83 md5 dd420b46ffdc57af804e3f918444aeb7 sha1 6d224656607820e2c618a5727cf65af76d41e10a )
-)
-
-game (
-	name "Seibu Cup Soccer (set 1)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsoc.zip size 1889323 crc 26005bae md5 a21a5d551639e86b461bfbb5f8425015 sha1 161f6d58ea352874f337f7449ffa376d7fa5cadb )
-)
-
-game (
-	name "Seibu Cup Soccer (set 2)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsoca.zip size 1889641 crc 2b5e973c md5 fce371a80df8e119b7dd533d92469706 sha1 91465d086715f06eeaff987645b1e67273a85d5b )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (set 1)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsocs.zip size 1986848 crc 352a9174 md5 db3e984cb0184433cf3b99466125afcc sha1 d0b5b6b22a0dd45bace15cb524b349998d5abf45 )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (set 2)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsocs2.zip size 1588271 crc 6d12253e md5 7388ea8adf4ed1d73ad623479d363e9b sha1 96aede6897afbf9ec4f372869abc9b89f11f89f6 )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (bootleg, set 1)"
-	year "1992"
-	developer "bootleg"
-	rom ( name cupsocsb.zip size 3251406 crc 50d37c9c md5 5f0af0c8995bcba9a73db2822201a170 sha1 ef65bba5878c324dde498c8ad79a8e47b4dcfda3 )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (bootleg, set 2)"
-	year "1992"
-	developer "bootleg"
-	rom ( name cupsocsb2.zip size 3251387 crc beba3332 md5 af37487f5f126ddf21e6a4f6a9bde512 sha1 94d567ec3144474dcf476d60ef8e69d4c6f3c1d3 )
 )
 
 game (
@@ -10916,38 +8239,10 @@ game (
 )
 
 game (
-	name "Capcom Vs. SNK 2 Millionaire Fighting 2001 (Rev A) (GDL-0007A)"
-	year "2001"
-	developer "Capcom / SNK"
-	rom ( name cvs2gd.zip size 1197 crc 2c27cb45 md5 d338e8e8874fa69a1b4c686a83abc5f4 sha1 75c327dd242a7381b11fa70d839ebb4f7d6601b8 )
-)
-
-game (
-	name "Capcom Vs. SNK Millenium Fight 2000 Pro (GDL-0004)"
-	year "2001"
-	developer "Capcom / SNK"
-	rom ( name cvsgd.zip size 1197 crc 29262628 md5 ec08503ae335e4b35a864f9a92317e60 sha1 fa00da1d9b91b153f43cfcf45955a87b1dc7446f )
-)
-
-game (
 	name "Capcom World (Japan)"
 	year "1989"
 	developer "Capcom"
 	rom ( name cworld.zip size 728155 crc 92fff834 md5 7b957f3061527245dd049f0afd9cf88a sha1 0a75499a74146f831ac2f1d6b8aa6aac822430aa )
-)
-
-game (
-	name "Adventure Quiz Capcom World 2 (Japan 920611)"
-	year "1992"
-	developer "Capcom"
-	rom ( name cworld2j.zip size 1753740 crc 3181ff10 md5 b32c4c73707d91596c5d375147c3c11a sha1 99f44bf54db8999d313bb0e6e021ea8cdb4b1459 )
-)
-
-game (
-	name "Cybattler"
-	year "1993"
-	developer "Jaleco"
-	rom ( name cybattlr.zip size 1266380 crc d454f84a md5 041ced047550d34d4aa37df69cfb3b18 sha1 e26f3a8131a4d6d8fbf0dfca8ba44c42045bfcbc )
 )
 
 game (
@@ -11017,14 +8312,7 @@ game (
 	name "Cyber-Lip"
 	year "1990"
 	developer "SNK"
-	rom ( name cyberlip.zip size 3316725 crc 5145a26f md5 71ebc45a98f4424381ad68b98235aef7 sha1 bf3f91f5a430aa29c6e472e58144297cc2f2b98e )
-)
-
-game (
-	name "Cyber Tank (v1.04)"
-	year "1988"
-	developer "Coreland"
-	rom ( name cybertnk.zip size 1594041 crc 19eacebb md5 a54e40121f2d35a4d8d2b6db957c8231 sha1 75f8cd8d0959e89d3f0a8224e9260b0202923ff1 )
+	rom ( name cyberlip.zip size 4663412 crc a909960b md5 f09019b7c02d0b8d87028e2f0503214c sha1 84c7758486833ddad2772da3dfaa5e11d52d6175 )
 )
 
 game (
@@ -11049,13 +8337,6 @@ game (
 )
 
 game (
-	name "Cyber Commando (Rev. CY1, Japan)"
-	year "1995"
-	developer "Namco"
-	rom ( name cybrcomm.zip size 9154610 crc dc4c1738 md5 d9ecc9e0fe6f9c61aab10d2e6204e639 sha1 77c3a2e803799a4c68b5cf0b1eedea30547a1823 )
-)
-
-game (
 	name "Cyber Cycles (Rev. CB2 Ver.C)"
 	year "1995"
 	developer "Namco"
@@ -11077,20 +8358,6 @@ game (
 )
 
 game (
-	name "Cycle Mahbou (Japan)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name cyclemb.zip size 59757 crc 8bd1cfcc md5 3db1e4688f9241fd97569c7bcef702eb sha1 cdd61356b697210d39df99df5649872320eab336 )
-)
-
-game (
-	name "Cycle Shooting"
-	year "1986"
-	developer "Taito"
-	rom ( name cyclshtg.zip size 142272 crc 2620c115 md5 b1057dddd11b630d09d693180f466d42 sha1 d60c25b3eb4ac636b3b9bb1758a45fbb18357447 )
-)
-
-game (
 	name "Cycle Warriors"
 	year "1991"
 	developer "Tatsumi"
@@ -11101,14 +8368,7 @@ game (
 	name "Cyvern (Japan)"
 	year "1998"
 	developer "Kaneko"
-	rom ( name cyvern.zip size 13784349 crc 7bf748ce md5 bf6418b0c6ef4ff56c767ea1dd6648db sha1 bd6892cc34acc2388d8f60424d51ed018ec63240 )
-)
-
-game (
-	name "Zeroize (Cassette)"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name czeroize.zip size 25175 crc ef0b1fc1 md5 9b6a793924475b77409b9a756b28859c sha1 193cf1538f272aa405d13e7e3d6702d11f8bb5e1 )
+	rom ( name cyvern.zip size 13816370 crc db3f9ba4 md5 94795ab8ffec07f5f5f424e5836df3d0 sha1 498e791f4a8312ec60103d4cb20f0d11e9617d61 )
 )
 
 game (
@@ -11116,13 +8376,6 @@ game (
 	year "1992"
 	developer "Excellent System"
 	rom ( name d9final.zip size 205019 crc 7dcad395 md5 842cf51e1aff6f2d7c5588e3f2c6b31c sha1 0d432fd362197660398297616db6756d4081547a )
-)
-
-game (
-	name "Dacholer"
-	year "1983"
-	developer "Nichibutsu"
-	rom ( name dacholer.zip size 49113 crc 8c095913 md5 430234ec4aad83d9a209c58a603a662a sha1 b3d5999b4990fe806468b1b11af50eeebb123c96 )
 )
 
 game (
@@ -11147,13 +8400,6 @@ game (
 )
 
 game (
-	name "Daimakaimura (Japan)"
-	year "1988"
-	developer "Capcom"
-	rom ( name daimakai.zip size 1639957 crc ef75d833 md5 98e9150233fd99b9d5b49c71184f3f72 sha1 a0b850cdaff1c237a1effa877d9fe48db7ae4c53 )
-)
-
-game (
 	name "Daimakaimura (Japan Resale Ver.)"
 	year "1988"
 	developer "Capcom"
@@ -11175,13 +8421,6 @@ game (
 )
 
 game (
-	name "Mahjong Daireikai (Japan)"
-	year "1989"
-	developer "Jaleco / NMK"
-	rom ( name daireika.zip size 782018 crc 620a8a38 md5 b484554869422814e7b0a4c91c53c58f sha1 d641e7eac4ccfa7c58642a9ac07e163003b7be41 )
-)
-
-game (
 	name "Dai Ressya Goutou (Japan)"
 	year "1986"
 	developer "Konami (Kawakusu license)"
@@ -11199,7 +8438,7 @@ game (
 	name "Daisu-Kiss (ver JAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name daiskiss.zip size 3824411 crc 968ffaa1 md5 ad5913634135e43b13add813af0ef91d sha1 0eef0365bda8df60e7e19db0b10cd1c7783fc54d )
+	rom ( name daiskiss.zip size 3833101 crc 390420d2 md5 ccfcfe3933ee9ea312bf45bb7fb0e577 sha1 81766c8c4bfe1f0dcc4622f2c92ebcbab752163f )
 )
 
 game (
@@ -11269,14 +8508,14 @@ game (
 	name "Danchi de Hanafuda (J 990607 V1.400)"
 	year "1999"
 	developer "Altron (Tecmo license)"
-	rom ( name danchih.zip size 8322692 crc f2c66a02 md5 c092fb87fb133077ee4cd18b53f4ef85 sha1 834d6d35476a5a97b38c28cebacfe53280d21060 )
+	rom ( name danchih.zip size 11021913 crc 8a44d5d3 md5 ab36973b2108a6fcae9217db7f65310c sha1 83d2c8354d4b4b1551eabc546cc87104da24c08b )
 )
 
 game (
 	name "Danchi de Quiz Okusan Yontaku Desuyo! (J 001128 V1.200)"
 	year "2000"
 	developer "Altron"
-	rom ( name danchiq.zip size 6940797 crc c805592f md5 abbc584bb94c8bdc71519c5c6f14b3af sha1 8a73827adcbc0eeef4bd3374fc014a4ed24844f4 )
+	rom ( name danchiq.zip size 9640018 crc ffaaa82d md5 36039676fd1b01753b9951c9b4e146a3 sha1 1223920c00f0ac98186300be6207408227c75561 )
 )
 
 game (
@@ -11298,13 +8537,6 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name dangarb.zip size 166126 crc 33a8123f md5 3a580aa08cf6e93cc72ad8875542bd9e sha1 8cc2624d8d14a5ea3d9a5b4bc2189099411d1540 )
-)
-
-game (
-	name "Dangerous Curves"
-	year "1995"
-	developer "Taito"
-	rom ( name dangcurv.zip size 15539901 crc 0c41353d md5 a9cb7c923a7f27ab70e4f282c52ce151 sha1 1ce91ce83630e2520697516dd5ceabe747a93322 )
 )
 
 game (
@@ -11434,20 +8666,6 @@ game (
 )
 
 game (
-	name "Dark Horse Legend (GX706 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name darkhleg.zip size 182 crc 1a548190 md5 586ca9974f867427cbd45a5fabe9a35d sha1 1e747b326cf425476ec052dd63924a31e21d1151 )
-)
-
-game (
-	name "Dark Horse (bootleg of Jockey Club II)"
-	year "2001"
-	developer "bootleg"
-	rom ( name darkhors.zip size 2016274 crc 9a085b6a md5 93da3283935cc1c8bf6deace26b2cbc5 sha1 dfacb21ba11900a2bcd5fd15e0241a3751bd8e6c )
-)
-
-game (
 	name "The Lost Castle In Darkmist"
 	year "1986"
 	developer "Taito"
@@ -11504,79 +8722,10 @@ game (
 )
 
 game (
-	name "Darth Vader"
-	developer "bootleg"
-	rom ( name darthvdr.zip size 5503 crc c56d7786 md5 2b1808572ea0da097eb8732bc4394b14 sha1 52cb0ff6ce48e8ee219a5417bf2560648401c103 )
-)
-
-game (
 	name "Darwin 4078 (Japan)"
 	year "1986"
 	developer "Data East Corporation"
 	rom ( name darwin.zip size 120044 crc 937ad0f0 md5 122efe0f51a9346400384bba7139f064 sha1 1f7ca842309e42e058b609e7ed313a834140324d )
-)
-
-game (
-	name "Desert Assault (US)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name dassault.zip size 3795603 crc 02f097f7 md5 2c689eb6d3014433420be70688b56bda sha1 46cb1fcafa194dbe34a512d398a8d574ac986472 )
-)
-
-game (
-	name "Desert Assault (US 4 Players)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name dassault4.zip size 3793126 crc 494ada01 md5 6283d8ca17d5bfaa5eeb574c0427337a sha1 914beccf65ae5611dddde0d86c71e341595ba71c )
-)
-
-game (
-	name "Daytona USA 2 Power Edition"
-	year "1998"
-	developer "Sega"
-	rom ( name dayto2pe.zip size 89082124 crc c9324bd2 md5 2431c3a8c949e3e51a67951a4563d74b sha1 6aaf5a75053ff817a23ba2db3b00dea120d93bfd )
-)
-
-game (
-	name "Daytona USA (Japan, Revision A)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytona.zip size 15080135 crc b3348b34 md5 5aaee46904e00b4ad5ac5c7867c34d42 sha1 c6bf07b851f18af18f2b84af9482768de8e526bb )
-)
-
-game (
-	name "Daytona USA 2 (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name daytona2.zip size 81715239 crc 3ce2b636 md5 19c92ac17f86950ff1471d270b995257 sha1 df93149dfefa20b5f6db0e5312e99872008fe33f )
-)
-
-game (
-	name "Daytona USA Deluxe '93"
-	year "1993"
-	developer "Sega"
-	rom ( name daytona93.zip size 15800142 crc 4d619365 md5 1af694b172463f1f48a160e8abc4c9d5 sha1 0f1ac4e5eca7fe7197cdd268fa0ee184590a2085 )
-)
-
-game (
-	name "Daytona USA (Japan, To The MAXX)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonam.zip size 15092135 crc b837a6f3 md5 af1c5cfbd9e0a301133d1be0094f0865 sha1 6999609bda2e0df522ea57917d7d17e64015690b )
-)
-
-game (
-	name "Daytona USA (With Saturn Adverts)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonas.zip size 15093480 crc 0bc696f1 md5 5b8076f221f937cded4c5eb9644a38e1 sha1 194608c828e191996029eb17b0cb09fe67de44e6 )
-)
-
-game (
-	name "Daytona USA (Japan, Turbo hack)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonat.zip size 15382103 crc 0b441a93 md5 a8e3e29d30f67b8cebb275d0f720cafe sha1 09d76a76730aaf8d8fe1262b183c7b011dd73345 )
 )
 
 game (
@@ -11650,13 +8799,6 @@ game (
 )
 
 game (
-	name "Double Wings"
-	year "1993"
-	developer "Mitchell"
-	rom ( name dblewing.zip size 2055341 crc 07b7b9c9 md5 de3c0e1d39b75db7169943e81e89ddc7 sha1 3d5dd495c08020a81491ad9d3757990fb6c167c1 )
-)
-
-game (
 	name "Super Baseball Double Play Home Run Derby"
 	year "1987"
 	developer "Leland Corp. / Tradewest"
@@ -11682,13 +8824,6 @@ game (
 	year "1989"
 	developer "Irem"
 	rom ( name dbreed.zip size 753922 crc b9fe793a md5 f4b31a4769276a862e5dd2717a428aba sha1 2aa947f887d7ca097519219bfe4d05b0626217f7 )
-)
-
-game (
-	name "Dragon Breed (M72 PCB version)"
-	year "1989"
-	developer "Irem"
-	rom ( name dbreedm72.zip size 1044173 crc 394b85a7 md5 f0cc388b0bad82e3ffda1be590e62969 sha1 894728810a6f976ab55b91d74b679f9cfa23d2ee )
 )
 
 game (
@@ -11811,13 +8946,6 @@ game (
 )
 
 game (
-	name "Double Dealer"
-	year "1991"
-	developer "NMK"
-	rom ( name ddealer.zip size 223338 crc 87ca013e md5 2e48d87248f2c0be4511e1be97c04fc2 sha1 cfdab8741df51cd75bbbdc8dc37cb94a348e51bc )
-)
-
-game (
 	name "Don Den Lover Vol. 1 - Shiro Kuro Tsukeyo! (Japan)"
 	year "1995"
 	developer "Dynax"
@@ -11857,139 +8985,6 @@ game (
 	year "1997"
 	developer "Cave (Atlus license)"
 	rom ( name ddonpachj.zip size 7872970 crc c22194b3 md5 3f8035b9fab733aaa8eee57b09e93217 sha1 6ab811ef00d6da12806119385d900abaa18636f5 )
-)
-
-game (
-	name "Bee Storm - DoDonPachi II (ver. 100)"
-	year "2001"
-	developer "IGS"
-	rom ( name ddp2.zip size 12881272 crc f206ea2f md5 9ab46976eb5f308dc3581fd193b449db sha1 570fd9e6d981c30117c345f47a6e4d47dc406d80 )
-)
-
-game (
-	name "Bee Storm - DoDonPachi II (ver. 102)"
-	year "2001"
-	developer "IGS"
-	rom ( name ddp2a.zip size 12881986 crc 9ecff09d md5 62ad8f32b78fc5142c34d77fb3cc3292 sha1 9daabb73e6841aca2e073e40b77deabe2bd669e8 )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix (GN895 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2m.zip size 174 crc e7188034 md5 223e2b1eabbe3ad1d471b4fbb4f43007 sha1 5b958c15631ee04acd8ce92b0a9caccd1eec097b )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX CLUB VERSiON (GE896 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2mc.zip size 172 crc 8f7db786 md5 7e38cf8a4fbdc234a6de07bd69053cbd sha1 dece8a1ac3d9f18d6db849bc72d522be5392e044 )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX substream CLUB VERSiON 2 (GE984 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2mc2.zip size 172 crc b220eaab md5 1325feb1a5451a56fb41f1600c172113 sha1 6264d7156d924335cff5ef9a2e5669988d84f48b )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix - Link Ver (GE885 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2ml.zip size 4057 crc ff1be293 md5 604be7e73f4ab6efa2852ec221c8e4ad sha1 30a3bf91c96f391fdfd0242f7049cc1dde0f9cc2 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix (GN887 VER. AAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr3ma.zip size 508 crc 5bcc87d8 md5 e18ce06d393d42e26f2285cc098754f3 sha1 2cebcfdd6b9b47b49f0ac5efb6ef23c6ef9c6861 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix (GN887 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr3mj.zip size 508 crc d651cb87 md5 04f1e15e34c04c04343303a27bd844ce sha1 5a4423c6c72f72535a34c73776a4c2b949520743 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix - Ver.Korea2 (GN887 VER. KBA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr3mk.zip size 508 crc 66745e0e md5 002d5e87f0aefa12f40af292614f8538 sha1 2946dd5ca3e1c9ec9bf19b231b29dbc5185d43e4 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix - Ver.Korea (GN887 VER. KAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr3mka.zip size 508 crc 9e1fa760 md5 41b38f3c2a61555683c3138d0e1f38e0 sha1 49c5c7123ea38511175e796384565625d9375062 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix Plus (G*A22 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr3mp.zip size 547 crc 0099dd86 md5 8c06a1e6b1fc867786a5af640f0fb64c sha1 8197e1daf6479711c6d4fb3d466a919e7dfb8f08 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix (G*A33 VER. AAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4m.zip size 548 crc ba8dce41 md5 d6f4a74f1dbf76fb380e820adf00c02c sha1 9b66e890e8e2fa0083ea3ee5cd520f037490fcef )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix (G*A33 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mj.zip size 544 crc 84b8985e md5 963062daa96bb8f3cdf83848826e456a sha1 cd77d796b392fff68984cc2cc4a4e386c0462347 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Plus (G*A34 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mp.zip size 686 crc 83ff7451 md5 e1ccce6f46672d2be1251f367d2580c2 sha1 4f52ae738b75ef1a7ec49995f054a7afbaf1641a )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Plus Solo (G*A34 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mps.zip size 686 crc 41e68758 md5 8cbb3d33bfee8275fc6ff114604e2266 sha1 4234f709fb5388cf6ba3f7aeeb9abae2362af4ec )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Solo (G*A33 VER. ABA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4ms.zip size 548 crc eb59b011 md5 e490430c29f2b04966edddc2403f6aad sha1 56b58798c54307433b41dd42747d662f0400a239 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Solo (G*A33 VER. JBA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4msj.zip size 544 crc 45c8c1a6 md5 144b958539f66c88c54fd4ab66d5d897 sha1 223ec8ddb710467dd3f5db62810eedf8b7a14cc6 )
-)
-
-game (
-	name "Dance Dance Revolution 5th Mix (G*A27 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name ddr5m.zip size 315 crc 12ef6a61 md5 f12b6640a4c9556d713b1c6d7dd2150d sha1 9f07b8c3024ec4945d2869c0813fba3074ef78a2 )
-)
-
-game (
-	name "Dance Dance Revolution (GN845 VER. AAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddra.zip size 172 crc eacf6ede md5 e41f971e2fb211dafceefc6f721f7809 sha1 38267e9aa40d565e9e414fa4bea855e52435a990 )
 )
 
 game (
@@ -12039,20 +9034,6 @@ game (
 	year "1990"
 	developer "Technos Japan"
 	rom ( name ddragon3p.zip size 1862252 crc 5149cb51 md5 4888d610712c9e08fcf7fee565f802d5 sha1 2a74b59f15b61e69f971cdaef901f4dddbb6854e )
-)
-
-game (
-	name "Double Dragon (bootleg with 3xM6809, set 1)"
-	year "1987"
-	developer "bootleg"
-	rom ( name ddragon6809.zip size 549334 crc 977aba85 md5 676a5bb3606dcadbb2c772259cc8f1b7 sha1 cbf2b9970e31ca4c454bdd0f749d969d51fcdff9 )
-)
-
-game (
-	name "Double Dragon (bootleg with 3xM6809, set 2)"
-	year "1987"
-	developer "bootleg"
-	rom ( name ddragon6809a.zip size 546706 crc 525d2cba md5 8fdb9be47f496568da1ab97d904558de sha1 f161be7f7ffc30168fcce8711ffc3b3d7edd3117 )
 )
 
 game (
@@ -12112,13 +9093,6 @@ game (
 )
 
 game (
-	name "Dance Dance Revolution Best of Cool Dancers (GE892 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrbocd.zip size 174 crc e7188034 md5 223e2b1eabbe3ad1d471b4fbb4f43007 sha1 5b958c15631ee04acd8ce92b0a9caccd1eec097b )
-)
-
-game (
 	name "Dunk Dream '95 (Japan 1.4, EAM)"
 	year "1995"
 	developer "Data East Corporation"
@@ -12126,73 +9100,10 @@ game (
 )
 
 game (
-	name "Dance Dance Revolution Extreme (G*C36 VER. JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name ddrextrm.zip size 315 crc fa7ecd67 md5 07d4915fc43ee2bb49c064f006b46c84 sha1 83df8b45bfcc5e7b74e32105547e2768a38f1c95 )
-)
-
-game (
 	name "Double Dribble"
 	year "1986"
 	developer "Konami"
 	rom ( name ddribble.zip size 358619 crc 0b4f3ea0 md5 def11feee81940591976f34c7e154917 sha1 b3b7b4d17cfe6861e0edbf9d333d9b6cdf234080 )
-)
-
-game (
-	name "Dance Dance Revolution - Internet Ranking Ver (GC845 VER. JBA)"
-	year "1998"
-	developer "Konami"
-	rom ( name ddrj.zip size 172 crc 87fa16d9 md5 d48eb8d9258dbfca90b4b93df0ccfc04 sha1 1c2be6b15e4ba70140db4f3aa3242e6a1aac6312 )
-)
-
-game (
-	name "DDR Max - Dance Dance Revolution 6th Mix (G*B19 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name ddrmax.zip size 314 crc 9773e351 md5 386eaaedd45da4566c7c65cf864c7a69 sha1 4b349cdc669d98985521ecdd863b65f86519f0bd )
-)
-
-game (
-	name "DDR Max 2 - Dance Dance Revolution 7th Mix (G*B20 VER. JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name ddrmax2.zip size 315 crc 0c9155c3 md5 cc2007117afc0d668d37d861771475d9 sha1 6bba6add32147b22c6cea8bc27e655dc8eaa7fed )
-)
-
-game (
-	name "Dance Dance Revolution Solo 2000 (GC905 VER. AAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrs2k.zip size 508 crc d23dea36 md5 8b61c455097f38503898e56b4c30d703 sha1 fac67a81ff3cd5e990345ff5ae7a04318cf716d9 )
-)
-
-game (
-	name "Dance Dance Revolution Solo 2000 (GC905 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrs2kj.zip size 508 crc c0646b01 md5 87d222551a0fe544a3f9192d8027f11c sha1 586ddfda7fea58dc29e3f590efaa98ebd96db9f8 )
-)
-
-game (
-	name "Dance Dance Revolution Solo Bass Mix (GQ894 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrsbm.zip size 282 crc 1cab704c md5 f7689bf26a5eef779653ecda61d1746b sha1 ec2cd0117142ddac61f0deb02560af609c7dee79 )
-)
-
-game (
-	name "Dance Dance Revolution (GN845 VER. UAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddru.zip size 172 crc 049610a8 md5 96b1dbaaa0609f175fc8927b8a68c0cf sha1 9fe6940e3c0210d97392320b7b65b370df5c8cb7 )
-)
-
-game (
-	name "Dance Dance Revolution USA (G*A44 VER. UAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddrusa.zip size 315 crc 6fc624c2 md5 fbef020574f971d5362e53bda15d2354 sha1 77b0a03177c641dbb88f58ebcb243a051a162a7d )
 )
 
 game (
@@ -12385,26 +9296,6 @@ game (
 )
 
 game (
-	name "Dynamite Dux (set 1, 8751 317-0095)"
-	year "1988"
-	developer "Sega"
-	rom ( name ddux1.zip size 480213 crc 6e56931b md5 b5f97c2c42d1464797d9e0ce18f70b82 sha1 32ff943d5c7948ce1882aa1256ea88957d2327c9 )
-)
-
-game (
-	name "Dynamite Dux (bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name dduxbl.zip size 481332 crc f54fcea1 md5 02b5fcad07e6120173ba6b5cec839152 sha1 d731fb16d51a859efee9c5dd384ed18a857382c6 )
-)
-
-game (
-	name "Dou Di Zhu"
-	developer "IGS?"
-	rom ( name ddz.zip size 4299073 crc f07bac13 md5 d05e2c85d361ada83d4bb0688f2903a9 sha1 d0437735902f136c22729a21e972a81671f54b58 )
-)
-
-game (
 	name "Dead Angle"
 	year "1988"
 	developer "Seibu Kaihatsu"
@@ -12440,38 +9331,10 @@ game (
 )
 
 game (
-	name "The Dealer"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name dealer.zip size 15702 crc 2521c727 md5 19144345952cedcd1222400e7f96d6a8 sha1 dd234ed4b9caae5014516d26ddba09c94964ebbe )
-)
-
-game (
 	name "Death Brade (Japan ver JM-3)"
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name deathbrd.zip size 4373159 crc dfde1020 md5 c915aa0f8c53709bbc008ec7b81ba078 sha1 a48616ec0b126258cafd6d5d830066e80363657d )
-)
-
-game (
-	name "Death Crimson OX (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Ecole"
-	rom ( name deathcox.zip size 56204685 crc 8eda24f3 md5 49742a7a930fb872b8c78d3fb9b75163 sha1 586e6b80d02e48c6a912b378ce172234360f8b85 )
-)
-
-game (
-	name "Decathlete (JUET 960709 V1.001)"
-	year "1996"
-	developer "Sega"
-	rom ( name decathlt.zip size 13143261 crc e7440d51 md5 d6bb4f0f1db74358845c1b07bf7eab0c sha1 902b1b283cef7c940d4226dc87e24d9e673386ac )
-)
-
-game (
-	name "Decathlete (JUET 960424 V1.000)"
-	year "1996"
-	developer "Sega"
-	rom ( name decathlto.zip size 13143405 crc f4b19444 md5 bab36c33ebb927905f1cd12d478cd0bd sha1 f8f5b84a1d768f67eccad29ece1473049bfcb1b3 )
 )
 
 game (
@@ -12545,31 +9408,10 @@ game (
 )
 
 game (
-	name "Defense (System 16B, FD1089A 317-0028)"
-	year "1987"
-	developer "Sega"
-	rom ( name defense.zip size 368501 crc 92e6e1f9 md5 0c18ca45fa3474517cbbd1dec6c391ee sha1 82975625e76c336adc29074df9a886276e2d6eda )
-)
-
-game (
-	name "Defender (bootleg)"
-	year "1980"
-	developer "bootleg (Jeutel)"
-	rom ( name defndjeu.zip size 19340 crc ed0313c4 md5 c98771d353435f8ae11999d35dd0d7e2 sha1 e84bca3401461f36dfd4ba014b7fadb964b699fb )
-)
-
-game (
 	name "Delta Race"
 	year "1981"
 	developer "bootleg (Allied Leisure)"
 	rom ( name deltrace.zip size 15452 crc 9b1d4e01 md5 7d351dd0b9adc6d4991d71f79c3ddec0 sha1 264cd96b5a4f83863b4161a0504e24100e2b7e25 )
-)
-
-game (
-	name "Demons _ Dragons (prototype)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name demndrgn.zip size 49939 crc 8f956f14 md5 1883f53438bb840f6e8c19664a0c0b25 sha1 50272844cf3987cf8e333e2e77fdb707df101568 )
 )
 
 game (
@@ -12587,24 +9429,10 @@ game (
 )
 
 game (
-	name "Demolish Fist"
-	year "2003"
-	developer "Polygon Magic / Dimps"
-	rom ( name demofist.zip size 109596850 crc dfc1658f md5 5e8347cf6bad4148da10942d22a61d1f sha1 535300a634ef5a523dd495c9f33543378ddcd433 )
-)
-
-game (
 	name "Demon"
 	year "1982"
 	developer "Rock-Ola"
 	rom ( name demon.zip size 16122 crc 8641b9f0 md5 791dc5e136c110a5f7524d63db1d1ce1 sha1 cf99c2506cf48632299788257ef6608626fd1691 )
-)
-
-game (
-	name "Demoneye-X"
-	year "1981"
-	developer "Irem"
-	rom ( name demoneye.zip size 19148 crc 129d57f6 md5 3dd29a6a05424a3ade086e944b9f00ad sha1 730127f512859a0d6f1389b723beaa33679556ac )
 )
 
 game (
@@ -12643,34 +9471,6 @@ game (
 )
 
 game (
-	name "Densya De Go (Japan)"
-	year "1996"
-	developer "Taito"
-	rom ( name dendeg.zip size 18697112 crc 1a00066d md5 733e110357965b8cfb17c41f426fd365 sha1 f606829b738039132266c2da0c04e612ae1f5ef9 )
-)
-
-game (
-	name "Densya De Go 2 (Japan)"
-	year "1998"
-	developer "Taito"
-	rom ( name dendeg2.zip size 26917738 crc d88c9224 md5 19ad4f746f99208a570da5fb7ad0932e sha1 e95a8e11fcc1b8361efb934b818aaeb6add9c287 )
-)
-
-game (
-	name "Densya De Go 2 Ex (Japan)"
-	year "1998"
-	developer "Taito"
-	rom ( name dendeg2x.zip size 27031071 crc 1b08778a md5 31d5ff649cc3aadc156742315b9749ab sha1 997d18b27fc5603e3e4326d7f1afbec155c7b79e )
-)
-
-game (
-	name "Densya De Go Ex (Japan)"
-	year "1996"
-	developer "Taito"
-	rom ( name dendegx.zip size 18698632 crc 4e38a361 md5 749f2792270c506101d5a1615bd02f21 sha1 fbd726bf0ffd07a4f4dbeabc9c4c8c01b9c008c4 )
-)
-
-game (
 	name "Denjin Makai"
 	year "1993"
 	developer "Banpresto"
@@ -12699,41 +9499,6 @@ game (
 )
 
 game (
-	name "Derby Owners Club (JPN, USA, EXP, KOR, AUS) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name derbyoc.zip size 45760592 crc d0b36612 md5 3769fc65b379761d6fe41f101fcbcc9d sha1 1a566e1acf24d13b74a8e0006ae8caf97a718fe2 )
-)
-
-game (
-	name "Derby Owners Club II (JPN, USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name derbyoc2.zip size 115304828 crc a8f6264c md5 14d1cae672c386af6e0c4b78b0e447c6 sha1 0a541724e1c704ea64cd02cb52e61c879566d722 )
-)
-
-game (
-	name "Derby Owners Club World Edition (JPN, USA, EXP, KOR, AUS) (Rev C)"
-	year "2001"
-	developer "Sega"
-	rom ( name derbyocw.zip size 34235746 crc 4b02fce6 md5 6b5da119d2e7fa419fac9196f812af55 sha1 80730d4c4ae09bc115ce5ce99a461e8648356253 )
-)
-
-game (
-	name "Deroon DeroDero"
-	year "1995"
-	developer "Tecmo"
-	rom ( name deroon.zip size 4006201 crc 59555686 md5 4f6817b242381fd5a945b0139dce403d sha1 aeb81c31639baf8e4065331a54780dbade7c1cad )
-)
-
-game (
-	name "Desert Tank"
-	year "1994"
-	developer "Sega / Martin Marietta"
-	rom ( name desert.zip size 8935233 crc c415cee3 md5 9d854300bcaf65a07c98fb31cc365981 sha1 a57d83c1a78ae45d207322765a1f9a68a82d26a7 )
-)
-
-game (
 	name "Desert Breaker (World, FD1094 317-0196)"
 	year "1992"
 	developer "Sega"
@@ -12755,31 +9520,10 @@ game (
 )
 
 game (
-	name "Desert War / Wangan Sensou"
-	year "1995"
-	developer "Jaleco"
-	rom ( name desertwr.zip size 10622164 crc 69f85da9 md5 7569556191d31c6ecca6d6d6a606d018 sha1 ca266a239f46e2b43a9b3893d034ae99cc9311ab )
-)
-
-game (
-	name "Destiny Horoscope"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name deshoros.zip size 41784 crc 979fc0c5 md5 21a388d1d74d9fcf9512b0b4a4fa967b sha1 9914a21b6045b47e41136b6387c0992911651d66 )
-)
-
-game (
 	name "Destination Earth"
 	year "1979"
 	developer "bootleg"
 	rom ( name desterth.zip size 10314 crc 3bad5e46 md5 52103a5cbd27fc517acea847a5b8d22e sha1 44203c6756e01f395f02414148ab9e92582fc4be )
-)
-
-game (
-	name "Destroyer"
-	year "1977"
-	developer "Atari"
-	rom ( name destroyr.zip size 3594 crc 6680c4af md5 5233593be72a687f332362d02abc30cb sha1 32680f3350c79fa84932e44f2c1d93cd48063006 )
 )
 
 game (
@@ -12853,13 +9597,6 @@ game (
 )
 
 game (
-	name "Devil Zone (easier)"
-	year "1980"
-	developer "Universal"
-	rom ( name devzone2.zip size 12519 crc 4c2cbc77 md5 740273f5bff885af643ed0de60cd51a1 sha1 7531bcf1427c865512f8c819ac6289185389e5b8 )
-)
-
-game (
 	name "Double Joker Poker (45%-75% payout)"
 	developer "DellFern Ltd."
 	rom ( name df_djpkr.zip size 7201 crc 743ced08 md5 0b0c9729018a95fa59a728e29a38c82f sha1 a08f072775c469829d61e4061b52b64d628433b3 )
@@ -12897,21 +9634,7 @@ game (
 	name "Die Hard Arcade (UET 960515 V1.000)"
 	year "1996"
 	developer "Sega"
-	rom ( name diehard.zip size 7089164 crc 1059a4a0 md5 5e9c34683179d19cace090c7cc74f941 sha1 964bd593f69ad0402a96fb57a41131bed62176cc )
-)
-
-game (
-	name "Diet Go Go (Euro v1.1 1992.09.26)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgo.zip size 2194196 crc ba979f30 md5 66934e4b2a2bf80c56e41d01f2cbd621 sha1 cc9e6b1e97e7b227509478264b1b7c9aae38bfa3 )
-)
-
-game (
-	name "Diet Go Go (Euro v1.1 1992.08.04)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgoe.zip size 2214207 crc 1e43e639 md5 d598e0898f48b8a60cea01723ba56d8b sha1 149e523bf9aac24e819e2227d37715c11fc7a646 )
+	rom ( name diehard.zip size 9788385 crc 856ccafc md5 870e6c6a91a8870aec43d2e30c330241 sha1 2d11142bc79ea6f27b3aefabf7c718a691a3c90a )
 )
 
 game (
@@ -12919,13 +9642,6 @@ game (
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name dietgoj.zip size 2193522 crc 59df571b md5 98a8fd70170b5e4280603cf1a4a80a86 sha1 064819075aa2f1638c672f9df0f4525d294a2b54 )
-)
-
-game (
-	name "Diet Go Go (USA v1.1 1992.09.26)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgou.zip size 2193480 crc f2a0d777 md5 a891e42831adb54dcab613e299f875d9 sha1 adc5976fc2db887ceb91cc0035bbbf3289822e7c )
 )
 
 game (
@@ -12971,13 +9687,6 @@ game (
 )
 
 game (
-	name "Digger"
-	year "1980"
-	developer "Sega"
-	rom ( name digger.zip size 7457 crc b0813344 md5 c560a494fb388386cc17ff25d5b3d4bf sha1 93be11e7dcc9303f2b20a4b3235cbff05620cbfa )
-)
-
-game (
 	name "Digger (CVS)"
 	year "1982"
 	developer "Century Electronics"
@@ -12988,7 +9697,7 @@ game (
 	name "Digger Man (prototype)"
 	year "2000"
 	developer "Kyle Hodgetts"
-	rom ( name diggerma.zip size 372322 crc 6bef009a md5 3074b8b9fe94355071cdfb36410469d3 sha1 480e68cea4a4056c2c2566cc83c3d58abe5a89b3 )
+	rom ( name diggerma.zip size 1719009 crc be44c412 md5 1f8c251021fe5e75a09b742e6c01754e sha1 423fd7ea71df795416f16e5419a751525fdf2c6a )
 )
 
 game (
@@ -13027,48 +9736,6 @@ game (
 )
 
 game (
-	name "Dingo (encrypted)"
-	year "1983"
-	developer "Ashby Computers and Graphics Ltd."
-	rom ( name dingoe.zip size 10641 crc e4b6ded7 md5 82f6d28917e3ad0c385500652953542a sha1 49ce697f1bad71a8c14d5af9fdd26c0e85f7c97f )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (World 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dino.zip size 4115385 crc 22ff20c9 md5 52b9e81c2ef937ec640e10a6d1454ece sha1 df365c931efdd29727939f05ac211aa6153e266d )
-)
-
-game (
-	name "Dinosaur Hunter (Chinese bootleg of Cadillacs and Dinosaurs)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinohunt.zip size 2865749 crc 52bc3aec md5 b480bfcfc3df21fb1bf4d30ae4db8abd sha1 ce7aa76bfc9fd472d229d880576ee54254157048 )
-)
-
-game (
-	name "Cadillacs: Kyouryuu Shin Seiki (Japan 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dinoj.zip size 4115608 crc 75ec2eba md5 f8db41a35da75a0aad8803cb7d09a395 sha1 2cf1fa539b34fe8374be8710c67b7f0d8887bec9 )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (bootleg with PIC16c57, set 1)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinopic.zip size 3127219 crc a37cba2e md5 5f0491a2bf256fae8a08e3ce88385800 sha1 3656d2d08e4bd0ebd65d56f7e0919ecce958e9aa )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (bootleg with PIC16c57, set 2)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinopic2.zip size 2915044 crc 8f91bb31 md5 4df959bff06afbf5a9b671fe0b4ae7db sha1 0cdbfd1c29caaca9eac875d3215b3d9c16f956cc )
-)
-
-game (
 	name "Dino Rex (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
@@ -13087,34 +9754,6 @@ game (
 	year "1992"
 	developer "Taito America Corporation"
 	rom ( name dinorexu.zip size 5630448 crc b53ad3ac md5 572849c06cf337a25e52c40e96982896 sha1 34d6a506d2bdfbd63d0af01104e5e354e1c78a74 )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (USA 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dinou.zip size 4115386 crc 9ea69060 md5 11a836bf851bc3424428c0565110d351 sha1 a09a54c440885e52a45ef658002b115c6d6bbaf0 )
-)
-
-game (
-	name "Dirt Dash (Rev. DT2)"
-	year "1995"
-	developer "Namco"
-	rom ( name dirtdash.zip size 17866918 crc 68c19a7f md5 c332b8aa2b0ca5981c95cfdeb47c38fe sha1 052d963660cf54f152112fdab74e7e495f3601e7 )
-)
-
-game (
-	name "Dirt Devils (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dirtdvls.zip size 47808705 crc 110580fa md5 5d0b2899401bfd731f42b03f93739aa0 sha1 29a887bac082dd06c70d7daa7dc1753bf5ea78ad )
-)
-
-game (
-	name "Dirt Devils (alt) (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dirtdvlsa.zip size 47808689 crc 5cce8ff7 md5 83d6151727a05512fd1c99ab93d046ca sha1 714cea6a747477ff0b5976aa655f126a65e0b2f9 )
 )
 
 game (
@@ -13178,13 +9817,6 @@ game (
 	year "1990"
 	developer "Irem"
 	rom ( name dkgensan.zip size 718426 crc 71dad722 md5 61c4c9c849d236e1177a6588f25c51ad sha1 7627173825c6003508ce8d47e7ac46e52061fe17 )
-)
-
-game (
-	name "Daiku no Gensan (Japan, M72)"
-	year "1990"
-	developer "Irem"
-	rom ( name dkgensanm72.zip size 719392 crc 88da5ee2 md5 92031a6778aadbcf2c117086ad160559 sha1 112b1f4512eead6ea57fa2ddbc681b057b3a995e )
 )
 
 game (
@@ -13279,66 +9911,10 @@ game (
 )
 
 game (
-	name "Donkey Kong Jr. (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name dkongjrm.zip size 30114 crc 0d41d3c2 md5 da5b45e620f856399c7022fcb56c0c69 sha1 11fd33c9ab39fc89e58534313406b20c8b080bee )
-)
-
-game (
 	name "Donkey Kong (US set 2)"
 	year "1981"
 	developer "Nintendo"
 	rom ( name dkongo.zip size 22294 crc 14f05c81 md5 e1c2d1971fc59e07057684c4b3dc76e1 sha1 f6e304cbb2a75897b9338bd5b8daed12a1e42f99 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. F2)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlair.zip size 22678 crc 594bf35a md5 392b06752685ce7199e26ce5ba06ca38 sha1 75957080b38ac49bbddd42bde759c5a710adf64a )
-)
-
-game (
-	name "Dragon's Lair (US Rev. A, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaira.zip size 21377 crc 2dbda8e0 md5 5c1fe04060140c0cdfb07fe4dfd3ca80 sha1 0de301fe1d3307ea90d34292eccc593820bfdc2a )
-)
-
-game (
-	name "Dragon's Lair (US Rev. B, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairb.zip size 21392 crc dc6d0146 md5 f22db7140369a760812a41b31cc8e914 sha1 cee503c02384edda7e1f392bfcc7e42f130b0afb )
-)
-
-game (
-	name "Dragon's Lair (US Rev. C, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairc.zip size 21399 crc d185eb63 md5 5c25d006f36e3df443437155cbab922e sha1 1fa494d9b4c6dfcb67833028869ac0dfebadb021 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. D, Pioneer LD-V1000)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaird.zip size 32449 crc 2644e73a md5 34d983af53bc1601f0ba6facdf2e0ca0 sha1 1cf03812e05f96bf6a037fd0321b129e18a317eb )
-)
-
-game (
-	name "Dragon's Lair (US Rev. E)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaire.zip size 25574 crc 2edc15d4 md5 590e545a2034c98f406228b16421a369 sha1 aff1bbb81f4f2de642e0e037437b141cb207fdd9 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. F)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairf.zip size 22669 crc 9338b1fc md5 4f51bd91017c9d6688e3999e99e98b22 sha1 653e8630426d0f968793760f734adb55a9a4b194 )
 )
 
 game (
@@ -13356,122 +9932,17 @@ game (
 )
 
 game (
-	name "Dragon's Lair (European)"
-	year "1983"
-	developer "Cinematronics (Atari license)"
-	rom ( name dleuro.zip size 10771 crc 6b041f9f md5 882670ab309cb1227ef7cdfc500e6cc2 sha1 27b98ce21948d6bce218a9fc32d641129b45b88b )
-)
-
-game (
-	name "Dragon's Lair (Italian)"
-	year "1983"
-	developer "Cinematronics (Sidam license?)"
-	rom ( name dlital.zip size 11355 crc 82ef32e8 md5 6c1ce451673186be1f5bf204afa94a70 sha1 a1fb0ad52eb56c728973a25507623a5e8f8b13ad )
-)
-
-game (
-	name "Diamond Touch (E - 30-06-97, Local)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name dmdtouch.zip size 758088 crc bbda8176 md5 8432afaa129dbc015a969eeaabcc013c sha1 b643e38d6a7be1e17fac5eba389da34a709f4652 )
-)
-
-game (
-	name "Diamond Derby (Newer)"
-	year "1994"
-	developer "Electrocoin"
-	rom ( name dmndrby.zip size 43838 crc 197c2146 md5 36b91a04e601ffdfcbda746f351a88a2 sha1 3320b0dcb9b4cf0992fc82c69fecbded1f504589 )
-)
-
-game (
-	name "Diamond Derby (Original)"
-	year "1986"
-	developer "Electrocoin"
-	rom ( name dmndrbya.zip size 44559 crc c3ddcc29 md5 230b8691f8b1c4afd49d0052ea6cacd9 sha1 da3e9366a00ef9051141b5f82919b7073a7df35b )
-)
-
-game (
-	name "Demon Front (ver. 102)"
-	year "2002"
-	developer "IGS"
-	rom ( name dmnfrnt.zip size 22900368 crc 0cf9030a md5 9d4927a9f86fd8930f31ea6aeba6de75 sha1 59429c8775b426a13117f8529aeb7d43ec9709fc )
-)
-
-game (
-	name "Demon Front (ver. 105)"
-	year "2002"
-	developer "IGS"
-	rom ( name dmnfrnta.zip size 22900750 crc 587c0898 md5 755a668fca31fc846076edc848ee8767 sha1 c2ab43c33bbffe49faaf21e153c4d7b28d448c80 )
-)
-
-game (
-	name "Dance Maniax (G*874 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dmx.zip size 314 crc e658be67 md5 c8e2500330ae011634b045459883ec45 sha1 e58896ba26c0ef90eb4870c4f511732492bb28ea )
-)
-
-game (
-	name "Dance Maniax 2nd Mix (G*A39 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dmx2m.zip size 314 crc 3f6d8e11 md5 4fc079d5157097f4bfa197a34f85ab73 sha1 fb3d589a1f53d47a0e5f69f3635e5bdad36872b5 )
-)
-
-game (
-	name "Dance Maniax 2nd Mix Append J-Paradise (G*A38 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name dmx2majp.zip size 4634 crc 6f5affa1 md5 0816a514c33acf8e6a4bfff80d81c0aa sha1 5b6be04023121f641b5dd7d8dc3306562e129532 )
-)
-
-game (
-	name "Dance Freaks (G*874 VER. KAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dncfrks.zip size 314 crc f9f737a2 md5 4bca5129ce2ca1075b7baacfa7d17a66 sha1 e17429fee02be248a21053cb994ef8010ad93fca )
-)
-
-game (
 	name "Dynamite Deka (J 960515 V1.000)"
 	year "1996"
 	developer "Sega"
-	rom ( name dnmtdeka.zip size 7089102 crc c0dda934 md5 82c04a52b1dec589af171326f49cca18 sha1 b12ac7439c09bd2e1e73e0a06e0c33063c7720c5 )
-)
-
-game (
-	name "Dead or Alive (Model 2B, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name doa.zip size 30324991 crc 9a6f5b67 md5 2c8870101893282c737f5e11c23f62f3 sha1 2200c407df29657cefa9d091a310ed855cabac07 )
-)
-
-game (
-	name "Dead or Alive 2 (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Tecmo"
-	rom ( name doa2.zip size 110833112 crc 38e5dcfe md5 61c0291e8b8458ae005388d0513df679 sha1 ca1a78a14694b93ef9a4a44f6c77add403ae140c )
-)
-
-game (
-	name "Dead or Alive 2 Millennium (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Tecmo"
-	rom ( name doa2m.zip size 110893403 crc d9b4f0f6 md5 d2f3706d64b36106642d459d83ce2723 sha1 f931417bf937b3170cc9e9206f3fd16123ffff09 )
-)
-
-game (
-	name "Dead or Alive (Model 2A, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name doaa.zip size 30748838 crc 1af57aae md5 166dd430e10bae27544a4239dc86bf56 sha1 005815d0b5f2b5cdd4bd4bedefd18810ed773c2c )
+	rom ( name dnmtdeka.zip size 9788323 crc 959d6eb0 md5 a9043a56011bd4a0e2cef361276c41f0 sha1 9c614004f4ab18599a60075cf6f2ac1950512849 )
 )
 
 game (
 	name "Dead Or Alive ++ (Japan)"
 	year "1998"
 	developer "Tecmo"
-	rom ( name doapp.zip size 13762285 crc ae91df65 md5 b2653725c2a747fbd2e87476806490ae sha1 6a9d264d0df9687b1db85f913407bfdaff37a3cf )
+	rom ( name doapp.zip size 13900737 crc b62bbee0 md5 9ccb651f29e9b9f0d8270a37686cfa12 sha1 977728c390b1ef01c42d38afb183acb5706603af )
 )
 
 game (
@@ -13500,20 +9971,6 @@ game (
 	year "1982"
 	developer "Taito Corporation"
 	rom ( name dockman.zip size 16711 crc 334b48a7 md5 1d49b7b0758fec868118fe23ea1086ed sha1 48c12422a84769c7dd54e749bc3f6dd690cd34b7 )
-)
-
-game (
-	name "Dodge City"
-	year "1986"
-	developer "Merit"
-	rom ( name dodge.zip size 34276 crc 62e27b36 md5 81bb9e44a81f4f3050f199c79ac46679 sha1 ed58ac81d547e62798cf838cd53578c762e307a2 )
-)
-
-game (
-	name "Dodgem"
-	year "1979"
-	developer "Zaccaria"
-	rom ( name dodgem.zip size 6580 crc f61e6575 md5 69598665867d0bb28d71f8b191836702 sha1 b2fc72f6ee4361ea6cfd650d4f3c562b84016813 )
 )
 
 game (
@@ -13559,20 +10016,6 @@ game (
 )
 
 game (
-	name "Dogyuun"
-	year "1992"
-	developer "Toaplan"
-	rom ( name dogyuun.zip size 2892442 crc 449d73bb md5 85579a46b662098b09553b1f03936cf7 sha1 a6b5070258595ab4d7a93e38e0d6eb831e0ec3f5 )
-)
-
-game (
-	name "Dogyuun (Unite Trading license)"
-	year "1992"
-	developer "Toaplan"
-	rom ( name dogyuunk.zip size 2892355 crc 0c3bcacd md5 bb6514b52501f8e706ca960ec03cc0ce sha1 f404ee611eae546e4a6c1acf8979c0ea2f5cdba5 )
-)
-
-game (
 	name "Dokaben (Japan)"
 	year "1989"
 	developer "Capcom"
@@ -13598,27 +10041,6 @@ game (
 	year "1995"
 	developer "Make Software / Elf / Media Trading"
 	rom ( name dokyusp.zip size 7090291 crc 2d7964bd md5 0e14ea5c92f78a3b7f9abb171a57ca53 sha1 4d691dffa58abb65fa11041317e2d2591b8b8a5a )
-)
-
-game (
-	name "Dolphin Blue"
-	year "2003"
-	developer "Sammy"
-	rom ( name dolphin.zip size 82591393 crc a2a08817 md5 1fc2018c8548953116f457a52f6569aa sha1 9db1341237f61aba8583f718ddaa6036490339eb )
-)
-
-game (
-	name "Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 1.24.4.0)"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name dolphntr.zip size 800520 crc 2a672a4e md5 60048aa3aac04b18bd1646d903cbd3b0 sha1 f595695c8507e7d8c653fb9633e91b41bc02005a )
-)
-
-game (
-	name "Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 3)"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name dolphtra.zip size 531116 crc 39fe003a md5 cd8d02525a7aea79d6a0c7e31835f073 sha1 e0a1a044c87bf30d897b812023434c002caef4b8 )
 )
 
 game (
@@ -13654,13 +10076,6 @@ game (
 	year "1983"
 	developer "Technos Japan"
 	rom ( name dommy.zip size 25511 crc fe66d09d md5 f9ddd665093b6471c154b49e3b0de1b7 sha1 97b6feca2ae94240330f3c792150683657c4ec6b )
-)
-
-game (
-	name "Donchan no Hanabi de Doon"
-	year "2003"
-	developer "Aruze / Takumi"
-	rom ( name doncdoon.zip size 19691175 crc ec7d1315 md5 8489d224631ca91adcbb18b4bdd350ac sha1 ce72d26f20e5440ada369461632342dc2f9b5422 )
 )
 
 game (
@@ -13717,13 +10132,6 @@ game (
 	year "1995"
 	developer "Cave (Atlus license)"
 	rom ( name donpachikr.zip size 4853009 crc 6680636d md5 eac9be8ef0a8155a5e99c59e353866e6 sha1 c49d38e822260ce4e93734431233540a3edc1e65 )
-)
-
-game (
-	name "Dorachan"
-	year "1980"
-	developer "Craul Denshi"
-	rom ( name dorachan.zip size 11301 crc 486f7f21 md5 1df037f8b200c78832e3f83d6d2b6665 sha1 c17ca350dc7c76c4ea6bff9fcccf1cf36d3618d7 )
 )
 
 game (
@@ -13807,7 +10215,7 @@ game (
 	name "Double Dragon (Neo-Geo)"
 	year "1995"
 	developer "Technos Japan"
-	rom ( name doubledr.zip size 9565151 crc 2f943a0c md5 daf2521039bd233ef2d1d8bbc31cb9f3 sha1 26c1b5e69d058d96d3ca78310cb90f48df9133f1 )
+	rom ( name doubledr.zip size 10911838 crc fe7b171b md5 fe463cc36ee84280e4061f800ee4765a sha1 954897b73a7d496e1bc33fd2c3567ccda4d6c155 )
 )
 
 game (
@@ -13822,13 +10230,6 @@ game (
 	year "1984"
 	developer "Universal"
 	rom ( name dowild.zip size 43654 crc f0fc706c md5 d9e69a1ca465c6ca8b5c889e9b098d61 sha1 89db8f372920e5eb1404cdf5ce12347c5738affc )
-)
-
-game (
-	name "Downhill Bikers (DH3 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name downhill.zip size 57991059 crc 73f39ca0 md5 0f1adf1d37544fb8d28529d1369c3969 sha1 b49c955621576272ceda0ca7ec24dda95fd4a280 )
 )
 
 game (
@@ -13860,50 +10261,10 @@ game (
 )
 
 game (
-	name "Draw Poker HI-LO (M.Kramer)"
-	year "1983"
-	developer "M.Kramer Manufacturing."
-	rom ( name dphl.zip size 5671 crc dc5516f2 md5 0abcc9f53ba16da7ab34215e15382a12 sha1 fec5ef1a5ed1c3ec436ef123bb5dcedbf029e58a )
-)
-
-game (
-	name "Draw Poker HI-LO (Alt)"
-	year "1983"
-	developer "&lt;unknown&gt;"
-	rom ( name dphla.zip size 4314 crc 103cb309 md5 05ec6c2c904c650409eb4baeef4b43a8 sha1 deb55147a94cdc2899ad7bfc04963c22c8f3d841 )
-)
-
-game (
-	name "Draw Poker HI-LO (Japanese)"
-	year "1983"
-	developer "&lt;unknown&gt;"
-	rom ( name dphljp.zip size 5551 crc 82c4efcd md5 37534b42d1c0f093b825f9cdf2285c3b sha1 993026343f0482a88707e027fca8eed9fbf56f0b )
-)
-
-game (
-	name "Draw Poker HI-LO (unknown, rev 1)"
-	developer "SMS Manufacturing Corp."
-	rom ( name dphlunka.zip size 5943 crc c1403fd9 md5 cabe944e33d7cff81ce2881b3ba184a1 sha1 158fa2daa7554c9678e1918ae9c7518c91e02b16 )
-)
-
-game (
-	name "Draw Poker HI-LO (unknown, rev 2)"
-	developer "SMS Manufacturing Corp."
-	rom ( name dphlunkb.zip size 5856 crc 32b600b7 md5 d0e4aa639fb530237cc58477ed7a9a9f sha1 663c5e8eff4c38e491835e5ec474bad16b7e28e6 )
-)
-
-game (
 	name "Double Play"
 	year "1977"
 	developer "Midway"
 	rom ( name dplay.zip size 6344 crc bf740d0a md5 dea1ec2e3f99ae0a6df51b9df031123e sha1 fff0dc0973da56cee7e6a586769fcedc7e5b3067 )
-)
-
-game (
-	name "Date Quiz Go Go (Korea)"
-	year "1998"
-	developer "SemiCom"
-	rom ( name dquizgo.zip size 1327729 crc 081f945d md5 6a2a30778523a7022cec607b04128c3f sha1 2b62d2071793d5b2cdb4079f1b6badf595715dbe )
 )
 
 game (
@@ -13918,13 +10279,6 @@ game (
 	year "1981"
 	developer "Cidelsa"
 	rom ( name draco.zip size 13763 crc d4493053 md5 3e40af261fc9a059ad03f9111aa136ff sha1 46b6be76ae7dae4044e4bb5678018e73675404a0 )
-)
-
-game (
-	name "Dragon Chronicles (DC001 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name dragchrn.zip size 2321284 crc 3eaf3810 md5 2b441168d74ef4c9f40cc63a8a3fe824 sha1 711ac16c948b9de5ea64de9da3e7d2418e9e83bb )
 )
 
 game (
@@ -13945,14 +10299,14 @@ game (
 	name "Dragoon Might (ver AAB)"
 	year "1995"
 	developer "Konami"
-	rom ( name dragoona.zip size 11435613 crc 3462e74d md5 bddf69a076ee9e7d587121108d116ed1 sha1 d4adf16e894b7b51858e05c3908abc1a37947662 )
+	rom ( name dragoona.zip size 11444303 crc ff24b2ae md5 761fab418a6ba4279e61568dd42ac7fa sha1 d102bc936ff0344992994b9334b1d219b06b5667 )
 )
 
 game (
 	name "Dragoon Might (ver JAA)"
 	year "1995"
 	developer "Konami"
-	rom ( name dragoonj.zip size 11435625 crc a818abda md5 02b9e677c2ee128f3423f017ca74e1df sha1 5a8075ba4e9e6dbd545b2a795183152fb4767782 )
+	rom ( name dragoonj.zip size 11444315 crc a1a1f9e4 md5 295fb08514eef2815e4fbfeb780c4feb sha1 ea3827fb6fdea46c2f2a829e17b328cd3439309b )
 )
 
 game (
@@ -13967,13 +10321,6 @@ game (
 	year "1984"
 	developer "Epos Corporation"
 	rom ( name drakton.zip size 17544 crc 4659e32f md5 8439319b9a7417a40ab64e99bdf988ce sha1 624a4e5f1ac35df3fb3e5b63a55ee92167dbc137 )
-)
-
-game (
-	name "Dream World"
-	year "2000"
-	developer "SemiCom"
-	rom ( name dreamwld.zip size 2007859 crc 7e39ed84 md5 87b93c596a51081bd1fe37c83ea5d9a4 sha1 82679e31d5694982becb4d0cdebe2da438aa97a1 )
 )
 
 game (
@@ -13995,13 +10342,6 @@ game (
 	year "1984"
 	developer "Namco"
 	rom ( name drgnbstr.zip size 60346 crc 94f96ab1 md5 69872262d0b16eb6381866ae3dfe2a14 sha1 845aaf84f2ab64fcb2e6829cd05e5cd5e30dcdd6 )
-)
-
-game (
-	name "Dragonninja (Japan)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name drgninja.zip size 447881 crc cb8dac56 md5 f612cf2e7850cb8429c839dbe7bbde44 sha1 b5f6f8fc90d02c01d6af4a00d4777b64b44f99ff )
 )
 
 game (
@@ -14075,66 +10415,10 @@ game (
 )
 
 game (
-	name "Dragon World II (ver. 110X, Export)"
-	year "1997"
-	developer "IGS"
-	rom ( name drgw2.zip size 3992048 crc 03c4b4e4 md5 4c7bd034e29b9491c9beccb06ee58f1b sha1 07353f1b569935b6905d43650a65b9708159a384 )
-)
-
-game (
 	name "Zhong Guo Long II (ver. 100C, China)"
 	year "1997"
 	developer "IGS"
-	rom ( name drgw2c.zip size 3991840 crc 8a4ff6a9 md5 c6fa48e04ee8cf7ccbf4a3e35bd4d90b sha1 ecaa4bea05bd39a072f64eabc00a85829e741feb )
-)
-
-game (
-	name "Chuugokuryuu II (ver. 100J, Japan)"
-	year "1997"
-	developer "IGS"
-	rom ( name drgw2j.zip size 3990690 crc a8d3b3f6 md5 b265904f1c485a844b3876a78f793712 sha1 7c9560cf358c0d702de67a17079b2829ce4ba5fb )
-)
-
-game (
-	name "Dragon World 3 (ver. 106, Korean Board)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3.zip size 5540174 crc fefbb250 md5 1461b2f7547751e511dd3968a14efd02 sha1 43a0c12c4e91388193e88d65f0ecad0a064cee42 )
-)
-
-game (
-	name "Dragon World 3 (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3100.zip size 5529252 crc 9539ba50 md5 38473dc734a92d6bf49d7f0bc3b0e215 sha1 a2714b838f43292e04e14216b5ffc7a034f6420c )
-)
-
-game (
-	name "Dragon World 3 (ver. 105)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3105.zip size 5540147 crc ee5011a8 md5 1d4e1066e16f4d4b77bb435714dc3e16 sha1 a88aa428d6a0b727cdf7ac158f977098e874613a )
-)
-
-game (
-	name "DRHL Poker (v.2.89)"
-	year "1986"
-	developer "Drews Inc."
-	rom ( name drhl.zip size 8702 crc 8fe37e73 md5 fb9b2a479c158eb36d038e767e0c44d1 sha1 23e773eca41a6fa08598144158f2c9370a0e203b )
-)
-
-game (
-	name "Dribbling"
-	year "1983"
-	developer "Model Racing"
-	rom ( name dribling.zip size 15461 crc 0e1c3ae2 md5 a12bb785b49d433c11e8cd56cf17fa12 sha1 f7237d4994c33c3da70ac1312533cb835864c37f )
-)
-
-game (
-	name "Dribbling (Olympia)"
-	year "1983"
-	developer "Model Racing (Olympia license)"
-	rom ( name driblingo.zip size 15550 crc ba5e89c1 md5 2af4387f46f83259e0a8b4f461f8fe86 sha1 70be3794864679e254afb2c67855c0ed31d28a02 )
+	rom ( name drgw2c.zip size 6086432 crc 1a5532fa md5 7c0340c47e196b7c1f633b33ff3a6886 sha1 29258c8508ef4ad2d4627e0d6fc00195b6d52038 )
 )
 
 game (
@@ -14163,13 +10447,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name driveout.zip size 1178395 crc 73f48efd md5 15d6c749f70ba3b1764cdc916762883a sha1 af9027760656a098fd4131461302d47d89020803 )
-)
-
-game (
-	name "Driver's Eyes (US)"
-	year "1991"
-	developer "Namco"
-	rom ( name driveyes.zip size 1800297 crc 8bdb910d md5 d672429672c627f10336c1c9d0c62470 sha1 065cb476de87e66b14f00323168fb9cba3387e18 )
 )
 
 game (
@@ -14215,73 +10492,10 @@ game (
 )
 
 game (
-	name "DrumMania (GQ881 VER. JAD)"
-	year "1999"
-	developer "Konami"
-	rom ( name drmn.zip size 4634 crc 34f4b5d4 md5 950295f7b7d57b46a5b02ef8667e8ead sha1 f2d264ccd7b2eb29fa066f761ee31f702b289ef7 )
-)
-
-game (
-	name "DrumMania 2nd Mix (GE912 VER. JAB)"
-	year "1999"
-	developer "Konami"
-	rom ( name drmn2m.zip size 548 crc eea97def md5 6cebef2beef31fc8a671d0294f796924 sha1 287631321ae50ce86691ab467d6348996417ba19 )
-)
-
-game (
-	name "DrumMania 2nd Mix Session Power Up Kit (GE912 VER. JAB)"
-	year "1999"
-	developer "Konami"
-	rom ( name drmn2mpu.zip size 548 crc eea97def md5 6cebef2beef31fc8a671d0294f796924 sha1 287631321ae50ce86691ab467d6348996417ba19 )
-)
-
-game (
-	name "DrumMania 3rd Mix (G*A23 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name drmn3m.zip size 546 crc 65f480b0 md5 61656352942a72f2ff5334084c66dfb3 sha1 5bcdd27470ad21822d20a3717652f57c54e7818c )
-)
-
-game (
 	name "Dr. Tomy"
 	year "1993"
 	developer "Playmark"
 	rom ( name drtomy.zip size 647547 crc 896806ec md5 fd9d0c4e8de0ed12070a55cc76391ad9 sha1 e2136ab36960b2c72dc519ce1626a87ba42b78f0 )
-)
-
-game (
-	name "Dr. Toppel's Adventure (World)"
-	year "1987"
-	developer "Kaneko / Taito Corporation Japan"
-	rom ( name drtoppel.zip size 399766 crc 9918e9f2 md5 1709c15d5d106dfc02a47a0846df2dd1 sha1 8a5c0bd41a7ad5dae9d6e3ba5c12b4b5f29f5eaf )
-)
-
-game (
-	name "Dr. Toppel's Tankentai (Japan)"
-	year "1987"
-	developer "Kaneko / Taito Corporation"
-	rom ( name drtoppelj.zip size 399766 crc 72100258 md5 f44dda1a8ef239b442c635a4658a83d9 sha1 aac8b7c658d31dc2aec0eac362d4bf87cf2f8f03 )
-)
-
-game (
-	name "Dr. Toppel's Adventure (US)"
-	year "1987"
-	developer "Kaneko / Taito America Corporation"
-	rom ( name drtoppelu.zip size 399766 crc 2fbc27c2 md5 b24f4ef7918769826c0acb1eec415b65 sha1 640e8722ec8517b31668047c3f42b11ef2305c62 )
-)
-
-game (
-	name "Draw 80 Poker - Minn"
-	year "1983"
-	developer "IGT - International Gaming Technology"
-	rom ( name drw80pk2.zip size 5890 crc f97db59f md5 65d7200747deb443bb998797265757e2 sha1 62b5bbf2e6c771d30a44bcac759f1e0ed57bf740 )
-)
-
-game (
-	name "Draw 80 Poker"
-	year "1982"
-	developer "IGT - International Gaming Technology"
-	rom ( name drw80pkr.zip size 7588 crc 645a9fba md5 fc7528b7418b4add050a2d3523fb2bab sha1 c3eb14c3e3e820311487bb39643b484e4dbe866f )
 )
 
 game (
@@ -14296,48 +10510,6 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name dsaberj.zip size 1979112 crc ce8006fc md5 a3e84ee7d9afd83affbb4d78ae6cd52a sha1 d19995135d0d48eee8e67a78daa119d6b3c26040 )
-)
-
-game (
-	name "Dancing Stage Euro Mix (G*936 VER. EAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dsem.zip size 290 crc 0b84aa39 md5 fda883a7808925deffe64826d8c5528f sha1 cdf2bbcbc754afe72a9475aa8c1a12cba55356c9 )
-)
-
-game (
-	name "Dancing Stage Euro Mix 2 (G*C23 VER. EAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name dsem2.zip size 314 crc 97973de3 md5 d46f67b66ebf2677b3db773c3587182d sha1 d24e62282ee4cba8dd1f4df29884a0da97e8fb76 )
-)
-
-game (
-	name "Dancing Stage featuring Dreams Come True (GC910 VER. JCA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsfdct.zip size 562 crc b9ce550a md5 7f9620de0c7fb4bf7e1eecfe861aa9ea sha1 0476f58d28dadf0d2c6b3efc108e502d45c80bda )
-)
-
-game (
-	name "Dancing Stage featuring Dreams Come True (GC910 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsfdcta.zip size 520 crc 26461800 md5 14b81023c177ff70527cdabc40c0253a sha1 699e051ff1a86952d79029dc2e2c87ece8caeacc )
-)
-
-game (
-	name "Dancing Stage Featuring Disney's Rave (GCA37JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dsfdr.zip size 548 crc 9175a62d md5 ae017408072eacd23f193194ff7e6c84 sha1 f6180a0679c23204f366f5284c692ec3b5fad324 )
-)
-
-game (
-	name "Dancing Stage featuring TRUE KiSS DESTiNATiON (G*884 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsftkd.zip size 282 crc 158cab8d md5 d3ccc8bcd00aabc04ef31f26fb200063 sha1 d5478456f4feda819d9b4673398a45f593b89c3b )
 )
 
 game (
@@ -14373,13 +10545,6 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name dspirito.zip size 1098855 crc 2e754460 md5 4b91ebc095c1633edc7fa02a8b37c12f sha1 b863fbfb2a5d383ac44313be7fbe775e82f326cc )
-)
-
-game (
-	name "Dancing Stage (GN845 VER. EAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dstage.zip size 172 crc 211884f7 md5 3f10c9aa74fe4f8e8b5fb180c7bce079 sha1 8302f141cd7a14e6f2a859df393e65d0e0d7ac08 )
 )
 
 game (
@@ -14439,13 +10604,6 @@ game (
 )
 
 game (
-	name "Dump Matsumoto (Japan, 8751 317-0011a)"
-	year "1986"
-	developer "Sega"
-	rom ( name dumpmtmt.zip size 339111 crc 07732161 md5 81d2564aa21f033ecdfad486029f3049 sha1 802a1980d726a4bd33150f59ccc3ec983b669f1f )
-)
-
-game (
 	name "Dungeon Magic (Ver 2.1O 1994/02/18)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -14488,48 +10646,6 @@ game (
 )
 
 game (
-	name "Devil Island"
-	year "2006"
-	developer "Amcoe"
-	rom ( name dvisland.zip size 221080 crc fb0f3f1d md5 2f755cde386e5ee5f617cdb16446462e sha1 96cc3098fecb0fa8d05e7c54f445fdabd1d0720d )
-)
-
-game (
-	name "Dragon World 2001"
-	year "2001"
-	developer "IGS"
-	rom ( name dw2001.zip size 3812332 crc c14bbb4a md5 55b777397579966adfee53b1a020bc82 sha1 e2e7ea59dbb9206fb2534f993c57f624d435c843 )
-)
-
-game (
-	name "Dwarfs Den"
-	year "1981"
-	developer "Electro-Sport"
-	rom ( name dwarfd.zip size 17403 crc 392353e1 md5 c9205d5b6c7461f184b62cd5d0761388 sha1 66845d5db9eebd0dbca30449598a79759ee7806a )
-)
-
-game (
-	name "Dragon World 3 EX (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name dwex.zip size 3617735 crc 4ddaa7ee md5 21b4eda55375e3efb793c7a6028897ba sha1 49aac07afa5830340c0f5205d6ac7a0589d5fe87 )
-)
-
-game (
-	name "Dynamite Baseball '99 (JPN) / World Series '99 (USA, EXP, KOR, AUS) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name dybb99.zip size 102221240 crc fc4c92ca md5 384354a930c05e50bb17879026eb95d6 sha1 db147f68072c4f7aae566082fd1af76609a60e12 )
-)
-
-game (
-	name "Dynamite Baseball NAOMI (JPN)"
-	year "1998"
-	developer "Sega"
-	rom ( name dybbnao.zip size 111036772 crc 7b647fd8 md5 f9b8fee1a75be4c9dbfe8d95a43cbfbe sha1 d9d62072f6e151c790c0e93f3d9ef7cfe190028a )
-)
-
-game (
 	name "Dyger (Korea set 1)"
 	year "1989"
 	developer "Philko"
@@ -14541,20 +10657,6 @@ game (
 	year "1989"
 	developer "Philko"
 	rom ( name dygera.zip size 249892 crc 1c016c1e md5 8cfa074b2d243a1cec6edcc117193c9b sha1 e499da5b2d86e6addb45e3f8de28aa4857d446cb )
-)
-
-game (
-	name "Virtua Golf / Dynamic Golf (Rev A) (GDS-0009A)"
-	year "2001"
-	developer "Sega"
-	rom ( name dygolf.zip size 3383 crc 6fa7f6a1 md5 f51bd3399e64d4a0ad2ca49cdba4cd20 sha1 5cf3d191badb71f067195914120aed867edc0415 )
-)
-
-game (
-	name "Dynamite Baseball '97 (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name dynabb.zip size 22633404 crc 7de4ba7d md5 c5fe7f985c0dea043e584cb39cedba77 sha1 7154c962bb4f5284879f92bce2814535f089a437 )
 )
 
 game (
@@ -14572,13 +10674,6 @@ game (
 )
 
 game (
-	name "Dynamite Bomber (Korea, Rev 1.5)"
-	year "2000"
-	developer "Limenko"
-	rom ( name dynabomb.zip size 5708807 crc 857c86cf md5 e1c5640ff9d9f83152e7b8353686522d sha1 0b9a99c62791bee27c7de4550d9cf827d20f104e )
-)
-
-game (
 	name "Dynamic Dice"
 	developer "&lt;unknown&gt;"
 	rom ( name dynadice.zip size 7102 crc 492b5182 md5 7445223e70e40a0ddcc41c347ae5ccda sha1 b2fdc494611402e5df879d51095533da077ce8fb )
@@ -14592,52 +10687,10 @@ game (
 )
 
 game (
-	name "Dynamite Cop (Export, Model 2A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcop.zip size 35013273 crc 8b2c12bb md5 7b36ddc720f2fedc0c7fb80457dd2ea4 sha1 5976ded905e098028430f9e69a1610b003a9978e )
-)
-
-game (
-	name "Dynamite Cop (Export, Model 2B)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcopb.zip size 34593470 crc 8330b54d md5 b41ea82010f0a66e0e91916f6dffdd1a sha1 8f9ed2456d62ef5cd5e93a57114f78f16f9278de )
-)
-
-game (
-	name "Dynamite Cop (USA, Model 2C)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcopc.zip size 34588142 crc 08d08f2c md5 8e67a2bfc3b6ae91df5813ae29425c8a sha1 6adcd0005c44b0495dc11a3430ae8929a9a266aa )
-)
-
-game (
 	name "Dynamic Ski"
 	year "1984"
 	developer "Taiyo"
 	rom ( name dynamski.zip size 36061 crc 9c578545 md5 684716f8d5ee86336ecfe5494205e1a3 sha1 ec69a8cb5dc79af218a0f7f213433f0e3e47bc62 )
-)
-
-game (
-	name "Dynamic Shooting"
-	year "1988"
-	developer "Jaleco"
-	rom ( name dynashot.zip size 67568 crc 48edb7c5 md5 626d6e3c8e6137d8104d6416a6ffa95e sha1 50abcd3eb85dc5c5510be60c7ac4732de844c06c )
-)
-
-game (
-	name "Dynamite Deka 2 (Japan, Model 2A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dyndeka2.zip size 35013220 crc d327bbe4 md5 8d7cbfc1dbbb01f54a768574d04e9b09 sha1 1d70105eef41a019bacc041bd50e1a5f21c0695a )
-)
-
-game (
-	name "Dynamite Deka 2 (Japan, Model 2B)"
-	year "1998"
-	developer "Sega"
-	rom ( name dyndeka2b.zip size 34593414 crc 2cf38a4b md5 e96190a9e99b937334d18c7016bf010f sha1 c562821c83dde250594d96e099e4d8520504a8a4 )
 )
 
 game (
@@ -14666,20 +10719,6 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name dynwar.zip size 2193606 crc 13133f73 md5 e45c907aa7c9d903403d9e7e38b07d68 sha1 80e256ade6aa053e026088210e9b4557e406c953 )
-)
-
-game (
-	name "Tenchi wo Kurau (Japan)"
-	year "1989"
-	developer "Capcom"
-	rom ( name dynwarj.zip size 2253157 crc caf6422e md5 53098e9732c61bbce01286b00ef2bf7b sha1 cc43e1b9b3cc6b92f6948b3da6e0d33349e92edc )
-)
-
-game (
-	name "Dynasty Wars (USA, set 2)"
-	year "1989"
-	developer "Capcom"
-	rom ( name dynwaru.zip size 2266318 crc 19515ecc md5 7bb070e8cf74998b104b7c02eb195de7 sha1 1a46d0ad3752bf96f09317bd11632b27198ebd8a )
 )
 
 game (
@@ -14732,20 +10771,6 @@ game (
 )
 
 game (
-	name "Emergency Call Ambulance"
-	year "1999"
-	developer "Sega"
-	rom ( name eca.zip size 59917658 crc 3d379e30 md5 109a69549a6003e4c21d68eeee8d01dc sha1 7a9d93fe283182cee1f01debf18f9648760ae292 )
-)
-
-game (
-	name "Emergency Call Ambulance (Export)"
-	year "1999"
-	developer "Sega"
-	rom ( name ecax.zip size 59917655 crc ce681437 md5 ec7bfc06e04e1433de9b4dcd1e82fc6a sha1 5bfd9b2b84cddb4dd1d31ece71fb592b971ec2b6 )
-)
-
-game (
 	name "Eco Fighters (World 931203)"
 	year "1993"
 	developer "Capcom"
@@ -14781,27 +10806,6 @@ game (
 )
 
 game (
-	name "E.D.F. : Earth Defense Force"
-	year "1991"
-	developer "Jaleco"
-	rom ( name edf.zip size 1166516 crc 621c9451 md5 36f6b6f7c778cb42b70f9b62838f047c sha1 0843e086044885aa1c5b6a95f577790f0045f5e0 )
-)
-
-game (
-	name "E.D.F. : Earth Defense Force (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name edfbl.zip size 1257715 crc b53540f4 md5 32e7d0f8cdaa6bac60a3cacde379b488 sha1 8d0023c47d7996fa3c1b920f0273795c7f54e240 )
-)
-
-game (
-	name "E.D.F. : Earth Defense Force (North America)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name edfu.zip size 1166510 crc 3c83ab18 md5 2f941401ff6d44bafa14edcf79251828 sha1 a7751e587e9ebc84a74ef53ba3b14ee72c60a1c7 )
-)
-
-game (
 	name "The Cliffhanger - Edward Randy (World ver 3)"
 	year "1990"
 	developer "Data East Corporation"
@@ -14830,13 +10834,6 @@ game (
 )
 
 game (
-	name "Enchanted Forest - 12XF528902"
-	year "1994"
-	developer "Aristocrat"
-	rom ( name eforest.zip size 51630 crc 04715ef3 md5 29d7d2ebe57c43bcc1bfa50096764c70 sha1 f6fa438facbe7cffab54aa57f72fe850a8f80c62 )
-)
-
-game (
 	name "Enchanted Forest - 4VXFC818"
 	year "1995"
 	developer "Aristocrat"
@@ -14855,13 +10852,6 @@ game (
 	year "1995"
 	developer "Invi Image"
 	rom ( name egghunt.zip size 973751 crc b0db3102 md5 5a12d14ce0a9f172b1dfd8ca752a9c14 sha1 54d83ed62909a5f64cf11002109ccf849eb40805 )
-)
-
-game (
-	name "Eggor"
-	year "1983"
-	developer "Telko"
-	rom ( name eggor.zip size 15733 crc 4f26a659 md5 b891df5d59d7b0faa260b9f7118b4a8e sha1 ef8095a7ae1ee548e0235af3492e1ef37394ed96 )
 )
 
 game (
@@ -14938,7 +10928,7 @@ game (
 	name "Eight Man"
 	year "1991"
 	developer "SNK / Pallas"
-	rom ( name eightman.zip size 2935505 crc a5740422 md5 3ca0f051c842cef437a86e5b212c8cd6 sha1 651a48e08ddcadc8140b929e7f4d3f4832017291 )
+	rom ( name eightman.zip size 4282192 crc bf20d024 md5 59038e4caf3116c32be5e13dcc25a744 sha1 9baf479d1c5b79869a936c4879dab77c9c6a2573 )
 )
 
 game (
@@ -14959,13 +10949,7 @@ game (
 	name "Ejihon Tantei Jimusyo (J 950613 V1.000)"
 	year "1995"
 	developer "Sega"
-	rom ( name ejihon.zip size 19898822 crc 7cfb1a57 md5 f665e66a94e4e3ad16572bca43776c65 sha1 dcec08c8df9ab6ab5a8fe5f35623d4bab9d01791 )
-)
-
-game (
-	name "Euro Jolly X5"
-	developer "Solar Games"
-	rom ( name ejollyx5.zip size 410664 crc ffed92d9 md5 39006ebbf6548b1d9cde68aa017afecd sha1 3468b4b7bd0f387970ff7adf518e3fa4c0711854 )
+	rom ( name ejihon.zip size 22598043 crc 6434210c md5 0f40265b8ce29ef58d9093b04dc7a0f4 sha1 f1471a14cbf3f89097d3477c997e1863011f1658 )
 )
 
 game (
@@ -14983,13 +10967,6 @@ game (
 )
 
 game (
-	name "Touryuu Densetsu Elan-Doree / Elan Doree - Legend of Dragoon (JUET 980922 V1.006)"
-	year "1998"
-	developer "Sai-Mate"
-	rom ( name elandore.zip size 12416279 crc 1973e039 md5 e7f696eb1f5b8f1dc71d5d02748c2644 sha1 6d95eff054e8ecc9af6916bd01c1d4a61fde5d38 )
-)
-
-game (
 	name "The Electric Yo-Yo (set 1)"
 	year "1982"
 	developer "Taito America Corporation"
@@ -15001,20 +10978,6 @@ game (
 	year "1982"
 	developer "Taito America Corporation"
 	rom ( name elecyoyo2.zip size 30048 crc fa62d89e md5 59fbea174b2f7d0399dea4d11423cb38 sha1 80922982bbbb694985696c537eb1a097dfa0718a )
-)
-
-game (
-	name "Elephant Family (Italian, new)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name elephfam.zip size 53968 crc c1714542 md5 17b7783f2d0b37b707ff4c041ab2006f sha1 0d5da2f9cf27ce4f696557e95f8ae7616f222992 )
-)
-
-game (
-	name "Elephant Family (Italian, old)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name elephfmb.zip size 27574 crc 1239e0db md5 c82eb438d5cd85184ba3f4d0b2a886b0 sha1 84b4d4657d0b6d045cbe7c8adc23f39432c476ea )
 )
 
 game (
@@ -15081,30 +11044,10 @@ game (
 )
 
 game (
-	name "Elevator Action Returns (Ver 2.2O 1995/02/20)"
-	year "1994"
-	developer "Taito Corporation Japan"
-	rom ( name elvactr.zip size 8186906 crc d89e457f md5 df255cc7c1faa0502dd0ff6512596fe0 sha1 c1aa23e690c86c85fcbec1b57e7ad6dc6d58eb5d )
-)
-
-game (
 	name "Elevator Action Returns (Ver 2.2J 1995/02/20)"
 	year "1994"
 	developer "Taito Corporation"
 	rom ( name elvactrj.zip size 8186059 crc 0a35cc00 md5 bf386617fb1544b748de5c572bf5ee44 sha1 0142301d633f3990a82e634a704f8cdd9d4736a4 )
-)
-
-game (
-	name "Elvis?"
-	developer "&lt;unknown&gt;"
-	rom ( name elvis.zip size 392765 crc 74ebf3b6 md5 86d460b82a3a02203971eee0d4c042a5 sha1 2e455d43a9182c7eb16aa18062da00d2d91df569 )
-)
-
-game (
-	name "Embargo"
-	year "1977"
-	developer "Cinematronics"
-	rom ( name embargo.zip size 3935 crc 454a6306 md5 c00a72c83b8272dd85874bcbf02ad7da sha1 639d676508573717f5d666f4d2ee1fa05b0da14d )
 )
 
 game (
@@ -15150,27 +11093,6 @@ game (
 )
 
 game (
-	name "Enchanted Forest (E - 23/06/95, Local)"
-	year "1995"
-	developer "Aristocrat"
-	rom ( name enchfrst.zip size 656213 crc 4ee6db7f md5 2a318822ebb664c2b44508ee989ea089 sha1 7d6827d2146a375de0cebcefb7aea2244f560629 )
-)
-
-game (
-	name "Gundam Wing: Endless Duel (SNES bootleg)"
-	year "1996"
-	developer "bootleg"
-	rom ( name endless.zip size 1501648 crc 732b7e75 md5 c4913184de02e1416abf9d5be8c2ec65 sha1 d365d7c29696c3aa5b314fda90b4995ea459dd1b )
-)
-
-game (
-	name "Enduro Racer (bootleg set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name endurob2.zip size 636034 crc 6da4a8c8 md5 64d8f1cdae20357bd4e25132fd0fca29 sha1 edd90d3f78d0dc61dace45e11c721933a4862a49 )
-)
-
-game (
 	name "Enduro Racer (bootleg set 1)"
 	year "1986"
 	developer "bootleg"
@@ -15206,20 +11128,6 @@ game (
 )
 
 game (
-	name "Enigma II (Space Invaders hardware)"
-	year "1984"
-	developer "Zilec Electronics"
-	rom ( name enigma2a.zip size 10881 crc b05bc706 md5 526d8db1d2e923ae2d11ffe55490418d sha1 c3b85f4dd7b24ab501d476b705eb90295feef3d3 )
-)
-
-game (
-	name "Phantoms II (Space Invaders hardware)"
-	year "1981"
-	developer "Zilec Electronics"
-	rom ( name enigma2b.zip size 10879 crc abca69a6 md5 29c2bc42e4a9902e5507ee9ad6ad8ba6 sha1 3e3b7c54b1e2ff2950d67a138f57bd051e88e38a )
-)
-
-game (
 	name "Escape from the Planet of the Robot Monsters (set 1)"
 	year "1989"
 	developer "Atari Games"
@@ -15248,13 +11156,6 @@ game (
 )
 
 game (
-	name "Erotictac/Tactic"
-	year "1990"
-	developer "Sisteme"
-	rom ( name ertictac.zip size 582304 crc c1fdbc4f md5 efaa666b578a3d15778008e0f4d2900e sha1 86745d75f28ec39136e73f5e43f98be6139202ea )
-)
-
-game (
 	name "The Empire Strikes Back"
 	year "1985"
 	developer "Atari Games"
@@ -15280,27 +11181,6 @@ game (
 	year "1990"
 	developer "BFM"
 	rom ( name escounts.zip size 450598 crc 85ee4d87 md5 74a88b51d7bf3b2f24ff223ce40406b2 sha1 4734719828ad3ed0e568957f727f28ccf725f2e6 )
-)
-
-game (
-	name "Esh's Aurunmilla (set 1)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name esh.zip size 21472 crc 72f34836 md5 19f6e5eafacecbd7be5f10afb6f3e61d sha1 ddd9f1cadee0ba7bd384c64c00022446490b2ada )
-)
-
-game (
-	name "Esh's Aurunmilla (Set 2)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name esha.zip size 21473 crc d1cfe5d4 md5 928e815baf2d9b5547fe4481fe945990 sha1 a5fc4abc71131b367d14263878267b2bd05e3ef3 )
-)
-
-game (
-	name "Esh's Aurunmilla (Set 3)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name eshb.zip size 21475 crc 029a0877 md5 7999733ae4ebf8e5fb8b34b87533c48e sha1 e3cc62c59b7a31dbf0d13f0fd72dbee45cd7c63d )
 )
 
 game (
@@ -15346,13 +11226,6 @@ game (
 )
 
 game (
-	name "E-Swat - Cyber Police (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name eswatbl.zip size 1045899 crc 1774f826 md5 e38177635bf5f76e51cf935a11f0bf36 sha1 b92d6714410bc6285528cf6f34f300f9c222540b )
-)
-
-game (
 	name "E-Swat - Cyber Police (set 1, Japan, FD1094 317-0128)"
 	year "1989"
 	developer "Sega"
@@ -15374,44 +11247,10 @@ game (
 )
 
 game (
-	name "Europa 2002 (Ver 2.0, set 1)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2.zip size 696520 crc 611f01d1 md5 6442225635c7bf23ce57b5a7a0bb94d6 sha1 ca2e106e85c8e2dd3d5945df6ddf1e2fe84a1a38 )
-)
-
-game (
-	name "Europa 2002 (Ver 2.0, set 2)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2a.zip size 774168 crc d837b41e md5 76e4f0c266a067becda0ef0a0b8e88d7 sha1 75b8adb1383cc13fedb5bab86f56d937b35aa66f )
-)
-
-game (
-	name "Europa 2002 Space (Ver 3.0)"
-	year "2002"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2s.zip size 661458 crc c5ba3b51 md5 4450276082bc33a0273fed016887c46e sha1 ea43f625e66feae40b916a4eae1ae03e936befa2 )
-)
-
-game (
 	name "Euro Champ '92 (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
 	rom ( name euroch92.zip size 2016458 crc a5b6d116 md5 1a106efcb8da5c2a21086a3fa80bb3cb sha1 858ba6d7ce67267ea615d933e52df9597da1e7ad )
-)
-
-game (
-	name "Euro Pass (Ver 1.1)"
-	developer "&lt;unknown&gt;"
-	rom ( name europass.zip size 240504 crc 404b65d8 md5 5582c097032885e4ad4b5644a5c06010 sha1 121cf8337d50e9c249f1193748d37fd378399e3d )
-)
-
-game (
-	name "Evil Night (ver EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name evilngt.zip size 3813571 crc 2235b717 md5 60916d0b936a9d1080b11bfd86dbc49d sha1 6d72b32e638e1399d168e7dbd5e3bf3e039c258e )
 )
 
 game (
@@ -15425,7 +11264,7 @@ game (
 	name "Evolution Soccer"
 	year "2001"
 	developer "Evoga"
-	rom ( name evosocc.zip size 20537914 crc a4f2ab30 md5 8c46ebd8f960316769de7eaf38a4a93f sha1 6374026c0d065ab7defcec13dc18e86354d85821 )
+	rom ( name evosocc.zip size 20581372 crc 3050e988 md5 d79ce9880a8766a91b0c387ce4cabb06 sha1 a7d0bbf05efb4440b5dc89cc091b6b748707b0a0 )
 )
 
 game (
@@ -15596,27 +11435,6 @@ game (
 )
 
 game (
-	name "Extermination (World)"
-	year "1987"
-	developer "Taito Corporation Japan"
-	rom ( name extrmatn.zip size 369284 crc 1f69d677 md5 9f7f0b26e33fc46c495fc62dce2fc811 sha1 fb611f82b86a4620e8248970a27a29ee2a677486 )
-)
-
-game (
-	name "Extermination (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name extrmatnj.zip size 369284 crc 77d4bc0b md5 15325320d8b3fe6c25935b0fb02aed3c sha1 de4ada625016e1d01ba987359c98f2dd71251bb9 )
-)
-
-game (
-	name "Extermination (US)"
-	year "1987"
-	developer "Taito (World Games license)"
-	rom ( name extrmatnu.zip size 369285 crc 37f9d15f md5 7b1a21ebe6389ccb7b67526c27096aa2 sha1 6bb22af2deaec9e3ddfaa673ff87975f75f2d288 )
-)
-
-game (
 	name "Exvania (Japan)"
 	year "1992"
 	developer "Namco"
@@ -15631,13 +11449,6 @@ game (
 )
 
 game (
-	name "Exzisus (Japan, conversion)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name exzisusa.zip size 273439 crc 1d659fea md5 fd0de37193734c2813933e665bf0cdda sha1 7e9a319613f253280525b82271ce2cfaed1bab34 )
-)
-
-game (
 	name "Eyes (Digitrex Techstar)"
 	year "1982"
 	developer "Digitrex Techstar (Rock-Ola license)"
@@ -15649,18 +11460,6 @@ game (
 	year "1982"
 	developer "Techstar (Rock-Ola license)"
 	rom ( name eyes2.zip size 15559 crc be54ab99 md5 1e1b20ea70d43f8e9a1030e6418a9c55 sha1 7a83fcec2e5e4b7406f18195a4b2279beedbe96b )
-)
-
-game (
-	name "Eyes Down (v1.3)"
-	developer "Barcrest"
-	rom ( name eyesdown.zip size 92968 crc 49e4aa95 md5 41c4683b0d78268e49c5834324561015 sha1 bfa22e67e55849463ce1d203bf09f895c7331d6f )
-)
-
-game (
-	name "Eyes Down (v1.3, Datapak)"
-	developer "Barcrest"
-	rom ( name eyesdownd.zip size 92968 crc 67d4a4b3 md5 fd562986c196c79b8cf24580ae266f25 sha1 b9a4a52b5f1e87699c7f6e0b3c319c561de5b8e8 )
 )
 
 game (
@@ -15682,13 +11481,6 @@ game (
 	year "1991"
 	developer "Microprose Games Inc."
 	rom ( name f15se21.zip size 1607252 crc fbdef45b md5 aca1a84dd586021b114a199b74c40dfb sha1 3a1b03f79c80c271775ab5c6f2d5adf6ad5d32c4 )
-)
-
-game (
-	name "F-1 Dream"
-	year "1988"
-	developer "Capcom (Romstar license)"
-	rom ( name f1dream.zip size 338876 crc 3fdf1f53 md5 90c9cf086d72d31a224fbc49880b4ae1 sha1 3ff536b5a5e5d5b283e26af5fd2f02c56cfcbfc7 )
 )
 
 game (
@@ -15720,13 +11512,6 @@ game (
 )
 
 game (
-	name "F-1 Grand Prix (Playmark bootleg)"
-	year "1991"
-	developer "bootleg (Playmark)"
-	rom ( name f1gpb.zip size 3129759 crc b696c797 md5 1d9a806ec64b769e01c988b4bb8e7338 sha1 b91dc02a7bcf464cc06140cedb0c9821e344ae0d )
-)
-
-game (
 	name "Grand Prix Star"
 	year "1991"
 	developer "Jaleco"
@@ -15738,41 +11523,6 @@ game (
 	year "1993"
 	developer "Jaleco"
 	rom ( name f1gpstr2.zip size 4131456 crc 51afa282 md5 b2e9661453316c975c2dddecaf18ebe8 sha1 bc26c842587dbe0392c00a00e85ec6ecaf0e3f15 )
-)
-
-game (
-	name "F1 Super Lap"
-	year "1993"
-	developer "Sega"
-	rom ( name f1lap.zip size 7283905 crc c0fb2ea5 md5 9517e036c9692418ba29e481500f176e sha1 72583508da16e1fc3602da2c78cc0cfc03fbf074 )
-)
-
-game (
-	name "F1 Super Battle"
-	year "1994"
-	developer "Jaleco"
-	rom ( name f1superb.zip size 17252759 crc db722fe3 md5 76c4bf623651ab6494cd9622005c95f5 sha1 3d47f57c2efc4779bac13f876fb62bd8f9af970a )
-)
-
-game (
-	name "Ferrari F355 Challenge"
-	year "1999"
-	developer "Sega"
-	rom ( name f355.zip size 100802019 crc a5f64cd9 md5 e420a44776c5609fe1254c6952a15e53 sha1 ded73a2e64295085c2d2821f68b304eec6957fd2 )
-)
-
-game (
-	name "Ferrari F355 Challenge (Twin)"
-	year "1999"
-	developer "Sega"
-	rom ( name f355twin.zip size 94300637 crc 541f373e md5 bd7ea30f43b0ed328f6c4775b94c5a6d sha1 b183a0967a1e5ddc0eca3ac1d21e85d490538095 )
-)
-
-game (
-	name "Ferrari F355 Challenge 2 (Twin)"
-	year "1999"
-	developer "Sega"
-	rom ( name f355twn2.zip size 107505518 crc 7df2a0e4 md5 4034a5d9f72661ac519f929ed5ae31fa sha1 5641a1f4e994bbfd70fc5ed9ca96696dd0915f60 )
 )
 
 game (
@@ -15842,14 +11592,14 @@ game (
 	name "Fantastic Journey (ver EAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name fantjour.zip size 5765614 crc 3f57f79d md5 45a31b3b1a4cc779343cf160096a80d6 sha1 27095fedb493c477ae31146b1630f090a5126ed3 )
+	rom ( name fantjour.zip size 5774304 crc c007b680 md5 0b7417d909d0880ca92e029b35634c94 sha1 2a2f03b5c5207fad818fe013b89ff9f74ec7ffd4 )
 )
 
 game (
 	name "Fantastic Journey (ver AAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name fantjoura.zip size 5765615 crc 1c005e39 md5 5e4e064fc75151444c7d42d86090b855 sha1 f3f629a2a9718191333772d34afa282cb5acd5c3 )
+	rom ( name fantjoura.zip size 5774305 crc 7e0e1920 md5 173fcc55ac3db111e078259072e84203 sha1 b9d5afc0f4a4d31f1f444ad87dcfd5d773cd007f )
 )
 
 game (
@@ -15921,37 +11671,10 @@ game (
 )
 
 game (
-	name "Far West"
-	year "1986"
-	developer "bootleg?"
-	rom ( name farwest.zip size 102736 crc 117db825 md5 8f3055d789824639c7053039d1a28dda sha1 37d0b7d41638c3515ff4472f2fac23fd10ed44e9 )
-)
-
-game (
 	name "Fashion (Version 2.14)"
 	year "2000"
 	developer "High Video"
 	rom ( name fashion.zip size 883892 crc 12ab0b3c md5 943f36ea39da1c1402c693030a91ae3d sha1 5d3709249253b7406762643bcbd0648382bc3e1d )
-)
-
-game (
-	name "Fashion Gambler"
-	year "1997"
-	developer "ADP"
-	rom ( name fashiong.zip size 220029 crc 8d47ad03 md5 5f5916942e303b755094d550d78552c2 sha1 b261f050232ff8e76a0f1a06ec86a17160f06c71 )
-)
-
-game (
-	name "Fast Draw Showdown v1.3"
-	year "1995"
-	developer "American Laser Games"
-	rom ( name fastdraw.zip size 86367 crc 8de6e141 md5 f7a5b3d9eb1434a0c7fa14ccb986a0db sha1 508139d96ec5f3a5eefb24047380eeb72b5f45bb )
-)
-
-game (
-	name "Fast Draw (poker conversion kit)?"
-	developer "Stern Electronics?"
-	rom ( name fastdrwp.zip size 5581 crc cc77ffcb md5 731c3bef014e42be0616bc7cf904f4d7 sha1 7be188e9e72c74a0471070b3cb0174b887e0acfa )
 )
 
 game (
@@ -15972,42 +11695,35 @@ game (
 	name "Fatal Fury Special / Garou Densetsu Special (set 2)"
 	year "1993"
 	developer "SNK"
-	rom ( name fatfursa.zip size 11512660 crc 4adda032 md5 884dd46df04228e70f13dbbfde068298 sha1 4fe352c58c6603d8db2f63f53dec2492e5d45f70 )
+	rom ( name fatfursa.zip size 12859347 crc 4a8ccb1e md5 62f7eedcce4187b9a66f5d9f615fe752 sha1 ed944a992d20353bcee8218ec7a9429b9fa8b6e1 )
 )
 
 game (
 	name "Fatal Fury Special / Garou Densetsu Special (set 1)"
 	year "1993"
 	developer "SNK"
-	rom ( name fatfursp.zip size 11294592 crc ad56bd3d md5 f93b0778e28289a34f73370e09b9511b sha1 5937aca6a04b5a1fc96d8d3fd902e021964a74cf )
-)
-
-game (
-	name "Fatal Fury: Wild Ambition (rev.A)"
-	year "1998"
-	developer "SNK"
-	rom ( name fatfurwa.zip size 91933857 crc 0e812d3c md5 29c5fe3b312d8f47f9258aa6b4a77cde sha1 07c27024140861a1b10301c0dbace683b411a702 )
+	rom ( name fatfursp.zip size 12641279 crc b4f92f66 md5 8239ff1116323ba56fb04ec5db1d9d28 sha1 d6dce6ea485858aa5b20dc5af721d860ddc8b82f )
 )
 
 game (
 	name "Fatal Fury - King of Fighters / Garou Densetsu - shukumei no tatakai"
 	year "1991"
 	developer "SNK"
-	rom ( name fatfury1.zip size 4054308 crc 11644f54 md5 f76acd6cde33fff7f474c09b3070390e sha1 5fa6f74b7d313eceecf1dd0af5ad05987f7e42c3 )
+	rom ( name fatfury1.zip size 5400995 crc 4dfc6310 md5 6556a12e0520dee91579473b758f8027 sha1 873ca1d9d0e45d7aefba85ad3d3a7b785ac10b85 )
 )
 
 game (
 	name "Fatal Fury 2 / Garou Densetsu 2 - arata-naru tatakai"
 	year "1992"
 	developer "SNK"
-	rom ( name fatfury2.zip size 7980231 crc 6e30263b md5 9fe776fbf724eb291077823bf18fe9a6 sha1 d60dcefe56e2f9002598ec1fbdecf2dc1feb2243 )
+	rom ( name fatfury2.zip size 9326918 crc b6debcfa md5 74a28451b46310c67f1d81fef725c273 sha1 2c25c8dc1d23b31fe300168039d590d5948efa14 )
 )
 
 game (
 	name "Fatal Fury 3 - Road to the Final Victory / Garou Densetsu 3 - haruka-naru tatakai"
 	year "1995"
 	developer "SNK"
-	rom ( name fatfury3.zip size 19557306 crc 15ec1db2 md5 c2c4619e709b5e9799fc5506af329149 sha1 336566af75e2c4d66e53b7850ec661b0711b0f3e )
+	rom ( name fatfury3.zip size 20903993 crc 73e80ff4 md5 8d017fac9639d5ca1029d6391158471e sha1 5a52ccd96b788d8c407a020f348d60f38dec6542 )
 )
 
 game (
@@ -16137,111 +11853,6 @@ game (
 )
 
 game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4.zip size 646767 crc 8076cc7a md5 0207a9d0b1a2a8229fbe26d1bce071a1 sha1 020d45b8de19ec972c5fdfd41c2aa5ae63a99de3 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4b2.zip size 646951 crc 7ab95821 md5 920f85eb311615804b90f551a937e591 sha1 4b95cbcd9d1c705953d852ca5740190de7ac9513 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4c1.zip size 647152 crc 1f82d65a md5 77f8e9763d8478d464c090740bac4141 sha1 6c888caff73847261227ffa2d4c08b9ff1eed133 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4c2.zip size 647312 crc d09b4174 md5 67a98dc79317c76ad5e95e717660cf72 sha1 8393d2802be74014a450148dad3f05640b14297d )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 3)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4d1.zip size 646521 crc 84189cfa md5 0909c19c83bf5f8dfa89b17472536a87 sha1 86cb8f1dc312c5eb4ab0443921ee091bd89014aa )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 3)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4d2.zip size 646697 crc f4dd12d3 md5 8fd7d695f9aa33a0cf3127651aa9c785 sha1 214fddd68f8433c9db94f18973ff7221d0431876 )
-)
-
-game (
-	name "Fruit Bonus 2005 (2004 Export - Version 1.5E Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4exp.zip size 647101 crc 96aa002e md5 40922e3fc089158172ee4047b45a4a04 sha1 23dd0d5d1eb66caf860ee3d36460d11e98c23f60 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.3XT)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4o.zip size 647046 crc e2083e0e md5 97a3d8ea8c7c65cf7d37b02b9df888a7 sha1 837dfa3e83c4ed71c768770376d9197aa1b1013a )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4o2.zip size 647145 crc 3b363f7c md5 c866d55c50018cb63c44107b377cb716 sha1 cf0a4f1f64d7cbd178f55fb39ddd0e351c68fb09 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4v1.zip size 646891 crc bcd563ed md5 572d33cde72618432d655d4f5a0f85ae sha1 fda44717130bb140452030c6abad759a66620fee )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4v2.zip size 646620 crc b543c8cf md5 9f600fe05af63fe85d27ba44b35a08a4 sha1 b7802095529f298eb5cd16691077a5fb7f89b5cc )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 1)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5.zip size 768770 crc 3dfc8d0a md5 426529d3cb9da4b4bf1df8127dedc977 sha1 0f26141c17ab9c1436f3d311897cb4ad81449f81 )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 2)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5c.zip size 768981 crc a47627ee md5 e7935c2069d1664f0b3f68c4083d7ee1 sha1 35f7092b5ccc2890a1386d6b087e78f278c1ef3a )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 3)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5d.zip size 767431 crc 3c2fa23c md5 fe5fd58e796e571ed3a9989d87eb879f sha1 a49c0c35025963f47f15666d36d049150750fead )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH Dual)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5v.zip size 768376 crc 27e7e5bf md5 398f98d6c7a10af089ca7c97fdef3363 sha1 431fe624aa4b41945bf028c77116f7d0a9e9199b )
-)
-
-game (
 	name "Fruit Bonus '06 - 10th anniversary (Version 1.7E CGA)"
 	year "2006"
 	developer "Amcoe"
@@ -16260,27 +11871,6 @@ game (
 	year "2006"
 	developer "Amcoe"
 	rom ( name fb6d2.zip size 823918 crc cf31e130 md5 85ec0b6a2958916981bef40457b77d01 sha1 d507ba40d41b08f577e92bdd31711835a2e34730 )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.7R CGA, set 2)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s1.zip size 568237 crc 6b6bbe21 md5 f945e012021a53d0a5daa0466ea7d74c sha1 bd4788593d4922757b7a850cd74b159013fd3660 )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.7LT CGA, set 2)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s2.zip size 564286 crc 1896d7fd md5 56a16a3535c34836c6e0c5633970e110 sha1 afd8d8fcaa47421283f766cdbe2364ca8ab0c827 )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.3R CGA)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s3.zip size 568092 crc 87c29079 md5 fb443f8616d292cdd0f3ec152d747add sha1 6aeb0e2af7ac983e7d0d3ce283b59730268508b4 )
 )
 
 game (
@@ -16347,52 +11937,10 @@ game (
 )
 
 game (
-	name "Fisherman's Bait 2 - A Bass Challenge (GE865 VER. UAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name fbait2bc.zip size 182 crc eb05f689 md5 877d342ed83e8b5ed47766918fcacb2b sha1 1b067281d729d9961360d2bc4e0a860f6f4c10c1 )
-)
-
-game (
-	name "Fisherman's Bait - A Bass Challenge (GE765 VER. UAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name fbaitbc.zip size 182 crc 98e197e4 md5 96799b037cd5bfc129e047fae49f237b sha1 c9842005d648ffeebd8c0ce170476b70c00861ee )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. EA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmc.zip size 172 crc de91fecb md5 40d7af846d82b18aa41d5d8f28fc94a5 sha1 cefec72b9c98db93245af37ae4acac298a1de08f )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. AA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmca.zip size 172 crc 946ffcdb md5 1f6bd8d4f6ff72df30a6b021021b18a8 sha1 37900e41b5225a0a76b6804d9591813c8aeb0bc3 )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. JA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmcj.zip size 172 crc 1a7f9709 md5 a21726d4a3ed85caef231f5bc8f46763 sha1 864aa7626b505e3d0f13a0191ec27383fe5a479c )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. UA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmcu.zip size 172 crc e520b1cb md5 d52d29237317fa962379e66824cd406b sha1 87e70017761c051c4b9e4a5822cca69cc63d73f2 )
-)
-
-game (
 	name "Football Frenzy"
 	year "1992"
 	developer "SNK"
-	rom ( name fbfrenzy.zip size 3093343 crc 4a56dee6 md5 56cffa58cee9a22f51a7f29edf7c86f1 sha1 31a4dbc1b0b6b8c3d84c78151a6277b39796c50d )
+	rom ( name fbfrenzy.zip size 4440030 crc f194b360 md5 0d3c52d40a4f30047a26c256192afada sha1 bcfc7107c54ae87d62fb007a32dbe2223e681611 )
 )
 
 game (
@@ -16466,24 +12014,10 @@ game (
 )
 
 game (
-	name "Field Combat"
-	year "1985"
-	developer "Jaleco"
-	rom ( name fcombat.zip size 56111 crc dbcaa410 md5 4e70334d87fdd4c768f73764d6462a73 sha1 8a3842cb17ba00547c210a57471b871a87c86195 )
-)
-
-game (
 	name "Final Crash (bootleg of Final Fight)"
 	year "1990"
 	developer "bootleg (Playmark)"
 	rom ( name fcrash.zip size 1321060 crc 16013c4e md5 4cbc0ae75a0d44779c628ba485179378 sha1 fad882a575f26c3b0b668a898bf2f804eaff9dda )
-)
-
-game (
-	name "Fenix (bootleg of Phoenix)"
-	year "1980"
-	developer "bootleg"
-	rom ( name fenix.zip size 15080 crc c52131b5 md5 e20071771d1ed10b78abd4afc37acf0f sha1 79a12f1c2f4712957381e6a181d17aba1b2aab1f )
 )
 
 game (
@@ -16515,13 +12049,6 @@ game (
 )
 
 game (
-	name "Fighting Fantasy (bootleg with 68705)"
-	year "1989"
-	developer "bootleg"
-	rom ( name ffantasybl.zip size 514537 crc f7742f6c md5 090d64c57ed15d5f064b0f72859548c8 sha1 55ed917053c7352aea5288c1362da61c65db2c0a )
-)
-
-game (
 	name "Final Fight (World)"
 	year "1989"
 	developer "Capcom"
@@ -16533,34 +12060,6 @@ game (
 	year "1996"
 	developer "bootleg"
 	rom ( name ffight2b.zip size 821200 crc 4f1a17ed md5 931e69deb648746c9777190e46c21408 sha1 02a896e821e6812d5a5c9ef6c8bc62d128dd9787 )
-)
-
-game (
-	name "Final Fight (Japan)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj.zip size 1470634 crc d3ec0189 md5 f50ec059522a7563088b78d204bfc9c3 sha1 13d868be3cbd28bef32f4e61a643633c0b71add8 )
-)
-
-game (
-	name "Final Fight (Japan 900112)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj1.zip size 1470648 crc e905ae20 md5 2aba73e4d4c90d179ad8dc95fa14a7b6 sha1 d655deb9041dde5b61faec073bca85247fd4884d )
-)
-
-game (
-	name "Final Fight (Japan 900305)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj2.zip size 1470790 crc 6fe254ae md5 8733f30fbae20284ea698a2461f13eff sha1 2d2e28ea582c0ed50c4f8e7dfb24243c1d430165 )
-)
-
-game (
-	name "Street Smart / Final Fight (Japan, hack)"
-	year "1989"
-	developer "bootleg"
-	rom ( name ffightjh.zip size 1429811 crc 7a4aad54 md5 f43f1dd192b1afcbbf5f0e532f3510ba sha1 d3ed2bdc0582cbf576c4916928aca692c6378769 )
 )
 
 game (
@@ -16592,13 +12091,6 @@ game (
 )
 
 game (
-	name "Final Fight Revenge (JUET 990714 V1.000)"
-	year "1999"
-	developer "Capcom"
-	rom ( name ffreveng.zip size 15337532 crc cc0f7ac4 md5 2129fb848aeb97659850a4e7cf3366f9 sha1 89afba1fd57b65af9341a93b3f3c91cc14166b19 )
-)
-
-game (
 	name "Fighter _ Attacker (US)"
 	year "1992"
 	developer "Namco"
@@ -16610,55 +12102,6 @@ game (
 	year "1984"
 	developer "Paradise Co. Ltd."
 	rom ( name fghtbskt.zip size 67905 crc 152bf84e md5 31f5d54dd3b65887d1f3f91d1234ecf8 sha1 ab1c87555aad0f541fb0ad5945cc28e885543d75 )
-)
-
-game (
-	name "Fighter's History (World ver 43-07)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthist.zip size 5649743 crc 7accf751 md5 fde7de3ddc1f01c01b49619d64ca2551 sha1 13e97cc5fa36c3bfde56377b0d02de8196d97d87 )
-)
-
-game (
-	name "Fighter's History (US ver 42-05, alternate hardware )"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthista.zip size 5649667 crc 42099d5f md5 6951ba91fa490d2a63e42049b43c5bee sha1 cc193542e18869e9653092bf7b198df6e1a784e2 )
-)
-
-game (
-	name "Fighter's History (Japan ver 42-03)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthistj.zip size 5649715 crc 72418819 md5 400203276a0469e023e8847122698d8b sha1 2148013702c171a6b142961cf7b4e9ec02c9ddea )
-)
-
-game (
-	name "Fighter's History (US ver 42-03)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthistu.zip size 5649715 crc f7ff496a md5 4a5e26c60e62068dc93d82734fb0f10b sha1 5e1f66ee39de12117be0d68874a91289e22d44d4 )
-)
-
-game (
-	name "Capcom Fighting Jam (JAM1 Ver. A)"
-	year "2004"
-	developer "Capcom / Namco"
-	rom ( name fghtjam.zip size 1149067 crc f8b036e0 md5 41a57f7de1bc050118e7256f0cf7c1f6 sha1 d8557b7b10d358a2b453044f7fca47ff942e4a8e )
-)
-
-game (
-	name "Field Goal"
-	year "1979"
-	developer "Taito"
-	rom ( name fgoal.zip size 8256 crc 672b0b3b md5 2436dbfd1c848aec181a0ce6db45d2c5 sha1 fe869fa220736c1479fa82364e0191407cde7eec )
-)
-
-game (
-	name "Field Goal (different)"
-	year "1979"
-	developer "Taito"
-	rom ( name fgoala.zip size 9383 crc c9983171 md5 5da91b20b4aa494ba048e48dfeda753a sha1 b714423684ccdebe8964ace4908d59f45714f9f9 )
 )
 
 game (
@@ -16683,31 +12126,17 @@ game (
 )
 
 game (
-	name "Funky Head Boxers (JUETBKAL 951218 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name fhboxers.zip size 19667759 crc 2842de81 md5 37a305aa6d14206475a7f92607a9ecf6 sha1 5c9e2a49f035601b888c93bd0a30adbec55b6395 )
-)
-
-game (
-	name "Field Day"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
-)
-
-game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
-	rom ( name fightfev.zip size 6265185 crc cf477658 md5 a98c6092a198b7ad4c03b00d171b622c sha1 cfc9c7f8a82a0124064dac420aec46f73cf881aa )
+	rom ( name fightfev.zip size 7611872 crc bdfc6e99 md5 cadb362b5c03854e07311d85b84d9724 sha1 eb60398ecc023f9f962425c816ecf8d61f39a2fb )
 )
 
 game (
 	name "Fight Fever (set 2)"
 	year "1994"
 	developer "Viccom"
-	rom ( name fightfeva.zip size 6035832 crc b4c20a9b md5 055b71a02769b9dec56fa2a051bc652d sha1 260d7be1508a53f49e98124b00a0613003d8c759 )
+	rom ( name fightfeva.zip size 7382519 crc e3f20a41 md5 227cf5285a08de290554f138387496ed sha1 017f08375e0f26ac43a9a175f00802ba61190a7c )
 )
 
 game (
@@ -16715,48 +12144,6 @@ game (
 	year "1983"
 	developer "Kaneko (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
-)
-
-game (
-	name "Filetto (v1.05 901009)"
-	year "1990"
-	developer "Novarmatic"
-	rom ( name filetto.zip size 291514 crc afcc3fd7 md5 8262db6e8817ee8fc4d5997f5f1ad51a sha1 4262a87aa9d272ff62e69da82a31f1d89cfd7c72 )
-)
-
-game (
-	name "Final Lap 2"
-	year "1990"
-	developer "Namco"
-	rom ( name finalap2.zip size 2006181 crc 266ca1dc md5 9075a2bca031d30d25c145abac56c41e sha1 12ac372e776bfe55e151bd8541e657bfb4bcddcb )
-)
-
-game (
-	name "Final Lap 2 (Japan)"
-	year "1990"
-	developer "Namco"
-	rom ( name finalap2j.zip size 2005167 crc f80343d3 md5 c3aed47ab448ecc39ed9209971224b63 sha1 2ebf7c4778f0a58d7e0b39b8d6e68e0337e7e57b )
-)
-
-game (
-	name "Final Lap 3 (World, set 1)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3.zip size 2408440 crc ea0e0096 md5 bbf03f16da3d4f7363c0f5574def9a48 sha1 e5926ce1b4534366979b027e78b6cfddf29c8fe0 )
-)
-
-game (
-	name "Final Lap 3 (World, set 2)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3a.zip size 2432419 crc 7cd0a69c md5 61c34ce4ab8eb0baac2f8eaf55373a18 sha1 203ce7a00e99a6ad6b01cf1c486ee838b42e4416 )
-)
-
-game (
-	name "Final Lap 3 (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3j.zip size 2409518 crc d863485a md5 ab5ddaa0bf0d8527b92e0e1f71e32516 sha1 a455e8def2ae727426376998f8fda367ae8008a5 )
 )
 
 game (
@@ -16816,66 +12203,10 @@ game (
 )
 
 game (
-	name "Finalizer - Super Transformation"
-	year "1985"
-	developer "Konami"
-	rom ( name finalizr.zip size 81140 crc 7a771edd md5 9c01699fdd7e4f6bc3292a3bb180846a sha1 98fdd6fc516ae9ceed3a480222a66f07e657458a )
-)
-
-game (
 	name "Finalizer - Super Transformation (bootleg)"
 	year "1985"
 	developer "bootleg"
 	rom ( name finalizrb.zip size 80178 crc 59af4cc1 md5 1fa3c46f88b45aa0d1dbba381a7d9c72 sha1 0eedcc97436551de119f5c39761e2c7621c6d229 )
-)
-
-game (
-	name "Final Lap (Rev E)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallap.zip size 1115399 crc f462a7d5 md5 74943d547b998ae2f5292cd49d8436b7 sha1 b68910a1e56d499e6f4b14deff41a4e57f48177c )
-)
-
-game (
-	name "Final Lap (Rev C)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapc.zip size 1116064 crc d7bdd46c md5 1afca43747f201e3161ffa7cae00348f sha1 1b2b1d04e55a0f846926dea42898988079eeb7d3 )
-)
-
-game (
-	name "Final Lap (Rev D)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapd.zip size 1114994 crc f19657f2 md5 b0066b27aaa84a0fb48391b521b49533 sha1 4c9b6b1b541880dff5fb9aaafa2f884e1767801b )
-)
-
-game (
-	name "Final Lap (Japan - Rev B)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapjb.zip size 1117811 crc 355d6d12 md5 73840d7170c691e972e9dd3631127be1 sha1 fe33719a2a94c462fa8c2bf3acfcdd9c1779df0c )
-)
-
-game (
-	name "Final Lap (Japan - Rev C)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapjc.zip size 1114552 crc 74ec233f md5 b5fc9053e6eb47887f70a87d935cf9a2 sha1 af132e03cb1d618077a43179203068d0e828fa04 )
-)
-
-game (
-	name "Final Tetris"
-	year "1993"
-	developer "Jeil Computer System"
-	rom ( name finalttr.zip size 260189 crc 711a654f md5 2ba81ba082709f6bd5bc2bc9dee28036 sha1 f138d18df311fd311b8541680acd348a617dcbe7 )
-)
-
-game (
-	name "Find Love (J 971212 V1.000)"
-	year "1997"
-	developer "Daiki / FCF"
-	rom ( name findlove.zip size 19577251 crc 79999a28 md5 57e71d9036087beda027592bd9dc83e3 sha1 e54d25db6454304dcace5c7c91a19bdca4e40eb3 )
 )
 
 game (
@@ -16890,34 +12221,6 @@ game (
 	year "1989"
 	developer "Namco"
 	rom ( name finehour.zip size 2297433 crc 81ef74a8 md5 ed09ff75a008007cc92896464bf0ec46 sha1 13ab919d68691b5b0bcb2fdd3fae53d1f9bd3fc7 )
-)
-
-game (
-	name "Final Furlong 2 (World)"
-	year "1999"
-	developer "Namco"
-	rom ( name finfurl2.zip size 39226099 crc 75a8224e md5 8def609f6bb469e50c694a7d8bc448bc sha1 bd522d926f72249815fe61d8700b454c6ff4de79 )
-)
-
-game (
-	name "Final Furlong 2 (Japan)"
-	year "1999"
-	developer "Namco"
-	rom ( name finfurl2j.zip size 39228455 crc 40397659 md5 05aed50d445a4d4b364304e176ff0c03 sha1 086b295b957b7138b47b1a89477a7fa11e6397c9 )
-)
-
-game (
-	name "Final Arch (J 950714 V1.001)"
-	year "1995"
-	developer "Sega"
-	rom ( name finlarch.zip size 9115325 crc 9de2bf13 md5 6dac2c43ab6466471a3003c8c0143471 sha1 f94c279bf979d785a3bb13dd8a64dd7e69efcd88 )
-)
-
-game (
-	name "Final Furlong (FF2 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name finlflng.zip size 32929152 crc a645460e md5 55eff8c40884720cd23ad353055d8db5 sha1 9de1e2ca71ff18fc8d56cb885dfc71bde2f23c79 )
 )
 
 game (
@@ -16963,52 +12266,10 @@ game (
 )
 
 game (
-	name "Fire One"
-	year "1979"
-	developer "Exidy"
-	rom ( name fireone.zip size 23249 crc 8a453614 md5 d122e2742eb81150bb201ee74390e721 sha1 c9c97afd680bbb89f15cff35c377b3fd6033f6de )
-)
-
-game (
-	name "Fire Shark"
-	year "1990"
-	developer "Toaplan"
-	rom ( name fireshrk.zip size 533640 crc 31b3b438 md5 6e188e233b1be78f296ff7620084e33c sha1 189548d506e1aa18d18f18958298633cdffdc8a0 )
-)
-
-game (
-	name "Fire Shark (Korea, set 1, easier)"
-	year "1990"
-	developer "Toaplan (Dooyong license)"
-	rom ( name fireshrkd.zip size 567060 crc f4988ef8 md5 53f481afca88a8b218b8e05773ca555f sha1 cc4de80e15bfcc1f0ade8c39b3c6d77afd825344 )
-)
-
-game (
-	name "Fire Shark (Korea, set 2, harder)"
-	year "1990"
-	developer "Toaplan (Dooyong license)"
-	rom ( name fireshrkdh.zip size 567271 crc 9f88268f md5 611b2f60822b028bdfecd9c19146dda3 sha1 cf28cac11f9ca439d3c76fb01153296bd0bc39c8 )
-)
-
-game (
-	name "Fire Trap (US)"
-	year "1986"
-	developer "Wood Place Inc. (Data East USA license)"
-	rom ( name firetrap.zip size 256265 crc d9548ab9 md5 db5088670a54b41a056407cc02e64d30 sha1 eb07d97a576a2da1657e9b8217cf6959d8feb961 )
-)
-
-game (
 	name "Fire Trap (Japan bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name firetrapbl.zip size 257103 crc 04c2cc9d md5 22e4c2ca2bc865bbbbd30f4a63e3a4ec sha1 55a22c188f9d2dcd841f72cd9218bf8f09215cb2 )
-)
-
-game (
-	name "Fire Trap (Japan)"
-	year "1986"
-	developer "Wood Place Inc."
-	rom ( name firetrapj.zip size 256663 crc 69a70224 md5 cbcb7ff4fdf3193ee4711d636d241f09 sha1 04a74865d80df10472cbedca5ddc878122f3034a )
 )
 
 game (
@@ -17040,12 +12301,6 @@ game (
 )
 
 game (
-	name "Fit of Fighting"
-	developer "bootleg"
-	rom ( name fitfight.zip size 3546120 crc 8e04860e md5 3ae075a6c34819573759987d2523cf70 sha1 666869a81b3646f343d76fed7a8d1780f6a3013f )
-)
-
-game (
 	name "Fitter"
 	year "1981"
 	developer "Taito Corporation"
@@ -17067,13 +12322,6 @@ game (
 )
 
 game (
-	name "FixEight"
-	year "1992"
-	developer "Toaplan"
-	rom ( name fixeight.zip size 2206694 crc 2d659584 md5 f2bb97a31e97937e4e6bf2d543e35e01 sha1 9974905df0aa8d11df71022bd6ffc630bb55aeae )
-)
-
-game (
 	name "FixEight (bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -17091,14 +12339,14 @@ game (
 	name "Flame Gunner"
 	year "1999"
 	developer "Gaps Inc."
-	rom ( name flamegun.zip size 30981306 crc 0ca441d2 md5 8e957646c86fe6ea6baa90f533a41297 sha1 d2070ca9e372ce4d05e7e8f3337335cab8ca28cf )
+	rom ( name flamegun.zip size 31119758 crc 6ff49d7b md5 e329f48441b72faaecb2e46f32ba10ad sha1 b7c578539dd5f634c9f914b17365720650fd0beb )
 )
 
 game (
 	name "Flame Gunner (Japan)"
 	year "1999"
 	developer "Gaps Inc."
-	rom ( name flamegunj.zip size 30890104 crc 13351c91 md5 155f87032d50bf15c48fc5c896a08532 sha1 75483558f359546162ca17113887e6e9e71da9f9 )
+	rom ( name flamegunj.zip size 31028556 crc 899b400f md5 ff982a58ec7703cba5edd0a9ad255acb sha1 813b4f6e35159435a7287a016110690f3678262a )
 )
 
 game (
@@ -17144,10 +12392,10 @@ game (
 )
 
 game (
-	name "Battle Flip Shot"
-	year "1998"
-	developer "Visco"
-	rom ( name flipshot.zip size 2311372 crc 5fc4aca3 md5 db8be925337c96729445c8e57b8a222e sha1 8cbac7dd711094043fc7376f29c31265712ffe05 )
+	name "Flip Maze (V2.04J)"
+	year "1999"
+	developer "Taito / Moss"
+	rom ( name flipmaze.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -17193,13 +12441,6 @@ game (
 )
 
 game (
-	name "Flyball"
-	year "1976"
-	developer "Atari"
-	rom ( name flyball.zip size 6136 crc 7d06a106 md5 65ac530796da5bab1e8c7c2cb89e8fc2 sha1 54342bbb4a2177aef0bdfe9458d7879d056051a1 )
-)
-
-game (
 	name "Fly-Boy"
 	year "1982"
 	developer "Kaneko"
@@ -17218,13 +12459,6 @@ game (
 	year "1992"
 	developer "Dooyong"
 	rom ( name flytiger.zip size 738480 crc dfdb5b13 md5 d3ab70d6ea3f7ea6c243352a66251e31 sha1 1a85e93a3a10b8b194eb9e139119bf5cfb8d70b2 )
-)
-
-game (
-	name "Fishing Maniac 3"
-	year "2002"
-	developer "Saero Entertainment"
-	rom ( name fmaniac3.zip size 6263655 crc 0f42cccc md5 946221ba8b2daa8066a7df1f5c9cd224 sha1 465a02cf1bd8bce72f826ad2ae7a6fde5583a155 )
 )
 
 game (
@@ -17284,13 +12518,6 @@ game (
 )
 
 game (
-	name "Forgotten Worlds (USA, 88618B B-Board)"
-	year "1988"
-	developer "Capcom"
-	rom ( name forgottnu.zip size 1907698 crc 0a250078 md5 99cda965a64c6d69248ba41c3ccf2610 sha1 f512fb958f4e4bddf5065d8ae38475de6bb57aec )
-)
-
-game (
 	name "Forgotten Worlds (USA, 88621B B-Board)"
 	year "1988"
 	developer "Capcom"
@@ -17305,37 +12532,10 @@ game (
 )
 
 game (
-	name "Fortress 2 Blue Arcade (ver 1.01 / pcb ver 3.05)"
-	year "2001"
-	developer "Eolith"
-	rom ( name fort2b.zip size 7795766 crc ca67c081 md5 9ca010016ccf8a2f595aeb18d41e3968 sha1 a3b363269125cc44b72e8db3ef5e15d9af3ffa99 )
-)
-
-game (
-	name "Fortress 2 Blue Arcade (ver 1.00 / pcb ver 3.05)"
-	year "2001"
-	developer "Eolith"
-	rom ( name fort2ba.zip size 7878729 crc 489195b5 md5 d675eb21e5d755c6deec70ffd2a3c125 sha1 994f34452d611d707a1a85a69a650745e0e83759 )
-)
-
-game (
-	name "Forte Card"
-	developer "Fortex Ltd"
-	rom ( name fortecar.zip size 93547 crc 251e36fa md5 1823d14e07cb6583a1cf6c6446e1e42a sha1 1463223e1ede81500ee22b70e6a0eb9d527651a1 )
-)
-
-game (
 	name "Fortune I (PK485-S) Draw Poker"
 	year "1984"
 	developer "IGT - International Gaming Technology"
 	rom ( name fortune1.zip size 6990 crc 60a27671 md5 9218305a69f0e5be833c99989f51079c sha1 daa1aaddce4efe84de51afff2a096a72d947fc63 )
-)
-
-game (
-	name "Fist Of The North Star"
-	year "2005"
-	developer "Sega / Arc System Works"
-	rom ( name fotns.zip size 117663839 crc cf0a8236 md5 85ebeb3feb9640fbd8caaedd15d33b3f sha1 193eb75e469721e38749e8f57e41b396cb91d7b8 )
 )
 
 game (
@@ -17357,20 +12557,6 @@ game (
 	year "1989"
 	developer "Sega"
 	rom ( name fpoint1.zip size 137014 crc 498983e1 md5 d79fb617c4b6d6c4567403a8cf84af86 sha1 383293b64cdcca52220f232ba6e0aa3a8c31468d )
-)
-
-game (
-	name "Flash Point (Japan, bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name fpointbj.zip size 140769 crc 21413adc md5 b873d6cdf425ad5afe50fac2bcf93c3f sha1 537600acb8a071ec47eba81461c5587cf5bb775c )
-)
-
-game (
-	name "Flash Point (World, bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name fpointbl.zip size 140360 crc 6e75a996 md5 b152fba23e02a6cf2f2d436143fd6f84 sha1 9f8629b481fd267c09aef05cf5d1d111668ae553 )
 )
 
 game (
@@ -17413,13 +12599,6 @@ game (
 	year "1994"
 	developer "Coastal Amusements"
 	rom ( name fredmesp.zip size 1964712 crc 91c1b5a1 md5 911ae0a09202c399aea83d2a0727329f sha1 25591cb0d1d9e6768b2f8fc22befff464f6f438d )
-)
-
-game (
-	name "Free Kick"
-	year "1987"
-	developer "Nihon System (Sega license)"
-	rom ( name freekick.zip size 38380 crc 134dddf7 md5 41038c6564c9b420f430c1871cda5a47 sha1 bab4a3bbd0994d90e7600e4c288316d544a9e065 )
 )
 
 game (
@@ -17633,13 +12812,6 @@ game (
 )
 
 game (
-	name "Flying Shark (bootleg)"
-	year "1987"
-	developer "bootleg"
-	rom ( name fsharkbt.zip size 285408 crc 2d474a43 md5 ae16f560139b55865e6be672610c63a8 sha1 85618f7a92c7a718dd9a85d4b9f3aece2ff2a020 )
-)
-
-game (
 	name "Fighting Soccer (version 4)"
 	year "1988"
 	developer "SNK"
@@ -17682,38 +12854,31 @@ game (
 )
 
 game (
-	name "Fun Station Spielekoffer 9 Spiele"
-	year "2000"
-	developer "ADP"
-	rom ( name fstation.zip size 578318 crc fd579ffa md5 148fd0edcbf8c128506e4e2a20a53179 sha1 cb21559ca0050cc543098239a43704f61e9e8048 )
-)
-
-game (
 	name "Fighters Swords (Korean release of Samurai Shodown III)"
 	year "1995"
 	developer "SNK"
-	rom ( name fswords.zip size 17547391 crc e23c044e md5 4008f1d493ffcf1f0a2eda6b0a26568b sha1 52b40366d22a026233271caddb664a069eecc0b7 )
+	rom ( name fswords.zip size 18894078 crc 71c3203b md5 35f041357dc366338082ceffcc88971c sha1 6afb5bc6b4d24938cc959c5b5f45dae3d1009f5c )
 )
 
 game (
 	name "Fighters' Impact (Ver 2.02O)"
 	year "1996"
 	developer "Taito"
-	rom ( name ftimpact.zip size 13440674 crc c2a98fb1 md5 594bd75c5d9fa4d2bb9a24b8a3971c13 sha1 a321c39080f6b0ec8859d6b061dbf125f7d22850 )
+	rom ( name ftimpact.zip size 13566812 crc d62679db md5 df9cc30e8507bd549b945a5d9c208dfc sha1 08221b7ffa702eba45a1a61594ee2aca6be469aa )
 )
 
 game (
 	name "Fighters' Impact (Ver 2.02J)"
 	year "1996"
 	developer "Taito"
-	rom ( name ftimpactj.zip size 13440674 crc 9e8ee824 md5 3e7a6ecb8a6387779d84aecc2f4df3a2 sha1 34e4007305dfc60c90690b3f86e147c75bf9101a )
+	rom ( name ftimpactj.zip size 13566812 crc 2e5bb073 md5 d0d03c84eb91f33d264afa1f5c4cf8d6 sha1 0bed428af7d9588cdfa0f19adcbddbed5103357b )
 )
 
 game (
 	name "Fighters' Impact A (Ver 2.00J)"
 	year "1997"
 	developer "Taito"
-	rom ( name ftimpcta.zip size 13637248 crc d0b46d86 md5 0ce8c7499dc74d2c23f09d495968f351 sha1 31ecd9e7ad9966fd272de7a9c660413eb6e803df )
+	rom ( name ftimpcta.zip size 13763386 crc 2abe4ddf md5 bae7bc8751637f738a6b56bb0482f04c sha1 b2bfb56ee74265cdf5644ebfc27a1c86bb3f4118 )
 )
 
 game (
@@ -17731,20 +12896,6 @@ game (
 )
 
 game (
-	name "Funcube 2 (v1.1)"
-	year "2001"
-	developer "Namco"
-	rom ( name funcube2.zip size 5097030 crc a493454b md5 7deeb6d7eb1d8e7944948fd0d5616903 sha1 9a34eea6ac9071c9dcc71f57b2bd9f105842ac4b )
-)
-
-game (
-	name "Funcube 4 (v1.0)"
-	year "2001"
-	developer "Namco"
-	rom ( name funcube4.zip size 5862668 crc 09ed4549 md5 4a10b7b145775b32e101e5643de91648 sha1 7172c37a6aa2b630602ea41f2526b2a74f737a20 )
-)
-
-game (
 	name "Funky Bee"
 	year "1982"
 	developer "Orca"
@@ -17756,13 +12907,6 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name funkybeeb.zip size 20181 crc d8735813 md5 1620b3f8b2ff78b73a5068cd3f3374c4 sha1 1f42c01c166dd5e0d32e3b16c6737be402aec69f )
-)
-
-game (
-	name "The First Funky Fighter"
-	year "1993"
-	developer "Nakanihon / East Technology (Taito license)"
-	rom ( name funkyfig.zip size 4972404 crc b016ea18 md5 734a5cf4f842bef765235acd0def6fe2 sha1 73ae89381895508b639bfdf4e53af2f4890df059 )
 )
 
 game (
@@ -17780,13 +12924,6 @@ game (
 )
 
 game (
-	name "Funny Land de Luxe"
-	year "1999"
-	developer "Stella"
-	rom ( name funlddlx.zip size 707655 crc 4b8bb5f1 md5 d7eb4580d953c9994b317fd1387ba491 sha1 d1196ae84f6fb4f81a2a86c814134196bdc40610 )
-)
-
-game (
 	name "Funny Mouse"
 	year "1982"
 	developer "bootleg? (Chuo Co. Ltd)"
@@ -17797,20 +12934,6 @@ game (
 	name "Fun World Quiz (Austrian)"
 	developer "Funworld"
 	rom ( name funquiz.zip size 154615 crc 54a649e2 md5 52f12ec9ab375c2153f7d449af201894 sha1 b5e3c75426d39c566ab5510c6112ad247675ed17 )
-)
-
-game (
-	name "Fun River (set 1)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name funriver.zip size 224761 crc 2f56f7a6 md5 771d2851c0658775d6d677c92dae074c sha1 46c6a3177740cf54b13533f22ea3782ae10da32a )
-)
-
-game (
-	name "Fun River (set 2)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name funriverv.zip size 225731 crc d204b4e4 md5 42618c8272aafb6fdbeefcf78b014b80 sha1 305d85fa20f2f537ee17fe8eb3d512873735c9c0 )
 )
 
 game (
@@ -17828,37 +12951,10 @@ game (
 )
 
 game (
-	name "Funny Strip"
-	developer "Microhard / MagicGames"
-	rom ( name funystrp.zip size 657346 crc dfc44be9 md5 9af8a96354aea827fc0a8b71c39a5083 sha1 dacce36dbee8058a5a93a157df74107312bb45fa )
-)
-
-game (
-	name "Future Flash"
-	year "1981"
-	developer "Hoei"
-	rom ( name futflash.zip size 20685 crc af65056a md5 5645befac98483d92c9e55534627f2ed sha1 b3be4086138c4155ee9a2722047e3be4e3167f55 )
-)
-
-game (
 	name "Future Spy (315-5061)"
 	year "1984"
 	developer "Sega"
 	rom ( name futspy.zip size 48411 crc 001f1b79 md5 ebd42eff9f42a022de62ec15b50c6d21 sha1 a097e4621e93757a79abc739cb06b41c4f7b92bb )
-)
-
-game (
-	name "Fighting Vipers (Revision D)"
-	year "1995"
-	developer "Sega"
-	rom ( name fvipers.zip size 17647257 crc 695a44d1 md5 dabcc4ed1173daba791462b899c52db1 sha1 77c51b602db642eee9760e9b8e57e6511fd6bce0 )
-)
-
-game (
-	name "Fighting Vipers 2 (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name fvipers2.zip size 100581207 crc ab8f0d3c md5 626c3afaaf10a3aef509f8002ae4408c sha1 dc6745f811bbf2f60dd6cf6ac2104509c583f3f0 )
 )
 
 game (
@@ -17957,12 +13053,6 @@ game (
 	year "1993"
 	developer "Fujic"
 	rom ( name gal10ren.zip size 1096332 crc 6aa461c9 md5 5cdc8b4b40d6ab7e8c20729145d89406 sha1 93d307f2bddf73bf573f71b657fa6a9516ff47e0 )
-)
-
-game (
-	name "Galaxian 3 - Theater 6 : Project Dragoon"
-	developer "Namco"
-	rom ( name gal3.zip size 2762438 crc 9d63cfab md5 7ca86e121f48e733dd4a689ee3785c2a sha1 fe537b83a4a044a8559a2f10a77918c2a1126d64 )
 )
 
 game (
@@ -18078,13 +13168,6 @@ game (
 )
 
 game (
-	name "Galaxia"
-	year "1979"
-	developer "Zaccaria"
-	rom ( name galaxia.zip size 11574 crc d389293b md5 dfdf22344f2da8e80b7160941d90c9c4 sha1 fe509d791e49215f2f4601f61f3a05202ad0f110 )
-)
-
-game (
 	name "Galaxian (Namco set 1)"
 	year "1979"
 	developer "Namco"
@@ -18123,7 +13206,7 @@ game (
 	name "Galaxy Fight - Universal Warriors"
 	year "1995"
 	developer "Sunsoft"
-	rom ( name galaxyfg.zip size 10673518 crc aae4c736 md5 527b246b6a336d73b39d694fd3587213 sha1 2f944c85cd6ffe04c626079912c64fd9e9f293fb )
+	rom ( name galaxyfg.zip size 12020205 crc 3618b328 md5 32c543513c1aaecd83204bc666e01a86 sha1 e01375ec4af13a03d2548b442a3ca55fe9723aeb )
 )
 
 game (
@@ -18131,27 +13214,6 @@ game (
 	year "1989"
 	developer "Electronics Devices Italy"
 	rom ( name galaxygn.zip size 482777 crc 0dfc5a56 md5 00170035dfee002a0a4ed8de73ee84db sha1 faa302725940b055f58f9057ddde0e094fd4bb8f )
-)
-
-game (
-	name "Galaxy Ranger"
-	year "1983"
-	developer "Sega"
-	rom ( name galaxyr.zip size 54752 crc 7020488e md5 af18993c6fe3dd101fe4a27b590d9921 sha1 eeba2d847b361014a9d3a9383ade6a4ab23860e2 )
-)
-
-game (
-	name "Galaxy Ranger (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name galaxyrp.zip size 54706 crc df335981 md5 e9b89f5034bb00ece5176142dc3f7b28 sha1 eeba1c79401a6e08c92b5674757adb7eb4fb4c64 )
-)
-
-game (
-	name "Galaxy Games StarPak 2"
-	year "1998"
-	developer "Creative Electronics &amp; Software / Namco"
-	rom ( name galgame2.zip size 835222 crc 896985c5 md5 478e3de1a1e5dc0e929ea3157aad4d41 sha1 0164d662c4ac69512cc0164cb90ee9e7f244675f )
 )
 
 game (
@@ -18197,13 +13259,6 @@ game (
 )
 
 game (
-	name "Gallagher's Gallery v2.2"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name gallgall.zip size 73771 crc 960687ee md5 effc2bddffeb6ef5eef0013fff139ddd sha1 ca14768c4d44d32855f7b58eb762a1bce779fb06 )
-)
-
-game (
 	name "Gallop - Armed police Unit (Japan)"
 	year "1991"
 	developer "Irem"
@@ -18218,34 +13273,6 @@ game (
 )
 
 game (
-	name "Gals Panic II (Asia)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2.zip size 18008924 crc 7a786dc2 md5 468896b043dd290dd75567f07f4c63c5 sha1 bda64fe6ea822643a70c4918d967da5b0ee08c29 )
-)
-
-game (
-	name "Gals Panic II (German)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2g.zip size 18477745 crc 390769b9 md5 66a7995544505efd0bb0deee7f384d23 sha1 325c5675a782eb550980e881a3c6afa6eedb52ee )
-)
-
-game (
-	name "Gals Panic II (Japan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2j.zip size 9877794 crc 90b48424 md5 d85f33c5e7fdcbc49d0db2af01ee899c sha1 7810eee1374c8529eeee08c6ef2ad5ec312f5868 )
-)
-
-game (
-	name "Gals Panic II (Taiwan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2t.zip size 18025992 crc ed55b882 md5 042df807d00eb00645b58789ebdec241 sha1 09f499c56dbcd381e750c7ad07787f478424021d )
-)
-
-game (
 	name "Gals Panic 3"
 	year "1995"
 	developer "Kaneko"
@@ -18256,14 +13283,14 @@ game (
 	name "Gals Panic 4 (Japan)"
 	year "1996"
 	developer "Kaneko"
-	rom ( name galpani4.zip size 4100557 crc 434f8e4a md5 a432b890a2dddd1f0f8ecc7b79a11a03 sha1 7cef4278b60dd81794b6d592198618414ed2e06a )
+	rom ( name galpani4.zip size 4132578 crc c9ca8378 md5 5f1a20c09b24acbd74be1490612ba0a8 sha1 45edddc7520dbe68693e82fb181ede3431aa75df )
 )
 
 game (
 	name "Gals Panic 4 (Korea)"
 	year "1996"
 	developer "Kaneko"
-	rom ( name galpani4k.zip size 5992436 crc 7753baaa md5 73ef2a06c132a056cda7828f638303e6 sha1 7173f7c1459b6c439fcbe8444068118593a1e950 )
+	rom ( name galpani4k.zip size 6143558 crc 2e1b76f6 md5 aa973943e2628f2de19eceeaeb617dea sha1 b2fb8642188be93eba7e842e77cf125bffebb850 )
 )
 
 game (
@@ -18284,35 +13311,35 @@ game (
 	name "Gals Panic S - Extra Edition (Japan)"
 	year "1997"
 	developer "Kaneko"
-	rom ( name galpanis.zip size 14825091 crc d6ed48cd md5 f09e2fb90587294a39f11346fb460c4d sha1 236ed45970d532e6d059d28356a1e005b3abcd9b )
+	rom ( name galpanis.zip size 14857112 crc 7a36e67c md5 10e1e4bd28a6f75fb1711f83c531ceb8 sha1 3c3d4917f5650fe029b0f68110a81ca0439dd3a5 )
 )
 
 game (
 	name "Gals Panic S - Extra Edition (Korea)"
 	year "1997"
 	developer "Kaneko"
-	rom ( name galpanisk.zip size 14822367 crc 7d9e27e6 md5 24602b815effb66d08a7ccbb2ce996fb sha1 ef8d39a899cf46992d56f30b90c9098923ae3ecd )
+	rom ( name galpanisk.zip size 14973489 crc 7bd16f15 md5 eca71897772a137e9837d5235f3141ae sha1 86ba0cd31230a697ec4b2aad5b9576a92ed98250 )
 )
 
 game (
 	name "Gals Panic S2 (Japan)"
 	year "1999"
 	developer "Kaneko"
-	rom ( name galpans2.zip size 17267032 crc ab27aa65 md5 0b39574fcceeae8e8225b016a51875cb sha1 3a65dc4c489a79e9a48f3044e8409e1e191f1e66 )
+	rom ( name galpans2.zip size 17299053 crc 0638fb47 md5 f70c8d06132bf9a72d9506afb441412b sha1 d2c928c92286266a66cd38837ba583c71a17f1dd )
 )
 
 game (
 	name "Gals Panic S2 (Asia)"
 	year "1999"
 	developer "Kaneko"
-	rom ( name galpans2a.zip size 17263480 crc e608c3fc md5 71a50c3bff4e0dcb91ed1ec102ccb15c sha1 0460945dbbace31c8a19584c01eb9aee6c4643e9 )
+	rom ( name galpans2a.zip size 17425195 crc 40cccf56 md5 b9415ced1eb52fcd3895681e3866ba11 sha1 bc0681f84148184801034b45d2d880fba1458b44 )
 )
 
 game (
 	name "Gals Panic S3 (Japan)"
 	year "2002"
 	developer "Kaneko"
-	rom ( name galpans3.zip size 9608363 crc 086ad939 md5 850edd1f016c822d614ef7a9e1c5cefb sha1 f4be44ca62307317e906505794274dcdac5b57b1 )
+	rom ( name galpans3.zip size 9640384 crc 5fb236eb md5 1990a90c9330e2f64db8e2f0750a1a40 sha1 1fa432cc69e31ec4203384dc405f2cf6b6670c0d )
 )
 
 game (
@@ -18386,34 +13413,6 @@ game (
 )
 
 game (
-	name "GameCristal (version 2.613)"
-	year "2002"
-	developer "Cristaltec"
-	rom ( name gamecst2.zip size 244009 crc 12e18a86 md5 5ad3530d842d8b21056b95e1d986917a sha1 19cff244de54c912c440e903caffcc5e7507d229 )
-)
-
-game (
-	name "GameCristal"
-	year "2002"
-	developer "Cristaltec"
-	rom ( name gamecstl.zip size 244009 crc 12e18a86 md5 5ad3530d842d8b21056b95e1d986917a sha1 19cff244de54c912c440e903caffcc5e7507d229 )
-)
-
-game (
-	name "The Game Paradise - Master of Shooting! / Game Tengoku - The Game Paradise"
-	year "1995"
-	developer "Jaleco"
-	rom ( name gametngk.zip size 13902738 crc fbf9eed6 md5 8c7e0ae282cb63d4dc0e8140977b81a4 sha1 8657d916ccce719dcc9442e6e7691bf6d9d6a7d5 )
-)
-
-game (
-	name "Gamshara (10021 Ver.A)"
-	year "2003"
-	developer "Mitchell"
-	rom ( name gamshara.zip size 12940855 crc 868b5cc8 md5 26e70aebe611829c91d3219ed894210d sha1 0fa67752c9c490ceda1cc8678fb254fce51388f6 )
-)
-
-game (
 	name "Ganbare! Gonta!! 2 / Party Time: Gonta the Diver II (Japan Release)"
 	year "1995"
 	developer "Mitchell"
@@ -18438,7 +13437,7 @@ game (
 	name "Ganryu / Musashi Ganryuki"
 	year "1999"
 	developer "Visco"
-	rom ( name ganryu.zip size 19337400 crc de64026d md5 04fbe8f4d450d0fe24f2be2b819b3a1f sha1 2dadbcb036a22eb56f3ce8db07b72425a11c00d6 )
+	rom ( name ganryu.zip size 20684087 crc b43bc617 md5 2cafc9c88696bc4eb64569edc6edae8f sha1 5740cbbb778ed10932b0a37bf19a907ea9b26fdf )
 )
 
 game (
@@ -18522,28 +13521,28 @@ game (
 	name "Garou - Mark of the Wolves (set 1)"
 	year "1999"
 	developer "SNK"
-	rom ( name garou.zip size 80982446 crc efab35e3 md5 224342f8cceb796c50cea257d3f134ad sha1 8d05d98bf273099fb044cd930248cdc21b10e854 )
+	rom ( name garou.zip size 82329133 crc 11861941 md5 830cf3ba33c35307390198414dd98718 sha1 57674ad16bce886c8566f79dda173b7937870ad3 )
 )
 
 game (
 	name "Garou - Mark of the Wolves (bootleg)"
 	year "1999"
 	developer "bootleg"
-	rom ( name garoubl.zip size 38555279 crc 7f2d3201 md5 03ae7edef31bd740d7557105d81eeb2a sha1 3eeb1b8f6fb5e1f2669372908001fa8bdce27377 )
+	rom ( name garoubl.zip size 39901966 crc c1945ded md5 fa9ad48e8bbca266d20f0d4d7ff4ae33 sha1 5aceea1eac13813f4f6c82a74890fa62214980e9 )
 )
 
 game (
 	name "Garou - Mark of the Wolves (set 2)"
 	year "1999"
 	developer "SNK"
-	rom ( name garouo.zip size 80811399 crc e1609b39 md5 e297453482f270d3aa1c5e8a5389dfaa sha1 67432e7ea6c47ad2169579aadfa8e45a2646d82e )
+	rom ( name garouo.zip size 82158086 crc de189157 md5 73cca3a14016d177873dd7917c8cf9a6 sha1 c5fde73d48f7845e7d7a4f4f25c1bf0f902ac9e5 )
 )
 
 game (
 	name "Garou - Mark of the Wolves (prototype)"
 	year "1999"
 	developer "SNK"
-	rom ( name garoup.zip size 38425374 crc 1d9d6fbd md5 76bee57c004857fb62ffe528f39623e7 sha1 7f6976d0947bad7e824892d497ad6e153e7ff375 )
+	rom ( name garoup.zip size 39772061 crc 20d106d9 md5 1bbf54dea8a9bc3f4eb4b5b2eb82bd2b sha1 eccfdb0d2a59f0a4aff3377d3427a2b0b42e0f6d )
 )
 
 game (
@@ -18551,13 +13550,6 @@ game (
 	year "1988"
 	developer "Konami"
 	rom ( name garuka.zip size 641165 crc 0b4e6cff md5 f9a96afaea68a780d20c4757a4aaf88d sha1 ab675fd4b5800748aeb3ed38d0232f1ec5c8f2aa )
-)
-
-game (
-	name "Garyo Retsuden (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name garyoret.zip size 420083 crc 22aefd95 md5 27a84c1193c4eb1e81b209ddb55b83b4 sha1 72813552144923325fa0940fa7bd2b8dc16ca219 )
 )
 
 game (
@@ -18635,13 +13627,6 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name gauntleg.zip size 257063 crc ac546d52 md5 a902d0a335ee8ac2ebf59a5c480f16e3 sha1 84b3e8ea1837e57241e23b045cac875cdcba4ccb )
-)
-
-game (
-	name "Gauntlet Legends (version 1.2)"
-	year "1998"
-	developer "Atari Games"
-	rom ( name gauntleg12.zip size 258082 crc c375aeb9 md5 201a7ca617505d5939f9f47d0c01e98e sha1 d0f8cf43b447e8f52cec3548e652b6f1cb439434 )
 )
 
 game (
@@ -18788,7 +13773,7 @@ game (
 	name "Golden Axe - The Duel (JUETL 950117 V1.000)"
 	year "1994"
 	developer "Sega"
-	rom ( name gaxeduel.zip size 13783746 crc 7dcf5ce5 md5 138818417a00f245c1d2e96485c9c1c8 sha1 de24154bc43ca8efcb09309435816a9a2233662d )
+	rom ( name gaxeduel.zip size 16482967 crc 5605efc6 md5 0e7506429b75fc4ae6e2569371d53edd sha1 c8f0af6b87f509e3c818d5b1b0b51df04bccbd48 )
 )
 
 game (
@@ -18796,13 +13781,6 @@ game (
 	year "1985"
 	developer "Konami"
 	rom ( name gberet.zip size 65844 crc 1a1442ff md5 ab61f37e28e80cbf5407f0572af4d8c1 sha1 37c5c8c8042f507f19b2184cd3e79952845b98a9 )
-)
-
-game (
-	name "Green Beret (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name gberetb.zip size 76784 crc 536e2547 md5 b47a117372449b56c72e37dfb8dddbd9 sha1 5c0e50e37c0239494e8b176572d03134bafd5934 )
 )
 
 game (
@@ -18837,21 +13815,21 @@ game (
 	name "G-Darius (Ver 2.01J)"
 	year "1997"
 	developer "Taito"
-	rom ( name gdarius.zip size 17864859 crc c5f56110 md5 b66ced419bfd10932685dafaacab3d9a sha1 9f52d8e76807d835a77d6da759d837de88d62956 )
+	rom ( name gdarius.zip size 17990997 crc a88ac2b0 md5 caf196d6a348cefd71319c5b7bd675e8 sha1 b94dfd26c2fd5865001eb7b5ba6a8faf32e8c743 )
 )
 
 game (
 	name "G-Darius Ver.2 (Ver 2.03J)"
 	year "1997"
 	developer "Taito"
-	rom ( name gdarius2.zip size 18006700 crc d521fd88 md5 56ec767c4d3783e313dcf779afdf8eb8 sha1 72ae4c4f5ca9231ac5fdbb0f75df70d895bc6139 )
+	rom ( name gdarius2.zip size 18132838 crc 024e28fe md5 c208b7d966bb13341b8fc8b130b111a6 sha1 ffa90c0f82d76772d46aaf4d6fab474e0ae3d815 )
 )
 
 game (
 	name "G-Darius (Ver 2.02A)"
 	year "1997"
 	developer "Taito"
-	rom ( name gdariusb.zip size 17865124 crc 1c140d57 md5 9811b06516b5eb27720f618df74ed90d sha1 e7c4615101f7c601ee29524d16c635bbe8de9d6e )
+	rom ( name gdariusb.zip size 17991262 crc 21a7dced md5 d5064d0999bd21e46056044d98867eb7 sha1 7aff1c06c26cfdfd3b7b3ce351ab66be31ca53ec )
 )
 
 game (
@@ -18897,13 +13875,6 @@ game (
 )
 
 game (
-	name "Geisha (A - 05/03/01, New Zealand)"
-	year "2001"
-	developer "Aristocrat"
-	rom ( name geishanz.zip size 949883 crc 70b98d27 md5 6818d0d6a1168212b07b2898cc906338 sha1 3210fde8535e1901382ea0e8c31cb6b86855c3fd )
-)
-
-game (
 	name "Quiz Gekiretsu Scramble (Japan)"
 	year "1992"
 	developer "Face"
@@ -18929,20 +13900,6 @@ game (
 	year "1985"
 	developer "Eastern Corp."
 	rom ( name gekisou.zip size 116137 crc 7f2bb56e md5 328fe7f40da2c5309fe0972292cc05f2 sha1 5b90aaa94c941aa324e3958b9d45a6c4b3b872af )
-)
-
-game (
-	name "Gekitsui Oh (Japan)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name gekitsui.zip size 125073 crc afeee65e md5 84e2128d56646b83be26a8163e96173c sha1 e0ec8fcf1d43434b6e9ce1733f2b793e46a3f33a )
-)
-
-game (
-	name "Gekitou Pro Yakyuu Mizushima Shinji All Stars vs. Pro Yakyuu (Rev C) (GDT-0008C)"
-	year "2003"
-	developer "Sega"
-	rom ( name gekpurya.zip size 219 crc b096fc08 md5 40ac6050a3c874be173b1bc9b26fa472 sha1 2b04110cbfce17d1b9aef82d6a6a921036cc5adb )
 )
 
 game (
@@ -19002,27 +13959,6 @@ game (
 )
 
 game (
-	name "Get Bass"
-	year "1997"
-	developer "Sega"
-	rom ( name getbass.zip size 43648709 crc 48f7a835 md5 fab7f1afb79b3acafc4ccaed714f613e sha1 0f3d6f0a8393cedd85893f4d1a22c0c4de9a9a13 )
-)
-
-game (
-	name "Guardian (US)"
-	year "1986"
-	developer "Toaplan / Taito America Corporation (Kitkorp license)"
-	rom ( name getstar.zip size 158272 crc 8c74ff48 md5 71fd94bf1d02e11d277d8c82cda0bf8c sha1 4309b5e6ae00c1fcab84117c452ad579396d5def )
-)
-
-game (
-	name "Get Star (Japan)"
-	year "1986"
-	developer "Toaplan / Taito"
-	rom ( name getstarj.zip size 158028 crc 3edb0d2e md5 70c5caba45948e961d562240b3542ffb sha1 3e4d6e77066254264a3335b97a9766826257656f )
-)
-
-game (
 	name "Golden Fire II"
 	year "1992"
 	developer "Topis Corp"
@@ -19051,41 +13987,6 @@ game (
 )
 
 game (
-	name "Go! Go! Connie chan Jaka Jaka Janken"
-	year "1996"
-	developer "Eighting"
-	rom ( name ggconnie.zip size 635546 crc 5294e4e3 md5 b1a1b0052d5d9d8dfaa26a1d8cdc122f sha1 f69e2f41112094b94f57b389392d8794fbc24025 )
-)
-
-game (
-	name "Goalie Ghost"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name gghost.zip size 33194 crc 99c97f79 md5 088130c4c4997dd2ed55cc0e7cc5e067 sha1 5b63c5e3c53cac54f965a79ca9a7aeea6c25628e )
-)
-
-game (
-	name "Guilty Gear Isuka"
-	year "2003"
-	developer "Sammy / Arc System Works"
-	rom ( name ggisuka.zip size 131961511 crc afa85b3c md5 1cc75ac9f4399917a4a6a3adaf7160d2 sha1 290629120bfb33935eae68112a50bf7bc90045fc )
-)
-
-game (
-	name "Giant Gram (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name ggram2.zip size 50483747 crc fbdfc186 md5 445adf6efb65f6d8980322ec5c4ab34d sha1 d6c939d803cf8af5ee8f21ed7128ac1aef77dd23 )
-)
-
-game (
-	name "Golfing Greats 2 (ver JAC)"
-	year "1994"
-	developer "Konami"
-	rom ( name ggreats2.zip size 12283215 crc cc80d4d4 md5 07213ad4679688b462f79b6b1c8b7f1b sha1 ecb6d0b337c9b682329dae4fd02118ea83c3e8c5 )
-)
-
-game (
 	name "Gain Ground (World, 3 Players, Floppy Based, FD1094 317-0058-03d Rev A)"
 	year "1988"
 	developer "Sega"
@@ -19097,41 +13998,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name ggroundj.zip size 817641 crc 80c46552 md5 3d29387932c77912b9937f1fea05f25e sha1 100ee68c701acaa95f151f796628c43920cc083c )
-)
-
-game (
-	name "Guilty Gear X (JPN)"
-	year "2000"
-	developer "Arc System Works"
-	rom ( name ggx.zip size 84546325 crc fff51674 md5 8b0c7dd7621694239af220a7d93c6b5f sha1 b2021dd4347177c07fe0012a216b5c043138a4f5 )
-)
-
-game (
-	name "Guilty Gear XX (GDL-0011)"
-	year "2002"
-	developer "Arc System Works"
-	rom ( name ggxx.zip size 1192 crc 931e87bf md5 522868038259a50a51b04b43109e7e25 sha1 def565849f0cb12792ac890349da0b72252b2d0a )
-)
-
-game (
-	name "Guilty Gear XX Accent Core (GDL-0041)"
-	year "2006"
-	developer "Arc System Works"
-	rom ( name ggxxac.zip size 1195 crc 68335cb1 md5 d82ff5b126363e503abd90ee2bc5b3f4 sha1 09cd22881ee28ecca767e63cb2f7d81bcc8a1fad )
-)
-
-game (
-	name "Guilty Gear XX #Reload (Rev A) (GDL-0019A)"
-	year "2003"
-	developer "Arc System Works"
-	rom ( name ggxxrl.zip size 1194 crc 5637e092 md5 732587e913d0438fdb8ef73a61437f33 sha1 7f864c3a3dbfa4f18bdc69d06b68d5598364cb95 )
-)
-
-game (
-	name "Guilty Gear XX Slash (Rev A) (GDL-0033A)"
-	year "2005"
-	developer "Arc System Works"
-	rom ( name ggxxsla.zip size 1196 crc f62cd712 md5 fb381ae46278c1625df74bd0850bc4dc sha1 5a21016cd49be7d8d0ee4369e17ab46d5bdaa2b7 )
 )
 
 game (
@@ -19149,31 +14015,10 @@ game (
 )
 
 game (
-	name "The Real Ghostbusters (US 2 Players)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name ghostb.zip size 417053 crc 2849223a md5 a68b9f4ca9df383a768c76be62886a67 sha1 29044ed4f740097646e64243ecb2b02982aa42ed )
-)
-
-game (
-	name "The Real Ghostbusters (US 3 Players)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name ghostb3.zip size 418966 crc 5a19e779 md5 261dabb3e01d4ff65dd8884a24943970 sha1 2a39333f9ad4c5d4b8dec3e11b87653355e5f6c6 )
-)
-
-game (
 	name "Ghostlop (prototype)"
 	year "1996"
 	developer "Data East Corporation"
-	rom ( name ghostlop.zip size 3298603 crc 42dbbfb8 md5 a8f817785a1a2db2d60175db3e4154df sha1 4db69eeeb330440e9102f5f441f40446847cbc74 )
-)
-
-game (
-	name "Ghost Squad (Ver. A?) (GDX-0012A)"
-	year "2005"
-	developer "Sega"
-	rom ( name ghostsqu.zip size 219 crc 059a49b7 md5 9472612fd9b3076805ff8686e54d7bdb sha1 a158f371174c63fe207e8b81d01b904b0a14c163 )
+	rom ( name ghostlop.zip size 4645290 crc f7109ffc md5 1c251f444b2c83833bb5431966e25c8f sha1 5fef6c7134c1ced2515e32119cc7c1727da8bae6 )
 )
 
 game (
@@ -19191,31 +14036,10 @@ game (
 )
 
 game (
-	name "Ghox (Spinner with Up/Down Axis)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name ghox.zip size 523946 crc 8fbc77e6 md5 8199a811cc193d584164c36cd5a717d9 sha1 90f5cae45489ac8da1f9dfeea3588e7c1f1ec58b )
-)
-
-game (
-	name "Ghox (8-Way Joystick)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name ghoxj.zip size 523704 crc 39273214 md5 4faa7ca32167586f9552050b1ec32399 sha1 0bc10c2fe93609121b2491c2d5b2108168e3dc36 )
-)
-
-game (
 	name "Gang Hunter (Spain)"
 	year "1988"
 	developer "Seibu Kaihatsu (Segasa/Sonic license)"
 	rom ( name ghunter.zip size 771348 crc 4928fad0 md5 5f67d529982e35373c6b98f5840a8467 sha1 c2ea8778c07a8df612fccaab5f61a16fdb34ebe4 )
-)
-
-game (
-	name "Giga Man 2: The Power Fighters (bootleg of Mega Man 2: The Power Fighters)"
-	year "1996"
-	developer "bootleg"
-	rom ( name gigamn2.zip size 1446805 crc 6c76ce89 md5 b1ad339f7f8de373804bceaa48c1b1a7 sha1 c05ea97e7039e78e21b068fab19c5a8396793e19 )
 )
 
 game (
@@ -19230,13 +14054,6 @@ game (
 	year "1989"
 	developer "East Technology"
 	rom ( name gigandesj.zip size 1507457 crc f0dd3da1 md5 909bcee7f944dc4c7e478490b34fb24b sha1 c17e97fb33654a124e15f960fa8fabff964d8c6c )
-)
-
-game (
-	name "Gigas (MC-8123, 317-5002)"
-	year "1986"
-	developer "Sega"
-	rom ( name gigas.zip size 58569 crc e88b39b1 md5 da9089957a72118ded8340a97900bd42 sha1 edcc5e32b5325a4e8a158d804e489f4cb27de2fa )
 )
 
 game (
@@ -19310,13 +14127,6 @@ game (
 )
 
 game (
-	name "Gimme A Break"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name gimeabrk.zip size 38709 crc 2265ae16 md5 a16efce0fed1866fbfe3b5fb1e3f37ce sha1 7675fb25d7988f2b60373b021eae6534b38fd300 )
-)
-
-game (
 	name "Ginga NinkyouDen (set 1)"
 	year "1987"
 	developer "Jaleco"
@@ -19352,13 +14162,6 @@ game (
 )
 
 game (
-	name "Gekitoride-Jong Space (10011 Ver.A)"
-	year "2001"
-	developer "Namco / Metro"
-	rom ( name gjspace.zip size 49271011 crc 56fb1fb7 md5 86a669183eb82ce891787281edc77c37 sha1 a96db4299481ca4ca409a05cb40575b544e6badd )
-)
-
-game (
 	name "Gladiator (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -19366,45 +14169,10 @@ game (
 )
 
 game (
-	name "Glass (Ver 1.1)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glass.zip size 3310646 crc 28b32237 md5 e949b302874442c3c8969a2315781315 sha1 cb79ceae423015ddd2ba88924a49f5e4b203dacf )
-)
-
-game (
-	name "Glass (Ver 1.0)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glass10.zip size 3360073 crc 52da7d49 md5 87f9d4f53a33fe8954eb99c254ffd1ab sha1 cff916c15479e24f4892e64d66e37375b8cf8685 )
-)
-
-game (
-	name "Glass (Ver 1.0, Break Edition)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glassbrk.zip size 3387819 crc ae6c693a md5 b6ce9d86ea65328770c1134f663efa59 sha1 e0a63eb412c0a145d6186d76dd69752f2e998886 )
-)
-
-game (
 	name "Golden Crown (Dutch, Game Card 95-752-011)"
 	year "1997"
 	developer "BFM/ELAM"
 	rom ( name gldncrwn.zip size 198254 crc 3ea7bb9d md5 cfe44fab492973ff5bedd8d888c622a8 sha1 8eb0a9ea02a81344584378d4b62c460e882729a7 )
-)
-
-game (
-	name "Golfing Greats"
-	year "1991"
-	developer "Konami"
-	rom ( name glfgreat.zip size 2437668 crc 1d06e0a8 md5 e4a0cf6c63d9d3594d339aa4c3f995bf sha1 3aa1cb9ba3cc911e7807636a21bbc441997b7cb3 )
-)
-
-game (
-	name "Golfing Greats (Japan)"
-	year "1991"
-	developer "Konami"
-	rom ( name glfgreatj.zip size 2438295 crc 7c0b16ae md5 70e93723d1262edd76cc3db577fba83f sha1 27516cb64f1e6db2cea503c0c504aaac26f47f14 )
 )
 
 game (
@@ -19425,35 +14193,14 @@ game (
 	name "Gallop Racer (Japan Ver 9.01.12)"
 	year "1996"
 	developer "Tecmo"
-	rom ( name glpracr.zip size 4359857 crc 35b92c22 md5 d94b389de6308576d50311b578cb5718 sha1 fe51da0217c696b0104a60d28c8be996f0aef83f )
-)
-
-game (
-	name "Gallop Racer 2 (USA)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2.zip size 11707336 crc f0da933e md5 7eedd9da110a9d997786f77a709b3c6f sha1 67ce2d223ec20ec09ca0802fb65e09542d7b784f )
-)
-
-game (
-	name "Gallop Racer 2 (Japan)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2j.zip size 11673845 crc b3e91ab2 md5 1165679e32b2401abbd24ae563be88b0 sha1 34b541945a45c128d1b76f6c6eb2999f7f4cabb8 )
-)
-
-game (
-	name "Gallop Racer 2 Link HW (Japan)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2l.zip size 11675399 crc 636ed337 md5 ed861380fb4d1ff5d1680f2e99e49a3a sha1 d433268886d60163f940fe9325c358f2db4875ca )
+	rom ( name glpracr.zip size 4485406 crc 5a62d328 md5 cb0f0c1029acda8b0139e2520eb7b3c7 sha1 a52461915e4ce1201ec74a89583af5160b28191d )
 )
 
 game (
 	name "Gallop Racer 3 (Japan)"
 	year "1999"
 	developer "Tecmo"
-	rom ( name glpracr3.zip size 10726233 crc d677fa99 md5 b580094ed1a0fe12bf9e28a680ba7e6b sha1 7b5551f295d5bcd422e65a954872f158ca1c4424 )
+	rom ( name glpracr3.zip size 10864685 crc 1ad03106 md5 59db02f6e777224be68d657fffb410d5 sha1 da568e4b6ef2eca11dc262745df5f909d764aec6 )
 )
 
 game (
@@ -19541,24 +14288,10 @@ game (
 )
 
 game (
-	name "Goal To Go"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name goaltogo.zip size 21716 crc 0e20e9a7 md5 50525cc9d666baa7e607eb412326a5df sha1 61e8d94097073c26145fa80f77dd43b52da9a0d8 )
-)
-
-game (
 	name "Goal! Goal! Goal!"
 	year "1995"
 	developer "Visco"
-	rom ( name goalx3.zip size 4881268 crc bfee618c md5 187a11c53575d4c18e9a9a5d0e0f32b2 sha1 2c55048e25a5b473adb5697cf48fee7c266d28c4 )
-)
-
-game (
-	name "Godzilla"
-	year "1993"
-	developer "Banpresto"
-	rom ( name godzilla.zip size 2667535 crc a34d6576 md5 49ab6051dd2ff933d82b4ed91763d9a9 sha1 cfad89125c1286e0cde1d4d696e7cda1ca1e8bb0 )
+	rom ( name goalx3.zip size 6227955 crc a46ddd2a md5 925caa5c65fd4832fd489ee2f6d0c989 sha1 a4c4f95ac33d32e484e5eb829e895827c1cc36c8 )
 )
 
 game (
@@ -19583,31 +14316,10 @@ game (
 )
 
 game (
-	name "Goindol (World)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindol.zip size 103720 crc 88e89ce6 md5 e7d6297f640017101f75f8c776983562 sha1 5a39346414803560e5a905ab92fdc3d3c3830ff0 )
-)
-
-game (
-	name "Goindol (Korea)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindolk.zip size 103721 crc fa8076a8 md5 7533e7a96af2f2518eeac1b01d935db2 sha1 412b0a3edebb2a407fe7d8936586fc9a7748bf7f )
-)
-
-game (
-	name "Goindol (US)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindolu.zip size 103718 crc fb012374 md5 d99e1b8c7d977f21187eeee66c3ff869 sha1 ac4d0240979ebffd636572f2a7b49f27e3c3fdb0 )
-)
-
-game (
 	name "Gokujyou Parodius (ver JAD)"
 	year "1994"
 	developer "Konami"
-	rom ( name gokuparo.zip size 5767148 crc 172907db md5 dff6d670b3ce2893c9ffe1873793979c sha1 29236b0900cbb74a48b4d7d419c5a2dbac79eb14 )
+	rom ( name gokuparo.zip size 5775838 crc 3e3480ef md5 93a57b002cc81502cd15413b08b89c97 sha1 e599d7fcf587b8e4159180fe8d3b7c3497797743 )
 )
 
 game (
@@ -19639,20 +14351,6 @@ game (
 )
 
 game (
-	name "Gold Medalist (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name goldmedlb.zip size 762008 crc 4da5ac2f md5 4d6df4bbebe50bd79a8a57cf89a1e4f9 sha1 34be3ad79b1b44241fa179342e5ecb8de9097734 )
-)
-
-game (
-	name "Golden Axe (set 6, US, 8751 317-123A)"
-	year "1989"
-	developer "Sega"
-	rom ( name goldnaxe.zip size 1162622 crc 0613beb6 md5 90a88e501fe0eb52df0061cf3e5bd220 sha1 5d0a09d15498d2e302a44fc119710413658f409d )
-)
-
-game (
 	name "Golden Axe (set 1, World, FD1094 317-0110)"
 	year "1989"
 	developer "Sega"
@@ -19660,31 +14358,10 @@ game (
 )
 
 game (
-	name "Golden Axe (set 2, US, 8751 317-0112)"
-	year "1989"
-	developer "Sega"
-	rom ( name goldnaxe2.zip size 1162105 crc 0cc43c89 md5 0af740269989f0ffca04a90fc334d6c0 sha1 8fa448a06436e27d15d241a578f0c938a99b26c6 )
-)
-
-game (
 	name "Golden Axe (set 3, World, FD1094 317-0120)"
 	year "1989"
 	developer "Sega"
 	rom ( name goldnaxe3.zip size 1262280 crc 50def9e0 md5 f8663e93ef751fa2d52d6cb332278017 sha1 9b780fa2bba02c4ed3a1ff59d655a6af0e13583d )
-)
-
-game (
-	name "Golden Axe (encrypted bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name goldnaxeb1.zip size 1257874 crc 0bf587bc md5 534e4ad1c0a7934bd930528109fbb539 sha1 843d934309222cc80099974fbf3a6ef66e3d2ca4 )
-)
-
-game (
-	name "Golden Axe (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name goldnaxeb2.zip size 1123593 crc 611c57ea md5 470f23586c3baf81156c080e5dba3f32 sha1 902d4b126ca3e7729504b20ff158e1b63e142249 )
 )
 
 game (
@@ -19713,13 +14390,6 @@ game (
 	year "1981"
 	developer "Bonanza Enterprises, Ltd"
 	rom ( name goldnpkr.zip size 13107 crc 5ff4a207 md5 766345979481458382c99ec8f0985f17 sha1 b2fb20c7f76d2c17c125ad4b1a71f6dea3b3ee25 )
-)
-
-game (
-	name "Golden Pyramids (B - 13-05-97, USA)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name goldprmd.zip size 912447 crc bf9a884b md5 efd0cbbd462bde70b45543e0a590ea22 sha1 bda6a5fdd45b9766b91a0e0f7bef2a4fc4e7a360 )
 )
 
 game (
@@ -19843,56 +14513,21 @@ game (
 	name "Voltage Fighter - Gowcaizer / Choujin Gakuen Gowcaizer"
 	year "1995"
 	developer "Technos Japan"
-	rom ( name gowcaizr.zip size 12583376 crc ac6355ba md5 feec2ed889057e9396224d5e5144a011 sha1 88085f73c93e1884575c148f36b7ad0797b03e93 )
-)
-
-game (
-	name "Gals Panic II - Quiz Version (Japan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name gp2quiz.zip size 10351466 crc 0bb5fda1 md5 3d8ff66260c962580fdbaf82956ac0cc sha1 0eb861f46aa6c48482f36a8cd95c5955fbc376e2 )
-)
-
-game (
-	name "Gals Panic II' - Special Edition (Japan)"
-	year "1994"
-	developer "Kaneko"
-	rom ( name gp2se.zip size 10929302 crc 0c600ccc md5 8014d42fb7c1e5567ebc25e2cff9913d sha1 cf85e37fb75f70b459a86592d0a56ff7ddaa1da3 )
-)
-
-game (
-	name "Grand Prix '98"
-	year "1998"
-	developer "Romtec Co. Ltd"
-	rom ( name gp98.zip size 280148 crc b156283a md5 ac53b0d6591a1ed9c92878f742d0b658 sha1 9f36e18729356f8a11cfbfc4bf0c11f8df9389bc )
-)
-
-game (
-	name "Golden Par Golf (Joystick, V1.1)"
-	year "1992"
-	developer "Strata/Incredible Technologies"
-	rom ( name gpgolf.zip size 521879 crc e1b858cc md5 887376bf11dc63882624ca25f817c6bc sha1 fd78ce67b14dfa05493c3bc8b44cc05447755ab7 )
+	rom ( name gowcaizr.zip size 13930063 crc 6f730d8e md5 0ca70526e12e506cec27d5a6183a3b77 sha1 e48204c6d8a7ec245bdad2d67cbb6837e208034a )
 )
 
 game (
 	name "Ghost Pilots (set 1)"
 	year "1991"
 	developer "SNK"
-	rom ( name gpilots.zip size 3708967 crc 92018396 md5 86207faf010de82bc33259527a694600 sha1 25f799b1b5b8e371c0d84ec25ce234ef6716bcec )
+	rom ( name gpilots.zip size 5055654 crc 92fd8dbd md5 b353cb03ab9065e5a513afbb3b6d3838 sha1 aeb11b632bbd81aa0ef3f6b0c756e56389293e9e )
 )
 
 game (
 	name "Ghost Pilots (set 2)"
 	year "1991"
 	developer "SNK"
-	rom ( name gpilotsh.zip size 3709548 crc 1f2458d0 md5 99e4160f9c1b6358fcea17fb2995ead0 sha1 80b706727fa3e29791993c300163c02be66f2eac )
-)
-
-game (
-	name "GP Rider (set 2, World, FD1094 317-0163)"
-	year "1990"
-	developer "Sega"
-	rom ( name gprider.zip size 1471284 crc 66887cd2 md5 287db13b4dfb4e2ae80e26fe6e773e43 sha1 fa8884d1accdf196ff967b761f83aa55357c7c33 )
+	rom ( name gpilotsh.zip size 5056235 crc 47c41e5a md5 06a2b1d7a9162edbd2141a6d460ad364 sha1 312bf05b4f23f1e319239c447656674bcc441668 )
 )
 
 game (
@@ -19900,13 +14535,6 @@ game (
 	year "1990"
 	developer "Sega"
 	rom ( name gprider1.zip size 1562255 crc b474b668 md5 a8c34ea6740b4d670ad308bc5dc03551 sha1 be412b67dcab7f26c4a00c717bd926af45cadbed )
-)
-
-game (
-	name "GP World"
-	year "1984"
-	developer "Sega"
-	rom ( name gpworld.zip size 91774 crc 72064578 md5 9a7ac7b716c07e891b3deb0533a5f08f sha1 8fc007a512a50bdb363960c8aef19fdc22e4e151 )
 )
 
 game (
@@ -19966,40 +14594,6 @@ game (
 )
 
 game (
-	name "SD Gundam Sangokushi Rainbow Tairiku Senki"
-	year "1993"
-	developer "Banpresto"
-	rom ( name grainbow.zip size 1694721 crc 093aca05 md5 e33322320674da99f99811d60660ef6c sha1 e99a33f70103d70cd931490037fe670d7132aad4 )
-)
-
-game (
-	name "Giant Gram 2000 (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name gram2000.zip size 111043462 crc 8a21c6d6 md5 aa485ac93eb078ab0981bd238fedeae8 sha1 a5678619a12d9e014678c052a2738eb2ff23dc8f )
-)
-
-game (
-	name "Grand Prix"
-	developer "4fun"
-	rom ( name grandprx.zip size 637140 crc 27bd77d4 md5 57e67e5ab9a4bdfd27ff55ed6673d03a sha1 3794a30381753f08e59ed21b43187924acb6d3fb )
-)
-
-game (
-	name "Gratia - Second Earth (92047-01 version)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name gratia.zip size 9860174 crc c943d00a md5 e6502a65cfc67d2226f2afd16c8a058e sha1 9b798fb1dd5d7b5c3ef2b23d41d868a39a8c09ab )
-)
-
-game (
-	name "Gratia - Second Earth (91022-10 version)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name gratiaa.zip size 9094463 crc bd03f496 md5 da78ed9c90ce86938cdf218c4a3b861d sha1 6a960e44c072e14138882af2fe4966526e026379 )
-)
-
-game (
 	name "Gravitar (version 3)"
 	year "1982"
 	developer "Atari"
@@ -20031,7 +14625,7 @@ game (
 	name "Guardian Force (JUET 980318 V0.105)"
 	year "1998"
 	developer "Success"
-	rom ( name grdforce.zip size 10701625 crc 62eae351 md5 62dcaefdb10a89bf135120e4ec74f3ad sha1 8564545145c2aba1cdbf169c24aa77525caa2334 )
+	rom ( name grdforce.zip size 13400846 crc e6caecaf md5 850a9264605488c4202f7cb2e4193f46 sha1 a9c0f29db8cd55d4917b75506e269178d14577c7 )
 )
 
 game (
@@ -20056,24 +14650,10 @@ game (
 )
 
 game (
-	name "Great Guns"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name greatgun.zip size 86041 crc 32bbd419 md5 89f9e845ca4927986299fbfd6631e3b5 sha1 0374fc5cee129d06a4cdcdf0d24bad614f2d52c6 )
-)
-
-game (
 	name "Great Gurianos (Japan?)"
 	year "1986"
 	developer "Taito Corporation"
 	rom ( name greatgur.zip size 269067 crc d3dffb63 md5 a510e2efa8018358e1c291739814d47c sha1 10f6af04a388020f87f1f1ed270f63e1c9ad5ce0 )
-)
-
-game (
-	name "Green Beret (Irem)"
-	year "1980"
-	developer "Irem"
-	rom ( name greenber.zip size 7700 crc b37016af md5 f3d1acb865f1f2b4f51a9769367f4ee9 sha1 7749331702fe6fbb38dd5890b00c724cf8e9bdfe )
 )
 
 game (
@@ -20102,20 +14682,6 @@ game (
 	year "1980"
 	developer "bootleg (Videotron)"
 	rom ( name griffon.zip size 16752 crc 6ad19a1e md5 0500ec70c0094ec225be492c37b632eb sha1 93f22c3394db8f8ef5b959cc77589449f5050bb2 )
-)
-
-game (
-	name "Grind Stormer"
-	year "1992"
-	developer "Toaplan"
-	rom ( name grindstm.zip size 1115522 crc f70447aa md5 b0d7ff6cbf232ed2a4fd839a92a5f4dd sha1 7b1fd0aaa2a6208a19cd5d5953a289b417ab2b11 )
-)
-
-game (
-	name "Grind Stormer (older set)"
-	year "1992"
-	developer "Toaplan"
-	rom ( name grindstma.zip size 1115543 crc cc1a0e47 md5 04d10067916b2eaf47e3cf06b009db2c sha1 7b4ba906b102f7fecb2c9525e7891cd1d8729818 )
 )
 
 game (
@@ -20157,7 +14723,7 @@ game (
 	name "Power Instinct 3 - Groove On Fight (J 970416 V1.001)"
 	year "1998"
 	developer "Atlus"
-	rom ( name groovef.zip size 13918956 crc 8a1b89c0 md5 a21381bd56ec9225266f692d98ccc6ca sha1 8247b5f071a34f6fc095e9b2b203a7a485faaeae )
+	rom ( name groovef.zip size 16618177 crc eea5659b md5 7dd0ad06664348a8335e9e9a602e5ac8 sha1 5413e05371e53c11489064e067dc1e0d403a0bbe )
 )
 
 game (
@@ -20179,33 +14745,6 @@ game (
 	year "1990"
 	developer "Taito America Corporation"
 	rom ( name growlu.zip size 2610285 crc 87ed9c5e md5 0ea29c5c1410ce1c838155dd4171022a sha1 5a53f84a1bcae15d8afd7d8354584d4e673b9b29 )
-)
-
-game (
-	name "Gran Tesoro? / Play 2000 (v5.01) (Italy)"
-	year "1999"
-	developer "Nova Desitec"
-	rom ( name grtesoro.zip size 910002 crc 51119acc md5 0d1f717611e1cde95f53e4b3f4bfbe4b sha1 48f8429ae7803ca91fc0edd3fb5047b7cfa4cae2 )
-)
-
-game (
-	name "Grudge Match (prototype)"
-	developer "Bally Midway"
-	rom ( name grudge.zip size 55828 crc f434bea0 md5 368c9d50d62fda8c2164d29f023ad4f5 sha1 b16729f20c2e821d37aef06c6fe2d6f7fee559ec )
-)
-
-game (
-	name "Gryzor (Set 1)"
-	year "1987"
-	developer "Konami"
-	rom ( name gryzor.zip size 388407 crc f7ea7084 md5 a5c3a53ad3a426df63088a93f789135f sha1 1c5f65d4d5ae517daa6e2fcf31a0eba13f3c338c )
-)
-
-game (
-	name "Gryzor (Set 2)"
-	year "1987"
-	developer "Konami"
-	rom ( name gryzora.zip size 388301 crc 14d55376 md5 ba556cf912a8e21a1c7d251c143bb0b1 sha1 d2209640536d2db700dcd2d0d1f4742626971476 )
 )
 
 game (
@@ -20297,20 +14836,6 @@ game (
 	year "1993"
 	developer "Human"
 	rom ( name gstrikera.zip size 5946805 crc 606c95f9 md5 19e3655387a726148189bacabcf3dac1 sha1 61f756571348ac5c15ef6eca9406f0a02215c790 )
-)
-
-game (
-	name "Great Swordsman (World?)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name gsword.zip size 68856 crc 1aad9299 md5 7f99c589cbb50842257f9611b876203a sha1 e9cd6383ea303ad03308b647350453d4e67aa04a )
-)
-
-game (
-	name "Great Swordsman (Japan?)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name gsword2.zip size 67159 crc 50dcc5a2 md5 fcc5da915d90947245e322611a54b2f9 sha1 b3c82b116438128af0c503e3276b3318999d1b4d )
 )
 
 game (
@@ -20608,38 +15133,10 @@ game (
 )
 
 game (
-	name "Guitar Freaks 11th Mix (G*D39 VER. JAA)"
-	year "2004"
-	developer "Konami"
-	rom ( name gtfrk11m.zip size 315 crc 50f4b46f md5 4b8081bf7140ff6649c18d4d038fa612 sha1 1409621265db60cb2f0e988e6112d4d9b4effdf3 )
-)
-
-game (
-	name "Guitar Freaks 3rd Mix (GE949 VER. JAB)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtfrk3ma.zip size 564 crc e2eb336a md5 b5ad24352b25cbbc17e2c4e1b49eadfe sha1 163b64063145c2819a3ea2f81c4e4e8d0bf87e9a )
-)
-
-game (
-	name "Guitar Freaks 3rd Mix - security cassette versionup (949JAZ02)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtfrk3mb.zip size 331 crc f8dc8f12 md5 78ae747af1a5952fe410ac9b3f589d74 sha1 72effcf39affb8430ced17794f71aa2c64a6e3c8 )
-)
-
-game (
 	name "Golden Tee Golf (Joystick, v3.1)"
 	year "1990"
 	developer "Strata/Incredible Technologies"
 	rom ( name gtg.zip size 501879 crc 1c92715b md5 cb2289b7e9e18502e21c842d09aa9c0a sha1 cd0ef8833ba2da101302400a5dcfea6825aca57f )
-)
-
-game (
-	name "Golden Tee Golf II (Trackball, V2.2)"
-	year "1992"
-	developer "Strata/Incredible Technologies"
-	rom ( name gtg2.zip size 522599 crc efd34213 md5 bdbf392ab3e4e974124333e8224cfbd1 sha1 68393ea856bbb7514fb99ad15c1cfa4f9929c47b )
 )
 
 game (
@@ -20661,48 +15158,6 @@ game (
 	year "1989"
 	developer "Strata/Incredible Technologies"
 	rom ( name gtgt.zip size 471125 crc 875bc38a md5 1cdaa8e95d87fbd2f6569b65b48972eb sha1 cce012087d8bc61f16059c1b62f066fdfca102f5 )
-)
-
-game (
-	name "GTI Club (ver EAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticlub.zip size 11884819 crc 82e94abb md5 c9de873522f1b784196f217f4cc77558 sha1 b5de264b566de6d526ced9f38016495e5988b1ca )
-)
-
-game (
-	name "GTI Club 2 (ver JAB)"
-	year "2001"
-	developer "Konami"
-	rom ( name gticlub2.zip size 13262 crc 895eb650 md5 0c0a09058fe28de45f6965f0dbe8164a sha1 f7c917bbe58c3e6d4fc203248dcd204ce9d52eb5 )
-)
-
-game (
-	name "GTI Club 2 (ver EAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gticlub2ea.zip size 7212 crc 7df2e4bf md5 3bdd679ff650b8b7c6df9c7a443e8b17 sha1 43cbccb0d5133b0b92a88559d7611bab6634766a )
-)
-
-game (
-	name "GTI Club (ver AAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticluba.zip size 11885213 crc 8effcf92 md5 f0619d0264015878791fbdf7d2df841c sha1 119c300e3c83ec68e36d8db206c417e360b07005 )
-)
-
-game (
-	name "GTI Club (ver JAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticlubj.zip size 11884793 crc 5918e987 md5 122ae24cadaff4a5add8aad009c168bd sha1 4adf7e1312226d4f7fc999f0709315c981972559 )
-)
-
-game (
-	name "GTI Poker"
-	year "1983"
-	developer "GTI Inc"
-	rom ( name gtipoker.zip size 5323 crc 8361f805 md5 0cb0730f47f0863c7b60dc4ddbf9f29d sha1 e4867da9f9bd3c0c24c9cb3a0bd5732b29fa86f7 )
 )
 
 game (
@@ -20752,76 +15207,6 @@ game (
 	year "1994"
 	developer "Kaneko"
 	rom ( name gtmrusa.zip size 5620070 crc bb6ef223 md5 4f75fc49e0b7887c17f6595c21ed1e55 sha1 7f4e2c9982244abd92a95fe23fdf6a889b4067d6 )
-)
-
-game (
-	name "Guitar Freaks 2nd Mix Ver 1.01 (GQ883 VER. JAD)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrk2m.zip size 285 crc 2382f279 md5 f064c5d8f40fb74fae823217321c2828 sha1 feead139ff366a2eee2161350061435a964f88d2 )
-)
-
-game (
-	name "Guitar Freaks 3rd Mix (GE949 VER. JAC)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtrfrk3m.zip size 564 crc e2eb336a md5 b5ad24352b25cbbc17e2c4e1b49eadfe sha1 163b64063145c2819a3ea2f81c4e4e8d0bf87e9a )
-)
-
-game (
-	name "Guitar Freaks 4th Mix (G*A24 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtrfrk4m.zip size 546 crc d6eb118c md5 d5d1153299e0e34af8a53b91fe174e24 sha1 a828515de37cc7ad6a0db2764e5bf670cb3bc4be )
-)
-
-game (
-	name "Guitar Freaks 5th Mix (G*A26 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk5m.zip size 4635 crc 86334513 md5 6361350d558d783704fc4aefb72f7563 sha1 e6a9c066aabe69e417b261b7a401cafb39f080af )
-)
-
-game (
-	name "Guitar Freaks 6th Mix (G*B06 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk6m.zip size 314 crc 8db94dc1 md5 5e4d6f7c4bfb03c9894762cafcc5a8d8 sha1 8c78ddddba2198e606042b5f9ec542a6ffa40a0c )
-)
-
-game (
-	name "Guitar Freaks 7th Mix (G*B17 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk7m.zip size 4638 crc 670c88a1 md5 4aaceda17981c32061b10bc4fb9cc975 sha1 d4ebbe552f0ccde40225d59caaa4df696b430e10 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. EAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrks.zip size 173 crc 1b5d831a md5 95ab51c7b4f8334131b9e4355d0e94cb sha1 6fec3d5630d123882d2b0d3f03e3929f00b9218f )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. AAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksa.zip size 173 crc c3dec7de md5 5759fbc8c387d69e81f34080c8e6b893 sha1 ded610f9268e82826aa27fd4a51d13856cb57884 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. JAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksj.zip size 173 crc 1963f21a md5 ca8ee2971ed51775510131ca59086b76 sha1 6bd51d572e17e21fb0f1ac44371bb6785dd44506 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. UAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksu.zip size 173 crc 1388324e md5 bbc10181f48d999dc5c75c4bc04d1c6a sha1 b11b9abef61705c5634900ac92f6a225104db553 )
 )
 
 game (
@@ -20993,13 +15378,6 @@ game (
 )
 
 game (
-	name "Guardians of the 'Hood"
-	year "1992"
-	developer "Atari Games"
-	rom ( name guardian.zip size 5584191 crc c9ae8a53 md5 7131f12c328660c2c43bad2d5c9ddf83 sha1 6ade59762108675864fdd632c68c0cdc4a5c32ea )
-)
-
-game (
 	name "The Guiness (Japan)"
 	year "1984"
 	developer "Sun Electronics"
@@ -21070,13 +15448,6 @@ game (
 )
 
 game (
-	name "Gunblade NY (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name gunblade.zip size 16991992 crc 0c048e8f md5 620d12b88c18903f7e6267abbad0bcd7 sha1 eec308bf3a3ec65d9f6e20fb3884af67a7feefb7 )
-)
-
-game (
 	name "Gun Bullet (Japan, GN1)"
 	year "1994"
 	developer "Namco"
@@ -21102,13 +15473,6 @@ game (
 	year "1994"
 	developer "Banpresto"
 	rom ( name gundamex.zip size 7383197 crc 90b902f8 md5 f8caea020e4418377aaa3e44ad9fe7fe sha1 6b9f2a260e4bee7ab0bed33df292ed69f4db1a7f )
-)
-
-game (
-	name "Gundam Battle Operating Simulator (GDX-0013)"
-	year "2005"
-	developer "Sega"
-	rom ( name gundamos.zip size 211 crc 6ff78f9f md5 d4232079e54d68388d13c207107302da sha1 833800f5303e53c7697c9f4446b09f97e4ebe597 )
 )
 
 game (
@@ -21143,20 +15507,6 @@ game (
 	year "1994"
 	developer "Dooyong"
 	rom ( name gundl94.zip size 524628 crc 287219ba md5 40c57ad5419ed1181f63f8a68a907f69 sha1 f47c55101f0c596ba144dd6795e8f0f67e9ce72b )
-)
-
-game (
-	name "Mobile Suit Gundam: Federation VS Zeon (GDL-0001)"
-	year "2001"
-	developer "Capcom"
-	rom ( name gundmgd.zip size 1195 crc 5a6900eb md5 cbe9cfd6d01f258e2e8193a045e4704b sha1 391d8e13f1720ea62a034123ec28dc617a978390 )
-)
-
-game (
-	name "Mobile Suit Gundam: Federation VS Zeon DX  (GDL-0006)"
-	year "2001"
-	developer "Capcom"
-	rom ( name gundmxgd.zip size 1195 crc bf64f74f md5 2301c250d64bf9d2944c5d0fbb49915a sha1 d9e1fd2d46328b7b6d5bb0caa8d40411fc7b0d16 )
 )
 
 game (
@@ -21237,13 +15587,6 @@ game (
 )
 
 game (
-	name "Gunpey"
-	year "2000"
-	developer "Banpresto"
-	rom ( name gunpey.zip size 3918523 crc c6e94c5d md5 84f02fc3c45630a74c35afa899883f08 sha1 838e9266285d8fc13b6fb0894f87677622526379 )
-)
-
-game (
 	name "Gun.Smoke (World)"
 	year "1985"
 	developer "Capcom"
@@ -21272,24 +15615,10 @@ game (
 )
 
 game (
-	name "Gun Survivor 2: Bio Hazard Code Veronica"
-	year "2001"
-	developer "Capcom / Namco"
-	rom ( name gunsur2.zip size 174937327 crc ec4d4704 md5 dff35fd5d30cb899f9065fc5497b3239 sha1 1523d4a00a01de9e1e85f099f2fce2b965301164 )
-)
-
-game (
-	name "Gunmen Wars (GM1 Ver. A)"
-	year "1998"
-	developer "Namco"
-	rom ( name gunwars.zip size 31144980 crc 43038449 md5 354d42af86a3b2a3b0572f3c658a06b7 sha1 ab25228bbb8cea8d68ff4df0148388b2281c8ff9 )
-)
-
-game (
 	name "Gururin"
 	year "1994"
 	developer "Face"
-	rom ( name gururin.zip size 909987 crc 910d164e md5 d92ece41432f5ce7be2be54177cddeb4 sha1 852698f7f4fdeee522ec9bd7f4225d1c9058d9ba )
+	rom ( name gururin.zip size 2256674 crc 9ef13f02 md5 37fdd52a20bfbf92abd1d3153c12fe8f sha1 c6faf95fd45f7f08b24555cb11ff462b7b863cb3 )
 )
 
 game (
@@ -21317,14 +15646,7 @@ game (
 	name "Guts'n (Japan)"
 	year "2000"
 	developer "Kaneko / Kouyousha"
-	rom ( name gutsn.zip size 7382002 crc 703ad57d md5 f613618ac7ed1ac707ddb5bcffa38b65 sha1 3965df8096e6504c887c681638d9758e381256a1 )
-)
-
-game (
-	name "Guwange (Japan, Master Ver. 99/06/24)"
-	year "1999"
-	developer "Cave (Atlus license)"
-	rom ( name guwange.zip size 18761704 crc 5386e849 md5 94f828b8096a2c9bda87b316a5b25161 sha1 92c92ca125f36a16a6cf325c7b6002836db81a31 )
+	rom ( name gutsn.zip size 7414023 crc aea01e5f md5 0ec4904778c674c5f70f0d4ee188b3be sha1 c5f908b075f5a64ffbef11fc149a33e6c62e380f )
 )
 
 game (
@@ -21370,24 +15692,10 @@ game (
 )
 
 game (
-	name "Giga Wing 2 (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Takumi / Capcom"
-	rom ( name gwing2.zip size 51078181 crc d22a987f md5 96d467b05bd7756eae402e475c1f933d sha1 f986cfd1cd29f7ef296bde58228dc599f8c32cf6 )
-)
-
-game (
 	name "Giga Wing (Japan 990223 Phoenix Edition) (bootleg)"
 	year "1999"
 	developer "bootleg"
 	rom ( name gwingjd.zip size 12371558 crc f225a9a0 md5 cf1db40e05a322e9bb33d14e0c02b7d1 sha1 66d10f763fdea383b5be572f0eef237edfe0a3c0 )
-)
-
-game (
-	name "Gypsy Juggler"
-	year "1978"
-	developer "Meadows"
-	rom ( name gypsyjug.zip size 6384 crc ed9c4676 md5 9ab30dc8fca882b68c58c9c7145e30ad sha1 6add65b1b1881829fc565fbf95cea31a5511c654 )
 )
 
 game (
@@ -21416,20 +15724,6 @@ game (
 	year "1983"
 	developer "Konami (Centuri license)"
 	rom ( name gyrussce.zip size 43143 crc 574e5729 md5 3ac6be881f1b3c5b3a51fad97cf20ea9 sha1 7e66fa8cb2f9f479524273a912662cc7fd0bd117 )
-)
-
-game (
-	name "Hacha Mecha Fighter (19th Sep. 1991)"
-	year "1991"
-	developer "NMK"
-	rom ( name hachamf.zip size 1203501 crc 06fc94dd md5 39115c90d008dfba8df4bf5aa89cea5a sha1 fa124731e7fa79920ef554f55399faffc192ea07 )
-)
-
-game (
-	name "Hachoo!"
-	year "1989"
-	developer "Jaleco"
-	rom ( name hachoo.zip size 1219596 crc bdb0452d md5 f32c8eacfef15fcbe492d71f6e4fcea6 sha1 8a8a52d5948d06550f964666f03ac978a91b156c )
 )
 
 game (
@@ -21492,7 +15786,7 @@ game (
 	name "Hanagumi Taisen Columns - Sakura Wars (J 971007 V1.010)"
 	year "1997"
 	developer "Sega"
-	rom ( name hanagumi.zip size 34244422 crc ca502eb1 md5 8eaf3945bab3856d502a909c023db305 sha1 235dd1eaf1829749fd28f327ec14cf9860a49058 )
+	rom ( name hanagumi.zip size 36943643 crc acb90a67 md5 6b56044221750b9fdb554996018a975d sha1 e7d3b873e126881b8dc5248ad8eb2e60be6f5483 )
 )
 
 game (
@@ -21594,38 +15888,10 @@ game (
 )
 
 game (
-	name "Hang Pilot"
-	year "1997"
-	developer "Konami"
-	rom ( name hangplt.zip size 11198743 crc 15f9537f md5 7020c82aa2261c708843a1de3f8888c3 sha1 d38d3440ec927ff0c83e82cb11be53aa2394b0cb )
-)
-
-game (
-	name "Happy 6-in-1 (ver. 101CN)"
-	year "2004"
-	developer "IGS"
-	rom ( name happy6.zip size 19974534 crc c3c678dd md5 a8667989774a6f09b386efa6263a05e7 sha1 ea9f288d602ebc5515a4c9496de374519c4e708e )
-)
-
-game (
-	name "Happy Tour"
-	year "2005"
-	developer "GAV Company"
-	rom ( name hapytour.zip size 13398254 crc e5d3731e md5 db7e716811c9ce592b37fbc10c330429 sha1 be1255505d34feba09c3198c118dc94059516a28 )
-)
-
-game (
 	name "Hard Drivin' (cockpit, rev 7)"
 	year "1988"
 	developer "Atari Games"
 	rom ( name harddriv.zip size 533603 crc de72f8f7 md5 e2c59cd2362484dcdbd9f31f225263f3 sha1 5d358309e320e0cee209cff4cb352a023096b820 )
-)
-
-game (
-	name "Hard Drivin' (cockpit, rev 1)"
-	year "1988"
-	developer "Atari Games"
-	rom ( name harddriv1.zip size 533109 crc 491b9abd md5 7e24c462362be0f3f9b3baa442b3cd4b sha1 12e64194669384175c7351dcb0d61adc5666fb96 )
 )
 
 game (
@@ -21776,17 +16042,10 @@ game (
 )
 
 game (
-	name "Harem"
-	year "1983"
-	developer "I.G.R."
-	rom ( name harem.zip size 29471 crc fc65f2f0 md5 d2ec7c6b7224e1abbf42b8c9013b659d sha1 a3a180b28aec85333215f5430b9eacfb996ca423 )
-)
-
-game (
-	name "Harley-Davidson and L.A. Riders (Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name harley.zip size 64082716 crc 3df05353 md5 1fc399bf6c0ef5787f4e7ade5a615be4 sha1 d48f7f797770894e00a611542f7b831409ca7828 )
+	name "Harem Challenge"
+	year "1995"
+	developer "CD Express"
+	rom ( name haremchl.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
@@ -21818,45 +16077,10 @@ game (
 )
 
 game (
-	name "Hat Trick"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name hattrick.zip size 20957 crc b92050af md5 10e700630a8f6a22206a029f45fbb9a8 sha1 50955d5cbcc66f29e056c0deae185d792144b01d )
-)
-
-game (
-	name "Hayaoshi Quiz Ouza Ketteisen - The King Of Quiz"
-	year "1993"
-	developer "Jaleco"
-	rom ( name hayaosi1.zip size 1243888 crc 230f194d md5 e3a3375678c7d5a21c1bf94efa671e4b sha1 de2b502d2455fa44e7932886e72c126d73ca7cb1 )
-)
-
-game (
-	name "Hayaoshi Quiz Grand Champion Taikai"
-	year "1994"
-	developer "Jaleco"
-	rom ( name hayaosi2.zip size 6534132 crc 0d4d53e2 md5 425d2f1e3ab9d7b1383991b439a6b07a sha1 80ec2a3bd77a2de577eb084b2c7b9d7f78bf2202 )
-)
-
-game (
-	name "Hayaoshi Quiz Nettou Namahousou"
-	year "1994"
-	developer "Jaleco"
-	rom ( name hayaosi3.zip size 8560302 crc 19ad31aa md5 7c76d5a566077e7a850277ddc889da75 sha1 67e82ef2b1ae2017602190abad76278c74c0a742 )
-)
-
-game (
 	name "Heavy Barrel (US)"
 	year "1987"
 	developer "Data East USA"
 	rom ( name hbarrel.zip size 531842 crc 1fcc48e4 md5 7848cbf9edf80c9227fc18f40996fecb sha1 0d1c3ad60099d4b69c84bbce51db62d0afdb0b22 )
-)
-
-game (
-	name "Heavy Barrel (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name hbarrelw.zip size 529376 crc 0f352d48 md5 3eb27f5ed4262e9b577ab0e4c77bc096 sha1 dd43aa9931558059dee7539f67942c75e5c782cd )
 )
 
 game (
@@ -21902,20 +16126,6 @@ game (
 )
 
 game (
-	name "Hard Drivin's Airborne (prototype)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name hdrivair.zip size 4528953 crc 2eba9202 md5 510b6e0ee6c7c466ed8d090a1e82fb9c sha1 1c022e599d2fa1f8e640503e91e08ff88b3ede13 )
-)
-
-game (
-	name "Hard Drivin's Airborne (prototype, early rev)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name hdrivairp.zip size 4987723 crc b4acc556 md5 1b3b8bb61f3b4f1bd310525378a6d53a sha1 814ab03b9172f14d2970fdf42ab680ec50ded138 )
-)
-
-game (
 	name "Head On (2 players)"
 	year "1979"
 	developer "Gremlin"
@@ -21930,24 +16140,10 @@ game (
 )
 
 game (
-	name "Head On 2 (Sidam bootleg)"
-	year "1979"
-	developer "bootleg (Sidam)"
-	rom ( name headon2s.zip size 7754 crc 0dc6e270 md5 dfd509666024e6a9564a131bf7034fcd sha1 7f9c41a608357898cb452b743a9f8ee883d490ac )
-)
-
-game (
 	name "Head On (1 player)"
 	year "1979"
 	developer "Gremlin"
 	rom ( name headonb.zip size 6721 crc 504e4c25 md5 9107b0f6e216aaf50d4afa8de51c8d21 sha1 6144054bbb60345a6cf3e6493e6fb54bdf06c883 )
-)
-
-game (
-	name "Head On (Irem, M-15 Hardware)"
-	year "1979"
-	developer "Irem"
-	rom ( name headoni.zip size 5663 crc 8a256f6b md5 0a38bd1c639c52e1abcdd629285cec36 sha1 3c0c213bcb89085ffa87dfa176d513cc49b75d42 )
 )
 
 game (
@@ -21958,52 +16154,10 @@ game (
 )
 
 game (
-	name "Head On (Sidam bootleg, set 2)"
-	year "1979"
-	developer "bootleg (Sidam)"
-	rom ( name headonsa.zip size 6613 crc 26dc863f md5 c2b395ada65cc7440eba12533123c80a sha1 cc2b74c0c63ea191ac5978216b3bfb042062602f )
-)
-
-game (
 	name "Heart Attack"
 	year "1983"
 	developer "Century Electronics"
 	rom ( name heartatk.zip size 20963 crc ea9817f9 md5 230c575b2756e2f46332811da64d13fb sha1 2119c26d5a9ca01f672de17eb8a54428d477c163 )
-)
-
-game (
-	name "Heated Barrel (World version 3)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrl.zip size 1575050 crc a31b3e34 md5 e3ca30a67525b20b389598bf85d5b9bc sha1 2c983b555abd518c18f90dc29fd30d16eabfec27 )
-)
-
-game (
-	name "Heated Barrel (World version 2)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrl2.zip size 1575211 crc c28e696b md5 2355378b396d4a8c1ead111a94e7a29f sha1 1664e211596a05a218c8ff6c05d22f9d92baf018 )
-)
-
-game (
-	name "Heated Barrel (World old version)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrlo.zip size 1575082 crc 2e005ec8 md5 380df3e9824d4c389c2e04cc8faf2eb1 sha1 b61ed4587f52939325f191e70232057157b82b2c )
-)
-
-game (
-	name "Heated Barrel (US)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrlu.zip size 1575196 crc 59fa3878 md5 e7106543ac770a0099f16446b0fc4706 sha1 b59610add6228ce2e27b48f91cb4cdaed71eb64f )
-)
-
-game (
-	name "Heat of Eleven '98 (ver EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name heatof11.zip size 631318 crc 52866959 md5 af54a4197519d5ae18f45e1fb8df29c3 sha1 df4509dae9197b64adb31ed321d4d71166014a6d )
 )
 
 game (
@@ -22035,27 +16189,6 @@ game (
 )
 
 game (
-	name "Heiankyo Alien"
-	year "1979"
-	developer "Denki Onkyo"
-	rom ( name heiankyo.zip size 12050 crc b0bf9544 md5 2b3158dda2ddf11b7983acea715c745e sha1 6745eec2295ea1df09b3b55d4c368ff70ce7ed67 )
-)
-
-game (
-	name "HeliFire (set 1)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name helifire.zip size 10248 crc 2d71af67 md5 c01159acea8ea1ca9d05ded9b9b97201 sha1 823b64910cb58ea102ba09307ead1511778f1293 )
-)
-
-game (
-	name "HeliFire (set 2)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name helifirea.zip size 10243 crc 83ee32bd md5 11690d6ac050e8bdce928fc8a97d84fa sha1 e5afb318ed4e63c6c60ed9dc4947a441620bb1f0 )
-)
-
-game (
 	name "Hellfire (2P Ver.)"
 	year "1989"
 	developer "Toaplan (Taito license)"
@@ -22084,13 +16217,6 @@ game (
 )
 
 game (
-	name "Hell Night (ver EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name hellngt.zip size 3813571 crc 2235b717 md5 60916d0b936a9d1080b11bfd86dbc49d sha1 6d72b32e638e1399d168e7dbd5e3bf3e039c258e )
-)
-
-game (
 	name "Herbie at the Olympics (DK conversion)"
 	year "1984"
 	developer "Century Electronics / Seatongrove Ltd"
@@ -22102,20 +16228,6 @@ game (
 	year "1984"
 	developer "Century Electronics / Seatongrove Ltd"
 	rom ( name hero.zip size 22127 crc 2e96ed4a md5 2c30819c469e12c5e769349393a8105e sha1 83132bf9cc6dbd4444cecd2fb24b5bec9cf375b4 )
-)
-
-game (
-	name "Hero in the Castle of Doom (DK conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Crown license)"
-	rom ( name herodk.zip size 17614 crc 6e68d207 md5 582c86f07798e749588caaf4dea84893 sha1 fed7672adeadf2f27be9a12f4f10521ca1e0170c )
-)
-
-game (
-	name "Hero in the Castle of Doom (DK conversion not encrypted)"
-	year "1984"
-	developer "Seatongrove Ltd (Crown license)"
-	rom ( name herodku.zip size 17520 crc f3ef3d3f md5 411ccf25ddb5f7ca88950525ac3c2fe1 sha1 39aa20dfa71bc440d3a352a368cdd8c3f826f977 )
 )
 
 game (
@@ -22187,27 +16299,6 @@ game (
 )
 
 game (
-	name "Hidden Catch 2 (pcb ver 3.03)"
-	year "1999"
-	developer "Eolith"
-	rom ( name hidctch2.zip size 20966101 crc c78a4acc md5 b83b91a4969060897cfe4f306f623a9d sha1 44008bdfe33289ee2b0bdf57c65959ffc97997a3 )
-)
-
-game (
-	name "Hidden Catch 3 (ver 1.00 / pcb ver 3.05)"
-	year "2000"
-	developer "Eolith"
-	rom ( name hidctch3.zip size 18524487 crc b04cfd6c md5 f71bf49c0d209239317dc849416bf6b2 sha1 5e8e8c571ded44587ce36968ca99b34411b2d038 )
-)
-
-game (
-	name "Hidden Catch (World) / Tul Lin Gu Lim Chat Ki '98 (Korea) (pcb ver 3.03)"
-	year "1998"
-	developer "Eolith"
-	rom ( name hidnctch.zip size 15354295 crc 30d57a77 md5 373413ab28b6d0101fee9e213fa25324 sha1 9e8a857ea58a6422ed6d8a71ec743f134b0f4c8a )
-)
-
-game (
 	name "Pirate Ship Higemaru"
 	year "1984"
 	developer "Capcom"
@@ -22236,59 +16327,10 @@ game (
 )
 
 game (
-	name "High Impact Football (rev LA5 02/15/91)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact.zip size 1208401 crc a9991165 md5 99f6fa091a27f6e66c7b12c7d9376e32 sha1 51d358d89329cc1b7a92110d89251d2db0c5e995 )
-)
-
-game (
-	name "High Impact Football (rev LA1 12/16/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact1.zip size 1205369 crc dc65d504 md5 cbe9ddf2d105167a3fc21d7178526722 sha1 7a50b526a3cea9cd63858dc6e38edb65e4dff49a )
-)
-
-game (
-	name "High Impact Football (rev LA2 12/26/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact2.zip size 1207607 crc 2cf568b4 md5 47936dd918030f848059fe7acdc69427 sha1 1928d391db7dc87c3a7e8d05371d374ddd7d9d96 )
-)
-
-game (
-	name "High Impact Football (rev LA3 12/27/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact3.zip size 1207591 crc 7937a285 md5 d6026f0d09e55e16e9d4e5ebc45b29f5 sha1 0569f44d2da21420a316bcac7a7c74b1f715e559 )
-)
-
-game (
-	name "High Impact Football (rev LA4 02/04/91)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact4.zip size 1208250 crc 25b92963 md5 86a77a8454a236aa5a9a950e6ca5df27 sha1 32fcfb916241c3a4c1b2170fb6758d9762bb0cf8 )
-)
-
-game (
-	name "High Impact Football (prototype, rev 8.6 12/09/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpactp.zip size 1202383 crc 5eefbf34 md5 71b82f101ff657aa10b1f7f3a57ee8f9 sha1 66316321f44378811f749f88304d935f551f56b7 )
-)
-
-game (
 	name "Himeshikibu (Japan)"
 	year "1989"
 	developer "Hi-Soft"
 	rom ( name himesiki.zip size 150866 crc 61260320 md5 8cb4570572bb39b35007837b400e21be sha1 443acdf7d3f616a2b9f19dd42f9dabd02494fc68 )
-)
-
-game (
-	name "Hi Pai Paradise"
-	year "2003"
-	developer "Aruze / Seta"
-	rom ( name hipai.zip size 28464828 crc cf146002 md5 d24bd0920f837e041f980fdc17826f14 sha1 97960066fc29c73cf7f1219ee5161b1dfb5e6485 )
 )
 
 game (
@@ -22310,12 +16352,6 @@ game (
 	year "1987"
 	developer "Toaplan / Taito Corporation"
 	rom ( name hishouza.zip size 286379 crc e2cb0e7d md5 d22413fcf9378f0e8dc0e17cbe2186ae sha1 4e0ab3f8d016f68f096f555792c85e6860d20c10 )
-)
-
-game (
-	name "The History of Martial Arts"
-	developer "bootleg"
-	rom ( name histryma.zip size 3484991 crc 77b9e338 md5 4663f1915b0d4ce2bde839748d02d2f1 sha1 46d904c626c109bd37be637fc5fa289272f90a12 )
 )
 
 game (
@@ -22351,13 +16387,6 @@ game (
 	year "1987"
 	developer "Exidy"
 	rom ( name hitnmiss2.zip size 228788 crc 560e5dfe md5 b3f74dc338ebc0986e12a88936a8e239 sha1 f25dfe11bbe0fecabaec3d882468991f5d7f1fa7 )
-)
-
-game (
-	name "Hit Poker (Bulgaria)"
-	year "1997"
-	developer "Accept Ltd."
-	rom ( name hitpoker.zip size 449344 crc 569e0046 md5 0e9b4583509d0d7d37e02c51de5ac44c sha1 6541b28ebe7f9421735960d3280d5a898c372919 )
 )
 
 game (
@@ -22445,20 +16474,6 @@ game (
 )
 
 game (
-	name "Heavy Metal Geomatrix (JPN, USA, EUR, ASI, AUS) (Rev A)"
-	year "2001"
-	developer "Capcom"
-	rom ( name hmgeo.zip size 68679919 crc 89b90bb6 md5 8a54005a4e7d2101512dbdaf03ee6766 sha1 82b4ea7e31d483833a0183ffe6e655fe0df1ac9e )
-)
-
-game (
-	name "AV Hanafuda Hana no Ageman (Japan 900716)"
-	year "1990"
-	developer "Nichibutsu / AV Japan"
-	rom ( name hnageman.zip size 299541 crc 25246c63 md5 6d69f993ce4acaf86a684424e2c5c050 sha1 27f0b123aa9244bff68889da78dfc80358490b1d )
-)
-
-game (
 	name "Hana Yayoi (Japan)"
 	year "1987"
 	developer "Dyna Electronics"
@@ -22501,13 +16516,6 @@ game (
 )
 
 game (
-	name "AV Hanafuda Hana no Christmas Eve (Japan 901204)"
-	year "1990"
-	developer "Nichibutsu / AV Japan"
-	rom ( name hnxmasev.zip size 208731 crc dc8545ac md5 5a2c2a4b4df3c6e75d55a113c3745658 sha1 fec1356d701035f977af89559fcf68cca449c6c6 )
-)
-
-game (
 	name "Hoccer (set 1)"
 	year "1983"
 	developer "Eastern Micro Electronics, Inc."
@@ -22540,13 +16548,6 @@ game (
 	year "1992"
 	developer "Sega"
 	rom ( name holo.zip size 5228140 crc 44be9ce3 md5 3664fdfd8d2ec53156ef54d350c1cb35 sha1 9e696362152232dac3f01cd13b7e12ff76485dce )
-)
-
-game (
-	name "Moero Pro Yakyuu Homerun"
-	year "1988"
-	developer "Jaleco"
-	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
 )
 
 game (
@@ -22662,34 +16663,6 @@ game (
 )
 
 game (
-	name "House of the Dead"
-	year "1997"
-	developer "Sega"
-	rom ( name hotd.zip size 29675840 crc 8c7b36b5 md5 374ab35f5d8add16c5edbe3b8ee88a40 sha1 de42682e8595c1f7dfe8a27ec7717af8fe2ea6f5 )
-)
-
-game (
-	name "House of the Dead 2"
-	year "1999"
-	developer "Sega"
-	rom ( name hotd2.zip size 103548842 crc 1775a44c md5 e02b03e0ea3ef010b1197bfbc8e2ea35 sha1 3556e83a81eb99786fb07e3d037f4d882ecf5e34 )
-)
-
-game (
-	name "House of the Dead 2 (original)"
-	year "1999"
-	developer "Sega"
-	rom ( name hotd2o.zip size 103548834 crc 0153c151 md5 ed9a8b175a007769387a85b29eedec61 sha1 71462c3010b3fad80fc9f0432ddcd01f03b5de2d )
-)
-
-game (
-	name "The House of the Dead III (GDX-0001)"
-	year "2002"
-	developer "Sega"
-	rom ( name hotd3.zip size 219 crc 2ae7bc01 md5 61254fe2154d4f8d2f45f5f4edf84f69 sha1 6e88cfff387b082dbf809179a24fbd71e1d3d87b )
-)
-
-game (
 	name "Quiz de Idol! Hot Debut (Japan)"
 	year "2000"
 	developer "Psikyo / Moss"
@@ -22736,13 +16709,6 @@ game (
 	year "1994"
 	developer "Tuning/Incredible Technologies"
 	rom ( name hotmemry.zip size 4912446 crc 0740b645 md5 31c9e01c7e0d40cff6afd48b1a6d282d sha1 99736b3634e3d340a79eee3dd4887da175c24707 )
-)
-
-game (
-	name "Hot Mind"
-	year "1995"
-	developer "Playmark"
-	rom ( name hotmind.zip size 314659 crc 60b80717 md5 3000ad3a8e0ff882d0c8b44c79b419e0 sha1 9cd57503d2becf384395106a50408d937178cebb )
 )
 
 game (
@@ -22795,13 +16761,6 @@ game (
 )
 
 game (
-	name "Hot Slot (ver. 05.01)"
-	year "1996"
-	developer "ABM Electronics"
-	rom ( name hotslot.zip size 524881 crc 5452e8e4 md5 2731cdfd10946cc607f34ef2832ff228 sha1 27b3b0d88d018af6c1b88b4ec0860aabf67c8c18 )
-)
-
-game (
 	name "Vs. Hot Smash"
 	year "1987"
 	developer "Taito"
@@ -22851,20 +16810,6 @@ game (
 )
 
 game (
-	name "Hard Times (set 1)"
-	year "1994"
-	developer "Playmark"
-	rom ( name hrdtimes.zip size 1587677 crc 9da5b12b md5 986b08c66fd4b7412298e9a46475264d sha1 95c7a0b63cab9285ae63813eba0ba0af60d2d60b )
-)
-
-game (
-	name "Hard Times (set 2)"
-	year "1994"
-	developer "Playmark"
-	rom ( name hrdtimesa.zip size 1537165 crc 44c40ed2 md5 c326e18f50d6b39be90ba73f004fde35 sha1 8c5a18df77cd3762116f08ff5321a5cfa4a92112 )
-)
-
-game (
 	name "Hyper Street Fighter 2: The Anniversary Edition (USA 040202)"
 	year "2004"
 	developer "Capcom"
@@ -22893,13 +16838,6 @@ game (
 )
 
 game (
-	name "High Seas Havoc"
-	year "1993"
-	developer "Data East"
-	rom ( name hshavoc.zip size 695950 crc 4b2a9b45 md5 24d00d885f8e08844f0bf8b343a9e540 sha1 81668b3e57fd069f80f5204c91c876f947f6a721 )
-)
-
-game (
 	name "Hot Shots Tennis (V1.1)"
 	year "1990"
 	developer "Strata/Incredible Technologies"
@@ -22911,13 +16849,6 @@ game (
 	year "1990"
 	developer "Strata/Incredible Technologies"
 	rom ( name hstennis10.zip size 455215 crc 2beeb047 md5 e0fd3d943199b4de50b06d95e5888c43 sha1 c5b891b7e30a501c983687de7dcbac5154e4442b )
-)
-
-game (
-	name "Hatch Catch"
-	year "1995"
-	developer "SemiCom"
-	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
 )
 
 game (
@@ -22977,13 +16908,6 @@ game (
 )
 
 game (
-	name "Hunchback (DK conversion)"
-	year "1983"
-	developer "Century Electronics"
-	rom ( name hunchbkd.zip size 16765 crc 162ce01c md5 5e42739d04f9505930c05d66e6b285db sha1 fa030754526a8240f0319fcf3c7a245aa3026d7e )
-)
-
-game (
 	name "Hunchback (Galaxian hardware)"
 	year "1983"
 	developer "Century Electronics"
@@ -23019,24 +16943,10 @@ game (
 )
 
 game (
-	name "Video Hustler (bootleg)"
-	year "1981"
-	developer "bootleg (Digimatic)"
-	rom ( name hustlerb.zip size 11697 crc 10651f90 md5 6d406b18eca93a8d23434edac3e8af3f sha1 455d9da91f629971a7297b26d34b15f59e5ab7ad )
-)
-
-game (
-	name "Fatsy Gambler (Video Hustler bootleg)"
-	year "1981"
-	developer "bootleg"
-	rom ( name hustlerb2.zip size 11613 crc 8e62ec29 md5 848c344b97079102e362cd64508dd1f0 sha1 a6e63b8251f6d3cd0be861650114ede0f5af3c29 )
-)
-
-game (
 	name "Heaven's Gate"
 	year "1996"
 	developer "Atlus / Racdym"
-	rom ( name hvnsgate.zip size 14323161 crc 174934f4 md5 75a5e0805a9a77b734c89dc8dc956276 sha1 3db7f9db07d5cf14ccddaa81cf98d9bdf7b9a399 )
+	rom ( name hvnsgate.zip size 14449210 crc ad5c1d4d md5 65e3ea53bd40fa904890952f925f0375 sha1 e580cdf3233c8493112385599a209ea24948f608 )
 )
 
 game (
@@ -23075,27 +16985,6 @@ game (
 )
 
 game (
-	name "Heavy Unit (World)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunit.zip size 625740 crc 2dd0d798 md5 e8ee5ef49f3cdbb3b4deccf9d7085e2b sha1 1d9665c3cbf1e1f82808fb4a54d475c9c7e2cbca )
-)
-
-game (
-	name "Heavy Unit (Japan, Newer)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunitj.zip size 600267 crc 02f490c8 md5 2b39ea647e161c3afb2ae8f0cefedc36 sha1 d759d0275ead160610b0ab8cee0582b5c36dca11 )
-)
-
-game (
-	name "Heavy Unit (Japan, Older)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunito.zip size 600258 crc d4e42620 md5 63468e7399d7ecf59d77666cbf97bbcc sha1 13d391be59882ada43218c25917ec0e2d556a24c )
-)
-
-game (
 	name "Heavyweight Champ"
 	year "1987"
 	developer "Sega"
@@ -23124,20 +17013,6 @@ game (
 )
 
 game (
-	name "Hydra (prototype 5/14/90)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name hydrap.zip size 1365027 crc c7db21ec md5 7f511162b5fbe9055f654bbc12dcebe5 sha1 46c70e0007a9c0509aa6fd56ce7a0e7d4e2894e2 )
-)
-
-game (
-	name "Hydra (prototype 5/25/90)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name hydrap2.zip size 573542 crc e3c7f1fd md5 ee4ebe5be34acbd4b60e961d0ced4175 sha1 86f03be3670341ac3dd521f22c78b44aeaf83741 )
-)
-
-game (
 	name "Taisen Quiz HYHOO (Japan)"
 	year "1987"
 	developer "Nichibutsu"
@@ -23162,21 +17037,7 @@ game (
 	name "Hyper Athlete (GV021 Japan 1.00)"
 	year "1996"
 	developer "Konami"
-	rom ( name hyperath.zip size 190 crc 29b5124c md5 217bff4ed69178ea634072345361c13a sha1 c5a002d323d21a9c6a2ab46fec2f8b254cc2c10d )
-)
-
-game (
-	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name hyperbbc.zip size 168 crc 9af2c9a4 md5 7c2030be99b2a53d0e4334d320b19926 sha1 4e941cbfcb3fad16d9a006cbb4fbce7133b832f7 )
-)
-
-game (
-	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. KAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name hyperbbck.zip size 168 crc 44ab53e6 md5 7ca726391d1242be190c4ac784422806 sha1 b3537626db78c0dbd4f15a44635f4489685bff8b )
+	rom ( name hyperath.zip size 81559 crc 1025b6b0 md5 a06e9f26ea1efd5638d8f8398fb2f7ed sha1 289249dc9eeee06a8e49d27a451d43e6a6ed25d4 )
 )
 
 game (
@@ -23205,13 +17066,6 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name hypersptb.zip size 112597 crc 47aca4bd md5 914d100430b541960dcb0ad7670453a8 sha1 adc4df9d7b437e6b08404b52e0943672bd0655bc )
-)
-
-game (
-	name "Hyperdrive"
-	year "1998"
-	developer "Midway Games"
-	rom ( name hyprdriv.zip size 127652 crc e32be5da md5 900a5ff2033de5812b55b1d88beb1e43 sha1 00211969d1c32f804087fee2c73505a79bdd347d )
 )
 
 game (
@@ -23247,13 +17101,6 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name hyprolym.zip size 64630 crc 79dd1a60 md5 92da29c22fd417a827fae03adf884e16 sha1 4988c9a3ccac236872c19a95e52f94220d664176 )
-)
-
-game (
-	name "Hyper Olympic (bootleg)"
-	year "1983"
-	developer "bootleg"
-	rom ( name hyprolymb.zip size 82546 crc 72a66bb9 md5 408b03b4bd6d3819f6a890ad6bcfd33f sha1 3a46638d3e167c4466962e997e8e9ca973778842 )
 )
 
 game (
@@ -23355,30 +17202,9 @@ game (
 )
 
 game (
-	name "Iga Ninjyutsuden (Japan)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name iganinju.zip size 901868 crc 4a843085 md5 a50daa13dc6a2137e1326e8c3ecb08c1 sha1 350961defd2dd8584d3c54093801484b807205e8 )
-)
-
-game (
-	name "IGMO"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name igmo.zip size 20946 crc 9ff45478 md5 bac686b9e8c052852dc6fd2b06a14a51 sha1 55406a6c97dd5aa00b8171ae45c5cd243bbb2909 )
-)
-
-game (
 	name "New Champion Skill (v100n)"
 	developer "IGS"
 	rom ( name igs_ncs.zip size 141502 crc 0bf9f74a md5 5254868750ec1ce2d4c2a810980f2119 sha1 b38d03a29dacbe1651d5dfbca3361cfc2c40577f )
-)
-
-game (
-	name "New Champion Skill (v100n 2000)"
-	year "2000"
-	developer "IGS"
-	rom ( name igs_ncs2.zip size 179683 crc c2686e23 md5 ce1b79789a8b6f9b2159d09123692cf6 sha1 48599236076927d5e195a6b8b21cf665b8cee436 )
 )
 
 game (
@@ -23431,23 +17257,10 @@ game (
 )
 
 game (
-	name "Ikaruga (GDL-0010)"
-	year "2001"
-	developer "Treasure"
-	rom ( name ikaruga.zip size 1196 crc c5ecb9fa md5 d103a037dd2d7a93e4bda3c6b449f7a6 sha1 da043d21ca19ebb8daccb4ac764d0c710106ca76 )
-)
-
-game (
 	name "Ikki (Japan)"
 	year "1985"
 	developer "Sun Electronics"
 	rom ( name ikki.zip size 75792 crc 86dc9eff md5 70cefaeddbc9732c6acae6c07465b37f sha1 3fd8d8cecca4d3c8648e019b0f64075035f25554 )
-)
-
-game (
-	name "Il Pagliaccio (Italy, Version 2.7C)"
-	developer "&lt;unknown&gt;"
-	rom ( name ilpag.zip size 746098 crc a978f61c md5 5a5a7d4cde7fb6af29112c41f054869b sha1 14afbcf60777a98d24e93d87d3dc4a3e699fd4f6 )
 )
 
 game (
@@ -23469,27 +17282,6 @@ game (
 	year "1994"
 	developer "Sphinx/AV Japan"
 	rom ( name imekura.zip size 2781537 crc afef8ac4 md5 b68b388c83eee9298613f06aca4b95ef sha1 e47363be71064f3f861846bec4202e7ea73bb16c )
-)
-
-game (
-	name "Image Fight (Japan, revision A)"
-	year "1988"
-	developer "Irem"
-	rom ( name imgfight.zip size 634384 crc 5221a34e md5 0ea61f9af90a04b7e514a638e6aa884f sha1 8c5638687464af92d65ac1e35b8ddcea8a04cda0 )
-)
-
-game (
-	name "Image Fight (Japan)"
-	year "1988"
-	developer "Irem"
-	rom ( name imgfighto.zip size 634558 crc dad530c6 md5 e3e67cb0277e6dfb75fcfe93d002a05d sha1 587e9a0c52aa45defc501119ccb8f3c739262ba5 )
-)
-
-game (
-	name "Imola Grand Prix"
-	year "1981"
-	developer "Alberici"
-	rom ( name imolagp.zip size 12959 crc 58983e15 md5 06dfd3f717c9f804527972c5beb02826 sha1 1f67965b4540a68dcfe525207ff66ed0183e9c0e )
 )
 
 game (
@@ -23520,34 +17312,6 @@ game (
 )
 
 game (
-	name "Indian Dreaming (B - 15/12/98, Local)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name indiandr.zip size 975008 crc 4b1fc83f md5 acf3af78f3ab338daa031c3e62bf6271 sha1 cfa7c3e5039acd50fe6034733032e81101188987 )
-)
-
-game (
-	name "INDY 500 Twin (Revision A, Newer)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500.zip size 15023750 crc 32a2c79e md5 e92a9d2a496e733c37694bcf4cd29c6a sha1 9fe6179d286fb0aac7362f8ae860285ded6be64f )
-)
-
-game (
-	name "INDY 500 Deluxe (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500d.zip size 14566080 crc 4de8c8bf md5 9b4da30ed681248b122862c04d1110ee sha1 75d075c25cb7d83ce1a3a6cad2f9cb80814fec0b )
-)
-
-game (
-	name "INDY 500 Twin (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500to.zip size 14718097 crc 0f2cf727 md5 b9e1a4ac66f146ba9c1b016947fffd0a sha1 65805ec0be2bcb6d572792f7c1cf7e766a5b8e36 )
-)
-
-game (
 	name "Danny Sullivan's Indy Heat"
 	year "1991"
 	developer "Leland Corp."
@@ -23555,45 +17319,10 @@ game (
 )
 
 game (
-	name "Indiana Jones and the Temple of Doom (set 1)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp.zip size 340077 crc 4773adb4 md5 60d666ebd8611b56f7c66cfb64997dee sha1 51b823872cd04947ec40ff3288d2caba73c3847c )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 2)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp2.zip size 340077 crc 94a1867b md5 abf7c8a82cc426b4c79f4ad11fa1ab05 sha1 8fe655919b95d60f6281eca26fb7a1c95e9d0587 )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 3)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp3.zip size 340250 crc 80c5864b md5 c1e70a719e28312987d15a4065083fcf sha1 ed6210d46373e1a3567fcbd6957f2ec1ede796d2 )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 4)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp4.zip size 340464 crc cb1e35a9 md5 3c250189222938d9f207525d79266882 sha1 e3469065854392fd5ccc5aee181e888f7293c7a5 )
-)
-
-game (
 	name "Indiana Jones and the Temple of Doom (Cocktail)"
 	year "1985"
 	developer "Atari Games"
-	rom ( name indytempc.zip size 357303 crc 562957e1 md5 b66bc35fda975b39e74d1e9d301bfb76 sha1 890155e830ffeef38dfcfc2033cb6ac471bd26b9 )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (German)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytempd.zip size 340151 crc 5fe76735 md5 c8521673d989fdac3680913d68c3bf6c sha1 3386fc61b9e3431eed6d0fcc34590e98a209a518 )
+	rom ( name indytempc.zip size 364487 crc 400bbfab md5 db43194f7475fa8b1d4ee40095712e42 sha1 d5982a952fd8f33609328cbf46d58bebd446c25b )
 )
 
 game (
@@ -23601,27 +17330,6 @@ game (
 	year "1984"
 	developer "Williams"
 	rom ( name inferno.zip size 67017 crc c0f2c5d7 md5 7ef49fb379e325682336c7f7ee3e0e1f sha1 9d085407074c5f4e6666f60e045c8f92a9a8e4f5 )
-)
-
-game (
-	name "Initial D Arcade Stage (Rev B) (Japan) (GDS-0020B)"
-	year "2002"
-	developer "Sega"
-	rom ( name initd.zip size 1194 crc 0fe16fc1 md5 1ef9168793a4d40e099a6a7c7dfd8c75 sha1 007ae65f56190a628170f3f1e91f395739769ccf )
-)
-
-game (
-	name "Initial D Arcade Stage (Export) (GDS-0025)"
-	year "2002"
-	developer "Sega"
-	rom ( name initdexp.zip size 1196 crc 8cc85cb3 md5 f8c823eb138396968b2336f8e2468fa7 sha1 9f49e117540d1f99c1c4cb75fa7894708dc677c5 )
-)
-
-game (
-	name "Inquizitor"
-	year "1989"
-	developer "BFM"
-	rom ( name inquiztr.zip size 64897 crc 16b9a3dc md5 822f6a8a5c220ddb0e982d3bdf210843 sha1 7a4b1dc8f7166850c6acb24cfc47f701047158b5 )
 )
 
 game (
@@ -23667,13 +17375,6 @@ game (
 )
 
 game (
-	name "International Team Laser (prototype)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name intlaser.zip size 396644 crc c1b96ff3 md5 73a68870efe55f5cfbf769ec1c06b092 sha1 c385f6e5bc32b3e6c02195b024a537a292a2670e )
-)
-
-game (
 	name "Intrepid (set 1)"
 	year "1983"
 	developer "Nova Games Ltd."
@@ -23691,13 +17392,7 @@ game (
 	name "Karaoke Quiz Intro Don Don! (J 960213 V1.000)"
 	year "1996"
 	developer "Sunsoft / Success"
-	rom ( name introdon.zip size 19733751 crc d6c3f651 md5 47feabc842363c6a25b55ee4a7857d8d sha1 e484dcbc4236c9a3d94fcc3a46cc3403021bc10d )
-)
-
-game (
-	name "Intersecti"
-	developer "&lt;unknown&gt;"
-	rom ( name intrscti.zip size 9672 crc 0b6b8711 md5 2d24f3d4ee8f3494f721ab7698539f8a sha1 8185af5fb7d94e8027903f818e532cce93413546 )
+	rom ( name introdon.zip size 22432972 crc b502c54f md5 203849d4ff0fe95216b05d32ce6a36a7 sha1 8569b000dc8683fe2dbae695d7ed30d2d0e2d535 )
 )
 
 game (
@@ -23705,20 +17400,6 @@ game (
 	year "1980"
 	developer "Taito (GamePlan license?)"
 	rom ( name intruder.zip size 5763 crc 6cffecab md5 76a3441d0a74dd6fffa116b10f336ca1 sha1 2eecd40beff34d860ddd10a093a5983684395a55 )
-)
-
-game (
-	name "International Toote (Germany)"
-	year "1998"
-	developer "Coinmaster"
-	rom ( name inttoote.zip size 1614067 crc de0ef912 md5 d2eac6d93474c0358e6037351c4f124f sha1 2eee4afa08bb0dbd6b215393e63bf89e7ac82abc )
-)
-
-game (
-	name "International Toote II (World?)"
-	year "1993"
-	developer "Coinmaster"
-	rom ( name inttootea.zip size 1629695 crc d6f9ed3e md5 82829f58dda719aeb80786fa4ccdd5af sha1 4100b83540a531bfb66813d7e57dc6a3a25df651 )
 )
 
 game (
@@ -23796,18 +17477,6 @@ game (
 )
 
 game (
-	name "Invasion (bootleg, set 3, R Z SRL Bologna)"
-	developer "bootleg (R Z SRL Bologna)"
-	rom ( name invasionrz.zip size 5603 crc 7b72f5f6 md5 c80db8fa964b5008c57867998bb427c5 sha1 027a128fc38b326ecdfe20e19124749734cb1bf1 )
-)
-
-game (
-	name "Invasion (bootleg, set 4, R Z SRL Bologna)"
-	developer "bootleg (R Z SRL Bologna)"
-	rom ( name invasionrza.zip size 6607 crc 04937ecc md5 c949c6aa4653ad280c450b9dc609f81a sha1 306164eb0ba0d9d8c35653b5caba6097e79af827 )
-)
-
-game (
 	name "Invasion - The Abductors (version 5.0)"
 	year "1999"
 	developer "Midway"
@@ -23862,13 +17531,6 @@ game (
 )
 
 game (
-	name "IPM Invader (Incomplete Dump)"
-	year "1979"
-	developer "IPM"
-	rom ( name ipminvad1.zip size 6532 crc 318f0416 md5 4da8a7a807684626b3fdaa85be8ffc41 sha1 1c4ee4fdb1f4057c4e48364350e990eaa21ac29b )
-)
-
-game (
 	name "Ippatsu Gyakuten [BET] (Japan)"
 	year "1986"
 	developer "Public Software / Paradais"
@@ -23880,27 +17542,6 @@ game (
 	year "1993"
 	developer "IGS"
 	rom ( name iqblock.zip size 193785 crc 182b1d90 md5 59a1172a482c984f20c2dd4fd5964d9e sha1 ef1e0baf2e12e0abff435e3a47eaf7f2a2f58511 )
-)
-
-game (
-	name "Shu Zi Le Yuan (V127M)"
-	year "1996"
-	developer "IGS"
-	rom ( name iqblocka.zip size 604615 crc 1f42f01f md5 9b7a585db42c7a0da63f89613085791d sha1 c724de3ef5304e47a146864963ffe84bc5df3b57 )
-)
-
-game (
-	name "Shu Zi Le Yuan (V113FR)"
-	year "1996"
-	developer "IGS"
-	rom ( name iqblockf.zip size 607343 crc 574b59bc md5 bc614f1cd7678ca406b51c6481607a63 sha1 9ade9fa4959fa723dc964f32fc7e2ee0674c5697 )
-)
-
-game (
-	name "IQ Pipe"
-	year "1991"
-	developer "AMT"
-	rom ( name iqpipe.zip size 83167 crc 05c3dfa7 md5 ae613a0a37a89f6f0548262ebad8ee1f sha1 85b666771466c14674235e3361e7436ded16ba3a )
 )
 
 game (
@@ -23918,20 +17559,6 @@ game (
 )
 
 game (
-	name "Iron Fortress"
-	year "1998"
-	developer "Eolith"
-	rom ( name ironfort.zip size 5044779 crc 4300d5ed md5 c01da7027fd431c7188897604b4ab529 sha1 237341f4e3f02d83b5db3a3ce7bc42b7e2d29d94 )
-)
-
-game (
-	name "Iron Fortress (Japan)"
-	year "1998"
-	developer "Eolith"
-	rom ( name ironfortj.zip size 5043965 crc 03349ae9 md5 a68b0b608871a58fa9d8624e6dfd6177 sha1 6c999c741f0bbbd4242904d054f19dcfd8834b53 )
-)
-
-game (
 	name "Iron Horse"
 	year "1986"
 	developer "Konami"
@@ -23942,7 +17569,7 @@ game (
 	name "The Irritating Maze / Ultra Denryu Iraira Bou"
 	year "1997"
 	developer "SNK / Saurus"
-	rom ( name irrmaze.zip size 4675628 crc def8abe0 md5 294a76f1de9832ce8fbf8df927107220 sha1 78f3a10f54cf297d761c3160b8555dfaa8e29a39 )
+	rom ( name irrmaze.zip size 4715728 crc f9b70a2d md5 714c73d89b725706ffa220c074438999 sha1 31842c99f1e1b44f4565ae7d4b4346fe862bb33e )
 )
 
 game (
@@ -23971,13 +17598,6 @@ game (
 	year "2005"
 	developer "Igrosoft"
 	rom ( name islanda.zip size 1999484 crc d5d6ab21 md5 bcdc667e568b238d3b3d50bdf1cd6118 sha1 551bb9fbe65d0545ebbd8e0c7d7a75acc9acc55d )
-)
-
-game (
-	name "Interstellar Laser Fantasy"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name istellar.zip size 44529 crc 4dd8b83a md5 ed66bc09ae179a3b2c4c3b833b6d9e20 sha1 7c97572c59e6a7b79fac98e44c00ce58cc532c77 )
 )
 
 game (
@@ -24023,27 +17643,6 @@ game (
 )
 
 game (
-	name "Happy Jackie (v110U)"
-	year "1993"
-	developer "IGS"
-	rom ( name jackie.zip size 191320 crc 97aebc98 md5 508af67ba9db4c01d5a01962a2b840e4 sha1 8d9c6e18bb2f9e874bf6bbe34653f93e10936e7f )
-)
-
-game (
-	name "Jackpot Cards / Jackpot Pool (Italy)"
-	year "1997"
-	developer "Electronic Projects"
-	rom ( name jackpool.zip size 430649 crc 88cfe3d5 md5 c58a2a87c466e38fbb21fe081095eda6 sha1 8f3daec403df059c2ccebaf45504d13fd1982006 )
-)
-
-game (
-	name "Jack Rabbit (set 1)"
-	year "1984"
-	developer "Zaccaria"
-	rom ( name jackrabt.zip size 55883 crc a7722c9d md5 3d93af2407203345dc5b47729d5c584f sha1 7b9015e1e6dea4278515d99db4a356fb95e445af )
-)
-
-game (
 	name "Jack Rabbit (set 2)"
 	year "1984"
 	developer "Zaccaria"
@@ -24065,24 +17664,10 @@ game (
 )
 
 game (
-	name "Jail Break (bootleg)"
-	year "1986"
-	developer "bootleg"
-	rom ( name jailbrekb.zip size 68418 crc 9555ac39 md5 68d138f265c40def938883ca1bc33b29 sha1 ba5c71cb6db714a871cb08f93fde7a4925987257 )
-)
-
-game (
 	name "Vs. Ninja Jajamaru Kun (Japan)"
 	year "1985"
 	developer "Jaleco"
 	rom ( name jajamaru.zip size 23888 crc 42482066 md5 4cc9e580ecf4af5f82c5b8778ada83dc sha1 89809aac3f2fe009a16e619ca506e992eef8dbe1 )
-)
-
-game (
-	name "Jambo! Safari (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "1999"
-	developer "Sega"
-	rom ( name jambo.zip size 23866373 crc 64df7281 md5 bbb13f268659ac336aad57ce0681fc5f sha1 b00f7d27927fd5d8b5e337cbab4a9f56f2549ad1 )
 )
 
 game (
@@ -24114,20 +17699,6 @@ game (
 )
 
 game (
-	name "Jan Oh (set 1)"
-	year "1984"
-	developer "Toaplan"
-	rom ( name janoh.zip size 16977 crc 0d350ed1 md5 4f1544b09980ee35cc243494569c9165 sha1 5ee44807da349f549dee689a831841c89cb615a9 )
-)
-
-game (
-	name "Jan Oh (set 2)"
-	year "1984"
-	developer "Toaplan"
-	rom ( name janoha.zip size 22954 crc 7df9f4b3 md5 d93e8f450c91f88506bc48066c3c94b2 sha1 0060404ad7bcd8bbc5dfae1681e4abb47843bbea )
-)
-
-game (
 	name "Janputer '96 (Japan)"
 	year "1996"
 	developer "Dynax"
@@ -24135,31 +17706,10 @@ game (
 )
 
 game (
-	name "New Double Bet Mahjong (Japan)"
-	year "1981"
-	developer "Public Software Ltd. / Mes"
-	rom ( name janputer.zip size 20202 crc 6184f21e md5 f0500e278b58ab376300a04ca921558f sha1 eec4d7369d76446be5b1a992e02a684806e5dad8 )
-)
-
-game (
-	name "Janshi"
-	year "1992"
-	developer "Eagle"
-	rom ( name janshi.zip size 513892 crc 6a97517e md5 7a57600a11c047936e7874ec7058c65e sha1 485866aa7b58aee377f0abaf562b29487a69e0f0 )
-)
-
-game (
 	name "Jyanshin Densetsu - Quest of Jongmaster"
 	year "1994"
 	developer "Aicom"
-	rom ( name janshin.zip size 3498756 crc 4f800bc5 md5 8862a2b515764deb1a5526160aac3de4 sha1 8f58c1915fc90540322885a6ea377dbc33ce97f2 )
-)
-
-game (
-	name "Jansou (set 1)"
-	year "1985"
-	developer "Dyna"
-	rom ( name jansou.zip size 64553 crc 0b0c63ff md5 70f9006799b672bdeafcc9ca98111a68 sha1 c04c67b9e98a8474eda63a1d472794853357c77a )
+	rom ( name janshin.zip size 4845443 crc 8e18c973 md5 d30041792af34e1889efcccf37cedc30 sha1 f6b1bc311060d150b9705a7e102468830ef8bc86 )
 )
 
 game (
@@ -24205,18 +17755,6 @@ game (
 )
 
 game (
-	name "Jockey Club II (newer hardware)"
-	developer "Seta"
-	rom ( name jclub2.zip size 4758679 crc 1fc45d42 md5 856f8101e35c790d1ba5101cecf3d25e sha1 0e7f4e4b438fcd4324c0658f62dbc740c1fea064 )
-)
-
-game (
-	name "Jockey Club II (older hardware)"
-	developer "Seta"
-	rom ( name jclub2o.zip size 3489624 crc 22687a78 md5 fb8f6819a7ff8f6a02edf930fc42e24e sha1 e087eace571239043b2600f18ca72f6abea4c920 )
-)
-
-game (
 	name "Jumping Cross"
 	year "1984"
 	developer "SNK"
@@ -24227,14 +17765,14 @@ game (
 	name "Judge Dredd (Rev C Dec. 17 1997)"
 	year "1996"
 	developer "Acclaim"
-	rom ( name jdredd.zip size 45782 crc 701d8360 md5 e02af2637a9f1e427dc72cbb817f6c54 sha1 5ad2466b3bb1ff5c9056ef5d4c78e1b25ed1722a )
+	rom ( name jdredd.zip size 171905 crc e0ec02a9 md5 7d7360c05a92d5e93949c0bfdea4fbf2 sha1 3d67155a91f4938b289b7bfd86eb1974665cfcb7 )
 )
 
 game (
 	name "Judge Dredd (Rev B Nov. 26 1997)"
 	year "1996"
 	developer "Acclaim"
-	rom ( name jdreddb.zip size 45782 crc 701d8360 md5 e02af2637a9f1e427dc72cbb817f6c54 sha1 5ad2466b3bb1ff5c9056ef5d4c78e1b25ed1722a )
+	rom ( name jdreddb.zip size 171905 crc e0ec02a9 md5 7d7360c05a92d5e93949c0bfdea4fbf2 sha1 3d67155a91f4938b289b7bfd86eb1974665cfcb7 )
 )
 
 game (
@@ -24255,7 +17793,7 @@ game (
 	name "Justice Gakuen (Japan 971117)"
 	year "1997"
 	developer "Capcom"
-	rom ( name jgakuen.zip size 28131592 crc d1ab20d0 md5 d496522c6bef012ebb1f8a27ff54d270 sha1 43ecb9fbad561ad7edc137c2cecbfd942c4ad602 )
+	rom ( name jgakuen.zip size 28269397 crc 385c700f md5 9156a7bc19fffd76a75327a568c6a50c sha1 723ce531ec279f710fbf033fb1593dd026e0a9ee )
 )
 
 game (
@@ -24270,26 +17808,6 @@ game (
 	year "1982"
 	developer "Falcon"
 	rom ( name jin.zip size 14013 crc d07fef6c md5 07eafbf03f9c38e60915170b784c8330 sha1 a7c846b4cfb2671be83b7f9a77fd0f6cc1b7fc3e )
-)
-
-game (
-	name "Jingle Bell (Italy, V133I)"
-	developer "IGS"
-	rom ( name jingbell.zip size 425074 crc 7e1c69ce md5 099cd81413b9ce01b5318bbfce6dd82f sha1 0366dd3dfaa06ce7015cd90d79a313641a4178dd )
-)
-
-game (
-	name "Jingi Storm - The Arcade (GDL-0037)"
-	year "2005"
-	developer "Atrativa Japan"
-	rom ( name jingystm.zip size 1196 crc 0b848fc8 md5 091a337475e10b6a693f64a44774713a sha1 a2b06bcf1224f03a0a5de74fe58ed98e5a0e2a7d )
-)
-
-game (
-	name "Jitsuryoku!! Pro Yakyuu (Japan)"
-	year "1989"
-	developer "Jaleco"
-	rom ( name jitsupro.zip size 1504321 crc e47b1e79 md5 1967b9acd0916487e4f7219cca8ebbf9 sha1 bccb1946075f09334565c5724efcb5129e875a53 )
 )
 
 game (
@@ -24310,14 +17828,14 @@ game (
 	name "Jan Jan Paradise 2"
 	year "1997"
 	developer "Electro Design"
-	rom ( name jjparad2.zip size 16117709 crc 3eb6c391 md5 7c2fcd04cad810ce4657995bcebbfc72 sha1 3967799cb2e34317dc132a65f9d64c1ee4b09b8a )
+	rom ( name jjparad2.zip size 16149730 crc 4954ef43 md5 8a84ef6198f4d78360fdff2eb02e3e73 sha1 283e591590cb730680c3699892db342426e0bb37 )
 )
 
 game (
 	name "Jan Jan Paradise"
 	year "1996"
 	developer "Electro Design"
-	rom ( name jjparads.zip size 10706584 crc 83dd09b4 md5 420b3e4828ee7230ad823274f5196600 sha1 e00a66ff1813085dfcd1f25a3092fa198c6cf0fe )
+	rom ( name jjparads.zip size 10738605 crc 70fb2d08 md5 36b9ec0f23878d83503755fec8d74f95 sha1 89daf50d67708bbaf94880a6263f539f28632210 )
 )
 
 game (
@@ -24349,12 +17867,6 @@ game (
 )
 
 game (
-	name "Joker Master"
-	developer "&lt;unknown&gt;"
-	rom ( name jkrmast.zip size 33734 crc c55783c8 md5 bff94e31f6da634e9649986ea7647b28 sha1 2fa3fea679255e3e9d71d9ac26f10c5cf079cd27 )
-)
-
-game (
 	name "The J.League 1994 (Japan)"
 	year "1994"
 	developer "Sega"
@@ -24366,13 +17878,6 @@ game (
 	year "1999"
 	developer "F2 System"
 	rom ( name jmpbreak.zip size 4951805 crc a4ec3b45 md5 9d0f802467110f03251e7e8fa9990779 sha1 2c527b646790f14ac158dc90a28a1b9471c0cf4b )
-)
-
-game (
-	name "Johnny Nero Action Hero"
-	year "2004"
-	developer "ICE/Play Mechanix"
-	rom ( name jnero.zip size 332827 crc e7711223 md5 c997b71c35138eac57ff6d244885bfdd sha1 6dfd7f5f10705d477a46bf0495e8baba7d64ec2c )
 )
 
 game (
@@ -24393,7 +17898,7 @@ game (
 	name "Jockey Grand Prix"
 	year "2001"
 	developer "Sun Amusement / BrezzaSoft"
-	rom ( name jockeygp.zip size 17273414 crc 314623f9 md5 961024968914dd5ed85cf2751fda31dc sha1 51010890f5ca29d93b957eda37dd83a0239143a6 )
+	rom ( name jockeygp.zip size 18620101 crc 784b17a4 md5 39002bb5b27607fd331f024084f55160 sha1 c801ce01a41d62781f8562361b9b010fda1cf9bb )
 )
 
 game (
@@ -24480,13 +17985,6 @@ game (
 )
 
 game (
-	name "Joker Card (Ver.A267BC, encrypted)"
-	year "1993"
-	developer "Vesely Svet"
-	rom ( name jokercrd.zip size 32609 crc 765749ba md5 94c4c0dfdfedf8f80946a87119e18a9d sha1 763dc8bdad8117da7c7e57e488cc7abf697fb266 )
-)
-
-game (
 	name "Joker Poker (Version 16.03B)"
 	year "1982"
 	developer "Greyhound Electronics"
@@ -24512,13 +18010,6 @@ game (
 	year "1983"
 	developer "Greyhound Electronics"
 	rom ( name jokpokerc.zip size 7985 crc 131cf7ed md5 2be8b98de20410eda2737d7d8fb2c8aa sha1 5259c68028b2f91dd338c6acba2c832e82955fc2 )
-)
-
-game (
-	name "Joker's Wild (encrypted)"
-	year "1988"
-	developer "Sigma"
-	rom ( name jokrwild.zip size 38043 crc e1649f5a md5 c8e81563a6ef0021f3ecd127721b949c sha1 9491d090326bae4563dbcdc24476dcafbf18396f )
 )
 
 game (
@@ -24561,20 +18052,6 @@ game (
 	year "1993"
 	developer "Soft Design"
 	rom ( name jolyccrb.zip size 26234 crc b9972239 md5 834163efc000ffa57977efce7b38d775 sha1 9e383b9ee8717ad53441454ae39c5bf799548a4a )
-)
-
-game (
-	name "Jolly Card (Austrian, Funworld, bootleg)"
-	year "1986"
-	developer "Inter Games"
-	rom ( name jolycdab.zip size 29521 crc 2143fceb md5 4f9eb524abba1fb97fcd4d97ad88aab3 sha1 ec1c6e73286996db02ed52259f719e7049193f07 )
-)
-
-game (
-	name "Jolly Card (Austrian, Funworld)"
-	year "1986"
-	developer "Funworld"
-	rom ( name jolycdat.zip size 32168 crc 38166793 md5 a3c16f1dfd193d14735db3d13f816e0f sha1 3c8acfc062c198ca306c05c2fa4fd7189dd5083d )
 )
 
 game (
@@ -24630,24 +18107,10 @@ game (
 )
 
 game (
-	name "Jongkyo"
-	year "1985"
-	developer "Kiwako"
-	rom ( name jongkyo.zip size 28861 crc 4e2be996 md5 2d1fef3ed312061e55adcd31ae825dad sha1 7fe9e56edfe36cd4b63a6879c7e8f2278582d5bf )
-)
-
-game (
 	name "Mahjong Jong-Tei (Japan, ver. NM532-01)"
 	year "1999"
 	developer "Dynax"
 	rom ( name jongtei.zip size 7401729 crc 1d55523f md5 028c02776920dc4456dc0b798bcd0bfe sha1 597ba66ca83b025e8b3e80bd5e8b83a5badf0b4a )
-)
-
-game (
-	name "Joshi Volleyball"
-	year "1983"
-	developer "Taito Corporation"
-	rom ( name josvolly.zip size 42690 crc 51b591ab md5 573efb9f7abfe6e7886828fc3b40727f sha1 bb6ef3f25b684db8271ca34bf3c028448cb1f2f0 )
 )
 
 game (
@@ -24696,7 +18159,7 @@ game (
 	name "Puzzled / Joy Joy Kid"
 	year "1990"
 	developer "SNK"
-	rom ( name joyjoy.zip size 1058342 crc 8278c7a2 md5 54cb957e6facd081c6ff15ed2db585b6 sha1 c0e8932ba9633b4cf97c042a3eb179ff29b8b4bc )
+	rom ( name joyjoy.zip size 2405029 crc fcb9711f md5 d89dd1036267deca4be6223a8d535634 sha1 3f9cdb17a98b19cfb4d216472ebbef15b1646328 )
 )
 
 game (
@@ -24711,13 +18174,6 @@ game (
 	year "1993"
 	developer "Sega"
 	rom ( name jpark.zip size 9562290 crc e6f8a94a md5 1f2fd2161fc6a666712dcad46691f0ac sha1 b4c8f19ba4210e3fe1200909ce87415b7e86832e )
-)
-
-game (
-	name "Jurassic Park 3 (ver EBC)"
-	year "2001"
-	developer "Konami"
-	rom ( name jpark3.zip size 791 crc bc66ed57 md5 87b775472b598dd86b7b11e1b271a7c8 sha1 04a75c119d3c78468c25123b32a265b3f5c7538c )
 )
 
 game (
@@ -24903,24 +18359,6 @@ game (
 )
 
 game (
-	name "Joker's Wild (B52 system, set 1)"
-	developer "Sigma"
-	rom ( name jwildb52.zip size 101881 crc 349cc060 md5 85c3f29b162acd7e7d68b4702966ac68 sha1 35b1b05cdcfa87b4dce594a60d950ebb9ce2cece )
-)
-
-game (
-	name "Joker's Wild (B52 system, set 2)"
-	developer "Sigma"
-	rom ( name jwildb52a.zip size 97041 crc 6f9a6a3d md5 5bbb629a5aff2dc91a8facfffe8bb339 sha1 d0a6cd565a1a5e0f02b23a3786da1ae667cb3cf0 )
-)
-
-game (
-	name "Joker's Wild (B52 system, Harrah's GFX)"
-	developer "Sigma"
-	rom ( name jwildb52h.zip size 103554 crc 749fe2f0 md5 e964f076cbaeab30d24364ccfceb8e56 sha1 961f0480fc5e275a375acbb1096f5f6938027aac )
-)
-
-game (
 	name "Jyangokushi: Haoh no Saihai (Japan 990527)"
 	year "1999"
 	developer "Capcom"
@@ -24931,7 +18369,7 @@ game (
 	name "Far East of Eden - Kabuki Klash / Tengai Makyou - Shin Den"
 	year "1995"
 	developer "Hudson"
-	rom ( name kabukikl.zip size 12077104 crc 148b632f md5 fc17f304c7a3a9917cb2c80176a3306c sha1 3be777590169bb91ebcf063240aef5449ed4ed6a )
+	rom ( name kabukikl.zip size 13423791 crc 84f3ff1e md5 a022ff0875bcf2a8b370161da6868f13 sha1 66ba005080680457014c70b5992c8748eff89591 )
 )
 
 game (
@@ -25026,27 +18464,6 @@ game (
 )
 
 game (
-	name "Kaiun Quiz (Japan, KW1/VER.A)"
-	year "1999"
-	developer "Namco"
-	rom ( name kaiunqz.zip size 34787590 crc 671b100d md5 cec265d498bd4129b2d97faad6a26777 sha1 9a9647f957fad21e9e31d94b1d7809e1444fb5d6 )
-)
-
-game (
-	name "Mahjong Kakumei (Japan)"
-	year "1990"
-	developer "Jaleco"
-	rom ( name kakumei.zip size 546133 crc 28f8fdc5 md5 1f9191815d9a1c4a2a65769d6e0abdcc sha1 693688e8f6bd2b039285d090a8e827ca1e8ec5d1 )
-)
-
-game (
-	name "Mahjong Kakumei 2 - Princess League (Japan)"
-	year "1992"
-	developer "Jaleco"
-	rom ( name kakumei2.zip size 1037704 crc 2eb34b77 md5 1f1dafdc947110082ea3095422e74996 sha1 104f70a4f2d8e6b44a1c54a4aabf015ea2636279 )
-)
-
-game (
 	name "Kamakazi III (superg hack)"
 	year "1979"
 	developer "hack"
@@ -25061,13 +18478,6 @@ game (
 )
 
 game (
-	name "Kamikaze"
-	year "1979"
-	developer "Leijac Corporation"
-	rom ( name kamikaze.zip size 5928 crc 5a4fefc8 md5 7bdacec83ded3f14a622750d540b0c46 sha1 b8cbbb27d5446fb696b6e963f6f41e3cb79a285a )
-)
-
-game (
 	name "Kamikaze Cabbie"
 	year "1984"
 	developer "Data East Corporation"
@@ -25079,20 +18489,6 @@ game (
 	year "1988"
 	developer "Panac"
 	rom ( name kanatuen.zip size 326075 crc 7958cbdb md5 2d299909a88ec8b88ea21c133631ec85 sha1 e78470dd8c6a999a72ce05bcc7cd9ddf755d8072 )
-)
-
-game (
-	name "Kangaroo"
-	year "1982"
-	developer "Sun Electronics"
-	rom ( name kangaroo.zip size 29696 crc 34252b40 md5 66fa791b13fe3cf44d6990709678d4aa sha1 0b1dc7390f485a98d4e15aaf586786889b49789d )
-)
-
-game (
-	name "Kangaroo (Atari)"
-	year "1982"
-	developer "Sun Electronics (Atari license)"
-	rom ( name kangarooa.zip size 29865 crc b9872bd9 md5 e555266761af620944251b297e6d3990 sha1 8b44d60eb290222a2b0841393ca1cc8fa6f689b2 )
 )
 
 game (
@@ -25176,21 +18572,7 @@ game (
 	name "Karnov's Revenge / Fighter's History Dynamite"
 	year "1994"
 	developer "Data East Corporation"
-	rom ( name karnovr.zip size 7080625 crc 68f0d0b5 md5 5f92883dac591379132d39282829fca6 sha1 714c129c491e02a0312ec868b79dc862f59a623a )
-)
-
-game (
-	name "Karous (GDL-0040)"
-	year "2006"
-	developer "Milestone"
-	rom ( name karous.zip size 1195 crc b3a81b11 md5 54f1234e8e6a9440286382f9f59d7d2e sha1 cd84b184069741842964ad6a4b5f7d14727ca02d )
-)
-
-game (
-	name "Ninja Kazan (World)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name kazan.zip size 874065 crc 539fb40f md5 152de260bc5e42de32fc9c3723f465cd sha1 40e09a127f9ccb344d4071308d206dbc9c28b07b )
+	rom ( name karnovr.zip size 8427312 crc 1e5c4b18 md5 c1e12027c5b20d02f861f3c3ff88135f sha1 8023b4288674c9b518480ce23fb80255bacbe706 )
 )
 
 game (
@@ -25205,27 +18587,6 @@ game (
 	year "1999"
 	developer "bootleg"
 	rom ( name kbash2.zip size 3803930 crc 4c466988 md5 f4e855534acd1bf38698a18f0edcffb6 sha1 81347ec2ca7501aa992bd751d83f45941701cc29 )
-)
-
-game (
-	name "Keyboardmania"
-	year "2000"
-	developer "Konami"
-	rom ( name kbm.zip size 34164 crc a88a840d md5 3dc42e78e13829e50e73e206954cd2d9 sha1 1de7f70ecd34f577e9e6edec0c2f5425d54eebe2 )
-)
-
-game (
-	name "Keyboardmania 2nd Mix"
-	year "2000"
-	developer "Konami"
-	rom ( name kbm2nd.zip size 34158 crc d843e859 md5 6c065f1e9cce685da4f369862883d7ce sha1 d59079c2bc73a754e094133ba3a84743da00bb54 )
-)
-
-game (
-	name "Keyboardmania 3rd Mix"
-	year "2001"
-	developer "Konami"
-	rom ( name kbm3rd.zip size 34159 crc 89586953 md5 6634b6d6d8cee682da8795208da03c82 sha1 801e41d99e6221b2c99372a8fa337cce737edb85 )
 )
 
 game (
@@ -25247,20 +18608,6 @@ game (
 	year "1984"
 	developer "Data East USA"
 	rom ( name kchampvs2.zip size 101255 crc e77b1459 md5 cfeab1bf396a6ea0a11b289ba2e11dd7 sha1 2d98b94a69b7e394d393b46f782fbc3523e12efa )
-)
-
-game (
-	name "Dead Eye (GV054 UA01)"
-	year "1996"
-	developer "Konami"
-	rom ( name kdeadeye.zip size 170 crc 4758dbb4 md5 c36437a272878a36ce63948f699196ba sha1 94dc7c62abb98d9c12e40bb5afb36190d3d91bff )
-)
-
-game (
-	name "King of Dynast Gear (version 1.8)"
-	year "1999"
-	developer "EZ Graphics"
-	rom ( name kdynastg.zip size 7716855 crc 2bf72300 md5 f0904eb19f3819116d6e2c8bd469541a sha1 fad4766e2fc9e5e43726756aa846e35c7f504bb8 )
 )
 
 game (
@@ -25334,59 +18681,52 @@ game (
 )
 
 game (
-	name "La Keyboardxyu (GDS-0017)"
-	year "2001"
-	developer "Sega"
-	rom ( name keyboard.zip size 1194 crc d08ba982 md5 6946920af7d2a62c970c5f3d019287a8 sha1 74944d9219344b342650de916528e2ca95bf9c21 )
-)
-
-game (
 	name "The King of Fighters 10th Anniversary Extra Plus (The King of Fighters 2002 bootleg)"
 	year "2005"
 	developer "bootleg"
-	rom ( name kf10thep.zip size 43249264 crc ef85a99b md5 418aa42f671e27a4fe1efdde4d1e1ae9 sha1 8c3d7abbb71ec9a1787c0840968ec57c4fbdb45e )
+	rom ( name kf10thep.zip size 44595951 crc fb7bf87d md5 89dd3c88f08f9fb310d575661429cd29 sha1 438192df23a2b084468673fba091a680864629b1 )
 )
 
 game (
 	name "The King of Fighters 2002 Magic Plus (bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kf2k2mp.zip size 83536014 crc 1ac5be95 md5 ef699f45dfeec0ed59d9442fc7cfd266 sha1 6acafd3fa996cd5465ec3a1f4b0587d5e959d0ca )
+	rom ( name kf2k2mp.zip size 84882701 crc 34132144 md5 0455bbc574eb014a30e6e6c8209403c0 sha1 68e04aee7fb1219dd2e486f27f5aa5cc6103a290 )
 )
 
 game (
 	name "The King of Fighters 2002 Magic Plus II (bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kf2k2mp2.zip size 82871384 crc 288300ad md5 fe3bfb1bc9d208daebadd14bb0802d3c sha1 ff969b3a5a7739d0f3adf75591ad2834bc4ec430 )
+	rom ( name kf2k2mp2.zip size 84218071 crc 8cd8745f md5 0d1bb017785f02e2cea3d3ace6f11df9 sha1 90ee8c578e423811b80a52b5643a561ef2c7f180 )
 )
 
 game (
 	name "The King of Fighters 2002 Plus (bootleg set 2)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kf2k2pla.zip size 82504957 crc 1a9cc0df md5 a0c895711d8b6f50fa3b74f3878e846d sha1 6308dabe2e4260d6b2981c84f2e05d25ab9d6384 )
+	rom ( name kf2k2pla.zip size 83851644 crc 7a948899 md5 c5f714c6530fe7d04f994bf618faec04 sha1 99457c890ef5ab6bac1f6785cfb09186e522ef8c )
 )
 
 game (
 	name "The King of Fighters 2002 Plus (bootleg set 1)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kf2k2pls.zip size 82506809 crc e7c83763 md5 928a295aabb534955202956a9c73bf7e sha1 253c1beaec81957fffb7be1f8d56cbf2dc10767b )
+	rom ( name kf2k2pls.zip size 83853496 crc 80912c6f md5 873e948d0eeb64d6c09eff387bcfe79f sha1 9f273adb087e2c1cadad8123bdedfa72b10585bb )
 )
 
 game (
 	name "The King of Fighters 2003 (bootleg set 1)"
 	year "2003"
 	developer "bootleg"
-	rom ( name kf2k3bl.zip size 81991948 crc 845e5748 md5 7093d9a8dbaea5ffd5f1590c7df9e01d sha1 3b216f6fd8429dc38cdc2e2e6559c79209c9f04f )
+	rom ( name kf2k3bl.zip size 83338635 crc 21f11b49 md5 1f34bdb4b1593a5c2c1744501ae844e6 sha1 802c9467726f41a6f6519a7177d77970a8041de6 )
 )
 
 game (
 	name "The King of Fighters 2003 (bootleg set 2)"
 	year "2003"
 	developer "bootleg"
-	rom ( name kf2k3bla.zip size 84172426 crc 1f041be6 md5 c9dfdafb73d545c7e5e3e839a7bc7b9b sha1 51d74ace9225728753812cc352168dcbc14060c6 )
+	rom ( name kf2k3bla.zip size 85519113 crc 0f501760 md5 d35ffdcc04d0a2a924aa46e5733fc81c sha1 e6787b285f1907c2cd6ca60a3da65780f2c3ec1c )
 )
 
 game (
@@ -25400,28 +18740,21 @@ game (
 	name "The King of Fighters 2004 Plus / Hero (The King of Fighters 2003 bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name kf2k3pl.zip size 84191667 crc 3c76f2bb md5 ca0e345787ee9fe0f0c546c9a76b2ce3 sha1 d38bf73533a166e6c3d2064b120c25a693788654 )
+	rom ( name kf2k3pl.zip size 85538354 crc 87fffd71 md5 79647baa775024e360c8cec4e631baef sha1 4db92364e5224e3dc321c7c3b3ec0ce92cdcf94a )
 )
 
 game (
 	name "The King of Fighters 2004 Ultra Plus (The King of Fighters 2003 bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name kf2k3upl.zip size 82013330 crc 9df59953 md5 6995574a2692625f2faf9ccb4f2e888c sha1 3ee1a62b293d8c6f11a860606160c789b88c8135 )
+	rom ( name kf2k3upl.zip size 83360017 crc 0bf849e0 md5 55b9f230cc07f444014ab171785e7066 sha1 d3a1e32d2bfcaac811d94d54b0b2fc38c1c7b536 )
 )
 
 game (
 	name "The King of Fighters 10th Anniversary 2005 Unique (The King of Fighters 2002 bootleg)"
 	year "2004"
 	developer "bootleg"
-	rom ( name kf2k5uni.zip size 43045035 crc 03311fe0 md5 151dac45566a381ca2f28eb1bbdc7f46 sha1 8b1466bff8f1ec73f1ac4681813350f8b46c6dad )
-)
-
-game (
-	name "Kick for the Goal"
-	year "1994"
-	developer "Jaleco"
-	rom ( name kftgoal.zip size 2961036 crc 227fa86c md5 89cb54fc85964228c97bad6ebed61a38 sha1 1f391fd7da3b7f2394cc1736a54b4af18891e0e5 )
+	rom ( name kf2k5uni.zip size 44391722 crc 8327b0cd md5 472c9ee1842448dcdc1fae485bb9a231 sha1 d8939204eb0929d61b0ae9d6545ba4c35b815051 )
 )
 
 game (
@@ -25446,13 +18779,6 @@ game (
 )
 
 game (
-	name "Kick '4' Cash"
-	year "2004"
-	developer "Sega"
-	rom ( name kick4csh.zip size 36244504 crc 2179bc37 md5 d75ceb7cd93f5c3f381845b312fa52b2 sha1 d0dfed93ed0133b2e6bd551d58060cb7d7cd39d3 )
-)
-
-game (
 	name "Kick Boy"
 	year "1983"
 	developer "Nichibutsu"
@@ -25474,31 +18800,10 @@ game (
 )
 
 game (
-	name "Kick Goal"
-	year "1995"
-	developer "TCH"
-	rom ( name kickgoal.zip size 1189017 crc c3ff3382 md5 8b0dbd8e19bab863db541e5c48f3a13f sha1 25c2f7fe2bb255c1922c0866c98c129c9e5d713d )
-)
-
-game (
 	name "Kickman (upright)"
 	year "1981"
 	developer "Midway"
 	rom ( name kickman.zip size 35543 crc 4d7de628 md5 131cf40ada6909cab40c7341b0465333 sha1 94281e6d18c6e851499036cab38865b510df37c2 )
-)
-
-game (
-	name "Kick and Run (World)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name kicknrun.zip size 153123 crc 0da177d8 md5 3ceb63eb806fa6254d90d92fd075c3de sha1 ea2e2873f59a90e83c255ba2eff8c5bc86124e35 )
-)
-
-game (
-	name "Kick and Run (US)"
-	year "1986"
-	developer "Taito America Corp"
-	rom ( name kicknrunu.zip size 153124 crc b401d099 md5 61e2f504d466a24679e64ecec0884d35 sha1 670abd80926cba3ab54a94ea0f2dad2629b4cedb )
 )
 
 game (
@@ -25533,7 +18838,7 @@ game (
 	name "Kikaioh (Japan 980914)"
 	year "1998"
 	developer "Capcom"
-	rom ( name kikaioh.zip size 39058497 crc c3b6eef7 md5 7f92aecfae9785dd3dbf8814e2e64d9c sha1 7079b1810a0434ff59ca5805a56675976c7d3592 )
+	rom ( name kikaioh.zip size 39196302 crc 6ca8bd62 md5 15b0fd3febe4b1b21f20abec57b0f55b sha1 c6b5a421f1f40549939060b09dee4befb53e70cf )
 )
 
 game (
@@ -25551,38 +18856,17 @@ game (
 )
 
 game (
-	name "KiKi KaiKai"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name kikikai.zip size 228593 crc 8a765bc0 md5 50ad6b55ec94d80d6d534fea3b553edf sha1 45b60dce7f549edcd7a387eccb23418ca369beb1 )
-)
-
-game (
-	name "Kick Start Wheelie King"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name kikstart.zip size 33608 crc 11f18636 md5 069d26bca2ac1ddc4641a13c3cb35302 sha1 f46efa023dfa729f58dd7a72ee3ca6302ec8354c )
-)
-
-game (
 	name "The Killing Blade (ver. 109, Chinese Board)"
 	year "1998"
 	developer "IGS"
-	rom ( name killbld.zip size 16331002 crc 065503be md5 062afec1bae382c443def65b7fb7206a sha1 ffd421b165d57fb26ae10aa7f418f15ac10f8b0f )
+	rom ( name killbld.zip size 18425594 crc e76a078d md5 7ec4899c77da8c299b585dd2d517d8d0 sha1 c99f999bd04c6e1aa5fe270f09881470c2a95598 )
 )
 
 game (
 	name "The Killing Blade (ver. 104)"
 	year "1998"
 	developer "IGS"
-	rom ( name killbld104.zip size 16266148 crc 2b3e02c1 md5 20212c8ef75e12853d7ce1c3017efb3c sha1 cc27f73f7e96a43c42fde2de36bbb6b83606b092 )
-)
-
-game (
-	name "The Killing Blade Plus (ver. 300)"
-	year "2005"
-	developer "IGS"
-	rom ( name killbldp.zip size 17948231 crc 505169fd md5 b506ca95a4248fb61d9aed7a8b759b5c sha1 bb77823efc90b06aad533bc8b7cab25a94d7f816 )
+	rom ( name killbld104.zip size 18360740 crc 19e3ab14 md5 7ad50509bb79b8a95eb3964235b41aee sha1 ba4cfeffc654983bc409d0a3480efca8c17e562c )
 )
 
 game (
@@ -25590,18 +18874,6 @@ game (
 	year "1980"
 	developer "GamePlan (Centuri license)"
 	rom ( name killcom.zip size 11091 crc 747951f7 md5 b3adec921e494e0b8c4df134c9d429d0 sha1 a432c06f4b2045955a0828d6003c5ffc5898a079 )
-)
-
-game (
-	name "Kimble Double HI-LO"
-	developer "Kimble Ireland"
-	rom ( name kimbldhl.zip size 11782 crc f3c70717 md5 26036c2a6b34f111eb1250d130840ba2 sha1 23c7ca081a694d8678893a77574404bf70eda11b )
-)
-
-game (
-	name "Kimble Double HI-LO (z80 version)"
-	developer "Kimble Ireland"
-	rom ( name kimblz80.zip size 13962 crc 6149b788 md5 7fa611245f659db5c5d29baddfdb5f94 sha1 f2205052b8b54230d4d1f46174feab750a680aa6 )
 )
 
 game (
@@ -25626,13 +18898,6 @@ game (
 )
 
 game (
-	name "King Derby (Taiwan bootleg)"
-	year "1986"
-	developer "bootleg (Casino Electronics)"
-	rom ( name kingdrbb.zip size 30848 crc eb26b24a md5 7535eeb589e965d9441aa2bd219babd8 sha1 7655992dccbb76b0dced82997c789aa0ef6c0850 )
-)
-
-game (
 	name "King Derby (1981)"
 	year "1981"
 	developer "Tazmi"
@@ -25644,33 +18909,6 @@ game (
 	year "1985"
 	developer "Wood Place Inc."
 	rom ( name kingofb.zip size 131512 crc ae78102b md5 eeffe376e5491f1b331381f35dfb5252 sha1 9e0c8669c490e9e3b2022904a1cfdcdac9becc24 )
-)
-
-game (
-	name "King Pin"
-	year "1983"
-	developer "American Communication Laboratories Inc."
-	rom ( name kingpin.zip size 25561 crc eb534908 md5 a60635fbd7a0c5b764047e7569e11212 sha1 6cfafe2c10a766571889e588898b4a30d3936ed4 )
-)
-
-game (
-	name "King Pin Multi-Game"
-	year "1983"
-	developer "American Communication Laboratories Inc."
-	rom ( name kingpinm.zip size 37756 crc 43d5d031 md5 e976116125a43e0b6b605f82bc96b256 sha1 86741c0bcb213d93a54bf097d8a32c3f341e14f1 )
-)
-
-game (
-	name "King Tut (NSW)"
-	developer "Konami"
-	rom ( name kingtut.zip size 2249931 crc dc45316e md5 b99a2dad7b30aff506a066297efffbb1 sha1 84a0c8d41b44f8ecadd7d152fd86038ea7f91728 )
-)
-
-game (
-	name "Kinnikuman Muscle Grand Prix (KN1 Ver. A)"
-	year "2006"
-	developer "Namco"
-	rom ( name kinniku.zip size 1321532 crc ffd901bd md5 4da2987561bed60a0b284085f247893d sha1 69be602b1843b454ff83d5c7327c43f49f9ed9f5 )
 )
 
 game (
@@ -25723,20 +18961,6 @@ game (
 )
 
 game (
-	name "Killer Instinct 2 (v1.3k, upgrade kit)"
-	year "1995"
-	developer "Rare"
-	rom ( name kinst2k3.zip size 4540954 crc a89b3da5 md5 791fa7f295ce844607190778d75e0cb2 sha1 26276580fcf555a9ef73a1fc438ae60b13996b98 )
-)
-
-game (
-	name "Killer Instinct 2 (v1.4k, upgrade kit)"
-	year "1995"
-	developer "Rare"
-	rom ( name kinst2k4.zip size 4541156 crc 60426b62 md5 326e2028f1ae359b4136501ce8da3d21 sha1 937bac4c0c4b4de06f88a634fc307fb88bb56c53 )
-)
-
-game (
 	name "Killer Instinct (SNES bootleg)"
 	developer "bootleg"
 	rom ( name kinstb.zip size 3209625 crc 4fbbcc5f md5 f4d9affe7cafc2e18aafbcd60eea2a72 sha1 58d57098044b0bd9002059f728cd5141ddec5cf4 )
@@ -25757,27 +18981,6 @@ game (
 )
 
 game (
-	name "Ryuusei Janshi Kirara Star"
-	year "1996"
-	developer "Jaleco"
-	rom ( name kirarast.zip size 13551531 crc b28fb495 md5 390ff256e11415db1477ffcc03f3b809 sha1 1765d3b4a15cf5d55252f0246a319cc8029ebc51 )
-)
-
-game (
-	name "Kisekae Hanafuda"
-	year "1995"
-	developer "I&apos;Max"
-	rom ( name kisekaeh.zip size 1762158 crc f1ac7f0d md5 e146376abb72f220d09113f2be350c67 sha1 8b6ce3a9d1d947be97884c2d8b0523bb4dd02536 )
-)
-
-game (
-	name "Kisekae Mahjong"
-	year "1995"
-	developer "I&apos;Max"
-	rom ( name kisekaem.zip size 1571996 crc 3f5d0b22 md5 c76a39abe3cf446df8018bd02a1d024b sha1 43317db83cd67b7d5413d21d8886b23396b78945 )
-)
-
-game (
 	name "Kitten Kaboodle"
 	year "1988"
 	developer "Konami"
@@ -25795,14 +18998,14 @@ game (
 	name "Pro Mahjong Kiwame S (J 951020 V1.208)"
 	year "1995"
 	developer "Athena"
-	rom ( name kiwames.zip size 4372956 crc 58639181 md5 1fab9605f9cabd2c776e206203885666 sha1 e55bd33636f2c469015b4af5136e5b3f9f0f8420 )
+	rom ( name kiwames.zip size 7072177 crc 846359fd md5 407704b3b93abe9f23db39999387b5cc sha1 1434cb6fab84cc6d3bfac796a2f91558bf5453cc )
 )
 
 game (
 	name "Kizuna Encounter - Super Tag Battle / Fu'un Super Tag Battle"
 	year "1996"
 	developer "SNK"
-	rom ( name kizuna.zip size 16771358 crc b28ffd5e md5 e992d4226059d8b2dc635d44bb74f13e sha1 0ad4b935711ab49476efb0582cb129edfefd93a7 )
+	rom ( name kizuna.zip size 18118045 crc 0ee74773 md5 4a42adcc378a4389b942f15d72524ed9 sha1 cac922a1ca9ac9c9726b93e3460f83c973d93528 )
 )
 
 game (
@@ -25868,12 +19071,6 @@ game (
 )
 
 game (
-	name "Kuai Le Xi You Ji"
-	developer "IGS"
-	rom ( name klxyj.zip size 2507238 crc 8e2b2b10 md5 7fe730b38a51fac8fdbee7c93dd4941d sha1 0a5b85237027311b40de4f1baf351bf22ca1bb71 )
-)
-
-game (
 	name "Knuckle Heads (World)"
 	year "1992"
 	developer "Namco"
@@ -25902,13 +19099,6 @@ game (
 )
 
 game (
-	name "Knightmare (prototype)"
-	year "1983"
-	developer "Gottlieb"
-	rom ( name kngtmare.zip size 34179 crc de99e96c md5 e6da01493f92e4eaad6225de345dd584 sha1 379b5caca5a7ab77874435e647d20178e0a259d4 )
-)
-
-game (
 	name "Knight Boy"
 	year "1986"
 	developer "bootleg"
@@ -25920,13 +19110,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name knights.zip size 2355204 crc 3228e413 md5 0b8c2e3bcad3ca8dc4fe8b06829f62d8 sha1 8a1c9937cda8cc5cbcf44822d99cd12f52c7091b )
-)
-
-game (
-	name "Knights of the Round (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name knightsb.zip size 2244978 crc 755f90ee md5 2f9ecbf7db5035d7fdecfc9c49bb00b5 sha1 ff8ec4807d231a05bf0b75a9f4e9a00896b60cbf )
 )
 
 game (
@@ -25951,269 +19134,192 @@ game (
 )
 
 game (
-	name "Kotoba no Puzzle Mojipittan (Japan, KPM1 Ver.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name knpuzzle.zip size 22507947 crc fe36f5e1 md5 8550c68ff52c9af2bf6a70eaa2422a73 sha1 3604aac5e68c376e6d4ab5a6840ce380073803e3 )
-)
-
-game (
-	name "The King of Dragons (World 910711)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kod.zip size 2365648 crc ad34a945 md5 06488f9f8375a3450e64a2d688f92694 sha1 c8d062de4c56e4de3222977813ea02991d7fe352 )
-)
-
-game (
-	name "The King of Dragons (bootleg)"
-	year "1991"
-	developer "bootleg (Playmark)"
-	rom ( name kodb.zip size 2426849 crc abb0a79f md5 53b651399cde0dcffe90481e72ac0918 sha1 e2c2d6353496278391dc805fbb9b6f48ced774cc )
-)
-
-game (
-	name "The King of Dragons (Japan 910805)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kodj.zip size 2367316 crc 0e8cf982 md5 d188c2337ff67f773af36cc827ff375f sha1 f190eab7209026a4299bccfa869c6b1ce48d11d1 )
-)
-
-game (
-	name "The King of Dragons (USA 910910)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kodu.zip size 2370275 crc 0ae98828 md5 8c664000511d8716f7e8354ae5efa802 sha1 6d8f5475a8e772dce59ef5040d61594af68de472 )
-)
-
-game (
-	name "Kodure Ookami (Japan)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name kodure.zip size 370512 crc 99e46e2b md5 49581849b6b3af6b3217a8181d8d200a sha1 abef54a1ea6158930da68f76702575fde1b70826 )
-)
-
-game (
 	name "The King of Fighters 10th Anniversary (The King of Fighters 2002 bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kof10th.zip size 43630396 crc 0127c885 md5 b603d626410ec8b9c162f5c17cca753e sha1 27e19c93695122f17eb8e8bd9568929f0d5638ff )
+	rom ( name kof10th.zip size 44977083 crc 83647932 md5 c42c6d86af90c0e5d5d377ec0b552cc9 sha1 15ae36178f9f65a6a19ce21f0f54bb07f1d03b99 )
 )
 
 game (
 	name "The King of Fighters 2000"
 	year "2000"
 	developer "SNK"
-	rom ( name kof2000.zip size 81525199 crc a8c6644b md5 83e51f7f6ded573ba91e646003b6a6f4 sha1 f3ef9e958b4f96f59b8986894333b7ffb7f961e2 )
+	rom ( name kof2000.zip size 82871886 crc 1463fcb2 md5 6833bd5444b3fc7392008007fe1723ef sha1 a635b80429f52dcb7ea5e2674104aa6c570c3a7c )
 )
 
 game (
 	name "The King of Fighters 2000 (not encrypted)"
 	year "2000"
 	developer "SNK"
-	rom ( name kof2000n.zip size 79946576 crc cacdd59c md5 70bafc85775ff7c9b0fb4aec8cccced8 sha1 d55ce4caaedfea333cd2bb588f40f77983129d33 )
+	rom ( name kof2000n.zip size 81293263 crc 1212dcd9 md5 595dc83705d7c9dd4419755d239ef1f4 sha1 be1f68675cb8ffeea1f206565cd854ebdf0b0a9d )
 )
 
 game (
 	name "The King of Fighters 2001 (set 1)"
 	year "2001"
 	developer "Eolith / SNK"
-	rom ( name kof2001.zip size 79827625 crc 1d193492 md5 ceb757bcda1ae0cfb0de8ddc91450541 sha1 7d5db577644eaaf575af91ceef0ba8539cb9a5f0 )
+	rom ( name kof2001.zip size 81174312 crc d0ab5b6b md5 c51d51827658f2c98af20a6ad6ea579b sha1 44622306657c9df0caf9fcd508f8726f27dc4bdb )
 )
 
 game (
 	name "The King of Fighters 2001 (set 2)"
 	year "2001"
 	developer "Eolith / SNK"
-	rom ( name kof2001h.zip size 79829564 crc 38584624 md5 833ac9b173f6cc4a88c3f46294f83730 sha1 055021141c3cb7cfe1b7cf674f2c20c438e07e01 )
+	rom ( name kof2001h.zip size 81176251 crc d6e57f85 md5 4be1a504f59f1430859078bbdea7e552 sha1 e669491fe731665d0ff98cc5bcdf7cae6d54d24d )
 )
 
 game (
 	name "The King of Fighters 2002"
 	year "2002"
 	developer "Eolith / Playmore"
-	rom ( name kof2002.zip size 82483697 crc 55393f10 md5 fe2708f26868b904faf4d62d02a29aae sha1 a1e33e88f7385b5fdff927425ba5d3134d0783ac )
+	rom ( name kof2002.zip size 83830384 crc e2c0fe97 md5 e4bdfc2b0d87b25bc66d6ca5bf2f1c8c sha1 d592ffaa72a96a94683eae7937f76e194c1bccb5 )
 )
 
 game (
 	name "The King of Fighters 2002 (bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name kof2002b.zip size 44133226 crc 792b4056 md5 c9a3bc8f0663e4a3fa8729da79400bd8 sha1 ef75fb75188d131ccc7b61da2e4c03af88b3e5b2 )
+	rom ( name kof2002b.zip size 45479913 crc b3d16f8e md5 29be0c7cfd03eb8797994327260d78d4 sha1 375c1e09d2835714fe9a0db73e918385285c271b )
 )
 
 game (
 	name "The King of Fighters 2003"
 	year "2003"
 	developer "SNK Playmore"
-	rom ( name kof2003.zip size 84143259 crc 9145aa59 md5 74eb34392cecae3b5dbf4d3d0aab5f80 sha1 e896fa5a158053c308c9315acb8bc3eb8923d3e8 )
+	rom ( name kof2003.zip size 85489946 crc 8522ca2c md5 648bf87409f886a115986547fcb693b6 sha1 f8a66bfaabcf3cab1d5430afd80093d39db36310 )
 )
 
 game (
 	name "The King of Fighters 2003 (AES cart)"
 	year "2003"
 	developer "SNK Playmore"
-	rom ( name kof2003h.zip size 84151454 crc 2da5c399 md5 016426dfc93e9d11820f5c90a293a820 sha1 6636a9e29b5432e33a6891f00060342559922d7c )
+	rom ( name kof2003h.zip size 85498141 crc 3ab59f52 md5 cab513fe335fb8b49e705ea86516fc0c sha1 ee42806ba98aedf3c8adfa8f79233c7f24f0f07d )
 )
 
 game (
 	name "The King of Fighters Special Edition 2004 (The King of Fighters 2002 bootleg)"
 	year "2004"
 	developer "bootleg"
-	rom ( name kof2k4se.zip size 41070102 crc 817e30eb md5 d085e17574b5176bc800c88207d9f985 sha1 30c4af9cae1dad7c1d7b753b49fa3bc2453e8b77 )
+	rom ( name kof2k4se.zip size 42416789 crc a4300584 md5 18c9d6beaba05b57be861e3fe7b953f7 sha1 b7119ae6db5c131353f5745c65224ebc832e1df5 )
 )
 
 game (
 	name "The King of Fighters '94"
 	year "1994"
 	developer "SNK"
-	rom ( name kof94.zip size 12771633 crc 97d5f4df md5 039b4a0ee7980b2b3ffc448c53586d4b sha1 46dc8e168d20e6807943d43c59071dfc465b9089 )
+	rom ( name kof94.zip size 14118320 crc c53a3a7e md5 6dcca762d441411087bcc8222d5484b4 sha1 3eb12ab51aa020d8072592b2851d020039769f30 )
 )
 
 game (
 	name "The King of Fighters '95 (set 1)"
 	year "1995"
 	developer "SNK"
-	rom ( name kof95.zip size 16156607 crc ffe39d82 md5 998b2c3a318783e519ff4bdf97079621 sha1 0e59bb08494f982a8b2ae485edc4131a17b2c605 )
+	rom ( name kof95.zip size 17503294 crc 0d9df811 md5 972437040ea8511eccfd3959cb7ec38b sha1 f0255cc9db483d9a1343a6bd9fe4f7be9a7dbece )
 )
 
 game (
 	name "The King of Fighters '95 (set 2)"
 	year "1995"
 	developer "SNK"
-	rom ( name kof95h.zip size 16153134 crc 41d4511d md5 60837a9d50818bfdd19d98f4604bba41 sha1 d910500fad7583d33b5d5f077773b8d90df7347a )
+	rom ( name kof95h.zip size 17499821 crc 1cbcdb47 md5 e6bfee77e1421a491242ec4f5a42f1ac sha1 c6805e8e6d34f15cb76894d18e09835317a5f7f4 )
 )
 
 game (
 	name "The King of Fighters '96 (set 1)"
 	year "1996"
 	developer "SNK"
-	rom ( name kof96.zip size 23568388 crc 3a558185 md5 afd2ee27264b50cea4e2368d18692f5c sha1 7066bc6776f23fe24fe07662b892b091de2173a9 )
+	rom ( name kof96.zip size 24915075 crc 2d6fe319 md5 c87ae03d5139221d146a93ac60b9ebe3 sha1 d824d807a665cd11969e99bd0c07c6df92bf7e42 )
 )
 
 game (
 	name "The King of Fighters '96 (set 2)"
 	year "1996"
 	developer "SNK"
-	rom ( name kof96h.zip size 23568450 crc a807b8fa md5 8f8c02259462915fefe411c9ec91c6e9 sha1 145728787b03cd58b2d162e109fd7d119c83e1ba )
+	rom ( name kof96h.zip size 24915137 crc ffc4ffd1 md5 94b5a9f4fa07cd088f44678f661a9664 sha1 952cde1513f86234f097f3394126b5f85a9b357d )
 )
 
 game (
 	name "The King of Fighters '97 (set 1)"
 	year "1997"
 	developer "SNK"
-	rom ( name kof97.zip size 28745764 crc ff6ee600 md5 a9645a213a911fdc85b726c928c90dae sha1 7a6b02e964ee087080bf2e00cbf51f5b8a1e9412 )
+	rom ( name kof97.zip size 30092451 crc 0420809f md5 e1fba7324baa554054b1402da87abe77 sha1 b494b89348cbc739f683f5da8e4634c82d4141ff )
 )
 
 game (
 	name "The King of Fighters '97 (set 2)"
 	year "1997"
 	developer "SNK"
-	rom ( name kof97h.zip size 28745746 crc 7bdd0604 md5 8ce97fe22d7af746369c4ad25409627a sha1 ad3a94e9b8a5a7f480c0abf91edb3420f694815e )
+	rom ( name kof97h.zip size 30092433 crc 506c549e md5 b2e48fd2b857fcd015d0fc78fad2742d sha1 58c4074bcabb2dd6b8d970c2a36d2f6490f55ce6 )
 )
 
 game (
 	name "The King of Fighters '97 Plus (bootleg)"
 	year "1997"
 	developer "bootleg"
-	rom ( name kof97pls.zip size 28748498 crc c61a8506 md5 4362eb6f581e76df8d759db8e1a7070e sha1 ab7161c3f4e0a547eb9a7bffdb904dcd7ed50fa4 )
+	rom ( name kof97pls.zip size 30095185 crc c41496ce md5 5b304cc48069e18271216b6f9db8c819 sha1 0591408a2f8aeae2b6b9be60631fcb9bc276fbe2 )
 )
 
 game (
 	name "The King of Fighters '98 - The Slugfest / King of Fighters '98 - dream match never ends"
 	year "1998"
 	developer "SNK"
-	rom ( name kof98.zip size 40445865 crc 7b9fbe4a md5 de51e4e1d904fab0704d928107225433 sha1 b77893705616a4bb63d4a4ce8f991244ce5e5d17 )
+	rom ( name kof98.zip size 41792552 crc 2cb4890d md5 21a782d96e5a4bfe1cd5ca6c3d4122cf sha1 6940a758e380f3016651a6201ac82b55f2e332b0 )
 )
 
 game (
 	name "The King of Fighters '98 - The Slugfest / King of Fighters '98 - dream match never ends (AES cart)"
 	year "1998"
 	developer "SNK"
-	rom ( name kof98h.zip size 40222227 crc 42d47f46 md5 47c4e00178a7f84bbc55ca7a9d62d5ca sha1 29043cf307c07a56a3f353e4de835b5c7c6b4a85 )
+	rom ( name kof98h.zip size 41568914 crc e6761fd9 md5 6b277993935ee625e305d6ea108e7ebf sha1 760868c4204edab36636b8476dc0c4c85ff929af )
 )
 
 game (
 	name "The King of Fighters '98 - The Slugfest / King of Fighters '98 - dream match never ends (Korean board)"
 	year "1998"
 	developer "SNK"
-	rom ( name kof98k.zip size 40445036 crc 792450a8 md5 38caf5faaf47a60efb83bc0c57ce843a sha1 2933f903645519016c699cb06e352692a820df0c )
+	rom ( name kof98k.zip size 41791723 crc 3644eaae md5 940bd4b95196e30017c5fd4f8717e547 sha1 832c88483c0cd5b5e7573f008c2ddd4b48a99632 )
 )
 
 game (
 	name "The King of Fighters '98 - The Slugfest / King of Fighters '98 - dream match never ends (Korean board 2)"
 	year "1998"
 	developer "SNK"
-	rom ( name kof98ka.zip size 40445045 crc a6a7b61d md5 a4e9819e601b6965df0c60a75e9e40bc sha1 ad0e4c0986d993c5be12700cf65e32b9449416bf )
+	rom ( name kof98ka.zip size 41791732 crc 59d62161 md5 0233e596860bf5b501a215497b87092d sha1 697b5ed4ca0e76241dad2441181c817b669157bb )
 )
 
 game (
 	name "The King of Fighters '99 - Millennium Battle (set 1)"
 	year "1999"
 	developer "SNK"
-	rom ( name kof99.zip size 78852037 crc 6c0581e8 md5 3283c45e5acd5eca9e772a66cb6f8c90 sha1 7d9d76403a89a8dd55af2459114ab5abbfe4e99d )
+	rom ( name kof99.zip size 80198724 crc f9cd6e64 md5 20915d4cbcd2f2a54fc89bb102feef8d sha1 61ef8aa83a1164bfbd7ac000c2ead75b2674cd51 )
 )
 
 game (
 	name "The King of Fighters '99 - Millennium Battle (set 2)"
 	year "1999"
 	developer "SNK"
-	rom ( name kof99a.zip size 78852500 crc dd9bf719 md5 3cf313fd3b44123f78cc30bd5ee3cc67 sha1 1b0c38cbcfd6d5c590a6ddd06e3101b5d3b9b3fb )
+	rom ( name kof99a.zip size 80199187 crc aa702bbc md5 9c67e1b22e57d3689052fdb7fe3e36f9 sha1 315e85b032fabdf3a3eb829545b0e1ebcb622475 )
 )
 
 game (
 	name "The King of Fighters '99 - Millennium Battle (earlier)"
 	year "1999"
 	developer "SNK"
-	rom ( name kof99e.zip size 79781557 crc d440d0bb md5 228682d87f1554792064e5044967d33c sha1 55c9ad6519fc5eff7aeb493e0b3d56aad00f7562 )
+	rom ( name kof99e.zip size 81128244 crc 9273ee10 md5 e5619c614127a8290db1cb900d29d9cb sha1 d846c88658ff7cfec435b6fdacd15905abdddc34 )
 )
 
 game (
 	name "The King of Fighters '99 - Millennium Battle (Korean release)"
 	year "1999"
 	developer "SNK"
-	rom ( name kof99k.zip size 77742960 crc 2ca04840 md5 74859870d5bcea5751609eb99ede9553 sha1 b20a987add6a2a6d5bfff865964436797fef1760 )
+	rom ( name kof99k.zip size 79089647 crc fc231e97 md5 9cacf070b89fe6136bffa5334e3df680 sha1 0d3a728012c716ecdb277871e28af764c331417b )
 )
 
 game (
 	name "The King of Fighters '99 - Millennium Battle (prototype)"
 	year "1999"
 	developer "SNK"
-	rom ( name kof99p.zip size 35554329 crc d5abd3ee md5 8008bd72bf65f06028e265a34218a6bb sha1 bd3799066e0fa64b7908b18c81bab6aa92316953 )
-)
-
-game (
-	name "The King of Fighters Neowave"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name kofnw.zip size 101031760 crc 8d826193 md5 c05216f9acc98329a70939e06f7feee0 sha1 5f6193a3268c59c35631e7ddd0b9761770c5cae9 )
-)
-
-game (
-	name "The King of Fighters Neowave (Japan)"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name kofnwj.zip size 101032301 crc 42b5d736 md5 9d40241861a95f5ab1884cf44ea9e345 sha1 fbd95cc63fe75d6e6f7c27bba756925ad5200ea7 )
-)
-
-game (
-	name "King of Football"
-	year "1995"
-	developer "BMC"
-	rom ( name koftball.zip size 234155 crc 7b800af1 md5 cbd4c5395e25f64c4f64109e9c65d549 sha1 25e4bcfd2d0912345807a8919cadb034379ac1f3 )
-)
-
-game (
-	name "King of Gladiator (The King of Fighters '97 bootleg)"
-	year "1997"
-	developer "bootleg"
-	rom ( name kog.zip size 29751947 crc 2d405ec9 md5 a6caaa9cd13f78b3c7a493315076c38c sha1 34eb33dfeda6a4463e1f9dee8b59ccf6438ba246 )
-)
-
-game (
-	name "Koi Koi Part 2"
-	year "1982"
-	developer "Kiwako"
-	rom ( name koikoi.zip size 17174 crc 4fe3bae6 md5 2c84e97dd4c4e4d138b631d9c75f9c38 sha1 1d6a8cf882bb0f1efcadd40bcd2680ef773433fb )
+	rom ( name kof99p.zip size 36901016 crc d00485fe md5 8cc403f0b94129404ac9e927b2e0083f sha1 b6cb8e1adfb16be4e6a7fd8cb7a03f08c282e967 )
 )
 
 game (
@@ -26244,45 +19350,17 @@ game (
 )
 
 game (
-	name "Kokoroji 2"
-	year "1994"
-	developer "Sega"
-	rom ( name kokoroj2.zip size 7736585 crc ef207b8d md5 48070caf26255085780cc0a7b527e9c5 sha1 988728353cbd24b9bed6f0c1328937685c8d8ea3 )
+	name "Kollon (V2.04J)"
+	year "2003"
+	developer "Taito"
+	rom ( name kollon.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
-	name "Konami 80's AC Special (GC826 VER. AAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80a.zip size 179 crc 93381d66 md5 959cb31b7265db1fcc54587c393694ed sha1 6767a30dd31c2ded31c92acfbd7194804bbd9773 )
-)
-
-game (
-	name "Konami 80's Gallery (GC826 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80j.zip size 179 crc d1cb7968 md5 895135fc0ef41ebb93c008aca75119fa sha1 f3ced37f8dfe88abe4c121a1de20782d6e81f59f )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. KAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80k.zip size 179 crc 2c2480d5 md5 8e66b5c43f8e0de54ccf85cbb6746cb3 sha1 fc6301236e09fb719977e9ddb16f8c3abf470488 )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80s.zip size 179 crc a059f691 md5 9490d46b275a48d9968c4825b51f7958 sha1 e24d5e92a45825e8bddcb8639e547ec8a2323a5b )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. UAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80u.zip size 179 crc 006b1b56 md5 bc2f76e67e39b06216540db516bf77af sha1 7dc1caabe197e37a3e01a90cd8fe4c5bf103dbea )
+	name "Kollon (V2.04JC)"
+	year "2003"
+	developer "Taito"
+	rom ( name kollonc.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -26297,20 +19375,6 @@ game (
 	year "1985"
 	developer "Konami"
 	rom ( name konamigt.zip size 83414 crc b1f1ad5f md5 c0753015de75b4376483dc1d37e6cc4f sha1 8d8369aa1c761aa2e07c3edf05c07f282ef5bed0 )
-)
-
-game (
-	name "Konek-Gorbunok"
-	year "1988"
-	developer "Terminal"
-	rom ( name konek.zip size 30665 crc 289c4ec5 md5 c7fb11bfc778aa674eec8ab3fd729f0f sha1 bfde1c9ec89338dd407b4527df76d57d269d2b3f )
-)
-
-game (
-	name "KO Punch"
-	year "1981"
-	developer "Sega"
-	rom ( name kopunch.zip size 16701 crc d6afeeed md5 603f05e58affacfcdcb03fd43946c9ec sha1 4dd415d376cbd29527adea48ec175114bacb77a7 )
 )
 
 game (
@@ -26372,140 +19436,70 @@ game (
 	name "King of the Monsters (set 1)"
 	year "1991"
 	developer "SNK"
-	rom ( name kotm.zip size 4025578 crc 035cb5e1 md5 afd3798a8cc31bb08e1fbf006a635658 sha1 94c113d963e234d1806ba3fa7c03c7761a8896df )
+	rom ( name kotm.zip size 5372265 crc 1539ff7e md5 50cba6e12647bdcf7d5ee338f2497ba9 sha1 5a1ac89fba6252b59940040c6d6b8a989c4acdb3 )
 )
 
 game (
 	name "King of the Monsters 2 - The Next Thing"
 	year "1992"
 	developer "SNK"
-	rom ( name kotm2.zip size 5502631 crc c1d2c2b6 md5 ce17b51f4b58c06607445b88fb2b2395 sha1 3e8cc2b7c265456d4f46d3a47a17c6ee386eb43f )
+	rom ( name kotm2.zip size 6849318 crc 66b1454e md5 8e6a984fde5c200f4463a8a97e83a717 sha1 c26f09b6fdca28c8cf4e0b51754d3d710eca016c )
 )
 
 game (
 	name "King of the Monsters (set 2)"
 	year "1991"
 	developer "SNK"
-	rom ( name kotmh.zip size 4026031 crc 22e5829c md5 656f35072c3d02e02bfd8b2cd4653f2e sha1 b90bb14b8b8363ec1255431bc359f584c94a4584 )
-)
-
-game (
-	name "The Koukouyakyuh"
-	year "1985"
-	developer "Alpha Denshi Co."
-	rom ( name kouyakyu.zip size 93857 crc 602e3d4e md5 d775a54e67fdfffabb02aefa3399091e sha1 813df9abb9d3c74fb9687617ebcd10b0b3f8d41d )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 117)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov.zip size 21034552 crc 3b802066 md5 9c358ab1b41afe0601e6fd9fbbe4b65a sha1 f81a492223da882284a80eaf54fbcdcc3c7a3980 )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 100, Japanese Board)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov100.zip size 20438392 crc b4698624 md5 b7b3109044bfcca5c114c2bd1fa8df80 sha1 7f11b100d2f7447212da117e73aa8f831579b5fc )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 115)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov115.zip size 21034626 crc e9831353 md5 de4a284441ef5c40c20a77cd0a3fafef sha1 eba7f927ebb7ecaf315c9c076f1f1b73326c5229 )
+	rom ( name kotmh.zip size 5372718 crc 0575a933 md5 921add6bc81bf8c2c19a9ef3d9c7e992 sha1 1b183d651a1f0034ddc9a9221983f76761c0d378 )
 )
 
 game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 107, 102, 100HK)"
 	year "2000"
 	developer "IGS"
-	rom ( name kov2.zip size 25744816 crc be1bdb60 md5 4a90358e76aed39494fe992619b2bbee sha1 c3eabb785198090bbcda307b6a97689687078b65 )
+	rom ( name kov2.zip size 27839408 crc 3b2f0f16 md5 e89fdd588a2071b055e875de631b4943 sha1 613a723e2986fac11894ea8dbb7f3664b712ef1b )
 )
 
 game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 100, 100, 100HK)"
 	year "2000"
 	developer "IGS"
-	rom ( name kov2100.zip size 25744860 crc 292d8748 md5 f2969080785c31c286d3efa193fca715 sha1 ea8b9d4750633f53a46baf26a05a0154bd91c428 )
+	rom ( name kov2100.zip size 27839452 crc 50a1b232 md5 1c852684ca9db4bf79d85884d0f1b517 sha1 c7c0cc228c8b0fbdf00c6fb0c938ae90070dc6f8 )
 )
 
 game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 102, 101, 100HK)"
 	year "2000"
 	developer "IGS"
-	rom ( name kov2102.zip size 25743815 crc 4db4cc18 md5 7c83ad6f1a17a4d5edada3a9ea4e7a54 sha1 43f226d6006fac3a124be4ce70628140cf39ddbb )
+	rom ( name kov2102.zip size 27838407 crc a524d600 md5 b8012810bb5cbeba5023c88792ac8894 sha1 b133c25df95ef1bd2804cffaa82e5668e4bad5f3 )
 )
 
 game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 103, 101, 100HK)"
 	year "2000"
 	developer "IGS"
-	rom ( name kov2103.zip size 25744267 crc e18051b5 md5 67ccf9cbd61513837b5aaaf54be3e311 sha1 9ccdb0eba80aebda1e63b2ea8e8a0393c867d3ec )
+	rom ( name kov2103.zip size 27838859 crc a1294cb7 md5 944ae131483b6d50e25851ab71b4a1d4 sha1 70c3c8eb1deab3d75f52fb22413593e101a9901c )
 )
 
 game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 106, 102, 100KH)"
 	year "2000"
 	developer "IGS"
-	rom ( name kov2106.zip size 25744545 crc d2ec9d82 md5 d0893a9515eeca0544f82223d09c38ab sha1 b0dfa75c0ada6b23b587e3400239faf029abe88f )
-)
-
-game (
-	name "Knights of Valour 2 Plus - Nine Dragons / Sangoku Senki 2 Plus - Nine Dragons (ver. M204XX)"
-	year "2001"
-	developer "IGS"
-	rom ( name kov2p.zip size 25085991 crc 15f1904b md5 4a8f921d906eaad7115e7cefdc6ee759 sha1 45e1f2d471334d1d582f18f7403851ef5dd6beea )
-)
-
-game (
-	name "Knights of Valour 2 Plus - Nine Dragons / Sangoku Senki 2 Plus - Nine Dragons (ver. M205XX)"
-	year "2001"
-	developer "IGS"
-	rom ( name kov2p205.zip size 25086029 crc db1c5e43 md5 69ea76876f2f031a9ecbb568c98e503d sha1 3e614081d91cb6d4f66a2a4c7fc6bc0b50211a0b )
-)
-
-game (
-	name "Knights of Valour - The Seven Spirits"
-	year "2004"
-	developer "Sammy / IGS"
-	rom ( name kov7sprt.zip size 109190277 crc 237152cc md5 a0cf419fab8199b0a1b3f65a4bc5cec4 sha1 638fa7fc572f82e48aaf854eee5951c56a15d88b )
-)
-
-game (
-	name "Knights of Valour Plus / Sangoku Senki Plus (ver. 119)"
-	year "1999"
-	developer "IGS"
-	rom ( name kovplus.zip size 21047523 crc ff1e6cbe md5 0639ae00812e3ff76c22ec718c34a187 sha1 e90d545515e31b5d31d200a64a19d126d6b1b5a5 )
-)
-
-game (
-	name "Knights of Valour Plus / Sangoku Senki Plus (alt ver. 119)"
-	year "1999"
-	developer "IGS"
-	rom ( name kovplusa.zip size 20444580 crc 12e69a49 md5 01f22ac499ce303cd50db120277e4445 sha1 38d31602add1365145140665efbaabbd395c5211 )
+	rom ( name kov2106.zip size 27839137 crc 20edecb9 md5 7291222e13ba1621eca8d508839de38d sha1 9332d51c2075fee3fffe6d7b66c0eed261d730a4 )
 )
 
 game (
 	name "Knights of Valour Super Heroes / Sangoku Senki Super Heroes (ver. 104, CN)"
 	year "1999"
 	developer "IGS"
-	rom ( name kovsh.zip size 22366836 crc 1886e131 md5 56f45b1a6a20f76f302147ecb8236a9e sha1 dc125aa2ad08f868c13007d06a8824897a7fcb8b )
+	rom ( name kovsh.zip size 24461428 crc c1ab4022 md5 ab95b511c85dbc2ad649ef8f61624cd9 sha1 c6ac776b8319a6aef316fd16fc22abd63ce577ba )
 )
 
 game (
 	name "Knights of Valour Super Heroes / Sangoku Senki Super Heroes (ver. 103, CN)"
 	year "1999"
 	developer "IGS"
-	rom ( name kovsh103.zip size 22825082 crc f2e44414 md5 44ccf6a164a6f659fba73ee1e0e4ec90 sha1 fdac2a55d3ffa7c84e1d024147170c0d87de8811 )
-)
-
-game (
-	name "Knights of Valour Super Heroes Plus / Sangoku Senki Super Heroes Plus (ver. 100)"
-	year "2004"
-	developer "IGS"
-	rom ( name kovshp.zip size 22558360 crc af2180e3 md5 58ecaedcf7e6ffbe542106047ad6a5de sha1 a0d6e8a6e0b2586bf6bc92c7f7048cacea96cfbb )
+	rom ( name kovsh103.zip size 24919674 crc 837d2892 md5 43b40c9fb019c71f22a821fea62862ba sha1 bcb4c3b2f88da8c7cec98686586984c4cb246bd2 )
 )
 
 game (
@@ -26558,13 +19552,6 @@ game (
 )
 
 game (
-	name "Kyukyoku Tiger (Japan)"
-	year "1987"
-	developer "Toaplan / Taito Corporation"
-	rom ( name ktiger.zip size 386617 crc 78169533 md5 924e6d886cb80f9859a8ad29098c32c4 sha1 58aa0ce009b73449b7a9b0f69197b5108d8963f6 )
-)
-
-game (
 	name "Kyukyoku Tiger II (Ver 2.1J 1995/11/30)"
 	year "1995"
 	developer "Taito Corporation"
@@ -26607,13 +19594,6 @@ game (
 )
 
 game (
-	name "Kung Fu Roushi"
-	year "1987"
-	developer "Namco"
-	rom ( name kungfur.zip size 259029 crc 6a1db4b0 md5 0331bed50c9423653496acc99c7a2c05 sha1 603ff97eab2dc409611e234502ff4d79aee3e134 )
-)
-
-game (
 	name "Kung-Fu Taikun"
 	year "1984"
 	developer "Seibu Kaihatsu"
@@ -26625,13 +19605,6 @@ game (
 	year "1984"
 	developer "Seibu Kaihatsu"
 	rom ( name kungfuta.zip size 61376 crc 0893a624 md5 0b46cbad30fee0a813c5e6867fe6661d sha1 fee2fce70236b56559497d7059202d1c1166d007 )
-)
-
-game (
-	name "Nekketsu Kouha Kunio-kun (Japan)"
-	year "1986"
-	developer "Technos Japan"
-	rom ( name kuniokun.zip size 372304 crc 203bb0a5 md5 e22eb80e3432d270ff6d97c693014511 sha1 87e72305b046b9e9a8df99551685ad82ad56191c )
 )
 
 game (
@@ -26667,20 +19640,6 @@ game (
 	year "1988"
 	developer "Taito America Corporation"
 	rom ( name kurikintu.zip size 532459 crc 67ecb509 md5 94d6e3c57166c10a0fc1082f5396138f sha1 df460e7328f274c35b4bde883ba8b4041e272074 )
-)
-
-game (
-	name "Kurukuru Chameleon (GDL-0034)"
-	year "2006"
-	developer "Able"
-	rom ( name kurucham.zip size 1196 crc 5d89791e md5 bc65ab557d701ba1f5469bfd41e3c0ae sha1 87fa37343cb71184ed002ac724392de21197b90e )
-)
-
-game (
-	name "Kurukuru Fever"
-	year "2003"
-	developer "Aruze / Takumi"
-	rom ( name kurufev.zip size 13646483 crc 375e053a md5 5a93e0bf3c302ee2a730b1e38f473bcf sha1 a427fa81176f7545837d14c3c9188b959895ed05 )
 )
 
 game (
@@ -26809,48 +19768,6 @@ game (
 )
 
 game (
-	name "Laguna Racer"
-	year "1977"
-	developer "Midway"
-	rom ( name lagunar.zip size 5584 crc 7dba2f3c md5 b20dc0c76887404f884f2fee0b9b2ccc sha1 5fa32d3eb3aec2d21c8a6b4d16a6aef05d23e447 )
-)
-
-game (
-	name "L.A. Machineguns"
-	year "1998"
-	developer "Sega"
-	rom ( name lamachin.zip size 76230646 crc fe18628f md5 0093f82839e7b1f78986ad9f926642a2 sha1 efc0b0267a3f7ce6baaaac3b0c407b858689fc7e )
-)
-
-game (
-	name "Land Breaker (World) / Miss Tang Ja Ru Gi (Korea) (pcb ver 3.02)"
-	year "1999"
-	developer "Eolith"
-	rom ( name landbrk.zip size 13460185 crc 2c47a71a md5 92c39aa4590dfcae7e0f50734443f31e sha1 b51683f064d64c0474b1b4d6643d83712bde77d0 )
-)
-
-game (
-	name "Land Breaker (World) / Miss Tang Ja Ru Gi (Korea) (pcb ver 3.03)"
-	year "1999"
-	developer "Eolith"
-	rom ( name landbrka.zip size 13326330 crc 6c285fe9 md5 1cd44c6f5f9cc3518f554d4a776d5971 sha1 31cae13c28f27039ba7a4eaca9cfc00b45e30c71 )
-)
-
-game (
-	name "Landing Gear"
-	year "1995"
-	developer "Taito"
-	rom ( name landgear.zip size 12727293 crc beb1e6eb md5 4e438ebbd4c2ce8048ee2ef3f76a150d sha1 94465fcf98b29baff81ee23c6cd935c0aad87ced )
-)
-
-game (
-	name "Landing High Japan"
-	year "1999"
-	developer "Taito"
-	rom ( name landhigh.zip size 33097 crc e3854b89 md5 bcb550ce90cbeb0b59eaf7c9c2deab5c sha1 5e5f47427cd428f78ba247b618b795003ea7cf4d )
-)
-
-game (
 	name "Land Maker (Ver 2.01J 1998/06/01)"
 	year "1998"
 	developer "Taito Corporation"
@@ -26868,21 +19785,7 @@ game (
 	name "Lansquenet 2004 (Shock Troopers - 2nd Squad bootleg)"
 	year "1998"
 	developer "bootleg"
-	rom ( name lans2004.zip size 29770974 crc b6ff6c6a md5 25d5e7d446367a6fb5d3d9667a8de4cd sha1 e6f4e4b579c94c34797f99c729c3cb306f683156 )
-)
-
-game (
-	name "La Perla Nera (Ver 2.0)"
-	year "2002"
-	developer "Nazionale Elettronica"
-	rom ( name laperla.zip size 585987 crc 71833ca3 md5 5a052f5bdd3b6c44c3ac1b816dd6fbc1 sha1 998b09003bfe712546dcb489176f96b76534733b )
-)
-
-game (
-	name "La Perla Nera Gold (Ver 2.0)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name laperlag.zip size 529971 crc 316a5f8a md5 5c0cefeb665d97e3d3e8b806e2fecbb1 sha1 16e491d764c61473d20318eb5cb2702fee8104ae )
+	rom ( name lans2004.zip size 31117661 crc 70bc87f0 md5 6764de5b2defdbdec1c925634a4420cd sha1 9f84903d3598f3aba8c97bc9e8bdf4236ec2e0ba )
 )
 
 game (
@@ -26893,34 +19796,6 @@ game (
 )
 
 game (
-	name "Laser 2001 (Ver 1.2)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name laser2k1.zip size 334003 crc 3324b809 md5 c1041e25e27634a7203fde6be14342ab sha1 4f6055b52c3db6c3614cf2927d8875fc9dac0d31 )
-)
-
-game (
-	name "Laser Base (set 1)"
-	year "1981"
-	developer "Hoei (Amstar license)"
-	rom ( name laserbas.zip size 20901 crc 11a2a15c md5 4e8c36972bf79193a93d2d8daeaed5e9 sha1 96ff88659c8dac0501595a4b02ef47daeef73e68 )
-)
-
-game (
-	name "Laser Base (set 2)"
-	year "1981"
-	developer "Hoei (Amstar license)"
-	rom ( name laserbasa.zip size 20895 crc 1f6585b5 md5 31225f7ec9be4d3635bc4e40d17f26a3 sha1 bdf5cb9022a29094bd1b927b58893cb565140a8e )
-)
-
-game (
-	name "Laser Battle"
-	year "1981"
-	developer "Zaccaria"
-	rom ( name laserbat.zip size 22389 crc 48d626f0 md5 a19ab551d4bf2c1fac8e2758932cb7d8 sha1 9a9fe6b88a4f925435a9d1150d607159ce88b822 )
-)
-
-game (
 	name "Lasso"
 	year "1982"
 	developer "SNK"
@@ -26928,45 +19803,31 @@ game (
 )
 
 game (
-	name "The Last Bounty Hunter v0.06"
-	year "1994"
-	developer "American Laser Games"
-	rom ( name lastbh.zip size 85759 crc 25d4995a md5 c84fcc7f9c7eca07cc7d937cffeb1446 sha1 dcb2a4a6f483360017babea10311f2d5e2a4632e )
+	name "Laser Strixx 2"
+	year "1995"
+	developer "CD Express"
+	rom ( name lasstixx.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
 	name "The Last Blade / Bakumatsu Roman - Gekka no Kenshi (set 1)"
 	year "1997"
 	developer "SNK"
-	rom ( name lastblad.zip size 26306432 crc c2090318 md5 d34db2ed63c32a2dd72395d7774d7ac4 sha1 790cecdcf76a72593cb1e26849df633142afbaed )
+	rom ( name lastblad.zip size 27653119 crc 9819e3fb md5 672dbcd677527781693f02dd77f2bfa6 sha1 651d3b99fb613d434b67e35dee95d5e613cd6220 )
 )
 
 game (
 	name "The Last Blade / Bakumatsu Roman - Gekka no Kenshi (set 2)"
 	year "1997"
 	developer "SNK"
-	rom ( name lastbladh.zip size 26306592 crc 576ce272 md5 198ae3c8771d4600112a80000e94a5f4 sha1 a7b5c335450aa6da8d1be78f3bc627fe51b91b95 )
+	rom ( name lastbladh.zip size 27653279 crc 1452483d md5 a770041f8f79fd2962a4c3564c926b84 sha1 6956e431e1a702d3ff3df98f1642b6301d25fe04 )
 )
 
 game (
 	name "The Last Blade 2 / Bakumatsu Roman - Dai Ni Maku Gekka no Kenshi"
 	year "1998"
 	developer "SNK"
-	rom ( name lastbld2.zip size 32382410 crc 3e60c222 md5 6ff6a655b42abcc8a685001f3b85d075 sha1 f6efeb91fe2de6c7a2abc48f13a609560526571a )
-)
-
-game (
-	name "Last Bronx (Export, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name lastbrnx.zip size 16049836 crc 8367723f md5 2a5f127925453978df0a79b7aee972fb sha1 afda93aa08ac97ee2eb50661f45fcef4b771b4ae )
-)
-
-game (
-	name "Last Bronx (Japan, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name lastbrnxj.zip size 16049858 crc d7a45a42 md5 c0f3024e266cdb75fcb3f882cef5b418 sha1 e86bd241f4fbbe2bf660401835b4da7e14e751a0 )
+	rom ( name lastbld2.zip size 33729097 crc cf28319a md5 fc76976d320dfef33e40c04f3c357eab sha1 c5327a777329171a1001d7256f33397a28d1e65b )
 )
 
 game (
@@ -27012,13 +19873,6 @@ game (
 )
 
 game (
-	name "Last Fighting"
-	year "2000"
-	developer "Subsino"
-	rom ( name lastfght.zip size 2376418 crc 2accacfc md5 57e87244a639c6a624e049d76248b50d sha1 b5be471851dd8c5a3cda3a7036766a43533eafd3 )
-)
-
-game (
 	name "Last Fortress - Toride"
 	year "1994"
 	developer "Metro"
@@ -27047,44 +19901,10 @@ game (
 )
 
 game (
-	name "Last Mission (US revision 6)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name lastmisn.zip size 208085 crc 0b434f4e md5 0dfaa0a8d4cbc6c20b0881d4bdc42ac7 sha1 6e0fdcf44eb80a01e9be1c1738bb6940bbdda820 )
-)
-
-game (
-	name "Last Mission (Japan)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name lastmisnj.zip size 207801 crc 11af638c md5 55b8c87cb59595bd6f985dcf7d42390a sha1 fc3529036a7af97d303165008d5ff79d962b40cb )
-)
-
-game (
-	name "Last Mission (US revision 5)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name lastmisno.zip size 208057 crc ca1483ca md5 870ba767f8c1edc0a198a5d62392b054 sha1 069acdc04b9c15617c48827640c4ddb4af1d71e8 )
-)
-
-game (
 	name "The Last Soldier (Korean release of The Last Blade)"
 	year "1997"
 	developer "SNK"
-	rom ( name lastsold.zip size 26308477 crc e35a9fc2 md5 dd80bca22d1f933ec73911dc219165bc sha1 35cad392c6677b519037b40e4d6a0c674dc38d01 )
-)
-
-game (
-	name "Las Vegas, Nevada"
-	developer "hack"
-	rom ( name lasvegas.zip size 3100 crc b94df8e0 md5 0758035b2be8765b3791e8517fa31032 sha1 eae5c7048939fa3a8558dcd9d8b6b83c3ea18bef )
-)
-
-game (
-	name "Lazarian"
-	year "1981"
-	developer "Zaccaria (Bally Midway license)"
-	rom ( name lazarian.zip size 23724 crc 2bcfb22d md5 d43d6e2302dbcc1a786a5df05f947a29 sha1 507bbad7de298dfa4624a612233822c6617c0048 )
+	rom ( name lastsold.zip size 27655164 crc efb2e2d3 md5 9ea16e393061337a236b303b252fc94a sha1 22a64a0766dec43d69f97a0d8effed121f307ff3 )
 )
 
 game (
@@ -27105,7 +19925,7 @@ game (
 	name "League Bowling"
 	year "1990"
 	developer "SNK"
-	rom ( name lbowling.zip size 1618135 crc b241c447 md5 f3eb30e6b08a5b70860ff37d4ee48579 sha1 5b3e10c4de232efba2a88bb9bee70b9bd8988d18 )
+	rom ( name lbowling.zip size 2964822 crc 736f5281 md5 f1d38eb6076c457418d18c08c6015bb0 sha1 3e21dc6f8b291c4c8096445c0093818ad1027861 )
 )
 
 game (
@@ -27154,21 +19974,21 @@ game (
 	name "Lethal Enforcers II: Gun Fighters (ver EAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name le2.zip size 12221531 crc f8438c1a md5 e2b0b83d5196c3e10460f3ac0e023d98 sha1 ded3d32657183b6acc961e773bd9ea05275e6ee2 )
+	rom ( name le2.zip size 12230221 crc 3e4386ef md5 31a408db9fb5c00a67273d8d59c7520e sha1 5bbce9ea9de0aa8a3d18a77202d212a954a0fd7c )
 )
 
 game (
 	name "Lethal Enforcers II: The Western (ver JAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name le2j.zip size 12221881 crc 93f7ce92 md5 aa4d6fdfcbed325d5c527449271f4351 sha1 8353316c23a10fba7418131edd81be6f681e759c )
+	rom ( name le2j.zip size 12230571 crc 566dae22 md5 23f330dd4ec5d7b7e042429efa92f3cb sha1 6d6c7c4d66f5438f96252a50f30c3e844e04a8db )
 )
 
 game (
 	name "Lethal Enforcers II: Gun Fighters (ver UAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name le2u.zip size 12219450 crc 3c648c4c md5 57d5f69f06a71f2c2468633c490737f5 sha1 58e1883a332ac742be257a23c98584a43013f464 )
+	rom ( name le2u.zip size 12228140 crc 38227a9e md5 5fc55cafd67ccd4d0ebf958678d2781e sha1 b441fe81debe1e3462c3d2c8e250f6e0e56f4978 )
 )
 
 game (
@@ -27176,13 +19996,6 @@ game (
 	year "1988"
 	developer "Seibu Kaihatsu"
 	rom ( name leadang.zip size 770957 crc d9c121ed md5 029d5c5b04c606148c444464c25e3f84 sha1 2eb5699ce0dea18680c7a8d58a0890107689fef2 )
-)
-
-game (
-	name "Leader"
-	year "1995"
-	developer "bootleg"
-	rom ( name leader.zip size 215539 crc 3625a876 md5 9c694d541eebc76a621f81012e3972d3 sha1 0a4936a511dc09efe40fc90315b832de101bd170 )
 )
 
 game (
@@ -27200,13 +20013,6 @@ game (
 )
 
 game (
-	name "Led Storm Rally 2011 (US)"
-	year "1988"
-	developer "Capcom"
-	rom ( name ledstorm2.zip size 752208 crc 47b340a2 md5 eb552fb18ca549456888b4b683253501 sha1 53b333f84996d1ea4bfe7c56e79cb5acc51db3a2 )
-)
-
-game (
 	name "Legend"
 	year "1986"
 	developer "Sega / Coreland"
@@ -27214,45 +20020,10 @@ game (
 )
 
 game (
-	name "Legend of Heroes"
-	year "2000"
-	developer "Limenko"
-	rom ( name legendoh.zip size 7731481 crc a46d9aa7 md5 cc0c10ccb8f4006090d18060dedba3b7 sha1 831451622364c342021f7d4d6f2765f8cb30d57e )
-)
-
-game (
 	name "Legend of Success Joe / Ashitano Joe Densetsu"
 	year "1991"
 	developer "SNK"
-	rom ( name legendos.zip size 1586004 crc dd4e76f4 md5 e57b1aa20e5376ed1008fb86379fd793 sha1 9a2271a616abc9222703bb395e219f9be6579683 )
-)
-
-game (
-	name "Chouji Meikyuu Legion (ver 2.03)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name legion.zip size 263039 crc 4bafa598 md5 383ec23c8a36e076631825618af1f0fa sha1 bdbf52de32c89377f150e21faabd3c9968547521 )
-)
-
-game (
-	name "Legionnaire (World)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name legionna.zip size 1385055 crc f4c4112e md5 283aabf122e22c22cf262453b2ae2fc8 sha1 5fea88b8383c843c67bfdff6269c058d8917ab29 )
-)
-
-game (
-	name "Legionnaire (US)"
-	year "1992"
-	developer "TAD Corporation (Fabtek license)"
-	rom ( name legionnau.zip size 1385035 crc ef949328 md5 ccb004c13930c719b96d3679d5859921 sha1 2cba6e03cd95c3651d248f5c185a2ecefda2905d )
-)
-
-game (
-	name "Chouji Meikyuu Legion (ver 1.05)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name legiono.zip size 262734 crc 78cd9c18 md5 08be847809c71c308e5b1085d8b1e9f4 sha1 a0e4634ac3092739aff1a9887be27ede74c19e44 )
+	rom ( name legendos.zip size 2932691 crc bfeb1b18 md5 8b6eb34305d91d7bb12d1b6dbf04caae sha1 88ecf5ed3d1ed6a26dd74c631f573808de3b49a8 )
 )
 
 game (
@@ -27260,13 +20031,6 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name legofair.zip size 424037 crc a40b2073 md5 9b70b9de065b0e5d984d5c7879ee42c7 sha1 33466591dc0028e6c983f08cdb2ca06cd6fed93a )
-)
-
-game (
-	name "LeMans 24"
-	year "1997"
-	developer "Sega"
-	rom ( name lemans24.zip size 34776980 crc 68890e92 md5 6d382eb8048873f9e4643426288611c8 sha1 e01f579cc409d05a0cbfa2210dded51447a361bb )
 )
 
 game (
@@ -27375,13 +20139,6 @@ game (
 )
 
 game (
-	name "Laser Grand Prix"
-	year "1983"
-	developer "Taito"
-	rom ( name lgp.zip size 127683 crc 5b54fdff md5 b4749e38fb6cfbb639970c9001f47ecd sha1 cc8b4c4d90f5d33b64523f40dea0858a79eadcdc )
-)
-
-game (
 	name "Lightning Fighters (World)"
 	year "1990"
 	developer "Konami"
@@ -27463,32 +20220,6 @@ game (
 	year "1995"
 	developer "IGS"
 	rom ( name lhbv33c.zip size 1144846 crc d09bb5ca md5 64675186cbbc18eb671fab4fb9b23ae2 sha1 11e6afb71e5850560125edf403fa0ec09129a4e1 )
-)
-
-game (
-	name "Mahjong Long Hu Zheng Ba 2 (set 1)"
-	year "1998"
-	developer "IGS"
-	rom ( name lhzb2.zip size 1189788 crc 9b24bc23 md5 dda02a60ea279fdb344851df04bce888 sha1 4ae436468c6e840cc96b71efbbe2e81a846f9b02 )
-)
-
-game (
-	name "Mahjong Long Hu Zheng Ba 2 (set 2)"
-	year "1998"
-	developer "IGS"
-	rom ( name lhzb2a.zip size 1245253 crc cb363c21 md5 df1e8b588eb72f7bf8540165c191a2b4 sha1 154b2e04f0bb5ae33f7ea856ed17dfc22330f92b )
-)
-
-game (
-	name "Long Hu Zheng Ba 3"
-	developer "IGS"
-	rom ( name lhzb3.zip size 2779975 crc 88d4dbc1 md5 2800dfd0708186d490b9d187296b6382 sha1 a73a3b9172b156f6b36832d978fd158667fd4295 )
-)
-
-game (
-	name "Long Hu Zheng Ba 4"
-	developer "IGS"
-	rom ( name lhzb4.zip size 3575030 crc 0f90545e md5 6ae757b8612c55c943783371a99044ca sha1 946eaf9195ee95f6a897b721b4eeb4157601ca50 )
 )
 
 game (
@@ -27576,13 +20307,6 @@ game (
 )
 
 game (
-	name "Little Robin"
-	year "1993"
-	developer "TCH"
-	rom ( name littlerb.zip size 794746 crc e48c0140 md5 8c9199af0cc2d1caa069018475dd1906 sha1 571b9b9c2f10eb70d093ff7fa2e2f084ecc91a72 )
-)
-
-game (
 	name "Live Gal (Japan 870530)"
 	year "1987"
 	developer "Central Denshi"
@@ -27646,20 +20370,6 @@ game (
 )
 
 game (
-	name "Lunar Lander (rev 2)"
-	year "1979"
-	developer "Atari"
-	rom ( name llander.zip size 10198 crc dac7d478 md5 9814166b25c9dcbc68ad1de183a069d7 sha1 dc7aff9095bbabef7e1069eff934c82c8c45224a )
-)
-
-game (
-	name "Lunar Lander (rev 1)"
-	year "1979"
-	developer "Atari"
-	rom ( name llander1.zip size 10179 crc 89edcaad md5 7344279aad238dc6d20fa1ebdf409778 sha1 1ef9454762395e7949a824de7a44853dac7d304f )
-)
-
-game (
 	name "Lucky Lady (3x3 deal)"
 	year "1991"
 	developer "TAB Austria"
@@ -27678,20 +20388,6 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name lnc.zip size 18677 crc bf2ec92c md5 9009dbd01f0663d5f2687cea8d21dd5c sha1 5985688c8a6b0a46ff8c37b7c6c5fa98704d3aab )
-)
-
-game (
-	name "Locked 'n Loaded (World)"
-	year "1994"
-	developer "Data East Corporation"
-	rom ( name lockload.zip size 14957720 crc 87ed7615 md5 c6d3a4270c9ee3f2813f3cd82faa3b4a sha1 b170be66e75c6e06e7d5c98cfdaa8325e1a522db )
-)
-
-game (
-	name "Locked 'n Loaded (US)"
-	year "1994"
-	developer "Data East Corporation"
-	rom ( name lockloadu.zip size 15420120 crc 8a130128 md5 c6862fe6c8f4157237b9ed18c6d4de95 sha1 c7af36777377bfb21f7140e482149285f1d5e696 )
 )
 
 game (
@@ -27737,13 +20433,6 @@ game (
 )
 
 game (
-	name "Line of Fire / Bakudan Yarou (World, FD1094 317-0136)"
-	year "1989"
-	developer "Sega"
-	rom ( name loffire.zip size 1541052 crc daac76b9 md5 ad9694e50968fd9f161322ee6695ff8a sha1 7a2650b1a6c6fa07abce6a61ae6b9e18d612c732 )
-)
-
-game (
 	name "Line of Fire / Bakudan Yarou (Japan, FD1094 317-0134)"
 	year "1989"
 	developer "Sega"
@@ -27776,20 +20465,6 @@ game (
 	year "1996"
 	developer "Deniam"
 	rom ( name logicpro.zip size 1666285 crc 909c6c69 md5 74279f969394acd41840bbb93bdb9594 sha1 112ea8400bccc9ed023b2a3b357b6150aaa9b49c )
-)
-
-game (
-	name "Legend of Hero Tonma"
-	year "1989"
-	developer "Irem"
-	rom ( name loht.zip size 672682 crc c692fa5b md5 48cf056a36d4eeb771830d9fa1ef0b97 sha1 07d598fa255fbcdde2fd83a97ef5029de95d04cd )
-)
-
-game (
-	name "Legend of Hero Tonma (bootleg, set 1)"
-	year "1989"
-	developer "bootleg"
-	rom ( name lohtb.zip size 651956 crc fa7fe353 md5 ddc39d8b557200e714e0635b54c1c9e8 sha1 69336bb61290c3750dfa120e6ab44f5f09455103 )
 )
 
 game (
@@ -27842,20 +20517,6 @@ game (
 )
 
 game (
-	name "Lord of Gun (USA)"
-	year "1994"
-	developer "IGS"
-	rom ( name lordgun.zip size 9849237 crc b029d011 md5 533f9817394b11359a2bfc5ed226cf76 sha1 a180209b8688a9be9bd32c784ea384ffc2e5079b )
-)
-
-game (
-	name "The Lord of King (Japan)"
-	year "1989"
-	developer "Jaleco"
-	rom ( name lordofk.zip size 1101973 crc 3f63f44b md5 47d8cd777ce917e49b01847949d2652f sha1 6b961f7ad3569de0d09dbbc1d241a77483dd68f3 )
-)
-
-game (
 	name "Lost Tomb (easy)"
 	year "1982"
 	developer "Stern Electronics"
@@ -27867,27 +20528,6 @@ game (
 	year "1982"
 	developer "Stern Electronics"
 	rom ( name losttombh.zip size 20308 crc 6b97828b md5 1fc2099309bfc99b6311819e604886b7 sha1 29883aa95c0058812139b8af76f556137b248469 )
-)
-
-game (
-	name "Lost Worlds (Japan)"
-	year "1988"
-	developer "Capcom"
-	rom ( name lostwrld.zip size 1960313 crc 7d287c42 md5 7c5492be9d680aec5307b71679a92071 sha1 89c9be975e957b0b1c090321b3de2a3e8c6e22be )
-)
-
-game (
-	name "Lost Worlds (Japan Old Ver.)"
-	year "1988"
-	developer "Capcom"
-	rom ( name lostwrldo.zip size 1958587 crc dc03ad9b md5 3645430e78647ad52e29c8b6c66379c6 sha1 1e48f0050e41891bd878d4ace3ad0ea39f9aceb8 )
-)
-
-game (
-	name "The Lost World"
-	year "1997"
-	developer "Sega"
-	rom ( name lostwsga.zip size 80345174 crc 68cb8df7 md5 f023a9039700894d2f56b13348d762de sha1 46c607440135d5aa4e0f27b2bb7732cc87cb1536 )
 )
 
 game (
@@ -27929,7 +20569,7 @@ game (
 	name "Logic Pro Adventure (Japan)"
 	year "1999"
 	developer "Amuse World"
-	rom ( name lpadv.zip size 2917016 crc 2965a6e5 md5 f13747794b7fbebdaf47a0654aa64274 sha1 045004274d7d4af49f76910077e211e92fb9c46e )
+	rom ( name lpadv.zip size 3055468 crc f588771b md5 9fbb5bb757a9ac89dd11a403795b3cb9 sha1 4df86f6edee7b4b5dd4663eb860715d7c04aae08 )
 )
 
 game (
@@ -27950,7 +20590,7 @@ game (
 	name "Last Resort"
 	year "1992"
 	developer "SNK"
-	rom ( name lresort.zip size 2916317 crc 95135c3f md5 e2d9f2c9e25e1a96406f834b06c51203 sha1 f758e45b09354d175660f3257fdf0e1b05a13d73 )
+	rom ( name lresort.zip size 4263004 crc 4286b7be md5 0b94f7cee1889b83a8a246a58a0f8668 sha1 744f26993751276dd19e32c47752212ed6c1c9a8 )
 )
 
 game (
@@ -27961,24 +20601,17 @@ game (
 )
 
 game (
-	name "Little Casino (newer)"
-	year "1984"
-	developer "Digital Controls Inc."
-	rom ( name ltcasinn.zip size 18774 crc 1021ff07 md5 933a8c5ca131ae994387649385534f1e sha1 8fc5566fa344db88f48096109e94abb129e97990 )
+	name "Laser Quiz Italy"
+	year "1995"
+	developer "CD Express"
+	rom ( name lsrquiz.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
-	name "Little Casino (older)"
-	year "1982"
-	developer "Digital Controls Inc."
-	rom ( name ltcasino.zip size 12907 crc 4c9b1e64 md5 fec535f03123576e654f1b94fd556c5d sha1 75d0e9ce212bc18b333487142fad349030ce5b2f )
-)
-
-game (
-	name "Lucky Girl (newer Z180 based hardware)"
-	year "1991"
-	developer "Wing Co., Ltd."
-	rom ( name luckgrln.zip size 295599 crc 2b0ce48d md5 0dca4a3617c8875f828a4cec79034e01 sha1 0fd9ba6f7cf79a5407a365ffe2c2c87dacc5e3a1 )
+	name "Laser Quiz 2 Italy (v1.0)"
+	year "1995"
+	developer "CD Express"
+	rom ( name lsrquiz2.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
@@ -27989,13 +20622,6 @@ game (
 )
 
 game (
-	name "Lucky 74 (bootleg, set 2)"
-	year "1988"
-	developer "Wing Co., Ltd."
-	rom ( name lucky74a.zip size 151641 crc 07285b40 md5 84695eead0a948db36befcd0898a34da sha1 8286afaf03c2a0ad9326e5ab9d3b7908e1014d07 )
-)
-
-game (
 	name "New Lucky 8 Lines (set 1, W-4)"
 	year "1989"
 	developer "Wing Co., Ltd. / GEI"
@@ -28003,23 +20629,10 @@ game (
 )
 
 game (
-	name "New Lucky 8 Lines (set 2, W-4)"
-	year "1989"
-	developer "Wing Co., Ltd. / GEI"
-	rom ( name lucky8a.zip size 45097 crc 0ef30d0e md5 5cdf4e4382f047e2692038b533c7a8f8 sha1 340ff805ea820b9948b605e98f155c1dabff2673 )
-)
-
-game (
 	name "New Lucky 8 Lines (set 3, W-4, extended gfx)"
 	year "1989"
 	developer "Wing Co., Ltd. / GEI"
 	rom ( name lucky8b.zip size 47367 crc da3c1769 md5 f0b33d70010b0cce4a17ea69bbf1954a sha1 feaede6f121dad29c368933c0a7d8ce9d9b7a0f0 )
-)
-
-game (
-	name "Lucky Girl? (Wing)"
-	developer "Wing Co., Ltd."
-	rom ( name luckygrl.zip size 17233 crc 165d57d1 md5 accfb2df8333cc068090f427bb8c8a4e sha1 700ef5aadb0637353af0c9b2990f7e74e652730f )
 )
 
 game (
@@ -28034,13 +20647,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name luckywldj.zip size 3318416 crc 3c6a2765 md5 8ed914c856f2a9fe4205559f39b75d7b sha1 71ab3d2e8f66b105b6dcc63dfcd31421110b369e )
-)
-
-game (
-	name "Lucky Today"
-	year "1980"
-	developer "Sigma"
-	rom ( name luctoday.zip size 4704 crc ffd91d42 md5 6c1d9ca0d886fc59ac925336347e8628 sha1 da712bd1d52399caf0ac230fa4e7ed668356782e )
 )
 
 game (
@@ -28072,31 +20678,10 @@ game (
 )
 
 game (
-	name "Lupin The Third - The Shooting (GDS-0018)"
-	year "2001"
-	developer "Sega"
-	rom ( name lupinsho.zip size 1192 crc 40fdbe2d md5 fa19212aca517b7b5c3ccdd953ba6e66 sha1 4f152414f6c8ff35f8b7b5b4d7d51a69c5dd5bee )
-)
-
-game (
-	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128)"
-	year "1999"
-	developer "Omega System"
-	rom ( name luplup.zip size 4937349 crc 5792a7e0 md5 df03406001b9fb4b715617611bbab4f2 sha1 6014c990daf94fc100c20da542ef2177eb422fcf )
-)
-
-game (
 	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 2.9 / 990108)"
 	year "1999"
 	developer "Omega System"
 	rom ( name luplup29.zip size 4873115 crc c3a0ad3c md5 5ed8093f253daac43a8e822a04676381 sha1 f6873c528eba12beab6e9cbee6d3d5fa65b7cf62 )
-)
-
-game (
-	name "Lupin The Third - The Typing (Rev A) (GDS-0021A)"
-	year "2002"
-	developer "Sega"
-	rom ( name luptype.zip size 1197 crc 0ac3fc59 md5 cd00c6049acd6cd975274e658a436bcd sha1 ea085aaf6f4b93f25a3f39f46301c7ae79780558 )
 )
 
 game (
@@ -28188,13 +20773,6 @@ game (
 	year "1977"
 	developer "RamTek"
 	rom ( name m79amb.zip size 7843 crc bb6b14be md5 333b87c1962e3658e35be9970499f60d sha1 6f36c14928724f598598b494a50b673a5c932825 )
-)
-
-game (
-	name "Club Grandslam (UK, Game Card 95-750-843)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_bcgslm.zip size 263912 crc a1438f69 md5 cf7ecd859d46a3f57725e7bbbd68ac46 sha1 68032e1767472357f82fe3905881ec51573efb6a )
 )
 
 game (
@@ -28324,151 +20902,10 @@ game (
 )
 
 game (
-	name "Focus (Dutch, Game Card 95-750-347)"
-	year "1995"
-	developer "BFM/ELAM"
-	rom ( name m_bfocus.zip size 150837 crc da901cdb md5 1122c7c5a3bcf2c87b7549df0399ede6 sha1 d7f925bf9bb5cf7029ee19a424272f6b867cf2a6 )
-)
-
-game (
-	name "The Big Breakfast (Set 2)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs1.zip size 514751 crc 3f77d38a md5 2a9911d128eb4f86d2056c6a23b4d841 sha1 188fb2daaad968eb6a466e9366490a9d47d87f72 )
-)
-
-game (
-	name "The Big Breakfast (Set 3)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs2.zip size 514677 crc 90d4ef13 md5 69e861b9c51f5b2015a6186446597766 sha1 d9d77833f3d4267986887038ab17666664b550c8 )
-)
-
-game (
-	name "The Big Breakfast (Set 4)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs3.zip size 514674 crc f827e2eb md5 ed99b805519d39d4848911b3ca740a9f sha1 1094645ac5229af2c26020d5cbd648b13eac55a6 )
-)
-
-game (
-	name "The Big Breakfast (Set 5)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs4.zip size 514686 crc a2588e47 md5 896fd7415e9a3750f00863934c12a1f1 sha1 cae765f167727fe85222b62a8eb7a5d85bf22301 )
-)
-
-game (
-	name "The Big Breakfast (Set 6)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs5.zip size 514628 crc 2da2a34c md5 fdd27e8a16187d9d1560d8d993c0fdbb sha1 bb39571ff778a45d319eff7a22b156fc3dabc9a9 )
-)
-
-game (
-	name "The Big Breakfast (Set 1 UK, Game Card 95-750-524)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfst.zip size 514600 crc e447917e md5 0b971d8e367f1978a6c80e49e0868436 sha1 fce3370e4435782a3ccf23f01426b461779b3f78 )
-)
-
-game (
-	name "Club Celebration"
-	developer "Barcrest"
-	rom ( name m_ccelbr.zip size 38682 crc a426542f md5 69aa90c169ab40785a9cf4525f9cf885 sha1 97c19aca065b0bf2c5b54406685433a33bc7ed49 )
-)
-
-game (
-	name "Club attraction (UK, Game Card 39-370-196)"
-	year "1990"
-	developer "BFM"
-	rom ( name m_clattr.zip size 57171 crc f688292b md5 23b7882732122479dfb38e3d28292583 sha1 dd11694090fea2818ce684a5d6d4b1e4064bcb6c )
-)
-
-game (
-	name "Club Public Enemy No.1 (UK, Game Card 95-750-846)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_cpeno1.zip size 559225 crc c9b4cfaa md5 1b0ebb29051b5b3e5b0314e5be8b3e6b sha1 e48cfc9cb68e289df5c3cb2469394767450497d5 )
-)
-
-game (
-	name "Gamball"
-	developer "Barcrest"
-	rom ( name m_gmball.zip size 35152 crc 6819888d md5 547ffb9ef5ea6b40e698a2eb24b8ad4f sha1 acc5809a990a98e7e784d28f5428c61ddfe61cc7 )
-)
-
-game (
-	name "Honey Money"
-	developer "Vivid"
-	rom ( name m_honmon.zip size 1469020 crc d6113d99 md5 9ce231e3e4ca511e93b1810cf5821e57 sha1 01995c8fb2e78939ab062d21a0458a4cc160998b )
-)
-
-game (
-	name "Lotus SE (Dutch)"
-	year "1988"
-	developer "BFM/ELAM"
-	rom ( name m_lotsse.zip size 37807 crc 1431a4db md5 06146180d771bd63294dc91fda300227 sha1 4a91337047cc4b6f26e790d54d89344a50925857 )
-)
-
-game (
-	name "Luvvly Jubbly (UK Multisite 10/25p, Game Card 95-750-808)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_luvjub.zip size 509177 crc 6d9015e6 md5 ea9cb77e2ac41ab9a1fa61e8177988af sha1 39f98bef88dc9a8d19a41045f02938134387c9d1 )
-)
-
-game (
-	name "Old Timer"
-	developer "Barcrest"
-	rom ( name m_oldtmr.zip size 27478 crc 680a52eb md5 9dcd931669ecaa786342211841dad3c4 sha1 6636854bd2585a1dc3fcecea5f0f1e2fb969bfeb )
-)
-
-game (
-	name "Roulette (Dutch, Game Card 39-360-129?)"
-	year "1988"
-	developer "BFM/ELAM"
-	rom ( name m_roulet.zip size 19565 crc 45be306e md5 f82a1e06e2d6808fabc432306ea8766e sha1 ccf2d021318039b6c6462f071d50e0e90b03a329 )
-)
-
-game (
-	name "Spotlight"
-	developer "Maygay Machines Ltd."
-	rom ( name m_sptlgt.zip size 26772 crc b2d066a5 md5 c15427e932f4b21ebca78d402a3d4e29 sha1 35c41e535f7409855ff6d6a7030e863ec2300740 )
-)
-
-game (
-	name "Supercards (Dutch, Game Card 39-340-271?)"
-	year "1985"
-	developer "BFM/ELAM"
-	rom ( name m_supcrd.zip size 20665 crc e5bf2be5 md5 09dbd9f84832666c972b97da0fd786b1 sha1 8c3256c7ba2ae27d8825bc55b8fb27fbc8a18de7 )
-)
-
-game (
-	name "Thunderbirds"
-	developer "JPM"
-	rom ( name m_tbirds.zip size 592978 crc 12026066 md5 e6ccdf0a70366cc0daeca71f50254377 sha1 7979b0bdcec98810ce6bf4157a94a301fa31f5a4 )
-)
-
-game (
-	name "Toppoker (Dutch, Game Card 95-750-899)"
-	year "1996"
-	developer "BFM/ELAM"
-	rom ( name m_tppokr.zip size 92424 crc 8b36303a md5 fab64ccc585f1c450acbe2157b78ef6c sha1 5d1d821e1d784f0e92698b01302fe1927bc54866 )
-)
-
-game (
 	name "Mace: The Dark Age (boot ROM 1.0ce, HDD 1.0b)"
 	year "1996"
 	developer "Atari Games"
 	rom ( name mace.zip size 416703 crc a3a54a34 md5 24ce7207f1344cebd8d3b94f6bf55bcf sha1 2bf4664b3c76210dabc88ac2cd8f0ea31d99deff )
-)
-
-game (
-	name "Mace: The Dark Age (HDD 1.0a)"
-	year "1997"
-	developer "Atari Games"
-	rom ( name macea.zip size 223650 crc 37427820 md5 08fd8389c8534e0adf51fe6534a22bbb sha1 6550b686c529988a80e348f3e80764505c098c8f )
 )
 
 game (
@@ -28542,13 +20979,6 @@ game (
 )
 
 game (
-	name "Mad Alien (Highway Chase)"
-	year "1980"
-	developer "Data East Corporation"
-	rom ( name madaliena.zip size 15907 crc 772b8b62 md5 46ed9616eee737a2893e3690944d56a3 sha1 2ebe226ddb6a3060cd2f4db5c1d547a0472b9a54 )
-)
-
-game (
 	name "Mad Ball V2.0"
 	year "1998"
 	developer "Yun Sung"
@@ -28577,52 +21007,10 @@ game (
 )
 
 game (
-	name "Mad Dog McCree v2.03 board rev.B"
-	year "1990"
-	developer "American Laser Games"
-	rom ( name maddog.zip size 52798 crc 09785076 md5 dcbb57ba080f131286a8c6379124ab9d sha1 4f1411477c352adfabc691cb56952f98230d7a79 )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v2.04"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog2.zip size 59550 crc db7bbfe0 md5 2aaf621c89425e7fbeb2f650c837d2ed sha1 522bd13f2c58d19aa5e5a4edaba6d669f33924bb )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v1.0"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog21.zip size 55410 crc 5fc23233 md5 dec34b8c1b2ef7ff475c8d7afc15ab2a sha1 bfbf022d07a786db3a0e2c56a86f448e4ebdc2b2 )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v2.02"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog22.zip size 57937 crc 276e0b1b md5 22d0229ebc727bf4ba98b48162a51933 sha1 61fcd03bf0dc43c3bce982da86d8414f51d452ef )
-)
-
-game (
-	name "Mad Dog McCree v1C board rev.A"
-	year "1990"
-	developer "American Laser Games"
-	rom ( name maddoga.zip size 41076 crc fa153bb2 md5 d98875c86be543fd64b8c2c9021a0555 sha1 ecba1e90f257abdc5d19e8f7bd562c02f9fd4d1b )
-)
-
-game (
 	name "Mad Donna (set 1)"
 	year "1995"
 	developer "Tuning"
 	rom ( name maddonna.zip size 2325661 crc 730605e7 md5 ff5d27bdfa8c13f8e6bf8c957646f10b sha1 dd796563799f31ba8ee54fb3c71f1a31493ad407 )
-)
-
-game (
-	name "Mad Donna (set 2)"
-	year "1995"
-	developer "Tuning"
-	rom ( name maddonnb.zip size 2277920 crc 1e9936ee md5 08c958b3cf17e9f83d03a1c2d3b6bd3a sha1 20b712991e95c544113f4600358e299788d5fa84 )
 )
 
 game (
@@ -28671,14 +21059,14 @@ game (
 	name "Magical Drop II"
 	year "1996"
 	developer "Data East Corporation"
-	rom ( name magdrop2.zip size 3679788 crc d9781e3b md5 37020103875deb0ce3cf0b4dba04786c sha1 8d3760d670bc24ee269b232ef796e9dbfab53696 )
+	rom ( name magdrop2.zip size 5026475 crc 4138e0f9 md5 0ded363461f22ba7455ef8079eda4da4 sha1 1b32b2e302fb9d820c5a937f7f860ecadc0057ce )
 )
 
 game (
 	name "Magical Drop III"
 	year "1997"
 	developer "Data East Corporation"
-	rom ( name magdrop3.zip size 8548268 crc 4ba8e9f1 md5 f3306f86d5c1f0335904a5f042a425ce sha1 22f208901b8414a5413a845018dc6ab8e517e464 )
+	rom ( name magdrop3.zip size 9894955 crc 872dbee4 md5 80f06b6324e252f784d9862740705517 sha1 0e2e421e084badd8f2f10cfb4f9f4fc8fd01777f )
 )
 
 game (
@@ -28703,13 +21091,6 @@ game (
 )
 
 game (
-	name "Magic's 10 2 (ver 1.1)"
-	year "1997"
-	developer "ABM Games"
-	rom ( name magic102.zip size 464671 crc d970ae36 md5 96f4bec87160bbb5f7ba803bdc474bf9 sha1 f23c2d061032835601f125b09aa253aa6b8c47ee )
-)
-
-game (
 	name "Magic's 10 (ver. 16.45)"
 	year "1995"
 	developer "A.W.P. Games"
@@ -28721,45 +21102,6 @@ game (
 	year "1995"
 	developer "A.W.P. Games"
 	rom ( name magic10b.zip size 303070 crc 2abfac3c md5 90a30fec02c4b68b5861fecc3b27a5f5 sha1 ef506e12d1ea8d1eb8b0c3412e95d7ed6fa617c8 )
-)
-
-game (
-	name "Magical Odds (set 1)"
-	year "1992"
-	developer "Pal Company / Micro Manufacturing Inc."
-	rom ( name magical.zip size 125085 crc 42772023 md5 2b9ece0adba952ce553f3a8fbd9bd3ec sha1 868256920bc257ddba846daf24e2226b13defb9e )
-)
-
-game (
-	name "Magical Odds (set 2)"
-	year "1992"
-	developer "Pal Company / Micro Manufacturing Inc."
-	rom ( name magicala.zip size 124516 crc cdb93c1e md5 b4f63bfd310c322bb958270d5231f6a3 sha1 f1f2e34b12873f1a9ded8ee85fb23f95355b4e00 )
-)
-
-game (
-	name "Magic Card (set 1)"
-	developer "Impera"
-	rom ( name magicard.zip size 126993 crc 3cc1a52c md5 254548938ce0eab4165b96f063773885 sha1 cf0da883104dcb73ba920ba110a2682e2206ba93 )
-)
-
-game (
-	name "Magic Card (set 2)"
-	developer "Impera"
-	rom ( name magicarda.zip size 111681 crc f0140ea4 md5 f93e46bc5fbd5b082a64de09da335f58 sha1 659e6527532066992e8e28176c47e5cc8517d889 )
-)
-
-game (
-	name "Magic Card (set 3)"
-	developer "Impera"
-	rom ( name magicardb.zip size 199145 crc 08941aa5 md5 4962f05a038a309f4d33b45192427d0b sha1 925312656e04ccd300d501cab26904f9d780c53f )
-)
-
-game (
-	name "Magic Card Jackpot (4.01)"
-	year "1998"
-	developer "Impera"
-	rom ( name magicardj.zip size 149170 crc ea06a999 md5 b788cbcf9d4299a7a1afeddf7a699b19 sha1 57063eff85047da0e2c9b0f7906d4c7dd6f76ce3 )
 )
 
 game (
@@ -28775,65 +21117,10 @@ game (
 )
 
 game (
-	name "Magic Card II (green TAB or Impera board)"
-	year "1996"
-	developer "Impera"
-	rom ( name magicd2a.zip size 43948 crc e9338db3 md5 e7227ff75c67e9bb1f7afea40ede121d sha1 09a405067b7da9147f2b19a8fbea86a12c7432bb )
-)
-
-game (
-	name "Magic Card II (blue TAB board, encrypted)"
-	year "1996"
-	developer "Impera"
-	rom ( name magicd2b.zip size 43412 crc 2d1fef0b md5 7b20a175e9f131f5fb5c94191f0332f5 sha1 89ad17dac8b3019689d3a92a10d4bb4974d168bf )
-)
-
-game (
-	name "Magic Fly"
-	developer "P&amp;A Games"
-	rom ( name magicfly.zip size 6703 crc 74809206 md5 1ddd4eebf74a98850548f5de380a658e sha1 e3041ffbc32cef289cd04d208827738bd40a371f )
-)
-
-game (
-	name "Magic Lotto Export (5.03)"
-	year "2001"
-	developer "Impera"
-	rom ( name magicle.zip size 107602 crc b0cb33a8 md5 6eb2646b171c641dc741d48bebab68a1 sha1 cd92fd490a0e8661f35496a1f5fb0563e3a15bbf )
-)
-
-game (
-	name "Magic Mask (A - 09/05/2000, Export))"
-	year "2000"
-	developer "Aristocrat"
-	rom ( name magicmsk.zip size 1040349 crc 43308267 md5 9e4a6da9711675eb174d8d074d9d14cb sha1 26041f8604eec24b46d6f59b2274c7433baa8924 )
-)
-
-game (
 	name "Magic Card II (Bulgarian)"
 	year "1996"
 	developer "Impera"
 	rom ( name magicrd2.zip size 62909 crc 4d8c8e63 md5 eea78fb28d61fccb221bbfe3ccaab9ae sha1 62da839958ebc377c23f4ba0e1e28c23897e857e )
-)
-
-game (
-	name "Magic Sticks"
-	year "1995"
-	developer "Playmark"
-	rom ( name magicstk.zip size 260245 crc 4756edde md5 8441263145338f3e9c203bcd034b1231 sha1 9db1c94ab1b0f9947b2914d9f2ee4861219bfa23 )
-)
-
-game (
-	name "Magic the Gathering: Armageddon (set 1)"
-	year "1997"
-	developer "Acclaim"
-	rom ( name magictg.zip size 38269552 crc f1fd0abe md5 bf3f38dcff71dc51d9c23dfe9fdc7c8f sha1 ada1c43d9b682d53b02646a1e2c39bed4c5c95a2 )
-)
-
-game (
-	name "Magic the Gathering: Armageddon (set 2)"
-	year "1997"
-	developer "Acclaim"
-	rom ( name magictga.zip size 1275607 crc 2458a401 md5 cb59375f9896437ca407fc1950afc542 sha1 6b3c7b3e31f9aca1f1b72d5f66de4d9bc2fee83c )
 )
 
 game (
@@ -28854,14 +21141,14 @@ game (
 	name "Magician Lord (set 1)"
 	year "1990"
 	developer "Alpha Denshi Co."
-	rom ( name maglord.zip size 2860815 crc e06e442a md5 7127a65451f32c3afec00075bbd59689 sha1 ab054c77e03865edabf73e0e2e17c042c503ecdd )
+	rom ( name maglord.zip size 4207502 crc 93893ffc md5 e9bda8862256d443d1cbff4c0259f26d sha1 b6edc30f942535bed061f47fe231c74cd3e20f8c )
 )
 
 game (
 	name "Magician Lord (set 2)"
 	year "1990"
 	developer "Alpha Denshi Co."
-	rom ( name maglordh.zip size 2861043 crc 6057d038 md5 7859339022378674ec17e4ff5171e72d sha1 e9f8ff30e5126256ac05240349a5e476835d8290 )
+	rom ( name maglordh.zip size 4207730 crc 14c7b98b md5 9ec4e15ed30869ed7b71405ce0e1a1fd sha1 fa8fd98d2d7707ce0293e935914de5ac9d5a10b6 )
 )
 
 game (
@@ -28886,13 +21173,6 @@ game (
 )
 
 game (
-	name "Magical Truck Adventure"
-	year "1998"
-	developer "Sega"
-	rom ( name magtruck.zip size 75094120 crc 8fa96d9a md5 d5d92e7f5497e488b24452490a3cbeb6 sha1 e0b8cdc3b42146f9a3642c7f564d0e76716e0fa4 )
-)
-
-game (
 	name "Magic Worm (bootleg)"
 	year "1980"
 	developer "bootleg"
@@ -28900,10 +21180,10 @@ game (
 )
 
 game (
-	name "Magical Zunou Power (J 961031 V1.000)"
-	year "1996"
-	developer "Sega"
-	rom ( name magzun.zip size 16926280 crc 5a322a24 md5 4aa9ff3d82e9a2d4023fd8a12a5eb9fc sha1 d34f3cb5cb51df566b47eaca78ed975a9050e45e )
+	name "Mahjong Oh (V2.06J)"
+	year "1999"
+	developer "Warashi / Mahjong Kobo / Taito"
+	rom ( name mahjngoh.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -28931,7 +21211,7 @@ game (
 	name "Mahjong Kyo Retsuden"
 	year "1990"
 	developer "SNK"
-	rom ( name mahretsu.zip size 3033722 crc 29c33a82 md5 0d0eb2ea74d3a08e492580ae5bbfd5e7 sha1 b4f80dd080a170b0ced22bb456faf47f0094e3a3 )
+	rom ( name mahretsu.zip size 4380409 crc 02e07587 md5 349238efb02febb5041f2b1f28a73719 sha1 8ca7cc9009f8bf798efef511dc628d76ed1924c5 )
 )
 
 game (
@@ -28983,31 +21263,10 @@ game (
 )
 
 game (
-	name "Mahjong Raijinhai DX"
-	year "1996"
-	developer "Dynax"
-	rom ( name majrjhdx.zip size 438745 crc da1e523e md5 5adeefe7768e7b83146d89a6a4065e65 sha1 fb6dd421afa72e43b8ed9401f5f1e1085e842048 )
-)
-
-game (
 	name "Mahjong Studio 101 [BET] (Japan)"
 	year "1988"
 	developer "Dynax"
 	rom ( name majs101b.zip size 140046 crc 019adc97 md5 376e778d0d22544a15fb837ea9c2ea3a sha1 d772e9a0ee9e4b9a19599ffe0c6754deea31d652 )
-)
-
-game (
-	name "Major Title 2 (World)"
-	year "1992"
-	developer "Irem"
-	rom ( name majtitl2.zip size 1811439 crc fb101978 md5 3cb1a085e1939c4ff87423ff232a0a64 sha1 29cc73e3b143d82f820fee893866e99939628556 )
-)
-
-game (
-	name "Major Title 2 (Japan)"
-	year "1992"
-	developer "Irem"
-	rom ( name majtitl2j.zip size 1808701 crc e47dd5aa md5 2ac673cbecfba12be7f5707bbf84dd9b sha1 5e9a54da8d3f39c82d7bd51fd9fd6305790d413c )
 )
 
 game (
@@ -29088,25 +21347,6 @@ game (
 )
 
 game (
-	name "Makyou Senshi (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name makyosen.zip size 400897 crc 768ff989 md5 f3c86668870f49304759a6d9908bd200 sha1 43ba32bccbaf60d69b30a1a5dc808541c8f08337 )
-)
-
-game (
-	name "Malzak"
-	developer "Kitronix"
-	rom ( name malzak.zip size 7411 crc 8221c269 md5 5165733a4a467143b36bc1f60d43b4dd sha1 2fdf6d1ec0700cd06bba3bcd30f770f0b16fc6ac )
-)
-
-game (
-	name "Malzak II"
-	developer "Kitronix"
-	rom ( name malzak2.zip size 8573 crc 30bc1adc md5 e31259703efa93e2884647b8db3dd6f8 sha1 b4a35c84dbdc11edcbb0dd87744ed5d633e3aa8a )
-)
-
-game (
 	name "Mang-Chi"
 	year "2000"
 	developer "Afega"
@@ -29149,13 +21389,6 @@ game (
 )
 
 game (
-	name "Manx TT Superbike (Revision C)"
-	year "1995"
-	developer "Sega"
-	rom ( name manxtt.zip size 15141111 crc 4d4f53c2 md5 8f8606afbbce95d26c61035b4e782d4e sha1 820829b382e5a0817620314b76d83238deff34fc )
-)
-
-game (
 	name "Many Block"
 	year "1991"
 	developer "Bee-Oh"
@@ -29177,59 +21410,10 @@ game (
 )
 
 game (
-	name "Marble Madness (set 1)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble.zip size 193238 crc c6135729 md5 3512ef1cc6d981a97ff0422b6e29c037 sha1 603cb95ee7269f849a2b3ef8afd7cadfd5f3799b )
-)
-
-game (
-	name "Marble Madness (set 2)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble2.zip size 192028 crc 9ea73818 md5 17dbfe45932d8e52dce47e5784405a99 sha1 e38f3ae1fb2337426ea03edb6a9ed1eef4390de5 )
-)
-
-game (
-	name "Marble Madness (set 3)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble3.zip size 192008 crc ce9a01d0 md5 6d53e1707560cf6ce21c84156d59a336 sha1 c64c10d63473dd458743211e4c6a6d95d9e2821e )
-)
-
-game (
-	name "Marble Madness (set 4)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble4.zip size 193320 crc 9f3238db md5 6957d6ace3d8e7ab23d9e017d7b76f94 sha1 8b96e7fcc1cbbeefacf5d8eaf161b4feff86b639 )
-)
-
-game (
-	name "Marble Madness (set 5 - LSI Cartridge)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble5.zip size 190119 crc 5cde1dd7 md5 6a180e8c2d71b0f200cee7572ae05c31 sha1 0cec4738dea3d3c071cc63d04b8f2129e50683b1 )
-)
-
-game (
-	name "Margarita Magic (A - 07/07/2000, NSW/ACT)"
-	year "2000"
-	developer "Aristocrat"
-	rom ( name margmgc.zip size 1121505 crc bd600656 md5 6eeb54a95e92bec344b0b52903b9d886 sha1 ac13fead277ad093dcaf0253b9d8814d56f19bde )
-)
-
-game (
 	name "Marine Boy"
 	year "1982"
 	developer "Orca"
 	rom ( name marineb.zip size 24169 crc 55e58c5d md5 2154b2a0082314092ada7882059a7326 sha1 c4f8ccb7344abaa63c1087ced11e522ab21cef6b )
-)
-
-game (
-	name "Marine Date"
-	year "1981"
-	developer "Taito"
-	rom ( name marinedt.zip size 16604 crc 88686e4a md5 3edf10aa28818622435ccdf5025fb323 sha1 0ea486a5a776be8ae34ed3863c952d6d83f0a6f6 )
 )
 
 game (
@@ -29285,28 +21469,28 @@ game (
 	name "Martial Masters (ver. 104, 102, 102US)"
 	year "2001"
 	developer "IGS"
-	rom ( name martmast.zip size 28525018 crc c56c4fb3 md5 2df0cf661e0b9128b3ab7ab865366aa2 sha1 12bf45e04427bb6d28f8c24f2e38166c15822a20 )
+	rom ( name martmast.zip size 30619610 crc 2e15f266 md5 6093b0f9d3f5809ea955af37bd095e1e sha1 a25c7318df1c189f530c73f66d928b9adfe48f48 )
 )
 
 game (
 	name "Martial Masters (ver. 104, 102, 101CN)"
 	year "2001"
 	developer "IGS"
-	rom ( name martmastc.zip size 28524070 crc a8b7a014 md5 50303e6d7e414f0c506d2d1041ad5a17 sha1 409de160afd6ef8a9fa0dc86504016a2abac9866 )
+	rom ( name martmastc.zip size 30618662 crc 02dc2f2f md5 a5218af145d2ed5745253a8124bbdfe7 sha1 5fd7bd8e44e866b3e6371d8619309435fa3c943d )
 )
 
 game (
 	name "Martial Masters (ver. 102, 101, 101CN)"
 	year "2001"
 	developer "IGS"
-	rom ( name martmastc102.zip size 28524475 crc 8ed306d2 md5 159f3ce9ddd7ca1d6b7d1ed15e12c926 sha1 a24a4b0f6006e6d89b885470be506dbde568da7f )
+	rom ( name martmastc102.zip size 30619067 crc e7da69f6 md5 903251bdb4a0743a5badf9b7ad098ab5 sha1 ce971e08a76e9a61e4a19ef90e31822af7fd408d )
 )
 
 game (
 	name "Maru-Chan de Goo! (J 971216 V1.000)"
 	year "1997"
 	developer "Sega / Toyosuisan"
-	rom ( name maruchan.zip size 16053585 crc 6495796f md5 fc4c989be29b5d2653327c1d20dce0e0 sha1 9740628b045a14386399b9b62fd694f617f19174 )
+	rom ( name maruchan.zip size 18752806 crc 8d602ab6 md5 0556fc4b9894a0798e8b1f97c7117a31 sha1 4daa7837a8bf780d2a7761d5c48bebe89569cbbb )
 )
 
 game (
@@ -29320,7 +21504,7 @@ game (
 	name "Chibi Marukochan Deluxe Quiz"
 	year "1995"
 	developer "Takara"
-	rom ( name marukodq.zip size 4432567 crc c4a77124 md5 7fa68c2cc5cdc45c756c79da76cde4de sha1 fc8fdc39d31d87d98eaf0c339732f8fe458b880a )
+	rom ( name marukodq.zip size 5779254 crc 5a911157 md5 0eb292bed797d23203c57f92093b543e sha1 fe97e5163a719d89acd7b9ea762ca29546ecff37 )
 )
 
 game (
@@ -29387,20 +21571,6 @@ game (
 )
 
 game (
-	name "The Masters of Kin"
-	year "1988"
-	developer "Du Tech"
-	rom ( name mastkin.zip size 39037 crc bc81cbc8 md5 8784d2fd5f868f372cd16783f2d18d4e sha1 53faf0a4430e23ceac8fde58ab4d0202864f0b2a )
-)
-
-game (
-	name "Master Ninja (bootleg of Shadow Warriors / Ninja Gaiden)"
-	year "1989"
-	developer "bootleg"
-	rom ( name mastninj.zip size 1117273 crc 721b85c3 md5 7770739824a775470ae2d5fddd86a0cb sha1 51a3d023aa614dfd742f1688b32ee1214d2c8331 )
-)
-
-game (
 	name "Match '98 (ver. 1.33)"
 	year "1998"
 	developer "Amcoe"
@@ -29422,18 +21592,6 @@ game (
 )
 
 game (
-	name "The Mating Game (v0.4)"
-	developer "Barcrest"
-	rom ( name mating.zip size 3121723 crc df9c5c61 md5 2a7464d60a7858573aed9499892fd7c6 sha1 9d0cc92a398b1ee9dcb8e818d8b7584a8f9e2a98 )
-)
-
-game (
-	name "The Mating Game (v0.4, Datapak)"
-	developer "Barcrest"
-	rom ( name matingd.zip size 3121723 crc d592822c md5 0fde72ee681421d87c76d28cfd41278b sha1 202f2284df0b55db28b827902c7ea59a4f4226a8 )
-)
-
-game (
 	name "Mat Mania"
 	year "1985"
 	developer "Technos Japan (Taito America license)"
@@ -29444,21 +21602,21 @@ game (
 	name "Matrimelee / Shin Gouketsuji Ichizoku Toukon"
 	year "2002"
 	developer "Noise Factory / Atlus"
-	rom ( name matrim.zip size 82318909 crc 3a0ae458 md5 0f722e383f997605ff9a63f4ecb39502 sha1 c3577144e4ee3257d4fea55536faca290a668e2f )
+	rom ( name matrim.zip size 83665596 crc 7ce8d46d md5 424d078824268e4f1e6fc8da6c415db3 sha1 dc78966c34ddf97cf21bc1d1dd31854ce3aea3d1 )
 )
 
 game (
 	name "Matrimelee / Shin Gouketsuji Ichizoku Toukon (bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name matrimbl.zip size 34796732 crc be26febb md5 c3ef815d5a6dc0e1533d794377c75c60 sha1 4802976e8903fb0a477a52de70743cdd25b05949 )
+	rom ( name matrimbl.zip size 36143419 crc 4320bd4b md5 53720ce28a1b5e6d331e582b84a87f00 sha1 28a3bd9a8ac1d2ef29351fe32188f3a390a92110 )
 )
 
 game (
 	name "Mausuke no Ojama the World (J 960314 V1.000)"
 	year "1996"
 	developer "Data East"
-	rom ( name mausuke.zip size 4617311 crc c49a03e1 md5 a247524c99c798d6c8dd090a3abd1a58 sha1 3d273a4d181be9e84897f99452ce43620567ed31 )
+	rom ( name mausuke.zip size 7316532 crc 4d2ffd92 md5 b7d1823f844dab5f1cd29bfc532bc956 sha1 f20464049aa29555d57349ff91b6d7d4de27501d )
 )
 
 game (
@@ -29538,20 +21696,6 @@ game (
 )
 
 game (
-	name "Mayjinsen 3"
-	year "2000"
-	developer "Seta / Able Corporation"
-	rom ( name mayjin3.zip size 5287034 crc 976aa48c md5 c73c6f5d1a40820f8616155414574d4c sha1 179e6bb5562f3230158b328f51952e629d0827d1 )
-)
-
-game (
-	name "Mayjinsen"
-	year "1994"
-	developer "Seta"
-	rom ( name mayjinsn.zip size 576960 crc cfaf3c38 md5 d04d7b64bdc26140d9309084ec900312 sha1 5c7dde71e289299ed9a2dc9307e7093e8d34cf53 )
-)
-
-game (
 	name "Mayjinsen 2"
 	year "1994"
 	developer "Seta"
@@ -29580,20 +21724,6 @@ game (
 )
 
 game (
-	name "Mazer Blazer (set 1)"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name mazerbla.zip size 30841 crc 5639d94a md5 c8740faf0b4cd881da4a2357359f5af4 sha1 10ba12b0be58781b83bc607982560f4714ce23f2 )
-)
-
-game (
-	name "Mazer Blazer (set 2)"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name mazerblaa.zip size 31293 crc 117cb885 md5 da41bb86603170c901338428b8ca8760 sha1 7d3a4278e5e440faddd54b3100248f913631ea76 )
-)
-
-game (
 	name "Mazinger Z (World)"
 	year "1994"
 	developer "Banpresto / Dynamic Pl. Toei Animation"
@@ -29605,27 +21735,6 @@ game (
 	year "1994"
 	developer "Banpresto / Dynamic Pl. Toei Animation"
 	rom ( name mazingerj.zip size 2912728 crc 16359508 md5 906459ae0a964fb342cf318ee2a9a2e4 sha1 1600718c0f425ba1da7cd79b16bfcb6e5d1887ed )
-)
-
-game (
-	name "Muscle Bomber: The Body Explosion (Japan 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbomberj.zip size 6613282 crc c91011cb md5 da0c9a02e09fa2cef903c12281daad7b sha1 9c75d6238e8654c7ac1c79a80d6cc60745b299f4 )
-)
-
-game (
-	name "Muscle Bomber Duo: Ultimate Team Battle (World 931206)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbombrd.zip size 6509365 crc 865500aa md5 dc624c8188d3d3e81293b12a11e8130e sha1 8e8dc17fd84f10ee679a7145f0524883e35aa2b8 )
-)
-
-game (
-	name "Muscle Bomber Duo: Heat Up Warriors (Japan 931206)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbombrdj.zip size 6534230 crc 1be31f10 md5 f709f20b8393258265ca6d11427aedd2 sha1 aef3e5f522eb43b4f7b18d8fae5ec3a99f5da4d7 )
 )
 
 game (
@@ -29671,12 +21780,6 @@ game (
 )
 
 game (
-	name "Magic Class (Ver 2.2)"
-	developer "&lt;unknown&gt;"
-	rom ( name mclass.zip size 266408 crc 7c5d7f7e md5 61311d49aac3f6360890e514fa92f4cd sha1 907dec7e5438eaba9194e6c0e50f8cb628f281f8 )
-)
-
-game (
 	name "Mahjong Campus Hunting (Japan)"
 	year "1990"
 	developer "Dynax"
@@ -29684,55 +21787,10 @@ game (
 )
 
 game (
-	name "Magic Colors (ver. 1.7a)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name mcolors.zip size 491840 crc d205b28c md5 257eec554ee8a9ecb9397ba45d61941f sha1 6df41db05d86d1be610f5e719c17d097d4075cfa )
-)
-
-game (
-	name "Missile Combat (Videotron bootleg, set 1)"
-	developer "bootleg (Videotron)"
-	rom ( name mcombat.zip size 10742 crc 92614c37 md5 8ce231a1b0ca1d7f9a9defb5053a63a3 sha1 e6511f17ae5134a43980d867367b10d53d8ad914 )
-)
-
-game (
-	name "Missile Combat (Videotron bootleg, set 2)"
-	developer "bootleg (Videotron)"
-	rom ( name mcombata.zip size 10718 crc ff9b53c9 md5 019539eaaef156efe240e17cc29b7943 sha1 52b7adf7012adc75c96f4c48164dcb277a0dab33 )
-)
-
-game (
 	name "Miss Mahjong Contest (Japan)"
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name mcontest.zip size 457455 crc 59bd1c87 md5 c2bdb2b9e538c4cf2bc194f09da48803 sha1 759391a06f96eb252102a2a5ebc30916622ccd09 )
-)
-
-game (
-	name "Derby Quiz My Dream Horse (Japan, MDH1/VER.A2)"
-	year "1998"
-	developer "Namco"
-	rom ( name mdhorse.zip size 24519092 crc 3c0977e0 md5 0fbd9f338637c89f7dba6752c1a39396 sha1 46dee58b579852d73406edf7a0bdc5e994bc31e3 )
-)
-
-game (
-	name "Draw Poker Joker's Wild (Standard)"
-	developer "Meyco Games"
-	rom ( name mdrawpkr.zip size 7441 crc a7097421 md5 e9189122a01a90501511091c47af14dd sha1 64cf9e717340d27f1e99b94eb6a5cee029dc629a )
-)
-
-game (
-	name "Draw Poker Joker's Wild (02-11)"
-	developer "Meyco Games"
-	rom ( name mdrawpkra.zip size 8681 crc c5024c46 md5 eb76dd88db3a7b1ac1638a7c21f5e87e sha1 a81e5e3fddc083a6e6d3ae1eb8e53898aa82cd52 )
-)
-
-game (
-	name "Magic Drink (Ver 1.2)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name mdrink.zip size 383957 crc f326f840 md5 679259104f7cc84bf1dbf6f7ec17a123 sha1 46139b3bd474ecd42be280e23b1622185d1cb89b )
 )
 
 game (
@@ -29911,13 +21969,6 @@ game (
 )
 
 game (
-	name "Megatouch 5 (9255-60-01 ROC, Standard version)"
-	year "1997"
-	developer "Merit"
-	rom ( name megat5a.zip size 1045652 crc 503a574a md5 6416428904faf7f0a8f8fc8d882265be sha1 bbdb7da6cbcb2ea7dd1ac3a79ccdf664b12ad94a )
-)
-
-game (
 	name "Megatouch 5 (9255-60-07 RON, New Jersey version)"
 	year "1998"
 	developer "Merit"
@@ -29995,58 +22046,9 @@ game (
 )
 
 game (
-	name "Melty Blood Act Cadenza Ver B (GDL-0039)"
-	year "2006"
-	developer "Ecole Software"
-	rom ( name meltyb.zip size 1196 crc 8cd3701d md5 5f08a3bec861b008df025783f00a4241 sha1 364a456b78f548d21bdbc0f52530849f88a7ae06 )
-)
-
-game (
-	name "Melty Blood Act Cadenza Ver B (Rev A) (GDL-0039A)"
-	year "2006"
-	developer "Ecole Software"
-	rom ( name meltyba.zip size 1196 crc 8cd3701d md5 5f08a3bec861b008df025783f00a4241 sha1 364a456b78f548d21bdbc0f52530849f88a7ae06 )
-)
-
-game (
-	name "Melty Blood Act Cadenza Ver A (Rev C) (GDL-0028C)"
-	year "2005"
-	developer "Ecole Software"
-	rom ( name meltybld.zip size 1197 crc 471ac9cb md5 d6dfc2b552809e1720f4e7e544e4ad70 sha1 2f3f7e3a98bcc47414014b1baca89966b6c4afba )
-)
-
-game (
 	name "Meosis Magic (Japan)"
 	developer "Sammy"
 	rom ( name meosism.zip size 4735058 crc 3eb94918 md5 e4a8aceac1eb17d1bb3437f77e722da2 sha1 585219022d93e66e04ef7e31bfbaecd885648656 )
-)
-
-game (
-	name "Mercs (World 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercs.zip size 1753910 crc 3da0b8bf md5 22c4897056f816bab7a01a4353b05a80 sha1 0469b59680031dd85710e31b2a9b0d4d46db836d )
-)
-
-game (
-	name "Senjou no Ookami II (Japan 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsj.zip size 1792753 crc 2dca37a8 md5 fe40b7d8cee3d94ab2dbdab85e6eb5eb sha1 8b7376e43b9706dfc4f0c04341c7aa0bcb483812 )
-)
-
-game (
-	name "Mercs (USA 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsu.zip size 1753902 crc a52879dd md5 4f202dcf2234f372a892253184d497be sha1 8de14207152b82b8476b6bb1440ac50c83c7c7c6 )
-)
-
-game (
-	name "Mercs (USA 900608)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsua.zip size 1757824 crc 86b2d0e1 md5 fa6a8c635590f0f8d955110f8926eabe sha1 4fb6542415435187f595c41ae5a22adf8f2caeae )
 )
 
 game (
@@ -30082,13 +22084,6 @@ game (
 	year "1991"
 	developer "Taito Corporation"
 	rom ( name metalbj.zip size 2487666 crc 097e8c76 md5 0ae959e13c875c51cae324e751d263fd sha1 3a7f3a60d4338b7c1647c0e202248cf05dcc1be3 )
-)
-
-game (
-	name "Metal Maniax (prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name metalmx.zip size 13188121 crc fb7e80c7 md5 bc81778def7e00e9846d955cb25aef72 sha1 f6ef2065540e0fabfed35b6353692cdcc093e22f )
 )
 
 game (
@@ -30141,27 +22136,6 @@ game (
 )
 
 game (
-	name "Metal Hawk"
-	year "1988"
-	developer "Namco"
-	rom ( name metlhawk.zip size 2050614 crc 173e2946 md5 003b8777ab0c53901ad590c4d1885999 sha1 9307a0f603b924e02b940ba0d2c1eebe009db4f6 )
-)
-
-game (
-	name "Metal Hawk (Japan)"
-	year "1988"
-	developer "Namco"
-	rom ( name metlhawkj.zip size 2050646 crc 584799cd md5 98fc296d746b0a087e0097b59b01aa38 sha1 d32fddad3bc9135128f2a82a89ada082d8be5c12 )
-)
-
-game (
-	name "Metal Saver"
-	year "1994"
-	developer "First Amusement"
-	rom ( name metlsavr.zip size 850810 crc 3f56d72d md5 7c1bd2cb4db4852bb20e413e62c9f29a sha1 4dd8f24d4a8209f8e652169b4b867bcb006c1a08 )
-)
-
-game (
 	name "Metamoqester (International)"
 	year "1995"
 	developer "Banpresto / Pandorabox"
@@ -30193,35 +22167,28 @@ game (
 	name "Astro Chase (Max-A-Flex)"
 	year "1982"
 	developer "Exidy / First Star Software"
-	rom ( name mf_achas.zip size 10090 crc 9e6a9ae1 md5 030e42204f40a398e57230c39178ba88 sha1 77a08897a81b8eeaaa8c1ed8894d756067a58d08 )
+	rom ( name mf_achas.zip size 23741 crc 0f867a9c md5 dcbaf281dcf355784664053ded22a623 sha1 2bdf2b5c722bbb7c8484622238e9c155439b4d24 )
 )
 
 game (
 	name "Boulder Dash (Max-A-Flex)"
 	year "1984"
 	developer "Exidy / First Star Software"
-	rom ( name mf_bdash.zip size 9407 crc 512337e3 md5 27a7eb9213ca457a47fd27ef615c5ba1 sha1 72b854e137f1b1a00f06a6e375c8bf66a07fa3a6 )
+	rom ( name mf_bdash.zip size 23058 crc f47560c9 md5 73b638328503b3ffd2cec24ea5556c61 sha1 e321eeecf2eebaf630a0362effe8a9fc22f32662 )
 )
 
 game (
 	name "Bristles (Max-A-Flex)"
 	year "1983"
 	developer "Exidy / First Star Software"
-	rom ( name mf_brist.zip size 11650 crc 654f5bbd md5 595db31a2a3d36e1ba13635b66c719a8 sha1 85f4183944100478bf4156acf97bb33d73a75c43 )
+	rom ( name mf_brist.zip size 25301 crc a462ed7a md5 5fd9a44d49d9b283ed76f579b820b221 sha1 b07fedc6152f64ee707984b6d2f931991c05bc8d )
 )
 
 game (
 	name "Flip _ Flop (Max-A-Flex)"
 	year "1983"
 	developer "Exidy / First Star Software"
-	rom ( name mf_flip.zip size 12410 crc d23d8909 md5 9278246ec1b5432d7487fd015bf42032 sha1 ccdaf9023325db2435dc86f3bbbd9b7ba1303256 )
-)
-
-game (
-	name "Mahjong Fight Club (ver JAD)"
-	year "2002"
-	developer "Konami"
-	rom ( name mfightc.zip size 1342 crc 40f10c27 md5 e1f9dfe4f762164ff5187deae5134f4b sha1 5a21603d720a2b080c5fd3a674de90c995b98101 )
+	rom ( name mf_flip.zip size 26061 crc f777f358 md5 fab6413a64116e520bb1fd1b2e1aa4b7 sha1 677c2c9e17f864e336c3d9615a4ce45344499591 )
 )
 
 game (
@@ -30270,7 +22237,7 @@ game (
 	name "Monster Farm Jump (Japan)"
 	year "2001"
 	developer "Tecmo"
-	rom ( name mfjump.zip size 3063397 crc b46ad4ea md5 46d36fa79c93ac4690911be2f5323aaa sha1 5374999e07eb4dfa8d8998d6cef9fe99451675c8 )
+	rom ( name mfjump.zip size 3201849 crc 35b485c2 md5 428c910ca90a6685cf8f27c27329c914 sha1 a3e803685891b73b52b8dcfa92bab53229aae603 )
 )
 
 game (
@@ -30298,14 +22265,14 @@ game (
 	name "Magical Date / Magical Date - dokidoki kokuhaku daisakusen (Ver 2.02J)"
 	year "1996"
 	developer "Taito"
-	rom ( name mgcldate.zip size 12554559 crc fe0dbcec md5 af6bfce34e29907bbd6fa4985ebeedd9 sha1 93306d609f22396e7d0676c6216d5db757bbe6a0 )
+	rom ( name mgcldate.zip size 12680697 crc 0ee43cd5 md5 f32b4b5dfd8edaed71167a4be44a62f9 sha1 ddc6c1f399749f5c009c8667a09ac0dd3ae73d36 )
 )
 
 game (
 	name "Magical Date EX / Magical Date - sotsugyou kokuhaku daisakusen (Ver 2.01J)"
 	year "1997"
 	developer "Taito"
-	rom ( name mgcldtex.zip size 13486293 crc cf4f24a2 md5 a1b62f5e4c02a15b3c9ccba7688f1cb3 sha1 3051c7c165f183fbb1e13a41f6b16d9b3e2ce52a )
+	rom ( name mgcldtex.zip size 13612431 crc 8871da0a md5 5dfbd9d7c0fe13739a251502d5be5368 sha1 ad19c9f00b5b34d1a3bf17ea7f5121d419cb1652 )
 )
 
 game (
@@ -30330,24 +22297,10 @@ game (
 )
 
 game (
-	name "Mahjong Man Guan Cai Shen (V103CS)"
-	year "1998"
-	developer "IGS"
-	rom ( name mgcs.zip size 1836185 crc e352f557 md5 c2db9f2101a29a885171111be6993c21 sha1 d656c949a8ffca569cc81949ca72edb5a9bd3bc3 )
-)
-
-game (
 	name "Mahjong Man Guan Da Heng (Taiwan, V123T1)"
 	year "1997"
 	developer "IGS"
 	rom ( name mgdh.zip size 1212088 crc 5237b7de md5 11e2d356221b1bc233527eaf578c2f9a sha1 40abc813272258bf933c44d63c5dc10ef3760493 )
-)
-
-game (
-	name "Man Guan Fu Xing"
-	year "2000"
-	developer "IGS"
-	rom ( name mgfx.zip size 2151851 crc b3f12e66 md5 6d31b0d697e1c4fef309d470e68cc90e sha1 21199e5f75aa06ae8fc7300a934f23ca6817bd29 )
 )
 
 game (
@@ -30365,38 +22318,17 @@ game (
 )
 
 game (
-	name "Atari Mini Golf (prototype)"
-	year "1978"
-	developer "Atari"
-	rom ( name mgolf.zip size 9303 crc 16c61cc3 md5 93f606f746c18bfbbe571a36d78a8ae8 sha1 4be72dcc0838ed57dafc0c3037defe8bb1015666 )
+	name "Magic Number"
+	year "1995"
+	developer "CD Express"
+	rom ( name mgnumber.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
-	name "Major Havoc (rev 3)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavoc.zip size 69696 crc 6a5cff34 md5 3bad435ebd898d1972a7670fde3896dc sha1 ab486e8b94235ec4973e64ea450262f859b02cb7 )
-)
-
-game (
-	name "Major Havoc (rev 2)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavoc2.zip size 69406 crc 6dcbd7e1 md5 00706eecdad778917aa5813e2020a292 sha1 1897ef74ce3a36dde44ceea9c795b312fb7d500b )
-)
-
-game (
-	name "Major Havoc (prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavocp.zip size 67100 crc 9641bda0 md5 8590d9f940ff714cd42b3dd587eea78c sha1 70e496458c99df44b950972edfab224f4d3da01f )
-)
-
-game (
-	name "Major Havoc (Return to Vax)"
-	year "1983"
-	developer "Atari / JMA"
-	rom ( name mhavocrv.zip size 71599 crc a0a29f12 md5 7f35d52b4ba2fbb39701303345615577 sha1 628792610d09e099c192bfc97e431c72c8f1ac70 )
+	name "Magic Premium (v1.1)"
+	year "1996"
+	developer "CD Express"
+	rom ( name mgprem11.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
 )
 
 game (
@@ -30431,13 +22363,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name miaj.zip size 537779 crc 64c0109c md5 4ab371d5cbce9a2558efae4653b2a7d8 sha1 9621afc59487e6c1fa1beb9449555baf2eea0e31 )
-)
-
-game (
-	name "Microman Battle Charge (J 990326 V1.000)"
-	year "1999"
-	developer "Sega"
-	rom ( name micrombc.zip size 3765026 crc 21254382 md5 c1f924896647c559f5e75204a82c1343 sha1 642fde77f337da6a46f9f4241bdb084e21aac783 )
 )
 
 game (
@@ -30479,14 +22404,7 @@ game (
 	name "Money Puzzle Exchanger / Money Idol Exchanger"
 	year "1997"
 	developer "Face"
-	rom ( name miexchng.zip size 5344083 crc 726152ba md5 990f321dd12990316e5b445e259a4475 sha1 1dd8e88157f339a68fd49551292c201195fdac98 )
-)
-
-game (
-	name "Mighty Guy"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name mightguy.zip size 119652 crc 887991bb md5 308f57ec25d5f12d03af515e403e7e5e sha1 0e251c40625633b77855795ad3fb91eeffb5c22d )
+	rom ( name miexchng.zip size 6690770 crc 124c896d md5 4edb89cb395fd81eac8e2c84809dd8ec sha1 e7983dfe3e524e43293bdc6ba75391526697dda4 )
 )
 
 game (
@@ -30518,34 +22436,6 @@ game (
 )
 
 game (
-	name "Millennium Nuovo 4000 (Version 2.0)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000.zip size 655497 crc aff65f57 md5 ac50ed89ad19d0fce89707d9983a823c sha1 caaeacfb710570b24d3806a540f1c97094f863f9 )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.8)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000a.zip size 655363 crc 8262740d md5 8148c3374b8f5b3f576e1744e673b2f2 sha1 811ec4f784315c782484ba424e90eb26fb8abd88 )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.5)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000b.zip size 654300 crc af9141a6 md5 6071dc12b62e64cc4f1b7509edce4f56 sha1 fa027d450fc18cba55495e3b0ba79c621976c9d5 )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.6)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000c.zip size 653618 crc d3a8aad5 md5 f9c85fda37f80def9d40700d14978f6c sha1 93c9a7bb7f0de5835a563eb4e803d9f34cbe1ab7 )
-)
-
-game (
 	name "Millipede Dux (hack)"
 	year "1982"
 	developer "hack"
@@ -30564,12 +22454,6 @@ game (
 	year "1980"
 	developer "bootleg? (Valadon Automation)"
 	rom ( name millpac.zip size 10269 crc de0319f2 md5 7c95b0f647dee7dc68a1e061b0ec482c sha1 f4f171e3b0d23f08779220f4b3d8386baafbe4ae )
-)
-
-game (
-	name "Millennium Sun"
-	developer "&lt;unknown&gt;"
-	rom ( name millsun.zip size 303530 crc 7b47dd03 md5 b2325883340b911f301c1dd8c0102a5a sha1 667b310c3f47f11a2033725256657e619ed60473 )
 )
 
 game (
@@ -30597,7 +22481,7 @@ game (
 	name "Minnasanno Okagesamadesu"
 	year "1990"
 	developer "Monolith Corp."
-	rom ( name minasan.zip size 2070320 crc 2f772145 md5 9a5804731b7b90c37c92ac862e14ab2d sha1 f375a6265b9b7c8d921375cce3245fb529d7e7b6 )
+	rom ( name minasan.zip size 3417007 crc 67fc0aa5 md5 e07be3d998060d679ac0266beaf16eee sha1 c32242273a8d600af5911644a74fe63bdeb683b8 )
 )
 
 game (
@@ -30622,34 +22506,6 @@ game (
 )
 
 game (
-	name "Inferno (Meadows)"
-	year "1978"
-	developer "Meadows"
-	rom ( name minferno.zip size 3689 crc e5f179b6 md5 4b6af272086a57ce3f3d8c6af291593d sha1 a114e8235dfdb06a9949b781ef649528419afd72 )
-)
-
-game (
-	name "Mini Boy 7"
-	year "1983"
-	developer "Bonanza Enterprises, Ltd"
-	rom ( name miniboy7.zip size 33431 crc ddc9b884 md5 bac8d6760f4ee3ba295e3968758401b1 sha1 5422dabfb50c90260d046f3ab5ffd769dc6e070c )
-)
-
-game (
-	name "Mini Golf (set 1)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name minigolf.zip size 60514 crc b1da511b md5 7c8582d62938519caf847b33bd31c4ef sha1 afbef1502b724bb8e576e5c2e7962a3a8ffecc11 )
-)
-
-game (
-	name "Mini Golf (set 2)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name minigolf2.zip size 62036 crc 79d024b7 md5 b1694480f920d4b85c52e3c61e427150 sha1 298021141fd3a9f31d799aba3f0be7d1fa886512 )
-)
-
-game (
 	name "Minivader"
 	year "1990"
 	developer "Taito Corporation"
@@ -30664,45 +22520,10 @@ game (
 )
 
 game (
-	name "Mirax"
-	year "1985"
-	developer "Current Technologies"
-	rom ( name mirax.zip size 85342 crc 16e9b160 md5 927d7cd8840379806d0feb643dcdf92c sha1 b58ad044f1282b267eb9d4e8d1efc8c371adda46 )
-)
-
-game (
-	name "Mirax (set 2)"
-	year "1985"
-	developer "Current Technologies"
-	rom ( name miraxa.zip size 85410 crc 29970667 md5 fb2f3c0b89fb470023034497d0557f01 sha1 93d7aede9da4f51145beda9b2477434f6ce15496 )
-)
-
-game (
-	name "Miracle Derby - Ascot"
-	year "1988"
-	developer "Home Data?"
-	rom ( name mirderby.zip size 102668 crc 4198fb26 md5 074e54e37a96dc93568927e689b99d04 sha1 00e20d642bfeae60afb0341cacd45eac2ee8d6d7 )
-)
-
-game (
 	name "Mirai Ninja (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name mirninja.zip size 1556575 crc 0f0726b0 md5 788744993e6924cb2af8ffedac8ba1ff sha1 0f4be16f197d957563c91f61e6ac575d6d949c49 )
-)
-
-game (
-	name "Mission Craft (version 2.4)"
-	year "2000"
-	developer "Sun"
-	rom ( name misncrft.zip size 5914155 crc 4977204d md5 a222d02a867b259f4d088b82ccda7f17 sha1 0a024dc11577a11fa1e8ec4c47ca9f5c18d190f3 )
-)
-
-game (
-	name "Miss Bubble II"
-	year "1996"
-	developer "Alpha Co."
-	rom ( name missb2.zip size 1567164 crc 52abf6c0 md5 a04888d98fd5217f3e8142c56b1a0eb8 sha1 b863ff9ed73cc2b3934bc1665bfc4aaf9c376a2e )
 )
 
 game (
@@ -31117,13 +22938,6 @@ game (
 )
 
 game (
-	name "Mahjong Senka (Japan)"
-	year "1986"
-	developer "Visco"
-	rom ( name mjsenka.zip size 27896 crc 23c01fc1 md5 b3ae8415afc9b703999db9002be162b2 sha1 6a649618173d3f3d4c6fea50e0525fe64f743ad6 )
-)
-
-game (
 	name "Mahjong Shikaku (Japan 880722)"
 	year "1988"
 	developer "Nichibutsu"
@@ -31159,20 +22973,6 @@ game (
 )
 
 game (
-	name "Mahjong Shiyou (Japan)"
-	year "1986"
-	developer "Visco"
-	rom ( name mjsiyoub.zip size 64637 crc b9118c14 md5 98b87a111c38bcace6abe5d115cd74c4 sha1 9ee47cdfa30088e67b36ce8a2f2ac71448a931fe )
-)
-
-game (
-	name "Mahjong Tensinhai (Japan)"
-	year "1995"
-	developer "Dynax"
-	rom ( name mjtensin.zip size 600261 crc bc34837c md5 a82d5d5474a7fe5e380e53be83aac381 sha1 85f98be24e1f0b60a0b611cc42aea15a45e0fab6 )
-)
-
-game (
 	name "Mahjong Uranai Densetsu (Japan)"
 	year "1992"
 	developer "Nichibutsu/Yubis"
@@ -31180,24 +22980,10 @@ game (
 )
 
 game (
-	name "Mahjong Vegas (Japan)"
-	year "1991"
-	developer "Dynax"
-	rom ( name mjvegas.zip size 314835 crc 2ab3dd5e md5 26c349ec720d740bc6b859f0dc9db99c sha1 097b495a3fe5edb3c0aabc40736c5ffaaad0fd56 )
-)
-
-game (
 	name "Mahjong Vegas (Japan, unprotected)"
 	year "1991"
 	developer "Dynax"
 	rom ( name mjvegasa.zip size 315105 crc b9ae49f2 md5 ef11ab5707c121917e8f9329c5694d3e sha1 c6fece15ddc3721f6d07f11fadcc6d5dab3ac575 )
-)
-
-game (
-	name "Mahjong Yarou [BET] (Japan)"
-	year "1986"
-	developer "Visco / Video System"
-	rom ( name mjyarou.zip size 26298 crc afa6e657 md5 377d39a58bc5569e9127d777a07769dd sha1 a36afdd3e3b55be4932479ee370fe91534db5a33 )
 )
 
 game (
@@ -31219,13 +23005,6 @@ game (
 	year "1990"
 	developer "Visco"
 	rom ( name mjyuugia.zip size 1756152 crc 11e824eb md5 14c280179fa06f9770c64324d7c7962b sha1 7e9e746b9398b08dfae82deac076b2f17ce43949 )
-)
-
-game (
-	name "Mahjong Channel Zoom In (Japan)"
-	year "1990"
-	developer "Jaleco"
-	rom ( name mjzoomin.zip size 724176 crc 476c5b8a md5 dcc07435c4a5d90c32389f81b898d796 sha1 7232c3cfe65822e9eb02419c0727990be979eee7 )
 )
 
 game (
@@ -31348,13 +23127,6 @@ game (
 )
 
 game (
-	name "Mortal Kombat 4 (version 1.0)"
-	year "1997"
-	developer "Midway"
-	rom ( name mk4b.zip size 18079555 crc 6022388a md5 61177606fb91a171dcde19d80e090249 sha1 aaaa7df74ee869c39a85f99564e72152336e59ad )
-)
-
-game (
 	name "Mahjong Keibaou (Japan)"
 	year "1993"
 	developer "Nichibutsu"
@@ -31450,13 +23222,6 @@ game (
 	year "1980"
 	developer "bootleg (Leisure Time Electronics)"
 	rom ( name mlander.zip size 9637 crc 1862f2dc md5 9f7a3f140f3bd3fa6f4a3d9fadf50390 sha1 f34b0e3c5f303b04f35f1c447bd95806fa329c48 )
-)
-
-game (
-	name "Midnight Landing (Germany)"
-	year "1987"
-	developer "Taito America Corporation"
-	rom ( name mlanding.zip size 341578 crc 874f2c20 md5 956d1b93acb17f41ad3987031dac72d3 sha1 cd1fd7c333ba432dec777b512170162d4aa87eef )
 )
 
 game (
@@ -31558,56 +23323,10 @@ game (
 )
 
 game (
-	name "Mystery Number"
-	developer "M.M. - B.R.L."
-	rom ( name mnumber.zip size 501068 crc c09d09f6 md5 64e58090d7abe777b41823dbc38b3782 sha1 754f383b1ff63e3b6fd84d2cdc474abd23aa585f )
-)
-
-game (
-	name "Magic Number (Italian Gambling Game, Ver 1.5)"
-	developer "&lt;unknown&gt;"
-	rom ( name mnumitg.zip size 384211 crc 76a5e7d7 md5 c08400b678c6829db4a1f2c820400364 sha1 b6dfda713883ae0139084bd6a48e62e3ed149400 )
-)
-
-game (
-	name "Mocap Boxing (ver AAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapb.zip size 1239 crc 45f0deff md5 bd3379b38614073a1fdd7bbf3889bea2 sha1 5447a8271a1b0a9acc7e35b2b70961fdb08e7e5b )
-)
-
-game (
-	name "Mocap Boxing (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapbj.zip size 1297 crc 61c6e91f md5 7c7467defbae45746b5c5e1e66534dfd sha1 d3b6d47efb68ffcb3d63595010ea18f77aed4087 )
-)
-
-game (
-	name "Mocap Golf (ver UAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapglf.zip size 3336 crc cc129ab9 md5 c842ccda696462adb8c6a70add696b13 sha1 f620baed42ec524d42e0b7cb878636effb3a2628 )
-)
-
-game (
-	name "unknown Model Racing gun game"
-	developer "Model Racing"
-	rom ( name modelr.zip size 6407 crc ed13fa62 md5 b9f9ca0a528fd5b900b104e6a384d547 sha1 6190f0876d9068a06804b0cdf6e6cb3bfbc28ad0 )
-)
-
-game (
 	name "Moeyo Gonta!! (Japan)"
 	year "1993"
 	developer "Yanyaka"
 	rom ( name moegonta.zip size 1450182 crc 7654930f md5 d84ccec7ba2523e97fc307585420aa73 sha1 2dde5b94ad9615b36297c4aeaa84d0b8b41d7773 )
-)
-
-game (
-	name "Moeru Casinyo (GDL-0013)"
-	year "2002"
-	developer "Altron"
-	rom ( name moeru.zip size 1195 crc 85f2648f md5 3d1ae20b653c95fe3df4f92969eb4af4 sha1 16cc6b13c0ad8f51989668770cb16909b2bfe2b0 )
 )
 
 game (
@@ -31618,24 +23337,10 @@ game (
 )
 
 game (
-	name "Moguchan"
-	year "1982"
-	developer "Orca (Eastern Commerce Inc. license) (bootleg?)"
-	rom ( name moguchan.zip size 17716 crc 1be2f278 md5 c6def5047f542455a61147117da1a38a sha1 3743c8488eac6bf51ebb70d31aaeec468a6fde70 )
-)
-
-game (
 	name "Mogura Desse (Japan)"
 	year "1991"
 	developer "Konami"
 	rom ( name mogura.zip size 7515 crc 74299875 md5 e7ca2672f954b3028b2cd9a5a7ab4d57 sha1 3ca566077fda85dfacafbb9d26b11b6054493b66 )
-)
-
-game (
-	name "The Maze of the Kings (GDS-0022)"
-	year "2002"
-	developer "Sega"
-	rom ( name mok.zip size 1198 crc 646799c1 md5 59900bba3bf81e6666afb61f0aba0726 sha1 998ef878245eb869e7d0cb3937889774409ce96f )
 )
 
 game (
@@ -31650,12 +23355,6 @@ game (
 	year "1986"
 	developer "Jaleco"
 	rom ( name momoko.zip size 121845 crc 5e14b6f3 md5 af885abcdc8b940210008c535a933338 sha1 826b7ba43be62deb6d8a0b6e091918a87aa6b26d )
-)
-
-game (
-	name "Money In The Bank (NSW)"
-	developer "Konami"
-	rom ( name moneybnk.zip size 1387862 crc b37bc71c md5 8abc79406d4e106344c87ac3a04a68db sha1 4a8aeabc4244f78fcc8c3ebd8ec6b19425a8e1d8 )
 )
 
 game (
@@ -31694,33 +23393,6 @@ game (
 )
 
 game (
-	name "Mongolfier New (Italian)"
-	developer "bootleg"
-	rom ( name mongolnw.zip size 52179 crc 98f8153e md5 ab92854a0abf47c41e2cbd17e981b96e sha1 ff0d7210d90713ca859caa211a765556ca5a34b6 )
-)
-
-game (
-	name "Monky Elf (Korean bootleg of Avenging Spirit)"
-	year "1990"
-	developer "bootleg"
-	rom ( name monkelf.zip size 1060195 crc 1d87a3ce md5 0896d88fc6537f26aea720f291b2f2a2 sha1 2429ff3eb58f37436ce191ddc234e739138f295a )
-)
-
-game (
-	name "Monkey Ball (GDS-0008)"
-	year "2001"
-	developer "Sega"
-	rom ( name monkeyba.zip size 1194 crc 6d181b13 md5 496a0552cfa67c4e6f989dd712dc8d7d sha1 348a6df95446f47e8364ba38fe03e1b7b268d23c )
-)
-
-game (
-	name "Monkey Donkey"
-	year "1981"
-	developer "bootleg"
-	rom ( name monkeyd.zip size 30655 crc 8c56ee21 md5 361738afdd314a007a81a9717fb1ab89 sha1 a5f8388938bcc1fd8194e04137228fa80d04dfa2 )
-)
-
-game (
 	name "Monopoly Classic"
 	year "1995"
 	developer "JPM"
@@ -31756,13 +23428,6 @@ game (
 )
 
 game (
-	name "Monster Zero"
-	year "1982"
-	developer "Nihon Game"
-	rom ( name monsterz.zip size 35212 crc e5f667d9 md5 c38128581bdf9720318651d163f3ff11 sha1 6200ad422658d81cb594dcc7347f7e3c96cc7cf7 )
-)
-
-game (
 	name "Monte Carlo"
 	year "1979"
 	developer "Atari"
@@ -31777,13 +23442,6 @@ game (
 )
 
 game (
-	name "Monza GP"
-	year "1981"
-	developer "Olympia"
-	rom ( name monzagp.zip size 9938 crc 81ccd857 md5 f954c013b6e2906477931c687043b527 sha1 535993d7474aca7fa2b79d77e8b08726a5b40cb7 )
-)
-
-game (
 	name "Wild West C.O.W.-Boys of Moo Mesa (ver EA)"
 	year "1992"
 	developer "Konami"
@@ -31795,13 +23453,6 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name mooaa.zip size 4613733 crc 316e0792 md5 4070f60bfca7066f5f260ab525d000e8 sha1 1c90223948f5662e947482ffbd8bb14b2e37a910 )
-)
-
-game (
-	name "Wild West C.O.W.-Boys of Moo Mesa (bootleg ver AA)"
-	year "1992"
-	developer "bootleg"
-	rom ( name moobl.zip size 3575723 crc 93e04be6 md5 ebe0207ded150a7fb00c35e96faeaa56 sha1 96163e698ba2cb371ac6d55da6c3b43954470367 )
 )
 
 game (
@@ -31950,20 +23601,6 @@ game (
 )
 
 game (
-	name "More More"
-	year "1999"
-	developer "SemiCom / Exit"
-	rom ( name moremore.zip size 938135 crc ed54ea8e md5 b4d531f29da7a36e72d25884afbc0831 sha1 74cd327bc3569bd7a3502bc87999fffbf8bd6cf6 )
-)
-
-game (
-	name "More More Plus"
-	year "1999"
-	developer "SemiCom / Exit"
-	rom ( name moremorp.zip size 910432 crc 84090157 md5 14f341ac6f8b6a21feeb907e1ad03009 sha1 b53073ddbf9a87093467aedc2e2e37746b737b94 )
-)
-
-game (
 	name "Mosaic"
 	year "1990"
 	developer "Space"
@@ -31988,35 +23625,7 @@ game (
 	name "Syougi No Tatsujin - Master of Syougi"
 	year "1995"
 	developer "ADK / SNK"
-	rom ( name mosyougi.zip size 3728200 crc b7f9af9f md5 d5b1441c4965b84da2249b674a71dabb sha1 2ac1960317ca64afbdba109f0253e38b6c58c46a )
-)
-
-game (
-	name "Moto Frenzy"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofren.zip size 5694483 crc 0e2cd4ac md5 a139c06ed00f0bb0238664cb72811562 sha1 58589f2ffa995e31a0fb49bcffc7cbf9240c1597 )
-)
-
-game (
-	name "Moto Frenzy (Field Test Version)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenft.zip size 5695488 crc 78d01bb2 md5 1c48f95836805dcc27d760be033b9194 sha1 c6f4e2026abbf9bffa95d3b48e6c9e263b2c7b76 )
-)
-
-game (
-	name "Moto Frenzy (Mini Deluxe)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenmd.zip size 5697716 crc 4fb35ae7 md5 0069ffccc493148e583d2a61343468ef sha1 5cdaecaba361f160862e92be0b05d644736467d3 )
-)
-
-game (
-	name "Moto Frenzy (Mini Deluxe Field Test Version)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenmf.zip size 5699467 crc 396a6150 md5 773e2e79c77ea42981b953b0ea8ef657 sha1 0789718f41acdc31cec881272126fbf32a5cb343 )
+	rom ( name mosyougi.zip size 5074887 crc 71f7e128 md5 466a6d9eb6041f9b45b213c552c7c200 sha1 1ecfa72ab7a97aba690f6adaa6735989d4504aa6 )
 )
 
 game (
@@ -32027,24 +23636,10 @@ game (
 )
 
 game (
-	name "Motoraid"
-	year "1995"
-	developer "Sega"
-	rom ( name motoraid.zip size 32680675 crc 6a7f8d8b md5 c78e789f2e8549ed01c443f371f72e69 sha1 1bc90088653b91109912ff59b2615faed4cadcb5 )
-)
-
-game (
 	name "Motos"
 	year "1985"
 	developer "Namco"
 	rom ( name motos.zip size 39030 crc ffe7ad59 md5 b81ff43f7182873988b85f53733fc27c sha1 7498a168d5e6e5b0185219bf3b8ad8fe7d4cfba3 )
-)
-
-game (
-	name "Motocross Go! (MG3 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name motoxgo.zip size 45107025 crc 70e2974b md5 48373e105173778135544bf5b7e845da sha1 0e6de94526eb1ff72720d437a3a131b2c824f703 )
 )
 
 game (
@@ -32079,70 +23674,70 @@ game (
 	name "Bio-hazard Battle (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_bio.zip size 593040 crc 58228310 md5 01fa17d89d06a3ac01f718d8494df229 sha1 ff27d438e801bf5a438db79e9bb9584bc8cec159 )
+	rom ( name mp_bio.zip size 642996 crc e6785521 md5 0be30dab44570a3b6bb735d301b0d525 sha1 6e0fc46f100e437e9216053ced63b39504c25b66 )
 )
 
 game (
 	name "Columns III (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_col3.zip size 260312 crc 6b617341 md5 ab80953e8756e6299348ce05b919b674 sha1 ff6846b27a8f630bad00aec72df1e5ffe179d116 )
+	rom ( name mp_col3.zip size 310268 crc 5f692f20 md5 9c133e25c3eedc2703519c6f2cbce47e sha1 0be9cd5e61acbdae5066e4160d5b388cb99be0d6 )
 )
 
 game (
 	name "Golden Axe II (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_gaxe2.zip size 353251 crc 9fc0bb0d md5 d1bc8d7825786277ce6b74fe1bc3c11f sha1 c25b6c21d7a2a2fd9f2d179cb01521ac43673158 )
+	rom ( name mp_gaxe2.zip size 403207 crc d3a4b0cc md5 858c28a151f815529cc67f293182756e sha1 7528853d21e356fbbbcbbff8ea733be1486a893c )
 )
 
 game (
 	name "Grand Slam (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_gslam.zip size 225720 crc d07cb2d2 md5 382c33d2596f3b4c8822bff78240211d sha1 ccd89ad6a0497c5735f3140f3308facd36466989 )
+	rom ( name mp_gslam.zip size 275676 crc 59439c59 md5 3de3cb377a28b1865314f29804553bf9 sha1 124bd88cc080d293962a1bc316c785d166d58342 )
 )
 
 game (
 	name "Mazin Wars / Mazin Saga (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_mazin.zip size 716190 crc 9da91302 md5 91f05567c7ab40ff36f4317077a6862c sha1 6c133a4f835cf1fbfab760ea89316db426e9dbaa )
+	rom ( name mp_mazin.zip size 766146 crc 39c50483 md5 97f1dbf76c43f415ef1b725bcca32587 sha1 85d4714c93f6acb6b8701f39338dd767fa87eae5 )
 )
 
 game (
 	name "Shinobi III (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_shnb3.zip size 661012 crc 657f504c md5 d7e91b53d0e94e746d9307c1cc367400 sha1 bceb6aae1c5f1536278700c2a3bbd9826a2ecf7b )
+	rom ( name mp_shnb3.zip size 710968 crc 6199982a md5 ff972b01df738deb4dd85bce5ba4bb8b sha1 e020482fb3b0f55ebd0f02c541d961340107500a )
 )
 
 game (
 	name "Sonic The Hedgehog 2 (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_soni2.zip size 763848 crc 3f8eaded md5 2360c0a66ba5ce46d77b2a9e2c964ca5 sha1 dde6d7af015dac7eaf0027a7f141927ecb8e91ba )
+	rom ( name mp_soni2.zip size 813804 crc d44aaa95 md5 838c425e70d2c7ae7a3ff5914efb8d3e sha1 8d99b896ad4e3ed5521bc3f8c6f3047482110d5c )
 )
 
 game (
 	name "Sonic The Hedgehog (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_sonic.zip size 409313 crc 06d16bf2 md5 15e6310db99279f8a2a5f4e6890ac1ed sha1 2724c8ef660ae2476baf4f133a69b3d6207f70cb )
+	rom ( name mp_sonic.zip size 459269 crc 007ba976 md5 ed81127015fed7904bed28d5360ae085 sha1 b7a7575845ad275c21b9080833ff6a1746dd30b6 )
 )
 
 game (
 	name "Streets of Rage II (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_sor2.zip size 1060213 crc a0c06d3c md5 66da6c7be339343106404362dba2e2c1 sha1 305dfbf8c68cd013a46f89cc63aec95616f86248 )
+	rom ( name mp_sor2.zip size 1110169 crc aacd4cbf md5 9e6fd355c28c8ef7a6f9f1c879f3b424 sha1 8bc4716650cecd1cfe2bfb4ad1ac54aa66357783 )
 )
 
 game (
 	name "Tecmo World Cup (Mega Play)"
 	year "1993"
 	developer "Sega"
-	rom ( name mp_twc.zip size 175501 crc 147ed384 md5 84bd9b3f5c09f704bb83b3937289e2ee sha1 882e67350eb812616f17807a25ac67c928218ea6 )
+	rom ( name mp_twc.zip size 225457 crc 586fb359 md5 3bb6d556d5f61c74bbad8731e984f524 sha1 29f503325f173d139fad88e0584ab00934b1658f )
 )
 
 game (
@@ -32202,13 +23797,6 @@ game (
 )
 
 game (
-	name "Multi-Poker"
-	year "1981"
-	developer "Merit Industries"
-	rom ( name mpoker.zip size 11913 crc 6f7dc405 md5 e78cff135d54ee1d38c76e9244699394 sha1 18397eda2729958e9505cc7cd85f1f9e86032eb8 )
-)
-
-game (
 	name "MPU4 Meter Clear ROM"
 	developer "Barcrest"
 	rom ( name mpu4met0.zip size 13579 crc b541da20 md5 d58236ad63010d0b9594d76e8f9d26fe sha1 07aee4aaebcb6f2d71270ed88018e97e95771a8a )
@@ -32224,13 +23812,6 @@ game (
 	name "MPU4 Unit Test (Program 4)"
 	developer "Barcrest"
 	rom ( name mpu4utst.zip size 6031 crc e72c175f md5 3b007cf7a2cb1e75b85493ade741661c sha1 7fe2036e677164d1f16bce664100c24436ca40db )
-)
-
-game (
-	name "Moonquake"
-	year "1987"
-	developer "Sente"
-	rom ( name mquake.zip size 1021019 crc 336be105 md5 9686320eccb222e99618210d578d6555 sha1 47a6ff6ac1982ed0198559d993d680b4788a7781 )
 )
 
 game (
@@ -32276,27 +23857,6 @@ game (
 )
 
 game (
-	name "Mr. Driller 2 (Japan, DR21 Ver.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name mrdrilr2.zip size 31210626 crc 7d2e320c md5 4af1caa848aa07505f5fbb1a0cbc7960 sha1 969685313700cb086399ada82d58d8c4cc9c0992 )
-)
-
-game (
-	name "Mr. Driller G (Japan, DRG1 Ver.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name mrdrilrg.zip size 37838847 crc 4ab9fd54 md5 83cd5455638433a114ed0630f2c4cc56 sha1 cb7433443815fb2877aed1f2db4dd2d9faefd1f2 )
-)
-
-game (
-	name "Mr. Driller 2 (Japan, DR22 Ver.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name mrdrlr2a.zip size 31210399 crc f6419fc3 md5 918c4982e6984a0c4ea570e80d7cdc1a sha1 17a1e25e4778f4ef27f3b449d9988ea9b22ea56a )
-)
-
-game (
 	name "Mr. Du!"
 	year "1982"
 	developer "bootleg"
@@ -32318,24 +23878,10 @@ game (
 )
 
 game (
-	name "Mr. HELI no Dai-Bouken"
-	year "1987"
-	developer "Irem"
-	rom ( name mrheli.zip size 625581 crc 44663616 md5 e8d10aded2b145dff60b25398d3fd908 sha1 c9cd5151f463ae34a7a30580d4b035ce4823b3eb )
-)
-
-game (
 	name "Mr. Jong (Japan)"
 	year "1983"
 	developer "Kiwako"
 	rom ( name mrjong.zip size 24673 crc 996eaa41 md5 27ef2b8bc4bf02b99550954719996191 sha1 6c7cf7338883d750b223381880bf5827d2f49f87 )
-)
-
-game (
-	name "Mr. Kicker"
-	year "2001"
-	developer "SemiCom"
-	rom ( name mrkicker.zip size 1967477 crc 9080655a md5 54f32221ad66d3a0da9ba35efcf84451 sha1 e792968ffb7a8b91b478ae55ae0972fb111f3584 )
 )
 
 game (
@@ -32405,21 +23951,14 @@ game (
 	name "Metal Slug 4 Plus (bootleg)"
 	year "2002"
 	developer "bootleg"
-	rom ( name ms4plus.zip size 63414073 crc 9a5bd0b3 md5 bed9fa9c987bd523fe4c47fee4fb914f sha1 efa1387cd7adfca180e6a8256118246b52033fd5 )
-)
-
-game (
-	name "Metal Slug 5 (JAMMA PCB)"
-	year "2003"
-	developer "SNK Playmore"
-	rom ( name ms5pcb.zip size 74422925 crc 240bc4e3 md5 ff8c79658fd8d053b4459c7bbcaefa38 sha1 fdb1ce09477ff87f4c9038ade386d0ede8ddcf5b )
+	rom ( name ms4plus.zip size 64760760 crc cc4e5311 md5 1cab72e3d96c2ec3dacdf8a10b3964be sha1 f4f49469898a763413d04d4ed56829d22978db87 )
 )
 
 game (
 	name "Metal Slug 5 Plus (bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name ms5plus.zip size 80548077 crc 4fedb623 md5 bed66e83127e828dd48de82cd03bb55e sha1 5f8579badea16d38bfb1ce85bff8da50ffc91194 )
+	rom ( name ms5plus.zip size 81894764 crc 884e70b2 md5 c6e683741f22e4df4e673682594a373a sha1 5567c921740dcdb95f777b410a82012ef1770016 )
 )
 
 game (
@@ -32626,13 +24165,6 @@ game (
 )
 
 game (
-	name "Metal Soldier Isaac II"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name msisaac.zip size 72622 crc 25eaeca0 md5 8c0a9d26d01dfd816d2abdd9c2d1d940 sha1 c1afcca42afa1b186dc6da4d254f10f17b3b4421 )
-)
-
-game (
 	name "Mahjong Satsujin Jiken (Japan 881017)"
 	year "1988"
 	developer "Nichibutsu"
@@ -32650,70 +24182,70 @@ game (
 	name "Metal Slug - Super Vehicle-001"
 	year "1996"
 	developer "Nazca"
-	rom ( name mslug.zip size 13165430 crc 34254c4a md5 c84b70c587d9729ffc4cfb0f3a0862ce sha1 b613f572e8d3cf252fd7a025e71ffd33f8207425 )
+	rom ( name mslug.zip size 14512117 crc 5a56a45d md5 a375e11db56e5e96ef58679177b31a14 sha1 0fe3bed8d5b78ad649643a31e0f664641ebe514f )
 )
 
 game (
 	name "Metal Slug 2 - Super Vehicle-001/II"
 	year "1998"
 	developer "SNK"
-	rom ( name mslug2.zip size 17473911 crc 8239fa08 md5 7eb26f833f4762e68633fe2d92712b64 sha1 4f229f875d88c83228635a2fc8f3bc85598e963f )
+	rom ( name mslug2.zip size 18820598 crc ec8cc01b md5 4615c5c9b883fab10b0a4d79ca7ce3af sha1 99884c4d296d4ddb84f9099e23b16d6d22b048ad )
 )
 
 game (
 	name "Metal Slug 3"
 	year "2000"
 	developer "SNK"
-	rom ( name mslug3.zip size 80456874 crc 750759fb md5 e94b551ed54754003066c9d834d7a3ca sha1 7351ebf5f571699e0c6ebfc7ad5446e176d93c22 )
+	rom ( name mslug3.zip size 81803561 crc c33c9582 md5 ebca3ee4be74721fcc997ab69a8a9ad3 sha1 c7d37f692745cd1f790023ace1e73253bcba204a )
 )
 
 game (
 	name "Metal Slug 6 (Metal Slug 3 bootleg)"
 	year "2000"
 	developer "bootleg"
-	rom ( name mslug3b6.zip size 79895224 crc aca39c83 md5 e98044fcfc70fd10dfb8fdf1b7e6d6f5 sha1 7ae978866429196cc8ee706723295804ff2e80be )
+	rom ( name mslug3b6.zip size 81241911 crc 6253dd42 md5 5f786df97a50479574dd7269418d9741 sha1 b4e194cd38ae6f87903654d2a66e98e97c6ab7ce )
 )
 
 game (
 	name "Metal Slug 3 (not encrypted)"
 	year "2000"
 	developer "SNK"
-	rom ( name mslug3h.zip size 79444306 crc 4460c41e md5 d13ff0b69ea7339bdb92bd4bc89de38a sha1 f8ead21d1ab3153bbfb54d625d86c23fa954223e )
+	rom ( name mslug3h.zip size 80790993 crc a5664275 md5 d481c1ef04f2bda7e0d7d7bfa95a5d11 sha1 1247129aa43d1bfd6abf53d79053e63cb940223b )
 )
 
 game (
 	name "Metal Slug 4 (set 1)"
 	year "2002"
 	developer "Mega / Playmore"
-	rom ( name mslug4.zip size 63381512 crc bda88d74 md5 b45d0ecee41ab84263c3841600a0ed8c sha1 26ab86592ea0f6ac008b31aa8e660a92abcfbf80 )
+	rom ( name mslug4.zip size 64728199 crc 3b8e205c md5 7dab1fa6c0783d88f84fa6cb3a90b931 sha1 17394d0f52eeac7df27d48302558289072910606 )
 )
 
 game (
 	name "Metal Slug 4 (set 2)"
 	year "2002"
 	developer "Mega / Playmore"
-	rom ( name mslug4h.zip size 63390203 crc d57216f6 md5 d1d7960a9463315c5d2f15322566512b sha1 be859be9274aa3740789b4d480a69c2304dfb1fe )
+	rom ( name mslug4h.zip size 64736890 crc 8869b744 md5 2725482427422f8537325d8eabc2fdcd sha1 92b58df89863adb4437e48c74091bd9318020bfa )
 )
 
 game (
 	name "Metal Slug 5"
 	year "2003"
 	developer "SNK Playmore"
-	rom ( name mslug5.zip size 81157405 crc b36c4be3 md5 59d4090493b1640236fbe0b0130104df sha1 9969af23709cccf20ad1aa44f1f5c9a06f12debe )
+	rom ( name mslug5.zip size 82504092 crc 9a564b92 md5 0c85ebbaf619c301fefecd3e437709a8 sha1 16bc21005734cf30990cc0fdb6ba58e2a7960f7c )
 )
 
 game (
 	name "Metal Slug 5 (AES Cart)"
 	year "2003"
 	developer "SNK Playmore"
-	rom ( name mslug5h.zip size 81157358 crc 09a690a8 md5 cee5cabc3a2b76c252a7fb306b0e7859 sha1 fd66b2bc0557493e6d6aa2001221ba634d508b8d )
+	rom ( name mslug5h.zip size 82504045 crc a76839ad md5 21f2009e865448c309138a3a23959ed9 sha1 76c8bcb47cb15b9b87c8d4ba2b8c79299a87985b )
 )
 
 game (
 	name "Metal Slug X - Super Vehicle-001"
 	year "1999"
 	developer "SNK"
-	rom ( name mslugx.zip size 28493682 crc ca11e905 md5 7c2183aa5eea39ded2c3a5c9a5b2559e sha1 d479eb67c2c827069ce3e504b634d6aceffdc7eb )
+	rom ( name mslugx.zip size 29840369 crc 55ec8810 md5 43f8b80747ca93e75ed87f78990b5ccf sha1 69cff56124014c12763ac58ce1cbb22303626dfd )
 )
 
 game (
@@ -32773,13 +24305,6 @@ game (
 )
 
 game (
-	name "Miss Puzzle (Nudes)"
-	year "1994"
-	developer "Min Corp."
-	rom ( name mspuzzlen.zip size 1634633 crc 3abc508b md5 3592f7573087db10e2a3f9bfaa0ae315 sha1 48948938b4c85b017c342dc5f72df4e0a36a7396 )
-)
-
-game (
 	name "Main Stadium (Japan)"
 	year "1989"
 	developer "Konami"
@@ -32801,13 +24326,6 @@ game (
 )
 
 game (
-	name "Magic Sword (Japan 900623)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mswordj.zip size 1477781 crc b4628f62 md5 c159fc017cd4d859ce4696447d97f776 sha1 1408280100c48e9c10d3b955123e8f79cfcdc762 )
-)
-
-game (
 	name "Magic Sword: Heroic Fantasy (World 900623)"
 	year "1990"
 	developer "Capcom"
@@ -32819,334 +24337,6 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name mswordu.zip size 1440354 crc 2252a9ff md5 1c0bbca73127580e83b7d0752ac776e5 sha1 a047f6e06dfd672f26876549c5507d113f0eeccb )
-)
-
-game (
-	name "After Burner (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_aftrb.zip size 207688 crc 6ddc2a8d md5 78a8819e5fd745b40a7fc0a49cf4d994 sha1 e660081c684d9d6080bfc9e14363a482572c0ae7 )
-)
-
-game (
-	name "Arrow Flash (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_arrow.zip size 271204 crc c4457390 md5 54374218dd732d28db637043f788ced0 sha1 59d570c9914248c850da5dc0e9925f2dd2219f28 )
-)
-
-game (
-	name "Alien Storm (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_astrm.zip size 381704 crc 3df98820 md5 e02247608f3daf3016a761a4e77cd113 sha1 4f456e9dc47fbe62b5551c80089b41b10222f144 )
-)
-
-game (
-	name "Astro Warrior (Mega-Tech, SMS based)"
-	year "1986"
-	developer "Sega"
-	rom ( name mt_astro.zip size 44501 crc 8233d8df md5 050d5249dd01b065a49c9001d4f0940a sha1 fe4db0930e69b0bb5370cfa4e32e8a439495f8dd )
-)
-
-game (
-	name "Alien Syndrome (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_asyn.zip size 136046 crc e9e7de46 md5 2c622cfaae4bb1ca9f2b6aee80457913 sha1 a5dd3d42534bdbe9678b3b11a934fa8119da2ce5 )
-)
-
-game (
-	name "Bonanza Bros. (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_bbros.zip size 415877 crc bcbf2660 md5 c56e4625d67629ef22a0d2ea491dd502 sha1 21bedc35b60a61db122cc1a4688d8cce676db74d )
-)
-
-game (
-	name "Altered Beast (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_beast.zip size 337394 crc 9181e9a1 md5 d47dce4fb75861b0a04b82cd85d93cd7 sha1 bf2bdd394bef995addfb018bfe006b5126c45195 )
-)
-
-game (
-	name "Columns (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_cols.zip size 344902 crc c7ab9e83 md5 5aa6041161da9bf0e168c0efd6686a45 sha1 5e348bb7bddd4f46e98b1286cd8e0dc1d7990ff4 )
-)
-
-game (
-	name "Crack Down (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_crack.zip size 237814 crc fc0148b2 md5 d48d0784f27fcb1101562cbe9d75d68c sha1 a83d5933b334dd940a7a2f12fd5310bcb482ae5c )
-)
-
-game (
-	name "Cyber Police ESWAT: Enhanced Special Weapons and Tactics (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_eswat.zip size 386037 crc dc7373ed md5 de849162336188bbd3858b0378401c46 sha1 857081c96024977212a1a2b649a4c868692b7278 )
-)
-
-game (
-	name "Fire Shark (Mega-Tech)"
-	year "1990"
-	developer "Toaplan / Sega"
-	rom ( name mt_fshrk.zip size 205348 crc 8eaa6a9c md5 669921f38cbd1f55e6e665e78b46fd47 sha1 b584e37e5a7c21acef81cf7c5f7154f2e60fb0b7 )
-)
-
-game (
-	name "Forgotten Worlds (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_fwrld.zip size 387157 crc efe2f231 md5 1e7c063a0bdf20edfd486c96a7de8e70 sha1 625bb0a07be9860979214fea1907d2420fe309a0 )
-)
-
-game (
-	name "Golden Axe (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_gaxe.zip size 353339 crc 113984b0 md5 bf276ef40d9f733c0b680dde47884b51 sha1 1cd20e2f2bc69280e91d4d741ded635b87b45f9f )
-)
-
-game (
-	name "Golden Axe II (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_gaxe2.zip size 343141 crc 954bc5ea md5 9fdc93d9e19dadf0f5a71b95f0dd081b sha1 83d84ca9845883ee7f49cd24bdf4bc13d7fe64d7 )
-)
-
-game (
-	name "Great Football (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_gfoot.zip size 54943 crc 6434bd10 md5 d79b877b4028dfec61252406c7b2663f sha1 538c2d602cd43ffa5d5e1c9c4268b145161a5894 )
-)
-
-game (
-	name "Great Golf (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_ggolf.zip size 63623 crc 9a8a334b md5 4ddca31927547228fc3dcf00ad428539 sha1 d9ba8212365c0bf92edb6268725f809a56bdcc4c )
-)
-
-game (
-	name "Ghouls'n Ghosts (Mega-Tech)"
-	year "1989"
-	developer "Capcom / Sega"
-	rom ( name mt_gng.zip size 455338 crc 165cb989 md5 4d52bdc0693622c91ec62a0bf07f6c3d sha1 1f51c816f65522eff6b8cb8a05667d4a4e658b96 )
-)
-
-game (
-	name "Great Soccer (Mega-Tech, SMS based)"
-	developer "Sega"
-	rom ( name mt_gsocr.zip size 78357 crc 6f8e7714 md5 60dee04ff4f147c249769babe098a176 sha1 6b6e8d3a7f3e732ef71e6341cc84339a24e03e4a )
-)
-
-game (
-	name "Kid Chameleon (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_kcham.zip size 758808 crc b3416579 md5 7867982102b79dfe5df045749d08b2c8 sha1 391d87ed9d1f6dd00dbe09f08aa6312cdbe9458e )
-)
-
-game (
-	name "Last Battle (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_lastb.zip size 322100 crc ae8c31e7 md5 9fa1c28acdf0f449f7802bd66958a91c sha1 5d97ca4ae4e1ee85be66e0cacc31f167c21b902b )
-)
-
-game (
-	name "Mario Lemieux Hockey (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_mlh.zip size 279176 crc 8312a04c md5 70bec02d901dd01de449a93d71163417 sha1 ee10ef5b3c8a19c87d0ef7cfcf43a8c34ab9f4a0 )
-)
-
-game (
-	name "Michael Jackson's Moonwalker (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_mwalk.zip size 346672 crc 9d1c478c md5 9fe832fbe775b48868ae8c8fbb88e4a3 sha1 444efe0e00722ea5ce62a2d42aa1b61d17d1e116 )
-)
-
-game (
-	name "Mystic Defender (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_mystd.zip size 289317 crc 27a1cc19 md5 f1dae1034f50a94bbaf34937da4c34a0 sha1 32b2962b223650141bd50587b90b8b3dffdd8f40 )
-)
-
-game (
-	name "Out Run (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_orun.zip size 143164 crc b1adbbf5 md5 d349e5cc40432ae61ef5e611a849c432 sha1 568799166602ef0189917d3d894a82c9e9698f62 )
-)
-
-game (
-	name "Parlour Games (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_parlg.zip size 81421 crc 082d21b9 md5 5902603c040c08e2da0933b946d84edc sha1 0a978f9c2c9f2a898aafc58f4ccc208d71293787 )
-)
-
-game (
-	name "The Revenge of Shinobi (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_revsh.zip size 381871 crc 38f2a93f md5 d577e76064d75114a4e5b93ec129ad29 sha1 9621bf2722feb61f453ae2b91ce2947dbd5675dc )
-)
-
-game (
-	name "Shadow Dancer (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_shado.zip size 357291 crc abde3538 md5 433bfd5f1ff9cab0a4e5024681f3d2d5 sha1 389044c67fcaab788966cfa64f64d657ad5f30fc )
-)
-
-game (
-	name "Super Hang-On (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_shang.zip size 262804 crc 87956a92 md5 84a51503441aa86579df7d08ec63366e sha1 be622610289efc38f319b46757fe9bdd7ab12c84 )
-)
-
-game (
-	name "Space Harrier II (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_shar2.zip size 318310 crc b2194541 md5 991915b95c4e087484e0add6aa310e55 sha1 d7f1f08041e9ac7730e677f95aba7ef8ac050496 )
-)
-
-game (
-	name "Shinobi (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_shnbi.zip size 134808 crc 42241a3e md5 c97cafbd8a75bdf5f1c0900ce6fb8812 sha1 4fa7bc57fbb727ae0e0851313871cff456a0c03d )
-)
-
-game (
-	name "Super Monaco GP (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_smgp.zip size 405432 crc b06375bb md5 59a570620601d9dbe6627e275b34fcfb sha1 640bc253ed794075974273cb04f1ceac5c10a69d )
-)
-
-game (
-	name "Sonic The Hedgehog 2 (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_soni2.zip size 763175 crc 3b30b713 md5 c108c39022bc2387cf3edf1e5af0c92c sha1 5e4304cb7076fbe4d0f9858e36046df14440e057 )
-)
-
-game (
-	name "Sonic The Hedgehog (Mega-Tech, set 2)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_sonia.zip size 396928 crc 975346f5 md5 45cd2dea97fff8914a53b6f82971d0c2 sha1 80118ff64ebbeef6cccfbd9cf5ba475bcc1ee046 )
-)
-
-game (
-	name "Sonic The Hedgehog (Mega-Tech, set 1)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_sonic.zip size 398183 crc 70ccfcd2 md5 b3a9d8000c90dc8ad2c521e295ed30d6 sha1 f98979f6d7f1f86518aedbce0086dcf0f1691cab )
-)
-
-game (
-	name "Spider-Man vs The Kingpin (Mega-Tech)"
-	year "1991"
-	developer "Marvel / Sega"
-	rom ( name mt_spman.zip size 402601 crc dca7eb8d md5 f9a52cd79cb89c2902f07883f8e21e98 sha1 c4a04cbe8163cc651c45629314fed8e9fd55b52f )
-)
-
-game (
-	name "Streets of Rage (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_srage.zip size 382823 crc 84ecba18 md5 b47b5cd74adca8a38977c159da57f408 sha1 6ce5b3dc0125e89c835e85c2cfb6a80031199ae8 )
-)
-
-game (
-	name "Super Real Basketball (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_srbb.zip size 190138 crc 9ae77ac6 md5 27bbedca3c5f537491f53da1637b000a sha1 4cdabf693f05fbeb1c012fc25c6a13c7892dfb20 )
-)
-
-game (
-	name "Super Thunder Blade (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_stbld.zip size 278619 crc b081741c md5 385e036e641d83948d2c24bc052a2be8 sha1 8f29ac548f446195d4956b4eabcf5dc43d099577 )
-)
-
-game (
-	name "Joe Montana II: Sports Talk Football (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_stf.zip size 619687 crc b3f5a284 md5 9fcec387f8dcc72e2be3eb0ba2fab778 sha1 f1ea8214107d2c4a9f0b286bde4343fee6fb7f08 )
-)
-
-game (
-	name "Tetris (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tetri.zip size 128223 crc 07a2d255 md5 08009f4229e8c698a5ac5a5c42162152 sha1 e2b41de4f9b727942069e6928022b026a410055b )
-)
-
-game (
-	name "Thunder Force II MD (Mega-Tech)"
-	year "1989"
-	developer "Tecno Soft / Sega"
-	rom ( name mt_tfor2.zip size 389329 crc b451112c md5 8876ed7ed2544e42f6242ab8c1ef1442 sha1 974f17847bcb7b099b2d269f4954fcb860228d25 )
-)
-
-game (
-	name "Arnold Palmer Tournament Golf (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tgolf.zip size 305746 crc 5212161b md5 15c5855b2c4fab1de29c534848416a57 sha1 61f0823ea63617f38470c37075a5508a8bc8fbce )
-)
-
-game (
-	name "Tommy Lasorda Baseball (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tlbba.zip size 299587 crc fc1a5ece md5 144805c9c8617812965276b394e05962 sha1 a4dc04cede24f1650b6cdf0bc5724d1f55cf410f )
-)
-
-game (
-	name "Turbo Outrun (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_tout.zip size 302002 crc dc139729 md5 0d79a25debf7ed2a41b40228b360e3ed sha1 7796b781994fef4c5f68d42df38cd63173c291a3 )
-)
-
-game (
-	name "World Championship Soccer (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_wcsoc.zip size 335869 crc 40e8c1b1 md5 488babbccd807e371dc69465c52f8582 sha1 560201ce2c6c6df6f7dd12d79048c2c4779ee849 )
-)
-
-game (
-	name "Wrestle War (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_wwar.zip size 412700 crc 8edb6fa2 md5 5ad3a80a5f89bccedd0fa6e7f8cd068e sha1 50f4d73f29a42bbcd96d22f68142b05298f68289 )
-)
-
-game (
-	name "Magical Tetris Challenge (981009 Japan)"
-	year "1998"
-	developer "Capcom"
-	rom ( name mtetrisc.zip size 12151575 crc 8e7f1137 md5 b539f43d9486ec03d0883a9c0a38f4a5 sha1 b8dd76f8b65a9666f3959a7665d2dc8f9260e04f )
 )
 
 game (
@@ -33185,13 +24375,6 @@ game (
 )
 
 game (
-	name "Magical Odds (set 3, alt hardware)"
-	year "1991"
-	developer "Pal Company"
-	rom ( name mtonic.zip size 105676 crc 117b4049 md5 40c0e751187c55b32949ed44aae34b1c sha1 32fb3a8a8ef14366a49ca77676feec25d5e118e7 )
-)
-
-game (
 	name "Mouse Trap (version 5)"
 	year "1981"
 	developer "Exidy"
@@ -33210,13 +24393,6 @@ game (
 	year "1981"
 	developer "Exidy"
 	rom ( name mtrap4.zip size 33272 crc 0f46afc1 md5 8b3b0209704bc6b65ab36e05617fa209 sha1 3c8653f20680c7236cc7f23a8fbd66e20ad4e4ea )
-)
-
-game (
-	name "Mega Twins (World 900619)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mtwins.zip size 1435278 crc 7c4217bc md5 ad60091137010317baef2db22523ffb6 sha1 e8d16c0fa1e8dbabb45b40b05574450addb47d56 )
 )
 
 game (
@@ -33272,32 +24448,6 @@ game (
 	year "1992"
 	developer "Tung Sheng Electronics"
 	rom ( name multigmt.zip size 356672 crc 968f29c0 md5 029c660a8e3ba0e12d4e33f2edc80384 sha1 de1b3c4e09eebac8612b8c49332b5cb1bcd05717 )
-)
-
-game (
-	name "Multi Win (Ver.0167, encrypted)"
-	year "1992"
-	developer "Funworld"
-	rom ( name multiwin.zip size 37907 crc 48e4b715 md5 04e1730c0398b9acc20c821dd44bfb96 sha1 cb13d310996c6066f2178f26b00a42278a36e6a6 )
-)
-
-game (
-	name "Muroge Monaco (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name murogem.zip size 3163 crc abdace90 md5 362928e59f6603965c96b87a4ea8b938 sha1 e0984320467695a3b8e6c67f010c304fffa75bd1 )
-)
-
-game (
-	name "Muroge Monaco (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name murogema.zip size 3048 crc ba7c28e1 md5 369d44f54201f63a6444ba569a20b74a sha1 c1f8fdacfcc616e7ecfcec9d2f77e4d2de909a67 )
-)
-
-game (
-	name "Muroge Monaco (bootleg?)"
-	year "1982"
-	developer "bootleg?"
-	rom ( name murogmbl.zip size 4887 crc 8a96222f md5 813aa4d7c1c35b60b31c935d5cc863e7 sha1 0fcb89cd58073313d24a63b38da6da1938e2c33d )
 )
 
 game (
@@ -33367,14 +24517,7 @@ game (
 	name "Mutation Nation"
 	year "1992"
 	developer "SNK"
-	rom ( name mutnat.zip size 3772516 crc ee0375ca md5 f1ae0f6983d38df0a2a3e2c0139b97c4 sha1 5dc95395fa1c38a4f090e1ef875bae2988342502 )
-)
-
-game (
-	name "Mini Vegas 4in1"
-	year "1983"
-	developer "Entertainment Enterprises"
-	rom ( name mv4in1.zip size 17192 crc 09e8ccbf md5 2fefc6b5e62783341cd4e472950e565f sha1 9ef09931755ca9d5ce8784908af9f18af85f5625 )
+	rom ( name mutnat.zip size 5119203 crc 6e85d1d9 md5 8d3c2a92648470627116ab7021e11d1a sha1 ef44b02c951bb67e87030811b7a0b19f2d8d107e )
 )
 
 game (
@@ -33389,20 +24532,6 @@ game (
 	year "1989"
 	developer "Sega"
 	rom ( name mvpj.zip size 1331655 crc 77e6bd77 md5 39fb3f687e94e863dd7e79771be1302d sha1 ed8250a38cc61a3c5058cf9cc2497c4ec242e13d )
-)
-
-game (
-	name "Marvel Vs. Capcom: Clash of Super Heroes (Euro 980123)"
-	year "1998"
-	developer "Capcom"
-	rom ( name mvsc.zip size 22699647 crc 7ff321cb md5 c6ce600537da8962022ff0ff0b6084c8 sha1 8b948de6bfed689b18ce4a7b745e3b79400a885a )
-)
-
-game (
-	name "Marvel vs. Capcom 2 (JPN, USA, EUR, ASI, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom"
-	rom ( name mvsc2.zip size 83282157 crc 0cc71c69 md5 f364963c1f2921097e4483cc619efcbd sha1 b869b3e5afeacbe25fb59ceff5eaea90685dc4c9 )
 )
 
 game (
@@ -33490,13 +24619,6 @@ game (
 )
 
 game (
-	name "Michael Jackson's Moonwalker (Japan, FD1094/8751 317-0157)"
-	year "1990"
-	developer "Sega"
-	rom ( name mwalkj.zip size 1941919 crc b7e7df52 md5 9dcc4494e3cf115a4cf867f368e33a10 sha1 bc581cdea82d32c1302c42fbe92c27b68eedd944 )
-)
-
-game (
 	name "Michael Jackson's Moonwalker (US, FD1094/8751 317-0158)"
 	year "1990"
 	developer "Sega"
@@ -33541,7 +24663,7 @@ game (
 	name "Virtual Mahjong 2 - My Fair Lady (J 980608 V1.000)"
 	year "1998"
 	developer "Micronet"
-	rom ( name myfairld.zip size 16598031 crc 4bef5095 md5 c3790b1e099f12be6c5e9d219d6c295b sha1 d328ecc059ca983b6e3bde6e01a4cd5595ea6cfd )
+	rom ( name myfairld.zip size 19297252 crc 126c941a md5 fda4a28bc02fd75b0658cc6646e5a7bd sha1 615b4df7713561be4befacc673dac246fea4b261 )
 )
 
 game (
@@ -33632,28 +24754,14 @@ game (
 	name "Nagano Winter Olympics '98 (GX720 EAA)"
 	year "1998"
 	developer "Konami"
-	rom ( name nagano98.zip size 171 crc ec91e818 md5 c907f52030d9daa3ee112dc8aa1f401a sha1 0bc4bce03fa9759e94579929dd402b2218b50627 )
+	rom ( name nagano98.zip size 81540 crc b3b74efd md5 a1b62562056e29b9c6f3edf99c1fe366 sha1 8b2807bd850706b101f0693cc45c7b341a5842a8 )
 )
 
 game (
 	name "NAM-1975"
 	year "1990"
 	developer "SNK"
-	rom ( name nam1975.zip size 3109482 crc 7f4c05b6 md5 ed51f017d7d52ab6a04a4e3facf51b95 sha1 a8c40d826ea7d387cf90e316e4ba3358699d9564 )
-)
-
-game (
-	name "Name That Tune"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nametune.zip size 152433 crc e960ddcc md5 c11d4fb3707a2909c9dd1267f2df354b sha1 acb3abba2f7dce7a43e4b3a4b13faf3c150291c2 )
-)
-
-game (
-	name "Name That Tune (3-23-86)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nametune2.zip size 152371 crc aab36b08 md5 9e66540a2ad75e85fc44aa9858a0d98c sha1 af71ad227bcb9ad0fab805975a5cc1f3ec46beab )
+	rom ( name nam1975.zip size 4456169 crc 5ebefd09 md5 13bf71ade91dbd1a7edc1c2406bcb288 sha1 120829dfa2cef898da9039fce117ca0194765da2 )
 )
 
 game (
@@ -33762,13 +24870,6 @@ game (
 )
 
 game (
-	name "NBA Jam Extreme"
-	year "1996"
-	developer "Acclaim"
-	rom ( name nbajamex.zip size 26439450 crc 79dd064f md5 9e1b1db8147e4f3a88ce215708a83e3f sha1 9026b4662951d09fcb1c1248cc62ce167162d157 )
-)
-
-game (
 	name "NBA Jam (rev 2.00 02/10/93)"
 	year "1993"
 	developer "Midway"
@@ -33818,24 +24919,10 @@ game (
 )
 
 game (
-	name "NBA Showtime / NFL Blitz 2000"
-	year "1999"
-	developer "Midway Games"
-	rom ( name nbanfl.zip size 174605 crc 0f4318c6 md5 b28cdf2ece8ce0fc8ee8f7984d439dd4 sha1 18e15050cc3a77b1276bec3ae48a2c24be41bb6c )
-)
-
-game (
 	name "NBA Play By Play"
 	year "1998"
 	developer "Konami"
 	rom ( name nbapbp.zip size 22240372 crc 3f0878b3 md5 8765f015d851b18fa63949b74762d84f sha1 bcfbc0dfc6907a6e86f93bffb5580bcf21b8db25 )
-)
-
-game (
-	name "NBA Showtime: NBA on NBC"
-	year "1998"
-	developer "Midway Games"
-	rom ( name nbashowt.zip size 168674 crc c7b45007 md5 a8210107a5190b19976337ebb6ae7d86 sha1 78ff340a186d89e074bb3f1675377fecc3c8e312 )
 )
 
 game (
@@ -33881,37 +24968,24 @@ game (
 )
 
 game (
-	name "Cherry Bonus III (ver.1.40, set 1)"
-	developer "Dyna"
-	rom ( name ncb3.zip size 76485 crc 8a763e9e md5 55fd61da1e2540bee45043c3858b4910 sha1 67795e3a044d09eba5d2c285d1abe5f4189a8b4a )
-)
-
-game (
-	name "Name Club Ver.3 (J 970723 V1.000)"
-	year "1997"
-	developer "Sega"
-	rom ( name nclubv3.zip size 15237734 crc 83de3f1d md5 f7e60ed46f43fc36e29842bec74978a6 sha1 82129ff00f759a9326ecda879677ea884e3ff5da )
-)
-
-game (
 	name "Ninja Combat (set 1)"
 	year "1990"
 	developer "Alpha Denshi Co."
-	rom ( name ncombat.zip size 3051535 crc a298bd96 md5 c840f66afdb5f807e132b8dff3467445 sha1 8c0ca15a232b1c4f31278224cacfa8ff409d7776 )
+	rom ( name ncombat.zip size 4398222 crc a7123260 md5 d1bff5dba3163bd67919d131647e6d2e sha1 b3ee2bef295391c73f6cb86e6ce71460be37df2f )
 )
 
 game (
 	name "Ninja Combat (set 2)"
 	year "1990"
 	developer "Alpha Denshi Co."
-	rom ( name ncombath.zip size 3051759 crc abeb8e39 md5 882a443fdba69e38779ed7fefe0f433a sha1 497cf7adf1f8d5bbab9b0b53ed328baae99aecb6 )
+	rom ( name ncombath.zip size 4398446 crc a2374cad md5 705ebf3ee08fc6ba1432ac80e4ec8485 sha1 689fd55231ac410f15d0e1bc96095edd81213adc )
 )
 
 game (
 	name "Ninja Commando"
 	year "1992"
 	developer "Alpha Denshi Co."
-	rom ( name ncommand.zip size 3353097 crc 19b8305f md5 5346176f31381219ce146c24de8b7665 sha1 15fce09c1192d53b65490a6dcc15d86a510196de )
+	rom ( name ncommand.zip size 4699784 crc d7e21317 md5 5e0434be62bae5711bb69f811d6e11c7 sha1 8fa7428a5460a7d646a61d21916413feebe39fbf )
 )
 
 game (
@@ -33933,20 +25007,6 @@ game (
 	year "1995"
 	developer "Namco"
 	rom ( name ncv1j2.zip size 2113207 crc aa97ec68 md5 ea4bc5bce7ffd78ee40a4a5237cecc2d sha1 a6243fae8cce6d7f5d2125dd6461a86cdc771c87 )
-)
-
-game (
-	name "Namco Classic Collection Vol.2"
-	year "1996"
-	developer "Namco"
-	rom ( name ncv2.zip size 2940716 crc 10c06612 md5 506103b1b31146b497fd491dbeee07f2 sha1 2cf185b819c5e91d7831cff44cea95349b3da4d3 )
-)
-
-game (
-	name "Namco Classic Collection Vol.2 (Japan)"
-	year "1996"
-	developer "Namco"
-	rom ( name ncv2j.zip size 2941313 crc 35907e9d md5 fce345b4c7e254d7ca518dd6d74d30e2 sha1 a9c07da998a9aa294a9d635d8d5728c77565e3c3 )
 )
 
 game (
@@ -34006,13 +25066,6 @@ game (
 )
 
 game (
-	name "Nemo (Japan 901120)"
-	year "1990"
-	developer "Capcom"
-	rom ( name nemoj.zip size 1386260 crc a25478c9 md5 07b61eee7ec631b176d0f8a4fc3c57f9 sha1 6f29e17e81d9825fe65e733d59d7d1d6a2d7ae6f )
-)
-
-game (
 	name "SD Gundam Neo Battling (Japan)"
 	year "1992"
 	developer "Banpresto / Sotsu Agency. Sunrise"
@@ -34023,34 +25076,28 @@ game (
 	name "Neo Bomberman"
 	year "1997"
 	developer "Hudson"
-	rom ( name neobombe.zip size 6249744 crc cb74b2cf md5 986eb491212a0835d7623b01d601e7f7 sha1 59db0755211fb85bafc832943f9d2046ca5d2018 )
+	rom ( name neobombe.zip size 7596431 crc 523bc7d9 md5 91789f8eb1be5bf493bdc5cdf152f053 sha1 394221d05e77acdd7038d1f7bba7248e20058503 )
 )
 
 game (
 	name "Neo-Geo Cup '98 - The Road to the Victory"
 	year "1998"
 	developer "SNK"
-	rom ( name neocup98.zip size 10003309 crc 356ee253 md5 b78fa6284da9eb6a3729a87c3426b1ac sha1 c42b7d9f7ec55fb98e5cc37512647f974da03730 )
+	rom ( name neocup98.zip size 11349996 crc 0c3a9789 md5 36813ea7a5fdd5964f7c7675c8ec886a sha1 fe6d8a57dc961fcbe4b808948fa9d7d96c46bab4 )
 )
 
 game (
 	name "Neo Drift Out - New Technology"
 	year "1996"
 	developer "Visco"
-	rom ( name neodrift.zip size 8575446 crc 5e6373a4 md5 294b8472fa9f8702eb20100e41b323ee sha1 17b56c374c1dd3164433c00e456d285586330289 )
+	rom ( name neodrift.zip size 9922133 crc 6e974aaa md5 297a6719e2d949f9929f69e6539e8aac sha1 8be5df7f6195b922b5512006ea740b35793a7f38 )
 )
 
 game (
 	name "Neo Mr. Do!"
 	year "1996"
 	developer "Visco"
-	rom ( name neomrdo.zip size 1604413 crc 1d328c1f md5 2aed5804ce0cb33e398ffe5a67c2964a sha1 d3f80ff191606ed415485096c66b9335d63d20e9 )
-)
-
-game (
-	name "Neptune's Pearls 2"
-	developer "Unidesa?"
-	rom ( name neptunp2.zip size 1435260 crc 4129f1ce md5 585fd29012f96e81262f3fced9d7a6c3 sha1 db6086570c07caabf007dbcedfeb937c1fbe1a3c )
+	rom ( name neomrdo.zip size 2951100 crc 67d930fb md5 a8baef3eea4cb821d9cff738b84d6961 sha1 6e5f91041bba47ba79b7dd53ce90155115fb8e21 )
 )
 
 game (
@@ -34058,13 +25105,6 @@ game (
 	year "1990"
 	developer "Dynax / Yukiyoshi Tokoro"
 	rom ( name neruton.zip size 1309859 crc 1a1d8861 md5 753a8522fff7da67fe09fcf0c9446479 sha1 ed25cfc181203d9df30cc1cd9b81bccc4ac49cb6 )
-)
-
-game (
-	name "Netchuu Pro Yakyuu 2002 (NPY1 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name netchu02.zip size 620620 crc 2fd47250 md5 a39012ab4e4133d2482b5b9a8a1974a9 sha1 0468501034286087db86b5f4ebcae0a2e727f80c )
 )
 
 game (
@@ -34121,13 +25161,6 @@ game (
 	year "1980"
 	developer "hack"
 	rom ( name newpuckx.zip size 14035 crc 9480aba5 md5 b649150fbf063c6b106eef71a985a9e7 sha1 f974ca5b7aaccecb650e5b0e1722e98379257a5a )
-)
-
-game (
-	name "News (set 1)"
-	year "1993"
-	developer "Poby / Virus"
-	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
 )
 
 game (
@@ -34194,66 +25227,10 @@ game (
 )
 
 game (
-	name "New Fruit Bonus '96 Special Edition (bootleg, set 2)"
-	year "1996"
-	developer "bootleg"
-	rom ( name nfb96sea.zip size 74165 crc 33d33a51 md5 16cb1e8160e9b44db70a35533f1025e7 sha1 6d02bfd97d285cc495258208ca29902cbdd292c7 )
-)
-
-game (
-	name "New Fruit Bonus '96 Special Edition (bootleg, set 3)"
-	year "1996"
-	developer "bootleg"
-	rom ( name nfb96seb.zip size 59254 crc e22833d5 md5 6bf8f69fbca37fc8bdbb7672dbe68753 sha1 a62adbcbf0428a2ac7a9dab0c2fa226fab160bb4 )
-)
-
-game (
 	name "New Fruit Bonus '96 Special Edition (set 5, Texas XT)"
 	year "1996"
 	developer "Amcoe"
 	rom ( name nfb96txt.zip size 92889 crc 87a764b3 md5 3f0cee04de0c76acc93f37e999171f6a sha1 6626c77478f9e83fd5dce6a21a473003de1388aa )
-)
-
-game (
-	name "NFL Football"
-	year "1983"
-	developer "Bally Midway"
-	rom ( name nflfoot.zip size 55074 crc 75421c6b md5 8a645dfbe28a6621c4c3e324c61f57fc sha1 4e2cbd9824e0b012047211068b1330fdcb69ee80 )
-)
-
-game (
-	name "New Fruit Machine (Ming-Yang Electronic)"
-	year "2003"
-	developer "Ming-Yang Electronic"
-	rom ( name nfm.zip size 68145 crc abbae41f md5 8c80ff6a474d7cf4697eff6b0475bd5b sha1 1b5ff244a7eae816613d168118b42b57d40bd6a7 )
-)
-
-game (
-	name "Night Gal Summer"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name ngalsumr.zip size 86806 crc ff529bb4 md5 ecd9281a12ea51c18b53fe90c9d20dfc sha1 6ce49913ae2eb2270bf3c0943ce2ab7e1185068a )
-)
-
-game (
-	name "Neo-Geo Battle Coliseum"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name ngbc.zip size 1397688 crc 5da708d9 md5 63eab679362aa191d928a90af47418c9 sha1 70e39a18905c1818ec91526ccdac199178655a00 )
-)
-
-game (
-	name "Naomi DIMM Firmware Updater (GDS-0023A)"
-	year "2001"
-	developer "Sega"
-	rom ( name ngdup23a.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Naomi DIMM Firmware Updater (GDS-0023C)"
-	year "2001"
-	developer "Sega"
-	rom ( name ngdup23c.zip size 1194 crc 2936114c md5 381739a42986b6e56706c85576e6e33a sha1 360c2c830794c274a7ec309f8472100cf1c1c33e )
 )
 
 game (
@@ -34268,13 +25245,6 @@ game (
 	year "1984"
 	developer "Nichibutsu"
 	rom ( name ngtbunny.zip size 27690 crc fb923e3c md5 8a3a9d0704ed910f7d3989751e91de84 sha1 03073f77f9de2a30d5abec3c3e85bee0e4f28789 )
-)
-
-game (
-	name "New Hidden Catch (World) / New Tul Lin Gu Lim Chat Ki '98 (Korea) (pcb ver 3.02)"
-	year "1999"
-	developer "Eolith"
-	rom ( name nhidctch.zip size 20136320 crc b9933d41 md5 8614070b65ff439f06034f45a23799bb sha1 cbfe0db42e0a4823792c0441fb910a39c3e4e406 )
 )
 
 game (
@@ -34310,13 +25280,6 @@ game (
 	year "1984"
 	developer "Nichibutsu"
 	rom ( name nightgal.zip size 37406 crc 0b21942c md5 34dd6a1add9fb5dc5c9b1a565db7e29b sha1 7a430ed8fa10ec7f7e1f150a4b2d93da7d6190a3 )
-)
-
-game (
-	name "Night Love (Japan 860705)"
-	year "1986"
-	developer "Central Denshi"
-	rom ( name nightlov.zip size 129652 crc b7caf1b0 md5 d8fa161e818fd1eda903f0abcbc3da23 sha1 976babcbc6a0d00c04dccb0959a7cb97adc4f0f5 )
 )
 
 game (
@@ -34407,7 +25370,7 @@ game (
 	name "Ninja Master's - haoh-ninpo-cho"
 	year "1996"
 	developer "ADK / SNK"
-	rom ( name ninjamas.zip size 18012673 crc 471348d5 md5 d19bef4000f563b4859f2fa7aee2e913 sha1 2250eaa7fe5048bf914f602101924cfc66eb6c1d )
+	rom ( name ninjamas.zip size 19359360 crc 67631a9b md5 7c9bf08f1588ae51e14e840b9857e657 sha1 d43d4dbf15f40f5e7f9f75864ec5688819648615 )
 )
 
 game (
@@ -34425,24 +25388,17 @@ game (
 )
 
 game (
-	name "Ninja Emaki (US)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name ninjemak.zip size 219787 crc a6d62528 md5 00ec58d18b5efc4bc2335f6932f531e1 sha1 cbe53ea7f93e5ff597b56ec55880730bad91fc33 )
-)
-
-game (
 	name "Nightmare in the Dark"
 	year "2000"
 	developer "Eleven / Gavaking"
-	rom ( name nitd.zip size 17880911 crc 25811aa7 md5 5c8ce8e1707346b3809948d81d0c6ec6 sha1 6c4d1cf83a6a50319593f4117b7a97b60d2b79f6 )
+	rom ( name nitd.zip size 19227598 crc a08c9624 md5 a74cda8d3f8ca7098edada01aab4a93a sha1 c218aef18ce836c9ff7227dc634e870d4516314b )
 )
 
 game (
 	name "Nightmare in the Dark (bootleg)"
 	year "2001"
 	developer "bootleg"
-	rom ( name nitdbl.zip size 5029367 crc 5ccb7f73 md5 c0a835b36a48c08fd124d09c1e596a65 sha1 7b5004c8aa6fd5159d1c4aa36aff7acd157b691f )
+	rom ( name nitdbl.zip size 6376054 crc ffe82a4b md5 87f53c6e35da44928e469dc84a4ce9e2 sha1 66b2c315bb4d826b438e8a46c27abdd1110ba698 )
 )
 
 game (
@@ -34464,27 +25420,6 @@ game (
 	year "1996"
 	developer "Nichibutsu"
 	rom ( name niyanpai.zip size 997812 crc c6a23980 md5 0b88935de104339f260b6df64644fecd sha1 8945fb99c2fb27be996c6cc141a3312f0bc74234 )
-)
-
-game (
-	name "Nekketsu Koukou Dodgeball Bu (Japan)"
-	year "1987"
-	developer "Technos Japan"
-	rom ( name nkdodge.zip size 319405 crc fb5c41cf md5 f615251cf0a015c2db06e1ffaae51ff9 sha1 706ab87451568ce2566c1927e515b18871aecb7e )
-)
-
-game (
-	name "Nekketsu Koukou Dodgeball Bu (Japan, bootleg)"
-	year "1987"
-	developer "bootleg"
-	rom ( name nkdodgeb.zip size 320485 crc 60e2b0a5 md5 ad853cacde50b27b6cbe9063ffdb24e2 sha1 2385e2bf61d4f19982c04065f2f5971255cbc109 )
-)
-
-game (
-	name "Mahjong Nenrikishu SP"
-	year "1998"
-	developer "IGS / Alta"
-	rom ( name nkishusp.zip size 2108199 crc 1fd7d1e4 md5 d1a402d2bd51fa93c8f7395166ddbfdc sha1 3857ebd07f885b369fdd91d53e25540c9443e474 )
 )
 
 game (
@@ -34530,13 +25465,6 @@ game (
 )
 
 game (
-	name "Nandemo Seal Iinkai"
-	year "1997"
-	developer "I&apos;Max / Jaleco"
-	rom ( name nndmseal.zip size 2955693 crc e752453a md5 922e2ec01d9ff2ee127dd804b17a01ac sha1 c24b778bea382a950b0eb73f033a7788422427b3 )
-)
-
-game (
 	name "Noah's Ark"
 	year "1983"
 	developer "Enter-Tech"
@@ -34569,20 +25497,6 @@ game (
 	year "1980"
 	developer "Universal (Gottlieb license)"
 	rom ( name nomnlndg.zip size 12347 crc 264fd3ba md5 44308c389e09f65fb622fc436af5550e sha1 6feeb20b9d6737138fa1a9910e98d6858f98d9d7 )
-)
-
-game (
-	name "Noraut Joker Poker (V3.010a)"
-	year "2002"
-	developer "Noraut Ltd."
-	rom ( name noraut3a.zip size 21631 crc d15d2f03 md5 5ffab075207071a5f4a7423a1887aa01 sha1 00ed9c379f0bac9d2dd740880645bb3f87963fc1 )
-)
-
-game (
-	name "Noraut Joker Poker (V3.011a)"
-	year "2003"
-	developer "Noraut Ltd."
-	rom ( name noraut3b.zip size 22575 crc bcb1b3ac md5 a97f5cb4d09ace9cf77a67b7fae78756 sha1 7467dc596743818cd63585e7900a08ae2c7cc4ce )
 )
 
 game (
@@ -34634,25 +25548,6 @@ game (
 	year "1988"
 	developer "Noraut Ltd."
 	rom ( name norautrh.zip size 6418 crc c564069b md5 595665b84807c18c6a99363eace16ab7 sha1 ba951505df4099f34676c8c9d0b69053054ce696 )
-)
-
-game (
-	name "Noraut Poker (NTX10A)"
-	year "1988"
-	developer "Noraut Ltd."
-	rom ( name norautu.zip size 11018 crc fe7d30bf md5 39828efc4b715f12b67614578bd80b6e sha1 4bc5d741cd33c296889a5d6af56104f128323a6d )
-)
-
-game (
-	name "Noraut unknown set 1 (console)"
-	developer "Noraut Ltd."
-	rom ( name norautua.zip size 8430 crc 26b8e0b9 md5 2d7e7ca175dfb4390670d26abcc30ae7 sha1 83eb66bced970e10a1dd95ee2104608d7f21c077 )
-)
-
-game (
-	name "Noraut unknown set 2 (console)"
-	developer "Noraut Ltd."
-	rom ( name norautub.zip size 8154 crc 58003dbe md5 8598d1528e1fbd8eb4bbb3391f79fd9f sha1 1844576d1caebb0ab3eb402064428e1932c9f7c0 )
 )
 
 game (
@@ -34780,129 +25675,10 @@ game (
 )
 
 game (
-	name "Ninja Spirit"
-	year "1988"
-	developer "Irem"
-	rom ( name nspirit.zip size 585051 crc a9c0aa55 md5 51db030c9f0f8245440a076bf7ec141f sha1 c792a326fa586ba2fccdae7d5e3efb3933dae0bc )
-)
-
-game (
 	name "Saigo no Nindou (Japan)"
 	year "1988"
 	developer "Irem"
 	rom ( name nspiritj.zip size 586754 crc 750a08e0 md5 cb5063c812aae08d60a8f80ac17ced69 sha1 57611e471d15607abd886d0fd261223a3bd2881d )
-)
-
-game (
-	name "Act Raiser (Nintendo Super System)"
-	year "1992"
-	developer "Enix"
-	rom ( name nss_actr.zip size 545627 crc 2b6aee52 md5 cf84f71fe3c76179e1e5b0c11b3f63a1 sha1 565fc4ef15cd9a1d9132bc4657f731d056d2ecce )
-)
-
-game (
-	name "The Addams Family (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_adam.zip size 765726 crc 6e7c4dd3 md5 e6d90f8e55146a3e56131509b7219deb sha1 9683f6dded8eba80ea07ec07a304ffe292a78a35 )
-)
-
-game (
-	name "David Crane's Amazing Tennis (Nintendo Super System)"
-	year "1992"
-	developer "Absolute Entertainment Inc."
-	rom ( name nss_aten.zip size 520898 crc 99e887f0 md5 ca0fe68fa61740492d41016c4174d082 sha1 aeae289487a7aab3feeb9b306597aeb4346644e2 )
-)
-
-game (
-	name "Contra 3: The Alien Wars (Nintendo Super System)"
-	year "1992"
-	developer "Konami"
-	rom ( name nss_con3.zip size 754880 crc ed105df5 md5 1b88b20da7587894925b3e13b884cdc9 sha1 7fe74257dea4fd86b8249d6a9c464d73f2b4541f )
-)
-
-game (
-	name "F-Zero (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_fzer.zip size 583719 crc 479398e6 md5 665457681df31c410c02f20212b1bd3f sha1 8b9b2e521d9567a595b88568d771aeb07a31d21e )
-)
-
-game (
-	name "Lethal Weapon (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_lwep.zip size 684860 crc 33bac38c md5 91383768663dbde8f0bbff6443d1c17b sha1 8a7129e1c4ca12559565e5ea154663996f7d3722 )
-)
-
-game (
-	name "NCAA Basketball (Nintendo Super System)"
-	year "1992"
-	developer "Sculptured Software Inc."
-	rom ( name nss_ncaa.zip size 578249 crc 36e27bf5 md5 65829a44b0ce0eb275852c32fcfa477d sha1 b6c1f466f4a5af0e1d9775259aa735ab643b11bd )
-)
-
-game (
-	name "Robocop 3 (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_rob3.zip size 467245 crc def1d440 md5 ebee9dda14b5acc76858f9de7b5fd58f sha1 9ef285237505f609e44e51edbb84f657b39ee22e )
-)
-
-game (
-	name "Skins Game (Nintendo Super System)"
-	year "1992"
-	developer "Irem"
-	rom ( name nss_skin.zip size 484912 crc fa86ae04 md5 4ffa0aacd15db17d9047c7b4e70c436a sha1 9cfec1ee1cbeda10cea36bf76c7ec60a3a42989b )
-)
-
-game (
-	name "Super Mario World (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_smw.zip size 353561 crc 41d196a7 md5 5fa731fb9513da1b3a4f5591e9f0d5ae sha1 05dcff6c91dcd7280b7e88a011a917875be072bd )
-)
-
-game (
-	name "Super Soccer (Nintendo Super System)"
-	year "1992"
-	developer "Human Inc."
-	rom ( name nss_ssoc.zip size 263069 crc 08405600 md5 dd35d3c3e7249e156aaeaa882ff9c121 sha1 96e43cd42b45197c7c346dff093ff4bf8dc55c22 )
-)
-
-game (
-	name "Super Tennis (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_sten.zip size 532940 crc f5017ff6 md5 5e98004f277ab4f700dfb8170128250e sha1 8a40ce16ef1ccbe5943c67d267a206196d6b8c51 )
-)
-
-game (
-	name "Night Stocker (set 1)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nstocker.zip size 69916 crc b4706cfd md5 e51875956118b11a665c325e6e86ac50 sha1 e8d2d0e5e0092faac7d953b9a9a1aeb8a90d722b )
-)
-
-game (
-	name "Night Stocker (set 2)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nstocker2.zip size 69856 crc 801a7134 md5 109f97df628ccf25832d69cc61201c11 sha1 82ae29550b842a8f52c2cbeac041b5575a273eed )
-)
-
-game (
-	name "N-Sub (upright)"
-	year "1980"
-	developer "Sega"
-	rom ( name nsub.zip size 12662 crc bcc71dbe md5 1c7827e6c15910a6bf9a68f4c8ba0a1d sha1 a157330cffb6664698d1b7c5da79f545c09e7fd7 )
-)
-
-game (
-	name "NtCash"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name ntcash.zip size 380581 crc 44f6236f md5 9098c86f037f36c9c8e4c3b431f386a6 sha1 4cb3035475573dc1f889d682695ff74beca558ad )
 )
 
 game (
@@ -35018,20 +25794,6 @@ game (
 )
 
 game (
-	name "New Zero Team"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name nzerotea.zip size 5471009 crc cc11b965 md5 638698377019c93ab035b9559e4f0b56 sha1 e70f049060584d7ca6db837a4b4ffd5539f578d2 )
-)
-
-game (
-	name "The Ocean Hunter"
-	year "1998"
-	developer "Sega"
-	rom ( name oceanhun.zip size 81763466 crc eec2ea44 md5 6d91e1454c2870e762962c34592b2fd8 sha1 e14b21c8ed98f9913cd1448208689c0d54fc358c )
-)
-
-game (
 	name "Oedo Fight (Japan Bloodshed Ver.)"
 	year "1994"
 	developer "Kaneko"
@@ -35039,45 +25801,10 @@ game (
 )
 
 game (
-	name "Office Yeo In Cheon Ha (version 1.2)"
-	year "2001"
-	developer "Danbi"
-	rom ( name officeye.zip size 12899207 crc 863db969 md5 b24b15ccd18f920bcb97524cc9dc538f sha1 8ea32f19596928928199ab6a5a4ad19c947f7f65 )
-)
-
-game (
 	name "Ironman Ivan Stewart's Super Off-Road"
 	year "1989"
 	developer "Leland Corp."
 	rom ( name offroad.zip size 479859 crc 394921fb md5 5f5e2c8c00aa8d1bc06099306640d701 sha1 9fc4e04b59cbbdff233841dc23aa7ba404d6f2ce )
-)
-
-game (
-	name "Off Road Challenge (v1.63)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc.zip size 15659751 crc cad711b2 md5 0b364b69bcbed66159244d95fb8d24da sha1 fb0e6fd3d636f6979bc824a87d0f459f417cfd41 )
-)
-
-game (
-	name "Off Road Challenge (v1.10)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc1.zip size 15659321 crc 65af3f2e md5 cb55106ded34559989549090136d21c4 sha1 c75e722b038b480df7c6abc1964827396af9f31f )
-)
-
-game (
-	name "Off Road Challenge (v1.30)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc3.zip size 15659506 crc b51d61ee md5 8d516747b39977de15371e0c3e3536d3 sha1 48e8e56c5de5a59c91804c6714c42dfb850bf837 )
-)
-
-game (
-	name "Off Road Challenge (v1.40)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc4.zip size 15659574 crc 2dab653d md5 6947ee606c73a5851b0c595e786c7930 sha1 15a48e80d726df10a6c38eda8b1297701d972e99 )
 )
 
 game (
@@ -35130,13 +25857,6 @@ game (
 )
 
 game (
-	name "Oigas (bootleg)"
-	year "1986"
-	developer "bootleg"
-	rom ( name oigas.zip size 67995 crc b37c9061 md5 18ea2172a2285066e87e9cba6ead1fee sha1 9cdfbdbd8aa00e8174be4398ba5239e460c9d759 )
-)
-
-game (
 	name "Oishii Puzzle Ha Irimasenka"
 	year "1993"
 	developer "Sunsoft / Atlus"
@@ -35183,55 +25903,6 @@ game (
 	year "1987"
 	developer "Nichibutsu"
 	rom ( name ojousanm.zip size 311101 crc c9088660 md5 bde1523f571aad1ed08d7be93efb9fb5 sha1 57b299f708dc086abd1d2e3ac7fa757ae3632c45 )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (ver. 101, Korean Board)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds.zip size 21083119 crc 7c0ee6a0 md5 a9b521c91c7f0bb83acd40e30490d875 sha1 b23ccc312c78d9f777a8d7f3b8a2d247abfa6246 )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds100.zip size 21083083 crc cc29b3ac md5 701ff697db6a7ac6989b2bd2839069e4 sha1 5648bd970b5586cb72f169ba5b2a392b967162dc )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (alt ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds100a.zip size 21097689 crc 150f90a6 md5 9f451c561b0e0885bf63dd186eac8320 sha1 7da99bea410907ff8bf65a6a00b20170a808ca08 )
-)
-
-game (
-	name "Oriental Legend Special Plus / Xi You Shi E Zhuan Super Plus"
-	year "2004"
-	developer "IGS"
-	rom ( name oldsplus.zip size 23069455 crc 2fe8d9c7 md5 aa9018f8732b8af95ee6969d1b6e5517 sha1 91e895ff815a8e9ca0d1ae491fbcec4b8410e9c2 )
-)
-
-game (
-	name "Oli-Boo-Chu"
-	year "1981"
-	developer "Irem / GDI"
-	rom ( name olibochu.zip size 35413 crc ec73c654 md5 b308efcb8b0292b80b3e848702179d14 sha1 b8459d404213a189365fde83560797b3a6df6ec3 )
-)
-
-game (
-	name "Ollie King (GDX-0007)"
-	year "2005"
-	developer "Sega"
-	rom ( name ollie.zip size 211 crc 8f81fdd3 md5 f1a6ad864014414f527d1623effe8622 sha1 a7cf4a1000752968de953798144180369ab45e01 )
-)
-
-game (
-	name "Olympic Soccer '92"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name olysoc92.zip size 1445126 crc 482641d1 md5 eba1e4e4163d752a2331c3f79e25fb3f sha1 b3ed3b893996c28bf2c9240c5f9dbb9289ae21f4 )
 )
 
 game (
@@ -35295,38 +25966,10 @@ game (
 )
 
 game (
-	name "Onna Sansirou - Typhoon Gal (set 1)"
-	year "1985"
-	developer "Taito"
-	rom ( name onna34ro.zip size 124290 crc db907038 md5 6b03397a0721948c065e8f4be1cbcaa5 sha1 ed4256e4c3f9599bf8b64aeb16509398165c3e2c )
-)
-
-game (
-	name "Onna Sansirou - Typhoon Gal (set 2)"
-	year "1985"
-	developer "Taito"
-	rom ( name onna34roa.zip size 124254 crc 971d6210 md5 f365458c2a658ebea9543e0aa6f95c7a sha1 1d7c58d7b587be7d77f603b0701e832ab65d94a3 )
-)
-
-game (
 	name "Opa Opa (MC-8123, 317-0042)"
 	year "1987"
 	developer "Sega"
 	rom ( name opaopa.zip size 167646 crc c013ba04 md5 76de1d1651a470d240f752cf09f54faa sha1 c5a0d1df53c2df6ab84e19dfde751e6af3b276ac )
-)
-
-game (
-	name "Konami's Open Golf Championship (ver EAE)"
-	year "1994"
-	developer "Konami"
-	rom ( name opengolf.zip size 12285530 crc d0bcb651 md5 328c6d0244399217aa265ebe8649b85b sha1 416d848bba28d21126f3967f6bb0b8253126adea )
-)
-
-game (
-	name "Konami's Open Golf Championship (ver EAD)"
-	year "1994"
-	developer "Konami"
-	rom ( name opengolf2.zip size 12285640 crc 9dcfea72 md5 42b5c429233c5e452bc9fbd06bd18cc1 sha1 319848970a55bb56712264bebbd14f48e49d68ab )
 )
 
 game (
@@ -35340,13 +25983,6 @@ game (
 	name "Open Mahjong [BET] (Japan)"
 	developer "Sapporo Mechanic"
 	rom ( name openmj.zip size 16714 crc 2e76756e md5 e5cc28f4cbd35afbe0e0392a48a67ab4 sha1 8d8bfc7d2b1287a58a9536760c30ad7fe3c77512 )
-)
-
-game (
-	name "Operation Tiger"
-	year "1998"
-	developer "Taito"
-	rom ( name optiger.zip size 24437097 crc 8a843eda md5 c1a515c64ef28fa18a8caab3670009ff sha1 48386427b3f5d0209d34922d2fd6165471f3f2e6 )
 )
 
 game (
@@ -35451,42 +26087,42 @@ game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. 126)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegend.zip size 17288509 crc 974d8a9e md5 9480b4b7d159786d2228f78a1a199f91 sha1 9542ea72d04b6e4f5e7b0d8de0ac0fdcf6af716d )
+	rom ( name orlegend.zip size 19383101 crc f520f8d0 md5 826a495ee8d9dcd99f8a1e5b0a1f1a7a sha1 8ef043dec6ba17a3bdb818e4ab9f6d553788535b )
 )
 
 game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. 105, Korean Board)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegend105k.zip size 17302973 crc 4545eef1 md5 068982db45acd4f9ee1debd1cc96b8e3 sha1 f0971e98bee437463daddb2e4073fdd86e6e7280 )
+	rom ( name orlegend105k.zip size 19397565 crc 7f408145 md5 2850773062e98799d0032b206c67503f sha1 f23ce8b4d0aa49dda995002fe13a852cc04b3bfd )
 )
 
 game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. 111, Chinese Board)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegend111c.zip size 17303193 crc 251ba3ed md5 da6c08ab627c4f4765195ef2ddbd1850 sha1 1f954217e8e2a62996d16d3353efe0fa7a95088a )
+	rom ( name orlegend111c.zip size 19397785 crc 70fb5bed md5 c32646c6a76607fb3ccf290f9ad84b9a sha1 ce76a97b759d85baff86eff2dfd0cce367a4b9bf )
 )
 
 game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. 112, Chinese Board)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegendc.zip size 17288380 crc 9c879866 md5 ad2e223a2668f5aed37b81e272bd4690 sha1 9fd10e644172ad566609d610776c1a293cf7e4d3 )
+	rom ( name orlegendc.zip size 19382972 crc ceb6697a md5 1f2c5985ffd0478cea00d890916b1423 sha1 de87c1d1b8a103c512a6c7e6cacfee6d852a11f6 )
 )
 
 game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. ???, Chinese Board)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegendca.zip size 17328300 crc 55cfdd79 md5 e1ffbf913257440f7fa5a0462efbf101 sha1 11865dffb099ab3edb98c6768178eb3613850fbd )
+	rom ( name orlegendca.zip size 19422892 crc 8c603a72 md5 360c4f5f8486a364bef1a3f85b1ec660 sha1 91cf785d1737eff5fdaa88a496c34cec801f05df )
 )
 
 game (
 	name "Oriental Legend / Xi You Shi E Zhuan (ver. 112)"
 	year "1997"
 	developer "IGS"
-	rom ( name orlegende.zip size 17288530 crc c2e127f9 md5 2a4845103b4240ced1e4dea57d7117cc sha1 a4a55bb771e368b308a2f0731307b69009b5e851 )
+	rom ( name orlegende.zip size 19383122 crc 74c9338a md5 b863464f9c4801d1d3119e357f3750d7 sha1 d0c9084a1ca6b64841f25f82588d40907c247024 )
 )
 
 game (
@@ -35504,34 +26140,6 @@ game (
 )
 
 game (
-	name "Psycho-Nics Oscar (World revision 0)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name oscar.zip size 270950 crc 108ce66b md5 76cd960b73e1dbc1bf2c41b168b4e1d6 sha1 82b77af4fa0c531eadcdec1309f97d0c15a54994 )
-)
-
-game (
-	name "Psycho-Nics Oscar (Japan revision 1)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name oscarj1.zip size 271202 crc a30ec736 md5 2e37762ff2af9a92087bf5c30fa05f11 sha1 5804d5e81a70f3035838fa3eb4787053d93fdace )
-)
-
-game (
-	name "Psycho-Nics Oscar (Japan revision 2)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name oscarj2.zip size 271201 crc f7de8dd4 md5 76f74cffc1c01d3a5607b2236f73f4a0 sha1 ffd893cf211c1dcfd0d9446c1f1ff2783e5a58cd )
-)
-
-game (
-	name "Psycho-Nics Oscar (US)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name oscaru.zip size 271433 crc a0bea7b3 md5 2e4e0aff1046af24ecf8ba8a23905805 sha1 27b580c035b9878cceb6f8c08963f4f010f20f49 )
-)
-
-game (
 	name "Osman (World)"
 	year "1996"
 	developer "Mitchell"
@@ -35546,17 +26154,31 @@ game (
 )
 
 game (
-	name "Othello (version 3.0)"
-	year "1984"
+	name "Otenami Haiken Final (V2.07JC)"
+	year "2005"
+	developer "Success / Warashi"
+	rom ( name otenamhf.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
+	name "Otenami Haiken (V2.04J)"
+	year "1999"
 	developer "Success"
-	rom ( name othello.zip size 26580 crc df61a98d md5 8f74aff9f6534b150bf88a617d81a643 sha1 0c55afcb5738a6bccb82c477f060c910f637a5da )
+	rom ( name otenamih.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
+	name "Otenki Kororin (V2.01J)"
+	year "2001"
+	developer "Takumi"
+	rom ( name otenki.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
 	name "Othello Shiyouyo (J 980423 V1.002)"
 	year "1998"
 	developer "Success"
-	rom ( name othellos.zip size 10688377 crc 4a9b415d md5 7c63d84ad804e7412826cc01f8bc22ac sha1 1766e18910e762ce7e16427eb1b926bc27ef9050 )
+	rom ( name othellos.zip size 13387598 crc 8dd9dc64 md5 e882e52360414dcdf8a8fa5da5c72bfe sha1 474c4bfc7a95e48efeea094f12e9566cf95a0e12 )
 )
 
 game (
@@ -35602,20 +26224,6 @@ game (
 )
 
 game (
-	name "OutTrigger (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name otrigger.zip size 76793068 crc 78a4bb4b md5 a585d45e29843fa54333fa70cbf79ac7 sha1 89b65fd0aceb681de5baad3bc63bac554ec86d25 )
-)
-
-game (
-	name "Off the Wall (Sente)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name otwalls.zip size 31281 crc 696c7e94 md5 1aeef6cd63c95f15500d571df6e451c5 sha1 b983436f556bb9675c5215557f3e1b9eb636485e )
-)
-
-game (
 	name "Outfoxies (World, OU2)"
 	year "1994"
 	developer "Namco"
@@ -35634,13 +26242,6 @@ game (
 	year "1982"
 	developer "Century Electronics"
 	rom ( name outline.zip size 21868 crc 03c718e4 md5 c16394821ace02adb28991978ec60f16 sha1 b3dffd7c5f3c360cf3cc620c8071855c4cc2aa1b )
-)
-
-game (
-	name "Out Run 2 (Rev. A) (GDX-0004A)"
-	year "2003"
-	developer "Sega"
-	rom ( name outr2.zip size 218 crc 3e51aa84 md5 56b36a52a565fceb6c3b5052032526b8 sha1 a9cc840fefa199f3857e4f08b76e2bb61a707c5d )
 )
 
 game (
@@ -35714,24 +26315,10 @@ game (
 )
 
 game (
-	name "Over Drive"
-	year "1990"
-	developer "Konami"
-	rom ( name overdriv.zip size 3148085 crc 95b24440 md5 31b53ac44224cfa30efde9f0b9dbf112 sha1 8fb4585bfe47762de05559a09cf66b37aecc037a )
-)
-
-game (
-	name "Over Rev (Revision A)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name overrev.zip size 14143936 crc 0871e58c md5 c4981602a7cb039f777f347f3f13099d sha1 8280398b760f3a250f05b59f0b21aaab1d694f09 )
-)
-
-game (
 	name "Over Top"
 	year "1996"
 	developer "ADK"
-	rom ( name overtop.zip size 12254433 crc f69af182 md5 3fe2279b74298544a6e9f69712de809f sha1 dd60e086593a6935146c2c286e20e91127f2d0ac )
+	rom ( name overtop.zip size 13601120 crc 8388768b md5 11e05e7fc09ffe1681e0092086798ce5 sha1 cc1ef248b3f74d0e13875dc713175679b3d7aae9 )
 )
 
 game (
@@ -35763,38 +26350,10 @@ game (
 )
 
 game (
-	name "P-47 Aces"
-	year "1995"
-	developer "Jaleco"
-	rom ( name p47aces.zip size 8715750 crc 6d6a4ad7 md5 732428f7fc1a99ba20e1024fea1791c3 sha1 c7f6bb507f692d22d75a3237439ece283582082e )
-)
-
-game (
 	name "P-47 - The Freedom Fighter (Japan)"
 	year "1988"
 	developer "Jaleco"
 	rom ( name p47j.zip size 703209 crc b58cc0bf md5 6f3a27f3d3a6a6c73dd0ec4942c52a80 sha1 005b1c40f5dd2d01e07e56ac922b3f21e20b9633 )
-)
-
-game (
-	name "Police 911 (ver UAD)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911.zip size 1483 crc cbc55c88 md5 a9fd11d72f219aea1b3df65707d06652 sha1 29230e32ec8fac25bde71cfb15ced9a9d7d11570 )
-)
-
-game (
-	name "Keisatsukan Shinjuku 24ji (ver JAC)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911j.zip size 802 crc c6f69598 md5 02678b2d8e2bc4d826a1a746039dce1b sha1 8dd10a032bbb62f1ca146b0203044ccf52ceaf58 )
-)
-
-game (
-	name "Police 911 (ver KAC)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911kc.zip size 687 crc 71cbe576 md5 d879e3d7a41f75891269b5f48ff18cef sha1 68666075e4c85fa19f26593fd5517c6845bd2ef0 )
 )
 
 game (
@@ -36043,27 +26602,6 @@ game (
 )
 
 game (
-	name "Pang! 3 (Euro 950601)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3.zip size 1536054 crc a87f3739 md5 c0de95b04c2f94e3b3220f1df6fb9ec7 sha1 40f258558a0131042df75952e6616f8a8ae44958 )
-)
-
-game (
-	name "Pang! 3: Kaitou Tachi no Karei na Gogo (Japan 950511)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3j.zip size 1535390 crc 9a2c87aa md5 ce8f83df17ff9207e4e13c0756b888e5 sha1 bc2842290d3ee2b7549147cc8c2007924efe2930 )
-)
-
-game (
-	name "Pang! 3 (Euro 950511, not encrypted)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3n.zip size 1534041 crc a8e56489 md5 3b08a34d661aaef6967ba88032733a9b sha1 03aeb507ef0fb5db3c07284c995bf85644a07c32 )
-)
-
-game (
 	name "Pang (bootleg, set 1)"
 	year "1989"
 	developer "bootleg"
@@ -36071,31 +26609,10 @@ game (
 )
 
 game (
-	name "Pang (bootleg, set 3)"
-	year "1989"
-	developer "bootleg"
-	rom ( name pangba.zip size 483323 crc 73b8c1e0 md5 fcc6deef33ff001166e188c6a63361aa sha1 2a58c967c1a85d129fb464c4915f6e85df00439a )
-)
-
-game (
 	name "Pang (bootleg, set 2)"
 	year "1989"
 	developer "bootleg"
 	rom ( name pangbold.zip size 491119 crc cdeed8d3 md5 280437ba5cf53c29cbfe81f9dca96c38 sha1 6c9422236795f06ab723dd9f119e3daf3a001ae5 )
-)
-
-game (
-	name "Pango Fun (Italy)"
-	year "1995"
-	developer "InfoCube"
-	rom ( name pangofun.zip size 1988654 crc 0cebe61a md5 e87f007cf44cf0f7e95f9a53fa775704 sha1 64e87818ee2b841292dbfd5a12737e9d6e2a960d )
-)
-
-game (
-	name "Pang Pang"
-	year "1994"
-	developer "Dong Gue La Mi Ltd."
-	rom ( name pangpang.zip size 1327359 crc 6d4091d6 md5 ed64180c61efdcff8fcf8eb1abbc7f85 sha1 7cc71bd8f59396cce15bb67c73aa98ed5cc5516e )
 )
 
 game (
@@ -36137,7 +26654,7 @@ game (
 	name "Panic Bomber"
 	year "1994"
 	developer "Eighting / Hudson"
-	rom ( name panicbom.zip size 2640574 crc c3077b37 md5 eb65ce80af31d0e16c70b67325f15bbe sha1 0d51843149fb1ec7a34cf9833ebdd213bdbd4165 )
+	rom ( name panicbom.zip size 3987261 crc 8057ba1f md5 583a73499e96ed266e8d4442b7de5f4e sha1 9c9472c6ec0c02f00d45d04b8eb678ba49537fcf )
 )
 
 game (
@@ -36155,31 +26672,10 @@ game (
 )
 
 game (
-	name "Panic Park (PNP2 Ver. A)"
-	year "1998"
-	developer "Namco"
-	rom ( name panicprk.zip size 48146357 crc f02abe69 md5 c1d75b3aacad07aa24ca73735c85ce7d sha1 f458b143c7c44f9656983d17604d156c2bb65a5a )
-)
-
-game (
-	name "Panic Road"
-	year "1986"
-	developer "Taito"
-	rom ( name panicr.zip size 174680 crc d0143677 md5 ea9209dacdac7f5481aadbb8024d1b38 sha1 2da479b496406e9a3f0e80b80309412e2439607b )
-)
-
-game (
 	name "Panic Street (Japan)"
 	year "1999"
 	developer "Kaneko"
-	rom ( name panicstr.zip size 8649424 crc 2f00742f md5 946dec33ad264802e9d36ded7ff07d64 sha1 ca860648a89cb25f006406fc4f943b5ed963f4fc )
-)
-
-game (
-	name "Panther"
-	year "1981"
-	developer "Irem"
-	rom ( name panther.zip size 14081 crc f4a931a8 md5 6a43b2ee4529db9cda749cbb2440eb97 sha1 b42a52ce4a1309aa8970e7b3c6d61cc83618fbf5 )
+	rom ( name panicstr.zip size 8681445 crc 658ad475 md5 006ab3262eed9932ecf7c9ab3f7304b7 sha1 8bf2023e7371c93c8a6ec0bbb823bb5f6e4ba6c2 )
 )
 
 game (
@@ -36240,20 +26736,6 @@ game (
 	name "Paradise Deluxe"
 	developer "Yun Sung"
 	rom ( name paradlx.zip size 1485725 crc 707a3921 md5 c36a11b29fd780a3bd1fbf652b6f85de sha1 65d465fb3dfd784ac8a91c1029c624e4deaa8def )
-)
-
-game (
-	name "Paranoia"
-	year "1990"
-	developer "Naxat Soft"
-	rom ( name paranoia.zip size 169106 crc 2f687016 md5 064dc2d30d7d1c4270427e8af44f0144 sha1 ea83d75257220d1f9f9774683d221fe3f5bbd2ea )
-)
-
-game (
-	name "Parent Jack"
-	year "1989"
-	developer "Taito"
-	rom ( name parentj.zip size 288112 crc 863d6850 md5 ec0bd922ed1294222e6686056c6a66cf sha1 42716ae305933a821e0479ce884014c6a01dc5ce )
 )
 
 game (
@@ -36320,13 +26802,6 @@ game (
 )
 
 game (
-	name "Passing Shot (4 Players) (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name passht4b.zip size 355250 crc 3decc2e2 md5 8f8966585e123b088c20cd31740581c6 sha1 874d430b957f9d3d93565dfacd6dac4c76fdbc60 )
-)
-
-game (
 	name "Passing Shot (World, 2 Players, FD1094 317-0080)"
 	year "1988"
 	developer "Sega"
@@ -36345,13 +26820,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name passshta.zip size 430054 crc 3573c43c md5 3cd61b24583bb24f9050c725497bcd2c sha1 e070461eaf7b2df16d4deb3d28b332b18d2e1db1 )
-)
-
-game (
-	name "Passing Shot (2 Players) (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name passshtb.zip size 407088 crc f0945527 md5 e810b75af7765bb5e8e3a1a8d99b39b3 sha1 ffd89856355ed129e7de116722e149d6f544607a )
 )
 
 game (
@@ -36428,14 +26896,7 @@ game (
 	name "Powerful Baseball '96 (GV017 Japan 1.03)"
 	year "1996"
 	developer "Konami"
-	rom ( name pbball96.zip size 266 crc a482151d md5 da4599577d4ee4da3654a417daf5fab6 sha1 b34f5b1eaa9328c8d5bdc6a81e458740fdab45be )
-)
-
-game (
-	name "Powerful Pro Baseball EX (GX802 VER. JAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name pbballex.zip size 179 crc 933b6fab md5 475cdbd7c07599f57ea185e4028a46a4 sha1 56dc6285077011c9c8b3d2dacc44ab7dff9cb813 )
+	rom ( name pbball96.zip size 81635 crc 873fd4d5 md5 ed0b219ed24d0958959ec5c23fc3fb3a sha1 0b0e4d184a091cfdbcbd978de91dedaeb08cba1e )
 )
 
 game (
@@ -36443,13 +26904,6 @@ game (
 	year "1995"
 	developer "bootleg? (Veltmeijer Automaten)"
 	rom ( name pbchmp95.zip size 249245 crc 3f7d6fc5 md5 ce12171fdad245e66cface780101210c sha1 cefa76dcdb0e3d9dfd0c46a97c9e422df5755996 )
-)
-
-game (
-	name "Prebillian"
-	year "1986"
-	developer "Taito"
-	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -36470,14 +26924,14 @@ game (
 	name "Pebble Beach - The Great Shot (JUE 950913 V0.990)"
 	year "1995"
 	developer "T&amp;E Soft"
-	rom ( name pblbeach.zip size 13909385 crc 05c6cf38 md5 7dfa364e6bf1907e89157fb06ce0b009 sha1 56267680dee04cf8d027343612c74f6890cfe32a )
+	rom ( name pblbeach.zip size 16608606 crc 89d7c0c2 md5 be6981457c8285e5077fde0c6dc9293b sha1 6a6b0ff5b13f9909e88efa41d8682daecc255898 )
 )
 
 game (
 	name "Puzzle Bobble 2 / Bust-A-Move Again (Neo-Geo)"
 	year "1999"
 	developer "Taito (SNK license)"
-	rom ( name pbobbl2n.zip size 8562779 crc 667bfa18 md5 4563cc56af6eca1d8c21ef55e4180951 sha1 73ef3cccda8e317b6ac179b511d2faafa4710bcc )
+	rom ( name pbobbl2n.zip size 9909466 crc 5dfa1845 md5 8bcf5da6be72ab4891e01099cf21791c sha1 b3f05fdc6542ddaa11b12cfd04220c03ca894652 )
 )
 
 game (
@@ -36544,38 +26998,17 @@ game (
 )
 
 game (
-	name "Puzzle Bobble 4 (Ver 2.04O 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4.zip size 6978003 crc 67476786 md5 1fb77610e9f75281822a5009e8805167 sha1 5b5c095d914a2301856b058745c21edea7ba6d52 )
-)
-
-game (
-	name "Puzzle Bobble 4 (Ver 2.04J 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4j.zip size 6978002 crc 2d94849a md5 7f43e714e2d5c8cf4f335c66a61c4e3b sha1 b137ec936359e34fd36306ccf25f8ce232376186 )
-)
-
-game (
-	name "Puzzle Bobble 4 (Ver 2.04A 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4u.zip size 6978003 crc a91eb401 md5 8d0b0d0619aaf2d4dc8e4bbcceb2e026 sha1 4d17e858f333a1cd20e70c839e2bc23d6f4afb8b )
-)
-
-game (
 	name "Puzzle Bobble / Bust-A-Move (Neo-Geo) (set 1)"
 	year "1994"
 	developer "Taito"
-	rom ( name pbobblen.zip size 3671505 crc b999cd40 md5 cb3575518b84d3f21fc9c6ebf87b3103 sha1 c55c44ffb1ee3165235a1b568a5918245509f31c )
+	rom ( name pbobblen.zip size 5018192 crc 6edbb6ee md5 29b0fcaf6aa094b48c6c360b42a081ff sha1 13ceb536c1c8cd26bea1d4cc0f747b8048f7bbea )
 )
 
 game (
 	name "Puzzle Bobble / Bust-A-Move (Neo-Geo) (bootleg)"
 	year "1994"
 	developer "bootleg"
-	rom ( name pbobblenb.zip size 1403946 crc 2cd4b856 md5 979d45b280070cee5485c93e13879e3b sha1 9bbf6ddd4355ba4bb1686e095be0cb28e2cf328f )
+	rom ( name pbobblenb.zip size 2750633 crc 61002166 md5 6d829842c5992b1310fa8d0558f284d8 sha1 6717ec7a64887dc69d34440892c2bb4d1aa89985 )
 )
 
 game (
@@ -36596,371 +27029,371 @@ game (
 	name "1942 (PlayChoice-10)"
 	year "1987"
 	developer "Capcom"
-	rom ( name pc_1942.zip size 31276 crc e6551987 md5 75ac74f775e79b7583239410b5bdc859 sha1 50c026b0a7aae1f0e3ee7a885c6ffbc63d81a9ce )
+	rom ( name pc_1942.zip size 54642 crc ffaea53d md5 335c8a6b095ab2fbed87655749b98fb1 sha1 4aa3f3a178734d38dc08571acd089ac442de74e1 )
 )
 
 game (
 	name "Baseball (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo of America"
-	rom ( name pc_bball.zip size 20021 crc 4432d775 md5 256d106e4168fa5c3018802356715539 sha1 7827c452421e1e94fe12285fc18eef1ab9a5c6bb )
+	rom ( name pc_bball.zip size 43387 crc fa3c6bbf md5 3bce5d246df5b1db99dcd2f8f13815a5 sha1 347a8b3843b8955aed5365edccc03e44f2894cb4 )
 )
 
 game (
 	name "Balloon Fight (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_bfght.zip size 19008 crc cb54e6f5 md5 389cb4091b823dcfcb32fc1729ef4d58 sha1 e334214a8bee61eae82ac7a48d4c55201660a358 )
+	rom ( name pc_bfght.zip size 42374 crc c46a8748 md5 fecdc76479f6f309721f75e13c1a6a23 sha1 69a3d15359ad3c4c358a3391e49962f2873ee958 )
 )
 
 game (
 	name "Baseball Stars: Be a Champ! (PlayChoice-10)"
 	year "1989"
 	developer "SNK (Nintendo of America license)"
-	rom ( name pc_bstar.zip size 132439 crc cf9bd52b md5 af328af9bdbc6ec9d0a8109ab7bc6cdb sha1 74ec57ed3bc4fb0fa392bc8f408320e594d50bef )
+	rom ( name pc_bstar.zip size 155805 crc 7536743c md5 c0c4bb5ec0b947c84722bd761e3a81d1 sha1 15b041db3c9ce4f06f3ce63cf983afd27607b706 )
 )
 
 game (
 	name "Contra (PlayChoice-10)"
 	year "1988"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_cntra.zip size 93213 crc 1439a31d md5 76fbfa14d6c3e983adc92ed5f350d197 sha1 b856c7dc284a2e7fa1d540cc59f1da9d27dcbf93 )
+	rom ( name pc_cntra.zip size 116579 crc 3f47f025 md5 2b1b4184badd2a20013a4eac7315a3bc sha1 4b0d93a317ebba9d8258688038a254f5e9e70a81 )
 )
 
 game (
 	name "Captain Sky Hawk (PlayChoice-10)"
 	year "1989"
 	developer "Rare (Nintendo of America license)"
-	rom ( name pc_cshwk.zip size 84868 crc 66a7df3a md5 c46c377e31c51149c7a226956b9a0331 sha1 7d57621146fcf126a37bcc816f22b6f8b2b1bc3a )
+	rom ( name pc_cshwk.zip size 108234 crc 6ec654ee md5 03af935d187ada33d669ce3ea24a1941 sha1 c934c3b12900bff97f17334f7cf3a1b8a42fd8a5 )
 )
 
 game (
 	name "Castlevania (PlayChoice-10)"
 	year "1987"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_cvnia.zip size 69539 crc 13fff922 md5 ec3b7f388aff56b2e1d3d4d78dbec882 sha1 27f7e3827493a6d617ee034be89c19402d2975a5 )
+	rom ( name pc_cvnia.zip size 92905 crc b9218714 md5 f617e5147b279baf9efea7c861e719e5 sha1 ff58c804c7ab943f452ed0b34be4976295ab2475 )
 )
 
 game (
 	name "Double Dribble (PlayChoice-10)"
 	year "1987"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_dbldr.zip size 91029 crc 6d0f9bb0 md5 58fea45b333fd11f5d2d3a850462b064 sha1 14d41af9b68ba61e6ad9b5113c0c4c3b4f7fb51f )
+	rom ( name pc_dbldr.zip size 114395 crc f1aeab56 md5 024d96ed3232e0793548ffcd519607db sha1 e551bf3057f56de345a4c1865bdc1ededd49338c )
 )
 
 game (
 	name "Double Dragon (PlayChoice-10)"
 	year "1988"
 	developer "Technos Japan"
-	rom ( name pc_ddrgn.zip size 143607 crc 602e9b38 md5 7edaaaaa06fc901e4d1bba52229ae50e sha1 733d3583b667a43da7b18848bc9ae316a3728bcf )
+	rom ( name pc_ddrgn.zip size 166973 crc 7d6fbf06 md5 611af769c05f259ac6c31abadccde4df sha1 e0917cb03a7dc71cf7152d62a6700fda77a6ab26 )
 )
 
 game (
 	name "Dr. Mario (PlayChoice-10)"
 	year "1990"
 	developer "Nintendo"
-	rom ( name pc_drmro.zip size 35336 crc 5bbb673d md5 cd916fbb01accdf2fc8f7baa32d19462 sha1 fdb4decb68a137fd845046b39ac5821ecc8430a5 )
+	rom ( name pc_drmro.zip size 58702 crc 8e350525 md5 86e7efa4abdcd4dce0f67a2e46d3d904 sha1 b8fe0109ed544969a83f628793a366d10df57915 )
 )
 
 game (
 	name "Duck Hunt (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_duckh.zip size 19050 crc 9c9cfe10 md5 5a998aba61ac1ccdf9fe335580e7d27e sha1 a4e6aab373045fdb24de53c8df31c6331e63715c )
+	rom ( name pc_duckh.zip size 42416 crc e07cd49f md5 d3eed8aa9ac6654239d992a42d1960fe sha1 40593aa8bbebbcb13bd9831c3acfee80319318b7 )
 )
 
 game (
 	name "Excite Bike (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_ebike.zip size 20683 crc 98951229 md5 748af31606f9f08016791b566986ef6f sha1 c8f3844ed70eda968f7bc60d754b7fa179d9b039 )
+	rom ( name pc_ebike.zip size 44049 crc 2f15a6e8 md5 ac71406bd6a89ae5a15ca45cb81a189b sha1 fdbeecccf5252518100889d49cab4b3f6e6a0e8a )
 )
 
 game (
 	name "Uncle Fester's Quest: The Addams Family (PlayChoice-10)"
 	year "1989"
 	developer "Sunsoft (Nintendo of America license)"
-	rom ( name pc_ftqst.zip size 108922 crc b0ea971a md5 128d23220323177dce8954f81e16b669 sha1 c94612b0df93f1da96ab73cf99c73980890352e1 )
+	rom ( name pc_ftqst.zip size 132288 crc 7800fa46 md5 11ceadef9ce0473acd7e0ec3bee04a0b sha1 f24f79c8bb436ed0118259dae307c6b3a5d143b6 )
 )
 
 game (
 	name "Gauntlet (PlayChoice-10)"
 	year "1985"
 	developer "Atari / Tengen (Nintendo of America license)"
-	rom ( name pc_gntlt.zip size 89091 crc 94a2716c md5 367c5a22b622668aa24fc70da0e977cf sha1 522585eaa3423b10c5cc19f137beaa5f4b1c301c )
+	rom ( name pc_gntlt.zip size 112457 crc 41d33183 md5 1bb901e8d3c37cd0de684fa31beab8a5 sha1 e4ad342bbf01bd06b887a79f667390c5cc7568de )
 )
 
 game (
 	name "Golf (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_golf.zip size 19464 crc fe118b0c md5 063462acd6771a3137d3696623c9fa68 sha1 fa9435e72efaa37a5c42a9485fe4e0b1d3b3ba97 )
+	rom ( name pc_golf.zip size 42830 crc 92d9c321 md5 6addfef370620cda601140a0c23cfd71 sha1 7aadb913b98fd568cbd55d29aa9d9100f01c24b6 )
 )
 
 game (
 	name "The Goonies (PlayChoice-10)"
 	year "1986"
 	developer "Konami"
-	rom ( name pc_goons.zip size 37097 crc 354a5dd5 md5 6588745634f5a8193f96f9959f95ce0f sha1 8035cec5f0101a1b67c477a9e9df5e3b8dda1d6e )
+	rom ( name pc_goons.zip size 60463 crc 71163af4 md5 d5e506a184f317c15def53caf7ef4db4 sha1 48deac39d3e34e435de502a1702316753dd94ac5 )
 )
 
 game (
 	name "Gradius (PlayChoice-10, older)"
 	year "1986"
 	developer "Konami"
-	rom ( name pc_grdue.zip size 41282 crc 46e50ffc md5 dc43c3535fde6d2c2d909507c6b96338 sha1 2c2113b51103577d48699f3f401e179843bceb51 )
+	rom ( name pc_grdue.zip size 64648 crc 8f68be56 md5 0c3a30f6ef9cbfb00dcb048012000b9d sha1 58171cda02ee33d37314b88d7c6b10b675b64bee )
 )
 
 game (
 	name "Gradius (PlayChoice-10)"
 	year "1986"
 	developer "Konami"
-	rom ( name pc_grdus.zip size 41246 crc 844a6efa md5 f30c46f3c468f1fcb6ef24f2c42cd08c sha1 ed045b95f1931c9af68dd03e95409edf12e212b2 )
+	rom ( name pc_grdus.zip size 64612 crc 048aa40c md5 4bb7a67eb461dd422ac8d63643fda6d2 sha1 627465294fd130743980e7f1f695dc292571ac18 )
 )
 
 game (
 	name "Hogan's Alley (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_hgaly.zip size 18415 crc 3936a668 md5 3052fdc1b7f7e7fdb913c17cb096d6a8 sha1 61f681138d13675382a38fbc7fe3a1e42bb5736c )
+	rom ( name pc_hgaly.zip size 41781 crc ed1bc955 md5 b571291f8b5392e50e07275868bb6f69 sha1 f576b60d3acd4acd3c19646ee7a86940c857a45c )
 )
 
 game (
 	name "Kung Fu (PlayChoice-10)"
 	year "1985"
 	developer "Irem (Nintendo license)"
-	rom ( name pc_kngfu.zip size 32388 crc 51269c3c md5 585e8a2d28fe3dc3e58bffae640d35d6 sha1 7c49fcca2b491fbf8db662056d7a4dfdf1489279 )
+	rom ( name pc_kngfu.zip size 55754 crc 26d48344 md5 405680a44e8c65e206b1d04663f5e809 sha1 3cf1810380719dd4d1864ce70c1ec6edea461c45 )
 )
 
 game (
 	name "Mario Bros. (PlayChoice-10)"
 	year "1983"
 	developer "Nintendo"
-	rom ( name pc_mario.zip size 19726 crc 79317309 md5 163060959d51d057eb827707e7fb05fd sha1 6ad15423ab2fa1df30d8c7c17fb843b172ebeef8 )
+	rom ( name pc_mario.zip size 43092 crc 71ece693 md5 7d2585581fd191eea1f1744c648bda79 sha1 62abd92e3b181038d4bdaa2fc8eb36a8940404ed )
 )
 
 game (
 	name "Mike Tyson's Punch-Out!! (PlayChoice-10)"
 	year "1987"
 	developer "Nintendo"
-	rom ( name pc_miket.zip size 138442 crc 48cc49d3 md5 a772ee98a734df974e0306d4083bdd14 sha1 8b184501dd4952c1cc4d0a1661bb0b4b9ae56b8c )
+	rom ( name pc_miket.zip size 161808 crc dc635e27 md5 c6ef009ec84b46e2532b801bb4b0b9fe sha1 95136b38af6390c34175b1077656fdc93c85fa41 )
 )
 
 game (
 	name "Mega Man III (PlayChoice-10)"
 	year "1990"
 	developer "Capcom USA (Nintendo of America license)"
-	rom ( name pc_mman3.zip size 228203 crc c14f51b1 md5 127be2dd6cdc8af8e60cfc93c229cde1 sha1 4d78ef3c6d3cf82bfdb8bbd2ec8f7ce8beeb50db )
+	rom ( name pc_mman3.zip size 251569 crc 0b6bdebe md5 929fa3fe2ce5f7b66ae9be0dc21fae55 sha1 fef6dc55d82fe42dc0287877444730a509b13dac )
 )
 
 game (
 	name "Mario's Open Golf (PlayChoice-10)"
 	year "1991"
 	developer "Nintendo"
-	rom ( name pc_moglf.zip size 190686 crc 101c8850 md5 b0d1388b4dd02e95037b67c0ef6fd7d5 sha1 2730716b4a89daa23747ab618a1709acae456953 )
+	rom ( name pc_moglf.zip size 214052 crc 9b5b0531 md5 44718500f91dd479eb28ad77084324dc sha1 3764c2d5ec5be135f0a7a6eb2e974f09f5dbccd2 )
 )
 
 game (
 	name "Metroid (PlayChoice-10)"
 	year "1986"
 	developer "Nintendo"
-	rom ( name pc_mtoid.zip size 70075 crc bc17f4ec md5 f531b0ec54f12814143089879433835f sha1 7210055dd2dbd6454d795898caeead2253dfbd2c )
+	rom ( name pc_mtoid.zip size 93441 crc a18f9b64 md5 9e11353ece491172d5f3ee59858496c5 sha1 d2ebacf3932b2c8f61e7f449b25c9355643e82bd )
 )
 
 game (
 	name "Ninja Gaiden Episode II: The Dark Sword of Chaos (PlayChoice-10)"
 	year "1990"
 	developer "Tecmo (Nintendo of America license)"
-	rom ( name pc_ngai2.zip size 172083 crc adefd10a md5 2a8bc624c97c1734e14ffc2b3f24f2b7 sha1 ebeac3ec788f34d6b5b0dd0258f741cf4492caf1 )
+	rom ( name pc_ngai2.zip size 195449 crc 2b26cc22 md5 f621e6ce1797dd5eaf931be0fbe614ad sha1 85ccf14e7425f21d9c14a692350d4cdaeeb9007b )
 )
 
 game (
 	name "Ninja Gaiden Episode III: The Ancient Ship of Doom (PlayChoice-10)"
 	year "1991"
 	developer "Tecmo (Nintendo of America license)"
-	rom ( name pc_ngai3.zip size 172689 crc 28402628 md5 ba925dfb0b14513d9162725355250b33 sha1 5baf3328ab81165959ecdc3d85af987cf74b1db0 )
+	rom ( name pc_ngai3.zip size 196055 crc 3dfe27c6 md5 a1cee282c504e47bfcf9230b0a3fa77b sha1 832a8ee27ce65b54381b6f60181c7ce0e36feb73 )
 )
 
 game (
 	name "Ninja Gaiden (PlayChoice-10)"
 	year "1989"
 	developer "Tecmo (Nintendo of America license)"
-	rom ( name pc_ngaid.zip size 144540 crc 7e1854e9 md5 c3dce1d685eb6495ade355aeee98663c sha1 f559b0fdd1e3186fcb5d9761c1d325bc53f349b6 )
+	rom ( name pc_ngaid.zip size 167906 crc 93590d9c md5 288a2a82189d105176bf2d397840d751 sha1 f73e149132f08f02e5810ea397c37cf3787e5baa )
 )
 
 game (
 	name "PinBot (PlayChoice-10)"
 	year "1988"
 	developer "Rare (Nintendo of America license)"
-	rom ( name pc_pinbt.zip size 107340 crc df5619fb md5 685c887dda14e03d8b18d7b7be581416 sha1 430ba735b757516d32152b5ba484c5772a6f3210 )
+	rom ( name pc_pinbt.zip size 130706 crc d25a8d8d md5 ce95bfce3b5e99ccd0d58610fdb3b304 sha1 8c88d9298b593ba712f6297293d7c3ae0cc26031 )
 )
 
 game (
 	name "Power Blade (PlayChoice-10)"
 	year "1991"
 	developer "Taito (Nintendo of America license)"
-	rom ( name pc_pwbld.zip size 131704 crc 22633029 md5 d8bf4015e95ffaa263eeb29f66c46cef sha1 d839120aaa81a8fe5824a56e08b3c5da502405ea )
+	rom ( name pc_pwbld.zip size 155070 crc 590db741 md5 f0ee5175413d72578c51ddc5ff5ceb67 sha1 5b036a4a456a5b4d4b6f222fb099765625bee4e4 )
 )
 
 game (
 	name "Pro Wrestling (PlayChoice-10)"
 	year "1986"
 	developer "Nintendo"
-	rom ( name pc_pwrst.zip size 56305 crc 41c9d380 md5 7ecdb2561001c2fccd55ff2295d80eb7 sha1 55e4cbd3450a15d44809e5d9108ba9f46a913ffd )
+	rom ( name pc_pwrst.zip size 79671 crc 6bf4b517 md5 605233c4b3031d122f9aa5c509e8d194 sha1 0f0897e9ad4bdd64f7a02aa9cc1b280a6d8502ec )
 )
 
 game (
 	name "Rad Racer II (PlayChoice-10)"
 	year "1990"
 	developer "Square (Nintendo of America license)"
-	rom ( name pc_radr2.zip size 57497 crc 4e3d2528 md5 5249ed182cb339e4c89d58c78e570358 sha1 d97c57996cbebb5a23b656bb166fe94be5165a42 )
+	rom ( name pc_radr2.zip size 80863 crc 6d1e9a85 md5 24698b46fa58209bb86e4b24c1a391d1 sha1 f13903f323a3fff677b29f45ba41457a53d356bc )
 )
 
 game (
 	name "Rad Racer (PlayChoice-10)"
 	year "1987"
 	developer "Square"
-	rom ( name pc_radrc.zip size 49818 crc 4e31c22a md5 090ade23cf46b60e54cabfe3b97fc2d2 sha1 81ceb40bd3eb21a953bf7a2c8bdbb2ac91e3951f )
+	rom ( name pc_radrc.zip size 73184 crc d85c2938 md5 66e20cafff5f78fc7a9c45091a7cfd39 sha1 a660b274d4528e09a224bbfd02d325821c36f251 )
 )
 
 game (
 	name "R.C. Pro-Am (PlayChoice-10)"
 	year "1987"
 	developer "Rare"
-	rom ( name pc_rcpam.zip size 40452 crc 537056d4 md5 d59ee0ffa09be58d8b2b4d9f4c545d5d sha1 409115eacff1faed13e11bff5fa0cbad7d65cb41 )
+	rom ( name pc_rcpam.zip size 63818 crc 8aee8c80 md5 26f7115faf10b85d6a9f581486881bd6 sha1 497c9c78877a7c45178b4b40f5e361f10d1dcbbe )
 )
 
 game (
 	name "Rockin' Kats (PlayChoice-10)"
 	year "1991"
 	developer "Atlus (Nintendo of America license)"
-	rom ( name pc_rkats.zip size 150920 crc 6867e26c md5 7038339277a7c89d39949fa9844321df sha1 bb8fea2d7075ac4d59cd2f2464be4c61adbc3f0f )
+	rom ( name pc_rkats.zip size 174286 crc b8fc13fa md5 720211d6b7d68c787b8068bbb9e47921 sha1 709d2a0fe7a5932a500f9337ff32cf4fca61ec87 )
 )
 
 game (
 	name "Rush'n Attack (PlayChoice-10)"
 	year "1987"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_rnatk.zip size 63319 crc 46b541ec md5 b39231b0b36a5c89977edcfddb998c60 sha1 a0f38e6c81b389a81a357005ee7f0b9269da962b )
+	rom ( name pc_rnatk.zip size 86685 crc 5e3d4203 md5 bd2c85d9c559fa2e4a6bd6e5b1d59af8 sha1 dcd4866484779c33d43c2b77231d59c11b132245 )
 )
 
 game (
 	name "Chip'n Dale: Rescue Rangers (PlayChoice-10)"
 	year "1987"
 	developer "Capcom USA (Nintendo of America license)"
-	rom ( name pc_rrngr.zip size 149839 crc 1a9aa40e md5 1e75f5d8af7cc497ce5204916e27b50b sha1 99cfd475d71581b4c7b8efe01da31dcf28bbda15 )
+	rom ( name pc_rrngr.zip size 173205 crc 6366ea33 md5 f8ad9827de679ae5ccd9d810ecd78457 sha1 66ea2dd4c3b454773d77fa3fa800ba80cb7205ad )
 )
 
 game (
 	name "Rygar (PlayChoice-10)"
 	year "1987"
 	developer "Tecmo (Nintendo of America license)"
-	rom ( name pc_rygar.zip size 79756 crc ade8751e md5 a3e19721b755d84868d7d806317471ca sha1 218771e951b068fc25351a67c57e1a161814136c )
+	rom ( name pc_rygar.zip size 103122 crc dae59fa8 md5 019f41683c07df17b1b46f9bb634ffbf sha1 036387bba5dbbc4d44d261198493b8c5359dc10a )
 )
 
 game (
 	name "Solar Jetman (PlayChoice-10)"
 	year "1990"
 	developer "Rare"
-	rom ( name pc_sjetm.zip size 170288 crc 32fc7b6d md5 3ce6b03df59f636df30f657b9a189077 sha1 79bf1e7241b12ccccbcde5bf927dd5b04537db37 )
+	rom ( name pc_sjetm.zip size 193654 crc a2040c00 md5 68d3bbc4fcb20609f69f62634c0ccbe2 sha1 5098a5c28f6acceae2df20a44aaca948c402181c )
 )
 
 game (
 	name "Super Mario Bros. (PlayChoice-10)"
 	year "1985"
 	developer "Nintendo"
-	rom ( name pc_smb.zip size 34883 crc efde4b66 md5 f689b9a88611397b6156e972857035df sha1 88f369071049e750058bed206a31f109265cd1ad )
+	rom ( name pc_smb.zip size 58249 crc af51bdd1 md5 853192ad76a3b0fca398c3532c1a5324 sha1 d6025e8fa4ad8254ae9f0d8107d9d7a6698a2d1c )
 )
 
 game (
 	name "Super Mario Bros. 2 (PlayChoice-10)"
 	year "1988"
 	developer "Nintendo"
-	rom ( name pc_smb2.zip size 80818 crc 7b1bc833 md5 30abebc41b66d3d6bf9e4adda3ba3af8 sha1 756633a8900c1fa08e29528e5f540389a26fe4c1 )
+	rom ( name pc_smb2.zip size 104184 crc d1af7e3e md5 ecbde39104bb5c8afcde951a5e28c66e sha1 bf7f389e48b62b22c0727d68184ebe948a33df30 )
 )
 
 game (
 	name "Super Mario Bros. 3 (PlayChoice-10)"
 	year "1988"
 	developer "Nintendo"
-	rom ( name pc_smb3.zip size 230673 crc e1d56eb1 md5 f558e643cc5b2718795a7b9c5a68c148 sha1 c184c302a82f1e6fddfa26f1a0402c535088e305 )
+	rom ( name pc_smb3.zip size 254039 crc b2ff9aeb md5 198dadd2af93c390095b6a4d68317f3f sha1 bb756bc8f79461c298e8b3683809c74bc0f57f84 )
 )
 
 game (
 	name "Super C (PlayChoice-10)"
 	year "1990"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_suprc.zip size 152098 crc 9f5af877 md5 c36a7353b008bd16ee634dc1af530a65 sha1 bc9a89191758ebae1d56c837075414c4b607f73c )
+	rom ( name pc_suprc.zip size 175464 crc def62261 md5 310d47dba75c415e8fc7a2f59e1a1626 sha1 79666a1e87a73ee869cdf11c2f112dc13d40d350 )
 )
 
 game (
 	name "Tecmo Bowl (PlayChoice-10)"
 	year "1989"
 	developer "Tecmo (Nintendo of America license)"
-	rom ( name pc_tbowl.zip size 103630 crc 4aafde93 md5 f32b8ab5f0a8f8088402ba74e223830b sha1 60342a19755963c50ca0454a188467aba1792584 )
+	rom ( name pc_tbowl.zip size 126996 crc 94d6dd42 md5 3d273065ec46a2ea17a2f8681231f2ed sha1 aa485fb6b1e41ced90a33b351c6ea62ea0bbcf7f )
 )
 
 game (
 	name "Tennis (PlayChoice-10)"
 	year "1983"
 	developer "Nintendo"
-	rom ( name pc_tenis.zip size 19681 crc 16c7ab30 md5 625f6d2912f555c8ec1c45cf5712286c sha1 e657dfeedb9b20903c477aa699f6d3e887b3a2ca )
+	rom ( name pc_tenis.zip size 43047 crc 38cc2176 md5 dc6dc9524c964c305291b5345e83ab99 sha1 7c04790815389d9152aa217b9ced171d94424345 )
 )
 
 game (
 	name "Track _ Field (PlayChoice-10)"
 	year "1987"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_tkfld.zip size 36300 crc 58a4a63d md5 64a09119d1d72f12717dfcd2fc9a327b sha1 0201a82c78013d7abcd7a999d2c4594cb395c855 )
+	rom ( name pc_tkfld.zip size 59666 crc 21863297 md5 b5ffe6a011f0e54aa190822a1302ef9a sha1 74e63f00f409fb2c7adaf902c4a4cf2606ce9e9e )
 )
 
 game (
 	name "Teenage Mutant Ninja Turtles (PlayChoice-10)"
 	year "1989"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_tmnt.zip size 148511 crc e9d4781e md5 2297e77cf580542caaeec290f2e79f6b sha1 1335bb2213cbb7dd74f6429145de9d969329e402 )
+	rom ( name pc_tmnt.zip size 171877 crc 63bc8a60 md5 ea60c4a0bf5cc2a49ccfbe39e5b32222 sha1 78ee71de26255d4a2ecf8dfe797eda8c0630dad3 )
 )
 
 game (
 	name "Teenage Mutant Ninja Turtles II: The Arcade Game (PlayChoice-10)"
 	year "1990"
 	developer "Konami (Nintendo of America license)"
-	rom ( name pc_tmnt2.zip size 263770 crc 20bbaf14 md5 68c094dac49dadac0da97371112bd149 sha1 44a46415dec76a7e3fc5bc1c913558be313d1ce3 )
+	rom ( name pc_tmnt2.zip size 287136 crc 4220788e md5 92c4a44ad5dc195fd87eec777f9854fc sha1 46ca885137c4aebb017044ad4bec989fda072c59 )
 )
 
 game (
 	name "Trojan (PlayChoice-10)"
 	year "1986"
 	developer "Capcom USA (Nintendo of America license)"
-	rom ( name pc_trjan.zip size 78145 crc e045bfb1 md5 98de3912c7184744ef00c84b7f08deb0 sha1 ef015db11bd30051b1789cf551f8e3a2c9397e37 )
+	rom ( name pc_trjan.zip size 101511 crc b9e6c62d md5 b86d1981963d7760e2bb8a77eb5c0a61 sha1 9d59e78d15e3f7180a158d5f61e2354522a7a7ab )
 )
 
 game (
 	name "Volley Ball (PlayChoice-10)"
 	year "1986"
 	developer "Nintendo"
-	rom ( name pc_vball.zip size 24517 crc b739da07 md5 02620c1a07a5d60c782f1cdefcc40c60 sha1 f5ca683c8ce5c93cf2ad8dd224714dfa37df96b4 )
+	rom ( name pc_vball.zip size 47883 crc af8bb975 md5 d3745f502d1a1c8fb6c221bc949a44da sha1 af4ee1ab5f68d085084616967d61c5bbff2d94e6 )
 )
 
 game (
 	name "Nintendo World Cup (PlayChoice-10)"
 	year "1990"
 	developer "Technos Japan (Nintendo license)"
-	rom ( name pc_wcup.zip size 113034 crc 70bda801 md5 5d8b24eac9135af451dc8517680276c8 sha1 d35c8cf61b88a7dbb7cc815740d730328cbf5135 )
+	rom ( name pc_wcup.zip size 136400 crc 8e15c174 md5 201550e6e5b79d82c006eb0fc7535f33 sha1 31b3ef2e81935d2ad883be913315f5d5c3b9524b )
 )
 
 game (
 	name "Wild Gunman (PlayChoice-10)"
 	year "1984"
 	developer "Nintendo"
-	rom ( name pc_wgnmn.zip size 19278 crc fab4b261 md5 703788e801345477885447809834785e sha1 49d0756af3c5ab275ead561fadc2182ae6513efb )
+	rom ( name pc_wgnmn.zip size 42644 crc 6d2612a5 md5 f7e74537d095310e23e6a69e72da096e sha1 125ec4eb45df3b563edcbc0ba8d9d885ad4627cb )
 )
 
 game (
 	name "Yo! Noid (PlayChoice-10)"
 	year "1990"
 	developer "Capcom USA (Nintendo of America license)"
-	rom ( name pc_ynoid.zip size 135116 crc 26dd152d md5 3982795a8b26250286ffb103e84e4c48 sha1 38eedf271931681eff76ea91a29ed721f6c7521a )
+	rom ( name pc_ynoid.zip size 158482 crc c40f4246 md5 fbdf499837dd8ecf948629f53d506db2 sha1 41b8645d1f706c2c9b39aeb6e8ccb693f6cad1bd )
 )
 
 game (
@@ -36992,55 +27425,6 @@ game (
 )
 
 game (
-	name "Print Club 2 (U 970921 V1.000)"
-	year "1997"
-	developer "Atlus"
-	rom ( name pclub2.zip size 4650907 crc bd4003c0 md5 27412f646b519ffb61af65d4e154ba6b sha1 009bc0905aed4bc597341e62668833b45044a2e5 )
-)
-
-game (
-	name "Print Club 2 Vol. 3 (U 990310 V1.000)"
-	year "1999"
-	developer "Atlus"
-	rom ( name pclub2v3.zip size 4802363 crc 2aeb1b34 md5 5299e61c9af7532e36ef42e5184b6d7a sha1 03586cbe6ea0648eab33489e465876b1368169be )
-)
-
-game (
-	name "Print Club (Japan Vol.1)"
-	year "1995"
-	developer "Atlus"
-	rom ( name pclubj.zip size 521141 crc a40ded29 md5 4944980e7a5979fc4d72cced715d7da2 sha1 8eb37b0df8ec564bb446422ebbdb2d537c62fc1a )
-)
-
-game (
-	name "Print Club (Japan Vol.2)"
-	year "1995"
-	developer "Atlus"
-	rom ( name pclubjv2.zip size 527790 crc bb97da83 md5 eada3d68eb766e4c8235953757d7d773 sha1 e22d61000ae26d6edafae8d23c35e1e4a3632aeb )
-)
-
-game (
-	name "Print Club (Japan Vol.4)"
-	year "1996"
-	developer "Atlus"
-	rom ( name pclubjv4.zip size 472113 crc 5db3c4f6 md5 547dc46438d4f96bd02a429adc4c0f27 sha1 aa5ded0c1503145b631187709eb3a7094d58ca9b )
-)
-
-game (
-	name "Print Club (Japan Vol.5)"
-	year "1996"
-	developer "Atlus"
-	rom ( name pclubjv5.zip size 510613 crc 89db096d md5 2157d806299173a01774e434677b647f sha1 3ac840ecccdd51b571984631c5d85232be670241 )
-)
-
-game (
-	name "Print Club Pokemon B (U 991126 V1.000)"
-	year "1999"
-	developer "Atlus"
-	rom ( name pclubpok.zip size 6203132 crc 3ee9e36b md5 88e8f552d90a6660d5320313e6046c96 sha1 180966410aa05ddda70351c87e3af04f4f7036af )
-)
-
-game (
 	name "Puzzle Club (Yun Sung, set 1)"
 	year "2000"
 	developer "Yun Sung"
@@ -37052,13 +27436,6 @@ game (
 	year "2000"
 	developer "Yun Sung"
 	rom ( name pclubysa.zip size 12990588 crc b57f5033 md5 e997b317ae6773e2ba8f72d2c2b866ad sha1 f3735a88f404cbd5252e798696d6f06184844373 )
-)
-
-game (
-	name "Percussion Freaks 3rd Mix (G*A23 VER. KAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name pcnfrk3m.zip size 546 crc 3b7b646b md5 524e550645b9171d160d9ea3276644c7 sha1 6b423ea0b927dacc67f810a915c3891599811b4c )
 )
 
 game (
@@ -37094,13 +27471,6 @@ game (
 	year "1994"
 	developer "IGT - International Gaming Technology"
 	rom ( name pebe0014.zip size 43773 crc c1b79a98 md5 d76401310f850e1a327570d1cbf969f2 sha1 79d6b0f0d8678134cd56ddde8f1c5bb084948097 )
-)
-
-game (
-	name "Peek-a-Boo!"
-	year "1993"
-	developer "Jaleco"
-	rom ( name peekaboo.zip size 1267072 crc 7f4335c8 md5 dd6c7746b1ab9d149158f8109d3c7e1d sha1 76dc3f1edad3630d9c75921a9efe94b2598436fc )
 )
 
 game (
@@ -37349,27 +27719,6 @@ game (
 )
 
 game (
-	name "Pest Place"
-	year "1983"
-	developer "bootleg"
-	rom ( name pestplce.zip size 33952 crc ad93042b md5 708987d7fe42287957ada94ce5cee151 sha1 02599e81c870b111a23ca75c77599a9ffc6b54f8 )
-)
-
-game (
-	name "Peter Pack-Rat"
-	year "1984"
-	developer "Atari Games"
-	rom ( name peterpak.zip size 206852 crc a3037cff md5 25de0233e1dbca7f00b2dd25d130606b sha1 ae68432abb968941b79479f13da5186e3ca67385 )
-)
-
-game (
-	name "Pettan Pyuu (Japan)"
-	year "1984"
-	developer "Sun Electronics"
-	rom ( name pettanp.zip size 47746 crc b7ed442d md5 236f3d3d2474eb4bb6ea6e49e52db332 sha1 3ec5c97e006e9e5cd146253d7cd8386df158dc67 )
-)
-
-game (
 	name "Player's Edge Plus (X002069P) Double Double Bonus Poker"
 	year "1995"
 	developer "IGT - International Gaming Technology"
@@ -37419,13 +27768,6 @@ game (
 )
 
 game (
-	name "Psychic Force 2012"
-	year "1997"
-	developer "Taito"
-	rom ( name pf2012.zip size 37901242 crc ac2ddeb4 md5 ba5991d93ab66dcb94c87ceb6d6b7b67 sha1 fac634c2c7bf75548aa86ef0263dd95c95c40dcf )
-)
-
-game (
 	name "Pocket Fighter (Japan 970904)"
 	year "1997"
 	developer "Capcom"
@@ -37450,7 +27792,7 @@ game (
 	name "Pleasure Goal / Futsal - 5 on 5 Mini Soccer"
 	year "1996"
 	developer "Saurus"
-	rom ( name pgoal.zip size 7244990 crc 383a0df0 md5 586ac67e0d139218fda30af7d047e166 sha1 331d84060352d5c4520437c756945f6f1796df31 )
+	rom ( name pgoal.zip size 8591677 crc 23fa2eb5 md5 804bc614495b18fc1767ad677fe063bc sha1 8b79a4589bd5e555610abe16d6c00f3e677d8a14 )
 )
 
 game (
@@ -37489,23 +27831,10 @@ game (
 )
 
 game (
-	name "Planet Harriers"
-	year "2001"
-	developer "Sega"
-	rom ( name pharrier.zip size 146488863 crc 01bc728c md5 28b4ec7917674e5bcfd9e0ef18f297f8 sha1 c19341f773d6266df7e77986dbe8e4143ddc58f0 )
-)
-
-game (
 	name "Phelios (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name phelios.zip size 1519633 crc fef8dc2b md5 07392e8573a863bd1110eadff321bff8 sha1 beb9c48c9bf57011ef65bdfd9c2452e01e01607d )
-)
-
-game (
-	name "Klad / Labyrinth (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phklad.zip size 9882 crc 38bbc068 md5 97153cfcbb5b10e4e0f4645590dcb993 sha1 ff6b6604cd22c65f3684bc3284014441616b5c3e )
 )
 
 game (
@@ -37572,30 +27901,24 @@ game (
 )
 
 game (
-	name "PhotoPlay"
-	developer "Funworld"
-	rom ( name photoply.zip size 112001 crc cf5dc568 md5 2056c3ec55f155c4ac672087af25e473 sha1 14306391fd905c6eff398ba8b4240d0fdcfc96e5 )
-)
-
-game (
 	name "Photo Y2K (ver. 105)"
 	year "1999"
 	developer "IGS"
-	rom ( name photoy2k.zip size 15555105 crc 9ba86046 md5 d6b3d1fa7c4123938ab77560e9a2d2b2 sha1 5145f125ac3c9f0f46c723b40419bbbfd3e1e91a )
+	rom ( name photoy2k.zip size 17649697 crc 12a76c3a md5 65354ff20d4fc015c0dabc2b0b009a34 sha1 4bfbb162ca1d882393644b4063601c3fbb9c669a )
 )
 
 game (
 	name "Photo Y2K (ver. 102, Japanese Board)"
 	year "1999"
 	developer "IGS"
-	rom ( name photoy2k102.zip size 15407100 crc a1cd7424 md5 6485f8683df300674791a82dbaf60fd3 sha1 930b83d87f73cb774e3d531ea4d2f98d267e883d )
+	rom ( name photoy2k102.zip size 17501692 crc 9b113385 md5 50996d1f6ec4b1881778c19887952c24 sha1 9546cbfcbf4c34c7f75351a44443aae2657cda65 )
 )
 
 game (
 	name "Photo Y2K (ver. 104)"
 	year "1999"
 	developer "IGS"
-	rom ( name photoy2k104.zip size 15543577 crc 9401006a md5 1dd36f16b9e4329ebb10915e66cec9b9 sha1 bc645154848accd3fb4323e20f2eaf46f714fc98 )
+	rom ( name photoy2k104.zip size 17638169 crc 758b2687 md5 06af3fe31feb0c4ecf8629f7ce37779e sha1 c35137fa7e6c17196c5e4b7d41513e7443bd9ee4 )
 )
 
 game (
@@ -37603,12 +27926,6 @@ game (
 	year "1983"
 	developer "Namco"
 	rom ( name phozon.zip size 31616 crc 71b8da10 md5 e146b1cd980624e4d8ddcb2e158faac8 sha1 66bfad457cbb5703ef9b2dd609b0be7c3b038f4f )
-)
-
-game (
-	name "Python (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phpython.zip size 4735 crc 310b8131 md5 0b14748a725264eeb897216e760da88e sha1 7d5562ea7f49c36b6245a8fb56a67cfcbb4963e1 )
 )
 
 game (
@@ -37637,19 +27954,6 @@ game (
 	year "1986"
 	developer "Merit"
 	rom ( name phrcrazec.zip size 264795 crc c76a5a61 md5 22ffb22b28e68fa90b93ecb53893c0d8 sha1 2f5a0e34191bdc52f3ff69e1e3c9b93d3dd165ab )
-)
-
-game (
-	name "Phraze Craze (Sex Kit, Vertical)"
-	year "1986"
-	developer "Merit"
-	rom ( name phrcrazev.zip size 232466 crc c67a15b6 md5 3badacfd0e9f7e4e7a488e64ee4e1929 sha1 cd6302b54e07b9bed9ee7309c891de53e2d99692 )
-)
-
-game (
-	name "Tetris (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phtetris.zip size 9369 crc 3e432f38 md5 b1500f93765e3ac1838cac3501b1dd4b sha1 c21681de17086c9f1ede9fcf8c55e41ad13ce266 )
 )
 
 game (
@@ -37723,20 +28027,6 @@ game (
 )
 
 game (
-	name "Pig Newton (version C)"
-	year "1983"
-	developer "Sega"
-	rom ( name pignewt.zip size 41651 crc db3fda51 md5 aa6e091315be92442c51c85f5fb5e5d8 sha1 3906317a8247a719a399af266abf35d6797b5dd9 )
-)
-
-game (
-	name "Pig Newton (version A)"
-	year "1983"
-	developer "Sega"
-	rom ( name pignewta.zip size 37918 crc e274f509 md5 5bfcf60a66ff7576dce0f8eb2a0f7d1d sha1 183fe94c4b3a3c3eae99096acb081beb8142d0b4 )
-)
-
-game (
 	name "Pig Out: Dine Like a Swine! (set 1)"
 	year "1990"
 	developer "Leland Corp."
@@ -37786,13 +28076,6 @@ game (
 )
 
 game (
-	name "Pinkiri 8"
-	year "1994"
-	developer "Alta"
-	rom ( name pinkiri8.zip size 111761 crc 843e1105 md5 f4e04261ff981993e2baa3e330e9605d sha1 9945bad33f1f9af92056d6ad5200b8148bd6ea0f )
-)
-
-game (
 	name "Pipe Dream (World)"
 	year "1990"
 	developer "Video System Co."
@@ -37811,13 +28094,6 @@ game (
 	year "1990"
 	developer "Video System Co."
 	rom ( name pipedrmu.zip size 1086490 crc 7c0dc5bc md5 6ebbf09936beaa6869d7bccbe8598d1c sha1 a262076a3308596928a000a0dd769b422d3821b0 )
-)
-
-game (
-	name "Pipeline"
-	year "1990"
-	developer "Daehyun Electronics"
-	rom ( name pipeline.zip size 346843 crc 5d5b1f6e md5 6696b6784acbea9f661cbb21efbbff20 sha1 5129abe5367a210b110a2b82fa26729eea234a6a )
 )
 
 game (
@@ -38073,13 +28349,6 @@ game (
 )
 
 game (
-	name "Pirati"
-	year "2001"
-	developer "Cin"
-	rom ( name pirati.zip size 201744 crc 3a2e3ea2 md5 8aceb390b0506166f94be00c4e625076 sha1 f9fdf1fede435d4b0a56c040550b35538cc5626e )
-)
-
-game (
 	name "Pirate Pete"
 	year "1982"
 	developer "Taito America Corporation"
@@ -38288,13 +28557,6 @@ game (
 )
 
 game (
-	name "Moero Justice Gakuen (JPN) / Project Justice (USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom"
-	rom ( name pjustic.zip size 122945688 crc b02b4341 md5 f41e36c097064d39592bb481bcf0b8fa sha1 5784383e7b1b8fbae9d7abe71a0ea320f6218ff1 )
-)
-
-game (
 	name "Pachinko Gindama Shoubu (Japan)"
 	year "1998"
 	developer "Nakanihon / Dynax"
@@ -38316,13 +28578,6 @@ game (
 )
 
 game (
-	name "Poker Ladies (Censored bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name pkladiesbl.zip size 759586 crc 8dab0e86 md5 844e6db4f1f169e5462036c863564044 sha1 bbcd872b98665f44ea292cb005c231ae9bd068c3 )
-)
-
-game (
 	name "Poker Ladies (Leprechaun ver. 510)"
 	year "1989"
 	developer "Leprechaun"
@@ -38341,18 +28596,6 @@ game (
 	year "1990"
 	developer "bootleg"
 	rom ( name pkrdewin.zip size 23508 crc 071822cc md5 cd8131e5218273d4726ef9bcb8a37f9e sha1 c2630d5e16e87cd4b52b187b0424a3308588e2a6 )
-)
-
-game (
-	name "Poker Master (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name pkrmast.zip size 84421 crc fbc5460c md5 5ded4660410c296d00e775ea0f78d7bc sha1 db225fb31615b637850230683d0c4f106e2f8101 )
-)
-
-game (
-	name "Poker Master (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name pkrmasta.zip size 80685 crc c043d03c md5 5877681fe60fe0b6943e9d7fc0d5e866 sha1 6ea1a34c3d41c76a4e5be0b598403ec7698897c2 )
 )
 
 game (
@@ -38498,90 +28741,21 @@ game (
 	name "Plasma Sword (USA 980316)"
 	year "1998"
 	developer "Capcom"
-	rom ( name plsmaswd.zip size 24321317 crc b83745f2 md5 008fd62864a460a630dcdf735d5a4cc6 sha1 e795543f73493f55252ced48278c84db822eddf1 )
+	rom ( name plsmaswd.zip size 24459122 crc 9dd80560 md5 7adb5774967ab8aa6635a2d86a99266c sha1 6df7cddccae0b5a230fe323520fb78533a65af44 )
 )
 
 game (
 	name "Plasma Sword (Asia 980316)"
 	year "1998"
 	developer "Capcom"
-	rom ( name plsmaswda.zip size 24321294 crc e1b5ae85 md5 015ebdd3441eed79a7f1511d54800cf9 sha1 b659c3a79cbeaa84e1a4a9f0d0c275c0daa43021 )
-)
-
-game (
-	name "Pilot Kids (Model 2B, Revision A)"
-	year "1998"
-	developer "Psikyo"
-	rom ( name pltkids.zip size 37303998 crc e7e64e60 md5 e90ebe437fb6f3ecb08e556f8b3254a4 sha1 e1f78c05a30bd012349be8f6aba243dd36c919cd )
-)
-
-game (
-	name "Pilot Kids (Model 2A)"
-	year "1998"
-	developer "Psikyo"
-	rom ( name pltkidsa.zip size 37739139 crc cabacd9d md5 f380a265139288ffca9e31409a69fd72 sha1 efab757eaf3b3f0f25d67fbaebd3a6ccb9d053f6 )
-)
-
-game (
-	name "Plump Pop (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
-)
-
-game (
-	name "Plus Alpha"
-	year "1989"
-	developer "Jaleco"
-	rom ( name plusalph.zip size 1014633 crc a37f8119 md5 7f936d4d34914b2b9b0577b5e1828174 sha1 2a5a7ebdf17935e70156be788590bdd64987fa94 )
-)
-
-game (
-	name "Polygonet Commanders (ver UAA)"
-	year "1993"
-	developer "Konami"
-	rom ( name plygonet.zip size 2307132 crc f5a006fe md5 65456d7fc687448d3643985a503fe9b7 sha1 b624e6deae05ff4b31abacc1774c70f782dfbc93 )
-)
-
-game (
-	name "PMA Poker"
-	year "1983"
-	developer "PMA"
-	rom ( name pma.zip size 5570 crc b779749d md5 a60521fdd8c35aeb6967a3c2d32c3052 sha1 3fb8c3c66240662893e8fd22a2cfa678631574c3 )
-)
-
-game (
-	name "PlayMan Poker (German)"
-	year "1981"
-	developer "PlayMan"
-	rom ( name pmpoker.zip size 12852 crc 243392db md5 23ec82bb1473133a3449d44509b8cd79 sha1 c779d609e229cb37cfb3fb5e48ec23532918fadd )
-)
-
-game (
-	name "Croupier (Playmark Roulette)"
-	year "1997"
-	developer "Playmark"
-	rom ( name pmroulet.zip size 942555 crc 947250c3 md5 01a1c7bdeee878b3a02be58d90519afa sha1 e804e65d5057bbb75516bea87b8b08d1d7f703c8 )
-)
-
-game (
-	name "Pnickies (Japan 940608)"
-	year "1994"
-	developer "Capcom, licensed by Compile)"
-	rom ( name pnickj.zip size 768482 crc 051b5dc5 md5 0193b457c1f8ef81575570fdf644fe2a sha1 4794c11915dc391005a26136e4cd34988e52fa23 )
-)
-
-game (
-	name "Paint _ Puzzle"
-	developer "Century?"
-	rom ( name pntnpuzl.zip size 60000 crc b37ced17 md5 5133ada5004367a0d396b76dcb0d5fe4 sha1 f94a4f8057610e7b3037387aef762c3747a2d11b )
+	rom ( name plsmaswda.zip size 24459099 crc 8c3f4bf2 md5 95073feb86a700c646db78b4d8e975d2 sha1 f70938b80b6fd83d0b0c9736ce44bc75dc23b2ed )
 )
 
 game (
 	name "Pochi and Nyaa"
 	year "2003"
 	developer "Aiky / Taito"
-	rom ( name pnyaa.zip size 21031165 crc fc5ab8b8 md5 e89e10e23ded84c81b2e3e482f73d98f sha1 54c7ac1fb32aba0606883f7d57b7d66c0f331457 )
+	rom ( name pnyaa.zip size 22377852 crc 463b39c2 md5 192bb531f3109c3fd0e698d2ad442303 sha1 cd9019cce4394b145172d7857681db874c4bb2b0 )
 )
 
 game (
@@ -38592,31 +28766,10 @@ game (
 )
 
 game (
-	name "Star Wars Pod Racer"
-	year "2001"
-	developer "Sega"
-	rom ( name podrace.zip size 4272990 crc ab86a36e md5 02cf97a61c641939ed6558a681d794c0 sha1 178449a67282520461ceebbc343215202738b4b8 )
-)
-
-game (
 	name "Poitto!"
 	year "1993"
 	developer "Metro / Able Corp."
 	rom ( name poitto.zip size 1091689 crc e5f70678 md5 a6d99aee06cdab1c459662312e423a8b sha1 80ff027ac8d235aff1c8f44bebd3a5f279bd7794 )
-)
-
-game (
-	name "Poizone"
-	year "1991"
-	developer "Eterna"
-	rom ( name poizone.zip size 485365 crc 5e906fe8 md5 1c602955ebe2aaeedb3aba21da561c24 sha1 4a6e66735f448cbf243b7e662d66aa8cc9ae197e )
-)
-
-game (
-	name "Poke Champ"
-	year "1995"
-	developer "DGRM"
-	rom ( name pokechmp.zip size 1173371 crc 97cc98b1 md5 45a3ae675377809923d143972d322566 sha1 bf5e55c64d1135dbadf70f14751b14c70cd9a62b )
 )
 
 game (
@@ -38627,24 +28780,10 @@ game (
 )
 
 game (
-	name "Poker Monarch (v2.50)"
-	year "1995"
-	developer "Extrema Systems International Ltd."
-	rom ( name poker72.zip size 367035 crc 9a8b5c6f md5 42bc13d8148c04a1050d28bf0dc8a817 sha1 edb7509c353a4d477484674206d6afba43cf0cfc )
-)
-
-game (
 	name "Poker 91"
 	year "1991"
 	developer "&lt;unknown&gt;"
 	rom ( name poker91.zip size 16139 crc 1fc3a149 md5 585cc3a12d123f477cc4c7eb6cff166e sha1 db2a34117cb6f33265218e6905bddc0506458189 )
-)
-
-game (
-	name "Poker Roulette (Version 8.22)"
-	year "1990"
-	developer "Coinmaster"
-	rom ( name pokeroul.zip size 27723 crc 79a06199 md5 7562c9cbd2d5f3c76ee9c5f97b526b34 sha1 6a9ede3e12081b0d328d4d2fe51702757d6559a0 )
 )
 
 game (
@@ -38697,13 +28836,6 @@ game (
 )
 
 game (
-	name "Pole Position (Atari version 1)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name polepos1.zip size 61856 crc fb78e5ec md5 4f54bae29089ec5688e97ebad45cba56 sha1 7745782924d6ad9aef80cff254888e4b13e7d7ef )
-)
-
-game (
 	name "Pole Position II"
 	year "1983"
 	developer "Namco"
@@ -38711,31 +28843,10 @@ game (
 )
 
 game (
-	name "Pole Position II (Atari)"
-	year "1983"
-	developer "Namco (Atari license)"
-	rom ( name polepos2a.zip size 71363 crc 8294d79f md5 5769684d2c9f5e5ac99c1895b1cc91d8 sha1 26a0f9c49b4d8673b78ca7bb1d1e743da9b48f1b )
-)
-
-game (
 	name "Pole Position II (bootleg)"
 	year "1983"
 	developer "bootleg"
 	rom ( name polepos2b.zip size 71769 crc b16c812f md5 1a77e4a0286fb2653ceed2880005a583 sha1 5e714ee682840d1405395835995bc8fa3553bd80 )
-)
-
-game (
-	name "Gran Premio F1 (Italian bootleg of Pole Position II)"
-	year "1984"
-	developer "bootleg"
-	rom ( name polepos2bi.zip size 65682 crc c7fff7d3 md5 449684f71866543b06a57394c5d53eb1 sha1 4e15d630bcd80301653be2d7cfeaedc6a8909304 )
-)
-
-game (
-	name "Pole Position (Atari version 2)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name poleposa.zip size 61883 crc dc1ed56f md5 cdb69dc8f6ab98e22fac2002f5e2dc1d sha1 7bff329b25cec068f7aa34426fc77071a11cf40d )
 )
 
 game (
@@ -38795,24 +28906,10 @@ game (
 )
 
 game (
-	name "Poly-Net Warriors (ver JAA)"
-	year "1993"
-	developer "Konami"
-	rom ( name polynetw.zip size 4042874 crc e004ac28 md5 baf38c65a205ba8b6978cbd5f7159461 sha1 16dcae2bc3428a120bdb50c2061ac31a123a085a )
-)
-
-game (
 	name "Poly-Play"
 	year "1985"
 	developer "VEB Polytechnik Karl-Marx-Stadt"
 	rom ( name polyplay.zip size 27147 crc c494b703 md5 6ad41ed4ecc9f27c29decd08d733a75e sha1 01d8cf48c2738be816ef1cf82f94267c4882d646 )
-)
-
-game (
-	name "Tobe! Polystars (ver JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name polystar.zip size 709581 crc 01a16230 md5 e69f179831d4f660327c06a75e655b00 sha1 28cab463f7de77891a324aa313c77a2286648e7f )
 )
 
 game (
@@ -38851,45 +28948,10 @@ game (
 )
 
 game (
-	name "Pontoon"
-	year "1989"
-	developer "Sega"
-	rom ( name pontoon.zip size 143701 crc efa80f97 md5 d60067d43932c2237c1f91e154f6b2b9 sha1 ad358f9c9b014c262cf0aea33efc12d02010d865 )
-)
-
-game (
 	name "Pontoon (Tehkan)"
 	year "1985"
 	developer "Tehkan"
 	rom ( name ponttehk.zip size 21561 crc 834670ce md5 79b9c5d39cd5797c9dfd1e0674bba796 sha1 724110eca09ef9aa4729e9ee03ba257cde06593c )
-)
-
-game (
-	name "Pool 10 (Italian, set 1)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10.zip size 20398 crc 84f48fe3 md5 ce613ad55bd40c2d8ba48fdb52ace5e4 sha1 8318545929fad958ba17ef9b9a40f66bb2cc0353 )
-)
-
-game (
-	name "Pool 10 (Italian, set 2)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10b.zip size 38313 crc 4e23f5c4 md5 8161d7b17d4c9cbd3d748b178e1f000c sha1 e9d7eeb699ca776b92cfb8738666d1dd1829be70 )
-)
-
-game (
-	name "Pool 10 (Italian, set 3)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10c.zip size 20385 crc 523f54b1 md5 868e229f08c9cb60948230d09cb242f1 sha1 b7304558c4fbfd25669b11db04bf5f556b28e369 )
-)
-
-game (
-	name "Pool 10 (Italian, set 4)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name pool10d.zip size 34118 crc b82878bd md5 ce9429d5ff6d200dffcdaf9c0b04282d sha1 6b755aaefdf59134ae29dbf0b2f50be56e9f3503 )
 )
 
 game (
@@ -38938,7 +29000,7 @@ game (
 	name "Pop 'n Bounce / Gapporin"
 	year "1997"
 	developer "Video System Co."
-	rom ( name popbounc.zip size 3032998 crc b6bc4f8e md5 ca4b290b4256aaa04fce46cdb8a7de38 sha1 f871b81b5f9939194dcc715f27e4b9cc1c74a296 )
+	rom ( name popbounc.zip size 4379685 crc 92cf72bf md5 39c2ba9027e6c6b870ce3877df8875a2 sha1 53654f3c7dbb87acd78f6d8d4451f3a0c4743875 )
 )
 
 game (
@@ -39012,41 +29074,6 @@ game (
 )
 
 game (
-	name "Pop n' Music 5"
-	year "2000"
-	developer "Konami"
-	rom ( name popn5.zip size 77293 crc aeb818fc md5 23abf7f31da8c3c49e41b764e187bf43 sha1 dfca6654203c72d64ad470fd4b2200a6c7ab9730 )
-)
-
-game (
-	name "Pop n' Music 7"
-	year "2001"
-	developer "Konami"
-	rom ( name popn7.zip size 77480 crc dbce2321 md5 aac067dbd72ec80cf7204093a4af21d2 sha1 a8b40435b2776d39ee2929cfe6280427a82468a8 )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07O 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpop.zip size 5652566 crc a8bb9331 md5 bdb8ef0c629e68fed1b41b2f4c9ae7c5 sha1 68b3d7dfb6d2b574edf5302e1312047cde02ce77 )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07J 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpopj.zip size 5652565 crc 9d46d8bc md5 86c06feb65f08224a11077a3b2687b64 sha1 bfc1ee02351bf115934913414712cf4701f24539 )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07A 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpopu.zip size 5652565 crc 224c8974 md5 a5b73b80fa427952277c82a7ecf7c235 sha1 f85e4cbd1078100d6fec18a5b2349739b1063524 )
-)
-
-game (
 	name "Popper"
 	year "1983"
 	developer "Omori Electric Co., Ltd."
@@ -39068,44 +29095,10 @@ game (
 )
 
 game (
-	name "Port Man (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name porter.zip size 17109 crc 084fc4ae md5 2e31986952ef71edf0b4a7ec82b512f7 sha1 cae0028ff3da248ad418a774774e035af85c8518 )
-)
-
-game (
 	name "Port Man"
 	year "1982"
 	developer "Taito Corporation (Nova Games Ltd. license)"
 	rom ( name portman.zip size 16687 crc 373476f2 md5 8bf09ee70b1a56147442e8be7505435b sha1 f193f1d74cee8a9b6477042797d83781828b508c )
-)
-
-game (
-	name "Portraits (set 1)"
-	year "1983"
-	developer "Olympia"
-	rom ( name portrait.zip size 55822 crc 2c226293 md5 5e3fd30251ecdb80b1b0415b7f101f05 sha1 08f5eb76fb5aa1f565009294478de8af49ab271c )
-)
-
-game (
-	name "Portraits (set 2)"
-	year "1983"
-	developer "Olympia"
-	rom ( name portraita.zip size 55901 crc f26fa140 md5 3ba4810c27a6f244e6cce7035da91fd9 sha1 063d7c27e5ee1127da93000eb39440f2f0942ded )
-)
-
-game (
-	name "Pot Game (Italian)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name potgame.zip size 18056 crc 87924391 md5 c08ca9b28c3482282bb1000a8098453a sha1 5b010fc3ae5d2207bce0a0473fc8c679de403a96 )
-)
-
-game (
-	name "Jack Potten's Poker (set 2)"
-	developer "bootleg"
-	rom ( name potnpkra.zip size 10560 crc 61409662 md5 40f807a0e06347c05bd3b92771534c0f sha1 96a41e18233506df6bbecb0184a788a8ac005e8d )
 )
 
 game (
@@ -39124,12 +29117,6 @@ game (
 	name "Jack Potten's Poker (set 5)"
 	developer "bootleg"
 	rom ( name potnpkrd.zip size 10542 crc acf7705f md5 03a0d46c42844af87c99c4d9d822569d sha1 6d8d05ac4915793299b6ffd32e3e6e70cc1511f3 )
-)
-
-game (
-	name "Jack Potten's Poker (set 6)"
-	developer "bootleg"
-	rom ( name potnpkre.zip size 10684 crc b38a1a8e md5 e27b2d35cc8fd8f5c2ed7620600fa773 sha1 a4c33c9c84c4a4e3eb212e88a937d8b68f633403 )
 )
 
 game (
@@ -39178,13 +29165,6 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name pow.zip size 806437 crc f6157c0e md5 5f70874fb2f3708253d46eb4331d0edb sha1 e92d354061cce1ac548d402f6cebde20841d8712 )
-)
-
-game (
-	name "Power Balls"
-	year "1994"
-	developer "Playmark"
-	rom ( name powerbal.zip size 1561777 crc f12ad31f md5 0b47ed0acf97cdf809bb74ac2c209f12 sha1 24a4710947ebd0f923e3725292c6195c157de633 )
 )
 
 game (
@@ -39251,13 +29231,6 @@ game (
 )
 
 game (
-	name "Pang Pang Car"
-	year "1999"
-	developer "Icarus"
-	rom ( name ppcar.zip size 4620728 crc 0ac2e1ea md5 d677bf19491b14db1c1ab66b10d7d1e7 sha1 12cb6224b316f4c73c757edf0e1d9b54744c6611 )
-)
-
-game (
 	name "Pasha Pasha Champ Mini Game Festival (Korea)"
 	year "1997"
 	developer "Dongsung"
@@ -39265,38 +29238,10 @@ game (
 )
 
 game (
-	name "ParaParaDancing"
-	year "2000"
-	developer "Konami"
-	rom ( name ppd.zip size 45738 crc 2a5cb780 md5 7db360e84cdfae2d7b35f0dec92d3c5d sha1 49401c056e8744b26ef5271803d1fa9a0462ea19 )
-)
-
-game (
-	name "Ping-Pong King"
-	year "1985"
-	developer "Taito America Corporation"
-	rom ( name ppking.zip size 76329 crc 4e4fedc0 md5 8331c11e78040962881f64e073059e2f sha1 e315a3a3525e063e36bb5cbdefaef867d4890d29 )
-)
-
-game (
 	name "Ping Pong Masters '93"
 	year "1993"
 	developer "Electronic Devices S.R.L."
 	rom ( name ppmast93.zip size 118481 crc 04d7409f md5 b55b8b1175cde60ee51234d200dce4eb sha1 86d9bcd3fc74c8d45507421da09460f7dd0da2f7 )
-)
-
-game (
-	name "ParaParaParadise"
-	year "2000"
-	developer "Konami"
-	rom ( name ppp.zip size 45737 crc 7cdfee29 md5 575700551afee00f6695d7fe8ff3ab91 sha1 42264ac7aa99d56187d3ff8d6741ddb354d4e2d3 )
-)
-
-game (
-	name "ParaParaParadise v1.1"
-	year "2000"
-	developer "Konami"
-	rom ( name ppp11.zip size 45737 crc 7cdfee29 md5 575700551afee00f6695d7fe8ff3ab91 sha1 42264ac7aa99d56187d3ff8d6741ddb354d4e2d3 )
 )
 
 game (
@@ -39317,14 +29262,14 @@ game (
 	name "Prehistoric Isle 2"
 	year "1999"
 	developer "Yumekobo"
-	rom ( name preisle2.zip size 54664858 crc 9fa6284b md5 642c06c4de3335a2e53ad8f64142ac9d sha1 707b8f7d93af0afd03f86f818c41ab23cafbabb5 )
+	rom ( name preisle2.zip size 56011545 crc 35257b8c md5 8022fcfd00fb91d510aedb75e8ebb813 sha1 ec3d1d84f32fa4586be9de88c5401df011bd86f2 )
 )
 
 game (
 	name "Princess Clara Daisakusen (J 960910 V1.000)"
 	year "1996"
 	developer "Atlus"
-	rom ( name prikura.zip size 6253034 crc b20685d4 md5 a2a087f16bf85d079ebff2b782d80bd4 sha1 8e5b1234e353dd4be13558d636c2cc0bbab706e3 )
+	rom ( name prikura.zip size 8952255 crc d03eb53c md5 ba7f5675e158696cd174c39fb851bc0f sha1 0020b43ac5d654779cc168aabacdc512f574e862 )
 )
 
 game (
@@ -39339,33 +29284,6 @@ game (
 	year "1996"
 	developer "Namco"
 	rom ( name primglex.zip size 9906991 crc 6ce3fcaa md5 6785c37e8fe3e0a7b8d2697b8cda7a5c sha1 4f51683dbdd174d2a4b6e2c987407043ee12f899 )
-)
-
-game (
-	name "Primal Rage 2 (Ver 0.36a)"
-	year "1996"
-	developer "Atari"
-	rom ( name primrag2.zip size 576120 crc 9427ea35 md5 540617cd1614ec80e0af4383c7f9e2aa sha1 7bdedd84553cbd594c3f4671b9e468d0a37b045b )
-)
-
-game (
-	name "Primal Rage (version 2.3)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name primrage.zip size 24306046 crc 2dbfa62b md5 9df56777c1a4ce242d3f50253a07fa52 sha1 77fa4b3de41d055bc4d93f40f0ce53cc3c64363a )
-)
-
-game (
-	name "Primal Rage (version 2.0)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name primrage20.zip size 24048491 crc 81e4ddf1 md5 585dc706bde9b7dc3713703b0bf13116 sha1 b1802b5cb5a106a4adf5431107eb3a7facbe4aed )
-)
-
-game (
-	name "Prize Space Invaders (20&quot; v1.1)"
-	developer "BwB"
-	rom ( name prizeinv.zip size 90054 crc 4c2aed12 md5 458dbdac0c1a6100ce20b82b170b56aa sha1 ffc23e6a38bcbffe0ace8690f5f403a48fef5ef0 )
 )
 
 game (
@@ -39436,13 +29354,6 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name progolf.zip size 18460 crc 0f82452f md5 be42427222ed63fbc1791b88a041ea7c sha1 99c2a19d85e5b70a796d90e4bb580f956b853dd4 )
-)
-
-game (
-	name "18 Holes Pro Golf (set 2)"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name progolfa.zip size 19101 crc 3014b397 md5 6086f235159f34b6efa770211526ee33 sha1 914c4c470194dd6ba859981f7aaa381bdab9ca68 )
 )
 
 game (
@@ -39537,13 +29448,6 @@ game (
 )
 
 game (
-	name "P's Attack"
-	year "2004"
-	developer "Uniana"
-	rom ( name psattack.zip size 423836 crc 54317ed2 md5 bb488ccf4c57e426f51a72eeac0e2003 sha1 c80a267c0a710ffcb6452e928152fbe169a2c423 )
-)
-
-game (
 	name "Perfect Soldiers (Japan)"
 	year "1993"
 	developer "Irem"
@@ -39561,7 +29465,7 @@ game (
 	name "Power Spikes II"
 	year "1994"
 	developer "Video System Co."
-	rom ( name pspikes2.zip size 3985176 crc 127c6856 md5 299bc51fabbe2cbef20d37369af1eb5d sha1 09fa9a94f2f64f386dc256266b85d4635460f9e3 )
+	rom ( name pspikes2.zip size 5331863 crc 26eae3ae md5 3a3e76473d3a2aa27f3d36ae7c997879 sha1 16ec782a71adcfc01b0897e532159250d9fb89d5 )
 )
 
 game (
@@ -39586,37 +29490,10 @@ game (
 )
 
 game (
-	name "New Super 3D Golf Simulation - Waialae No Kiseki / Super Mahjong 2 (Super Famicom Box)"
-	developer "T&amp;E Soft / I&apos;Max"
-	rom ( name pss62.zip size 679542 crc 18dec073 md5 7d212a0f172c4aca00f30b5eed0da823 sha1 be57ca77b30ae5c025da51e20335a8b41a5f394d )
-)
-
-game (
 	name "Mahjong Panic Stadium (Japan)"
 	year "1990"
 	developer "Nichibutsu"
 	rom ( name pstadium.zip size 418203 crc d56279b6 md5 741835ffd943993da5208c53da01a204 sha1 4e3ff2f9a8f50b3fe6e8b92f9f72f6e689611ef4 )
-)
-
-game (
-	name "Power Stone (JPN, USA, EUR, ASI, AUS)"
-	year "1999"
-	developer "Capcom"
-	rom ( name pstone.zip size 36436166 crc bcdf2426 md5 63e026bf487ee9b0bbc8295b9ed62126 sha1 aa3793f0505257107d4bd32bfbd829049b1e38f5 )
-)
-
-game (
-	name "Power Stone 2 (JPN, USA, EUR, ASI, AUS)"
-	year "2000"
-	developer "Capcom"
-	rom ( name pstone2.zip size 50086377 crc 42ec3b49 md5 80f900261580b50eee83bb8dc11a2e87 sha1 645f4b235ca375dd7fe9d1f17cfeed2aa9b1b6d6 )
-)
-
-game (
-	name "Power Surge"
-	year "1988"
-	developer "&lt;unknown&gt;"
-	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
 )
 
 game (
@@ -39651,28 +29528,35 @@ game (
 	name "Psychic Force (Ver 2.4O)"
 	year "1995"
 	developer "Taito"
-	rom ( name psyforce.zip size 5683682 crc 5ebf397f md5 3d3dddc9be7c1152f03da004adfd0592 sha1 ad4f947e96606a1c829832e6139c0450aa9323a0 )
+	rom ( name psyforce.zip size 5809820 crc eea18945 md5 e9fdab37afa977a8e3f721d2c45a887f sha1 5b235185cb5153a9171654bfd6c2b329f4b81f16 )
 )
 
 game (
 	name "Psychic Force (Ver 2.4J)"
 	year "1995"
 	developer "Taito"
-	rom ( name psyforcej.zip size 5683676 crc f6aee39c md5 8a883ed119d62c083d13696f62e32e81 sha1 0d69b9fc66b11ea7fa76aaebcc2de808ad470283 )
+	rom ( name psyforcej.zip size 5809814 crc 18d86610 md5 3eea52887ba7a1e64b7a82db762ac2fe sha1 2f717850c0c62051d2df87d024946ce2c00d879b )
 )
 
 game (
 	name "Psychic Force EX (Ver 2.0J)"
 	year "1995"
 	developer "Taito"
-	rom ( name psyforcex.zip size 5906897 crc 5e08164f md5 70fe8cb345344f5647b062a2cdf97ef8 sha1 e8e44c4929ad2e50f7e400396873761070dd0bba )
+	rom ( name psyforcex.zip size 6033035 crc 16885fab md5 209b44c7a308f1091a9d869cffb3dddf sha1 5a3494c008049ec6b0037ead82a498745560198d )
 )
 
 game (
-	name "Psyvariar 2 - The Will To Fabricate (GDL-0024)"
-	year "2003"
-	developer "G-Rev"
-	rom ( name psyvar2.zip size 1197 crc 78c151c7 md5 46425f48b615a04728683e186d914d62 sha1 af7d50c9191cc5df308f35c84a43a82c7118c0d5 )
+	name "Psyvariar -Medium Unit- (V2.04J)"
+	year "2000"
+	developer "Success"
+	rom ( name psyvaria.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
+	name "Psyvariar -Revision- (V2.04J)"
+	year "2000"
+	developer "Success"
+	rom ( name psyvarrv.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -39694,13 +29578,6 @@ game (
 	year "1999"
 	developer "Namco"
 	rom ( name ptblnk2a.zip size 15068749 crc eaf370a4 md5 cd34ef742602e5cc1a2822f077c49c32 sha1 0be4e4a93f3d6415bb742db9e5e672beb75d86cd )
-)
-
-game (
-	name "PT Reach Mahjong (Japan)"
-	year "1979"
-	developer "Irem"
-	rom ( name ptrmj.zip size 8496 crc 18900a9d md5 af127bd1a65d157998d797c54f7f4ce7 sha1 c80144f73e6d2ad8bea2987cf5fd9ddbd1d2aa69 )
 )
 
 game (
@@ -39760,12 +29637,6 @@ game (
 )
 
 game (
-	name "Puck People"
-	developer "Microhard"
-	rom ( name puckpepl.zip size 512087 crc 5b5c39e8 md5 939d35220f5071e670440f432d8be5b8 sha1 3ba8bb98ad757ec132cc18e40aed4ff787e04767 )
-)
-
-game (
 	name "Puckman Pockimon"
 	year "2000"
 	developer "Genie"
@@ -39804,7 +29675,7 @@ game (
 	name "Pulstar"
 	year "1995"
 	developer "Aicom"
-	rom ( name pulstar.zip size 18755786 crc 6954e191 md5 c230f295dee4aac52ac940c5a357fb82 sha1 6f3d159679ae50cbb466b939c74c7fd062b3c400 )
+	rom ( name pulstar.zip size 20102473 crc 540bbe3e md5 b071ee93c4a36d08f3a804eedf326c51 sha1 1b6b63c7479073151dcbc77e9c149f53ca17f30c )
 )
 
 game (
@@ -39822,52 +29693,10 @@ game (
 )
 
 game (
-	name "The Punisher (bootleg with PIC16c57, set 1)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic.zip size 3036818 crc 8f0c308a md5 bb2aff87f655f431a8390caa25e0e9c4 sha1 1aaa8d96a7159b88d252d097ffdaadff1f1b2b99 )
-)
-
-game (
-	name "The Punisher (bootleg with PIC16c57, set 2)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic2.zip size 2977697 crc d07bbdce md5 ffed7100f0772e4cbc8aeb26d19d6a71 sha1 43c12ca05f02b09eff8c2a3c3967a9698b583a24 )
-)
-
-game (
-	name "The Punisher (bootleg with PIC16c57, set 3)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic3.zip size 2522756 crc 2732f08a md5 d8d2f64191e5a8bdc947bb0ab1f2aa2d sha1 2de7a5029145a0a5d86afecfe2700c061d0299bb )
-)
-
-game (
-	name "The Punisher (World 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisher.zip size 4041934 crc 817cbb2a md5 57fdbc0298708807a43ff37890d864a0 sha1 e420fe80faa14ac8a36a9ed93f1698cfec5d60aa )
-)
-
-game (
 	name "Biaofeng Zhanjing (Chinese bootleg of The Punisher)"
 	year "1993"
 	developer "bootleg"
 	rom ( name punisherbz.zip size 2797190 crc 6012cad2 md5 4be2d44bf65707371f9036bdc38d49ad sha1 c7aca8773fe695017edd43c223528c87027a19e4 )
-)
-
-game (
-	name "The Punisher (Japan 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisherj.zip size 4023387 crc d938f8cf md5 c7a7f5801fac3abc293716c28e2c3570 sha1 ff3ab6ab0ccf35793ae0cc62b606efecaa19d739 )
-)
-
-game (
-	name "The Punisher (USA 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisheru.zip size 4041938 crc 30adae89 md5 84175a2e1843edaa21f47bafbe2f17b5 sha1 67f7339bfc668a3bbc1356c2aefc6d731c460b27 )
 )
 
 game (
@@ -39941,13 +29770,6 @@ game (
 )
 
 game (
-	name "Puyo Puyo Fever (GDS-0031)"
-	year "2003"
-	developer "Sega"
-	rom ( name puyofev.zip size 1197 crc eba1e1ab md5 e08f0a50617366fe8388add87c647491 sha1 301f83a958e8b39ba69372283b8e6d0dfab571b8 )
-)
-
-game (
 	name "Puyo Puyo (Japan, Rev B)"
 	year "1992"
 	developer "Sega / Compile"
@@ -39972,7 +29794,7 @@ game (
 	name "Puyo Puyo Sun (J 961115 V0.001)"
 	year "1996"
 	developer "Compile"
-	rom ( name puyosun.zip size 22599864 crc 1f5fdc32 md5 c8d1ddb7c651ca38c91c8762a5695ae7 sha1 955aeda4abb8c63b4784a727339166b5c3539177 )
+	rom ( name puyosun.zip size 25299085 crc 33f71b9b md5 237bd596965af95fa5395361f83af0ea sha1 e5e5de6d8639db32ebddacdc127c69d481ee6363 )
 )
 
 game (
@@ -39993,42 +29815,14 @@ game (
 	name "Taisen Puzzle-dama (ver JAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name puzldama.zip size 5451926 crc 33b86169 md5 6ff9f29d51eca13aee193d355046a607 sha1 8ee3d40598e5bdd9aaa4db8ab7303691e2bbe0f2 )
-)
-
-game (
-	name "Puzzle Star (ver. 100MG)"
-	year "1999"
-	developer "IGS"
-	rom ( name puzlstar.zip size 5980261 crc 07540417 md5 2215b469a2447b9ed0cd6ab4043cd006 sha1 a4623c6ca421e4bd971048e3f9cd56c2bc7e4dc7 )
-)
-
-game (
-	name "Puzzle De Pon! R!"
-	year "1997"
-	developer "Taito (Visco license)"
-	rom ( name puzzldpr.zip size 766727 crc 7d697920 md5 b1b62791e3573511f9fa7d75d31121d9 sha1 89e6ef339af21e9fbce20441df6440de26a44d18 )
+	rom ( name puzldama.zip size 5460616 crc 213af0bc md5 80b45a71bc6317d4f7a77fae043da012 sha1 5727d71767de3e168a4c3beaba07d3899597b263 )
 )
 
 game (
 	name "Puzzle De Pon!"
 	year "1995"
 	developer "Taito (Visco license)"
-	rom ( name puzzledp.zip size 768736 crc e8e81a72 md5 e96a70a21c06683e986cad0cadcd042b sha1 532d979a0405405797c3ff9e5ba640d56ebf8b6e )
-)
-
-game (
-	name "Puzzle King (Dance _ Puzzle)"
-	year "1998"
-	developer "Eolith"
-	rom ( name puzzlekg.zip size 16929954 crc 37b3dffa md5 d427c9a9cbd94df26b2b6eb134de9ea1 sha1 4920c768baca49f34b05f5c9c4d9cfbe0dc8a959 )
-)
-
-game (
-	name "Puzzlet (Japan)"
-	year "2000"
-	developer "Unies Corporation"
-	rom ( name puzzlet.zip size 4251221 crc 1ba5df9f md5 e740870223f1dd733fa1761c6c8ae2cb sha1 7f3dfa70446915788ced5388da9723f2ee2f2aff )
+	rom ( name puzzledp.zip size 2115423 crc 78a259ca md5 ba70e9e81ee78f378ef5ec29bcc1a77e sha1 263508947027137a3879bb72b31987a29d52f285 )
 )
 
 game (
@@ -40039,52 +29833,38 @@ game (
 )
 
 game (
-	name "Puzzli 2 Super (ver. 200)"
-	year "2001"
-	developer "IGS"
-	rom ( name puzzli2.zip size 5126339 crc 7788fab5 md5 818937b3ac103e122b4a83508409f643 sha1 bf700269ad69e13e94a90a3e35fa66ce4ebb6203 )
-)
-
-game (
 	name "Puzz Loop (Europe)"
 	year "1998"
 	developer "Mitchell"
-	rom ( name puzzloop.zip size 6091824 crc b529873b md5 0e46ac11cce225dba359b8e4dd21f97b sha1 d0acfc4099987865ab3d10c58b794aa1064c80b1 )
+	rom ( name puzzloop.zip size 6368239 crc 1d950b35 md5 8a2b942d0f28b140ea2fda0c62cc2c5d sha1 6b5bb41d11c47fadf877dafc001c6c0ec36ead26 )
 )
 
 game (
 	name "Puzz Loop (Asia)"
 	year "1998"
 	developer "Mitchell"
-	rom ( name puzzloopa.zip size 6096367 crc 841464e0 md5 dc0fe9d889cfd6efc0375d49d9f22bc9 sha1 55e79cb989fcfafa43212c64b1ce7d5b10cd68df )
+	rom ( name puzzloopa.zip size 6258082 crc 024cbc3d md5 0e36363fa0a52010d04dbb704bf53fb0 sha1 5730fc6f41047ab84547d918b8926bbdad88cbb0 )
 )
 
 game (
 	name "Puzz Loop (Japan)"
 	year "1998"
 	developer "Mitchell"
-	rom ( name puzzloopj.zip size 6105346 crc 3201cc66 md5 41e2026c545feab41ce5e796d6fbac30 sha1 c1fd92f47681c008490c8938406116a362b4a149 )
+	rom ( name puzzloopj.zip size 6137367 crc f1d0c818 md5 c4dbe13d36996e791afeef75774167f7 sha1 07fa47582f1b19dd97434ac722bebc30b88b415e )
 )
 
 game (
 	name "Puzz Loop (Korea)"
 	year "1998"
 	developer "Mitchell"
-	rom ( name puzzloopk.zip size 6096712 crc 97410f27 md5 21644e02012e22e3a775e192832264a0 sha1 8479a3abe97133efdc6162f8d8ec1fa2e89929c2 )
+	rom ( name puzzloopk.zip size 6247834 crc 7fc79400 md5 cf7db0ef66b81b89a8c74094359e6286 sha1 06b032619b75c65db217ece624b4eccfd1a4d555 )
 )
 
 game (
 	name "Puzz Loop (USA)"
 	year "1998"
 	developer "Mitchell"
-	rom ( name puzzloopu.zip size 6097028 crc e5bd6cb3 md5 02186be06aba6ff45f2032a2ed8218bc sha1 07bd58fb09583c9496967ab0cdf4d09f412e7e57 )
-)
-
-game (
-	name "Puzznic (World)"
-	year "1989"
-	developer "Taito Corporation Japan"
-	rom ( name puzznic.zip size 55467 crc bc6229c3 md5 bdfefff6e6bf604499f43ee5bad2318b sha1 bb29be31df5ba1a6f51d90cbd39ea186e83b6a82 )
+	rom ( name puzzloopu.zip size 6259499 crc 8c186079 md5 b815040f6fcb08f1eaefe1226091b843 sha1 3c4c404ed980a497e37257845ee29d7912fcf534 )
 )
 
 game (
@@ -40092,13 +29872,6 @@ game (
 	year "1989"
 	developer "bootleg"
 	rom ( name puzznici.zip size 130658 crc 5de407ba md5 ca623ca75bbf7755726348ad786a2509 sha1 11b709be85ec2973d2d15780ea8c098241d8da9d )
-)
-
-game (
-	name "Puzznic (Japan)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name puzznicj.zip size 130560 crc beba7156 md5 cc1052a40ee31a1ce60e398c3ea4f25f sha1 23262726e766c491e3f4f3b88a5fd64f365bcc84 )
 )
 
 game (
@@ -40130,13 +29903,6 @@ game (
 )
 
 game (
-	name "Photo Y2K 2"
-	year "2001"
-	developer "IGS"
-	rom ( name py2k2.zip size 27835941 crc 5de8ef4b md5 8aff53bbe6174c50a40fb8468bdb58d8 sha1 2fb92b79d487268f66e38e8ac7d1bf0018210b8c )
-)
-
-game (
 	name "Pyramid (Dutch, Game Card 95-750-898)"
 	year "1996"
 	developer "BFM/ELAM"
@@ -40155,20 +29921,6 @@ game (
 	year "1999"
 	developer "Nihon System / Moss"
 	rom ( name pzlbowl.zip size 5900443 crc eb81a5b5 md5 4c7055693eebd84727f1dd47e5f081f4 sha1 8043c25613252b5030fad20e5c55ab5f9045ceac )
-)
-
-game (
-	name "Puzzle Break"
-	year "1997"
-	developer "SemiCom"
-	rom ( name pzlbreak.zip size 524061 crc b3502f4b md5 02282e91d44e492181781d612bf26cda sha1 875582b56386d025224b8f3696f56b820c812fac )
-)
-
-game (
-	name "Puzzle Star (Sang Ho Soft)"
-	year "1991"
-	developer "Sang Ho Soft"
-	rom ( name pzlestar.zip size 765254 crc 02daa45d md5 2e6bf54af0fd649e4680593e31ef6b2f sha1 3c3b7537b61ab8002ed3fc032745e436fdd7b6f0 )
 )
 
 game (
@@ -40252,13 +30004,6 @@ game (
 	year "1982"
 	developer "Gottlieb"
 	rom ( name qbtrktst.zip size 24851 crc 4545777c md5 03cc321a127d3be9ddf3edb253ac90bf sha1 a11e31aac3963830a6e7486c1b90f35cb68a561c )
-)
-
-game (
-	name "Quarter Horse Classic"
-	year "1995"
-	developer "ArJay Exports/Prestige Games"
-	rom ( name qc.zip size 18292 crc 023773e2 md5 3eb44c6c0db6a012401a1e6fca08f7f8 sha1 ec84c118c061dda50d7ccd5b5392096aaaa0ac13 )
 )
 
 game (
@@ -40346,13 +30091,6 @@ game (
 )
 
 game (
-	name "Quiz Ah Megamisama (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name qmegamis.zip size 53636039 crc 3f2c6b05 md5 0289358b0886a0a57c157a406aeb75a0 sha1 848db79eaef056f209ae3b56ff4ef11bbbdc2a44 )
-)
-
-game (
 	name "Quiz-Mahjong Hayaku Yatteyo! (Japan)"
 	year "1991"
 	developer "Nichibutsu"
@@ -40402,13 +30140,6 @@ game (
 )
 
 game (
-	name "Queen of the Nile (B - 13-05-97, NSW/ACT)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name qotn.zip size 822082 crc 9f35e68e md5 1c4fa85128b3d8b471e5a1c294e7aa1c sha1 0f618b889c582e098a7a64dfa00946fa4693b673 )
-)
-
-game (
 	name "Quiz Rouka Ni Tattenasai (Japan, ROM Based)"
 	year "1991"
 	developer "Sega"
@@ -40444,45 +30175,10 @@ game (
 )
 
 game (
-	name "Quiz Tonosama no Yabou 2: Zenkoku-ban (Japan 950123)"
-	year "1995"
-	developer "Capcom"
-	rom ( name qtono2j.zip size 1944928 crc 9064b2b9 md5 8f1424cf328dcd7a007a4a4be0c7eea3 sha1 b965ed1b1f8a248ad8e8aa2f02a11a6648f95779 )
-)
-
-game (
 	name "Quiz Torimonochou (Japan)"
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name qtorimon.zip size 513555 crc e41953d4 md5 814be223337a21e1df927e9e569fe9c3 sha1 e0169b435c4bea7ebafdbb2e7d064f17bf257a91 )
-)
-
-game (
-	name "Quantum (rev 2)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantum.zip size 47012 crc 74b2f516 md5 ce561fb1a17ed9989a3cafee44cf1faf sha1 4af46ae800a4320c270eec78a9230580d911c26c )
-)
-
-game (
-	name "Quantum (rev 1)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantum1.zip size 47016 crc 65ad3398 md5 f24741c261a527ed077badb2a63afe8c sha1 d2a60559b3b961c0ec5dfeee04d84eece0953e04 )
-)
-
-game (
-	name "Quantum (prototype)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantump.zip size 46725 crc 38dda378 md5 7382d1aefd8fa4cf54a68e6d8270412f sha1 aa58fa3918efd0330fcd52aa387f21047a9111f9 )
-)
-
-game (
-	name "Quadro Quiz II"
-	year "1985"
-	developer "Status Games"
-	rom ( name quaquiz2.zip size 141444 crc 24bb6312 md5 24b6f480c22d08d8af43f141037c0fed sha1 60f6dd68d3353e6e89fd30a8c45133266a097806 )
 )
 
 game (
@@ -40500,34 +30196,6 @@ game (
 )
 
 game (
-	name "Quarter Horse (set 1, Pioneer PR-8210)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterh.zip size 13457 crc ed45698c md5 82273517b345cd1a39d86814bc33297d sha1 ebd4f9ca0faf5d7887d8b720e2b31129b7723e76 )
-)
-
-game (
-	name "Quarter Horse (set 2, Pioneer PR-8210)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterha.zip size 13353 crc 86b2b83a md5 a861ca1b9345aafc8710608cf36fc757 sha1 946ace45f60cec4e8a31391c1801d605d56de50d )
-)
-
-game (
-	name "Quarter Horse (set 3, Pioneer LD-V2000)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterhb.zip size 12419 crc 76c78ad2 md5 f662b6a208cd57fd600e12d5573a9c9d sha1 53889373338218234f9701c9bda8ca66e68f5155 )
-)
-
-game (
-	name "Quartet (Rev A, 8751 315-5194)"
-	year "1986"
-	developer "Sega"
-	rom ( name quartet.zip size 329453 crc c435ece7 md5 b72d5f4ce8cb5ecf244c17f26983c214 sha1 8d28c61e7a3a48d866922e9ec3306c2f969e5d42 )
-)
-
-game (
 	name "Quartet 2 (8751 317-0010)"
 	year "1986"
 	developer "Sega"
@@ -40539,13 +30207,6 @@ game (
 	year "1986"
 	developer "Sega"
 	rom ( name quartet2a.zip size 330874 crc 6d4219a2 md5 0baa6a90db48c71effbdd3f7f5537727 sha1 8ad2837dfe85779ba7da21b130efc1be77bed471 )
-)
-
-game (
-	name "Quartet (8751 315-5194)"
-	year "1986"
-	developer "Sega"
-	rom ( name quarteta.zip size 329383 crc 5c218823 md5 2300c5da2b76075445d1f4a901827f29 sha1 ab0bc6b38812042bb99814bd0a9e5cac5e1f2ddc )
 )
 
 game (
@@ -40570,68 +30231,10 @@ game (
 )
 
 game (
-	name "Queen?"
-	developer "STG"
-	rom ( name queen.zip size 225714 crc f2071c29 md5 697d7bee7b6e7bf96e1b16f9ba8376f5 sha1 0338a0cacd02b630e10250dfd9de88da03ac0179 )
-)
-
-game (
 	name "Quester (Japan)"
 	year "1987"
 	developer "Namco"
 	rom ( name quester.zip size 160104 crc b48ef65a md5 2f1f39658ff5ec6dd90dd51cb295cf5f sha1 1478023c8c2e9efe79ea3443f615f51403fd2e8e )
-)
-
-game (
-	name "Quick Jack"
-	year "1993"
-	developer "ADP"
-	rom ( name quickjac.zip size 93912 crc cf1727d1 md5 b7fa9b0c3d139d0c0148f1bc7841bcd7 sha1 b5c72e96ba266bddc13deb6e470ff6e31cd821d6 )
-)
-
-game (
-	name "Ten Quid Grid (v1.2)"
-	developer "Barcrest"
-	rom ( name quidgrid.zip size 65736 crc 2a47a853 md5 b14ff0e817e6bd3b6664d7c498bc75e4 sha1 44c4d51063ca02fa5ba67c0bd732956eed544137 )
-)
-
-game (
-	name "Ten Quid Grid (v2.4)"
-	developer "Barcrest"
-	rom ( name quidgrid2.zip size 71061 crc 4f905f49 md5 934d32d20fd73798fd222fcd29277079 sha1 e435bac31641050adea7f7f8c261e958ff40da69 )
-)
-
-game (
-	name "Ten Quid Grid (v2.4, Datapak)"
-	developer "Barcrest"
-	rom ( name quidgrid2d.zip size 71062 crc 541b59e6 md5 b3a2ab3b3088b8785d5c809796da36ea sha1 b3c4e57508dff10eede21d0867e9172741244977 )
-)
-
-game (
-	name "Ten Quid Grid (v1.2, Datapak)"
-	developer "Barcrest"
-	rom ( name quidgridd.zip size 65738 crc 526d817a md5 dc22a3ee673ab0724645feced42ff2c6 sha1 f98cb4d573bf5d01e20a7004d0c7989a46a8b2f9 )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-751-206, Datapak)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintond.zip size 127596 crc 1145ffd4 md5 46e3636ad0acfd85e4e74cc365055a08 sha1 01902f61fefafbf2ee048235f4f5724c894c3c7e )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-750-203)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintono.zip size 127821 crc e4d12384 md5 4699b292c00ea58fb913881d0da46da8 sha1 b2f2b2499943f7db36fc61039b491ad3ab0925c0 )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-750-206)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintoon.zip size 127592 crc bd7226f5 md5 2f6531f18028f7e9a9496189ab917ba6 sha1 6b50a5860783238f0959f0c4ad73cc82ca70bacb )
 )
 
 game (
@@ -40649,59 +30252,24 @@ game (
 )
 
 game (
-	name "Quiz (Revision 2.11)"
-	year "1991"
-	developer "Elettronolo"
-	rom ( name quiz211.zip size 53546 crc e631a1b3 md5 12eecfa9add482b36d5d29f7026a873d sha1 da0274db8b6291243fd5d9f6c060f240ea4fe927 )
-)
-
-game (
-	name "Quiz 365 (Japan)"
-	year "1994"
-	developer "Nakanihon"
-	rom ( name quiz365.zip size 3973379 crc b0784e6f md5 309eb1312dc849ca346224f88af36569 sha1 ad090679bf478f8ee793dd9cee846c278d7e5825 )
-)
-
-game (
-	name "Quiz 365 (Hong Kong _ Taiwan)"
-	year "1994"
-	developer "Nakanihon / Taito"
-	rom ( name quiz365t.zip size 4273399 crc e5528489 md5 96466de0f6f49ab14a5d2b3954273113 sha1 ea838bcde71908dc4b2be61a278cdf047a56bd87 )
-)
-
-game (
-	name "Quiz Channel Question (Ver 1.00) (Japan)"
-	year "1993"
-	developer "Nakanihon"
-	rom ( name quizchq.zip size 2832492 crc 4c34416a md5 2a55ec49afb183de169019e22548081a sha1 972fe354d25f0b8396a907a72491dd97503a09a8 )
-)
-
-game (
-	name "Quiz Channel Question (Ver 1.23) (Taiwan?)"
-	year "1993"
-	developer "Nakanihon (Laxan license)"
-	rom ( name quizchql.zip size 3272924 crc 7e9eba6a md5 a88a22f2a6ac4b52a20915a785dde5af sha1 bf6d131edceecd03f52c5dabdf2248c1eea3be95 )
-)
-
-game (
 	name "Quiz Meitantei Neo _ Geo - Quiz Daisousa Sen part 2"
 	year "1992"
 	developer "SNK"
-	rom ( name quizdai2.zip size 3506219 crc 00099843 md5 fbb7d0b34bf21aaf4d135ce1b6a3d00d sha1 62b0740e598b31c9a62eab1972017d67f8c5ebd8 )
+	rom ( name quizdai2.zip size 4852906 crc 75371d73 md5 f36ebbd62adac58b0f091af784e68de0 sha1 5a65dc51bcef672840f2bdeb0f5b3f8ff7d1b0fc )
 )
 
 game (
 	name "Quiz Daisousa Sen - The Last Count Down"
 	year "1991"
 	developer "SNK"
-	rom ( name quizdais.zip size 2069136 crc 797d9111 md5 8ebe4db6372e3d56c907819c2f1272d1 sha1 cc0d2ce8ef11a71b048e5495cbc3d589dddf6c0f )
+	rom ( name quizdais.zip size 3415823 crc cf87b3a2 md5 0acdb60245ea6e1734582990ec6e6923 sha1 ee4bc058b1cc56363468738e66928bc7763153f0 )
 )
 
 game (
 	name "Quiz Daisousa Sen - The Last Count Down (Korean release)"
 	year "1991"
 	developer "SNK"
-	rom ( name quizdaisk.zip size 2220045 crc 53442119 md5 b0892c767b479e52a1efc860a27d324c sha1 b80021829a3ead65f02e72a55d59b586c80d4b66 )
+	rom ( name quizdaisk.zip size 3566732 crc 12a858a4 md5 bb92866adbda523ab840549e3ec4af4e sha1 19999884ae6364bfab9da96efed8a723951fee7e )
 )
 
 game (
@@ -40736,14 +30304,14 @@ game (
 	name "Quiz King of Fighters"
 	year "1995"
 	developer "Saurus"
-	rom ( name quizkof.zip size 8649159 crc 887ce5b8 md5 085f17a245379e9c1836ecfdf419cd92 sha1 525711b8ce0ddde9643a0e6ed33ded93e4e0ea58 )
+	rom ( name quizkof.zip size 9995846 crc b7a1d134 md5 4e23a528a360befaa250ba2b2aa9a97b sha1 53af959ceb3606b7784fc6f9fc4ef96a65a602e0 )
 )
 
 game (
 	name "Quiz King of Fighters (Korean release)"
 	year "1995"
 	developer "Saurus"
-	rom ( name quizkofk.zip size 8677910 crc 74825161 md5 683f233f35d132b5aa320adf8f38b8e7 sha1 afc914abbf315eb41ed21bb29056b83eb55b4511 )
+	rom ( name quizkofk.zip size 10024597 crc 99ebf004 md5 9d3cb2d34ad18d81e5a80c8c2d1bd194 sha1 014d02678acd43086f6d771ff9538bceb02d502a )
 )
 
 game (
@@ -40758,13 +30326,6 @@ game (
 	year "1997"
 	developer "Banpresto"
 	rom ( name quizmoon.zip size 23097005 crc 2d8ea5bd md5 4e4372360aeb2450ed076e5e589bf7c0 sha1 45a5094f770648023dbee911c99197f2dba2072d )
-)
-
-game (
-	name "Quizmaster (German)"
-	year "1985"
-	developer "Loewen Spielautomaten"
-	rom ( name quizmstr.zip size 354249 crc 8c843197 md5 7be65f3c07beb992829f57e1de91af6a sha1 8d45a48ec9dff3000eb3bc2123d0cb0ab06d4830 )
 )
 
 game (
@@ -40789,20 +30350,6 @@ game (
 )
 
 game (
-	name "Quiz Punch 2"
-	year "1989"
-	developer "Space Computer"
-	rom ( name quizpun2.zip size 313061 crc 5d032fed md5 df688a09302f06469d3391dc3ad1fed0 sha1 24b52a2cfe50a942ccd2e3a8d80f885110876c28 )
-)
-
-game (
-	name "Quiz Keitai Q mode (GDL-0017)"
-	year "2002"
-	developer "Amedio (Taito license)"
-	rom ( name quizqgd.zip size 1195 crc 62abf8b0 md5 f5baaab64d8b8217c2a866fb04ac4bc4 sha1 5d3732f2c07c59c8d9cd429f5869ece7b676018f )
-)
-
-game (
 	name "Nettou! Gekitou! Quiztou!! (Japan)"
 	year "1993"
 	developer "Namco"
@@ -40821,13 +30368,6 @@ game (
 	year "1991"
 	developer "BFM"
 	rom ( name quizvadr.zip size 1304408 crc c541c5f7 md5 2bf7f25ca379e36c8ad4ab6c3b6b2b57 sha1 360e5cd0084229b2f0060611cef56c2a880643a2 )
-)
-
-game (
-	name "Video Quiz"
-	year "1986"
-	developer "bootleg"
-	rom ( name quizvid.zip size 98690 crc 7eb96c0f md5 f2fb3f30e7ce4f0f5a8b30dcb870136d sha1 f84216391f4cc27577fc37cec7da0171b005156a )
 )
 
 game (
@@ -40880,20 +30420,6 @@ game (
 )
 
 game (
-	name "Raiden II / DX (newer V33 PCB)"
-	year "1996"
-	developer "Seibu Kaihatsu"
-	rom ( name r2dx_v33.zip size 11658133 crc 55371003 md5 43bc2b92b92a65a3ccc8612259a81cb8 sha1 861e9bcdd75e792bed6b939ff6ceca33c034dc04 )
-)
-
-game (
-	name "Rabbit (Japan)"
-	year "1997"
-	developer "Electronic Arts / Aorn"
-	rom ( name rabbit.zip size 10172689 crc 868ef0b8 md5 129cef10ae126daebe4ba42dfbc43201 sha1 5815d30174018f4ca41c04366a28565517fefaf2 )
-)
-
-game (
 	name "Rabbit Poker (Arizona Poker v1.1?)"
 	year "1990"
 	developer "bootleg"
@@ -40908,192 +30434,10 @@ game (
 )
 
 game (
-	name "Raccoon World"
-	year "1998"
-	developer "Eolith"
-	rom ( name raccoon.zip size 3367831 crc e2da8d9e md5 22bbe085fadfd15d548710fd864614f2 sha1 0c0f783081a1e3cdfeb01672190ac41407d3843a )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv.zip size 814136 crc 97b25542 md5 2432dc88898105f0b684a4b381494371 sha1 ba9bac6256b53ee5279e61c950aaab092b690df5 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv1.zip size 798156 crc e1281aba md5 3c13584233d2e4bc5e3f6e4785ba9f68 sha1 c4aa5f8c27f2c675c72e46f4138d04dfaa538f90 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv2.zip size 799024 crc f857193e md5 72dc2dc5d6eebf1552d6565b7e9d965a sha1 53ed8af8410857735062bee73f6676cee3ddda99 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 3)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv3.zip size 799009 crc b9cc917b md5 6f588301cdd6ffb9b202d038139391e2 sha1 44d447811101be07c18c5043ffaedf4bd1292337 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv4.zip size 813603 crc 26c7a7a0 md5 cfcb2250856fb1dac18f1f002c7f374a sha1 312dbc219cc8e44c609e00e353c004a1351a1fa3 )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb.zip size 815063 crc 930be5a6 md5 bdd25eb76035292c0f740d07ab730ee0 sha1 279671498d34da7c797e00b19137dae878e3c2d3 )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb1.zip size 799323 crc fa696582 md5 daf554605826bd1f80ffc88188321be8 sha1 1673b6bc34f812476131be4b7211f465c8f740bd )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb4.zip size 814530 crc 4d76af0a md5 b31e8f9f07528f76198ae00016335a71 sha1 1e91651aad010106ccbc9fa8b12a9a6797281240 )
-)
-
-game (
-	name "Race Drivin' (compact, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc.zip size 767471 crc fc299a9f md5 b6caff28a8dab1b5a051fd12333760a2 sha1 aa579c5eab40e1f1c5aaa7db1c98594b38017c72 )
-)
-
-game (
-	name "Race Drivin' (compact, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc1.zip size 755529 crc c449c423 md5 512e2b8f96441bff262db5e98306ca70 sha1 78f207382c163b7eec5a9c1d9338f816b6dba6b9 )
-)
-
-game (
-	name "Race Drivin' (compact, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc2.zip size 755515 crc 7af02e9f md5 a1549a9b9291c9c02ce9b5fffd2f934f sha1 ae72055d21bb8780683711130228c8d13e6397f1 )
-)
-
-game (
-	name "Race Drivin' (compact, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc4.zip size 767051 crc dbba7042 md5 174732df9230abbba8067cb875ab4891 sha1 67d919001b6c0582541c281b1b464a04f63bc77e )
-)
-
-game (
-	name "Race Drivin' (compact, British, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcb.zip size 768398 crc a6ba19b5 md5 c0b9af3f09fc108629dccf496d70cd0e sha1 5b6b2d7533bd6715f48228e725e67a0495feea31 )
-)
-
-game (
-	name "Race Drivin' (compact, British, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcb4.zip size 767978 crc 4e528519 md5 808e8bb21a05f38ff0d363e7963fce8e sha1 a53df5bf1b88e38fb2323cde5c5a8699c9fcd565 )
-)
-
-game (
-	name "Race Drivin' (compact, German, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcg.zip size 768344 crc 1acaef70 md5 da6bc79982c933811e05f40bf80bbde0 sha1 3ff07ac3fd993d44faa19ccdb34e4abb52c9d815 )
-)
-
-game (
-	name "Race Drivin' (compact, German, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcg4.zip size 767993 crc eeecd2b4 md5 4b6dffd56053ad0a1b365d2459321a44 sha1 70d9e3b59b43301e9a30cb4565018f436132deb9 )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg.zip size 815272 crc e3fa03c4 md5 6988b22457a86f510ecfd1c1fbdc811a sha1 0730a5ac00686d37852e9912ebc0cd213a48ea33 )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg1.zip size 800035 crc 548e9f64 md5 c65c69f1d1be4ef3a6585b68e7330412 sha1 37cbaf89ec4d89eb2b65e26971a4880b8f2b8841 )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg4.zip size 814824 crc 21aed470 md5 a970b864d8e52627c52f692fc95174d2 sha1 101499c357dbef4a31bfabb07f8a1a5c847f4771 )
-)
-
-game (
-	name "Race Drivin' Panorama (prototype, rev 2.1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivpan.zip size 1327982 crc 4059622e md5 742794cdaa708462d31bb152daeff3db sha1 d49b421ec783fdcb633b2e2ab99c5031ff509ebf )
-)
-
-game (
 	name "Racing Hero (FD1094 317-0144)"
 	year "1989"
 	developer "Sega"
 	rom ( name rachero.zip size 1489830 crc 945ffdf7 md5 605da3334195c983a8d360bdf141377c sha1 e887a2b29e294f5b5cfa9a8b8059e4ed5a480d33 )
-)
-
-game (
-	name "Racin' Force (ver EAC)"
-	year "1994"
-	developer "Konami"
-	rom ( name racinfrc.zip size 9239661 crc 7b5b1b8a md5 a5f2e94fc54ce72ba198e50913ee555e sha1 7223bdc3fa666776b5141957f0c3e0e4688eec9d )
-)
-
-game (
-	name "Racin' Force (ver UAB)"
-	year "1994"
-	developer "Konami"
-	rom ( name racinfrcu.zip size 9239968 crc cd18ea1a md5 f9ac678cc1c4d444e7e854ff5f940126 sha1 e909474ab059bae3f55ecec54a1f71a7bbbae8d5 )
-)
-
-game (
-	name "Racing Beat (World)"
-	year "1991"
-	developer "Taito Corporation Japan"
-	rom ( name racingb.zip size 3623032 crc dea78c34 md5 d9ffcd43f181d35d56d0f640effa6316 sha1 c2fcf9ac97760f68207cfd3000dd64157e6c324e )
-)
-
-game (
-	name "Racing Jam"
-	year "1998"
-	developer "Konami"
-	rom ( name racingj.zip size 13926330 crc d01645d5 md5 86fbd7a4677d6e27394f550433892213 sha1 8ec1dc064c214a5ef8b7bdac5b74f84fc51a16a9 )
-)
-
-game (
-	name "Racing Jam: Chapter 2"
-	year "1999"
-	developer "Konami"
-	rom ( name racingj2.zip size 16517107 crc 5290e79e md5 1f72f385e28ac392ace90aab739339f4 sha1 df9b0a67e0476ef49aedca365dbebc717fd2adc9 )
 )
 
 game (
@@ -41115,13 +30459,6 @@ game (
 	year "1980"
 	developer "Nintendo"
 	rom ( name radarscp.zip size 18113 crc d902667f md5 5a6a1e4c68d6c232b0e83a12444f8f41 sha1 96d757bdb49ede9042a7a76422cab8afdc2cbb1f )
-)
-
-game (
-	name "Radar Scope (TRS01)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name radarscp1.zip size 20425 crc 87f25fa4 md5 0c437ed7c453b7f322f829ca25e1fe91 sha1 862507c74082eac43120bb65625858eb12bbc7f1 )
 )
 
 game (
@@ -41150,13 +30487,6 @@ game (
 	year "1998"
 	developer "Gaelco"
 	rom ( name radikalb.zip size 18485282 crc f01608a4 md5 98056abc8df730d3f775af01c805efd9 sha1 18a0335909e7ade7d8fc8f2f401f2540d6c6a2e0 )
-)
-
-game (
-	name "Radirgy (GDL-0032)"
-	year "2005"
-	developer "Milestone"
-	rom ( name radirgy.zip size 1196 crc b2d7d006 md5 c183da1fc5224f7aa077cd99a3632453 sha1 a2bda21fac9caada56ca71967f5346c5ff7cc1f2 )
 )
 
 game (
@@ -41205,7 +30535,7 @@ game (
 	name "Ragnagard / Shin-Oh-Ken"
 	year "1996"
 	developer "Saurus"
-	rom ( name ragnagrd.zip size 22854663 crc e9033e2a md5 b98d2abd04dee02aa62155ec256e5a5c sha1 7c60b48dd3c9f1219f6db67198a82eec59e068fa )
+	rom ( name ragnagrd.zip size 24201350 crc 2456c94c md5 312857c02fc747e7d3fa3db81571daba sha1 dabfef9378943057b89bf96e47662bd0e560f18d )
 )
 
 game (
@@ -41220,62 +30550,6 @@ game (
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name ragtimea.zip size 8305898 crc 2575f589 md5 0e04fae50e8deb8209dc21a90cd29b25 sha1 27c5e719604539de054bc22d7c40f92bd7919e64 )
-)
-
-game (
-	name "Raiden"
-	year "1990"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden.zip size 890877 crc 7c672f3b md5 669cf45efe5b51c7db1eab8789f50949 sha1 8f10a0788462eaef4207dc0f88f5887deee05812 )
-)
-
-game (
-	name "Raiden II (set 1, US Fabtek)"
-	year "1993"
-	developer "Seibu Kaihatsu (Fabtek license)"
-	rom ( name raiden2.zip size 10973661 crc e8a1daff md5 841d1156bc0831a897a70e1758c53a2d sha1 d4e754e98724c122bad85d0b00a9b684eed5149e )
-)
-
-game (
-	name "Raiden II (set 2, Metrotainment)"
-	year "1993"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raiden2a.zip size 10478434 crc da4b50ae md5 c4ff8efdf95fa595cc809aef92f5c242 sha1 bcabeddd3746fb87d56f622999c1f2af0ad6f4e0 )
-)
-
-game (
-	name "Raiden II (set 3, Japan)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2b.zip size 10478432 crc 51f02a43 md5 80ffffb0de9aa2178456cb845632e712 sha1 48f12ea1a389e700ee539ac396e7caa96381d135 )
-)
-
-game (
-	name "Raiden II (set 4, Japan)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2c.zip size 10653662 crc 35656be4 md5 822ebe737c02148b1d1cd71f86404ac7 sha1 62424997a725cd2e053377bacfa28a24efeea476 )
-)
-
-game (
-	name "Raiden II (set 5, Italy)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2d.zip size 10653718 crc 72e949d0 md5 7e85bbcf70cbe3fa29db4c6e897f86e3 sha1 bd760201c3173f5b87df195d7bfd6f1883104e4e )
-)
-
-game (
-	name "Raiden II (set 6, Easy Version)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2e.zip size 10636760 crc 55003792 md5 e3800ab49a6210c2482890600d9d90da sha1 0f547efa4b5523a4ffc200070ddc6da4797906c2 )
-)
-
-game (
-	name "Raiden II (set 7)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2f.zip size 10786889 crc ebf35d2a md5 35befa4ea6f84cac334457a6304bf5d6 sha1 edc6d672a4c6a2428cc4c2ca2576037d824c0b34 )
 )
 
 game (
@@ -41325,55 +30599,6 @@ game (
 	year "1985"
 	developer "UPL (Taito license)"
 	rom ( name raiders5t.zip size 34725 crc 0f24adce md5 298f3ac7b8a1c3267d5776a4ad413505 sha1 b3abe020eab21b26d83615f6f1a88ec0c71d69d7 )
-)
-
-game (
-	name "Raiden DX (UK)"
-	year "1994"
-	developer "Seibu Kaihatsu"
-	rom ( name raidndx.zip size 11225182 crc f282dd41 md5 bdf2b9ab10cb8f1aad68ea3cbe2fd006 sha1 c82155d5d210eb8fadbb77c6a6c7f89d9ef26a52 )
-)
-
-game (
-	name "Raiden DX (Asia set 1)"
-	year "1994"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raidndxa1.zip size 11225118 crc 4c630dc0 md5 8c8dbbf2ca8db1d8e4ebb5632a18a124 sha1 1140a99eba0a025e3b809c6bd99c1eb51164e3ae )
-)
-
-game (
-	name "Raiden DX (Asia set 2)"
-	year "1994"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raidndxa2.zip size 11225023 crc 906c9c1a md5 95816c7fee4def330665403756caea13 sha1 a8a6c711b685589abfea669e1b5b5553fa20233c )
-)
-
-game (
-	name "Raiden DX (Germany)"
-	year "1994"
-	developer "Seibu Kaihatsu (Tuning license)"
-	rom ( name raidndxg.zip size 11225263 crc a3461ef0 md5 cbb6e971513d3cefdbf090ff0b1a2e1e sha1 b726ac65803e5878b2390489dc80d03011fb56be )
-)
-
-game (
-	name "Raiden DX (Japan)"
-	year "1994"
-	developer "Seibu Kaihatsu"
-	rom ( name raidndxj.zip size 11225283 crc 340084c1 md5 dbc59957c60b10bbd6a28fc5db407b71 sha1 f51f6b7972cdab4d9f3a5da1ede0470754d4de16 )
-)
-
-game (
-	name "Raiden DX (US)"
-	year "1994"
-	developer "Seibu Kaihatsu (Fabtek license)"
-	rom ( name raidndxu.zip size 11342429 crc 509a2eb3 md5 3c6daf377ae091cf308ebe8e178d863c sha1 ee59f299a57e0e2962fd0486f84fba5b82c38999 )
-)
-
-game (
-	name "Raiga - Strato Fighter (Japan)"
-	year "1991"
-	developer "Tecmo"
-	rom ( name raiga.zip size 765646 crc 3cd0e291 md5 e3d6675c331bc2b90e42be04dab67c3a sha1 db60005181e83c85db7cb87ffceac20b45891e1c )
 )
 
 game (
@@ -41510,13 +30735,6 @@ game (
 )
 
 game (
-	name "Ranger Mission"
-	year "2004"
-	developer "Sammy"
-	rom ( name rangrmsn.zip size 81514419 crc 5c6da30c md5 86031711d4e3ffabdcf5615068d439b7 sha1 003096e3ad966f3bfd3016e9ed5487e67e70871e )
-)
-
-game (
 	name "Rapid Hero"
 	year "1994"
 	developer "NMK / Media Shoji"
@@ -41535,20 +30753,6 @@ game (
 	year "1998"
 	developer "Hanaho Games"
 	rom ( name rapidfire.zip size 4586402 crc 29a90562 md5 b82df32560a83fc5a10b24c57364fa9e sha1 6add48676e945b8966265f9ccac28f0fdd8cd352 )
-)
-
-game (
-	name "Rapid River (RD3 Ver. C)"
-	year "1997"
-	developer "Namco"
-	rom ( name rapidrvr.zip size 78989140 crc 89316757 md5 9ab4333d5dc8d87ed9a4960581942c5e sha1 6ea8278b031da5b07b01d2ac8d64b7a3ac3055e0 )
-)
-
-game (
-	name "Rapid River (RD2 Ver. C)"
-	year "1997"
-	developer "Namco"
-	rom ( name rapidrvr2.zip size 78989105 crc 664283d1 md5 db4d6e625c49dda17b689a9cf2b09432 sha1 8d463906dbfda8186265d52b4f73fc68c921ffe9 )
 )
 
 game (
@@ -41615,6 +30819,13 @@ game (
 )
 
 game (
+	name "Ray Crisis (V2.03J)"
+	year "1998"
+	developer "Taito"
+	rom ( name raycris.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Ray Force (Ver 2.3A 1994/01/20)"
 	year "1993"
 	developer "Taito America Corporation"
@@ -41632,14 +30843,14 @@ game (
 	name "Ray Storm (Ver 2.06A)"
 	year "1996"
 	developer "Taito"
-	rom ( name raystorm.zip size 8266725 crc fb3efa9e md5 15039b53eae94f2f53ee5c9a1d0afd66 sha1 b52411aa286d5f503d924c5074b58fa5e055d650 )
+	rom ( name raystorm.zip size 8392863 crc ae79eb6a md5 12e47db5c2abfff39461761cc4f8fac1 sha1 1aa09fc31fab4b49d16e1c11c9a7f885f3a9fb19 )
 )
 
 game (
 	name "Ray Storm (Ver 2.05J)"
 	year "1996"
 	developer "Taito"
-	rom ( name raystormj.zip size 8266625 crc e7e340cf md5 a96c8238ca0a7e73fefaa78f50748a58 sha1 b956ae2a16e85ad5a8be7d5a1d7d4d13fd7aa4a7 )
+	rom ( name raystormj.zip size 8392763 crc 24337b2f md5 56eb9037bccfd4eef60557331e089298 sha1 8b749f3f4ec9ad0a53920b61e4445f69bdd878e4 )
 )
 
 game (
@@ -41653,49 +30864,49 @@ game (
 	name "Real Bout Fatal Fury / Real Bout Garou Densetsu"
 	year "1995"
 	developer "SNK"
-	rom ( name rbff1.zip size 24118787 crc de245983 md5 e64270a85f0c6cc16aab89a345e0e3bc sha1 61dea78fecc71f71d13842edb21506cb6a6a1ff9 )
+	rom ( name rbff1.zip size 25465474 crc 57181ed0 md5 e37087d39a33a1877d9b18d4c89fd7cd sha1 a2c1c7fb78b71113dc4b277c06c1021dad6df121 )
 )
 
 game (
 	name "Real Bout Fatal Fury / Real Bout Garou Densetsu (bug fix revision)"
 	year "1995"
 	developer "SNK"
-	rom ( name rbff1a.zip size 24313680 crc c3aa12a2 md5 f9b7f7dc3cf3cfd4a5827d022a9bb60d sha1 5686cb469e8eada196b4d83ae987b4599ab1f5fd )
+	rom ( name rbff1a.zip size 25660367 crc c6305336 md5 70032619cee228f52b9ddcfc07f1a9fa sha1 01c5aaa30ad6d64a38119617ce349cccf52229be )
 )
 
 game (
 	name "Real Bout Fatal Fury 2 - The Newcomers / Real Bout Garou Densetsu 2 - the newcomers (set 1)"
 	year "1998"
 	developer "SNK"
-	rom ( name rbff2.zip size 29723171 crc f9829d4b md5 dbe87449f0918303c110c1d209f1d075 sha1 506185730f73b4718598ce9ff69f844051105789 )
+	rom ( name rbff2.zip size 31069858 crc 455575a3 md5 231ed2826189859486f245ea62a12770 sha1 b89fe359c43223d32e1171cd6b886b54e72beeb3 )
 )
 
 game (
 	name "Real Bout Fatal Fury 2 - The Newcomers / Real Bout Garou Densetsu 2 - the newcomers (set 2)"
 	year "1998"
 	developer "SNK"
-	rom ( name rbff2h.zip size 29723191 crc 66a00efe md5 fbb7a5e97474763cf1f396af89f98307 sha1 5223aa38ee1c918669c50ce32077ac42a4a88f05 )
+	rom ( name rbff2h.zip size 31069878 crc 3b3a9e72 md5 05d6dd9710232d5e5c2da881c3558858 sha1 6714c55e4b8cb0c42021c1ecd84df9dc2c466dff )
 )
 
 game (
 	name "Real Bout Fatal Fury 2 - The Newcomers (Korean release)"
 	year "1998"
 	developer "SNK"
-	rom ( name rbff2k.zip size 29723199 crc a918702a md5 449a487abd8bcb83458f66da198dd5ab sha1 5ee7f88ac6b20981b42b29149a0b47b577ec57ff )
+	rom ( name rbff2k.zip size 31069886 crc 0e911cd7 md5 70336d0badd802e32b3a9059c6d452eb sha1 6e75585b5b58916227c4e69099f5f1ebe5fce1c4 )
 )
 
 game (
 	name "Real Bout Fatal Fury Special / Real Bout Garou Densetsu Special"
 	year "1996"
 	developer "SNK"
-	rom ( name rbffspec.zip size 24869035 crc 5b13b3f1 md5 48f276c36ed5bee3f3dcb6220d72dbd4 sha1 1e0479254090f31846eab70ead669bed10e925aa )
+	rom ( name rbffspec.zip size 26215722 crc 0e26377e md5 4f682ea82fb8a33f43a233dd3459d7c6 sha1 fa324b290b428da6890bb668e88491a4efad7ffa )
 )
 
 game (
 	name "Real Bout Fatal Fury Special / Real Bout Garou Densetsu Special (Korean release)"
 	year "1996"
 	developer "SNK"
-	rom ( name rbffspeck.zip size 24868739 crc f039f8ee md5 fd9dc4c5bb7d772ce0adf71a071f0f51 sha1 d4e1ff21e03d2faa796de5eed7263f6c13884051 )
+	rom ( name rbffspeck.zip size 26215426 crc c091e4f3 md5 5ccfa70a519d0f8377cf54862b517e22 sha1 198769266b89c1dda09f4bd46492bb42c70363d2 )
 )
 
 game (
@@ -41710,20 +30921,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name rbibba.zip size 40476 crc 5ba7105b md5 c4c39dc4d5c90c4a09b1731f5190efd2 sha1 03064f068be9e003fd9f9b309e4c062e279c1d0c )
-)
-
-game (
-	name "Road Blaster (Data East LD)"
-	year "1985"
-	developer "Data East"
-	rom ( name rblaster.zip size 32391 crc 30c397eb md5 eaf2822f5eb82084554305cf1e8b8f8d sha1 5e575c57f42ddf1d2c35fb7a4e6e7349214f6360 )
-)
-
-game (
-	name "Real Battle Mahjong King"
-	year "1998"
-	developer "GMS"
-	rom ( name rbmk.zip size 846459 crc ee069ba7 md5 6d1df5b19e1de67fdf7668d9c6cda47b sha1 b53b74ed5afed9d6db09b282e72ec90ec5bc4db8 )
 )
 
 game (
@@ -41745,13 +30942,6 @@ game (
 	year "1991"
 	developer "Sega"
 	rom ( name rchase.zip size 6251532 crc d33791aa md5 6f1718fbc22b80c1f5cade39f32fe771 sha1 c4d4871653aaaf007953b37b0d184904eb1b4596 )
-)
-
-game (
-	name "Rail Chase 2 (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name rchase2.zip size 13979877 crc 0068d603 md5 1bcd71c49f366cd5c6ee97d290b3fb9d sha1 2062cbfd61d411529b5520186e87eb6c5605a61e )
 )
 
 game (
@@ -41780,13 +30970,6 @@ game (
 	year "2004"
 	developer "Igrosoft"
 	rom ( name rclimb_3b.zip size 1973400 crc bf30180f md5 4e2705a680e9ca5b738fb704a159c648 sha1 7ea900e0c3183cf2e7d6419a3a8244195d676a2e )
-)
-
-game (
-	name "Red Corsair"
-	year "1984"
-	developer "Nakasawa"
-	rom ( name rcorsair.zip size 15213 crc d0494c67 md5 b9d097e959075babb1b51f73c0f404a4 sha1 c35d162ad03483484dab383b94a5a7468fb6ffa3 )
 )
 
 game (
@@ -41951,13 +31134,6 @@ game (
 )
 
 game (
-	name "Rebus"
-	year "1995"
-	developer "Microhard"
-	rom ( name rebus.zip size 2859633 crc 9ed15861 md5 b03525384eb4e6cbffa88eed9809615d sha1 a76f6fc751c7bf1d2805f3f985a255d28971df67 )
-)
-
-game (
 	name "Recalhorn (Ver 1.42J 1994/5/11) (Prototype)"
 	year "1994"
 	developer "Taito Corporation"
@@ -41986,38 +31162,10 @@ game (
 )
 
 game (
-	name "Red Clash (set 1)"
-	year "1981"
-	developer "Tehkan"
-	rom ( name redclash.zip size 12835 crc 77641685 md5 0df3b1e6c11d7d2e4074d84107c09aba sha1 064a57eb5626b1e38b705d2fde79a99e2d563026 )
-)
-
-game (
-	name "Red Clash (set 2)"
-	year "1981"
-	developer "Tehkan"
-	rom ( name redclasha.zip size 11797 crc d3bbd141 md5 0d1e572e4941cdf59e92bf17df795316 sha1 0bb7e18270fccf22064992c2cb5f096abfd7f964 )
-)
-
-game (
-	name "Red Clash (Kaneko)"
-	year "1981"
-	developer "Tehkan (Kaneko license)"
-	rom ( name redclashk.zip size 13598 crc 74cf2845 md5 7511637940db059d9f8fe79108a40692 sha1 220904176df5e169aee6a736a0eff9a527052916 )
-)
-
-game (
 	name "Red Earth (Euro, 961121)"
 	year "1996"
 	developer "Capcom"
 	rom ( name redearth.zip size 132465 crc ec87dc78 md5 1e0999adcb3a64dbb004a1be7bbc6a58 sha1 46b5eb45b7a1a03db9592151a0cb24624908c73f )
-)
-
-game (
-	name "Red Earth (961121, NO CD)"
-	year "1996"
-	developer "Capcom"
-	rom ( name redeartn.zip size 36057981 crc ccc1837b md5 f3d69f019e7fded67fecfaccf122dc45 sha1 a2b1d958362fda28d2a17faec70416a197a4eeea )
 )
 
 game (
@@ -42046,13 +31194,6 @@ game (
 	year "1997"
 	developer "Afega (Hea Dong Corp license)"
 	rom ( name redhawki.zip size 833699 crc f1626a48 md5 f8e0c3e4fcaef177c1a26396ddaa61eb sha1 983357476188068152c59038dc9c1e0cd4f385aa )
-)
-
-game (
-	name "Redline Racer (2 players)"
-	year "1987"
-	developer "Cinematronics (Tradewest license)"
-	rom ( name redlin2p.zip size 224176 crc 6bd90636 md5 2cfcb235db4703cbf0031c01291909fc sha1 ef209a5e9639b1daec2d3e2225fec2fd121d7537 )
 )
 
 game (
@@ -42088,13 +31229,6 @@ game (
 	year "1986"
 	developer "Greyhound Electronics"
 	rom ( name reelfun1.zip size 144631 crc f0457e59 md5 e75fa80eab75fd983855a2e95adf55b2 sha1 f30a334026ceb8057374a76de1fcbe72e3f5c6d1 )
-)
-
-game (
-	name "Reelin-n-Rockin (A - 13/07/98, Local)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name reelrock.zip size 1050784 crc ed0f9e99 md5 e0e9cf62557b18f97f121b3f2303245d sha1 eb4ed15486909f78a6810cd45bd9a4308aa74f3a )
 )
 
 game (
@@ -42168,20 +31302,6 @@ game (
 )
 
 game (
-	name "Rescue Raider"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name rescraid.zip size 88433 crc 54a45f86 md5 51c4315790d606d28fd9c5505084ff7b sha1 2615969ae3be3cd8c6dbae0e95c7f4cb017fec63 )
-)
-
-game (
-	name "Rescue Raider (stand-alone)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name rescraida.zip size 88364 crc 9da81db9 md5 e6f6b9ba374ce19b8b36a598f522e6d2 sha1 4496e99ffdb627d5b03a153b8146f9e17df19ad7 )
-)
-
-game (
 	name "Rescue"
 	year "1982"
 	developer "Stern Electronics"
@@ -42203,13 +31323,6 @@ game (
 )
 
 game (
-	name "Return of the Invaders"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name retofinv.zip size 48110 crc bb87612b md5 d0701657e1065a099258b1d458176d14 sha1 974ec9619c55b83d3d767cf9a2b6051de8c9bab5 )
-)
-
-game (
 	name "Return of the Invaders (bootleg set 1)"
 	year "1985"
 	developer "bootleg"
@@ -42221,13 +31334,6 @@ game (
 	year "1985"
 	developer "bootleg"
 	rom ( name retofinv2.zip size 47538 crc 9b73d5e3 md5 76541e377460854bdf0535fcea31c196 sha1 7f8821ab98b2741113d1a9c6cf579d2199ae257b )
-)
-
-game (
-	name "Revenger"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name revenger.zip size 24171 crc 47a75942 md5 6e1daedeb84704dd344b02a023c36157 sha1 34e1013cccc9ff31b5728a810145b6bfc0f833e4 )
 )
 
 game (
@@ -42301,12 +31407,6 @@ game (
 )
 
 game (
-	name "Royal Gum (Italy)"
-	developer "&lt;unknown&gt;"
-	rom ( name rgum.zip size 56734 crc 8df7b09c md5 c7d51c36a575d151ebae12666cde8fa6 sha1 6ae5138c231582ffdd3db34adb3a774308bded25 )
-)
-
-game (
 	name "Ribbit!"
 	year "1991"
 	developer "Sega"
@@ -42366,35 +31466,14 @@ game (
 	name "Riding Hero (set 1)"
 	year "1990"
 	developer "SNK"
-	rom ( name ridhero.zip size 3670306 crc 588e8e34 md5 5d392e39ad12d6dacd78ebac13381e9e sha1 9799ac560dbac133fff85418c34f49cfa95a95da )
+	rom ( name ridhero.zip size 5016993 crc d531b050 md5 8af6c47cd558fe7ac484d7e5a7bd3fc7 sha1 32fff24f4c8c85317eb36df0cfdcb97810c0e985 )
 )
 
 game (
 	name "Riding Hero (set 2)"
 	year "1990"
 	developer "SNK"
-	rom ( name ridheroh.zip size 3670291 crc a6768732 md5 c6696b719d048a0d8c66acebd24c784c sha1 0fa009ad05b114ed79b4df09b73231ec6a4d1ad9 )
-)
-
-game (
-	name "Riding Fight (Ver 1.0O)"
-	year "1992"
-	developer "Taito Corporation Japan"
-	rom ( name ridingf.zip size 4728731 crc 1cff49e4 md5 c99a4db6f9f75a617a273d542d558636 sha1 e1358344ad61a2b625243570a5308d35f8d32fdc )
-)
-
-game (
-	name "Riding Fight (Ver 1.0J)"
-	year "1992"
-	developer "Taito Corporation"
-	rom ( name ridingfj.zip size 4728730 crc f8d7d4bd md5 5b0630386ba9c3edcec1af211817843f sha1 06b20dca94544e0f109a7027ec81eaee0125db3b )
-)
-
-game (
-	name "Riding Fight (Ver 1.0A)"
-	year "1992"
-	developer "Taito America Corporation"
-	rom ( name ridingfu.zip size 4728731 crc aac95574 md5 c21006324f42dde61bf78a72ae097dba sha1 167dd7906bf8d5a6123dcda33bc39becf513aa5b )
+	rom ( name ridheroh.zip size 5016978 crc 855e1cd5 md5 e1e4c0dfb3dfd6d6ca70483613d4d5ff sha1 3f2e9c8b993a376440498f483aad018fc494ea98 )
 )
 
 game (
@@ -42402,13 +31481,6 @@ game (
 	year "1986"
 	developer "Sega / Nasco"
 	rom ( name ridleofp.zip size 83575 crc 500bad17 md5 264dbc2fe17d03c3ebd7432f0b7f0718 sha1 40e7243ef98246dcf3695eddbc81d873a2152b47 )
-)
-
-game (
-	name "Rim Rockin' Basketball (V2.2)"
-	year "1991"
-	developer "Strata/Incredible Technologies"
-	rom ( name rimrockn.zip size 916426 crc c001d28e md5 55ad31a7f1d397e8c9c5ca557fe9a943 sha1 0c795b7ef4d65fec3ff6f7eaf58f59f71f48429d )
 )
 
 game (
@@ -42615,90 +31687,6 @@ game (
 )
 
 game (
-	name "Road Blasters (upright, rev 4)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst.zip size 514197 crc b2858160 md5 81ef78c9596849c649eb4986c827743f sha1 cbaea7041f946eb89bb309f3b266189b79b2f621 )
-)
-
-game (
-	name "Road Blasters (upright, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst1.zip size 514356 crc 6934c24c md5 8b183f0104f1e4ee2616ba9db8bf5c52 sha1 eab8606bbed91f70c5e9a0df4591c8aba3f7d183 )
-)
-
-game (
-	name "Road Blasters (upright, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst2.zip size 514335 crc 26231a09 md5 bcdb9e233833892599489ad22f8026e7 sha1 d4c8a7b9a7c248f732d4c5f110782e532e9e7351 )
-)
-
-game (
-	name "Road Blasters (upright, rev 3)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst3.zip size 514187 crc 37243e79 md5 594ca0ec201bc3a86a095a4c217ae3bc sha1 847dc7a7a5f38fe655a2cb3be8b80d7a42fd0e4f )
-)
-
-game (
-	name "Road Blasters (cockpit, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstc.zip size 514184 crc 8fbe6d02 md5 4a3a57f4c6a49b702e8bd2b231c8bda1 sha1 1bffeeec390c9dbe7d867d2e32fbc32bb850d64c )
-)
-
-game (
-	name "Road Blasters (cockpit, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstc1.zip size 514066 crc e4b0599f md5 a6a9bb118a217b999b2caa950e4b7b33 sha1 4264948f3492d298fba1b22dccbeb4f9a5b899db )
-)
-
-game (
-	name "Road Blasters (cockpit, German, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstcg.zip size 512812 crc 3a963b6a md5 ad4f3350ac93548016e5d5d18ee50dfd sha1 7fbf87a66c038dca1e75dd05e5996ced031ebe10 )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 3)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg.zip size 512991 crc f54252a9 md5 0b3966321814fff731eaed4e442cdade sha1 9656edb496b1003dd75c935f19763d76eadfe6a1 )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg1.zip size 513110 crc ed123db5 md5 3145f171edaf133ea7635026efdfdfd0 sha1 fb72a19920f7f23ec5fe6f7cb4b6d2cdb7741595 )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg2.zip size 513147 crc 90a41b82 md5 7b1de741c4e2db90b053b1339b3edd81 sha1 b57010f1496abd36f03bdcdd4a3aaac081616540 )
-)
-
-game (
-	name "Road Burners"
-	year "1999"
-	developer "Atari Games"
-	rom ( name roadburn.zip size 268745 crc bcf97285 md5 6642fa2be301e35d9b4fe93dc56994c2 sha1 7d0b5498d0a63fcf535bb0043078b08235c1f642 )
-)
-
-game (
-	name "Roads Edge / Round Trip (rev.B)"
-	year "1997"
-	developer "SNK"
-	rom ( name roadedge.zip size 39141986 crc 64a1ec3a md5 c7e53aea511ff5ee0a16cfc459f40c1b sha1 c136da7fe8b6c8c8cc58f71cfa6f49302dd0ae6d )
-)
-
-game (
 	name "Road Fighter (set 1)"
 	year "1984"
 	developer "Konami"
@@ -42713,38 +31701,10 @@ game (
 )
 
 game (
-	name "Road Riot 4WD"
-	year "1991"
-	developer "Atari Games"
-	rom ( name roadriot.zip size 2280668 crc 9210fa76 md5 4ac7e4f67e5e46b2b792902555d1e241 sha1 0156e6a4569b73ae77f89bce7063c2e7c32e0916 )
-)
-
-game (
 	name "Road Runner (Midway)"
 	year "1977"
 	developer "Midway"
 	rom ( name roadrunm.zip size 6013 crc 60d53e98 md5 79bec8cf2c10fb135671c0e55fcfce69 sha1 49c01cd27b86cc3b4648d468599996509145abde )
-)
-
-game (
-	name "Road Runner (rev 2)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn.zip size 471093 crc 2fa8989e md5 05dc4eb45c0f4508c8dd4f5e4a04f1de sha1 81b9b72627d75fd328bc6f7f2ccfc26abe6eabcc )
-)
-
-game (
-	name "Road Runner (rev 1)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn1.zip size 471080 crc b04957ca md5 b3e08132be1e0bbac2ce41c8bd39460a sha1 234dd4a32ffd01f7d11fbc85f85de5882e12b27d )
-)
-
-game (
-	name "Road Runner (rev 1+)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn2.zip size 471043 crc 3d0bcad0 md5 c5075e952fc5996d645417471c499e7f sha1 892931e09ce44b519d58888bc788e02d025a519d )
 )
 
 game (
@@ -42877,7 +31837,7 @@ game (
 	name "Robo Army"
 	year "1991"
 	developer "SNK"
-	rom ( name roboarmy.zip size 3087422 crc d0304af7 md5 edda9339f86556c313c11341abe94c5e sha1 db6baf11801ef785ec3eaf7f6af200172f86a6aa )
+	rom ( name roboarmy.zip size 4434109 crc f2c7092b md5 189048ec929d7f569f868b5ba6a1e1c7 sha1 5ea80f21810cc1f226541ec8ff5dcf589db898d4 )
 )
 
 game (
@@ -43007,13 +31967,6 @@ game (
 )
 
 game (
-	name "Rock Duck (prototype?)"
-	year "1983"
-	developer "Datel SAS"
-	rom ( name rockduck.zip size 18823 crc d61f8b53 md5 d400ed8e40149eaea77b3ef9ee2f6a5a sha1 6cad70beb126648d5eb6e4b14702a49a7404c4df )
-)
-
-game (
 	name "Rockman 2: The Power Fighters (Japan 960708)"
 	year "1996"
 	developer "Capcom"
@@ -43097,27 +32050,6 @@ game (
 )
 
 game (
-	name "MTV Rock-N-Roll Trivia (Part 2)"
-	year "1986"
-	developer "Triumph Software Inc."
-	rom ( name rocktrv2.zip size 142645 crc 5bd912da md5 9ee397b766436c2430d5e8324ef59ff8 sha1 eee89b219e1a69f8125126217bd3c00ec0fd4f75 )
-)
-
-game (
-	name "Roc'n Rope"
-	year "1983"
-	developer "Konami"
-	rom ( name rocnrope.zip size 50109 crc ec7750e3 md5 7375f0b315c719c55e24b014222e39a2 sha1 c081576af46aa5db220d9602923ac57918e02928 )
-)
-
-game (
-	name "Roc'n Rope (Kosuka)"
-	year "1983"
-	developer "Konami / Kosuka"
-	rom ( name rocnropek.zip size 50124 crc 5f5cf42d md5 f60d1564320b18b14b53bf1ef41ad1a3 sha1 f806eecc0051cc7b340fc543890c89c69fa233f0 )
-)
-
-game (
 	name "Rod-Land (World)"
 	year "1990"
 	developer "Jaleco"
@@ -43178,20 +32110,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name roishtar.zip size 114339 crc 19465745 md5 a41827894f2b87ea1b4a52355d230f67 sha1 d8f6cd30174002085db5d35511b2217a85afaefe )
-)
-
-game (
-	name "The Return of Lady Frog (set 1)"
-	year "1993"
-	developer "Microhard"
-	rom ( name roldfrog.zip size 3517801 crc 687f55ce md5 7497385c50848b965607969125acedad sha1 9820f5fbafbbdafb602127ec662df15d204a697c )
-)
-
-game (
-	name "The Return of Lady Frog (set 2)"
-	year "1993"
-	developer "Microhard"
-	rom ( name roldfroga.zip size 3517775 crc 286564d2 md5 a559adfce743b4991b9da948648d786e sha1 2aa3c519ca2f2af334b16be30d80b9f8dd681738 )
 )
 
 game (
@@ -43272,23 +32190,10 @@ game (
 )
 
 game (
-	name "Ron Jan (Super)"
-	year "1994"
-	developer "Wing Co., Ltd"
-	rom ( name ronjan.zip size 459164 crc 62c91487 md5 bb47a9636ee99430e7019e1720ae542b sha1 6f9481cf776ffb3162f476119b48ba10b7a326cf )
-)
-
-game (
-	name "Rotary Fighter"
-	developer "&lt;unknown&gt;"
-	rom ( name rotaryf.zip size 5433 crc 5b4c6532 md5 f52aef87f724ef18150fc0c745749c03 sha1 1a8ec9d09c7070412548a744af93d6807e9a9ad8 )
-)
-
-game (
 	name "Rage of the Dragons"
 	year "2002"
 	developer "Evoga / Playmore"
-	rom ( name rotd.zip size 76583491 crc 86c73cd9 md5 f820ebb5670ccb22d3d9aa43fde21a89 sha1 c45ec90b649b1e9ef96e44774dac316219747fc6 )
+	rom ( name rotd.zip size 77930178 crc 4164879c md5 f16e5bbe866aa4f33fa0067ff64f8905 sha1 47432e0bfa574863e4ae6291455ed2bc00bdbb90 )
 )
 
 game (
@@ -43383,46 +32288,6 @@ game (
 )
 
 game (
-	name "Royal Card (Austrian, set 5)"
-	year "1991"
-	developer "TAB Austria"
-	rom ( name royalcrdd.zip size 28308 crc 2b8db133 md5 bf9e33c7c7164e53a740a6334cadddc5 sha1 cc264e84151d33353a6e606fc7d098a97095953e )
-)
-
-game (
-	name "Royal Card (Austrian, set 6)"
-	year "1991"
-	developer "TAB Austria"
-	rom ( name royalcrde.zip size 53430 crc 45d22a6f md5 0ea2a42bd0d7dc44b4b26ea1c4726089 sha1 72df27224707b1fc698f2fb9878fa9a79c8b3778 )
-)
-
-game (
-	name "Royal Card (Slovak, encrypted)"
-	year "1991"
-	developer "Evona Electronic"
-	rom ( name royalcrdf.zip size 43619 crc a0a9e900 md5 4f7a3088ab74d6189a877f1fe48ad612 sha1 8b4e6692923293899902f3fe308c4db71e58d354 )
-)
-
-game (
-	name "Royal Card v2.0 Professional"
-	year "1993"
-	developer "Digital Dreams"
-	rom ( name royalcrdp.zip size 30133 crc bf6ef284 md5 7ea1c901b2b0487b1b0f542180b44712 sha1 32e0917ca0d85127b107bc5dec0ee2770e3f7b9c )
-)
-
-game (
-	name "Royale (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name royale.zip size 13472 crc 07ce3d5f md5 863ce11b09a5d4489b3af1acf512e739 sha1 486b33333c09a4c47aa88396312ac8947a32375f )
-)
-
-game (
-	name "Royale (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name royalea.zip size 13568 crc f4e68601 md5 39a01dcdf02eac3716be957ff6f55ac7 sha1 0a42de79d6942ac91bad501859eff873a789d075 )
-)
-
-game (
 	name "Royal Mahjong (Falcon bootleg, v1.01)"
 	year "1982"
 	developer "bootleg"
@@ -43500,38 +32365,10 @@ game (
 )
 
 game (
-	name "Ridge Racer (Full Scale, 1993-12-13, World)"
-	year "1993"
-	developer "Namco"
-	rom ( name rrf.zip size 7544535 crc c46abf33 md5 57a58de086759ab8fed60ffcbd5dccbf sha1 39aedd85dc900906e04c19103ea0dc07cf10b0d4 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Sep 06, 1994)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrreveng.zip size 5191901 crc 562ce048 md5 94202e578b79b81c72a4ace48dabcc51 sha1 f7552e834c3edd9d2e23f2b882b93ccbd4f9fb38 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Jan 27, 1994, set 1)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrrevenga.zip size 5220032 crc 3e13b2fa md5 618f08bc3de5f2f3572766e99455df94 sha1 935feb8e4880ae287915ea15cfde0e6b9ad9e8e2 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Jan 27, 1994, set 2)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrrevengb.zip size 5221472 crc 2a172b22 md5 9542c06986755f52a259825476711ecf sha1 e2b6a2cb795fb4ac3829106fb74a30d7146f4d33 )
-)
-
-game (
 	name "Radiant Silvergun (JUET 980523 V1.000)"
 	year "1998"
 	developer "Treasure"
-	rom ( name rsgun.zip size 5841021 crc aa8b56ba md5 69a2ae5a1e0fa6d081b6f7d2673c80b4 sha1 54be42bf3528a79a3c74ab46ec1357d812654fd7 )
+	rom ( name rsgun.zip size 8540242 crc e0db38eb md5 df4976f62f9d052eea9093eb7c1aa767 sha1 7a54598b79deb86690024ffb5607521870a08ee3 )
 )
 
 game (
@@ -43567,12 +32404,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name rthundero.zip size 343646 crc 3d6ead34 md5 b13d4c84350f3345e1da72de1751815a sha1 0d1c0e334ed5d6a0a952ea689dc6b9f130847426 )
-)
-
-game (
-	name "Romar Triv"
-	developer "Romar"
-	rom ( name rtriv.zip size 215867 crc 64c0ccba md5 c821753c3f27bc5b8dafe6e24c3af438 sha1 a1d682ad823aee115b6c92d45314ea080540a370 )
 )
 
 game (
@@ -43639,24 +32470,10 @@ game (
 )
 
 game (
-	name "R-Type (US)"
-	year "1987"
-	developer "Irem (Nintendo of America license)"
-	rom ( name rtypeu.zip size 386918 crc 3fb6dc37 md5 117793ac2a6a68a7fdeee5f365c16451 sha1 68ed7db1209e31f2b32a2b67e533a4651783b2d9 )
-)
-
-game (
 	name "Rug Rats"
 	year "1983"
 	developer "Nichibutsu"
 	rom ( name rugrats.zip size 32115 crc eb40a48a md5 443775ad1e7b3b2d5b66c68511b946e6 sha1 5d3e8846a939122d7e7f385721fd765775b25279 )
-)
-
-game (
-	name "The Rumble Fish"
-	year "2004"
-	developer "Sammy / Dimps"
-	rom ( name rumblef.zip size 109652763 crc f7ce9f74 md5 2127b61a2605a7c975e370ea9322e323 sha1 90b9fe5a8af58793c6520861c842d9cb84295371 )
 )
 
 game (
@@ -43691,7 +32508,7 @@ game (
 	name "Run and Gun 2 (ver UAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name rungun2.zip size 18468886 crc 6d264d19 md5 aa9a994efe8648ce6c7b2f632ba4add5 sha1 dddf49db08691c78108932faa294cf2039b485ed )
+	rom ( name rungun2.zip size 18477576 crc acd9b81e md5 3fa1357e2c6994ac4c87f89322aefdf7 sha1 7b6bc41a5d877c8d2ec39bd9a9832fac82af16f1 )
 )
 
 game (
@@ -43699,20 +32516,6 @@ game (
 	year "1993"
 	developer "Konami"
 	rom ( name runguna.zip size 7064631 crc 56c84a54 md5 867e3b209da3f130c95e80695c6babc4 sha1 49fa8151a51a07a834b8c87698f115f64ba18ca4 )
-)
-
-game (
-	name "Run and Gun (ver UAB 1993 10.12)"
-	year "1993"
-	developer "Konami"
-	rom ( name rungunu.zip size 6536289 crc eebccd3a md5 90e29616a6c587f049dd95536100dfba sha1 bed619ed16075eb087859de3a0b16b90f5aee14e )
-)
-
-game (
-	name "Run and Gun (ver UBA 1993 10.8)"
-	year "1993"
-	developer "Konami"
-	rom ( name rungunua.zip size 7187509 crc d0c96856 md5 1540c3945386934fe5f0d3fcc83ed362 sha1 a741094b48f63e911acbe2b6aabaa14699e16efe )
 )
 
 game (
@@ -43730,24 +32533,17 @@ game (
 )
 
 game (
-	name "Rushing Heroes (ver UAB)"
-	year "1996"
-	developer "Konami"
-	rom ( name rushhero.zip size 18700360 crc 5f0e56d2 md5 68e03a80143456f2d74ee73077a9b08f sha1 bfc9b6a8be19577b0a83cc755fa33ce3915e3e1f )
-)
-
-game (
 	name "Rival Schools (USA 971117)"
 	year "1997"
 	developer "Capcom"
-	rom ( name rvschool.zip size 28131626 crc 10f5a7e5 md5 9bcee24747b8a0238fb820a1e93b99f0 sha1 6287ab4645a16338766bcdc4a4d96ee180608517 )
+	rom ( name rvschool.zip size 28269431 crc 97388421 md5 1a7dc4936b20012969e85e9043dedc59 sha1 869a7781e463bbb285d43d50ffedceba2cb2f318 )
 )
 
 game (
 	name "Rival Schools (Asia 971117)"
 	year "1997"
 	developer "Capcom"
-	rom ( name rvschoola.zip size 28131610 crc ffef14e9 md5 6d92de7a2f774470147a96ec782240c1 sha1 70cc9b57c9a92f009d95d80882eef0d006e94bac )
+	rom ( name rvschoola.zip size 28269415 crc 32eb57f0 md5 a2eaf47ef056863886d9d5a84765bc5e sha1 f30c6d24b89919663ff3d0c00a67f0eccf3e9496 )
 )
 
 game (
@@ -43789,7 +32585,7 @@ game (
 	name "VS Mahjong Otome Ryouran"
 	year "1998"
 	developer "Electro Design"
-	rom ( name ryouran.zip size 14345182 crc f714517e md5 376ed99ae90c7e1b47e2a86d2aae32b5 sha1 a960cba27a94a8eb1915eb4e12922bb30a7c1862 )
+	rom ( name ryouran.zip size 14377203 crc 634bf695 md5 662cf955c1ae7fea374d4e52e5f13273 sha1 33046b35326cbb9a22d2a02247d79c8902a45bc3 )
 )
 
 game (
@@ -43835,20 +32631,6 @@ game (
 )
 
 game (
-	name "Strikers 1945 (World)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945.zip size 5455851 crc 3531fb50 md5 d05941ecbabeacdc15dcdd46fc321f96 sha1 588e673cd5e486f53ef9e0b9c8e49f000981acae )
-)
-
-game (
-	name "Strikers 1945 (Japan / World)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945a.zip size 5456220 crc 78fc492a md5 5adee769a00469661c5ea8a1aeba64bd sha1 1e4ad7a208e33ae29e046655e55f71100969cb67 )
-)
-
-game (
 	name "Strikers 1945 (Hong Kong, bootleg)"
 	year "1995"
 	developer "bootleg"
@@ -43870,13 +32652,6 @@ game (
 )
 
 game (
-	name "Strikers 1945 (Japan)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945j.zip size 5455898 crc 164c1239 md5 8ad9d7b756155cd91ffb67bc2d3eb5a8 sha1 7f5159015bc7458531187436474e3a876fc638df )
-)
-
-game (
 	name "Strikers 1945 (Japan, unprotected)"
 	year "1995"
 	developer "Psikyo"
@@ -43884,17 +32659,10 @@ game (
 )
 
 game (
-	name "Strikers 1945 (Korea)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945k.zip size 5456059 crc dd9dcf23 md5 e7c9c16bae8473528d4981c2aec4b4a8 sha1 202866be68412cd2fb02389cbc0b7ef04cba5256 )
-)
-
-game (
 	name "Strikers 1945 Plus"
 	year "1999"
 	developer "Psikyo"
-	rom ( name s1945p.zip size 77360817 crc 1a3e869e md5 e3316912f6c44ffc92a47d35d182a0ad sha1 6e4f4cd12deb5ec6b7196016d3b0ba2267560685 )
+	rom ( name s1945p.zip size 78707504 crc 74bd5d9f md5 3e27fa780c87fcc448df24d1412ea9a1 sha1 0ccac4ac82dc5094a3cf7a8ff08abc7a8225b4e4 )
 )
 
 game (
@@ -43916,27 +32684,6 @@ game (
 	year "1993"
 	developer "Dooyong (NTC license)"
 	rom ( name sadari.zip size 419961 crc 2098925e md5 a8c90040639d6c4a848e53c99bb13265 sha1 38edf4e63b0f35c4170447cbbf43b5c257d9ece7 )
-)
-
-game (
-	name "Space Ace (European)"
-	year "1983"
-	developer "Cinematronics (Atari license)"
-	rom ( name saeuro.zip size 23853 crc d82ef079 md5 2d5b68caeec51ec72885c8b22839e773 sha1 ebec27d569085c022d1ca38971b1a001b8ed7f13 )
-)
-
-game (
-	name "Safari (set 1)"
-	year "1977"
-	developer "Gremlin"
-	rom ( name safari.zip size 8123 crc 1022c961 md5 9e227d83baba0cf1f6a5862b4be7f208 sha1 18ef2830fd0fe08cdbca5ec90a43d5bbc7f3fb07 )
-)
-
-game (
-	name "Safari (set 2, bootleg?)"
-	year "1977"
-	developer "Gremlin"
-	rom ( name safaria.zip size 8026 crc 31cfa558 md5 2d7c85a7fd3ce113ab96cba13249e10c sha1 c544d5d6a626fd297aaab82a5c2f669ca598aad7 )
 )
 
 game (
@@ -44052,13 +32799,6 @@ game (
 )
 
 game (
-	name "Sai Yu Gou Ma Roku (Japan)"
-	year "1988"
-	developer "Technos Japan"
-	rom ( name saiyugou.zip size 573861 crc c8929d6e md5 915ab13d68e8b7f2c4045275283c0bee sha1 c78481a2670a9e7fd1a60e8979793500da05042e )
-)
-
-game (
 	name "Sai Yu Gou Ma Roku (Japan bootleg 1)"
 	year "1988"
 	developer "bootleg"
@@ -44094,177 +32834,101 @@ game (
 )
 
 game (
-	name "Salary Man Champ (GCA18 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name salarymc.zip size 286 crc d62cd521 md5 cebda5b93cd25de919585476f56d3dfc sha1 f470e8ae1c606ea97ca4130caec9ff442396cebc )
-)
-
-game (
-	name "Salary Man Kintarou"
-	year "2004"
-	developer "Sammy"
-	rom ( name salmankt.zip size 102635461 crc 2aae6b02 md5 44d166d44168d21a7b3bf0764761beb7 sha1 70a4f13a1f8dddcf95ccc78d3c4c45f71cd6f203 )
-)
-
-game (
-	name "Salamander 2 (ver JAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name salmndr2.zip size 6203124 crc 0e896367 md5 c78d6b3f5fc78da69cb440aa9f57c52c sha1 8db50362781f5404a8d3f2f5034712c12741c1d1 )
-)
-
-game (
-	name "Salamander 2 (ver AAB)"
-	year "1996"
-	developer "Konami"
-	rom ( name salmndr2a.zip size 6203069 crc cb060e1b md5 65e0bedabd8a69ef4a8881d4618b68d9 sha1 b5a814d0bcd4c88e746cff195f8623c5b3845471 )
-)
-
-game (
-	name "Saloon (French, encrypted)"
-	developer "&lt;unknown&gt;"
-	rom ( name saloon.zip size 43233 crc ee8f8cb1 md5 685bb8d9529e50a0118fb0b4847d2381 sha1 0a6c9404cd818d85d7e9c602039f95fab3259ab3 )
-)
-
-game (
-	name "Samba De Amigo (JPN) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name samba.zip size 122223475 crc 5b383144 md5 4ebde0fc5426873c993f32f1974fffdc sha1 40d0fc7c6417af500323c7e9d35281f68086c3be )
-)
-
-game (
-	name "Same! Same! Same! (2 player alternating ver.)"
-	year "1989"
-	developer "Toaplan"
-	rom ( name samesame.zip size 532879 crc 758c8b6b md5 bf565d35681c78b1a590233e79af9db4 sha1 2e682c003f2af1cb3b114b9d5d62ca106bc8bdc4 )
-)
-
-game (
-	name "Same! Same! Same!"
-	year "1989"
-	developer "Toaplan"
-	rom ( name samesame2.zip size 533515 crc f5dd6d10 md5 194b2d496ee720a8860d599e42f441b7 sha1 0af58fee5c0f7bdc79ef95277a9267eafdeaa4c9 )
-)
-
-game (
-	name "Samurai Shodown 64 / Samurai Spirits 64"
-	year "1998"
-	developer "SNK"
-	rom ( name sams64.zip size 39889147 crc 23b29397 md5 c78cf8e48772bb12f98ed895a8df1f34 sha1 894c5a1165ea94e6c236a655c0cff0067a59a2b4 )
-)
-
-game (
-	name "Samurai Shodown: Warrior's Rage / Samurai Spirits 2: Asura Zanmaden"
-	year "1998"
-	developer "SNK"
-	rom ( name sams64_2.zip size 72026116 crc 72a04040 md5 77de0bb53e88a82f56b449c1ce6e4f54 sha1 2d43bab487dfff06e4f4ea8d32efa75c23de970c )
-)
-
-game (
 	name "Samurai Shodown V Special / Samurai Spirits Zero Special (set 1, uncensored)"
 	year "2004"
 	developer "Yuki Enterprise / SNK Playmore"
-	rom ( name samsh5sp.zip size 83033290 crc bfe6b89d md5 a67e7ac4f72c6328c8917044b87018a3 sha1 f561b7f92d847d9a65b5d065ad03aad6aa231e2b )
+	rom ( name samsh5sp.zip size 84379977 crc 0f3b041b md5 f745f6031d69e7768fa9100e0ea97f11 sha1 1c60494b79fad3b81458bbb64e0ba0b1f67a9d44 )
 )
 
 game (
 	name "Samurai Shodown V Special / Samurai Spirits Zero Special (set 2, censored)"
 	year "2004"
 	developer "Yuki Enterprise / SNK Playmore"
-	rom ( name samsh5sph.zip size 83035685 crc c8488dbd md5 b6e223b3294927fa8aed7e5b9e5dfa3a sha1 43feabe484b93ce63fd987b0bb8e321bf1cb83a8 )
+	rom ( name samsh5sph.zip size 84382372 crc 32626430 md5 a4dc1815bd927a67e76d91aff0a436c2 sha1 9e117a87cee499819053368f7870c8f86340be55 )
 )
 
 game (
 	name "Samurai Shodown V Special / Samurai Spirits Zero Special (set 3, less censored)"
 	year "2004"
 	developer "Yuki Enterprise / SNK Playmore"
-	rom ( name samsh5spn.zip size 83024346 crc 2b2dfe30 md5 c0950a80630f451903651939c3a65bde sha1 fc0a6376bc62a57c6aaf3e9b02fe1538ba88a43f )
+	rom ( name samsh5spn.zip size 84371033 crc 721903cb md5 e759f86f2350b8bacede70c8a0f14b12 sha1 6337914923001658dc8c53620566c043fafb22f3 )
 )
 
 game (
 	name "Samurai Shodown / Samurai Spirits (set 1)"
 	year "1993"
 	developer "SNK"
-	rom ( name samsho.zip size 8347762 crc 2babdc8a md5 35e0903b82fe63c962677b948933703c sha1 63f9864700b37b6e473e484b8d8866975e773571 )
+	rom ( name samsho.zip size 9694449 crc 17a8ba54 md5 c4ba428b9b3c5b6c2000ef5a9b3e13d4 sha1 0da443d31dd45add74548e881a3e0945c9179320 )
 )
 
 game (
 	name "Samurai Shodown II / Shin Samurai Spirits - Haohmaru jigokuhen"
 	year "1994"
 	developer "SNK"
-	rom ( name samsho2.zip size 14482604 crc 7abfa7cd md5 10ba3028db0bfe4291cc1ca2776a1f4f sha1 1cbbfb71d6689dfe671c00e9ec5a79794fb0bc48 )
+	rom ( name samsho2.zip size 15829291 crc e6c5e8ac md5 fd5a8d677ec7b95638d97c9a66ff4a0d sha1 99e41c4f4f90c16015091ca6fde1cc63e56dae33 )
 )
 
 game (
 	name "Saulabi Spirits / Jin Saulabi Tu Hon (Korean release of Samurai Shodown II)"
 	year "1994"
 	developer "SNK"
-	rom ( name samsho2k.zip size 14980151 crc e74c68e8 md5 a57026b932fddaa439f4b55f566bcc27 sha1 5b7254f04758d0b0bca224829df85b9c7f4ae3bf )
+	rom ( name samsho2k.zip size 16326838 crc 5f74cc4e md5 cf75e636e1dda28fa9ac7960e0de057f sha1 afdc25c320c069febfabb1037dfc0f6eced387fd )
 )
 
 game (
 	name "Samurai Shodown III / Samurai Spirits - Zankurou Musouken (set 1)"
 	year "1995"
 	developer "SNK"
-	rom ( name samsho3.zip size 17548288 crc 55a672a6 md5 b65fd34e7a69feddb9a646a053c7b2c0 sha1 a00229818720f75d73d89d8c26fc1d78ce2a4f2e )
+	rom ( name samsho3.zip size 18894975 crc 09436f94 md5 a0d128d63a19939954e2e8337ba5cdc3 sha1 f53c95a2bf5f7c0aff1cceb3279c9e53ba083d67 )
 )
 
 game (
 	name "Samurai Shodown III / Samurai Spirits - Zankurou Musouken (set 2)"
 	year "1995"
 	developer "SNK"
-	rom ( name samsho3h.zip size 17547634 crc 233f4a24 md5 6a797fd66c48d1e7ff40b6f9debb3d28 sha1 26d8025a0528e077f1d0e736b163b18ad4db629c )
+	rom ( name samsho3h.zip size 18894321 crc c7865fd4 md5 1a3304091ba37d946cbcea35871710f5 sha1 eb266eee3ec3c9364b4220f9d14da7c6bee66841 )
 )
 
 game (
 	name "Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin"
 	year "1996"
 	developer "SNK"
-	rom ( name samsho4.zip size 22671985 crc 9fcc428c md5 3ab0fd0c3e3e9e322daab19d60bdb1c7 sha1 6f42211097dc88be8758fba356b20bb98a848663 )
+	rom ( name samsho4.zip size 24018672 crc b1a86d01 md5 2bde40cb3534667d1ea70e7b9f496c78 sha1 d04a35b37f7962eb2d813db69fadc29fc26c208a )
 )
 
 game (
 	name "Pae Wang Jeon Seol / Legend of a Warrior (Korean censored Samurai Shodown IV)"
 	year "1996"
 	developer "SNK"
-	rom ( name samsho4k.zip size 22668963 crc d9e59798 md5 b71daa382143d40f00fb71c73aa7f0f3 sha1 5841c8bbd12359860226e8f50f6a5f941e340a0d )
+	rom ( name samsho4k.zip size 24015650 crc 21623e52 md5 6fc9c0cf470a8c9a2578f1b602d2015e sha1 0e980e254c5b489c589eae7663806f18c478a078 )
 )
 
 game (
 	name "Samurai Shodown V / Samurai Spirits Zero (set 1)"
 	year "2003"
 	developer "Yuki Enterprise / SNK Playmore"
-	rom ( name samsho5.zip size 83164380 crc ef2218c0 md5 73da45d0fd0bf7a83e3238d56fbf7a75 sha1 6f5290a6c17647d9b52a2911a4b466e15417c9b5 )
+	rom ( name samsho5.zip size 84511067 crc 513cbca4 md5 405ea682e0693d7248de1a6ba861ded8 sha1 ea8dfb3157d7af5e0fd6d2b92432f41c1700dcf6 )
 )
 
 game (
 	name "Samurai Shodown V / Samurai Spirits Zero (bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name samsho5b.zip size 41223684 crc 7cbd0b71 md5 a1de9b60d5e2468e7aa8f60ddf6c2df3 sha1 e813e2a484c425c91d0b09197be8ba3058c2343d )
+	rom ( name samsho5b.zip size 42570371 crc 8f4b1eb4 md5 e8190c076da86a4322b8cb7ae2df2976 sha1 e28275a764dd2932b18a295ababcc1768f4f8b8b )
 )
 
 game (
 	name "Samurai Shodown V / Samurai Spirits Zero (set 2)"
 	year "2003"
 	developer "Yuki Enterprise / SNK Playmore"
-	rom ( name samsho5h.zip size 83164279 crc f7d165c2 md5 50426995db1c00f8b20798c29d8199ee sha1 e7985bfc2e2bea3c9a15e2f9c20ffcf1acf6b30c )
+	rom ( name samsho5h.zip size 84510966 crc c1c183f0 md5 14fb20f58944796178e09b418d5f5cf0 sha1 a871e809b3588c97de041ae7c08796312ae2d22c )
 )
 
 game (
 	name "Samurai Shodown / Samurai Spirits (set 2)"
 	year "1993"
 	developer "SNK"
-	rom ( name samshoh.zip size 8343250 crc 5e45496e md5 923a2aef77a2ed17405e593d3f5b1e33 sha1 47cbb4e0959512b7a1d167524aaa6e988ca86a83 )
-)
-
-game (
-	name "Samurai"
-	year "1980"
-	developer "Sega"
-	rom ( name samurai.zip size 12151 crc ee040cec md5 5c2958cf5de0b3ad57eb6813fcec358f sha1 8a377436fd690fffc7f5fdfab4dad92091819879 )
+	rom ( name samshoh.zip size 9689937 crc 86b2be8c md5 5b020a9de61acfd6827df40453103cd2 sha1 2b750e1e563cf1cf10d3cc537b07558b0a78aa64 )
 )
 
 game (
@@ -44278,7 +32942,7 @@ game (
 	name "Puzzle _ Action: Sando-R (J 951114 V1.000)"
 	year "1995"
 	developer "Sega"
-	rom ( name sandor.zip size 14296345 crc caba1478 md5 c60590962be3f5db28b520369bbce3e5 sha1 305cb5945f7aea0210ff10dd42dd8936b0809c01 )
+	rom ( name sandor.zip size 16995566 crc 21740af7 md5 36c3b4539230fe053e58c97868239a16 sha1 72de3e6ef4f26a219f7113458c751d3780c6acad )
 )
 
 game (
@@ -44306,28 +32970,21 @@ game (
 	name "DaeJeon! SanJeon SuJeon (AJTUE 990412 V1.000)"
 	year "1999"
 	developer "Sega / Deniam"
-	rom ( name sanjeon.zip size 9277215 crc 7c7cc18c md5 5bb77662359701c8253fa8b209bffd0a sha1 37cb17783007a2b758004e20590cad6c922a00af )
-)
-
-game (
-	name "Sarge"
-	year "1985"
-	developer "Bally Midway"
-	rom ( name sarge.zip size 84020 crc 19794f30 md5 c52f5e03f7c539c77f5ae573abd079a6 sha1 68d891cc01d5be32931f167816d040217b6924ed )
+	rom ( name sanjeon.zip size 11976436 crc 006e6116 md5 70927bed5d928c4a58ba2a0e0633cee0 sha1 ab04e3282527d59986426d60ee1bd2c707b663ab )
 )
 
 game (
 	name "Saru-Kani-Hamu-Zou (Japan)"
 	year "1997"
 	developer "Kaneko / Mediaworks"
-	rom ( name sarukani.zip size 3402417 crc 17ee99c0 md5 a95bb85ad0ecd2951993385b0449dd7b sha1 071c53eea482310d4bfd20c18f2a572006ddaefd )
+	rom ( name sarukani.zip size 3434438 crc 9ab8e1c8 md5 91ea690d497d028ab2030ddba2c99763 sha1 bc91a7ab35d48cb9bacfda44cb02cfb5073e43e4 )
 )
 
 game (
 	name "Taisen Tanto-R Sashissu!! (J 980216 V1.000)"
 	year "1998"
 	developer "Sega"
-	rom ( name sasissu.zip size 9625681 crc cb034852 md5 03b99c33d174540caa402d6d69764550 sha1 17820034b370eef4cabb71bc9ff260ad2f19e73c )
+	rom ( name sasissu.zip size 12324902 crc f13b0341 md5 687016e602f87ae5fc52ca03fb8f3258 sha1 6c98a56e2bf4c419ed2fc77eb91a5a186971554d )
 )
 
 game (
@@ -44369,7 +33026,7 @@ game (
 	name "Savage Reign / Fu'un Mokushiroku - kakutou sousei"
 	year "1995"
 	developer "SNK"
-	rom ( name savagere.zip size 13252209 crc b07284b0 md5 7c9a81e98ac9823cfb59854dd803d4d6 sha1 95991455b7e1ab75b7172fb31ba22896ed1beb87 )
+	rom ( name savagere.zip size 14598896 crc 3286a798 md5 74e6735da016175b0c60a4464385333f sha1 4c7e6463ad32eb2ddc88bd989c9aeff94b18cc3f )
 )
 
 game (
@@ -44377,20 +33034,6 @@ game (
 	year "1985"
 	developer "Capcom (Memetron license)"
 	rom ( name savgbees.zip size 74668 crc b1de8409 md5 159fabc9b2c5bc5d4438285ef50fd673 sha1 0cb9abcae63cf5fdeb9d8dad46e9778405b9dc62 )
-)
-
-game (
-	name "Super Bubble 2003 (World, Ver 1.0)"
-	year "2003"
-	developer "Limenko"
-	rom ( name sb2003.zip size 6413782 crc c50b1a1a md5 f47dda175996ba3c4a34d26388191f28 sha1 f4de6ce621ed86d36f1d6c6652987af1ac15b4c0 )
-)
-
-game (
-	name "Super Bubble 2003 (Asia, Ver 1.0)"
-	year "2003"
-	developer "Limenko"
-	rom ( name sb2003a.zip size 6413783 crc b78a1860 md5 f46d0d33c0d05e618a51f5acaaa49f50 sha1 9942f80fd4f517279683b3b6d563c634748a58b4 )
 )
 
 game (
@@ -44450,13 +33093,6 @@ game (
 )
 
 game (
-	name "Super Bike (DK conversion)"
-	year "1984"
-	developer "Century Electronics"
-	rom ( name sbdk.zip size 18655 crc 42f00b04 md5 aecfb0d96cf02d4c49c009dc75bdebe3 sha1 b1f1dfce136167969bb424017b7cb6febd972694 )
-)
-
-game (
 	name "Super Bishi Bashi Championship (ver JAA, 2 Players)"
 	year "1998"
 	developer "Konami"
@@ -44475,13 +33111,6 @@ game (
 	year "1997"
 	developer "bootleg"
 	rom ( name sblast2b.zip size 1146376 crc 022ffcbf md5 51ffe86d157291cd02e586ccaca8ee10 sha1 0352aee683c14def174d02c52d4f82f7ed00b3ed )
-)
-
-game (
-	name "Star Blazer (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name sblazerp.zip size 54663 crc f7372424 md5 b185ca766bc837f0683ee7375c057cfd sha1 890bc67118f73b91c73670cf470f301882a99d83 )
 )
 
 game (
@@ -44541,20 +33170,6 @@ game (
 )
 
 game (
-	name "Space Bugger (set 1)"
-	year "1981"
-	developer "Game-A-Tron"
-	rom ( name sbugger.zip size 11803 crc 6d3999eb md5 3e7cb7b015df5c348b0da284dbe54e6e sha1 3d17d21727fd289fd1a0d979f2b0fb2fa50cacfe )
-)
-
-game (
-	name "Space Bugger (set 2)"
-	year "1981"
-	developer "Game-A-Tron"
-	rom ( name sbuggera.zip size 12259 crc 09b62d39 md5 598b33409accb5ad40046599e9401269 sha1 29283b8b93dd50dfb00f1a66343c5c27628a3a8b )
-)
-
-game (
 	name "Scandal Mahjong (Japan 890213)"
 	year "1989"
 	developer "Nichibutsu"
@@ -44583,20 +33198,6 @@ game (
 )
 
 game (
-	name "Sega Club Golf 2006 Next Tours (Rev A) (GDX-0018A)"
-	year "2006"
-	developer "Sega"
-	rom ( name scg06nt.zip size 211 crc 30de779c md5 270ebfae1a224a239e8bd18cf63b1f36 sha1 f1d05eddf7f7177ddcc86aed9ce2a972a71b8cc7 )
-)
-
-game (
-	name "Sonic Championship"
-	year "1996"
-	developer "Sega"
-	rom ( name schamp.zip size 17724718 crc 3fad7e5a md5 fc4c9e5d187dbb0cd985e4363908ae84 sha1 a3704bd9022b8bcba8e82cab2d5424975fdc6504 )
-)
-
-game (
 	name "Space Chaser"
 	year "1979"
 	developer "Taito"
@@ -44608,13 +33209,6 @@ game (
 	year "1979"
 	developer "Taito"
 	rom ( name schasercv.zip size 9322 crc 109a261a md5 91f8679248fe1d9ccf4f9ab9b77b93e4 sha1 b81dc111c9790786cf7b631e16a65bbdc6140802 )
-)
-
-game (
-	name "Super Cherry Master"
-	year "2001"
-	developer "Dyna"
-	rom ( name scherrym.zip size 65393 crc a9e96fb8 md5 e70f0f429b21fce9a97f44125a910557 sha1 6e511c98a0c12774c6d004e5830491fe0443fe0d )
 )
 
 game (
@@ -44737,13 +33331,6 @@ game (
 )
 
 game (
-	name "Scorpion (set 2)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name scorpiona.zip size 34609 crc 730644e3 md5 1a9d31e18c7e5f00e23bfd24de166e8f sha1 3047d21fd10c3646027362e2f9aae85aa82fa7c6 )
-)
-
-game (
 	name "Scorpion (set 3)"
 	year "1982"
 	developer "Zaccaria"
@@ -44792,38 +33379,10 @@ game (
 )
 
 game (
-	name "Scramble (Karateko, French bootleg)"
-	year "1981"
-	developer "bootleg (Karateko)"
-	rom ( name scramblebf.zip size 15388 crc c0edc825 md5 4070ebae7777e87e3c50035c7c07a251 sha1 03ad46b442424cf186299f274dd9d60b19c71a6b )
-)
-
-game (
 	name "Scramble (Stern Electronics)"
 	year "1981"
 	developer "Konami (Stern Electronics license)"
 	rom ( name scrambles.zip size 15282 crc ab78051b md5 1286c10743b845f8ff283cdd6a1b6918 sha1 c9baf5bdd15342cf259aab7bf9be6e32bb0484cb )
-)
-
-game (
-	name "Screen Play (ver. 1.9)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenp1.zip size 521494 crc 527c6f54 md5 395fed27011d830c0f53e2956ddd85c3 sha1 d680a279fd5f1c19de05a60e7b2cbca8dbfd157d )
-)
-
-game (
-	name "Screen Play (ver. 1.9, Isle of Man)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenp2.zip size 521492 crc 06107250 md5 20002b810ba9712cd39a14514fbb10d6 sha1 13ec675e96372dc04bebe1a37e37eb5581642380 )
-)
-
-game (
-	name "Screen Play (ver. 4.0)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenpl.zip size 513560 crc 6e03cd48 md5 de391b0a7f59f341367790a8fbc970d6 sha1 49bf58a1c06c8e3504c3aee8d5f437d62146976a )
 )
 
 game (
@@ -44855,44 +33414,10 @@ game (
 )
 
 game (
-	name "Scud Race (Australia)"
-	year "1996"
-	developer "Sega"
-	rom ( name scud.zip size 63199987 crc d32af293 md5 1b5df83c9a03dfbc5f37a172f521f75e sha1 02f61f8767e0b30b16d45b77795b10b1cba83d38 )
-)
-
-game (
-	name "Scud Race (Export)"
-	year "1996"
-	developer "Sega"
-	rom ( name scuda.zip size 63200047 crc 5e863e8f md5 8e8fbfefc3f12f259790db4aa03e9215 sha1 75a2a538894e2d5d0980394c462812cbb5039121 )
-)
-
-game (
 	name "Scud Hammer"
 	year "1994"
 	developer "Jaleco"
 	rom ( name scudhamm.zip size 2716298 crc 195932c9 md5 68d6bccc833528a73e88afc1211f600c sha1 876b4087fa2fd71d73419c260ebe91e75f86fcf0 )
-)
-
-game (
-	name "Scud Race (Japan)"
-	year "1996"
-	developer "Sega"
-	rom ( name scudj.zip size 58577265 crc 665b9f2e md5 456e3f329defe83c8654dd895137c961 sha1 6faf1bff67c1bb7247e4769ff1c9bb1e88e293e9 )
-)
-
-game (
-	name "Scud Race Plus (Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name scudp.zip size 68555534 crc 1793ff62 md5 f71a0513712efed40658b67ee2fe8dba sha1 940037ee6e72e27dd5dae22530debb837af885eb )
-)
-
-game (
-	name "Super Dou Di Zhu"
-	developer "IGS"
-	rom ( name sddz.zip size 3157310 crc ef164bd4 md5 67ea99ee579c577ea004b9c3352c7396 sha1 1778aaeab284d3d503975ad7006212134ea67223 )
 )
 
 game (
@@ -44903,31 +33428,10 @@ game (
 )
 
 game (
-	name "SD Fighters (Korea)"
-	year "1996"
-	developer "SemiCom"
-	rom ( name sdfight.zip size 2085175 crc 5505567e md5 d2cb25ca81746b7e65625ae5cf718c9c sha1 0f0e20fdfdea9582edad5b3af05dead474a25d03 )
-)
-
-game (
 	name "SD Gundam Psycho Salamander no Kyoui"
 	year "1991"
 	developer "Banpresto / Bandai"
 	rom ( name sdgndmps.zip size 1492205 crc 21ef9783 md5 70ef6141c8748ed19dd38007d603a12e sha1 c9bcf42cf112266b541734945fa5dd7b99cbf89d )
-)
-
-game (
-	name "SDI - Strategic Defense Initiative (Japan, old, System 16A, FD1089B 317-0027)"
-	year "1987"
-	developer "Sega"
-	rom ( name sdi.zip size 366622 crc 558f377a md5 a60733a012c3a05cf0e53e069d138033 sha1 98a49da7b72a35b016dde057cdc9e325925adadc )
-)
-
-game (
-	name "SDI - Strategic Defense Initiative (System 16B, FD1089A 317-0028)"
-	year "1987"
-	developer "Sega"
-	rom ( name sdib.zip size 368982 crc 4e0fc1d9 md5 e3ec9c8e9c31ada3d49d79b214f0ded7 sha1 596386b0b7383e0b426747f67742a386af798b9e )
 )
 
 game (
@@ -44948,7 +33452,7 @@ game (
 	name "Super Dodge Ball / Kunio no Nekketsu Toukyuu Densetsu"
 	year "1996"
 	developer "Technos Japan"
-	rom ( name sdodgeb.zip size 7214450 crc a11aad07 md5 23ad6f56b9afd0c6ec7565f00778ec74 sha1 6f0827893d099903d31ae42a2f5a32363c3cedf3 )
+	rom ( name sdodgeb.zip size 8561137 crc 28a517cf md5 fe7241cc20d8e8000aedb7e6edf4a56f sha1 5eb5d149228f25f1e2dc4339bc1db742761a57aa )
 )
 
 game (
@@ -44966,17 +33470,10 @@ game (
 )
 
 game (
-	name "Sheng Dan Wu Xian"
-	year "2002"
-	developer "IGS"
-	rom ( name sdwx.zip size 1714304 crc 422c78fa md5 72acff551f1a3c3500fbb7f8dd1523f9 sha1 e3ad6bb69b723d4123149efec76cc878f534cf55 )
-)
-
-game (
 	name "Sea Bass Fishing (JUET 971110 V0.001)"
 	year "1997"
 	developer "A wave inc. (Able license)"
-	rom ( name seabass.zip size 29206048 crc 7976f61a md5 95e5d5c00c31f41e4392abc6d25d0837 sha1 be8db520f36d4cd7ec879967f74fda7bb263f2cd )
+	rom ( name seabass.zip size 31905269 crc 73f5b7e6 md5 ba41ca484c6252b0bb1007e3ee40e9f3 sha1 16149e4623e7d5e148cb899f522cb00485bd85d9 )
 )
 
 game (
@@ -45071,13 +33568,6 @@ game (
 )
 
 game (
-	name "Secret Agent (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name secretab.zip size 524052 crc 12d480f3 md5 58ea7a112c4964f36b0a0f957dd7597e sha1 af90657cbd79c8e6a769bc991720fb3a82eecdfd )
-)
-
-game (
 	name "Secret Agent (World)"
 	year "1989"
 	developer "Data East Corporation"
@@ -45120,13 +33610,6 @@ game (
 )
 
 game (
-	name "Sega Water Ski (Japan, Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name segawski.zip size 29699014 crc 8b21c179 md5 83b762146e2f128fb8e3b31f43c2c401 sha1 e48530a4e676b967abb600cb993df72f43c6438f )
-)
-
-game (
 	name "Seicross"
 	year "1984"
 	developer "Nichibutsu / Alice"
@@ -45155,31 +33638,24 @@ game (
 )
 
 game (
-	name "MuHanSeungBu (SemiCom Baseball) (Korea)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name semibase.zip size 2020618 crc d21a9c65 md5 86efa50c202de62ebaf78f90c8338b71 sha1 cf9667d40a08b4300fac3d586afd101cc091ec3f )
-)
-
-game (
 	name "Sengeki Striker (Asia)"
 	year "1997"
 	developer "Kaneko / Warashi"
-	rom ( name sengekis.zip size 14884309 crc 63e08683 md5 3184be8299f3e936010ffb078de46ed5 sha1 390157a04d15704d6712c3cff0942a40293ba3c2 )
+	rom ( name sengekis.zip size 15046024 crc 57b8a4e3 md5 dfe5fe308ba6bdd642b805c0cffd66be sha1 c1c2de716b29b4b6a97272252b646055870df90a )
 )
 
 game (
 	name "Sengeki Striker (Japan)"
 	year "1997"
 	developer "Kaneko / Warashi"
-	rom ( name sengekisj.zip size 14888185 crc 91f2457f md5 90469e7c49c40bec93900f2dde875f5c sha1 b6a2bcb11f7e7a4a86353457110c92381d475672 )
+	rom ( name sengekisj.zip size 14920206 crc 86014c81 md5 e079ccc64a809692a20929cd171c99e7 sha1 ae3e567b764992fb058b9e3c120aacebbc3f96dd )
 )
 
 game (
 	name "Sengoku / Sengoku Denshou (set 2)"
 	year "1991"
 	developer "SNK"
-	rom ( name sengokh.zip size 3555184 crc d11959df md5 49145af5e01be73f6c5c1d659da5daca sha1 785ce468061289579d0db7fb4d9bdcb976464f32 )
+	rom ( name sengokh.zip size 4901871 crc 3e94e4bb md5 b595bde55ff4fb5ed225c1c9cacf7be5 sha1 b859d9773f7d1aab186c5808b2fea9add4cc3205 )
 )
 
 game (
@@ -45193,21 +33669,21 @@ game (
 	name "Sengoku / Sengoku Denshou (set 1)"
 	year "1991"
 	developer "SNK"
-	rom ( name sengoku.zip size 3554666 crc d5447eb1 md5 582cb17635c16691d4695abc60ad4c21 sha1 652c7ae86fcf324a4f29e02548d71c0014b5031c )
+	rom ( name sengoku.zip size 4901353 crc f525acec md5 6dda59ca0496e30120da7ae151015040 sha1 8d37ec598b72401f24515f4727518d5aacad79ea )
 )
 
 game (
 	name "Sengoku 2 / Sengoku Denshou 2"
 	year "1993"
 	developer "SNK"
-	rom ( name sengoku2.zip size 5280916 crc 783d77b2 md5 0751a66f80d84446a6e847f0c961c1c4 sha1 f2cf27cbeede2222ba5b9ff6818fdd31e797347d )
+	rom ( name sengoku2.zip size 6627603 crc e3803e15 md5 2adeed1f73bc68bcd1bf179d0554e6a8 sha1 d7cb00fcb21b282daddf78b02465558dec6ce3cf )
 )
 
 game (
 	name "Sengoku 3 / Sengoku Densho 2001"
 	year "2001"
 	developer "Noise Factory / SNK"
-	rom ( name sengoku3.zip size 44804701 crc 0a99ab95 md5 0652b1a16eba357557d26e9cc0dcca8b sha1 02aaebf35729afeb03c486ccdc2fb3978ac4ce7a )
+	rom ( name sengoku3.zip size 46151388 crc a4fa6054 md5 f93d21e3386593c7de12ee78328d90b7 sha1 32ca3766bb75e0c65489229095e381ddff2b93c7 )
 )
 
 game (
@@ -45221,28 +33697,7 @@ game (
 	name "Sen-Know (Japan)"
 	year "1999"
 	developer "Kaneko / Kouyousha"
-	rom ( name senknow.zip size 11205177 crc 7c77a6b0 md5 76f6ecb0e63e202945e045d0238ae06b sha1 457e2a6ae08a3e6b9455e5f1dd0e536c3c16cd2f )
-)
-
-game (
-	name "Senko No Ronde NEW ver. (Rev A) (GDL-0030A)"
-	year "2005"
-	developer "G-Rev"
-	rom ( name senko.zip size 1195 crc c63f30f3 md5 4f68985187a638ae585ca114e9ef7b61 sha1 521096beb03a3b15474d0ba7e1720d8078bc6016 )
-)
-
-game (
-	name "Senko No Ronde (GDL-0030)"
-	year "2005"
-	developer "G-Rev"
-	rom ( name senkoo.zip size 1195 crc c63f30f3 md5 4f68985187a638ae585ca114e9ef7b61 sha1 521096beb03a3b15474d0ba7e1720d8078bc6016 )
-)
-
-game (
-	name "Senko No Ronde Special (GDL-0038)"
-	year "2006"
-	developer "G-Rev"
-	rom ( name senkosp.zip size 1195 crc 01789c6a md5 84f4168433971451503079171e3c87a0 sha1 a19b9a3dd53195d6a7823d3c29a932d43d3e85b3 )
+	rom ( name senknow.zip size 11237198 crc c0374119 md5 e4340b83440b516f78f4dcc9fbd7b3ec sha1 65a676fac755012140f18c7b5ceef3561b2dc048 )
 )
 
 game (
@@ -45257,19 +33712,6 @@ game (
 	year "1995"
 	developer "Seibu Kaihatsu"
 	rom ( name senkyua.zip size 8368351 crc a4ff390a md5 762beab672bf216d856ab156f4aa297a sha1 353eee6376d97798b188490453309bf9096290c1 )
-)
-
-game (
-	name "Sente Diagnostic Cartridge"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name sentetst.zip size 9743 crc 1f2628e4 md5 dd11377d68a60831abe5fd295f98f455 sha1 c869c65e11f2a466ed0ac268aa3889ba05f701e1 )
-)
-
-game (
-	name "Seta / Visco Roulette?"
-	developer "Seta / Visco"
-	rom ( name setaroul.zip size 2668598 crc d820d07f md5 8cfd07f3b2f694cd11ce4bce29b3f9d6 sha1 9d096c9ba7eab879fba01412b2cb2a041d175c4f )
 )
 
 game (
@@ -45294,24 +33736,10 @@ game (
 )
 
 game (
-	name "Sexy Boom"
-	year "1992"
-	developer "Sang Ho Soft"
-	rom ( name sexyboom.zip size 664711 crc 40974bde md5 2e9df30e542d1174f8a639d07b08a86e sha1 025525cb0716bb4d3a90d188aaa90c935ad3f431 )
-)
-
-game (
-	name "Sexy Gal (Japan 850501 SXG 1-00)"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name sexygal.zip size 97052 crc d91b7180 md5 6dd5e57a6e9b7abd4de995926018a14b sha1 33d39c4bcb06b5892ed0e33eceb5b004b0b5ede0 )
-)
-
-game (
 	name "Sexy Parodius (ver JAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name sexyparo.zip size 6501610 crc 801b9c31 md5 379527a9cd4629b2983e9eeca1053ffa sha1 e820e6a9717400441dd35baa5e96d01740b51fa1 )
+	rom ( name sexyparo.zip size 6510300 crc 037608ca md5 356417a5195e8355c4c292ac92c9295f sha1 b3413aa8b148ec1492e02b97b644b81f0491ba9c )
 )
 
 game (
@@ -45319,34 +33747,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sf.zip size 1153892 crc 0d76ea0e md5 09e85bad4e24755d1c29e70bff5da66b sha1 fb27aa542a13496fe81d89afa0002f3a5e28ca9d )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (World 910522)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2.zip size 3551675 crc 57aa0ffe md5 bd33f8bfe89c2c4270a398cb77545eee sha1 ad7d7527ff7b2c0b0b5e1f7acd6e4fcfda1fbd0f )
-)
-
-game (
-	name "San Francisco Rush 2049"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049.zip size 249217 crc bd1a028e md5 b73914b447f2fecd7ed9a59ee3aeceba sha1 93e606c57660b053a1f7e51d0098dda1ee0ff9e5 )
-)
-
-game (
-	name "San Francisco Rush 2049: Special Edition"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049se.zip size 272281 crc 5b59d4e2 md5 28e89bdccdffb98acda7e9a5a63631cc sha1 f6b2a2fa4943aea96c21af0c88ab5e132bc330a9 )
-)
-
-game (
-	name "San Francisco Rush 2049: Tournament Edition"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049te.zip size 266738 crc 40278e23 md5 4ac82d6eacdc894209a7a348c4f67b95 sha1 76718d5edda7b3955a42f36d496587eb73cc6b33 )
 )
 
 game (
@@ -45364,52 +33764,10 @@ game (
 )
 
 game (
-	name "Street Fighter II': Champion Edition (World 920313)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ce.zip size 3615435 crc 8d0ac6df md5 db9414707a2fa816b05608251784d08b sha1 f6ebbc9926859f0ce68ee911a4433ae39dca86bf )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (Japan 920513)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2cej.zip size 3588007 crc 2ac02184 md5 b7561189cd367c611b6e0bd3c1881012 sha1 0dbcfd8145f5657c1dc2f4d59c3fad81ec55802e )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920313)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceua.zip size 3615430 crc 3741a692 md5 9df4439e0d47eeb9aaaa5df6a537813c sha1 6c25f0d925bb087bbb72824e1e9e8b6b708016db )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920513)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceub.zip size 3584615 crc ec4d46c2 md5 36838d3ecfa8ff219c7a6ed7f3071318 sha1 46ef3b3fc5e574f3f1784ffd088f8420b26cebbd )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920803)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceuc.zip size 3584467 crc e108d380 md5 69380318e4572d762c35453621a4520a sha1 21970c644f1dff727197a173b5ccc7bc48e7a278 )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2dkot2.zip size 3645546 crc ccf6514f md5 507b9213899ada0b6624b97b5b56cf24 sha1 28926e3da813000d25263c779c239c88b8492579 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (World 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2eb.zip size 3512463 crc 8f8e1d03 md5 4707c2b1aab579fa01b021e2438caaa4 sha1 6bd8f40e40c2356623bf6c9f8e48cec796885641 )
 )
 
 game (
@@ -45420,48 +33778,6 @@ game (
 )
 
 game (
-	name "Street Fighter II': Hyper Fighting (World 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hf.zip size 3640194 crc fe834e3b md5 aa753de798080d48044e4df1cbd2e44a sha1 d0bad63d0e4f81f59c1da149c04a7be3a2f8819d )
-)
-
-game (
-	name "Street Fighter II' Turbo: Hyper Fighting (Japan 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hfj.zip size 3638945 crc 66ddf02d md5 94f90aa02b88718889194ce9a25c289a sha1 fe9ca624e9e36a5ef806424bd62c670bae6ac39c )
-)
-
-game (
-	name "Street Fighter II': Hyper Fighting (USA 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hfu.zip size 3640194 crc 224930f7 md5 bcab090c17ea6c33452ddc3c2e08602b sha1 b3191b1de2ae813a563c95b16f32fb749e6bef3f )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 911210)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2j.zip size 3511544 crc 75371e93 md5 13c632c9d70f4493158bffc4a847593b sha1 20e71e3a6079d4fe219887eb62ceb3dba1084b98 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ja.zip size 3512477 crc e6555abb md5 d92a038afe5bd97aeeda82dbc1bb9de4 sha1 738c8f182cd26620b4a425526e05c3cfe6bd1128 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 910306)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2jc.zip size 3548274 crc 35e03d8c md5 566a484368a755a02b57557e38f2c1a4 sha1 f15ddab853bcde97f8df32fbe53f3be272b4dcf7 )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (Xiang Long, Chinese bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -45469,24 +33785,10 @@ game (
 )
 
 game (
-	name "Street Fighter II': Champion Edition (M1, bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2m1.zip size 3601143 crc 15aecec4 md5 ff12ef98ec9abc8fe541017acb05ba46 sha1 4ec2233c4008cc998923ce1d9748dbf406c2647d )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (M2, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2m2.zip size 3616866 crc a1342eb4 md5 f83b5517464e575fb6fdf810d60ea139 sha1 0c3b53b3d290a773eb166762d248658d34db57f8 )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (M3, bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2m3.zip size 3589254 crc bb20175a md5 94a0361066ea52740a113207af264d08 sha1 4c185fd9b31108b53a59651bd8e2fb4b5f7bd5e1 )
 )
 
 game (
@@ -45515,13 +33817,6 @@ game (
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2m7.zip size 3630574 crc 82a22794 md5 db043e0b59364536fc5365f22f0e3cdc sha1 4310f0ded98d7711ceed61e14ff4345669eac50d )
-)
-
-game (
-	name "Street Fighter II': Magic Delta Turbo (bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2mdt.zip size 3553992 crc a4fa7d2b md5 75a4ce45cdb9af9ec586a8644de50a87 sha1 6bde7866794120ca489fbba14c06f0a354c6d22c )
 )
 
 game (
@@ -45564,55 +33859,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name sf2thndr.zip size 3512251 crc 031f8c19 md5 f58e436c93e63d04f80538b411a7563f sha1 6e89e4b15593ba33ade01c199334233e101eb165 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910206)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ua.zip size 3510008 crc 87816e2c md5 96f9e63e7c94042c5e5be31e26673eeb sha1 c29083dbeedd3646208522c134b662edd74fbec0 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ub.zip size 3512465 crc 5095ee00 md5 40cb260ee3561abf38aeb8078609b9c3 sha1 b8ea4b8cc62a40f464d3134d7ad07889c240a8ed )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910318)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ud.zip size 3549569 crc 6aecfce0 md5 f1ab63a3581e5f0a20fe8ec9d9204534 sha1 8e42eaf9cdc28e4020e04c8bdd905fc70562a3c9 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910228)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ue.zip size 3536086 crc 6d60ffd9 md5 e343202429c477119cc9c7a0b6a28762 sha1 29194f22d7dc2f546fd9ab0100ea2560a1373f9d )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910411)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2uf.zip size 3511429 crc 4b60faef md5 4b1b3555acf34abbda2996973bb82780 sha1 92b1d04559c6cd6cbf84e85ccd7e74a3e5475fef )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910522)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ui.zip size 3541261 crc 7964615f md5 ac335852247a3c7d512449f0a13889d0 sha1 af0d2572611636e7247e02946ef19ce9aefc4e9e )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 911101)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2uk.zip size 3559569 crc f9ad7298 md5 b1aad3354656ca978c890c418f7dd7ea sha1 b23a798678d2d7f9f13867bc06ebdcefea4218a9 )
 )
 
 game (
@@ -45766,126 +34012,119 @@ game (
 	name "Super Football Champ (Ver 2.5O)"
 	year "1995"
 	developer "Taito"
-	rom ( name sfchamp.zip size 5998445 crc 42bee21e md5 dd5b85be4b4f9fb7bb1bef1f55a7fb13 sha1 1fdb189fb13f985c8b9de6018934acb84b5036b3 )
+	rom ( name sfchamp.zip size 6124583 crc 7d784964 md5 e80a2623df9e82e3a87f6cd5fe29a755 sha1 7e9ca2a2b9c09ea4fc9bfc7897d4db4a3f242414 )
 )
 
 game (
 	name "Super Football Champ (Ver 2.4O)"
 	year "1995"
 	developer "Taito"
-	rom ( name sfchamp24o.zip size 5990707 crc 95bd5515 md5 c7f51e5cb9539df77088a9744161e8d7 sha1 443d0ff44f5f5560850ff528a1dc406076299366 )
+	rom ( name sfchamp24o.zip size 6116845 crc 3c0721a3 md5 a77d41b94c3fb8969528b0497071a336 sha1 33b7d7bbd61470d5b07dd43c7aa50cbd28bc5559 )
 )
 
 game (
 	name "Super Football Champ (Ver 2.4J)"
 	year "1995"
 	developer "Taito"
-	rom ( name sfchampj.zip size 5990707 crc b463deed md5 c13c7cb9cdf2c027779af1f29bb6cbe3 sha1 c2ed7c83cdd1ee4331b9495f6d48e2dfc4c6a0e6 )
+	rom ( name sfchampj.zip size 6116845 crc f94abd66 md5 5f005272fabdea84420af692150d7902 sha1 8aa8e6e63d3ad6a9388fb935fc0bca105b70a8ab )
 )
 
 game (
 	name "Street Fighter EX (Euro 961219)"
 	year "1996"
 	developer "Capcom / Arika"
-	rom ( name sfex.zip size 10929182 crc ab4c14ac md5 3e99225c83878bce969a411fcf1c5d4a sha1 343008aae27afb3539c8a7537f721a84ac29341c )
+	rom ( name sfex.zip size 11054731 crc 2cd402d0 md5 64b50fc03adf08479220e092f0a66a10 sha1 dcf763b05dff2e07dd472b3fb3ef153475d9e746 )
 )
 
 game (
 	name "Street Fighter EX 2 (USA 980526)"
 	year "1998"
 	developer "Capcom / Arika"
-	rom ( name sfex2.zip size 16977047 crc ab744afa md5 9207de5428b1e6ecf595e2593dd005ac sha1 ebc6bdbd116bc9b0601718f8efc4b475684688bc )
+	rom ( name sfex2.zip size 17114852 crc 1f7c0c1e md5 e3ba06364a777b816788f5bdd49201fd sha1 b5e27fabbc3af01ee4cf2483561874543cff2e58 )
 )
 
 game (
 	name "Street Fighter EX 2 (Asia 980312)"
 	year "1998"
 	developer "Capcom / Arika"
-	rom ( name sfex2a.zip size 16918713 crc 76033329 md5 7a91b520408028c720f3453203735b04 sha1 4336a5fcd0b93c034a268019de658bb223658183 )
+	rom ( name sfex2a.zip size 17056518 crc a14bd91d md5 beec31ed4b47f37f288ed77e91f623b2 sha1 47f8d549e400e97ca8bbf4f221450c9107d3b41e )
 )
 
 game (
 	name "Street Fighter EX 2 (Hispanic 980312)"
 	year "1998"
 	developer "Capcom / Arika"
-	rom ( name sfex2h.zip size 16918712 crc b756e977 md5 c4baa50c5c52c1afbf93b20f9a0c517a sha1 989ce1c1205e98471da7de314fa5ad4400899a09 )
+	rom ( name sfex2h.zip size 17056517 crc 08ff8b28 md5 1fd9ccfe921341f555cca8f6929ea14c sha1 b804628e203dfd0acd1504692c26de053e9406f6 )
 )
 
 game (
 	name "Street Fighter EX 2 (Japan 980312)"
 	year "1998"
 	developer "Capcom / Arika"
-	rom ( name sfex2j.zip size 16918711 crc c6fc88ee md5 331ebe60ac44204982f728f635bb93e4 sha1 57f2f17b23104a792e6d3845a495f476d053877b )
+	rom ( name sfex2j.zip size 17056516 crc 29bf8cd9 md5 7a5190858c034a03af417ab3ef0d2016 sha1 6e02610bfd39db33f9e9164d6cd9f1353d171a1c )
 )
 
 game (
 	name "Street Fighter EX 2 Plus (USA 990611)"
 	year "1999"
 	developer "Capcom / Arika"
-	rom ( name sfex2p.zip size 24880042 crc e30dee85 md5 f72131b037f5a9315ef750036f0a12df sha1 61721e5603b350eea1e1c047d30a03ded430bc96 )
+	rom ( name sfex2p.zip size 25017847 crc af22c00d md5 983f5e00ce2382c7b3989d2ffa70c537 sha1 1e2e3f118be723aea9599c7679570a9ae583ca6c )
 )
 
 game (
 	name "Street Fighter EX 2 Plus (Asia 990611)"
 	year "1999"
 	developer "Capcom / Arika"
-	rom ( name sfex2pa.zip size 24880042 crc 9c68b88e md5 eb1ac728cfdbfc23d0207c9f1514c1cb sha1 c56befc96cf00c5be362b14b818c6cd6fdaa3c47 )
+	rom ( name sfex2pa.zip size 25017847 crc 6779633d md5 c80f9dd1d3c43358751811bd997557d2 sha1 56696a3a0fbe43e8ec53ab3d1961875c7ba03387 )
 )
 
 game (
 	name "Street Fighter EX 2 Plus (Japan 990611)"
 	year "1999"
 	developer "Capcom / Arika"
-	rom ( name sfex2pj.zip size 24880042 crc 794a276b md5 016fdd32d40ce0021c7b03d407fc8cd5 sha1 ddfbd3bd2fcc46518aa9f1ab2fc2c81953a3e371 )
+	rom ( name sfex2pj.zip size 25017847 crc c463f11c md5 f702921e6bf0744236f3e514da94cc3d sha1 100549dc789ed7c8e832c8033a8b81f090c71a93 )
 )
 
 game (
 	name "Street Fighter EX (Asia 961219)"
 	year "1996"
 	developer "Capcom / Arika"
-	rom ( name sfexa.zip size 10929174 crc 5041fc37 md5 febaaa0184285334444d5a22be99c705 sha1 533276ac3efe291076f5cb5cb8dff29d2d56698a )
+	rom ( name sfexa.zip size 11054723 crc d88b7302 md5 cb5ccac9fa18f5f31c8f3af7e36e01cb sha1 976994972987464cd5af72138dfeb5216837e3db )
 )
 
 game (
 	name "Street Fighter EX (Japan 961130)"
 	year "1996"
 	developer "Capcom / Arika"
-	rom ( name sfexj.zip size 10929093 crc c18cfbf8 md5 6cdcdf04bc959eea7233f5ff9474bcef sha1 5925e43c5b9076ab6175cc65acbfc02c084eae68 )
+	rom ( name sfexj.zip size 11054642 crc 3c717bdd md5 022ac22dd0fc34c6e0abfb24cb7b8962 sha1 e412fa4a73b97a8a536f003a07ae020de4fea0eb )
 )
 
 game (
 	name "Street Fighter EX Plus (USA 970407)"
 	year "1997"
 	developer "Capcom / Arika"
-	rom ( name sfexp.zip size 11138895 crc 0a823e05 md5 6ca5b15a47f351ef1ca89ba6d565d29e sha1 a1e27903673e98c18316838654cca66251b443e6 )
+	rom ( name sfexp.zip size 11264444 crc 67365173 md5 be28acfb33dc8be8ba5e5ef608ab87af sha1 41519c56f62abed706199860788ed6ec56437159 )
 )
 
 game (
 	name "Street Fighter EX Plus (Japan 970311)"
 	year "1997"
 	developer "Capcom / Arika"
-	rom ( name sfexpj.zip size 11048461 crc 66473331 md5 d4ed7459033152d06408466d2b307d3b sha1 131cbcb606506a9c490d6b4375b264859dc34a88 )
+	rom ( name sfexpj.zip size 11174010 crc 5fa59257 md5 2138557f63cce268627776724d70097b sha1 432418955aa20126affb7891c5e93670e36ea0ca )
 )
 
 game (
 	name "Street Fighter EX Plus (USA 970311)"
 	year "1997"
 	developer "Capcom / Arika"
-	rom ( name sfexpu1.zip size 11048463 crc 23b52fdb md5 4a73a487353d823035d8ff7761f65c6b sha1 379fe105cde7f9afeba39affc4349910bc3b3480 )
+	rom ( name sfexpu1.zip size 11174012 crc e4188d12 md5 6e15f37e30374b671a0330723dc9e561 sha1 bbfce7aa4684291977e2cabc78b9e5315d771597 )
 )
 
 game (
 	name "Street Fighter EX (USA 961219)"
 	year "1996"
 	developer "Capcom / Arika"
-	rom ( name sfexu.zip size 10929176 crc 465434e4 md5 8adebe7037b3449a0c05e60ed881d25b sha1 ce071aa10f49ee44d3da16246d3f498da541bbb2 )
-)
-
-game (
-	name "Sonic The Fighters"
-	year "1996"
-	developer "Sega"
-	rom ( name sfight.zip size 17698526 crc 6d70ebdc md5 5102f66a7259d092889150b86e7eaf53 sha1 b2984f98967e1c5b21c78c47a44bc88baa002e22 )
+	rom ( name sfexu.zip size 11054725 crc 84f0b44e md5 570dcb1387b86714dbde3d8723baa33a sha1 80a11d5bec65214df741f5bbcb8ef89a7d8c4138 )
 )
 
 game (
@@ -45959,27 +34198,6 @@ game (
 )
 
 game (
-	name "Sport Fishing 2 (UET 951106 V1.10e)"
-	year "1995"
-	developer "Sega"
-	rom ( name sfish2.zip size 517069 crc f1066706 md5 5e51ef71cc3bb8a454ee53436edef67e sha1 260b27c64de34afb3660d8189a02d92fb32c5bdf )
-)
-
-game (
-	name "Sport Fishing 2 (J 951201 V1.100)"
-	year "1995"
-	developer "Sega"
-	rom ( name sfish2j.zip size 502304 crc d9c98fda md5 eeda0f5c601b168f0fc185d8cce4544d sha1 e2e90a1193880c0a96970911f2e831fa39937c1b )
-)
-
-game (
-	name "Street Fighter (Japan) (protected)"
-	year "1987"
-	developer "Capcom"
-	rom ( name sfj.zip size 1152796 crc 649a32b3 md5 eba7a30105325d163b17468c50b308f9 sha1 24f6d2e26b73fa5ed63e4ad81be60b3404259a82 )
-)
-
-game (
 	name "Super Free Kick (set 1)"
 	year "1988"
 	developer "Haesung/HJ Corp"
@@ -45990,20 +34208,6 @@ game (
 	name "Super Free Kick (set 2)"
 	developer "Haesung"
 	rom ( name sfkicka.zip size 87355 crc 61e43e47 md5 a141e34b083bab65b4d1dfe5f01a14f7 sha1 c96881eb8b902b78e53a8437dd69f8f3915bb144 )
-)
-
-game (
-	name "Straight Flush"
-	year "1979"
-	developer "Taito"
-	rom ( name sflush.zip size 8130 crc e7e06777 md5 e274c8ce40a72885179beaff02f9e596 sha1 ba2523baef74bf5bf0656bd638a7fbbba66962c3 )
-)
-
-game (
-	name "Street Football"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name sfootbal.zip size 47005 crc c11807d3 md5 661d9363da39bfad6cd619f756d728e8 sha1 1004c2beb15ff2072b2dc72959fe82fcf96acbb7 )
 )
 
 game (
@@ -46133,13 +34337,6 @@ game (
 )
 
 game (
-	name "San Francisco Rush: The Rock"
-	year "1996"
-	developer "Atari Games"
-	rom ( name sfrushrk.zip size 7586027 crc 9aacdca8 md5 7616a58ec6a8a63fe24c9c9336888d09 sha1 c6618711dd8b812ebff1281cb8345389755b7de0 )
-)
-
-game (
 	name "Street Fighter: The Movie (v1.12)"
 	year "1995"
 	developer "Capcom / Incredible Technologies"
@@ -46172,13 +34369,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sfu.zip size 1153920 crc 15e45dde md5 c73a8bca6aff13a576f354ba74891a40 sha1 a57c5f97cd85da1beecca65aa7a92692673d699f )
-)
-
-game (
-	name "Street Fighter (US, set 2) (protected)"
-	year "1987"
-	developer "Capcom"
-	rom ( name sfua.zip size 1152791 crc 0812c823 md5 f60641ec395d951414818443ac1df299 sha1 e723b915ab78497ecd9133ea1a7b478835c1258f )
 )
 
 game (
@@ -46308,13 +34498,6 @@ game (
 )
 
 game (
-	name "Street Fighter Zero 3 Upper (GDL-0002)"
-	year "2001"
-	developer "Capcom"
-	rom ( name sfz3ugd.zip size 1195 crc 2017472c md5 16d1e9f2d516fe99e6de0ad421bbf54e sha1 9e2afce9e34fd37cd02b48167da6d54f0ae2bcea )
-)
-
-game (
 	name "Street Fighter Zero (Asia 950627)"
 	year "1995"
 	developer "Capcom"
@@ -46406,13 +34589,6 @@ game (
 )
 
 game (
-	name "Super Masters Golf (World?, Floppy Based, FD1094 317-0058-05d?)"
-	year "1989"
-	developer "Sega"
-	rom ( name sgmast.zip size 2803429 crc 8b5c87be md5 06a05e88cfe755e96286b834789dcea9 sha1 06bac275f0c4caf343c5d80e2a6e7a19a6d9d41f )
-)
-
-game (
 	name "Jumbo Ozaki Super Masters Golf (World, Floppy Based, FD1094 317-0058-05c)"
 	year "1989"
 	developer "Sega"
@@ -46431,20 +34607,6 @@ game (
 	year "1996"
 	developer "New Impeuropex Corp."
 	rom ( name sgsafari.zip size 345500 crc c81205c1 md5 396142505e4e6bc90694742e16c1fb6d sha1 3d182f8c7e4eea2beca410c16945e9f44f8753f2 )
-)
-
-game (
-	name "Super GT 24h"
-	year "1996"
-	developer "Jaleco"
-	rom ( name sgt24h.zip size 10507378 crc cbffb27d md5 2579fc57c370b80f53296d43498cf8de sha1 71dc9b39bb4d67656682a367b59bf613af8a0a3d )
-)
-
-game (
-	name "Sega Tetris"
-	year "1999"
-	developer "Sega"
-	rom ( name sgtetris.zip size 26064618 crc 780ce393 md5 a8e73034c9d14c1061b52c7e5b5150e4 sha1 3ca2d584ea83987f44a00c44511f968e07fae98a )
 )
 
 game (
@@ -46473,20 +34635,6 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name sgunnerj.zip size 2063097 crc 4f50c0be md5 2cd19116ce6b4f669277facdf72b0fc4 sha1 9462f5058848cd0c7a36c1ae41e0956f8ea0cd27 )
-)
-
-game (
-	name "Shackled (US)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name shackled.zip size 277237 crc 45a28ff0 md5 9bd250cdae5b0a40bc4653c34e108e5b sha1 1c34a5e1383cb3fa9df92b23d2d3089d8aaba156 )
-)
-
-game (
-	name "Shadow Fighters"
-	year "1993"
-	developer "Dutech Inc."
-	rom ( name shadfgtr.zip size 981650 crc a6be8a6f md5 2990638a317d7a000f10fdf0bd3bb9cf sha1 b33ba9c7aa5bd55c7037eb20af775c724fceb308 )
 )
 
 game (
@@ -46553,6 +34701,13 @@ game (
 )
 
 game (
+	name "Shanghai Shoryu Sairin (V2.03J)"
+	year "2000"
+	developer "Warashi"
+	rom ( name shanghss.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Shanghai Kid"
 	year "1985"
 	developer "Taiyo (Data East license)"
@@ -46564,13 +34719,6 @@ game (
 	year "1987"
 	developer "Sega"
 	rom ( name shangon.zip size 691577 crc 3e999ebf md5 ebf7ae8f0dc55259e7609d3fc05578ab sha1 178b7b1a99969e001576379767eaa36a207b2a2b )
-)
-
-game (
-	name "Super Hang-On (mini ride-on?, FD1089B 317-0034)"
-	year "1987"
-	developer "Sega"
-	rom ( name shangon1.zip size 774265 crc bfe15bd8 md5 3120ab370ff07c5323b96b89fa2a2609 sha1 7fba58d9eadb28a9d9d95f9f095695a81cc34ae7 )
 )
 
 game (
@@ -46609,28 +34757,28 @@ game (
 )
 
 game (
-	name "Dengen Tenshi Taisen Janshi Shangri-la (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Marvelous Ent."
-	rom ( name shangril.zip size 94020913 crc 461e4185 md5 a9d4e74f865640a80590f9c598bbcaf1 sha1 ae7a220b9e5078bcd6553dedf17f91b4ad99bad7 )
+	name "Shanghai Sangokuhai Tougi (Ver 2.01J)"
+	year "2002"
+	developer "Warashi / Sunsoft / Taito"
+	rom ( name shangtou.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
 	name "Shanghai - The Great Wall / Shanghai Triple Threat (JUE 950623 V1.005)"
 	year "1995"
 	developer "Sunsoft / Activision"
-	rom ( name shanhigw.zip size 3003171 crc 38850a69 md5 1ad26295519599f95c9b640d591a6539 sha1 25d39924f4ad06c9ea94aa5a6351e85028945113 )
+	rom ( name shanhigw.zip size 5702392 crc 5a38888c md5 4a4489005eb69dc1aa7c3a90b2911d3e sha1 99beabbeecc33c365c2721d6064352198e183a29 )
 )
 
 game (
-	name "Shao-lin's Road (bootleg)"
+	name "Shao-lin's Road (set 2)"
 	year "1985"
-	developer "bootleg"
+	developer "Konami"
 	rom ( name shaolinb.zip size 51008 crc 6b46f99e md5 49f715143a6defad5bb2048530125af0 sha1 0836177ebb8a69f19ff01f4c8da942108ae5a9fc )
 )
 
 game (
-	name "Shao-lin's Road"
+	name "Shao-lin's Road (set 1)"
 	year "1985"
 	developer "Konami"
 	rom ( name shaolins.zip size 51068 crc 2881318e md5 d69aa66716ee6f4f10d1344bbf538a9a sha1 23254b234a03811fe93aa3c3972998a890c07ca8 )
@@ -46662,20 +34810,6 @@ game (
 	year "1995"
 	developer "American Alpha"
 	rom ( name sharkpye.zip size 195529 crc d62db879 md5 095de563323e37d600c84bec4658409b sha1 c7ccd22aca3c960c9996fb850c4312e1ca255355 )
-)
-
-game (
-	name "Space Harrier (Rev A, 8751 315-5163A)"
-	year "1985"
-	developer "Sega"
-	rom ( name sharrier.zip size 755119 crc db78b1c2 md5 3ad5238a51d7455e4d84f475bec44f84 sha1 45247b44f4fb6d6c1e8f33cf8024ad0a564f0e79 )
-)
-
-game (
-	name "Space Harrier (8751 315-5163)"
-	year "1985"
-	developer "Sega"
-	rom ( name sharrier1.zip size 754749 crc 32151dba md5 3aac6ee01ceb1d951dd90c9538341a8c sha1 7545b24d871a4516f53037dbdf0194e6b0b190d6 )
 )
 
 game (
@@ -46717,14 +34851,14 @@ game (
 	name "Shienryu (JUET 961226 V1.000)"
 	year "1997"
 	developer "Warashi"
-	rom ( name shienryu.zip size 5083989 crc 692989eb md5 81b44f8265feb1a3572877182c3d7187 sha1 0ce84f21cbfe5be15cc2aa2e3b6c510541d96031 )
+	rom ( name shienryu.zip size 7783210 crc bd82d1e8 md5 010fa0dacef7af7c75709f90fbf139d1 sha1 885d440f7365eeb26dc4b5adcd3e9ce4daaeb663 )
 )
 
 game (
-	name "Shikigami No Shiro II / The Castle of Shikigami II (GDL-0021)"
-	year "2003"
-	developer "Alfa System"
-	rom ( name shikgam2.zip size 1192 crc 76aa60b5 md5 8dce676a8699882dc380bb859de1f9e5 sha1 9c94efec2035966718a025265952801f05915536 )
+	name "Shikigami no Shiro (V2.03J)"
+	year "2001"
+	developer "Alfa System / Taito"
+	rom ( name shikigam.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -46798,20 +34932,6 @@ game (
 )
 
 game (
-	name "Shinobi (Beta bootleg)"
-	year "1987"
-	developer "bootleg (Beta)"
-	rom ( name shinoblb.zip size 487396 crc 9af08032 md5 fc45bfa522cc912780f3a13dfb72a8c2 sha1 e0447657c738cf4d2a0585f60b521cb0a82db900 )
-)
-
-game (
-	name "Shinobi (Datsu bootleg)"
-	year "1987"
-	developer "bootleg (Datsu)"
-	rom ( name shinobld.zip size 477255 crc 270c6bba md5 c80f3c7e0b80f5393360dced741869ef sha1 d226ec97dd234cc3f1ef933ff11804784a5de5ea )
-)
-
-game (
 	name "Shinobi (Star bootleg, System 16A)"
 	year "1987"
 	developer "bootleg (Star)"
@@ -46829,7 +34949,7 @@ game (
 	name "Strider Hiryu 2 (Japan 991213)"
 	year "1999"
 	developer "Capcom"
-	rom ( name shiryu2.zip size 21086446 crc 503df50d md5 fe34e5135f3567c0e29efbd67550688e sha1 932c3feabb5bdb33c66847c093e72dff427408ba )
+	rom ( name shiryu2.zip size 21224251 crc 86558def md5 f1d3cdf79bd04bda34fb7a13b0c13b86 sha1 19261a50dcab0350220c9e270aed58a8fb93366f )
 )
 
 game (
@@ -46850,7 +34970,7 @@ game (
 	name "Shanghai Matekibuyuu"
 	year "1998"
 	developer "Sunsoft / Activision"
-	rom ( name shngmtkb.zip size 12754925 crc 12b2ab0d md5 f2f97e7499d020d30c2ed1a809f33615 sha1 52a7038d3665d87ccaa6cc3ad7fb223b5fefbe32 )
+	rom ( name shngmtkb.zip size 12893377 crc 70a6e4ae md5 a0b6244564a83ef89f4ffe466df1cc81 sha1 297c32d36d984a472f6b1abd987972d0a8a35958 )
 )
 
 game (
@@ -46864,21 +34984,21 @@ game (
 	name "Shock Troopers - 2nd Squad"
 	year "1998"
 	developer "Saurus"
-	rom ( name shocktr2.zip size 28712910 crc 5cd46846 md5 8f1ec4c63b8022c4fe8755f1e150a424 sha1 a482d5a67c559e50a93d12c6e6fa0d6796c71685 )
+	rom ( name shocktr2.zip size 30059597 crc eed0257e md5 dad9b93e1a9133741cb8565d7644101c sha1 3dccd5ec8a5ebeb316246e18b6786f445db97bec )
 )
 
 game (
 	name "Shock Troopers (set 2)"
 	year "1997"
 	developer "Saurus"
-	rom ( name shocktra.zip size 19672781 crc 421371df md5 4181fce4f555f4e4746162c427d251f9 sha1 e505c9a6192bb785508b32b939e842aada5686c2 )
+	rom ( name shocktra.zip size 21019468 crc ff3b70e6 md5 fed114feef4a362a788541bdc3cabc22 sha1 960f4a0b9d1d6fee87fc736b43d2e443df7ce6b2 )
 )
 
 game (
 	name "Shock Troopers (set 1)"
 	year "1997"
 	developer "Saurus"
-	rom ( name shocktro.zip size 19672838 crc e3eb508e md5 c1f860858e9dc8cb353431fbbfb70211 sha1 d4e6c1164279bdc8b9279b5f8d0417e60754712b )
+	rom ( name shocktro.zip size 21019525 crc fcf561a9 md5 7dc37da313117c9cf4572326bc180f14 sha1 9ae77bce578d73e845c5d0e3d1a590e5d96dfb63 )
 )
 
 game (
@@ -46917,20 +35037,6 @@ game (
 )
 
 game (
-	name "Shooting Gallery"
-	year "1984"
-	developer "Seatongrove Ltd (Zaccaria license)"
-	rom ( name shootgal.zip size 18531 crc 16b5a427 md5 0af2f4fa102d9def57b9251fa318c84e sha1 7631ec033169132d0bfab8d7687a464289e394b5 )
-)
-
-game (
-	name "Shootout Pool"
-	year "2001"
-	developer "Sega"
-	rom ( name shootopl.zip size 8109765 crc 6552cef5 md5 302aefbec4852cce10dccde38c1ba168 sha1 5fe22cfc464bfc02a5903316f32fb61007d44852 )
-)
-
-game (
 	name "Shoot Out (US)"
 	year "1985"
 	developer "Data East USA"
@@ -46949,13 +35055,6 @@ game (
 	year "1985"
 	developer "Data East Corporation"
 	rom ( name shootoutj.zip size 76592 crc 99b90b38 md5 840eabf905a8dd4c8d06622504f29de5 sha1 22ef1e08f0e183e191187f54f796aded7c613313 )
-)
-
-game (
-	name "Shootout Pool (JPN, USA, KOR, AUS) / Shootout Pool Prize (EXP)"
-	year "2001"
-	developer "Sega"
-	rom ( name shootpl.zip size 6761970 crc 64c53783 md5 c2856bced8fded2f61586173dc8ee699 sha1 377767930bb6746b8c2c9007324dfa187230b6ac )
 )
 
 game (
@@ -46991,33 +35090,6 @@ game (
 	year "2000"
 	developer "Astro Corp."
 	rom ( name showhand.zip size 625050 crc dd38aa67 md5 7ef3866adb91b90400a947d92a7bb64d sha1 77f71905774a9a8bfb8d08972b32927972a028e8 )
-)
-
-game (
-	name "Sea Hunter Penguin"
-	year "1995"
-	developer "WSAC Systems?"
-	rom ( name shpeng.zip size 340265 crc 93e590c0 md5 189a7d8d6f0f020c55f096ab4b409f4c sha1 f48f784824910c58e36e37c0e111086a432fc0e5 )
-)
-
-game (
-	name "Shrike Avenger (prototype)"
-	developer "Bally/Sente"
-	rom ( name shrike.zip size 92846 crc c4ae135a md5 d8aa70cc6abdc529741cfa4533d6ec61 sha1 14ec599e7318f0c10cff76d158a2826fb2b924a0 )
-)
-
-game (
-	name "Shooting Master (8751 315-5159)"
-	year "1985"
-	developer "Sega"
-	rom ( name shtngmst.zip size 167299 crc 4ae2b6b6 md5 bf05349f3fb91043668fba9e75dd2fc1 sha1 ee4a2f71548ac1112e415140d6f7a6b15bbc4eec )
-)
-
-game (
-	name "Shooting Master (EVG, 8751 315-5159a)"
-	year "1985"
-	developer "Sega / EVG"
-	rom ( name shtngmste.zip size 168288 crc eab105ca md5 51dce6f4e1b69bff1ba4125605ee514d sha1 934d7c6cacdc0c787b4b381ce2aa177520a92d26 )
 )
 
 game (
@@ -47084,13 +35156,6 @@ game (
 )
 
 game (
-	name "Super Invader Attack"
-	year "1978"
-	developer "Zelco / Zaccaria"
-	rom ( name sia2650.zip size 5990 crc 597f8c91 md5 da58ca08603f2419e783fea0843193e0 sha1 bf15e3b25874e22dc3efaf8130213ad08705385b )
-)
-
-game (
 	name "Sichuan II (hack, set 1)"
 	year "1989"
 	developer "hack"
@@ -47154,13 +35219,6 @@ game (
 )
 
 game (
-	name "Side Pocket (World)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name sidepckt.zip size 89366 crc 38aa9b23 md5 81db4eb6bf15fe908e58d621e69bfc4a sha1 d6f6fe1dc698b311285a644082fd6e4c0dffb065 )
-)
-
-game (
 	name "Side Pocket (bootleg)"
 	year "1986"
 	developer "bootleg"
@@ -47168,23 +35226,10 @@ game (
 )
 
 game (
-	name "Side Pocket (Japan)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name sidepcktj.zip size 77606 crc c35bae25 md5 8e593f1de56d8065b952ab486f5072a3 sha1 4806b2615a0b36b825ba3c0e1c45d2bb33249837 )
-)
-
-game (
 	name "Side Track"
 	year "1979"
 	developer "Exidy"
 	rom ( name sidetrac.zip size 5513 crc 8eb05ec9 md5 57fb87948a02fea679ab2caba525ebc3 sha1 5d6c27a9ae485586d0f6995d531fc9b3d7a0f358 )
-)
-
-game (
-	name "Sidewinder"
-	developer "ACE"
-	rom ( name sidewndr.zip size 9853 crc 7237a0ae md5 6b5994c9024c24d8a5c092c6d930f5b8 sha1 2b00ad1010d2498ff167f21ada1bf67741e4115b )
 )
 
 game (
@@ -47254,7 +35299,7 @@ game (
 	name "Simpsons Bowling (GQ829 UAA)"
 	year "2000"
 	developer "Konami"
-	rom ( name simpbowl.zip size 173 crc 956fe29f md5 4f767d03b88207cc0327d317c7bfa3e6 sha1 3a25f970ee14275b9bda1409acf6c59404a3f5e1 )
+	rom ( name simpbowl.zip size 81542 crc f13063db md5 63bce7d283e0f9f900f074a049b9bb30 sha1 10c42e51ecf3cae491907f86a30c14d31339c256 )
 )
 
 game (
@@ -47382,59 +35427,10 @@ game (
 )
 
 game (
-	name "Sukeban Jansi Ryuko (set 2, System 16B, FD1089B 317-5021)"
-	year "1988"
-	developer "White Board"
-	rom ( name sjryuko.zip size 383635 crc 7ee5f1ad md5 425d150e3b3d0a6da11d0046c5605cb8 sha1 39f19483527ae8431717409c1193f99d2423c339 )
-)
-
-game (
-	name "Sukeban Jansi Ryuko (set 1, System 16A, FD1089B 317-5021)"
-	year "1987"
-	developer "White Board"
-	rom ( name sjryuko1.zip size 360577 crc c5642502 md5 97fb6dcececbb63bf38989739f9d4642 sha1 877b2ec01840fb166a5560c641a36ece5f80276a )
-)
-
-game (
 	name "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)"
 	year "1988"
 	developer "hack"
 	rom ( name skatekds.zip size 37242 crc 9eee7efb md5 6002465041f5fc1774ad0d3d9232bc12 sha1 9285f171c57602b12a328482f3cebf5c5cd5a855 )
-)
-
-game (
-	name "Skat TV"
-	year "1994"
-	developer "ADP"
-	rom ( name skattv.zip size 137306 crc 9448e1fa md5 c83b5ae9d2cf37f8c7d1ad38f2f372b2 sha1 9148dfac3a6b205e722fd078a3899d6a32566b95 )
-)
-
-game (
-	name "Skat TV (version TS3)"
-	year "1995"
-	developer "ADP"
-	rom ( name skattva.zip size 137199 crc d6dc5c57 md5 edad2c55d4bf158ef3b87816aa269ab5 sha1 edc06a91a3cf341a876cd5db67e2bdbcb9aa4071 )
-)
-
-game (
-	name "Skeet Shot"
-	year "1991"
-	developer "Dynamo"
-	rom ( name skeetsht.zip size 258354 crc 4b061c35 md5 23e092e8972044acf3924e08a93e0a65 sha1 93e0669bb83b0b7c4665e7da7a286fdea02b5598 )
-)
-
-game (
-	name "Skelagon"
-	year "1983"
-	developer "Nichibutsu USA"
-	rom ( name skelagon.zip size 41096 crc a64b3bfc md5 037fdda4e62180d22871b17b1623fce9 sha1 dd21ed679c889fd83b6b9aee952494ef1b1e2b99 )
-)
-
-game (
-	name "Ski Champ"
-	year "1998"
-	developer "Sega"
-	rom ( name skichamp.zip size 62065774 crc abb7da9e md5 56e9b8e6d467483191f1c9f9eb077d5c sha1 786a0ae9aa7de1712db709dc3827c09bf2a1e687 )
 )
 
 game (
@@ -47452,38 +35448,10 @@ game (
 )
 
 game (
-	name "Skill Trek (v1.1)"
-	year "1990"
-	developer "Barcrest"
-	rom ( name skiltrek.zip size 540798 crc 0659b47a md5 7e2dc3449076fe7a1dd331c59b105d02 sha1 97510dee4616adecbc33316d090b0c2535b35a1c )
-)
-
-game (
 	name "Skimaxx"
 	year "1996"
 	developer "Kyle Hodgetts / ICE"
 	rom ( name skimaxx.zip size 3208270 crc ea532447 md5 ab34b55b17aac77ece11589085c3d624 sha1 48733de55503ddf0ae78fdbfbe6880adf87f806d )
-)
-
-game (
-	name "The Irem Skins Game (US set 1)"
-	year "1992"
-	developer "Irem America"
-	rom ( name skingame.zip size 1811540 crc 285897c1 md5 4e494d8acec99ab3d15e72b426e0f7ed sha1 193f0f76d8762835b3365f88117d80075f2c8ea2 )
-)
-
-game (
-	name "The Irem Skins Game (US set 2)"
-	year "1992"
-	developer "Irem America"
-	rom ( name skingame2.zip size 1811433 crc b6b4b269 md5 a5300994022ee8aa4a1c0f4d43eacc58 sha1 9c89fe8c1b7335ac1ae707a6d8deab6fca34dc64 )
-)
-
-game (
-	name "Sega Ski Super G"
-	year "1996"
-	developer "Sega"
-	rom ( name skisuprg.zip size 17510173 crc c6ccea7a md5 b1d6181f1b452456e969789047279ec0 sha1 1e84d1df1e40126f868bc4db1e1ae651654063a8 )
 )
 
 game (
@@ -47585,13 +35553,6 @@ game (
 )
 
 game (
-	name "Sky Chuter"
-	year "1980"
-	developer "Irem"
-	rom ( name skychut.zip size 8246 crc a35dc6cc md5 ca48fe97c53334a1cb8b0c5d2f643ec6 sha1 71f0b130ae87ad686e9283031bf81e5f4de0ae5c )
-)
-
-game (
 	name "Sky Diver"
 	year "1978"
 	developer "Atari"
@@ -47690,13 +35651,6 @@ game (
 )
 
 game (
-	name "Sky Robo"
-	year "1989"
-	developer "Nichibutsu"
-	rom ( name skyrobo.zip size 484718 crc c5afe4c9 md5 31f9115a4be4700f83c763ca185e1e85 sha1 219ba11bbc0b1ba8ae26f31148850b4ed74551e8 )
-)
-
-game (
 	name "Sky Shark (US)"
 	year "1987"
 	developer "Toaplan / Taito America Corporation (Romstar license)"
@@ -47725,13 +35679,6 @@ game (
 )
 
 game (
-	name "Sky Target"
-	year "1995"
-	developer "Sega"
-	rom ( name skytargt.zip size 22544937 crc 7bdd1c30 md5 25acb1bd2a53d0e778b6b5f756b16f3e sha1 915c442bde120bd9f5030dde7a8a2a1df8dfb8d5 )
-)
-
-game (
 	name "Sky Wolf (set 1)"
 	year "1987"
 	developer "bootleg"
@@ -47756,21 +35703,7 @@ game (
 	name "Slam Dunk 2 (ver JAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name slamdnk2.zip size 18468929 crc e25f63f6 md5 cf6f4a42e83c72eebf8a8cb57acc5d56 sha1 c87e671d124b1fe52172aa48851d6f8e7c6fe623 )
-)
-
-game (
-	name "Saturday Night Slam Masters (World 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name slammast.zip size 6588432 crc eaac25c5 md5 2469cc51ea42952fd4338b38cc2028cf sha1 19d6bbeaf734d6823dc40759a45c49c9e1287bd3 )
-)
-
-game (
-	name "Saturday Night Slam Masters (USA 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name slammastu.zip size 6588677 crc a5bb0db0 md5 a2a12d836a77f4368ce4d40cfa315b30 sha1 78a4e743d41858f959ab888c6e2c3921658d247e )
+	rom ( name slamdnk2.zip size 18477619 crc 14c172c8 md5 a0adb403479315278f0a72e3713c91fd sha1 d63757b03a13699f9c0e9fcd6f4c6ccc978a986a )
 )
 
 game (
@@ -47778,13 +35711,6 @@ game (
 	year "1986"
 	developer "Toaplan / Taito"
 	rom ( name slapfigh.zip size 152320 crc 5ab1af3a md5 be0363b393d42b87d18de87e9391602e sha1 5d4ac452ccd35aecb40d5ff14de6ba08a71525a1 )
-)
-
-game (
-	name "Slap Fight (Japan set 2)"
-	year "1986"
-	developer "Toaplan / Taito"
-	rom ( name slapfigha.zip size 151331 crc 1f7dca3d md5 b671ef05d7839fef4dea6474b2dd4183 sha1 6edfbb319ede63ebbe9bdf9942d7bebeb437b9b0 )
 )
 
 game (
@@ -47813,20 +35739,6 @@ game (
 	year "1994"
 	developer "Taito Corporation"
 	rom ( name slapshot.zip size 2003048 crc c057d975 md5 a74b79e6f56a15c497a678e58ba362f4 sha1 c9c50af42a70434847898e9982cf48ba58cc7941 )
-)
-
-game (
-	name "Slashout (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name slasho.zip size 108744673 crc da595d7f md5 7546dc42ad62891b619ee1a9dbdefdb1 sha1 de9960a2635b26ba74bc2d16464182b7c9572d66 )
-)
-
-game (
-	name "Slashout (GDS-0004)"
-	year "2000"
-	developer "Sega"
-	rom ( name slashout.zip size 1195 crc a4171d27 md5 3c3d3468469b81af140b4450186a8050 sha1 daa1a2778dbb729ae11e130359a5ac130e39261f )
 )
 
 game (
@@ -47879,13 +35791,6 @@ game (
 )
 
 game (
-	name "Sliver"
-	year "1996"
-	developer "Hollow Corp"
-	rom ( name sliver.zip size 15501022 crc bfedd29a md5 b42445d774b2363ce4489831904bd30d sha1 0a7166de4c540469039e4c8212620faa6624acca )
-)
-
-game (
 	name "Slam Dunk (ver JAA 1993 10.8)"
 	year "1993"
 	developer "Konami"
@@ -47907,31 +35812,10 @@ game (
 )
 
 game (
-	name "Slot Carnival"
-	year "1985"
-	developer "Wing Co., Ltd."
-	rom ( name slotcarn.zip size 32675 crc 28110273 md5 fcefc2d4c7dde231c491389901472a44 sha1 4437976d79bb6b707c89a6845dc3ece2365823b4 )
-)
-
-game (
 	name "Slots (Dutch, Game Card 95-750-368)"
 	year "1995"
 	developer "BFM/ELAM"
 	rom ( name slotsnl.zip size 82191 crc f12224e9 md5 f654483668351bf2f7b6a69fb6723522 sha1 972abc091f31a02dffa3212ec38f947900bfe0e6 )
-)
-
-game (
-	name "Mahjong Shuang Long Qiang Zhu 2"
-	year "1998"
-	developer "IGS"
-	rom ( name slqz2.zip size 1308969 crc 61a93dd0 md5 5e1851605d5574d5bdaf146d1e7bd079 sha1 abc60a4903b455ad9a5c1c3e4c7cb568b9694b2c )
-)
-
-game (
-	name "Solar Assault (ver UAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name slrasslt.zip size 10560028 crc 769a6f45 md5 0fe8d328224d3c5a46a3e51621491600 sha1 d581aa46f936f8a863075075dc20d50e99ed76ae )
 )
 
 game (
@@ -47967,13 +35851,6 @@ game (
 	year "1989"
 	developer "Data East USA"
 	rom ( name slyspy2.zip size 561978 crc dc4332c6 md5 491d205c7a7ac5f80e024d64ff007938 sha1 1b6ba3fa1969b3bb8f8eb88834f6bd2e7aafd13f )
-)
-
-game (
-	name "Sega Marine Fishing"
-	year "2000"
-	developer "Sega"
-	rom ( name smarinef.zip size 28015943 crc 3c86d490 md5 12462705bceada0b7c23c094b7b22763 sha1 1febc101c3c3261cfeaf8daac9419167438da1ee )
 )
 
 game (
@@ -48037,13 +35914,6 @@ game (
 	year "1984"
 	developer "Nintendo"
 	rom ( name smgolf.zip size 31977 crc 7525673e md5 511dd9d50573a6c2e0672b420eef0952 sha1 da7890ebaadaf8f265208ce2643c16b39a2463b5 )
-)
-
-game (
-	name "Vs. Stroke _ Match Golf (Men Version, set 2)"
-	year "1985"
-	developer "Nintendo"
-	rom ( name smgolfb.zip size 28245 crc eb068c55 md5 bf582bf40fdcc3b7fc6413f86219a2f3 sha1 b3ea5e11650415ea2a6ff83e5c3aff6e30aca57e )
 )
 
 game (
@@ -48117,20 +35987,6 @@ game (
 )
 
 game (
-	name "Super Major League (U 960108 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name smleague.zip size 8680479 crc 1ec683cf md5 dadde40488d9791b3e766a3998011e1b sha1 f537492ae875852e453d2ee2e0fc10f823aef7e3 )
-)
-
-game (
-	name "Super Major League '99"
-	year "1999"
-	developer "Sega"
-	rom ( name smlg99.zip size 105684056 crc d0c9781a md5 24886ce6a46a07b40f9a45cdd1415f21 sha1 1336a8537cb1e815a569ad4d975fc71202281d26 )
-)
-
-game (
 	name "Super Moon Cresta"
 	developer "Nichibutsu (Gremlin license)"
 	rom ( name smooncrs.zip size 16392 crc 0c08a4ed md5 56c1e6f74baa002a725650af2b950986 sha1 851bbf0a55b9a90bdb2802036315f1ffd94d5f9a )
@@ -48151,27 +36007,6 @@ game (
 )
 
 game (
-	name "HI-LO Double Up Joker Poker"
-	year "1983"
-	developer "SMS Manufacturing Corp."
-	rom ( name smshilo.zip size 5524 crc abeea288 md5 f7de86aed3b9ee2399b740754c67c4b3 sha1 4ac043cbd966608aae71d4d7724a308994840f04 )
-)
-
-game (
-	name "Snake Pit"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name snakepit.zip size 47841 crc c80ebdf2 md5 e417dfa224b1616022e24a8aa01a242d sha1 d42a855cdd14396e58a6c80197b7942557140b9c )
-)
-
-game (
-	name "Snacks'n Jaxson"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name snakjack.zip size 59038 crc c5beec9a md5 59d0aa1101542d25ba5f2a8c51f6363e sha1 9ddee21b0c7b433db72b035a6729494e229ae0bd )
-)
-
-game (
 	name "Snap Jack"
 	year "1982"
 	developer "Universal"
@@ -48189,7 +36024,7 @@ game (
 	name "Sonic Wings Limited (Japan)"
 	year "1996"
 	developer "Video System Co."
-	rom ( name sncwgltd.zip size 8581314 crc 38d3f156 md5 da565122b06e6601bbce6295d358da09 sha1 2f94516514cdaf90fe3ec07b8b1438c6ad55de95 )
+	rom ( name sncwgltd.zip size 8707496 crc 1b0a1a06 md5 2133db666ea2e52487bff21bb32af509 sha1 01065281bb1adfaafcd2475421366f54dd2147bf )
 )
 
 game (
@@ -48202,22 +36037,8 @@ game (
 game (
 	name "Snooker 10 (Ver 1.11)"
 	year "1998"
-	developer "Sandii&apos;"
+	developer "Sandii'"
 	rom ( name snookr10.zip size 143682 crc a63909f8 md5 d3f6a427f840aa1d277fee5a2f14c7c1 sha1 153eef5a9f7009290de84c79545babf6a50858a1 )
-)
-
-game (
-	name "Snow Board Championship (Version 2.1)"
-	year "1996"
-	developer "Gaelco"
-	rom ( name snowboar.zip size 5512634 crc 8c3794c0 md5 38bb05bb1a2c87567470f44f94d68959 sha1 21eb0ad71afe4f16edecca74582f3995da49d578 )
-)
-
-game (
-	name "Snow Board Championship (Version 2.0)"
-	year "1996"
-	developer "Gaelco"
-	rom ( name snowboara.zip size 6416772 crc e797ec70 md5 34353e315def451123da1c1f898a4288 sha1 7c30d4494e70cab9a80be7aab876e4df86a05e5d )
 )
 
 game (
@@ -48232,13 +36053,6 @@ game (
 	year "1990"
 	developer "Toaplan"
 	rom ( name snowbros.zip size 289681 crc af8a4129 md5 216801a573f1a29d3a051af3ae4e6651 sha1 c3bdfa5acd020f201cdd17a8466e3a55074043c7 )
-)
-
-game (
-	name "Snow Brothers 3 - Magical Adventure"
-	year "2002"
-	developer "Syrmex"
-	rom ( name snowbros3.zip size 2094016 crc b351a896 md5 f7c9f7d6856e0e7c6ea252e06341890a sha1 ef2d4ed4ce58f46d72e72f3df2ad3c99b91f2be6 )
 )
 
 game (
@@ -48280,14 +36094,14 @@ game (
 	name "Soccer Brawl (set 1)"
 	year "1991"
 	developer "SNK"
-	rom ( name socbrawl.zip size 2930674 crc f2229b8b md5 3d8e4cad9d1ddcc612b48b6191a2e117 sha1 957df98f03192256ece19f3b90b8a1f1a3dec586 )
+	rom ( name socbrawl.zip size 4277361 crc 05deae7a md5 c0664fd6a9386581d54110a8c18d4cac sha1 f955238bdc4de140ff0f9252724b6407d4d7d4cb )
 )
 
 game (
 	name "Soccer Brawl (set 2)"
 	year "1991"
 	developer "SNK"
-	rom ( name socbrawlh.zip size 3165835 crc a8193b30 md5 660f021e1326ea2643f24b519b7ac6cb sha1 2de747b7b9d747c4c88267674083541835818b67 )
+	rom ( name socbrawlh.zip size 4512522 crc 6662c068 md5 6aeb3763311777ecc3033c14ed0c9db7 sha1 4946200f40b46222b31b50a4283c84a94db644cb )
 )
 
 game (
@@ -48298,44 +36112,31 @@ game (
 )
 
 game (
-	name "Soccer New (Italian)"
-	developer "bootleg"
-	rom ( name soccernw.zip size 49540 crc 340b609e md5 1c736af84c6eaf8ff9504492394f8421 sha1 c94315b4286e6dda7fd3b2932fdbda32437d0c86 )
-)
-
-game (
 	name "Soccer Superstars (ver EAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name soccerss.zip size 7120412 crc dee569db md5 58c6bc683e35367a081be9c851b1fd6d sha1 6fdc1180620093b09578e90389c7241a923adc0f )
+	rom ( name soccerss.zip size 7129102 crc 717d8c8e md5 1bfe069d849e39998b1932abd61d0ad4 sha1 b07b2ff5ae5b238f41a92384cd268d18a46f3b09 )
 )
 
 game (
 	name "Soccer Superstars (ver AAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name soccerssa.zip size 7120917 crc c9c50bc7 md5 d59272745943a63e02dc925862ba794a sha1 04dc86354d328b3bc48aae6a48f8894f0339a6b4 )
+	rom ( name soccerssa.zip size 7129607 crc 81a91c94 md5 c6609e059a1ff4f417d380163f8c1aea sha1 592434713965bb532ab86fb0e617ae2b1c000ed4 )
 )
 
 game (
 	name "Soccer Superstars (ver JAC)"
 	year "1994"
 	developer "Konami"
-	rom ( name soccerssj.zip size 7159022 crc d54a92b1 md5 37f05e2a905bec26c501871ef83d004f sha1 65b5d972de0d29545d92ecd38b96179de13048a8 )
+	rom ( name soccerssj.zip size 7167712 crc 1eb5a11a md5 9c69fa2f07029ae716e26bb87778e8b3 sha1 a35ef6ac23190da3e84a9bfd19e601bca186fff9 )
 )
 
 game (
 	name "Soccer Superstars (ver JAA)"
 	year "1994"
 	developer "Konami"
-	rom ( name soccerssja.zip size 7171018 crc bf2d161e md5 4e016a56eb60f83f1977048970688816 sha1 e0d015ac7a6b29b425a0ba7634250368ac6ddca5 )
-)
-
-game (
-	name "Sogeki (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name sogeki.zip size 1239 crc e75fd9f6 md5 4188b6b4adfa8bf4f5ee374cde722650 sha1 a2daea54f96d0a74213496698c32414ec11807d0 )
+	rom ( name soccerssja.zip size 7179708 crc 9c62b4be md5 fe16fea8a2efee04876ae43ac1c78a19 sha1 dccb466d1ad0ca5bb018020e73c52440cd0d565b )
 )
 
 game (
@@ -48349,7 +36150,7 @@ game (
 	name "Soukyugurentai / Terra Diver (JUET 960821 V1.000)"
 	year "1996"
 	developer "Raizing / Eighting"
-	rom ( name sokyugrt.zip size 9772636 crc d171a378 md5 49450603303a3940025873be9f3e2f4b sha1 c57471321acdae910133408aabf563a5e8f9facb )
+	rom ( name sokyugrt.zip size 12471857 crc daaa0bd0 md5 875a5165b7beccf8fca6ae269a21625e sha1 cf4dc32d08c897e25e42cf3250f4108c8187d23c )
 )
 
 game (
@@ -48461,14 +36262,14 @@ game (
 	name "Aero Fighters 2 / Sonic Wings 2"
 	year "1994"
 	developer "Video System Co."
-	rom ( name sonicwi2.zip size 5543868 crc 64326777 md5 3a1e5eaa06d436223b6d40c7de11a1e5 sha1 5178e94ab560464f369eed59c589ada61ec18532 )
+	rom ( name sonicwi2.zip size 6890555 crc 69d05cca md5 cb2dad3fb73a7b3612baf0b47ff8458c sha1 b431633e3561b69ee16013306e68f3138099b8a8 )
 )
 
 game (
 	name "Aero Fighters 3 / Sonic Wings 3"
 	year "1995"
 	developer "Video System Co."
-	rom ( name sonicwi3.zip size 9336752 crc e3aa2c0b md5 9f372e12ad1ff7f2b62ecd64d1676219 sha1 8920d372afbb52cb403d879462a2dbe1a6cc1276 )
+	rom ( name sonicwi3.zip size 10683439 crc d8304c0d md5 b9c4e93a47fe02c5493ef501b0a2e36b sha1 35846a70461a89836f3050205ac900db51709ec6 )
 )
 
 game (
@@ -48525,27 +36326,6 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name soukobdx.zip size 231145 crc 571b7246 md5 3fead3d185743412ed5732f3be43520a sha1 960d514f0f6e400091803ce17807ae3c56f177ad )
-)
-
-game (
-	name "Soul Calibur II (SC21 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name soulcl2a.zip size 2730555 crc bf335271 md5 e358acd24fc75fc42deb66716dc83bd2 sha1 e92c519d4a691af96a165524757b5be82f0ab6ad )
-)
-
-game (
-	name "Soul Calibur II (SC23 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name soulclb2.zip size 2730804 crc 7a28f690 md5 b5bfdaa0d3bd214ce6229b06930ac7a6 sha1 1ab73b88d60158486ada1b47796841e2f0b27df7 )
-)
-
-game (
-	name "Soul Calibur III (SC31001-NA-A)"
-	year "2005"
-	developer "Namco"
-	rom ( name soulclb3.zip size 2937770 crc ddeb47f1 md5 408ea5fbea08cf8eb02319b357f4b0b8 sha1 21d81dfe4a2babf93b1f3d2ddfdda3d2d899e5cc )
 )
 
 game (
@@ -48619,6 +36399,13 @@ game (
 )
 
 game (
+	name "Soutenryu (V2.07J)"
+	year "2000"
+	developer "Warashi"
+	rom ( name soutenry.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Space Battle (bootleg set 2)"
 	year "1980"
 	developer "bootleg"
@@ -48633,38 +36420,10 @@ game (
 )
 
 game (
-	name "Space Beam"
-	year "1979"
-	developer "Irem"
-	rom ( name spacbeam.zip size 5711 crc 811b2c2a md5 f82b8431d4c759952a53efd18d47635d sha1 53026a5e0d6613c0e2447f72d8c1b095d3af7c4c )
-)
-
-game (
 	name "Space Duel"
 	year "1980"
 	developer "Atari"
 	rom ( name spacduel.zip size 20161 crc a74ef564 md5 efbb96330ea51f5d317ee3addd4b3e8f sha1 581b30a1738f63bf2c8338d21cd20660d4f48ecf )
-)
-
-game (
-	name "Space Ace (US Rev. A)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceaa.zip size 26039 crc 5c3f3562 md5 af71c5582583a44cd70dc77dfd5e084b sha1 f7d16e8d847a8f991d4896fa030ea5b7de033b76 )
-)
-
-game (
-	name "Space Ace (US Rev. A2)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceaa2.zip size 26055 crc 2f5334ab md5 152b24f0e04fb32b844e75be300bf538 sha1 387e1f9ec0e83d1667e2ebd9164916a47ac79c86 )
-)
-
-game (
-	name "Space Ace (US Rev. A3)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceace.zip size 26055 crc 9f7a7ec5 md5 fd076c8fda71a16b04fe59095e573741 sha1 36e3085e22ce09e66eabc5831e5d5ed21bebfea7 )
 )
 
 game (
@@ -48714,20 +36473,6 @@ game (
 	year "1980"
 	developer "Nintendo (Fortrek license)"
 	rom ( name spacedem.zip size 15577 crc 09103eca md5 f1ed757fb183914ff853d30316cacbf1 sha1 e54a79c0933eaabf61e3d6867e09d62e00d31b6a )
-)
-
-game (
-	name "Space Invaders DX (US, v2.1)"
-	year "1994"
-	developer "Taito Corporation"
-	rom ( name spacedx.zip size 530613 crc 4d8b0176 md5 ec93c383cea9e6e9ad496bd3931a1d99 sha1 a679c33fd0e56e9a7319dcfeb0de14e1e83b9374 )
-)
-
-game (
-	name "Space Invaders DX (Japan, v2.1)"
-	year "1994"
-	developer "Taito Corporation"
-	rom ( name spacedxj.zip size 530576 crc 3699968b md5 9459ddbfc5232e50a910a7f3d860319c sha1 74ff1780e1f806868c75a8c0db92bd066fc5090d )
 )
 
 game (
@@ -48787,20 +36532,6 @@ game (
 )
 
 game (
-	name "Space Fortress (Zaccaria)"
-	year "1981"
-	developer "Cinematronics (Zaccaria license)"
-	rom ( name spaceftr.zip size 7976 crc 7028aea6 md5 a8314372211ec87783a48c43fc7738c0 sha1 353d7cf5e7972e1b0b586a00daafb741be6a996a )
-)
-
-game (
-	name "Space Guerrilla"
-	year "1979"
-	developer "Omori"
-	rom ( name spaceg.zip size 9735 crc 1e87b374 md5 4b4996fd20757397f9988d231d4399b5 sha1 8c4728c34d0fe71b3e060a84cad25c22e95deb6d )
-)
-
-game (
 	name "Space Gun (World)"
 	year "1990"
 	developer "Taito Corporation Japan"
@@ -48808,38 +36539,10 @@ game (
 )
 
 game (
-	name "Space Intruder"
-	year "1980"
-	developer "Shoei"
-	rom ( name spaceint.zip size 5365 crc f37eca0f md5 a4d22f488544b68474a3ed2630651033 sha1 d5df2540c7193d222412e521d5a0e7602ff5ec5d )
-)
-
-game (
-	name "Space Intruder (Japan)"
-	year "1980"
-	developer "Shoei"
-	rom ( name spaceintj.zip size 5517 crc 19da0248 md5 8de7a1ac4e338d53b1ebc28fec91c94c sha1 0dae47f8be075f57695b6550c858c9e3de595c64 )
-)
-
-game (
-	name "Space Launcher"
-	year "1979"
-	developer "Nintendo"
-	rom ( name spacelnc.zip size 7975 crc 4aa2c5d7 md5 4a086eae4856fc818aa59568f16d9d51 sha1 080db2c18c249a7a4a6948e5231d8bc5d240d009 )
-)
-
-game (
 	name "Space Empire (bootleg)"
 	year "1980"
 	developer "bootleg"
 	rom ( name spacempr.zip size 18098 crc c2dacdd7 md5 db6671285de655d41c69b0a4200e11bb sha1 ada75bd84652a95996715a65c16f4a048fb3c427 )
-)
-
-game (
-	name "Space Odyssey (version 2)"
-	year "1981"
-	developer "Sega"
-	rom ( name spaceod.zip size 39895 crc 2b6e33cd md5 d369ad29c3790e31bfc7604feaa1847a sha1 5535f92d7319d7f375dd483d7b44b185b6cadfd2 )
 )
 
 game (
@@ -48854,13 +36557,6 @@ game (
 	year "1979"
 	developer "SNK (Zilec Games license?)"
 	rom ( name spaceph.zip size 9711 crc eaed1fb5 md5 c003d7492228bd7437ab6b51199a123a sha1 c18506b1cfb9abe80c98805e4fa1254506acfee4 )
-)
-
-game (
-	name "Space Pirates v2.2"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name spacepir.zip size 62764 crc 95c004d7 md5 8c52b61539b3b0aea3fdfafed4c08021 sha1 7e456886643a87cb403e482446305b38e2a7719e )
 )
 
 game (
@@ -48882,20 +36578,6 @@ game (
 	year "1981"
 	developer "Taito Corporation"
 	rom ( name spaceskr.zip size 30970 crc 8fc32d74 md5 1eaa8d339092a3b101d9eb83a98e8f3a sha1 39a22605b050c18449b0db76ddd7e16f49d148fd )
-)
-
-game (
-	name "Space Trek (upright)"
-	year "1980"
-	developer "Sega"
-	rom ( name spacetrk.zip size 14213 crc d350ef13 md5 86b978925bc5192b18122caa4bf96bb7 sha1 88be756e0bb9b5ccdf48723ab95bed61c388b689 )
-)
-
-game (
-	name "Space Trek (cocktail)"
-	year "1980"
-	developer "Sega"
-	rom ( name spacetrkc.zip size 14290 crc 5cc2712c md5 ae20ac0f5524097cad17955161887dd0 sha1 ae0c75326b93cc7a9035dee037ee989940931550 )
 )
 
 game (
@@ -48962,31 +36644,10 @@ game (
 )
 
 game (
-	name "Super Pang (World 900914, bootleg)"
-	year "1990"
-	developer "bootleg"
-	rom ( name spangbl.zip size 662617 crc d26df448 md5 142744ff0b0b63f7ac3d19de2fbb765c sha1 382c018931f8db7ef780cea80bba09d839650e50 )
-)
-
-game (
 	name "Super Pang (Japan 901023)"
 	year "1990"
 	developer "Mitchell"
 	rom ( name spangj.zip size 671967 crc 855b425e md5 642c831c0afb57fa195bffdd5a1bf36b sha1 da6d39005ceef3331d3de29c82e2c968a43c0366 )
-)
-
-game (
-	name "Spark Man (v 2.0, set 1)"
-	year "1989"
-	developer "SunA"
-	rom ( name sparkman.zip size 314033 crc 9aaa49f6 md5 cb904ce05a2b5d3836da7c3f184ef1ff sha1 11afa4b324ffd50db29cbdc82c1590436b56390b )
-)
-
-game (
-	name "Spark Man (v 2.0, set 2)"
-	year "1989"
-	developer "SunA"
-	rom ( name sparkmana.zip size 314021 crc 6d6d62a2 md5 97835028963684f2bc9c3f9d682d2ff8 sha1 50f36ddab909ec82d0b6e184e2238b417740cb1c )
 )
 
 game (
@@ -49008,13 +36669,6 @@ game (
 	year "1984"
 	developer "Sega"
 	rom ( name spatter.zip size 81222 crc 1c3a0dec md5 8519100ce764326793b952df8695d1c6 sha1 0ddab60b643d8967e48ca687994927603813a87d )
-)
-
-game (
-	name "Spawn (JPN, USA, EUR, ASI, AUS)"
-	year "1999"
-	developer "Capcom"
-	rom ( name spawn.zip size 52057228 crc 5aae7c89 md5 9ed07253bd26bd92e72bbf35b5a981ec sha1 bf06e8d236c6fe77eee5eb21ecb497ccc523af69 )
 )
 
 game (
@@ -49087,13 +36741,6 @@ game (
 )
 
 game (
-	name "Special Forces II"
-	year "1985"
-	developer "Senko Industries (Magic Eletronics Inc. license)"
-	rom ( name spcfrcii.zip size 20421 crc b47f130b md5 59c93603f7967c781f17fe3673bce09c sha1 ae0a26b76e98bf5bc150e5bfeef278aea7678695 )
-)
-
-game (
 	name "Space Invaders '95: The Attack Of Lunar Loonies (Ver 2.5O 1995/06/14)"
 	year "1995"
 	developer "Taito Corporation Japan"
@@ -49129,41 +36776,6 @@ game (
 )
 
 game (
-	name "Special Forces"
-	year "1985"
-	developer "Senko Industries (Magic Eletronics Inc. license)"
-	rom ( name spclforc.zip size 20459 crc c3c13324 md5 3d3502ed841f7afe9aac0257b7152512 sha1 6e185580a6e08ca8c839fc609c946b5974df7763 )
-)
-
-game (
-	name "Space Lords (rev C)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclords.zip size 4227934 crc 159fe801 md5 d798b772501efada2325324d42ed4a12 sha1 9b4546b6aeef5d5f3791023b8109747bc3ac40ee )
-)
-
-game (
-	name "Space Lords (rev A)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsa.zip size 4226898 crc 1d56be95 md5 0edab2a171851731f5992a0c983a56d7 sha1 74e4db0ff0281bb28bdf42905f34355373a669dc )
-)
-
-game (
-	name "Space Lords (rev B)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsb.zip size 4227021 crc f041acdd md5 04916d20a97502b4b8ba34d2c03b57a9 sha1 1861ad84266e98e60ee32d626c9dd68519fde387 )
-)
-
-game (
-	name "Space Lords (rev A, German)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsg.zip size 4227118 crc abe17fb6 md5 60ebc8e7a7257b9c2509fe33b75e3e66 sha1 21e3c1a22baabbe0935bc5bc784af0afcd81fb77 )
-)
-
-game (
 	name "Space Position (Japan)"
 	year "1986"
 	developer "Sega / Nasco"
@@ -49188,13 +36800,6 @@ game (
 	year "1984"
 	developer "Stern Electronics"
 	rom ( name spdcoin.zip size 10375 crc a09ea6f5 md5 60cc34a3e894b260b7d238bc6ae22e0c sha1 7500f787ab08cffcc6ba30d6f54be36c219318e9 )
-)
-
-game (
-	name "Super Dodge Ball (US)"
-	year "1987"
-	developer "Technos Japan"
-	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
 )
 
 game (
@@ -49247,20 +36852,6 @@ game (
 )
 
 game (
-	name "Speed Freak"
-	year "1979"
-	developer "Vectorbeam"
-	rom ( name speedfrk.zip size 8037 crc 6c85d98c md5 5c7138d12b40d351cfe9dec62d7b5d3c sha1 b5df4232b3a6bfe54272aeb58a643557222f4632 )
-)
-
-game (
-	name "Speed Racer"
-	year "1995"
-	developer "Namco"
-	rom ( name speedrcr.zip size 9287692 crc eba41560 md5 943d9ad476028ef62bebe04f516b2f7d sha1 d482c59d1f2b4df647e9f365fbfd407f7f68178e )
-)
-
-game (
 	name "Speed Spin"
 	year "1994"
 	developer "TCH"
@@ -49279,19 +36870,6 @@ game (
 	year "1994"
 	developer "Seta"
 	rom ( name speglsht.zip size 3383092 crc 6e79fdfe md5 95d0d2fc3a17549b628961237717215c sha1 773ea02919112f086112d16b787499c167765565 )
-)
-
-game (
-	name "Spellbound"
-	developer "ACE"
-	rom ( name spellbnd.zip size 9653 crc be68977d md5 4f01e3b4aaf055f4e72924b11fc69d6e sha1 c557e1406ca003d78c2e0f133d739a872411e59a )
-)
-
-game (
-	name "Spelunker II"
-	year "1986"
-	developer "Irem (licensed from Broderbund)"
-	rom ( name spelunk2.zip size 136512 crc 1d55ade1 md5 f86b5da1428876751fd4058baaf27fff sha1 7037d6dc98ac44b459618c68681e7285ed3088cf )
 )
 
 game (
@@ -49344,20 +36922,6 @@ game (
 )
 
 game (
-	name "Space Fighter Mark II (set 1)"
-	year "1979"
-	developer "Data East"
-	rom ( name spfghmk2.zip size 6287 crc 28025964 md5 1cafbc76d9f1e320ad173ecb2b4f064a sha1 6f334e3a800ecbf08a484e9216d5c997ca798e86 )
-)
-
-game (
-	name "Space Fighter Mark II (set 2)"
-	year "1979"
-	developer "Data East"
-	rom ( name spfghmk22.zip size 6347 crc c7213d88 md5 e81b4add47bb124896ad84b05746e685 sha1 85584f3325331c45f20280d752b9cac009038569 )
-)
-
-game (
 	name "Spiders (set 1)"
 	year "1981"
 	developer "Sigma Enterprises Inc."
@@ -49393,45 +36957,10 @@ game (
 )
 
 game (
-	name "Spiel Bude (German)"
-	year "1985"
-	developer "ADP"
-	rom ( name spielbud.zip size 42281 crc 445cec24 md5 22e19898a0886ce3109ba176f28883d3 sha1 65c580c736ca142203c212cabcd138512255001e )
-)
-
-game (
 	name "Super Pierrot (Japan)"
 	year "1987"
 	developer "Universal"
 	rom ( name spiero.zip size 47010 crc 4308f1e1 md5 b5e43d90836a6934cf5f446b80bc8ded sha1 5c60cbd24285fedc1b91ae7f443001274654a831 )
-)
-
-game (
-	name "Spikeout Final Edition"
-	year "1998"
-	developer "Sega"
-	rom ( name spikeofe.zip size 83082843 crc 9a6448dc md5 078d88d5a534c1c6ec5dba3f8d946069 sha1 3f8f45b809574e828ff3d7b66ebd295c85ead5b1 )
-)
-
-game (
-	name "Spikeout (Revision C)"
-	year "1998"
-	developer "Sega"
-	rom ( name spikeout.zip size 135500829 crc cff99556 md5 df38ab21d83a9a92fedba7a2ec9daba8 sha1 c43db01d6f8721b68e8804fb04859a273511aae1 )
-)
-
-game (
-	name "Spiker"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name spiker.zip size 45190 crc b52b754c md5 a31652f7218a675a8a66a5b52610c0af sha1 b61500e0ac1c9e54e48f1744fa13e917988de3d2 )
-)
-
-game (
-	name "1991 Spikes (Italian bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name spikes91.zip size 628174 crc 272ca6d0 md5 5c28d8fcaa3baf4ef3fdbec106ae6f4e sha1 bd815ea53398c0278b83ac80542cf880bc4c34ec )
 )
 
 game (
@@ -49442,31 +36971,10 @@ game (
 )
 
 game (
-	name "Spinal Breakers (World)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrk.zip size 2303016 crc 994052e9 md5 e3950ffff9a6cbc34732de0ded28b045 sha1 4d32fe5c59cab1cec21c6d865bb91eb7cd6e502a )
-)
-
-game (
-	name "Spinal Breakers (Japan)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrkj.zip size 2303143 crc f0346dee md5 da43e83b377ae219a4b32067fb40d1a2 sha1 262f85d681d4933e1130df331b01ab1402b4b154 )
-)
-
-game (
-	name "Spinal Breakers (US)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrku.zip size 2303236 crc eeeccf32 md5 80c9a0ffdbf5155a473004951ec7f26e sha1 4c88fa98c2b6765641e7aaa58e21cbb83a633c29 )
-)
-
-game (
 	name "Spin Master / Miracle Adventure"
 	year "1993"
 	developer "Data East Corporation"
-	rom ( name spinmast.zip size 4037279 crc 2087dccd md5 20d098718585f229711319940e057739 sha1 08a72ebca57a4fe3de16480c7e6340de4da4c486 )
+	rom ( name spinmast.zip size 5383966 crc aff09fe7 md5 f4ed555e3e0491b2378d531eebf9bf25 sha1 4a19b96b4c600a9d5c088efb9ffa3e36be48d149 )
 )
 
 game (
@@ -49493,13 +37001,6 @@ game (
 	name "Super Poker (v116IT)"
 	developer "IGS"
 	rom ( name spk116it.zip size 484012 crc 207bf530 md5 16fef5dff2da50a0d335c4ee0c1dbafc sha1 be1aae5c8fea36c05ffc683760fa9f3907cd992b )
-)
-
-game (
-	name "Spikers Battle (GDS-0005)"
-	year "2001"
-	developer "Sega"
-	rom ( name spkrbtl.zip size 1198 crc 42e66618 md5 0682e5b95bcf468ee5051a699e598295 sha1 6d387a3e7f8665b2cd3013e655c8fa309a061dbd )
 )
 
 game (
@@ -49594,13 +37095,6 @@ game (
 )
 
 game (
-	name "Spotty (Ver. 2.0.2)"
-	year "2001"
-	developer "Prince Co."
-	rom ( name spotty.zip size 272327 crc 870dcf88 md5 6c9284d27a0612b60ba3bf646fc8a000 sha1 8bd7cc20160b86f017148dec9107406dbea72240 )
-)
-
-game (
 	name "Super Cross II (Japan, set 1)"
 	year "1986"
 	developer "GM Shoji"
@@ -49664,13 +37158,6 @@ game (
 )
 
 game (
-	name "Sprint 4 (set 2)"
-	year "1977"
-	developer "Atari"
-	rom ( name sprint4a.zip size 6775 crc c64a001c md5 f401bb5aaf4de0558bb5a053e5abd6bb sha1 b9226ba6ae7eea522e5cbecbc4b28758d1d937b2 )
-)
-
-game (
 	name "Sprint 8"
 	year "1977"
 	developer "Atari"
@@ -49692,13 +37179,6 @@ game (
 )
 
 game (
-	name "Sports Jam (GDS-0003)"
-	year "2000"
-	developer "Sega"
-	rom ( name sprtjam.zip size 1195 crc 881ee5ab md5 ab305710e1ffdd41373c40ec69f84203 sha1 54d7e2e88dcf6f8f7db3a79fe2e774890c8dba1d )
-)
-
-game (
 	name "Sports Match"
 	year "1989"
 	developer "Dynax (Fabtek license)"
@@ -49706,10 +37186,17 @@ game (
 )
 
 game (
-	name "Sports Shooting USA"
-	year "2002"
-	developer "Sammy USA"
-	rom ( name sprtshot.zip size 58739317 crc 6d8bf4c1 md5 1d72f8f74460cf2389c6f9e2cf0381fc sha1 379960a6208fe8b81aa08b3d1f2537ec9ede450b )
+	name "Super Puzzle Bobble (V2.05O)"
+	year "1999"
+	developer "Taito"
+	rom ( name spuzbobl.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
+	name "Super Puzzle Bobble (V2.04J)"
+	year "1999"
+	developer "Taito"
+	rom ( name spuzboblj.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -49724,20 +37211,6 @@ game (
 	year "1983"
 	developer "Bally Midway"
 	rom ( name spyhunt.zip size 105665 crc 3d35096d md5 332512bf0e76ec272b472bed95262d5b sha1 4da69217902e22be0e2bc045d6e6af341881201f )
-)
-
-game (
-	name "Spy Hunter 2 (rev 2)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name spyhunt2.zip size 363056 crc 4e509b2d md5 16df0f6b79f2dc33d9d17257bfc7b0ba sha1 c14de08325340a1b6e66eafffbe13472df90c883 )
-)
-
-game (
-	name "Spy Hunter 2 (rev 1)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name spyhunt2a.zip size 360909 crc 377483a0 md5 c5998cce9a36ec23437dcba10cb48eab sha1 08fbfd45c00fcce6db274932f4edf0cf5770eb1f )
 )
 
 game (
@@ -49762,31 +37235,10 @@ game (
 )
 
 game (
-	name "Super Qix (World, Rev 2)"
-	year "1987"
-	developer "Taito"
-	rom ( name sqix.zip size 141696 crc dd4aa61b md5 c47f4c5d2101b115c016578ebe176d48 sha1 1e0e268a3ce841201ca70f8f4d7603539cedf976 )
-)
-
-game (
-	name "Super Qix (bootleg set 1)"
-	year "1987"
-	developer "bootleg"
-	rom ( name sqixb1.zip size 142844 crc 12e11d54 md5 ac9b5a1c10ebae2f502d6cda00480dd9 sha1 7928ec03233181e0bddf1d905b129eee8e068a94 )
-)
-
-game (
 	name "Super Qix (bootleg set 2)"
 	year "1987"
 	developer "bootleg"
 	rom ( name sqixb2.zip size 141929 crc 97d19e7e md5 a64b9f0aea793a52f132757c41d19dea sha1 b9c97c7417b0473d19cbc808fca6914d88ffd78f )
-)
-
-game (
-	name "Super Qix (World, Rev 1)"
-	year "1987"
-	developer "Taito"
-	rom ( name sqixr1.zip size 142184 crc 724f598e md5 464fd6a4a0d87237eeca86a07fbb35d6 sha1 a1b17a84f52b7415d78eddafccc2e7516039e5c7 )
 )
 
 game (
@@ -49818,27 +37270,6 @@ game (
 )
 
 game (
-	name "Sega Rally 2"
-	year "1998"
-	developer "Sega"
-	rom ( name srally2.zip size 76292595 crc c4e60679 md5 6ab6dd3db8a062c8fe7dd1e8d51bf525 sha1 9f455b7145252a9704d636000232302e5d6c4d7c )
-)
-
-game (
-	name "Sega Rally 2 DX"
-	year "1998"
-	developer "Sega"
-	rom ( name srally2x.zip size 54062299 crc 6ea59223 md5 a831ae8a70788a1f44af6250e190278b sha1 730fd43569b1b770a13b566ce12a39bc7ed73669 )
-)
-
-game (
-	name "Sega Rally Championship"
-	year "1995"
-	developer "Sega"
-	rom ( name srallyc.zip size 17280930 crc 0f824413 md5 8b9b16d66bb4e02ed0245932c801b72d sha1 b7b732e1a01a9ff5f4c35116a420366c546f3841 )
-)
-
-game (
 	name "Super Ranger (v2.0)"
 	year "1988"
 	developer "SunA"
@@ -49846,31 +37277,10 @@ game (
 )
 
 game (
-	name "Super Ranger (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name srangerb.zip size 185773 crc 3857e5d7 md5 5d7d4ea037179bbec94faad5c1cb4cf5 sha1 40fa2090f37befeb4b2e31570182631d8613aead )
-)
-
-game (
 	name "Super Ranger (WDK)"
 	year "1988"
 	developer "SunA (WDK license)"
 	rom ( name srangerw.zip size 171911 crc 742e1165 md5 e67570b040da314e0585958c3ea6eee0 sha1 a77394cb9034830c0125f960c570daeadb976e70 )
-)
-
-game (
-	name "Super Real Darwin (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name srdarwin.zip size 191667 crc f5949dc6 md5 d3838f3c994a0c72ac9053308cd92ba3 sha1 f2fb0d3b28e230ed5d846b94d97f9674d8991cc7 )
-)
-
-game (
-	name "Super Real Darwin (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name srdarwinj.zip size 191660 crc 56584a3f md5 eeaae89565467d409e66eac16db9d3b9 sha1 a0693a116dbefff148fd57a623de098187f2024b )
 )
 
 game (
@@ -49937,13 +37347,6 @@ game (
 )
 
 game (
-	name "Super Real Mahjong VS"
-	year "1999"
-	developer "Seta"
-	rom ( name srmvs.zip size 28006028 crc cac7fbc2 md5 33646dc6503f43533474474b9ef19054 sha1 6a25d68b3f7b3bb3f3f20a5243601ac3f8a54fd0 )
-)
-
-game (
 	name "The Speed Rumbler (set 1)"
 	year "1986"
 	developer "Capcom"
@@ -49965,20 +37368,6 @@ game (
 )
 
 game (
-	name "Super Shanghai 2005 (GDL-0031)"
-	year "2005"
-	developer "Starfish"
-	rom ( name ss2005.zip size 1198 crc 23f852c5 md5 0a5e5a5795e411d780caadbd0ade4933 sha1 14423abd24229f3da0d840b31221bc6bed7d8e68 )
-)
-
-game (
-	name "Super Shanghai 2005 (Rev A) (GDL-0031A)"
-	year "2005"
-	developer "Starfish"
-	rom ( name ss2005a.zip size 1198 crc 23f852c5 md5 0a5e5a5795e411d780caadbd0ade4933 sha1 14423abd24229f3da0d840b31221bc6bed7d8e68 )
-)
-
-game (
 	name "Sanrin San Chan (Japan)"
 	year "1984"
 	developer "Sega"
@@ -49990,41 +37379,6 @@ game (
 	year "1985"
 	developer "Coreland / Sega"
 	rom ( name sscandal.zip size 84156 crc d8f2e991 md5 98882bcb9ffa4daf87a1f4b09e089707 sha1 eb0eb81cff351286acd27d94e439416499593c24 )
-)
-
-game (
-	name "Silent Scope (ver JZD)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscope.zip size 15165762 crc 89185c09 md5 a0f4cac6144ada39bc76863914244703 sha1 5174f6e920c0d3649c806713548c3fc7d5795027 )
-)
-
-game (
-	name "Silent Scope 2"
-	year "2000"
-	developer "Konami"
-	rom ( name sscope2.zip size 19068139 crc a0eccec1 md5 6a00f69d0ff8cf68c3133290a1a87333 sha1 828d93ce9237c727ccc46f6781f72227ce7ebe90 )
-)
-
-game (
-	name "Silent Scope (ver UAB)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscopea.zip size 15121622 crc 16ec8eae md5 8a3ef56f26a7bdb6ecf3530cc88712a4 sha1 5b83729cbca4746966c0ab059597b4564dc65352 )
-)
-
-game (
-	name "Silent Scope (ver UAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscopeb.zip size 15116768 crc a5be1b29 md5 5661af0de63a5748bd5216b4d4b29ce8 sha1 0d4d0a7fdf8251a8f97ea553103bdac48c5cf163 )
-)
-
-game (
-	name "Silent Scope EX (ver UAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name sscopex.zip size 608 crc b0fff066 md5 507cacc9e90ba56911657663a9518c3e sha1 e2d1a180705e5e8c9102e009a8ed57afc51ae517 )
 )
 
 game (
@@ -50168,24 +37522,10 @@ game (
 )
 
 game (
-	name "See See Find Out"
-	year "1999"
-	developer "Icarus"
-	rom ( name ssfindo.zip size 5886116 crc d52eb6a8 md5 0ce5368f686dc6d953d04a626e1a6d0e sha1 1467d76d5abed88eac869a674cbec4f1b0484da9 )
-)
-
-game (
 	name "Sunset Riders (bootleg of Megadrive version)"
 	year "1993"
 	developer "bootleg / Konami"
 	rom ( name ssgbl.zip size 379004 crc 002d0bca md5 7b0477718d4373ba90b871d0da02b425 sha1 bf41bc1822eb0e264d89571228138247047d08a6 )
-)
-
-game (
-	name "Super Shanghai Dragon's Eye (Japan)"
-	year "1992"
-	developer "Hot-B"
-	rom ( name sshangha.zip size 1798303 crc e77c76d2 md5 56fd437ce72d692a53cf34b130bcf1f4 sha1 06e776678138bd4e5216bdf6eff26d18628b1734 )
 )
 
 game (
@@ -50227,77 +37567,28 @@ game (
 	name "Super Sidekicks / Tokuten Ou"
 	year "1992"
 	developer "SNK"
-	rom ( name ssideki.zip size 3253037 crc 4fd8590b md5 8b882b1bd04b8ba557fcd7f30301eb5e sha1 42b4ba36f7a2bf1f99f3776c3f6003648a82d9f5 )
+	rom ( name ssideki.zip size 4599724 crc baf889bf md5 437a70e2a4eea1780c3f39e2c437c806 sha1 802897907a99e5633e0ec039df04b90b212c0378 )
 )
 
 game (
 	name "Super Sidekicks 2 - The World Championship / Tokuten Ou 2 - real fight football"
 	year "1994"
 	developer "SNK"
-	rom ( name ssideki2.zip size 6848147 crc 228e6c09 md5 573d87394417ff8a35e80fc6ad09f6f0 sha1 ad9bff70a636677ef669fb07b9daa48191e28f05 )
+	rom ( name ssideki2.zip size 8194834 crc e1771be7 md5 16f7990f811d5dc56ccd38b944a5273c sha1 c0656ce6d9105da6646a3ef507df02ebc24af072 )
 )
 
 game (
 	name "Super Sidekicks 3 - The Next Glory / Tokuten Ou 3 - eikoue no michi"
 	year "1995"
 	developer "SNK"
-	rom ( name ssideki3.zip size 9870603 crc 3e1db310 md5 975f6f72bda0198ac6d8a104d6012a9e sha1 fe1e16258ff822a36ec1aa7422b4b2730097957a )
+	rom ( name ssideki3.zip size 11217290 crc b1f6d691 md5 8808f173f5ddd85194d8eb76aa346a60 sha1 1ee2508ecb4e865aa214862fc47c669a3b5cfeef )
 )
 
 game (
 	name "The Ultimate 11 - The SNK Football Championship / Tokuten Ou - Honoo no Libero"
 	year "1996"
 	developer "SNK"
-	rom ( name ssideki4.zip size 13639446 crc 1b1dd29d md5 720e7deaf1b366661c1c990fd951225b sha1 34eef51a9cbe0addb4f342fd871c101eb69d50a3 )
-)
-
-game (
-	name "Swinging Singles"
-	year "1983"
-	developer "Ent. Ent. Ltd"
-	rom ( name ssingles.zip size 51433 crc 734975e4 md5 467dfa689602246a0117f312a3b7b103 sha1 a7d320cc6cf2825530bbcb2e9f928e0732e7db0d )
-)
-
-game (
-	name "SSI Poker (v2.4)"
-	year "1988"
-	developer "SSI"
-	rom ( name ssipkr24.zip size 11818 crc a87dc911 md5 ed34f9f2aec532a0bf20b156f7ab2ea9 sha1 715c7ef9cdd73edefc95fdf6dfbdbeb2679eb61f )
-)
-
-game (
-	name "SSI Poker (v3.0)"
-	year "1988"
-	developer "SSI"
-	rom ( name ssipkr30.zip size 12493 crc 36b083e1 md5 f929dc3f4cce277db1d7a19acf1759ad sha1 873a229eaca23dde6b3e27dcc991a7072849b431 )
-)
-
-game (
-	name "SSI Poker (v4.0)"
-	year "1990"
-	developer "SSI"
-	rom ( name ssipkr40.zip size 12647 crc 58df438e md5 7c13938ed979455ab8b4167581f001c9 sha1 801453e80636adb069266df9ff17e5d020c76673 )
-)
-
-game (
-	name "Southern Systems Joker Poker"
-	year "1982"
-	developer "Southern Systems &amp; Assembly"
-	rom ( name ssjkrpkr.zip size 5611 crc 954b0cef md5 9a66ecb717a4b19d7ecb10671aaebf96 sha1 a214fc632a34aaa9f74697136a9aca54ea8d89aa )
-)
-
-game (
-	name "Super Slam (set 1)"
-	year "1993"
-	developer "Playmark"
-	rom ( name sslam.zip size 1566942 crc 96bd8f82 md5 11784419dbd4e8c640d3fde16f9d0cc5 sha1 176ec29bba753504f650c42983a6ba4d6135c43b )
-)
-
-game (
-	name "Super Slam (set 2)"
-	year "1993"
-	developer "Playmark"
-	rom ( name sslama.zip size 1566934 crc 4493c327 md5 33e0fb1dd87444b2e17910843eaec3b1 sha1 9b85940059bdd55b52d22f742d336947c5bf151a )
+	rom ( name ssideki4.zip size 14986133 crc f781ef5d md5 d975a9d4b2f568fbe6f888d87ea8497c sha1 cb241a683f41151ba2ff5f88ecbf0c2ebb6f7e78 )
 )
 
 game (
@@ -50322,54 +37613,6 @@ game (
 )
 
 game (
-	name "Super Space 2001"
-	developer "&lt;unknown&gt;"
-	rom ( name sspac2k1.zip size 220533 crc 558eb2b1 md5 257dde3d213db022ac796f43a0f9fa78 sha1 30301515d752b25607e545c8511dd9f32be5bd99 )
-)
-
-game (
-	name "Space Attack / Head On"
-	year "1979"
-	developer "Sega"
-	rom ( name sspacaho.zip size 13045 crc 688a7299 md5 f234c9f0394560053e8aecc27c03fb6e sha1 380be7f2e53182a0e0b4954d7cdc5319a95c63ea )
-)
-
-game (
-	name "Space Attack (upright set 1)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat.zip size 7630 crc b7d48ade md5 c2f61bb364c134cbeec24267e9001a08 sha1 dc9eacdea547e287064c798ed9349d5f959a9a9b )
-)
-
-game (
-	name "Space Attack (upright set 2)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat2.zip size 7719 crc 1e209fa2 md5 5216306b2981d4a18c289acfe62c6361 sha1 dd427b29cae63eff93b17a001ceb09297421edcd )
-)
-
-game (
-	name "Space Attack (upright set 3)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat3.zip size 7825 crc d9273289 md5 1382095be2130dd76db9956482b5f7e2 sha1 57f13c3d9610c49213b97de6c51a54d8ff7fd106 )
-)
-
-game (
-	name "Space Attack (cocktail)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceatc.zip size 7702 crc c4fa9150 md5 9460e97ff4005b9bb7baa0113dea4894 sha1 ab8111ae778d2cfffa7425336187889b38dd744a )
-)
-
-game (
-	name "Super Speed Race"
-	year "1979"
-	developer "Midway"
-	rom ( name sspeedr.zip size 5092 crc 9b23af52 md5 22ca3744af4a63ddd0f416ecae361396 sha1 e88ee6aac51e101e007c19a6965f06978ece4961 )
-)
-
-game (
 	name "Scramble Spirits (Japan, Floppy DS3-5000-02-REV-A Based)"
 	year "1988"
 	developer "Sega"
@@ -50381,13 +37624,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name sspirits.zip size 802970 crc 8bee32b2 md5 c0ae24dacf68fe05893f7cdbf2a064c9 sha1 abd0b6a1bc43c024989c8a87e12761a854f8815e )
-)
-
-game (
-	name "Scramble Spirits (World, Floppy Based, FD1094 317-0058-02c)"
-	year "1988"
-	developer "Sega"
-	rom ( name sspirtfc.zip size 144534 crc 4f8fdaa4 md5 73b2abedc36a8dba49f03e7d1da9802e sha1 6d86d01bd8b23d6eaf2a9cb496641e4fbd0f3fda )
 )
 
 game (
@@ -50461,13 +37697,6 @@ game (
 )
 
 game (
-	name "Sunset Riders (bootleg 4 Players ver ADD)"
-	year "1991"
-	developer "bootleg"
-	rom ( name ssridersb.zip size 2146826 crc 9bcbe241 md5 8d1ce1ab0702a96f4abe2706990aa224 sha1 7d36cfe15d0a220a61b7a9bfcb948c59a7daa0ff )
-)
-
-game (
 	name "Sunset Riders (4 Players ver EAA)"
 	year "1991"
 	developer "Konami"
@@ -50517,23 +37746,10 @@ game (
 )
 
 game (
-	name "Super Speed Race Junior (Japan)"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name ssrj.zip size 29266 crc f29fcd99 md5 42aaf020b93e61ad2196c27b2916f230 sha1 63af6180f45d2a76a5d15bb69de3b3166cea0916 )
-)
-
-game (
 	name "Steep Slope Sliders (JUET 981110 V1.000)"
 	year "1998"
 	developer "Capcom / Cave / Victor"
-	rom ( name sss.zip size 10123314 crc 6094c420 md5 5a4f6da2f5d6926f1566e8b9d1b2f304 sha1 438f419c23b9a28fb5246fb930b3c83f8fff9e2b )
-)
-
-game (
-	name "Super Star"
-	developer "&lt;unknown&gt;"
-	rom ( name sstar.zip size 222904 crc 7b068616 md5 02b6871cb37ca436141e9906b4c760bb sha1 8236661b569d560269a7454261561d4b23976ad7 )
+	rom ( name sss.zip size 12822535 crc 7e560f73 md5 2c93a18ac221506a7a8b00044caf4c38 sha1 80a2f4f88059b9106491e344a2d2be568da7d185 )
 )
 
 game (
@@ -50548,20 +37764,6 @@ game (
 	year "1986"
 	developer "Alpha Denshi Co."
 	rom ( name sstingry.zip size 121285 crc 144dde35 md5 3a5fe8a58d9799c0a83eaee278cb6c81 sha1 76246cd52f4aa75422fefaab842c0c1d5705ecfd )
-)
-
-game (
-	name "Space Stranger"
-	year "1978"
-	developer "Yachiyo Electronics, Ltd."
-	rom ( name sstrangr.zip size 7170 crc c6df43aa md5 0a5869c638f56c882e2d5c4a9d74b872 sha1 d7e9d54dbcb1042522f59c0793e90004a3a4ceb5 )
-)
-
-game (
-	name "Space Stranger 2"
-	year "1979"
-	developer "Yachiyo Electronics, Ltd."
-	rom ( name sstrangr2.zip size 6588 crc bec246f5 md5 deefb73ee6112202a5ce5f7ce7574215 sha1 5b6edd7803a9f7ae904c67be51c7e00cb023879e )
 )
 
 game (
@@ -50586,38 +37788,10 @@ game (
 )
 
 game (
-	name "Sega Strike Fighter (Rev A)"
-	year "2000"
-	developer "Sega"
-	rom ( name sstrkfgt.zip size 70221448 crc bb210a64 md5 b7c55f6afabd72c0c10abfdd75efaf4a sha1 253ddef63ac17c85194377af7630c164a93f71fe )
-)
-
-game (
-	name "Space Tactics"
-	year "1981"
-	developer "Sega"
-	rom ( name stactics.zip size 10859 crc 83a36c76 md5 5a830bfe00a59938752b72f4f03ae1f0 sha1 c2fca912be137803213b05d657bc832552bda605 )
-)
-
-game (
 	name "Stadium Hero (Japan)"
 	year "1988"
 	developer "Data East Corporation"
 	rom ( name stadhero.zip size 289444 crc 9dd9770b md5 87b1930a10005ecbc8d138fe3309a031 sha1 6e23674fd3ebee50faca5e14d0b8f10f27500660 )
-)
-
-game (
-	name "Stadium Hero 96 (World, EAJ)"
-	year "1996"
-	developer "Data East Corporation"
-	rom ( name stadhr96.zip size 12607023 crc d300025c md5 5b4c0dc338469451fe38ae34c6dfca69 sha1 4187afcc5d356d1e551c4e0265ea8f11d21a2271 )
-)
-
-game (
-	name "Stadium Hero 96 (Japan, EAD)"
-	year "1996"
-	developer "Data East Corporation"
-	rom ( name stadhr96j.zip size 12606079 crc 2f71cef6 md5 43fe566f3724be8588ca150ada7fc80b sha1 f317b0597d6e29b01741029ca35aaa86b8f90248 )
 )
 
 game (
@@ -50631,14 +37805,14 @@ game (
 	name "Stakes Winner / Stakes Winner - GI kinzen seihae no michi"
 	year "1995"
 	developer "Saurus"
-	rom ( name stakwin.zip size 3368738 crc d4161d14 md5 63b4b948bc07ba54246cfa9dc5cc8c99 sha1 2568d172877b1233cd75eed4d04933c17cb68f1b )
+	rom ( name stakwin.zip size 4715425 crc 5491c972 md5 dd720aa35f01bef6bb60b8017c0d7325 sha1 cd639ad1a5c3fe53c2c89a0466849752ce11c566 )
 )
 
 game (
 	name "Stakes Winner 2"
 	year "1996"
 	developer "Saurus"
-	rom ( name stakwin2.zip size 10793219 crc bce862ea md5 d5ff5abddbe1b5c98309fad256fd9c21 sha1 2bcb7134f4b608535a05935d35e7f204adb3ff04 )
+	rom ( name stakwin2.zip size 12139906 crc f78be5fd md5 ef7ee643ab1b50df41afd046b844e048 sha1 264a6279b314f6ae9fed3b72c30be1958aca499a )
 )
 
 game (
@@ -50691,34 +37865,6 @@ game (
 )
 
 game (
-	name "Star Fighter (v1)"
-	year "1990"
-	developer "SunA"
-	rom ( name starfigh.zip size 340898 crc a6a17bc1 md5 e92157c23c1330eefab749933bf1952e sha1 dcf17594ff75e1fce9aaffef537c59f9175817cb )
-)
-
-game (
-	name "Star Fire 2"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfir2.zip size 17661 crc 13f38fa8 md5 95df966b981be78a0001267fe5a401b3 sha1 f6c5427f155d744231323f68baccd5a98ee705df )
-)
-
-game (
-	name "Star Fire (set 1)"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfire.zip size 16770 crc aa4d7132 md5 d0e073c2251458b52e732b953e8f6f6f sha1 d5af8de0eadb20646ebba68123d5368c456b24ba )
-)
-
-game (
-	name "Star Fire (set 2)"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfirea.zip size 16603 crc 7cc5a0fb md5 a5787f9b2304172427436aa962044c6b sha1 f1e14c3396143fe99d138ddf5f0c7f0413df6e2a )
-)
-
-game (
 	name "Star Force"
 	year "1984"
 	developer "Tehkan"
@@ -50757,21 +37903,21 @@ game (
 	name "Star Gladiator (USA 960627)"
 	year "1996"
 	developer "Capcom"
-	rom ( name starglad.zip size 11078559 crc dd41d7f0 md5 ddf8d33b12d8fdd6271ea3cecfc3f1ce sha1 70a246272260b836b604a1a78112ce8535119ffc )
+	rom ( name starglad.zip size 11204108 crc f6c5cc84 md5 835d21dce7a1f8a00fec5da451c05585 sha1 dd2c1446f38d47165fd141973a80ee700a18e844 )
 )
 
 game (
 	name "Star Gladiator (Japan 960627)"
 	year "1996"
 	developer "Capcom"
-	rom ( name stargladj.zip size 11078521 crc a3c579e8 md5 9181bc62d9e7c79d16c8a416196d1eaf sha1 b3ac08fc3ed4fd2cbbba3c106b8df1b53c39e056 )
+	rom ( name stargladj.zip size 11204070 crc 003c3f62 md5 09c96c79eb71e26b6fc162c332523bc9 sha1 71ebce212586197709de9fd98ab3bf281a84ac2e )
 )
 
 game (
 	name "Star Gladiator 2 (Japan 980316)"
 	year "1998"
 	developer "Capcom"
-	rom ( name stargld2.zip size 24321280 crc 11435fc7 md5 07dc88ae713dad1cfdac3d56b0bd047e sha1 e2e2773504917b9d445f6219ce0cae77ba095011 )
+	rom ( name stargld2.zip size 24459085 crc 939fb9ac md5 27fa778201738d4fa0077785af7ea0fa sha1 f4ab2630f3777b5ed9b3079261b53ff583133fed )
 )
 
 game (
@@ -50827,13 +37973,7 @@ game (
 	name "Star Soldier: Vanishing Earth"
 	year "1998"
 	developer "Hudson / Seta"
-	rom ( name starsldr.zip size 10123058 crc 1dc3f383 md5 ea598d5a13af4599c40eee8255c76e97 sha1 60816c4c66c22b34b67b352f1c5cbc539035f0f2 )
-)
-
-game (
-	name "Starspinner (Dutch/Nederlands)"
-	developer "ACE"
-	rom ( name starspnr.zip size 13787 crc 0265dc5f md5 d9d1ca8bc5aaa3d6d41019fb194cce46 sha1 156acb968b315aef3764194dce5473586dde2c81 )
+	rom ( name starsldr.zip size 10124840 crc 47b50233 md5 1c05e89c65f38f749f2dd6f479cc125c sha1 ad7137c2ea47094366986c39b7d6811e4eac2c35 )
 )
 
 game (
@@ -50848,13 +37988,6 @@ game (
 	year "1982"
 	developer "Sega"
 	rom ( name startrek.zip size 43999 crc 38dbb990 md5 b8dfd04af8317d79e321262d59489d9f sha1 5cff1571744fedde53f659e033805400855b2757 )
-)
-
-game (
-	name "Star Trigon (Japan, STT1 Ver.A)"
-	year "2002"
-	developer "Namco"
-	rom ( name startrgn.zip size 24605302 crc 77f28217 md5 58d60a1294359fe7e4ad87367e2a4ad0 sha1 505cd7f7bf4b6431be947e9f114721f48df8e204 )
 )
 
 game (
@@ -50886,86 +38019,10 @@ game (
 )
 
 game (
-	name "Super Tarzan (Italy, V100I)"
-	developer "IGS / G.F. Gioca"
-	rom ( name starzan.zip size 216465 crc 26eeed10 md5 98948f0a56c4a91c411645c56d104380 sha1 336299615227bdf4708e4ab99a513e6dd1e89ca6 )
-)
-
-game (
-	name "Triv Two"
-	year "1984"
-	developer "Status Games"
-	rom ( name statriv2.zip size 45382 crc 0c078504 md5 19cbb783850310f2f78db5b7637d1615 sha1 2b120b68ab9ddae04be493fb7f5d6034609702b0 )
-)
-
-game (
-	name "Triv Two (Vertical)"
-	year "1985"
-	developer "Status Games"
-	rom ( name statriv2v.zip size 46378 crc 5f74a27a md5 87621c97e475b43e30c6bdb4bbef6d72 sha1 2385d80fc199efac9308a252c52f45ceadb282c9 )
-)
-
-game (
 	name "Triv Four"
 	year "1985"
 	developer "Status Games"
 	rom ( name statriv4.zip size 39111 crc 76f31bee md5 4b8aa025fe9d375e41cc671f1d23cd77 sha1 7bca244ff295b37bbff85cb8bbc9b75bc8ec9d9f )
-)
-
-game (
-	name "Status Black Jack (V1.0c)"
-	year "1981"
-	developer "Status Games"
-	rom ( name statusbj.zip size 3839 crc cdcaf335 md5 ceb1523bfb87b5a0965aaf9a58cb6a24 sha1 7052b932a1e69a1f726aaa78f7413da71b75c8a9 )
-)
-
-game (
-	name "Sega Touring Car Championship (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name stcc.zip size 24075498 crc 51aed035 md5 49839255c076f2c3988fdc6d095a966b sha1 a0d000d8e071fd936897c850ee1a38bff889d7bc )
-)
-
-game (
-	name "Saint Dragon"
-	year "1989"
-	developer "Jaleco"
-	rom ( name stdragon.zip size 1062881 crc 4f83a544 md5 723158a4333a189deea1815d2f2711cc sha1 38fbd713ff16f5b9e20c6823c22e37be76f8e8cc )
-)
-
-game (
-	name "Strip Teaser (Italy, Version 1.22)"
-	year "1993"
-	developer "&lt;unknown&gt;"
-	rom ( name steaser.zip size 1325893 crc 377abe60 md5 3a1ce5dd1e4d21b34d13f6ae3321e85a sha1 f9bfc713bd71b33872af5fbcbe2fa5c0c16a4c1e )
-)
-
-game (
-	name "Steel Talons (rev 2)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltal.zip size 884903 crc eb4e4899 md5 fa774768b7da0e3cc49e6b21d293803d sha1 008617283017d2ac1d8f7342914429d854860ea8 )
-)
-
-game (
-	name "Steel Talons (rev 1)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltal1.zip size 884374 crc be8312ef md5 1ccd53084276f5afc953c8a18b070d1a sha1 b3bd2ea9dae3f13e87e604d0bf95561ce41606f9 )
-)
-
-game (
-	name "Steel Talons (German, rev 2)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltalg.zip size 885021 crc 866be43c md5 7246964729cfd3a81b33eed4c1fe939b sha1 9a50a9a2850a13ec83a4427057a64b5d839d677a )
-)
-
-game (
-	name "Steel Talons (prototype)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltalp.zip size 871102 crc b0b0fc24 md5 64e20c986103503b4f8248cf487ab67a sha1 eb46b2bbdfedb5d73d4ca4247e92d4d26583f246 )
 )
 
 game (
@@ -50980,27 +38037,6 @@ game (
 	year "1980"
 	developer "bootleg (Elettronolo)"
 	rom ( name stellcas.zip size 7965 crc 9bb21220 md5 7999d42a71e7315653755d016016bc49 sha1 d18de15d85bde0326fef01eddbe2dae90ef5d940 )
-)
-
-game (
-	name "Stelle e Cubi (Italy)"
-	year "1998"
-	developer "Sure"
-	rom ( name stellecu.zip size 318450 crc f3e770fb md5 2db5c7c9876efaa30787fcf4dca755df sha1 4fe68d8ab149284586b6fe554b2782e2bf757c3d )
-)
-
-game (
-	name "Stepping 3 Superior"
-	year "1999"
-	developer "Jaleco"
-	rom ( name step3.zip size 13065519 crc 24cc10cb md5 94136029347c1180bbaedff557c446c9 sha1 722f2c1332295ce80cc09e0f255f78da39e0ded3 )
-)
-
-game (
-	name "Stepping Stage Special"
-	year "1999"
-	developer "Jaleco"
-	rom ( name stepstag.zip size 9978154 crc 232b693b md5 c1b50848659c98e5d982dcdf09be7643 sha1 ba41ba4e500a89a4be6d4168a7e7b83af8066ea9 )
 )
 
 game (
@@ -51081,24 +38117,10 @@ game (
 )
 
 game (
-	name "Stocker (3/19/85)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name stocker.zip size 31209 crc a30d8761 md5 32be5430265d8c249cad8aaee37dbb32 sha1 7f644a7791dea5f1de73ed9c839f7a6f389e0d66 )
-)
-
-game (
 	name "Super Toffy"
 	year "1994"
 	developer "Midas (Unico license)"
 	rom ( name stoffy.zip size 90206 crc ee570a87 md5 382ee5be81efba1a58962c90877e3b0b sha1 0419f36244006a8a8efe1d749c778902c9b7904f )
-)
-
-game (
-	name "Stompin'"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name stompin.zip size 73853 crc 86d55893 md5 afa597b863c1a6d4f6af12b00c83007a sha1 2737564d455b1b1005e1d13ca30e8cc247dc3127 )
 )
 
 game (
@@ -51172,13 +38194,6 @@ game (
 )
 
 game (
-	name "Raiga - Strato Fighter (US)"
-	year "1991"
-	developer "Tecmo"
-	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
-)
-
-game (
 	name "Stratovox"
 	year "1980"
 	developer "Sun Electronics (Taito license)"
@@ -51197,41 +38212,6 @@ game (
 	year "1981"
 	developer "Shoei"
 	rom ( name streakng.zip size 14508 crc 2632d722 md5 4fcfb82fc2bdf670f924d2705b9bfd22 sha1 ebd63282f807849413024a1ce2d1d6452d78bda8 )
-)
-
-game (
-	name "Street Games (Revision 4)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg.zip size 624540 crc c98a91ab md5 22f0a4ac3bacd2ce5013eb37d399d1ef sha1 02ad50db5e03d27c74e321a5ce95817497cd1d70 )
-)
-
-game (
-	name "Street Games II (Revision 7C)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg2.zip size 581670 crc 01b261ab md5 fe77adbeec4d60206d3e5e49578a1fa8 sha1 cfa93d09970f83db08a152a4419eebd17e3e73a5 )
-)
-
-game (
-	name "Street Games II (Revision 5)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg2r5.zip size 580787 crc 9a4dea27 md5 fb509177492f2b99d12428cef63cf57b sha1 ec50a201b6b02f3ee1c77904fa786056d91ca68a )
-)
-
-game (
-	name "Street Games (Revision 3)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetgr3.zip size 646869 crc 75233f97 md5 a7de6e9d8e619a17978caf95b9ffd9c6 sha1 84dc4de205649da472cd4141b2c1ed622f925c3e )
-)
-
-game (
-	name "Street Smart (US version 2)"
-	year "1989"
-	developer "SNK"
-	rom ( name streetsm.zip size 1327100 crc 1a2401bc md5 dfa1f446839bb27e10662348477175e2 sha1 3c5643e6c006bfdd2284869f49391cb1918c54a8 )
 )
 
 game (
@@ -51256,13 +38236,6 @@ game (
 )
 
 game (
-	name "Stress Busters (J 981020 V1.000)"
-	year "1998"
-	developer "Sega"
-	rom ( name stress.zip size 23153669 crc 15595504 md5 d9504be054155fedd12695eda81ca15c sha1 fa4027499acd98bc7520b679098647a14081d204 )
-)
-
-game (
 	name "Strafe Bomb"
 	year "1981"
 	developer "bootleg? (Omni)"
@@ -51273,7 +38246,7 @@ game (
 	name "Street Hoop / Street Slam / Dunk Dream"
 	year "1994"
 	developer "Data East Corporation"
-	rom ( name strhoop.zip size 4677660 crc bf471df6 md5 f2b69401d4902280db95cdbf883fd7d0 sha1 9fb3277a05fbfae9c80c0ba8db4015799c599eab )
+	rom ( name strhoop.zip size 6024347 crc 18a62538 md5 3d5867d0c7578416308ecaec93f6342c sha1 d197557c33cf9884147b0673fc0ffbac4d0ac215 )
 )
 
 game (
@@ -51287,14 +38260,14 @@ game (
 	name "Strider 2 (USA 991213)"
 	year "1999"
 	developer "Capcom"
-	rom ( name strider2.zip size 21086473 crc 9bf66f0e md5 bcf62283fd205bcb8c11d0f6286bfde7 sha1 d697ddb2963c5fff6307489660239c985d3e464c )
+	rom ( name strider2.zip size 21224278 crc 59c8c604 md5 adb223bced4acd10827db1f4ff5a6a41 sha1 4b8315748b1b7b31ad621480d8f15894317b536a )
 )
 
 game (
 	name "Strider 2 (Asia 991213)"
 	year "1999"
 	developer "Capcom"
-	rom ( name strider2a.zip size 21086454 crc 54689456 md5 d6239dfd0e7fbdb3c581c3a8456acfb7 sha1 17e4751c0e007111f13b1371f98a69d47cd70ee3 )
+	rom ( name strider2a.zip size 21224259 crc 255a03e6 md5 b33158ef2c37654fe4c184d82bb6349c sha1 88903fb583039c109509804ce6a1ea4d47b94e15 )
 )
 
 game (
@@ -51302,44 +38275,6 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name striderj.zip size 2087531 crc fbd649da md5 7881bcd25f64ca1691b818797bae8764 sha1 65812a75c633336b7cbd804614ff0b9faf79a04d )
-)
-
-game (
-	name "Strider Hiryu (Japan Resale Ver.)"
-	year "1989"
-	developer "Capcom"
-	rom ( name striderjr.zip size 2107966 crc 851bfabe md5 e490a66c794a217144c6179ecfbad368 sha1 bf49d47f496982de35010f3efa9997b25cd4590c )
-)
-
-game (
-	name "Strider (USA, set 2)"
-	year "1989"
-	developer "Capcom"
-	rom ( name striderua.zip size 2103588 crc 461a11cf md5 fd6744f86c61d3b2eb5c455165ebc96f sha1 74696c0847609d2162e423922c0ad7aa6c641042 )
-)
-
-game (
-	name "Strike it Lucky (v0.5)"
-	developer "Barcrest"
-	rom ( name strikeit.zip size 268310 crc 2adecca2 md5 bcfd94e4b8247c4ecd45629d1e916acb sha1 bfc154b21193b4845bf29d7a7a5ebdf1daa2663c )
-)
-
-game (
-	name "Strike it Lucky (v0.53)"
-	developer "Barcrest"
-	rom ( name strikeit2.zip size 268312 crc ea5a1c87 md5 e15a0451cb541d689707eedbdce1d6fc sha1 661968310f6da8e8fa61d4fedef7892ca04e3bb1 )
-)
-
-game (
-	name "Strike it Lucky (v0.53, Datapak)"
-	developer "Barcrest"
-	rom ( name strikeit2d.zip size 268318 crc 8ec65d79 md5 0db5bc7e52fd9f6822744a21fb4f96df sha1 1c4a043599ff0539e5cdf31a517d71c4dfb5c606 )
-)
-
-game (
-	name "Strike it Lucky (v0.5, Datapak)"
-	developer "Barcrest"
-	rom ( name strikeitd.zip size 268312 crc 38ddef0f md5 8ce4a1e4cdb3e0b312db4d5409bef832 sha1 53f892c90b567b9334b31d81b5740de830dc3c8f )
 )
 
 game (
@@ -51385,24 +38320,10 @@ game (
 )
 
 game (
-	name "Street Drivin' (prototype)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name strtdriv.zip size 862616 crc 0d1a5abb md5 df2f674112514b205e3bae9956b3081f sha1 b0548b962dab41f799eb1e06ddbdc6f3300ad7fa )
-)
-
-game (
 	name "Street Heat - Cardinal Amusements"
 	year "1985"
 	developer "Epos Corporation"
 	rom ( name strtheat.zip size 17260 crc 67eaa4e9 md5 03197a772c2d9246f25716c34defe1ab sha1 f270133f175330fa83ec551218221d7c48e4b736 )
-)
-
-game (
-	name "Super Trivia Master"
-	year "1986"
-	developer "Enerdyne Technologies Inc."
-	rom ( name strvmstr.zip size 177612 crc 9c2661e2 md5 03aae55924cda1799ff2b1ea897f2f24 sha1 4c7872f1b3c6ad18eec60529bfd865eddc1a3f0b )
 )
 
 game (
@@ -51518,31 +38439,10 @@ game (
 )
 
 game (
-	name "Idol Janshi Suchie-Pai 3 (JPN)"
-	year "1999"
-	developer "Jaleco"
-	rom ( name suchie3.zip size 97944828 crc 6e70a4d7 md5 afd008911fe674dbdac09842e695420d sha1 b77aef2626100b9c5e170ec6c1d811a2dc492f06 )
-)
-
-game (
-	name "Idol Janshi Suchie-Pai Special (Japan)"
-	year "1993"
-	developer "Jaleco"
-	rom ( name suchipi.zip size 1947280 crc 4045e520 md5 c2b8676b68ea4fb23c893aec2942d32e sha1 e03450ff802dc0d85b3e548b43b70ef7251193f0 )
-)
-
-game (
 	name "Suikoenbu / Outlaws of the Lost Dynasty (JUETL 950314 V2.001)"
 	year "1995"
 	developer "Data East"
-	rom ( name suikoenb.zip size 15724636 crc d4dd674a md5 45f6de12117b835b70b0067932f02dee sha1 28aa2244c5c81ceab696b325879617f490ba159e )
-)
-
-game (
-	name "Quiz and Variety Suku Suku Inufuku 2 (IN2 Ver. A)"
-	year "2004"
-	developer "Namco"
-	rom ( name sukuinuf.zip size 1687525 crc 4c51c19f md5 7fe561e730fd103f909b35ae1402092a sha1 fd640fcaeaf4df7f1fa48e66402d18d6a923071f )
+	rom ( name suikoenb.zip size 18423857 crc e1383e33 md5 a465effb692d52e18efbda4f5c3849b6 sha1 3e98b3a38f9d5db88b355d3095d4c3dd37a9601c )
 )
 
 game (
@@ -51581,13 +38481,6 @@ game (
 )
 
 game (
-	name "Super Crash (bootleg of Head On)"
-	year "1979"
-	developer "bootleg"
-	rom ( name supcrash.zip size 6327 crc 4eaf919a md5 ab137833bf7494b05071c79251406016 sha1 c64bd5b06d0f762f7a187cb49b77fe635e981a3d )
-)
-
-game (
 	name "Super Draw Poker (set 1)"
 	year "1983"
 	developer "Valadon Automation (Stern Electronics license)"
@@ -51623,13 +38516,6 @@ game (
 )
 
 game (
-	name "Agent Super Bond (Scobra Hardware)"
-	year "1985"
-	developer "Signatron USA"
-	rom ( name superbon.zip size 20193 crc 56f1e60e md5 b825b187495ab8d327159e5d6a4f66f4 sha1 7ce5066f30c5a5a07f329376dd863408704e24fa )
-)
-
-game (
 	name "Super Bug"
 	year "1977"
 	developer "Atari"
@@ -51651,27 +38537,6 @@ game (
 )
 
 game (
-	name "Super Don Quix-ote (Long Scenes)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdq.zip size 16239 crc 9962bb8e md5 baf73150b3613a2adb0e418a10eb2c22 sha1 ee76681e720fd91ae3949a585661ac3384b10091 )
-)
-
-game (
-	name "Super Don Quix-ote (Short Scenes, Alt)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdqa.zip size 16272 crc 2cf9bc11 md5 7fdd4ca44673cba5c62a811c54900292 sha1 f5356fdac20920e32afacc6ea7ce96b2cf6dee74 )
-)
-
-game (
-	name "Super Don Quix-ote (Short Scenes)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdqs.zip size 16262 crc 9e8b5ef0 md5 78aa67d03b463b1fd9d93503ab2c8b30 sha1 dd18c597676b2be0d6bb7c4367471e13b0ae6d79 )
-)
-
-game (
 	name "Super Galaxians (galaxiana hack)"
 	year "1979"
 	developer "hack"
@@ -51683,13 +38548,6 @@ game (
 	year "1996"
 	developer "&lt;unknown&gt;"
 	rom ( name supergm3.zip size 2052131 crc 212784b6 md5 8eff17b9802472a4c321e7e90af7a99d sha1 3988b52130dcbb4a07ed7f463632f386ce1a5045 )
-)
-
-game (
-	name "Super GX"
-	year "1980"
-	developer "Nichibutsu"
-	rom ( name supergx.zip size 11192 crc b11532f1 md5 5ef0fdb261044c95e7a0d543e5cf0eec sha1 b0837b9c7ef9e67f7c2280f9927a4517e95ad1fb )
 )
 
 game (
@@ -51730,7 +38588,7 @@ game (
 	name "The Super Spy"
 	year "1990"
 	developer "SNK"
-	rom ( name superspy.zip size 3294106 crc c8e1b772 md5 a48b470728a61cc6032f4a449c968f6e sha1 510d6e402c9531f4ef1a6f2047c854e79ec71677 )
+	rom ( name superspy.zip size 4640793 crc 60ac7b20 md5 a5d02db4ef4da44913c4df2388dbf33f sha1 cdb006854cf2ab0b80189bef603735ff19df6cad )
 )
 
 game (
@@ -51738,13 +38596,6 @@ game (
 	year "1981"
 	developer "Video Games GmbH"
 	rom ( name supertnk.zip size 13410 crc be830d44 md5 dad61ecb6035a5c147d6c1e8064abcac sha1 54ae328db73348affdd055c55c460dbde9708870 )
-)
-
-game (
-	name "Super Triv II"
-	year "1986"
-	developer "Status Games"
-	rom ( name supertr2.zip size 143384 crc 319fb964 md5 12e9453390bf5f76ac1a321cb7f689ab sha1 2d8660d9b2054181ad4c4be19056019c6648312b )
 )
 
 game (
@@ -51769,12 +38620,6 @@ game (
 )
 
 game (
-	name "Super Jolly"
-	developer "&lt;unknown&gt;"
-	rom ( name supjolly.zip size 308864 crc 4235325c md5 0ac34bbd8928e753d4c30f88cf894bf8 sha1 364198b5abc24240abbddb5bdb6dbf5b9eb6c52b )
-)
-
-game (
 	name "Super Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 4.0 / 990518)"
 	year "1999"
 	developer "Omega System"
@@ -51786,13 +38631,6 @@ game (
 	year "1994"
 	developer "Comad &amp; New Japan System"
 	rom ( name supmodel.zip size 3328217 crc 9fac55f2 md5 6d3d5e855c96a246fb4b3d88515b7873 sha1 04ca6ba4cae140d93a035bb987d0cda36ac6cd4a )
-)
-
-game (
-	name "Super Nudger II (Version 5.21)"
-	year "1989"
-	developer "Coinmaster"
-	rom ( name supnudg2.zip size 571146 crc 54427cec md5 5d7e0497f5a759c0e7a86e113d55429f sha1 9a9f81aeb0e3148ed16042c6a258293b89746932 )
 )
 
 game (
@@ -51870,34 +38708,6 @@ game (
 	year "1986"
 	developer "Nintendo"
 	rom ( name suprmrioa.zip size 37111 crc 2bdfe232 md5 dd46a0aa4ef6ebe64a5c0d3e7be06ae7 sha1 11a1df32c5db2093ced49fc01fac4e928b57c6f5 )
-)
-
-game (
-	name "Vs. Super Mario Bros. (bootleg with Z80, set 1)"
-	year "1986"
-	developer "bootleg"
-	rom ( name suprmriobl.zip size 43885 crc 12ae5809 md5 29c36294fc671d2c995aca082112e45c sha1 bc3a232a4f1c84750b855063f7b3c34223758afd )
-)
-
-game (
-	name "Vs. Super Mario Bros. (bootleg with Z80, set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name suprmriobl2.zip size 42710 crc 3773add0 md5 e91ddafc0bcb1f8ca00739e59ec2718a sha1 090eeefa41bb9cc8eaa92d88f915fec69489b287 )
-)
-
-game (
-	name "Super Poker"
-	year "1987"
-	developer "Greyhound Electronics"
-	rom ( name suprpokr.zip size 19252 crc a0507132 md5 4780436f8210edd78fe634619b82e14e sha1 172248ace518f00bf3cf303e761d2f0c531241fb )
-)
-
-game (
-	name "Super Pool (9743 rev.01)"
-	year "1997"
-	developer "ABM Games"
-	rom ( name suprpool.zip size 327138 crc 351d4e9b md5 dc59f2ccea324f24c04ef301ca5435aa sha1 4799bfdeb32d44700d9546acbb7a1114b5745f91 )
 )
 
 game (
@@ -51995,7 +38805,7 @@ game (
 	name "Susume! Taisen Puzzle-Dama (GV027 Japan 1.20)"
 	year "1996"
 	developer "Konami"
-	rom ( name susume.zip size 238 crc ce291623 md5 8e2dd4fecd6b3b7a0e62c74d749497c3 sha1 73af338351778c70735732649ebee1bca6f379a8 )
+	rom ( name susume.zip size 81607 crc cfc9a841 md5 a22118c941b3b318767f9ffbfabbd3ed sha1 58040c77d1fa7a61a889f6cae950e304e1b07fc4 )
 )
 
 game (
@@ -52013,20 +38823,6 @@ game (
 )
 
 game (
-	name "Suzuka 8 Hours (World)"
-	year "1992"
-	developer "Namco"
-	rom ( name suzuka8h.zip size 2189192 crc 939be6f9 md5 4ee129d4893d4bb9168d1d55fa590c19 sha1 01a7738fb337cd90a417891fb03174eb8ac73118 )
-)
-
-game (
-	name "Suzuka 8 Hours (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name suzuka8hj.zip size 2189451 crc af16442c md5 73df94ab838b7b44b616214314ef5d96 sha1 492df454f7148f28f399a7dfbf8fae7abfa5ba08 )
-)
-
-game (
 	name "Watashiha Suzumechan (Japan)"
 	year "1986"
 	developer "Dyna Electronics"
@@ -52037,14 +38833,14 @@ game (
 	name "SNK vs. Capcom - SVC Chaos"
 	year "2003"
 	developer "SNK Playmore"
-	rom ( name svc.zip size 83260239 crc 00d2c9f8 md5 339241b197edbc04a8d8736d5b921ae2 sha1 7d0e928ea894d07a3ea3d9f8be4e00d571a92c13 )
+	rom ( name svc.zip size 84606926 crc 795af77f md5 928c0e2e1b9bda419e9654ebdab39052 sha1 ff3733afb357c1551fef2b352e9f3c56f8657a4b )
 )
 
 game (
 	name "SNK vs. Capcom - SVC Chaos (bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name svcboot.zip size 42743049 crc 9ac430f0 md5 8a2fad33455927a1d855da8bb7b61e3d sha1 8d573bdafea328ac1d97a051c7a862fdc9231eab )
+	rom ( name svcboot.zip size 44089736 crc 77ca5089 md5 6ccbb2ddbbd754bc0b62b7da99801db9 sha1 bb73a2af1e328c2e8b98eec3834217ab293292ef )
 )
 
 game (
@@ -52065,21 +38861,21 @@ game (
 	name "SNK vs. Capcom - SVC Chaos Plus (bootleg set 1)"
 	year "2003"
 	developer "bootleg"
-	rom ( name svcplus.zip size 43048225 crc 12c50b03 md5 c929309ce5a9ac9e2231f6a6002d5213 sha1 73ab909d17eafbd04216c724d6cb8e9ba773c277 )
+	rom ( name svcplus.zip size 44394912 crc c8a05def md5 d818e31ad7beec559b78fe28787fa7e2 sha1 72747e722f3aa8fdd743ace35ae79979e10c174a )
 )
 
 game (
 	name "SNK vs. Capcom - SVC Chaos Plus (bootleg set 2)"
 	year "2003"
 	developer "bootleg"
-	rom ( name svcplusa.zip size 41522010 crc f74af4e3 md5 fef804465c857fac77fdcea3fef576ca sha1 d39d48bb29fcdf411855f23e28f706a8f3937825 )
+	rom ( name svcplusa.zip size 42868697 crc ce400f8c md5 2c8b3b16cad5a9e9b39ca7a6dc3895bd sha1 2d5d11005e366960fa06cf0d85198c98f502d4b3 )
 )
 
 game (
 	name "SNK vs. Capcom - SVC Chaos Super Plus (bootleg)"
 	year "2003"
 	developer "bootleg"
-	rom ( name svcsplus.zip size 43343692 crc 91eb6989 md5 38eacde1adc1cd2ae1c95ed14da6ba8c sha1 4919970fb5620d0b90475d3357407c1a95c30edf )
+	rom ( name svcsplus.zip size 44690379 crc 7e5158c6 md5 0b20cc038bee04d9d1fcbd17412d50fa sha1 ff661e12ac72195a3b6cc4eac32416071b316da1 )
 )
 
 game (
@@ -52087,13 +38883,6 @@ game (
 	year "1994"
 	developer "Sega"
 	rom ( name svf.zip size 7544563 crc 04752607 md5 00b38c43abbfce0cda827391b1faf28d sha1 7f09300640fd7062d77bd020e1a9cacadc5674d5 )
-)
-
-game (
-	name "S.V.G. - Spectral vs Generation (ver. 200)"
-	year "2005"
-	developer "IGS"
-	rom ( name svg.zip size 26388674 crc 54c784f8 md5 43fb3b8632e85494b56fee00e26d2605 sha1 a17125a7f021f459770122a7f62502b7cf9c9c74 )
 )
 
 game (
@@ -52132,13 +38921,6 @@ game (
 )
 
 game (
-	name "Star Wars Arcade"
-	year "1993"
-	developer "Sega"
-	rom ( name swa.zip size 15194721 crc 931317a1 md5 cb8b4ab97e58b34d4e7ae701566f9042 sha1 c5d178ac81cd81e2ef372d7f668ad67f60af559f )
-)
-
-game (
 	name "Swarm (bootleg?)"
 	year "1979"
 	developer "bootleg? (Subelectro)"
@@ -52171,13 +38953,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name swcourtj.zip size 1508122 crc edd47e98 md5 f4e349d4963febc76c5469273708ae0c sha1 4b056d9927cf3cc826958bbe92295af56f1766aa )
-)
-
-game (
-	name "Sweet Gal (Japan 850510 SWG 1-02)"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name sweetgal.zip size 97709 crc 36601e92 md5 052d98ac235ac017a5aee0f235447a5f sha1 231e9a5ec987b75630c2aaa9a4da91a8faec1a0c )
 )
 
 game (
@@ -52227,20 +39002,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name sws.zip size 1630675 crc bb788d75 md5 35597d7802e75e881bb3eafa8897a5f5 sha1 f658652300e2156500cb3c2e2c0bd8bea41be68a )
-)
-
-game (
-	name "Super World Stadium 2000 (Japan, SS01/VER.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name sws2000.zip size 26226717 crc 304e2139 md5 725c2f7014140140a2373f49aa9674e3 sha1 36fb5ac674630c5e74bd7b2d858b75c3c0083026 )
-)
-
-game (
-	name "Super World Stadium 2001 (Japan, SS11/VER.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name sws2001.zip size 33098538 crc 86fc0c09 md5 b2ee22ee3d6a1e6bf1845f334853bb2f sha1 48744ec13fd8463ad32f9f92e4032728c57ad05d )
 )
 
 game (
@@ -52300,31 +39061,10 @@ game (
 )
 
 game (
-	name "Sweet Hearts II (C - 07/09/95, Venezuela version)"
-	year "1995"
-	developer "Aristocrat"
-	rom ( name swthrt2v.zip size 415733 crc c9504ac3 md5 4155d55af7c43fd2ade6a599f106e836 sha1 93bb8fcf1fd51457d76dfc2b651a1f2e607d3a9d )
-)
-
-game (
 	name "Sweet Hearts II - 1VXFC5461 (New Zealand)"
 	year "1998"
 	developer "Aristocrat"
 	rom ( name swtht2nz.zip size 51405 crc b6957ec6 md5 2e28511976743497838ae187c0b0c235 sha1 bc032a443ba302461d85e7497eeb905072d77165 )
-)
-
-game (
-	name "Star Wars Trilogy (Revision A)"
-	year "1998"
-	developer "Sega / LucasArts"
-	rom ( name swtrilgy.zip size 71464436 crc e2131bf1 md5 d548141066e335e0d5f6af4bed9d4a50 sha1 38e00254424ff079bd01aa94bc4234d6b3e46694 )
-)
-
-game (
-	name "Star Wars Trilogy"
-	year "1998"
-	developer "Sega / LucasArts"
-	rom ( name swtrilgya.zip size 71464245 crc 3efcc10b md5 1c0b1c3a407cff8e568ffde1fcd381b0 sha1 0afec1ac15ef6f120ff68189ea417fe5c86d7be1 )
 )
 
 game (
@@ -52398,20 +39138,6 @@ game (
 )
 
 game (
-	name "Taiko No Tatsujin 10 (T101001-NA-A)"
-	year "2007"
-	developer "Namco"
-	rom ( name taiko10.zip size 1532270 crc 344d7ead md5 bbd9d7101eeaa207f1394e8405a1d305 sha1 204931bd64ad71794c70a4a0aa232b0c3f101f13 )
-)
-
-game (
-	name "Taiko No Tatsujin 9 (TK91001-NA-A)"
-	year "2006"
-	developer "Namco"
-	rom ( name taiko9.zip size 1527101 crc 320cb84f md5 a0c8675d983efa09456a055ab2ba7cb4 sha1 aeca40544119c30904fde526b2625658643989a6 )
-)
-
-game (
 	name "Tail to Nose - Great Championship"
 	year "1989"
 	developer "V-System Co."
@@ -52430,13 +39156,6 @@ game (
 	year "1988"
 	developer "Miki Syouji"
 	rom ( name taiwanmb.zip size 290188 crc cbbcc39c md5 6f3474496a71c85add3c93ffb5849f2d sha1 0b58ff536ce5d362621dee906dd96d815c40d114 )
-)
-
-game (
-	name "Noukone Puzzle Takoron (GDL-0042)"
-	year "2006"
-	developer "Compile"
-	rom ( name takoron.zip size 1195 crc 6a8e062d md5 271f42a9ac4234ef577b94e7b9d0a2cf sha1 a1ca7f80b0f0708077d7b391f6c55a86b382de48 )
 )
 
 game (
@@ -52461,45 +39180,10 @@ game (
 )
 
 game (
-	name "Tank 8 (set 2)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8a.zip size 3256 crc cd781a5f md5 5fd5f89f2d56e87550a98e7ffb6bd9ff sha1 6ac667f742ad2821ac2310a88a213b5a32ec6c01 )
-)
-
-game (
-	name "Tank 8 (set 3)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8b.zip size 3228 crc 2d637ef5 md5 0b5b636c8bb187f0682bc6d798d5b203 sha1 3ed7cc5c9b9f8a111d2d1c1ec4372ebe9f9da28e )
-)
-
-game (
-	name "Tank 8 (set 4)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8c.zip size 4697 crc 24117a57 md5 192f895af17b42a54c1597fc018d9b3a sha1 dc33576930bab5fac0ad1d8653f441d5b5defcef )
-)
-
-game (
-	name "Tank 8 (set 5)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8d.zip size 4860 crc a99d4f98 md5 8aadeec7a278a238347a8d00f87820de sha1 fd421d8c36b6e61917566d8e452338b9475f84eb )
-)
-
-game (
 	name "Tank Battle (prototype rev. 4/21/92)"
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name tankbatl.zip size 1469310 crc 19d31524 md5 b77cf3ec5384cb1be990aa3117dc887f sha1 14ef2a8a83b9c458fa5807d9da1121205a19d524 )
-)
-
-game (
-	name "Tank Battalion"
-	year "1980"
-	developer "Namco"
-	rom ( name tankbatt.zip size 8337 crc 00986b0a md5 f8b6eb6c292289525fdd0165de9fea7a sha1 0d7893c13f8f6ad6759a385e84538e48add6c094 )
 )
 
 game (
@@ -52608,38 +39292,6 @@ game (
 )
 
 game (
-	name "Target Hits (ver 1.1)"
-	year "1994"
-	developer "Gaelco"
-	rom ( name targeth.zip size 2095194 crc 30c1bd0c md5 ea3f802945c01b465a3b38d76d1c6161 sha1 50f6ef70fb906e6af3218fe2d55f1dab4aef60b9 )
-)
-
-game (
-	name "Target Hits (ver 1.0)"
-	year "1994"
-	developer "Gaelco"
-	rom ( name targetha.zip size 2070108 crc 4c86ea1b md5 c27c9ec1eff17e2733b1ddac3ed552b4 sha1 02122744e961d92f16a0c8a3f974dff8ec0b1e61 )
-)
-
-game (
-	name "Tarzan (V109C)"
-	developer "IGS"
-	rom ( name tarzan.zip size 307845 crc a07f7da1 md5 e529f271092e6915d7b28e1cd8c24ed6 sha1 0cda4697109ee2aeb4d28ff16de34db2cd45a6fb )
-)
-
-game (
-	name "Tarzan (V107)"
-	developer "IGS"
-	rom ( name tarzana.zip size 232134 crc becb25bd md5 0ca14c30559269dafba9d0388e904524 sha1 0296a5e56507342dc22b99463cdaa89df995f098 )
-)
-
-game (
-	name "Time Attacker"
-	developer "Shonan"
-	rom ( name tattack.zip size 4017 crc 4cd0b725 md5 a985e24add955cf3a5065b86f42d694f sha1 25a08ea5bd16b683028c61a54b3124a22eecf0b3 )
-)
-
-game (
 	name "Tattoo Assassins (US prototype)"
 	year "1994"
 	developer "Data East Pinball"
@@ -52685,7 +39337,7 @@ game (
 	name "The Block Kuzushi (Japan)"
 	year "2000"
 	developer "Tamsoft / D3 Publisher"
-	rom ( name tblkkuzu.zip size 2290265 crc c31ec837 md5 2167ba8c232b51d0696b35326bc395c8 sha1 b6f5f1da77fd356b573013a7eae4b54bc9caf6d7 )
+	rom ( name tblkkuzu.zip size 2428717 crc b74efde5 md5 bbcfd816f84dc038593ec06cf1da10cd sha1 b2b49612d5a3c04b13d37845e88ba55d06dfad90 )
 )
 
 game (
@@ -52706,7 +39358,7 @@ game (
 	name "Twin Bee Yahhoo! (ver JAA)"
 	year "1995"
 	developer "Konami"
-	rom ( name tbyahhoo.zip size 6315242 crc 0afcc01f md5 761c36336f7592d2f284adc9cd474982 sha1 9338069d8665f80c97f97a01ed036984c88ddbc6 )
+	rom ( name tbyahhoo.zip size 6323932 crc 0d032166 md5 c7ebf742ce01a3e59f256b9fec0bfefe sha1 1b88bf729643b584ff26c34eed6d8c7c845e9684 )
 )
 
 game (
@@ -52721,13 +39373,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name tceptor2.zip size 319296 crc 91d070e3 md5 56ae7f0cce6fa65d7887b2236ecd16b7 sha1 c684fc4e110edb3ef4b84262ab74e759209fd2ab )
-)
-
-game (
-	name "Taiwan Chess Legend"
-	year "1995"
-	developer "Uniwang"
-	rom ( name tcl.zip size 132675 crc be1ae636 md5 9a8e36ec0464bfd4343785ab2f57d228 sha1 86eeb9cbb5b113bdf94ded13a44173981a2f42a7 )
 )
 
 game (
@@ -52808,13 +39453,6 @@ game (
 )
 
 game (
-	name "Puzzle Bobble (Italian Gambling Game)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name te0144.zip size 427074 crc 72934a64 md5 9531ff4654e644743f725d2356d9b199 sha1 02706a77c65aa7685cc3b3a362c0c8bbe3bfbba4 )
-)
-
-game (
 	name "John Elway's Team Quarterback (set 1)"
 	year "1988"
 	developer "Leland Corp."
@@ -52829,31 +39467,24 @@ game (
 )
 
 game (
-	name "Technical Bowling (J 971212 V1.000)"
-	year "1997"
-	developer "Sega"
-	rom ( name techbowl.zip size 1421281 crc 16c1e589 md5 23ddeaa3a6db839e6d5df75a085bbbba sha1 1ca021f391c7e09c96331df553e97f6bc6a453ad )
-)
-
-game (
 	name "Tech Romancer (Euro 980914)"
 	year "1998"
 	developer "Capcom"
-	rom ( name techromn.zip size 39058513 crc 32db0fb1 md5 af3ac4d7161133220fdff392f5c56312 sha1 ed3aa7855604325fb669392cce566da4a82ea558 )
+	rom ( name techromn.zip size 39196318 crc 671e50a3 md5 70b1944d59a69768905ece3f19db75aa sha1 1b87983254e434f419503a815764d55e595af9fe )
 )
 
 game (
 	name "Tech Romancer (USA 980914)"
 	year "1998"
 	developer "Capcom"
-	rom ( name techromnu.zip size 39058544 crc ace5a361 md5 825e90b82ef72e3a7ea4a5e8eeddf1c7 sha1 e36bfe04b2cc3586a74bf9132bf4d52f52d4b6d2 )
+	rom ( name techromnu.zip size 39196349 crc 725d62dd md5 45673e807b101dd22b79c3f1481877c0 sha1 5c4b9af3b789910c17ed96db081d9bf0bec1d505 )
 )
 
 game (
 	name "Tecmo World Cup Millennium (Japan)"
 	year "2000"
 	developer "Tecmo"
-	rom ( name tecmowcm.zip size 5225508 crc 5ba1cc30 md5 351d815c8c1cfca16be38bce07d85224 sha1 6ae689c5ffafd2781c8f5c7f8962d70850e6cfc9 )
+	rom ( name tecmowcm.zip size 5363960 crc 5af8715e md5 94e6bae4f966036ac4b08a8bc33b2426 sha1 3cc576c322c55b2aeef57bcb9077863647ca8583 )
 )
 
 game (
@@ -52896,20 +39527,6 @@ game (
 	year "1985"
 	developer "Tehkan"
 	rom ( name tehkanwcb.zip size 107679 crc ece301eb md5 a33e4a5bc237d22a2fd105b07e737ead sha1 6f5c58b17a195741b40c375434c25e9d108f72aa )
-)
-
-game (
-	name "Tehkan World Cup (set 3, bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name tehkanwcc.zip size 107538 crc 1b754658 md5 d59994d56b5c641385f8e9f10d96fa4b sha1 90a55fd704f9fea98485205c06b4a50f18d72b68 )
-)
-
-game (
-	name "Teki Paki"
-	year "1991"
-	developer "Toaplan"
-	rom ( name tekipaki.zip size 322362 crc d97ed91c md5 a4694fc8d623725d2538de14d00d551a sha1 e7c3b77db78ff64ec8a56c2be79f2445e1daa3e6 )
 )
 
 game (
@@ -52969,34 +39586,6 @@ game (
 )
 
 game (
-	name "Tekken 4 (TEF3 Ver. C)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4.zip size 3150691 crc 9687dcf4 md5 133ea8671e5e29946b83aadb9e5ca5c8 sha1 589d4c6c8f9a6d3e8c93c0c1b507a6d18d7f8ec8 )
-)
-
-game (
-	name "Tekken 4 (TEF2 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4a.zip size 3150921 crc eb814303 md5 b44e9d51086e27ada14b4fcdf85ad513 sha1 563834ac6a7487b68c303be8a40404e4cce93fd6 )
-)
-
-game (
-	name "Tekken 4 (TEF1 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4b.zip size 3148032 crc b9b2af7e md5 9feedb0f2b9f431392a644f0e41cb381 sha1 8ec335f89ed18b100d60112d888b8930d513f58e )
-)
-
-game (
-	name "Tekken 5.1 (TE51 Ver. B)"
-	year "2005"
-	developer "Namco"
-	rom ( name tekken51.zip size 5769717 crc 047ebc9b md5 b372516ab839015505398dd65d7dd4ba sha1 5a46b41198fd780d1755eff6cb883f4402f16228 )
-)
-
-game (
 	name "Tekken (TE2/VER.C)"
 	year "1994"
 	developer "Namco"
@@ -53032,24 +39621,10 @@ game (
 )
 
 game (
-	name "Tekken Tag Tournament (Japan, TEG1/VER.B)"
-	year "1999"
-	developer "Namco"
-	rom ( name tektagtb.zip size 58411594 crc e80ae2d8 md5 5fe733d7a084fde56eac1fc822a46bd5 sha1 2fad2b227b4d4662ffc5a29248616b21d1ac515c )
-)
-
-game (
-	name "Tekken Tag Tournament (Japan, TEG1/VER.A3)"
-	year "1999"
-	developer "Namco"
-	rom ( name tektagtc.zip size 58408976 crc 52b8c494 md5 7e1fdf052ad391b3e07de41fa4849230 sha1 08dcdfc75407b93538be0d3ea07cd57ea5dea019 )
-)
-
-game (
 	name "Tel Jan"
 	year "1999"
 	developer "Electro Design"
-	rom ( name teljan.zip size 10751301 crc 0aaadae0 md5 1bf581b9236772761e97cd04f6494a1e sha1 e3495e626a81175acc684889a58bdf8487c0524f )
+	rom ( name teljan.zip size 10783322 crc 200ab260 md5 0853160933d72b03ef0716f8037a3b15 sha1 4faf6e79ddcc41c6271f8661c951994e54956ece )
 )
 
 game (
@@ -53102,59 +39677,10 @@ game (
 )
 
 game (
-	name "Tengai (World)"
-	year "1996"
-	developer "Psikyo"
-	rom ( name tengai.zip size 6500431 crc 99b98f75 md5 91470b32675430f13f0892416163e6e8 sha1 93d82339ea7ce82efca9903c1275e477d57ab41c )
-)
-
-game (
-	name "Sengoku Blade: Sengoku Ace Episode II / Tengai"
-	year "1996"
-	developer "Psikyo"
-	rom ( name tengaij.zip size 6500427 crc da750992 md5 b9fe4e0616d95ca26ab6e120c45d33fc sha1 b88aab6d257efceabdf4ca12773f950ccc8f6471 )
-)
-
-game (
-	name "Mahjong Tenkaigen"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkai.zip size 659684 crc fcec3b2f md5 3641deb99edda5b8ca3248f2777594ba sha1 8e04089a44b491a9c0101d647621737cf9aefe51 )
-)
-
-game (
-	name "Mahjong Tenkaigen Part 2 (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tenkai2b.zip size 930387 crc e9407a17 md5 419cafdf305b24ba815b3926b2ef5a61 sha1 17369508d2e1695f35acbc18829f3a4c260e9929 )
-)
-
-game (
 	name "Mahjong Tenkaigen (bootleg b)"
 	year "1991"
 	developer "bootleg"
 	rom ( name tenkaibb.zip size 945247 crc 66dd10f2 md5 7af84111bb794a1342469f0cbc3842f2 sha1 4f7ce77d2efb320068fd16f5fe2946267388022c )
-)
-
-game (
-	name "Mahjong Tenkaigen (bootleg c)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tenkaicb.zip size 425730 crc 92e09b3e md5 4372b6f55e8b2a7dd4aade1d70e6bd39 sha1 2ad29d28b52a6be2d5c7ae4115356a183d2164a7 )
-)
-
-game (
-	name "Mahjong Tenkaigen (set 1)"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkaid.zip size 1043722 crc e7ad75d0 md5 56c418e99d6999ee2a13652f6530c1c5 sha1 8e40a04eb74b176ca65752a510d4aab0a98805a6 )
-)
-
-game (
-	name "Mahjong Tenkaigen (set 2)"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkaie.zip size 927266 crc 53e09f7b md5 b0015989f158f9b622a23295eb00fbcf sha1 8ade721603ec3ebceb2bd54430889f6bee8909b5 )
 )
 
 game (
@@ -53169,20 +39695,6 @@ game (
 	year "1998"
 	developer "Namco"
 	rom ( name tenkomorj.zip size 31638240 crc c965e6cb md5 3a2a75fc6d5f539a2646509b9f39707d sha1 5abade24abeea6f9c01aff3539c59236c3b030d8 )
-)
-
-game (
-	name "Ten Pin Deluxe"
-	year "1983"
-	developer "Bally Midway"
-	rom ( name tenpindx.zip size 60713 crc 7ccbae0e md5 13b38503cfe9d753aec62aa5b09e19cf sha1 e4ed733279fae46d0f7fb27f255f8fe4d1a188bf )
-)
-
-game (
-	name "Ten Spot"
-	year "1982"
-	developer "Thomas Automatics"
-	rom ( name tenspot.zip size 118486 crc cee814c3 md5 e3cec0dfc2ab906bd8c27369bda17abc sha1 b38f3e349425e04d3554c41dbdb63f64c7db6d3b )
 )
 
 game (
@@ -53204,20 +39716,6 @@ game (
 	year "1988"
 	developer "JPM"
 	rom ( name tenup3.zip size 331711 crc d065334f md5 e34b2551c88011d2bdbe37358f44f6bb sha1 674f2021511cf64b955fd45f96d61ca3fc8a01c9 )
-)
-
-game (
-	name "Teraburst (1998/07/17 ver UEL)"
-	year "1998"
-	developer "Konami"
-	rom ( name terabrst.zip size 15214788 crc 49abd3ac md5 190527979c7479440236efb1e3832541 sha1 361216558a61f8ad564826cc38c56ce4dcb4700d )
-)
-
-game (
-	name "Teraburst (1998/02/25 ver AAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name terabrsta.zip size 15214404 crc cb292778 md5 770d41a0122b5806fad3c51beb443640 sha1 c3b15891faa5526c88d42075ce024a70d0780a3e )
 )
 
 game (
@@ -53270,41 +39768,6 @@ game (
 )
 
 game (
-	name "Terra Force (set 1)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name terraf.zip size 377395 crc 0356dd12 md5 af2370e45dd017c433317cae0d68acf0 sha1 26d9cb009aa1a522ac29f48f10f0d858fc5d2a98 )
-)
-
-game (
-	name "Terra Force (set 2)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name terrafa.zip size 376917 crc c539c2ef md5 a33b058cedbfab72fb75652bb48719a0 sha1 203539232e41e7c1552622cbe202932cf28e7e4c )
-)
-
-game (
-	name "Terra Force (bootleg with additional Z80)"
-	year "1987"
-	developer "bootleg"
-	rom ( name terrafb.zip size 376039 crc f8b1683e md5 0d98df9775f710bc059c48aafde2fd0f sha1 cf4a7dc34cf5e0009a9c1514cbaf27d2557e3dd4 )
-)
-
-game (
-	name "Terra Force (US)"
-	year "1987"
-	developer "Nichibutsu USA"
-	rom ( name terrafu.zip size 376593 crc 72e792b0 md5 262309c6ed9e3004dbfff3c15b96ed66 sha1 a2a7d8fd7b6b912e8941136756f534a76ad7b424 )
-)
-
-game (
-	name "Tetris Kiwamemichi (GDL-0020)"
-	year "2004"
-	developer "Success"
-	rom ( name tetkiwam.zip size 1194 crc f32d0888 md5 05cc615496369c0959951477dc864991 sha1 e5b6b639b6987c2f778abc7af29cbaa658a8091c )
-)
-
-game (
 	name "Tetris (set 4, Japan, System 16A, FD1094 317-0093)"
 	year "1988"
 	developer "Sega"
@@ -53337,19 +39800,6 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name tetrisbl.zip size 157595 crc 73a78a78 md5 47ef06ec0038db552c7c656b5e6cf482 sha1 7854c81dc8cea10631a549bdc5017db779c766f9 )
-)
-
-game (
-	name "Tetris (bootleg of Mirrorsoft PC-XT Tetris version)"
-	developer "bootleg"
-	rom ( name tetriskr.zip size 184669 crc 8ad65f46 md5 70eb615ec5205fb52b7bbbf2d567bc1f sha1 a2c30b3a63e1101547da97213ebd86c3c94ace55 )
-)
-
-game (
-	name "Tetris Plus"
-	year "1995"
-	developer "Jaleco / BPS"
-	rom ( name tetrisp.zip size 6027113 crc 54bf037e md5 05ec2410c2f1b1f56d1279f4e8de563a sha1 231158a02fa8d0e83b1fd6efb2cd901c8e8d63d5 )
 )
 
 game (
@@ -53415,12 +39865,6 @@ game (
 )
 
 game (
-	name "Triforce DIMM Updater (GDT-0011)"
-	developer "Sega"
-	rom ( name tfupdate.zip size 211 crc d9159372 md5 449cc8f7ab3a96222478b880fb6025b7 sha1 8d61f0c994ee2380cc2b0f806a16fd56a1ce1724 )
-)
-
-game (
 	name "Tetris the Absolute The Grand Master 2"
 	year "2000"
 	developer "Arika"
@@ -53438,7 +39882,7 @@ game (
 	name "Tetris The Grand Master (Japan 980710)"
 	year "1998"
 	developer "Arika / Capcom"
-	rom ( name tgmj.zip size 2731116 crc b8642eaa md5 14032260c3628ebda4d538a4662e88bc sha1 eeb7437e0dce7d424d397e4e4e2415a3110fd127 )
+	rom ( name tgmj.zip size 2868921 crc f3359569 md5 c1f47daca50517ccca7b9517deda36b7 sha1 8bd18d636998eecaee21570cbdf4f5393daac983 )
 )
 
 game (
@@ -53477,20 +39921,6 @@ game (
 )
 
 game (
-	name "Thayer's Quest"
-	year "1984"
-	developer "RDI Video Systems"
-	rom ( name thayers.zip size 24144 crc 5f267bf6 md5 23f19f8465758ab58d9f3aaf4de59630 sha1 3a2a274642f02ac0f9f2b0b877c11401613b224d )
-)
-
-game (
-	name "Thayer's Quest (Alternate Set)"
-	year "1984"
-	developer "RDI Video Systems"
-	rom ( name thayersa.zip size 24172 crc 7972538b md5 3296a5fa821d4b10bae87a2067fdd95c sha1 0b6be8b6bed96ba1fda041266b816b040e55f7e3 )
-)
-
-game (
 	name "The Deep (Japan)"
 	year "1987"
 	developer "Wood Place Inc."
@@ -53509,20 +39939,6 @@ game (
 	year "1980"
 	developer "Konami (Stern Electronics license)"
 	rom ( name theends.zip size 13811 crc 3bda0640 md5 dfd0887cacfa89747ed4e847c039ddca sha1 5140ef4b2312a1d64b0d267f1590f7c2fbef5cb2 )
-)
-
-game (
-	name "The Gladiator (ver. 100)"
-	year "2003"
-	developer "IGS"
-	rom ( name theglad.zip size 21412132 crc 3aaafe08 md5 ff735d72d0fc7d3820dcdeab786f2b3b sha1 a73112dc741ccdd80cf4d0852b7679c34b355fc3 )
-)
-
-game (
-	name "The Gladiator (ver. 101)"
-	year "2003"
-	developer "IGS"
-	rom ( name theglada.zip size 21415278 crc 0d4c355e md5 25dcf6982f65003d46e212f71f39e62d sha1 d4191b44e32a70f9858984bb32706204d44bf291 )
 )
 
 game (
@@ -53551,20 +39967,6 @@ game (
 	year "1983"
 	developer "Epos Corporation"
 	rom ( name theglobp.zip size 15776 crc 3e4949d6 md5 b55dd947bc318b383f6d6ca9f7f5ac72 sha1 d0885574a3480f14e0788d2fc775cc59f245afea )
-)
-
-game (
-	name "The Grid (version 1.2)"
-	year "2001"
-	developer "Midway"
-	rom ( name thegrid.zip size 37781694 crc 5b0e926e md5 8f7188619ecacb8c66b394ca3f8fedd1 sha1 96f1e06c0a520586e596d3d5f6da0580c47174be )
-)
-
-game (
-	name "The Grid (version 1.1)"
-	year "2001"
-	developer "Midway"
-	rom ( name thegrida.zip size 37353961 crc aa0fd71e md5 37eaef9f86bd4adab9bc79bfaba8533f sha1 5076fb2d9031717a77de6d73f29a993a12df200e )
 )
 
 game (
@@ -53686,66 +40088,10 @@ game (
 )
 
 game (
-	name "Thunder Zone (World)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name thndzone.zip size 3794222 crc 1d67a46f md5 ec0585515c5eb4211a014e33544a1956 sha1 f305256f620f2e2269665c99963e7c9810a7a8a6 )
-)
-
-game (
 	name "Thunder Hoop (Ver. 1)"
 	year "1992"
 	developer "Gaelco"
 	rom ( name thoop.zip size 2899974 crc 8dd0c606 md5 fd90da9be053b58eebcb8f9c03094879 sha1 6398fa4185edfdb3665bcc0eee27df8c7822d4be )
-)
-
-game (
-	name "TH Strikes Back"
-	year "1994"
-	developer "Gaelco"
-	rom ( name thoop2.zip size 4713185 crc f2bd51f2 md5 a2f043c7b6a842b48f72a381f177ed52 sha1 f3a008024201f7e40ad84ebff091670f3c041f9b )
-)
-
-game (
-	name "Thrill Drive 2 (ver EBB)"
-	year "2001"
-	developer "Konami"
-	rom ( name thrild2.zip size 2094 crc a047dc65 md5 660fe04dddf2e8b180c3ced997602749 sha1 93a2c79032e2a779b19178aebc80a9b99a17b69d )
-)
-
-game (
-	name "Thrill Drive 2 (ver AAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name thrild2a.zip size 6490 crc 7e6cdf5f md5 f0735d7e54b8da758f5419679b72a84b sha1 5333416fd83117a222f845243cbf625815d9f258 )
-)
-
-game (
-	name "Thrill Drive (JAE)"
-	year "1998"
-	developer "Konami"
-	rom ( name thrilld.zip size 15228134 crc 667961db md5 25e6dc400efa82fdc67ec8a227613d17 sha1 66b222b1176fb4263f5c562b5aff5ef8c2201c41 )
-)
-
-game (
-	name "Thrill Drive (JAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name thrilldb.zip size 14970346 crc 4c853398 md5 b530d64bc8c87ce11d0685c42d458a9a sha1 00b64cd75c5f9a5d3c76401dde4828c3670fa909 )
-)
-
-game (
-	name "Operation Thunder Hurricane (ver EAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name thunderh.zip size 11570668 crc 08130401 md5 4b00da091cac5222d748bf742a1a1667 sha1 0638f8197311db8c2e553e58a4eef18011875766 )
-)
-
-game (
-	name "Operation Thunder Hurricane (ver UAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name thunderhu.zip size 11571806 crc a9a37046 md5 f68515cb218f1642e78446410a97a7e9 sha1 1460d400ff006b73ac16a951c68eba48889946c1 )
 )
 
 game (
@@ -53815,14 +40161,14 @@ game (
 	name "Puzzle _ Action: Treasure Hunt (JUET 970901 V2.00E)"
 	year "1997"
 	developer "Sega"
-	rom ( name thunt.zip size 13932140 crc b6c260e6 md5 f7bdedd19badb32c2eac9eee797f43d7 sha1 80fcdbca4f8180d5a7e25f9cf1b117657c2824b5 )
+	rom ( name thunt.zip size 16631361 crc 124efc34 md5 c5af07489be74c6f7dd7c2b4c575c272 sha1 d70cb6914f4183b6387b94db3807ad0e104414d7 )
 )
 
 game (
 	name "Puzzle _ Action: BoMulEul Chajara (JUET 970125 V2.00K)"
 	year "1997"
 	developer "Sega / Deniam"
-	rom ( name thuntk.zip size 13645257 crc be5cf918 md5 5c9c5bf70b741c4fcac6cd4790364d6a sha1 0a8d4e8e39cdcd6dade0c31578865d3276fdffcc )
+	rom ( name thuntk.zip size 16344478 crc 2a81a8a9 md5 609a47122a26f7e90f13101011bae904 sha1 d034096d1e6c955df63e1aea376d89fcacd93d03 )
 )
 
 game (
@@ -53837,13 +40183,6 @@ game (
 	year "1985"
 	developer "Merit"
 	rom ( name tictac.zip size 303266 crc 3160560e md5 99af7aa8dd87c4a2065f943bffe2036d sha1 5c0970df2883ea55b6c64affa1fad09a32458e1a )
-)
-
-game (
-	name "Tiger Heli (US)"
-	year "1985"
-	developer "Toaplan / Taito America Corp."
-	rom ( name tigerh.zip size 96861 crc 4c52aad7 md5 cfc2d493bc5a6f7a36c76afbe1769d99 sha1 d713c1d82f1abd5daefcf5d0e23e9832499efae0 )
 )
 
 game (
@@ -53973,34 +40312,6 @@ game (
 )
 
 game (
-	name "Time Crisis 2 (TSS3 Ver. B)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2.zip size 39202883 crc bc80172e md5 fc27caf20fbf19f239757fb81d686c28 sha1 5f3b53dbc9d4958fa3c1213ad5a3fab4d94bff70 )
-)
-
-game (
-	name "Time Crisis 2 (TSS2 Ver. B)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2b.zip size 39139287 crc 372ae25e md5 7ce9f4185bd79e05e7e8cb07197d4bba sha1 fe274162a07586bc59206b578673fe6131633d7e )
-)
-
-game (
-	name "Time Crisis 2 (TSS4 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2c.zip size 39203059 crc e50581b4 md5 2ccda5bdf296a007ddc83c6f89a920be sha1 9a787a2cba82ad743b0e76a311d09eac2cb7dd3a )
-)
-
-game (
-	name "Time Crisis 3 (TST1)"
-	year "2003"
-	developer "Namco"
-	rom ( name timecrs3.zip size 1761417 crc af2df1ce md5 d8cad66b7c09e09dd7d39a11ffc7fb38 sha1 1a7c9699dff3edfbc40836317a7af22ab0cdd304 )
-)
-
-game (
 	name "Time Killers (v1.32)"
 	year "1992"
 	developer "Strata/Incredible Technologies"
@@ -54012,20 +40323,6 @@ game (
 	year "1992"
 	developer "Strata/Incredible Technologies"
 	rom ( name timekill131.zip size 8025618 crc a92f9054 md5 e9bacf573da20972d44934081515f0e0 sha1 8f57a0b7d321492afd82d7cb0785e64fd029d4bc )
-)
-
-game (
-	name "Time Limit"
-	year "1983"
-	developer "Chuo Co. Ltd"
-	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
-)
-
-game (
-	name "Time Machine (v2.0)"
-	year "1989"
-	developer "Barcrest"
-	rom ( name timemchn.zip size 521367 crc 55aff606 md5 bb49ba926d0d107d70d9c14506a11503 sha1 0e2b713ca565eab3af5a149ca5c7807a60e9ad5d )
 )
 
 game (
@@ -54057,13 +40354,6 @@ game (
 )
 
 game (
-	name "Time Scanner (set 1, System 16A, FD1089B 317-0024)"
-	year "1987"
-	developer "Sega"
-	rom ( name timescan1.zip size 310475 crc f59904a3 md5 bba10d55a1d7420fcdf7e08db2c6baa6 sha1 38f64437fe755a0be746e74364839292103cc8c4 )
-)
-
-game (
 	name "Time Soldiers (US Rev 3)"
 	year "1987"
 	developer "Alpha Denshi Co. (SNK/Romstar license)"
@@ -54075,13 +40365,6 @@ game (
 	year "1987"
 	developer "Alpha Denshi Co. (SNK/Romstar license)"
 	rom ( name timesold1.zip size 911592 crc a8895ee6 md5 17c8b69d29fdf91166cfd97f0b172af5 sha1 e05c486ac4f6db57f760c5267d7b8024bc6f34e1 )
-)
-
-game (
-	name "Time Traveler"
-	year "1991"
-	developer "Virtual Image Productions (Sega license)"
-	rom ( name timetrv.zip size 53103 crc 5f036909 md5 62d0c281c966d27cedb393b31abd09b6 sha1 52677d7d576835ad7cac345fbc5bece9c09c84d4 )
 )
 
 game (
@@ -54113,24 +40396,10 @@ game (
 )
 
 game (
-	name "The Invaders"
-	year "1978"
-	developer "Zelco / Zaccaria"
-	rom ( name tinv2650.zip size 5944 crc 5f2a8be3 md5 47a293045e46e70f2ace141842ee196c sha1 6bdc61d7380074ac8b93a7b774b546be40eb8b25 )
-)
-
-game (
 	name "Tip Top"
 	year "1983"
 	developer "Sega"
 	rom ( name tiptop.zip size 55321 crc 7b4e38b3 md5 5417a29e7de246aaca8c86a7c6ec8e77 sha1 e78cd1b71055c5233d6df107bf35da0fcfc59890 )
-)
-
-game (
-	name "Treasure Island"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name tisland.zip size 30483 crc e2e0c43a md5 6c109d6107b36226ec115b489f35e525 sha1 92d9d1ab7fbdae675b12b45ca789e363f985804f )
 )
 
 game (
@@ -54162,45 +40431,10 @@ game (
 )
 
 game (
-	name "Mahjong Tian Jiang Shen Bing"
-	year "1997"
-	developer "IGS"
-	rom ( name tjsb.zip size 1398954 crc 25a09462 md5 ef1e7f31a4d17bdf987960e7da392f6b sha1 5262daaf7b36a7ccdfa7da712bf238882b9f7faa )
-)
-
-game (
-	name "Tobikose! Jumpman"
-	year "1999"
-	developer "Namco"
-	rom ( name tjumpman.zip size 488609 crc fe8d20b5 md5 5b5ca2c2d8074c26b318e684bbd1b31c sha1 8c345ded4f9a8630682630cf4811c7e4cd683fc6 )
-)
-
-game (
-	name "Touki Denshou -Angel Eyes- (VER. 960614)"
-	year "1996"
-	developer "Tecmo"
-	rom ( name tkdensho.zip size 14423230 crc de83cd11 md5 1ec081f1b50c0562533d4ddfa841bf10 sha1 b014cdbfd63b739561ff9feb0cf580f613c68209 )
-)
-
-game (
-	name "Touki Denshou -Angel Eyes- (VER. 960427)"
-	year "1996"
-	developer "Tecmo"
-	rom ( name tkdenshoa.zip size 14423058 crc c4aeb12d md5 4d14cd230a196348adcb72946fb9a97e sha1 1ad7a0406dd053af93bbbfe151cb3f09d9a88819 )
-)
-
-game (
 	name "Tokimeki Memorial Taisen Puzzle-dama (ver JAB)"
 	year "1995"
 	developer "Konami"
-	rom ( name tkmmpzdm.zip size 7298231 crc bee17002 md5 0008bc1a35732900ccac30924a9501e8 sha1 94c410173e135a913c96c6509ca2ac803c7ed1d7 )
-)
-
-game (
-	name "Tecmo Knight"
-	year "1989"
-	developer "Tecmo"
-	rom ( name tknight.zip size 1127117 crc bdd136d0 md5 9e0754dbe498dd9e084e828e34091eef sha1 aadbaa9d4ae3f4b9bb44768886197a703a6d78c4 )
+	rom ( name tkmmpzdm.zip size 7306921 crc 587d301f md5 17cdf1fba0f53a97d006a536fbe7defd sha1 312e8ded43d8adb75ae8b40c074b5b69fdde0a65 )
 )
 
 game (
@@ -54323,41 +40557,6 @@ game (
 )
 
 game (
-	name "T-MEK (v5.1, The Warlords)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek.zip size 19930714 crc 0716dca4 md5 d93a33ee27198a32aad1139b8742d721 sha1 6cc7262036eb0150282060a3c296d0a5fb672893 )
-)
-
-game (
-	name "T-MEK (v2.0, prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek20.zip size 19867211 crc 63e6b457 md5 84ffa9338e9898c2d1d0cfe32e836198 sha1 1b3969b32fbf3af6817b1e86a43017666a901e7f )
-)
-
-game (
-	name "T-MEK (v4.4)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek44.zip size 19918425 crc acb539aa md5 636a5e40604af0c10d541c9ae2d52d54 sha1 82bc613f93b9ddd33e4327b0d715d74dbadff0a1 )
-)
-
-game (
-	name "T-MEK (v4.5)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek45.zip size 19918811 crc 70eb5323 md5 3164188a39d8ef0e2c826e453b276b50 sha1 466c1b78c4696182946fddbc14d09aaab4a3f8d6 )
-)
-
-game (
-	name "T-MEK (v5.1, prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek51p.zip size 19930577 crc 3e806a47 md5 8cc4e9cb1c0560cc0f87c7ddefe2b1ad sha1 587088163d0ba0de4cb87dec08d35eee3690ab57 )
-)
-
-game (
 	name "Teenage Mutant Hero Turtles (UK 4 Players, set 1)"
 	year "1989"
 	developer "Konami"
@@ -54390,13 +40589,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name tmhta.zip size 1846993 crc 386bbaeb md5 e0cb8a763f23cfdf6ef6f6385f731bfe sha1 6b1243cc992f63d40733a1a70c01eae764bdc282 )
-)
-
-game (
-	name "Tokimeki Mahjong Paradise - Dear My Love"
-	year "1997"
-	developer "Media / Sonnet"
-	rom ( name tmmjprd.zip size 27572083 crc dc34ae2f md5 3dae59f29f18970b869fd37f27b4b5ca sha1 4ad745c29813d820a53854a75fca8312b83ad269 )
 )
 
 game (
@@ -54460,13 +40652,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name tmntua.zip size 1846823 crc 9a00ed2a md5 1644bafcdb03321d6a95598961180b46 sha1 af86178dcc9de8efb4988670a140589dd002418e )
-)
-
-game (
-	name "Tokimeki Mahjong Paradise - Doki Doki Hen"
-	year "1998"
-	developer "Media / Sonnet"
-	rom ( name tmpdoki.zip size 27568935 crc d18ed28d md5 4f5f327b67cc15d5a74aab7fc3fbd130 sha1 c5604deccac9e18a34085fb45876310d3a5b99d6 )
 )
 
 game (
@@ -54582,13 +40767,6 @@ game (
 )
 
 game (
-	name "Toggle (prototype)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name toggle.zip size 28942 crc b3d491d6 md5 5d42dc7f10c75c6d17819ff1d779f4dc sha1 0b0b420c5d754476df8294c40f308e89093b217e )
-)
-
-game (
 	name "Toki (World, set 1)"
 	year "1989"
 	developer "TAD Corporation"
@@ -54617,45 +40795,10 @@ game (
 )
 
 game (
-	name "Tokimeki Memorial Oshiete Your Heart (GE755 JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name tokimosh.zip size 237 crc a4d2a1f8 md5 2886eef3e9cc564387cac177886013a8 sha1 b98bf0f26d3b823fabeea10cc4f07d5cd8a57a15 )
-)
-
-game (
-	name "Tokimeki Memorial Oshiete Your Heart Seal version PLUS (GE756 JAB)"
-	year "1997"
-	developer "Konami"
-	rom ( name tokimosp.zip size 236 crc f4facb8d md5 d58baf8631bd1a6569744615519195c4 sha1 0619df705a165b6afdbdbb57ee849104e5b5c470 )
-)
-
-game (
-	name "Tokio / Scramble Formation (newer)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name tokio.zip size 343947 crc 8c9af2fe md5 3500cdedc7befd0ed685ac16467c6dea sha1 d89bc91a250767b8be1336b22e50565a97021d18 )
-)
-
-game (
 	name "Tokio / Scramble Formation (bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name tokiob.zip size 344493 crc 84d66b79 md5 b1979fad1a6aa05da8332b7305348019 sha1 e9457e0bbcf35f2cadc6b826b0442cb452f1c566 )
-)
-
-game (
-	name "Tokio / Scramble Formation (older)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name tokioo.zip size 344029 crc 6c248cdc md5 fa3224828d44c651bb2970612312a23e sha1 9517c37b825129f714a99c0e49aa2da48534bd63 )
-)
-
-game (
-	name "Tokio / Scramble Formation (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name tokiou.zip size 344408 crc 6e50da73 md5 969133aea5a6640b21c49bfbec1a5973 sha1 4925db56c50f26e2edc518c55c342040b08dad6c )
 )
 
 game (
@@ -54683,7 +40826,7 @@ game (
 	name "Taisen Tokkae-dama (ver JAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name tokkae.zip size 7199441 crc 57dbe7db md5 322139f4f8e25b8061bc8019f72636fa sha1 472db3a085f918ea8d2530de22e52cef0d2bd066 )
+	rom ( name tokkae.zip size 7208131 crc 5cbde3c0 md5 aaa0fc83f3191bfe59e4a12fe437bf6b sha1 94bafb99fa94a2708a0f51b5c565fcd95cf8d6e6 )
 )
 
 game (
@@ -54691,13 +40834,6 @@ game (
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name tokyogal.zip size 387665 crc 3886b278 md5 6c350d86ad17dddf750058cadb724cb2 sha1 a107f629b6f7ff4bec8a9f86422b384d00560ae9 )
-)
-
-game (
-	name "Tokyo Wars (Rev. TW2 Ver.A)"
-	year "1996"
-	developer "Namco"
-	rom ( name tokyowar.zip size 14948944 crc a9acef40 md5 71c0b6f4b915908087c8422e9cb04bd5 sha1 d89e9e111357a0a169b2d2482c0843d0c1b72481 )
 )
 
 game (
@@ -54722,17 +40858,10 @@ game (
 )
 
 game (
-	name "TomCat (Star Wars hardware, prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name tomcatsw.zip size 17502 crc 770ea84f md5 293c8356622aa31e38ba08f6ee76b179 sha1 b46a0970371bccd99a2c135138225ad944743b27 )
-)
-
-game (
 	name "Tondemo Crisis (Japan)"
 	year "1999"
 	developer "Tecmo"
-	rom ( name tondemo.zip size 13249388 crc 9367d820 md5 177f9ab4567e4007f68965fa4c7ffd06 sha1 9566eaf064d5c1f98b783034fb8d33c0503a4a27 )
+	rom ( name tondemo.zip size 13387840 crc a17a0cfa md5 093e40a3c7f93963387030e91a9cfe43 sha1 e406a4e7ade7a9d1de6b5742cf7f06c3f42b81cc )
 )
 
 game (
@@ -54785,20 +40914,6 @@ game (
 )
 
 game (
-	name "Top Blade V"
-	year "2003"
-	developer "SonoKong / Expotato"
-	rom ( name topbladv.zip size 10318862 crc f10ccc9e md5 391d17a3e7888ea5150b86e1b1042760 sha1 693fdbb9a83c9c84db875ca22c2b67c954af93ce )
-)
-
-game (
-	name "Top Gear - 4VXFC969"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name topgear.zip size 48765 crc de330cea md5 5741ae23239adf4ba39bd74425988288 sha1 aa83e06a6a1cd23394808506bb21ccac75a643a5 )
-)
-
-game (
 	name "Vs. Top Gun"
 	year "1987"
 	developer "Konami"
@@ -54830,28 +40945,14 @@ game (
 	name "Top Hunter - Roddy _ Cathy (set 1)"
 	year "1994"
 	developer "SNK"
-	rom ( name tophuntr.zip size 6958588 crc 7bec8868 md5 642522bc7efb6160f4906f56d9806ab9 sha1 e16c48eb74e8c9b7eedbe642b0602f5435568e1a )
+	rom ( name tophuntr.zip size 8305275 crc a35d964a md5 19ba37909f8adbcd4cd9177e16923810 sha1 876b3e761d4213c16a42e21f3f7ba0eed7d31ab4 )
 )
 
 game (
 	name "Top Hunter - Roddy _ Cathy (set 2)"
 	year "1994"
 	developer "SNK"
-	rom ( name tophuntrh.zip size 6959456 crc 03d46e38 md5 827f11ca8a98b215900c9bf08ea62c87 sha1 7250b5d35d6a2aef706dda075e91dbab9a9ba8e0 )
-)
-
-game (
-	name "Top Landing (World)"
-	year "1988"
-	developer "Taito Corporation Japan"
-	rom ( name topland.zip size 1101580 crc 3d6dbb10 md5 775d64b707172a61a65b6e1d6fd0199d sha1 8f01dff109f616f9fd161e068ebf7100febe2fd4 )
-)
-
-game (
-	name "Toppy _ Rappy"
-	year "1996"
-	developer "SemiCom"
-	rom ( name toppyrap.zip size 899598 crc d49e6bb7 md5 61bbd8147ccafe4c91480c2083f590e0 sha1 99620ac1f426bfa55d603e5423313ac15c3a05dc )
+	rom ( name tophuntrh.zip size 8306143 crc 4aafd02a md5 6aea0196921ec6fe48a5b90bd0cbaf9a sha1 e97c1baf0df2ccfd7b2da858bafe821dbec9b907 )
 )
 
 game (
@@ -54890,31 +40991,10 @@ game (
 )
 
 game (
-	name "Top Secret (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name topsecrt.zip size 338416 crc cbdcc8da md5 b8c824aaa5bf2e83633967fbdecd12b6 sha1 1e880bbe9eba132062e7f1ac3ff55650936f5dfb )
-)
-
-game (
 	name "Top Shooter"
 	year "1995"
 	developer "Sun Mixing"
 	rom ( name topshoot.zip size 187152 crc 3d6f0a6b md5 1bdecf04a543749844810276be87a66f sha1 6b16470ac22917584fd98f115c9f9c7a650d63e5 )
-)
-
-game (
-	name "Top Skater (Export, Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name topskatr.zip size 41391632 crc 1b1f80d3 md5 c5350e2d041e68ea17cb4f2b60207d20 sha1 6daea8ba609a12de1a94d37a116be7ce665d36b8 )
-)
-
-game (
-	name "Top Skater (USA)"
-	year "1997"
-	developer "Sega"
-	rom ( name topskatru.zip size 41391619 crc 0c5fe1eb md5 253b68b79ccd113c7f60ef95df8712f6 sha1 c07f0139f1df25df59b7ebf7f7e1d6c417b445e5 )
 )
 
 game (
@@ -54936,13 +41016,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name toramich.zip size 1013597 crc d81deb1e md5 c4b477b3bedf922f438e5442e42bfc06 sha1 2dd02359f564f57bbc4803760dbf0e94dca9a776 )
-)
-
-game (
-	name "Tora Tora (prototype?)"
-	year "1980"
-	developer "GamePlan"
-	rom ( name toratora.zip size 8083 crc 88dd4f5e md5 5a6e37a33bd857b8a420876408328bcd sha1 f8864f46425f0b224092b9af28d58d76794f33e7 )
 )
 
 game (
@@ -54974,24 +41047,10 @@ game (
 )
 
 game (
-	name "Tornado (bootleg set 2)"
-	year "1980"
-	developer "bootleg (Jeutel)"
-	rom ( name tornado2.zip size 15955 crc 0276723d md5 18340987dad0709c32121928fd1d2a0e sha1 2d30a0f77209e12fb0cee4687293e49dfd66886f )
-)
-
-game (
 	name "Tornado Baseball / Ball Park"
 	year "1976"
 	developer "Midway / Taito"
 	rom ( name tornbase.zip size 4610 crc 172c9ce8 md5 346b14f98e5cd8a63dd035be3ed1009a sha1 1ce3da395e611546a20d95846b07e56da924b49a )
-)
-
-game (
-	name "Tortuga Family (Italian)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name tortufam.zip size 30995 crc 12a433af md5 42f852152a30fc23e2cdbd82e2b57371 sha1 7411f6988e799a8bee2496c4ac35a0c84a91337e )
 )
 
 game (
@@ -55023,27 +41082,6 @@ game (
 )
 
 game (
-	name "The Typing of the Dead (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Sega"
-	rom ( name totd.zip size 84411452 crc af96d271 md5 d1547d04315ff00054a2403cfc70efa7 sha1 43c12a983729561231e987d3cdd7840afa80282d )
-)
-
-game (
-	name "Total Vice (ver UAC)"
-	year "1997"
-	developer "Konami"
-	rom ( name totlvice.zip size 1539142 crc 78e98336 md5 13b360b91763afaf1a87c86e8e7207fa sha1 934a7ecbe196516131d5835913afe6e88ec62468 )
-)
-
-game (
-	name "Total Vice (ver JAD)"
-	year "1997"
-	developer "Konami"
-	rom ( name totlvicj.zip size 1539142 crc 78e98336 md5 13b360b91763afaf1a87c86e8e7207fa sha1 934a7ecbe196516131d5835913afe6e88ec62468 )
-)
-
-game (
 	name "Tottemo E Jong"
 	year "1991"
 	developer "Seibu Kaihatsu (Tecmo license)"
@@ -55054,27 +41092,6 @@ game (
 	name "Touche Me"
 	developer "&lt;unknown&gt;"
 	rom ( name toucheme.zip size 94774 crc 58f46660 md5 23e04a2f2987acf989d68322ec6496c8 sha1 b5bcd7ce1ea2f5fee8e03f79c6d7e91284a5c71a )
-)
-
-game (
-	name "Touch _ Go (World)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgo.zip size 5543391 crc 685a9f0f md5 fc11c95fe8a2992f4302904ea005df9e sha1 e6c14e1957e951fa9b25538fc486234f9c437453 )
-)
-
-game (
-	name "Touch _ Go (earlier revision)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgoe.zip size 5538971 crc def9edb8 md5 c0ea4d3729743ffef3fb1e6ebf08d810 sha1 8d94faa378fcf8344a58bdb82ef54964d7bd0bc8 )
-)
-
-game (
-	name "Touch _ Go (Non North America)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgon.zip size 5535292 crc 1028fee1 md5 b82b51e5f6fdefae0b3994d2c113fd97 sha1 0cf256568ee6302ff9edec1e00a0159750c3be97 )
 )
 
 game (
@@ -55096,20 +41113,6 @@ game (
 	year "2000"
 	developer "High Video"
 	rom ( name tour4010.zip size 596390 crc 5705b6aa md5 83664514ef1a21c70408d76c0db63e2b sha1 1a649f634ae0ff28e444655cacd17b6689f6b725 )
-)
-
-game (
-	name "Tournament Solitaire (V1.06, 08/03/95)"
-	year "1995"
-	developer "Dynamo"
-	rom ( name toursol.zip size 586434 crc 50076f27 md5 f92e5bcf9e1aa277a0d03106a7e6b816 sha1 8081a7ad9511c4b9e7faee65b969a86c57c4ad70 )
-)
-
-game (
-	name "Tournament Solitaire (V1.04, 06/22/95)"
-	year "1995"
-	developer "Dynamo"
-	rom ( name toursol1.zip size 617235 crc d8a241d8 md5 359e1b0890e7391f92f77e438ea07b5d sha1 ee39df87550a8ac6eb12ef37a086eeb7981f7f3e )
 )
 
 game (
@@ -55141,13 +41144,6 @@ game (
 )
 
 game (
-	name "Turbo Out Run (cockpit, FD1094 317-unknown)"
-	year "1989"
-	developer "Sega"
-	rom ( name toutrun2.zip size 1153280 crc 7b44a80b md5 62837526792fbcab82898d21838750b2 sha1 cc0a537d1672ad722d9e5e56c8150085592df748 )
-)
-
-game (
 	name "Turbo Out Run (upright, FD1094 317-unknown)"
 	year "1989"
 	developer "Sega"
@@ -55155,24 +41151,10 @@ game (
 )
 
 game (
-	name "Toy Fighter"
-	year "1999"
-	developer "Sega"
-	rom ( name toyfight.zip size 38940433 crc 7d64791e md5 3479046dc018032ab34f8e964771510f sha1 05d21f09061afa60227d28ce6e7081fa4be278a0 )
-)
-
-game (
 	name "Toypop"
 	year "1986"
 	developer "Namco"
 	rom ( name toypop.zip size 54934 crc 6d0e39a7 md5 235f087dde8805bf8a5f78620e0c0dea sha1 5b4b0ce5f6606bd6ad73697e201f601df176d100 )
-)
-
-game (
-	name "Tetris Plus 2 (MegaSystem 32 Version)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name tp2m32.zip size 8476556 crc 16683cf1 md5 1b52cc5b884f5b6733ebe0246139f802 sha1 8cdd201b89b6d6e0a5e855ff176da3f899a44961 )
 )
 
 game (
@@ -55200,14 +41182,7 @@ game (
 	name "Top Player's Golf"
 	year "1990"
 	developer "SNK"
-	rom ( name tpgolf.zip size 3792378 crc a103b264 md5 26357ffa8ee29c09be1cb1e72637fda7 sha1 816bd15a733e8c4d365798928bd45b8777b29c64 )
-)
-
-game (
-	name "Turbo Poker 2"
-	year "1993"
-	developer "Micro Manufacturing Inc."
-	rom ( name tpoker2.zip size 21193 crc bdc2f88a md5 9357208af93bd046e8ae9991c2e99298 sha1 aab57f44656c56648489918b498ddcb7b669395b )
+	rom ( name tpgolf.zip size 5139065 crc a2e147c2 md5 1596bbc5bd673d057cee938c881ec941 sha1 298874d04e6dd8025b3b6ebea49ce14b56e7e17a )
 )
 
 game (
@@ -55225,31 +41200,10 @@ game (
 )
 
 game (
-	name "Track _ Field (NZ bootleg?)"
-	year "1982"
-	developer "bootleg? (Goldberg Enterprizes Inc.)"
-	rom ( name trackfldnz.zip size 64865 crc 090261aa md5 68d4d743d1bca1d7f519dc1eb52148a6 sha1 6940df89941d81015cd2e792259c7b47057cad39 )
-)
-
-game (
-	name "Trail Blazer"
-	year "1987"
-	developer "Coinmaster"
-	rom ( name trailblz.zip size 25151 crc 84cda34f md5 dcc1e869fd107f1cca6d844bef3b0228 sha1 bb9fac030656587deefd799480b268f496410cfc )
-)
-
-game (
 	name "Thrash Rally"
 	year "1991"
 	developer "Alpha Denshi Co."
-	rom ( name trally.zip size 2872564 crc 7c581f5b md5 f2b50aac05018f14ff995cae4e852b35 sha1 82b0e4c08c6447c16e8594fd72088b9f1dc14297 )
-)
-
-game (
-	name "Tranquillizer Gun"
-	year "1980"
-	developer "Sega"
-	rom ( name tranqgun.zip size 13883 crc cb07f221 md5 65b7b8734cfd9197b3ef964746cc6213 sha1 ea5ba0f4746ec6b09eba29ddb4dc97cf733eacce )
+	rom ( name trally.zip size 4219251 crc 049accff md5 d647c81defd54799c8df5f4c8b1b3839 sha1 c7cc0f05b8c2fd609dd4b88954328263e428b17e )
 )
 
 game (
@@ -55295,13 +41249,6 @@ game (
 )
 
 game (
-	name "Trigger Heart Exelica (Rev A) (GDL-0036A)"
-	year "2005"
-	developer "Warashi"
-	rom ( name trgheart.zip size 1197 crc 2e1e0474 md5 7366baacaec4f07908aa60a43f9470fb sha1 3b91acfb08008724a70bc8aaa71ac9b9c3c6de07 )
-)
-
-game (
 	name "Trick Trap (World?)"
 	year "1987"
 	developer "Konami"
@@ -55327,13 +41274,6 @@ game (
 	year "1989"
 	developer "Data East Corporation"
 	rom ( name triothepj.zip size 438462 crc b77cd16d md5 ede28791709eebf722a1bd35ebfeaf68 sha1 4753877eeb241f13b60a88a698e67a1e0b8a8caa )
-)
-
-game (
-	name "Tripple Draw (V3.1 s)"
-	year "1981"
-	developer "Status Games"
-	rom ( name tripdraw.zip size 3873 crc 1eacd7d2 md5 882629000c458013b31c114af0d4d939 sha1 e5608201b3e5dd3a9a46a23ae43c234ef32abec7 )
 )
 
 game (
@@ -55386,80 +41326,10 @@ game (
 )
 
 game (
-	name "Tri-Sports"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name trisport.zip size 391600 crc 9d1ed04b md5 23baf9702c40ee7236ec462a36ae48a8 sha1 6ed7b4493ac639831b93a1172fc7e3b88bca28d2 )
-)
-
-game (
-	name "Trivial Pursuit (Genus I) (set 2)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name trivia12.zip size 62892 crc a592eebc md5 43831bdde92dc32d106016de14e8f85d sha1 718bcd7747ea6683281402402d933997d5cc597d )
-)
-
-game (
-	name "Trivial Pursuit (Baby Boomer Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviabb.zip size 86909 crc fcd62551 md5 06b51d3ad5cd79c50c1cc978353f17ff sha1 9d78f0a7aed4d0cb71ace35685c7f5ce8e6f5fef )
-)
-
-game (
-	name "Trivial Pursuit (Spanish Edition)"
-	year "1987"
-	developer "Bally/Sente"
-	rom ( name triviaes.zip size 98540 crc 5fe1dee9 md5 82277fd6a3c241a5a39c8d022f285895 sha1 aa34c88bb85efa6029016ab96a5871aa67f91f76 )
-)
-
-game (
-	name "Trivial Pursuit (Genus I) (set 1)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviag1.zip size 63161 crc 42412d19 md5 355c6cddb4d9ed5291069d533b20a79a sha1 362b1d7f984c400488e804169cde08efb3a86ea2 )
-)
-
-game (
-	name "Trivial Pursuit (Genus II)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviag2.zip size 81472 crc 35e28e9a md5 f17d97b0dc95431217f05c7b13c24d6e sha1 e74d3acc230a27c7521406686428f8ad250240dd )
-)
-
-game (
 	name "Trivial Pursuit (prod. 1D)"
 	year "1996"
 	developer "JPM"
 	rom ( name trivialp.zip size 4629707 crc 69c30118 md5 650ec075162fe6ef59b814cb48cece69 sha1 6fac4dee5e78172d453f9db846111990a6d60004 )
-)
-
-game (
-	name "Trivial Pursuit (All Star Sports Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviasp.zip size 79007 crc 9fec4b51 md5 434d67ccc984a67a7e386e74acb19f66 sha1 d16547ced6599031a230103097fff69611e3e8b3 )
-)
-
-game (
-	name "Trivial Pursuit (Young Players Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviayp.zip size 81290 crc 3ea8b933 md5 a98d9c07b9e1e5a97e2fd9b802ebdf08 sha1 484d137137c31343702190e89addad65d9cca49b )
-)
-
-game (
-	name "Triv Quiz"
-	year "1984"
-	developer "Status Games"
-	rom ( name trivquiz.zip size 44640 crc 87331852 md5 7750c2aa24abe738c824108301f14223 sha1 7b7916e6594e8a6b4fef765e408a734d3c58b8e3 )
-)
-
-game (
-	name "Trizeal (GDL-0026)"
-	year "2004"
-	developer "Taito"
-	rom ( name trizeal.zip size 1196 crc ad843c95 md5 7bd38c86155a75fe6f293ed9b0ba8ad5 sha1 1f302410af35d840ce07fe4941b69f23c98a4ed7 )
 )
 
 game (
@@ -55526,34 +41396,6 @@ game (
 )
 
 game (
-	name "Tron (8/9)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron.zip size 48412 crc ca5217e6 md5 b1f988a78519c5dfd18e81918c2c0c97 sha1 4ebf329d173d2b3d4f95bda0a7e97f6cd1c06d08 )
-)
-
-game (
-	name "Tron (6/25)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron2.zip size 48435 crc 15498746 md5 0066db603bdfaad4139621be9d340585 sha1 48e746071d9c6bc97980f867dc0bf79474c3d3a3 )
-)
-
-game (
-	name "Tron (6/17)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron3.zip size 48582 crc d895822d md5 5fd9ee29f98887c1f63654e612f100f0 sha1 68447183de33dd3fec0d79218d4fc19c0cb0ab0c )
-)
-
-game (
-	name "Tron (6/15)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron4.zip size 48750 crc b3152e97 md5 eef5483eaebb1b6a55fa26a703ac638e sha1 f8a3f6c7f3083d2e8823974837054ee55ac15161 )
-)
-
-game (
 	name "Trophy Hunting - Bear _ Moose V1.0"
 	year "2002"
 	developer "Sammy USA Corporation"
@@ -55565,12 +41407,6 @@ game (
 	year "1993"
 	developer "Taito Corporation Japan"
 	rom ( name trstar.zip size 6730512 crc 904e2c27 md5 3eebb273d9fe234c6de470d27bac8989 sha1 17847f5b0394387e3d78ed397a41cdef1d4b0a38 )
-)
-
-game (
-	name "Triple Star 2000"
-	developer "A.M."
-	rom ( name trstar2k.zip size 278983 crc 6ebe85ac md5 da88d22f654f5cdda7362effce860c6c sha1 6d433126d41f9fdea87006e61e00e4dfdc8e2c07 )
 )
 
 game (
@@ -55622,13 +41458,6 @@ game (
 )
 
 game (
-	name "Trivia Challenge"
-	year "1985"
-	developer "Joyland (Senko license)"
-	rom ( name trvchlng.zip size 20815 crc 7357da19 md5 5881d8db2f010789487eef9c4731bb1a sha1 17394db4b31d1dea357a92c9841044fd32f04f0f )
-)
-
-game (
 	name "Trivia Genius"
 	year "1985"
 	developer "bootleg"
@@ -55640,20 +41469,6 @@ game (
 	year "1984"
 	developer "SMS Manufacturing Corp."
 	rom ( name trvhang.zip size 125229 crc 5a1ccbc8 md5 12cf81630da1c504be99b0bda33c9a9b sha1 da6288a017e31cfd16d18231bc823d936282b252 )
-)
-
-game (
-	name "Trivia Hangup (Question Set 2)"
-	year "1984"
-	developer "SMS Manufacturing Corp."
-	rom ( name trvhanga.zip size 25930 crc 671c18cf md5 0ff13a658cc30bb7dd7fa198668f843b sha1 f1e7406ed80bba2a0ec07dbb7253b828522d898b )
-)
-
-game (
-	name "Trivia Madness"
-	year "1985"
-	developer "Thunderhead Inc."
-	rom ( name trvmadns.zip size 113713 crc 300a51bb md5 0939040a87841a614eac86810878bcbf sha1 4c02ad0f696ff9abfd657a0df43cf688adeb479d )
 )
 
 game (
@@ -55786,14 +41601,14 @@ game (
 	name "Battle Arena Toshinden 2 (USA 951124)"
 	year "1995"
 	developer "Capcom / Takara"
-	rom ( name ts2.zip size 8385622 crc 88d30858 md5 995e371b25b13a43f5e7ed1d96dbbec8 sha1 7e9e10d48cbb4453b0af407d61841c30aea209d4 )
+	rom ( name ts2.zip size 8511171 crc 751dfbd1 md5 792588ac61386a256d0e601a722642bd sha1 575f462581d7e1699865ad1afe4322b9a57f0356 )
 )
 
 game (
 	name "Battle Arena Toshinden 2 (Japan 951124)"
 	year "1995"
 	developer "Capcom / Takara"
-	rom ( name ts2j.zip size 8385616 crc 9d1be1ca md5 379b0f75ea1718bf013eff4f1165dcc4 sha1 a339e578709f078abb0423de33551b176198aa98 )
+	rom ( name ts2j.zip size 8511165 crc 22e50744 md5 70c4aeb3f456c69b4a38bb910e6dc7e2 sha1 0b450c54ec10e171501df14451ef4f4cdf9145cb )
 )
 
 game (
@@ -55815,20 +41630,6 @@ game (
 	year "1985"
 	developer "Kaneko / Taito"
 	rom ( name tsamuraih.zip size 71900 crc c07b4b18 md5 43f390e840cb37ae6559015071cacb24 sha1 ab75c76ebcce4d5e628684575ff17b512b440e60 )
-)
-
-game (
-	name "Shingen Samurai-Fighter (Japan, English)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name tshingen.zip size 800531 crc f9576ca7 md5 9ac76b1bd2e9a7104de273de6e9127c3 sha1 da6513cfb037cdc7903e38574f381b9f2cbabfdb )
-)
-
-game (
-	name "Takeda Shingen (Japan, Japanese)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name tshingena.zip size 795838 crc 0c666c80 md5 dad3fb98c5f596221947c3115a16b860 sha1 d5157578da41888edfa4af2f0a9d952fb0e823dd )
 )
 
 game (
@@ -55865,43 +41666,10 @@ game (
 )
 
 game (
-	name "Tsurugi (ver EAB)"
-	year "2001"
-	developer "Konami"
-	rom ( name tsurugi.zip size 681 crc 8224037c md5 07357f68e73ba4377c488e3cb8680c79 sha1 e38f462c2fee9380942c6fd46aa774c1f1fcad0e )
-)
-
-game (
-	name "Table Tennis Champions (set 1)"
-	developer "Gamart?"
-	rom ( name ttchamp.zip size 882634 crc 24d3a9e6 md5 e7c872f2cd61016e8c6ffab07c5722ca sha1 b386e05233f000ce6d80d581419ebacf3df3c56d )
-)
-
-game (
-	name "Table Tennis Champions (set 2)"
-	developer "Gamart?"
-	rom ( name ttchampa.zip size 881818 crc fc860ab3 md5 5ea051eb79be3951ef457560105b0ad6 sha1 ca90778131b3235981858f49a16046b084889ddd )
-)
-
-game (
 	name "T.T Mahjong"
 	year "1981"
 	developer "Taito"
 	rom ( name ttmahjng.zip size 15587 crc 5d12c981 md5 23c3df1eff55409c6cf5dc242eff9e83 sha1 cea2cf872965aec8b6430ddd54aab696cb4dee62 )
-)
-
-game (
-	name "Tough Turf (set 2, Japan, 8751 317-0104)"
-	year "1989"
-	developer "Sega / Sunsoft"
-	rom ( name tturf.zip size 525537 crc 56a7b5d1 md5 de62ce29c90a86429dda0a3f5ea3218f sha1 5a8ee2258cad7cf8c899058155133068dd867e8b )
-)
-
-game (
-	name "Tough Turf (bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name tturfbl.zip size 509822 crc 49948e50 md5 436c6cfdcfbf554a5deb45c8d94a06d9 sha1 6a795e04c8c52517e56410a0bb3638bdc98eaa65 )
 )
 
 game (
@@ -55944,13 +41712,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name tumbleb.zip size 1074812 crc 68bd3ed9 md5 77a9a846661416a1097a13b3e333bd63 sha1 0e160b33f2a5b84f145f2f529ad4d27c0eac8d9b )
-)
-
-game (
-	name "Tumble Pop (bootleg set 2)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tumbleb2.zip size 1074460 crc 32d81dc3 md5 cc0d093fd870e8323201ac468dbd01d2 sha1 b3b6867cda8c5fe8e430c5c4134fe112c56a478e )
 )
 
 game (
@@ -56031,17 +41792,10 @@ game (
 )
 
 game (
-	name "Turbo Tag (prototype)"
-	year "1985"
-	developer "Bally Midway"
-	rom ( name turbotag.zip size 81349 crc 110a73f3 md5 299492db454f6e474158d50d247cd68b sha1 efb26d0470e0185af509c50c68a318d096c59233 )
-)
-
-game (
 	name "Neo Turf Masters / Big Tournament Golf"
 	year "1996"
 	developer "Nazca"
-	rom ( name turfmast.zip size 9330744 crc 069101ad md5 df125778ca66b85bc46fbd9ed29b6a97 sha1 e52410e1b3a7e994ccf8b54aac738cebbc5624b5 )
+	rom ( name turfmast.zip size 10677431 crc b1deadb3 md5 513564037307eddb2563f669d5f4e16b sha1 27a824fdce6604729667750a1137cadef6f752bf )
 )
 
 game (
@@ -56052,30 +41806,10 @@ game (
 )
 
 game (
-	name "Turnover (v2.3)"
-	developer "Barcrest"
-	rom ( name turnover.zip size 585639 crc 4af33d94 md5 e2aaffa51ad19121b3afdbf2861fdd10 sha1 44d5bc2b69c95cb6602da459bd8b2211f2d2c768 )
-)
-
-game (
 	name "Turpin"
 	year "1981"
 	developer "Konami (Sega license)"
 	rom ( name turpin.zip size 15691 crc 22fcbd4e md5 fa7013ece9292906327632f662a3b937 sha1 d9ddca911db6fb241397639048ad75741a70fa7b )
-)
-
-game (
-	name "Turpin (bootleg on Scramble hardware)"
-	year "1981"
-	developer "bootleg"
-	rom ( name turpins.zip size 15676 crc ff5cf6d5 md5 dfadd0b2d3bdaf231d930b99043aa8a2 sha1 a680ca3398182018d48454f274503d1ef451c584 )
-)
-
-game (
-	name "Turret Tower"
-	year "2001"
-	developer "Dell Electronics (Namco license)"
-	rom ( name turrett.zip size 395948 crc 43f9b137 md5 f9bbe98cc57784fe6ad2261a47da93a4 sha1 3d2022eaf050d1b4f36d4da507c0fff037cf3440 )
 )
 
 game (
@@ -56125,13 +41859,6 @@ game (
 	year "1996"
 	developer "Island Design"
 	rom ( name tutstomb.zip size 174339 crc 8a42cc6d md5 651c3e72afb66f80842c5f05d815eeca sha1 aee1c6213a32e0d839f78ac0ca25a842479cea95 )
-)
-
-game (
-	name "Tecmo World Cup '98 (JUET 980410 V1.000)"
-	year "1998"
-	developer "Tecmo"
-	rom ( name twcup98.zip size 7713473 crc 789fdabd md5 43df7074654913431ac5f0917efd00a4 sha1 35b058e5297cf2357be3e8a1889a76239712bf1c )
 )
 
 game (
@@ -56226,20 +41953,6 @@ game (
 )
 
 game (
-	name "Twinkle"
-	year "1997"
-	developer "SemiCom"
-	rom ( name twinkle.zip size 377505 crc 87513d91 md5 d439c4e525244b83cfca5280dd09019d sha1 f963d9fcb539a9233fb3a5fb9f231811024b26a3 )
-)
-
-game (
-	name "Twin Qix (Ver 1.0A 1995/01/17) (Prototype)"
-	year "1995"
-	developer "Taito America Corporation"
-	rom ( name twinqix.zip size 3028197 crc a9e0703d md5 a43b278642f60c6891c43b23ef14309c sha1 1fc627611d3ed1f75690ae6eb9355760597a4cbd )
-)
-
-game (
 	name "Twins (set 1)"
 	year "1994"
 	developer "Electronic Devices"
@@ -56257,7 +41970,7 @@ game (
 	name "Twinkle Star Sprites"
 	year "1996"
 	developer "ADK / SNK"
-	rom ( name twinspri.zip size 9071856 crc 719e12fa md5 2ee92d098905da31f75e70cd99a980b0 sha1 10c3e8827d19b9f8ac1a1199ee87f70357127baa )
+	rom ( name twinspri.zip size 10418543 crc 27a2e81d md5 bcab191aba0515e41ddf4ec6be62ca98 sha1 3c4e36745963dd11687c5af4e5bfc296a24c80c0 )
 )
 
 game (
@@ -56289,38 +42002,10 @@ game (
 )
 
 game (
-	name "Tecmo World Cup '94 (set 1)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name twrldc94.zip size 3668253 crc 4b39eded md5 4ed2aa753020897618551c98335f1e5f sha1 bd217187dd6422f17add409b7be7b67ecab7f42e )
-)
-
-game (
-	name "Tecmo World Cup '94 (set 2)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name twrldc94a.zip size 3669058 crc c2dc6fc6 md5 ff44a3dcfb985533061f88837f2715f1 sha1 266c10f4aa912df416947c8353e7a0adc8e4008f )
-)
-
-game (
-	name "Tower _ Shaft"
-	year "2003"
-	developer "Aruze"
-	rom ( name twrshaft.zip size 2833960 crc 2d673cd7 md5 54edbb1ed30234c2544c9b11ffca68dd sha1 a0759914a13dbefc6a530a41390d76f10e8d518d )
-)
-
-game (
 	name "Tecmo World Soccer '96"
 	year "1996"
 	developer "Tecmo"
-	rom ( name tws96.zip size 6149679 crc 42604778 md5 eac62521bb2cf6c8f7951a2284601bf9 sha1 b98bb439ac653d78d3f6540d1796d52242d791be )
-)
-
-game (
-	name "TX-1"
-	year "1983"
-	developer "Tatsumi"
-	rom ( name tx1.zip size 107770 crc e1d14f3e md5 29e33378420a1311fed9b003e07acedb sha1 3da4d488dbcb3941cefdae9d706f642c90d07867 )
+	rom ( name tws96.zip size 7496366 crc 3741481a md5 7364e68e4ce7b8aa17e0fea3cf963644 sha1 38c390160bccf6d4edceecd7d557f873eae764fb )
 )
 
 game (
@@ -56401,13 +42086,6 @@ game (
 )
 
 game (
-	name "Ufo Senshi Yohko Chan (not encrypted)"
-	year "1988"
-	developer "bootleg"
-	rom ( name ufosensib.zip size 216864 crc 27779205 md5 14fd386eeff9f702eff83f6bd6ff8ffc sha1 a9b963ae8030d66adf9e1e299b34231d31fa0673 )
-)
-
-game (
 	name "Ultimate Tennis"
 	year "1993"
 	developer "Art &amp; Magic"
@@ -56485,20 +42163,6 @@ game (
 )
 
 game (
-	name "Under Defeat (GDL-0035)"
-	year "2005"
-	developer "G-Rev"
-	rom ( name undefeat.zip size 1196 crc abb3ebc8 md5 2cd21b6316f13ed401f83c8a14c88e15 sha1 f5a3e81a8747a16a333c73b0d4e65bd6fc2f8d49 )
-)
-
-game (
-	name "The Undoukai (Japan)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name undoukai.zip size 98272 crc 80319054 md5 69bacd1a039c50989513262a0a587ef8 sha1 80cbb94db867518774f1911ff0e51cfc76dc6e20 )
-)
-
-game (
 	name "Under Fire (World)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -56524,40 +42188,6 @@ game (
 	year "1980"
 	developer "Irem"
 	rom ( name uniwars.zip size 18267 crc cf1c989f md5 679dd61a884eb13d3694cfe10c7f4a51 sha1 6a11612bb946be70243ffba890df0d0186fceacc )
-)
-
-game (
-	name "New Cherry Gold '99 (bootleg of Super Cherry Master) (set 1)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch1.zip size 104305 crc 19319d8a md5 070a117c255fec90f9a1b98812688cb8 sha1 d3be84063b8fbafc9dc1bdde1857000d1b4bbb11 )
-)
-
-game (
-	name "Super Cherry Gold (bootleg of Super Cherry Master)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch2.zip size 104656 crc 363146f8 md5 858c4b34adf5ed922db2208efe2054dc sha1 582559184126c4108ae2aa69abb0880e52535828 )
-)
-
-game (
-	name "New Cherry Gold '99 (bootleg of Super Cherry Master) (set 2)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch3.zip size 109009 crc 8867c7f0 md5 05f309c7f61d642d8d0f3bb34b1fec25 sha1 6bde3125eb44240e795037fb203c99c41710f50c )
-)
-
-game (
-	name "Grand Cherry Master (bootleg of Super Cherry Master)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch4.zip size 104302 crc 5604743d md5 dd68539860028b19dcd1a38a4ccd1586 sha1 42e5408241d6aff7ffc8f173da84abf1f87dfcb3 )
-)
-
-game (
-	name "unknown Meyco game"
-	developer "Meyco Games"
-	rom ( name unkmeyco.zip size 10802 crc ca452218 md5 ba6fc6e84746058aae34ee1e0b7cd2dd sha1 91a80f0040126bd2463b9d7565f114d87960931d )
 )
 
 game (
@@ -56617,17 +42247,10 @@ game (
 )
 
 game (
-	name "Otogizoushi Urashima Mahjong (Japan)"
-	year "1989"
-	developer "UPL"
-	rom ( name urashima.zip size 842889 crc 40519bc6 md5 a316e07bc309b3d56c91e811625acba4 sha1 b8aea9e4f54f74c0ea82017c1395138130d29291 )
-)
-
-game (
-	name "Usagi - Yamashiro Mahjong Hen (GDL-0022)"
-	year "2003"
+	name "Usagi (V2.02J)"
+	year "2001"
 	developer "Warashi / Mahjong Kobo / Taito"
-	rom ( name usagui.zip size 1196 crc 2ea1a204 md5 105629083c44cf4fd4ffe837d3434043 sha1 5a6a8962d09fc7ade7b3f6c12a7020282f71690c )
+	rom ( name usagi.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -56757,13 +42380,6 @@ game (
 )
 
 game (
-	name "Vandyke (bootleg with PIC16c57)"
-	year "1990"
-	developer "bootleg"
-	rom ( name vandykeb.zip size 1082292 crc 250b1af4 md5 778ff19d3cdf634500179a27a1bc50b6 sha1 46eaf589206c476fc211a860b018de8c02e9c964 )
-)
-
-game (
 	name "Vandyke (Jaleco, Set 1)"
 	year "1990"
 	developer "UPL (Jaleco license)"
@@ -56869,31 +42485,10 @@ game (
 )
 
 game (
-	name "Varth: Operation Thunderstorm (World 920714)"
-	year "1992"
-	developer "Capcom"
-	rom ( name varth.zip size 1544763 crc 5e0796fe md5 6179a7782065b3f0a23e5be3ed69ec99 sha1 c777ddc4f79531b67188e07119961b97cb111270 )
-)
-
-game (
 	name "Varth: Operation Thunderstorm (Japan 920714)"
 	year "1992"
 	developer "Capcom"
 	rom ( name varthj.zip size 1581220 crc 0437f904 md5 f2bb19cd8fb982b92040325a20f2f8f1 sha1 1a020dd3ed4774d9ed6d8379bafc54f3b3fc8ed8 )
-)
-
-game (
-	name "Varth: Operation Thunderstorm (World 920612)"
-	year "1992"
-	developer "Capcom"
-	rom ( name varthr1.zip size 1536406 crc 5ec6bb64 md5 cc06314b486a183c862c672f6aabdea4 sha1 a9afe05f4e4f06d373e54613422a1d62dcd9172d )
-)
-
-game (
-	name "Varth: Operation Thunderstorm (USA 920612)"
-	year "1992"
-	developer "Capcom, distributed by Romstar"
-	rom ( name varthu.zip size 1539113 crc 1b2b6398 md5 8c85dd23c4ec73d4bf67c4f0eb991173 sha1 28ef18237d2939ab6f7315b9c3eca1e4875c4e99 )
 )
 
 game (
@@ -56929,13 +42524,6 @@ game (
 	year "1983"
 	developer "Sesame Japan"
 	rom ( name vastar2.zip size 52822 crc 0b17dea4 md5 f5c85d836f73c3ef1fd5eea783b2d000 sha1 7ce2fd76002de3557809776b56388bdb13c77a4c )
-)
-
-game (
-	name "Virtua Athletics / Virtua Athlete (GDS-0019)"
-	year "2002"
-	developer "Sega"
-	rom ( name vathlete.zip size 1197 crc e2188c1c md5 3ae592f9405498b656728623e12e43ea sha1 320c77ebe9ab3ec09bf68c50c51b8d00eb79cbee )
 )
 
 game (
@@ -56977,14 +42565,7 @@ game (
 	name "VS Block Breaker (Asia)"
 	year "1997"
 	developer "Kaneko / Mediaworks"
-	rom ( name vblokbrk.zip size 3397578 crc b2ff7906 md5 32f0b65139955ebbed2157a7e7119acb sha1 b2d0e4afc72675b564377b80a56ed2e4b2dbf2e3 )
-)
-
-game (
-	name "Virtua Bowling (World, V101XCM)"
-	year "1996"
-	developer "IGS"
-	rom ( name vbowl.zip size 2363570 crc de0aba54 md5 6e293b5ec25533541bea76e1be0ca2ed sha1 b10589dd59d24ef582bbac82212d280295706552 )
+	rom ( name vblokbrk.zip size 3559293 crc b3f06582 md5 79c1890ae778a11557a8ee1034b4ea17 sha1 ef4a361eeb115cadf88296bd316d9a55ba7cf385 )
 )
 
 game (
@@ -57006,40 +42587,6 @@ game (
 	year "1996"
 	developer "Atari Games"
 	rom ( name vcircle.zip size 245898 crc 21baac8e md5 759ac2bce11d91101f1184af2f28bef7 sha1 b3b25329a9dc9e2bccdf435abf81440cdb688f3f )
-)
-
-game (
-	name "Virtual Combat"
-	year "1993"
-	developer "VR8 Inc."
-	rom ( name vcombat.zip size 1517690 crc 3e218f8e md5 41e7e07e8eb8749e8abe1c97a80ea443 sha1 a6ac438771ac687865d75676a4f444bb12ccccd7 )
-)
-
-game (
-	name "Virtua Cop (Revision B)"
-	year "1994"
-	developer "Sega"
-	rom ( name vcop.zip size 9507185 crc 664a488f md5 011f851d9c58a43c37c464e6b651ac87 sha1 da629c7713f2b4f77a2cfe3ad135514a07eb038e )
-)
-
-game (
-	name "Virtua Cop 2"
-	year "1995"
-	developer "Sega"
-	rom ( name vcop2.zip size 14778188 crc 0950054d md5 d33ffe46a9596b3ffc8a9a03b88139db sha1 e33ec1b8a3a420f8945e3c87ddf1a4d77f94bd7a )
-)
-
-game (
-	name "Virtua Cop 3 (GDX-0003A)"
-	year "2003"
-	developer "Sega"
-	rom ( name vcop3.zip size 219 crc c84f2805 md5 47c1219dfb620c4aed769355134d6643 sha1 6c5ae7bfc0000093e9363fd49dd206137d4ae9a6 )
-)
-
-game (
-	name "Vega"
-	developer "Olympia?"
-	rom ( name vega.zip size 13753 crc 74fb894b md5 7a4f18d2309fb9a17588ece3a182cbbb sha1 524e2faded3e4b269ead0f035fbe602993255c29 )
 )
 
 game (
@@ -57141,13 +42688,6 @@ game (
 )
 
 game (
-	name "Version 4 (Version 4.2R)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name version4.zip size 146244 crc b0195fb1 md5 a1a8d92ad131292532015ba5f765bc53 sha1 79998d03bf8bbb01ab176b51e4cf76cc733c9f71 )
-)
-
-game (
 	name "Virtua Fighter"
 	year "1993"
 	developer "Sega"
@@ -57155,177 +42695,10 @@ game (
 )
 
 game (
-	name "Virtua Fighter 2 (Version 2.1)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2.zip size 19940995 crc 9f29e31d md5 2645d155fe62c39c758e88d825d4cac2 sha1 ef801401f3488e6e61f215395ba1faebaddb514e )
-)
-
-game (
-	name "Virtua Fighter 2 (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2a.zip size 19931175 crc debfddb5 md5 006fd3c5ad396194013702505858af0b sha1 41cd0f96514c98de2dc623c9d5cab0b016cc9cb1 )
-)
-
-game (
-	name "Virtua Fighter 2 (Revision B)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2b.zip size 19937151 crc 5ddc891b md5 9e40907a913aa1ffb24eb4dec3866826 sha1 837f409d84ff9747f556e990dc5dade0965d19fb )
-)
-
-game (
-	name "Virtua Fighter 2"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2o.zip size 19931077 crc ec7d082e md5 1972b04c2139a408b5d0e18741e7d5e6 sha1 b66bcc8d6cef7a3bb85f8068f7ec4e4026ecdb02 )
-)
-
-game (
-	name "Virtua Fighter 3 (Revision C)"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3.zip size 69730653 crc 55da172e md5 10a23e1f0a6b891919bfe240be3bc342 sha1 f000b2b074998087702498f89acd59ec3fc13dca )
-)
-
-game (
-	name "Virtua Fighter 3 (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3a.zip size 69715705 crc ecef5522 md5 4044dd235dc2b2299ef0e9c9f8608adb sha1 f2c17a80a20a5309046af46404338d6f05b0e902 )
-)
-
-game (
-	name "Virtua Fighter 3 Team Battle"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3tb.zip size 69879413 crc b6a4107e md5 3622c0fad035eca8a2c72c5215f1efc1 sha1 3ab1ecf10f99654a6f134489d48e57a950a08b1a )
-)
-
-game (
-	name "Virtua Fighter 4 (GDS-0012)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Virtua Fighter 4 (Rev B) (GDS-0012B)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4b.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Virtua Fighter 4 (Rev C) (GDS-0012C)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4c.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Virtua Fighter 4 (Cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4cart.zip size 136676704 crc f4802443 md5 7a57e5bcdf4a0d686466c289e0f6779d sha1 55bc2fec62cf8c32c51c35f4f296a80b0722dd2d )
-)
-
-game (
-	name "Virtua Fighter 4 Evolution (Rev B) (GDS-0024B)"
-	year "2002"
-	developer "Sega"
-	rom ( name vf4evo.zip size 1194 crc 2936114c md5 381739a42986b6e56706c85576e6e33a sha1 360c2c830794c274a7ec309f8472100cf1c1c33e )
-)
-
-game (
-	name "Virtua Fighter 4 Evolution (Rev A) (GDS-0024A)"
-	year "2002"
-	developer "Sega"
-	rom ( name vf4evoa.zip size 1194 crc 2936114c md5 381739a42986b6e56706c85576e6e33a sha1 360c2c830794c274a7ec309f8472100cf1c1c33e )
-)
-
-game (
-	name "Virtua Fighter 4 Evolution (Cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4evoct.zip size 135639761 crc b1d38673 md5 730b7bda92daa82ccc63cb9b8e365048 sha1 6a400f704e312e975b49fe437a6c8ebef6f694ff )
-)
-
-game (
-	name "Virtua Fighter 4 Final Tuned (Rev F) (GDS-0036F)"
-	year "2004"
-	developer "Sega"
-	rom ( name vf4tuned.zip size 1196 crc f37667e2 md5 9c3f452daf1166721d19360e90da36c1 sha1 111d5e1c0bf97fe008e16bd0089985b3696d766e )
-)
-
-game (
-	name "Virtua Fighter 4 Final Tuned (Rev A) (GDS-0036A)"
-	year "2004"
-	developer "Sega"
-	rom ( name vf4tuneda.zip size 1196 crc f37667e2 md5 9c3f452daf1166721d19360e90da36c1 sha1 111d5e1c0bf97fe008e16bd0089985b3696d766e )
-)
-
-game (
-	name "Virtua Fighter 4 Final Tuned (Rev D) (GDS-0036D)"
-	year "2004"
-	developer "Sega"
-	rom ( name vf4tunedd.zip size 1196 crc f37667e2 md5 9c3f452daf1166721d19360e90da36c1 sha1 111d5e1c0bf97fe008e16bd0089985b3696d766e )
-)
-
-game (
-	name "V-Five (Japan)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name vfive.zip size 1115620 crc 15d6bf51 md5 5048fb81a0cae5cf8306bd96ae5ad805 sha1 28140e3734a4e552fb4c0beba8b573429923d413 )
-)
-
-game (
 	name "Virtua Fighter Kids (JUET 960319 V0.000)"
 	year "1996"
 	developer "Sega"
-	rom ( name vfkids.zip size 24176482 crc 4d738c97 md5 d580a83247e3e571af72d6c5734efa0b sha1 3f7e193c4764cf063a0c532b2f017ebe1575612f )
-)
-
-game (
-	name "Virtua Formula"
-	year "1993"
-	developer "Sega"
-	rom ( name vformula.zip size 9750247 crc 039685b7 md5 d49f52ee0cef7900465944a34695dd72 sha1 dfd603e32f09a600bf866593163ca46e59303fa7 )
-)
-
-game (
-	name "Virtua Fighter Remix (JUETBKAL 950428 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name vfremix.zip size 13245661 crc ae738cc0 md5 8e0c28202242f69f64928b2d786bd86f sha1 9fea35a65264c3a512b463e9333b53a3db8a4eb9 )
-)
-
-game (
-	name "Net Select Keiba Victory Furlong"
-	year "2005"
-	developer "Sammy"
-	rom ( name vfurlong.zip size 101810678 crc b1988b94 md5 df01e11e318d74daea4282f3d2888c2f sha1 40d026ceac4aeae56d7650a488feed941cf38840 )
-)
-
-game (
-	name "V Goal Soccer (set 2)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name vgoalsca.zip size 3978951 crc 1ef71cc6 md5 83aac8eae53dfcfd4318199b6e44281c sha1 6042a43ed4efc2cad98943412a32c6f6c5c02054 )
-)
-
-game (
-	name "V Goal Soccer (set 1)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name vgoalsoc.zip size 3998125 crc fd11882a md5 8d28bacb20f1690149ef45a57d5bd5ea sha1 381d6d9f3172298e7b05b7938595678c26c2415b )
-)
-
-game (
-	name "Vegas Poker (prototype, release 2)"
-	developer "BwB"
-	rom ( name vgpoker.zip size 184496 crc 3da116cf md5 e2fa939bcbbfab6c8db344613b8260e8 sha1 6176d000b755ca679b2da477839eb885d87e55fb )
+	rom ( name vfkids.zip size 26875703 crc 5d245814 md5 898b56267e77e6da0cf67d5e2fd85928 sha1 1181f4902ecaf3571623ea606aa61c04348597d5 )
 )
 
 game (
@@ -57371,24 +42744,10 @@ game (
 )
 
 game (
-	name "Victorious Nine"
-	year "1984"
-	developer "Taito"
-	rom ( name victnine.zip size 99727 crc a48c32af md5 af3a5cb752bb9ac4bb1e8a20e582d698 sha1 7cf1f37b57ec9c2ce64566ad4b51c7071589a996 )
-)
-
-game (
 	name "Victor 21"
 	year "1990"
 	developer "Subsino / Buffy"
 	rom ( name victor21.zip size 59931 crc 8058f02c md5 133b21b0fbe1a562bdbe67117ecbafd5 sha1 c7fdf4bbdc5dd33831aa68ed0cb781656d249cbc )
-)
-
-game (
-	name "G.E.A."
-	year "1991"
-	developer "Subsino"
-	rom ( name victor5.zip size 60370 crc 789405ce md5 19a92dc9bb867380b6b3e7c53e2777f9 sha1 d5fc128372b04617e4b19a23070d47daff30c5bc )
 )
 
 game (
@@ -57458,49 +42817,7 @@ game (
 	name "Viewpoint"
 	year "1992"
 	developer "Sammy / Aicom"
-	rom ( name viewpoin.zip size 4045243 crc b3c55b87 md5 35e82eb1e37eb96aafe43f88e7d4addf sha1 8e0905a6463b06c01c2f37d8fef077bec05560cb )
-)
-
-game (
-	name "Vigilante (World)"
-	year "1988"
-	developer "Irem"
-	rom ( name vigilant.zip size 443942 crc 0ea1d86f md5 53bbcbe368c25fb0776a756f9fd06e4f sha1 7d969ba8c64596bac482beb4cf481845b7b773b6 )
-)
-
-game (
-	name "Vigilante (Japan)"
-	year "1988"
-	developer "Irem"
-	rom ( name vigilantj.zip size 444100 crc d78137b0 md5 899b7ab7a2847bd4606534b89c8216b9 sha1 d32c5e0ee5c6d81227f8fdc3f21cc11537837df6 )
-)
-
-game (
-	name "Vigilante (US)"
-	year "1988"
-	developer "Irem (Data East USA license)"
-	rom ( name vigilantu.zip size 443935 crc 983fb0d6 md5 e8f11bb0393e3579461da1c82c45fe1a sha1 a311b89231faf5232f6172d9e95a7620bf072035 )
-)
-
-game (
-	name "Vimana"
-	year "1991"
-	developer "Toaplan"
-	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
-)
-
-game (
-	name "Vimana (Japan)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name vimana1.zip size 792172 crc fae43844 md5 f6dd90ad479f91912d3ec0706c7da4ec sha1 9e34ecb4ee6096bca47752aee7f4709a01938799 )
-)
-
-game (
-	name "Vimana (Nova Apparate GmbH)"
-	year "1991"
-	developer "Toaplan (Nova Apparate GmbH license)"
-	rom ( name vimanan.zip size 792398 crc 2bc288f3 md5 8831d66ca21ec4127ea7c2536dd9ee1b sha1 e4a56fdd4bebb5c9a2ff815ddc8ffe22400d9a69 )
+	rom ( name viewpoin.zip size 5391930 crc 89df3ead md5 e0b1cb5d2cba3b7858451ecade88cd34 sha1 986fe7c8b6621c10e2a5f96f87bfd6e7195e0af6 )
 )
 
 game (
@@ -57700,20 +43017,6 @@ game (
 )
 
 game (
-	name "Virtua NBA (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name virnba.zip size 95708034 crc 76ee2d60 md5 3ede4f22fb9e08040a94886ebe1b3e3d sha1 cee901991cd2a394d6ea82b707f8ff94b2bead95 )
-)
-
-game (
-	name "Virtua NBA (JPN, USA, EXP, KOR, AUS) (original)"
-	year "2000"
-	developer "Sega"
-	rom ( name virnbao.zip size 95707746 crc 6c10ed0a md5 288896022b0ca169bca220efac107665 sha1 6bdf8b0e7719a92f3a242762551f9e3f854ea17a )
-)
-
-game (
 	name "Mahjong Vitamin C (Japan)"
 	year "1989"
 	developer "Home Data"
@@ -57724,28 +43027,28 @@ game (
 	name "Vivid Dolls"
 	year "1998"
 	developer "Visco"
-	rom ( name vivdolls.zip size 1895382 crc c7c5dcf0 md5 135621b9b5283dfc81ee1bf842bf47c3 sha1 2892113ac573a7ee08dd56c0c32a89d835c4bca9 )
+	rom ( name vivdolls.zip size 1897164 crc 8a0aa8aa md5 e7a07c8ab766158bf344ef3669ce3b17 sha1 3a10a92467f78006e98acf6e6d93af2087860035 )
 )
 
 game (
 	name "V-Liner (set 1)"
 	year "2001"
 	developer "Dyna / BrezzaSoft"
-	rom ( name vliner.zip size 198731 crc de2c0bfd md5 8f595c228009dbbba28940c021d63844 sha1 4cd34952140b96b5eb389515de6b08ce48aa8047 )
+	rom ( name vliner.zip size 1545418 crc db44bba6 md5 72520ccd09e1a155dfd4e6285963a3ef sha1 d148112fda3d4cc6e75e767401dd601cf845f793 )
 )
 
 game (
 	name "V-Liner (set 2)"
 	year "2001"
 	developer "Dyna / BrezzaSoft"
-	rom ( name vlinero.zip size 198607 crc 684d5c33 md5 6ac9d9ad0a2458d04fb5489079808284 sha1 17968c769c01a43f17c558d977f0c463c3a330db )
+	rom ( name vlinero.zip size 1545294 crc de44692f md5 5d2fa4d3dcdb9152037f302839d88c80 sha1 2e9d90a4ac210fb0a8ebb7781698f799ed6b9c64 )
 )
 
 game (
 	name "Virtual Mahjong (J 961214 V1.000)"
 	year "1997"
 	developer "Micronet"
-	rom ( name vmahjong.zip size 16676226 crc cc6e02cc md5 51489427317327442d4bbeb725c05573 sha1 412393547f654453baf370d9108d22aa18808b08 )
+	rom ( name vmahjong.zip size 19375447 crc e999862f md5 0248dca7733c341361ff346936b67331 sha1 a619ffd2b17f28749f73746c09cc95f0cc85ee68 )
 )
 
 game (
@@ -57791,34 +43094,6 @@ game (
 )
 
 game (
-	name "Virtual On Cyber Troopers (US, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name von.zip size 27081340 crc 266dac32 md5 bfd81bb631b972866ce579973c2d09d8 sha1 b90924ef0cfd00b8389996da2443516214578abf )
-)
-
-game (
-	name "Virtual On 2: Oratorio Tangram (Revision B)"
-	year "1998"
-	developer "Sega"
-	rom ( name von2.zip size 73360340 crc c622ac96 md5 34da253ee9965156857dd59b86e13530 sha1 d34df7a19014b37a6928bceb6909b4ce9f7bfa57 )
-)
-
-game (
-	name "Virtual On 2: Oratorio Tangram (ver 5.4g)"
-	year "1998"
-	developer "Sega"
-	rom ( name von254g.zip size 77012655 crc 139fd2c1 md5 d18eda790a5f20c9871e4470deae376d sha1 d8c4acb1e523d62a276eeaee7a7824cef1b6778c )
-)
-
-game (
-	name "Virtual On Cyber Troopers (Japan, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name vonj.zip size 27079862 crc 719b904c md5 8e41d1bc978d83a2b5909a6813bfd97f sha1 957d25d4784770d607187d5a055d7bd61192654f )
-)
-
-game (
 	name "Vortex"
 	year "1980"
 	developer "Zilec Electronics Ltd."
@@ -57826,23 +43101,10 @@ game (
 )
 
 game (
-	name "Videotronics Poker"
-	developer "Videotronics"
-	rom ( name vpoker.zip size 9232 crc 3fe190fe md5 ca23e4170a38304b022fde5fdf8f4c76 sha1 0575c2d12f185692b383119f235bb512f4276082 )
-)
-
-game (
 	name "Video Pool (bootleg on Moon Cresta hardware)"
 	year "1980"
 	developer "bootleg"
 	rom ( name vpool.zip size 10801 crc 12ef8d56 md5 d2270d488c8494291790ff356af4c7d4 sha1 5838e4dd7157077b393ecb6d9d6f0deafffb695e )
-)
-
-game (
-	name "Virtua Racing"
-	year "1992"
-	developer "Sega"
-	rom ( name vr.zip size 9761594 crc 68f2d49a md5 28a9134834b668a21833c0448ad51104 sha1 ad169f0c44fe377076258a02e80303a6b19891f0 )
 )
 
 game (
@@ -57871,104 +43133,6 @@ game (
 	year "1984"
 	developer "Irem (Taito license)"
 	rom ( name vs10yardu.zip size 63777 crc b42c5d8c md5 29a06d7b668579e23683aaf875729d84 sha1 23bf417cc7811d30a63004ef9a6359c0dae22d74 )
-)
-
-game (
-	name "Virtua Striker 2 (Step 2.0)"
-	year "1997"
-	developer "Sega"
-	rom ( name vs2.zip size 50909273 crc 22275471 md5 802507312328b00fbe7c946d72806285 sha1 dcef25a6b5b374661ca2b1c7f05d215f57dbfe0b )
-)
-
-game (
-	name "Virtua Striker 2002 (GDT-0002)"
-	year "2002"
-	developer "Sega"
-	rom ( name vs2002ex.zip size 219 crc 31fd9201 md5 5cb11ccef3248ccd7917ab9750398585 sha1 066cce38a986e1851a842ae1f2f66c253341f8f8 )
-)
-
-game (
-	name "Virtua Striker 2002 (GDT-0001)"
-	year "2002"
-	developer "Sega"
-	rom ( name vs2002j.zip size 211 crc aced4165 md5 bbd7bf2b8db780d22266234ace233337 sha1 70f35b8d28cb3f174de6c2037e2ca82e576e1108 )
-)
-
-game (
-	name "Virtua Striker 2 (Step 1.5)"
-	year "1997"
-	developer "Sega"
-	rom ( name vs215.zip size 49502335 crc 514b7390 md5 7b5fd37da42d1051f945923310c7c7da sha1 a2198b08e6ee27061831742f3e0f287af74023dc )
-)
-
-game (
-	name "Virtua Striker 2 '98 (Step 2.0)"
-	year "1998"
-	developer "Sega"
-	rom ( name vs298.zip size 58691960 crc f1237873 md5 aaa60d79645e33ebade2af8eb7317019 sha1 2e0f45e491ac57060f60e6a89c6fb7ae93de2432 )
-)
-
-game (
-	name "Virtua Striker 2 '98 (Step 1.5)"
-	year "1998"
-	developer "Sega"
-	rom ( name vs29815.zip size 57340402 crc 57dc2de9 md5 d8403eb83ea5e385e17f8bd4669e464b sha1 26a2c1e46694e5b2c0d3d675555af31b3f5a7133 )
-)
-
-game (
-	name "Virtua Striker 2 '99"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299.zip size 60531946 crc cdb60e6c md5 766d704edbdc46a4c781ea3655d25f1d sha1 ad5b2670a9924345bbcda46d56ca57c193a0f7a3 )
-)
-
-game (
-	name "Virtua Striker 2 '99 (Revision A)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299a.zip size 60549611 crc 66b49b10 md5 1fa031b844e6b5bbdf31aea3cb5fc1e9 sha1 dda850924c09f464efa445521c073792b9b2ba76 )
-)
-
-game (
-	name "Virtua Striker 2 '99 (Revision B)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299b.zip size 60568092 crc 5624ebd4 md5 597f1d5c48e8a744858669d3eeb2b76b sha1 739ce6a453ac53112a9b21a18122d23659a165d7 )
-)
-
-game (
-	name "Virtua Striker 2 Ver. 2000 (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs2_2k.zip size 54546410 crc e1e91c35 md5 db8c5824eb2a9e9a09c2fa5698654dce sha1 9b9e929271866839e367a08521e93bbc0c19e6de )
-)
-
-game (
-	name "Virtua Striker 2 '99.1 (Revision B)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs2v991.zip size 60568201 crc 0bafab9c md5 2c1f047cf643c83f30f74cfd6ef80238 sha1 8ce509494ebbf567c9fa14b4b13909fa983a44c3 )
-)
-
-game (
-	name "Virtua Striker 4 (Export) (GDT-0015)"
-	year "2004"
-	developer "Sega"
-	rom ( name vs4.zip size 219 crc aed5c1c0 md5 5ed3e9851c239f5a1f2e4dea6e443474 sha1 1e27c511c90d07d3744097eaab31b52afc7968fb )
-)
-
-game (
-	name "Virtua Striker 4 ver. 2006 (Rev D) (Japan) (GDT-0020D)"
-	year "2006"
-	developer "Sega"
-	rom ( name vs42006.zip size 210 crc 87316dbb md5 3b55690d5ddc0d88fb0af64c0b3e31b2 sha1 227ab14baf8a30f9f1c110b44cb9be5248ccc941 )
-)
-
-game (
-	name "Virtua Striker 4 (Japan) (GDT-0013E)"
-	year "2004"
-	developer "Sega"
-	rom ( name vs4j.zip size 218 crc afe6c304 md5 e4013f278113c9cd7118ac85d4e73f52 sha1 b254304974563b31e5d767411c935da907ced3b3 )
 )
 
 game (
@@ -58094,35 +43258,35 @@ game (
 	name "Versus Net Soccer (ver EAD)"
 	year "1996"
 	developer "Konami"
-	rom ( name vsnetscr.zip size 16492239 crc f293244f md5 afe6aec8d7624802237e31cf98fbde6b sha1 c8df0f9fc77bd2878a64dc57f02a99115c0af583 )
+	rom ( name vsnetscr.zip size 16500929 crc 5a192c81 md5 c527df335b156f264bec21fa3d65440e sha1 a6991799334421e7ef715e2d58492a99b1a534a7 )
 )
 
 game (
 	name "Versus Net Soccer (ver AAA)"
 	year "1996"
 	developer "Konami"
-	rom ( name vsnetscra.zip size 16492723 crc a87507c9 md5 8a68177c17957f4559616e782b139c63 sha1 775caa4e0599641febbc66ed123eb7744919caa8 )
+	rom ( name vsnetscra.zip size 16501413 crc 686f0d9b md5 f3611db1a3b2915872112946fa1f8cc6 sha1 372b0b2b28a39256ca8a5e6ee886df190340919a )
 )
 
 game (
 	name "Versus Net Soccer (ver EAB)"
 	year "1996"
 	developer "Konami"
-	rom ( name vsnetscreb.zip size 16492176 crc 5d3b3ce4 md5 f7f932b9d5c3a16427a9bfa5e4b37e7b sha1 316f716ac4fc2f186f0e625fff468a5841fde8e1 )
+	rom ( name vsnetscreb.zip size 16500866 crc 6a6a4c0d md5 ed73b405b5e28da33532579cc416739d sha1 3a030a6e50058a1765d3362d021c9d1ec1e16331 )
 )
 
 game (
 	name "Versus Net Soccer (ver JAB)"
 	year "1996"
 	developer "Konami"
-	rom ( name vsnetscrj.zip size 16492284 crc e796ca20 md5 94eb8d0c000356f66aff5b6229062b98 sha1 7ea58ad751ab6fd91321a134099216f6dbe49194 )
+	rom ( name vsnetscrj.zip size 16500974 crc e5d9b80b md5 a3d9828d20da4130090ef4ba6b9b5d55 sha1 82527d736a4c798bad99feb20643b8f8c06c6215 )
 )
 
 game (
 	name "Versus Net Soccer (ver UAB)"
 	year "1996"
 	developer "Konami"
-	rom ( name vsnetscru.zip size 16492642 crc a94a4bb6 md5 b40dbcb98d955381180d00f9fbcec42f sha1 bb171a7b098e4603f249ff97bfe8c8081f124fee )
+	rom ( name vsnetscru.zip size 16501332 crc decb6d5d md5 29389aa052845a86646fdbd832415df2 sha1 f330cc72de90fb983f2d4bf43a2ac7c34abe8c9e )
 )
 
 game (
@@ -58168,13 +43332,6 @@ game (
 )
 
 game (
-	name "Video Stars"
-	year "1982"
-	developer "Competitive Video?"
-	rom ( name vstars.zip size 21244 crc 07721780 md5 621f7ac43cc3a282eba1ea4d5385168b sha1 0bd42bdf96153db81ce78c7a52b16077cc002cce )
-)
-
-game (
 	name "Vs. Tennis"
 	year "1984"
 	developer "Nintendo"
@@ -58193,62 +43350,6 @@ game (
 	year "1987"
 	developer "Academysoft-Elorg"
 	rom ( name vstetris.zip size 14572 crc 69c80caa md5 798a8d686961b50d5c1e16e760dc8b79 sha1 dff75516168583c65f5296e1648922697eb4e40e )
-)
-
-game (
-	name "Virtua Striker 3 (GDS-0006)"
-	year "2001"
-	developer "Sega"
-	rom ( name vstrik3.zip size 1194 crc 94a6867c md5 079dba6a81c953e22e6fa6bf0cfd1b42 sha1 83d1b160e03536a3369f3ec45f2766ac1d94d240 )
-)
-
-game (
-	name "Virtua Striker 3 (Cart) (USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name vstrik3c.zip size 117980538 crc 526ab909 md5 2d5f651bc647d81325760606f4930359 sha1 57bec10a2cac6daf2729c6049170be0fc9c2cca5 )
-)
-
-game (
-	name "Virtua Striker (Revision A)"
-	year "1994"
-	developer "Sega"
-	rom ( name vstriker.zip size 9987856 crc 8bfcb204 md5 15e17213780ae2a6d8b88af4acce4137 sha1 2e75959005206926e49ed1a1637476ea177fe5f8 )
-)
-
-game (
-	name "Virtua Striker"
-	year "1994"
-	developer "Sega"
-	rom ( name vstrikero.zip size 9985035 crc 79a896df md5 1c01885d85bd1df670b6cb43144cac25 sha1 0b0e5d8d2550d7e8be0ce5c4a39daaf1e56184dd )
-)
-
-game (
-	name "Power Smash 2 / Virtua Tennis 2 (cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtenis2c.zip size 81919505 crc 06906d89 md5 4cae7204cd4f8005c4aebdd3de7276ff sha1 5fd4f231e9196380e42aaef19ece1dd41ca2c071 )
-)
-
-game (
-	name "Power Smash (JPN) / Virtua Tennis (USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name vtennis.zip size 25044701 crc 7529d9ec md5 6e3502075e31bc1550e3479ad031ff7e sha1 6b66a1c636dee8bce67df95e8a2d55ca4c5ff8fe )
-)
-
-game (
-	name "Virtua Tennis 2 (Rev A) (GDS-0015A)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtennis2.zip size 1197 crc eeabce60 md5 07a404eabaa3ceea7b91e6b5337a21b9 sha1 8ec5e09d51b4ead397d12a023295bacbb60a65c4 )
-)
-
-game (
-	name "Virtua Tennis (GDS-0011)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtennisg.zip size 1197 crc ab1190ee md5 f6581310d24e8284e883ff78c91857dc sha1 97b9b1372fdf15d6e429fe12fc2da08491a2782c )
 )
 
 game (
@@ -58304,7 +43405,7 @@ game (
 	name "Waku Waku 7"
 	year "1996"
 	developer "Sunsoft"
-	rom ( name wakuwak7.zip size 13611483 crc cc9d3511 md5 19e0a77be2473a7e46a27d7c2b0328f6 sha1 6cbac48cc6e6ed9577e7e4e045e2c8f7d2fbe7ea )
+	rom ( name wakuwak7.zip size 14958170 crc 07079df7 md5 08260f97f39f3ac2e19c9fdfecb6e40d sha1 78b71384594e4e47024d8cdd082e57012d81eb33 )
 )
 
 game (
@@ -58329,20 +43430,6 @@ game (
 )
 
 game (
-	name "Wangan Midnight Maximum Tune (Rev. B) (Export) (GDX-0009B)"
-	year "2005"
-	developer "Sega"
-	rom ( name wangmid.zip size 213 crc c21c1120 md5 6c60d3c8212935bdaeb75e41042f5336 sha1 c6d72c20223a8d134bb16a6a8daeb472b31863d4 )
-)
-
-game (
-	name "Wangan Midnight Maximum Tune 2 (Export) (GDX-0015)"
-	year "2005"
-	developer "Sega"
-	rom ( name wangmid2.zip size 219 crc 0d7925ad md5 940bf8298a61e6c538c11d192cfbaaed sha1 0ee544a5dc20d608be3747b15f933d82bb7d3b1f )
-)
-
-game (
 	name "Wanted"
 	year "1984"
 	developer "Sigma Enterprises Inc."
@@ -58364,13 +43451,6 @@ game (
 )
 
 game (
-	name "War: The Final Assault"
-	year "1999"
-	developer "Atari Games"
-	rom ( name warfa.zip size 260157 crc b71482e4 md5 fbd3358d120daff16231a4d3fcfbc26e sha1 d123c8b2be19780ff302cdbc00ca23c142f268e6 )
-)
-
-game (
 	name "War Gods"
 	year "1995"
 	developer "Midway"
@@ -58389,13 +43469,6 @@ game (
 	year "1981"
 	developer "Armenia"
 	rom ( name warofbug.zip size 9633 crc a05751b7 md5 d0c3c7100a5b118f3ba58fd3f93d8645 sha1 5b8c62c30d0cac065f2b41dc3f3749ebfa034208 )
-)
-
-game (
-	name "War of the Bugs or Monsterous Manouvers in a Mushroom Maze (German)"
-	year "1981"
-	developer "Armenia"
-	rom ( name warofbugg.zip size 8037 crc 0b2704cf md5 405020fbcbcd6079f59d92d085e816b7 sha1 e197d6bb1d357714e9172bf034edaf6b530ba3c3 )
 )
 
 game (
@@ -58455,27 +43528,6 @@ game (
 )
 
 game (
-	name "Wave Runner (Japan, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name waverunr.zip size 15825589 crc 5252d820 md5 33bcc747b5c2c50a7e6b746de58639c2 sha1 8ccd8bb5770af943da44bbe090241dc0121b6d62 )
-)
-
-game (
-	name "Wave Shark (UAB, USA v1.04)"
-	year "1996"
-	developer "Konami"
-	rom ( name waveshrk.zip size 10429985 crc 6b6ebe6f md5 4bfb60e6f1d8490a09dc4418a0499870 sha1 c67b284c8c76859c377421642b82ac544a6fd1e1 )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (set 5, World, System 16B, 8751 317-0098)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb3.zip size 391158 crc f91e30a4 md5 01cc32ea1ae54c6e3d9f0c0c2ec00c54 sha1 8ec512b7b6d1e77cd0e1ce2d3cf0250cbd7c4077 )
-)
-
-game (
 	name "Wonder Boy III - Monster Lair (set 1, System 16A, FD1094 317-0084)"
 	year "1988"
 	developer "Sega / Westone"
@@ -58504,27 +43556,6 @@ game (
 )
 
 game (
-	name "Wonder Boy III - Monster Lair (set 5, System 16A, FD1089A 317-xxxx, bad dump?)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb35.zip size 484250 crc 39b1bac2 md5 1bb256260e66d247248f91a7cd7b1e1d sha1 657005eba3d9208abd71a895af75173613d40f0b )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (set 6, System 16A, FD1089A 317-xxxx)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb35a.zip size 465317 crc 33208680 md5 e4735336c3cb7e19d99ed08c6d16c010 sha1 c947eaf9198562e4c0ccd1971ae0d0932172e506 )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name wb3bbl.zip size 395202 crc c7ab3ceb md5 4103828eeadbcc62edfb95b72201d57f sha1 838047a3d8710557d06c3a6b2f4062eb7bc8ecee )
-)
-
-game (
 	name "Beach Festival World Championship 1997"
 	year "1997"
 	developer "Comad"
@@ -58536,20 +43567,6 @@ game (
 	year "1986"
 	developer "Sega (Escape license)"
 	rom ( name wbdeluxe.zip size 82117 crc fb778468 md5 076a7547499a84ff3d2bb726fb9cd49a sha1 9063d90484cea97fc1e5bfb658c7052f54a17acd )
-)
-
-game (
-	name "World Beach Volley (set 1)"
-	year "1995"
-	developer "Playmark"
-	rom ( name wbeachvl.zip size 3037511 crc a7e64b63 md5 8c24a0dc0f0fc04202edb0a0324154c3 sha1 671d53acb9f10c23e5b8fa5974c20b8b9c3f0109 )
-)
-
-game (
-	name "World Beach Volley (set 2)"
-	year "1995"
-	developer "Playmark"
-	rom ( name wbeachvl2.zip size 3036021 crc 4c797d2a md5 54da8132516f68be41aa3d621a4127c8 sha1 fac30605a2d5274831d742ccb6a824520236d0b2 )
 )
 
 game (
@@ -58665,30 +43682,10 @@ game (
 )
 
 game (
-	name "Euro League (Italian hack of Tecmo World Cup '90)"
-	year "1989"
-	developer "bootleg"
-	rom ( name wc90b1.zip size 400477 crc b0bf4256 md5 c32a9f1044995ffffb4e670df4bf81b6 sha1 4a84141f7517490037994c7420e548f05ce432f9 )
-)
-
-game (
-	name "Worldcup '90"
-	year "1989"
-	developer "bootleg"
-	rom ( name wc90b2.zip size 400762 crc 22467977 md5 8b60be8f48b0abd75473d9ea368eec79 sha1 2a3d9c79990c54cb6dd15cf92f0e43fe8cf15028 )
-)
-
-game (
 	name "Tecmo World Cup '90 (trackball set 1)"
 	year "1989"
 	developer "Tecmo"
 	rom ( name wc90t.zip size 397203 crc bbcd5f9c md5 8c5d750736fc7129f14d4913c7a502f3 sha1 941c9dd1b7a436a8595f8d21d5688c694e54cf5a )
-)
-
-game (
-	name "Wild Cat 3"
-	developer "E.A.I."
-	rom ( name wcat3.zip size 84762 crc 0ebe0f1e md5 dedc5f14495da4d5493f870eade43b7f sha1 9aa12644544c39578a066534608f4d86880f6667 )
 )
 
 game (
@@ -58762,27 +43759,6 @@ game (
 )
 
 game (
-	name "World Combat (ver UAA?)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombat.zip size 3775 crc b045cc21 md5 aac84148769c55647229d9ebe2443b76 sha1 9da44bc9d9d628ee1194fa091b1b24c2285215d0 )
-)
-
-game (
-	name "World Combat (ver JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombatj.zip size 3730 crc 00aa974f md5 289177932257b311f6d01028f9b649ab sha1 6eff1992166ae69ff09e12f735d791e8cb23aec4 )
-)
-
-game (
-	name "World Combat (ver KBC)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombatk.zip size 3889 crc 221dd784 md5 53c296d3d4a9f9f5e6683c0b76b49aa4 sha1 75edb5d62a0c8c23b23407a561e2c0730006db38 )
-)
-
-game (
 	name "World Cup Volley '95 (Japan v1.0)"
 	year "1995"
 	developer "Data East Corporation"
@@ -58800,7 +43776,7 @@ game (
 	name "Wedding Rhapsody (GX624 JAA)"
 	year "1997"
 	developer "Konami"
-	rom ( name weddingr.zip size 235 crc c4eb9495 md5 506396f566d443b55336087182a34f7a sha1 ffa89d9c282614da27a8c44712377ba232ce62c8 )
+	rom ( name weddingr.zip size 81604 crc ef31d56c md5 84a60637a7c2b2279e7c61e9a1f7afc3 sha1 8ffcc41e5e16fbbbf36867034b2ac481b7382451 )
 )
 
 game (
@@ -58815,13 +43791,6 @@ game (
 	year "1991"
 	developer "Video System Co."
 	rom ( name welltrisj.zip size 1836526 crc 5c495227 md5 2ad08afa7fdea5bca8d16480b9b2512b sha1 94bd642fbb9e7398951adecdba598e5a5a9b0adc )
-)
-
-game (
-	name "West Story (bootleg of Blood Bros.)"
-	year "1990"
-	developer "bootleg (Datsu)"
-	rom ( name weststry.zip size 1238170 crc 31019093 md5 058e8db91e7f67d3c7566b61b6409a38 sha1 f2f8bd9424e62c9032b7e776ff5b4af0948e9b6b )
 )
 
 game (
@@ -58867,92 +43836,45 @@ game (
 )
 
 game (
-	name "World Grand Prix (US)"
-	year "1989"
-	developer "Taito America Corporation"
-	rom ( name wgp.zip size 2705736 crc f1e59ea3 md5 ed74f8b95cadaad2e60b61ff084bba20 sha1 6e4fc0dc6fb22e629094cff99f3f6456b4cbb5a5 )
-)
-
-game (
-	name "World Grand Prix 2 (Japan)"
-	year "1990"
-	developer "Taito Corporation"
-	rom ( name wgp2.zip size 2764565 crc fd1439af md5 f6e43d246b64d9126bcc0f63825ef4a6 sha1 136cf3c2603293cf9cfd876533a182344fcf4d6f )
-)
-
-game (
-	name "World Grand Prix (Japan)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpj.zip size 2705911 crc 212e9985 md5 94df97db198346650d5e8778163a61b6 sha1 fc57f2a987564922f8fbe0883d53ad4e02c0ffc5 )
-)
-
-game (
-	name "World Grand Prix (joystick version) (Japan, set 1)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpjoy.zip size 2728252 crc 0b1db883 md5 f73728ee046d3fb445e14e193fba8e0e sha1 b21e1cf01c6043ae3ab22dc0695cc92b9f73bb61 )
-)
-
-game (
-	name "World Grand Prix (joystick version) (Japan, set 2)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpjoya.zip size 2728231 crc 415462aa md5 2c58a6180a0467290eb1e987966913cd sha1 a65a254945fb11e5a70b6aa30eff064f331a7954 )
-)
-
-game (
 	name "World Heroes (set 1)"
 	year "1992"
 	developer "Alpha Denshi Co."
-	rom ( name wh1.zip size 4800025 crc 1da64ce5 md5 839c02b17976ff8be5dff914d9806261 sha1 03586dd184ea519a12752d6753f3751d3d9bae19 )
+	rom ( name wh1.zip size 6146712 crc 40e29290 md5 6c0ed0bd259e00092d31e3ba82625df8 sha1 52011bccebba8c49e9451710117cf8f0ca06dcb3 )
 )
 
 game (
 	name "World Heroes (set 2)"
 	year "1992"
 	developer "Alpha Denshi Co."
-	rom ( name wh1h.zip size 4803831 crc 94c82f24 md5 50a60c9bce8dbca4ee279c8ce59146cb sha1 a2a54033c08a508933a38cd68cf645695709122a )
+	rom ( name wh1h.zip size 6150518 crc b927aa03 md5 75b759a7def9bb948df4c1ae35a093c4 sha1 a9bb49317253f1378bd10bc987a7b374b93c3f6a )
 )
 
 game (
 	name "World Heroes (set 3)"
 	year "1992"
 	developer "Alpha Denshi Co."
-	rom ( name wh1ha.zip size 4836193 crc 140df3c0 md5 66a5be79c9070d6cd6fc5e85a6ca2f7c sha1 77e8ed286c162ff516d5057ba406d7253bc6ad75 )
+	rom ( name wh1ha.zip size 6182880 crc c1911c82 md5 93699360044eb3c184dd955e7e8ffd03 sha1 494f10a6054251b61e670252865a9e481e200347 )
 )
 
 game (
 	name "World Heroes 2"
 	year "1993"
 	developer "ADK"
-	rom ( name wh2.zip size 9025876 crc 05d4f89b md5 e4c6aae36df38238a1178738a96f429c sha1 86d21d8850297ce6cb951c924fed127575367ac0 )
+	rom ( name wh2.zip size 10372563 crc 2f24b75d md5 ae3c74004c55bcfd9efdf96633cc84a2 sha1 a5012c823a22eb40e4501c709ca33b731f963397 )
 )
 
 game (
 	name "World Heroes 2 Jet (set 1)"
 	year "1994"
 	developer "ADK / SNK"
-	rom ( name wh2j.zip size 10867142 crc 4c1b8986 md5 e212b64ce4c9c1d27fa9c8f5fbbe82cc sha1 89f2d7b73b4ef2d157ca39c44ac646d2d2b06985 )
+	rom ( name wh2j.zip size 12213829 crc a1734daf md5 b76b115225ad178e65c3ad5ec09e9110 sha1 96517bcd222c01e277f38dd0dd4a26132ebbb21d )
 )
 
 game (
 	name "World Heroes 2 Jet (set 2)"
 	year "1994"
 	developer "ADK / SNK"
-	rom ( name wh2jh.zip size 10868754 crc e1289189 md5 2b354db40f1175521fef6a80460e4f07 sha1 74f59948e773038c2a6c8be5836dc4b21d2b5725 )
-)
-
-game (
-	name "Wheels _ Fire"
-	developer "TCH"
-	rom ( name wheelfir.zip size 2275665 crc 18320311 md5 8999b7396b2014c8908052e0ab32e111 sha1 12839c6d851a452842cd84629473db447f91e646 )
-)
-
-game (
-	name "Wheels Runner"
-	developer "International Games"
-	rom ( name wheelrun.zip size 266060 crc 01cc5ffb md5 9f4ed4d024100f95ec451c8927bb9519 sha1 b38f11dfdc350802cbb8bf496ff1f8ff9babc5d7 )
+	rom ( name wh2jh.zip size 12215441 crc bbff7a7c md5 c588696b1268848c936a840bcf524789 sha1 b5c32af0385f9f9c1fc77361351c7718786d2fcf )
 )
 
 game (
@@ -58970,17 +43892,10 @@ game (
 )
 
 game (
-	name "Pipi _ Bibis / Whoopee!! (Whoopee!! board)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name whoopee.zip size 510889 crc b95c208e md5 fedf38748d33252de6d6fa3786cfb857 sha1 9b9108dfcf9e8121396410b246c0b0daa532b3e2 )
-)
-
-game (
 	name "World Heroes Perfect"
 	year "1995"
 	developer "ADK / SNK"
-	rom ( name whp.zip size 14989579 crc 3bb62a8f md5 84969b3bc398420b920c9dac772dcf99 sha1 f16e6a035fdec481ceb7f7d8b453aaac1107840e )
+	rom ( name whp.zip size 16336266 crc 559798d1 md5 4000461ab447ed96f40dfe77ecf09cf7 sha1 c38d99dd7408b102cda4b0fae354b6694556f709 )
 )
 
 game (
@@ -58988,20 +43903,6 @@ game (
 	year "1994"
 	developer "Promat"
 	rom ( name wiggie.zip size 532267 crc e1e971ae md5 7f89ec33811e849b47beaeb04e896b41 sha1 03408b34ed34201ee184ef411b7ee1a67a2978d7 )
-)
-
-game (
-	name "Wild Fang / Tecmo Knight"
-	year "1989"
-	developer "Tecmo"
-	rom ( name wildfang.zip size 1127216 crc 1bbd53df md5 bdf5feea32db29d4fb9bddc09454f287 sha1 5f75aafe536acc379790a20c2fa9fb2f26ca4196 )
-)
-
-game (
-	name "Wild Fang"
-	year "1989"
-	developer "Tecmo"
-	rom ( name wildfangs.zip size 1127156 crc dab69d66 md5 571c22ca0f3deda285e14f1bd8fd719f sha1 f9b556514221f7a52c014a83960c46f5f6e54975 )
 )
 
 game (
@@ -59019,13 +43920,6 @@ game (
 )
 
 game (
-	name "Willow (Japan, Japanese)"
-	year "1989"
-	developer "Capcom"
-	rom ( name willowj.zip size 1769362 crc 732cdc85 md5 5bc507c5cdbc4e4e24960de7d83d7e01 sha1 6a81c41da6101878acd7b8ee4d7eb44ab1a64a78 )
-)
-
-game (
 	name "Willow (Japan, English)"
 	year "1989"
 	developer "Capcom"
@@ -59037,18 +43931,6 @@ game (
 	year "1984"
 	developer "Irem"
 	rom ( name wilytowr.zip size 38625 crc e7ad435f md5 836d0d60ceabd3f2bc47923c968ad375 sha1 6e6b320aa9feb168486cf35ca4567bc037f660b4 )
-)
-
-game (
-	name "Win Win Bingo (set 1)"
-	developer "Astro Corp."
-	rom ( name winbingo.zip size 1321961 crc 39e6609e md5 16d17a2ead7ce9646777794bb31f1159 sha1 e94521253b1087f275c8d1456d08b03e9ab058b5 )
-)
-
-game (
-	name "Win Win Bingo (set 2)"
-	developer "Astro Corp."
-	rom ( name winbingoa.zip size 1744073 crc c9eec9ba md5 6cd10e04973b9bd2efbad030315a195e sha1 db0a1bb97b318d2b38dcba33b2e00ee4c7828edd )
 )
 
 game (
@@ -59073,69 +43955,6 @@ game (
 )
 
 game (
-	name "Wing War (World)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwar.zip size 13322227 crc 1fa2c631 md5 7c0d0d207381daff05d6d2f2de9f3939 sha1 497d35aadc420fe8a4e855c3801e241932c79d50 )
-)
-
-game (
-	name "Wing War (Japan)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwarj.zip size 13322227 crc 50239da1 md5 717621c7a559f0c6a8c467798da8e76a sha1 50b2415c769a84a4e370a3054ed4071e966fe376 )
-)
-
-game (
-	name "Wing War (US)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwaru.zip size 13322247 crc 807bcadd md5 2b646ab51cd06d923de4155b833f039e sha1 afe1cb5550b199943759b652aa9f6c9250885307 )
-)
-
-game (
-	name "Wink (set 1)"
-	year "1985"
-	developer "Midcoin"
-	rom ( name wink.zip size 42545 crc 6e5cdbf7 md5 93265f49b12671c547d3cd3b55aca06f sha1 da6dcd8436f9072850e64612d3d1893cace97aae )
-)
-
-game (
-	name "Wink (set 2)"
-	year "1985"
-	developer "Midcoin"
-	rom ( name winka.zip size 42495 crc 3381b0a1 md5 250bde2e0bbe616f89365bb528c7363d sha1 7de3bf1fa0491e52781688f2c528eaf1f50718eb )
-)
-
-game (
-	name "Winning Run Suzuka Grand Prix (Japan)"
-	year "1989"
-	developer "Namco"
-	rom ( name winrun.zip size 1347588 crc 7d5d9c90 md5 f4b613a8d3c6fb1cf5ba932becd2749a sha1 8f114003f5f04dc9852305ef8e57e9289919fe7d )
-)
-
-game (
-	name "Winning Run 91 (Japan)"
-	year "1991"
-	developer "Namco"
-	rom ( name winrun91.zip size 1373304 crc e3d8d0aa md5 70a44b526270256e7430da9568536d2c sha1 c58b1d480d77b29a13e3fcdf982426dc21e13d13 )
-)
-
-game (
-	name "Winning Spike (ver EAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name winspike.zip size 11053108 crc 4a80055c md5 af9931b5c586fb5862ca889ef0bed503 sha1 c5bd760d848ec14d4d15a2bec4e6274cc3dbfd02 )
-)
-
-game (
-	name "Winning Spike (ver JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name winspikej.zip size 11053456 crc 6f62c780 md5 b90939c2e4d6e8746bf4cf3239011c46 sha1 b47340d32d23ab5ab542c5b2880990c12549877c )
-)
-
-game (
 	name "The Winter Bobble (bootleg of Snow Bros.)"
 	year "1990"
 	developer "bootleg (Sakowa Project Korea)"
@@ -59146,7 +43965,7 @@ game (
 	name "Winter Heat (JUET 971012 V1.000)"
 	year "1997"
 	developer "Sega"
-	rom ( name winterht.zip size 21208197 crc 2537a1a2 md5 802af67e3161d8fd999bee6573ed362f sha1 f99b44df73301b28fe372fa84402e3af8c78afa9 )
+	rom ( name winterht.zip size 23907418 crc bd8edcee md5 3ae13d96adc16099fd1f61d030ee2e69 sha1 ead836fb154983faf0c142d331b97024410309e2 )
 )
 
 game (
@@ -59199,27 +44018,6 @@ game (
 )
 
 game (
-	name "Witch Card (German, set 2)"
-	year "1994"
-	developer "bootleg?"
-	rom ( name witchcde.zip size 21000 crc 841d70b8 md5 5e15fdb9684bc6b2d49fdf20dd61adf4 sha1 4b6cafa16243a095dca956054f9596a640b68f0b )
-)
-
-game (
-	name "Witch Card (English, witch game, lamps)"
-	year "1985"
-	developer "PlayMan"
-	rom ( name witchcdf.zip size 12217 crc 87baef18 md5 e8b780adf98fef5d75b18b2b266384af sha1 85da776a330e605b4b15740d567022f573688bc7 )
-)
-
-game (
-	name "Witch Card (Video Klein)"
-	year "1991"
-	developer "Video Klein"
-	rom ( name witchcrd.zip size 13079 crc 1797bf70 md5 8ea96a23bfb39e561dd2cb6617e31e68 sha1 7ac40fd62f31e728e3e7183d02f19032a3ea6e02 )
-)
-
-game (
 	name "Wit's (Japan)"
 	year "1989"
 	developer "Athena (Visco license)"
@@ -59231,13 +44029,6 @@ game (
 	year "1985"
 	developer "Seibu Kaihatsu"
 	rom ( name wiz.zip size 72739 crc 29055c7a md5 119accb2311e0ef6044a5623aa99922b sha1 d918cfb80ff4387bfd13ddf315096b49d25e1ffd )
-)
-
-game (
-	name "Wizard (Ver 1.0)"
-	year "1999"
-	developer "A.A."
-	rom ( name wizard.zip size 556097 crc ca89c079 md5 c723b10d80176623aefe99603f7d140d sha1 eb47b4c10142743bed5c53689eb32091c7fdc441 )
 )
 
 game (
@@ -59293,7 +44084,7 @@ game (
 	name "Windjammers / Flying Power Disc"
 	year "1994"
 	developer "Data East Corporation"
-	rom ( name wjammers.zip size 4041216 crc c6171d88 md5 b4ce615f4190fa976f2d80fadc247e1b sha1 a8c777d34082282f04571f9238390cfe47f5eea9 )
+	rom ( name wjammers.zip size 5387903 crc 5481f496 md5 513cdd95c3272fae8a102da4adac5dcb sha1 31e5ef023af1c0b2b02cc5b989759a23ab30cf4f )
 )
 
 game (
@@ -59315,20 +44106,6 @@ game (
 	year "1988"
 	developer "Namco"
 	rom ( name wldcourt.zip size 361601 crc a818ea5d md5 bd75dfee229e1b67606091738a165822 sha1 19494a8f8756db48eb51691f87e7053f1451b9cb )
-)
-
-game (
-	name "Wild Riders (JPN, USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name wldrider.zip size 62184249 crc c63a1304 md5 5445e5d703f5ac7e3a98f544a2d627ff sha1 365cd08911768de5cbc9296611e17ac75e418429 )
-)
-
-game (
-	name "Wonder League Star - Sok-Magicball Fighting (Korea)"
-	year "1995"
-	developer "Mijin"
-	rom ( name wlstar.zip size 1111873 crc 50c60903 md5 fc261854f1666e504d5e89b474e1c99b sha1 0809e620299942bfe252fa6912a34613339ace1f )
 )
 
 game (
@@ -59381,13 +44158,6 @@ game (
 )
 
 game (
-	name "Warriors of Fate (USA 921031)"
-	year "1992"
-	developer "Capcom"
-	rom ( name wofu.zip size 3943037 crc b1cebed9 md5 efde103d8e343f2b6851e18ee0e7e3f8 sha1 2b06da2dfe47e4dac0b26175444df4896ae5cd26 )
-)
-
-game (
 	name "Wolf Fang -Kuhga 2001- (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -59406,13 +44176,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name wonder3.zip size 2545771 crc 294de24f md5 30bcab9cd246220fa9da59e81f43d634 sha1 5a69a4ac353029072fccf32a5410266f9bdec59c )
-)
-
-game (
-	name "Wonder League '96 (Korea)"
-	year "1996"
-	developer "SemiCom"
-	rom ( name wondl96.zip size 1134743 crc 829ed1a5 md5 89b56076d71f4c1caba5cb5194e40eed sha1 07b88d1d2c796106a0883a46f9711bd2b5f36ce5 )
 )
 
 game (
@@ -59478,48 +44241,6 @@ game (
 )
 
 game (
-	name "World PK Soccer"
-	year "1995"
-	developer "Jaleco"
-	rom ( name wpksoc.zip size 2961417 crc e81143ba md5 c6691cdb3e9839002ba7fa69900d34dc sha1 b309df873e60b7d7a928813b393a7f0d695d1671 )
-)
-
-game (
-	name "World PK Soccer V2 (ver 1.1)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name wpksocv2.zip size 10936454 crc 15459333 md5 6e2330a479a07cf99cb8ccaa4d4a91d8 sha1 35a8e524c393d1d5321dfd260942289441d3610c )
-)
-
-game (
-	name "World Rally (set 1)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name wrally.zip size 2150671 crc 0a96fa55 md5 c0b150867a535dd91c0a0185bbbe9d2f sha1 1648718faf86e70554754324e1888c95b06e4eea )
-)
-
-game (
-	name "World Rally 2: Twin Racing"
-	year "1995"
-	developer "Gaelco"
-	rom ( name wrally2.zip size 5449380 crc e5746c19 md5 ba8317624dcb7294e9ecd769054cc08a sha1 e7e8da50591d0a9114a1dcd794567fd72813c266 )
-)
-
-game (
-	name "World Rally (set 2)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name wrallya.zip size 2150655 crc 560506db md5 709b7bffefd01796f3a719910a8a04a3 sha1 2a414a31178d8a17eceffc732eb0d0d90590a028 )
-)
-
-game (
-	name "World Rally (US, 930217)"
-	year "1993"
-	developer "Gaelco (Atari license)"
-	rom ( name wrallyb.zip size 2112189 crc 060a4bf2 md5 f0a2f1d4f57ae0efc2f2f0a3cf1bc730 sha1 25b7da3424934adffa65a06ed9cdbc09fd0a04fa )
-)
-
-game (
 	name "Vs. Wrecking Crew"
 	year "1984"
 	developer "Nintendo"
@@ -59576,13 +44297,6 @@ game (
 )
 
 game (
-	name "World Series Baseball / Super Major League (GDS-0010)"
-	year "2001"
-	developer "Sega"
-	rom ( name wsbbgd.zip size 1195 crc 62c3cdab md5 a68c20c274dca3a9551e60b48f6bf05f sha1 05aca61a3ee864f195a0aebc8de29f66adc66108 )
-)
-
-game (
 	name "Wing Shooting Championship V2.00"
 	year "2001"
 	developer "Sammy USA Corporation"
@@ -59608,20 +44322,6 @@ game (
 	year "1990"
 	developer "Leland Corp."
 	rom ( name wsf.zip size 584465 crc f9562bf7 md5 bc17a474b233ecb69ff8462b2866481d sha1 141471b18a27b303397db67de2f13ae2b361affd )
-)
-
-game (
-	name "Who Shot Johnny Rock? v1.6"
-	year "1991"
-	developer "American Laser Games"
-	rom ( name wsjr.zip size 51956 crc 0c42fec1 md5 4a167149fc7ad1a219adc3d91bff5806 sha1 766cba1751325db9dc8a213ca85f585c66ea979b )
-)
-
-game (
-	name "Who Shot Johnny Rock? v1.5"
-	year "1991"
-	developer "American Laser Games"
-	rom ( name wsjr15.zip size 51902 crc d5bed392 md5 e64919c46b44abf93e54c097af4d3ae1 sha1 be855101e49a1d1272421c37f6e17c2f5264de66 )
 )
 
 game (
@@ -59688,31 +44388,10 @@ game (
 )
 
 game (
-	name "WWF Royal Rumble (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name wwfroyal.zip size 100313238 crc 5ef1919d md5 6c2672baa1138730c4c24c5f302843d9 sha1 873753373ed645bfdfb9924378909ec1a0231edb )
-)
-
-game (
-	name "WWF Superstars (Europe)"
-	year "1989"
-	developer "Technos Japan"
-	rom ( name wwfsstar.zip size 1521277 crc 380f9e41 md5 7938b364e050b627d2be494b89d450f2 sha1 d2caa65883c6298e8a02d372c8fe76606d47e6f1 )
-)
-
-game (
 	name "WWF Superstars (US, Newer)"
 	year "1989"
 	developer "Technos Japan"
 	rom ( name wwfsstara.zip size 1510432 crc 46a98200 md5 6dd5f41cc21be1fd8481106d58c92b24 sha1 1594a5425a4a832a327dc10ee90f905f1f665d66 )
-)
-
-game (
-	name "WWF Superstars (Japan)"
-	year "1989"
-	developer "Technos Japan"
-	rom ( name wwfsstarj.zip size 1444109 crc 133c2bb3 md5 a8ca04be8e2fbbd77d2d0fda07bc8f73 sha1 b5dfb6333ae775b8b3980e08299abb8ccc4a86a0 )
 )
 
 game (
@@ -59758,30 +44437,10 @@ game (
 )
 
 game (
-	name "Wyvern Wings"
-	year "2001"
-	developer "SemiCom (Game Vision license)"
-	rom ( name wyvernwg.zip size 8172603 crc 627e0ad3 md5 6eb71a34799c2300628565f67d8bc7bd sha1 b4bd2da04515b6913fcddf8d198713f126ca6d54 )
-)
-
-game (
-	name "X Five Jokers (Version 1.12)"
-	developer "Electronic Projects"
-	rom ( name x5jokers.zip size 362947 crc a2d826f9 md5 0b93e5affcc38caf563ad08650b623b3 sha1 334283e724e68a29c454538a853c5283940ea969 )
-)
-
-game (
 	name "X-Day 2 (Japan)"
 	year "1995"
 	developer "Namco"
 	rom ( name xday2.zip size 3011634 crc 30ac96f0 md5 25d2261ff890e47d5a2b51cbb1ef9a1b sha1 8cf8f073c861faf040e0ba2e04614a047131172d )
-)
-
-game (
-	name "Xenophobe"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name xenophob.zip size 392037 crc f90765c3 md5 39a392cd04bd5ce6e42619c5667602a0 sha1 0973544f28d70c1e3fc52dc12fb7dfe80d612a35 )
 )
 
 game (
@@ -59806,27 +44465,6 @@ game (
 )
 
 game (
-	name "Xevious (Atari set 1)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousa.zip size 45384 crc 7498a41b md5 426d2319ff9bfdc47a696c76ec3ae623 sha1 13284570397157ec4cf659cf969bb50fa9a858c1 )
-)
-
-game (
-	name "Xevious (Atari set 2)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousb.zip size 45236 crc 97e7250e md5 7c09e3d69941f33154306c110b519739 sha1 e0680191bf3aa525cc2a48893485b81f298dc5b0 )
-)
-
-game (
-	name "Xevious (Atari set 3)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousc.zip size 45761 crc 0b5c1a40 md5 7697c698928ed5403cdbdcfb76e63239 sha1 d8311dc07521597b8ff7d76d992e74b196ce50eb )
-)
-
-game (
 	name "Xexex (ver EAA)"
 	year "1991"
 	developer "Konami"
@@ -59848,10 +44486,10 @@ game (
 )
 
 game (
-	name "X-Files"
-	year "1999"
-	developer "dgPIX Entertainment Inc."
-	rom ( name xfiles.zip size 9572115 crc 506f86cc md5 d0a43a1734b47a4c6f8f362c15affd10 sha1 2fe664db2ab05fedc885dc06914dc7a342aa98fc )
+	name "XII Stag (V2.01J)"
+	year "2002"
+	developer "Triangle Service"
+	rom ( name xiistag.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
 )
 
 game (
@@ -59995,13 +44633,6 @@ game (
 )
 
 game (
-	name "X Multiply (Japan, M72)"
-	year "1989"
-	developer "Irem"
-	rom ( name xmultiplm72.zip size 853744 crc 75af49dd md5 404ac0208101260f4609bcb8946f1d61 sha1 0ede1ed3886d8295719eab4ab3eb5daa8d886215 )
-)
-
-game (
 	name "X-Men Vs. Street Fighter (Euro 961004)"
 	year "1996"
 	developer "Capcom"
@@ -60100,20 +44731,6 @@ game (
 )
 
 game (
-	name "Xtreme Rally / Off Beat Racer!"
-	year "1998"
-	developer "SNK"
-	rom ( name xrally.zip size 27419979 crc 2f2a6705 md5 7c40921061eeb83c065c01a5c4c6fa55 sha1 8901a0d8dcd58eea28715feedf13ede8d607eb40 )
-)
-
-game (
-	name "X Se Dae Quiz"
-	year "1995"
-	developer "Dream Island"
-	rom ( name xsedae.zip size 1782906 crc 590493ee md5 f3ad2d4ce1d39d2824510b51cca03db7 sha1 b1b90142ae2cd7bf330e78e25eb16cf053c76445 )
-)
-
-game (
 	name "Xain'd Sleena"
 	year "1986"
 	developer "Technos Japan"
@@ -60135,27 +44752,6 @@ game (
 )
 
 game (
-	name "Xtrial Racing (ver JAB)"
-	year "2002"
-	developer "Konami"
-	rom ( name xtrial.zip size 6635 crc c1aff998 md5 8932a885393911c0a5c4890e9f6aabed sha1 97f397aac088da3c1a6a20a93ec5bf60060feb53 )
-)
-
-game (
-	name "Extreme Hunting 2"
-	year "2006"
-	developer "Sega"
-	rom ( name xtrmhnt2.zip size 122106350 crc ee9cc16c md5 01b8e7ce2cf0d023eeaf1ca3fe44b677 sha1 e83f8c2f8287e80c0f2ceae5069e4b5c7eb59a87 )
-)
-
-game (
-	name "Extreme Hunting"
-	year "2005"
-	developer "Sammy"
-	rom ( name xtrmhunt.zip size 104215731 crc 2a994ee7 md5 4bde7c8ff651f9a8c442aaf7af5dd53d sha1 d7dfde46494c97837ebacdb210dae345d18c8d7b )
-)
-
-game (
 	name "XX Mission"
 	year "1986"
 	developer "UPL"
@@ -60167,13 +44763,6 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311744 crc 02c2e99b md5 292a1cbc0304beaa0ca64831f537cbb4 sha1 3fe003a960431b455308fc212ee2d87500041759 )
-)
-
-game (
-	name "Xybots (rev 0)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name xybots0.zip size 276460 crc 9df71bce md5 7081c4ed11cb1ca739d7e6f2d6eb5715 sha1 bfb7140a4ec73a3b6d423490f08196057948137b )
 )
 
 game (
@@ -60345,48 +44934,6 @@ game (
 )
 
 game (
-	name "Youma Ninpou Chou (Japan)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name youma.zip size 220558 crc 2c332f21 md5 f409ff6a4705fbf49570ccd13be8fda8 sha1 5cb4a4922bb769a2a1e7802acaf58f945c8e7976 )
-)
-
-game (
-	name "Youma Ninpou Chou (Japan, alt)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name youma2.zip size 218421 crc 69e1a040 md5 e47170f4f375011d0e4bd5299b09a07f sha1 89cd194076d8636584083676b7dbeddd79e21035 )
-)
-
-game (
-	name "Youma Ninpou Chou (Game Electronics bootleg, set 1)"
-	year "1986"
-	developer "bootleg"
-	rom ( name youmab.zip size 231884 crc 6ca9d3f2 md5 563c776e12b94f65cc14c681b61776b9 sha1 966e4451e7342d8633e65713770ab7b83c970749 )
-)
-
-game (
-	name "Youma Ninpou Chou (Game Electronics bootleg, set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name youmab2.zip size 231559 crc 65445f7c md5 1b51e1805dc153662e0c99b229072ab5 sha1 57cd9a79cd69f4a9efe9ae2ceb89ef4bbbe567ce )
-)
-
-game (
-	name "Yu-Jan"
-	year "1999"
-	developer "Yubis / T.System"
-	rom ( name yujan.zip size 954075 crc e3156c85 md5 2523fa5f0656bf3dda9bc0e0dbe30700 sha1 2989ac4c2420787b627c0092fc16d1496a7b703e )
-)
-
-game (
-	name "Yu-Ka"
-	year "1999"
-	developer "Yubis / T.System"
-	rom ( name yuka.zip size 1156984 crc 35d0a61e md5 651a630a7b8199ea9505dbe23aabf927 sha1 762dc5457c9baa54eb902835c004a929a0238fea )
-)
-
-game (
 	name "Yukon (version 2.0)"
 	year "1989"
 	developer "Exidy"
@@ -60412,13 +44959,6 @@ game (
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name yuyugogo.zip size 2027558 crc 1553e098 md5 3c42b2338c506c5fc62c32830decbc9e sha1 615b8e61ce37e11318b91e79079b1f083524522f )
-)
-
-game (
-	name "Zarya Vostoka"
-	year "1984"
-	developer "Nova Games of Canada"
-	rom ( name zaryavos.zip size 18044 crc 26709d01 md5 88f333162afd69c4b6e114d8bb07ee87 sha1 0a5b2eaf84b98ca2941317a844fa2cfcfcfb7807 )
 )
 
 game (
@@ -60481,7 +45021,7 @@ game (
 	name "Zed Blade / Operation Ragnarok"
 	year "1994"
 	developer "NMK"
-	rom ( name zedblade.zip size 5159523 crc e1cb979e md5 77c18254f6ed7f9fbfdd3132440cfd7b sha1 e1affe2816ecfe10fba0c12e0b09283f64216441 )
+	rom ( name zedblade.zip size 6506210 crc c8445771 md5 18d54baef484d455ddc1cfa9394eb24a sha1 ee1296a8564021ed351f5f8ba3691528f7663661 )
 )
 
 game (
@@ -60506,34 +45046,6 @@ game (
 )
 
 game (
-	name "Zero Gunner (Model 2B)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zerogun.zip size 14877576 crc d7299369 md5 7a6d464a4b3962373b64b06ffb243cca sha1 1f689045bf27094dbc0b60098e072bb23ec8c6ec )
-)
-
-game (
-	name "Zero Gunner (Model 2A)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zeroguna.zip size 15312515 crc 413b92dd md5 f881205787f3eea2c7c80d4fbc580cd5 sha1 2ce2e8b8d633a9938a0d71dc3d19dae8f326ee14 )
-)
-
-game (
-	name "Zero Gunner (Japan Model 2B)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zerogunj.zip size 14877584 crc 866aabc2 md5 be77704a76ea352c49b95a8dc4cf1249 sha1 0f8edca5b562c874c36bf08ee52f815f53872839 )
-)
-
-game (
-	name "Zero Hour"
-	year "1980"
-	developer "Universal"
-	rom ( name zerohour.zip size 13101 crc 37aa3e08 md5 743be989d2cddf24ad3b3218cfc14ee3 sha1 cf85d15f48eae82c8e9afae3933d8764282453db )
-)
-
-game (
 	name "Zero Point (set 1)"
 	year "1998"
 	developer "Unico"
@@ -60555,52 +45067,10 @@ game (
 )
 
 game (
-	name "Zero Team (set 1)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteam.zip size 5811905 crc 51aa0af0 md5 8d000f291db067da20e3155f71c0a3ce sha1 6c68072430d8ba84564fa44b9ea23e062ea2be01 )
-)
-
-game (
-	name "Zero Team (set 2)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteama.zip size 5806819 crc eaa83473 md5 5e26a67e93cd0d41dc2f79918a32105b sha1 a9e51f9d9bd066ddaa4955da4706eba9116898bf )
-)
-
-game (
-	name "Zero Team (set 3)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteamb.zip size 5812224 crc 262c976c md5 6df04975d3a288eb31ec022b7233d66e sha1 b17f8889a8fd81bf8bf3bd7bffcd626c8acc5875 )
-)
-
-game (
-	name "Zero Team (set 4)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteamc.zip size 5810912 crc c32826bf md5 abd1d5dccb5436e158bd674fc3f1d7bd sha1 98d3ce67754659be23a3fa0e6b2d5273563019bb )
-)
-
-game (
-	name "Zero Team Selection"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteams.zip size 5808463 crc da606194 md5 c9ff6549b514de45f9e33301f0d7b4a1 sha1 36095034034db2c58583d30e96c9c3587fdcd955 )
-)
-
-game (
 	name "Zero Time"
 	year "1979"
 	developer "bootleg? (Petaco S.A.)"
 	rom ( name zerotime.zip size 10377 crc 3003cc94 md5 c52a3dd4ba1beb18d8e803c01fb0b64e sha1 60c3a1945c3c2b62b0b724ec4064267370d14e0b )
-)
-
-game (
-	name "Zero Target (World)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name zerotrgt.zip size 124967 crc 9ba32a1b md5 a05d47f048d0df8b12e3a0214c5b0e3e sha1 2c6076949f8c8a1d380826a97e4b736c67832ada )
 )
 
 game (
@@ -60622,20 +45092,6 @@ game (
 	year "1993"
 	developer "Comad"
 	rom ( name zerozone.zip size 441111 crc 85157b48 md5 928117f37cd1782061dc86b89b83b4a7 sha1 fc16ac825eb959af6180304e939c51ad9dc26a6c )
-)
-
-game (
-	name "Mobile Suit Z-Gundam: A.E.U.G. vs Titans (ZGA1 Ver. A)"
-	year "2003"
-	developer "Capcom / Banpresto"
-	rom ( name zgundm.zip size 1687219 crc a8dd5253 md5 689122fc656b728c14622480ab792c87 sha1 d1103f47c710dcbc7e9fb18b9c923d11d3ba39e7 )
-)
-
-game (
-	name "Mobile Suit Z-Gundam: A.E.U.G. vs Titans DX (ZDX1 Ver. A)"
-	year "2004"
-	developer "Capcom / Banpresto"
-	rom ( name zgundmdx.zip size 2086458 crc 53cecf96 md5 3ab2e430acea55d8386da089ca583e6c sha1 da4e5ee8e19ae78c2e56db6761ab0aba02869208 )
 )
 
 game (
@@ -60663,21 +45119,14 @@ game (
 	name "Zintrick / Oshidashi Zentrix (hack)"
 	year "1996"
 	developer "hack"
-	rom ( name zintrckb.zip size 2087676 crc d71221b7 md5 fb38821b2cd5736f7033e8562fa3d3c8 sha1 95b00af1fbbe8e58735a13b0d7dc7917a0d0388b )
-)
-
-game (
-	name "Zip _ Zap"
-	year "1995"
-	developer "Barko Corp"
-	rom ( name zipzap.zip size 1889854 crc b5f99dd5 md5 3128e2238388cbc3f27565eb04e21cc7 sha1 19cd1b0a118aee8d46e6cb6e8103a4f3fadf55cc )
+	rom ( name zintrckb.zip size 3434363 crc 81b42563 md5 374118c98b71b82d2e69cf77f59bbe3e sha1 50c80a8749990526c1d045511b52c9d40395f83c )
 )
 
 game (
 	name "Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000)"
 	year "1997"
 	developer "Sega"
-	rom ( name znpwfv.zip size 14635490 crc c01be769 md5 9f9ddc081899de18f5506f4958b7a0c5 sha1 62dd782dd33bc945382aba859ac985d3efbde4b4 )
+	rom ( name znpwfv.zip size 17334711 crc d6d77845 md5 9d3de4b6e0d56defed5d51bf141ccce7 sha1 a06a410592bdc808717317863ae5203a14cbdf3c )
 )
 
 game (
@@ -60695,23 +45144,17 @@ game (
 )
 
 game (
+	name "Zoku Otenamihaiken (V2.03J)"
+	year "2000"
+	developer "Success"
+	rom ( name zokuoten.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Zombie Raid (US)"
 	year "1995"
 	developer "American Sammy"
 	rom ( name zombraid.zip size 6902645 crc 56cfd5fd md5 11517c9ba52b85fa08a46446c54199e6 sha1 ece3db9236c9fce717d35443bfcae6da8bef2c01 )
-)
-
-game (
-	name "Zombie Revenge (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name zombrvn.zip size 92581206 crc ed57befe md5 e217770532c97d0dcfe9c88fb5f39567 sha1 cd27c69144b6f6979d9db3ab74d891e2698fc37a )
-)
-
-game (
-	name "Zoo"
-	developer "Astro Corp."
-	rom ( name zoo.zip size 984993 crc 6b386ca3 md5 89ed4d935eb0bd1bb7ba0e6cebe7f9fc sha1 1d68ac6c660331e104db1011ebbd5677af64d785 )
 )
 
 game (
@@ -60736,20 +45179,6 @@ game (
 )
 
 game (
-	name "Zoom 909"
-	year "1982"
-	developer "Sega"
-	rom ( name zoom909.zip size 92092 crc c5b3a53d md5 b489fc18bae9d84ef62109941828f2e4 sha1 44f821bfe36c63c32c207c388fee1165bf67c801 )
-)
-
-game (
-	name "Zorton Brothers (Los Justicieros)"
-	year "1993"
-	developer "Web Picmatic"
-	rom ( name zortonbr.zip size 37112 crc 5295e430 md5 4486ab0c46210f1da891487569af8c11 sha1 b2d470912c772d8167dcc64a560ca42b6d074420 )
-)
-
-game (
 	name "Zunzunkyou No Yabou (Japan)"
 	year "1994"
 	developer "Sega"
@@ -60760,14 +45189,7 @@ game (
 	name "Zupapa!"
 	year "2001"
 	developer "SNK"
-	rom ( name zupapa.zip size 17945799 crc 3c886433 md5 1536c540dab80feefc6ae2a880f3289b sha1 b89c7ddeb7a0828fb67bc50a55356af082b5360c )
-)
-
-game (
-	name "Zwackery"
-	year "1984"
-	developer "Bally Midway"
-	rom ( name zwackery.zip size 194039 crc 058b606e md5 a292f0585b2d99cb8da733ad7ecc5f94 sha1 8d2e8d67c6f1b90c37c9ea99db34e8297247b20a )
+	rom ( name zupapa.zip size 19292486 crc 75b76e6a md5 edcd0b309e88534252cefec0b0c0b4de sha1 3255db5df86610b7fdff37dff74119d5c9f7d3e1 )
 )
 
 game (

--- a/metadat/mame-split/MAME 2010.dat
+++ b/metadat/mame-split/MAME 2010.dat
@@ -1,13 +1,6 @@
 clrmamepro (
-	name "MAME 0.139 Split TorrentZipped (No BIOS, Device, Mechanical)"
-	version 2017-02-14
-)
-
-game (
-	name "005"
-	year "1981"
-	developer "Sega"
-	rom ( name 005.zip size 29769 crc d123fe67 md5 64ba2c1869a491bdae1384d3a95c2027 sha1 aeebfd4a3a6214e6efed19dd4d5716215e253b13 )
+  name "MAME 2010 Split Working"
+  version "2019-01-03"
 )
 
 game (
@@ -32,31 +25,10 @@ game (
 )
 
 game (
-	name "Eleven Beat"
-	year "1998"
-	developer "Hudson"
-	rom ( name 11beat.zip size 4787189 crc 5f254a6c md5 9acbaa0f01b5e2e988ed2c322f4962ea sha1 79f30a15c48ee8d625ae4376b56f764126c1579e )
-)
-
-game (
-	name "18 Wheeler (JPN)"
-	year "2000"
-	developer "Sega"
-	rom ( name 18wheelr.zip size 101133212 crc 093619ab md5 4d840a2b0a358ecc43c38b0f52a36bfd sha1 c133a08de797e3d74832d0d0866443003073f633 )
-)
-
-game (
 	name "1941: Counter Attack (World)"
 	year "1990"
 	developer "Capcom"
 	rom ( name 1941.zip size 1419821 crc de03fb24 md5 3a72d8463b47ce63dee199137a13ac64 sha1 d6ee54766d377d1136f6a5e17b772666a072e74e )
-)
-
-game (
-	name "1941: Counter Attack (Japan)"
-	year "1990"
-	developer "Capcom"
-	rom ( name 1941j.zip size 198831 crc 3e3858d8 md5 a7f35765472e9ea9dada3261ea653641 sha1 1fecb5f198c4dcc4e65968a63bd9b8a92f27e13e )
 )
 
 game (
@@ -92,34 +64,6 @@ game (
 	year "1985"
 	developer "Capcom (Williams Electronics license)"
 	rom ( name 1942w.zip size 42673 crc a348c6c4 md5 d587d7159b8dc29bab7b92938a2ac5ba sha1 980739111a38690ccd7022b9267a96e09bfe5d20 )
-)
-
-game (
-	name "1943: The Battle of Midway (Euro)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943.zip size 305392 crc d0e80fef md5 905c7d99b594af7fe2ac31392835e9b8 sha1 a5acd39d166a43450b8f01cafe1a6e98e7122b4e )
-)
-
-game (
-	name "1943: Midway Kaisen (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943j.zip size 63104 crc 47fdfba8 md5 0d85af4d039673d06b5813c804eab8b0 sha1 227b07dedd6430ebd6e88beca0f9bb3b7174ca40 )
-)
-
-game (
-	name "1943 Kai: Midway Kaisen (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943kai.zip size 313068 crc 992baef8 md5 763bf59dd41cfbf9540330b541d03f35 sha1 a4b53090206e4d7186a9615b6c3f3c7654b4d93e )
-)
-
-game (
-	name "1943: The Battle of Midway (US)"
-	year "1987"
-	developer "Capcom"
-	rom ( name 1943u.zip size 62872 crc 433c6a96 md5 251ef0ad4c1144a86f2278019b7fa0b0 sha1 a0970a904a869def6a4354250b4021a67552e306 )
 )
 
 game (
@@ -256,31 +200,10 @@ game (
 )
 
 game (
-	name "Datsun 280 Zzzap"
-	year "1976"
-	developer "Midway"
-	rom ( name 280zzzap.zip size 5229 crc c476b857 md5 6fda35567e29e62681add5de4c2d4f5b sha1 8dd2dc4e8abe83ab7ceb4c0fb553a3513652a44e )
-)
-
-game (
-	name "Two Minute Drill"
-	year "1993"
-	developer "Taito"
-	rom ( name 2mindril.zip size 5504856 crc f5588598 md5 3e78cb4f77323375f66e495bed6951b3 sha1 49e937b9f89bc1729171da44ad26cc98b1ad21e0 )
-)
-
-game (
 	name "39 in 1 MAME bootleg"
 	year "2004"
 	developer "bootleg"
 	rom ( name 39in1.zip size 2474365 crc 7d9cc353 md5 42d87d475a20d60d81df5bd08730970e sha1 0681320bc989a4099701cc331075b02cd37fb950 )
-)
-
-game (
-	name "3 Bags Full - 3VXFC5345 (New Zealand)"
-	year "1994"
-	developer "Aristocrat"
-	rom ( name 3bagflnz.zip size 53100 crc abe7d8ba md5 ae05bc562a050ac57d08bd3b2978de5e sha1 93b2902480c056be234514c6b2ecf7545fabe2d4 )
 )
 
 game (
@@ -298,13 +221,6 @@ game (
 )
 
 game (
-	name "XESS - The New Revolution (SemiCom 3-in-1)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name 3in1semi.zip size 1187337 crc c8ce23a8 md5 37ab524977d28c1fee901ddfdf200a02 sha1 5655e9f337cf9ddb9451a3ecc2ba22b27fe46e82 )
-)
-
-game (
 	name "Sankokushi (Japan)"
 	year "1996"
 	developer "Mitchell"
@@ -316,12 +232,6 @@ game (
 	year "1984"
 	developer "Mylstar"
 	rom ( name 3stooges.zip size 73365 crc 5fe01517 md5 716239c23bd55423ecb01bbaebadb870 sha1 36bb2c3c323eb31074f60bcfe5b11630232cba2c )
-)
-
-game (
-	name "3 Super 8 (Italy)"
-	developer "&lt;unknown&gt;"
-	rom ( name 3super8.zip size 403221 crc f14e771c md5 3135cb08fd8b92cb695e14046402e6a7 sha1 308f3f8ed4e5867143f5c337f1fe0a8716b89f9e )
 )
 
 game (
@@ -343,41 +253,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name 3wondersu.zip size 356164 crc 42a1b2af md5 60b5de4b7b0fc1216bb3ed9d9c7d22c0 sha1 91a9484929d961dd20581b71d484ee9c66e717d5 )
-)
-
-game (
-	name "Forty-Love"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
-)
-
-game (
-	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
-	year "1994"
-	developer "Jaleco"
-	rom ( name 47pie2.zip size 10228866 crc 09321e19 md5 f9d67336316a83050a1be7d3e174990c sha1 158bf6e56bcfdc03d0a32f7d881a07351554c8fd )
-)
-
-game (
-	name "Idol Janshi Su-Chi-Pie 2 (v1.0)"
-	year "1994"
-	developer "Jaleco"
-	rom ( name 47pie2o.zip size 753148 crc 97f1499c md5 63ef035a625f57b88c0e005cc1b519d5 sha1 74cbdac53287a774fafc99f67ba7932f03cac6e9 )
-)
-
-game (
-	name "48 in 1 MAME bootleg (ver 3.09)"
-	year "2004"
-	developer "bootleg"
-	rom ( name 48in1.zip size 465610 crc fcac4db2 md5 53f7ece036fa2e5ea6acc0cca7c6b51c sha1 1ae9c2ad1802c26da6bf3652fc0e0c1842050f86 )
-)
-
-game (
-	name "48 in 1 MAME bootleg (ver 3.02)"
-	year "2004"
-	developer "bootleg"
-	rom ( name 48in1a.zip size 482792 crc 7281b6ee md5 c5c1a55d199b20ab97c4638cbb1e2594 sha1 0767863a3c7b3bfa485bbdc460fda2585358395d )
 )
 
 game (
@@ -416,38 +291,10 @@ game (
 )
 
 game (
-	name "Four Roses (encrypted, set 1)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name 4roses.zip size 98411 crc 85e4951e md5 86cfb78de260094e1d7a322511c8a8fa sha1 b7549eb13876c5dd7bd16be3ff8c93419bb52cd8 )
-)
-
-game (
-	name "Four Roses (encrypted, set 2)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name 4rosesa.zip size 16802 crc 9153c9c8 md5 2ae16552fde83f8035f515e2c20875a8 sha1 4aa334bb0a78ffbc9593b740ddbccf48705a0250 )
-)
-
-game (
-	name "500 GP (5GP3 Ver. C)"
-	year "1998"
-	developer "Namco"
-	rom ( name 500gp.zip size 40299932 crc 9064fb08 md5 65e8098eed9cd9d2c7d7135b86677f94 sha1 046494e6a3f5dab02ada0eebe8f1906662705089 )
-)
-
-game (
 	name "Five Clown (English, set 1)"
 	year "1993"
 	developer "IGS"
 	rom ( name 5clown.zip size 63250 crc 97b36d3e md5 ada16ed9eb1ae6440babc982b8cdeb41 sha1 4b66f40192f075547d07e018c73ce57dc4e6bfb5 )
-)
-
-game (
-	name "Five Clown (English, set 2)"
-	year "1993"
-	developer "IGS"
-	rom ( name 5clowna.zip size 13513 crc a225b8a1 md5 12417f34738d661e66dd4ca1812b9efd sha1 1cbb4ace0dd0215bfa9ff63bf5ee912804ae4967 )
 )
 
 game (
@@ -462,20 +309,6 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14326 crc d5525571 md5 d2b402201bba517b9d100c2731ece9b4 sha1 55261d6a9e522cebfa8c1fc586f288cf5deb14f0 )
-)
-
-game (
-	name "64th. Street - A Detective Story (World)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
-)
-
-game (
-	name "64th. Street - A Detective Story (Japan)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name 64streetj.zip size 108598 crc 1ffe5fb9 md5 e101e9161e72f624dbe178a3caca8255 sha1 123d0776a452658849a27a124182a9cbef9607f5 )
 )
 
 game (
@@ -555,13 +388,6 @@ game (
 )
 
 game (
-	name "86 Lions"
-	year "1985"
-	developer "Aristocrat"
-	rom ( name 86lions.zip size 9957 crc 0ed6f606 md5 714d4ee21c6298a6ecf75c7f2bc12f03 sha1 8f35bf08a14c225c33b29da7675f56f35c97c66c )
-)
-
-game (
 	name "'88 Games"
 	year "1988"
 	developer "Konami"
@@ -583,31 +409,10 @@ game (
 )
 
 game (
-	name "Eight Ball Action (DK conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Magic Eletronics USA license)"
-	rom ( name 8ballact.zip size 16261 crc c7b9822e md5 81cc86d18b8604c5ba85de72830011b6 sha1 3024248c8c6f47b2ed4ac525b428236c43dafcd0 )
-)
-
-game (
-	name "Eight Ball Action (DKJr conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Magic Eletronics USA license)"
-	rom ( name 8ballact2.zip size 15523 crc 79ca2322 md5 6a279a7c5cfb030d1e2cd3bac33d23d5 sha1 da2aea3362ccf1ed1262d0f12520e0defbbd24a5 )
-)
-
-game (
 	name "Eight Ball Action (Pac-Man conversion)"
 	year "1985"
 	developer "Seatongrove Ltd (Magic Eletronics USA license)"
 	rom ( name 8bpm.zip size 12301 crc 1f39b634 md5 2c509ce7e2234e2a43c2b7b8005b64cf sha1 b685ca19a861607053aade8557ef9283e969544b )
-)
-
-game (
-	name "'98 NeoPri Best 44 (Neo Print)"
-	year "1998"
-	developer "SNK"
-	rom ( name 98best44.zip size 2135046 crc 75d47503 md5 76256e30153a2d37e5b28a46b5d2476f sha1 49ea078bb54fbe888355b1fc0e812579d18f500a )
 )
 
 game (
@@ -667,20 +472,6 @@ game (
 )
 
 game (
-	name "Area 51: Site 4"
-	year "1998"
-	developer "Atari Games"
-	rom ( name a51site4.zip size 90541 crc 3a259eba md5 f51c3a40f277deeccdf558928aba7508 sha1 09dcbbab7451775571c3d8c4fd82bfbd78ec37aa )
-)
-
-game (
-	name "All American Football (rev E)"
-	year "1989"
-	developer "Leland Corp."
-	rom ( name aafb.zip size 525577 crc 4535f25a md5 234ae3914d7eb81036e38beb0eca4d9b sha1 4e33bdea83ad2897e40855ed163ba0d06eb4e5de )
-)
-
-game (
 	name "All American Football (rev B)"
 	year "1989"
 	developer "Leland Corp."
@@ -699,12 +490,6 @@ game (
 	year "1989"
 	developer "Leland Corp."
 	rom ( name aafbd2p.zip size 118751 crc eec3de3b md5 11872304d8595dee360eba55509906b9 sha1 8b8dd86c03b111ae5f3361a33b436e15aab93501 )
-)
-
-game (
-	name "Abacus (Ver 1.0)"
-	developer "&lt;unknown&gt;"
-	rom ( name abacus.zip size 496571 crc 638c65fb md5 9e0c86a40c53bf8f57eb1ecef83a22d6 sha1 432780165ad18f851818961e18dab2eb093c5976 )
 )
 
 game (
@@ -799,20 +584,6 @@ game (
 )
 
 game (
-	name "Ace"
-	year "1976"
-	developer "Allied Leisure"
-	rom ( name ace.zip size 2862 crc 3db2236f md5 83ca82ca99a83dfee572e8a0ce62d7a0 sha1 185e6ac2d1b76bcb4007e048fe2d325229173806 )
-)
-
-game (
-	name "Ace Attacker (FD1094 317-0059)"
-	year "1988"
-	developer "Sega"
-	rom ( name aceattac.zip size 469948 crc feef4f10 md5 184de2ebe9706e4ddbeb86a49cbdf9e8 sha1 bdd2ccf04d4ba8f9662413aba01e48bfc4158ec3 )
-)
-
-game (
 	name "Ace Attacker (Japan, System 16A, FD1094 317-0060)"
 	year "1988"
 	developer "Sega"
@@ -824,12 +595,6 @@ game (
 	year "1994"
 	developer "Namco"
 	rom ( name acedrvrw.zip size 7790956 crc ecc23531 md5 26343984ae1b62631f08252183c307c1 sha1 19961e0a7360028570448f5a2eae6af8c74bbac8 )
-)
-
-game (
-	name "unknown ACE fruits game"
-	developer "ACE"
-	rom ( name acefruit.zip size 12257 crc 73cf297e md5 c9e0a328229c76e9eb6182149e2ee0d2 sha1 7aa6eb7da57e61788a7fd127aa9c6349740a29c5 )
 )
 
 game (
@@ -851,13 +616,6 @@ game (
 	year "1979"
 	developer "bootleg"
 	rom ( name acombato.zip size 10439 crc 40d43a65 md5 99e75449e9221dcbc1b08682f6cda4c6 sha1 646166aec7b2895eb5ede4ebb16348699b3fb09e )
-)
-
-game (
-	name "Alien Command"
-	year "1994"
-	developer "Jaleco"
-	rom ( name acommand.zip size 2788724 crc 91946a02 md5 12df5b1c39cac7f9fe8939fc50cb9b3f sha1 108742eb6144c0c1f072ace2688688dea72b907c )
 )
 
 game (
@@ -956,34 +714,6 @@ game (
 	year "1989"
 	developer "Data East Corporation"
 	rom ( name actfancrj.zip size 51433 crc 69e2089e md5 2e1376a3ac79eb39d050ca20f88fb43d sha1 bdd910c192b4a4fae71db40fed3f7e19f1d42118 )
-)
-
-game (
-	name "Action Hollywood"
-	year "1995"
-	developer "TCH"
-	rom ( name actionhw.zip size 1321130 crc 34e2ced3 md5 560b7326579a82c1f92de6949a84960b sha1 4078379bf8e45be863a1ce175841f213def23e10 )
-)
-
-game (
-	name "A. D. 2083"
-	year "1983"
-	developer "Midcoin"
-	rom ( name ad2083.zip size 37545 crc 3676a561 md5 0838dc3da631045ddf93611f0d32090f sha1 0d59e1987ce60306df165d307ef0c26e3677b38c )
-)
-
-game (
-	name "Adders and Ladders (v2.0)"
-	year "1989"
-	developer "Barcrest"
-	rom ( name adders.zip size 527319 crc 104980a2 md5 ae2ed9f9fa402faf594ba47fd32f5744 sha1 96a133a33b096c35ae3d7de2bf8d6f886c067188 )
-)
-
-game (
-	name "Adonis (A - 25-05-98, NSW/ACT)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name adonis.zip size 601302 crc 1c06fe91 md5 5fe7e1e60769331aadc65ed77f8b8992 sha1 8b14ee68c46175b59500192c52e1490fb168428c )
 )
 
 game (
@@ -1134,13 +864,6 @@ game (
 )
 
 game (
-	name "Air Inferno (US)"
-	year "1990"
-	developer "Taito America Corporation"
-	rom ( name ainferno.zip size 1149947 crc c94d1c87 md5 c341009c791ed4e5668e528a3ba097e2 sha1 f1917a825c143682381ae1641ed1cf51f9d0bef5 )
-)
-
-game (
 	name "Air Attack (set 1)"
 	year "1996"
 	developer "Comad"
@@ -1155,80 +878,10 @@ game (
 )
 
 game (
-	name "Air Buster: Trouble Specialty Raid Unit (World)"
-	year "1990"
-	developer "Kaneko (Namco license)"
-	rom ( name airbustr.zip size 693968 crc d9e397ed md5 48fe2cda23a4ec913b254fcf67ca17b0 sha1 9f3d12511be5bc05d17c220d1a933a12698df5f1 )
-)
-
-game (
 	name "Air Buster: Trouble Specialty Raid Unit (bootleg)"
 	year "1990"
 	developer "bootleg"
 	rom ( name airbustrb.zip size 693421 crc c104e133 md5 2f84a386de9d416ad6eb735afe966d7f sha1 5325ed965ec5cbb0ea22b314ae058f534d4f550e )
-)
-
-game (
-	name "Air Buster: Trouble Specialty Raid Unit (Japan)"
-	year "1990"
-	developer "Kaneko (Namco license)"
-	rom ( name airbustrj.zip size 118196 crc 35ba7c90 md5 69a1f9c8b11fc541bbec7b07249c55ce sha1 7dc27b2def38201b4a21b8c4a30a2294cb9acd45 )
-)
-
-game (
-	name "Air Combat 22 (Rev. ACS1 Ver.B, Japan)"
-	year "1995"
-	developer "Namco"
-	rom ( name airco22b.zip size 17502906 crc 15b0e20a md5 bd693068dccc61ef457e8cb608dd2dc0 sha1 f014ce2b006df935a9d2213e9ee16566dcd5df09 )
-)
-
-game (
-	name "Air Combat (US)"
-	year "1992"
-	developer "Namco"
-	rom ( name aircomb.zip size 3285350 crc 435615cc md5 b61f229acfa736f82d1a8bff27225700 sha1 415c38f5fa1bd61bf76082882fbaf13b89c28036 )
-)
-
-game (
-	name "Air Combat (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name aircombj.zip size 905318 crc dd5befb4 md5 ea5fa598559367a9683fc89a997e52b7 sha1 055c69e847b6b9a06a71cd6ef3081892ff8c6814 )
-)
-
-game (
-	name "Air Duel (Japan)"
-	year "1990"
-	developer "Irem"
-	rom ( name airduel.zip size 1129917 crc 9d4f621c md5 f32170fdb460883767cdd30e3fec4def sha1 3a77c08f548679ff8f1d7e2a5722e7031e0ae797 )
-)
-
-game (
-	name "Air Raid (encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu"
-	rom ( name airraid.zip size 54989 crc 706d7fc6 md5 dee6ea84024c892fbb10ed9479cb6d8d sha1 b45761fab41231b5be8053144a0f4c1266d5b84e )
-)
-
-game (
-	name "Air Trix"
-	year "2000"
-	developer "Sega"
-	rom ( name airtrix.zip size 43740423 crc 112e51c1 md5 b86df32c6480ab682ac33eb37a4df1f9 sha1 49b8f405a59b9a222fb5df852468ca037c52e96c )
-)
-
-game (
-	name "Airwolf"
-	year "1987"
-	developer "Kyugo"
-	rom ( name airwolf.zip size 81889 crc 11104399 md5 962be6e1dcc6bff7861750416468419d sha1 6d139e060f781ee3a41618113aff13d0a9836942 )
-)
-
-game (
-	name "Airwolf (US)"
-	year "1987"
-	developer "Kyugo (UA Theatre license)"
-	rom ( name airwolfa.zip size 18845 crc c2d30740 md5 9e2e1a233be9d6e8f19148d96e7541df sha1 04580466196d2b9130dd61172706373338e268ae )
 )
 
 game (
@@ -1250,13 +903,6 @@ game (
 	year "1996"
 	developer "Dynax (Nakanihon license)"
 	rom ( name akamaru.zip size 5870697 crc 1f829dfd md5 6c2604e10553e30e4f2ce4aae7ccd7d8 sha1 60cc32f9eca177ef17f87edaf8c40939178446dc )
-)
-
-game (
-	name "Mahjong Angel Kiss"
-	year "1995"
-	developer "Jaleco"
-	rom ( name akiss.zip size 13222340 crc 63cbbff4 md5 6c26fe69eb301a68a489174881fb58ae sha1 834cbff5a4e90fb9fdeb10e550cf7090dbe3a6aa )
 )
 
 game (
@@ -1288,20 +934,6 @@ game (
 )
 
 game (
-	name "Alex Kidd: The Lost Stars (set 1, FD1089A 317-0021)"
-	year "1986"
-	developer "Sega"
-	rom ( name alexkidd1.zip size 170861 crc d193ba16 md5 f4db60e727d234b7227fd4816b25c219 sha1 46ff1d3297d17e27400fafbff405fb322b445929 )
-)
-
-game (
-	name "Ali Baba and 40 Thieves"
-	year "1982"
-	developer "Sega"
-	rom ( name alibaba.zip size 20184 crc a5edcb7a md5 fdb65ceadc7d9362bf56e5e2e4e40436 sha1 4bae12a1e21275f9093a4f9c7e52934da6d86895 )
-)
-
-game (
 	name "Alien3: The Gun (World)"
 	year "1993"
 	developer "Sega"
@@ -1327,20 +959,6 @@ game (
 	year "1985"
 	developer "Duncan Brown"
 	rom ( name alienaru.zip size 2904 crc 193001ef md5 28dc4efc020520999e07a8c2915d9b5d sha1 14a13d7a5f4e42cb343f57af7fd9c964ebcb85a3 )
-)
-
-game (
-	name "Alien Challenge (World)"
-	year "1994"
-	developer "IGS"
-	rom ( name aliencha.zip size 11413569 crc f66e5bd1 md5 d3cfdd25bf2d65da705afe9ea3ced31f sha1 3cd2e364de1ea7244f6fa24bca235b2cb3cd1123 )
-)
-
-game (
-	name "Alien Challenge (China)"
-	year "1994"
-	developer "IGS"
-	rom ( name alienchac.zip size 186865 crc 9e10468c md5 4c8cfd087d777a89fdb64043e246f722 sha1 6ebcef4402aa0255243d6a0cd953c80acebfa675 )
 )
 
 game (
@@ -1454,13 +1072,6 @@ game (
 )
 
 game (
-	name "Alligator Hunt"
-	year "1994"
-	developer "Gaelco"
-	rom ( name aligator.zip size 8818059 crc 7013687a md5 17462eef86a896ca2b564e6f54aa1efa sha1 87865984a5566757b0971576dc3df25f05bd78da )
-)
-
-game (
 	name "Alligator Hunt (unprotected)"
 	year "1994"
 	developer "Gaelco"
@@ -1472,19 +1083,6 @@ game (
 	year "1986"
 	developer "Cinematronics"
 	rom ( name alleymas.zip size 101524 crc ec12950f md5 744f23541de1eb4349750db469062c9f sha1 f58e4a3cea9ff7d4b43703f78c61c98d90106b8b )
-)
-
-game (
-	name "Alpha One (Vision Electronics / Kyle Hodgetts)"
-	year "1988"
-	developer "Vision Electronics"
-	rom ( name alpha1v.zip size 25694 crc a653cde6 md5 ffa16bc2f8a9ca089c86e70009404ada sha1 f02041829776206270c084c84b7dc9a9fd0d4f90 )
-)
-
-game (
-	name "Alpha Fighter / Head On"
-	developer "Data East Corporation"
-	rom ( name alphaho.zip size 14445 crc 184c8caa md5 9a5f40b6be34059e7db8ba9678436939 sha1 63b322f199de66a9bdda6b919747520278d562bf )
 )
 
 game (
@@ -1502,38 +1100,10 @@ game (
 )
 
 game (
-	name "Alpha One (prototype, 3 lives)"
-	year "1983"
-	developer "Atari"
-	rom ( name alphaone.zip size 53724 crc d26f9b80 md5 739eea18d143762de1dde265fe0a73c5 sha1 300688c44035ef36dd2aa3e6879146efca364da7 )
-)
-
-game (
-	name "Alpha One (prototype, 5 lives)"
-	year "1983"
-	developer "Atari"
-	rom ( name alphaonea.zip size 53721 crc 67526513 md5 bc830cd225c8a21fbe2318a0b3e544ed sha1 79c3ee3e5322dfa3807269b94c5d56a83e53cf8b )
-)
-
-game (
 	name "The Alphax Z (Japan)"
 	year "1986"
 	developer "Ed Co. Ltd. (Wood Place Inc. license)"
 	rom ( name alphaxz.zip size 50462 crc 0ef150b1 md5 e98b9a4bf2690c766dca9d9eda1595e8 sha1 5bec9a026684848583b03f42d80cd97e137cd4d6 )
-)
-
-game (
-	name "Airline Pilots (Rev A)"
-	year "1999"
-	developer "Sega"
-	rom ( name alpilota.zip size 1028479 crc f6ee2e9b md5 1b5a1e1b6771077c6ae449e986ca4e57 sha1 81bd5046b5fdaec4d477f884e516f8d8969a83f1 )
-)
-
-game (
-	name "Airline Pilots Deluxe (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name alpiltdx.zip size 42574169 crc 6e85c373 md5 0c0386125a39262de9bc6441462f9599 sha1 36b53082f4d315c8f0a4f6afd60269a824fcb474 )
 )
 
 game (
@@ -1572,13 +1142,6 @@ game (
 )
 
 game (
-	name "Alpine Racer 2 (Rev. ARS2 Ver.A)"
-	year "1996"
-	developer "Namco"
-	rom ( name alpinr2a.zip size 1657449 crc 65e7fa7d md5 a839b75fbdabed77529b986eb43b0f76 sha1 0d87055c57cc07a71fd68a06c8484f2bd45118e6 )
-)
-
-game (
 	name "Alpine Racer 2 (Rev. ARS2 Ver.B)"
 	year "1996"
 	developer "Namco"
@@ -1590,13 +1153,6 @@ game (
 	year "1981"
 	developer "Cidelsa"
 	rom ( name altair.zip size 9758 crc 88e8c78f md5 969a24aff748af9049223096032cc7e0 sha1 c0ba33ad1af34707ed6ba863e3d5e4ac0471148c )
-)
-
-game (
-	name "Altered Beast (set 8, 8751 317-0078)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeast.zip size 848905 crc e431711b md5 64ae9698dd3816c123e464ef1df3f446 sha1 5d1431b186c2fe481bc7c2a84f565405e1ed1c9a )
 )
 
 game (
@@ -1614,59 +1170,10 @@ game (
 )
 
 game (
-	name "Altered Beast (set 6, 8751 317-0076)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeast5.zip size 668682 crc 85347f3b md5 150869a07b28ef1012d9c4d30ed59c07 sha1 519055a3c5fe7f702441045f496e17d5609880d7 )
-)
-
-game (
-	name "Juuouki (set 7, Japan, 8751 317-0077)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj.zip size 668488 crc 8d90dcd0 md5 3ceb4c488fd96e55081df9755ac16f33 sha1 39daaa89c097c1ad256c641a476449514069b619 )
-)
-
-game (
-	name "Juuouki (set 1, Japan, FD1094 317-0065)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj1.zip size 134963 crc 62d0c5e1 md5 9ec8b5873b49e4b813bbd6dc5edb3ecb sha1 4049c4a0885b510fcb99b5afe5b330503b021ea9 )
-)
-
-game (
-	name "Juuouki (set 5, Japan, FD1094 317-0069)"
-	year "1988"
-	developer "Sega"
-	rom ( name altbeastj2.zip size 701354 crc 1ae84936 md5 c296ab93dc35e53189ee7f514fecb6af sha1 31a5150ecb07f57c50a6375776cdd48fdcd02178 )
-)
-
-game (
 	name "Juuouki (set 3, Japan, FD1094 317-0068)"
 	year "1988"
 	developer "Sega"
 	rom ( name altbeastj3.zip size 708968 crc 2c5b74d0 md5 6f41233273b2274598291488b87893ec sha1 f80f7d070fe71823927bf521cd2225bdcc65c8cc )
-)
-
-game (
-	name "Multi Game I (V.Ger 2.4)"
-	year "2000"
-	developer "Amatic Trading GmbH"
-	rom ( name am_mg24.zip size 606363 crc e907f644 md5 1c44b9378af3ac34936bcc59e79b6554 sha1 af7c0ccac63bb51845ca13fa652df3ecf8e008eb )
-)
-
-game (
-	name "Multi Game III (V.Ger 3.5)"
-	year "2000"
-	developer "Amatic Trading GmbH"
-	rom ( name am_mg3.zip size 626214 crc 501c6844 md5 854e18a545d7dd0f3866040aabd69b3d sha1 9ef1d9d2995c93663020a136e8cc4342c675c001 )
-)
-
-game (
-	name "Amatic Unknown Slots Game"
-	year "1996"
-	developer "Amatic Trading GmbH"
-	rom ( name am_uslot.zip size 67278 crc 433189d5 md5 f1a7ffc98f48ce702c542b20903d7d61 sha1 e2a96462f91ba83b947d315765dff5b0be326981 )
 )
 
 game (
@@ -1702,12 +1209,6 @@ game (
 	year "1983"
 	developer "Tecfri (Volt Electronics license)"
 	rom ( name ambushv.zip size 29568 crc 51ff98a5 md5 e751b88eb9b415fe84003d1e51e743c9 sha1 08f6427b728fccaaf8a289605572e094d3154369 )
-)
-
-game (
-	name "Amcoe Link Control Box (Version 2.2)"
-	developer "Amcoe"
-	rom ( name amclink.zip size 59340 crc 14d4a266 md5 fcb965547eff756cbbe69022b9d771c9 sha1 405eebe64f2ac8afecbe6a03858e5b1e341b630f )
 )
 
 game (
@@ -1858,13 +1359,6 @@ game (
 )
 
 game (
-	name "Andromeda (Japan?)"
-	year "1979"
-	developer "IPM"
-	rom ( name andromed.zip size 7933 crc 7b192acc md5 8dde2f27d822dbda1e86e19a365794d5 sha1 88e4fe7323b37647d30e249e2458532675fb5e92 )
-)
-
-game (
 	name "Angel Kids (Japan)"
 	year "1988"
 	developer "Sega / Nasco?"
@@ -1974,13 +1468,6 @@ game (
 	year "1993"
 	developer "Nakanihon / East Technology (Taito license)"
 	rom ( name animaljrj.zip size 318563 crc dcd49beb md5 e6d726f2dd4d42a548b8f1887972dc71 sha1 1db64018471d49d881d86da988889340a82307a7 )
-)
-
-game (
-	name "Animalandia Jr. (Spanish)"
-	year "1993"
-	developer "Nakanihon / East Technology (Taito license)"
-	rom ( name animaljrs.zip size 515968 crc 543dc3d8 md5 db5e3fdee3cdad39f3dfc0ace4d72977 sha1 e5444947e2c8d8e85c68895f076b7a8ace51449a )
 )
 
 game (
@@ -2166,12 +1653,6 @@ game (
 )
 
 game (
-	name "Platoon V.?.? US"
-	developer "Nova?"
-	rom ( name aplatoon.zip size 131361 crc a3a933ac md5 beb4ea5a5454e09639b2c5e5c71e4766 sha1 903982d84001dbd1c6d6999ddec412d3bbaba921 )
-)
-
-game (
 	name "Apocaljpse Now"
 	year "1982"
 	developer "bootleg"
@@ -2188,7 +1669,7 @@ game (
 game (
 	name "Apple 10 (Ver 1.21)"
 	year "1998"
-	developer "Sandii&apos;"
+	developer "Sandii'"
 	rom ( name apple10.zip size 144770 crc bb8f8b1c md5 3a628b009003222af70ad3b3d70a9290 sha1 bf8aced9d241cba0631b442060f1b19d8e189472 )
 )
 
@@ -2260,20 +1741,6 @@ game (
 	year "1987"
 	developer "Arcadia Systems"
 	rom ( name ar_dart.zip size 326135 crc 8cbc717c md5 6df354d34bb00d6794ec8a5b092ccaf7 sha1 0031cfb122f07695c3ab395882d60274208cc218 )
-)
-
-game (
-	name "World Darts (Arcadia, set 2)"
-	year "1987"
-	developer "Arcadia Systems"
-	rom ( name ar_dart2.zip size 323979 crc 563706a3 md5 b5a74950786a0241d732a648889ea6f7 sha1 71040950ff16eefd3c056c41f8425cb8e39da25a )
-)
-
-game (
-	name "Magic Johnson's Fast Break (Arcadia, V 2.8)"
-	year "1988"
-	developer "Arcadia Systems"
-	rom ( name ar_fast.zip size 485048 crc 196c2e53 md5 259252446be16ccb76785cef691d4a7f sha1 527927ba7d8089a555566b7f452e30aa60cdaf3a )
 )
 
 game (
@@ -2437,20 +1904,6 @@ game (
 )
 
 game (
-	name "Arch Rivals (rev 4.0)"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name archrivl.zip size 360208 crc d8667efb md5 9152563491b6a5244b57c291b63cbd2c sha1 680e6b296fcc288dc90aa11ae571d6566fc73c80 )
-)
-
-game (
-	name "Arch Rivals (rev 2.0)"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name archrivl2.zip size 81643 crc 4fa10e40 md5 7eaa2ba5d43217a9dcd2c84440b3be25 sha1 958d4d5b937ccd6b4d1e936a47e67befa5702216 )
-)
-
-game (
 	name "Area 51 (R3000)"
 	year "1996"
 	developer "Atari Games"
@@ -2514,13 +1967,6 @@ game (
 )
 
 game (
-	name "Arkanoid (bootleg with MCU, harder)"
-	year "1986"
-	developer "bootleg"
-	rom ( name ark1ball.zip size 36470 crc c2fc7ac9 md5 ecd65023c9155aeb7778bc07f865a83a sha1 40d04eb9c3cef09ccd9ce8aa8c7f9c6f22a8f57e )
-)
-
-game (
 	name "Arkanoid (Game Corporation bootleg, set 1)"
 	year "1986"
 	developer "bootleg (Game Corporation)"
@@ -2542,20 +1988,6 @@ game (
 )
 
 game (
-	name "Arkanoid (Japan)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name arkanoidj.zip size 37324 crc f23510b4 md5 862ab076cd1ddfd95c7446247b2c0435 sha1 5cef8244d3ba7e413574ee38bf5202f3c6db1c38 )
-)
-
-game (
-	name "Arkanoid (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arkanoidu.zip size 37221 crc cd0e2dd9 md5 20dff2be2fc979b61b29a6f61315cd24 sha1 81d869b2c9d812d4a9718e28134c9505db660fab )
-)
-
-game (
 	name "Arkanoid (US, older)"
 	year "1986"
 	developer "Taito America Corporation (Romstar license)"
@@ -2574,13 +2006,6 @@ game (
 	year "1986"
 	developer "bootleg (Tayto)"
 	rom ( name arkatayt.zip size 36618 crc a9b718d3 md5 b1f0e0881890588eb9184811e6d023aa sha1 e9b12ffdce528420c89b36848d33e896f302b927 )
-)
-
-game (
-	name "Tournament Arkanoid (US)"
-	year "1987"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arkatour.zip size 68720 crc ae0fb022 md5 d31e4e5c2d9539d2e016837a24e87c07 sha1 01313a342b3aac403e2fbc357243ee6d7048e3f8 )
 )
 
 game (
@@ -2616,34 +2041,6 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name arkgcbla.zip size 37860 crc 10bed885 md5 e5031ec63e9be556a881fe9c1d86f296 sha1 83984708bbee9cdff58f3449083fb310764b3419 )
-)
-
-game (
-	name "Arkanoid (bootleg with MCU)"
-	year "1986"
-	developer "bootleg"
-	rom ( name arkmcubl.zip size 37271 crc 6b02e681 md5 c22fa44d54ebea9988ea1b285e628721 sha1 b68681ca7c3b5b15cf4e50a41174ac6e9ba80e01 )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (World)"
-	year "1987"
-	developer "Taito Corporation Japan"
-	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name arknoid2j.zip size 17257 crc 32bd6d4f md5 e1fee4ded4282ab2baaa8ef04f909637 sha1 4bb3b0509712b736180763bde5f0f0ff81f1c42a )
-)
-
-game (
-	name "Arkanoid - Revenge of DOH (US)"
-	year "1987"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name arknoid2u.zip size 42246 crc 4a89847e md5 114ddc55aaefe0b23a8f13bcc339a2fe sha1 53e6ebb4a181e2548a42ad40024ba5ebca02228f )
 )
 
 game (
@@ -2955,13 +2352,6 @@ game (
 )
 
 game (
-	name "Alien Storm (bootleg, set 2)"
-	year "1990"
-	developer "bootleg"
-	rom ( name astormb2.zip size 2187068 crc 8eeb013d md5 39a1a92ba84492fb630d61e1ab3d4890 sha1 a5145c95f8e97245dbbb562dface9ff6bdde01bd )
-)
-
-game (
 	name "Alien Storm (bootleg, set 1)"
 	year "1990"
 	developer "bootleg"
@@ -2983,24 +2373,10 @@ game (
 )
 
 game (
-	name "Astra SuperStars (J 980514 V1.002)"
-	year "1998"
-	developer "Sunsoft"
-	rom ( name astrass.zip size 17183446 crc ccb36035 md5 1e8fd5e2cc3905c31a7add667cb181b0 sha1 3872eb964ff84c652e465222c9d93f00bb749b71 )
-)
-
-game (
 	name "Astro Blaster (version 3)"
 	year "1981"
 	developer "Sega"
 	rom ( name astrob.zip size 34688 crc aa435f8b md5 bbec3c2b9eea2b3e628e599b407ec087 sha1 95abe377dfa5d531928584ba58cd57fc811210f2 )
-)
-
-game (
-	name "Astro Blaster (version 1)"
-	year "1981"
-	developer "Sega"
-	rom ( name astrob1.zip size 22730 crc f60888e1 md5 b1770ed411b2edd231743d1501aa0b80 sha1 f57473c6b79c914bbae644fadcf8fd03a56a192a )
 )
 
 game (
@@ -3053,37 +2429,9 @@ game (
 )
 
 game (
-	name "Astron Belt"
-	year "1983"
-	developer "Sega"
-	rom ( name astron.zip size 62658 crc bdb608d9 md5 4a85f633afcbde8d25d83d8de3ce092f sha1 6d3f6f922c934cee5ca6a3e01e3fda41587b9b8a )
-)
-
-game (
-	name "Astron Belt (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name astronp.zip size 23307 crc a6376f98 md5 72f8a1866c7002f399676d6bd9eb369a sha1 f3c93e9f90876706fac7ab9bc6163c1dede1503b )
-)
-
-game (
 	name "Astropal"
 	developer "Sidam?"
 	rom ( name astropal.zip size 7000 crc af301370 md5 fc7e7ed8a3c16ef410ef693bb8b85904 sha1 b326e28cbadfb85b67c5ca55fed394594e75ffd4 )
-)
-
-game (
-	name "Astro Wars"
-	year "1980"
-	developer "Zaccaria"
-	rom ( name astrowar.zip size 11367 crc 1cdd3f69 md5 8de1a73da08220fea25b603244b28e08 sha1 f110a254fcfdd243e701842723e4c53812f5886f )
-)
-
-game (
-	name "The Astyanax"
-	year "1989"
-	developer "Jaleco"
-	rom ( name astyanax.zip size 1101266 crc bcf42d2b md5 2f3aad524d08d3e64c0a0993a227a423 sha1 bdcc2b5eee0be493445729a53bb749206aa55adb )
 )
 
 game (
@@ -3119,13 +2467,6 @@ game (
 	year "1991"
 	developer "Leland Corp."
 	rom ( name asylum.zip size 2396177 crc a0136f4d md5 2962b861c8ef9156f8f46633c8674bc4 sha1 28f11ac38e1cb1d12cad85aa5837a694f1a8ccc4 )
-)
-
-game (
-	name "Computer Quiz Atama no Taisou (Japan)"
-	year "1983"
-	developer "Yachiyo Denki / Uni Enterprize"
-	rom ( name atamanot.zip size 111986 crc adf7a04e md5 a994705a32c4c6da8fd1a063ba77e1e4 sha1 712b6cdd6c0a2f199ad371cbaea986b669f0651a )
 )
 
 game (
@@ -3332,52 +2673,10 @@ game (
 )
 
 game (
-	name "Automat (bootleg of Robocop)"
-	year "1988"
-	developer "bootleg"
-	rom ( name automat.zip size 385778 crc 09ae667c md5 e49d5f0cfc43eb90581d625cf82d7c47 sha1 9adfa22a709852f53100b56c0e9e90b37746ba68 )
-)
-
-game (
-	name "AV2Mahjong No.1 Bay Bridge no Seijo (Japan)"
-	year "1991"
-	developer "Miki Syouji / AV Japan"
-	rom ( name av2mj1bb.zip size 280169 crc f50b0395 md5 6f3515819019cab7a132226212f9ecec sha1 955c46125885387c5cfbe2f555c8d4a52a5d3977 )
-)
-
-game (
-	name "AV2Mahjong No.2 Rouge no Kaori (Japan)"
-	year "1991"
-	developer "Miki Syouji / AV Japan"
-	rom ( name av2mj2rg.zip size 357844 crc c28d815e md5 8c779e441107a304eb446db66ca41a63 sha1 1f06c34b43fa49a07d31fd8add8fedd7930955f4 )
-)
-
-game (
 	name "Avalanche"
 	year "1978"
 	developer "Atari"
 	rom ( name avalnche.zip size 5012 crc 70e24341 md5 2df7eff0a72abbf89c57dd4cbb7c2a32 sha1 60ee8d4019e43f733d36819ea40dc307c327daa5 )
-)
-
-game (
-	name "The Key Of Avalon 1.3 - Chaotic Sabbat - Client (GDT-0010C) (V4.000)"
-	year "2004"
-	developer "Sega"
-	rom ( name avalon13.zip size 213 crc f8875e42 md5 2a31941e25d8780971d76be81dd0432f sha1 4d2fbe71a0b75f2335ea3790b0a1c6697323530d )
-)
-
-game (
-	name "The Key Of Avalon 2.0 - Eutaxy and Commandment - Client (GDT-0017B) (V3.001)"
-	year "2004"
-	developer "Sega"
-	rom ( name avalon20.zip size 213 crc d35c5df2 md5 2d46157b2570e06be8f293348ed93d8b sha1 a78f9cb8f6fa8f2336dfca8590161643a04de708 )
-)
-
-game (
-	name "The Key Of Avalon - The Wizard Master - Server (GDT-0005C) (V4.001)"
-	year "2003"
-	developer "Sega"
-	rom ( name avalons.zip size 211 crc c20b3755 md5 bd3e160f8a78b9e19b02421eeb48aed3 sha1 e8d98a549d016844182f33d524074aae1009c4de )
 )
 
 game (
@@ -3437,13 +2736,6 @@ game (
 )
 
 game (
-	name "Avenging Spirit"
-	year "1991"
-	developer "Jaleco"
-	rom ( name avspirit.zip size 1060778 crc 6707417d md5 cf4e3c32cdd6158b51585915ede39195 sha1 3cef5b36308d25e6612d72f83d6badb8d971268c )
-)
-
-game (
 	name "Alien vs. Predator (Japan 940520)"
 	year "1994"
 	developer "Capcom"
@@ -3462,13 +2754,6 @@ game (
 	year "1983"
 	developer "Centuri"
 	rom ( name aztarac.zip size 32536 crc ad36a737 md5 69fd96aa9ec408b6b5e49ff31c531458 sha1 79b3761d3b0d068c8250d0ca95b5459f2486c378 )
-)
-
-game (
-	name "Azumanga Daioh Puzzle Bobble (GDL-0018)"
-	year "2002"
-	developer "Moss (Taito license)"
-	rom ( name azumanga.zip size 219 crc 3da26a27 md5 bc9e0b6bc943159678dc70163dd03d12 sha1 f8f3884128c5d0951eb52c5752351441ce199432 )
 )
 
 game (
@@ -3493,13 +2778,6 @@ game (
 )
 
 game (
-	name "Backfire! (set 1)"
-	year "1995"
-	developer "Data East Corporation"
-	rom ( name backfire.zip size 9859906 crc 28fdb800 md5 3d338c08570acd51771f87677c72da36 sha1 3162de077c9e5196b5878b14689e9216eb0825ee )
-)
-
-game (
 	name "Backfire! (set 2)"
 	year "1995"
 	developer "Data East Corporation"
@@ -3514,20 +2792,6 @@ game (
 )
 
 game (
-	name "Backgammon"
-	year "1990"
-	developer "ADP"
-	rom ( name backgamn.zip size 39995 crc e352e16d md5 ff271b6250c73602b25ae120f521c4ab sha1 34cdfb5e9e0bc8aff3f1d9795a3f00639be55327 )
-)
-
-game (
-	name "Bad Dudes vs. Dragonninja (US)"
-	year "1988"
-	developer "Data East USA"
-	rom ( name baddudes.zip size 454673 crc 823dddde md5 9f61003dd6e361e91df4312a54187f74 sha1 5f5b1c66cb9998d369a15cd56b98f096ac8e21c2 )
-)
-
-game (
 	name "Bad Lands"
 	year "1989"
 	developer "Atari Games"
@@ -3535,31 +2799,10 @@ game (
 )
 
 game (
-	name "Bad Lands (bootleg)"
-	year "1989"
-	developer "bootleg (Playmark)"
-	rom ( name badlandsb.zip size 374128 crc 655c2c3d md5 98395c358aebc3f6cd761c2ec866a4d3 sha1 7be7452f516b8629f49e840b45526a4389a25e51 )
-)
-
-game (
 	name "Bagman"
 	year "1982"
 	developer "Valadon Automation"
 	rom ( name bagman.zip size 23250 crc b2334187 md5 2450cea77840cd1a30b60de6a99a86e9 sha1 543ee9cd463fc9d63b643cba8ba842f323ea7e4a )
-)
-
-game (
-	name "Bagman (bootleg on Crazy Kong hardware)"
-	year "1981"
-	developer "bootleg"
-	rom ( name bagmanf.zip size 10142 crc 6a26b3ac md5 4d019b57220f911f4d14d15a5dd57096 sha1 cb04f6d48df95cea0d961cede08794b73eb09862 )
-)
-
-game (
-	name "Bagman (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name bagmanmc.zip size 21737 crc 4d143fe6 md5 ed839d556dd74d6491553813c6f042c5 sha1 b2f46e780ed18e9d4fc2837014075ed2fb76dfa0 )
 )
 
 game (
@@ -3598,13 +2841,6 @@ game (
 )
 
 game (
-	name "Baku Baku Animal (J 950407 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name bakubaku.zip size 5936271 crc 4d49e6f3 md5 de0359dd8eccee2dcf1f94851291bfda sha1 17b2df9858084e52c5efff899d02c19ffa2b1410 )
-)
-
-game (
 	name "Bakuretsu Breaker"
 	year "1992"
 	developer "Kaneko"
@@ -3633,13 +2869,6 @@ game (
 )
 
 game (
-	name "Balloon Bomber"
-	year "1980"
-	developer "Taito"
-	rom ( name ballbomb.zip size 6936 crc d8c9cbc6 md5 bd95aa39956fa02fdd5ecbd68f0437c2 sha1 46daff2917dbbb69b5081e904d182727fb4c83f0 )
-)
-
-game (
 	name "Balloon Brothers"
 	year "1992"
 	developer "East Technology"
@@ -3654,17 +2883,10 @@ game (
 )
 
 game (
-	name "Baluba-louk no Densetsu"
+	name "Baluba-louk no Densetsu (Japan)"
 	year "1986"
 	developer "Able Corp, Ltd."
 	rom ( name baluba.zip size 68148 crc 640d45af md5 c84daa05bf3bcd5faa3fac247068c7b0 sha1 de9bfd1291768f84ebf3f7fdaecb345a615882fe )
-)
-
-game (
-	name "Bust a Move 2 (Japanese ROM ver. 1999/07/17 10:00:00)"
-	year "1999"
-	developer "Metro / Enix / Namco"
-	rom ( name bam2.zip size 27357381 crc 0c24b882 md5 648be02a41d3bcd46210f001a5f51707 sha1 b9ede3c86829e3ee11f10fe048744fbd87d7cce0 )
 )
 
 game (
@@ -3672,13 +2894,6 @@ game (
 	year "1989"
 	developer "Digital Soft"
 	rom ( name bananadr.zip size 434150 crc d39f1488 md5 e2a838c811c721bfb134419619f64685 sha1 a6202201175275bf1157bb76481d632374d97a26 )
-)
-
-game (
-	name "BanBam"
-	year "1984"
-	developer "Sun Electronics"
-	rom ( name banbam.zip size 46036 crc a97f678a md5 d866593f9cc1ac2027b22877a3699b02 sha1 8af4251b677ab70309a7d9e3126a0c2980a69eb5 )
 )
 
 game (
@@ -3717,13 +2932,6 @@ game (
 )
 
 game (
-	name "Bank Panic"
-	year "1984"
-	developer "Sanritsu / Sega"
-	rom ( name bankp.zip size 68081 crc c891b681 md5 b95e5c2016bf570c4438f9d742cce44e sha1 5cade8bfbac308caca5b4844dce525be5a134cb2 )
-)
-
-game (
 	name "Baraduke"
 	year "1985"
 	developer "Namco"
@@ -3755,27 +2963,6 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name basebal2.zip size 132687 crc afab8769 md5 d938e769b6db97e280062b0d7e5d5d32 sha1 f2776d7d8717f6a760a9602d9a670ffb0c53d100 )
-)
-
-game (
-	name "Sega Bass Fishing"
-	year "1997"
-	developer "Sega"
-	rom ( name bass.zip size 43709726 crc 505c2bac md5 0a61a5f56742043a3c70de5c580f8e14 sha1 2a98b655c8e0b08a5b48abebae6ea99b2f2ea8dc )
-)
-
-game (
-	name "Bass Angler 2 (GE865 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name bassang2.zip size 182 crc 58103c23 md5 152227827baf38c778d50cff8dacdb75 sha1 3f1dffa8ffebb13844422b8d5c0f5d94f44880b3 )
-)
-
-game (
-	name "Bass Angler (GE765 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name bassangl.zip size 182 crc 786221d4 md5 481d0a427167a7175a00b6c5ef57bfa2 sha1 eb7902169ce094a0234cf165ca0f65d242d22525 )
 )
 
 game (
@@ -3835,20 +3022,6 @@ game (
 )
 
 game (
-	name "Battle Gear"
-	year "1999"
-	developer "Taito"
-	rom ( name batlgear.zip size 26289 crc 2734b16d md5 778fc5f630276d7324379e4db00c30a1 sha1 cdb2e1241be258eae829e8d6fd402dae47f8e78e )
-)
-
-game (
-	name "Battle Gear 2"
-	year "2000"
-	developer "Taito"
-	rom ( name batlgr2.zip size 26488 crc c97da0ce md5 2f0fac897e68892b40122506a13110a4 sha1 1fa012f02812eb1ee7a789552b51e26179578bea )
-)
-
-game (
 	name "Batman"
 	year "1991"
 	developer "Atari Games"
@@ -3860,13 +3033,6 @@ game (
 	year "1981"
 	developer "bootleg"
 	rom ( name batman2.zip size 16185 crc 1e53a1d4 md5 1796144ac5f4c9a7864d175cc6f87157 sha1 0bda3fd598ee4064d8f97012b069db8115ab8cf1 )
-)
-
-game (
-	name "Batman Forever (JUE 960507 V1.000)"
-	year "1996"
-	developer "Acclaim"
-	rom ( name batmanfr.zip size 24447417 crc 3f6dcfd3 md5 947d220e7d847e02dc6e9f16729cd80f sha1 3527513bb7385f1c81d075ec9a6278ed4f980804 )
 )
 
 game (
@@ -3916,27 +3082,6 @@ game (
 	year "1998"
 	developer "Raizing / Eighting"
 	rom ( name batridu.zip size 173246 crc 517f15c4 md5 429660cccd190d8586dfb473c8a85ff9 sha1 7ddde9ce1a365b549f448f3a4d475e71e337d4c0 )
-)
-
-game (
-	name "Batsugun (set 1)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsugun.zip size 2409345 crc 22069212 md5 9b10f2234e03680ce7d211c1fb928d42 sha1 6b9e9624cc6d9d9f80039d0a4a34534016f67799 )
-)
-
-game (
-	name "Batsugun (set 2)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsuguna.zip size 177683 crc 7fcfc28b md5 7d1e13bc75de862e862b332e9ab182cc sha1 0b5a4e7b5316d00e8c378068e3decae1523bfcf7 )
-)
-
-game (
-	name "Batsugun (Special Ver.)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name batsugunsp.zip size 178914 crc 7f64f5c3 md5 57316d77bede660bcb7efe067a317636 sha1 7b3db8e93ede62eb8fec492fad99583b63bdeb0f )
 )
 
 game (
@@ -4017,52 +3162,10 @@ game (
 )
 
 game (
-	name "Bay Route (set 1, US, unprotected)"
-	year "1989"
-	developer "Sunsoft / Sega"
-	rom ( name bayroute1.zip size 319050 crc 90d3b52d md5 34babc812237ccbcdbdd11990cb5bb12 sha1 ccdad9703f10f03a41e94775a112cf318e200e89 )
-)
-
-game (
-	name "Bay Route (encrypted, protected bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name bayrouteb1.zip size 476394 crc c770fdac md5 da21a1cad1c033f287c03534f4e01049 sha1 3ca63c04d0c33a21d3c9d75c1165aab514849a61 )
-)
-
-game (
-	name "Bay Route (Datsu bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name bayrouteb2.zip size 533843 crc 3956d805 md5 b3f1acb8e460cb2582ec09e5c3f9cb8a sha1 3ce905a2c0a24135b0dbfdde44843ff41e01ed46 )
-)
-
-game (
 	name "Bay Route (set 2, Japan, FD1094 317-0115)"
 	year "1989"
 	developer "Sunsoft / Sega"
 	rom ( name bayroutej.zip size 111442 crc bf99537e md5 f25c026be4281d12c01ef8a6ee6007a6 sha1 cb9ef491a03535b6572553498f6f4a92349638fc )
-)
-
-game (
-	name "Balloon _ Balloon"
-	year "2003"
-	developer "Eolith"
-	rom ( name bballoon.zip size 3881400 crc a67596bf md5 9769218a3f5ac3813b1d72fc6244eb39 sha1 96bb79f908ae6d737193e05fd223130bd3f07b37 )
-)
-
-game (
-	name "Bouncing Balls"
-	year "1991"
-	developer "Comad"
-	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
-)
-
-game (
-	name "Best Bout Boxing"
-	year "1994"
-	developer "Jaleco"
-	rom ( name bbbxing.zip size 10429515 crc 9b47d8ac md5 96986e1972839f0821aadd48b87dc13e sha1 53470be999ffa957d32e44d999dff936d8beb436 )
 )
 
 game (
@@ -4087,23 +3190,10 @@ game (
 )
 
 game (
-	name "unknown fighting game 'BB' (prototype)"
-	developer "&lt;unknown&gt;"
-	rom ( name bbprot.zip size 2485034 crc 39c604b7 md5 309a492e84cecc54675755d63ed4e33b sha1 6eeacb0b9a5c23fce8ad83f7510452a13acabc8a )
-)
-
-game (
 	name "Buster Bros. (US)"
 	year "1989"
 	developer "Mitchell (Capcom license)"
 	rom ( name bbros.zip size 212410 crc 557e8774 md5 59922633ccd8e56bf515252ac97b152d sha1 dd55a08cc8282f807050eb62a0d9d76bebab88ae )
-)
-
-game (
-	name "Beast Busters 2nd Nightmare"
-	year "1998"
-	developer "SNK"
-	rom ( name bbust2.zip size 21055444 crc ba9bee97 md5 36eb573856c6fffb403f8b4e9837c7b8 sha1 60e7760ea8922c3f3ef805aa42c8a93ff18975bf )
 )
 
 game (
@@ -4121,13 +3211,6 @@ game (
 )
 
 game (
-	name "Battle Chopper"
-	year "1987"
-	developer "Irem"
-	rom ( name bchopper.zip size 625484 crc bb2ba4e2 md5 b1c23702556a56b13ea7120566b6691e sha1 d640f7466fd4409a89b81c19bf7c1cf0446ca71b )
-)
-
-game (
 	name "Bone Crusher"
 	year "1985"
 	developer "bootleg"
@@ -4142,59 +3225,10 @@ game (
 )
 
 game (
-	name "B.C. Story (set 1)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name bcstry.zip size 1867429 crc 2790dc04 md5 af6c843f42e06c5a5ff56952afaba6ce sha1 b099fe0618c298d712f4e955e004602ee5849c19 )
-)
-
-game (
-	name "B.C. Story (set 2)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name bcstrya.zip size 122570 crc 9897a79a md5 618abbcf930d247d85c0917614a57182 sha1 660fe45ca870d751a1bf624cd160f4114347d9f6 )
-)
-
-game (
-	name "Border Down (Rev A) (GDL-0023A)"
-	year "2004"
-	developer "G-Rev"
-	rom ( name bdrdown.zip size 1196 crc 9e7b60f5 md5 93142b1dbd4ca6c83b79f832ea0bda11 sha1 578f3f11be969702c1cb246cd2b75cd033bd3c98 )
-)
-
-game (
-	name "Beach Spikers (GDS-0014)"
-	year "2002"
-	developer "Sega"
-	rom ( name beachspi.zip size 1194 crc 9d5c8b2c md5 c114cc2701d7551bc3c1b9f1e3c8cbe3 sha1 1ad864c5ce47e05502094659c37df52380f32910 )
-)
-
-game (
-	name "Beam Invader (set 1)"
-	year "1979"
-	developer "Tekunon Kougyou"
-	rom ( name beaminv.zip size 5895 crc 51c74ff3 md5 82fc1d88fdbc2c3f05e14b4a02851ce9 sha1 2711c5c3fbc5f85d06efb203cce021bc649bbddb )
-)
-
-game (
-	name "Beam Invader (set 2)"
-	year "1979"
-	developer "Tekunon Kougyou"
-	rom ( name beaminva.zip size 5814 crc 9f651089 md5 de5dfb78c148efa8ae51a0428a074374 sha1 f728f42437b6d88f252f38e19fa2ece8c686b91c )
-)
-
-game (
 	name "Beastie Feastie"
 	year "1984"
 	developer "Epos Corporation"
 	rom ( name beastf.zip size 15858 crc c4c97703 md5 b33860f5ea52fa3a88508593f1b1915e sha1 9d0c070145bb059457ce0f33123e29da14ca8a59 )
-)
-
-game (
-	name "Beastorizer (USA bootleg)"
-	year "1997"
-	developer "bootleg"
-	rom ( name beastrzb.zip size 6326204 crc 2d08f12e md5 ee525d47c0e223ad90e1ad1f2fdac251 sha1 9fb9cff912e736963f12737274175e450abcb1d6 )
 )
 
 game (
@@ -4212,20 +3246,6 @@ game (
 )
 
 game (
-	name "Beauty Block"
-	year "1991"
-	developer "AMT"
-	rom ( name beautyb.zip size 90881 crc bff50aae md5 bfef3bae6459aea1d74ca579d01e26d7 sha1 ff2b658edfa8eb46015d779aab9e51c1a97ad48f )
-)
-
-game (
-	name "Beeline (39-360-075)"
-	year "1991"
-	developer "BFM"
-	rom ( name beeline.zip size 107525 crc 76d70440 md5 4b9246a359b847a106071dabac9e0a2a sha1 55975fc2ef505a2277a7c7c3521e1de1aaf17132 )
-)
-
-game (
 	name "Beezer (set 1)"
 	year "1982"
 	developer "Tong Electronic"
@@ -4237,27 +3257,6 @@ game (
 	year "1982"
 	developer "Tong Electronic"
 	rom ( name beezer1.zip size 16685 crc 980efe00 md5 8726c8ff1de4d910d1fd4f6a806ac798 sha1 8a1aa2c6dbf5e83d0e01aab1fa55727f3c2fbcf0 )
-)
-
-game (
-	name "Bega's Battle (Revision 3)"
-	year "1983"
-	developer "Data East"
-	rom ( name begas.zip size 54554 crc 35a6ae14 md5 455c76c39ead02e7ebc89a2bf43ecb46 sha1 b59df21c99b0523d36bb9c790ee8c4bbf47b61b0 )
-)
-
-game (
-	name "Bega's Battle (Revision 1)"
-	year "1983"
-	developer "Data East"
-	rom ( name begas1.zip size 19993 crc b59bbbb7 md5 eabd4dc320dfe1ec7d77d3c8aa942913 sha1 69ba4a32034712354c85106353dbbd1182c8e1d6 )
-)
-
-game (
-	name "Behind Enemy Lines"
-	year "1998"
-	developer "Sega / EPL Productions"
-	rom ( name bel.zip size 27328296 crc b2e85671 md5 eb1baf8fefad0d765d1a73f82a8a0678 sha1 2164da6c78742c3ef1af4024d684c598d5d337f1 )
 )
 
 game (
@@ -4359,13 +3358,6 @@ game (
 )
 
 game (
-	name "Best League (bootleg of Big Striker, World Cup)"
-	year "1993"
-	developer "bootleg"
-	rom ( name bestleaw.zip size 966967 crc 42fce0ce md5 db72a6f702b3d1c3616efabfde166196 sha1 4cfcd0b1b133c38bbfab7386c4311c970eed1091 )
-)
-
-game (
 	name "Bestri (Korea)"
 	year "1998"
 	developer "F2 System"
@@ -4442,27 +3434,6 @@ game (
 )
 
 game (
-	name "Big D2"
-	year "2000"
-	developer "IGS"
-	rom ( name bigd2.zip size 2217046 crc 506b3015 md5 531c3083ea1534db16ec1dcdcb643ece sha1 8fd17f83df412592bb35d95646a0edb44763fefc )
-)
-
-game (
-	name "Big Deal (Hungarian, set 1)"
-	year "1986"
-	developer "Funworld"
-	rom ( name bigdeal.zip size 31494 crc 11dc02dc md5 5c0a83f4f50b9d3f04ad053af2a41cd2 sha1 26149d8c6eab579cfad8077330388f0debd2dad7 )
-)
-
-game (
-	name "Big Deal (Hungarian, set 2)"
-	year "1986"
-	developer "Funworld"
-	rom ( name bigdealb.zip size 17366 crc b4bad886 md5 d28982f725f3525548833dc62c2c63d5 sha1 816536a8425ccc92d3f478b7cc55771173724b55 )
-)
-
-game (
 	name "Big Event Golf (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -4474,13 +3445,6 @@ game (
 	year "1986"
 	developer "Taito Corporation"
 	rom ( name bigevglfj.zip size 29147 crc 5063e5ec md5 6f197f18cde145a0abf4976b49e94562 sha1 0bd010df6fa1296d0851f296fa82e3808979d1ee )
-)
-
-game (
-	name "Tatakae! Big Fighter"
-	year "1989"
-	developer "Nichibutsu"
-	rom ( name bigfghtr.zip size 164637 crc 5a2d660b md5 19ca681766ea75b154ceb1613758ef74 sha1 13e195ed0e39beb9ba193e4d53899a1b2bd546fd )
 )
 
 game (
@@ -4516,13 +3480,6 @@ game (
 	year "1989"
 	developer "Jaleco"
 	rom ( name bigrun.zip size 2462344 crc c1e11087 md5 2e6e4fcccbfbbf11748cedc28adda5e7 sha1 303b2e99c94e7d16026610edbee9e2a1ea97b933 )
-)
-
-game (
-	name "Big Striker"
-	year "1992"
-	developer "Jaleco"
-	rom ( name bigstrik.zip size 838155 crc 08b43cdd md5 a256c29d166eb5694001ef4138e7880d sha1 67c7e723947c8e76aa1c78be13aa854c45717af7 )
 )
 
 game (
@@ -4568,48 +3525,6 @@ game (
 )
 
 game (
-	name "Bingo Circus (Rev. A 891001)"
-	year "1989"
-	developer "Sega"
-	rom ( name bingoc.zip size 252105 crc aacd1796 md5 5d35b83cba1876258a05ff9a9e8103a7 sha1 09e200bc4d84342d49b040e45e19dd4557b04b6a )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 1)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor1.zip size 55112 crc edae3d70 md5 55c09726b360fbf9b36c7bdbbf858412 sha1 145030a397f8738774c7063ba789120221032c3b )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 2)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor2.zip size 85502 crc 5291dbed md5 20a0081e4c330f3beb083f0887329ed0 sha1 aa3e54bb13679a3f3aa2feb017f23438aae3d833 )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 3)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor3.zip size 46424 crc ec7ba36d md5 0739030fdef066626d20435fccff5a84 sha1 2947e815cd018f2004bedc4167c68a1067fc41f6 )
-)
-
-game (
-	name "Bingo Roll / Bell Star? (set 4)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor4.zip size 60613 crc 946d6af9 md5 223c2ff5fefbfc24af653812d4b0c287 sha1 7497dba4412cbb9c2738b601616aab8101051757 )
-)
-
-game (
-	name "Bingo Roll / Bell Star V3? (set 5)"
-	year "2002"
-	developer "&lt;unknown&gt;"
-	rom ( name bingor5.zip size 46072 crc 98056045 md5 fa64bf4811fb11f73b0cd3014e2009a9 sha1 0fd7bf72d024fc51802c5086ddcce0b544ad69b6 )
-)
-
-game (
 	name "Bio Attack"
 	year "1983"
 	developer "Taito Corporation (Fox Video Games license)"
@@ -4631,27 +3546,6 @@ game (
 )
 
 game (
-	name "Bionic Commando (Euro)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc.zip size 341032 crc 4618814f md5 3edd644f35021365a73f65e166ca38eb sha1 9ab366c3635e1536cdd61d83dadd43e7f758e038 )
-)
-
-game (
-	name "Bionic Commando (US set 1)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc1.zip size 150039 crc a287b52c md5 07c7c78c25df173ddd2d35974e4adc26 sha1 9b4573035f3781b824f2cae362c83ea95f5f4e5e )
-)
-
-game (
-	name "Bionic Commando (US set 2)"
-	year "1987"
-	developer "Capcom"
-	rom ( name bionicc2.zip size 150016 crc 87c56ccf md5 1eef855a416ec2ce9c34e244d0d98e1b sha1 2195a66e4db0b18baab5c82815e12a4f10c4168b )
-)
-
-game (
 	name "Bio-ship Paladin"
 	year "1990"
 	developer "UPL (American Sammy license)"
@@ -4659,37 +3553,10 @@ game (
 )
 
 game (
-	name "Birdie Try (Japan)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name birdtry.zip size 405472 crc 45008a6a md5 b648f6d50ec138500a4c2f01c2804f55 sha1 19f033951fdfff2eaa124649573699c460b7179c )
-)
-
-game (
-	name "Bishi Bashi Championship Mini Game Senshuken (ver JAA, 3 Players)"
-	year "1996"
-	developer "Konami"
-	rom ( name bishi.zip size 2693368 crc 8e6d5bf6 md5 c1892ca48e05516f9744229b3807557e sha1 6f491d1def0a8ea1a7ef074b3ab47f92f04c653c )
-)
-
-game (
-	name "Bishou Jan (Japan 203)"
-	year "1999"
-	developer "Subsino"
-	rom ( name bishjan.zip size 2794769 crc 8c3fcf15 md5 02741fa4862560466659d146e7c7b4fb sha1 c6318a748de35d087cf1c876babb33a0f563f3f4 )
-)
-
-game (
 	name "Blue's Journey / Raguy"
 	year "1990"
 	developer "Alpha Denshi Co."
 	rom ( name bjourney.zip size 2929979 crc 9fc19733 md5 640af332280677aa05fcb965a56090e0 sha1 0ca5b299d321dd8ed2c269a1b063f7ebea6c7ee2 )
-)
-
-game (
-	name "Poker / Black Jack (Model 7521)"
-	developer "M.Kramer Manufacturing."
-	rom ( name bjpoker.zip size 21786 crc 84277ab7 md5 f5883d0bdfe8b1c77b00f2ec5d208fbb sha1 45dcfc65e95e3880eadd8ba327a2f3bd23fc393e )
 )
 
 game (
@@ -4762,13 +3629,6 @@ game (
 )
 
 game (
-	name "Black Touch '96"
-	year "1996"
-	developer "D.G.R.M."
-	rom ( name blackt96.zip size 1764185 crc ed39ee22 md5 e00acd2b279ab3c682b2151ee68acc51 sha1 1960a1044b7982a8739638f4b8730847f26657c6 )
-)
-
-game (
 	name "Blades of Steel (version T)"
 	year "1987"
 	developer "Konami"
@@ -4801,13 +3661,6 @@ game (
 	year "1992"
 	developer "Allumer"
 	rom ( name blandiap.zip size 3668983 crc 7f1d8ef2 md5 adc947b0d849cd7752aee22959f9dd60 sha1 5d9f038f3631c81d0c1f00dcabd5ad2bfc6ab1dd )
-)
-
-game (
-	name "Blasted"
-	year "1988"
-	developer "Bally Midway"
-	rom ( name blasted.zip size 485570 crc 3c79c3b1 md5 f070f2b43a0739ee69fca9cb2cbb8b2b sha1 2dec7d45fab77121634c3a14a8a1b66251950afc )
 )
 
 game (
@@ -5209,18 +4062,6 @@ game (
 )
 
 game (
-	name "Blox (v2.0)"
-	developer "BwB"
-	rom ( name blox.zip size 88469 crc 717546fe md5 a5df1d22f0b72db4ac6a68e33a93d70b sha1 cb26375a521dcb556c4b9335c3aa4a99368b54f3 )
-)
-
-game (
-	name "Blox (v2.0, Datapak)"
-	developer "BwB"
-	rom ( name bloxd.zip size 3351 crc 0b898419 md5 aca65db9aee6534b0c2dad14c3100673 sha1 5edfaa3ae4607c329d152883bdaa6b74de237669 )
-)
-
-game (
 	name "Bloxeed (Japan, FD1094 317-0139)"
 	year "1989"
 	developer "Sega"
@@ -5438,55 +4279,6 @@ game (
 )
 
 game (
-	name "beatmania IIDX 3th style (GC992 JA)"
-	year "2000"
-	developer "Konami"
-	rom ( name bmiidx3.zip size 146 crc 642dbfd0 md5 4adf21d9b53aa5e3ca4d405a1ded11bb sha1 9e7bdbd9097230628d3e8be98c3bb1cec46e4b6a )
-)
-
-game (
-	name "beatmania IIDX 4th style (GCA03 JA)"
-	year "2000"
-	developer "Konami"
-	rom ( name bmiidx4.zip size 150 crc e24f5af4 md5 a36ec3a1304434e01e3cdf09fbf62a84 sha1 cf5c1eb9e683adf9feedda88301fdb7c98290cd2 )
-)
-
-game (
-	name "beatmania IIDX 6th style (GCB4U JA)"
-	year "2001"
-	developer "Konami"
-	rom ( name bmiidx6.zip size 146 crc 93f5297c md5 7489fa3ddaa35027a8653f98afbd3522 sha1 c06d89b8dbcd48822eed3887a9371831bb697612 )
-)
-
-game (
-	name "beatmania IIDX 7th style (GCB44 JA)"
-	year "2002"
-	developer "Konami"
-	rom ( name bmiidx7.zip size 146 crc 0c37b6a5 md5 fb52eebeeaeddd4250be6e5e4f670465 sha1 51a09a86f213b590282a54140770e1e1f3a9fba0 )
-)
-
-game (
-	name "beatmania IIDX 8th style (GCC44 JA)"
-	year "2002"
-	developer "Konami"
-	rom ( name bmiidx8.zip size 146 crc 8971df25 md5 ed572f8e954647a21585c7b831228946 sha1 af2afdb036bbd388032e9d5e58115a8c8fc56195 )
-)
-
-game (
-	name "beatmania IIDX with DDR 2nd Club Version (896 JAB)"
-	year "1999"
-	developer "Konami"
-	rom ( name bmiidxc.zip size 146 crc 0d976b08 md5 b8f565a508b234d7a2f0cd5eb909ac83 sha1 85eeac47f26372594c89f95056ffe4f8d9bb7bb9 )
-)
-
-game (
-	name "beatmania IIDX Substream 2 with DDR 2nd Club Version (984 A01 BM)"
-	year "1999"
-	developer "Konami"
-	rom ( name bmiidxc2.zip size 146 crc 15f35ba7 md5 b38e7cf691d981aa3955ce07f814b5ed sha1 c86faa89081a8df209adbe9d4d343169df29e7bf )
-)
-
-game (
 	name "Vs. Raid on Bungeling Bay (Japan)"
 	year "1985"
 	developer "Nintendo / Broderbund Software Inc."
@@ -5498,20 +4290,6 @@ game (
 	year "1982"
 	developer "Data East USA (Bally Midway license)"
 	rom ( name bnj.zip size 12972 crc 5581afec md5 841df1249b78a9ea0d4471a0accef9e5 sha1 9eea1e11e462601840be6646d0c2e8f2b9119f7c )
-)
-
-game (
-	name "Vs. Janshi Brandnew Stars (MegaSystem32 Version)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name bnstars.zip size 1280497 crc 01cac0ee md5 7e6ac0b4f65e7b3f3b0358fe8545ef3f sha1 5b454bf364b6ee0f42787c8f61d5aac751cfdbff )
-)
-
-game (
-	name "Vs. Janshi Brandnew Stars"
-	year "1997"
-	developer "Jaleco"
-	rom ( name bnstars1.zip size 17328000 crc 763772f2 md5 af9c8495c8a3363ba489837098ced956 sha1 88c3535a1b7305566bb39b26077b62d51caf4da2 )
 )
 
 game (
@@ -5559,7 +4337,7 @@ game (
 game (
 	name "Boggy '84 (bootleg)"
 	year "1983"
-	developer "bootleg (Eddie&apos;s Games)"
+	developer "bootleg (Eddie's Games)"
 	rom ( name boggy84b.zip size 5207 crc 4c28e779 md5 1848cc90e40040fb1ef271a56b390b6e sha1 bf758893e737b2cbef4bd60051c22f9e10078ea0 )
 )
 
@@ -5606,27 +4384,6 @@ game (
 )
 
 game (
-	name "Bombs Away"
-	year "1988"
-	developer "Jaleco"
-	rom ( name bombsa.zip size 153114 crc 9e7b85ae md5 d02c9d9a0f6d8cd1c24069db26eb5279 sha1 91c59588acb0e11e14c2d0f9a32a40d948a1a598 )
-)
-
-game (
-	name "Bonanza (Revision 3)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name bonanza.zip size 1460778 crc a0bb755f md5 e236cea2fbc5338cb2c33ad766f21c7f sha1 5ce06420bbb38587814279bdb728a77a28273ba4 )
-)
-
-game (
-	name "Bonanza (Revision 2)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name bonanzar2.zip size 1402182 crc 10ad6db0 md5 93c65baae2931da6b1c709d7e1fbd340 sha1 203278712cb4a40b593f37a92f23cf88d22cf400 )
-)
-
-game (
 	name "Bongo"
 	year "1983"
 	developer "Jetsoft"
@@ -5662,13 +4419,6 @@ game (
 )
 
 game (
-	name "Booby Kids (Italian manufactured graphic hack / bootleg of Kid no Hore Hore Daisakusen (bootleg))"
-	year "1987"
-	developer "bootleg"
-	rom ( name boobhack.zip size 67335 crc 508d8f2f md5 10068ac3439c45d411b2e50b5ff666d9 sha1 cf37d12a5e170123b890a26bfaff145381c4f011 )
-)
-
-game (
 	name "Boogie Wings (Euro v1.5, 92.12.07)"
 	year "1992"
 	developer "Data East Corporation"
@@ -5680,12 +4430,6 @@ game (
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name boogwinga.zip size 991542 crc 16226f6b md5 371de4bc9c79871876ff38a546328b87 sha1 b0839935a83235492c675339515bebac6c3051a4 )
-)
-
-game (
-	name "Book Theatre (Ver 1.2)"
-	developer "&lt;unknown&gt;"
-	rom ( name bookthr.zip size 600947 crc f4e37363 md5 b533a38e50f820a9a5011a4f91423410 sha1 4d0cc5523d2295429cd388e385eebc698afc8791 )
 )
 
 game (
@@ -5737,20 +4481,6 @@ game (
 )
 
 game (
-	name "Bosconian (Midway, new version)"
-	year "1981"
-	developer "Namco (Midway license)"
-	rom ( name boscomd.zip size 18613 crc 44b2e559 md5 d8a90d2580612e31a26dc8887f57fd4f sha1 22f4f6c40128421c0ca8c835de4d8a85eba90976 )
-)
-
-game (
-	name "Bosconian (Midway, old version)"
-	year "1981"
-	developer "Namco (Midway license)"
-	rom ( name boscomdo.zip size 18762 crc c3016cc8 md5 88e9e02b26eff5d6935bcc76378e351a sha1 fe921bbbab23b655fc8eca1b69f6ef717aa90f27 )
-)
-
-game (
 	name "Bosconian (old version)"
 	year "1981"
 	developer "Namco"
@@ -5783,20 +4513,6 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name botssa.zip size 337526 crc 2d4849d1 md5 e03832279b53e337981bbf90a312fb2b sha1 b21bef0a77a6aaff932ea31fa88606aacbc5db73 )
-)
-
-game (
-	name "Bottle 10 (Italian, set 2)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name bottl10b.zip size 2709 crc 9339515b md5 99fedd5f9ba75a6bc354fd848a33124f sha1 8b72591125a709f45a7e457a779a763b1a90972e )
-)
-
-game (
-	name "Bottle 10 (Italian, set 1)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name bottle10.zip size 19483 crc 8addc9ce md5 7a0334d3b023c3025f00e04ea53613ce sha1 81c0fa21548cd484d909e0114a3bdb09c19e1ae1 )
 )
 
 game (
@@ -5835,13 +4551,6 @@ game (
 )
 
 game (
-	name "3-D Bowling"
-	year "1978"
-	developer "Meadows"
-	rom ( name bowl3d.zip size 6423 crc c16a7c86 md5 e169b64161d4acedf432acd7deb7dd47 sha1 c2ba0f9c089ed9dba8649a53f33a8911c57bf91d )
-)
-
-game (
 	name "Bowling Alley"
 	year "1978"
 	developer "Midway"
@@ -5856,24 +4565,10 @@ game (
 )
 
 game (
-	name "Boxer (prototype)"
-	year "1978"
-	developer "Atari"
-	rom ( name boxer.zip size 5583 crc 5759a1c6 md5 17f37cbcb77aa140a127783009089268 sha1 a9c45ca8f981a4c71426cdad10f7a551ad272fd6 )
-)
-
-game (
 	name "Boxing Bugs"
 	year "1981"
 	developer "Cinematronics"
 	rom ( name boxingb.zip size 27123 crc 854dbfbe md5 cb9b0501ada8177ec918761cfd41d3b8 sha1 229dd4258194fa775f369b32ad6b271a42a39a7d )
-)
-
-game (
-	name "Boxing Mania (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name boxingm.zip size 802 crc 73585a4f md5 3e73210695f37eeaa251ebe21ea3aa8c sha1 316efb4c4f0fccd6e9fcb850ede98c9e72974575 )
 )
 
 game (
@@ -5888,13 +4583,6 @@ game (
 	year "1980"
 	developer "Atari"
 	rom ( name bradley.zip size 15479 crc d0b3b841 md5 ee761bd58196edc6b05036b73ed09924 sha1 3e63a80e3badf541c326c033c6bb3a947aaee353 )
-)
-
-game (
-	name "Brain"
-	year "1986"
-	developer "Coreland / Sega"
-	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
 )
 
 game (
@@ -5926,27 +4614,6 @@ game (
 )
 
 game (
-	name "Borderline (Karateco bootleg)"
-	year "1981"
-	developer "bootleg (Karateco)"
-	rom ( name brdrlinb.zip size 12936 crc faf6b848 md5 9d779089a498b889b44719bf3f0df86a sha1 659f8eedc0a4619e25dbff39101e66239fa5c909 )
-)
-
-game (
-	name "Borderline"
-	year "1981"
-	developer "Sega"
-	rom ( name brdrline.zip size 15236 crc 9886f011 md5 e672205b32565e977ca919ca623c8681 sha1 f6019f3c99075de17f140fe9777d4e6a8ad18941 )
-)
-
-game (
-	name "Borderline (Sidam bootleg)"
-	year "1981"
-	developer "bootleg (Sidam)"
-	rom ( name brdrlins.zip size 944 crc 8bcefc9d md5 f058af306c16715adaa2ca11e4a12337 sha1 bdfa65c9a4dfe95c22ab4f92cdf08e10d4eae1ff )
-)
-
-game (
 	name "Breakers"
 	year "1996"
 	developer "Visco"
@@ -5961,31 +4628,10 @@ game (
 )
 
 game (
-	name "Breywood (Japan revision 2)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name breywood.zip size 288503 crc ff6fee69 md5 1ceff7a2902aa5eb0d122bccf64c366d sha1 c23860d32ce21b3915f11e674b48c9eaa530d42e )
-)
-
-game (
 	name "Brickyard"
 	year "1976"
 	developer "RamTek"
 	rom ( name brickyrd.zip size 1461 crc 4b09b880 md5 4150bc02815254f9ba174c26e05f121f sha1 26bd69bc871dffe7d98f72a19120c42f5da3d1fd )
-)
-
-game (
-	name "Brick Zone (v5.0)"
-	year "1992"
-	developer "SunA"
-	rom ( name brickzn.zip size 531025 crc 8ac71e75 md5 7a22b365cbbe3e0b12229dcd89311e8a sha1 b792b38b4344df79a3a8ad3db57dd1b57c4f102c )
-)
-
-game (
-	name "Brick Zone (v4.0)"
-	year "1992"
-	developer "SunA"
-	rom ( name brickzn3.zip size 133949 crc df60ef81 md5 6200f0d53ef7cb55dae908ae7e7b36fb sha1 bef6882992da53d8812cf06bbf3ae66c6eaddbc7 )
 )
 
 game (
@@ -6289,13 +4935,6 @@ game (
 )
 
 game (
-	name "Beat the Champ (GV053 UAA01)"
-	year "1996"
-	developer "Konami"
-	rom ( name btchamp.zip size 151 crc ee2ffa6f md5 e5fe5528eed0fadbef614cc9cc8d9dee sha1 45cdcfe5992e58165c7bd172550821ad3218cf7e )
-)
-
-game (
 	name "Burger Time (Data East set 1)"
 	year "1982"
 	developer "Data East Corporation"
@@ -6335,20 +4974,6 @@ game (
 	year "1987"
 	developer "bootleg"
 	rom ( name btlfieldb.zip size 769329 crc 8b36035e md5 cedf178105163fbac6a771ad94f6c5f4 sha1 2853bd3b51e247273048765a65e0c5a0d57ac06f )
-)
-
-game (
-	name "Battle K-Road"
-	year "1994"
-	developer "Psikyo"
-	rom ( name btlkroad.zip size 4161327 crc 18ed9e21 md5 00603afe66310ebe8d340c6564c84cc2 sha1 cfcefd05c4fb1492741caf392c3938754bd89fd3 )
-)
-
-game (
-	name "Battle Tryst (ver JAC)"
-	year "1998"
-	developer "Konami"
-	rom ( name btltryst.zip size 630980 crc 8c9cca39 md5 3ff37c6fc6370ec3d2b547864577f919 sha1 b2c907f18e436311e76f030739fd37631f8b26f8 )
 )
 
 game (
@@ -6401,13 +5026,6 @@ game (
 )
 
 game (
-	name "Bubble Trouble (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name bubbletr.zip size 911433 crc 56650225 md5 48acc135eb5ccac7bfef02fe3fd7aa48 sha1 6f37ea115eae404632dd468db7a6ee10888692e3 )
-)
-
-game (
 	name "Bubble 2000"
 	year "1998"
 	developer "Tuning"
@@ -6419,41 +5037,6 @@ game (
 	year "1994"
 	developer "Taito Corporation Japan"
 	rom ( name bublbob2.zip size 4906715 crc 224c696e md5 9c746ee1f7aea62567477df58d46af56 sha1 0ba71f6aa86952b65aac20c9e01508f0fa43d7d8 )
-)
-
-game (
-	name "Bubble Bobble"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name bublbobl.zip size 183843 crc 4fea6af9 md5 7f7e392e6152e97737de4d54cc7b5108 sha1 829142c9ba2aec2372ba14371e8f5ec8893194f4 )
-)
-
-game (
-	name "Bubble Bobble (older)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name bublbobl1.zip size 50204 crc 180352f9 md5 007106c32cfdb5b49a91bee4054353f3 sha1 3ed8028b10a95b940d186bf7733f1fa3b7d27002 )
-)
-
-game (
-	name "Bubble Bobble (US with mode select)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name bublboblr.zip size 50221 crc 284d7775 md5 e9ffaa902764778d11374a83ba5c95ec sha1 2b7ffd208e2431eb68da0cf9c66e003a2ed541b2 )
-)
-
-game (
-	name "Bubble Bobble (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name bublboblr1.zip size 50215 crc 221bea4c md5 d036a4f298326361c8608220036a2419 sha1 a6cfe48242861315b8c44bf38a63ad8cfc1575d2 )
-)
-
-game (
-	name "Bubble Symphony (bootleg with OKI6295)"
-	year "1994"
-	developer "bootleg"
-	rom ( name bubsymphb.zip size 2602910 crc 2ebae6f6 md5 2def73da00a343fad8589deb36e7b4a8 sha1 7e4d6529e265bfa3af7757712e261e23d5b35534 )
 )
 
 game (
@@ -6475,13 +5058,6 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name bubsymphu.zip size 112365 crc 5de23843 md5 fdf774d1154d31d19bf92817114bba10 sha1 b8f143b8727d3459d9fe8c182a294b578fb20cd4 )
-)
-
-game (
-	name "Buccaneers (set 1)"
-	year "1989"
-	developer "Duintronic"
-	rom ( name buccanrs.zip size 292256 crc ad4e7b3f md5 15e909f3f8557171f5b865eafbbba64a sha1 df84215553cf9bf265455fb54f8631d15666d886 )
 )
 
 game (
@@ -6569,13 +5145,6 @@ game (
 )
 
 game (
-	name "Buggy Boy Junior/Speed Buggy (upright)"
-	year "1986"
-	developer "Tatsumi"
-	rom ( name buggyboyjr.zip size 182287 crc ccdd183d md5 054b3524edd1dd2c3b432fbb9c3cb83d sha1 4ac048e045122cd85e41a3783698b91c3bf2cdac )
-)
-
-game (
 	name "Buggy Challenge"
 	year "1984"
 	developer "Taito Corporation"
@@ -6587,13 +5156,6 @@ game (
 	year "1984"
 	developer "Taito Corporation (Tecfri license)"
 	rom ( name buggychlt.zip size 23531 crc e8de4627 md5 ec3272e805688ecbde928e6e413e0fd4 sha1 3af54500c9dd2f47f877cd1db6468b74ded7addf )
-)
-
-game (
-	name "Bullet (FD1094 317-0041)"
-	year "1987"
-	developer "Sega"
-	rom ( name bullet.zip size 343072 crc 1c3ddb9c md5 3f0874a51fd3928ca403421e8d278440 sha1 988573070b9810b1b2a525198472b51cfd18ea1d )
 )
 
 game (
@@ -6618,13 +5180,6 @@ game (
 )
 
 game (
-	name "Bulls Eye Darts"
-	year "1985"
-	developer "Shinkai Inc. (Magic Eletronics Inc. license)"
-	rom ( name bullsdrt.zip size 18099 crc 0f7d4a14 md5 c50f036aae4c57d9cc296cdd229637a9 sha1 e018d0b8583962fdb42914a841f675ff82ff31d9 )
-)
-
-game (
 	name "Hissatsu Buraiken (Japan)"
 	year "1987"
 	developer "Capcom"
@@ -6636,13 +5191,6 @@ game (
 	year "1997"
 	developer "Unico"
 	rom ( name burglarx.zip size 4820018 crc d292786b md5 bf55727fdf7785eea80045abeec4b968 sha1 4e443f1eb3ddc53783f6b954a06da98542057c61 )
-)
-
-game (
-	name "Buriki One (rev.B)"
-	year "1999"
-	developer "SNK"
-	rom ( name buriki.zip size 54519633 crc 16435a4a md5 be5ac200fdb0922d9a21db4357217b37 sha1 14bb16aecb66a0a765e6f2b191146efb5a7e41c4 )
 )
 
 game (
@@ -6671,13 +5219,6 @@ game (
 	year "1991"
 	developer "SNK"
 	rom ( name burningfh.zip size 162348 crc b9fc0678 md5 109c90bcf9a3a4e39b61e18681bf7e73 sha1 1799b6dd821ece2e63c769ead46f5288bf176b81 )
-)
-
-game (
-	name "Buster"
-	year "1987"
-	developer "Marian Electronics Ltd."
-	rom ( name buster.zip size 19323 crc 0daa1c09 md5 6d42ed32514a66a76473c6a42c41fc0f sha1 bbee41a4f7efcfebd2c98032659a945f0a0a4f01 )
 )
 
 game (
@@ -6800,13 +5341,6 @@ game (
 )
 
 game (
-	name "Cabaret"
-	year "1992"
-	developer "AMT Co. Ltd."
-	rom ( name cabaret.zip size 233926 crc bb72cda8 md5 33eff9d0b8cabfd979693eff6a5dc4c2 sha1 7fd038b7249525675a723aa55eff6299dbb35744 )
-)
-
-game (
 	name "Cachat (Japan)"
 	year "1993"
 	developer "Taito Corporation"
@@ -6863,20 +5397,6 @@ game (
 )
 
 game (
-	name "Mahjong Cafe Break"
-	year "1999"
-	developer "Nakanihon / Dynax"
-	rom ( name cafebrk.zip size 1390142 crc c0bd5623 md5 7dab8bbebfbcda5e3ced2009c6bd5912 sha1 a6a722f6be44ebe359fa4ba9a5f64855c70eae7c )
-)
-
-game (
-	name "Mahjong Cafe Doll (Japan)"
-	year "1993"
-	developer "Dynax"
-	rom ( name cafedoll.zip size 559452 crc 16c3fdf4 md5 2f99903133f46ab4e8243d1863061f36 sha1 88d5a71c9092e18e37b66920df90197be687de1e )
-)
-
-game (
 	name "Mahjong Cafe Time"
 	year "1992"
 	developer "Dynax"
@@ -6888,13 +5408,6 @@ game (
 	year "1999"
 	developer "Sammy"
 	rom ( name cairblad.zip size 13533920 crc c8716878 md5 f6a7777922650c300c0a28ce8486c34b sha1 07bedb17e9ed6e19710272f1cd566dd0b59ec399 )
-)
-
-game (
-	name "California Chase"
-	year "1999"
-	developer "The Game Room"
-	rom ( name calchase.zip size 131969 crc 631e0743 md5 f8d14d38a98efc3c854b425e90770b44 sha1 2b95d667f22ccdb1fbafe1cae6430939af8bd87a )
 )
 
 game (
@@ -7003,12 +5516,6 @@ game (
 )
 
 game (
-	name "Cannon Ball (Pacman Hardware)"
-	developer "Novomatic"
-	rom ( name cannonbp.zip size 13520 crc 043cc321 md5 092062965a660cef9612dceb1346b67c sha1 1141eaf74a1cc7082be41395f350695a5a06680b )
-)
-
-game (
 	name "Canvas Croquis"
 	year "1985"
 	developer "SNK"
@@ -7058,31 +5565,10 @@ game (
 )
 
 game (
-	name "Capitani Coraggiosi (Ver 1.3)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name capcor.zip size 528091 crc 9f111251 md5 624d384180db423225fcab9ecde8e7a0 sha1 86fdc4cccb35668d535bc996ca063a3dbb017b76 )
-)
-
-game (
 	name "Capitol"
 	year "1981"
 	developer "bootleg? (Universal Video Spiel)"
 	rom ( name capitol.zip size 16530 crc cee20fd8 md5 6c1a0e23422ce768311dfb24db0b9856 sha1 d1759ef898e053404f0d82452ad5d56d6c9932a7 )
-)
-
-game (
-	name "Capcom Vs. SNK Millennium Fight 2000 (000904 JPN, USA, EXP, KOR, AUS) (Rev C)"
-	year "2000"
-	developer "Capcom / SNK"
-	rom ( name capsnk.zip size 90874201 crc ed476428 md5 509c16b5eced2f0849c5fd87c6c9a81f sha1 1c8cfbcd7f1c22ec3319e6974eefa17d52e6e2a8 )
-)
-
-game (
-	name "Capcom Vs. SNK Millennium Fight 2000 (000804 JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom / SNK"
-	rom ( name capsnka.zip size 1336728 crc 0056471c md5 1529dc955ab9572bfa5e6b35492ca5ee sha1 43edba9b3cf4af46dda2b0a2c4eb0dc5077b93ed )
 )
 
 game (
@@ -7097,13 +5583,6 @@ game (
 	year "1991"
 	developer "Data East Corporation"
 	rom ( name captavena.zip size 176817 crc ab2b24d1 md5 22eb83751040e981f8f341473dc57935 sha1 fada28fad7dd0a1fa2cdb19733616536a7927649 )
-)
-
-game (
-	name "Captain America and The Avengers (UK Rev 1.4)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name captavene.zip size 176825 crc e9aaf215 md5 06ad25092de069e61e6c4f86a0d490d5 sha1 4d20c09c0d0f4430c74f90097bd7c9370d21e13e )
 )
 
 game (
@@ -7135,20 +5614,6 @@ game (
 )
 
 game (
-	name "Captain Commando (World 911202)"
-	year "1991"
-	developer "Capcom"
-	rom ( name captcomm.zip size 2541835 crc f0e6245b md5 abc7c7ee61319dd421c202c086f2c3b4 sha1 f46abadc44a2b1ec022dccc2dac3f26f4eff88aa )
-)
-
-game (
-	name "Captain Commando (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name captcommb.zip size 2625802 crc 849eb0d9 md5 5b4f821409c11c0fe604c806443f9aab sha1 e765389b07f8b6428e48fd389b2e0fa6fa8ec7b8 )
-)
-
-game (
 	name "Captain Commando (Japan 911202)"
 	year "1991"
 	developer "Capcom"
@@ -7177,13 +5642,6 @@ game (
 )
 
 game (
-	name "Capitan Uncino (Ver 1.2)"
-	year "2000"
-	developer "Nazionale Elettronica"
-	rom ( name capunc.zip size 557181 crc e31977f7 md5 a9ad3a4ae09b56fb2dfb82fd407865dc sha1 430127ff1894c35295bf0c0629fc4fc1673cb20c )
-)
-
-game (
 	name "Car 2 (bootleg of Head On 2)"
 	year "1979"
 	developer "bootleg (RZ Bologna)"
@@ -7195,20 +5653,6 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name caractn.zip size 12353 crc 72cc0fbc md5 b27c6525b2ae71b413251e098a883a79 sha1 d4f4949105f949a152d99112d3c0986af0b5205a )
-)
-
-game (
-	name "Carriage Bonus 2002 (bootleg)"
-	year "2002"
-	developer "bootleg"
-	rom ( name carb2002.zip size 73630 crc 330d4b08 md5 a1e5af3ec5cb50390469b307449041eb sha1 93ba662ba43a876bd85d8dd28a5f21f4cec9fa15 )
-)
-
-game (
-	name "Carriage Bonus 2003 (bootleg)"
-	year "2003"
-	developer "bootleg"
-	rom ( name carb2003.zip size 58792 crc efdccac9 md5 f47f6d2dd0544bdf69a728e2c2fbcff5 sha1 ba3383a7c6ca8ee0ab459b1bfc135650d96e3c28 )
 )
 
 game (
@@ -7260,23 +5704,9 @@ game (
 )
 
 game (
-	name "Car Polo"
-	year "1977"
-	developer "Exidy"
-	rom ( name carpolo.zip size 5574 crc 92bcf55d md5 bde33e30020d209594ae065fae9c23dd sha1 7043a4bf4ff800dcc96477bbab113cdfa4ccce00 )
-)
-
-game (
 	name "Carrera (Version 6.7)"
 	developer "BS Electronics"
 	rom ( name carrera.zip size 46908 crc 70f6d233 md5 fc30dfd07b5e7a27ebc92b0afda74993 sha1 ca114e8b1dd9a6dfb665ce186a8795d560ecbecd )
-)
-
-game (
-	name "Cart Fury"
-	year "2000"
-	developer "Midway Games"
-	rom ( name cartfury.zip size 177931 crc 62d13f75 md5 62a4c8a8cda54f00b478be069fe89257 sha1 6cf7d0e33c6b1268f639fb544433f792dc76df18 )
 )
 
 game (
@@ -7284,13 +5714,6 @@ game (
 	year "1978"
 	developer "bootleg? (Sidam)"
 	rom ( name cascade.zip size 5037 crc 9cac9d3c md5 80687d98b1a35f782ca1c0653b1024f2 sha1 a47a221add6377f314a0a48b838b13ad40fcce2b )
-)
-
-game (
-	name "Cash Quiz (Type B, Version 5)"
-	year "1986"
-	developer "Zilec-Zenitone"
-	rom ( name cashquiz.zip size 163824 crc ae2baab7 md5 4116fc74601f7a21a643fbeb22e09369 sha1 d6a267423ae84929005a3c164fb885c5691badf4 )
 )
 
 game (
@@ -7315,20 +5738,6 @@ game (
 )
 
 game (
-	name "Catacomb"
-	year "1982"
-	developer "MTM Games"
-	rom ( name catacomb.zip size 6934 crc 16cea5fc md5 e61554ef95709a6406fd3be2a477f265 sha1 78d01f133c5357a2592efaf3b6b731dd7e1bc126 )
-)
-
-game (
-	name "Catapult"
-	year "1982"
-	developer "Epos Corporation"
-	rom ( name catapult.zip size 19986 crc 2475400b md5 c5f75c3c7bd817d914d2df8f63b60532 sha1 ee10550734cbf5e68697656fec2c66626d3787e8 )
-)
-
-game (
 	name "Catch-22 (version 8.0)"
 	year "1985"
 	developer "Exidy"
@@ -7340,27 +5749,6 @@ game (
 	year "1980"
 	developer "bootleg"
 	rom ( name caterplr.zip size 8579 crc 567d8c20 md5 e3f696cf682932a7917fbac89fae4f2d sha1 e994743656915a56006086b345f1dd9217ddbbcf )
-)
-
-game (
-	name "Cat and Mouse (set 1)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name catnmous.zip size 29654 crc 185a9c66 md5 212e0a860a6ecf993d3ca3839bb6b892 sha1 1a65eeec5e12ebfe396de5fc0113a5d470c51af9 )
-)
-
-game (
-	name "Cat and Mouse (set 2)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name catnmousa.zip size 17444 crc d23da2b4 md5 e4e4b4ef16ee56d843e6cf72987ea12b sha1 366fe75acac160cf61fd0250ce63eff3d6859603 )
-)
-
-game (
-	name "Catt (Japan)"
-	year "1993"
-	developer "Wintechno"
-	rom ( name catt.zip size 1613336 crc f7f5fb81 md5 f1b1648ba5a092200ddb449a1247aa06 sha1 6b8394a6279812d63f62b8b7290ca46fcccd3fa7 )
 )
 
 game (
@@ -7385,13 +5773,6 @@ game (
 )
 
 game (
-	name "U.S. Navy (Japan 901012)"
-	year "1990"
-	developer "Capcom"
-	rom ( name cawingj.zip size 1103242 crc 8a08d3d8 md5 920696014bebd03840e351c106eb1bab sha1 9ce9ee8ffc39e2874005bb81ad10dd3c2d3c46aa )
-)
-
-game (
 	name "Carrier Air Wing (World 901009)"
 	year "1990"
 	developer "Capcom"
@@ -7406,48 +5787,10 @@ game (
 )
 
 game (
-	name "Cherry Bonus 2001"
-	year "2001"
-	developer "Dyna"
-	rom ( name cb2001.zip size 126365 crc 27a76a66 md5 11f70def8f339e52a9dd4283fa3880de sha1 9c9e8b40fdc0e4a046eb49f1f9d5a7b70f2bc733 )
-)
-
-game (
-	name "Cherry Bonus III (ver.1.40, encrypted)"
-	developer "Dyna"
-	rom ( name cb3.zip size 32377 crc 3f23eba0 md5 5782a45d937d8e2afafb3499e7ed8f4e sha1 9f5d0a8ac9d31266dda20cf005558cff82128f0f )
-)
-
-game (
-	name "Cherry Bonus III (ver.1.40, set 2)"
-	developer "Dyna"
-	rom ( name cb3a.zip size 27372 crc 50cd5fbf md5 7683bd232d804fb460ef7b6dcea2274f sha1 5240b0a5e7c4c185ff3ae8507bbc82d7397ec22b )
-)
-
-game (
-	name "Cherry Bonus III (alt)"
-	developer "Dyna"
-	rom ( name cb3b.zip size 85813 crc 8678e6b9 md5 4e6c8af86e96b00075db6d79a6c12b60 sha1 47863151a4af57889dd711515bd9f31cfec372fa )
-)
-
-game (
-	name "Cherry Bonus III (alt, set 2)"
-	developer "bootleg"
-	rom ( name cb3c.zip size 72819 crc fbf9b392 md5 d060a29faf4495a50c2e653bef87af39 sha1 b7d6384bf6bd267c518c7b6f743c76a9cd8af068 )
-)
-
-game (
 	name "Cool Boarders Arcade Jam"
 	year "1998"
 	developer "Tecmo"
 	rom ( name cbaj.zip size 16030178 crc 7c2ad7a0 md5 d09b9c81cd44b3fbabd7be0468bdb420 sha1 9ff4bfb101b12be60141fb78040fca5a5cccd09a )
-)
-
-game (
-	name "Cannonball (Atari, prototype)"
-	year "1976"
-	developer "Atari"
-	rom ( name cball.zip size 4227 crc cf0b0beb md5 df833d6af13e68958f2ae1d75861bd03 sha1 d0e1145ef6396e2b30aba420822f44845cfd5fe6 )
 )
 
 game (
@@ -7598,12 +5941,6 @@ game (
 )
 
 game (
-	name "Cherry Chance"
-	developer "&lt;unknown&gt;"
-	rom ( name cchance.zip size 37963 crc 798dee25 md5 0b52bc7329f84a89022c46e03db041c3 sha1 cd37b98a8783a4a0d82c08583ea6582a464a705c )
-)
-
-game (
 	name "Cosmic Chasm (set 1)"
 	year "1983"
 	developer "Cinematronics / GCE"
@@ -7709,13 +6046,6 @@ game (
 )
 
 game (
-	name "Explorer (Cassette)"
-	year "1982"
-	developer "Data East Corporation"
-	rom ( name cexplore.zip size 18374 crc db477e31 md5 07dafae4c4a0fae39006372851b4e6dd sha1 509d0fdfc285dfc8f301f1b3b67bec6f08d17e1d )
-)
-
-game (
 	name "Chicken Farm (Version 2.0)"
 	year "1999"
 	developer "LAI Games"
@@ -7765,13 +6095,6 @@ game (
 )
 
 game (
-	name "Chaos Field (GDL-0025)"
-	year "2004"
-	developer "Able"
-	rom ( name cfield.zip size 1196 crc 2d510786 md5 78250a81d8daaa6248d0355d92469e40 sha1 384b6072448858d1017c0b16d1bdc8a4287a258b )
-)
-
-game (
 	name "Flying Ball (Cassette)"
 	year "1985"
 	developer "Data East Corporation"
@@ -7804,13 +6127,6 @@ game (
 	year "1983"
 	developer "Data East Corporation"
 	rom ( name cgraplop.zip size 20458 crc 3adab3e0 md5 448400ab1001f7d452abbcdeeb16c78b sha1 2baa0df7d1887e0d0804a37cf544169699549358 )
-)
-
-game (
-	name "Cluster Buster / Graplop (Cassette, set 2)"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name cgraplop2.zip size 12634 crc 194cfbd2 md5 ceceb5b5bec2e93e5bc7f09fd730160e sha1 7b6af1242970effa5df91d23e200d660d3fa9536 )
 )
 
 game (
@@ -7905,24 +6221,10 @@ game (
 )
 
 game (
-	name "Chack'n Pop"
-	year "1983"
-	developer "Taito Corporation"
-	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
-)
-
-game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
 	rom ( name challeng.zip size 14901 crc 61e8276b md5 0c53b4676e3335279a67da49517ca1c0 sha1 325323db1b927b14119571c06b1880fe124cacf6 )
-)
-
-game (
-	name "Chameleon 24"
-	year "2002"
-	developer "bootleg"
-	rom ( name cham24.zip size 942902 crc 07092d53 md5 a4cf2d24005af8343755fe339b1be1a5 sha1 066c36dc8ae05c3a2f798ac755f611617e17e440 )
 )
 
 game (
@@ -7958,20 +6260,6 @@ game (
 	year "1983"
 	developer "Alpha Denshi Co. (Sega license)"
 	rom ( name champbb2.zip size 52147 crc fddc6463 md5 30408ce846c510ca286f5050dac13152 sha1 7bac73045cac299ea58ac956a5f74406106cfd1b )
-)
-
-game (
-	name "Champion Baseball II (set 2)"
-	year "1983"
-	developer "Alpha Denshi Co."
-	rom ( name champbb2a.zip size 19554 crc dbb74808 md5 7cc085f72a1c459f2fa26ab69ac2c1fe sha1 0c782c079a72d8887b7acd1b35a3ca3507c263ca )
-)
-
-game (
-	name "Champion Baseball II (Japan)"
-	year "1983"
-	developer "Alpha Denshi Co."
-	rom ( name champbb2j.zip size 43775 crc 7c4c203c md5 b408427f38083ca3b09da16c93f7f420 sha1 df17242228c48402bc278728ccabcd5f8a65f91e )
 )
 
 game (
@@ -8038,27 +6326,6 @@ game (
 )
 
 game (
-	name "Chase H.Q. (World)"
-	year "1988"
-	developer "Taito Corporation Japan"
-	rom ( name chasehq.zip size 3728581 crc 28121659 md5 2331a078acf3f5915ac22da046eee5fb sha1 0a43f9fa46e07354242723241c30d2c3866c6905 )
-)
-
-game (
-	name "Chase H.Q. (Japan)"
-	year "1988"
-	developer "Taito Corporation"
-	rom ( name chasehqj.zip size 1720082 crc 842ffb1a md5 0c6e931f44750ce5b72c0375bc939c10 sha1 0ebab3a2346fb5dc281f418ec79b5803470f1906 )
-)
-
-game (
-	name "Chase H.Q. (US)"
-	year "1988"
-	developer "Taito America Corporation"
-	rom ( name chasehqu.zip size 69323 crc e874c0f3 md5 1e8af211fec879591e5fa7d98cbf6bfa sha1 e30594eb249a4c4783e2028e8367c95ec44f6796 )
-)
-
-game (
 	name "Champion Boxing"
 	year "1984"
 	developer "Sega"
@@ -8077,13 +6344,6 @@ game (
 	year "1982"
 	developer "Zilec-Zenitone (Jaleco license)"
 	rom ( name checkmanj.zip size 10837 crc fd123f28 md5 0cd355d18b69beaee38c8d8d8fb80820 sha1 7de04c16e0af3a9cf8fc9da7ea007280e28541a7 )
-)
-
-game (
-	name "Checkmate"
-	year "1977"
-	developer "Midway"
-	rom ( name checkmat.zip size 3681 crc 07b85371 md5 704d93f7dc3334ad7a82db3773298f37 sha1 c6032d475c2a64f77d252c43ed96762772a35375 )
 )
 
 game (
@@ -8149,20 +6409,6 @@ game (
 )
 
 game (
-	name "Chimera Beast (prototype)"
-	year "1993"
-	developer "Jaleco"
-	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
-)
-
-game (
-	name "China Gate (US)"
-	year "1988"
-	developer "Technos Japan (Taito / Romstar license)"
-	rom ( name chinagat.zip size 570940 crc f69e5596 md5 b7879cc59c11d7c546958fed372ebfe4 sha1 3a60a36b5841b283e12ab61e7ba4c8c26f2f5673 )
-)
-
-game (
 	name "China Town (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -8205,13 +6451,6 @@ game (
 )
 
 game (
-	name "Chance Kun"
-	year "1982"
-	developer "&lt;unknown&gt;"
-	rom ( name chkun.zip size 126759 crc 5682a169 md5 42ec7597208bd35577ba83f89b528d5c sha1 efb159837defb39677b87baff77c72e3c1025292 )
-)
-
-game (
 	name "Champion League (Poker)"
 	year "2000"
 	developer "IGS"
@@ -8233,45 +6472,10 @@ game (
 )
 
 game (
-	name "Musapey's Choco Marker (Rev A) (GDL-0014A)"
-	year "2002"
-	developer "Ecole Software"
-	rom ( name chocomk.zip size 1197 crc 6a13106f md5 3d7c4a307eb51d5ae6ddba5f2bd35a30 sha1 3d4fbd9aa1292aa37caebee36ea808d614a854b5 )
-)
-
-game (
-	name "Choky! Choky!"
-	year "1995"
-	developer "SemiCom"
-	rom ( name chokchok.zip size 1105332 crc e49ff98c md5 10bdec45413daa6880abccf9ed8695b7 sha1 4bf77f1df9bf1e61b96b30ea7f176fd32976f53c )
-)
-
-game (
 	name "Janpai Puzzle Choukou (Japan 010820)"
 	year "2001"
 	developer "Mitchell (Capcom license)"
 	rom ( name choko.zip size 4923896 crc af3b9ce9 md5 6b916fdfe389946df5b293b4fc3d8532 sha1 138bd736202f8de1ee0a2c2a29da7e358c0d6c2c )
-)
-
-game (
-	name "Choplifter (8751 315-5151)"
-	year "1985"
-	developer "Sega"
-	rom ( name choplift.zip size 138193 crc 1c4bff6a md5 e2e71305b100c701a67b262220f04ca2 sha1 6affaa22ea10ca727dabdae41eb720a676f7de17 )
-)
-
-game (
-	name "Choplifter (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name chopliftbl.zip size 20693 crc 0458fe75 md5 9f85d581118deffa02603d233be311e0 sha1 8149d8d98f241a72f8660ef79ac012549c1108ef )
-)
-
-game (
-	name "Choplifter (unprotected)"
-	year "1985"
-	developer "Sega"
-	rom ( name chopliftu.zip size 39337 crc df8682f6 md5 e57bda53eee38bc4f30fb6731a272218 sha1 1ed384eaab4947693dd5c0f82f6e723b4d486c51 )
 )
 
 game (
@@ -8293,32 +6497,6 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name chopperb.zip size 132034 crc 9f5c9f0d md5 41dc5d5d7e2da3fe48bd3a282362b842 sha1 d9ba5b06df4b969ba7c71729c4eb61b6a9dc6b7b )
-)
-
-game (
-	name "Chequered Flag"
-	year "1988"
-	developer "Konami"
-	rom ( name chqflag.zip size 1325979 crc c170b656 md5 5728a509ae752d36577ea02bc348d6a0 sha1 976e1c7d2384752745b24dd94a105356909f175f )
-)
-
-game (
-	name "Chequered Flag (Japan)"
-	year "1988"
-	developer "Konami"
-	rom ( name chqflagj.zip size 38511 crc c81d7c42 md5 ca39f43118bc430de5fa72cc78d025cf sha1 a0378e26f0aa076f84d7bb00ebab2ad129b1fa26 )
-)
-
-game (
-	name "Cherry 10 (bootleg with PIC16F84)"
-	developer "bootleg"
-	rom ( name chry10.zip size 76925 crc dd0884ea md5 b33be0c1d8d7b7f1d498f769441dea6f sha1 db713de9f2fa66b637cc376e6b4e9f4f355b1e43 )
-)
-
-game (
-	name "Cherry Gold I"
-	developer "bootleg"
-	rom ( name chrygld.zip size 63347 crc 69866dac md5 55c4b8d72f9f99f2324cbef13b708201 sha1 a2400ea45f3fe5252c43757bed43b8b4450f2248 )
 )
 
 game (
@@ -8361,13 +6539,6 @@ game (
 	year "1985"
 	developer "Sega"
 	rom ( name chwrestl.zip size 35843 crc 9d88439c md5 d3ca349c776d55c7fd9fe30e65dc7321 sha1 91d6aaddc557759d21d6bbbc12c785ff91c9a810 )
-)
-
-game (
-	name "Highway Chase (Cassette)"
-	year "1980"
-	developer "Data East Corporation"
-	rom ( name chwy.zip size 15056 crc 10736c54 md5 d30b24fa6550e810bcd261353c420dc8 sha1 dd64977399b20dbac1db26cfb81f3cf3161d61dd )
 )
 
 game (
@@ -8485,7 +6656,7 @@ game (
 	name "Crazy Kong (Alca bootleg)"
 	year "1981"
 	developer "bootleg (Alca)"
-	rom ( name ckongalc.zip size 30675 crc 5c4d4bc2 md5 72d807af08b5c8d29e36387b267018c6 sha1 638e192c37156606393a6cb6110c31165561f3e1 )
+	rom ( name ckongalc.zip size 6761 crc 2340bbdb md5 8fad5cdda50bd4dbd8632f3fc7b3fbc6 sha1 4988f85863280b8fad05f1638d6bb19f5cb38c0c )
 )
 
 game (
@@ -8566,62 +6737,6 @@ game (
 )
 
 game (
-	name "Classic Edition (Version 1.6E)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice.zip size 715269 crc bcc46dbd md5 5e92a66015bccda25c622a6c364e3096 sha1 c0518f8aab24b0d7c986d88585248bdacb44307b )
-)
-
-game (
-	name "Classic Edition (Version 1.6R, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice1.zip size 206049 crc 87e25cac md5 25996f322181bd3242f1c07220396a2e sha1 643e82b2a4734d01ae3817ba382b6e41579c49aa )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classice2.zip size 206312 crc dab3fe2f md5 55d8d462c82daa53ed2ea665e9ca84a0 sha1 af41599d203721a4a48de7adcaef4a9043a16755 )
-)
-
-game (
-	name "Classic Edition (Version 1.6R, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classiced1.zip size 204997 crc 9cc5d501 md5 299bdb23a383edbc173963a8a1d0f18e sha1 176ab708b5af4a0df6ae8078e39e5475ca18c49d )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classiced2.zip size 205387 crc 054e3611 md5 4790027673f86278ca791dfae38c517e sha1 367354dc72db22b00b0c6568b8ed5e2736c9315a )
-)
-
-game (
-	name "Classic Edition (Version 1.6E Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev.zip size 206179 crc 9e314685 md5 ab57ea5757003151e954498288a7a3a1 sha1 1d0ba0662819de7d0b85b2e742e33985bc08dbff )
-)
-
-game (
-	name "Classic Edition (Version 1.6R Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev1.zip size 206020 crc c37ec79e md5 4f25d7393d5b351ab3d6b30acbc4fa77 sha1 d9a3bc38eb63ca61a031033034647ba6582ec79d )
-)
-
-game (
-	name "Classic Edition (Version 1.6LT Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name classicev2.zip size 206087 crc ab3a130f md5 ae1dc45116cd6edc970218443baa67af sha1 132b9dfb8cd1ca5df553cdf2568485f0398e2375 )
-)
-
-game (
 	name "Clay Pigeon (version 2.0)"
 	year "1986"
 	developer "Exidy"
@@ -8629,24 +6744,10 @@ game (
 )
 
 game (
-	name "Clay Shoot"
-	year "1979"
-	developer "Allied Leisure"
-	rom ( name clayshoo.zip size 6453 crc d8b2cb3a md5 4401c797845344f5700935c25bd2d5db sha1 3a9402b6f03b31e8000c5c8a4e69bc10584eec3e )
-)
-
-game (
 	name "Coors Light Bowling"
 	year "1989"
 	developer "Incredible Technologies / Capcom"
 	rom ( name clbowl.zip size 100005 crc 3ce43928 md5 e2b2e97aad33555f91a3bc4c763ad943 sha1 3c45a76dc9f28bac1772701cb9cb5485739a523d )
-)
-
-game (
-	name "Cleopatra Fortune Plus (GDL-0012)"
-	year "2002"
-	developer "Altron"
-	rom ( name cleoftp.zip size 1195 crc 89b4f12b md5 2d29a06a8493b8b711a8c906cc948bef sha1 efe6831a6fe1448ccb158f700af02a5532d4d11b )
 )
 
 game (
@@ -8706,13 +6807,6 @@ game (
 )
 
 game (
-	name "Cloud 9 (prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name cloud9.zip size 22630 crc 84caff0f md5 0868c27a4b6d65518e01d456ef766ac2 sha1 821c6bb14ea941e9d120e81648f9dc9a9f10fded )
-)
-
-game (
 	name "Clowns (rev. 2)"
 	year "1978"
 	developer "Midway"
@@ -8769,13 +6863,6 @@ game (
 )
 
 game (
-	name "Club Kart: European Session"
-	year "2002"
-	developer "Sega"
-	rom ( name clubkrte.zip size 139630974 crc 01a259ca md5 defbd9799019f24f3cb9a304b3cfcfe8 sha1 d0163dc27444a6aed52bde59db6e9c844fdef3ee )
-)
-
-game (
 	name "Lucky Poker (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
@@ -8811,26 +6898,6 @@ game (
 )
 
 game (
-	name "Carta Magica (Ver 1.8)"
-	developer "&lt;unknown&gt;"
-	rom ( name cmagica.zip size 425498 crc 256eb1f5 md5 2a91fac75a9ee5eadc967845e5dc9298 sha1 b9e25c0f6041dac1491ede2f5804bd3fed3c1b49 )
-)
-
-game (
-	name "Cherry Master '91 (ver.1.30)"
-	year "1991"
-	developer "Dyna"
-	rom ( name cmast91.zip size 124394 crc a1a6abb1 md5 c1dd7066427057dd054404822d20297b sha1 f7950ed9fd3d6cafcd657f1f870f94a877e87aaa )
-)
-
-game (
-	name "Cherry Master '92"
-	year "1992"
-	developer "Dyna"
-	rom ( name cmast92.zip size 17718 crc c73d9176 md5 1f7c1b45985e650f639b7e7c62eed7d4 sha1 2ab8357a28cc687666e26f0a1b37ea4753a6e09e )
-)
-
-game (
 	name "Cherry Master I (ver.1.01, set 1)"
 	year "1991"
 	developer "Dyna"
@@ -8842,13 +6909,6 @@ game (
 	year "1991"
 	developer "Dyna"
 	rom ( name cmasterb.zip size 43832 crc 5033cd67 md5 5259685ae1a0e8c92b1e611c0e0415e2 sha1 76c05e12096e1ec8100ed6e86bd5d6dc1da8ac34 )
-)
-
-game (
-	name "Cherry Master I (ver.1.01, set 4, with Blitz Poker ROM?)"
-	year "1991"
-	developer "Dyna"
-	rom ( name cmasterbv.zip size 78477 crc 7b046742 md5 5d6988114aba6b7b2623d7560d529777 sha1 51a840241c2ea5bba2c8f9a9c74b9fab0b315190 )
 )
 
 game (
@@ -8908,50 +6968,10 @@ game (
 )
 
 game (
-	name "Coinmaster Keno (Y2K, Spanish, 2000-12-14)"
-	year "2000"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmkenosp.zip size 5174964 crc fd03f3e4 md5 08531201d1783d09017783ac8fe508e5 sha1 820219816f85d803ca8308ff68b0580baee2ba84 )
-)
-
-game (
-	name "Coinmaster Keno (Y2K, Spanish, 2000-12-02)"
-	year "2000"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmkenospa.zip size 301521 crc 830a41d4 md5 5356d4188c626f0feed5d9898b9d8525 sha1 8396bf780f134bd444f29f4ae62a712f97268866 )
-)
-
-game (
-	name "Multipede (V1.00)"
-	developer "Infogrames / Cosmodog"
-	rom ( name cmmb162.zip size 147152 crc 18f734b7 md5 85e998cd75efbd5413165aee0355a548 sha1 1cf3c46baff5e176517b3d882248d95432ade38e )
-)
-
-game (
-	name "Coinmaster Roulette V75 (Y2K, Spanish)"
-	year "2001"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name cmrltv75.zip size 6583014 crc 44558d84 md5 68e6c69ff3fb3ccd6a6410891a234c58 sha1 0ca8dcb24c6da97b1bb287247100a7bc77a9a1ac )
-)
-
-game (
 	name "Cherry Master (ver.4, set 1)"
 	year "1992"
 	developer "Dyna"
 	rom ( name cmv4.zip size 58346 crc 39fce85a md5 c981a34a6c8b8cf4569436d1f07bfaab sha1 941300f13339fee16767962d58b774c0adb549b9 )
-)
-
-game (
-	name "Cherry Master (ver.4, set 2)"
-	year "1992"
-	developer "Dyna"
-	rom ( name cmv4a.zip size 78518 crc 9a3ca984 md5 4c5443338d080b56b93d992c99ca65f7 sha1 f2122ad4ae1b5e3bd10ac7a5011889c77a3713c8 )
-)
-
-game (
-	name "Cherry Master (Corsica, ver.8.01)"
-	developer "Corsica"
-	rom ( name cmv801.zip size 63718 crc 25c94c82 md5 d02d783854aaf79b018dc37777172454 sha1 3dc6691fba35614c033ea07f19456f83bd66a667 )
 )
 
 game (
@@ -8989,13 +7009,6 @@ game (
 )
 
 game (
-	name "Caveman Ninja (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name cninjabl.zip size 2217384 crc 7de87ee7 md5 538547c6100b04fe00a2e370415f2d42 sha1 23f5690c37ebf9ce48d495fa173003b7ce7f2df7 )
-)
-
-game (
 	name "Caveman Ninja (US ver 4)"
 	year "1991"
 	developer "Data East Corporation"
@@ -9014,20 +7027,6 @@ game (
 	year "1984"
 	developer "Nichibutsu"
 	rom ( name cntrygrla.zip size 12196 crc 0d4c44f4 md5 54c6c3795871bd1a8febc7779299f76a sha1 8fa3379946168595d9b32873c9c6c88fe1bf6936 )
-)
-
-game (
-	name "Counter Steer (Japan)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name cntsteer.zip size 109874 crc 1f4377c2 md5 fb7183032add6b15dc6884730c125c7a sha1 e7a5aa04fea70529ed9a3378f41ca1a00d568266 )
-)
-
-game (
-	name "Cobra Command (Data East LD)"
-	year "1984"
-	developer "Data East"
-	rom ( name cobra.zip size 32085 crc 45c49d29 md5 fc1b65a61bb7f11d7615111acedbdf27 sha1 37f00714e60ea5ad92f8cb8607fc1ee22410945c )
 )
 
 game (
@@ -9052,13 +7051,6 @@ game (
 )
 
 game (
-	name "Cobra Command (Sega LaserDisc Hardware)"
-	year "1983"
-	developer "Sega"
-	rom ( name cobraseg.zip size 20648 crc f1b6c781 md5 c0813af5a7d9d5ee8352b6b9b37239f3 sha1 f142f55434b464892c2bafb9eabaa563c9e18838 )
-)
-
-game (
 	name "Columns '97 (JET 961209 V1.000)"
 	year "1996"
 	developer "Sega"
@@ -9077,20 +7069,6 @@ game (
 	year "1981"
 	developer "Taito"
 	rom ( name colony7a.zip size 8830 crc ccceede4 md5 99ba57ccd64a0c495f5305f7116105ae sha1 fd5e6a3af0eb7a02b71b3448e8bfcb177f8a9e44 )
-)
-
-game (
-	name "Colorama (English)"
-	year "2001"
-	developer "Coinmaster-Gaming, Ltd."
-	rom ( name colorama.zip size 1771751 crc 34ffa6ae md5 48e30ad9164fb790c351e501c29e8af3 sha1 a46bae5eff8ec3ca3eef5c59aaedd2c52a7ac287 )
-)
-
-game (
-	name "Colt"
-	year "1986"
-	developer "bootleg"
-	rom ( name colt.zip size 52881 crc 54c474a5 md5 3e057dd82b2bcec64ff454dd55aef0e9 sha1 c58b76b486dd3e6cf1b43b4d2ff4dc173d1afc31 )
 )
 
 game (
@@ -9136,13 +7114,6 @@ game (
 )
 
 game (
-	name "Combat School (joystick)"
-	year "1988"
-	developer "Konami"
-	rom ( name combatsc.zip size 536697 crc 737e2796 md5 2fd1d3696d9aa56c5deb0bbcee20c01e sha1 86f39b054525498962424cf2af8c422443b42391 )
-)
-
-game (
 	name "Combat School (bootleg)"
 	year "1988"
 	developer "bootleg"
@@ -9164,73 +7135,10 @@ game (
 )
 
 game (
-	name "Combat Hawk"
-	year "1987"
-	developer "Sanritsu / Sega"
-	rom ( name combh.zip size 57206 crc 3b563a57 md5 5f50f040b72bb2eb8a8ce0e3930c3303 sha1 366a8b95d44e7fccdda45669dc2a27b01c26085e )
-)
-
-game (
-	name "Cal Omega - Game 7.4 (Gaming Poker, W.Export)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg074.zip size 11237 crc 0e7ba0ce md5 7e5b0549e0bae999d0a4b35039d720a4 sha1 c20835afe061f47306203ef0bbb401dcc8e40ccf )
-)
-
-game (
 	name "Cal Omega - Game 7.6 (Arcade Poker)"
 	year "1981"
 	developer "Cal Omega Inc."
 	rom ( name comg076.zip size 10767 crc 941f06ce md5 3fe80555c99a10b46af848f6b9097355 sha1 a879dc2ffa18c5fd9ea2cced7a093ba4db32374e )
-)
-
-game (
-	name "Cal Omega - Game 7.9 (Arcade Poker)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg079.zip size 12238 crc ba34d239 md5 a65116b1ff8c226e1be85f10c9ee1cde sha1 3e9c60cc3f0c70fa12eeb411f602af7edaee2622 )
-)
-
-game (
-	name "Cal Omega - Game 8.0 (Arcade Black Jack)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg080.zip size 9969 crc 339d118d md5 a29c2866dbc817e4383f2cca043f09ee sha1 e8fb045fe0b1a38e408a0eb167f8fcdef7fb0738 )
-)
-
-game (
-	name "Cal Omega - Game 9.4 (Keno)"
-	year "1981"
-	developer "Cal Omega Inc."
-	rom ( name comg094.zip size 7032 crc ad655df6 md5 425a2ee9b038b9d6b639880356c30efa sha1 b624b2aea6e95e52ea191c12c7355f0cfc39022f )
-)
-
-game (
-	name "Cal Omega - Game 10.7c (Big Game)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg107.zip size 8937 crc 758e99cf md5 ad29f47b6057b0241b1048a30de1e1fe sha1 4d20239a83baeaab598e0998d8e48be829aad1c1 )
-)
-
-game (
-	name "Cal Omega - Game 12.3 (Ticket Poker)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg123.zip size 10703 crc 17855223 md5 d914ee1c49dbdb1ba12a4aff276ddad3 sha1 3ab0731c83ea81f645e5e75436ea0a35104dc9a8 )
-)
-
-game (
-	name "Cal Omega - Game 12.5 (Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg125.zip size 9725 crc 26bafb56 md5 947ad970c557e281b1aadf4c5a579050 sha1 aa4e5fde433abe10745dcc57fc02dc95f86e1dc6 )
-)
-
-game (
-	name "Cal Omega - Game 12.7 (Keno)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg127.zip size 7028 crc 04262b95 md5 155c89e6bbaf49b657864190b50545e3 sha1 cacf93fd315667b30a6293c6d3fd38d6f4cb59e2 )
 )
 
 game (
@@ -9241,136 +7149,10 @@ game (
 )
 
 game (
-	name "Cal Omega - Game 13.4 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg134.zip size 9707 crc 920b097e md5 d00886c7927ff1815c43942efebb2d63 sha1 8d514eba2112cc5e0adb74a719005808f6909979 )
-)
-
-game (
-	name "Cal Omega - Game 14.5 (Pixels)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg145.zip size 11909 crc c1aad10e md5 1f53404c06d1b5a4593b4e8f5ab67fd4 sha1 c3c7e885a2d048022693b03061b759d500cd8c1c )
-)
-
-game (
-	name "Cal Omega - Game 15.7 (Double-Draw Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg157.zip size 12671 crc 88ae08a9 md5 0ccdb436a8151eab4322b994b2441b01 sha1 2e78ddc3fe1cc804846059ad4b6933ed1a4e4f20 )
-)
-
-game (
-	name "Cal Omega - Game 15.9 (Wild Double-Up)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg159.zip size 12883 crc 1de913c6 md5 f02bcb9f305958a49206e0861f5da56e sha1 fa95755b9b04f4b9d5461535435c7075571e4867 )
-)
-
-game (
-	name "Cal Omega - Game 16.4 (Keno)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg164.zip size 7790 crc ec527c0f md5 8d5187fc9da53185fb1c370fe04f688d sha1 733db447c48d91bcbed5bd94843b326baa62b1f3 )
-)
-
-game (
-	name "Cal Omega - Game 16.8 (Keno)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg168.zip size 6979 crc 6d78036f md5 4a8814aefd245f011b74b996a4cf9227 sha1 2e3ff85226423a54503d0826e7dbde6e31252183 )
-)
-
-game (
-	name "Cal Omega - Game 17.2 (Double Double Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg172.zip size 13283 crc 9df1eb1d md5 b72d2dd25f5e84fc389e6a88acd8288e sha1 95c8dbb564c7ceb384b369c8e0c810fd2653685e )
-)
-
-game (
 	name "Cal Omega - Game 17.51 (Gaming Draw Poker)"
 	year "1984"
 	developer "Cal Omega / Casino Electronics Inc."
 	rom ( name comg175.zip size 12594 crc b44fdb21 md5 76e0d09cf85fd61e517ca1250213c7be sha1 c9cc0a338567e6f3fb1737f961d663dace56004e )
-)
-
-game (
-	name "Cal Omega - Game 17.6 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg176.zip size 9922 crc 6019ed01 md5 d663fc606f869961207370135f60d132 sha1 1fe135832d015d05349891c46c35f5ce493c983e )
-)
-
-game (
-	name "Cal Omega - Game 18.1 (Nudge Bingo)"
-	year "1982"
-	developer "Cal Omega Inc."
-	rom ( name comg181.zip size 9770 crc 7cfb3b5d md5 fc1b11727f9d8ff9ec0bf8aff36d3110 sha1 3f85ec0f559218489c9ce6dc0da4a98ebdf87862 )
-)
-
-game (
-	name "Cal Omega - Game 18.3 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg183.zip size 13151 crc 19905488 md5 37a519af701656c6643546c5de491ffb sha1 bbe21f35b53cb9445a7591f50f7d27cbf3e0a757 )
-)
-
-game (
-	name "Cal Omega - Game 18.5 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg185.zip size 14952 crc f5036012 md5 3800805b2f8942a1cc9e3c388d892fb1 sha1 79a3a26442d4bf76366df09a889000e8318d98e3 )
-)
-
-game (
-	name "Cal Omega - Game 18.6 (Pixels)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg186.zip size 13271 crc eeea2740 md5 ae869f0f9577b0856f916d827977c442 sha1 9af9fa256625f160e523251a4b44ed787c6d5402 )
-)
-
-game (
-	name "Cal Omega - Game 18.7 (Amusement Poker)"
-	year "1983"
-	developer "Cal Omega Inc."
-	rom ( name comg187.zip size 13315 crc d985bbc7 md5 8978a4fb9ca30474c7293e13f1929c93 sha1 62fd6461579b486b93b4895fb9837bf2cbaf3fcb )
-)
-
-game (
-	name "Cal Omega - Game 20.4 (Super Blackjack)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg204.zip size 18499 crc 21e0e8c2 md5 44dc25e96f967633f3f5292314ce8edf sha1 4eb850119d37eac43469d3ba463e39b6e7f035f5 )
-)
-
-game (
-	name "Cal Omega - Game 20.8 (Winner's Choice)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg208.zip size 21871 crc f54403fb md5 f21973805a082af2a5e598e1e0822cfb sha1 f6c2197bbc8cf3d4f930b21ee36dbc5fec5f1829 )
-)
-
-game (
-	name "Cal Omega - Game 22.7 (Amusement Poker, d/d)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg227.zip size 12345 crc 8ffc9c9c md5 ccd5b89826ca98c555e6e45f7791bb83 sha1 47b886f521e3865e27cf1b3a2d37ec2fa7859ecd )
-)
-
-game (
-	name "Cal Omega - Game 23.0 (FC Bingo (4-card))"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg230.zip size 8114 crc 664631d7 md5 2231a329734d1255822a06e2ddf59ed2 sha1 881a33390b9df9d52cc784199bcd51470e04658d )
-)
-
-game (
-	name "Cal Omega - Game 23.6 (Hotline)"
-	year "1984"
-	developer "Cal Omega Inc."
-	rom ( name comg236.zip size 14607 crc 3c60f5f9 md5 452b4ba3e2f5f18fc1afe9188fbf916c sha1 dbb12500e0fb9618843e7145a451e3ef4ec35bb0 )
 )
 
 game (
@@ -9381,50 +7163,10 @@ game (
 )
 
 game (
-	name "Cal Omega - Game 24.6 (Hotline)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg246.zip size 14998 crc 5aeac3ee md5 2e856b8fb5f3b8e1bea5e607634ffe1d sha1 a12f439bf777914080f6810ad1814abca166d0fc )
-)
-
-game (
-	name "Cal Omega - Game 27.2 (Keno, amusement)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg272a.zip size 7024 crc b0e49d89 md5 552231d7ebd498bc256a244f2e75a203 sha1 e225cc33506b21dab891d20268f939bee8d3b16b )
-)
-
-game (
-	name "Cal Omega - Game 27.2 (Keno, gaming)"
-	year "1985"
-	developer "Cal Omega Inc."
-	rom ( name comg272b.zip size 7620 crc 52543873 md5 57c47eeed8e1a2e302445bc836ea85b9 sha1 1d3b314b2334e30a3eec0a3312d85f99d1f6fdb6 )
-)
-
-game (
-	name "Cal Omega - System 903 Diag.PROM"
-	developer "Cal Omega Inc."
-	rom ( name comg903d.zip size 2980 crc a01be3a2 md5 ff54feac3016b19eb845c54b65b53908 sha1 074da12a6a37cc4dce08a5a5b9b79febedbc0b7b )
-)
-
-game (
-	name "Cal Omega - System 905 Diag.PROM"
-	developer "Cal Omega Inc."
-	rom ( name comg905d.zip size 4725 crc b0c6223b md5 76cb56ae8a53629e954b280ad9edbe8a sha1 265f09e77067463c455766e0b8e2fb97f7c1ff2e )
-)
-
-game (
 	name "Commando (World)"
 	year "1985"
 	developer "Capcom"
 	rom ( name commando.zip size 135332 crc fa4bac04 md5 84b2cf3dd2393c8c6cc13caa6440f4c3 sha1 1af11df9f2ccdc33564f606db8cef4c586b03f2a )
-)
-
-game (
-	name "Commando (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name commandob.zip size 19068 crc 85a0275e md5 0f8bafa299a9cefcf92ef2d1e25c7fb0 sha1 33c37789e68e71466dc93cbd9382e6e8ded425fc )
 )
 
 game (
@@ -9491,13 +7233,6 @@ game (
 )
 
 game (
-	name "Confidential Mission (GDS-0001)"
-	year "2001"
-	developer "Sega"
-	rom ( name confmiss.zip size 1193 crc 98a3cadc md5 4a40598e228949a16cbac3326079c47c sha1 7f592dc72ca8f6b42f81e827f61d804ac52e2096 )
-)
-
-game (
 	name "Congo Bongo"
 	year "1983"
 	developer "Sega"
@@ -9508,13 +7243,6 @@ game (
 	name "Connect 4"
 	developer "Dolbeck Systems"
 	rom ( name connect4.zip size 17836 crc 5639ae8a md5 f8197ef2a86b6dd457c25630d12a84b4 sha1 53d5d4f13ea522c694fc4c349d7a3ea43dfe2ca1 )
-)
-
-game (
-	name "Conquer"
-	year "1982"
-	developer "&lt;unknown&gt;"
-	rom ( name conquer.zip size 15424 crc 7a19c643 md5 cb38dd56f8b0452c3ca8313d7b3e1666 sha1 91833d5a1e09a9b2b794388685a3092069390716 )
 )
 
 game (
@@ -9539,20 +7267,6 @@ game (
 )
 
 game (
-	name "Contra (US, Set 1)"
-	year "1987"
-	developer "Konami"
-	rom ( name contra.zip size 388410 crc 3d1478a8 md5 ee1ba16d382481b9158c4d85e23c4e47 sha1 20f9644b22773cc1e45f8bf18750faf54cd1884c )
-)
-
-game (
-	name "Contra (US, Set 2)"
-	year "1987"
-	developer "Konami"
-	rom ( name contra1.zip size 33839 crc bd9ed4f3 md5 cf5d5674afd64c73827c88bc18fb5a37 sha1 90a047ad3796108bdb95e25b93f86d27af3c7b5f )
-)
-
-game (
 	name "Contra (bootleg)"
 	year "1987"
 	developer "bootleg"
@@ -9560,38 +7274,10 @@ game (
 )
 
 game (
-	name "Contra (Japan)"
-	year "1987"
-	developer "Konami"
-	rom ( name contraj.zip size 60273 crc 4f71841d md5 deb86c0a34052ca9adc388b782e9a6e6 sha1 437c374378079ba077c455ca688f4f8bf9fe8ad5 )
-)
-
-game (
 	name "Contra (Japan bootleg)"
 	year "1987"
 	developer "bootleg"
 	rom ( name contrajb.zip size 357110 crc 714b6097 md5 ce03f000b7914bf0c4e8c388e5b9f512 sha1 50878f906ff92aa3df0905d6c4d28823eec9639f )
-)
-
-game (
-	name "Cookie _ Bibi"
-	year "1995"
-	developer "SemiCom"
-	rom ( name cookbib.zip size 342327 crc 97dea0ac md5 41965c465e6bbf17dd4742b1b4086f04 sha1 cfd3d80bdf61705dfc7039ae92e922935d991b64 )
-)
-
-game (
-	name "Cookie _ Bibi 2"
-	year "1996"
-	developer "SemiCom"
-	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
-)
-
-game (
-	name "Cookie _ Bibi 3"
-	year "1997"
-	developer "SemiCom"
-	rom ( name cookbib3.zip size 846012 crc b25ea726 md5 08d84864359d554308c0d542f2bba183 sha1 4793eb59e453b5e8d72eff74dfed1538fe467610 )
 )
 
 game (
@@ -9616,13 +7302,6 @@ game (
 )
 
 game (
-	name "Cool Riders (US)"
-	year "1995"
-	developer "Sega"
-	rom ( name coolridr.zip size 44572286 crc c4dec29e md5 b711067a5a95e62ed76903e8f098eafc sha1 51a824c71b13fabd038e3e6d33b69737cbed9dde )
-)
-
-game (
 	name "Cop 01 (set 1)"
 	year "1985"
 	developer "Nichibutsu"
@@ -9634,13 +7313,6 @@ game (
 	year "1985"
 	developer "Nichibutsu"
 	rom ( name cop01a.zip size 48615 crc 432b9931 md5 087e173b6a5b35956d4372a0064be026 sha1 6a40054a62bbfb0589ae1dd296216096e0ce2814 )
-)
-
-game (
-	name "Cops'n Robbers"
-	year "1976"
-	developer "Atari"
-	rom ( name copsnrob.zip size 5679 crc 6ac18272 md5 0199eebff107ffc27dfacb314b304f61 sha1 89b071ba7e243eb6e92c6be14cdb28ad2095adcb )
 )
 
 game (
@@ -9676,13 +7348,6 @@ game (
 	year "1979"
 	developer "Universal"
 	rom ( name cosmica1.zip size 10166 crc a946cd8b md5 208209b302e0207a6cdd67467c878c65 sha1 8e808861fe5daa268f15272e69ce182c30c4a1c0 )
-)
-
-game (
-	name "Cosmic Alien (early version II?)"
-	year "1979"
-	developer "Universal"
-	rom ( name cosmica2.zip size 9230 crc d6a904c3 md5 9f55ca693fb1c1ad15b6e1139dd51675 sha1 291a466f8b2d2a35805cdd919ad1d3a1689a2ed8 )
 )
 
 game (
@@ -9777,13 +7442,6 @@ game (
 )
 
 game (
-	name "Counter Run"
-	year "1988"
-	developer "Nihon System (Sega license)"
-	rom ( name countrun.zip size 45649 crc 99365d7e md5 ed2c2b648bb2e154739ae8ab42f87d45 sha1 d4a7c3c0d581e6376ffae306a9621a189b8003e8 )
-)
-
-game (
 	name "Counter Run (bootleg set 1)"
 	year "1988"
 	developer "bootleg"
@@ -9791,45 +7449,10 @@ game (
 )
 
 game (
-	name "Counter Run (bootleg set 2)"
-	year "1988"
-	developer "bootleg"
-	rom ( name countrunb2.zip size 21262 crc 65bdd405 md5 b9ac7793789e0943f165b12a71c10bba sha1 f9194fc72a1c462693e5031ae8bb949889986bf8 )
-)
-
-game (
 	name "Country Club"
 	year "1988"
 	developer "SNK"
 	rom ( name countryc.zip size 113057 crc f39a381d md5 3a4c86108e38acf091557a57619ea6ac sha1 c1dfe7c35a012c0321f90f4b132e35840d7d85b1 )
-)
-
-game (
-	name "The Couples (Set 1)"
-	year "1988"
-	developer "Merit"
-	rom ( name couple.zip size 53983 crc 128e4e73 md5 e2aaa5235207ccf22e771a1f8c69ff5b sha1 7aff661949da7f9e2d234f59fa550d42f5b0a013 )
-)
-
-game (
-	name "The Couples (Set 3)"
-	year "1988"
-	developer "Merit"
-	rom ( name couplei.zip size 16979 crc a25ac17d md5 c47acb9d1b5e8cf9aa02416036690db3 sha1 0cc43b21f1c886b42da504c91b54b95281cdb41c )
-)
-
-game (
-	name "The Couples (Set 2)"
-	year "1988"
-	developer "Merit"
-	rom ( name couplep.zip size 17096 crc d1fa75c7 md5 ab4f5f292fb2f31ee097c32c5495ae9d sha1 640101a644fdeb2f01ac66c35d08d6e75c134084 )
-)
-
-game (
-	name "Cow Race (1986 King Derby hack)"
-	year "2000"
-	developer "bootleg"
-	rom ( name cowrace.zip size 129620 crc eeb04708 md5 116f335fff20602581d08f3625ebfd37 sha1 d8ecbbdf10e75349478b0060f7b415786ced056f )
 )
 
 game (
@@ -9842,12 +7465,6 @@ game (
 	name "Champion Italian PK (bootleg, blue board)"
 	developer "bootleg (SGS)"
 	rom ( name cpokerpk.zip size 336412 crc 10e88aa5 md5 575d7622575610ad83aae5aeb0be50ad sha1 e116ee02b487fa5f9fd70cccf2692b440344d750 )
-)
-
-game (
-	name "Champion Italian PK (bootleg, green board)"
-	developer "bootleg (SGS)"
-	rom ( name cpokerpkg.zip size 43885 crc f8481935 md5 177fb4a4a812801e6bc04ea16c343506 sha1 01adb36b67fbcd2fefd49c21d9e337f0c6cd4906 )
 )
 
 game (
@@ -9899,13 +7516,6 @@ game (
 )
 
 game (
-	name "Crackin' DJ"
-	year "2000"
-	developer "Sega"
-	rom ( name crackndj.zip size 103939119 crc fd8bc350 md5 80cbd085c54eac02454b8def3af4701a sha1 93572ea3c4712400a9a09a02a7765bae666ac2a5 )
-)
-
-game (
 	name "Crackshot (version 2.0)"
 	year "1985"
 	developer "Exidy"
@@ -9941,20 +7551,6 @@ game (
 )
 
 game (
-	name "Crazy Fight"
-	year "1996"
-	developer "Subsino"
-	rom ( name crazyfgt.zip size 1570605 crc ef867d42 md5 e1a5b5a71e72e7db8b340401b2ecb0aa sha1 3c3b9a8f54c9c9ee9c2aa3d4a6b833765aeb1105 )
-)
-
-game (
-	name "Crazy War"
-	year "2002"
-	developer "Eolith"
-	rom ( name crazywar.zip size 12682336 crc 0da6e2b1 md5 71fc6380adc8fc98186161af0f00ac56 sha1 525b44d4a69edbf9d787e95400fd91131f1342ea )
-)
-
-game (
 	name "Crazy Balloon (set 1)"
 	year "1980"
 	developer "Taito Corporation"
@@ -9966,20 +7562,6 @@ game (
 	year "1980"
 	developer "Taito Corporation"
 	rom ( name crbaloon2.zip size 4714 crc 45eb0b3b md5 e79eb4a6446aaae4ace305841f88067a sha1 c8f2f688cfc83b8483a447bce6a0380f2ac6b1a1 )
-)
-
-game (
-	name "Crowns Golf (834-5419-04)"
-	year "1984"
-	developer "Nasco Japan"
-	rom ( name crgolf.zip size 48587 crc 512e0094 md5 3a13536a8d6577c0beec45f831e4840f sha1 44ed1b8d429eed892b8143d61902e1f3de3426e4 )
-)
-
-game (
-	name "Crowns Golf (834-5419-03)"
-	year "1984"
-	developer "Nasco Japan"
-	rom ( name crgolfa.zip size 13322 crc 99c0c119 md5 340340de80965b43d3fe279e824c1423 sha1 e9ccd012ba283c40c48224010ef3a67d5872828b )
 )
 
 game (
@@ -10032,27 +7614,6 @@ game (
 )
 
 game (
-	name "Crime Patrol 2: Drug Wars v1.3"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimep2.zip size 62957 crc a04290c3 md5 37801632e64270838c0435d3018f2365 sha1 3fe0d794b6c241702a0df80035a0d83ca726408a )
-)
-
-game (
-	name "Crime Patrol 2: Drug Wars v1.1"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimep211.zip size 62227 crc 30e96206 md5 e3f00d6c7692232a27f09530e4a95bee sha1 32102a215216372eb4a9995f8b03e04343fbdd48 )
-)
-
-game (
-	name "Crime Patrol v1.4"
-	year "1993"
-	developer "American Laser Games"
-	rom ( name crimepat.zip size 64047 crc 3d55fb8b md5 d74f79d25cd7bfdcb12bc9a975377990 sha1 ccaca1963b287dc986d80169c42a09c01566e8a7 )
-)
-
-game (
 	name "Crime Fighters (US 4 players)"
 	year "1989"
 	developer "Konami"
@@ -10071,13 +7632,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name crimfghtj.zip size 66897 crc 188f9bca md5 67d18bcd24a5c75c297aec36827d3abb sha1 bb3919c101f67909decb2694b69ac7a30499c3fb )
-)
-
-game (
-	name "Criss Cross (Sweden)"
-	year "1986"
-	developer "JPM"
-	rom ( name crisscrs.zip size 18194 crc 563bf3b4 md5 4a8fdaca74d34421531843ca1539e064 sha1 ef5bf8f27a9daa1e69a44678276d250357a02b9c )
 )
 
 game (
@@ -10109,69 +7663,6 @@ game (
 )
 
 game (
-	name "The Crystal Maze (v1.3)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze.zip size 2718918 crc 8d463d01 md5 a0b20e342941a2502aeaff32089d52ac sha1 8511c42b5b3b77ca63bcbc34ff759e6ece5f40fa )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v2.2)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2.zip size 1905063 crc cfa310b7 md5 77cd0f0c5252d73ae840eab69d02af6c sha1 a847eb5eece85207a3c7b0ed369e43c005cb3871 )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v0.1, AMLD)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2a.zip size 1895494 crc 3fcbe465 md5 5053f17077f4219ce6946878f473abd8 sha1 f6bd2f36cc0d0720620fa364014fa1a6b95358bf )
-)
-
-game (
-	name "The New Crystal Maze Featuring Ocean Zone (v2.2d)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmaze2d.zip size 152724 crc 8306ee86 md5 c6fd11ee39eea401ad62d0b115936d47 sha1 0db8d740664cb4ecae4a26a5cb38a64228ef1838 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v0.9)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3.zip size 1911772 crc f7514bb1 md5 64f545b51a5004efe427b5b977000f60 sha1 25163b2d185a980a72094dc5c975379b4a888ab1 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v1.2, AMLD)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3a.zip size 1330216 crc fc601b9b md5 cd6a7cb1e5f20151ef39f210597dd397 sha1 939673a621954d3aeac5ebe24c4eeb536e3c3432 )
-)
-
-game (
-	name "The Crystal Maze Team Challenge (v0.9, Datapak)"
-	year "1994"
-	developer "Barcrest"
-	rom ( name crmaze3d.zip size 164653 crc 1532db15 md5 631e48082e177315fc22313390be4bab sha1 1b436ae14cdb67e459f7e798c7016fdf51658c39 )
-)
-
-game (
-	name "The Crystal Maze (v0.1, AMLD)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmazea.zip size 1332263 crc a6bf434c md5 f883ce72ce7bea7dcabc36bd36754248 sha1 7838c00a229d3c5809de434589acc376caa34599 )
-)
-
-game (
-	name "The Crystal Maze (v1.3, Datapak)"
-	year "1993"
-	developer "Barcrest"
-	rom ( name crmazed.zip size 99132 crc cb89d240 md5 926718a2e3ea2dc8b64e7f8e46353af4 sha1 b4091fef8d86b8e56d830e1dfec07c912de4a200 )
-)
-
-game (
 	name "Croquis (Germany)"
 	year "1996"
 	developer "Deniam"
@@ -10200,13 +7691,6 @@ game (
 )
 
 game (
-	name "Poker Carnival"
-	year "1991"
-	developer "Subsino"
-	rom ( name crsbingo.zip size 59323 crc bf514419 md5 8c9f8a769f852de3fff6b15842535833 sha1 cdac4d35379322cf6c1a9c4c01907e2791b67b70 )
-)
-
-game (
 	name "Lethal Crash Race (set 1)"
 	year "1993"
 	developer "Video System Co."
@@ -10225,13 +7709,6 @@ game (
 	year "1991"
 	developer "Alpha Denshi Co."
 	rom ( name crsword.zip size 2724948 crc e157a16a md5 84bac100e9bb85fbacfe8c8505ea34db sha1 e867d2964d9bcc9eeb6483a943aa5acb85b7ba6d )
-)
-
-game (
-	name "Crisis Zone (CSZO3 Ver. B)"
-	year "2000"
-	developer "Namco"
-	rom ( name crszone.zip size 60082757 crc c1d966ab md5 c32841f242f48774665d2508414367f2 sha1 4c53868ce25fbf82fa56852f2cd16d9da08707d7 )
 )
 
 game (
@@ -10293,34 +7770,6 @@ game (
 	name "Crush Roller (Sidam bootleg)"
 	developer "bootleg (Sidam)"
 	rom ( name crushs.zip size 14076 crc 3dcac035 md5 c5a6ff995723c1d48dfbe26f4f6323ae sha1 dd5c08efaa2684b4c85f88cfc9d65d7765734344 )
-)
-
-game (
-	name "Cruis'n Exotica (version 2.4)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexo.zip size 42826650 crc 6f7074c4 md5 09d225c9ed514752fb656e4d55372666 sha1 1dec5ad9162627347c213ec780aa9e8c0d3bd220 )
-)
-
-game (
-	name "Cruis'n Exotica (version 2.0)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexoa.zip size 3438146 crc 212d821f md5 7b46abb5f3071afd3a4009ada45820ff sha1 76670d52a83910ab9e6c2732d838ffbc216544e3 )
-)
-
-game (
-	name "Cruis'n Exotica (version 1.6)"
-	year "1999"
-	developer "Midway"
-	rom ( name crusnexob.zip size 3436845 crc 43d02f48 md5 e6e7315d33c0658c9f5d8e433016b2f8 sha1 bda6fe6b56da583ab99a5e32aaeb5ef009015f11 )
-)
-
-game (
-	name "Cruis'n USA (rev L4.1)"
-	year "1994"
-	developer "Midway"
-	rom ( name crusnusa.zip size 11277901 crc dc92d005 md5 b60f7571b1c48d2c2a2ebee557d0c25c sha1 31a02b25028c17602de4e9e1a10a9a27244c47aa )
 )
 
 game (
@@ -10436,31 +7885,10 @@ game (
 )
 
 game (
-	name "Crazy Rally (set 1)"
-	year "1985"
-	developer "Tecfri"
-	rom ( name crzrally.zip size 58840 crc 393d1ceb md5 c7c6fe20f661faf0ec7a93009fc33edc sha1 26981eee4b60477f6d3647b8444a3043a6a3998a )
-)
-
-game (
-	name "Crazy Rally (set 2)"
-	year "1985"
-	developer "Tecfri"
-	rom ( name crzrallya.zip size 36328 crc 7abd90c8 md5 dce797f4455757cdbd6027d2176b0455 sha1 974697c5d562e941655ae319ce55d90fda5da7ac )
-)
-
-game (
 	name "Crazy Rally (Gecas license)"
 	year "1985"
 	developer "Tecfri (Gecas license)"
 	rom ( name crzrallyg.zip size 53569 crc fd92b138 md5 50a50ff55f3dcdd971d5c2abe53f6053 sha1 edaf887a03867e39ff5f604696494361999f15c9 )
-)
-
-game (
-	name "Crazy Taxi (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name crzytaxi.zip size 55999707 crc 724b1303 md5 cb12e129efc3005a76daeb18bc025dd2 sha1 d7836734b4e083f17f9fa06da6eec99cd70f7569 )
 )
 
 game (
@@ -10513,41 +7941,6 @@ game (
 )
 
 game (
-	name "Chicken Shift"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name cshift.zip size 43315 crc 7c6abca8 md5 de1ee67a321e96e354c0618228bfe451 sha1 618c93be227f68390501e771d806d291cb271eb9 )
-)
-
-game (
-	name "Cross Shooter (not encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu (Taito license)"
-	rom ( name cshooter.zip size 43638 crc 480864cf md5 1f94c6bd5dd2b1075e92823fb12cee35 sha1 ca6e55c9d34531284497663d2fa8406f375e8d2b )
-)
-
-game (
-	name "Cross Shooter (encrypted)"
-	year "1987"
-	developer "Seibu Kaihatsu (J.K.H. license)"
-	rom ( name cshootere.zip size 50811 crc 71f79d75 md5 d8b5aa51b8729a7f9ad17f5ab6fc4dce sha1 c3ab0ae3345270aceb9f75cc7162e15e28206ddf )
-)
-
-game (
-	name "Captain Silver (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name csilver.zip size 403065 crc cdbcd8a3 md5 9396631f721ab08913e6c430857b331c sha1 e510c6c0c8c7755351b5c3d1d557c46ab504cf86 )
-)
-
-game (
-	name "Captain Silver (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name csilverj.zip size 16681 crc 4356e2fd md5 b0aa99b028663f801d77415fc468eb11 sha1 adc4aa7c38d535757ae942df4e5fe683607aafb5 )
-)
-
-game (
 	name "Champion Skill (with Ability)"
 	developer "IGS"
 	rom ( name csk227it.zip size 191499 crc 469bff08 md5 363ca7bcc081203567f774f3a550c494 sha1 f9ac4061288c557787bac0171164695033d1b683 )
@@ -10557,27 +7950,6 @@ game (
 	name "Champion Skill (Ability, Poker _ Symbols)"
 	developer "IGS"
 	rom ( name csk234it.zip size 130074 crc 2400cd6b md5 d9936868460621049a6f977ab2ba4d7d sha1 89611afd6266f0294b079e862fb3a55522f3f59d )
-)
-
-game (
-	name "Cosmic Smash (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2001"
-	developer "Sega"
-	rom ( name csmash.zip size 35525841 crc c8781b8f md5 e2c2127dc12c9ec331bfadfae90feea9 sha1 d75e9ad69de5f7c2723e8d52017e1335f9794956 )
-)
-
-game (
-	name "Cosmic Smash (JPN, USA, EXP, KOR, AUS) (original)"
-	year "2001"
-	developer "Sega"
-	rom ( name csmasho.zip size 521249 crc 4af6ef4e md5 2f7dca4c136b9db66db192715579cb93 sha1 f83ec77404aac065afb9eb3b953d1f4e60818a63 )
-)
-
-game (
-	name "Gun Spike (JPN) / Cannon Spike (USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Psikyo / Capcom"
-	rom ( name cspike.zip size 57347306 crc e11a5991 md5 f871cf616d61d1ddb983447cf2a6103c sha1 1fbfc2c9a057d768078df9d34604d965c0d89b11 )
 )
 
 game (
@@ -10644,13 +8016,6 @@ game (
 )
 
 game (
-	name "Casino Strip XI"
-	year "1990"
-	developer "Status Games"
-	rom ( name cstripxi.zip size 7814 crc baaa8f0e md5 8fcad99e334447163c2ac688dbd9d0c0 sha1 e2ad6fb1a468ca0d526d43464df0870b82f791af )
-)
-
-game (
 	name "Super Astro Fighter (Cassette)"
 	year "1981"
 	developer "Data East Corporation"
@@ -10704,13 +8069,6 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name ctisland2.zip size 15967 crc b6339375 md5 e7c8426c23403149a722920c4970dfd8 sha1 e5efa6952a989fabc0e024d2d276acac14ef2d15 )
-)
-
-game (
-	name "Treasure Island (Cassette, set 3)"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name ctisland3.zip size 15564 crc ace9d58b md5 612bc9f31f54c94e2d72bf29caccd231 sha1 0224fa70b4bf62797817d6a03aed202046cd7169 )
 )
 
 game (
@@ -10811,13 +8169,6 @@ game (
 )
 
 game (
-	name "Seimei-Kantei-Meimei-Ki Cult Name"
-	year "1996"
-	developer "I&apos;Max"
-	rom ( name cultname.zip size 2374339 crc 6e0d55d7 md5 46ef4d95ca1c98521648460136315d38 sha1 d30f4147c2fc9101ae4b103cee74afc10bef835d )
-)
-
-game (
 	name "Jibun wo Migaku Culture School Mahjong Hen"
 	year "1994"
 	developer "Face"
@@ -10825,59 +8176,10 @@ game (
 )
 
 game (
-	name "Cuore 1 (Italian)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name cuoreuno.zip size 19253 crc 94c0fea5 md5 24f2f15db3d20da4c4401fce4548585a sha1 b16af13650d2b114253773644601b2788ca1c7c1 )
-)
-
-game (
 	name "Taito Cup Finals (Ver 1.0O 1993/02/28)"
 	year "1993"
 	developer "Taito Corporation Japan"
 	rom ( name cupfinal.zip size 5437282 crc 7651ee83 md5 dd420b46ffdc57af804e3f918444aeb7 sha1 6d224656607820e2c618a5727cf65af76d41e10a )
-)
-
-game (
-	name "Seibu Cup Soccer (set 1)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsoc.zip size 1889323 crc 26005bae md5 a21a5d551639e86b461bfbb5f8425015 sha1 161f6d58ea352874f337f7449ffa376d7fa5cadb )
-)
-
-game (
-	name "Seibu Cup Soccer (set 2)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsoca.zip size 435737 crc 3ae079e5 md5 7ae76a47669418a6783dbe95b67d5ea4 sha1 ccb187792923ba8629889ddc50be051a5ea14c22 )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (set 1)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsocs.zip size 532948 crc 8621e0e4 md5 ccd1ba344769d710957b6d018ae2d2e8 sha1 58b6ebeaaec567d8a82e3944d08d5c2e0976f04a )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (set 2)"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name cupsocs2.zip size 532978 crc 9d0f1d1d md5 6138dd1e27047460bbbf2743af4a815f sha1 e1d79b9522d6af520997484588f84c82f98d87fd )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (bootleg, set 1)"
-	year "1992"
-	developer "bootleg"
-	rom ( name cupsocsb.zip size 2277371 crc 5301cf62 md5 5b7d9abd589d80203c8649e9f3973c98 sha1 b5238296d24721f85e73e05a7d89dcd6ad52120e )
-)
-
-game (
-	name "Seibu Cup Soccer :Selection: (bootleg, set 2)"
-	year "1992"
-	developer "bootleg"
-	rom ( name cupsocsb2.zip size 2277352 crc 50bca826 md5 e52825fd9b314a46ded95a4b65caa7ee sha1 1b3d13d30e26a4103db708d6897bcdb60ba06d15 )
 )
 
 game (
@@ -10895,38 +8197,10 @@ game (
 )
 
 game (
-	name "Capcom Vs. SNK 2 Millionaire Fighting 2001 (Rev A) (GDL-0007A)"
-	year "2001"
-	developer "Capcom / SNK"
-	rom ( name cvs2gd.zip size 1197 crc 2c27cb45 md5 d338e8e8874fa69a1b4c686a83abc5f4 sha1 75c327dd242a7381b11fa70d839ebb4f7d6601b8 )
-)
-
-game (
-	name "Capcom Vs. SNK Millenium Fight 2000 Pro (GDL-0004)"
-	year "2001"
-	developer "Capcom / SNK"
-	rom ( name cvsgd.zip size 1197 crc 29262628 md5 ec08503ae335e4b35a864f9a92317e60 sha1 fa00da1d9b91b153f43cfcf45955a87b1dc7446f )
-)
-
-game (
 	name "Capcom World (Japan)"
 	year "1989"
 	developer "Capcom"
 	rom ( name cworld.zip size 728155 crc 92fff834 md5 7b957f3061527245dd049f0afd9cf88a sha1 0a75499a74146f831ac2f1d6b8aa6aac822430aa )
-)
-
-game (
-	name "Adventure Quiz Capcom World 2 (Japan 920611)"
-	year "1992"
-	developer "Capcom"
-	rom ( name cworld2j.zip size 1753740 crc 3181ff10 md5 b32c4c73707d91596c5d375147c3c11a sha1 99f44bf54db8999d313bb0e6e021ea8cdb4b1459 )
-)
-
-game (
-	name "Cybattler"
-	year "1993"
-	developer "Jaleco"
-	rom ( name cybattlr.zip size 1266380 crc d454f84a md5 041ced047550d34d4aa37df69cfb3b18 sha1 e26f3a8131a4d6d8fbf0dfca8ba44c42045bfcbc )
 )
 
 game (
@@ -11000,13 +8274,6 @@ game (
 )
 
 game (
-	name "Cyber Tank (v1.04)"
-	year "1988"
-	developer "Coreland"
-	rom ( name cybertnk.zip size 1594041 crc 19eacebb md5 a54e40121f2d35a4d8d2b6db957c8231 sha1 75f8cd8d0959e89d3f0a8224e9260b0202923ff1 )
-)
-
-game (
 	name "Cyberbots: Fullmetal Madness (Euro 950424)"
 	year "1995"
 	developer "Capcom"
@@ -11025,13 +8292,6 @@ game (
 	year "1995"
 	developer "Capcom"
 	rom ( name cybotsu.zip size 626945 crc b93e2fba md5 57822040ce1bae3f2bc8058223ecf740 sha1 71f922148cafb73c745a468303c816ced5c1c385 )
-)
-
-game (
-	name "Cyber Commando (Rev. CY1, Japan)"
-	year "1995"
-	developer "Namco"
-	rom ( name cybrcomm.zip size 9154610 crc dc4c1738 md5 d9ecc9e0fe6f9c61aab10d2e6204e639 sha1 77c3a2e803799a4c68b5cf0b1eedea30547a1823 )
 )
 
 game (
@@ -11056,20 +8316,6 @@ game (
 )
 
 game (
-	name "Cycle Mahbou (Japan)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name cyclemb.zip size 59757 crc 8bd1cfcc md5 3db1e4688f9241fd97569c7bcef702eb sha1 cdd61356b697210d39df99df5649872320eab336 )
-)
-
-game (
-	name "Cycle Shooting"
-	year "1986"
-	developer "Taito"
-	rom ( name cyclshtg.zip size 142272 crc 2620c115 md5 b1057dddd11b630d09d693180f466d42 sha1 d60c25b3eb4ac636b3b9bb1758a45fbb18357447 )
-)
-
-game (
 	name "Cycle Warriors"
 	year "1991"
 	developer "Tatsumi"
@@ -11084,24 +8330,10 @@ game (
 )
 
 game (
-	name "Zeroize (Cassette)"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name czeroize.zip size 25175 crc ef0b1fc1 md5 9b6a793924475b77409b9a756b28859c sha1 193cf1538f272aa405d13e7e3d6702d11f8bb5e1 )
-)
-
-game (
 	name "Dream 9 Final (v2.24)"
 	year "1992"
 	developer "Excellent System"
 	rom ( name d9final.zip size 205019 crc 7dcad395 md5 842cf51e1aff6f2d7c5588e3f2c6b31c sha1 0d432fd362197660398297616db6756d4081547a )
-)
-
-game (
-	name "Dacholer"
-	year "1983"
-	developer "Nichibutsu"
-	rom ( name dacholer.zip size 49113 crc 8c095913 md5 430234ec4aad83d9a209c58a603a662a sha1 b3d5999b4990fe806468b1b11af50eeebb123c96 )
 )
 
 game (
@@ -11126,13 +8358,6 @@ game (
 )
 
 game (
-	name "Daimakaimura (Japan)"
-	year "1988"
-	developer "Capcom"
-	rom ( name daimakai.zip size 1145540 crc a2d80e34 md5 9e13bfc3a1a93ed65f302f05b04322ce sha1 316627cf5a6182afae677f3fba605daaeecccb37 )
-)
-
-game (
 	name "Daimakaimura (Japan Resale Ver.)"
 	year "1988"
 	developer "Capcom"
@@ -11151,13 +8376,6 @@ game (
 	year "1993"
 	developer "Athena"
 	rom ( name daioh.zip size 3149073 crc 99d0e1e4 md5 6cc25c79e0e2aed2ce5fd5d187120322 sha1 7deb6e35e8face8145e3d71f646832059cf78f5b )
-)
-
-game (
-	name "Mahjong Daireikai (Japan)"
-	year "1989"
-	developer "Jaleco / NMK"
-	rom ( name daireika.zip size 782018 crc 620a8a38 md5 b484554869422814e7b0a4c91c53c58f sha1 d641e7eac4ccfa7c58642a9ac07e163003b7be41 )
 )
 
 game (
@@ -11277,13 +8495,6 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name dangarb.zip size 40151 crc 1c97ce3d md5 843008b227f0e7e7f997d71ae3e96cba sha1 dc51a90aeccaa751d5a5f3514eea3b89fae538aa )
-)
-
-game (
-	name "Dangerous Curves"
-	year "1995"
-	developer "Taito"
-	rom ( name dangcurv.zip size 15539901 crc 0c41353d md5 a9cb7c923a7f27ab70e4f282c52ce151 sha1 1ce91ce83630e2520697516dd5ceabe747a93322 )
 )
 
 game (
@@ -11413,20 +8624,6 @@ game (
 )
 
 game (
-	name "Dark Horse Legend (GX706 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name darkhleg.zip size 182 crc 1a548190 md5 586ca9974f867427cbd45a5fabe9a35d sha1 1e747b326cf425476ec052dd63924a31e21d1151 )
-)
-
-game (
-	name "Dark Horse (bootleg of Jockey Club II)"
-	year "2001"
-	developer "bootleg"
-	rom ( name darkhors.zip size 2016274 crc 9a085b6a md5 93da3283935cc1c8bf6deace26b2cbc5 sha1 dfacb21ba11900a2bcd5fd15e0241a3751bd8e6c )
-)
-
-game (
 	name "The Lost Castle In Darkmist"
 	year "1986"
 	developer "Taito"
@@ -11483,79 +8680,10 @@ game (
 )
 
 game (
-	name "Darth Vader"
-	developer "bootleg"
-	rom ( name darthvdr.zip size 5503 crc c56d7786 md5 2b1808572ea0da097eb8732bc4394b14 sha1 52cb0ff6ce48e8ee219a5417bf2560648401c103 )
-)
-
-game (
 	name "Darwin 4078 (Japan)"
 	year "1986"
 	developer "Data East Corporation"
 	rom ( name darwin.zip size 120044 crc 937ad0f0 md5 122efe0f51a9346400384bba7139f064 sha1 1f7ca842309e42e058b609e7ed313a834140324d )
-)
-
-game (
-	name "Desert Assault (US)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name dassault.zip size 160514 crc baf51c90 md5 c6b593ba552bdd9d7fe18712299a69a8 sha1 5faddf79d8243f5f6dc290cb13752108c56f00ec )
-)
-
-game (
-	name "Desert Assault (US 4 Players)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name dassault4.zip size 158037 crc e53acff0 md5 2ad4113274cf5cb06c7a6fad663f5a3f sha1 6b36e081fb416e9e6d1248ae1017a4708a3754a9 )
-)
-
-game (
-	name "Daytona USA 2 Power Edition"
-	year "1998"
-	developer "Sega"
-	rom ( name dayto2pe.zip size 89082124 crc c9324bd2 md5 2431c3a8c949e3e51a67951a4563d74b sha1 6aaf5a75053ff817a23ba2db3b00dea120d93bfd )
-)
-
-game (
-	name "Daytona USA (Japan, Revision A)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytona.zip size 15080135 crc b3348b34 md5 5aaee46904e00b4ad5ac5c7867c34d42 sha1 c6bf07b851f18af18f2b84af9482768de8e526bb )
-)
-
-game (
-	name "Daytona USA 2 (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name daytona2.zip size 81715239 crc 3ce2b636 md5 19c92ac17f86950ff1471d270b995257 sha1 df93149dfefa20b5f6db0e5312e99872008fe33f )
-)
-
-game (
-	name "Daytona USA Deluxe '93"
-	year "1993"
-	developer "Sega"
-	rom ( name daytona93.zip size 2816237 crc a7b67015 md5 a56dce5a1f46e16c57f0f5e7428557ad sha1 013e24eee317d1245cee9fe16b1bdf9cb9bdf7b5 )
-)
-
-game (
-	name "Daytona USA (Japan, To The MAXX)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonam.zip size 112333 crc 22c237a2 md5 3daec64379c79d2642f09c25d41175ec sha1 7a9eab4d14d753f5698f310b25b34ba3e6b8bc10 )
-)
-
-game (
-	name "Daytona USA (With Saturn Adverts)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonas.zip size 604447 crc fb0783ac md5 f968356b0dffe508ecfe30d9e84ab230 sha1 86580143d89757800e1d2aa1c7bb423b344f7153 )
-)
-
-game (
-	name "Daytona USA (Japan, Turbo hack)"
-	year "1993"
-	developer "Sega"
-	rom ( name daytonat.zip size 402301 crc d89e684f md5 45fa3e88f403b2529373cb9883939f63 sha1 7df859df1c9794c266f78ef3e513d4ce6c4b17fe )
 )
 
 game (
@@ -11629,13 +8757,6 @@ game (
 )
 
 game (
-	name "Double Wings"
-	year "1993"
-	developer "Mitchell"
-	rom ( name dblewing.zip size 2055341 crc 07b7b9c9 md5 de3c0e1d39b75db7169943e81e89ddc7 sha1 3d5dd495c08020a81491ad9d3757990fb6c167c1 )
-)
-
-game (
 	name "Super Baseball Double Play Home Run Derby"
 	year "1987"
 	developer "Leland Corp. / Tradewest"
@@ -11661,13 +8782,6 @@ game (
 	year "1989"
 	developer "Irem"
 	rom ( name dbreed.zip size 753922 crc b9fe793a md5 f4b31a4769276a862e5dd2717a428aba sha1 2aa947f887d7ca097519219bfe4d05b0626217f7 )
-)
-
-game (
-	name "Dragon Breed (M72 PCB version)"
-	year "1989"
-	developer "Irem"
-	rom ( name dbreedm72.zip size 149958 crc 0400bd7b md5 e8013b17f01561c3a1bc66e3fd180e98 sha1 935ac60a704942f78c29c68b079c4f564eb11c7b )
 )
 
 game (
@@ -11790,13 +8904,6 @@ game (
 )
 
 game (
-	name "Double Dealer"
-	year "1991"
-	developer "NMK"
-	rom ( name ddealer.zip size 223338 crc 87ca013e md5 2e48d87248f2c0be4511e1be97c04fc2 sha1 cfdab8741df51cd75bbbdc8dc37cb94a348e51bc )
-)
-
-game (
 	name "Don Den Lover Vol. 1 - Shiro Kuro Tsukeyo! (Japan)"
 	year "1995"
 	developer "Dynax"
@@ -11836,125 +8943,6 @@ game (
 	year "1997"
 	developer "Cave (Atlus license)"
 	rom ( name ddonpachj.zip size 256039 crc c52bc6e4 md5 68d687a9119d5f67dc1ddf13f4558743 sha1 2cc92e8579deb9d139487bb9f8a4fb7d9f07ffcf )
-)
-
-game (
-	name "Bee Storm - DoDonPachi II (ver. 100)"
-	year "2001"
-	developer "IGS"
-	rom ( name ddp2.zip size 12881272 crc f206ea2f md5 9ab46976eb5f308dc3581fd193b449db sha1 570fd9e6d981c30117c345f47a6e4d47dc406d80 )
-)
-
-game (
-	name "Bee Storm - DoDonPachi II (ver. 102)"
-	year "2001"
-	developer "IGS"
-	rom ( name ddp2a.zip size 410562 crc 00d7a931 md5 f445a89fecb03b33bafec879d9e4a95a sha1 62e27b87e7f9edf77ec535f857c8574db69fdf07 )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix (GN895 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2m.zip size 174 crc e7188034 md5 223e2b1eabbe3ad1d471b4fbb4f43007 sha1 5b958c15631ee04acd8ce92b0a9caccd1eec097b )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX CLUB VERSiON (GE896 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2mc.zip size 172 crc 8f7db786 md5 7e38cf8a4fbdc234a6de07bd69053cbd sha1 dece8a1ac3d9f18d6db849bc72d522be5392e044 )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX substream CLUB VERSiON 2 (GE984 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2mc2.zip size 172 crc b220eaab md5 1325feb1a5451a56fb41f1600c172113 sha1 6264d7156d924335cff5ef9a2e5669988d84f48b )
-)
-
-game (
-	name "Dance Dance Revolution 2nd Mix - Link Ver (GE885 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr2ml.zip size 4057 crc ff1be293 md5 604be7e73f4ab6efa2852ec221c8e4ad sha1 30a3bf91c96f391fdfd0242f7049cc1dde0f9cc2 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix (GN887 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddr3mj.zip size 296 crc 375b5f3c md5 fabe39775b652a4db703a06ce43f5871 sha1 ae7c1586d480e6d66a8124a778d1f5d908a49e2d )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix - Ver.Korea2 (GN887 VER. KBA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr3mk.zip size 508 crc 66745e0e md5 002d5e87f0aefa12f40af292614f8538 sha1 2946dd5ca3e1c9ec9bf19b231b29dbc5185d43e4 )
-)
-
-game (
-	name "Dance Dance Revolution 3rd Mix Plus (G*A22 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr3mp.zip size 547 crc 0099dd86 md5 8c06a1e6b1fc867786a5af640f0fb64c sha1 8197e1daf6479711c6d4fb3d466a919e7dfb8f08 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix (G*A33 VER. AAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4m.zip size 548 crc ba8dce41 md5 d6f4a74f1dbf76fb380e820adf00c02c sha1 9b66e890e8e2fa0083ea3ee5cd520f037490fcef )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix (G*A33 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mj.zip size 334 crc 8ca723a7 md5 8db397a2acde611a6a4864e4ac885e75 sha1 893a54372fbb1eb570b59844264911384d954be8 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Plus (G*A34 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mp.zip size 686 crc 83ff7451 md5 e1ccce6f46672d2be1251f367d2580c2 sha1 4f52ae738b75ef1a7ec49995f054a7afbaf1641a )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Plus Solo (G*A34 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4mps.zip size 686 crc 41e68758 md5 8cbb3d33bfee8275fc6ff114604e2266 sha1 4234f709fb5388cf6ba3f7aeeb9abae2362af4ec )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Solo (G*A33 VER. ABA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4ms.zip size 548 crc eb59b011 md5 e490430c29f2b04966edddc2403f6aad sha1 56b58798c54307433b41dd42747d662f0400a239 )
-)
-
-game (
-	name "Dance Dance Revolution 4th Mix Solo (G*A33 VER. JBA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddr4msj.zip size 334 crc 18d8dc93 md5 c7c37707634aa1e70fbb5f28841beef2 sha1 979fd6148fc00ef253739926c23402c40436edb2 )
-)
-
-game (
-	name "Dance Dance Revolution 5th Mix (G*A27 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name ddr5m.zip size 315 crc 12ef6a61 md5 f12b6640a4c9556d713b1c6d7dd2150d sha1 9f07b8c3024ec4945d2869c0813fba3074ef78a2 )
-)
-
-game (
-	name "Dance Dance Revolution (GN845 VER. AAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddra.zip size 172 crc eacf6ede md5 e41f971e2fb211dafceefc6f721f7809 sha1 38267e9aa40d565e9e414fa4bea855e52435a990 )
 )
 
 game (
@@ -12007,20 +8995,6 @@ game (
 )
 
 game (
-	name "Double Dragon (bootleg with 3xM6809, set 1)"
-	year "1987"
-	developer "bootleg"
-	rom ( name ddragon6809.zip size 549334 crc 977aba85 md5 676a5bb3606dcadbb2c772259cc8f1b7 sha1 cbf2b9970e31ca4c454bdd0f749d969d51fcdff9 )
-)
-
-game (
-	name "Double Dragon (bootleg with 3xM6809, set 2)"
-	year "1987"
-	developer "bootleg"
-	rom ( name ddragon6809a.zip size 546706 crc 525d2cba md5 8fdb9be47f496568da1ab97d904558de sha1 f161be7f7ffc30168fcce8711ffc3b3d7edd3117 )
-)
-
-game (
 	name "Double Dragon (bootleg with HD6309)"
 	year "1987"
 	developer "bootleg"
@@ -12031,7 +9005,7 @@ game (
 	name "Double Dragon (bootleg)"
 	year "1987"
 	developer "bootleg"
-	rom ( name ddragonb2.zip size 534467 crc bbc1177b md5 11d549979e7ba4f9b47d961466093e81 sha1 93997e7262bd5b59f3a59d4aa094ea3f0eb7874a )
+	rom ( name ddragonb2.zip size 72651 crc af17ae0f md5 35064e5d022202cd763150c0d534b359 sha1 1bc426c13bae1f1696533ffba760e0429c3f69f7 )
 )
 
 game (
@@ -12084,73 +9058,10 @@ game (
 )
 
 game (
-	name "Dance Dance Revolution Extreme (G*C36 VER. JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name ddrextrm.zip size 315 crc fa7ecd67 md5 07d4915fc43ee2bb49c064f006b46c84 sha1 83df8b45bfcc5e7b74e32105547e2768a38f1c95 )
-)
-
-game (
 	name "Double Dribble"
 	year "1986"
 	developer "Konami"
 	rom ( name ddribble.zip size 358619 crc 0b4f3ea0 md5 def11feee81940591976f34c7e154917 sha1 b3b7b4d17cfe6861e0edbf9d333d9b6cdf234080 )
-)
-
-game (
-	name "Dance Dance Revolution - Internet Ranking Ver (GC845 VER. JBA)"
-	year "1998"
-	developer "Konami"
-	rom ( name ddrj.zip size 172 crc 87fa16d9 md5 d48eb8d9258dbfca90b4b93df0ccfc04 sha1 1c2be6b15e4ba70140db4f3aa3242e6a1aac6312 )
-)
-
-game (
-	name "DDR Max - Dance Dance Revolution 6th Mix (G*B19 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name ddrmax.zip size 314 crc 9773e351 md5 386eaaedd45da4566c7c65cf864c7a69 sha1 4b349cdc669d98985521ecdd863b65f86519f0bd )
-)
-
-game (
-	name "DDR Max 2 - Dance Dance Revolution 7th Mix (G*B20 VER. JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name ddrmax2.zip size 315 crc 0c9155c3 md5 cc2007117afc0d668d37d861771475d9 sha1 6bba6add32147b22c6cea8bc27e655dc8eaa7fed )
-)
-
-game (
-	name "Dance Dance Revolution Solo 2000 (GC905 VER. AAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrs2k.zip size 508 crc d23dea36 md5 8b61c455097f38503898e56b4c30d703 sha1 fac67a81ff3cd5e990345ff5ae7a04318cf716d9 )
-)
-
-game (
-	name "Dance Dance Revolution Solo 2000 (GC905 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrs2kj.zip size 296 crc 8e2db255 md5 0cdd40c246ddbed4504bd2659c63e716 sha1 890f0fa0fce45d3afffa197c21a9b038fe0ca345 )
-)
-
-game (
-	name "Dance Dance Revolution Solo Bass Mix (GQ894 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddrsbm.zip size 282 crc 1cab704c md5 f7689bf26a5eef779653ecda61d1746b sha1 ec2cd0117142ddac61f0deb02560af609c7dee79 )
-)
-
-game (
-	name "Dance Dance Revolution (GN845 VER. UAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name ddru.zip size 172 crc 049610a8 md5 96b1dbaaa0609f175fc8927b8a68c0cf sha1 9fe6940e3c0210d97392320b7b65b370df5c8cb7 )
-)
-
-game (
-	name "Dance Dance Revolution USA (G*A44 VER. UAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name ddrusa.zip size 315 crc 6fc624c2 md5 fbef020574f971d5362e53bda15d2354 sha1 77b0a03177c641dbb88f58ebcb243a051a162a7d )
 )
 
 game (
@@ -12343,26 +9254,6 @@ game (
 )
 
 game (
-	name "Dynamite Dux (set 1, 8751 317-0095)"
-	year "1988"
-	developer "Sega"
-	rom ( name ddux1.zip size 100002 crc 436bad9c md5 0a55138f1534f1872b8f49db6a9d08b9 sha1 bdc7f9ab3a6665c04769af33ec597558ef80cbde )
-)
-
-game (
-	name "Dynamite Dux (bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name dduxbl.zip size 436925 crc 4030105d md5 d14022af90e3d069cff49af5fbc1a402 sha1 d77a7daa91818c581eb6affdfbaf888dba115b6b )
-)
-
-game (
-	name "Dou Di Zhu"
-	developer "IGS?"
-	rom ( name ddz.zip size 4299073 crc f07bac13 md5 d05e2c85d361ada83d4bb0688f2903a9 sha1 d0437735902f136c22729a21e972a81671f54b58 )
-)
-
-game (
 	name "Dead Angle"
 	year "1988"
 	developer "Seibu Kaihatsu"
@@ -12398,38 +9289,10 @@ game (
 )
 
 game (
-	name "The Dealer"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name dealer.zip size 15702 crc 2521c727 md5 19144345952cedcd1222400e7f96d6a8 sha1 dd234ed4b9caae5014516d26ddba09c94964ebbe )
-)
-
-game (
 	name "Death Brade (Japan ver JM-3)"
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name deathbrd.zip size 102000 crc 7486c7b1 md5 c9b91d9405d8e786cfe69e6fe32d9bf7 sha1 122203ed6301555a28d164601c59f7a99575ff49 )
-)
-
-game (
-	name "Death Crimson OX (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Ecole"
-	rom ( name deathcox.zip size 56204685 crc 8eda24f3 md5 49742a7a930fb872b8c78d3fb9b75163 sha1 586e6b80d02e48c6a912b378ce172234360f8b85 )
-)
-
-game (
-	name "Decathlete (JUET 960709 V1.001)"
-	year "1996"
-	developer "Sega"
-	rom ( name decathlt.zip size 13143261 crc e7440d51 md5 d6bb4f0f1db74358845c1b07bf7eab0c sha1 902b1b283cef7c940d4226dc87e24d9e673386ac )
-)
-
-game (
-	name "Decathlete (JUET 960424 V1.000)"
-	year "1996"
-	developer "Sega"
-	rom ( name decathlto.zip size 422139 crc ebde67c1 md5 360131bdf83bcfe2c0da12c5787d8be0 sha1 6463a18e31af0481345035936e6d8320954ed434 )
 )
 
 game (
@@ -12503,31 +9366,10 @@ game (
 )
 
 game (
-	name "Defense (System 16B, FD1089A 317-0028)"
-	year "1987"
-	developer "Sega"
-	rom ( name defense.zip size 345936 crc 8c56fcd2 md5 b5b79c4c7b4a39bbc3247903719b7283 sha1 e9ce5aba7380b91fe6ce2c3e6ec223e874d183c7 )
-)
-
-game (
-	name "Defender (bootleg)"
-	year "1980"
-	developer "bootleg (Jeutel)"
-	rom ( name defndjeu.zip size 19340 crc ed0313c4 md5 c98771d353435f8ae11999d35dd0d7e2 sha1 e84bca3401461f36dfd4ba014b7fadb964b699fb )
-)
-
-game (
 	name "Delta Race"
 	year "1981"
 	developer "bootleg (Allied Leisure)"
 	rom ( name deltrace.zip size 2546 crc f29e1e28 md5 cc39212db56d5cae15ac2b48fd31d63c sha1 a416b3449494681d250ecdc322232b0a278f73c1 )
-)
-
-game (
-	name "Demons _ Dragons (prototype)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name demndrgn.zip size 49939 crc 8f956f14 md5 1883f53438bb840f6e8c19664a0c0b25 sha1 50272844cf3987cf8e333e2e77fdb707df101568 )
 )
 
 game (
@@ -12545,24 +9387,10 @@ game (
 )
 
 game (
-	name "Demolish Fist"
-	year "2003"
-	developer "Polygon Magic / Dimps"
-	rom ( name demofist.zip size 109596850 crc dfc1658f md5 5e8347cf6bad4148da10942d22a61d1f sha1 535300a634ef5a523dd495c9f33543378ddcd433 )
-)
-
-game (
 	name "Demon"
 	year "1982"
 	developer "Rock-Ola"
 	rom ( name demon.zip size 16122 crc 8641b9f0 md5 791dc5e136c110a5f7524d63db1d1ce1 sha1 cf99c2506cf48632299788257ef6608626fd1691 )
-)
-
-game (
-	name "Demoneye-X"
-	year "1981"
-	developer "Irem"
-	rom ( name demoneye.zip size 19148 crc 129d57f6 md5 3dd29a6a05424a3ade086e944b9f00ad sha1 730127f512859a0d6f1389b723beaa33679556ac )
 )
 
 game (
@@ -12601,34 +9429,6 @@ game (
 )
 
 game (
-	name "Densya De Go (Japan)"
-	year "1996"
-	developer "Taito"
-	rom ( name dendeg.zip size 18697112 crc 1a00066d md5 733e110357965b8cfb17c41f426fd365 sha1 f606829b738039132266c2da0c04e612ae1f5ef9 )
-)
-
-game (
-	name "Densya De Go 2 (Japan)"
-	year "1998"
-	developer "Taito"
-	rom ( name dendeg2.zip size 26917738 crc d88c9224 md5 19ad4f746f99208a570da5fb7ad0932e sha1 e95a8e11fcc1b8361efb934b818aaeb6add9c287 )
-)
-
-game (
-	name "Densya De Go 2 Ex (Japan)"
-	year "1998"
-	developer "Taito"
-	rom ( name dendeg2x.zip size 4501398 crc 92ada332 md5 ec0ced89a50ea19777a85cbf19a54f84 sha1 779dcf172fff336cbaa9050a5282f9672fedc07c )
-)
-
-game (
-	name "Densya De Go Ex (Japan)"
-	year "1996"
-	developer "Taito"
-	rom ( name dendegx.zip size 519453 crc e41ccdff md5 78d226ac185de24b684dee147bacf9c1 sha1 afb12f8347a00bbe5386b3fae6a77ee90bd4944a )
-)
-
-game (
 	name "Denjin Makai"
 	year "1993"
 	developer "Banpresto"
@@ -12657,41 +9457,6 @@ game (
 )
 
 game (
-	name "Derby Owners Club (JPN, USA, EXP, KOR, AUS) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name derbyoc.zip size 45760592 crc d0b36612 md5 3769fc65b379761d6fe41f101fcbcc9d sha1 1a566e1acf24d13b74a8e0006ae8caf97a718fe2 )
-)
-
-game (
-	name "Derby Owners Club II (JPN, USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name derbyoc2.zip size 115304828 crc a8f6264c md5 14d1cae672c386af6e0c4b78b0e447c6 sha1 0a541724e1c704ea64cd02cb52e61c879566d722 )
-)
-
-game (
-	name "Derby Owners Club World Edition (JPN, USA, EXP, KOR, AUS) (Rev C)"
-	year "2001"
-	developer "Sega"
-	rom ( name derbyocw.zip size 34235746 crc 4b02fce6 md5 6b5da119d2e7fa419fac9196f812af55 sha1 80730d4c4ae09bc115ce5ce99a461e8648356253 )
-)
-
-game (
-	name "Deroon DeroDero"
-	year "1995"
-	developer "Tecmo"
-	rom ( name deroon.zip size 4006201 crc 59555686 md5 4f6817b242381fd5a945b0139dce403d sha1 aeb81c31639baf8e4065331a54780dbade7c1cad )
-)
-
-game (
-	name "Desert Tank"
-	year "1994"
-	developer "Sega / Martin Marietta"
-	rom ( name desert.zip size 8935233 crc c415cee3 md5 9d854300bcaf65a07c98fb31cc365981 sha1 a57d83c1a78ae45d207322765a1f9a68a82d26a7 )
-)
-
-game (
 	name "Desert Breaker (World, FD1094 317-0196)"
 	year "1992"
 	developer "Sega"
@@ -12713,31 +9478,10 @@ game (
 )
 
 game (
-	name "Desert War / Wangan Sensou"
-	year "1995"
-	developer "Jaleco"
-	rom ( name desertwr.zip size 10622164 crc 69f85da9 md5 7569556191d31c6ecca6d6d6a606d018 sha1 ca266a239f46e2b43a9b3893d034ae99cc9311ab )
-)
-
-game (
-	name "Destiny Horoscope"
-	year "1983"
-	developer "Data East Corporation"
-	rom ( name deshoros.zip size 41784 crc 979fc0c5 md5 21a388d1d74d9fcf9512b0b4a4fa967b sha1 9914a21b6045b47e41136b6387c0992911651d66 )
-)
-
-game (
 	name "Destination Earth"
 	year "1979"
 	developer "bootleg"
 	rom ( name desterth.zip size 10141 crc c0dc86ca md5 d148dd76f41f3ff392bb7a8f48d385a0 sha1 3f08e82c671b897eb1a681d57701476fbfc7aea1 )
-)
-
-game (
-	name "Destroyer"
-	year "1977"
-	developer "Atari"
-	rom ( name destroyr.zip size 3594 crc 6680c4af md5 5233593be72a687f332362d02abc30cb sha1 32680f3350c79fa84932e44f2c1d93cd48063006 )
 )
 
 game (
@@ -12811,13 +9555,6 @@ game (
 )
 
 game (
-	name "Devil Zone (easier)"
-	year "1980"
-	developer "Universal"
-	rom ( name devzone2.zip size 11232 crc 85c49f48 md5 de64dbd2266ea0e8805f42deffc33119 sha1 2c08119d7805e4f1329cf7c28ec890edfd7bb082 )
-)
-
-game (
 	name "Double Joker Poker (45%-75% payout)"
 	developer "DellFern Ltd."
 	rom ( name df_djpkr.zip size 7201 crc 743ced08 md5 0b0c9729018a95fa59a728e29a38c82f sha1 a08f072775c469829d61e4061b52b64d628433b3 )
@@ -12859,31 +9596,10 @@ game (
 )
 
 game (
-	name "Diet Go Go (Euro v1.1 1992.09.26)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgo.zip size 2194196 crc ba979f30 md5 66934e4b2a2bf80c56e41d01f2cbd621 sha1 cc9e6b1e97e7b227509478264b1b7c9aae38bfa3 )
-)
-
-game (
-	name "Diet Go Go (Euro v1.1 1992.08.04)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgoe.zip size 469614 crc 6419495a md5 e30638edc81ff3d70473996584bdbbe3 sha1 c7f8fc6481b26aae95fc47b23d10a668688ec854 )
-)
-
-game (
 	name "Diet Go Go (Japan v1.1 1992.09.26)"
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name dietgoj.zip size 448935 crc 9d2d07ca md5 c2455cbd0658022859349899e678443d sha1 33737f973679f7c7591e1b4e0172c6cea60e088a )
-)
-
-game (
-	name "Diet Go Go (USA v1.1 1992.09.26)"
-	year "1992"
-	developer "Data East Corporation"
-	rom ( name dietgou.zip size 448893 crc 3ef70184 md5 d50aeec2e83fcbf15845503e8735c653 sha1 e2f65c54201a1336ff88bd1c1507d90402adda9d )
 )
 
 game (
@@ -12926,13 +9642,6 @@ game (
 	year "1982"
 	developer "Namco (Atari license)"
 	rom ( name digdugat1.zip size 20987 crc 052ddde2 md5 0c1d9eb4219b0ccbde709b38fca3bdb7 sha1 c7f7067b433555587c48a2f175eda1423319918d )
-)
-
-game (
-	name "Digger"
-	year "1980"
-	developer "Sega"
-	rom ( name digger.zip size 7457 crc b0813344 md5 c560a494fb388386cc17ff25d5b3d4bf sha1 93be11e7dcc9303f2b20a4b3235cbff05620cbfa )
 )
 
 game (
@@ -12985,48 +9694,6 @@ game (
 )
 
 game (
-	name "Dingo (encrypted)"
-	year "1983"
-	developer "Ashby Computers and Graphics Ltd."
-	rom ( name dingoe.zip size 10641 crc e4b6ded7 md5 82f6d28917e3ad0c385500652953542a sha1 49ce697f1bad71a8c14d5af9fdd26c0e85f7c97f )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (World 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dino.zip size 4115385 crc 22ff20c9 md5 52b9e81c2ef937ec640e10a6d1454ece sha1 df365c931efdd29727939f05ac211aa6153e266d )
-)
-
-game (
-	name "Dinosaur Hunter (Chinese bootleg of Cadillacs and Dinosaurs)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinohunt.zip size 2865749 crc 52bc3aec md5 b480bfcfc3df21fb1bf4d30ae4db8abd sha1 ce7aa76bfc9fd472d229d880576ee54254157048 )
-)
-
-game (
-	name "Cadillacs: Kyouryuu Shin Seiki (Japan 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dinoj.zip size 408349 crc 9089e01d md5 06fb870685305c3ac97bb80f46117647 sha1 feffb298e1434c21052de2e674c4314d0b7f4cb6 )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (bootleg with PIC16c57, set 1)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinopic.zip size 3127219 crc a37cba2e md5 5f0491a2bf256fae8a08e3ce88385800 sha1 3656d2d08e4bd0ebd65d56f7e0919ecce958e9aa )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (bootleg with PIC16c57, set 2)"
-	year "1993"
-	developer "bootleg"
-	rom ( name dinopic2.zip size 2915044 crc 8f91bb31 md5 4df959bff06afbf5a9b671fe0b4ae7db sha1 0cdbfd1c29caaca9eac875d3215b3d9c16f956cc )
-)
-
-game (
 	name "Dino Rex (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
@@ -13045,34 +9712,6 @@ game (
 	year "1992"
 	developer "Taito America Corporation"
 	rom ( name dinorexu.zip size 132491 crc b1f0e97b md5 a2729ca96f497e354e4cc8b896ad1d87 sha1 9344ca0689305eb4f6a19454b6c5d5b1142dbd8a )
-)
-
-game (
-	name "Cadillacs and Dinosaurs (USA 930201)"
-	year "1993"
-	developer "Capcom"
-	rom ( name dinou.zip size 408201 crc b8fac7da md5 1b1858792f85ab36d8cd65c8fa0ad4d7 sha1 ef1b9072a172d7a174009d16528aa46de2b9368f )
-)
-
-game (
-	name "Dirt Dash (Rev. DT2)"
-	year "1995"
-	developer "Namco"
-	rom ( name dirtdash.zip size 17866918 crc 68c19a7f md5 c332b8aa2b0ca5981c95cfdeb47c38fe sha1 052d963660cf54f152112fdab74e7e495f3601e7 )
-)
-
-game (
-	name "Dirt Devils (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dirtdvls.zip size 47808705 crc 110580fa md5 5d0b2899401bfd731f42b03f93739aa0 sha1 29a887bac082dd06c70d7daa7dc1753bf5ea78ad )
-)
-
-game (
-	name "Dirt Devils (alt) (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dirtdvlsa.zip size 523239 crc 03286932 md5 1a8f4c26c184f70cb5d9cad1af6d1c33 sha1 ec4b5c8fccede343461871f8d334f7b355017bae )
 )
 
 game (
@@ -13136,13 +9775,6 @@ game (
 	year "1990"
 	developer "Irem"
 	rom ( name dkgensan.zip size 284435 crc 4238d94f md5 44395d265ac55c9699ff7beb0399bc38 sha1 19f88c68a0f876fdfe0c90e81f19f27c1ce81397 )
-)
-
-game (
-	name "Daiku no Gensan (Japan, M72)"
-	year "1990"
-	developer "Irem"
-	rom ( name dkgensanm72.zip size 473080 crc 0fb774f9 md5 2c305ec33f0c84ff6a67823502cd6609 sha1 971a2561251f0050ac00a80bb61717e880cef9f7 )
 )
 
 game (
@@ -13237,66 +9869,10 @@ game (
 )
 
 game (
-	name "Donkey Kong Jr. (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name dkongjrm.zip size 30114 crc 0d41d3c2 md5 da5b45e620f856399c7022fcb56c0c69 sha1 11fd33c9ab39fc89e58534313406b20c8b080bee )
-)
-
-game (
 	name "Donkey Kong (US set 2)"
 	year "1981"
 	developer "Nintendo"
 	rom ( name dkongo.zip size 9812 crc c7714c4f md5 7998c53ac9d51a89c4c23b819612bf3c sha1 e750b9be554a8a1328bda79d0bd945db0cb6af85 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. F2)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlair.zip size 22678 crc 594bf35a md5 392b06752685ce7199e26ce5ba06ca38 sha1 75957080b38ac49bbddd42bde759c5a710adf64a )
-)
-
-game (
-	name "Dragon's Lair (US Rev. A, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaira.zip size 21377 crc 2dbda8e0 md5 5c1fe04060140c0cdfb07fe4dfd3ca80 sha1 0de301fe1d3307ea90d34292eccc593820bfdc2a )
-)
-
-game (
-	name "Dragon's Lair (US Rev. B, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairb.zip size 21392 crc dc6d0146 md5 f22db7140369a760812a41b31cc8e914 sha1 cee503c02384edda7e1f392bfcc7e42f130b0afb )
-)
-
-game (
-	name "Dragon's Lair (US Rev. C, Pioneer PR-7820)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairc.zip size 21399 crc d185eb63 md5 5c25d006f36e3df443437155cbab922e sha1 1fa494d9b4c6dfcb67833028869ac0dfebadb021 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. D, Pioneer LD-V1000)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaird.zip size 27677 crc 3d20d358 md5 5e12e4096fdc222922e0bad12eb82132 sha1 938cd9ba8c5796a5e1c3eee51d84681457648f02 )
-)
-
-game (
-	name "Dragon's Lair (US Rev. E)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlaire.zip size 20802 crc 851a2256 md5 5a469b1844922e9816f2f15a89f36f3a sha1 974bc0fe985ed94edfbb1f23475f5f7ca2076c1d )
-)
-
-game (
-	name "Dragon's Lair (US Rev. F)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name dlairf.zip size 6027 crc dab4d1e6 md5 9dba941b73f384845dce4a8378e10b8f sha1 650364e230898e299f801010cc0682853d706573 )
 )
 
 game (
@@ -13314,115 +9890,10 @@ game (
 )
 
 game (
-	name "Dragon's Lair (European)"
-	year "1983"
-	developer "Cinematronics (Atari license)"
-	rom ( name dleuro.zip size 10771 crc 6b041f9f md5 882670ab309cb1227ef7cdfc500e6cc2 sha1 27b98ce21948d6bce218a9fc32d641129b45b88b )
-)
-
-game (
-	name "Dragon's Lair (Italian)"
-	year "1983"
-	developer "Cinematronics (Sidam license?)"
-	rom ( name dlital.zip size 11355 crc 82ef32e8 md5 6c1ce451673186be1f5bf204afa94a70 sha1 a1fb0ad52eb56c728973a25507623a5e8f8b13ad )
-)
-
-game (
-	name "Diamond Touch (E - 30-06-97, Local)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name dmdtouch.zip size 758088 crc bbda8176 md5 8432afaa129dbc015a969eeaabcc013c sha1 b643e38d6a7be1e17fac5eba389da34a709f4652 )
-)
-
-game (
-	name "Diamond Derby (Newer)"
-	year "1994"
-	developer "Electrocoin"
-	rom ( name dmndrby.zip size 43838 crc 197c2146 md5 36b91a04e601ffdfcbda746f351a88a2 sha1 3320b0dcb9b4cf0992fc82c69fecbded1f504589 )
-)
-
-game (
-	name "Diamond Derby (Original)"
-	year "1986"
-	developer "Electrocoin"
-	rom ( name dmndrbya.zip size 16983 crc 2a3ab8e3 md5 cb2bd311797bdbe6b4fe134292c73d99 sha1 88ed1bfdaffadbedef8dde640de6d163844b2a17 )
-)
-
-game (
-	name "Demon Front (ver. 102)"
-	year "2002"
-	developer "IGS"
-	rom ( name dmnfrnt.zip size 22900368 crc 0cf9030a md5 9d4927a9f86fd8930f31ea6aeba6de75 sha1 59429c8775b426a13117f8529aeb7d43ec9709fc )
-)
-
-game (
-	name "Demon Front (ver. 105)"
-	year "2002"
-	developer "IGS"
-	rom ( name dmnfrnta.zip size 3855007 crc 016a9ac6 md5 e4930ff31d07e9387d933cd64fc56d0c sha1 70d0115eef1347bbe4057c4fd56941f7b342aab9 )
-)
-
-game (
-	name "Dance Maniax (G*874 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dmx.zip size 208 crc 2100e31a md5 1f82d7eae630e2598566dae93315c740 sha1 6c64aec863f1b75504a017a06c80c5b30c1da3f5 )
-)
-
-game (
-	name "Dance Maniax 2nd Mix (G*A39 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dmx2m.zip size 314 crc 3f6d8e11 md5 4fc079d5157097f4bfa197a34f85ab73 sha1 fb3d589a1f53d47a0e5f69f3635e5bdad36872b5 )
-)
-
-game (
-	name "Dance Maniax 2nd Mix Append J-Paradise (G*A38 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name dmx2majp.zip size 4634 crc 6f5affa1 md5 0816a514c33acf8e6a4bfff80d81c0aa sha1 5b6be04023121f641b5dd7d8dc3306562e129532 )
-)
-
-game (
-	name "Dance Freaks (G*874 VER. KAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dncfrks.zip size 314 crc f9f737a2 md5 4bca5129ce2ca1075b7baacfa7d17a66 sha1 e17429fee02be248a21053cb994ef8010ad93fca )
-)
-
-game (
 	name "Dynamite Deka (J 960515 V1.000)"
 	year "1996"
 	developer "Sega"
 	rom ( name dnmtdeka.zip size 275390 crc b1afea12 md5 af3fe2f8da8cdcfe50f3cb80f539bde6 sha1 12aabfeedb01f575588586c487528ef0027955f6 )
-)
-
-game (
-	name "Dead or Alive (Model 2B, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name doa.zip size 30324991 crc 9a6f5b67 md5 2c8870101893282c737f5e11c23f62f3 sha1 2200c407df29657cefa9d091a310ed855cabac07 )
-)
-
-game (
-	name "Dead or Alive 2 (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Tecmo"
-	rom ( name doa2.zip size 110833112 crc 38e5dcfe md5 61c0291e8b8458ae005388d0513df679 sha1 ca1a78a14694b93ef9a4a44f6c77add403ae140c )
-)
-
-game (
-	name "Dead or Alive 2 Millennium (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Tecmo"
-	rom ( name doa2m.zip size 110893403 crc d9b4f0f6 md5 d2f3706d64b36106642d459d83ce2723 sha1 f931417bf937b3170cc9e9206f3fd16123ffff09 )
-)
-
-game (
-	name "Dead or Alive (Model 2A, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name doaa.zip size 765136 crc 341696b1 md5 20126b800022c38e46cf05058ebdcde5 sha1 caceba7521f2759c4e6424ccc5123340b2903ec5 )
 )
 
 game (
@@ -13458,20 +9929,6 @@ game (
 	year "1982"
 	developer "Taito Corporation"
 	rom ( name dockman.zip size 16711 crc 334b48a7 md5 1d49b7b0758fec868118fe23ea1086ed sha1 48c12422a84769c7dd54e749bc3f6dd690cd34b7 )
-)
-
-game (
-	name "Dodge City"
-	year "1986"
-	developer "Merit"
-	rom ( name dodge.zip size 34276 crc 62e27b36 md5 81bb9e44a81f4f3050f199c79ac46679 sha1 ed58ac81d547e62798cf838cd53578c762e307a2 )
-)
-
-game (
-	name "Dodgem"
-	year "1979"
-	developer "Zaccaria"
-	rom ( name dodgem.zip size 6580 crc f61e6575 md5 69598665867d0bb28d71f8b191836702 sha1 b2fc72f6ee4361ea6cfd650d4f3c562b84016813 )
 )
 
 game (
@@ -13517,20 +9974,6 @@ game (
 )
 
 game (
-	name "Dogyuun"
-	year "1992"
-	developer "Toaplan"
-	rom ( name dogyuun.zip size 2892442 crc 449d73bb md5 85579a46b662098b09553b1f03936cf7 sha1 a6b5070258595ab4d7a93e38e0d6eb831e0ec3f5 )
-)
-
-game (
-	name "Dogyuun (Unite Trading license)"
-	year "1992"
-	developer "Toaplan"
-	rom ( name dogyuunk.zip size 204590 crc 88f3e56e md5 d68d498305c954e95518ad5cab48c572 sha1 a7cf8f03df1993d479872883ea96af8e37049bd2 )
-)
-
-game (
 	name "Dokaben (Japan)"
 	year "1989"
 	developer "Capcom"
@@ -13556,27 +9999,6 @@ game (
 	year "1995"
 	developer "Make Software / Elf / Media Trading"
 	rom ( name dokyusp.zip size 7090291 crc 2d7964bd md5 0e14ea5c92f78a3b7f9abb171a57ca53 sha1 4d691dffa58abb65fa11041317e2d2591b8b8a5a )
-)
-
-game (
-	name "Dolphin Blue"
-	year "2003"
-	developer "Sammy"
-	rom ( name dolphin.zip size 82591393 crc a2a08817 md5 1fc2018c8548953116f457a52f6569aa sha1 9db1341237f61aba8583f718ddaa6036490339eb )
-)
-
-game (
-	name "Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 1.24.4.0)"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name dolphntr.zip size 800520 crc 2a672a4e md5 60048aa3aac04b18bd1646d903cbd3b0 sha1 f595695c8507e7d8c653fb9633e91b41bc02005a )
-)
-
-game (
-	name "Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 3)"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name dolphtra.zip size 531116 crc 39fe003a md5 cd8d02525a7aea79d6a0c7e31835f073 sha1 e0a1a044c87bf30d897b812023434c002caef4b8 )
 )
 
 game (
@@ -13612,13 +10034,6 @@ game (
 	year "1983"
 	developer "Technos Japan"
 	rom ( name dommy.zip size 25511 crc fe66d09d md5 f9ddd665093b6471c154b49e3b0de1b7 sha1 97b6feca2ae94240330f3c792150683657c4ec6b )
-)
-
-game (
-	name "Donchan no Hanabi de Doon"
-	year "2003"
-	developer "Aruze / Takumi"
-	rom ( name doncdoon.zip size 19691175 crc ec7d1315 md5 8489d224631ca91adcbb18b4bdd350ac sha1 ce72d26f20e5440ada369461632342dc2f9b5422 )
 )
 
 game (
@@ -13675,13 +10090,6 @@ game (
 	year "1995"
 	developer "Cave (Atlus license)"
 	rom ( name donpachikr.zip size 245628 crc b667ecb5 md5 922586cfb037c37b0195854541bc5b50 sha1 64e850172cfa98a3d1c3352e3b94b98ab0327223 )
-)
-
-game (
-	name "Dorachan"
-	year "1980"
-	developer "Craul Denshi"
-	rom ( name dorachan.zip size 11301 crc 486f7f21 md5 1df037f8b200c78832e3f83d6d2b6665 sha1 c17ca350dc7c76c4ea6bff9fcccf1cf36d3618d7 )
 )
 
 game (
@@ -13783,13 +10191,6 @@ game (
 )
 
 game (
-	name "Downhill Bikers (DH3 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name downhill.zip size 57991059 crc 73f39ca0 md5 0f1adf1d37544fb8d28529d1369c3969 sha1 b49c955621576272ceda0ca7ec24dda95fd4a280 )
-)
-
-game (
 	name "DownTown / Mokugeki (Set 1)"
 	year "1989"
 	developer "Seta"
@@ -13818,50 +10219,10 @@ game (
 )
 
 game (
-	name "Draw Poker HI-LO (M.Kramer)"
-	year "1983"
-	developer "M.Kramer Manufacturing."
-	rom ( name dphl.zip size 5671 crc dc5516f2 md5 0abcc9f53ba16da7ab34215e15382a12 sha1 fec5ef1a5ed1c3ec436ef123bb5dcedbf029e58a )
-)
-
-game (
-	name "Draw Poker HI-LO (Alt)"
-	year "1983"
-	developer "&lt;unknown&gt;"
-	rom ( name dphla.zip size 4314 crc 103cb309 md5 05ec6c2c904c650409eb4baeef4b43a8 sha1 deb55147a94cdc2899ad7bfc04963c22c8f3d841 )
-)
-
-game (
-	name "Draw Poker HI-LO (Japanese)"
-	year "1983"
-	developer "&lt;unknown&gt;"
-	rom ( name dphljp.zip size 5551 crc 82c4efcd md5 37534b42d1c0f093b825f9cdf2285c3b sha1 993026343f0482a88707e027fca8eed9fbf56f0b )
-)
-
-game (
-	name "Draw Poker HI-LO (unknown, rev 1)"
-	developer "SMS Manufacturing Corp."
-	rom ( name dphlunka.zip size 5943 crc c1403fd9 md5 cabe944e33d7cff81ce2881b3ba184a1 sha1 158fa2daa7554c9678e1918ae9c7518c91e02b16 )
-)
-
-game (
-	name "Draw Poker HI-LO (unknown, rev 2)"
-	developer "SMS Manufacturing Corp."
-	rom ( name dphlunkb.zip size 5856 crc 32b600b7 md5 d0e4aa639fb530237cc58477ed7a9a9f sha1 663c5e8eff4c38e491835e5ec474bad16b7e28e6 )
-)
-
-game (
 	name "Double Play"
 	year "1977"
 	developer "Midway"
 	rom ( name dplay.zip size 6344 crc bf740d0a md5 dea1ec2e3f99ae0a6df51b9df031123e sha1 fff0dc0973da56cee7e6a586769fcedc7e5b3067 )
-)
-
-game (
-	name "Date Quiz Go Go (Korea)"
-	year "1998"
-	developer "SemiCom"
-	rom ( name dquizgo.zip size 1327729 crc 081f945d md5 6a2a30778523a7022cec607b04128c3f sha1 2b62d2071793d5b2cdb4079f1b6badf595715dbe )
 )
 
 game (
@@ -13876,13 +10237,6 @@ game (
 	year "1981"
 	developer "Cidelsa"
 	rom ( name draco.zip size 13763 crc d4493053 md5 3e40af261fc9a059ad03f9111aa136ff sha1 46b6be76ae7dae4044e4bb5678018e73675404a0 )
-)
-
-game (
-	name "Dragon Chronicles (DC001 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name dragchrn.zip size 2321284 crc 3eaf3810 md5 2b441168d74ef4c9f40cc63a8a3fe824 sha1 711ac16c948b9de5ea64de9da3e7d2418e9e83bb )
 )
 
 game (
@@ -13928,13 +10282,6 @@ game (
 )
 
 game (
-	name "Dream World"
-	year "2000"
-	developer "SemiCom"
-	rom ( name dreamwld.zip size 2007859 crc 7e39ed84 md5 87b93c596a51081bd1fe37c83ea5d9a4 sha1 82679e31d5694982becb4d0cdebe2da438aa97a1 )
-)
-
-game (
 	name "Dream Shopper"
 	year "1982"
 	developer "Sanritsu"
@@ -13953,13 +10300,6 @@ game (
 	year "1984"
 	developer "Namco"
 	rom ( name drgnbstr.zip size 60346 crc 94f96ab1 md5 69872262d0b16eb6381866ae3dfe2a14 sha1 845aaf84f2ab64fcb2e6829cd05e5cd5e30dcdd6 )
-)
-
-game (
-	name "Dragonninja (Japan)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name drgninja.zip size 310675 crc 71712687 md5 6c20538128e137953353706e17496e29 sha1 76fb1f65984ea65eb5fdc51e4e5c2d252ae24ca3 )
 )
 
 game (
@@ -14033,66 +10373,10 @@ game (
 )
 
 game (
-	name "Dragon World II (ver. 110X, Export)"
-	year "1997"
-	developer "IGS"
-	rom ( name drgw2.zip size 3992048 crc 03c4b4e4 md5 4c7bd034e29b9491c9beccb06ee58f1b sha1 07353f1b569935b6905d43650a65b9708159a384 )
-)
-
-game (
 	name "Zhong Guo Long II (ver. 100C, China)"
 	year "1997"
 	developer "IGS"
 	rom ( name drgw2c.zip size 263223 crc 7aa9ff4d md5 f9ab64783fb08d6a6c5cf0556614db03 sha1 be864fb4d3f69c89ee2f45e627500a27aca83fca )
-)
-
-game (
-	name "Chuugokuryuu II (ver. 100J, Japan)"
-	year "1997"
-	developer "IGS"
-	rom ( name drgw2j.zip size 262073 crc 291e2a97 md5 a5f2782a15376b26fe16a7885a658470 sha1 97feac77edd720185c1afca5a55c31a67a8fd6cb )
-)
-
-game (
-	name "Dragon World 3 (ver. 106, Korean Board)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3.zip size 5540174 crc fefbb250 md5 1461b2f7547751e511dd3968a14efd02 sha1 43a0c12c4e91388193e88d65f0ecad0a064cee42 )
-)
-
-game (
-	name "Dragon World 3 (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3100.zip size 272127 crc 2f9b528b md5 551e314d8e24f90be20f83f5916fc309 sha1 f754aacb0093b5a4d0d971ff5979491e29aebdb7 )
-)
-
-game (
-	name "Dragon World 3 (ver. 105)"
-	year "1998"
-	developer "IGS"
-	rom ( name drgw3105.zip size 283022 crc 3cc33a00 md5 8f34fd6efffb02bf3c37789fad8d1875 sha1 b8d2cc7ecec44ef57eaed1b86995547203df4658 )
-)
-
-game (
-	name "DRHL Poker (v.2.89)"
-	year "1986"
-	developer "Drews Inc."
-	rom ( name drhl.zip size 8702 crc 8fe37e73 md5 fb9b2a479c158eb36d038e767e0c44d1 sha1 23e773eca41a6fa08598144158f2c9370a0e203b )
-)
-
-game (
-	name "Dribbling"
-	year "1983"
-	developer "Model Racing"
-	rom ( name dribling.zip size 15461 crc 0e1c3ae2 md5 a12bb785b49d433c11e8cd56cf17fa12 sha1 f7237d4994c33c3da70ac1312533cb835864c37f )
-)
-
-game (
-	name "Dribbling (Olympia)"
-	year "1983"
-	developer "Model Racing (Olympia license)"
-	rom ( name driblingo.zip size 8812 crc 46c3afff md5 8adbe9acc45a8ec291fea3a8511fe16a sha1 f725e03f7d25813584b028f0119dab4a19d2ef9a )
 )
 
 game (
@@ -14121,13 +10405,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name driveout.zip size 927906 crc a93f80fa md5 0327906c8cd3a476c2797bf719b1efe5 sha1 509fad4be4afe57818b87d0202f3e78fae17e8cb )
-)
-
-game (
-	name "Driver's Eyes (US)"
-	year "1991"
-	developer "Namco"
-	rom ( name driveyes.zip size 1800297 crc 8bdb910d md5 d672429672c627f10336c1c9d0c62470 sha1 065cb476de87e66b14f00323168fb9cba3387e18 )
 )
 
 game (
@@ -14173,66 +10450,10 @@ game (
 )
 
 game (
-	name "DrumMania (GQ881 VER. JAD)"
-	year "1999"
-	developer "Konami"
-	rom ( name drmn.zip size 4634 crc 34f4b5d4 md5 950295f7b7d57b46a5b02ef8667e8ead sha1 f2d264ccd7b2eb29fa066f761ee31f702b289ef7 )
-)
-
-game (
-	name "DrumMania 2nd Mix (GE912 VER. JAB)"
-	year "1999"
-	developer "Konami"
-	rom ( name drmn2m.zip size 548 crc eea97def md5 6cebef2beef31fc8a671d0294f796924 sha1 287631321ae50ce86691ab467d6348996417ba19 )
-)
-
-game (
-	name "DrumMania 3rd Mix (G*A23 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name drmn3m.zip size 336 crc d345a0a6 md5 63d2fe28cc0aef2098ce2527db6a3e4e sha1 03338746c7d9261d63d1bae8182a542603314cf0 )
-)
-
-game (
 	name "Dr. Tomy"
 	year "1993"
 	developer "Playmark"
 	rom ( name drtomy.zip size 647547 crc 896806ec md5 fd9d0c4e8de0ed12070a55cc76391ad9 sha1 e2136ab36960b2c72dc519ce1626a87ba42b78f0 )
-)
-
-game (
-	name "Dr. Toppel's Adventure (World)"
-	year "1987"
-	developer "Kaneko / Taito Corporation Japan"
-	rom ( name drtoppel.zip size 399766 crc 9918e9f2 md5 1709c15d5d106dfc02a47a0846df2dd1 sha1 8a5c0bd41a7ad5dae9d6e3ba5c12b4b5f29f5eaf )
-)
-
-game (
-	name "Dr. Toppel's Tankentai (Japan)"
-	year "1987"
-	developer "Kaneko / Taito Corporation"
-	rom ( name drtoppelj.zip size 12155 crc 56b8fa71 md5 1c97cb4bb3daf7e92924f6e606a9d26a sha1 3a592cbe660a0c35a918347a19fa799b740aec4b )
-)
-
-game (
-	name "Dr. Toppel's Adventure (US)"
-	year "1987"
-	developer "Kaneko / Taito America Corporation"
-	rom ( name drtoppelu.zip size 12155 crc fe6c74de md5 b8d33e4ed5e3d30b197e2c793e6d870f sha1 3581ea54357fceabc95a9bcac36259a2d54648a0 )
-)
-
-game (
-	name "Draw 80 Poker - Minn"
-	year "1983"
-	developer "IGT - International Gaming Technology"
-	rom ( name drw80pk2.zip size 5890 crc f97db59f md5 65d7200747deb443bb998797265757e2 sha1 62b5bbf2e6c771d30a44bcac759f1e0ed57bf740 )
-)
-
-game (
-	name "Draw 80 Poker"
-	year "1982"
-	developer "IGT - International Gaming Technology"
-	rom ( name drw80pkr.zip size 7588 crc 645a9fba md5 fc7528b7418b4add050a2d3523fb2bab sha1 c3eb14c3e3e820311487bb39643b484e4dbe866f )
 )
 
 game (
@@ -14247,48 +10468,6 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name dsaberj.zip size 102170 crc 9bb798d2 md5 f17f1331c22f035532fbc42827da6179 sha1 a52c9ce9c1797d61da1c16d4b1ac8049db6f1c55 )
-)
-
-game (
-	name "Dancing Stage Euro Mix (G*936 VER. EAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dsem.zip size 290 crc 0b84aa39 md5 fda883a7808925deffe64826d8c5528f sha1 cdf2bbcbc754afe72a9475aa8c1a12cba55356c9 )
-)
-
-game (
-	name "Dancing Stage Euro Mix 2 (G*C23 VER. EAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name dsem2.zip size 314 crc 97973de3 md5 d46f67b66ebf2677b3db773c3587182d sha1 d24e62282ee4cba8dd1f4df29884a0da97e8fb76 )
-)
-
-game (
-	name "Dancing Stage featuring Dreams Come True (GC910 VER. JCA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsfdct.zip size 562 crc b9ce550a md5 7f9620de0c7fb4bf7e1eecfe861aa9ea sha1 0476f58d28dadf0d2c6b3efc108e502d45c80bda )
-)
-
-game (
-	name "Dancing Stage featuring Dreams Come True (GC910 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsfdcta.zip size 308 crc 788616f2 md5 452df39ea008420351952fb9d599b142 sha1 2949fcee916167dccf26414bf272a9abb23b64db )
-)
-
-game (
-	name "Dancing Stage Featuring Disney's Rave (GCA37JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name dsfdr.zip size 548 crc 9175a62d md5 ae017408072eacd23f193194ff7e6c84 sha1 f6180a0679c23204f366f5284c692ec3b5fad324 )
-)
-
-game (
-	name "Dancing Stage featuring TRUE KiSS DESTiNATiON (G*884 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dsftkd.zip size 282 crc 158cab8d md5 d3ccc8bcd00aabc04ef31f26fb200063 sha1 d5478456f4feda819d9b4673398a45f593b89c3b )
 )
 
 game (
@@ -14324,13 +10503,6 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name dspirito.zip size 59442 crc d83eb646 md5 c142ab96b9afeca3e03821d9a7dfdd74 sha1 61dc2642562bbce9f9d975d12067ba3018c2bae2 )
-)
-
-game (
-	name "Dancing Stage (GN845 VER. EAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name dstage.zip size 172 crc 211884f7 md5 3f10c9aa74fe4f8e8b5fb180c7bce079 sha1 8302f141cd7a14e6f2a859df393e65d0e0d7ac08 )
 )
 
 game (
@@ -14390,13 +10562,6 @@ game (
 )
 
 game (
-	name "Dump Matsumoto (Japan, 8751 317-0011a)"
-	year "1986"
-	developer "Sega"
-	rom ( name dumpmtmt.zip size 281178 crc 334f90ac md5 fcb4de2f1215db30a260eaa7dcc07305 sha1 2cbb5fff651635bfca0e9768e2c085862267c4d9 )
-)
-
-game (
 	name "Dungeon Magic (Ver 2.1O 1994/02/18)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -14439,48 +10604,6 @@ game (
 )
 
 game (
-	name "Devil Island"
-	year "2006"
-	developer "Amcoe"
-	rom ( name dvisland.zip size 221080 crc fb0f3f1d md5 2f755cde386e5ee5f617cdb16446462e sha1 96cc3098fecb0fa8d05e7c54f445fdabd1d0720d )
-)
-
-game (
-	name "Dragon World 2001"
-	year "2001"
-	developer "IGS"
-	rom ( name dw2001.zip size 3812332 crc c14bbb4a md5 55b777397579966adfee53b1a020bc82 sha1 e2e7ea59dbb9206fb2534f993c57f624d435c843 )
-)
-
-game (
-	name "Dwarfs Den"
-	year "1981"
-	developer "Electro-Sport"
-	rom ( name dwarfd.zip size 17403 crc 392353e1 md5 c9205d5b6c7461f184b62cd5d0761388 sha1 66845d5db9eebd0dbca30449598a79759ee7806a )
-)
-
-game (
-	name "Dragon World 3 EX (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name dwex.zip size 3617735 crc 4ddaa7ee md5 21b4eda55375e3efb793c7a6028897ba sha1 49aac07afa5830340c0f5205d6ac7a0589d5fe87 )
-)
-
-game (
-	name "Dynamite Baseball '99 (JPN) / World Series '99 (USA, EXP, KOR, AUS) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name dybb99.zip size 102221240 crc fc4c92ca md5 384354a930c05e50bb17879026eb95d6 sha1 db147f68072c4f7aae566082fd1af76609a60e12 )
-)
-
-game (
-	name "Dynamite Baseball NAOMI (JPN)"
-	year "1998"
-	developer "Sega"
-	rom ( name dybbnao.zip size 111036772 crc 7b647fd8 md5 f9b8fee1a75be4c9dbfe8d95a43cbfbe sha1 d9d62072f6e151c790c0e93f3d9ef7cfe190028a )
-)
-
-game (
 	name "Dyger (Korea set 1)"
 	year "1989"
 	developer "Philko"
@@ -14492,20 +10615,6 @@ game (
 	year "1989"
 	developer "Philko"
 	rom ( name dygera.zip size 16423 crc 8d0f674c md5 3a23f0c364997592b29c53a247e9efa8 sha1 fbcb72a9046dbccb0eddc3fd07e78d824695aac7 )
-)
-
-game (
-	name "Virtua Golf / Dynamic Golf (Rev A) (GDS-0009A)"
-	year "2001"
-	developer "Sega"
-	rom ( name dygolf.zip size 3383 crc 6fa7f6a1 md5 f51bd3399e64d4a0ad2ca49cdba4cd20 sha1 5cf3d191badb71f067195914120aed867edc0415 )
-)
-
-game (
-	name "Dynamite Baseball '97 (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name dynabb.zip size 22633404 crc 7de4ba7d md5 c5fe7f985c0dea043e584cb39cedba77 sha1 7154c962bb4f5284879f92bce2814535f089a437 )
 )
 
 game (
@@ -14523,13 +10632,6 @@ game (
 )
 
 game (
-	name "Dynamite Bomber (Korea, Rev 1.5)"
-	year "2000"
-	developer "Limenko"
-	rom ( name dynabomb.zip size 5708807 crc 857c86cf md5 e1c5640ff9d9f83152e7b8353686522d sha1 0b9a99c62791bee27c7de4550d9cf827d20f104e )
-)
-
-game (
 	name "Dynamic Dice"
 	developer "&lt;unknown&gt;"
 	rom ( name dynadice.zip size 7102 crc 492b5182 md5 7445223e70e40a0ddcc41c347ae5ccda sha1 b2fdc494611402e5df879d51095533da077ce8fb )
@@ -14543,52 +10645,10 @@ game (
 )
 
 game (
-	name "Dynamite Cop (Export, Model 2A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcop.zip size 35013273 crc 8b2c12bb md5 7b36ddc720f2fedc0c7fb80457dd2ea4 sha1 5976ded905e098028430f9e69a1610b003a9978e )
-)
-
-game (
-	name "Dynamite Cop (Export, Model 2B)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcopb.zip size 361346 crc e0bfdd65 md5 26a40d75ad65062a9f8ec649b7bd8a19 sha1 9d1b63e9f3d89750a42bcdde4eb5e4dd0ff867eb )
-)
-
-game (
-	name "Dynamite Cop (USA, Model 2C)"
-	year "1998"
-	developer "Sega"
-	rom ( name dynamcopc.zip size 356018 crc ac1d17a6 md5 29c2b0a540e84dce578ab9d9e8e789ef sha1 8391a46420f3a2d660b260ce098a892483e1cadd )
-)
-
-game (
 	name "Dynamic Ski"
 	year "1984"
 	developer "Taiyo"
 	rom ( name dynamski.zip size 36061 crc 9c578545 md5 684716f8d5ee86336ecfe5494205e1a3 sha1 ec69a8cb5dc79af218a0f7f213433f0e3e47bc62 )
-)
-
-game (
-	name "Dynamic Shooting"
-	year "1988"
-	developer "Jaleco"
-	rom ( name dynashot.zip size 67568 crc 48edb7c5 md5 626d6e3c8e6137d8104d6416a6ffa95e sha1 50abcd3eb85dc5c5510be60c7ac4732de844c06c )
-)
-
-game (
-	name "Dynamite Deka 2 (Japan, Model 2A)"
-	year "1998"
-	developer "Sega"
-	rom ( name dyndeka2.zip size 345986 crc fda0186f md5 a6c00717c4fcce05905affb4b73cec06 sha1 aac6b8a4f9a77621610e9255f662de20514feee7 )
-)
-
-game (
-	name "Dynamite Deka 2 (Japan, Model 2B)"
-	year "1998"
-	developer "Sega"
-	rom ( name dyndeka2b.zip size 361290 crc 5ca6e64d md5 9cd2d2f40e22284e9f336fc52da5c1da sha1 88964e3b4748aaadbd13a3216eff3f52119b2ba4 )
 )
 
 game (
@@ -14617,20 +10677,6 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name dynwar.zip size 2193606 crc 13133f73 md5 e45c907aa7c9d903403d9e7e38b07d68 sha1 80e256ade6aa053e026088210e9b4557e406c953 )
-)
-
-game (
-	name "Tenchi wo Kurau (Japan)"
-	year "1989"
-	developer "Capcom"
-	rom ( name dynwarj.zip size 2234688 crc d1edcff6 md5 87ca5dfd65321f03be104fada43f613f sha1 605e0d745d8e683415e641bb2f59b44a06cf1104 )
-)
-
-game (
-	name "Dynasty Wars (USA, set 2)"
-	year "1989"
-	developer "Capcom"
-	rom ( name dynwaru.zip size 2029034 crc e417cbbb md5 3c4279b76ba008e77e7748c88dadc51f sha1 7fadb21ae480f546927f0897cfa480a5a719c76a )
 )
 
 game (
@@ -14683,20 +10729,6 @@ game (
 )
 
 game (
-	name "Emergency Call Ambulance"
-	year "1999"
-	developer "Sega"
-	rom ( name eca.zip size 59917658 crc 3d379e30 md5 109a69549a6003e4c21d68eeee8d01dc sha1 7a9d93fe283182cee1f01debf18f9648760ae292 )
-)
-
-game (
-	name "Emergency Call Ambulance (Export)"
-	year "1999"
-	developer "Sega"
-	rom ( name ecax.zip size 466393 crc f2183450 md5 c4f89ce3447b809fef3a1fe33f533c59 sha1 827ba8fcc1fb4a9e48a46d460f4abdf0d4889dfd )
-)
-
-game (
 	name "Eco Fighters (World 931203)"
 	year "1993"
 	developer "Capcom"
@@ -14732,27 +10764,6 @@ game (
 )
 
 game (
-	name "E.D.F. : Earth Defense Force"
-	year "1991"
-	developer "Jaleco"
-	rom ( name edf.zip size 1166516 crc 621c9451 md5 36f6b6f7c778cb42b70f9b62838f047c sha1 0843e086044885aa1c5b6a95f577790f0045f5e0 )
-)
-
-game (
-	name "E.D.F. : Earth Defense Force (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name edfbl.zip size 1233291 crc 50f70c06 md5 2df6b19b5d86728aac366d2b30cb4c71 sha1 a8f576e15e27c69046c77825c98e5a555d7d357e )
-)
-
-game (
-	name "E.D.F. : Earth Defense Force (North America)"
-	year "1991"
-	developer "Jaleco"
-	rom ( name edfu.zip size 125561 crc 12fe65ce md5 9bb7379b7ad01bfd696b3ec28f82320d sha1 4c019606138395a8790940368e3c7f7d4994cce9 )
-)
-
-game (
 	name "The Cliffhanger - Edward Randy (World ver 3)"
 	year "1990"
 	developer "Data East Corporation"
@@ -14781,13 +10792,6 @@ game (
 )
 
 game (
-	name "Enchanted Forest - 12XF528902"
-	year "1994"
-	developer "Aristocrat"
-	rom ( name eforest.zip size 51630 crc 04715ef3 md5 29d7d2ebe57c43bcc1bfa50096764c70 sha1 f6fa438facbe7cffab54aa57f72fe850a8f80c62 )
-)
-
-game (
 	name "Enchanted Forest - 4VXFC818"
 	year "1995"
 	developer "Aristocrat"
@@ -14806,13 +10810,6 @@ game (
 	year "1995"
 	developer "Invi Image"
 	rom ( name egghunt.zip size 973751 crc b0db3102 md5 5a12d14ce0a9f172b1dfd8ca752a9c14 sha1 54d83ed62909a5f64cf11002109ccf849eb40805 )
-)
-
-game (
-	name "Eggor"
-	year "1983"
-	developer "Telko"
-	rom ( name eggor.zip size 15733 crc 4f26a659 md5 b891df5d59d7b0faa260b9f7118b4a8e sha1 ef8095a7ae1ee548e0235af3492e1ef37394ed96 )
 )
 
 game (
@@ -14914,12 +10911,6 @@ game (
 )
 
 game (
-	name "Euro Jolly X5"
-	developer "Solar Games"
-	rom ( name ejollyx5.zip size 410664 crc ffed92d9 md5 39006ebbf6548b1d9cde68aa017afecd sha1 3468b4b7bd0f387970ff7adf518e3fa4c0711854 )
-)
-
-game (
 	name "E-Jan Sakurasou (v2.0)"
 	year "1999"
 	developer "Seibu Kaihatsu"
@@ -14934,13 +10925,6 @@ game (
 )
 
 game (
-	name "Touryuu Densetsu Elan-Doree / Elan Doree - Legend of Dragoon (JUET 980922 V1.006)"
-	year "1998"
-	developer "Sai-Mate"
-	rom ( name elandore.zip size 12416279 crc 1973e039 md5 e7f696eb1f5b8f1dc71d5d02748c2644 sha1 6d95eff054e8ecc9af6916bd01c1d4a61fde5d38 )
-)
-
-game (
 	name "The Electric Yo-Yo (set 1)"
 	year "1982"
 	developer "Taito America Corporation"
@@ -14952,20 +10936,6 @@ game (
 	year "1982"
 	developer "Taito America Corporation"
 	rom ( name elecyoyo2.zip size 5535 crc 5da1863b md5 58201627975f4b8152af81b2a1ac30e8 sha1 45be8ea0544a201b29a439252dd2a89300e5491f )
-)
-
-game (
-	name "Elephant Family (Italian, new)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name elephfam.zip size 53968 crc c1714542 md5 17b7783f2d0b37b707ff4c041ab2006f sha1 0d5da2f9cf27ce4f696557e95f8ae7616f222992 )
-)
-
-game (
-	name "Elephant Family (Italian, old)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name elephfmb.zip size 27268 crc 6720875a md5 de479275581bf8cf0b64957b27a60f61 sha1 6e3a27aaeff4a92f951741288d2b3ecd352db9ef )
 )
 
 game (
@@ -15032,30 +11002,10 @@ game (
 )
 
 game (
-	name "Elevator Action Returns (Ver 2.2O 1995/02/20)"
-	year "1994"
-	developer "Taito Corporation Japan"
-	rom ( name elvactr.zip size 8186906 crc d89e457f md5 df255cc7c1faa0502dd0ff6512596fe0 sha1 c1aa23e690c86c85fcbec1b57e7ad6dc6d58eb5d )
-)
-
-game (
 	name "Elevator Action Returns (Ver 2.2J 1995/02/20)"
 	year "1994"
 	developer "Taito Corporation"
 	rom ( name elvactrj.zip size 123930 crc a9476008 md5 a309136bbce48ce1b66fe9ae512c0b11 sha1 6174d6a4f31ab3796345773e0d0a57e4b19dba37 )
-)
-
-game (
-	name "Elvis?"
-	developer "&lt;unknown&gt;"
-	rom ( name elvis.zip size 392765 crc 74ebf3b6 md5 86d460b82a3a02203971eee0d4c042a5 sha1 2e455d43a9182c7eb16aa18062da00d2d91df569 )
-)
-
-game (
-	name "Embargo"
-	year "1977"
-	developer "Cinematronics"
-	rom ( name embargo.zip size 3935 crc 454a6306 md5 c00a72c83b8272dd85874bcbf02ad7da sha1 639d676508573717f5d666f4d2ee1fa05b0da14d )
 )
 
 game (
@@ -15101,27 +11051,6 @@ game (
 )
 
 game (
-	name "Enchanted Forest (E - 23/06/95, Local)"
-	year "1995"
-	developer "Aristocrat"
-	rom ( name enchfrst.zip size 656213 crc 4ee6db7f md5 2a318822ebb664c2b44508ee989ea089 sha1 7d6827d2146a375de0cebcefb7aea2244f560629 )
-)
-
-game (
-	name "Gundam Wing: Endless Duel (SNES bootleg)"
-	year "1996"
-	developer "bootleg"
-	rom ( name endless.zip size 1501648 crc 732b7e75 md5 c4913184de02e1416abf9d5be8c2ec65 sha1 d365d7c29696c3aa5b314fda90b4995ea459dd1b )
-)
-
-game (
-	name "Enduro Racer (bootleg set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name endurob2.zip size 203882 crc d0d3f589 md5 78c6ab7eafb633c49384bda69d946044 sha1 ab6fdc9097919d56d592318ab266892485e0835d )
-)
-
-game (
 	name "Enduro Racer (bootleg set 1)"
 	year "1986"
 	developer "bootleg"
@@ -15157,20 +11086,6 @@ game (
 )
 
 game (
-	name "Enigma II (Space Invaders hardware)"
-	year "1984"
-	developer "Zilec Electronics"
-	rom ( name enigma2a.zip size 7977 crc d954a25b md5 7719bdb88678a36f71ae3012c0df4ab8 sha1 9b0b5223b80b212c1323ede08479eb598c3aef52 )
-)
-
-game (
-	name "Phantoms II (Space Invaders hardware)"
-	year "1981"
-	developer "Zilec Electronics"
-	rom ( name enigma2b.zip size 7963 crc 1372c3a8 md5 5eca27ffc7a0233d0610af739272d600 sha1 84cbe6212b2eaa1358594342f95ead9bc294dee0 )
-)
-
-game (
 	name "Escape from the Planet of the Robot Monsters (set 1)"
 	year "1989"
 	developer "Atari Games"
@@ -15199,13 +11114,6 @@ game (
 )
 
 game (
-	name "Erotictac/Tactic"
-	year "1990"
-	developer "Sisteme"
-	rom ( name ertictac.zip size 582304 crc c1fdbc4f md5 efaa666b578a3d15778008e0f4d2900e sha1 86745d75f28ec39136e73f5e43f98be6139202ea )
-)
-
-game (
 	name "The Empire Strikes Back"
 	year "1985"
 	developer "Atari Games"
@@ -15231,27 +11139,6 @@ game (
 	year "1990"
 	developer "BFM"
 	rom ( name escounts.zip size 450598 crc 85ee4d87 md5 74a88b51d7bf3b2f24ff223ce40406b2 sha1 4734719828ad3ed0e568957f727f28ccf725f2e6 )
-)
-
-game (
-	name "Esh's Aurunmilla (set 1)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name esh.zip size 21472 crc 72f34836 md5 19f6e5eafacecbd7be5f10afb6f3e61d sha1 ddd9f1cadee0ba7bd384c64c00022446490b2ada )
-)
-
-game (
-	name "Esh's Aurunmilla (Set 2)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name esha.zip size 21473 crc d1cfe5d4 md5 928e815baf2d9b5547fe4481fe945990 sha1 a5fc4abc71131b367d14263878267b2bd05e3ef3 )
-)
-
-game (
-	name "Esh's Aurunmilla (Set 3)"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name eshb.zip size 5263 crc 7ccb48fb md5 adf3ac173f59286fcda83610cb076b12 sha1 9399862b5856b176847923e95b548ee8737210ee )
 )
 
 game (
@@ -15297,13 +11184,6 @@ game (
 )
 
 game (
-	name "E-Swat - Cyber Police (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name eswatbl.zip size 168421 crc be243e8c md5 70476a7246b5453b79c3612f3ba22db9 sha1 77e2e0c3d4e15aac3b8aabdc09bf46436f85dcb4 )
-)
-
-game (
 	name "E-Swat - Cyber Police (set 1, Japan, FD1094 317-0128)"
 	year "1989"
 	developer "Sega"
@@ -15325,44 +11205,10 @@ game (
 )
 
 game (
-	name "Europa 2002 (Ver 2.0, set 1)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2.zip size 696520 crc 611f01d1 md5 6442225635c7bf23ce57b5a7a0bb94d6 sha1 ca2e106e85c8e2dd3d5945df6ddf1e2fe84a1a38 )
-)
-
-game (
-	name "Europa 2002 (Ver 2.0, set 2)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2a.zip size 774168 crc d837b41e md5 76e4f0c266a067becda0ef0a0b8e88d7 sha1 75b8adb1383cc13fedb5bab86f56d937b35aa66f )
-)
-
-game (
-	name "Europa 2002 Space (Ver 3.0)"
-	year "2002"
-	developer "Nazionale Elettronica"
-	rom ( name euro2k2s.zip size 661458 crc c5ba3b51 md5 4450276082bc33a0273fed016887c46e sha1 ea43f625e66feae40b916a4eae1ae03e936befa2 )
-)
-
-game (
 	name "Euro Champ '92 (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
 	rom ( name euroch92.zip size 796502 crc 9a1b5782 md5 efe3d5fe77ba1ad68cd4c840c9d17958 sha1 d937f0b3e44499beb5960dcbfcac01712e0133b0 )
-)
-
-game (
-	name "Euro Pass (Ver 1.1)"
-	developer "&lt;unknown&gt;"
-	rom ( name europass.zip size 240504 crc 404b65d8 md5 5582c097032885e4ad4b5644a5c06010 sha1 121cf8337d50e9c249f1193748d37fd378399e3d )
-)
-
-game (
-	name "Evil Night (ver EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name evilngt.zip size 3813571 crc 2235b717 md5 60916d0b936a9d1080b11bfd86dbc49d sha1 6d72b32e638e1399d168e7dbd5e3bf3e039c258e )
 )
 
 game (
@@ -15547,27 +11393,6 @@ game (
 )
 
 game (
-	name "Extermination (World)"
-	year "1987"
-	developer "Taito Corporation Japan"
-	rom ( name extrmatn.zip size 369284 crc 1f69d677 md5 9f7f0b26e33fc46c495fc62dce2fc811 sha1 fb611f82b86a4620e8248970a27a29ee2a677486 )
-)
-
-game (
-	name "Extermination (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name extrmatnj.zip size 12196 crc b04ce1cd md5 9b3a6a03d658dc84b3bcb3292be0b841 sha1 20d54859603fcd6df08852e7ca06ddc92016fa57 )
-)
-
-game (
-	name "Extermination (US)"
-	year "1987"
-	developer "Taito (World Games license)"
-	rom ( name extrmatnu.zip size 86745 crc 52da26f8 md5 c10d2f70d4df9dc4dd8f0d2d466c802b sha1 d64057613ded50f6637cd2d33e9b6e35797cc376 )
-)
-
-game (
 	name "Exvania (Japan)"
 	year "1992"
 	developer "Namco"
@@ -15582,13 +11407,6 @@ game (
 )
 
 game (
-	name "Exzisus (Japan, conversion)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name exzisusa.zip size 176462 crc 2eeae837 md5 0d5df6af5b92a83d1d54555b960481e0 sha1 1f51142a9dc245c41ccc5dfe42e423d3c2f940bf )
-)
-
-game (
 	name "Eyes (Digitrex Techstar)"
 	year "1982"
 	developer "Digitrex Techstar (Rock-Ola license)"
@@ -15600,18 +11418,6 @@ game (
 	year "1982"
 	developer "Techstar (Rock-Ola license)"
 	rom ( name eyes2.zip size 12396 crc 056ab42d md5 585c15a667ea7dacf061c9a753fc4ce2 sha1 83c4b1cc23637c1e631ab85145e87a0e16d04a38 )
-)
-
-game (
-	name "Eyes Down (v1.3)"
-	developer "Barcrest"
-	rom ( name eyesdown.zip size 92968 crc 49e4aa95 md5 41c4683b0d78268e49c5834324561015 sha1 bfa22e67e55849463ce1d203bf09f895c7331d6f )
-)
-
-game (
-	name "Eyes Down (v1.3, Datapak)"
-	developer "Barcrest"
-	rom ( name eyesdownd.zip size 23008 crc 280627b6 md5 01a94c7cadfb785ae55871faa48e86f5 sha1 c0705d40e5a34b8400e1092cdcb8aff6fbe083e6 )
 )
 
 game (
@@ -15633,13 +11439,6 @@ game (
 	year "1991"
 	developer "Microprose Games Inc."
 	rom ( name f15se21.zip size 300686 crc 1ac2916e md5 0831c53ed4901be2f88351b65384ab2e sha1 f46016964c0f27b4c8faa5f09451797b23f10fd6 )
-)
-
-game (
-	name "F-1 Dream"
-	year "1988"
-	developer "Capcom (Romstar license)"
-	rom ( name f1dream.zip size 338876 crc 3fdf1f53 md5 90c9cf086d72d31a224fbc49880b4ae1 sha1 3ff536b5a5e5d5b283e26af5fd2f02c56cfcbfc7 )
 )
 
 game (
@@ -15671,13 +11470,6 @@ game (
 )
 
 game (
-	name "F-1 Grand Prix (Playmark bootleg)"
-	year "1991"
-	developer "bootleg (Playmark)"
-	rom ( name f1gpb.zip size 3129759 crc b696c797 md5 1d9a806ec64b769e01c988b4bb8e7338 sha1 b91dc02a7bcf464cc06140cedb0c9821e344ae0d )
-)
-
-game (
 	name "Grand Prix Star"
 	year "1991"
 	developer "Jaleco"
@@ -15689,41 +11481,6 @@ game (
 	year "1993"
 	developer "Jaleco"
 	rom ( name f1gpstr2.zip size 4131456 crc 51afa282 md5 b2e9661453316c975c2dddecaf18ebe8 sha1 bc26c842587dbe0392c00a00e85ec6ecaf0e3f15 )
-)
-
-game (
-	name "F1 Super Lap"
-	year "1993"
-	developer "Sega"
-	rom ( name f1lap.zip size 7283905 crc c0fb2ea5 md5 9517e036c9692418ba29e481500f176e sha1 72583508da16e1fc3602da2c78cc0cfc03fbf074 )
-)
-
-game (
-	name "F1 Super Battle"
-	year "1994"
-	developer "Jaleco"
-	rom ( name f1superb.zip size 17252759 crc db722fe3 md5 76c4bf623651ab6494cd9622005c95f5 sha1 3d47f57c2efc4779bac13f876fb62bd8f9af970a )
-)
-
-game (
-	name "Ferrari F355 Challenge"
-	year "1999"
-	developer "Sega"
-	rom ( name f355.zip size 100802019 crc a5f64cd9 md5 e420a44776c5609fe1254c6952a15e53 sha1 ded73a2e64295085c2d2821f68b304eec6957fd2 )
-)
-
-game (
-	name "Ferrari F355 Challenge (Twin)"
-	year "1999"
-	developer "Sega"
-	rom ( name f355twin.zip size 94300637 crc 541f373e md5 bd7ea30f43b0ed328f6c4775b94c5a6d sha1 b183a0967a1e5ddc0eca3ac1d21e85d490538095 )
-)
-
-game (
-	name "Ferrari F355 Challenge 2 (Twin)"
-	year "1999"
-	developer "Sega"
-	rom ( name f355twn2.zip size 107505518 crc 7df2a0e4 md5 4034a5d9f72661ac519f929ed5ae31fa sha1 5641a1f4e994bbfd70fc5ed9ca96696dd0915f60 )
 )
 
 game (
@@ -15872,37 +11629,10 @@ game (
 )
 
 game (
-	name "Far West"
-	year "1986"
-	developer "bootleg?"
-	rom ( name farwest.zip size 102573 crc 393c07c5 md5 08a06c9c74a73fca3e1e7886fdef234e sha1 b74c15155e543e0aee3398216340ad36648f8de4 )
-)
-
-game (
 	name "Fashion (Version 2.14)"
 	year "2000"
 	developer "High Video"
 	rom ( name fashion.zip size 883892 crc 12ab0b3c md5 943f36ea39da1c1402c693030a91ae3d sha1 5d3709249253b7406762643bcbd0648382bc3e1d )
-)
-
-game (
-	name "Fashion Gambler"
-	year "1997"
-	developer "ADP"
-	rom ( name fashiong.zip size 220029 crc 8d47ad03 md5 5f5916942e303b755094d550d78552c2 sha1 b261f050232ff8e76a0f1a06ec86a17160f06c71 )
-)
-
-game (
-	name "Fast Draw Showdown v1.3"
-	year "1995"
-	developer "American Laser Games"
-	rom ( name fastdraw.zip size 86367 crc 8de6e141 md5 f7a5b3d9eb1434a0c7fa14ccb986a0db sha1 508139d96ec5f3a5eefb24047380eeb72b5f45bb )
-)
-
-game (
-	name "Fast Draw (poker conversion kit)?"
-	developer "Stern Electronics?"
-	rom ( name fastdrwp.zip size 5581 crc cc77ffcb md5 731c3bef014e42be0616bc7cf904f4d7 sha1 7be188e9e72c74a0471070b3cb0174b887e0acfa )
 )
 
 game (
@@ -15931,13 +11661,6 @@ game (
 	year "1993"
 	developer "SNK"
 	rom ( name fatfursp.zip size 11294592 crc ad56bd3d md5 f93b0778e28289a34f73370e09b9511b sha1 5937aca6a04b5a1fc96d8d3fd902e021964a74cf )
-)
-
-game (
-	name "Fatal Fury: Wild Ambition (rev.A)"
-	year "1998"
-	developer "SNK"
-	rom ( name fatfurwa.zip size 91933857 crc 0e812d3c md5 29c5fe3b312d8f47f9258aa6b4a77cde sha1 07c27024140861a1b10301c0dbace683b411a702 )
 )
 
 game (
@@ -16088,111 +11811,6 @@ game (
 )
 
 game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4.zip size 646767 crc 8076cc7a md5 0207a9d0b1a2a8229fbe26d1bce071a1 sha1 020d45b8de19ec972c5fdfd41c2aa5ae63a99de3 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 1)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4b2.zip size 148328 crc 5afec92a md5 2820aa25c4ca0c2e0991364fa8b1f73f sha1 4068f0155458521e700a2d59ebb774f96c298b90 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4c1.zip size 148529 crc 4bac0768 md5 2a6ffcc6631e630e5d2b84a5a93abad1 sha1 08ca20e7f0c5ef7a3a5d0d6bc22c43da0ca68145 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4c2.zip size 148689 crc 7d895190 md5 ac7ff5e579b5a121ed43faf127b2d33c sha1 d734b89597bb57652ceb628753c43915a16b34ab )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R, set 3)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4d1.zip size 147898 crc 81e8018f md5 f536ef4b4172c11d45191372db50c0c7 sha1 4278c734b609339d0ec52c9f31a480d114d9684e )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT, set 3)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4d2.zip size 148074 crc 7509005a md5 6d0f6c569ce14a245b8837e009a9b132 sha1 da68dfdc6ad7542efedd0db0a21cbb58ff320251 )
-)
-
-game (
-	name "Fruit Bonus 2005 (2004 Export - Version 1.5E Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4exp.zip size 471816 crc d4a77121 md5 f350c3b1af83710c94013ffde4beff51 sha1 f0379a8dfbf5cc2a36ad70fafb7ba5e1884520e8 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.3XT)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4o.zip size 148423 crc a98b4019 md5 32c568a5f8a4844570424189d448befc sha1 d07a6d1067e27e5174ffe21212f40663886d7511 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.2)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4o2.zip size 148522 crc 669bc663 md5 4290b6d264b55e706c8f7b64facb3ba9 sha1 bdcf66a4630e29480780e04dec932eb2aae738fd )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5R Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4v1.zip size 148268 crc 65c11efc md5 897bbe31e7b7302b5a6b70bf1d85f308 sha1 ffd2a9098d124c0bd17cf3d40d1d9341d66dd8c0 )
-)
-
-game (
-	name "Fruit Bonus 2004 (Version 1.5LT Dual)"
-	year "2004"
-	developer "Amcoe"
-	rom ( name fb4v2.zip size 147997 crc f76426a7 md5 65fd5b2258ecfd2eafc4c13aac1154be sha1 5514c1ff09f692dbc4cb3df9a3c0997685b3f209 )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 1)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5.zip size 768770 crc 3dfc8d0a md5 426529d3cb9da4b4bf1df8127dedc977 sha1 0f26141c17ab9c1436f3d311897cb4ad81449f81 )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 2)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5c.zip size 143347 crc a14c4d73 md5 9dfe6ff9d70406caca92a2022129c3fb sha1 3123327d5c1cedbb5cc474a5c7690a91fa197397 )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH, set 3)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5d.zip size 141797 crc 3d48b6dd md5 4c672b8d373b3dfca16539e8cbc74562 sha1 1193a914ba236265f3d1669a3b790f0717883e99 )
-)
-
-game (
-	name "Fruit Bonus 2005 (Version 1.5SH Dual)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name fb5v.zip size 142742 crc d91895ee md5 eeb8fcc0eb2e53e49c859a1abb2cd584 sha1 2f2342aa62ecbd785e46f764c0822f8b00715471 )
-)
-
-game (
 	name "Fruit Bonus '06 - 10th anniversary (Version 1.7E CGA)"
 	year "2006"
 	developer "Amcoe"
@@ -16211,27 +11829,6 @@ game (
 	year "2006"
 	developer "Amcoe"
 	rom ( name fb6d2.zip size 140234 crc edee2131 md5 4cffeaea52a11b566caa7cbbcdb1f425 sha1 1bc0c85d2333af77d8e15519db1286d02c2ea264 )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.7R CGA, set 2)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s1.zip size 141268 crc 21b05e81 md5 4dd51cc4395d7246691b2be852d46350 sha1 a4304f6add804bc00f14b134552d788795d4902d )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.7LT CGA, set 2)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s2.zip size 137317 crc 84fab054 md5 3d01317f65293e25bd18ffae43e061f8 sha1 7b57a3284df7b8b0086e1fe5e14383076619965e )
-)
-
-game (
-	name "Fruit Bonus '06 - 10th anniversary (Version 1.3R CGA)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name fb6s3.zip size 141123 crc d7b05364 md5 add79ead99d94f3d8c51a66779740a84 sha1 9043a97ef68ca4fda2e10a2cfa1e93ea30d9abb6 )
 )
 
 game (
@@ -16295,48 +11892,6 @@ game (
 	year "2006"
 	developer "Amcoe"
 	rom ( name fb6v2.zip size 139918 crc 95a955f4 md5 26000919d05b4c697a62db08606399cc sha1 f822f8c510d6436c3b68a144bf5e130693dd3dc8 )
-)
-
-game (
-	name "Fisherman's Bait 2 - A Bass Challenge (GE865 VER. UAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name fbait2bc.zip size 182 crc eb05f689 md5 877d342ed83e8b5ed47766918fcacb2b sha1 1b067281d729d9961360d2bc4e0a860f6f4c10c1 )
-)
-
-game (
-	name "Fisherman's Bait - A Bass Challenge (GE765 VER. UAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name fbaitbc.zip size 182 crc 98e197e4 md5 96799b037cd5bfc129e047fae49f237b sha1 c9842005d648ffeebd8c0ce170476b70c00861ee )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. EA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmc.zip size 172 crc de91fecb md5 40d7af846d82b18aa41d5d8f28fc94a5 sha1 cefec72b9c98db93245af37ae4acac298a1de08f )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. AA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmca.zip size 172 crc 946ffcdb md5 1f6bd8d4f6ff72df30a6b021021b18a8 sha1 37900e41b5225a0a76b6804d9591813c8aeb0bc3 )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. JA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmcj.zip size 172 crc 1a7f9709 md5 a21726d4a3ed85caef231f5bc8f46763 sha1 864aa7626b505e3d0f13a0191ec27383fe5a479c )
-)
-
-game (
-	name "Fisherman's Bait - Marlin Challenge (GX889 VER. UA)"
-	year "1999"
-	developer "Konami"
-	rom ( name fbaitmcu.zip size 172 crc e520b1cb md5 d52d29237317fa962379e66824cd406b sha1 87e70017761c051c4b9e4a5822cca69cc63d73f2 )
 )
 
 game (
@@ -16417,24 +11972,10 @@ game (
 )
 
 game (
-	name "Field Combat"
-	year "1985"
-	developer "Jaleco"
-	rom ( name fcombat.zip size 56111 crc dbcaa410 md5 4e70334d87fdd4c768f73764d6462a73 sha1 8a3842cb17ba00547c210a57471b871a87c86195 )
-)
-
-game (
 	name "Final Crash (bootleg of Final Fight)"
 	year "1990"
 	developer "bootleg (Playmark)"
 	rom ( name fcrash.zip size 1321060 crc 16013c4e md5 4cbc0ae75a0d44779c628ba485179378 sha1 fad882a575f26c3b0b668a898bf2f804eaff9dda )
-)
-
-game (
-	name "Fenix (bootleg of Phoenix)"
-	year "1980"
-	developer "bootleg"
-	rom ( name fenix.zip size 12740 crc 6d550916 md5 a36504ed06017fb48b74863a6f8ddd67 sha1 d0e10e65a7ef0b9a2ccc88d476a73eab39304801 )
 )
 
 game (
@@ -16466,13 +12007,6 @@ game (
 )
 
 game (
-	name "Fighting Fantasy (bootleg with 68705)"
-	year "1989"
-	developer "bootleg"
-	rom ( name ffantasybl.zip size 204614 crc a96b9d9b md5 32f44401c810001173d93d4dc62fce04 sha1 788eb9be6113dd40d0d13585d20661c40aa4c741 )
-)
-
-game (
 	name "Final Fight (World)"
 	year "1989"
 	developer "Capcom"
@@ -16484,34 +12018,6 @@ game (
 	year "1996"
 	developer "bootleg"
 	rom ( name ffight2b.zip size 821200 crc 4f1a17ed md5 931e69deb648746c9777190e46c21408 sha1 02a896e821e6812d5a5c9ef6c8bc62d128dd9787 )
-)
-
-game (
-	name "Final Fight (Japan)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj.zip size 1073054 crc c5b0380f md5 8bf50535792545c67f614633ff680162 sha1 e6d2180ad6c703c04c7bb39e376c264917b8a92c )
-)
-
-game (
-	name "Final Fight (Japan 900112)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj1.zip size 1210211 crc 96e03151 md5 fe36c2d9a4dfb25e444c5a497bf18252 sha1 0a795638e7a70245d441c9edeb53040cdaed5b83 )
-)
-
-game (
-	name "Final Fight (Japan 900305)"
-	year "1989"
-	developer "Capcom"
-	rom ( name ffightj2.zip size 1210353 crc 22147444 md5 3afc783231bd49c9a3aba25f7c898eec sha1 b6482a2eafe1b4ff98fc8004ef914fe5558de20d )
-)
-
-game (
-	name "Street Smart / Final Fight (Japan, hack)"
-	year "1989"
-	developer "bootleg"
-	rom ( name ffightjh.zip size 1169235 crc 4cefb840 md5 30c97d5229a96e5d35b418b2db10e63c sha1 3fa2a28600102482f3bb0dbb0ab09c8fc930b380 )
 )
 
 game (
@@ -16543,13 +12049,6 @@ game (
 )
 
 game (
-	name "Final Fight Revenge (JUET 990714 V1.000)"
-	year "1999"
-	developer "Capcom"
-	rom ( name ffreveng.zip size 15337532 crc cc0f7ac4 md5 2129fb848aeb97659850a4e7cf3366f9 sha1 89afba1fd57b65af9341a93b3f3c91cc14166b19 )
-)
-
-game (
 	name "Fighter _ Attacker (US)"
 	year "1992"
 	developer "Namco"
@@ -16561,55 +12060,6 @@ game (
 	year "1984"
 	developer "Paradise Co. Ltd."
 	rom ( name fghtbskt.zip size 67905 crc 152bf84e md5 31f5d54dd3b65887d1f3f91d1234ecf8 sha1 ab1c87555aad0f541fb0ad5945cc28e885543d75 )
-)
-
-game (
-	name "Fighter's History (World ver 43-07)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthist.zip size 5649743 crc 7accf751 md5 fde7de3ddc1f01c01b49619d64ca2551 sha1 13e97cc5fa36c3bfde56377b0d02de8196d97d87 )
-)
-
-game (
-	name "Fighter's History (US ver 42-05, alternate hardware )"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthista.zip size 437701 crc 8cc3e286 md5 efb471db10ba54e4578ac19830428272 sha1 c375a05ad8afba46dd8a47b6b4b940604b4cd071 )
-)
-
-game (
-	name "Fighter's History (Japan ver 42-03)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthistj.zip size 437749 crc cf5b4629 md5 b44769ed4040da2b92dda19f2af60576 sha1 e2205dbceb6a186106f8240dbbb5404f46b22854 )
-)
-
-game (
-	name "Fighter's History (US ver 42-03)"
-	year "1993"
-	developer "Data East Corporation"
-	rom ( name fghthistu.zip size 437749 crc 36295639 md5 b42f9117c8708ad5024ac0849b1c3e3f sha1 ef97443fcbd5384c2821ed5e485e5dcff5e0faff )
-)
-
-game (
-	name "Capcom Fighting Jam (JAM1 Ver. A)"
-	year "2004"
-	developer "Capcom / Namco"
-	rom ( name fghtjam.zip size 1149067 crc f8b036e0 md5 41a57f7de1bc050118e7256f0cf7c1f6 sha1 d8557b7b10d358a2b453044f7fca47ff942e4a8e )
-)
-
-game (
-	name "Field Goal"
-	year "1979"
-	developer "Taito"
-	rom ( name fgoal.zip size 8256 crc 672b0b3b md5 2436dbfd1c848aec181a0ce6db45d2c5 sha1 fe869fa220736c1479fa82364e0191407cde7eec )
-)
-
-game (
-	name "Field Goal (different)"
-	year "1979"
-	developer "Taito"
-	rom ( name fgoala.zip size 8447 crc e8765599 md5 7a1b848af8d9b390c84def5f1c6277c6 sha1 72c23f0ac07a5d1d5519890e0f440e212dda0b28 )
 )
 
 game (
@@ -16634,20 +12084,6 @@ game (
 )
 
 game (
-	name "Funky Head Boxers (JUETBKAL 951218 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name fhboxers.zip size 19667759 crc 2842de81 md5 37a305aa6d14206475a7f92607a9ecf6 sha1 5c9e2a49f035601b888c93bd0a30adbec55b6395 )
-)
-
-game (
-	name "Field Day"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
-)
-
-game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
@@ -16666,48 +12102,6 @@ game (
 	year "1983"
 	developer "Kaneko (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
-)
-
-game (
-	name "Filetto (v1.05 901009)"
-	year "1990"
-	developer "Novarmatic"
-	rom ( name filetto.zip size 291514 crc afcc3fd7 md5 8262db6e8817ee8fc4d5997f5f1ad51a sha1 4262a87aa9d272ff62e69da82a31f1d89cfd7c72 )
-)
-
-game (
-	name "Final Lap 2"
-	year "1990"
-	developer "Namco"
-	rom ( name finalap2.zip size 2006181 crc 266ca1dc md5 9075a2bca031d30d25c145abac56c41e sha1 12ac372e776bfe55e151bd8541e657bfb4bcddcb )
-)
-
-game (
-	name "Final Lap 2 (Japan)"
-	year "1990"
-	developer "Namco"
-	rom ( name finalap2j.zip size 39058 crc e86090ce md5 12e5b050c559d200ada8ca3a6f521756 sha1 0fc768b1fc3ae492dd0b79eb39664ff2d29a95fb )
-)
-
-game (
-	name "Final Lap 3 (World, set 1)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3.zip size 2408440 crc ea0e0096 md5 bbf03f16da3d4f7363c0f5574def9a48 sha1 e5926ce1b4534366979b027e78b6cfddf29c8fe0 )
-)
-
-game (
-	name "Final Lap 3 (World, set 2)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3a.zip size 65953 crc 940a10e9 md5 8c58f5d602f84ee9c4782bbcb4f3bed2 sha1 941b35ddbfc5ceae9fea419ed4a139a33f2e8910 )
-)
-
-game (
-	name "Final Lap 3 (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name finalap3j.zip size 130083 crc c024e4be md5 f225208c62ff110257bc790eb003bf0e sha1 25216270653b668c7656af0bbc21b697fcb687cf )
 )
 
 game (
@@ -16767,66 +12161,10 @@ game (
 )
 
 game (
-	name "Finalizer - Super Transformation"
-	year "1985"
-	developer "Konami"
-	rom ( name finalizr.zip size 81140 crc 7a771edd md5 9c01699fdd7e4f6bc3292a3bb180846a sha1 98fdd6fc516ae9ceed3a480222a66f07e657458a )
-)
-
-game (
 	name "Finalizer - Super Transformation (bootleg)"
 	year "1985"
 	developer "bootleg"
 	rom ( name finalizrb.zip size 38116 crc 620a4e38 md5 eb105ac7b76eec91c849711ec931f8b8 sha1 bfac93c20579b008d186a9c4c1a6d0438c9f412c )
-)
-
-game (
-	name "Final Lap (Rev E)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallap.zip size 1115399 crc f462a7d5 md5 74943d547b998ae2f5292cd49d8436b7 sha1 b68910a1e56d499e6f4b14deff41a4e57f48177c )
-)
-
-game (
-	name "Final Lap (Rev C)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapc.zip size 48545 crc cb7b77c7 md5 15de023e0302f817e630f667f9482f76 sha1 19a410d013473eb61cff48cc9edd3244709c8cbd )
-)
-
-game (
-	name "Final Lap (Rev D)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapd.zip size 38498 crc 86390bc7 md5 95578b155bf85e2b26b55c3f7022b8b4 sha1 eead37f0b22d6711a0cd505423147db910cc5f2f )
-)
-
-game (
-	name "Final Lap (Japan - Rev B)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapjb.zip size 94941 crc d6449da4 md5 42433d418f840ffbcbe23db6b466b3a6 sha1 6cf19be4d764a902fbc733bc5ff9d64c68ee73ed )
-)
-
-game (
-	name "Final Lap (Japan - Rev C)"
-	year "1987"
-	developer "Namco"
-	rom ( name finallapjc.zip size 38056 crc 262cc4b4 md5 cf319f8293f61064140dd213ee433894 sha1 90b2ce27d738990f1f5aa3a5f353b0d24226898f )
-)
-
-game (
-	name "Final Tetris"
-	year "1993"
-	developer "Jeil Computer System"
-	rom ( name finalttr.zip size 260189 crc 711a654f md5 2ba81ba082709f6bd5bc2bc9dee28036 sha1 f138d18df311fd311b8541680acd348a617dcbe7 )
-)
-
-game (
-	name "Find Love (J 971212 V1.000)"
-	year "1997"
-	developer "Daiki / FCF"
-	rom ( name findlove.zip size 19577251 crc 79999a28 md5 57e71d9036087beda027592bd9dc83e3 sha1 e54d25db6454304dcace5c7c91a19bdca4e40eb3 )
 )
 
 game (
@@ -16841,34 +12179,6 @@ game (
 	year "1989"
 	developer "Namco"
 	rom ( name finehour.zip size 2297433 crc 81ef74a8 md5 ed09ff75a008007cc92896464bf0ec46 sha1 13ab919d68691b5b0bcb2fdd3fae53d1f9bd3fc7 )
-)
-
-game (
-	name "Final Furlong 2 (World)"
-	year "1999"
-	developer "Namco"
-	rom ( name finfurl2.zip size 39226099 crc 75a8224e md5 8def609f6bb469e50c694a7d8bc448bc sha1 bd522d926f72249815fe61d8700b454c6ff4de79 )
-)
-
-game (
-	name "Final Furlong 2 (Japan)"
-	year "1999"
-	developer "Namco"
-	rom ( name finfurl2j.zip size 403285 crc 5ef30a86 md5 5ad458aa257a19b56793b0f0d9efdc98 sha1 db4e98cc686497606f4a0c079af6507a439adfb7 )
-)
-
-game (
-	name "Final Arch (J 950714 V1.001)"
-	year "1995"
-	developer "Sega"
-	rom ( name finlarch.zip size 9115325 crc 9de2bf13 md5 6dac2c43ab6466471a3003c8c0143471 sha1 f94c279bf979d785a3bb13dd8a64dd7e69efcd88 )
-)
-
-game (
-	name "Final Furlong (FF2 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name finlflng.zip size 32929152 crc a645460e md5 55eff8c40884720cd23ad353055d8db5 sha1 9de1e2ca71ff18fc8d56cb885dfc71bde2f23c79 )
 )
 
 game (
@@ -16914,52 +12224,10 @@ game (
 )
 
 game (
-	name "Fire One"
-	year "1979"
-	developer "Exidy"
-	rom ( name fireone.zip size 23249 crc 8a453614 md5 d122e2742eb81150bb201ee74390e721 sha1 c9c97afd680bbb89f15cff35c377b3fd6033f6de )
-)
-
-game (
-	name "Fire Shark"
-	year "1990"
-	developer "Toaplan"
-	rom ( name fireshrk.zip size 533640 crc 31b3b438 md5 6e188e233b1be78f296ff7620084e33c sha1 189548d506e1aa18d18f18958298633cdffdc8a0 )
-)
-
-game (
-	name "Fire Shark (Korea, set 1, easier)"
-	year "1990"
-	developer "Toaplan (Dooyong license)"
-	rom ( name fireshrkd.zip size 67893 crc 32ddb848 md5 79da4c0ba81b1f82b3ae203eef59b6c3 sha1 8882fc8bb487678db850af212ce29aedde44083c )
-)
-
-game (
-	name "Fire Shark (Korea, set 2, harder)"
-	year "1990"
-	developer "Toaplan (Dooyong license)"
-	rom ( name fireshrkdh.zip size 68104 crc 3f16019d md5 bab757d4620bee73d11bf01843863f04 sha1 881e49f5688cb2fdb8803349ef7afb05ddaef451 )
-)
-
-game (
-	name "Fire Trap (US)"
-	year "1986"
-	developer "Wood Place Inc. (Data East USA license)"
-	rom ( name firetrap.zip size 256265 crc d9548ab9 md5 db5088670a54b41a056407cc02e64d30 sha1 eb07d97a576a2da1657e9b8217cf6959d8feb961 )
-)
-
-game (
 	name "Fire Trap (Japan bootleg)"
 	year "1986"
 	developer "bootleg"
-	rom ( name firetrapbl.zip size 257103 crc 04c2cc9d md5 22e4c2ca2bc865bbbbd30f4a63e3a4ec sha1 55a22c188f9d2dcd841f72cd9218bf8f09215cb2 )
-)
-
-game (
-	name "Fire Trap (Japan)"
-	year "1986"
-	developer "Wood Place Inc."
-	rom ( name firetrapj.zip size 76599 crc ecd35fdf md5 286d424d3f9d4c602ea13dd513e7212e sha1 b20ec5b40565faccfe952c0e8d992bc43630a092 )
+	rom ( name firetrapbl.zip size 62520 crc e7253351 md5 b1cda7dc82359d35ee6b23e37ec1dbd3 sha1 43545b3c7aee3a6539b623331d30f3d5d40d4fcf )
 )
 
 game (
@@ -16991,16 +12259,10 @@ game (
 )
 
 game (
-	name "Fit of Fighting"
-	developer "bootleg"
-	rom ( name fitfight.zip size 3546120 crc 8e04860e md5 3ae075a6c34819573759987d2523cf70 sha1 666869a81b3646f343d76fed7a8d1780f6a3013f )
-)
-
-game (
 	name "Fitter"
 	year "1981"
 	developer "Taito Corporation"
-	rom ( name fitter.zip size 17646 crc d43e4c93 md5 d03a609086a409f60cd710feadcf9dde sha1 1eda1163938bb1702e2cca7472fee0adf54f03bb )
+	rom ( name fitter.zip size 11896 crc e61201ea md5 714dda1f8a30f2371fd07b9c88ed4a1c sha1 b66ddbf2b6f68c9e1b334bca088bb7e5b85c80a5 )
 )
 
 game (
@@ -17015,13 +12277,6 @@ game (
 	year "1995"
 	developer "Konami"
 	rom ( name fiveside.zip size 1609293 crc 182217c1 md5 81c56b22e18cbdc8a26edef431337e97 sha1 343096cc1f1c59639d1bcfb8609da8ba131ef075 )
-)
-
-game (
-	name "FixEight"
-	year "1992"
-	developer "Toaplan"
-	rom ( name fixeight.zip size 2206694 crc 2d659584 md5 f2bb97a31e97937e4e6bf2d543e35e01 sha1 9974905df0aa8d11df71022bd6ffc630bb55aeae )
 )
 
 game (
@@ -17095,13 +12350,6 @@ game (
 )
 
 game (
-	name "Battle Flip Shot"
-	year "1998"
-	developer "Visco"
-	rom ( name flipshot.zip size 2311372 crc 5fc4aca3 md5 db8be925337c96729445c8e57b8a222e sha1 8cbac7dd711094043fc7376f29c31265712ffe05 )
-)
-
-game (
 	name "Flipull (Japan)"
 	year "1989"
 	developer "Taito Corporation"
@@ -17144,13 +12392,6 @@ game (
 )
 
 game (
-	name "Flyball"
-	year "1976"
-	developer "Atari"
-	rom ( name flyball.zip size 6136 crc 7d06a106 md5 65ac530796da5bab1e8c7c2cb89e8fc2 sha1 54342bbb4a2177aef0bdfe9458d7879d056051a1 )
-)
-
-game (
 	name "Fly-Boy"
 	year "1982"
 	developer "Kaneko"
@@ -17169,13 +12410,6 @@ game (
 	year "1992"
 	developer "Dooyong"
 	rom ( name flytiger.zip size 738480 crc dfdb5b13 md5 d3ab70d6ea3f7ea6c243352a66251e31 sha1 1a85e93a3a10b8b194eb9e139119bf5cfb8d70b2 )
-)
-
-game (
-	name "Fishing Maniac 3"
-	year "2002"
-	developer "Saero Entertainment"
-	rom ( name fmaniac3.zip size 6263655 crc 0f42cccc md5 946221ba8b2daa8066a7df1f5c9cd224 sha1 465a02cf1bd8bce72f826ad2ae7a6fde5583a155 )
 )
 
 game (
@@ -17235,13 +12469,6 @@ game (
 )
 
 game (
-	name "Forgotten Worlds (USA, 88618B B-Board)"
-	year "1988"
-	developer "Capcom"
-	rom ( name forgottnu.zip size 726314 crc 20de77d0 md5 430661a5b5085e5dfed13d6cac8aec29 sha1 89201ae5b7f9db6091043ba55bbb2a85af09c09c )
-)
-
-game (
 	name "Forgotten Worlds (USA, 88621B B-Board)"
 	year "1988"
 	developer "Capcom"
@@ -17256,37 +12483,10 @@ game (
 )
 
 game (
-	name "Fortress 2 Blue Arcade (ver 1.01 / pcb ver 3.05)"
-	year "2001"
-	developer "Eolith"
-	rom ( name fort2b.zip size 7795766 crc ca67c081 md5 9ca010016ccf8a2f595aeb18d41e3968 sha1 a3b363269125cc44b72e8db3ef5e15d9af3ffa99 )
-)
-
-game (
-	name "Fortress 2 Blue Arcade (ver 1.00 / pcb ver 3.05)"
-	year "2001"
-	developer "Eolith"
-	rom ( name fort2ba.zip size 7067888 crc f700ed78 md5 46d646756df555883d4abbc387139707 sha1 c26f653f5d63548d16bedbfd3ccfb78ea0db53c1 )
-)
-
-game (
-	name "Forte Card"
-	developer "Fortex Ltd"
-	rom ( name fortecar.zip size 93547 crc 251e36fa md5 1823d14e07cb6583a1cf6c6446e1e42a sha1 1463223e1ede81500ee22b70e6a0eb9d527651a1 )
-)
-
-game (
 	name "Fortune I (PK485-S) Draw Poker"
 	year "1984"
 	developer "IGT - International Gaming Technology"
 	rom ( name fortune1.zip size 5018 crc eb9c23b4 md5 4ab3893593d0379a1c4b1bd414c90aef sha1 cd78f8acd7d6d332fc45b60a466cd7ea069b8aaa )
-)
-
-game (
-	name "Fist Of The North Star"
-	year "2005"
-	developer "Sega / Arc System Works"
-	rom ( name fotns.zip size 117663839 crc cf0a8236 md5 85ebeb3feb9640fbd8caaedd15d33b3f sha1 193eb75e469721e38749e8f57e41b396cb91d7b8 )
 )
 
 game (
@@ -17308,20 +12508,6 @@ game (
 	year "1989"
 	developer "Sega"
 	rom ( name fpoint1.zip size 49449 crc 62d3bb8e md5 f5976a73bb45171316eeff6b60f24a5e sha1 4f3e282e13425dea1f35c77168eb1d6fc5a8e90f )
-)
-
-game (
-	name "Flash Point (Japan, bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name fpointbj.zip size 124655 crc 62c32760 md5 38b8e03df333ed2982ddc7c2e8246b1a sha1 c4b01d82cab0cbaee4ad19197ed5b14c808ae832 )
-)
-
-game (
-	name "Flash Point (World, bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name fpointbl.zip size 124246 crc f88ba932 md5 44e9063636209fa8298face4ab2f9c88 sha1 42dc43978594ee320287278eb9ab94a7d97a8102 )
 )
 
 game (
@@ -17364,13 +12550,6 @@ game (
 	year "1994"
 	developer "Coastal Amusements"
 	rom ( name fredmesp.zip size 204024 crc 5f2a8782 md5 fec684ee9300b95f194381aa78c2209e sha1 237d167fe76febc3d0e4938475e1091ee783ff03 )
-)
-
-game (
-	name "Free Kick"
-	year "1987"
-	developer "Nihon System (Sega license)"
-	rom ( name freekick.zip size 38380 crc 134dddf7 md5 41038c6564c9b420f430c1871cda5a47 sha1 bab4a3bbd0994d90e7600e4c288316d544a9e065 )
 )
 
 game (
@@ -17584,13 +12763,6 @@ game (
 )
 
 game (
-	name "Flying Shark (bootleg)"
-	year "1987"
-	developer "bootleg"
-	rom ( name fsharkbt.zip size 49743 crc f4ea87d0 md5 3b779c90b7b4fcfdeca1ebb9318598c1 sha1 1382cf5afae1f9f15d53eebc68f804a87ebe54ba )
-)
-
-game (
 	name "Fighting Soccer (version 4)"
 	year "1988"
 	developer "SNK"
@@ -17630,13 +12802,6 @@ game (
 	year "1992"
 	developer "Tecmo"
 	rom ( name fstarfrcj.zip size 91733 crc 9e20e571 md5 5fe3126e3518c376795ca2fe98f99b14 sha1 db8d4e1774f8de1637a88ea9157e7c0cf6ecd0ea )
-)
-
-game (
-	name "Fun Station Spielekoffer 9 Spiele"
-	year "2000"
-	developer "ADP"
-	rom ( name fstation.zip size 578318 crc fd579ffa md5 148fd0edcbf8c128506e4e2a20a53179 sha1 cb21559ca0050cc543098239a43704f61e9e8048 )
 )
 
 game (
@@ -17682,20 +12847,6 @@ game (
 )
 
 game (
-	name "Funcube 2 (v1.1)"
-	year "2001"
-	developer "Namco"
-	rom ( name funcube2.zip size 5097030 crc a493454b md5 7deeb6d7eb1d8e7944948fd0d5616903 sha1 9a34eea6ac9071c9dcc71f57b2bd9f105842ac4b )
-)
-
-game (
-	name "Funcube 4 (v1.0)"
-	year "2001"
-	developer "Namco"
-	rom ( name funcube4.zip size 5862668 crc 09ed4549 md5 4a10b7b145775b32e101e5643de91648 sha1 7172c37a6aa2b630602ea41f2526b2a74f737a20 )
-)
-
-game (
 	name "Funky Bee"
 	year "1982"
 	developer "Orca"
@@ -17707,13 +12858,6 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name funkybeeb.zip size 5798 crc af0386f7 md5 36d778da792df165338674a23c3f463b sha1 5509e6882a6d07a326f58109014f9b1a1ac9eebb )
-)
-
-game (
-	name "The First Funky Fighter"
-	year "1993"
-	developer "Nakanihon / East Technology (Taito license)"
-	rom ( name funkyfig.zip size 4972404 crc b016ea18 md5 734a5cf4f842bef765235acd0def6fe2 sha1 73ae89381895508b639bfdf4e53af2f4890df059 )
 )
 
 game (
@@ -17731,13 +12875,6 @@ game (
 )
 
 game (
-	name "Funny Land de Luxe"
-	year "1999"
-	developer "Stella"
-	rom ( name funlddlx.zip size 707655 crc 4b8bb5f1 md5 d7eb4580d953c9994b317fd1387ba491 sha1 d1196ae84f6fb4f81a2a86c814134196bdc40610 )
-)
-
-game (
 	name "Funny Mouse"
 	year "1982"
 	developer "bootleg? (Chuo Co. Ltd)"
@@ -17748,20 +12885,6 @@ game (
 	name "Fun World Quiz (Austrian)"
 	developer "Funworld"
 	rom ( name funquiz.zip size 154615 crc 54a649e2 md5 52f12ec9ab375c2153f7d449af201894 sha1 b5e3c75426d39c566ab5510c6112ad247675ed17 )
-)
-
-game (
-	name "Fun River (set 1)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name funriver.zip size 224761 crc 2f56f7a6 md5 771d2851c0658775d6d677c92dae074c sha1 46c6a3177740cf54b13533f22ea3782ae10da32a )
-)
-
-game (
-	name "Fun River (set 2)"
-	year "2005"
-	developer "Amcoe"
-	rom ( name funriverv.zip size 225613 crc a4af7d67 md5 6a237872b62b44741ebb519c60b62c2a sha1 1e4e8d9b7cef17a322dfd3f62b45ea68b690b8d6 )
 )
 
 game (
@@ -17779,37 +12902,10 @@ game (
 )
 
 game (
-	name "Funny Strip"
-	developer "Microhard / MagicGames"
-	rom ( name funystrp.zip size 657346 crc dfc44be9 md5 9af8a96354aea827fc0a8b71c39a5083 sha1 dacce36dbee8058a5a93a157df74107312bb45fa )
-)
-
-game (
-	name "Future Flash"
-	year "1981"
-	developer "Hoei"
-	rom ( name futflash.zip size 14810 crc 7b26256d md5 6458522e4d6d3fcff59b01d0b707b1a8 sha1 de4813f3f778f9dec7442d833ed92345c61df94f )
-)
-
-game (
 	name "Future Spy (315-5061)"
 	year "1984"
 	developer "Sega"
 	rom ( name futspy.zip size 48411 crc 001f1b79 md5 ebd42eff9f42a022de62ec15b50c6d21 sha1 a097e4621e93757a79abc739cb06b41c4f7b92bb )
-)
-
-game (
-	name "Fighting Vipers (Revision D)"
-	year "1995"
-	developer "Sega"
-	rom ( name fvipers.zip size 17647257 crc 695a44d1 md5 dabcc4ed1173daba791462b899c52db1 sha1 77c51b602db642eee9760e9b8e57e6511fd6bce0 )
-)
-
-game (
-	name "Fighting Vipers 2 (Revision A)"
-	year "1998"
-	developer "Sega"
-	rom ( name fvipers2.zip size 100581207 crc ab8f0d3c md5 626c3afaaf10a3aef509f8002ae4408c sha1 dc6745f811bbf2f60dd6cf6ac2104509c583f3f0 )
 )
 
 game (
@@ -17908,12 +13004,6 @@ game (
 	year "1993"
 	developer "Fujic"
 	rom ( name gal10ren.zip size 1096332 crc 6aa461c9 md5 5cdc8b4b40d6ab7e8c20729145d89406 sha1 93d307f2bddf73bf573f71b657fa6a9516ff47e0 )
-)
-
-game (
-	name "Galaxian 3 - Theater 6 : Project Dragoon"
-	developer "Namco"
-	rom ( name gal3.zip size 2762438 crc 9d63cfab md5 7ca86e121f48e733dd4a689ee3785c2a sha1 fe537b83a4a044a8559a2f10a77918c2a1126d64 )
 )
 
 game (
@@ -18029,13 +13119,6 @@ game (
 )
 
 game (
-	name "Galaxia"
-	year "1979"
-	developer "Zaccaria"
-	rom ( name galaxia.zip size 11574 crc d389293b md5 dfdf22344f2da8e80b7160941d90c9c4 sha1 fe509d791e49215f2f4601f61f3a05202ad0f110 )
-)
-
-game (
 	name "Galaxian (Namco set 1)"
 	year "1979"
 	developer "Namco"
@@ -18085,27 +13168,6 @@ game (
 )
 
 game (
-	name "Galaxy Ranger"
-	year "1983"
-	developer "Sega"
-	rom ( name galaxyr.zip size 54752 crc 7020488e md5 af18993c6fe3dd101fe4a27b590d9921 sha1 eeba2d847b361014a9d3a9383ade6a4ab23860e2 )
-)
-
-game (
-	name "Galaxy Ranger (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name galaxyrp.zip size 20042 crc 7fa27962 md5 1f380f8f3496c53ee01edadd682186ea sha1 e2dc9a11af6c195791b990a193b87ca833e22a27 )
-)
-
-game (
-	name "Galaxy Games StarPak 2"
-	year "1998"
-	developer "Creative Electronics &amp; Software / Namco"
-	rom ( name galgame2.zip size 835222 crc 896985c5 md5 478e3de1a1e5dc0e929ea3157aad4d41 sha1 0164d662c4ac69512cc0164cb90ee9e7f244675f )
-)
-
-game (
 	name "Gals Hustler"
 	year "1997"
 	developer "ACE International"
@@ -18148,13 +13210,6 @@ game (
 )
 
 game (
-	name "Gallagher's Gallery v2.2"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name gallgall.zip size 73771 crc 960687ee md5 effc2bddffeb6ef5eef0013fff139ddd sha1 ca14768c4d44d32855f7b58eb762a1bce779fb06 )
-)
-
-game (
 	name "Gallop - Armed police Unit (Japan)"
 	year "1991"
 	developer "Irem"
@@ -18166,34 +13221,6 @@ game (
 	year "1992"
 	developer "Visco"
 	rom ( name galmedes.zip size 596989 crc 244da00e md5 70dd2a770bac650f8d9bf8effef5f519 sha1 2adb18a9244eda041e97926591b83b0c14eb67ca )
-)
-
-game (
-	name "Gals Panic II (Asia)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2.zip size 18008924 crc 7a786dc2 md5 468896b043dd290dd75567f07f4c63c5 sha1 bda64fe6ea822643a70c4918d967da5b0ee08c29 )
-)
-
-game (
-	name "Gals Panic II (German)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2g.zip size 1842234 crc 846f564c md5 dcd3c16244db5564a9491e16f3a259be sha1 b94a2cd2e6281e408eea0c54357545051b82794e )
-)
-
-game (
-	name "Gals Panic II (Japan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2j.zip size 9877794 crc 90b48424 md5 d85f33c5e7fdcbc49d0db2af01ee899c sha1 7810eee1374c8529eeee08c6ef2ad5ec312f5868 )
-)
-
-game (
-	name "Gals Panic II (Taiwan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name galpani2t.zip size 421971 crc 2181a7e8 md5 587ac49c96ce63716b0131f3e3fcb407 sha1 3a5a8bf4d984ce9142cbdc3e215c18f88920dc6c )
 )
 
 game (
@@ -18327,27 +13354,6 @@ game (
 	year "1979"
 	developer "Universal (Taito license?)"
 	rom ( name galxwarst.zip size 5323 crc 63be739e md5 cf6470876c576109dfec245e852ea938 sha1 d1ec747ffff431a577896616a3c6889a4056eb9e )
-)
-
-game (
-	name "GameCristal"
-	year "2002"
-	developer "Cristaltec"
-	rom ( name gamecstl.zip size 244009 crc 12e18a86 md5 5ad3530d842d8b21056b95e1d986917a sha1 19cff244de54c912c440e903caffcc5e7507d229 )
-)
-
-game (
-	name "The Game Paradise - Master of Shooting! / Game Tengoku - The Game Paradise"
-	year "1995"
-	developer "Jaleco"
-	rom ( name gametngk.zip size 13902738 crc fbf9eed6 md5 8c7e0ae282cb63d4dc0e8140977b81a4 sha1 8657d916ccce719dcc9442e6e7691bf6d9d6a7d5 )
-)
-
-game (
-	name "Gamshara (10021 Ver.A)"
-	year "2003"
-	developer "Mitchell"
-	rom ( name gamshara.zip size 12940855 crc 868b5cc8 md5 26e70aebe611829c91d3219ed894210d sha1 0fa67752c9c490ceda1cc8678fb254fce51388f6 )
 )
 
 game (
@@ -18491,13 +13497,6 @@ game (
 )
 
 game (
-	name "Garyo Retsuden (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name garyoret.zip size 420083 crc 22aefd95 md5 27a84c1193c4eb1e81b209ddb55b83b4 sha1 72813552144923325fa0940fa7bd2b8dc16ca219 )
-)
-
-game (
 	name "Gate of Doom (US revision 4)"
 	year "1990"
 	developer "Data East Corporation"
@@ -18565,13 +13564,6 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name gauntleg.zip size 257063 crc ac546d52 md5 a902d0a335ee8ac2ebf59a5c480f16e3 sha1 84b3e8ea1837e57241e23b045cac875cdcba4ccb )
-)
-
-game (
-	name "Gauntlet Legends (version 1.2)"
-	year "1998"
-	developer "Atari Games"
-	rom ( name gauntleg12.zip size 255583 crc 4caa14cc md5 93bcb66fd50233dd19e295b0e5827f82 sha1 403fcb9f1848dd4eadc4141aabbaa239b93cc548 )
 )
 
 game (
@@ -18729,13 +13721,6 @@ game (
 )
 
 game (
-	name "Green Beret (bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name gberetb.zip size 76289 crc 70cb8bb4 md5 0cf8ec2f2480670950581df90d108494 sha1 2f560d8d677745a723e3689ac53bad5a979babd0 )
-)
-
-game (
 	name "Global Champion (Ver 2.1A 1994/07/29)"
 	year "1994"
 	developer "Taito America Corporation"
@@ -18827,13 +13812,6 @@ game (
 )
 
 game (
-	name "Geisha (A - 05/03/01, New Zealand)"
-	year "2001"
-	developer "Aristocrat"
-	rom ( name geishanz.zip size 949883 crc 70b98d27 md5 6818d0d6a1168212b07b2898cc906338 sha1 3210fde8535e1901382ea0e8c31cb6b86855c3fd )
-)
-
-game (
 	name "Quiz Gekiretsu Scramble (Japan)"
 	year "1992"
 	developer "Face"
@@ -18859,20 +13837,6 @@ game (
 	year "1985"
 	developer "Eastern Corp."
 	rom ( name gekisou.zip size 116137 crc 7f2bb56e md5 328fe7f40da2c5309fe0972292cc05f2 sha1 5b90aaa94c941aa324e3958b9d45a6c4b3b872af )
-)
-
-game (
-	name "Gekitsui Oh (Japan)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name gekitsui.zip size 23958 crc 44d59e67 md5 ba0dec6f950c45560bb0c28b63e77336 sha1 749fa5a56eac0f593e28a88d6e7dbaa60d950ad2 )
-)
-
-game (
-	name "Gekitou Pro Yakyuu Mizushima Shinji All Stars vs. Pro Yakyuu (Rev C) (GDT-0008C)"
-	year "2003"
-	developer "Sega"
-	rom ( name gekpurya.zip size 219 crc b096fc08 md5 40ac6050a3c874be173b1bc9b26fa472 sha1 2b04110cbfce17d1b9aef82d6a6a921036cc5adb )
 )
 
 game (
@@ -18932,27 +13896,6 @@ game (
 )
 
 game (
-	name "Get Bass"
-	year "1997"
-	developer "Sega"
-	rom ( name getbass.zip size 608691 crc 99822fb6 md5 eedd401af72937f5effe6f20ea42185c sha1 c245889559dd4d80aaf28d08e7bd6d45adf3f146 )
-)
-
-game (
-	name "Guardian (US)"
-	year "1986"
-	developer "Toaplan / Taito America Corporation (Kitkorp license)"
-	rom ( name getstar.zip size 158272 crc 8c74ff48 md5 71fd94bf1d02e11d277d8c82cda0bf8c sha1 4309b5e6ae00c1fcab84117c452ad579396d5def )
-)
-
-game (
-	name "Get Star (Japan)"
-	year "1986"
-	developer "Toaplan / Taito"
-	rom ( name getstarj.zip size 39954 crc 75591042 md5 fafe307420db0d73948eae7057259a18 sha1 d9829fb00ca80f3c3e9231e01080ca3cdb769f0f )
-)
-
-game (
 	name "Golden Fire II"
 	year "1992"
 	developer "Topis Corp"
@@ -18981,41 +13924,6 @@ game (
 )
 
 game (
-	name "Go! Go! Connie chan Jaka Jaka Janken"
-	year "1996"
-	developer "Eighting"
-	rom ( name ggconnie.zip size 635546 crc 5294e4e3 md5 b1a1b0052d5d9d8dfaa26a1d8cdc122f sha1 f69e2f41112094b94f57b389392d8794fbc24025 )
-)
-
-game (
-	name "Goalie Ghost"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name gghost.zip size 33194 crc 99c97f79 md5 088130c4c4997dd2ed55cc0e7cc5e067 sha1 5b63c5e3c53cac54f965a79ca9a7aeea6c25628e )
-)
-
-game (
-	name "Guilty Gear Isuka"
-	year "2003"
-	developer "Sammy / Arc System Works"
-	rom ( name ggisuka.zip size 131961511 crc afa85b3c md5 1cc75ac9f4399917a4a6a3adaf7160d2 sha1 290629120bfb33935eae68112a50bf7bc90045fc )
-)
-
-game (
-	name "Giant Gram (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name ggram2.zip size 50483747 crc fbdfc186 md5 445adf6efb65f6d8980322ec5c4ab34d sha1 d6c939d803cf8af5ee8f21ed7128ac1aef77dd23 )
-)
-
-game (
-	name "Golfing Greats 2 (ver JAC)"
-	year "1994"
-	developer "Konami"
-	rom ( name ggreats2.zip size 317941 crc 5b88827d md5 ea97a87b6925b6f554f776e221835e2d sha1 8ed901ec4555fdd647b2e3e2f16bb3a8ff22cc37 )
-)
-
-game (
 	name "Gain Ground (World, 3 Players, Floppy Based, FD1094 317-0058-03d Rev A)"
 	year "1988"
 	developer "Sega"
@@ -19027,41 +13935,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name ggroundj.zip size 681013 crc 62063502 md5 4fc5ed690733a4df821302f789351755 sha1 f8871ee2a3804f929f9a28a2855f0d17158fc86b )
-)
-
-game (
-	name "Guilty Gear X (JPN)"
-	year "2000"
-	developer "Arc System Works"
-	rom ( name ggx.zip size 84546325 crc fff51674 md5 8b0c7dd7621694239af220a7d93c6b5f sha1 b2021dd4347177c07fe0012a216b5c043138a4f5 )
-)
-
-game (
-	name "Guilty Gear XX (GDL-0011)"
-	year "2002"
-	developer "Arc System Works"
-	rom ( name ggxx.zip size 1192 crc 931e87bf md5 522868038259a50a51b04b43109e7e25 sha1 def565849f0cb12792ac890349da0b72252b2d0a )
-)
-
-game (
-	name "Guilty Gear XX Accent Core (GDL-0041)"
-	year "2006"
-	developer "Arc System Works"
-	rom ( name ggxxac.zip size 1195 crc 68335cb1 md5 d82ff5b126363e503abd90ee2bc5b3f4 sha1 09cd22881ee28ecca767e63cb2f7d81bcc8a1fad )
-)
-
-game (
-	name "Guilty Gear XX #Reload (Rev A) (GDL-0019A)"
-	year "2003"
-	developer "Arc System Works"
-	rom ( name ggxxrl.zip size 1194 crc 5637e092 md5 732587e913d0438fdb8ef73a61437f33 sha1 7f864c3a3dbfa4f18bdc69d06b68d5598364cb95 )
-)
-
-game (
-	name "Guilty Gear XX Slash (Rev A) (GDL-0033A)"
-	year "2005"
-	developer "Arc System Works"
-	rom ( name ggxxsla.zip size 1196 crc f62cd712 md5 fb381ae46278c1625df74bd0850bc4dc sha1 5a21016cd49be7d8d0ee4369e17ab46d5bdaa2b7 )
 )
 
 game (
@@ -19079,31 +13952,10 @@ game (
 )
 
 game (
-	name "The Real Ghostbusters (US 2 Players)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name ghostb.zip size 417053 crc 2849223a md5 a68b9f4ca9df383a768c76be62886a67 sha1 29044ed4f740097646e64243ecb2b02982aa42ed )
-)
-
-game (
-	name "The Real Ghostbusters (US 3 Players)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name ghostb3.zip size 63753 crc e21e11d4 md5 3f3f60fe7abc3dd00328e718ec9ef3bb sha1 cf7ba7357ba0470b7f864a3ae04e7db842c9811b )
-)
-
-game (
 	name "Ghostlop (prototype)"
 	year "1996"
 	developer "Data East Corporation"
 	rom ( name ghostlop.zip size 3298603 crc 42dbbfb8 md5 a8f817785a1a2db2d60175db3e4154df sha1 4db69eeeb330440e9102f5f441f40446847cbc74 )
-)
-
-game (
-	name "Ghost Squad (Ver. A?) (GDX-0012A)"
-	year "2005"
-	developer "Sega"
-	rom ( name ghostsqu.zip size 219 crc 059a49b7 md5 9472612fd9b3076805ff8686e54d7bdb sha1 a158f371174c63fe207e8b81d01b904b0a14c163 )
 )
 
 game (
@@ -19121,31 +13973,10 @@ game (
 )
 
 game (
-	name "Ghox (Spinner with Up/Down Axis)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name ghox.zip size 523946 crc 8fbc77e6 md5 8199a811cc193d584164c36cd5a717d9 sha1 90f5cae45489ac8da1f9dfeea3588e7c1f1ec58b )
-)
-
-game (
-	name "Ghox (8-Way Joystick)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name ghoxj.zip size 74805 crc 1f79c951 md5 f24f3baecce6d6e014d0d490923841e1 sha1 c8205e25c46395faf6c35f97db104a7e0d7dbece )
-)
-
-game (
 	name "Gang Hunter (Spain)"
 	year "1988"
 	developer "Seibu Kaihatsu (Segasa/Sonic license)"
 	rom ( name ghunter.zip size 115708 crc e0982361 md5 a29c6c021d42ab90dcb719c07b68faf2 sha1 117fa645678e9e4fac57d2154a8f16aed80d8769 )
-)
-
-game (
-	name "Giga Man 2: The Power Fighters (bootleg of Mega Man 2: The Power Fighters)"
-	year "1996"
-	developer "bootleg"
-	rom ( name gigamn2.zip size 1446805 crc 6c76ce89 md5 b1ad339f7f8de373804bceaa48c1b1a7 sha1 c05ea97e7039e78e21b068fab19c5a8396793e19 )
 )
 
 game (
@@ -19160,13 +13991,6 @@ game (
 	year "1989"
 	developer "East Technology"
 	rom ( name gigandesj.zip size 104477 crc c0e92291 md5 74549ae5444b85c742adadb2d30c96ee sha1 c86641626766463b39fb3c8ed01c4f619d1ea13a )
-)
-
-game (
-	name "Gigas (MC-8123, 317-5002)"
-	year "1986"
-	developer "Sega"
-	rom ( name gigas.zip size 58569 crc e88b39b1 md5 da9089957a72118ded8340a97900bd42 sha1 edcc5e32b5325a4e8a158d804e489f4cb27de2fa )
 )
 
 game (
@@ -19240,13 +14064,6 @@ game (
 )
 
 game (
-	name "Gimme A Break"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name gimeabrk.zip size 38709 crc 2265ae16 md5 a16efce0fed1866fbfe3b5fb1e3f37ce sha1 7675fb25d7988f2b60373b021eae6534b38fd300 )
-)
-
-game (
 	name "Ginga NinkyouDen (set 1)"
 	year "1987"
 	developer "Jaleco"
@@ -19282,13 +14099,6 @@ game (
 )
 
 game (
-	name "Gekitoride-Jong Space (10011 Ver.A)"
-	year "2001"
-	developer "Namco / Metro"
-	rom ( name gjspace.zip size 49271011 crc 56fb1fb7 md5 86a669183eb82ce891787281edc77c37 sha1 a96db4299481ca4ca409a05cb40575b544e6badd )
-)
-
-game (
 	name "Gladiator (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -19296,45 +14106,10 @@ game (
 )
 
 game (
-	name "Glass (Ver 1.1)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glass.zip size 3310646 crc 28b32237 md5 e949b302874442c3c8969a2315781315 sha1 cb79ceae423015ddd2ba88924a49f5e4b203dacf )
-)
-
-game (
-	name "Glass (Ver 1.0)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glass10.zip size 267577 crc 7d57b051 md5 99d40844d0b2528ebf1a21418c7c1a78 sha1 b4e38d9902e7ab73f5e63c8596762f9202785f69 )
-)
-
-game (
-	name "Glass (Ver 1.0, Break Edition)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name glassbrk.zip size 295323 crc 08089bc6 md5 859fd8b66ff743312bb5c9888bd6dea5 sha1 aabd14903eb6b425ad3fa6f6ccc981284979cb58 )
-)
-
-game (
 	name "Golden Crown (Dutch, Game Card 95-752-011)"
 	year "1997"
 	developer "BFM/ELAM"
 	rom ( name gldncrwn.zip size 198254 crc 3ea7bb9d md5 cfe44fab492973ff5bedd8d888c622a8 sha1 8eb0a9ea02a81344584378d4b62c460e882729a7 )
-)
-
-game (
-	name "Golfing Greats"
-	year "1991"
-	developer "Konami"
-	rom ( name glfgreat.zip size 2437668 crc 1d06e0a8 md5 e4a0cf6c63d9d3594d339aa4c3f995bf sha1 3aa1cb9ba3cc911e7807636a21bbc441997b7cb3 )
-)
-
-game (
-	name "Golfing Greats (Japan)"
-	year "1991"
-	developer "Konami"
-	rom ( name glfgreatj.zip size 98974 crc 290a5eee md5 0d87240f32bf8c3273bcc36e55a558fe sha1 23c5b48d313ed52475d75ccc8c61d87d90c5c032 )
 )
 
 game (
@@ -19356,27 +14131,6 @@ game (
 	year "1996"
 	developer "Tecmo"
 	rom ( name glpracr.zip size 4359857 crc 35b92c22 md5 d94b389de6308576d50311b578cb5718 sha1 fe51da0217c696b0104a60d28c8be996f0aef83f )
-)
-
-game (
-	name "Gallop Racer 2 (USA)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2.zip size 11707336 crc f0da933e md5 7eedd9da110a9d997786f77a709b3c6f sha1 67ce2d223ec20ec09ca0802fb65e09542d7b784f )
-)
-
-game (
-	name "Gallop Racer 2 (Japan)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2j.zip size 669013 crc 5b4a51db md5 282f94cc1db28356aedac1234b73f058 sha1 6d4e51c494cb3b95790fdf281b286517e059c822 )
-)
-
-game (
-	name "Gallop Racer 2 Link HW (Japan)"
-	year "1997"
-	developer "Tecmo"
-	rom ( name glpracr2l.zip size 670567 crc 7d7a5eac md5 fead480ccd5f24007864066cad6063a8 sha1 8104448e5c8d8b661a6e645c4a00a722c3fe0f83 )
 )
 
 game (
@@ -19471,24 +14225,10 @@ game (
 )
 
 game (
-	name "Goal To Go"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name goaltogo.zip size 21716 crc 0e20e9a7 md5 50525cc9d666baa7e607eb412326a5df sha1 61e8d94097073c26145fa80f77dd43b52da9a0d8 )
-)
-
-game (
 	name "Goal! Goal! Goal!"
 	year "1995"
 	developer "Visco"
 	rom ( name goalx3.zip size 4881268 crc bfee618c md5 187a11c53575d4c18e9a9a5d0e0f32b2 sha1 2c55048e25a5b473adb5697cf48fee7c266d28c4 )
-)
-
-game (
-	name "Godzilla"
-	year "1993"
-	developer "Banpresto"
-	rom ( name godzilla.zip size 2667535 crc a34d6576 md5 49ab6051dd2ff933d82b4ed91763d9a9 sha1 cfad89125c1286e0cde1d4d696e7cda1ca1e8bb0 )
 )
 
 game (
@@ -19510,27 +14250,6 @@ game (
 	year "1995"
 	developer "Fuuki"
 	rom ( name gogomilej.zip size 155508 crc a2a72dbf md5 e5b464e9c5a03045e0014de06a027823 sha1 5da9e7ee53cac9602813852ecfd4f8c3c742bdc7 )
-)
-
-game (
-	name "Goindol (World)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindol.zip size 103720 crc 88e89ce6 md5 e7d6297f640017101f75f8c776983562 sha1 5a39346414803560e5a905ab92fdc3d3c3830ff0 )
-)
-
-game (
-	name "Goindol (Korea)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindolk.zip size 21250 crc 18226c6c md5 fd371c054ff5050b5ba643a5c66922f4 sha1 8242be6d60421c70646728f92e9a1ad6c373fb5c )
-)
-
-game (
-	name "Goindol (US)"
-	year "1987"
-	developer "SunA"
-	rom ( name goindolu.zip size 21247 crc 6272a87c md5 16340ca2c7f6ea3b37fc1be0a981935c sha1 452b7646600f4e7b8f1632e8fd38aad1edf18e1d )
 )
 
 game (
@@ -19569,20 +14288,6 @@ game (
 )
 
 game (
-	name "Gold Medalist (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name goldmedlb.zip size 85532 crc 00538629 md5 e76871cb6ddf2015c6e33cb2b23bd854 sha1 739ee79bc627bc162e65662a56b4a44004f02506 )
-)
-
-game (
-	name "Golden Axe (set 6, US, 8751 317-123A)"
-	year "1989"
-	developer "Sega"
-	rom ( name goldnaxe.zip size 1162622 crc 0613beb6 md5 90a88e501fe0eb52df0061cf3e5bd220 sha1 5d0a09d15498d2e302a44fc119710413658f409d )
-)
-
-game (
 	name "Golden Axe (set 1, World, FD1094 317-0110)"
 	year "1989"
 	developer "Sega"
@@ -19590,31 +14295,10 @@ game (
 )
 
 game (
-	name "Golden Axe (set 2, US, 8751 317-0112)"
-	year "1989"
-	developer "Sega"
-	rom ( name goldnaxe2.zip size 177465 crc 9a3039bb md5 9424de9df9b5ac73777f84683743cf14 sha1 a031abfcecc1e3882b69a88c8c0fd22966302538 )
-)
-
-game (
 	name "Golden Axe (set 3, World, FD1094 317-0120)"
 	year "1989"
 	developer "Sega"
 	rom ( name goldnaxe3.zip size 277640 crc 3b8776f7 md5 6e4a68ebf478aec38cb6155adeb79189 sha1 7beff6d0a2064ad05713c8089a14179798675271 )
-)
-
-game (
-	name "Golden Axe (encrypted bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name goldnaxeb1.zip size 1243203 crc 6ce06730 md5 1c20942e1f2920d314827b45e0bbeda2 sha1 11b0fdeb9fd444fa52e2c4dc6bbbd83e24b47edd )
-)
-
-game (
-	name "Golden Axe (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name goldnaxeb2.zip size 1123593 crc 611c57ea md5 470f23586c3baf81156c080e5dba3f32 sha1 902d4b126ca3e7729504b20ff158e1b63e142249 )
 )
 
 game (
@@ -19643,13 +14327,6 @@ game (
 	year "1981"
 	developer "Bonanza Enterprises, Ltd"
 	rom ( name goldnpkr.zip size 13107 crc 5ff4a207 md5 766345979481458382c99ec8f0985f17 sha1 b2fb20c7f76d2c17c125ad4b1a71f6dea3b3ee25 )
-)
-
-game (
-	name "Golden Pyramids (B - 13-05-97, USA)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name goldprmd.zip size 912447 crc bf9a884b md5 efd0cbbd462bde70b45543e0a590ea22 sha1 bda6a5fdd45b9766b91a0e0f7bef2a4fc4e7a360 )
 )
 
 game (
@@ -19777,34 +14454,6 @@ game (
 )
 
 game (
-	name "Gals Panic II - Quiz Version (Japan)"
-	year "1993"
-	developer "Kaneko"
-	rom ( name gp2quiz.zip size 10351466 crc 0bb5fda1 md5 3d8ff66260c962580fdbaf82956ac0cc sha1 0eb861f46aa6c48482f36a8cd95c5955fbc376e2 )
-)
-
-game (
-	name "Gals Panic II' - Special Edition (Japan)"
-	year "1994"
-	developer "Kaneko"
-	rom ( name gp2se.zip size 10929302 crc 0c600ccc md5 8014d42fb7c1e5567ebc25e2cff9913d sha1 cf85e37fb75f70b459a86592d0a56ff7ddaa1da3 )
-)
-
-game (
-	name "Grand Prix '98"
-	year "1998"
-	developer "Romtec Co. Ltd"
-	rom ( name gp98.zip size 280148 crc b156283a md5 ac53b0d6591a1ed9c92878f742d0b658 sha1 9f36e18729356f8a11cfbfc4bf0c11f8df9389bc )
-)
-
-game (
-	name "Golden Par Golf (Joystick, V1.1)"
-	year "1992"
-	developer "Strata/Incredible Technologies"
-	rom ( name gpgolf.zip size 521879 crc e1b858cc md5 887376bf11dc63882624ca25f817c6bc sha1 fd78ce67b14dfa05493c3bc8b44cc05447755ab7 )
-)
-
-game (
 	name "Ghost Pilots (set 1)"
 	year "1991"
 	developer "SNK"
@@ -19819,24 +14468,10 @@ game (
 )
 
 game (
-	name "GP Rider (set 2, World, FD1094 317-0163)"
-	year "1990"
-	developer "Sega"
-	rom ( name gprider.zip size 1471284 crc 66887cd2 md5 287db13b4dfb4e2ae80e26fe6e773e43 sha1 fa8884d1accdf196ff967b761f83aa55357c7c33 )
-)
-
-game (
 	name "GP Rider (set 1, US, FD1094 317-0162)"
 	year "1990"
 	developer "Sega"
 	rom ( name gprider1.zip size 98496 crc 39cd7d25 md5 beb65c7d3c8a07f3229cf1c0343a234d sha1 96c52bdc03790326c9ac8ed17df0751ac9242721 )
-)
-
-game (
-	name "GP World"
-	year "1984"
-	developer "Sega"
-	rom ( name gpworld.zip size 91774 crc 72064578 md5 9a7ac7b716c07e891b3deb0533a5f08f sha1 8fc007a512a50bdb363960c8aef19fdc22e4e151 )
 )
 
 game (
@@ -19896,40 +14531,6 @@ game (
 )
 
 game (
-	name "SD Gundam Sangokushi Rainbow Tairiku Senki"
-	year "1993"
-	developer "Banpresto"
-	rom ( name grainbow.zip size 1694721 crc 093aca05 md5 e33322320674da99f99811d60660ef6c sha1 e99a33f70103d70cd931490037fe670d7132aad4 )
-)
-
-game (
-	name "Giant Gram 2000 (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name gram2000.zip size 111043462 crc 8a21c6d6 md5 aa485ac93eb078ab0981bd238fedeae8 sha1 a5678619a12d9e014678c052a2738eb2ff23dc8f )
-)
-
-game (
-	name "Grand Prix"
-	developer "4fun"
-	rom ( name grandprx.zip size 637140 crc 27bd77d4 md5 57e67e5ab9a4bdfd27ff55ed6673d03a sha1 3794a30381753f08e59ed21b43187924acb6d3fb )
-)
-
-game (
-	name "Gratia - Second Earth (92047-01 version)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name gratia.zip size 9860174 crc c943d00a md5 e6502a65cfc67d2226f2afd16c8a058e sha1 9b798fb1dd5d7b5c3ef2b23d41d868a39a8c09ab )
-)
-
-game (
-	name "Gratia - Second Earth (91022-10 version)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name gratiaa.zip size 1746388 crc 1d7e06c5 md5 e91546d3c85a7fc512dd74e86b3eb076 sha1 e7a896b18d73c415356390f67935e30e85f167e4 )
-)
-
-game (
 	name "Gravitar (version 3)"
 	year "1982"
 	developer "Atari"
@@ -19986,24 +14587,10 @@ game (
 )
 
 game (
-	name "Great Guns"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name greatgun.zip size 86041 crc 32bbd419 md5 89f9e845ca4927986299fbfd6631e3b5 sha1 0374fc5cee129d06a4cdcdf0d24bad614f2d52c6 )
-)
-
-game (
 	name "Great Gurianos (Japan?)"
 	year "1986"
 	developer "Taito Corporation"
 	rom ( name greatgur.zip size 66196 crc 30c41de1 md5 0fb95cc899a218761192bd3463ba99a9 sha1 f4cea7ad317712a2d61c85a25399b044b90b87e9 )
-)
-
-game (
-	name "Green Beret (Irem)"
-	year "1980"
-	developer "Irem"
-	rom ( name greenber.zip size 7700 crc b37016af md5 f3d1acb865f1f2b4f51a9769367f4ee9 sha1 7749331702fe6fbb38dd5890b00c724cf8e9bdfe )
 )
 
 game (
@@ -20032,20 +14619,6 @@ game (
 	year "1980"
 	developer "bootleg (Videotron)"
 	rom ( name griffon.zip size 14400 crc 6147d4e2 md5 05061e117900f717a7dea0d80549179d sha1 d072ce580e019f37344218321f7d493c8660ae84 )
-)
-
-game (
-	name "Grind Stormer"
-	year "1992"
-	developer "Toaplan"
-	rom ( name grindstm.zip size 153041 crc b0cc4356 md5 317ca736738924650e3b5ba57e9b7631 sha1 05b7c63aefe727b8b2787505970913a84db08afb )
-)
-
-game (
-	name "Grind Stormer (older set)"
-	year "1992"
-	developer "Toaplan"
-	rom ( name grindstma.zip size 153062 crc e7398300 md5 6823ce3f72d11f712ab436720254a56f sha1 5ff36a1016712f339d4b4593a5a6602b77ae7167 )
 )
 
 game (
@@ -20109,33 +14682,6 @@ game (
 	year "1990"
 	developer "Taito America Corporation"
 	rom ( name growlu.zip size 62557 crc 2a648307 md5 ec656f82826032e110f423ecf69f7d25 sha1 bf30e058f129a16a242396368d51d8c721fbfd84 )
-)
-
-game (
-	name "Gran Tesoro? / Play 2000 (v5.01) (Italy)"
-	year "1999"
-	developer "Nova Desitec"
-	rom ( name grtesoro.zip size 910002 crc 51119acc md5 0d1f717611e1cde95f53e4b3f4bfbe4b sha1 48f8429ae7803ca91fc0edd3fb5047b7cfa4cae2 )
-)
-
-game (
-	name "Grudge Match (prototype)"
-	developer "Bally Midway"
-	rom ( name grudge.zip size 55828 crc f434bea0 md5 368c9d50d62fda8c2164d29f023ad4f5 sha1 b16729f20c2e821d37aef06c6fe2d6f7fee559ec )
-)
-
-game (
-	name "Gryzor (Set 1)"
-	year "1987"
-	developer "Konami"
-	rom ( name gryzor.zip size 60209 crc c2c44590 md5 4613133eb5b7b1f5aeed48f74fedd05a sha1 006f19b29597d7eb9a11c0329e4d785138d968fd )
-)
-
-game (
-	name "Gryzor (Set 2)"
-	year "1987"
-	developer "Konami"
-	rom ( name gryzora.zip size 60103 crc a3cc544b md5 a6b39a03cd4fb3e43a2b661d1d87ab42 sha1 a1d24eb9c212d1bec3a624915193c0d8c2dffbfe )
 )
 
 game (
@@ -20227,20 +14773,6 @@ game (
 	year "1993"
 	developer "Human"
 	rom ( name gstrikera.zip size 330936 crc 2ac2b9a4 md5 7078c967cfbc16f3530d895b69ecea6b sha1 dbd9157182d038714de1954176923ca87bec1c2f )
-)
-
-game (
-	name "Great Swordsman (World?)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name gsword.zip size 68856 crc 1aad9299 md5 7f99c589cbb50842257f9611b876203a sha1 e9cd6383ea303ad03308b647350453d4e67aa04a )
-)
-
-game (
-	name "Great Swordsman (Japan?)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name gsword2.zip size 36596 crc 2a7b2600 md5 29eef239319341baa3193d370c24c1ee sha1 2994b6b95463299a48d928ef14a0b14f142d6651 )
 )
 
 game (
@@ -20538,31 +15070,10 @@ game (
 )
 
 game (
-	name "Guitar Freaks 11th Mix (G*D39 VER. JAA)"
-	year "2004"
-	developer "Konami"
-	rom ( name gtfrk11m.zip size 315 crc 50f4b46f md5 4b8081bf7140ff6649c18d4d038fa612 sha1 1409621265db60cb2f0e988e6112d4d9b4effdf3 )
-)
-
-game (
-	name "Guitar Freaks 3rd Mix - security cassette versionup (949JAZ02)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtfrk3mb.zip size 223 crc 8dd21c91 md5 a4128608d30f9f0369e07c95db73153a sha1 ba9604adaedb537b68aed4eed4f86fcbe7c64a30 )
-)
-
-game (
 	name "Golden Tee Golf (Joystick, v3.1)"
 	year "1990"
 	developer "Strata/Incredible Technologies"
 	rom ( name gtg.zip size 501879 crc 1c92715b md5 cb2289b7e9e18502e21c842d09aa9c0a sha1 cd0ef8833ba2da101302400a5dcfea6825aca57f )
-)
-
-game (
-	name "Golden Tee Golf II (Trackball, V2.2)"
-	year "1992"
-	developer "Strata/Incredible Technologies"
-	rom ( name gtg2.zip size 522599 crc efd34213 md5 bdbf392ab3e4e974124333e8224cfbd1 sha1 68393ea856bbb7514fb99ad15c1cfa4f9929c47b )
 )
 
 game (
@@ -20584,48 +15095,6 @@ game (
 	year "1989"
 	developer "Strata/Incredible Technologies"
 	rom ( name gtgt.zip size 173140 crc ad650ca9 md5 4c99e0ad92d5dcca77dd7e090745a502 sha1 ea29057d658037c6249c07257375ff63ea8ecf54 )
-)
-
-game (
-	name "GTI Club (ver EAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticlub.zip size 11884819 crc 82e94abb md5 c9de873522f1b784196f217f4cc77558 sha1 b5de264b566de6d526ced9f38016495e5988b1ca )
-)
-
-game (
-	name "GTI Club 2 (ver JAB)"
-	year "2001"
-	developer "Konami"
-	rom ( name gticlub2.zip size 13262 crc 895eb650 md5 0c0a09058fe28de45f6965f0dbe8164a sha1 f7c917bbe58c3e6d4fc203248dcd204ce9d52eb5 )
-)
-
-game (
-	name "GTI Club 2 (ver EAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gticlub2ea.zip size 7212 crc 7df2e4bf md5 3bdd679ff650b8b7c6df9c7a443e8b17 sha1 43cbccb0d5133b0b92a88559d7611bab6634766a )
-)
-
-game (
-	name "GTI Club (ver AAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticluba.zip size 572992 crc 63c04044 md5 9440011fefad90fffd7827d573fd4fb1 sha1 63fecd5929eeecf6fafe087c80e82ebebe82560f )
-)
-
-game (
-	name "GTI Club (ver JAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name gticlubj.zip size 572572 crc 436b1f2c md5 23e3d087c0f32b96d7574db73bf4ea9e sha1 ac03509100b7e4aafa1fe8e508e260a1e4819c40 )
-)
-
-game (
-	name "GTI Poker"
-	year "1983"
-	developer "GTI Inc"
-	rom ( name gtipoker.zip size 5323 crc 8361f805 md5 0cb0730f47f0863c7b60dc4ddbf9f29d sha1 e4867da9f9bd3c0c24c9cb3a0bd5732b29fa86f7 )
 )
 
 game (
@@ -20675,76 +15144,6 @@ game (
 	year "1994"
 	developer "Kaneko"
 	rom ( name gtmrusa.zip size 1901378 crc aeabc738 md5 f6e98feb9159bec493887c326639386f sha1 b5ec0c576afdc5d09047461acdc0c597630df234 )
-)
-
-game (
-	name "Guitar Freaks 2nd Mix Ver 1.01 (GQ883 VER. JAD)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrk2m.zip size 285 crc 2382f279 md5 f064c5d8f40fb74fae823217321c2828 sha1 feead139ff366a2eee2161350061435a964f88d2 )
-)
-
-game (
-	name "Guitar Freaks 3rd Mix (GE949 VER. JAC)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtrfrk3m.zip size 564 crc e2eb336a md5 b5ad24352b25cbbc17e2c4e1b49eadfe sha1 163b64063145c2819a3ea2f81c4e4e8d0bf87e9a )
-)
-
-game (
-	name "Guitar Freaks 4th Mix (G*A24 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name gtrfrk4m.zip size 546 crc d6eb118c md5 d5d1153299e0e34af8a53b91fe174e24 sha1 a828515de37cc7ad6a0db2764e5bf670cb3bc4be )
-)
-
-game (
-	name "Guitar Freaks 5th Mix (G*A26 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk5m.zip size 4635 crc 86334513 md5 6361350d558d783704fc4aefb72f7563 sha1 e6a9c066aabe69e417b261b7a401cafb39f080af )
-)
-
-game (
-	name "Guitar Freaks 6th Mix (G*B06 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk6m.zip size 314 crc 8db94dc1 md5 5e4d6f7c4bfb03c9894762cafcc5a8d8 sha1 8c78ddddba2198e606042b5f9ec542a6ffa40a0c )
-)
-
-game (
-	name "Guitar Freaks 7th Mix (G*B17 VER. JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name gtrfrk7m.zip size 4638 crc 670c88a1 md5 4aaceda17981c32061b10bc4fb9cc975 sha1 d4ebbe552f0ccde40225d59caaa4df696b430e10 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. EAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrks.zip size 173 crc 1b5d831a md5 95ab51c7b4f8334131b9e4355d0e94cb sha1 6fec3d5630d123882d2b0d3f03e3929f00b9218f )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. AAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksa.zip size 173 crc c3dec7de md5 5759fbc8c387d69e81f34080c8e6b893 sha1 ded610f9268e82826aa27fd4a51d13856cb57884 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. JAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksj.zip size 173 crc 1963f21a md5 ca8ee2971ed51775510131ca59086b76 sha1 6bd51d572e17e21fb0f1ac44371bb6785dd44506 )
-)
-
-game (
-	name "Guitar Freaks (GQ886 VER. UAC)"
-	year "1999"
-	developer "Konami"
-	rom ( name gtrfrksu.zip size 173 crc 1388324e md5 bbc10181f48d999dc5c75c4bc04d1c6a sha1 b11b9abef61705c5634900ac92f6a225104db553 )
 )
 
 game (
@@ -20916,13 +15315,6 @@ game (
 )
 
 game (
-	name "Guardians of the 'Hood"
-	year "1992"
-	developer "Atari Games"
-	rom ( name guardian.zip size 5584191 crc c9ae8a53 md5 7131f12c328660c2c43bad2d5c9ddf83 sha1 6ade59762108675864fdd632c68c0cdc4a5c32ea )
-)
-
-game (
 	name "The Guiness (Japan)"
 	year "1984"
 	developer "Sun Electronics"
@@ -20993,13 +15385,6 @@ game (
 )
 
 game (
-	name "Gunblade NY (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name gunblade.zip size 16991992 crc 0c048e8f md5 620d12b88c18903f7e6267abbad0bcd7 sha1 eec308bf3a3ec65d9f6e20fb3884af67a7feefb7 )
-)
-
-game (
 	name "Gun Bullet (Japan, GN1)"
 	year "1994"
 	developer "Namco"
@@ -21025,13 +15410,6 @@ game (
 	year "1994"
 	developer "Banpresto"
 	rom ( name gundamex.zip size 7383197 crc 90b902f8 md5 f8caea020e4418377aaa3e44ad9fe7fe sha1 6b9f2a260e4bee7ab0bed33df292ed69f4db1a7f )
-)
-
-game (
-	name "Gundam Battle Operating Simulator (GDX-0013)"
-	year "2005"
-	developer "Sega"
-	rom ( name gundamos.zip size 211 crc 6ff78f9f md5 d4232079e54d68388d13c207107302da sha1 833800f5303e53c7697c9f4446b09f97e4ebe597 )
 )
 
 game (
@@ -21066,20 +15444,6 @@ game (
 	year "1994"
 	developer "Dooyong"
 	rom ( name gundl94.zip size 524628 crc 287219ba md5 40c57ad5419ed1181f63f8a68a907f69 sha1 f47c55101f0c596ba144dd6795e8f0f67e9ce72b )
-)
-
-game (
-	name "Mobile Suit Gundam: Federation VS Zeon (GDL-0001)"
-	year "2001"
-	developer "Capcom"
-	rom ( name gundmgd.zip size 1195 crc 5a6900eb md5 cbe9cfd6d01f258e2e8193a045e4704b sha1 391d8e13f1720ea62a034123ec28dc617a978390 )
-)
-
-game (
-	name "Mobile Suit Gundam: Federation VS Zeon DX  (GDL-0006)"
-	year "2001"
-	developer "Capcom"
-	rom ( name gundmxgd.zip size 1195 crc bf64f74f md5 2301c250d64bf9d2944c5d0fbb49915a sha1 d9e1fd2d46328b7b6d5bb0caa8d40411fc7b0d16 )
 )
 
 game (
@@ -21160,13 +15524,6 @@ game (
 )
 
 game (
-	name "Gunpey"
-	year "2000"
-	developer "Banpresto"
-	rom ( name gunpey.zip size 3918523 crc c6e94c5d md5 84f02fc3c45630a74c35afa899883f08 sha1 838e9266285d8fc13b6fb0894f87677622526379 )
-)
-
-game (
 	name "Gun.Smoke (World)"
 	year "1985"
 	developer "Capcom"
@@ -21192,20 +15549,6 @@ game (
 	year "1986"
 	developer "Capcom (Romstar license)"
 	rom ( name gunsmokeua.zip size 33184 crc 8aa313b0 md5 613b8926da416796965226b5239686dc sha1 745bc7f633483f381ff206ccdccdb0b609561a5d )
-)
-
-game (
-	name "Gun Survivor 2: Bio Hazard Code Veronica"
-	year "2001"
-	developer "Capcom / Namco"
-	rom ( name gunsur2.zip size 174937327 crc ec4d4704 md5 dff35fd5d30cb899f9065fc5497b3239 sha1 1523d4a00a01de9e1e85f099f2fce2b965301164 )
-)
-
-game (
-	name "Gunmen Wars (GM1 Ver. A)"
-	year "1998"
-	developer "Namco"
-	rom ( name gunwars.zip size 31144980 crc 43038449 md5 354d42af86a3b2a3b0572f3c658a06b7 sha1 ab25228bbb8cea8d68ff4df0148388b2281c8ff9 )
 )
 
 game (
@@ -21241,13 +15584,6 @@ game (
 	year "2000"
 	developer "Kaneko / Kouyousha"
 	rom ( name gutsn.zip size 7382002 crc 703ad57d md5 f613618ac7ed1ac707ddb5bcffa38b65 sha1 3965df8096e6504c887c681638d9758e381256a1 )
-)
-
-game (
-	name "Guwange (Japan, Master Ver. 99/06/24)"
-	year "1999"
-	developer "Cave (Atlus license)"
-	rom ( name guwange.zip size 18761704 crc 5386e849 md5 94f828b8096a2c9bda87b316a5b25161 sha1 92c92ca125f36a16a6cf325c7b6002836db81a31 )
 )
 
 game (
@@ -21293,24 +15629,10 @@ game (
 )
 
 game (
-	name "Giga Wing 2 (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Takumi / Capcom"
-	rom ( name gwing2.zip size 51078181 crc d22a987f md5 96d467b05bd7756eae402e475c1f933d sha1 f986cfd1cd29f7ef296bde58228dc599f8c32cf6 )
-)
-
-game (
 	name "Giga Wing (Japan 990223 Phoenix Edition) (bootleg)"
 	year "1999"
 	developer "bootleg"
 	rom ( name gwingjd.zip size 485949 crc 81e1bcfb md5 084896c05a02bc7b341d04c7487b8dd8 sha1 9767a69adac410da8a9806f8c2d96bb33d1481e4 )
-)
-
-game (
-	name "Gypsy Juggler"
-	year "1978"
-	developer "Meadows"
-	rom ( name gypsyjug.zip size 6384 crc ed9c4676 md5 9ab30dc8fca882b68c58c9c7145e30ad sha1 6add65b1b1881829fc565fbf95cea31a5511c654 )
 )
 
 game (
@@ -21339,20 +15661,6 @@ game (
 	year "1983"
 	developer "Konami (Centuri license)"
 	rom ( name gyrussce.zip size 18476 crc 011c46c6 md5 f2211dd79a29ab0663900e94a3ca00a4 sha1 de1709390663d6a2f5563d029fdb097c35c7ecfb )
-)
-
-game (
-	name "Hacha Mecha Fighter (19th Sep. 1991)"
-	year "1991"
-	developer "NMK"
-	rom ( name hachamf.zip size 1203501 crc 06fc94dd md5 39115c90d008dfba8df4bf5aa89cea5a sha1 fa124731e7fa79920ef554f55399faffc192ea07 )
-)
-
-game (
-	name "Hachoo!"
-	year "1989"
-	developer "Jaleco"
-	rom ( name hachoo.zip size 1219596 crc bdb0452d md5 f32c8eacfef15fcbe492d71f6e4fcea6 sha1 8a8a52d5948d06550f964666f03ac978a91b156c )
 )
 
 game (
@@ -21517,38 +15825,10 @@ game (
 )
 
 game (
-	name "Hang Pilot"
-	year "1997"
-	developer "Konami"
-	rom ( name hangplt.zip size 11198743 crc 15f9537f md5 7020c82aa2261c708843a1de3f8888c3 sha1 d38d3440ec927ff0c83e82cb11be53aa2394b0cb )
-)
-
-game (
-	name "Happy 6-in-1 (ver. 101CN)"
-	year "2004"
-	developer "IGS"
-	rom ( name happy6.zip size 19974534 crc c3c678dd md5 a8667989774a6f09b386efa6263a05e7 sha1 ea9f288d602ebc5515a4c9496de374519c4e708e )
-)
-
-game (
-	name "Happy Tour"
-	year "2005"
-	developer "GAV Company"
-	rom ( name hapytour.zip size 13398254 crc e5d3731e md5 db7e716811c9ce592b37fbc10c330429 sha1 be1255505d34feba09c3198c118dc94059516a28 )
-)
-
-game (
 	name "Hard Drivin' (cockpit, rev 7)"
 	year "1988"
 	developer "Atari Games"
 	rom ( name harddriv.zip size 533603 crc de72f8f7 md5 e2c59cd2362484dcdbd9f31f225263f3 sha1 5d358309e320e0cee209cff4cb352a023096b820 )
-)
-
-game (
-	name "Hard Drivin' (cockpit, rev 1)"
-	year "1988"
-	developer "Atari Games"
-	rom ( name harddriv1.zip size 131899 crc 718bc2e9 md5 cc8ed70cd7c8070fdc38fe28b46ad6d1 sha1 e952b2cefbe0af9900eb96258a34f8b9eab1aa35 )
 )
 
 game (
@@ -21699,20 +15979,6 @@ game (
 )
 
 game (
-	name "Harem"
-	year "1983"
-	developer "I.G.R."
-	rom ( name harem.zip size 29471 crc fc65f2f0 md5 d2ec7c6b7224e1abbf42b8c9013b659d sha1 a3a180b28aec85333215f5430b9eacfb996ca423 )
-)
-
-game (
-	name "Harley-Davidson and L.A. Riders (Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name harley.zip size 64082716 crc 3df05353 md5 1fc399bf6c0ef5787f4e7ade5a615be4 sha1 d48f7f797770894e00a611542f7b831409ca7828 )
-)
-
-game (
 	name "Hasamu (Japan)"
 	year "1991"
 	developer "Irem"
@@ -21741,45 +16007,10 @@ game (
 )
 
 game (
-	name "Hat Trick"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name hattrick.zip size 20957 crc b92050af md5 10e700630a8f6a22206a029f45fbb9a8 sha1 50955d5cbcc66f29e056c0deae185d792144b01d )
-)
-
-game (
-	name "Hayaoshi Quiz Ouza Ketteisen - The King Of Quiz"
-	year "1993"
-	developer "Jaleco"
-	rom ( name hayaosi1.zip size 1243888 crc 230f194d md5 e3a3375678c7d5a21c1bf94efa671e4b sha1 de2b502d2455fa44e7932886e72c126d73ca7cb1 )
-)
-
-game (
-	name "Hayaoshi Quiz Grand Champion Taikai"
-	year "1994"
-	developer "Jaleco"
-	rom ( name hayaosi2.zip size 6534132 crc 0d4d53e2 md5 425d2f1e3ab9d7b1383991b439a6b07a sha1 80ec2a3bd77a2de577eb084b2c7b9d7f78bf2202 )
-)
-
-game (
-	name "Hayaoshi Quiz Nettou Namahousou"
-	year "1994"
-	developer "Jaleco"
-	rom ( name hayaosi3.zip size 8560302 crc 19ad31aa md5 7c76d5a566077e7a850277ddc889da75 sha1 67e82ef2b1ae2017602190abad76278c74c0a742 )
-)
-
-game (
 	name "Heavy Barrel (US)"
 	year "1987"
 	developer "Data East USA"
 	rom ( name hbarrel.zip size 531842 crc 1fcc48e4 md5 7848cbf9edf80c9227fc18f40996fecb sha1 0d1c3ad60099d4b69c84bbce51db62d0afdb0b22 )
-)
-
-game (
-	name "Heavy Barrel (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name hbarrelw.zip size 151856 crc 0009daf5 md5 60965beb0a7280902f35707334534efd sha1 dfe1656f37e4fe2548d8d21e597a57516e483e97 )
 )
 
 game (
@@ -21825,20 +16056,6 @@ game (
 )
 
 game (
-	name "Hard Drivin's Airborne (prototype)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name hdrivair.zip size 4528953 crc 2eba9202 md5 510b6e0ee6c7c466ed8d090a1e82fb9c sha1 1c022e599d2fa1f8e640503e91e08ff88b3ede13 )
-)
-
-game (
-	name "Hard Drivin's Airborne (prototype, early rev)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name hdrivairp.zip size 4445269 crc aeff64e9 md5 b19dab95be9c217e3a8e824fb3f4ddcc sha1 f390e3f5362089d9c85cf3247099de4e7d4b6baa )
-)
-
-game (
 	name "Head On (2 players)"
 	year "1979"
 	developer "Gremlin"
@@ -21853,24 +16070,10 @@ game (
 )
 
 game (
-	name "Head On 2 (Sidam bootleg)"
-	year "1979"
-	developer "bootleg (Sidam)"
-	rom ( name headon2s.zip size 5977 crc b8bbbf40 md5 5d18434e7ab9bfbcfe6c040058f208d0 sha1 12935f2c5fe6dbed2667764d6e67d563567dd33b )
-)
-
-game (
 	name "Head On (1 player)"
 	year "1979"
 	developer "Gremlin"
 	rom ( name headonb.zip size 2665 crc 68f78a6c md5 079fabc77cc527217a3ad2cb5e132a43 sha1 a8ac8bde33f2ca95484922d5b8893a583834eae4 )
-)
-
-game (
-	name "Head On (Irem, M-15 Hardware)"
-	year "1979"
-	developer "Irem"
-	rom ( name headoni.zip size 5663 crc 8a256f6b md5 0a38bd1c639c52e1abcdd629285cec36 sha1 3c0c213bcb89085ffa87dfa176d513cc49b75d42 )
 )
 
 game (
@@ -21881,52 +16084,10 @@ game (
 )
 
 game (
-	name "Head On (Sidam bootleg, set 2)"
-	year "1979"
-	developer "bootleg (Sidam)"
-	rom ( name headonsa.zip size 4518 crc 4efff158 md5 55ec98d27dc3dd31f01fb46896d6ab86 sha1 60860061139f45c6383ae894435acc742df97caf )
-)
-
-game (
 	name "Heart Attack"
 	year "1983"
 	developer "Century Electronics"
 	rom ( name heartatk.zip size 20963 crc ea9817f9 md5 230c575b2756e2f46332811da64d13fb sha1 2119c26d5a9ca01f672de17eb8a54428d477c163 )
-)
-
-game (
-	name "Heated Barrel (World version 3)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrl.zip size 1575050 crc a31b3e34 md5 e3ca30a67525b20b389598bf85d5b9bc sha1 2c983b555abd518c18f90dc29fd30d16eabfec27 )
-)
-
-game (
-	name "Heated Barrel (World version 2)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrl2.zip size 167361 crc 4ee09904 md5 7cfa6a964aa67320ca5225546194e473 sha1 18da46e618f186e61ef71732dc7e2135c1f7f72d )
-)
-
-game (
-	name "Heated Barrel (World old version)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrlo.zip size 167232 crc 7f33c5f0 md5 7ead4fb0cb8deb45f5183d1f00b00c46 sha1 eb397621452e2734998c3807c6080ccf1bfab9bb )
-)
-
-game (
-	name "Heated Barrel (US)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name heatbrlu.zip size 167346 crc a529d612 md5 acfd082eef01df999fc56472eb4881e7 sha1 4d11ddf71b62244ef98bcdf0304ef3a0cdec6861 )
-)
-
-game (
-	name "Heat of Eleven '98 (ver EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name heatof11.zip size 631318 crc 52866959 md5 af54a4197519d5ae18f45e1fb8df29c3 sha1 df4509dae9197b64adb31ed321d4d71166014a6d )
 )
 
 game (
@@ -21955,27 +16116,6 @@ game (
 	year "1999"
 	developer "ESD"
 	rom ( name hedpanico.zip size 4746363 crc 6584db0b md5 3f0072bda54835cb5d1f4580df10f9e6 sha1 aa2fc2459b4bd1e06820e61cfcf9767bdc5ab673 )
-)
-
-game (
-	name "Heiankyo Alien"
-	year "1979"
-	developer "Denki Onkyo"
-	rom ( name heiankyo.zip size 12050 crc b0bf9544 md5 2b3158dda2ddf11b7983acea715c745e sha1 6745eec2295ea1df09b3b55d4c368ff70ce7ed67 )
-)
-
-game (
-	name "HeliFire (set 1)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name helifire.zip size 10248 crc 2d71af67 md5 c01159acea8ea1ca9d05ded9b9b97201 sha1 823b64910cb58ea102ba09307ead1511778f1293 )
-)
-
-game (
-	name "HeliFire (set 2)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name helifirea.zip size 4728 crc a1e0e489 md5 4d25f8fe420c49d7a3068924af1fcb13 sha1 9898fb95059ce04d066ebd07d61ceaf6636e5afa )
 )
 
 game (
@@ -22018,20 +16158,6 @@ game (
 	year "1984"
 	developer "Century Electronics / Seatongrove Ltd"
 	rom ( name hero.zip size 22127 crc 2e96ed4a md5 2c30819c469e12c5e769349393a8105e sha1 83132bf9cc6dbd4444cecd2fb24b5bec9cf375b4 )
-)
-
-game (
-	name "Hero in the Castle of Doom (DK conversion)"
-	year "1984"
-	developer "Seatongrove Ltd (Crown license)"
-	rom ( name herodk.zip size 17614 crc 6e68d207 md5 582c86f07798e749588caaf4dea84893 sha1 fed7672adeadf2f27be9a12f4f10521ca1e0170c )
-)
-
-game (
-	name "Hero in the Castle of Doom (DK conversion not encrypted)"
-	year "1984"
-	developer "Seatongrove Ltd (Crown license)"
-	rom ( name herodku.zip size 17520 crc f3ef3d3f md5 411ccf25ddb5f7ca88950525ac3c2fe1 sha1 39aa20dfa71bc440d3a352a368cdd8c3f826f977 )
 )
 
 game (
@@ -22103,27 +16229,6 @@ game (
 )
 
 game (
-	name "Hidden Catch 2 (pcb ver 3.03)"
-	year "1999"
-	developer "Eolith"
-	rom ( name hidctch2.zip size 20966101 crc c78a4acc md5 b83b91a4969060897cfe4f306f623a9d sha1 44008bdfe33289ee2b0bdf57c65959ffc97997a3 )
-)
-
-game (
-	name "Hidden Catch 3 (ver 1.00 / pcb ver 3.05)"
-	year "2000"
-	developer "Eolith"
-	rom ( name hidctch3.zip size 18524487 crc b04cfd6c md5 f71bf49c0d209239317dc849416bf6b2 sha1 5e8e8c571ded44587ce36968ca99b34411b2d038 )
-)
-
-game (
-	name "Hidden Catch (World) / Tul Lin Gu Lim Chat Ki '98 (Korea) (pcb ver 3.03)"
-	year "1998"
-	developer "Eolith"
-	rom ( name hidnctch.zip size 15354295 crc 30d57a77 md5 373413ab28b6d0101fee9e213fa25324 sha1 9e8a857ea58a6422ed6d8a71ec743f134b0f4c8a )
-)
-
-game (
 	name "Pirate Ship Higemaru"
 	year "1984"
 	developer "Capcom"
@@ -22152,59 +16257,10 @@ game (
 )
 
 game (
-	name "High Impact Football (rev LA5 02/15/91)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact.zip size 1208401 crc a9991165 md5 99f6fa091a27f6e66c7b12c7d9376e32 sha1 51d358d89329cc1b7a92110d89251d2db0c5e995 )
-)
-
-game (
-	name "High Impact Football (rev LA1 12/16/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact1.zip size 114063 crc 89d1f262 md5 9ece7e23c377ea6d607e40f3d49e2b09 sha1 14afc876b92d4e2143bb5ee6e28f273af07f2947 )
-)
-
-game (
-	name "High Impact Football (rev LA2 12/26/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact2.zip size 116301 crc 6e9cd0b6 md5 97ca943a38fc2520eb3fb1b1a9457eca sha1 44739bdc301ae3a09aefb7d7b1d8f54f65335b0b )
-)
-
-game (
-	name "High Impact Football (rev LA3 12/27/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact3.zip size 116285 crc 350f5fa8 md5 4b26169399fa6c6570c0991ce0c104aa sha1 97e57f608e972f881269d0e30c677c73907d69b5 )
-)
-
-game (
-	name "High Impact Football (rev LA4 02/04/91)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpact4.zip size 116944 crc dd23c0e0 md5 a630377915c5e662ef07f5670d126117 sha1 f4777a410a23aa84b3259716d9f230efff34002c )
-)
-
-game (
-	name "High Impact Football (prototype, rev 8.6 12/09/90)"
-	year "1990"
-	developer "Williams"
-	rom ( name hiimpactp.zip size 111077 crc 6bb8ae38 md5 edb257a262760e32e30ca808d0473448 sha1 73d8e05716fbc60025bf90dd737651c4835e067a )
-)
-
-game (
 	name "Himeshikibu (Japan)"
 	year "1989"
 	developer "Hi-Soft"
 	rom ( name himesiki.zip size 150866 crc 61260320 md5 8cb4570572bb39b35007837b400e21be sha1 443acdf7d3f616a2b9f19dd42f9dabd02494fc68 )
-)
-
-game (
-	name "Hi Pai Paradise"
-	year "2003"
-	developer "Aruze / Seta"
-	rom ( name hipai.zip size 28464828 crc cf146002 md5 d24bd0920f837e041f980fdc17826f14 sha1 97960066fc29c73cf7f1219ee5161b1dfb5e6485 )
 )
 
 game (
@@ -22226,12 +16282,6 @@ game (
 	year "1987"
 	developer "Toaplan / Taito Corporation"
 	rom ( name hishouza.zip size 63573 crc 4bd5d6eb md5 92d754e276c28bf003274fb9cf225b14 sha1 aab6cd99db9a6b8b98cd902e4906b36af3f3de64 )
-)
-
-game (
-	name "The History of Martial Arts"
-	developer "bootleg"
-	rom ( name histryma.zip size 3484991 crc 77b9e338 md5 4663f1915b0d4ce2bde839748d02d2f1 sha1 46d904c626c109bd37be637fc5fa289272f90a12 )
 )
 
 game (
@@ -22267,13 +16317,6 @@ game (
 	year "1987"
 	developer "Exidy"
 	rom ( name hitnmiss2.zip size 131442 crc 320a0cc1 md5 29527f232dde1238d6181375a2b61447 sha1 09d7f15a9d7f0cdb8bcdad0889245fced49d2345 )
-)
-
-game (
-	name "Hit Poker (Bulgaria)"
-	year "1997"
-	developer "Accept Ltd."
-	rom ( name hitpoker.zip size 449344 crc 569e0046 md5 0e9b4583509d0d7d37e02c51de5ac44c sha1 6541b28ebe7f9421735960d3280d5a898c372919 )
 )
 
 game (
@@ -22361,20 +16404,6 @@ game (
 )
 
 game (
-	name "Heavy Metal Geomatrix (JPN, USA, EUR, ASI, AUS) (Rev A)"
-	year "2001"
-	developer "Capcom"
-	rom ( name hmgeo.zip size 68679919 crc 89b90bb6 md5 8a54005a4e7d2101512dbdaf03ee6766 sha1 82b4ea7e31d483833a0183ffe6e655fe0df1ac9e )
-)
-
-game (
-	name "AV Hanafuda Hana no Ageman (Japan 900716)"
-	year "1990"
-	developer "Nichibutsu / AV Japan"
-	rom ( name hnageman.zip size 299541 crc 25246c63 md5 6d69f993ce4acaf86a684424e2c5c050 sha1 27f0b123aa9244bff68889da78dfc80358490b1d )
-)
-
-game (
 	name "Hana Yayoi (Japan)"
 	year "1987"
 	developer "Dyna Electronics"
@@ -22417,13 +16446,6 @@ game (
 )
 
 game (
-	name "AV Hanafuda Hana no Christmas Eve (Japan 901204)"
-	year "1990"
-	developer "Nichibutsu / AV Japan"
-	rom ( name hnxmasev.zip size 208731 crc dc8545ac md5 5a2c2a4b4df3c6e75d55a113c3745658 sha1 fec1356d701035f977af89559fcf68cca449c6c6 )
-)
-
-game (
 	name "Hoccer (set 1)"
 	year "1983"
 	developer "Eastern Micro Electronics, Inc."
@@ -22456,13 +16478,6 @@ game (
 	year "1992"
 	developer "Sega"
 	rom ( name holo.zip size 5228140 crc 44be9ce3 md5 3664fdfd8d2ec53156ef54d350c1cb35 sha1 9e696362152232dac3f01cd13b7e12ff76485dce )
-)
-
-game (
-	name "Moero Pro Yakyuu Homerun"
-	year "1988"
-	developer "Jaleco"
-	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
 )
 
 game (
@@ -22578,34 +16593,6 @@ game (
 )
 
 game (
-	name "House of the Dead"
-	year "1997"
-	developer "Sega"
-	rom ( name hotd.zip size 29675840 crc 8c7b36b5 md5 374ab35f5d8add16c5edbe3b8ee88a40 sha1 de42682e8595c1f7dfe8a27ec7717af8fe2ea6f5 )
-)
-
-game (
-	name "House of the Dead 2"
-	year "1999"
-	developer "Sega"
-	rom ( name hotd2.zip size 103548842 crc 1775a44c md5 e02b03e0ea3ef010b1197bfbc8e2ea35 sha1 3556e83a81eb99786fb07e3d037f4d882ecf5e34 )
-)
-
-game (
-	name "House of the Dead 2 (original)"
-	year "1999"
-	developer "Sega"
-	rom ( name hotd2o.zip size 734529 crc 19dccfe9 md5 1986e09a47f634b49ce127b078058820 sha1 9fe8c2cedefd6dcc84976e2bdbbd1a52b1d4d019 )
-)
-
-game (
-	name "The House of the Dead III (GDX-0001)"
-	year "2002"
-	developer "Sega"
-	rom ( name hotd3.zip size 219 crc 2ae7bc01 md5 61254fe2154d4f8d2f45f5f4edf84f69 sha1 6e88cfff387b082dbf809179a24fbd71e1d3d87b )
-)
-
-game (
 	name "Quiz de Idol! Hot Debut (Japan)"
 	year "2000"
 	developer "Psikyo / Moss"
@@ -22652,13 +16639,6 @@ game (
 	year "1994"
 	developer "Tuning/Incredible Technologies"
 	rom ( name hotmemry.zip size 3287071 crc 5b9614ac md5 9121e1c7e802a1d2a0d8f590e7f7e75c sha1 00e500a5f72a0d46ac8f48d460fded88b3f0bbcd )
-)
-
-game (
-	name "Hot Mind"
-	year "1995"
-	developer "Playmark"
-	rom ( name hotmind.zip size 314659 crc 60b80717 md5 3000ad3a8e0ff882d0c8b44c79b419e0 sha1 9cd57503d2becf384395106a50408d937178cebb )
 )
 
 game (
@@ -22711,13 +16691,6 @@ game (
 )
 
 game (
-	name "Hot Slot (ver. 05.01)"
-	year "1996"
-	developer "ABM Electronics"
-	rom ( name hotslot.zip size 524881 crc 5452e8e4 md5 2731cdfd10946cc607f34ef2832ff228 sha1 27b3b0d88d018af6c1b88b4ec0860aabf67c8c18 )
-)
-
-game (
 	name "Vs. Hot Smash"
 	year "1987"
 	developer "Taito"
@@ -22767,20 +16740,6 @@ game (
 )
 
 game (
-	name "Hard Times (set 1)"
-	year "1994"
-	developer "Playmark"
-	rom ( name hrdtimes.zip size 1587677 crc 9da5b12b md5 986b08c66fd4b7412298e9a46475264d sha1 95c7a0b63cab9285ae63813eba0ba0af60d2d60b )
-)
-
-game (
-	name "Hard Times (set 2)"
-	year "1994"
-	developer "Playmark"
-	rom ( name hrdtimesa.zip size 1125018 crc f4ae143f md5 6270642895a6606c0075b0d027aa9534 sha1 a0083ad5372637d684c3caad9c2680b10e1a4349 )
-)
-
-game (
 	name "Hyper Street Fighter 2: The Anniversary Edition (USA 040202)"
 	year "2004"
 	developer "Capcom"
@@ -22809,13 +16768,6 @@ game (
 )
 
 game (
-	name "High Seas Havoc"
-	year "1993"
-	developer "Data East"
-	rom ( name hshavoc.zip size 695950 crc 4b2a9b45 md5 24d00d885f8e08844f0bf8b343a9e540 sha1 81668b3e57fd069f80f5204c91c876f947f6a721 )
-)
-
-game (
 	name "Hot Shots Tennis (V1.1)"
 	year "1990"
 	developer "Strata/Incredible Technologies"
@@ -22827,13 +16779,6 @@ game (
 	year "1990"
 	developer "Strata/Incredible Technologies"
 	rom ( name hstennis10.zip size 42292 crc 083b672a md5 573d8e4bf51326a1274cffd653d79622 sha1 07377c15e7f7ed66214339efbdb9cb528c73c4d9 )
-)
-
-game (
-	name "Hatch Catch"
-	year "1995"
-	developer "SemiCom"
-	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
 )
 
 game (
@@ -22893,13 +16838,6 @@ game (
 )
 
 game (
-	name "Hunchback (DK conversion)"
-	year "1983"
-	developer "Century Electronics"
-	rom ( name hunchbkd.zip size 16765 crc 162ce01c md5 5e42739d04f9505930c05d66e6b285db sha1 fa030754526a8240f0319fcf3c7a245aa3026d7e )
-)
-
-game (
 	name "Hunchback (Galaxian hardware)"
 	year "1983"
 	developer "Century Electronics"
@@ -22932,20 +16870,6 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name hustler.zip size 14260 crc 62cf9e6d md5 052eeceeac66f76305f270d9bb454147 sha1 83d5c11a63f3ef8a737ac9158759b602eee6e02f )
-)
-
-game (
-	name "Video Hustler (bootleg)"
-	year "1981"
-	developer "bootleg (Digimatic)"
-	rom ( name hustlerb.zip size 10328 crc f694e5c7 md5 676574f6385dd3ddb6c44e82cdbd19c0 sha1 f091c50d36b2a0a89c001347f7c42e15af3a7659 )
-)
-
-game (
-	name "Fatsy Gambler (Video Hustler bootleg)"
-	year "1981"
-	developer "bootleg"
-	rom ( name hustlerb2.zip size 7765 crc f82dec8e md5 f5184fe4cd64aa95a092a0c8390674b4 sha1 84a0ef7773dd1c8f5039d816eed7a4dfde3b0cc0 )
 )
 
 game (
@@ -22991,27 +16915,6 @@ game (
 )
 
 game (
-	name "Heavy Unit (World)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunit.zip size 625740 crc 2dd0d798 md5 e8ee5ef49f3cdbb3b4deccf9d7085e2b sha1 1d9665c3cbf1e1f82808fb4a54d475c9c7e2cbca )
-)
-
-game (
-	name "Heavy Unit (Japan, Newer)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunitj.zip size 71196 crc 76833329 md5 35b165cc6c0d93658195e98cf2b94d95 sha1 6956d425fb2353bf232858899fe3fc28d613bd7a )
-)
-
-game (
-	name "Heavy Unit (Japan, Older)"
-	year "1988"
-	developer "Kaneko / Taito"
-	rom ( name hvyunito.zip size 71187 crc 2392d3db md5 fb1a6ec2ea80fcbcc7f1b77d51cc9fc1 sha1 2cf7606fd517f4a4db9043890c592ebb756d84a0 )
-)
-
-game (
 	name "Heavyweight Champ"
 	year "1987"
 	developer "Sega"
@@ -23037,20 +16940,6 @@ game (
 	year "1990"
 	developer "Atari Games"
 	rom ( name hydra.zip size 1393019 crc 442c8581 md5 0e741df3e8cb95fb7301b73ef80102ce sha1 6c340a590a3c335df546635711eef871f8eaf73d )
-)
-
-game (
-	name "Hydra (prototype 5/14/90)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name hydrap.zip size 912537 crc 1c74da4f md5 c36b8440732b9a4f6203e411763925b4 sha1 e3b17199ef877747c697bf7f397c2f8a94e7ea07 )
-)
-
-game (
-	name "Hydra (prototype 5/25/90)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name hydrap2.zip size 185358 crc ab6e42a3 md5 a6a9316bf18146b4408cb6713b717e77 sha1 5135408eb82a65412f7b144b6eb2d9b2615605b7 )
 )
 
 game (
@@ -23082,20 +16971,6 @@ game (
 )
 
 game (
-	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. JAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name hyperbbc.zip size 168 crc 9af2c9a4 md5 7c2030be99b2a53d0e4334d320b19926 sha1 4e941cbfcb3fad16d9a006cbb4fbce7133b832f7 )
-)
-
-game (
-	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. KAA)"
-	year "1999"
-	developer "Konami"
-	rom ( name hyperbbck.zip size 168 crc 44ab53e6 md5 7ca726391d1242be190c4ac784422806 sha1 b3537626db78c0dbd4f15a44635f4489685bff8b )
-)
-
-game (
 	name "Hyper Pacman"
 	year "1995"
 	developer "SemiCom"
@@ -23121,13 +16996,6 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name hypersptb.zip size 52561 crc de70b785 md5 39dc5e6656a13588fad1313d031074c2 sha1 f3ded3860ce1176c6c0444caf5a3f4d729c2b4c3 )
-)
-
-game (
-	name "Hyperdrive"
-	year "1998"
-	developer "Midway Games"
-	rom ( name hyprdriv.zip size 127652 crc e32be5da md5 900a5ff2033de5812b55b1d88beb1e43 sha1 00211969d1c32f804087fee2c73505a79bdd347d )
 )
 
 game (
@@ -23163,13 +17031,6 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name hyprolym.zip size 35758 crc 7d0784a8 md5 4c91288783f3e9b42902f781661b0152 sha1 28124353bac4d25b1fe393f463eb9dbd9197462c )
-)
-
-game (
-	name "Hyper Olympic (bootleg)"
-	year "1983"
-	developer "bootleg"
-	rom ( name hyprolymb.zip size 60733 crc 96b59795 md5 a1a566a2e6bef0559ae9f23241ac0ef1 sha1 fb557af26e91a1fd8f1dce2947e4eec4f468dcfc )
 )
 
 game (
@@ -23271,30 +17132,9 @@ game (
 )
 
 game (
-	name "Iga Ninjyutsuden (Japan)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name iganinju.zip size 863977 crc 5e327254 md5 a5f363348d5af77637f9d9f82324a467 sha1 715a69e9f92d7766bd3361e70b66b44435f0e9b6 )
-)
-
-game (
-	name "IGMO"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name igmo.zip size 20946 crc 9ff45478 md5 bac686b9e8c052852dc6fd2b06a14a51 sha1 55406a6c97dd5aa00b8171ae45c5cd243bbb2909 )
-)
-
-game (
 	name "New Champion Skill (v100n)"
 	developer "IGS"
 	rom ( name igs_ncs.zip size 141502 crc 0bf9f74a md5 5254868750ec1ce2d4c2a810980f2119 sha1 b38d03a29dacbe1651d5dfbca3361cfc2c40577f )
-)
-
-game (
-	name "New Champion Skill (v100n 2000)"
-	year "2000"
-	developer "IGS"
-	rom ( name igs_ncs2.zip size 179683 crc c2686e23 md5 ce1b79789a8b6f9b2159d09123692cf6 sha1 48599236076927d5e195a6b8b21cf665b8cee436 )
 )
 
 game (
@@ -23347,23 +17187,10 @@ game (
 )
 
 game (
-	name "Ikaruga (GDL-0010)"
-	year "2001"
-	developer "Treasure"
-	rom ( name ikaruga.zip size 1196 crc c5ecb9fa md5 d103a037dd2d7a93e4bda3c6b449f7a6 sha1 da043d21ca19ebb8daccb4ac764d0c710106ca76 )
-)
-
-game (
 	name "Ikki (Japan)"
 	year "1985"
 	developer "Sun Electronics"
 	rom ( name ikki.zip size 75792 crc 86dc9eff md5 70cefaeddbc9732c6acae6c07465b37f sha1 3fd8d8cecca4d3c8648e019b0f64075035f25554 )
-)
-
-game (
-	name "Il Pagliaccio (Italy, Version 2.7C)"
-	developer "&lt;unknown&gt;"
-	rom ( name ilpag.zip size 746098 crc a978f61c md5 5a5a7d4cde7fb6af29112c41f054869b sha1 14afbcf60777a98d24e93d87d3dc4a3e699fd4f6 )
 )
 
 game (
@@ -23385,27 +17212,6 @@ game (
 	year "1994"
 	developer "Sphinx/AV Japan"
 	rom ( name imekura.zip size 2781537 crc afef8ac4 md5 b68b388c83eee9298613f06aca4b95ef sha1 e47363be71064f3f861846bec4202e7ea73bb16c )
-)
-
-game (
-	name "Image Fight (Japan, revision A)"
-	year "1988"
-	developer "Irem"
-	rom ( name imgfight.zip size 634384 crc 5221a34e md5 0ea61f9af90a04b7e514a638e6aa884f sha1 8c5638687464af92d65ac1e35b8ddcea8a04cda0 )
-)
-
-game (
-	name "Image Fight (Japan)"
-	year "1988"
-	developer "Irem"
-	rom ( name imgfighto.zip size 66939 crc f195377a md5 c337c9a907caef94577df67c5b6be0c2 sha1 991e6f0bb3ab375f0a0682dca9e4a528fd9b6fdb )
-)
-
-game (
-	name "Imola Grand Prix"
-	year "1981"
-	developer "Alberici"
-	rom ( name imolagp.zip size 12959 crc 58983e15 md5 06dfd3f717c9f804527972c5beb02826 sha1 1f67965b4540a68dcfe525207ff66ed0183e9c0e )
 )
 
 game (
@@ -23436,66 +17242,10 @@ game (
 )
 
 game (
-	name "Indian Dreaming (B - 15/12/98, Local)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name indiandr.zip size 975008 crc 4b1fc83f md5 acf3af78f3ab338daa031c3e62bf6271 sha1 cfa7c3e5039acd50fe6034733032e81101188987 )
-)
-
-game (
-	name "INDY 500 Twin (Revision A, Newer)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500.zip size 15023750 crc 32a2c79e md5 e92a9d2a496e733c37694bcf4cd29c6a sha1 9fe6179d286fb0aac7362f8ae860285ded6be64f )
-)
-
-game (
-	name "INDY 500 Deluxe (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500d.zip size 375930 crc 99d4fa3d md5 3ecfb34b9bdef4e393dfeb19b8a96416 sha1 511a48cd510163e3a94356391e3182794342ac6c )
-)
-
-game (
-	name "INDY 500 Twin (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name indy500to.zip size 527947 crc 2a7699fc md5 04196559e193e305f3812c9fea3d1bef sha1 4ba22a0a69576bd3df86c80f53e5d435bb9d1a6f )
-)
-
-game (
 	name "Danny Sullivan's Indy Heat"
 	year "1991"
 	developer "Leland Corp."
 	rom ( name indyheat.zip size 1576160 crc cb7e149f md5 3a2306954d97843a9f43cc0d4a87ceb7 sha1 6e86d393dc2c7dd8d7abf2fe0fa82a3685a1f4bc )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 1)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp.zip size 340077 crc 4773adb4 md5 60d666ebd8611b56f7c66cfb64997dee sha1 51b823872cd04947ec40ff3288d2caba73c3847c )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 2)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp2.zip size 37735 crc c66e291d md5 07df56c5a17769129097b06f5eea44b9 sha1 cb6b3a737bd2c9be25be8f02fe1cdd579e6270fb )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 3)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp3.zip size 93260 crc 1665027b md5 3433ec07b4195ea399c554b321b4911a sha1 a3d239dcadd1b4a073859f63be3ca41c43e299b6 )
-)
-
-game (
-	name "Indiana Jones and the Temple of Doom (set 4)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytemp4.zip size 84847 crc c6465b1b md5 80f7d25214d39cefa47ba738e66fc62c sha1 64dc8003adf1b5196b774336abb446d16e581fe6 )
 )
 
 game (
@@ -23506,38 +17256,10 @@ game (
 )
 
 game (
-	name "Indiana Jones and the Temple of Doom (German)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name indytempd.zip size 84534 crc ba94d8cb md5 00910797f05e5437f8adc0d2391bae36 sha1 e9b6de75007e3e141e8e57daf519cbb8e8430487 )
-)
-
-game (
 	name "Inferno"
 	year "1984"
 	developer "Williams"
 	rom ( name inferno.zip size 67017 crc c0f2c5d7 md5 7ef49fb379e325682336c7f7ee3e0e1f sha1 9d085407074c5f4e6666f60e045c8f92a9a8e4f5 )
-)
-
-game (
-	name "Initial D Arcade Stage (Rev B) (Japan) (GDS-0020B)"
-	year "2002"
-	developer "Sega"
-	rom ( name initd.zip size 1194 crc 0fe16fc1 md5 1ef9168793a4d40e099a6a7c7dfd8c75 sha1 007ae65f56190a628170f3f1e91f395739769ccf )
-)
-
-game (
-	name "Initial D Arcade Stage (Export) (GDS-0025)"
-	year "2002"
-	developer "Sega"
-	rom ( name initdexp.zip size 1196 crc 8cc85cb3 md5 f8c823eb138396968b2336f8e2468fa7 sha1 9f49e117540d1f99c1c4cb75fa7894708dc677c5 )
-)
-
-game (
-	name "Inquizitor"
-	year "1989"
-	developer "BFM"
-	rom ( name inquiztr.zip size 64897 crc 16b9a3dc md5 822f6a8a5c220ddb0e982d3bdf210843 sha1 7a4b1dc8f7166850c6acb24cfc47f701047158b5 )
 )
 
 game (
@@ -23583,13 +17305,6 @@ game (
 )
 
 game (
-	name "International Team Laser (prototype)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name intlaser.zip size 396644 crc c1b96ff3 md5 73a68870efe55f5cfbf769ec1c06b092 sha1 c385f6e5bc32b3e6c02195b024a537a292a2670e )
-)
-
-game (
 	name "Intrepid (set 1)"
 	year "1983"
 	developer "Nova Games Ltd."
@@ -23611,30 +17326,10 @@ game (
 )
 
 game (
-	name "Intersecti"
-	developer "&lt;unknown&gt;"
-	rom ( name intrscti.zip size 9672 crc 0b6b8711 md5 2d24f3d4ee8f3494f721ab7698539f8a sha1 8185af5fb7d94e8027903f818e532cce93413546 )
-)
-
-game (
 	name "Intruder"
 	year "1980"
 	developer "Taito (GamePlan license?)"
 	rom ( name intruder.zip size 1610 crc f19d165a md5 eb706649a8e5bf96c4f9e6232f73c759 sha1 d4be5e1d7f03d4766c9d1fb6b63f83ccf27a06f1 )
-)
-
-game (
-	name "International Toote (Germany)"
-	year "1998"
-	developer "Coinmaster"
-	rom ( name inttoote.zip size 57027 crc 3e0397f7 md5 caaa67fe3c6eef2d170592df44e450d5 sha1 c2098dcd22449fef5810d0fd2808dcd90e016220 )
-)
-
-game (
-	name "International Toote II (World?)"
-	year "1993"
-	developer "Coinmaster"
-	rom ( name inttootea.zip size 72655 crc fff55614 md5 9b511046d9f9a8c26ffd9b1161105165 sha1 461536f5db0efd27c0b3df1fda8d179661af1d7b )
 )
 
 game (
@@ -23712,18 +17407,6 @@ game (
 )
 
 game (
-	name "Invasion (bootleg, set 3, R Z SRL Bologna)"
-	developer "bootleg (R Z SRL Bologna)"
-	rom ( name invasionrz.zip size 5603 crc 7b72f5f6 md5 c80db8fa964b5008c57867998bb427c5 sha1 027a128fc38b326ecdfe20e19124749734cb1bf1 )
-)
-
-game (
-	name "Invasion (bootleg, set 4, R Z SRL Bologna)"
-	developer "bootleg (R Z SRL Bologna)"
-	rom ( name invasionrza.zip size 6607 crc 04937ecc md5 c949c6aa4653ad280c450b9dc609f81a sha1 306164eb0ba0d9d8c35653b5caba6097e79af827 )
-)
-
-game (
 	name "Invasion - The Abductors (version 5.0)"
 	year "1999"
 	developer "Midway"
@@ -23778,13 +17461,6 @@ game (
 )
 
 game (
-	name "IPM Invader (Incomplete Dump)"
-	year "1979"
-	developer "IPM"
-	rom ( name ipminvad1.zip size 6532 crc 318f0416 md5 4da8a7a807684626b3fdaa85be8ffc41 sha1 1c4ee4fdb1f4057c4e48364350e990eaa21ac29b )
-)
-
-game (
 	name "Ippatsu Gyakuten [BET] (Japan)"
 	year "1986"
 	developer "Public Software / Paradais"
@@ -23799,27 +17475,6 @@ game (
 )
 
 game (
-	name "Shu Zi Le Yuan (V127M)"
-	year "1996"
-	developer "IGS"
-	rom ( name iqblocka.zip size 604615 crc 1f42f01f md5 9b7a585db42c7a0da63f89613085791d sha1 c724de3ef5304e47a146864963ffe84bc5df3b57 )
-)
-
-game (
-	name "Shu Zi Le Yuan (V113FR)"
-	year "1996"
-	developer "IGS"
-	rom ( name iqblockf.zip size 607343 crc 574b59bc md5 bc614f1cd7678ca406b51c6481607a63 sha1 9ade9fa4959fa723dc964f32fc7e2ee0674c5697 )
-)
-
-game (
-	name "IQ Pipe"
-	year "1991"
-	developer "AMT"
-	rom ( name iqpipe.zip size 83167 crc 05c3dfa7 md5 ae613a0a37a89f6f0548262ebad8ee1f sha1 85b666771466c14674235e3361e7436ded16ba3a )
-)
-
-game (
 	name "I, Robot"
 	year "1983"
 	developer "Atari"
@@ -23831,20 +17486,6 @@ game (
 	year "1996"
 	developer "bootleg"
 	rom ( name iron.zip size 976406 crc 52590369 md5 f7da2099fff929b1da23b56b8464af8d sha1 9d7835859e1fddf545076b52a466b6d13b03c46f )
-)
-
-game (
-	name "Iron Fortress"
-	year "1998"
-	developer "Eolith"
-	rom ( name ironfort.zip size 5044779 crc 4300d5ed md5 c01da7027fd431c7188897604b4ab529 sha1 237341f4e3f02d83b5db3a3ce7bc42b7e2d29d94 )
-)
-
-game (
-	name "Iron Fortress (Japan)"
-	year "1998"
-	developer "Eolith"
-	rom ( name ironfortj.zip size 67721 crc b793a702 md5 9924921c38f653d056536836883f2fbf sha1 6bc9c8253963d21ede28a9ea854a05628d460a1e )
 )
 
 game (
@@ -23890,13 +17531,6 @@ game (
 )
 
 game (
-	name "Interstellar Laser Fantasy"
-	year "1983"
-	developer "Funai/Gakken"
-	rom ( name istellar.zip size 44529 crc 4dd8b83a md5 ed66bc09ae179a3b2c4c3b833b6d9e20 sha1 7c97572c59e6a7b79fac98e44c00ce58cc532c77 )
-)
-
-game (
 	name "Ixion (prototype)"
 	year "1983"
 	developer "Sega"
@@ -23939,27 +17573,6 @@ game (
 )
 
 game (
-	name "Happy Jackie (v110U)"
-	year "1993"
-	developer "IGS"
-	rom ( name jackie.zip size 191320 crc 97aebc98 md5 508af67ba9db4c01d5a01962a2b840e4 sha1 8d9c6e18bb2f9e874bf6bbe34653f93e10936e7f )
-)
-
-game (
-	name "Jackpot Cards / Jackpot Pool (Italy)"
-	year "1997"
-	developer "Electronic Projects"
-	rom ( name jackpool.zip size 430649 crc 88cfe3d5 md5 c58a2a87c466e38fbb21fe081095eda6 sha1 8f3daec403df059c2ccebaf45504d13fd1982006 )
-)
-
-game (
-	name "Jack Rabbit (set 1)"
-	year "1984"
-	developer "Zaccaria"
-	rom ( name jackrabt.zip size 55883 crc a7722c9d md5 3d93af2407203345dc5b47729d5c584f sha1 7b9015e1e6dea4278515d99db4a356fb95e445af )
-)
-
-game (
 	name "Jack Rabbit (set 2)"
 	year "1984"
 	developer "Zaccaria"
@@ -23981,24 +17594,10 @@ game (
 )
 
 game (
-	name "Jail Break (bootleg)"
-	year "1986"
-	developer "bootleg"
-	rom ( name jailbrekb.zip size 67788 crc 672cdd18 md5 630a3b3a69a888ce0edd7d8b80ea527a sha1 57945b14e59eeef2d6fd29ec894919e881336048 )
-)
-
-game (
 	name "Vs. Ninja Jajamaru Kun (Japan)"
 	year "1985"
 	developer "Jaleco"
 	rom ( name jajamaru.zip size 23888 crc 42482066 md5 4cc9e580ecf4af5f82c5b8778ada83dc sha1 89809aac3f2fe009a16e619ca506e992eef8dbe1 )
-)
-
-game (
-	name "Jambo! Safari (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "1999"
-	developer "Sega"
-	rom ( name jambo.zip size 23866373 crc 64df7281 md5 bbb13f268659ac336aad57ce0681fc5f sha1 b00f7d27927fd5d8b5e337cbab4a9f56f2549ad1 )
 )
 
 game (
@@ -24030,20 +17629,6 @@ game (
 )
 
 game (
-	name "Jan Oh (set 1)"
-	year "1984"
-	developer "Toaplan"
-	rom ( name janoh.zip size 16977 crc 0d350ed1 md5 4f1544b09980ee35cc243494569c9165 sha1 5ee44807da349f549dee689a831841c89cb615a9 )
-)
-
-game (
-	name "Jan Oh (set 2)"
-	year "1984"
-	developer "Toaplan"
-	rom ( name janoha.zip size 21231 crc 83328c63 md5 4912819ae6f9870e68a4e7ca7ad63864 sha1 17909cf1da78950bb60c21c4a706ae4af5644504 )
-)
-
-game (
 	name "Janputer '96 (Japan)"
 	year "1996"
 	developer "Dynax"
@@ -24051,31 +17636,10 @@ game (
 )
 
 game (
-	name "New Double Bet Mahjong (Japan)"
-	year "1981"
-	developer "Public Software Ltd. / Mes"
-	rom ( name janputer.zip size 20202 crc 6184f21e md5 f0500e278b58ab376300a04ca921558f sha1 eec4d7369d76446be5b1a992e02a684806e5dad8 )
-)
-
-game (
-	name "Janshi"
-	year "1992"
-	developer "Eagle"
-	rom ( name janshi.zip size 513892 crc 6a97517e md5 7a57600a11c047936e7874ec7058c65e sha1 485866aa7b58aee377f0abaf562b29487a69e0f0 )
-)
-
-game (
 	name "Jyanshin Densetsu - Quest of Jongmaster"
 	year "1994"
 	developer "Aicom"
 	rom ( name janshin.zip size 3498756 crc 4f800bc5 md5 8862a2b515764deb1a5526160aac3de4 sha1 8f58c1915fc90540322885a6ea377dbc33ce97f2 )
-)
-
-game (
-	name "Jansou (set 1)"
-	year "1985"
-	developer "Dyna"
-	rom ( name jansou.zip size 64553 crc 0b0c63ff md5 70f9006799b672bdeafcc9ca98111a68 sha1 c04c67b9e98a8474eda63a1d472794853357c77a )
 )
 
 game (
@@ -24118,18 +17682,6 @@ game (
 	year "1995"
 	developer "Kaneko"
 	rom ( name jchan2.zip size 21775869 crc c84ad737 md5 e86807b65f465d66e07ec29425f05da3 sha1 704dc6bd8179ef4961e2ba85d785c7a7b3fab0d1 )
-)
-
-game (
-	name "Jockey Club II (newer hardware)"
-	developer "Seta"
-	rom ( name jclub2.zip size 4758679 crc 1fc45d42 md5 856f8101e35c790d1ba5101cecf3d25e sha1 0e7f4e4b438fcd4324c0658f62dbc740c1fea064 )
-)
-
-game (
-	name "Jockey Club II (older hardware)"
-	developer "Seta"
-	rom ( name jclub2o.zip size 3489624 crc 22687a78 md5 fb8f6819a7ff8f6a02edf930fc42e24e sha1 e087eace571239043b2600f18ca72f6abea4c920 )
 )
 
 game (
@@ -24179,26 +17731,6 @@ game (
 	year "1982"
 	developer "Falcon"
 	rom ( name jin.zip size 14013 crc d07fef6c md5 07eafbf03f9c38e60915170b784c8330 sha1 a7c846b4cfb2671be83b7f9a77fd0f6cc1b7fc3e )
-)
-
-game (
-	name "Jingle Bell (Italy, V133I)"
-	developer "IGS"
-	rom ( name jingbell.zip size 425074 crc 7e1c69ce md5 099cd81413b9ce01b5318bbfce6dd82f sha1 0366dd3dfaa06ce7015cd90d79a313641a4178dd )
-)
-
-game (
-	name "Jingi Storm - The Arcade (GDL-0037)"
-	year "2005"
-	developer "Atrativa Japan"
-	rom ( name jingystm.zip size 1196 crc 0b848fc8 md5 091a337475e10b6a693f64a44774713a sha1 a2b06bcf1224f03a0a5de74fe58ed98e5a0e2a7d )
-)
-
-game (
-	name "Jitsuryoku!! Pro Yakyuu (Japan)"
-	year "1989"
-	developer "Jaleco"
-	rom ( name jitsupro.zip size 1504321 crc e47b1e79 md5 1967b9acd0916487e4f7219cca8ebbf9 sha1 bccb1946075f09334565c5724efcb5129e875a53 )
 )
 
 game (
@@ -24258,12 +17790,6 @@ game (
 )
 
 game (
-	name "Joker Master"
-	developer "&lt;unknown&gt;"
-	rom ( name jkrmast.zip size 33734 crc c55783c8 md5 bff94e31f6da634e9649986ea7647b28 sha1 2fa3fea679255e3e9d71d9ac26f10c5cf079cd27 )
-)
-
-game (
 	name "The J.League 1994 (Japan)"
 	year "1994"
 	developer "Sega"
@@ -24275,13 +17801,6 @@ game (
 	year "1999"
 	developer "F2 System"
 	rom ( name jmpbreak.zip size 4951805 crc a4ec3b45 md5 9d0f802467110f03251e7e8fa9990779 sha1 2c527b646790f14ac158dc90a28a1b9471c0cf4b )
-)
-
-game (
-	name "Johnny Nero Action Hero"
-	year "2004"
-	developer "ICE/Play Mechanix"
-	rom ( name jnero.zip size 332827 crc e7711223 md5 c997b71c35138eac57ff6d244885bfdd sha1 6dfd7f5f10705d477a46bf0495e8baba7d64ec2c )
 )
 
 game (
@@ -24382,13 +17901,6 @@ game (
 )
 
 game (
-	name "Joker Card (Ver.A267BC, encrypted)"
-	year "1993"
-	developer "Vesely Svet"
-	rom ( name jokercrd.zip size 32609 crc 765749ba md5 94c4c0dfdfedf8f80946a87119e18a9d sha1 763dc8bdad8117da7c7e57e488cc7abf697fb266 )
-)
-
-game (
 	name "Joker Poker (Version 16.03B)"
 	year "1982"
 	developer "Greyhound Electronics"
@@ -24414,13 +17926,6 @@ game (
 	year "1983"
 	developer "Greyhound Electronics"
 	rom ( name jokpokerc.zip size 7985 crc 131cf7ed md5 2be8b98de20410eda2737d7d8fb2c8aa sha1 5259c68028b2f91dd338c6acba2c832e82955fc2 )
-)
-
-game (
-	name "Joker's Wild (encrypted)"
-	year "1988"
-	developer "Sigma"
-	rom ( name jokrwild.zip size 38043 crc e1649f5a md5 c8e81563a6ef0021f3ecd127721b949c sha1 9491d090326bae4563dbcdc24476dcafbf18396f )
 )
 
 game (
@@ -24463,20 +17968,6 @@ game (
 	year "1993"
 	developer "Soft Design"
 	rom ( name jolyccrb.zip size 11427 crc ff25b2c9 md5 9d7005f857520d0aa41570fe4d4821df sha1 53a775446e8baf079aa8b00338b7369ef56f17a7 )
-)
-
-game (
-	name "Jolly Card (Austrian, Funworld, bootleg)"
-	year "1986"
-	developer "Inter Games"
-	rom ( name jolycdab.zip size 29302 crc 1d78176f md5 ecf7fffb07869ffc50c325b9b28334e9 sha1 0bfe53bbc5fffbc319ed59b598c04a2f5afb6018 )
-)
-
-game (
-	name "Jolly Card (Austrian, Funworld)"
-	year "1986"
-	developer "Funworld"
-	rom ( name jolycdat.zip size 31923 crc a683ca4a md5 8af1aa9b1b2764e3a4b79ffc2ab53e76 sha1 12ca56abeccffa05ae218479e482a53483978a06 )
 )
 
 game (
@@ -24532,24 +18023,10 @@ game (
 )
 
 game (
-	name "Jongkyo"
-	year "1985"
-	developer "Kiwako"
-	rom ( name jongkyo.zip size 28861 crc 4e2be996 md5 2d1fef3ed312061e55adcd31ae825dad sha1 7fe9e56edfe36cd4b63a6879c7e8f2278582d5bf )
-)
-
-game (
 	name "Mahjong Jong-Tei (Japan, ver. NM532-01)"
 	year "1999"
 	developer "Dynax"
 	rom ( name jongtei.zip size 7401729 crc 1d55523f md5 028c02776920dc4456dc0b798bcd0bfe sha1 597ba66ca83b025e8b3e80bd5e8b83a5badf0b4a )
-)
-
-game (
-	name "Joshi Volleyball"
-	year "1983"
-	developer "Taito Corporation"
-	rom ( name josvolly.zip size 42690 crc 51b591ab md5 573efb9f7abfe6e7886828fc3b40727f sha1 bb6ef3f25b684db8271ca34bf3c028448cb1f2f0 )
 )
 
 game (
@@ -24605,7 +18082,7 @@ game (
 	name "Joyman"
 	year "1982"
 	developer "hack"
-	rom ( name joyman.zip size 14897 crc 3a847dc1 md5 ccd6af3b6b2219cc2b67d39c9dd628d5 sha1 7cfa55ba878f781281690aaa9245f91265393685 )
+	rom ( name joyman.zip size 14271 crc cafbd8b5 md5 67c5191cd516b3119b7173e515137292 sha1 7049741e7a06d1ab725a82ab3104d66623d14360 )
 )
 
 game (
@@ -24613,13 +18090,6 @@ game (
 	year "1993"
 	developer "Sega"
 	rom ( name jpark.zip size 9562290 crc e6f8a94a md5 1f2fd2161fc6a666712dcad46691f0ac sha1 b4c8f19ba4210e3fe1200909ce87415b7e86832e )
-)
-
-game (
-	name "Jurassic Park 3 (ver EBC)"
-	year "2001"
-	developer "Konami"
-	rom ( name jpark3.zip size 791 crc bc66ed57 md5 87b775472b598dd86b7b11e1b271a7c8 sha1 04a75c119d3c78468c25123b32a265b3f5c7538c )
 )
 
 game (
@@ -24805,24 +18275,6 @@ game (
 )
 
 game (
-	name "Joker's Wild (B52 system, set 1)"
-	developer "Sigma"
-	rom ( name jwildb52.zip size 101881 crc 349cc060 md5 85c3f29b162acd7e7d68b4702966ac68 sha1 35b1b05cdcfa87b4dce594a60d950ebb9ce2cece )
-)
-
-game (
-	name "Joker's Wild (B52 system, set 2)"
-	developer "Sigma"
-	rom ( name jwildb52a.zip size 36844 crc a7d45ec4 md5 87e1b78f5013ee584da1bfaa5ab1714f sha1 038f2404b5737553c608aa1e4d55a40545bee314 )
-)
-
-game (
-	name "Joker's Wild (B52 system, Harrah's GFX)"
-	developer "Sigma"
-	rom ( name jwildb52h.zip size 51023 crc a1286470 md5 da335b5f6b9e9e27b034e801e8fa5d0e sha1 554d041b3d32400f40f42d905f9d40b79ee59be8 )
-)
-
-game (
 	name "Jyangokushi: Haoh no Saihai (Japan 990527)"
 	year "1999"
 	developer "Capcom"
@@ -24928,27 +18380,6 @@ game (
 )
 
 game (
-	name "Kaiun Quiz (Japan, KW1/VER.A)"
-	year "1999"
-	developer "Namco"
-	rom ( name kaiunqz.zip size 34787590 crc 671b100d md5 cec265d498bd4129b2d97faad6a26777 sha1 9a9647f957fad21e9e31d94b1d7809e1444fb5d6 )
-)
-
-game (
-	name "Mahjong Kakumei (Japan)"
-	year "1990"
-	developer "Jaleco"
-	rom ( name kakumei.zip size 546133 crc 28f8fdc5 md5 1f9191815d9a1c4a2a65769d6e0abdcc sha1 693688e8f6bd2b039285d090a8e827ca1e8ec5d1 )
-)
-
-game (
-	name "Mahjong Kakumei 2 - Princess League (Japan)"
-	year "1992"
-	developer "Jaleco"
-	rom ( name kakumei2.zip size 1037704 crc 2eb34b77 md5 1f1dafdc947110082ea3095422e74996 sha1 104f70a4f2d8e6b44a1c54a4aabf015ea2636279 )
-)
-
-game (
 	name "Kamakazi III (superg hack)"
 	year "1979"
 	developer "hack"
@@ -24963,13 +18394,6 @@ game (
 )
 
 game (
-	name "Kamikaze"
-	year "1979"
-	developer "Leijac Corporation"
-	rom ( name kamikaze.zip size 5928 crc 5a4fefc8 md5 7bdacec83ded3f14a622750d540b0c46 sha1 b8cbbb27d5446fb696b6e963f6f41e3cb79a285a )
-)
-
-game (
 	name "Kamikaze Cabbie"
 	year "1984"
 	developer "Data East Corporation"
@@ -24981,20 +18405,6 @@ game (
 	year "1988"
 	developer "Panac"
 	rom ( name kanatuen.zip size 326075 crc 7958cbdb md5 2d299909a88ec8b88ea21c133631ec85 sha1 e78470dd8c6a999a72ce05bcc7cd9ddf755d8072 )
-)
-
-game (
-	name "Kangaroo"
-	year "1982"
-	developer "Sun Electronics"
-	rom ( name kangaroo.zip size 29696 crc 34252b40 md5 66fa791b13fe3cf44d6990709678d4aa sha1 0b1dc7390f485a98d4e15aaf586786889b49789d )
-)
-
-game (
-	name "Kangaroo (Atari)"
-	year "1982"
-	developer "Sun Electronics (Atari license)"
-	rom ( name kangarooa.zip size 6370 crc 8c259a8a md5 8b9baef91dc865d39a4423ac93f79737 sha1 db64f8742c65e90659634a93a7ad44ae137cc390 )
 )
 
 game (
@@ -25082,20 +18492,6 @@ game (
 )
 
 game (
-	name "Karous (GDL-0040)"
-	year "2006"
-	developer "Milestone"
-	rom ( name karous.zip size 1195 crc b3a81b11 md5 54f1234e8e6a9440286382f9f59d7d2e sha1 cd84b184069741842964ad6a4b5f7d14727ca02d )
-)
-
-game (
-	name "Ninja Kazan (World)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name kazan.zip size 874065 crc 539fb40f md5 152de260bc5e42de32fc9c3723f465cd sha1 40e09a127f9ccb344d4071308d206dbc9c28b07b )
-)
-
-game (
 	name "Knuckle Bash"
 	year "1993"
 	developer "Toaplan"
@@ -25107,27 +18503,6 @@ game (
 	year "1999"
 	developer "bootleg"
 	rom ( name kbash2.zip size 3803930 crc 4c466988 md5 f4e855534acd1bf38698a18f0edcffb6 sha1 81347ec2ca7501aa992bd751d83f45941701cc29 )
-)
-
-game (
-	name "Keyboardmania"
-	year "2000"
-	developer "Konami"
-	rom ( name kbm.zip size 34164 crc a88a840d md5 3dc42e78e13829e50e73e206954cd2d9 sha1 1de7f70ecd34f577e9e6edec0c2f5425d54eebe2 )
-)
-
-game (
-	name "Keyboardmania 2nd Mix"
-	year "2000"
-	developer "Konami"
-	rom ( name kbm2nd.zip size 34158 crc d843e859 md5 6c065f1e9cce685da4f369862883d7ce sha1 d59079c2bc73a754e094133ba3a84743da00bb54 )
-)
-
-game (
-	name "Keyboardmania 3rd Mix"
-	year "2001"
-	developer "Konami"
-	rom ( name kbm3rd.zip size 34159 crc 89586953 md5 6634b6d6d8cee682da8795208da03c82 sha1 801e41d99e6221b2c99372a8fa337cce737edb85 )
 )
 
 game (
@@ -25149,20 +18524,6 @@ game (
 	year "1984"
 	developer "Data East USA"
 	rom ( name kchampvs2.zip size 73117 crc fbf36901 md5 683d89ba979569304eb53613a839ecab sha1 c8c046fade0200cfae43cd7a5a5d2a8c253df3d1 )
-)
-
-game (
-	name "Dead Eye (GV054 UA01)"
-	year "1996"
-	developer "Konami"
-	rom ( name kdeadeye.zip size 170 crc 4758dbb4 md5 c36437a272878a36ce63948f699196ba sha1 94dc7c62abb98d9c12e40bb5afb36190d3d91bff )
-)
-
-game (
-	name "King of Dynast Gear (version 1.8)"
-	year "1999"
-	developer "EZ Graphics"
-	rom ( name kdynastg.zip size 7716855 crc 2bf72300 md5 f0904eb19f3819116d6e2c8bd469541a sha1 fad4766e2fc9e5e43726756aa846e35c7f504bb8 )
 )
 
 game (
@@ -25233,13 +18594,6 @@ game (
 	year "1993"
 	developer "Sammy Industries"
 	rom ( name keroppi.zip size 910866 crc 0c5d5216 md5 499f76867e751b7127e4dd861d7bb8d0 sha1 e8037fc8a34b2462c7aeafe8bb68f589619bd266 )
-)
-
-game (
-	name "La Keyboardxyu (GDS-0017)"
-	year "2001"
-	developer "Sega"
-	rom ( name keyboard.zip size 1194 crc d08ba982 md5 6946920af7d2a62c970c5f3d019287a8 sha1 74944d9219344b342650de916528e2ca95bf9c21 )
 )
 
 game (
@@ -25320,13 +18674,6 @@ game (
 )
 
 game (
-	name "Kick for the Goal"
-	year "1994"
-	developer "Jaleco"
-	rom ( name kftgoal.zip size 1916358 crc 300aa2c0 md5 1665f76952981c59f3d4778c5143037a sha1 dc43c15c1feaa3dfa5ad1abdff378a8ec3761482 )
-)
-
-game (
 	name "K.G Bird - 4VXFC5341 (New Zealand, 87.98%)"
 	year "1996"
 	developer "Aristocrat"
@@ -25337,7 +18684,7 @@ game (
 	name "K.G Bird - 4VXFC5341 (New Zealand, 91.97%)"
 	year "1996"
 	developer "Aristocrat"
-	rom ( name kgbirda.zip size 49824 crc c43fd293 md5 6279ff80683f338182d20c5fb9bc20d8 sha1 1309700a33c5b36e276df365a160c4f5056b0943 )
+	rom ( name kgbirda.zip size 4871 crc 4c4a7b19 md5 566dd20773baa19fc57f07a4097d703c sha1 ce9efba7247a4cf9fcfcb88c613169c76cf9d8dc )
 )
 
 game (
@@ -25345,13 +18692,6 @@ game (
 	year "1981"
 	developer "Midway"
 	rom ( name kick.zip size 36183 crc c6456218 md5 4e525a8465af9c9fac9209a096a41f51 sha1 073286879a13523c446b1e4ffb18c9a8b134a661 )
-)
-
-game (
-	name "Kick '4' Cash"
-	year "2004"
-	developer "Sega"
-	rom ( name kick4csh.zip size 36244504 crc 2179bc37 md5 d75ceb7cd93f5c3f381845b312fa52b2 sha1 d0dfed93ed0133b2e6bd551d58060cb7d7cd39d3 )
 )
 
 game (
@@ -25376,31 +18716,10 @@ game (
 )
 
 game (
-	name "Kick Goal"
-	year "1995"
-	developer "TCH"
-	rom ( name kickgoal.zip size 1189017 crc c3ff3382 md5 8b0dbd8e19bab863db541e5c48f3a13f sha1 25c2f7fe2bb255c1922c0866c98c129c9e5d713d )
-)
-
-game (
 	name "Kickman (upright)"
 	year "1981"
 	developer "Midway"
 	rom ( name kickman.zip size 17098 crc c520cdf9 md5 157f41aec237fbc928106f2696d63ca8 sha1 c03ca0498469ded9183d2152b74da1be175aea20 )
-)
-
-game (
-	name "Kick and Run (World)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name kicknrun.zip size 153123 crc 0da177d8 md5 3ceb63eb806fa6254d90d92fd075c3de sha1 ea2e2873f59a90e83c255ba2eff8c5bc86124e35 )
-)
-
-game (
-	name "Kick and Run (US)"
-	year "1986"
-	developer "Taito America Corp"
-	rom ( name kicknrunu.zip size 61720 crc b8990c7d md5 60ea6bd45a35688e9b4a76e79c8b58ee sha1 e02bf2dcb10f70aebd6a741b18c1e453a0a572a3 )
 )
 
 game (
@@ -25453,20 +18772,6 @@ game (
 )
 
 game (
-	name "KiKi KaiKai"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name kikikai.zip size 228593 crc 8a765bc0 md5 50ad6b55ec94d80d6d534fea3b553edf sha1 45b60dce7f549edcd7a387eccb23418ca369beb1 )
-)
-
-game (
-	name "Kick Start Wheelie King"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name kikstart.zip size 33608 crc 11f18636 md5 069d26bca2ac1ddc4641a13c3cb35302 sha1 f46efa023dfa729f58dd7a72ee3ca6302ec8354c )
-)
-
-game (
 	name "The Killing Blade (ver. 109, Chinese Board)"
 	year "1998"
 	developer "IGS"
@@ -25481,29 +18786,10 @@ game (
 )
 
 game (
-	name "The Killing Blade Plus (ver. 300)"
-	year "2005"
-	developer "IGS"
-	rom ( name killbldp.zip size 17948231 crc 505169fd md5 b506ca95a4248fb61d9aed7a8b759b5c sha1 bb77823efc90b06aad533bc8b7cab25a94d7f816 )
-)
-
-game (
 	name "Killer Comet"
 	year "1980"
 	developer "GamePlan (Centuri license)"
 	rom ( name killcom.zip size 11091 crc 747951f7 md5 b3adec921e494e0b8c4df134c9d429d0 sha1 a432c06f4b2045955a0828d6003c5ffc5898a079 )
-)
-
-game (
-	name "Kimble Double HI-LO"
-	developer "Kimble Ireland"
-	rom ( name kimbldhl.zip size 11782 crc f3c70717 md5 26036c2a6b34f111eb1250d130840ba2 sha1 23c7ca081a694d8678893a77574404bf70eda11b )
-)
-
-game (
-	name "Kimble Double HI-LO (z80 version)"
-	developer "Kimble Ireland"
-	rom ( name kimblz80.zip size 13962 crc 6149b788 md5 7fa611245f659db5c5d29baddfdb5f94 sha1 f2205052b8b54230d4d1f46174feab750a680aa6 )
 )
 
 game (
@@ -25528,13 +18814,6 @@ game (
 )
 
 game (
-	name "King Derby (Taiwan bootleg)"
-	year "1986"
-	developer "bootleg (Casino Electronics)"
-	rom ( name kingdrbb.zip size 30848 crc eb26b24a md5 7535eeb589e965d9441aa2bd219babd8 sha1 7655992dccbb76b0dced82997c789aa0ef6c0850 )
-)
-
-game (
 	name "King Derby (1981)"
 	year "1981"
 	developer "Tazmi"
@@ -25546,33 +18825,6 @@ game (
 	year "1985"
 	developer "Wood Place Inc."
 	rom ( name kingofb.zip size 131512 crc ae78102b md5 eeffe376e5491f1b331381f35dfb5252 sha1 9e0c8669c490e9e3b2022904a1cfdcdac9becc24 )
-)
-
-game (
-	name "King Pin"
-	year "1983"
-	developer "American Communication Laboratories Inc."
-	rom ( name kingpin.zip size 25561 crc eb534908 md5 a60635fbd7a0c5b764047e7569e11212 sha1 6cfafe2c10a766571889e588898b4a30d3936ed4 )
-)
-
-game (
-	name "King Pin Multi-Game"
-	year "1983"
-	developer "American Communication Laboratories Inc."
-	rom ( name kingpinm.zip size 37756 crc 43d5d031 md5 e976116125a43e0b6b605f82bc96b256 sha1 86741c0bcb213d93a54bf097d8a32c3f341e14f1 )
-)
-
-game (
-	name "King Tut (NSW)"
-	developer "Konami"
-	rom ( name kingtut.zip size 2249931 crc dc45316e md5 b99a2dad7b30aff506a066297efffbb1 sha1 84a0c8d41b44f8ecadd7d152fd86038ea7f91728 )
-)
-
-game (
-	name "Kinnikuman Muscle Grand Prix (KN1 Ver. A)"
-	year "2006"
-	developer "Namco"
-	rom ( name kinniku.zip size 1321532 crc ffd901bd md5 4da2987561bed60a0b284085f247893d sha1 69be602b1843b454ff83d5c7327c43f49f9ed9f5 )
 )
 
 game (
@@ -25625,20 +18877,6 @@ game (
 )
 
 game (
-	name "Killer Instinct 2 (v1.3k, upgrade kit)"
-	year "1995"
-	developer "Rare"
-	rom ( name kinst2k3.zip size 420740 crc 4d9e2a82 md5 9f8e8d59c3f6f1449b267191d6d2fba6 sha1 c814510360bc51cf805d37b53a888667506aa29d )
-)
-
-game (
-	name "Killer Instinct 2 (v1.4k, upgrade kit)"
-	year "1995"
-	developer "Rare"
-	rom ( name kinst2k4.zip size 420942 crc 61057e1a md5 bc3cd252ba1af7a6d2973023f76e800e sha1 e493a0badef015981b14e90f3faf54b185b284bc )
-)
-
-game (
 	name "Killer Instinct (SNES bootleg)"
 	developer "bootleg"
 	rom ( name kinstb.zip size 3209625 crc 4fbbcc5f md5 f4d9affe7cafc2e18aafbcd60eea2a72 sha1 58d57098044b0bd9002059f728cd5141ddec5cf4 )
@@ -25656,27 +18894,6 @@ game (
 	year "1997"
 	developer "Taito Corporation"
 	rom ( name kirameki.zip size 13454543 crc 9239064b md5 56241853e77b49176d50b00012dedd0f sha1 1cf32a578d05a7bcab539c12d1442061fdce9b03 )
-)
-
-game (
-	name "Ryuusei Janshi Kirara Star"
-	year "1996"
-	developer "Jaleco"
-	rom ( name kirarast.zip size 13551531 crc b28fb495 md5 390ff256e11415db1477ffcc03f3b809 sha1 1765d3b4a15cf5d55252f0246a319cc8029ebc51 )
-)
-
-game (
-	name "Kisekae Hanafuda"
-	year "1995"
-	developer "I&apos;Max"
-	rom ( name kisekaeh.zip size 1762158 crc f1ac7f0d md5 e146376abb72f220d09113f2be350c67 sha1 8b6ce3a9d1d947be97884c2d8b0523bb4dd02536 )
-)
-
-game (
-	name "Kisekae Mahjong"
-	year "1995"
-	developer "I&apos;Max"
-	rom ( name kisekaem.zip size 1571996 crc 3f5d0b22 md5 c76a39abe3cf446df8018bd02a1d024b sha1 43317db83cd67b7d5413d21d8886b23396b78945 )
 )
 
 game (
@@ -25770,12 +18987,6 @@ game (
 )
 
 game (
-	name "Kuai Le Xi You Ji"
-	developer "IGS"
-	rom ( name klxyj.zip size 2507238 crc 8e2b2b10 md5 7fe730b38a51fac8fdbee7c93dd4941d sha1 0a5b85237027311b40de4f1baf351bf22ca1bb71 )
-)
-
-game (
 	name "Knuckle Heads (World)"
 	year "1992"
 	developer "Namco"
@@ -25804,13 +19015,6 @@ game (
 )
 
 game (
-	name "Knightmare (prototype)"
-	year "1983"
-	developer "Gottlieb"
-	rom ( name kngtmare.zip size 34179 crc de99e96c md5 e6da01493f92e4eaad6225de345dd584 sha1 379b5caca5a7ab77874435e647d20178e0a259d4 )
-)
-
-game (
 	name "Knight Boy"
 	year "1986"
 	developer "bootleg"
@@ -25822,13 +19026,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name knights.zip size 2355204 crc 3228e413 md5 0b8c2e3bcad3ca8dc4fe8b06829f62d8 sha1 8a1c9937cda8cc5cbcf44822d99cd12f52c7091b )
-)
-
-game (
-	name "Knights of the Round (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name knightsb.zip size 414437 crc 77f14482 md5 34c9f13b2537d4fe2daa77e30e82666e sha1 12041e83cd91199de449d086c846f7f70a0b7d87 )
 )
 
 game (
@@ -25850,48 +19047,6 @@ game (
 	year "1982"
 	developer "KKK"
 	rom ( name knockout.zip size 10668 crc f12f03ba md5 b25bdfd3bd583dfde3522af1b6336bda sha1 e5dcf993d58fea93f6f8580faa53516f62dce6da )
-)
-
-game (
-	name "Kotoba no Puzzle Mojipittan (Japan, KPM1 Ver.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name knpuzzle.zip size 22507947 crc fe36f5e1 md5 8550c68ff52c9af2bf6a70eaa2422a73 sha1 3604aac5e68c376e6d4ab5a6840ce380073803e3 )
-)
-
-game (
-	name "The King of Dragons (World 910711)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kod.zip size 2365648 crc ad34a945 md5 06488f9f8375a3450e64a2d688f92694 sha1 c8d062de4c56e4de3222977813ea02991d7fe352 )
-)
-
-game (
-	name "The King of Dragons (bootleg)"
-	year "1991"
-	developer "bootleg (Playmark)"
-	rom ( name kodb.zip size 2426849 crc abb0a79f md5 53b651399cde0dcffe90481e72ac0918 sha1 e2c2d6353496278391dc805fbb9b6f48ced774cc )
-)
-
-game (
-	name "The King of Dragons (Japan 910805)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kodj.zip size 522022 crc e45fd2b3 md5 f806cb5670739b088ff4cffefb228f7e sha1 8c016613df924a4dc1dc10689c354fdac598b197 )
-)
-
-game (
-	name "The King of Dragons (USA 910910)"
-	year "1991"
-	developer "Capcom"
-	rom ( name kodu.zip size 494233 crc 8e50dd82 md5 d1d7b9d89468a5481041a023c0c9d5a0 sha1 7c44cf73a90bc753a1cc63f1ad08b8441fcdf98c )
-)
-
-game (
-	name "Kodure Ookami (Japan)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name kodure.zip size 370512 crc 99e46e2b md5 49581849b6b3af6b3217a8181d8d200a sha1 abef54a1ea6158930da68f76702575fde1b70826 )
 )
 
 game (
@@ -26084,41 +19239,6 @@ game (
 )
 
 game (
-	name "The King of Fighters Neowave"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name kofnw.zip size 101031760 crc 8d826193 md5 c05216f9acc98329a70939e06f7feee0 sha1 5f6193a3268c59c35631e7ddd0b9761770c5cae9 )
-)
-
-game (
-	name "The King of Fighters Neowave (Japan)"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name kofnwj.zip size 101032301 crc 42b5d736 md5 9d40241861a95f5ab1884cf44ea9e345 sha1 fbd95cc63fe75d6e6f7c27bba756925ad5200ea7 )
-)
-
-game (
-	name "King of Football"
-	year "1995"
-	developer "BMC"
-	rom ( name koftball.zip size 234155 crc 7b800af1 md5 cbd4c5395e25f64c4f64109e9c65d549 sha1 25e4bcfd2d0912345807a8919cadb034379ac1f3 )
-)
-
-game (
-	name "King of Gladiator (The King of Fighters '97 bootleg)"
-	year "1997"
-	developer "bootleg"
-	rom ( name kog.zip size 18012786 crc 3e16b2be md5 e76331f2701d2c9b9d67f1258b364421 sha1 dea637973e41af47ad5935fb862108556d2b1e9d )
-)
-
-game (
-	name "Koi Koi Part 2"
-	year "1982"
-	developer "Kiwako"
-	rom ( name koikoi.zip size 17174 crc 4fe3bae6 md5 2c84e97dd4c4e4d138b631d9c75f9c38 sha1 1d6a8cf882bb0f1efcadd40bcd2680ef773433fb )
-)
-
-game (
 	name "Koi Koi Shimasho"
 	year "1995"
 	developer "Visco"
@@ -26146,48 +19266,6 @@ game (
 )
 
 game (
-	name "Kokoroji 2"
-	year "1994"
-	developer "Sega"
-	rom ( name kokoroj2.zip size 7736585 crc ef207b8d md5 48070caf26255085780cc0a7b527e9c5 sha1 988728353cbd24b9bed6f0c1328937685c8d8ea3 )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. AAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80a.zip size 179 crc 93381d66 md5 959cb31b7265db1fcc54587c393694ed sha1 6767a30dd31c2ded31c92acfbd7194804bbd9773 )
-)
-
-game (
-	name "Konami 80's Gallery (GC826 VER. JAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80j.zip size 179 crc d1cb7968 md5 895135fc0ef41ebb93c008aca75119fa sha1 f3ced37f8dfe88abe4c121a1de20782d6e81f59f )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. KAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80k.zip size 179 crc 2c2480d5 md5 8e66b5c43f8e0de54ccf85cbb6746cb3 sha1 fc6301236e09fb719977e9ddb16f8c3abf470488 )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. EAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80s.zip size 179 crc a059f691 md5 9490d46b275a48d9968c4825b51f7958 sha1 e24d5e92a45825e8bddcb8639e547ec8a2323a5b )
-)
-
-game (
-	name "Konami 80's AC Special (GC826 VER. UAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name konam80u.zip size 179 crc 006b1b56 md5 bc2f76e67e39b06216540db516bf77af sha1 7dc1caabe197e37a3e01a90cd8fe4c5bf103dbea )
-)
-
-game (
 	name "Konami '88"
 	year "1988"
 	developer "Konami"
@@ -26199,20 +19277,6 @@ game (
 	year "1985"
 	developer "Konami"
 	rom ( name konamigt.zip size 83414 crc b1f1ad5f md5 c0753015de75b4376483dc1d37e6cc4f sha1 8d8369aa1c761aa2e07c3edf05c07f282ef5bed0 )
-)
-
-game (
-	name "Konek-Gorbunok"
-	year "1988"
-	developer "Terminal"
-	rom ( name konek.zip size 30665 crc 289c4ec5 md5 c7fb11bfc778aa674eec8ab3fd729f0f sha1 bfde1c9ec89338dd407b4527df76d57d269d2b3f )
-)
-
-game (
-	name "KO Punch"
-	year "1981"
-	developer "Sega"
-	rom ( name kopunch.zip size 16701 crc d6afeeed md5 603f05e58affacfcdcb03fd43946c9ec sha1 4dd415d376cbd29527adea48ec175114bacb77a7 )
 )
 
 game (
@@ -26292,34 +19356,6 @@ game (
 )
 
 game (
-	name "The Koukouyakyuh"
-	year "1985"
-	developer "Alpha Denshi Co."
-	rom ( name kouyakyu.zip size 93857 crc 602e3d4e md5 d775a54e67fdfffabb02aefa3399091e sha1 813df9abb9d3c74fb9687617ebcd10b0b3f8d41d )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 117)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov.zip size 21034552 crc 3b802066 md5 9c358ab1b41afe0601e6fd9fbbe4b65a sha1 f81a492223da882284a80eaf54fbcdcc3c7a3980 )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 100, Japanese Board)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov100.zip size 1678896 crc f2fed7fc md5 c9fb432e742c1960e9b7dcc656ce3fa7 sha1 3266e4901c3d6463f2bd6ba1be0e0eed3b163298 )
-)
-
-game (
-	name "Knights of Valour / Sangoku Senki (ver. 115)"
-	year "1999"
-	developer "IGS"
-	rom ( name kov115.zip size 2275130 crc 0b910736 md5 df0cf1a9d5e6bc62e6e970045873be4b sha1 c472b3d6f33cf4671d90b7e89608446ad4c02b21 )
-)
-
-game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 107, 102, 100HK)"
 	year "2000"
 	developer "IGS"
@@ -26355,41 +19391,6 @@ game (
 )
 
 game (
-	name "Knights of Valour 2 Plus - Nine Dragons / Sangoku Senki 2 Plus - Nine Dragons (ver. M204XX)"
-	year "2001"
-	developer "IGS"
-	rom ( name kov2p.zip size 25085991 crc 15f1904b md5 4a8f921d906eaad7115e7cefdc6ee759 sha1 45e1f2d471334d1d582f18f7403851ef5dd6beea )
-)
-
-game (
-	name "Knights of Valour 2 Plus - Nine Dragons / Sangoku Senki 2 Plus - Nine Dragons (ver. M205XX)"
-	year "2001"
-	developer "IGS"
-	rom ( name kov2p205.zip size 927458 crc 1c4426fe md5 1cece18d22fe23384955c7f5cb16ad88 sha1 133bee61466ce8458754d3e4d87ec248ca2f4b71 )
-)
-
-game (
-	name "Knights of Valour - The Seven Spirits"
-	year "2004"
-	developer "Sammy / IGS"
-	rom ( name kov7sprt.zip size 109190277 crc 237152cc md5 a0cf419fab8199b0a1b3f65a4bc5cec4 sha1 638fa7fc572f82e48aaf854eee5951c56a15d88b )
-)
-
-game (
-	name "Knights of Valour Plus / Sangoku Senki Plus (ver. 119)"
-	year "1999"
-	developer "IGS"
-	rom ( name kovplus.zip size 21047523 crc ff1e6cbe md5 0639ae00812e3ff76c22ec718c34a187 sha1 e90d545515e31b5d31d200a64a19d126d6b1b5a5 )
-)
-
-game (
-	name "Knights of Valour Plus / Sangoku Senki Plus (alt ver. 119)"
-	year "1999"
-	developer "IGS"
-	rom ( name kovplusa.zip size 1685084 crc a2370639 md5 9eb8d7a6d11165ed04882fe2480a5c48 sha1 3db9214cbda15f3bcf2fd9ef1c127cef31fd7513 )
-)
-
-game (
 	name "Knights of Valour Super Heroes / Sangoku Senki Super Heroes (ver. 104, CN)"
 	year "1999"
 	developer "IGS"
@@ -26401,13 +19402,6 @@ game (
 	year "1999"
 	developer "IGS"
 	rom ( name kovsh103.zip size 2783303 crc 4a05d6cf md5 5898d5c8a5639de56641651fa6e85a60 sha1 cdc7568d5f098daf45417ea9f1dd3f45a3247c3c )
-)
-
-game (
-	name "Knights of Valour Super Heroes Plus / Sangoku Senki Super Heroes Plus (ver. 100)"
-	year "2004"
-	developer "IGS"
-	rom ( name kovshp.zip size 22558360 crc af2180e3 md5 58ecaedcf7e6ffbe542106047ad6a5de sha1 a0d6e8a6e0b2586bf6bc92c7f7048cacea96cfbb )
 )
 
 game (
@@ -26460,13 +19454,6 @@ game (
 )
 
 game (
-	name "Kyukyoku Tiger (Japan)"
-	year "1987"
-	developer "Toaplan / Taito Corporation"
-	rom ( name ktiger.zip size 43409 crc 184d5f36 md5 fa3ec97b2e809be0124debfd935ff4f3 sha1 fc6cf4d696448944a3552a4488c3ad60f9118b18 )
-)
-
-game (
 	name "Kyukyoku Tiger II (Ver 2.1J 1995/11/30)"
 	year "1995"
 	developer "Taito Corporation"
@@ -26509,13 +19496,6 @@ game (
 )
 
 game (
-	name "Kung Fu Roushi"
-	year "1987"
-	developer "Namco"
-	rom ( name kungfur.zip size 259029 crc 6a1db4b0 md5 0331bed50c9423653496acc99c7a2c05 sha1 603ff97eab2dc409611e234502ff4d79aee3e134 )
-)
-
-game (
 	name "Kung-Fu Taikun"
 	year "1984"
 	developer "Seibu Kaihatsu"
@@ -26527,13 +19507,6 @@ game (
 	year "1984"
 	developer "Seibu Kaihatsu"
 	rom ( name kungfuta.zip size 60797 crc 35b31e6e md5 aab218efcd132c69b69e95b043cab06d sha1 e82c67b7ea149689c108ff7d2a4763f15d0e732b )
-)
-
-game (
-	name "Nekketsu Kouha Kunio-kun (Japan)"
-	year "1986"
-	developer "Technos Japan"
-	rom ( name kuniokun.zip size 336294 crc d64973ea md5 d8abbcb52095b328f3390aa4aac94626 sha1 ce9abdb28a5fb1df04d555eab433bdd1c4f208ad )
 )
 
 game (
@@ -26569,20 +19542,6 @@ game (
 	year "1988"
 	developer "Taito America Corporation"
 	rom ( name kurikintu.zip size 71230 crc af130518 md5 18cf41dda6e3bb80f9374362595e1f2b sha1 5a064ee6d85d3e4bfe099321bc168cdce01a87e1 )
-)
-
-game (
-	name "Kurukuru Chameleon (GDL-0034)"
-	year "2006"
-	developer "Able"
-	rom ( name kurucham.zip size 1196 crc 5d89791e md5 bc65ab557d701ba1f5469bfd41e3c0ae sha1 87fa37343cb71184ed002ac724392de21197b90e )
-)
-
-game (
-	name "Kurukuru Fever"
-	year "2003"
-	developer "Aruze / Takumi"
-	rom ( name kurufev.zip size 13646483 crc 375e053a md5 5a93e0bf3c302ee2a730b1e38f473bcf sha1 a427fa81176f7545837d14c3c9188b959895ed05 )
 )
 
 game (
@@ -26711,48 +19670,6 @@ game (
 )
 
 game (
-	name "Laguna Racer"
-	year "1977"
-	developer "Midway"
-	rom ( name lagunar.zip size 5584 crc 7dba2f3c md5 b20dc0c76887404f884f2fee0b9b2ccc sha1 5fa32d3eb3aec2d21c8a6b4d16a6aef05d23e447 )
-)
-
-game (
-	name "L.A. Machineguns"
-	year "1998"
-	developer "Sega"
-	rom ( name lamachin.zip size 76230646 crc fe18628f md5 0093f82839e7b1f78986ad9f926642a2 sha1 efc0b0267a3f7ce6baaaac3b0c407b858689fc7e )
-)
-
-game (
-	name "Land Breaker (World) / Miss Tang Ja Ru Gi (Korea) (pcb ver 3.02)"
-	year "1999"
-	developer "Eolith"
-	rom ( name landbrk.zip size 13460185 crc 2c47a71a md5 92c39aa4590dfcae7e0f50734443f31e sha1 b51683f064d64c0474b1b4d6643d83712bde77d0 )
-)
-
-game (
-	name "Land Breaker (World) / Miss Tang Ja Ru Gi (Korea) (pcb ver 3.03)"
-	year "1999"
-	developer "Eolith"
-	rom ( name landbrka.zip size 12634374 crc a6c8a27b md5 154c886e53e3eda5062c9bce6a0d63cf sha1 2c55436145019512e14aedb338facfe320ce2f0e )
-)
-
-game (
-	name "Landing Gear"
-	year "1995"
-	developer "Taito"
-	rom ( name landgear.zip size 12727293 crc beb1e6eb md5 4e438ebbd4c2ce8048ee2ef3f76a150d sha1 94465fcf98b29baff81ee23c6cd935c0aad87ced )
-)
-
-game (
-	name "Landing High Japan"
-	year "1999"
-	developer "Taito"
-	rom ( name landhigh.zip size 33097 crc e3854b89 md5 bcb550ce90cbeb0b59eaf7c9c2deab5c sha1 5e5f47427cd428f78ba247b618b795003ea7cf4d )
-)
-
-game (
 	name "Land Maker (Ver 2.01J 1998/06/01)"
 	year "1998"
 	developer "Taito Corporation"
@@ -26774,20 +19691,6 @@ game (
 )
 
 game (
-	name "La Perla Nera (Ver 2.0)"
-	year "2002"
-	developer "Nazionale Elettronica"
-	rom ( name laperla.zip size 585987 crc 71833ca3 md5 5a052f5bdd3b6c44c3ac1b816dd6fbc1 sha1 998b09003bfe712546dcb489176f96b76534733b )
-)
-
-game (
-	name "La Perla Nera Gold (Ver 2.0)"
-	year "2001"
-	developer "Nazionale Elettronica"
-	rom ( name laperlag.zip size 529971 crc 316a5f8a md5 5c0cefeb665d97e3d3e8b806e2fecbb1 sha1 16e491d764c61473d20318eb5cb2702fee8104ae )
-)
-
-game (
 	name "Astro Laser"
 	year "1980"
 	developer "bootleg (Leisure Time Electronics Inc.)"
@@ -26795,45 +19698,10 @@ game (
 )
 
 game (
-	name "Laser 2001 (Ver 1.2)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name laser2k1.zip size 334003 crc 3324b809 md5 c1041e25e27634a7203fde6be14342ab sha1 4f6055b52c3db6c3614cf2927d8875fc9dac0d31 )
-)
-
-game (
-	name "Laser Base (set 1)"
-	year "1981"
-	developer "Hoei (Amstar license)"
-	rom ( name laserbas.zip size 20901 crc 11a2a15c md5 4e8c36972bf79193a93d2d8daeaed5e9 sha1 96ff88659c8dac0501595a4b02ef47daeef73e68 )
-)
-
-game (
-	name "Laser Base (set 2)"
-	year "1981"
-	developer "Hoei (Amstar license)"
-	rom ( name laserbasa.zip size 6572 crc 32600a35 md5 c83d0e6cf5088e488de710d27385b65a sha1 3457189fdaf894c2b4b7f7c63c62b46062442c89 )
-)
-
-game (
-	name "Laser Battle"
-	year "1981"
-	developer "Zaccaria"
-	rom ( name laserbat.zip size 22389 crc 48d626f0 md5 a19ab551d4bf2c1fac8e2758932cb7d8 sha1 9a9fe6b88a4f925435a9d1150d607159ce88b822 )
-)
-
-game (
 	name "Lasso"
 	year "1982"
 	developer "SNK"
 	rom ( name lasso.zip size 20219 crc 5936c688 md5 4d92cdb6fd25e34076be668471e5a5f9 sha1 6275f51e56fed847fab070865d0b0c33f118749a )
-)
-
-game (
-	name "The Last Bounty Hunter v0.06"
-	year "1994"
-	developer "American Laser Games"
-	rom ( name lastbh.zip size 85759 crc 25d4995a md5 c84fcc7f9c7eca07cc7d937cffeb1446 sha1 dcb2a4a6f483360017babea10311f2d5e2a4632e )
 )
 
 game (
@@ -26855,20 +19723,6 @@ game (
 	year "1998"
 	developer "SNK"
 	rom ( name lastbld2.zip size 32382410 crc 3e60c222 md5 6ff6a655b42abcc8a685001f3b85d075 sha1 f6efeb91fe2de6c7a2abc48f13a609560526571a )
-)
-
-game (
-	name "Last Bronx (Export, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name lastbrnx.zip size 16049836 crc 8367723f md5 2a5f127925453978df0a79b7aee972fb sha1 afda93aa08ac97ee2eb50661f45fcef4b771b4ae )
-)
-
-game (
-	name "Last Bronx (Japan, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name lastbrnxj.zip size 370248 crc 59d0189d md5 25cd10f7ac588b19ca00156ec5de3ca3 sha1 cc91f1c8abb0bc62294ad4125c811a526dfc45f3 )
 )
 
 game (
@@ -26914,13 +19768,6 @@ game (
 )
 
 game (
-	name "Last Fighting"
-	year "2000"
-	developer "Subsino"
-	rom ( name lastfght.zip size 2376418 crc 2accacfc md5 57e87244a639c6a624e049d76248b50d sha1 b5be471851dd8c5a3cda3a7036766a43533eafd3 )
-)
-
-game (
 	name "Last Fortress - Toride"
 	year "1994"
 	developer "Metro"
@@ -26949,44 +19796,10 @@ game (
 )
 
 game (
-	name "Last Mission (US revision 6)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name lastmisn.zip size 208085 crc 0b434f4e md5 0dfaa0a8d4cbc6c20b0881d4bdc42ac7 sha1 6e0fdcf44eb80a01e9be1c1738bb6940bbdda820 )
-)
-
-game (
-	name "Last Mission (Japan)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name lastmisnj.zip size 54294 crc 68c1500c md5 089309874b171c934b2cef2c0cedb240 sha1 e57ce2f277e30addcd01845d3a22f7ea00f2dac5 )
-)
-
-game (
-	name "Last Mission (US revision 5)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name lastmisno.zip size 16157 crc dfc3cc66 md5 1dd1691571feb75710299079246817d0 sha1 282f7a1aa5345e41eb51277129c2860cd3fadb4e )
-)
-
-game (
 	name "The Last Soldier (Korean release of The Last Blade)"
 	year "1997"
 	developer "SNK"
 	rom ( name lastsold.zip size 271015 crc edfa0b9f md5 d910567a1060d5f114d8fde814dd17cf sha1 765e536d2673a13c3c3f486713c4e859ae659b8c )
-)
-
-game (
-	name "Las Vegas, Nevada"
-	developer "hack"
-	rom ( name lasvegas.zip size 2985 crc 92262b6b md5 3b5ea8b3339d5d7407c305b0f65693ad sha1 5748584befc905f83bf5a9cd3209518c015d9438 )
-)
-
-game (
-	name "Lazarian"
-	year "1981"
-	developer "Zaccaria (Bally Midway license)"
-	rom ( name lazarian.zip size 22950 crc 9483091f md5 918aaf02c35bcac7d879bda2c666c760 sha1 f83e9bb7889385f197bb028218f4740e16e1e789 )
 )
 
 game (
@@ -27077,14 +19890,7 @@ game (
 	name "Lead Angle (Japan)"
 	year "1988"
 	developer "Seibu Kaihatsu"
-	rom ( name leadang.zip size 770957 crc d9c121ed md5 029d5c5b04c606148c444464c25e3f84 sha1 2eb5699ce0dea18680c7a8d58a0890107689fef2 )
-)
-
-game (
-	name "Leader"
-	year "1995"
-	developer "bootleg"
-	rom ( name leader.zip size 215539 crc 3625a876 md5 9c694d541eebc76a621f81012e3972d3 sha1 0a4936a511dc09efe40fc90315b832de101bd170 )
+	rom ( name leadang.zip size 108021 crc cb6894da md5 9b8e06044ea94e6dcc097a39d1716206 sha1 1e3235d42b44fc691498c8dba0ab645fc57407ad )
 )
 
 game (
@@ -27102,24 +19908,10 @@ game (
 )
 
 game (
-	name "Led Storm Rally 2011 (US)"
-	year "1988"
-	developer "Capcom"
-	rom ( name ledstorm2.zip size 320086 crc b8c6d1b2 md5 4659ee1528557154d3eb27d80bc650b0 sha1 b13d60769580b3af94da202a5e620eed3142d4a3 )
-)
-
-game (
 	name "Legend"
 	year "1986"
 	developer "Sega / Coreland"
 	rom ( name legend.zip size 93944 crc 16b93060 md5 04230335f8ece6a0b64bf861b3f6176c sha1 551736b4387a1579ac88caf9b0827632f172ec76 )
-)
-
-game (
-	name "Legend of Heroes"
-	year "2000"
-	developer "Limenko"
-	rom ( name legendoh.zip size 7731481 crc a46d9aa7 md5 cc0c10ccb8f4006090d18060dedba3b7 sha1 831451622364c342021f7d4d6f2765f8cb30d57e )
 )
 
 game (
@@ -27130,45 +19922,10 @@ game (
 )
 
 game (
-	name "Chouji Meikyuu Legion (ver 2.03)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name legion.zip size 263039 crc 4bafa598 md5 383ec23c8a36e076631825618af1f0fa sha1 bdbf52de32c89377f150e21faabd3c9968547521 )
-)
-
-game (
-	name "Legionnaire (World)"
-	year "1992"
-	developer "TAD Corporation"
-	rom ( name legionna.zip size 1385055 crc f4c4112e md5 283aabf122e22c22cf262453b2ae2fc8 sha1 5fea88b8383c843c67bfdff6269c058d8917ab29 )
-)
-
-game (
-	name "Legionnaire (US)"
-	year "1992"
-	developer "TAD Corporation (Fabtek license)"
-	rom ( name legionnau.zip size 62488 crc 8ea28d60 md5 350e89fe0ee479c293bf2eb259ca09f3 sha1 1d8ebf0d19616a88bac42df7088a0798fe92648a )
-)
-
-game (
-	name "Chouji Meikyuu Legion (ver 1.05)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name legiono.zip size 75161 crc 6d1720a4 md5 395b6cb8e11a7df6e66f0cfbf389fbbe sha1 de86ad1a8894cd6227d718d613931f05d80b33f8 )
-)
-
-game (
 	name "Koukuu Kihei Monogatari - The Legend of Air Cavalry (Japan)"
 	year "1988"
 	developer "SNK"
 	rom ( name legofair.zip size 44472 crc d0131419 md5 0397de9289f504b7d6388ffbc27afec7 sha1 c8fdc7deb1b5b4a5399c07f4eb9ad35a7d458709 )
-)
-
-game (
-	name "LeMans 24"
-	year "1997"
-	developer "Sega"
-	rom ( name lemans24.zip size 34776980 crc 68890e92 md5 6d382eb8048873f9e4643426288611c8 sha1 e01f579cc409d05a0cbfa2210dded51447a361bb )
 )
 
 game (
@@ -27277,13 +20034,6 @@ game (
 )
 
 game (
-	name "Laser Grand Prix"
-	year "1983"
-	developer "Taito"
-	rom ( name lgp.zip size 127683 crc 5b54fdff md5 b4749e38fb6cfbb639970c9001f47ecd sha1 cc8b4c4d90f5d33b64523f40dea0858a79eadcdc )
-)
-
-game (
 	name "Lightning Fighters (World)"
 	year "1990"
 	developer "Konami"
@@ -27365,32 +20115,6 @@ game (
 	year "1995"
 	developer "IGS"
 	rom ( name lhbv33c.zip size 614804 crc e355ff73 md5 c7d0c5f4e62bc2b003a61aa23b251600 sha1 74ef018ccf56f2d638336b3566f72330f20cfd7a )
-)
-
-game (
-	name "Mahjong Long Hu Zheng Ba 2 (set 1)"
-	year "1998"
-	developer "IGS"
-	rom ( name lhzb2.zip size 1189788 crc 9b24bc23 md5 dda02a60ea279fdb344851df04bce888 sha1 4ae436468c6e840cc96b71efbbe2e81a846f9b02 )
-)
-
-game (
-	name "Mahjong Long Hu Zheng Ba 2 (set 2)"
-	year "1998"
-	developer "IGS"
-	rom ( name lhzb2a.zip size 370183 crc 62e683a3 md5 f7e2ee615b469653b6df49c45350f739 sha1 533ace760b1c0d163ad398c2e4260d5811ba86bf )
-)
-
-game (
-	name "Long Hu Zheng Ba 3"
-	developer "IGS"
-	rom ( name lhzb3.zip size 2779975 crc 88d4dbc1 md5 2800dfd0708186d490b9d187296b6382 sha1 a73a3b9172b156f6b36832d978fd158667fd4295 )
-)
-
-game (
-	name "Long Hu Zheng Ba 4"
-	developer "IGS"
-	rom ( name lhzb4.zip size 3575030 crc 0f90545e md5 6ae757b8612c55c943783371a99044ca sha1 946eaf9195ee95f6a897b721b4eeb4157601ca50 )
 )
 
 game (
@@ -27478,13 +20202,6 @@ game (
 )
 
 game (
-	name "Little Robin"
-	year "1993"
-	developer "TCH"
-	rom ( name littlerb.zip size 794746 crc e48c0140 md5 8c9199af0cc2d1caa069018475dd1906 sha1 571b9b9c2f10eb70d093ff7fa2e2f084ecc91a72 )
-)
-
-game (
 	name "Live Gal (Japan 870530)"
 	year "1987"
 	developer "Central Denshi"
@@ -27548,20 +20265,6 @@ game (
 )
 
 game (
-	name "Lunar Lander (rev 2)"
-	year "1979"
-	developer "Atari"
-	rom ( name llander.zip size 10198 crc dac7d478 md5 9814166b25c9dcbc68ad1de183a069d7 sha1 dc7aff9095bbabef7e1069eff934c82c8c45224a )
-)
-
-game (
-	name "Lunar Lander (rev 1)"
-	year "1979"
-	developer "Atari"
-	rom ( name llander1.zip size 5529 crc 8d3d776e md5 bc50273b22780415fe4a0ea58e15c332 sha1 7247648460d981dad9cf3fa774b1030c7131b50b )
-)
-
-game (
 	name "Lucky Lady (3x3 deal)"
 	year "1991"
 	developer "TAB Austria"
@@ -27580,20 +20283,6 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name lnc.zip size 18677 crc bf2ec92c md5 9009dbd01f0663d5f2687cea8d21dd5c sha1 5985688c8a6b0a46ff8c37b7c6c5fa98704d3aab )
-)
-
-game (
-	name "Locked 'n Loaded (World)"
-	year "1994"
-	developer "Data East Corporation"
-	rom ( name lockload.zip size 14957720 crc 87ed7615 md5 c6d3a4270c9ee3f2813f3cd82faa3b4a sha1 b170be66e75c6e06e7d5c98cfdaa8325e1a522db )
-)
-
-game (
-	name "Locked 'n Loaded (US)"
-	year "1994"
-	developer "Data East Corporation"
-	rom ( name lockloadu.zip size 1022729 crc 12d3f0cd md5 593ba518af5e3c3881493bf59b4219bb sha1 638a486019dda72b692b7159bd94643eaeffc13e )
 )
 
 game (
@@ -27639,13 +20328,6 @@ game (
 )
 
 game (
-	name "Line of Fire / Bakudan Yarou (World, FD1094 317-0136)"
-	year "1989"
-	developer "Sega"
-	rom ( name loffire.zip size 1541052 crc daac76b9 md5 ad9694e50968fd9f161322ee6695ff8a sha1 7a2650b1a6c6fa07abce6a61ae6b9e18d612c732 )
-)
-
-game (
 	name "Line of Fire / Bakudan Yarou (Japan, FD1094 317-0134)"
 	year "1989"
 	developer "Sega"
@@ -27678,20 +20360,6 @@ game (
 	year "1996"
 	developer "Deniam"
 	rom ( name logicpro.zip size 1666285 crc 909c6c69 md5 74279f969394acd41840bbb93bdb9594 sha1 112ea8400bccc9ed023b2a3b357b6150aaa9b49c )
-)
-
-game (
-	name "Legend of Hero Tonma"
-	year "1989"
-	developer "Irem"
-	rom ( name loht.zip size 672682 crc c692fa5b md5 48cf056a36d4eeb771830d9fa1ef0b97 sha1 07d598fa255fbcdde2fd83a97ef5029de95d04cd )
-)
-
-game (
-	name "Legend of Hero Tonma (bootleg, set 1)"
-	year "1989"
-	developer "bootleg"
-	rom ( name lohtb.zip size 553576 crc 33959c4f md5 228115f97170b56007839b823a21eb66 sha1 aeb16ae8c3df7fdf8003481a0c14c3fc447b305d )
 )
 
 game (
@@ -27744,20 +20412,6 @@ game (
 )
 
 game (
-	name "Lord of Gun (USA)"
-	year "1994"
-	developer "IGS"
-	rom ( name lordgun.zip size 9849237 crc b029d011 md5 533f9817394b11359a2bfc5ed226cf76 sha1 a180209b8688a9be9bd32c784ea384ffc2e5079b )
-)
-
-game (
-	name "The Lord of King (Japan)"
-	year "1989"
-	developer "Jaleco"
-	rom ( name lordofk.zip size 111147 crc f706641d md5 5c95f34a6dd71c3a927d33f301bb6b3e sha1 e5e1af580ba2bbbfbd355107376779c2fc9bfc3c )
-)
-
-game (
 	name "Lost Tomb (easy)"
 	year "1982"
 	developer "Stern Electronics"
@@ -27769,27 +20423,6 @@ game (
 	year "1982"
 	developer "Stern Electronics"
 	rom ( name losttombh.zip size 2561 crc 012a8e27 md5 9034fd65d8324e768af1bb057192abdc sha1 f4b38342cf16e23ff4385d1e86ffc97fd534d121 )
-)
-
-game (
-	name "Lost Worlds (Japan)"
-	year "1988"
-	developer "Capcom"
-	rom ( name lostwrld.zip size 930597 crc ad301b96 md5 a7e228a5b60e8e3300da3eb5caa2c44c sha1 9997bc68818e333847c064d944e73e84e73dec0a )
-)
-
-game (
-	name "Lost Worlds (Japan Old Ver.)"
-	year "1988"
-	developer "Capcom"
-	rom ( name lostwrldo.zip size 928871 crc aaa73533 md5 9831a2d05a8afd69708b3cbb53cd6c6b sha1 a2c5b622f87ecae0b9ebe612887198a53f288ae5 )
-)
-
-game (
-	name "The Lost World"
-	year "1997"
-	developer "Sega"
-	rom ( name lostwsga.zip size 80345174 crc 68cb8df7 md5 f023a9039700894d2f56b13348d762de sha1 46c607440135d5aa4e0f27b2bb7732cc87cb1536 )
 )
 
 game (
@@ -27863,38 +20496,10 @@ game (
 )
 
 game (
-	name "Little Casino (newer)"
-	year "1984"
-	developer "Digital Controls Inc."
-	rom ( name ltcasinn.zip size 18774 crc 1021ff07 md5 933a8c5ca131ae994387649385534f1e sha1 8fc5566fa344db88f48096109e94abb129e97990 )
-)
-
-game (
-	name "Little Casino (older)"
-	year "1982"
-	developer "Digital Controls Inc."
-	rom ( name ltcasino.zip size 12907 crc 4c9b1e64 md5 fec535f03123576e654f1b94fd556c5d sha1 75d0e9ce212bc18b333487142fad349030ce5b2f )
-)
-
-game (
-	name "Lucky Girl (newer Z180 based hardware)"
-	year "1991"
-	developer "Wing Co., Ltd."
-	rom ( name luckgrln.zip size 295599 crc 2b0ce48d md5 0dca4a3617c8875f828a4cec79034e01 sha1 0fd9ba6f7cf79a5407a365ffe2c2c87dacc5e3a1 )
-)
-
-game (
 	name "Lucky 74 (bootleg, set 1)"
 	year "1988"
 	developer "Wing Co., Ltd."
 	rom ( name lucky74.zip size 152900 crc c6e6d0df md5 04c31f7f067cca5baeb9181df1efc263 sha1 e68c5e65a5775986d5acf92108c731f2d84596a9 )
-)
-
-game (
-	name "Lucky 74 (bootleg, set 2)"
-	year "1988"
-	developer "Wing Co., Ltd."
-	rom ( name lucky74a.zip size 97520 crc ff339ef4 md5 afb057f1f06ac1498411fb4d037f96b3 sha1 6e7c2408bd4ea03b482084dd7f1598d79b615d1b )
 )
 
 game (
@@ -27905,23 +20510,10 @@ game (
 )
 
 game (
-	name "New Lucky 8 Lines (set 2, W-4)"
-	year "1989"
-	developer "Wing Co., Ltd. / GEI"
-	rom ( name lucky8a.zip size 45097 crc 0ef30d0e md5 5cdf4e4382f047e2692038b533c7a8f8 sha1 340ff805ea820b9948b605e98f155c1dabff2673 )
-)
-
-game (
 	name "New Lucky 8 Lines (set 3, W-4, extended gfx)"
 	year "1989"
 	developer "Wing Co., Ltd. / GEI"
 	rom ( name lucky8b.zip size 46832 crc dc5c73a9 md5 42738d1b14af87ed568c9c4ad099c324 sha1 c153d17a97684a7b95e03a6989e4f19dbd2c1d1b )
-)
-
-game (
-	name "Lucky Girl? (Wing)"
-	developer "Wing Co., Ltd."
-	rom ( name luckygrl.zip size 17233 crc 165d57d1 md5 accfb2df8333cc068090f427bb8c8a4e sha1 700ef5aadb0637353af0c9b2990f7e74e652730f )
 )
 
 game (
@@ -27936,13 +20528,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name luckywldj.zip size 97675 crc c78803a7 md5 672fa1196e36b7c0c72402a09f39aad3 sha1 af927a91630a4b92cfbf900dacd7893b8b494c0f )
-)
-
-game (
-	name "Lucky Today"
-	year "1980"
-	developer "Sigma"
-	rom ( name luctoday.zip size 4704 crc ffd91d42 md5 6c1d9ca0d886fc59ac925336347e8628 sha1 da712bd1d52399caf0ac230fa4e7ed668356782e )
 )
 
 game (
@@ -27974,31 +20559,10 @@ game (
 )
 
 game (
-	name "Lupin The Third - The Shooting (GDS-0018)"
-	year "2001"
-	developer "Sega"
-	rom ( name lupinsho.zip size 1192 crc 40fdbe2d md5 fa19212aca517b7b5c3ccdd953ba6e66 sha1 4f152414f6c8ff35f8b7b5b4d7d51a69c5dd5bee )
-)
-
-game (
-	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128)"
-	year "1999"
-	developer "Omega System"
-	rom ( name luplup.zip size 4717969 crc 452fa4ef md5 7b7f42508210657c0c2cc5baf93dc75c sha1 1a648888ef5587a470f20889d10df0aa74cc7d44 )
-)
-
-game (
 	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 2.9 / 990108)"
 	year "1999"
 	developer "Omega System"
 	rom ( name luplup29.zip size 4653735 crc f5f67553 md5 5b2c96e8bcfc97319be81bd560a75819 sha1 1e04c2ad8cc59bb7928ad1d505ba7a44f3ab2877 )
-)
-
-game (
-	name "Lupin The Third - The Typing (Rev A) (GDS-0021A)"
-	year "2002"
-	developer "Sega"
-	rom ( name luptype.zip size 1197 crc 0ac3fc59 md5 cd00c6049acd6cd975274e658a436bcd sha1 ea085aaf6f4b93f25a3f39f46301c7ae79780558 )
 )
 
 game (
@@ -28090,13 +20654,6 @@ game (
 	year "1977"
 	developer "RamTek"
 	rom ( name m79amb.zip size 7843 crc bb6b14be md5 333b87c1962e3658e35be9970499f60d sha1 6f36c14928724f598598b494a50b673a5c932825 )
-)
-
-game (
-	name "Club Grandslam (UK, Game Card 95-750-843)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_bcgslm.zip size 263912 crc a1438f69 md5 cf7ecd859d46a3f57725e7bbbd68ac46 sha1 68032e1767472357f82fe3905881ec51573efb6a )
 )
 
 game (
@@ -28226,151 +20783,10 @@ game (
 )
 
 game (
-	name "Focus (Dutch, Game Card 95-750-347)"
-	year "1995"
-	developer "BFM/ELAM"
-	rom ( name m_bfocus.zip size 150837 crc da901cdb md5 1122c7c5a3bcf2c87b7549df0399ede6 sha1 d7f925bf9bb5cf7029ee19a424272f6b867cf2a6 )
-)
-
-game (
-	name "The Big Breakfast (Set 2)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs1.zip size 58353 crc 7d330458 md5 3127c89e70bfd0f484320b42cfb00450 sha1 d4cfa058978d146091f89fc2aef35b11fa452fd6 )
-)
-
-game (
-	name "The Big Breakfast (Set 3)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs2.zip size 58279 crc 875e1784 md5 e847eb37675731631da5fbaa5cb2688b sha1 8840bb579db1e6662426bee355e8e82af77cfd8f )
-)
-
-game (
-	name "The Big Breakfast (Set 4)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs3.zip size 58276 crc a8795823 md5 3f2f0c10fb3025dac06d38c7be2428c7 sha1 b298975cd9aa4ee53a2a75b4d4a3d459b4b27fb3 )
-)
-
-game (
-	name "The Big Breakfast (Set 5)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs4.zip size 58288 crc 284c20ea md5 677b6f5a457c26c3547c15fae09e0a22 sha1 939490b5693b99924860d9a35c4dcb00cf3fabf0 )
-)
-
-game (
-	name "The Big Breakfast (Set 6)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfs5.zip size 58230 crc 2682ac0d md5 0d0aa37364bf6d136c7b7ccd92963b8a sha1 6b3cda03dad7f95cafa1d5b7a4515413f9071878 )
-)
-
-game (
-	name "The Big Breakfast (Set 1 UK, Game Card 95-750-524)"
-	year "1994"
-	developer "BFM"
-	rom ( name m_brkfst.zip size 514600 crc e447917e md5 0b971d8e367f1978a6c80e49e0868436 sha1 fce3370e4435782a3ccf23f01426b461779b3f78 )
-)
-
-game (
-	name "Club Celebration"
-	developer "Barcrest"
-	rom ( name m_ccelbr.zip size 38682 crc a426542f md5 69aa90c169ab40785a9cf4525f9cf885 sha1 97c19aca065b0bf2c5b54406685433a33bc7ed49 )
-)
-
-game (
-	name "Club attraction (UK, Game Card 39-370-196)"
-	year "1990"
-	developer "BFM"
-	rom ( name m_clattr.zip size 57171 crc f688292b md5 23b7882732122479dfb38e3d28292583 sha1 dd11694090fea2818ce684a5d6d4b1e4064bcb6c )
-)
-
-game (
-	name "Club Public Enemy No.1 (UK, Game Card 95-750-846)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_cpeno1.zip size 559225 crc c9b4cfaa md5 1b0ebb29051b5b3e5b0314e5be8b3e6b sha1 e48cfc9cb68e289df5c3cb2469394767450497d5 )
-)
-
-game (
-	name "Gamball"
-	developer "Barcrest"
-	rom ( name m_gmball.zip size 35152 crc 6819888d md5 547ffb9ef5ea6b40e698a2eb24b8ad4f sha1 acc5809a990a98e7e784d28f5428c61ddfe61cc7 )
-)
-
-game (
-	name "Honey Money"
-	developer "Vivid"
-	rom ( name m_honmon.zip size 1469020 crc d6113d99 md5 9ce231e3e4ca511e93b1810cf5821e57 sha1 01995c8fb2e78939ab062d21a0458a4cc160998b )
-)
-
-game (
-	name "Lotus SE (Dutch)"
-	year "1988"
-	developer "BFM/ELAM"
-	rom ( name m_lotsse.zip size 37807 crc 1431a4db md5 06146180d771bd63294dc91fda300227 sha1 4a91337047cc4b6f26e790d54d89344a50925857 )
-)
-
-game (
-	name "Luvvly Jubbly (UK Multisite 10/25p, Game Card 95-750-808)"
-	year "1996"
-	developer "BFM"
-	rom ( name m_luvjub.zip size 509177 crc 6d9015e6 md5 ea9cb77e2ac41ab9a1fa61e8177988af sha1 39f98bef88dc9a8d19a41045f02938134387c9d1 )
-)
-
-game (
-	name "Old Timer"
-	developer "Barcrest"
-	rom ( name m_oldtmr.zip size 27478 crc 680a52eb md5 9dcd931669ecaa786342211841dad3c4 sha1 6636854bd2585a1dc3fcecea5f0f1e2fb969bfeb )
-)
-
-game (
-	name "Roulette (Dutch, Game Card 39-360-129?)"
-	year "1988"
-	developer "BFM/ELAM"
-	rom ( name m_roulet.zip size 19565 crc 45be306e md5 f82a1e06e2d6808fabc432306ea8766e sha1 ccf2d021318039b6c6462f071d50e0e90b03a329 )
-)
-
-game (
-	name "Spotlight"
-	developer "Maygay Machines Ltd."
-	rom ( name m_sptlgt.zip size 26772 crc b2d066a5 md5 c15427e932f4b21ebca78d402a3d4e29 sha1 35c41e535f7409855ff6d6a7030e863ec2300740 )
-)
-
-game (
-	name "Supercards (Dutch, Game Card 39-340-271?)"
-	year "1985"
-	developer "BFM/ELAM"
-	rom ( name m_supcrd.zip size 20665 crc e5bf2be5 md5 09dbd9f84832666c972b97da0fd786b1 sha1 8c3256c7ba2ae27d8825bc55b8fb27fbc8a18de7 )
-)
-
-game (
-	name "Thunderbirds"
-	developer "JPM"
-	rom ( name m_tbirds.zip size 592978 crc 12026066 md5 e6ccdf0a70366cc0daeca71f50254377 sha1 7979b0bdcec98810ce6bf4157a94a301fa31f5a4 )
-)
-
-game (
-	name "Toppoker (Dutch, Game Card 95-750-899)"
-	year "1996"
-	developer "BFM/ELAM"
-	rom ( name m_tppokr.zip size 92424 crc 8b36303a md5 fab64ccc585f1c450acbe2157b78ef6c sha1 5d1d821e1d784f0e92698b01302fe1927bc54866 )
-)
-
-game (
 	name "Mace: The Dark Age (boot ROM 1.0ce, HDD 1.0b)"
 	year "1996"
 	developer "Atari Games"
 	rom ( name mace.zip size 416703 crc a3a54a34 md5 24ce7207f1344cebd8d3b94f6bf55bcf sha1 2bf4664b3c76210dabc88ac2cd8f0ea31d99deff )
-)
-
-game (
-	name "Mace: The Dark Age (HDD 1.0a)"
-	year "1997"
-	developer "Atari Games"
-	rom ( name macea.zip size 221787 crc d603c957 md5 57253c01e967658be893780d6433eb02 sha1 158f1bf4b8685fafc985b4fa51508d2ebb862b5f )
 )
 
 game (
@@ -28444,13 +20860,6 @@ game (
 )
 
 game (
-	name "Mad Alien (Highway Chase)"
-	year "1980"
-	developer "Data East Corporation"
-	rom ( name madaliena.zip size 15020 crc d3873a30 md5 c4fc94830a8ebc86479f132d221820d7 sha1 ea3ca9f72cbd3e0c492676792464fa66354e071e )
-)
-
-game (
 	name "Mad Ball V2.0"
 	year "1998"
 	developer "Yun Sung"
@@ -28479,52 +20888,10 @@ game (
 )
 
 game (
-	name "Mad Dog McCree v2.03 board rev.B"
-	year "1990"
-	developer "American Laser Games"
-	rom ( name maddog.zip size 52798 crc 09785076 md5 dcbb57ba080f131286a8c6379124ab9d sha1 4f1411477c352adfabc691cb56952f98230d7a79 )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v2.04"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog2.zip size 59550 crc db7bbfe0 md5 2aaf621c89425e7fbeb2f650c837d2ed sha1 522bd13f2c58d19aa5e5a4edaba6d669f33924bb )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v1.0"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog21.zip size 55410 crc 5fc23233 md5 dec34b8c1b2ef7ff475c8d7afc15ab2a sha1 bfbf022d07a786db3a0e2c56a86f448e4ebdc2b2 )
-)
-
-game (
-	name "Mad Dog II: The Lost Gold v2.02"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name maddog22.zip size 57937 crc 276e0b1b md5 22d0229ebc727bf4ba98b48162a51933 sha1 61fcd03bf0dc43c3bce982da86d8414f51d452ef )
-)
-
-game (
-	name "Mad Dog McCree v1C board rev.A"
-	year "1990"
-	developer "American Laser Games"
-	rom ( name maddoga.zip size 41076 crc fa153bb2 md5 d98875c86be543fd64b8c2c9021a0555 sha1 ecba1e90f257abdc5d19e8f7bd562c02f9fd4d1b )
-)
-
-game (
 	name "Mad Donna (set 1)"
 	year "1995"
 	developer "Tuning"
 	rom ( name maddonna.zip size 2325661 crc 730605e7 md5 ff5d27bdfa8c13f8e6bf8c957646f10b sha1 dd796563799f31ba8ee54fb3c71f1a31493ad407 )
-)
-
-game (
-	name "Mad Donna (set 2)"
-	year "1995"
-	developer "Tuning"
-	rom ( name maddonnb.zip size 2260156 crc 19c68577 md5 4786e87eece381ab6c2811f716340d87 sha1 00ed106cdaf13efd5e62ef5ce6299b9caec0a028 )
 )
 
 game (
@@ -28605,13 +20972,6 @@ game (
 )
 
 game (
-	name "Magic's 10 2 (ver 1.1)"
-	year "1997"
-	developer "ABM Games"
-	rom ( name magic102.zip size 464671 crc d970ae36 md5 96f4bec87160bbb5f7ba803bdc474bf9 sha1 f23c2d061032835601f125b09aa253aa6b8c47ee )
-)
-
-game (
 	name "Magic's 10 (ver. 16.45)"
 	year "1995"
 	developer "A.W.P. Games"
@@ -28623,45 +20983,6 @@ game (
 	year "1995"
 	developer "A.W.P. Games"
 	rom ( name magic10b.zip size 32441 crc 6e9e61d5 md5 e618efef513e236ede77a0279886c2b3 sha1 174e6f7f45312c94e0801075621bda973876702b )
-)
-
-game (
-	name "Magical Odds (set 1)"
-	year "1992"
-	developer "Pal Company / Micro Manufacturing Inc."
-	rom ( name magical.zip size 125085 crc 42772023 md5 2b9ece0adba952ce553f3a8fbd9bd3ec sha1 868256920bc257ddba846daf24e2226b13defb9e )
-)
-
-game (
-	name "Magical Odds (set 2)"
-	year "1992"
-	developer "Pal Company / Micro Manufacturing Inc."
-	rom ( name magicala.zip size 74913 crc 50bc6f2e md5 223e38efb9b4667bb01b3ff2cea33384 sha1 9e7a11c68b3f67ca5a27ab8111457dd1d043a1f3 )
-)
-
-game (
-	name "Magic Card (set 1)"
-	developer "Impera"
-	rom ( name magicard.zip size 126993 crc 3cc1a52c md5 254548938ce0eab4165b96f063773885 sha1 cf0da883104dcb73ba920ba110a2682e2206ba93 )
-)
-
-game (
-	name "Magic Card (set 2)"
-	developer "Impera"
-	rom ( name magicarda.zip size 111468 crc be028f77 md5 e35056b669834a6a63c011ede3465bec sha1 70b3f1b1ab9da636b97ee9581eb6d737b21ae549 )
-)
-
-game (
-	name "Magic Card (set 3)"
-	developer "Impera"
-	rom ( name magicardb.zip size 199145 crc 08941aa5 md5 4962f05a038a309f4d33b45192427d0b sha1 925312656e04ccd300d501cab26904f9d780c53f )
-)
-
-game (
-	name "Magic Card Jackpot (4.01)"
-	year "1998"
-	developer "Impera"
-	rom ( name magicardj.zip size 149170 crc ea06a999 md5 b788cbcf9d4299a7a1afeddf7a699b19 sha1 57063eff85047da0e2c9b0f7906d4c7dd6f76ce3 )
 )
 
 game (
@@ -28677,65 +20998,10 @@ game (
 )
 
 game (
-	name "Magic Card II (green TAB or Impera board)"
-	year "1996"
-	developer "Impera"
-	rom ( name magicd2a.zip size 17630 crc 58f557e6 md5 a37d0e20dcba8fb1f1f6a379f244228e sha1 9a1b1a9ed251a7b538b387b154555715617e8793 )
-)
-
-game (
-	name "Magic Card II (blue TAB board, encrypted)"
-	year "1996"
-	developer "Impera"
-	rom ( name magicd2b.zip size 42937 crc e8184ad3 md5 ab7d45f5cd2554ea9ba2b1000e6d0b98 sha1 aff485727378a466e13b5a97405d5ef26d030ad2 )
-)
-
-game (
-	name "Magic Fly"
-	developer "P&amp;A Games"
-	rom ( name magicfly.zip size 6703 crc 74809206 md5 1ddd4eebf74a98850548f5de380a658e sha1 e3041ffbc32cef289cd04d208827738bd40a371f )
-)
-
-game (
-	name "Magic Lotto Export (5.03)"
-	year "2001"
-	developer "Impera"
-	rom ( name magicle.zip size 107602 crc b0cb33a8 md5 6eb2646b171c641dc741d48bebab68a1 sha1 cd92fd490a0e8661f35496a1f5fb0563e3a15bbf )
-)
-
-game (
-	name "Magic Mask (A - 09/05/2000, Export))"
-	year "2000"
-	developer "Aristocrat"
-	rom ( name magicmsk.zip size 1040349 crc 43308267 md5 9e4a6da9711675eb174d8d074d9d14cb sha1 26041f8604eec24b46d6f59b2274c7433baa8924 )
-)
-
-game (
 	name "Magic Card II (Bulgarian)"
 	year "1996"
 	developer "Impera"
 	rom ( name magicrd2.zip size 62909 crc 4d8c8e63 md5 eea78fb28d61fccb221bbfe3ccaab9ae sha1 62da839958ebc377c23f4ba0e1e28c23897e857e )
-)
-
-game (
-	name "Magic Sticks"
-	year "1995"
-	developer "Playmark"
-	rom ( name magicstk.zip size 260245 crc 4756edde md5 8441263145338f3e9c203bcd034b1231 sha1 9db1c94ab1b0f9947b2914d9f2ee4861219bfa23 )
-)
-
-game (
-	name "Magic the Gathering: Armageddon (set 1)"
-	year "1997"
-	developer "Acclaim"
-	rom ( name magictg.zip size 38269552 crc f1fd0abe md5 bf3f38dcff71dc51d9c23dfe9fdc7c8f sha1 ada1c43d9b682d53b02646a1e2c39bed4c5c95a2 )
-)
-
-game (
-	name "Magic the Gathering: Armageddon (set 2)"
-	year "1997"
-	developer "Acclaim"
-	rom ( name magictga.zip size 1275607 crc 2458a401 md5 cb59375f9896437ca407fc1950afc542 sha1 6b3c7b3e31f9aca1f1b72d5f66de4d9bc2fee83c )
 )
 
 game (
@@ -28788,24 +21054,10 @@ game (
 )
 
 game (
-	name "Magical Truck Adventure"
-	year "1998"
-	developer "Sega"
-	rom ( name magtruck.zip size 75094120 crc 8fa96d9a md5 d5d92e7f5497e488b24452490a3cbeb6 sha1 e0b8cdc3b42146f9a3642c7f564d0e76716e0fa4 )
-)
-
-game (
 	name "Magic Worm (bootleg)"
 	year "1980"
 	developer "bootleg"
 	rom ( name magworm.zip size 8151 crc f63e10f4 md5 2c775eacb4ccdcd04b4b9d147230fe89 sha1 dbf15b076c7bc2bd5511f1d8ab1fef8039706d38 )
-)
-
-game (
-	name "Magical Zunou Power (J 961031 V1.000)"
-	year "1996"
-	developer "Sega"
-	rom ( name magzun.zip size 16926280 crc 5a322a24 md5 4aa9ff3d82e9a2d4023fd8a12a5eb9fc sha1 d34f3cb5cb51df566b47eaca78ed975a9050e45e )
 )
 
 game (
@@ -28885,31 +21137,10 @@ game (
 )
 
 game (
-	name "Mahjong Raijinhai DX"
-	year "1996"
-	developer "Dynax"
-	rom ( name majrjhdx.zip size 438745 crc da1e523e md5 5adeefe7768e7b83146d89a6a4065e65 sha1 fb6dd421afa72e43b8ed9401f5f1e1085e842048 )
-)
-
-game (
 	name "Mahjong Studio 101 [BET] (Japan)"
 	year "1988"
 	developer "Dynax"
 	rom ( name majs101b.zip size 140046 crc 019adc97 md5 376e778d0d22544a15fb837ea9c2ea3a sha1 d772e9a0ee9e4b9a19599ffe0c6754deea31d652 )
-)
-
-game (
-	name "Major Title 2 (World)"
-	year "1992"
-	developer "Irem"
-	rom ( name majtitl2.zip size 1811439 crc fb101978 md5 3cb1a085e1939c4ff87423ff232a0a64 sha1 29cc73e3b143d82f820fee893866e99939628556 )
-)
-
-game (
-	name "Major Title 2 (Japan)"
-	year "1992"
-	developer "Irem"
-	rom ( name majtitl2j.zip size 196175 crc 491e43af md5 248b7deaabe91b7833ba7962683f5448 sha1 770b707935ce923711871a2d5ecc920acb2b408b )
 )
 
 game (
@@ -28990,25 +21221,6 @@ game (
 )
 
 game (
-	name "Makyou Senshi (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name makyosen.zip size 110807 crc 21fa0916 md5 86c44a5b24c9a09fc181521caf4600c8 sha1 880bfed9fe5bb3f3356f377bd9af180da18743d1 )
-)
-
-game (
-	name "Malzak"
-	developer "Kitronix"
-	rom ( name malzak.zip size 7411 crc 8221c269 md5 5165733a4a467143b36bc1f60d43b4dd sha1 2fdf6d1ec0700cd06bba3bcd30f770f0b16fc6ac )
-)
-
-game (
-	name "Malzak II"
-	developer "Kitronix"
-	rom ( name malzak2.zip size 6770 crc 5030d16f md5 036aafdac0e27fcc5e7925177843c1b5 sha1 9ed088c64b81fa8a375b168067a48f950c68a820 )
-)
-
-game (
 	name "Mang-Chi"
 	year "2000"
 	developer "Afega"
@@ -29051,13 +21263,6 @@ game (
 )
 
 game (
-	name "Manx TT Superbike (Revision C)"
-	year "1995"
-	developer "Sega"
-	rom ( name manxtt.zip size 15141111 crc 4d4f53c2 md5 8f8606afbbce95d26c61035b4e782d4e sha1 820829b382e5a0817620314b76d83238deff34fc )
-)
-
-game (
 	name "Many Block"
 	year "1991"
 	developer "Bee-Oh"
@@ -29079,59 +21284,10 @@ game (
 )
 
 game (
-	name "Marble Madness (set 1)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble.zip size 193238 crc c6135729 md5 3512ef1cc6d981a97ff0422b6e29c037 sha1 603cb95ee7269f849a2b3ef8afd7cadfd5f3799b )
-)
-
-game (
-	name "Marble Madness (set 2)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble2.zip size 66463 crc 6610b051 md5 fe0e146746deae65e8287312eefceb76 sha1 a19a38d9f57912955907c7a382c500ca721a4b04 )
-)
-
-game (
-	name "Marble Madness (set 3)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble3.zip size 80187 crc 8d1262a8 md5 213db41dc41f27ce5ac5cba8fa0e8f4e sha1 6ad5148d2bc435f65a051448c0d0a329cda24b83 )
-)
-
-game (
-	name "Marble Madness (set 4)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble4.zip size 75274 crc 2df0dedb md5 5ec2c81ad77e0d1c66bc38af78bba106 sha1 e1b380a2250c97b499e31dde6cab4a41d0b05fb9 )
-)
-
-game (
-	name "Marble Madness (set 5 - LSI Cartridge)"
-	year "1984"
-	developer "Atari Games"
-	rom ( name marble5.zip size 149265 crc 321eb37e md5 167ebe1354e9716b2bbfd2b4ad2b57d2 sha1 5b2f5779da65159d9fd38f4b47626719282c83c8 )
-)
-
-game (
-	name "Margarita Magic (A - 07/07/2000, NSW/ACT)"
-	year "2000"
-	developer "Aristocrat"
-	rom ( name margmgc.zip size 1121505 crc bd600656 md5 6eeb54a95e92bec344b0b52903b9d886 sha1 ac13fead277ad093dcaf0253b9d8814d56f19bde )
-)
-
-game (
 	name "Marine Boy"
 	year "1982"
 	developer "Orca"
 	rom ( name marineb.zip size 24169 crc 55e58c5d md5 2154b2a0082314092ada7882059a7326 sha1 c4f8ccb7344abaa63c1087ced11e522ab21cef6b )
-)
-
-game (
-	name "Marine Date"
-	year "1981"
-	developer "Taito"
-	rom ( name marinedt.zip size 16604 crc 88686e4a md5 3edf10aa28818622435ccdf5025fb323 sha1 0ea486a5a776be8ae34ed3863c952d6d83f0a6f6 )
 )
 
 game (
@@ -29289,20 +21445,6 @@ game (
 )
 
 game (
-	name "The Masters of Kin"
-	year "1988"
-	developer "Du Tech"
-	rom ( name mastkin.zip size 39037 crc bc81cbc8 md5 8784d2fd5f868f372cd16783f2d18d4e sha1 53faf0a4430e23ceac8fde58ab4d0202864f0b2a )
-)
-
-game (
-	name "Master Ninja (bootleg of Shadow Warriors / Ninja Gaiden)"
-	year "1989"
-	developer "bootleg"
-	rom ( name mastninj.zip size 1117273 crc 721b85c3 md5 7770739824a775470ae2d5fddd86a0cb sha1 51a3d023aa614dfd742f1688b32ee1214d2c8331 )
-)
-
-game (
 	name "Match '98 (ver. 1.33)"
 	year "1998"
 	developer "Amcoe"
@@ -29321,18 +21463,6 @@ game (
 	year "1993"
 	developer "Tamtex"
 	rom ( name matchit2.zip size 899084 crc 1e43e6b1 md5 5d623a21a73cec3c6811fbbe10a47be0 sha1 2d51d00ff1a2686e9938ab8beb1fcfc0978650f9 )
-)
-
-game (
-	name "The Mating Game (v0.4)"
-	developer "Barcrest"
-	rom ( name mating.zip size 3121723 crc df9c5c61 md5 2a7464d60a7858573aed9499892fd7c6 sha1 9d0cc92a398b1ee9dcb8e818d8b7584a8f9e2a98 )
-)
-
-game (
-	name "The Mating Game (v0.4, Datapak)"
-	developer "Barcrest"
-	rom ( name matingd.zip size 49098 crc dc146c1f md5 61441972f056f23c0558b0af38bba374 sha1 a04c6b30e9ef9a4c7e91e5b41fddd4bb1528a28f )
 )
 
 game (
@@ -29440,20 +21570,6 @@ game (
 )
 
 game (
-	name "Mayjinsen 3"
-	year "2000"
-	developer "Seta / Able Corporation"
-	rom ( name mayjin3.zip size 5287034 crc 976aa48c md5 c73c6f5d1a40820f8616155414574d4c sha1 179e6bb5562f3230158b328f51952e629d0827d1 )
-)
-
-game (
-	name "Mayjinsen"
-	year "1994"
-	developer "Seta"
-	rom ( name mayjinsn.zip size 576960 crc cfaf3c38 md5 d04d7b64bdc26140d9309084ec900312 sha1 5c7dde71e289299ed9a2dc9307e7093e8d34cf53 )
-)
-
-game (
 	name "Mayjinsen 2"
 	year "1994"
 	developer "Seta"
@@ -29482,20 +21598,6 @@ game (
 )
 
 game (
-	name "Mazer Blazer (set 1)"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name mazerbla.zip size 30841 crc 5639d94a md5 c8740faf0b4cd881da4a2357359f5af4 sha1 10ba12b0be58781b83bc607982560f4714ce23f2 )
-)
-
-game (
-	name "Mazer Blazer (set 2)"
-	year "1983"
-	developer "Stern Electronics"
-	rom ( name mazerblaa.zip size 16015 crc 4404b528 md5 e97a99e0eeff394c63cb37d186ffad8b sha1 71c92b0e49c4e1a3b8cc4c8b1c0e80a0e7773d02 )
-)
-
-game (
 	name "Mazinger Z (World)"
 	year "1994"
 	developer "Banpresto / Dynamic Pl. Toei Animation"
@@ -29507,27 +21609,6 @@ game (
 	year "1994"
 	developer "Banpresto / Dynamic Pl. Toei Animation"
 	rom ( name mazingerj.zip size 168 crc 135d61b7 md5 19df5299be634bf4774b22e17330dc86 sha1 d20e66faea6c8d9af43ec4c350f114eaa1e94ee3 )
-)
-
-game (
-	name "Muscle Bomber: The Body Explosion (Japan 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbomberj.zip size 1179311 crc 8d26c425 md5 0e2585515c14b9e37c1e2ecc83cc5046 sha1 1463f6eb9283955feb7cfb2e09e5e4de1b7214d8 )
-)
-
-game (
-	name "Muscle Bomber Duo: Ultimate Team Battle (World 931206)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbombrd.zip size 6509365 crc 865500aa md5 dc624c8188d3d3e81293b12a11e8130e sha1 8e8dc17fd84f10ee679a7145f0524883e35aa2b8 )
-)
-
-game (
-	name "Muscle Bomber Duo: Heat Up Warriors (Japan 931206)"
-	year "1993"
-	developer "Capcom"
-	rom ( name mbombrdj.zip size 1004351 crc 4fb92510 md5 39f38fd890954593b41880c6f33c45d5 sha1 58dbfe27c06975a67cbcef9d478a50de7c0bd31a )
 )
 
 game (
@@ -29573,12 +21654,6 @@ game (
 )
 
 game (
-	name "Magic Class (Ver 2.2)"
-	developer "&lt;unknown&gt;"
-	rom ( name mclass.zip size 266408 crc 7c5d7f7e md5 61311d49aac3f6360890e514fa92f4cd sha1 907dec7e5438eaba9194e6c0e50f8cb628f281f8 )
-)
-
-game (
 	name "Mahjong Campus Hunting (Japan)"
 	year "1990"
 	developer "Dynax"
@@ -29586,55 +21661,10 @@ game (
 )
 
 game (
-	name "Magic Colors (ver. 1.7a)"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name mcolors.zip size 491840 crc d205b28c md5 257eec554ee8a9ecb9397ba45d61941f sha1 6df41db05d86d1be610f5e719c17d097d4075cfa )
-)
-
-game (
-	name "Missile Combat (Videotron bootleg, set 1)"
-	developer "bootleg (Videotron)"
-	rom ( name mcombat.zip size 10626 crc dfd5385b md5 6653a05ba5cc78297024f93e1b862e86 sha1 08718094d3ee3eea58cccd3aedd871ca91a44a7b )
-)
-
-game (
-	name "Missile Combat (Videotron bootleg, set 2)"
-	developer "bootleg (Videotron)"
-	rom ( name mcombata.zip size 10602 crc 7775ece6 md5 e28b6055ee3d9b637d4702922e16e23b sha1 da68c513d2e0c812e0af9828d4a4927c2e07f491 )
-)
-
-game (
 	name "Miss Mahjong Contest (Japan)"
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name mcontest.zip size 457455 crc 59bd1c87 md5 c2bdb2b9e538c4cf2bc194f09da48803 sha1 759391a06f96eb252102a2a5ebc30916622ccd09 )
-)
-
-game (
-	name "Derby Quiz My Dream Horse (Japan, MDH1/VER.A2)"
-	year "1998"
-	developer "Namco"
-	rom ( name mdhorse.zip size 24519092 crc 3c0977e0 md5 0fbd9f338637c89f7dba6752c1a39396 sha1 46dee58b579852d73406edf7a0bdc5e994bc31e3 )
-)
-
-game (
-	name "Draw Poker Joker's Wild (Standard)"
-	developer "Meyco Games"
-	rom ( name mdrawpkr.zip size 7441 crc a7097421 md5 e9189122a01a90501511091c47af14dd sha1 64cf9e717340d27f1e99b94eb6a5cee029dc629a )
-)
-
-game (
-	name "Draw Poker Joker's Wild (02-11)"
-	developer "Meyco Games"
-	rom ( name mdrawpkra.zip size 8681 crc c5024c46 md5 eb76dd88db3a7b1ac1638a7c21f5e87e sha1 a81e5e3fddc083a6e6d3ae1eb8e53898aa82cd52 )
-)
-
-game (
-	name "Magic Drink (Ver 1.2)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name mdrink.zip size 383957 crc f326f840 md5 679259104f7cc84bf1dbf6f7ec17a123 sha1 46139b3bd474ecd42be280e23b1622185d1cb89b )
 )
 
 game (
@@ -29813,13 +21843,6 @@ game (
 )
 
 game (
-	name "Megatouch 5 (9255-60-01 ROC, Standard version)"
-	year "1997"
-	developer "Merit"
-	rom ( name megat5a.zip size 319800 crc 4d30fafe md5 3e0f1a34ee5a8c308dcaec74e0d73532 sha1 20608c3b1e8c6e867bfc00e275b1d165ab1e2528 )
-)
-
-game (
 	name "Megatouch 5 (9255-60-07 RON, New Jersey version)"
 	year "1998"
 	developer "Merit"
@@ -29897,51 +21920,9 @@ game (
 )
 
 game (
-	name "Melty Blood Act Cadenza Ver B (GDL-0039)"
-	year "2006"
-	developer "Ecole Software"
-	rom ( name meltyb.zip size 1196 crc 8cd3701d md5 5f08a3bec861b008df025783f00a4241 sha1 364a456b78f548d21bdbc0f52530849f88a7ae06 )
-)
-
-game (
-	name "Melty Blood Act Cadenza Ver A (Rev C) (GDL-0028C)"
-	year "2005"
-	developer "Ecole Software"
-	rom ( name meltybld.zip size 1197 crc 471ac9cb md5 d6dfc2b552809e1720f4e7e544e4ad70 sha1 2f3f7e3a98bcc47414014b1baca89966b6c4afba )
-)
-
-game (
 	name "Meosis Magic (Japan)"
 	developer "Sammy"
 	rom ( name meosism.zip size 4735058 crc 3eb94918 md5 e4a8aceac1eb17d1bb3437f77e722da2 sha1 585219022d93e66e04ef7e31bfbaecd885648656 )
-)
-
-game (
-	name "Mercs (World 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercs.zip size 1753910 crc 3da0b8bf md5 22c4897056f816bab7a01a4353b05a80 sha1 0469b59680031dd85710e31b2a9b0d4d46db836d )
-)
-
-game (
-	name "Senjou no Ookami II (Japan 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsj.zip size 1046473 crc 693c60ac md5 ecd90a90027ab187051b56a9caa19dcd sha1 c4ef9abc784329166e476384de72170a2d16d1e0 )
-)
-
-game (
-	name "Mercs (USA 900302)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsu.zip size 52640 crc 00ef8646 md5 17ac18241c2c7d1bd57e331e1d8d7325 sha1 40522dd9d1ac39a4110ea87e310e3a699aaf930d )
-)
-
-game (
-	name "Mercs (USA 900608)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mercsua.zip size 156242 crc 9c217ec1 md5 f6c9d280d048d604fa493dd8581807cf sha1 86b3d1f928ed83062e9725413895f37e91a8b94d )
 )
 
 game (
@@ -29977,13 +21958,6 @@ game (
 	year "1991"
 	developer "Taito Corporation"
 	rom ( name metalbj.zip size 163055 crc bfee708d md5 dec85364462d4f621b9df0f8c6008151 sha1 a4607c9fd656253c3553e3acf813cc5446f957b0 )
-)
-
-game (
-	name "Metal Maniax (prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name metalmx.zip size 13188121 crc fb7e80c7 md5 bc81778def7e00e9846d955cb25aef72 sha1 f6ef2065540e0fabfed35b6353692cdcc093e22f )
 )
 
 game (
@@ -30033,27 +22007,6 @@ game (
 	year "1985"
 	developer "Data East"
 	rom ( name metlclsh.zip size 97952 crc 4baed0a0 md5 24a2a4f978086004590cfc7c84417df4 sha1 bdef944a8757e5f5edef1738cd3715e7a3dc4624 )
-)
-
-game (
-	name "Metal Hawk"
-	year "1988"
-	developer "Namco"
-	rom ( name metlhawk.zip size 2050614 crc 173e2946 md5 003b8777ab0c53901ad590c4d1885999 sha1 9307a0f603b924e02b940ba0d2c1eebe009db4f6 )
-)
-
-game (
-	name "Metal Hawk (Japan)"
-	year "1988"
-	developer "Namco"
-	rom ( name metlhawkj.zip size 59200 crc 1556c888 md5 d812620e7c4a82eca0a53c02520663a6 sha1 be81eab159efa912a4f0812a3b0f65822d58adc6 )
-)
-
-game (
-	name "Metal Saver"
-	year "1994"
-	developer "First Amusement"
-	rom ( name metlsavr.zip size 850810 crc 3f56d72d md5 7c1bd2cb4db4852bb20e413e62c9f29a sha1 4dd8f24d4a8209f8e652169b4b867bcb006c1a08 )
 )
 
 game (
@@ -30110,13 +22063,6 @@ game (
 	year "1983"
 	developer "Exidy / First Star Software"
 	rom ( name mf_flip.zip size 12410 crc d23d8909 md5 9278246ec1b5432d7487fd015bf42032 sha1 ccdaf9023325db2435dc86f3bbbd9b7ba1303256 )
-)
-
-game (
-	name "Mahjong Fight Club (ver JAD)"
-	year "2002"
-	developer "Konami"
-	rom ( name mfightc.zip size 1342 crc 40f10c27 md5 e1f9dfe4f762164ff5187deae5134f4b sha1 5a21603d720a2b080c5fd3a674de90c995b98101 )
 )
 
 game (
@@ -30225,24 +22171,10 @@ game (
 )
 
 game (
-	name "Mahjong Man Guan Cai Shen (V103CS)"
-	year "1998"
-	developer "IGS"
-	rom ( name mgcs.zip size 1836185 crc e352f557 md5 c2db9f2101a29a885171111be6993c21 sha1 d656c949a8ffca569cc81949ca72edb5a9bd3bc3 )
-)
-
-game (
 	name "Mahjong Man Guan Da Heng (Taiwan, V123T1)"
 	year "1997"
 	developer "IGS"
 	rom ( name mgdh.zip size 1212088 crc 5237b7de md5 11e2d356221b1bc233527eaf578c2f9a sha1 40abc813272258bf933c44d63c5dc10ef3760493 )
-)
-
-game (
-	name "Man Guan Fu Xing"
-	year "2000"
-	developer "IGS"
-	rom ( name mgfx.zip size 2151851 crc b3f12e66 md5 6d31b0d697e1c4fef309d470e68cc90e sha1 21199e5f75aa06ae8fc7300a934f23ca6817bd29 )
 )
 
 game (
@@ -30257,41 +22189,6 @@ game (
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name mgmen89.zip size 488888 crc 10ce1f2c md5 db0659f6db3db4079a30ae29c8c42c9c sha1 bfe7b632787bddd39ef686c681676cacf95a3f68 )
-)
-
-game (
-	name "Atari Mini Golf (prototype)"
-	year "1978"
-	developer "Atari"
-	rom ( name mgolf.zip size 9303 crc 16c61cc3 md5 93f606f746c18bfbbe571a36d78a8ae8 sha1 4be72dcc0838ed57dafc0c3037defe8bb1015666 )
-)
-
-game (
-	name "Major Havoc (rev 3)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavoc.zip size 69696 crc 6a5cff34 md5 3bad435ebd898d1972a7670fde3896dc sha1 ab486e8b94235ec4973e64ea450262f859b02cb7 )
-)
-
-game (
-	name "Major Havoc (rev 2)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavoc2.zip size 42778 crc 3194afb4 md5 3393c5170211391eebc910cb566b0d73 sha1 ac6edecc95c27b689319c752cd350feba5b70dbb )
-)
-
-game (
-	name "Major Havoc (prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name mhavocp.zip size 66943 crc d2aa24e4 md5 fa194536cdefedcbe955f34d1e218e6a sha1 118ea868f569de81be4b46d08e7d6056c154a9cc )
-)
-
-game (
-	name "Major Havoc (Return to Vax)"
-	year "1983"
-	developer "Atari / JMA"
-	rom ( name mhavocrv.zip size 57051 crc ca052fce md5 1db414343a52c3a807a2deca5763a00a sha1 01bb12e7e6ea672640c3bcdb2dfa31f6c629ab63 )
 )
 
 game (
@@ -30326,13 +22223,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name miaj.zip size 146220 crc bda7e7bc md5 5fa38961999f4e0bbb0e7c32aaf134a9 sha1 16a323637dcf34d769fc04a537bdf0aa682ee95a )
-)
-
-game (
-	name "Microman Battle Charge (J 990326 V1.000)"
-	year "1999"
-	developer "Sega"
-	rom ( name micrombc.zip size 3765026 crc 21254382 md5 c1f924896647c559f5e75204a82c1343 sha1 642fde77f337da6a46f9f4241bdb084e21aac783 )
 )
 
 game (
@@ -30378,13 +22268,6 @@ game (
 )
 
 game (
-	name "Mighty Guy"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name mightguy.zip size 119652 crc 887991bb md5 308f57ec25d5f12d03af515e403e7e5e sha1 0e251c40625633b77855795ad3fb91eeffb5c22d )
-)
-
-game (
 	name "Vs. Mighty Bomb Jack (Japan)"
 	year "1986"
 	developer "Tecmo"
@@ -30413,34 +22296,6 @@ game (
 )
 
 game (
-	name "Millennium Nuovo 4000 (Version 2.0)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000.zip size 655497 crc aff65f57 md5 ac50ed89ad19d0fce89707d9983a823c sha1 caaeacfb710570b24d3806a540f1c97094f863f9 )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.8)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000a.zip size 655363 crc 8262740d md5 8148c3374b8f5b3f576e1744e673b2f2 sha1 811ec4f784315c782484ba424e90eb26fb8abd88 )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.5)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000b.zip size 147526 crc 1bc59b8d md5 56e5049a0ca5652d475c198c1d6588cd sha1 3f79c1c31f7d585d6a431dca3a27f260cd0097bd )
-)
-
-game (
-	name "Millennium Nuovo 4000 (Version 1.6)"
-	year "2000"
-	developer "Sure Milano"
-	rom ( name mil4000c.zip size 79428 crc 56f1393c md5 6fde1b12f08dcecb32441c175c5e4d63 sha1 205d959e940e5ff04877afc240bc32762c20f92c )
-)
-
-game (
 	name "Millipede Dux (hack)"
 	year "1982"
 	developer "hack"
@@ -30459,12 +22314,6 @@ game (
 	year "1980"
 	developer "bootleg? (Valadon Automation)"
 	rom ( name millpac.zip size 10269 crc de0319f2 md5 7c95b0f647dee7dc68a1e061b0ec482c sha1 f4f171e3b0d23f08779220f4b3d8386baafbe4ae )
-)
-
-game (
-	name "Millennium Sun"
-	developer "&lt;unknown&gt;"
-	rom ( name millsun.zip size 303530 crc 7b47dd03 md5 b2325883340b911f301c1dd8c0102a5a sha1 667b310c3f47f11a2033725256657e619ed60473 )
 )
 
 game (
@@ -30517,34 +22366,6 @@ game (
 )
 
 game (
-	name "Inferno (Meadows)"
-	year "1978"
-	developer "Meadows"
-	rom ( name minferno.zip size 3689 crc e5f179b6 md5 4b6af272086a57ce3f3d8c6af291593d sha1 a114e8235dfdb06a9949b781ef649528419afd72 )
-)
-
-game (
-	name "Mini Boy 7"
-	year "1983"
-	developer "Bonanza Enterprises, Ltd"
-	rom ( name miniboy7.zip size 33431 crc ddc9b884 md5 bac8d6760f4ee3ba295e3968758401b1 sha1 5422dabfb50c90260d046f3ab5ffd769dc6e070c )
-)
-
-game (
-	name "Mini Golf (set 1)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name minigolf.zip size 60514 crc b1da511b md5 7c8582d62938519caf847b33bd31c4ef sha1 afbef1502b724bb8e576e5c2e7962a3a8ffecc11 )
-)
-
-game (
-	name "Mini Golf (set 2)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name minigolf2.zip size 20177 crc 4a142cbc md5 4b61e7bb9f43a8ed75229237b1d3d8f2 sha1 adcc523088590c749d0ec0162a3062b5e2d603e7 )
-)
-
-game (
 	name "Minivader"
 	year "1990"
 	developer "Taito Corporation"
@@ -30559,45 +22380,10 @@ game (
 )
 
 game (
-	name "Mirax"
-	year "1985"
-	developer "Current Technologies"
-	rom ( name mirax.zip size 85342 crc 16e9b160 md5 927d7cd8840379806d0feb643dcdf92c sha1 b58ad044f1282b267eb9d4e8d1efc8c371adda46 )
-)
-
-game (
-	name "Mirax (set 2)"
-	year "1985"
-	developer "Current Technologies"
-	rom ( name miraxa.zip size 29685 crc 2dc80597 md5 766b49972e7328d73a82f4f2f775ac04 sha1 01f9ca00cf1cef8a703bc65d4ac765b4744f5edd )
-)
-
-game (
-	name "Miracle Derby - Ascot"
-	year "1988"
-	developer "Home Data?"
-	rom ( name mirderby.zip size 102668 crc 4198fb26 md5 074e54e37a96dc93568927e689b99d04 sha1 00e20d642bfeae60afb0341cacd45eac2ee8d6d7 )
-)
-
-game (
 	name "Mirai Ninja (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name mirninja.zip size 1556575 crc 0f0726b0 md5 788744993e6924cb2af8ffedac8ba1ff sha1 0f4be16f197d957563c91f61e6ac575d6d949c49 )
-)
-
-game (
-	name "Mission Craft (version 2.4)"
-	year "2000"
-	developer "Sun"
-	rom ( name misncrft.zip size 5914155 crc 4977204d md5 a222d02a867b259f4d088b82ccda7f17 sha1 0a024dc11577a11fa1e8ec4c47ca9f5c18d190f3 )
-)
-
-game (
-	name "Miss Bubble II"
-	year "1996"
-	developer "Alpha Co."
-	rom ( name missb2.zip size 1567164 crc 52abf6c0 md5 a04888d98fd5217f3e8142c56b1a0eb8 sha1 b863ff9ed73cc2b3934bc1665bfc4aaf9c376a2e )
 )
 
 game (
@@ -31012,13 +22798,6 @@ game (
 )
 
 game (
-	name "Mahjong Senka (Japan)"
-	year "1986"
-	developer "Visco"
-	rom ( name mjsenka.zip size 27896 crc 23c01fc1 md5 b3ae8415afc9b703999db9002be162b2 sha1 6a649618173d3f3d4c6fea50e0525fe64f743ad6 )
-)
-
-game (
 	name "Mahjong Shikaku (Japan 880722)"
 	year "1988"
 	developer "Nichibutsu"
@@ -31054,20 +22833,6 @@ game (
 )
 
 game (
-	name "Mahjong Shiyou (Japan)"
-	year "1986"
-	developer "Visco"
-	rom ( name mjsiyoub.zip size 64637 crc b9118c14 md5 98b87a111c38bcace6abe5d115cd74c4 sha1 9ee47cdfa30088e67b36ce8a2f2ac71448a931fe )
-)
-
-game (
-	name "Mahjong Tensinhai (Japan)"
-	year "1995"
-	developer "Dynax"
-	rom ( name mjtensin.zip size 600261 crc bc34837c md5 a82d5d5474a7fe5e380e53be83aac381 sha1 85f98be24e1f0b60a0b611cc42aea15a45e0fab6 )
-)
-
-game (
 	name "Mahjong Uranai Densetsu (Japan)"
 	year "1992"
 	developer "Nichibutsu/Yubis"
@@ -31075,24 +22840,10 @@ game (
 )
 
 game (
-	name "Mahjong Vegas (Japan)"
-	year "1991"
-	developer "Dynax"
-	rom ( name mjvegas.zip size 51822 crc b1112980 md5 1c9352cdabcf4a266462d72bc6459ad7 sha1 3b0bcc718ac4c1137e2fdde82508ef5f68bdf46b )
-)
-
-game (
 	name "Mahjong Vegas (Japan, unprotected)"
 	year "1991"
 	developer "Dynax"
 	rom ( name mjvegasa.zip size 315105 crc b9ae49f2 md5 ef11ab5707c121917e8f9329c5694d3e sha1 c6fece15ddc3721f6d07f11fadcc6d5dab3ac575 )
-)
-
-game (
-	name "Mahjong Yarou [BET] (Japan)"
-	year "1986"
-	developer "Visco / Video System"
-	rom ( name mjyarou.zip size 26298 crc afa6e657 md5 377d39a58bc5569e9127d777a07769dd sha1 a36afdd3e3b55be4932479ee370fe91534db5a33 )
 )
 
 game (
@@ -31114,13 +22865,6 @@ game (
 	year "1990"
 	developer "Visco"
 	rom ( name mjyuugia.zip size 36308 crc 163cd8b7 md5 41a065b32c0137fd3dcebfd0224193d1 sha1 8447c705ce0cfc6ed25325abcaa6e193e0289c97 )
-)
-
-game (
-	name "Mahjong Channel Zoom In (Japan)"
-	year "1990"
-	developer "Jaleco"
-	rom ( name mjzoomin.zip size 724176 crc 476c5b8a md5 dcc07435c4a5d90c32389f81b898d796 sha1 7232c3cfe65822e9eb02419c0727990be979eee7 )
 )
 
 game (
@@ -31243,13 +22987,6 @@ game (
 )
 
 game (
-	name "Mortal Kombat 4 (version 1.0)"
-	year "1997"
-	developer "Midway"
-	rom ( name mk4b.zip size 13924591 crc a23422ab md5 18a171403e9c4b5e6c59f421893d9b93 sha1 285d72b5cc58ab48985573dd8533d2f4c4312abe )
-)
-
-game (
 	name "Mahjong Keibaou (Japan)"
 	year "1993"
 	developer "Nichibutsu"
@@ -31345,13 +23082,6 @@ game (
 	year "1980"
 	developer "bootleg (Leisure Time Electronics)"
 	rom ( name mlander.zip size 8027 crc a0315ffb md5 6810f023d28b6fdf118d8bc2b641cc1d sha1 cc69b2b33cb139700392825f79525287dc510587 )
-)
-
-game (
-	name "Midnight Landing (Germany)"
-	year "1987"
-	developer "Taito America Corporation"
-	rom ( name mlanding.zip size 341578 crc 874f2c20 md5 956d1b93acb17f41ad3987031dac72d3 sha1 cd1fd7c333ba432dec777b512170162d4aa87eef )
 )
 
 game (
@@ -31453,56 +23183,10 @@ game (
 )
 
 game (
-	name "Mystery Number"
-	developer "M.M. - B.R.L."
-	rom ( name mnumber.zip size 501068 crc c09d09f6 md5 64e58090d7abe777b41823dbc38b3782 sha1 754f383b1ff63e3b6fd84d2cdc474abd23aa585f )
-)
-
-game (
-	name "Magic Number (Italian Gambling Game, Ver 1.5)"
-	developer "&lt;unknown&gt;"
-	rom ( name mnumitg.zip size 384211 crc 76a5e7d7 md5 c08400b678c6829db4a1f2c820400364 sha1 b6dfda713883ae0139084bd6a48e62e3ed149400 )
-)
-
-game (
-	name "Mocap Boxing (ver AAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapb.zip size 1239 crc 45f0deff md5 bd3379b38614073a1fdd7bbf3889bea2 sha1 5447a8271a1b0a9acc7e35b2b70961fdb08e7e5b )
-)
-
-game (
-	name "Mocap Boxing (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapbj.zip size 1297 crc 61c6e91f md5 7c7467defbae45746b5c5e1e66534dfd sha1 d3b6d47efb68ffcb3d63595010ea18f77aed4087 )
-)
-
-game (
-	name "Mocap Golf (ver UAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name mocapglf.zip size 3336 crc cc129ab9 md5 c842ccda696462adb8c6a70add696b13 sha1 f620baed42ec524d42e0b7cb878636effb3a2628 )
-)
-
-game (
-	name "unknown Model Racing gun game"
-	developer "Model Racing"
-	rom ( name modelr.zip size 6407 crc ed13fa62 md5 b9f9ca0a528fd5b900b104e6a384d547 sha1 6190f0876d9068a06804b0cdf6e6cb3bfbc28ad0 )
-)
-
-game (
 	name "Moeyo Gonta!! (Japan)"
 	year "1993"
 	developer "Yanyaka"
 	rom ( name moegonta.zip size 334507 crc 30c34680 md5 38a09c42ebc694d50d2fc080617c813d sha1 4646c18843904b06d5cc051f164e64199a8cfd58 )
-)
-
-game (
-	name "Moeru Casinyo (GDL-0013)"
-	year "2002"
-	developer "Altron"
-	rom ( name moeru.zip size 1195 crc 85f2648f md5 3d1ae20b653c95fe3df4f92969eb4af4 sha1 16cc6b13c0ad8f51989668770cb16909b2bfe2b0 )
 )
 
 game (
@@ -31513,24 +23197,10 @@ game (
 )
 
 game (
-	name "Moguchan"
-	year "1982"
-	developer "Orca (Eastern Commerce Inc. license) (bootleg?)"
-	rom ( name moguchan.zip size 17716 crc 1be2f278 md5 c6def5047f542455a61147117da1a38a sha1 3743c8488eac6bf51ebb70d31aaeec468a6fde70 )
-)
-
-game (
 	name "Mogura Desse (Japan)"
 	year "1991"
 	developer "Konami"
 	rom ( name mogura.zip size 7515 crc 74299875 md5 e7ca2672f954b3028b2cd9a5a7ab4d57 sha1 3ca566077fda85dfacafbb9d26b11b6054493b66 )
-)
-
-game (
-	name "The Maze of the Kings (GDS-0022)"
-	year "2002"
-	developer "Sega"
-	rom ( name mok.zip size 1198 crc 646799c1 md5 59900bba3bf81e6666afb61f0aba0726 sha1 998ef878245eb869e7d0cb3937889774409ce96f )
 )
 
 game (
@@ -31545,12 +23215,6 @@ game (
 	year "1986"
 	developer "Jaleco"
 	rom ( name momoko.zip size 121845 crc 5e14b6f3 md5 af885abcdc8b940210008c535a933338 sha1 826b7ba43be62deb6d8a0b6e091918a87aa6b26d )
-)
-
-game (
-	name "Money In The Bank (NSW)"
-	developer "Konami"
-	rom ( name moneybnk.zip size 1387862 crc b37bc71c md5 8abc79406d4e106344c87ac3a04a68db sha1 4a8aeabc4244f78fcc8c3ebd8ec6b19425a8e1d8 )
 )
 
 game (
@@ -31589,33 +23253,6 @@ game (
 )
 
 game (
-	name "Mongolfier New (Italian)"
-	developer "bootleg"
-	rom ( name mongolnw.zip size 52179 crc 98f8153e md5 ab92854a0abf47c41e2cbd17e981b96e sha1 ff0d7210d90713ca859caa211a765556ca5a34b6 )
-)
-
-game (
-	name "Monky Elf (Korean bootleg of Avenging Spirit)"
-	year "1990"
-	developer "bootleg"
-	rom ( name monkelf.zip size 131308 crc d9691747 md5 604c4547f23cb01f4ac387294db1e6d3 sha1 02e1f2d97c809372028eccf7ea04302ca60ef2f4 )
-)
-
-game (
-	name "Monkey Ball (GDS-0008)"
-	year "2001"
-	developer "Sega"
-	rom ( name monkeyba.zip size 1194 crc 6d181b13 md5 496a0552cfa67c4e6f989dd712dc8d7d sha1 348a6df95446f47e8364ba38fe03e1b7b268d23c )
-)
-
-game (
-	name "Monkey Donkey"
-	year "1981"
-	developer "bootleg"
-	rom ( name monkeyd.zip size 9628 crc f0b79632 md5 5a51ddd0bfbf26ca85c11f553f31afb8 sha1 b4d54adf9d2c88b5dac6d0584df510a806a2ed12 )
-)
-
-game (
 	name "Monopoly Classic"
 	year "1995"
 	developer "JPM"
@@ -31651,13 +23288,6 @@ game (
 )
 
 game (
-	name "Monster Zero"
-	year "1982"
-	developer "Nihon Game"
-	rom ( name monsterz.zip size 35212 crc e5f667d9 md5 c38128581bdf9720318651d163f3ff11 sha1 6200ad422658d81cb594dcc7347f7e3c96cc7cf7 )
-)
-
-game (
 	name "Monte Carlo"
 	year "1979"
 	developer "Atari"
@@ -31672,13 +23302,6 @@ game (
 )
 
 game (
-	name "Monza GP"
-	year "1981"
-	developer "Olympia"
-	rom ( name monzagp.zip size 9938 crc 81ccd857 md5 f954c013b6e2906477931c687043b527 sha1 535993d7474aca7fa2b79d77e8b08726a5b40cb7 )
-)
-
-game (
 	name "Wild West C.O.W.-Boys of Moo Mesa (ver EA)"
 	year "1992"
 	developer "Konami"
@@ -31690,13 +23313,6 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name mooaa.zip size 82631 crc cac88083 md5 e24fa7115d5286c9ab5958ac1681d82e sha1 032e2aed788dd7e0c155d62841a05e2eb6fff169 )
-)
-
-game (
-	name "Wild West C.O.W.-Boys of Moo Mesa (bootleg ver AA)"
-	year "1992"
-	developer "bootleg"
-	rom ( name moobl.zip size 1756393 crc 7cfa51a7 md5 5817d4de703341c5465e3b3250a3db5c sha1 ac1668f195b43453301cad430d9bb943ed74f067 )
 )
 
 game (
@@ -31845,20 +23461,6 @@ game (
 )
 
 game (
-	name "More More"
-	year "1999"
-	developer "SemiCom / Exit"
-	rom ( name moremore.zip size 938135 crc ed54ea8e md5 b4d531f29da7a36e72d25884afbc0831 sha1 74cd327bc3569bd7a3502bc87999fffbf8bd6cf6 )
-)
-
-game (
-	name "More More Plus"
-	year "1999"
-	developer "SemiCom / Exit"
-	rom ( name moremorp.zip size 910432 crc 84090157 md5 14f341ac6f8b6a21feeb907e1ad03009 sha1 b53073ddbf9a87093467aedc2e2e37746b737b94 )
-)
-
-game (
 	name "Mosaic"
 	year "1990"
 	developer "Space"
@@ -31887,34 +23489,6 @@ game (
 )
 
 game (
-	name "Moto Frenzy"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofren.zip size 5694483 crc 0e2cd4ac md5 a139c06ed00f0bb0238664cb72811562 sha1 58589f2ffa995e31a0fb49bcffc7cbf9240c1597 )
-)
-
-game (
-	name "Moto Frenzy (Field Test Version)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenft.zip size 199375 crc 48dd2ee7 md5 10d9ee7d6a89bb678d6e64a94d949fc1 sha1 04a9b33724cc99baf508b459b712a1aa82208736 )
-)
-
-game (
-	name "Moto Frenzy (Mini Deluxe)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenmd.zip size 219533 crc e94439d6 md5 11798c3b43855efa40293de0adc416c9 sha1 225bf2d551c237fa99d7563b9ff36fab9e20e08f )
-)
-
-game (
-	name "Moto Frenzy (Mini Deluxe Field Test Version)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name motofrenmf.zip size 203354 crc a6576062 md5 58a485f775d5860af0cb67b81f56855d sha1 9838ca06432f0ce5f26d8d566e419bfeb51ab163 )
-)
-
-game (
 	name "MotoRace USA"
 	year "1983"
 	developer "Irem (Williams license)"
@@ -31922,24 +23496,10 @@ game (
 )
 
 game (
-	name "Motoraid"
-	year "1995"
-	developer "Sega"
-	rom ( name motoraid.zip size 32680675 crc 6a7f8d8b md5 c78e789f2e8549ed01c443f371f72e69 sha1 1bc90088653b91109912ff59b2615faed4cadcb5 )
-)
-
-game (
 	name "Motos"
 	year "1985"
 	developer "Namco"
 	rom ( name motos.zip size 39030 crc ffe7ad59 md5 b81ff43f7182873988b85f53733fc27c sha1 7498a168d5e6e5b0185219bf3b8ad8fe7d4cfba3 )
-)
-
-game (
-	name "Motocross Go! (MG3 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name motoxgo.zip size 45107025 crc 70e2974b md5 48373e105173778135544bf5b7e845da sha1 0e6de94526eb1ff72720d437a3a131b2c824f703 )
 )
 
 game (
@@ -32097,13 +23657,6 @@ game (
 )
 
 game (
-	name "Multi-Poker"
-	year "1981"
-	developer "Merit Industries"
-	rom ( name mpoker.zip size 11913 crc 6f7dc405 md5 e78cff135d54ee1d38c76e9244699394 sha1 18397eda2729958e9505cc7cd85f1f9e86032eb8 )
-)
-
-game (
 	name "MPU4 Meter Clear ROM"
 	developer "Barcrest"
 	rom ( name mpu4met0.zip size 13579 crc b541da20 md5 d58236ad63010d0b9594d76e8f9d26fe sha1 07aee4aaebcb6f2d71270ed88018e97e95771a8a )
@@ -32119,13 +23672,6 @@ game (
 	name "MPU4 Unit Test (Program 4)"
 	developer "Barcrest"
 	rom ( name mpu4utst.zip size 6031 crc e72c175f md5 3b007cf7a2cb1e75b85493ade741661c sha1 7fe2036e677164d1f16bce664100c24436ca40db )
-)
-
-game (
-	name "Moonquake"
-	year "1987"
-	developer "Sente"
-	rom ( name mquake.zip size 1021019 crc 336be105 md5 9686320eccb222e99618210d578d6555 sha1 47a6ff6ac1982ed0198559d993d680b4788a7781 )
 )
 
 game (
@@ -32171,27 +23717,6 @@ game (
 )
 
 game (
-	name "Mr. Driller 2 (Japan, DR21 Ver.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name mrdrilr2.zip size 31210626 crc 7d2e320c md5 4af1caa848aa07505f5fbb1a0cbc7960 sha1 969685313700cb086399ada82d58d8c4cc9c0992 )
-)
-
-game (
-	name "Mr. Driller G (Japan, DRG1 Ver.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name mrdrilrg.zip size 37838847 crc 4ab9fd54 md5 83cd5455638433a114ed0630f2c4cc56 sha1 cb7433443815fb2877aed1f2db4dd2d9faefd1f2 )
-)
-
-game (
-	name "Mr. Driller 2 (Japan, DR22 Ver.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name mrdrlr2a.zip size 6649068 crc 48742771 md5 84f1e799b0be0b3b654f9a61a12576de sha1 254819c327ceb920e1036dc58a30a4e2a41ce693 )
-)
-
-game (
 	name "Mr. Du!"
 	year "1982"
 	developer "bootleg"
@@ -32213,24 +23738,10 @@ game (
 )
 
 game (
-	name "Mr. HELI no Dai-Bouken"
-	year "1987"
-	developer "Irem"
-	rom ( name mrheli.zip size 486553 crc 5861bbcb md5 891a728687b4421533b7c4a9f2721c80 sha1 b7c646509c202fe2e9a2b41a309055b81a7c286f )
-)
-
-game (
 	name "Mr. Jong (Japan)"
 	year "1983"
 	developer "Kiwako"
 	rom ( name mrjong.zip size 24673 crc 996eaa41 md5 27ef2b8bc4bf02b99550954719996191 sha1 6c7cf7338883d750b223381880bf5827d2f49f87 )
-)
-
-game (
-	name "Mr. Kicker"
-	year "2001"
-	developer "SemiCom"
-	rom ( name mrkicker.zip size 1967477 crc 9080655a md5 54f32221ad66d3a0da9ba35efcf84451 sha1 e792968ffb7a8b91b478ae55ae0972fb111f3584 )
 )
 
 game (
@@ -32301,13 +23812,6 @@ game (
 	year "2002"
 	developer "bootleg"
 	rom ( name ms4plus.zip size 421261 crc 101d0ac5 md5 37d86572cce3cd9770883e6bc4cb7bde sha1 8cf170b39e199c9e101812ecce745a6bc10b819f )
-)
-
-game (
-	name "Metal Slug 5 (JAMMA PCB)"
-	year "2003"
-	developer "SNK Playmore"
-	rom ( name ms5pcb.zip size 74422925 crc 240bc4e3 md5 ff8c79658fd8d053b4459c7bbcaefa38 sha1 fdb1ce09477ff87f4c9038ade386d0ede8ddcf5b )
 )
 
 game (
@@ -32521,13 +24025,6 @@ game (
 )
 
 game (
-	name "Metal Soldier Isaac II"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name msisaac.zip size 72622 crc 25eaeca0 md5 8c0a9d26d01dfd816d2abdd9c2d1d940 sha1 c1afcca42afa1b186dc6da4d254f10f17b3b4421 )
-)
-
-game (
 	name "Mahjong Satsujin Jiken (Japan 881017)"
 	year "1988"
 	developer "Nichibutsu"
@@ -32668,13 +24165,6 @@ game (
 )
 
 game (
-	name "Miss Puzzle (Nudes)"
-	year "1994"
-	developer "Min Corp."
-	rom ( name mspuzzlen.zip size 1527661 crc bb6c04c9 md5 74458217f47412b1328a96b087e460ad sha1 9b1e0f8ad9c0fc28273777b36f52b2da1ac197e0 )
-)
-
-game (
 	name "Main Stadium (Japan)"
 	year "1989"
 	developer "Konami"
@@ -32696,13 +24186,6 @@ game (
 )
 
 game (
-	name "Magic Sword (Japan 900623)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mswordj.zip size 1228457 crc 4e57ce1f md5 b35b709a4d6cdfa746832a1e747a64fe sha1 2d4c15810e0bd167e04d1119e817776ec970f566 )
-)
-
-game (
 	name "Magic Sword: Heroic Fantasy (World 900623)"
 	year "1990"
 	developer "Capcom"
@@ -32714,334 +24197,6 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name mswordu.zip size 192003 crc d92b5723 md5 51577a1fe5172c8efd2a2c7459f2a9fa sha1 896dabfa83bf08ee832cb078f5d3aab3e2370bba )
-)
-
-game (
-	name "After Burner (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_aftrb.zip size 207688 crc 6ddc2a8d md5 78a8819e5fd745b40a7fc0a49cf4d994 sha1 e660081c684d9d6080bfc9e14363a482572c0ae7 )
-)
-
-game (
-	name "Arrow Flash (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_arrow.zip size 271204 crc c4457390 md5 54374218dd732d28db637043f788ced0 sha1 59d570c9914248c850da5dc0e9925f2dd2219f28 )
-)
-
-game (
-	name "Alien Storm (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_astrm.zip size 381704 crc 3df98820 md5 e02247608f3daf3016a761a4e77cd113 sha1 4f456e9dc47fbe62b5551c80089b41b10222f144 )
-)
-
-game (
-	name "Astro Warrior (Mega-Tech, SMS based)"
-	year "1986"
-	developer "Sega"
-	rom ( name mt_astro.zip size 44501 crc 8233d8df md5 050d5249dd01b065a49c9001d4f0940a sha1 fe4db0930e69b0bb5370cfa4e32e8a439495f8dd )
-)
-
-game (
-	name "Alien Syndrome (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_asyn.zip size 136046 crc e9e7de46 md5 2c622cfaae4bb1ca9f2b6aee80457913 sha1 a5dd3d42534bdbe9678b3b11a934fa8119da2ce5 )
-)
-
-game (
-	name "Bonanza Bros. (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_bbros.zip size 415877 crc bcbf2660 md5 c56e4625d67629ef22a0d2ea491dd502 sha1 21bedc35b60a61db122cc1a4688d8cce676db74d )
-)
-
-game (
-	name "Altered Beast (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_beast.zip size 337394 crc 9181e9a1 md5 d47dce4fb75861b0a04b82cd85d93cd7 sha1 bf2bdd394bef995addfb018bfe006b5126c45195 )
-)
-
-game (
-	name "Columns (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_cols.zip size 344902 crc c7ab9e83 md5 5aa6041161da9bf0e168c0efd6686a45 sha1 5e348bb7bddd4f46e98b1286cd8e0dc1d7990ff4 )
-)
-
-game (
-	name "Crack Down (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_crack.zip size 237814 crc fc0148b2 md5 d48d0784f27fcb1101562cbe9d75d68c sha1 a83d5933b334dd940a7a2f12fd5310bcb482ae5c )
-)
-
-game (
-	name "Cyber Police ESWAT: Enhanced Special Weapons and Tactics (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_eswat.zip size 386037 crc dc7373ed md5 de849162336188bbd3858b0378401c46 sha1 857081c96024977212a1a2b649a4c868692b7278 )
-)
-
-game (
-	name "Fire Shark (Mega-Tech)"
-	year "1990"
-	developer "Toaplan / Sega"
-	rom ( name mt_fshrk.zip size 205348 crc 8eaa6a9c md5 669921f38cbd1f55e6e665e78b46fd47 sha1 b584e37e5a7c21acef81cf7c5f7154f2e60fb0b7 )
-)
-
-game (
-	name "Forgotten Worlds (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_fwrld.zip size 387157 crc efe2f231 md5 1e7c063a0bdf20edfd486c96a7de8e70 sha1 625bb0a07be9860979214fea1907d2420fe309a0 )
-)
-
-game (
-	name "Golden Axe (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_gaxe.zip size 353339 crc 113984b0 md5 bf276ef40d9f733c0b680dde47884b51 sha1 1cd20e2f2bc69280e91d4d741ded635b87b45f9f )
-)
-
-game (
-	name "Golden Axe II (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_gaxe2.zip size 343141 crc 954bc5ea md5 9fdc93d9e19dadf0f5a71b95f0dd081b sha1 83d84ca9845883ee7f49cd24bdf4bc13d7fe64d7 )
-)
-
-game (
-	name "Great Football (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_gfoot.zip size 54943 crc 6434bd10 md5 d79b877b4028dfec61252406c7b2663f sha1 538c2d602cd43ffa5d5e1c9c4268b145161a5894 )
-)
-
-game (
-	name "Great Golf (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_ggolf.zip size 63623 crc 9a8a334b md5 4ddca31927547228fc3dcf00ad428539 sha1 d9ba8212365c0bf92edb6268725f809a56bdcc4c )
-)
-
-game (
-	name "Ghouls'n Ghosts (Mega-Tech)"
-	year "1989"
-	developer "Capcom / Sega"
-	rom ( name mt_gng.zip size 455338 crc 165cb989 md5 4d52bdc0693622c91ec62a0bf07f6c3d sha1 1f51c816f65522eff6b8cb8a05667d4a4e658b96 )
-)
-
-game (
-	name "Great Soccer (Mega-Tech, SMS based)"
-	developer "Sega"
-	rom ( name mt_gsocr.zip size 78357 crc 6f8e7714 md5 60dee04ff4f147c249769babe098a176 sha1 6b6e8d3a7f3e732ef71e6341cc84339a24e03e4a )
-)
-
-game (
-	name "Kid Chameleon (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_kcham.zip size 758808 crc b3416579 md5 7867982102b79dfe5df045749d08b2c8 sha1 391d87ed9d1f6dd00dbe09f08aa6312cdbe9458e )
-)
-
-game (
-	name "Last Battle (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_lastb.zip size 322100 crc ae8c31e7 md5 9fa1c28acdf0f449f7802bd66958a91c sha1 5d97ca4ae4e1ee85be66e0cacc31f167c21b902b )
-)
-
-game (
-	name "Mario Lemieux Hockey (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_mlh.zip size 279176 crc 8312a04c md5 70bec02d901dd01de449a93d71163417 sha1 ee10ef5b3c8a19c87d0ef7cfcf43a8c34ab9f4a0 )
-)
-
-game (
-	name "Michael Jackson's Moonwalker (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_mwalk.zip size 346672 crc 9d1c478c md5 9fe832fbe775b48868ae8c8fbb88e4a3 sha1 444efe0e00722ea5ce62a2d42aa1b61d17d1e116 )
-)
-
-game (
-	name "Mystic Defender (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_mystd.zip size 289317 crc 27a1cc19 md5 f1dae1034f50a94bbaf34937da4c34a0 sha1 32b2962b223650141bd50587b90b8b3dffdd8f40 )
-)
-
-game (
-	name "Out Run (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_orun.zip size 143164 crc b1adbbf5 md5 d349e5cc40432ae61ef5e611a849c432 sha1 568799166602ef0189917d3d894a82c9e9698f62 )
-)
-
-game (
-	name "Parlour Games (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_parlg.zip size 81421 crc 082d21b9 md5 5902603c040c08e2da0933b946d84edc sha1 0a978f9c2c9f2a898aafc58f4ccc208d71293787 )
-)
-
-game (
-	name "The Revenge of Shinobi (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_revsh.zip size 381871 crc 38f2a93f md5 d577e76064d75114a4e5b93ec129ad29 sha1 9621bf2722feb61f453ae2b91ce2947dbd5675dc )
-)
-
-game (
-	name "Shadow Dancer (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_shado.zip size 357291 crc abde3538 md5 433bfd5f1ff9cab0a4e5024681f3d2d5 sha1 389044c67fcaab788966cfa64f64d657ad5f30fc )
-)
-
-game (
-	name "Super Hang-On (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_shang.zip size 262804 crc 87956a92 md5 84a51503441aa86579df7d08ec63366e sha1 be622610289efc38f319b46757fe9bdd7ab12c84 )
-)
-
-game (
-	name "Space Harrier II (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_shar2.zip size 318310 crc b2194541 md5 991915b95c4e087484e0add6aa310e55 sha1 d7f1f08041e9ac7730e677f95aba7ef8ac050496 )
-)
-
-game (
-	name "Shinobi (Mega-Tech, SMS based)"
-	year "1987"
-	developer "Sega"
-	rom ( name mt_shnbi.zip size 134808 crc 42241a3e md5 c97cafbd8a75bdf5f1c0900ce6fb8812 sha1 4fa7bc57fbb727ae0e0851313871cff456a0c03d )
-)
-
-game (
-	name "Super Monaco GP (Mega-Tech)"
-	year "1990"
-	developer "Sega"
-	rom ( name mt_smgp.zip size 405432 crc b06375bb md5 59a570620601d9dbe6627e275b34fcfb sha1 640bc253ed794075974273cb04f1ceac5c10a69d )
-)
-
-game (
-	name "Sonic The Hedgehog 2 (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_soni2.zip size 763175 crc 3b30b713 md5 c108c39022bc2387cf3edf1e5af0c92c sha1 5e4304cb7076fbe4d0f9858e36046df14440e057 )
-)
-
-game (
-	name "Sonic The Hedgehog (Mega-Tech, set 2)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_sonia.zip size 395402 crc edd737c9 md5 2b75ce593aaa2ad2263e0702cdcb8f8c sha1 802aa135c4b597205bd5720a1c0603ab2a73190e )
-)
-
-game (
-	name "Sonic The Hedgehog (Mega-Tech, set 1)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_sonic.zip size 398183 crc 70ccfcd2 md5 b3a9d8000c90dc8ad2c521e295ed30d6 sha1 f98979f6d7f1f86518aedbce0086dcf0f1691cab )
-)
-
-game (
-	name "Spider-Man vs The Kingpin (Mega-Tech)"
-	year "1991"
-	developer "Marvel / Sega"
-	rom ( name mt_spman.zip size 402601 crc dca7eb8d md5 f9a52cd79cb89c2902f07883f8e21e98 sha1 c4a04cbe8163cc651c45629314fed8e9fd55b52f )
-)
-
-game (
-	name "Streets of Rage (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_srage.zip size 382823 crc 84ecba18 md5 b47b5cd74adca8a38977c159da57f408 sha1 6ce5b3dc0125e89c835e85c2cfb6a80031199ae8 )
-)
-
-game (
-	name "Super Real Basketball (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_srbb.zip size 190138 crc 9ae77ac6 md5 27bbedca3c5f537491f53da1637b000a sha1 4cdabf693f05fbeb1c012fc25c6a13c7892dfb20 )
-)
-
-game (
-	name "Super Thunder Blade (Mega-Tech)"
-	year "1988"
-	developer "Sega"
-	rom ( name mt_stbld.zip size 278619 crc b081741c md5 385e036e641d83948d2c24bc052a2be8 sha1 8f29ac548f446195d4956b4eabcf5dc43d099577 )
-)
-
-game (
-	name "Joe Montana II: Sports Talk Football (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_stf.zip size 619687 crc b3f5a284 md5 9fcec387f8dcc72e2be3eb0ba2fab778 sha1 f1ea8214107d2c4a9f0b286bde4343fee6fb7f08 )
-)
-
-game (
-	name "Tetris (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tetri.zip size 128223 crc 07a2d255 md5 08009f4229e8c698a5ac5a5c42162152 sha1 e2b41de4f9b727942069e6928022b026a410055b )
-)
-
-game (
-	name "Thunder Force II MD (Mega-Tech)"
-	year "1989"
-	developer "Tecno Soft / Sega"
-	rom ( name mt_tfor2.zip size 389329 crc b451112c md5 8876ed7ed2544e42f6242ab8c1ef1442 sha1 974f17847bcb7b099b2d269f4954fcb860228d25 )
-)
-
-game (
-	name "Arnold Palmer Tournament Golf (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tgolf.zip size 305746 crc 5212161b md5 15c5855b2c4fab1de29c534848416a57 sha1 61f0823ea63617f38470c37075a5508a8bc8fbce )
-)
-
-game (
-	name "Tommy Lasorda Baseball (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_tlbba.zip size 299587 crc fc1a5ece md5 144805c9c8617812965276b394e05962 sha1 a4dc04cede24f1650b6cdf0bc5724d1f55cf410f )
-)
-
-game (
-	name "Turbo Outrun (Mega-Tech)"
-	year "1992"
-	developer "Sega"
-	rom ( name mt_tout.zip size 302002 crc dc139729 md5 0d79a25debf7ed2a41b40228b360e3ed sha1 7796b781994fef4c5f68d42df38cd63173c291a3 )
-)
-
-game (
-	name "World Championship Soccer (Mega-Tech)"
-	year "1989"
-	developer "Sega"
-	rom ( name mt_wcsoc.zip size 335869 crc 40e8c1b1 md5 488babbccd807e371dc69465c52f8582 sha1 560201ce2c6c6df6f7dd12d79048c2c4779ee849 )
-)
-
-game (
-	name "Wrestle War (Mega-Tech)"
-	year "1991"
-	developer "Sega"
-	rom ( name mt_wwar.zip size 412700 crc 8edb6fa2 md5 5ad3a80a5f89bccedd0fa6e7f8cd068e sha1 50f4d73f29a42bbcd96d22f68142b05298f68289 )
-)
-
-game (
-	name "Magical Tetris Challenge (981009 Japan)"
-	year "1998"
-	developer "Capcom"
-	rom ( name mtetrisc.zip size 12151575 crc 8e7f1137 md5 b539f43d9486ec03d0883a9c0a38f4a5 sha1 b8dd76f8b65a9666f3959a7665d2dc8f9260e04f )
 )
 
 game (
@@ -33080,13 +24235,6 @@ game (
 )
 
 game (
-	name "Magical Odds (set 3, alt hardware)"
-	year "1991"
-	developer "Pal Company"
-	rom ( name mtonic.zip size 105676 crc 117b4049 md5 40c0e751187c55b32949ed44aae34b1c sha1 32fb3a8a8ef14366a49ca77676feec25d5e118e7 )
-)
-
-game (
 	name "Mouse Trap (version 5)"
 	year "1981"
 	developer "Exidy"
@@ -33105,13 +24253,6 @@ game (
 	year "1981"
 	developer "Exidy"
 	rom ( name mtrap4.zip size 15841 crc 5932986f md5 a480d151bb54a6a7cd112723ed9f5cb4 sha1 43a01f10bbc8d6cb30a991fa990954f95bd0d5a9 )
-)
-
-game (
-	name "Mega Twins (World 900619)"
-	year "1990"
-	developer "Capcom"
-	rom ( name mtwins.zip size 1435278 crc 7c4217bc md5 ad60091137010317baef2db22523ffb6 sha1 e8d16c0fa1e8dbabb45b40b05574450addb47d56 )
 )
 
 game (
@@ -33167,32 +24308,6 @@ game (
 	year "1992"
 	developer "Tung Sheng Electronics"
 	rom ( name multigmt.zip size 356672 crc 968f29c0 md5 029c660a8e3ba0e12d4e33f2edc80384 sha1 de1b3c4e09eebac8612b8c49332b5cb1bcd05717 )
-)
-
-game (
-	name "Multi Win (Ver.0167, encrypted)"
-	year "1992"
-	developer "Funworld"
-	rom ( name multiwin.zip size 37907 crc 48e4b715 md5 04e1730c0398b9acc20c821dd44bfb96 sha1 cb13d310996c6066f2178f26b00a42278a36e6a6 )
-)
-
-game (
-	name "Muroge Monaco (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name murogem.zip size 3163 crc abdace90 md5 362928e59f6603965c96b87a4ea8b938 sha1 e0984320467695a3b8e6c67f010c304fffa75bd1 )
-)
-
-game (
-	name "Muroge Monaco (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name murogema.zip size 2933 crc a0909b0d md5 ab87bcd06ffa6273dd935c58a6d89653 sha1 fb733a24607094fe16c8ce03dfb03c17b3486ed5 )
-)
-
-game (
-	name "Muroge Monaco (bootleg?)"
-	year "1982"
-	developer "bootleg?"
-	rom ( name murogmbl.zip size 4887 crc 8a96222f md5 813aa4d7c1c35b60b31c935d5cc863e7 sha1 0fcb89cd58073313d24a63b38da6da1938e2c33d )
 )
 
 game (
@@ -33266,13 +24381,6 @@ game (
 )
 
 game (
-	name "Mini Vegas 4in1"
-	year "1983"
-	developer "Entertainment Enterprises"
-	rom ( name mv4in1.zip size 17192 crc 09e8ccbf md5 2fefc6b5e62783341cd4e472950e565f sha1 9ef09931755ca9d5ce8784908af9f18af85f5625 )
-)
-
-game (
 	name "MVP (set 2, US, FD1094 317-0143)"
 	year "1989"
 	developer "Sega"
@@ -33284,20 +24392,6 @@ game (
 	year "1989"
 	developer "Sega"
 	rom ( name mvpj.zip size 1331655 crc 77e6bd77 md5 39fb3f687e94e863dd7e79771be1302d sha1 ed8250a38cc61a3c5058cf9cc2497c4ec242e13d )
-)
-
-game (
-	name "Marvel Vs. Capcom: Clash of Super Heroes (Euro 980123)"
-	year "1998"
-	developer "Capcom"
-	rom ( name mvsc.zip size 22699647 crc 7ff321cb md5 c6ce600537da8962022ff0ff0b6084c8 sha1 8b948de6bfed689b18ce4a7b745e3b79400a885a )
-)
-
-game (
-	name "Marvel vs. Capcom 2 (JPN, USA, EUR, ASI, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom"
-	rom ( name mvsc2.zip size 83282157 crc 0cc71c69 md5 f364963c1f2921097e4483cc619efcbd sha1 b869b3e5afeacbe25fb59ceff5eaea90685dc4c9 )
 )
 
 game (
@@ -33382,13 +24476,6 @@ game (
 	year "1990"
 	developer "bootleg"
 	rom ( name mwalkbl.zip size 227945 crc 5e309ba0 md5 198147eddbe8ae25ab66e6a34c482881 sha1 50cce7b7a6a365219784909475ece33708be0800 )
-)
-
-game (
-	name "Michael Jackson's Moonwalker (Japan, FD1094/8751 317-0157)"
-	year "1990"
-	developer "Sega"
-	rom ( name mwalkj.zip size 278418 crc 954cd697 md5 df47b37beb3b9e6d214553c81065ca8e sha1 aa910f8bd672306e0a8c772f053fde475c749450 )
 )
 
 game (
@@ -33538,20 +24625,6 @@ game (
 )
 
 game (
-	name "Name That Tune"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nametune.zip size 152433 crc e960ddcc md5 c11d4fb3707a2909c9dd1267f2df354b sha1 acb3abba2f7dce7a43e4b3a4b13faf3c150291c2 )
-)
-
-game (
-	name "Name That Tune (3-23-86)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nametune2.zip size 147655 crc 081e9e78 md5 61da5b1e8fa7123a36a954183826ce59 sha1 12a8beff780455031735ad8e68dd1a29e6a7a9ba )
-)
-
-game (
 	name "Naname de Magic! (Japan)"
 	year "1994"
 	developer "Atlus"
@@ -33650,13 +24723,6 @@ game (
 )
 
 game (
-	name "NBA Jam Extreme"
-	year "1996"
-	developer "Acclaim"
-	rom ( name nbajamex.zip size 26439450 crc 79dd064f md5 9e1b1db8147e4f3a88ce215708a83e3f sha1 9026b4662951d09fcb1c1248cc62ce167162d157 )
-)
-
-game (
 	name "NBA Jam (rev 2.00 02/10/93)"
 	year "1993"
 	developer "Midway"
@@ -33706,24 +24772,10 @@ game (
 )
 
 game (
-	name "NBA Showtime / NFL Blitz 2000"
-	year "1999"
-	developer "Midway Games"
-	rom ( name nbanfl.zip size 174605 crc 0f4318c6 md5 b28cdf2ece8ce0fc8ee8f7984d439dd4 sha1 18e15050cc3a77b1276bec3ae48a2c24be41bb6c )
-)
-
-game (
 	name "NBA Play By Play"
 	year "1998"
 	developer "Konami"
 	rom ( name nbapbp.zip size 22240372 crc 3f0878b3 md5 8765f015d851b18fa63949b74762d84f sha1 bcfbc0dfc6907a6e86f93bffb5580bcf21b8db25 )
-)
-
-game (
-	name "NBA Showtime: NBA on NBC"
-	year "1998"
-	developer "Midway Games"
-	rom ( name nbashowt.zip size 168674 crc c7b45007 md5 a8210107a5190b19976337ebb6ae7d86 sha1 78ff340a186d89e074bb3f1675377fecc3c8e312 )
 )
 
 game (
@@ -33769,19 +24821,6 @@ game (
 )
 
 game (
-	name "Cherry Bonus III (ver.1.40, set 1)"
-	developer "Dyna"
-	rom ( name ncb3.zip size 76485 crc 8a763e9e md5 55fd61da1e2540bee45043c3858b4910 sha1 67795e3a044d09eba5d2c285d1abe5f4189a8b4a )
-)
-
-game (
-	name "Name Club Ver.3 (J 970723 V1.000)"
-	year "1997"
-	developer "Sega"
-	rom ( name nclubv3.zip size 15237734 crc 83de3f1d md5 f7e60ed46f43fc36e29842bec74978a6 sha1 82129ff00f759a9326ecda879677ea884e3ff5da )
-)
-
-game (
 	name "Ninja Combat (set 1)"
 	year "1990"
 	developer "Alpha Denshi Co."
@@ -33821,20 +24860,6 @@ game (
 	year "1995"
 	developer "Namco"
 	rom ( name ncv1j2.zip size 341179 crc f8aaa3a1 md5 af48a3f659ac6e335b781272e8db3a2b sha1 aea92d829d10c88f41e77d252844cadff52884ed )
-)
-
-game (
-	name "Namco Classic Collection Vol.2"
-	year "1996"
-	developer "Namco"
-	rom ( name ncv2.zip size 2940716 crc 10c06612 md5 506103b1b31146b497fd491dbeee07f2 sha1 2cf185b819c5e91d7831cff44cea95349b3da4d3 )
-)
-
-game (
-	name "Namco Classic Collection Vol.2 (Japan)"
-	year "1996"
-	developer "Namco"
-	rom ( name ncv2j.zip size 422107 crc 45a45afd md5 af0df53155c6c83eea0a64f608c325dd sha1 2914626bd70581e97f60a594cdaa627c0ea6e4a2 )
 )
 
 game (
@@ -33894,13 +24919,6 @@ game (
 )
 
 game (
-	name "Nemo (Japan 901120)"
-	year "1990"
-	developer "Capcom"
-	rom ( name nemoj.zip size 1149808 crc 71ec8478 md5 61c9b11fd2e1df1c136c16b1000f5a47 sha1 e0dce5355e7dbee9da1881ee533745a72795e227 )
-)
-
-game (
 	name "SD Gundam Neo Battling (Japan)"
 	year "1992"
 	developer "Banpresto / Sotsu Agency. Sunrise"
@@ -33936,23 +24954,10 @@ game (
 )
 
 game (
-	name "Neptune's Pearls 2"
-	developer "Unidesa?"
-	rom ( name neptunp2.zip size 1435260 crc 4129f1ce md5 585fd29012f96e81262f3fced9d7a6c3 sha1 db6086570c07caabf007dbcedfeb937c1fbe1a3c )
-)
-
-game (
 	name "Mahjong Neruton Haikujiradan (Japan)"
 	year "1990"
 	developer "Dynax / Yukiyoshi Tokoro"
 	rom ( name neruton.zip size 1309859 crc 1a1d8861 md5 753a8522fff7da67fe09fcf0c9446479 sha1 ed25cfc181203d9df30cc1cd9b81bccc4ac49cb6 )
-)
-
-game (
-	name "Netchuu Pro Yakyuu 2002 (NPY1 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name netchu02.zip size 620620 crc 2fd47250 md5 a39012ab4e4133d2482b5b9a8a1974a9 sha1 0468501034286087db86b5f4ebcae0a2e727f80c )
 )
 
 game (
@@ -34009,13 +25014,6 @@ game (
 	year "1980"
 	developer "hack"
 	rom ( name newpuckx.zip size 10815 crc a72a3529 md5 6261f5a683cae96edaf6c6f90839f9d3 sha1 97d349084ac3f3c0a4a36bbc6eb20ded9f326698 )
-)
-
-game (
-	name "News (set 1)"
-	year "1993"
-	developer "Poby / Virus"
-	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
 )
 
 game (
@@ -34082,66 +25080,10 @@ game (
 )
 
 game (
-	name "New Fruit Bonus '96 Special Edition (bootleg, set 2)"
-	year "1996"
-	developer "bootleg"
-	rom ( name nfb96sea.zip size 73527 crc 4d62c1a7 md5 7a6c563072ab2d7c9ac4ab6dbab00900 sha1 7f2614d926c557c86763f44633b95bb7ab0ce1da )
-)
-
-game (
-	name "New Fruit Bonus '96 Special Edition (bootleg, set 3)"
-	year "1996"
-	developer "bootleg"
-	rom ( name nfb96seb.zip size 58616 crc cd86c820 md5 23ee36e3d44382a889caba43b9fb330f sha1 440c8538d14da51d0a55e569b2db146a6598ad39 )
-)
-
-game (
 	name "New Fruit Bonus '96 Special Edition (set 5, Texas XT)"
 	year "1996"
 	developer "Amcoe"
 	rom ( name nfb96txt.zip size 92251 crc b6fa4fc4 md5 859e3d1713ed2bc8a04df6994759240e sha1 2df9fc4751f2197a3450960131baf403f09f4854 )
-)
-
-game (
-	name "NFL Football"
-	year "1983"
-	developer "Bally Midway"
-	rom ( name nflfoot.zip size 55074 crc 75421c6b md5 8a645dfbe28a6621c4c3e324c61f57fc sha1 4e2cbd9824e0b012047211068b1330fdcb69ee80 )
-)
-
-game (
-	name "New Fruit Machine (Ming-Yang Electronic)"
-	year "2003"
-	developer "Ming-Yang Electronic"
-	rom ( name nfm.zip size 68145 crc abbae41f md5 8c80ff6a474d7cf4697eff6b0475bd5b sha1 1b5ff244a7eae816613d168118b42b57d40bd6a7 )
-)
-
-game (
-	name "Night Gal Summer"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name ngalsumr.zip size 86806 crc ff529bb4 md5 ecd9281a12ea51c18b53fe90c9d20dfc sha1 6ce49913ae2eb2270bf3c0943ce2ab7e1185068a )
-)
-
-game (
-	name "Neo-Geo Battle Coliseum"
-	year "2005"
-	developer "Sammy / SNK Playmore"
-	rom ( name ngbc.zip size 1397688 crc 5da708d9 md5 63eab679362aa191d928a90af47418c9 sha1 70e39a18905c1818ec91526ccdac199178655a00 )
-)
-
-game (
-	name "Naomi DIMM Firmware Updater (GDS-0023A)"
-	year "2001"
-	developer "Sega"
-	rom ( name ngdup23a.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Naomi DIMM Firmware Updater (GDS-0023C)"
-	year "2001"
-	developer "Sega"
-	rom ( name ngdup23c.zip size 1194 crc 2936114c md5 381739a42986b6e56706c85576e6e33a sha1 360c2c830794c274a7ec309f8472100cf1c1c33e )
 )
 
 game (
@@ -34156,13 +25098,6 @@ game (
 	year "1984"
 	developer "Nichibutsu"
 	rom ( name ngtbunny.zip size 27690 crc fb923e3c md5 8a3a9d0704ed910f7d3989751e91de84 sha1 03073f77f9de2a30d5abec3c3e85bee0e4f28789 )
-)
-
-game (
-	name "New Hidden Catch (World) / New Tul Lin Gu Lim Chat Ki '98 (Korea) (pcb ver 3.02)"
-	year "1999"
-	developer "Eolith"
-	rom ( name nhidctch.zip size 20136320 crc b9933d41 md5 8614070b65ff439f06034f45a23799bb sha1 cbfe0db42e0a4823792c0441fb910a39c3e4e406 )
 )
 
 game (
@@ -34198,13 +25133,6 @@ game (
 	year "1984"
 	developer "Nichibutsu"
 	rom ( name nightgal.zip size 37406 crc 0b21942c md5 34dd6a1add9fb5dc5c9b1a565db7e29b sha1 7a430ed8fa10ec7f7e1f150a4b2d93da7d6190a3 )
-)
-
-game (
-	name "Night Love (Japan 860705)"
-	year "1986"
-	developer "Central Denshi"
-	rom ( name nightlov.zip size 129652 crc b7caf1b0 md5 d8fa161e818fd1eda903f0abcbc3da23 sha1 976babcbc6a0d00c04dccb0959a7cb97adc4f0f5 )
 )
 
 game (
@@ -34313,13 +25241,6 @@ game (
 )
 
 game (
-	name "Ninja Emaki (US)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name ninjemak.zip size 219787 crc a6d62528 md5 00ec58d18b5efc4bc2335f6932f531e1 sha1 cbe53ea7f93e5ff597b56ec55880730bad91fc33 )
-)
-
-game (
 	name "Nightmare in the Dark"
 	year "2000"
 	developer "Eleven / Gavaking"
@@ -34352,27 +25273,6 @@ game (
 	year "1996"
 	developer "Nichibutsu"
 	rom ( name niyanpai.zip size 997812 crc c6a23980 md5 0b88935de104339f260b6df64644fecd sha1 8945fb99c2fb27be996c6cc141a3312f0bc74234 )
-)
-
-game (
-	name "Nekketsu Koukou Dodgeball Bu (Japan)"
-	year "1987"
-	developer "Technos Japan"
-	rom ( name nkdodge.zip size 207851 crc 430b2675 md5 d9d592ca50ce9f03bcc55b09d2b11b44 sha1 eebfd95a745b173307b01d8ca00b003d4a8c8ebd )
-)
-
-game (
-	name "Nekketsu Koukou Dodgeball Bu (Japan, bootleg)"
-	year "1987"
-	developer "bootleg"
-	rom ( name nkdodgeb.zip size 208931 crc 5f93dffd md5 74335d8781287e2208e0a6996cf1b84c sha1 4a9ed5b5d1024b0678eb332f7a3549e315493d92 )
-)
-
-game (
-	name "Mahjong Nenrikishu SP"
-	year "1998"
-	developer "IGS / Alta"
-	rom ( name nkishusp.zip size 767645 crc 66b9f48a md5 140327a4641d66a64ac992a5c6526976 sha1 c8cd7b8fc1ad8d12017be47be1ecb3611cd019bf )
 )
 
 game (
@@ -34418,13 +25318,6 @@ game (
 )
 
 game (
-	name "Nandemo Seal Iinkai"
-	year "1997"
-	developer "I&apos;Max / Jaleco"
-	rom ( name nndmseal.zip size 2955693 crc e752453a md5 922e2ec01d9ff2ee127dd804b17a01ac sha1 c24b778bea382a950b0eb73f033a7788422427b3 )
-)
-
-game (
 	name "Noah's Ark"
 	year "1983"
 	developer "Enter-Tech"
@@ -34457,20 +25350,6 @@ game (
 	year "1980"
 	developer "Universal (Gottlieb license)"
 	rom ( name nomnlndg.zip size 9743 crc 46e388d7 md5 78169585f952dcbac184c00741ee3735 sha1 e537d5eddc5de962da3176f9554caf27731adc55 )
-)
-
-game (
-	name "Noraut Joker Poker (V3.010a)"
-	year "2002"
-	developer "Noraut Ltd."
-	rom ( name noraut3a.zip size 21631 crc d15d2f03 md5 5ffab075207071a5f4a7423a1887aa01 sha1 00ed9c379f0bac9d2dd740880645bb3f87963fc1 )
-)
-
-game (
-	name "Noraut Joker Poker (V3.011a)"
-	year "2003"
-	developer "Noraut Ltd."
-	rom ( name noraut3b.zip size 22575 crc bcb1b3ac md5 a97f5cb4d09ace9cf77a67b7fae78756 sha1 7467dc596743818cd63585e7900a08ae2c7cc4ce )
 )
 
 game (
@@ -34522,25 +25401,6 @@ game (
 	year "1988"
 	developer "Noraut Ltd."
 	rom ( name norautrh.zip size 6418 crc c564069b md5 595665b84807c18c6a99363eace16ab7 sha1 ba951505df4099f34676c8c9d0b69053054ce696 )
-)
-
-game (
-	name "Noraut Poker (NTX10A)"
-	year "1988"
-	developer "Noraut Ltd."
-	rom ( name norautu.zip size 11018 crc fe7d30bf md5 39828efc4b715f12b67614578bd80b6e sha1 4bc5d741cd33c296889a5d6af56104f128323a6d )
-)
-
-game (
-	name "Noraut unknown set 1 (console)"
-	developer "Noraut Ltd."
-	rom ( name norautua.zip size 8430 crc 26b8e0b9 md5 2d7e7ca175dfb4390670d26abcc30ae7 sha1 83eb66bced970e10a1dd95ee2104608d7f21c077 )
-)
-
-game (
-	name "Noraut unknown set 2 (console)"
-	developer "Noraut Ltd."
-	rom ( name norautub.zip size 8154 crc 58003dbe md5 8598d1528e1fbd8eb4bbb3391f79fd9f sha1 1844576d1caebb0ab3eb402064428e1932c9f7c0 )
 )
 
 game (
@@ -34668,129 +25528,10 @@ game (
 )
 
 game (
-	name "Ninja Spirit"
-	year "1988"
-	developer "Irem"
-	rom ( name nspirit.zip size 585051 crc a9c0aa55 md5 51db030c9f0f8245440a076bf7ec141f sha1 c792a326fa586ba2fccdae7d5e3efb3933dae0bc )
-)
-
-game (
 	name "Saigo no Nindou (Japan)"
 	year "1988"
 	developer "Irem"
 	rom ( name nspiritj.zip size 101692 crc 151390cd md5 ab11640a210ce3aefcd27002ebbe2ce5 sha1 d9da755d4e7321cf1e687d606cce62a1cf88e464 )
-)
-
-game (
-	name "Act Raiser (Nintendo Super System)"
-	year "1992"
-	developer "Enix"
-	rom ( name nss_actr.zip size 545627 crc 2b6aee52 md5 cf84f71fe3c76179e1e5b0c11b3f63a1 sha1 565fc4ef15cd9a1d9132bc4657f731d056d2ecce )
-)
-
-game (
-	name "The Addams Family (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_adam.zip size 765726 crc 6e7c4dd3 md5 e6d90f8e55146a3e56131509b7219deb sha1 9683f6dded8eba80ea07ec07a304ffe292a78a35 )
-)
-
-game (
-	name "David Crane's Amazing Tennis (Nintendo Super System)"
-	year "1992"
-	developer "Absolute Entertainment Inc."
-	rom ( name nss_aten.zip size 520898 crc 99e887f0 md5 ca0fe68fa61740492d41016c4174d082 sha1 aeae289487a7aab3feeb9b306597aeb4346644e2 )
-)
-
-game (
-	name "Contra 3: The Alien Wars (Nintendo Super System)"
-	year "1992"
-	developer "Konami"
-	rom ( name nss_con3.zip size 754880 crc ed105df5 md5 1b88b20da7587894925b3e13b884cdc9 sha1 7fe74257dea4fd86b8249d6a9c464d73f2b4541f )
-)
-
-game (
-	name "F-Zero (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_fzer.zip size 583719 crc 479398e6 md5 665457681df31c410c02f20212b1bd3f sha1 8b9b2e521d9567a595b88568d771aeb07a31d21e )
-)
-
-game (
-	name "Lethal Weapon (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_lwep.zip size 684860 crc 33bac38c md5 91383768663dbde8f0bbff6443d1c17b sha1 8a7129e1c4ca12559565e5ea154663996f7d3722 )
-)
-
-game (
-	name "NCAA Basketball (Nintendo Super System)"
-	year "1992"
-	developer "Sculptured Software Inc."
-	rom ( name nss_ncaa.zip size 578249 crc 36e27bf5 md5 65829a44b0ce0eb275852c32fcfa477d sha1 b6c1f466f4a5af0e1d9775259aa735ab643b11bd )
-)
-
-game (
-	name "Robocop 3 (Nintendo Super System)"
-	year "1992"
-	developer "Ocean"
-	rom ( name nss_rob3.zip size 467245 crc def1d440 md5 ebee9dda14b5acc76858f9de7b5fd58f sha1 9ef285237505f609e44e51edbb84f657b39ee22e )
-)
-
-game (
-	name "Skins Game (Nintendo Super System)"
-	year "1992"
-	developer "Irem"
-	rom ( name nss_skin.zip size 484912 crc fa86ae04 md5 4ffa0aacd15db17d9047c7b4e70c436a sha1 9cfec1ee1cbeda10cea36bf76c7ec60a3a42989b )
-)
-
-game (
-	name "Super Mario World (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_smw.zip size 353561 crc 41d196a7 md5 5fa731fb9513da1b3a4f5591e9f0d5ae sha1 05dcff6c91dcd7280b7e88a011a917875be072bd )
-)
-
-game (
-	name "Super Soccer (Nintendo Super System)"
-	year "1992"
-	developer "Human Inc."
-	rom ( name nss_ssoc.zip size 263069 crc 08405600 md5 dd35d3c3e7249e156aaeaa882ff9c121 sha1 96e43cd42b45197c7c346dff093ff4bf8dc55c22 )
-)
-
-game (
-	name "Super Tennis (Nintendo Super System)"
-	year "1991"
-	developer "Nintendo"
-	rom ( name nss_sten.zip size 532940 crc f5017ff6 md5 5e98004f277ab4f700dfb8170128250e sha1 8a40ce16ef1ccbe5943c67d267a206196d6b8c51 )
-)
-
-game (
-	name "Night Stocker (set 1)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nstocker.zip size 69916 crc b4706cfd md5 e51875956118b11a665c325e6e86ac50 sha1 e8d2d0e5e0092faac7d953b9a9a1aeb8a90d722b )
-)
-
-game (
-	name "Night Stocker (set 2)"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name nstocker2.zip size 69856 crc 801a7134 md5 109f97df628ccf25832d69cc61201c11 sha1 82ae29550b842a8f52c2cbeac041b5575a273eed )
-)
-
-game (
-	name "N-Sub (upright)"
-	year "1980"
-	developer "Sega"
-	rom ( name nsub.zip size 12662 crc bcc71dbe md5 1c7827e6c15910a6bf9a68f4c8ba0a1d sha1 a157330cffb6664698d1b7c5da79f545c09e7fd7 )
-)
-
-game (
-	name "NtCash"
-	year "1999"
-	developer "&lt;unknown&gt;"
-	rom ( name ntcash.zip size 380581 crc 44f6236f md5 9098c86f037f36c9c8e4c3b431f386a6 sha1 4cb3035475573dc1f889d682695ff74beca558ad )
 )
 
 game (
@@ -34906,20 +25647,6 @@ game (
 )
 
 game (
-	name "New Zero Team"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name nzerotea.zip size 420818 crc 3cdb7b72 md5 2e68708b5ef3910f3df8856e2d162ade sha1 94de7cb006b96e32897805da52deb338e5649332 )
-)
-
-game (
-	name "The Ocean Hunter"
-	year "1998"
-	developer "Sega"
-	rom ( name oceanhun.zip size 81763466 crc eec2ea44 md5 6d91e1454c2870e762962c34592b2fd8 sha1 e14b21c8ed98f9913cd1448208689c0d54fc358c )
-)
-
-game (
 	name "Oedo Fight (Japan Bloodshed Ver.)"
 	year "1994"
 	developer "Kaneko"
@@ -34927,45 +25654,10 @@ game (
 )
 
 game (
-	name "Office Yeo In Cheon Ha (version 1.2)"
-	year "2001"
-	developer "Danbi"
-	rom ( name officeye.zip size 12899207 crc 863db969 md5 b24b15ccd18f920bcb97524cc9dc538f sha1 8ea32f19596928928199ab6a5a4ad19c947f7f65 )
-)
-
-game (
 	name "Ironman Ivan Stewart's Super Off-Road"
 	year "1989"
 	developer "Leland Corp."
 	rom ( name offroad.zip size 479859 crc 394921fb md5 5f5e2c8c00aa8d1bc06099306640d701 sha1 9fc4e04b59cbbdff233841dc23aa7ba404d6f2ce )
-)
-
-game (
-	name "Off Road Challenge (v1.63)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc.zip size 15659751 crc cad711b2 md5 0b364b69bcbed66159244d95fb8d24da sha1 fb0e6fd3d636f6979bc824a87d0f459f417cfd41 )
-)
-
-game (
-	name "Off Road Challenge (v1.10)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc1.zip size 2985729 crc d7fe2798 md5 464c7d99e911f68e4eb456473d158c30 sha1 15e3a212497c0f2ee109c9a9336ec5f02d2b796c )
-)
-
-game (
-	name "Off Road Challenge (v1.30)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc3.zip size 2985914 crc 468f3fd0 md5 2014c0f7f92c3e1e72d1261a949a0fb9 sha1 5193f1e57f3556c95ca099455ea3a2bc16861787 )
-)
-
-game (
-	name "Off Road Challenge (v1.40)"
-	year "1997"
-	developer "Midway"
-	rom ( name offroadc4.zip size 2985982 crc 09fa2000 md5 38b7b2874eadf72707c592cde6e7322f sha1 ca699d110824b05c75d5deceaeaf9789a6590a5b )
 )
 
 game (
@@ -35018,13 +25710,6 @@ game (
 )
 
 game (
-	name "Oigas (bootleg)"
-	year "1986"
-	developer "bootleg"
-	rom ( name oigas.zip size 38954 crc 4e757952 md5 da23ddf94899c37ce7951ec3e4da700b sha1 c992d6620fd2092cb49c1b109a4f6aa2fe01a7b1 )
-)
-
-game (
 	name "Oishii Puzzle Ha Irimasenka"
 	year "1993"
 	developer "Sunsoft / Atlus"
@@ -35071,55 +25756,6 @@ game (
 	year "1987"
 	developer "Nichibutsu"
 	rom ( name ojousanm.zip size 97761 crc f6814eef md5 f6793f84e8610609a26e3104fac444a7 sha1 64c3f09320558d1865bcd5259a04dc8a2b6d1241 )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (ver. 101, Korean Board)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds.zip size 21083119 crc 7c0ee6a0 md5 a9b521c91c7f0bb83acd40e30490d875 sha1 b23ccc312c78d9f777a8d7f3b8a2d247abfa6246 )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds100.zip size 866148 crc 965cb01e md5 ea17d74ac0206153ce23c1e50fd5858f sha1 bf772b3f97e7442d7bcfd80e9851677ee83543d0 )
-)
-
-game (
-	name "Oriental Legend Special / Xi You Shi E Zhuan Super (alt ver. 100)"
-	year "1998"
-	developer "IGS"
-	rom ( name olds100a.zip size 880754 crc a208d40e md5 4ab5f77ca0b7e3fff6e6d8df3d033be0 sha1 ada1aa93dd081d238f54b4196d4799ffef6d63f6 )
-)
-
-game (
-	name "Oriental Legend Special Plus / Xi You Shi E Zhuan Super Plus"
-	year "2004"
-	developer "IGS"
-	rom ( name oldsplus.zip size 23069455 crc 2fe8d9c7 md5 aa9018f8732b8af95ee6969d1b6e5517 sha1 91e895ff815a8e9ca0d1ae491fbcec4b8410e9c2 )
-)
-
-game (
-	name "Oli-Boo-Chu"
-	year "1981"
-	developer "Irem / GDI"
-	rom ( name olibochu.zip size 35413 crc ec73c654 md5 b308efcb8b0292b80b3e848702179d14 sha1 b8459d404213a189365fde83560797b3a6df6ec3 )
-)
-
-game (
-	name "Ollie King (GDX-0007)"
-	year "2005"
-	developer "Sega"
-	rom ( name ollie.zip size 211 crc 8f81fdd3 md5 f1a6ad864014414f527d1623effe8622 sha1 a7cf4a1000752968de953798144180369ab45e01 )
-)
-
-game (
-	name "Olympic Soccer '92"
-	year "1992"
-	developer "Seibu Kaihatsu"
-	rom ( name olysoc92.zip size 389833 crc c7f69560 md5 12f5dc66a6df92dccab260a6bae779db sha1 da04898626c30079f3bfd33fc421affcffb3c229 )
 )
 
 game (
@@ -35183,38 +25819,10 @@ game (
 )
 
 game (
-	name "Onna Sansirou - Typhoon Gal (set 1)"
-	year "1985"
-	developer "Taito"
-	rom ( name onna34ro.zip size 124290 crc db907038 md5 6b03397a0721948c065e8f4be1cbcaa5 sha1 ed4256e4c3f9599bf8b64aeb16509398165c3e2c )
-)
-
-game (
-	name "Onna Sansirou - Typhoon Gal (set 2)"
-	year "1985"
-	developer "Taito"
-	rom ( name onna34roa.zip size 27490 crc 2d96f8ee md5 107f6ad0ec95e9cc8535170bd832803d sha1 2645e46b246d4f8027f44030a0be2d305cb85957 )
-)
-
-game (
 	name "Opa Opa (MC-8123, 317-0042)"
 	year "1987"
 	developer "Sega"
 	rom ( name opaopa.zip size 167646 crc c013ba04 md5 76de1d1651a470d240f752cf09f54faa sha1 c5a0d1df53c2df6ab84e19dfde751e6af3b276ac )
-)
-
-game (
-	name "Konami's Open Golf Championship (ver EAE)"
-	year "1994"
-	developer "Konami"
-	rom ( name opengolf.zip size 12285530 crc d0bcb651 md5 328c6d0244399217aa265ebe8649b85b sha1 416d848bba28d21126f3967f6bb0b8253126adea )
-)
-
-game (
-	name "Konami's Open Golf Championship (ver EAD)"
-	year "1994"
-	developer "Konami"
-	rom ( name opengolf2.zip size 320366 crc 34c6a7ed md5 9f643e0fe6c6d51fa67ac4b06b9c671b sha1 ccdf88de09af94fd215946efd612008a16e499c8 )
 )
 
 game (
@@ -35228,13 +25836,6 @@ game (
 	name "Open Mahjong [BET] (Japan)"
 	developer "Sapporo Mechanic"
 	rom ( name openmj.zip size 16602 crc 10a13c77 md5 1bb2317770a678ee0b44bcc686a2b20f sha1 436b910bb7dae45394ebe68cadb17d6e383955f9 )
-)
-
-game (
-	name "Operation Tiger"
-	year "1998"
-	developer "Taito"
-	rom ( name optiger.zip size 24437097 crc 8a843eda md5 c1a515c64ef28fa18a8caab3670009ff sha1 48386427b3f5d0209d34922d2fd6165471f3f2e6 )
 )
 
 game (
@@ -35392,34 +25993,6 @@ game (
 )
 
 game (
-	name "Psycho-Nics Oscar (World revision 0)"
-	year "1988"
-	developer "Data East Corporation"
-	rom ( name oscar.zip size 270950 crc 108ce66b md5 76cd960b73e1dbc1bf2c41b168b4e1d6 sha1 82b77af4fa0c531eadcdec1309f97d0c15a54994 )
-)
-
-game (
-	name "Psycho-Nics Oscar (Japan revision 1)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name oscarj1.zip size 15727 crc 3d928ee5 md5 df21d49325e984a98e463fefbe73e48e sha1 0d77d039dc979f6e1e2426204d4f96c7c9f491f5 )
-)
-
-game (
-	name "Psycho-Nics Oscar (Japan revision 2)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name oscarj2.zip size 15726 crc daba584c md5 956a5304d490eee5773c3cde30222931 sha1 1736c22593a4ef43e79b67e4762b88ac1b82d9ef )
-)
-
-game (
-	name "Psycho-Nics Oscar (US)"
-	year "1987"
-	developer "Data East USA"
-	rom ( name oscaru.zip size 38931 crc 099ce174 md5 6853711b59720c9fcccc587cb2a9d9ce sha1 3b0973a0e5c24d3aeb52dfb3ea0382d227eadda1 )
-)
-
-game (
 	name "Osman (World)"
 	year "1996"
 	developer "Mitchell"
@@ -35431,13 +26004,6 @@ game (
 	year "1995"
 	developer "Sphinx"
 	rom ( name otatidai.zip size 769924 crc 7b823cad md5 998bda9b2ec7b8344a4f93fa217a9e95 sha1 54064763a6d6183431d92bde0b7d3419bae0661f )
-)
-
-game (
-	name "Othello (version 3.0)"
-	year "1984"
-	developer "Success"
-	rom ( name othello.zip size 26580 crc df61a98d md5 8f74aff9f6534b150bf88a617d81a643 sha1 0c55afcb5738a6bccb82c477f060c910f637a5da )
 )
 
 game (
@@ -35490,20 +26056,6 @@ game (
 )
 
 game (
-	name "OutTrigger (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name otrigger.zip size 76793068 crc 78a4bb4b md5 a585d45e29843fa54333fa70cbf79ac7 sha1 89b65fd0aceb681de5baad3bc63bac554ec86d25 )
-)
-
-game (
-	name "Off the Wall (Sente)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name otwalls.zip size 31281 crc 696c7e94 md5 1aeef6cd63c95f15500d571df6e451c5 sha1 b983436f556bb9675c5215557f3e1b9eb636485e )
-)
-
-game (
 	name "Outfoxies (World, OU2)"
 	year "1994"
 	developer "Namco"
@@ -35522,13 +26074,6 @@ game (
 	year "1982"
 	developer "Century Electronics"
 	rom ( name outline.zip size 18234 crc c0bb11d3 md5 f7b19d1d94af37806bfbac47930ba1b7 sha1 dee3c759da5d95e43fc8e176f3a32346e3ebab05 )
-)
-
-game (
-	name "Out Run 2 (Rev. A) (GDX-0004A)"
-	year "2003"
-	developer "Sega"
-	rom ( name outr2.zip size 218 crc 3e51aa84 md5 56b36a52a565fceb6c3b5052032526b8 sha1 a9cc840fefa199f3857e4f08b76e2bb61a707c5d )
 )
 
 game (
@@ -35602,20 +26147,6 @@ game (
 )
 
 game (
-	name "Over Drive"
-	year "1990"
-	developer "Konami"
-	rom ( name overdriv.zip size 3148085 crc 95b24440 md5 31b53ac44224cfa30efde9f0b9dbf112 sha1 8fb4585bfe47762de05559a09cf66b37aecc037a )
-)
-
-game (
-	name "Over Rev (Revision A)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name overrev.zip size 14143936 crc 0871e58c md5 c4981602a7cb039f777f347f3f13099d sha1 8280398b760f3a250f05b59f0b21aaab1d694f09 )
-)
-
-game (
 	name "Over Top"
 	year "1996"
 	developer "ADK"
@@ -35651,38 +26182,10 @@ game (
 )
 
 game (
-	name "P-47 Aces"
-	year "1995"
-	developer "Jaleco"
-	rom ( name p47aces.zip size 8715750 crc 6d6a4ad7 md5 732428f7fc1a99ba20e1024fea1791c3 sha1 c7f6bb507f692d22d75a3237439ece283582082e )
-)
-
-game (
 	name "P-47 - The Freedom Fighter (Japan)"
 	year "1988"
 	developer "Jaleco"
 	rom ( name p47j.zip size 74429 crc 3a321026 md5 4f4fc3c38ad47cb6ef335665e915d2de sha1 4b613c78682f524c4f9b642f3cbead61afcf09c7 )
-)
-
-game (
-	name "Police 911 (ver UAD)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911.zip size 1483 crc cbc55c88 md5 a9fd11d72f219aea1b3df65707d06652 sha1 29230e32ec8fac25bde71cfb15ced9a9d7d11570 )
-)
-
-game (
-	name "Keisatsukan Shinjuku 24ji (ver JAC)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911j.zip size 802 crc c6f69598 md5 02678b2d8e2bc4d826a1a746039dce1b sha1 8dd10a032bbb62f1ca146b0203044ccf52ceaf58 )
-)
-
-game (
-	name "Police 911 (ver KAC)"
-	year "2001"
-	developer "Konami"
-	rom ( name p911kc.zip size 687 crc 71cbe576 md5 d879e3d7a41f75891269b5f48ff18cef sha1 68666075e4c85fa19f26593fd5517c6845bd2ef0 )
 )
 
 game (
@@ -35717,7 +26220,7 @@ game (
 	name "Pac-Man (Hearts)"
 	year "1981"
 	developer "hack"
-	rom ( name pacheart.zip size 14869 crc 0219b919 md5 5948c3d0f654ca2c8e70a3590019bd8d sha1 eeeb949a676e0ff3a4ab14d760ee8ed9ca248165 )
+	rom ( name pacheart.zip size 14243 crc cf7b7ac0 md5 3f85c0a0a8015a14b447de814535ebec sha1 a49df2871a88cd204f596f8d1be51e36eab00216 )
 )
 
 game (
@@ -35931,27 +26434,6 @@ game (
 )
 
 game (
-	name "Pang! 3 (Euro 950601)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3.zip size 1536054 crc a87f3739 md5 c0de95b04c2f94e3b3220f1df6fb9ec7 sha1 40f258558a0131042df75952e6616f8a8ae44958 )
-)
-
-game (
-	name "Pang! 3: Kaitou Tachi no Karei na Gogo (Japan 950511)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3j.zip size 145169 crc 9931a464 md5 e2c83cdd590436a482e3a697996345d2 sha1 c163acb92b9dffed38daf6fbf59592d6d08d091e )
-)
-
-game (
-	name "Pang! 3 (Euro 950511, not encrypted)"
-	year "1995"
-	developer "Mitchell"
-	rom ( name pang3n.zip size 143820 crc 646b27ec md5 0a737bb335a58c71240d53b59c0f533c sha1 6bd49b974f872c504e206c840fe8166ac5eede2b )
-)
-
-game (
 	name "Pang (bootleg, set 1)"
 	year "1989"
 	developer "bootleg"
@@ -35959,31 +26441,10 @@ game (
 )
 
 game (
-	name "Pang (bootleg, set 3)"
-	year "1989"
-	developer "bootleg"
-	rom ( name pangba.zip size 483323 crc 73b8c1e0 md5 fcc6deef33ff001166e188c6a63361aa sha1 2a58c967c1a85d129fb464c4915f6e85df00439a )
-)
-
-game (
 	name "Pang (bootleg, set 2)"
 	year "1989"
 	developer "bootleg"
 	rom ( name pangbold.zip size 294151 crc 6a3e80d4 md5 e38fc24e1ee94cfc6d6db90fee7b677c sha1 ae4cf1be274aa15a413bb84080bef9917db79b4f )
-)
-
-game (
-	name "Pango Fun (Italy)"
-	year "1995"
-	developer "InfoCube"
-	rom ( name pangofun.zip size 1988654 crc 0cebe61a md5 e87f007cf44cf0f7e95f9a53fa775704 sha1 64e87818ee2b841292dbfd5a12737e9d6e2a960d )
-)
-
-game (
-	name "Pang Pang"
-	year "1994"
-	developer "Dong Gue La Mi Ltd."
-	rom ( name pangpang.zip size 1327359 crc 6d4091d6 md5 ed64180c61efdcff8fcf8eb1abbc7f85 sha1 7cc71bd8f59396cce15bb67c73aa98ed5cc5516e )
 )
 
 game (
@@ -36043,31 +26504,10 @@ game (
 )
 
 game (
-	name "Panic Park (PNP2 Ver. A)"
-	year "1998"
-	developer "Namco"
-	rom ( name panicprk.zip size 48146357 crc f02abe69 md5 c1d75b3aacad07aa24ca73735c85ce7d sha1 f458b143c7c44f9656983d17604d156c2bb65a5a )
-)
-
-game (
-	name "Panic Road"
-	year "1986"
-	developer "Taito"
-	rom ( name panicr.zip size 174680 crc d0143677 md5 ea9209dacdac7f5481aadbb8024d1b38 sha1 2da479b496406e9a3f0e80b80309412e2439607b )
-)
-
-game (
 	name "Panic Street (Japan)"
 	year "1999"
 	developer "Kaneko"
 	rom ( name panicstr.zip size 8649424 crc 2f00742f md5 946dec33ad264802e9d36ded7ff07d64 sha1 ca860648a89cb25f006406fc4f943b5ed963f4fc )
-)
-
-game (
-	name "Panther"
-	year "1981"
-	developer "Irem"
-	rom ( name panther.zip size 14081 crc f4a931a8 md5 6a43b2ee4529db9cda749cbb2440eb97 sha1 b42a52ce4a1309aa8970e7b3c6d61cc83618fbf5 )
 )
 
 game (
@@ -36128,20 +26568,6 @@ game (
 	name "Paradise Deluxe"
 	developer "Yun Sung"
 	rom ( name paradlx.zip size 1485725 crc 707a3921 md5 c36a11b29fd780a3bd1fbf652b6f85de sha1 65d465fb3dfd784ac8a91c1029c624e4deaa8def )
-)
-
-game (
-	name "Paranoia"
-	year "1990"
-	developer "Naxat Soft"
-	rom ( name paranoia.zip size 169106 crc 2f687016 md5 064dc2d30d7d1c4270427e8af44f0144 sha1 ea83d75257220d1f9f9774683d221fe3f5bbd2ea )
-)
-
-game (
-	name "Parent Jack"
-	year "1989"
-	developer "Taito"
-	rom ( name parentj.zip size 288112 crc 863d6850 md5 ec0bd922ed1294222e6686056c6a66cf sha1 42716ae305933a821e0479ce884014c6a01dc5ce )
 )
 
 game (
@@ -36208,13 +26634,6 @@ game (
 )
 
 game (
-	name "Passing Shot (4 Players) (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name passht4b.zip size 205754 crc e0a5084f md5 1c515afd654325a38469ddfcff39db17 sha1 207b08de841c06ff860f00e83dad2e3f07230604 )
-)
-
-game (
 	name "Passing Shot (World, 2 Players, FD1094 317-0080)"
 	year "1988"
 	developer "Sega"
@@ -36233,13 +26652,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name passshta.zip size 83928 crc a7ee16c3 md5 39c4bacfda1a967d0fc6d38fd7c49460 sha1 7fb3a9ef045245875a4958768af655c26e1c1624 )
-)
-
-game (
-	name "Passing Shot (2 Players) (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name passshtb.zip size 60990 crc 3a776d29 md5 e94c3afe46d90bbfa89905a5e37edd22 sha1 30445e3cd333a30e14d097daf5c0e460e34fda12 )
 )
 
 game (
@@ -36320,24 +26732,10 @@ game (
 )
 
 game (
-	name "Powerful Pro Baseball EX (GX802 VER. JAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name pbballex.zip size 179 crc 933b6fab md5 475cdbd7c07599f57ea185e4028a46a4 sha1 56dc6285077011c9c8b3d2dacc44ab7dff9cb813 )
-)
-
-game (
 	name "Pinball Champ '95 (bootleg?)"
 	year "1995"
 	developer "bootleg? (Veltmeijer Automaten)"
 	rom ( name pbchmp95.zip size 99312 crc 2089687f md5 751e0a34c55be593238c590a40ad36dd sha1 ec424941de9b1dfca8e206afb4ca5859663ff348 )
-)
-
-game (
-	name "Prebillian"
-	year "1986"
-	developer "Taito"
-	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -36429,27 +26827,6 @@ game (
 	year "1996"
 	developer "Taito Corporation"
 	rom ( name pbobble3u.zip size 247621 crc d387e6c4 md5 5b7bbf38d0f2eb04cfc49f4872c97457 sha1 e43ccc5df5fe315b5a3e36578e02b2efc04dd750 )
-)
-
-game (
-	name "Puzzle Bobble 4 (Ver 2.04O 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4.zip size 6978003 crc 67476786 md5 1fb77610e9f75281822a5009e8805167 sha1 5b5c095d914a2301856b058745c21edea7ba6d52 )
-)
-
-game (
-	name "Puzzle Bobble 4 (Ver 2.04J 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4j.zip size 190293 crc 13b223e5 md5 f4cc1ba850b70459b3fc0ac05940c898 sha1 6fce23aa27c75a448682cfa62650c6dbf7d21119 )
-)
-
-game (
-	name "Puzzle Bobble 4 (Ver 2.04A 1997/12/19)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name pbobble4u.zip size 190294 crc e14fb4c6 md5 360534f63cc3ae248d39b3fd976e31dd sha1 6f88df48a9b3c165c1f5c3754b1d961c608e0c10 )
 )
 
 game (
@@ -36880,55 +27257,6 @@ game (
 )
 
 game (
-	name "Print Club 2 (U 970921 V1.000)"
-	year "1997"
-	developer "Atlus"
-	rom ( name pclub2.zip size 4650907 crc bd4003c0 md5 27412f646b519ffb61af65d4e154ba6b sha1 009bc0905aed4bc597341e62668833b45044a2e5 )
-)
-
-game (
-	name "Print Club 2 Vol. 3 (U 990310 V1.000)"
-	year "1999"
-	developer "Atlus"
-	rom ( name pclub2v3.zip size 4802363 crc 2aeb1b34 md5 5299e61c9af7532e36ef42e5184b6d7a sha1 03586cbe6ea0648eab33489e465876b1368169be )
-)
-
-game (
-	name "Print Club (Japan Vol.1)"
-	year "1995"
-	developer "Atlus"
-	rom ( name pclubj.zip size 521141 crc a40ded29 md5 4944980e7a5979fc4d72cced715d7da2 sha1 8eb37b0df8ec564bb446422ebbdb2d537c62fc1a )
-)
-
-game (
-	name "Print Club (Japan Vol.2)"
-	year "1995"
-	developer "Atlus"
-	rom ( name pclubjv2.zip size 317673 crc 36da1c6f md5 b46dd04e5b367ddea3ceb32464f71aba sha1 1d8c7544c434f728249bfc6279493a14ec236a73 )
-)
-
-game (
-	name "Print Club (Japan Vol.4)"
-	year "1996"
-	developer "Atlus"
-	rom ( name pclubjv4.zip size 261996 crc 89c7c049 md5 9c75ba8d0e1d8280e3fe3abbbbd2e0a6 sha1 3d5a67a86c0adbd3993855d48cbd11fe6c588e46 )
-)
-
-game (
-	name "Print Club (Japan Vol.5)"
-	year "1996"
-	developer "Atlus"
-	rom ( name pclubjv5.zip size 300496 crc 56c812f4 md5 a8aef4e4784edfe7055af5178ec36872 sha1 3148491f2f8f9ea7bd709edb778869725374cb5e )
-)
-
-game (
-	name "Print Club Pokemon B (U 991126 V1.000)"
-	year "1999"
-	developer "Atlus"
-	rom ( name pclubpok.zip size 6203132 crc 3ee9e36b md5 88e8f552d90a6660d5320313e6046c96 sha1 180966410aa05ddda70351c87e3af04f4f7036af )
-)
-
-game (
 	name "Puzzle Club (Yun Sung, set 1)"
 	year "2000"
 	developer "Yun Sung"
@@ -36940,13 +27268,6 @@ game (
 	year "2000"
 	developer "Yun Sung"
 	rom ( name pclubysa.zip size 389307 crc e52411bd md5 71573dd4c2e61f7fa434ba888f928c6d sha1 5acead14749dd3dcee3f82638140072c03acc6df )
-)
-
-game (
-	name "Percussion Freaks 3rd Mix (G*A23 VER. KAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name pcnfrk3m.zip size 546 crc 3b7b646b md5 524e550645b9171d160d9ea3276644c7 sha1 6b423ea0b927dacc67f810a915c3891599811b4c )
 )
 
 game (
@@ -36982,13 +27303,6 @@ game (
 	year "1994"
 	developer "IGT - International Gaming Technology"
 	rom ( name pebe0014.zip size 43773 crc c1b79a98 md5 d76401310f850e1a327570d1cbf969f2 sha1 79d6b0f0d8678134cd56ddde8f1c5bb084948097 )
-)
-
-game (
-	name "Peek-a-Boo!"
-	year "1993"
-	developer "Jaleco"
-	rom ( name peekaboo.zip size 1267072 crc 7f4335c8 md5 dd6c7746b1ab9d149158f8109d3c7e1d sha1 76dc3f1edad3630d9c75921a9efe94b2598436fc )
 )
 
 game (
@@ -37237,27 +27551,6 @@ game (
 )
 
 game (
-	name "Pest Place"
-	year "1983"
-	developer "bootleg"
-	rom ( name pestplce.zip size 33952 crc ad93042b md5 708987d7fe42287957ada94ce5cee151 sha1 02599e81c870b111a23ca75c77599a9ffc6b54f8 )
-)
-
-game (
-	name "Peter Pack-Rat"
-	year "1984"
-	developer "Atari Games"
-	rom ( name peterpak.zip size 206852 crc a3037cff md5 25de0233e1dbca7f00b2dd25d130606b sha1 ae68432abb968941b79479f13da5186e3ca67385 )
-)
-
-game (
-	name "Pettan Pyuu (Japan)"
-	year "1984"
-	developer "Sun Electronics"
-	rom ( name pettanp.zip size 41557 crc 108f1d74 md5 9cbfe52d40731bc2b7035b8924c9116a sha1 5d1442139e5ecbbc65e7dd5cf40ae2203cd352c0 )
-)
-
-game (
 	name "Player's Edge Plus (X002069P) Double Double Bonus Poker"
 	year "1995"
 	developer "IGT - International Gaming Technology"
@@ -37304,13 +27597,6 @@ game (
 	year "1997"
 	developer "IGT - International Gaming Technology"
 	rom ( name pexs0006.zip size 79388 crc 48194995 md5 13d3e7e76ffe97116744997f84129009 sha1 b59730eeb532649464dd51c86dabcd314e68eabc )
-)
-
-game (
-	name "Psychic Force 2012"
-	year "1997"
-	developer "Taito"
-	rom ( name pf2012.zip size 37901242 crc ac2ddeb4 md5 ba5991d93ab66dcb94c87ceb6d6b7b67 sha1 fac634c2c7bf75548aa86ef0263dd95c95c40dcf )
 )
 
 game (
@@ -37377,23 +27663,10 @@ game (
 )
 
 game (
-	name "Planet Harriers"
-	year "2001"
-	developer "Sega"
-	rom ( name pharrier.zip size 146488863 crc 01bc728c md5 28b4ec7917674e5bcfd9e0ef18f297f8 sha1 c19341f773d6266df7e77986dbe8e4143ddc58f0 )
-)
-
-game (
 	name "Phelios (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name phelios.zip size 1519633 crc fef8dc2b md5 07392e8573a863bd1110eadff321bff8 sha1 beb9c48c9bf57011ef65bdfd9c2452e01e01607d )
-)
-
-game (
-	name "Klad / Labyrinth (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phklad.zip size 9882 crc 38bbc068 md5 97153cfcbb5b10e4e0f4645590dcb993 sha1 ff6b6604cd22c65f3684bc3284014441616b5c3e )
 )
 
 game (
@@ -37460,12 +27733,6 @@ game (
 )
 
 game (
-	name "PhotoPlay"
-	developer "Funworld"
-	rom ( name photoply.zip size 112001 crc cf5dc568 md5 2056c3ec55f155c4ac672087af25e473 sha1 14306391fd905c6eff398ba8b4240d0fdcfc96e5 )
-)
-
-game (
 	name "Photo Y2K (ver. 105)"
 	year "1999"
 	developer "IGS"
@@ -37494,12 +27761,6 @@ game (
 )
 
 game (
-	name "Python (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phpython.zip size 4735 crc 310b8131 md5 0b14748a725264eeb897216e760da88e sha1 7d5562ea7f49c36b6245a8fb56a67cfcbb4963e1 )
-)
-
-game (
 	name "Phraze Craze (set 1)"
 	year "1986"
 	developer "Merit"
@@ -37525,19 +27786,6 @@ game (
 	year "1986"
 	developer "Merit"
 	rom ( name phrcrazec.zip size 251509 crc f58a959b md5 e878af9cdb65c155dcda6f6cdc70e049 sha1 a01734521f3f333d211e333f0affdb9520db31ea )
-)
-
-game (
-	name "Phraze Craze (Sex Kit, Vertical)"
-	year "1986"
-	developer "Merit"
-	rom ( name phrcrazev.zip size 77644 crc 3bd8b6be md5 ae3a1de8da35c822b78cad6ff7092598 sha1 62d0bed03106fc168f2f2892b654f8e441c21258 )
-)
-
-game (
-	name "Tetris (Photon System)"
-	developer "&lt;unknown&gt;"
-	rom ( name phtetris.zip size 9369 crc 3e432f38 md5 b1500f93765e3ac1838cac3501b1dd4b sha1 c21681de17086c9f1ede9fcf8c55e41ad13ce266 )
 )
 
 game (
@@ -37611,20 +27859,6 @@ game (
 )
 
 game (
-	name "Pig Newton (version C)"
-	year "1983"
-	developer "Sega"
-	rom ( name pignewt.zip size 41651 crc db3fda51 md5 aa6e091315be92442c51c85f5fb5e5d8 sha1 3906317a8247a719a399af266abf35d6797b5dd9 )
-)
-
-game (
-	name "Pig Newton (version A)"
-	year "1983"
-	developer "Sega"
-	rom ( name pignewta.zip size 22721 crc 2661d4d6 md5 fe371e4556e23bef94398d10e3a9f985 sha1 14e5a12a9ca9b65d934a7b575720ed20de3093c2 )
-)
-
-game (
 	name "Pig Out: Dine Like a Swine! (set 1)"
 	year "1990"
 	developer "Leland Corp."
@@ -37674,13 +27908,6 @@ game (
 )
 
 game (
-	name "Pinkiri 8"
-	year "1994"
-	developer "Alta"
-	rom ( name pinkiri8.zip size 111761 crc 843e1105 md5 f4e04261ff981993e2baa3e330e9605d sha1 9945bad33f1f9af92056d6ad5200b8148bd6ea0f )
-)
-
-game (
 	name "Pipe Dream (World)"
 	year "1990"
 	developer "Video System Co."
@@ -37699,13 +27926,6 @@ game (
 	year "1990"
 	developer "Video System Co."
 	rom ( name pipedrmu.zip size 35920 crc d5756134 md5 e7ea29d82e261f07024df0cd03ff5037 sha1 94eda443b5808a2e5a18e56e3195d4e9840df71d )
-)
-
-game (
-	name "Pipeline"
-	year "1990"
-	developer "Daehyun Electronics"
-	rom ( name pipeline.zip size 346843 crc 5d5b1f6e md5 6696b6784acbea9f661cbb21efbbff20 sha1 5129abe5367a210b110a2b82fa26729eea234a6a )
 )
 
 game (
@@ -37961,13 +28181,6 @@ game (
 )
 
 game (
-	name "Pirati"
-	year "2001"
-	developer "Cin"
-	rom ( name pirati.zip size 201744 crc 3a2e3ea2 md5 8aceb390b0506166f94be00c4e625076 sha1 f9fdf1fede435d4b0a56c040550b35538cc5626e )
-)
-
-game (
 	name "Pirate Pete"
 	year "1982"
 	developer "Taito America Corporation"
@@ -38176,13 +28389,6 @@ game (
 )
 
 game (
-	name "Moero Justice Gakuen (JPN) / Project Justice (USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Capcom"
-	rom ( name pjustic.zip size 122945688 crc b02b4341 md5 f41e36c097064d39592bb481bcf0b8fa sha1 5784383e7b1b8fbae9d7abe71a0ea320f6218ff1 )
-)
-
-game (
 	name "Pachinko Gindama Shoubu (Japan)"
 	year "1998"
 	developer "Nakanihon / Dynax"
@@ -38204,13 +28410,6 @@ game (
 )
 
 game (
-	name "Poker Ladies (Censored bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name pkladiesbl.zip size 759586 crc 8dab0e86 md5 844e6db4f1f169e5462036c863564044 sha1 bbcd872b98665f44ea292cb005c231ae9bd068c3 )
-)
-
-game (
 	name "Poker Ladies (Leprechaun ver. 510)"
 	year "1989"
 	developer "Leprechaun"
@@ -38229,18 +28428,6 @@ game (
 	year "1990"
 	developer "bootleg"
 	rom ( name pkrdewin.zip size 16754 crc 328eb985 md5 f80f669d06c28a11124c215f74d41559 sha1 020442ba71c056c713aee9b3a50cf873b4f6e13c )
-)
-
-game (
-	name "Poker Master (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name pkrmast.zip size 84421 crc fbc5460c md5 5ded4660410c296d00e775ea0f78d7bc sha1 db225fb31615b637850230683d0c4f106e2f8101 )
-)
-
-game (
-	name "Poker Master (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name pkrmasta.zip size 80685 crc c043d03c md5 5877681fe60fe0b6943e9d7fc0d5e866 sha1 6ea1a34c3d41c76a4e5be0b598403ec7698897c2 )
 )
 
 game (
@@ -38397,75 +28584,6 @@ game (
 )
 
 game (
-	name "Pilot Kids (Model 2B, Revision A)"
-	year "1998"
-	developer "Psikyo"
-	rom ( name pltkids.zip size 37303998 crc e7e64e60 md5 e90ebe437fb6f3ecb08e556f8b3254a4 sha1 e1f78c05a30bd012349be8f6aba243dd36c919cd )
-)
-
-game (
-	name "Pilot Kids (Model 2A)"
-	year "1998"
-	developer "Psikyo"
-	rom ( name pltkidsa.zip size 726189 crc bdf076ef md5 a5286b8c49d9845ac93213fc94c536a1 sha1 f2b38b9e0159db959d42fdb9f01af9b7aeb3547a )
-)
-
-game (
-	name "Plump Pop (Japan)"
-	year "1987"
-	developer "Taito Corporation"
-	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
-)
-
-game (
-	name "Plus Alpha"
-	year "1989"
-	developer "Jaleco"
-	rom ( name plusalph.zip size 1014633 crc a37f8119 md5 7f936d4d34914b2b9b0577b5e1828174 sha1 2a5a7ebdf17935e70156be788590bdd64987fa94 )
-)
-
-game (
-	name "Polygonet Commanders (ver UAA)"
-	year "1993"
-	developer "Konami"
-	rom ( name plygonet.zip size 2307132 crc f5a006fe md5 65456d7fc687448d3643985a503fe9b7 sha1 b624e6deae05ff4b31abacc1774c70f782dfbc93 )
-)
-
-game (
-	name "PMA Poker"
-	year "1983"
-	developer "PMA"
-	rom ( name pma.zip size 5570 crc b779749d md5 a60521fdd8c35aeb6967a3c2d32c3052 sha1 3fb8c3c66240662893e8fd22a2cfa678631574c3 )
-)
-
-game (
-	name "PlayMan Poker (German)"
-	year "1981"
-	developer "PlayMan"
-	rom ( name pmpoker.zip size 12852 crc 243392db md5 23ec82bb1473133a3449d44509b8cd79 sha1 c779d609e229cb37cfb3fb5e48ec23532918fadd )
-)
-
-game (
-	name "Croupier (Playmark Roulette)"
-	year "1997"
-	developer "Playmark"
-	rom ( name pmroulet.zip size 942555 crc 947250c3 md5 01a1c7bdeee878b3a02be58d90519afa sha1 e804e65d5057bbb75516bea87b8b08d1d7f703c8 )
-)
-
-game (
-	name "Pnickies (Japan 940608)"
-	year "1994"
-	developer "Capcom, licensed by Compile)"
-	rom ( name pnickj.zip size 768482 crc 051b5dc5 md5 0193b457c1f8ef81575570fdf644fe2a sha1 4794c11915dc391005a26136e4cd34988e52fa23 )
-)
-
-game (
-	name "Paint _ Puzzle"
-	developer "Century?"
-	rom ( name pntnpuzl.zip size 60000 crc b37ced17 md5 5133ada5004367a0d396b76dcb0d5fe4 sha1 f94a4f8057610e7b3037387aef762c3747a2d11b )
-)
-
-game (
 	name "Pochi and Nyaa"
 	year "2003"
 	developer "Aiky / Taito"
@@ -38480,31 +28598,10 @@ game (
 )
 
 game (
-	name "Star Wars Pod Racer"
-	year "2001"
-	developer "Sega"
-	rom ( name podrace.zip size 4272990 crc ab86a36e md5 02cf97a61c641939ed6558a681d794c0 sha1 178449a67282520461ceebbc343215202738b4b8 )
-)
-
-game (
 	name "Poitto!"
 	year "1993"
 	developer "Metro / Able Corp."
 	rom ( name poitto.zip size 1091689 crc e5f70678 md5 a6d99aee06cdab1c459662312e423a8b sha1 80ff027ac8d235aff1c8f44bebd3a5f279bd7794 )
-)
-
-game (
-	name "Poizone"
-	year "1991"
-	developer "Eterna"
-	rom ( name poizone.zip size 485365 crc 5e906fe8 md5 1c602955ebe2aaeedb3aba21da561c24 sha1 4a6e66735f448cbf243b7e662d66aa8cc9ae197e )
-)
-
-game (
-	name "Poke Champ"
-	year "1995"
-	developer "DGRM"
-	rom ( name pokechmp.zip size 1173371 crc 97cc98b1 md5 45a3ae675377809923d143972d322566 sha1 bf5e55c64d1135dbadf70f14751b14c70cd9a62b )
 )
 
 game (
@@ -38515,24 +28612,10 @@ game (
 )
 
 game (
-	name "Poker Monarch (v2.50)"
-	year "1995"
-	developer "Extrema Systems International Ltd."
-	rom ( name poker72.zip size 367035 crc 9a8b5c6f md5 42bc13d8148c04a1050d28bf0dc8a817 sha1 edb7509c353a4d477484674206d6afba43cf0cfc )
-)
-
-game (
 	name "Poker 91"
 	year "1991"
 	developer "&lt;unknown&gt;"
 	rom ( name poker91.zip size 16139 crc 1fc3a149 md5 585cc3a12d123f477cc4c7eb6cff166e sha1 db2a34117cb6f33265218e6905bddc0506458189 )
-)
-
-game (
-	name "Poker Roulette (Version 8.22)"
-	year "1990"
-	developer "Coinmaster"
-	rom ( name pokeroul.zip size 27723 crc 79a06199 md5 7562c9cbd2d5f3c76ee9c5f97b526b34 sha1 6a9ede3e12081b0d328d4d2fe51702757d6559a0 )
 )
 
 game (
@@ -38585,13 +28668,6 @@ game (
 )
 
 game (
-	name "Pole Position (Atari version 1)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name polepos1.zip size 45746 crc bb978c64 md5 eb0b701c895378b259b58ad3c709fee5 sha1 01bbd6c8cb1865cbd3ef187532567dd85380ca98 )
-)
-
-game (
 	name "Pole Position II"
 	year "1983"
 	developer "Namco"
@@ -38599,31 +28675,10 @@ game (
 )
 
 game (
-	name "Pole Position II (Atari)"
-	year "1983"
-	developer "Namco (Atari license)"
-	rom ( name polepos2a.zip size 51441 crc 5f8aafbe md5 23d58a0a42f14f7039a27ed6f01b6d67 sha1 d670c17bc01215d22d36ccf4d7ce3d2cfbb95d5c )
-)
-
-game (
 	name "Pole Position II (bootleg)"
 	year "1983"
 	developer "bootleg"
 	rom ( name polepos2b.zip size 51847 crc 405b4516 md5 bdee38e743d85bb76e0fe194e91b0dcd sha1 d419250bcf8999f4d4f3ad35e5fe8fa769c39198 )
-)
-
-game (
-	name "Gran Premio F1 (Italian bootleg of Pole Position II)"
-	year "1984"
-	developer "bootleg"
-	rom ( name polepos2bi.zip size 55055 crc bf144686 md5 cc9e55c7ac3fa0d1db4ded1bd7671d44 sha1 73d3583e6471e1ac8341da459d02695240a6c6f0 )
-)
-
-game (
-	name "Pole Position (Atari version 2)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name poleposa.zip size 45115 crc e40470d9 md5 b00adc65636ed90d3b92d74f48d501ab sha1 6d5f63a7c2ffad8cc9fe02e3a5a7663df50229de )
 )
 
 game (
@@ -38683,24 +28738,10 @@ game (
 )
 
 game (
-	name "Poly-Net Warriors (ver JAA)"
-	year "1993"
-	developer "Konami"
-	rom ( name polynetw.zip size 4042874 crc e004ac28 md5 baf38c65a205ba8b6978cbd5f7159461 sha1 16dcae2bc3428a120bdb50c2061ac31a123a085a )
-)
-
-game (
 	name "Poly-Play"
 	year "1985"
 	developer "VEB Polytechnik Karl-Marx-Stadt"
 	rom ( name polyplay.zip size 27147 crc c494b703 md5 6ad41ed4ecc9f27c29decd08d733a75e sha1 01d8cf48c2738be816ef1cf82f94267c4882d646 )
-)
-
-game (
-	name "Tobe! Polystars (ver JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name polystar.zip size 709581 crc 01a16230 md5 e69f179831d4f660327c06a75e655b00 sha1 28cab463f7de77891a324aa313c77a2286648e7f )
 )
 
 game (
@@ -38739,45 +28780,10 @@ game (
 )
 
 game (
-	name "Pontoon"
-	year "1989"
-	developer "Sega"
-	rom ( name pontoon.zip size 143701 crc efa80f97 md5 d60067d43932c2237c1f91e154f6b2b9 sha1 ad358f9c9b014c262cf0aea33efc12d02010d865 )
-)
-
-game (
 	name "Pontoon (Tehkan)"
 	year "1985"
 	developer "Tehkan"
 	rom ( name ponttehk.zip size 21561 crc 834670ce md5 79b9c5d39cd5797c9dfd1e0674bba796 sha1 724110eca09ef9aa4729e9ee03ba257cde06593c )
-)
-
-game (
-	name "Pool 10 (Italian, set 1)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10.zip size 20398 crc 84f48fe3 md5 ce613ad55bd40c2d8ba48fdb52ace5e4 sha1 8318545929fad958ba17ef9b9a40f66bb2cc0353 )
-)
-
-game (
-	name "Pool 10 (Italian, set 2)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10b.zip size 38134 crc d1b794f0 md5 ebb855c65e75f6fba11d85f1e2d67bac sha1 ea121adb2d469e144f329ca789a4b0a3774f2be2 )
-)
-
-game (
-	name "Pool 10 (Italian, set 3)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name pool10c.zip size 14027 crc 03ebd786 md5 82ab6ce7a6eef0cea3d0e4f8ad23ce5d sha1 ed6918abcbc57180b60268de60a08603a7185da8 )
-)
-
-game (
-	name "Pool 10 (Italian, set 4)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name pool10d.zip size 27760 crc ca5722d5 md5 0858943d8d831e9b14d03f1a6847b0b6 sha1 29d9d986cb8c1a521b38bc82c22ddbb1e71e2f47 )
 )
 
 game (
@@ -38900,41 +28906,6 @@ game (
 )
 
 game (
-	name "Pop n' Music 5"
-	year "2000"
-	developer "Konami"
-	rom ( name popn5.zip size 77293 crc aeb818fc md5 23abf7f31da8c3c49e41b764e187bf43 sha1 dfca6654203c72d64ad470fd4b2200a6c7ab9730 )
-)
-
-game (
-	name "Pop n' Music 7"
-	year "2001"
-	developer "Konami"
-	rom ( name popn7.zip size 77480 crc dbce2321 md5 aac067dbd72ec80cf7204093a4af21d2 sha1 a8b40435b2776d39ee2929cfe6280427a82468a8 )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07O 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpop.zip size 5652566 crc a8bb9331 md5 bdb8ef0c629e68fed1b41b2f4c9ae7c5 sha1 68b3d7dfb6d2b574edf5302e1312047cde02ce77 )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07J 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpopj.zip size 153007 crc 1e31cce8 md5 06d170adc945c58ee578ea835ca48f90 sha1 dc0170c9de82642b3399476494bb7fb38fbac70e )
-)
-
-game (
-	name "Pop'n Pop (Ver 2.07A 1998/02/09)"
-	year "1997"
-	developer "Taito Corporation"
-	rom ( name popnpopu.zip size 153007 crc 10ce197f md5 537d0103735d8acfd2604752dc4194d3 sha1 227ee2f1b8252c6bbb0a4f81e10e307101c2f7b0 )
-)
-
-game (
 	name "Popper"
 	year "1983"
 	developer "Omori Electric Co., Ltd."
@@ -38956,44 +28927,10 @@ game (
 )
 
 game (
-	name "Port Man (bootleg on Moon Cresta hardware)"
-	year "1982"
-	developer "bootleg"
-	rom ( name porter.zip size 17109 crc 084fc4ae md5 2e31986952ef71edf0b4a7ec82b512f7 sha1 cae0028ff3da248ad418a774774e035af85c8518 )
-)
-
-game (
 	name "Port Man"
 	year "1982"
 	developer "Taito Corporation (Nova Games Ltd. license)"
 	rom ( name portman.zip size 9356 crc 533f1dde md5 445361fbb4316de9ed6fddc165d8af79 sha1 1170f8dd375c704a223960ed5118cc5b83fe899c )
-)
-
-game (
-	name "Portraits (set 1)"
-	year "1983"
-	developer "Olympia"
-	rom ( name portrait.zip size 55822 crc 2c226293 md5 5e3fd30251ecdb80b1b0415b7f101f05 sha1 08f5eb76fb5aa1f565009294478de8af49ab271c )
-)
-
-game (
-	name "Portraits (set 2)"
-	year "1983"
-	developer "Olympia"
-	rom ( name portraita.zip size 16144 crc ec55432b md5 debd5e4de050f2cc1a880bd31811ab4e sha1 86cdd70ce4f780e448c4418a18e123f2790c8dc1 )
-)
-
-game (
-	name "Pot Game (Italian)"
-	year "1996"
-	developer "C.M.C."
-	rom ( name potgame.zip size 18056 crc 87924391 md5 c08ca9b28c3482282bb1000a8098453a sha1 5b010fc3ae5d2207bce0a0473fc8c679de403a96 )
-)
-
-game (
-	name "Jack Potten's Poker (set 2)"
-	developer "bootleg"
-	rom ( name potnpkra.zip size 10389 crc bdf2e846 md5 a5e51be26d8eb70e221fe287f0395048 sha1 6e46e96c61b54ee36b14d13b1a06a0f5838e95b0 )
 )
 
 game (
@@ -39012,12 +28949,6 @@ game (
 	name "Jack Potten's Poker (set 5)"
 	developer "bootleg"
 	rom ( name potnpkrd.zip size 8016 crc 3e0dab10 md5 850a088e855bc4d251a187c23c6b6a69 sha1 a4d9c0b5eadbbbfc13a9037836bdef3776d00482 )
-)
-
-game (
-	name "Jack Potten's Poker (set 6)"
-	developer "bootleg"
-	rom ( name potnpkre.zip size 5881 crc 777523a1 md5 b87b6fd6728144de56070f3913e1a869 sha1 c8141f663d5174e7cbbe654078c4d5dce0881069 )
 )
 
 game (
@@ -39066,13 +28997,6 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name pow.zip size 806437 crc f6157c0e md5 5f70874fb2f3708253d46eb4331d0edb sha1 e92d354061cce1ac548d402f6cebde20841d8712 )
-)
-
-game (
-	name "Power Balls"
-	year "1994"
-	developer "Playmark"
-	rom ( name powerbal.zip size 1561777 crc f12ad31f md5 0b47ed0acf97cdf809bb74ac2c209f12 sha1 24a4710947ebd0f923e3725292c6195c157de633 )
 )
 
 game (
@@ -39139,13 +29063,6 @@ game (
 )
 
 game (
-	name "Pang Pang Car"
-	year "1999"
-	developer "Icarus"
-	rom ( name ppcar.zip size 4620728 crc 0ac2e1ea md5 d677bf19491b14db1c1ab66b10d7d1e7 sha1 12cb6224b316f4c73c757edf0e1d9b54744c6611 )
-)
-
-game (
 	name "Pasha Pasha Champ Mini Game Festival (Korea)"
 	year "1997"
 	developer "Dongsung"
@@ -39153,38 +29070,10 @@ game (
 )
 
 game (
-	name "ParaParaDancing"
-	year "2000"
-	developer "Konami"
-	rom ( name ppd.zip size 45738 crc 2a5cb780 md5 7db360e84cdfae2d7b35f0dec92d3c5d sha1 49401c056e8744b26ef5271803d1fa9a0462ea19 )
-)
-
-game (
-	name "Ping-Pong King"
-	year "1985"
-	developer "Taito America Corporation"
-	rom ( name ppking.zip size 76329 crc 4e4fedc0 md5 8331c11e78040962881f64e073059e2f sha1 e315a3a3525e063e36bb5cbdefaef867d4890d29 )
-)
-
-game (
 	name "Ping Pong Masters '93"
 	year "1993"
 	developer "Electronic Devices S.R.L."
 	rom ( name ppmast93.zip size 118481 crc 04d7409f md5 b55b8b1175cde60ee51234d200dce4eb sha1 86d9bcd3fc74c8d45507421da09460f7dd0da2f7 )
-)
-
-game (
-	name "ParaParaParadise"
-	year "2000"
-	developer "Konami"
-	rom ( name ppp.zip size 45737 crc 7cdfee29 md5 575700551afee00f6695d7fe8ff3ab91 sha1 42264ac7aa99d56187d3ff8d6741ddb354d4e2d3 )
-)
-
-game (
-	name "ParaParaParadise v1.1"
-	year "2000"
-	developer "Konami"
-	rom ( name ppp11.zip size 45737 crc 7cdfee29 md5 575700551afee00f6695d7fe8ff3ab91 sha1 42264ac7aa99d56187d3ff8d6741ddb354d4e2d3 )
 )
 
 game (
@@ -39227,33 +29116,6 @@ game (
 	year "1996"
 	developer "Namco"
 	rom ( name primglex.zip size 9906991 crc 6ce3fcaa md5 6785c37e8fe3e0a7b8d2697b8cda7a5c sha1 4f51683dbdd174d2a4b6e2c987407043ee12f899 )
-)
-
-game (
-	name "Primal Rage 2 (Ver 0.36a)"
-	year "1996"
-	developer "Atari"
-	rom ( name primrag2.zip size 576120 crc 9427ea35 md5 540617cd1614ec80e0af4383c7f9e2aa sha1 7bdedd84553cbd594c3f4671b9e468d0a37b045b )
-)
-
-game (
-	name "Primal Rage (version 2.3)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name primrage.zip size 24306046 crc 2dbfa62b md5 9df56777c1a4ce242d3f50253a07fa52 sha1 77fa4b3de41d055bc4d93f40f0ce53cc3c64363a )
-)
-
-game (
-	name "Primal Rage (version 2.0)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name primrage20.zip size 769498 crc 812353c8 md5 44d16527714bd903846b9ea33cb11cac sha1 713e29fb277725c165c1e0d15f2a1113aac75eb1 )
-)
-
-game (
-	name "Prize Space Invaders (20&quot; v1.1)"
-	developer "BwB"
-	rom ( name prizeinv.zip size 90054 crc 4c2aed12 md5 458dbdac0c1a6100ce20b82b170b56aa sha1 ffc23e6a38bcbffe0ace8690f5f403a48fef5ef0 )
 )
 
 game (
@@ -39324,13 +29186,6 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name progolf.zip size 18460 crc 0f82452f md5 be42427222ed63fbc1791b88a041ea7c sha1 99c2a19d85e5b70a796d90e4bb580f956b853dd4 )
-)
-
-game (
-	name "18 Holes Pro Golf (set 2)"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name progolfa.zip size 11824 crc d5eed0cf md5 72ce3515310b363cdb4d95bf3ecde455 sha1 0e35addacfb7e90b643a6ed3d7896dadaf081d62 )
 )
 
 game (
@@ -39425,13 +29280,6 @@ game (
 )
 
 game (
-	name "P's Attack"
-	year "2004"
-	developer "Uniana"
-	rom ( name psattack.zip size 423836 crc 54317ed2 md5 bb488ccf4c57e426f51a72eeac0e2003 sha1 c80a267c0a710ffcb6452e928152fbe169a2c423 )
-)
-
-game (
 	name "Perfect Soldiers (Japan)"
 	year "1993"
 	developer "Irem"
@@ -39474,37 +29322,10 @@ game (
 )
 
 game (
-	name "New Super 3D Golf Simulation - Waialae No Kiseki / Super Mahjong 2 (Super Famicom Box)"
-	developer "T&amp;E Soft / I&apos;Max"
-	rom ( name pss62.zip size 679542 crc 18dec073 md5 7d212a0f172c4aca00f30b5eed0da823 sha1 be57ca77b30ae5c025da51e20335a8b41a5f394d )
-)
-
-game (
 	name "Mahjong Panic Stadium (Japan)"
 	year "1990"
 	developer "Nichibutsu"
 	rom ( name pstadium.zip size 418203 crc d56279b6 md5 741835ffd943993da5208c53da01a204 sha1 4e3ff2f9a8f50b3fe6e8b92f9f72f6e689611ef4 )
-)
-
-game (
-	name "Power Stone (JPN, USA, EUR, ASI, AUS)"
-	year "1999"
-	developer "Capcom"
-	rom ( name pstone.zip size 36436166 crc bcdf2426 md5 63e026bf487ee9b0bbc8295b9ed62126 sha1 aa3793f0505257107d4bd32bfbd829049b1e38f5 )
-)
-
-game (
-	name "Power Stone 2 (JPN, USA, EUR, ASI, AUS)"
-	year "2000"
-	developer "Capcom"
-	rom ( name pstone2.zip size 50086377 crc 42ec3b49 md5 80f900261580b50eee83bb8dc11a2e87 sha1 645f4b235ca375dd7fe9d1f17cfeed2aa9b1b6d6 )
-)
-
-game (
-	name "Power Surge"
-	year "1988"
-	developer "&lt;unknown&gt;"
-	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
 )
 
 game (
@@ -39557,13 +29378,6 @@ game (
 )
 
 game (
-	name "Psyvariar 2 - The Will To Fabricate (GDL-0024)"
-	year "2003"
-	developer "G-Rev"
-	rom ( name psyvar2.zip size 1197 crc 78c151c7 md5 46425f48b615a04728683e186d914d62 sha1 af7d50c9191cc5df308f35c84a43a82c7118c0d5 )
-)
-
-game (
 	name "Point Blank (World, GN2 Rev B)"
 	year "1994"
 	developer "Namco"
@@ -39582,13 +29396,6 @@ game (
 	year "1999"
 	developer "Namco"
 	rom ( name ptblnk2a.zip size 1000786 crc f07668e9 md5 e75adf78a730774c0a2b4985ba46caa6 sha1 f39d21e814ac93326afea217c847117f005d50ef )
-)
-
-game (
-	name "PT Reach Mahjong (Japan)"
-	year "1979"
-	developer "Irem"
-	rom ( name ptrmj.zip size 8496 crc 18900a9d md5 af127bd1a65d157998d797c54f7f4ce7 sha1 c80144f73e6d2ad8bea2987cf5fd9ddbd1d2aa69 )
 )
 
 game (
@@ -39648,12 +29455,6 @@ game (
 )
 
 game (
-	name "Puck People"
-	developer "Microhard"
-	rom ( name puckpepl.zip size 512087 crc 5b5c39e8 md5 939d35220f5071e670440f432d8be5b8 sha1 3ba8bb98ad757ec132cc18e40aed4ff787e04767 )
-)
-
-game (
 	name "Puckman Pockimon"
 	year "2000"
 	developer "Genie"
@@ -39699,7 +29500,7 @@ game (
 	name "Punch-Out!! (Italian bootleg)"
 	year "1984"
 	developer "bootleg"
-	rom ( name punchita.zip size 164458 crc cc849989 md5 9cc9ee41bd5a89b247f89bf5abbec47f sha1 b5ce18f2121fa9295ce4fe8f320dfed50f084845 )
+	rom ( name punchita.zip size 67897 crc babf1800 md5 60107fda0d5bef0bb12d80d988e690fe sha1 5ec712a985657e94180749c29ddbe10c273084ca )
 )
 
 game (
@@ -39710,52 +29511,10 @@ game (
 )
 
 game (
-	name "The Punisher (bootleg with PIC16c57, set 1)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic.zip size 3036818 crc 8f0c308a md5 bb2aff87f655f431a8390caa25e0e9c4 sha1 1aaa8d96a7159b88d252d097ffdaadff1f1b2b99 )
-)
-
-game (
-	name "The Punisher (bootleg with PIC16c57, set 2)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic2.zip size 2977697 crc d07bbdce md5 ffed7100f0772e4cbc8aeb26d19d6a71 sha1 43c12ca05f02b09eff8c2a3c3967a9698b583a24 )
-)
-
-game (
-	name "The Punisher (bootleg with PIC16c57, set 3)"
-	year "1993"
-	developer "bootleg"
-	rom ( name punipic3.zip size 2522756 crc 2732f08a md5 d8d2f64191e5a8bdc947bb0ab1f2aa2d sha1 2de7a5029145a0a5d86afecfe2700c061d0299bb )
-)
-
-game (
-	name "The Punisher (World 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisher.zip size 4041934 crc 817cbb2a md5 57fdbc0298708807a43ff37890d864a0 sha1 e420fe80faa14ac8a36a9ed93f1698cfec5d60aa )
-)
-
-game (
 	name "Biaofeng Zhanjing (Chinese bootleg of The Punisher)"
 	year "1993"
 	developer "bootleg"
 	rom ( name punisherbz.zip size 1874748 crc e0642a46 md5 a403f2cd3a9dd86d75a525f225e5d7ec sha1 93a457791fa328be950668f87e1ac89c730b29da )
-)
-
-game (
-	name "The Punisher (Japan 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisherj.zip size 402652 crc 29c3d4f9 md5 416ad59afe0d70683da35dd9b1cab21e sha1 2e74407e170e56a986da6894ddefd9eca986bd54 )
-)
-
-game (
-	name "The Punisher (USA 930422)"
-	year "1993"
-	developer "Capcom"
-	rom ( name punisheru.zip size 421251 crc 39b08dd7 md5 519f987fe799bd54fcac2fef813321b4 sha1 77e0c035fd13505303cbfaee742d7b834b02aad1 )
 )
 
 game (
@@ -39829,13 +29588,6 @@ game (
 )
 
 game (
-	name "Puyo Puyo Fever (GDS-0031)"
-	year "2003"
-	developer "Sega"
-	rom ( name puyofev.zip size 1197 crc eba1e1ab md5 e08f0a50617366fe8388add87c647491 sha1 301f83a958e8b39ba69372283b8e6d0dfab571b8 )
-)
-
-game (
 	name "Puyo Puyo (Japan, Rev B)"
 	year "1992"
 	developer "Sega / Compile"
@@ -39885,20 +29637,6 @@ game (
 )
 
 game (
-	name "Puzzle Star (ver. 100MG)"
-	year "1999"
-	developer "IGS"
-	rom ( name puzlstar.zip size 5980261 crc 07540417 md5 2215b469a2447b9ed0cd6ab4043cd006 sha1 a4623c6ca421e4bd971048e3f9cd56c2bc7e4dc7 )
-)
-
-game (
-	name "Puzzle De Pon! R!"
-	year "1997"
-	developer "Taito (Visco license)"
-	rom ( name puzzldpr.zip size 158229 crc 061977f0 md5 87f11c7afe188e2ec60c97b0b1b9f3ce sha1 2fcf40f5564c41a3ae7d9d33cdaf2b0a09e71c08 )
-)
-
-game (
 	name "Puzzle De Pon!"
 	year "1995"
 	developer "Taito (Visco license)"
@@ -39906,31 +29644,10 @@ game (
 )
 
 game (
-	name "Puzzle King (Dance _ Puzzle)"
-	year "1998"
-	developer "Eolith"
-	rom ( name puzzlekg.zip size 16929954 crc 37b3dffa md5 d427c9a9cbd94df26b2b6eb134de9ea1 sha1 4920c768baca49f34b05f5c9c4d9cfbe0dc8a959 )
-)
-
-game (
-	name "Puzzlet (Japan)"
-	year "2000"
-	developer "Unies Corporation"
-	rom ( name puzzlet.zip size 4251221 crc 1ba5df9f md5 e740870223f1dd733fa1761c6c8ae2cb sha1 7f3dfa70446915788ced5388da9723f2ee2f2aff )
-)
-
-game (
 	name "Puzzli"
 	year "1995"
 	developer "Metro / Banpresto"
 	rom ( name puzzli.zip size 954668 crc 5311a521 md5 e2e759b269ce5293156bdfa19c117b71 sha1 1d14c693e1fba31d0f15dc619b8414b4087ef3ba )
-)
-
-game (
-	name "Puzzli 2 Super (ver. 200)"
-	year "2001"
-	developer "IGS"
-	rom ( name puzzli2.zip size 5126339 crc 7788fab5 md5 818937b3ac103e122b4a83508409f643 sha1 bf700269ad69e13e94a90a3e35fa66ce4ebb6203 )
 )
 
 game (
@@ -39969,24 +29686,10 @@ game (
 )
 
 game (
-	name "Puzznic (World)"
-	year "1989"
-	developer "Taito Corporation Japan"
-	rom ( name puzznic.zip size 55467 crc bc6229c3 md5 bdfefff6e6bf604499f43ee5bad2318b sha1 bb29be31df5ba1a6f51d90cbd39ea186e83b6a82 )
-)
-
-game (
 	name "Puzznic (Italian bootleg)"
 	year "1989"
 	developer "bootleg"
 	rom ( name puzznici.zip size 130658 crc 5de407ba md5 ca623ca75bbf7755726348ad786a2509 sha1 11b709be85ec2973d2d15780ea8c098241d8da9d )
-)
-
-game (
-	name "Puzznic (Japan)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name puzznicj.zip size 130560 crc beba7156 md5 cc1052a40ee31a1ce60e398c3ea4f25f sha1 23262726e766c491e3f4f3b88a5fd64f365bcc84 )
 )
 
 game (
@@ -40018,13 +29721,6 @@ game (
 )
 
 game (
-	name "Photo Y2K 2"
-	year "2001"
-	developer "IGS"
-	rom ( name py2k2.zip size 27835941 crc 5de8ef4b md5 8aff53bbe6174c50a40fb8468bdb58d8 sha1 2fb92b79d487268f66e38e8ac7d1bf0018210b8c )
-)
-
-game (
 	name "Pyramid (Dutch, Game Card 95-750-898)"
 	year "1996"
 	developer "BFM/ELAM"
@@ -40043,20 +29739,6 @@ game (
 	year "1999"
 	developer "Nihon System / Moss"
 	rom ( name pzlbowl.zip size 5900443 crc eb81a5b5 md5 4c7055693eebd84727f1dd47e5f081f4 sha1 8043c25613252b5030fad20e5c55ab5f9045ceac )
-)
-
-game (
-	name "Puzzle Break"
-	year "1997"
-	developer "SemiCom"
-	rom ( name pzlbreak.zip size 524061 crc b3502f4b md5 02282e91d44e492181781d612bf26cda sha1 875582b56386d025224b8f3696f56b820c812fac )
-)
-
-game (
-	name "Puzzle Star (Sang Ho Soft)"
-	year "1991"
-	developer "Sang Ho Soft"
-	rom ( name pzlestar.zip size 765254 crc 02daa45d md5 2e6bf54af0fd649e4680593e31ef6b2f sha1 3c3b7537b61ab8002ed3fc032745e436fdd7b6f0 )
 )
 
 game (
@@ -40140,13 +29822,6 @@ game (
 	year "1982"
 	developer "Gottlieb"
 	rom ( name qbtrktst.zip size 1182 crc c6b726d8 md5 c13bd78b89c905a249accc6d8507b58d sha1 4f2f2650782c800de79e2e4c0f9fd5d30d17c6ca )
-)
-
-game (
-	name "Quarter Horse Classic"
-	year "1995"
-	developer "ArJay Exports/Prestige Games"
-	rom ( name qc.zip size 18292 crc 023773e2 md5 3eb44c6c0db6a012401a1e6fca08f7f8 sha1 ec84c118c061dda50d7ccd5b5392096aaaa0ac13 )
 )
 
 game (
@@ -40234,13 +29909,6 @@ game (
 )
 
 game (
-	name "Quiz Ah Megamisama (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name qmegamis.zip size 53636039 crc 3f2c6b05 md5 0289358b0886a0a57c157a406aeb75a0 sha1 848db79eaef056f209ae3b56ff4ef11bbbdc2a44 )
-)
-
-game (
 	name "Quiz-Mahjong Hayaku Yatteyo! (Japan)"
 	year "1991"
 	developer "Nichibutsu"
@@ -40290,13 +29958,6 @@ game (
 )
 
 game (
-	name "Queen of the Nile (B - 13-05-97, NSW/ACT)"
-	year "1997"
-	developer "Aristocrat"
-	rom ( name qotn.zip size 822082 crc 9f35e68e md5 1c4fa85128b3d8b471e5a1c294e7aa1c sha1 0f618b889c582e098a7a64dfa00946fa4693b673 )
-)
-
-game (
 	name "Quiz Rouka Ni Tattenasai (Japan, ROM Based)"
 	year "1991"
 	developer "Sega"
@@ -40332,45 +29993,10 @@ game (
 )
 
 game (
-	name "Quiz Tonosama no Yabou 2: Zenkoku-ban (Japan 950123)"
-	year "1995"
-	developer "Capcom"
-	rom ( name qtono2j.zip size 1944928 crc 9064b2b9 md5 8f1424cf328dcd7a007a4a4be0c7eea3 sha1 b965ed1b1f8a248ad8e8aa2f02a11a6648f95779 )
-)
-
-game (
 	name "Quiz Torimonochou (Japan)"
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name qtorimon.zip size 513555 crc e41953d4 md5 814be223337a21e1df927e9e569fe9c3 sha1 e0169b435c4bea7ebafdbb2e7d064f17bf257a91 )
-)
-
-game (
-	name "Quantum (rev 2)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantum.zip size 47012 crc 74b2f516 md5 ce561fb1a17ed9989a3cafee44cf1faf sha1 4af46ae800a4320c270eec78a9230580d911c26c )
-)
-
-game (
-	name "Quantum (rev 1)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantum1.zip size 18499 crc ccef1d33 md5 3ff8ddbd0cf592cda61d37ffca2c82dd sha1 e8bdaf0a186f934c97b10e1e98f8dc179c26b942 )
-)
-
-game (
-	name "Quantum (prototype)"
-	year "1982"
-	developer "Atari"
-	rom ( name quantump.zip size 46566 crc e5fc3310 md5 ea78c1e1689895d08633fef2092c113b sha1 ee1c29d08f76d831042e6a488616d348da8adac0 )
-)
-
-game (
-	name "Quadro Quiz II"
-	year "1985"
-	developer "Status Games"
-	rom ( name quaquiz2.zip size 141444 crc 24bb6312 md5 24b6f480c22d08d8af43f141037c0fed sha1 60f6dd68d3353e6e89fd30a8c45133266a097806 )
 )
 
 game (
@@ -40388,34 +30014,6 @@ game (
 )
 
 game (
-	name "Quarter Horse (set 1, Pioneer PR-8210)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterh.zip size 13457 crc ed45698c md5 82273517b345cd1a39d86814bc33297d sha1 ebd4f9ca0faf5d7887d8b720e2b31129b7723e76 )
-)
-
-game (
-	name "Quarter Horse (set 2, Pioneer PR-8210)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterha.zip size 10688 crc 86893622 md5 2bf39094f9b88ce1f06155b99e552a37 sha1 05d56ffe7c238d8fadbcc95ba2ae5a4003fccd19 )
-)
-
-game (
-	name "Quarter Horse (set 3, Pioneer LD-V2000)"
-	year "1983"
-	developer "Electro-Sport"
-	rom ( name quarterhb.zip size 12298 crc 5105606d md5 ab0f4b2ab8823420a22bdc2d8eee9317 sha1 dd7dbd1f4ef50f6f7a69cf4a72389cc8589d30a7 )
-)
-
-game (
-	name "Quartet (Rev A, 8751 315-5194)"
-	year "1986"
-	developer "Sega"
-	rom ( name quartet.zip size 329453 crc c435ece7 md5 b72d5f4ce8cb5ecf244c17f26983c214 sha1 8d28c61e7a3a48d866922e9ec3306c2f969e5d42 )
-)
-
-game (
 	name "Quartet 2 (8751 317-0010)"
 	year "1986"
 	developer "Sega"
@@ -40427,13 +30025,6 @@ game (
 	year "1986"
 	developer "Sega"
 	rom ( name quartet2a.zip size 128599 crc 32633597 md5 a354783f0b30cc1ba5a2a68c20ecd462 sha1 15dd8610e2d9cada27c887c3a8ca3a7f89709f1f )
-)
-
-game (
-	name "Quartet (8751 315-5194)"
-	year "1986"
-	developer "Sega"
-	rom ( name quarteta.zip size 58684 crc a4158dc4 md5 6501c8f1656216151359484fd14913ab sha1 9ae2dab940db933f88865b6345922945cc0a8f54 )
 )
 
 game (
@@ -40458,68 +30049,10 @@ game (
 )
 
 game (
-	name "Queen?"
-	developer "STG"
-	rom ( name queen.zip size 225714 crc f2071c29 md5 697d7bee7b6e7bf96e1b16f9ba8376f5 sha1 0338a0cacd02b630e10250dfd9de88da03ac0179 )
-)
-
-game (
 	name "Quester (Japan)"
 	year "1987"
 	developer "Namco"
 	rom ( name quester.zip size 160104 crc b48ef65a md5 2f1f39658ff5ec6dd90dd51cb295cf5f sha1 1478023c8c2e9efe79ea3443f615f51403fd2e8e )
-)
-
-game (
-	name "Quick Jack"
-	year "1993"
-	developer "ADP"
-	rom ( name quickjac.zip size 93912 crc cf1727d1 md5 b7fa9b0c3d139d0c0148f1bc7841bcd7 sha1 b5c72e96ba266bddc13deb6e470ff6e31cd821d6 )
-)
-
-game (
-	name "Ten Quid Grid (v1.2)"
-	developer "Barcrest"
-	rom ( name quidgrid.zip size 65736 crc 2a47a853 md5 b14ff0e817e6bd3b6664d7c498bc75e4 sha1 44c4d51063ca02fa5ba67c0bd732956eed544137 )
-)
-
-game (
-	name "Ten Quid Grid (v2.4)"
-	developer "Barcrest"
-	rom ( name quidgrid2.zip size 71061 crc 4f905f49 md5 934d32d20fd73798fd222fcd29277079 sha1 e435bac31641050adea7f7f8c261e958ff40da69 )
-)
-
-game (
-	name "Ten Quid Grid (v2.4, Datapak)"
-	developer "Barcrest"
-	rom ( name quidgrid2d.zip size 71062 crc 541b59e6 md5 b3a2ab3b3088b8785d5c809796da36ea sha1 b3c4e57508dff10eede21d0867e9172741244977 )
-)
-
-game (
-	name "Ten Quid Grid (v1.2, Datapak)"
-	developer "Barcrest"
-	rom ( name quidgridd.zip size 15749 crc 1d33e1b5 md5 52d1f90238dd99e1b787f0ae4f9686ca sha1 d4365d0e8a33a40d1fa567e43feca500a3012b55 )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-751-206, Datapak)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintond.zip size 56469 crc 06578993 md5 c530c7cffcd4ed435b820e3a4d7adf41 sha1 637d543850473ea191ee9071e5254cd5355075b6 )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-750-203)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintono.zip size 56694 crc 30d21af3 md5 0c2f8ac982381b273ed8e3927349217d sha1 23207a10453a08632ef2d768165a7413cdb32030 )
-)
-
-game (
-	name "Quintoon (UK, Game Card 95-750-206)"
-	year "1993"
-	developer "BFM"
-	rom ( name quintoon.zip size 127592 crc bd7226f5 md5 2f6531f18028f7e9a9496189ab917ba6 sha1 6b50a5860783238f0959f0c4ad73cc82ca70bacb )
 )
 
 game (
@@ -40534,41 +30067,6 @@ game (
 	year "1992"
 	developer "EIM"
 	rom ( name quiz18k.zip size 2058384 crc 65cea25c md5 06b84dad170b3575a329987450563c71 sha1 91eea1ac7ea2c01c21a9617811abfb2ff4d1e108 )
-)
-
-game (
-	name "Quiz (Revision 2.11)"
-	year "1991"
-	developer "Elettronolo"
-	rom ( name quiz211.zip size 53546 crc e631a1b3 md5 12eecfa9add482b36d5d29f7026a873d sha1 da0274db8b6291243fd5d9f6c060f240ea4fe927 )
-)
-
-game (
-	name "Quiz 365 (Japan)"
-	year "1994"
-	developer "Nakanihon"
-	rom ( name quiz365.zip size 3973379 crc b0784e6f md5 309eb1312dc849ca346224f88af36569 sha1 ad090679bf478f8ee793dd9cee846c278d7e5825 )
-)
-
-game (
-	name "Quiz 365 (Hong Kong _ Taiwan)"
-	year "1994"
-	developer "Nakanihon / Taito"
-	rom ( name quiz365t.zip size 2521913 crc 05cf78e2 md5 9e2e5fddbde6a3c219a90bebeb8b9e43 sha1 fd553b6308a6ef7b53ada76251e390fcde01d01e )
-)
-
-game (
-	name "Quiz Channel Question (Ver 1.00) (Japan)"
-	year "1993"
-	developer "Nakanihon"
-	rom ( name quizchq.zip size 2832492 crc 4c34416a md5 2a55ec49afb183de169019e22548081a sha1 972fe354d25f0b8396a907a72491dd97503a09a8 )
-)
-
-game (
-	name "Quiz Channel Question (Ver 1.23) (Taiwan?)"
-	year "1993"
-	developer "Nakanihon (Laxan license)"
-	rom ( name quizchql.zip size 3272924 crc 7e9eba6a md5 a88a22f2a6ac4b52a20915a785dde5af sha1 bf6d131edceecd03f52c5dabdf2248c1eea3be95 )
 )
 
 game (
@@ -40649,13 +30147,6 @@ game (
 )
 
 game (
-	name "Quizmaster (German)"
-	year "1985"
-	developer "Loewen Spielautomaten"
-	rom ( name quizmstr.zip size 354249 crc 8c843197 md5 7be65f3c07beb992829f57e1de91af6a sha1 8d45a48ec9dff3000eb3bc2123d0cb0ab06d4830 )
-)
-
-game (
 	name "Quiz Olympic (set 1)"
 	year "1985"
 	developer "Seoul Coin Corp."
@@ -40677,20 +30168,6 @@ game (
 )
 
 game (
-	name "Quiz Punch 2"
-	year "1989"
-	developer "Space Computer"
-	rom ( name quizpun2.zip size 313061 crc 5d032fed md5 df688a09302f06469d3391dc3ad1fed0 sha1 24b52a2cfe50a942ccd2e3a8d80f885110876c28 )
-)
-
-game (
-	name "Quiz Keitai Q mode (GDL-0017)"
-	year "2002"
-	developer "Amedio (Taito license)"
-	rom ( name quizqgd.zip size 1195 crc 62abf8b0 md5 f5baaab64d8b8217c2a866fb04ac4bc4 sha1 5d3732f2c07c59c8d9cd429f5869ece7b676018f )
-)
-
-game (
 	name "Nettou! Gekitou! Quiztou!! (Japan)"
 	year "1993"
 	developer "Namco"
@@ -40709,13 +30186,6 @@ game (
 	year "1991"
 	developer "BFM"
 	rom ( name quizvadr.zip size 1304408 crc c541c5f7 md5 2bf7f25ca379e36c8ad4ab6c3b6b2b57 sha1 360e5cd0084229b2f0060611cef56c2a880643a2 )
-)
-
-game (
-	name "Video Quiz"
-	year "1986"
-	developer "bootleg"
-	rom ( name quizvid.zip size 98690 crc 7eb96c0f md5 f2fb3f30e7ce4f0f5a8b30dcb870136d sha1 f84216391f4cc27577fc37cec7da0171b005156a )
 )
 
 game (
@@ -40768,20 +30238,6 @@ game (
 )
 
 game (
-	name "Raiden II / DX (newer V33 PCB)"
-	year "1996"
-	developer "Seibu Kaihatsu"
-	rom ( name r2dx_v33.zip size 11658133 crc 55371003 md5 43bc2b92b92a65a3ccc8612259a81cb8 sha1 861e9bcdd75e792bed6b939ff6ceca33c034dc04 )
-)
-
-game (
-	name "Rabbit (Japan)"
-	year "1997"
-	developer "Electronic Arts / Aorn"
-	rom ( name rabbit.zip size 10172689 crc 868ef0b8 md5 129cef10ae126daebe4ba42dfbc43201 sha1 5815d30174018f4ca41c04366a28565517fefaf2 )
-)
-
-game (
 	name "Rabbit Poker (Arizona Poker v1.1?)"
 	year "1990"
 	developer "bootleg"
@@ -40796,192 +30252,10 @@ game (
 )
 
 game (
-	name "Raccoon World"
-	year "1998"
-	developer "Eolith"
-	rom ( name raccoon.zip size 3367831 crc e2da8d9e md5 22bbe085fadfd15d548710fd864614f2 sha1 0c0f783081a1e3cdfeb01672190ac41407d3843a )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv.zip size 814136 crc 97b25542 md5 2432dc88898105f0b684a4b381494371 sha1 ba9bac6256b53ee5279e61c950aaab092b690df5 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv1.zip size 452774 crc 7ac7ebe6 md5 b5cb63b90518f078c5221b728449cbe5 sha1 099734915fbd491e3977bee3a58aad8500151cc8 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv2.zip size 391367 crc bc34316a md5 25a4c5fb7ef26c5bc27b01b7ebf3c6b9 sha1 b3393b306ce18415f66c4d4cea1985ce3d972cff )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 3)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv3.zip size 391352 crc 08b3bafb md5 5f18b602fb40d82ea6f914071df58c6e sha1 768d1bfbb60821a38c0ff76dc120d9d8711f7b98 )
-)
-
-game (
-	name "Race Drivin' (cockpit, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedriv4.zip size 188572 crc 2a43450e md5 7bfa6eb12a3cd47e98ef5e76f3650336 sha1 74c8b681fecc5df0b4f0c9e4a26d66b5733d2620 )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb.zip size 53983 crc a14e60d3 md5 b0a6d95377846bb966411730e4937e4b sha1 7ad758bcbf83b254e0a24935f08fd307e72d6b0a )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb1.zip size 506953 crc 8df8787b md5 297e9db0c09c712249200d6308d89096 sha1 ccae46f6f3a5a70d4618dad3b10b9b47ac5b0281 )
-)
-
-game (
-	name "Race Drivin' (cockpit, British, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivb4.zip size 242511 crc f798651d md5 e91a176ac13535a042173414d71b92a5 sha1 1e9f93591095392ff620f4c082d1fb78e15bfc77 )
-)
-
-game (
-	name "Race Drivin' (compact, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc.zip size 441600 crc d4a876be md5 118392e80bf7a1ba4085a69e5e92d81f sha1 192bc717f117598fe50116503c00cf68d7b16fac )
-)
-
-game (
-	name "Race Drivin' (compact, rev 1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc1.zip size 429658 crc 822bd48a md5 101c50eecd7b72ce2235f5ea503990a9 sha1 bf79bb1afa41b1959b40e8e30eca1ac072cc4e1c )
-)
-
-game (
-	name "Race Drivin' (compact, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc2.zip size 429644 crc ac737060 md5 02bc61e733cdc1888bb66bf5fed8de7e sha1 4a22bced10412970e62b0addbd82aac6fdefcd5c )
-)
-
-game (
-	name "Race Drivin' (compact, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivc4.zip size 441180 crc 36b22b47 md5 3cf77084acda3dcdeabef88463362c18 sha1 4991a054cf1c92ceb968e074fff9e39802686fe7 )
-)
-
-game (
-	name "Race Drivin' (compact, British, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcb.zip size 495539 crc 90a58753 md5 7cf2d31a4811a9c1c76975d56561bcbe sha1 b7db205811cfd555c61109ae978e65c958129035 )
-)
-
-game (
-	name "Race Drivin' (compact, British, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcb4.zip size 495119 crc e9e92ae5 md5 ee799000ef9e7d64a129d8cd817d86f1 sha1 1bd641db1d270d7619f354fe655de0e6d34c22cc )
-)
-
-game (
-	name "Race Drivin' (compact, German, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcg.zip size 442473 crc b4837f45 md5 d1d67089d37628685e376df23ecab5b0 sha1 f95a0bb58c9c8ed6141cde5aae747b4f5d60325f )
-)
-
-game (
-	name "Race Drivin' (compact, German, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivcg4.zip size 442122 crc b633bb2b md5 903f60975629c65ece7a3d8df180f19e sha1 7272fb65fbd386f2a1ffdd664899b02f36ac3666 )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 5)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg.zip size 190241 crc 764e5709 md5 21d2de8779ee8dfeb0d66504cd3bdf14 sha1 20dcc7c86257cfad7b34e8027c8622dd1208e4a4 )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 2)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg1.zip size 392378 crc 1aaa8682 md5 681924a3254c3f2988604c1921afc153 sha1 a59941c7dd61420bf34ef4dfd4ee5e436faf06ce )
-)
-
-game (
-	name "Race Drivin' (cockpit, German, rev 4)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivg4.zip size 189793 crc b4ef5097 md5 4a2d3db81de409f84666081e1f7e1965 sha1 45522dc9a548eacd6a40b1bba323e67ce2d52810 )
-)
-
-game (
-	name "Race Drivin' Panorama (prototype, rev 2.1)"
-	year "1990"
-	developer "Atari Games"
-	rom ( name racedrivpan.zip size 996677 crc 4a0e5faa md5 a70fde8ae9d1c1641de5502e243066d9 sha1 7c3163e1925e8cbc01a30336628cfbb9f621db68 )
-)
-
-game (
 	name "Racing Hero (FD1094 317-0144)"
 	year "1989"
 	developer "Sega"
 	rom ( name rachero.zip size 1489830 crc 945ffdf7 md5 605da3334195c983a8d360bdf141377c sha1 e887a2b29e294f5b5cfa9a8b8059e4ed5a480d33 )
-)
-
-game (
-	name "Racin' Force (ver EAC)"
-	year "1994"
-	developer "Konami"
-	rom ( name racinfrc.zip size 9239661 crc 7b5b1b8a md5 a5f2e94fc54ce72ba198e50913ee555e sha1 7223bdc3fa666776b5141957f0c3e0e4688eec9d )
-)
-
-game (
-	name "Racin' Force (ver UAB)"
-	year "1994"
-	developer "Konami"
-	rom ( name racinfrcu.zip size 343132 crc 50f0e73c md5 6ff0d15e781630697015a0bb14084c29 sha1 9f9ca8263f14794dfdbb98a1b67aa1bcdba77d78 )
-)
-
-game (
-	name "Racing Beat (World)"
-	year "1991"
-	developer "Taito Corporation Japan"
-	rom ( name racingb.zip size 3623032 crc dea78c34 md5 d9ffcd43f181d35d56d0f640effa6316 sha1 c2fcf9ac97760f68207cfd3000dd64157e6c324e )
-)
-
-game (
-	name "Racing Jam"
-	year "1998"
-	developer "Konami"
-	rom ( name racingj.zip size 13926330 crc d01645d5 md5 86fbd7a4677d6e27394f550433892213 sha1 8ec1dc064c214a5ef8b7bdac5b74f84fc51a16a9 )
-)
-
-game (
-	name "Racing Jam: Chapter 2"
-	year "1999"
-	developer "Konami"
-	rom ( name racingj2.zip size 16517107 crc 5290e79e md5 1f72f385e28ac392ace90aab739339f4 sha1 df9b0a67e0476ef49aedca365dbebc717fd2adc9 )
 )
 
 game (
@@ -41003,13 +30277,6 @@ game (
 	year "1980"
 	developer "Nintendo"
 	rom ( name radarscp.zip size 18113 crc d902667f md5 5a6a1e4c68d6c232b0e83a12444f8f41 sha1 96d757bdb49ede9042a7a76422cab8afdc2cbb1f )
-)
-
-game (
-	name "Radar Scope (TRS01)"
-	year "1980"
-	developer "Nintendo"
-	rom ( name radarscp1.zip size 4755 crc 96bc2eda md5 887ea1fc5b19bb2e8e6a10d597dca174 sha1 8cc2bc248268d5aa5d328992d13532d580fd7c72 )
 )
 
 game (
@@ -41038,13 +30305,6 @@ game (
 	year "1998"
 	developer "Gaelco"
 	rom ( name radikalb.zip size 18485282 crc f01608a4 md5 98056abc8df730d3f775af01c805efd9 sha1 18a0335909e7ade7d8fc8f2f401f2540d6c6a2e0 )
-)
-
-game (
-	name "Radirgy (GDL-0032)"
-	year "2005"
-	developer "Milestone"
-	rom ( name radirgy.zip size 1196 crc b2d7d006 md5 c183da1fc5224f7aa077cd99a3632453 sha1 a2bda21fac9caada56ca71967f5346c5ff7cc1f2 )
 )
 
 game (
@@ -41111,62 +30371,6 @@ game (
 )
 
 game (
-	name "Raiden"
-	year "1990"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden.zip size 890877 crc 7c672f3b md5 669cf45efe5b51c7db1eab8789f50949 sha1 8f10a0788462eaef4207dc0f88f5887deee05812 )
-)
-
-game (
-	name "Raiden II (set 1, US Fabtek)"
-	year "1993"
-	developer "Seibu Kaihatsu (Fabtek license)"
-	rom ( name raiden2.zip size 10973661 crc e8a1daff md5 841d1156bc0831a897a70e1758c53a2d sha1 d4e754e98724c122bad85d0b00a9b684eed5149e )
-)
-
-game (
-	name "Raiden II (set 2, Metrotainment)"
-	year "1993"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raiden2a.zip size 349523 crc c838e8dc md5 43af0a9f64fd085df07aafbeb87de8b6 sha1 5596957553d67c42e66c5180bc6f2196a7e93fea )
-)
-
-game (
-	name "Raiden II (set 3, Japan)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2b.zip size 349521 crc da7b500f md5 b5013da4208c203323eeccca0148be95 sha1 f2d4e99b5d93ea7c0b3a19c8d9884bf98ae04530 )
-)
-
-game (
-	name "Raiden II (set 4, Japan)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2c.zip size 524751 crc 0dd092c8 md5 e076b894a33f545e5c2a937182414fd7 sha1 4c2ec56b0886951c6b212f2e2f2b502081dd9f02 )
-)
-
-game (
-	name "Raiden II (set 5, Italy)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2d.zip size 759439 crc 0db016a5 md5 800d0ff80fefd488d67b99afa42c0cad sha1 22c105a247c3c2b4ea9e3ecc9f793ab25d0fb9c1 )
-)
-
-game (
-	name "Raiden II (set 6, Easy Version)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2e.zip size 763344 crc f5935a4c md5 b1c7b6031cf898600b5f7c48407b43e0 sha1 a863a92f69f90f12cdab2003f8755a066b88013c )
-)
-
-game (
-	name "Raiden II (set 7)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name raiden2f.zip size 562952 crc 3339f0c4 md5 47976a91220ac8763b34559b009ded4e sha1 c818a73eecad9a453a9e0a6f563a2556d9f3d415 )
-)
-
-game (
 	name "Raiden (Alternate Hardware)"
 	year "1990"
 	developer "Seibu Kaihatsu"
@@ -41213,55 +30417,6 @@ game (
 	year "1985"
 	developer "UPL (Taito license)"
 	rom ( name raiders5t.zip size 19666 crc 3feb7909 md5 08a048c1d9e591ac3c6525a774c746ad sha1 ff7fe2fc8f2290c45afa387d5d122a1d40ed342a )
-)
-
-game (
-	name "Raiden DX (UK)"
-	year "1994"
-	developer "Seibu Kaihatsu"
-	rom ( name raidndx.zip size 11225182 crc f282dd41 md5 bdf2b9ab10cb8f1aad68ea3cbe2fd006 sha1 c82155d5d210eb8fadbb77c6a6c7f89d9ef26a52 )
-)
-
-game (
-	name "Raiden DX (Asia set 1)"
-	year "1994"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raidndxa1.zip size 822194 crc 53b0eac6 md5 2fa75ae718b1f21eef51bf8eb28b4f39 sha1 bc393606278e9c0ff51555d1eaa090b1403eb6a9 )
-)
-
-game (
-	name "Raiden DX (Asia set 2)"
-	year "1994"
-	developer "Seibu Kaihatsu (Metrotainment license)"
-	rom ( name raidndxa2.zip size 822099 crc bb850954 md5 759cc0e611f79cf42f2e20d2e73fe589 sha1 2a410e55101d7b23a7003a7dd0fdeef3aee357ee )
-)
-
-game (
-	name "Raiden DX (Germany)"
-	year "1994"
-	developer "Seibu Kaihatsu (Tuning license)"
-	rom ( name raidndxg.zip size 179329 crc f8d4f6f6 md5 7f47740fa8978da7db32314d2c9d1f5b sha1 282a96d34e582432ccc0ebb6bae8bb05ce9beece )
-)
-
-game (
-	name "Raiden DX (Japan)"
-	year "1994"
-	developer "Seibu Kaihatsu"
-	rom ( name raidndxj.zip size 822359 crc 543619be md5 e86bfc6d063f326a4a5e006e7630b496 sha1 44e0e9d4b529134333442292da597ef27f95be26 )
-)
-
-game (
-	name "Raiden DX (US)"
-	year "1994"
-	developer "Seibu Kaihatsu (Fabtek license)"
-	rom ( name raidndxu.zip size 939505 crc 4840fce6 md5 b3fe145b879d868d4cef2b465dbb24fe sha1 300ece9a0b0fc16b9a5acda8d67cd62b8eeee851 )
-)
-
-game (
-	name "Raiga - Strato Fighter (Japan)"
-	year "1991"
-	developer "Tecmo"
-	rom ( name raiga.zip size 90970 crc fa05c124 md5 71411a99eca13b295c9d12e018c0126c sha1 5f2b2a3fd5c7dc90b3494cfa3cf508c135dbbf92 )
 )
 
 game (
@@ -41398,13 +30553,6 @@ game (
 )
 
 game (
-	name "Ranger Mission"
-	year "2004"
-	developer "Sammy"
-	rom ( name rangrmsn.zip size 81514419 crc 5c6da30c md5 86031711d4e3ffabdcf5615068d439b7 sha1 003096e3ad966f3bfd3016e9ed5487e67e70871e )
-)
-
-game (
 	name "Rapid Hero"
 	year "1994"
 	developer "NMK / Media Shoji"
@@ -41426,20 +30574,6 @@ game (
 )
 
 game (
-	name "Rapid River (RD3 Ver. C)"
-	year "1997"
-	developer "Namco"
-	rom ( name rapidrvr.zip size 78989140 crc 89316757 md5 9ab4333d5dc8d87ed9a4960581942c5e sha1 6ea8278b031da5b07b01d2ac8d64b7a3ac3055e0 )
-)
-
-game (
-	name "Rapid River (RD2 Ver. C)"
-	year "1997"
-	developer "Namco"
-	rom ( name rapidrvr2.zip size 1118839 crc 032a3658 md5 8a4fdad0ad9853cd7fc2fbd8c1715645 sha1 5639d076ebb8567f2546cb99f89d27841a60768e )
-)
-
-game (
 	name "Rastan (World)"
 	year "1987"
 	developer "Taito Corporation Japan"
@@ -41450,7 +30584,7 @@ game (
 	name "Rastan (US, set 1)"
 	year "1987"
 	developer "Taito America Corporation"
-	rom ( name rastanu.zip size 523796 crc dbe6b0ff md5 83b51a410e54c3432d890ac7913be5f8 sha1 b3dd93575e31638ab2a477702971a8fc398c8552 )
+	rom ( name rastanu.zip size 67951 crc e9c403e7 md5 bc335c113828db980b2562c65e7d216a sha1 fdb1c504679c8398e72b6457ce346e9402ce41b6 )
 )
 
 game (
@@ -41471,7 +30605,7 @@ game (
 	name "Rastan Saga (Japan)"
 	year "1987"
 	developer "Taito Corporation"
-	rom ( name rastsaga.zip size 524447 crc 7cd76665 md5 27e49284518821fe20e3011bb633f0d2 sha1 76caddbbcee0c1363f85094d28645584b75d9bd3 )
+	rom ( name rastsaga.zip size 112190 crc 4ac12833 md5 e053973eb211d2943fda9133852d9c21 sha1 ccc7e8b420c851ebe18a36b71c5001be0e618376 )
 )
 
 game (
@@ -41601,20 +30735,6 @@ game (
 )
 
 game (
-	name "Road Blaster (Data East LD)"
-	year "1985"
-	developer "Data East"
-	rom ( name rblaster.zip size 32391 crc 30c397eb md5 eaf2822f5eb82084554305cf1e8b8f8d sha1 5e575c57f42ddf1d2c35fb7a4e6e7349214f6360 )
-)
-
-game (
-	name "Real Battle Mahjong King"
-	year "1998"
-	developer "GMS"
-	rom ( name rbmk.zip size 846459 crc ee069ba7 md5 6d1df5b19e1de67fdf7668d9c6cda47b sha1 b53b74ed5afed9d6db09b282e72ec90ec5bc4db8 )
-)
-
-game (
 	name "Tapper (Root Beer)"
 	year "1984"
 	developer "Bally Midway"
@@ -41633,13 +30753,6 @@ game (
 	year "1991"
 	developer "Sega"
 	rom ( name rchase.zip size 6251532 crc d33791aa md5 6f1718fbc22b80c1f5cade39f32fe771 sha1 c4d4871653aaaf007953b37b0d184904eb1b4596 )
-)
-
-game (
-	name "Rail Chase 2 (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name rchase2.zip size 13979877 crc 0068d603 md5 1bcd71c49f366cd5c6ee97d290b3fb9d sha1 2062cbfd61d411529b5520186e87eb6c5605a61e )
 )
 
 game (
@@ -41668,13 +30781,6 @@ game (
 	year "2004"
 	developer "Igrosoft"
 	rom ( name rclimb_3b.zip size 1688562 crc c3bc03db md5 3c7b6557d92186aca7f9ca345cce65a1 sha1 3de9b000233dd20c62fe63893c98e9da57d894e0 )
-)
-
-game (
-	name "Red Corsair"
-	year "1984"
-	developer "Nakasawa"
-	rom ( name rcorsair.zip size 15213 crc d0494c67 md5 b9d097e959075babb1b51f73c0f404a4 sha1 c35d162ad03483484dab383b94a5a7468fb6ffa3 )
 )
 
 game (
@@ -41839,13 +30945,6 @@ game (
 )
 
 game (
-	name "Rebus"
-	year "1995"
-	developer "Microhard"
-	rom ( name rebus.zip size 2859633 crc 9ed15861 md5 b03525384eb4e6cbffa88eed9809615d sha1 a76f6fc751c7bf1d2805f3f985a255d28971df67 )
-)
-
-game (
 	name "Recalhorn (Ver 1.42J 1994/5/11) (Prototype)"
 	year "1994"
 	developer "Taito Corporation"
@@ -41874,38 +30973,10 @@ game (
 )
 
 game (
-	name "Red Clash (set 1)"
-	year "1981"
-	developer "Tehkan"
-	rom ( name redclash.zip size 12835 crc 77641685 md5 0df3b1e6c11d7d2e4074d84107c09aba sha1 064a57eb5626b1e38b705d2fde79a99e2d563026 )
-)
-
-game (
-	name "Red Clash (set 2)"
-	year "1981"
-	developer "Tehkan"
-	rom ( name redclasha.zip size 10528 crc 3e999732 md5 81a55b12678529a7f7406f51cbf34dd8 sha1 ec2239dbc0e94c8f56e693a8d0631123c3319be8 )
-)
-
-game (
-	name "Red Clash (Kaneko)"
-	year "1981"
-	developer "Tehkan (Kaneko license)"
-	rom ( name redclashk.zip size 8318 crc 41c2c651 md5 fa507ed51f0728a552526b2d7af17ae3 sha1 e02a5a460ad7b3a5344803277a53747537f7b5ef )
-)
-
-game (
 	name "Red Earth (Euro, 961121)"
 	year "1996"
 	developer "Capcom"
 	rom ( name redearth.zip size 132465 crc ec87dc78 md5 1e0999adcb3a64dbb004a1be7bbc6a58 sha1 46b5eb45b7a1a03db9592151a0cb24624908c73f )
-)
-
-game (
-	name "Red Earth (961121, NO CD)"
-	year "1996"
-	developer "Capcom"
-	rom ( name redeartn.zip size 36057981 crc ccc1837b md5 f3d69f019e7fded67fecfaccf122dc45 sha1 a2b1d958362fda28d2a17faec70416a197a4eeea )
 )
 
 game (
@@ -41934,13 +31005,6 @@ game (
 	year "1997"
 	developer "Afega (Hea Dong Corp license)"
 	rom ( name redhawki.zip size 592163 crc 0abc7d17 md5 bcf51f128885baa64f185eb723a2097b sha1 f98e1cb9a7b179bd09d19e6e587b700df5254079 )
-)
-
-game (
-	name "Redline Racer (2 players)"
-	year "1987"
-	developer "Cinematronics (Tradewest license)"
-	rom ( name redlin2p.zip size 224176 crc 6bd90636 md5 2cfcb235db4703cbf0031c01291909fc sha1 ef209a5e9639b1daec2d3e2225fec2fd121d7537 )
 )
 
 game (
@@ -41976,13 +31040,6 @@ game (
 	year "1986"
 	developer "Greyhound Electronics"
 	rom ( name reelfun1.zip size 9861 crc 7d2e5189 md5 07ba958bc92abb9f18b75fd1ff216623 sha1 bd03148adab91ca3c836a23636c63e96aab3d60b )
-)
-
-game (
-	name "Reelin-n-Rockin (A - 13/07/98, Local)"
-	year "1998"
-	developer "Aristocrat"
-	rom ( name reelrock.zip size 1050784 crc ed0f9e99 md5 e0e9cf62557b18f97f121b3f2303245d sha1 eb4ed15486909f78a6810cd45bd9a4308aa74f3a )
 )
 
 game (
@@ -42056,20 +31113,6 @@ game (
 )
 
 game (
-	name "Rescue Raider"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name rescraid.zip size 88433 crc 54a45f86 md5 51c4315790d606d28fd9c5505084ff7b sha1 2615969ae3be3cd8c6dbae0e95c7f4cb017fec63 )
-)
-
-game (
-	name "Rescue Raider (stand-alone)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name rescraida.zip size 64782 crc 04bbfbd9 md5 9a62a9d3858725482ae1e94f3a931f01 sha1 80dbf7cfbd6cfcd7f49551d26c9b34cea173fa83 )
-)
-
-game (
 	name "Rescue"
 	year "1982"
 	developer "Stern Electronics"
@@ -42091,13 +31134,6 @@ game (
 )
 
 game (
-	name "Return of the Invaders"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name retofinv.zip size 48110 crc bb87612b md5 d0701657e1065a099258b1d458176d14 sha1 974ec9619c55b83d3d767cf9a2b6051de8c9bab5 )
-)
-
-game (
 	name "Return of the Invaders (bootleg set 1)"
 	year "1985"
 	developer "bootleg"
@@ -42109,13 +31145,6 @@ game (
 	year "1985"
 	developer "bootleg"
 	rom ( name retofinv2.zip size 14506 crc 0f513aad md5 a35b80acd951df4c6f1dc08c1e3db2f9 sha1 aab650137da3b507c56a1d700ea52ca042cbb261 )
-)
-
-game (
-	name "Revenger"
-	year "1984"
-	developer "Epos Corporation"
-	rom ( name revenger.zip size 24171 crc 47a75942 md5 6e1daedeb84704dd344b02a023c36157 sha1 34e1013cccc9ff31b5728a810145b6bfc0f833e4 )
 )
 
 game (
@@ -42189,12 +31218,6 @@ game (
 )
 
 game (
-	name "Royal Gum (Italy)"
-	developer "&lt;unknown&gt;"
-	rom ( name rgum.zip size 56734 crc 8df7b09c md5 c7d51c36a575d151ebae12666cde8fa6 sha1 6ae5138c231582ffdd3db34adb3a774308bded25 )
-)
-
-game (
 	name "Ribbit!"
 	year "1991"
 	developer "Sega"
@@ -42265,38 +31288,10 @@ game (
 )
 
 game (
-	name "Riding Fight (Ver 1.0O)"
-	year "1992"
-	developer "Taito Corporation Japan"
-	rom ( name ridingf.zip size 4728731 crc 1cff49e4 md5 c99a4db6f9f75a617a273d542d558636 sha1 e1358344ad61a2b625243570a5308d35f8d32fdc )
-)
-
-game (
-	name "Riding Fight (Ver 1.0J)"
-	year "1992"
-	developer "Taito Corporation"
-	rom ( name ridingfj.zip size 117615 crc 335ef61b md5 537e180173f08a52fc98858970692a27 sha1 d04bc361ea5e1dd79e39220c4d1db373f4ebefa9 )
-)
-
-game (
-	name "Riding Fight (Ver 1.0A)"
-	year "1992"
-	developer "Taito America Corporation"
-	rom ( name ridingfu.zip size 117616 crc 6ef1a4b3 md5 a24f4a18894190a395e5fbaa0b2aa59a sha1 7bf26017c4b80fa4a5a2882b0750cbf58d868d90 )
-)
-
-game (
 	name "Riddle of Pythagoras (Japan)"
 	year "1986"
 	developer "Sega / Nasco"
 	rom ( name ridleofp.zip size 83575 crc 500bad17 md5 264dbc2fe17d03c3ebd7432f0b7f0718 sha1 40e7243ef98246dcf3695eddbc81d873a2152b47 )
-)
-
-game (
-	name "Rim Rockin' Basketball (V2.2)"
-	year "1991"
-	developer "Strata/Incredible Technologies"
-	rom ( name rimrockn.zip size 916426 crc c001d28e md5 55ad31a7f1d397e8c9c5ca557fe9a943 sha1 0c795b7ef4d65fec3ff6f7eaf58f59f71f48429d )
 )
 
 game (
@@ -42503,90 +31498,6 @@ game (
 )
 
 game (
-	name "Road Blasters (upright, rev 4)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst.zip size 514197 crc b2858160 md5 81ef78c9596849c649eb4986c827743f sha1 cbaea7041f946eb89bb309f3b266189b79b2f621 )
-)
-
-game (
-	name "Road Blasters (upright, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst1.zip size 83142 crc f1a10111 md5 cb13f6fcb42e7611e7eef987cf14a1ea sha1 88239713e5327780b8f7b1e469b3b8dfd263b948 )
-)
-
-game (
-	name "Road Blasters (upright, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst2.zip size 83121 crc 14bc50dc md5 1cc28a5f27240b240e295a35d3013bb3 sha1 4ee03a45918746bd189912d8890ffbc265cae630 )
-)
-
-game (
-	name "Road Blasters (upright, rev 3)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblst3.zip size 60681 crc e15fc37a md5 1aad3df920f5dc0505c7da8d865afcf9 sha1 0368aae45e4894837eaac78612d95b7824ca0780 )
-)
-
-game (
-	name "Road Blasters (cockpit, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstc.zip size 60678 crc 7b9bab57 md5 73a7d0db7e12455c8ee48473db190568 sha1 886c452e08a10417e7c9c854818724ab7361e2a1 )
-)
-
-game (
-	name "Road Blasters (cockpit, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstc1.zip size 60560 crc c8bbbf59 md5 c2f6e7fc1d9ce8f1392d9971d6b2c471 sha1 d798d6d3f30562fe6f782a673341aa5689463b37 )
-)
-
-game (
-	name "Road Blasters (cockpit, German, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstcg.zip size 59306 crc 69ccdbcb md5 587dd4380002514723afb273f5575566 sha1 111a2d1f22093fc4207c5569a5caa7f47dbea56f )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 3)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg.zip size 59485 crc 476d7141 md5 3ee54253a3f5797ef4ab23fa7de84aa8 sha1 b07807463216583b3ae05938a50712e7ba5baf6a )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 1)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg1.zip size 81896 crc 57be3fd5 md5 11fd778043b2f65261a70653b8733c7a sha1 2a7f50bc307edd8d346c3b00a55a3136247588ad )
-)
-
-game (
-	name "Road Blasters (upright, German, rev 2)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name roadblstg2.zip size 81933 crc ff848d95 md5 7505a0858ab3ae1867f1269106ab071b sha1 67c31374af3baccd113ae1b5d79597646e6fa5ea )
-)
-
-game (
-	name "Road Burners"
-	year "1999"
-	developer "Atari Games"
-	rom ( name roadburn.zip size 268745 crc bcf97285 md5 6642fa2be301e35d9b4fe93dc56994c2 sha1 7d0b5498d0a63fcf535bb0043078b08235c1f642 )
-)
-
-game (
-	name "Roads Edge / Round Trip (rev.B)"
-	year "1997"
-	developer "SNK"
-	rom ( name roadedge.zip size 39141986 crc 64a1ec3a md5 c7e53aea511ff5ee0a16cfc459f40c1b sha1 c136da7fe8b6c8c8cc58f71cfa6f49302dd0ae6d )
-)
-
-game (
 	name "Road Fighter (set 1)"
 	year "1984"
 	developer "Konami"
@@ -42601,38 +31512,10 @@ game (
 )
 
 game (
-	name "Road Riot 4WD"
-	year "1991"
-	developer "Atari Games"
-	rom ( name roadriot.zip size 2280668 crc 9210fa76 md5 4ac7e4f67e5e46b2b792902555d1e241 sha1 0156e6a4569b73ae77f89bce7063c2e7c32e0916 )
-)
-
-game (
 	name "Road Runner (Midway)"
 	year "1977"
 	developer "Midway"
 	rom ( name roadrunm.zip size 1489 crc 888752fc md5 469709a34c40db7ea4026fb49385c47d sha1 5dab5d53b159b09278e833d8ce72bb4cb8dbe2f0 )
-)
-
-game (
-	name "Road Runner (rev 2)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn.zip size 471093 crc 2fa8989e md5 05dc4eb45c0f4508c8dd4f5e4a04f1de sha1 81b9b72627d75fd328bc6f7f2ccfc26abe6eabcc )
-)
-
-game (
-	name "Road Runner (rev 1)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn1.zip size 55536 crc 52eafd44 md5 b077f661654b319a7ceea727057a1aba sha1 05909c35d1fabe7f0081dc37154d3a934d0f0918 )
-)
-
-game (
-	name "Road Runner (rev 1+)"
-	year "1985"
-	developer "Atari Games"
-	rom ( name roadrunn2.zip size 55499 crc 072c5d3e md5 d36dfd0f833ae8c05db57f4adf91c9ad sha1 836907639b6cb0bf3419a7418ae6a129e896f7d3 )
 )
 
 game (
@@ -42895,13 +31778,6 @@ game (
 )
 
 game (
-	name "Rock Duck (prototype?)"
-	year "1983"
-	developer "Datel SAS"
-	rom ( name rockduck.zip size 18823 crc d61f8b53 md5 d400ed8e40149eaea77b3ef9ee2f6a5a sha1 6cad70beb126648d5eb6e4b14702a49a7404c4df )
-)
-
-game (
 	name "Rockman 2: The Power Fighters (Japan 960708)"
 	year "1996"
 	developer "Capcom"
@@ -42985,27 +31861,6 @@ game (
 )
 
 game (
-	name "MTV Rock-N-Roll Trivia (Part 2)"
-	year "1986"
-	developer "Triumph Software Inc."
-	rom ( name rocktrv2.zip size 142645 crc 5bd912da md5 9ee397b766436c2430d5e8324ef59ff8 sha1 eee89b219e1a69f8125126217bd3c00ec0fd4f75 )
-)
-
-game (
-	name "Roc'n Rope"
-	year "1983"
-	developer "Konami"
-	rom ( name rocnrope.zip size 50109 crc ec7750e3 md5 7375f0b315c719c55e24b014222e39a2 sha1 c081576af46aa5db220d9602923ac57918e02928 )
-)
-
-game (
-	name "Roc'n Rope (Kosuka)"
-	year "1983"
-	developer "Konami / Kosuka"
-	rom ( name rocnropek.zip size 23966 crc bf20a46b md5 98c2bade09d9fe021a62177c92abc377 sha1 524b740c31198196fb3b5a0aae5adb077e63222e )
-)
-
-game (
 	name "Rod-Land (World)"
 	year "1990"
 	developer "Jaleco"
@@ -43066,20 +31921,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name roishtar.zip size 114339 crc 19465745 md5 a41827894f2b87ea1b4a52355d230f67 sha1 d8f6cd30174002085db5d35511b2217a85afaefe )
-)
-
-game (
-	name "The Return of Lady Frog (set 1)"
-	year "1993"
-	developer "Microhard"
-	rom ( name roldfrog.zip size 3517801 crc 687f55ce md5 7497385c50848b965607969125acedad sha1 9820f5fbafbbdafb602127ec662df15d204a697c )
-)
-
-game (
-	name "The Return of Lady Frog (set 2)"
-	year "1993"
-	developer "Microhard"
-	rom ( name roldfroga.zip size 423778 crc 565698f4 md5 e07f231ec27762411fce1ae35bcb1460 sha1 7e9706f19ced749ca2591e6e7abc9ef490ec7841 )
 )
 
 game (
@@ -43157,19 +31998,6 @@ game (
 	year "1994"
 	developer "Nakanihon (Activision license)"
 	rom ( name rongrongj.zip size 1193424 crc e292a08e md5 04496730757360d409cd099bf40b6caa sha1 f0cecaeb929dad9fa5655d4f0f411f4704926c8a )
-)
-
-game (
-	name "Ron Jan (Super)"
-	year "1994"
-	developer "Wing Co., Ltd"
-	rom ( name ronjan.zip size 459164 crc 62c91487 md5 bb47a9636ee99430e7019e1720ae542b sha1 6f9481cf776ffb3162f476119b48ba10b7a326cf )
-)
-
-game (
-	name "Rotary Fighter"
-	developer "&lt;unknown&gt;"
-	rom ( name rotaryf.zip size 5433 crc 5b4c6532 md5 f52aef87f724ef18150fc0c745749c03 sha1 1a8ec9d09c7070412548a744af93d6807e9a9ad8 )
 )
 
 game (
@@ -43271,46 +32099,6 @@ game (
 )
 
 game (
-	name "Royal Card (Austrian, set 5)"
-	year "1991"
-	developer "TAB Austria"
-	rom ( name royalcrdd.zip size 28308 crc 2b8db133 md5 bf9e33c7c7164e53a740a6334cadddc5 sha1 cc264e84151d33353a6e606fc7d098a97095953e )
-)
-
-game (
-	name "Royal Card (Austrian, set 6)"
-	year "1991"
-	developer "TAB Austria"
-	rom ( name royalcrde.zip size 53430 crc 45d22a6f md5 0ea2a42bd0d7dc44b4b26ea1c4726089 sha1 72df27224707b1fc698f2fb9878fa9a79c8b3778 )
-)
-
-game (
-	name "Royal Card (Slovak, encrypted)"
-	year "1991"
-	developer "Evona Electronic"
-	rom ( name royalcrdf.zip size 43619 crc a0a9e900 md5 4f7a3088ab74d6189a877f1fe48ad612 sha1 8b4e6692923293899902f3fe308c4db71e58d354 )
-)
-
-game (
-	name "Royal Card v2.0 Professional"
-	year "1993"
-	developer "Digital Dreams"
-	rom ( name royalcrdp.zip size 21797 crc d72a2437 md5 39194d7ef3737d4f5d4eff0dbc390a14 sha1 70e39999b33fa6597573be110248ee6a1b70fdaa )
-)
-
-game (
-	name "Royale (set 1)"
-	developer "&lt;unknown&gt;"
-	rom ( name royale.zip size 13472 crc 07ce3d5f md5 863ce11b09a5d4489b3af1acf512e739 sha1 486b33333c09a4c47aa88396312ac8947a32375f )
-)
-
-game (
-	name "Royale (set 2)"
-	developer "&lt;unknown&gt;"
-	rom ( name royalea.zip size 7661 crc 72e99187 md5 27bb9220909c3852d8398b86387c6ecc sha1 1e42b06db0db6da432a69264eed07ece9946bfdc )
-)
-
-game (
 	name "Royal Mahjong (Falcon bootleg, v1.01)"
 	year "1982"
 	developer "bootleg"
@@ -43388,34 +32176,6 @@ game (
 )
 
 game (
-	name "Ridge Racer (Full Scale, 1993-12-13, World)"
-	year "1993"
-	developer "Namco"
-	rom ( name rrf.zip size 2189551 crc 70b915c9 md5 f769ffd91fc8e5b3955a974eae607e13 sha1 24021e443438c7e3232751c2e94c5ef77c26a436 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Sep 06, 1994)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrreveng.zip size 5191901 crc 562ce048 md5 94202e578b79b81c72a4ace48dabcc51 sha1 f7552e834c3edd9d2e23f2b882b93ccbd4f9fb38 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Jan 27, 1994, set 1)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrrevenga.zip size 865685 crc f61fadf0 md5 40a10025462ad7f9d01543c1bee9521d sha1 1ac7b3dab30fc1af56cc8c61b3e2659a32f086f0 )
-)
-
-game (
-	name "Road Riot's Revenge (prototype, Jan 27, 1994, set 2)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name rrrevengb.zip size 2177065 crc ed96e17e md5 c1889d160d9517e5690080b7b6ac28ec sha1 695e63691aad65146ec6f274fd1a9f6f2126b206 )
-)
-
-game (
 	name "Radiant Silvergun (JUET 980523 V1.000)"
 	year "1998"
 	developer "Treasure"
@@ -43455,12 +32215,6 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name rthundero.zip size 56339 crc 1d73c088 md5 c92e3a36030bbf58f3de4b949a791bf4 sha1 01cb97569fdca1f853a814f0ff1bba1877d94b22 )
-)
-
-game (
-	name "Romar Triv"
-	developer "Romar"
-	rom ( name rtriv.zip size 215867 crc 64c0ccba md5 c821753c3f27bc5b8dafe6e24c3af438 sha1 a1d682ad823aee115b6c92d45314ea080540a370 )
 )
 
 game (
@@ -43527,24 +32281,10 @@ game (
 )
 
 game (
-	name "R-Type (US)"
-	year "1987"
-	developer "Irem (Nintendo of America license)"
-	rom ( name rtypeu.zip size 116717 crc d5a7401b md5 ec6c00b10820711fef90f45049dbc361 sha1 09f79bddf8320b6c33224d72324b46389e77c340 )
-)
-
-game (
 	name "Rug Rats"
 	year "1983"
 	developer "Nichibutsu"
 	rom ( name rugrats.zip size 20720 crc e6cce946 md5 3120805a50f13592c3a40abf721c3845 sha1 7e9ad3c8e38217681f550961e8e5a0b6822cdaac )
-)
-
-game (
-	name "The Rumble Fish"
-	year "2004"
-	developer "Sammy / Dimps"
-	rom ( name rumblef.zip size 109652763 crc f7ce9f74 md5 2127b61a2605a7c975e370ea9322e323 sha1 90b9fe5a8af58793c6520861c842d9cb84295371 )
 )
 
 game (
@@ -43590,20 +32330,6 @@ game (
 )
 
 game (
-	name "Run and Gun (ver UAB 1993 10.12)"
-	year "1993"
-	developer "Konami"
-	rom ( name rungunu.zip size 1088250 crc e2c535a6 md5 cc828ff04b51c3a16eee377c20560113 sha1 569aa27e331cce43471a0b7d0e3e1b5a451a2d49 )
-)
-
-game (
-	name "Run and Gun (ver UBA 1993 10.8)"
-	year "1993"
-	developer "Konami"
-	rom ( name rungunua.zip size 1286961 crc b8ef7d79 md5 03a4ea79849a063fc2ff68baec05d08d sha1 7fac472a604cef92afc660c7430ad941588fcefc )
-)
-
-game (
 	name "Rush'n Attack (US)"
 	year "1985"
 	developer "Konami"
@@ -43615,13 +32341,6 @@ game (
 	year "1986"
 	developer "Capcom"
 	rom ( name rushcrsh.zip size 89169 crc 55c339eb md5 205eae49a35c96fbcfb9a6cf256cd050 sha1 4f45afb79c56c4149556e14b1c588e72c1de8158 )
-)
-
-game (
-	name "Rushing Heroes (ver UAB)"
-	year "1996"
-	developer "Konami"
-	rom ( name rushhero.zip size 18700360 crc 5f0e56d2 md5 68e03a80143456f2d74ee73077a9b08f sha1 bfc9b6a8be19577b0a83cc755fa33ce3915e3e1f )
 )
 
 game (
@@ -43723,20 +32442,6 @@ game (
 )
 
 game (
-	name "Strikers 1945 (World)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945.zip size 5455851 crc 3531fb50 md5 d05941ecbabeacdc15dcdd46fc321f96 sha1 588e673cd5e486f53ef9e0b9c8e49f000981acae )
-)
-
-game (
-	name "Strikers 1945 (Japan / World)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945a.zip size 214324 crc 6cfa523f md5 da66f02c269ea24d0912df28cefcfa49 sha1 98621bae3735415a32f45b43a425917e42febdf7 )
-)
-
-game (
 	name "Strikers 1945 (Hong Kong, bootleg)"
 	year "1995"
 	developer "bootleg"
@@ -43758,24 +32463,10 @@ game (
 )
 
 game (
-	name "Strikers 1945 (Japan)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945j.zip size 214002 crc 6ee6c9f7 md5 fa195835f2119008ab2541ac17156b3e sha1 7f917dc657843af727d1a1eed8affa3aab857a84 )
-)
-
-game (
 	name "Strikers 1945 (Japan, unprotected)"
 	year "1995"
 	developer "Psikyo"
 	rom ( name s1945jn.zip size 1710590 crc bcd0a485 md5 c962b66e1e7c131987474dcbfd7b4771 sha1 376fe33fc5718ef4c97dfdec74fdf2128777e87a )
-)
-
-game (
-	name "Strikers 1945 (Korea)"
-	year "1995"
-	developer "Psikyo"
-	rom ( name s1945k.zip size 214163 crc 67f9f298 md5 65e3ceddd2aec884d36fde7c4dc38c90 sha1 5709b81dce52ee922c0a1cffd4300e2849175df1 )
 )
 
 game (
@@ -43804,27 +32495,6 @@ game (
 	year "1993"
 	developer "Dooyong (NTC license)"
 	rom ( name sadari.zip size 419961 crc 2098925e md5 a8c90040639d6c4a848e53c99bb13265 sha1 38edf4e63b0f35c4170447cbbf43b5c257d9ece7 )
-)
-
-game (
-	name "Space Ace (European)"
-	year "1983"
-	developer "Cinematronics (Atari license)"
-	rom ( name saeuro.zip size 23853 crc d82ef079 md5 2d5b68caeec51ec72885c8b22839e773 sha1 ebec27d569085c022d1ca38971b1a001b8ed7f13 )
-)
-
-game (
-	name "Safari (set 1)"
-	year "1977"
-	developer "Gremlin"
-	rom ( name safari.zip size 8123 crc 1022c961 md5 9e227d83baba0cf1f6a5862b4be7f208 sha1 18ef2830fd0fe08cdbca5ec90a43d5bbc7f3fb07 )
-)
-
-game (
-	name "Safari (set 2, bootleg?)"
-	year "1977"
-	developer "Gremlin"
-	rom ( name safaria.zip size 7793 crc bc8c0bf8 md5 8ecbb820bb388231a9c4256f38196f26 sha1 44f287d377da6271552366633a5045e0f1811506 )
 )
 
 game (
@@ -43940,13 +32610,6 @@ game (
 )
 
 game (
-	name "Sai Yu Gou Ma Roku (Japan)"
-	year "1988"
-	developer "Technos Japan"
-	rom ( name saiyugou.zip size 95396 crc ea2ac88d md5 d61361c1cd7865e2a851aa6dd9813f6b sha1 dbb720739e0d7f9e4acdcc3ce4c0d2b1ead2499a )
-)
-
-game (
 	name "Sai Yu Gou Ma Roku (Japan bootleg 1)"
 	year "1988"
 	developer "bootleg"
@@ -43979,75 +32642,6 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name salamandj.zip size 66958 crc f61a6168 md5 6c8527d036d133006a013cb065f47739 sha1 2a2c96a751cb8f66fd8e8a1636b00fe0d1ab56d1 )
-)
-
-game (
-	name "Salary Man Champ (GCA18 VER. JAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name salarymc.zip size 286 crc d62cd521 md5 cebda5b93cd25de919585476f56d3dfc sha1 f470e8ae1c606ea97ca4130caec9ff442396cebc )
-)
-
-game (
-	name "Salary Man Kintarou"
-	year "2004"
-	developer "Sammy"
-	rom ( name salmankt.zip size 102635461 crc 2aae6b02 md5 44d166d44168d21a7b3bf0764761beb7 sha1 70a4f13a1f8dddcf95ccc78d3c4c45f71cd6f203 )
-)
-
-game (
-	name "Salamander 2 (ver JAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name salmndr2.zip size 6203124 crc 0e896367 md5 c78d6b3f5fc78da69cb440aa9f57c52c sha1 8db50362781f5404a8d3f2f5034712c12741c1d1 )
-)
-
-game (
-	name "Salamander 2 (ver AAB)"
-	year "1996"
-	developer "Konami"
-	rom ( name salmndr2a.zip size 483599 crc b048b876 md5 a0b04a9d7778c921da40f806125331cf sha1 d105b502cd9a7c924826c3cd16803ae5baca1499 )
-)
-
-game (
-	name "Saloon (French, encrypted)"
-	developer "&lt;unknown&gt;"
-	rom ( name saloon.zip size 43233 crc ee8f8cb1 md5 685bb8d9529e50a0118fb0b4847d2381 sha1 0a6c9404cd818d85d7e9c602039f95fab3259ab3 )
-)
-
-game (
-	name "Samba De Amigo (JPN) (Rev B)"
-	year "1999"
-	developer "Sega"
-	rom ( name samba.zip size 122223475 crc 5b383144 md5 4ebde0fc5426873c993f32f1974fffdc sha1 40d0fc7c6417af500323c7e9d35281f68086c3be )
-)
-
-game (
-	name "Same! Same! Same! (2 player alternating ver.)"
-	year "1989"
-	developer "Toaplan"
-	rom ( name samesame.zip size 78015 crc 0138e552 md5 d2b44aebc267ca9b9c269f31d5bd4168 sha1 166f3ad0618219fdc19748a602cff4f628100e13 )
-)
-
-game (
-	name "Same! Same! Same!"
-	year "1989"
-	developer "Toaplan"
-	rom ( name samesame2.zip size 34348 crc 349722b8 md5 711f5813cac7e32f9cc90b2dc167ac0b sha1 9fb537d6d2e4f93256053239a83aaa163bbe440e )
-)
-
-game (
-	name "Samurai Shodown 64 / Samurai Spirits 64"
-	year "1998"
-	developer "SNK"
-	rom ( name sams64.zip size 39889147 crc 23b29397 md5 c78cf8e48772bb12f98ed895a8df1f34 sha1 894c5a1165ea94e6c236a655c0cff0067a59a2b4 )
-)
-
-game (
-	name "Samurai Shodown: Warrior's Rage / Samurai Spirits 2: Asura Zanmaden"
-	year "1998"
-	developer "SNK"
-	rom ( name sams64_2.zip size 72026116 crc 72a04040 md5 77de0bb53e88a82f56b449c1ce6e4f54 sha1 2d43bab487dfff06e4f4ea8d32efa75c23de970c )
 )
 
 game (
@@ -44149,13 +32743,6 @@ game (
 )
 
 game (
-	name "Samurai"
-	year "1980"
-	developer "Sega"
-	rom ( name samurai.zip size 12151 crc ee040cec md5 5c2958cf5de0b3ad57eb6813fcec358f sha1 8a377436fd690fffc7f5fdfab4dad92091819879 )
-)
-
-game (
 	name "Samurai Aces (World)"
 	year "1993"
 	developer "Psikyo"
@@ -44195,13 +32782,6 @@ game (
 	year "1999"
 	developer "Sega / Deniam"
 	rom ( name sanjeon.zip size 9277215 crc 7c7cc18c md5 5bb77662359701c8253fa8b209bffd0a sha1 37cb17783007a2b758004e20590cad6c922a00af )
-)
-
-game (
-	name "Sarge"
-	year "1985"
-	developer "Bally Midway"
-	rom ( name sarge.zip size 84020 crc 19794f30 md5 c52f5e03f7c539c77f5ae573abd079a6 sha1 68d891cc01d5be32931f167816d040217b6924ed )
 )
 
 game (
@@ -44268,20 +32848,6 @@ game (
 )
 
 game (
-	name "Super Bubble 2003 (World, Ver 1.0)"
-	year "2003"
-	developer "Limenko"
-	rom ( name sb2003.zip size 6413782 crc c50b1a1a md5 f47dda175996ba3c4a34d26388191f28 sha1 f4de6ce621ed86d36f1d6c6652987af1ac15b4c0 )
-)
-
-game (
-	name "Super Bubble 2003 (Asia, Ver 1.0)"
-	year "2003"
-	developer "Limenko"
-	rom ( name sb2003a.zip size 250147 crc a4fc7be8 md5 c2752f232af260ed394a33507dc1e756 sha1 f41810a6d9750479133ed63da32c28fd42f4d266 )
-)
-
-game (
 	name "Super Bagman"
 	year "1984"
 	developer "Valadon Automation"
@@ -44338,13 +32904,6 @@ game (
 )
 
 game (
-	name "Super Bike (DK conversion)"
-	year "1984"
-	developer "Century Electronics"
-	rom ( name sbdk.zip size 18655 crc 42f00b04 md5 aecfb0d96cf02d4c49c009dc75bdebe3 sha1 b1f1dfce136167969bb424017b7cb6febd972694 )
-)
-
-game (
 	name "Super Bishi Bashi Championship (ver JAA, 2 Players)"
 	year "1998"
 	developer "Konami"
@@ -44363,13 +32922,6 @@ game (
 	year "1997"
 	developer "bootleg"
 	rom ( name sblast2b.zip size 1146376 crc 022ffcbf md5 51ffe86d157291cd02e586ccaca8ee10 sha1 0352aee683c14def174d02c52d4f82f7ed00b3ed )
-)
-
-game (
-	name "Star Blazer (Pioneer LDV1000)"
-	year "1983"
-	developer "Sega"
-	rom ( name sblazerp.zip size 19999 crc 9bbe255b md5 c1d565cfa71905861619a120d4bee80e sha1 29200ce13490a0dcb146f7ccc1dbc3f7ee2daf1d )
 )
 
 game (
@@ -44429,20 +32981,6 @@ game (
 )
 
 game (
-	name "Space Bugger (set 1)"
-	year "1981"
-	developer "Game-A-Tron"
-	rom ( name sbugger.zip size 11803 crc 6d3999eb md5 3e7cb7b015df5c348b0da284dbe54e6e sha1 3d17d21727fd289fd1a0d979f2b0fb2fa50cacfe )
-)
-
-game (
-	name "Space Bugger (set 2)"
-	year "1981"
-	developer "Game-A-Tron"
-	rom ( name sbuggera.zip size 10503 crc ff44316a md5 158f0bb403fd99550773033e9c106f07 sha1 cd1284ebab71e263ab2c1fa866deec62451561f5 )
-)
-
-game (
 	name "Scandal Mahjong (Japan 890213)"
 	year "1989"
 	developer "Nichibutsu"
@@ -44471,20 +33009,6 @@ game (
 )
 
 game (
-	name "Sega Club Golf 2006 Next Tours (Rev A) (GDX-0018A)"
-	year "2006"
-	developer "Sega"
-	rom ( name scg06nt.zip size 211 crc 30de779c md5 270ebfae1a224a239e8bd18cf63b1f36 sha1 f1d05eddf7f7177ddcc86aed9ce2a972a71b8cc7 )
-)
-
-game (
-	name "Sonic Championship"
-	year "1996"
-	developer "Sega"
-	rom ( name schamp.zip size 17724718 crc 3fad7e5a md5 fc4c9e5d187dbb0cd985e4363908ae84 sha1 a3704bd9022b8bcba8e82cab2d5424975fdc6504 )
-)
-
-game (
 	name "Space Chaser"
 	year "1979"
 	developer "Taito"
@@ -44496,13 +33020,6 @@ game (
 	year "1979"
 	developer "Taito"
 	rom ( name schasercv.zip size 9322 crc 109a261a md5 91f8679248fe1d9ccf4f9ab9b77b93e4 sha1 b81dc111c9790786cf7b631e16a65bbdc6140802 )
-)
-
-game (
-	name "Super Cherry Master"
-	year "2001"
-	developer "Dyna"
-	rom ( name scherrym.zip size 65393 crc a9e96fb8 md5 e70f0f429b21fce9a97f44125a910557 sha1 6e511c98a0c12774c6d004e5830491fe0443fe0d )
 )
 
 game (
@@ -44625,13 +33142,6 @@ game (
 )
 
 game (
-	name "Scorpion (set 2)"
-	year "1982"
-	developer "Zaccaria"
-	rom ( name scorpiona.zip size 25310 crc c05d6f22 md5 7e3fd40b770b02008f0b3614ba8abca3 sha1 b97c70ff2557784009e8776572382440f533b762 )
-)
-
-game (
 	name "Scorpion (set 3)"
 	year "1982"
 	developer "Zaccaria"
@@ -44680,38 +33190,10 @@ game (
 )
 
 game (
-	name "Scramble (Karateko, French bootleg)"
-	year "1981"
-	developer "bootleg (Karateko)"
-	rom ( name scramblebf.zip size 10507 crc 3e19c751 md5 33662dc14a1db2f4c7e37a9d187db5af sha1 049c59f405652b6678677027af2c9596577709df )
-)
-
-game (
 	name "Scramble (Stern Electronics)"
 	year "1981"
 	developer "Konami (Stern Electronics license)"
 	rom ( name scrambles.zip size 11782 crc 0271e046 md5 dc406d236a9eb4aa7ad1a289c70dcfe3 sha1 10afa0348a891231a05a7c853358406555792dca )
-)
-
-game (
-	name "Screen Play (ver. 1.9)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenp1.zip size 397192 crc 2fc2eb37 md5 95e7af49fc6b6965605b66673000dfd1 sha1 856c243f3a93c1f5db05e98533b642c91c3eddea )
-)
-
-game (
-	name "Screen Play (ver. 1.9, Isle of Man)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenp2.zip size 397186 crc 5791424d md5 729bf902b72c48a5ae388141f113bce0 sha1 01e65fea0458f7421ddcde35b3d99fef5c15056f )
-)
-
-game (
-	name "Screen Play (ver. 4.0)"
-	year "1991"
-	developer "Maygay"
-	rom ( name screenpl.zip size 513560 crc 6e03cd48 md5 de391b0a7f59f341367790a8fbc970d6 sha1 49bf58a1c06c8e3504c3aee8d5f437d62146976a )
 )
 
 game (
@@ -44743,44 +33225,10 @@ game (
 )
 
 game (
-	name "Scud Race (Australia)"
-	year "1996"
-	developer "Sega"
-	rom ( name scud.zip size 63199987 crc d32af293 md5 1b5df83c9a03dfbc5f37a172f521f75e sha1 02f61f8767e0b30b16d45b77795b10b1cba83d38 )
-)
-
-game (
-	name "Scud Race (Export)"
-	year "1996"
-	developer "Sega"
-	rom ( name scuda.zip size 300212 crc 62b88b4f md5 35060ecd429bb7c9eccab497853efdd7 sha1 c5edeebbefd785b66a2bf741eb6b5168346c693b )
-)
-
-game (
 	name "Scud Hammer"
 	year "1994"
 	developer "Jaleco"
 	rom ( name scudhamm.zip size 2716298 crc 195932c9 md5 68d6bccc833528a73e88afc1211f600c sha1 876b4087fa2fd71d73419c260ebe91e75f86fcf0 )
-)
-
-game (
-	name "Scud Race (Japan)"
-	year "1996"
-	developer "Sega"
-	rom ( name scudj.zip size 52111275 crc 5ba579e3 md5 c96e296a58624325723371f9eaebb485 sha1 a2ca76439881b279ec70a12ad96cbe4527277b02 )
-)
-
-game (
-	name "Scud Race Plus (Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name scudp.zip size 8306130 crc 4fa8cc8c md5 d28621299a1eea539813b3b94c9b4aa1 sha1 b4b32034b02f20baf55df17cf93399e6d2ebfc9f )
-)
-
-game (
-	name "Super Dou Di Zhu"
-	developer "IGS"
-	rom ( name sddz.zip size 3157310 crc ef164bd4 md5 67ea99ee579c577ea004b9c3352c7396 sha1 1778aaeab284d3d503975ad7006212134ea67223 )
 )
 
 game (
@@ -44791,31 +33239,10 @@ game (
 )
 
 game (
-	name "SD Fighters (Korea)"
-	year "1996"
-	developer "SemiCom"
-	rom ( name sdfight.zip size 2085175 crc 5505567e md5 d2cb25ca81746b7e65625ae5cf718c9c sha1 0f0e20fdfdea9582edad5b3af05dead474a25d03 )
-)
-
-game (
 	name "SD Gundam Psycho Salamander no Kyoui"
 	year "1991"
 	developer "Banpresto / Bandai"
 	rom ( name sdgndmps.zip size 1492205 crc 21ef9783 md5 70ef6141c8748ed19dd38007d603a12e sha1 c9bcf42cf112266b541734945fa5dd7b99cbf89d )
-)
-
-game (
-	name "SDI - Strategic Defense Initiative (Japan, old, System 16A, FD1089B 317-0027)"
-	year "1987"
-	developer "Sega"
-	rom ( name sdi.zip size 366622 crc 558f377a md5 a60733a012c3a05cf0e53e069d138033 sha1 98a49da7b72a35b016dde057cdc9e325925adadc )
-)
-
-game (
-	name "SDI - Strategic Defense Initiative (System 16B, FD1089A 317-0028)"
-	year "1987"
-	developer "Sega"
-	rom ( name sdib.zip size 346417 crc 33614d07 md5 d344ae4318756a916a305fd35ed9e0a5 sha1 91fceca86437cff1d67f17f20494a56dbc079a2b )
 )
 
 game (
@@ -44851,13 +33278,6 @@ game (
 	year "1981"
 	developer "Taito America Corporation"
 	rom ( name sdungeon.zip size 32891 crc aab49305 md5 5e815fd4353a1c666bdb1efc0bfd0f3d sha1 20e94b8c294280bf01bdf573065575e4e3e940aa )
-)
-
-game (
-	name "Sheng Dan Wu Xian"
-	year "2002"
-	developer "IGS"
-	rom ( name sdwx.zip size 1714304 crc 422c78fa md5 72acff551f1a3c3500fbb7f8dd1523f9 sha1 e3ad6bb69b723d4123149efec76cc878f534cf55 )
 )
 
 game (
@@ -44959,13 +33379,6 @@ game (
 )
 
 game (
-	name "Secret Agent (bootleg)"
-	year "1989"
-	developer "bootleg"
-	rom ( name secretab.zip size 524052 crc 12d480f3 md5 58ea7a112c4964f36b0a0f957dd7597e sha1 af90657cbd79c8e6a769bc991720fb3a82eecdfd )
-)
-
-game (
 	name "Secret Agent (World)"
 	year "1989"
 	developer "Data East Corporation"
@@ -45008,13 +33421,6 @@ game (
 )
 
 game (
-	name "Sega Water Ski (Japan, Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name segawski.zip size 29699014 crc 8b21c179 md5 83b762146e2f128fb8e3b31f43c2c401 sha1 e48530a4e676b967abb600cb993df72f43c6438f )
-)
-
-game (
 	name "Seicross"
 	year "1984"
 	developer "Nichibutsu / Alice"
@@ -45040,13 +33446,6 @@ game (
 	year "1991"
 	developer "East Technology"
 	rom ( name selfeena.zip size 930982 crc dfa694ca md5 d798846535b5fbc98dc3ccdb7c182959 sha1 38c341a14517df2710685ffeaab41d5103e16daa )
-)
-
-game (
-	name "MuHanSeungBu (SemiCom Baseball) (Korea)"
-	year "1997"
-	developer "SemiCom"
-	rom ( name semibase.zip size 2020618 crc d21a9c65 md5 86efa50c202de62ebaf78f90c8338b71 sha1 cf9667d40a08b4300fac3d586afd101cc091ec3f )
 )
 
 game (
@@ -45113,20 +33512,6 @@ game (
 )
 
 game (
-	name "Senko No Ronde NEW ver. (Rev A) (GDL-0030A)"
-	year "2005"
-	developer "G-Rev"
-	rom ( name senko.zip size 1195 crc c63f30f3 md5 4f68985187a638ae585ca114e9ef7b61 sha1 521096beb03a3b15474d0ba7e1720d8078bc6016 )
-)
-
-game (
-	name "Senko No Ronde Special (GDL-0038)"
-	year "2006"
-	developer "G-Rev"
-	rom ( name senkosp.zip size 1195 crc 01789c6a md5 84f4168433971451503079171e3c87a0 sha1 a19b9a3dd53195d6a7823d3c29a932d43d3e85b3 )
-)
-
-game (
 	name "Senkyu (Japan, set 1)"
 	year "1995"
 	developer "Seibu Kaihatsu"
@@ -45138,19 +33523,6 @@ game (
 	year "1995"
 	developer "Seibu Kaihatsu"
 	rom ( name senkyua.zip size 378742 crc 90be5bf2 md5 58dfb2bb5bf42cc2a9667c7c396c4da7 sha1 e4e54edbea6cb3da5ce363758f9d554c17e7eb78 )
-)
-
-game (
-	name "Sente Diagnostic Cartridge"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name sentetst.zip size 9743 crc 1f2628e4 md5 dd11377d68a60831abe5fd295f98f455 sha1 c869c65e11f2a466ed0ac268aa3889ba05f701e1 )
-)
-
-game (
-	name "Seta / Visco Roulette?"
-	developer "Seta / Visco"
-	rom ( name setaroul.zip size 2668598 crc d820d07f md5 8cfd07f3b2f694cd11ce4bce29b3f9d6 sha1 9d096c9ba7eab879fba01412b2cb2a041d175c4f )
 )
 
 game (
@@ -45175,20 +33547,6 @@ game (
 )
 
 game (
-	name "Sexy Boom"
-	year "1992"
-	developer "Sang Ho Soft"
-	rom ( name sexyboom.zip size 664711 crc 40974bde md5 2e9df30e542d1174f8a639d07b08a86e sha1 025525cb0716bb4d3a90d188aaa90c935ad3f431 )
-)
-
-game (
-	name "Sexy Gal (Japan 850501 SXG 1-00)"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name sexygal.zip size 97052 crc d91b7180 md5 6dd5e57a6e9b7abd4de995926018a14b sha1 33d39c4bcb06b5892ed0e33eceb5b004b0b5ede0 )
-)
-
-game (
 	name "Sexy Parodius (ver JAA)"
 	year "1996"
 	developer "Konami"
@@ -45200,34 +33558,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sf.zip size 1153892 crc 0d76ea0e md5 09e85bad4e24755d1c29e70bff5da66b sha1 fb27aa542a13496fe81d89afa0002f3a5e28ca9d )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (World 910522)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2.zip size 3551675 crc 57aa0ffe md5 bd33f8bfe89c2c4270a398cb77545eee sha1 ad7d7527ff7b2c0b0b5e1f7acd6e4fcfda1fbd0f )
-)
-
-game (
-	name "San Francisco Rush 2049"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049.zip size 249217 crc bd1a028e md5 b73914b447f2fecd7ed9a59ee3aeceba sha1 93e606c57660b053a1f7e51d0098dda1ee0ff9e5 )
-)
-
-game (
-	name "San Francisco Rush 2049: Special Edition"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049se.zip size 272281 crc 5b59d4e2 md5 28e89bdccdffb98acda7e9a5a63631cc sha1 f6b2a2fa4943aea96c21af0c88ab5e132bc330a9 )
-)
-
-game (
-	name "San Francisco Rush 2049: Tournament Edition"
-	year "1998"
-	developer "Atari Games"
-	rom ( name sf2049te.zip size 266738 crc 40278e23 md5 4ac82d6eacdc894209a7a348c4f67b95 sha1 76718d5edda7b3955a42f36d496587eb73cc6b33 )
 )
 
 game (
@@ -45245,52 +33575,10 @@ game (
 )
 
 game (
-	name "Street Fighter II': Champion Edition (World 920313)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ce.zip size 3615435 crc 8d0ac6df md5 db9414707a2fa816b05608251784d08b sha1 f6ebbc9926859f0ce68ee911a4433ae39dca86bf )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (Japan 920513)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2cej.zip size 317134 crc cc80d137 md5 c3ba95ae0737ae4a858d4ca749e4d9d0 sha1 d4e04e51f0819eba5cf7fb36e5debad9c75def10 )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920313)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceua.zip size 216255 crc f71e13aa md5 78f8a0eda0400dbb60a9c57e5742b02f sha1 ce39f08f30ff22b9e7e83ce9d24e008565e32224 )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920513)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceub.zip size 363103 crc dad249b7 md5 ddfa2f81b96351fa5e99c0f030ec0093 sha1 6b5042d7e8a75d695a017df241ec30006c4685e7 )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (USA 920803)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2ceuc.zip size 362955 crc ccb8b5a1 md5 1c7a13b187b8e87260fd9b774a317425 sha1 a1c296a93c6b07f106c803b60c64301b1164aa9b )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2dkot2.zip size 425277 crc 7b815d54 md5 46dcab6f3878b39f6ab7de65b0db2dfd sha1 b5408ddb68ff37554d67fca9ec447ec92404ac62 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (World 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2eb.zip size 256070 crc 8abc5736 md5 ba8c3606107b9d719fdda10c146e5fa9 sha1 b3cea133c1b6a4dbf7e44d41c8c63ca70f68357a )
 )
 
 game (
@@ -45301,48 +33589,6 @@ game (
 )
 
 game (
-	name "Street Fighter II': Hyper Fighting (World 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hf.zip size 3640194 crc fe834e3b md5 aa753de798080d48044e4df1cbd2e44a sha1 d0bad63d0e4f81f59c1da149c04a7be3a2f8819d )
-)
-
-game (
-	name "Street Fighter II' Turbo: Hyper Fighting (Japan 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hfj.zip size 1176957 crc 978b0d3f md5 d46ac4450e96a202f2a822eeac3ca29c sha1 1b013ceedf1cdbf8cc05594a3aa6de8005f66817 )
-)
-
-game (
-	name "Street Fighter II': Hyper Fighting (USA 921209)"
-	year "1992"
-	developer "Capcom"
-	rom ( name sf2hfu.zip size 221040 crc 4414918c md5 50c8620191b68c35411b48878ee7776c sha1 1a25a61294ceadb1b5001ffbf431e30b785f62bc )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 911210)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2j.zip size 255151 crc 06ff1c9b md5 5db760246ca531e9dedc427dea4b924b sha1 7d14314a3945a67be907688cd662798c5821ce13 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ja.zip size 256074 crc c5fce120 md5 b61ee36c597001cf17b3292d1fbecc52 sha1 82905d405923ad523ced2e91bd25d1416b5f1e78 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (Japan 910306)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2jc.zip size 291881 crc 0763943a md5 3fe99898dcfe5553c42b691fdec7f653 sha1 b2992680acd02104edceeb28c3111b5c41158c04 )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (Xiang Long, Chinese bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -45350,24 +33596,10 @@ game (
 )
 
 game (
-	name "Street Fighter II': Champion Edition (M1, bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2m1.zip size 331505 crc 584c33f6 md5 86ba504172c3de9aa6db78add3a58560 sha1 787b1c57306fddf73fad53bcccf71689305af7b1 )
-)
-
-game (
 	name "Street Fighter II': Champion Edition (M2, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2m2.zip size 347228 crc b6b50d9d md5 e48d7263b5f7f47f98dd93f564443cc0 sha1 a661fd5cf493a7ea2fb7a1577034a42812c28d45 )
-)
-
-game (
-	name "Street Fighter II': Champion Edition (M3, bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2m3.zip size 319616 crc 28c7b30b md5 b33d1ca0c98f6030ee75fe5ffb539a4e sha1 db96b8d4ea46743930a1193821126d5b66588b3c )
 )
 
 game (
@@ -45396,13 +33628,6 @@ game (
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2m7.zip size 360936 crc 07ca3c09 md5 845efa80d7602404a7028afd3e94dd6d sha1 64006e4a342be0aef3e4a706c520b01368faa059 )
-)
-
-game (
-	name "Street Fighter II': Magic Delta Turbo (bootleg)"
-	year "1992"
-	developer "bootleg"
-	rom ( name sf2mdt.zip size 3553992 crc a4fa7d2b md5 75a4ce45cdb9af9ec586a8644de50a87 sha1 6bde7866794120ca489fbba14c06f0a354c6d22c )
 )
 
 game (
@@ -45445,55 +33670,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name sf2thndr.zip size 303854 crc 397e914c md5 0e05ce06afd0adc1ea0e9a71536a1e05 sha1 91705e6d595c3186210a589a499e5de148199c97 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910206)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ua.zip size 253615 crc 8c42bcce md5 e7edbdc4740aea0bb62f5400d0748b26 sha1 9f2a4690657f8cb741cae940bb6ccf642e5a763e )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910214)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ub.zip size 256074 crc f952565e md5 b1b10f16b83103db4610ee30a5e6613f sha1 99a735223473d8e025ae18e21c2a57f44be3c363 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910318)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ud.zip size 293176 crc d424eabb md5 a7dde65c64567ad98e8fd0b1008487fe sha1 499813bd9b4862006cdd80dbb9de00631bbc83af )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910228)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ue.zip size 279977 crc 71a2200e md5 cd124549e1f462e875e7c969302a3578 sha1 0a5849ca08f6e69102feafb2dc1e791d8ccf62c6 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910411)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2uf.zip size 189809 crc 86281160 md5 10e87910e9056399749a06523c0ca0b1 sha1 d844b03d5db16b99288bda0e086d523ade3a3d1c )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 910522)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2ui.zip size 219627 crc 84a10fa2 md5 8ae95d606903613dfb01372910db1078 sha1 5f22b26281bb8c513dad3b539e6d0d37f0828b67 )
-)
-
-game (
-	name "Street Fighter II: The World Warrior (USA 911101)"
-	year "1991"
-	developer "Capcom"
-	rom ( name sf2uk.zip size 303176 crc fc19c814 md5 36e98fa027f69e30e5c8fee021eec4ac sha1 5d3591af3991f1d1d04acf35e571bb272ef38c44 )
 )
 
 game (
@@ -45763,13 +33939,6 @@ game (
 )
 
 game (
-	name "Sonic The Fighters"
-	year "1996"
-	developer "Sega"
-	rom ( name sfight.zip size 594826 crc f7fd8354 md5 8ccf6109093669923b9bfde1af8a57ed sha1 711688e3dbf7585acc1bcae1c2ab00b3b57354d6 )
-)
-
-game (
 	name "Street Fighter III: New Generation (USA, 970204)"
 	year "1997"
 	developer "Capcom"
@@ -45833,27 +34002,6 @@ game (
 )
 
 game (
-	name "Sport Fishing 2 (UET 951106 V1.10e)"
-	year "1995"
-	developer "Sega"
-	rom ( name sfish2.zip size 517069 crc f1066706 md5 5e51ef71cc3bb8a454ee53436edef67e sha1 260b27c64de34afb3660d8189a02d92fb32c5bdf )
-)
-
-game (
-	name "Sport Fishing 2 (J 951201 V1.100)"
-	year "1995"
-	developer "Sega"
-	rom ( name sfish2j.zip size 177039 crc 449c0fca md5 327845f5315292bbf997a3cda80bc36d sha1 9d7622a43f0eb33e0b3eaa0bfe7ff7c29571d42c )
-)
-
-game (
-	name "Street Fighter (Japan) (protected)"
-	year "1987"
-	developer "Capcom"
-	rom ( name sfj.zip size 146983 crc 3d4bd67b md5 3a76e17b0046b5f268075e7b1a68fc07 sha1 7795ae44f2ed059c69a7b1d40c19a753a4fbe306 )
-)
-
-game (
 	name "Super Free Kick (set 1)"
 	year "1988"
 	developer "Haesung/HJ Corp"
@@ -45864,20 +34012,6 @@ game (
 	name "Super Free Kick (set 2)"
 	developer "Haesung"
 	rom ( name sfkicka.zip size 28745 crc fdb24cef md5 5ac2a6e9118be41874c90b92071c9571 sha1 c38b616740cd99a15dcb016814b984358d03ae4c )
-)
-
-game (
-	name "Straight Flush"
-	year "1979"
-	developer "Taito"
-	rom ( name sflush.zip size 8130 crc e7e06777 md5 e274c8ce40a72885179beaff02f9e596 sha1 ba2523baef74bf5bf0656bd638a7fbbba66962c3 )
-)
-
-game (
-	name "Street Football"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name sfootbal.zip size 47005 crc c11807d3 md5 661d9363da39bfad6cd619f756d728e8 sha1 1004c2beb15ff2072b2dc72959fe82fcf96acbb7 )
 )
 
 game (
@@ -46007,13 +34141,6 @@ game (
 )
 
 game (
-	name "San Francisco Rush: The Rock"
-	year "1996"
-	developer "Atari Games"
-	rom ( name sfrushrk.zip size 7586027 crc 9aacdca8 md5 7616a58ec6a8a63fe24c9c9336888d09 sha1 c6618711dd8b812ebff1281cb8345389755b7de0 )
-)
-
-game (
 	name "Street Fighter: The Movie (v1.12)"
 	year "1995"
 	developer "Capcom / Incredible Technologies"
@@ -46046,13 +34173,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sfu.zip size 55026 crc 4c7c1f01 md5 16b0ee257262d29ffc20add3f026dfff sha1 b2cf2dce4e709bcd8e75dad09303bd847142b652 )
-)
-
-game (
-	name "Street Fighter (US, set 2) (protected)"
-	year "1987"
-	developer "Capcom"
-	rom ( name sfua.zip size 54126 crc a297bdaf md5 c886d93a957fdb2cc78d2975e9df5e54 sha1 c4476e8e8c8984955a458ce41131f374f2060ec0 )
 )
 
 game (
@@ -46182,13 +34302,6 @@ game (
 )
 
 game (
-	name "Street Fighter Zero 3 Upper (GDL-0002)"
-	year "2001"
-	developer "Capcom"
-	rom ( name sfz3ugd.zip size 1195 crc 2017472c md5 16d1e9f2d516fe99e6de0ad421bbf54e sha1 9e2afce9e34fd37cd02b48167da6d54f0ae2bcea )
-)
-
-game (
 	name "Street Fighter Zero (Asia 950627)"
 	year "1995"
 	developer "Capcom"
@@ -46280,13 +34393,6 @@ game (
 )
 
 game (
-	name "Super Masters Golf (World?, Floppy Based, FD1094 317-0058-05d?)"
-	year "1989"
-	developer "Sega"
-	rom ( name sgmast.zip size 2803429 crc 8b5c87be md5 06a05e88cfe755e96286b834789dcea9 sha1 06bac275f0c4caf343c5d80e2a6e7a19a6d9d41f )
-)
-
-game (
 	name "Jumbo Ozaki Super Masters Golf (World, Floppy Based, FD1094 317-0058-05c)"
 	year "1989"
 	developer "Sega"
@@ -46305,20 +34411,6 @@ game (
 	year "1996"
 	developer "New Impeuropex Corp."
 	rom ( name sgsafari.zip size 345500 crc c81205c1 md5 396142505e4e6bc90694742e16c1fb6d sha1 3d182f8c7e4eea2beca410c16945e9f44f8753f2 )
-)
-
-game (
-	name "Super GT 24h"
-	year "1996"
-	developer "Jaleco"
-	rom ( name sgt24h.zip size 10507378 crc cbffb27d md5 2579fc57c370b80f53296d43498cf8de sha1 71dc9b39bb4d67656682a367b59bf613af8a0a3d )
-)
-
-game (
-	name "Sega Tetris"
-	year "1999"
-	developer "Sega"
-	rom ( name sgtetris.zip size 26064618 crc 780ce393 md5 a8e73034c9d14c1061b52c7e5b5150e4 sha1 3ca2d584ea83987f44a00c44511f968e07fae98a )
 )
 
 game (
@@ -46347,20 +34439,6 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name sgunnerj.zip size 90368 crc 4c5be069 md5 c8af00d05dee6cfd7dfa3b52a8b3e97c sha1 f226480dce694ea5735e772b64fc1fb353b729cd )
-)
-
-game (
-	name "Shackled (US)"
-	year "1986"
-	developer "Data East USA"
-	rom ( name shackled.zip size 277237 crc 45a28ff0 md5 9bd250cdae5b0a40bc4653c34e108e5b sha1 1c34a5e1383cb3fa9df92b23d2d3089d8aaba156 )
-)
-
-game (
-	name "Shadow Fighters"
-	year "1993"
-	developer "Dutech Inc."
-	rom ( name shadfgtr.zip size 981650 crc a6be8a6f md5 2990638a317d7a000f10fdf0bd3bb9cf sha1 b33ba9c7aa5bd55c7037eb20af775c724fceb308 )
 )
 
 game (
@@ -46441,13 +34519,6 @@ game (
 )
 
 game (
-	name "Super Hang-On (mini ride-on?, FD1089B 317-0034)"
-	year "1987"
-	developer "Sega"
-	rom ( name shangon1.zip size 609995 crc ed4ee755 md5 b52a841811a97a6ba2465de78e0bac28 sha1 b05c5b120a6c3a5e3c416d5c64855334de2ee336 )
-)
-
-game (
 	name "Super Hang-On (mini ride-on, Rev A, FD1089B 317-0034)"
 	year "1987"
 	developer "Sega"
@@ -46483,13 +34554,6 @@ game (
 )
 
 game (
-	name "Dengen Tenshi Taisen Janshi Shangri-la (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Marvelous Ent."
-	rom ( name shangril.zip size 94020913 crc 461e4185 md5 a9d4e74f865640a80590f9c598bbcaf1 sha1 ae7a220b9e5078bcd6553dedf17f91b4ad99bad7 )
-)
-
-game (
 	name "Shanghai - The Great Wall / Shanghai Triple Threat (JUE 950623 V1.005)"
 	year "1995"
 	developer "Sunsoft / Activision"
@@ -46497,14 +34561,14 @@ game (
 )
 
 game (
-	name "Shao-lin's Road (bootleg)"
+	name "Shao-lin's Road (set 2)"
 	year "1985"
-	developer "bootleg"
+	developer "Konami"
 	rom ( name shaolinb.zip size 26045 crc 7046acc1 md5 6f9a8438322e6edb0f5943702ac5c562 sha1 6f20ee1386ec8e204534d3bf9324cbfd781afd83 )
 )
 
 game (
-	name "Shao-lin's Road"
+	name "Shao-lin's Road (set 1)"
 	year "1985"
 	developer "Konami"
 	rom ( name shaolins.zip size 7872 crc 4738d234 md5 267baa4c4be75dc98864a2fb7ac25dbc sha1 fcbdfb763be0e8011d74794de38f35d379dfd7a0 )
@@ -46536,20 +34600,6 @@ game (
 	year "1995"
 	developer "American Alpha"
 	rom ( name sharkpye.zip size 107061 crc b8916375 md5 45a063061e10ef8a8f5438cb02497296 sha1 aa21d41e1255879ab2c4a5e88ec972e5bfa7e02d )
-)
-
-game (
-	name "Space Harrier (Rev A, 8751 315-5163A)"
-	year "1985"
-	developer "Sega"
-	rom ( name sharrier.zip size 755119 crc db78b1c2 md5 3ad5238a51d7455e4d84f475bec44f84 sha1 45247b44f4fb6d6c1e8f33cf8024ad0a564f0e79 )
-)
-
-game (
-	name "Space Harrier (8751 315-5163)"
-	year "1985"
-	developer "Sega"
-	rom ( name sharrier1.zip size 27415 crc 7ce84d71 md5 08fd260c5de8bc08e9cb55aa5ee21783 sha1 7d09dff6b9f0063e861aba16cbcd44761a858b51 )
 )
 
 game (
@@ -46592,13 +34642,6 @@ game (
 	year "1997"
 	developer "Warashi"
 	rom ( name shienryu.zip size 5083989 crc 692989eb md5 81b44f8265feb1a3572877182c3d7187 sha1 0ce84f21cbfe5be15cc2aa2e3b6c510541d96031 )
-)
-
-game (
-	name "Shikigami No Shiro II / The Castle of Shikigami II (GDL-0021)"
-	year "2003"
-	developer "Alfa System"
-	rom ( name shikgam2.zip size 1192 crc 76aa60b5 md5 8dce676a8699882dc380bb859de1f9e5 sha1 9c94efec2035966718a025265952801f05915536 )
 )
 
 game (
@@ -46669,20 +34712,6 @@ game (
 	year "1987"
 	developer "Sega"
 	rom ( name shinobi5.zip size 490390 crc 8b241929 md5 3089ae5bacb03aff5a799876cb6cd968 sha1 b4b2981a9ec3c138973a711fc22822c12b26be71 )
-)
-
-game (
-	name "Shinobi (Beta bootleg)"
-	year "1987"
-	developer "bootleg (Beta)"
-	rom ( name shinoblb.zip size 107868 crc 4f438e38 md5 9568abc407ca67cdbc40228260bfc4a5 sha1 0669c0fa5d8610eb64cc1aae6d6ee5207f7a782c )
-)
-
-game (
-	name "Shinobi (Datsu bootleg)"
-	year "1987"
-	developer "bootleg (Datsu)"
-	rom ( name shinobld.zip size 245445 crc 87c4ac23 md5 96bb42aa4f967494c16165a0a58e9b9c sha1 79c8b8f553137ce1d06392b95723ae916ab79870 )
 )
 
 game (
@@ -46791,20 +34820,6 @@ game (
 )
 
 game (
-	name "Shooting Gallery"
-	year "1984"
-	developer "Seatongrove Ltd (Zaccaria license)"
-	rom ( name shootgal.zip size 18531 crc 16b5a427 md5 0af2f4fa102d9def57b9251fa318c84e sha1 7631ec033169132d0bfab8d7687a464289e394b5 )
-)
-
-game (
-	name "Shootout Pool"
-	year "2001"
-	developer "Sega"
-	rom ( name shootopl.zip size 8109765 crc 6552cef5 md5 302aefbec4852cce10dccde38c1ba168 sha1 5fe22cfc464bfc02a5903316f32fb61007d44852 )
-)
-
-game (
 	name "Shoot Out (US)"
 	year "1985"
 	developer "Data East USA"
@@ -46823,13 +34838,6 @@ game (
 	year "1985"
 	developer "Data East Corporation"
 	rom ( name shootoutj.zip size 59862 crc af8dde7f md5 5889695da6cd5690857433191756e961 sha1 1367f1bde6f995104de8e93d24541cea9a365ac2 )
-)
-
-game (
-	name "Shootout Pool (JPN, USA, KOR, AUS) / Shootout Pool Prize (EXP)"
-	year "2001"
-	developer "Sega"
-	rom ( name shootpl.zip size 6761970 crc 64c53783 md5 c2856bced8fded2f61586173dc8ee699 sha1 377767930bb6746b8c2c9007324dfa187230b6ac )
 )
 
 game (
@@ -46865,33 +34873,6 @@ game (
 	year "2000"
 	developer "Astro Corp."
 	rom ( name showhand.zip size 625050 crc dd38aa67 md5 7ef3866adb91b90400a947d92a7bb64d sha1 77f71905774a9a8bfb8d08972b32927972a028e8 )
-)
-
-game (
-	name "Sea Hunter Penguin"
-	year "1995"
-	developer "WSAC Systems?"
-	rom ( name shpeng.zip size 340265 crc 93e590c0 md5 189a7d8d6f0f020c55f096ab4b409f4c sha1 f48f784824910c58e36e37c0e111086a432fc0e5 )
-)
-
-game (
-	name "Shrike Avenger (prototype)"
-	developer "Bally/Sente"
-	rom ( name shrike.zip size 92846 crc c4ae135a md5 d8aa70cc6abdc529741cfa4533d6ec61 sha1 14ec599e7318f0c10cff76d158a2826fb2b924a0 )
-)
-
-game (
-	name "Shooting Master (8751 315-5159)"
-	year "1985"
-	developer "Sega"
-	rom ( name shtngmst.zip size 167299 crc 4ae2b6b6 md5 bf05349f3fb91043668fba9e75dd2fc1 sha1 ee4a2f71548ac1112e415140d6f7a6b15bbc4eec )
-)
-
-game (
-	name "Shooting Master (EVG, 8751 315-5159a)"
-	year "1985"
-	developer "Sega / EVG"
-	rom ( name shtngmste.zip size 168288 crc eab105ca md5 51dce6f4e1b69bff1ba4125605ee514d sha1 934d7c6cacdc0c787b4b381ce2aa177520a92d26 )
 )
 
 game (
@@ -46958,13 +34939,6 @@ game (
 )
 
 game (
-	name "Super Invader Attack"
-	year "1978"
-	developer "Zelco / Zaccaria"
-	rom ( name sia2650.zip size 5990 crc 597f8c91 md5 da58ca08603f2419e783fea0843193e0 sha1 bf15e3b25874e22dc3efaf8130213ad08705385b )
-)
-
-game (
 	name "Sichuan II (hack, set 1)"
 	year "1989"
 	developer "hack"
@@ -47028,13 +35002,6 @@ game (
 )
 
 game (
-	name "Side Pocket (World)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name sidepckt.zip size 89366 crc 38aa9b23 md5 81db4eb6bf15fe908e58d621e69bfc4a sha1 d6f6fe1dc698b311285a644082fd6e4c0dffb065 )
-)
-
-game (
 	name "Side Pocket (bootleg)"
 	year "1986"
 	developer "bootleg"
@@ -47042,23 +35009,10 @@ game (
 )
 
 game (
-	name "Side Pocket (Japan)"
-	year "1986"
-	developer "Data East Corporation"
-	rom ( name sidepcktj.zip size 44298 crc d92f44ae md5 48d591c110f4c9e59dd53031ce2db788 sha1 c02790dcbcdf6e49b2b39111fe87a416d75d6b97 )
-)
-
-game (
 	name "Side Track"
 	year "1979"
 	developer "Exidy"
 	rom ( name sidetrac.zip size 5513 crc 8eb05ec9 md5 57fb87948a02fea679ab2caba525ebc3 sha1 5d6c27a9ae485586d0f6995d531fc9b3d7a0f358 )
-)
-
-game (
-	name "Sidewinder"
-	developer "ACE"
-	rom ( name sidewndr.zip size 9853 crc 7237a0ae md5 6b5994c9024c24d8a5c092c6d930f5b8 sha1 2b00ad1010d2498ff167f21ada1bf67741e4115b )
 )
 
 game (
@@ -47256,59 +35210,10 @@ game (
 )
 
 game (
-	name "Sukeban Jansi Ryuko (set 2, System 16B, FD1089B 317-5021)"
-	year "1988"
-	developer "White Board"
-	rom ( name sjryuko.zip size 383635 crc 7ee5f1ad md5 425d150e3b3d0a6da11d0046c5605cb8 sha1 39f19483527ae8431717409c1193f99d2423c339 )
-)
-
-game (
-	name "Sukeban Jansi Ryuko (set 1, System 16A, FD1089B 317-5021)"
-	year "1987"
-	developer "White Board"
-	rom ( name sjryuko1.zip size 142741 crc df5140fa md5 db5d33989fc76a664bebf1443fb1e5bb sha1 a9e889883e0048dff7ab5352f5487a386076e6a3 )
-)
-
-game (
 	name "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)"
 	year "1988"
 	developer "hack"
-	rom ( name skatekds.zip size 37242 crc 9eee7efb md5 6002465041f5fc1774ad0d3d9232bc12 sha1 9285f171c57602b12a328482f3cebf5c5cd5a855 )
-)
-
-game (
-	name "Skat TV"
-	year "1994"
-	developer "ADP"
-	rom ( name skattv.zip size 137306 crc 9448e1fa md5 c83b5ae9d2cf37f8c7d1ad38f2f372b2 sha1 9148dfac3a6b205e722fd078a3899d6a32566b95 )
-)
-
-game (
-	name "Skat TV (version TS3)"
-	year "1995"
-	developer "ADP"
-	rom ( name skattva.zip size 137199 crc d6dc5c57 md5 edad2c55d4bf158ef3b87816aa269ab5 sha1 edc06a91a3cf341a876cd5db67e2bdbcb9aa4071 )
-)
-
-game (
-	name "Skeet Shot"
-	year "1991"
-	developer "Dynamo"
-	rom ( name skeetsht.zip size 258354 crc 4b061c35 md5 23e092e8972044acf3924e08a93e0a65 sha1 93e0669bb83b0b7c4665e7da7a286fdea02b5598 )
-)
-
-game (
-	name "Skelagon"
-	year "1983"
-	developer "Nichibutsu USA"
-	rom ( name skelagon.zip size 24310 crc 60105434 md5 87ebb9dd1f382c5163c7c7ad9e5cae3a sha1 c40b5c83ccb8bc659a0daf947e89f28f68f28f52 )
-)
-
-game (
-	name "Ski Champ"
-	year "1998"
-	developer "Sega"
-	rom ( name skichamp.zip size 62065774 crc abb7da9e md5 56e9b8e6d467483191f1c9f9eb077d5c sha1 786a0ae9aa7de1712db709dc3827c09bf2a1e687 )
+	rom ( name skatekds.zip size 18055 crc 8dd4db53 md5 8faf7369fc714bb9a9a37132118bb60a sha1 617f8755412bb8a33f3db16ac220438bde94d105 )
 )
 
 game (
@@ -47326,38 +35231,10 @@ game (
 )
 
 game (
-	name "Skill Trek (v1.1)"
-	year "1990"
-	developer "Barcrest"
-	rom ( name skiltrek.zip size 540798 crc 0659b47a md5 7e2dc3449076fe7a1dd331c59b105d02 sha1 97510dee4616adecbc33316d090b0c2535b35a1c )
-)
-
-game (
 	name "Skimaxx"
 	year "1996"
 	developer "Kyle Hodgetts / ICE"
 	rom ( name skimaxx.zip size 3208270 crc ea532447 md5 ab34b55b17aac77ece11589085c3d624 sha1 48733de55503ddf0ae78fdbfbe6880adf87f806d )
-)
-
-game (
-	name "The Irem Skins Game (US set 1)"
-	year "1992"
-	developer "Irem America"
-	rom ( name skingame.zip size 199014 crc 81f8be86 md5 94eb6da53658dafbae837c5ae425b2a3 sha1 dfcd728ab3f176ce5db8b8359616e64e78b00535 )
-)
-
-game (
-	name "The Irem Skins Game (US set 2)"
-	year "1992"
-	developer "Irem America"
-	rom ( name skingame2.zip size 198907 crc b0f21e80 md5 0f50d8d340e62e246d92de07dac78c97 sha1 a6b0ebf66fe7e8f48880ace626cad102053f3226 )
-)
-
-game (
-	name "Sega Ski Super G"
-	year "1996"
-	developer "Sega"
-	rom ( name skisuprg.zip size 17510173 crc c6ccea7a md5 b1d6181f1b452456e969789047279ec0 sha1 1e84d1df1e40126f868bc4db1e1ae651654063a8 )
 )
 
 game (
@@ -47459,13 +35336,6 @@ game (
 )
 
 game (
-	name "Sky Chuter"
-	year "1980"
-	developer "Irem"
-	rom ( name skychut.zip size 8246 crc a35dc6cc md5 ca48fe97c53334a1cb8b0c5d2f643ec6 sha1 71f0b130ae87ad686e9283031bf81e5f4de0ae5c )
-)
-
-game (
 	name "Sky Diver"
 	year "1978"
 	developer "Atari"
@@ -47564,13 +35434,6 @@ game (
 )
 
 game (
-	name "Sky Robo"
-	year "1989"
-	developer "Nichibutsu"
-	rom ( name skyrobo.zip size 484718 crc c5afe4c9 md5 31f9115a4be4700f83c763ca185e1e85 sha1 219ba11bbc0b1ba8ae26f31148850b4ed74551e8 )
-)
-
-game (
 	name "Sky Shark (US)"
 	year "1987"
 	developer "Toaplan / Taito America Corporation (Romstar license)"
@@ -47596,13 +35459,6 @@ game (
 	year "1988"
 	developer "Alpha Denshi Co. (SNK of America/Romstar license)"
 	rom ( name skysoldr.zip size 966546 crc 81a6420d md5 9a82508db60da55e1641a9ba1b4dc1c6 sha1 de41344198b722307a3b448ba01d9c3d41cb0516 )
-)
-
-game (
-	name "Sky Target"
-	year "1995"
-	developer "Sega"
-	rom ( name skytargt.zip size 22544937 crc 7bdd1c30 md5 25acb1bd2a53d0e778b6b5f756b16f3e sha1 915c442bde120bd9f5030dde7a8a2a1df8dfb8d5 )
 )
 
 game (
@@ -47634,31 +35490,10 @@ game (
 )
 
 game (
-	name "Saturday Night Slam Masters (World 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name slammast.zip size 6588432 crc eaac25c5 md5 2469cc51ea42952fd4338b38cc2028cf sha1 19d6bbeaf734d6823dc40759a45c49c9e1287bd3 )
-)
-
-game (
-	name "Saturday Night Slam Masters (USA 930713)"
-	year "1993"
-	developer "Capcom"
-	rom ( name slammastu.zip size 367604 crc 18415bad md5 a538889c3c6caf88d57d824e2fc37c83 sha1 a28fb9c1604ceabe61df6ec9ae18ba8809132a96 )
-)
-
-game (
 	name "Slap Fight (Japan set 1)"
 	year "1986"
 	developer "Toaplan / Taito"
 	rom ( name slapfigh.zip size 43094 crc c53d6dc0 md5 e3ca44c8ec86c76bbf36c3ec41521b13 sha1 20ba64a2d39bbca2001291affe09158667dfdf85 )
-)
-
-game (
-	name "Slap Fight (Japan set 2)"
-	year "1986"
-	developer "Toaplan / Taito"
-	rom ( name slapfigha.zip size 43518 crc 9f465666 md5 e73fae74545c776e1856b6df1d780ae2 sha1 99deab316d27236c748cc44f7bb12ccc829c2ceb )
 )
 
 game (
@@ -47687,20 +35522,6 @@ game (
 	year "1994"
 	developer "Taito Corporation"
 	rom ( name slapshot.zip size 2003048 crc c057d975 md5 a74b79e6f56a15c497a678e58ba362f4 sha1 c9c50af42a70434847898e9982cf48ba58cc7941 )
-)
-
-game (
-	name "Slashout (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name slasho.zip size 108744673 crc da595d7f md5 7546dc42ad62891b619ee1a9dbdefdb1 sha1 de9960a2635b26ba74bc2d16464182b7c9572d66 )
-)
-
-game (
-	name "Slashout (GDS-0004)"
-	year "2000"
-	developer "Sega"
-	rom ( name slashout.zip size 1195 crc a4171d27 md5 3c3d3468469b81af140b4450186a8050 sha1 daa1a2778dbb729ae11e130359a5ac130e39261f )
 )
 
 game (
@@ -47753,13 +35574,6 @@ game (
 )
 
 game (
-	name "Sliver"
-	year "1996"
-	developer "Hollow Corp"
-	rom ( name sliver.zip size 15501022 crc bfedd29a md5 b42445d774b2363ce4489831904bd30d sha1 0a7166de4c540469039e4c8212620faa6624acca )
-)
-
-game (
 	name "Slam Dunk (ver JAA 1993 10.8)"
 	year "1993"
 	developer "Konami"
@@ -47781,31 +35595,10 @@ game (
 )
 
 game (
-	name "Slot Carnival"
-	year "1985"
-	developer "Wing Co., Ltd."
-	rom ( name slotcarn.zip size 32675 crc 28110273 md5 fcefc2d4c7dde231c491389901472a44 sha1 4437976d79bb6b707c89a6845dc3ece2365823b4 )
-)
-
-game (
 	name "Slots (Dutch, Game Card 95-750-368)"
 	year "1995"
 	developer "BFM/ELAM"
 	rom ( name slotsnl.zip size 82191 crc f12224e9 md5 f654483668351bf2f7b6a69fb6723522 sha1 972abc091f31a02dffa3212ec38f947900bfe0e6 )
-)
-
-game (
-	name "Mahjong Shuang Long Qiang Zhu 2"
-	year "1998"
-	developer "IGS"
-	rom ( name slqz2.zip size 1308969 crc 61a93dd0 md5 5e1851605d5574d5bdaf146d1e7bd079 sha1 abc60a4903b455ad9a5c1c3e4c7cb568b9694b2c )
-)
-
-game (
-	name "Solar Assault (ver UAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name slrasslt.zip size 10560028 crc 769a6f45 md5 0fe8d328224d3c5a46a3e51621491600 sha1 d581aa46f936f8a863075075dc20d50e99ed76ae )
 )
 
 game (
@@ -47841,13 +35634,6 @@ game (
 	year "1989"
 	developer "Data East USA"
 	rom ( name slyspy2.zip size 16177 crc 0f1c5204 md5 67d69dc66080a5dfea02afe70081a253 sha1 a5ea0755c2c25d517e535439ac4c6de1113e582e )
-)
-
-game (
-	name "Sega Marine Fishing"
-	year "2000"
-	developer "Sega"
-	rom ( name smarinef.zip size 28015943 crc 3c86d490 md5 12462705bceada0b7c23c094b7b22763 sha1 1febc101c3c3261cfeaf8daac9419167438da1ee )
 )
 
 game (
@@ -47911,13 +35697,6 @@ game (
 	year "1984"
 	developer "Nintendo"
 	rom ( name smgolf.zip size 31977 crc 7525673e md5 511dd9d50573a6c2e0672b420eef0952 sha1 da7890ebaadaf8f265208ce2643c16b39a2463b5 )
-)
-
-game (
-	name "Vs. Stroke _ Match Golf (Men Version, set 2)"
-	year "1985"
-	developer "Nintendo"
-	rom ( name smgolfb.zip size 28043 crc 724a48dd md5 0d360b0a71c96ab68e8b2631b72416f3 sha1 77efba92d2f16c002871382bd5675bb5676ec3c4 )
 )
 
 game (
@@ -47991,20 +35770,6 @@ game (
 )
 
 game (
-	name "Super Major League (U 960108 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name smleague.zip size 8680479 crc 1ec683cf md5 dadde40488d9791b3e766a3998011e1b sha1 f537492ae875852e453d2ee2e0fc10f823aef7e3 )
-)
-
-game (
-	name "Super Major League '99"
-	year "1999"
-	developer "Sega"
-	rom ( name smlg99.zip size 105684056 crc d0c9781a md5 24886ce6a46a07b40f9a45cdd1415f21 sha1 1336a8537cb1e815a569ad4d975fc71202281d26 )
-)
-
-game (
 	name "Super Moon Cresta"
 	developer "Nichibutsu (Gremlin license)"
 	rom ( name smooncrs.zip size 14321 crc 80d05037 md5 d3f26f133777ecac8b4d3ec55c065acd sha1 eb6af4c28766c7bf23b0bd759d14cbd7c0ffa396 )
@@ -48022,27 +35787,6 @@ game (
 	year "1996"
 	developer "Subsino"
 	rom ( name smoto20.zip size 162945 crc 0864f809 md5 41ee50497e612a65645accedac4b28fa sha1 9fbc75cbf8ad5a8bc06f277f0f1412726ed623a4 )
-)
-
-game (
-	name "HI-LO Double Up Joker Poker"
-	year "1983"
-	developer "SMS Manufacturing Corp."
-	rom ( name smshilo.zip size 5524 crc abeea288 md5 f7de86aed3b9ee2399b740754c67c4b3 sha1 4ac043cbd966608aae71d4d7724a308994840f04 )
-)
-
-game (
-	name "Snake Pit"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name snakepit.zip size 47841 crc c80ebdf2 md5 e417dfa224b1616022e24a8aa01a242d sha1 d42a855cdd14396e58a6c80197b7942557140b9c )
-)
-
-game (
-	name "Snacks'n Jaxson"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name snakjack.zip size 59038 crc c5beec9a md5 59d0aa1101542d25ba5f2a8c51f6363e sha1 9ddee21b0c7b433db72b035a6729494e229ae0bd )
 )
 
 game (
@@ -48076,22 +35820,8 @@ game (
 game (
 	name "Snooker 10 (Ver 1.11)"
 	year "1998"
-	developer "Sandii&apos;"
+	developer "Sandii'"
 	rom ( name snookr10.zip size 143682 crc a63909f8 md5 d3f6a427f840aa1d277fee5a2f14c7c1 sha1 153eef5a9f7009290de84c79545babf6a50858a1 )
-)
-
-game (
-	name "Snow Board Championship (Version 2.1)"
-	year "1996"
-	developer "Gaelco"
-	rom ( name snowboar.zip size 5512634 crc 8c3794c0 md5 38bb05bb1a2c87567470f44f94d68959 sha1 21eb0ad71afe4f16edecca74582f3995da49d578 )
-)
-
-game (
-	name "Snow Board Championship (Version 2.0)"
-	year "1996"
-	developer "Gaelco"
-	rom ( name snowboara.zip size 6416772 crc e797ec70 md5 34353e315def451123da1c1f898a4288 sha1 7c30d4494e70cab9a80be7aab876e4df86a05e5d )
 )
 
 game (
@@ -48106,13 +35836,6 @@ game (
 	year "1990"
 	developer "Toaplan"
 	rom ( name snowbros.zip size 289681 crc af8a4129 md5 216801a573f1a29d3a051af3ae4e6651 sha1 c3bdfa5acd020f201cdd17a8466e3a55074043c7 )
-)
-
-game (
-	name "Snow Brothers 3 - Magical Adventure"
-	year "2002"
-	developer "Syrmex"
-	rom ( name snowbros3.zip size 2094016 crc b351a896 md5 f7c9f7d6856e0e7c6ea252e06341890a sha1 ef2d4ed4ce58f46d72e72f3df2ad3c99b91f2be6 )
 )
 
 game (
@@ -48172,12 +35895,6 @@ game (
 )
 
 game (
-	name "Soccer New (Italian)"
-	developer "bootleg"
-	rom ( name soccernw.zip size 49540 crc 340b609e md5 1c736af84c6eaf8ff9504492394f8421 sha1 c94315b4286e6dda7fd3b2932fdbda32437d0c86 )
-)
-
-game (
 	name "Soccer Superstars (ver EAA)"
 	year "1994"
 	developer "Konami"
@@ -48203,13 +35920,6 @@ game (
 	year "1994"
 	developer "Konami"
 	rom ( name soccerssja.zip size 354693 crc 28c3acdf md5 0604c903626657d1e0b416c1cb58250e sha1 584be12f91e167aa660a279a4b6fcc5ecf59d463 )
-)
-
-game (
-	name "Sogeki (ver JAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name sogeki.zip size 1239 crc e75fd9f6 md5 4188b6b4adfa8bf4f5ee374cde722650 sha1 a2daea54f96d0a74213496698c32414ec11807d0 )
 )
 
 game (
@@ -48402,27 +36112,6 @@ game (
 )
 
 game (
-	name "Soul Calibur II (SC21 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name soulcl2a.zip size 2730555 crc bf335271 md5 e358acd24fc75fc42deb66716dc83bd2 sha1 e92c519d4a691af96a165524757b5be82f0ab6ad )
-)
-
-game (
-	name "Soul Calibur II (SC23 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name soulclb2.zip size 2730804 crc 7a28f690 md5 b5bfdaa0d3bd214ce6229b06930ac7a6 sha1 1ab73b88d60158486ada1b47796841e2f0b27df7 )
-)
-
-game (
-	name "Soul Calibur III (SC31001-NA-A)"
-	year "2005"
-	developer "Namco"
-	rom ( name soulclb3.zip size 2937770 crc ddeb47f1 md5 408ea5fbea08cf8eb02319b357f4b0b8 sha1 21d81dfe4a2babf93b1f3d2ddfdda3d2d899e5cc )
-)
-
-game (
 	name "Soul Calibur (SOC14/VER.C)"
 	year "1998"
 	developer "Namco"
@@ -48507,38 +36196,10 @@ game (
 )
 
 game (
-	name "Space Beam"
-	year "1979"
-	developer "Irem"
-	rom ( name spacbeam.zip size 5711 crc 811b2c2a md5 f82b8431d4c759952a53efd18d47635d sha1 53026a5e0d6613c0e2447f72d8c1b095d3af7c4c )
-)
-
-game (
 	name "Space Duel"
 	year "1980"
 	developer "Atari"
 	rom ( name spacduel.zip size 20161 crc a74ef564 md5 efbb96330ea51f5d317ee3addd4b3e8f sha1 581b30a1738f63bf2c8338d21cd20660d4f48ecf )
-)
-
-game (
-	name "Space Ace (US Rev. A)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceaa.zip size 3752 crc dd706631 md5 8b21150f03bbe29a7b3e0b3adf9e366b sha1 66149ccca44efc9ea45ae50f6db07730f4e1057b )
-)
-
-game (
-	name "Space Ace (US Rev. A2)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceaa2.zip size 3760 crc 1500bd19 md5 0d42e4b788f2a783c20c950587f8fad9 sha1 648028a31d8155bff712c43effbfc2e93cb49554 )
-)
-
-game (
-	name "Space Ace (US Rev. A3)"
-	year "1983"
-	developer "Cinematronics"
-	rom ( name spaceace.zip size 26055 crc 9f7a7ec5 md5 fd076c8fda71a16b04fe59095e573741 sha1 36e3085e22ce09e66eabc5831e5d5ed21bebfea7 )
 )
 
 game (
@@ -48588,20 +36249,6 @@ game (
 	year "1980"
 	developer "Nintendo (Fortrek license)"
 	rom ( name spacedem.zip size 15383 crc bc26f5bb md5 225cce8a44fad8a6b25b7668fc401697 sha1 ed3900eecc1beeae5a8b94c3516fccb9a49c7a6b )
-)
-
-game (
-	name "Space Invaders DX (US, v2.1)"
-	year "1994"
-	developer "Taito Corporation"
-	rom ( name spacedx.zip size 530613 crc 4d8b0176 md5 ec93c383cea9e6e9ad496bd3931a1d99 sha1 a679c33fd0e56e9a7319dcfeb0de14e1e83b9374 )
-)
-
-game (
-	name "Space Invaders DX (Japan, v2.1)"
-	year "1994"
-	developer "Taito Corporation"
-	rom ( name spacedxj.zip size 33598 crc 303cfc30 md5 2efce96351cde72b3b5deeed47c9d718 sha1 4fbfc2ec082267b0ebde7536708f03a1ba1dccdc )
 )
 
 game (
@@ -48661,20 +36308,6 @@ game (
 )
 
 game (
-	name "Space Fortress (Zaccaria)"
-	year "1981"
-	developer "Cinematronics (Zaccaria license)"
-	rom ( name spaceftr.zip size 7223 crc 23286c41 md5 01c9737834be7bec1583ecdb93b36ca0 sha1 dd97799cfe4b7dac3c0e61ffc3dfcfe7ca0788ac )
-)
-
-game (
-	name "Space Guerrilla"
-	year "1979"
-	developer "Omori"
-	rom ( name spaceg.zip size 9735 crc 1e87b374 md5 4b4996fd20757397f9988d231d4399b5 sha1 8c4728c34d0fe71b3e060a84cad25c22e95deb6d )
-)
-
-game (
 	name "Space Gun (World)"
 	year "1990"
 	developer "Taito Corporation Japan"
@@ -48682,38 +36315,10 @@ game (
 )
 
 game (
-	name "Space Intruder"
-	year "1980"
-	developer "Shoei"
-	rom ( name spaceint.zip size 5365 crc f37eca0f md5 a4d22f488544b68474a3ed2630651033 sha1 d5df2540c7193d222412e521d5a0e7602ff5ec5d )
-)
-
-game (
-	name "Space Intruder (Japan)"
-	year "1980"
-	developer "Shoei"
-	rom ( name spaceintj.zip size 5384 crc 7279b7cd md5 8b98469a8d045668c0daf492f45acdf5 sha1 7fd61629b7ddb5d61652756a75aa1ad2b0e6fada )
-)
-
-game (
-	name "Space Launcher"
-	year "1979"
-	developer "Nintendo"
-	rom ( name spacelnc.zip size 7975 crc 4aa2c5d7 md5 4a086eae4856fc818aa59568f16d9d51 sha1 080db2c18c249a7a4a6948e5231d8bc5d240d009 )
-)
-
-game (
 	name "Space Empire (bootleg)"
 	year "1980"
 	developer "bootleg"
 	rom ( name spacempr.zip size 10632 crc eb28d03c md5 fc895a8fac0640f00b091700402c5e2e sha1 4ac4048f257b4377ad60d4359ad39fcd6764682e )
-)
-
-game (
-	name "Space Odyssey (version 2)"
-	year "1981"
-	developer "Sega"
-	rom ( name spaceod.zip size 39895 crc 2b6e33cd md5 d369ad29c3790e31bfc7604feaa1847a sha1 5535f92d7319d7f375dd483d7b44b185b6cadfd2 )
 )
 
 game (
@@ -48728,13 +36333,6 @@ game (
 	year "1979"
 	developer "SNK (Zilec Games license?)"
 	rom ( name spaceph.zip size 9711 crc eaed1fb5 md5 c003d7492228bd7437ab6b51199a123a sha1 c18506b1cfb9abe80c98805e4fa1254506acfee4 )
-)
-
-game (
-	name "Space Pirates v2.2"
-	year "1992"
-	developer "American Laser Games"
-	rom ( name spacepir.zip size 62764 crc 95c004d7 md5 8c52b61539b3b0aea3fdfafed4c08021 sha1 7e456886643a87cb403e482446305b38e2a7719e )
 )
 
 game (
@@ -48756,20 +36354,6 @@ game (
 	year "1981"
 	developer "Taito Corporation"
 	rom ( name spaceskr.zip size 30970 crc 8fc32d74 md5 1eaa8d339092a3b101d9eb83a98e8f3a sha1 39a22605b050c18449b0db76ddd7e16f49d148fd )
-)
-
-game (
-	name "Space Trek (upright)"
-	year "1980"
-	developer "Sega"
-	rom ( name spacetrk.zip size 14213 crc d350ef13 md5 86b978925bc5192b18122caa4bf96bb7 sha1 88be756e0bb9b5ccdf48723ab95bed61c388b689 )
-)
-
-game (
-	name "Space Trek (cocktail)"
-	year "1980"
-	developer "Sega"
-	rom ( name spacetrkc.zip size 13917 crc aff9c7f0 md5 528f535d7e1daa01368959709f504fa5 sha1 92b91e4419c5f30a2df12d5384115f63cd1bc995 )
 )
 
 game (
@@ -48836,31 +36420,10 @@ game (
 )
 
 game (
-	name "Super Pang (World 900914, bootleg)"
-	year "1990"
-	developer "bootleg"
-	rom ( name spangbl.zip size 662617 crc d26df448 md5 142744ff0b0b63f7ac3d19de2fbb765c sha1 382c018931f8db7ef780cea80bba09d839650e50 )
-)
-
-game (
 	name "Super Pang (Japan 901023)"
 	year "1990"
 	developer "Mitchell"
 	rom ( name spangj.zip size 450706 crc 235e57da md5 27b98f44e757eafdf3ec2877a7d0d99e sha1 737c2c5ecb8d7dd778914771248ea84ff76dadfe )
-)
-
-game (
-	name "Spark Man (v 2.0, set 1)"
-	year "1989"
-	developer "SunA"
-	rom ( name sparkman.zip size 314033 crc 9aaa49f6 md5 cb904ce05a2b5d3836da7c3f184ef1ff sha1 11afa4b324ffd50db29cbdc82c1590436b56390b )
-)
-
-game (
-	name "Spark Man (v 2.0, set 2)"
-	year "1989"
-	developer "SunA"
-	rom ( name sparkmana.zip size 22549 crc 566484d1 md5 643146580e1cf7b48d5952aa337223d7 sha1 f4bc757400982376e719d3b7882d751eda913482 )
 )
 
 game (
@@ -48882,13 +36445,6 @@ game (
 	year "1984"
 	developer "Sega"
 	rom ( name spatter.zip size 81222 crc 1c3a0dec md5 8519100ce764326793b952df8695d1c6 sha1 0ddab60b643d8967e48ca687994927603813a87d )
-)
-
-game (
-	name "Spawn (JPN, USA, EUR, ASI, AUS)"
-	year "1999"
-	developer "Capcom"
-	rom ( name spawn.zip size 52057228 crc 5aae7c89 md5 9ed07253bd26bd92e72bbf35b5a981ec sha1 bf06e8d236c6fe77eee5eb21ecb497ccc523af69 )
 )
 
 game (
@@ -48961,13 +36517,6 @@ game (
 )
 
 game (
-	name "Special Forces II"
-	year "1985"
-	developer "Senko Industries (Magic Eletronics Inc. license)"
-	rom ( name spcfrcii.zip size 20421 crc b47f130b md5 59c93603f7967c781f17fe3673bce09c sha1 ae0a26b76e98bf5bc150e5bfeef278aea7678695 )
-)
-
-game (
 	name "Space Invaders '95: The Attack Of Lunar Loonies (Ver 2.5O 1995/06/14)"
 	year "1995"
 	developer "Taito Corporation Japan"
@@ -49003,41 +36552,6 @@ game (
 )
 
 game (
-	name "Special Forces"
-	year "1985"
-	developer "Senko Industries (Magic Eletronics Inc. license)"
-	rom ( name spclforc.zip size 20459 crc c3c13324 md5 3d3502ed841f7afe9aac0257b7152512 sha1 6e185580a6e08ca8c839fc609c946b5974df7763 )
-)
-
-game (
-	name "Space Lords (rev C)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclords.zip size 4227934 crc 159fe801 md5 d798b772501efada2325324d42ed4a12 sha1 9b4546b6aeef5d5f3791023b8109747bc3ac40ee )
-)
-
-game (
-	name "Space Lords (rev A)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsa.zip size 3779363 crc 1f5c25de md5 6dce056a6cb1a8430eaf5f03c519d457 sha1 8fc6404f3944cbfd7ef9127c1e30dcf8624a3c45 )
-)
-
-game (
-	name "Space Lords (rev B)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsb.zip size 165183 crc fbc64dbf md5 964c718ea807d24335f238f45eb2aefa sha1 3d3ece5b6f114d7e70c2f982f9a42e43b11ca535 )
-)
-
-game (
-	name "Space Lords (rev A, German)"
-	year "1992"
-	developer "Atari Games"
-	rom ( name spclordsg.zip size 3779583 crc 663d876f md5 2b191ab58bf6e71ec1ad8a99d19d6baa sha1 7abe5b5d30af1cf015619f7f27d4f0402efdace0 )
-)
-
-game (
 	name "Space Position (Japan)"
 	year "1986"
 	developer "Sega / Nasco"
@@ -49062,13 +36576,6 @@ game (
 	year "1984"
 	developer "Stern Electronics"
 	rom ( name spdcoin.zip size 10375 crc a09ea6f5 md5 60cc34a3e894b260b7d238bc6ae22e0c sha1 7500f787ab08cffcc6ba30d6f54be36c219318e9 )
-)
-
-game (
-	name "Super Dodge Ball (US)"
-	year "1987"
-	developer "Technos Japan"
-	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
 )
 
 game (
@@ -49121,20 +36628,6 @@ game (
 )
 
 game (
-	name "Speed Freak"
-	year "1979"
-	developer "Vectorbeam"
-	rom ( name speedfrk.zip size 8037 crc 6c85d98c md5 5c7138d12b40d351cfe9dec62d7b5d3c sha1 b5df4232b3a6bfe54272aeb58a643557222f4632 )
-)
-
-game (
-	name "Speed Racer"
-	year "1995"
-	developer "Namco"
-	rom ( name speedrcr.zip size 9287692 crc eba41560 md5 943d9ad476028ef62bebe04f516b2f7d sha1 d482c59d1f2b4df647e9f365fbfd407f7f68178e )
-)
-
-game (
 	name "Speed Spin"
 	year "1994"
 	developer "TCH"
@@ -49153,19 +36646,6 @@ game (
 	year "1994"
 	developer "Seta"
 	rom ( name speglsht.zip size 3383092 crc 6e79fdfe md5 95d0d2fc3a17549b628961237717215c sha1 773ea02919112f086112d16b787499c167765565 )
-)
-
-game (
-	name "Spellbound"
-	developer "ACE"
-	rom ( name spellbnd.zip size 9653 crc be68977d md5 4f01e3b4aaf055f4e72924b11fc69d6e sha1 c557e1406ca003d78c2e0f133d739a872411e59a )
-)
-
-game (
-	name "Spelunker II"
-	year "1986"
-	developer "Irem (licensed from Broderbund)"
-	rom ( name spelunk2.zip size 136512 crc 1d55ade1 md5 f86b5da1428876751fd4058baaf27fff sha1 7037d6dc98ac44b459618c68681e7285ed3088cf )
 )
 
 game (
@@ -49218,20 +36698,6 @@ game (
 )
 
 game (
-	name "Space Fighter Mark II (set 1)"
-	year "1979"
-	developer "Data East"
-	rom ( name spfghmk2.zip size 6287 crc 28025964 md5 1cafbc76d9f1e320ad173ecb2b4f064a sha1 6f334e3a800ecbf08a484e9216d5c997ca798e86 )
-)
-
-game (
-	name "Space Fighter Mark II (set 2)"
-	year "1979"
-	developer "Data East"
-	rom ( name spfghmk22.zip size 6221 crc 46336e90 md5 36955b0595bd51b3055987b29f7809ab sha1 1fe2549991132677902c1579f290c6fd39aa7c45 )
-)
-
-game (
 	name "Spiders (set 1)"
 	year "1981"
 	developer "Sigma Enterprises Inc."
@@ -49267,13 +36733,6 @@ game (
 )
 
 game (
-	name "Spiel Bude (German)"
-	year "1985"
-	developer "ADP"
-	rom ( name spielbud.zip size 42281 crc 445cec24 md5 22e19898a0886ce3109ba176f28883d3 sha1 65c580c736ca142203c212cabcd138512255001e )
-)
-
-game (
 	name "Super Pierrot (Japan)"
 	year "1987"
 	developer "Universal"
@@ -49281,59 +36740,10 @@ game (
 )
 
 game (
-	name "Spikeout Final Edition"
-	year "1998"
-	developer "Sega"
-	rom ( name spikeofe.zip size 83082843 crc 9a6448dc md5 078d88d5a534c1c6ec5dba3f8d946069 sha1 3f8f45b809574e828ff3d7b66ebd295c85ead5b1 )
-)
-
-game (
-	name "Spikeout (Revision C)"
-	year "1998"
-	developer "Sega"
-	rom ( name spikeout.zip size 135500829 crc cff99556 md5 df38ab21d83a9a92fedba7a2ec9daba8 sha1 c43db01d6f8721b68e8804fb04859a273511aae1 )
-)
-
-game (
-	name "Spiker"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name spiker.zip size 45190 crc b52b754c md5 a31652f7218a675a8a66a5b52610c0af sha1 b61500e0ac1c9e54e48f1744fa13e917988de3d2 )
-)
-
-game (
-	name "1991 Spikes (Italian bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name spikes91.zip size 628174 crc 272ca6d0 md5 5c28d8fcaa3baf4ef3fdbec106ae6f4e sha1 bd815ea53398c0278b83ac80542cf880bc4c34ec )
-)
-
-game (
 	name "Hec's Spinkick"
 	year "1988"
 	developer "Haesung/Seojin"
 	rom ( name spinkick.zip size 5504 crc 3dfb9936 md5 e5648cffe46881080952e3c958206844 sha1 3784962b657f7aacb960d0e0ad6b47cdbe06eb42 )
-)
-
-game (
-	name "Spinal Breakers (World)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrk.zip size 2303016 crc 994052e9 md5 e3950ffff9a6cbc34732de0ded28b045 sha1 4d32fe5c59cab1cec21c6d865bb91eb7cd6e502a )
-)
-
-game (
-	name "Spinal Breakers (Japan)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrkj.zip size 112995 crc c2c8f350 md5 e778a8912febca423e03a79d9242d12e sha1 b155e841c15c4f0e0cfe099ca56df47cdd517adc )
-)
-
-game (
-	name "Spinal Breakers (US)"
-	year "1990"
-	developer "V-System Co."
-	rom ( name spinlbrku.zip size 113088 crc a9dec94a md5 00a71ea4f02c6f0529ee82f50cc93630 sha1 da4c38112254c17befd76489f537514541efa11a )
 )
 
 game (
@@ -49360,20 +36770,13 @@ game (
 game (
 	name "Super Poker (v115IT)"
 	developer "IGS"
-	rom ( name spk115it.zip size 483206 crc 4ca0baab md5 10edb8d6e2aa5f87ce4585abccd7834f sha1 5bf9c647c4ff1e71d8262a9b2c792a315364c49b )
+	rom ( name spk115it.zip size 225129 crc 3c835fac md5 54b4553f8d6482bd9d7b8dfdef1aa03e sha1 188e8d6bd1c9ad42ad7a77866f62a82a2257fbf5 )
 )
 
 game (
 	name "Super Poker (v116IT)"
 	developer "IGS"
 	rom ( name spk116it.zip size 484012 crc 207bf530 md5 16fef5dff2da50a0d335c4ee0c1dbafc sha1 be1aae5c8fea36c05ffc683760fa9f3907cd992b )
-)
-
-game (
-	name "Spikers Battle (GDS-0005)"
-	year "2001"
-	developer "Sega"
-	rom ( name spkrbtl.zip size 1198 crc 42e66618 md5 0682e5b95bcf468ee5051a699e598295 sha1 6d387a3e7f8665b2cd3013e655c8fa309a061dbd )
 )
 
 game (
@@ -49468,13 +36871,6 @@ game (
 )
 
 game (
-	name "Spotty (Ver. 2.0.2)"
-	year "2001"
-	developer "Prince Co."
-	rom ( name spotty.zip size 272327 crc 870dcf88 md5 6c9284d27a0612b60ba3bf646fc8a000 sha1 8bd7cc20160b86f017148dec9107406dbea72240 )
-)
-
-game (
 	name "Super Cross II (Japan, set 1)"
 	year "1986"
 	developer "GM Shoji"
@@ -49538,13 +36934,6 @@ game (
 )
 
 game (
-	name "Sprint 4 (set 2)"
-	year "1977"
-	developer "Atari"
-	rom ( name sprint4a.zip size 509 crc bcf61846 md5 04b348f9aa230ac2318a550740d4d915 sha1 8e62b7c56c8c0361145f886767499254591a7b0d )
-)
-
-game (
 	name "Sprint 8"
 	year "1977"
 	developer "Atari"
@@ -49566,24 +36955,10 @@ game (
 )
 
 game (
-	name "Sports Jam (GDS-0003)"
-	year "2000"
-	developer "Sega"
-	rom ( name sprtjam.zip size 1195 crc 881ee5ab md5 ab305710e1ffdd41373c40ec69f84203 sha1 54d7e2e88dcf6f8f7db3a79fe2e774890c8dba1d )
-)
-
-game (
 	name "Sports Match"
 	year "1989"
 	developer "Dynax (Fabtek license)"
 	rom ( name sprtmtch.zip size 132336 crc 81e26a6f md5 963a8d5f0f9f3c238128b35fb986ece8 sha1 fef4a459b2777c14b3c077816699ac686dfeeedc )
-)
-
-game (
-	name "Sports Shooting USA"
-	year "2002"
-	developer "Sammy USA"
-	rom ( name sprtshot.zip size 58739317 crc 6d8bf4c1 md5 1d72f8f74460cf2389c6f9e2cf0381fc sha1 379960a6208fe8b81aa08b3d1f2537ec9ede450b )
 )
 
 game (
@@ -49598,20 +36973,6 @@ game (
 	year "1983"
 	developer "Bally Midway"
 	rom ( name spyhunt.zip size 105665 crc 3d35096d md5 332512bf0e76ec272b472bed95262d5b sha1 4da69217902e22be0e2bc045d6e6af341881201f )
-)
-
-game (
-	name "Spy Hunter 2 (rev 2)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name spyhunt2.zip size 363056 crc 4e509b2d md5 16df0f6b79f2dc33d9d17257bfc7b0ba sha1 c14de08325340a1b6e66eafffbe13472df90c883 )
-)
-
-game (
-	name "Spy Hunter 2 (rev 1)"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name spyhunt2a.zip size 98743 crc eb5159b5 md5 c8e360ebb227e16000265838b4d80d1b sha1 bc35f2ca8d68fc49f97ae780409e56ee1d1ec9cb )
 )
 
 game (
@@ -49636,31 +36997,10 @@ game (
 )
 
 game (
-	name "Super Qix (World, Rev 2)"
-	year "1987"
-	developer "Taito"
-	rom ( name sqix.zip size 141696 crc dd4aa61b md5 c47f4c5d2101b115c016578ebe176d48 sha1 1e0e268a3ce841201ca70f8f4d7603539cedf976 )
-)
-
-game (
-	name "Super Qix (bootleg set 1)"
-	year "1987"
-	developer "bootleg"
-	rom ( name sqixb1.zip size 76513 crc e2bfcb17 md5 f90051b01cfbd8987fd60d707ced3415 sha1 15892736a5954b6889485833cd6843385d6160ba )
-)
-
-game (
 	name "Super Qix (bootleg set 2)"
 	year "1987"
 	developer "bootleg"
 	rom ( name sqixb2.zip size 76558 crc 2614603a md5 a6d56a5f1d4781669fc38e75ca6c87c4 sha1 1a18f007b6b573f4d2e30b6ee43601fe6030b19e )
-)
-
-game (
-	name "Super Qix (World, Rev 1)"
-	year "1987"
-	developer "Taito"
-	rom ( name sqixr1.zip size 20168 crc 545d2083 md5 532f281881632c039a2ac36121bcfe27 sha1 32a927f50777e4a648c58aa853734b9de866dd7f )
 )
 
 game (
@@ -49692,27 +37032,6 @@ game (
 )
 
 game (
-	name "Sega Rally 2"
-	year "1998"
-	developer "Sega"
-	rom ( name srally2.zip size 76292595 crc c4e60679 md5 6ab6dd3db8a062c8fe7dd1e8d51bf525 sha1 9f455b7145252a9704d636000232302e5d6c4d7c )
-)
-
-game (
-	name "Sega Rally 2 DX"
-	year "1998"
-	developer "Sega"
-	rom ( name srally2x.zip size 54062299 crc 6ea59223 md5 a831ae8a70788a1f44af6250e190278b sha1 730fd43569b1b770a13b566ce12a39bc7ed73669 )
-)
-
-game (
-	name "Sega Rally Championship"
-	year "1995"
-	developer "Sega"
-	rom ( name srallyc.zip size 17280930 crc 0f824413 md5 8b9b16d66bb4e02ed0245932c801b72d sha1 b7b732e1a01a9ff5f4c35116a420366c546f3841 )
-)
-
-game (
 	name "Super Ranger (v2.0)"
 	year "1988"
 	developer "SunA"
@@ -49720,31 +37039,10 @@ game (
 )
 
 game (
-	name "Super Ranger (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name srangerb.zip size 30575 crc ea4c8e74 md5 2f4231a0dc32b9757586eb0880f2922d sha1 5a5c3fd120c9ea5d83add331738da210ee3e506a )
-)
-
-game (
 	name "Super Ranger (WDK)"
 	year "1988"
 	developer "SunA (WDK license)"
 	rom ( name srangerw.zip size 34106 crc dae55d70 md5 f5044e9586cb03b50cd5975ec3926e86 sha1 ea6467d2529182425702cd1fb0e9ffa0e03dace5 )
-)
-
-game (
-	name "Super Real Darwin (World)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name srdarwin.zip size 191667 crc f5949dc6 md5 d3838f3c994a0c72ac9053308cd92ba3 sha1 f2fb0d3b28e230ed5d846b94d97f9674d8991cc7 )
-)
-
-game (
-	name "Super Real Darwin (Japan)"
-	year "1987"
-	developer "Data East Corporation"
-	rom ( name srdarwinj.zip size 37223 crc 0c4a984d md5 a6f38b0b504112176eb7f85a781042df sha1 5decf55d3901a3247897e754dff12bc21072421c )
 )
 
 game (
@@ -49811,13 +37109,6 @@ game (
 )
 
 game (
-	name "Super Real Mahjong VS"
-	year "1999"
-	developer "Seta"
-	rom ( name srmvs.zip size 28006028 crc cac7fbc2 md5 33646dc6503f43533474474b9ef19054 sha1 6a25d68b3f7b3bb3f3f20a5243601ac3f8a54fd0 )
-)
-
-game (
 	name "The Speed Rumbler (set 1)"
 	year "1986"
 	developer "Capcom"
@@ -49839,13 +37130,6 @@ game (
 )
 
 game (
-	name "Super Shanghai 2005 (GDL-0031)"
-	year "2005"
-	developer "Starfish"
-	rom ( name ss2005.zip size 1198 crc 23f852c5 md5 0a5e5a5795e411d780caadbd0ade4933 sha1 14423abd24229f3da0d840b31221bc6bed7d8e68 )
-)
-
-game (
 	name "Sanrin San Chan (Japan)"
 	year "1984"
 	developer "Sega"
@@ -49857,41 +37141,6 @@ game (
 	year "1985"
 	developer "Coreland / Sega"
 	rom ( name sscandal.zip size 57051 crc 4e910787 md5 2f758cb73c1a6beed9fda23ec2d197e8 sha1 2491c95af0886495029a4569b74a1385184a693a )
-)
-
-game (
-	name "Silent Scope (ver JZD)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscope.zip size 15165762 crc 89185c09 md5 a0f4cac6144ada39bc76863914244703 sha1 5174f6e920c0d3649c806713548c3fc7d5795027 )
-)
-
-game (
-	name "Silent Scope 2"
-	year "2000"
-	developer "Konami"
-	rom ( name sscope2.zip size 19068139 crc a0eccec1 md5 6a00f69d0ff8cf68c3133290a1a87333 sha1 828d93ce9237c727ccc46f6781f72227ce7ebe90 )
-)
-
-game (
-	name "Silent Scope (ver UAB)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscopea.zip size 1838263 crc ffe3e70e md5 6c7e317171c0e91754985798bbc45266 sha1 0bf56e16bf85aeba195b97f3254296d5b2dedfc5 )
-)
-
-game (
-	name "Silent Scope (ver UAA)"
-	year "2000"
-	developer "Konami"
-	rom ( name sscopeb.zip size 1833409 crc 29264454 md5 8fdf7322ac16bbdeaf9460deefb3b4ee sha1 6acdb62b23299cedc65a4e111f5a78a79be27704 )
-)
-
-game (
-	name "Silent Scope EX (ver UAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name sscopex.zip size 608 crc b0fff066 md5 507cacc9e90ba56911657663a9518c3e sha1 e2d1a180705e5e8c9102e009a8ed57afc51ae517 )
 )
 
 game (
@@ -50035,24 +37284,10 @@ game (
 )
 
 game (
-	name "See See Find Out"
-	year "1999"
-	developer "Icarus"
-	rom ( name ssfindo.zip size 5886116 crc d52eb6a8 md5 0ce5368f686dc6d953d04a626e1a6d0e sha1 1467d76d5abed88eac869a674cbec4f1b0484da9 )
-)
-
-game (
 	name "Sunset Riders (bootleg of Megadrive version)"
 	year "1993"
 	developer "bootleg / Konami"
 	rom ( name ssgbl.zip size 379004 crc 002d0bca md5 7b0477718d4373ba90b871d0da02b425 sha1 bf41bc1822eb0e264d89571228138247047d08a6 )
-)
-
-game (
-	name "Super Shanghai Dragon's Eye (Japan)"
-	year "1992"
-	developer "Hot-B"
-	rom ( name sshangha.zip size 1798303 crc e77c76d2 md5 56fd437ce72d692a53cf34b130bcf1f4 sha1 06e776678138bd4e5216bdf6eff26d18628b1734 )
 )
 
 game (
@@ -50119,55 +37354,6 @@ game (
 )
 
 game (
-	name "Swinging Singles"
-	year "1983"
-	developer "Ent. Ent. Ltd"
-	rom ( name ssingles.zip size 51433 crc 734975e4 md5 467dfa689602246a0117f312a3b7b103 sha1 a7d320cc6cf2825530bbcb2e9f928e0732e7db0d )
-)
-
-game (
-	name "SSI Poker (v2.4)"
-	year "1988"
-	developer "SSI"
-	rom ( name ssipkr24.zip size 11818 crc a87dc911 md5 ed34f9f2aec532a0bf20b156f7ab2ea9 sha1 715c7ef9cdd73edefc95fdf6dfbdbeb2679eb61f )
-)
-
-game (
-	name "SSI Poker (v3.0)"
-	year "1988"
-	developer "SSI"
-	rom ( name ssipkr30.zip size 8046 crc fe67cc99 md5 cbb0f979a1cb8425bbf63be23fc9daca sha1 5fd4e62523a05f1e964c6794a3d06f5c1fb83ad8 )
-)
-
-game (
-	name "SSI Poker (v4.0)"
-	year "1990"
-	developer "SSI"
-	rom ( name ssipkr40.zip size 8200 crc f404b4ef md5 a87b9ddd92c2f601e7eee224158aad23 sha1 22eac07b9f91e55e658294729270e33c569fca40 )
-)
-
-game (
-	name "Southern Systems Joker Poker"
-	year "1982"
-	developer "Southern Systems &amp; Assembly"
-	rom ( name ssjkrpkr.zip size 5611 crc 954b0cef md5 9a66ecb717a4b19d7ecb10671aaebf96 sha1 a214fc632a34aaa9f74697136a9aca54ea8d89aa )
-)
-
-game (
-	name "Super Slam (set 1)"
-	year "1993"
-	developer "Playmark"
-	rom ( name sslam.zip size 1566942 crc 96bd8f82 md5 11784419dbd4e8c640d3fde16f9d0cc5 sha1 176ec29bba753504f650c42983a6ba4d6135c43b )
-)
-
-game (
-	name "Super Slam (set 2)"
-	year "1993"
-	developer "Playmark"
-	rom ( name sslama.zip size 230992 crc 9a0eaca8 md5 5ef1e67bc6440b2d206ff2ec2d1456c0 sha1 29e2ccf3d9374b6c5718cfe93fe9745aba241531 )
-)
-
-game (
 	name "S.S. Mission"
 	year "1992"
 	developer "Comad"
@@ -50189,54 +37375,6 @@ game (
 )
 
 game (
-	name "Super Space 2001"
-	developer "&lt;unknown&gt;"
-	rom ( name sspac2k1.zip size 220533 crc 558eb2b1 md5 257dde3d213db022ac796f43a0f9fa78 sha1 30301515d752b25607e545c8511dd9f32be5bd99 )
-)
-
-game (
-	name "Space Attack / Head On"
-	year "1979"
-	developer "Sega"
-	rom ( name sspacaho.zip size 13045 crc 688a7299 md5 f234c9f0394560053e8aecc27c03fb6e sha1 380be7f2e53182a0e0b4954d7cdc5319a95c63ea )
-)
-
-game (
-	name "Space Attack (upright set 1)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat.zip size 7630 crc b7d48ade md5 c2f61bb364c134cbeec24267e9001a08 sha1 dc9eacdea547e287064c798ed9349d5f959a9a9b )
-)
-
-game (
-	name "Space Attack (upright set 2)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat2.zip size 7327 crc ce63c836 md5 5ac15b1513aec19b2cba16f59004d814 sha1 ef05fd6388ce4426cf900c2e62f2a0f21844550c )
-)
-
-game (
-	name "Space Attack (upright set 3)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceat3.zip size 7433 crc a0e26ab1 md5 ffe1695f8a48be9a1a5f7c3a2cb93d15 sha1 0ddb85f5fad93e30d6f1c6ef479554f977b57ead )
-)
-
-game (
-	name "Space Attack (cocktail)"
-	year "1979"
-	developer "Sega"
-	rom ( name sspaceatc.zip size 7310 crc a76a9cad md5 57e7c4dcd927fa915ffb19626cec2348 sha1 fd3afdf73d7361b97ba2e0253376cd0009a1b881 )
-)
-
-game (
-	name "Super Speed Race"
-	year "1979"
-	developer "Midway"
-	rom ( name sspeedr.zip size 5092 crc 9b23af52 md5 22ca3744af4a63ddd0f416ecae361396 sha1 e88ee6aac51e101e007c19a6965f06978ece4961 )
-)
-
-game (
 	name "Scramble Spirits (Japan, Floppy DS3-5000-02-REV-A Based)"
 	year "1988"
 	developer "Sega"
@@ -50248,13 +37386,6 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name sspirits.zip size 802970 crc 8bee32b2 md5 c0ae24dacf68fe05893f7cdbf2a064c9 sha1 abd0b6a1bc43c024989c8a87e12761a854f8815e )
-)
-
-game (
-	name "Scramble Spirits (World, Floppy Based, FD1094 317-0058-02c)"
-	year "1988"
-	developer "Sega"
-	rom ( name sspirtfc.zip size 7906 crc 52d904ad md5 d5b044db64a85d92e1543256d4001c79 sha1 9d73637f7c58d5e48929b7be2966e1deaa5fd1be )
 )
 
 game (
@@ -50328,13 +37459,6 @@ game (
 )
 
 game (
-	name "Sunset Riders (bootleg 4 Players ver ADD)"
-	year "1991"
-	developer "bootleg"
-	rom ( name ssridersb.zip size 1650699 crc d0520efc md5 e102831acbac0c96cf1ed994bd78ee37 sha1 ac62fa135ddd9e643176d99b1b41148cf9e7a96d )
-)
-
-game (
 	name "Sunset Riders (4 Players ver EAA)"
 	year "1991"
 	developer "Konami"
@@ -50384,23 +37508,10 @@ game (
 )
 
 game (
-	name "Super Speed Race Junior (Japan)"
-	year "1985"
-	developer "Taito Corporation"
-	rom ( name ssrj.zip size 29266 crc f29fcd99 md5 42aaf020b93e61ad2196c27b2916f230 sha1 63af6180f45d2a76a5d15bb69de3b3166cea0916 )
-)
-
-game (
 	name "Steep Slope Sliders (JUET 981110 V1.000)"
 	year "1998"
 	developer "Capcom / Cave / Victor"
 	rom ( name sss.zip size 10123314 crc 6094c420 md5 5a4f6da2f5d6926f1566e8b9d1b2f304 sha1 438f419c23b9a28fb5246fb930b3c83f8fff9e2b )
-)
-
-game (
-	name "Super Star"
-	developer "&lt;unknown&gt;"
-	rom ( name sstar.zip size 222904 crc 7b068616 md5 02b6871cb37ca436141e9906b4c760bb sha1 8236661b569d560269a7454261561d4b23976ad7 )
 )
 
 game (
@@ -50415,20 +37526,6 @@ game (
 	year "1986"
 	developer "Alpha Denshi Co."
 	rom ( name sstingry.zip size 121285 crc 144dde35 md5 3a5fe8a58d9799c0a83eaee278cb6c81 sha1 76246cd52f4aa75422fefaab842c0c1d5705ecfd )
-)
-
-game (
-	name "Space Stranger"
-	year "1978"
-	developer "Yachiyo Electronics, Ltd."
-	rom ( name sstrangr.zip size 7170 crc c6df43aa md5 0a5869c638f56c882e2d5c4a9d74b872 sha1 d7e9d54dbcb1042522f59c0793e90004a3a4ceb5 )
-)
-
-game (
-	name "Space Stranger 2"
-	year "1979"
-	developer "Yachiyo Electronics, Ltd."
-	rom ( name sstrangr2.zip size 6588 crc bec246f5 md5 deefb73ee6112202a5ce5f7ce7574215 sha1 5b6edd7803a9f7ae904c67be51c7e00cb023879e )
 )
 
 game (
@@ -50453,38 +37550,10 @@ game (
 )
 
 game (
-	name "Sega Strike Fighter (Rev A)"
-	year "2000"
-	developer "Sega"
-	rom ( name sstrkfgt.zip size 70221448 crc bb210a64 md5 b7c55f6afabd72c0c10abfdd75efaf4a sha1 253ddef63ac17c85194377af7630c164a93f71fe )
-)
-
-game (
-	name "Space Tactics"
-	year "1981"
-	developer "Sega"
-	rom ( name stactics.zip size 10859 crc 83a36c76 md5 5a830bfe00a59938752b72f4f03ae1f0 sha1 c2fca912be137803213b05d657bc832552bda605 )
-)
-
-game (
 	name "Stadium Hero (Japan)"
 	year "1988"
 	developer "Data East Corporation"
 	rom ( name stadhero.zip size 289444 crc 9dd9770b md5 87b1930a10005ecbc8d138fe3309a031 sha1 6e23674fd3ebee50faca5e14d0b8f10f27500660 )
-)
-
-game (
-	name "Stadium Hero 96 (World, EAJ)"
-	year "1996"
-	developer "Data East Corporation"
-	rom ( name stadhr96.zip size 12607023 crc d300025c md5 5b4c0dc338469451fe38ae34c6dfca69 sha1 4187afcc5d356d1e551c4e0265ea8f11d21a2271 )
-)
-
-game (
-	name "Stadium Hero 96 (Japan, EAD)"
-	year "1996"
-	developer "Data East Corporation"
-	rom ( name stadhr96j.zip size 1161447 crc 23f120d4 md5 485c9b7a5219a5105fdc31dec26d08f1 sha1 aabc9da02e7318fc349097b6778f6bfb212243a0 )
 )
 
 game (
@@ -50555,34 +37624,6 @@ game (
 	year "1979"
 	developer "bootleg (Jeutel)"
 	rom ( name starfght.zip size 11073 crc 8a299d3b md5 d0537567296e684d4df5f366a5cf1d29 sha1 054a0c1b0276dcfcb631933eb39e1c2b854f2527 )
-)
-
-game (
-	name "Star Fighter (v1)"
-	year "1990"
-	developer "SunA"
-	rom ( name starfigh.zip size 340898 crc a6a17bc1 md5 e92157c23c1330eefab749933bf1952e sha1 dcf17594ff75e1fce9aaffef537c59f9175817cb )
-)
-
-game (
-	name "Star Fire 2"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfir2.zip size 17661 crc 13f38fa8 md5 95df966b981be78a0001267fe5a401b3 sha1 f6c5427f155d744231323f68baccd5a98ee705df )
-)
-
-game (
-	name "Star Fire (set 1)"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfire.zip size 16770 crc aa4d7132 md5 d0e073c2251458b52e732b953e8f6f6f sha1 d5af8de0eadb20646ebba68123d5368c456b24ba )
-)
-
-game (
-	name "Star Fire (set 2)"
-	year "1979"
-	developer "Exidy"
-	rom ( name starfirea.zip size 16373 crc eb35b66a md5 8f933cbc276820b7eb31fa6cc25e7dc1 sha1 44be71ca0c63b9a40721b65e742419e923b5b670 )
 )
 
 game (
@@ -50698,12 +37739,6 @@ game (
 )
 
 game (
-	name "Starspinner (Dutch/Nederlands)"
-	developer "ACE"
-	rom ( name starspnr.zip size 13787 crc 0265dc5f md5 d9d1ca8bc5aaa3d6d41019fb194cce46 sha1 156acb968b315aef3764194dce5473586dde2c81 )
-)
-
-game (
 	name "Star Sweep (Japan, STP1/VER.A)"
 	year "1997"
 	developer "Axela/Namco"
@@ -50715,13 +37750,6 @@ game (
 	year "1982"
 	developer "Sega"
 	rom ( name startrek.zip size 43999 crc 38dbb990 md5 b8dfd04af8317d79e321262d59489d9f sha1 5cff1571744fedde53f659e033805400855b2757 )
-)
-
-game (
-	name "Star Trigon (Japan, STT1 Ver.A)"
-	year "2002"
-	developer "Namco"
-	rom ( name startrgn.zip size 24605302 crc 77f28217 md5 58d60a1294359fe7e4ad87367e2a4ad0 sha1 505cd7f7bf4b6431be947e9f114721f48df8e204 )
 )
 
 game (
@@ -50753,86 +37781,10 @@ game (
 )
 
 game (
-	name "Super Tarzan (Italy, V100I)"
-	developer "IGS / G.F. Gioca"
-	rom ( name starzan.zip size 216465 crc 26eeed10 md5 98948f0a56c4a91c411645c56d104380 sha1 336299615227bdf4708e4ab99a513e6dd1e89ca6 )
-)
-
-game (
-	name "Triv Two"
-	year "1984"
-	developer "Status Games"
-	rom ( name statriv2.zip size 45382 crc 0c078504 md5 19cbb783850310f2f78db5b7637d1615 sha1 2b120b68ab9ddae04be493fb7f5d6034609702b0 )
-)
-
-game (
-	name "Triv Two (Vertical)"
-	year "1985"
-	developer "Status Games"
-	rom ( name statriv2v.zip size 7177 crc 5eff9411 md5 ec65dcaa7c268fc29335def050665b24 sha1 d5f36ae0026e1c8ef1637a1ad31e482b851d5223 )
-)
-
-game (
 	name "Triv Four"
 	year "1985"
 	developer "Status Games"
 	rom ( name statriv4.zip size 39111 crc 76f31bee md5 4b8aa025fe9d375e41cc671f1d23cd77 sha1 7bca244ff295b37bbff85cb8bbc9b75bc8ec9d9f )
-)
-
-game (
-	name "Status Black Jack (V1.0c)"
-	year "1981"
-	developer "Status Games"
-	rom ( name statusbj.zip size 3839 crc cdcaf335 md5 ceb1523bfb87b5a0965aaf9a58cb6a24 sha1 7052b932a1e69a1f726aaa78f7413da71b75c8a9 )
-)
-
-game (
-	name "Sega Touring Car Championship (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name stcc.zip size 24075498 crc 51aed035 md5 49839255c076f2c3988fdc6d095a966b sha1 a0d000d8e071fd936897c850ee1a38bff889d7bc )
-)
-
-game (
-	name "Saint Dragon"
-	year "1989"
-	developer "Jaleco"
-	rom ( name stdragon.zip size 1062881 crc 4f83a544 md5 723158a4333a189deea1815d2f2711cc sha1 38fbd713ff16f5b9e20c6823c22e37be76f8e8cc )
-)
-
-game (
-	name "Strip Teaser (Italy, Version 1.22)"
-	year "1993"
-	developer "&lt;unknown&gt;"
-	rom ( name steaser.zip size 1325893 crc 377abe60 md5 3a1ce5dd1e4d21b34d13f6ae3321e85a sha1 f9bfc713bd71b33872af5fbcbe2fa5c0c16a4c1e )
-)
-
-game (
-	name "Steel Talons (rev 2)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltal.zip size 884903 crc eb4e4899 md5 fa774768b7da0e3cc49e6b21d293803d sha1 008617283017d2ac1d8f7342914429d854860ea8 )
-)
-
-game (
-	name "Steel Talons (rev 1)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltal1.zip size 168442 crc d3b90387 md5 07fad88a2c3b9a1e44b2dc9cc7b4861d sha1 f744e66017497ed82415894783c347a936f07c86 )
-)
-
-game (
-	name "Steel Talons (German, rev 2)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltalg.zip size 129256 crc 9b89e124 md5 bcc28b385a780028b62fdd32d1073112 sha1 7abae740942e75c8cedbabebb79ee2303b135c75 )
-)
-
-game (
-	name "Steel Talons (prototype)"
-	year "1991"
-	developer "Atari Games"
-	rom ( name steeltalp.zip size 574226 crc 12e9aa20 md5 0682c053a5f2f81dcc7b632d0c854d8e sha1 54c4ff37dad0d6b7203686527d92817333e4c3c5 )
 )
 
 game (
@@ -50847,27 +37799,6 @@ game (
 	year "1980"
 	developer "bootleg (Elettronolo)"
 	rom ( name stellcas.zip size 7212 crc abc6ff33 md5 6462a7824c14181fe89873536a1a4cd4 sha1 b1e7ff1e779620a884a5d85e6dce43b19117520f )
-)
-
-game (
-	name "Stelle e Cubi (Italy)"
-	year "1998"
-	developer "Sure"
-	rom ( name stellecu.zip size 318450 crc f3e770fb md5 2db5c7c9876efaa30787fcf4dca755df sha1 4fe68d8ab149284586b6fe554b2782e2bf757c3d )
-)
-
-game (
-	name "Stepping 3 Superior"
-	year "1999"
-	developer "Jaleco"
-	rom ( name step3.zip size 13065519 crc 24cc10cb md5 94136029347c1180bbaedff557c446c9 sha1 722f2c1332295ce80cc09e0f255f78da39e0ded3 )
-)
-
-game (
-	name "Stepping Stage Special"
-	year "1999"
-	developer "Jaleco"
-	rom ( name stepstag.zip size 9978154 crc 232b693b md5 c1b50848659c98e5d982dcdf09be7643 sha1 ba41ba4e500a89a4be6d4168a7e7b83af8066ea9 )
 )
 
 game (
@@ -50948,24 +37879,10 @@ game (
 )
 
 game (
-	name "Stocker (3/19/85)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name stocker.zip size 31209 crc a30d8761 md5 32be5430265d8c249cad8aaee37dbb32 sha1 7f644a7791dea5f1de73ed9c839f7a6f389e0d66 )
-)
-
-game (
 	name "Super Toffy"
 	year "1994"
 	developer "Midas (Unico license)"
 	rom ( name stoffy.zip size 90206 crc ee570a87 md5 382ee5be81efba1a58962c90877e3b0b sha1 0419f36244006a8a8efe1d749c778902c9b7904f )
-)
-
-game (
-	name "Stompin'"
-	year "1986"
-	developer "Bally/Sente"
-	rom ( name stompin.zip size 73853 crc 86d55893 md5 afa597b863c1a6d4f6af12b00c83007a sha1 2737564d455b1b1005e1d13ca30e8cc247dc3127 )
 )
 
 game (
@@ -51039,13 +37956,6 @@ game (
 )
 
 game (
-	name "Raiga - Strato Fighter (US)"
-	year "1991"
-	developer "Tecmo"
-	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
-)
-
-game (
 	name "Stratovox"
 	year "1980"
 	developer "Sun Electronics (Taito license)"
@@ -51067,41 +37977,6 @@ game (
 )
 
 game (
-	name "Street Games (Revision 4)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg.zip size 624540 crc c98a91ab md5 22f0a4ac3bacd2ce5013eb37d399d1ef sha1 02ad50db5e03d27c74e321a5ce95817497cd1d70 )
-)
-
-game (
-	name "Street Games II (Revision 7C)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg2.zip size 581670 crc 01b261ab md5 fe77adbeec4d60206d3e5e49578a1fa8 sha1 cfa93d09970f83db08a152a4419eebd17e3e73a5 )
-)
-
-game (
-	name "Street Games II (Revision 5)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetg2r5.zip size 529989 crc 4e734222 md5 a77ddd6302aadb9938455b2a61ed311c sha1 9644b49f2eacb198bd6d4d7db5113c53db9abafc )
-)
-
-game (
-	name "Street Games (Revision 3)"
-	year "1993"
-	developer "New Image Technologies"
-	rom ( name streetgr3.zip size 598535 crc 20a36445 md5 b0f7f49f2fb6af4792efa55754b10e12 sha1 ac049b5e441d7d0477baa1b32d3471f9fd659afc )
-)
-
-game (
-	name "Street Smart (US version 2)"
-	year "1989"
-	developer "SNK"
-	rom ( name streetsm.zip size 1327100 crc 1a2401bc md5 dfa1f446839bb27e10662348477175e2 sha1 3c5643e6c006bfdd2284869f49391cb1918c54a8 )
-)
-
-game (
 	name "Street Smart (US version 1)"
 	year "1989"
 	developer "SNK"
@@ -51120,13 +37995,6 @@ game (
 	year "1989"
 	developer "SNK"
 	rom ( name streetsmw.zip size 90846 crc 8196dcda md5 4b8f0ff3b147e43cf2fbfbe5de5cd8d2 sha1 28735f96c826fd961199995e1e25dd45f3dff6ce )
-)
-
-game (
-	name "Stress Busters (J 981020 V1.000)"
-	year "1998"
-	developer "Sega"
-	rom ( name stress.zip size 23153669 crc 15595504 md5 d9504be054155fedd12695eda81ca15c sha1 fa4027499acd98bc7520b679098647a14081d204 )
 )
 
 game (
@@ -51172,44 +38040,6 @@ game (
 )
 
 game (
-	name "Strider Hiryu (Japan Resale Ver.)"
-	year "1989"
-	developer "Capcom"
-	rom ( name striderjr.zip size 239008 crc 1978f905 md5 8ab0b831dd9c0bd31ed9a45971e2ad8c sha1 c72bcd017d9519ef4a4301203c988146d8e6e2dc )
-)
-
-game (
-	name "Strider (USA, set 2)"
-	year "1989"
-	developer "Capcom"
-	rom ( name striderua.zip size 234534 crc e0093246 md5 2995861459763a1253523ff85452f692 sha1 1548a7626e6b30737a82910db5f17fa5b959c5b3 )
-)
-
-game (
-	name "Strike it Lucky (v0.5)"
-	developer "Barcrest"
-	rom ( name strikeit.zip size 268310 crc 2adecca2 md5 bcfd94e4b8247c4ecd45629d1e916acb sha1 bfc154b21193b4845bf29d7a7a5ebdf1daa2663c )
-)
-
-game (
-	name "Strike it Lucky (v0.53)"
-	developer "Barcrest"
-	rom ( name strikeit2.zip size 53036 crc 990fa4c7 md5 784d32cf6051f892ab8469b391a153f2 sha1 4886da30d78b6b5a51b2eedced17c0515ed0329d )
-)
-
-game (
-	name "Strike it Lucky (v0.53, Datapak)"
-	developer "Barcrest"
-	rom ( name strikeit2d.zip size 53042 crc 7b737536 md5 3d5a3206b6fa114484dcdb2d26136b12 sha1 de533190bc9ae7a440de170032968a98f0f18c98 )
-)
-
-game (
-	name "Strike it Lucky (v0.5, Datapak)"
-	developer "Barcrest"
-	rom ( name strikeitd.zip size 53036 crc 5b7f0414 md5 227b176c4f25db3cab636d8686322e4c sha1 31b6b9510c1da556c04c719964d965ecd8cb2860 )
-)
-
-game (
 	name "Super Triv"
 	year "1985"
 	developer "Hara Industries"
@@ -51252,24 +38082,10 @@ game (
 )
 
 game (
-	name "Street Drivin' (prototype)"
-	year "1993"
-	developer "Atari Games"
-	rom ( name strtdriv.zip size 862616 crc 0d1a5abb md5 df2f674112514b205e3bae9956b3081f sha1 b0548b962dab41f799eb1e06ddbdc6f3300ad7fa )
-)
-
-game (
 	name "Street Heat - Cardinal Amusements"
 	year "1985"
 	developer "Epos Corporation"
 	rom ( name strtheat.zip size 17260 crc 67eaa4e9 md5 03197a772c2d9246f25716c34defe1ab sha1 f270133f175330fa83ec551218221d7c48e4b736 )
-)
-
-game (
-	name "Super Trivia Master"
-	year "1986"
-	developer "Enerdyne Technologies Inc."
-	rom ( name strvmstr.zip size 177612 crc 9c2661e2 md5 03aae55924cda1799ff2b1ea897f2f24 sha1 4c7872f1b3c6ad18eec60529bfd865eddc1a3f0b )
 )
 
 game (
@@ -51385,31 +38201,10 @@ game (
 )
 
 game (
-	name "Idol Janshi Suchie-Pai 3 (JPN)"
-	year "1999"
-	developer "Jaleco"
-	rom ( name suchie3.zip size 97944828 crc 6e70a4d7 md5 afd008911fe674dbdac09842e695420d sha1 b77aef2626100b9c5e170ec6c1d811a2dc492f06 )
-)
-
-game (
-	name "Idol Janshi Suchie-Pai Special (Japan)"
-	year "1993"
-	developer "Jaleco"
-	rom ( name suchipi.zip size 1947280 crc 4045e520 md5 c2b8676b68ea4fb23c893aec2942d32e sha1 e03450ff802dc0d85b3e548b43b70ef7251193f0 )
-)
-
-game (
 	name "Suikoenbu / Outlaws of the Lost Dynasty (JUETL 950314 V2.001)"
 	year "1995"
 	developer "Data East"
 	rom ( name suikoenb.zip size 15724636 crc d4dd674a md5 45f6de12117b835b70b0067932f02dee sha1 28aa2244c5c81ceab696b325879617f490ba159e )
-)
-
-game (
-	name "Quiz and Variety Suku Suku Inufuku 2 (IN2 Ver. A)"
-	year "2004"
-	developer "Namco"
-	rom ( name sukuinuf.zip size 1687525 crc 4c51c19f md5 7fe561e730fd103f909b35ae1402092a sha1 fd640fcaeaf4df7f1fa48e66402d18d6a923071f )
 )
 
 game (
@@ -51448,13 +38243,6 @@ game (
 )
 
 game (
-	name "Super Crash (bootleg of Head On)"
-	year "1979"
-	developer "bootleg"
-	rom ( name supcrash.zip size 6070 crc 5531db06 md5 21edfac520ba0d731856568282ac2f7b sha1 bc9e12362fe339ea79166ab807e993df943f3d3d )
-)
-
-game (
 	name "Super Draw Poker (set 1)"
 	year "1983"
 	developer "Valadon Automation (Stern Electronics license)"
@@ -51490,13 +38278,6 @@ game (
 )
 
 game (
-	name "Agent Super Bond (Scobra Hardware)"
-	year "1985"
-	developer "Signatron USA"
-	rom ( name superbon.zip size 20193 crc 56f1e60e md5 b825b187495ab8d327159e5d6a4f66f4 sha1 7ce5066f30c5a5a07f329376dd863408704e24fa )
-)
-
-game (
 	name "Super Bug"
 	year "1977"
 	developer "Atari"
@@ -51518,27 +38299,6 @@ game (
 )
 
 game (
-	name "Super Don Quix-ote (Long Scenes)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdq.zip size 16239 crc 9962bb8e md5 baf73150b3613a2adb0e418a10eb2c22 sha1 ee76681e720fd91ae3949a585661ac3384b10091 )
-)
-
-game (
-	name "Super Don Quix-ote (Short Scenes, Alt)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdqa.zip size 11380 crc 657cf5c7 md5 22187fc1172841050dfc3d9708f74890 sha1 1a060d3ac52bbff94132eaee5adc8486cccc80d2 )
-)
-
-game (
-	name "Super Don Quix-ote (Short Scenes)"
-	year "1984"
-	developer "Universal"
-	rom ( name superdqs.zip size 11370 crc edc702c6 md5 0f7300f6b4b7bb852fa73c3a8f2cd7a9 sha1 6e6e3201fa8a3e0c0fdf4abd6e39cf72f597a65c )
-)
-
-game (
 	name "Super Galaxians (galaxiana hack)"
 	year "1979"
 	developer "hack"
@@ -51550,13 +38310,6 @@ game (
 	year "1996"
 	developer "&lt;unknown&gt;"
 	rom ( name supergm3.zip size 2052131 crc 212784b6 md5 8eff17b9802472a4c321e7e90af7a99d sha1 3988b52130dcbb4a07ed7f463632f386ce1a5045 )
-)
-
-game (
-	name "Super GX"
-	year "1980"
-	developer "Nichibutsu"
-	rom ( name supergx.zip size 11192 crc b11532f1 md5 5ef0fdb261044c95e7a0d543e5cf0eec sha1 b0837b9c7ef9e67f7c2280f9927a4517e95ad1fb )
 )
 
 game (
@@ -51608,13 +38361,6 @@ game (
 )
 
 game (
-	name "Super Triv II"
-	year "1986"
-	developer "Status Games"
-	rom ( name supertr2.zip size 143384 crc 319fb964 md5 12e9453390bf5f76ac1a321cb7f689ab sha1 2d8660d9b2054181ad4c4be19056019c6648312b )
-)
-
-game (
 	name "Super Triv III"
 	year "1988"
 	developer "Status Games"
@@ -51636,12 +38382,6 @@ game (
 )
 
 game (
-	name "Super Jolly"
-	developer "&lt;unknown&gt;"
-	rom ( name supjolly.zip size 308864 crc 4235325c md5 0ac34bbd8928e753d4c30f88cf894bf8 sha1 364198b5abc24240abbddb5bdb6dbf5b9eb6c52b )
-)
-
-game (
 	name "Super Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 4.0 / 990518)"
 	year "1999"
 	developer "Omega System"
@@ -51653,13 +38393,6 @@ game (
 	year "1994"
 	developer "Comad &amp; New Japan System"
 	rom ( name supmodel.zip size 3328217 crc 9fac55f2 md5 6d3d5e855c96a246fb4b3d88515b7873 sha1 04ca6ba4cae140d93a035bb987d0cda36ac6cd4a )
-)
-
-game (
-	name "Super Nudger II (Version 5.21)"
-	year "1989"
-	developer "Coinmaster"
-	rom ( name supnudg2.zip size 571146 crc 54427cec md5 5d7e0497f5a759c0e7a86e113d55429f sha1 9a9f81aeb0e3148ed16042c6a258293b89746932 )
 )
 
 game (
@@ -51736,35 +38469,7 @@ game (
 	name "Vs. Super Mario Bros. (alt)"
 	year "1986"
 	developer "Nintendo"
-	rom ( name suprmrioa.zip size 37111 crc 2bdfe232 md5 dd46a0aa4ef6ebe64a5c0d3e7be06ae7 sha1 11a1df32c5db2093ced49fc01fac4e928b57c6f5 )
-)
-
-game (
-	name "Vs. Super Mario Bros. (bootleg with Z80, set 1)"
-	year "1986"
-	developer "bootleg"
-	rom ( name suprmriobl.zip size 32292 crc b77c5399 md5 9f05451447f3f1c20ddea20a96d43696 sha1 5f6f49271246428b7deb76d73108746943f114ef )
-)
-
-game (
-	name "Vs. Super Mario Bros. (bootleg with Z80, set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name suprmriobl2.zip size 31097 crc 726634a6 md5 7cd2c8d8aa4a1a8b139c00f95af9a19d sha1 33fe64fbea692211040353a73eefe7d648b99e4c )
-)
-
-game (
-	name "Super Poker"
-	year "1987"
-	developer "Greyhound Electronics"
-	rom ( name suprpokr.zip size 19252 crc a0507132 md5 4780436f8210edd78fe634619b82e14e sha1 172248ace518f00bf3cf303e761d2f0c531241fb )
-)
-
-game (
-	name "Super Pool (9743 rev.01)"
-	year "1997"
-	developer "ABM Games"
-	rom ( name suprpool.zip size 327138 crc 351d4e9b md5 dc59f2ccea324f24c04ef301ca5435aa sha1 4799bfdeb32d44700d9546acbb7a1114b5745f91 )
+	rom ( name suprmrioa.zip size 6512 crc 8db6d265 md5 29b0d03112541b7590809462063c122b sha1 2a8a3474497378ad65bb0a574eb906a3ccde656d )
 )
 
 game (
@@ -51880,20 +38585,6 @@ game (
 )
 
 game (
-	name "Suzuka 8 Hours (World)"
-	year "1992"
-	developer "Namco"
-	rom ( name suzuka8h.zip size 2189192 crc 939be6f9 md5 4ee129d4893d4bb9168d1d55fa590c19 sha1 01a7738fb337cd90a417891fb03174eb8ac73118 )
-)
-
-game (
-	name "Suzuka 8 Hours (Japan)"
-	year "1992"
-	developer "Namco"
-	rom ( name suzuka8hj.zip size 253079 crc 81cb8614 md5 7bd7445a6ccb450d4395e983b663e450 sha1 9a2c7e66d23af7264457c6c43ca0907d1d831ad6 )
-)
-
-game (
 	name "Watashiha Suzumechan (Japan)"
 	year "1986"
 	developer "Dyna Electronics"
@@ -51957,13 +38648,6 @@ game (
 )
 
 game (
-	name "S.V.G. - Spectral vs Generation (ver. 200)"
-	year "2005"
-	developer "IGS"
-	rom ( name svg.zip size 26388674 crc 54c784f8 md5 43fb3b8632e85494b56fee00e26d2605 sha1 a17125a7f021f459770122a7f62502b7cf9c9c74 )
-)
-
-game (
 	name "Super Volleyball (Japan)"
 	year "1989"
 	developer "V-System Co."
@@ -51999,13 +38683,6 @@ game (
 )
 
 game (
-	name "Star Wars Arcade"
-	year "1993"
-	developer "Sega"
-	rom ( name swa.zip size 15194721 crc 931317a1 md5 cb8b4ab97e58b34d4e7ae701566f9042 sha1 c5d178ac81cd81e2ef372d7f668ad67f60af559f )
-)
-
-game (
 	name "Swarm (bootleg?)"
 	year "1979"
 	developer "bootleg? (Subelectro)"
@@ -52038,13 +38715,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name swcourtj.zip size 468483 crc 514528ca md5 9903bb397e4bfe2197eadedd9d7f7738 sha1 271e1537694c7503325fbccde43b1665dabd8619 )
-)
-
-game (
-	name "Sweet Gal (Japan 850510 SWG 1-02)"
-	year "1985"
-	developer "Nichibutsu"
-	rom ( name sweetgal.zip size 97709 crc 36601e92 md5 052d98ac235ac017a5aee0f235447a5f sha1 231e9a5ec987b75630c2aaa9a4da91a8faec1a0c )
 )
 
 game (
@@ -52094,20 +38764,6 @@ game (
 	year "1992"
 	developer "Namco"
 	rom ( name sws.zip size 1630675 crc bb788d75 md5 35597d7802e75e881bb3eafa8897a5f5 sha1 f658652300e2156500cb3c2e2c0bd8bea41be68a )
-)
-
-game (
-	name "Super World Stadium 2000 (Japan, SS01/VER.A)"
-	year "2000"
-	developer "Namco"
-	rom ( name sws2000.zip size 26226717 crc 304e2139 md5 725c2f7014140140a2373f49aa9674e3 sha1 36fb5ac674630c5e74bd7b2d858b75c3c0083026 )
-)
-
-game (
-	name "Super World Stadium 2001 (Japan, SS11/VER.A)"
-	year "2001"
-	developer "Namco"
-	rom ( name sws2001.zip size 8663054 crc 338cca52 md5 507b402aa927f7f3878f9f7f10a968d6 sha1 543bd24e71f410cd2555c0a613fe8f06ffd5ee12 )
 )
 
 game (
@@ -52167,31 +38823,10 @@ game (
 )
 
 game (
-	name "Sweet Hearts II (C - 07/09/95, Venezuela version)"
-	year "1995"
-	developer "Aristocrat"
-	rom ( name swthrt2v.zip size 415733 crc c9504ac3 md5 4155d55af7c43fd2ade6a599f106e836 sha1 93bb8fcf1fd51457d76dfc2b651a1f2e607d3a9d )
-)
-
-game (
 	name "Sweet Hearts II - 1VXFC5461 (New Zealand)"
 	year "1998"
 	developer "Aristocrat"
 	rom ( name swtht2nz.zip size 51405 crc b6957ec6 md5 2e28511976743497838ae187c0b0c235 sha1 bc032a443ba302461d85e7497eeb905072d77165 )
-)
-
-game (
-	name "Star Wars Trilogy (Revision A)"
-	year "1998"
-	developer "Sega / LucasArts"
-	rom ( name swtrilgy.zip size 71464436 crc e2131bf1 md5 d548141066e335e0d5f6af4bed9d4a50 sha1 38e00254424ff079bd01aa94bc4234d6b3e46694 )
-)
-
-game (
-	name "Star Wars Trilogy"
-	year "1998"
-	developer "Sega / LucasArts"
-	rom ( name swtrilgya.zip size 1050819 crc d6d8ca2a md5 a8f62ce5c58eff4e68e98c788dc932c3 sha1 8d9e437e3ebe2c433625511e9e1c41589c3885a2 )
 )
 
 game (
@@ -52265,20 +38900,6 @@ game (
 )
 
 game (
-	name "Taiko No Tatsujin 10 (T101001-NA-A)"
-	year "2007"
-	developer "Namco"
-	rom ( name taiko10.zip size 1532270 crc 344d7ead md5 bbd9d7101eeaa207f1394e8405a1d305 sha1 204931bd64ad71794c70a4a0aa232b0c3f101f13 )
-)
-
-game (
-	name "Taiko No Tatsujin 9 (TK91001-NA-A)"
-	year "2006"
-	developer "Namco"
-	rom ( name taiko9.zip size 1527101 crc 320cb84f md5 a0c8675d983efa09456a055ab2ba7cb4 sha1 aeca40544119c30904fde526b2625658643989a6 )
-)
-
-game (
 	name "Tail to Nose - Great Championship"
 	year "1989"
 	developer "V-System Co."
@@ -52297,13 +38918,6 @@ game (
 	year "1988"
 	developer "Miki Syouji"
 	rom ( name taiwanmb.zip size 290188 crc cbbcc39c md5 6f3474496a71c85add3c93ffb5849f2d sha1 0b58ff536ce5d362621dee906dd96d815c40d114 )
-)
-
-game (
-	name "Noukone Puzzle Takoron (GDL-0042)"
-	year "2006"
-	developer "Compile"
-	rom ( name takoron.zip size 1195 crc 6a8e062d md5 271f42a9ac4234ef577b94e7b9d0a2cf sha1 a1ca7f80b0f0708077d7b391f6c55a86b382de48 )
 )
 
 game (
@@ -52328,45 +38942,10 @@ game (
 )
 
 game (
-	name "Tank 8 (set 2)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8a.zip size 2437 crc 30a85c79 md5 4a2d644f766660a64fbe98669b819c87 sha1 0f8009d4daf503e1f1a1be02c04250c695718d79 )
-)
-
-game (
-	name "Tank 8 (set 3)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8b.zip size 2409 crc be20f24c md5 525ef065494de81c768a7a5f60ef04b0 sha1 fa22cc3d2262456dbedae841d17006f3e4f0af33 )
-)
-
-game (
-	name "Tank 8 (set 4)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8c.zip size 2563 crc de0eef2c md5 37934fc7c986ef19df053c64e913a2ee sha1 6bcca24e713fd4ccf0722096a76c53fb2cc1f1cc )
-)
-
-game (
-	name "Tank 8 (set 5)"
-	year "1976"
-	developer "Atari"
-	rom ( name tank8d.zip size 2726 crc 1b3bd37d md5 def93727b2ab3617fbc66cba064e4efb sha1 622d8c68ce5d7eee890d56f7f8c5a0f078c53916 )
-)
-
-game (
 	name "Tank Battle (prototype rev. 4/21/92)"
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name tankbatl.zip size 1469310 crc 19d31524 md5 b77cf3ec5384cb1be990aa3117dc887f sha1 14ef2a8a83b9c458fa5807d9da1121205a19d524 )
-)
-
-game (
-	name "Tank Battalion"
-	year "1980"
-	developer "Namco"
-	rom ( name tankbatt.zip size 8337 crc 00986b0a md5 f8b6eb6c292289525fdd0165de9fea7a sha1 0d7893c13f8f6ad6759a385e84538e48add6c094 )
 )
 
 game (
@@ -52475,38 +39054,6 @@ game (
 )
 
 game (
-	name "Target Hits (ver 1.1)"
-	year "1994"
-	developer "Gaelco"
-	rom ( name targeth.zip size 2095194 crc 30c1bd0c md5 ea3f802945c01b465a3b38d76d1c6161 sha1 50f6ef70fb906e6af3218fe2d55f1dab4aef60b9 )
-)
-
-game (
-	name "Target Hits (ver 1.0)"
-	year "1994"
-	developer "Gaelco"
-	rom ( name targetha.zip size 105545 crc 62d50815 md5 c00f143f727233218da94d96fa9f6f15 sha1 62dbfc14e840f88675088d1db618d333b08e2452 )
-)
-
-game (
-	name "Tarzan (V109C)"
-	developer "IGS"
-	rom ( name tarzan.zip size 307845 crc a07f7da1 md5 e529f271092e6915d7b28e1cd8c24ed6 sha1 0cda4697109ee2aeb4d28ff16de34db2cd45a6fb )
-)
-
-game (
-	name "Tarzan (V107)"
-	developer "IGS"
-	rom ( name tarzana.zip size 232134 crc becb25bd md5 0ca14c30559269dafba9d0388e904524 sha1 0296a5e56507342dc22b99463cdaa89df995f098 )
-)
-
-game (
-	name "Time Attacker"
-	developer "Shonan"
-	rom ( name tattack.zip size 4017 crc 4cd0b725 md5 a985e24add955cf3a5065b86f42d694f sha1 25a08ea5bd16b683028c61a54b3124a22eecf0b3 )
-)
-
-game (
 	name "Tattoo Assassins (US prototype)"
 	year "1994"
 	developer "Data East Pinball"
@@ -52591,13 +39138,6 @@ game (
 )
 
 game (
-	name "Taiwan Chess Legend"
-	year "1995"
-	developer "Uniwang"
-	rom ( name tcl.zip size 132675 crc be1ae636 md5 9a8e36ec0464bfd4343785ab2f57d228 sha1 86eeb9cbb5b113bdf94ded13a44173981a2f42a7 )
-)
-
-game (
 	name "Twin Cobra II (Ver 2.1O 1995/11/30)"
 	year "1995"
 	developer "Taito Corporation Japan"
@@ -52675,13 +39215,6 @@ game (
 )
 
 game (
-	name "Puzzle Bobble (Italian Gambling Game)"
-	year "2001"
-	developer "&lt;unknown&gt;"
-	rom ( name te0144.zip size 427074 crc 72934a64 md5 9531ff4654e644743f725d2356d9b199 sha1 02706a77c65aa7685cc3b3a362c0c8bbe3bfbba4 )
-)
-
-game (
 	name "John Elway's Team Quarterback (set 1)"
 	year "1988"
 	developer "Leland Corp."
@@ -52693,13 +39226,6 @@ game (
 	year "1988"
 	developer "Leland Corp."
 	rom ( name teamqb2.zip size 23156 crc b723efdb md5 431ebaadfd10456f8c40881bfe94486b sha1 5e02ed630121ae182c4cbc74e63500dd6962f0ea )
-)
-
-game (
-	name "Technical Bowling (J 971212 V1.000)"
-	year "1997"
-	developer "Sega"
-	rom ( name techbowl.zip size 1421281 crc 16c1e589 md5 23ddeaa3a6db839e6d5df75a085bbbba sha1 1ca021f391c7e09c96331df553e97f6bc6a453ad )
 )
 
 game (
@@ -52766,20 +39292,6 @@ game (
 )
 
 game (
-	name "Tehkan World Cup (set 3, bootleg)"
-	year "1985"
-	developer "bootleg"
-	rom ( name tehkanwcc.zip size 28158 crc 733109da md5 2a47ec4deb8ac542855689147a3da6fc sha1 c4e0dab12e2d5c433ea9a25d544834c40efacbc8 )
-)
-
-game (
-	name "Teki Paki"
-	year "1991"
-	developer "Toaplan"
-	rom ( name tekipaki.zip size 322362 crc d97ed91c md5 a4694fc8d623725d2538de14d00d551a sha1 e7c3b77db78ff64ec8a56c2be79f2445e1daa3e6 )
-)
-
-game (
 	name "Tekken (TE4/VER.C)"
 	year "1994"
 	developer "Namco"
@@ -52836,34 +39348,6 @@ game (
 )
 
 game (
-	name "Tekken 4 (TEF3 Ver. C)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4.zip size 3150691 crc 9687dcf4 md5 133ea8671e5e29946b83aadb9e5ca5c8 sha1 589d4c6c8f9a6d3e8c93c0c1b507a6d18d7f8ec8 )
-)
-
-game (
-	name "Tekken 4 (TEF2 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4a.zip size 3150921 crc eb814303 md5 b44e9d51086e27ada14b4fcdf85ad513 sha1 563834ac6a7487b68c303be8a40404e4cce93fd6 )
-)
-
-game (
-	name "Tekken 4 (TEF1 Ver. A)"
-	year "2002"
-	developer "Namco"
-	rom ( name tekken4b.zip size 3148032 crc b9b2af7e md5 9feedb0f2b9f431392a644f0e41cb381 sha1 8ec335f89ed18b100d60112d888b8930d513f58e )
-)
-
-game (
-	name "Tekken 5.1 (TE51 Ver. B)"
-	year "2005"
-	developer "Namco"
-	rom ( name tekken51.zip size 5769717 crc 047ebc9b md5 b372516ab839015505398dd65d7dd4ba sha1 5a46b41198fd780d1755eff6cb883f4402f16228 )
-)
-
-game (
 	name "Tekken (TE2/VER.C)"
 	year "1994"
 	developer "Namco"
@@ -52896,20 +39380,6 @@ game (
 	year "1999"
 	developer "Namco"
 	rom ( name tektagta.zip size 1923661 crc 890f0393 md5 91febf904b0b5b8cfee40f2d8697176e sha1 2a842ed2396cd54db6830db7e659521828c9c818 )
-)
-
-game (
-	name "Tekken Tag Tournament (Japan, TEG1/VER.B)"
-	year "1999"
-	developer "Namco"
-	rom ( name tektagtb.zip size 1926059 crc 42f75b01 md5 ff1b653083e2496912f64027a18105c9 sha1 e211a9f369c590aab7d53e59dd84342dbf09f97a )
-)
-
-game (
-	name "Tekken Tag Tournament (Japan, TEG1/VER.A3)"
-	year "1999"
-	developer "Namco"
-	rom ( name tektagtc.zip size 1923441 crc d4cf20c1 md5 0ca7c987b47db7872cd4c46c7acde6b0 sha1 26063348a5b5253af7e835bdd356b7551325c83c )
 )
 
 game (
@@ -52969,59 +39439,10 @@ game (
 )
 
 game (
-	name "Tengai (World)"
-	year "1996"
-	developer "Psikyo"
-	rom ( name tengai.zip size 6500431 crc 99b98f75 md5 91470b32675430f13f0892416163e6e8 sha1 93d82339ea7ce82efca9903c1275e477d57ab41c )
-)
-
-game (
-	name "Sengoku Blade: Sengoku Ace Episode II / Tengai"
-	year "1996"
-	developer "Psikyo"
-	rom ( name tengaij.zip size 297798 crc 51bb8e58 md5 7bf9df9b4fa74ad36a4fb984381ce86a sha1 d7c9bb4651598d6f8609d5deed41aeff265ac1fe )
-)
-
-game (
-	name "Mahjong Tenkaigen"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkai.zip size 659684 crc fcec3b2f md5 3641deb99edda5b8ca3248f2777594ba sha1 8e04089a44b491a9c0101d647621737cf9aefe51 )
-)
-
-game (
-	name "Mahjong Tenkaigen Part 2 (bootleg)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tenkai2b.zip size 930387 crc e9407a17 md5 419cafdf305b24ba815b3926b2ef5a61 sha1 17369508d2e1695f35acbc18829f3a4c260e9929 )
-)
-
-game (
 	name "Mahjong Tenkaigen (bootleg b)"
 	year "1991"
 	developer "bootleg"
 	rom ( name tenkaibb.zip size 945247 crc 66dd10f2 md5 7af84111bb794a1342469f0cbc3842f2 sha1 4f7ce77d2efb320068fd16f5fe2946267388022c )
-)
-
-game (
-	name "Mahjong Tenkaigen (bootleg c)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tenkaicb.zip size 80524 crc 751f4626 md5 0ea21274f71cb805ca0a22dce55aaf70 sha1 dc223d4874baa079207de6e3e97006a76ddeedfd )
-)
-
-game (
-	name "Mahjong Tenkaigen (set 1)"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkaid.zip size 809258 crc b41e4ffc md5 97beb48d105487bcf019fd3effde1722 sha1 57f5c239e8b68eeba0cacd7c009bad3b2f3efb59 )
-)
-
-game (
-	name "Mahjong Tenkaigen (set 2)"
-	year "1991"
-	developer "Dynax"
-	rom ( name tenkaie.zip size 847594 crc 7b10b97f md5 776ef6a648571dab8fb804eaccdcdf56 sha1 8e4f1b2075f9b69bea6804ae6f11d33aba77c08a )
 )
 
 game (
@@ -53036,20 +39457,6 @@ game (
 	year "1998"
 	developer "Namco"
 	rom ( name tenkomorj.zip size 1770952 crc 89df32e5 md5 439ac7ef40100947c3cbb1e745c1f170 sha1 e41cc77a43902146be1a86a86572aa0b014fd4c8 )
-)
-
-game (
-	name "Ten Pin Deluxe"
-	year "1983"
-	developer "Bally Midway"
-	rom ( name tenpindx.zip size 60713 crc 7ccbae0e md5 13b38503cfe9d753aec62aa5b09e19cf sha1 e4ed733279fae46d0f7fb27f255f8fe4d1a188bf )
-)
-
-game (
-	name "Ten Spot"
-	year "1982"
-	developer "Thomas Automatics"
-	rom ( name tenspot.zip size 118486 crc cee814c3 md5 e3cec0dfc2ab906bd8c27369bda17abc sha1 b38f3e349425e04d3554c41dbdb63f64c7db6d3b )
 )
 
 game (
@@ -53071,20 +39478,6 @@ game (
 	year "1988"
 	developer "JPM"
 	rom ( name tenup3.zip size 304621 crc 6b31282a md5 70a9042a71c737b873a43e84b6259a1f sha1 691ae364673952fac49288426e9769de988d438c )
-)
-
-game (
-	name "Teraburst (1998/07/17 ver UEL)"
-	year "1998"
-	developer "Konami"
-	rom ( name terabrst.zip size 15214788 crc 49abd3ac md5 190527979c7479440236efb1e3832541 sha1 361216558a61f8ad564826cc38c56ce4dcb4700d )
-)
-
-game (
-	name "Teraburst (1998/02/25 ver AAA)"
-	year "1998"
-	developer "Konami"
-	rom ( name terabrsta.zip size 2278944 crc 1c7298b0 md5 840063609bd085c9fe6b2bd2f72cc558 sha1 c17b01c8078db58522d3a7864186fcbcc17441fc )
 )
 
 game (
@@ -53137,41 +39530,6 @@ game (
 )
 
 game (
-	name "Terra Force (set 1)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name terraf.zip size 377395 crc 0356dd12 md5 af2370e45dd017c433317cae0d68acf0 sha1 26d9cb009aa1a522ac29f48f10f0d858fc5d2a98 )
-)
-
-game (
-	name "Terra Force (set 2)"
-	year "1987"
-	developer "Nichibutsu"
-	rom ( name terrafa.zip size 208240 crc 210e02b1 md5 e4d00335ac77390e800488e5fcc0007d sha1 eefacdb752ac1a2d0dab09c659f9c7e9199883b7 )
-)
-
-game (
-	name "Terra Force (bootleg with additional Z80)"
-	year "1987"
-	developer "bootleg"
-	rom ( name terrafb.zip size 105431 crc 62838e2b md5 9254f06ce43f1f61fce16a4ad30f2ea1 sha1 b344621da6b0574e37b450841b4a128c903ad686 )
-)
-
-game (
-	name "Terra Force (US)"
-	year "1987"
-	developer "Nichibutsu USA"
-	rom ( name terrafu.zip size 105124 crc 00b85007 md5 e109204f597517ae900aa95ccc1d7454 sha1 99995ae56e56fdfad3940537495474aef62b1a12 )
-)
-
-game (
-	name "Tetris Kiwamemichi (GDL-0020)"
-	year "2004"
-	developer "Success"
-	rom ( name tetkiwam.zip size 1194 crc f32d0888 md5 05cc615496369c0959951477dc864991 sha1 e5b6b639b6987c2f778abc7af29cbaa658a8091c )
-)
-
-game (
 	name "Tetris (set 4, Japan, System 16A, FD1094 317-0093)"
 	year "1988"
 	developer "Sega"
@@ -53204,19 +39562,6 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name tetrisbl.zip size 157595 crc 73a78a78 md5 47ef06ec0038db552c7c656b5e6cf482 sha1 7854c81dc8cea10631a549bdc5017db779c766f9 )
-)
-
-game (
-	name "Tetris (bootleg of Mirrorsoft PC-XT Tetris version)"
-	developer "bootleg"
-	rom ( name tetriskr.zip size 184669 crc 8ad65f46 md5 70eb615ec5205fb52b7bbbf2d567bc1f sha1 a2c30b3a63e1101547da97213ebd86c3c94ace55 )
-)
-
-game (
-	name "Tetris Plus"
-	year "1995"
-	developer "Jaleco / BPS"
-	rom ( name tetrisp.zip size 6027113 crc 54bf037e md5 05ec2410c2f1b1f56d1279f4e8de563a sha1 231158a02fa8d0e83b1fd6efb2cd901c8e8d63d5 )
 )
 
 game (
@@ -53282,12 +39627,6 @@ game (
 )
 
 game (
-	name "Triforce DIMM Updater (GDT-0011)"
-	developer "Sega"
-	rom ( name tfupdate.zip size 211 crc d9159372 md5 449cc8f7ab3a96222478b880fb6025b7 sha1 8d61f0c994ee2380cc2b0f806a16fd56a1ce1724 )
-)
-
-game (
 	name "Tetris the Absolute The Grand Master 2"
 	year "2000"
 	developer "Arika"
@@ -53344,20 +39683,6 @@ game (
 )
 
 game (
-	name "Thayer's Quest"
-	year "1984"
-	developer "RDI Video Systems"
-	rom ( name thayers.zip size 24144 crc 5f267bf6 md5 23f19f8465758ab58d9f3aaf4de59630 sha1 3a2a274642f02ac0f9f2b0b877c11401613b224d )
-)
-
-game (
-	name "Thayer's Quest (Alternate Set)"
-	year "1984"
-	developer "RDI Video Systems"
-	rom ( name thayersa.zip size 24172 crc 7972538b md5 3296a5fa821d4b10bae87a2067fdd95c sha1 0b6be8b6bed96ba1fda041266b816b040e55f7e3 )
-)
-
-game (
 	name "The Deep (Japan)"
 	year "1987"
 	developer "Wood Place Inc."
@@ -53376,20 +39701,6 @@ game (
 	year "1980"
 	developer "Konami (Stern Electronics license)"
 	rom ( name theends.zip size 13680 crc 5d71510a md5 fc92f1f590a6205d143bc4d8cf1a1f42 sha1 f82d27f830745ba3eb0906aeef0745be19c1836f )
-)
-
-game (
-	name "The Gladiator (ver. 100)"
-	year "2003"
-	developer "IGS"
-	rom ( name theglad.zip size 21412132 crc 3aaafe08 md5 ff735d72d0fc7d3820dcdeab786f2b3b sha1 a73112dc741ccdd80cf4d0852b7679c34b355fc3 )
-)
-
-game (
-	name "The Gladiator (ver. 101)"
-	year "2003"
-	developer "IGS"
-	rom ( name theglada.zip size 1785218 crc d9cf2c7a md5 4da6b91eb95e16eac5a452e357ab3493 sha1 d4e1dbf6b7d9e4be8c5a19c93535aba9d8876988 )
 )
 
 game (
@@ -53418,20 +39729,6 @@ game (
 	year "1983"
 	developer "Epos Corporation"
 	rom ( name theglobp.zip size 15776 crc 3e4949d6 md5 b55dd947bc318b383f6d6ca9f7f5ac72 sha1 d0885574a3480f14e0788d2fc775cc59f245afea )
-)
-
-game (
-	name "The Grid (version 1.2)"
-	year "2001"
-	developer "Midway"
-	rom ( name thegrid.zip size 37781694 crc 5b0e926e md5 8f7188619ecacb8c66b394ca3f8fedd1 sha1 96f1e06c0a520586e596d3d5f6da0580c47174be )
-)
-
-game (
-	name "The Grid (version 1.1)"
-	year "2001"
-	developer "Midway"
-	rom ( name thegrida.zip size 1430811 crc db6b6e67 md5 6ab67883220c240d4d84811651297f05 sha1 368b3a1876c90955b61bef17dd64af4144d1b3b9 )
 )
 
 game (
@@ -53553,66 +39850,10 @@ game (
 )
 
 game (
-	name "Thunder Zone (World)"
-	year "1991"
-	developer "Data East Corporation"
-	rom ( name thndzone.zip size 3794222 crc 1d67a46f md5 ec0585515c5eb4211a014e33544a1956 sha1 f305256f620f2e2269665c99963e7c9810a7a8a6 )
-)
-
-game (
 	name "Thunder Hoop (Ver. 1)"
 	year "1992"
 	developer "Gaelco"
 	rom ( name thoop.zip size 2899974 crc 8dd0c606 md5 fd90da9be053b58eebcb8f9c03094879 sha1 6398fa4185edfdb3665bcc0eee27df8c7822d4be )
-)
-
-game (
-	name "TH Strikes Back"
-	year "1994"
-	developer "Gaelco"
-	rom ( name thoop2.zip size 4713185 crc f2bd51f2 md5 a2f043c7b6a842b48f72a381f177ed52 sha1 f3a008024201f7e40ad84ebff091670f3c041f9b )
-)
-
-game (
-	name "Thrill Drive 2 (ver EBB)"
-	year "2001"
-	developer "Konami"
-	rom ( name thrild2.zip size 2094 crc a047dc65 md5 660fe04dddf2e8b180c3ced997602749 sha1 93a2c79032e2a779b19178aebc80a9b99a17b69d )
-)
-
-game (
-	name "Thrill Drive 2 (ver AAA)"
-	year "2001"
-	developer "Konami"
-	rom ( name thrild2a.zip size 6490 crc 7e6cdf5f md5 f0735d7e54b8da758f5419679b72a84b sha1 5333416fd83117a222f845243cbf625815d9f258 )
-)
-
-game (
-	name "Thrill Drive (JAE)"
-	year "1998"
-	developer "Konami"
-	rom ( name thrilld.zip size 15228134 crc 667961db md5 25e6dc400efa82fdc67ec8a227613d17 sha1 66b222b1176fb4263f5c562b5aff5ef8c2201c41 )
-)
-
-game (
-	name "Thrill Drive (JAB)"
-	year "1998"
-	developer "Konami"
-	rom ( name thrilldb.zip size 1551529 crc 0db025f7 md5 ff468cfba1189b347c0dd1292886ac84 sha1 406c947dc82945024303fab6411cdab168deb1cb )
-)
-
-game (
-	name "Operation Thunder Hurricane (ver EAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name thunderh.zip size 11570668 crc 08130401 md5 4b00da091cac5222d748bf742a1a1667 sha1 0638f8197311db8c2e553e58a4eef18011875766 )
-)
-
-game (
-	name "Operation Thunder Hurricane (ver UAA)"
-	year "1996"
-	developer "Konami"
-	rom ( name thunderhu.zip size 599289 crc 0974594f md5 9f6370d26303999a1a2f7e69ff0662a1 sha1 673c02b8dece93111fd156fddd5b83a888f6b6bc )
 )
 
 game (
@@ -53704,13 +39945,6 @@ game (
 	year "1985"
 	developer "Merit"
 	rom ( name tictac.zip size 303266 crc 3160560e md5 99af7aa8dd87c4a2065f943bffe2036d sha1 5c0970df2883ea55b6c64affa1fad09a32458e1a )
-)
-
-game (
-	name "Tiger Heli (US)"
-	year "1985"
-	developer "Toaplan / Taito America Corp."
-	rom ( name tigerh.zip size 96861 crc 4c52aad7 md5 cfc2d493bc5a6f7a36c76afbe1769d99 sha1 d713c1d82f1abd5daefcf5d0e23e9832499efae0 )
 )
 
 game (
@@ -53840,34 +40074,6 @@ game (
 )
 
 game (
-	name "Time Crisis 2 (TSS3 Ver. B)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2.zip size 39202883 crc bc80172e md5 fc27caf20fbf19f239757fb81d686c28 sha1 5f3b53dbc9d4958fa3c1213ad5a3fab4d94bff70 )
-)
-
-game (
-	name "Time Crisis 2 (TSS2 Ver. B)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2b.zip size 897604 crc 31485f91 md5 c8cad24a18c9a2c5ee2408216d395f80 sha1 db1103edba9f0bf1e0130d990df6c455d4c57911 )
-)
-
-game (
-	name "Time Crisis 2 (TSS4 Ver. A)"
-	year "1997"
-	developer "Namco"
-	rom ( name timecrs2c.zip size 961376 crc 16d62a82 md5 6b2bb8bf384e9490c3cf67a83a03adfa sha1 3a94246d3cf956da54a8e1f61c357f6150db78d9 )
-)
-
-game (
-	name "Time Crisis 3 (TST1)"
-	year "2003"
-	developer "Namco"
-	rom ( name timecrs3.zip size 1761417 crc af2df1ce md5 d8cad66b7c09e09dd7d39a11ffc7fb38 sha1 1a7c9699dff3edfbc40836317a7af22ab0cdd304 )
-)
-
-game (
 	name "Time Killers (v1.32)"
 	year "1992"
 	developer "Strata/Incredible Technologies"
@@ -53879,20 +40085,6 @@ game (
 	year "1992"
 	developer "Strata/Incredible Technologies"
 	rom ( name timekill131.zip size 301376 crc 49b7a45d md5 ff4512ee4e3aa064a4cb845c92005c9d sha1 ef046e5331cc8638a640f73cf69ba034dc8953fc )
-)
-
-game (
-	name "Time Limit"
-	year "1983"
-	developer "Chuo Co. Ltd"
-	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
-)
-
-game (
-	name "Time Machine (v2.0)"
-	year "1989"
-	developer "Barcrest"
-	rom ( name timemchn.zip size 521367 crc 55aff606 md5 bb49ba926d0d107d70d9c14506a11503 sha1 0e2b713ca565eab3af5a149ca5c7807a60e9ad5d )
 )
 
 game (
@@ -53924,13 +40116,6 @@ game (
 )
 
 game (
-	name "Time Scanner (set 1, System 16A, FD1089B 317-0024)"
-	year "1987"
-	developer "Sega"
-	rom ( name timescan1.zip size 181726 crc c14f93e0 md5 0eeee068e46bf19860f3d6e5ca7ab632 sha1 85eae90fa2e012de69afa2ab60537c89e4bea3ff )
-)
-
-game (
 	name "Time Soldiers (US Rev 3)"
 	year "1987"
 	developer "Alpha Denshi Co. (SNK/Romstar license)"
@@ -53942,13 +40127,6 @@ game (
 	year "1987"
 	developer "Alpha Denshi Co. (SNK/Romstar license)"
 	rom ( name timesold1.zip size 43268 crc 2eea9fc2 md5 847ffeaf47dc4584861b640d6acd6667 sha1 893daa0472e69654eab5fc9547762a3d38053311 )
-)
-
-game (
-	name "Time Traveler"
-	year "1991"
-	developer "Virtual Image Productions (Sega license)"
-	rom ( name timetrv.zip size 53103 crc 5f036909 md5 62d0c281c966d27cedb393b31abd09b6 sha1 52677d7d576835ad7cac345fbc5bece9c09c84d4 )
 )
 
 game (
@@ -53980,24 +40158,10 @@ game (
 )
 
 game (
-	name "The Invaders"
-	year "1978"
-	developer "Zelco / Zaccaria"
-	rom ( name tinv2650.zip size 3500 crc bb51c29a md5 e4619c7b86a4fd023bd54fba898517d1 sha1 0cc19956013262bd729b2f575615bce6d3b4e74e )
-)
-
-game (
 	name "Tip Top"
 	year "1983"
 	developer "Sega"
 	rom ( name tiptop.zip size 21860 crc 6df7af85 md5 bf6137158d359092cf23e530d81c69f9 sha1 4360fe3a7610a1ae0e226abc09b6d2278b4c774e )
-)
-
-game (
-	name "Treasure Island"
-	year "1981"
-	developer "Data East Corporation"
-	rom ( name tisland.zip size 30483 crc e2e0c43a md5 6c109d6107b36226ec115b489f35e525 sha1 92d9d1ab7fbdae675b12b45ca789e363f985804f )
 )
 
 game (
@@ -54029,45 +40193,10 @@ game (
 )
 
 game (
-	name "Mahjong Tian Jiang Shen Bing"
-	year "1997"
-	developer "IGS"
-	rom ( name tjsb.zip size 1398954 crc 25a09462 md5 ef1e7f31a4d17bdf987960e7da392f6b sha1 5262daaf7b36a7ccdfa7da712bf238882b9f7faa )
-)
-
-game (
-	name "Tobikose! Jumpman"
-	year "1999"
-	developer "Namco"
-	rom ( name tjumpman.zip size 488609 crc fe8d20b5 md5 5b5ca2c2d8074c26b318e684bbd1b31c sha1 8c345ded4f9a8630682630cf4811c7e4cd683fc6 )
-)
-
-game (
-	name "Touki Denshou -Angel Eyes- (VER. 960614)"
-	year "1996"
-	developer "Tecmo"
-	rom ( name tkdensho.zip size 14423230 crc de83cd11 md5 1ec081f1b50c0562533d4ddfa841bf10 sha1 b014cdbfd63b739561ff9feb0cf580f613c68209 )
-)
-
-game (
-	name "Touki Denshou -Angel Eyes- (VER. 960427)"
-	year "1996"
-	developer "Tecmo"
-	rom ( name tkdenshoa.zip size 298531 crc a38b8b30 md5 ee206cbbc74d0f46d703b87f83ca3384 sha1 2999b20ada38e76720dae2e290d4b3f96e1455c4 )
-)
-
-game (
 	name "Tokimeki Memorial Taisen Puzzle-dama (ver JAB)"
 	year "1995"
 	developer "Konami"
 	rom ( name tkmmpzdm.zip size 7298231 crc bee17002 md5 0008bc1a35732900ccac30924a9501e8 sha1 94c410173e135a913c96c6509ca2ac803c7ed1d7 )
-)
-
-game (
-	name "Tecmo Knight"
-	year "1989"
-	developer "Tecmo"
-	rom ( name tknight.zip size 329041 crc bb24a96e md5 9e1524793baa1b447bc9eb19c91e6072 sha1 1a3938c5b5c07c8b9b18f942f9d00e4e248b1eac )
 )
 
 game (
@@ -54190,41 +40319,6 @@ game (
 )
 
 game (
-	name "T-MEK (v5.1, The Warlords)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek.zip size 19930714 crc 0716dca4 md5 d93a33ee27198a32aad1139b8742d721 sha1 6cc7262036eb0150282060a3c296d0a5fb672893 )
-)
-
-game (
-	name "T-MEK (v2.0, prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek20.zip size 244746 crc 8b9f3223 md5 e14ada0002eb8dfc384a66f62eb5fb4c sha1 759f40be85011aa3b480413991985795db079e64 )
-)
-
-game (
-	name "T-MEK (v4.4)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek44.zip size 256758 crc 31e36c7e md5 63bfa8afc59edc8aea2401b4101a5111 sha1 c80788aa71eb2d526fbf6a1f34029af36bdc2463 )
-)
-
-game (
-	name "T-MEK (v4.5)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek45.zip size 257144 crc 024d08f8 md5 db4aceda90bc3e43929451c8aafed810 sha1 4830969029e3c1d46d335c451495035787a48a81 )
-)
-
-game (
-	name "T-MEK (v5.1, prototype)"
-	year "1994"
-	developer "Atari Games"
-	rom ( name tmek51p.zip size 240656 crc 0e03d2ca md5 bf8fa7c2aa81b8b1bd459fd60ae1dcc9 sha1 4c2d37cb628ad6f25c71c1089e3ff2128de8f9c8 )
-)
-
-game (
 	name "Teenage Mutant Hero Turtles (UK 4 Players, set 1)"
 	year "1989"
 	developer "Konami"
@@ -54257,13 +40351,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name tmhta.zip size 176741 crc ba8090fa md5 c04f192b0e4200ef3e1e620f40c872f7 sha1 0b036fe6c5756808ecef46591f373a8056a0b2d8 )
-)
-
-game (
-	name "Tokimeki Mahjong Paradise - Dear My Love"
-	year "1997"
-	developer "Media / Sonnet"
-	rom ( name tmmjprd.zip size 27572083 crc dc34ae2f md5 3dae59f29f18970b869fd37f27b4b5ca sha1 4ad745c29813d820a53854a75fca8312b83ad269 )
 )
 
 game (
@@ -54327,13 +40414,6 @@ game (
 	year "1989"
 	developer "Konami"
 	rom ( name tmntua.zip size 176571 crc 7db57f0a md5 f3d260fcbf29776520d6fc8014e09a9b sha1 9f6a0916f4d88890695aaa693973320136837b79 )
-)
-
-game (
-	name "Tokimeki Mahjong Paradise - Doki Doki Hen"
-	year "1998"
-	developer "Media / Sonnet"
-	rom ( name tmpdoki.zip size 670462 crc ae7db8a6 md5 e96a713fa84b8d5816f2edfa8496ee20 sha1 0028257fc2c27dac6bc9bcac0a56857812d70bcf )
 )
 
 game (
@@ -54449,13 +40529,6 @@ game (
 )
 
 game (
-	name "Toggle (prototype)"
-	year "1985"
-	developer "Bally/Sente"
-	rom ( name toggle.zip size 28942 crc b3d491d6 md5 5d42dc7f10c75c6d17819ff1d779f4dc sha1 0b0b420c5d754476df8294c40f308e89093b217e )
-)
-
-game (
 	name "Toki (World, set 1)"
 	year "1989"
 	developer "TAD Corporation"
@@ -54484,45 +40557,10 @@ game (
 )
 
 game (
-	name "Tokimeki Memorial Oshiete Your Heart (GE755 JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name tokimosh.zip size 237 crc a4d2a1f8 md5 2886eef3e9cc564387cac177886013a8 sha1 b98bf0f26d3b823fabeea10cc4f07d5cd8a57a15 )
-)
-
-game (
-	name "Tokimeki Memorial Oshiete Your Heart Seal version PLUS (GE756 JAB)"
-	year "1997"
-	developer "Konami"
-	rom ( name tokimosp.zip size 236 crc f4facb8d md5 d58baf8631bd1a6569744615519195c4 sha1 0619df705a165b6afdbdbb57ee849104e5b5c470 )
-)
-
-game (
-	name "Tokio / Scramble Formation (newer)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name tokio.zip size 343947 crc 8c9af2fe md5 3500cdedc7befd0ed685ac16467c6dea sha1 d89bc91a250767b8be1336b22e50565a97021d18 )
-)
-
-game (
 	name "Tokio / Scramble Formation (bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name tokiob.zip size 39617 crc 6d4a3208 md5 41182138886e3f2ca3d1ce8cea55793b sha1 e912e8c80ef183ea6299ee9dbba9e4cfbae48640 )
-)
-
-game (
-	name "Tokio / Scramble Formation (older)"
-	year "1986"
-	developer "Taito Corporation"
-	rom ( name tokioo.zip size 39004 crc 5ff756a1 md5 049d1f37ae511da3fe333c85eecdba1b sha1 0c9b061fddbb5dda026c71b145760b4a477b7643 )
-)
-
-game (
-	name "Tokio / Scramble Formation (US)"
-	year "1986"
-	developer "Taito America Corporation (Romstar license)"
-	rom ( name tokiou.zip size 29855 crc 89695daa md5 7fcdf79622e87ba48bd390585329743d sha1 374fd9b049115911b2a07dd484b651bc10f1fbbd )
 )
 
 game (
@@ -54561,13 +40599,6 @@ game (
 )
 
 game (
-	name "Tokyo Wars (Rev. TW2 Ver.A)"
-	year "1996"
-	developer "Namco"
-	rom ( name tokyowar.zip size 14948944 crc a9acef40 md5 71c0b6f4b915908087c8422e9cb04bd5 sha1 d89e9e111357a0a169b2d2482c0843d0c1b72481 )
-)
-
-game (
 	name "Tomahawk 777 (rev 5)"
 	year "1980"
 	developer "Data East"
@@ -54586,13 +40617,6 @@ game (
 	year "1985"
 	developer "Atari"
 	rom ( name tomcat.zip size 17855 crc 18360def md5 7c8b4c5f42bd0e7fa1ad1594f1389af9 sha1 095f9d883cd750d8e4231bbfe3d60fc768431e95 )
-)
-
-game (
-	name "TomCat (Star Wars hardware, prototype)"
-	year "1983"
-	developer "Atari"
-	rom ( name tomcatsw.zip size 17349 crc be9cb92f md5 89d5d25b33cae9e523792c8db7e2cd3f sha1 52bc89e01f6b4168c667c93db9c290f830ac938f )
 )
 
 game (
@@ -54652,20 +40676,6 @@ game (
 )
 
 game (
-	name "Top Blade V"
-	year "2003"
-	developer "SonoKong / Expotato"
-	rom ( name topbladv.zip size 10318862 crc f10ccc9e md5 391d17a3e7888ea5150b86e1b1042760 sha1 693fdbb9a83c9c84db875ca22c2b67c954af93ce )
-)
-
-game (
-	name "Top Gear - 4VXFC969"
-	year "1996"
-	developer "Aristocrat"
-	rom ( name topgear.zip size 48765 crc de330cea md5 5741ae23239adf4ba39bd74425988288 sha1 aa83e06a6a1cd23394808506bb21ccac75a643a5 )
-)
-
-game (
 	name "Vs. Top Gun"
 	year "1987"
 	developer "Konami"
@@ -54708,20 +40718,6 @@ game (
 )
 
 game (
-	name "Top Landing (World)"
-	year "1988"
-	developer "Taito Corporation Japan"
-	rom ( name topland.zip size 1101580 crc 3d6dbb10 md5 775d64b707172a61a65b6e1d6fd0199d sha1 8f01dff109f616f9fd161e068ebf7100febe2fd4 )
-)
-
-game (
-	name "Toppy _ Rappy"
-	year "1996"
-	developer "SemiCom"
-	rom ( name toppyrap.zip size 899598 crc d49e6bb7 md5 61bbd8147ccafe4c91480c2083f590e0 sha1 99620ac1f426bfa55d603e5423313ac15c3a05dc )
-)
-
-game (
 	name "Top Racer (with MB8841 + MB8842, 1984)"
 	year "1984"
 	developer "bootleg"
@@ -54757,31 +40753,10 @@ game (
 )
 
 game (
-	name "Top Secret (Japan)"
-	year "1987"
-	developer "Capcom"
-	rom ( name topsecrt.zip size 249187 crc 219d6939 md5 b832e5c3f97d1cde73f62595c357516f sha1 af76c863975df45fc66a59685b72dbc10c79921e )
-)
-
-game (
 	name "Top Shooter"
 	year "1995"
 	developer "Sun Mixing"
 	rom ( name topshoot.zip size 187152 crc 3d6f0a6b md5 1bdecf04a543749844810276be87a66f sha1 6b16470ac22917584fd98f115c9f9c7a650d63e5 )
-)
-
-game (
-	name "Top Skater (Export, Revision A)"
-	year "1997"
-	developer "Sega"
-	rom ( name topskatr.zip size 41391632 crc 1b1f80d3 md5 c5350e2d041e68ea17cb4f2b60207d20 sha1 6daea8ba609a12de1a94d37a116be7ce665d36b8 )
-)
-
-game (
-	name "Top Skater (USA)"
-	year "1997"
-	developer "Sega"
-	rom ( name topskatru.zip size 324655 crc d25c4806 md5 cbb505cb3a92dd0ce07743c162861a0c sha1 f5ff7b845abbe6ef9bb2675794585b29f5c5bf36 )
 )
 
 game (
@@ -54803,13 +40778,6 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name toramich.zip size 178812 crc 42889d39 md5 6f24f4fa12087142e13579e768805b68 sha1 bf79c61611e145b6936fba8a0fb2b6a030d9232e )
-)
-
-game (
-	name "Tora Tora (prototype?)"
-	year "1980"
-	developer "GamePlan"
-	rom ( name toratora.zip size 8083 crc 88dd4f5e md5 5a6e37a33bd857b8a420876408328bcd sha1 f8864f46425f0b224092b9af28d58d76794f33e7 )
 )
 
 game (
@@ -54841,24 +40809,10 @@ game (
 )
 
 game (
-	name "Tornado (bootleg set 2)"
-	year "1980"
-	developer "bootleg (Jeutel)"
-	rom ( name tornado2.zip size 15955 crc 0276723d md5 18340987dad0709c32121928fd1d2a0e sha1 2d30a0f77209e12fb0cee4687293e49dfd66886f )
-)
-
-game (
 	name "Tornado Baseball / Ball Park"
 	year "1976"
 	developer "Midway / Taito"
 	rom ( name tornbase.zip size 4610 crc 172c9ce8 md5 346b14f98e5cd8a63dd035be3ed1009a sha1 1ce3da395e611546a20d95846b07e56da924b49a )
-)
-
-game (
-	name "Tortuga Family (Italian)"
-	year "1997"
-	developer "C.M.C."
-	rom ( name tortufam.zip size 30995 crc 12a433af md5 42f852152a30fc23e2cdbd82e2b57371 sha1 7411f6988e799a8bee2496c4ac35a0c84a91337e )
 )
 
 game (
@@ -54890,20 +40844,6 @@ game (
 )
 
 game (
-	name "The Typing of the Dead (JPN, USA, EXP, KOR, AUS) (Rev A)"
-	year "2000"
-	developer "Sega"
-	rom ( name totd.zip size 84411452 crc af96d271 md5 d1547d04315ff00054a2403cfc70efa7 sha1 43c12a983729561231e987d3cdd7840afa80282d )
-)
-
-game (
-	name "Total Vice (ver UAC)"
-	year "1997"
-	developer "Konami"
-	rom ( name totlvice.zip size 1539142 crc 78e98336 md5 13b360b91763afaf1a87c86e8e7207fa sha1 934a7ecbe196516131d5835913afe6e88ec62468 )
-)
-
-game (
 	name "Tottemo E Jong"
 	year "1991"
 	developer "Seibu Kaihatsu (Tecmo license)"
@@ -54914,27 +40854,6 @@ game (
 	name "Touche Me"
 	developer "&lt;unknown&gt;"
 	rom ( name toucheme.zip size 94774 crc 58f46660 md5 23e04a2f2987acf989d68322ec6496c8 sha1 b5bcd7ce1ea2f5fee8e03f79c6d7e91284a5c71a )
-)
-
-game (
-	name "Touch _ Go (World)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgo.zip size 5543391 crc 685a9f0f md5 fc11c95fe8a2992f4302904ea005df9e sha1 e6c14e1957e951fa9b25538fc486234f9c437453 )
-)
-
-game (
-	name "Touch _ Go (earlier revision)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgoe.zip size 552973 crc b825223b md5 dd41236919f9a6be06ed6aed75f0ad41 sha1 f26b36733ebfe5dec1046a573122314b663102bd )
-)
-
-game (
-	name "Touch _ Go (Non North America)"
-	year "1995"
-	developer "Gaelco"
-	rom ( name touchgon.zip size 549294 crc cf44b864 md5 8cbb12cd8789363679c7b072eefd8859 sha1 7cf423ac2868a4ddb89bfecc5ad1c162b4d5e40e )
 )
 
 game (
@@ -54956,20 +40875,6 @@ game (
 	year "2000"
 	developer "High Video"
 	rom ( name tour4010.zip size 596390 crc 5705b6aa md5 83664514ef1a21c70408d76c0db63e2b sha1 1a649f634ae0ff28e444655cacd17b6689f6b725 )
-)
-
-game (
-	name "Tournament Solitaire (V1.06, 08/03/95)"
-	year "1995"
-	developer "Dynamo"
-	rom ( name toursol.zip size 586434 crc 50076f27 md5 f92e5bcf9e1aa277a0d03106a7e6b816 sha1 8081a7ad9511c4b9e7faee65b969a86c57c4ad70 )
-)
-
-game (
-	name "Tournament Solitaire (V1.04, 06/22/95)"
-	year "1995"
-	developer "Dynamo"
-	rom ( name toursol1.zip size 552580 crc a25b923e md5 82ef22f99e2aa016fdd838db415059a4 sha1 bf666ece88cf91ddb3e13987245f0549660f3a41 )
 )
 
 game (
@@ -55001,13 +40906,6 @@ game (
 )
 
 game (
-	name "Turbo Out Run (cockpit, FD1094 317-unknown)"
-	year "1989"
-	developer "Sega"
-	rom ( name toutrun2.zip size 667293 crc 5c7c9c94 md5 919a71df2082b305204763a2002a0893 sha1 44ab603307334cc15728a2d3215c8efadfb7b3ac )
-)
-
-game (
 	name "Turbo Out Run (upright, FD1094 317-unknown)"
 	year "1989"
 	developer "Sega"
@@ -55015,24 +40913,10 @@ game (
 )
 
 game (
-	name "Toy Fighter"
-	year "1999"
-	developer "Sega"
-	rom ( name toyfight.zip size 38940433 crc 7d64791e md5 3479046dc018032ab34f8e964771510f sha1 05d21f09061afa60227d28ce6e7081fa4be278a0 )
-)
-
-game (
 	name "Toypop"
 	year "1986"
 	developer "Namco"
 	rom ( name toypop.zip size 54934 crc 6d0e39a7 md5 235f087dde8805bf8a5f78620e0c0dea sha1 5b4b0ce5f6606bd6ad73697e201f601df176d100 )
-)
-
-game (
-	name "Tetris Plus 2 (MegaSystem 32 Version)"
-	year "1997"
-	developer "Jaleco"
-	rom ( name tp2m32.zip size 6879740 crc 586cbf16 md5 d8f609ec690f1e967a2f923b0c3c6cfc sha1 512fae269cf6ef441d538a7cb6a55d65f088fe78 )
 )
 
 game (
@@ -55064,13 +40948,6 @@ game (
 )
 
 game (
-	name "Turbo Poker 2"
-	year "1993"
-	developer "Micro Manufacturing Inc."
-	rom ( name tpoker2.zip size 21193 crc bdc2f88a md5 9357208af93bd046e8ae9991c2e99298 sha1 aab57f44656c56648489918b498ddcb7b669395b )
-)
-
-game (
 	name "Track _ Field"
 	year "1983"
 	developer "Konami"
@@ -55085,31 +40962,10 @@ game (
 )
 
 game (
-	name "Track _ Field (NZ bootleg?)"
-	year "1982"
-	developer "bootleg? (Goldberg Enterprizes Inc.)"
-	rom ( name trackfldnz.zip size 30629 crc e3d4eb7d md5 8001d880ac5ec961542d1c62594c444a sha1 abe97578fe377a959c8171020ad36469ab377570 )
-)
-
-game (
-	name "Trail Blazer"
-	year "1987"
-	developer "Coinmaster"
-	rom ( name trailblz.zip size 25151 crc 84cda34f md5 dcc1e869fd107f1cca6d844bef3b0228 sha1 bb9fac030656587deefd799480b268f496410cfc )
-)
-
-game (
 	name "Thrash Rally"
 	year "1991"
 	developer "Alpha Denshi Co."
 	rom ( name trally.zip size 2872564 crc 7c581f5b md5 f2b50aac05018f14ff995cae4e852b35 sha1 82b0e4c08c6447c16e8594fd72088b9f1dc14297 )
-)
-
-game (
-	name "Tranquillizer Gun"
-	year "1980"
-	developer "Sega"
-	rom ( name tranqgun.zip size 13883 crc cb07f221 md5 65b7b8734cfd9197b3ef964746cc6213 sha1 ea5ba0f4746ec6b09eba29ddb4dc97cf733eacce )
 )
 
 game (
@@ -55155,13 +41011,6 @@ game (
 )
 
 game (
-	name "Trigger Heart Exelica (Rev A) (GDL-0036A)"
-	year "2005"
-	developer "Warashi"
-	rom ( name trgheart.zip size 1197 crc 2e1e0474 md5 7366baacaec4f07908aa60a43f9470fb sha1 3b91acfb08008724a70bc8aaa71ac9b9c3c6de07 )
-)
-
-game (
 	name "Trick Trap (World?)"
 	year "1987"
 	developer "Konami"
@@ -55187,13 +41036,6 @@ game (
 	year "1989"
 	developer "Data East Corporation"
 	rom ( name triothepj.zip size 193041 crc 6a523a98 md5 c211efe5bf2920130970a150dea8af44 sha1 2ad3bd4c7c4ca4bd32cdb81f032caf025538162e )
-)
-
-game (
-	name "Tripple Draw (V3.1 s)"
-	year "1981"
-	developer "Status Games"
-	rom ( name tripdraw.zip size 3873 crc 1eacd7d2 md5 882629000c458013b31c114af0d4d939 sha1 e5608201b3e5dd3a9a46a23ae43c234ef32abec7 )
 )
 
 game (
@@ -55246,80 +41088,10 @@ game (
 )
 
 game (
-	name "Tri-Sports"
-	year "1989"
-	developer "Bally Midway"
-	rom ( name trisport.zip size 391600 crc 9d1ed04b md5 23baf9702c40ee7236ec462a36ae48a8 sha1 6ed7b4493ac639831b93a1172fc7e3b88bca28d2 )
-)
-
-game (
-	name "Trivial Pursuit (Genus I) (set 2)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name trivia12.zip size 62892 crc a592eebc md5 43831bdde92dc32d106016de14e8f85d sha1 718bcd7747ea6683281402402d933997d5cc597d )
-)
-
-game (
-	name "Trivial Pursuit (Baby Boomer Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviabb.zip size 86909 crc fcd62551 md5 06b51d3ad5cd79c50c1cc978353f17ff sha1 9d78f0a7aed4d0cb71ace35685c7f5ce8e6f5fef )
-)
-
-game (
-	name "Trivial Pursuit (Spanish Edition)"
-	year "1987"
-	developer "Bally/Sente"
-	rom ( name triviaes.zip size 98540 crc 5fe1dee9 md5 82277fd6a3c241a5a39c8d022f285895 sha1 aa34c88bb85efa6029016ab96a5871aa67f91f76 )
-)
-
-game (
-	name "Trivial Pursuit (Genus I) (set 1)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviag1.zip size 63161 crc 42412d19 md5 355c6cddb4d9ed5291069d533b20a79a sha1 362b1d7f984c400488e804169cde08efb3a86ea2 )
-)
-
-game (
-	name "Trivial Pursuit (Genus II)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviag2.zip size 81472 crc 35e28e9a md5 f17d97b0dc95431217f05c7b13c24d6e sha1 e74d3acc230a27c7521406686428f8ad250240dd )
-)
-
-game (
 	name "Trivial Pursuit (prod. 1D)"
 	year "1996"
 	developer "JPM"
 	rom ( name trivialp.zip size 4629707 crc 69c30118 md5 650ec075162fe6ef59b814cb48cece69 sha1 6fac4dee5e78172d453f9db846111990a6d60004 )
-)
-
-game (
-	name "Trivial Pursuit (All Star Sports Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviasp.zip size 79007 crc 9fec4b51 md5 434d67ccc984a67a7e386e74acb19f66 sha1 d16547ced6599031a230103097fff69611e3e8b3 )
-)
-
-game (
-	name "Trivial Pursuit (Young Players Edition)"
-	year "1984"
-	developer "Bally/Sente"
-	rom ( name triviayp.zip size 81290 crc 3ea8b933 md5 a98d9c07b9e1e5a97e2fd9b802ebdf08 sha1 484d137137c31343702190e89addad65d9cca49b )
-)
-
-game (
-	name "Triv Quiz"
-	year "1984"
-	developer "Status Games"
-	rom ( name trivquiz.zip size 44640 crc 87331852 md5 7750c2aa24abe738c824108301f14223 sha1 7b7916e6594e8a6b4fef765e408a734d3c58b8e3 )
-)
-
-game (
-	name "Trizeal (GDL-0026)"
-	year "2004"
-	developer "Taito"
-	rom ( name trizeal.zip size 1196 crc ad843c95 md5 7bd38c86155a75fe6f293ed9b0ba8ad5 sha1 1f302410af35d840ce07fe4941b69f23c98a4ed7 )
 )
 
 game (
@@ -55386,34 +41158,6 @@ game (
 )
 
 game (
-	name "Tron (8/9)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron.zip size 48412 crc ca5217e6 md5 b1f988a78519c5dfd18e81918c2c0c97 sha1 4ebf329d173d2b3d4f95bda0a7e97f6cd1c06d08 )
-)
-
-game (
-	name "Tron (6/25)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron2.zip size 48435 crc 15498746 md5 0066db603bdfaad4139621be9d340585 sha1 48e746071d9c6bc97980f867dc0bf79474c3d3a3 )
-)
-
-game (
-	name "Tron (6/17)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron3.zip size 48582 crc d895822d md5 5fd9ee29f98887c1f63654e612f100f0 sha1 68447183de33dd3fec0d79218d4fc19c0cb0ab0c )
-)
-
-game (
-	name "Tron (6/15)"
-	year "1982"
-	developer "Bally Midway"
-	rom ( name tron4.zip size 38175 crc e9328452 md5 73e5c52a06588238a02c17155401e849 sha1 e4e1e0ebd7e2121bcc845764aeb3421faec9680a )
-)
-
-game (
 	name "Trophy Hunting - Bear _ Moose V1.0"
 	year "2002"
 	developer "Sammy USA Corporation"
@@ -55425,12 +41169,6 @@ game (
 	year "1993"
 	developer "Taito Corporation Japan"
 	rom ( name trstar.zip size 6730512 crc 904e2c27 md5 3eebb273d9fe234c6de470d27bac8989 sha1 17847f5b0394387e3d78ed397a41cdef1d4b0a38 )
-)
-
-game (
-	name "Triple Star 2000"
-	developer "A.M."
-	rom ( name trstar2k.zip size 278983 crc 6ebe85ac md5 da88d22f654f5cdda7362effce860c6c sha1 6d433126d41f9fdea87006e61e00e4dfdc8e2c07 )
 )
 
 game (
@@ -55482,13 +41220,6 @@ game (
 )
 
 game (
-	name "Trivia Challenge"
-	year "1985"
-	developer "Joyland (Senko license)"
-	rom ( name trvchlng.zip size 20815 crc 7357da19 md5 5881d8db2f010789487eef9c4731bb1a sha1 17394db4b31d1dea357a92c9841044fd32f04f0f )
-)
-
-game (
 	name "Trivia Genius"
 	year "1985"
 	developer "bootleg"
@@ -55500,20 +41231,6 @@ game (
 	year "1984"
 	developer "SMS Manufacturing Corp."
 	rom ( name trvhang.zip size 125229 crc 5a1ccbc8 md5 12cf81630da1c504be99b0bda33c9a9b sha1 da6288a017e31cfd16d18231bc823d936282b252 )
-)
-
-game (
-	name "Trivia Hangup (Question Set 2)"
-	year "1984"
-	developer "SMS Manufacturing Corp."
-	rom ( name trvhanga.zip size 25930 crc 671c18cf md5 0ff13a658cc30bb7dd7fa198668f843b sha1 f1e7406ed80bba2a0ec07dbb7253b828522d898b )
-)
-
-game (
-	name "Trivia Madness"
-	year "1985"
-	developer "Thunderhead Inc."
-	rom ( name trvmadns.zip size 113713 crc 300a51bb md5 0939040a87841a614eac86810878bcbf sha1 4c02ad0f696ff9abfd657a0df43cf688adeb479d )
 )
 
 game (
@@ -55534,7 +41251,7 @@ game (
 	name "Trivia Master (set 3)"
 	year "1985"
 	developer "Enerdyne Technologies Inc."
-	rom ( name trvmstrb.zip size 91183 crc 3d096c84 md5 8ceb682d93f1a97f8328dfc96dde80dd sha1 a6ab8522912a0c9db2df33c29ecb07ce5c8c05f1 )
+	rom ( name trvmstrb.zip size 87212 crc 348e6d27 md5 96a33c564d3eaab03f753efb3362685c sha1 63ccda3e75baa85c190843aa3de799319f379808 )
 )
 
 game (
@@ -55671,20 +41388,6 @@ game (
 )
 
 game (
-	name "Shingen Samurai-Fighter (Japan, English)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name tshingen.zip size 800531 crc f9576ca7 md5 9ac76b1bd2e9a7104de273de6e9127c3 sha1 da6513cfb037cdc7903e38574f381b9f2cbabfdb )
-)
-
-game (
-	name "Takeda Shingen (Japan, Japanese)"
-	year "1988"
-	developer "Jaleco"
-	rom ( name tshingena.zip size 207168 crc 99d9089a md5 0f7fb21ae0a6442553862bbe787406c8 sha1 59ddac65c9c512302988ec409c408a71410db922 )
-)
-
-game (
 	name "Turkey Shoot"
 	year "1984"
 	developer "Williams"
@@ -55718,43 +41421,10 @@ game (
 )
 
 game (
-	name "Tsurugi (ver EAB)"
-	year "2001"
-	developer "Konami"
-	rom ( name tsurugi.zip size 681 crc 8224037c md5 07357f68e73ba4377c488e3cb8680c79 sha1 e38f462c2fee9380942c6fd46aa774c1f1fcad0e )
-)
-
-game (
-	name "Table Tennis Champions (set 1)"
-	developer "Gamart?"
-	rom ( name ttchamp.zip size 882634 crc 24d3a9e6 md5 e7c872f2cd61016e8c6ffab07c5722ca sha1 b386e05233f000ce6d80d581419ebacf3df3c56d )
-)
-
-game (
-	name "Table Tennis Champions (set 2)"
-	developer "Gamart?"
-	rom ( name ttchampa.zip size 386428 crc da4d014d md5 45cd77315372403dec854e045675aa83 sha1 14b0183a0d7022d414a75ff23dd139fb178f3a48 )
-)
-
-game (
 	name "T.T Mahjong"
 	year "1981"
 	developer "Taito"
 	rom ( name ttmahjng.zip size 15587 crc 5d12c981 md5 23c3df1eff55409c6cf5dc242eff9e83 sha1 cea2cf872965aec8b6430ddd54aab696cb4dee62 )
-)
-
-game (
-	name "Tough Turf (set 2, Japan, 8751 317-0104)"
-	year "1989"
-	developer "Sega / Sunsoft"
-	rom ( name tturf.zip size 525537 crc 56a7b5d1 md5 de62ce29c90a86429dda0a3f5ea3218f sha1 5a8ee2258cad7cf8c899058155133068dd867e8b )
-)
-
-game (
-	name "Tough Turf (bootleg)"
-	year "1989"
-	developer "bootleg (Datsu)"
-	rom ( name tturfbl.zip size 291266 crc 6de7eaad md5 e9b0787203df3f5dccaff74a9eb2a931 sha1 55d1f8cb0e96059790e9baba9e0c6b0545cf10b9 )
 )
 
 game (
@@ -55797,13 +41467,6 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name tumbleb.zip size 676021 crc 97720acc md5 068da54751b5898d972489bbfefa30ad sha1 b7d59dd6491377f22beda325868fd8d5c8818418 )
-)
-
-game (
-	name "Tumble Pop (bootleg set 2)"
-	year "1991"
-	developer "bootleg"
-	rom ( name tumbleb2.zip size 675669 crc 46ae3da0 md5 7423f1a013d1e79e074b71ea1813b227 sha1 cb580f576d1fdf528b9f03ad650e4f3f34c7d116 )
 )
 
 game (
@@ -55884,13 +41547,6 @@ game (
 )
 
 game (
-	name "Turbo Tag (prototype)"
-	year "1985"
-	developer "Bally Midway"
-	rom ( name turbotag.zip size 81349 crc 110a73f3 md5 299492db454f6e474158d50d247cd68b sha1 efb26d0470e0185af509c50c68a318d096c59233 )
-)
-
-game (
 	name "Neo Turf Masters / Big Tournament Golf"
 	year "1996"
 	developer "Nazca"
@@ -55905,30 +41561,10 @@ game (
 )
 
 game (
-	name "Turnover (v2.3)"
-	developer "Barcrest"
-	rom ( name turnover.zip size 585639 crc 4af33d94 md5 e2aaffa51ad19121b3afdbf2861fdd10 sha1 44d5bc2b69c95cb6602da459bd8b2211f2d2c768 )
-)
-
-game (
 	name "Turpin"
 	year "1981"
 	developer "Konami (Sega license)"
 	rom ( name turpin.zip size 8403 crc d6f0e60b md5 2b7252cc75aefb340caf8f603f740bb8 sha1 127ae32c2c37f822661be951ae9890bdef9929ec )
-)
-
-game (
-	name "Turpin (bootleg on Scramble hardware)"
-	year "1981"
-	developer "bootleg"
-	rom ( name turpins.zip size 11853 crc aa383f59 md5 8d8a9c606871787d8a1b0f1efda015a2 sha1 94333b5e674191f551c481b42b78b827b6b2b83c )
-)
-
-game (
-	name "Turret Tower"
-	year "2001"
-	developer "Dell Electronics (Namco license)"
-	rom ( name turrett.zip size 395948 crc 43f9b137 md5 f9bbe98cc57784fe6ad2261a47da93a4 sha1 3d2022eaf050d1b4f36d4da507c0fff037cf3440 )
 )
 
 game (
@@ -55978,13 +41614,6 @@ game (
 	year "1996"
 	developer "Island Design"
 	rom ( name tutstomb.zip size 174339 crc 8a42cc6d md5 651c3e72afb66f80842c5f05d815eeca sha1 aee1c6213a32e0d839f78ac0ca25a842479cea95 )
-)
-
-game (
-	name "Tecmo World Cup '98 (JUET 980410 V1.000)"
-	year "1998"
-	developer "Tecmo"
-	rom ( name twcup98.zip size 7713473 crc 789fdabd md5 43df7074654913431ac5f0917efd00a4 sha1 35b058e5297cf2357be3e8a1889a76239712bf1c )
 )
 
 game (
@@ -56079,20 +41708,6 @@ game (
 )
 
 game (
-	name "Twinkle"
-	year "1997"
-	developer "SemiCom"
-	rom ( name twinkle.zip size 377505 crc 87513d91 md5 d439c4e525244b83cfca5280dd09019d sha1 f963d9fcb539a9233fb3a5fb9f231811024b26a3 )
-)
-
-game (
-	name "Twin Qix (Ver 1.0A 1995/01/17) (Prototype)"
-	year "1995"
-	developer "Taito America Corporation"
-	rom ( name twinqix.zip size 3028197 crc a9e0703d md5 a43b278642f60c6891c43b23ef14309c sha1 1fc627611d3ed1f75690ae6eb9355760597a4cbd )
-)
-
-game (
 	name "Twins (set 1)"
 	year "1994"
 	developer "Electronic Devices"
@@ -56142,38 +41757,10 @@ game (
 )
 
 game (
-	name "Tecmo World Cup '94 (set 1)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name twrldc94.zip size 3668253 crc 4b39eded md5 4ed2aa753020897618551c98335f1e5f sha1 bd217187dd6422f17add409b7be7b67ecab7f42e )
-)
-
-game (
-	name "Tecmo World Cup '94 (set 2)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name twrldc94a.zip size 252596 crc 94a527dc md5 1d4a895855866fe8b023ebfbb985d7e1 sha1 8563fbbfeb17b1a12fcd54ab4752e99fb507aa1d )
-)
-
-game (
-	name "Tower _ Shaft"
-	year "2003"
-	developer "Aruze"
-	rom ( name twrshaft.zip size 2833960 crc 2d673cd7 md5 54edbb1ed30234c2544c9b11ffca68dd sha1 a0759914a13dbefc6a530a41390d76f10e8d518d )
-)
-
-game (
 	name "Tecmo World Soccer '96"
 	year "1996"
 	developer "Tecmo"
 	rom ( name tws96.zip size 6149679 crc 42604778 md5 eac62521bb2cf6c8f7951a2284601bf9 sha1 b98bb439ac653d78d3f6540d1796d52242d791be )
-)
-
-game (
-	name "TX-1"
-	year "1983"
-	developer "Tatsumi"
-	rom ( name tx1.zip size 107770 crc e1d14f3e md5 29e33378420a1311fed9b003e07acedb sha1 3da4d488dbcb3941cefdae9d706f642c90d07867 )
 )
 
 game (
@@ -56254,13 +41841,6 @@ game (
 )
 
 game (
-	name "Ufo Senshi Yohko Chan (not encrypted)"
-	year "1988"
-	developer "bootleg"
-	rom ( name ufosensib.zip size 98759 crc dcb80a59 md5 6fa39f62cafcadea6aaf139d608dcfdf sha1 669adcb0f0ffc8061417faa723c5a4b97062dc29 )
-)
-
-game (
 	name "Ultimate Tennis"
 	year "1993"
 	developer "Art &amp; Magic"
@@ -56338,20 +41918,6 @@ game (
 )
 
 game (
-	name "Under Defeat (GDL-0035)"
-	year "2005"
-	developer "G-Rev"
-	rom ( name undefeat.zip size 1196 crc abb3ebc8 md5 2cd21b6316f13ed401f83c8a14c88e15 sha1 f5a3e81a8747a16a333c73b0d4e65bd6fc2f8d49 )
-)
-
-game (
-	name "The Undoukai (Japan)"
-	year "1984"
-	developer "Taito Corporation"
-	rom ( name undoukai.zip size 97596 crc 1dec3d90 md5 450624ba6b92513df4363e2486072614 sha1 a599ef09eef56ca0adc97f743ee1c1a0509e8f8c )
-)
-
-game (
 	name "Under Fire (World)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -56377,40 +41943,6 @@ game (
 	year "1980"
 	developer "Irem"
 	rom ( name uniwars.zip size 18267 crc cf1c989f md5 679dd61a884eb13d3694cfe10c7f4a51 sha1 6a11612bb946be70243ffba890df0d0186fceacc )
-)
-
-game (
-	name "New Cherry Gold '99 (bootleg of Super Cherry Master) (set 1)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch1.zip size 104305 crc 19319d8a md5 070a117c255fec90f9a1b98812688cb8 sha1 d3be84063b8fbafc9dc1bdde1857000d1b4bbb11 )
-)
-
-game (
-	name "Super Cherry Gold (bootleg of Super Cherry Master)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch2.zip size 60092 crc 2d276ce4 md5 4d9d4e2d50b1a597eebc653083c84c0f sha1 7113a7cf08e6906f082925116f9c0bf70cfe8c30 )
-)
-
-game (
-	name "New Cherry Gold '99 (bootleg of Super Cherry Master) (set 2)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch3.zip size 49312 crc ce2ea104 md5 f79863bc4dafe3d7a86ba7880ce203b4 sha1 34d43d485668ee4cdead9afc933f788b6d1f8107 )
-)
-
-game (
-	name "Grand Cherry Master (bootleg of Super Cherry Master)"
-	year "1999"
-	developer "bootleg"
-	rom ( name unkch4.zip size 104302 crc 5604743d md5 dd68539860028b19dcd1a38a4ccd1586 sha1 42e5408241d6aff7ffc8f173da84abf1f87dfcb3 )
-)
-
-game (
-	name "unknown Meyco game"
-	developer "Meyco Games"
-	rom ( name unkmeyco.zip size 10802 crc ca452218 md5 ba6fc6e84746058aae34ee1e0b7cd2dd sha1 91a80f0040126bd2463b9d7565f114d87960931d )
 )
 
 game (
@@ -56467,20 +41999,6 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name upyoural.zip size 110212 crc c2a3fef4 md5 708658c54b604df2fecb7026b35d5573 sha1 50b122ea1406d1c928b00b14982d8a8a878ba724 )
-)
-
-game (
-	name "Otogizoushi Urashima Mahjong (Japan)"
-	year "1989"
-	developer "UPL"
-	rom ( name urashima.zip size 842889 crc 40519bc6 md5 a316e07bc309b3d56c91e811625acba4 sha1 b8aea9e4f54f74c0ea82017c1395138130d29291 )
-)
-
-game (
-	name "Usagi - Yamashiro Mahjong Hen (GDL-0022)"
-	year "2003"
-	developer "Warashi / Mahjong Kobo / Taito"
-	rom ( name usagui.zip size 1196 crc 2ea1a204 md5 105629083c44cf4fd4ffe837d3434043 sha1 5a6a8962d09fc7ade7b3f6c12a7020282f71690c )
 )
 
 game (
@@ -56610,13 +42128,6 @@ game (
 )
 
 game (
-	name "Vandyke (bootleg with PIC16c57)"
-	year "1990"
-	developer "bootleg"
-	rom ( name vandykeb.zip size 1072369 crc 5a2e6809 md5 fb23870c2a01a79836cb1ce8514c7343 sha1 8c97eed3121b2db2d92d02a49057a616bd2bf178 )
-)
-
-game (
 	name "Vandyke (Jaleco, Set 1)"
 	year "1990"
 	developer "UPL (Jaleco license)"
@@ -56715,31 +42226,10 @@ game (
 )
 
 game (
-	name "Varth: Operation Thunderstorm (World 920714)"
-	year "1992"
-	developer "Capcom"
-	rom ( name varth.zip size 1544763 crc 5e0796fe md5 6179a7782065b3f0a23e5be3ed69ec99 sha1 c777ddc4f79531b67188e07119961b97cb111270 )
-)
-
-game (
 	name "Varth: Operation Thunderstorm (Japan 920714)"
 	year "1992"
 	developer "Capcom"
 	rom ( name varthj.zip size 1317826 crc b1172b4c md5 4b08f6a1e719b6523bf65e8b12a60d12 sha1 14bb79d4d4abd7d25a92bbc8f39197b57d4dab71 )
-)
-
-game (
-	name "Varth: Operation Thunderstorm (World 920612)"
-	year "1992"
-	developer "Capcom"
-	rom ( name varthr1.zip size 371744 crc d79966b6 md5 dfc1d50f27d7f3db58b79b05c826f02a sha1 0eb6f2a3a510229d708e13d0a942ab2f983070bf )
-)
-
-game (
-	name "Varth: Operation Thunderstorm (USA 920612)"
-	year "1992"
-	developer "Capcom, distributed by Romstar"
-	rom ( name varthu.zip size 374451 crc 7f7ed097 md5 66d7a6e9ef118b3ee9535e27aa043e65 sha1 0606b4b3b49d28df2f56261aa5c302e6d6861da6 )
 )
 
 game (
@@ -56775,13 +42265,6 @@ game (
 	year "1983"
 	developer "Sesame Japan"
 	rom ( name vastar2.zip size 24162 crc a1cb9414 md5 1d4458a3c01edad0708e1494067055c3 sha1 1b4a15590afa237b7944800490df80d216195800 )
-)
-
-game (
-	name "Virtua Athletics / Virtua Athlete (GDS-0019)"
-	year "2002"
-	developer "Sega"
-	rom ( name vathlete.zip size 1197 crc e2188c1c md5 3ae592f9405498b656728623e12e43ea sha1 320c77ebe9ab3ec09bf68c50c51b8d00eb79cbee )
 )
 
 game (
@@ -56827,13 +42310,6 @@ game (
 )
 
 game (
-	name "Virtua Bowling (World, V101XCM)"
-	year "1996"
-	developer "IGS"
-	rom ( name vbowl.zip size 2363570 crc de0aba54 md5 6e293b5ec25533541bea76e1be0ca2ed sha1 b10589dd59d24ef582bbac82212d280295706552 )
-)
-
-game (
 	name "Virtua Bowling (Japan, V100JCM)"
 	year "1996"
 	developer "IGS / Alta"
@@ -56852,40 +42328,6 @@ game (
 	year "1996"
 	developer "Atari Games"
 	rom ( name vcircle.zip size 245898 crc 21baac8e md5 759ac2bce11d91101f1184af2f28bef7 sha1 b3b25329a9dc9e2bccdf435abf81440cdb688f3f )
-)
-
-game (
-	name "Virtual Combat"
-	year "1993"
-	developer "VR8 Inc."
-	rom ( name vcombat.zip size 1517690 crc 3e218f8e md5 41e7e07e8eb8749e8abe1c97a80ea443 sha1 a6ac438771ac687865d75676a4f444bb12ccccd7 )
-)
-
-game (
-	name "Virtua Cop (Revision B)"
-	year "1994"
-	developer "Sega"
-	rom ( name vcop.zip size 9507185 crc 664a488f md5 011f851d9c58a43c37c464e6b651ac87 sha1 da629c7713f2b4f77a2cfe3ad135514a07eb038e )
-)
-
-game (
-	name "Virtua Cop 2"
-	year "1995"
-	developer "Sega"
-	rom ( name vcop2.zip size 14778188 crc 0950054d md5 d33ffe46a9596b3ffc8a9a03b88139db sha1 e33ec1b8a3a420f8945e3c87ddf1a4d77f94bd7a )
-)
-
-game (
-	name "Virtua Cop 3 (GDX-0003A)"
-	year "2003"
-	developer "Sega"
-	rom ( name vcop3.zip size 219 crc c84f2805 md5 47c1219dfb620c4aed769355134d6643 sha1 6c5ae7bfc0000093e9363fd49dd206137d4ae9a6 )
-)
-
-game (
-	name "Vega"
-	developer "Olympia?"
-	rom ( name vega.zip size 13753 crc 74fb894b md5 7a4f18d2309fb9a17588ece3a182cbbb sha1 524e2faded3e4b269ead0f035fbe602993255c29 )
 )
 
 game (
@@ -56987,13 +42429,6 @@ game (
 )
 
 game (
-	name "Version 4 (Version 4.2R)"
-	year "2006"
-	developer "Amcoe"
-	rom ( name version4.zip size 146244 crc b0195fb1 md5 a1a8d92ad131292532015ba5f765bc53 sha1 79998d03bf8bbb01ab176b51e4cf76cc733c9f71 )
-)
-
-game (
 	name "Virtua Fighter"
 	year "1993"
 	developer "Sega"
@@ -57001,142 +42436,10 @@ game (
 )
 
 game (
-	name "Virtua Fighter 2 (Version 2.1)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2.zip size 19940995 crc 9f29e31d md5 2645d155fe62c39c758e88d825d4cac2 sha1 ef801401f3488e6e61f215395ba1faebaddb514e )
-)
-
-game (
-	name "Virtua Fighter 2 (Revision A)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2a.zip size 195942 crc 386c6487 md5 d86622296d1562257757b13e679c7406 sha1 e31d42d12d160cfb68a75965e65de4a8b7587b70 )
-)
-
-game (
-	name "Virtua Fighter 2 (Revision B)"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2b.zip size 201918 crc feff9fdb md5 594857fd6c63460ed6c643647447063c sha1 349dd764235829c68efd9d4a8e1055294f036bb2 )
-)
-
-game (
-	name "Virtua Fighter 2"
-	year "1995"
-	developer "Sega"
-	rom ( name vf2o.zip size 195844 crc 8f292d4e md5 a171180b7a7bfb5723385b95b02b7745 sha1 482a9d09cafea5e56d2f8a559aa76d9d148321d9 )
-)
-
-game (
-	name "Virtua Fighter 3 (Revision C)"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3.zip size 69730653 crc 55da172e md5 10a23e1f0a6b891919bfe240be3bc342 sha1 f000b2b074998087702498f89acd59ec3fc13dca )
-)
-
-game (
-	name "Virtua Fighter 3 (Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3a.zip size 998056 crc 2f87412d md5 feac014300ac539d7ab90163386accd8 sha1 82d64ef6af055a6d35b054530f7fd5a203c255bf )
-)
-
-game (
-	name "Virtua Fighter 3 Team Battle"
-	year "1996"
-	developer "Sega"
-	rom ( name vf3tb.zip size 10121647 crc f2fec498 md5 20389f1fd8a7fff014dfc38dfde00783 sha1 1d120ffb09dcc22d8b6a68b16caffd31793d66c7 )
-)
-
-game (
-	name "Virtua Fighter 4 (GDS-0012)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4.zip size 1194 crc f56f284f md5 383ee658d376419bb7f48b65e8f7d6f2 sha1 027ba367867821caecd2335d6e51fa0a12540851 )
-)
-
-game (
-	name "Virtua Fighter 4 (Cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4cart.zip size 136676704 crc f4802443 md5 7a57e5bcdf4a0d686466c289e0f6779d sha1 55bc2fec62cf8c32c51c35f4f296a80b0722dd2d )
-)
-
-game (
-	name "Virtua Fighter 4 Evolution (Rev B) (GDS-0024B)"
-	year "2002"
-	developer "Sega"
-	rom ( name vf4evo.zip size 1194 crc 2936114c md5 381739a42986b6e56706c85576e6e33a sha1 360c2c830794c274a7ec309f8472100cf1c1c33e )
-)
-
-game (
-	name "Virtua Fighter 4 Evolution (Cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vf4evoct.zip size 135639761 crc b1d38673 md5 730b7bda92daa82ccc63cb9b8e365048 sha1 6a400f704e312e975b49fe437a6c8ebef6f694ff )
-)
-
-game (
-	name "Virtua Fighter 4 Final Tuned (Rev F) (GDS-0036F)"
-	year "2004"
-	developer "Sega"
-	rom ( name vf4tuned.zip size 1196 crc f37667e2 md5 9c3f452daf1166721d19360e90da36c1 sha1 111d5e1c0bf97fe008e16bd0089985b3696d766e )
-)
-
-game (
-	name "V-Five (Japan)"
-	year "1993"
-	developer "Toaplan"
-	rom ( name vfive.zip size 1115620 crc 15d6bf51 md5 5048fb81a0cae5cf8306bd96ae5ad805 sha1 28140e3734a4e552fb4c0beba8b573429923d413 )
-)
-
-game (
 	name "Virtua Fighter Kids (JUET 960319 V0.000)"
 	year "1996"
 	developer "Sega"
 	rom ( name vfkids.zip size 24176482 crc 4d738c97 md5 d580a83247e3e571af72d6c5734efa0b sha1 3f7e193c4764cf063a0c532b2f017ebe1575612f )
-)
-
-game (
-	name "Virtua Formula"
-	year "1993"
-	developer "Sega"
-	rom ( name vformula.zip size 573026 crc 9adb4aa5 md5 5acd5c3fae5560410d31a46e3adcfed3 sha1 8e7b5cfb2b60bca84bdc16013b9469e3c8d2a69b )
-)
-
-game (
-	name "Virtua Fighter Remix (JUETBKAL 950428 V1.000)"
-	year "1995"
-	developer "Sega"
-	rom ( name vfremix.zip size 13245661 crc ae738cc0 md5 8e0c28202242f69f64928b2d786bd86f sha1 9fea35a65264c3a512b463e9333b53a3db8a4eb9 )
-)
-
-game (
-	name "Net Select Keiba Victory Furlong"
-	year "2005"
-	developer "Sammy"
-	rom ( name vfurlong.zip size 101810678 crc b1988b94 md5 df01e11e318d74daea4282f3d2888c2f sha1 40d026ceac4aeae56d7650a488feed941cf38840 )
-)
-
-game (
-	name "V Goal Soccer (set 2)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name vgoalsca.zip size 3248038 crc e710bbb6 md5 2284170ce2fc39fa62a7da2d928778f9 sha1 150bff7482e841cc3927c305f74d8ec6cb60a6cb )
-)
-
-game (
-	name "V Goal Soccer (set 1)"
-	year "1994"
-	developer "Tecmo"
-	rom ( name vgoalsoc.zip size 3998125 crc fd11882a md5 8d28bacb20f1690149ef45a57d5bd5ea sha1 381d6d9f3172298e7b05b7938595678c26c2415b )
-)
-
-game (
-	name "Vegas Poker (prototype, release 2)"
-	developer "BwB"
-	rom ( name vgpoker.zip size 184496 crc 3da116cf md5 e2fa939bcbbfab6c8db344613b8260e8 sha1 6176d000b755ca679b2da477839eb885d87e55fb )
 )
 
 game (
@@ -57182,24 +42485,10 @@ game (
 )
 
 game (
-	name "Victorious Nine"
-	year "1984"
-	developer "Taito"
-	rom ( name victnine.zip size 99727 crc a48c32af md5 af3a5cb752bb9ac4bb1e8a20e582d698 sha1 7cf1f37b57ec9c2ce64566ad4b51c7071589a996 )
-)
-
-game (
 	name "Victor 21"
 	year "1990"
 	developer "Subsino / Buffy"
 	rom ( name victor21.zip size 59931 crc 8058f02c md5 133b21b0fbe1a562bdbe67117ecbafd5 sha1 c7fdf4bbdc5dd33831aa68ed0cb781656d249cbc )
-)
-
-game (
-	name "G.E.A."
-	year "1991"
-	developer "Subsino"
-	rom ( name victor5.zip size 60370 crc 789405ce md5 19a92dc9bb867380b6b3e7c53e2777f9 sha1 d5fc128372b04617e4b19a23070d47daff30c5bc )
 )
 
 game (
@@ -57270,48 +42559,6 @@ game (
 	year "1992"
 	developer "Sammy / Aicom"
 	rom ( name viewpoin.zip size 4045243 crc b3c55b87 md5 35e82eb1e37eb96aafe43f88e7d4addf sha1 8e0905a6463b06c01c2f37d8fef077bec05560cb )
-)
-
-game (
-	name "Vigilante (World)"
-	year "1988"
-	developer "Irem"
-	rom ( name vigilant.zip size 443942 crc 0ea1d86f md5 53bbcbe368c25fb0776a756f9fd06e4f sha1 7d969ba8c64596bac482beb4cf481845b7b773b6 )
-)
-
-game (
-	name "Vigilante (Japan)"
-	year "1988"
-	developer "Irem"
-	rom ( name vigilantj.zip size 51115 crc a2b0d130 md5 da58029faf1a73db3265b971a8796051 sha1 40996678b3234eb969e978b4217b16164cda9e28 )
-)
-
-game (
-	name "Vigilante (US)"
-	year "1988"
-	developer "Irem (Data East USA license)"
-	rom ( name vigilantu.zip size 50950 crc 4a7b0112 md5 7e485058a667fee01f66924155614101 sha1 bcc2db2881c89661675b4480eaf9bc9bcbecf9a9 )
-)
-
-game (
-	name "Vimana"
-	year "1991"
-	developer "Toaplan"
-	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
-)
-
-game (
-	name "Vimana (Japan)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name vimana1.zip size 87452 crc b0fb5004 md5 de2e2733070b6b3f3297fb2d25d86c4d sha1 db38432f670ea24c7102ef2f8c6d67914375ca06 )
-)
-
-game (
-	name "Vimana (Nova Apparate GmbH)"
-	year "1991"
-	developer "Toaplan (Nova Apparate GmbH license)"
-	rom ( name vimanan.zip size 87678 crc ca61b5d0 md5 bfd828f2653fea976d8c4367836d433c sha1 4a6f5300832dcb0f7211993cb427f9b80a7308dd )
 )
 
 game (
@@ -57511,20 +42758,6 @@ game (
 )
 
 game (
-	name "Virtua NBA (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name virnba.zip size 95708034 crc 76ee2d60 md5 3ede4f22fb9e08040a94886ebe1b3e3d sha1 cee901991cd2a394d6ea82b707f8ff94b2bead95 )
-)
-
-game (
-	name "Virtua NBA (JPN, USA, EXP, KOR, AUS) (original)"
-	year "2000"
-	developer "Sega"
-	rom ( name virnbao.zip size 2261285 crc 666ee79f md5 fd5c89ba124d124fb0fe8b82aad2bcf9 sha1 7392f7817687a1cf077614f900f57e219fb26db3 )
-)
-
-game (
 	name "Mahjong Vitamin C (Japan)"
 	year "1989"
 	developer "Home Data"
@@ -57602,34 +42835,6 @@ game (
 )
 
 game (
-	name "Virtual On Cyber Troopers (US, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name von.zip size 27081340 crc 266dac32 md5 bfd81bb631b972866ce579973c2d09d8 sha1 b90924ef0cfd00b8389996da2443516214578abf )
-)
-
-game (
-	name "Virtual On 2: Oratorio Tangram (Revision B)"
-	year "1998"
-	developer "Sega"
-	rom ( name von2.zip size 73360340 crc c622ac96 md5 34da253ee9965156857dd59b86e13530 sha1 d34df7a19014b37a6928bceb6909b4ce9f7bfa57 )
-)
-
-game (
-	name "Virtual On 2: Oratorio Tangram (ver 5.4g)"
-	year "1998"
-	developer "Sega"
-	rom ( name von254g.zip size 4796306 crc 30d6b28d md5 e6040624b3f5b69632aabe3a0f40c923 sha1 64011cdc0fcae8a9d927c277ec1d1da4556d82cb )
-)
-
-game (
-	name "Virtual On Cyber Troopers (Japan, Revision B)"
-	year "1996"
-	developer "Sega"
-	rom ( name vonj.zip size 330817 crc 8b828843 md5 39f0b6bc454abeb2b15c7c00661f0777 sha1 ab244a51812087528181f43b7b59f917f82701f5 )
-)
-
-game (
 	name "Vortex"
 	year "1980"
 	developer "Zilec Electronics Ltd."
@@ -57637,23 +42842,10 @@ game (
 )
 
 game (
-	name "Videotronics Poker"
-	developer "Videotronics"
-	rom ( name vpoker.zip size 9232 crc 3fe190fe md5 ca23e4170a38304b022fde5fdf8f4c76 sha1 0575c2d12f185692b383119f235bb512f4276082 )
-)
-
-game (
 	name "Video Pool (bootleg on Moon Cresta hardware)"
 	year "1980"
 	developer "bootleg"
 	rom ( name vpool.zip size 9432 crc a7aa7c3e md5 1ac0e0c5c8e00d787285b8f3bfb87cac sha1 a9a1a21f36f10664e62dcdd7cf2b6e69e4d9c93b )
-)
-
-game (
-	name "Virtua Racing"
-	year "1992"
-	developer "Sega"
-	rom ( name vr.zip size 9761594 crc 68f2d49a md5 28a9134834b668a21833c0448ad51104 sha1 ad169f0c44fe377076258a02e80303a6b19891f0 )
 )
 
 game (
@@ -57682,104 +42874,6 @@ game (
 	year "1984"
 	developer "Irem (Taito license)"
 	rom ( name vs10yardu.zip size 23158 crc 4553991d md5 84c3598ba370dde20c5db4134b1c642e sha1 725ed9ddf9d15fc84ce5966f9bb336638581406e )
-)
-
-game (
-	name "Virtua Striker 2 (Step 2.0)"
-	year "1997"
-	developer "Sega"
-	rom ( name vs2.zip size 50909273 crc 22275471 md5 802507312328b00fbe7c946d72806285 sha1 dcef25a6b5b374661ca2b1c7f05d215f57dbfe0b )
-)
-
-game (
-	name "Virtua Striker 2002 (GDT-0002)"
-	year "2002"
-	developer "Sega"
-	rom ( name vs2002ex.zip size 219 crc 31fd9201 md5 5cb11ccef3248ccd7917ab9750398585 sha1 066cce38a986e1851a842ae1f2f66c253341f8f8 )
-)
-
-game (
-	name "Virtua Striker 2002 (GDT-0001)"
-	year "2002"
-	developer "Sega"
-	rom ( name vs2002j.zip size 211 crc aced4165 md5 bbd7bf2b8db780d22266234ace233337 sha1 70f35b8d28cb3f174de6c2037e2ca82e576e1108 )
-)
-
-game (
-	name "Virtua Striker 2 (Step 1.5)"
-	year "1997"
-	developer "Sega"
-	rom ( name vs215.zip size 1135016 crc f1b691b5 md5 6ee21026fc6cd9c34fb8dbd19ffde5d5 sha1 02bab775d87ac032e1feefadab6fc501f69113ab )
-)
-
-game (
-	name "Virtua Striker 2 '98 (Step 2.0)"
-	year "1998"
-	developer "Sega"
-	rom ( name vs298.zip size 58691960 crc f1237873 md5 aaa60d79645e33ebade2af8eb7317019 sha1 2e0f45e491ac57060f60e6a89c6fb7ae93de2432 )
-)
-
-game (
-	name "Virtua Striker 2 '98 (Step 1.5)"
-	year "1998"
-	developer "Sega"
-	rom ( name vs29815.zip size 988371 crc 07815803 md5 d0495d544d9261738d29545f9ef18076 sha1 3801199700e8a2608ed7dd49d08fc31562b4a23e )
-)
-
-game (
-	name "Virtua Striker 2 '99"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299.zip size 2199393 crc 339cfc8e md5 566caf049899215c7c678896926ea6f5 sha1 9785baaa0a2b9a1be197f1dae1a6e5eb555bea58 )
-)
-
-game (
-	name "Virtua Striker 2 '99 (Revision A)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299a.zip size 2217058 crc 3145f93a md5 fb33169750af57b4c56194188c5b9e41 sha1 ccf88de71dd5e333cc60eb8306fa522558752136 )
-)
-
-game (
-	name "Virtua Striker 2 '99 (Revision B)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs299b.zip size 2235539 crc eb181e5f md5 50033a99d18829ba28136bc53acaa7fd sha1 ded92c000cf770839be47575d9c9845e9b77b8e1 )
-)
-
-game (
-	name "Virtua Striker 2 Ver. 2000 (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs2_2k.zip size 54546410 crc e1e91c35 md5 db8c5824eb2a9e9a09c2fa5698654dce sha1 9b9e929271866839e367a08521e93bbc0c19e6de )
-)
-
-game (
-	name "Virtua Striker 2 '99.1 (Revision B)"
-	year "1999"
-	developer "Sega"
-	rom ( name vs2v991.zip size 60568201 crc 0bafab9c md5 2c1f047cf643c83f30f74cfd6ef80238 sha1 8ce509494ebbf567c9fa14b4b13909fa983a44c3 )
-)
-
-game (
-	name "Virtua Striker 4 (Export) (GDT-0015)"
-	year "2004"
-	developer "Sega"
-	rom ( name vs4.zip size 219 crc aed5c1c0 md5 5ed3e9851c239f5a1f2e4dea6e443474 sha1 1e27c511c90d07d3744097eaab31b52afc7968fb )
-)
-
-game (
-	name "Virtua Striker 4 ver. 2006 (Rev D) (Japan) (GDT-0020D)"
-	year "2006"
-	developer "Sega"
-	rom ( name vs42006.zip size 210 crc 87316dbb md5 3b55690d5ddc0d88fb0af64c0b3e31b2 sha1 227ab14baf8a30f9f1c110b44cb9be5248ccc941 )
-)
-
-game (
-	name "Virtua Striker 4 (Japan) (GDT-0013E)"
-	year "2004"
-	developer "Sega"
-	rom ( name vs4j.zip size 218 crc afe6c304 md5 e4013f278113c9cd7118ac85d4e73f52 sha1 b254304974563b31e5d767411c935da907ced3b3 )
 )
 
 game (
@@ -57979,13 +43073,6 @@ game (
 )
 
 game (
-	name "Video Stars"
-	year "1982"
-	developer "Competitive Video?"
-	rom ( name vstars.zip size 21244 crc 07721780 md5 621f7ac43cc3a282eba1ea4d5385168b sha1 0bd42bdf96153db81ce78c7a52b16077cc002cce )
-)
-
-game (
 	name "Vs. Tennis"
 	year "1984"
 	developer "Nintendo"
@@ -58004,62 +43091,6 @@ game (
 	year "1987"
 	developer "Academysoft-Elorg"
 	rom ( name vstetris.zip size 14572 crc 69c80caa md5 798a8d686961b50d5c1e16e760dc8b79 sha1 dff75516168583c65f5296e1648922697eb4e40e )
-)
-
-game (
-	name "Virtua Striker 3 (GDS-0006)"
-	year "2001"
-	developer "Sega"
-	rom ( name vstrik3.zip size 1194 crc 94a6867c md5 079dba6a81c953e22e6fa6bf0cfd1b42 sha1 83d1b160e03536a3369f3ec45f2766ac1d94d240 )
-)
-
-game (
-	name "Virtua Striker 3 (Cart) (USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name vstrik3c.zip size 117980538 crc 526ab909 md5 2d5f651bc647d81325760606f4930359 sha1 57bec10a2cac6daf2729c6049170be0fc9c2cca5 )
-)
-
-game (
-	name "Virtua Striker (Revision A)"
-	year "1994"
-	developer "Sega"
-	rom ( name vstriker.zip size 9987856 crc 8bfcb204 md5 15e17213780ae2a6d8b88af4acce4137 sha1 2e75959005206926e49ed1a1637476ea177fe5f8 )
-)
-
-game (
-	name "Virtua Striker"
-	year "1994"
-	developer "Sega"
-	rom ( name vstrikero.zip size 325978 crc 30ce5dba md5 10b6b6e2abbabe53dce06148e37bcf0b sha1 dfebfdd9e99c9c066afc0d5da2b27097f45306c5 )
-)
-
-game (
-	name "Power Smash 2 / Virtua Tennis 2 (cartridge)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtenis2c.zip size 81919505 crc 06906d89 md5 4cae7204cd4f8005c4aebdd3de7276ff sha1 5fd4f231e9196380e42aaef19ece1dd41ca2c071 )
-)
-
-game (
-	name "Power Smash (JPN) / Virtua Tennis (USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name vtennis.zip size 25044701 crc 7529d9ec md5 6e3502075e31bc1550e3479ad031ff7e sha1 6b66a1c636dee8bce67df95e8a2d55ca4c5ff8fe )
-)
-
-game (
-	name "Virtua Tennis 2 (Rev A) (GDS-0015A)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtennis2.zip size 1197 crc eeabce60 md5 07a404eabaa3ceea7b91e6b5337a21b9 sha1 8ec5e09d51b4ead397d12a023295bacbb60a65c4 )
-)
-
-game (
-	name "Virtua Tennis (GDS-0011)"
-	year "2001"
-	developer "Sega"
-	rom ( name vtennisg.zip size 1197 crc ab1190ee md5 f6581310d24e8284e883ff78c91857dc sha1 97b9b1372fdf15d6e429fe12fc2da08491a2782c )
 )
 
 game (
@@ -58140,20 +43171,6 @@ game (
 )
 
 game (
-	name "Wangan Midnight Maximum Tune (Rev. B) (Export) (GDX-0009B)"
-	year "2005"
-	developer "Sega"
-	rom ( name wangmid.zip size 213 crc c21c1120 md5 6c60d3c8212935bdaeb75e41042f5336 sha1 c6d72c20223a8d134bb16a6a8daeb472b31863d4 )
-)
-
-game (
-	name "Wangan Midnight Maximum Tune 2 (Export) (GDX-0015)"
-	year "2005"
-	developer "Sega"
-	rom ( name wangmid2.zip size 219 crc 0d7925ad md5 940bf8298a61e6c538c11d192cfbaaed sha1 0ee544a5dc20d608be3747b15f933d82bb7d3b1f )
-)
-
-game (
 	name "Wanted"
 	year "1984"
 	developer "Sigma Enterprises Inc."
@@ -58175,13 +43192,6 @@ game (
 )
 
 game (
-	name "War: The Final Assault"
-	year "1999"
-	developer "Atari Games"
-	rom ( name warfa.zip size 260157 crc b71482e4 md5 fbd3358d120daff16231a4d3fcfbc26e sha1 d123c8b2be19780ff302cdbc00ca23c142f268e6 )
-)
-
-game (
 	name "War Gods"
 	year "1995"
 	developer "Midway"
@@ -58200,13 +43210,6 @@ game (
 	year "1981"
 	developer "Armenia"
 	rom ( name warofbug.zip size 9633 crc a05751b7 md5 d0c3c7100a5b118f3ba58fd3f93d8645 sha1 5b8c62c30d0cac065f2b41dc3f3749ebfa034208 )
-)
-
-game (
-	name "War of the Bugs or Monsterous Manouvers in a Mushroom Maze (German)"
-	year "1981"
-	developer "Armenia"
-	rom ( name warofbugg.zip size 5737 crc 77840d5e md5 5d692b89b053a7812ed5261bb51f1166 sha1 f58cc70d9dff7da3667fccff4fc11b5ca573d8b2 )
 )
 
 game (
@@ -58266,27 +43269,6 @@ game (
 )
 
 game (
-	name "Wave Runner (Japan, Revision A)"
-	year "1996"
-	developer "Sega"
-	rom ( name waverunr.zip size 15825589 crc 5252d820 md5 33bcc747b5c2c50a7e6b746de58639c2 sha1 8ccd8bb5770af943da44bbe090241dc0121b6d62 )
-)
-
-game (
-	name "Wave Shark (UAB, USA v1.04)"
-	year "1996"
-	developer "Konami"
-	rom ( name waveshrk.zip size 10429985 crc 6b6ebe6f md5 4bfb60e6f1d8490a09dc4418a0499870 sha1 c67b284c8c76859c377421642b82ac544a6fd1e1 )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (set 5, World, System 16B, 8751 317-0098)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb3.zip size 391158 crc f91e30a4 md5 01cc32ea1ae54c6e3d9f0c0c2ec00c54 sha1 8ec512b7b6d1e77cd0e1ce2d3cf0250cbd7c4077 )
-)
-
-game (
 	name "Wonder Boy III - Monster Lair (set 1, System 16A, FD1094 317-0084)"
 	year "1988"
 	developer "Sega / Westone"
@@ -58315,27 +43297,6 @@ game (
 )
 
 game (
-	name "Wonder Boy III - Monster Lair (set 5, System 16A, FD1089A 317-xxxx, bad dump?)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb35.zip size 344920 crc 322872ee md5 5f407ce432cd8f9e47d8a0e0492f78a0 sha1 cd3fecb896042a77a0132504d41dce4c8e65d20b )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (set 6, System 16A, FD1089A 317-xxxx)"
-	year "1988"
-	developer "Sega / Westone"
-	rom ( name wb35a.zip size 243684 crc 19830c6e md5 bac4c0b6973054db7001f07d4bac98d6 sha1 2c65a1dd790ac50f5769ef55ee029ade5b6a4432 )
-)
-
-game (
-	name "Wonder Boy III - Monster Lair (bootleg)"
-	year "1988"
-	developer "bootleg"
-	rom ( name wb3bbl.zip size 159781 crc 88e81ba7 md5 7777430ae2ae1c90d24e4c267488e9a0 sha1 e5d9528a7f49eb77c68f9252f88695297e23ce75 )
-)
-
-game (
 	name "Beach Festival World Championship 1997"
 	year "1997"
 	developer "Comad"
@@ -58347,20 +43308,6 @@ game (
 	year "1986"
 	developer "Sega (Escape license)"
 	rom ( name wbdeluxe.zip size 32880 crc 3044baf2 md5 a9670ef84dd9596f0785437ed3c503ff sha1 0274e8c61dbfcaab780c9e6546f36b02c7d68953 )
-)
-
-game (
-	name "World Beach Volley (set 1)"
-	year "1995"
-	developer "Playmark"
-	rom ( name wbeachvl.zip size 3037511 crc a7e64b63 md5 8c24a0dc0f0fc04202edb0a0324154c3 sha1 671d53acb9f10c23e5b8fa5974c20b8b9c3f0109 )
-)
-
-game (
-	name "World Beach Volley (set 2)"
-	year "1995"
-	developer "Playmark"
-	rom ( name wbeachvl2.zip size 92915 crc 9f32b6c1 md5 36f159c7583d30c5d0b703ef3b4e9adb sha1 be9043afeaee676bd28f88b02146556209b85ef1 )
 )
 
 game (
@@ -58476,30 +43423,10 @@ game (
 )
 
 game (
-	name "Euro League (Italian hack of Tecmo World Cup '90)"
-	year "1989"
-	developer "bootleg"
-	rom ( name wc90b1.zip size 400477 crc b0bf4256 md5 c32a9f1044995ffffb4e670df4bf81b6 sha1 4a84141f7517490037994c7420e548f05ce432f9 )
-)
-
-game (
-	name "Worldcup '90"
-	year "1989"
-	developer "bootleg"
-	rom ( name wc90b2.zip size 400762 crc 22467977 md5 8b60be8f48b0abd75473d9ea368eec79 sha1 2a3d9c79990c54cb6dd15cf92f0e43fe8cf15028 )
-)
-
-game (
 	name "Tecmo World Cup '90 (trackball set 1)"
 	year "1989"
 	developer "Tecmo"
 	rom ( name wc90t.zip size 34511 crc ba6948c4 md5 45a1b25143b3d82c868d432cf3045d86 sha1 de85a499b179edd025ec346679c7670ea72667c2 )
-)
-
-game (
-	name "Wild Cat 3"
-	developer "E.A.I."
-	rom ( name wcat3.zip size 84762 crc 0ebe0f1e md5 dedc5f14495da4d5493f870eade43b7f sha1 9aa12644544c39578a066534608f4d86880f6667 )
 )
 
 game (
@@ -58573,27 +43500,6 @@ game (
 )
 
 game (
-	name "World Combat (ver UAA?)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombat.zip size 3775 crc b045cc21 md5 aac84148769c55647229d9ebe2443b76 sha1 9da44bc9d9d628ee1194fa091b1b24c2285215d0 )
-)
-
-game (
-	name "World Combat (ver JAA)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombatj.zip size 3730 crc 00aa974f md5 289177932257b311f6d01028f9b649ab sha1 6eff1992166ae69ff09e12f735d791e8cb23aec4 )
-)
-
-game (
-	name "World Combat (ver KBC)"
-	year "2002"
-	developer "Konami"
-	rom ( name wcombatk.zip size 3889 crc 221dd784 md5 53c296d3d4a9f9f5e6683c0b76b49aa4 sha1 75edb5d62a0c8c23b23407a561e2c0730006db38 )
-)
-
-game (
 	name "World Cup Volley '95 (Japan v1.0)"
 	year "1995"
 	developer "Data East Corporation"
@@ -58626,13 +43532,6 @@ game (
 	year "1991"
 	developer "Video System Co."
 	rom ( name welltrisj.zip size 140539 crc e44714e8 md5 e012b6de23dfd2e7fa5c262f21dcf728 sha1 618afe8e76394db2b9e50def736a1dd4a6afe07e )
-)
-
-game (
-	name "West Story (bootleg of Blood Bros.)"
-	year "1990"
-	developer "bootleg (Datsu)"
-	rom ( name weststry.zip size 1093405 crc b920c9bf md5 b55cd788bacc3db8015edf86842d0aba sha1 27be77ef92924f4424c0b535003719bf8cd29c25 )
 )
 
 game (
@@ -58678,41 +43577,6 @@ game (
 )
 
 game (
-	name "World Grand Prix (US)"
-	year "1989"
-	developer "Taito America Corporation"
-	rom ( name wgp.zip size 2705736 crc f1e59ea3 md5 ed74f8b95cadaad2e60b61ff084bba20 sha1 6e4fc0dc6fb22e629094cff99f3f6456b4cbb5a5 )
-)
-
-game (
-	name "World Grand Prix 2 (Japan)"
-	year "1990"
-	developer "Taito Corporation"
-	rom ( name wgp2.zip size 232630 crc e5a4c69e md5 09eb70ffb07a3dccbb3bb0cf8388daad sha1 8ed14f916e082ceda65b7044ee802ea0312a85f1 )
-)
-
-game (
-	name "World Grand Prix (Japan)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpj.zip size 89567 crc 2f03eece md5 34e6596ffe04250623590a214afbf9c9 sha1 9c2a0c209a58c0764679a4b34ebccdaa60e5f98d )
-)
-
-game (
-	name "World Grand Prix (joystick version) (Japan, set 1)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpjoy.zip size 196317 crc 4a4cfc2f md5 62ec709e68fd77f2ab3396dcb1655e65 sha1 bc00a5475018908be58a260f8d7eaa0c78bca297 )
-)
-
-game (
-	name "World Grand Prix (joystick version) (Japan, set 2)"
-	year "1989"
-	developer "Taito Corporation"
-	rom ( name wgpjoya.zip size 196296 crc 6dc42a38 md5 fb01df444c30ce7d880273270df935ae sha1 e260d989b1996b49c309ed2fc7dd6589baeb503e )
-)
-
-game (
 	name "World Heroes (set 1)"
 	year "1992"
 	developer "Alpha Denshi Co."
@@ -58755,18 +43619,6 @@ game (
 )
 
 game (
-	name "Wheels _ Fire"
-	developer "TCH"
-	rom ( name wheelfir.zip size 2275665 crc 18320311 md5 8999b7396b2014c8908052e0ab32e111 sha1 12839c6d851a452842cd84629473db447f91e646 )
-)
-
-game (
-	name "Wheels Runner"
-	developer "International Games"
-	rom ( name wheelrun.zip size 266060 crc 01cc5ffb md5 9f4ed4d024100f95ec451c8927bb9519 sha1 b38f11dfdc350802cbb8bf496ff1f8ff9babc5d7 )
-)
-
-game (
 	name "Whizz"
 	year "1989"
 	developer "Philko"
@@ -58778,13 +43630,6 @@ game (
 	year "1988"
 	developer "Exidy"
 	rom ( name whodunit.zip size 275013 crc 3548b608 md5 9cf3252a4edc589fec3158cc7b4efb76 sha1 44000221c3f240d74022a23c24bee6c368d63f4c )
-)
-
-game (
-	name "Pipi _ Bibis / Whoopee!! (Whoopee!! board)"
-	year "1991"
-	developer "Toaplan"
-	rom ( name whoopee.zip size 59555 crc e74225b3 md5 59bd91f4109f59ab6fb0f28b7854ce8c sha1 925e2d433ef0d690b65130da7e162e472e1e8cd6 )
 )
 
 game (
@@ -58802,20 +43647,6 @@ game (
 )
 
 game (
-	name "Wild Fang / Tecmo Knight"
-	year "1989"
-	developer "Tecmo"
-	rom ( name wildfang.zip size 1127216 crc 1bbd53df md5 bdf5feea32db29d4fb9bddc09454f287 sha1 5f75aafe536acc379790a20c2fa9fb2f26ca4196 )
-)
-
-game (
-	name "Wild Fang"
-	year "1989"
-	developer "Tecmo"
-	rom ( name wildfangs.zip size 97318 crc af986de2 md5 0007f7ed9a358bb0062b63ad86db791e sha1 346e990529d01ee98d9ca22fb655482381709348 )
-)
-
-game (
 	name "Wild Pilot"
 	year "1992"
 	developer "Jaleco"
@@ -58830,13 +43661,6 @@ game (
 )
 
 game (
-	name "Willow (Japan, Japanese)"
-	year "1989"
-	developer "Capcom"
-	rom ( name willowj.zip size 131101 crc 249794d9 md5 102adfb8c128765c40980ca7abd05dee sha1 290feac9dd5c492e60a113b8e77f9ba28a164707 )
-)
-
-game (
 	name "Willow (Japan, English)"
 	year "1989"
 	developer "Capcom"
@@ -58848,18 +43672,6 @@ game (
 	year "1984"
 	developer "Irem"
 	rom ( name wilytowr.zip size 38625 crc e7ad435f md5 836d0d60ceabd3f2bc47923c968ad375 sha1 6e6b320aa9feb168486cf35ca4567bc037f660b4 )
-)
-
-game (
-	name "Win Win Bingo (set 1)"
-	developer "Astro Corp."
-	rom ( name winbingo.zip size 1321961 crc 39e6609e md5 16d17a2ead7ce9646777794bb31f1159 sha1 e94521253b1087f275c8d1456d08b03e9ab058b5 )
-)
-
-game (
-	name "Win Win Bingo (set 2)"
-	developer "Astro Corp."
-	rom ( name winbingoa.zip size 1744073 crc c9eec9ba md5 6cd10e04973b9bd2efbad030315a195e sha1 db0a1bb97b318d2b38dcba33b2e00ee4c7828edd )
 )
 
 game (
@@ -58881,69 +43693,6 @@ game (
 	year "1996"
 	developer "Konami"
 	rom ( name windheatu.zip size 1183000 crc 6b028ed1 md5 b99bc93109ef52b2bb38f8b438e883e1 sha1 f824fef1f7f1ab4834eda037468043bec19bc27d )
-)
-
-game (
-	name "Wing War (World)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwar.zip size 13322227 crc 1fa2c631 md5 7c0d0d207381daff05d6d2f2de9f3939 sha1 497d35aadc420fe8a4e855c3801e241932c79d50 )
-)
-
-game (
-	name "Wing War (Japan)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwarj.zip size 147628 crc 90dfe41a md5 09ba7d38e46de2821b128062e44c1195 sha1 0c5cdaf8becbda38de537d43b714117a0f5806c9 )
-)
-
-game (
-	name "Wing War (US)"
-	year "1994"
-	developer "Sega"
-	rom ( name wingwaru.zip size 147648 crc affbc7ad md5 0fe2dbe457ceda0ba0a426a3c42a2a99 sha1 d9eabca9f31bf806eb70e7e8fd96b0046b44c247 )
-)
-
-game (
-	name "Wink (set 1)"
-	year "1985"
-	developer "Midcoin"
-	rom ( name wink.zip size 42545 crc 6e5cdbf7 md5 93265f49b12671c547d3cd3b55aca06f sha1 da6dcd8436f9072850e64612d3d1893cace97aae )
-)
-
-game (
-	name "Wink (set 2)"
-	year "1985"
-	developer "Midcoin"
-	rom ( name winka.zip size 32447 crc b1324f9f md5 b990e586d49026dd0c496a5dd993b5ea sha1 681c256b84959baccae3e601c8de8927ed2575ed )
-)
-
-game (
-	name "Winning Run Suzuka Grand Prix (Japan)"
-	year "1989"
-	developer "Namco"
-	rom ( name winrun.zip size 1347588 crc 7d5d9c90 md5 f4b613a8d3c6fb1cf5ba932becd2749a sha1 8f114003f5f04dc9852305ef8e57e9289919fe7d )
-)
-
-game (
-	name "Winning Run 91 (Japan)"
-	year "1991"
-	developer "Namco"
-	rom ( name winrun91.zip size 1373304 crc e3d8d0aa md5 70a44b526270256e7430da9568536d2c sha1 c58b1d480d77b29a13e3fcdf982426dc21e13d13 )
-)
-
-game (
-	name "Winning Spike (ver EAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name winspike.zip size 11053108 crc 4a80055c md5 af9931b5c586fb5862ca889ef0bed503 sha1 c5bd760d848ec14d4d15a2bec4e6274cc3dbfd02 )
-)
-
-game (
-	name "Winning Spike (ver JAA)"
-	year "1997"
-	developer "Konami"
-	rom ( name winspikej.zip size 442012 crc a9af5fd8 md5 6070faca65ad4889e237c20e30f0c116 sha1 5b2c240d70ac40d95a92600ecc1d11ccdae2c5a4 )
 )
 
 game (
@@ -59010,27 +43759,6 @@ game (
 )
 
 game (
-	name "Witch Card (German, set 2)"
-	year "1994"
-	developer "bootleg?"
-	rom ( name witchcde.zip size 20829 crc 87777bb8 md5 7444e3a8bb9c3d3a40ef138e5f2ca276 sha1 5e5448477f283334bd61d9946b5998a145d57ddf )
-)
-
-game (
-	name "Witch Card (English, witch game, lamps)"
-	year "1985"
-	developer "PlayMan"
-	rom ( name witchcdf.zip size 8443 crc e1ffb6e7 md5 4f0110ffe2b4eb4650fb30641c7d44f6 sha1 58dd6eebbc47d162edd3e3f169d0680457267087 )
-)
-
-game (
-	name "Witch Card (Video Klein)"
-	year "1991"
-	developer "Video Klein"
-	rom ( name witchcrd.zip size 13079 crc 1797bf70 md5 8ea96a23bfb39e561dd2cb6617e31e68 sha1 7ac40fd62f31e728e3e7183d02f19032a3ea6e02 )
-)
-
-game (
 	name "Wit's (Japan)"
 	year "1989"
 	developer "Athena (Visco license)"
@@ -59042,13 +43770,6 @@ game (
 	year "1985"
 	developer "Seibu Kaihatsu"
 	rom ( name wiz.zip size 72739 crc 29055c7a md5 119accb2311e0ef6044a5623aa99922b sha1 d918cfb80ff4387bfd13ddf315096b49d25e1ffd )
-)
-
-game (
-	name "Wizard (Ver 1.0)"
-	year "1999"
-	developer "A.A."
-	rom ( name wizard.zip size 556097 crc ca89c079 md5 c723b10d80176623aefe99603f7d140d sha1 eb47b4c10142743bed5c53689eb32091c7fdc441 )
 )
 
 game (
@@ -59129,20 +43850,6 @@ game (
 )
 
 game (
-	name "Wild Riders (JPN, USA, EXP, KOR, AUS)"
-	year "2001"
-	developer "Sega"
-	rom ( name wldrider.zip size 62184249 crc c63a1304 md5 5445e5d703f5ac7e3a98f544a2d627ff sha1 365cd08911768de5cbc9296611e17ac75e418429 )
-)
-
-game (
-	name "Wonder League Star - Sok-Magicball Fighting (Korea)"
-	year "1995"
-	developer "Mijin"
-	rom ( name wlstar.zip size 1111873 crc 50c60903 md5 fc261854f1666e504d5e89b474e1c99b sha1 0809e620299942bfe252fa6912a34613339ace1f )
-)
-
-game (
 	name "Water Match (315-5064)"
 	year "1984"
 	developer "Sega"
@@ -59192,13 +43899,6 @@ game (
 )
 
 game (
-	name "Warriors of Fate (USA 921031)"
-	year "1992"
-	developer "Capcom"
-	rom ( name wofu.zip size 435876 crc a99e6f31 md5 e09cf79c47b401c18a80040e93cee117 sha1 284f09f503633fbe23361f562eb560e1f4ddafc2 )
-)
-
-game (
 	name "Wolf Fang -Kuhga 2001- (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -59217,13 +43917,6 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name wonder3.zip size 2188617 crc e5076c63 md5 9c254a46d911ad47fefa9cc6df686fbe sha1 5f10cd88532802673590f787b479143f8ca82c89 )
-)
-
-game (
-	name "Wonder League '96 (Korea)"
-	year "1996"
-	developer "SemiCom"
-	rom ( name wondl96.zip size 1134743 crc 829ed1a5 md5 89b56076d71f4c1caba5cb5194e40eed sha1 07b88d1d2c796106a0883a46f9711bd2b5f36ce5 )
 )
 
 game (
@@ -59279,48 +43972,6 @@ game (
 	year "2002"
 	developer "Comad"
 	rom ( name wownfant.zip size 3732704 crc 54a82a1e md5 feea599d0ef0cac04182100c1fdb4c5a sha1 5fb7030ffb3819b280594892f9e01a9a68a08372 )
-)
-
-game (
-	name "World PK Soccer"
-	year "1995"
-	developer "Jaleco"
-	rom ( name wpksoc.zip size 2961417 crc e81143ba md5 c6691cdb3e9839002ba7fa69900d34dc sha1 b309df873e60b7d7a928813b393a7f0d695d1671 )
-)
-
-game (
-	name "World PK Soccer V2 (ver 1.1)"
-	year "1996"
-	developer "Jaleco"
-	rom ( name wpksocv2.zip size 10936454 crc 15459333 md5 6e2330a479a07cf99cb8ccaa4d4a91d8 sha1 35a8e524c393d1d5321dfd260942289441d3610c )
-)
-
-game (
-	name "World Rally (set 1)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name wrally.zip size 2150671 crc 0a96fa55 md5 c0b150867a535dd91c0a0185bbbe9d2f sha1 1648718faf86e70554754324e1888c95b06e4eea )
-)
-
-game (
-	name "World Rally 2: Twin Racing"
-	year "1995"
-	developer "Gaelco"
-	rom ( name wrally2.zip size 5449380 crc e5746c19 md5 ba8317624dcb7294e9ecd769054cc08a sha1 e7e8da50591d0a9114a1dcd794567fd72813c266 )
-)
-
-game (
-	name "World Rally (set 2)"
-	year "1993"
-	developer "Gaelco"
-	rom ( name wrallya.zip size 338926 crc b09b6be9 md5 5c5225767666a80d0046f0709e89a46c sha1 1e08d1621dd561759e3d034dc56ba54c84c70371 )
-)
-
-game (
-	name "World Rally (US, 930217)"
-	year "1993"
-	developer "Gaelco (Atari license)"
-	rom ( name wrallyb.zip size 2101104 crc 514c0d67 md5 a2b5a177227145476358b81cade78294 sha1 24d114aeb963bce234fb67aeaeb6fa039deb8df3 )
 )
 
 game (
@@ -59380,13 +44031,6 @@ game (
 )
 
 game (
-	name "World Series Baseball / Super Major League (GDS-0010)"
-	year "2001"
-	developer "Sega"
-	rom ( name wsbbgd.zip size 1195 crc 62c3cdab md5 a68c20c274dca3a9551e60b48f6bf05f sha1 05aca61a3ee864f195a0aebc8de29f66adc66108 )
-)
-
-game (
 	name "Wing Shooting Championship V2.00"
 	year "2001"
 	developer "Sammy USA Corporation"
@@ -59412,20 +44056,6 @@ game (
 	year "1990"
 	developer "Leland Corp."
 	rom ( name wsf.zip size 584465 crc f9562bf7 md5 bc17a474b233ecb69ff8462b2866481d sha1 141471b18a27b303397db67de2f13ae2b361affd )
-)
-
-game (
-	name "Who Shot Johnny Rock? v1.6"
-	year "1991"
-	developer "American Laser Games"
-	rom ( name wsjr.zip size 51956 crc 0c42fec1 md5 4a167149fc7ad1a219adc3d91bff5806 sha1 766cba1751325db9dc8a213ca85f585c66ea979b )
-)
-
-game (
-	name "Who Shot Johnny Rock? v1.5"
-	year "1991"
-	developer "American Laser Games"
-	rom ( name wsjr15.zip size 51902 crc d5bed392 md5 e64919c46b44abf93e54c097af4d3ae1 sha1 be855101e49a1d1272421c37f6e17c2f5264de66 )
 )
 
 game (
@@ -59492,31 +44122,10 @@ game (
 )
 
 game (
-	name "WWF Royal Rumble (JPN, USA, EXP, KOR, AUS)"
-	year "2000"
-	developer "Sega"
-	rom ( name wwfroyal.zip size 100313238 crc 5ef1919d md5 6c2672baa1138730c4c24c5f302843d9 sha1 873753373ed645bfdfb9924378909ec1a0231edb )
-)
-
-game (
-	name "WWF Superstars (Europe)"
-	year "1989"
-	developer "Technos Japan"
-	rom ( name wwfsstar.zip size 1521277 crc 380f9e41 md5 7938b364e050b627d2be494b89d450f2 sha1 d2caa65883c6298e8a02d372c8fe76606d47e6f1 )
-)
-
-game (
 	name "WWF Superstars (US, Newer)"
 	year "1989"
 	developer "Technos Japan"
 	rom ( name wwfsstara.zip size 1340685 crc 378b0b78 md5 a55fcbe01b5eab2a18e6ee60e902a013 sha1 7ccb8be9f29923aaf8ba72793ed2413ca2f76b3c )
-)
-
-game (
-	name "WWF Superstars (Japan)"
-	year "1989"
-	developer "Technos Japan"
-	rom ( name wwfsstarj.zip size 54069 crc 3ea59a08 md5 6dec829ef62afe058d4f859b8c05aebe sha1 66a62aa34c7f92f8c537dd1a994ce2f4cdaf6ccb )
 )
 
 game (
@@ -59562,30 +44171,10 @@ game (
 )
 
 game (
-	name "Wyvern Wings"
-	year "2001"
-	developer "SemiCom (Game Vision license)"
-	rom ( name wyvernwg.zip size 8172603 crc 627e0ad3 md5 6eb71a34799c2300628565f67d8bc7bd sha1 b4bd2da04515b6913fcddf8d198713f126ca6d54 )
-)
-
-game (
-	name "X Five Jokers (Version 1.12)"
-	developer "Electronic Projects"
-	rom ( name x5jokers.zip size 362947 crc a2d826f9 md5 0b93e5affcc38caf563ad08650b623b3 sha1 334283e724e68a29c454538a853c5283940ea969 )
-)
-
-game (
 	name "X-Day 2 (Japan)"
 	year "1995"
 	developer "Namco"
 	rom ( name xday2.zip size 3011634 crc 30ac96f0 md5 25d2261ff890e47d5a2b51cbb1ef9a1b sha1 8cf8f073c861faf040e0ba2e04614a047131172d )
-)
-
-game (
-	name "Xenophobe"
-	year "1987"
-	developer "Bally Midway"
-	rom ( name xenophob.zip size 392037 crc f90765c3 md5 39a392cd04bd5ce6e42619c5667602a0 sha1 0973544f28d70c1e3fc52dc12fb7dfe80d612a35 )
 )
 
 game (
@@ -59610,27 +44199,6 @@ game (
 )
 
 game (
-	name "Xevious (Atari set 1)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousa.zip size 14810 crc 11b7cbd1 md5 ba4db9ee4ce85d6d11d9d94beb5a4147 sha1 27e0e16f665cd7c0609ab716912e12a773e483a9 )
-)
-
-game (
-	name "Xevious (Atari set 2)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousb.zip size 14662 crc 85cbfdcc md5 f02b28ad7fcd97c3c4ec3f12e333aae8 sha1 1aee6f1d6fb689027783427d10df10bfa897f2ee )
-)
-
-game (
-	name "Xevious (Atari set 3)"
-	year "1982"
-	developer "Namco (Atari license)"
-	rom ( name xeviousc.zip size 12112 crc 3fc497a5 md5 4b93437e5e77bc152e14314d61445f15 sha1 273418204d6152588216f5e572d212a0d2574faa )
-)
-
-game (
 	name "Xexex (ver EAA)"
 	year "1991"
 	developer "Konami"
@@ -59649,13 +44217,6 @@ game (
 	year "1991"
 	developer "Konami"
 	rom ( name xexexj.zip size 229654 crc 4d769163 md5 a34739a954da5b8d23d2feaa341277ea sha1 043b832d7330a423a671747ff735e459de76b077 )
-)
-
-game (
-	name "X-Files"
-	year "1999"
-	developer "dgPIX Entertainment Inc."
-	rom ( name xfiles.zip size 9572115 crc 506f86cc md5 d0a43a1734b47a4c6f8f362c15affd10 sha1 2fe664db2ab05fedc885dc06914dc7a342aa98fc )
 )
 
 game (
@@ -59799,13 +44360,6 @@ game (
 )
 
 game (
-	name "X Multiply (Japan, M72)"
-	year "1989"
-	developer "Irem"
-	rom ( name xmultiplm72.zip size 179262 crc d65233a5 md5 a3f520928adfb7b475cdfc617ce311d2 sha1 636ce7451c931637caada1f1894daaf4f60792bc )
-)
-
-game (
 	name "X-Men Vs. Street Fighter (Euro 961004)"
 	year "1996"
 	developer "Capcom"
@@ -59904,20 +44458,6 @@ game (
 )
 
 game (
-	name "Xtreme Rally / Off Beat Racer!"
-	year "1998"
-	developer "SNK"
-	rom ( name xrally.zip size 27419979 crc 2f2a6705 md5 7c40921061eeb83c065c01a5c4c6fa55 sha1 8901a0d8dcd58eea28715feedf13ede8d607eb40 )
-)
-
-game (
-	name "X Se Dae Quiz"
-	year "1995"
-	developer "Dream Island"
-	rom ( name xsedae.zip size 1782906 crc 590493ee md5 f3ad2d4ce1d39d2824510b51cca03db7 sha1 b1b90142ae2cd7bf330e78e25eb16cf053c76445 )
-)
-
-game (
 	name "Xain'd Sleena"
 	year "1986"
 	developer "Technos Japan"
@@ -59939,27 +44479,6 @@ game (
 )
 
 game (
-	name "Xtrial Racing (ver JAB)"
-	year "2002"
-	developer "Konami"
-	rom ( name xtrial.zip size 6635 crc c1aff998 md5 8932a885393911c0a5c4890e9f6aabed sha1 97f397aac088da3c1a6a20a93ec5bf60060feb53 )
-)
-
-game (
-	name "Extreme Hunting 2"
-	year "2006"
-	developer "Sega"
-	rom ( name xtrmhnt2.zip size 122106350 crc ee9cc16c md5 01b8e7ce2cf0d023eeaf1ca3fe44b677 sha1 e83f8c2f8287e80c0f2ceae5069e4b5c7eb59a87 )
-)
-
-game (
-	name "Extreme Hunting"
-	year "2005"
-	developer "Sammy"
-	rom ( name xtrmhunt.zip size 104215731 crc 2a994ee7 md5 4bde7c8ff651f9a8c442aaf7af5dd53d sha1 d7dfde46494c97837ebacdb210dae345d18c8d7b )
-)
-
-game (
 	name "XX Mission"
 	year "1986"
 	developer "UPL"
@@ -59971,13 +44490,6 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311744 crc 02c2e99b md5 292a1cbc0304beaa0ca64831f537cbb4 sha1 3fe003a960431b455308fc212ee2d87500041759 )
-)
-
-game (
-	name "Xybots (rev 0)"
-	year "1987"
-	developer "Atari Games"
-	rom ( name xybots0.zip size 140063 crc 11e07b16 md5 800e1ddb5ba603d224bea38dc4d6d083 sha1 d4b3a8e12d017013407da3ac5b4726886627b61b )
 )
 
 game (
@@ -60149,48 +44661,6 @@ game (
 )
 
 game (
-	name "Youma Ninpou Chou (Japan)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name youma.zip size 55977 crc 3242fc02 md5 cb1ae450e09b5b7098889298e3faac59 sha1 b3c6bae860444649328efbc3e6d4ed726e3c5a93 )
-)
-
-game (
-	name "Youma Ninpou Chou (Japan, alt)"
-	year "1986"
-	developer "Nichibutsu"
-	rom ( name youma2.zip size 218421 crc 69e1a040 md5 e47170f4f375011d0e4bd5299b09a07f sha1 89cd194076d8636584083676b7dbeddd79e21035 )
-)
-
-game (
-	name "Youma Ninpou Chou (Game Electronics bootleg, set 1)"
-	year "1986"
-	developer "bootleg"
-	rom ( name youmab.zip size 82409 crc 78217f44 md5 ff70a0a4f9889e29454357ef33cca16b sha1 7bcbb5c64697ba35dcdaf4de51683217b6d74bd2 )
-)
-
-game (
-	name "Youma Ninpou Chou (Game Electronics bootleg, set 2)"
-	year "1986"
-	developer "bootleg"
-	rom ( name youmab2.zip size 67132 crc 5cc3d9c7 md5 06d4681cd21abbbf0ea5c13ca384ba95 sha1 ba5b0929569cb3e868af3f94e5f685a7b296bb2d )
-)
-
-game (
-	name "Yu-Jan"
-	year "1999"
-	developer "Yubis / T.System"
-	rom ( name yujan.zip size 954075 crc e3156c85 md5 2523fa5f0656bf3dda9bc0e0dbe30700 sha1 2989ac4c2420787b627c0092fc16d1496a7b703e )
-)
-
-game (
-	name "Yu-Ka"
-	year "1999"
-	developer "Yubis / T.System"
-	rom ( name yuka.zip size 1156984 crc 35d0a61e md5 651a630a7b8199ea9505dbe23aabf927 sha1 762dc5457c9baa54eb902835c004a929a0238fea )
-)
-
-game (
 	name "Yukon (version 2.0)"
 	year "1989"
 	developer "Exidy"
@@ -60216,13 +44686,6 @@ game (
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name yuyugogo.zip size 2027558 crc 1553e098 md5 3c42b2338c506c5fc62c32830decbc9e sha1 615b8e61ce37e11318b91e79079b1f083524522f )
-)
-
-game (
-	name "Zarya Vostoka"
-	year "1984"
-	developer "Nova Games of Canada"
-	rom ( name zaryavos.zip size 18044 crc 26709d01 md5 88f333162afd69c4b6e114d8bb07ee87 sha1 0a5b2eaf84b98ca2941317a844fa2cfcfcfb7807 )
 )
 
 game (
@@ -60310,34 +44773,6 @@ game (
 )
 
 game (
-	name "Zero Gunner (Model 2B)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zerogun.zip size 14877576 crc d7299369 md5 7a6d464a4b3962373b64b06ffb243cca sha1 1f689045bf27094dbc0b60098e072bb23ec8c6ec )
-)
-
-game (
-	name "Zero Gunner (Model 2A)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zeroguna.zip size 659009 crc 564cdc3d md5 84053e808cf3c52c10db51d9ed4e20ac sha1 8028b158f0a79c4c23dd253600a3ce88aa294a00 )
-)
-
-game (
-	name "Zero Gunner (Japan Model 2B)"
-	year "1997"
-	developer "Psikyo"
-	rom ( name zerogunj.zip size 224078 crc a508c0dd md5 3e84ce91ee12a44d2082be29f1ce68ff sha1 810a617e737cbee08373367a2f07615e4be96484 )
-)
-
-game (
-	name "Zero Hour"
-	year "1980"
-	developer "Universal"
-	rom ( name zerohour.zip size 13101 crc 37aa3e08 md5 743be989d2cddf24ad3b3218cfc14ee3 sha1 cf85d15f48eae82c8e9afae3933d8764282453db )
-)
-
-game (
 	name "Zero Point (set 1)"
 	year "1998"
 	developer "Unico"
@@ -60359,52 +44794,10 @@ game (
 )
 
 game (
-	name "Zero Team (set 1)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteam.zip size 5811905 crc 51aa0af0 md5 8d000f291db067da20e3155f71c0a3ce sha1 6c68072430d8ba84564fa44b9ea23e062ea2be01 )
-)
-
-game (
-	name "Zero Team (set 2)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteama.zip size 574770 crc 3bc03ba7 md5 fc4db75078a3e2da3a0d0e30d600c738 sha1 0e1b9fca7045de6b2f908537b73fe965aa455d21 )
-)
-
-game (
-	name "Zero Team (set 3)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteamb.zip size 519699 crc 0c68ad4e md5 646779343ce8a8fbd55b42af9314d92d sha1 ce293edf477b871fe799c15911528754eba33d71 )
-)
-
-game (
-	name "Zero Team (set 4)"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteamc.zip size 808070 crc ac9f7238 md5 67789355159ab810895d90d06a824fae sha1 769ec75eeec25f2ceebda39746bcb33a97242db7 )
-)
-
-game (
-	name "Zero Team Selection"
-	year "1993"
-	developer "Seibu Kaihatsu"
-	rom ( name zeroteams.zip size 533409 crc 4d0f968e md5 269ae1dfd447e51a6c7bf991bcc0b5fb sha1 d57a27e4644cf8a93895a9eef499284cfb0797a6 )
-)
-
-game (
 	name "Zero Time"
 	year "1979"
 	developer "bootleg? (Petaco S.A.)"
 	rom ( name zerotime.zip size 10254 crc 90871e3f md5 e371e9a74fb1c769413693954294646b sha1 11e9789eb25ea046de968f8c4a297aa094b5242d )
-)
-
-game (
-	name "Zero Target (World)"
-	year "1985"
-	developer "Data East Corporation"
-	rom ( name zerotrgt.zip size 124967 crc 9ba32a1b md5 a05d47f048d0df8b12e3a0214c5b0e3e sha1 2c6076949f8c8a1d380826a97e4b736c67832ada )
 )
 
 game (
@@ -60426,20 +44819,6 @@ game (
 	year "1993"
 	developer "Comad"
 	rom ( name zerozone.zip size 441111 crc 85157b48 md5 928117f37cd1782061dc86b89b83b4a7 sha1 fc16ac825eb959af6180304e939c51ad9dc26a6c )
-)
-
-game (
-	name "Mobile Suit Z-Gundam: A.E.U.G. vs Titans (ZGA1 Ver. A)"
-	year "2003"
-	developer "Capcom / Banpresto"
-	rom ( name zgundm.zip size 1687219 crc a8dd5253 md5 689122fc656b728c14622480ab792c87 sha1 d1103f47c710dcbc7e9fb18b9c923d11d3ba39e7 )
-)
-
-game (
-	name "Mobile Suit Z-Gundam: A.E.U.G. vs Titans DX (ZDX1 Ver. A)"
-	year "2004"
-	developer "Capcom / Banpresto"
-	rom ( name zgundmdx.zip size 2086458 crc 53cecf96 md5 3ab2e430acea55d8386da089ca583e6c sha1 da4e5ee8e19ae78c2e56db6761ab0aba02869208 )
 )
 
 game (
@@ -60471,13 +44850,6 @@ game (
 )
 
 game (
-	name "Zip _ Zap"
-	year "1995"
-	developer "Barko Corp"
-	rom ( name zipzap.zip size 1889854 crc b5f99dd5 md5 3128e2238388cbc3f27565eb04e21cc7 sha1 19cd1b0a118aee8d46e6cb6e8103a4f3fadf55cc )
-)
-
-game (
 	name "Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000)"
 	year "1997"
 	developer "Sega"
@@ -60506,19 +44878,6 @@ game (
 )
 
 game (
-	name "Zombie Revenge (JPN, USA, EXP, KOR, AUS)"
-	year "1999"
-	developer "Sega"
-	rom ( name zombrvn.zip size 92581206 crc ed57befe md5 e217770532c97d0dcfe9c88fb5f39567 sha1 cd27c69144b6f6979d9db3ab74d891e2698fc37a )
-)
-
-game (
-	name "Zoo"
-	developer "Astro Corp."
-	rom ( name zoo.zip size 984993 crc 6b386ca3 md5 89ed4d935eb0bd1bb7ba0e6cebe7f9fc sha1 1d68ac6c660331e104db1011ebbd5677af64d785 )
-)
-
-game (
 	name "Zoo Keeper (set 1)"
 	year "1982"
 	developer "Taito America Corporation"
@@ -60540,20 +44899,6 @@ game (
 )
 
 game (
-	name "Zoom 909"
-	year "1982"
-	developer "Sega"
-	rom ( name zoom909.zip size 70848 crc db4249eb md5 586b34ac542dc99c832288049c2b49fb sha1 f769e58810fb555765901f8d9eb88050ea1939f6 )
-)
-
-game (
-	name "Zorton Brothers (Los Justicieros)"
-	year "1993"
-	developer "Web Picmatic"
-	rom ( name zortonbr.zip size 37112 crc 5295e430 md5 4486ab0c46210f1da891487569af8c11 sha1 b2d470912c772d8167dcc64a560ca42b6d074420 )
-)
-
-game (
 	name "Zunzunkyou No Yabou (Japan)"
 	year "1994"
 	developer "Sega"
@@ -60565,13 +44910,6 @@ game (
 	year "2001"
 	developer "SNK"
 	rom ( name zupapa.zip size 17945799 crc 3c886433 md5 1536c540dab80feefc6ae2a880f3289b sha1 b89c7ddeb7a0828fb67bc50a55356af082b5360c )
-)
-
-game (
-	name "Zwackery"
-	year "1984"
-	developer "Bally Midway"
-	rom ( name zwackery.zip size 194039 crc 058b606e md5 a292f0585b2d99cb8da733ad7ecc5f94 sha1 8d2e8d67c6f1b90c37c9ea99db34e8297247b20a )
 )
 
 game (


### PR DESCRIPTION
I was able to get MAME 2010 to generate its own DAT for the first time a few days ago.

With that more accurate XML DAT to start with, there are also these changes to the DATs with the romset checksums. The good news is that lots of non-working, bad dump, and unemulated copy protection romsets that can't work in MAME 2010 are no longer going to match this RDB.