### PR TITLE
Cleanup code + New Additions

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -1,25 +1,25 @@
 clrmamepro (
 	name "Doom"
 	description "Doom"
-	version 2017.02.18
+	version 2019.04.21
 	author "Obiwantje, libretro"
 )
 
 game (
-	name "Action Doom 2: Urban Brawl"
-	description "Action Doom 2: Urban Brawl"
+	name "Action Doom 2 - Urban Brawl"
+	description "Action Doom 2 - Urban Brawl"
 	rom ( name ACTION2.WAD size 143208125 crc a65d503b md5 1914b280b0a4b517214523bc2270e758 sha1 4dbb7b0c4600ffa1c6f3fe9e052b071176498eeb )
 )
 
 game (
 	name "Adventures of Square, The - Episodes 1 & 2 (v2.0)"
 	description "Adventures of Square, The - Episodes 1 & 2 (v2.0)"
-	rom ( name SQUARE1.pk3 size 71463305 crc 1745357b md5 04d49330d26dcbf31abb4a23f9ef28ac sha1 20b1485b72f810bf98c3af7dfa75e02abb06490d )
+	rom ( name SQUARE1.PK3 size 71463305 crc 1745357b md5 04d49330d26dcbf31abb4a23f9ef28ac sha1 20b1485b72f810bf98c3af7dfa75e02abb06490d )
 )
 
 game (
-	name "Blasphemer (0.1.5)"
-	description "Blasphemer (0.1.5)"
+	name "Blasphemer (v0.1.5)"
+	description "Blasphemer (v0.1.5)"
 	rom ( name BLASPHEM.WAD size 7502640 crc b6a1d3d5 md5 c98a0eca0187edef40a06cab38949210 sha1 7fea92986e91e2f7d58e3bb7a34733ef8e0efd9d )
 )
 
@@ -36,9 +36,15 @@ game (
 )
 
 game (
-	name "Chex Quest 3 (1.4)"
-	description "Chex Quest 3 (1.4)"
+	name "Chex Quest 3 (v1.4)"
+	description "Chex Quest 3 (v1.4)"
 	rom ( name CHEX3.WAD size 19191031 crc 34aa2168 md5 bce163d06521f9d15f9686786e64df13 sha1 f0581563604543060c1dce2f148fd74412adb8b8 )
+)
+
+game (
+	name "Delaweare"
+	description "Delaweare"
+	rom ( name DELAWEARE.WAD size 83219726 crc 787548eb md5 9691100ff85b0902be3851890ec5aca9 sha1 b1319702b200d95adf8da277fa237c7c0318a1b6 )
 )
 
 game (
@@ -54,6 +60,12 @@ game (
 )
 
 game (
+	name "Doom (v0.3) (Alpha)"
+	description "Doom (v0.3) (Alpha)"
+	rom ( name DOOM.WAD size 1901322 crc f97fe671 md5 dae9b1eea1a8e090fdfa5707187f4a43 sha1 df8ffe821a212d130ae48cf2c23721bd0ee6543b )
+)
+
+game (
 	name "Doom (v0.4) (Alpha)"
 	description "Doom (v0.4) (Alpha)"
 	rom ( name DOOM.WAD size 2675669 crc c8a8b5ea md5 b6afa12a8b22e2726a8ff5bd249223de sha1 5f78b23fbffc828f5863ecff7e908d556241ff45 )
@@ -66,8 +78,8 @@ game (
 )
 
 game (
-	name "Doom (v1.0) (Demo)"
-	description "Doom (v1.0) (Demo)"
+	name "Doom (Demo)"
+	description "Doom (Demo)"
 	rom ( name DOOM1.WAD size 4207819 crc eedae672 md5 90facab21eede7981be10790e3f82da2 sha1 fc0359e191bd257b3507863ae412ef3250515866 )
 )
 
@@ -153,6 +165,12 @@ game (
 	name "Doom (v1.9) (Demo)"
 	description "Doom (v1.9) (Demo)"
 	rom ( name DOOM1.WAD size 4196020 crc 162b696a md5 f0cefca49926d00903cf57551d901abe sha1 5b2e249b9c5133ec987b3ea77596381dc0d6bc1d )
+)
+
+game (
+	name "Doom (PocketPC)"
+	description "Doom (PocketPC)"
+	rom ( name DOOM.WAD size 14445632 crc 4500749f md5 dae77aff77a0491e3b7254c9c8401aa8 sha1 a89b39d91122882214c3088b8cd6b308713bd7c2 )
 )
 
 game (
@@ -271,32 +289,32 @@ game (
 )
 
 game (
-	name "Freedoom - FreeDM (0.10.3)"
+	name "Freedoom - FreeDM (v0.10.3)"
 	description "Freedoom - FreeDM (0.10.3)"
 	rom ( name FREEDM.WAD size 21112116 crc ae55bb4d md5 87ee2494d921633420ce9bdb418127c4 sha1 7e979209685ff81f4d709e0926ba585a37d2e35a )
 )
 
 game (
-	name "Freedoom - Phase 1 (0.10.3)"
+	name "Freedoom - Phase 1 (v0.10.3)"
 	description "Freedoom - Phase 1 (0.10.3)"
 	rom ( name FREEDOOM1.WAD size 23578720 crc 81901f03 md5 ea471a3d38fcee0fb3a69bcd3221e335 sha1 36db0eb476486fa56c43f24d9b23e9d8afdbbff5 )
 )
 
 game (
-	name "Freedoom - Phase 2 (0.10.3)"
-	description "Freedoom - Phase 2 (0.10.3)"
+	name "Freedoom - Phase 2 (v0.10.3)"
+	description "Freedoom - Phase 2 (v0.10.3)"
 	rom ( name FREEDOOM2.WAD size 29102220 crc cef01ecb md5 984f99af08f085e38070f51095ab7c31 sha1 0c03d1f754b98c53f292f66bc9505a29f47c6a9f )
 )
 
 game (
-	name "HACX (v1.0)"
-	description "HACX (v1.0)"
+	name "HACX"
+	description "HACX"
 	rom ( name HACX.WAD size 22102300 crc b95a03d2 md5 b7fd2f43f3382cf012dc6b097a3cb182 sha1 1125a16243d1e1d5259e0f387d955382432f1424 )
 )
 
 game (
-	name "HACX (v1.0) (Demo)"
-	description "HACX (v1.0) (Demo)"
+	name "HACX (Demo)"
+	description "HACX (Demo)"
 	rom ( name HACXSW.WAD size 9745911 crc 5e11e85e md5 4268af0335f9454c489a794058cd02f2 sha1 126432aef79cf85c7e1134e88174880b38610008 )
 )
 
@@ -307,20 +325,14 @@ game (
 )
 
 game (
-	name "HACX (v2.0-r58)"
-	description "HACX (v2.0-r58)"
-	rom ( name HACX.WAD size 39504485 crc 80b881c3 md5 ad8db94ef3bdb8522f57d4c5b3b92bd7 sha1 d5cb3d93345b2eb33e9fd4ec45fa6c87e59732ee )
-)
-
-game (
 	name "HACX (v2.0-r61)"
 	description "HACX (v2.0-r61)"
 	rom ( name HACX.WAD size 51079920 crc 19d1bb98 md5 793f07ebadb3d7353ee5b6b6429d9afa sha1 bae5769b52f39e3461cf0fbcaffc4bf1e805107d )
 )
 
 game (
-	name "Harmony (1.1)"
-	description "Harmony (1.1)"
+	name "Harmony (v1.1)"
+	description "Harmony (v1.1)"
 	rom ( name HARM1.WAD size 58396393 crc bf979c23 md5 48ebb49b52f6a3020d174dbcc1b9aeaf sha1 d7c5f9095fd5f1ebfe14ecd97ca31503e2a02964 )
 )
 
@@ -345,14 +357,14 @@ game (
 )
 
 game (
-	name "Heretic (v1.0)"
-	description "Heretic (v1.0)"
+	name "Heretic"
+	description "Heretic"
 	rom ( name HERETIC.WAD size 11096488 crc 77482d1e md5 3117e399cdb4298eaa3941625f4b2923 sha1 b5a6cc79cde48d97905b44282e82c4c966a23a87 )
 )
 
 game (
-	name "Heretic (v1.0) (Demo)"
-	description "Heretic (v1.0) (Demo)"
+	name "Heretic (Demo)"
+	description "Heretic (Demo)"
 	rom ( name HERETIC1.WAD size 5120300 crc 884a3e45 md5 023b52175d2f260c3bdc5528df5d0a8c sha1 5ef073366e5ca523b26a529e843f05c4907c23a4 )
 )
 
@@ -387,14 +399,26 @@ game (
 )
 
 game (
+	name "Hexen - Beyond Heretic (Mac Edition)"
+	description "Hexen - Beyond Heretic (Mac Edition)"
+	rom ( name HEXEN.WAD size 21078584 crc d6379951 md5 b68140a796f6fd7f3a5d3226a32b93be sha1 4343fbe5aef905ef6d077a1517a50c919e5cc906 )
+)
+
+game (
+	name "Hexen - Beyond Heretic (Mac Edition - Demo)"
+	description "Hexen - Beyond Heretic (Mac Edition - Demo)"
+	rom ( name HEXEN.WAD size 13596228 crc 8929dbfa md5 925f9f5000e17dc84b0a6a3bed3a6f31 sha1 c2338e52c06c3a4925b9a9fb2c720252fe917c08 )
+)
+
+game (
 	name "Hexen - Beyond Heretic (Retail Store Beta)"
 	description "Hexen - Beyond Heretic (Retail Store Beta)"
 	rom ( name HEXEN.WAD size 20428208 crc 5185684a md5 c88a2bb3d783e2ad7b599a8e301e099e sha1 ae797f5fdce845be24a7a24dd5bfc3e762a17bbe )
 )
 
 game (
-	name "Hexen - Beyond Heretic (v1.0)"
-	description "Hexen - Beyond Heretic (v1.0)"
+	name "Hexen - Beyond Heretic"
+	description "Hexen - Beyond Heretic"
 	rom ( name HEXEN.WAD size 20128392 crc eece0236 md5 b2543a03521365261d0a0f74d5dd90f0 sha1 ac129c4331bf26f0f080c4a56aaa40d64969c98a )
 )
 
@@ -405,8 +429,8 @@ game (
 )
 
 game (
-	name "Hexen - Deathkings of the Dark Citadel (v1.0)"
-	description "Hexen - Deathkings of the Dark Citadel (v1.0)"
+	name "Hexen - Deathkings of the Dark Citadel"
+	description "Hexen - Deathkings of the Dark Citadel"
 	rom ( name HEXDD.WAD size 4429700 crc 0c20539a md5 1077432e2690d390c256ac908b5f4efa sha1 c3065527d62b05a930fe75fe8181a64fb1982976 )
 )
 
@@ -488,15 +512,21 @@ game (
 )
 
 game (
-	name "Strife (v1.0)"
-	description "Strife (v1.0)"
+	name "Rise Of The Wool Ball (v1.3)"
+	description "Rise Of The Wool Ball (v1.3)"
+	rom ( name ROTWB.WAD size 20592999 crc ca8a9299 md5 9176043468e10eaa471ae556e8e55745 sha1 a9cc79f7383dffb5447da109b0bd9e283424cff2 )
+)
+
+game (
+	name "Strife"
+	description "Strife"
 	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
 	rom ( name STRIFE1.WAD size 28372168 crc b7581abd md5 8f2d3a6a289f5d2f2f9c1eec02b47299 sha1 eb0f3e157b35c34d5a598701f775e789ec85b4ae )
 )
 
 game (
-	name "Strife (v1.0) (Demo)"
-	description "Strife (v1.0) (Demo)"
+	name "Strife (Demo)"
+	description "Strife (Demo)"
 	rom ( name STRIFE0.WAD size 10493652 crc 3a6ab94d md5 de2c8dcad7cca206292294bdab524292 sha1 92a5fcff91fef9f55ce1da00c57e4aa933bd6f8d )
 )
 
@@ -509,6 +539,30 @@ game (
 game (
 	name "Strife (v1.2)"
 	description "Strife (v1.2)"
+	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
+	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
+)
+
+game (
+	name "Strife - Veteran Edition"
+	description "Strife - Veteran Edition"
+	rom ( name SVE.WAD size 102621358 crc 5a1ce95e md5 06a8f99b9b756ac908917c3868b8e3bc sha1 4768b23a2d4778862e15a14ef744da121f711d5b )
+	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
+	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
+)
+
+game (
+	name "Strife - Veteran Edition (v1.1)"
+	description "Strife - Veteran Edition (v1.1)"
+	rom ( name SVE.WAD size 102621358 crc e8a1fcfd md5 2c0a712d3e39b010519c879f734d79ae sha1 08ba56e6171cec65c10c9feff8705124e72421f3 )
+	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
+	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
+)
+
+game (
+	name "Strife - Veteran Edition (v1.2)"
+	description "Strife - Veteran Edition (v1.2)"
+	rom ( name SVE.WAD size 102407969 crc 0645464b md5 47958a4fea8a54116e4b51fc155799c0 sha1 539ff0d7d9971c2c33e663dca8072c629e177dfb )
 	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
 	rom ( name STRIFE1.WAD size 28377364 crc 4234ace5 md5 2fed2031a5b03892106e0f117f17901f sha1 64c13b951a845ca7f8081f68138a6181557458d1 )
 )


### PR DESCRIPTION
Cleanups:
- Removed 1.0 tags (redundant information)
- Added "v" to the version numbers to be consistent with the majority of name entries 
- Removed HACX (v2.0-r58), the official thread no longer has that version available (https://forum.drdteam.org/viewtopic.php?t=5771), the other 3rd party wad repositories usually has the HACX (v2.0-r61) which it's the latest, so the r58 kinda redundant too.

New Commercial Additions:
- Doom (v0.3) (Alpha)
- Doom (PocketPC)
- Hexen - Beyond Heretic (Mac Edition)
- Hexen - Beyond Heretic (Mac Edition - Demo)
- Strife - Veteran Edition
- Strife - Veteran Edition (v1.1)
- Strife - Veteran Edition (v1.3)

New Freeware Additions (from ZDoom list https://zdoom.org/wiki/IWAD):
- Delaweare (https://space-is-green.itch.io/delaweare)
- Rise Of The Wool Ball (v1.3) (https://forum.zdoom.org/viewtopic.php?t=56668)