### PR TITLE
Add a few Super Metroid Rom Hacks to SNES.dat

### DIFF
--- a/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
@@ -3,6 +3,12 @@ clrmamepro (
     description "Romhacks of Super Nintendo / Super Famicom games"
 )
 game (
+    name "Ancient Chozo (1.1.0)"
+    description "'Super Metroid' Hack by Albert V."
+    homepage "http://metroidconstruction.com/hack.php?id=365"
+    rom ( name "Ancient_Chozo_1.1.0.smc" size 3244032 crc 0f3890f5 md5 a817bc339d87dbb68fb03dae8decbcd9 sha1 fa7328f225cf1ffa6d1f34487fb66e63c03ad944 )
+)
+game (
     name "Banzai Mario World (USA)"
     description "'Super Mario World' hack by GbreezeSunset"
     rom ( name "Banzai Mario World.sfc" size 2097152 crc 922d3660 md5 1daa2333725eec3e0f0ec077c2395755 sha1 ddc5df0b72a3a7b8e4904649087991ad3ab694d8 )
@@ -169,6 +175,12 @@ game (
     rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu B).sfc" size 4194304 crc 59486963 md5 003b119e354c70022d4e8ce67e5ddba3 sha1 750bf9dec0e428c1a164691a67c22147752955ab )
 )
 game (
+    name "Hyper Metroid (1.0)"
+    description "'Super Metroid' Hack by RealRed"
+    homepage "http://metroidconstruction.com/hack.php?id=294"
+    rom ( name "Hyper Metroid.sfc" size 4194304 crc d4d38230 md5 6b3c722165b3c566eda465386b585b51 sha1 727f8763983753e014e706520bb958bb4752e8b7 )
+)
+game (
     name "Mario & Luigi - Kola Kingdom Quest (USA)"
     description "'Super Mario World' hack by GammaV"
     rom ( name "KKQFinalFixed.sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )
@@ -182,6 +194,12 @@ game (
     name "Oh No! More Zombies Ate My Neighbors! (USA)"
     description "'Zombies Ate My Neighbors' hack by Stanley_Decker and sloat version 1.0"
     rom ( name "Oh No! More Zombies Ate My Neighbors!.sfc" size 4194304 crc d218147c md5 7f44a65cf20b213502314fc118b5a6f4 sha1 917b2c381e0ed77b8c3f196171d7285fce21a090 )
+)
+game (
+    name "Project Base (0.7.3)"
+    description "'Super Metroid' Hack by begrimed"
+    homepage "http://metroidconstruction.com/hack.php?id=307"
+    rom ( name "project_base_0.7.3.sfc" size 3211264 crc f225d664 md5 7bcd52c50cfacc8bf6d162a952e9bcbc sha1 8144b131714b87dc314618bcee810921de79dfde )
 )
 game (
     name  "Super Boss Gaiden (J)"


### PR DESCRIPTION
Hacks in question added were Hyper Metroid, Project Base, and Ancient Chozo, with Homepages pointing at Metroid Construction.
Probably could do with having more hacks be added to the hacks section in general, but I figure this might be a good start.