### PR TITLE
Unique spelling for Squaresoft in developer and publisher

### DIFF
--- a/metadat/developer/Bandai - WonderSwan Color.dat
+++ b/metadat/developer/Bandai - WonderSwan Color.dat
@@ -37,7 +37,7 @@ game (
 
 game (
 	name "Blue Wing Blitz (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 99027238
 	)
@@ -141,7 +141,7 @@ game (
 
 game (
 	name "Final Fantasy (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc B7243E88
 	)
@@ -149,7 +149,7 @@ game (
 
 game (
 	name "Final Fantasy II (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F09E752F
 	)
@@ -221,7 +221,7 @@ game (
 
 game (
 	name "Front Mission (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 2F9E2560
 	)
@@ -541,7 +541,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 9C98D97D
 	)
@@ -709,7 +709,7 @@ game (
 
 game (
 	name "Wild Card (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D9401F0A
 	)

--- a/metadat/developer/Microsoft - MSX.dat
+++ b/metadat/developer/Microsoft - MSX.dat
@@ -173,7 +173,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc C6FC7BD7
 	)
@@ -181,7 +181,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan) (Alt 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc A6E924AB
 	)
@@ -189,7 +189,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan) (Alt 2)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 3DDCB524
 	)

--- a/metadat/developer/Nintendo - Famicom Disk System.dat
+++ b/metadat/developer/Nintendo - Famicom Disk System.dat
@@ -61,7 +61,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan) (Proto) [b]"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 2B779EE3
 	)
@@ -77,7 +77,7 @@ game (
 
 game (
 	name "Apple Town Monogatari - Little Computer People (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 0F160238
 	)
@@ -229,7 +229,7 @@ game (
 
 game (
 	name "Cleopatra no Mahou (Japan) [b]"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc B65E1335
 	)
@@ -1517,7 +1517,7 @@ game (
 
 game (
 	name "Suishou no Dragon (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6B56808B
 	)
@@ -1653,7 +1653,7 @@ game (
 
 game (
 	name "Tobidase Daisakusen (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 25CBBE75
 	)

--- a/metadat/developer/Nintendo - Game Boy Advance.dat
+++ b/metadat/developer/Nintendo - Game Boy Advance.dat
@@ -2588,7 +2588,7 @@ game (
 
 game (
 	name "Chocobo Land - A Game of Dice (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D4F8152E
 	)

--- a/metadat/developer/Nintendo - Game Boy.dat
+++ b/metadat/developer/Nintendo - Game Boy.dat
@@ -2708,7 +2708,7 @@ game (
 
 game (
 	name "Final Fantasy Adventure (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 18C78B3A
 	)
@@ -2716,7 +2716,7 @@ game (
 
 game (
 	name "Final Fantasy Legend II (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 58314182
 	)
@@ -2724,7 +2724,7 @@ game (
 
 game (
 	name "Final Fantasy Legend III (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 3E454710
 	)
@@ -2732,7 +2732,7 @@ game (
 
 game (
 	name "Final Fantasy Legend, The (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 8046148F
 	)
@@ -4820,7 +4820,7 @@ game (
 
 game (
 	name "Makai Toushi Sa-Ga (Japan) (Rev A)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 1953820F
 	)
@@ -4828,7 +4828,7 @@ game (
 
 game (
 	name "Makai Toushi Sa-Ga (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 131B09F2
 	)
@@ -5628,7 +5628,7 @@ game (
 
 game (
 	name "Mystic Quest (France)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc B6E134AF
 	)
@@ -5636,7 +5636,7 @@ game (
 
 game (
 	name "Mystic Quest (Germany)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 0351B9A6
 	)
@@ -5644,7 +5644,7 @@ game (
 
 game (
 	name "Mystic Quest (Europe)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 57D95C92
 	)
@@ -7724,7 +7724,7 @@ game (
 
 game (
 	name "Sa-Ga 2 - Hihou Densetsu (Japan) (Rev A)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F6CFCFB1
 	)
@@ -7732,7 +7732,7 @@ game (
 
 game (
 	name "Sa-Ga 2 - Hihou Densetsu (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 18055BB9
 	)
@@ -7740,7 +7740,7 @@ game (
 
 game (
 	name "Sa-Ga 3 - Jikuu no Hasha (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 575D6D9D
 	)

--- a/metadat/developer/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/developer/Nintendo - Nintendo Entertainment System.dat
@@ -76,7 +76,7 @@ game (
 
 game (
 	name "3-D WorldRunner (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc E6A477B2
 	)
@@ -5356,7 +5356,7 @@ game (
 
 game (
 	name "Final Fantasy (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc CEBD2A31
 	)
@@ -5364,7 +5364,7 @@ game (
 
 game (
 	name "Final Fantasy (Japan) (Rev B)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F71E7EDD
 	)
@@ -5372,7 +5372,7 @@ game (
 
 game (
 	name "Final Fantasy (Japan) (Rev 0A)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 466EFDC2
 	)
@@ -5380,7 +5380,7 @@ game (
 
 game (
 	name "Final Fantasy I, II (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc C9556B36
 	)
@@ -5388,7 +5388,7 @@ game (
 
 game (
 	name "Final Fantasy II (USA) (Proto)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 93A2EEFB
 	)
@@ -5396,7 +5396,7 @@ game (
 
 game (
 	name "Final Fantasy II (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D29DB3C7
 	)
@@ -5404,7 +5404,7 @@ game (
 
 game (
 	name "Final Fantasy III (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 57E220D0
 	)
@@ -6716,7 +6716,7 @@ game (
 
 game (
 	name "Highway Star (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 02589598
 	)
@@ -12404,7 +12404,7 @@ game (
 
 game (
 	name "Rad Racer (Europe)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 654F4E90
 	)
@@ -12412,7 +12412,7 @@ game (
 
 game (
 	name "Rad Racer (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 8B9D3E9C
 	)
@@ -12420,7 +12420,7 @@ game (
 
 game (
 	name "Rad Racer II (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 404B2E8B
 	)
@@ -14524,7 +14524,7 @@ game (
 
 game (
 	name "Square no Tom Sawyer (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc CB0A76B1
 	)

--- a/metadat/developer/Nintendo - Satellaview.dat
+++ b/metadat/developer/Nintendo - Satellaview.dat
@@ -277,7 +277,7 @@ game (
 
 game (
 	name "Chrono Trigger - Character Zukan (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D584AE5B
 	)
@@ -285,7 +285,7 @@ game (
 
 game (
 	name "Chrono Trigger - Jet Bike Special (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 8E150196
 	)
@@ -293,7 +293,7 @@ game (
 
 game (
 	name "Chrono Trigger - Music Library (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F268DC1B
 	)
@@ -349,7 +349,7 @@ game (
 
 game (
 	name "Dynami Tracer (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F8C2024A
 	)
@@ -597,7 +597,7 @@ game (
 
 game (
 	name "Radical Dreamers - Nusume Nai Houseki (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 660B8CC4
 	)
@@ -837,7 +837,7 @@ game (
 
 game (
 	name "Treasure Conflix (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F50FB0B7
 	)

--- a/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
@@ -1092,7 +1092,7 @@ game (
 
 game (
 	name "Bahamut Lagoon (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 1B83C440
 	)
@@ -2860,7 +2860,7 @@ game (
 
 game (
 	name "Chrono Trigger (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 4D014C20
 	)
@@ -2868,7 +2868,7 @@ game (
 
 game (
 	name "Chrono Trigger (Japan) (Sample)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 17C9F363
 	)
@@ -2876,7 +2876,7 @@ game (
 
 game (
 	name "Chrono Trigger (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 2D206BF7
 	)
@@ -2884,7 +2884,7 @@ game (
 
 game (
 	name "Chrono Trigger - Character Zukan (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D584AE5B
 	)
@@ -2892,7 +2892,7 @@ game (
 
 game (
 	name "Chrono Trigger - Jet Bike Special (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 8E150196
 	)
@@ -2900,7 +2900,7 @@ game (
 
 game (
 	name "Chrono Trigger - Music Library (Japan) (BS)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F268DC1B
 	)
@@ -5244,7 +5244,7 @@ game (
 
 game (
 	name "Final Fantasy - Mystic Quest (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6B19A2C6
 	)
@@ -5252,7 +5252,7 @@ game (
 
 game (
 	name "Final Fantasy - Mystic Quest (USA) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 2C52C792
 	)
@@ -5260,7 +5260,7 @@ game (
 
 game (
 	name "Final Fantasy II (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 65D0A825
 	)
@@ -5268,7 +5268,7 @@ game (
 
 game (
 	name "Final Fantasy II (USA) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 23084FCD
 	)
@@ -5276,7 +5276,7 @@ game (
 
 game (
 	name "Final Fantasy III (USA) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc C0FA0464
 	)
@@ -5284,7 +5284,7 @@ game (
 
 game (
 	name "Final Fantasy III (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc A27F1C7A
 	)
@@ -5292,7 +5292,7 @@ game (
 
 game (
 	name "Final Fantasy III (USA) (Beta)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 4BD8902B
 	)
@@ -5300,7 +5300,7 @@ game (
 
 game (
 	name "Final Fantasy IV (Japan) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc CAA15E97
 	)
@@ -5308,7 +5308,7 @@ game (
 
 game (
 	name "Final Fantasy IV (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 21027C5D
 	)
@@ -5316,7 +5316,7 @@ game (
 
 game (
 	name "Final Fantasy IV - Easy Type (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6CDA700C
 	)
@@ -5324,7 +5324,7 @@ game (
 
 game (
 	name "Final Fantasy USA - Mystic Quest (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 1DA17F0C
 	)
@@ -5332,7 +5332,7 @@ game (
 
 game (
 	name "Final Fantasy V (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc C1BC267D
 	)
@@ -5340,7 +5340,7 @@ game (
 
 game (
 	name "Final Fantasy VI (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 45EF5AC8
 	)
@@ -9716,7 +9716,7 @@ game (
 
 game (
 	name "Live A Live (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6291EE08
 	)
@@ -11484,7 +11484,7 @@ game (
 
 game (
 	name "Mystic Quest Legend (France)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F997DEBC
 	)
@@ -11492,7 +11492,7 @@ game (
 
 game (
 	name "Mystic Quest Legend (Germany)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc F21760DF
 	)
@@ -11500,7 +11500,7 @@ game (
 
 game (
 	name "Mystic Quest Legend (Europe)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 45A7328F
 	)
@@ -14516,7 +14516,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc A6D82435
 	)
@@ -14524,7 +14524,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga (Japan) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 9684526D
 	)
@@ -14532,7 +14532,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga 2 (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 54A585BC
 	)
@@ -14540,7 +14540,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga 3 (Japan) (Sample)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc BBBE3253
 	)
@@ -14548,7 +14548,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga 3 (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 5399BDDB
 	)
@@ -14556,7 +14556,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga 3 (Japan) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6C50C2CF
 	)
@@ -14588,7 +14588,7 @@ game (
 
 game (
 	name "Rudra no Hihou (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 5D8CB7AC
 	)
@@ -14988,7 +14988,7 @@ game (
 
 game (
 	name "Secret of Mana (France) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc E9334B9E
 	)
@@ -14996,7 +14996,7 @@ game (
 
 game (
 	name "Secret of Mana (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc D0176B24
 	)
@@ -15004,7 +15004,7 @@ game (
 
 game (
 	name "Secret of Mana (Germany)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc B069BB3A
 	)
@@ -15012,7 +15012,7 @@ game (
 
 game (
 	name "Secret of Mana (France)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 6BE4CA95
 	)
@@ -15020,7 +15020,7 @@ game (
 
 game (
 	name "Secret of Mana (Europe) (Rev 1)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc DE112322
 	)
@@ -15028,7 +15028,7 @@ game (
 
 game (
 	name "Secret of Mana (Europe)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc C5CB2F26
 	)
@@ -15052,7 +15052,7 @@ game (
 
 game (
 	name "Seiken Densetsu 2 (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc B8049E3C
 	)
@@ -15060,7 +15060,7 @@ game (
 
 game (
 	name "Seiken Densetsu 3 (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 863ED0B8
 	)
@@ -15068,7 +15068,7 @@ game (
 
 game (
 	name "Seiken Densetsu 3 (Japan) (Sample)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 4801E76A
 	)
@@ -18340,7 +18340,7 @@ game (
 
 game (
 	name "Super Mario RPG (Japan)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 5527071E
 	)
@@ -18348,7 +18348,7 @@ game (
 
 game (
 	name "Super Mario RPG - Legend of the Seven Stars (USA)"
-	developer "SquareSoft"
+	developer "Squaresoft"
 	rom (
 		crc 1B8A0625
 	)

--- a/metadat/publisher/Bandai - WonderSwan Color.dat
+++ b/metadat/publisher/Bandai - WonderSwan Color.dat
@@ -37,7 +37,7 @@ game (
 
 game (
 	name "Blue Wing Blitz (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 99027238
 	)
@@ -141,7 +141,7 @@ game (
 
 game (
 	name "Final Fantasy (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc B7243E88
 	)
@@ -149,7 +149,7 @@ game (
 
 game (
 	name "Final Fantasy II (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc F09E752F
 	)
@@ -157,7 +157,7 @@ game (
 
 game (
 	name "Final Fantasy IV (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc F699D6D1
 	)
@@ -221,7 +221,7 @@ game (
 
 game (
 	name "Front Mission (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 2F9E2560
 	)
@@ -285,7 +285,7 @@ game (
 
 game (
 	name "Hanjuku Hero - Ah, Sekai yo Hanjuku Nare...!! (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 31E09BED
 	)
@@ -429,7 +429,7 @@ game (
 
 game (
 	name "Makai Toushi Sa-Ga (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 1B6F5F30
 	)
@@ -541,7 +541,7 @@ game (
 
 game (
 	name "Romancing Sa-Ga (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 9C98D97D
 	)
@@ -709,7 +709,7 @@ game (
 
 game (
 	name "Wild Card (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc D9401F0A
 	)

--- a/metadat/publisher/Microsoft - MSX.dat
+++ b/metadat/publisher/Microsoft - MSX.dat
@@ -173,7 +173,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc C6FC7BD7
 	)
@@ -181,7 +181,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan) (Alt 1)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc A6E924AB
 	)
@@ -189,7 +189,7 @@ game (
 
 game (
 	name "Aliens - Alien 2 (Japan) (Alt 2)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 3DDCB524
 	)
@@ -1717,7 +1717,7 @@ game (
 
 game (
 	name "Dragon Slayer (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 6A515349
 	)
@@ -3213,7 +3213,7 @@ game (
 
 game (
 	name "King Knight (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc A0481321
 	)
@@ -3221,7 +3221,7 @@ game (
 
 game (
 	name "King Knight (Japan) (Alt 1)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 4D884352
 	)
@@ -3229,7 +3229,7 @@ game (
 
 game (
 	name "King Knight (Japan) (Alt 2)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc AB6CD62C
 	)

--- a/metadat/publisher/Nintendo - Famicom Disk System.dat
+++ b/metadat/publisher/Nintendo - Famicom Disk System.dat
@@ -45,7 +45,7 @@ game (
 
 game (
 	name "Akuu Senki Raijin (Japan) (Disk Writer) [b]"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 115208BE
 	)
@@ -53,7 +53,7 @@ game (
 
 game (
 	name "Apple Town Monogatari - Little Computer People (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 0F160238
 	)
@@ -181,7 +181,7 @@ game (
 
 game (
 	name "Cleopatra no Mahou (Japan) [b]"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc B65E1335
 	)
@@ -669,7 +669,7 @@ game (
 
 game (
 	name "Hao-kun no Fushigi na Tabi (Japan) [b]"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc CB7A8570
 	)
@@ -757,7 +757,7 @@ game (
 
 game (
 	name "Jikai Shounen Met Mag (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 7851DD72
 	)
@@ -773,7 +773,7 @@ game (
 
 game (
 	name "Kalin no Tsurugi (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc C63A0059
 	)
@@ -997,7 +997,7 @@ game (
 
 game (
 	name "Moonball Magic (Japan) (Disk Writer) [b]"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc CCFE663F
 	)
@@ -1317,7 +1317,7 @@ game (
 
 game (
 	name "Suishou no Dragon (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 6B56808B
 	)
@@ -1453,7 +1453,7 @@ game (
 
 game (
 	name "Tobidase Daisakusen (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 25CBBE75
 	)

--- a/metadat/publisher/Nintendo - Satellaview.dat
+++ b/metadat/publisher/Nintendo - Satellaview.dat
@@ -349,7 +349,7 @@ game (
 
 game (
 	name "Dynami Tracer (Japan) (BS)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc F8C2024A
 	)
@@ -597,7 +597,7 @@ game (
 
 game (
 	name "Radical Dreamers - Nusume Nai Houseki (Japan) (BS)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 660B8CC4
 	)
@@ -805,7 +805,7 @@ game (
 
 game (
 	name "Treasure Conflix (Japan) (BS)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc F50FB0B7
 	)

--- a/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
@@ -12,7 +12,7 @@ game (
 
 game (
 	name "Chrono Trigger (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 4D014C20
 	)
@@ -20,7 +20,7 @@ game (
 
 game (
 	name "Chrono Trigger (Japan) (Sample)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 17C9F363
 	)
@@ -28,7 +28,7 @@ game (
 
 game (
 	name "Chrono Trigger (USA)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 2D206BF7
 	)
@@ -532,7 +532,7 @@ game (
 
 game (
 	name "Live A Live (Japan)"
-	publisher "SquareSoft"
+	publisher "Squaresoft"
 	rom (
 		crc 6291EE08
 	)


### PR DESCRIPTION
It was sometimes spelled `SquareSoft` resulting on wrong having two different developer pages for the same trademark.