### PR TITLE
Remove missing Tomb Raider entries without CRCs

### DIFF
--- a/dat/Tomb Raider.dat
+++ b/dat/Tomb Raider.dat
@@ -72,12 +72,6 @@ game (
 )
 
 game (
-	name "Tomb Raider 3 (PSX Japan)"
-	description "Third Game"
-	rom ( name "TITLE.PSX" size 653485 )
-)
-
-game (
 	name "Tomb Raider 3 - The Lost Artifact (PC)"
 	description "Third Game"
 	rom ( name "TITLE.TR2" size 1278452 crc 479aaa79 md5 ae0244a0dbb50457b1f4161b2cac42a3 sha1 fdd88f81daca2a4abc058b30874f9b3aaa417eef )

--- a/dat/Tomb Raider.dat
+++ b/dat/Tomb Raider.dat
@@ -20,12 +20,6 @@ game (
 game (
 	name "Tomb Raider 1 (PC)"
 	description "First Game"
-	rom ( name "TITLE.PHD" size 334874 )
-)
-
-game (
-	name "Tomb Raider 1 (PC)"
-	description "First Game"
 	rom ( name "TITLE.PHD" size 387980 crc b2f236bb md5 7337ad5db9ba2e7d63b4a3a13f57eac2 sha1 52a23137fa8c28c9cb5239ce86dab9ca3c3b51d0 )
 )
 
@@ -42,21 +36,9 @@ game (
 )
 
 game (
-	name "Tomb Raider 1 (PSX) (Japan)"
-	description "First Game"
-	rom ( name "TITLE.PSX" size 585648 )
-)
-
-game (
 	name "Tomb Raider 1 (Saturn) (USA)"
 	description "First Game"
 	rom ( name "title.sat" size 5148 crc 4beeecde md5 98e034265ccc9ff644e5fe470814009f sha1 64c54ec1e207a9c34b84db29cdfb4c39e4d7c970 )
-)
-
-game (
-	name "Tomb Raider 1 (PC Japan)"
-	description "First Game"
-	rom ( name "TITLE.PSX" size 320412 )
 )
 
 game (
@@ -69,12 +51,6 @@ game (
 	name "Tomb Raider 2 (PSX)"
 	description "Second Game"
 	rom ( name "TITLE.PSX" size 148744 crc f1d8babc md5 baf06458adf7ab2835cdc51a23fd6d39 sha1 12588bec0b7ef4ca84d7d90129ee119d5fbc9017 )
-)
-
-game (
-	name "Tomb Raider 2 (PSX Japan)"
-	description "Second Game"
-	rom ( name "TITLE.PSX" size 148698 )
 )
 
 game (


### PR DESCRIPTION
@alfrix Without the CRCs in the entries, we get warnings when building the RDB...

```
=== Building Tomb Raider ===
Parsing dat file '/home/rob/Documents/libretro-super/retroarch/media/libretrodb/dat/Tomb Raider.dat'...
  - Missing match key 'rom.crc' on line 26
```

Mind adding them? If you can't find them we may need to remove them for now.