### PR TITLE
mame2003 and 2010: add working nodump and baddump romsets to scanner

### DIFF
--- a/metadat/mame-nonmerged/MAME 2003.dat
+++ b/metadat/mame-nonmerged/MAME 2003.dat
@@ -1,6 +1,6 @@
 clrmamepro (
   name "MAME 2003 - Full Non-Merged TorrentZipped Working Romsets"
-  version "2018-12-14"
+  version "2018-12-13"
   description "Format: Full Non-Merged (No Separate BIOS Sets), Working Romsets Only, TorrentZipped"
 )
 
@@ -152,6 +152,13 @@ game (
 )
 
 game (
+	name "Forty-Love"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
+)
+
+game (
 	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
 	year "1994"
 	developer "Jaleco"
@@ -187,10 +194,30 @@ game (
 )
 
 game (
+	name "4-in-1 bootleg"
+	developer "bootleg"
+	rom ( name 4in1boot.zip size 921991 crc 0a78ac38 md5 96055d95961204db3d84be0ec6dc3873 sha1 2a90ad9b70d3b55ac49bb9d26ace4d96552e47dc )
+)
+
+game (
 	name "600"
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14459 crc e8e6b845 md5 6b249af98f7b27b35c55df083188d7a4 sha1 b40bd175b43a494a19d0b7e7b6021243027bb8df )
+)
+
+game (
+	name "64th. Street - A Detective Story (Japan)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64streej.zip size 1294030 crc 38192b3d md5 72160ca1b1d25604d50e22c18f9eec4d sha1 f6992618cee1fceabcdacaa294e6f8ddbce49b82 )
+)
+
+game (
+	name "64th. Street - A Detective Story (World)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
 )
 
 game (
@@ -233,6 +260,13 @@ game (
 	year "1986"
 	developer "Atari Games"
 	rom ( name 720r3.zip size 640299 crc 41cb9f85 md5 109098059a97131f80fde2bd2ffc2442 sha1 7e39f5a26a10e0b6bb884dfb16c7980793bd3b14 )
+)
+
+game (
+	name "7jigen no Youseitachi - Mahjong 7 Dimensions (Japan)"
+	year "1990"
+	developer "Dynax"
+	rom ( name 7jigen.zip size 1094390 crc e5a13dc4 md5 c9e02b91cf59baf718cfc78815eb9a2f sha1 34ed5f6f95eb85f5028124b86c0f4135c66f6bd3 )
 )
 
 game (
@@ -285,6 +319,13 @@ game (
 )
 
 game (
+	name "Eight Ball Action (Pac-Man conversion)"
+	year "1985"
+	developer "Seatongrove Ltd (Magic Eletronics USA licence)"
+	rom ( name 8bpm.zip size 12311 crc 783554f4 md5 dddcc73720c53723ddecb6c8c89aba89 sha1 00a02b852f810733275da9a6cd79f566604adf2c )
+)
+
+game (
 	name "'99: The Last War"
 	year "1985"
 	developer "Proma"
@@ -303,6 +344,20 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name a51mxr3k.zip size 292721 crc 985fabf5 md5 2e7914b5ff2238a81fe1041b7fcacb95 sha1 1df0b4dae65689d5d2f40382c1a1f79f9011ecbd )
+)
+
+game (
+	name "All American Football (rev E)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafb.zip size 525444 crc 2be03fdc md5 e6aec2fd817bacede3af08d2d4be5a09 sha1 792f4bd79355ca5b26b99f7d238927d4dc638347 )
+)
+
+game (
+	name "All American Football (rev B)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafbb.zip size 520288 crc 2ea71024 md5 5db0e5935cfbd38745879d914b364ec1 sha1 cc5705b6e561e5be49030fce82ed0af55ed4711b )
 )
 
 game (
@@ -561,6 +616,12 @@ game (
 	year "1986"
 	developer "Cinematronics"
 	rom ( name alleymas.zip size 101385 crc 19a6552e md5 20f578d63cf0f01ab6687c0b36e6bc2f sha1 0fc4237fcf7893a5fea8c9f7e5ed6199d5fa32db )
+)
+
+game (
+	name "Alpha Fighter / Head On"
+	developer "Data East Corporation"
+	rom ( name alphaho.zip size 14445 crc 184c8caa md5 9a5f40b6be34059e7db8ba9678436939 sha1 63b322f199de66a9bdda6b919747520278d562bf )
 )
 
 game (
@@ -990,10 +1051,52 @@ game (
 )
 
 game (
+	name "Tournament Arkanoid (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkatour.zip size 68670 crc 52978f77 md5 194516f15a98d70b0036350f7a7c12ae sha1 f3dfc76689213acdd38bfc3abbcf6f6ab752962c )
+)
+
+game (
 	name "Block (Game Corporation bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name arkbloc2.zip size 68787 crc d9396060 md5 854b1e2d58f2accea4ae67749e100c6a sha1 e5b0a0ea6b31f00b884be55d8895090ad966c3d0 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name arknid2j.zip size 165315 crc e73cbb79 md5 3370138aca19dac0bec247c7f945af9a sha1 0f770962bc298e25f5fb89d6adf4cc18757878cb )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknid2u.zip size 165246 crc 83c4dcdc md5 110c4a9fe87fd15696640aa8859dfa2e sha1 51192a5aa0b50e7e760ce0ef5bfd77bb5c018171 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
+)
+
+game (
+	name "Arkanoid (Japan)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name arknoidj.zip size 69489 crc 463bc22f md5 6cd6494b95ff7b136e1cf9bca007e3a4 sha1 ac553f69fc5476e89b080e9aca52dbd297b5e569 )
+)
+
+game (
+	name "Arkanoid (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknoidu.zip size 69382 crc be6a8132 md5 4508311fb0c8b3685dd02d06bce31bfc sha1 f8d0132414c4578aa8d022c3bd57ab61e19888a4 )
 )
 
 game (
@@ -1508,6 +1611,13 @@ game (
 )
 
 game (
+	name "Bagman (Moon Cresta hardware)"
+	year "1982"
+	developer "bootleg"
+	rom ( name bagmanmc.zip size 21737 crc 4d143fe6 md5 ed839d556dd74d6491553813c6f042c5 sha1 b2f46e780ed18e9d4fc2837014075ed2fb76dfa0 )
+)
+
+game (
 	name "Bagman (Stern set 1)"
 	year "1982"
 	developer "Valadon Automation (Stern license)"
@@ -1858,6 +1968,13 @@ game (
 )
 
 game (
+	name "Bouncing Balls"
+	year "1991"
+	developer "Comad"
+	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
+)
+
+game (
 	name "Best Bout Boxing"
 	year "1994"
 	developer "Jaleco"
@@ -2073,6 +2190,13 @@ game (
 )
 
 game (
+	name "Big Striker"
+	year "1992"
+	developer "Jaleco"
+	rom ( name bigstrik.zip size 734386 crc 66282984 md5 9dd26ba991c207f1f371436667d33de8 sha1 dec65dcc721faf7f54130c972989093a00ae1bd8 )
+)
+
+game (
 	name "Big Striker (bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -2150,6 +2274,13 @@ game (
 )
 
 game (
+	name "Bishi Bashi Championship Mini Game Senshuken"
+	year "1996"
+	developer "Konami"
+	rom ( name bishi.zip size 2693336 crc b2f59ff8 md5 5db8d60ed016045311db6e3acf3d153f sha1 6cd73477d06f42dbaaf8f79eb8a54b99f953f133 )
+)
+
+game (
 	name "Blue's Journey / Raguy"
 	year "1990"
 	developer "Alpha Denshi Co."
@@ -2175,6 +2306,13 @@ game (
 	year "1983"
 	developer "Taito Corporation"
 	rom ( name bking2.zip size 40059 crc e9d37dda md5 916d651b7ea733ac9ad9603919809478 sha1 6051518b61986328ba968ddf4201c6d86c756e2d )
+)
+
+game (
+	name "Birdie King 3"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name bking3.zip size 47780 crc 49e2b834 md5 85eed1d3d17b704da9237eebd7218f70 sha1 35c5994ddf72c92733c83a4fedbf6d6b2e7a6280 )
 )
 
 game (
@@ -2856,6 +2994,13 @@ game (
 )
 
 game (
+	name "Brain"
+	year "1986"
+	developer "Coreland / Sega"
+	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
+)
+
+game (
 	name "Borderline (bootleg)"
 	year "1981"
 	developer "bootleg"
@@ -3514,6 +3659,13 @@ game (
 )
 
 game (
+	name "Car Polo"
+	year "1977"
+	developer "Exidy"
+	rom ( name carpolo.zip size 5574 crc 92bcf55d md5 bde33e30020d209594ae065fae9c23dd sha1 7043a4bf4ff800dcc96477bbab113cdfa4ccce00 )
+)
+
+game (
 	name "Cassette: Astro Fantasia"
 	year "1981"
 	developer "DECO"
@@ -3780,6 +3932,13 @@ game (
 )
 
 game (
+	name "Chack'n Pop"
+	year "1983"
+	developer "Taito Corporation"
+	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
+)
+
+game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
@@ -3923,6 +4082,20 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name chiller.zip size 263851 crc 9545a100 md5 de20ffe9b2a329c79ea61584387338c5 sha1 cd112a6b44dbc7faeef51c80e33d7f51108de889 )
+)
+
+game (
+	name "Chimera Beast (prototype)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
+)
+
+game (
+	name "China Gate (US)"
+	year "1988"
+	developer "[Technos] (Taito Romstar license)"
+	rom ( name chinagat.zip size 669565 crc daf329d8 md5 1a7ecae60c4c03642e577ac743460b71 sha1 c12f1d93a26a5b7c6e8a4a063d068c8004f097ab )
 )
 
 game (
@@ -4507,6 +4680,13 @@ game (
 )
 
 game (
+	name "Cookie and Bibi 2"
+	year "1996"
+	developer "SemiCom"
+	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
+)
+
+game (
 	name "Cook Race"
 	year "1982"
 	developer "bootleg"
@@ -4874,6 +5054,13 @@ game (
 	year "1994"
 	developer "Midway"
 	rom ( name crusnusa.zip size 11277108 crc 2a29e7b8 md5 aa0f8937ad64031b4d6895691a5b63ec sha1 3ea7b111277572b9f8430a4f5d2541ae651692b2 )
+)
+
+game (
+	name "Cruis'n World (rev L1.3)"
+	year "1996"
+	developer "Midway"
+	rom ( name crusnw13.zip size 15823281 crc e1b6bead md5 2f7bc991753525741e314d50de90921f sha1 f5765b74fcd0ad1b8b22ae88215f84fd78e9dc8c )
 )
 
 game (
@@ -5982,6 +6169,13 @@ game (
 )
 
 game (
+	name "Devil Zone (easier)"
+	year "1980"
+	developer "Universal"
+	rom ( name devzone2.zip size 12519 crc 4c2cbc77 md5 740273f5bff885af643ed0de60cd51a1 sha1 7531bcf1427c865512f8c819ac6289185389e5b8 )
+)
+
+game (
 	name "Dangun Feveron (Japan)"
 	year "1998"
 	developer "Cave (Nihon System license)"
@@ -6175,6 +6369,13 @@ game (
 	year "1983"
 	developer "Nintendo of America"
 	rom ( name dkong3.zip size 42389 crc 317a8875 md5 53bcbf8591f68d360f36cda8ad766d85 sha1 453e8d47014ddc0e71b9befaac4a2d9e8048d83d )
+)
+
+game (
+	name "Donkey Kong 3 (bootleg on Donkey Kong Jr. hardware)"
+	year "1984"
+	developer "bootleg"
+	rom ( name dkong3b.zip size 36480 crc a3a1705c md5 de03f99f89c1b650ab86010cadc84b73 sha1 e04662c8e8b90fb5a40dccde270797232027d404 )
 )
 
 game (
@@ -6513,6 +6714,13 @@ game (
 )
 
 game (
+	name "Mr. Do's Wild Ride"
+	year "1984"
+	developer "Universal"
+	rom ( name dowild.zip size 43432 crc 77690fcb md5 664304c0f1fe87c18da5830785406d1f sha1 29f834e7b2c4c0ef8e280895185d66083c0c7dee )
+)
+
+game (
 	name "DownTown"
 	year "1989"
 	developer "Seta"
@@ -6646,6 +6854,13 @@ game (
 )
 
 game (
+	name "Driving Force (Galaxian conversion)"
+	year "1984"
+	developer "Shinkai Inc. (Magic Eletronics USA licence)"
+	rom ( name drivfrcg.zip size 17429 crc 9c1bdda3 md5 f0971fe5e8bf1cdf138a82b02ca4efd5 sha1 4bb114171d25e8c2e00b9e9401dbf61999c33b15 )
+)
+
+game (
 	name "Driving Force (Pac-Man conversion)"
 	year "1984"
 	developer "Shinkai Inc. (Magic Eletronics Inc. licence)"
@@ -6664,6 +6879,27 @@ game (
 	year "1983"
 	developer "Sanritsu"
 	rom ( name drmicro.zip size 54750 crc a9cc4018 md5 704b6d5e41ced6a59b61fef279a9a852 sha1 e80009ea0383fc22e022b829ca88efe151d00afb )
+)
+
+game (
+	name "Dr. Toppel's Adventure (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name drtoppel.zip size 399774 crc fd1387f9 md5 77f5dc35d6e052796c8173f8dfe05acf sha1 583e4245985e565b5d0409d85df56f05e89f188f )
+)
+
+game (
+	name "Dr. Toppel's Tankentai (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name drtopplj.zip size 399774 crc 7394c3b2 md5 a945b5aefc4c130d5ca105608c61bf37 sha1 4a4623c3ec5b61e1a17dbf937c62c50de4d4005a )
+)
+
+game (
+	name "Dr. Toppel's Adventure (US)"
+	year "1987"
+	developer "Taito America Corporation"
+	rom ( name drtopplu.zip size 399774 crc 58b6b726 md5 766757b80bcce201f37724b8f5736387 sha1 03b2acf29a220817e4af743c9931cb543fd3cb15 )
 )
 
 game (
@@ -6898,6 +7134,13 @@ game (
 )
 
 game (
+	name "Eggor"
+	year "1983"
+	developer "Telko"
+	rom ( name eggor.zip size 15733 crc 4f26a659 md5 b891df5d59d7b0faa260b9f7118b4a8e sha1 ef8095a7ae1ee548e0235af3492e1ef37394ed96 )
+)
+
+game (
 	name "Eggs"
 	year "1983"
 	developer "[Technos] Universal USA"
@@ -7080,6 +7323,20 @@ game (
 )
 
 game (
+	name "Enigma 2"
+	year "1981"
+	developer "GamePlan (Zilec Electronics license)"
+	rom ( name enigma2.zip size 11169 crc 297c5944 md5 7d15275e6c1d86bf3a5de282f735aaf9 sha1 18c51816f495b3c5615212cc35a894271445c24a )
+)
+
+game (
+	name "Enigma 2 (Space Invaders Hardware)"
+	year "1984"
+	developer "Zilec Electronics"
+	rom ( name enigma2a.zip size 10881 crc b05bc706 md5 526d8db1d2e923ae2d11ffe55490418d sha1 c3b85f4dd7b24ab501d476b705eb90295feef3d3 )
+)
+
+game (
 	name "Escape from the Planet of the Robot Monsters (set 1)"
 	year "1989"
 	developer "Atari Games"
@@ -7199,6 +7456,13 @@ game (
 )
 
 game (
+	name "Exciting Soccer (bootleg)"
+	year "1983"
+	developer "bootleg"
+	rom ( name exctsccb.zip size 50732 crc 4fc40505 md5 9a99b833f867d7d8582cee2ccf18624d sha1 311cf91e48d71ad6692d1142e3c75abbe61d8862 )
+)
+
+game (
 	name "Exciting Soccer"
 	year "1983"
 	developer "Alpha Denshi Co."
@@ -7272,6 +7536,13 @@ game (
 	year "1989"
 	developer "Gottlieb / Premier Technology"
 	rom ( name exterm.zip size 941767 crc 956fe605 md5 c70880dbc76aaf4428ecdab0775a1a97 sha1 46b60e7aed1e05e157632e6e413218ce0be7afb1 )
+)
+
+game (
+	name "Extermination (US)"
+	year "1987"
+	developer "[Taito] World Games"
+	rom ( name extrmatn.zip size 369293 crc 99b8f1ec md5 d6366d5cac27317e812ceee355126b4e sha1 6103d95839ad75c0be20929375ba1c32541054c2 )
 )
 
 game (
@@ -7384,6 +7655,13 @@ game (
 	year "1981"
 	developer "SNK"
 	rom ( name fantasyj.zip size 33318 crc 7d997539 md5 7f7021030e960377a949c3a0b2ff000d sha1 518fba9cf7acd672b3cb4a1cbe1f241e835bf363 )
+)
+
+game (
+	name "Fantazia"
+	year "1980"
+	developer "bootleg"
+	rom ( name fantazia.zip size 15505 crc 7f259c07 md5 970d025fa95ef70f78d860e813d88f61 sha1 fda5edfc64d86ce5ea15147ca53492263f281746 )
 )
 
 game (
@@ -7554,6 +7832,13 @@ game (
 )
 
 game (
+	name "Field Day"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
+)
+
+game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
@@ -7572,6 +7857,27 @@ game (
 	year "1983"
 	developer "[Kaneko] (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
+)
+
+game (
+	name "Final Lap 3 (Japan set 1)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3.zip size 2409181 crc 35f7c6f4 md5 ae55320f01b6af307092b51ebc2da3e3 sha1 753d47f9e796227c8632ec32760a6927b87a0992 )
+)
+
+game (
+	name "Final Lap (Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finalapc.zip size 1115864 crc fe8429ea md5 a86807af5c4f86a9cc45491bc95f0714 sha1 eaaa7d385dbd23eac09b3d3db55518c3edd2205e )
+)
+
+game (
+	name "Final Lap (Rev D)"
+	year "1987"
+	developer "Namco"
+	rom ( name finalapd.zip size 1114794 crc b8b5b2ff md5 e9c58dd17197a4430e4f0f55236dba6c sha1 7fc0b72d80962ee32671b200a65971f176f9bbed )
 )
 
 game (
@@ -7610,6 +7916,13 @@ game (
 )
 
 game (
+	name "Final Lap (Rev E)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallap.zip size 1115199 crc ce85ce2e md5 2f3e2c1ee5f563e62978badaed9131c2 sha1 38f95d6188b1bf5c9de235f81358f13c8579bee3 )
+)
+
+game (
 	name "Find Out"
 	year "1987"
 	developer "Elettronolo"
@@ -7621,6 +7934,20 @@ game (
 	year "1989"
 	developer "Namco"
 	rom ( name finehour.zip size 2297433 crc 81ef74a8 md5 ed09ff75a008007cc92896464bf0ec46 sha1 13ab919d68691b5b0bcb2fdd3fae53d1f9bd3fc7 )
+)
+
+game (
+	name "Final Lap (Japan - Rev B)"
+	year "1987"
+	developer "Namco"
+	rom ( name finlapjb.zip size 1117611 crc f99c7c93 md5 6bdd818d45e7047c431f54e3e541a893 sha1 9b286b02565df42ffd940b7cf52057e802d2763c )
+)
+
+game (
+	name "Final Lap (Japan - Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finlapjc.zip size 1114352 crc 77780abf md5 cca77f8fda05c38683c2908b34c2ec1f sha1 ca5eb174b3b032852c2f84f67e31e3ff355a725c )
 )
 
 game (
@@ -7642,6 +7969,13 @@ game (
 	year "1979"
 	developer "Exidy"
 	rom ( name fireone.zip size 23019 crc 8ea78b5f md5 19d65861cdd9c1b4704c520780ebbccc sha1 e7a590e70fcf6d572d14b6dbce85b9b91ad60c1a )
+)
+
+game (
+	name "Fire Shark"
+	year "1990"
+	developer "Toaplan"
+	rom ( name fireshrk.zip size 533656 crc fe7108e5 md5 f0d73a3e26839b427ed950a3ae234cb8 sha1 79c49bea2e1ccf5e2f8ba07a3a1c8581606af181 )
 )
 
 game (
@@ -7725,6 +8059,13 @@ game (
 	year "1987"
 	developer "Konami"
 	rom ( name flkatck.zip size 411694 crc a06b784f md5 c94bd8bf90c6bbfd97317cfd7669459c sha1 ca21bb46e80c02f1a7f345ccf24b4b424aa5048d )
+)
+
+game (
+	name "Flower"
+	year "1986"
+	developer "Komax"
+	rom ( name flower.zip size 75740 crc e81cd8c6 md5 fc99c48b9450844938c69f7bc547876d sha1 49f131cc3f947c3cca3f0056440b4bb61e9a9ee2 )
 )
 
 game (
@@ -9107,6 +9448,13 @@ game (
 )
 
 game (
+	name "Gratia - Second Earth (91022-10 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratiaa.zip size 9094463 crc bd03f496 md5 da78ed9c90ce86938cdf218c4a3b861d sha1 6a960e44c072e14138882af2fe4966526e026379 )
+)
+
+game (
 	name "Gravitar (version 3)"
 	year "1982"
 	developer "Atari"
@@ -9386,10 +9734,24 @@ game (
 )
 
 game (
+	name "Great 1000 Miles Rally"
+	year "1994"
+	developer "Kaneko"
+	rom ( name gtmr.zip size 4906312 crc 0faaff68 md5 a6b8ef0d66eb42ac162881238e9da8c7 sha1 7dfc026885c50a3570c33f2ffa16ceaaf967f6e1 )
+)
+
+game (
 	name "Mille Miglia 2: Great 1000 Miles Rally"
 	year "1995"
 	developer "Kaneko"
 	rom ( name gtmr2.zip size 5718258 crc 2ac10cee md5 4907cdf1766fae4e4ca978efba3b4ed0 sha1 a24048aa8204bfce58d141f3d19c2281b7673a64 )
+)
+
+game (
+	name "Great 1000 Miles Rally (Evolution Model)"
+	year "1994"
+	developer "Kaneko"
+	rom ( name gtmre.zip size 5560432 crc c536af0c md5 95049e1c3a5cc5be2e97df6faddace71 sha1 0ded1220fdc1801ca3424d56cc09fa867b873d2e )
 )
 
 game (
@@ -10321,6 +10683,13 @@ game (
 )
 
 game (
+	name "Hana Oriduru (Japan)"
+	year "1989"
+	developer "Dynax"
+	rom ( name hnoridur.zip size 497246 crc c3521819 md5 483ad9c04e411d532c3a79c648f9bdd7 sha1 9a5baca2a9dfa1fa5c4762283df941affe8ab9c6 )
+)
+
+game (
 	name "Hoccer (set 1)"
 	year "1983"
 	developer "Eastern Micro Electronics, Inc."
@@ -10353,6 +10722,13 @@ game (
 	year "1992"
 	developer "Sega"
 	rom ( name holo.zip size 5228140 crc 44be9ce3 md5 3664fdfd8d2ec53156ef54d350c1cb35 sha1 9e696362152232dac3f01cd13b7e12ff76485dce )
+)
+
+game (
+	name "Moero Pro Yakyuu Homerun"
+	year "1988"
+	developer "Jaleco"
+	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
 )
 
 game (
@@ -10524,6 +10900,13 @@ game (
 )
 
 game (
+	name "Hatch Catch"
+	year "1995"
+	developer "SemiCom"
+	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
+)
+
+game (
 	name "Hat Trick Hero (Japan)"
 	year "1990"
 	developer "Taito Corporation"
@@ -10626,6 +11009,20 @@ game (
 	year "1990"
 	developer "Atari Games"
 	rom ( name hydra.zip size 1392773 crc 7836f4e8 md5 0588a36f5fcb45420a9f60a2f70382a6 sha1 c75d2ab46d30a9da74da917c1c9e541856111b67 )
+)
+
+game (
+	name "Hydra (prototype 5/14/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap.zip size 1364949 crc 57682d92 md5 7b20deaa28cd323d7914b76249befff0 sha1 682198a293cbfe1acbe56fe44f0a44b9b4ac0a94 )
+)
+
+game (
+	name "Hydra (prototype 5/25/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap2.zip size 1396646 crc 99b3b329 md5 97191d62546cef253489d980b1da037f sha1 44890333ac6cfac521f768b72da2dd7eb24bf000 )
 )
 
 game (
@@ -10783,6 +11180,20 @@ game (
 )
 
 game (
+	name "Iga Ninjyutsuden (Japan)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name iganinju.zip size 901742 crc c2860aaf md5 0babe1c7921b24a00afedd59ca99a566 sha1 d29af4d4e8dd78a6c98e8db89faef85fbbdee1a7 )
+)
+
+game (
+	name "IGMO"
+	year "1984"
+	developer "Epos Corporation"
+	rom ( name igmo.zip size 20946 crc 9ff45478 md5 bac686b9e8c052852dc6fd2b06a14a51 sha1 55406a6c97dd5aa00b8171ae45c5cd243bbb2909 )
+)
+
+game (
 	name "Ikari Warriors (US)"
 	year "1986"
 	developer "SNK"
@@ -10815,6 +11226,13 @@ game (
 	year "1985"
 	developer "Sun Electronics"
 	rom ( name ikki.zip size 75792 crc 86dc9eff md5 70cefaeddbc9732c6acae6c07465b37f sha1 3fd8d8cecca4d3c8648e019b0f64075035f25554 )
+)
+
+game (
+	name "Imago"
+	year "1983"
+	developer "Acom"
+	rom ( name imago.zip size 30894 crc 236ffefa md5 6f34a01deb3f45a3594d0002745023e4 sha1 8aea054e3bf1d7fb97dcab0cfe8063041cd6dec2 )
 )
 
 game (
@@ -10906,6 +11324,13 @@ game (
 	year "1989"
 	developer "Taito Corporation Japan"
 	rom ( name insectx.zip size 545814 crc 96e2c167 md5 924a3e5ac43a7806ab2a3230fb24f8dc sha1 586079911f49d8c8ce87e1224a721feadc22797f )
+)
+
+game (
+	name "International Cup '94"
+	year "1994"
+	developer "Taito Corporation Japan"
+	rom ( name intcup94.zip size 4866359 crc ccf5818f md5 0cf4985c5b1b0b84371887b449b5b746 sha1 c532ad3e351cc43e92280575d8befdf2f64de1e4 )
 )
 
 game (
@@ -11325,6 +11750,13 @@ game (
 )
 
 game (
+	name "Jump Kids"
+	year "1993"
+	developer "Comad"
+	rom ( name jumpkids.zip size 1099388 crc 463d7ed0 md5 c1f6eaedb75d963882441f11aedc50aa sha1 1c55bf2d0d8418d1e43d49c675c6c757d837f172 )
+)
+
+game (
 	name "Jump Shot"
 	year "1985"
 	developer "Bally Midway"
@@ -11455,6 +11887,13 @@ game (
 	year "1993"
 	developer "Toei / Banpresto"
 	rom ( name kamenrid.zip size 1645002 crc be8b3858 md5 dd5be3f5b58092d1c3ff64b886b95261 sha1 0291ac3e9296abb19ef7472d9c58fc06283bb23a )
+)
+
+game (
+	name "Kamikaze"
+	year "1979"
+	developer "Leijac"
+	rom ( name kamikaze.zip size 5928 crc 5a4fefc8 md5 7bdacec83ded3f14a622750d540b0c46 sha1 b8cbbb27d5446fb696b6e963f6f41e3cb79a285a )
 )
 
 game (
@@ -11619,10 +12058,31 @@ game (
 )
 
 game (
+	name "Kick Goal"
+	year "1995"
+	developer "TCH"
+	rom ( name kickgoal.zip size 1189017 crc c3ff3382 md5 8b0dbd8e19bab863db541e5c48f3a13f sha1 25c2f7fe2bb255c1922c0866c98c129c9e5d713d )
+)
+
+game (
+	name "Kick and Run"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kicknrun.zip size 152032 crc 9a9b55cd md5 a80df6467b1ea03181520030eb0d5555 sha1 6dd6869b140cb579da5a478a29548c30cfdf1c60 )
+)
+
+game (
 	name "Kick Off (Japan)"
 	year "1988"
 	developer "Jaleco"
 	rom ( name kickoff.zip size 464558 crc 21cc580e md5 95a1ab4925d9416efd51fd52097645fb sha1 b35e21669a362b3e83e10237579c48f0a004e976 )
+)
+
+game (
+	name "Kick Rider"
+	year "1984"
+	developer "Universal"
+	rom ( name kickridr.zip size 37613 crc 6de518ec md5 f716a2652a69c8662cdea9f96e0bfa1b sha1 b7c14c94ba08fbcfbe2284d8b025ec2e51673eae )
 )
 
 game (
@@ -12102,6 +12562,13 @@ game (
 )
 
 game (
+	name "Kyukyoku Tiger (Japan)"
+	year "1987"
+	developer "[Toaplan] Taito Corporation"
+	rom ( name ktiger.zip size 386609 crc add330cc md5 629b96cc507ebe66334ccca00f5f9317 sha1 5bf64f9dde55b4b2a3e4e8a828a4fe041333f472 )
+)
+
+game (
 	name "Kyukyoku Tiger 2 (Japan)"
 	year "1995"
 	developer "Taito Corporation"
@@ -12155,6 +12622,13 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name kuniokub.zip size 372523 crc 9f5629d7 md5 f8ce01fc16acb685aaccf042587a5552 sha1 acd5f9b89129d76cc0c768df715b78a37e46da7f )
+)
+
+game (
+	name "Nekketsu Kouha Kunio-kun (Japan)"
+	year "1986"
+	developer "Technos"
+	rom ( name kuniokun.zip size 372304 crc 203bb0a5 md5 e22eb80e3432d270ff6d97c693014511 sha1 87e72305b046b9e9a8df99551685ad82ad56191c )
 )
 
 game (
@@ -12465,6 +12939,13 @@ game (
 )
 
 game (
+	name "Led Storm (US)"
+	year "1988"
+	developer "Capcom"
+	rom ( name ledstorm.zip size 762768 crc 1b535639 md5 cbce03ebccfcad6f01294dc68ab1d75c sha1 57afcaf83241c44ef51b9c8c35d54bda4d66a2c4 )
+)
+
+game (
 	name "Legend"
 	developer "Sega / Coreland ?"
 	rom ( name legend.zip size 93563 crc c1cd6e96 md5 a1adfa68818e2a1a29970392f4a4cfc1 sha1 2669f9d8997c766e937877e0e9f5cd74a9a64a43 )
@@ -12541,6 +13022,13 @@ game (
 )
 
 game (
+	name "Liberator (set 1)"
+	year "1982"
+	developer "Atari"
+	rom ( name liberatr.zip size 30734 crc ae5d1ad4 md5 c12ca5177907acb1f433b703ab682ce2 sha1 bd24a1ed7eb06e917e152378daf066c68a98a2fc )
+)
+
+game (
 	name "Libble Rabble"
 	year "1983"
 	developer "Namco"
@@ -12597,6 +13085,13 @@ game (
 )
 
 game (
+	name "The Legend of Kage (bootleg set 1)"
+	year "1984"
+	developer "bootleg"
+	rom ( name lkageb.zip size 77418 crc 3f769b27 md5 485adde1f730d9c8ca18c9dcf89984c9 sha1 972b24b7c36cebf03a8d1164f4dff947be174036 )
+)
+
+game (
 	name "The Legend of Kage (bootleg set 2)"
 	year "1984"
 	developer "bootleg"
@@ -12608,6 +13103,20 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name lkageb3.zip size 77406 crc aba7cbc4 md5 356a0f9d3eb56726d90225f8c061fdf2 sha1 dd2b9b59a652f82d9dd9783beb9769de7a842cc6 )
+)
+
+game (
+	name "Lunar Lander (rev 2)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander.zip size 9997 crc 82f5646d md5 fd30420a2e5ffc7cab354da41c962bcd sha1 5b7bb0bc7d4498a2b147b9ad80d339c2d05755b3 )
+)
+
+game (
+	name "Lunar Lander (rev 1)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander1.zip size 9978 crc 9809c308 md5 1f2a4cd20f726611a591feef1e158010 sha1 afede8df58db9fa75c10d61c3a8ca7b3908fe67c )
 )
 
 game (
@@ -12884,6 +13393,13 @@ game (
 )
 
 game (
+	name "Macho Mouse"
+	year "1982"
+	developer "Techstar"
+	rom ( name machomou.zip size 17444 crc 345b8f23 md5 c270dd46676828d7de2ff194704543aa sha1 de2c27c14386683043fa6bc0ec57ccc74206a373 )
+)
+
+game (
 	name "Vs. Mach Rider (Japan, Fighting Course Version)"
 	year "1985"
 	developer "Nintendo"
@@ -12930,6 +13446,20 @@ game (
 	year "1995"
 	developer "Tuning"
 	rom ( name maddonna.zip size 2325661 crc 730605e7 md5 ff5d27bdfa8c13f8e6bf8c957646f10b sha1 dd796563799f31ba8ee54fb3c71f1a31493ad407 )
+)
+
+game (
+	name "Mad Gear (US)"
+	year "1989"
+	developer "Capcom"
+	rom ( name madgear.zip size 764354 crc 79278357 md5 209af18bbe611c703ff15aa3aaf8a6fb sha1 bf887ad6bd8b6877dd38d6b8e587825fc1c59c61 )
+)
+
+game (
+	name "Mad Gear (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name madgearj.zip size 764340 crc 687beded md5 25b8d6d1782d069a55e5f376bd3af5e8 sha1 f3c25b5a6bf27739d56c734f60ac6b06d93f742c )
 )
 
 game (
@@ -13338,6 +13868,13 @@ game (
 )
 
 game (
+	name "The Masters of Kin"
+	year "1988"
+	developer "Du Tech"
+	rom ( name mastkin.zip size 39037 crc bc81cbc8 md5 8784d2fd5f868f372cd16783f2d18d4e sha1 53faf0a4430e23ceac8fde58ab4d0202864f0b2a )
+)
+
+game (
 	name "Match It"
 	year "1989"
 	developer "Tamtex"
@@ -13572,6 +14109,13 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name megazone.zip size 58725 crc fe8c220b md5 ff3a0267f5180d87b4b49ba636ed1727 sha1 8e9d8845542b9087d0754293cc0fdea655aad822 )
+)
+
+game (
+	name "Meikyuu Hunter G (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name meikyuh.zip size 404389 crc 8bd8d87a md5 b19cc4d2af2034932b6e65480af0b5e6 sha1 6fd570051576f61ea3ef4dab9cb1488ae2f8b4a4 )
 )
 
 game (
@@ -14451,6 +14995,13 @@ game (
 )
 
 game (
+	name "Monkey Donkey"
+	year "1981"
+	developer "bootleg"
+	rom ( name monkeyd.zip size 30643 crc 13918892 md5 a689ac1fb1d8a3a087d3872e3d838a88 sha1 58d1969b3f72549c60ce5ed1daa3dd6f9f05f96a )
+)
+
+game (
 	name "Monster Bash"
 	year "1982"
 	developer "Sega"
@@ -14660,6 +15211,13 @@ game (
 )
 
 game (
+	name "Moon Patrol (Williams)"
+	year "1982"
+	developer "Irem (Williams license)"
+	rom ( name mpatrolw.zip size 24611 crc 74e8f798 md5 5f63076f8bb5b41497a12d7b59190b12 sha1 09165338e1addeec2e2b88568ebd9819cc58b938 )
+)
+
+game (
 	name "Mad Planets"
 	year "1983"
 	developer "Gottlieb"
@@ -14776,6 +15334,13 @@ game (
 	year "1988"
 	developer "Home Data"
 	rom ( name mrokumei.zip size 384910 crc 5ba59aca md5 9ab98b6413380a7c4e4a9001be577873 sha1 042eeb9ec10d762edbbf19f52a7301377c079bfe )
+)
+
+game (
+	name "Mr. TNT"
+	year "1983"
+	developer "Telko"
+	rom ( name mrtnt.zip size 16312 crc 81babd83 md5 077a26144b4a30ed52bf7b5c6f1bb14a sha1 a6d3a4bda41274ffe538521c976f50c01e28b84c )
 )
 
 game (
@@ -15618,6 +16183,13 @@ game (
 )
 
 game (
+	name "News"
+	year "1993"
+	developer "Poby / Virus"
+	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
+)
+
+game (
 	name "New Sinbad 7"
 	year "1983"
 	developer "ATW USA, Inc."
@@ -15723,6 +16295,13 @@ game (
 )
 
 game (
+	name "Ninja Emaki (US)"
+	year "1986"
+	developer "Nichibutsu"
+	rom ( name ninjemak.zip size 219787 crc a6d62528 md5 00ec58d18b5efc4bc2335f6932f531e1 sha1 cbe53ea7f93e5ff597b56ec55880730bad91fc33 )
+)
+
+game (
 	name "Nightmare in the Dark"
 	year "2000"
 	developer "Eleven / Gavaking"
@@ -15748,6 +16327,13 @@ game (
 	year "1996"
 	developer "Nichibutsu"
 	rom ( name niyanpai.zip size 997812 crc c6a23980 md5 0b88935de104339f260b6df64644fecd sha1 8945fb99c2fb27be996c6cc141a3312f0bc74234 )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan bootleg)"
+	year "1987"
+	developer "Technos"
+	rom ( name nkdodgeb.zip size 320485 crc 60e2b0a5 md5 ad853cacde50b27b6cbe9063ffdb24e2 sha1 2385e2bf61d4f19982c04065f2f5971255cbc109 )
 )
 
 game (
@@ -16031,6 +16617,13 @@ game (
 )
 
 game (
+	name "Oigas (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name oigas.zip size 67995 crc b37c9061 md5 18ea2172a2285066e87e9cba6ead1fee sha1 9cdfbdbd8aa00e8174be4398ba5239e460c9d759 )
+)
+
+game (
 	name "Oishii Puzzle Ha Irimasenka"
 	year "1993"
 	developer "Sunsoft + Atlus"
@@ -16077,6 +16670,12 @@ game (
 	year "1981"
 	developer "Irem + GDI"
 	rom ( name olibochu.zip size 35413 crc ec73c654 md5 b308efcb8b0292b80b3e848702179d14 sha1 b8459d404213a189365fde83560797b3a6df6ec3 )
+)
+
+game (
+	name "Omega"
+	developer "bootleg?"
+	rom ( name omega.zip size 11839 crc 6e2ded37 md5 a868eb41642262003d1a75a891ca8429 sha1 55f39a1c1e09b11f56f800541051dbf2b4c8be22 )
 )
 
 game (
@@ -16470,6 +17069,13 @@ game (
 )
 
 game (
+	name "Pac-Man _ Chomp Chomp"
+	year "1983"
+	developer "Namco"
+	rom ( name pacnchmp.zip size 22237 crc 19da8a5b md5 0ff843e64791694443b8f12530ec336d sha1 a86b1ae7a7610f87207703e74bb913e280ac73e0 )
+)
+
+game (
 	name "Pac _ Pal"
 	year "1983"
 	developer "Namco"
@@ -16732,6 +17338,13 @@ game (
 	year "1996"
 	developer "Fuuki"
 	rom ( name pbancho.zip size 2257641 crc 9edd54cf md5 7cca2339628749297e3c85caf49501b3 sha1 a479c9984acebb1386ea2621bf53020010cafd7d )
+)
+
+game (
+	name "Prebillian"
+	year "1986"
+	developer "Taito"
+	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -17337,6 +17950,13 @@ game (
 )
 
 game (
+	name "Pest Place"
+	year "1983"
+	developer "bootleg"
+	rom ( name pestplce.zip size 29401 crc 776626de md5 5bb6dc7e2785a0087ede8e33d61fe6ea sha1 613b7e891eec5c65e62a32c1d5eb8002688f6d15 )
+)
+
+game (
 	name "Peter Pack-Rat"
 	year "1984"
 	developer "Atari Games"
@@ -17446,6 +18066,20 @@ game (
 	year "1983"
 	developer "Valadon Automation"
 	rom ( name pickin.zip size 16423 crc 47b51d97 md5 d33fdaef3fb8e635229d62749523d1e7 sha1 d690f1f63adf9914d40af437fde192bf0d2a6ab9 )
+)
+
+game (
+	name "Pig Newton (version C)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewt.zip size 39539 crc 8caec6e8 md5 4aa526afd8de76d481c8f510ecc6c540 sha1 16e1b78b72e9d242f8469c78146089be87933df3 )
+)
+
+game (
+	name "Pig Newton (version A)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewta.zip size 25726 crc 36e3207c md5 d9859359c098e12e947b393354c7c24e sha1 d80c567d7c51ff6c5b87455425ac74d18653c2be )
 )
 
 game (
@@ -17708,6 +18342,13 @@ game (
 	year "1989"
 	developer "Taito Corporation Japan"
 	rom ( name plotting.zip size 71612 crc b0df8c3c md5 3159e359420ef336b5796558fec52d16 sha1 fdfa605577bd233e9aefc73db2a0d71f5e7cc07b )
+)
+
+game (
+	name "Plump Pop (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
 )
 
 game (
@@ -18187,6 +18828,13 @@ game (
 )
 
 game (
+	name "Power Surge"
+	year "1988"
+	developer "&lt;unknown&gt;"
+	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
+)
+
+game (
 	name "Psychic 5"
 	year "1987"
 	developer "Jaleco"
@@ -18429,6 +19077,13 @@ game (
 	year "1998"
 	developer "Mitchell"
 	rom ( name puzzloop.zip size 6368239 crc 1d950b35 md5 8a2b942d0f28b140ea2fda0c62cc2c5d sha1 6b5bb41d11c47fadf877dafc001c6c0ec36ead26 )
+)
+
+game (
+	name "Puzznic (Japan)"
+	year "1989"
+	developer "Taito Corporation"
+	rom ( name puzznic.zip size 130556 crc 6d8f3ce1 md5 a4db9301b0e631aa831a14431d5f5a9a sha1 1f6f9759fc0a38af71776b226f5d456f61fbefac )
 )
 
 game (
@@ -19076,6 +19731,13 @@ game (
 )
 
 game (
+	name "Raiga - Strato Fighter (Japan)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name raiga.zip size 765646 crc 3cd0e291 md5 e3d6675c331bc2b90e42be04dab67c3a sha1 db60005181e83c85db7cb87ffceac20b45891e1c )
+)
+
+game (
 	name "Raimais (Japan)"
 	year "1988"
 	developer "Taito Corporation"
@@ -19439,6 +20101,13 @@ game (
 )
 
 game (
+	name "Renegade (US)"
+	year "1986"
+	developer "Technos (Taito America license)"
+	rom ( name renegade.zip size 376370 crc 5b8a287f md5 497b058836630f20504bfe961f042a0e sha1 9fe0443988f8d204b9c8c7f311d5d2f4aaf03c09 )
+)
+
+game (
 	name "Repulse"
 	year "1985"
 	developer "Sega"
@@ -19611,6 +20280,13 @@ game (
 	year "1985"
 	developer "Data East USA"
 	rom ( name ringkin2.zip size 139687 crc 0c11c352 md5 fef4e8b8dd9bc990f9d7a24d86c79acb sha1 7f3a635f4659017a570a9578a64e1a8f75fbc0e7 )
+)
+
+game (
+	name "Ring King (US set 3)"
+	year "1985"
+	developer "Data East USA"
+	rom ( name ringkin3.zip size 131513 crc 0c7987ba md5 000a952fb2b86d20d9b422f2aaba743c sha1 1adc6f76554e70461eb32b450e1d4a918c9c9caa )
 )
 
 game (
@@ -19950,6 +20626,20 @@ game (
 )
 
 game (
+	name "Rock'n Tread (Japan)"
+	year "1999"
+	developer "Jaleco"
+	rom ( name rockn.zip size 2374149 crc aad0254a md5 9baa2fe1811efe447bddbe3288a578fb sha1 0990db97f88e713764769091e604f6b6641c7cab )
+)
+
+game (
+	name "Rock 'n Rage (World?)"
+	year "1986"
+	developer "Konami"
+	rom ( name rockrage.zip size 291478 crc bc8fa769 md5 e3ec5bed9b367d29ced07dfc67ff0c2e sha1 4e10727b60f34f903ba42e9fa8b74d0367936172 )
+)
+
+game (
 	name "Koi no Hotrock (Japan)"
 	year "1986"
 	developer "Konami"
@@ -20242,6 +20932,13 @@ game (
 )
 
 game (
+	name "Run and Gun (World ver. EAA)"
+	year "1993"
+	developer "Konami"
+	rom ( name rungun.zip size 7092222 crc c52ee2c5 md5 c27befac8f2e02a558342d4fcd2b27f3 sha1 845639a31554d51fd337f944e6414835136ffc90 )
+)
+
+game (
 	name "Run and Gun (US ver. UAB)"
 	year "1993"
 	developer "Konami"
@@ -20424,6 +21121,13 @@ game (
 )
 
 game (
+	name "Sai Yu Gou Ma Roku (Japan)"
+	year "1988"
+	developer "Technos"
+	rom ( name saiyugou.zip size 672486 crc d1a9581c md5 edb51ba860bddcfc0309919d00862966 sha1 b7c15dac436f3e5f00d92188e5ad7b2677faeff7 )
+)
+
+game (
 	name "Salamander (version D)"
 	year "1986"
 	developer "Konami"
@@ -20435,6 +21139,20 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name salamanj.zip size 271361 crc bdc6e20e md5 8c9a546858cb293b325b2e4fcedc4c63 sha1 5735574a0f9b5f73deb3008d0fb6df94019c1ace )
+)
+
+game (
+	name "Same! Same! Same! (2P Ver.)"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesam2.zip size 533531 crc b5bc5abe md5 821ef424fce9f95f25f543cb71f0dac4 sha1 ada200f853e8c974e55c3a7f9c7245e411ee78b7 )
+)
+
+game (
+	name "Same! Same! Same!"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame.zip size 532895 crc 07c4265b md5 baf874b29506daae9dd5b10f12d553f1 sha1 8b08bce6093e1d645fea70e53d288de61de09391 )
 )
 
 game (
@@ -21592,6 +22310,13 @@ game (
 )
 
 game (
+	name "Sheriff"
+	year "1979"
+	developer "Nintendo"
+	rom ( name sheriff.zip size 9418 crc 9383d774 md5 3c9f7ac4bf8382038b3177fec64f60bc sha1 b3ebb4b83f79c11a62346ee7ab88cb8baf23ffa2 )
+)
+
+game (
 	name "Shienryu"
 	year "1997"
 	developer "Warashi"
@@ -22233,6 +22958,13 @@ game (
 )
 
 game (
+	name "Slam Dunk (Japan ver. JAA))"
+	year "1993"
+	developer "Konami"
+	rom ( name slmdunkj.zip size 6729429 crc c0a05ec7 md5 0e5dddaf9c617754a8823ddc35f6db32 sha1 83f1e369170f180d954bcb940da0c888d90aaec9 )
+)
+
+game (
 	name "Sly Spy (US revision 3)"
 	year "1989"
 	developer "Data East USA"
@@ -22589,6 +23321,13 @@ game (
 )
 
 game (
+	name "Space Echo"
+	year "1980"
+	developer "bootleg"
+	rom ( name spacecho.zip size 14008 crc 335437af md5 f88ceaad0375d1fcf7c73ff8c9f9c88b sha1 26995ed76090c4c9684030bf0b119b4a82e0a96e )
+)
+
+game (
 	name "Space Cruiser"
 	year "1981"
 	developer "Taito Corporation"
@@ -22889,6 +23628,13 @@ game (
 )
 
 game (
+	name "Super Dodge Ball (US)"
+	year "1987"
+	developer "Technos"
+	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
+)
+
+game (
 	name "Speak _ Rescue"
 	year "1980"
 	developer "Sun Electronics"
@@ -23131,6 +23877,13 @@ game (
 	year "1977"
 	developer "Atari"
 	rom ( name sprint4.zip size 7441 crc 88d66f96 md5 3d4c57f4f542015e433a6f232ce61b3a sha1 3530a3f6d6547c98c97b8b5ceb2e63a6c81da14d )
+)
+
+game (
+	name "Sprint 4 (set 2)"
+	year "1977"
+	developer "Atari"
+	rom ( name sprint4a.zip size 6775 crc c64a001c md5 f401bb5aaf4de0558bb5a053e5abd6bb sha1 b9226ba6ae7eea522e5cbecbc4b28758d1d937b2 )
 )
 
 game (
@@ -23596,6 +24349,20 @@ game (
 )
 
 game (
+	name "Super Speed Race Junior (Japan)"
+	year "1985"
+	developer "Taito Corporation"
+	rom ( name ssrj.zip size 29266 crc f29fcd99 md5 42aaf020b93e61ad2196c27b2916f230 sha1 63af6180f45d2a76a5d15bb69de3b3166cea0916 )
+)
+
+game (
+	name "Super Stingray"
+	year "1986"
+	developer "Alpha Denshi Co."
+	rom ( name sstingry.zip size 120433 crc 33fee390 md5 0180ce799c7e9c2146f3f70c91efb7cd sha1 0a556fcb40164d496422cabbb38334424289ba2d )
+)
+
+game (
 	name "Space Stranger"
 	year "1978"
 	developer "Yachiyo Electronics, Ltd."
@@ -23747,6 +24514,13 @@ game (
 	year "1983"
 	developer "Sega"
 	rom ( name starjack.zip size 49146 crc cdfa7350 md5 f3a130a94a20f2928eb4daeaaf7c930a sha1 89fc6c78c094aa98daf0b20304965429c912b5da )
+)
+
+game (
+	name "Star Jacker (Stern)"
+	year "1983"
+	developer "Stern"
+	rom ( name starjacs.zip size 50484 crc 1d46eef3 md5 3be2eb32f091122c252f421a9441dfe4 sha1 f4bd668c27ae7789159febc280a582f2a11c35ed )
 )
 
 game (
@@ -23985,6 +24759,13 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name stratgyx.zip size 22018 crc fe4b2868 md5 00246fda59f8ed63c1e6113a6953a460 sha1 93f571880f62c40304d0784c475534e62a7cad14 )
+)
+
+game (
+	name "Raiga - Strato Fighter (US)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
 )
 
 game (
@@ -24233,6 +25014,12 @@ game (
 )
 
 game (
+	name "Super Bond"
+	developer "bootleg"
+	rom ( name superbon.zip size 20193 crc 56f1e60e md5 b825b187495ab8d327159e5d6a4f66f4 sha1 7ce5066f30c5a5a07f329376dd863408704e24fa )
+)
+
+game (
 	name "Super Bug"
 	year "1977"
 	developer "Atari"
@@ -24390,6 +25177,20 @@ game (
 	year "1993"
 	developer "Namco"
 	rom ( name suzuk8h2.zip size 3490793 crc c325814d md5 78df5bd42550019d3cb6dac0787274c1 sha1 49c702bb0a0bcbe877552bf04f5fe7d1e7f01f28 )
+)
+
+game (
+	name "Suzuka 8 Hours (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuk8hj.zip size 2189145 crc 677c9546 md5 db6ee32dc72e942819441c7364f72516 sha1 6f60811f6b39637e27b41861a03c35cd79e16947 )
+)
+
+game (
+	name "Suzuka 8 Hours (World?)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8h.zip size 2188886 crc 999bb67f md5 1993ea3e6715735ffc9b779682f8f997 sha1 aba636d40c75afb6186e582b43f23dd69377f0b7 )
 )
 
 game (
@@ -24841,6 +25642,20 @@ game (
 )
 
 game (
+	name "Tekken 2 Ver.B (TES3/VER.B)"
+	year "1995"
+	developer "Namco"
+	rom ( name tekken2.zip size 20925868 crc c583c399 md5 abb99e56d070bc47b66d1ffd165a40e4 sha1 d33888b45712b04b7dab9947dc5ee96705f6fbf8 )
+)
+
+game (
+	name "Tekken 2 Ver.B (TES2/VER.B)"
+	year "1995"
+	developer "Namco"
+	rom ( name tekken2a.zip size 20925864 crc c73bd974 md5 f9dd2389891d4035aed1647697054711 sha1 03d5db198cf57828faacc77d200c09c1bf966f81 )
+)
+
+game (
 	name "Tekken 2 (TES2/VER.A)"
 	year "1995"
 	developer "Namco"
@@ -25267,6 +26082,13 @@ game (
 )
 
 game (
+	name "Time Limit"
+	year "1983"
+	developer "Chuo Co. Ltd"
+	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
+)
+
+game (
 	name "Time Pilot"
 	year "1982"
 	developer "Konami"
@@ -25355,6 +26177,13 @@ game (
 	year "1987"
 	developer "Namco LTD."
 	rom ( name tkoboxng.zip size 63570 crc 8643e559 md5 d767dabecbdfcee8c6f51ef9a23b8e88 sha1 2c30aa5d40cbae09d35c3153c03314035be11330 )
+)
+
+game (
+	name "T-MEK (prototype)"
+	year "1994"
+	developer "Atari Games"
+	rom ( name tmekprot.zip size 19895465 crc ed2d1068 md5 4a456208954878a1751287010c6e422d sha1 59f26fe535493554146545d96223c02ab8d181c5 )
 )
 
 game (
@@ -25652,6 +26481,13 @@ game (
 )
 
 game (
+	name "Top Racer"
+	year "1982"
+	developer "bootleg"
+	rom ( name topracer.zip size 53805 crc e5cb0c4b md5 d23984d66c192e18e69cc6c6009a153f sha1 013e7b38557f904144318a09458988027f239fbd )
+)
+
+game (
 	name "Top Secret (Exidy) (version 1.0)"
 	year "1986"
 	developer "Exidy"
@@ -25698,6 +26534,13 @@ game (
 	year "1994"
 	developer "Metro"
 	rom ( name toride2g.zip size 1056837 crc 03952538 md5 4636b2873c0d6ed3bd51f02b50e60af3 sha1 e537483cf093475b07ec326bbfd121648074f399 )
+)
+
+game (
+	name "Tornado Baseball"
+	year "1976"
+	developer "Midway"
+	rom ( name tornbase.zip size 4614 crc cd9162da md5 2d727019221dda840e7d6151b0a2c4ac sha1 90dc2fc8de46ce4ea9ccc6cf22cc1c1ff996c2f9 )
 )
 
 game (
@@ -26111,6 +26954,13 @@ game (
 )
 
 game (
+	name "Tough Turf (Japan)"
+	year "1989"
+	developer "Sega / Sunsoft"
+	rom ( name tturf.zip size 525537 crc 70ea1981 md5 8304be2da36d36ae7d66ed9f5b0afaec sha1 fe77c82c9585756d0d0b95e6373afdf1830b8936 )
+)
+
+game (
 	name "Tough Turf (bootleg)"
 	year "1989"
 	developer "bootleg"
@@ -26213,6 +27063,13 @@ game (
 	year "1991"
 	developer "Video System Co."
 	rom ( name turbofrc.zip size 2234188 crc 89b0f71a md5 674b328b5d418b6a8e2d7ca9984c7b39 sha1 78abef997aa3f3b5538b6ef09550822a50eedabd )
+)
+
+game (
+	name "Turbo Tag (prototype)"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name turbotag.zip size 81230 crc b9f51999 md5 c9b7a23bcffe9c84e58727ef8b212a5a sha1 2a13a5a5508ecb79174bb521ef77ad9591fcaa95 )
 )
 
 game (
@@ -26430,6 +27287,13 @@ game (
 	year "1994"
 	developer "Midway"
 	rom ( name umk3r11.zip size 22106897 crc 7674427c md5 5c22ef96f532dd8f25bd0dc7de4f038c sha1 b0a69b39811762dff54031f51d6803ac0df4ae53 )
+)
+
+game (
+	name "The Undoukai (Japan)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name undoukai.zip size 98272 crc 80319054 md5 69bacd1a039c50989513262a0a587ef8 sha1 80cbb94db867518774f1911ff0e51cfc76dc6e20 )
 )
 
 game (
@@ -26902,6 +27766,27 @@ game (
 )
 
 game (
+	name "Vimana"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
+)
+
+game (
+	name "Vimana (old set)"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana1.zip size 792172 crc fae43844 md5 f6dd90ad479f91912d3ec0706c7da4ec sha1 9e34ecb4ee6096bca47752aee7f4709a01938799 )
+)
+
+game (
+	name "Vimana (Nova Apparate GMBH _ Co)"
+	year "1991"
+	developer "Toaplan (Nova Apparate GMBH &amp; Co license)"
+	rom ( name vimanan.zip size 792398 crc 2bc288f3 md5 8831d66ca21ec4127ea7c2536dd9ee1b sha1 e4a56fdd4bebb5c9a2ff815ddc8ffe22400d9a69 )
+)
+
+game (
 	name "Vindicators Part II (rev 1)"
 	year "1988"
 	developer "Atari Games"
@@ -27364,6 +28249,13 @@ game (
 )
 
 game (
+	name "World Beach Volley"
+	year "1995"
+	developer "Playmark"
+	rom ( name wbeachvl.zip size 3037511 crc a7e64b63 md5 8c24a0dc0f0fc04202edb0a0324154c3 sha1 671d53acb9f10c23e5b8fa5974c20b8b9c3f0109 )
+)
+
+game (
 	name "Wonder Boy in Monster Land"
 	year "1987"
 	developer "bootleg"
@@ -27606,6 +28498,13 @@ game (
 	year "1988"
 	developer "Exidy"
 	rom ( name whodunit.zip size 273900 crc 52cee884 md5 2d718375ab885d061236385865adce9c sha1 b5bb83d81847a84654338446a0013a4d5a2885bc )
+)
+
+game (
+	name "Whoopee!! / Pipi _ Bibis"
+	year "1991"
+	developer "Toaplan"
+	rom ( name whoopee.zip size 519355 crc e671ba6f md5 4ae920cae00524addcbdf59b0ffb1497 sha1 9cd33f4192926ae8d946b9c1858f63e7ac2bf12e )
 )
 
 game (
@@ -28096,6 +28995,13 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311644 crc b7c4c47d md5 0606cddfb28aed80f9b14872b48a64be sha1 9ba6c05718b348ae4330a695fa158a15457d00a6 )
+)
+
+game (
+	name "Xybots (rev 0)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name xybots0.zip size 276366 crc eaa5e0c3 md5 2194e6434622b0ddc04ddb47d196fb60 sha1 6b9d2948068ed0637f1d806e3b328171ac1a7f83 )
 )
 
 game (

--- a/metadat/mame-nonmerged/MAME 2010.dat
+++ b/metadat/mame-nonmerged/MAME 2010.dat
@@ -1,6 +1,14 @@
 clrmamepro (
-  name "MAME 2010 Full Non-Merged Working"
+  name "MAME 2010 - Full Non-Merged TorrentZipped Working Romsets"
   version "2019-01-03"
+  description "Format: Full Non-Merged (No Separate BIOS Sets), Working Romsets Only, TorrentZipped"
+)
+
+game (
+	name "005"
+	year "1981"
+	developer "Sega"
+	rom ( name 005.zip size 29769 crc d123fe67 md5 64ba2c1869a491bdae1384d3a95c2027 sha1 aeebfd4a3a6214e6efed19dd4d5716215e253b13 )
 )
 
 game (
@@ -29,6 +37,13 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name 1941.zip size 1419821 crc de03fb24 md5 3a72d8463b47ce63dee199137a13ac64 sha1 d6ee54766d377d1136f6a5e17b772666a072e74e )
+)
+
+game (
+	name "1941: Counter Attack (Japan)"
+	year "1990"
+	developer "Capcom"
+	rom ( name 1941j.zip size 1419323 crc aefdd791 md5 b7ac353d4638406fb29cf8b13cf5f924 sha1 b953cc7fa4f727008afe7cbff3579c61e4fbfae5 )
 )
 
 game (
@@ -64,6 +79,34 @@ game (
 	year "1985"
 	developer "Capcom (Williams Electronics license)"
 	rom ( name 1942w.zip size 106956 crc 3ca92bd4 md5 c393fd70c115d8317e296b8f4b419a79 sha1 adda61865b029ac39296138abb5dd0a256e30605 )
+)
+
+game (
+	name "1943: The Battle of Midway (Euro)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943.zip size 305392 crc d0e80fef md5 905c7d99b594af7fe2ac31392835e9b8 sha1 a5acd39d166a43450b8f01cafe1a6e98e7122b4e )
+)
+
+game (
+	name "1943: Midway Kaisen (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943j.zip size 305250 crc b76b02f5 md5 2cf7f5363e7a648528770702b0227446 sha1 68a0ea3b855bbe0a24f81d632aab15d34bd57e95 )
+)
+
+game (
+	name "1943 Kai: Midway Kaisen (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943kai.zip size 313068 crc 992baef8 md5 763bf59dd41cfbf9540330b541d03f35 sha1 a4b53090206e4d7186a9615b6c3f3c7654b4d93e )
+)
+
+game (
+	name "1943: The Battle of Midway (US)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943u.zip size 305018 crc 66b05a68 md5 e82ccdf57ec8eecab6587d6901adc8ad sha1 90e72d1ecb739490f7e3bf122ca9575ec9b58664 )
 )
 
 game (
@@ -207,6 +250,13 @@ game (
 )
 
 game (
+	name "3 Bags Full - 3VXFC5345 (New Zealand)"
+	year "1994"
+	developer "Aristocrat"
+	rom ( name 3bagflnz.zip size 53100 crc abe7d8ba md5 ae05bc562a050ac57d08bd3b2978de5e sha1 93b2902480c056be234514c6b2ecf7545fabe2d4 )
+)
+
+game (
 	name "3 Count Bout / Fire Suplex"
 	year "1993"
 	developer "SNK"
@@ -218,6 +268,13 @@ game (
 	year "1985"
 	developer "Nichibutsu"
 	rom ( name 3ds.zip size 93856 crc 28ae71bf md5 5ebb59f496cff93fe75c83344c2d4cf5 sha1 f7e5498b3fdc92ff34fcb5736047cf57cb36f2d0 )
+)
+
+game (
+	name "XESS - The New Revolution (SemiCom 3-in-1)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name 3in1semi.zip size 1187337 crc c8ce23a8 md5 37ab524977d28c1fee901ddfdf200a02 sha1 5655e9f337cf9ddb9451a3ecc2ba22b27fe46e82 )
 )
 
 game (
@@ -253,6 +310,27 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name 3wondersu.zip size 2476254 crc 2f41cfa6 md5 65251d86571756cd16031e01ac24b681 sha1 7d79508b95b2b06ccf34e85b3b9d48f3133129f4 )
+)
+
+game (
+	name "Forty-Love"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
+)
+
+game (
+	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
+	year "1994"
+	developer "Jaleco"
+	rom ( name 47pie2.zip size 10228866 crc 09321e19 md5 f9d67336316a83050a1be7d3e174990c sha1 158bf6e56bcfdc03d0a32f7d881a07351554c8fd )
+)
+
+game (
+	name "Idol Janshi Su-Chi-Pie 2 (v1.0)"
+	year "1994"
+	developer "Jaleco"
+	rom ( name 47pie2o.zip size 10229218 crc 7100955c md5 ecf6d7d7f4cf46c6927183872962db53 sha1 c83e4a41e2f628c48f871351a05cb85e462ffa16 )
 )
 
 game (
@@ -298,6 +376,13 @@ game (
 )
 
 game (
+	name "Five Clown (English, set 2)"
+	year "1993"
+	developer "IGS"
+	rom ( name 5clowna.zip size 63943 crc 58041a43 md5 ef28648f12f5d56577372984937b9eb3 sha1 909c5613c546892e7e9f0dc362b0400d488d1887 )
+)
+
+game (
 	name "Five Clown (Spanish hack)"
 	year "1993"
 	developer "IGS"
@@ -309,6 +394,20 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14459 crc e8e6b845 md5 6b249af98f7b27b35c55df083188d7a4 sha1 b40bd175b43a494a19d0b7e7b6021243027bb8df )
+)
+
+game (
+	name "64th. Street - A Detective Story (World)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
+)
+
+game (
+	name "64th. Street - A Detective Story (Japan)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64streetj.zip size 1294030 crc 38192b3d md5 72160ca1b1d25604d50e22c18f9eec4d sha1 f6992618cee1fceabcdacaa294e6f8ddbce49b82 )
 )
 
 game (
@@ -409,6 +508,20 @@ game (
 )
 
 game (
+	name "Eight Ball Action (DK conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Magic Eletronics USA license)"
+	rom ( name 8ballact.zip size 16261 crc c7b9822e md5 81cc86d18b8604c5ba85de72830011b6 sha1 3024248c8c6f47b2ed4ac525b428236c43dafcd0 )
+)
+
+game (
+	name "Eight Ball Action (DKJr conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Magic Eletronics USA license)"
+	rom ( name 8ballact2.zip size 17183 crc 62e3f146 md5 c45ca3398de25eaedf86b66c32dc8926 sha1 b3e52e2825966a11ba98b0530dd846107794545d )
+)
+
+game (
 	name "Eight Ball Action (Pac-Man conversion)"
 	year "1985"
 	developer "Seatongrove Ltd (Magic Eletronics USA license)"
@@ -469,6 +582,13 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name a51mxr3k.zip size 292721 crc 985fabf5 md5 2e7914b5ff2238a81fe1041b7fcacb95 sha1 1df0b4dae65689d5d2f40382c1a1f79f9011ecbd )
+)
+
+game (
+	name "All American Football (rev E)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafb.zip size 525577 crc 4535f25a md5 234ae3914d7eb81036e38beb0eca4d9b sha1 4e33bdea83ad2897e40855ed163ba0d06eb4e5de )
 )
 
 game (
@@ -717,6 +837,20 @@ game (
 )
 
 game (
+	name "Action Hollywood"
+	year "1995"
+	developer "TCH"
+	rom ( name actionhw.zip size 1321130 crc 34e2ced3 md5 560b7326579a82c1f92de6949a84960b sha1 4078379bf8e45be863a1ce175841f213def23e10 )
+)
+
+game (
+	name "A. D. 2083"
+	year "1983"
+	developer "Midcoin"
+	rom ( name ad2083.zip size 37545 crc 3676a561 md5 0838dc3da631045ddf93611f0d32090f sha1 0d59e1987ce60306df165d307ef0c26e3677b38c )
+)
+
+game (
 	name "Aero Fighters (bootleg set 2)"
 	year "1992"
 	developer "bootleg"
@@ -878,10 +1012,45 @@ game (
 )
 
 game (
+	name "Air Buster: Trouble Specialty Raid Unit (World)"
+	year "1990"
+	developer "Kaneko (Namco license)"
+	rom ( name airbustr.zip size 693968 crc d9e397ed md5 48fe2cda23a4ec913b254fcf67ca17b0 sha1 9f3d12511be5bc05d17c220d1a933a12698df5f1 )
+)
+
+game (
 	name "Air Buster: Trouble Specialty Raid Unit (bootleg)"
 	year "1990"
 	developer "bootleg"
 	rom ( name airbustrb.zip size 729359 crc 40b9c205 md5 8be3cb86a353516ca6edb61f95bad303 sha1 5685db462ef175fc317c81f58e3de5f291f21b35 )
+)
+
+game (
+	name "Air Buster: Trouble Specialty Raid Unit (Japan)"
+	year "1990"
+	developer "Kaneko (Namco license)"
+	rom ( name airbustrj.zip size 704896 crc 1dbd6225 md5 0e1a35246a73224a410eb5a81d8ad3f1 sha1 02f8644418305dde573a883b3a6022aa9a8b5d96 )
+)
+
+game (
+	name "Air Duel (Japan)"
+	year "1990"
+	developer "Irem"
+	rom ( name airduel.zip size 1129917 crc 9d4f621c md5 f32170fdb460883767cdd30e3fec4def sha1 3a77c08f548679ff8f1d7e2a5722e7031e0ae797 )
+)
+
+game (
+	name "Airwolf"
+	year "1987"
+	developer "Kyugo"
+	rom ( name airwolf.zip size 81889 crc 11104399 md5 962be6e1dcc6bff7861750416468419d sha1 6d139e060f781ee3a41618113aff13d0a9836942 )
+)
+
+game (
+	name "Airwolf (US)"
+	year "1987"
+	developer "Kyugo (UA Theatre license)"
+	rom ( name airwolfa.zip size 82048 crc 928c6ec9 md5 1379ca51c5b52917b7bcae35ec9f82f9 sha1 aeddf36a8ecfb527b303a242b7c52dd4b32f3f52 )
 )
 
 game (
@@ -903,6 +1072,13 @@ game (
 	year "1996"
 	developer "Dynax (Nakanihon license)"
 	rom ( name akamaru.zip size 5870697 crc 1f829dfd md5 6c2604e10553e30e4f2ce4aae7ccd7d8 sha1 60cc32f9eca177ef17f87edaf8c40939178446dc )
+)
+
+game (
+	name "Mahjong Angel Kiss"
+	year "1995"
+	developer "Jaleco"
+	rom ( name akiss.zip size 13222340 crc 63cbbff4 md5 6c26fe69eb301a68a489174881fb58ae sha1 834cbff5a4e90fb9fdeb10e550cf7090dbe3a6aa )
 )
 
 game (
@@ -931,6 +1107,13 @@ game (
 	year "1986"
 	developer "Sega"
 	rom ( name alexkidd.zip size 304621 crc fc637b17 md5 67500ca0b423e124c535694e5b4b6ef1 sha1 e6a43a2322a9096b77cf9c4d6e42310031769916 )
+)
+
+game (
+	name "Alex Kidd: The Lost Stars (set 1, FD1089A 317-0021)"
+	year "1986"
+	developer "Sega"
+	rom ( name alexkidd1.zip size 384886 crc 46bd804c md5 8c5c694ef82dd97336a5a92c46321d96 sha1 dfe47c558225da42dfc7a25c9147f3eafc518bb6 )
 )
 
 game (
@@ -1100,6 +1283,20 @@ game (
 )
 
 game (
+	name "Alpha One (prototype, 3 lives)"
+	year "1983"
+	developer "Atari"
+	rom ( name alphaone.zip size 53881 crc 3827642b md5 333f4d8063d134664e2b327aa40776c4 sha1 8f205ee2d70432b2c3932a7fb07eee0b3fa23449 )
+)
+
+game (
+	name "Alpha One (prototype, 5 lives)"
+	year "1983"
+	developer "Atari"
+	rom ( name alphaonea.zip size 53880 crc 82f61f1e md5 365e9b9d809fb35f218cae6049082e82 sha1 115344ad232d9089026418f771b44b9084ad5753 )
+)
+
+game (
 	name "The Alphax Z (Japan)"
 	year "1986"
 	developer "Ed Co. Ltd. (Wood Place Inc. license)"
@@ -1156,6 +1353,13 @@ game (
 )
 
 game (
+	name "Altered Beast (set 8, 8751 317-0078)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeast.zip size 848905 crc e431711b md5 64ae9698dd3816c123e464ef1df3f446 sha1 5d1431b186c2fe481bc7c2a84f565405e1ed1c9a )
+)
+
+game (
 	name "Altered Beast (set 2, MC-8123B 317-0066)"
 	year "1988"
 	developer "Sega"
@@ -1167,6 +1371,20 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name altbeast4.zip size 865797 crc 0de5ed87 md5 7107acb610a26d199164a3103d7317a4 sha1 9dfa118dcb6d02b1a97c4ae7eb1a3a18b0f7ca01 )
+)
+
+game (
+	name "Altered Beast (set 6, 8751 317-0076)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeast5.zip size 848579 crc fac03d47 md5 a9b86a51947d53ce548235d588aa426f sha1 7b47092d0d1a4d0f23abdbb71d98c0938f79b1b7 )
+)
+
+game (
+	name "Juuouki (set 7, Japan, 8751 317-0077)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeastj.zip size 848385 crc 38d7e51f md5 1174a10ab5c833cc34f19ebbb1e32efd sha1 e1f0037c53ace5fcde9cf9b4b6b0019a479265e6 )
 )
 
 game (
@@ -1471,6 +1689,13 @@ game (
 )
 
 game (
+	name "Animalandia Jr. (Spanish)"
+	year "1993"
+	developer "Nakanihon / East Technology (Taito license)"
+	rom ( name animaljrs.zip size 1355937 crc ab7efa53 md5 25fce01079d3c6fa801e9ec62002b597 sha1 0b6b8a77b78537b033564ba3c1a34af5ce45f1db )
+)
+
+game (
 	name "Animal Treasure Hunt (Version 1.9R, set 1)"
 	year "2003"
 	developer "Amcoe"
@@ -1744,6 +1969,13 @@ game (
 )
 
 game (
+	name "Magic Johnson's Fast Break (Arcadia, V 2.8)"
+	year "1988"
+	developer "Arcadia Systems"
+	rom ( name ar_fast.zip size 866104 crc e2a9c10c md5 1e5e132df77be88bf373647cca021d8d sha1 a70a1e767e1a63e903ed5ee21c41ca6de4cc1c1d )
+)
+
+game (
 	name "Leader Board (Arcadia, V 2.4?)"
 	year "1988"
 	developer "Arcadia Systems"
@@ -1904,6 +2136,20 @@ game (
 )
 
 game (
+	name "Arch Rivals (rev 4.0)"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name archrivl.zip size 360208 crc d8667efb md5 9152563491b6a5244b57c291b63cbd2c sha1 680e6b296fcc288dc90aa11ae571d6566fc73c80 )
+)
+
+game (
+	name "Arch Rivals (rev 2.0)"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name archrivl2.zip size 360062 crc 1b65c9f8 md5 5588e3ddeaac8e8e930f087c424aa7c2 sha1 ee6f0187d5a3274233fc1bcf05414bf8d448bcc2 )
+)
+
+game (
 	name "Area 51 (R3000)"
 	year "1996"
 	developer "Atari Games"
@@ -1967,6 +2213,13 @@ game (
 )
 
 game (
+	name "Arkanoid (bootleg with MCU, harder)"
+	year "1986"
+	developer "bootleg"
+	rom ( name ark1ball.zip size 69354 crc f432b025 md5 d9071aa347a71c080535068f5b871d60 sha1 c8f5ae6b090c8db27b6ac43f9ac63ee11a591ffd )
+)
+
+game (
 	name "Arkanoid (Game Corporation bootleg, set 1)"
 	year "1986"
 	developer "bootleg (Game Corporation)"
@@ -1988,6 +2241,20 @@ game (
 )
 
 game (
+	name "Arkanoid (Japan)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name arkanoidj.zip size 69529 crc 952d9c11 md5 68ab9e027e64e8adddd2acfd253350d2 sha1 116f876f59cb5f61e37a33323bcbfead79d69557 )
+)
+
+game (
+	name "Arkanoid (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkanoidu.zip size 69426 crc 9529993e md5 70373c8aa3402ecd8a6cb10f9fb3cbf8 sha1 352094d1d88f7def9849089f40018c81917fcf78 )
+)
+
+game (
 	name "Arkanoid (US, older)"
 	year "1986"
 	developer "Taito America Corporation (Romstar license)"
@@ -2006,6 +2273,13 @@ game (
 	year "1986"
 	developer "bootleg (Tayto)"
 	rom ( name arkatayt.zip size 68793 crc 3e625c8d md5 a170ca2801532b1633546efb95c13bea sha1 d04529015c1569db7e3d2d276db6901dbfa672ec )
+)
+
+game (
+	name "Tournament Arkanoid (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkatour.zip size 68720 crc ae0fb022 md5 d31e4e5c2d9539d2e016837a24e87c07 sha1 01313a342b3aac403e2fbc357243ee6d7048e3f8 )
 )
 
 game (
@@ -2041,6 +2315,34 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name arkgcbla.zip size 69288 crc 63a8089a md5 2b49b44e80cdd6dc7bf9a7646bf36813 sha1 5743451abb588e938eaf6b31492231a3a6de9d6c )
+)
+
+game (
+	name "Arkanoid (bootleg with MCU)"
+	year "1986"
+	developer "bootleg"
+	rom ( name arkmcubl.zip size 70179 crc 997685eb md5 54f09ab5ba737417b6cbda529cab088b sha1 5b678f1b75f4a099fbd534d1dab41fcfec16946f )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name arknoid2j.zip size 165315 crc e73cbb79 md5 3370138aca19dac0bec247c7f945af9a sha1 0f770962bc298e25f5fb89d6adf4cc18757878cb )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknoid2u.zip size 165246 crc 83c4dcdc md5 110c4a9fe87fd15696640aa8859dfa2e sha1 51192a5aa0b50e7e760ce0ef5bfd77bb5c018171 )
 )
 
 game (
@@ -2373,6 +2675,13 @@ game (
 )
 
 game (
+	name "Astra SuperStars (J 980514 V1.002)"
+	year "1998"
+	developer "Sunsoft"
+	rom ( name astrass.zip size 19882667 crc 609dad42 md5 9d15442649837b2a3d2e182782e7d431 sha1 c172f5c874fd2f25b4df11fd9102cd27a1fa4ec8 )
+)
+
+game (
 	name "Astro Blaster (version 3)"
 	year "1981"
 	developer "Sega"
@@ -2432,6 +2741,13 @@ game (
 	name "Astropal"
 	developer "Sidam?"
 	rom ( name astropal.zip size 7000 crc af301370 md5 fc7e7ed8a3c16ef410ef693bb8b85904 sha1 b326e28cbadfb85b67c5ca55fed394594e75ffd4 )
+)
+
+game (
+	name "The Astyanax"
+	year "1989"
+	developer "Jaleco"
+	rom ( name astyanax.zip size 1101266 crc bcf42d2b md5 2f3aad524d08d3e64c0a0993a227a423 sha1 bdcc2b5eee0be493445729a53bb749206aa55adb )
 )
 
 game (
@@ -2736,6 +3052,13 @@ game (
 )
 
 game (
+	name "Avenging Spirit"
+	year "1991"
+	developer "Jaleco"
+	rom ( name avspirit.zip size 1060778 crc 6707417d md5 cf4e3c32cdd6158b51585915ede39195 sha1 3cef5b36308d25e6612d72f83d6badb8d971268c )
+)
+
+game (
 	name "Alien vs. Predator (Japan 940520)"
 	year "1994"
 	developer "Capcom"
@@ -2778,6 +3101,13 @@ game (
 )
 
 game (
+	name "Backfire! (set 1)"
+	year "1995"
+	developer "Data East Corporation"
+	rom ( name backfire.zip size 9859906 crc 28fdb800 md5 3d338c08570acd51771f87677c72da36 sha1 3162de077c9e5196b5878b14689e9216eb0825ee )
+)
+
+game (
 	name "Backfire! (set 2)"
 	year "1995"
 	developer "Data East Corporation"
@@ -2789,6 +3119,13 @@ game (
 	year "1988"
 	developer "Tecmo"
 	rom ( name backfirt.zip size 318498 crc cdb79070 md5 be341b344f7aa36922de7db55c3d1bcb sha1 da0f33d86dfc63c7db00579a9fa964953efe84bd )
+)
+
+game (
+	name "Bad Dudes vs. Dragonninja (US)"
+	year "1988"
+	developer "Data East USA"
+	rom ( name baddudes.zip size 454673 crc 823dddde md5 9f61003dd6e361e91df4312a54187f74 sha1 5f5b1c66cb9998d369a15cd56b98f096ac8e21c2 )
 )
 
 game (
@@ -2869,6 +3206,13 @@ game (
 )
 
 game (
+	name "Balloon Bomber"
+	year "1980"
+	developer "Taito"
+	rom ( name ballbomb.zip size 6936 crc d8c9cbc6 md5 bd95aa39956fa02fdd5ecbd68f0437c2 sha1 46daff2917dbbb69b5081e904d182727fb4c83f0 )
+)
+
+game (
 	name "Balloon Brothers"
 	year "1992"
 	developer "East Technology"
@@ -2932,6 +3276,13 @@ game (
 )
 
 game (
+	name "Bank Panic"
+	year "1984"
+	developer "Sanritsu / Sega"
+	rom ( name bankp.zip size 68081 crc c891b681 md5 b95e5c2016bf570c4438f9d742cce44e sha1 5cade8bfbac308caca5b4844dce525be5a134cb2 )
+)
+
+game (
 	name "Baraduke"
 	year "1985"
 	developer "Namco"
@@ -2963,6 +3314,20 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name basebal2.zip size 132687 crc afab8769 md5 d938e769b6db97e280062b0d7e5d5d32 sha1 f2776d7d8717f6a760a9602d9a670ffb0c53d100 )
+)
+
+game (
+	name "Bass Angler 2 (GE865 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name bassang2.zip size 63466 crc 5db0336f md5 15a6fdefb6eb4e8dce4c5515afca6b03 sha1 ac169e41a0d26459cf53ee72ef9c9efd2f039599 )
+)
+
+game (
+	name "Bass Angler (GE765 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name bassangl.zip size 63466 crc d3e7ddb0 md5 099b6cd8d3da59f5e54e43c911ffc3cb sha1 d8367c4ee1d6162af4d8be226ec0a2044f0e547b )
 )
 
 game (
@@ -3162,10 +3527,31 @@ game (
 )
 
 game (
+	name "Bay Route (set 1, US, unprotected)"
+	year "1989"
+	developer "Sunsoft / Sega"
+	rom ( name bayroute1.zip size 431287 crc a7efe0f8 md5 508c1d8c8e904b7975a35353a01272e7 sha1 927eb31797c2b5545b905b0a5ab699e661ba65f1 )
+)
+
+game (
 	name "Bay Route (set 2, Japan, FD1094 317-0115)"
 	year "1989"
 	developer "Sunsoft / Sega"
 	rom ( name bayroutej.zip size 705201 crc 8eafd6cf md5 d38ac2f6deda9048d1296fc460bec0d5 sha1 c0e52a2e9085bda565cd8860687e38af4dd9045f )
+)
+
+game (
+	name "Bouncing Balls"
+	year "1991"
+	developer "Comad"
+	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
+)
+
+game (
+	name "Best Bout Boxing"
+	year "1994"
+	developer "Jaleco"
+	rom ( name bbbxing.zip size 10429515 crc 9b47d8ac md5 96986e1972839f0821aadd48b87dc13e sha1 53470be999ffa957d32e44d999dff936d8beb436 )
 )
 
 game (
@@ -3211,6 +3597,13 @@ game (
 )
 
 game (
+	name "Battle Chopper"
+	year "1987"
+	developer "Irem"
+	rom ( name bchopper.zip size 625484 crc bb2ba4e2 md5 b1c23702556a56b13ea7120566b6691e sha1 d640f7466fd4409a89b81c19bf7c1cf0446ca71b )
+)
+
+game (
 	name "Bone Crusher"
 	year "1985"
 	developer "bootleg"
@@ -3222,6 +3615,20 @@ game (
 	year "1983"
 	developer "Sigma Enterprises Inc."
 	rom ( name bcruzm12.zip size 24051 crc 844dd296 md5 68f050c0e0e9798fc97ad1ff88f6c32d sha1 e53a7ef1ca8c8a4049145ed921690396ecd923ba )
+)
+
+game (
+	name "B.C. Story (set 1)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name bcstry.zip size 1867429 crc 2790dc04 md5 af6c843f42e06c5a5ff56952afaba6ce sha1 b099fe0618c298d712f4e955e004602ee5849c19 )
+)
+
+game (
+	name "B.C. Story (set 2)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name bcstrya.zip size 1867473 crc 5e2b182f md5 6aeb49666e15739e5c72fcb0d0e31821 sha1 2685955e416af1a85f644983181a169dcbae74eb )
 )
 
 game (
@@ -3358,6 +3765,13 @@ game (
 )
 
 game (
+	name "Best League (bootleg of Big Striker, World Cup)"
+	year "1993"
+	developer "bootleg"
+	rom ( name bestleaw.zip size 966967 crc 42fce0ce md5 db72a6f702b3d1c3616efabfde166196 sha1 4cfcd0b1b133c38bbfab7386c4311c970eed1091 )
+)
+
+game (
 	name "Bestri (Korea)"
 	year "1998"
 	developer "F2 System"
@@ -3434,6 +3848,20 @@ game (
 )
 
 game (
+	name "Big Deal (Hungarian, set 1)"
+	year "1986"
+	developer "Funworld"
+	rom ( name bigdeal.zip size 31494 crc 11dc02dc md5 5c0a83f4f50b9d3f04ad053af2a41cd2 sha1 26149d8c6eab579cfad8077330388f0debd2dad7 )
+)
+
+game (
+	name "Big Deal (Hungarian, set 2)"
+	year "1986"
+	developer "Funworld"
+	rom ( name bigdealb.zip size 31499 crc 99229386 md5 824d5adf15c08054c5bec654e216bd2a sha1 a1c345a20be13daeab0d3c117cce06ad4dbaf77f )
+)
+
+game (
 	name "Big Event Golf (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -3480,6 +3908,13 @@ game (
 	year "1989"
 	developer "Jaleco"
 	rom ( name bigrun.zip size 2462344 crc c1e11087 md5 2e6e4fcccbfbbf11748cedc28adda5e7 sha1 303b2e99c94e7d16026610edbee9e2a1ea97b933 )
+)
+
+game (
+	name "Big Striker"
+	year "1992"
+	developer "Jaleco"
+	rom ( name bigstrik.zip size 838155 crc 08b43cdd md5 a256c29d166eb5694001ef4138e7880d sha1 67c7e723947c8e76aa1c78be13aa854c45717af7 )
 )
 
 game (
@@ -3546,10 +3981,38 @@ game (
 )
 
 game (
+	name "Bionic Commando (Euro)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc.zip size 341032 crc 4618814f md5 3edd644f35021365a73f65e166ca38eb sha1 9ab366c3635e1536cdd61d83dadd43e7f758e038 )
+)
+
+game (
+	name "Bionic Commando (US set 1)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc1.zip size 341057 crc 11e7248d md5 5f7349b3e9512de05eb5fef50c52432e sha1 d45161d816fa76486e8dbba479e4d0c5e9803582 )
+)
+
+game (
+	name "Bionic Commando (US set 2)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc2.zip size 341034 crc 650e68ba md5 0804d0a3b9ca4ea612c6581bf8f230d3 sha1 0e33ed5fd37e37920542d49bd93f62df804e2900 )
+)
+
+game (
 	name "Bio-ship Paladin"
 	year "1990"
 	developer "UPL (American Sammy license)"
 	rom ( name bioship.zip size 1367266 crc 5ab792c3 md5 a0470e95131c3f5d58227ea2ab39d436 sha1 9bdb67800341d2d0cacf6c9f176350df60b38c35 )
+)
+
+game (
+	name "Bishi Bashi Championship Mini Game Senshuken (ver JAA, 3 Players)"
+	year "1996"
+	developer "Konami"
+	rom ( name bishi.zip size 2693368 crc 8e6d5bf6 md5 c1892ca48e05516f9744229b3807557e sha1 6f491d1def0a8ea1a7ef074b3ab47f92f04c653c )
 )
 
 game (
@@ -3661,6 +4124,13 @@ game (
 	year "1992"
 	developer "Allumer"
 	rom ( name blandiap.zip size 3668983 crc 7f1d8ef2 md5 adc947b0d849cd7752aee22959f9dd60 sha1 5d9f038f3631c81d0c1f00dcabd5ad2bfc6ab1dd )
+)
+
+game (
+	name "Blasted"
+	year "1988"
+	developer "Bally Midway"
+	rom ( name blasted.zip size 485570 crc 3c79c3b1 md5 f070f2b43a0739ee69fca9cb2cbb8b2b sha1 2dec7d45fab77121634c3a14a8a1b66251950afc )
 )
 
 game (
@@ -4293,6 +4763,13 @@ game (
 )
 
 game (
+	name "Vs. Janshi Brandnew Stars (MegaSystem32 Version)"
+	year "1997"
+	developer "Jaleco"
+	rom ( name bnstars.zip size 14048911 crc c6411513 md5 f0243b0e9201cf1629aff0eb9fc32dda sha1 9ae665d20b5537327277ecfcb57c26ecd25d4694 )
+)
+
+game (
 	name "Bonanza Bros (US, Floppy DS3-5000-07d? Based)"
 	year "1990"
 	developer "Sega"
@@ -4419,6 +4896,13 @@ game (
 )
 
 game (
+	name "Booby Kids (Italian manufactured graphic hack / bootleg of Kid no Hore Hore Daisakusen (bootleg))"
+	year "1987"
+	developer "bootleg"
+	rom ( name boobhack.zip size 196432 crc f7f34d26 md5 189e329ec5f5f863f3f21119b3536c8e sha1 726af6b574029fa3a6e1081a684db24a3832113d )
+)
+
+game (
 	name "Boogie Wings (Euro v1.5, 92.12.07)"
 	year "1992"
 	developer "Data East Corporation"
@@ -4481,6 +4965,20 @@ game (
 )
 
 game (
+	name "Bosconian (Midway, new version)"
+	year "1981"
+	developer "Namco (Midway license)"
+	rom ( name boscomd.zip size 38842 crc 147893c9 md5 edc202f3c2a6b9db0610cdfa79ed2e03 sha1 7ee2fe1b601d2230c83f848a8013f1333d1f5890 )
+)
+
+game (
+	name "Bosconian (Midway, old version)"
+	year "1981"
+	developer "Namco (Midway license)"
+	rom ( name boscomdo.zip size 38991 crc 4c39968d md5 fbcdb731aaddeb4ac620452210cffa66 sha1 c0d2b33ae9c68655f3aaf25756121c7636c23c66 )
+)
+
+game (
 	name "Bosconian (old version)"
 	year "1981"
 	developer "Namco"
@@ -4513,6 +5011,20 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name botssa.zip size 1549571 crc c3c77601 md5 9ebc3b927a9de824df62964b10a412c9 sha1 894e27844bfad8194a265dc5f556cd3b36dcac2e )
+)
+
+game (
+	name "Bottle 10 (Italian, set 2)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name bottl10b.zip size 19470 crc 795f9141 md5 703c1974037e82dfa4404a7b743ad03d sha1 fdfc81bf7655aadf5613a8e766f829c30341c566 )
+)
+
+game (
+	name "Bottle 10 (Italian, set 1)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name bottle10.zip size 19483 crc 8addc9ce md5 7a0334d3b023c3025f00e04ea53613ce sha1 81c0fa21548cd484d909e0114a3bdb09c19e1ae1 )
 )
 
 game (
@@ -4586,6 +5098,13 @@ game (
 )
 
 game (
+	name "Brain"
+	year "1986"
+	developer "Coreland / Sega"
+	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
+)
+
+game (
 	name "B.Rap Boys (World)"
 	year "1992"
 	developer "Kaneko"
@@ -4625,6 +5144,13 @@ game (
 	year "1998"
 	developer "Visco"
 	rom ( name breakrev.zip size 17168279 crc 36b50107 md5 afb110d595470ab76c33dd4d7e7abadd sha1 fb7c45bfc15c61609a0cfbad99a2be561113aaef )
+)
+
+game (
+	name "Breywood (Japan revision 2)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name breywood.zip size 288503 crc ff6fee69 md5 1ceff7a2902aa5eb0d122bccf64c366d sha1 c23860d32ce21b3915f11e674b48c9eaa530d42e )
 )
 
 game (
@@ -4977,6 +5503,13 @@ game (
 )
 
 game (
+	name "Battle K-Road"
+	year "1994"
+	developer "Psikyo"
+	rom ( name btlkroad.zip size 4161327 crc 18ed9e21 md5 00603afe66310ebe8d340c6564c84cc2 sha1 cfcefd05c4fb1492741caf392c3938754bd89fd3 )
+)
+
+game (
 	name "Battle Toads"
 	year "1994"
 	developer "Rare"
@@ -5026,6 +5559,13 @@ game (
 )
 
 game (
+	name "Bubble Trouble (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name bubbletr.zip size 911433 crc 56650225 md5 48acc135eb5ccac7bfef02fe3fd7aa48 sha1 6f37ea115eae404632dd468db7a6ee10888692e3 )
+)
+
+game (
 	name "Bubble 2000"
 	year "1998"
 	developer "Tuning"
@@ -5037,6 +5577,34 @@ game (
 	year "1994"
 	developer "Taito Corporation Japan"
 	rom ( name bublbob2.zip size 4906715 crc 224c696e md5 9c746ee1f7aea62567477df58d46af56 sha1 0ba71f6aa86952b65aac20c9e01508f0fa43d7d8 )
+)
+
+game (
+	name "Bubble Bobble"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name bublbobl.zip size 183843 crc 4fea6af9 md5 7f7e392e6152e97737de4d54cc7b5108 sha1 829142c9ba2aec2372ba14371e8f5ec8893194f4 )
+)
+
+game (
+	name "Bubble Bobble (older)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name bublbobl1.zip size 183826 crc ea563bed md5 7ea60edc196566e5710e289695d2d3e3 sha1 9653e056a9bbebdc05c4bc86e74333aabc1f32a3 )
+)
+
+game (
+	name "Bubble Bobble (US with mode select)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name bublboblr.zip size 183843 crc 46a46e42 md5 3746508ab29446d3571147b149c8e095 sha1 76b8a9867ce493be0f848a2a077a42ad22987964 )
+)
+
+game (
+	name "Bubble Bobble (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name bublboblr1.zip size 183837 crc e55c6cd8 md5 ebd55c450c817327ce1ce8ed375499e4 sha1 024a4eb4dac0f9a1ac351e4dcb1b9fdfad322f56 )
 )
 
 game (
@@ -5058,6 +5626,13 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name bubsymphu.zip size 4906715 crc b09cad05 md5 aa67b30f61db31b3e0743772a87da479 sha1 4785522896a7fcdcc54f3b735dd2aec6ac742ed4 )
+)
+
+game (
+	name "Buccaneers (set 1)"
+	year "1989"
+	developer "Duintronic"
+	rom ( name buccanrs.zip size 292256 crc ad4e7b3f md5 15e909f3f8557171f5b865eafbbba64a sha1 df84215553cf9bf265455fb54f8631d15666d886 )
 )
 
 game (
@@ -5142,6 +5717,13 @@ game (
 	year "1985"
 	developer "Tatsumi"
 	rom ( name buggyboy.zip size 235344 crc 779df158 md5 f068269c4f7e574ed400c908db16377b sha1 b5eea921d36d15c198594679285df09bf190cbc1 )
+)
+
+game (
+	name "Buggy Boy Junior/Speed Buggy (upright)"
+	year "1986"
+	developer "Tatsumi"
+	rom ( name buggyboyjr.zip size 231963 crc 50643292 md5 7d6656d484f91864395333c19a9c4942 sha1 187c1c7abe51daedbd27de22703ea229a28746a9 )
 )
 
 game (
@@ -5593,6 +6175,13 @@ game (
 )
 
 game (
+	name "Captain America and The Avengers (UK Rev 1.4)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name captavene.zip size 7448214 crc ca014fa6 md5 251d9d02677411a37d69f45e65ff2f78 sha1 794ffb413ecaf0961a4433a8f6f85553be3e9ff4 )
+)
+
+game (
 	name "Captain America and The Avengers (Japan Rev 0.2)"
 	year "1991"
 	developer "Data East Corporation"
@@ -5618,6 +6207,13 @@ game (
 	year "1991"
 	developer "Data East Corporation"
 	rom ( name captavenuu.zip size 7449577 crc 03428d19 md5 79c1eed907b8f1a3cec2086d2bc30740 sha1 62836ab12a78afe2a1b18c8b84d66d0e8fc50932 )
+)
+
+game (
+	name "Captain Commando (World 911202)"
+	year "1991"
+	developer "Capcom"
+	rom ( name captcomm.zip size 2541835 crc f0e6245b md5 abc7c7ee61319dd421c202c086f2c3b4 sha1 f46abadc44a2b1ec022dccc2dac3f26f4eff88aa )
 )
 
 game (
@@ -5683,6 +6279,13 @@ game (
 )
 
 game (
+	name "CarnEvil (v1.0.1)"
+	year "1998"
+	developer "Midway Games"
+	rom ( name carnevil1.zip size 127977 crc 71494d59 md5 881db2dd46fa960b34f5bb4d56c86609 sha1 49596c05f99515356c9f5501780dc6574de11735 )
+)
+
+game (
 	name "Carnival (upright)"
 	year "1980"
 	developer "Sega"
@@ -5724,6 +6327,13 @@ game (
 )
 
 game (
+	name "Cash Quiz (Type B, Version 5)"
+	year "1986"
+	developer "Zilec-Zenitone"
+	rom ( name cashquiz.zip size 163824 crc ae2baab7 md5 4116fc74601f7a21a643fbeb22e09369 sha1 d6a267423ae84929005a3c164fb885c5691badf4 )
+)
+
+game (
 	name "Casino Five"
 	year "1984"
 	developer "Merit"
@@ -5759,6 +6369,13 @@ game (
 )
 
 game (
+	name "Catt (Japan)"
+	year "1993"
+	developer "Wintechno"
+	rom ( name catt.zip size 3023322 crc ceec2587 md5 f57677dbea4d9ca3396bd970c1c57c93 sha1 71319691c40ca3455ef4f23392724dc2214d4bf7 )
+)
+
+game (
 	name "Cavelon"
 	year "1983"
 	developer "Jetsoft"
@@ -5780,6 +6397,13 @@ game (
 )
 
 game (
+	name "U.S. Navy (Japan 901012)"
+	year "1990"
+	developer "Capcom"
+	rom ( name cawingj.zip size 1511162 crc 7d187d5f md5 bf4beda24a5302219ac903a832d2aacb sha1 df579aa9c396d150c7da99234a081540232cd2b2 )
+)
+
+game (
 	name "Carrier Air Wing (World 901009)"
 	year "1990"
 	developer "Capcom"
@@ -5791,6 +6415,24 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name cawingu.zip size 1440062 crc d7a3c272 md5 f79360b08816f169389aa3831f02e890 sha1 bfef3d86357d3f13134c54f9fc2f3672a9d29868 )
+)
+
+game (
+	name "Cherry Bonus III (ver.1.40, encrypted)"
+	developer "Dyna"
+	rom ( name cb3.zip size 81529 crc d176dd38 md5 f54ec370fa5fa83b2a7b4f5b3d00dbcc sha1 9748d513a6f4655dd74919821d4aa020960e5f6a )
+)
+
+game (
+	name "Cherry Bonus III (ver.1.40, set 2)"
+	developer "Dyna"
+	rom ( name cb3a.zip size 76484 crc b8f4db84 md5 4c7eaf5da44efb6cd054b5d2bd6346f7 sha1 104b8e07cdf9efd9983323d6521355da4213933e )
+)
+
+game (
+	name "Cherry Bonus III (alt)"
+	developer "Dyna"
+	rom ( name cb3b.zip size 86027 crc 666d7e2c md5 b42847b91823c81702e74db6f797fb9e sha1 22e419f913277480a46d42089d807e09b7424af2 )
 )
 
 game (
@@ -6228,6 +6870,13 @@ game (
 )
 
 game (
+	name "Chack'n Pop"
+	year "1983"
+	developer "Taito Corporation"
+	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
+)
+
+game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
@@ -6347,6 +6996,27 @@ game (
 )
 
 game (
+	name "Chase H.Q. (World)"
+	year "1988"
+	developer "Taito Corporation Japan"
+	rom ( name chasehq.zip size 3728581 crc 28121659 md5 2331a078acf3f5915ac22da046eee5fb sha1 0a43f9fa46e07354242723241c30d2c3866c6905 )
+)
+
+game (
+	name "Chase H.Q. (Japan)"
+	year "1988"
+	developer "Taito Corporation"
+	rom ( name chasehqj.zip size 3681743 crc 681fa553 md5 3f521b9efeec02c4325979111eb442e2 sha1 1b84c7a9397875852f641e21faec49fc4a898433 )
+)
+
+game (
+	name "Chase H.Q. (US)"
+	year "1988"
+	developer "Taito America Corporation"
+	rom ( name chasehqu.zip size 3728824 crc 151577fe md5 a756a0ecfc599f6874c1fb7f2b686200 sha1 0df2fa3b8af5ec6a4aef9ad029836a6f5af39bc6 )
+)
+
+game (
 	name "Champion Boxing"
 	year "1984"
 	developer "Sega"
@@ -6365,6 +7035,13 @@ game (
 	year "1982"
 	developer "Zilec-Zenitone (Jaleco license)"
 	rom ( name checkmanj.zip size 10972 crc be592c2d md5 8ab21575a212046d4a0064deb1b4217c sha1 7cdc082b7ec4bcb92cb7297b2e0812e4ac3fac43 )
+)
+
+game (
+	name "Checkmate"
+	year "1977"
+	developer "Midway"
+	rom ( name checkmat.zip size 3681 crc 07b85371 md5 704d93f7dc3334ad7a82db3773298f37 sha1 c6032d475c2a64f77d252c43ed96762772a35375 )
 )
 
 game (
@@ -6427,6 +7104,20 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name chiller.zip size 264964 crc 9db43e0f md5 4b3692a0af315e682405d09715b05814 sha1 29e536766b1f50555493d72fcc17d055f27516ef )
+)
+
+game (
+	name "Chimera Beast (prototype)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
+)
+
+game (
+	name "China Gate (US)"
+	year "1988"
+	developer "Technos Japan (Taito / Romstar license)"
+	rom ( name chinagat.zip size 570940 crc f69e5596 md5 b7879cc59c11d7c546958fed372ebfe4 sha1 3a60a36b5841b283e12ab61e7ba4c8c26f2f5673 )
 )
 
 game (
@@ -6493,10 +7184,38 @@ game (
 )
 
 game (
+	name "Choky! Choky!"
+	year "1995"
+	developer "SemiCom"
+	rom ( name chokchok.zip size 1105332 crc e49ff98c md5 10bdec45413daa6880abccf9ed8695b7 sha1 4bf77f1df9bf1e61b96b30ea7f176fd32976f53c )
+)
+
+game (
 	name "Janpai Puzzle Choukou (Japan 010820)"
 	year "2001"
 	developer "Mitchell (Capcom license)"
 	rom ( name choko.zip size 4923896 crc af3b9ce9 md5 6b916fdfe389946df5b293b4fc3d8532 sha1 138bd736202f8de1ee0a2c2a29da7e358c0d6c2c )
+)
+
+game (
+	name "Choplifter (8751 315-5151)"
+	year "1985"
+	developer "Sega"
+	rom ( name choplift.zip size 138193 crc 1c4bff6a md5 e2e71305b100c701a67b262220f04ca2 sha1 6affaa22ea10ca727dabdae41eb720a676f7de17 )
+)
+
+game (
+	name "Choplifter (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name chopliftbl.zip size 137535 crc b752694d md5 69daa4fb5d1f85c2e45d627bbfec5588 sha1 910806c5ff7190bf1fa50bd456d6afbd9a17310b )
+)
+
+game (
+	name "Choplifter (unprotected)"
+	year "1985"
+	developer "Sega"
+	rom ( name chopliftu.zip size 137757 crc 07f1511c md5 8190951fa98026933bbeeb41a3ca1210 sha1 90c242b12ddf6997d1fb92d8d1844a1338b7d5a8 )
 )
 
 game (
@@ -6518,6 +7237,18 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name chopperb.zip size 422267 crc e3643ccf md5 2b1a2094d140faacb4ec41d3ae7fb706 sha1 91a45d122846928923b9d9383e6cdc4729401f4f )
+)
+
+game (
+	name "Cherry 10 (bootleg with PIC16F84)"
+	developer "bootleg"
+	rom ( name chry10.zip size 76925 crc dd0884ea md5 b33be0c1d8d7b7f1d498f769441dea6f sha1 db713de9f2fa66b637cc376e6b4e9f4f355b1e43 )
+)
+
+game (
+	name "Cherry Gold I"
+	developer "bootleg"
+	rom ( name chrygld.zip size 63347 crc 69866dac md5 55c4b8d72f9f99f2324cbef13b708201 sha1 a2400ea45f3fe5252c43757bed43b8b4450f2248 )
 )
 
 game (
@@ -6560,6 +7291,13 @@ game (
 	year "1985"
 	developer "Sega"
 	rom ( name chwrestl.zip size 35843 crc 9d88439c md5 d3ca349c776d55c7fd9fe30e65dc7321 sha1 91d6aaddc557759d21d6bbbc12c785ff91c9a810 )
+)
+
+game (
+	name "Highway Chase (Cassette)"
+	year "1980"
+	developer "Data East Corporation"
+	rom ( name chwy.zip size 25457 crc 4eef1a2d md5 9506cdf50af5a9c447a18da1b0c7517b sha1 90dce5c6a664f1290d545a83b88afbe762d67c2d )
 )
 
 game (
@@ -6758,6 +7496,62 @@ game (
 )
 
 game (
+	name "Classic Edition (Version 1.6E)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice.zip size 715269 crc bcc46dbd md5 5e92a66015bccda25c622a6c364e3096 sha1 c0518f8aab24b0d7c986d88585248bdacb44307b )
+)
+
+game (
+	name "Classic Edition (Version 1.6R, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice1.zip size 716182 crc 027075d0 md5 3ebee978f86cefed209dbfe2ab6e69f0 sha1 bba880dd65c886d897cde7c6a60ac821ddc1cd77 )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice2.zip size 716445 crc 407bf78a md5 e27cc09e9f5fbc34f99aebee46b02b82 sha1 159d853c1fb7e174112d36d5e898728cb26e1dfb )
+)
+
+game (
+	name "Classic Edition (Version 1.6R, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classiced1.zip size 715130 crc 99afeb39 md5 87c082e9b5e1e8dabf9b7b74bb988a94 sha1 6d171f0ed2b00760c889f1bc070f43c890cde4f4 )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classiced2.zip size 715520 crc 7c25674c md5 209e675f866d79df10e908326f2bca9f sha1 a5be9015a4a85a139a6d6506c757c0da0b219d09 )
+)
+
+game (
+	name "Classic Edition (Version 1.6E Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev.zip size 716433 crc f24e2a74 md5 e26333e8c7032740799ee94a55e6090f sha1 be72f01eb5344afe048561d434fd67470416907d )
+)
+
+game (
+	name "Classic Edition (Version 1.6R Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev1.zip size 716153 crc c4d71dc3 md5 cad685f0df292c5e4649c77770ad723d sha1 32465f876e449ce0c2a660db983c4729b9368653 )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev2.zip size 716220 crc 233e50e6 md5 4f1848bd6dce69ea66904893f4f9c93a sha1 da85b652e1277a7151a17a7b63adca2cf62cc1fa )
+)
+
+game (
 	name "Clay Pigeon (version 2.0)"
 	year "1986"
 	developer "Exidy"
@@ -6825,6 +7619,13 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name clocknch.zip size 26337 crc fc163091 md5 3874066b7ac760062a9ea934696ba30a sha1 cbb695adbed82083d52990d65ebf459799834b7d )
+)
+
+game (
+	name "Cloud 9 (prototype)"
+	year "1983"
+	developer "Atari"
+	rom ( name cloud9.zip size 22630 crc 84caff0f md5 0868c27a4b6d65518e01d456ef766ac2 sha1 821c6bb14ea941e9d120e81648f9dc9a9f10fded )
 )
 
 game (
@@ -6919,6 +7720,13 @@ game (
 )
 
 game (
+	name "Cherry Master '91 (ver.1.30)"
+	year "1991"
+	developer "Dyna"
+	rom ( name cmast91.zip size 124394 crc a1a6abb1 md5 c1dd7066427057dd054404822d20297b sha1 f7950ed9fd3d6cafcd657f1f870f94a877e87aaa )
+)
+
+game (
 	name "Cherry Master I (ver.1.01, set 1)"
 	year "1991"
 	developer "Dyna"
@@ -6993,6 +7801,12 @@ game (
 	year "1992"
 	developer "Dyna"
 	rom ( name cmv4.zip size 58346 crc 39fce85a md5 c981a34a6c8b8cf4569436d1f07bfaab sha1 941300f13339fee16767962d58b774c0adb549b9 )
+)
+
+game (
+	name "Cherry Master (Corsica, ver.8.01)"
+	developer "Corsica"
+	rom ( name cmv801.zip size 63718 crc 25c94c82 md5 d02d783854aaf79b018dc37777172454 sha1 3dc6691fba35614c033ea07f19456f83bd66a667 )
 )
 
 game (
@@ -7142,6 +7956,13 @@ game (
 )
 
 game (
+	name "Combat School (joystick)"
+	year "1988"
+	developer "Konami"
+	rom ( name combatsc.zip size 536697 crc 737e2796 md5 2fd1d3696d9aa56c5deb0bbcee20c01e sha1 86f39b054525498962424cf2af8c422443b42391 )
+)
+
+game (
 	name "Combat School (bootleg)"
 	year "1988"
 	developer "bootleg"
@@ -7160,6 +7981,20 @@ game (
 	year "1987"
 	developer "Konami"
 	rom ( name combatsct.zip size 536594 crc b0612dc0 md5 655628c41c55ba0fdbbb50b82c349269 sha1 48be8753d6d35711ed65b5ed754864cb93d53817 )
+)
+
+game (
+	name "Combat Hawk"
+	year "1987"
+	developer "Sanritsu / Sega"
+	rom ( name combh.zip size 57206 crc 3b563a57 md5 5f50f040b72bb2eb8a8ce0e3930c3303 sha1 366a8b95d44e7fccdda45669dc2a27b01c26085e )
+)
+
+game (
+	name "Cal Omega - Game 7.4 (Gaming Poker, W.Export)"
+	year "1981"
+	developer "Cal Omega Inc."
+	rom ( name comg074.zip size 11237 crc 0e7ba0ce md5 7e5b0549e0bae999d0a4b35039d720a4 sha1 c20835afe061f47306203ef0bbb401dcc8e40ccf )
 )
 
 game (
@@ -7195,6 +8030,13 @@ game (
 	year "1985"
 	developer "Capcom"
 	rom ( name commando.zip size 135332 crc fa4bac04 md5 84b2cf3dd2393c8c6cc13caa6440f4c3 sha1 1af11df9f2ccdc33564f606db8cef4c586b03f2a )
+)
+
+game (
+	name "Commando (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name commandob.zip size 135368 crc 31907663 md5 5f40db47a810d2520b03094ff1d64aca sha1 849488c03726481a8f9c81a8b67d9b79e64230a2 )
 )
 
 game (
@@ -7295,6 +8137,20 @@ game (
 )
 
 game (
+	name "Contra (US, Set 1)"
+	year "1987"
+	developer "Konami"
+	rom ( name contra.zip size 388410 crc 3d1478a8 md5 ee1ba16d382481b9158c4d85e23c4e47 sha1 20f9644b22773cc1e45f8bf18750faf54cd1884c )
+)
+
+game (
+	name "Contra (US, Set 2)"
+	year "1987"
+	developer "Konami"
+	rom ( name contra1.zip size 388400 crc b5e6223e md5 c0552568fceab7bb2b59f25aa992ac36 sha1 ce440f3aa7b22dc09f79de87096feae4aebbf749 )
+)
+
+game (
 	name "Contra (bootleg)"
 	year "1987"
 	developer "bootleg"
@@ -7302,10 +8158,38 @@ game (
 )
 
 game (
+	name "Contra (Japan)"
+	year "1987"
+	developer "Konami"
+	rom ( name contraj.zip size 388471 crc 83841d3e md5 9a0cbfc01ab0a41f200673f50659270b sha1 01742dd591f8e1c29bc62e710c7444ba47d6d268 )
+)
+
+game (
 	name "Contra (Japan bootleg)"
 	year "1987"
 	developer "bootleg"
 	rom ( name contrajb.zip size 373785 crc ce9e6fde md5 c69e1c60865d4822680802dbc80bbf14 sha1 84c23f8d25c5f7040b6e519af645368ec015e172 )
+)
+
+game (
+	name "Cookie _ Bibi"
+	year "1995"
+	developer "SemiCom"
+	rom ( name cookbib.zip size 342327 crc 97dea0ac md5 41965c465e6bbf17dd4742b1b4086f04 sha1 cfd3d80bdf61705dfc7039ae92e922935d991b64 )
+)
+
+game (
+	name "Cookie _ Bibi 2"
+	year "1996"
+	developer "SemiCom"
+	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
+)
+
+game (
+	name "Cookie _ Bibi 3"
+	year "1997"
+	developer "SemiCom"
+	rom ( name cookbib3.zip size 846012 crc b25ea726 md5 08d84864359d554308c0d542f2bba183 sha1 4793eb59e453b5e8d72eff74dfed1538fe467610 )
 )
 
 game (
@@ -7376,6 +8260,13 @@ game (
 	year "1979"
 	developer "Universal"
 	rom ( name cosmica1.zip size 11303 crc d420e7c9 md5 c60863df6532f04bc18860fbd1403bc1 sha1 7df16681f2539adb878a8fb0281ca6af1e648b68 )
+)
+
+game (
+	name "Cosmic Alien (early version II?)"
+	year "1979"
+	developer "Universal"
+	rom ( name cosmica2.zip size 12383 crc 8fb16d59 md5 6559277b0fe726f5c440d59f3cc19ddc sha1 5b27c049d877e082fb6aa7ee8667e32fa9e4b6b9 )
 )
 
 game (
@@ -7496,6 +8387,12 @@ game (
 )
 
 game (
+	name "Champion Italian PK (bootleg, green board)"
+	developer "bootleg (SGS)"
+	rom ( name cpokerpkg.zip size 336734 crc c5eb5d92 md5 7d85452305941d6d19caf63e36188041 sha1 442659a63810c2bd8c6eaa36b8ec0918adba0bd2 )
+)
+
+game (
 	name "Champion Poker (v200G)"
 	developer "IGS (Tuning license)"
 	rom ( name cpokert.zip size 154764 crc 03fa655a md5 3fbc9c04d44d9b2b606d6aebd726b6be sha1 4a5efd3d7f713775bc3cfdfc7686cf4c6cbefa4e )
@@ -7604,6 +8501,20 @@ game (
 	year "1980"
 	developer "Taito Corporation"
 	rom ( name crbaloon2.zip size 11123 crc b2f99dff md5 79b852a64fa796dc2c90781deb04812c sha1 0e470447bc1d91d1357217fa70b0e21a6c75c1bc )
+)
+
+game (
+	name "Crowns Golf (834-5419-04)"
+	year "1984"
+	developer "Nasco Japan"
+	rom ( name crgolf.zip size 48587 crc 512e0094 md5 3a13536a8d6577c0beec45f831e4840f sha1 44ed1b8d429eed892b8143d61902e1f3de3426e4 )
+)
+
+game (
+	name "Crowns Golf (834-5419-03)"
+	year "1984"
+	developer "Nasco Japan"
+	rom ( name crgolfa.zip size 48446 crc d0539b73 md5 08439967c5e3b4aa50db540740789674 sha1 8ba14a3610238f4c150e6691a28bde1a78e64283 )
 )
 
 game (
@@ -7733,6 +8644,13 @@ game (
 )
 
 game (
+	name "Poker Carnival"
+	year "1991"
+	developer "Subsino"
+	rom ( name crsbingo.zip size 59323 crc bf514419 md5 8c9f8a769f852de3fff6b15842535833 sha1 cdac4d35379322cf6c1a9c4c01907e2791b67b70 )
+)
+
+game (
 	name "Lethal Crash Race (set 1)"
 	year "1993"
 	developer "Video System Co."
@@ -7812,6 +8730,13 @@ game (
 	name "Crush Roller (Sidam bootleg)"
 	developer "bootleg (Sidam)"
 	rom ( name crushs.zip size 16308 crc 4f50e1e7 md5 07cbd87fe336ab01fa6d877f6926b599 sha1 b3c1552a4310dac70ecf40708f29ba406c30ac30 )
+)
+
+game (
+	name "Cruis'n USA (rev L4.1)"
+	year "1994"
+	developer "Midway"
+	rom ( name crusnusa.zip size 11277901 crc dc92d005 md5 b60f7571b1c48d2c2a2ebee557d0c25c sha1 31a02b25028c17602de4e9e1a10a9a27244c47aa )
 )
 
 game (
@@ -7927,6 +8852,20 @@ game (
 )
 
 game (
+	name "Crazy Rally (set 1)"
+	year "1985"
+	developer "Tecfri"
+	rom ( name crzrally.zip size 58840 crc 393d1ceb md5 c7c6fe20f661faf0ec7a93009fc33edc sha1 26981eee4b60477f6d3647b8444a3043a6a3998a )
+)
+
+game (
+	name "Crazy Rally (set 2)"
+	year "1985"
+	developer "Tecfri"
+	rom ( name crzrallya.zip size 58894 crc e3676f47 md5 98c7ecbc53b527dd5224bfc292919641 sha1 23c58116adda135fa834cc23487efa36ae3428fc )
+)
+
+game (
 	name "Crazy Rally (Gecas license)"
 	year "1985"
 	developer "Tecfri (Gecas license)"
@@ -7980,6 +8919,27 @@ game (
 	year "1984"
 	developer "Data East Corporation"
 	rom ( name cscrtry2.zip size 38488 crc 67d87185 md5 bbd57d14e1fbce475e917f890cbdb180 sha1 bc7e54b57c3023489579245fab836ba4c4439172 )
+)
+
+game (
+	name "Chicken Shift"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name cshift.zip size 43315 crc 7c6abca8 md5 de1ee67a321e96e354c0618228bfe451 sha1 618c93be227f68390501e771d806d291cb271eb9 )
+)
+
+game (
+	name "Captain Silver (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name csilver.zip size 403065 crc cdbcd8a3 md5 9396631f721ab08913e6c430857b331c sha1 e510c6c0c8c7755351b5c3d1d557c46ab504cf86 )
+)
+
+game (
+	name "Captain Silver (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name csilverj.zip size 400952 crc 5962214d md5 b697fb405697a8f8519e87e73fbe01f2 sha1 87c3b265298d68a3bb2246680ab83f8c2073f531 )
 )
 
 game (
@@ -8218,6 +9178,13 @@ game (
 )
 
 game (
+	name "Cuore 1 (Italian)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name cuoreuno.zip size 19253 crc 94c0fea5 md5 24f2f15db3d20da4c4401fce4548585a sha1 b16af13650d2b114253773644601b2788ca1c7c1 )
+)
+
+game (
 	name "Taito Cup Finals (Ver 1.0O 1993/02/28)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -8243,6 +9210,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name cworld.zip size 728155 crc 92fff834 md5 7b957f3061527245dd049f0afd9cf88a sha1 0a75499a74146f831ac2f1d6b8aa6aac822430aa )
+)
+
+game (
+	name "Adventure Quiz Capcom World 2 (Japan 920611)"
+	year "1992"
+	developer "Capcom"
+	rom ( name cworld2j.zip size 1753740 crc 3181ff10 md5 b32c4c73707d91596c5d375147c3c11a sha1 99f44bf54db8999d313bb0e6e021ea8cdb4b1459 )
+)
+
+game (
+	name "Cybattler"
+	year "1993"
+	developer "Jaleco"
+	rom ( name cybattlr.zip size 1266380 crc d454f84a md5 041ced047550d34d4aa37df69cfb3b18 sha1 e26f3a8131a4d6d8fbf0dfca8ba44c42045bfcbc )
 )
 
 game (
@@ -8372,6 +9353,13 @@ game (
 )
 
 game (
+	name "Zeroize (Cassette)"
+	year "1983"
+	developer "Data East Corporation"
+	rom ( name czeroize.zip size 35576 crc 9d8badbd md5 b0cfd2dac609896f2268c1c1f2087054 sha1 2c2328855d8fefed4ba756c7e5f407c1057876e8 )
+)
+
+game (
 	name "Dream 9 Final (v2.24)"
 	year "1992"
 	developer "Excellent System"
@@ -8400,6 +9388,13 @@ game (
 )
 
 game (
+	name "Daimakaimura (Japan)"
+	year "1988"
+	developer "Capcom"
+	rom ( name daimakai.zip size 1639957 crc ef75d833 md5 98e9150233fd99b9d5b49c71184f3f72 sha1 a0b850cdaff1c237a1effa877d9fe48db7ae4c53 )
+)
+
+game (
 	name "Daimakaimura (Japan Resale Ver.)"
 	year "1988"
 	developer "Capcom"
@@ -8418,6 +9413,13 @@ game (
 	year "1993"
 	developer "Athena"
 	rom ( name daioh.zip size 3149073 crc 99d0e1e4 md5 6cc25c79e0e2aed2ce5fd5d187120322 sha1 7deb6e35e8face8145e3d71f646832059cf78f5b )
+)
+
+game (
+	name "Mahjong Daireikai (Japan)"
+	year "1989"
+	developer "Jaleco / NMK"
+	rom ( name daireika.zip size 782018 crc 620a8a38 md5 b484554869422814e7b0a4c91c53c58f sha1 d641e7eac4ccfa7c58642a9ac07e163003b7be41 )
 )
 
 game (
@@ -8666,6 +9668,20 @@ game (
 )
 
 game (
+	name "Dark Horse Legend (GX706 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name darkhleg.zip size 63466 crc ea0c85ea md5 43edf69dd43ed5011a322fe74df16335 sha1 692ad3e7b98adfa10307f4f50bbf6fa40f80322c )
+)
+
+game (
+	name "Dark Horse (bootleg of Jockey Club II)"
+	year "2001"
+	developer "bootleg"
+	rom ( name darkhors.zip size 2016274 crc 9a085b6a md5 93da3283935cc1c8bf6deace26b2cbc5 sha1 dfacb21ba11900a2bcd5fd15e0241a3751bd8e6c )
+)
+
+game (
 	name "The Lost Castle In Darkmist"
 	year "1986"
 	developer "Taito"
@@ -8726,6 +9742,20 @@ game (
 	year "1986"
 	developer "Data East Corporation"
 	rom ( name darwin.zip size 120044 crc 937ad0f0 md5 122efe0f51a9346400384bba7139f064 sha1 1f7ca842309e42e058b609e7ed313a834140324d )
+)
+
+game (
+	name "Desert Assault (US)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name dassault.zip size 3795603 crc 02f097f7 md5 2c689eb6d3014433420be70688b56bda sha1 46cb1fcafa194dbe34a512d398a8d574ac986472 )
+)
+
+game (
+	name "Desert Assault (US 4 Players)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name dassault4.zip size 3793126 crc 494ada01 md5 6283d8ca17d5bfaa5eeb574c0427337a sha1 914beccf65ae5611dddde0d86c71e341595ba71c )
 )
 
 game (
@@ -8824,6 +9854,13 @@ game (
 	year "1989"
 	developer "Irem"
 	rom ( name dbreed.zip size 753922 crc b9fe793a md5 f4b31a4769276a862e5dd2717a428aba sha1 2aa947f887d7ca097519219bfe4d05b0626217f7 )
+)
+
+game (
+	name "Dragon Breed (M72 PCB version)"
+	year "1989"
+	developer "Irem"
+	rom ( name dbreedm72.zip size 1044173 crc 394b85a7 md5 f0cc388b0bad82e3ffda1be590e62969 sha1 894728810a6f976ab55b91d74b679f9cfa23d2ee )
 )
 
 game (
@@ -8946,6 +9983,13 @@ game (
 )
 
 game (
+	name "Double Dealer"
+	year "1991"
+	developer "NMK"
+	rom ( name ddealer.zip size 223338 crc 87ca013e md5 2e48d87248f2c0be4511e1be97c04fc2 sha1 cfdab8741df51cd75bbbdc8dc37cb94a348e51bc )
+)
+
+game (
 	name "Don Den Lover Vol. 1 - Shiro Kuro Tsukeyo! (Japan)"
 	year "1995"
 	developer "Dynax"
@@ -8985,6 +10029,41 @@ game (
 	year "1997"
 	developer "Cave (Atlus license)"
 	rom ( name ddonpachj.zip size 7872970 crc c22194b3 md5 3f8035b9fab733aaa8eee57b09e93217 sha1 6ab811ef00d6da12806119385d900abaa18636f5 )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix (GN895 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2m.zip size 63458 crc 31a43f35 md5 b0954cf13eabd943dbe4f7727d4142ce sha1 bc22198ac61c8219ed6ce163e27846114dd50bd3 )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX CLUB VERSiON (GE896 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2mc.zip size 63456 crc 84100aee md5 a01805b34d7d06351004b0d0dfa032a2 sha1 2e07104a8dbb26496d2ce4c5f53bed142b3c7cfb )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX substream CLUB VERSiON 2 (GE984 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2mc2.zip size 63456 crc bb0c711b md5 26459f2a0078fb848317493669a94aec sha1 414046bd4864701ce5f868fe3213c14dd91a8805 )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix - Link Ver (GE885 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2ml.zip size 67341 crc 65b09990 md5 5ca4a61161486c155c880d4fd1c91ee7 sha1 ebb810eeeeee00b756adf033688dbbc73237cd5d )
+)
+
+game (
+	name "Dance Dance Revolution (GN845 VER. AAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddra.zip size 63456 crc f7289477 md5 5be5b310e2ace252d5d7b90c7e5aeb92 sha1 f5cb93ce05655093aecb4d2511a1e642d13bbf70 )
 )
 
 game (
@@ -9093,6 +10172,13 @@ game (
 )
 
 game (
+	name "Dance Dance Revolution Best of Cool Dancers (GE892 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddrbocd.zip size 63458 crc 31a43f35 md5 b0954cf13eabd943dbe4f7727d4142ce sha1 bc22198ac61c8219ed6ce163e27846114dd50bd3 )
+)
+
+game (
 	name "Dunk Dream '95 (Japan 1.4, EAM)"
 	year "1995"
 	developer "Data East Corporation"
@@ -9104,6 +10190,20 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name ddribble.zip size 358619 crc 0b4f3ea0 md5 def11feee81940591976f34c7e154917 sha1 b3b7b4d17cfe6861e0edbf9d333d9b6cdf234080 )
+)
+
+game (
+	name "Dance Dance Revolution - Internet Ranking Ver (GC845 VER. JBA)"
+	year "1998"
+	developer "Konami"
+	rom ( name ddrj.zip size 63456 crc b964d908 md5 811163e8b448d988c2b5ce0553b455f6 sha1 08ad490b74aeff621172e58270c269a3d1ffdda1 )
+)
+
+game (
+	name "Dance Dance Revolution (GN845 VER. UAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddru.zip size 63456 crc 5616c68b md5 5129ba0a4010ff881d0b232293e4dc11 sha1 f69421ed8dab3c99f005b0c365a5afc8b9419b50 )
 )
 
 game (
@@ -9296,6 +10396,13 @@ game (
 )
 
 game (
+	name "Dynamite Dux (set 1, 8751 317-0095)"
+	year "1988"
+	developer "Sega"
+	rom ( name ddux1.zip size 480213 crc 6e56931b md5 b5f97c2c42d1464797d9e0ce18f70b82 sha1 32ff943d5c7948ce1882aa1256ea88957d2327c9 )
+)
+
+game (
 	name "Dead Angle"
 	year "1988"
 	developer "Seibu Kaihatsu"
@@ -9408,6 +10515,13 @@ game (
 )
 
 game (
+	name "Defense (System 16B, FD1089A 317-0028)"
+	year "1987"
+	developer "Sega"
+	rom ( name defense.zip size 368501 crc 92e6e1f9 md5 0c18ca45fa3474517cbbd1dec6c391ee sha1 82975625e76c336adc29074df9a886276e2d6eda )
+)
+
+game (
 	name "Delta Race"
 	year "1981"
 	developer "bootleg (Allied Leisure)"
@@ -9499,6 +10613,13 @@ game (
 )
 
 game (
+	name "Deroon DeroDero"
+	year "1995"
+	developer "Tecmo"
+	rom ( name deroon.zip size 4006201 crc 59555686 md5 4f6817b242381fd5a945b0139dce403d sha1 aeb81c31639baf8e4065331a54780dbade7c1cad )
+)
+
+game (
 	name "Desert Breaker (World, FD1094 317-0196)"
 	year "1992"
 	developer "Sega"
@@ -9517,6 +10638,13 @@ game (
 	year "1977"
 	developer "Midway"
 	rom ( name desertgu.zip size 6017 crc b20d10c2 md5 cbb91aa4c882a607f0c62a5cd204516e sha1 de970daf007aeb1f8859b801cf822969990be01d )
+)
+
+game (
+	name "Desert War / Wangan Sensou"
+	year "1995"
+	developer "Jaleco"
+	rom ( name desertwr.zip size 10622164 crc 69f85da9 md5 7569556191d31c6ecca6d6d6a606d018 sha1 ca266a239f46e2b43a9b3893d034ae99cc9311ab )
 )
 
 game (
@@ -9597,6 +10725,13 @@ game (
 )
 
 game (
+	name "Devil Zone (easier)"
+	year "1980"
+	developer "Universal"
+	rom ( name devzone2.zip size 12519 crc 4c2cbc77 md5 740273f5bff885af643ed0de60cd51a1 sha1 7531bcf1427c865512f8c819ac6289185389e5b8 )
+)
+
+game (
 	name "Double Joker Poker (45%-75% payout)"
 	developer "DellFern Ltd."
 	rom ( name df_djpkr.zip size 7201 crc 743ced08 md5 0b0c9729018a95fa59a728e29a38c82f sha1 a08f072775c469829d61e4061b52b64d628433b3 )
@@ -9638,10 +10773,31 @@ game (
 )
 
 game (
+	name "Diet Go Go (Euro v1.1 1992.09.26)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgo.zip size 2194196 crc ba979f30 md5 66934e4b2a2bf80c56e41d01f2cbd621 sha1 cc9e6b1e97e7b227509478264b1b7c9aae38bfa3 )
+)
+
+game (
+	name "Diet Go Go (Euro v1.1 1992.08.04)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgoe.zip size 2214207 crc 1e43e639 md5 d598e0898f48b8a60cea01723ba56d8b sha1 149e523bf9aac24e819e2227d37715c11fc7a646 )
+)
+
+game (
 	name "Diet Go Go (Japan v1.1 1992.09.26)"
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name dietgoj.zip size 2193522 crc 59df571b md5 98a8fd70170b5e4280603cf1a4a80a86 sha1 064819075aa2f1638c672f9df0f4525d294a2b54 )
+)
+
+game (
+	name "Diet Go Go (USA v1.1 1992.09.26)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgou.zip size 2193480 crc f2a0d777 md5 a891e42831adb54dcab613e299f875d9 sha1 adc5976fc2db887ceb91cc0035bbbf3289822e7c )
 )
 
 game (
@@ -9736,6 +10892,20 @@ game (
 )
 
 game (
+	name "Cadillacs and Dinosaurs (World 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dino.zip size 4115385 crc 22ff20c9 md5 52b9e81c2ef937ec640e10a6d1454ece sha1 df365c931efdd29727939f05ac211aa6153e266d )
+)
+
+game (
+	name "Cadillacs: Kyouryuu Shin Seiki (Japan 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dinoj.zip size 4115608 crc 75ec2eba md5 f8db41a35da75a0aad8803cb7d09a395 sha1 2cf1fa539b34fe8374be8710c67b7f0d8887bec9 )
+)
+
+game (
 	name "Dino Rex (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
@@ -9754,6 +10924,13 @@ game (
 	year "1992"
 	developer "Taito America Corporation"
 	rom ( name dinorexu.zip size 5630448 crc b53ad3ac md5 572849c06cf337a25e52c40e96982896 sha1 34d6a506d2bdfbd63d0af01104e5e354e1c78a74 )
+)
+
+game (
+	name "Cadillacs and Dinosaurs (USA 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dinou.zip size 4115386 crc 9ea69060 md5 11a836bf851bc3424428c0565110d351 sha1 a09a54c440885e52a45ef658002b115c6d6bbaf0 )
 )
 
 game (
@@ -9817,6 +10994,13 @@ game (
 	year "1990"
 	developer "Irem"
 	rom ( name dkgensan.zip size 718426 crc 71dad722 md5 61c4c9c849d236e1177a6588f25c51ad sha1 7627173825c6003508ce8d47e7ac46e52061fe17 )
+)
+
+game (
+	name "Daiku no Gensan (Japan, M72)"
+	year "1990"
+	developer "Irem"
+	rom ( name dkgensanm72.zip size 719392 crc 88da5ee2 md5 92031a6778aadbcf2c117086ad160559 sha1 112b1f4512eead6ea57fa2ddbc681b057b3a995e )
 )
 
 game (
@@ -10044,6 +11228,13 @@ game (
 )
 
 game (
+	name "Dolphin Blue"
+	year "2003"
+	developer "Sammy"
+	rom ( name dolphin.zip size 82608316 crc 581185be md5 d431110eaa925aead613829b6e85a052 sha1 e0154daa7e1156e7dcd7986c1adc672d0ac3fe8f )
+)
+
+game (
 	name "Domino Man"
 	year "1982"
 	developer "Bally Midway"
@@ -10268,6 +11459,13 @@ game (
 )
 
 game (
+	name "Date Quiz Go Go (Korea)"
+	year "1998"
+	developer "SemiCom"
+	rom ( name dquizgo.zip size 1327729 crc 081f945d md5 6a2a30778523a7022cec607b04128c3f sha1 2b62d2071793d5b2cdb4079f1b6badf595715dbe )
+)
+
+game (
 	name "Date Quiz Go Go Episode 2"
 	year "2000"
 	developer "SemiCom"
@@ -10324,6 +11522,13 @@ game (
 )
 
 game (
+	name "Dream World"
+	year "2000"
+	developer "SemiCom"
+	rom ( name dreamwld.zip size 2007859 crc 7e39ed84 md5 87b93c596a51081bd1fe37c83ea5d9a4 sha1 82679e31d5694982becb4d0cdebe2da438aa97a1 )
+)
+
+game (
 	name "Dream Shopper"
 	year "1982"
 	developer "Sanritsu"
@@ -10342,6 +11547,13 @@ game (
 	year "1984"
 	developer "Namco"
 	rom ( name drgnbstr.zip size 60346 crc 94f96ab1 md5 69872262d0b16eb6381866ae3dfe2a14 sha1 845aaf84f2ab64fcb2e6829cd05e5cd5e30dcdd6 )
+)
+
+game (
+	name "Dragonninja (Japan)"
+	year "1988"
+	developer "Data East Corporation"
+	rom ( name drgninja.zip size 447881 crc cb8dac56 md5 f612cf2e7850cb8429c839dbe7bbde44 sha1 b5f6f8fc90d02c01d6af4a00d4777b64b44f99ff )
 )
 
 game (
@@ -10499,6 +11711,27 @@ game (
 )
 
 game (
+	name "Dr. Toppel's Adventure (World)"
+	year "1987"
+	developer "Kaneko / Taito Corporation Japan"
+	rom ( name drtoppel.zip size 399766 crc 9918e9f2 md5 1709c15d5d106dfc02a47a0846df2dd1 sha1 8a5c0bd41a7ad5dae9d6e3ba5c12b4b5f29f5eaf )
+)
+
+game (
+	name "Dr. Toppel's Tankentai (Japan)"
+	year "1987"
+	developer "Kaneko / Taito Corporation"
+	rom ( name drtoppelj.zip size 399766 crc 72100258 md5 f44dda1a8ef239b442c635a4658a83d9 sha1 aac8b7c658d31dc2aec0eac362d4bf87cf2f8f03 )
+)
+
+game (
+	name "Dr. Toppel's Adventure (US)"
+	year "1987"
+	developer "Kaneko / Taito America Corporation"
+	rom ( name drtoppelu.zip size 399766 crc 2fbc27c2 md5 b24f4ef7918769826c0acb1eec415b65 sha1 640e8722ec8517b31668047c3f42b11ef2305c62 )
+)
+
+game (
 	name "Dragon Saber"
 	year "1990"
 	developer "Namco"
@@ -10510,6 +11743,20 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name dsaberj.zip size 1979112 crc ce8006fc md5 a3e84ee7d9afd83affbb4d78ae6cd52a sha1 d19995135d0d48eee8e67a78daa119d6b3c26040 )
+)
+
+game (
+	name "Dancing Stage featuring Dreams Come True (GC910 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dsfdcta.zip size 63804 crc ee22462e md5 a2485292d7c35eb570e288f664c2e58d sha1 77dd01afc324ccd2fdf2bbc20b424b7ae87c591a )
+)
+
+game (
+	name "Dancing Stage featuring TRUE KiSS DESTiNATiON (G*884 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dsftkd.zip size 63566 crc cd1c6134 md5 9e033b6a4dde7152ca1605603bb46bac sha1 2eb19429af9282c0386cc0dd3905ae76f2027109 )
 )
 
 game (
@@ -10545,6 +11792,13 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name dspirito.zip size 1098855 crc 2e754460 md5 4b91ebc095c1633edc7fa02a8b37c12f sha1 b863fbfb2a5d383ac44313be7fbe775e82f326cc )
+)
+
+game (
+	name "Dancing Stage (GN845 VER. EAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dstage.zip size 63456 crc e6b1402e md5 006f473d74fa18e9bf1b591df71c144b sha1 24b894fcd5ed72cafcca1d5d42a31c9bf0cbf026 )
 )
 
 game (
@@ -10694,6 +11948,13 @@ game (
 )
 
 game (
+	name "Dynamic Shooting"
+	year "1988"
+	developer "Jaleco"
+	rom ( name dynashot.zip size 67568 crc 48edb7c5 md5 626d6e3c8e6137d8104d6416a6ffa95e sha1 50abcd3eb85dc5c5510be60c7ac4732de844c06c )
+)
+
+game (
 	name "Dynamite Duke (Japan)"
 	year "1989"
 	developer "Seibu Kaihatsu"
@@ -10719,6 +11980,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name dynwar.zip size 2193606 crc 13133f73 md5 e45c907aa7c9d903403d9e7e38b07d68 sha1 80e256ade6aa053e026088210e9b4557e406c953 )
+)
+
+game (
+	name "Tenchi wo Kurau (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name dynwarj.zip size 2253157 crc caf6422e md5 53098e9732c61bbce01286b00ef2bf7b sha1 cc43e1b9b3cc6b92f6948b3da6e0d33349e92edc )
+)
+
+game (
+	name "Dynasty Wars (USA, set 2)"
+	year "1989"
+	developer "Capcom"
+	rom ( name dynwaru.zip size 2266318 crc 19515ecc md5 7bb070e8cf74998b104b7c02eb195de7 sha1 1a46d0ad3752bf96f09317bd11632b27198ebd8a )
 )
 
 game (
@@ -10803,6 +12078,20 @@ game (
 	year "1993"
 	developer "Capcom"
 	rom ( name ecofghtru1.zip size 8008466 crc 90a68e70 md5 645729f7b880d6d11addc0b180e41029 sha1 602be0ef05617c28658da76ed63f6708d8f26dad )
+)
+
+game (
+	name "E.D.F. : Earth Defense Force"
+	year "1991"
+	developer "Jaleco"
+	rom ( name edf.zip size 1166516 crc 621c9451 md5 36f6b6f7c778cb42b70f9b62838f047c sha1 0843e086044885aa1c5b6a95f577790f0045f5e0 )
+)
+
+game (
+	name "E.D.F. : Earth Defense Force (North America)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name edfu.zip size 1166510 crc 3c83ab18 md5 2f941401ff6d44bafa14edcf79251828 sha1 a7751e587e9ebc84a74ef53ba3b14ee72c60a1c7 )
 )
 
 game (
@@ -10981,6 +12270,20 @@ game (
 )
 
 game (
+	name "Elephant Family (Italian, new)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name elephfam.zip size 53968 crc c1714542 md5 17b7783f2d0b37b707ff4c041ab2006f sha1 0d5da2f9cf27ce4f696557e95f8ae7616f222992 )
+)
+
+game (
+	name "Elephant Family (Italian, old)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name elephfmb.zip size 27574 crc 1239e0db md5 c82eb438d5cd85184ba3f4d0b2a886b0 sha1 84b4d4657d0b6d045cbe7c8adc23f39432c476ea )
+)
+
+game (
 	name "Elevator Action"
 	year "1983"
 	developer "Taito Corporation"
@@ -11041,6 +12344,13 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name elvact2u.zip size 8186059 crc fd65525f md5 b28b8cc58863755faf58993e093411e2 sha1 563652aa3574095dd424bb75d3edfca4f010daed )
+)
+
+game (
+	name "Elevator Action Returns (Ver 2.2O 1995/02/20)"
+	year "1994"
+	developer "Taito Corporation Japan"
+	rom ( name elvactr.zip size 8186906 crc d89e457f md5 df255cc7c1faa0502dd0ff6512596fe0 sha1 c1aa23e690c86c85fcbec1b57e7ad6dc6d58eb5d )
 )
 
 game (
@@ -11125,6 +12435,20 @@ game (
 	year "1981"
 	developer "GamePlan (Zilec Electronics license)"
 	rom ( name enigma2.zip size 11376 crc 7075d0f7 md5 cf646e6746bfee7ec2a79a70fc209e72 sha1 660cdd5cb6583871c997af42ff668d814eb1db1f )
+)
+
+game (
+	name "Enigma II (Space Invaders hardware)"
+	year "1984"
+	developer "Zilec Electronics"
+	rom ( name enigma2a.zip size 10881 crc b05bc706 md5 526d8db1d2e923ae2d11ffe55490418d sha1 c3b85f4dd7b24ab501d476b705eb90295feef3d3 )
+)
+
+game (
+	name "Phantoms II (Space Invaders hardware)"
+	year "1981"
+	developer "Zilec Electronics"
+	rom ( name enigma2b.zip size 10879 crc abca69a6 md5 29c2bc42e4a9902e5507ee9ad6ad8ba6 sha1 3e3b7c54b1e2ff2950d67a138f57bd051e88e38a )
 )
 
 game (
@@ -11435,6 +12759,27 @@ game (
 )
 
 game (
+	name "Extermination (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name extrmatn.zip size 369284 crc 1f69d677 md5 9f7f0b26e33fc46c495fc62dce2fc811 sha1 fb611f82b86a4620e8248970a27a29ee2a677486 )
+)
+
+game (
+	name "Extermination (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name extrmatnj.zip size 369284 crc 77d4bc0b md5 15325320d8b3fe6c25935b0fb02aed3c sha1 de4ada625016e1d01ba987359c98f2dd71251bb9 )
+)
+
+game (
+	name "Extermination (US)"
+	year "1987"
+	developer "Taito (World Games license)"
+	rom ( name extrmatnu.zip size 369285 crc 37f9d15f md5 7b1a21ebe6389ccb7b67526c27096aa2 sha1 6bb22af2deaec9e3ddfaa673ff87975f75f2d288 )
+)
+
+game (
 	name "Exvania (Japan)"
 	year "1992"
 	developer "Namco"
@@ -11446,6 +12791,13 @@ game (
 	year "1987"
 	developer "Taito Corporation"
 	rom ( name exzisus.zip size 272501 crc 4382d354 md5 c4d5bc09d8362d16fb4f347da95ddb56 sha1 bcad925468f0f34cefae781e422badfd70a5ccf9 )
+)
+
+game (
+	name "Exzisus (Japan, conversion)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name exzisusa.zip size 273439 crc 1d659fea md5 fd0de37193734c2813933e665bf0cdda sha1 7e9a319613f253280525b82271ce2cfaed1bab34 )
 )
 
 game (
@@ -11481,6 +12833,13 @@ game (
 	year "1991"
 	developer "Microprose Games Inc."
 	rom ( name f15se21.zip size 1607252 crc fbdef45b md5 aca1a84dd586021b114a199b74c40dfb sha1 3a1b03f79c80c271775ab5c6f2d5adf6ad5d32c4 )
+)
+
+game (
+	name "F-1 Dream"
+	year "1988"
+	developer "Capcom (Romstar license)"
+	rom ( name f1dream.zip size 338876 crc 3fdf1f53 md5 90c9cf086d72d31a224fbc49880b4ae1 sha1 3ff536b5a5e5d5b283e26af5fd2f02c56cfcbfc7 )
 )
 
 game (
@@ -11853,6 +13212,111 @@ game (
 )
 
 game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4.zip size 646767 crc 8076cc7a md5 0207a9d0b1a2a8229fbe26d1bce071a1 sha1 020d45b8de19ec972c5fdfd41c2aa5ae63a99de3 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4b2.zip size 646951 crc 7ab95821 md5 920f85eb311615804b90f551a937e591 sha1 4b95cbcd9d1c705953d852ca5740190de7ac9513 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4c1.zip size 647152 crc 1f82d65a md5 77f8e9763d8478d464c090740bac4141 sha1 6c888caff73847261227ffa2d4c08b9ff1eed133 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4c2.zip size 647312 crc d09b4174 md5 67a98dc79317c76ad5e95e717660cf72 sha1 8393d2802be74014a450148dad3f05640b14297d )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 3)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4d1.zip size 646521 crc 84189cfa md5 0909c19c83bf5f8dfa89b17472536a87 sha1 86cb8f1dc312c5eb4ab0443921ee091bd89014aa )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 3)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4d2.zip size 646697 crc f4dd12d3 md5 8fd7d695f9aa33a0cf3127651aa9c785 sha1 214fddd68f8433c9db94f18973ff7221d0431876 )
+)
+
+game (
+	name "Fruit Bonus 2005 (2004 Export - Version 1.5E Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4exp.zip size 647101 crc 96aa002e md5 40922e3fc089158172ee4047b45a4a04 sha1 23dd0d5d1eb66caf860ee3d36460d11e98c23f60 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.3XT)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4o.zip size 647046 crc e2083e0e md5 97a3d8ea8c7c65cf7d37b02b9df888a7 sha1 837dfa3e83c4ed71c768770376d9197aa1b1013a )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4o2.zip size 647145 crc 3b363f7c md5 c866d55c50018cb63c44107b377cb716 sha1 cf0a4f1f64d7cbd178f55fb39ddd0e351c68fb09 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4v1.zip size 646891 crc bcd563ed md5 572d33cde72618432d655d4f5a0f85ae sha1 fda44717130bb140452030c6abad759a66620fee )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4v2.zip size 646620 crc b543c8cf md5 9f600fe05af63fe85d27ba44b35a08a4 sha1 b7802095529f298eb5cd16691077a5fb7f89b5cc )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 1)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5.zip size 768770 crc 3dfc8d0a md5 426529d3cb9da4b4bf1df8127dedc977 sha1 0f26141c17ab9c1436f3d311897cb4ad81449f81 )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 2)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5c.zip size 768981 crc a47627ee md5 e7935c2069d1664f0b3f68c4083d7ee1 sha1 35f7092b5ccc2890a1386d6b087e78f278c1ef3a )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 3)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5d.zip size 767431 crc 3c2fa23c md5 fe5fd58e796e571ed3a9989d87eb879f sha1 a49c0c35025963f47f15666d36d049150750fead )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH Dual)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5v.zip size 768376 crc 27e7e5bf md5 398f98d6c7a10af089ca7c97fdef3363 sha1 431fe624aa4b41945bf028c77116f7d0a9e9199b )
+)
+
+game (
 	name "Fruit Bonus '06 - 10th anniversary (Version 1.7E CGA)"
 	year "2006"
 	developer "Amcoe"
@@ -11934,6 +13398,48 @@ game (
 	year "2006"
 	developer "Amcoe"
 	rom ( name fb6v2.zip size 823602 crc 211cf671 md5 38f634d84d96f5e99a3ed728c57f1c2f sha1 ba7e2a87e36952949b1fc4e7be8d8304d0b82455 )
+)
+
+game (
+	name "Fisherman's Bait 2 - A Bass Challenge (GE865 VER. UAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name fbait2bc.zip size 63466 crc f4814701 md5 7893212e2c5c134eb3817cbbba9cf29b sha1 ad26a51483c300efc8cbdb81d4c90cbf725527c2 )
+)
+
+game (
+	name "Fisherman's Bait - A Bass Challenge (GE765 VER. UAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name fbaitbc.zip size 63466 crc 93c745d2 md5 6aeab17bb37f748caf2d7b6b0f192b6b sha1 b3e0b9923099b99e8c89ee1b07f5c7245b91f2ae )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. EA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmc.zip size 63456 crc fd74e59c md5 ccf539245b52c1a0d3a7951cc393441c sha1 44d62616e329a5af570adb7a6b4363dd07220b71 )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. AA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmca.zip size 63456 crc 00e618e4 md5 fdd95db7bbc46f3fc78ec80037fef5ac sha1 0046b451d1eab943cbd5706f90af756aa41c33d8 )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. JA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmcj.zip size 63456 crc faf250e5 md5 d8a2665b89f390a908a45ccd3ba1243c sha1 e08a794ebdcacd140657e260652d97ab791538d3 )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. UA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmcu.zip size 63456 crc e87a1092 md5 80d4df608ef4ad4e16f96d0361903d05 sha1 a6b68c76d730f13ed1e2344afb6a4e5369d684e2 )
 )
 
 game (
@@ -12063,6 +13569,34 @@ game (
 )
 
 game (
+	name "Final Fight (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj.zip size 1470634 crc d3ec0189 md5 f50ec059522a7563088b78d204bfc9c3 sha1 13d868be3cbd28bef32f4e61a643633c0b71add8 )
+)
+
+game (
+	name "Final Fight (Japan 900112)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj1.zip size 1470648 crc e905ae20 md5 2aba73e4d4c90d179ad8dc95fa14a7b6 sha1 d655deb9041dde5b61faec073bca85247fd4884d )
+)
+
+game (
+	name "Final Fight (Japan 900305)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj2.zip size 1470790 crc 6fe254ae md5 8733f30fbae20284ea698a2461f13eff sha1 2d2e28ea582c0ed50c4f8e7dfb24243c1d430165 )
+)
+
+game (
+	name "Street Smart / Final Fight (Japan, hack)"
+	year "1989"
+	developer "bootleg"
+	rom ( name ffightjh.zip size 1429811 crc 7a4aad54 md5 f43f1dd192b1afcbbf5f0e532f3510ba sha1 d3ed2bdc0582cbf576c4916928aca692c6378769 )
+)
+
+game (
 	name "Final Fight (USA)"
 	year "1989"
 	developer "Capcom"
@@ -12105,6 +13639,34 @@ game (
 )
 
 game (
+	name "Fighter's History (World ver 43-07)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthist.zip size 5649743 crc 7accf751 md5 fde7de3ddc1f01c01b49619d64ca2551 sha1 13e97cc5fa36c3bfde56377b0d02de8196d97d87 )
+)
+
+game (
+	name "Fighter's History (US ver 42-05, alternate hardware )"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthista.zip size 5649667 crc 42099d5f md5 6951ba91fa490d2a63e42049b43c5bee sha1 cc193542e18869e9653092bf7b198df6e1a784e2 )
+)
+
+game (
+	name "Fighter's History (Japan ver 42-03)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthistj.zip size 5649715 crc 72418819 md5 400203276a0469e023e8847122698d8b sha1 2148013702c171a6b142961cf7b4e9ec02c9ddea )
+)
+
+game (
+	name "Fighter's History (US ver 42-03)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthistu.zip size 5649715 crc f7ff496a md5 4a5e26c60e62068dc93d82734fb0f10b sha1 5e1f66ee39de12117be0d68874a91289e22d44d4 )
+)
+
+game (
 	name "Fighting Layer (Japan, FTL1/VER.A)"
 	year "1998"
 	developer "Arika / Namco"
@@ -12126,6 +13688,13 @@ game (
 )
 
 game (
+	name "Field Day"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
+)
+
+game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
@@ -12144,6 +13713,41 @@ game (
 	year "1983"
 	developer "Kaneko (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
+)
+
+game (
+	name "Final Lap 2"
+	year "1990"
+	developer "Namco"
+	rom ( name finalap2.zip size 2006181 crc 266ca1dc md5 9075a2bca031d30d25c145abac56c41e sha1 12ac372e776bfe55e151bd8541e657bfb4bcddcb )
+)
+
+game (
+	name "Final Lap 2 (Japan)"
+	year "1990"
+	developer "Namco"
+	rom ( name finalap2j.zip size 2005167 crc f80343d3 md5 c3aed47ab448ecc39ed9209971224b63 sha1 2ebf7c4778f0a58d7e0b39b8d6e68e0337e7e57b )
+)
+
+game (
+	name "Final Lap 3 (World, set 1)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3.zip size 2408440 crc ea0e0096 md5 bbf03f16da3d4f7363c0f5574def9a48 sha1 e5926ce1b4534366979b027e78b6cfddf29c8fe0 )
+)
+
+game (
+	name "Final Lap 3 (World, set 2)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3a.zip size 2432419 crc 7cd0a69c md5 61c34ce4ab8eb0baac2f8eaf55373a18 sha1 203ce7a00e99a6ad6b01cf1c486ee838b42e4416 )
+)
+
+game (
+	name "Final Lap 3 (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3j.zip size 2409518 crc d863485a md5 ab5ddaa0bf0d8527b92e0e1f71e32516 sha1 a455e8def2ae727426376998f8fda367ae8008a5 )
 )
 
 game (
@@ -12203,10 +13807,59 @@ game (
 )
 
 game (
+	name "Finalizer - Super Transformation"
+	year "1985"
+	developer "Konami"
+	rom ( name finalizr.zip size 81140 crc 7a771edd md5 9c01699fdd7e4f6bc3292a3bb180846a sha1 98fdd6fc516ae9ceed3a480222a66f07e657458a )
+)
+
+game (
 	name "Finalizer - Super Transformation (bootleg)"
 	year "1985"
 	developer "bootleg"
 	rom ( name finalizrb.zip size 80178 crc 59af4cc1 md5 1fa3c46f88b45aa0d1dbba381a7d9c72 sha1 0eedcc97436551de119f5c39761e2c7621c6d229 )
+)
+
+game (
+	name "Final Lap (Rev E)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallap.zip size 1115399 crc f462a7d5 md5 74943d547b998ae2f5292cd49d8436b7 sha1 b68910a1e56d499e6f4b14deff41a4e57f48177c )
+)
+
+game (
+	name "Final Lap (Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapc.zip size 1116064 crc d7bdd46c md5 1afca43747f201e3161ffa7cae00348f sha1 1b2b1d04e55a0f846926dea42898988079eeb7d3 )
+)
+
+game (
+	name "Final Lap (Rev D)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapd.zip size 1114994 crc f19657f2 md5 b0066b27aaa84a0fb48391b521b49533 sha1 4c9b6b1b541880dff5fb9aaafa2f884e1767801b )
+)
+
+game (
+	name "Final Lap (Japan - Rev B)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapjb.zip size 1117811 crc 355d6d12 md5 73840d7170c691e972e9dd3631127be1 sha1 fe33719a2a94c462fa8c2bf3acfcdd9c1779df0c )
+)
+
+game (
+	name "Final Lap (Japan - Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapjc.zip size 1114552 crc 74ec233f md5 b5fc9053e6eb47887f70a87d935cf9a2 sha1 af132e03cb1d618077a43179203068d0e828fa04 )
+)
+
+game (
+	name "Final Tetris"
+	year "1993"
+	developer "Jeil Computer System"
+	rom ( name finalttr.zip size 260189 crc 711a654f md5 2ba81ba082709f6bd5bc2bc9dee28036 sha1 f138d18df311fd311b8541680acd348a617dcbe7 )
 )
 
 game (
@@ -12266,10 +13919,45 @@ game (
 )
 
 game (
+	name "Fire Shark"
+	year "1990"
+	developer "Toaplan"
+	rom ( name fireshrk.zip size 533640 crc 31b3b438 md5 6e188e233b1be78f296ff7620084e33c sha1 189548d506e1aa18d18f18958298633cdffdc8a0 )
+)
+
+game (
+	name "Fire Shark (Korea, set 1, easier)"
+	year "1990"
+	developer "Toaplan (Dooyong license)"
+	rom ( name fireshrkd.zip size 567060 crc f4988ef8 md5 53f481afca88a8b218b8e05773ca555f sha1 cc4de80e15bfcc1f0ade8c39b3c6d77afd825344 )
+)
+
+game (
+	name "Fire Shark (Korea, set 2, harder)"
+	year "1990"
+	developer "Toaplan (Dooyong license)"
+	rom ( name fireshrkdh.zip size 567271 crc 9f88268f md5 611b2f60822b028bdfecd9c19146dda3 sha1 cf28cac11f9ca439d3c76fb01153296bd0bc39c8 )
+)
+
+game (
+	name "Fire Trap (US)"
+	year "1986"
+	developer "Wood Place Inc. (Data East USA license)"
+	rom ( name firetrap.zip size 256265 crc d9548ab9 md5 db5088670a54b41a056407cc02e64d30 sha1 eb07d97a576a2da1657e9b8217cf6959d8feb961 )
+)
+
+game (
 	name "Fire Trap (Japan bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name firetrapbl.zip size 257103 crc 04c2cc9d md5 22e4c2ca2bc865bbbbd30f4a63e3a4ec sha1 55a22c188f9d2dcd841f72cd9218bf8f09215cb2 )
+)
+
+game (
+	name "Fire Trap (Japan)"
+	year "1986"
+	developer "Wood Place Inc."
+	rom ( name firetrapj.zip size 256663 crc 69a70224 md5 cbcb7ff4fdf3193ee4711d636d241f09 sha1 04a74865d80df10472cbedca5ddc878122f3034a )
 )
 
 game (
@@ -12399,6 +14087,13 @@ game (
 )
 
 game (
+	name "Battle Flip Shot"
+	year "1998"
+	developer "Visco"
+	rom ( name flipshot.zip size 3658059 crc 3d0c6329 md5 c8a340d6af6a6cfa4a8dc8c3768f4c75 sha1 34d23a1a1e020f83b2239da9b80a13f7199d43ca )
+)
+
+game (
 	name "Flipull (Japan)"
 	year "1989"
 	developer "Taito Corporation"
@@ -12515,6 +14210,13 @@ game (
 	year "1988"
 	developer "Capcom"
 	rom ( name forgottn.zip size 1937908 crc 67c08578 md5 7995ed8a54b12ba850e2143bf5090e44 sha1 079dba637a12b1676e1b67af44529d8cc838873a )
+)
+
+game (
+	name "Forgotten Worlds (USA, 88618B B-Board)"
+	year "1988"
+	developer "Capcom"
+	rom ( name forgottnu.zip size 1907698 crc 0a250078 md5 99cda965a64c6d69248ba41c3ccf2610 sha1 f512fb958f4e4bddf5065d8ae38475de6bb57aec )
 )
 
 game (
@@ -12812,6 +14514,13 @@ game (
 )
 
 game (
+	name "Flying Shark (bootleg)"
+	year "1987"
+	developer "bootleg"
+	rom ( name fsharkbt.zip size 285408 crc 2d474a43 md5 ae16f560139b55865e6be672610c63a8 sha1 85618f7a92c7a718dd9a85d4b9f3aece2ff2a020 )
+)
+
+game (
 	name "Fighting Soccer (version 4)"
 	year "1988"
 	developer "SNK"
@@ -12907,6 +14616,13 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name funkybeeb.zip size 20181 crc d8735813 md5 1620b3f8b2ff78b73a5068cd3f3374c4 sha1 1f42c01c166dd5e0d32e3b16c6737be402aec69f )
+)
+
+game (
+	name "The First Funky Fighter"
+	year "1993"
+	developer "Nakanihon / East Technology (Taito license)"
+	rom ( name funkyfig.zip size 4972404 crc b016ea18 md5 734a5cf4f842bef765235acd0def6fe2 sha1 73ae89381895508b639bfdf4e53af2f4890df059 )
 )
 
 game (
@@ -13217,6 +14933,13 @@ game (
 )
 
 game (
+	name "Galaxy Games StarPak 2"
+	year "1998"
+	developer "Creative Electronics &amp; Software / Namco"
+	rom ( name galgame2.zip size 1507871 crc ab9cdb76 md5 9ede0fb2a75cc6da8edead7fb9d1417e sha1 1775614db63cf84a73dbb82471cfcea16ef0410f )
+)
+
+game (
 	name "Gals Hustler"
 	year "1997"
 	developer "ACE International"
@@ -13413,6 +15136,13 @@ game (
 )
 
 game (
+	name "The Game Paradise - Master of Shooting! / Game Tengoku - The Game Paradise"
+	year "1995"
+	developer "Jaleco"
+	rom ( name gametngk.zip size 13902738 crc fbf9eed6 md5 8c7e0ae282cb63d4dc0e8140977b81a4 sha1 8657d916ccce719dcc9442e6e7691bf6d9d6a7d5 )
+)
+
+game (
 	name "Ganbare! Gonta!! 2 / Party Time: Gonta the Diver II (Japan Release)"
 	year "1995"
 	developer "Mitchell"
@@ -13550,6 +15280,13 @@ game (
 	year "1988"
 	developer "Konami"
 	rom ( name garuka.zip size 641165 crc 0b4e6cff md5 f9a96afaea68a780d20c4757a4aaf88d sha1 ab675fd4b5800748aeb3ed38d0232f1ec5c8f2aa )
+)
+
+game (
+	name "Garyo Retsuden (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name garyoret.zip size 420083 crc 22aefd95 md5 27a84c1193c4eb1e81b209ddb55b83b4 sha1 72813552144923325fa0940fa7bd2b8dc16ca219 )
 )
 
 game (
@@ -13784,6 +15521,13 @@ game (
 )
 
 game (
+	name "Green Beret (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name gberetb.zip size 76784 crc 536e2547 md5 b47a117372449b56c72e37dfb8dddbd9 sha1 5c0e50e37c0239494e8b176572d03134bafd5934 )
+)
+
+game (
 	name "Global Champion (Ver 2.1A 1994/07/29)"
 	year "1994"
 	developer "Taito America Corporation"
@@ -13959,6 +15703,20 @@ game (
 )
 
 game (
+	name "Guardian (US)"
+	year "1986"
+	developer "Toaplan / Taito America Corporation (Kitkorp license)"
+	rom ( name getstar.zip size 158272 crc 8c74ff48 md5 71fd94bf1d02e11d277d8c82cda0bf8c sha1 4309b5e6ae00c1fcab84117c452ad579396d5def )
+)
+
+game (
+	name "Get Star (Japan)"
+	year "1986"
+	developer "Toaplan / Taito"
+	rom ( name getstarj.zip size 158028 crc 3edb0d2e md5 70c5caba45948e961d562240b3542ffb sha1 3e4d6e77066254264a3335b97a9766826257656f )
+)
+
+game (
 	name "Golden Fire II"
 	year "1992"
 	developer "Topis Corp"
@@ -13987,6 +15745,20 @@ game (
 )
 
 game (
+	name "Goalie Ghost"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name gghost.zip size 33194 crc 99c97f79 md5 088130c4c4997dd2ed55cc0e7cc5e067 sha1 5b63c5e3c53cac54f965a79ca9a7aeea6c25628e )
+)
+
+game (
+	name "Guilty Gear Isuka"
+	year "2003"
+	developer "Sammy / Arc System Works"
+	rom ( name ggisuka.zip size 131978434 crc d580caf2 md5 43ffbbc6b695a46e40d45b5fd1d7d956 sha1 ce70ecf4a138b64517c7d0dcd78bf56dcd85018a )
+)
+
+game (
 	name "Gain Ground (World, 3 Players, Floppy Based, FD1094 317-0058-03d Rev A)"
 	year "1988"
 	developer "Sega"
@@ -14012,6 +15784,20 @@ game (
 	year "1996"
 	developer "Hanaho Games"
 	rom ( name ghoshunt.zip size 206467 crc 51e51408 md5 8631deeb227ddf5c7b7a56e622903d3f sha1 0b78f65b3a9f6301d4dc3852263ecc5f50237032 )
+)
+
+game (
+	name "The Real Ghostbusters (US 2 Players)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name ghostb.zip size 417053 crc 2849223a md5 a68b9f4ca9df383a768c76be62886a67 sha1 29044ed4f740097646e64243ecb2b02982aa42ed )
+)
+
+game (
+	name "The Real Ghostbusters (US 3 Players)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name ghostb3.zip size 418966 crc 5a19e779 md5 261dabb3e01d4ff65dd8884a24943970 sha1 2a39333f9ad4c5d4b8dec3e11b87653355e5f6c6 )
 )
 
 game (
@@ -14124,6 +15910,13 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name gijoeu.zip size 4063603 crc a9d88385 md5 88e5c42b4c1b50b672f0930f1e363169 sha1 00fd59e0fa6b8ad90a7e5e397b968dddc749c73c )
+)
+
+game (
+	name "Gimme A Break"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name gimeabrk.zip size 38709 crc 2265ae16 md5 a16efce0fed1866fbfe3b5fb1e3f37ce sha1 7675fb25d7988f2b60373b021eae6534b38fd300 )
 )
 
 game (
@@ -14351,10 +16144,24 @@ game (
 )
 
 game (
+	name "Golden Axe (set 6, US, 8751 317-123A)"
+	year "1989"
+	developer "Sega"
+	rom ( name goldnaxe.zip size 1162622 crc 0613beb6 md5 90a88e501fe0eb52df0061cf3e5bd220 sha1 5d0a09d15498d2e302a44fc119710413658f409d )
+)
+
+game (
 	name "Golden Axe (set 1, World, FD1094 317-0110)"
 	year "1989"
 	developer "Sega"
 	rom ( name goldnaxe1.zip size 1267469 crc dd87fcf3 md5 a69d17cbec9a58a736e68fd7a76d2e00 sha1 04c4dc63b52516259518b79b165302040b5f108a )
+)
+
+game (
+	name "Golden Axe (set 2, US, 8751 317-0112)"
+	year "1989"
+	developer "Sega"
+	rom ( name goldnaxe2.zip size 1162105 crc 0cc43c89 md5 0af740269989f0ffca04a90fc334d6c0 sha1 8fa448a06436e27d15d241a578f0c938a99b26c6 )
 )
 
 game (
@@ -14517,6 +16324,13 @@ game (
 )
 
 game (
+	name "Golden Par Golf (Joystick, V1.1)"
+	year "1992"
+	developer "Strata/Incredible Technologies"
+	rom ( name gpgolf.zip size 521879 crc e1b858cc md5 887376bf11dc63882624ca25f817c6bc sha1 fd78ce67b14dfa05493c3bc8b44cc05447755ab7 )
+)
+
+game (
 	name "Ghost Pilots (set 1)"
 	year "1991"
 	developer "SNK"
@@ -14591,6 +16405,20 @@ game (
 	year "1998"
 	developer "Konami"
 	rom ( name gradius4.zip size 14137104 crc ba1b413d md5 50fae18877457f5df896cc5e2389fa88 sha1 3a0a876c133d0784ffc0599c4574fe2922027c2e )
+)
+
+game (
+	name "Gratia - Second Earth (92047-01 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratia.zip size 9860174 crc c943d00a md5 e6502a65cfc67d2226f2afd16c8a058e sha1 9b798fb1dd5d7b5c3ef2b23d41d868a39a8c09ab )
+)
+
+game (
+	name "Gratia - Second Earth (91022-10 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratiaa.zip size 9094463 crc bd03f496 md5 da78ed9c90ce86938cdf218c4a3b861d sha1 6a960e44c072e14138882af2fe4966526e026379 )
 )
 
 game (
@@ -14748,6 +16576,26 @@ game (
 )
 
 game (
+	name "Grudge Match (prototype)"
+	developer "Bally Midway"
+	rom ( name grudge.zip size 55828 crc f434bea0 md5 368c9d50d62fda8c2164d29f023ad4f5 sha1 b16729f20c2e821d37aef06c6fe2d6f7fee559ec )
+)
+
+game (
+	name "Gryzor (Set 1)"
+	year "1987"
+	developer "Konami"
+	rom ( name gryzor.zip size 388407 crc f7ea7084 md5 a5c3a53ad3a426df63088a93f789135f sha1 1c5f65d4d5ae517daa6e2fcf31a0eba13f3c338c )
+)
+
+game (
+	name "Gryzor (Set 2)"
+	year "1987"
+	developer "Konami"
+	rom ( name gryzora.zip size 388301 crc 14d55376 md5 ba556cf912a8e21a1c7d251c143bb0b1 sha1 d2209640536d2db700dcd2d0d1f4742626971476 )
+)
+
+game (
 	name "Selection (Version 40.02TMB, set 1)"
 	year "1982"
 	developer "Greyhound Electronics"
@@ -14836,6 +16684,20 @@ game (
 	year "1993"
 	developer "Human"
 	rom ( name gstrikera.zip size 5946805 crc 606c95f9 md5 19e3655387a726148189bacabcf3dac1 sha1 61f756571348ac5c15ef6eca9406f0a02215c790 )
+)
+
+game (
+	name "Great Swordsman (World?)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name gsword.zip size 68856 crc 1aad9299 md5 7f99c589cbb50842257f9611b876203a sha1 e9cd6383ea303ad03308b647350453d4e67aa04a )
+)
+
+game (
+	name "Great Swordsman (Japan?)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name gsword2.zip size 67159 crc 50dcc5a2 md5 fcc5da915d90947245e322611a54b2f9 sha1 b3c82b116438128af0c503e3276b3318999d1b4d )
 )
 
 game (
@@ -15140,6 +17002,13 @@ game (
 )
 
 game (
+	name "Golden Tee Golf II (Trackball, V2.2)"
+	year "1992"
+	developer "Strata/Incredible Technologies"
+	rom ( name gtg2.zip size 522599 crc efd34213 md5 bdbf392ab3e4e974124333e8224cfbd1 sha1 68393ea856bbb7514fb99ad15c1cfa4f9929c47b )
+)
+
+game (
 	name "Golden Tee Golf II (Joystick, V1.0)"
 	year "1991"
 	developer "Strata/Incredible Technologies"
@@ -15207,6 +17076,41 @@ game (
 	year "1994"
 	developer "Kaneko"
 	rom ( name gtmrusa.zip size 5620070 crc bb6ef223 md5 4f75fc49e0b7887c17f6595c21ed1e55 sha1 7f4e2c9982244abd92a95fe23fdf6a889b4067d6 )
+)
+
+game (
+	name "Guitar Freaks 2nd Mix Ver 1.01 (GQ883 VER. JAD)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrk2m.zip size 63569 crc 54291e4e md5 ac7494b700f301d106a77b92f1401a18 sha1 a8a6ed773fa568b86acc88527f0bcba0db506e8c )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. EAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrks.zip size 63457 crc b2996d1d md5 99bd9a2e1c4a3397797dd9763f884f97 sha1 369b7910c286a75fdeedb53dd536c81c736ba649 )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. AAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksa.zip size 63457 crc 7dc2e70e md5 13b291104e2dae40e291bf284d12209a sha1 c086f1f8c03a6ae6eab4132c87550d3a5ec2f4cc )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. JAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksj.zip size 63457 crc 3b3d7f4f md5 b286fcf1454abd90225513d109e6e267 sha1 916eed39615b1d7102bdd303ac826c9ccd8942e3 )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. UAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksu.zip size 63457 crc 39697fa9 md5 924e57a6d159e67d68749061602500b4 sha1 682e43426a4ddcb0cbe6930ac79ea6392463dd64 )
 )
 
 game (
@@ -15375,6 +17279,13 @@ game (
 	year "1986"
 	developer "JPM"
 	rom ( name guab7.zip size 314083 crc fee7c28a md5 e970f2d4e884e29b831a0801f45dcd1a sha1 5b8f269ac5a5cb4f2e4e08bd897e2a85a91cdc80 )
+)
+
+game (
+	name "Guardians of the 'Hood"
+	year "1992"
+	developer "Atari Games"
+	rom ( name guardian.zip size 5584191 crc c9ae8a53 md5 7131f12c328660c2c43bad2d5c9ddf83 sha1 6ade59762108675864fdd632c68c0cdc4a5c32ea )
 )
 
 game (
@@ -15650,6 +17561,13 @@ game (
 )
 
 game (
+	name "Guwange (Japan, Master Ver. 99/06/24)"
+	year "1999"
+	developer "Cave (Atlus license)"
+	rom ( name guwange.zip size 18761704 crc 5386e849 md5 94f828b8096a2c9bda87b316a5b25161 sha1 92c92ca125f36a16a6cf325c7b6002836db81a31 )
+)
+
+game (
 	name "Guzzler"
 	year "1983"
 	developer "Tehkan"
@@ -15699,6 +17617,13 @@ game (
 )
 
 game (
+	name "Gypsy Juggler"
+	year "1978"
+	developer "Meadows"
+	rom ( name gypsyjug.zip size 6384 crc ed9c4676 md5 9ab30dc8fca882b68c58c9c7145e30ad sha1 6add65b1b1881829fc565fbf95cea31a5511c654 )
+)
+
+game (
 	name "Gyrodine"
 	year "1984"
 	developer "Crux"
@@ -15724,6 +17649,13 @@ game (
 	year "1983"
 	developer "Konami (Centuri license)"
 	rom ( name gyrussce.zip size 43143 crc 574e5729 md5 3ac6be881f1b3c5b3a51fad97cf20ea9 sha1 7e66fa8cb2f9f479524273a912662cc7fd0bd117 )
+)
+
+game (
+	name "Hachoo!"
+	year "1989"
+	developer "Jaleco"
+	rom ( name hachoo.zip size 1219596 crc bdb0452d md5 f32c8eacfef15fcbe492d71f6e4fcea6 sha1 8a8a52d5948d06550f964666f03ac978a91b156c )
 )
 
 game (
@@ -16077,10 +18009,45 @@ game (
 )
 
 game (
+	name "Hat Trick"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name hattrick.zip size 20957 crc b92050af md5 10e700630a8f6a22206a029f45fbb9a8 sha1 50955d5cbcc66f29e056c0deae185d792144b01d )
+)
+
+game (
+	name "Hayaoshi Quiz Ouza Ketteisen - The King Of Quiz"
+	year "1993"
+	developer "Jaleco"
+	rom ( name hayaosi1.zip size 1243888 crc 230f194d md5 e3a3375678c7d5a21c1bf94efa671e4b sha1 de2b502d2455fa44e7932886e72c126d73ca7cb1 )
+)
+
+game (
+	name "Hayaoshi Quiz Grand Champion Taikai"
+	year "1994"
+	developer "Jaleco"
+	rom ( name hayaosi2.zip size 6534132 crc 0d4d53e2 md5 425d2f1e3ab9d7b1383991b439a6b07a sha1 80ec2a3bd77a2de577eb084b2c7b9d7f78bf2202 )
+)
+
+game (
+	name "Hayaoshi Quiz Nettou Namahousou"
+	year "1994"
+	developer "Jaleco"
+	rom ( name hayaosi3.zip size 8560302 crc 19ad31aa md5 7c76d5a566077e7a850277ddc889da75 sha1 67e82ef2b1ae2017602190abad76278c74c0a742 )
+)
+
+game (
 	name "Heavy Barrel (US)"
 	year "1987"
 	developer "Data East USA"
 	rom ( name hbarrel.zip size 531842 crc 1fcc48e4 md5 7848cbf9edf80c9227fc18f40996fecb sha1 0d1c3ad60099d4b69c84bbce51db62d0afdb0b22 )
+)
+
+game (
+	name "Heavy Barrel (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name hbarrelw.zip size 529376 crc 0f352d48 md5 3eb27f5ed4262e9b577ab0e4c77bc096 sha1 dd43aa9931558059dee7539f67942c75e5c782cd )
 )
 
 game (
@@ -16231,6 +18198,20 @@ game (
 )
 
 game (
+	name "Hero in the Castle of Doom (DK conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Crown license)"
+	rom ( name herodk.zip size 17614 crc 6e68d207 md5 582c86f07798e749588caaf4dea84893 sha1 fed7672adeadf2f27be9a12f4f10521ca1e0170c )
+)
+
+game (
+	name "Hero in the Castle of Doom (DK conversion not encrypted)"
+	year "1984"
+	developer "Seatongrove Ltd (Crown license)"
+	rom ( name herodku.zip size 17520 crc f3ef3d3f md5 411ccf25ddb5f7ca88950525ac3c2fe1 sha1 39aa20dfa71bc440d3a352a368cdd8c3f826f977 )
+)
+
+game (
 	name "Heuk Sun Baek Sa (Korea)"
 	developer "Oksan / F2 System"
 	rom ( name heuksun.zip size 1344601 crc ce210158 md5 743b6eb3779ef407f9b656dcb44420ea sha1 a8a2f5e0cf7bdd4d906ed5d47ab07b47c082d43c )
@@ -16324,6 +18305,48 @@ game (
 	year "1979"
 	developer "Nintendo"
 	rom ( name highspltb.zip size 8717 crc f295e002 md5 22d6e18a0cb34cdc50ab128d7677a168 sha1 e2ff5246ad5c34004b8c4633804cf22f919995c7 )
+)
+
+game (
+	name "High Impact Football (rev LA5 02/15/91)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact.zip size 1208401 crc a9991165 md5 99f6fa091a27f6e66c7b12c7d9376e32 sha1 51d358d89329cc1b7a92110d89251d2db0c5e995 )
+)
+
+game (
+	name "High Impact Football (rev LA1 12/16/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact1.zip size 1205369 crc dc65d504 md5 cbe9ddf2d105167a3fc21d7178526722 sha1 7a50b526a3cea9cd63858dc6e38edb65e4dff49a )
+)
+
+game (
+	name "High Impact Football (rev LA2 12/26/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact2.zip size 1207607 crc 2cf568b4 md5 47936dd918030f848059fe7acdc69427 sha1 1928d391db7dc87c3a7e8d05371d374ddd7d9d96 )
+)
+
+game (
+	name "High Impact Football (rev LA3 12/27/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact3.zip size 1207591 crc 7937a285 md5 d6026f0d09e55e16e9d4e5ebc45b29f5 sha1 0569f44d2da21420a316bcac7a7c74b1f715e559 )
+)
+
+game (
+	name "High Impact Football (rev LA4 02/04/91)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact4.zip size 1208250 crc 25b92963 md5 86a77a8454a236aa5a9a950e6ca5df27 sha1 32fcfb916241c3a4c1b2170fb6758d9762bb0cf8 )
+)
+
+game (
+	name "High Impact Football (prototype, rev 8.6 12/09/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpactp.zip size 1202383 crc 5eefbf34 md5 71b82f101ff657aa10b1f7f3a57ee8f9 sha1 66316321f44378811f749f88304d935f551f56b7 )
 )
 
 game (
@@ -16551,6 +18574,13 @@ game (
 )
 
 game (
+	name "Moero Pro Yakyuu Homerun"
+	year "1988"
+	developer "Jaleco"
+	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
+)
+
+game (
 	name "Homo"
 	year "1987"
 	developer "bootleg"
@@ -16712,6 +18742,13 @@ game (
 )
 
 game (
+	name "Hot Mind"
+	year "1995"
+	developer "Playmark"
+	rom ( name hotmind.zip size 314659 crc 60b80717 md5 3000ad3a8e0ff882d0c8b44c79b419e0 sha1 9cd57503d2becf384395106a50408d937178cebb )
+)
+
+game (
 	name "Hot Mind (adjustable prize)"
 	year "1995"
 	developer "Playmark"
@@ -16852,6 +18889,13 @@ game (
 )
 
 game (
+	name "Hatch Catch"
+	year "1995"
+	developer "SemiCom"
+	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
+)
+
+game (
 	name "Hanafuda Hana Tengoku (Japan)"
 	year "1992"
 	developer "Dynax"
@@ -16905,6 +18949,13 @@ game (
 	year "1983"
 	developer "Century Electronics"
 	rom ( name hunchbaka.zip size 23020 crc f97799d3 md5 253a80f28370a134b7b4d1831f93c97d sha1 77e55b524a90efaf7acd29b3bb17a5e33ce78b55 )
+)
+
+game (
+	name "Hunchback (DK conversion)"
+	year "1983"
+	developer "Century Electronics"
+	rom ( name hunchbkd.zip size 16765 crc 162ce01c md5 5e42739d04f9505930c05d66e6b285db sha1 fa030754526a8240f0319fcf3c7a245aa3026d7e )
 )
 
 game (
@@ -17013,6 +19064,20 @@ game (
 )
 
 game (
+	name "Hydra (prototype 5/14/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap.zip size 1365027 crc c7db21ec md5 7f511162b5fbe9055f654bbc12dcebe5 sha1 46c70e0007a9c0509aa6fd56ce7a0e7d4e2894e2 )
+)
+
+game (
+	name "Hydra (prototype 5/25/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap2.zip size 573542 crc e3c7f1fd md5 ee4ebe5be34acbd4b60e961d0ced4175 sha1 86f03be3670341ac3dd521f22c78b44aeaf83741 )
+)
+
+game (
 	name "Taisen Quiz HYHOO (Japan)"
 	year "1987"
 	developer "Nichibutsu"
@@ -17041,6 +19106,20 @@ game (
 )
 
 game (
+	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name hyperbbc.zip size 63452 crc 4d861ab6 md5 e13f577e5354ed90116a815a86df679f sha1 51961bf291446916fed568e30f23c51d0184227d )
+)
+
+game (
+	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. KAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name hyperbbck.zip size 63452 crc 781b818d md5 c4e82c1a7b5c2a4eefaa53761a552059 sha1 4de5121f59a64ddcf405d5dc5bea7542fa26c0ea )
+)
+
+game (
 	name "Hyper Pacman"
 	year "1995"
 	developer "SemiCom"
@@ -17066,6 +19145,13 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name hypersptb.zip size 112597 crc 47aca4bd md5 914d100430b541960dcb0ad7670453a8 sha1 adc4df9d7b437e6b08404b52e0943672bd0655bc )
+)
+
+game (
+	name "Hyperdrive"
+	year "1998"
+	developer "Midway Games"
+	rom ( name hyprdriv.zip size 127652 crc e32be5da md5 900a5ff2033de5812b55b1d88beb1e43 sha1 00211969d1c32f804087fee2c73505a79bdd347d )
 )
 
 game (
@@ -17101,6 +19187,13 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name hyprolym.zip size 64630 crc 79dd1a60 md5 92da29c22fd417a827fae03adf884e16 sha1 4988c9a3ccac236872c19a95e52f94220d664176 )
+)
+
+game (
+	name "Hyper Olympic (bootleg)"
+	year "1983"
+	developer "bootleg"
+	rom ( name hyprolymb.zip size 82546 crc 72a66bb9 md5 408b03b4bd6d3819f6a890ad6bcfd33f sha1 3a46638d3e167c4466962e997e8e9ca973778842 )
 )
 
 game (
@@ -17202,9 +19295,23 @@ game (
 )
 
 game (
+	name "Iga Ninjyutsuden (Japan)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name iganinju.zip size 901868 crc 4a843085 md5 a50daa13dc6a2137e1326e8c3ecb08c1 sha1 350961defd2dd8584d3c54093801484b807205e8 )
+)
+
+game (
 	name "New Champion Skill (v100n)"
 	developer "IGS"
 	rom ( name igs_ncs.zip size 141502 crc 0bf9f74a md5 5254868750ec1ce2d4c2a810980f2119 sha1 b38d03a29dacbe1651d5dfbca3361cfc2c40577f )
+)
+
+game (
+	name "New Champion Skill (v100n 2000)"
+	year "2000"
+	developer "IGS"
+	rom ( name igs_ncs2.zip size 179683 crc c2686e23 md5 ce1b79789a8b6f9b2159d09123692cf6 sha1 48599236076927d5e195a6b8b21cf665b8cee436 )
 )
 
 game (
@@ -17285,6 +19392,20 @@ game (
 )
 
 game (
+	name "Image Fight (Japan, revision A)"
+	year "1988"
+	developer "Irem"
+	rom ( name imgfight.zip size 634384 crc 5221a34e md5 0ea61f9af90a04b7e514a638e6aa884f sha1 8c5638687464af92d65ac1e35b8ddcea8a04cda0 )
+)
+
+game (
+	name "Image Fight (Japan)"
+	year "1988"
+	developer "Irem"
+	rom ( name imgfighto.zip size 634558 crc dad530c6 md5 e3e67cb0277e6dfb75fcfe93d002a05d sha1 587e9a0c52aa45defc501119ccb8f3c739262ba5 )
+)
+
+game (
 	name "I'm Sorry (315-5110, US)"
 	year "1985"
 	developer "Coreland / Sega"
@@ -17319,10 +19440,45 @@ game (
 )
 
 game (
+	name "Indiana Jones and the Temple of Doom (set 1)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp.zip size 389206 crc cf2f1389 md5 1892e0d9b4fddb5ca23e12447f2ea8c2 sha1 0e5cf86a0e6f839aa6abbca49dc0ae07d45f7231 )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 2)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp2.zip size 389206 crc 9d5fa425 md5 b38fc1430462d153516baf74db5edb1b sha1 ddea57aade1ef0a9ef271e9665d2a33180c8a3fe )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 3)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp3.zip size 389379 crc 6f850dca md5 bf100009e67a4c66898b720cfc9a95f9 sha1 18570b0a73705f32387740d717c6e7967d5fa562 )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 4)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp4.zip size 389593 crc 43586218 md5 770bf52398cb52c6becf685bc4b1cb86 sha1 570cb4e8907f025b57a5f926e83e132b24e2fd95 )
+)
+
+game (
 	name "Indiana Jones and the Temple of Doom (Cocktail)"
 	year "1985"
 	developer "Atari Games"
 	rom ( name indytempc.zip size 364487 crc 400bbfab md5 db43194f7475fa8b1d4ee40095712e42 sha1 d5982a952fd8f33609328cbf46d58bebd446c25b )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (German)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytempd.zip size 389280 crc e02e3b86 md5 3bae1401f3a46a752f59abedd7b5c7b9 sha1 1faa499281487fb15f7cf63ed8e42bfde027d1f3 )
 )
 
 game (
@@ -17372,6 +19528,13 @@ game (
 	year "1993"
 	developer "Irem America"
 	rom ( name inthuntu.zip size 3017667 crc bbbe0a6c md5 d568c3fe91d7aa3cf62bac6f401382e5 sha1 ff15e649d841381d40c8e8b183c4030321dfb1dc )
+)
+
+game (
+	name "International Team Laser (prototype)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name intlaser.zip size 396644 crc c1b96ff3 md5 73a68870efe55f5cfbf769ec1c06b092 sha1 c385f6e5bc32b3e6c02195b024a537a292a2670e )
 )
 
 game (
@@ -17643,6 +19806,20 @@ game (
 )
 
 game (
+	name "Happy Jackie (v110U)"
+	year "1993"
+	developer "IGS"
+	rom ( name jackie.zip size 191320 crc 97aebc98 md5 508af67ba9db4c01d5a01962a2b840e4 sha1 8d9c6e18bb2f9e874bf6bbe34653f93e10936e7f )
+)
+
+game (
+	name "Jack Rabbit (set 1)"
+	year "1984"
+	developer "Zaccaria"
+	rom ( name jackrabt.zip size 55883 crc a7722c9d md5 3d93af2407203345dc5b47729d5c584f sha1 7b9015e1e6dea4278515d99db4a356fb95e445af )
+)
+
+game (
 	name "Jack Rabbit (set 2)"
 	year "1984"
 	developer "Zaccaria"
@@ -17661,6 +19838,13 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name jailbrek.zip size 69169 crc 5ccb9ec7 md5 bfa606dbc35d8d50c340c4a142ae4242 sha1 b88510bdde8b2a194f96b224fdba591a5e30276a )
+)
+
+game (
+	name "Jail Break (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name jailbrekb.zip size 68418 crc 9555ac39 md5 68d138f265c40def938883ca1bc33b29 sha1 ba5c71cb6db714a871cb08f93fde7a4925987257 )
 )
 
 game (
@@ -17703,6 +19887,13 @@ game (
 	year "1996"
 	developer "Dynax"
 	rom ( name janptr96.zip size 627648 crc f68cea3a md5 6ac5319848107121e9cf9e268c4f0e9b sha1 fccfbb51a73744075ae062a9e7ee57356a40e42b )
+)
+
+game (
+	name "New Double Bet Mahjong (Japan)"
+	year "1981"
+	developer "Public Software Ltd. / Mes"
+	rom ( name janputer.zip size 20202 crc 6184f21e md5 f0500e278b58ab376300a04ca921558f sha1 eec4d7369d76446be5b1a992e02a684806e5dad8 )
 )
 
 game (
@@ -17808,6 +19999,13 @@ game (
 	year "1982"
 	developer "Falcon"
 	rom ( name jin.zip size 14013 crc d07fef6c md5 07eafbf03f9c38e60915170b784c8330 sha1 a7c846b4cfb2671be83b7f9a77fd0f6cc1b7fc3e )
+)
+
+game (
+	name "Jitsuryoku!! Pro Yakyuu (Japan)"
+	year "1989"
+	developer "Jaleco"
+	rom ( name jitsupro.zip size 1504321 crc e47b1e79 md5 1967b9acd0916487e4f7219cca8ebbf9 sha1 bccb1946075f09334565c5724efcb5129e875a53 )
 )
 
 game (
@@ -18052,6 +20250,13 @@ game (
 	year "1993"
 	developer "Soft Design"
 	rom ( name jolyccrb.zip size 26234 crc b9972239 md5 834163efc000ffa57977efce7b38d775 sha1 9e383b9ee8717ad53441454ae39c5bf799548a4a )
+)
+
+game (
+	name "Jolly Card (Austrian, Funworld)"
+	year "1986"
+	developer "Funworld"
+	rom ( name jolycdat.zip size 32168 crc 38166793 md5 a3c16f1dfd193d14735db3d13f816e0f sha1 3c8acfc062c198ca306c05c2fa4fd7189dd5083d )
 )
 
 game (
@@ -18464,6 +20669,20 @@ game (
 )
 
 game (
+	name "Mahjong Kakumei (Japan)"
+	year "1990"
+	developer "Jaleco"
+	rom ( name kakumei.zip size 546133 crc 28f8fdc5 md5 1f9191815d9a1c4a2a65769d6e0abdcc sha1 693688e8f6bd2b039285d090a8e827ca1e8ec5d1 )
+)
+
+game (
+	name "Mahjong Kakumei 2 - Princess League (Japan)"
+	year "1992"
+	developer "Jaleco"
+	rom ( name kakumei2.zip size 1037704 crc 2eb34b77 md5 1f1dafdc947110082ea3095422e74996 sha1 104f70a4f2d8e6b44a1c54a4aabf015ea2636279 )
+)
+
+game (
 	name "Kamakazi III (superg hack)"
 	year "1979"
 	developer "hack"
@@ -18478,6 +20697,13 @@ game (
 )
 
 game (
+	name "Kamikaze"
+	year "1979"
+	developer "Leijac Corporation"
+	rom ( name kamikaze.zip size 5928 crc 5a4fefc8 md5 7bdacec83ded3f14a622750d540b0c46 sha1 b8cbbb27d5446fb696b6e963f6f41e3cb79a285a )
+)
+
+game (
 	name "Kamikaze Cabbie"
 	year "1984"
 	developer "Data East Corporation"
@@ -18489,6 +20715,20 @@ game (
 	year "1988"
 	developer "Panac"
 	rom ( name kanatuen.zip size 326075 crc 7958cbdb md5 2d299909a88ec8b88ea21c133631ec85 sha1 e78470dd8c6a999a72ce05bcc7cd9ddf755d8072 )
+)
+
+game (
+	name "Kangaroo"
+	year "1982"
+	developer "Sun Electronics"
+	rom ( name kangaroo.zip size 29696 crc 34252b40 md5 66fa791b13fe3cf44d6990709678d4aa sha1 0b1dc7390f485a98d4e15aaf586786889b49789d )
+)
+
+game (
+	name "Kangaroo (Atari)"
+	year "1982"
+	developer "Sun Electronics (Atari license)"
+	rom ( name kangarooa.zip size 29865 crc b9872bd9 md5 e555266761af620944251b297e6d3990 sha1 8b44d60eb290222a2b0841393ca1cc8fa6f689b2 )
 )
 
 game (
@@ -18573,6 +20813,13 @@ game (
 	year "1994"
 	developer "Data East Corporation"
 	rom ( name karnovr.zip size 8427312 crc 1e5c4b18 md5 c1e12027c5b20d02f861f3c3ff88135f sha1 8023b4288674c9b518480ce23fb80255bacbe706 )
+)
+
+game (
+	name "Ninja Kazan (World)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name kazan.zip size 874065 crc 539fb40f md5 152de260bc5e42de32fc9c3723f465cd sha1 40e09a127f9ccb344d4071308d206dbc9c28b07b )
 )
 
 game (
@@ -18807,6 +21054,20 @@ game (
 )
 
 game (
+	name "Kick and Run (World)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kicknrun.zip size 153123 crc 0da177d8 md5 3ceb63eb806fa6254d90d92fd075c3de sha1 ea2e2873f59a90e83c255ba2eff8c5bc86124e35 )
+)
+
+game (
+	name "Kick and Run (US)"
+	year "1986"
+	developer "Taito America Corp"
+	rom ( name kicknrunu.zip size 153124 crc b401d099 md5 61e2f504d466a24679e64ecec0884d35 sha1 670abd80926cba3ab54a94ea0f2dad2629b4cedb )
+)
+
+game (
 	name "Kick Off (Japan)"
 	year "1988"
 	developer "Jaleco"
@@ -18853,6 +21114,20 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name kikcubicb.zip size 270701 crc f82dff44 md5 682deaf473366b5ac6dcb3de347c7954 sha1 7dc458dd1d704f27f52a635de920bd957b7c7e38 )
+)
+
+game (
+	name "KiKi KaiKai"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kikikai.zip size 228593 crc 8a765bc0 md5 50ad6b55ec94d80d6d534fea3b553edf sha1 45b60dce7f549edcd7a387eccb23418ca369beb1 )
+)
+
+game (
+	name "Kick Start Wheelie King"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name kikstart.zip size 33608 crc 11f18636 md5 069d26bca2ac1ddc4641a13c3cb35302 sha1 f46efa023dfa729f58dd7a72ee3ca6302ec8354c )
 )
 
 game (
@@ -18978,6 +21253,13 @@ game (
 	year "1997"
 	developer "Taito Corporation"
 	rom ( name kirameki.zip size 13454543 crc 9239064b md5 56241853e77b49176d50b00012dedd0f sha1 1cf32a578d05a7bcab539c12d1442061fdce9b03 )
+)
+
+game (
+	name "Ryuusei Janshi Kirara Star"
+	year "1996"
+	developer "Jaleco"
+	rom ( name kirarast.zip size 13551531 crc b28fb495 md5 390ff256e11415db1477ffcc03f3b809 sha1 1765d3b4a15cf5d55252f0246a319cc8029ebc51 )
 )
 
 game (
@@ -19131,6 +21413,27 @@ game (
 	year "1982"
 	developer "KKK"
 	rom ( name knockout.zip size 12825 crc 862c179a md5 ac3aad736309da2c0882dd65dbceceb3 sha1 57f01322719fb5e599604cf1d276504bda18c3da )
+)
+
+game (
+	name "The King of Dragons (World 910711)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kod.zip size 2365648 crc ad34a945 md5 06488f9f8375a3450e64a2d688f92694 sha1 c8d062de4c56e4de3222977813ea02991d7fe352 )
+)
+
+game (
+	name "The King of Dragons (Japan 910805)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kodj.zip size 2367316 crc 0e8cf982 md5 d188c2337ff67f773af36cc827ff375f sha1 f190eab7209026a4299bccfa869c6b1ce48d11d1 )
+)
+
+game (
+	name "The King of Dragons (USA 910910)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kodu.zip size 2370275 crc 0ae98828 md5 8c664000511d8716f7e8354ae5efa802 sha1 6d8f5475a8e772dce59ef5040d61594af68de472 )
 )
 
 game (
@@ -19364,6 +21667,41 @@ game (
 )
 
 game (
+	name "Konami 80's AC Special (GC826 VER. AAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80a.zip size 63463 crc d2e22b3c md5 74739636dceb39178a6e7fc7052ebbea sha1 dd19b7f53dc7017740c3ba452a6722d33b177b7f )
+)
+
+game (
+	name "Konami 80's Gallery (GC826 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80j.zip size 63463 crc 05a838a9 md5 80d8380f57e4afd8f26837a1c92de766 sha1 032bf057e83c9e9d82b647e1726a788abed18a82 )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. KAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80k.zip size 63463 crc 88548e76 md5 078efbec9403e0e6e7117c08e7e52c6f sha1 ecf68641d58b1f48651109be9085b08789ccc376 )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. EAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80s.zip size 63463 crc 030d6aee md5 adf670f2285da0f8932ac386a4d4dc86 sha1 d6bc279a1360184765c57e2571be7ce9c239bfaf )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. UAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80u.zip size 63463 crc 937b5041 md5 ca61af8bf91b28afb4e5000cc39faaee sha1 f4b12d8695a4813a9f3711ca35e6a1c4296a905c )
+)
+
+game (
 	name "Konami '88"
 	year "1988"
 	developer "Konami"
@@ -19375,6 +21713,13 @@ game (
 	year "1985"
 	developer "Konami"
 	rom ( name konamigt.zip size 83414 crc b1f1ad5f md5 c0753015de75b4376483dc1d37e6cc4f sha1 8d8369aa1c761aa2e07c3edf05c07f282ef5bed0 )
+)
+
+game (
+	name "Konek-Gorbunok"
+	year "1988"
+	developer "Terminal"
+	rom ( name konek.zip size 30665 crc 289c4ec5 md5 c7fb11bfc778aa674eec8ab3fd729f0f sha1 bfde1c9ec89338dd407b4527df76d57d269d2b3f )
 )
 
 game (
@@ -19454,6 +21799,13 @@ game (
 )
 
 game (
+	name "The Koukouyakyuh"
+	year "1985"
+	developer "Alpha Denshi Co."
+	rom ( name kouyakyu.zip size 93857 crc 602e3d4e md5 d775a54e67fdfffabb02aefa3399091e sha1 813df9abb9d3c74fb9687617ebcd10b0b3f8d41d )
+)
+
+game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 107, 102, 100HK)"
 	year "2000"
 	developer "IGS"
@@ -19486,6 +21838,13 @@ game (
 	year "2000"
 	developer "IGS"
 	rom ( name kov2106.zip size 27839137 crc 20edecb9 md5 7291222e13ba1621eca8d508839de38d sha1 9332d51c2075fee3fffe6d7b66c0eed261d730a4 )
+)
+
+game (
+	name "Knights of Valour - The Seven Spirits"
+	year "2004"
+	developer "Sammy / IGS"
+	rom ( name kov7sprt.zip size 109207200 crc f315cbd0 md5 28389f4f9887dfbeb48d982e004a22b3 sha1 bbac1f301d00c1c911341f2ce39ff55922e81f44 )
 )
 
 game (
@@ -19552,6 +21911,13 @@ game (
 )
 
 game (
+	name "Kyukyoku Tiger (Japan)"
+	year "1987"
+	developer "Toaplan / Taito Corporation"
+	rom ( name ktiger.zip size 386617 crc 78169533 md5 924e6d886cb80f9859a8ad29098c32c4 sha1 58aa0ce009b73449b7a9b0f69197b5108d8963f6 )
+)
+
+game (
 	name "Kyukyoku Tiger II (Ver 2.1J 1995/11/30)"
 	year "1995"
 	developer "Taito Corporation"
@@ -19605,6 +21971,13 @@ game (
 	year "1984"
 	developer "Seibu Kaihatsu"
 	rom ( name kungfuta.zip size 61376 crc 0893a624 md5 0b46cbad30fee0a813c5e6867fe6661d sha1 fee2fce70236b56559497d7059202d1c1166d007 )
+)
+
+game (
+	name "Nekketsu Kouha Kunio-kun (Japan)"
+	year "1986"
+	developer "Technos Japan"
+	rom ( name kuniokun.zip size 372304 crc 203bb0a5 md5 e22eb80e3432d270ff6d97c693014511 sha1 87e72305b046b9e9a8df99551685ad82ad56191c )
 )
 
 game (
@@ -19901,6 +22274,27 @@ game (
 )
 
 game (
+	name "Last Mission (US revision 6)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name lastmisn.zip size 208085 crc 0b434f4e md5 0dfaa0a8d4cbc6c20b0881d4bdc42ac7 sha1 6e0fdcf44eb80a01e9be1c1738bb6940bbdda820 )
+)
+
+game (
+	name "Last Mission (Japan)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name lastmisnj.zip size 207801 crc 11af638c md5 55b8c87cb59595bd6f985dcf7d42390a sha1 fc3529036a7af97d303165008d5ff79d962b40cb )
+)
+
+game (
+	name "Last Mission (US revision 5)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name lastmisno.zip size 208057 crc ca1483ca md5 870ba767f8c1edc0a198a5d62392b054 sha1 069acdc04b9c15617c48827640c4ddb4af1d71e8 )
+)
+
+game (
 	name "The Last Soldier (Korean release of The Last Blade)"
 	year "1997"
 	developer "SNK"
@@ -20010,6 +22404,13 @@ game (
 	year "1988"
 	developer "Capcom"
 	rom ( name ledstorm.zip size 762958 crc 72b6706a md5 2d8d866eeabc659d641448143050be1f sha1 41314dffcb0f2e7fc2c9153dcb6a2e434d258525 )
+)
+
+game (
+	name "Led Storm Rally 2011 (US)"
+	year "1988"
+	developer "Capcom"
+	rom ( name ledstorm2.zip size 752208 crc 47b340a2 md5 eb552fb18ca549456888b4b683253501 sha1 53b333f84996d1ea4bfe7c56e79cb5acc51db3a2 )
 )
 
 game (
@@ -20370,6 +22771,20 @@ game (
 )
 
 game (
+	name "Lunar Lander (rev 2)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander.zip size 10198 crc dac7d478 md5 9814166b25c9dcbc68ad1de183a069d7 sha1 dc7aff9095bbabef7e1069eff934c82c8c45224a )
+)
+
+game (
+	name "Lunar Lander (rev 1)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander1.zip size 10179 crc 89edcaad md5 7344279aad238dc6d20fa1ebdf409778 sha1 1ef9454762395e7949a824de7a44853dac7d304f )
+)
+
+game (
 	name "Lucky Lady (3x3 deal)"
 	year "1991"
 	developer "TAB Austria"
@@ -20433,6 +22848,13 @@ game (
 )
 
 game (
+	name "Line of Fire / Bakudan Yarou (World, FD1094 317-0136)"
+	year "1989"
+	developer "Sega"
+	rom ( name loffire.zip size 1541052 crc daac76b9 md5 ad9694e50968fd9f161322ee6695ff8a sha1 7a2650b1a6c6fa07abce6a61ae6b9e18d612c732 )
+)
+
+game (
 	name "Line of Fire / Bakudan Yarou (Japan, FD1094 317-0134)"
 	year "1989"
 	developer "Sega"
@@ -20465,6 +22887,13 @@ game (
 	year "1996"
 	developer "Deniam"
 	rom ( name logicpro.zip size 1666285 crc 909c6c69 md5 74279f969394acd41840bbb93bdb9594 sha1 112ea8400bccc9ed023b2a3b357b6150aaa9b49c )
+)
+
+game (
+	name "Legend of Hero Tonma"
+	year "1989"
+	developer "Irem"
+	rom ( name loht.zip size 672682 crc c692fa5b md5 48cf056a36d4eeb771830d9fa1ef0b97 sha1 07d598fa255fbcdde2fd83a97ef5029de95d04cd )
 )
 
 game (
@@ -20517,6 +22946,13 @@ game (
 )
 
 game (
+	name "The Lord of King (Japan)"
+	year "1989"
+	developer "Jaleco"
+	rom ( name lordofk.zip size 1101973 crc 3f63f44b md5 47d8cd777ce917e49b01847949d2652f sha1 6b961f7ad3569de0d09dbbc1d241a77483dd68f3 )
+)
+
+game (
 	name "Lost Tomb (easy)"
 	year "1982"
 	developer "Stern Electronics"
@@ -20528,6 +22964,20 @@ game (
 	year "1982"
 	developer "Stern Electronics"
 	rom ( name losttombh.zip size 20308 crc 6b97828b md5 1fc2099309bfc99b6311819e604886b7 sha1 29883aa95c0058812139b8af76f556137b248469 )
+)
+
+game (
+	name "Lost Worlds (Japan)"
+	year "1988"
+	developer "Capcom"
+	rom ( name lostwrld.zip size 1960313 crc 7d287c42 md5 7c5492be9d680aec5307b71679a92071 sha1 89c9be975e957b0b1c090321b3de2a3e8c6e22be )
+)
+
+game (
+	name "Lost Worlds (Japan Old Ver.)"
+	year "1988"
+	developer "Capcom"
+	rom ( name lostwrldo.zip size 1958587 crc dc03ad9b md5 3645430e78647ad52e29c8b6c66379c6 sha1 1e48f0050e41891bd878d4ace3ad0ea39f9aceb8 )
 )
 
 game (
@@ -20629,6 +23079,13 @@ game (
 )
 
 game (
+	name "New Lucky 8 Lines (set 2, W-4)"
+	year "1989"
+	developer "Wing Co., Ltd. / GEI"
+	rom ( name lucky8a.zip size 45097 crc 0ef30d0e md5 5cdf4e4382f047e2692038b533c7a8f8 sha1 340ff805ea820b9948b605e98f155c1dabff2673 )
+)
+
+game (
 	name "New Lucky 8 Lines (set 3, W-4, extended gfx)"
 	year "1989"
 	developer "Wing Co., Ltd. / GEI"
@@ -20675,6 +23132,13 @@ game (
 	year "1980"
 	developer "Taito"
 	rom ( name lupin3a.zip size 11370 crc 6f375e87 md5 71d185a332f8dea4091bb820604ceea6 sha1 6cf9d20579a7462e41c9c8293c49cb5c8d8ea99a )
+)
+
+game (
+	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128)"
+	year "1999"
+	developer "Omega System"
+	rom ( name luplup.zip size 4937349 crc 5792a7e0 md5 df03406001b9fb4b715617611bbab4f2 sha1 6014c990daf94fc100c20da542ef2177eb422fcf )
 )
 
 game (
@@ -20909,6 +23373,13 @@ game (
 )
 
 game (
+	name "Mace: The Dark Age (HDD 1.0a)"
+	year "1997"
+	developer "Atari Games"
+	rom ( name macea.zip size 223650 crc 37427820 md5 08fd8389c8534e0adf51fe6534a22bbb sha1 6550b686c529988a80e348f3e80764505c098c8f )
+)
+
+game (
 	name "M.A.C.H. 3"
 	year "1983"
 	developer "Mylstar"
@@ -20976,6 +23447,13 @@ game (
 	year "1980"
 	developer "Data East Corporation"
 	rom ( name madalien.zip size 15460 crc b9575c95 md5 4206a4f48b9db00ae265f7098b45b3c2 sha1 a199f7817d24d0b127116f370f5ac02c94afbb42 )
+)
+
+game (
+	name "Mad Alien (Highway Chase)"
+	year "1980"
+	developer "Data East Corporation"
+	rom ( name madaliena.zip size 15907 crc 772b8b62 md5 46ed9616eee737a2893e3690944d56a3 sha1 2ebe226ddb6a3060cd2f4db5c1d547a0472b9a54 )
 )
 
 game (
@@ -21117,10 +23595,23 @@ game (
 )
 
 game (
+	name "Magic Fly"
+	developer "P&amp;A Games"
+	rom ( name magicfly.zip size 6703 crc 74809206 md5 1ddd4eebf74a98850548f5de380a658e sha1 e3041ffbc32cef289cd04d208827738bd40a371f )
+)
+
+game (
 	name "Magic Card II (Bulgarian)"
 	year "1996"
 	developer "Impera"
 	rom ( name magicrd2.zip size 62909 crc 4d8c8e63 md5 eea78fb28d61fccb221bbfe3ccaab9ae sha1 62da839958ebc377c23f4ba0e1e28c23897e857e )
+)
+
+game (
+	name "Magic Sticks"
+	year "1995"
+	developer "Playmark"
+	rom ( name magicstk.zip size 260245 crc 4756edde md5 8441263145338f3e9c203bcd034b1231 sha1 9db1c94ab1b0f9947b2914d9f2ee4861219bfa23 )
 )
 
 game (
@@ -21270,6 +23761,20 @@ game (
 )
 
 game (
+	name "Major Title 2 (World)"
+	year "1992"
+	developer "Irem"
+	rom ( name majtitl2.zip size 1811439 crc fb101978 md5 3cb1a085e1939c4ff87423ff232a0a64 sha1 29cc73e3b143d82f820fee893866e99939628556 )
+)
+
+game (
+	name "Major Title 2 (Japan)"
+	year "1992"
+	developer "Irem"
+	rom ( name majtitl2j.zip size 1808701 crc e47dd5aa md5 2ac673cbecfba12be7f5707bbf84dd9b sha1 5e9a54da8d3f39c82d7bd51fd9fd6305790d413c )
+)
+
+game (
 	name "Major Title (World)"
 	year "1990"
 	developer "Irem"
@@ -21347,6 +23852,13 @@ game (
 )
 
 game (
+	name "Makyou Senshi (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name makyosen.zip size 400897 crc 768ff989 md5 f3c86668870f49304759a6d9908bd200 sha1 43ba32bccbaf60d69b30a1a5dc808541c8f08337 )
+)
+
+game (
 	name "Mang-Chi"
 	year "2000"
 	developer "Afega"
@@ -21407,6 +23919,41 @@ game (
 	year "1983"
 	developer "Namco"
 	rom ( name mappyj.zip size 28432 crc 29a1f03f md5 795236868f0ffbcf94d5eea9dea25d03 sha1 f72d6d3fff02c5fe827553e4dc8d76ebd1d82ade )
+)
+
+game (
+	name "Marble Madness (set 1)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble.zip size 242367 crc c6d1b4da md5 7555b3484899a09f48d85c11ecb1158c sha1 b33a2cbd3241322f167574813b72a966b1c18519 )
+)
+
+game (
+	name "Marble Madness (set 2)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble2.zip size 241157 crc 6e805d00 md5 e048639b72add305f2db61dc7edac97f sha1 8a4bed1df3acc95668fd2c38d9efca01e68684e8 )
+)
+
+game (
+	name "Marble Madness (set 3)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble3.zip size 241137 crc e5006d56 md5 d7bf8562e58271ef70919c8130e514bc sha1 88204b59d3156f4088334b76a3f5b863ead33890 )
+)
+
+game (
+	name "Marble Madness (set 4)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble4.zip size 242449 crc 3ecbceb3 md5 685a8c9221921e31ccc503d07cbecf45 sha1 baef2b5e87a00485913d908da4f4eee1824bc522 )
+)
+
+game (
+	name "Marble Madness (set 5 - LSI Cartridge)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble5.zip size 239248 crc 4a8d9315 md5 07efc8a37281321ada49648f55f79b7d sha1 df9782f95db0c0ff3b0d0de4921a22c27f98055b )
 )
 
 game (
@@ -21738,6 +24285,27 @@ game (
 )
 
 game (
+	name "Muscle Bomber: The Body Explosion (Japan 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbomberj.zip size 6613282 crc c91011cb md5 da0c9a02e09fa2cef903c12281daad7b sha1 9c75d6238e8654c7ac1c79a80d6cc60745b299f4 )
+)
+
+game (
+	name "Muscle Bomber Duo: Ultimate Team Battle (World 931206)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbombrd.zip size 6509365 crc 865500aa md5 dc624c8188d3d3e81293b12a11e8130e sha1 8e8dc17fd84f10ee679a7145f0524883e35aa2b8 )
+)
+
+game (
+	name "Muscle Bomber Duo: Heat Up Warriors (Japan 931206)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbombrdj.zip size 6534230 crc 1be31f10 md5 f709f20b8393258265ca6d11427aedd2 sha1 aef3e5f522eb43b4f7b18d8fae5ec3a99f5da4d7 )
+)
+
+game (
 	name "Magic Brush"
 	year "1981"
 	developer "bootleg"
@@ -22052,6 +24620,34 @@ game (
 )
 
 game (
+	name "Mercs (World 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercs.zip size 1753910 crc 3da0b8bf md5 22c4897056f816bab7a01a4353b05a80 sha1 0469b59680031dd85710e31b2a9b0d4d46db836d )
+)
+
+game (
+	name "Senjou no Ookami II (Japan 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsj.zip size 1792753 crc 2dca37a8 md5 fe40b7d8cee3d94ab2dbdab85e6eb5eb sha1 8b7376e43b9706dfc4f0c04341c7aa0bcb483812 )
+)
+
+game (
+	name "Mercs (USA 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsu.zip size 1753902 crc a52879dd md5 4f202dcf2234f372a892253184d497be sha1 8de14207152b82b8476b6bb1440ac50c83c7c7c6 )
+)
+
+game (
+	name "Mercs (USA 900608)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsua.zip size 1757824 crc 86b2d0e1 md5 fa6a8c635590f0f8d955110f8926eabe sha1 4fb6542415435187f595c41ae5a22adf8f2caeae )
+)
+
+game (
 	name "Merlins Money Maze"
 	year "1986"
 	developer "Zilec-Zenitone"
@@ -22133,6 +24729,27 @@ game (
 	year "1985"
 	developer "Data East"
 	rom ( name metlclsh.zip size 97952 crc 4baed0a0 md5 24a2a4f978086004590cfc7c84417df4 sha1 bdef944a8757e5f5edef1738cd3715e7a3dc4624 )
+)
+
+game (
+	name "Metal Hawk"
+	year "1988"
+	developer "Namco"
+	rom ( name metlhawk.zip size 2050614 crc 173e2946 md5 003b8777ab0c53901ad590c4d1885999 sha1 9307a0f603b924e02b940ba0d2c1eebe009db4f6 )
+)
+
+game (
+	name "Metal Hawk (Japan)"
+	year "1988"
+	developer "Namco"
+	rom ( name metlhawkj.zip size 2050646 crc 584799cd md5 98fc296d746b0a087e0097b59b01aa38 sha1 d32fddad3bc9135128f2a82a89ada082d8be5c12 )
+)
+
+game (
+	name "Metal Saver"
+	year "1994"
+	developer "First Amusement"
+	rom ( name metlsavr.zip size 850810 crc 3f56d72d md5 7c1bd2cb4db4852bb20e413e62c9f29a sha1 4dd8f24d4a8209f8e652169b4b867bcb006c1a08 )
 )
 
 game (
@@ -22332,6 +24949,34 @@ game (
 )
 
 game (
+	name "Major Havoc (rev 3)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavoc.zip size 69696 crc 6a5cff34 md5 3bad435ebd898d1972a7670fde3896dc sha1 ab486e8b94235ec4973e64ea450262f859b02cb7 )
+)
+
+game (
+	name "Major Havoc (rev 2)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavoc2.zip size 69406 crc 6dcbd7e1 md5 00706eecdad778917aa5813e2020a292 sha1 1897ef74ce3a36dde44ceea9c795b312fb7d500b )
+)
+
+game (
+	name "Major Havoc (prototype)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavocp.zip size 67100 crc 9641bda0 md5 8590d9f940ff714cd42b3dd587eea78c sha1 70e496458c99df44b950972edfab224f4d3da01f )
+)
+
+game (
+	name "Major Havoc (Return to Vax)"
+	year "1983"
+	developer "Atari / JMA"
+	rom ( name mhavocrv.zip size 71599 crc a0a29f12 md5 7f35d52b4ba2fbb39701303345615577 sha1 628792610d09e099c192bfc97e431c72c8f1ac70 )
+)
+
+game (
 	name "Mahjong Hourouki Gaiden (Japan)"
 	year "1987"
 	developer "Home Data"
@@ -22436,6 +25081,34 @@ game (
 )
 
 game (
+	name "Millennium Nuovo 4000 (Version 2.0)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000.zip size 655497 crc aff65f57 md5 ac50ed89ad19d0fce89707d9983a823c sha1 caaeacfb710570b24d3806a540f1c97094f863f9 )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.8)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000a.zip size 655363 crc 8262740d md5 8148c3374b8f5b3f576e1744e673b2f2 sha1 811ec4f784315c782484ba424e90eb26fb8abd88 )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.5)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000b.zip size 654300 crc af9141a6 md5 6071dc12b62e64cc4f1b7509edce4f56 sha1 fa027d450fc18cba55495e3b0ba79c621976c9d5 )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.6)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000c.zip size 653618 crc d3a8aad5 md5 f9c85fda37f80def9d40700d14978f6c sha1 93c9a7bb7f0de5835a563eb4e803d9f34cbe1ab7 )
+)
+
+game (
 	name "Millipede Dux (hack)"
 	year "1982"
 	developer "hack"
@@ -22506,6 +25179,20 @@ game (
 )
 
 game (
+	name "Mini Golf (set 1)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name minigolf.zip size 60514 crc b1da511b md5 7c8582d62938519caf847b33bd31c4ef sha1 afbef1502b724bb8e576e5c2e7962a3a8ffecc11 )
+)
+
+game (
+	name "Mini Golf (set 2)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name minigolf2.zip size 62036 crc 79d024b7 md5 b1694480f920d4b85c52e3c61e427150 sha1 298021141fd3a9f31d799aba3f0be7d1fa886512 )
+)
+
+game (
 	name "Minivader"
 	year "1990"
 	developer "Taito Corporation"
@@ -22520,10 +25207,31 @@ game (
 )
 
 game (
+	name "Mirax"
+	year "1985"
+	developer "Current Technologies"
+	rom ( name mirax.zip size 85342 crc 16e9b160 md5 927d7cd8840379806d0feb643dcdf92c sha1 b58ad044f1282b267eb9d4e8d1efc8c371adda46 )
+)
+
+game (
+	name "Mirax (set 2)"
+	year "1985"
+	developer "Current Technologies"
+	rom ( name miraxa.zip size 85410 crc 29970667 md5 fb2f3c0b89fb470023034497d0557f01 sha1 93d7aede9da4f51145beda9b2477434f6ce15496 )
+)
+
+game (
 	name "Mirai Ninja (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name mirninja.zip size 1556575 crc 0f0726b0 md5 788744993e6924cb2af8ffedac8ba1ff sha1 0f4be16f197d957563c91f61e6ac575d6d949c49 )
+)
+
+game (
+	name "Miss Bubble II"
+	year "1996"
+	developer "Alpha Co."
+	rom ( name missb2.zip size 1567164 crc 52abf6c0 md5 a04888d98fd5217f3e8142c56b1a0eb8 sha1 b863ff9ed73cc2b3934bc1665bfc4aaf9c376a2e )
 )
 
 game (
@@ -23008,6 +25716,13 @@ game (
 )
 
 game (
+	name "Mahjong Channel Zoom In (Japan)"
+	year "1990"
+	developer "Jaleco"
+	rom ( name mjzoomin.zip size 724176 crc 476c5b8a md5 dcc07435c4a5d90c32389f81b898d796 sha1 7232c3cfe65822e9eb02419c0727990be979eee7 )
+)
+
+game (
 	name "Mortal Kombat (rev 5.0 T-Unit 03/19/93)"
 	year "1992"
 	developer "Midway"
@@ -23393,6 +26108,13 @@ game (
 )
 
 game (
+	name "Monkey Donkey"
+	year "1981"
+	developer "bootleg"
+	rom ( name monkeyd.zip size 30655 crc 8c56ee21 md5 361738afdd314a007a81a9717fb1ab89 sha1 a5f8388938bcc1fd8194e04137228fa80d04dfa2 )
+)
+
+game (
 	name "Monopoly Classic"
 	year "1995"
 	developer "JPM"
@@ -23598,6 +26320,20 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name mooua.zip size 4613733 crc c8c03e4f md5 af23822a065b5d3dd604dd5f2d2c631f sha1 9b910d5587dc7ebf6f738a1fa421c1c8a38a5b56 )
+)
+
+game (
+	name "More More"
+	year "1999"
+	developer "SemiCom / Exit"
+	rom ( name moremore.zip size 938135 crc ed54ea8e md5 b4d531f29da7a36e72d25884afbc0831 sha1 74cd327bc3569bd7a3502bc87999fffbf8bd6cf6 )
+)
+
+game (
+	name "More More Plus"
+	year "1999"
+	developer "SemiCom / Exit"
+	rom ( name moremorp.zip size 910432 crc 84090157 md5 14f341ac6f8b6a21feeb907e1ad03009 sha1 b53073ddbf9a87093467aedc2e2e37746b737b94 )
 )
 
 game (
@@ -23875,6 +26611,13 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name mrgoemon.zip size 81115 crc 42baf036 md5 3ab191ee6e577dc274f4425afc973c97 sha1 cc940cefcaf967c3ed9b24b43ff6083c933efcf6 )
+)
+
+game (
+	name "Mr. HELI no Dai-Bouken"
+	year "1987"
+	developer "Irem"
+	rom ( name mrheli.zip size 625581 crc 44663616 md5 e8d10aded2b145dff60b25398d3fd908 sha1 c9cd5151f463ae34a7a30580d4b035ce4823b3eb )
 )
 
 game (
@@ -24326,6 +27069,13 @@ game (
 )
 
 game (
+	name "Magic Sword (Japan 900623)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mswordj.zip size 1477781 crc b4628f62 md5 c159fc017cd4d859ce4696447d97f776 sha1 1408280100c48e9c10d3b955123e8f79cfcdc762 )
+)
+
+game (
 	name "Magic Sword: Heroic Fantasy (World 900623)"
 	year "1990"
 	developer "Capcom"
@@ -24393,6 +27143,13 @@ game (
 	year "1981"
 	developer "Exidy"
 	rom ( name mtrap4.zip size 33272 crc 0f46afc1 md5 8b3b0209704bc6b65ab36e05617fa209 sha1 3c8653f20680c7236cc7f23a8fbd66e20ad4e4ea )
+)
+
+game (
+	name "Mega Twins (World 900619)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mtwins.zip size 1435278 crc 7c4217bc md5 ad60091137010317baef2db22523ffb6 sha1 e8d16c0fa1e8dbabb45b40b05574450addb47d56 )
 )
 
 game (
@@ -24535,6 +27292,13 @@ game (
 )
 
 game (
+	name "Marvel Vs. Capcom: Clash of Super Heroes (Euro 980123)"
+	year "1998"
+	developer "Capcom"
+	rom ( name mvsc.zip size 22699647 crc 7ff321cb md5 c6ce600537da8962022ff0ff0b6084c8 sha1 8b948de6bfed689b18ce4a7b745e3b79400a885a )
+)
+
+game (
 	name "Marvel Vs. Capcom: Clash of Super Heroes (Asia 980123)"
 	year "1998"
 	developer "Capcom"
@@ -24616,6 +27380,13 @@ game (
 	year "1990"
 	developer "bootleg"
 	rom ( name mwalkbl.zip size 1890851 crc 0c820f6f md5 7d09e8385534daf1fd70cec7d027ee24 sha1 572fba18d0110eac8503dda8bea2cd1bd2619f5a )
+)
+
+game (
+	name "Michael Jackson's Moonwalker (Japan, FD1094/8751 317-0157)"
+	year "1990"
+	developer "Sega"
+	rom ( name mwalkj.zip size 1941919 crc b7e7df52 md5 9dcc4494e3cf115a4cf867f368e33a10 sha1 bc581cdea82d32c1302c42fbe92c27b68eedd944 )
 )
 
 game (
@@ -24762,6 +27533,20 @@ game (
 	year "1990"
 	developer "SNK"
 	rom ( name nam1975.zip size 4456169 crc 5ebefd09 md5 13bf71ade91dbd1a7edc1c2406bcb288 sha1 120829dfa2cef898da9039fce117ca0194765da2 )
+)
+
+game (
+	name "Name That Tune"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nametune.zip size 152433 crc e960ddcc md5 c11d4fb3707a2909c9dd1267f2df354b sha1 acb3abba2f7dce7a43e4b3a4b13faf3c150291c2 )
+)
+
+game (
+	name "Name That Tune (3-23-86)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nametune2.zip size 152371 crc aab36b08 md5 9e66540a2ad75e85fc44aa9858a0d98c sha1 af71ad227bcb9ad0fab805975a5cc1f3ec46beab )
 )
 
 game (
@@ -24968,6 +27753,12 @@ game (
 )
 
 game (
+	name "Cherry Bonus III (ver.1.40, set 1)"
+	developer "Dyna"
+	rom ( name ncb3.zip size 76485 crc 8a763e9e md5 55fd61da1e2540bee45043c3858b4910 sha1 67795e3a044d09eba5d2c285d1abe5f4189a8b4a )
+)
+
+game (
 	name "Ninja Combat (set 1)"
 	year "1990"
 	developer "Alpha Denshi Co."
@@ -25066,6 +27857,13 @@ game (
 )
 
 game (
+	name "Nemo (Japan 901120)"
+	year "1990"
+	developer "Capcom"
+	rom ( name nemoj.zip size 1386260 crc a25478c9 md5 07b61eee7ec631b176d0f8a4fc3c57f9 sha1 6f29e17e81d9825fe65e733d59d7d1d6a2d7ae6f )
+)
+
+game (
 	name "SD Gundam Neo Battling (Japan)"
 	year "1992"
 	developer "Banpresto / Sotsu Agency. Sunrise"
@@ -25161,6 +27959,13 @@ game (
 	year "1980"
 	developer "hack"
 	rom ( name newpuckx.zip size 14035 crc 9480aba5 md5 b649150fbf063c6b106eef71a985a9e7 sha1 f974ca5b7aaccecb650e5b0e1722e98379257a5a )
+)
+
+game (
+	name "News (set 1)"
+	year "1993"
+	developer "Poby / Virus"
+	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
 )
 
 game (
@@ -25423,6 +28228,20 @@ game (
 )
 
 game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan)"
+	year "1987"
+	developer "Technos Japan"
+	rom ( name nkdodge.zip size 319405 crc fb5c41cf md5 f615251cf0a015c2db06e1ffaae51ff9 sha1 706ab87451568ce2566c1927e515b18871aecb7e )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan, bootleg)"
+	year "1987"
+	developer "bootleg"
+	rom ( name nkdodgeb.zip size 320485 crc 60e2b0a5 md5 ad853cacde50b27b6cbe9063ffdb24e2 sha1 2385e2bf61d4f19982c04065f2f5971255cbc109 )
+)
+
+game (
 	name "Oni - The Ninja Master (Japan)"
 	year "1995"
 	developer "Banpresto / Pandorabox"
@@ -25675,10 +28494,31 @@ game (
 )
 
 game (
+	name "Ninja Spirit"
+	year "1988"
+	developer "Irem"
+	rom ( name nspirit.zip size 585051 crc a9c0aa55 md5 51db030c9f0f8245440a076bf7ec141f sha1 c792a326fa586ba2fccdae7d5e3efb3933dae0bc )
+)
+
+game (
 	name "Saigo no Nindou (Japan)"
 	year "1988"
 	developer "Irem"
 	rom ( name nspiritj.zip size 586754 crc 750a08e0 md5 cb5063c812aae08d60a8f80ac17ced69 sha1 57611e471d15607abd886d0fd261223a3bd2881d )
+)
+
+game (
+	name "Night Stocker (set 1)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nstocker.zip size 69916 crc b4706cfd md5 e51875956118b11a665c325e6e86ac50 sha1 e8d2d0e5e0092faac7d953b9a9a1aeb8a90d722b )
+)
+
+game (
+	name "Night Stocker (set 2)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nstocker2.zip size 69856 crc 801a7134 md5 109f97df628ccf25832d69cc61201c11 sha1 82ae29550b842a8f52c2cbeac041b5575a273eed )
 )
 
 game (
@@ -25854,6 +28694,13 @@ game (
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name ohpaipee.zip size 351155 crc c9b31181 md5 ed0bc1373b0e95d7ae1f9392149acf73 sha1 e6f02839c3a63e8498d2c11bba9fbe6daf351a54 )
+)
+
+game (
+	name "Oigas (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name oigas.zip size 67995 crc b37c9061 md5 18ea2172a2285066e87e9cba6ead1fee sha1 9cdfbdbd8aa00e8174be4398ba5239e460c9d759 )
 )
 
 game (
@@ -26140,6 +28987,34 @@ game (
 )
 
 game (
+	name "Psycho-Nics Oscar (World revision 0)"
+	year "1988"
+	developer "Data East Corporation"
+	rom ( name oscar.zip size 270950 crc 108ce66b md5 76cd960b73e1dbc1bf2c41b168b4e1d6 sha1 82b77af4fa0c531eadcdec1309f97d0c15a54994 )
+)
+
+game (
+	name "Psycho-Nics Oscar (Japan revision 1)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name oscarj1.zip size 271202 crc a30ec736 md5 2e37762ff2af9a92087bf5c30fa05f11 sha1 5804d5e81a70f3035838fa3eb4787053d93fdace )
+)
+
+game (
+	name "Psycho-Nics Oscar (Japan revision 2)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name oscarj2.zip size 271201 crc f7de8dd4 md5 76f74cffc1c01d3a5607b2236f73f4a0 sha1 ffd893cf211c1dcfd0d9446c1f1ff2783e5a58cd )
+)
+
+game (
+	name "Psycho-Nics Oscar (US)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name oscaru.zip size 271433 crc a0bea7b3 md5 2e4e0aff1046af24ecf8ba8a23905805 sha1 27b580c035b9878cceb6f8c08963f4f010f20f49 )
+)
+
+game (
 	name "Osman (World)"
 	year "1996"
 	developer "Mitchell"
@@ -26221,6 +29096,13 @@ game (
 	year "1988"
 	developer "Apple"
 	rom ( name otonano.zip size 427882 crc 4e46cd14 md5 ad95a05943fb73ad30e199a501b84e20 sha1 2b23bb0df8b3b43cba860d4e4eac87e0942fc981 )
+)
+
+game (
+	name "Off the Wall (Sente)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name otwalls.zip size 31281 crc 696c7e94 md5 1aeef6cd63c95f15500d571df6e451c5 sha1 b983436f556bb9675c5215557f3e1b9eb636485e )
 )
 
 game (
@@ -26347,6 +29229,13 @@ game (
 	year "1988"
 	developer "Jaleco"
 	rom ( name p47.zip size 716099 crc 12dcc48f md5 8bf2390533497b5171a4bdb4e5e779b4 sha1 234988f0243a2a7266c68bff43edacfb0c16bbfe )
+)
+
+game (
+	name "P-47 Aces"
+	year "1995"
+	developer "Jaleco"
+	rom ( name p47aces.zip size 8715750 crc 6d6a4ad7 md5 732428f7fc1a99ba20e1024fea1791c3 sha1 c7f6bb507f692d22d75a3237439ece283582082e )
 )
 
 game (
@@ -26602,6 +29491,27 @@ game (
 )
 
 game (
+	name "Pang! 3 (Euro 950601)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3.zip size 1536054 crc a87f3739 md5 c0de95b04c2f94e3b3220f1df6fb9ec7 sha1 40f258558a0131042df75952e6616f8a8ae44958 )
+)
+
+game (
+	name "Pang! 3: Kaitou Tachi no Karei na Gogo (Japan 950511)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3j.zip size 1535390 crc 9a2c87aa md5 ce8f83df17ff9207e4e13c0756b888e5 sha1 bc2842290d3ee2b7549147cc8c2007924efe2930 )
+)
+
+game (
+	name "Pang! 3 (Euro 950511, not encrypted)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3n.zip size 1534041 crc a8e56489 md5 3b08a34d661aaef6967ba88032733a9b sha1 03aeb507ef0fb5db3c07284c995bf85644a07c32 )
+)
+
+game (
 	name "Pang (bootleg, set 1)"
 	year "1989"
 	developer "bootleg"
@@ -26613,6 +29523,13 @@ game (
 	year "1989"
 	developer "bootleg"
 	rom ( name pangbold.zip size 491119 crc cdeed8d3 md5 280437ba5cf53c29cbfe81f9dca96c38 sha1 6c9422236795f06ab723dd9f119e3daf3a001ae5 )
+)
+
+game (
+	name "Pang Pang"
+	year "1994"
+	developer "Dong Gue La Mi Ltd."
+	rom ( name pangpang.zip size 1327359 crc 6d4091d6 md5 ed64180c61efdcff8fcf8eb1abbc7f85 sha1 7cc71bd8f59396cce15bb67c73aa98ed5cc5516e )
 )
 
 game (
@@ -26900,10 +29817,24 @@ game (
 )
 
 game (
+	name "Powerful Pro Baseball EX (GX802 VER. JAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name pbballex.zip size 63463 crc 82923e05 md5 26457e3b56f93ec3f5f1a288b31e5a29 sha1 21700294363d8dfe47b3f8f17d0b12ec79350fc6 )
+)
+
+game (
 	name "Pinball Champ '95 (bootleg?)"
 	year "1995"
 	developer "bootleg? (Veltmeijer Automaten)"
 	rom ( name pbchmp95.zip size 249245 crc 3f7d6fc5 md5 ce12171fdad245e66cface780101210c sha1 cefa76dcdb0e3d9dfd0c46a97c9e422df5755996 )
+)
+
+game (
+	name "Prebillian"
+	year "1986"
+	developer "Taito"
+	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -26995,6 +29926,27 @@ game (
 	year "1996"
 	developer "Taito Corporation"
 	rom ( name pbobble3u.zip size 6969055 crc 868c56a6 md5 7c0d6625af1e726403cecd3a79828957 sha1 e9a1fc3874def994bf1502f6e068f06d5b73ff9e )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04O 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4.zip size 6978003 crc 67476786 md5 1fb77610e9f75281822a5009e8805167 sha1 5b5c095d914a2301856b058745c21edea7ba6d52 )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04J 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4j.zip size 6978002 crc 2d94849a md5 7f43e714e2d5c8cf4f335c66a61c4e3b sha1 b137ec936359e34fd36306ccf25f8ce232376186 )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04A 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4u.zip size 6978003 crc a91eb401 md5 8d0b0d0619aaf2d4dc8e4bbcceb2e026 sha1 4d17e858f333a1cd20e70c839e2bc23d6f4afb8b )
 )
 
 game (
@@ -27474,6 +30426,13 @@ game (
 )
 
 game (
+	name "Peek-a-Boo!"
+	year "1993"
+	developer "Jaleco"
+	rom ( name peekaboo.zip size 1267072 crc 7f4335c8 md5 dd6c7746b1ab9d149158f8109d3c7e1d sha1 76dc3f1edad3630d9c75921a9efe94b2598436fc )
+)
+
+game (
 	name "Nozokimeguri Mahjong Peep Show (Japan 890404)"
 	year "1989"
 	developer "AC"
@@ -27719,6 +30678,13 @@ game (
 )
 
 game (
+	name "Peter Pack-Rat"
+	year "1984"
+	developer "Atari Games"
+	rom ( name peterpak.zip size 255981 crc c57a47ed md5 a313297003cc3a21f6362e537e622b44 sha1 53c4cd6070dcd543f8cbbaaa241504d3e83a8aaf )
+)
+
+game (
 	name "Player's Edge Plus (X002069P) Double Double Bonus Poker"
 	year "1995"
 	developer "IGT - International Gaming Technology"
@@ -27838,6 +30804,12 @@ game (
 )
 
 game (
+	name "Klad / Labyrinth (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phklad.zip size 9882 crc 38bbc068 md5 97153cfcbb5b10e4e0f4645590dcb993 sha1 ff6b6604cd22c65f3684bc3284014441616b5c3e )
+)
+
+game (
 	name "Phoenix (Amstar)"
 	year "1980"
 	developer "Amstar"
@@ -27929,6 +30901,12 @@ game (
 )
 
 game (
+	name "Python (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phpython.zip size 4735 crc 310b8131 md5 0b14748a725264eeb897216e760da88e sha1 7d5562ea7f49c36b6245a8fb56a67cfcbb4963e1 )
+)
+
+game (
 	name "Phraze Craze (set 1)"
 	year "1986"
 	developer "Merit"
@@ -27954,6 +30932,19 @@ game (
 	year "1986"
 	developer "Merit"
 	rom ( name phrcrazec.zip size 264795 crc c76a5a61 md5 22ffb22b28e68fa90b93ecb53893c0d8 sha1 2f5a0e34191bdc52f3ff69e1e3c9b93d3dd165ab )
+)
+
+game (
+	name "Phraze Craze (Sex Kit, Vertical)"
+	year "1986"
+	developer "Merit"
+	rom ( name phrcrazev.zip size 232466 crc c67a15b6 md5 3badacfd0e9f7e4e7a488e64ee4e1929 sha1 cd6302b54e07b9bed9ee7309c891de53e2d99692 )
+)
+
+game (
+	name "Tetris (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phtetris.zip size 9369 crc 3e432f38 md5 b1500f93765e3ac1838cac3501b1dd4b sha1 c21681de17086c9f1ede9fcf8c55e41ad13ce266 )
 )
 
 game (
@@ -28024,6 +31015,20 @@ game (
 	year "2001"
 	developer "Amcoe"
 	rom ( name pickwinvt.zip size 636721 crc b7243638 md5 e33db33d368c5619b71d59e654efe387 sha1 f958d9c51ec7496b5574ab3660ddbf44021b2bce )
+)
+
+game (
+	name "Pig Newton (version C)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewt.zip size 41651 crc db3fda51 md5 aa6e091315be92442c51c85f5fb5e5d8 sha1 3906317a8247a719a399af266abf35d6797b5dd9 )
+)
+
+game (
+	name "Pig Newton (version A)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewta.zip size 37918 crc e274f509 md5 5bfcf60a66ff7576dce0f8eb2a0f7d1d sha1 183fe94c4b3a3c3eae99096acb081beb8142d0b4 )
 )
 
 game (
@@ -28752,6 +31757,34 @@ game (
 )
 
 game (
+	name "Plump Pop (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
+)
+
+game (
+	name "Plus Alpha"
+	year "1989"
+	developer "Jaleco"
+	rom ( name plusalph.zip size 1014633 crc a37f8119 md5 7f936d4d34914b2b9b0577b5e1828174 sha1 2a5a7ebdf17935e70156be788590bdd64987fa94 )
+)
+
+game (
+	name "PlayMan Poker (German)"
+	year "1981"
+	developer "PlayMan"
+	rom ( name pmpoker.zip size 12852 crc 243392db md5 23ec82bb1473133a3449d44509b8cd79 sha1 c779d609e229cb37cfb3fb5e48ec23532918fadd )
+)
+
+game (
+	name "Pnickies (Japan 940608)"
+	year "1994"
+	developer "Capcom, licensed by Compile)"
+	rom ( name pnickj.zip size 768482 crc 051b5dc5 md5 0193b457c1f8ef81575570fdf644fe2a sha1 4794c11915dc391005a26136e4cd34988e52fa23 )
+)
+
+game (
 	name "Pochi and Nyaa"
 	year "2003"
 	developer "Aiky / Taito"
@@ -28836,6 +31869,13 @@ game (
 )
 
 game (
+	name "Pole Position (Atari version 1)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name polepos1.zip size 61856 crc fb78e5ec md5 4f54bae29089ec5688e97ebad45cba56 sha1 7745782924d6ad9aef80cff254888e4b13e7d7ef )
+)
+
+game (
 	name "Pole Position II"
 	year "1983"
 	developer "Namco"
@@ -28843,10 +31883,31 @@ game (
 )
 
 game (
+	name "Pole Position II (Atari)"
+	year "1983"
+	developer "Namco (Atari license)"
+	rom ( name polepos2a.zip size 71363 crc 8294d79f md5 5769684d2c9f5e5ac99c1895b1cc91d8 sha1 26a0f9c49b4d8673b78ca7bb1d1e743da9b48f1b )
+)
+
+game (
 	name "Pole Position II (bootleg)"
 	year "1983"
 	developer "bootleg"
 	rom ( name polepos2b.zip size 71769 crc b16c812f md5 1a77e4a0286fb2653ceed2880005a583 sha1 5e714ee682840d1405395835995bc8fa3553bd80 )
+)
+
+game (
+	name "Gran Premio F1 (Italian bootleg of Pole Position II)"
+	year "1984"
+	developer "bootleg"
+	rom ( name polepos2bi.zip size 65682 crc c7fff7d3 md5 449684f71866543b06a57394c5d53eb1 sha1 4e15d630bcd80301653be2d7cfeaedc6a8909304 )
+)
+
+game (
+	name "Pole Position (Atari version 2)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name poleposa.zip size 61883 crc dc1ed56f md5 cdb69dc8f6ab98e22fac2002f5e2dc1d sha1 7bff329b25cec068f7aa34426fc77071a11cf40d )
 )
 
 game (
@@ -28952,6 +32013,34 @@ game (
 	year "1985"
 	developer "Tehkan"
 	rom ( name ponttehk.zip size 21561 crc 834670ce md5 79b9c5d39cd5797c9dfd1e0674bba796 sha1 724110eca09ef9aa4729e9ee03ba257cde06593c )
+)
+
+game (
+	name "Pool 10 (Italian, set 1)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10.zip size 20398 crc 84f48fe3 md5 ce613ad55bd40c2d8ba48fdb52ace5e4 sha1 8318545929fad958ba17ef9b9a40f66bb2cc0353 )
+)
+
+game (
+	name "Pool 10 (Italian, set 2)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10b.zip size 38313 crc 4e23f5c4 md5 8161d7b17d4c9cbd3d748b178e1f000c sha1 e9d7eeb699ca776b92cfb8738666d1dd1829be70 )
+)
+
+game (
+	name "Pool 10 (Italian, set 3)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10c.zip size 20385 crc 523f54b1 md5 868e229f08c9cb60948230d09cb242f1 sha1 b7304558c4fbfd25669b11db04bf5f556b28e369 )
+)
+
+game (
+	name "Pool 10 (Italian, set 4)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name pool10d.zip size 34118 crc b82878bd md5 ce9429d5ff6d200dffcdaf9c0b04282d sha1 6b755aaefdf59134ae29dbf0b2f50be56e9f3503 )
 )
 
 game (
@@ -29074,6 +32163,27 @@ game (
 )
 
 game (
+	name "Pop'n Pop (Ver 2.07O 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpop.zip size 5652566 crc a8bb9331 md5 bdb8ef0c629e68fed1b41b2f4c9ae7c5 sha1 68b3d7dfb6d2b574edf5302e1312047cde02ce77 )
+)
+
+game (
+	name "Pop'n Pop (Ver 2.07J 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpopj.zip size 5652565 crc 9d46d8bc md5 86c06feb65f08224a11077a3b2687b64 sha1 bfc1ee02351bf115934913414712cf4701f24539 )
+)
+
+game (
+	name "Pop'n Pop (Ver 2.07A 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpopu.zip size 5652565 crc 224c8974 md5 a5b73b80fa427952277c82a7ecf7c235 sha1 f85e4cbd1078100d6fec18a5b2349739b1063524 )
+)
+
+game (
 	name "Popper"
 	year "1983"
 	developer "Omori Electric Co., Ltd."
@@ -29095,10 +32205,30 @@ game (
 )
 
 game (
+	name "Port Man (bootleg on Moon Cresta hardware)"
+	year "1982"
+	developer "bootleg"
+	rom ( name porter.zip size 17109 crc 084fc4ae md5 2e31986952ef71edf0b4a7ec82b512f7 sha1 cae0028ff3da248ad418a774774e035af85c8518 )
+)
+
+game (
 	name "Port Man"
 	year "1982"
 	developer "Taito Corporation (Nova Games Ltd. license)"
 	rom ( name portman.zip size 16687 crc 373476f2 md5 8bf09ee70b1a56147442e8be7505435b sha1 f193f1d74cee8a9b6477042797d83781828b508c )
+)
+
+game (
+	name "Pot Game (Italian)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name potgame.zip size 18056 crc 87924391 md5 c08ca9b28c3482282bb1000a8098453a sha1 5b010fc3ae5d2207bce0a0473fc8c679de403a96 )
+)
+
+game (
+	name "Jack Potten's Poker (set 2)"
+	developer "bootleg"
+	rom ( name potnpkra.zip size 10560 crc 61409662 md5 40f807a0e06347c05bd3b92771534c0f sha1 96a41e18233506df6bbecb0184a788a8ac005e8d )
 )
 
 game (
@@ -29117,6 +32247,12 @@ game (
 	name "Jack Potten's Poker (set 5)"
 	developer "bootleg"
 	rom ( name potnpkrd.zip size 10542 crc acf7705f md5 03a0d46c42844af87c99c4d9d822569d sha1 6d8d05ac4915793299b6ffd32e3e6e70cc1511f3 )
+)
+
+game (
+	name "Jack Potten's Poker (set 6)"
+	developer "bootleg"
+	rom ( name potnpkre.zip size 10684 crc b38a1a8e md5 e27b2d35cc8fd8f5c2ed7620600fa773 sha1 a4c33c9c84c4a4e3eb212e88a937d8b68f633403 )
 )
 
 game (
@@ -29165,6 +32301,13 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name pow.zip size 806437 crc f6157c0e md5 5f70874fb2f3708253d46eb4331d0edb sha1 e92d354061cce1ac548d402f6cebde20841d8712 )
+)
+
+game (
+	name "Power Balls"
+	year "1994"
+	developer "Playmark"
+	rom ( name powerbal.zip size 1561777 crc f12ad31f md5 0b47ed0acf97cdf809bb74ac2c209f12 sha1 24a4710947ebd0f923e3725292c6195c157de633 )
 )
 
 game (
@@ -29497,6 +32640,13 @@ game (
 )
 
 game (
+	name "Power Surge"
+	year "1988"
+	developer "&lt;unknown&gt;"
+	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
+)
+
+game (
 	name "Psychic 5 (set 1)"
 	year "1987"
 	developer "Jaleco"
@@ -29693,10 +32843,31 @@ game (
 )
 
 game (
+	name "The Punisher (World 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisher.zip size 4041934 crc 817cbb2a md5 57fdbc0298708807a43ff37890d864a0 sha1 e420fe80faa14ac8a36a9ed93f1698cfec5d60aa )
+)
+
+game (
 	name "Biaofeng Zhanjing (Chinese bootleg of The Punisher)"
 	year "1993"
 	developer "bootleg"
 	rom ( name punisherbz.zip size 2797190 crc 6012cad2 md5 4be2d44bf65707371f9036bdc38d49ad sha1 c7aca8773fe695017edd43c223528c87027a19e4 )
+)
+
+game (
+	name "The Punisher (Japan 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisherj.zip size 4023387 crc d938f8cf md5 c7a7f5801fac3abc293716c28e2c3570 sha1 ff3ab6ab0ccf35793ae0cc62b606efecaa19d739 )
+)
+
+game (
+	name "The Punisher (USA 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisheru.zip size 4041938 crc 30adae89 md5 84175a2e1843edaa21f47bafbe2f17b5 sha1 67f7339bfc668a3bbc1356c2aefc6d731c460b27 )
 )
 
 game (
@@ -29819,6 +32990,13 @@ game (
 )
 
 game (
+	name "Puzzle De Pon! R!"
+	year "1997"
+	developer "Taito (Visco license)"
+	rom ( name puzzldpr.zip size 2113414 crc d84a85ba md5 cc29bcc2ceb94a733665ef5beeff1503 sha1 42af923577e6000217312ef56e75222ef3b38a0a )
+)
+
+game (
 	name "Puzzle De Pon!"
 	year "1995"
 	developer "Taito (Visco license)"
@@ -29868,10 +33046,24 @@ game (
 )
 
 game (
+	name "Puzznic (World)"
+	year "1989"
+	developer "Taito Corporation Japan"
+	rom ( name puzznic.zip size 55467 crc bc6229c3 md5 bdfefff6e6bf604499f43ee5bad2318b sha1 bb29be31df5ba1a6f51d90cbd39ea186e83b6a82 )
+)
+
+game (
 	name "Puzznic (Italian bootleg)"
 	year "1989"
 	developer "bootleg"
 	rom ( name puzznici.zip size 130658 crc 5de407ba md5 ca623ca75bbf7755726348ad786a2509 sha1 11b709be85ec2973d2d15780ea8c098241d8da9d )
+)
+
+game (
+	name "Puzznic (Japan)"
+	year "1989"
+	developer "Taito Corporation"
+	rom ( name puzznicj.zip size 130560 crc beba7156 md5 cc1052a40ee31a1ce60e398c3ea4f25f sha1 23262726e766c491e3f4f3b88a5fd64f365bcc84 )
 )
 
 game (
@@ -29921,6 +33113,13 @@ game (
 	year "1999"
 	developer "Nihon System / Moss"
 	rom ( name pzlbowl.zip size 5900443 crc eb81a5b5 md5 4c7055693eebd84727f1dd47e5f081f4 sha1 8043c25613252b5030fad20e5c55ab5f9045ceac )
+)
+
+game (
+	name "Puzzle Break"
+	year "1997"
+	developer "SemiCom"
+	rom ( name pzlbreak.zip size 524061 crc b3502f4b md5 02282e91d44e492181781d612bf26cda sha1 875582b56386d025224b8f3696f56b820c812fac )
 )
 
 game (
@@ -30175,10 +33374,38 @@ game (
 )
 
 game (
+	name "Quiz Tonosama no Yabou 2: Zenkoku-ban (Japan 950123)"
+	year "1995"
+	developer "Capcom"
+	rom ( name qtono2j.zip size 1944928 crc 9064b2b9 md5 8f1424cf328dcd7a007a4a4be0c7eea3 sha1 b965ed1b1f8a248ad8e8aa2f02a11a6648f95779 )
+)
+
+game (
 	name "Quiz Torimonochou (Japan)"
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name qtorimon.zip size 513555 crc e41953d4 md5 814be223337a21e1df927e9e569fe9c3 sha1 e0169b435c4bea7ebafdbb2e7d064f17bf257a91 )
+)
+
+game (
+	name "Quantum (rev 2)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantum.zip size 47012 crc 74b2f516 md5 ce561fb1a17ed9989a3cafee44cf1faf sha1 4af46ae800a4320c270eec78a9230580d911c26c )
+)
+
+game (
+	name "Quantum (rev 1)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantum1.zip size 47016 crc 65ad3398 md5 f24741c261a527ed077badb2a63afe8c sha1 d2a60559b3b961c0ec5dfeee04d84eece0953e04 )
+)
+
+game (
+	name "Quantum (prototype)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantump.zip size 46725 crc 38dda378 md5 7382d1aefd8fa4cf54a68e6d8270412f sha1 aa58fa3918efd0330fcd52aa387f21047a9111f9 )
 )
 
 game (
@@ -30238,6 +33465,20 @@ game (
 )
 
 game (
+	name "Quintoon (UK, Game Card 95-750-203)"
+	year "1993"
+	developer "BFM"
+	rom ( name quintono.zip size 127821 crc e4d12384 md5 4699b292c00ea58fb913881d0da46da8 sha1 b2f2b2499943f7db36fc61039b491ad3ab0925c0 )
+)
+
+game (
+	name "Quintoon (UK, Game Card 95-750-206)"
+	year "1993"
+	developer "BFM"
+	rom ( name quintoon.zip size 127592 crc bd7226f5 md5 2f6531f18028f7e9a9496189ab917ba6 sha1 6b50a5860783238f0959f0c4ad73cc82ca70bacb )
+)
+
+game (
 	name "Quiz (Revision 2)"
 	year "1986"
 	developer "bootleg"
@@ -30249,6 +33490,13 @@ game (
 	year "1992"
 	developer "EIM"
 	rom ( name quiz18k.zip size 2058384 crc 65cea25c md5 06b84dad170b3575a329987450563c71 sha1 91eea1ac7ea2c01c21a9617811abfb2ff4d1e108 )
+)
+
+game (
+	name "Quiz (Revision 2.11)"
+	year "1991"
+	developer "Elettronolo"
+	rom ( name quiz211.zip size 53546 crc e631a1b3 md5 12eecfa9add482b36d5d29f7026a873d sha1 da0274db8b6291243fd5d9f6c060f240ea4fe927 )
 )
 
 game (
@@ -30371,6 +33619,13 @@ game (
 )
 
 game (
+	name "Video Quiz"
+	year "1986"
+	developer "bootleg"
+	rom ( name quizvid.zip size 98690 crc 7eb96c0f md5 f2fb3f30e7ce4f0f5a8b30dcb870136d sha1 f84216391f4cc27577fc37cec7da0171b005156a )
+)
+
+game (
 	name "Qwak (prototype)"
 	year "1982"
 	developer "Atari"
@@ -30434,6 +33689,111 @@ game (
 )
 
 game (
+	name "Race Drivin' (cockpit, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv.zip size 814136 crc 97b25542 md5 2432dc88898105f0b684a4b381494371 sha1 ba9bac6256b53ee5279e61c950aaab092b690df5 )
+)
+
+game (
+	name "Race Drivin' (cockpit, rev 3)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv3.zip size 799009 crc b9cc917b md5 6f588301cdd6ffb9b202d038139391e2 sha1 44d447811101be07c18c5043ffaedf4bd1292337 )
+)
+
+game (
+	name "Race Drivin' (cockpit, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv4.zip size 813603 crc 26c7a7a0 md5 cfcb2250856fb1dac18f1f002c7f374a sha1 312dbc219cc8e44c609e00e353c004a1351a1fa3 )
+)
+
+game (
+	name "Race Drivin' (cockpit, British, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivb.zip size 815063 crc 930be5a6 md5 bdd25eb76035292c0f740d07ab730ee0 sha1 279671498d34da7c797e00b19137dae878e3c2d3 )
+)
+
+game (
+	name "Race Drivin' (cockpit, British, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivb4.zip size 814530 crc 4d76af0a md5 b31e8f9f07528f76198ae00016335a71 sha1 1e91651aad010106ccbc9fa8b12a9a6797281240 )
+)
+
+game (
+	name "Race Drivin' (compact, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc.zip size 767471 crc fc299a9f md5 b6caff28a8dab1b5a051fd12333760a2 sha1 aa579c5eab40e1f1c5aaa7db1c98594b38017c72 )
+)
+
+game (
+	name "Race Drivin' (compact, rev 1)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc1.zip size 755529 crc c449c423 md5 512e2b8f96441bff262db5e98306ca70 sha1 78f207382c163b7eec5a9c1d9338f816b6dba6b9 )
+)
+
+game (
+	name "Race Drivin' (compact, rev 2)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc2.zip size 755515 crc 7af02e9f md5 a1549a9b9291c9c02ce9b5fffd2f934f sha1 ae72055d21bb8780683711130228c8d13e6397f1 )
+)
+
+game (
+	name "Race Drivin' (compact, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc4.zip size 767051 crc dbba7042 md5 174732df9230abbba8067cb875ab4891 sha1 67d919001b6c0582541c281b1b464a04f63bc77e )
+)
+
+game (
+	name "Race Drivin' (compact, British, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcb.zip size 768398 crc a6ba19b5 md5 c0b9af3f09fc108629dccf496d70cd0e sha1 5b6b2d7533bd6715f48228e725e67a0495feea31 )
+)
+
+game (
+	name "Race Drivin' (compact, British, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcb4.zip size 767978 crc 4e528519 md5 808e8bb21a05f38ff0d363e7963fce8e sha1 a53df5bf1b88e38fb2323cde5c5a8699c9fcd565 )
+)
+
+game (
+	name "Race Drivin' (compact, German, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcg.zip size 768344 crc 1acaef70 md5 da6bc79982c933811e05f40bf80bbde0 sha1 3ff07ac3fd993d44faa19ccdb34e4abb52c9d815 )
+)
+
+game (
+	name "Race Drivin' (compact, German, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcg4.zip size 767993 crc eeecd2b4 md5 4b6dffd56053ad0a1b365d2459321a44 sha1 70d9e3b59b43301e9a30cb4565018f436132deb9 )
+)
+
+game (
+	name "Race Drivin' (cockpit, German, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivg.zip size 815272 crc e3fa03c4 md5 6988b22457a86f510ecfd1c1fbdc811a sha1 0730a5ac00686d37852e9912ebc0cd213a48ea33 )
+)
+
+game (
+	name "Race Drivin' (cockpit, German, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivg4.zip size 814824 crc 21aed470 md5 a970b864d8e52627c52f692fc95174d2 sha1 101499c357dbef4a31bfabb07f8a1a5c847f4771 )
+)
+
+game (
 	name "Racing Hero (FD1094 317-0144)"
 	year "1989"
 	developer "Sega"
@@ -30459,6 +33819,13 @@ game (
 	year "1980"
 	developer "Nintendo"
 	rom ( name radarscp.zip size 18113 crc d902667f md5 5a6a1e4c68d6c232b0e83a12444f8f41 sha1 96d757bdb49ede9042a7a76422cab8afdc2cbb1f )
+)
+
+game (
+	name "Radar Scope (TRS01)"
+	year "1980"
+	developer "Nintendo"
+	rom ( name radarscp1.zip size 20425 crc 87f25fa4 md5 0c437ed7c453b7f322f829ca25e1fe91 sha1 862507c74082eac43120bb65625858eb12bbc7f1 )
 )
 
 game (
@@ -30553,6 +33920,13 @@ game (
 )
 
 game (
+	name "Raiden"
+	year "1990"
+	developer "Seibu Kaihatsu"
+	rom ( name raiden.zip size 890877 crc 7c672f3b md5 669cf45efe5b51c7db1eab8789f50949 sha1 8f10a0788462eaef4207dc0f88f5887deee05812 )
+)
+
+game (
 	name "Raiden (Alternate Hardware)"
 	year "1990"
 	developer "Seibu Kaihatsu"
@@ -30599,6 +33973,13 @@ game (
 	year "1985"
 	developer "UPL (Taito license)"
 	rom ( name raiders5t.zip size 34725 crc 0f24adce md5 298f3ac7b8a1c3267d5776a4ad413505 sha1 b3abe020eab21b26d83615f6f1a88ec0c71d69d7 )
+)
+
+game (
+	name "Raiga - Strato Fighter (Japan)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name raiga.zip size 765646 crc 3cd0e291 md5 e3d6675c331bc2b90e42be04dab67c3a sha1 db60005181e83c85db7cb87ffceac20b45891e1c )
 )
 
 game (
@@ -31197,6 +34578,13 @@ game (
 )
 
 game (
+	name "Redline Racer (2 players)"
+	year "1987"
+	developer "Cinematronics (Tradewest license)"
+	rom ( name redlin2p.zip size 224176 crc 6bd90636 md5 2cfcb235db4703cbf0031c01291909fc sha1 ef209a5e9639b1daec2d3e2225fec2fd121d7537 )
+)
+
+game (
 	name "Red Robin"
 	year "1986"
 	developer "Elettronolo"
@@ -31302,6 +34690,20 @@ game (
 )
 
 game (
+	name "Rescue Raider"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name rescraid.zip size 88433 crc 54a45f86 md5 51c4315790d606d28fd9c5505084ff7b sha1 2615969ae3be3cd8c6dbae0e95c7f4cb017fec63 )
+)
+
+game (
+	name "Rescue Raider (stand-alone)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name rescraida.zip size 88364 crc 9da81db9 md5 e6f6b9ba374ce19b8b36a598f522e6d2 sha1 4496e99ffdb627d5b03a153b8146f9e17df19ad7 )
+)
+
+game (
 	name "Rescue"
 	year "1982"
 	developer "Stern Electronics"
@@ -31320,6 +34722,13 @@ game (
 	year "2004"
 	developer "Igrosoft"
 	rom ( name resdnt_2a.zip size 1604883 crc 37684002 md5 ae21d87c769676b76b3b8f99208ff5ed sha1 e484f0b19f2c70e9e2c9f0a217c4428a4509ec61 )
+)
+
+game (
+	name "Return of the Invaders"
+	year "1985"
+	developer "Taito Corporation"
+	rom ( name retofinv.zip size 48110 crc bb87612b md5 d0701657e1065a099258b1d458176d14 sha1 974ec9619c55b83d3d767cf9a2b6051de8c9bab5 )
 )
 
 game (
@@ -31481,6 +34890,13 @@ game (
 	year "1986"
 	developer "Sega / Nasco"
 	rom ( name ridleofp.zip size 83575 crc 500bad17 md5 264dbc2fe17d03c3ebd7432f0b7f0718 sha1 40e7243ef98246dcf3695eddbc81d873a2152b47 )
+)
+
+game (
+	name "Rim Rockin' Basketball (V2.2)"
+	year "1991"
+	developer "Strata/Incredible Technologies"
+	rom ( name rimrockn.zip size 916426 crc c001d28e md5 55ad31a7f1d397e8c9c5ca557fe9a943 sha1 0c795b7ef4d65fec3ff6f7eaf58f59f71f48429d )
 )
 
 game (
@@ -31687,6 +35103,76 @@ game (
 )
 
 game (
+	name "Road Blasters (upright, rev 4)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst.zip size 563326 crc 2d2d2b42 md5 c414af23b79082e63d9ba52495e2c730 sha1 a526f4dc87013bd4114b496ec033a2479ad3c3ec )
+)
+
+game (
+	name "Road Blasters (upright, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst1.zip size 563485 crc a856d61c md5 3193bda263da546817f6da87b3152e4e sha1 690700aa8991b86488df5a747a7308edc8e5e9a7 )
+)
+
+game (
+	name "Road Blasters (upright, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst2.zip size 563464 crc 969c505a md5 fdc7979e08f9be39492a85b5b8a62b29 sha1 2d39aa5803adbc6d75754f4752f8dd497e6e294b )
+)
+
+game (
+	name "Road Blasters (upright, rev 3)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst3.zip size 563316 crc 96a5fe1c md5 58f8fd18ddd6def0168567e40ff058ef sha1 c731f636b08806aa832609dd5c03539e4949ef1c )
+)
+
+game (
+	name "Road Blasters (cockpit, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstc.zip size 563313 crc b9d097c0 md5 34ed4bb77961447ef4e156063723e025 sha1 d8869a819f4975e16f1501e8deb3df2b4302fe78 )
+)
+
+game (
+	name "Road Blasters (cockpit, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstc1.zip size 563195 crc a4dd373c md5 d3eb0d0269621d5dc2e2df81b47cca46 sha1 8302f32571090f0b88173ac99345c5077e3aa2cd )
+)
+
+game (
+	name "Road Blasters (cockpit, German, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstcg.zip size 561941 crc 04d787f2 md5 c40406ed574c9ed67a66e7287b3707a6 sha1 61806c385708171c4d322d099f6ec342a5ab1af9 )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 3)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg.zip size 562120 crc a4583e14 md5 6f7e609668483f30af289817f660a929 sha1 4b966a4bd137da73d6b89473423bfde77b1dd826 )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg1.zip size 562239 crc 98bf392f md5 7cac89e92fbafee00d78dae560367dd6 sha1 cb1abef70f2a6289ee204744ad5d44653cfc739e )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg2.zip size 562276 crc 81343882 md5 e7551a975dd0d52ef226a6adc470cf70 sha1 52ff559cc50a65dc13be716ec7f973a8604b50e8 )
+)
+
+game (
 	name "Road Fighter (set 1)"
 	year "1984"
 	developer "Konami"
@@ -31705,6 +35191,27 @@ game (
 	year "1977"
 	developer "Midway"
 	rom ( name roadrunm.zip size 6013 crc 60d53e98 md5 79bec8cf2c10fb135671c0e55fcfce69 sha1 49c01cd27b86cc3b4648d468599996509145abde )
+)
+
+game (
+	name "Road Runner (rev 2)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn.zip size 520222 crc 767627a2 md5 966e77448e31f80f7839ce88a0cb24b1 sha1 0c65d1bc78f61d3ca387a8ab6aa8d9feb48d75b7 )
+)
+
+game (
+	name "Road Runner (rev 1)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn1.zip size 520209 crc 53b4d821 md5 6e8686aaea3d9d79eb4f468ef4ac4b33 sha1 49a2f06c13bc81f8ac4379c9917c3ba23152394b )
+)
+
+game (
+	name "Road Runner (rev 1+)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn2.zip size 520172 crc 4119b5a6 md5 2d74d29e7fa77f33023c8b90d7d402de sha1 9ed76ba2a49451e2efa3ce5b4bd6c87268302914 )
 )
 
 game (
@@ -32050,6 +35557,27 @@ game (
 )
 
 game (
+	name "MTV Rock-N-Roll Trivia (Part 2)"
+	year "1986"
+	developer "Triumph Software Inc."
+	rom ( name rocktrv2.zip size 142645 crc 5bd912da md5 9ee397b766436c2430d5e8324ef59ff8 sha1 eee89b219e1a69f8125126217bd3c00ec0fd4f75 )
+)
+
+game (
+	name "Roc'n Rope"
+	year "1983"
+	developer "Konami"
+	rom ( name rocnrope.zip size 50109 crc ec7750e3 md5 7375f0b315c719c55e24b014222e39a2 sha1 c081576af46aa5db220d9602923ac57918e02928 )
+)
+
+game (
+	name "Roc'n Rope (Kosuka)"
+	year "1983"
+	developer "Konami / Kosuka"
+	rom ( name rocnropek.zip size 50124 crc 5f5cf42d md5 f60d1564320b18b14b53bf1ef41ad1a3 sha1 f806eecc0051cc7b340fc543890c89c69fa233f0 )
+)
+
+game (
 	name "Rod-Land (World)"
 	year "1990"
 	developer "Jaleco"
@@ -32288,6 +35816,20 @@ game (
 )
 
 game (
+	name "Royal Card (Austrian, set 5)"
+	year "1991"
+	developer "TAB Austria"
+	rom ( name royalcrdd.zip size 28308 crc 2b8db133 md5 bf9e33c7c7164e53a740a6334cadddc5 sha1 cc264e84151d33353a6e606fc7d098a97095953e )
+)
+
+game (
+	name "Royal Card (Austrian, set 6)"
+	year "1991"
+	developer "TAB Austria"
+	rom ( name royalcrde.zip size 53430 crc 45d22a6f md5 0ea2a42bd0d7dc44b4b26ea1c4726089 sha1 72df27224707b1fc698f2fb9878fa9a79c8b3778 )
+)
+
+game (
 	name "Royal Mahjong (Falcon bootleg, v1.01)"
 	year "1982"
 	developer "bootleg"
@@ -32470,10 +36012,24 @@ game (
 )
 
 game (
+	name "R-Type (US)"
+	year "1987"
+	developer "Irem (Nintendo of America license)"
+	rom ( name rtypeu.zip size 386918 crc 3fb6dc37 md5 117793ac2a6a68a7fdeee5f365c16451 sha1 68ed7db1209e31f2b32a2b67e533a4651783b2d9 )
+)
+
+game (
 	name "Rug Rats"
 	year "1983"
 	developer "Nichibutsu"
 	rom ( name rugrats.zip size 32115 crc eb40a48a md5 443775ad1e7b3b2d5b66c68511b946e6 sha1 5d3e8846a939122d7e7f385721fd765775b25279 )
+)
+
+game (
+	name "The Rumble Fish"
+	year "2004"
+	developer "Sammy / Dimps"
+	rom ( name rumblef.zip size 109669686 crc b5219d1b md5 717e10fe5c8431fc4c2a38a63352602d sha1 6a1d284b1bd3bbd53a9d74d4b2151b382297a057 )
 )
 
 game (
@@ -32530,6 +36086,13 @@ game (
 	year "1986"
 	developer "Capcom"
 	rom ( name rushcrsh.zip size 353470 crc 9c7d068c md5 116dd0666117f825e308248c70fd28a7 sha1 17b753a74e9802baa1086bba062750bce3b364e1 )
+)
+
+game (
+	name "Rushing Heroes (ver UAB)"
+	year "1996"
+	developer "Konami"
+	rom ( name rushhero.zip size 18709050 crc be44d8c4 md5 09befc0fb920ec7aafbd1df4a014d059 sha1 a25a53969ea5ad140a7d7e81f3227e82b4b3f7f2 )
 )
 
 game (
@@ -32631,6 +36194,20 @@ game (
 )
 
 game (
+	name "Strikers 1945 (World)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945.zip size 5455851 crc 3531fb50 md5 d05941ecbabeacdc15dcdd46fc321f96 sha1 588e673cd5e486f53ef9e0b9c8e49f000981acae )
+)
+
+game (
+	name "Strikers 1945 (Japan / World)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945a.zip size 5456220 crc 78fc492a md5 5adee769a00469661c5ea8a1aeba64bd sha1 1e4ad7a208e33ae29e046655e55f71100969cb67 )
+)
+
+game (
 	name "Strikers 1945 (Hong Kong, bootleg)"
 	year "1995"
 	developer "bootleg"
@@ -32652,10 +36229,24 @@ game (
 )
 
 game (
+	name "Strikers 1945 (Japan)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945j.zip size 5455898 crc 164c1239 md5 8ad9d7b756155cd91ffb67bc2d3eb5a8 sha1 7f5159015bc7458531187436474e3a876fc638df )
+)
+
+game (
 	name "Strikers 1945 (Japan, unprotected)"
 	year "1995"
 	developer "Psikyo"
 	rom ( name s1945jn.zip size 5224554 crc 25eaa4e1 md5 5e78735a5e7cc55a39168de418b75d9d sha1 aed3eb325c87f058dd4a446352777e9f84b24c1e )
+)
+
+game (
+	name "Strikers 1945 (Korea)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945k.zip size 5456059 crc dd9dcf23 md5 e7c9c16bae8473528d4981c2aec4b4a8 sha1 202866be68412cd2fb02389cbc0b7ef04cba5256 )
 )
 
 game (
@@ -32799,6 +36390,13 @@ game (
 )
 
 game (
+	name "Sai Yu Gou Ma Roku (Japan)"
+	year "1988"
+	developer "Technos Japan"
+	rom ( name saiyugou.zip size 573861 crc c8929d6e md5 915ab13d68e8b7f2c4045275283c0bee sha1 c78481a2670a9e7fd1a60e8979793500da05042e )
+)
+
+game (
 	name "Sai Yu Gou Ma Roku (Japan bootleg 1)"
 	year "1988"
 	developer "bootleg"
@@ -32831,6 +36429,27 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name salamandj.zip size 271405 crc ff136319 md5 2964170089193123098de5de8842a2d8 sha1 4c1eb0c344939916c1b6dcfec78d82d5054b133e )
+)
+
+game (
+	name "Salary Man Champ (GCA18 VER. JAA)"
+	year "2000"
+	developer "Konami"
+	rom ( name salarymc.zip size 63570 crc e2bcf892 md5 06a65b81aadc7f288a1e61a7a029225c sha1 65a5c470f0b0a47cfc16ba7de68491d59fbe6932 )
+)
+
+game (
+	name "Same! Same! Same! (2 player alternating ver.)"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame.zip size 532879 crc 758c8b6b md5 bf565d35681c78b1a590233e79af9db4 sha1 2e682c003f2af1cb3b114b9d5d62ca106bc8bdc4 )
+)
+
+game (
+	name "Same! Same! Same!"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame2.zip size 533515 crc f5dd6d10 md5 194b2d496ee720a8860d599e42f441b7 sha1 0af58fee5c0f7bdc79ef95277a9267eafdeaa4c9 )
 )
 
 game (
@@ -32974,6 +36593,13 @@ game (
 )
 
 game (
+	name "Sarge"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name sarge.zip size 84020 crc 19794f30 md5 c52f5e03f7c539c77f5ae573abd079a6 sha1 68d891cc01d5be32931f167816d040217b6924ed )
+)
+
+game (
 	name "Saru-Kani-Hamu-Zou (Japan)"
 	year "1997"
 	developer "Kaneko / Mediaworks"
@@ -33093,6 +36719,13 @@ game (
 )
 
 game (
+	name "Super Bike (DK conversion)"
+	year "1984"
+	developer "Century Electronics"
+	rom ( name sbdk.zip size 18655 crc 42f00b04 md5 aecfb0d96cf02d4c49c009dc75bdebe3 sha1 b1f1dfce136167969bb424017b7cb6febd972694 )
+)
+
+game (
 	name "Super Bishi Bashi Championship (ver JAA, 2 Players)"
 	year "1998"
 	developer "Konami"
@@ -33167,6 +36800,13 @@ game (
 	year "1990"
 	developer "UPL"
 	rom ( name sbsgomo.zip size 1365389 crc 58f246f5 md5 399c4ba5b7320004496cfd847477f240 sha1 4e0eb865a329eb7791665058f8285fbe671bab4e )
+)
+
+game (
+	name "Space Bugger (set 2)"
+	year "1981"
+	developer "Game-A-Tron"
+	rom ( name sbuggera.zip size 12259 crc 09b62d39 md5 598b33409accb5ad40046599e9401269 sha1 29283b8b93dd50dfb00f1a66343c5c27628a3a8b )
 )
 
 game (
@@ -33379,6 +37019,13 @@ game (
 )
 
 game (
+	name "Scramble (Karateko, French bootleg)"
+	year "1981"
+	developer "bootleg (Karateko)"
+	rom ( name scramblebf.zip size 15388 crc c0edc825 md5 4070ebae7777e87e3c50035c7c07a251 sha1 03ad46b442424cf186299f274dd9d60b19c71a6b )
+)
+
+game (
 	name "Scramble (Stern Electronics)"
 	year "1981"
 	developer "Konami (Stern Electronics license)"
@@ -33428,10 +37075,31 @@ game (
 )
 
 game (
+	name "SD Fighters (Korea)"
+	year "1996"
+	developer "SemiCom"
+	rom ( name sdfight.zip size 2085175 crc 5505567e md5 d2cb25ca81746b7e65625ae5cf718c9c sha1 0f0e20fdfdea9582edad5b3af05dead474a25d03 )
+)
+
+game (
 	name "SD Gundam Psycho Salamander no Kyoui"
 	year "1991"
 	developer "Banpresto / Bandai"
 	rom ( name sdgndmps.zip size 1492205 crc 21ef9783 md5 70ef6141c8748ed19dd38007d603a12e sha1 c9bcf42cf112266b541734945fa5dd7b99cbf89d )
+)
+
+game (
+	name "SDI - Strategic Defense Initiative (Japan, old, System 16A, FD1089B 317-0027)"
+	year "1987"
+	developer "Sega"
+	rom ( name sdi.zip size 366622 crc 558f377a md5 a60733a012c3a05cf0e53e069d138033 sha1 98a49da7b72a35b016dde057cdc9e325925adadc )
+)
+
+game (
+	name "SDI - Strategic Defense Initiative (System 16B, FD1089A 317-0028)"
+	year "1987"
+	developer "Sega"
+	rom ( name sdib.zip size 368982 crc 4e0fc1d9 md5 e3ec9c8e9c31ada3d49d79b214f0ded7 sha1 596386b0b7383e0b426747f67742a386af798b9e )
 )
 
 game (
@@ -33638,6 +37306,13 @@ game (
 )
 
 game (
+	name "MuHanSeungBu (SemiCom Baseball) (Korea)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name semibase.zip size 2020618 crc d21a9c65 md5 86efa50c202de62ebaf78f90c8338b71 sha1 cf9667d40a08b4300fac3d586afd101cc091ec3f )
+)
+
+game (
 	name "Sengeki Striker (Asia)"
 	year "1997"
 	developer "Kaneko / Warashi"
@@ -33715,6 +37390,13 @@ game (
 )
 
 game (
+	name "Sente Diagnostic Cartridge"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name sentetst.zip size 9743 crc 1f2628e4 md5 dd11377d68a60831abe5fd295f98f455 sha1 c869c65e11f2a466ed0ac268aa3889ba05f701e1 )
+)
+
+game (
 	name "Sex Triv"
 	year "1985"
 	developer "Status Games"
@@ -33750,6 +37432,13 @@ game (
 )
 
 game (
+	name "Street Fighter II: The World Warrior (World 910522)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2.zip size 3551675 crc 57aa0ffe md5 bd33f8bfe89c2c4270a398cb77545eee sha1 ad7d7527ff7b2c0b0b5e1f7acd6e4fcfda1fbd0f )
+)
+
+game (
 	name "Street Fighter II': Champion Edition (Accelerator!, bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -33764,6 +37453,41 @@ game (
 )
 
 game (
+	name "Street Fighter II': Champion Edition (World 920313)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ce.zip size 3615435 crc 8d0ac6df md5 db9414707a2fa816b05608251784d08b sha1 f6ebbc9926859f0ce68ee911a4433ae39dca86bf )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (Japan 920513)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2cej.zip size 3588007 crc 2ac02184 md5 b7561189cd367c611b6e0bd3c1881012 sha1 0dbcfd8145f5657c1dc2f4d59c3fad81ec55802e )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920313)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceua.zip size 3615430 crc 3741a692 md5 9df4439e0d47eeb9aaaa5df6a537813c sha1 6c25f0d925bb087bbb72824e1e9e8b6b708016db )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920513)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceub.zip size 3584615 crc ec4d46c2 md5 36838d3ecfa8ff219c7a6ed7f3071318 sha1 46ef3b3fc5e574f3f1784ffd088f8420b26cebbd )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920803)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceuc.zip size 3584467 crc e108d380 md5 69380318e4572d762c35453621a4520a sha1 21970c644f1dff727197a173b5ccc7bc48e7a278 )
+)
+
+game (
 	name "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -33771,10 +37495,59 @@ game (
 )
 
 game (
+	name "Street Fighter II: The World Warrior (World 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2eb.zip size 3512463 crc 8f8e1d03 md5 4707c2b1aab579fa01b021e2438caaa4 sha1 6bd8f40e40c2356623bf6c9f8e48cec796885641 )
+)
+
+game (
 	name "Street Fighter II: The World Warrior (TAB Austria, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2ebbl.zip size 3751599 crc 5b7e4499 md5 02be9805eadb42c1bd76c16d84ac3916 sha1 b51617ac5ef85750f3ed93f5aef71e1cfd5a5977 )
+)
+
+game (
+	name "Street Fighter II': Hyper Fighting (World 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hf.zip size 3640194 crc fe834e3b md5 aa753de798080d48044e4df1cbd2e44a sha1 d0bad63d0e4f81f59c1da149c04a7be3a2f8819d )
+)
+
+game (
+	name "Street Fighter II' Turbo: Hyper Fighting (Japan 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hfj.zip size 3638945 crc 66ddf02d md5 94f90aa02b88718889194ce9a25c289a sha1 fe9ca624e9e36a5ef806424bd62c670bae6ac39c )
+)
+
+game (
+	name "Street Fighter II': Hyper Fighting (USA 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hfu.zip size 3640194 crc 224930f7 md5 bcab090c17ea6c33452ddc3c2e08602b sha1 b3191b1de2ae813a563c95b16f32fb749e6bef3f )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 911210)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2j.zip size 3511544 crc 75371e93 md5 13c632c9d70f4493158bffc4a847593b sha1 20e71e3a6079d4fe219887eb62ceb3dba1084b98 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ja.zip size 3512477 crc e6555abb md5 d92a038afe5bd97aeeda82dbc1bb9de4 sha1 738c8f182cd26620b4a425526e05c3cfe6bd1128 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 910306)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2jc.zip size 3548274 crc 35e03d8c md5 566a484368a755a02b57557e38f2c1a4 sha1 f15ddab853bcde97f8df32fbe53f3be272b4dcf7 )
 )
 
 game (
@@ -33859,6 +37632,55 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name sf2thndr.zip size 3512251 crc 031f8c19 md5 f58e436c93e63d04f80538b411a7563f sha1 6e89e4b15593ba33ade01c199334233e101eb165 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910206)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ua.zip size 3510008 crc 87816e2c md5 96f9e63e7c94042c5e5be31e26673eeb sha1 c29083dbeedd3646208522c134b662edd74fbec0 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ub.zip size 3512465 crc 5095ee00 md5 40cb260ee3561abf38aeb8078609b9c3 sha1 b8ea4b8cc62a40f464d3134d7ad07889c240a8ed )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910318)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ud.zip size 3549569 crc 6aecfce0 md5 f1ab63a3581e5f0a20fe8ec9d9204534 sha1 8e42eaf9cdc28e4020e04c8bdd905fc70562a3c9 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910228)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ue.zip size 3536086 crc 6d60ffd9 md5 e343202429c477119cc9c7a0b6a28762 sha1 29194f22d7dc2f546fd9ab0100ea2560a1373f9d )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910411)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2uf.zip size 3511429 crc 4b60faef md5 4b1b3555acf34abbda2996973bb82780 sha1 92b1d04559c6cd6cbf84e85ccd7e74a3e5475fef )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910522)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ui.zip size 3541261 crc 7964615f md5 ac335852247a3c7d512449f0a13889d0 sha1 af0d2572611636e7247e02946ef19ce9aefc4e9e )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 911101)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2uk.zip size 3559569 crc f9ad7298 md5 b1aad3354656ca978c890c418f7dd7ea sha1 b23a798678d2d7f9f13867bc06ebdcefea4218a9 )
 )
 
 game (
@@ -34198,6 +38020,13 @@ game (
 )
 
 game (
+	name "Street Fighter (Japan) (protected)"
+	year "1987"
+	developer "Capcom"
+	rom ( name sfj.zip size 1152796 crc 649a32b3 md5 eba7a30105325d163b17468c50b308f9 sha1 24f6d2e26b73fa5ed63e4ad81be60b3404259a82 )
+)
+
+game (
 	name "Super Free Kick (set 1)"
 	year "1988"
 	developer "Haesung/HJ Corp"
@@ -34208,6 +38037,13 @@ game (
 	name "Super Free Kick (set 2)"
 	developer "Haesung"
 	rom ( name sfkicka.zip size 87355 crc 61e43e47 md5 a141e34b083bab65b4d1dfe5f01a14f7 sha1 c96881eb8b902b78e53a8437dd69f8f3915bb144 )
+)
+
+game (
+	name "Street Football"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name sfootbal.zip size 47005 crc c11807d3 md5 661d9363da39bfad6cd619f756d728e8 sha1 1004c2beb15ff2072b2dc72959fe82fcf96acbb7 )
 )
 
 game (
@@ -34369,6 +38205,13 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sfu.zip size 1153920 crc 15e45dde md5 c73a8bca6aff13a576f354ba74891a40 sha1 a57c5f97cd85da1beecca65aa7a92692673d699f )
+)
+
+game (
+	name "Street Fighter (US, set 2) (protected)"
+	year "1987"
+	developer "Capcom"
+	rom ( name sfua.zip size 1152791 crc 0812c823 md5 f60641ec395d951414818443ac1df299 sha1 e723b915ab78497ecd9133ea1a7b478835c1258f )
 )
 
 game (
@@ -34638,6 +38481,13 @@ game (
 )
 
 game (
+	name "Shackled (US)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name shackled.zip size 277237 crc 45a28ff0 md5 9bd250cdae5b0a40bc4653c34e108e5b sha1 1c34a5e1383cb3fa9df92b23d2d3089d8aaba156 )
+)
+
+game (
 	name "Shadow Force (US Version 2)"
 	year "1993"
 	developer "Technos Japan"
@@ -34813,6 +38663,20 @@ game (
 )
 
 game (
+	name "Space Harrier (Rev A, 8751 315-5163A)"
+	year "1985"
+	developer "Sega"
+	rom ( name sharrier.zip size 755119 crc db78b1c2 md5 3ad5238a51d7455e4d84f475bec44f84 sha1 45247b44f4fb6d6c1e8f33cf8024ad0a564f0e79 )
+)
+
+game (
+	name "Space Harrier (8751 315-5163)"
+	year "1985"
+	developer "Sega"
+	rom ( name sharrier1.zip size 754749 crc 32151dba md5 3aac6ee01ceb1d951dd90c9538341a8c sha1 7545b24d871a4516f53037dbdf0194e6b0b190d6 )
+)
+
+game (
 	name "Shadow Dancer (bootleg)"
 	year "1989"
 	developer "bootleg"
@@ -34932,6 +38796,13 @@ game (
 )
 
 game (
+	name "Shinobi (Beta bootleg)"
+	year "1987"
+	developer "bootleg (Beta)"
+	rom ( name shinoblb.zip size 487396 crc 9af08032 md5 fc45bfa522cc912780f3a13dfb72a8c2 sha1 e0447657c738cf4d2a0585f60b521cb0a82db900 )
+)
+
+game (
 	name "Shinobi (Star bootleg, System 16A)"
 	year "1987"
 	developer "bootleg (Star)"
@@ -35037,6 +38908,13 @@ game (
 )
 
 game (
+	name "Shooting Gallery"
+	year "1984"
+	developer "Seatongrove Ltd (Zaccaria license)"
+	rom ( name shootgal.zip size 18531 crc 16b5a427 md5 0af2f4fa102d9def57b9251fa318c84e sha1 7631ec033169132d0bfab8d7687a464289e394b5 )
+)
+
+game (
 	name "Shoot Out (US)"
 	year "1985"
 	developer "Data East USA"
@@ -35090,6 +38968,19 @@ game (
 	year "2000"
 	developer "Astro Corp."
 	rom ( name showhand.zip size 625050 crc dd38aa67 md5 7ef3866adb91b90400a947d92a7bb64d sha1 77f71905774a9a8bfb8d08972b32927972a028e8 )
+)
+
+game (
+	name "Shrike Avenger (prototype)"
+	developer "Bally/Sente"
+	rom ( name shrike.zip size 92846 crc c4ae135a md5 d8aa70cc6abdc529741cfa4533d6ec61 sha1 14ec599e7318f0c10cff76d158a2826fb2b924a0 )
+)
+
+game (
+	name "Shooting Master (EVG, 8751 315-5159a)"
+	year "1985"
+	developer "Sega / EVG"
+	rom ( name shtngmste.zip size 168288 crc eab105ca md5 51dce6f4e1b69bff1ba4125605ee514d sha1 934d7c6cacdc0c787b4b381ce2aa177520a92d26 )
 )
 
 game (
@@ -35219,10 +39110,24 @@ game (
 )
 
 game (
+	name "Side Pocket (World)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name sidepckt.zip size 89366 crc 38aa9b23 md5 81db4eb6bf15fe908e58d621e69bfc4a sha1 d6f6fe1dc698b311285a644082fd6e4c0dffb065 )
+)
+
+game (
 	name "Side Pocket (bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name sidepcktb.zip size 92004 crc f1634e80 md5 efff14e4dfefbd4bfea96c0ab8fc7310 sha1 4b268cdd483a0574bb7889f19e8eb6a885b52b2f )
+)
+
+game (
+	name "Side Pocket (Japan)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name sidepcktj.zip size 77606 crc c35bae25 md5 8e593f1de56d8065b952ab486f5072a3 sha1 4806b2615a0b36b825ba3c0e1c45d2bb33249837 )
 )
 
 game (
@@ -35427,6 +39332,20 @@ game (
 )
 
 game (
+	name "Sukeban Jansi Ryuko (set 2, System 16B, FD1089B 317-5021)"
+	year "1988"
+	developer "White Board"
+	rom ( name sjryuko.zip size 383635 crc 7ee5f1ad md5 425d150e3b3d0a6da11d0046c5605cb8 sha1 39f19483527ae8431717409c1193f99d2423c339 )
+)
+
+game (
+	name "Sukeban Jansi Ryuko (set 1, System 16A, FD1089B 317-5021)"
+	year "1987"
+	developer "White Board"
+	rom ( name sjryuko1.zip size 360577 crc c5642502 md5 97fb6dcececbb63bf38989739f9d4642 sha1 877b2ec01840fb166a5560c641a36ece5f80276a )
+)
+
+game (
 	name "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)"
 	year "1988"
 	developer "hack"
@@ -35452,6 +39371,20 @@ game (
 	year "1996"
 	developer "Kyle Hodgetts / ICE"
 	rom ( name skimaxx.zip size 3208270 crc ea532447 md5 ab34b55b17aac77ece11589085c3d624 sha1 48733de55503ddf0ae78fdbfbe6880adf87f806d )
+)
+
+game (
+	name "The Irem Skins Game (US set 1)"
+	year "1992"
+	developer "Irem America"
+	rom ( name skingame.zip size 1811540 crc 285897c1 md5 4e494d8acec99ab3d15e72b426e0f7ed sha1 193f0f76d8762835b3365f88117d80075f2c8ea2 )
+)
+
+game (
+	name "The Irem Skins Game (US set 2)"
+	year "1992"
+	developer "Irem America"
+	rom ( name skingame2.zip size 1811433 crc b6b4b269 md5 a5300994022ee8aa4a1c0f4d43eacc58 sha1 9c89fe8c1b7335ac1ae707a6d8deab6fca34dc64 )
 )
 
 game (
@@ -35707,6 +39640,20 @@ game (
 )
 
 game (
+	name "Saturday Night Slam Masters (World 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name slammast.zip size 6588432 crc eaac25c5 md5 2469cc51ea42952fd4338b38cc2028cf sha1 19d6bbeaf734d6823dc40759a45c49c9e1287bd3 )
+)
+
+game (
+	name "Saturday Night Slam Masters (USA 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name slammastu.zip size 6588677 crc a5bb0db0 md5 a2a12d836a77f4368ce4d40cfa315b30 sha1 78a4e743d41858f959ab888c6e2c3921658d247e )
+)
+
+game (
 	name "Slap Fight (Japan set 1)"
 	year "1986"
 	developer "Toaplan / Taito"
@@ -35788,6 +39735,13 @@ game (
 	year "1982"
 	developer "Century II"
 	rom ( name slithera.zip size 16819 crc 5f40cafd md5 2c6bee5b1bc4f30897e159598f86c611 sha1 34d4ae5a3cec0d9e767c4f72c66a9c365e9ecea1 )
+)
+
+game (
+	name "Sliver"
+	year "1996"
+	developer "Hollow Corp"
+	rom ( name sliver.zip size 15501022 crc bfedd29a md5 b42445d774b2363ce4489831904bd30d sha1 0a7166de4c540469039e4c8212620faa6624acca )
 )
 
 game (
@@ -36007,6 +39961,20 @@ game (
 )
 
 game (
+	name "Snake Pit"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name snakepit.zip size 47841 crc c80ebdf2 md5 e417dfa224b1616022e24a8aa01a242d sha1 d42a855cdd14396e58a6c80197b7942557140b9c )
+)
+
+game (
+	name "Snacks'n Jaxson"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name snakjack.zip size 59038 crc c5beec9a md5 59d0aa1101542d25ba5f2a8c51f6363e sha1 9ddee21b0c7b433db72b035a6729494e229ae0bd )
+)
+
+game (
 	name "Snap Jack"
 	year "1982"
 	developer "Universal"
@@ -36053,6 +40021,13 @@ game (
 	year "1990"
 	developer "Toaplan"
 	rom ( name snowbros.zip size 289681 crc af8a4129 md5 216801a573f1a29d3a051af3ae4e6651 sha1 c3bdfa5acd020f201cdd17a8466e3a55074043c7 )
+)
+
+game (
+	name "Snow Brothers 3 - Magical Adventure"
+	year "2002"
+	developer "Syrmex"
+	rom ( name snowbros3.zip size 2094016 crc b351a896 md5 f7c9f7d6856e0e7c6ea252e06341890a sha1 ef2d4ed4ce58f46d72e72f3df2ad3c99b91f2be6 )
 )
 
 game (
@@ -36476,6 +40451,20 @@ game (
 )
 
 game (
+	name "Space Invaders DX (US, v2.1)"
+	year "1994"
+	developer "Taito Corporation"
+	rom ( name spacedx.zip size 530613 crc 4d8b0176 md5 ec93c383cea9e6e9ad496bd3931a1d99 sha1 a679c33fd0e56e9a7319dcfeb0de14e1e83b9374 )
+)
+
+game (
+	name "Space Invaders DX (Japan, v2.1)"
+	year "1994"
+	developer "Taito Corporation"
+	rom ( name spacedxj.zip size 530576 crc 3699968b md5 9459ddbfc5232e50a910a7f3d860319c sha1 74ff1780e1f806868c75a8c0db92bd066fc5090d )
+)
+
+game (
 	name "Space Invaders DX (Japan, v2.0)"
 	year "1994"
 	developer "Taito Corporation"
@@ -36532,6 +40521,13 @@ game (
 )
 
 game (
+	name "Space Fortress (Zaccaria)"
+	year "1981"
+	developer "Cinematronics (Zaccaria license)"
+	rom ( name spaceftr.zip size 7976 crc 7028aea6 md5 a8314372211ec87783a48c43fc7738c0 sha1 353d7cf5e7972e1b0b586a00daafb741be6a996a )
+)
+
+game (
 	name "Space Gun (World)"
 	year "1990"
 	developer "Taito Corporation Japan"
@@ -36543,6 +40539,13 @@ game (
 	year "1980"
 	developer "bootleg"
 	rom ( name spacempr.zip size 18098 crc c2dacdd7 md5 db6671285de655d41c69b0a4200e11bb sha1 ada75bd84652a95996715a65c16f4a048fb3c427 )
+)
+
+game (
+	name "Space Odyssey (version 2)"
+	year "1981"
+	developer "Sega"
+	rom ( name spaceod.zip size 39895 crc 2b6e33cd md5 d369ad29c3790e31bfc7604feaa1847a sha1 5535f92d7319d7f375dd483d7b44b185b6cadfd2 )
 )
 
 game (
@@ -36803,6 +40806,13 @@ game (
 )
 
 game (
+	name "Super Dodge Ball (US)"
+	year "1987"
+	developer "Technos Japan"
+	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
+)
+
+game (
 	name "Speak _ Rescue"
 	year "1980"
 	developer "Sun Electronics"
@@ -36852,6 +40862,13 @@ game (
 )
 
 game (
+	name "Speed Racer"
+	year "1995"
+	developer "Namco"
+	rom ( name speedrcr.zip size 9287692 crc eba41560 md5 943d9ad476028ef62bebe04f516b2f7d sha1 d482c59d1f2b4df647e9f365fbfd407f7f68178e )
+)
+
+game (
 	name "Speed Spin"
 	year "1994"
 	developer "TCH"
@@ -36870,6 +40887,13 @@ game (
 	year "1994"
 	developer "Seta"
 	rom ( name speglsht.zip size 3383092 crc 6e79fdfe md5 95d0d2fc3a17549b628961237717215c sha1 773ea02919112f086112d16b787499c167765565 )
+)
+
+game (
+	name "Spelunker II"
+	year "1986"
+	developer "Irem (licensed from Broderbund)"
+	rom ( name spelunk2.zip size 136512 crc 1d55ade1 md5 f86b5da1428876751fd4058baaf27fff sha1 7037d6dc98ac44b459618c68681e7285ed3088cf )
 )
 
 game (
@@ -36964,10 +40988,38 @@ game (
 )
 
 game (
+	name "Spiker"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name spiker.zip size 45190 crc b52b754c md5 a31652f7218a675a8a66a5b52610c0af sha1 b61500e0ac1c9e54e48f1744fa13e917988de3d2 )
+)
+
+game (
 	name "Hec's Spinkick"
 	year "1988"
 	developer "Haesung/Seojin"
 	rom ( name spinkick.zip size 84705 crc 5085b115 md5 6800cf0d4e3bda272b2f2d1eb0fa4930 sha1 7cd9fa82328f2f7c375624e576ea4549e357b2ec )
+)
+
+game (
+	name "Spinal Breakers (World)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrk.zip size 2303016 crc 994052e9 md5 e3950ffff9a6cbc34732de0ded28b045 sha1 4d32fe5c59cab1cec21c6d865bb91eb7cd6e502a )
+)
+
+game (
+	name "Spinal Breakers (Japan)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrkj.zip size 2303143 crc f0346dee md5 da43e83b377ae219a4b32067fb40d1a2 sha1 262f85d681d4933e1130df331b01ab1402b4b154 )
+)
+
+game (
+	name "Spinal Breakers (US)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrku.zip size 2303236 crc eeeccf32 md5 80c9a0ffdbf5155a473004951ec7f26e sha1 4c88fa98c2b6765641e7aaa58e21cbb83a633c29 )
 )
 
 game (
@@ -37158,6 +41210,13 @@ game (
 )
 
 game (
+	name "Sprint 4 (set 2)"
+	year "1977"
+	developer "Atari"
+	rom ( name sprint4a.zip size 6775 crc c64a001c md5 f401bb5aaf4de0558bb5a053e5abd6bb sha1 b9226ba6ae7eea522e5cbecbc4b28758d1d937b2 )
+)
+
+game (
 	name "Sprint 8"
 	year "1977"
 	developer "Atari"
@@ -37214,6 +41273,20 @@ game (
 )
 
 game (
+	name "Spy Hunter 2 (rev 2)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name spyhunt2.zip size 363056 crc 4e509b2d md5 16df0f6b79f2dc33d9d17257bfc7b0ba sha1 c14de08325340a1b6e66eafffbe13472df90c883 )
+)
+
+game (
+	name "Spy Hunter 2 (rev 1)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name spyhunt2a.zip size 360909 crc 377483a0 md5 c5998cce9a36ec23437dcba10cb48eab sha1 08fbfd45c00fcce6db274932f4edf0cf5770eb1f )
+)
+
+game (
 	name "Spy Hunter (Playtronic license)"
 	year "1983"
 	developer "Bally Midway"
@@ -37235,10 +41308,31 @@ game (
 )
 
 game (
+	name "Super Qix (World, Rev 2)"
+	year "1987"
+	developer "Taito"
+	rom ( name sqix.zip size 141696 crc dd4aa61b md5 c47f4c5d2101b115c016578ebe176d48 sha1 1e0e268a3ce841201ca70f8f4d7603539cedf976 )
+)
+
+game (
+	name "Super Qix (bootleg set 1)"
+	year "1987"
+	developer "bootleg"
+	rom ( name sqixb1.zip size 142844 crc 12e11d54 md5 ac9b5a1c10ebae2f502d6cda00480dd9 sha1 7928ec03233181e0bddf1d905b129eee8e068a94 )
+)
+
+game (
 	name "Super Qix (bootleg set 2)"
 	year "1987"
 	developer "bootleg"
 	rom ( name sqixb2.zip size 141929 crc 97d19e7e md5 a64b9f0aea793a52f132757c41d19dea sha1 b9c97c7417b0473d19cbc808fca6914d88ffd78f )
+)
+
+game (
+	name "Super Qix (World, Rev 1)"
+	year "1987"
+	developer "Taito"
+	rom ( name sqixr1.zip size 142184 crc 724f598e md5 464fd6a4a0d87237eeca86a07fbb35d6 sha1 a1b17a84f52b7415d78eddafccc2e7516039e5c7 )
 )
 
 game (
@@ -37277,10 +41371,31 @@ game (
 )
 
 game (
+	name "Super Ranger (bootleg)"
+	year "1988"
+	developer "bootleg"
+	rom ( name srangerb.zip size 185773 crc 3857e5d7 md5 5d7d4ea037179bbec94faad5c1cb4cf5 sha1 40fa2090f37befeb4b2e31570182631d8613aead )
+)
+
+game (
 	name "Super Ranger (WDK)"
 	year "1988"
 	developer "SunA (WDK license)"
 	rom ( name srangerw.zip size 171911 crc 742e1165 md5 e67570b040da314e0585958c3ea6eee0 sha1 a77394cb9034830c0125f960c570daeadb976e70 )
+)
+
+game (
+	name "Super Real Darwin (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name srdarwin.zip size 191667 crc f5949dc6 md5 d3838f3c994a0c72ac9053308cd92ba3 sha1 f2fb0d3b28e230ed5d846b94d97f9674d8991cc7 )
+)
+
+game (
+	name "Super Real Darwin (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name srdarwinj.zip size 191660 crc 56584a3f md5 eeaae89565467d409e66eac16db9d3b9 sha1 a0693a116dbefff148fd57a623de098187f2024b )
 )
 
 game (
@@ -37589,6 +41704,41 @@ game (
 	year "1996"
 	developer "SNK"
 	rom ( name ssideki4.zip size 14986133 crc f781ef5d md5 d975a9d4b2f568fbe6f888d87ea8497c sha1 cb241a683f41151ba2ff5f88ecbf0c2ebb6f7e78 )
+)
+
+game (
+	name "SSI Poker (v2.4)"
+	year "1988"
+	developer "SSI"
+	rom ( name ssipkr24.zip size 11818 crc a87dc911 md5 ed34f9f2aec532a0bf20b156f7ab2ea9 sha1 715c7ef9cdd73edefc95fdf6dfbdbeb2679eb61f )
+)
+
+game (
+	name "SSI Poker (v3.0)"
+	year "1988"
+	developer "SSI"
+	rom ( name ssipkr30.zip size 12493 crc 36b083e1 md5 f929dc3f4cce277db1d7a19acf1759ad sha1 873a229eaca23dde6b3e27dcc991a7072849b431 )
+)
+
+game (
+	name "SSI Poker (v4.0)"
+	year "1990"
+	developer "SSI"
+	rom ( name ssipkr40.zip size 12647 crc 58df438e md5 7c13938ed979455ab8b4167581f001c9 sha1 801453e80636adb069266df9ff17e5d020c76673 )
+)
+
+game (
+	name "Super Slam (set 1)"
+	year "1993"
+	developer "Playmark"
+	rom ( name sslam.zip size 1566942 crc 96bd8f82 md5 11784419dbd4e8c640d3fde16f9d0cc5 sha1 176ec29bba753504f650c42983a6ba4d6135c43b )
+)
+
+game (
+	name "Super Slam (set 2)"
+	year "1993"
+	developer "Playmark"
+	rom ( name sslama.zip size 1566934 crc 4493c327 md5 33e0fb1dd87444b2e17910843eaec3b1 sha1 9b85940059bdd55b52d22f742d336947c5bf151a )
 )
 
 game (
@@ -38019,10 +42169,59 @@ game (
 )
 
 game (
+	name "Triv Two"
+	year "1984"
+	developer "Status Games"
+	rom ( name statriv2.zip size 45382 crc 0c078504 md5 19cbb783850310f2f78db5b7637d1615 sha1 2b120b68ab9ddae04be493fb7f5d6034609702b0 )
+)
+
+game (
+	name "Triv Two (Vertical)"
+	year "1985"
+	developer "Status Games"
+	rom ( name statriv2v.zip size 46378 crc 5f74a27a md5 87621c97e475b43e30c6bdb4bbef6d72 sha1 2385d80fc199efac9308a252c52f45ceadb282c9 )
+)
+
+game (
 	name "Triv Four"
 	year "1985"
 	developer "Status Games"
 	rom ( name statriv4.zip size 39111 crc 76f31bee md5 4b8aa025fe9d375e41cc671f1d23cd77 sha1 7bca244ff295b37bbff85cb8bbc9b75bc8ec9d9f )
+)
+
+game (
+	name "Status Black Jack (V1.0c)"
+	year "1981"
+	developer "Status Games"
+	rom ( name statusbj.zip size 3839 crc cdcaf335 md5 ceb1523bfb87b5a0965aaf9a58cb6a24 sha1 7052b932a1e69a1f726aaa78f7413da71b75c8a9 )
+)
+
+game (
+	name "Saint Dragon"
+	year "1989"
+	developer "Jaleco"
+	rom ( name stdragon.zip size 1062881 crc 4f83a544 md5 723158a4333a189deea1815d2f2711cc sha1 38fbd713ff16f5b9e20c6823c22e37be76f8e8cc )
+)
+
+game (
+	name "Steel Talons (rev 2)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltal.zip size 884903 crc eb4e4899 md5 fa774768b7da0e3cc49e6b21d293803d sha1 008617283017d2ac1d8f7342914429d854860ea8 )
+)
+
+game (
+	name "Steel Talons (rev 1)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltal1.zip size 884374 crc be8312ef md5 1ccd53084276f5afc953c8a18b070d1a sha1 b3bd2ea9dae3f13e87e604d0bf95561ce41606f9 )
+)
+
+game (
+	name "Steel Talons (German, rev 2)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltalg.zip size 885021 crc 866be43c md5 7246964729cfd3a81b33eed4c1fe939b sha1 9a50a9a2850a13ec83a4427057a64b5d839d677a )
 )
 
 game (
@@ -38117,10 +42316,24 @@ game (
 )
 
 game (
+	name "Stocker (3/19/85)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name stocker.zip size 31209 crc a30d8761 md5 32be5430265d8c249cad8aaee37dbb32 sha1 7f644a7791dea5f1de73ed9c839f7a6f389e0d66 )
+)
+
+game (
 	name "Super Toffy"
 	year "1994"
 	developer "Midas (Unico license)"
 	rom ( name stoffy.zip size 90206 crc ee570a87 md5 382ee5be81efba1a58962c90877e3b0b sha1 0419f36244006a8a8efe1d749c778902c9b7904f )
+)
+
+game (
+	name "Stompin'"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name stompin.zip size 73853 crc 86d55893 md5 afa597b863c1a6d4f6af12b00c83007a sha1 2737564d455b1b1005e1d13ca30e8cc247dc3127 )
 )
 
 game (
@@ -38194,6 +42407,13 @@ game (
 )
 
 game (
+	name "Raiga - Strato Fighter (US)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
+)
+
+game (
 	name "Stratovox"
 	year "1980"
 	developer "Sun Electronics (Taito license)"
@@ -38212,6 +42432,13 @@ game (
 	year "1981"
 	developer "Shoei"
 	rom ( name streakng.zip size 14508 crc 2632d722 md5 4fcfb82fc2bdf670f924d2705b9bfd22 sha1 ebd63282f807849413024a1ce2d1d6452d78bda8 )
+)
+
+game (
+	name "Street Smart (US version 2)"
+	year "1989"
+	developer "SNK"
+	rom ( name streetsm.zip size 1327100 crc 1a2401bc md5 dfa1f446839bb27e10662348477175e2 sha1 3c5643e6c006bfdd2284869f49391cb1918c54a8 )
 )
 
 game (
@@ -38275,6 +42502,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name striderj.zip size 2087531 crc fbd649da md5 7881bcd25f64ca1691b818797bae8764 sha1 65812a75c633336b7cbd804614ff0b9faf79a04d )
+)
+
+game (
+	name "Strider Hiryu (Japan Resale Ver.)"
+	year "1989"
+	developer "Capcom"
+	rom ( name striderjr.zip size 2107966 crc 851bfabe md5 e490a66c794a217144c6179ecfbad368 sha1 bf49d47f496982de35010f3efa9997b25cd4590c )
+)
+
+game (
+	name "Strider (USA, set 2)"
+	year "1989"
+	developer "Capcom"
+	rom ( name striderua.zip size 2103588 crc 461a11cf md5 fd6744f86c61d3b2eb5c455165ebc96f sha1 74696c0847609d2162e423922c0ad7aa6c641042 )
 )
 
 game (
@@ -38439,6 +42680,13 @@ game (
 )
 
 game (
+	name "Idol Janshi Suchie-Pai Special (Japan)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name suchipi.zip size 1947280 crc 4045e520 md5 c2b8676b68ea4fb23c893aec2942d32e sha1 e03450ff802dc0d85b3e548b43b70ef7251193f0 )
+)
+
+game (
 	name "Suikoenbu / Outlaws of the Lost Dynasty (JUETL 950314 V2.001)"
 	year "1995"
 	developer "Data East"
@@ -38599,6 +42847,13 @@ game (
 )
 
 game (
+	name "Super Triv II"
+	year "1986"
+	developer "Status Games"
+	rom ( name supertr2.zip size 143384 crc 319fb964 md5 12e9453390bf5f76ac1a321cb7f689ab sha1 2d8660d9b2054181ad4c4be19056019c6648312b )
+)
+
+game (
 	name "Super Triv III"
 	year "1988"
 	developer "Status Games"
@@ -38711,6 +42966,13 @@ game (
 )
 
 game (
+	name "Super Poker"
+	year "1987"
+	developer "Greyhound Electronics"
+	rom ( name suprpokr.zip size 19252 crc a0507132 md5 4780436f8210edd78fe634619b82e14e sha1 172248ace518f00bf3cf303e761d2f0c531241fb )
+)
+
+game (
 	name "Super Rider"
 	year "1983"
 	developer "Venture Line (Taito Corporation license)"
@@ -38820,6 +43082,20 @@ game (
 	year "1993"
 	developer "Namco"
 	rom ( name suzuk8h2.zip size 3491123 crc ea0ed660 md5 3dd4a9e5b2ac0577be672f3e593f870e sha1 059d5fee3e77eda0c9c384a6d665a4bbcf8fb37c )
+)
+
+game (
+	name "Suzuka 8 Hours (World)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8h.zip size 2189192 crc 939be6f9 md5 4ee129d4893d4bb9168d1d55fa590c19 sha1 01a7738fb337cd90a417891fb03174eb8ac73118 )
+)
+
+game (
+	name "Suzuka 8 Hours (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8hj.zip size 2189451 crc af16442c md5 73df94ab838b7b44b616214314ef5d96 sha1 492df454f7148f28f399a7dfbf8fae7abfa5ba08 )
 )
 
 game (
@@ -39184,6 +43460,13 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name tankbatl.zip size 1469310 crc 19d31524 md5 b77cf3ec5384cb1be990aa3117dc887f sha1 14ef2a8a83b9c458fa5807d9da1121205a19d524 )
+)
+
+game (
+	name "Tank Battalion"
+	year "1980"
+	developer "Namco"
+	rom ( name tankbatt.zip size 8337 crc 00986b0a md5 f8b6eb6c292289525fdd0165de9fea7a sha1 0d7893c13f8f6ad6759a385e84538e48add6c094 )
 )
 
 game (
@@ -39677,10 +43960,45 @@ game (
 )
 
 game (
+	name "Tengai (World)"
+	year "1996"
+	developer "Psikyo"
+	rom ( name tengai.zip size 6500431 crc 99b98f75 md5 91470b32675430f13f0892416163e6e8 sha1 93d82339ea7ce82efca9903c1275e477d57ab41c )
+)
+
+game (
+	name "Sengoku Blade: Sengoku Ace Episode II / Tengai"
+	year "1996"
+	developer "Psikyo"
+	rom ( name tengaij.zip size 6500427 crc da750992 md5 b9fe4e0616d95ca26ab6e120c45d33fc sha1 b88aab6d257efceabdf4ca12773f950ccc8f6471 )
+)
+
+game (
+	name "Mahjong Tenkaigen"
+	year "1991"
+	developer "Dynax"
+	rom ( name tenkai.zip size 659684 crc fcec3b2f md5 3641deb99edda5b8ca3248f2777594ba sha1 8e04089a44b491a9c0101d647621737cf9aefe51 )
+)
+
+game (
 	name "Mahjong Tenkaigen (bootleg b)"
 	year "1991"
 	developer "bootleg"
 	rom ( name tenkaibb.zip size 945247 crc 66dd10f2 md5 7af84111bb794a1342469f0cbc3842f2 sha1 4f7ce77d2efb320068fd16f5fe2946267388022c )
+)
+
+game (
+	name "Mahjong Tenkaigen (bootleg c)"
+	year "1991"
+	developer "bootleg"
+	rom ( name tenkaicb.zip size 425730 crc 92e09b3e md5 4372b6f55e8b2a7dd4aade1d70e6bd39 sha1 2ad29d28b52a6be2d5c7ae4115356a183d2164a7 )
+)
+
+game (
+	name "Mahjong Tenkaigen (set 2)"
+	year "1991"
+	developer "Dynax"
+	rom ( name tenkaie.zip size 927266 crc 53e09f7b md5 b0015989f158f9b622a23295eb00fbcf sha1 8ade721603ec3ebceb2bd54430889f6bee8909b5 )
 )
 
 game (
@@ -39800,6 +44118,13 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name tetrisbl.zip size 157595 crc 73a78a78 md5 47ef06ec0038db552c7c656b5e6cf482 sha1 7854c81dc8cea10631a549bdc5017db779c766f9 )
+)
+
+game (
+	name "Tetris Plus"
+	year "1995"
+	developer "Jaleco / BPS"
+	rom ( name tetrisp.zip size 6027113 crc 54bf037e md5 05ec2410c2f1b1f56d1279f4e8de563a sha1 231158a02fa8d0e83b1fd6efb2cd901c8e8d63d5 )
 )
 
 game (
@@ -40088,6 +44413,13 @@ game (
 )
 
 game (
+	name "Thunder Zone (World)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name thndzone.zip size 3794222 crc 1d67a46f md5 ec0585515c5eb4211a014e33544a1956 sha1 f305256f620f2e2269665c99963e7c9810a7a8a6 )
+)
+
+game (
 	name "Thunder Hoop (Ver. 1)"
 	year "1992"
 	developer "Gaelco"
@@ -40183,6 +44515,13 @@ game (
 	year "1985"
 	developer "Merit"
 	rom ( name tictac.zip size 303266 crc 3160560e md5 99af7aa8dd87c4a2065f943bffe2036d sha1 5c0970df2883ea55b6c64affa1fad09a32458e1a )
+)
+
+game (
+	name "Tiger Heli (US)"
+	year "1985"
+	developer "Toaplan / Taito America Corp."
+	rom ( name tigerh.zip size 96861 crc 4c52aad7 md5 cfc2d493bc5a6f7a36c76afbe1769d99 sha1 d713c1d82f1abd5daefcf5d0e23e9832499efae0 )
 )
 
 game (
@@ -40326,6 +44665,13 @@ game (
 )
 
 game (
+	name "Time Limit"
+	year "1983"
+	developer "Chuo Co. Ltd"
+	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
+)
+
+game (
 	name "Time Pilot"
 	year "1982"
 	developer "Konami"
@@ -40351,6 +44697,13 @@ game (
 	year "1987"
 	developer "Sega"
 	rom ( name timescan.zip size 253547 crc acc0c3dc md5 d3c3e93cc80de3421c3df5c48eeae066 sha1 4ba5295a28bc21d14f05f59380532c117b1f9f41 )
+)
+
+game (
+	name "Time Scanner (set 1, System 16A, FD1089B 317-0024)"
+	year "1987"
+	developer "Sega"
+	rom ( name timescan1.zip size 310475 crc f59904a3 md5 bba10d55a1d7420fcdf7e08db2c6baa6 sha1 38f64437fe755a0be746e74364839292103cc8c4 )
 )
 
 game (
@@ -40431,10 +44784,38 @@ game (
 )
 
 game (
+	name "Tobikose! Jumpman"
+	year "1999"
+	developer "Namco"
+	rom ( name tjumpman.zip size 488609 crc fe8d20b5 md5 5b5ca2c2d8074c26b318e684bbd1b31c sha1 8c345ded4f9a8630682630cf4811c7e4cd683fc6 )
+)
+
+game (
+	name "Touki Denshou -Angel Eyes- (VER. 960614)"
+	year "1996"
+	developer "Tecmo"
+	rom ( name tkdensho.zip size 14423230 crc de83cd11 md5 1ec081f1b50c0562533d4ddfa841bf10 sha1 b014cdbfd63b739561ff9feb0cf580f613c68209 )
+)
+
+game (
+	name "Touki Denshou -Angel Eyes- (VER. 960427)"
+	year "1996"
+	developer "Tecmo"
+	rom ( name tkdenshoa.zip size 14423058 crc c4aeb12d md5 4d14cd230a196348adcb72946fb9a97e sha1 1ad7a0406dd053af93bbbfe151cb3f09d9a88819 )
+)
+
+game (
 	name "Tokimeki Memorial Taisen Puzzle-dama (ver JAB)"
 	year "1995"
 	developer "Konami"
 	rom ( name tkmmpzdm.zip size 7306921 crc 587d301f md5 17cdf1fba0f53a97d006a536fbe7defd sha1 312e8ded43d8adb75ae8b40c074b5b69fdde0a65 )
+)
+
+game (
+	name "Tecmo Knight"
+	year "1989"
+	developer "Tecmo"
+	rom ( name tknight.zip size 1127117 crc bdd136d0 md5 9e0754dbe498dd9e084e828e34091eef sha1 aadbaa9d4ae3f4b9bb44768886197a703a6d78c4 )
 )
 
 game (
@@ -40554,6 +44935,13 @@ game (
 	year "1996"
 	developer "CES Inc., Midway Games Inc."
 	rom ( name tmdo.zip size 1491805 crc 0ddff570 md5 e674a330e410dd71fe10ffee3a0d7981 sha1 d0ae06c033134567350868c8a5e6f8578b608c0d )
+)
+
+game (
+	name "T-MEK (v2.0, prototype)"
+	year "1994"
+	developer "Atari Games"
+	rom ( name tmek20.zip size 19867211 crc 63e6b457 md5 84ffa9338e9898c2d1d0cfe32e836198 sha1 1b3969b32fbf3af6817b1e86a43017666a901e7f )
 )
 
 game (
@@ -40767,6 +45155,13 @@ game (
 )
 
 game (
+	name "Toggle (prototype)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name toggle.zip size 28942 crc b3d491d6 md5 5d42dc7f10c75c6d17819ff1d779f4dc sha1 0b0b420c5d754476df8294c40f308e89093b217e )
+)
+
+game (
 	name "Toki (World, set 1)"
 	year "1989"
 	developer "TAD Corporation"
@@ -40956,6 +45351,13 @@ game (
 )
 
 game (
+	name "Toppy _ Rappy"
+	year "1996"
+	developer "SemiCom"
+	rom ( name toppyrap.zip size 899598 crc d49e6bb7 md5 61bbd8147ccafe4c91480c2083f590e0 sha1 99620ac1f426bfa55d603e5423313ac15c3a05dc )
+)
+
+game (
 	name "Top Racer (with MB8841 + MB8842, 1984)"
 	year "1984"
 	developer "bootleg"
@@ -40988,6 +45390,13 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name topsecex.zip size 223906 crc 2d6b5bed md5 80f04c733de18b9fd01ccea3af7584ef sha1 310893e7709a51cb7119350e375a4da898975649 )
+)
+
+game (
+	name "Top Secret (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name topsecrt.zip size 338416 crc cbdcc8da md5 b8c824aaa5bf2e83633967fbdecd12b6 sha1 1e880bbe9eba132062e7f1ac3ff55650936f5dfb )
 )
 
 game (
@@ -41051,6 +45460,13 @@ game (
 	year "1976"
 	developer "Midway / Taito"
 	rom ( name tornbase.zip size 4610 crc 172c9ce8 md5 346b14f98e5cd8a63dd035be3ed1009a sha1 1ce3da395e611546a20d95846b07e56da924b49a )
+)
+
+game (
+	name "Tortuga Family (Italian)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name tortufam.zip size 30995 crc 12a433af md5 42f852152a30fc23e2cdbd82e2b57371 sha1 7411f6988e799a8bee2496c4ac35a0c84a91337e )
 )
 
 game (
@@ -41155,6 +45571,13 @@ game (
 	year "1986"
 	developer "Namco"
 	rom ( name toypop.zip size 54934 crc 6d0e39a7 md5 235f087dde8805bf8a5f78620e0c0dea sha1 5b4b0ce5f6606bd6ad73697e201f601df176d100 )
+)
+
+game (
+	name "Tetris Plus 2 (MegaSystem 32 Version)"
+	year "1997"
+	developer "Jaleco"
+	rom ( name tp2m32.zip size 8476556 crc 16683cf1 md5 1b52cc5b884f5b6733ebe0246139f802 sha1 8cdd201b89b6d6e0a5e855ff176da3f899a44961 )
 )
 
 game (
@@ -41326,10 +45749,73 @@ game (
 )
 
 game (
+	name "Tri-Sports"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name trisport.zip size 391600 crc 9d1ed04b md5 23baf9702c40ee7236ec462a36ae48a8 sha1 6ed7b4493ac639831b93a1172fc7e3b88bca28d2 )
+)
+
+game (
+	name "Trivial Pursuit (Genus I) (set 2)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name trivia12.zip size 62892 crc a592eebc md5 43831bdde92dc32d106016de14e8f85d sha1 718bcd7747ea6683281402402d933997d5cc597d )
+)
+
+game (
+	name "Trivial Pursuit (Baby Boomer Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviabb.zip size 86909 crc fcd62551 md5 06b51d3ad5cd79c50c1cc978353f17ff sha1 9d78f0a7aed4d0cb71ace35685c7f5ce8e6f5fef )
+)
+
+game (
+	name "Trivial Pursuit (Spanish Edition)"
+	year "1987"
+	developer "Bally/Sente"
+	rom ( name triviaes.zip size 98540 crc 5fe1dee9 md5 82277fd6a3c241a5a39c8d022f285895 sha1 aa34c88bb85efa6029016ab96a5871aa67f91f76 )
+)
+
+game (
+	name "Trivial Pursuit (Genus I) (set 1)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviag1.zip size 63161 crc 42412d19 md5 355c6cddb4d9ed5291069d533b20a79a sha1 362b1d7f984c400488e804169cde08efb3a86ea2 )
+)
+
+game (
+	name "Trivial Pursuit (Genus II)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviag2.zip size 81472 crc 35e28e9a md5 f17d97b0dc95431217f05c7b13c24d6e sha1 e74d3acc230a27c7521406686428f8ad250240dd )
+)
+
+game (
 	name "Trivial Pursuit (prod. 1D)"
 	year "1996"
 	developer "JPM"
 	rom ( name trivialp.zip size 4629707 crc 69c30118 md5 650ec075162fe6ef59b814cb48cece69 sha1 6fac4dee5e78172d453f9db846111990a6d60004 )
+)
+
+game (
+	name "Trivial Pursuit (All Star Sports Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviasp.zip size 79007 crc 9fec4b51 md5 434d67ccc984a67a7e386e74acb19f66 sha1 d16547ced6599031a230103097fff69611e3e8b3 )
+)
+
+game (
+	name "Trivial Pursuit (Young Players Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviayp.zip size 81290 crc 3ea8b933 md5 a98d9c07b9e1e5a97e2fd9b802ebdf08 sha1 484d137137c31343702190e89addad65d9cca49b )
+)
+
+game (
+	name "Triv Quiz"
+	year "1984"
+	developer "Status Games"
+	rom ( name trivquiz.zip size 44640 crc 87331852 md5 7750c2aa24abe738c824108301f14223 sha1 7b7916e6594e8a6b4fef765e408a734d3c58b8e3 )
 )
 
 game (
@@ -41393,6 +45879,34 @@ game (
 	year "1986"
 	developer "Capcom (Romstar license)"
 	rom ( name trojanr.zip size 328457 crc e5da663a md5 6f8fecc8cea266e84bee89d150e378b4 sha1 00452121bfb7cd020bc1f7544184c287888fab52 )
+)
+
+game (
+	name "Tron (8/9)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron.zip size 48412 crc ca5217e6 md5 b1f988a78519c5dfd18e81918c2c0c97 sha1 4ebf329d173d2b3d4f95bda0a7e97f6cd1c06d08 )
+)
+
+game (
+	name "Tron (6/25)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron2.zip size 48435 crc 15498746 md5 0066db603bdfaad4139621be9d340585 sha1 48e746071d9c6bc97980f867dc0bf79474c3d3a3 )
+)
+
+game (
+	name "Tron (6/17)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron3.zip size 48582 crc d895822d md5 5fd9ee29f98887c1f63654e612f100f0 sha1 68447183de33dd3fec0d79218d4fc19c0cb0ab0c )
+)
+
+game (
+	name "Tron (6/15)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron4.zip size 48750 crc b3152e97 md5 eef5483eaebb1b6a55fa26a703ac638e sha1 f8a3f6c7f3083d2e8823974837054ee55ac15161 )
 )
 
 game (
@@ -41633,6 +46147,20 @@ game (
 )
 
 game (
+	name "Shingen Samurai-Fighter (Japan, English)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name tshingen.zip size 800531 crc f9576ca7 md5 9ac76b1bd2e9a7104de273de6e9127c3 sha1 da6513cfb037cdc7903e38574f381b9f2cbabfdb )
+)
+
+game (
+	name "Takeda Shingen (Japan, Japanese)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name tshingena.zip size 795838 crc 0c666c80 md5 dad3fb98c5f596221947c3115a16b860 sha1 d5157578da41888edfa4af2f0a9d952fb0e823dd )
+)
+
+game (
 	name "Turkey Shoot"
 	year "1984"
 	developer "Williams"
@@ -41715,6 +46243,13 @@ game (
 )
 
 game (
+	name "Tumble Pop (bootleg set 2)"
+	year "1991"
+	developer "bootleg"
+	rom ( name tumbleb2.zip size 1074460 crc 32d81dc3 md5 cc0d093fd870e8323201ac468dbd01d2 sha1 b3b6867cda8c5fe8e430c5c4134fe112c56a478e )
+)
+
+game (
 	name "Tumble Pop (World)"
 	year "1991"
 	developer "Data East Corporation"
@@ -41789,6 +46324,13 @@ game (
 	year "1985"
 	developer "Entertainment Sciences"
 	rom ( name turbosub7.zip size 458527 crc a7377e4e md5 dfae2bf08c45ba5db5bfa0057fe17a53 sha1 2d17b85980694e015fcaa8a904c925568e8fe48c )
+)
+
+game (
+	name "Turbo Tag (prototype)"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name turbotag.zip size 81349 crc 110a73f3 md5 299492db454f6e474158d50d247cd68b sha1 efb26d0470e0185af509c50c68a318d096c59233 )
 )
 
 game (
@@ -41953,6 +46495,20 @@ game (
 )
 
 game (
+	name "Twinkle"
+	year "1997"
+	developer "SemiCom"
+	rom ( name twinkle.zip size 377505 crc 87513d91 md5 d439c4e525244b83cfca5280dd09019d sha1 f963d9fcb539a9233fb3a5fb9f231811024b26a3 )
+)
+
+game (
+	name "Twin Qix (Ver 1.0A 1995/01/17) (Prototype)"
+	year "1995"
+	developer "Taito America Corporation"
+	rom ( name twinqix.zip size 3028197 crc a9e0703d md5 a43b278642f60c6891c43b23ef14309c sha1 1fc627611d3ed1f75690ae6eb9355760597a4cbd )
+)
+
+game (
 	name "Twins (set 1)"
 	year "1994"
 	developer "Electronic Devices"
@@ -42006,6 +46562,13 @@ game (
 	year "1996"
 	developer "Tecmo"
 	rom ( name tws96.zip size 7496366 crc 3741481a md5 7364e68e4ce7b8aa17e0fea3cf963644 sha1 38c390160bccf6d4edceecd7d557f873eae764fb )
+)
+
+game (
+	name "TX-1"
+	year "1983"
+	developer "Tatsumi"
+	rom ( name tx1.zip size 107770 crc e1d14f3e md5 29e33378420a1311fed9b003e07acedb sha1 3da4d488dbcb3941cefdae9d706f642c90d07867 )
 )
 
 game (
@@ -42086,6 +46649,13 @@ game (
 )
 
 game (
+	name "Ufo Senshi Yohko Chan (not encrypted)"
+	year "1988"
+	developer "bootleg"
+	rom ( name ufosensib.zip size 216864 crc 27779205 md5 14fd386eeff9f702eff83f6bd6ff8ffc sha1 a9b963ae8030d66adf9e1e299b34231d31fa0673 )
+)
+
+game (
 	name "Ultimate Tennis"
 	year "1993"
 	developer "Art &amp; Magic"
@@ -42160,6 +46730,13 @@ game (
 	year "1983"
 	developer "Diatec"
 	rom ( name unclepoo.zip size 33464 crc e0e12af0 md5 3252ddeca86367d916fca1b9754c82e0 sha1 6a68f32108b772e4b623f3d0603cc87e461c783e )
+)
+
+game (
+	name "The Undoukai (Japan)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name undoukai.zip size 98272 crc 80319054 md5 69bacd1a039c50989513262a0a587ef8 sha1 80cbb94db867518774f1911ff0e51cfc76dc6e20 )
 )
 
 game (
@@ -42244,6 +46821,13 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name upyoural.zip size 110212 crc c2a3fef4 md5 708658c54b604df2fecb7026b35d5573 sha1 50b122ea1406d1c928b00b14982d8a8a878ba724 )
+)
+
+game (
+	name "Otogizoushi Urashima Mahjong (Japan)"
+	year "1989"
+	developer "UPL"
+	rom ( name urashima.zip size 842889 crc 40519bc6 md5 a316e07bc309b3d56c91e811625acba4 sha1 b8aea9e4f54f74c0ea82017c1395138130d29291 )
 )
 
 game (
@@ -42485,10 +47069,31 @@ game (
 )
 
 game (
+	name "Varth: Operation Thunderstorm (World 920714)"
+	year "1992"
+	developer "Capcom"
+	rom ( name varth.zip size 1544763 crc 5e0796fe md5 6179a7782065b3f0a23e5be3ed69ec99 sha1 c777ddc4f79531b67188e07119961b97cb111270 )
+)
+
+game (
 	name "Varth: Operation Thunderstorm (Japan 920714)"
 	year "1992"
 	developer "Capcom"
 	rom ( name varthj.zip size 1581220 crc 0437f904 md5 f2bb19cd8fb982b92040325a20f2f8f1 sha1 1a020dd3ed4774d9ed6d8379bafc54f3b3fc8ed8 )
+)
+
+game (
+	name "Varth: Operation Thunderstorm (World 920612)"
+	year "1992"
+	developer "Capcom"
+	rom ( name varthr1.zip size 1536406 crc 5ec6bb64 md5 cc06314b486a183c862c672f6aabdea4 sha1 a9afe05f4e4f06d373e54613422a1d62dcd9172d )
+)
+
+game (
+	name "Varth: Operation Thunderstorm (USA 920612)"
+	year "1992"
+	developer "Capcom, distributed by Romstar"
+	rom ( name varthu.zip size 1539113 crc 1b2b6398 md5 8c85dd23c4ec73d4bf67c4f0eb991173 sha1 28ef18237d2939ab6f7315b9c3eca1e4875c4e99 )
 )
 
 game (
@@ -42566,6 +47171,13 @@ game (
 	year "1997"
 	developer "Kaneko / Mediaworks"
 	rom ( name vblokbrk.zip size 3559293 crc b3f06582 md5 79c1890ae778a11557a8ee1034b4ea17 sha1 ef4a361eeb115cadf88296bd316d9a55ba7cf385 )
+)
+
+game (
+	name "Virtua Bowling (World, V101XCM)"
+	year "1996"
+	developer "IGS"
+	rom ( name vbowl.zip size 2363570 crc de0aba54 md5 6e293b5ec25533541bea76e1be0ca2ed sha1 b10589dd59d24ef582bbac82212d280295706552 )
 )
 
 game (
@@ -42702,6 +47314,13 @@ game (
 )
 
 game (
+	name "Virtua Formula"
+	year "1993"
+	developer "Sega"
+	rom ( name vformula.zip size 9750247 crc 039685b7 md5 d49f52ee0cef7900465944a34695dd72 sha1 dfd603e32f09a600bf866593163ca46e59303fa7 )
+)
+
+game (
 	name "Vampire Hunter 2: Darkstalkers Revenge (Japan 970929)"
 	year "1997"
 	developer "Capcom"
@@ -42744,10 +47363,24 @@ game (
 )
 
 game (
+	name "Victorious Nine"
+	year "1984"
+	developer "Taito"
+	rom ( name victnine.zip size 99727 crc a48c32af md5 af3a5cb752bb9ac4bb1e8a20e582d698 sha1 7cf1f37b57ec9c2ce64566ad4b51c7071589a996 )
+)
+
+game (
 	name "Victor 21"
 	year "1990"
 	developer "Subsino / Buffy"
 	rom ( name victor21.zip size 59931 crc 8058f02c md5 133b21b0fbe1a562bdbe67117ecbafd5 sha1 c7fdf4bbdc5dd33831aa68ed0cb781656d249cbc )
+)
+
+game (
+	name "G.E.A."
+	year "1991"
+	developer "Subsino"
+	rom ( name victor5.zip size 60370 crc 789405ce md5 19a92dc9bb867380b6b3e7c53e2777f9 sha1 d5fc128372b04617e4b19a23070d47daff30c5bc )
 )
 
 game (
@@ -42818,6 +47451,48 @@ game (
 	year "1992"
 	developer "Sammy / Aicom"
 	rom ( name viewpoin.zip size 5391930 crc 89df3ead md5 e0b1cb5d2cba3b7858451ecade88cd34 sha1 986fe7c8b6621c10e2a5f96f87bfd6e7195e0af6 )
+)
+
+game (
+	name "Vigilante (World)"
+	year "1988"
+	developer "Irem"
+	rom ( name vigilant.zip size 443942 crc 0ea1d86f md5 53bbcbe368c25fb0776a756f9fd06e4f sha1 7d969ba8c64596bac482beb4cf481845b7b773b6 )
+)
+
+game (
+	name "Vigilante (Japan)"
+	year "1988"
+	developer "Irem"
+	rom ( name vigilantj.zip size 444100 crc d78137b0 md5 899b7ab7a2847bd4606534b89c8216b9 sha1 d32c5e0ee5c6d81227f8fdc3f21cc11537837df6 )
+)
+
+game (
+	name "Vigilante (US)"
+	year "1988"
+	developer "Irem (Data East USA license)"
+	rom ( name vigilantu.zip size 443935 crc 983fb0d6 md5 e8f11bb0393e3579461da1c82c45fe1a sha1 a311b89231faf5232f6172d9e95a7620bf072035 )
+)
+
+game (
+	name "Vimana"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
+)
+
+game (
+	name "Vimana (Japan)"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana1.zip size 792172 crc fae43844 md5 f6dd90ad479f91912d3ec0706c7da4ec sha1 9e34ecb4ee6096bca47752aee7f4709a01938799 )
+)
+
+game (
+	name "Vimana (Nova Apparate GmbH)"
+	year "1991"
+	developer "Toaplan (Nova Apparate GmbH license)"
+	rom ( name vimanan.zip size 792398 crc 2bc288f3 md5 8831d66ca21ec4127ea7c2536dd9ee1b sha1 e4a56fdd4bebb5c9a2ff815ddc8ffe22400d9a69 )
 )
 
 game (
@@ -43105,6 +47780,13 @@ game (
 	year "1980"
 	developer "bootleg"
 	rom ( name vpool.zip size 10801 crc 12ef8d56 md5 d2270d488c8494291790ff356af4c7d4 sha1 5838e4dd7157077b393ecb6d9d6f0deafffb695e )
+)
+
+game (
+	name "Virtua Racing"
+	year "1992"
+	developer "Sega"
+	rom ( name vr.zip size 9761594 crc 68f2d49a md5 28a9134834b668a21833c0448ad51104 sha1 ad169f0c44fe377076258a02e80303a6b19891f0 )
 )
 
 game (
@@ -43528,6 +48210,13 @@ game (
 )
 
 game (
+	name "Wonder Boy III - Monster Lair (set 5, World, System 16B, 8751 317-0098)"
+	year "1988"
+	developer "Sega / Westone"
+	rom ( name wb3.zip size 391158 crc f91e30a4 md5 01cc32ea1ae54c6e3d9f0c0c2ec00c54 sha1 8ec512b7b6d1e77cd0e1ce2d3cf0250cbd7c4077 )
+)
+
+game (
 	name "Wonder Boy III - Monster Lair (set 1, System 16A, FD1094 317-0084)"
 	year "1988"
 	developer "Sega / Westone"
@@ -43679,6 +48368,20 @@ game (
 	year "1989"
 	developer "Tecmo"
 	rom ( name wc90b.zip size 397616 crc 73e9b25e md5 9b98a1b0c94b0b1d797c93aa6640d9de sha1 3a023458ab861a5e3168ac6afab1acdb4b11ca5e )
+)
+
+game (
+	name "Euro League (Italian hack of Tecmo World Cup '90)"
+	year "1989"
+	developer "bootleg"
+	rom ( name wc90b1.zip size 400477 crc b0bf4256 md5 c32a9f1044995ffffb4e670df4bf81b6 sha1 4a84141f7517490037994c7420e548f05ce432f9 )
+)
+
+game (
+	name "Worldcup '90"
+	year "1989"
+	developer "bootleg"
+	rom ( name wc90b2.zip size 400762 crc 22467977 md5 8b60be8f48b0abd75473d9ea368eec79 sha1 2a3d9c79990c54cb6dd15cf92f0e43fe8cf15028 )
 )
 
 game (
@@ -43878,6 +48581,12 @@ game (
 )
 
 game (
+	name "Wheels Runner"
+	developer "International Games"
+	rom ( name wheelrun.zip size 266060 crc 01cc5ffb md5 9f4ed4d024100f95ec451c8927bb9519 sha1 b38f11dfdc350802cbb8bf496ff1f8ff9babc5d7 )
+)
+
+game (
 	name "Whizz"
 	year "1989"
 	developer "Philko"
@@ -43906,6 +48615,20 @@ game (
 )
 
 game (
+	name "Wild Fang / Tecmo Knight"
+	year "1989"
+	developer "Tecmo"
+	rom ( name wildfang.zip size 1127216 crc 1bbd53df md5 bdf5feea32db29d4fb9bddc09454f287 sha1 5f75aafe536acc379790a20c2fa9fb2f26ca4196 )
+)
+
+game (
+	name "Wild Fang"
+	year "1989"
+	developer "Tecmo"
+	rom ( name wildfangs.zip size 1127156 crc dab69d66 md5 571c22ca0f3deda285e14f1bd8fd719f sha1 f9b556514221f7a52c014a83960c46f5f6e54975 )
+)
+
+game (
 	name "Wild Pilot"
 	year "1992"
 	developer "Jaleco"
@@ -43917,6 +48640,13 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name willow.zip size 1773768 crc 6d01bbd4 md5 aca68da886b22d3945147ca8120e9959 sha1 2106a5e22c9cd5521eb6f0cc86ea041fc385ce14 )
+)
+
+game (
+	name "Willow (Japan, Japanese)"
+	year "1989"
+	developer "Capcom"
+	rom ( name willowj.zip size 1769362 crc 732cdc85 md5 5bc507c5cdbc4e4e24960de7d83d7e01 sha1 6a81c41da6101878acd7b8ee4d7eb44ab1a64a78 )
 )
 
 game (
@@ -44018,6 +48748,13 @@ game (
 )
 
 game (
+	name "Witch Card (English, witch game, lamps)"
+	year "1985"
+	developer "PlayMan"
+	rom ( name witchcdf.zip size 12217 crc 87baef18 md5 e8b780adf98fef5d75b18b2b266384af sha1 85da776a330e605b4b15740d567022f573688bc7 )
+)
+
+game (
 	name "Wit's (Japan)"
 	year "1989"
 	developer "Athena (Visco license)"
@@ -44109,6 +48846,13 @@ game (
 )
 
 game (
+	name "Wonder League Star - Sok-Magicball Fighting (Korea)"
+	year "1995"
+	developer "Mijin"
+	rom ( name wlstar.zip size 1111873 crc 50c60903 md5 fc261854f1666e504d5e89b474e1c99b sha1 0809e620299942bfe252fa6912a34613339ace1f )
+)
+
+game (
 	name "Water Match (315-5064)"
 	year "1984"
 	developer "Sega"
@@ -44158,6 +48902,13 @@ game (
 )
 
 game (
+	name "Warriors of Fate (USA 921031)"
+	year "1992"
+	developer "Capcom"
+	rom ( name wofu.zip size 3943037 crc b1cebed9 md5 efde103d8e343f2b6851e18ee0e7e3f8 sha1 2b06da2dfe47e4dac0b26175444df4896ae5cd26 )
+)
+
+game (
 	name "Wolf Fang -Kuhga 2001- (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -44176,6 +48927,13 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name wonder3.zip size 2545771 crc 294de24f md5 30bcab9cd246220fa9da59e81f43d634 sha1 5a69a4ac353029072fccf32a5410266f9bdec59c )
+)
+
+game (
+	name "Wonder League '96 (Korea)"
+	year "1996"
+	developer "SemiCom"
+	rom ( name wondl96.zip size 1134743 crc 829ed1a5 md5 89b56076d71f4c1caba5cb5194e40eed sha1 07b88d1d2c796106a0883a46f9711bd2b5f36ce5 )
 )
 
 game (
@@ -44238,6 +48996,34 @@ game (
 	year "2002"
 	developer "Comad"
 	rom ( name wownfant.zip size 3732704 crc 54a82a1e md5 feea599d0ef0cac04182100c1fdb4c5a sha1 5fb7030ffb3819b280594892f9e01a9a68a08372 )
+)
+
+game (
+	name "World PK Soccer V2 (ver 1.1)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name wpksocv2.zip size 10936454 crc 15459333 md5 6e2330a479a07cf99cb8ccaa4d4a91d8 sha1 35a8e524c393d1d5321dfd260942289441d3610c )
+)
+
+game (
+	name "World Rally (set 1)"
+	year "1993"
+	developer "Gaelco"
+	rom ( name wrally.zip size 2150671 crc 0a96fa55 md5 c0b150867a535dd91c0a0185bbbe9d2f sha1 1648718faf86e70554754324e1888c95b06e4eea )
+)
+
+game (
+	name "World Rally (set 2)"
+	year "1993"
+	developer "Gaelco"
+	rom ( name wrallya.zip size 2150655 crc 560506db md5 709b7bffefd01796f3a719910a8a04a3 sha1 2a414a31178d8a17eceffc732eb0d0d90590a028 )
+)
+
+game (
+	name "World Rally (US, 930217)"
+	year "1993"
+	developer "Gaelco (Atari license)"
+	rom ( name wrallyb.zip size 2112189 crc 060a4bf2 md5 f0a2f1d4f57ae0efc2f2f0a3cf1bc730 sha1 25b7da3424934adffa65a06ed9cdbc09fd0a04fa )
 )
 
 game (
@@ -44388,6 +49174,13 @@ game (
 )
 
 game (
+	name "WWF Superstars (Europe)"
+	year "1989"
+	developer "Technos Japan"
+	rom ( name wwfsstar.zip size 1521277 crc 380f9e41 md5 7938b364e050b627d2be494b89d450f2 sha1 d2caa65883c6298e8a02d372c8fe76606d47e6f1 )
+)
+
+game (
 	name "WWF Superstars (US, Newer)"
 	year "1989"
 	developer "Technos Japan"
@@ -44444,6 +49237,13 @@ game (
 )
 
 game (
+	name "Xenophobe"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name xenophob.zip size 392037 crc f90765c3 md5 39a392cd04bd5ce6e42619c5667602a0 sha1 0973544f28d70c1e3fc52dc12fb7dfe80d612a35 )
+)
+
+game (
 	name "Xevious 3D/G (Japan, XV31/VER.A)"
 	year "1995"
 	developer "Namco"
@@ -44462,6 +49262,27 @@ game (
 	year "1982"
 	developer "Namco"
 	rom ( name xevious.zip size 45634 crc 1421f28d md5 bc09dfa00e72694661e549d17a51cbb8 sha1 bae87aefcbef9c776f8f6cbd3cfc4ec24d4248f4 )
+)
+
+game (
+	name "Xevious (Atari set 1)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousa.zip size 45384 crc 7498a41b md5 426d2319ff9bfdc47a696c76ec3ae623 sha1 13284570397157ec4cf659cf969bb50fa9a858c1 )
+)
+
+game (
+	name "Xevious (Atari set 2)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousb.zip size 45236 crc 97e7250e md5 7c09e3d69941f33154306c110b519739 sha1 e0680191bf3aa525cc2a48893485b81f298dc5b0 )
+)
+
+game (
+	name "Xevious (Atari set 3)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousc.zip size 45761 crc 0b5c1a40 md5 7697c698928ed5403cdbdcfb76e63239 sha1 d8311dc07521597b8ff7d76d992e74b196ce50eb )
 )
 
 game (
@@ -44633,6 +49454,13 @@ game (
 )
 
 game (
+	name "X Multiply (Japan, M72)"
+	year "1989"
+	developer "Irem"
+	rom ( name xmultiplm72.zip size 853744 crc 75af49dd md5 404ac0208101260f4609bcb8946f1d61 sha1 0ede1ed3886d8295719eab4ab3eb5daa8d886215 )
+)
+
+game (
 	name "X-Men Vs. Street Fighter (Euro 961004)"
 	year "1996"
 	developer "Capcom"
@@ -44763,6 +49591,13 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311744 crc 02c2e99b md5 292a1cbc0304beaa0ca64831f537cbb4 sha1 3fe003a960431b455308fc212ee2d87500041759 )
+)
+
+game (
+	name "Xybots (rev 0)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name xybots0.zip size 276460 crc 9df71bce md5 7081c4ed11cb1ca739d7e6f2d6eb5715 sha1 bfb7140a4ec73a3b6d423490f08196057948137b )
 )
 
 game (
@@ -44931,6 +49766,20 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name youkaidko.zip size 896766 crc 75d57778 md5 4b3b7a739f483bbabcf3348d612fe69e sha1 a499b791fcc4f3e06aa2c21ccff876e99d6182eb )
+)
+
+game (
+	name "Yu-Jan"
+	year "1999"
+	developer "Yubis / T.System"
+	rom ( name yujan.zip size 954075 crc e3156c85 md5 2523fa5f0656bf3dda9bc0e0dbe30700 sha1 2989ac4c2420787b627c0092fc16d1496a7b703e )
+)
+
+game (
+	name "Yu-Ka"
+	year "1999"
+	developer "Yubis / T.System"
+	rom ( name yuka.zip size 1156984 crc 35d0a61e md5 651a630a7b8199ea9505dbe23aabf927 sha1 762dc5457c9baa54eb902835c004a929a0238fea )
 )
 
 game (
@@ -45123,6 +49972,13 @@ game (
 )
 
 game (
+	name "Zip _ Zap"
+	year "1995"
+	developer "Barko Corp"
+	rom ( name zipzap.zip size 1889854 crc b5f99dd5 md5 3128e2238388cbc3f27565eb04e21cc7 sha1 19cd1b0a118aee8d46e6cb6e8103a4f3fadf55cc )
+)
+
+game (
 	name "Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000)"
 	year "1997"
 	developer "Sega"
@@ -45179,6 +50035,13 @@ game (
 )
 
 game (
+	name "Zoom 909"
+	year "1982"
+	developer "Sega"
+	rom ( name zoom909.zip size 92092 crc c5b3a53d md5 b489fc18bae9d84ef62109941828f2e4 sha1 44f821bfe36c63c32c207c388fee1165bf67c801 )
+)
+
+game (
 	name "Zunzunkyou No Yabou (Japan)"
 	year "1994"
 	developer "Sega"
@@ -45190,6 +50053,13 @@ game (
 	year "2001"
 	developer "SNK"
 	rom ( name zupapa.zip size 19292486 crc 75b76e6a md5 edcd0b309e88534252cefec0b0c0b4de sha1 3255db5df86610b7fdff37dff74119d5c9f7d3e1 )
+)
+
+game (
+	name "Zwackery"
+	year "1984"
+	developer "Bally Midway"
+	rom ( name zwackery.zip size 194039 crc 058b606e md5 a292f0585b2d99cb8da733ad7ecc5f94 sha1 8d2e8d67c6f1b90c37c9ea99db34e8297247b20a )
 )
 
 game (

--- a/metadat/mame-split/MAME 2003.dat
+++ b/metadat/mame-split/MAME 2003.dat
@@ -1,6 +1,6 @@
 clrmamepro (
   name "MAME 2003 - Split TorrentZipped Working Romsets"
-  version "2018-12-14"
+  version "2018-12-13"
   description "Format: Split, Working Romsets Only, TorrentZipped"
 )
 
@@ -152,6 +152,13 @@ game (
 )
 
 game (
+	name "Forty-Love"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
+)
+
+game (
 	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
 	year "1994"
 	developer "Jaleco"
@@ -187,10 +194,30 @@ game (
 )
 
 game (
+	name "4-in-1 bootleg"
+	developer "bootleg"
+	rom ( name 4in1boot.zip size 921991 crc 0a78ac38 md5 96055d95961204db3d84be0ec6dc3873 sha1 2a90ad9b70d3b55ac49bb9d26ace4d96552e47dc )
+)
+
+game (
 	name "600"
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14326 crc d5525571 md5 d2b402201bba517b9d100c2731ece9b4 sha1 55261d6a9e522cebfa8c1fc586f288cf5deb14f0 )
+)
+
+game (
+	name "64th. Street - A Detective Story (Japan)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64streej.zip size 108598 crc 1ffe5fb9 md5 e101e9161e72f624dbe178a3caca8255 sha1 123d0776a452658849a27a124182a9cbef9607f5 )
+)
+
+game (
+	name "64th. Street - A Detective Story (World)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
 )
 
 game (
@@ -292,6 +319,13 @@ game (
 )
 
 game (
+	name "Eight Ball Action (Pac-Man conversion)"
+	year "1985"
+	developer "Seatongrove Ltd (Magic Eletronics USA licence)"
+	rom ( name 8bpm.zip size 12311 crc 783554f4 md5 dddcc73720c53723ddecb6c8c89aba89 sha1 00a02b852f810733275da9a6cd79f566604adf2c )
+)
+
+game (
 	name "'99: The Last War"
 	year "1985"
 	developer "Proma"
@@ -310,6 +344,20 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name a51mxr3k.zip size 292721 crc 985fabf5 md5 2e7914b5ff2238a81fe1041b7fcacb95 sha1 1df0b4dae65689d5d2f40382c1a1f79f9011ecbd )
+)
+
+game (
+	name "All American Football (rev E)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafb.zip size 525444 crc 2be03fdc md5 e6aec2fd817bacede3af08d2d4be5a09 sha1 792f4bd79355ca5b26b99f7d238927d4dc638347 )
+)
+
+game (
+	name "All American Football (rev B)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafbb.zip size 104191 crc 4f2a387a md5 84f376c4ece2a825b4b68c5dc9968a4e sha1 60b798c290be562c653d6fb068fe1bbe74c6059a )
 )
 
 game (
@@ -568,6 +616,12 @@ game (
 	year "1986"
 	developer "Cinematronics"
 	rom ( name alleymas.zip size 101385 crc 19a6552e md5 20f578d63cf0f01ab6687c0b36e6bc2f sha1 0fc4237fcf7893a5fea8c9f7e5ed6199d5fa32db )
+)
+
+game (
+	name "Alpha Fighter / Head On"
+	developer "Data East Corporation"
+	rom ( name alphaho.zip size 14445 crc 184c8caa md5 9a5f40b6be34059e7db8ba9678436939 sha1 63b322f199de66a9bdda6b919747520278d562bf )
 )
 
 game (
@@ -997,10 +1051,52 @@ game (
 )
 
 game (
+	name "Tournament Arkanoid (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkatour.zip size 67929 crc 534620d2 md5 f366ad34d37b5ce32da4f1dfca1887cc sha1 a069640592bac954cb903687daa6e8e3bea8ed33 )
+)
+
+game (
 	name "Block (Game Corporation bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name arkbloc2.zip size 36618 crc 6c5d4e43 md5 c37cb78d1e67a68e502278db8c93d08c sha1 e8510b32f9142df563dda08c25b4a78db01380d0 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name arknid2j.zip size 17257 crc 32bd6d4f md5 e1fee4ded4282ab2baaa8ef04f909637 sha1 4bb3b0509712b736180763bde5f0f0ff81f1c42a )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknid2u.zip size 42246 crc 4a89847e md5 114ddc55aaefe0b23a8f13bcc339a2fe sha1 53e6ebb4a181e2548a42ad40024ba5ebca02228f )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
+)
+
+game (
+	name "Arkanoid (Japan)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name arknoidj.zip size 37320 crc a6ea0e70 md5 6607dbf9de6314a2b78f135df6121a7f sha1 e102782364e0987288096e3b5ed76130ac106696 )
+)
+
+game (
+	name "Arkanoid (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknoidu.zip size 37213 crc 084f86a6 md5 6443d9a7db0037ccc974ef799ced979c sha1 c81f8440f71ed8745644f64e31325fff6036d15f )
 )
 
 game (
@@ -1515,6 +1611,13 @@ game (
 )
 
 game (
+	name "Bagman (Moon Cresta hardware)"
+	year "1982"
+	developer "bootleg"
+	rom ( name bagmanmc.zip size 21737 crc 4d143fe6 md5 ed839d556dd74d6491553813c6f042c5 sha1 b2f46e780ed18e9d4fc2837014075ed2fb76dfa0 )
+)
+
+game (
 	name "Bagman (Stern set 1)"
 	year "1982"
 	developer "Valadon Automation (Stern license)"
@@ -1865,6 +1968,13 @@ game (
 )
 
 game (
+	name "Bouncing Balls"
+	year "1991"
+	developer "Comad"
+	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
+)
+
+game (
 	name "Best Bout Boxing"
 	year "1994"
 	developer "Jaleco"
@@ -2080,6 +2190,13 @@ game (
 )
 
 game (
+	name "Big Striker"
+	year "1992"
+	developer "Jaleco"
+	rom ( name bigstrik.zip size 734386 crc 66282984 md5 9dd26ba991c207f1f371436667d33de8 sha1 dec65dcc721faf7f54130c972989093a00ae1bd8 )
+)
+
+game (
 	name "Big Striker (bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -2157,6 +2274,13 @@ game (
 )
 
 game (
+	name "Bishi Bashi Championship Mini Game Senshuken"
+	year "1996"
+	developer "Konami"
+	rom ( name bishi.zip size 2693336 crc b2f59ff8 md5 5db8d60ed016045311db6e3acf3d153f sha1 6cd73477d06f42dbaaf8f79eb8a54b99f953f133 )
+)
+
+game (
 	name "Blue's Journey / Raguy"
 	year "1990"
 	developer "Alpha Denshi Co."
@@ -2182,6 +2306,13 @@ game (
 	year "1983"
 	developer "Taito Corporation"
 	rom ( name bking2.zip size 40059 crc e9d37dda md5 916d651b7ea733ac9ad9603919809478 sha1 6051518b61986328ba968ddf4201c6d86c756e2d )
+)
+
+game (
+	name "Birdie King 3"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name bking3.zip size 47780 crc 49e2b834 md5 85eed1d3d17b704da9237eebd7218f70 sha1 35c5994ddf72c92733c83a4fedbf6d6b2e7a6280 )
 )
 
 game (
@@ -2863,6 +2994,13 @@ game (
 )
 
 game (
+	name "Brain"
+	year "1986"
+	developer "Coreland / Sega"
+	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
+)
+
+game (
 	name "Borderline (bootleg)"
 	year "1981"
 	developer "bootleg"
@@ -3521,6 +3659,13 @@ game (
 )
 
 game (
+	name "Car Polo"
+	year "1977"
+	developer "Exidy"
+	rom ( name carpolo.zip size 5574 crc 92bcf55d md5 bde33e30020d209594ae065fae9c23dd sha1 7043a4bf4ff800dcc96477bbab113cdfa4ccce00 )
+)
+
+game (
 	name "Cassette: Astro Fantasia"
 	year "1981"
 	developer "DECO"
@@ -3787,6 +3932,13 @@ game (
 )
 
 game (
+	name "Chack'n Pop"
+	year "1983"
+	developer "Taito Corporation"
+	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
+)
+
+game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
@@ -3930,6 +4082,20 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name chiller.zip size 263851 crc 9545a100 md5 de20ffe9b2a329c79ea61584387338c5 sha1 cd112a6b44dbc7faeef51c80e33d7f51108de889 )
+)
+
+game (
+	name "Chimera Beast (prototype)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
+)
+
+game (
+	name "China Gate (US)"
+	year "1988"
+	developer "[Technos] (Taito Romstar license)"
+	rom ( name chinagat.zip size 669565 crc daf329d8 md5 1a7ecae60c4c03642e577ac743460b71 sha1 c12f1d93a26a5b7c6e8a4a063d068c8004f097ab )
 )
 
 game (
@@ -4514,6 +4680,13 @@ game (
 )
 
 game (
+	name "Cookie and Bibi 2"
+	year "1996"
+	developer "SemiCom"
+	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
+)
+
+game (
 	name "Cook Race"
 	year "1982"
 	developer "bootleg"
@@ -4881,6 +5054,13 @@ game (
 	year "1994"
 	developer "Midway"
 	rom ( name crusnusa.zip size 11277108 crc 2a29e7b8 md5 aa0f8937ad64031b4d6895691a5b63ec sha1 3ea7b111277572b9f8430a4f5d2541ae651692b2 )
+)
+
+game (
+	name "Cruis'n World (rev L1.3)"
+	year "1996"
+	developer "Midway"
+	rom ( name crusnw13.zip size 2156615 crc 28bf06c3 md5 4a1cd253a407f3f2a49826ad18b55510 sha1 c4356596218ca59923bd39037d6271e4b1588c00 )
 )
 
 game (
@@ -5989,6 +6169,13 @@ game (
 )
 
 game (
+	name "Devil Zone (easier)"
+	year "1980"
+	developer "Universal"
+	rom ( name devzone2.zip size 11232 crc 85c49f48 md5 de64dbd2266ea0e8805f42deffc33119 sha1 2c08119d7805e4f1329cf7c28ec890edfd7bb082 )
+)
+
+game (
 	name "Dangun Feveron (Japan)"
 	year "1998"
 	developer "Cave (Nihon System license)"
@@ -6182,6 +6369,13 @@ game (
 	year "1983"
 	developer "Nintendo of America"
 	rom ( name dkong3.zip size 42389 crc 317a8875 md5 53bcbf8591f68d360f36cda8ad766d85 sha1 453e8d47014ddc0e71b9befaac4a2d9e8048d83d )
+)
+
+game (
+	name "Donkey Kong 3 (bootleg on Donkey Kong Jr. hardware)"
+	year "1984"
+	developer "bootleg"
+	rom ( name dkong3b.zip size 28851 crc 21cec73a md5 346579b62b0b9dd360f9d96c0c80872d sha1 2d6db4a80cef57f9be07465596d98f1ff99b874d )
 )
 
 game (
@@ -6520,6 +6714,13 @@ game (
 )
 
 game (
+	name "Mr. Do's Wild Ride"
+	year "1984"
+	developer "Universal"
+	rom ( name dowild.zip size 43432 crc 77690fcb md5 664304c0f1fe87c18da5830785406d1f sha1 29f834e7b2c4c0ef8e280895185d66083c0c7dee )
+)
+
+game (
 	name "DownTown"
 	year "1989"
 	developer "Seta"
@@ -6653,6 +6854,13 @@ game (
 )
 
 game (
+	name "Driving Force (Galaxian conversion)"
+	year "1984"
+	developer "Shinkai Inc. (Magic Eletronics USA licence)"
+	rom ( name drivfrcg.zip size 17429 crc 9c1bdda3 md5 f0971fe5e8bf1cdf138a82b02ca4efd5 sha1 4bb114171d25e8c2e00b9e9401dbf61999c33b15 )
+)
+
+game (
 	name "Driving Force (Pac-Man conversion)"
 	year "1984"
 	developer "Shinkai Inc. (Magic Eletronics Inc. licence)"
@@ -6671,6 +6879,27 @@ game (
 	year "1983"
 	developer "Sanritsu"
 	rom ( name drmicro.zip size 54750 crc a9cc4018 md5 704b6d5e41ced6a59b61fef279a9a852 sha1 e80009ea0383fc22e022b829ca88efe151d00afb )
+)
+
+game (
+	name "Dr. Toppel's Adventure (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name drtoppel.zip size 399774 crc fd1387f9 md5 77f5dc35d6e052796c8173f8dfe05acf sha1 583e4245985e565b5d0409d85df56f05e89f188f )
+)
+
+game (
+	name "Dr. Toppel's Tankentai (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name drtopplj.zip size 12151 crc a783dbaf md5 f502b9951a1a989fb2c57753a8cd54a6 sha1 da9b32275d3a2175dd5fbb9f84d4c083e80c0335 )
+)
+
+game (
+	name "Dr. Toppel's Adventure (US)"
+	year "1987"
+	developer "Taito America Corporation"
+	rom ( name drtopplu.zip size 12151 crc 99af4ac3 md5 30b9ea5bbcbf24ac15867506ca686c37 sha1 821bdcef77a4017b90a919dd25a5286398e4a8e0 )
 )
 
 game (
@@ -6905,6 +7134,13 @@ game (
 )
 
 game (
+	name "Eggor"
+	year "1983"
+	developer "Telko"
+	rom ( name eggor.zip size 15733 crc 4f26a659 md5 b891df5d59d7b0faa260b9f7118b4a8e sha1 ef8095a7ae1ee548e0235af3492e1ef37394ed96 )
+)
+
+game (
 	name "Eggs"
 	year "1983"
 	developer "[Technos] Universal USA"
@@ -7087,6 +7323,20 @@ game (
 )
 
 game (
+	name "Enigma 2"
+	year "1981"
+	developer "GamePlan (Zilec Electronics license)"
+	rom ( name enigma2.zip size 11169 crc 297c5944 md5 7d15275e6c1d86bf3a5de282f735aaf9 sha1 18c51816f495b3c5615212cc35a894271445c24a )
+)
+
+game (
+	name "Enigma 2 (Space Invaders Hardware)"
+	year "1984"
+	developer "Zilec Electronics"
+	rom ( name enigma2a.zip size 7977 crc d954a25b md5 7719bdb88678a36f71ae3012c0df4ab8 sha1 9b0b5223b80b212c1323ede08479eb598c3aef52 )
+)
+
+game (
 	name "Escape from the Planet of the Robot Monsters (set 1)"
 	year "1989"
 	developer "Atari Games"
@@ -7206,6 +7456,13 @@ game (
 )
 
 game (
+	name "Exciting Soccer (bootleg)"
+	year "1983"
+	developer "bootleg"
+	rom ( name exctsccb.zip size 50249 crc ca0e8c6a md5 0238972ac2b327a8fa7ca81f9a5d41d8 sha1 f22c1d0230c86f19825bb362b070012475144bc2 )
+)
+
+game (
 	name "Exciting Soccer"
 	year "1983"
 	developer "Alpha Denshi Co."
@@ -7279,6 +7536,13 @@ game (
 	year "1989"
 	developer "Gottlieb / Premier Technology"
 	rom ( name exterm.zip size 941767 crc 956fe605 md5 c70880dbc76aaf4428ecdab0775a1a97 sha1 46b60e7aed1e05e157632e6e413218ce0be7afb1 )
+)
+
+game (
+	name "Extermination (US)"
+	year "1987"
+	developer "[Taito] World Games"
+	rom ( name extrmatn.zip size 369293 crc 99b8f1ec md5 d6366d5cac27317e812ceee355126b4e sha1 6103d95839ad75c0be20929375ba1c32541054c2 )
 )
 
 game (
@@ -7391,6 +7655,13 @@ game (
 	year "1981"
 	developer "SNK"
 	rom ( name fantasyj.zip size 22470 crc 28b271c9 md5 4db449f5594011a2b3e8d6e4896e448e sha1 aea3b30ecbb6bda08aa3cd931f4abd8ea47dae2e )
+)
+
+game (
+	name "Fantazia"
+	year "1980"
+	developer "bootleg"
+	rom ( name fantazia.zip size 13565 crc 48d6fdcf md5 d3c592375ffee60612469a05a5228051 sha1 8265b616a5835a1db570b731e5e5fb83b6611bbf )
 )
 
 game (
@@ -7561,6 +7832,13 @@ game (
 )
 
 game (
+	name "Field Day"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
+)
+
+game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
@@ -7579,6 +7857,27 @@ game (
 	year "1983"
 	developer "[Kaneko] (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
+)
+
+game (
+	name "Final Lap 3 (Japan set 1)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3.zip size 2409181 crc 35f7c6f4 md5 ae55320f01b6af307092b51ebc2da3e3 sha1 753d47f9e796227c8632ec32760a6927b87a0992 )
+)
+
+game (
+	name "Final Lap (Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finalapc.zip size 48545 crc cb7b77c7 md5 15de023e0302f817e630f667f9482f76 sha1 19a410d013473eb61cff48cc9edd3244709c8cbd )
+)
+
+game (
+	name "Final Lap (Rev D)"
+	year "1987"
+	developer "Namco"
+	rom ( name finalapd.zip size 38498 crc 86390bc7 md5 95578b155bf85e2b26b55c3f7022b8b4 sha1 eead37f0b22d6711a0cd505423147db910cc5f2f )
 )
 
 game (
@@ -7617,6 +7916,13 @@ game (
 )
 
 game (
+	name "Final Lap (Rev E)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallap.zip size 1115199 crc ce85ce2e md5 2f3e2c1ee5f563e62978badaed9131c2 sha1 38f95d6188b1bf5c9de235f81358f13c8579bee3 )
+)
+
+game (
 	name "Find Out"
 	year "1987"
 	developer "Elettronolo"
@@ -7628,6 +7934,20 @@ game (
 	year "1989"
 	developer "Namco"
 	rom ( name finehour.zip size 2297433 crc 81ef74a8 md5 ed09ff75a008007cc92896464bf0ec46 sha1 13ab919d68691b5b0bcb2fdd3fae53d1f9bd3fc7 )
+)
+
+game (
+	name "Final Lap (Japan - Rev B)"
+	year "1987"
+	developer "Namco"
+	rom ( name finlapjb.zip size 94941 crc d6449da4 md5 42433d418f840ffbcbe23db6b466b3a6 sha1 6cf19be4d764a902fbc733bc5ff9d64c68ee73ed )
+)
+
+game (
+	name "Final Lap (Japan - Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finlapjc.zip size 38056 crc 262cc4b4 md5 cf319f8293f61064140dd213ee433894 sha1 90b2ce27d738990f1f5aa3a5f353b0d24226898f )
 )
 
 game (
@@ -7649,6 +7969,13 @@ game (
 	year "1979"
 	developer "Exidy"
 	rom ( name fireone.zip size 23019 crc 8ea78b5f md5 19d65861cdd9c1b4704c520780ebbccc sha1 e7a590e70fcf6d572d14b6dbce85b9b91ad60c1a )
+)
+
+game (
+	name "Fire Shark"
+	year "1990"
+	developer "Toaplan"
+	rom ( name fireshrk.zip size 533656 crc fe7108e5 md5 f0d73a3e26839b427ed950a3ae234cb8 sha1 79c49bea2e1ccf5e2f8ba07a3a1c8581606af181 )
 )
 
 game (
@@ -7732,6 +8059,13 @@ game (
 	year "1987"
 	developer "Konami"
 	rom ( name flkatck.zip size 42800 crc 0b34ebfb md5 86f64e9f101f93502a9db1d8c1ec23f9 sha1 eac3081df4daf4c736f5497ec97e372e788a9027 )
+)
+
+game (
+	name "Flower"
+	year "1986"
+	developer "Komax"
+	rom ( name flower.zip size 75740 crc e81cd8c6 md5 fc99c48b9450844938c69f7bc547876d sha1 49f131cc3f947c3cca3f0056440b4bb61e9a9ee2 )
 )
 
 game (
@@ -9107,6 +9441,13 @@ game (
 )
 
 game (
+	name "Gratia - Second Earth (91022-10 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratiaa.zip size 1746388 crc 1d7e06c5 md5 e91546d3c85a7fc512dd74e86b3eb076 sha1 e7a896b18d73c415356390f67935e30e85f167e4 )
+)
+
+game (
 	name "Gravitar (version 3)"
 	year "1982"
 	developer "Atari"
@@ -9386,10 +9727,24 @@ game (
 )
 
 game (
+	name "Great 1000 Miles Rally"
+	year "1994"
+	developer "Kaneko"
+	rom ( name gtmr.zip size 4906312 crc 0faaff68 md5 a6b8ef0d66eb42ac162881238e9da8c7 sha1 7dfc026885c50a3570c33f2ffa16ceaaf967f6e1 )
+)
+
+game (
 	name "Mille Miglia 2: Great 1000 Miles Rally"
 	year "1995"
 	developer "Kaneko"
 	rom ( name gtmr2.zip size 5718258 crc 2ac10cee md5 4907cdf1766fae4e4ca978efba3b4ed0 sha1 a24048aa8204bfce58d141f3d19c2281b7673a64 )
+)
+
+game (
+	name "Great 1000 Miles Rally (Evolution Model)"
+	year "1994"
+	developer "Kaneko"
+	rom ( name gtmre.zip size 911563 crc 174d7d76 md5 bbd9d7a170e60b75cc9b003fb7834291 sha1 ebc23f95021e2f2ca9898853f4114b920d2dde7d )
 )
 
 game (
@@ -10321,6 +10676,13 @@ game (
 )
 
 game (
+	name "Hana Oriduru (Japan)"
+	year "1989"
+	developer "Dynax"
+	rom ( name hnoridur.zip size 497246 crc c3521819 md5 483ad9c04e411d532c3a79c648f9bdd7 sha1 9a5baca2a9dfa1fa5c4762283df941affe8ab9c6 )
+)
+
+game (
 	name "Hoccer (set 1)"
 	year "1983"
 	developer "Eastern Micro Electronics, Inc."
@@ -10353,6 +10715,13 @@ game (
 	year "1992"
 	developer "Sega"
 	rom ( name holo.zip size 5228140 crc 44be9ce3 md5 3664fdfd8d2ec53156ef54d350c1cb35 sha1 9e696362152232dac3f01cd13b7e12ff76485dce )
+)
+
+game (
+	name "Moero Pro Yakyuu Homerun"
+	year "1988"
+	developer "Jaleco"
+	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
 )
 
 game (
@@ -10524,6 +10893,13 @@ game (
 )
 
 game (
+	name "Hatch Catch"
+	year "1995"
+	developer "SemiCom"
+	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
+)
+
+game (
 	name "Hat Trick Hero (Japan)"
 	year "1990"
 	developer "Taito Corporation"
@@ -10626,6 +11002,20 @@ game (
 	year "1990"
 	developer "Atari Games"
 	rom ( name hydra.zip size 1392773 crc 7836f4e8 md5 0588a36f5fcb45420a9f60a2f70382a6 sha1 c75d2ab46d30a9da74da917c1c9e541856111b67 )
+)
+
+game (
+	name "Hydra (prototype 5/14/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap.zip size 912537 crc 1c74da4f md5 c36b8440732b9a4f6203e411763925b4 sha1 e3b17199ef877747c697bf7f397c2f8a94e7ea07 )
+)
+
+game (
+	name "Hydra (prototype 5/25/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap2.zip size 185358 crc ab6e42a3 md5 a6a9316bf18146b4408cb6713b717e77 sha1 5135408eb82a65412f7b144b6eb2d9b2615605b7 )
 )
 
 game (
@@ -10783,6 +11173,20 @@ game (
 )
 
 game (
+	name "Iga Ninjyutsuden (Japan)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name iganinju.zip size 901742 crc c2860aaf md5 0babe1c7921b24a00afedd59ca99a566 sha1 d29af4d4e8dd78a6c98e8db89faef85fbbdee1a7 )
+)
+
+game (
+	name "IGMO"
+	year "1984"
+	developer "Epos Corporation"
+	rom ( name igmo.zip size 20946 crc 9ff45478 md5 bac686b9e8c052852dc6fd2b06a14a51 sha1 55406a6c97dd5aa00b8171ae45c5cd243bbb2909 )
+)
+
+game (
 	name "Ikari Warriors (US)"
 	year "1986"
 	developer "SNK"
@@ -10815,6 +11219,13 @@ game (
 	year "1985"
 	developer "Sun Electronics"
 	rom ( name ikki.zip size 75792 crc 86dc9eff md5 70cefaeddbc9732c6acae6c07465b37f sha1 3fd8d8cecca4d3c8648e019b0f64075035f25554 )
+)
+
+game (
+	name "Imago"
+	year "1983"
+	developer "Acom"
+	rom ( name imago.zip size 30894 crc 236ffefa md5 6f34a01deb3f45a3594d0002745023e4 sha1 8aea054e3bf1d7fb97dcab0cfe8063041cd6dec2 )
 )
 
 game (
@@ -10906,6 +11317,13 @@ game (
 	year "1989"
 	developer "Taito Corporation Japan"
 	rom ( name insectx.zip size 545814 crc 96e2c167 md5 924a3e5ac43a7806ab2a3230fb24f8dc sha1 586079911f49d8c8ce87e1224a721feadc22797f )
+)
+
+game (
+	name "International Cup '94"
+	year "1994"
+	developer "Taito Corporation Japan"
+	rom ( name intcup94.zip size 367550 crc d3c037a9 md5 c38cc598a9bed4118f1e41eebdcbf3ca sha1 87e61dd7e4abeb4331e6d957ea8042f9a05f7ebc )
 )
 
 game (
@@ -11325,6 +11743,13 @@ game (
 )
 
 game (
+	name "Jump Kids"
+	year "1993"
+	developer "Comad"
+	rom ( name jumpkids.zip size 1099388 crc 463d7ed0 md5 c1f6eaedb75d963882441f11aedc50aa sha1 1c55bf2d0d8418d1e43d49c675c6c757d837f172 )
+)
+
+game (
 	name "Jump Shot"
 	year "1985"
 	developer "Bally Midway"
@@ -11455,6 +11880,13 @@ game (
 	year "1993"
 	developer "Toei / Banpresto"
 	rom ( name kamenrid.zip size 1645002 crc be8b3858 md5 dd5be3f5b58092d1c3ff64b886b95261 sha1 0291ac3e9296abb19ef7472d9c58fc06283bb23a )
+)
+
+game (
+	name "Kamikaze"
+	year "1979"
+	developer "Leijac"
+	rom ( name kamikaze.zip size 5696 crc b04acc2e md5 3342ca49d9d71e325891ac1e56581adf sha1 7bb208ca4825180704f906d5ed01ade61eb27cbd )
 )
 
 game (
@@ -11619,10 +12051,31 @@ game (
 )
 
 game (
+	name "Kick Goal"
+	year "1995"
+	developer "TCH"
+	rom ( name kickgoal.zip size 1189017 crc c3ff3382 md5 8b0dbd8e19bab863db541e5c48f3a13f sha1 25c2f7fe2bb255c1922c0866c98c129c9e5d713d )
+)
+
+game (
+	name "Kick and Run"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kicknrun.zip size 152032 crc 9a9b55cd md5 a80df6467b1ea03181520030eb0d5555 sha1 6dd6869b140cb579da5a478a29548c30cfdf1c60 )
+)
+
+game (
 	name "Kick Off (Japan)"
 	year "1988"
 	developer "Jaleco"
 	rom ( name kickoff.zip size 464558 crc 21cc580e md5 95a1ab4925d9416efd51fd52097645fb sha1 b35e21669a362b3e83e10237579c48f0a004e976 )
+)
+
+game (
+	name "Kick Rider"
+	year "1984"
+	developer "Universal"
+	rom ( name kickridr.zip size 37613 crc 6de518ec md5 f716a2652a69c8662cdea9f96e0bfa1b sha1 b7c14c94ba08fbcfbe2284d8b025ec2e51673eae )
 )
 
 game (
@@ -12102,6 +12555,13 @@ game (
 )
 
 game (
+	name "Kyukyoku Tiger (Japan)"
+	year "1987"
+	developer "[Toaplan] Taito Corporation"
+	rom ( name ktiger.zip size 43409 crc 184d5f36 md5 fa3ec97b2e809be0124debfd935ff4f3 sha1 fc6cf4d696448944a3552a4488c3ad60f9118b18 )
+)
+
+game (
 	name "Kyukyoku Tiger 2 (Japan)"
 	year "1995"
 	developer "Taito Corporation"
@@ -12155,6 +12615,13 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name kuniokub.zip size 336513 crc 83d142ce md5 fe480420fcee343957d7e81b28c50630 sha1 b2d9a360eb886d562434bc7b23b64ec8d40d19e7 )
+)
+
+game (
+	name "Nekketsu Kouha Kunio-kun (Japan)"
+	year "1986"
+	developer "Technos"
+	rom ( name kuniokun.zip size 336294 crc d64973ea md5 d8abbcb52095b328f3390aa4aac94626 sha1 ce9abdb28a5fb1df04d555eab433bdd1c4f208ad )
 )
 
 game (
@@ -12465,6 +12932,13 @@ game (
 )
 
 game (
+	name "Led Storm (US)"
+	year "1988"
+	developer "Capcom"
+	rom ( name ledstorm.zip size 194281 crc 890af49e md5 ac1019ec462f194001c313b3e408f5b1 sha1 5da26626b46dd35a214f3afe7a6e9410c6d1ad8b )
+)
+
+game (
 	name "Legend"
 	developer "Sega / Coreland ?"
 	rom ( name legend.zip size 93563 crc c1cd6e96 md5 a1adfa68818e2a1a29970392f4a4cfc1 sha1 2669f9d8997c766e937877e0e9f5cd74a9a64a43 )
@@ -12541,6 +13015,13 @@ game (
 )
 
 game (
+	name "Liberator (set 1)"
+	year "1982"
+	developer "Atari"
+	rom ( name liberatr.zip size 30734 crc ae5d1ad4 md5 c12ca5177907acb1f433b703ab682ce2 sha1 bd24a1ed7eb06e917e152378daf066c68a98a2fc )
+)
+
+game (
 	name "Libble Rabble"
 	year "1983"
 	developer "Namco"
@@ -12597,6 +13078,13 @@ game (
 )
 
 game (
+	name "The Legend of Kage (bootleg set 1)"
+	year "1984"
+	developer "bootleg"
+	rom ( name lkageb.zip size 63402 crc 5dba9243 md5 fd6ae55412ec8b294b84601b66991377 sha1 c0aa8b1bbc578a94f27f3c97fed643b2b81c8d7a )
+)
+
+game (
 	name "The Legend of Kage (bootleg set 2)"
 	year "1984"
 	developer "bootleg"
@@ -12608,6 +13096,20 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name lkageb3.zip size 63390 crc ef891bfb md5 5dce1fcdac356c4190a0ba259fbbc77e sha1 d68fd69a55c1f6a8cfb6e20c84a28c378da3f4b6 )
+)
+
+game (
+	name "Lunar Lander (rev 2)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander.zip size 9997 crc 82f5646d md5 fd30420a2e5ffc7cab354da41c962bcd sha1 5b7bb0bc7d4498a2b147b9ad80d339c2d05755b3 )
+)
+
+game (
+	name "Lunar Lander (rev 1)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander1.zip size 5509 crc ef1d7025 md5 65a0f11f9ba3552109bd1e8f6a773152 sha1 386572a7553751299c633e75808ec9976ffcbe58 )
 )
 
 game (
@@ -12884,6 +13386,13 @@ game (
 )
 
 game (
+	name "Macho Mouse"
+	year "1982"
+	developer "Techstar"
+	rom ( name machomou.zip size 17444 crc 345b8f23 md5 c270dd46676828d7de2ff194704543aa sha1 de2c27c14386683043fa6bc0ec57ccc74206a373 )
+)
+
+game (
 	name "Vs. Mach Rider (Japan, Fighting Course Version)"
 	year "1985"
 	developer "Nintendo"
@@ -12930,6 +13439,20 @@ game (
 	year "1995"
 	developer "Tuning"
 	rom ( name maddonna.zip size 2325661 crc 730605e7 md5 ff5d27bdfa8c13f8e6bf8c957646f10b sha1 dd796563799f31ba8ee54fb3c71f1a31493ad407 )
+)
+
+game (
+	name "Mad Gear (US)"
+	year "1989"
+	developer "Capcom"
+	rom ( name madgear.zip size 764354 crc 79278357 md5 209af18bbe611c703ff15aa3aaf8a6fb sha1 bf887ad6bd8b6877dd38d6b8e587825fc1c59c61 )
+)
+
+game (
+	name "Mad Gear (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name madgearj.zip size 97692 crc fe05e7c4 md5 4235c75b90587272c962aeb190314127 sha1 a7d11dbb1f4b0792ac0d5c0b1a53b5813c5d5e12 )
 )
 
 game (
@@ -13338,6 +13861,13 @@ game (
 )
 
 game (
+	name "The Masters of Kin"
+	year "1988"
+	developer "Du Tech"
+	rom ( name mastkin.zip size 39037 crc bc81cbc8 md5 8784d2fd5f868f372cd16783f2d18d4e sha1 53faf0a4430e23ceac8fde58ab4d0202864f0b2a )
+)
+
+game (
 	name "Match It"
 	year "1989"
 	developer "Tamtex"
@@ -13572,6 +14102,13 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name megazone.zip size 58725 crc fe8c220b md5 ff3a0267f5180d87b4b49ba636ed1727 sha1 8e9d8845542b9087d0754293cc0fdea655aad822 )
+)
+
+game (
+	name "Meikyuu Hunter G (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name meikyuh.zip size 389948 crc bbff1edf md5 c91e61822b6b0e12fd164da79cf7045b sha1 6104d32d7f95196b66d48a7d25d0b786ceae9533 )
 )
 
 game (
@@ -14451,6 +14988,13 @@ game (
 )
 
 game (
+	name "Monkey Donkey"
+	year "1981"
+	developer "bootleg"
+	rom ( name monkeyd.zip size 27176 crc 07c797bb md5 ada6fd90c6010deff8dbe8d50e44c409 sha1 350d6382ba94bd63b1a49dd270bee30d076d458d )
+)
+
+game (
 	name "Monster Bash"
 	year "1982"
 	developer "Sega"
@@ -14660,6 +15204,13 @@ game (
 )
 
 game (
+	name "Moon Patrol (Williams)"
+	year "1982"
+	developer "Irem (Williams license)"
+	rom ( name mpatrolw.zip size 15059 crc 600026a8 md5 ccedb92efbb2006de3335c3d30b9df93 sha1 6449c885a75027ec3ccaf86ecfe5d9b62993369e )
+)
+
+game (
 	name "Mad Planets"
 	year "1983"
 	developer "Gottlieb"
@@ -14776,6 +15327,13 @@ game (
 	year "1988"
 	developer "Home Data"
 	rom ( name mrokumei.zip size 384910 crc 5ba59aca md5 9ab98b6413380a7c4e4a9001be577873 sha1 042eeb9ec10d762edbbf19f52a7301377c079bfe )
+)
+
+game (
+	name "Mr. TNT"
+	year "1983"
+	developer "Telko"
+	rom ( name mrtnt.zip size 16312 crc 81babd83 md5 077a26144b4a30ed52bf7b5c6f1bb14a sha1 a6d3a4bda41274ffe538521c976f50c01e28b84c )
 )
 
 game (
@@ -15611,6 +16169,13 @@ game (
 )
 
 game (
+	name "News"
+	year "1993"
+	developer "Poby / Virus"
+	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
+)
+
+game (
 	name "New Sinbad 7"
 	year "1983"
 	developer "ATW USA, Inc."
@@ -15716,6 +16281,13 @@ game (
 )
 
 game (
+	name "Ninja Emaki (US)"
+	year "1986"
+	developer "Nichibutsu"
+	rom ( name ninjemak.zip size 219787 crc a6d62528 md5 00ec58d18b5efc4bc2335f6932f531e1 sha1 cbe53ea7f93e5ff597b56ec55880730bad91fc33 )
+)
+
+game (
 	name "Nightmare in the Dark"
 	year "2000"
 	developer "Eleven / Gavaking"
@@ -15741,6 +16313,13 @@ game (
 	year "1996"
 	developer "Nichibutsu"
 	rom ( name niyanpai.zip size 997812 crc c6a23980 md5 0b88935de104339f260b6df64644fecd sha1 8945fb99c2fb27be996c6cc141a3312f0bc74234 )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan bootleg)"
+	year "1987"
+	developer "Technos"
+	rom ( name nkdodgeb.zip size 208931 crc 5f93dffd md5 74335d8781287e2208e0a6996cf1b84c sha1 4a9ed5b5d1024b0678eb332f7a3549e315493d92 )
 )
 
 game (
@@ -16024,6 +16603,13 @@ game (
 )
 
 game (
+	name "Oigas (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name oigas.zip size 38954 crc 4e757952 md5 da23ddf94899c37ce7951ec3e4da700b sha1 c992d6620fd2092cb49c1b109a4f6aa2fe01a7b1 )
+)
+
+game (
 	name "Oishii Puzzle Ha Irimasenka"
 	year "1993"
 	developer "Sunsoft + Atlus"
@@ -16070,6 +16656,12 @@ game (
 	year "1981"
 	developer "Irem + GDI"
 	rom ( name olibochu.zip size 35413 crc ec73c654 md5 b308efcb8b0292b80b3e848702179d14 sha1 b8459d404213a189365fde83560797b3a6df6ec3 )
+)
+
+game (
+	name "Omega"
+	developer "bootleg?"
+	rom ( name omega.zip size 11706 crc 55590511 md5 a9e7452a3319fa5c34804f77069e1648 sha1 f28da823694ba01f17a6b0b484fbabac43492951 )
 )
 
 game (
@@ -16463,6 +17055,13 @@ game (
 )
 
 game (
+	name "Pac-Man _ Chomp Chomp"
+	year "1983"
+	developer "Namco"
+	rom ( name pacnchmp.zip size 14725 crc 3629b9ff md5 ed60052b942f48e55fc7b19acaab962a sha1 08a7af26d7cd3233cdea54b25dcab932d9591589 )
+)
+
+game (
 	name "Pac _ Pal"
 	year "1983"
 	developer "Namco"
@@ -16725,6 +17324,13 @@ game (
 	year "1996"
 	developer "Fuuki"
 	rom ( name pbancho.zip size 2257641 crc 9edd54cf md5 7cca2339628749297e3c85caf49501b3 sha1 a479c9984acebb1386ea2621bf53020010cafd7d )
+)
+
+game (
+	name "Prebillian"
+	year "1986"
+	developer "Taito"
+	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -17330,6 +17936,13 @@ game (
 )
 
 game (
+	name "Pest Place"
+	year "1983"
+	developer "bootleg"
+	rom ( name pestplce.zip size 29401 crc 776626de md5 5bb6dc7e2785a0087ede8e33d61fe6ea sha1 613b7e891eec5c65e62a32c1d5eb8002688f6d15 )
+)
+
+game (
 	name "Peter Pack-Rat"
 	year "1984"
 	developer "Atari Games"
@@ -17439,6 +18052,20 @@ game (
 	year "1983"
 	developer "Valadon Automation"
 	rom ( name pickin.zip size 16423 crc 47b51d97 md5 d33fdaef3fb8e635229d62749523d1e7 sha1 d690f1f63adf9914d40af437fde192bf0d2a6ab9 )
+)
+
+game (
+	name "Pig Newton (version C)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewt.zip size 39539 crc 8caec6e8 md5 4aa526afd8de76d481c8f510ecc6c540 sha1 16e1b78b72e9d242f8469c78146089be87933df3 )
+)
+
+game (
+	name "Pig Newton (version A)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewta.zip size 22397 crc 3165db85 md5 a4a3dd7245770186863bbbe06f76e986 sha1 ce8000b1585c8a19a3a2696fe4209e46f09d9165 )
 )
 
 game (
@@ -17701,6 +18328,13 @@ game (
 	year "1989"
 	developer "Taito Corporation Japan"
 	rom ( name plotting.zip size 71612 crc b0df8c3c md5 3159e359420ef336b5796558fec52d16 sha1 fdfa605577bd233e9aefc73db2a0d71f5e7cc07b )
+)
+
+game (
+	name "Plump Pop (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
 )
 
 game (
@@ -18180,6 +18814,13 @@ game (
 )
 
 game (
+	name "Power Surge"
+	year "1988"
+	developer "&lt;unknown&gt;"
+	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
+)
+
+game (
 	name "Psychic 5"
 	year "1987"
 	developer "Jaleco"
@@ -18422,6 +19063,13 @@ game (
 	year "1998"
 	developer "Mitchell"
 	rom ( name puzzloop.zip size 6091824 crc b529873b md5 0e46ac11cce225dba359b8e4dd21f97b sha1 d0acfc4099987865ab3d10c58b794aa1064c80b1 )
+)
+
+game (
+	name "Puzznic (Japan)"
+	year "1989"
+	developer "Taito Corporation"
+	rom ( name puzznic.zip size 130556 crc 6d8f3ce1 md5 a4db9301b0e631aa831a14431d5f5a9a sha1 1f6f9759fc0a38af71776b226f5d456f61fbefac )
 )
 
 game (
@@ -19069,6 +19717,13 @@ game (
 )
 
 game (
+	name "Raiga - Strato Fighter (Japan)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name raiga.zip size 90970 crc fa05c124 md5 71411a99eca13b295c9d12e018c0126c sha1 5f2b2a3fd5c7dc90b3494cfa3cf508c135dbbf92 )
+)
+
+game (
 	name "Raimais (Japan)"
 	year "1988"
 	developer "Taito Corporation"
@@ -19432,6 +20087,13 @@ game (
 )
 
 game (
+	name "Renegade (US)"
+	year "1986"
+	developer "Technos (Taito America license)"
+	rom ( name renegade.zip size 376370 crc 5b8a287f md5 497b058836630f20504bfe961f042a0e sha1 9fe0443988f8d204b9c8c7f311d5d2f4aaf03c09 )
+)
+
+game (
 	name "Repulse"
 	year "1985"
 	developer "Sega"
@@ -19604,6 +20266,13 @@ game (
 	year "1985"
 	developer "Data East USA"
 	rom ( name ringkin2.zip size 126315 crc 491bb57e md5 a533f8aa7a193084b15326cab636d58e sha1 8e5ef33ee765d5914cebd8145463dba4675ae33d )
+)
+
+game (
+	name "Ring King (US set 3)"
+	year "1985"
+	developer "Data East USA"
+	rom ( name ringkin3.zip size 51487 crc 8477224e md5 d8f8ae506855b425e37bfc04624d489f sha1 64ba4cab2432c6bb6ddfe7074f9c895956ea2f83 )
 )
 
 game (
@@ -19943,6 +20612,20 @@ game (
 )
 
 game (
+	name "Rock'n Tread (Japan)"
+	year "1999"
+	developer "Jaleco"
+	rom ( name rockn.zip size 2374149 crc aad0254a md5 9baa2fe1811efe447bddbe3288a578fb sha1 0990db97f88e713764769091e604f6b6641c7cab )
+)
+
+game (
+	name "Rock 'n Rage (World?)"
+	year "1986"
+	developer "Konami"
+	rom ( name rockrage.zip size 291478 crc bc8fa769 md5 e3ec5bed9b367d29ced07dfc67ff0c2e sha1 4e10727b60f34f903ba42e9fa8b74d0367936172 )
+)
+
+game (
 	name "Koi no Hotrock (Japan)"
 	year "1986"
 	developer "Konami"
@@ -20235,6 +20918,13 @@ game (
 )
 
 game (
+	name "Run and Gun (World ver. EAA)"
+	year "1993"
+	developer "Konami"
+	rom ( name rungun.zip size 7092222 crc c52ee2c5 md5 c27befac8f2e02a558342d4fcd2b27f3 sha1 845639a31554d51fd337f944e6414835136ffc90 )
+)
+
+game (
 	name "Run and Gun (US ver. UAB)"
 	year "1993"
 	developer "Konami"
@@ -20417,6 +21107,13 @@ game (
 )
 
 game (
+	name "Sai Yu Gou Ma Roku (Japan)"
+	year "1988"
+	developer "Technos"
+	rom ( name saiyugou.zip size 95396 crc ea2ac88d md5 d61361c1cd7865e2a851aa6dd9813f6b sha1 dbb720739e0d7f9e4acdcc3ce4c0d2b1ead2499a )
+)
+
+game (
 	name "Salamander (version D)"
 	year "1986"
 	developer "Konami"
@@ -20428,6 +21125,20 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name salamanj.zip size 66954 crc eeedb894 md5 4eff2d718b0f59dc9a0d7d8fa9badff9 sha1 f21919ec161fecb68f42052e6dfa024d6ca03665 )
+)
+
+game (
+	name "Same! Same! Same! (2P Ver.)"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesam2.zip size 34348 crc 349722b8 md5 711f5813cac7e32f9cc90b2dc167ac0b sha1 9fb537d6d2e4f93256053239a83aaa163bbe440e )
+)
+
+game (
+	name "Same! Same! Same!"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame.zip size 78015 crc 0138e552 md5 d2b44aebc267ca9b9c269f31d5bd4168 sha1 166f3ad0618219fdc19748a602cff4f628100e13 )
 )
 
 game (
@@ -21585,6 +22296,13 @@ game (
 )
 
 game (
+	name "Sheriff"
+	year "1979"
+	developer "Nintendo"
+	rom ( name sheriff.zip size 9418 crc 9383d774 md5 3c9f7ac4bf8382038b3177fec64f60bc sha1 b3ebb4b83f79c11a62346ee7ab88cb8baf23ffa2 )
+)
+
+game (
 	name "Shienryu"
 	year "1997"
 	developer "Warashi"
@@ -22226,6 +22944,13 @@ game (
 )
 
 game (
+	name "Slam Dunk (Japan ver. JAA))"
+	year "1993"
+	developer "Konami"
+	rom ( name slmdunkj.zip size 122411 crc b7571e84 md5 cf55eb867df4e01c51d3ff3c6ee0be4c sha1 6bed5b9b4d2e2916c30e8d723fa2bfc068f690ba )
+)
+
+game (
 	name "Sly Spy (US revision 3)"
 	year "1989"
 	developer "Data East USA"
@@ -22582,6 +23307,13 @@ game (
 )
 
 game (
+	name "Space Echo"
+	year "1980"
+	developer "bootleg"
+	rom ( name spacecho.zip size 13710 crc c0f7d9bf md5 1941203e2e1b85176e2195a81d3ede87 sha1 a0c992f084668d556624d2ae2e5a59dcfce6d6c3 )
+)
+
+game (
 	name "Space Cruiser"
 	year "1981"
 	developer "Taito Corporation"
@@ -22882,6 +23614,13 @@ game (
 )
 
 game (
+	name "Super Dodge Ball (US)"
+	year "1987"
+	developer "Technos"
+	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
+)
+
+game (
 	name "Speak _ Rescue"
 	year "1980"
 	developer "Sun Electronics"
@@ -23124,6 +23863,13 @@ game (
 	year "1977"
 	developer "Atari"
 	rom ( name sprint4.zip size 7441 crc 88d66f96 md5 3d4c57f4f542015e433a6f232ce61b3a sha1 3530a3f6d6547c98c97b8b5ceb2e63a6c81da14d )
+)
+
+game (
+	name "Sprint 4 (set 2)"
+	year "1977"
+	developer "Atari"
+	rom ( name sprint4a.zip size 509 crc bcf61846 md5 04b348f9aa230ac2318a550740d4d915 sha1 8e62b7c56c8c0361145f886767499254591a7b0d )
 )
 
 game (
@@ -23589,6 +24335,20 @@ game (
 )
 
 game (
+	name "Super Speed Race Junior (Japan)"
+	year "1985"
+	developer "Taito Corporation"
+	rom ( name ssrj.zip size 29266 crc f29fcd99 md5 42aaf020b93e61ad2196c27b2916f230 sha1 63af6180f45d2a76a5d15bb69de3b3166cea0916 )
+)
+
+game (
+	name "Super Stingray"
+	year "1986"
+	developer "Alpha Denshi Co."
+	rom ( name sstingry.zip size 120433 crc 33fee390 md5 0180ce799c7e9c2146f3f70c91efb7cd sha1 0a556fcb40164d496422cabbb38334424289ba2d )
+)
+
+game (
 	name "Space Stranger"
 	year "1978"
 	developer "Yachiyo Electronics, Ltd."
@@ -23740,6 +24500,13 @@ game (
 	year "1983"
 	developer "Sega"
 	rom ( name starjack.zip size 49146 crc cdfa7350 md5 f3a130a94a20f2928eb4daeaaf7c930a sha1 89fc6c78c094aa98daf0b20304965429c912b5da )
+)
+
+game (
+	name "Star Jacker (Stern)"
+	year "1983"
+	developer "Stern"
+	rom ( name starjacs.zip size 30704 crc ab59f314 md5 74c54f92337bf9e4d195a6c63417726d sha1 f836e384d9aa4e216b02db1fe2f93cd9d8326ae6 )
 )
 
 game (
@@ -23978,6 +24745,13 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name stratgyx.zip size 22018 crc fe4b2868 md5 00246fda59f8ed63c1e6113a6953a460 sha1 93f571880f62c40304d0784c475534e62a7cad14 )
+)
+
+game (
+	name "Raiga - Strato Fighter (US)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
 )
 
 game (
@@ -24226,6 +25000,12 @@ game (
 )
 
 game (
+	name "Super Bond"
+	developer "bootleg"
+	rom ( name superbon.zip size 20193 crc 56f1e60e md5 b825b187495ab8d327159e5d6a4f66f4 sha1 7ce5066f30c5a5a07f329376dd863408704e24fa )
+)
+
+game (
 	name "Super Bug"
 	year "1977"
 	developer "Atari"
@@ -24383,6 +25163,20 @@ game (
 	year "1993"
 	developer "Namco"
 	rom ( name suzuk8h2.zip size 3490793 crc c325814d md5 78df5bd42550019d3cb6dac0787274c1 sha1 49c702bb0a0bcbe877552bf04f5fe7d1e7f01f28 )
+)
+
+game (
+	name "Suzuka 8 Hours (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuk8hj.zip size 253079 crc 81cb8614 md5 7bd7445a6ccb450d4395e983b663e450 sha1 9a2c7e66d23af7264457c6c43ca0907d1d831ad6 )
+)
+
+game (
+	name "Suzuka 8 Hours (World?)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8h.zip size 2188886 crc 999bb67f md5 1993ea3e6715735ffc9b779682f8f997 sha1 aba636d40c75afb6186e582b43f23dd69377f0b7 )
 )
 
 game (
@@ -24834,6 +25628,20 @@ game (
 )
 
 game (
+	name "Tekken 2 Ver.B (TES3/VER.B)"
+	year "1995"
+	developer "Namco"
+	rom ( name tekken2.zip size 20925868 crc c583c399 md5 abb99e56d070bc47b66d1ffd165a40e4 sha1 d33888b45712b04b7dab9947dc5ee96705f6fbf8 )
+)
+
+game (
+	name "Tekken 2 Ver.B (TES2/VER.B)"
+	year "1995"
+	developer "Namco"
+	rom ( name tekken2a.zip size 1580705 crc d5a85772 md5 971db4de91584c690c3d2ac09bd8cf29 sha1 99c684dda6163643012e3e6fda459a2303faf64b )
+)
+
+game (
 	name "Tekken 2 (TES2/VER.A)"
 	year "1995"
 	developer "Namco"
@@ -25260,6 +26068,13 @@ game (
 )
 
 game (
+	name "Time Limit"
+	year "1983"
+	developer "Chuo Co. Ltd"
+	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
+)
+
+game (
 	name "Time Pilot"
 	year "1982"
 	developer "Konami"
@@ -25348,6 +26163,13 @@ game (
 	year "1987"
 	developer "Namco LTD."
 	rom ( name tkoboxng.zip size 63570 crc 8643e559 md5 d767dabecbdfcee8c6f51ef9a23b8e88 sha1 2c30aa5d40cbae09d35c3153c03314035be11330 )
+)
+
+game (
+	name "T-MEK (prototype)"
+	year "1994"
+	developer "Atari Games"
+	rom ( name tmekprot.zip size 244746 crc 8b9f3223 md5 e14ada0002eb8dfc384a66f62eb5fb4c sha1 759f40be85011aa3b480413991985795db079e64 )
 )
 
 game (
@@ -25645,6 +26467,13 @@ game (
 )
 
 game (
+	name "Top Racer"
+	year "1982"
+	developer "bootleg"
+	rom ( name topracer.zip size 45371 crc 66a62912 md5 63bc12b0052c8ef4a6df605333231fec sha1 54ec0fbc0e6b3f1f63f3f64ba0a7a8246497418b )
+)
+
+game (
 	name "Top Secret (Exidy) (version 1.0)"
 	year "1986"
 	developer "Exidy"
@@ -25691,6 +26520,13 @@ game (
 	year "1994"
 	developer "Metro"
 	rom ( name toride2g.zip size 1056837 crc 03952538 md5 4636b2873c0d6ed3bd51f02b50e60af3 sha1 e537483cf093475b07ec326bbfd121648074f399 )
+)
+
+game (
+	name "Tornado Baseball"
+	year "1976"
+	developer "Midway"
+	rom ( name tornbase.zip size 4614 crc cd9162da md5 2d727019221dda840e7d6151b0a2c4ac sha1 90dc2fc8de46ce4ea9ccc6cf22cc1c1ff996c2f9 )
 )
 
 game (
@@ -26104,6 +26940,13 @@ game (
 )
 
 game (
+	name "Tough Turf (Japan)"
+	year "1989"
+	developer "Sega / Sunsoft"
+	rom ( name tturf.zip size 525537 crc 70ea1981 md5 8304be2da36d36ae7d66ed9f5b0afaec sha1 fe77c82c9585756d0d0b95e6373afdf1830b8936 )
+)
+
+game (
 	name "Tough Turf (bootleg)"
 	year "1989"
 	developer "bootleg"
@@ -26206,6 +27049,13 @@ game (
 	year "1991"
 	developer "Video System Co."
 	rom ( name turbofrc.zip size 2234188 crc 89b0f71a md5 674b328b5d418b6a8e2d7ca9984c7b39 sha1 78abef997aa3f3b5538b6ef09550822a50eedabd )
+)
+
+game (
+	name "Turbo Tag (prototype)"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name turbotag.zip size 81230 crc b9f51999 md5 c9b7a23bcffe9c84e58727ef8b212a5a sha1 2a13a5a5508ecb79174bb521ef77ad9591fcaa95 )
 )
 
 game (
@@ -26423,6 +27273,13 @@ game (
 	year "1994"
 	developer "Midway"
 	rom ( name umk3r11.zip size 7368570 crc f97bab62 md5 8360cb4441e0c407a826fe0580b4bf90 sha1 ad9c8d366682b5457a474c2f93e1dfd31f97e6db )
+)
+
+game (
+	name "The Undoukai (Japan)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name undoukai.zip size 97596 crc 1dec3d90 md5 450624ba6b92513df4363e2486072614 sha1 a599ef09eef56ca0adc97f743ee1c1a0509e8f8c )
 )
 
 game (
@@ -26895,6 +27752,27 @@ game (
 )
 
 game (
+	name "Vimana"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
+)
+
+game (
+	name "Vimana (old set)"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana1.zip size 87452 crc b0fb5004 md5 de2e2733070b6b3f3297fb2d25d86c4d sha1 db38432f670ea24c7102ef2f8c6d67914375ca06 )
+)
+
+game (
+	name "Vimana (Nova Apparate GMBH _ Co)"
+	year "1991"
+	developer "Toaplan (Nova Apparate GMBH &amp; Co license)"
+	rom ( name vimanan.zip size 87678 crc ca61b5d0 md5 bfd828f2653fea976d8c4367836d433c sha1 4a6f5300832dcb0f7211993cb427f9b80a7308dd )
+)
+
+game (
 	name "Vindicators Part II (rev 1)"
 	year "1988"
 	developer "Atari Games"
@@ -27357,6 +28235,13 @@ game (
 )
 
 game (
+	name "World Beach Volley"
+	year "1995"
+	developer "Playmark"
+	rom ( name wbeachvl.zip size 3037511 crc a7e64b63 md5 8c24a0dc0f0fc04202edb0a0324154c3 sha1 671d53acb9f10c23e5b8fa5974c20b8b9c3f0109 )
+)
+
+game (
 	name "Wonder Boy in Monster Land"
 	year "1987"
 	developer "bootleg"
@@ -27599,6 +28484,13 @@ game (
 	year "1988"
 	developer "Exidy"
 	rom ( name whodunit.zip size 273900 crc 52cee884 md5 2d718375ab885d061236385865adce9c sha1 b5bb83d81847a84654338446a0013a4d5a2885bc )
+)
+
+game (
+	name "Whoopee!! / Pipi _ Bibis"
+	year "1991"
+	developer "Toaplan"
+	rom ( name whoopee.zip size 68021 crc bea52d7b md5 f90a71d7e6cacb59359f6040c5f98ed5 sha1 c99ca0bbdc210aefcaeea3bda7b260f8ab16e784 )
 )
 
 game (
@@ -28089,6 +28981,13 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311644 crc b7c4c47d md5 0606cddfb28aed80f9b14872b48a64be sha1 9ba6c05718b348ae4330a695fa158a15457d00a6 )
+)
+
+game (
+	name "Xybots (rev 0)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name xybots0.zip size 140017 crc 8912445f md5 889deaa0e89706497b74dcae3f1dfa63 sha1 7baa378ac5fd7527467d2810d8168d7c3dd580df )
 )
 
 game (

--- a/metadat/mame-split/MAME 2010.dat
+++ b/metadat/mame-split/MAME 2010.dat
@@ -1,6 +1,14 @@
 clrmamepro (
-  name "MAME 2010 Split Working"
+  name "MAME 2010 - Split TorrentZipped Working Romsets"
   version "2019-01-03"
+  description "Format: Split, Working Romsets Only, TorrentZipped"
+)
+
+game (
+	name "005"
+	year "1981"
+	developer "Sega"
+	rom ( name 005.zip size 29769 crc d123fe67 md5 64ba2c1869a491bdae1384d3a95c2027 sha1 aeebfd4a3a6214e6efed19dd4d5716215e253b13 )
 )
 
 game (
@@ -29,6 +37,13 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name 1941.zip size 1419821 crc de03fb24 md5 3a72d8463b47ce63dee199137a13ac64 sha1 d6ee54766d377d1136f6a5e17b772666a072e74e )
+)
+
+game (
+	name "1941: Counter Attack (Japan)"
+	year "1990"
+	developer "Capcom"
+	rom ( name 1941j.zip size 198831 crc 3e3858d8 md5 a7f35765472e9ea9dada3261ea653641 sha1 1fecb5f198c4dcc4e65968a63bd9b8a92f27e13e )
 )
 
 game (
@@ -64,6 +79,34 @@ game (
 	year "1985"
 	developer "Capcom (Williams Electronics license)"
 	rom ( name 1942w.zip size 42673 crc a348c6c4 md5 d587d7159b8dc29bab7b92938a2ac5ba sha1 980739111a38690ccd7022b9267a96e09bfe5d20 )
+)
+
+game (
+	name "1943: The Battle of Midway (Euro)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943.zip size 305392 crc d0e80fef md5 905c7d99b594af7fe2ac31392835e9b8 sha1 a5acd39d166a43450b8f01cafe1a6e98e7122b4e )
+)
+
+game (
+	name "1943: Midway Kaisen (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943j.zip size 63104 crc 47fdfba8 md5 0d85af4d039673d06b5813c804eab8b0 sha1 227b07dedd6430ebd6e88beca0f9bb3b7174ca40 )
+)
+
+game (
+	name "1943 Kai: Midway Kaisen (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943kai.zip size 313068 crc 992baef8 md5 763bf59dd41cfbf9540330b541d03f35 sha1 a4b53090206e4d7186a9615b6c3f3c7654b4d93e )
+)
+
+game (
+	name "1943: The Battle of Midway (US)"
+	year "1987"
+	developer "Capcom"
+	rom ( name 1943u.zip size 62872 crc 433c6a96 md5 251ef0ad4c1144a86f2278019b7fa0b0 sha1 a0970a904a869def6a4354250b4021a67552e306 )
 )
 
 game (
@@ -207,6 +250,13 @@ game (
 )
 
 game (
+	name "3 Bags Full - 3VXFC5345 (New Zealand)"
+	year "1994"
+	developer "Aristocrat"
+	rom ( name 3bagflnz.zip size 53100 crc abe7d8ba md5 ae05bc562a050ac57d08bd3b2978de5e sha1 93b2902480c056be234514c6b2ecf7545fabe2d4 )
+)
+
+game (
 	name "3 Count Bout / Fire Suplex"
 	year "1993"
 	developer "SNK"
@@ -218,6 +268,13 @@ game (
 	year "1985"
 	developer "Nichibutsu"
 	rom ( name 3ds.zip size 93856 crc 28ae71bf md5 5ebb59f496cff93fe75c83344c2d4cf5 sha1 f7e5498b3fdc92ff34fcb5736047cf57cb36f2d0 )
+)
+
+game (
+	name "XESS - The New Revolution (SemiCom 3-in-1)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name 3in1semi.zip size 1187337 crc c8ce23a8 md5 37ab524977d28c1fee901ddfdf200a02 sha1 5655e9f337cf9ddb9451a3ecc2ba22b27fe46e82 )
 )
 
 game (
@@ -253,6 +310,27 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name 3wondersu.zip size 356164 crc 42a1b2af md5 60b5de4b7b0fc1216bb3ed9d9c7d22c0 sha1 91a9484929d961dd20581b71d484ee9c66e717d5 )
+)
+
+game (
+	name "Forty-Love"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name 40love.zip size 95925 crc c7304fc0 md5 74493a84f2a9b15b328e63ff16ce4f2a sha1 db31ad6a38b3b3265d3fc5aa0c31b0b85a924cb0 )
+)
+
+game (
+	name "Idol Janshi Su-Chi-Pie 2 (v1.1)"
+	year "1994"
+	developer "Jaleco"
+	rom ( name 47pie2.zip size 10228866 crc 09321e19 md5 f9d67336316a83050a1be7d3e174990c sha1 158bf6e56bcfdc03d0a32f7d881a07351554c8fd )
+)
+
+game (
+	name "Idol Janshi Su-Chi-Pie 2 (v1.0)"
+	year "1994"
+	developer "Jaleco"
+	rom ( name 47pie2o.zip size 753148 crc 97f1499c md5 63ef035a625f57b88c0e005cc1b519d5 sha1 74cbdac53287a774fafc99f67ba7932f03cac6e9 )
 )
 
 game (
@@ -298,6 +376,13 @@ game (
 )
 
 game (
+	name "Five Clown (English, set 2)"
+	year "1993"
+	developer "IGS"
+	rom ( name 5clowna.zip size 13513 crc a225b8a1 md5 12417f34738d661e66dd4ca1812b9efd sha1 1cbb4ace0dd0215bfa9ff63bf5ee912804ae4967 )
+)
+
+game (
 	name "Five Clown (Spanish hack)"
 	year "1993"
 	developer "IGS"
@@ -309,6 +394,20 @@ game (
 	year "1981"
 	developer "Konami"
 	rom ( name 600.zip size 14326 crc d5525571 md5 d2b402201bba517b9d100c2731ece9b4 sha1 55261d6a9e522cebfa8c1fc586f288cf5deb14f0 )
+)
+
+game (
+	name "64th. Street - A Detective Story (World)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64street.zip size 1294031 crc 5ab8660e md5 fb5ba76f93217b5bf1bc9afd9fbb0de8 sha1 2ca1542218ad19245a55f329cfcce1cd1290381a )
+)
+
+game (
+	name "64th. Street - A Detective Story (Japan)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name 64streetj.zip size 108598 crc 1ffe5fb9 md5 e101e9161e72f624dbe178a3caca8255 sha1 123d0776a452658849a27a124182a9cbef9607f5 )
 )
 
 game (
@@ -409,6 +508,20 @@ game (
 )
 
 game (
+	name "Eight Ball Action (DK conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Magic Eletronics USA license)"
+	rom ( name 8ballact.zip size 16261 crc c7b9822e md5 81cc86d18b8604c5ba85de72830011b6 sha1 3024248c8c6f47b2ed4ac525b428236c43dafcd0 )
+)
+
+game (
+	name "Eight Ball Action (DKJr conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Magic Eletronics USA license)"
+	rom ( name 8ballact2.zip size 15523 crc 79ca2322 md5 6a279a7c5cfb030d1e2cd3bac33d23d5 sha1 da2aea3362ccf1ed1262d0f12520e0defbbd24a5 )
+)
+
+game (
 	name "Eight Ball Action (Pac-Man conversion)"
 	year "1985"
 	developer "Seatongrove Ltd (Magic Eletronics USA license)"
@@ -469,6 +582,13 @@ game (
 	year "1998"
 	developer "Atari Games"
 	rom ( name a51mxr3k.zip size 292721 crc 985fabf5 md5 2e7914b5ff2238a81fe1041b7fcacb95 sha1 1df0b4dae65689d5d2f40382c1a1f79f9011ecbd )
+)
+
+game (
+	name "All American Football (rev E)"
+	year "1989"
+	developer "Leland Corp."
+	rom ( name aafb.zip size 525577 crc 4535f25a md5 234ae3914d7eb81036e38beb0eca4d9b sha1 4e33bdea83ad2897e40855ed163ba0d06eb4e5de )
 )
 
 game (
@@ -619,6 +739,13 @@ game (
 )
 
 game (
+	name "Acclaim PSX"
+	year "1995"
+	developer "Acclaim"
+	rom ( name acpsx.zip size 126167 crc 9c9601ca md5 fcb631bf18a56f2d5b077fa846bab4a6 sha1 5426d52e17e0ff9195fabbb42f704342e556d08e )
+)
+
+game (
 	name "Acrobat Mission"
 	year "1991"
 	developer "UPL (Taito license)"
@@ -714,6 +841,20 @@ game (
 	year "1989"
 	developer "Data East Corporation"
 	rom ( name actfancrj.zip size 51433 crc 69e2089e md5 2e1376a3ac79eb39d050ca20f88fb43d sha1 bdd910c192b4a4fae71db40fed3f7e19f1d42118 )
+)
+
+game (
+	name "Action Hollywood"
+	year "1995"
+	developer "TCH"
+	rom ( name actionhw.zip size 1321130 crc 34e2ced3 md5 560b7326579a82c1f92de6949a84960b sha1 4078379bf8e45be863a1ce175841f213def23e10 )
+)
+
+game (
+	name "A. D. 2083"
+	year "1983"
+	developer "Midcoin"
+	rom ( name ad2083.zip size 37545 crc 3676a561 md5 0838dc3da631045ddf93611f0d32090f sha1 0d59e1987ce60306df165d307ef0c26e3677b38c )
 )
 
 game (
@@ -878,10 +1019,45 @@ game (
 )
 
 game (
+	name "Air Buster: Trouble Specialty Raid Unit (World)"
+	year "1990"
+	developer "Kaneko (Namco license)"
+	rom ( name airbustr.zip size 693968 crc d9e397ed md5 48fe2cda23a4ec913b254fcf67ca17b0 sha1 9f3d12511be5bc05d17c220d1a933a12698df5f1 )
+)
+
+game (
 	name "Air Buster: Trouble Specialty Raid Unit (bootleg)"
 	year "1990"
 	developer "bootleg"
 	rom ( name airbustrb.zip size 693421 crc c104e133 md5 2f84a386de9d416ad6eb735afe966d7f sha1 5325ed965ec5cbb0ea22b314ae058f534d4f550e )
+)
+
+game (
+	name "Air Buster: Trouble Specialty Raid Unit (Japan)"
+	year "1990"
+	developer "Kaneko (Namco license)"
+	rom ( name airbustrj.zip size 118196 crc 35ba7c90 md5 69a1f9c8b11fc541bbec7b07249c55ce sha1 7dc27b2def38201b4a21b8c4a30a2294cb9acd45 )
+)
+
+game (
+	name "Air Duel (Japan)"
+	year "1990"
+	developer "Irem"
+	rom ( name airduel.zip size 1129917 crc 9d4f621c md5 f32170fdb460883767cdd30e3fec4def sha1 3a77c08f548679ff8f1d7e2a5722e7031e0ae797 )
+)
+
+game (
+	name "Airwolf"
+	year "1987"
+	developer "Kyugo"
+	rom ( name airwolf.zip size 81889 crc 11104399 md5 962be6e1dcc6bff7861750416468419d sha1 6d139e060f781ee3a41618113aff13d0a9836942 )
+)
+
+game (
+	name "Airwolf (US)"
+	year "1987"
+	developer "Kyugo (UA Theatre license)"
+	rom ( name airwolfa.zip size 18845 crc c2d30740 md5 9e2e1a233be9d6e8f19148d96e7541df sha1 04580466196d2b9130dd61172706373338e268ae )
 )
 
 game (
@@ -906,6 +1082,13 @@ game (
 )
 
 game (
+	name "Mahjong Angel Kiss"
+	year "1995"
+	developer "Jaleco"
+	rom ( name akiss.zip size 13222340 crc 63cbbff4 md5 6c26fe69eb301a68a489174881fb58ae sha1 834cbff5a4e90fb9fdeb10e550cf7090dbe3a6aa )
+)
+
+game (
 	name "Akkanbeder (Ver 2.5J 1995/06/14)"
 	year "1995"
 	developer "Taito Corporation"
@@ -927,10 +1110,30 @@ game (
 )
 
 game (
+	name "Aleck64 PIF BIOS"
+	year "1998"
+	developer "Nintendo / Seta"
+	rom ( name aleck64.zip size 1826 crc 51015e32 md5 de240f38f9f6f0e99a011a1f9b677b2c sha1 6f2f76832d6dc2c18997421ba26d22d623715c77 )
+)
+
+game (
 	name "Alex Kidd: The Lost Stars (set 2, unprotected)"
 	year "1986"
 	developer "Sega"
 	rom ( name alexkidd.zip size 304621 crc fc637b17 md5 67500ca0b423e124c535694e5b4b6ef1 sha1 e6a43a2322a9096b77cf9c4d6e42310031769916 )
+)
+
+game (
+	name "Alex Kidd: The Lost Stars (set 1, FD1089A 317-0021)"
+	year "1986"
+	developer "Sega"
+	rom ( name alexkidd1.zip size 170861 crc d193ba16 md5 f4db60e727d234b7227fd4816b25c219 sha1 46ff1d3297d17e27400fafbff405fb322b445929 )
+)
+
+game (
+	name "American Laser Games BIOS"
+	developer "American Laser Games"
+	rom ( name alg_bios.zip size 143143 crc e33e63b6 md5 5e9ad7949b8a754013450a682038a0ae sha1 c98ea1d28015f0ec5c59c6c314b9750c88bea857 )
 )
 
 game (
@@ -1100,6 +1303,20 @@ game (
 )
 
 game (
+	name "Alpha One (prototype, 3 lives)"
+	year "1983"
+	developer "Atari"
+	rom ( name alphaone.zip size 53724 crc d26f9b80 md5 739eea18d143762de1dde265fe0a73c5 sha1 300688c44035ef36dd2aa3e6879146efca364da7 )
+)
+
+game (
+	name "Alpha One (prototype, 5 lives)"
+	year "1983"
+	developer "Atari"
+	rom ( name alphaonea.zip size 53721 crc 67526513 md5 bc830cd225c8a21fbe2318a0b3e544ed sha1 79c3ee3e5322dfa3807269b94c5d56a83e53cf8b )
+)
+
+game (
 	name "The Alphax Z (Japan)"
 	year "1986"
 	developer "Ed Co. Ltd. (Wood Place Inc. license)"
@@ -1156,6 +1373,13 @@ game (
 )
 
 game (
+	name "Altered Beast (set 8, 8751 317-0078)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeast.zip size 848905 crc e431711b md5 64ae9698dd3816c123e464ef1df3f446 sha1 5d1431b186c2fe481bc7c2a84f565405e1ed1c9a )
+)
+
+game (
 	name "Altered Beast (set 2, MC-8123B 317-0066)"
 	year "1988"
 	developer "Sega"
@@ -1167,6 +1391,20 @@ game (
 	year "1988"
 	developer "Sega"
 	rom ( name altbeast4.zip size 699995 crc b9f505ec md5 cdfa54ca9337a279f04ede84b42c075e sha1 cde4639d7f9c03f443b3e3e832869a77ed21d56b )
+)
+
+game (
+	name "Altered Beast (set 6, 8751 317-0076)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeast5.zip size 668682 crc 85347f3b md5 150869a07b28ef1012d9c4d30ed59c07 sha1 519055a3c5fe7f702441045f496e17d5609880d7 )
+)
+
+game (
+	name "Juuouki (set 7, Japan, 8751 317-0077)"
+	year "1988"
+	developer "Sega"
+	rom ( name altbeastj.zip size 668488 crc 8d90dcd0 md5 3ceb4c488fd96e55081df9755ac16f33 sha1 39daaa89c097c1ad256c641a476449514069b619 )
 )
 
 game (
@@ -1471,6 +1709,13 @@ game (
 )
 
 game (
+	name "Animalandia Jr. (Spanish)"
+	year "1993"
+	developer "Nakanihon / East Technology (Taito license)"
+	rom ( name animaljrs.zip size 515968 crc 543dc3d8 md5 db5e3fdee3cdad39f3dfc0ace4d72977 sha1 e5444947e2c8d8e85c68895f076b7a8ace51449a )
+)
+
+game (
 	name "Animal Treasure Hunt (Version 1.9R, set 1)"
 	year "2003"
 	developer "Amcoe"
@@ -1730,6 +1975,13 @@ game (
 )
 
 game (
+	name "Arcadia System BIOS"
+	year "1988"
+	developer "Arcadia Systems"
+	rom ( name ar_bios.zip size 381100 crc 66756cd3 md5 04dbc0477b2c69c7df85ab6ce8a1e56c sha1 ab48982b7998dd03235aba1e86fbad669f3907e5 )
+)
+
+game (
 	name "SportTime Bowling (Arcadia, V 2.1)"
 	year "1988"
 	developer "Arcadia Systems"
@@ -1741,6 +1993,13 @@ game (
 	year "1987"
 	developer "Arcadia Systems"
 	rom ( name ar_dart.zip size 326135 crc 8cbc717c md5 6df354d34bb00d6794ec8a5b092ccaf7 sha1 0031cfb122f07695c3ab395882d60274208cc218 )
+)
+
+game (
+	name "Magic Johnson's Fast Break (Arcadia, V 2.8)"
+	year "1988"
+	developer "Arcadia Systems"
+	rom ( name ar_fast.zip size 485048 crc 196c2e53 md5 259252446be16ccb76785cef691d4a7f sha1 527927ba7d8089a555566b7f452e30aa60cdaf3a )
 )
 
 game (
@@ -1904,6 +2163,20 @@ game (
 )
 
 game (
+	name "Arch Rivals (rev 4.0)"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name archrivl.zip size 360208 crc d8667efb md5 9152563491b6a5244b57c291b63cbd2c sha1 680e6b296fcc288dc90aa11ae571d6566fc73c80 )
+)
+
+game (
+	name "Arch Rivals (rev 2.0)"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name archrivl2.zip size 81643 crc 4fa10e40 md5 7eaa2ba5d43217a9dcd2c84440b3be25 sha1 958d4d5b937ccd6b4d1e936a47e67befa5702216 )
+)
+
+game (
 	name "Area 51 (R3000)"
 	year "1996"
 	developer "Atari Games"
@@ -1967,6 +2240,13 @@ game (
 )
 
 game (
+	name "Arkanoid (bootleg with MCU, harder)"
+	year "1986"
+	developer "bootleg"
+	rom ( name ark1ball.zip size 36470 crc c2fc7ac9 md5 ecd65023c9155aeb7778bc07f865a83a sha1 40d04eb9c3cef09ccd9ce8aa8c7f9c6f22a8f57e )
+)
+
+game (
 	name "Arkanoid (Game Corporation bootleg, set 1)"
 	year "1986"
 	developer "bootleg (Game Corporation)"
@@ -1988,6 +2268,20 @@ game (
 )
 
 game (
+	name "Arkanoid (Japan)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name arkanoidj.zip size 37324 crc f23510b4 md5 862ab076cd1ddfd95c7446247b2c0435 sha1 5cef8244d3ba7e413574ee38bf5202f3c6db1c38 )
+)
+
+game (
+	name "Arkanoid (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkanoidu.zip size 37221 crc cd0e2dd9 md5 20dff2be2fc979b61b29a6f61315cd24 sha1 81d869b2c9d812d4a9718e28134c9505db660fab )
+)
+
+game (
 	name "Arkanoid (US, older)"
 	year "1986"
 	developer "Taito America Corporation (Romstar license)"
@@ -2006,6 +2300,13 @@ game (
 	year "1986"
 	developer "bootleg (Tayto)"
 	rom ( name arkatayt.zip size 36618 crc a9b718d3 md5 b1f0e0881890588eb9184811e6d023aa sha1 e9b12ffdce528420c89b36848d33e896f302b927 )
+)
+
+game (
+	name "Tournament Arkanoid (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arkatour.zip size 68720 crc ae0fb022 md5 d31e4e5c2d9539d2e016837a24e87c07 sha1 01313a342b3aac403e2fbc357243ee6d7048e3f8 )
 )
 
 game (
@@ -2041,6 +2342,34 @@ game (
 	year "1986"
 	developer "bootleg"
 	rom ( name arkgcbla.zip size 37860 crc 10bed885 md5 e5031ec63e9be556a881fe9c1d86f296 sha1 83984708bbee9cdff58f3449083fb310764b3419 )
+)
+
+game (
+	name "Arkanoid (bootleg with MCU)"
+	year "1986"
+	developer "bootleg"
+	rom ( name arkmcubl.zip size 37271 crc 6b02e681 md5 c22fa44d54ebea9988ea1b285e628721 sha1 b68681ca7c3b5b15cf4e50a41174ac6e9ba80e01 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name arknoid2.zip size 165315 crc c9fb6010 md5 a1ecdd0eebc3bb81f5d8e86fc6baa355 sha1 07ade4f6fdc0fca316b439ea03e2ffb0ce5607e2 )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name arknoid2j.zip size 17257 crc 32bd6d4f md5 e1fee4ded4282ab2baaa8ef04f909637 sha1 4bb3b0509712b736180763bde5f0f0ff81f1c42a )
+)
+
+game (
+	name "Arkanoid - Revenge of DOH (US)"
+	year "1987"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name arknoid2u.zip size 42246 crc 4a89847e md5 114ddc55aaefe0b23a8f13bcc339a2fe sha1 53e6ebb4a181e2548a42ad40024ba5ebca02228f )
 )
 
 game (
@@ -2373,6 +2702,13 @@ game (
 )
 
 game (
+	name "Astra SuperStars (J 980514 V1.002)"
+	year "1998"
+	developer "Sunsoft"
+	rom ( name astrass.zip size 17183446 crc ccb36035 md5 1e8fd5e2cc3905c31a7add667cb181b0 sha1 3872eb964ff84c652e465222c9d93f00bb749b71 )
+)
+
+game (
 	name "Astro Blaster (version 3)"
 	year "1981"
 	developer "Sega"
@@ -2435,6 +2771,13 @@ game (
 )
 
 game (
+	name "The Astyanax"
+	year "1989"
+	developer "Jaleco"
+	rom ( name astyanax.zip size 1101266 crc bcf42d2b md5 2f3aad524d08d3e64c0a0993a227a423 sha1 bdcc2b5eee0be493445729a53bb749206aa55adb )
+)
+
+game (
 	name "Asuka _ Asuka (World)"
 	year "1988"
 	developer "Taito Corporation"
@@ -2488,6 +2831,13 @@ game (
 	year "1979"
 	developer "Atari"
 	rom ( name atarifb4.zip size 8955 crc 900ebb98 md5 402e68c7467fa3acafd09661abe267ab sha1 f2403a7328e0f08af95c86169a2da0a5dac34b5f )
+)
+
+game (
+	name "Atari System 1 BIOS"
+	year "1984"
+	developer "Atari Games"
+	rom ( name atarisy1.zip size 49173 crc 3c0e1e65 md5 4d853beb493b2cc0819af9570d785fcf sha1 19b49dd38bc6807d62affeaa39d257796bee52d5 )
 )
 
 game (
@@ -2596,6 +2946,13 @@ game (
 )
 
 game (
+	name "Atlus PSX"
+	year "1996"
+	developer "Sony / Atlus"
+	rom ( name atluspsx.zip size 126093 crc 0dc8a1a9 md5 3295b9890891083b29b9b639bcfafc50 sha1 d9535ef98f54f83304a8f8f653aafbe654788d94 )
+)
+
+game (
 	name "Atomic Boy (revision B)"
 	year "1985"
 	developer "Irem (Memetron license)"
@@ -2621,6 +2978,13 @@ game (
 	year "1991"
 	developer "Irem America (licensed from Hudson Soft)"
 	rom ( name atompunk.zip size 73258 crc 475b94db md5 e2e90b73b545b29c8b07c789a4b0c08e sha1 cdabad0f77856c9a43e63787859f8af302700040 )
+)
+
+game (
+	name "Atari PSX"
+	year "1996"
+	developer "Atari"
+	rom ( name atpsx.zip size 126055 crc 9c311a83 md5 b2026f0ad5a217a422066341ac6c5dc3 sha1 b06f1efa6741a38530709907ad9fb14bcb56d7f7 )
 )
 
 game (
@@ -2736,6 +3100,13 @@ game (
 )
 
 game (
+	name "Avenging Spirit"
+	year "1991"
+	developer "Jaleco"
+	rom ( name avspirit.zip size 1060778 crc 6707417d md5 cf4e3c32cdd6158b51585915ede39195 sha1 3cef5b36308d25e6612d72f83d6badb8d971268c )
+)
+
+game (
 	name "Alien vs. Predator (Japan 940520)"
 	year "1994"
 	developer "Capcom"
@@ -2778,6 +3149,13 @@ game (
 )
 
 game (
+	name "Backfire! (set 1)"
+	year "1995"
+	developer "Data East Corporation"
+	rom ( name backfire.zip size 9859906 crc 28fdb800 md5 3d338c08570acd51771f87677c72da36 sha1 3162de077c9e5196b5878b14689e9216eb0825ee )
+)
+
+game (
 	name "Backfire! (set 2)"
 	year "1995"
 	developer "Data East Corporation"
@@ -2789,6 +3167,13 @@ game (
 	year "1988"
 	developer "Tecmo"
 	rom ( name backfirt.zip size 318498 crc cdb79070 md5 be341b344f7aa36922de7db55c3d1bcb sha1 da0f33d86dfc63c7db00579a9fa964953efe84bd )
+)
+
+game (
+	name "Bad Dudes vs. Dragonninja (US)"
+	year "1988"
+	developer "Data East USA"
+	rom ( name baddudes.zip size 454673 crc 823dddde md5 9f61003dd6e361e91df4312a54187f74 sha1 5f5b1c66cb9998d369a15cd56b98f096ac8e21c2 )
 )
 
 game (
@@ -2869,6 +3254,13 @@ game (
 )
 
 game (
+	name "Balloon Bomber"
+	year "1980"
+	developer "Taito"
+	rom ( name ballbomb.zip size 6936 crc d8c9cbc6 md5 bd95aa39956fa02fdd5ecbd68f0437c2 sha1 46daff2917dbbb69b5081e904d182727fb4c83f0 )
+)
+
+game (
 	name "Balloon Brothers"
 	year "1992"
 	developer "East Technology"
@@ -2932,6 +3324,13 @@ game (
 )
 
 game (
+	name "Bank Panic"
+	year "1984"
+	developer "Sanritsu / Sega"
+	rom ( name bankp.zip size 68081 crc c891b681 md5 b95e5c2016bf570c4438f9d742cce44e sha1 5cade8bfbac308caca5b4844dce525be5a134cb2 )
+)
+
+game (
 	name "Baraduke"
 	year "1985"
 	developer "Namco"
@@ -2963,6 +3362,20 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name basebal2.zip size 132687 crc afab8769 md5 d938e769b6db97e280062b0d7e5d5d32 sha1 f2776d7d8717f6a760a9602d9a670ffb0c53d100 )
+)
+
+game (
+	name "Bass Angler 2 (GE865 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name bassang2.zip size 182 crc 58103c23 md5 152227827baf38c778d50cff8dacdb75 sha1 3f1dffa8ffebb13844422b8d5c0f5d94f44880b3 )
+)
+
+game (
+	name "Bass Angler (GE765 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name bassangl.zip size 182 crc 786221d4 md5 481d0a427167a7175a00b6c5ef57bfa2 sha1 eb7902169ce094a0234cf165ca0f65d242d22525 )
 )
 
 game (
@@ -3162,10 +3575,31 @@ game (
 )
 
 game (
+	name "Bay Route (set 1, US, unprotected)"
+	year "1989"
+	developer "Sunsoft / Sega"
+	rom ( name bayroute1.zip size 319050 crc 90d3b52d md5 34babc812237ccbcdbdd11990cb5bb12 sha1 ccdad9703f10f03a41e94775a112cf318e200e89 )
+)
+
+game (
 	name "Bay Route (set 2, Japan, FD1094 317-0115)"
 	year "1989"
 	developer "Sunsoft / Sega"
 	rom ( name bayroutej.zip size 111442 crc bf99537e md5 f25c026be4281d12c01ef8a6ee6007a6 sha1 cb9ef491a03535b6572553498f6f4a92349638fc )
+)
+
+game (
+	name "Bouncing Balls"
+	year "1991"
+	developer "Comad"
+	rom ( name bballs.zip size 177312 crc 70ab4f51 md5 f1db7f56abc0d7efaa6bf618fbba4614 sha1 a7fa992c83146915f1628c629913c90561cc7826 )
+)
+
+game (
+	name "Best Bout Boxing"
+	year "1994"
+	developer "Jaleco"
+	rom ( name bbbxing.zip size 10429515 crc 9b47d8ac md5 96986e1972839f0821aadd48b87dc13e sha1 53470be999ffa957d32e44d999dff936d8beb436 )
 )
 
 game (
@@ -3211,6 +3645,13 @@ game (
 )
 
 game (
+	name "Battle Chopper"
+	year "1987"
+	developer "Irem"
+	rom ( name bchopper.zip size 625484 crc bb2ba4e2 md5 b1c23702556a56b13ea7120566b6691e sha1 d640f7466fd4409a89b81c19bf7c1cf0446ca71b )
+)
+
+game (
 	name "Bone Crusher"
 	year "1985"
 	developer "bootleg"
@@ -3222,6 +3663,26 @@ game (
 	year "1983"
 	developer "Sigma Enterprises Inc."
 	rom ( name bcruzm12.zip size 24051 crc 844dd296 md5 68f050c0e0e9798fc97ad1ff88f6c32d sha1 e53a7ef1ca8c8a4049145ed921690396ecd923ba )
+)
+
+game (
+	name "B.C. Story (set 1)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name bcstry.zip size 1867429 crc 2790dc04 md5 af6c843f42e06c5a5ff56952afaba6ce sha1 b099fe0618c298d712f4e955e004602ee5849c19 )
+)
+
+game (
+	name "B.C. Story (set 2)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name bcstrya.zip size 122570 crc 9897a79a md5 618abbcf930d247d85c0917614a57182 sha1 660fe45ca870d751a1bf624cd160f4114347d9f6 )
+)
+
+game (
+	name "MPU4 Video Firmware"
+	developer "Barcrest"
+	rom ( name bctvidbs.zip size 3775 crc 4ffce055 md5 5c4e07b9dedce435379ad35c56c18bb2 sha1 9964f68aadd3eef4daa4c0d946422821b4352208 )
 )
 
 game (
@@ -3358,6 +3819,13 @@ game (
 )
 
 game (
+	name "Best League (bootleg of Big Striker, World Cup)"
+	year "1993"
+	developer "bootleg"
+	rom ( name bestleaw.zip size 966967 crc 42fce0ce md5 db72a6f702b3d1c3616efabfde166196 sha1 4cfcd0b1b133c38bbfab7386c4311c970eed1091 )
+)
+
+game (
 	name "Bestri (Korea)"
 	year "1998"
 	developer "F2 System"
@@ -3434,6 +3902,20 @@ game (
 )
 
 game (
+	name "Big Deal (Hungarian, set 1)"
+	year "1986"
+	developer "Funworld"
+	rom ( name bigdeal.zip size 31494 crc 11dc02dc md5 5c0a83f4f50b9d3f04ad053af2a41cd2 sha1 26149d8c6eab579cfad8077330388f0debd2dad7 )
+)
+
+game (
+	name "Big Deal (Hungarian, set 2)"
+	year "1986"
+	developer "Funworld"
+	rom ( name bigdealb.zip size 17366 crc b4bad886 md5 d28982f725f3525548833dc62c2c63d5 sha1 816536a8425ccc92d3f478b7cc55771173724b55 )
+)
+
+game (
 	name "Big Event Golf (US)"
 	year "1986"
 	developer "Taito America Corporation"
@@ -3480,6 +3962,13 @@ game (
 	year "1989"
 	developer "Jaleco"
 	rom ( name bigrun.zip size 2462344 crc c1e11087 md5 2e6e4fcccbfbbf11748cedc28adda5e7 sha1 303b2e99c94e7d16026610edbee9e2a1ea97b933 )
+)
+
+game (
+	name "Big Striker"
+	year "1992"
+	developer "Jaleco"
+	rom ( name bigstrik.zip size 838155 crc 08b43cdd md5 a256c29d166eb5694001ef4138e7880d sha1 67c7e723947c8e76aa1c78be13aa854c45717af7 )
 )
 
 game (
@@ -3546,10 +4035,38 @@ game (
 )
 
 game (
+	name "Bionic Commando (Euro)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc.zip size 341032 crc 4618814f md5 3edd644f35021365a73f65e166ca38eb sha1 9ab366c3635e1536cdd61d83dadd43e7f758e038 )
+)
+
+game (
+	name "Bionic Commando (US set 1)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc1.zip size 150039 crc a287b52c md5 07c7c78c25df173ddd2d35974e4adc26 sha1 9b4573035f3781b824f2cae362c83ea95f5f4e5e )
+)
+
+game (
+	name "Bionic Commando (US set 2)"
+	year "1987"
+	developer "Capcom"
+	rom ( name bionicc2.zip size 150016 crc 87c56ccf md5 1eef855a416ec2ce9c34e244d0d98e1b sha1 2195a66e4db0b18baab5c82815e12a4f10c4168b )
+)
+
+game (
 	name "Bio-ship Paladin"
 	year "1990"
 	developer "UPL (American Sammy license)"
 	rom ( name bioship.zip size 1367266 crc 5ab792c3 md5 a0470e95131c3f5d58227ea2ab39d436 sha1 9bdb67800341d2d0cacf6c9f176350df60b38c35 )
+)
+
+game (
+	name "Bishi Bashi Championship Mini Game Senshuken (ver JAA, 3 Players)"
+	year "1996"
+	developer "Konami"
+	rom ( name bishi.zip size 2693368 crc 8e6d5bf6 md5 c1892ca48e05516f9744229b3807557e sha1 6f491d1def0a8ea1a7ef074b3ab47f92f04c653c )
 )
 
 game (
@@ -3661,6 +4178,13 @@ game (
 	year "1992"
 	developer "Allumer"
 	rom ( name blandiap.zip size 3668983 crc 7f1d8ef2 md5 adc947b0d849cd7752aee22959f9dd60 sha1 5d9f038f3631c81d0c1f00dcabd5ad2bfc6ab1dd )
+)
+
+game (
+	name "Blasted"
+	year "1988"
+	developer "Bally Midway"
+	rom ( name blasted.zip size 485570 crc 3c79c3b1 md5 f070f2b43a0739ee69fca9cb2cbb8b2b sha1 2dec7d45fab77121634c3a14a8a1b66251950afc )
 )
 
 game (
@@ -4293,6 +4817,13 @@ game (
 )
 
 game (
+	name "Vs. Janshi Brandnew Stars (MegaSystem32 Version)"
+	year "1997"
+	developer "Jaleco"
+	rom ( name bnstars.zip size 1280497 crc 01cac0ee md5 7e6ac0b4f65e7b3f3b0358fe8545ef3f sha1 5b454bf364b6ee0f42787c8f61d5aac751cfdbff )
+)
+
+game (
 	name "Bonanza Bros (US, Floppy DS3-5000-07d? Based)"
 	year "1990"
 	developer "Sega"
@@ -4419,6 +4950,13 @@ game (
 )
 
 game (
+	name "Booby Kids (Italian manufactured graphic hack / bootleg of Kid no Hore Hore Daisakusen (bootleg))"
+	year "1987"
+	developer "bootleg"
+	rom ( name boobhack.zip size 67335 crc 508d8f2f md5 10068ac3439c45d411b2e50b5ff666d9 sha1 cf37d12a5e170123b890a26bfaff145381c4f011 )
+)
+
+game (
 	name "Boogie Wings (Euro v1.5, 92.12.07)"
 	year "1992"
 	developer "Data East Corporation"
@@ -4481,6 +5019,20 @@ game (
 )
 
 game (
+	name "Bosconian (Midway, new version)"
+	year "1981"
+	developer "Namco (Midway license)"
+	rom ( name boscomd.zip size 18613 crc 44b2e559 md5 d8a90d2580612e31a26dc8887f57fd4f sha1 22f4f6c40128421c0ca8c835de4d8a85eba90976 )
+)
+
+game (
+	name "Bosconian (Midway, old version)"
+	year "1981"
+	developer "Namco (Midway license)"
+	rom ( name boscomdo.zip size 18762 crc c3016cc8 md5 88e9e02b26eff5d6935bcc76378e351a sha1 fe921bbbab23b655fc8eca1b69f6ef717aa90f27 )
+)
+
+game (
 	name "Bosconian (old version)"
 	year "1981"
 	developer "Namco"
@@ -4513,6 +5065,20 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name botssa.zip size 337526 crc 2d4849d1 md5 e03832279b53e337981bbf90a312fb2b sha1 b21bef0a77a6aaff932ea31fa88606aacbc5db73 )
+)
+
+game (
+	name "Bottle 10 (Italian, set 2)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name bottl10b.zip size 2709 crc 9339515b md5 99fedd5f9ba75a6bc354fd848a33124f sha1 8b72591125a709f45a7e457a779a763b1a90972e )
+)
+
+game (
+	name "Bottle 10 (Italian, set 1)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name bottle10.zip size 19483 crc 8addc9ce md5 7a0334d3b023c3025f00e04ea53613ce sha1 81c0fa21548cd484d909e0114a3bdb09c19e1ae1 )
 )
 
 game (
@@ -4586,6 +5152,13 @@ game (
 )
 
 game (
+	name "Brain"
+	year "1986"
+	developer "Coreland / Sega"
+	rom ( name brain.zip size 92798 crc f475878f md5 e363c6dc802a10d78bfa7de2a31e227a sha1 f3619f1ab15a73e48153d16e06997439e8f502a3 )
+)
+
+game (
 	name "B.Rap Boys (World)"
 	year "1992"
 	developer "Kaneko"
@@ -4625,6 +5198,13 @@ game (
 	year "1998"
 	developer "Visco"
 	rom ( name breakrev.zip size 15821592 crc 76c4e4d4 md5 1f746d513a29bd7d9d3b686be73dcd3c sha1 7c87ec6fd944ffb27afdd3d8916610818c12c8b8 )
+)
+
+game (
+	name "Breywood (Japan revision 2)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name breywood.zip size 288503 crc ff6fee69 md5 1ceff7a2902aa5eb0d122bccf64c366d sha1 c23860d32ce21b3915f11e674b48c9eaa530d42e )
 )
 
 game (
@@ -4977,6 +5557,13 @@ game (
 )
 
 game (
+	name "Battle K-Road"
+	year "1994"
+	developer "Psikyo"
+	rom ( name btlkroad.zip size 4161327 crc 18ed9e21 md5 00603afe66310ebe8d340c6564c84cc2 sha1 cfcefd05c4fb1492741caf392c3938754bd89fd3 )
+)
+
+game (
 	name "Battle Toads"
 	year "1994"
 	developer "Rare"
@@ -5026,6 +5613,13 @@ game (
 )
 
 game (
+	name "Bubble Trouble (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name bubbletr.zip size 911433 crc 56650225 md5 48acc135eb5ccac7bfef02fe3fd7aa48 sha1 6f37ea115eae404632dd468db7a6ee10888692e3 )
+)
+
+game (
 	name "Bubble 2000"
 	year "1998"
 	developer "Tuning"
@@ -5037,6 +5631,34 @@ game (
 	year "1994"
 	developer "Taito Corporation Japan"
 	rom ( name bublbob2.zip size 4906715 crc 224c696e md5 9c746ee1f7aea62567477df58d46af56 sha1 0ba71f6aa86952b65aac20c9e01508f0fa43d7d8 )
+)
+
+game (
+	name "Bubble Bobble"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name bublbobl.zip size 183843 crc 4fea6af9 md5 7f7e392e6152e97737de4d54cc7b5108 sha1 829142c9ba2aec2372ba14371e8f5ec8893194f4 )
+)
+
+game (
+	name "Bubble Bobble (older)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name bublbobl1.zip size 50204 crc 180352f9 md5 007106c32cfdb5b49a91bee4054353f3 sha1 3ed8028b10a95b940d186bf7733f1fa3b7d27002 )
+)
+
+game (
+	name "Bubble Bobble (US with mode select)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name bublboblr.zip size 50221 crc 284d7775 md5 e9ffaa902764778d11374a83ba5c95ec sha1 2b7ffd208e2431eb68da0cf9c66e003a2ed541b2 )
+)
+
+game (
+	name "Bubble Bobble (US)"
+	year "1986"
+	developer "Taito America Corporation (Romstar license)"
+	rom ( name bublboblr1.zip size 50215 crc 221bea4c md5 d036a4f298326361c8608220036a2419 sha1 a6cfe48242861315b8c44bf38a63ad8cfc1575d2 )
 )
 
 game (
@@ -5058,6 +5680,13 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name bubsymphu.zip size 112365 crc 5de23843 md5 fdf774d1154d31d19bf92817114bba10 sha1 b8f143b8727d3459d9fe8c182a294b578fb20cd4 )
+)
+
+game (
+	name "Buccaneers (set 1)"
+	year "1989"
+	developer "Duintronic"
+	rom ( name buccanrs.zip size 292256 crc ad4e7b3f md5 15e909f3f8557171f5b865eafbbba64a sha1 df84215553cf9bf265455fb54f8631d15666d886 )
 )
 
 game (
@@ -5142,6 +5771,13 @@ game (
 	year "1985"
 	developer "Tatsumi"
 	rom ( name buggyboy.zip size 235344 crc 779df158 md5 f068269c4f7e574ed400c908db16377b sha1 b5eea921d36d15c198594679285df09bf190cbc1 )
+)
+
+game (
+	name "Buggy Boy Junior/Speed Buggy (upright)"
+	year "1986"
+	developer "Tatsumi"
+	rom ( name buggyboyjr.zip size 182287 crc ccdd183d md5 054b3524edd1dd2c3b432fbb9c3cb83d sha1 4ac048e045122cd85e41a3783698b91c3bf2cdac )
 )
 
 game (
@@ -5586,6 +6222,13 @@ game (
 )
 
 game (
+	name "Captain America and The Avengers (UK Rev 1.4)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name captavene.zip size 176825 crc e9aaf215 md5 06ad25092de069e61e6c4f86a0d490d5 sha1 4d20c09c0d0f4430c74f90097bd7c9370d21e13e )
+)
+
+game (
 	name "Captain America and The Avengers (Japan Rev 0.2)"
 	year "1991"
 	developer "Data East Corporation"
@@ -5611,6 +6254,13 @@ game (
 	year "1991"
 	developer "Data East Corporation"
 	rom ( name captavenuu.zip size 178188 crc 025de822 md5 7fecad87bf339849ebcf0e8f0bb63259 sha1 89cb73f07880df71b7fc77c3414871e718b5c335 )
+)
+
+game (
+	name "Captain Commando (World 911202)"
+	year "1991"
+	developer "Capcom"
+	rom ( name captcomm.zip size 2541835 crc f0e6245b md5 abc7c7ee61319dd421c202c086f2c3b4 sha1 f46abadc44a2b1ec022dccc2dac3f26f4eff88aa )
 )
 
 game (
@@ -5717,6 +6367,13 @@ game (
 )
 
 game (
+	name "Cash Quiz (Type B, Version 5)"
+	year "1986"
+	developer "Zilec-Zenitone"
+	rom ( name cashquiz.zip size 163824 crc ae2baab7 md5 4116fc74601f7a21a643fbeb22e09369 sha1 d6a267423ae84929005a3c164fb885c5691badf4 )
+)
+
+game (
 	name "Casino Five"
 	year "1984"
 	developer "Merit"
@@ -5752,6 +6409,13 @@ game (
 )
 
 game (
+	name "Catt (Japan)"
+	year "1993"
+	developer "Wintechno"
+	rom ( name catt.zip size 1613336 crc f7f5fb81 md5 f1b1648ba5a092200ddb449a1247aa06 sha1 6b8394a6279812d63f62b8b7290ca46fcccd3fa7 )
+)
+
+game (
 	name "Cavelon"
 	year "1983"
 	developer "Jetsoft"
@@ -5773,6 +6437,13 @@ game (
 )
 
 game (
+	name "U.S. Navy (Japan 901012)"
+	year "1990"
+	developer "Capcom"
+	rom ( name cawingj.zip size 1103242 crc 8a08d3d8 md5 920696014bebd03840e351c106eb1bab sha1 9ce9ee8ffc39e2874005bb81ad10dd3c2d3c46aa )
+)
+
+game (
 	name "Carrier Air Wing (World 901009)"
 	year "1990"
 	developer "Capcom"
@@ -5784,6 +6455,24 @@ game (
 	year "1990"
 	developer "Capcom"
 	rom ( name cawingu.zip size 75226 crc b2835bee md5 d2904bdaa25b6340683ab470bbfef9fb sha1 d44a911eb91ac6e97b885d247f0a2ce960626b2b )
+)
+
+game (
+	name "Cherry Bonus III (ver.1.40, encrypted)"
+	developer "Dyna"
+	rom ( name cb3.zip size 32377 crc 3f23eba0 md5 5782a45d937d8e2afafb3499e7ed8f4e sha1 9f5d0a8ac9d31266dda20cf005558cff82128f0f )
+)
+
+game (
+	name "Cherry Bonus III (ver.1.40, set 2)"
+	developer "Dyna"
+	rom ( name cb3a.zip size 27372 crc 50cd5fbf md5 7683bd232d804fb460ef7b6dcea2274f sha1 5240b0a5e7c4c185ff3ae8507bbc82d7397ec22b )
+)
+
+game (
+	name "Cherry Bonus III (alt)"
+	developer "Dyna"
+	rom ( name cb3b.zip size 85813 crc 8678e6b9 md5 4e6c8af86e96b00075db6d79a6c12b60 sha1 47863151a4af57889dd711515bd9f31cfec372fa )
 )
 
 game (
@@ -5987,6 +6676,20 @@ game (
 	year "1999"
 	developer "LAI Games"
 	rom ( name cclownz.zip size 2047936 crc 865fe5c7 md5 51cc0acd27ebf16ed8364c72f0a3068a sha1 bf9cb9fda8b6b85d8375dc14f7ea68a1a57d10cb )
+)
+
+game (
+	name "Amiga CD32 Bios"
+	year "1993"
+	developer "Commodore"
+	rom ( name cd32.zip size 673571 crc a3b9579b md5 b10ef8966c3ff292db079b9f26c8333d sha1 2b43d67e90767a43b435b3a9f504346cff0f64ca )
+)
+
+game (
+	name "CD-i (Mono-I) BIOS"
+	year "1991"
+	developer "Philips"
+	rom ( name cdi.zip size 231003 crc 4686c54f md5 ccbd274f2566e1907d649a0d4f941fe4 sha1 a458ad6bf3936dbeca6ef75a58485df91bb01677 )
 )
 
 game (
@@ -6221,6 +6924,13 @@ game (
 )
 
 game (
+	name "Chack'n Pop"
+	year "1983"
+	developer "Taito Corporation"
+	rom ( name chaknpop.zip size 36488 crc 6d83b0ae md5 624f535d43568bd351966b4fff0b1aaa sha1 a49c721c4db382fe651b9778f980823909ec2825 )
+)
+
+game (
 	name "Challenger"
 	year "1981"
 	developer "GamePlan (Centuri license)"
@@ -6326,6 +7036,27 @@ game (
 )
 
 game (
+	name "Chase H.Q. (World)"
+	year "1988"
+	developer "Taito Corporation Japan"
+	rom ( name chasehq.zip size 3728581 crc 28121659 md5 2331a078acf3f5915ac22da046eee5fb sha1 0a43f9fa46e07354242723241c30d2c3866c6905 )
+)
+
+game (
+	name "Chase H.Q. (Japan)"
+	year "1988"
+	developer "Taito Corporation"
+	rom ( name chasehqj.zip size 1720082 crc 842ffb1a md5 0c6e931f44750ce5b72c0375bc939c10 sha1 0ebab3a2346fb5dc281f418ec79b5803470f1906 )
+)
+
+game (
+	name "Chase H.Q. (US)"
+	year "1988"
+	developer "Taito America Corporation"
+	rom ( name chasehqu.zip size 69323 crc e874c0f3 md5 1e8af211fec879591e5fa7d98cbf6bfa sha1 e30594eb249a4c4783e2028e8367c95ec44f6796 )
+)
+
+game (
 	name "Champion Boxing"
 	year "1984"
 	developer "Sega"
@@ -6344,6 +7075,13 @@ game (
 	year "1982"
 	developer "Zilec-Zenitone (Jaleco license)"
 	rom ( name checkmanj.zip size 10837 crc fd123f28 md5 0cd355d18b69beaee38c8d8d8fb80820 sha1 7de04c16e0af3a9cf8fc9da7ea007280e28541a7 )
+)
+
+game (
+	name "Checkmate"
+	year "1977"
+	developer "Midway"
+	rom ( name checkmat.zip size 3681 crc 07b85371 md5 704d93f7dc3334ad7a82db3773298f37 sha1 c6032d475c2a64f77d252c43ed96762772a35375 )
 )
 
 game (
@@ -6406,6 +7144,20 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name chiller.zip size 264964 crc 9db43e0f md5 4b3692a0af315e682405d09715b05814 sha1 29e536766b1f50555493d72fcc17d055f27516ef )
+)
+
+game (
+	name "Chimera Beast (prototype)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name chimerab.zip size 1177376 crc 9394623b md5 3988ece32ca9094656954376c004675a sha1 cbae5650d9f090dd80990090f9d9f547274b217b )
+)
+
+game (
+	name "China Gate (US)"
+	year "1988"
+	developer "Technos Japan (Taito / Romstar license)"
+	rom ( name chinagat.zip size 570940 crc f69e5596 md5 b7879cc59c11d7c546958fed372ebfe4 sha1 3a60a36b5841b283e12ab61e7ba4c8c26f2f5673 )
 )
 
 game (
@@ -6472,10 +7224,38 @@ game (
 )
 
 game (
+	name "Choky! Choky!"
+	year "1995"
+	developer "SemiCom"
+	rom ( name chokchok.zip size 1105332 crc e49ff98c md5 10bdec45413daa6880abccf9ed8695b7 sha1 4bf77f1df9bf1e61b96b30ea7f176fd32976f53c )
+)
+
+game (
 	name "Janpai Puzzle Choukou (Japan 010820)"
 	year "2001"
 	developer "Mitchell (Capcom license)"
 	rom ( name choko.zip size 4923896 crc af3b9ce9 md5 6b916fdfe389946df5b293b4fc3d8532 sha1 138bd736202f8de1ee0a2c2a29da7e358c0d6c2c )
+)
+
+game (
+	name "Choplifter (8751 315-5151)"
+	year "1985"
+	developer "Sega"
+	rom ( name choplift.zip size 138193 crc 1c4bff6a md5 e2e71305b100c701a67b262220f04ca2 sha1 6affaa22ea10ca727dabdae41eb720a676f7de17 )
+)
+
+game (
+	name "Choplifter (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name chopliftbl.zip size 20693 crc 0458fe75 md5 9f85d581118deffa02603d233be311e0 sha1 8149d8d98f241a72f8660ef79ac012549c1108ef )
+)
+
+game (
+	name "Choplifter (unprotected)"
+	year "1985"
+	developer "Sega"
+	rom ( name chopliftu.zip size 39337 crc df8682f6 md5 e57bda53eee38bc4f30fb6731a272218 sha1 1ed384eaab4947693dd5c0f82f6e723b4d486c51 )
 )
 
 game (
@@ -6497,6 +7277,18 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name chopperb.zip size 132034 crc 9f5c9f0d md5 41dc5d5d7e2da3fe48bd3a282362b842 sha1 d9ba5b06df4b969ba7c71729c4eb61b6a9dc6b7b )
+)
+
+game (
+	name "Cherry 10 (bootleg with PIC16F84)"
+	developer "bootleg"
+	rom ( name chry10.zip size 76925 crc dd0884ea md5 b33be0c1d8d7b7f1d498f769441dea6f sha1 db713de9f2fa66b637cc376e6b4e9f4f355b1e43 )
+)
+
+game (
+	name "Cherry Gold I"
+	developer "bootleg"
+	rom ( name chrygld.zip size 63347 crc 69866dac md5 55c4b8d72f9f99f2324cbef13b708201 sha1 a2400ea45f3fe5252c43757bed43b8b4450f2248 )
 )
 
 game (
@@ -6539,6 +7331,13 @@ game (
 	year "1985"
 	developer "Sega"
 	rom ( name chwrestl.zip size 35843 crc 9d88439c md5 d3ca349c776d55c7fd9fe30e65dc7321 sha1 91d6aaddc557759d21d6bbbc12c785ff91c9a810 )
+)
+
+game (
+	name "Highway Chase (Cassette)"
+	year "1980"
+	developer "Data East Corporation"
+	rom ( name chwy.zip size 15056 crc 10736c54 md5 d30b24fa6550e810bcd261353c420dc8 sha1 dd64977399b20dbac1db26cfb81f3cf3161d61dd )
 )
 
 game (
@@ -6737,6 +7536,62 @@ game (
 )
 
 game (
+	name "Classic Edition (Version 1.6E)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice.zip size 715269 crc bcc46dbd md5 5e92a66015bccda25c622a6c364e3096 sha1 c0518f8aab24b0d7c986d88585248bdacb44307b )
+)
+
+game (
+	name "Classic Edition (Version 1.6R, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice1.zip size 206049 crc 87e25cac md5 25996f322181bd3242f1c07220396a2e sha1 643e82b2a4734d01ae3817ba382b6e41579c49aa )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classice2.zip size 206312 crc dab3fe2f md5 55d8d462c82daa53ed2ea665e9ca84a0 sha1 af41599d203721a4a48de7adcaef4a9043a16755 )
+)
+
+game (
+	name "Classic Edition (Version 1.6R, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classiced1.zip size 204997 crc 9cc5d501 md5 299bdb23a383edbc173963a8a1d0f18e sha1 176ab708b5af4a0df6ae8078e39e5475ca18c49d )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classiced2.zip size 205387 crc 054e3611 md5 4790027673f86278ca791dfae38c517e sha1 367354dc72db22b00b0c6568b8ed5e2736c9315a )
+)
+
+game (
+	name "Classic Edition (Version 1.6E Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev.zip size 206179 crc 9e314685 md5 ab57ea5757003151e954498288a7a3a1 sha1 1d0ba0662819de7d0b85b2e742e33985bc08dbff )
+)
+
+game (
+	name "Classic Edition (Version 1.6R Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev1.zip size 206020 crc c37ec79e md5 4f25d7393d5b351ab3d6b30acbc4fa77 sha1 d9a3bc38eb63ca61a031033034647ba6582ec79d )
+)
+
+game (
+	name "Classic Edition (Version 1.6LT Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name classicev2.zip size 206087 crc ab3a130f md5 ae1dc45116cd6edc970218443baa67af sha1 132b9dfb8cd1ca5df553cdf2568485f0398e2375 )
+)
+
+game (
 	name "Clay Pigeon (version 2.0)"
 	year "1986"
 	developer "Exidy"
@@ -6804,6 +7659,13 @@ game (
 	year "1981"
 	developer "Data East Corporation"
 	rom ( name clocknch.zip size 15936 crc 263255a6 md5 a1f7ea74039b363b28b155c8ef3607c9 sha1 e15fb90995e6e41c97fc11f2b22846cae32890de )
+)
+
+game (
+	name "Cloud 9 (prototype)"
+	year "1983"
+	developer "Atari"
+	rom ( name cloud9.zip size 22630 crc 84caff0f md5 0868c27a4b6d65518e01d456ef766ac2 sha1 821c6bb14ea941e9d120e81648f9dc9a9f10fded )
 )
 
 game (
@@ -6898,6 +7760,13 @@ game (
 )
 
 game (
+	name "Cherry Master '91 (ver.1.30)"
+	year "1991"
+	developer "Dyna"
+	rom ( name cmast91.zip size 124394 crc a1a6abb1 md5 c1dd7066427057dd054404822d20297b sha1 f7950ed9fd3d6cafcd657f1f870f94a877e87aaa )
+)
+
+game (
 	name "Cherry Master I (ver.1.01, set 1)"
 	year "1991"
 	developer "Dyna"
@@ -6972,6 +7841,12 @@ game (
 	year "1992"
 	developer "Dyna"
 	rom ( name cmv4.zip size 58346 crc 39fce85a md5 c981a34a6c8b8cf4569436d1f07bfaab sha1 941300f13339fee16767962d58b774c0adb549b9 )
+)
+
+game (
+	name "Cherry Master (Corsica, ver.8.01)"
+	developer "Corsica"
+	rom ( name cmv801.zip size 63718 crc 25c94c82 md5 d02d783854aaf79b018dc37777172454 sha1 3dc6691fba35614c033ea07f19456f83bd66a667 )
 )
 
 game (
@@ -7114,6 +7989,13 @@ game (
 )
 
 game (
+	name "Combat School (joystick)"
+	year "1988"
+	developer "Konami"
+	rom ( name combatsc.zip size 536697 crc 737e2796 md5 2fd1d3696d9aa56c5deb0bbcee20c01e sha1 86f39b054525498962424cf2af8c422443b42391 )
+)
+
+game (
 	name "Combat School (bootleg)"
 	year "1988"
 	developer "bootleg"
@@ -7132,6 +8014,20 @@ game (
 	year "1987"
 	developer "Konami"
 	rom ( name combatsct.zip size 42480 crc 0091d49d md5 fc09272baf6e615f13eaa4de60c9b7b9 sha1 bc60c0135586b8fc7c806ae1ae3ff2c7b26841d7 )
+)
+
+game (
+	name "Combat Hawk"
+	year "1987"
+	developer "Sanritsu / Sega"
+	rom ( name combh.zip size 57206 crc 3b563a57 md5 5f50f040b72bb2eb8a8ce0e3930c3303 sha1 366a8b95d44e7fccdda45669dc2a27b01c26085e )
+)
+
+game (
+	name "Cal Omega - Game 7.4 (Gaming Poker, W.Export)"
+	year "1981"
+	developer "Cal Omega Inc."
+	rom ( name comg074.zip size 11237 crc 0e7ba0ce md5 7e5b0549e0bae999d0a4b35039d720a4 sha1 c20835afe061f47306203ef0bbb401dcc8e40ccf )
 )
 
 game (
@@ -7167,6 +8063,13 @@ game (
 	year "1985"
 	developer "Capcom"
 	rom ( name commando.zip size 135332 crc fa4bac04 md5 84b2cf3dd2393c8c6cc13caa6440f4c3 sha1 1af11df9f2ccdc33564f606db8cef4c586b03f2a )
+)
+
+game (
+	name "Commando (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name commandob.zip size 19068 crc 85a0275e md5 0f8bafa299a9cefcf92ef2d1e25c7fb0 sha1 33c37789e68e71466dc93cbd9382e6e8ded425fc )
 )
 
 game (
@@ -7267,6 +8170,20 @@ game (
 )
 
 game (
+	name "Contra (US, Set 1)"
+	year "1987"
+	developer "Konami"
+	rom ( name contra.zip size 388410 crc 3d1478a8 md5 ee1ba16d382481b9158c4d85e23c4e47 sha1 20f9644b22773cc1e45f8bf18750faf54cd1884c )
+)
+
+game (
+	name "Contra (US, Set 2)"
+	year "1987"
+	developer "Konami"
+	rom ( name contra1.zip size 33839 crc bd9ed4f3 md5 cf5d5674afd64c73827c88bc18fb5a37 sha1 90a047ad3796108bdb95e25b93f86d27af3c7b5f )
+)
+
+game (
 	name "Contra (bootleg)"
 	year "1987"
 	developer "bootleg"
@@ -7274,10 +8191,38 @@ game (
 )
 
 game (
+	name "Contra (Japan)"
+	year "1987"
+	developer "Konami"
+	rom ( name contraj.zip size 60273 crc 4f71841d md5 deb86c0a34052ca9adc388b782e9a6e6 sha1 437c374378079ba077c455ca688f4f8bf9fe8ad5 )
+)
+
+game (
 	name "Contra (Japan bootleg)"
 	year "1987"
 	developer "bootleg"
 	rom ( name contrajb.zip size 357110 crc 714b6097 md5 ce03f000b7914bf0c4e8c388e5b9f512 sha1 50878f906ff92aa3df0905d6c4d28823eec9639f )
+)
+
+game (
+	name "Cookie _ Bibi"
+	year "1995"
+	developer "SemiCom"
+	rom ( name cookbib.zip size 342327 crc 97dea0ac md5 41965c465e6bbf17dd4742b1b4086f04 sha1 cfd3d80bdf61705dfc7039ae92e922935d991b64 )
+)
+
+game (
+	name "Cookie _ Bibi 2"
+	year "1996"
+	developer "SemiCom"
+	rom ( name cookbib2.zip size 741279 crc 0861d9d1 md5 12d83fa3a156a0a13ab8bb4270337769 sha1 db4b772292b9d82a1b89058503dec83e48a987dd )
+)
+
+game (
+	name "Cookie _ Bibi 3"
+	year "1997"
+	developer "SemiCom"
+	rom ( name cookbib3.zip size 846012 crc b25ea726 md5 08d84864359d554308c0d542f2bba183 sha1 4793eb59e453b5e8d72eff74dfed1538fe467610 )
 )
 
 game (
@@ -7348,6 +8293,13 @@ game (
 	year "1979"
 	developer "Universal"
 	rom ( name cosmica1.zip size 10166 crc a946cd8b md5 208209b302e0207a6cdd67467c878c65 sha1 8e808861fe5daa268f15272e69ce182c30c4a1c0 )
+)
+
+game (
+	name "Cosmic Alien (early version II?)"
+	year "1979"
+	developer "Universal"
+	rom ( name cosmica2.zip size 9230 crc d6a904c3 md5 9f55ca693fb1c1ad15b6e1139dd51675 sha1 291a466f8b2d2a35805cdd919ad1d3a1689a2ed8 )
 )
 
 game (
@@ -7468,6 +8420,12 @@ game (
 )
 
 game (
+	name "Champion Italian PK (bootleg, green board)"
+	developer "bootleg (SGS)"
+	rom ( name cpokerpkg.zip size 43885 crc f8481935 md5 177fb4a4a812801e6bc04ea16c343506 sha1 01adb36b67fbcd2fefd49c21d9e337f0c6cd4906 )
+)
+
+game (
 	name "Champion Poker (v200G)"
 	developer "IGS (Tuning license)"
 	rom ( name cpokert.zip size 154764 crc 03fa655a md5 3fbc9c04d44d9b2b606d6aebd726b6be sha1 4a5efd3d7f713775bc3cfdfc7686cf4c6cbefa4e )
@@ -7513,6 +8471,20 @@ game (
 	year "1982"
 	developer "Data East Corporation"
 	rom ( name cptennis.zip size 13544 crc 93143b31 md5 9f37f91e3a96256621bd7cd0223f45f9 sha1 109aa2bce463d699405d0d0d32a9357e9bd4aa38 )
+)
+
+game (
+	name "ZN1"
+	year "1995"
+	developer "Sony / Capcom"
+	rom ( name cpzn1.zip size 125593 crc 3cefc20e md5 c817e00bbb235e6bd2f5a8e1d26e772a sha1 3dfc48ab10c520166a055b08cd585ddc66770509 )
+)
+
+game (
+	name "ZN2"
+	year "1997"
+	developer "Sony / Capcom"
+	rom ( name cpzn2.zip size 137849 crc ac88ef5c md5 99304c05983b337217ab4b56400a14ac sha1 0fac5924acd8dcf1e458ae378ab677c8dc646d66 )
 )
 
 game (
@@ -7562,6 +8534,20 @@ game (
 	year "1980"
 	developer "Taito Corporation"
 	rom ( name crbaloon2.zip size 4714 crc 45eb0b3b md5 e79eb4a6446aaae4ace305841f88067a sha1 c8f2f688cfc83b8483a447bce6a0380f2ac6b1a1 )
+)
+
+game (
+	name "Crowns Golf (834-5419-04)"
+	year "1984"
+	developer "Nasco Japan"
+	rom ( name crgolf.zip size 48587 crc 512e0094 md5 3a13536a8d6577c0beec45f831e4840f sha1 44ed1b8d429eed892b8143d61902e1f3de3426e4 )
+)
+
+game (
+	name "Crowns Golf (834-5419-03)"
+	year "1984"
+	developer "Nasco Japan"
+	rom ( name crgolfa.zip size 13322 crc 99c0c119 md5 340340de80965b43d3fe279e824c1423 sha1 e9ccd012ba283c40c48224010ef3a67d5872828b )
 )
 
 game (
@@ -7691,6 +8677,13 @@ game (
 )
 
 game (
+	name "Poker Carnival"
+	year "1991"
+	developer "Subsino"
+	rom ( name crsbingo.zip size 59323 crc bf514419 md5 8c9f8a769f852de3fff6b15842535833 sha1 cdac4d35379322cf6c1a9c4c01907e2791b67b70 )
+)
+
+game (
 	name "Lethal Crash Race (set 1)"
 	year "1993"
 	developer "Video System Co."
@@ -7773,6 +8766,13 @@ game (
 )
 
 game (
+	name "Cruis'n USA (rev L4.1)"
+	year "1994"
+	developer "Midway"
+	rom ( name crusnusa.zip size 11277901 crc dc92d005 md5 b60f7571b1c48d2c2a2ebee557d0c25c sha1 31a02b25028c17602de4e9e1a10a9a27244c47aa )
+)
+
+game (
 	name "Cruis'n USA (rev L2.1)"
 	year "1994"
 	developer "Midway"
@@ -7826,6 +8826,13 @@ game (
 	year "1995"
 	developer "Konami"
 	rom ( name cryptklr.zip size 599689 crc 8d891f74 md5 ccbd2e4328bf4c6b1d93cbaecf361010 sha1 aec839d70bde345aa6db445e52910b6c3841fd67 )
+)
+
+game (
+	name "Crystal System BIOS"
+	year "2001"
+	developer "BrezzaSoft"
+	rom ( name crysbios.zip size 43502 crc 8b8c8072 md5 f42d62f8cc690a87278a6d602519c607 sha1 0935e72cc84203dc044e4e2fe7cf623fe2f38ea1 )
 )
 
 game (
@@ -7885,6 +8892,20 @@ game (
 )
 
 game (
+	name "Crazy Rally (set 1)"
+	year "1985"
+	developer "Tecfri"
+	rom ( name crzrally.zip size 58840 crc 393d1ceb md5 c7c6fe20f661faf0ec7a93009fc33edc sha1 26981eee4b60477f6d3647b8444a3043a6a3998a )
+)
+
+game (
+	name "Crazy Rally (set 2)"
+	year "1985"
+	developer "Tecfri"
+	rom ( name crzrallya.zip size 36328 crc 7abd90c8 md5 dce797f4455757cdbd6027d2176b0455 sha1 974697c5d562e941655ae319ce55d90fda5da7ac )
+)
+
+game (
 	name "Crazy Rally (Gecas license)"
 	year "1985"
 	developer "Tecfri (Gecas license)"
@@ -7938,6 +8959,27 @@ game (
 	year "1984"
 	developer "Data East Corporation"
 	rom ( name cscrtry2.zip size 17427 crc f50da944 md5 bb2206915208b2c97a289e64a20534c1 sha1 11383e7b094afae5d95b00b61f7d37ec944755af )
+)
+
+game (
+	name "Chicken Shift"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name cshift.zip size 43315 crc 7c6abca8 md5 de1ee67a321e96e354c0618228bfe451 sha1 618c93be227f68390501e771d806d291cb271eb9 )
+)
+
+game (
+	name "Captain Silver (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name csilver.zip size 403065 crc cdbcd8a3 md5 9396631f721ab08913e6c430857b331c sha1 e510c6c0c8c7755351b5c3d1d557c46ab504cf86 )
+)
+
+game (
+	name "Captain Silver (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name csilverj.zip size 16681 crc 4356e2fd md5 b0aa99b028663f801d77415fc468eb11 sha1 adc4aa7c38d535757ae942df4e5fe683607aafb5 )
 )
 
 game (
@@ -8176,6 +9218,13 @@ game (
 )
 
 game (
+	name "Cuore 1 (Italian)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name cuoreuno.zip size 19253 crc 94c0fea5 md5 24f2f15db3d20da4c4401fce4548585a sha1 b16af13650d2b114253773644601b2788ca1c7c1 )
+)
+
+game (
 	name "Taito Cup Finals (Ver 1.0O 1993/02/28)"
 	year "1993"
 	developer "Taito Corporation Japan"
@@ -8201,6 +9250,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name cworld.zip size 728155 crc 92fff834 md5 7b957f3061527245dd049f0afd9cf88a sha1 0a75499a74146f831ac2f1d6b8aa6aac822430aa )
+)
+
+game (
+	name "Adventure Quiz Capcom World 2 (Japan 920611)"
+	year "1992"
+	developer "Capcom"
+	rom ( name cworld2j.zip size 1753740 crc 3181ff10 md5 b32c4c73707d91596c5d375147c3c11a sha1 99f44bf54db8999d313bb0e6e021ea8cdb4b1459 )
+)
+
+game (
+	name "Cybattler"
+	year "1993"
+	developer "Jaleco"
+	rom ( name cybattlr.zip size 1266380 crc d454f84a md5 041ced047550d34d4aa37df69cfb3b18 sha1 e26f3a8131a4d6d8fbf0dfca8ba44c42045bfcbc )
 )
 
 game (
@@ -8330,6 +9393,13 @@ game (
 )
 
 game (
+	name "Zeroize (Cassette)"
+	year "1983"
+	developer "Data East Corporation"
+	rom ( name czeroize.zip size 25175 crc ef0b1fc1 md5 9b6a793924475b77409b9a756b28859c sha1 193cf1538f272aa405d13e7e3d6702d11f8bb5e1 )
+)
+
+game (
 	name "Dream 9 Final (v2.24)"
 	year "1992"
 	developer "Excellent System"
@@ -8358,6 +9428,13 @@ game (
 )
 
 game (
+	name "Daimakaimura (Japan)"
+	year "1988"
+	developer "Capcom"
+	rom ( name daimakai.zip size 1145540 crc a2d80e34 md5 9e13bfc3a1a93ed65f302f05b04322ce sha1 316627cf5a6182afae677f3fba605daaeecccb37 )
+)
+
+game (
 	name "Daimakaimura (Japan Resale Ver.)"
 	year "1988"
 	developer "Capcom"
@@ -8376,6 +9453,13 @@ game (
 	year "1993"
 	developer "Athena"
 	rom ( name daioh.zip size 3149073 crc 99d0e1e4 md5 6cc25c79e0e2aed2ce5fd5d187120322 sha1 7deb6e35e8face8145e3d71f646832059cf78f5b )
+)
+
+game (
+	name "Mahjong Daireikai (Japan)"
+	year "1989"
+	developer "Jaleco / NMK"
+	rom ( name daireika.zip size 782018 crc 620a8a38 md5 b484554869422814e7b0a4c91c53c58f sha1 d641e7eac4ccfa7c58642a9ac07e163003b7be41 )
 )
 
 game (
@@ -8624,6 +9708,20 @@ game (
 )
 
 game (
+	name "Dark Horse Legend (GX706 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name darkhleg.zip size 182 crc 1a548190 md5 586ca9974f867427cbd45a5fabe9a35d sha1 1e747b326cf425476ec052dd63924a31e21d1151 )
+)
+
+game (
+	name "Dark Horse (bootleg of Jockey Club II)"
+	year "2001"
+	developer "bootleg"
+	rom ( name darkhors.zip size 2016274 crc 9a085b6a md5 93da3283935cc1c8bf6deace26b2cbc5 sha1 dfacb21ba11900a2bcd5fd15e0241a3751bd8e6c )
+)
+
+game (
 	name "The Lost Castle In Darkmist"
 	year "1986"
 	developer "Taito"
@@ -8684,6 +9782,20 @@ game (
 	year "1986"
 	developer "Data East Corporation"
 	rom ( name darwin.zip size 120044 crc 937ad0f0 md5 122efe0f51a9346400384bba7139f064 sha1 1f7ca842309e42e058b609e7ed313a834140324d )
+)
+
+game (
+	name "Desert Assault (US)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name dassault.zip size 160514 crc baf51c90 md5 c6b593ba552bdd9d7fe18712299a69a8 sha1 5faddf79d8243f5f6dc290cb13752108c56f00ec )
+)
+
+game (
+	name "Desert Assault (US 4 Players)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name dassault4.zip size 158037 crc e53acff0 md5 2ad4113274cf5cb06c7a6fad663f5a3f sha1 6b36e081fb416e9e6d1248ae1017a4708a3754a9 )
 )
 
 game (
@@ -8782,6 +9894,13 @@ game (
 	year "1989"
 	developer "Irem"
 	rom ( name dbreed.zip size 753922 crc b9fe793a md5 f4b31a4769276a862e5dd2717a428aba sha1 2aa947f887d7ca097519219bfe4d05b0626217f7 )
+)
+
+game (
+	name "Dragon Breed (M72 PCB version)"
+	year "1989"
+	developer "Irem"
+	rom ( name dbreedm72.zip size 149958 crc 0400bd7b md5 e8013b17f01561c3a1bc66e3fd180e98 sha1 935ac60a704942f78c29c68b079c4f564eb11c7b )
 )
 
 game (
@@ -8904,6 +10023,13 @@ game (
 )
 
 game (
+	name "Double Dealer"
+	year "1991"
+	developer "NMK"
+	rom ( name ddealer.zip size 223338 crc 87ca013e md5 2e48d87248f2c0be4511e1be97c04fc2 sha1 cfdab8741df51cd75bbbdc8dc37cb94a348e51bc )
+)
+
+game (
 	name "Don Den Lover Vol. 1 - Shiro Kuro Tsukeyo! (Japan)"
 	year "1995"
 	developer "Dynax"
@@ -8943,6 +10069,41 @@ game (
 	year "1997"
 	developer "Cave (Atlus license)"
 	rom ( name ddonpachj.zip size 256039 crc c52bc6e4 md5 68d687a9119d5f67dc1ddf13f4558743 sha1 2cc92e8579deb9d139487bb9f8a4fb7d9f07ffcf )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix (GN895 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2m.zip size 174 crc e7188034 md5 223e2b1eabbe3ad1d471b4fbb4f43007 sha1 5b958c15631ee04acd8ce92b0a9caccd1eec097b )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX CLUB VERSiON (GE896 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2mc.zip size 172 crc 8f7db786 md5 7e38cf8a4fbdc234a6de07bd69053cbd sha1 dece8a1ac3d9f18d6db849bc72d522be5392e044 )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix with beatmaniaIIDX substream CLUB VERSiON 2 (GE984 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2mc2.zip size 172 crc b220eaab md5 1325feb1a5451a56fb41f1600c172113 sha1 6264d7156d924335cff5ef9a2e5669988d84f48b )
+)
+
+game (
+	name "Dance Dance Revolution 2nd Mix - Link Ver (GE885 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddr2ml.zip size 4057 crc ff1be293 md5 604be7e73f4ab6efa2852ec221c8e4ad sha1 30a3bf91c96f391fdfd0242f7049cc1dde0f9cc2 )
+)
+
+game (
+	name "Dance Dance Revolution (GN845 VER. AAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddra.zip size 172 crc eacf6ede md5 e41f971e2fb211dafceefc6f721f7809 sha1 38267e9aa40d565e9e414fa4bea855e52435a990 )
 )
 
 game (
@@ -9062,6 +10223,20 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name ddribble.zip size 358619 crc 0b4f3ea0 md5 def11feee81940591976f34c7e154917 sha1 b3b7b4d17cfe6861e0edbf9d333d9b6cdf234080 )
+)
+
+game (
+	name "Dance Dance Revolution - Internet Ranking Ver (GC845 VER. JBA)"
+	year "1998"
+	developer "Konami"
+	rom ( name ddrj.zip size 172 crc 87fa16d9 md5 d48eb8d9258dbfca90b4b93df0ccfc04 sha1 1c2be6b15e4ba70140db4f3aa3242e6a1aac6312 )
+)
+
+game (
+	name "Dance Dance Revolution (GN845 VER. UAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name ddru.zip size 172 crc 049610a8 md5 96b1dbaaa0609f175fc8927b8a68c0cf sha1 9fe6940e3c0210d97392320b7b65b370df5c8cb7 )
 )
 
 game (
@@ -9254,6 +10429,13 @@ game (
 )
 
 game (
+	name "Dynamite Dux (set 1, 8751 317-0095)"
+	year "1988"
+	developer "Sega"
+	rom ( name ddux1.zip size 100002 crc 436bad9c md5 0a55138f1534f1872b8f49db6a9d08b9 sha1 bdc7f9ab3a6665c04769af33ec597558ef80cbde )
+)
+
+game (
 	name "Dead Angle"
 	year "1988"
 	developer "Seibu Kaihatsu"
@@ -9293,6 +10475,13 @@ game (
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name deathbrd.zip size 102000 crc 7486c7b1 md5 c9b91d9405d8e786cfe69e6fe32d9bf7 sha1 122203ed6301555a28d164601c59f7a99575ff49 )
+)
+
+game (
+	name "DECO Cassette System"
+	year "1981"
+	developer "Data East Corporation"
+	rom ( name decocass.zip size 10445 crc d086c942 md5 bc80f5cdacd23ce122a2c91e34b4cd73 sha1 d668b876d41fec5fa3fd790845a1ad1b2f704383 )
 )
 
 game (
@@ -9363,6 +10552,13 @@ game (
 	year "1980"
 	developer "Williams"
 	rom ( name defenderw.zip size 19801 crc 6d604f30 md5 05cee75509bd1c8430350ae04aed144f sha1 022349f81e9be172cefac718f9da8cbf9a81f3f0 )
+)
+
+game (
+	name "Defense (System 16B, FD1089A 317-0028)"
+	year "1987"
+	developer "Sega"
+	rom ( name defense.zip size 345936 crc 8c56fcd2 md5 b5b79c4c7b4a39bbc3247903719b7283 sha1 e9ce5aba7380b91fe6ce2c3e6ec223e874d183c7 )
 )
 
 game (
@@ -9457,6 +10653,13 @@ game (
 )
 
 game (
+	name "Deroon DeroDero"
+	year "1995"
+	developer "Tecmo"
+	rom ( name deroon.zip size 4006201 crc 59555686 md5 4f6817b242381fd5a945b0139dce403d sha1 aeb81c31639baf8e4065331a54780dbade7c1cad )
+)
+
+game (
 	name "Desert Breaker (World, FD1094 317-0196)"
 	year "1992"
 	developer "Sega"
@@ -9475,6 +10678,13 @@ game (
 	year "1977"
 	developer "Midway"
 	rom ( name desertgu.zip size 6017 crc b20d10c2 md5 cbb91aa4c882a607f0c62a5cd204516e sha1 de970daf007aeb1f8859b801cf822969990be01d )
+)
+
+game (
+	name "Desert War / Wangan Sensou"
+	year "1995"
+	developer "Jaleco"
+	rom ( name desertwr.zip size 10622164 crc 69f85da9 md5 7569556191d31c6ecca6d6d6a606d018 sha1 ca266a239f46e2b43a9b3893d034ae99cc9311ab )
 )
 
 game (
@@ -9555,6 +10765,13 @@ game (
 )
 
 game (
+	name "Devil Zone (easier)"
+	year "1980"
+	developer "Universal"
+	rom ( name devzone2.zip size 11232 crc 85c49f48 md5 de64dbd2266ea0e8805f42deffc33119 sha1 2c08119d7805e4f1329cf7c28ec890edfd7bb082 )
+)
+
+game (
 	name "Double Joker Poker (45%-75% payout)"
 	developer "DellFern Ltd."
 	rom ( name df_djpkr.zip size 7201 crc 743ced08 md5 0b0c9729018a95fa59a728e29a38c82f sha1 a08f072775c469829d61e4061b52b64d628433b3 )
@@ -9596,10 +10813,31 @@ game (
 )
 
 game (
+	name "Diet Go Go (Euro v1.1 1992.09.26)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgo.zip size 2194196 crc ba979f30 md5 66934e4b2a2bf80c56e41d01f2cbd621 sha1 cc9e6b1e97e7b227509478264b1b7c9aae38bfa3 )
+)
+
+game (
+	name "Diet Go Go (Euro v1.1 1992.08.04)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgoe.zip size 469614 crc 6419495a md5 e30638edc81ff3d70473996584bdbbe3 sha1 c7f8fc6481b26aae95fc47b23d10a668688ec854 )
+)
+
+game (
 	name "Diet Go Go (Japan v1.1 1992.09.26)"
 	year "1992"
 	developer "Data East Corporation"
 	rom ( name dietgoj.zip size 448935 crc 9d2d07ca md5 c2455cbd0658022859349899e678443d sha1 33737f973679f7c7591e1b4e0172c6cea60e088a )
+)
+
+game (
+	name "Diet Go Go (USA v1.1 1992.09.26)"
+	year "1992"
+	developer "Data East Corporation"
+	rom ( name dietgou.zip size 448893 crc 3ef70184 md5 d50aeec2e83fcbf15845503e8735c653 sha1 e2f65c54201a1336ff88bd1c1507d90402adda9d )
 )
 
 game (
@@ -9694,6 +10932,20 @@ game (
 )
 
 game (
+	name "Cadillacs and Dinosaurs (World 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dino.zip size 4115385 crc 22ff20c9 md5 52b9e81c2ef937ec640e10a6d1454ece sha1 df365c931efdd29727939f05ac211aa6153e266d )
+)
+
+game (
+	name "Cadillacs: Kyouryuu Shin Seiki (Japan 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dinoj.zip size 408349 crc 9089e01d md5 06fb870685305c3ac97bb80f46117647 sha1 feffb298e1434c21052de2e674c4314d0b7f4cb6 )
+)
+
+game (
 	name "Dino Rex (World)"
 	year "1992"
 	developer "Taito Corporation Japan"
@@ -9712,6 +10964,13 @@ game (
 	year "1992"
 	developer "Taito America Corporation"
 	rom ( name dinorexu.zip size 132491 crc b1f0e97b md5 a2729ca96f497e354e4cc8b896ad1d87 sha1 9344ca0689305eb4f6a19454b6c5d5b1142dbd8a )
+)
+
+game (
+	name "Cadillacs and Dinosaurs (USA 930201)"
+	year "1993"
+	developer "Capcom"
+	rom ( name dinou.zip size 408201 crc b8fac7da md5 1b1858792f85ab36d8cd65c8fa0ad4d7 sha1 ef1b9072a172d7a174009d16528aa46de2b9368f )
 )
 
 game (
@@ -9775,6 +11034,13 @@ game (
 	year "1990"
 	developer "Irem"
 	rom ( name dkgensan.zip size 284435 crc 4238d94f md5 44395d265ac55c9699ff7beb0399bc38 sha1 19f88c68a0f876fdfe0c90e81f19f27c1ce81397 )
+)
+
+game (
+	name "Daiku no Gensan (Japan, M72)"
+	year "1990"
+	developer "Irem"
+	rom ( name dkgensanm72.zip size 473080 crc 0fb774f9 md5 2c305ec33f0c84ff6a67823502cd6609 sha1 971a2561251f0050ac00a80bb61717e880cef9f7 )
 )
 
 game (
@@ -10002,6 +11268,13 @@ game (
 )
 
 game (
+	name "Dolphin Blue"
+	year "2003"
+	developer "Sammy"
+	rom ( name dolphin.zip size 82591393 crc a2a08817 md5 1fc2018c8548953116f457a52f6569aa sha1 9db1341237f61aba8583f718ddaa6036490339eb )
+)
+
+game (
 	name "Domino Man"
 	year "1982"
 	developer "Bally Midway"
@@ -10226,6 +11499,13 @@ game (
 )
 
 game (
+	name "Date Quiz Go Go (Korea)"
+	year "1998"
+	developer "SemiCom"
+	rom ( name dquizgo.zip size 1327729 crc 081f945d md5 6a2a30778523a7022cec607b04128c3f sha1 2b62d2071793d5b2cdb4079f1b6badf595715dbe )
+)
+
+game (
 	name "Date Quiz Go Go Episode 2"
 	year "2000"
 	developer "SemiCom"
@@ -10282,6 +11562,13 @@ game (
 )
 
 game (
+	name "Dream World"
+	year "2000"
+	developer "SemiCom"
+	rom ( name dreamwld.zip size 2007859 crc 7e39ed84 md5 87b93c596a51081bd1fe37c83ea5d9a4 sha1 82679e31d5694982becb4d0cdebe2da438aa97a1 )
+)
+
+game (
 	name "Dream Shopper"
 	year "1982"
 	developer "Sanritsu"
@@ -10300,6 +11587,13 @@ game (
 	year "1984"
 	developer "Namco"
 	rom ( name drgnbstr.zip size 60346 crc 94f96ab1 md5 69872262d0b16eb6381866ae3dfe2a14 sha1 845aaf84f2ab64fcb2e6829cd05e5cd5e30dcdd6 )
+)
+
+game (
+	name "Dragonninja (Japan)"
+	year "1988"
+	developer "Data East Corporation"
+	rom ( name drgninja.zip size 310675 crc 71712687 md5 6c20538128e137953353706e17496e29 sha1 76fb1f65984ea65eb5fdc51e4e5c2d252ae24ca3 )
 )
 
 game (
@@ -10457,6 +11751,27 @@ game (
 )
 
 game (
+	name "Dr. Toppel's Adventure (World)"
+	year "1987"
+	developer "Kaneko / Taito Corporation Japan"
+	rom ( name drtoppel.zip size 399766 crc 9918e9f2 md5 1709c15d5d106dfc02a47a0846df2dd1 sha1 8a5c0bd41a7ad5dae9d6e3ba5c12b4b5f29f5eaf )
+)
+
+game (
+	name "Dr. Toppel's Tankentai (Japan)"
+	year "1987"
+	developer "Kaneko / Taito Corporation"
+	rom ( name drtoppelj.zip size 12155 crc 56b8fa71 md5 1c97cb4bb3daf7e92924f6e606a9d26a sha1 3a592cbe660a0c35a918347a19fa799b740aec4b )
+)
+
+game (
+	name "Dr. Toppel's Adventure (US)"
+	year "1987"
+	developer "Kaneko / Taito America Corporation"
+	rom ( name drtoppelu.zip size 12155 crc fe6c74de md5 b8d33e4ed5e3d30b197e2c793e6d870f sha1 3581ea54357fceabc95a9bcac36259a2d54648a0 )
+)
+
+game (
 	name "Dragon Saber"
 	year "1990"
 	developer "Namco"
@@ -10468,6 +11783,20 @@ game (
 	year "1990"
 	developer "Namco"
 	rom ( name dsaberj.zip size 102170 crc 9bb798d2 md5 f17f1331c22f035532fbc42827da6179 sha1 a52c9ce9c1797d61da1c16d4b1ac8049db6f1c55 )
+)
+
+game (
+	name "Dancing Stage featuring Dreams Come True (GC910 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dsfdcta.zip size 308 crc 788616f2 md5 452df39ea008420351952fb9d599b142 sha1 2949fcee916167dccf26414bf272a9abb23b64db )
+)
+
+game (
+	name "Dancing Stage featuring TRUE KiSS DESTiNATiON (G*884 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dsftkd.zip size 282 crc 158cab8d md5 d3ccc8bcd00aabc04ef31f26fb200063 sha1 d5478456f4feda819d9b4673398a45f593b89c3b )
 )
 
 game (
@@ -10503,6 +11832,13 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name dspirito.zip size 59442 crc d83eb646 md5 c142ab96b9afeca3e03821d9a7dfdd74 sha1 61dc2642562bbce9f9d975d12067ba3018c2bae2 )
+)
+
+game (
+	name "Dancing Stage (GN845 VER. EAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name dstage.zip size 172 crc 211884f7 md5 3f10c9aa74fe4f8e8b5fb180c7bce079 sha1 8302f141cd7a14e6f2a859df393e65d0e0d7ac08 )
 )
 
 game (
@@ -10652,6 +11988,13 @@ game (
 )
 
 game (
+	name "Dynamic Shooting"
+	year "1988"
+	developer "Jaleco"
+	rom ( name dynashot.zip size 67568 crc 48edb7c5 md5 626d6e3c8e6137d8104d6416a6ffa95e sha1 50abcd3eb85dc5c5510be60c7ac4732de844c06c )
+)
+
+game (
 	name "Dynamite Duke (Japan)"
 	year "1989"
 	developer "Seibu Kaihatsu"
@@ -10677,6 +12020,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name dynwar.zip size 2193606 crc 13133f73 md5 e45c907aa7c9d903403d9e7e38b07d68 sha1 80e256ade6aa053e026088210e9b4557e406c953 )
+)
+
+game (
+	name "Tenchi wo Kurau (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name dynwarj.zip size 2234688 crc d1edcff6 md5 87ca5dfd65321f03be104fada43f613f sha1 605e0d745d8e683415e641bb2f59b44a06cf1104 )
+)
+
+game (
+	name "Dynasty Wars (USA, set 2)"
+	year "1989"
+	developer "Capcom"
+	rom ( name dynwaru.zip size 2029034 crc e417cbbb md5 3c4279b76ba008e77e7748c88dadc51f sha1 7fadb21ae480f546927f0897cfa480a5a719c76a )
 )
 
 game (
@@ -10761,6 +12118,20 @@ game (
 	year "1993"
 	developer "Capcom"
 	rom ( name ecofghtru1.zip size 1260542 crc e0b0caff md5 5067c5ace97ab0cb08e724c71d12547c sha1 a43ab802515dea67553921e8c332a4113e25c37f )
+)
+
+game (
+	name "E.D.F. : Earth Defense Force"
+	year "1991"
+	developer "Jaleco"
+	rom ( name edf.zip size 1166516 crc 621c9451 md5 36f6b6f7c778cb42b70f9b62838f047c sha1 0843e086044885aa1c5b6a95f577790f0045f5e0 )
+)
+
+game (
+	name "E.D.F. : Earth Defense Force (North America)"
+	year "1991"
+	developer "Jaleco"
+	rom ( name edfu.zip size 125561 crc 12fe65ce md5 9bb7379b7ad01bfd696b3ec28f82320d sha1 4c019606138395a8790940368e3c7f7d4994cce9 )
 )
 
 game (
@@ -10939,6 +12310,20 @@ game (
 )
 
 game (
+	name "Elephant Family (Italian, new)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name elephfam.zip size 53968 crc c1714542 md5 17b7783f2d0b37b707ff4c041ab2006f sha1 0d5da2f9cf27ce4f696557e95f8ae7616f222992 )
+)
+
+game (
+	name "Elephant Family (Italian, old)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name elephfmb.zip size 27268 crc 6720875a md5 de479275581bf8cf0b64957b27a60f61 sha1 6e3a27aaeff4a92f951741288d2b3ecd352db9ef )
+)
+
+game (
 	name "Elevator Action"
 	year "1983"
 	developer "Taito Corporation"
@@ -10999,6 +12384,13 @@ game (
 	year "1994"
 	developer "Taito America Corporation"
 	rom ( name elvact2u.zip size 123930 crc 2d7ddd65 md5 2d4ffe786b71ef8522a9a411d42f6773 sha1 9080b66f0d29f6434e32651ee84622fed2e3def3 )
+)
+
+game (
+	name "Elevator Action Returns (Ver 2.2O 1995/02/20)"
+	year "1994"
+	developer "Taito Corporation Japan"
+	rom ( name elvactr.zip size 8186906 crc d89e457f md5 df255cc7c1faa0502dd0ff6512596fe0 sha1 c1aa23e690c86c85fcbec1b57e7ad6dc6d58eb5d )
 )
 
 game (
@@ -11083,6 +12475,20 @@ game (
 	year "1981"
 	developer "GamePlan (Zilec Electronics license)"
 	rom ( name enigma2.zip size 11376 crc 7075d0f7 md5 cf646e6746bfee7ec2a79a70fc209e72 sha1 660cdd5cb6583871c997af42ff668d814eb1db1f )
+)
+
+game (
+	name "Enigma II (Space Invaders hardware)"
+	year "1984"
+	developer "Zilec Electronics"
+	rom ( name enigma2a.zip size 7977 crc d954a25b md5 7719bdb88678a36f71ae3012c0df4ab8 sha1 9b0b5223b80b212c1323ede08479eb598c3aef52 )
+)
+
+game (
+	name "Phantoms II (Space Invaders hardware)"
+	year "1981"
+	developer "Zilec Electronics"
+	rom ( name enigma2b.zip size 7963 crc 1372c3a8 md5 5eca27ffc7a0233d0610af739272d600 sha1 84cbe6212b2eaa1358594342f95ead9bc294dee0 )
 )
 
 game (
@@ -11393,6 +12799,27 @@ game (
 )
 
 game (
+	name "Extermination (World)"
+	year "1987"
+	developer "Taito Corporation Japan"
+	rom ( name extrmatn.zip size 369284 crc 1f69d677 md5 9f7f0b26e33fc46c495fc62dce2fc811 sha1 fb611f82b86a4620e8248970a27a29ee2a677486 )
+)
+
+game (
+	name "Extermination (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name extrmatnj.zip size 12196 crc b04ce1cd md5 9b3a6a03d658dc84b3bcb3292be0b841 sha1 20d54859603fcd6df08852e7ca06ddc92016fa57 )
+)
+
+game (
+	name "Extermination (US)"
+	year "1987"
+	developer "Taito (World Games license)"
+	rom ( name extrmatnu.zip size 86745 crc 52da26f8 md5 c10d2f70d4df9dc4dd8f0d2d466c802b sha1 d64057613ded50f6637cd2d33e9b6e35797cc376 )
+)
+
+game (
 	name "Exvania (Japan)"
 	year "1992"
 	developer "Namco"
@@ -11404,6 +12831,13 @@ game (
 	year "1987"
 	developer "Taito Corporation"
 	rom ( name exzisus.zip size 272501 crc 4382d354 md5 c4d5bc09d8362d16fb4f347da95ddb56 sha1 bcad925468f0f34cefae781e422badfd70a5ccf9 )
+)
+
+game (
+	name "Exzisus (Japan, conversion)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name exzisusa.zip size 176462 crc 2eeae837 md5 0d5df6af5b92a83d1d54555b960481e0 sha1 1f51142a9dc245c41ccc5dfe42e423d3c2f940bf )
 )
 
 game (
@@ -11439,6 +12873,13 @@ game (
 	year "1991"
 	developer "Microprose Games Inc."
 	rom ( name f15se21.zip size 300686 crc 1ac2916e md5 0831c53ed4901be2f88351b65384ab2e sha1 f46016964c0f27b4c8faa5f09451797b23f10fd6 )
+)
+
+game (
+	name "F-1 Dream"
+	year "1988"
+	developer "Capcom (Romstar license)"
+	rom ( name f1dream.zip size 338876 crc 3fdf1f53 md5 90c9cf086d72d31a224fbc49880b4ae1 sha1 3ff536b5a5e5d5b283e26af5fd2f02c56cfcbfc7 )
 )
 
 game (
@@ -11811,6 +13252,111 @@ game (
 )
 
 game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4.zip size 646767 crc 8076cc7a md5 0207a9d0b1a2a8229fbe26d1bce071a1 sha1 020d45b8de19ec972c5fdfd41c2aa5ae63a99de3 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 1)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4b2.zip size 148328 crc 5afec92a md5 2820aa25c4ca0c2e0991364fa8b1f73f sha1 4068f0155458521e700a2d59ebb774f96c298b90 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4c1.zip size 148529 crc 4bac0768 md5 2a6ffcc6631e630e5d2b84a5a93abad1 sha1 08ca20e7f0c5ef7a3a5d0d6bc22c43da0ca68145 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4c2.zip size 148689 crc 7d895190 md5 ac7ff5e579b5a121ed43faf127b2d33c sha1 d734b89597bb57652ceb628753c43915a16b34ab )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R, set 3)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4d1.zip size 147898 crc 81e8018f md5 f536ef4b4172c11d45191372db50c0c7 sha1 4278c734b609339d0ec52c9f31a480d114d9684e )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT, set 3)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4d2.zip size 148074 crc 7509005a md5 6d0f6c569ce14a245b8837e009a9b132 sha1 da68dfdc6ad7542efedd0db0a21cbb58ff320251 )
+)
+
+game (
+	name "Fruit Bonus 2005 (2004 Export - Version 1.5E Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4exp.zip size 471816 crc d4a77121 md5 f350c3b1af83710c94013ffde4beff51 sha1 f0379a8dfbf5cc2a36ad70fafb7ba5e1884520e8 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.3XT)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4o.zip size 148423 crc a98b4019 md5 32c568a5f8a4844570424189d448befc sha1 d07a6d1067e27e5174ffe21212f40663886d7511 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.2)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4o2.zip size 148522 crc 669bc663 md5 4290b6d264b55e706c8f7b64facb3ba9 sha1 bdcf66a4630e29480780e04dec932eb2aae738fd )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5R Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4v1.zip size 148268 crc 65c11efc md5 897bbe31e7b7302b5a6b70bf1d85f308 sha1 ffd2a9098d124c0bd17cf3d40d1d9341d66dd8c0 )
+)
+
+game (
+	name "Fruit Bonus 2004 (Version 1.5LT Dual)"
+	year "2004"
+	developer "Amcoe"
+	rom ( name fb4v2.zip size 147997 crc f76426a7 md5 65fd5b2258ecfd2eafc4c13aac1154be sha1 5514c1ff09f692dbc4cb3df9a3c0997685b3f209 )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 1)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5.zip size 768770 crc 3dfc8d0a md5 426529d3cb9da4b4bf1df8127dedc977 sha1 0f26141c17ab9c1436f3d311897cb4ad81449f81 )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 2)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5c.zip size 143347 crc a14c4d73 md5 9dfe6ff9d70406caca92a2022129c3fb sha1 3123327d5c1cedbb5cc474a5c7690a91fa197397 )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH, set 3)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5d.zip size 141797 crc 3d48b6dd md5 4c672b8d373b3dfca16539e8cbc74562 sha1 1193a914ba236265f3d1669a3b790f0717883e99 )
+)
+
+game (
+	name "Fruit Bonus 2005 (Version 1.5SH Dual)"
+	year "2005"
+	developer "Amcoe"
+	rom ( name fb5v.zip size 142742 crc d91895ee md5 eeb8fcc0eb2e53e49c859a1abb2cd584 sha1 2f2342aa62ecbd785e46f764c0822f8b00715471 )
+)
+
+game (
 	name "Fruit Bonus '06 - 10th anniversary (Version 1.7E CGA)"
 	year "2006"
 	developer "Amcoe"
@@ -11892,6 +13438,48 @@ game (
 	year "2006"
 	developer "Amcoe"
 	rom ( name fb6v2.zip size 139918 crc 95a955f4 md5 26000919d05b4c697a62db08606399cc sha1 f822f8c510d6436c3b68a144bf5e130693dd3dc8 )
+)
+
+game (
+	name "Fisherman's Bait 2 - A Bass Challenge (GE865 VER. UAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name fbait2bc.zip size 182 crc eb05f689 md5 877d342ed83e8b5ed47766918fcacb2b sha1 1b067281d729d9961360d2bc4e0a860f6f4c10c1 )
+)
+
+game (
+	name "Fisherman's Bait - A Bass Challenge (GE765 VER. UAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name fbaitbc.zip size 182 crc 98e197e4 md5 96799b037cd5bfc129e047fae49f237b sha1 c9842005d648ffeebd8c0ce170476b70c00861ee )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. EA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmc.zip size 172 crc de91fecb md5 40d7af846d82b18aa41d5d8f28fc94a5 sha1 cefec72b9c98db93245af37ae4acac298a1de08f )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. AA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmca.zip size 172 crc 946ffcdb md5 1f6bd8d4f6ff72df30a6b021021b18a8 sha1 37900e41b5225a0a76b6804d9591813c8aeb0bc3 )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. JA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmcj.zip size 172 crc 1a7f9709 md5 a21726d4a3ed85caef231f5bc8f46763 sha1 864aa7626b505e3d0f13a0191ec27383fe5a479c )
+)
+
+game (
+	name "Fisherman's Bait - Marlin Challenge (GX889 VER. UA)"
+	year "1999"
+	developer "Konami"
+	rom ( name fbaitmcu.zip size 172 crc e520b1cb md5 d52d29237317fa962379e66824cd406b sha1 87e70017761c051c4b9e4a5822cca69cc63d73f2 )
 )
 
 game (
@@ -12021,6 +13609,34 @@ game (
 )
 
 game (
+	name "Final Fight (Japan)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj.zip size 1073054 crc c5b0380f md5 8bf50535792545c67f614633ff680162 sha1 e6d2180ad6c703c04c7bb39e376c264917b8a92c )
+)
+
+game (
+	name "Final Fight (Japan 900112)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj1.zip size 1210211 crc 96e03151 md5 fe36c2d9a4dfb25e444c5a497bf18252 sha1 0a795638e7a70245d441c9edeb53040cdaed5b83 )
+)
+
+game (
+	name "Final Fight (Japan 900305)"
+	year "1989"
+	developer "Capcom"
+	rom ( name ffightj2.zip size 1210353 crc 22147444 md5 3afc783231bd49c9a3aba25f7c898eec sha1 b6482a2eafe1b4ff98fc8004ef914fe5558de20d )
+)
+
+game (
+	name "Street Smart / Final Fight (Japan, hack)"
+	year "1989"
+	developer "bootleg"
+	rom ( name ffightjh.zip size 1169235 crc 4cefb840 md5 30c97d5229a96e5d35b418b2db10e63c sha1 3fa2a28600102482f3bb0dbb0ab09c8fc930b380 )
+)
+
+game (
 	name "Final Fight (USA)"
 	year "1989"
 	developer "Capcom"
@@ -12063,6 +13679,34 @@ game (
 )
 
 game (
+	name "Fighter's History (World ver 43-07)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthist.zip size 5649743 crc 7accf751 md5 fde7de3ddc1f01c01b49619d64ca2551 sha1 13e97cc5fa36c3bfde56377b0d02de8196d97d87 )
+)
+
+game (
+	name "Fighter's History (US ver 42-05, alternate hardware )"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthista.zip size 437701 crc 8cc3e286 md5 efb471db10ba54e4578ac19830428272 sha1 c375a05ad8afba46dd8a47b6b4b940604b4cd071 )
+)
+
+game (
+	name "Fighter's History (Japan ver 42-03)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthistj.zip size 437749 crc cf5b4629 md5 b44769ed4040da2b92dda19f2af60576 sha1 e2205dbceb6a186106f8240dbbb5404f46b22854 )
+)
+
+game (
+	name "Fighter's History (US ver 42-03)"
+	year "1993"
+	developer "Data East Corporation"
+	rom ( name fghthistu.zip size 437749 crc 36295639 md5 b42f9117c8708ad5024ac0849b1c3e3f sha1 ef97443fcbd5384c2821ed5e485e5dcff5e0faff )
+)
+
+game (
 	name "Fighting Layer (Japan, FTL1/VER.A)"
 	year "1998"
 	developer "Arika / Namco"
@@ -12084,6 +13728,13 @@ game (
 )
 
 game (
+	name "Field Day"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name fieldday.zip size 104233 crc fd33340b md5 6ec59ca3300bf2f9568041368219f3dd sha1 25f2fefc6473d1acf8f743cb6b6dcfdc0210be84 )
+)
+
+game (
 	name "Fight Fever (set 1)"
 	year "1994"
 	developer "Viccom"
@@ -12102,6 +13753,41 @@ game (
 	year "1983"
 	developer "Kaneko (Taito license)"
 	rom ( name fightrol.zip size 46497 crc 71b0539f md5 c09fd7b12c911cdfced5f2b7a17f98f6 sha1 83cb50113e2f2bbf33c3a3b886559dbc625d8a91 )
+)
+
+game (
+	name "Final Lap 2"
+	year "1990"
+	developer "Namco"
+	rom ( name finalap2.zip size 2006181 crc 266ca1dc md5 9075a2bca031d30d25c145abac56c41e sha1 12ac372e776bfe55e151bd8541e657bfb4bcddcb )
+)
+
+game (
+	name "Final Lap 2 (Japan)"
+	year "1990"
+	developer "Namco"
+	rom ( name finalap2j.zip size 39058 crc e86090ce md5 12e5b050c559d200ada8ca3a6f521756 sha1 0fc768b1fc3ae492dd0b79eb39664ff2d29a95fb )
+)
+
+game (
+	name "Final Lap 3 (World, set 1)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3.zip size 2408440 crc ea0e0096 md5 bbf03f16da3d4f7363c0f5574def9a48 sha1 e5926ce1b4534366979b027e78b6cfddf29c8fe0 )
+)
+
+game (
+	name "Final Lap 3 (World, set 2)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3a.zip size 65953 crc 940a10e9 md5 8c58f5d602f84ee9c4782bbcb4f3bed2 sha1 941b35ddbfc5ceae9fea419ed4a139a33f2e8910 )
+)
+
+game (
+	name "Final Lap 3 (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name finalap3j.zip size 130083 crc c024e4be md5 f225208c62ff110257bc790eb003bf0e sha1 25216270653b668c7656af0bbc21b697fcb687cf )
 )
 
 game (
@@ -12161,10 +13847,59 @@ game (
 )
 
 game (
+	name "Finalizer - Super Transformation"
+	year "1985"
+	developer "Konami"
+	rom ( name finalizr.zip size 81140 crc 7a771edd md5 9c01699fdd7e4f6bc3292a3bb180846a sha1 98fdd6fc516ae9ceed3a480222a66f07e657458a )
+)
+
+game (
 	name "Finalizer - Super Transformation (bootleg)"
 	year "1985"
 	developer "bootleg"
 	rom ( name finalizrb.zip size 38116 crc 620a4e38 md5 eb105ac7b76eec91c849711ec931f8b8 sha1 bfac93c20579b008d186a9c4c1a6d0438c9f412c )
+)
+
+game (
+	name "Final Lap (Rev E)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallap.zip size 1115399 crc f462a7d5 md5 74943d547b998ae2f5292cd49d8436b7 sha1 b68910a1e56d499e6f4b14deff41a4e57f48177c )
+)
+
+game (
+	name "Final Lap (Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapc.zip size 48545 crc cb7b77c7 md5 15de023e0302f817e630f667f9482f76 sha1 19a410d013473eb61cff48cc9edd3244709c8cbd )
+)
+
+game (
+	name "Final Lap (Rev D)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapd.zip size 38498 crc 86390bc7 md5 95578b155bf85e2b26b55c3f7022b8b4 sha1 eead37f0b22d6711a0cd505423147db910cc5f2f )
+)
+
+game (
+	name "Final Lap (Japan - Rev B)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapjb.zip size 94941 crc d6449da4 md5 42433d418f840ffbcbe23db6b466b3a6 sha1 6cf19be4d764a902fbc733bc5ff9d64c68ee73ed )
+)
+
+game (
+	name "Final Lap (Japan - Rev C)"
+	year "1987"
+	developer "Namco"
+	rom ( name finallapjc.zip size 38056 crc 262cc4b4 md5 cf319f8293f61064140dd213ee433894 sha1 90b2ce27d738990f1f5aa3a5f353b0d24226898f )
+)
+
+game (
+	name "Final Tetris"
+	year "1993"
+	developer "Jeil Computer System"
+	rom ( name finalttr.zip size 260189 crc 711a654f md5 2ba81ba082709f6bd5bc2bc9dee28036 sha1 f138d18df311fd311b8541680acd348a617dcbe7 )
 )
 
 game (
@@ -12224,10 +13959,45 @@ game (
 )
 
 game (
+	name "Fire Shark"
+	year "1990"
+	developer "Toaplan"
+	rom ( name fireshrk.zip size 533640 crc 31b3b438 md5 6e188e233b1be78f296ff7620084e33c sha1 189548d506e1aa18d18f18958298633cdffdc8a0 )
+)
+
+game (
+	name "Fire Shark (Korea, set 1, easier)"
+	year "1990"
+	developer "Toaplan (Dooyong license)"
+	rom ( name fireshrkd.zip size 67893 crc 32ddb848 md5 79da4c0ba81b1f82b3ae203eef59b6c3 sha1 8882fc8bb487678db850af212ce29aedde44083c )
+)
+
+game (
+	name "Fire Shark (Korea, set 2, harder)"
+	year "1990"
+	developer "Toaplan (Dooyong license)"
+	rom ( name fireshrkdh.zip size 68104 crc 3f16019d md5 bab757d4620bee73d11bf01843863f04 sha1 881e49f5688cb2fdb8803349ef7afb05ddaef451 )
+)
+
+game (
+	name "Fire Trap (US)"
+	year "1986"
+	developer "Wood Place Inc. (Data East USA license)"
+	rom ( name firetrap.zip size 256265 crc d9548ab9 md5 db5088670a54b41a056407cc02e64d30 sha1 eb07d97a576a2da1657e9b8217cf6959d8feb961 )
+)
+
+game (
 	name "Fire Trap (Japan bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name firetrapbl.zip size 62520 crc e7253351 md5 b1cda7dc82359d35ee6b23e37ec1dbd3 sha1 43545b3c7aee3a6539b623331d30f3d5d40d4fcf )
+)
+
+game (
+	name "Fire Trap (Japan)"
+	year "1986"
+	developer "Wood Place Inc."
+	rom ( name firetrapj.zip size 76599 crc ecd35fdf md5 286d424d3f9d4c602ea13dd513e7212e sha1 b20ec5b40565faccfe952c0e8d992bc43630a092 )
 )
 
 game (
@@ -12350,6 +14120,13 @@ game (
 )
 
 game (
+	name "Battle Flip Shot"
+	year "1998"
+	developer "Visco"
+	rom ( name flipshot.zip size 2311372 crc 5fc4aca3 md5 db8be925337c96729445c8e57b8a222e sha1 8cbac7dd711094043fc7376f29c31265712ffe05 )
+)
+
+game (
 	name "Flipull (Japan)"
 	year "1989"
 	developer "Taito Corporation"
@@ -12466,6 +14243,13 @@ game (
 	year "1988"
 	developer "Capcom"
 	rom ( name forgottn.zip size 1937908 crc 67c08578 md5 7995ed8a54b12ba850e2143bf5090e44 sha1 079dba637a12b1676e1b67af44529d8cc838873a )
+)
+
+game (
+	name "Forgotten Worlds (USA, 88618B B-Board)"
+	year "1988"
+	developer "Capcom"
+	rom ( name forgottnu.zip size 726314 crc 20de77d0 md5 430661a5b5085e5dfed13d6cac8aec29 sha1 89201ae5b7f9db6091043ba55bbb2a85af09c09c )
 )
 
 game (
@@ -12763,6 +14547,13 @@ game (
 )
 
 game (
+	name "Flying Shark (bootleg)"
+	year "1987"
+	developer "bootleg"
+	rom ( name fsharkbt.zip size 49743 crc f4ea87d0 md5 3b779c90b7b4fcfdeca1ebb9318598c1 sha1 1382cf5afae1f9f15d53eebc68f804a87ebe54ba )
+)
+
+game (
 	name "Fighting Soccer (version 4)"
 	year "1988"
 	developer "SNK"
@@ -12858,6 +14649,13 @@ game (
 	year "1982"
 	developer "bootleg"
 	rom ( name funkybeeb.zip size 5798 crc af0386f7 md5 36d778da792df165338674a23c3f463b sha1 5509e6882a6d07a326f58109014f9b1a1ac9eebb )
+)
+
+game (
+	name "The First Funky Fighter"
+	year "1993"
+	developer "Nakanihon / East Technology (Taito license)"
+	rom ( name funkyfig.zip size 4972404 crc b016ea18 md5 734a5cf4f842bef765235acd0def6fe2 sha1 73ae89381895508b639bfdf4e53af2f4890df059 )
 )
 
 game (
@@ -13168,6 +14966,20 @@ game (
 )
 
 game (
+	name "Galaxy Games StarPak 2"
+	year "1998"
+	developer "Creative Electronics &amp; Software / Namco"
+	rom ( name galgame2.zip size 835222 crc 896985c5 md5 478e3de1a1e5dc0e929ea3157aad4d41 sha1 0164d662c4ac69512cc0164cb90ee9e7f244675f )
+)
+
+game (
+	name "Galaxy Games (BIOS v1.90)"
+	year "1998"
+	developer "Creative Electronics &amp; Software"
+	rom ( name galgbios.zip size 672693 crc d48fb1b7 md5 5e47080415522d11c82362eb58cb11e6 sha1 4333731f447124af1d7286ab36e4d6395e4d444a )
+)
+
+game (
 	name "Gals Hustler"
 	year "1997"
 	developer "ACE International"
@@ -13357,6 +15169,13 @@ game (
 )
 
 game (
+	name "The Game Paradise - Master of Shooting! / Game Tengoku - The Game Paradise"
+	year "1995"
+	developer "Jaleco"
+	rom ( name gametngk.zip size 13902738 crc fbf9eed6 md5 8c7e0ae282cb63d4dc0e8140977b81a4 sha1 8657d916ccce719dcc9442e6e7691bf6d9d6a7d5 )
+)
+
+game (
 	name "Ganbare! Gonta!! 2 / Party Time: Gonta the Diver II (Japan Release)"
 	year "1995"
 	developer "Mitchell"
@@ -13494,6 +15313,13 @@ game (
 	year "1988"
 	developer "Konami"
 	rom ( name garuka.zip size 42612 crc fec1b2e3 md5 85eadf41bb9836e5c953c2148a62ce96 sha1 5674fed5d1b373058ea08c2287519a364dbb7d4b )
+)
+
+game (
+	name "Garyo Retsuden (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name garyoret.zip size 420083 crc 22aefd95 md5 27a84c1193c4eb1e81b209ddb55b83b4 sha1 72813552144923325fa0940fa7bd2b8dc16ca219 )
 )
 
 game (
@@ -13721,6 +15547,13 @@ game (
 )
 
 game (
+	name "Green Beret (bootleg)"
+	year "1985"
+	developer "bootleg"
+	rom ( name gberetb.zip size 76289 crc 70cb8bb4 md5 0cf8ec2f2480670950581df90d108494 sha1 2f560d8d677745a723e3689ac53bad5a979babd0 )
+)
+
+game (
 	name "Global Champion (Ver 2.1A 1994/07/29)"
 	year "1994"
 	developer "Taito America Corporation"
@@ -13896,6 +15729,20 @@ game (
 )
 
 game (
+	name "Guardian (US)"
+	year "1986"
+	developer "Toaplan / Taito America Corporation (Kitkorp license)"
+	rom ( name getstar.zip size 158272 crc 8c74ff48 md5 71fd94bf1d02e11d277d8c82cda0bf8c sha1 4309b5e6ae00c1fcab84117c452ad579396d5def )
+)
+
+game (
+	name "Get Star (Japan)"
+	year "1986"
+	developer "Toaplan / Taito"
+	rom ( name getstarj.zip size 39954 crc 75591042 md5 fafe307420db0d73948eae7057259a18 sha1 d9829fb00ca80f3c3e9231e01080ca3cdb769f0f )
+)
+
+game (
 	name "Golden Fire II"
 	year "1992"
 	developer "Topis Corp"
@@ -13924,6 +15771,20 @@ game (
 )
 
 game (
+	name "Goalie Ghost"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name gghost.zip size 33194 crc 99c97f79 md5 088130c4c4997dd2ed55cc0e7cc5e067 sha1 5b63c5e3c53cac54f965a79ca9a7aeea6c25628e )
+)
+
+game (
+	name "Guilty Gear Isuka"
+	year "2003"
+	developer "Sammy / Arc System Works"
+	rom ( name ggisuka.zip size 131961511 crc afa85b3c md5 1cc75ac9f4399917a4a6a3adaf7160d2 sha1 290629120bfb33935eae68112a50bf7bc90045fc )
+)
+
+game (
 	name "Gain Ground (World, 3 Players, Floppy Based, FD1094 317-0058-03d Rev A)"
 	year "1988"
 	developer "Sega"
@@ -13949,6 +15810,20 @@ game (
 	year "1996"
 	developer "Hanaho Games"
 	rom ( name ghoshunt.zip size 206467 crc 51e51408 md5 8631deeb227ddf5c7b7a56e622903d3f sha1 0b78f65b3a9f6301d4dc3852263ecc5f50237032 )
+)
+
+game (
+	name "The Real Ghostbusters (US 2 Players)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name ghostb.zip size 417053 crc 2849223a md5 a68b9f4ca9df383a768c76be62886a67 sha1 29044ed4f740097646e64243ecb2b02982aa42ed )
+)
+
+game (
+	name "The Real Ghostbusters (US 3 Players)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name ghostb3.zip size 63753 crc e21e11d4 md5 3f3f60fe7abc3dd00328e718ec9ef3bb sha1 cf7ba7357ba0470b7f864a3ae04e7db842c9811b )
 )
 
 game (
@@ -14061,6 +15936,13 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name gijoeu.zip size 207894 crc 8b51cf63 md5 c3bd9284218541ed1ee62096e053109b sha1 ecae955290c6a4b218b3e989aacd7557d0898208 )
+)
+
+game (
+	name "Gimme A Break"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name gimeabrk.zip size 38709 crc 2265ae16 md5 a16efce0fed1866fbfe3b5fb1e3f37ce sha1 7675fb25d7988f2b60373b021eae6534b38fd300 )
 )
 
 game (
@@ -14288,10 +16170,24 @@ game (
 )
 
 game (
+	name "Golden Axe (set 6, US, 8751 317-123A)"
+	year "1989"
+	developer "Sega"
+	rom ( name goldnaxe.zip size 1162622 crc 0613beb6 md5 90a88e501fe0eb52df0061cf3e5bd220 sha1 5d0a09d15498d2e302a44fc119710413658f409d )
+)
+
+game (
 	name "Golden Axe (set 1, World, FD1094 317-0110)"
 	year "1989"
 	developer "Sega"
 	rom ( name goldnaxe1.zip size 282801 crc ce127891 md5 ce13c9558db5741fa8f788cf262cb8fc sha1 d55198510d3fe868f7548da49dba73fdc822c407 )
+)
+
+game (
+	name "Golden Axe (set 2, US, 8751 317-0112)"
+	year "1989"
+	developer "Sega"
+	rom ( name goldnaxe2.zip size 177465 crc 9a3039bb md5 9424de9df9b5ac73777f84683743cf14 sha1 a031abfcecc1e3882b69a88c8c0fd22966302538 )
 )
 
 game (
@@ -14454,6 +16350,13 @@ game (
 )
 
 game (
+	name "Golden Par Golf (Joystick, V1.1)"
+	year "1992"
+	developer "Strata/Incredible Technologies"
+	rom ( name gpgolf.zip size 521879 crc e1b858cc md5 887376bf11dc63882624ca25f817c6bc sha1 fd78ce67b14dfa05493c3bc8b44cc05447755ab7 )
+)
+
+game (
 	name "Ghost Pilots (set 1)"
 	year "1991"
 	developer "SNK"
@@ -14472,6 +16375,13 @@ game (
 	year "1990"
 	developer "Sega"
 	rom ( name gprider1.zip size 98496 crc 39cd7d25 md5 beb65c7d3c8a07f3229cf1c0343a234d sha1 96c52bdc03790326c9ac8ed17df0751ac9242721 )
+)
+
+game (
+	name "Twinkle System"
+	year "1999"
+	developer "Konami"
+	rom ( name gq863.zip size 74484 crc 7e3cd247 md5 d520d30148cba5f329acd81878cbfee7 sha1 f216c17e3191b1c8acb36568b0a2f983b5b7fea1 )
 )
 
 game (
@@ -14528,6 +16438,20 @@ game (
 	year "1998"
 	developer "Konami"
 	rom ( name gradius4.zip size 14137104 crc ba1b413d md5 50fae18877457f5df896cc5e2389fa88 sha1 3a0a876c133d0784ffc0599c4574fe2922027c2e )
+)
+
+game (
+	name "Gratia - Second Earth (92047-01 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratia.zip size 9860174 crc c943d00a md5 e6502a65cfc67d2226f2afd16c8a058e sha1 9b798fb1dd5d7b5c3ef2b23d41d868a39a8c09ab )
+)
+
+game (
+	name "Gratia - Second Earth (91022-10 version)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name gratiaa.zip size 1746388 crc 1d7e06c5 md5 e91546d3c85a7fc512dd74e86b3eb076 sha1 e7a896b18d73c415356390f67935e30e85f167e4 )
 )
 
 game (
@@ -14685,6 +16609,26 @@ game (
 )
 
 game (
+	name "Grudge Match (prototype)"
+	developer "Bally Midway"
+	rom ( name grudge.zip size 55828 crc f434bea0 md5 368c9d50d62fda8c2164d29f023ad4f5 sha1 b16729f20c2e821d37aef06c6fe2d6f7fee559ec )
+)
+
+game (
+	name "Gryzor (Set 1)"
+	year "1987"
+	developer "Konami"
+	rom ( name gryzor.zip size 60209 crc c2c44590 md5 4613133eb5b7b1f5aeed48f74fedd05a sha1 006f19b29597d7eb9a11c0329e4d785138d968fd )
+)
+
+game (
+	name "Gryzor (Set 2)"
+	year "1987"
+	developer "Konami"
+	rom ( name gryzora.zip size 60103 crc a3cc544b md5 a6b39a03cd4fb3e43a2b661d1d87ab42 sha1 a1d24eb9c212d1bec3a624915193c0d8c2dffbfe )
+)
+
+game (
 	name "Selection (Version 40.02TMB, set 1)"
 	year "1982"
 	developer "Greyhound Electronics"
@@ -14773,6 +16717,20 @@ game (
 	year "1993"
 	developer "Human"
 	rom ( name gstrikera.zip size 330936 crc 2ac2b9a4 md5 7078c967cfbc16f3530d895b69ecea6b sha1 dbd9157182d038714de1954176923ca87bec1c2f )
+)
+
+game (
+	name "Great Swordsman (World?)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name gsword.zip size 68856 crc 1aad9299 md5 7f99c589cbb50842257f9611b876203a sha1 e9cd6383ea303ad03308b647350453d4e67aa04a )
+)
+
+game (
+	name "Great Swordsman (Japan?)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name gsword2.zip size 36596 crc 2a7b2600 md5 29eef239319341baa3193d370c24c1ee sha1 2994b6b95463299a48d928ef14a0b14f142d6651 )
 )
 
 game (
@@ -15077,6 +17035,13 @@ game (
 )
 
 game (
+	name "Golden Tee Golf II (Trackball, V2.2)"
+	year "1992"
+	developer "Strata/Incredible Technologies"
+	rom ( name gtg2.zip size 522599 crc efd34213 md5 bdbf392ab3e4e974124333e8224cfbd1 sha1 68393ea856bbb7514fb99ad15c1cfa4f9929c47b )
+)
+
+game (
 	name "Golden Tee Golf II (Joystick, V1.0)"
 	year "1991"
 	developer "Strata/Incredible Technologies"
@@ -15144,6 +17109,41 @@ game (
 	year "1994"
 	developer "Kaneko"
 	rom ( name gtmrusa.zip size 1901378 crc aeabc738 md5 f6e98feb9159bec493887c326639386f sha1 b5ec0c576afdc5d09047461acdc0c597630df234 )
+)
+
+game (
+	name "Guitar Freaks 2nd Mix Ver 1.01 (GQ883 VER. JAD)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrk2m.zip size 285 crc 2382f279 md5 f064c5d8f40fb74fae823217321c2828 sha1 feead139ff366a2eee2161350061435a964f88d2 )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. EAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrks.zip size 173 crc 1b5d831a md5 95ab51c7b4f8334131b9e4355d0e94cb sha1 6fec3d5630d123882d2b0d3f03e3929f00b9218f )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. AAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksa.zip size 173 crc c3dec7de md5 5759fbc8c387d69e81f34080c8e6b893 sha1 ded610f9268e82826aa27fd4a51d13856cb57884 )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. JAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksj.zip size 173 crc 1963f21a md5 ca8ee2971ed51775510131ca59086b76 sha1 6bd51d572e17e21fb0f1ac44371bb6785dd44506 )
+)
+
+game (
+	name "Guitar Freaks (GQ886 VER. UAC)"
+	year "1999"
+	developer "Konami"
+	rom ( name gtrfrksu.zip size 173 crc 1388324e md5 bbc10181f48d999dc5c75c4bc04d1c6a sha1 b11b9abef61705c5634900ac92f6a225104db553 )
 )
 
 game (
@@ -15312,6 +17312,13 @@ game (
 	year "1986"
 	developer "JPM"
 	rom ( name guab7.zip size 278606 crc 6eb15b69 md5 32b2d2eec0e61ac01e78c71d846f7282 sha1 f0cb76d8a0a3fcb59e0fd02755c5095c51d988d9 )
+)
+
+game (
+	name "Guardians of the 'Hood"
+	year "1992"
+	developer "Atari Games"
+	rom ( name guardian.zip size 5584191 crc c9ae8a53 md5 7131f12c328660c2c43bad2d5c9ddf83 sha1 6ade59762108675864fdd632c68c0cdc4a5c32ea )
 )
 
 game (
@@ -15587,6 +17594,13 @@ game (
 )
 
 game (
+	name "Guwange (Japan, Master Ver. 99/06/24)"
+	year "1999"
+	developer "Cave (Atlus license)"
+	rom ( name guwange.zip size 18761704 crc 5386e849 md5 94f828b8096a2c9bda87b316a5b25161 sha1 92c92ca125f36a16a6cf325c7b6002836db81a31 )
+)
+
+game (
 	name "Guzzler"
 	year "1983"
 	developer "Tehkan"
@@ -15636,6 +17650,13 @@ game (
 )
 
 game (
+	name "Gypsy Juggler"
+	year "1978"
+	developer "Meadows"
+	rom ( name gypsyjug.zip size 6384 crc ed9c4676 md5 9ab30dc8fca882b68c58c9c7145e30ad sha1 6add65b1b1881829fc565fbf95cea31a5511c654 )
+)
+
+game (
 	name "Gyrodine"
 	year "1984"
 	developer "Crux"
@@ -15661,6 +17682,13 @@ game (
 	year "1983"
 	developer "Konami (Centuri license)"
 	rom ( name gyrussce.zip size 18476 crc 011c46c6 md5 f2211dd79a29ab0663900e94a3ca00a4 sha1 de1709390663d6a2f5563d029fdb097c35c7ecfb )
+)
+
+game (
+	name "Hachoo!"
+	year "1989"
+	developer "Jaleco"
+	rom ( name hachoo.zip size 1219596 crc bdb0452d md5 f32c8eacfef15fcbe492d71f6e4fcea6 sha1 8a8a52d5948d06550f964666f03ac978a91b156c )
 )
 
 game (
@@ -16007,10 +18035,45 @@ game (
 )
 
 game (
+	name "Hat Trick"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name hattrick.zip size 20957 crc b92050af md5 10e700630a8f6a22206a029f45fbb9a8 sha1 50955d5cbcc66f29e056c0deae185d792144b01d )
+)
+
+game (
+	name "Hayaoshi Quiz Ouza Ketteisen - The King Of Quiz"
+	year "1993"
+	developer "Jaleco"
+	rom ( name hayaosi1.zip size 1243888 crc 230f194d md5 e3a3375678c7d5a21c1bf94efa671e4b sha1 de2b502d2455fa44e7932886e72c126d73ca7cb1 )
+)
+
+game (
+	name "Hayaoshi Quiz Grand Champion Taikai"
+	year "1994"
+	developer "Jaleco"
+	rom ( name hayaosi2.zip size 6534132 crc 0d4d53e2 md5 425d2f1e3ab9d7b1383991b439a6b07a sha1 80ec2a3bd77a2de577eb084b2c7b9d7f78bf2202 )
+)
+
+game (
+	name "Hayaoshi Quiz Nettou Namahousou"
+	year "1994"
+	developer "Jaleco"
+	rom ( name hayaosi3.zip size 8560302 crc 19ad31aa md5 7c76d5a566077e7a850277ddc889da75 sha1 67e82ef2b1ae2017602190abad76278c74c0a742 )
+)
+
+game (
 	name "Heavy Barrel (US)"
 	year "1987"
 	developer "Data East USA"
 	rom ( name hbarrel.zip size 531842 crc 1fcc48e4 md5 7848cbf9edf80c9227fc18f40996fecb sha1 0d1c3ad60099d4b69c84bbce51db62d0afdb0b22 )
+)
+
+game (
+	name "Heavy Barrel (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name hbarrelw.zip size 151856 crc 0009daf5 md5 60965beb0a7280902f35707334534efd sha1 dfe1656f37e4fe2548d8d21e597a57516e483e97 )
 )
 
 game (
@@ -16161,6 +18224,20 @@ game (
 )
 
 game (
+	name "Hero in the Castle of Doom (DK conversion)"
+	year "1984"
+	developer "Seatongrove Ltd (Crown license)"
+	rom ( name herodk.zip size 17614 crc 6e68d207 md5 582c86f07798e749588caaf4dea84893 sha1 fed7672adeadf2f27be9a12f4f10521ca1e0170c )
+)
+
+game (
+	name "Hero in the Castle of Doom (DK conversion not encrypted)"
+	year "1984"
+	developer "Seatongrove Ltd (Crown license)"
+	rom ( name herodku.zip size 17520 crc f3ef3d3f md5 411ccf25ddb5f7ca88950525ac3c2fe1 sha1 39aa20dfa71bc440d3a352a368cdd8c3f826f977 )
+)
+
+game (
 	name "Heuk Sun Baek Sa (Korea)"
 	developer "Oksan / F2 System"
 	rom ( name heuksun.zip size 1344601 crc ce210158 md5 743b6eb3779ef407f9b656dcb44420ea sha1 a8a2f5e0cf7bdd4d906ed5d47ab07b47c082d43c )
@@ -16254,6 +18331,48 @@ game (
 	year "1979"
 	developer "Nintendo"
 	rom ( name highspltb.zip size 2896 crc 00bda584 md5 8e244304c2b2c2b9a2d2734b8c31e09e sha1 9d8033a777aeaea231ea7fea4f6d5cb0927f240b )
+)
+
+game (
+	name "High Impact Football (rev LA5 02/15/91)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact.zip size 1208401 crc a9991165 md5 99f6fa091a27f6e66c7b12c7d9376e32 sha1 51d358d89329cc1b7a92110d89251d2db0c5e995 )
+)
+
+game (
+	name "High Impact Football (rev LA1 12/16/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact1.zip size 114063 crc 89d1f262 md5 9ece7e23c377ea6d607e40f3d49e2b09 sha1 14afc876b92d4e2143bb5ee6e28f273af07f2947 )
+)
+
+game (
+	name "High Impact Football (rev LA2 12/26/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact2.zip size 116301 crc 6e9cd0b6 md5 97ca943a38fc2520eb3fb1b1a9457eca sha1 44739bdc301ae3a09aefb7d7b1d8f54f65335b0b )
+)
+
+game (
+	name "High Impact Football (rev LA3 12/27/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact3.zip size 116285 crc 350f5fa8 md5 4b26169399fa6c6570c0991ce0c104aa sha1 97e57f608e972f881269d0e30c677c73907d69b5 )
+)
+
+game (
+	name "High Impact Football (rev LA4 02/04/91)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpact4.zip size 116944 crc dd23c0e0 md5 a630377915c5e662ef07f5670d126117 sha1 f4777a410a23aa84b3259716d9f230efff34002c )
+)
+
+game (
+	name "High Impact Football (prototype, rev 8.6 12/09/90)"
+	year "1990"
+	developer "Williams"
+	rom ( name hiimpactp.zip size 111077 crc 6bb8ae38 md5 edb257a262760e32e30ca808d0473448 sha1 73d8e05716fbc60025bf90dd737651c4835e067a )
 )
 
 game (
@@ -16481,6 +18600,13 @@ game (
 )
 
 game (
+	name "Moero Pro Yakyuu Homerun"
+	year "1988"
+	developer "Jaleco"
+	rom ( name homerun.zip size 105642 crc 0ddf7ef0 md5 c0a9aba42da0b1bd4cda146c5f23c6ba sha1 deba6cfd47ea6bf09f42d3467a5b7fe42a675726 )
+)
+
+game (
 	name "Homo"
 	year "1987"
 	developer "bootleg"
@@ -16642,6 +18768,13 @@ game (
 )
 
 game (
+	name "Hot Mind"
+	year "1995"
+	developer "Playmark"
+	rom ( name hotmind.zip size 314659 crc 60b80717 md5 3000ad3a8e0ff882d0c8b44c79b419e0 sha1 9cd57503d2becf384395106a50408d937178cebb )
+)
+
+game (
 	name "Hot Mind (adjustable prize)"
 	year "1995"
 	developer "Playmark"
@@ -16782,6 +18915,13 @@ game (
 )
 
 game (
+	name "Hatch Catch"
+	year "1995"
+	developer "SemiCom"
+	rom ( name htchctch.zip size 200769 crc 3e7e2485 md5 e3d8fd4168254a6aab4806ac7b4575aa sha1 1bd6bb6935556c54860236eda77eda15f0a7a40e )
+)
+
+game (
 	name "Hanafuda Hana Tengoku (Japan)"
 	year "1992"
 	developer "Dynax"
@@ -16835,6 +18975,13 @@ game (
 	year "1983"
 	developer "Century Electronics"
 	rom ( name hunchbaka.zip size 14164 crc 9d12d26b md5 c1763753618f4457a72e0e27841da152 sha1 f1646a72e966934036169cb0642a812f36cb1541 )
+)
+
+game (
+	name "Hunchback (DK conversion)"
+	year "1983"
+	developer "Century Electronics"
+	rom ( name hunchbkd.zip size 16765 crc 162ce01c md5 5e42739d04f9505930c05d66e6b285db sha1 fa030754526a8240f0319fcf3c7a245aa3026d7e )
 )
 
 game (
@@ -16943,6 +19090,20 @@ game (
 )
 
 game (
+	name "Hydra (prototype 5/14/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap.zip size 912537 crc 1c74da4f md5 c36b8440732b9a4f6203e411763925b4 sha1 e3b17199ef877747c697bf7f397c2f8a94e7ea07 )
+)
+
+game (
+	name "Hydra (prototype 5/25/90)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name hydrap2.zip size 185358 crc ab6e42a3 md5 a6a9316bf18146b4408cb6713b717e77 sha1 5135408eb82a65412f7b144b6eb2d9b2615605b7 )
+)
+
+game (
 	name "Taisen Quiz HYHOO (Japan)"
 	year "1987"
 	developer "Nichibutsu"
@@ -16971,6 +19132,20 @@ game (
 )
 
 game (
+	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. JAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name hyperbbc.zip size 168 crc 9af2c9a4 md5 7c2030be99b2a53d0e4334d320b19926 sha1 4e941cbfcb3fad16d9a006cbb4fbce7133b832f7 )
+)
+
+game (
+	name "Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. KAA)"
+	year "1999"
+	developer "Konami"
+	rom ( name hyperbbck.zip size 168 crc 44ab53e6 md5 7ca726391d1242be190c4ac784422806 sha1 b3537626db78c0dbd4f15a44635f4489685bff8b )
+)
+
+game (
 	name "Hyper Pacman"
 	year "1995"
 	developer "SemiCom"
@@ -16996,6 +19171,13 @@ game (
 	year "1984"
 	developer "bootleg"
 	rom ( name hypersptb.zip size 52561 crc de70b785 md5 39dc5e6656a13588fad1313d031074c2 sha1 f3ded3860ce1176c6c0444caf5a3f4d729c2b4c3 )
+)
+
+game (
+	name "Hyperdrive"
+	year "1998"
+	developer "Midway Games"
+	rom ( name hyprdriv.zip size 127652 crc e32be5da md5 900a5ff2033de5812b55b1d88beb1e43 sha1 00211969d1c32f804087fee2c73505a79bdd347d )
 )
 
 game (
@@ -17031,6 +19213,13 @@ game (
 	year "1983"
 	developer "Konami"
 	rom ( name hyprolym.zip size 35758 crc 7d0784a8 md5 4c91288783f3e9b42902f781661b0152 sha1 28124353bac4d25b1fe393f463eb9dbd9197462c )
+)
+
+game (
+	name "Hyper Olympic (bootleg)"
+	year "1983"
+	developer "bootleg"
+	rom ( name hyprolymb.zip size 60733 crc 96b59795 md5 a1a566a2e6bef0559ae9f23241ac0ef1 sha1 fb557af26e91a1fd8f1dce2947e4eec4f468dcfc )
 )
 
 game (
@@ -17132,9 +19321,23 @@ game (
 )
 
 game (
+	name "Iga Ninjyutsuden (Japan)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name iganinju.zip size 863977 crc 5e327254 md5 a5f363348d5af77637f9d9f82324a467 sha1 715a69e9f92d7766bd3361e70b66b44435f0e9b6 )
+)
+
+game (
 	name "New Champion Skill (v100n)"
 	developer "IGS"
 	rom ( name igs_ncs.zip size 141502 crc 0bf9f74a md5 5254868750ec1ce2d4c2a810980f2119 sha1 b38d03a29dacbe1651d5dfbca3361cfc2c40577f )
+)
+
+game (
+	name "New Champion Skill (v100n 2000)"
+	year "2000"
+	developer "IGS"
+	rom ( name igs_ncs2.zip size 179683 crc c2686e23 md5 ce1b79789a8b6f9b2159d09123692cf6 sha1 48599236076927d5e195a6b8b21cf665b8cee436 )
 )
 
 game (
@@ -17215,6 +19418,20 @@ game (
 )
 
 game (
+	name "Image Fight (Japan, revision A)"
+	year "1988"
+	developer "Irem"
+	rom ( name imgfight.zip size 634384 crc 5221a34e md5 0ea61f9af90a04b7e514a638e6aa884f sha1 8c5638687464af92d65ac1e35b8ddcea8a04cda0 )
+)
+
+game (
+	name "Image Fight (Japan)"
+	year "1988"
+	developer "Irem"
+	rom ( name imgfighto.zip size 66939 crc f195377a md5 c337c9a907caef94577df67c5b6be0c2 sha1 991e6f0bb3ab375f0a0682dca9e4a528fd9b6fdb )
+)
+
+game (
 	name "I'm Sorry (315-5110, US)"
 	year "1985"
 	developer "Coreland / Sega"
@@ -17249,10 +19466,45 @@ game (
 )
 
 game (
+	name "Indiana Jones and the Temple of Doom (set 1)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp.zip size 340077 crc 4773adb4 md5 60d666ebd8611b56f7c66cfb64997dee sha1 51b823872cd04947ec40ff3288d2caba73c3847c )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 2)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp2.zip size 37735 crc c66e291d md5 07df56c5a17769129097b06f5eea44b9 sha1 cb6b3a737bd2c9be25be8f02fe1cdd579e6270fb )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 3)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp3.zip size 93260 crc 1665027b md5 3433ec07b4195ea399c554b321b4911a sha1 a3d239dcadd1b4a073859f63be3ca41c43e299b6 )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (set 4)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytemp4.zip size 84847 crc c6465b1b md5 80f7d25214d39cefa47ba738e66fc62c sha1 64dc8003adf1b5196b774336abb446d16e581fe6 )
+)
+
+game (
 	name "Indiana Jones and the Temple of Doom (Cocktail)"
 	year "1985"
 	developer "Atari Games"
 	rom ( name indytempc.zip size 126323 crc be3fa3f4 md5 b2521a4c20c8ef156b139228aebc22b7 sha1 7b65cf30cd4228da22dc44de4009c315be6dbfc1 )
+)
+
+game (
+	name "Indiana Jones and the Temple of Doom (German)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name indytempd.zip size 84534 crc ba94d8cb md5 00910797f05e5437f8adc0d2391bae36 sha1 e9b6de75007e3e141e8e57daf519cbb8e8430487 )
 )
 
 game (
@@ -17302,6 +19554,13 @@ game (
 	year "1993"
 	developer "Irem America"
 	rom ( name inthuntu.zip size 294849 crc e35ca2b1 md5 ef4c6be0c945502fbf1882f2f39ee774 sha1 f40d9fce6ba358550f6debb1faa6955aafe36d4f )
+)
+
+game (
+	name "International Team Laser (prototype)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name intlaser.zip size 396644 crc c1b96ff3 md5 73a68870efe55f5cfbf769ec1c06b092 sha1 c385f6e5bc32b3e6c02195b024a537a292a2670e )
 )
 
 game (
@@ -17573,6 +19832,20 @@ game (
 )
 
 game (
+	name "Happy Jackie (v110U)"
+	year "1993"
+	developer "IGS"
+	rom ( name jackie.zip size 191320 crc 97aebc98 md5 508af67ba9db4c01d5a01962a2b840e4 sha1 8d9c6e18bb2f9e874bf6bbe34653f93e10936e7f )
+)
+
+game (
+	name "Jack Rabbit (set 1)"
+	year "1984"
+	developer "Zaccaria"
+	rom ( name jackrabt.zip size 55883 crc a7722c9d md5 3d93af2407203345dc5b47729d5c584f sha1 7b9015e1e6dea4278515d99db4a356fb95e445af )
+)
+
+game (
 	name "Jack Rabbit (set 2)"
 	year "1984"
 	developer "Zaccaria"
@@ -17591,6 +19864,13 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name jailbrek.zip size 69169 crc 5ccb9ec7 md5 bfa606dbc35d8d50c340c4a142ae4242 sha1 b88510bdde8b2a194f96b224fdba591a5e30276a )
+)
+
+game (
+	name "Jail Break (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name jailbrekb.zip size 67788 crc 672cdd18 md5 630a3b3a69a888ce0edd7d8b80ea527a sha1 57945b14e59eeef2d6fd29ec894919e881336048 )
 )
 
 game (
@@ -17633,6 +19913,13 @@ game (
 	year "1996"
 	developer "Dynax"
 	rom ( name janptr96.zip size 627648 crc f68cea3a md5 6ac5319848107121e9cf9e268c4f0e9b sha1 fccfbb51a73744075ae062a9e7ee57356a40e42b )
+)
+
+game (
+	name "New Double Bet Mahjong (Japan)"
+	year "1981"
+	developer "Public Software Ltd. / Mes"
+	rom ( name janputer.zip size 20202 crc 6184f21e md5 f0500e278b58ab376300a04ca921558f sha1 eec4d7369d76446be5b1a992e02a684806e5dad8 )
 )
 
 game (
@@ -17731,6 +20018,13 @@ game (
 	year "1982"
 	developer "Falcon"
 	rom ( name jin.zip size 14013 crc d07fef6c md5 07eafbf03f9c38e60915170b784c8330 sha1 a7c846b4cfb2671be83b7f9a77fd0f6cc1b7fc3e )
+)
+
+game (
+	name "Jitsuryoku!! Pro Yakyuu (Japan)"
+	year "1989"
+	developer "Jaleco"
+	rom ( name jitsupro.zip size 1504321 crc e47b1e79 md5 1967b9acd0916487e4f7219cca8ebbf9 sha1 bccb1946075f09334565c5724efcb5129e875a53 )
 )
 
 game (
@@ -17968,6 +20262,13 @@ game (
 	year "1993"
 	developer "Soft Design"
 	rom ( name jolyccrb.zip size 11427 crc ff25b2c9 md5 9d7005f857520d0aa41570fe4d4821df sha1 53a775446e8baf079aa8b00338b7369ef56f17a7 )
+)
+
+game (
+	name "Jolly Card (Austrian, Funworld)"
+	year "1986"
+	developer "Funworld"
+	rom ( name jolycdat.zip size 31923 crc a683ca4a md5 8af1aa9b1b2764e3a4b79ffc2ab53e76 sha1 12ca56abeccffa05ae218479e482a53483978a06 )
 )
 
 game (
@@ -18380,6 +20681,20 @@ game (
 )
 
 game (
+	name "Mahjong Kakumei (Japan)"
+	year "1990"
+	developer "Jaleco"
+	rom ( name kakumei.zip size 546133 crc 28f8fdc5 md5 1f9191815d9a1c4a2a65769d6e0abdcc sha1 693688e8f6bd2b039285d090a8e827ca1e8ec5d1 )
+)
+
+game (
+	name "Mahjong Kakumei 2 - Princess League (Japan)"
+	year "1992"
+	developer "Jaleco"
+	rom ( name kakumei2.zip size 1037704 crc 2eb34b77 md5 1f1dafdc947110082ea3095422e74996 sha1 104f70a4f2d8e6b44a1c54a4aabf015ea2636279 )
+)
+
+game (
 	name "Kamakazi III (superg hack)"
 	year "1979"
 	developer "hack"
@@ -18394,6 +20709,13 @@ game (
 )
 
 game (
+	name "Kamikaze"
+	year "1979"
+	developer "Leijac Corporation"
+	rom ( name kamikaze.zip size 5928 crc 5a4fefc8 md5 7bdacec83ded3f14a622750d540b0c46 sha1 b8cbbb27d5446fb696b6e963f6f41e3cb79a285a )
+)
+
+game (
 	name "Kamikaze Cabbie"
 	year "1984"
 	developer "Data East Corporation"
@@ -18405,6 +20727,20 @@ game (
 	year "1988"
 	developer "Panac"
 	rom ( name kanatuen.zip size 326075 crc 7958cbdb md5 2d299909a88ec8b88ea21c133631ec85 sha1 e78470dd8c6a999a72ce05bcc7cd9ddf755d8072 )
+)
+
+game (
+	name "Kangaroo"
+	year "1982"
+	developer "Sun Electronics"
+	rom ( name kangaroo.zip size 29696 crc 34252b40 md5 66fa791b13fe3cf44d6990709678d4aa sha1 0b1dc7390f485a98d4e15aaf586786889b49789d )
+)
+
+game (
+	name "Kangaroo (Atari)"
+	year "1982"
+	developer "Sun Electronics (Atari license)"
+	rom ( name kangarooa.zip size 6370 crc 8c259a8a md5 8b9baef91dc865d39a4423ac93f79737 sha1 db64f8742c65e90659634a93a7ad44ae137cc390 )
 )
 
 game (
@@ -18489,6 +20825,13 @@ game (
 	year "1994"
 	developer "Data East Corporation"
 	rom ( name karnovr.zip size 7080625 crc 68f0d0b5 md5 5f92883dac591379132d39282829fca6 sha1 714c129c491e02a0312ec868b79dc862f59a623a )
+)
+
+game (
+	name "Ninja Kazan (World)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name kazan.zip size 874065 crc 539fb40f md5 152de260bc5e42de32fc9c3723f465cd sha1 40e09a127f9ccb344d4071308d206dbc9c28b07b )
 )
 
 game (
@@ -18723,6 +21066,20 @@ game (
 )
 
 game (
+	name "Kick and Run (World)"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kicknrun.zip size 153123 crc 0da177d8 md5 3ceb63eb806fa6254d90d92fd075c3de sha1 ea2e2873f59a90e83c255ba2eff8c5bc86124e35 )
+)
+
+game (
+	name "Kick and Run (US)"
+	year "1986"
+	developer "Taito America Corp"
+	rom ( name kicknrunu.zip size 61720 crc b8990c7d md5 60ea6bd45a35688e9b4a76e79c8b58ee sha1 e02bf2dcb10f70aebd6a741b18c1e453a0a572a3 )
+)
+
+game (
 	name "Kick Off (Japan)"
 	year "1988"
 	developer "Jaleco"
@@ -18769,6 +21126,20 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name kikcubicb.zip size 207945 crc 15e7417b md5 ecf85d2dde7f8c492989a74cafab04d1 sha1 38cd4636232f14077020a3f70359abfab17d7ee8 )
+)
+
+game (
+	name "KiKi KaiKai"
+	year "1986"
+	developer "Taito Corporation"
+	rom ( name kikikai.zip size 228593 crc 8a765bc0 md5 50ad6b55ec94d80d6d534fea3b553edf sha1 45b60dce7f549edcd7a387eccb23418ca369beb1 )
+)
+
+game (
+	name "Kick Start Wheelie King"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name kikstart.zip size 33608 crc 11f18636 md5 069d26bca2ac1ddc4641a13c3cb35302 sha1 f46efa023dfa729f58dd7a72ee3ca6302ec8354c )
 )
 
 game (
@@ -18894,6 +21265,13 @@ game (
 	year "1997"
 	developer "Taito Corporation"
 	rom ( name kirameki.zip size 13454543 crc 9239064b md5 56241853e77b49176d50b00012dedd0f sha1 1cf32a578d05a7bcab539c12d1442061fdce9b03 )
+)
+
+game (
+	name "Ryuusei Janshi Kirara Star"
+	year "1996"
+	developer "Jaleco"
+	rom ( name kirarast.zip size 13551531 crc b28fb495 md5 390ff256e11415db1477ffcc03f3b809 sha1 1765d3b4a15cf5d55252f0246a319cc8029ebc51 )
 )
 
 game (
@@ -19047,6 +21425,27 @@ game (
 	year "1982"
 	developer "KKK"
 	rom ( name knockout.zip size 10668 crc f12f03ba md5 b25bdfd3bd583dfde3522af1b6336bda sha1 e5dcf993d58fea93f6f8580faa53516f62dce6da )
+)
+
+game (
+	name "The King of Dragons (World 910711)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kod.zip size 2365648 crc ad34a945 md5 06488f9f8375a3450e64a2d688f92694 sha1 c8d062de4c56e4de3222977813ea02991d7fe352 )
+)
+
+game (
+	name "The King of Dragons (Japan 910805)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kodj.zip size 522022 crc e45fd2b3 md5 f806cb5670739b088ff4cffefb228f7e sha1 8c016613df924a4dc1dc10689c354fdac598b197 )
+)
+
+game (
+	name "The King of Dragons (USA 910910)"
+	year "1991"
+	developer "Capcom"
+	rom ( name kodu.zip size 494233 crc 8e50dd82 md5 d1d7b9d89468a5481041a023c0c9d5a0 sha1 7c44cf73a90bc753a1cc63f1ad08b8441fcdf98c )
 )
 
 game (
@@ -19266,6 +21665,41 @@ game (
 )
 
 game (
+	name "Konami 80's AC Special (GC826 VER. AAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80a.zip size 179 crc 93381d66 md5 959cb31b7265db1fcc54587c393694ed sha1 6767a30dd31c2ded31c92acfbd7194804bbd9773 )
+)
+
+game (
+	name "Konami 80's Gallery (GC826 VER. JAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80j.zip size 179 crc d1cb7968 md5 895135fc0ef41ebb93c008aca75119fa sha1 f3ced37f8dfe88abe4c121a1de20782d6e81f59f )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. KAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80k.zip size 179 crc 2c2480d5 md5 8e66b5c43f8e0de54ccf85cbb6746cb3 sha1 fc6301236e09fb719977e9ddb16f8c3abf470488 )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. EAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80s.zip size 179 crc a059f691 md5 9490d46b275a48d9968c4825b51f7958 sha1 e24d5e92a45825e8bddcb8639e547ec8a2323a5b )
+)
+
+game (
+	name "Konami 80's AC Special (GC826 VER. UAA)"
+	year "1998"
+	developer "Konami"
+	rom ( name konam80u.zip size 179 crc 006b1b56 md5 bc2f76e67e39b06216540db516bf77af sha1 7dc1caabe197e37a3e01a90cd8fe4c5bf103dbea )
+)
+
+game (
 	name "Konami '88"
 	year "1988"
 	developer "Konami"
@@ -19277,6 +21711,27 @@ game (
 	year "1985"
 	developer "Konami"
 	rom ( name konamigt.zip size 83414 crc b1f1ad5f md5 c0753015de75b4376483dc1d37e6cc4f sha1 8d8369aa1c761aa2e07c3edf05c07f282ef5bed0 )
+)
+
+game (
+	name "Baby Phoenix/GV System"
+	year "1995"
+	developer "Konami"
+	rom ( name konamigv.zip size 81413 crc 165453e7 md5 0ae0cea76cee8287e5a0b6d97a883793 sha1 02dcad570077ee8e7aefec944e91650b99205bae )
+)
+
+game (
+	name "System GX"
+	year "1994"
+	developer "Konami"
+	rom ( name konamigx.zip size 8734 crc 08ba2527 md5 981fa4057f4bd5c064ce446963d8ac33 sha1 dc5c6cc5c294accff4ebce2ac33355063cff8a9d )
+)
+
+game (
+	name "Konek-Gorbunok"
+	year "1988"
+	developer "Terminal"
+	rom ( name konek.zip size 30665 crc 289c4ec5 md5 c7fb11bfc778aa674eec8ab3fd729f0f sha1 bfde1c9ec89338dd407b4527df76d57d269d2b3f )
 )
 
 game (
@@ -19356,6 +21811,13 @@ game (
 )
 
 game (
+	name "The Koukouyakyuh"
+	year "1985"
+	developer "Alpha Denshi Co."
+	rom ( name kouyakyu.zip size 93857 crc 602e3d4e md5 d775a54e67fdfffabb02aefa3399091e sha1 813df9abb9d3c74fb9687617ebcd10b0b3f8d41d )
+)
+
+game (
 	name "Knights of Valour 2 / Sangoku Senki 2 (ver. 107, 102, 100HK)"
 	year "2000"
 	developer "IGS"
@@ -19388,6 +21850,13 @@ game (
 	year "2000"
 	developer "IGS"
 	rom ( name kov2106.zip size 818592 crc 54eed352 md5 770b384e2f4845e0b50bdeffd594fc1b sha1 2bd4aee9efa11df6bf366bc3b2cfc3306ac8f6d8 )
+)
+
+game (
+	name "Knights of Valour - The Seven Spirits"
+	year "2004"
+	developer "Sammy / IGS"
+	rom ( name kov7sprt.zip size 109190277 crc 237152cc md5 a0cf419fab8199b0a1b3f65a4bc5cec4 sha1 638fa7fc572f82e48aaf854eee5951c56a15d88b )
 )
 
 game (
@@ -19454,6 +21923,13 @@ game (
 )
 
 game (
+	name "Kyukyoku Tiger (Japan)"
+	year "1987"
+	developer "Toaplan / Taito Corporation"
+	rom ( name ktiger.zip size 43409 crc 184d5f36 md5 fa3ec97b2e809be0124debfd935ff4f3 sha1 fc6cf4d696448944a3552a4488c3ad60f9118b18 )
+)
+
+game (
 	name "Kyukyoku Tiger II (Ver 2.1J 1995/11/30)"
 	year "1995"
 	developer "Taito Corporation"
@@ -19510,6 +21986,13 @@ game (
 )
 
 game (
+	name "Nekketsu Kouha Kunio-kun (Japan)"
+	year "1986"
+	developer "Technos Japan"
+	rom ( name kuniokun.zip size 336294 crc d64973ea md5 d8abbcb52095b328f3390aa4aac94626 sha1 ce9abdb28a5fb1df04d555eab433bdd1c4f208ad )
+)
+
+game (
 	name "Nekketsu Kouha Kunio-kun (Japan bootleg)"
 	year "1986"
 	developer "bootleg"
@@ -19542,6 +22025,13 @@ game (
 	year "1988"
 	developer "Taito America Corporation"
 	rom ( name kurikintu.zip size 71230 crc af130518 md5 18cf41dda6e3bb80f9374362595e1f2b sha1 5a064ee6d85d3e4bfe099321bc168cdce01a87e1 )
+)
+
+game (
+	name "Konami Viper BIOS"
+	year "1999"
+	developer "Konami"
+	rom ( name kviper.zip size 16899 crc 2f2fb3e8 md5 7b2a3d76acd9ff7de00cb724ec380995 sha1 0a3536b938ef75eca289d2d0cce51864b9cdc95f )
 )
 
 game (
@@ -19796,6 +22286,27 @@ game (
 )
 
 game (
+	name "Last Mission (US revision 6)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name lastmisn.zip size 208085 crc 0b434f4e md5 0dfaa0a8d4cbc6c20b0881d4bdc42ac7 sha1 6e0fdcf44eb80a01e9be1c1738bb6940bbdda820 )
+)
+
+game (
+	name "Last Mission (Japan)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name lastmisnj.zip size 54294 crc 68c1500c md5 089309874b171c934b2cef2c0cedb240 sha1 e57ce2f277e30addcd01845d3a22f7ea00f2dac5 )
+)
+
+game (
+	name "Last Mission (US revision 5)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name lastmisno.zip size 16157 crc dfc3cc66 md5 1dd1691571feb75710299079246817d0 sha1 282f7a1aa5345e41eb51277129c2860cd3fadb4e )
+)
+
+game (
 	name "The Last Soldier (Korean release of The Last Blade)"
 	year "1997"
 	developer "SNK"
@@ -19905,6 +22416,13 @@ game (
 	year "1988"
 	developer "Capcom"
 	rom ( name ledstorm.zip size 194357 crc 920993cb md5 4ec69da441eee8d531348edf6f90f0e4 sha1 6a945a64c81f28a325d1f72a37889b825368bcfa )
+)
+
+game (
+	name "Led Storm Rally 2011 (US)"
+	year "1988"
+	developer "Capcom"
+	rom ( name ledstorm2.zip size 320086 crc b8c6d1b2 md5 4659ee1528557154d3eb27d80bc650b0 sha1 b13d60769580b3af94da202a5e620eed3142d4a3 )
 )
 
 game (
@@ -20265,6 +22783,20 @@ game (
 )
 
 game (
+	name "Lunar Lander (rev 2)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander.zip size 10198 crc dac7d478 md5 9814166b25c9dcbc68ad1de183a069d7 sha1 dc7aff9095bbabef7e1069eff934c82c8c45224a )
+)
+
+game (
+	name "Lunar Lander (rev 1)"
+	year "1979"
+	developer "Atari"
+	rom ( name llander1.zip size 5529 crc 8d3d776e md5 bc50273b22780415fe4a0ea58e15c332 sha1 7247648460d981dad9cf3fa774b1030c7131b50b )
+)
+
+game (
 	name "Lucky Lady (3x3 deal)"
 	year "1991"
 	developer "TAB Austria"
@@ -20328,6 +22860,13 @@ game (
 )
 
 game (
+	name "Line of Fire / Bakudan Yarou (World, FD1094 317-0136)"
+	year "1989"
+	developer "Sega"
+	rom ( name loffire.zip size 1541052 crc daac76b9 md5 ad9694e50968fd9f161322ee6695ff8a sha1 7a2650b1a6c6fa07abce6a61ae6b9e18d612c732 )
+)
+
+game (
 	name "Line of Fire / Bakudan Yarou (Japan, FD1094 317-0134)"
 	year "1989"
 	developer "Sega"
@@ -20360,6 +22899,13 @@ game (
 	year "1996"
 	developer "Deniam"
 	rom ( name logicpro.zip size 1666285 crc 909c6c69 md5 74279f969394acd41840bbb93bdb9594 sha1 112ea8400bccc9ed023b2a3b357b6150aaa9b49c )
+)
+
+game (
+	name "Legend of Hero Tonma"
+	year "1989"
+	developer "Irem"
+	rom ( name loht.zip size 672682 crc c692fa5b md5 48cf056a36d4eeb771830d9fa1ef0b97 sha1 07d598fa255fbcdde2fd83a97ef5029de95d04cd )
 )
 
 game (
@@ -20412,6 +22958,13 @@ game (
 )
 
 game (
+	name "The Lord of King (Japan)"
+	year "1989"
+	developer "Jaleco"
+	rom ( name lordofk.zip size 111147 crc f706641d md5 5c95f34a6dd71c3a927d33f301bb6b3e sha1 e5e1af580ba2bbbfbd355107376779c2fc9bfc3c )
+)
+
+game (
 	name "Lost Tomb (easy)"
 	year "1982"
 	developer "Stern Electronics"
@@ -20423,6 +22976,20 @@ game (
 	year "1982"
 	developer "Stern Electronics"
 	rom ( name losttombh.zip size 2561 crc 012a8e27 md5 9034fd65d8324e768af1bb057192abdc sha1 f4b38342cf16e23ff4385d1e86ffc97fd534d121 )
+)
+
+game (
+	name "Lost Worlds (Japan)"
+	year "1988"
+	developer "Capcom"
+	rom ( name lostwrld.zip size 930597 crc ad301b96 md5 a7e228a5b60e8e3300da3eb5caa2c44c sha1 9997bc68818e333847c064d944e73e84e73dec0a )
+)
+
+game (
+	name "Lost Worlds (Japan Old Ver.)"
+	year "1988"
+	developer "Capcom"
+	rom ( name lostwrldo.zip size 928871 crc aaa73533 md5 9831a2d05a8afd69708b3cbb53cd6c6b sha1 a2c5b622f87ecae0b9ebe612887198a53f288ae5 )
 )
 
 game (
@@ -20510,6 +23077,13 @@ game (
 )
 
 game (
+	name "New Lucky 8 Lines (set 2, W-4)"
+	year "1989"
+	developer "Wing Co., Ltd. / GEI"
+	rom ( name lucky8a.zip size 23328 crc 92f5ee14 md5 f7d2a1b4e487506b95b0439b11625c94 sha1 5826b67a96b30c2be7175433423a0c1e300d4ad3 )
+)
+
+game (
 	name "New Lucky 8 Lines (set 3, W-4, extended gfx)"
 	year "1989"
 	developer "Wing Co., Ltd. / GEI"
@@ -20556,6 +23130,13 @@ game (
 	year "1980"
 	developer "Taito"
 	rom ( name lupin3a.zip size 9669 crc 45050a84 md5 4034cf7add2708d9fc8ae9fc5c6c9952 sha1 d234f05bf8821b285cb6b2b0fd611fad252fe328 )
+)
+
+game (
+	name "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128)"
+	year "1999"
+	developer "Omega System"
+	rom ( name luplup.zip size 4717969 crc 452fa4ef md5 7b7f42508210657c0c2cc5baf93dc75c sha1 1a648888ef5587a470f20889d10df0aa74cc7d44 )
 )
 
 game (
@@ -20790,6 +23371,13 @@ game (
 )
 
 game (
+	name "Mace: The Dark Age (HDD 1.0a)"
+	year "1997"
+	developer "Atari Games"
+	rom ( name macea.zip size 221787 crc d603c957 md5 57253c01e967658be893780d6433eb02 sha1 158f1bf4b8685fafc985b4fa51508d2ebb862b5f )
+)
+
+game (
 	name "M.A.C.H. 3"
 	year "1983"
 	developer "Mylstar"
@@ -20857,6 +23445,13 @@ game (
 	year "1980"
 	developer "Data East Corporation"
 	rom ( name madalien.zip size 15460 crc b9575c95 md5 4206a4f48b9db00ae265f7098b45b3c2 sha1 a199f7817d24d0b127116f370f5ac02c94afbb42 )
+)
+
+game (
+	name "Mad Alien (Highway Chase)"
+	year "1980"
+	developer "Data East Corporation"
+	rom ( name madaliena.zip size 15020 crc d3873a30 md5 c4fc94830a8ebc86479f132d221820d7 sha1 ea3ca9f72cbd3e0c492676792464fa66354e071e )
 )
 
 game (
@@ -20998,10 +23593,23 @@ game (
 )
 
 game (
+	name "Magic Fly"
+	developer "P&amp;A Games"
+	rom ( name magicfly.zip size 6703 crc 74809206 md5 1ddd4eebf74a98850548f5de380a658e sha1 e3041ffbc32cef289cd04d208827738bd40a371f )
+)
+
+game (
 	name "Magic Card II (Bulgarian)"
 	year "1996"
 	developer "Impera"
 	rom ( name magicrd2.zip size 62909 crc 4d8c8e63 md5 eea78fb28d61fccb221bbfe3ccaab9ae sha1 62da839958ebc377c23f4ba0e1e28c23897e857e )
+)
+
+game (
+	name "Magic Sticks"
+	year "1995"
+	developer "Playmark"
+	rom ( name magicstk.zip size 260245 crc 4756edde md5 8441263145338f3e9c203bcd034b1231 sha1 9db1c94ab1b0f9947b2914d9f2ee4861219bfa23 )
 )
 
 game (
@@ -21144,6 +23752,20 @@ game (
 )
 
 game (
+	name "Major Title 2 (World)"
+	year "1992"
+	developer "Irem"
+	rom ( name majtitl2.zip size 1811439 crc fb101978 md5 3cb1a085e1939c4ff87423ff232a0a64 sha1 29cc73e3b143d82f820fee893866e99939628556 )
+)
+
+game (
+	name "Major Title 2 (Japan)"
+	year "1992"
+	developer "Irem"
+	rom ( name majtitl2j.zip size 196175 crc 491e43af md5 248b7deaabe91b7833ba7962683f5448 sha1 770b707935ce923711871a2d5ecc920acb2b408b )
+)
+
+game (
 	name "Major Title (World)"
 	year "1990"
 	developer "Irem"
@@ -21221,6 +23843,13 @@ game (
 )
 
 game (
+	name "Makyou Senshi (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name makyosen.zip size 110807 crc 21fa0916 md5 86c44a5b24c9a09fc181521caf4600c8 sha1 880bfed9fe5bb3f3356f377bd9af180da18743d1 )
+)
+
+game (
 	name "Mang-Chi"
 	year "2000"
 	developer "Afega"
@@ -21281,6 +23910,41 @@ game (
 	year "1983"
 	developer "Namco"
 	rom ( name mappyj.zip size 11060 crc 13b0aa8c md5 fe431eea36478860a064de3cf69ba80a sha1 951f8c7488694fe43fb36e3607df9435037b8e67 )
+)
+
+game (
+	name "Marble Madness (set 1)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble.zip size 193238 crc c6135729 md5 3512ef1cc6d981a97ff0422b6e29c037 sha1 603cb95ee7269f849a2b3ef8afd7cadfd5f3799b )
+)
+
+game (
+	name "Marble Madness (set 2)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble2.zip size 66463 crc 6610b051 md5 fe0e146746deae65e8287312eefceb76 sha1 a19a38d9f57912955907c7a382c500ca721a4b04 )
+)
+
+game (
+	name "Marble Madness (set 3)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble3.zip size 80187 crc 8d1262a8 md5 213db41dc41f27ce5ac5cba8fa0e8f4e sha1 6ad5148d2bc435f65a051448c0d0a329cda24b83 )
+)
+
+game (
+	name "Marble Madness (set 4)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble4.zip size 75274 crc 2df0dedb md5 5ec2c81ad77e0d1c66bc38af78bba106 sha1 e1b380a2250c97b499e31dde6cab4a41d0b05fb9 )
+)
+
+game (
+	name "Marble Madness (set 5 - LSI Cartridge)"
+	year "1984"
+	developer "Atari Games"
+	rom ( name marble5.zip size 149265 crc 321eb37e md5 167ebe1354e9716b2bbfd2b4ad2b57d2 sha1 5b2f5779da65159d9fd38f4b47626719282c83c8 )
 )
 
 game (
@@ -21500,6 +24164,13 @@ game (
 )
 
 game (
+	name "Max-A-Flex"
+	year "1984"
+	developer "Exidy"
+	rom ( name maxaflex.zip size 13695 crc 171fcf96 md5 130bc449ec6becd0f9efc9eccc005714 sha1 8542b67124c552629ec3b4ebca5035d8db64b799 )
+)
+
+game (
 	name "Maximum Force v1.02"
 	year "1996"
 	developer "Atari Games"
@@ -21609,6 +24280,27 @@ game (
 	year "1994"
 	developer "Banpresto / Dynamic Pl. Toei Animation"
 	rom ( name mazingerj.zip size 168 crc 135d61b7 md5 19df5299be634bf4774b22e17330dc86 sha1 d20e66faea6c8d9af43ec4c350f114eaa1e94ee3 )
+)
+
+game (
+	name "Muscle Bomber: The Body Explosion (Japan 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbomberj.zip size 1179311 crc 8d26c425 md5 0e2585515c14b9e37c1e2ecc83cc5046 sha1 1463f6eb9283955feb7cfb2e09e5e4de1b7214d8 )
+)
+
+game (
+	name "Muscle Bomber Duo: Ultimate Team Battle (World 931206)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbombrd.zip size 6509365 crc 865500aa md5 dc624c8188d3d3e81293b12a11e8130e sha1 8e8dc17fd84f10ee679a7145f0524883e35aa2b8 )
+)
+
+game (
+	name "Muscle Bomber Duo: Heat Up Warriors (Japan 931206)"
+	year "1993"
+	developer "Capcom"
+	rom ( name mbombrdj.zip size 1004351 crc 4fb92510 md5 39f38fd890954593b41880c6f33c45d5 sha1 58dbfe27c06975a67cbcef9d478a50de7c0bd31a )
 )
 
 game (
@@ -21759,6 +24451,13 @@ game (
 )
 
 game (
+	name "Mega Play BIOS"
+	year "1993"
+	developer "Sega"
+	rom ( name megaplay.zip size 50000 crc 85e87484 md5 0375720cc0a3e098b4f8593087818676 sha1 b1b52970683cc07baeea575b0d52a04f0e437d26 )
+)
+
+game (
 	name "Megatouch III (9255-20-01 RON, Standard version)"
 	year "1996"
 	developer "Merit"
@@ -21864,6 +24563,13 @@ game (
 )
 
 game (
+	name "Mega-Tech BIOS"
+	year "1989"
+	developer "Sega"
+	rom ( name megatech.zip size 8302 crc 49600391 md5 be13b1b04addbc8262ea36e05f7b1d5d sha1 f9fd7ff9d48a53e051f649a760bcf4fa1de71162 )
+)
+
+game (
 	name "Mega Zone (Konami set 1)"
 	year "1983"
 	developer "Konami"
@@ -21923,6 +24629,34 @@ game (
 	name "Meosis Magic (Japan)"
 	developer "Sammy"
 	rom ( name meosism.zip size 4735058 crc 3eb94918 md5 e4a8aceac1eb17d1bb3437f77e722da2 sha1 585219022d93e66e04ef7e31bfbaecd885648656 )
+)
+
+game (
+	name "Mercs (World 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercs.zip size 1753910 crc 3da0b8bf md5 22c4897056f816bab7a01a4353b05a80 sha1 0469b59680031dd85710e31b2a9b0d4d46db836d )
+)
+
+game (
+	name "Senjou no Ookami II (Japan 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsj.zip size 1046473 crc 693c60ac md5 ecd90a90027ab187051b56a9caa19dcd sha1 c4ef9abc784329166e476384de72170a2d16d1e0 )
+)
+
+game (
+	name "Mercs (USA 900302)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsu.zip size 52640 crc 00ef8646 md5 17ac18241c2c7d1bd57e331e1d8d7325 sha1 40522dd9d1ac39a4110ea87e310e3a699aaf930d )
+)
+
+game (
+	name "Mercs (USA 900608)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mercsua.zip size 156242 crc 9c217ec1 md5 f6c9d280d048d604fa493dd8581807cf sha1 86b3d1f928ed83062e9725413895f37e91a8b94d )
 )
 
 game (
@@ -22007,6 +24741,27 @@ game (
 	year "1985"
 	developer "Data East"
 	rom ( name metlclsh.zip size 97952 crc 4baed0a0 md5 24a2a4f978086004590cfc7c84417df4 sha1 bdef944a8757e5f5edef1738cd3715e7a3dc4624 )
+)
+
+game (
+	name "Metal Hawk"
+	year "1988"
+	developer "Namco"
+	rom ( name metlhawk.zip size 2050614 crc 173e2946 md5 003b8777ab0c53901ad590c4d1885999 sha1 9307a0f603b924e02b940ba0d2c1eebe009db4f6 )
+)
+
+game (
+	name "Metal Hawk (Japan)"
+	year "1988"
+	developer "Namco"
+	rom ( name metlhawkj.zip size 59200 crc 1556c888 md5 d812620e7c4a82eca0a53c02520663a6 sha1 be81eab159efa912a4f0812a3b0f65822d58adc6 )
+)
+
+game (
+	name "Metal Saver"
+	year "1994"
+	developer "First Amusement"
+	rom ( name metlsavr.zip size 850810 crc 3f56d72d md5 7c1bd2cb4db4852bb20e413e62c9f29a sha1 4dd8f24d4a8209f8e652169b4b867bcb006c1a08 )
 )
 
 game (
@@ -22192,6 +24947,34 @@ game (
 )
 
 game (
+	name "Major Havoc (rev 3)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavoc.zip size 69696 crc 6a5cff34 md5 3bad435ebd898d1972a7670fde3896dc sha1 ab486e8b94235ec4973e64ea450262f859b02cb7 )
+)
+
+game (
+	name "Major Havoc (rev 2)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavoc2.zip size 42778 crc 3194afb4 md5 3393c5170211391eebc910cb566b0d73 sha1 ac6edecc95c27b689319c752cd350feba5b70dbb )
+)
+
+game (
+	name "Major Havoc (prototype)"
+	year "1983"
+	developer "Atari"
+	rom ( name mhavocp.zip size 66943 crc d2aa24e4 md5 fa194536cdefedcbe955f34d1e218e6a sha1 118ea868f569de81be4b46d08e7d6056c154a9cc )
+)
+
+game (
+	name "Major Havoc (Return to Vax)"
+	year "1983"
+	developer "Atari / JMA"
+	rom ( name mhavocrv.zip size 57051 crc ca052fce md5 1db414343a52c3a807a2deca5763a00a sha1 01bb12e7e6ea672640c3bcdb2dfa31f6c629ab63 )
+)
+
+game (
 	name "Mahjong Hourouki Gaiden (Japan)"
 	year "1987"
 	developer "Home Data"
@@ -22296,6 +25079,34 @@ game (
 )
 
 game (
+	name "Millennium Nuovo 4000 (Version 2.0)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000.zip size 655497 crc aff65f57 md5 ac50ed89ad19d0fce89707d9983a823c sha1 caaeacfb710570b24d3806a540f1c97094f863f9 )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.8)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000a.zip size 148589 crc 5260276f md5 687a04147830c8a1b45b2fc0ec04e3b6 sha1 ede15aa8af69d2942164c58fb2eb02eb5331e10d )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.5)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000b.zip size 147526 crc 1bc59b8d md5 56e5049a0ca5652d475c198c1d6588cd sha1 3f79c1c31f7d585d6a431dca3a27f260cd0097bd )
+)
+
+game (
+	name "Millennium Nuovo 4000 (Version 1.6)"
+	year "2000"
+	developer "Sure Milano"
+	rom ( name mil4000c.zip size 79428 crc 56f1393c md5 6fde1b12f08dcecb32441c175c5e4d63 sha1 205d959e940e5ff04877afc240bc32762c20f92c )
+)
+
+game (
 	name "Millipede Dux (hack)"
 	year "1982"
 	developer "hack"
@@ -22366,6 +25177,20 @@ game (
 )
 
 game (
+	name "Mini Golf (set 1)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name minigolf.zip size 60514 crc b1da511b md5 7c8582d62938519caf847b33bd31c4ef sha1 afbef1502b724bb8e576e5c2e7962a3a8ffecc11 )
+)
+
+game (
+	name "Mini Golf (set 2)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name minigolf2.zip size 20177 crc 4a142cbc md5 4b61e7bb9f43a8ed75229237b1d3d8f2 sha1 adcc523088590c749d0ec0162a3062b5e2d603e7 )
+)
+
+game (
 	name "Minivader"
 	year "1990"
 	developer "Taito Corporation"
@@ -22380,10 +25205,31 @@ game (
 )
 
 game (
+	name "Mirax"
+	year "1985"
+	developer "Current Technologies"
+	rom ( name mirax.zip size 85342 crc 16e9b160 md5 927d7cd8840379806d0feb643dcdf92c sha1 b58ad044f1282b267eb9d4e8d1efc8c371adda46 )
+)
+
+game (
+	name "Mirax (set 2)"
+	year "1985"
+	developer "Current Technologies"
+	rom ( name miraxa.zip size 29685 crc 2dc80597 md5 766b49972e7328d73a82f4f2f775ac04 sha1 01f9ca00cf1cef8a703bc65d4ac765b4744f5edd )
+)
+
+game (
 	name "Mirai Ninja (Japan)"
 	year "1988"
 	developer "Namco"
 	rom ( name mirninja.zip size 1556575 crc 0f0726b0 md5 788744993e6924cb2af8ffedac8ba1ff sha1 0f4be16f197d957563c91f61e6ac575d6d949c49 )
+)
+
+game (
+	name "Miss Bubble II"
+	year "1996"
+	developer "Alpha Co."
+	rom ( name missb2.zip size 1567164 crc 52abf6c0 md5 a04888d98fd5217f3e8142c56b1a0eb8 sha1 b863ff9ed73cc2b3934bc1665bfc4aaf9c376a2e )
 )
 
 game (
@@ -22868,6 +25714,13 @@ game (
 )
 
 game (
+	name "Mahjong Channel Zoom In (Japan)"
+	year "1990"
+	developer "Jaleco"
+	rom ( name mjzoomin.zip size 724176 crc 476c5b8a md5 dcc07435c4a5d90c32389f81b898d796 sha1 7232c3cfe65822e9eb02419c0727990be979eee7 )
+)
+
+game (
 	name "Mortal Kombat (rev 5.0 T-Unit 03/19/93)"
 	year "1992"
 	developer "Midway"
@@ -23253,6 +26106,13 @@ game (
 )
 
 game (
+	name "Monkey Donkey"
+	year "1981"
+	developer "bootleg"
+	rom ( name monkeyd.zip size 9628 crc f0b79632 md5 5a51ddd0bfbf26ca85c11f553f31afb8 sha1 b4d54adf9d2c88b5dac6d0584df510a806a2ed12 )
+)
+
+game (
 	name "Monopoly Classic"
 	year "1995"
 	developer "JPM"
@@ -23458,6 +26318,20 @@ game (
 	year "1992"
 	developer "Konami"
 	rom ( name mooua.zip size 82736 crc 962bc30c md5 f7f63bc91468c58275ada1568aebf5d3 sha1 78bbf22189f1d7c210e464ddc8897e7a27d65694 )
+)
+
+game (
+	name "More More"
+	year "1999"
+	developer "SemiCom / Exit"
+	rom ( name moremore.zip size 938135 crc ed54ea8e md5 b4d531f29da7a36e72d25884afbc0831 sha1 74cd327bc3569bd7a3502bc87999fffbf8bd6cf6 )
+)
+
+game (
+	name "More More Plus"
+	year "1999"
+	developer "SemiCom / Exit"
+	rom ( name moremorp.zip size 910432 crc 84090157 md5 14f341ac6f8b6a21feeb907e1ad03009 sha1 b53073ddbf9a87093467aedc2e2e37746b737b94 )
 )
 
 game (
@@ -23735,6 +26609,13 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name mrgoemon.zip size 81115 crc 42baf036 md5 3ab191ee6e577dc274f4425afc973c97 sha1 cc940cefcaf967c3ed9b24b43ff6083c933efcf6 )
+)
+
+game (
+	name "Mr. HELI no Dai-Bouken"
+	year "1987"
+	developer "Irem"
+	rom ( name mrheli.zip size 486553 crc 5861bbcb md5 891a728687b4421533b7c4a9f2721c80 sha1 b7c646509c202fe2e9a2b41a309055b81a7c286f )
 )
 
 game (
@@ -24186,6 +27067,13 @@ game (
 )
 
 game (
+	name "Magic Sword (Japan 900623)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mswordj.zip size 1228457 crc 4e57ce1f md5 b35b709a4d6cdfa746832a1e747a64fe sha1 2d4c15810e0bd167e04d1119e817776ec970f566 )
+)
+
+game (
 	name "Magic Sword: Heroic Fantasy (World 900623)"
 	year "1990"
 	developer "Capcom"
@@ -24253,6 +27141,13 @@ game (
 	year "1981"
 	developer "Exidy"
 	rom ( name mtrap4.zip size 15841 crc 5932986f md5 a480d151bb54a6a7cd112723ed9f5cb4 sha1 43a01f10bbc8d6cb30a991fa990954f95bd0d5a9 )
+)
+
+game (
+	name "Mega Twins (World 900619)"
+	year "1990"
+	developer "Capcom"
+	rom ( name mtwins.zip size 1435278 crc 7c4217bc md5 ad60091137010317baef2db22523ffb6 sha1 e8d16c0fa1e8dbabb45b40b05574450addb47d56 )
 )
 
 game (
@@ -24395,6 +27290,13 @@ game (
 )
 
 game (
+	name "Marvel Vs. Capcom: Clash of Super Heroes (Euro 980123)"
+	year "1998"
+	developer "Capcom"
+	rom ( name mvsc.zip size 22699647 crc 7ff321cb md5 c6ce600537da8962022ff0ff0b6084c8 sha1 8b948de6bfed689b18ce4a7b745e3b79400a885a )
+)
+
+game (
 	name "Marvel Vs. Capcom: Clash of Super Heroes (Asia 980123)"
 	year "1998"
 	developer "Capcom"
@@ -24476,6 +27378,13 @@ game (
 	year "1990"
 	developer "bootleg"
 	rom ( name mwalkbl.zip size 227945 crc 5e309ba0 md5 198147eddbe8ae25ab66e6a34c482881 sha1 50cce7b7a6a365219784909475ece33708be0800 )
+)
+
+game (
+	name "Michael Jackson's Moonwalker (Japan, FD1094/8751 317-0157)"
+	year "1990"
+	developer "Sega"
+	rom ( name mwalkj.zip size 278418 crc 954cd697 md5 df47b37beb3b9e6d214553c81065ca8e sha1 aa910f8bd672306e0a8c772f053fde475c749450 )
 )
 
 game (
@@ -24622,6 +27531,20 @@ game (
 	year "1990"
 	developer "SNK"
 	rom ( name nam1975.zip size 3109482 crc 7f4c05b6 md5 ed51f017d7d52ab6a04a4e3facf51b95 sha1 a8c40d826ea7d387cf90e316e4ba3358699d9564 )
+)
+
+game (
+	name "Name That Tune"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nametune.zip size 152433 crc e960ddcc md5 c11d4fb3707a2909c9dd1267f2df354b sha1 acb3abba2f7dce7a43e4b3a4b13faf3c150291c2 )
+)
+
+game (
+	name "Name That Tune (3-23-86)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nametune2.zip size 147655 crc 081e9e78 md5 61da5b1e8fa7123a36a954183826ce59 sha1 12a8beff780455031735ad8e68dd1a29e6a7a9ba )
 )
 
 game (
@@ -24821,6 +27744,12 @@ game (
 )
 
 game (
+	name "Cherry Bonus III (ver.1.40, set 1)"
+	developer "Dyna"
+	rom ( name ncb3.zip size 76485 crc 8a763e9e md5 55fd61da1e2540bee45043c3858b4910 sha1 67795e3a044d09eba5d2c285d1abe5f4189a8b4a )
+)
+
+game (
 	name "Ninja Combat (set 1)"
 	year "1990"
 	developer "Alpha Denshi Co."
@@ -24919,6 +27848,13 @@ game (
 )
 
 game (
+	name "Nemo (Japan 901120)"
+	year "1990"
+	developer "Capcom"
+	rom ( name nemoj.zip size 1149808 crc 71ec8478 md5 61c9b11fd2e1df1c136c16b1000f5a47 sha1 e0dce5355e7dbee9da1881ee533745a72795e227 )
+)
+
+game (
 	name "SD Gundam Neo Battling (Japan)"
 	year "1992"
 	developer "Banpresto / Sotsu Agency. Sunrise"
@@ -24944,6 +27880,13 @@ game (
 	year "1996"
 	developer "Visco"
 	rom ( name neodrift.zip size 8575446 crc 5e6373a4 md5 294b8472fa9f8702eb20100e41b323ee sha1 17b56c374c1dd3164433c00e456d285586330289 )
+)
+
+game (
+	name "Neo-Geo"
+	year "1990"
+	developer "SNK"
+	rom ( name neogeo.zip size 1346731 crc afce86ac md5 9323dfa8b1fd45b071f5ec84317d01aa sha1 0e0d456c2c0db42cefce54e55b8bc6712fe4d547 )
 )
 
 game (
@@ -25014,6 +27957,13 @@ game (
 	year "1980"
 	developer "hack"
 	rom ( name newpuckx.zip size 10815 crc a72a3529 md5 6261f5a683cae96edaf6c6f90839f9d3 sha1 97d349084ac3f3c0a4a36bbc6eb20ded9f326698 )
+)
+
+game (
+	name "News (set 1)"
+	year "1993"
+	developer "Poby / Virus"
+	rom ( name news.zip size 429094 crc 82e90002 md5 f861f440b9dd54d8b614a66cea978c67 sha1 1aab5aa130d7229e20c8cd1b58f3c2a2990205d2 )
 )
 
 game (
@@ -25276,6 +28226,20 @@ game (
 )
 
 game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan)"
+	year "1987"
+	developer "Technos Japan"
+	rom ( name nkdodge.zip size 207851 crc 430b2675 md5 d9d592ca50ce9f03bcc55b09d2b11b44 sha1 eebfd95a745b173307b01d8ca00b003d4a8c8ebd )
+)
+
+game (
+	name "Nekketsu Koukou Dodgeball Bu (Japan, bootleg)"
+	year "1987"
+	developer "bootleg"
+	rom ( name nkdodgeb.zip size 208931 crc 5f93dffd md5 74335d8781287e2208e0a6996cf1b84c sha1 4a9ed5b5d1024b0678eb332f7a3549e315493d92 )
+)
+
+game (
 	name "Oni - The Ninja Master (Japan)"
 	year "1995"
 	developer "Banpresto / Pandorabox"
@@ -25528,10 +28492,37 @@ game (
 )
 
 game (
+	name "Ninja Spirit"
+	year "1988"
+	developer "Irem"
+	rom ( name nspirit.zip size 585051 crc a9c0aa55 md5 51db030c9f0f8245440a076bf7ec141f sha1 c792a326fa586ba2fccdae7d5e3efb3933dae0bc )
+)
+
+game (
 	name "Saigo no Nindou (Japan)"
 	year "1988"
 	developer "Irem"
 	rom ( name nspiritj.zip size 101692 crc 151390cd md5 ab11640a210ce3aefcd27002ebbe2ce5 sha1 d9da755d4e7321cf1e687d606cce62a1cf88e464 )
+)
+
+game (
+	name "Nintendo Super System BIOS"
+	developer "Nintendo"
+	rom ( name nss.zip size 34674 crc 0f72d3b6 md5 248e7c578a0ea2854d8d7d0c50e4f44b sha1 99a47d0660d931579ad9794f658973fb588f19b6 )
+)
+
+game (
+	name "Night Stocker (set 1)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nstocker.zip size 69916 crc b4706cfd md5 e51875956118b11a665c325e6e86ac50 sha1 e8d2d0e5e0092faac7d953b9a9a1aeb8a90d722b )
+)
+
+game (
+	name "Night Stocker (set 2)"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name nstocker2.zip size 11778 crc 2d6b8984 md5 2adf44285900fc78eb4b40e91a9bfde4 sha1 d20907b7959ab450c41896fca35046dbfdce6697 )
 )
 
 game (
@@ -25707,6 +28698,13 @@ game (
 	year "1989"
 	developer "Nichibutsu"
 	rom ( name ohpaipee.zip size 351155 crc c9b31181 md5 ed0bc1373b0e95d7ae1f9392149acf73 sha1 e6f02839c3a63e8498d2c11bba9fbe6daf351a54 )
+)
+
+game (
+	name "Oigas (bootleg)"
+	year "1986"
+	developer "bootleg"
+	rom ( name oigas.zip size 38954 crc 4e757952 md5 da23ddf94899c37ce7951ec3e4da700b sha1 c992d6620fd2092cb49c1b109a4f6aa2fe01a7b1 )
 )
 
 game (
@@ -25993,6 +28991,34 @@ game (
 )
 
 game (
+	name "Psycho-Nics Oscar (World revision 0)"
+	year "1988"
+	developer "Data East Corporation"
+	rom ( name oscar.zip size 270950 crc 108ce66b md5 76cd960b73e1dbc1bf2c41b168b4e1d6 sha1 82b77af4fa0c531eadcdec1309f97d0c15a54994 )
+)
+
+game (
+	name "Psycho-Nics Oscar (Japan revision 1)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name oscarj1.zip size 15727 crc 3d928ee5 md5 df21d49325e984a98e463fefbe73e48e sha1 0d77d039dc979f6e1e2426204d4f96c7c9f491f5 )
+)
+
+game (
+	name "Psycho-Nics Oscar (Japan revision 2)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name oscarj2.zip size 15726 crc daba584c md5 956a5304d490eee5773c3cde30222931 sha1 1736c22593a4ef43e79b67e4762b88ac1b82d9ef )
+)
+
+game (
+	name "Psycho-Nics Oscar (US)"
+	year "1987"
+	developer "Data East USA"
+	rom ( name oscaru.zip size 38931 crc 099ce174 md5 6853711b59720c9fcccc587cb2a9d9ce sha1 3b0973a0e5c24d3aeb52dfb3ea0382d227eadda1 )
+)
+
+game (
 	name "Osman (World)"
 	year "1996"
 	developer "Mitchell"
@@ -26053,6 +29079,13 @@ game (
 	year "1988"
 	developer "Apple"
 	rom ( name otonano.zip size 427882 crc 4e46cd14 md5 ad95a05943fb73ad30e199a501b84e20 sha1 2b23bb0df8b3b43cba860d4e4eac87e0942fc981 )
+)
+
+game (
+	name "Off the Wall (Sente)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name otwalls.zip size 31281 crc 696c7e94 md5 1aeef6cd63c95f15500d571df6e451c5 sha1 b983436f556bb9675c5215557f3e1b9eb636485e )
 )
 
 game (
@@ -26179,6 +29212,13 @@ game (
 	year "1988"
 	developer "Jaleco"
 	rom ( name p47.zip size 716099 crc 12dcc48f md5 8bf2390533497b5171a4bdb4e5e779b4 sha1 234988f0243a2a7266c68bff43edacfb0c16bbfe )
+)
+
+game (
+	name "P-47 Aces"
+	year "1995"
+	developer "Jaleco"
+	rom ( name p47aces.zip size 8715750 crc 6d6a4ad7 md5 732428f7fc1a99ba20e1024fea1791c3 sha1 c7f6bb507f692d22d75a3237439ece283582082e )
 )
 
 game (
@@ -26434,6 +29474,27 @@ game (
 )
 
 game (
+	name "Pang! 3 (Euro 950601)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3.zip size 1536054 crc a87f3739 md5 c0de95b04c2f94e3b3220f1df6fb9ec7 sha1 40f258558a0131042df75952e6616f8a8ae44958 )
+)
+
+game (
+	name "Pang! 3: Kaitou Tachi no Karei na Gogo (Japan 950511)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3j.zip size 145169 crc 9931a464 md5 e2c83cdd590436a482e3a697996345d2 sha1 c163acb92b9dffed38daf6fbf59592d6d08d091e )
+)
+
+game (
+	name "Pang! 3 (Euro 950511, not encrypted)"
+	year "1995"
+	developer "Mitchell"
+	rom ( name pang3n.zip size 143820 crc 646b27ec md5 0a737bb335a58c71240d53b59c0f533c sha1 6bd49b974f872c504e206c840fe8166ac5eede2b )
+)
+
+game (
 	name "Pang (bootleg, set 1)"
 	year "1989"
 	developer "bootleg"
@@ -26445,6 +29506,13 @@ game (
 	year "1989"
 	developer "bootleg"
 	rom ( name pangbold.zip size 294151 crc 6a3e80d4 md5 e38fc24e1ee94cfc6d6db90fee7b677c sha1 ae4cf1be274aa15a413bb84080bef9917db79b4f )
+)
+
+game (
+	name "Pang Pang"
+	year "1994"
+	developer "Dong Gue La Mi Ltd."
+	rom ( name pangpang.zip size 1327359 crc 6d4091d6 md5 ed64180c61efdcff8fcf8eb1abbc7f85 sha1 7cc71bd8f59396cce15bb67c73aa98ed5cc5516e )
 )
 
 game (
@@ -26732,10 +29800,24 @@ game (
 )
 
 game (
+	name "Powerful Pro Baseball EX (GX802 VER. JAB)"
+	year "1998"
+	developer "Konami"
+	rom ( name pbballex.zip size 179 crc 933b6fab md5 475cdbd7c07599f57ea185e4028a46a4 sha1 56dc6285077011c9c8b3d2dacc44ab7dff9cb813 )
+)
+
+game (
 	name "Pinball Champ '95 (bootleg?)"
 	year "1995"
 	developer "bootleg? (Veltmeijer Automaten)"
 	rom ( name pbchmp95.zip size 99312 crc 2089687f md5 751e0a34c55be593238c590a40ad36dd sha1 ec424941de9b1dfca8e206afb4ca5859663ff348 )
+)
+
+game (
+	name "Prebillian"
+	year "1986"
+	developer "Taito"
+	rom ( name pbillian.zip size 63651 crc c91aee9d md5 4bf1cc0879ebb2fd324ebdd061a6ecea sha1 55f1605ef6be675413737be17e7d52d2f961b542 )
 )
 
 game (
@@ -26827,6 +29909,27 @@ game (
 	year "1996"
 	developer "Taito Corporation"
 	rom ( name pbobble3u.zip size 247621 crc d387e6c4 md5 5b7bbf38d0f2eb04cfc49f4872c97457 sha1 e43ccc5df5fe315b5a3e36578e02b2efc04dd750 )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04O 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4.zip size 6978003 crc 67476786 md5 1fb77610e9f75281822a5009e8805167 sha1 5b5c095d914a2301856b058745c21edea7ba6d52 )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04J 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4j.zip size 190293 crc 13b223e5 md5 f4cc1ba850b70459b3fc0ac05940c898 sha1 6fce23aa27c75a448682cfa62650c6dbf7d21119 )
+)
+
+game (
+	name "Puzzle Bobble 4 (Ver 2.04A 1997/12/19)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name pbobble4u.zip size 190294 crc e14fb4c6 md5 360534f63cc3ae248d39b3fd976e31dd sha1 6f88df48a9b3c165c1f5c3754b1d961c608e0c10 )
 )
 
 game (
@@ -27306,6 +30409,13 @@ game (
 )
 
 game (
+	name "Peek-a-Boo!"
+	year "1993"
+	developer "Jaleco"
+	rom ( name peekaboo.zip size 1267072 crc 7f4335c8 md5 dd6c7746b1ab9d149158f8109d3c7e1d sha1 76dc3f1edad3630d9c75921a9efe94b2598436fc )
+)
+
+game (
 	name "Nozokimeguri Mahjong Peep Show (Japan 890404)"
 	year "1989"
 	developer "AC"
@@ -27551,6 +30661,13 @@ game (
 )
 
 game (
+	name "Peter Pack-Rat"
+	year "1984"
+	developer "Atari Games"
+	rom ( name peterpak.zip size 206852 crc a3037cff md5 25de0233e1dbca7f00b2dd25d130606b sha1 ae68432abb968941b79479f13da5186e3ca67385 )
+)
+
+game (
 	name "Player's Edge Plus (X002069P) Double Double Bonus Poker"
 	year "1995"
 	developer "IGT - International Gaming Technology"
@@ -27621,6 +30738,13 @@ game (
 )
 
 game (
+	name "PGM (Polygame Master) System BIOS"
+	year "1997"
+	developer "IGS"
+	rom ( name pgm.zip size 2094636 crc bf3dd2ef md5 87cc944eef4c671aa2629a8ba48a08e0 sha1 c0c001ec80fa860857000f4cfc9844a28498a355 )
+)
+
+game (
 	name "Pleasure Goal / Futsal - 5 on 5 Mini Soccer"
 	year "1996"
 	developer "Saurus"
@@ -27667,6 +30791,12 @@ game (
 	year "1988"
 	developer "Namco"
 	rom ( name phelios.zip size 1519633 crc fef8dc2b md5 07392e8573a863bd1110eadff321bff8 sha1 beb9c48c9bf57011ef65bdfd9c2452e01e01607d )
+)
+
+game (
+	name "Klad / Labyrinth (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phklad.zip size 9882 crc 38bbc068 md5 97153cfcbb5b10e4e0f4645590dcb993 sha1 ff6b6604cd22c65f3684bc3284014441616b5c3e )
 )
 
 game (
@@ -27761,6 +30891,12 @@ game (
 )
 
 game (
+	name "Python (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phpython.zip size 4735 crc 310b8131 md5 0b14748a725264eeb897216e760da88e sha1 7d5562ea7f49c36b6245a8fb56a67cfcbb4963e1 )
+)
+
+game (
 	name "Phraze Craze (set 1)"
 	year "1986"
 	developer "Merit"
@@ -27786,6 +30922,19 @@ game (
 	year "1986"
 	developer "Merit"
 	rom ( name phrcrazec.zip size 251509 crc f58a959b md5 e878af9cdb65c155dcda6f6cdc70e049 sha1 a01734521f3f333d211e333f0affdb9520db31ea )
+)
+
+game (
+	name "Phraze Craze (Sex Kit, Vertical)"
+	year "1986"
+	developer "Merit"
+	rom ( name phrcrazev.zip size 77644 crc 3bd8b6be md5 ae3a1de8da35c822b78cad6ff7092598 sha1 62d0bed03106fc168f2f2892b654f8e441c21258 )
+)
+
+game (
+	name "Tetris (Photon System)"
+	developer "&lt;unknown&gt;"
+	rom ( name phtetris.zip size 9369 crc 3e432f38 md5 b1500f93765e3ac1838cac3501b1dd4b sha1 c21681de17086c9f1ede9fcf8c55e41ad13ce266 )
 )
 
 game (
@@ -27856,6 +31005,20 @@ game (
 	year "2001"
 	developer "Amcoe"
 	rom ( name pickwinvt.zip size 160293 crc 3f1f1284 md5 e5bd0180cea764d8ff7c46a346c2f109 sha1 d2b71ed5ddea50490a161d0e826eb561c2b624ba )
+)
+
+game (
+	name "Pig Newton (version C)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewt.zip size 41651 crc db3fda51 md5 aa6e091315be92442c51c85f5fb5e5d8 sha1 3906317a8247a719a399af266abf35d6797b5dd9 )
+)
+
+game (
+	name "Pig Newton (version A)"
+	year "1983"
+	developer "Sega"
+	rom ( name pignewta.zip size 22721 crc 2661d4d6 md5 fe371e4556e23bef94398d10e3a9f985 sha1 14e5a12a9ca9b65d934a7b575720ed20de3093c2 )
 )
 
 game (
@@ -28493,6 +31656,13 @@ game (
 )
 
 game (
+	name "PlayChoice-10 BIOS"
+	year "1986"
+	developer "Nintendo of America"
+	rom ( name playch10.zip size 23410 crc e551f471 md5 f3e6ac0abfd134ab6b05df035ab01c9d sha1 7b2ffe23a41a31c93882bfd5a6e7cc1b5184fdfd )
+)
+
+game (
 	name "Power Instinct Legends (US, Ver. 95/06/20)"
 	year "1995"
 	developer "Atlus"
@@ -28584,6 +31754,34 @@ game (
 )
 
 game (
+	name "Plump Pop (Japan)"
+	year "1987"
+	developer "Taito Corporation"
+	rom ( name plumppop.zip size 222302 crc 2ab5a90d md5 b725e7aaadf866c1e8102fd5c5333c62 sha1 2364f35334408e29428909cbb8edebc42d35f4fb )
+)
+
+game (
+	name "Plus Alpha"
+	year "1989"
+	developer "Jaleco"
+	rom ( name plusalph.zip size 1014633 crc a37f8119 md5 7f936d4d34914b2b9b0577b5e1828174 sha1 2a5a7ebdf17935e70156be788590bdd64987fa94 )
+)
+
+game (
+	name "PlayMan Poker (German)"
+	year "1981"
+	developer "PlayMan"
+	rom ( name pmpoker.zip size 12852 crc 243392db md5 23ec82bb1473133a3449d44509b8cd79 sha1 c779d609e229cb37cfb3fb5e48ec23532918fadd )
+)
+
+game (
+	name "Pnickies (Japan 940608)"
+	year "1994"
+	developer "Capcom, licensed by Compile)"
+	rom ( name pnickj.zip size 768482 crc 051b5dc5 md5 0193b457c1f8ef81575570fdf644fe2a sha1 4794c11915dc391005a26136e4cd34988e52fa23 )
+)
+
+game (
 	name "Pochi and Nyaa"
 	year "2003"
 	developer "Aiky / Taito"
@@ -28668,6 +31866,13 @@ game (
 )
 
 game (
+	name "Pole Position (Atari version 1)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name polepos1.zip size 45746 crc bb978c64 md5 eb0b701c895378b259b58ad3c709fee5 sha1 01bbd6c8cb1865cbd3ef187532567dd85380ca98 )
+)
+
+game (
 	name "Pole Position II"
 	year "1983"
 	developer "Namco"
@@ -28675,10 +31880,31 @@ game (
 )
 
 game (
+	name "Pole Position II (Atari)"
+	year "1983"
+	developer "Namco (Atari license)"
+	rom ( name polepos2a.zip size 51441 crc 5f8aafbe md5 23d58a0a42f14f7039a27ed6f01b6d67 sha1 d670c17bc01215d22d36ccf4d7ce3d2cfbb95d5c )
+)
+
+game (
 	name "Pole Position II (bootleg)"
 	year "1983"
 	developer "bootleg"
 	rom ( name polepos2b.zip size 51847 crc 405b4516 md5 bdee38e743d85bb76e0fe194e91b0dcd sha1 d419250bcf8999f4d4f3ad35e5fe8fa769c39198 )
+)
+
+game (
+	name "Gran Premio F1 (Italian bootleg of Pole Position II)"
+	year "1984"
+	developer "bootleg"
+	rom ( name polepos2bi.zip size 55055 crc bf144686 md5 cc9e55c7ac3fa0d1db4ded1bd7671d44 sha1 73d3583e6471e1ac8341da459d02695240a6c6f0 )
+)
+
+game (
+	name "Pole Position (Atari version 2)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name poleposa.zip size 45115 crc e40470d9 md5 b00adc65636ed90d3b92d74f48d501ab sha1 6d5f63a7c2ffad8cc9fe02e3a5a7663df50229de )
 )
 
 game (
@@ -28784,6 +32010,34 @@ game (
 	year "1985"
 	developer "Tehkan"
 	rom ( name ponttehk.zip size 21561 crc 834670ce md5 79b9c5d39cd5797c9dfd1e0674bba796 sha1 724110eca09ef9aa4729e9ee03ba257cde06593c )
+)
+
+game (
+	name "Pool 10 (Italian, set 1)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10.zip size 20398 crc 84f48fe3 md5 ce613ad55bd40c2d8ba48fdb52ace5e4 sha1 8318545929fad958ba17ef9b9a40f66bb2cc0353 )
+)
+
+game (
+	name "Pool 10 (Italian, set 2)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10b.zip size 38134 crc d1b794f0 md5 ebb855c65e75f6fba11d85f1e2d67bac sha1 ea121adb2d469e144f329ca789a4b0a3774f2be2 )
+)
+
+game (
+	name "Pool 10 (Italian, set 3)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name pool10c.zip size 14027 crc 03ebd786 md5 82ab6ce7a6eef0cea3d0e4f8ad23ce5d sha1 ed6918abcbc57180b60268de60a08603a7185da8 )
+)
+
+game (
+	name "Pool 10 (Italian, set 4)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name pool10d.zip size 27760 crc ca5722d5 md5 0858943d8d831e9b14d03f1a6847b0b6 sha1 29d9d986cb8c1a521b38bc82c22ddbb1e71e2f47 )
 )
 
 game (
@@ -28906,6 +32160,27 @@ game (
 )
 
 game (
+	name "Pop'n Pop (Ver 2.07O 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpop.zip size 5652566 crc a8bb9331 md5 bdb8ef0c629e68fed1b41b2f4c9ae7c5 sha1 68b3d7dfb6d2b574edf5302e1312047cde02ce77 )
+)
+
+game (
+	name "Pop'n Pop (Ver 2.07J 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpopj.zip size 153007 crc 1e31cce8 md5 06d170adc945c58ee578ea835ca48f90 sha1 dc0170c9de82642b3399476494bb7fb38fbac70e )
+)
+
+game (
+	name "Pop'n Pop (Ver 2.07A 1998/02/09)"
+	year "1997"
+	developer "Taito Corporation"
+	rom ( name popnpopu.zip size 153007 crc 10ce197f md5 537d0103735d8acfd2604752dc4194d3 sha1 227ee2f1b8252c6bbb0a4f81e10e307101c2f7b0 )
+)
+
+game (
 	name "Popper"
 	year "1983"
 	developer "Omori Electric Co., Ltd."
@@ -28927,10 +32202,30 @@ game (
 )
 
 game (
+	name "Port Man (bootleg on Moon Cresta hardware)"
+	year "1982"
+	developer "bootleg"
+	rom ( name porter.zip size 17109 crc 084fc4ae md5 2e31986952ef71edf0b4a7ec82b512f7 sha1 cae0028ff3da248ad418a774774e035af85c8518 )
+)
+
+game (
 	name "Port Man"
 	year "1982"
 	developer "Taito Corporation (Nova Games Ltd. license)"
 	rom ( name portman.zip size 9356 crc 533f1dde md5 445361fbb4316de9ed6fddc165d8af79 sha1 1170f8dd375c704a223960ed5118cc5b83fe899c )
+)
+
+game (
+	name "Pot Game (Italian)"
+	year "1996"
+	developer "C.M.C."
+	rom ( name potgame.zip size 18056 crc 87924391 md5 c08ca9b28c3482282bb1000a8098453a sha1 5b010fc3ae5d2207bce0a0473fc8c679de403a96 )
+)
+
+game (
+	name "Jack Potten's Poker (set 2)"
+	developer "bootleg"
+	rom ( name potnpkra.zip size 10389 crc bdf2e846 md5 a5e51be26d8eb70e221fe287f0395048 sha1 6e46e96c61b54ee36b14d13b1a06a0f5838e95b0 )
 )
 
 game (
@@ -28949,6 +32244,12 @@ game (
 	name "Jack Potten's Poker (set 5)"
 	developer "bootleg"
 	rom ( name potnpkrd.zip size 8016 crc 3e0dab10 md5 850a088e855bc4d251a187c23c6b6a69 sha1 a4d9c0b5eadbbbfc13a9037836bdef3776d00482 )
+)
+
+game (
+	name "Jack Potten's Poker (set 6)"
+	developer "bootleg"
+	rom ( name potnpkre.zip size 5881 crc 777523a1 md5 b87b6fd6728144de56070f3913e1a869 sha1 c8141f663d5174e7cbbe654078c4d5dce0881069 )
 )
 
 game (
@@ -28997,6 +32298,13 @@ game (
 	year "1988"
 	developer "SNK"
 	rom ( name pow.zip size 806437 crc f6157c0e md5 5f70874fb2f3708253d46eb4331d0edb sha1 e92d354061cce1ac548d402f6cebde20841d8712 )
+)
+
+game (
+	name "Power Balls"
+	year "1994"
+	developer "Playmark"
+	rom ( name powerbal.zip size 1561777 crc f12ad31f md5 0b47ed0acf97cdf809bb74ac2c209f12 sha1 24a4710947ebd0f923e3725292c6195c157de633 )
 )
 
 game (
@@ -29280,6 +32588,13 @@ game (
 )
 
 game (
+	name "PS Arcade 95"
+	year "1997"
+	developer "Sony / Eighting / Raizing"
+	rom ( name psarc95.zip size 128532 crc 90c1f2db md5 42fd29136ae22e8c99f9e47c82dd6c72 sha1 b9b76c75d3c7a55f0fa00ced86e3e11654c19867 )
+)
+
+game (
 	name "Perfect Soldiers (Japan)"
 	year "1993"
 	developer "Irem"
@@ -29326,6 +32641,13 @@ game (
 	year "1990"
 	developer "Nichibutsu"
 	rom ( name pstadium.zip size 418203 crc d56279b6 md5 741835ffd943993da5208c53da01a204 sha1 4e3ff2f9a8f50b3fe6e8b92f9f72f6e689611ef4 )
+)
+
+game (
+	name "Power Surge"
+	year "1988"
+	developer "&lt;unknown&gt;"
+	rom ( name psurge.zip size 19629 crc 8b13fa63 md5 e0a832036e0e1a8ab75b11a39314e477 sha1 05475674ce1fc08f0b974c0aca03707009ff3a64 )
 )
 
 game (
@@ -29511,10 +32833,31 @@ game (
 )
 
 game (
+	name "The Punisher (World 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisher.zip size 4041934 crc 817cbb2a md5 57fdbc0298708807a43ff37890d864a0 sha1 e420fe80faa14ac8a36a9ed93f1698cfec5d60aa )
+)
+
+game (
 	name "Biaofeng Zhanjing (Chinese bootleg of The Punisher)"
 	year "1993"
 	developer "bootleg"
 	rom ( name punisherbz.zip size 1874748 crc e0642a46 md5 a403f2cd3a9dd86d75a525f225e5d7ec sha1 93a457791fa328be950668f87e1ac89c730b29da )
+)
+
+game (
+	name "The Punisher (Japan 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisherj.zip size 402652 crc 29c3d4f9 md5 416ad59afe0d70683da35dd9b1cab21e sha1 2e74407e170e56a986da6894ddefd9eca986bd54 )
+)
+
+game (
+	name "The Punisher (USA 930422)"
+	year "1993"
+	developer "Capcom"
+	rom ( name punisheru.zip size 421251 crc 39b08dd7 md5 519f987fe799bd54fcac2fef813321b4 sha1 77e0c035fd13505303cbfaee742d7b834b02aad1 )
 )
 
 game (
@@ -29637,6 +32980,13 @@ game (
 )
 
 game (
+	name "Puzzle De Pon! R!"
+	year "1997"
+	developer "Taito (Visco license)"
+	rom ( name puzzldpr.zip size 158229 crc 061977f0 md5 87f11c7afe188e2ec60c97b0b1b9f3ce sha1 2fcf40f5564c41a3ae7d9d33cdaf2b0a09e71c08 )
+)
+
+game (
 	name "Puzzle De Pon!"
 	year "1995"
 	developer "Taito (Visco license)"
@@ -29686,10 +33036,24 @@ game (
 )
 
 game (
+	name "Puzznic (World)"
+	year "1989"
+	developer "Taito Corporation Japan"
+	rom ( name puzznic.zip size 55467 crc bc6229c3 md5 bdfefff6e6bf604499f43ee5bad2318b sha1 bb29be31df5ba1a6f51d90cbd39ea186e83b6a82 )
+)
+
+game (
 	name "Puzznic (Italian bootleg)"
 	year "1989"
 	developer "bootleg"
 	rom ( name puzznici.zip size 130658 crc 5de407ba md5 ca623ca75bbf7755726348ad786a2509 sha1 11b709be85ec2973d2d15780ea8c098241d8da9d )
+)
+
+game (
+	name "Puzznic (Japan)"
+	year "1989"
+	developer "Taito Corporation"
+	rom ( name puzznicj.zip size 130560 crc beba7156 md5 cc1052a40ee31a1ce60e398c3ea4f25f sha1 23262726e766c491e3f4f3b88a5fd64f365bcc84 )
 )
 
 game (
@@ -29739,6 +33103,13 @@ game (
 	year "1999"
 	developer "Nihon System / Moss"
 	rom ( name pzlbowl.zip size 5900443 crc eb81a5b5 md5 4c7055693eebd84727f1dd47e5f081f4 sha1 8043c25613252b5030fad20e5c55ab5f9045ceac )
+)
+
+game (
+	name "Puzzle Break"
+	year "1997"
+	developer "SemiCom"
+	rom ( name pzlbreak.zip size 524061 crc b3502f4b md5 02282e91d44e492181781d612bf26cda sha1 875582b56386d025224b8f3696f56b820c812fac )
 )
 
 game (
@@ -29993,10 +33364,38 @@ game (
 )
 
 game (
+	name "Quiz Tonosama no Yabou 2: Zenkoku-ban (Japan 950123)"
+	year "1995"
+	developer "Capcom"
+	rom ( name qtono2j.zip size 1944928 crc 9064b2b9 md5 8f1424cf328dcd7a007a4a4be0c7eea3 sha1 b965ed1b1f8a248ad8e8aa2f02a11a6648f95779 )
+)
+
+game (
 	name "Quiz Torimonochou (Japan)"
 	year "1990"
 	developer "Taito Corporation"
 	rom ( name qtorimon.zip size 513555 crc e41953d4 md5 814be223337a21e1df927e9e569fe9c3 sha1 e0169b435c4bea7ebafdbb2e7d064f17bf257a91 )
+)
+
+game (
+	name "Quantum (rev 2)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantum.zip size 47012 crc 74b2f516 md5 ce561fb1a17ed9989a3cafee44cf1faf sha1 4af46ae800a4320c270eec78a9230580d911c26c )
+)
+
+game (
+	name "Quantum (rev 1)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantum1.zip size 18499 crc ccef1d33 md5 3ff8ddbd0cf592cda61d37ffca2c82dd sha1 e8bdaf0a186f934c97b10e1e98f8dc179c26b942 )
+)
+
+game (
+	name "Quantum (prototype)"
+	year "1982"
+	developer "Atari"
+	rom ( name quantump.zip size 46566 crc e5fc3310 md5 ea78c1e1689895d08633fef2092c113b sha1 ee1c29d08f76d831042e6a488616d348da8adac0 )
 )
 
 game (
@@ -30056,6 +33455,20 @@ game (
 )
 
 game (
+	name "Quintoon (UK, Game Card 95-750-203)"
+	year "1993"
+	developer "BFM"
+	rom ( name quintono.zip size 56694 crc 30d21af3 md5 0c2f8ac982381b273ed8e3927349217d sha1 23207a10453a08632ef2d768165a7413cdb32030 )
+)
+
+game (
+	name "Quintoon (UK, Game Card 95-750-206)"
+	year "1993"
+	developer "BFM"
+	rom ( name quintoon.zip size 127592 crc bd7226f5 md5 2f6531f18028f7e9a9496189ab917ba6 sha1 6b50a5860783238f0959f0c4ad73cc82ca70bacb )
+)
+
+game (
 	name "Quiz (Revision 2)"
 	year "1986"
 	developer "bootleg"
@@ -30067,6 +33480,13 @@ game (
 	year "1992"
 	developer "EIM"
 	rom ( name quiz18k.zip size 2058384 crc 65cea25c md5 06b84dad170b3575a329987450563c71 sha1 91eea1ac7ea2c01c21a9617811abfb2ff4d1e108 )
+)
+
+game (
+	name "Quiz (Revision 2.11)"
+	year "1991"
+	developer "Elettronolo"
+	rom ( name quiz211.zip size 53546 crc e631a1b3 md5 12eecfa9add482b36d5d29f7026a873d sha1 da0274db8b6291243fd5d9f6c060f240ea4fe927 )
 )
 
 game (
@@ -30189,6 +33609,13 @@ game (
 )
 
 game (
+	name "Video Quiz"
+	year "1986"
+	developer "bootleg"
+	rom ( name quizvid.zip size 98690 crc 7eb96c0f md5 f2fb3f30e7ce4f0f5a8b30dcb870136d sha1 f84216391f4cc27577fc37cec7da0171b005156a )
+)
+
+game (
 	name "Qwak (prototype)"
 	year "1982"
 	developer "Atari"
@@ -30252,6 +33679,111 @@ game (
 )
 
 game (
+	name "Race Drivin' (cockpit, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv.zip size 814136 crc 97b25542 md5 2432dc88898105f0b684a4b381494371 sha1 ba9bac6256b53ee5279e61c950aaab092b690df5 )
+)
+
+game (
+	name "Race Drivin' (cockpit, rev 3)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv3.zip size 391352 crc 08b3bafb md5 5f18b602fb40d82ea6f914071df58c6e sha1 768d1bfbb60821a38c0ff76dc120d9d8711f7b98 )
+)
+
+game (
+	name "Race Drivin' (cockpit, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedriv4.zip size 188572 crc 2a43450e md5 7bfa6eb12a3cd47e98ef5e76f3650336 sha1 74c8b681fecc5df0b4f0c9e4a26d66b5733d2620 )
+)
+
+game (
+	name "Race Drivin' (cockpit, British, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivb.zip size 53983 crc a14e60d3 md5 b0a6d95377846bb966411730e4937e4b sha1 7ad758bcbf83b254e0a24935f08fd307e72d6b0a )
+)
+
+game (
+	name "Race Drivin' (cockpit, British, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivb4.zip size 242511 crc f798651d md5 e91a176ac13535a042173414d71b92a5 sha1 1e9f93591095392ff620f4c082d1fb78e15bfc77 )
+)
+
+game (
+	name "Race Drivin' (compact, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc.zip size 441600 crc d4a876be md5 118392e80bf7a1ba4085a69e5e92d81f sha1 192bc717f117598fe50116503c00cf68d7b16fac )
+)
+
+game (
+	name "Race Drivin' (compact, rev 1)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc1.zip size 429658 crc 822bd48a md5 101c50eecd7b72ce2235f5ea503990a9 sha1 bf79bb1afa41b1959b40e8e30eca1ac072cc4e1c )
+)
+
+game (
+	name "Race Drivin' (compact, rev 2)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc2.zip size 429644 crc ac737060 md5 02bc61e733cdc1888bb66bf5fed8de7e sha1 4a22bced10412970e62b0addbd82aac6fdefcd5c )
+)
+
+game (
+	name "Race Drivin' (compact, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivc4.zip size 441180 crc 36b22b47 md5 3cf77084acda3dcdeabef88463362c18 sha1 4991a054cf1c92ceb968e074fff9e39802686fe7 )
+)
+
+game (
+	name "Race Drivin' (compact, British, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcb.zip size 495539 crc 90a58753 md5 7cf2d31a4811a9c1c76975d56561bcbe sha1 b7db205811cfd555c61109ae978e65c958129035 )
+)
+
+game (
+	name "Race Drivin' (compact, British, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcb4.zip size 495119 crc e9e92ae5 md5 ee799000ef9e7d64a129d8cd817d86f1 sha1 1bd641db1d270d7619f354fe655de0e6d34c22cc )
+)
+
+game (
+	name "Race Drivin' (compact, German, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcg.zip size 442473 crc b4837f45 md5 d1d67089d37628685e376df23ecab5b0 sha1 f95a0bb58c9c8ed6141cde5aae747b4f5d60325f )
+)
+
+game (
+	name "Race Drivin' (compact, German, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivcg4.zip size 442122 crc b633bb2b md5 903f60975629c65ece7a3d8df180f19e sha1 7272fb65fbd386f2a1ffdd664899b02f36ac3666 )
+)
+
+game (
+	name "Race Drivin' (cockpit, German, rev 5)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivg.zip size 190241 crc 764e5709 md5 21d2de8779ee8dfeb0d66504cd3bdf14 sha1 20dcc7c86257cfad7b34e8027c8622dd1208e4a4 )
+)
+
+game (
+	name "Race Drivin' (cockpit, German, rev 4)"
+	year "1990"
+	developer "Atari Games"
+	rom ( name racedrivg4.zip size 189793 crc b4ef5097 md5 4a2d3db81de409f84666081e1f7e1965 sha1 45522dc9a548eacd6a40b1bba323e67ce2d52810 )
+)
+
+game (
 	name "Racing Hero (FD1094 317-0144)"
 	year "1989"
 	developer "Sega"
@@ -30277,6 +33809,13 @@ game (
 	year "1980"
 	developer "Nintendo"
 	rom ( name radarscp.zip size 18113 crc d902667f md5 5a6a1e4c68d6c232b0e83a12444f8f41 sha1 96d757bdb49ede9042a7a76422cab8afdc2cbb1f )
+)
+
+game (
+	name "Radar Scope (TRS01)"
+	year "1980"
+	developer "Nintendo"
+	rom ( name radarscp1.zip size 4755 crc 96bc2eda md5 887ea1fc5b19bb2e8e6a10d597dca174 sha1 8cc2bc248268d5aa5d328992d13532d580fd7c72 )
 )
 
 game (
@@ -30371,6 +33910,13 @@ game (
 )
 
 game (
+	name "Raiden"
+	year "1990"
+	developer "Seibu Kaihatsu"
+	rom ( name raiden.zip size 890877 crc 7c672f3b md5 669cf45efe5b51c7db1eab8789f50949 sha1 8f10a0788462eaef4207dc0f88f5887deee05812 )
+)
+
+game (
 	name "Raiden (Alternate Hardware)"
 	year "1990"
 	developer "Seibu Kaihatsu"
@@ -30417,6 +33963,13 @@ game (
 	year "1985"
 	developer "UPL (Taito license)"
 	rom ( name raiders5t.zip size 19666 crc 3feb7909 md5 08a048c1d9e591ac3c6525a774c746ad sha1 ff7fe2fc8f2290c45afa387d5d122a1d40ed342a )
+)
+
+game (
+	name "Raiga - Strato Fighter (Japan)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name raiga.zip size 90970 crc fa05c124 md5 71411a99eca13b295c9d12e018c0126c sha1 5f2b2a3fd5c7dc90b3494cfa3cf508c135dbbf92 )
 )
 
 game (
@@ -31008,6 +34561,13 @@ game (
 )
 
 game (
+	name "Redline Racer (2 players)"
+	year "1987"
+	developer "Cinematronics (Tradewest license)"
+	rom ( name redlin2p.zip size 224176 crc 6bd90636 md5 2cfcb235db4703cbf0031c01291909fc sha1 ef209a5e9639b1daec2d3e2225fec2fd121d7537 )
+)
+
+game (
 	name "Red Robin"
 	year "1986"
 	developer "Elettronolo"
@@ -31113,6 +34673,20 @@ game (
 )
 
 game (
+	name "Rescue Raider"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name rescraid.zip size 88433 crc 54a45f86 md5 51c4315790d606d28fd9c5505084ff7b sha1 2615969ae3be3cd8c6dbae0e95c7f4cb017fec63 )
+)
+
+game (
+	name "Rescue Raider (stand-alone)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name rescraida.zip size 64782 crc 04bbfbd9 md5 9a62a9d3858725482ae1e94f3a931f01 sha1 80dbf7cfbd6cfcd7f49551d26c9b34cea173fa83 )
+)
+
+game (
 	name "Rescue"
 	year "1982"
 	developer "Stern Electronics"
@@ -31131,6 +34705,13 @@ game (
 	year "2004"
 	developer "Igrosoft"
 	rom ( name resdnt_2a.zip size 61177 crc 01b2ff55 md5 148f0cfeb2f1b9a2532cf1b2f99e9277 sha1 f4fbecd7e3b49a45594c11b671acca1d7f359b75 )
+)
+
+game (
+	name "Return of the Invaders"
+	year "1985"
+	developer "Taito Corporation"
+	rom ( name retofinv.zip size 48110 crc bb87612b md5 d0701657e1065a099258b1d458176d14 sha1 974ec9619c55b83d3d767cf9a2b6051de8c9bab5 )
 )
 
 game (
@@ -31292,6 +34873,13 @@ game (
 	year "1986"
 	developer "Sega / Nasco"
 	rom ( name ridleofp.zip size 83575 crc 500bad17 md5 264dbc2fe17d03c3ebd7432f0b7f0718 sha1 40e7243ef98246dcf3695eddbc81d873a2152b47 )
+)
+
+game (
+	name "Rim Rockin' Basketball (V2.2)"
+	year "1991"
+	developer "Strata/Incredible Technologies"
+	rom ( name rimrockn.zip size 916426 crc c001d28e md5 55ad31a7f1d397e8c9c5ca557fe9a943 sha1 0c795b7ef4d65fec3ff6f7eaf58f59f71f48429d )
 )
 
 game (
@@ -31498,6 +35086,76 @@ game (
 )
 
 game (
+	name "Road Blasters (upright, rev 4)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst.zip size 514197 crc b2858160 md5 81ef78c9596849c649eb4986c827743f sha1 cbaea7041f946eb89bb309f3b266189b79b2f621 )
+)
+
+game (
+	name "Road Blasters (upright, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst1.zip size 83142 crc f1a10111 md5 cb13f6fcb42e7611e7eef987cf14a1ea sha1 88239713e5327780b8f7b1e469b3b8dfd263b948 )
+)
+
+game (
+	name "Road Blasters (upright, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst2.zip size 83121 crc 14bc50dc md5 1cc28a5f27240b240e295a35d3013bb3 sha1 4ee03a45918746bd189912d8890ffbc265cae630 )
+)
+
+game (
+	name "Road Blasters (upright, rev 3)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblst3.zip size 60681 crc e15fc37a md5 1aad3df920f5dc0505c7da8d865afcf9 sha1 0368aae45e4894837eaac78612d95b7824ca0780 )
+)
+
+game (
+	name "Road Blasters (cockpit, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstc.zip size 60678 crc 7b9bab57 md5 73a7d0db7e12455c8ee48473db190568 sha1 886c452e08a10417e7c9c854818724ab7361e2a1 )
+)
+
+game (
+	name "Road Blasters (cockpit, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstc1.zip size 60560 crc c8bbbf59 md5 c2f6e7fc1d9ce8f1392d9971d6b2c471 sha1 d798d6d3f30562fe6f782a673341aa5689463b37 )
+)
+
+game (
+	name "Road Blasters (cockpit, German, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstcg.zip size 59306 crc 69ccdbcb md5 587dd4380002514723afb273f5575566 sha1 111a2d1f22093fc4207c5569a5caa7f47dbea56f )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 3)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg.zip size 59485 crc 476d7141 md5 3ee54253a3f5797ef4ab23fa7de84aa8 sha1 b07807463216583b3ae05938a50712e7ba5baf6a )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 1)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg1.zip size 81896 crc 57be3fd5 md5 11fd778043b2f65261a70653b8733c7a sha1 2a7f50bc307edd8d346c3b00a55a3136247588ad )
+)
+
+game (
+	name "Road Blasters (upright, German, rev 2)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name roadblstg2.zip size 81933 crc ff848d95 md5 7505a0858ab3ae1867f1269106ab071b sha1 67c31374af3baccd113ae1b5d79597646e6fa5ea )
+)
+
+game (
 	name "Road Fighter (set 1)"
 	year "1984"
 	developer "Konami"
@@ -31516,6 +35174,27 @@ game (
 	year "1977"
 	developer "Midway"
 	rom ( name roadrunm.zip size 1489 crc 888752fc md5 469709a34c40db7ea4026fb49385c47d sha1 5dab5d53b159b09278e833d8ce72bb4cb8dbe2f0 )
+)
+
+game (
+	name "Road Runner (rev 2)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn.zip size 471093 crc 2fa8989e md5 05dc4eb45c0f4508c8dd4f5e4a04f1de sha1 81b9b72627d75fd328bc6f7f2ccfc26abe6eabcc )
+)
+
+game (
+	name "Road Runner (rev 1)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn1.zip size 55536 crc 52eafd44 md5 b077f661654b319a7ceea727057a1aba sha1 05909c35d1fabe7f0081dc37154d3a934d0f0918 )
+)
+
+game (
+	name "Road Runner (rev 1+)"
+	year "1985"
+	developer "Atari Games"
+	rom ( name roadrunn2.zip size 55499 crc 072c5d3e md5 d36dfd0f833ae8c05db57f4adf91c9ad sha1 836907639b6cb0bf3419a7418ae6a129e896f7d3 )
 )
 
 game (
@@ -31861,6 +35540,27 @@ game (
 )
 
 game (
+	name "MTV Rock-N-Roll Trivia (Part 2)"
+	year "1986"
+	developer "Triumph Software Inc."
+	rom ( name rocktrv2.zip size 142645 crc 5bd912da md5 9ee397b766436c2430d5e8324ef59ff8 sha1 eee89b219e1a69f8125126217bd3c00ec0fd4f75 )
+)
+
+game (
+	name "Roc'n Rope"
+	year "1983"
+	developer "Konami"
+	rom ( name rocnrope.zip size 50109 crc ec7750e3 md5 7375f0b315c719c55e24b014222e39a2 sha1 c081576af46aa5db220d9602923ac57918e02928 )
+)
+
+game (
+	name "Roc'n Rope (Kosuka)"
+	year "1983"
+	developer "Konami / Kosuka"
+	rom ( name rocnropek.zip size 23966 crc bf20a46b md5 98c2bade09d9fe021a62177c92abc377 sha1 524b740c31198196fb3b5a0aae5adb077e63222e )
+)
+
+game (
 	name "Rod-Land (World)"
 	year "1990"
 	developer "Jaleco"
@@ -32099,6 +35799,20 @@ game (
 )
 
 game (
+	name "Royal Card (Austrian, set 5)"
+	year "1991"
+	developer "TAB Austria"
+	rom ( name royalcrdd.zip size 19994 crc 98cef76a md5 f3aca49632276180b99ae05945508e9e sha1 e71d0fa355625ab9d18a910ea9282f1135b19a0a )
+)
+
+game (
+	name "Royal Card (Austrian, set 6)"
+	year "1991"
+	developer "TAB Austria"
+	rom ( name royalcrde.zip size 53430 crc 45d22a6f md5 0ea2a42bd0d7dc44b4b26ea1c4726089 sha1 72df27224707b1fc698f2fb9878fa9a79c8b3778 )
+)
+
+game (
 	name "Royal Mahjong (Falcon bootleg, v1.01)"
 	year "1982"
 	developer "bootleg"
@@ -32281,10 +35995,24 @@ game (
 )
 
 game (
+	name "R-Type (US)"
+	year "1987"
+	developer "Irem (Nintendo of America license)"
+	rom ( name rtypeu.zip size 116717 crc d5a7401b md5 ec6c00b10820711fef90f45049dbc361 sha1 09f79bddf8320b6c33224d72324b46389e77c340 )
+)
+
+game (
 	name "Rug Rats"
 	year "1983"
 	developer "Nichibutsu"
 	rom ( name rugrats.zip size 20720 crc e6cce946 md5 3120805a50f13592c3a40abf721c3845 sha1 7e9ad3c8e38217681f550961e8e5a0b6822cdaac )
+)
+
+game (
+	name "The Rumble Fish"
+	year "2004"
+	developer "Sammy / Dimps"
+	rom ( name rumblef.zip size 109652763 crc f7ce9f74 md5 2127b61a2605a7c975e370ea9322e323 sha1 90b9fe5a8af58793c6520861c842d9cb84295371 )
 )
 
 game (
@@ -32341,6 +36069,13 @@ game (
 	year "1986"
 	developer "Capcom"
 	rom ( name rushcrsh.zip size 89169 crc 55c339eb md5 205eae49a35c96fbcfb9a6cf256cd050 sha1 4f45afb79c56c4149556e14b1c588e72c1de8158 )
+)
+
+game (
+	name "Rushing Heroes (ver UAB)"
+	year "1996"
+	developer "Konami"
+	rom ( name rushhero.zip size 18700360 crc 5f0e56d2 md5 68e03a80143456f2d74ee73077a9b08f sha1 bfc9b6a8be19577b0a83cc755fa33ce3915e3e1f )
 )
 
 game (
@@ -32442,6 +36177,20 @@ game (
 )
 
 game (
+	name "Strikers 1945 (World)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945.zip size 5455851 crc 3531fb50 md5 d05941ecbabeacdc15dcdd46fc321f96 sha1 588e673cd5e486f53ef9e0b9c8e49f000981acae )
+)
+
+game (
+	name "Strikers 1945 (Japan / World)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945a.zip size 214324 crc 6cfa523f md5 da66f02c269ea24d0912df28cefcfa49 sha1 98621bae3735415a32f45b43a425917e42febdf7 )
+)
+
+game (
 	name "Strikers 1945 (Hong Kong, bootleg)"
 	year "1995"
 	developer "bootleg"
@@ -32463,10 +36212,24 @@ game (
 )
 
 game (
+	name "Strikers 1945 (Japan)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945j.zip size 214002 crc 6ee6c9f7 md5 fa195835f2119008ab2541ac17156b3e sha1 7f917dc657843af727d1a1eed8affa3aab857a84 )
+)
+
+game (
 	name "Strikers 1945 (Japan, unprotected)"
 	year "1995"
 	developer "Psikyo"
 	rom ( name s1945jn.zip size 1710590 crc bcd0a485 md5 c962b66e1e7c131987474dcbfd7b4771 sha1 376fe33fc5718ef4c97dfdec74fdf2128777e87a )
+)
+
+game (
+	name "Strikers 1945 (Korea)"
+	year "1995"
+	developer "Psikyo"
+	rom ( name s1945k.zip size 214163 crc 67f9f298 md5 65e3ceddd2aec884d36fde7c4dc38c90 sha1 5709b81dce52ee922c0a1cffd4300e2849175df1 )
 )
 
 game (
@@ -32610,6 +36373,13 @@ game (
 )
 
 game (
+	name "Sai Yu Gou Ma Roku (Japan)"
+	year "1988"
+	developer "Technos Japan"
+	rom ( name saiyugou.zip size 95396 crc ea2ac88d md5 d61361c1cd7865e2a851aa6dd9813f6b sha1 dbb720739e0d7f9e4acdcc3ce4c0d2b1ead2499a )
+)
+
+game (
 	name "Sai Yu Gou Ma Roku (Japan bootleg 1)"
 	year "1988"
 	developer "bootleg"
@@ -32642,6 +36412,27 @@ game (
 	year "1986"
 	developer "Konami"
 	rom ( name salamandj.zip size 66958 crc f61a6168 md5 6c8527d036d133006a013cb065f47739 sha1 2a2c96a751cb8f66fd8e8a1636b00fe0d1ab56d1 )
+)
+
+game (
+	name "Salary Man Champ (GCA18 VER. JAA)"
+	year "2000"
+	developer "Konami"
+	rom ( name salarymc.zip size 286 crc d62cd521 md5 cebda5b93cd25de919585476f56d3dfc sha1 f470e8ae1c606ea97ca4130caec9ff442396cebc )
+)
+
+game (
+	name "Same! Same! Same! (2 player alternating ver.)"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame.zip size 78015 crc 0138e552 md5 d2b44aebc267ca9b9c269f31d5bd4168 sha1 166f3ad0618219fdc19748a602cff4f628100e13 )
+)
+
+game (
+	name "Same! Same! Same!"
+	year "1989"
+	developer "Toaplan"
+	rom ( name samesame2.zip size 34348 crc 349722b8 md5 711f5813cac7e32f9cc90b2dc167ac0b sha1 9fb537d6d2e4f93256053239a83aaa163bbe440e )
 )
 
 game (
@@ -32785,6 +36576,13 @@ game (
 )
 
 game (
+	name "Sarge"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name sarge.zip size 84020 crc 19794f30 md5 c52f5e03f7c539c77f5ae573abd079a6 sha1 68d891cc01d5be32931f167816d040217b6924ed )
+)
+
+game (
 	name "Saru-Kani-Hamu-Zou (Japan)"
 	year "1997"
 	developer "Kaneko / Mediaworks"
@@ -32904,6 +36702,13 @@ game (
 )
 
 game (
+	name "Super Bike (DK conversion)"
+	year "1984"
+	developer "Century Electronics"
+	rom ( name sbdk.zip size 18655 crc 42f00b04 md5 aecfb0d96cf02d4c49c009dc75bdebe3 sha1 b1f1dfce136167969bb424017b7cb6febd972694 )
+)
+
+game (
 	name "Super Bishi Bashi Championship (ver JAA, 2 Players)"
 	year "1998"
 	developer "Konami"
@@ -32978,6 +36783,13 @@ game (
 	year "1990"
 	developer "UPL"
 	rom ( name sbsgomo.zip size 88789 crc 64f47fbf md5 e5aa60ec68e2cb17f928cd3d7f16ea8f sha1 afb973596d2ec669300b4588d55651f2b16e3cbd )
+)
+
+game (
+	name "Space Bugger (set 2)"
+	year "1981"
+	developer "Game-A-Tron"
+	rom ( name sbuggera.zip size 10503 crc ff44316a md5 158f0bb403fd99550773033e9c106f07 sha1 cd1284ebab71e263ab2c1fa866deec62451561f5 )
 )
 
 game (
@@ -33190,6 +37002,13 @@ game (
 )
 
 game (
+	name "Scramble (Karateko, French bootleg)"
+	year "1981"
+	developer "bootleg (Karateko)"
+	rom ( name scramblebf.zip size 10507 crc 3e19c751 md5 33662dc14a1db2f4c7e37a9d187db5af sha1 049c59f405652b6678677027af2c9596577709df )
+)
+
+game (
 	name "Scramble (Stern Electronics)"
 	year "1981"
 	developer "Konami (Stern Electronics license)"
@@ -33239,10 +37058,31 @@ game (
 )
 
 game (
+	name "SD Fighters (Korea)"
+	year "1996"
+	developer "SemiCom"
+	rom ( name sdfight.zip size 2085175 crc 5505567e md5 d2cb25ca81746b7e65625ae5cf718c9c sha1 0f0e20fdfdea9582edad5b3af05dead474a25d03 )
+)
+
+game (
 	name "SD Gundam Psycho Salamander no Kyoui"
 	year "1991"
 	developer "Banpresto / Bandai"
 	rom ( name sdgndmps.zip size 1492205 crc 21ef9783 md5 70ef6141c8748ed19dd38007d603a12e sha1 c9bcf42cf112266b541734945fa5dd7b99cbf89d )
+)
+
+game (
+	name "SDI - Strategic Defense Initiative (Japan, old, System 16A, FD1089B 317-0027)"
+	year "1987"
+	developer "Sega"
+	rom ( name sdi.zip size 366622 crc 558f377a md5 a60733a012c3a05cf0e53e069d138033 sha1 98a49da7b72a35b016dde057cdc9e325925adadc )
+)
+
+game (
+	name "SDI - Strategic Defense Initiative (System 16B, FD1089A 317-0028)"
+	year "1987"
+	developer "Sega"
+	rom ( name sdib.zip size 346417 crc 33614d07 md5 d344ae4318756a916a305fd35ed9e0a5 sha1 91fceca86437cff1d67f17f20494a56dbc079a2b )
 )
 
 game (
@@ -33449,6 +37289,13 @@ game (
 )
 
 game (
+	name "MuHanSeungBu (SemiCom Baseball) (Korea)"
+	year "1997"
+	developer "SemiCom"
+	rom ( name semibase.zip size 2020618 crc d21a9c65 md5 86efa50c202de62ebaf78f90c8338b71 sha1 cf9667d40a08b4300fac3d586afd101cc091ec3f )
+)
+
+game (
 	name "Sengeki Striker (Asia)"
 	year "1997"
 	developer "Kaneko / Warashi"
@@ -33526,6 +37373,13 @@ game (
 )
 
 game (
+	name "Sente Diagnostic Cartridge"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name sentetst.zip size 9743 crc 1f2628e4 md5 dd11377d68a60831abe5fd295f98f455 sha1 c869c65e11f2a466ed0ac268aa3889ba05f701e1 )
+)
+
+game (
 	name "Sex Triv"
 	year "1985"
 	developer "Status Games"
@@ -33561,6 +37415,13 @@ game (
 )
 
 game (
+	name "Street Fighter II: The World Warrior (World 910522)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2.zip size 3551675 crc 57aa0ffe md5 bd33f8bfe89c2c4270a398cb77545eee sha1 ad7d7527ff7b2c0b0b5e1f7acd6e4fcfda1fbd0f )
+)
+
+game (
 	name "Street Fighter II': Champion Edition (Accelerator!, bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -33575,6 +37436,41 @@ game (
 )
 
 game (
+	name "Street Fighter II': Champion Edition (World 920313)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ce.zip size 3615435 crc 8d0ac6df md5 db9414707a2fa816b05608251784d08b sha1 f6ebbc9926859f0ce68ee911a4433ae39dca86bf )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (Japan 920513)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2cej.zip size 317134 crc cc80d137 md5 c3ba95ae0737ae4a858d4ca749e4d9d0 sha1 d4e04e51f0819eba5cf7fb36e5debad9c75def10 )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920313)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceua.zip size 216255 crc f71e13aa md5 78f8a0eda0400dbb60a9c57e5742b02f sha1 ce39f08f30ff22b9e7e83ce9d24e008565e32224 )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920513)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceub.zip size 363103 crc dad249b7 md5 ddfa2f81b96351fa5e99c0f030ec0093 sha1 6b5042d7e8a75d695a017df241ec30006c4685e7 )
+)
+
+game (
+	name "Street Fighter II': Champion Edition (USA 920803)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2ceuc.zip size 362955 crc ccb8b5a1 md5 1c7a13b187b8e87260fd9b774a317425 sha1 a1c296a93c6b07f106c803b60c64301b1164aa9b )
+)
+
+game (
 	name "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)"
 	year "1992"
 	developer "bootleg"
@@ -33582,10 +37478,59 @@ game (
 )
 
 game (
+	name "Street Fighter II: The World Warrior (World 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2eb.zip size 256070 crc 8abc5736 md5 ba8c3606107b9d719fdda10c146e5fa9 sha1 b3cea133c1b6a4dbf7e44d41c8c63ca70f68357a )
+)
+
+game (
 	name "Street Fighter II: The World Warrior (TAB Austria, bootleg)"
 	year "1992"
 	developer "bootleg"
 	rom ( name sf2ebbl.zip size 543874 crc 1c00a370 md5 12ea3a3a9da040b855241662d9a06b1e sha1 3370fe737661215df359c9d70b0ad872e12b0ffa )
+)
+
+game (
+	name "Street Fighter II': Hyper Fighting (World 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hf.zip size 3640194 crc fe834e3b md5 aa753de798080d48044e4df1cbd2e44a sha1 d0bad63d0e4f81f59c1da149c04a7be3a2f8819d )
+)
+
+game (
+	name "Street Fighter II' Turbo: Hyper Fighting (Japan 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hfj.zip size 1176957 crc 978b0d3f md5 d46ac4450e96a202f2a822eeac3ca29c sha1 1b013ceedf1cdbf8cc05594a3aa6de8005f66817 )
+)
+
+game (
+	name "Street Fighter II': Hyper Fighting (USA 921209)"
+	year "1992"
+	developer "Capcom"
+	rom ( name sf2hfu.zip size 221040 crc 4414918c md5 50c8620191b68c35411b48878ee7776c sha1 1a25a61294ceadb1b5001ffbf431e30b785f62bc )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 911210)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2j.zip size 255151 crc 06ff1c9b md5 5db760246ca531e9dedc427dea4b924b sha1 7d14314a3945a67be907688cd662798c5821ce13 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ja.zip size 256074 crc c5fce120 md5 b61ee36c597001cf17b3292d1fbecc52 sha1 82905d405923ad523ced2e91bd25d1416b5f1e78 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (Japan 910306)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2jc.zip size 291881 crc 0763943a md5 3fe99898dcfe5553c42b691fdec7f653 sha1 b2992680acd02104edceeb28c3111b5c41158c04 )
 )
 
 game (
@@ -33670,6 +37615,55 @@ game (
 	year "1991"
 	developer "bootleg"
 	rom ( name sf2thndr.zip size 303854 crc 397e914c md5 0e05ce06afd0adc1ea0e9a71536a1e05 sha1 91705e6d595c3186210a589a499e5de148199c97 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910206)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ua.zip size 253615 crc 8c42bcce md5 e7edbdc4740aea0bb62f5400d0748b26 sha1 9f2a4690657f8cb741cae940bb6ccf642e5a763e )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910214)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ub.zip size 256074 crc f952565e md5 b1b10f16b83103db4610ee30a5e6613f sha1 99a735223473d8e025ae18e21c2a57f44be3c363 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910318)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ud.zip size 293176 crc d424eabb md5 a7dde65c64567ad98e8fd0b1008487fe sha1 499813bd9b4862006cdd80dbb9de00631bbc83af )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910228)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ue.zip size 279977 crc 71a2200e md5 cd124549e1f462e875e7c969302a3578 sha1 0a5849ca08f6e69102feafb2dc1e791d8ccf62c6 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910411)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2uf.zip size 189809 crc 86281160 md5 10e87910e9056399749a06523c0ca0b1 sha1 d844b03d5db16b99288bda0e086d523ade3a3d1c )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 910522)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2ui.zip size 219627 crc 84a10fa2 md5 8ae95d606903613dfb01372910db1078 sha1 5f22b26281bb8c513dad3b539e6d0d37f0828b67 )
+)
+
+game (
+	name "Street Fighter II: The World Warrior (USA 911101)"
+	year "1991"
+	developer "Capcom"
+	rom ( name sf2uk.zip size 303176 crc fc19c814 md5 36e98fa027f69e30e5c8fee021eec4ac sha1 5d3591af3991f1d1d04acf35e571bb272ef38c44 )
 )
 
 game (
@@ -33817,6 +37811,12 @@ game (
 	year "2003"
 	developer "Amcoe"
 	rom ( name sfbonusv1.zip size 194670 crc 67e49983 md5 7f2dae22c650be1aaa096665352f7f9a sha1 09e01f9f93070e8333769639346292af18e647f3 )
+)
+
+game (
+	name "Super Famicom Box BIOS"
+	developer "Nintendo"
+	rom ( name sfcbox.zip size 169903 crc f2b4ff71 md5 91a232669cbecff2a173b34864a57044 sha1 5994f7b224100b719db6834884db95527630704d )
 )
 
 game (
@@ -34002,6 +38002,13 @@ game (
 )
 
 game (
+	name "Street Fighter (Japan) (protected)"
+	year "1987"
+	developer "Capcom"
+	rom ( name sfj.zip size 146983 crc 3d4bd67b md5 3a76e17b0046b5f268075e7b1a68fc07 sha1 7795ae44f2ed059c69a7b1d40c19a753a4fbe306 )
+)
+
+game (
 	name "Super Free Kick (set 1)"
 	year "1988"
 	developer "Haesung/HJ Corp"
@@ -34012,6 +38019,13 @@ game (
 	name "Super Free Kick (set 2)"
 	developer "Haesung"
 	rom ( name sfkicka.zip size 28745 crc fdb24cef md5 5ac2a6e9118be41874c90b92071c9571 sha1 c38b616740cd99a15dcb016814b984358d03ae4c )
+)
+
+game (
+	name "Street Football"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name sfootbal.zip size 47005 crc c11807d3 md5 661d9363da39bfad6cd619f756d728e8 sha1 1004c2beb15ff2072b2dc72959fe82fcf96acbb7 )
 )
 
 game (
@@ -34173,6 +38187,13 @@ game (
 	year "1987"
 	developer "Capcom"
 	rom ( name sfu.zip size 55026 crc 4c7c1f01 md5 16b0ee257262d29ffc20add3f026dfff sha1 b2cf2dce4e709bcd8e75dad09303bd847142b652 )
+)
+
+game (
+	name "Street Fighter (US, set 2) (protected)"
+	year "1987"
+	developer "Capcom"
+	rom ( name sfua.zip size 54126 crc a297bdaf md5 c886d93a957fdb2cc78d2975e9df5e54 sha1 c4476e8e8c8984955a458ce41131f374f2060ec0 )
 )
 
 game (
@@ -34442,6 +38463,13 @@ game (
 )
 
 game (
+	name "Shackled (US)"
+	year "1986"
+	developer "Data East USA"
+	rom ( name shackled.zip size 277237 crc 45a28ff0 md5 9bd250cdae5b0a40bc4653c34e108e5b sha1 1c34a5e1383cb3fa9df92b23d2d3089d8aaba156 )
+)
+
+game (
 	name "Shadow Force (US Version 2)"
 	year "1993"
 	developer "Technos Japan"
@@ -34603,6 +38631,20 @@ game (
 )
 
 game (
+	name "Space Harrier (Rev A, 8751 315-5163A)"
+	year "1985"
+	developer "Sega"
+	rom ( name sharrier.zip size 755119 crc db78b1c2 md5 3ad5238a51d7455e4d84f475bec44f84 sha1 45247b44f4fb6d6c1e8f33cf8024ad0a564f0e79 )
+)
+
+game (
+	name "Space Harrier (8751 315-5163)"
+	year "1985"
+	developer "Sega"
+	rom ( name sharrier1.zip size 27415 crc 7ce84d71 md5 08fd260c5de8bc08e9cb55aa5ee21783 sha1 7d09dff6b9f0063e861aba16cbcd44761a858b51 )
+)
+
+game (
 	name "Shadow Dancer (bootleg)"
 	year "1989"
 	developer "bootleg"
@@ -34715,6 +38757,13 @@ game (
 )
 
 game (
+	name "Shinobi (Beta bootleg)"
+	year "1987"
+	developer "bootleg (Beta)"
+	rom ( name shinoblb.zip size 107868 crc 4f438e38 md5 9568abc407ca67cdbc40228260bfc4a5 sha1 0669c0fa5d8610eb64cc1aae6d6ee5207f7a782c )
+)
+
+game (
 	name "Shinobi (Star bootleg, System 16A)"
 	year "1987"
 	developer "bootleg (Star)"
@@ -34820,6 +38869,13 @@ game (
 )
 
 game (
+	name "Shooting Gallery"
+	year "1984"
+	developer "Seatongrove Ltd (Zaccaria license)"
+	rom ( name shootgal.zip size 18531 crc 16b5a427 md5 0af2f4fa102d9def57b9251fa318c84e sha1 7631ec033169132d0bfab8d7687a464289e394b5 )
+)
+
+game (
 	name "Shoot Out (US)"
 	year "1985"
 	developer "Data East USA"
@@ -34873,6 +38929,19 @@ game (
 	year "2000"
 	developer "Astro Corp."
 	rom ( name showhand.zip size 625050 crc dd38aa67 md5 7ef3866adb91b90400a947d92a7bb64d sha1 77f71905774a9a8bfb8d08972b32927972a028e8 )
+)
+
+game (
+	name "Shrike Avenger (prototype)"
+	developer "Bally/Sente"
+	rom ( name shrike.zip size 92846 crc c4ae135a md5 d8aa70cc6abdc529741cfa4533d6ec61 sha1 14ec599e7318f0c10cff76d158a2826fb2b924a0 )
+)
+
+game (
+	name "Shooting Master (EVG, 8751 315-5159a)"
+	year "1985"
+	developer "Sega / EVG"
+	rom ( name shtngmste.zip size 21468 crc cbedea74 md5 5695c2210a06c110b6e4b3f713dbf282 sha1 1f304cfda714187f2cab1d087a1875804276a2a0 )
 )
 
 game (
@@ -35002,10 +39071,24 @@ game (
 )
 
 game (
+	name "Side Pocket (World)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name sidepckt.zip size 89366 crc 38aa9b23 md5 81db4eb6bf15fe908e58d621e69bfc4a sha1 d6f6fe1dc698b311285a644082fd6e4c0dffb065 )
+)
+
+game (
 	name "Side Pocket (bootleg)"
 	year "1986"
 	developer "bootleg"
 	rom ( name sidepcktb.zip size 25428 crc 6fe2a7bb md5 cd6b61c6224d2de773fba0b1b7f71491 sha1 82ba6e14b85d8132c5dfbea0a8cdf55783987efb )
+)
+
+game (
+	name "Side Pocket (Japan)"
+	year "1986"
+	developer "Data East Corporation"
+	rom ( name sidepcktj.zip size 44298 crc d92f44ae md5 48d591c110f4c9e59dd53031ce2db788 sha1 c02790dcbcdf6e49b2b39111fe87a416d75d6b97 )
 )
 
 game (
@@ -35210,6 +39293,20 @@ game (
 )
 
 game (
+	name "Sukeban Jansi Ryuko (set 2, System 16B, FD1089B 317-5021)"
+	year "1988"
+	developer "White Board"
+	rom ( name sjryuko.zip size 383635 crc 7ee5f1ad md5 425d150e3b3d0a6da11d0046c5605cb8 sha1 39f19483527ae8431717409c1193f99d2423c339 )
+)
+
+game (
+	name "Sukeban Jansi Ryuko (set 1, System 16A, FD1089B 317-5021)"
+	year "1987"
+	developer "White Board"
+	rom ( name sjryuko1.zip size 142741 crc df5140fa md5 db5d33989fc76a664bebf1443fb1e5bb sha1 a9e889883e0048dff7ab5352f5487a386076e6a3 )
+)
+
+game (
 	name "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)"
 	year "1988"
 	developer "hack"
@@ -35235,6 +39332,27 @@ game (
 	year "1996"
 	developer "Kyle Hodgetts / ICE"
 	rom ( name skimaxx.zip size 3208270 crc ea532447 md5 ab34b55b17aac77ece11589085c3d624 sha1 48733de55503ddf0ae78fdbfbe6880adf87f806d )
+)
+
+game (
+	name "The Irem Skins Game (US set 1)"
+	year "1992"
+	developer "Irem America"
+	rom ( name skingame.zip size 199014 crc 81f8be86 md5 94eb6da53658dafbae837c5ae425b2a3 sha1 dfcd728ab3f176ce5db8b8359616e64e78b00535 )
+)
+
+game (
+	name "The Irem Skins Game (US set 2)"
+	year "1992"
+	developer "Irem America"
+	rom ( name skingame2.zip size 198907 crc b0f21e80 md5 0f50d8d340e62e246d92de07dac78c97 sha1 a6b0ebf66fe7e8f48880ace626cad102053f3226 )
+)
+
+game (
+	name "Super Kaneko Nova System BIOS"
+	year "1996"
+	developer "Kaneko"
+	rom ( name skns.zip size 783788 crc 5b7a6095 md5 ecd315d48f3da12eef14f83a534ecb7f sha1 4ff6c5806428e47311ec2779acbe44c600b19bca )
 )
 
 game (
@@ -35490,6 +39608,20 @@ game (
 )
 
 game (
+	name "Saturday Night Slam Masters (World 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name slammast.zip size 6588432 crc eaac25c5 md5 2469cc51ea42952fd4338b38cc2028cf sha1 19d6bbeaf734d6823dc40759a45c49c9e1287bd3 )
+)
+
+game (
+	name "Saturday Night Slam Masters (USA 930713)"
+	year "1993"
+	developer "Capcom"
+	rom ( name slammastu.zip size 367604 crc 18415bad md5 a538889c3c6caf88d57d824e2fc37c83 sha1 a28fb9c1604ceabe61df6ec9ae18ba8809132a96 )
+)
+
+game (
 	name "Slap Fight (Japan set 1)"
 	year "1986"
 	developer "Toaplan / Taito"
@@ -35571,6 +39703,13 @@ game (
 	year "1982"
 	developer "Century II"
 	rom ( name slithera.zip size 2993 crc fb8d6661 md5 cfc0708cd7a1437b9a71ff2e755123fb sha1 f1fe350e84fd5a7c8ee9a9148ede1fe0f1770dfb )
+)
+
+game (
+	name "Sliver"
+	year "1996"
+	developer "Hollow Corp"
+	rom ( name sliver.zip size 15501022 crc bfedd29a md5 b42445d774b2363ce4489831904bd30d sha1 0a7166de4c540469039e4c8212620faa6624acca )
 )
 
 game (
@@ -35790,6 +39929,20 @@ game (
 )
 
 game (
+	name "Snake Pit"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name snakepit.zip size 47841 crc c80ebdf2 md5 e417dfa224b1616022e24a8aa01a242d sha1 d42a855cdd14396e58a6c80197b7942557140b9c )
+)
+
+game (
+	name "Snacks'n Jaxson"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name snakjack.zip size 59038 crc c5beec9a md5 59d0aa1101542d25ba5f2a8c51f6363e sha1 9ddee21b0c7b433db72b035a6729494e229ae0bd )
+)
+
+game (
 	name "Snap Jack"
 	year "1982"
 	developer "Universal"
@@ -35836,6 +39989,13 @@ game (
 	year "1990"
 	developer "Toaplan"
 	rom ( name snowbros.zip size 289681 crc af8a4129 md5 216801a573f1a29d3a051af3ae4e6651 sha1 c3bdfa5acd020f201cdd17a8466e3a55074043c7 )
+)
+
+game (
+	name "Snow Brothers 3 - Magical Adventure"
+	year "2002"
+	developer "Syrmex"
+	rom ( name snowbros3.zip size 2094016 crc b351a896 md5 f7c9f7d6856e0e7c6ea252e06341890a sha1 ef2d4ed4ce58f46d72e72f3df2ad3c99b91f2be6 )
 )
 
 game (
@@ -36252,6 +40412,20 @@ game (
 )
 
 game (
+	name "Space Invaders DX (US, v2.1)"
+	year "1994"
+	developer "Taito Corporation"
+	rom ( name spacedx.zip size 530613 crc 4d8b0176 md5 ec93c383cea9e6e9ad496bd3931a1d99 sha1 a679c33fd0e56e9a7319dcfeb0de14e1e83b9374 )
+)
+
+game (
+	name "Space Invaders DX (Japan, v2.1)"
+	year "1994"
+	developer "Taito Corporation"
+	rom ( name spacedxj.zip size 33598 crc 303cfc30 md5 2efce96351cde72b3b5deeed47c9d718 sha1 4fbfc2ec082267b0ebde7536708f03a1ba1dccdc )
+)
+
+game (
 	name "Space Invaders DX (Japan, v2.0)"
 	year "1994"
 	developer "Taito Corporation"
@@ -36308,6 +40482,13 @@ game (
 )
 
 game (
+	name "Space Fortress (Zaccaria)"
+	year "1981"
+	developer "Cinematronics (Zaccaria license)"
+	rom ( name spaceftr.zip size 7223 crc 23286c41 md5 01c9737834be7bec1583ecdb93b36ca0 sha1 dd97799cfe4b7dac3c0e61ffc3dfcfe7ca0788ac )
+)
+
+game (
 	name "Space Gun (World)"
 	year "1990"
 	developer "Taito Corporation Japan"
@@ -36319,6 +40500,13 @@ game (
 	year "1980"
 	developer "bootleg"
 	rom ( name spacempr.zip size 10632 crc eb28d03c md5 fc895a8fac0640f00b091700402c5e2e sha1 4ac4048f257b4377ad60d4359ad39fcd6764682e )
+)
+
+game (
+	name "Space Odyssey (version 2)"
+	year "1981"
+	developer "Sega"
+	rom ( name spaceod.zip size 39895 crc 2b6e33cd md5 d369ad29c3790e31bfc7604feaa1847a sha1 5535f92d7319d7f375dd483d7b44b185b6cadfd2 )
 )
 
 game (
@@ -36579,6 +40767,13 @@ game (
 )
 
 game (
+	name "Super Dodge Ball (US)"
+	year "1987"
+	developer "Technos Japan"
+	rom ( name spdodgeb.zip size 323661 crc c8b1ea9e md5 c229d7424411bb2dc5ad732ac2ef9024 sha1 f797cc4616c2261fe46258e75ee3962a9105e038 )
+)
+
+game (
 	name "Speak _ Rescue"
 	year "1980"
 	developer "Sun Electronics"
@@ -36628,6 +40823,13 @@ game (
 )
 
 game (
+	name "Speed Racer"
+	year "1995"
+	developer "Namco"
+	rom ( name speedrcr.zip size 9287692 crc eba41560 md5 943d9ad476028ef62bebe04f516b2f7d sha1 d482c59d1f2b4df647e9f365fbfd407f7f68178e )
+)
+
+game (
 	name "Speed Spin"
 	year "1994"
 	developer "TCH"
@@ -36646,6 +40848,13 @@ game (
 	year "1994"
 	developer "Seta"
 	rom ( name speglsht.zip size 3383092 crc 6e79fdfe md5 95d0d2fc3a17549b628961237717215c sha1 773ea02919112f086112d16b787499c167765565 )
+)
+
+game (
+	name "Spelunker II"
+	year "1986"
+	developer "Irem (licensed from Broderbund)"
+	rom ( name spelunk2.zip size 136512 crc 1d55ade1 md5 f86b5da1428876751fd4058baaf27fff sha1 7037d6dc98ac44b459618c68681e7285ed3088cf )
 )
 
 game (
@@ -36740,10 +40949,38 @@ game (
 )
 
 game (
+	name "Spiker"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name spiker.zip size 45190 crc b52b754c md5 a31652f7218a675a8a66a5b52610c0af sha1 b61500e0ac1c9e54e48f1744fa13e917988de3d2 )
+)
+
+game (
 	name "Hec's Spinkick"
 	year "1988"
 	developer "Haesung/Seojin"
 	rom ( name spinkick.zip size 5504 crc 3dfb9936 md5 e5648cffe46881080952e3c958206844 sha1 3784962b657f7aacb960d0e0ad6b47cdbe06eb42 )
+)
+
+game (
+	name "Spinal Breakers (World)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrk.zip size 2303016 crc 994052e9 md5 e3950ffff9a6cbc34732de0ded28b045 sha1 4d32fe5c59cab1cec21c6d865bb91eb7cd6e502a )
+)
+
+game (
+	name "Spinal Breakers (Japan)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrkj.zip size 112995 crc c2c8f350 md5 e778a8912febca423e03a79d9242d12e sha1 b155e841c15c4f0e0cfe099ca56df47cdd517adc )
+)
+
+game (
+	name "Spinal Breakers (US)"
+	year "1990"
+	developer "V-System Co."
+	rom ( name spinlbrku.zip size 113088 crc a9dec94a md5 00a71ea4f02c6f0529ee82f50cc93630 sha1 da4c38112254c17befd76489f537514541efa11a )
 )
 
 game (
@@ -36934,6 +41171,13 @@ game (
 )
 
 game (
+	name "Sprint 4 (set 2)"
+	year "1977"
+	developer "Atari"
+	rom ( name sprint4a.zip size 509 crc bcf61846 md5 04b348f9aa230ac2318a550740d4d915 sha1 8e62b7c56c8c0361145f886767499254591a7b0d )
+)
+
+game (
 	name "Sprint 8"
 	year "1977"
 	developer "Atari"
@@ -36976,6 +41220,20 @@ game (
 )
 
 game (
+	name "Spy Hunter 2 (rev 2)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name spyhunt2.zip size 363056 crc 4e509b2d md5 16df0f6b79f2dc33d9d17257bfc7b0ba sha1 c14de08325340a1b6e66eafffbe13472df90c883 )
+)
+
+game (
+	name "Spy Hunter 2 (rev 1)"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name spyhunt2a.zip size 98743 crc eb5159b5 md5 c8e360ebb227e16000265838b4d80d1b sha1 bc35f2ca8d68fc49f97ae780409e56ee1d1ec9cb )
+)
+
+game (
 	name "Spy Hunter (Playtronic license)"
 	year "1983"
 	developer "Bally Midway"
@@ -36997,10 +41255,31 @@ game (
 )
 
 game (
+	name "Super Qix (World, Rev 2)"
+	year "1987"
+	developer "Taito"
+	rom ( name sqix.zip size 141696 crc dd4aa61b md5 c47f4c5d2101b115c016578ebe176d48 sha1 1e0e268a3ce841201ca70f8f4d7603539cedf976 )
+)
+
+game (
+	name "Super Qix (bootleg set 1)"
+	year "1987"
+	developer "bootleg"
+	rom ( name sqixb1.zip size 76513 crc e2bfcb17 md5 f90051b01cfbd8987fd60d707ced3415 sha1 15892736a5954b6889485833cd6843385d6160ba )
+)
+
+game (
 	name "Super Qix (bootleg set 2)"
 	year "1987"
 	developer "bootleg"
 	rom ( name sqixb2.zip size 76558 crc 2614603a md5 a6d56a5f1d4781669fc38e75ca6c87c4 sha1 1a18f007b6b573f4d2e30b6ee43601fe6030b19e )
+)
+
+game (
+	name "Super Qix (World, Rev 1)"
+	year "1987"
+	developer "Taito"
+	rom ( name sqixr1.zip size 20168 crc 545d2083 md5 532f281881632c039a2ac36121bcfe27 sha1 32a927f50777e4a648c58aa853734b9de866dd7f )
 )
 
 game (
@@ -37039,10 +41318,31 @@ game (
 )
 
 game (
+	name "Super Ranger (bootleg)"
+	year "1988"
+	developer "bootleg"
+	rom ( name srangerb.zip size 30575 crc ea4c8e74 md5 2f4231a0dc32b9757586eb0880f2922d sha1 5a5c3fd120c9ea5d83add331738da210ee3e506a )
+)
+
+game (
 	name "Super Ranger (WDK)"
 	year "1988"
 	developer "SunA (WDK license)"
 	rom ( name srangerw.zip size 34106 crc dae55d70 md5 f5044e9586cb03b50cd5975ec3926e86 sha1 ea6467d2529182425702cd1fb0e9ffa0e03dace5 )
+)
+
+game (
+	name "Super Real Darwin (World)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name srdarwin.zip size 191667 crc f5949dc6 md5 d3838f3c994a0c72ac9053308cd92ba3 sha1 f2fb0d3b28e230ed5d846b94d97f9674d8991cc7 )
+)
+
+game (
+	name "Super Real Darwin (Japan)"
+	year "1987"
+	developer "Data East Corporation"
+	rom ( name srdarwinj.zip size 37223 crc 0c4a984d md5 a6f38b0b504112176eb7f85a781042df sha1 5decf55d3901a3247897e754dff12bc21072421c )
 )
 
 game (
@@ -37351,6 +41651,41 @@ game (
 	year "1996"
 	developer "SNK"
 	rom ( name ssideki4.zip size 13639446 crc 1b1dd29d md5 720e7deaf1b366661c1c990fd951225b sha1 34eef51a9cbe0addb4f342fd871c101eb69d50a3 )
+)
+
+game (
+	name "SSI Poker (v2.4)"
+	year "1988"
+	developer "SSI"
+	rom ( name ssipkr24.zip size 11818 crc a87dc911 md5 ed34f9f2aec532a0bf20b156f7ab2ea9 sha1 715c7ef9cdd73edefc95fdf6dfbdbeb2679eb61f )
+)
+
+game (
+	name "SSI Poker (v3.0)"
+	year "1988"
+	developer "SSI"
+	rom ( name ssipkr30.zip size 8046 crc fe67cc99 md5 cbb0f979a1cb8425bbf63be23fc9daca sha1 5fd4e62523a05f1e964c6794a3d06f5c1fb83ad8 )
+)
+
+game (
+	name "SSI Poker (v4.0)"
+	year "1990"
+	developer "SSI"
+	rom ( name ssipkr40.zip size 8200 crc f404b4ef md5 a87b9ddd92c2f601e7eee224158aad23 sha1 22eac07b9f91e55e658294729270e33c569fca40 )
+)
+
+game (
+	name "Super Slam (set 1)"
+	year "1993"
+	developer "Playmark"
+	rom ( name sslam.zip size 1566942 crc 96bd8f82 md5 11784419dbd4e8c640d3fde16f9d0cc5 sha1 176ec29bba753504f650c42983a6ba4d6135c43b )
+)
+
+game (
+	name "Super Slam (set 2)"
+	year "1993"
+	developer "Playmark"
+	rom ( name sslama.zip size 230992 crc 9a0eaca8 md5 5ef1e67bc6440b2d206ff2ec2d1456c0 sha1 29e2ccf3d9374b6c5718cfe93fe9745aba241531 )
 )
 
 game (
@@ -37781,10 +42116,59 @@ game (
 )
 
 game (
+	name "Triv Two"
+	year "1984"
+	developer "Status Games"
+	rom ( name statriv2.zip size 45382 crc 0c078504 md5 19cbb783850310f2f78db5b7637d1615 sha1 2b120b68ab9ddae04be493fb7f5d6034609702b0 )
+)
+
+game (
+	name "Triv Two (Vertical)"
+	year "1985"
+	developer "Status Games"
+	rom ( name statriv2v.zip size 7177 crc 5eff9411 md5 ec65dcaa7c268fc29335def050665b24 sha1 d5f36ae0026e1c8ef1637a1ad31e482b851d5223 )
+)
+
+game (
 	name "Triv Four"
 	year "1985"
 	developer "Status Games"
 	rom ( name statriv4.zip size 39111 crc 76f31bee md5 4b8aa025fe9d375e41cc671f1d23cd77 sha1 7bca244ff295b37bbff85cb8bbc9b75bc8ec9d9f )
+)
+
+game (
+	name "Status Black Jack (V1.0c)"
+	year "1981"
+	developer "Status Games"
+	rom ( name statusbj.zip size 3839 crc cdcaf335 md5 ceb1523bfb87b5a0965aaf9a58cb6a24 sha1 7052b932a1e69a1f726aaa78f7413da71b75c8a9 )
+)
+
+game (
+	name "Saint Dragon"
+	year "1989"
+	developer "Jaleco"
+	rom ( name stdragon.zip size 1062881 crc 4f83a544 md5 723158a4333a189deea1815d2f2711cc sha1 38fbd713ff16f5b9e20c6823c22e37be76f8e8cc )
+)
+
+game (
+	name "Steel Talons (rev 2)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltal.zip size 884903 crc eb4e4899 md5 fa774768b7da0e3cc49e6b21d293803d sha1 008617283017d2ac1d8f7342914429d854860ea8 )
+)
+
+game (
+	name "Steel Talons (rev 1)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltal1.zip size 168442 crc d3b90387 md5 07fad88a2c3b9a1e44b2dc9cc7b4861d sha1 f744e66017497ed82415894783c347a936f07c86 )
+)
+
+game (
+	name "Steel Talons (German, rev 2)"
+	year "1991"
+	developer "Atari Games"
+	rom ( name steeltalg.zip size 129256 crc 9b89e124 md5 bcc28b385a780028b62fdd32d1073112 sha1 7abae740942e75c8cedbabebb79ee2303b135c75 )
 )
 
 game (
@@ -37879,10 +42263,24 @@ game (
 )
 
 game (
+	name "Stocker (3/19/85)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name stocker.zip size 31209 crc a30d8761 md5 32be5430265d8c249cad8aaee37dbb32 sha1 7f644a7791dea5f1de73ed9c839f7a6f389e0d66 )
+)
+
+game (
 	name "Super Toffy"
 	year "1994"
 	developer "Midas (Unico license)"
 	rom ( name stoffy.zip size 90206 crc ee570a87 md5 382ee5be81efba1a58962c90877e3b0b sha1 0419f36244006a8a8efe1d749c778902c9b7904f )
+)
+
+game (
+	name "Stompin'"
+	year "1986"
+	developer "Bally/Sente"
+	rom ( name stompin.zip size 73853 crc 86d55893 md5 afa597b863c1a6d4f6af12b00c83007a sha1 2737564d455b1b1005e1d13ca30e8cc247dc3127 )
 )
 
 game (
@@ -37956,6 +42354,13 @@ game (
 )
 
 game (
+	name "Raiga - Strato Fighter (US)"
+	year "1991"
+	developer "Tecmo"
+	rom ( name stratof.zip size 765614 crc 8f8eeb77 md5 b807ddf5f773fab5d4562a01483fe347 sha1 6604af0005d53084337bdaaca896443d940da782 )
+)
+
+game (
 	name "Stratovox"
 	year "1980"
 	developer "Sun Electronics (Taito license)"
@@ -37974,6 +42379,13 @@ game (
 	year "1981"
 	developer "Shoei"
 	rom ( name streakng.zip size 14508 crc 2632d722 md5 4fcfb82fc2bdf670f924d2705b9bfd22 sha1 ebd63282f807849413024a1ce2d1d6452d78bda8 )
+)
+
+game (
+	name "Street Smart (US version 2)"
+	year "1989"
+	developer "SNK"
+	rom ( name streetsm.zip size 1327100 crc 1a2401bc md5 dfa1f446839bb27e10662348477175e2 sha1 3c5643e6c006bfdd2284869f49391cb1918c54a8 )
 )
 
 game (
@@ -38037,6 +42449,20 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name striderj.zip size 1849125 crc 9234de69 md5 e8eae3647e60b50b3e78a9e1398a5f13 sha1 35c3a849b5343ce4ed27f52bf9726ad359e5ec1a )
+)
+
+game (
+	name "Strider Hiryu (Japan Resale Ver.)"
+	year "1989"
+	developer "Capcom"
+	rom ( name striderjr.zip size 239008 crc 1978f905 md5 8ab0b831dd9c0bd31ed9a45971e2ad8c sha1 c72bcd017d9519ef4a4301203c988146d8e6e2dc )
+)
+
+game (
+	name "Strider (USA, set 2)"
+	year "1989"
+	developer "Capcom"
+	rom ( name striderua.zip size 234534 crc e0093246 md5 2995861459763a1253523ff85452f692 sha1 1548a7626e6b30737a82910db5f17fa5b959c5b3 )
 )
 
 game (
@@ -38166,6 +42592,13 @@ game (
 )
 
 game (
+	name "ST-V Bios"
+	year "1996"
+	developer "Sega"
+	rom ( name stvbios.zip size 2699265 crc 9faf9397 md5 f7c34fed7fa3252a1ed1bc4d1ea855ab sha1 d3360dd4a8aa7fcc6ce674237810496c1f2605d6 )
+)
+
+game (
 	name "Submarine"
 	year "1985"
 	developer "Sigma Enterprises Inc."
@@ -38198,6 +42631,13 @@ game (
 	year "1984"
 	developer "Data Amusement"
 	rom ( name sucasino.zip size 23891 crc 3c510a27 md5 d6d737a8aaf8ca312e060935d39dd06e sha1 ea4d495f3962ff558005c527bf6ac7304e7154d5 )
+)
+
+game (
+	name "Idol Janshi Suchie-Pai Special (Japan)"
+	year "1993"
+	developer "Jaleco"
+	rom ( name suchipi.zip size 1947280 crc 4045e520 md5 c2b8676b68ea4fb23c893aec2942d32e sha1 e03450ff802dc0d85b3e548b43b70ef7251193f0 )
 )
 
 game (
@@ -38361,6 +42801,13 @@ game (
 )
 
 game (
+	name "Super Triv II"
+	year "1986"
+	developer "Status Games"
+	rom ( name supertr2.zip size 143384 crc 319fb964 md5 12e9453390bf5f76ac1a321cb7f689ab sha1 2d8660d9b2054181ad4c4be19056019c6648312b )
+)
+
+game (
 	name "Super Triv III"
 	year "1988"
 	developer "Status Games"
@@ -38473,6 +42920,13 @@ game (
 )
 
 game (
+	name "Super Poker"
+	year "1987"
+	developer "Greyhound Electronics"
+	rom ( name suprpokr.zip size 19252 crc a0507132 md5 4780436f8210edd78fe634619b82e14e sha1 172248ace518f00bf3cf303e761d2f0c531241fb )
+)
+
+game (
 	name "Super Rider"
 	year "1983"
 	developer "Venture Line (Taito Corporation license)"
@@ -38582,6 +43036,20 @@ game (
 	year "1993"
 	developer "Namco"
 	rom ( name suzuk8h2.zip size 3491123 crc ea0ed660 md5 3dd4a9e5b2ac0577be672f3e593f870e sha1 059d5fee3e77eda0c9c384a6d665a4bbcf8fb37c )
+)
+
+game (
+	name "Suzuka 8 Hours (World)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8h.zip size 2189192 crc 939be6f9 md5 4ee129d4893d4bb9168d1d55fa590c19 sha1 01a7738fb337cd90a417891fb03174eb8ac73118 )
+)
+
+game (
+	name "Suzuka 8 Hours (Japan)"
+	year "1992"
+	developer "Namco"
+	rom ( name suzuka8hj.zip size 253079 crc 81cb8614 md5 7bd7445a6ccb450d4395e983b663e450 sha1 9a2c7e66d23af7264457c6c43ca0907d1d831ad6 )
 )
 
 game (
@@ -38858,6 +43326,13 @@ game (
 )
 
 game (
+	name "System 573 BIOS"
+	year "1998"
+	developer "Konami"
+	rom ( name sys573.zip size 63328 crc 695dd76d md5 07fe45624cbf62d00e3cefb88770c6c4 sha1 9d2f6da3639a789a5ab53b6010670c39ed6941f7 )
+)
+
+game (
 	name "Syvalion (Japan)"
 	year "1988"
 	developer "Taito Corporation"
@@ -38914,6 +43389,20 @@ game (
 )
 
 game (
+	name "Taito FX1"
+	year "1995"
+	developer "Sony / Taito"
+	rom ( name taitofx1.zip size 126182 crc 4471e5f0 md5 b44109eaca346b3d551c0a8154e6dfcb sha1 0001b8cc0e8b7f51aa307d437d588c4cd0860ea1 )
+)
+
+game (
+	name "Taito GNET"
+	year "1997"
+	developer "Sony / Taito"
+	rom ( name taitogn.zip size 331520 crc fbb9031b md5 07896f33c00e61adb616110c5b5ae85e sha1 52c1b8d283bc0ebea277d1f58376b09fd98a0a04 )
+)
+
+game (
 	name "Taiwan Mahjong [BET] (Japan 881208)"
 	year "1988"
 	developer "Miki Syouji"
@@ -38946,6 +43435,13 @@ game (
 	year "1992"
 	developer "Microprose Games Inc."
 	rom ( name tankbatl.zip size 1469310 crc 19d31524 md5 b77cf3ec5384cb1be990aa3117dc887f sha1 14ef2a8a83b9c458fa5807d9da1121205a19d524 )
+)
+
+game (
+	name "Tank Battalion"
+	year "1980"
+	developer "Namco"
+	rom ( name tankbatt.zip size 8337 crc 00986b0a md5 f8b6eb6c292289525fdd0165de9fea7a sha1 0d7893c13f8f6ad6759a385e84538e48add6c094 )
 )
 
 game (
@@ -39439,10 +43935,45 @@ game (
 )
 
 game (
+	name "Tengai (World)"
+	year "1996"
+	developer "Psikyo"
+	rom ( name tengai.zip size 6500431 crc 99b98f75 md5 91470b32675430f13f0892416163e6e8 sha1 93d82339ea7ce82efca9903c1275e477d57ab41c )
+)
+
+game (
+	name "Sengoku Blade: Sengoku Ace Episode II / Tengai"
+	year "1996"
+	developer "Psikyo"
+	rom ( name tengaij.zip size 297798 crc 51bb8e58 md5 7bf9df9b4fa74ad36a4fb984381ce86a sha1 d7c9bb4651598d6f8609d5deed41aeff265ac1fe )
+)
+
+game (
+	name "Mahjong Tenkaigen"
+	year "1991"
+	developer "Dynax"
+	rom ( name tenkai.zip size 659684 crc fcec3b2f md5 3641deb99edda5b8ca3248f2777594ba sha1 8e04089a44b491a9c0101d647621737cf9aefe51 )
+)
+
+game (
 	name "Mahjong Tenkaigen (bootleg b)"
 	year "1991"
 	developer "bootleg"
 	rom ( name tenkaibb.zip size 945247 crc 66dd10f2 md5 7af84111bb794a1342469f0cbc3842f2 sha1 4f7ce77d2efb320068fd16f5fe2946267388022c )
+)
+
+game (
+	name "Mahjong Tenkaigen (bootleg c)"
+	year "1991"
+	developer "bootleg"
+	rom ( name tenkaicb.zip size 80524 crc 751f4626 md5 0ea21274f71cb805ca0a22dce55aaf70 sha1 dc223d4874baa079207de6e3e97006a76ddeedfd )
+)
+
+game (
+	name "Mahjong Tenkaigen (set 2)"
+	year "1991"
+	developer "Dynax"
+	rom ( name tenkaie.zip size 847594 crc 7b10b97f md5 776ef6a648571dab8fb804eaccdcdf56 sha1 8e4f1b2075f9b69bea6804ae6f11d33aba77c08a )
 )
 
 game (
@@ -39562,6 +44093,13 @@ game (
 	year "1988"
 	developer "bootleg"
 	rom ( name tetrisbl.zip size 157595 crc 73a78a78 md5 47ef06ec0038db552c7c656b5e6cf482 sha1 7854c81dc8cea10631a549bdc5017db779c766f9 )
+)
+
+game (
+	name "Tetris Plus"
+	year "1995"
+	developer "Jaleco / BPS"
+	rom ( name tetrisp.zip size 6027113 crc 54bf037e md5 05ec2410c2f1b1f56d1279f4e8de563a sha1 231158a02fa8d0e83b1fd6efb2cd901c8e8d63d5 )
 )
 
 game (
@@ -39850,6 +44388,13 @@ game (
 )
 
 game (
+	name "Thunder Zone (World)"
+	year "1991"
+	developer "Data East Corporation"
+	rom ( name thndzone.zip size 3794222 crc 1d67a46f md5 ec0585515c5eb4211a014e33544a1956 sha1 f305256f620f2e2269665c99963e7c9810a7a8a6 )
+)
+
+game (
 	name "Thunder Hoop (Ver. 1)"
 	year "1992"
 	developer "Gaelco"
@@ -39945,6 +44490,13 @@ game (
 	year "1985"
 	developer "Merit"
 	rom ( name tictac.zip size 303266 crc 3160560e md5 99af7aa8dd87c4a2065f943bffe2036d sha1 5c0970df2883ea55b6c64affa1fad09a32458e1a )
+)
+
+game (
+	name "Tiger Heli (US)"
+	year "1985"
+	developer "Toaplan / Taito America Corp."
+	rom ( name tigerh.zip size 96861 crc 4c52aad7 md5 cfc2d493bc5a6f7a36c76afbe1769d99 sha1 d713c1d82f1abd5daefcf5d0e23e9832499efae0 )
 )
 
 game (
@@ -40088,6 +44640,13 @@ game (
 )
 
 game (
+	name "Time Limit"
+	year "1983"
+	developer "Chuo Co. Ltd"
+	rom ( name timelimt.zip size 30735 crc ab5d8029 md5 4900b18bbc18c1372774dddcd14d612a sha1 4ed28ebba9f744637ad42c722e6bf1bb79593701 )
+)
+
+game (
 	name "Time Pilot"
 	year "1982"
 	developer "Konami"
@@ -40113,6 +44672,13 @@ game (
 	year "1987"
 	developer "Sega"
 	rom ( name timescan.zip size 253547 crc acc0c3dc md5 d3c3e93cc80de3421c3df5c48eeae066 sha1 4ba5295a28bc21d14f05f59380532c117b1f9f41 )
+)
+
+game (
+	name "Time Scanner (set 1, System 16A, FD1089B 317-0024)"
+	year "1987"
+	developer "Sega"
+	rom ( name timescan1.zip size 181726 crc c14f93e0 md5 0eeee068e46bf19860f3d6e5ca7ab632 sha1 85eae90fa2e012de69afa2ab60537c89e4bea3ff )
 )
 
 game (
@@ -40193,10 +44759,38 @@ game (
 )
 
 game (
+	name "Tobikose! Jumpman"
+	year "1999"
+	developer "Namco"
+	rom ( name tjumpman.zip size 488609 crc fe8d20b5 md5 5b5ca2c2d8074c26b318e684bbd1b31c sha1 8c345ded4f9a8630682630cf4811c7e4cd683fc6 )
+)
+
+game (
+	name "Touki Denshou -Angel Eyes- (VER. 960614)"
+	year "1996"
+	developer "Tecmo"
+	rom ( name tkdensho.zip size 14423230 crc de83cd11 md5 1ec081f1b50c0562533d4ddfa841bf10 sha1 b014cdbfd63b739561ff9feb0cf580f613c68209 )
+)
+
+game (
+	name "Touki Denshou -Angel Eyes- (VER. 960427)"
+	year "1996"
+	developer "Tecmo"
+	rom ( name tkdenshoa.zip size 298531 crc a38b8b30 md5 ee206cbbc74d0f46d703b87f83ca3384 sha1 2999b20ada38e76720dae2e290d4b3f96e1455c4 )
+)
+
+game (
 	name "Tokimeki Memorial Taisen Puzzle-dama (ver JAB)"
 	year "1995"
 	developer "Konami"
 	rom ( name tkmmpzdm.zip size 7298231 crc bee17002 md5 0008bc1a35732900ccac30924a9501e8 sha1 94c410173e135a913c96c6509ca2ac803c7ed1d7 )
+)
+
+game (
+	name "Tecmo Knight"
+	year "1989"
+	developer "Tecmo"
+	rom ( name tknight.zip size 329041 crc bb24a96e md5 9e1524793baa1b447bc9eb19c91e6072 sha1 1a3938c5b5c07c8b9b18f942f9d00e4e248b1eac )
 )
 
 game (
@@ -40316,6 +44910,13 @@ game (
 	year "1996"
 	developer "CES Inc., Midway Games Inc."
 	rom ( name tmdo.zip size 749709 crc d4fafb9a md5 f760851f1e5db0a47f5ffeae25ea0c66 sha1 f55ce9aa3ae5c285b2764b86492ef9b3db1c2767 )
+)
+
+game (
+	name "T-MEK (v2.0, prototype)"
+	year "1994"
+	developer "Atari Games"
+	rom ( name tmek20.zip size 244746 crc 8b9f3223 md5 e14ada0002eb8dfc384a66f62eb5fb4c sha1 759f40be85011aa3b480413991985795db079e64 )
 )
 
 game (
@@ -40529,6 +45130,13 @@ game (
 )
 
 game (
+	name "Toggle (prototype)"
+	year "1985"
+	developer "Bally/Sente"
+	rom ( name toggle.zip size 28942 crc b3d491d6 md5 5d42dc7f10c75c6d17819ff1d779f4dc sha1 0b0b420c5d754476df8294c40f308e89093b217e )
+)
+
+game (
 	name "Toki (World, set 1)"
 	year "1989"
 	developer "TAD Corporation"
@@ -40718,6 +45326,13 @@ game (
 )
 
 game (
+	name "Toppy _ Rappy"
+	year "1996"
+	developer "SemiCom"
+	rom ( name toppyrap.zip size 899598 crc d49e6bb7 md5 61bbd8147ccafe4c91480c2083f590e0 sha1 99620ac1f426bfa55d603e5423313ac15c3a05dc )
+)
+
+game (
 	name "Top Racer (with MB8841 + MB8842, 1984)"
 	year "1984"
 	developer "bootleg"
@@ -40750,6 +45365,13 @@ game (
 	year "1986"
 	developer "Exidy"
 	rom ( name topsecex.zip size 223906 crc 2d6b5bed md5 80f04c733de18b9fd01ccea3af7584ef sha1 310893e7709a51cb7119350e375a4da898975649 )
+)
+
+game (
+	name "Top Secret (Japan)"
+	year "1987"
+	developer "Capcom"
+	rom ( name topsecrt.zip size 249187 crc 219d6939 md5 b832e5c3f97d1cde73f62595c357516f sha1 af76c863975df45fc66a59685b72dbc10c79921e )
 )
 
 game (
@@ -40813,6 +45435,13 @@ game (
 	year "1976"
 	developer "Midway / Taito"
 	rom ( name tornbase.zip size 4610 crc 172c9ce8 md5 346b14f98e5cd8a63dd035be3ed1009a sha1 1ce3da395e611546a20d95846b07e56da924b49a )
+)
+
+game (
+	name "Tortuga Family (Italian)"
+	year "1997"
+	developer "C.M.C."
+	rom ( name tortufam.zip size 30995 crc 12a433af md5 42f852152a30fc23e2cdbd82e2b57371 sha1 7411f6988e799a8bee2496c4ac35a0c84a91337e )
 )
 
 game (
@@ -40920,6 +45549,13 @@ game (
 )
 
 game (
+	name "Tetris Plus 2 (MegaSystem 32 Version)"
+	year "1997"
+	developer "Jaleco"
+	rom ( name tp2m32.zip size 6879740 crc 586cbf16 md5 d8f609ec690f1e967a2f923b0c3c6cfc sha1 512fae269cf6ef441d538a7cb6a55d65f088fe78 )
+)
+
+game (
 	name "Time Pilot '84 (set 1)"
 	year "1984"
 	developer "Konami"
@@ -40945,6 +45581,13 @@ game (
 	year "1990"
 	developer "SNK"
 	rom ( name tpgolf.zip size 3792378 crc a103b264 md5 26357ffa8ee29c09be1cb1e72637fda7 sha1 816bd15a733e8c4d365798928bd45b8777b29c64 )
+)
+
+game (
+	name "TPS"
+	year "1997"
+	developer "Sony / Tecmo"
+	rom ( name tps.zip size 138496 crc 7497ce0b md5 25d6987d2369a2522df5f2f4f2c773b8 sha1 36a729f8a1f2f4e88519573521b08c0210464d78 )
 )
 
 game (
@@ -41088,10 +45731,73 @@ game (
 )
 
 game (
+	name "Tri-Sports"
+	year "1989"
+	developer "Bally Midway"
+	rom ( name trisport.zip size 391600 crc 9d1ed04b md5 23baf9702c40ee7236ec462a36ae48a8 sha1 6ed7b4493ac639831b93a1172fc7e3b88bca28d2 )
+)
+
+game (
+	name "Trivial Pursuit (Genus I) (set 2)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name trivia12.zip size 62892 crc a592eebc md5 43831bdde92dc32d106016de14e8f85d sha1 718bcd7747ea6683281402402d933997d5cc597d )
+)
+
+game (
+	name "Trivial Pursuit (Baby Boomer Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviabb.zip size 86909 crc fcd62551 md5 06b51d3ad5cd79c50c1cc978353f17ff sha1 9d78f0a7aed4d0cb71ace35685c7f5ce8e6f5fef )
+)
+
+game (
+	name "Trivial Pursuit (Spanish Edition)"
+	year "1987"
+	developer "Bally/Sente"
+	rom ( name triviaes.zip size 98540 crc 5fe1dee9 md5 82277fd6a3c241a5a39c8d022f285895 sha1 aa34c88bb85efa6029016ab96a5871aa67f91f76 )
+)
+
+game (
+	name "Trivial Pursuit (Genus I) (set 1)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviag1.zip size 63161 crc 42412d19 md5 355c6cddb4d9ed5291069d533b20a79a sha1 362b1d7f984c400488e804169cde08efb3a86ea2 )
+)
+
+game (
+	name "Trivial Pursuit (Genus II)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviag2.zip size 81472 crc 35e28e9a md5 f17d97b0dc95431217f05c7b13c24d6e sha1 e74d3acc230a27c7521406686428f8ad250240dd )
+)
+
+game (
 	name "Trivial Pursuit (prod. 1D)"
 	year "1996"
 	developer "JPM"
 	rom ( name trivialp.zip size 4629707 crc 69c30118 md5 650ec075162fe6ef59b814cb48cece69 sha1 6fac4dee5e78172d453f9db846111990a6d60004 )
+)
+
+game (
+	name "Trivial Pursuit (All Star Sports Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviasp.zip size 79007 crc 9fec4b51 md5 434d67ccc984a67a7e386e74acb19f66 sha1 d16547ced6599031a230103097fff69611e3e8b3 )
+)
+
+game (
+	name "Trivial Pursuit (Young Players Edition)"
+	year "1984"
+	developer "Bally/Sente"
+	rom ( name triviayp.zip size 81290 crc 3ea8b933 md5 a98d9c07b9e1e5a97e2fd9b802ebdf08 sha1 484d137137c31343702190e89addad65d9cca49b )
+)
+
+game (
+	name "Triv Quiz"
+	year "1984"
+	developer "Status Games"
+	rom ( name trivquiz.zip size 44640 crc 87331852 md5 7750c2aa24abe738c824108301f14223 sha1 7b7916e6594e8a6b4fef765e408a734d3c58b8e3 )
 )
 
 game (
@@ -41155,6 +45861,34 @@ game (
 	year "1986"
 	developer "Capcom (Romstar license)"
 	rom ( name trojanr.zip size 36180 crc 5037815f md5 60e59ab77e7524a5d8a286e2f850e992 sha1 99b879e1ad512b913c50066b2f48abcb6caabee7 )
+)
+
+game (
+	name "Tron (8/9)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron.zip size 48412 crc ca5217e6 md5 b1f988a78519c5dfd18e81918c2c0c97 sha1 4ebf329d173d2b3d4f95bda0a7e97f6cd1c06d08 )
+)
+
+game (
+	name "Tron (6/25)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron2.zip size 6133 crc 16f4de07 md5 ff73b1516f422be97afaa3342fd48522 sha1 1ffca4003df5494639abfb10ce807faaa1f5aaa8 )
+)
+
+game (
+	name "Tron (6/17)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron3.zip size 30693 crc dac929f3 md5 8a28662a827478e017690ef3c30033af sha1 f42e922df19e379b48b1ffe4f1984ffe509325e4 )
+)
+
+game (
+	name "Tron (6/15)"
+	year "1982"
+	developer "Bally Midway"
+	rom ( name tron4.zip size 38175 crc e9328452 md5 73e5c52a06588238a02c17155401e849 sha1 e4e1e0ebd7e2121bcc845764aeb3421faec9680a )
 )
 
 game (
@@ -41388,6 +46122,20 @@ game (
 )
 
 game (
+	name "Shingen Samurai-Fighter (Japan, English)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name tshingen.zip size 800531 crc f9576ca7 md5 9ac76b1bd2e9a7104de273de6e9127c3 sha1 da6513cfb037cdc7903e38574f381b9f2cbabfdb )
+)
+
+game (
+	name "Takeda Shingen (Japan, Japanese)"
+	year "1988"
+	developer "Jaleco"
+	rom ( name tshingena.zip size 207168 crc 99d9089a md5 0f7fb21ae0a6442553862bbe787406c8 sha1 59ddac65c9c512302988ec409c408a71410db922 )
+)
+
+game (
 	name "Turkey Shoot"
 	year "1984"
 	developer "Williams"
@@ -41470,6 +46218,13 @@ game (
 )
 
 game (
+	name "Tumble Pop (bootleg set 2)"
+	year "1991"
+	developer "bootleg"
+	rom ( name tumbleb2.zip size 675669 crc 46ae3da0 md5 7423f1a013d1e79e074b71ea1813b227 sha1 cb580f576d1fdf528b9f03ad650e4f3f34c7d116 )
+)
+
+game (
 	name "Tumble Pop (World)"
 	year "1991"
 	developer "Data East Corporation"
@@ -41544,6 +46299,13 @@ game (
 	year "1985"
 	developer "Entertainment Sciences"
 	rom ( name turbosub7.zip size 423324 crc 079ab130 md5 dd70057612041e9da502b064caed9eb3 sha1 b6d2d96db3bb3d420e64ccc3b4ff46c07dda14b2 )
+)
+
+game (
+	name "Turbo Tag (prototype)"
+	year "1985"
+	developer "Bally Midway"
+	rom ( name turbotag.zip size 81349 crc 110a73f3 md5 299492db454f6e474158d50d247cd68b sha1 efb26d0470e0185af509c50c68a318d096c59233 )
 )
 
 game (
@@ -41708,6 +46470,20 @@ game (
 )
 
 game (
+	name "Twinkle"
+	year "1997"
+	developer "SemiCom"
+	rom ( name twinkle.zip size 377505 crc 87513d91 md5 d439c4e525244b83cfca5280dd09019d sha1 f963d9fcb539a9233fb3a5fb9f231811024b26a3 )
+)
+
+game (
+	name "Twin Qix (Ver 1.0A 1995/01/17) (Prototype)"
+	year "1995"
+	developer "Taito America Corporation"
+	rom ( name twinqix.zip size 3028197 crc a9e0703d md5 a43b278642f60c6891c43b23ef14309c sha1 1fc627611d3ed1f75690ae6eb9355760597a4cbd )
+)
+
+game (
 	name "Twins (set 1)"
 	year "1994"
 	developer "Electronic Devices"
@@ -41761,6 +46537,13 @@ game (
 	year "1996"
 	developer "Tecmo"
 	rom ( name tws96.zip size 6149679 crc 42604778 md5 eac62521bb2cf6c8f7951a2284601bf9 sha1 b98bb439ac653d78d3f6540d1796d52242d791be )
+)
+
+game (
+	name "TX-1"
+	year "1983"
+	developer "Tatsumi"
+	rom ( name tx1.zip size 107770 crc e1d14f3e md5 29e33378420a1311fed9b003e07acedb sha1 3da4d488dbcb3941cefdae9d706f642c90d07867 )
 )
 
 game (
@@ -41841,6 +46624,13 @@ game (
 )
 
 game (
+	name "Ufo Senshi Yohko Chan (not encrypted)"
+	year "1988"
+	developer "bootleg"
+	rom ( name ufosensib.zip size 98759 crc dcb80a59 md5 6fa39f62cafcadea6aaf139d608dcfdf sha1 669adcb0f0ffc8061417faa723c5a4b97062dc29 )
+)
+
+game (
 	name "Ultimate Tennis"
 	year "1993"
 	developer "Art &amp; Magic"
@@ -41915,6 +46705,13 @@ game (
 	year "1983"
 	developer "Diatec"
 	rom ( name unclepoo.zip size 33464 crc e0e12af0 md5 3252ddeca86367d916fca1b9754c82e0 sha1 6a68f32108b772e4b623f3d0603cc87e461c783e )
+)
+
+game (
+	name "The Undoukai (Japan)"
+	year "1984"
+	developer "Taito Corporation"
+	rom ( name undoukai.zip size 97596 crc 1dec3d90 md5 450624ba6b92513df4363e2486072614 sha1 a599ef09eef56ca0adc97f743ee1c1a0509e8f8c )
 )
 
 game (
@@ -41999,6 +46796,13 @@ game (
 	year "1987"
 	developer "Cinematronics"
 	rom ( name upyoural.zip size 110212 crc c2a3fef4 md5 708658c54b604df2fecb7026b35d5573 sha1 50b122ea1406d1c928b00b14982d8a8a878ba724 )
+)
+
+game (
+	name "Otogizoushi Urashima Mahjong (Japan)"
+	year "1989"
+	developer "UPL"
+	rom ( name urashima.zip size 842889 crc 40519bc6 md5 a316e07bc309b3d56c91e811625acba4 sha1 b8aea9e4f54f74c0ea82017c1395138130d29291 )
 )
 
 game (
@@ -42226,10 +47030,31 @@ game (
 )
 
 game (
+	name "Varth: Operation Thunderstorm (World 920714)"
+	year "1992"
+	developer "Capcom"
+	rom ( name varth.zip size 1544763 crc 5e0796fe md5 6179a7782065b3f0a23e5be3ed69ec99 sha1 c777ddc4f79531b67188e07119961b97cb111270 )
+)
+
+game (
 	name "Varth: Operation Thunderstorm (Japan 920714)"
 	year "1992"
 	developer "Capcom"
 	rom ( name varthj.zip size 1317826 crc b1172b4c md5 4b08f6a1e719b6523bf65e8b12a60d12 sha1 14bb79d4d4abd7d25a92bbc8f39197b57d4dab71 )
+)
+
+game (
+	name "Varth: Operation Thunderstorm (World 920612)"
+	year "1992"
+	developer "Capcom"
+	rom ( name varthr1.zip size 371744 crc d79966b6 md5 dfc1d50f27d7f3db58b79b05c826f02a sha1 0eb6f2a3a510229d708e13d0a942ab2f983070bf )
+)
+
+game (
+	name "Varth: Operation Thunderstorm (USA 920612)"
+	year "1992"
+	developer "Capcom, distributed by Romstar"
+	rom ( name varthu.zip size 374451 crc 7f7ed097 md5 66d7a6e9ef118b3ee9535e27aa043e65 sha1 0606b4b3b49d28df2f56261aa5c302e6d6861da6 )
 )
 
 game (
@@ -42307,6 +47132,13 @@ game (
 	year "1997"
 	developer "Kaneko / Mediaworks"
 	rom ( name vblokbrk.zip size 3397578 crc b2ff7906 md5 32f0b65139955ebbed2157a7e7119acb sha1 b2d0e4afc72675b564377b80a56ed2e4b2dbf2e3 )
+)
+
+game (
+	name "Virtua Bowling (World, V101XCM)"
+	year "1996"
+	developer "IGS"
+	rom ( name vbowl.zip size 2363570 crc de0aba54 md5 6e293b5ec25533541bea76e1be0ca2ed sha1 b10589dd59d24ef582bbac82212d280295706552 )
 )
 
 game (
@@ -42443,6 +47275,13 @@ game (
 )
 
 game (
+	name "Virtua Formula"
+	year "1993"
+	developer "Sega"
+	rom ( name vformula.zip size 573026 crc 9adb4aa5 md5 5acd5c3fae5560410d31a46e3adcfed3 sha1 8e7b5cfb2b60bca84bdc16013b9469e3c8d2a69b )
+)
+
+game (
 	name "Vampire Hunter 2: Darkstalkers Revenge (Japan 970929)"
 	year "1997"
 	developer "Capcom"
@@ -42485,10 +47324,24 @@ game (
 )
 
 game (
+	name "Victorious Nine"
+	year "1984"
+	developer "Taito"
+	rom ( name victnine.zip size 99727 crc a48c32af md5 af3a5cb752bb9ac4bb1e8a20e582d698 sha1 7cf1f37b57ec9c2ce64566ad4b51c7071589a996 )
+)
+
+game (
 	name "Victor 21"
 	year "1990"
 	developer "Subsino / Buffy"
 	rom ( name victor21.zip size 59931 crc 8058f02c md5 133b21b0fbe1a562bdbe67117ecbafd5 sha1 c7fdf4bbdc5dd33831aa68ed0cb781656d249cbc )
+)
+
+game (
+	name "G.E.A."
+	year "1991"
+	developer "Subsino"
+	rom ( name victor5.zip size 60370 crc 789405ce md5 19a92dc9bb867380b6b3e7c53e2777f9 sha1 d5fc128372b04617e4b19a23070d47daff30c5bc )
 )
 
 game (
@@ -42559,6 +47412,48 @@ game (
 	year "1992"
 	developer "Sammy / Aicom"
 	rom ( name viewpoin.zip size 4045243 crc b3c55b87 md5 35e82eb1e37eb96aafe43f88e7d4addf sha1 8e0905a6463b06c01c2f37d8fef077bec05560cb )
+)
+
+game (
+	name "Vigilante (World)"
+	year "1988"
+	developer "Irem"
+	rom ( name vigilant.zip size 443942 crc 0ea1d86f md5 53bbcbe368c25fb0776a756f9fd06e4f sha1 7d969ba8c64596bac482beb4cf481845b7b773b6 )
+)
+
+game (
+	name "Vigilante (Japan)"
+	year "1988"
+	developer "Irem"
+	rom ( name vigilantj.zip size 51115 crc a2b0d130 md5 da58029faf1a73db3265b971a8796051 sha1 40996678b3234eb969e978b4217b16164cda9e28 )
+)
+
+game (
+	name "Vigilante (US)"
+	year "1988"
+	developer "Irem (Data East USA license)"
+	rom ( name vigilantu.zip size 50950 crc 4a7b0112 md5 7e485058a667fee01f66924155614101 sha1 bcc2db2881c89661675b4480eaf9bc9bcbecf9a9 )
+)
+
+game (
+	name "Vimana"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana.zip size 792366 crc 13fa183b md5 337d31dd699ebccabda08a3931bf5fda sha1 5f0ec27fc6b32cececedd03abe9bbfa8cfb1a1d2 )
+)
+
+game (
+	name "Vimana (Japan)"
+	year "1991"
+	developer "Toaplan"
+	rom ( name vimana1.zip size 87452 crc b0fb5004 md5 de2e2733070b6b3f3297fb2d25d86c4d sha1 db38432f670ea24c7102ef2f8c6d67914375ca06 )
+)
+
+game (
+	name "Vimana (Nova Apparate GmbH)"
+	year "1991"
+	developer "Toaplan (Nova Apparate GmbH license)"
+	rom ( name vimanan.zip size 87678 crc ca61b5d0 md5 bfd828f2653fea976d8c4367836d433c sha1 4a6f5300832dcb0f7211993cb427f9b80a7308dd )
 )
 
 game (
@@ -42849,6 +47744,13 @@ game (
 )
 
 game (
+	name "Virtua Racing"
+	year "1992"
+	developer "Sega"
+	rom ( name vr.zip size 9761594 crc 68f2d49a md5 28a9134834b668a21833c0448ad51104 sha1 ad169f0c44fe377076258a02e80303a6b19891f0 )
+)
+
+game (
 	name "Vegas Roulette"
 	year "1989"
 	developer "World Game"
@@ -43042,6 +47944,13 @@ game (
 	year "1984"
 	developer "Nintendo"
 	rom ( name vspinbalj.zip size 25727 crc 1fe4b9a1 md5 45a399399f20327008211d620fa109c1 sha1 13047de16ceac434a8e721e346dab1891963fc9e )
+)
+
+game (
+	name "Video System PSX"
+	year "1996"
+	developer "Video System Co."
+	rom ( name vspsx.zip size 126226 crc 3e55548f md5 cc083a4bed6f28fdff3580753ae86bf8 sha1 e51cc969438c37ecf3fbc68a1b30da732f19fa81 )
 )
 
 game (
@@ -43269,6 +48178,13 @@ game (
 )
 
 game (
+	name "Wonder Boy III - Monster Lair (set 5, World, System 16B, 8751 317-0098)"
+	year "1988"
+	developer "Sega / Westone"
+	rom ( name wb3.zip size 391158 crc f91e30a4 md5 01cc32ea1ae54c6e3d9f0c0c2ec00c54 sha1 8ec512b7b6d1e77cd0e1ce2d3cf0250cbd7c4077 )
+)
+
+game (
 	name "Wonder Boy III - Monster Lair (set 1, System 16A, FD1094 317-0084)"
 	year "1988"
 	developer "Sega / Westone"
@@ -43420,6 +48336,20 @@ game (
 	year "1989"
 	developer "Tecmo"
 	rom ( name wc90b.zip size 15147 crc 5261a1b1 md5 dfd4a4a5cd983a90032356881a1ab7a5 sha1 57df7b8288ac3a90f8d22077d47cd4902bae2da0 )
+)
+
+game (
+	name "Euro League (Italian hack of Tecmo World Cup '90)"
+	year "1989"
+	developer "bootleg"
+	rom ( name wc90b1.zip size 400477 crc b0bf4256 md5 c32a9f1044995ffffb4e670df4bf81b6 sha1 4a84141f7517490037994c7420e548f05ce432f9 )
+)
+
+game (
+	name "Worldcup '90"
+	year "1989"
+	developer "bootleg"
+	rom ( name wc90b2.zip size 400762 crc 22467977 md5 8b60be8f48b0abd75473d9ea368eec79 sha1 2a3d9c79990c54cb6dd15cf92f0e43fe8cf15028 )
 )
 
 game (
@@ -43619,6 +48549,12 @@ game (
 )
 
 game (
+	name "Wheels Runner"
+	developer "International Games"
+	rom ( name wheelrun.zip size 266060 crc 01cc5ffb md5 9f4ed4d024100f95ec451c8927bb9519 sha1 b38f11dfdc350802cbb8bf496ff1f8ff9babc5d7 )
+)
+
+game (
 	name "Whizz"
 	year "1989"
 	developer "Philko"
@@ -43647,6 +48583,20 @@ game (
 )
 
 game (
+	name "Wild Fang / Tecmo Knight"
+	year "1989"
+	developer "Tecmo"
+	rom ( name wildfang.zip size 1127216 crc 1bbd53df md5 bdf5feea32db29d4fb9bddc09454f287 sha1 5f75aafe536acc379790a20c2fa9fb2f26ca4196 )
+)
+
+game (
+	name "Wild Fang"
+	year "1989"
+	developer "Tecmo"
+	rom ( name wildfangs.zip size 97318 crc af986de2 md5 0007f7ed9a358bb0062b63ad86db791e sha1 346e990529d01ee98d9ca22fb655482381709348 )
+)
+
+game (
 	name "Wild Pilot"
 	year "1992"
 	developer "Jaleco"
@@ -43658,6 +48608,13 @@ game (
 	year "1989"
 	developer "Capcom"
 	rom ( name willow.zip size 1773768 crc 6d01bbd4 md5 aca68da886b22d3945147ca8120e9959 sha1 2106a5e22c9cd5521eb6f0cc86ea041fc385ce14 )
+)
+
+game (
+	name "Willow (Japan, Japanese)"
+	year "1989"
+	developer "Capcom"
+	rom ( name willowj.zip size 131101 crc 249794d9 md5 102adfb8c128765c40980ca7abd05dee sha1 290feac9dd5c492e60a113b8e77f9ba28a164707 )
 )
 
 game (
@@ -43759,6 +48716,13 @@ game (
 )
 
 game (
+	name "Witch Card (English, witch game, lamps)"
+	year "1985"
+	developer "PlayMan"
+	rom ( name witchcdf.zip size 8443 crc e1ffb6e7 md5 4f0110ffe2b4eb4650fb30641c7d44f6 sha1 58dd6eebbc47d162edd3e3f169d0680457267087 )
+)
+
+game (
 	name "Wit's (Japan)"
 	year "1989"
 	developer "Athena (Visco license)"
@@ -43850,6 +48814,13 @@ game (
 )
 
 game (
+	name "Wonder League Star - Sok-Magicball Fighting (Korea)"
+	year "1995"
+	developer "Mijin"
+	rom ( name wlstar.zip size 1111873 crc 50c60903 md5 fc261854f1666e504d5e89b474e1c99b sha1 0809e620299942bfe252fa6912a34613339ace1f )
+)
+
+game (
 	name "Water Match (315-5064)"
 	year "1984"
 	developer "Sega"
@@ -43899,6 +48870,13 @@ game (
 )
 
 game (
+	name "Warriors of Fate (USA 921031)"
+	year "1992"
+	developer "Capcom"
+	rom ( name wofu.zip size 435876 crc a99e6f31 md5 e09cf79c47b401c18a80040e93cee117 sha1 284f09f503633fbe23361f562eb560e1f4ddafc2 )
+)
+
+game (
 	name "Wolf Fang -Kuhga 2001- (Japan)"
 	year "1991"
 	developer "Data East Corporation"
@@ -43917,6 +48895,13 @@ game (
 	year "1991"
 	developer "Capcom"
 	rom ( name wonder3.zip size 2188617 crc e5076c63 md5 9c254a46d911ad47fefa9cc6df686fbe sha1 5f10cd88532802673590f787b479143f8ca82c89 )
+)
+
+game (
+	name "Wonder League '96 (Korea)"
+	year "1996"
+	developer "SemiCom"
+	rom ( name wondl96.zip size 1134743 crc 829ed1a5 md5 89b56076d71f4c1caba5cb5194e40eed sha1 07b88d1d2c796106a0883a46f9711bd2b5f36ce5 )
 )
 
 game (
@@ -43972,6 +48957,34 @@ game (
 	year "2002"
 	developer "Comad"
 	rom ( name wownfant.zip size 3732704 crc 54a82a1e md5 feea599d0ef0cac04182100c1fdb4c5a sha1 5fb7030ffb3819b280594892f9e01a9a68a08372 )
+)
+
+game (
+	name "World PK Soccer V2 (ver 1.1)"
+	year "1996"
+	developer "Jaleco"
+	rom ( name wpksocv2.zip size 10936454 crc 15459333 md5 6e2330a479a07cf99cb8ccaa4d4a91d8 sha1 35a8e524c393d1d5321dfd260942289441d3610c )
+)
+
+game (
+	name "World Rally (set 1)"
+	year "1993"
+	developer "Gaelco"
+	rom ( name wrally.zip size 2150671 crc 0a96fa55 md5 c0b150867a535dd91c0a0185bbbe9d2f sha1 1648718faf86e70554754324e1888c95b06e4eea )
+)
+
+game (
+	name "World Rally (set 2)"
+	year "1993"
+	developer "Gaelco"
+	rom ( name wrallya.zip size 338926 crc b09b6be9 md5 5c5225767666a80d0046f0709e89a46c sha1 1e08d1621dd561759e3d034dc56ba54c84c70371 )
+)
+
+game (
+	name "World Rally (US, 930217)"
+	year "1993"
+	developer "Gaelco (Atari license)"
+	rom ( name wrallyb.zip size 2101104 crc 514c0d67 md5 a2b5a177227145476358b81cade78294 sha1 24d114aeb963bce234fb67aeaeb6fa039deb8df3 )
 )
 
 game (
@@ -44122,6 +49135,13 @@ game (
 )
 
 game (
+	name "WWF Superstars (Europe)"
+	year "1989"
+	developer "Technos Japan"
+	rom ( name wwfsstar.zip size 1521277 crc 380f9e41 md5 7938b364e050b627d2be494b89d450f2 sha1 d2caa65883c6298e8a02d372c8fe76606d47e6f1 )
+)
+
+game (
 	name "WWF Superstars (US, Newer)"
 	year "1989"
 	developer "Technos Japan"
@@ -44178,6 +49198,13 @@ game (
 )
 
 game (
+	name "Xenophobe"
+	year "1987"
+	developer "Bally Midway"
+	rom ( name xenophob.zip size 392037 crc f90765c3 md5 39a392cd04bd5ce6e42619c5667602a0 sha1 0973544f28d70c1e3fc52dc12fb7dfe80d612a35 )
+)
+
+game (
 	name "Xevious 3D/G (Japan, XV31/VER.A)"
 	year "1995"
 	developer "Namco"
@@ -44196,6 +49223,27 @@ game (
 	year "1982"
 	developer "Namco"
 	rom ( name xevious.zip size 45634 crc 1421f28d md5 bc09dfa00e72694661e549d17a51cbb8 sha1 bae87aefcbef9c776f8f6cbd3cfc4ec24d4248f4 )
+)
+
+game (
+	name "Xevious (Atari set 1)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousa.zip size 14810 crc 11b7cbd1 md5 ba4db9ee4ce85d6d11d9d94beb5a4147 sha1 27e0e16f665cd7c0609ab716912e12a773e483a9 )
+)
+
+game (
+	name "Xevious (Atari set 2)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousb.zip size 14662 crc 85cbfdcc md5 f02b28ad7fcd97c3c4ec3f12e333aae8 sha1 1aee6f1d6fb689027783427d10df10bfa897f2ee )
+)
+
+game (
+	name "Xevious (Atari set 3)"
+	year "1982"
+	developer "Namco (Atari license)"
+	rom ( name xeviousc.zip size 12112 crc 3fc497a5 md5 4b93437e5e77bc152e14314d61445f15 sha1 273418204d6152588216f5e572d212a0d2574faa )
 )
 
 game (
@@ -44360,6 +49408,13 @@ game (
 )
 
 game (
+	name "X Multiply (Japan, M72)"
+	year "1989"
+	developer "Irem"
+	rom ( name xmultiplm72.zip size 179262 crc d65233a5 md5 a3f520928adfb7b475cdfc617ce311d2 sha1 636ce7451c931637caada1f1894daaf4f60792bc )
+)
+
+game (
 	name "X-Men Vs. Street Fighter (Euro 961004)"
 	year "1996"
 	developer "Capcom"
@@ -44490,6 +49545,13 @@ game (
 	year "1987"
 	developer "Atari Games"
 	rom ( name xybots.zip size 311744 crc 02c2e99b md5 292a1cbc0304beaa0ca64831f537cbb4 sha1 3fe003a960431b455308fc212ee2d87500041759 )
+)
+
+game (
+	name "Xybots (rev 0)"
+	year "1987"
+	developer "Atari Games"
+	rom ( name xybots0.zip size 140063 crc 11e07b16 md5 800e1ddb5ba603d224bea38dc4d6d083 sha1 d4b3a8e12d017013407da3ac5b4726886627b61b )
 )
 
 game (
@@ -44658,6 +49720,20 @@ game (
 	year "1987"
 	developer "Namco"
 	rom ( name youkaidko.zip size 38949 crc 9ab3aadc md5 28652443bff6420411d5684c2399524c sha1 094ecb4a18007f3e84df16f7ae9c570fd172cac0 )
+)
+
+game (
+	name "Yu-Jan"
+	year "1999"
+	developer "Yubis / T.System"
+	rom ( name yujan.zip size 954075 crc e3156c85 md5 2523fa5f0656bf3dda9bc0e0dbe30700 sha1 2989ac4c2420787b627c0092fc16d1496a7b703e )
+)
+
+game (
+	name "Yu-Ka"
+	year "1999"
+	developer "Yubis / T.System"
+	rom ( name yuka.zip size 1156984 crc 35d0a61e md5 651a630a7b8199ea9505dbe23aabf927 sha1 762dc5457c9baa54eb902835c004a929a0238fea )
 )
 
 game (
@@ -44850,6 +49926,13 @@ game (
 )
 
 game (
+	name "Zip _ Zap"
+	year "1995"
+	developer "Barko Corp"
+	rom ( name zipzap.zip size 1889854 crc b5f99dd5 md5 3128e2238388cbc3f27565eb04e21cc7 sha1 19cd1b0a118aee8d46e6cb6e8103a4f3fadf55cc )
+)
+
+game (
 	name "Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000)"
 	year "1997"
 	developer "Sega"
@@ -44899,6 +49982,13 @@ game (
 )
 
 game (
+	name "Zoom 909"
+	year "1982"
+	developer "Sega"
+	rom ( name zoom909.zip size 70848 crc db4249eb md5 586b34ac542dc99c832288049c2b49fb sha1 f769e58810fb555765901f8d9eb88050ea1939f6 )
+)
+
+game (
 	name "Zunzunkyou No Yabou (Japan)"
 	year "1994"
 	developer "Sega"
@@ -44910,6 +50000,13 @@ game (
 	year "2001"
 	developer "SNK"
 	rom ( name zupapa.zip size 17945799 crc 3c886433 md5 1536c540dab80feefc6ae2a880f3289b sha1 b89c7ddeb7a0828fb67bc50a55356af082b5360c )
+)
+
+game (
+	name "Zwackery"
+	year "1984"
+	developer "Bally Midway"
+	rom ( name zwackery.zip size 194039 crc 058b606e md5 a292f0585b2d99cb8da733ad7ecc5f94 sha1 8d2e8d67c6f1b90c37c9ea99db34e8297247b20a )
 )
 
 game (


### PR DESCRIPTION
I intend for this to be the last change to the MAME 2003 and MAME 2010 databases from me.

Certain romsets are playable even though they are flagged in the XML DAT as having `nodump` or `baddump` ROMs inside the set. I didn't realize this with my last two PRs and inadvertently didn't include those romsets. This PR fixes that oversight on my part.