### PR TITLE
gamecube: Add Super Methane Brothers

### DIFF
--- a/metadat/hacks/Nintendo - GameCube.dat
+++ b/metadat/hacks/Nintendo - GameCube.dat
@@ -1,0 +1,11 @@
+clrmamepro (
+    name "Nintendo - GameCube"
+    description "Hacks and homebrew for Nintendo - GameCube"
+)
+
+game (
+    name "Super Methane Brothers"
+    description "Super Methane Brothers"
+    homepage "https://github.com/carstene1ns/super-methane-brothers"
+    rom ( name "Super Methane Brothers.dol" size 5668768 crc b505482e md5 8b755dcdfa8ccab9732858e2a3b97239 sha1 f49cdb9c34e422572dd1a5ab8b663bbc4fba6b92 )
+)


### PR DESCRIPTION
[Super Methane Brothers](https://github.com/carstene1ns/super-methane-brothers) is a homebrew port of the original. It's now available on the buildbot! :+1: