### PR TITLE
BIOS: update ggenie.bin to it's latest revision

### DIFF
--- a/dat/BIOS - Non-Merged.dat
+++ b/dat/BIOS - Non-Merged.dat
@@ -2,7 +2,7 @@ clrmamepro (
 	name "BIOS - Non-Merged"
 	description "BIOS - Non-Merged"
 	comment "BIOS files required by libretro. The non-merged version provides files organized by platform folder."
-	version "2018-03-12"
+	version "2019-01-08"
 	author "libretro"
 	homepage "http://github.com/libretro/libretro-database"
 	url "http://github.com/libretro/libretro-database"
@@ -181,7 +181,7 @@ game (
 	rom ( name bios_E.sms size 8192 crc 0072ed54 md5 840481177270d5642a14ca71ee72844c sha1 c315672807d8ddb8d91443729405c766dd95cae7 )
 	rom ( name bios_J.sms size 8192 crc 48d44a13 md5 24a519c53f67b00640d0048ef7089105 sha1 a8c1b39a2e41137835eda6a5de6d46dd9fadbaf2 )
 	rom ( name bios_U.sms size 8192 crc 0072ed54 md5 840481177270d5642a14ca71ee72844c sha1 c315672807d8ddb8d91443729405c766dd95cae7 )
-	rom ( name ggenie.bin size 32768 crc 5f293e4c md5 b5d5ff1147036b06944b4d2cac2dd1e1 sha1 ea4b0418d90bc47996f6788ad455391d07cad6cc )
+	rom ( name ggenie.bin size 32768 crc 14dbce4a md5 e8af7fe115a75c849f6aab3701e7799b sha1 937e1878ebd104f489e6bdbc410a184f79f1144a )
 	rom ( name sk.bin size 2097152 crc 0658f691 md5 4ea493ea4e9f6c9ebfccbdb15110367e sha1 88d6499d874dcb5721ff58d76fe1b9af811192e3 )
 	rom ( name sk2chip.bin size 262144 crc 4dcfd55c md5 b4e76e416b887f4e7413ba76fa735f16 sha1 70429f1d80503a0632f603bf762fe0bbaa881d22 )
 	rom ( name rom.db size 17742 crc c94e8c8b md5 ff4a3572475236e859e3e9ac5c87d1f1 sha1 02c287d10da6de579af7a4ce73b134bbdf23c970 )


### PR DESCRIPTION
The ggenie.bin available match with "Game Genie (USA, Europe) (Program)" from no-intro dat (http://datomatic.no-intro.org/index.php?page=show_record&s=32&n=0024), so I decided to change the hash to the "Game Genie (USA, Europe) (Rev A) (Program)" (http://datomatic.no-intro.org/?page=show_record&s=32&n=0025) for 3 main reasons:
-It's a verified dump;
-It's an updated revision;
-Remains compatible with Genesis Plus GX core;

more info: https://github.com/ekeeke/Genesis-Plus-GX/issues/257