### PR TITLE
Remove Doom II - NRFTL (BFG Edition) (Xbox 360)

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -258,12 +258,6 @@ game (
 )
 
 game (
-	name "Doom II - No Rest for the Living (BFG Edition) (Xbox 360)"
-	description "Doom II - No Rest for the Living (BFG Edition) (Xbox 360)"
-	rom ( name NERVE.WAD size 3786293 crc 0fe8df75 md5 4f47bb32bf5fd06bc1cc0b4a2e8e3910 sha1 bb78b34dba684cc1ef1eea21f37092c6784d3b6f )
-)
-
-game (
 	name "Final Doom - Evilution"
 	description "Final Doom - Evilution"
 	rom ( name TNT.WAD size 18195736 crc 903dcc27 md5 4e158d9953c79ccf97bd0663244cc6b6 sha1 9fbc66aedef7fe3bae0986cdb9323d2b8db4c9d3 )


### PR DESCRIPTION
All copies of No Rest for the Living have identical checksums.  I have verified this using my own personal copies.

4f47bb32bf5fd06bc1cc0b4a2e8e3910 is a fan modification with MAPINFO added in.