### PR TITLE
FBAlphaFB to FBNeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Generally, RetroArch's scanner is configured for ROMs that have been validated b
 |Bandai - WonderSwan Color|[No-Intro](http://datomatic.no-intro.org)|
 |Cave Story|[CaveStory.org (English or Japanese)](http://www.cavestory.org)|
 |DOS|[Total DOS Collection](http://www.totaldoscollection.org/)|[libretro-database-dos](https://github.com/robloach/libretro-database-dos)|
-|FB Alpha - Arcade Games|pre-0.2.97.44|[lr-fbalpha dats](https://github.com/libretro/fbalpha/tree/master/dats)|
-|FB Alpha (FB Edition) - Arcade Games| 0.2.97.44 (WIP)|[lr-FBAlphaFB dats](https://github.com/libretro/FBAlphaFB/tree/master/dats)|
+|FinalBurn Alpha - Arcade Games|pre-0.2.97.44|[lr-fbalpha dats](https://github.com/libretro/fbalpha/tree/master/dats)|
+|FinalBurn Neo - Arcade Games|0.2.97.44 (WIP)|[lr-FBAlphaFB dats](https://github.com/libretro/fbneo/tree/master/dats)|
 |GCE - Vectrex|[No-Intro](http://datomatic.no-intro.org)|
 |Id Software - Doom|Unknown|[libretro-database-doom](https://github.com/libretro/libretro-database/blob/master/dat/DOOM.dat)|
 |Id Software - Quake|Unknown|[libretro-database-quake](https://github.com/libretro/libretro-database/blob/master/dat/Quake1.dat)|


### PR DESCRIPTION
The new FBAlpha fork, formerly named FBAlphaFB, got the new official name as FinalBurn Neo. So this update reflect that change.