### PR TITLE
Update Sinclair ZX81 DAT

### DIFF
--- a/dat/Sinclair - ZX 81.dat
+++ b/dat/Sinclair - ZX 81.dat
@@ -1,6089 +1,3149 @@
 clrmamepro (
-  name "Sinclair - ZX 81"
-  description "Sinclair - ZX 81"
-  version 20160505113721
-  comment "extracted from http://www.zx81stuff.org.uk, also with games from http://www.bobs-stuff.co.uk/zx81.html"
+	name "Sinclair - ZX 81"
+	description "Sinclair - ZX 81"
+	version "20160505113721"
+	author ""
+	comment "extracted from http://www.zx81stuff.org.uk, also with games from http://www.bobs-stuff.co.uk/zx81.html"
 )
-
 game (
-  name "10 Games (J. K. Greye)"
-  description "10 Games (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
+	name "1K Games (Sinclair Research)"
+	description "1K Games (Sinclair Research)"
+	manufacturer "Artic"
+	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
 )
-
 game (
-  name "1K Games Pack (Artic)"
-  description "1K Games Pack (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+	name "1K Games Pack (Artic)"
+	description "1K Games Pack (Artic)"
+	manufacturer "Artic"
+	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
 )
-
 game (
-  name "1K Games (Sinclair Research)"
-  description "1K Games (Sinclair Research)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+	name "1K ZX Chess (Artic)"
+	description "1K ZX Chess (Artic)"
+	manufacturer "Artic"
+	rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9c750652 md5 d6694fd23f6a9aa6ff644a0d7417332c sha1 ed848d9bd69311536da64c0414f7ae2ec9316622 )
+	rom ( name "chessqueen.p" size 941 crc 1a82385a md5 5292e4cac70342eed1b350846db0a90f sha1 dfad4c2de72aa4900367dbe92271f126ea192804 )
 )
-
 game (
-  name "1K ZX Chess (Sinclair Research)"
-  description "1K ZX Chess (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
+	name "1K ZX Chess (Sinclair Research)"
+	description "1K ZX Chess (Sinclair Research)"
+	year 1982
+	manufacturer "Artic"
+	rom ( name "1KZXChess.tzx" size 2223 crc 2fc225b9 md5 ddf8021eef88111be73fbccf8392439e sha1 055730a794e227e02d6fa780f1bb82a68c1b86bf )
 )
-
 game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
+	name "2K Games Pack (International Publishing and Software Inc.)"
+	description "2K Games Pack (International Publishing and Software Inc.)"
+	year 1982
+	rom ( name "2KGamesPack(IPS).tzx" size 6977 crc c1893b03 md5 25ebafa20015b01a383b70c19394e307 sha1 b33fdc40eb4631617c2687795de02904c92255c3 )
 )
-
 game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
+	name "3D Defender (J. K. Greye)"
+	description "3D Defender (J. K. Greye)"
+	year 1981
+	manufacturer "J. K. Greye"
+	rom ( name "3ddefender.p" size 11857 crc 4f97cbc6 md5 b344194f7456805b053f3e6786cfcdd5 sha1 bbaf7cd6f122f2508efecca8a8b2e1006b728752 )
+	rom ( name "3DDefender.tzx" size 12095 crc a9e69d1c md5 cd64e962bfcc000a9e3bd8cdb6e1c3e1 sha1 7c6b0a1fdef5c43aeed21f9d98f4e0c9837214cf )
 )
-
 game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
-  description "2K Games Pack (International Publishing and Software Inc.)"
-  year "1982"
-  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
+	name "3D Defender (New Generation)"
+	description "3D Defender (New Generation)"
+	year 1981
+	manufacturer "M. E. Evans"
+	rom ( name "3ddefender(ngs).p" size 11857 crc eb8178fd md5 57e5bdeaef06c83ae246bf132618a5ff sha1 1c9205c36224875446de0dc3abf0907200b7b993 )
+	rom ( name "3DDefender(NGS).tzx" size 12095 crc 0df02e27 md5 b2fe247ea9c9e64ba9fe419c96c9fc9c sha1 6aa9a12e6256bc2657326361c636571faf2cfb83 )
 )
-
 game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
+	name "3D Monster Maze (J. K. Greye)"
+	description "3D Monster Maze (J. K. Greye)"
+	year 1981
+	manufacturer "J. K. Greye"
+	rom ( name "3dmonstermaze.p" size 10552 crc 8f782725 md5 4e344f938d5600d81b7b0fde756abe7e sha1 cb254b2ce2012140211b641deeaf57177757ac25 )
+	rom ( name "3DMonsterMaze.tzx" size 10798 crc 436d8b0e md5 c38f7c7e81c6e781a9d665a4e468c6ef sha1 c6c141057d870b114d8844bb7578040ad8c5b151 )
 )
-
 game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
+	name "3D Monster Maze (New Generation)"
+	description "3D Monster Maze (New Generation)"
+	year 1982
+	manufacturer "J. K. Greye"
+	rom ( name "3dmonstermaze(ngs).p" size 10552 crc f4ce6079 md5 9cd5af6a9a9c61b2ea272f4f35058928 sha1 15093d2b89b5c5c4c0454af917be5554454864a7 )
+	rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38dbcc52 md5 5912b1261d2ed44f40d80bd6ca813405 sha1 2b0e9cd691979154c2d75ac76f93be076aab3423 )
 )
-
 game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
+	name "5-2K Family Pak (Timeworks)"
+	description "5-2K Family Pak (Timeworks)"
+	manufacturer "Timeworks"
+	rom ( name "52KFamilyPak.tzx" size 7846 crc fa438ced md5 e0b79ae2de178ddab3c3ee2691c68f78 sha1 1d613e0ab6462ab52c757aa1b6b6262311eb6c8e )
 )
-
 game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
+	name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+	description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+	manufacturer "GM4IHJ (J Branegan)"
+	rom ( name "8Programs.tzx" size 56578 crc bb788390 md5 4cf8b801597ae314132d8de1d5dc5d9b sha1 e2185c5962d8c89bb020028a22e25470405bef0f )
 )
-
 game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
+	name "10 Games (J. K. Greye)"
+	description "10 Games (J. K. Greye)"
+	year 1981
+	manufacturer "J. K. Greye"
+	rom ( name "10Games.tzx" size 7636 crc 141cddd1 md5 02eb203cd57645589a158495c2f7cebb sha1 3a776f7dbf4fd169572aad5b775b4ca27c61222a )
 )
-
 game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
+	name "Admiral Graf Spee (Temptation Software)"
+	description "Admiral Graf Spee (Temptation Software)"
+	manufacturer "Simon Mansfield"
+	rom ( name "AdmiralGrafSpee.tzx" size 17024 crc c583887e md5 3bd4fac61bdb6fc0a1bbc04ec7270df9 sha1 741a2b608801fc12705535fa88f2d895af486e80 )
 )
-
 game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
+	name "Advanced Budget Manager (Softsync)"
+	description "Advanced Budget Manager (Softsync)"
+	year 1982
+	manufacturer "Robert E. Davis Jr."
+	rom ( name "advancedbudgetmanager.p" size 16065 crc 3c9470f1 md5 57f9a0131be02387c11ff873da3c4fd4 sha1 9fff89fe3b70caac516db12f50e35c44fdd2c8e9 )
+	rom ( name "AdvancedBudgetManager.tzx" size 16291 crc 72a0eeda md5 b27dc1e6bb1a68b163457dad74a83f06 sha1 617af815c0545f0832cd9502ba51a0a5db5dcd1d )
 )
-
 game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
+	name "Advanced Mathematics (W. H. Smith)"
+	description "Advanced Mathematics (W. H. Smith)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "advancedmathematics.p" size 13415 crc 53d03118 md5 3057d11d80675cc9910181c915387cc6 sha1 944f9cfd8dbfd6038ae71c1c84343e17a3308f8b )
+	rom ( name "AdvancedMathematics.tzx" size 13671 crc e6a14eaa md5 0707dca0772a33981eb91f87dfab135d sha1 8caa2805da995945d9153828c921ad4ab96678a5 )
 )
-
 game (
-  name "5-2K Family Pak (Timeworks)"
-  description "5-2K Family Pak (Timeworks)"
-  manufacturer "Timeworks"
-  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
+	name "Adventure (Bug Byte)"
+	description "Adventure (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "adventure.p" size 15783 crc dd2dc75d md5 756ee1b0642b97ec7fa586aa0e8ef519 sha1 e06106ebb14581c6f69b351261f88f24be8c7bd2 )
+	rom ( name "Adventure.tzx" size 16017 crc 35d4be2a md5 55bae9d8b6d5e7d62ef8f1646c0dcc03 sha1 c5fb1e4aa356ec4a406a2da76495d9f9b368d058 )
 )
-
 game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  manufacturer "GM4IHJ (J Branegan)"
-  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
+	name "Adventure A - Planet of Death (Artic)"
+	description "Adventure A: Planet of Death (Artic)"
+	manufacturer "Artic"
+	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
+	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
 )
-
 game (
-  name "Admiral Graf Spee (Temptation Software)"
-  description "Admiral Graf Spee (Temptation Software)"
-  manufacturer "Simon Mansfield"
-  rom ( name "AdmiralGrafSpee.tzx" size 17024 crc C583887E md5 3BD4FAC61BDB6FC0A1BBC04EC7270DF9 sha1 741A2B608801FC12705535FA88F2D895AF486E80 )
+	name "Adventure A - Planet of Death (Sinclair Research)"
+	description "Adventure A: Planet of Death (Sinclair Research)"
+	year 1981
+	manufacturer "Artic"
+	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
+	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
 )
-
 game (
-  name "Advanced Budget Manager (Softsync)"
-  description "Advanced Budget Manager (Softsync)"
-  year "1982"
-  manufacturer "Robert E. Davis Jr."
-  rom ( name "advancedbudgetmanager.p" size 16065 crc 3C9470F1 md5 57F9A0131BE02387C11FF873DA3C4FD4 sha1 9FFF89FE3B70CAAC516DB12F50E35C44FDD2C8E9 )
+	name "Adventure B - Inca Curse (Artic)"
+	description "Adventure B: Inca Curse (Artic)"
+	year 1981
+	manufacturer "Artic"
+	rom ( name "incacurse(artic).p" size 11975 crc e5a05a0a md5 e24f9ea9c889a9587479085276980fa1 sha1 b1b85676ade56e51488f2262ee60facc22989967 )
+	rom ( name "IncaCurse(Artic).tzx" size 12205 crc 76d699e6 md5 15459a76af72151af7309c00ff13abae sha1 c3840c1539239437150d7e300b0bae412ad6a987 )
 )
-
 game (
-  name "Advanced Budget Manager (Softsync)"
-  description "Advanced Budget Manager (Softsync)"
-  year "1982"
-  manufacturer "Robert E. Davis Jr."
-  rom ( name "AdvancedBudgetManager.tzx" size 16291 crc 72A0EEDA md5 B27DC1E6BB1A68B163457DAD74A83F06 sha1 617AF815C0545F0832CD9502BA51A0A5DB5DCD1D )
+	name "Adventure B - Inca Curse (Sinclair Research)"
+	description "Adventure B: Inca Curse (Sinclair Research)"
+	year 1981
+	manufacturer "Artic"
+	rom ( name "incacurse.p" size 11975 crc e37cddd8 md5 736fd7c4c8854760206a05361299faf1 sha1 acb41012d467f473cb452f3cf1acb8608f108725 )
+	rom ( name "IncaCurse.tzx" size 12205 crc 700a1e34 md5 438603d7eaed102378af94260a15be1a sha1 8948f63c75c80dffa4e317e4d8ed400bd6b11de9 )
 )
-
 game (
-  name "Advanced Mathematics (W. H. Smith)"
-  description "Advanced Mathematics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "advancedmathematics.p" size 13415 crc 53D03118 md5 3057D11D80675CC9910181C915387CC6 sha1 944F9CFD8DBFD6038AE71C1C84343E17A3308F8B )
+	name "Adventure C (Monochrome) (Artic)"
+	description "Adventure C (Monochrome) (Artic)"
+	year 1982
+	manufacturer "Artic"
+	rom ( name "adventurec.p" size 14045 crc 52f0a175 md5 c824db7237c7299477c957becdf39335 sha1 152de35905f06389f06925e5a09cb30183669ad0 )
+	rom ( name "AdventureC.tzx" size 14275 crc 449ed54f md5 d4bbb25a3eb32b2e063a3ab9b09565ab sha1 ebc2d62e91088447c40bd394aa825acbe2982210 )
 )
-
 game (
-  name "Advanced Mathematics (W. H. Smith)"
-  description "Advanced Mathematics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "AdvancedMathematics.tzx" size 13671 crc E6A14EAA md5 0707DCA0772A33981EB91F87DFAB135D sha1 8CAA2805DA995945D9153828C921AD4AB96678A5 )
+	name "Adventure C - Ship of Doom (Artic)"
+	description "Adventure C: Ship of Doom (Artic)"
+	manufacturer "Artic"
+	rom ( name "shipofdoom(artic).p" size 14045 crc 3e244575 md5 47ae04d2d34190dd2f9d47fb9815f4de sha1 689552ef631facc558c6fc9b902f20495e870936 )
+	rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284a314f md5 ca0bab03eeff0fc9bcc040148e20c7d2 sha1 96221bceba4ff6e90fdc59271da1d7973362e8f8 )
 )
-
 game (
-  name "Adventure (Bug Byte)"
-  description "Adventure (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "adventure.p" size 15783 crc DD2DC75D md5 756EE1B0642B97EC7FA586AA0E8EF519 sha1 E06106EBB14581C6F69B351261F88F24BE8C7BD2 )
+	name "Adventure C - The Ship of Doom (Sinclair Research)"
+	description "Adventure C: The Ship of Doom (Sinclair Research)"
+	year 1982
+	manufacturer "Artic"
+	rom ( name "shipofdoom.p" size 14045 crc b8e32f06 md5 2515ba4ad2c1758f83d4e2f2cc81d6ca sha1 c64b4ae9fdbd955695660e6bd6a04ef2a6f91f39 )
+	rom ( name "ShipOfDoom.tzx" size 14275 crc ae8d5b3c md5 6e53ef483b27d942ff3ad6e69256c116 sha1 a1e5ab55214da2ca312345586f684e65204d52ad )
 )
-
 game (
-  name "Adventure (Bug Byte)"
-  description "Adventure (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "Adventure.tzx" size 16017 crc 35D4BE2A md5 55BAE9D8B6D5E7D62EF8F1646C0DCC03 sha1 C5FB1E4AA356EC4A406A2DA76495D9F9B368D058 )
+	name "Adventure D - Espionage Island (Artic)"
+	description "Adventure D: Espionage Island (Artic)"
+	manufacturer "Artic"
+	rom ( name "espionageisland(artic).p" size 15504 crc ac8df706 md5 348a6b4fbec8e375daf1be03d1c674df sha1 8ad3e1ae97a34a6f6b1e2f653aeed770ba33f01e )
+	rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06a3887c md5 30754aa09608d83deb1c0194c04b85cb sha1 7b36f0bce5eccb9fc3dc4fb553516e5e7f5adabe )
 )
-
 game (
-  name "Adventure C (Monochrome) (Artic)"
-  description "Adventure C (Monochrome) (Artic)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "adventurec.p" size 14045 crc 52F0A175 md5 C824DB7237C7299477C957BECDF39335 sha1 152DE35905F06389F06925E5A09CB30183669AD0 )
+	name "Adventure D - Espionage Island (Sinclair Research)"
+	description "Adventure D: Espionage Island (Sinclair Research)"
+	year 1982
+	manufacturer "Artic"
+	rom ( name "espionageisland.p" size 15504 crc 81ddf2b0 md5 24c456b967f1b621685579289a656ceb sha1 9c2db35b667f12a155aad2f2e5725b9fcf54e290 )
+	rom ( name "EspionageIsland.tzx" size 15734 crc 2bf38dca md5 50a59a5a1ca60349959ba2283e4188f8 sha1 1afaa1c3773c78f8f92941d95de226a727cc8822 )
 )
-
 game (
-  name "Adventure C (Monochrome) (Artic)"
-  description "Adventure C (Monochrome) (Artic)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "AdventureC.tzx" size 14275 crc 449ED54F md5 D4BBB25A3EB32B2E063A3AB9B09565AB sha1 EBC2D62E91088447C40BD394AA825ACBE2982210 )
+	name "Adventure One (Abersoft)"
+	description "Adventure One (Abersoft)"
+	year 1982
+	manufacturer "Abersoft"
+	rom ( name "adventureone.p" size 15612 crc 67617c4d md5 a3ddf09fae32bb1bebc9890bee01e788 sha1 34f97d91871439200f127334a675d01e5a918b4c )
+	rom ( name "AdventureOne.tzx" size 15848 crc b1cbaaa7 md5 95e5c9663fdd2dae7494826beb4b3d39 sha1 bad2e766140ee0159389ac513f37c0e8372ed5c8 )
 )
-
 game (
-  name "Adventure One (Abersoft)"
-  description "Adventure One (Abersoft)"
-  year "1982"
-  manufacturer "Abersoft"
-  rom ( name "AdventureOne.tzx" size 15848 crc B1CBAAA7 md5 95E5C9663FDD2DAE7494826BEB4B3D39 sha1 BAD2E766140EE0159389AC513F37C0E8372ED5C8 )
+	name "Adventure Tape 1 (Phipps Associates)"
+	description "Adventure Tape 1 (Phipps Associates)"
+	year 1983
+	manufacturer "Phipps Associates"
+	rom ( name "AdventureTape1.tzx" size 57316 crc f85217cb md5 ebf8c22018a8a88743ce8f926c7a5592 sha1 851fd8d8c082c534766deb7c7d724ed0e9ae9410 )
 )
-
 game (
-  name "Adventure One (Abersoft)"
-  description "Adventure One (Abersoft)"
-  year "1982"
-  manufacturer "Abersoft"
-  rom ( name "adventureone.p" size 15612 crc 67617C4D md5 A3DDF09FAE32BB1BEBC9890BEE01E788 sha1 34F97D91871439200F127334A675D01E5A918B4C )
+	name "Adventure Tape No. 1 (Phipps Associates)"
+	description "Adventure Tape No. 1 (Phipps Associates)"
+	year 1982
+	manufacturer "Phipps Associates"
+	rom ( name "AdventureTapeNo1.tzx" size 57280 crc 48254758 md5 80d738ef8e9bf92f06760da0bd986cbd sha1 bc8d49cbfa4156fcd10739b8ba17987a6708a2aa )
 )
-
 game (
-  name "Adventure Tape 1 (Phipps Associates)"
-  description "Adventure Tape 1 (Phipps Associates)"
-  year "1983"
-  manufacturer "Phipps Associates"
-  rom ( name "AdventureTape1.tzx" size 57316 crc F85217CB md5 EBF8C22018A8A88743CE8F926C7A5592 sha1 851FD8D8C082C534766DEB7C7D724ED0E9AE9410 )
+	name "Airline (Cases Computer Simulations)"
+	description "Airline (Cases Computer Simulations)"
+	year 1982
+	rom ( name "airline.p" size 15842 crc ee5ebb38 md5 0d2270547b0e378edaa4f22d1058deb4 sha1 88e1c1454ce376710f1ef8d864b20af8d6bb2fd5 )
+	rom ( name "Airline.tzx" size 16072 crc 844cbaac md5 3f4f3645c603230b8eb3742585c743c3 sha1 56b18d5296da989927c05c0f33dc30d2a3b1ba4c )
 )
-
 game (
-  name "Adventure Tape No. 1 (Phipps Associates)"
-  description "Adventure Tape No. 1 (Phipps Associates)"
-  year "1982"
-  manufacturer "Phipps Associates"
-  rom ( name "AdventureTapeNo1.tzx" size 57280 crc 48254758 md5 80D738EF8E9BF92F06760DA0BD986CBD sha1 BC8D49CBFA4156FCD10739B8BA17987A6708A2AA )
+	name "Algebra 1 (Timex)"
+	description "Algebra 1 (Timex)"
+	year 1982
+	manufacturer "Home Computer Software"
+	rom ( name "Algebra1.tzx" size 3926 crc 11f6af7c md5 06f5ba26638ce245da0d0c622bca75f1 sha1 4cfec3ba12646b6b5cf05860401750fa149fbce9 )
 )
-
 game (
-  name "Airline (Cases Computer Simulations)"
-  description "Airline (Cases Computer Simulations)"
-  year "1982"
-  rom ( name "airline.p" size 15842 crc EE5EBB38 md5 0D2270547B0E378EDAA4F22D1058DEB4 sha1 88E1C1454CE376710F1EF8D864B20AF8D6BB2FD5 )
+	name "Alien (PSS)"
+	description "Alien (PSS)"
+	year 1982
+	manufacturer "PSS"
+	rom ( name "alien.p" size 11735 crc b85d2a16 md5 47ab0a499a9a5558d7b76d9acc02f86f sha1 bbfd196dc9ca7694987fc079c7ba445f29435b3b )
+	rom ( name "Alien.tzx" size 11961 crc febc8fef md5 bf6d8512bdb99c04e3f0e40157fc6b6a sha1 9545ca45d3440c9a34be3411bc7395f37af82777 )
 )
-
 game (
-  name "Airline (Cases Computer Simulations)"
-  description "Airline (Cases Computer Simulations)"
-  year "1982"
-  rom ( name "Airline.tzx" size 16072 crc 844CBAAC md5 3F4F3645C603230B8EB3742585C743C3 sha1 56B18D5296DA989927C05C0F33DC30D2A3B1BA4C )
+	name "Alien Attack (Computer Rentals)"
+	description "Alien Attack (Computer Rentals)"
+	manufacturer "Computer Rentals"
+	rom ( name "alienattack.p" size 6209 crc 946e0ed7 md5 52cdd5d46f020af4a42c898919c866cf sha1 fb0be0363133dcd5dab240253fdcbf21c7f50c65 )
+	rom ( name "AlienAttack.tzx" size 6429 crc e6ce2fa6 md5 53ff8e58ba83e04522c87e4cb0d54002 sha1 f52df2571903d9aae931b359eabb67e2bbd6fc41 )
 )
-
 game (
-  name "Algebra 1 (Timex)"
-  description "Algebra 1 (Timex)"
-  year "1982"
-  manufacturer "Home Computer Software"
-  rom ( name "Algebra1.tzx" size 3926 crc 11F6AF7C md5 06F5BA26638CE245DA0D0C622BCA75F1 sha1 4CFEC3BA12646B6B5CF05860401750FA149FBCE9 )
+	name "Alien-Dropout (Silversoft)"
+	description "Alien-Dropout (Silversoft)"
+	year 1982
+	manufacturer "Silversoft"
+	rom ( name "aliendropout.p" size 3192 crc d6570c8d md5 f20b18d295751068432cd101cecab2c9 sha1 a18219e3e44a6cacb38afabd21153a6abf72fe82 )
+	rom ( name "AlienDropout.tzx" size 3424 crc fe0f33f4 md5 80d3c0c640aa71a3c12691b83b4c26cf sha1 c51813b542dd1432421ad7bb222a6f5cef4cd641 )
 )
-
 game (
-  name "Alien (PSS)"
-  description "Alien (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "alien.p" size 11735 crc B85D2A16 md5 47AB0A499A9A5558D7B76D9ACC02F86F sha1 BBFD196DC9CA7694987FC079C7BA445F29435B3B )
+	name "Alphaprobe (Artic)"
+	description "Alphaprobe (Artic)"
+	manufacturer "Artic"
+	rom ( name "alphaprobe.p" size 11016 crc 4b8bb297 md5 0fadaebde9d1d1843b74415333eadc7b sha1 cdaba21f5432945bf9ae06b111804f3c4cd385e2 )
+	rom ( name "Alphaprobe.tzx" size 11252 crc 7b7603f0 md5 0c36b487eaccb85755604c91d05dd8fe sha1 a71fdaec9225187ad0724bdaaab65b2860e994fb )
 )
-
-game (
-  name "Alien (PSS)"
-  description "Alien (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "Alien.tzx" size 11961 crc FEBC8FEF md5 BF6D8512BDB99C04E3F0E40157FC6B6A sha1 9545CA45D3440C9A34BE3411BC7395F37AF82777 )
-)
-
-game (
-  name "Alien Attack (Computer Rentals)"
-  description "Alien Attack (Computer Rentals)"
-  manufacturer "Computer Rentals"
-  rom ( name "AlienAttack.tzx" size 6429 crc E6CE2FA6 md5 53FF8E58BA83E04522C87E4CB0D54002 sha1 F52DF2571903D9AAE931B359EABB67E2BBD6FC41 )
-)
-
-game (
-  name "Alien Attack (Computer Rentals)"
-  description "Alien Attack (Computer Rentals)"
-  manufacturer "Computer Rentals"
-  rom ( name "alienattack.p" size 6209 crc 946E0ED7 md5 52CDD5D46F020AF4A42C898919C866CF sha1 FB0BE0363133DCD5DAB240253FDCBF21C7F50C65 )
-)
-
-game (
-  name "Alien-Dropout (Silversoft)"
-  description "Alien-Dropout (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "AlienDropout.tzx" size 3424 crc FE0F33F4 md5 80D3C0C640AA71A3C12691B83B4C26CF sha1 C51813B542DD1432421AD7BB222A6F5CEF4CD641 )
-)
-
-game (
-  name "Alien-Dropout (Silversoft)"
-  description "Alien-Dropout (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "aliendropout.p" size 3192 crc D6570C8D md5 F20B18D295751068432CD101CECAB2C9 sha1 A18219E3E44A6CACB38AFABD21153A6ABF72FE82 )
-)
-
-game (
-  name "Alphaprobe (Artic)"
-  description "Alphaprobe (Artic)"
-  manufacturer "Artic"
-  rom ( name "Alphaprobe.tzx" size 11252 crc 7B7603F0 md5 0C36B487EACCB85755604C91D05DD8FE sha1 A71FDAEC9225187AD0724BDAAAB65B2860E994FB )
-)
-
-game (
-  name "Alphaprobe (Artic)"
-  description "Alphaprobe (Artic)"
-  manufacturer "Artic"
-  rom ( name "alphaprobe.p" size 11016 crc 4B8BB297 md5 0FADAEBDE9D1D1843B74415333EADC7B sha1 CDABA21F5432945BF9AE06B111804F3C4CD385E2 )
-)
-
-game (
-  name "Arcade Action (Micromega)"
-  description "Arcade Action (Micromega)"
-  manufacturer "Micromega"
-  rom ( name "ArcadeAction.tzx" size 4651 crc 5CB215E3 md5 5A76C5D34BAA6D9AAF3BDD34E5C89597 sha1 04FC1FFA34592F093F1C0EAE9D54B3FF31EB3E86 )
-)
-
-game (
-  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-  description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-  year "1982"
-  rom ( name "aroundeuropein80hours.p" size 15223 crc 2DA984A7 md5 1DD7D90A090B80EA53C1B387B852D497 sha1 5D2A941CD7EDCA847BFD6C10B41B9025A81D4352 )
-)
-
-game (
-  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-  description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-  year "1982"
-  rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758C6 md5 5FEEE6F195CEE427CD9195A1C4462F58 sha1 CB59D966FE38C858DF9A002F2EAAAE2CB0E1BA73 )
-)
-
-game (
-  name "Asteroids (Silversoft)"
-  description "Asteroids (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "Asteroids.tzx" size 3776 crc 939E50E5 md5 5F4836D37CB10B4BB5C7C71BB857409A sha1 85047AB187BFCD02195F00150419CEE1BFC07A5F )
-)
-
-game (
-  name "Asteroids (Silversoft)"
-  description "Asteroids (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "asteroids.p" size 3542 crc 7484AC13 md5 0A392517E1D78420E0A5B5AAFEFE0C39 sha1 27D633E47D4E5A6B1594B16103E6A7EA12B5D0A7 )
-)
-
-game (
-  name "Asteroids (Software Farm)"
-  description "Asteroids (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "Asteroids(SF).tzx" size 8594 crc 8B6F8743 md5 D7F2518BD65DBD7D99842F5A27AAB588 sha1 D56D7E03A545B99607174FAEC186C42E64618189 )
-)
-
-game (
-  name "Asteroids (Software Farm)"
-  description "Asteroids (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "asteroids(sf).p" size 8360 crc 0EFCEBD4 md5 583C3E31090F678A465C46D0CFCF2AD7 sha1 7F114CD978045301B7C63F7177D2FE2D0EE33264 )
-)
-
-game (
-  name "Autochef (Cases Computer Simulations)"
-  description "Autochef (Cases Computer Simulations)"
-  year "1982"
-  rom ( name "Autochef.tzx" size 15648 crc 3869AE07 md5 81856A30F98CCAA2FDBD6C88D8C7897F sha1 2B7416327BDB907108D287F8CD4EAA0FD291ECBA )
-)
-
-game (
-  name "Autochef (Cases Computer Simulations)"
-  description "Autochef (Cases Computer Simulations)"
-  year "1982"
-  rom ( name "autochef.p" size 15430 crc 575560BB md5 21C42C6C6EAF0866DC56533F89688F4F sha1 DD0EE23E39D50738D91731C427063AC8E59AD9D3 )
-)
-
-game (
-  name "Avenger (Abacus)"
-  description "Avenger (Abacus)"
-  year "1982"
-  manufacturer "K. Flynn"
-  rom ( name "Avenger.tzx" size 7368 crc B545FDAE md5 B0E975A6CDFF98F667536F3FD4D902BD sha1 529B2A9EB67C50DB12494CC0FF7272925E9D18B4 )
-)
-
-game (
-  name "Avenger (Abacus)"
-  description "Avenger (Abacus)"
-  year "1982"
-  manufacturer "K. Flynn"
-  rom ( name "avenger.p" size 7138 crc 53621A49 md5 1AF4B6A7F31315A701B5DD54068C5596 sha1 0F402A98C52410358F2A3EC94280AF6C7375F9AC )
-)
-
-game (
-  name "Backgammon (Keith Archer)"
-  description "Backgammon (Keith Archer)"
-  year "1982"
-  manufacturer "Keith Archer"
-  rom ( name "Backgammon(KA).tzx" size 11861 crc 153ED883 md5 71F46D576FE8BFA343D41949DABD2E55 sha1 81F25C1667C8EBA6936EABFD080CCAD3A3A34ADD )
-)
-
-game (
-  name "Backgammon (Keith Archer)"
-  description "Backgammon (Keith Archer)"
-  year "1982"
-  manufacturer "Keith Archer"
-  rom ( name "backgammon(ka).p" size 11625 crc F4D9073B md5 B0A388F1B834D98852D96F998C1978CC sha1 C0C4E28934D05735B2200C41F2AF8EB7B3ABD1CB )
-)
-
-game (
-  name "Backgammon (Timex)"
-  description "Backgammon (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "Backgammon(Timex).tzx" size 17108 crc 307AACD2 md5 D068903731302F4DC6C0E7810D1ED944 sha1 5A78754D849FE5284342089159AF45588029C0A9 )
-)
-
-game (
-  name "Bank Robber (Romik Software)"
-  description "Bank Robber (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "bankrobber.p" size 6560 crc 2973AF44 md5 8CA20ED973A7A1B830087CD30DB7EDBA sha1 5EBDBD6B13B82933C158BD439B89BF6CE69149A7 )
-)
-
-game (
-  name "Bank Robber (Romik Software)"
-  description "Bank Robber (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "BankRobber.tzx" size 6798 crc F9A7AB7D md5 36E6E97BD4EA83C494B6134E1AEEE1C2 sha1 40D0FCC8FAAF73B0082D4F1937EF16626D289F66 )
-)
-
-game (
-  name "Baron (Temptation Software)"
-  description "Baron (Temptation Software)"
-  manufacturer "Simon Mansfield"
-  rom ( name "Baron.tzx" size 16716 crc 2813C7A1 md5 C6AE4F6CF29411686BDE01114A682498 sha1 FD944CEDD638D3A5D6B70A8A4D50F2D41C16EA74 )
-)
-
-game (
-  name "Basicode 2 (BBC)"
-  description "Basicode 2 (BBC)"
-  year "1984"
-  manufacturer "The Chip Shop"
-  rom ( name "Basicode2.A.tzx" size 3570 crc DB6F1818 md5 AD1857F473CA1DE8ED5D7B855D566C54 sha1 9204245ADF3F343E82C43D6EC70117C4DC491908 )
-)
-
-game (
-  name "Basicode 2 (BBC)"
-  description "Basicode 2 (BBC)"
-  year "1984"
-  manufacturer "The Chip Shop"
-  rom ( name "basicode2.p" size 3338 crc 89CE64F1 md5 CAB7E8ADF644459CE8C1DD54897A184C sha1 07A3DE146663D0E77A98A0800FB6F0545D567D77 )
-)
-
-game (
-  name "Bat Cage (Timex)"
-  description "Bat Cage (Timex)"
-  year "1982"
-  manufacturer "Thomas J. Burke"
-  rom ( name "batcage.p" size 1222 crc A1B5D16F md5 0A716AD28C067C5938D776FABADFC176 sha1 E3DBDE749FF3618AB07A6C8FC712531BE6272BCF )
-)
-
-game (
-  name "Bat Cage (Timex)"
-  description "Bat Cage (Timex)"
-  year "1982"
-  manufacturer "Thomas J. Burke"
-  rom ( name "BatCage.tzx" size 1446 crc 650A94D8 md5 C3B8A71965F8BA025D546B7FE8F1531B sha1 8F6842F02E416E8B66C8D6172F2E852A5E14D2F8 )
-)
-
-game (
-  name "Battleships (JRS Software)"
-  description "Battleships (JRS Software)"
-  year "1982"
-  manufacturer "JRS Software"
-  rom ( name "Battleships.tzx" size 12962 crc A1057BC5 md5 8840352DD5514D5BC84E82F14F6211E2 sha1 0C36982F0243F39C028A21207A2218D40B1CB369 )
-)
-
-game (
-  name "Battleships (JRS Software)"
-  description "Battleships (JRS Software)"
-  year "1982"
-  manufacturer "JRS Software"
-  rom ( name "battleships.p" size 12732 crc A0A631A4 md5 99BDB02395ED7A85C8B13911C0344516 sha1 6897424919C684A7A18235D967C7F621F02D1CF0 )
-)
-
-game (
-  name "Bigflap Attack (Timex)"
-  description "Bigflap Attack (Timex)"
-  manufacturer "Timex"
-  rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66C706F432AD9277573B709C913B16A0 sha1 985F2F32AE4478051B5B7D91CB17BBC474FD26F6 )
-)
-
-game (
-  name "Black Star (Quicksilva)"
-  description "Black Star (Quicksilva)"
-  year "1983"
-  manufacturer "M. Sudworth"
-  rom ( name "blackstar.p" size 6811 crc 0407BEAC md5 D34202B6AC2F39323AD1212CA360E18B sha1 C17AA876DFEEF10FD9D8DA5BD83CC6FEC9396FB9 )
-)
-
-game (
-  name "Black Star (Quicksilva)"
-  description "Black Star (Quicksilva)"
-  year "1983"
-  manufacturer "M. Sudworth"
-  rom ( name "BlackStar.tzx" size 7047 crc F227253F md5 C5B418B890BB6D828EC84D2FB36152AB sha1 0ABE2CA4064679C23DA82773FAB70BF05C245844 )
-)
-
-game (
-  name "Bouncing Bert (Software Farm)"
-  description "Bouncing Bert (Software Farm)"
-  year "1985"
-  manufacturer "S C T"
-  rom ( name "bouncingbert.p" size 14919 crc FB88AD49 md5 E575AA04406A3F9EB1C095E8C0B6CD3A sha1 A56DDDC42A1383C392D6988C9DAFB4C8DB37007A )
-)
-
-game (
-  name "Bouncing Bert (Software Farm)"
-  description "Bouncing Bert (Software Farm)"
-  year "1985"
-  manufacturer "S C T"
-  rom ( name "BouncingBert.tzx" size 15151 crc C30CAF71 md5 AE2A31C5A4B92C6213B7547608110E86 sha1 EF3BE8446D80452A155ED647A55C7D24AEE58A6D )
-)
-
-game (
-  name "Breakout (CDS Micro Systems)"
-  description "Breakout (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "breakout.p" size 3235 crc 82836AC3 md5 3F4B0E39130BE53AE22381F8A82A3081 sha1 EB36D14650C568ED47326DC094392C70FD249B3C )
-)
-
-game (
-  name "Breakout (CDS Micro Systems)"
-  description "Breakout (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "Breakout.tzx" size 3467 crc 322FAFD6 md5 0323A0D24248E0DE2DCE75C7CD3B71A9 sha1 1CB495C3B751E64E8B1FC38C68FABF0340365F39 )
-)
-
-game (
-  name "Breakout (J. K. Greye)"
-  description "Breakout (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "breakout(jkg).p" size 716 crc 15CB56B4 md5 4655A4C1F58C705F303D31D2F2E64F7F sha1 2A4DDAE5DF3C18192C851BE567DAEB9AB59AA456 )
-)
-
-game (
-  name "Breakout (J. K. Greye)"
-  description "Breakout (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "Breakout(JKG).tzx" size 948 crc E3F0284A md5 C52F2080DC8E969B4636DA6F9D4F1E54 sha1 C8138F8960AEDF4D848C65B676D76BF717EC9154 )
-)
-
-game (
-  name "Breakout (New Generation)"
-  description "Breakout (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "breakout(ngs).p" size 716 crc D4496E38 md5 E488EF1A3EFC25F2ABD308F9AEF901B5 sha1 BD90A91D1EF17E19802D145DAC955D0D34CAB5F0 )
-)
-
-game (
-  name "Breakout (New Generation)"
-  description "Breakout (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "Breakout(NGS).tzx" size 948 crc 227210C6 md5 50FE074B25394A62A8FBBB8DAC9513FB sha1 86B96863CFFCA1038110A78B99B4DF5FBCC75DAA )
-)
-
-game (
-  name "Breakout 3 (Axis)"
-  description "Breakout 3 (Axis)"
-  year "1982"
-  manufacturer "Axis"
-  rom ( name "Breakout3.tzx" size 5705 crc 69B9A5BF md5 595C064A5D18089BEC87664DC37AB2DA sha1 FAF622EFF6CCA236E0623D7F23CF35BFEF74D823 )
-)
-
-game (
-  name "Breakout 3 (Axis)"
-  description "Breakout 3 (Axis)"
-  year "1982"
-  manufacturer "Axis"
-  rom ( name "breakout3.p" size 5485 crc A836659C md5 9AE6333AD0003617DA56543E57A60903 sha1 F226DF48CFCABEA16956FAFF21E88E3EEECCF66C )
-)
-
-game (
-  name "Breakout, Space Invaders and Music (Macronics)"
-  description "Breakout, Space Invaders and Music (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "BreakoutSIAndMusic.tzx" size 2734 crc D383DB01 md5 13110862ADF0B4ABB06573A2BE710087 sha1 D5582E7A6A79BD6B8A2096ED968C91292B46483B )
-)
-
-game (
-  name "Brick Stop (CDS Micro Systems)"
-  description "Brick Stop (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "BrickStop.tzx" size 3362 crc 2E173AFA md5 65A723688C0FD694AD600407FC12EC17 sha1 232822DEB023BE4037E9864A1CCD01E8C42A32BF )
-)
-
-game (
-  name "Brick Stop (CDS Micro Systems)"
-  description "Brick Stop (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "brickstop.p" size 3126 crc 8EE66ABE md5 B70594C6CB40AC4B3B7706574153563D sha1 FD697AE6EC522406F4E6B91A5C7A5D7C9058A4FF )
-)
-
-game (
-  name "Bubble Bugs (Romik Software)"
-  description "Bubble Bugs (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "BubbleBugs.tzx" size 6647 crc 368C6F68 md5 3E4FEEB96B4FF463FF81BE369592C0DE sha1 E52DDAB32B1183910D1C74AE04999A8FB92DC158 )
-)
-
-game (
-  name "Bubble Bugs (Romik Software)"
-  description "Bubble Bugs (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "bubblebugs.p" size 6409 crc 1E09B9EC md5 00B1A8FE3030CF7B4CD91B5EAF986516 sha1 8770497D4DB9455F31DC6F422B710BA44DCAB096 )
-)
-
-game (
-  name "The Budgeter (Timex)"
-  description "The Budgeter (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "BudgeterThe.tzx" size 7653 crc 5EA30258 md5 AB5775378AF88AAF6FD6B6E653F00318 sha1 936A4BDF69507C24B8A634C94065548A3757FAC9 )
-)
-
-game (
-  name "The Budgeter (Timex)"
-  description "The Budgeter (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "budgeterthe.p" size 7421 crc 8D3B6FC8 md5 F8F70240FD3CE11EDA2D349F26D760D9 sha1 C2D31635238B2D581C1D8E4C7ED0565933275B1D )
-)
-
-game (
-  name "Bumper 7 (Axis)"
-  description "Bumper 7 (Axis)"
-  year "1981"
-  manufacturer "Axis"
-  rom ( name "Bumper7.tzx" size 5179 crc 3C31D394 md5 7A42934F415AD9587A203974BBE2F6F2 sha1 2ADC581BACA7D49305C0CCD720F594C50618BE5E )
-)
-
-game (
-  name "Byter (Protek)"
-  description "Byter (Protek)"
-  year "1983"
-  manufacturer "Protek"
-  rom ( name "byter.p" size 5045 crc 1C53AC02 md5 8DB34A0ED323545380AC2EB69190FA18 sha1 C396155336A5F43E908DE08C5398B670F694B4F7 )
-)
-
-game (
-  name "Byter (Protek)"
-  description "Byter (Protek)"
-  year "1983"
-  manufacturer "Protek"
-  rom ( name "Byter.tzx" size 5271 crc 540854FE md5 423D68CC0EDD3F4C360CC58F167F0E71 sha1 AB1F4D1F13735E7FFE4E143C1EE159A2CA1A0617 )
-)
-
-game (
-  name "Can of Worms (Automata Cartography)"
-  description "Can of Worms (Automata Cartography)"
-  manufacturer "Automata Cartography"
-  rom ( name "CanOfWorms.tzx" size 7150 crc B2E6FA12 md5 3A724F1A32F350922012F1FF6B6E0193 sha1 9BB651B39206913BBE74600997114FCBCD70747C )
-)
-
-game (
-  name "The Carpooler (Timex)"
-  description "The Carpooler (Timex)"
-  manufacturer "Timex"
-  rom ( name "CarpoolerThe.tzx" size 14507 crc D8258CEF md5 9F1A67808E8506B0DF3C66BF00568CAF sha1 CAFBB78BF77F88C0FFB29E6C2A92666899149C8E )
-)
-
-game (
-  name "The Carpooler (Timex)"
-  description "The Carpooler (Timex)"
-  manufacturer "Timex"
-  rom ( name "carpoolerthe.p" size 14277 crc 0D8ABCAC md5 068BE6E28AF97837FFBB6D292930B6D7 sha1 992B08B7FC5BC7D0D891459FBCEBB078BA9D2649 )
-)
-
-game (
-  name "Cassette 3 (M. Orwin)"
-  description "Cassette 3 (M. Orwin)"
-  year "1982"
-  manufacturer "Various"
-  rom ( name "Cassette3.tzx" size 96710 crc F612E596 md5 688FE0BD73CF475D632EBB2BC920F92C sha1 A3A02C88CD119F5ACF87EF056A8B26DAD0A79390 )
-)
-
-game (
-  name "Cassette 4 (M. Orwin)"
-  description "Cassette 4 (M. Orwin)"
-  year "1982"
-  manufacturer "Various"
-  rom ( name "Cassette4.tzx" size 53160 crc 9C246427 md5 ACFC26DD06D2A03808F0FF71E9BE96D2 sha1 5CDB627AC5B3498225D7D4D5FB90D80751187218 )
-)
-
-game (
-  name "Castle Adventure (CDS Micro Systems)"
-  description "Castle Adventure (CDS Micro Systems)"
-  manufacturer "CDS Micro Systems"
-  rom ( name "Castle.tzx" size 14716 crc BA09CC38 md5 EF3141D3308BCD5DD7831A27E8CC5899 sha1 688ABD7300F76E35F69AE025A4411F2767514B94 )
-)
-
-game (
-  name "Castle Adventure (CDS Micro Systems)"
-  description "Castle Adventure (CDS Micro Systems)"
-  manufacturer "CDS Micro Systems"
-  rom ( name "castle.p" size 14488 crc 1D01ED81 md5 239C2112AE0B67A045BFEB0397D4F3E0 sha1 00755932CA214C899B866036E666DF6325FDD59A )
-)
-
-game (
-  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-  description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "Castle.tzx" size 14716 crc BA09CC38 md5 EF3141D3308BCD5DD7831A27E8CC5899 sha1 688ABD7300F76E35F69AE025A4411F2767514B94 )
-)
-
-game (
-  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-  description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "castle.p" size 14488 crc 1D01ED81 md5 239C2112AE0B67A045BFEB0397D4F3E0 sha1 00755932CA214C899B866036E666DF6325FDD59A )
-)
-
-game (
-  name "Catacombs (J. K. Greye)"
-  description "Catacombs (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "Catacombs.tzx" size 12740 crc F8D6AEE6 md5 6EC147973D7561EDE4726BC413409CDD sha1 C872D07E278DF997DF9A66185852F580FD851151 )
-)
-
-game (
-  name "Catacombs (J. K. Greye)"
-  description "Catacombs (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "catacombs.p" size 12506 crc B1ED0B59 md5 5E674CE62EFD5AB861BBEEF9DE75D711 sha1 A5D32E1D50D291C485549C4740E5CC6BA3DE36AB )
-)
-
-game (
-  name "Cave Crusade (AWA Software)"
-  description "Cave Crusade (AWA Software)"
-  manufacturer "S. Hughes"
-  rom ( name "CaveCrusade.tzx" size 6510 crc 9DEC44E3 md5 4E27965613610224B2C60F824983F7A7 sha1 BC4A46FDEC5734A88AFC005DF4864FEAE26549E1 )
-)
-
-game (
-  name "Cave Crusade (AWA Software)"
-  description "Cave Crusade (AWA Software)"
-  manufacturer "S. Hughes"
-  rom ( name "cavecrusade.p" size 6270 crc A2EB2F80 md5 B6C9C3F387D5BA97D80FE92A03E6D0C5 sha1 5F05D170D3EBA9A7C4915EECD7E65BBBB958FECA )
-)
-
-game (
-  name "Centipede (Llamasoft)"
-  description "Centipede (Llamasoft)"
-  year "1982"
-  manufacturer "Jeff Minter"
-  rom ( name "Centipede.tzx" size 9940 crc 163CF493 md5 74AC41B73E525977DD00E99E92A46E53 sha1 DD75BBB4EC90C8D054E1C0A41164E02A8F3121E3 )
-)
-
-game (
-  name "Centipede (Llamasoft)"
-  description "Centipede (Llamasoft)"
-  year "1982"
-  manufacturer "Jeff Minter"
-  rom ( name "centipede.p" size 9706 crc F2414D13 md5 EEBA50F572E820D43FB3F8D140C673E1 sha1 0F23AA3EAC663BD04DE225074B80701BA05FCB1B )
-)
-
-game (
-  name "Centipede (Green cover) (dK'tronics)"
-  description "Centipede (Green cover) (dK'tronics)"
-  manufacturer "dK'tronics"
-  rom ( name "Centipede(Green).tzx" size 9967 crc 0ED972CD md5 9DD33FD4999F2D1DE4BF52E4590D2521 sha1 1BF47EF2651D5D09A6971CE9EB931AA41ED846CB )
-)
-
-game (
-  name "Centipede (Green cover) (dK'tronics)"
-  description "Centipede (Green cover) (dK'tronics)"
-  manufacturer "dK'tronics"
-  rom ( name "centipede(green).p" size 9733 crc F5F4B919 md5 90610D4FA888969F53204A5CA98F6A20 sha1 418C10220FBF3BCF83C07B2A9C717DD12DC92C53 )
-)
-
-game (
-  name "Centipede (dktronics) (dK'tronics)"
-  description "Centipede (dktronics) (dK'tronics)"
-  year "1982"
-  manufacturer "Jeff Minter"
-  rom ( name "centipede(dktronics).p" size 9790 crc 1E369CE6 md5 DD7D3F2E2B36FFBD2CC169624FC60421 sha1 7770684A912C0BB2116D9F73F1CAAFC1796A23DF )
-)
-
-game (
-  name "Centipede (dktronics) (dK'tronics)"
-  description "Centipede (dktronics) (dK'tronics)"
-  year "1982"
-  manufacturer "Jeff Minter"
-  rom ( name "Centipede(dktronics).tzx" size 10008 crc F12C5EE1 md5 78B3D51B99FA1B99182D60B206FE2944 sha1 C90D0CA1DD3E1679C9C0E4A359D6B84978C129F7 )
-)
-
-game (
-  name "Challenge (Micromega)"
-  description "Challenge (Micromega)"
-  manufacturer "Micromega"
-  rom ( name "Challenge.tzx" size 4865 crc 8439C8B1 md5 B963B33677E4E187630608606FECBA67 sha1 B3DD53DF21A684570B3120A8A996FAE738DFB15A )
-)
-
-game (
-  name "The Challenger 1 (Timex)"
-  description "The Challenger 1 (Timex)"
-  year "1982"
-  manufacturer "R. Fowkes"
-  rom ( name "Challenger1The.tzx" size 4178 crc A01B37E4 md5 CA1D005637983ED5618C1BFD4B9BB08D sha1 5B9809A27911E43D8FB882A60DA3752FE202BC27 )
-)
-
-game (
-  name "Champions! (Peaksoft)"
-  description "Champions! (Peaksoft)"
-  manufacturer "Peaksoft"
-  rom ( name "champions.p" size 14858 crc D363867F md5 806E86A4E8C5807CE53717E4BA441C98 sha1 2148C6108E52C8C33A8C1593C47A1EE89ED711B8 )
-)
-
-game (
-  name "Champions! (Peaksoft)"
-  description "Champions! (Peaksoft)"
-  manufacturer "Peaksoft"
-  rom ( name "Champions.tzx" size 15086 crc 7AE0415B md5 7F738BEFE88938AE2F5BFAF464CC2C16 sha1 1847183FFCAF74BB7F709D09D1D5FEA24C720E6A )
-)
-
-game (
-  name "The Checkbook Manager (Timex)"
-  description "The Checkbook Manager (Timex)"
-  year "1982"
-  manufacturer "John Heaney"
-  rom ( name "checkbookmanagerthe.p" size 13483 crc B9446D9B md5 6E610DCA9691A1FC82C89A5BA4A4574D sha1 5A12849CE4BE86742C393306023FBF2FB081CA6A )
-)
-
-game (
-  name "The Checkbook Manager (Timex)"
-  description "The Checkbook Manager (Timex)"
-  year "1982"
-  manufacturer "John Heaney"
-  rom ( name "CheckbookManagerThe.tzx" size 13713 crc B32EAA12 md5 59CD50185F32789958737B3EAC99C64B sha1 D1B150FEE25332715AF8115604D8063E5A71B77D )
-)
-
-game (
-  name "Chess (Timex)"
-  description "Chess (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "Chess(Timex).tzx" size 10227 crc 8F6BFDC7 md5 C0678ED697E11DFA85E483DB93DD053C sha1 BD2A54D8CCB6BD918DEABA02B0793CF0372C8F27 )
-)
-
-game (
-  name "Chrs Demo (Quicksilva)"
-  description "Chrs Demo (Quicksilva)"
-  manufacturer "Quicksilva"
-  rom ( name "ChrsDemo.tzx" size 5993 crc 3E8D1DA7 md5 B69EA89A89170660517BF2284C791E12 sha1 8509B1FC61DC20C1E9280526858B0E95BD6359B5 )
-)
-
-game (
-  name "City of Xon (Pleasantrees)"
-  description "City of Xon (Pleasantrees)"
-  year "1982"
-  manufacturer "Pleasantrees"
-  rom ( name "CityOfXon.tzx" size 15729 crc 3B72AF94 md5 18B114EE78E469EA4B85E858802A716C sha1 0D07FB55913B3495B0C26178C84D010CD5EEB03E )
-)
-
-game (
-  name "City of Xon (Pleasantrees)"
-  description "City of Xon (Pleasantrees)"
-  year "1982"
-  manufacturer "Pleasantrees"
-  rom ( name "cityofxon.p" size 15507 crc E853667C md5 82A04AFAF98222545389663888140B7B sha1 2111223FD0CAB96C1ACA585430336E60D501017F )
-)
-
-game (
-  name "City Patrol (Sinclair Research)"
-  description "City Patrol (Sinclair Research)"
-  year "1982"
-  manufacturer "Macronics (Don Priestley)"
-  rom ( name "citypatrol.p" size 9168 crc B9CF2E5F md5 A14424F16ED442E3C0AF074F2EA01C95 sha1 333C2E1052DC734D76B19DA5DDDFAA9835177E12 )
-)
-
-game (
-  name "City Patrol (Sinclair Research)"
-  description "City Patrol (Sinclair Research)"
-  year "1982"
-  manufacturer "Macronics (Don Priestley)"
-  rom ( name "CityPatrol.tzx" size 9388 crc 1EA8841E md5 71C94BC78806C1EA06D1996CBF6D64E8 sha1 99D5AE89CFE7940E67D8EDE6DBD860020B1AD9DF )
-)
-
-game (
-  name "Club Record Controller (Sinclair Research)"
-  description "Club Record Controller (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "clubrecordcontroller.p" size 6857 crc 16B8F22F md5 481DAF4708C4217FF3C5446F049E5D61 sha1 73048E28D5C2F198A97C1BA33E9A2111A1901465 )
-)
-
-game (
-  name "Club Record Controller (Sinclair Research)"
-  description "Club Record Controller (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "ClubRecordController.tzx" size 7075 crc C1BDAA09 md5 03638152AFE7D50F7F3050D42423FB5A sha1 246F887ED316A62311165AF8AC7ABEE59C0CFCE6 )
-)
-
-game (
-  name "Club Records (W. H. Smith)"
-  description "Club Records (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "clubrecords.p" size 7526 crc 770EAD60 md5 43274F46A93F29E10650A6C0EA5D6EA6 sha1 06C9B03442650D03948BDD73095BA4541CF4FFF4 )
-)
-
-game (
-  name "Club Records (W. H. Smith)"
-  description "Club Records (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "ClubRecords.tzx" size 7744 crc 229BF155 md5 9061510C942E211DB25159985FD39A7B sha1 D62DC88512D6DC336DAD5637924E6056A19E12A7 )
-)
-
-game (
-  name "Collector's Pack (Sinclair Research)"
-  description "Collector's Pack (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "collectorspack.p" size 7447 crc AD2FAA57 md5 DC7C428A0DF6B6140DD71F0924F80316 sha1 67FF172B4EC0B7B088B17EE62DF3860851748705 )
-)
-
-game (
-  name "Collector's Pack (Sinclair Research)"
-  description "Collector's Pack (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "CollectorsPack.tzx" size 7665 crc 4998A5D6 md5 8FD43049AE5C0246D79C82D59CEF6CD4 sha1 BB2B43893119EABF30754BE20992BF32E05E6832 )
-)
-
-game (
-  name "Collector's Recording System (W. H. Smith)"
-  description "Collector's Recording System (W. H. Smith)"
-  manufacturer "ICL"
-  rom ( name "collectorsrecordingsystem.p" size 7447 crc FE3EB9CC md5 8AF2B0E4D7A7480859B978AFF6B8954D sha1 BF4B5D5C78B6A1E68784296567AA655362D6A552 )
-)
-
-game (
-  name "Collector's Recording System (W. H. Smith)"
-  description "Collector's Recording System (W. H. Smith)"
-  manufacturer "ICL"
-  rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1A89B64D md5 D0735FC71D39A879E80FE130F3CA8226 sha1 7FB6CF85C4A0E47A2AD78F5F4371DEEEBADCB923 )
-)
-
-game (
-  name "Community Chest (Artic)"
-  description "Community Chest (Artic)"
-  manufacturer "Artic"
-  rom ( name "CommunityChest.tzx" size 14270 crc BF585C82 md5 A4B42D6021CECA0F9C09AA0E6596C110 sha1 C95AF3F37795ADABE7F251643EFFF51CB7E2579F )
-)
-
-game (
-  name "Community Chest (Artic)"
-  description "Community Chest (Artic)"
-  manufacturer "Artic"
-  rom ( name "communitychest.p" size 14048 crc 0FE4512D md5 A40B1C79C5B578238002454F2A4B92BC sha1 941725AEEF9136F7B105BD1E8C21245EC671AC86 )
-)
-
-game (
-  name "ComputaCalc ZX (Silicon Tricks)"
-  description "ComputaCalc ZX (Silicon Tricks)"
-  year "1981"
-  manufacturer "S. C. Stephens"
-  rom ( name "computacalc.p" size 8990 crc 45EAF966 md5 7D48EECD455038A643E84CFD5FEAB476 sha1 D765D5C3AA5E516E07EB9465E222A777ED540FA8 )
-)
-
-game (
-  name "ComputaCalc ZX (Silicon Tricks)"
-  description "ComputaCalc ZX (Silicon Tricks)"
-  year "1981"
-  manufacturer "S. C. Stephens"
-  rom ( name "ComputaCalc.tzx" size 9228 crc 06066AFC md5 FE153257A523703B95488A6CDB4640BC sha1 496065DBC17D2461647BB76933AD9247F03CD1DE )
-)
-
-game (
-  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-  description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-  year "1981"
-  manufacturer "S. C. Stephens"
-  rom ( name "computacalc.p" size 8990 crc 45EAF966 md5 7D48EECD455038A643E84CFD5FEAB476 sha1 D765D5C3AA5E516E07EB9465E222A777ED540FA8 )
-)
-
-game (
-  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-  description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-  year "1981"
-  manufacturer "S. C. Stephens"
-  rom ( name "ComputaCalc.tzx" size 9228 crc 06066AFC md5 FE153257A523703B95488A6CDB4640BC sha1 496065DBC17D2461647BB76933AD9247F03CD1DE )
-)
-
-game (
-  name "Constellation (Bug Byte)"
-  description "Constellation (Bug Byte)"
-  manufacturer "Bug Byte"
-  rom ( name "constellation.p" size 12385 crc 82892356 md5 B7FF958C98E6955281AED8D50CE4A8B2 sha1 B020CEC9FD14F00882DE28165F4F2A207E020306 )
-)
-
-game (
-  name "Constellation (Bug Byte)"
-  description "Constellation (Bug Byte)"
-  manufacturer "Bug Byte"
-  rom ( name "Constellation.tzx" size 12611 crc A0146B49 md5 500508C55BFAE7C20D1191CF95B37E5D sha1 FB8BBC99988812C5EF372A7358A36CEADB53AE73 )
-)
-
-game (
-  name "Constellation (Gladstone) (Gladstone Electronics)"
-  description "Constellation (Gladstone) (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "Constellation(GE).tzx" size 15694 crc 89092DE9 md5 E76748A332503ED9799FB76A16CF24F2 sha1 69DA2B7F7A1F311A73858F4787F05C31460E7172 )
-)
-
-game (
-  name "Constellation (Gladstone) (Gladstone Electronics)"
-  description "Constellation (Gladstone) (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "constellation(ge).p" size 15452 crc CA46CB85 md5 7EB28D1AD0F29BE00794F00BE04FF1E7 sha1 58F35FB046A9E20052DC7B838E1754C593FCDB53 )
-)
-
-game (
-  name "Control Technology Tapes 1,2,3 (Control Technology)"
-  description "Control Technology Tapes 1,2,3 (Control Technology)"
-  manufacturer "Control Technology"
-  rom ( name "ControlTechnology123.tzx" size 48433 crc D9610EA9 md5 1C5691270A4F2EF50A859F6EEFE7891F sha1 8E630DBC2725862733CD138E69A7C8CA9EEED84F )
-)
-
-game (
-  name "Conversational German (Timex)"
-  description "Conversational German (Timex)"
-  year "1983"
-  manufacturer "D. E. Hagan"
-  rom ( name "conversationalgerman.p" size 15375 crc 2A3A859E md5 B73D18D611AF33AD7C555F03F0CC597D sha1 F03403678A5B6CAA88CEDEE89AEE74BA8D4270AB )
-)
-
-game (
-  name "Conversational German (Timex)"
-  description "Conversational German (Timex)"
-  year "1983"
-  manufacturer "D. E. Hagan"
-  rom ( name "ConversationalGerman.tzx" size 15603 crc 810BDCC4 md5 1E27801FD4DB30240671C6F1ECBBE73D sha1 DDB421FE807557A6F4A2EB7EA78E15C249B15DE1 )
-)
-
-game (
-  name "Cosmic Guerilla (Quicksilva)"
-  description "Cosmic Guerilla (Quicksilva)"
-  year "1983"
-  manufacturer "C. K. Tame"
-  rom ( name "CosmicGuerilla.tzx" size 7561 crc 001EF96D md5 DE8CA35128D7EC90516DD6EE759E65A6 sha1 EF8E79312D0DC7EFEC6BF2A9A6CA785B0E4A94A0 )
-)
-
-game (
-  name "Cosmic Guerilla (Quicksilva)"
-  description "Cosmic Guerilla (Quicksilva)"
-  year "1983"
-  manufacturer "C. K. Tame"
-  rom ( name "cosmicguerilla.p" size 7333 crc 8594884E md5 37C438DBF7EC1A61B574C870AB04B375 sha1 1F0226F4DE15F5EE393761631A6D3AAD46C75A10 )
-)
-
-game (
-  name "Counter Attack (Woodside Software)"
-  description "Counter Attack (Woodside Software)"
-  manufacturer "P. Hennessy"
-  rom ( name "CounterAttack.tzx" size 7219 crc 6B8852CA md5 DFE0270C48C5AF69BD0652F723F6C5B2 sha1 286CD36A713F95FFCC5E847539A59DE6C55F6C42 )
-)
-
-game (
-  name "Counter Attack (Woodside Software)"
-  description "Counter Attack (Woodside Software)"
-  manufacturer "P. Hennessy"
-  rom ( name "counterattack.p" size 6975 crc 4095691A md5 846BE5D9FAF79197323D5C2B05B82136 sha1 45AAE62DC5ED72ECBA3C33B280B2C3D7310CF942 )
-)
-
-game (
-  name "The Coupon Manager (Timex)"
-  description "The Coupon Manager (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "couponmanagerthe.p" size 15892 crc D4803E75 md5 AE154DF5FAD396DF2C60A12FF7275328 sha1 E6F50FCC128863CD06428A20A731B0CDB1B76379 )
-)
-
-game (
-  name "Critical Path Analysis (Hilderbay)"
-  description "Critical Path Analysis (Hilderbay)"
-  year "1981"
-  manufacturer "Hilderbay"
-  rom ( name "criticalpathanalysis.p" size 6053 crc 10FB4D01 md5 30F5B565EEBB684D446A1D9073860BD2 sha1 E6E505E111C04A395E8A946CF2C5B7BBED948BA1 )
-)
-
-game (
-  name "Critical Path Analysis (Hilderbay)"
-  description "Critical Path Analysis (Hilderbay)"
-  year "1981"
-  manufacturer "Hilderbay"
-  rom ( name "CriticalPathAnalysis.tzx" size 6275 crc 28EE5886 md5 47B2D99A813EA1744AD5A41D15016A8D sha1 3EE5A82DEC70E4BD7EB1D514CDD4538CB433F24A )
-)
-
-game (
-  name "Critical Path Analysis (Timex)"
-  description "Critical Path Analysis (Timex)"
-  year "1982"
-  manufacturer "W. Emery"
-  rom ( name "CriticalPathAnalysis(Timex).tzx" size 6720 crc C1835895 md5 AF015196BC37C30E8F529DA34262ED28 sha1 469F80FBF8E3979B8534E28DABD9D7089E55425E )
-)
-
-game (
-  name "Croaka-Crawla (Quicksilva)"
-  description "Croaka-Crawla (Quicksilva)"
-  year "1983"
-  manufacturer "Quicksilva"
-  rom ( name "croakacrawla.p" size 14666 crc 2E8A9AF1 md5 96FDEAF0F549A9198B633A19510BE1FE sha1 4BB58B01E86AAF1DC21999E77EC7D557F4353FFE )
-)
-
-game (
-  name "Croaka-Crawla (Quicksilva)"
-  description "Croaka-Crawla (Quicksilva)"
-  year "1983"
-  manufacturer "Quicksilva"
-  rom ( name "CroakaCrawla.tzx" size 14896 crc 1E07D1C3 md5 51E05750EDA73CBD667E52D945C742D9 sha1 3489FD97EE769B1B59E0B74CCDEB667F135DBCBD )
-)
-
-game (
-  name "The Cube Game (Timex)"
-  description "The Cube Game (Timex)"
-  year "1982"
-  manufacturer "John Heaney"
-  rom ( name "CubeGameThe.tzx" size 13714 crc C87BEA16 md5 E7E0B000B8FCE72A25F358B4B5F2478E sha1 DBF04E07FF5ED808DF032C66191F79D0C96488A5 )
-)
-
-game (
-  name "The Cube Game (Timex)"
-  description "The Cube Game (Timex)"
-  year "1982"
-  manufacturer "John Heaney"
-  rom ( name "cubegamethe.p" size 13490 crc 5B814EA8 md5 46141C523CF55F37AD18594D434C118E sha1 C30033CD7773CF740F517B3E5C8FD7B1BFE593DA )
-)
-
-game (
-  name "D Coder (Cosma)"
-  description "D Coder (Cosma)"
-  manufacturer "Cosma"
-  rom ( name "DCoder.A.tzx" size 7680 crc 1684BA79 md5 229D7EB3CD3C17B82A1FB4E5DAEC5370 sha1 39F16BB21B52C566218F38AA07B1951E38C0F8BD )
-)
-
-game (
-  name "Dallas (French) (Cases Computer Simulations)"
-  description "Dallas (French) (Cases Computer Simulations)"
-  year "1983"
-  manufacturer "Cases Computer Simulations"
-  rom ( name "Dallas(French).tzx" size 16379 crc 4A65562E md5 6EA358B625C6DEECCE8B906983884A27 sha1 499BEE247F3BDC37ECA67E95EEE1624DE11EC5D6 )
-)
-
-game (
-  name "Dallas (French) (Cases Computer Simulations)"
-  description "Dallas (French) (Cases Computer Simulations)"
-  year "1983"
-  manufacturer "Cases Computer Simulations"
-  rom ( name "dallas(french).p" size 16151 crc 6FC5F7EC md5 C76BD00587E4017E445C023AD12FDFCB sha1 1D1CD2F2CE3CDFC7A8C18E8BDD1CD0CDC8F2797E )
-)
-
-game (
-  name "The Damsel and the Beast (Bug Byte)"
-  description "The Damsel and the Beast (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "damselandthebeastthe.p" size 10200 crc E572E012 md5 A4BA6FB14BE2C6841565DFFC496D8C18 sha1 15033D3454985A1CE45289BB33296791AB3332AA )
-)
-
-game (
-  name "The Damsel and the Beast (Bug Byte)"
-  description "The Damsel and the Beast (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "DamselAndTheBeastThe.tzx" size 10464 crc B34252C8 md5 D055C7009157DCF01DC9689D414DBAFA sha1 574392A27B8328EC82121E1C666E2C3411F34342 )
-)
-
-game (
-  name "Dictator (Bug Byte)"
-  description "Dictator (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "Dictator.tzx" size 16306 crc B01E01A7 md5 2E2E96ED20915990EB8280021CE7838E sha1 C14608ECC904B6AD8141D64BB4EED66C43B6316D )
-)
-
-game (
-  name "Dictator (Bug Byte)"
-  description "Dictator (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "dictator.p" size 16074 crc 9EF1B3CF md5 8AA9775F53F519DED0AE7F7A2C5B3F60 sha1 42B98D75F715B69C1C54722A05A8D0D7B07783EC )
-)
-
-game (
-  name "Do Not Pass Go (Work Force)"
-  description "Do Not Pass Go (Work Force)"
-  manufacturer "Work Force"
-  rom ( name "donotpassgo.p" size 13355 crc 292A5505 md5 0480349FBEE60FD0939F31CC6D210C2B sha1 A05BA8AD8560A15C5ECFFFF289D10DAA421B5CB8 )
-)
-
-game (
-  name "Do Not Pass Go (Work Force)"
-  description "Do Not Pass Go (Work Force)"
-  manufacturer "Work Force"
-  rom ( name "DoNotPassGo.tzx" size 13587 crc A2DD0F0C md5 D4CDFCEE0472C465483738B520960D65 sha1 45DED58CE3255E5239722C956EEF084BAC20AD6D )
-)
-
-game (
-  name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-  description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "DodgemsAndConnect4(Brown).tzx" size 9488 crc 39D4E107 md5 B6110B1177643DFB269784EE01902964 sha1 DE9F3293E482AC4F92B3278D262E45321450FE79 )
-)
-
-game (
-  name "Dominoes (Phipps Associates)"
-  description "Dominoes (Phipps Associates)"
-  year "1983"
-  manufacturer "D. G. Cross"
-  rom ( name "Dominoes.tzx" size 15375 crc 4FC4E410 md5 C9EC351812095D3A1A91E4DB7926A5D8 sha1 B780954C535CCD6F6A778999B7244DE33BB3AD53 )
-)
-
-game (
-  name "Dominoes (Phipps Associates)"
-  description "Dominoes (Phipps Associates)"
-  year "1983"
-  manufacturer "D. G. Cross"
-  rom ( name "dominoes.p" size 15143 crc F53499E9 md5 7C250A09C6E3E1FE996AB0DF7FC312FF sha1 CD00BF0A030844133F39FBBAC4712BA1C8591DCA )
-)
-
-game (
-  name "Dr. Floyd (Apropos Technology)"
-  description "Dr. Floyd (Apropos Technology)"
-  manufacturer "Apropos Technology"
-  rom ( name "DrFloyd.tzx" size 14294 crc D5B0408F md5 5E0B05B046B113239EC5EFDB9E23589E sha1 6982C898304A0E319434984A019B96682D177661 )
-)
-
-game (
-  name "Dr. Floyd (Apropos Technology)"
-  description "Dr. Floyd (Apropos Technology)"
-  manufacturer "Apropos Technology"
-  rom ( name "drfloyd.p" size 14062 crc D16282DA md5 4E26541F29E46BABA6BEAC4AD8BCCC31 sha1 C5531613742A634A5B41503198AE567ADC6A42AB )
-)
-
-game (
-  name "Dragon Maze (Macronics)"
-  description "Dragon Maze (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "DragonMaze.tzx" size 4970 crc C2A29E0D md5 3AAAADD623DF3A672361715BB3B9C6F3 sha1 58E77F8D47F0A0061F0545E3D95485D9041D7025 )
-)
-
-game (
-  name "Dragon Maze (Macronics)"
-  description "Dragon Maze (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "dragonmaze.p" size 4750 crc B252B048 md5 D5520C004ECD8E8D15D36FA70FDDEC8E sha1 F6F90B253527935B27CE3674C49B33D914B37DFC )
-)
-
-game (
-  name "Dungeons of Doom (Temptation Software)"
-  description "Dungeons of Doom (Temptation Software)"
-  year "1982"
-  manufacturer "Simon Mansfield"
-  rom ( name "DungeonsOfDoom.tzx" size 15074 crc D5034066 md5 747215BD1AFEBF2217ADDC18B14B1E36 sha1 B2884C73AF5DA39E4C32D9A11206769E006F456F )
-)
-
-game (
-  name "E.E. 1 - Filter Design (Timex)"
-  description "E.E. 1 - Filter Design (Timex)"
-  year "1982"
-  manufacturer "American Micro Products"
-  rom ( name "EE1FilterDesign.tzx" size 12047 crc 1159B6AA md5 0A3FB9FD79259C485B0DF31A4D387D20 sha1 D6714FE623F9E444C22CDE90F56488A58FCE0D33 )
-)
-
-game (
-  name "E.E. 1 - Filter Design (Timex)"
-  description "E.E. 1 - Filter Design (Timex)"
-  year "1982"
-  manufacturer "American Micro Products"
-  rom ( name "ee1filterdesign.p" size 11825 crc A6A157C9 md5 5E5B10ECC426F5820F3DAB25B7C6AD92 sha1 152342A49020A5740A50650D9B2BBF9C5D66C9B7 )
-)
-
-game (
-  name "Electric Cost Analyzer (Timex)"
-  description "Electric Cost Analyzer (Timex)"
-  year "1983"
-  manufacturer "Tim Rossetti"
-  rom ( name "electriccostanalyzer.p" size 15557 crc BCCAE88D md5 ADCA050F5154D5E1107CA72433DB06E1 sha1 DD7AE4F987B76D764D60D5A0FD95CF879310DDE2 )
-)
-
-game (
-  name "Electric Cost Analyzer (Timex)"
-  description "Electric Cost Analyzer (Timex)"
-  year "1983"
-  manufacturer "Tim Rossetti"
-  rom ( name "ElectricCostAnalyzer.tzx" size 15789 crc D6745B7A md5 CA1D14BAD434D1AD36F829AAAC3939A1 sha1 F5F5C2A8038DF69484937CE4B853B4E83DFCF5F5 )
-)
-
-game (
-  name "The Electronic Checkbook (Timeworks)"
-  description "The Electronic Checkbook (Timeworks)"
-  year "1982"
-  manufacturer "Timeworks"
-  rom ( name "electroniccheckbookthe.p" size 16162 crc 75097784 md5 CDD6EA720F382F5DC8F2C971A53E3E2F sha1 A2ACE5B2B1BF45C5DBD0EBF2CBD47934DC668787 )
-)
-
-game (
-  name "The Electronic Checkbook (Timeworks)"
-  description "The Electronic Checkbook (Timeworks)"
-  year "1982"
-  manufacturer "Timeworks"
-  rom ( name "ElectronicCheckbookThe.tzx" size 16382 crc BC3ED36D md5 C0F35B0FCEF5474812364C0EA6CDCF2E sha1 3791720C3974C31C322B9D1E6A6281DE6E6BCFCD )
-)
-
-game (
-  name "Electronics (Spectre)"
-  description "Electronics (Spectre)"
-  manufacturer "Spectre"
-  rom ( name "electronics.p" size 15899 crc B18D5D28 md5 8D3EE1B1EB0D3DF446F50731C6659279 sha1 2F56472672D41361C60591D7CF177EB18148976B )
-)
-
-game (
-  name "Electronics (Spectre)"
-  description "Electronics (Spectre)"
-  manufacturer "Spectre"
-  rom ( name "Electronics.tzx" size 16121 crc E777753A md5 48B223D7A2E94415AD4DC381B6A33FE8 sha1 D3A41D3AA66DB93144EEF927A1C37FC8BB9FAB90 )
-)
-
-game (
-  name "Encounter (Quicksilva)"
-  description "Encounter (Quicksilva)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Encounter.tzx" size 17612 crc AF150F3F md5 D526D1745135DCC2BC1F357FA2CAB910 sha1 EC8355C006D83DFC367A166EE6F33CB3530381AB )
-)
-
-game (
-  name "Escape From Manhattan (Computer Rentals)"
-  description "Escape From Manhattan (Computer Rentals)"
-  year "1983"
-  manufacturer "N. Taylor"
-  rom ( name "EscapeFromManhattan.tzx" size 16320 crc 2CACBB72 md5 2B526BA624AF0FDFC1733099CCEC82AB sha1 975C976E36B9DBD47FCF5312FAE4AD5C2521D6D7 )
-)
-
-game (
-  name "Escape From Manhattan (Computer Rentals)"
-  description "Escape From Manhattan (Computer Rentals)"
-  year "1983"
-  manufacturer "N. Taylor"
-  rom ( name "escapefrommanhattan.p" size 16102 crc 63F8023F md5 135B8483BB5B316C8744D824ACBB86C1 sha1 53799E5EA4DA7A6C5EBBA8537126F25EBBEB8285 )
-)
-
-game (
-  name "Escape from Shazzar (International Publishing and Software Inc.)"
-  description "Escape from Shazzar (International Publishing and Software Inc.)"
-  year "1983"
-  manufacturer "A. F. Nuttall"
-  rom ( name "EscapeFromShazzar.tzx" size 16376 crc 78075B95 md5 0854165D7CAA9F5D43203E5F9C999FA0 sha1 992DFCECE29B42C729BBCA05422BF090DC7C275C )
-)
-
-game (
-  name "Escape from Shazzar (International Publishing and Software Inc.)"
-  description "Escape from Shazzar (International Publishing and Software Inc.)"
-  year "1983"
-  manufacturer "A. F. Nuttall"
-  rom ( name "escapefromshazzar.p" size 16146 crc C587593D md5 B2DC9A81AC27D4BC267C8D4A0236ACB5 sha1 48FA28F6B637E59F48A58E618617A98F83FE6813 )
-)
-
-game (
-  name "Adventure D: Espionage Island (Sinclair Research)"
-  description "Adventure D: Espionage Island (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "EspionageIsland.tzx" size 15734 crc 2BF38DCA md5 50A59A5A1CA60349959BA2283E4188F8 sha1 1AFAA1C3773C78F8F92941D95DE226A727CC8822 )
-)
-
-game (
-  name "Adventure D: Espionage Island (Sinclair Research)"
-  description "Adventure D: Espionage Island (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "espionageisland.p" size 15504 crc 81DDF2B0 md5 24C456B967F1B621685579289A656CEB sha1 9C2DB35B667F12A155AAD2F2E5725B9FCF54E290 )
-)
-
-game (
-  name "Adventure D: Espionage Island (Artic)"
-  description "Adventure D: Espionage Island (Artic)"
-  manufacturer "Artic"
-  rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06A3887C md5 30754AA09608D83DEB1C0194C04B85CB sha1 7B36F0BCE5ECCB9FC3DC4FB553516E5E7F5ADABE )
-)
-
-game (
-  name "Adventure D: Espionage Island (Artic)"
-  description "Adventure D: Espionage Island (Artic)"
-  manufacturer "Artic"
-  rom ( name "espionageisland(artic).p" size 15504 crc AC8DF706 md5 348A6B4FBEC8E375DAF1BE03D1C674DF sha1 8AD3E1AE97A34A6F6B1E2F653AEED770BA33F01E )
-)
-
-game (
-  name "FUNdamentals of Math (Timex)"
-  description "FUNdamentals of Math (Timex)"
-  year "1983"
-  manufacturer "ATM"
-  rom ( name "FUNdamentalsOfMath.tzx" size 39312 crc 75ADE9A1 md5 FBE76752CE6FD550C78F7116E8472D37 sha1 0C1FD6D5034FA73E8D1D3DD525E088CD96971BD7 )
-)
-
-game (
-  name "Fast Load Save (Musamy Software)"
-  description "Fast Load Save (Musamy Software)"
-  year "1982"
-  manufacturer "Musamy Software"
-  rom ( name "FastLoadSave.tzx" size 11000 crc 939F03CB md5 BE316FADC3492E475E6D07BDF9AE310E sha1 616DFC2662D46F415277990BEBF0B09E187ED36E )
-)
-
-game (
-  name "The Fast One (Campbell Systems)"
-  description "The Fast One (Campbell Systems)"
-  manufacturer "Campbell Systems"
-  rom ( name "FastOne(Green).tzx" size 9837 crc 3C57D2F2 md5 24BFE29D78AC664AA6B367EF983C590D sha1 C31F2892EA9145CDAB6EF5F21CD126AB9D079036 )
-)
-
-game (
-  name "Flight Simulation (Sinclair Research)"
-  description "Flight Simulation (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
-)
-
-game (
-  name "Flight Simulation (Sinclair Research)"
-  description "Flight Simulation (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
-)
-
-game (
-  name "The Flight Simulator (Timex)"
-  description "The Flight Simulator (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
-)
-
-game (
-  name "The Flight Simulator (Timex)"
-  description "The Flight Simulator (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
-)
-
-game (
-  name "Flug-Simulation (Sinclair Research)"
-  description "Flug-Simulation (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
-)
-
-game (
-  name "Flug-Simulation (Sinclair Research)"
-  description "Flug-Simulation (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
-)
-
-game (
-  name "Football (Tyrant)"
-  description "Football (Tyrant)"
-  manufacturer "Tyrant"
-  rom ( name "Football.tzx" size 15858 crc 8503533C md5 673DFECB1920D35FCD55F23AAB95DBF8 sha1 D75DFC7310F08160F7FF61F2E08F2ED4FA5AABB0 )
-)
-
-game (
-  name "Football (Tyrant)"
-  description "Football (Tyrant)"
-  manufacturer "Tyrant"
-  rom ( name "football.p" size 15626 crc 33233387 md5 EF4F6C235F9017F7B4C83F19FFC72818 sha1 F0EE8A1607A606D22B7C2BA518A06BD2CD387FD9 )
-)
-
-game (
-  name "Football-League (Video Software)"
-  description "Football-League (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "FootballLeague.A.tzx" size 14343 crc 78694C75 md5 64AD8A73B7B3B45C35AA937B09E14817 sha1 4887F03B6E5725D1ACB156A485DDC9C450607D88 )
-)
-
-game (
-  name "Football-League (Video Software)"
-  description "Football-League (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "footballleague.p" size 14097 crc 9E4623C5 md5 B430448D983A97C6DE8D0FD776BEF9C8 sha1 C8B1BD7A85D2981EC2B6478E0C58B36DCCB42AC3 )
-)
-
-game (
-  name "Football Manager (Addictive Games)"
-  description "Football Manager (Addictive Games)"
-  year "1982"
-  manufacturer "Kevin J. Toms"
-  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
-)
-
-game (
-  name "Football Manager (Addictive Games)"
-  description "Football Manager (Addictive Games)"
-  year "1982"
-  manufacturer "Kevin J. Toms"
-  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
-)
-
-game (
-  name "Football Manager (Black inlay) (Addictive Games)"
-  description "Football Manager (Black inlay) (Addictive Games)"
-  year "1981"
-  manufacturer "Kevin J. Toms"
-  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
-)
-
-game (
-  name "Football Manager (Black inlay) (Addictive Games)"
-  description "Football Manager (Black inlay) (Addictive Games)"
-  year "1981"
-  manufacturer "Kevin J. Toms"
-  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
-)
-
-game (
-  name "Football Manager (Red) (Addictive Games)"
-  description "Football Manager (Red) (Addictive Games)"
-  year "1981"
-  manufacturer "Kevin J. Toms"
-  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
-)
-
-game (
-  name "Football Manager (Red) (Addictive Games)"
-  description "Football Manager (Red) (Addictive Games)"
-  year "1981"
-  manufacturer "Kevin J. Toms"
-  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
-)
-
-game (
-  name "Football Pools Program (Hartland Software)"
-  description "Football Pools Program (Hartland Software)"
-  manufacturer "Hartland Software"
-  rom ( name "FootballPools.tzx" size 24422 crc 2D0ED98B md5 387BB8707269DE22CFB13B4C8781D20C sha1 A2AE0611AD434600777C2BA0DF4CC48D8109D9F8 )
-)
-
-game (
-  name "Forth (Sinclair Research)"
-  description "Forth (Sinclair Research)"
-  year "1983"
-  manufacturer "Artic"
-  rom ( name "Forth.tzx" size 14183 crc 376C5750 md5 5AD0F910D2987E3A51716DD82E6F4113 sha1 012A7E585C3F2D245E3D7FFBA935EA1962BE21C4 )
-)
-
-game (
-  name "Fortress of Zorlac (Timex)"
-  description "Fortress of Zorlac (Timex)"
-  year "1982"
-  manufacturer "Paul Carlson"
-  rom ( name "fortressofzorlac.p" size 7214 crc ADED8203 md5 0852A128DF135AF9F240356567D626B8 sha1 872B7049CAB2FEA166921BA30D93FCCDAF63F840 )
-)
-
-game (
-  name "Fortress of Zorlac (Timex)"
-  description "Fortress of Zorlac (Timex)"
-  year "1982"
-  manufacturer "Paul Carlson"
-  rom ( name "FortressOfZorlac.tzx" size 7442 crc 30D3BA7D md5 05B14472E34F62F64D40E71F0001F900 sha1 13F8969E92932F3F6E4C6F177BBE34512780B96F )
-)
-
-game (
-  name "Forty Niner (Software Farm)"
-  description "Forty Niner (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "FortyNiner.tzx" size 14106 crc 1C4EFF0A md5 FBA0B998270A673AF60EDE6B1F6DA4FF sha1 E563342E858B8C38A384EBFD695C479FEB01A4A5 )
-)
-
-game (
-  name "Forty Niner (Software Farm)"
-  description "Forty Niner (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "fortyniner.p" size 13868 crc B8650DA4 md5 9729D9B8A4FAEE1D12F4384F789C0B44 sha1 694AC6D1410EADE17ECC9E06A3C39191E8DDA352 )
-)
-
-game (
-  name "Frogger (DJL Software)"
-  description "Frogger (DJL Software)"
-  manufacturer "DJL Software"
-  rom ( name "frogger.p" size 13493 crc 8D24D478 md5 DB791414F02377A0B2BB60E1539401F3 sha1 29D815B98770A1FBAE3714642C5C70583D02ED17 )
-)
-
-game (
-  name "Frogger (DJL Software)"
-  description "Frogger (DJL Software)"
-  manufacturer "DJL Software"
-  rom ( name "Frogger.tzx" size 13723 crc BD7DF880 md5 9A8C77A4C24E8E67F7308BE91A2B95AA sha1 75499B16DE8DFBABF668328109D0A36963BFD11B )
-)
-
-game (
-  name "Frogger (Sega) (Timex)"
-  description "Frogger (Sega) (Timex)"
-  year "1981"
-  manufacturer "Cornsoft/Sega"
-  rom ( name "frogger(sega).p" size 10638 crc 3993108B md5 1E6FDFE09452BA5609C693A7683C94F7 sha1 B17FACF22BB6F66FE8EEF0977CBDF1B1ECDE6C6C )
-)
-
-game (
-  name "Frogger (Sega) (Timex)"
-  description "Frogger (Sega) (Timex)"
-  year "1981"
-  manufacturer "Cornsoft/Sega"
-  rom ( name "Frogger(Sega).tzx" size 10868 crc 95952886 md5 E8EBE732890B6DC7D39674E7BF527716 sha1 08999372CAF4A07B532E7360F1573C5262B56ED7 )
-)
-
-game (
-  name "Froggy (DJL Software)"
-  description "Froggy (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "froggy.p" size 10394 crc 5624F4F4 md5 C0408BB2B6D716D9643FA64670D7C241 sha1 9F45088A30FDBDDFFCCB01F55690CDE7276DF088 )
-)
-
-game (
-  name "Froggy (DJL Software)"
-  description "Froggy (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "Froggy.tzx" size 10622 crc E84F00DA md5 8A827657CCD27300BAFAA4AF1076045A sha1 C0D7D2DB94E8FB84BB22428B0B6A5C5CCC11C52B )
-)
-
-game (
-  name "Frogs (Mikro-Gen)"
-  description "Frogs (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "frogs.p" size 4223 crc B5335A99 md5 55D1B367C05A5F9259DA78AAD2B072DA sha1 D3EDABF6C4E7E88CB1224ACE1C63B2735DBF2F0F )
-)
-
-game (
-  name "Frogs (Mikro-Gen)"
-  description "Frogs (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "Frogs.tzx" size 4453 crc EFD0F05E md5 9409197480D2E19DA908B0594580EE89 sha1 899D5CDF74208E30D17C5D34F5733D207222DAAA )
-)
-
-game (
-  name "Fun Fair Adventure (Fawkes Computing)"
-  description "Fun Fair Adventure (Fawkes Computing)"
-  year "1983"
-  manufacturer "Fawkes Computing"
-  rom ( name "funfairadventure.p" size 15670 crc F5238943 md5 4F267D0AD39D72853CBB7FF914A491B0 sha1 D654CCA3195F48A50E1391BC5BC8DB72A1D4215F )
-)
-
-game (
-  name "Fun Fair Adventure (Fawkes Computing)"
-  description "Fun Fair Adventure (Fawkes Computing)"
-  year "1983"
-  manufacturer "Fawkes Computing"
-  rom ( name "FunFairAdventure.tzx" size 15892 crc 477B0E8F md5 8B00DDE0094158BE9FA735E62BC99BF9 sha1 C828C69E2A899E1B15968DAFEAEB19B6045B360B )
-)
-
-game (
-  name "Galactic Gunner (Timex)"
-  description "Galactic Gunner (Timex)"
-  year "1983"
-  manufacturer "Paul W. Carlson"
-  rom ( name "galacticgunner.p" size 8786 crc FEF205CE md5 35300CA762E104FC8C6EFBA2280FEB96 sha1 CBB2FB7C55CAA311826D2A2481C6DFFAD40B5863 )
-)
-
-game (
-  name "Galactic Gunner (Timex)"
-  description "Galactic Gunner (Timex)"
-  year "1983"
-  manufacturer "Paul W. Carlson"
-  rom ( name "GalacticGunner.tzx" size 9014 crc 1EE1C007 md5 9E6D42B5BA230A9E298DFE1C49744B23 sha1 93F8F8B5FDE8DE8305D0946F25296DA88E26D720 )
-)
-
-game (
-  name "Galactic Patrol (Computer Rentals)"
-  description "Galactic Patrol (Computer Rentals)"
-  year "1983"
-  manufacturer "Richard Brisbourne"
-  rom ( name "GalacticPatrol.tzx" size 6295 crc 25CB9C4E md5 03A02BF71F85C41298C99424A97C1FFD sha1 ED32FC48477D367E241B4A7F311F7D0C7CAA615A )
-)
-
-game (
-  name "Galactic Patrol (Computer Rentals)"
-  description "Galactic Patrol (Computer Rentals)"
-  year "1983"
-  manufacturer "Richard Brisbourne"
-  rom ( name "galacticpatrol.p" size 6063 crc 6FC3B9B1 md5 D88DCBD760136C7635C3CD44FC2F7548 sha1 E3C8AFBB3E1DFD637AA974F33A887293965F573E )
-)
-
-game (
-  name "Galactic Patrol (Omega re-release) (Omega)"
-  description "Galactic Patrol (Omega re-release) (Omega)"
-  year "1984"
-  manufacturer "CRL"
-  rom ( name "GalacticPatrol.tzx" size 6295 crc 25CB9C4E md5 03A02BF71F85C41298C99424A97C1FFD sha1 ED32FC48477D367E241B4A7F311F7D0C7CAA615A )
-)
-
-game (
-  name "Galactic Patrol (Omega re-release) (Omega)"
-  description "Galactic Patrol (Omega re-release) (Omega)"
-  year "1984"
-  manufacturer "CRL"
-  rom ( name "galacticpatrol.p" size 6063 crc 6FC3B9B1 md5 D88DCBD760136C7635C3CD44FC2F7548 sha1 E3C8AFBB3E1DFD637AA974F33A887293965F573E )
-)
-
-game (
-  name "Galactic Trooper (Romik Software)"
-  description "Galactic Trooper (Romik Software)"
-  year "1983"
-  manufacturer "Ian Morrison and David Anderson"
-  rom ( name "GalacticTrooper.tzx" size 4517 crc 95146C5F md5 86CD07956E3D37C94D5CC19C7753F152 sha1 EE48EE10E53ADBBBFE6D62C8B4FBADEA8BC1EB16 )
-)
-
-game (
-  name "Galactic Trooper (Romik Software)"
-  description "Galactic Trooper (Romik Software)"
-  year "1983"
-  manufacturer "Ian Morrison and David Anderson"
-  rom ( name "galactictrooper.p" size 4269 crc AE87F0A7 md5 74661343C5098F10BF44FDF40DC02F04 sha1 E6BA889B1F3D97366CC829D07E9D13FD665D40F5 )
-)
-
-game (
-  name "Galaxians (Artic)"
-  description "Galaxians (Artic)"
-  manufacturer "Artic"
-  rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
-)
-
-game (
-  name "Galaxians (Artic)"
-  description "Galaxians (Artic)"
-  manufacturer "Artic"
-  rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
-)
-
-game (
-  name "Galaxians (Monochrome) (Artic)"
-  description "Galaxians (Monochrome) (Artic)"
-  manufacturer "Artic"
-  rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
-)
-
-game (
-  name "Galaxians (Monochrome) (Artic)"
-  description "Galaxians (Monochrome) (Artic)"
-  manufacturer "Artic"
-  rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
-)
-
-game (
-  name "Galaxy Invaders (International Publishing and Software Inc.)"
-  description "Galaxy Invaders (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "GalaxyInvaders(IPS).tzx" size 4224 crc 6DF4E24B md5 490E79F413DCB97060633218E014A62F sha1 23FC85B7E2ECFACD664DC991ACF7E56393A345A1 )
-)
-
-game (
-  name "Galaxy Invaders (International Publishing and Software Inc.)"
-  description "Galaxy Invaders (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "galaxyinvaders(ips).p" size 4002 crc 4328BEBA md5 FB94065D6C8B3A4AA2F12A7D015E569D sha1 1BB9B928230DE4AB517BF8B248A687C94C3DF639 )
-)
-
-game (
-  name "Galaxy Jailbreak (Romik Software)"
-  description "Galaxy Jailbreak (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "galaxyjailbreak.p" size 5413 crc AE762991 md5 6493AC3CD7C77BE6027BC00C3932C68C sha1 AEB080263F016D94BF0A13FF521BBC30D7032686 )
-)
-
-game (
-  name "Galaxy Jailbreak (Romik Software)"
-  description "Galaxy Jailbreak (Romik Software)"
-  year "1983"
-  manufacturer "Roland Stokes"
-  rom ( name "GalaxyJailbreak.tzx" size 5661 crc 8F630CE4 md5 F1CEB2D7E0CEE7CB924A0B824DBF418B sha1 351DCE4FF4D8D3DCC68508B39BB910B21CECFB84 )
-)
-
-game (
-  name "Galaxy Warrior/Star Trek (Artic)"
-  description "Galaxy Warrior/Star Trek (Artic)"
-  manufacturer "Artic"
-  rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1BCB3A5F md5 FFF5135CA3AC8C8553E9EACE62D55667 sha1 ABFB5609BFA713C2F4841BC45BA11EB7363B6BF7 )
-)
-
-game (
-  name "The Gambler (Timex)"
-  description "The Gambler (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "GamblerThe.tzx" size 19202 crc E05A3062 md5 EA6C404AF8FC06091341E038643A85A6 sha1 61DA0728B3850A4235D13B1A71E7BB0E339FAC63 )
-)
-
-game (
-  name "Games Pack (JRS Software)"
-  description "Games Pack (JRS Software)"
-  year "1982"
-  manufacturer "JRS Software"
-  rom ( name "GamesPack.tzx" size 20187 crc 4C92529E md5 893ED24F30DBBA822DC001B87750B873 sha1 EB8AEC55C92FC530591E033C862CE3B95C40A149 )
-)
-
-game (
-  name "The Gauntlet (Colourmatic)"
-  description "The Gauntlet (Colourmatic)"
-  year "1982"
-  manufacturer "Colourmatic"
-  rom ( name "gauntletthe.p" size 14411 crc AE7D6FEC md5 B0F5118CDB2D11510AE8A9F6CD735225 sha1 4B1AD35595A0DDD772A3FACC1F0C57499030D69A )
-)
-
-game (
-  name "The Gauntlet (Colourmatic)"
-  description "The Gauntlet (Colourmatic)"
-  year "1982"
-  manufacturer "Colourmatic"
-  rom ( name "GauntletThe.tzx" size 14643 crc 7DE2E0A3 md5 90C561D24D267DD43E349EED180FE51D sha1 49E714E58E9725925B28F8E17D90C708961064B5 )
-)
-
-game (
-  name "The Gauntlet (PSS) (PSS)"
-  description "The Gauntlet (PSS) (PSS)"
-  year "1984"
-  manufacturer "Colourmatic"
-  rom ( name "gauntletthe(pss).p" size 14561 crc F8F47BBF md5 C0F5783184D967260C7D8E4A0B027850 sha1 27B343C7B034563FF4C5218AE6FFA8E190B7313F )
-)
-
-game (
-  name "The Gauntlet (PSS) (PSS)"
-  description "The Gauntlet (PSS) (PSS)"
-  year "1984"
-  manufacturer "Colourmatic"
-  rom ( name "GauntletThe(PSS).tzx" size 14793 crc 076726DD md5 F4AD5284A8D7ECA0E7E7E564131B3B6B sha1 3756C65AC420104C97A01317CDF156C2F412A2DF )
-)
-
-game (
-  name "General Statistics (W. H. Smith)"
-  description "General Statistics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "GeneralStatistics.tzx" size 14466 crc 8889D5E3 md5 ACF9669F43AF8B165CDA56888E9A1348 sha1 A1F94C7CA3A27E24EBFABA575700CFCCF8640356 )
-)
-
-game (
-  name "General Statistics (W. H. Smith)"
-  description "General Statistics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "generalstatistics.p" size 14214 crc 10C6EF87 md5 A779367A54AD8AC03543A2D70C2E88E1 sha1 F65E699472236439C262640299628CB01284223E )
-)
-
-game (
-  name "Geographics UK (Novus Software)"
-  description "Geographics UK (Novus Software)"
-  manufacturer "Novus"
-  rom ( name "GeographicsUK.tzx" size 16281 crc 4AF3CFC9 md5 4534B531E811C27A32EFFAA76A9A257E sha1 0D88E5BC5E71CC898A375156E40396B5B536D7A0 )
-)
-
-game (
-  name "Geographics UK (Novus Software)"
-  description "Geographics UK (Novus Software)"
-  manufacturer "Novus"
-  rom ( name "geographicsuk.p" size 16037 crc FBC771BF md5 FEA62F9B738C3F63CF9DE62A37431588 sha1 FB07EBDDCA1F03EEF2B4D06052D4ABDE520D4AE0 )
-)
-
-game (
-  name "Geometry 1 (Timex)"
-  description "Geometry 1 (Timex)"
-  year "1982"
-  manufacturer "Home Computer Software"
-  rom ( name "Geometry1.tzx" size 5483 crc 80DAD6C4 md5 D8C843396EA93E08A986ED3EC74A1B53 sha1 BE9373F6519A369E7D2DBA40A14319F4751B1B78 )
-)
-
-game (
-  name "Ghost Hunt (PSS)"
-  description "Ghost Hunt (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "GhostHunt.tzx" size 5538 crc 8E8D76F5 md5 C3B97B5345EA55BDC8C6307EE40F21B2 sha1 33AC921BE892A02C115F7DFA73C54CAFE178671B )
-)
-
-game (
-  name "Ghost Hunt (PSS)"
-  description "Ghost Hunt (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "ghosthunt.p" size 5302 crc DEA898BD md5 DC3E16535DCF3395085A311DECC1D8E5 sha1 DA84C5B1E1E7CB26EBDBAA119A4E0F29F9E4EF4F )
-)
-
-game (
-  name "Gobbleman (Monochrome Inlay) (Artic)"
-  description "Gobbleman (Monochrome Inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
-)
-
-game (
-  name "Gobbleman (Colour Inlay) (Artic)"
-  description "Gobbleman (Colour Inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
-)
-
-game (
-  name "Gobblers (Software Farm)"
-  description "Gobblers (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "gobblers.p" size 7162 crc B7687E93 md5 CB4CFA5B341C3D129405A82D97BC84BF sha1 FC15194E2CD43C8ED2121BC76331313532BD49DA )
-)
-
-game (
-  name "Gobblers (Software Farm)"
-  description "Gobblers (Software Farm)"
-  manufacturer "Software Farm"
-  rom ( name "Gobblers.tzx" size 7394 crc DAFE76E1 md5 8DE20A364CA8693EB9C755A7DA120189 sha1 681BD965A868D25B3DED5C9111C6F6A622A7DF1E )
-)
-
-game (
-  name "Gold (Hilderbay)"
-  description "Gold (Hilderbay)"
-  year "1981"
-  manufacturer "Hilderbay"
-  rom ( name "Gold.tzx" size 23791 crc A280FCBA md5 6824A18251ADF4CAE7CA49EA6F04D865 sha1 33C0ACAC2F430CC9884739426E287098D646BD92 )
-)
-
-game (
-  name "Golf (R & R Software)"
-  description "Golf (R & R Software)"
-  year "1982"
-  manufacturer "R & R Software"
-  rom ( name "Golf.tzx" size 9468 crc 1B658FAB md5 01ADE7A91BD9F70953004CB25D9E1D88 sha1 3177BEA82297A86A2C5C541CDE8426FFF95CC052 )
-)
-
-game (
-  name "Golf (R & R Software)"
-  description "Golf (R & R Software)"
-  year "1982"
-  manufacturer "R & R Software"
-  rom ( name "golf.p" size 9244 crc BDC6FF4E md5 761909F603CEAA4FB32BDFC288FBB19E sha1 0ADD3B45B1A4A246DDB24CE1D3EEA288032F8D99 )
-)
-
-game (
-  name "Graphics Kit (Softsync)"
-  description "Graphics Kit (Softsync)"
-  year "1981"
-  manufacturer "Paul Holmes"
-  rom ( name "GraphicsKit.tzx" size 6203 crc 0E978F07 md5 53AC6583CA184C362108642E40F086CD sha1 2E26B56A9895655424D29D23D2836C28B0A26226 )
-)
-
-game (
-  name "Great Britain Ltd (Simon W. Hessel)"
-  description "Great Britain Ltd (Simon W. Hessel)"
-  manufacturer "Simon W. Hessel"
-  rom ( name "greatbritainltd.p" size 15541 crc 23AD347C md5 E4B1812BD16EA7CFDD416E932467E4D4 sha1 8EAFC58C5610B3901B85478DA04D25156F00BFF1 )
-)
-
-game (
-  name "Great Britain Ltd (Simon W. Hessel)"
-  description "Great Britain Ltd (Simon W. Hessel)"
-  manufacturer "Simon W. Hessel"
-  rom ( name "GreatBritainLtd.tzx" size 15767 crc 4B717923 md5 07BFF59AB86D31689CF4450D21F3741D sha1 BBDE7B36F9F2CB65CD0EF2F112C52CE612A19433 )
-)
-
-game (
-  name "Grimm's Fairy Trails (Timex)"
-  description "Grimm's Fairy Trails (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "grimmsfairytrails.p" size 9331 crc AD7E74E0 md5 BDEA9F593D45946FA07521844B0DD51E sha1 EE1B726655BFD5E897DA2AF3888F3C8545D85B99 )
-)
-
-game (
-  name "Grimm's Fairy Trails (Timex)"
-  description "Grimm's Fairy Trails (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "GrimmsFairyTrails.tzx" size 9563 crc 55FE8F96 md5 2ED795D94CAA50CD02CF68475E01AEF5 sha1 CB65770BE85ADD8B3AA5E01CECACC3B2B2835ECB )
-)
-
-game (
-  name "Guitar For Beginners (Timex)"
-  description "Guitar For Beginners (Timex)"
-  year "1982"
-  manufacturer "Tim Rossetti"
-  rom ( name "GuitarForBeginners.tzx" size 11246 crc 10734BFB md5 69EDFC6FCF6F8B26D2907AA32E3C5669 sha1 975DECA435C26ED3E0604497454129186E139307 )
-)
-
-game (
-  name "Guitar For Beginners (Timex)"
-  description "Guitar For Beginners (Timex)"
-  year "1982"
-  manufacturer "Tim Rossetti"
-  rom ( name "guitarforbeginners.p" size 11018 crc 73AF3C6D md5 FB35ABB3BCE84CD543E1BB9D46F65C82 sha1 97ADFD80A6ABB57717469A3FDAF17F7A160793F2 )
-)
-
-game (
-  name "Gulp (Mindware)"
-  description "Gulp (Mindware)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "Gulp(Mindware).1.Gulp.tzx" size 1125 crc C651F1E5 md5 E342F3FCC020D8AFD4BF4A496CA75F75 sha1 C91C14F5EC001C991ED3C67673FE38C8B7B9D02D )
-)
-
-game (
-  name "Gulp (Mindware)"
-  description "Gulp (Mindware)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "gulp.p" size 901 crc BE88DF61 md5 338AF799286FEE95CA3F1131A2C00BAC sha1 FBBE0822184C0A4594C5932358EDCFBE3DF4E7BE )
-)
-
-game (
-  name "Gulp 2 (Campbell Systems)"
-  description "Gulp 2 (Campbell Systems)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "gulp2.p" size 6116 crc 1BFD713D md5 C7DB6F6ED8CBA0F14AA92DF6D55F93A7 sha1 2399DFF41D799578005AD8B23CC5086E120971E0 )
-)
-
-game (
-  name "Gulp 2 (Campbell Systems)"
-  description "Gulp 2 (Campbell Systems)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "Gulp2.tzx" size 6342 crc B041F1BF md5 7C1BE7D5A5B5D0F65DAFDD2A0F252A2D sha1 AA0FADD80146C2DAB98DAB49C88F52BA4852C861 )
-)
-
-game (
-  name "Gulpman (Micromega)"
-  description "Gulpman (Micromega)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "Gulpman.tzx" size 6351 crc 7BAEBE9A md5 E47F73D6AADF86310E6379A22A7D6B7A sha1 D28C22863672B87A1F0F6B23F2262B0195B3E1FB )
-)
-
-game (
-  name "Gulpman (Micromega)"
-  description "Gulpman (Micromega)"
-  year "1982"
-  manufacturer "Campbell Systems"
-  rom ( name "gulpman.p" size 6121 crc 74A38569 md5 3EF8B687B566F338A2C672133E638379 sha1 9551CFDF7D738E0DB679F08B35B72724D2F5A7A2 )
-)
-
-game (
-  name "HRG 7.0 (Unknown)"
-  description "HRG 7.0 (Unknown)"
-  year "1983"
-  manufacturer "J. M. Cohen"
-  rom ( name "HRG70.tzx" size 19444 crc 75ADEE54 md5 EEC31C8470C05281F4E8C957E56889D3 sha1 9F062EA8B3BD11A868A773DD4FED573A51225A1E )
-)
-
-game (
-  name "Haute Resolution (Pluto)"
-  description "Haute Resolution (Pluto)"
-  year "1984"
-  manufacturer "CRL"
-  rom ( name "HauteResolution.tzx" size 6970 crc F52D460F md5 42186664D3F698C0EDE72A2B0C2AB398 sha1 91CD6738FCEC38D4FC9D3E3BA08614634935918A )
-)
-
-game (
-  name "Heating System Analyzer (Timex)"
-  description "Heating System Analyzer (Timex)"
-  year "1982"
-  manufacturer "Tim Rossetti"
-  rom ( name "HeatingSystemAnalyzer.tzx" size 15718 crc EA836C43 md5 29FA5B64D2C89DE8A19C0F678C6B2C94 sha1 9D5E5A4F1E26F6A5DBA03028940310BB796DA199 )
-)
-
-game (
-  name "Heating System Analyzer (Timex)"
-  description "Heating System Analyzer (Timex)"
-  year "1982"
-  manufacturer "Tim Rossetti"
-  rom ( name "heatingsystemanalyzer.p" size 15494 crc 17D05FC2 md5 8B2ACEADFBB20F65C305CDEAEA598262 sha1 087D0E4680643E6D9E808CCE10C918E58D3C72AB )
-)
-
-game (
-  name "High Res (Macronics)"
-  description "High Res (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "highres.p" size 10763 crc E37BAD7F md5 493817D98B6D96356DF1E1C3F93866E9 sha1 D817B3DB8F0065843E3B3D7EB4E55B673C08DE03 )
-)
-
-game (
-  name "High Res (Macronics)"
-  description "High Res (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "HighRes.tzx" size 10985 crc FA40DBC1 md5 F48465678582D4FD7BD8325DDEDE7788 sha1 9B81B10A719AF4C6C61A03ED003F1198F68BDA1B )
-)
-
-game (
-  name "The Home Asset Manager (Timex)"
-  description "The Home Asset Manager (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "homeassetmanagerthe.p" size 14886 crc 20B3E57E md5 9B8CB2A6F3192DB3DD54C6DE1AB895DC sha1 2BFD33290AC86115BBD77E00CA1617F3AAB588EA )
-)
-
-game (
-  name "The Home Asset Manager (Timex)"
-  description "The Home Asset Manager (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "HomeAssetManagerThe.tzx" size 15112 crc FD728104 md5 9EAD11C52ED50477589A292313FAA4B9 sha1 E19508787E6EDE4EC4323DF540DD7516B49B295D )
-)
-
-game (
-  name "The Home Improvement Planner (Timex)"
-  description "The Home Improvement Planner (Timex)"
-  year "1982"
-  manufacturer "K. Frink"
-  rom ( name "homeimprovementplannerthe.p" size 15647 crc F3A473A6 md5 D966246149AB479D02FE07DEBB61FCD5 sha1 3536D7CD6538E0CE71B00CB9D8166303114D769D )
-)
-
-game (
-  name "The Home Improvement Planner (Timex)"
-  description "The Home Improvement Planner (Timex)"
-  year "1982"
-  manufacturer "K. Frink"
-  rom ( name "HomeImprovementPlannerThe.tzx" size 15871 crc 4E4DF58C md5 15D4996825631A65404BCBEBB7358E09 sha1 45E98DB0F02643A37ED71B86A85042A331B9AAC1 )
-)
-
-game (
-  name "Hopper (PSS)"
-  description "Hopper (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "Hopper.tzx" size 11061 crc F5601550 md5 30ED7CC222C8A94447629233BB357832 sha1 4102DBFE6C3CDDB82877BB9B089F764420F0A249 )
-)
-
-game (
-  name "Hopper (PSS)"
-  description "Hopper (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "hopper.p" size 10833 crc 965D961A md5 F76D900361978E5A354569718C918783 sha1 9E5B1E824F492A88999C023646486A9620E1C89F )
-)
-
-game (
-  name "Hopper (Truck) (PSS)"
-  description "Hopper (Truck) (PSS)"
-  year "1981"
-  manufacturer "PSS"
-  rom ( name "hopper(truck).p" size 10833 crc 343EC159 md5 E49392779795505C5E776A86BB27DE9B sha1 347965BC2AB0003C295C1005E89CDE7053DD7040 )
-)
-
-game (
-  name "Hopper (Truck) (PSS)"
-  description "Hopper (Truck) (PSS)"
-  year "1981"
-  manufacturer "PSS"
-  rom ( name "Hopper(Truck).tzx" size 11061 crc 57034213 md5 ECC9DA3396BA5F0EEE543E3915A3AB8D sha1 5747373BE057F05059C47D8ACB42F2C9312EEB83 )
-)
-
-game (
-  name "House of Death (A. J. Rushton)"
-  description "House of Death (A. J. Rushton)"
-  manufacturer "A. J. Rushton"
-  rom ( name "HouseOfDeath.tzx" size 15289 crc E78272E3 md5 68FB7BFD61E73901337800B912DB3760 sha1 80EE47DD77A43C051C600A38DEF525950A110119 )
-)
-
-game (
-  name "House of Death (A. J. Rushton)"
-  description "House of Death (A. J. Rushton)"
-  manufacturer "A. J. Rushton"
-  rom ( name "houseofdeath.p" size 15045 crc D88C206A md5 89E832D5035229BCFE30A9D77A0242A9 sha1 962346B1F5E5D9F8C025994824736AC497BE1EA2 )
-)
-
-game (
-  name "The IRA Planner (Timex)"
-  description "The IRA Planner (Timex)"
-  year "1982"
-  manufacturer "Vincent H. Chase"
-  rom ( name "IRAPlannerThe.tzx" size 16247 crc AD9F1B1C md5 73D76E80FE78E640708645B14E6DAC88 sha1 74F585B9673B45307F59019F5D03E324FFEDFB8C )
-)
-
-game (
-  name "Adventure B: Inca Curse (Sinclair Research)"
-  description "Adventure B: Inca Curse (Sinclair Research)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "incacurse.p" size 11975 crc E37CDDD8 md5 736FD7C4C8854760206A05361299FAF1 sha1 ACB41012D467F473CB452F3CF1ACB8608F108725 )
-)
-
-game (
-  name "Adventure B: Inca Curse (Sinclair Research)"
-  description "Adventure B: Inca Curse (Sinclair Research)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "IncaCurse.tzx" size 12205 crc 700A1E34 md5 438603D7EAED102378AF94260A15BE1A sha1 8948F63C75C80DFFA4E317E4D8ED400BD6B11DE9 )
-)
-
-game (
-  name "Adventure B: Inca Curse (Artic)"
-  description "Adventure B: Inca Curse (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "IncaCurse(Artic).tzx" size 12205 crc 76D699E6 md5 15459A76AF72151AF7309C00FF13ABAE sha1 C3840C1539239437150D7E300B0BAE412AD6A987 )
-)
-
-game (
-  name "Adventure B: Inca Curse (Artic)"
-  description "Adventure B: Inca Curse (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "incacurse(artic).p" size 11975 crc E5A05A0A md5 E24F9EA9C889A9587479085276980FA1 sha1 B1B85676ADE56E51488F2262EE60FACC22989967 )
-)
-
-game (
-  name "Introduction To Chemistry (Timex)"
-  description "Introduction To Chemistry (Timex)"
-  year "1983"
-  manufacturer "J. J. Hollandsworth"
-  rom ( name "IntroductionToChemistry.tzx" size 37232 crc 7B7D1B69 md5 F7C95B6D075D662664527EFC3FC842D0 sha1 4A49F3C842E387DD1353DC859877B93C92AA8ACE )
-)
-
-game (
-  name "Invaders (Bug Byte)"
-  description "Invaders (Bug Byte)"
-  year "1982"
-  manufacturer "S. Munnery"
-  rom ( name "Invaders.tzx" size 2605 crc 93D1D5D7 md5 1D391665FB5734A2B274E2C9630D35F7 sha1 BB79A0EA9FF54E882D45A7CA94DC71762488B2CD )
-)
-
-game (
-  name "Invaders (Bug Byte)"
-  description "Invaders (Bug Byte)"
-  year "1982"
-  manufacturer "S. Munnery"
-  rom ( name "invaders.p" size 2373 crc 3B79C6AC md5 E3CD419E7F34DBFC4EFD9B4C8E0A7633 sha1 8683FD832959844FB6357FD272DCDE5ECE0A601D )
-)
-
-game (
-  name "Invaders (A. G. Software)"
-  description "Invaders (A. G. Software)"
-  manufacturer "Andrew Glaister"
-  rom ( name "Invaders(AGS).tzx" size 2349 crc 58299C24 md5 6A329B8B6BDCA462DC2564297FB425F2 sha1 37503B2C552016A3265FF387AFCA6FFA6380C5E8 )
-)
-
-game (
-  name "Invaders (A. G. Software)"
-  description "Invaders (A. G. Software)"
-  manufacturer "Andrew Glaister"
-  rom ( name "invaders(ags).p" size 2117 crc 134835D7 md5 B2CB96DEB94F2CAF1167C6AA9EED3C35 sha1 125D09E68F9AD9490B47ADEE512BF46DB7286C2A )
-)
-
-game (
-  name "Invaders (Re-release) (Bug Byte)"
-  description "Invaders (Re-release) (Bug Byte)"
-  year "1982"
-  manufacturer "S. Munnery"
-  rom ( name "Invaders(Alt).tzx" size 2605 crc E2B37050 md5 8886052187AD052BD05D2CB8E6D2A713 sha1 C5A9F1683D2730EAF40A879C0F5C676B5F718E03 )
-)
-
-game (
-  name "Invaders (Re-release) (Bug Byte)"
-  description "Invaders (Re-release) (Bug Byte)"
-  year "1982"
-  manufacturer "S. Munnery"
-  rom ( name "invaders(alt).p" size 2373 crc 4A1B632B md5 119058DBC93BB2AC6A7E804A878F03CC sha1 6BEB1369D7F96B83092CD84C0E32FE2AD786C2AC )
-)
-
-game (
-  name "Invaders (Forward Software)"
-  description "Invaders (Forward Software)"
-  manufacturer "Silversoft"
-  rom ( name "Invaders(Forward).tzx" size 3697 crc 3EA98BB5 md5 B52FECD042DA1349D326508F77D3DB33 sha1 A8AE592FE3B4B939B664BE00454FB591B004F478 )
-)
-
-game (
-  name "Invaders (Forward Software)"
-  description "Invaders (Forward Software)"
-  manufacturer "Silversoft"
-  rom ( name "invaders(forward).p" size 3465 crc 7005EDA5 md5 0E940CD5D0FAB16B860C1E5648EA7B8A sha1 425223961FDB8C2825796B99BBC5358E51BF9B14 )
-)
-
-game (
-  name "Invaders (Monochrome) (Bug Byte)"
-  description "Invaders (Monochrome) (Bug Byte)"
-  manufacturer "S. Munnery"
-  rom ( name "invaders(mono).p" size 2373 crc 2840348B md5 1B95516181A57DA16F56109CC87CFD94 sha1 1971694D7A009402C065F5D23CEC3AD847839232 )
-)
-
-game (
-  name "Invaders (Monochrome) (Bug Byte)"
-  description "Invaders (Monochrome) (Bug Byte)"
-  manufacturer "S. Munnery"
-  rom ( name "Invaders(Mono).tzx" size 2605 crc 80E827F0 md5 186D39211398BDBB5497D1BA89DF5AB9 sha1 3AEB0FA4A5C458ACE0AFFC01F528D4B15EE047B8 )
-)
-
-game (
-  name "Invaders (Typed Inlay) (Bug Byte)"
-  description "Invaders (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "S. Munnery"
-  rom ( name "Invaders(Typed).tzx" size 2605 crc 4647C030 md5 C6DBCED1C948E5322109052583789338 sha1 A3669F5CE7897E144314B0A4EA5E3E1B79CFF5EF )
-)
-
-game (
-  name "Invaders (Typed Inlay) (Bug Byte)"
-  description "Invaders (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "S. Munnery"
-  rom ( name "invaders(typed).p" size 2373 crc EEEFD34B md5 F426DF7408433E814F04CF3909A5A2F5 sha1 5FF6048270FDD16665EB1B1169F2F026C84A3B24 )
-)
-
-game (
-  name "Invasion Force (Artic)"
-  description "Invasion Force (Artic)"
-  year "1982"
-  manufacturer "Simon Wadsworth"
-  rom ( name "InvasionForce.tzx" size 7890 crc 84B20542 md5 C38EC3F7BABA880DCB937E9419956A22 sha1 3BF53649FDF8249FDB8A601BB7AE7DBBB38B08DE )
-)
-
-game (
-  name "Invasion Force (Artic)"
-  description "Invasion Force (Artic)"
-  year "1982"
-  manufacturer "Simon Wadsworth"
-  rom ( name "invasionforce.p" size 7658 crc A997EF38 md5 111B625CEFAE5439236A45013066A7AE sha1 6A3516B9127E8345A56C076990A9FFB7BF5834E7 )
-)
-
-game (
-  name "Invasion Force (International Publishing and Software Inc.)"
-  description "Invasion Force (International Publishing and Software Inc.)"
-  year "1983"
-  manufacturer "Simon Wadsworth"
-  rom ( name "InvasionForce(IPS).tzx" size 7890 crc C7842B97 md5 4C05EBB64D88D13EC859403F5C7F2B1E sha1 3B59F5A004F92D081181834AA59073BA74B47909 )
-)
-
-game (
-  name "Invasion Force (International Publishing and Software Inc.)"
-  description "Invasion Force (International Publishing and Software Inc.)"
-  year "1983"
-  manufacturer "Simon Wadsworth"
-  rom ( name "invasionforce(ips).p" size 7658 crc EAA1C1ED md5 C38F1C2548052873D8FBFF20F67A29DD sha1 39EBCEAFC98F2A8A7B2B4EB5CB35B4E2A4B34ADF )
-)
-
-game (
-  name "Inventory Control (Data-assette)"
-  description "Inventory Control (Data-assette)"
-  manufacturer "John Powers"
-  rom ( name "InventoryControl(DA).tzx" size 16175 crc 21D56EC5 md5 BFADCA8523ED9926C47C20B04E980289 sha1 390707E52E816A1DF284B65CE1FD52E14110A504 )
-)
-
-game (
-  name "Inventory Control (Data-assette)"
-  description "Inventory Control (Data-assette)"
-  manufacturer "John Powers"
-  rom ( name "inventorycontrol(da).p" size 15941 crc EB911B8B md5 2E9C7B2134665A0FA235764E75CC2957 sha1 4F63DB3C39FF4AABB3E0661500095F0C69DAB41D )
-)
-
-game (
-  name "J.D.Arcades (Computer Rentals)"
-  description "J.D.Arcades (Computer Rentals)"
-  year "1982"
-  manufacturer "John Davies"
-  rom ( name "jdarcades.p" size 8548 crc E7EA958D md5 E555EF74EC2F6346B82B363C24D97C96 sha1 7D47EC7D6670D7009CF6D059FE50C730E068D891 )
-)
-
-game (
-  name "J.D.Arcades (Computer Rentals)"
-  description "J.D.Arcades (Computer Rentals)"
-  year "1982"
-  manufacturer "John Davies"
-  rom ( name "JDArcades.tzx" size 8782 crc 6FB5F451 md5 E4AB3D1820711EB5B96DCD106694AA1D sha1 08C17DC95D0A7E8A68FB9B534398D45656E25EA5 )
-)
-
-game (
-  name "Kasino Kraps (Timex)"
-  description "Kasino Kraps (Timex)"
-  year "1983"
-  manufacturer "Gerald Bennett"
-  rom ( name "kasinokraps.p" size 12557 crc F041256F md5 DEDAB418C1EE0B2E03200ACF878164F3 sha1 C782994290DA3A40A82433718FB877A59FCD771B )
-)
-
-game (
-  name "Kasino Kraps (Timex)"
-  description "Kasino Kraps (Timex)"
-  year "1983"
-  manufacturer "Gerald Bennett"
-  rom ( name "KasinoKraps.tzx" size 12777 crc 7E27AD21 md5 32A434E44B75CFEEDF737A25E4D22AE0 sha1 39950E34A01E852C6DF5FB06E59DFAE019D54E90 )
-)
-
-game (
-  name "Keyboard Calculator (Timex)"
-  description "Keyboard Calculator (Timex)"
-  year "1982"
-  manufacturer "J. Gishen"
-  rom ( name "KeyboardCalculator.tzx" size 6160 crc 56B36255 md5 781D98F620DB9510336788EB8FF310EA sha1 064ABD828A4D801E1E2029234762F6AADCBA008E )
-)
-
-game (
-  name "Keys To Gondrun (International Publishing and Software Inc.)"
-  description "Keys To Gondrun (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "KeysToGondrun.tzx" size 15928 crc 97E9AC6D md5 9D45DCB3C159FFB5396641C88E7E5196 sha1 38C82913732383AE4FAE62DD1BE8F5A04927CDFD )
-)
-
-game (
-  name "Keys To Gondrun (International Publishing and Software Inc.)"
-  description "Keys To Gondrun (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "keystogondrun.p" size 15704 crc F8340D3B md5 AACA5C9EB8AE112EB41D7A3B99E93A6B sha1 639D2EB5931FD7B874D0CA9B1374BCE68971DED6 )
-)
-
-game (
-  name "Kingdom of Nam (Microgame Simulations)"
-  description "Kingdom of Nam (Microgame Simulations)"
-  year "1981"
-  manufacturer "R. Erskine"
-  rom ( name "KingdomOfNam.tzx" size 8202 crc CA57C0C9 md5 5D075C2EA9428E0C2D3B09597056D810 sha1 D5C07352365144B1F0C9EB4C89A3F854747B7A90 )
-)
-
-game (
-  name "Kingdom of Nam (Microgame Simulations)"
-  description "Kingdom of Nam (Microgame Simulations)"
-  year "1981"
-  manufacturer "R. Erskine"
-  rom ( name "kingdomofnam.p" size 7958 crc A997242D md5 ECCAD4F7E6CA9806B1D2976970EE39FD sha1 718235CFDDAFACFDF7276438614712042488ECF5 )
-)
-
-game (
-  name "The Knight's Quest (Phipps Associates)"
-  description "The Knight's Quest (Phipps Associates)"
-  year "1983"
-  manufacturer "Mike Farley"
-  rom ( name "KnightsQuest.tzx" size 52909 crc 2BCEDB3F md5 BB390C8D2BD1CED32C6E0A739DAECDB3 sha1 CE182BF32766964CA43066727475EADBAA6A8D1A )
-)
-
-game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
-  description "Kongs Revenge (Stephen Hartley Computing)"
-  year "1984"
-  manufacturer "I. Kendrick"
-  rom ( name "KongsRevenge.tzx" size 14843 crc CC315ACA md5 C82FD9679EE58446A0C54271E2F56287 sha1 C87D1A7F00CCA913B0D9BDBE8A8752E82C72FD6C )
-)
-
-game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
-  description "Kongs Revenge (Stephen Hartley Computing)"
-  year "1984"
-  manufacturer "I. Kendrick"
-  rom ( name "kongsrevenge.p" size 14601 crc DAF31C48 md5 A88F23545D67709D83D214EFC9344173 sha1 6915C841A5AF606E7E0A0198EFEC07AED4C8CB91 )
-)
-
-game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
-  description "Kongs Revenge (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. Kendrick"
-  rom ( name "kongsrevenge.p" size 14601 crc DAF31C48 md5 A88F23545D67709D83D214EFC9344173 sha1 6915C841A5AF606E7E0A0198EFEC07AED4C8CB91 )
-)
-
-game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
-  description "Kongs Revenge (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. Kendrick"
-  rom ( name "KongsRevenge.tzx" size 14843 crc CC315ACA md5 C82FD9679EE58446A0C54271E2F56287 sha1 C87D1A7F00CCA913B0D9BDBE8A8752E82C72FD6C )
-)
-
-game (
-  name "Krazy Kong (PSS)"
-  description "Krazy Kong (PSS)"
-  year "1982"
-  manufacturer "C. P. Cullen"
-  rom ( name "krazykong.p" size 8229 crc E5E30579 md5 FEA1DD4EDF42F770255B5D90D6DA9CFF sha1 0BBEE2723AAA7A2758B5394D2AD269FFC561EDE8 )
-)
-
-game (
-  name "Krazy Kong (PSS)"
-  description "Krazy Kong (PSS)"
-  year "1982"
-  manufacturer "C. P. Cullen"
-  rom ( name "KrazyKong.tzx" size 8465 crc A5DD2AFE md5 4DF17878870A7BC5B63FA607C8EB4C36 sha1 AC74298BADC343B3C81A96FCA8BCAB1B43FAAD87 )
-)
-
-game (
-  name "Krazy Kong (Intercomputer Inc)"
-  description "Krazy Kong (Intercomputer Inc)"
-  year "1983"
-  manufacturer "C. P. Cullen"
-  rom ( name "KrazyKong(Inter).tzx" size 7799 crc D5A3DDD8 md5 B355C229F453610568AB040EA9CEBB5E sha1 1E4EDF41F7A576A8B68ECFAAB4F936BA80460360 )
-)
-
-game (
-  name "Krazy Kong (Intercomputer Inc)"
-  description "Krazy Kong (Intercomputer Inc)"
-  year "1983"
-  manufacturer "C. P. Cullen"
-  rom ( name "krazykong(inter).p" size 7563 crc AD4FE8FF md5 C1AAF449BDC105EE2CCD74DE7BA82EC5 sha1 554D1D5B991C9A221183DD6F6067E41C77746D7B )
-)
-
-game (
-  name "Labyrinth (Axis)"
-  description "Labyrinth (Axis)"
-  year "1981"
-  manufacturer "Axis"
-  rom ( name "Labyrinth.tzx" size 10956 crc 2BD7DD50 md5 25EB8D058AB8AEB9D5CE8FF64DFCC0D8 sha1 2CE0F07C10363839828A54FB00FB278F1ED5AEAC )
-)
-
-game (
-  name "Labyrinth (Axis)"
-  description "Labyrinth (Axis)"
-  year "1981"
-  manufacturer "Axis"
-  rom ( name "labyrinth.p" size 10722 crc 46400A6F md5 0A3F962C532CB046D7A71998CC29D412 sha1 8AD0DF41D206AD534AEED2BE3FE208BB00F99BB6 )
-)
-
-game (
-  name "Labyrinth (Colour Inlay) (Axis)"
-  description "Labyrinth (Colour Inlay) (Axis)"
-  year "1981"
-  manufacturer "Axis"
-  rom ( name "labyrinth.p" size 10722 crc 46400A6F md5 0A3F962C532CB046D7A71998CC29D412 sha1 8AD0DF41D206AD534AEED2BE3FE208BB00F99BB6 )
-)
-
-game (
-  name "Labyrinth (Colour Inlay) (Axis)"
-  description "Labyrinth (Colour Inlay) (Axis)"
-  year "1981"
-  manufacturer "Axis"
-  rom ( name "Labyrinth.tzx" size 10956 crc 2BD7DD50 md5 25EB8D058AB8AEB9D5CE8FF64DFCC0D8 sha1 2CE0F07C10363839828A54FB00FB278F1ED5AEAC )
-)
-
-game (
-  name "Language Usage (Timex)"
-  description "Language Usage (Timex)"
-  year "1982"
-  manufacturer "Software for Excellence"
-  rom ( name "LanguageUsage.tzx" size 43685 crc F83BA0CD md5 81F643D82C2F273248421F15F4E8F91B sha1 8892AAC163FEB54128EE568636C905C0CB18E7E5 )
-)
-
-game (
-  name "Lap Record (Macronics)"
-  description "Lap Record (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "laprecord.p" size 4895 crc 13522B1E md5 4E017F1D09E8CD51B3B3656B5C1EFDFA sha1 5091EAF17D8816A7766811F0D57EA54611825670 )
-)
-
-game (
-  name "Lap Record (Macronics)"
-  description "Lap Record (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "LapRecord.tzx" size 5115 crc 4AB33041 md5 075644FA16A629B4B732265C9129998C sha1 28D2A56BC5974BED6E848A495367140893F35EB1 )
-)
-
-game (
-  name "The List Manager (Timex)"
-  description "The List Manager (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "ListManagerThe.tzx" size 29918 crc 9DF64F46 md5 7994115109D17648490EFB35403448B0 sha1 F3FED91B2947D49A6D85C26797F46366BA614769 )
-)
-
-game (
-  name "The Loan/Mortgage Amortizer (Timex)"
-  description "The Loan/Mortgage Amortizer (Timex)"
-  year "1982"
-  manufacturer "T. J. Software"
-  rom ( name "LoanMortgageAmortizerThe.tzx" size 10564 crc 8FD28637 md5 B0BF87937E33697F07D9B3D62D436E36 sha1 60988BEEEFB18DD293F49A3F91C6487D6245A554 )
-)
-
-game (
-  name "The Loan/Mortgage Amortizer (Timex)"
-  description "The Loan/Mortgage Amortizer (Timex)"
-  year "1982"
-  manufacturer "T. J. Software"
-  rom ( name "loanmortgageamortizerthe.p" size 10332 crc 08257DA4 md5 418E25313141160CD04D7AC8693B5784 sha1 731AAA3F99ED2AA3F71D86858037F37C4B7AF86B )
-)
-
-game (
-  name "Lost Island (JRS Software)"
-  description "Lost Island (JRS Software)"
-  year "1982"
-  manufacturer "JRS Software"
-  rom ( name "lostisland.p" size 15542 crc C93D1958 md5 F1783D3018E369FE915E919646AB845C sha1 56310E5EA2F0DC1E77C95717E7B5E988C9C0FFF9 )
-)
-
-game (
-  name "Lost Island (JRS Software)"
-  description "Lost Island (JRS Software)"
-  year "1982"
-  manufacturer "JRS Software"
-  rom ( name "LostIsland.tzx" size 15766 crc B0682DDB md5 28AC9145502B4144B038821D63B419E4 sha1 B1BED07DD568166C87352C1700C8E3FB81A43A7B )
-)
-
-game (
-  name "Lunar Rescue (Mikro-Gen)"
-  description "Lunar Rescue (Mikro-Gen)"
-  manufacturer "K. J. Bezant"
-  rom ( name "lunarrescue.p" size 4657 crc 0EC491CE md5 62D3CD05D6EA6103CB47824C7316135F sha1 810FE42934480BC6967D058F91586CC558BF4BC5 )
-)
-
-game (
-  name "Lunar Rescue (Mikro-Gen)"
-  description "Lunar Rescue (Mikro-Gen)"
-  manufacturer "K. J. Bezant"
-  rom ( name "LunarRescue.tzx" size 4885 crc B63D952A md5 9D99D03E0DA02AB1601A4DBE89446BAB sha1 620F51472B3313AA14BEE80521E5654C05B4C5B6 )
-)
-
-game (
-  name "MCoder (PSS)"
-  description "MCoder (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "mcoder.p" size 3558 crc 7297A09D md5 712640382C22590907ACDF151C7C35F3 sha1 48E7BCFB62552FD617AF3C4B903B3F52F759DB3B )
-)
-
-game (
-  name "MCoder (PSS)"
-  description "MCoder (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "MCoder.tzx" size 3786 crc 3AEF6340 md5 3E6A131A6FF49DFF552F0E8518686726 sha1 74D2103372C2D6E5D627C9DEDDBA2ED948606C77 )
-)
-
-game (
-  name "MCoder 11 (PSS)"
-  description "MCoder 11 (PSS)"
-  year "1983"
-  manufacturer "PSS"
-  rom ( name "MCoder11.tzx" size 5941 crc 4C0EE232 md5 4E67FB609FA6B32E7B84C3C9713E468F sha1 E4D21864BFBBA4E7584FB8D4817494EDDEBEBA52 )
-)
-
-game (
-  name "MCoder 11 (PSS)"
-  description "MCoder 11 (PSS)"
-  year "1983"
-  manufacturer "PSS"
-  rom ( name "mcoder11.p" size 5713 crc 44B1BBE5 md5 7B5D8EAAAED4BA91FF36B3308126976F sha1 CD400D506C292DFD1946264D8D5518FECEB8E0BA )
-)
-
-game (
-  name "Machine Code Test Tool (F. O. Ainley)"
-  description "Machine Code Test Tool (F. O. Ainley)"
-  year "1982"
-  manufacturer "F. O. Ainley"
-  rom ( name "machinecodetesttool.p" size 2823 crc 778F13A8 md5 440B350563FA9DD8AC48B7A3D01A27BD sha1 5063E60E26A804E8CB2F210349D9CCEF375F3C2E )
-)
-
-game (
-  name "Machine Code Test Tool (F. O. Ainley)"
-  description "Machine Code Test Tool (F. O. Ainley)"
-  year "1982"
-  manufacturer "F. O. Ainley"
-  rom ( name "MachineCodeTestTool.tzx" size 3047 crc E7FC10FC md5 FB5CD1E9564AF7FCBDA7227B19104342 sha1 9108F1176687353A4B9E0A0EFF750478A863D5C2 )
-)
-
-game (
-  name "Manufacturing Control (Timex)"
-  description "Manufacturing Control (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "manufacturingcontrol.p" size 14780 crc 10E493B2 md5 84384096921E088B18CC9E3EEDB3B143 sha1 C603B553FC42D949FED9139CB58D0BDE4F3C3D3E )
-)
-
-game (
-  name "Manufacturing Control (Timex)"
-  description "Manufacturing Control (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "ManufacturingControl.tzx" size 15008 crc FEC50D8E md5 38BCF567460A33EDB8FF13034834100F sha1 694CFA2652B6134621F5B6A2A189AF5B8F1E853B )
-)
-
-game (
-  name "Marine Rescue (International Publishing and Software Inc.)"
-  description "Marine Rescue (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing & Software Inc."
-  rom ( name "marinerescue.p" size 10829 crc D91C71E8 md5 BF106CF05B1E4D7318DF3F7C1A7C125C sha1 39AF94024CCBBE9262BBF98B8841CB00D258C418 )
-)
-
-game (
-  name "Marine Rescue (International Publishing and Software Inc.)"
-  description "Marine Rescue (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing & Software Inc."
-  rom ( name "MarineRescue.tzx" size 11057 crc 60217181 md5 CA6CE91A6AEA06AC28859C418DAAC227 sha1 C0FE4882D84B9FC7503004128975115B5CC355F2 )
-)
-
-game (
-  name "Math Routines and Fit (Zeta Software)"
-  description "Math Routines and Fit (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896DE80 md5 EE3E759E69B64248F0E5BD1846D63A76 sha1 AA81C6329174CB096D5690CF4D6456B0E0DBDCCC )
-)
-
-game (
-  name "Math Routines and Fit (Zeta Software)"
-  description "Math Routines and Fit (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "mathroutinesandfit.p" size 15850 crc EF830293 md5 205EFA1A71BA01038CD3BC523F1A9667 sha1 C1A6B8F1C9798FB57FAEA5EE52DC1BCACEE68B1B )
-)
-
-game (
-  name "Maths Invaders (Programs in Education)"
-  description "Maths Invaders (Programs in Education)"
-  rom ( name "mathsinvaders.p" size 7786 crc 27B974EC md5 0E79E0CEEBC05771120ADC45BEBB8FB9 sha1 348D5786FD8B153EA7EF26E7EB0AF63A273A9D18 )
-)
-
-game (
-  name "Maths Invaders (Programs in Education)"
-  description "Maths Invaders (Programs in Education)"
-  rom ( name "MathsInvaders.tzx" size 8030 crc 19057596 md5 479D85EE6074FB7E7ECCEDB399DBC1F2 sha1 4E6E0FC96692A767DE539EC97DF4B06B30C5AF70 )
-)
-
-game (
-  name "Mazogs (Bug Byte)"
-  description "Mazogs (Bug Byte)"
-  year "1982"
-  manufacturer "Don Priestley"
-  rom ( name "mazogs.p" size 12831 crc 007463E5 md5 589A35248F7A9CB539F91B03427F9A3C sha1 DEE47E0C7E717B9721E63078E1CFDCE88FF9F725 )
-)
-
-game (
-  name "Mazogs (Bug Byte)"
-  description "Mazogs (Bug Byte)"
-  year "1982"
-  manufacturer "Don Priestley"
-  rom ( name "Mazogs.tzx" size 13059 crc 4CB450B8 md5 421C3CDBE09CBA807770D925BBB56DDE sha1 EDEE5D84ED22C2CFFA6B605A4CAA998A8510DA17 )
-)
-
-game (
-  name "Mazogs (Gladstone) (Gladstone Electronics)"
-  description "Mazogs (Gladstone) (Gladstone Electronics)"
-  manufacturer "Don Priestley"
-  rom ( name "mazogs(ge).p" size 12942 crc BDAB60B2 md5 D8BBD02ADE6AC94438547F255C04517B sha1 14CA73F2AE0D621BA17FBC5E0F0E8D9184184347 )
-)
-
-game (
-  name "Mazogs (Gladstone) (Gladstone Electronics)"
-  description "Mazogs (Gladstone) (Gladstone Electronics)"
-  manufacturer "Don Priestley"
-  rom ( name "Mazogs(GE).tzx" size 13170 crc 5D7DD442 md5 CB162114851F80E1A4A820D4E7E4CC22 sha1 94E2DA0938BD44F9C0392E2061E390E69D49D47B )
-)
-
-game (
-  name "Mazogs (Monochrome) (Bug Byte)"
-  description "Mazogs (Monochrome) (Bug Byte)"
-  year "1981"
-  manufacturer "Don Priestley"
-  rom ( name "Mazogs.tzx" size 13059 crc 4CB450B8 md5 421C3CDBE09CBA807770D925BBB56DDE sha1 EDEE5D84ED22C2CFFA6B605A4CAA998A8510DA17 )
-)
-
-game (
-  name "Mazogs (Monochrome) (Bug Byte)"
-  description "Mazogs (Monochrome) (Bug Byte)"
-  year "1981"
-  manufacturer "Don Priestley"
-  rom ( name "mazogs.p" size 12831 crc 007463E5 md5 589A35248F7A9CB539F91B03427F9A3C sha1 DEE47E0C7E717B9721E63078E1CFDCE88FF9F725 )
-)
-
-game (
-  name "Mazogs (Softsync)"
-  description "Mazogs (Softsync)"
-  year "1982"
-  manufacturer "Don Priestley"
-  rom ( name "mazogs(softsync).p" size 12831 crc 60B3C966 md5 ACD2A6C8F4340C6F2553449225123CD8 sha1 A8E8494BEE216F4054CDB2F34735177108305DE8 )
-)
-
-game (
-  name "Mazogs (Softsync)"
-  description "Mazogs (Softsync)"
-  year "1982"
-  manufacturer "Don Priestley"
-  rom ( name "Mazogs(Softsync).tzx" size 13059 crc 2C73FA3B md5 C89ACD6EC795FFEEF1D658836BB0DDE3 sha1 56E5E86334CB633863FC2386FFDA515AD8C58EA9 )
-)
-
-game (
-  name "Merchant of Venus (Crystal)"
-  description "Merchant of Venus (Crystal)"
-  year "1983"
-  manufacturer "Crystal"
-  rom ( name "merchantofvenus.p" size 16161 crc 51CF1515 md5 F607C834C5F1405F7FF0F0E99AF1E934 sha1 4BE29A8DF43BB849740910A055A8773E4D35A2FD )
-)
-
-game (
-  name "Merchant of Venus (Crystal)"
-  description "Merchant of Venus (Crystal)"
-  year "1983"
-  manufacturer "Crystal"
-  rom ( name "MerchantOfVenus.tzx" size 16393 crc 5E4A029E md5 76409F6A8710A0231FFC4562A5217465 sha1 95F7628F548DCBFEB169FE3F12BAA23E720B6F8C )
-)
-
-game (
-  name "Meteor Storm (dK'tronics)"
-  description "Meteor Storm (dK'tronics)"
-  year "1982"
-  manufacturer "dK'tronics"
-  rom ( name "meteorstorm.p" size 5747 crc 8AED8FF8 md5 16A19477D2B25332DFD44117DA71FA78 sha1 1C737A14C4BAE0D2AF32F28ED9DD2BAA4D1DD792 )
-)
-
-game (
-  name "Meteor Storm (Fast Master) (dK'tronics)"
-  description "Meteor Storm (Fast Master) (dK'tronics)"
-  year "1982"
-  manufacturer "dK'tronics"
-  rom ( name "meteorstorm(fastmaster).p" size 5784 crc 83AE249C md5 0BBAAFB1A7802DBBBBB03EB1852330E7 sha1 736654E354223E719629101BB94FDAF8A847220C )
-)
-
-game (
-  name "Meteor Storm (Fast Master) (dK'tronics)"
-  description "Meteor Storm (Fast Master) (dK'tronics)"
-  year "1982"
-  manufacturer "dK'tronics"
-  rom ( name "MeteorStorm(FastMaster).tzx" size 6024 crc 35C2540E md5 4066B1DCFB69B1F9205ED0CB6B6BF35C sha1 E02A6983C28A40CCC70A3FA3EDD1DC6DBF176354 )
-)
-
-game (
-  name "Micro Mouse goes de-bugging (Lothlorien)"
-  description "Micro Mouse goes de-bugging (Lothlorien)"
-  year "1983"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "micromouse.p" size 8487 crc 17365457 md5 D0603604ED0847E629EEA1EC9E701457 sha1 C4510C08365BB8E873315F98FBBBBC067EC06612 )
-)
-
-game (
-  name "Micro Mouse goes de-bugging (Lothlorien)"
-  description "Micro Mouse goes de-bugging (Lothlorien)"
-  year "1983"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "MicroMouse.tzx" size 8713 crc DB8110B5 md5 052BC1C42964E438A69FEAB1759A255C sha1 012A444AC366224D63DAF2BC242CA30B58A0E33A )
-)
-
-game (
-  name "Mind vs. Machine (2-Bit Software)"
-  description "Mind vs. Machine (2-Bit Software)"
-  year "1982"
-  manufacturer "2-Bit Software"
-  rom ( name "MindvsMachine.B.tzx" size 3168 crc C7AC234D md5 BB2EF658C6FFE1DA45C34E32DD7A5161 sha1 5BF1942B1696AD670427A5119BAC1CBDDCAC30F0 )
-)
-
-game (
-  name "Mixed Game Bag III (Timex)"
-  description "Mixed Game Bag III (Timex)"
-  year "1982"
-  manufacturer "M. Orwin"
-  rom ( name "MixedGameBagIII.tzx" size 6939 crc 9115C144 md5 1AA50B1328AFE02CE01D69FCEE6EE746 sha1 9AD8A4C6321346B904995AC8E9AEE31124EB5868 )
-)
-
-game (
-  name "Money Analyzer 1 (Timex)"
-  description "Money Analyzer 1 (Timex)"
-  year "1982"
-  manufacturer "T. J. Software"
-  rom ( name "MoneyAnalyzer1.tzx" size 2508 crc 8B0ECF6C md5 38B90377D5298596FD2D123F2E1BD9C2 sha1 5A223F431B06F01CCD7E30C31D462422409A3C69 )
-)
-
-game (
-  name "Moniteur Desassembleur (Direco International)"
-  description "Moniteur Desassembleur (Direco International)"
-  year "1982"
-  rom ( name "moniteurdesassembleur.p" size 5593 crc 357448FF md5 5635D4860A5B03B9312EA12A87383631 sha1 6B32FF9CE4F9DAB7E9E43DF50C9DD8264D9CF5B9 )
-)
-
-game (
-  name "Moniteur Desassembleur (Direco International)"
-  description "Moniteur Desassembleur (Direco International)"
-  year "1982"
-  rom ( name "MoniteurDesassembleur.tzx" size 5825 crc E548A0E6 md5 4B422022A5ED280D6BD1F6F74F7B56C5 sha1 F3433D201596F069DFF1053A86FC2F293B8E4612 )
-)
-
-game (
-  name "Monster Mine (Gem Software)"
-  description "Monster Mine (Gem Software)"
-  year "1982"
-  manufacturer "Gem Software"
-  rom ( name "MonsterMine.tzx" size 11048 crc AC4BEC18 md5 BBA503301BE95EA4FE4F9E3C45E867C1 sha1 BCBF2D46F2C8B547600F979882968D4A57C5B524 )
-)
-
-game (
-  name "Monster Mine (Gem Software)"
-  description "Monster Mine (Gem Software)"
-  year "1982"
-  manufacturer "Gem Software"
-  rom ( name "monstermine.p" size 10808 crc C0B1F76E md5 951905CD41AA8A43D7CECE736A99099E sha1 F5063AFF551446D25A9CBD3D7080E5D505D1F66A )
-)
-
-game (
-  name "Morse Reader (JEP Electronics)"
-  description "Morse Reader (JEP Electronics)"
-  manufacturer "JEP Electronics"
-  rom ( name "morsereader.p" size 8827 crc 059EE1F6 md5 FFFBF7D1AAC3E3BF21F8895A5EA53194 sha1 51CE900CEC1C55F91037989DA1610DD6B73CBAE6 )
-)
-
-game (
-  name "Morse Reader (JEP Electronics)"
-  description "Morse Reader (JEP Electronics)"
-  manufacturer "JEP Electronics"
-  rom ( name "MorseReader.tzx" size 9055 crc 9FCE1AF5 md5 F01F1D0B641939493ED663D9703BAA5B sha1 DEBE28EC7E350D9B6431DC6FCA6DA97513232F02 )
-)
-
-game (
-  name "Mothership (Sinclair Research)"
-  description "Mothership (Sinclair Research)"
-  year "1982"
-  manufacturer "Alan Laity, Softsync"
-  rom ( name "Mothership.tzx" size 9863 crc 526E7FA1 md5 BD8246E4A145F366BC9BF23BB45913C1 sha1 05FD66EC3EB2C22DF673F2BDAA238FAAB8AE5FC2 )
-)
-
-game (
-  name "Mothership (Sinclair Research)"
-  description "Mothership (Sinclair Research)"
-  year "1982"
-  manufacturer "Alan Laity, Softsync"
-  rom ( name "mothership.p" size 9627 crc 7DE56C4B md5 33404FCDBD84277061D678EBE4D6DBE3 sha1 55CD6D320281C29978170E22A8286803F0C72049 )
-)
-
-game (
-  name "Mothership (Softsync)"
-  description "Mothership (Softsync)"
-  year "1983"
-  manufacturer "Alan Laity"
-  rom ( name "Mothership(Softsync).tzx" size 9863 crc 28F60C02 md5 B065399AD89B9C5D000A60F7AC971154 sha1 63DEC851B552AC48D167CE90DEEC768F0677D42F )
-)
-
-game (
-  name "Mothership (Softsync)"
-  description "Mothership (Softsync)"
-  year "1983"
-  manufacturer "Alan Laity"
-  rom ( name "mothership(softsync).p" size 9627 crc 077D1FE8 md5 4B63A2614E5907B002264EFEA78A41E5 sha1 697CA1D242137E2207A98C70181D02A7895DA64D )
-)
-
-game (
-  name "Multifile (Gladstone) (Gladstone Electronics)"
-  description "Multifile (Gladstone) (Gladstone Electronics)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "Multifile(GE).tzx" size 5783 crc 18343751 md5 B05754895C071D02F191E4D7D588BF59 sha1 D72DE512A1ADC62CF2DE299C2E1FF64ED630316B )
-)
-
-game (
-  name "Multifile (Gladstone) (Gladstone Electronics)"
-  description "Multifile (Gladstone) (Gladstone Electronics)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "multifile(ge).p" size 5549 crc D71BF8BC md5 E4806A5D67124ADA1F733F0E681CF66B sha1 BAB72E5AAE3AE98D0D4DA03CBA691B9E61E32FE6 )
-)
-
-game (
-  name "Multifile Plus (Gladstone Electronics)"
-  description "Multifile Plus (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952FF07 md5 80FF32332CB0BDA770C476A519B0365A sha1 C2866C2C9430D5AEC6EA4EB01D7F04C839B1B30C )
-)
-
-game (
-  name "Multifile Plus (Gladstone Electronics)"
-  description "Multifile Plus (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "multifileplus(ge).p" size 7677 crc 6CB1F589 md5 DEA427C0DDCDB0E27BDBFA199D903C8F sha1 E036FC55971244C9E2A3B157BD9F527B349DCE17 )
-)
-
-game (
-  name "Multigraphics 2.3 (Bridge Software)"
-  description "Multigraphics 2.3 (Bridge Software)"
-  year "1981"
-  manufacturer "Bridge Software"
-  rom ( name "Multigraphics.tzx" size 14452 crc 14DD97D3 md5 3B70EAA4B9C771FEED049F6C1E0B798B sha1 7B7BEAD37DB83539393B9BAB71C15ED048608D85 )
-)
-
-game (
-  name "Multigraphics 2.3 (Bridge Software)"
-  description "Multigraphics 2.3 (Bridge Software)"
-  year "1981"
-  manufacturer "Bridge Software"
-  rom ( name "multigraphics.p" size 14210 crc F55B43E1 md5 7000C83BD3B8B8EE761DFFC603B7B90C sha1 256D229A11058BED6F608553FC1D9D081397AE89 )
-)
-
-game (
-  name "Munchees (Quicksilva)"
-  description "Munchees (Quicksilva)"
-  year "1983"
-  manufacturer "A. Laird"
-  rom ( name "munchees.p" size 7545 crc B9365FA1 md5 4D0347C0D394CDF1BBCB10D5553BB34B sha1 7C59C57A62EB0AA7750175020287B913E34AAA19 )
-)
-
-game (
-  name "Munchees (Quicksilva)"
-  description "Munchees (Quicksilva)"
-  year "1983"
-  manufacturer "A. Laird"
-  rom ( name "Munchees.tzx" size 7777 crc 4DA90EED md5 B724025D7778E61DD088A66D0BA7B272 sha1 C64C8336F95030B957F3E6C3AED5BE3A2237DBB1 )
-)
-
-game (
-  name "Muncher (Silversoft)"
-  description "Muncher (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "muncher.p" size 5200 crc CADFF742 md5 DBA0E8079AB8F60C47B31BDFF986E49E sha1 F9FCBBD7D5AAC8A8C22BF7E73B87ECCB18AEDC00 )
-)
-
-game (
-  name "Muncher (Silversoft)"
-  description "Muncher (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "Muncher.tzx" size 5430 crc 7334AD2A md5 2E1104B8D2D21F6C359477CC66366358 sha1 2D7EDCFD205DFBDFE253967FA8DD25711964B00C )
-)
-
-game (
-  name "Murgatroyds (Collins Computing)"
-  description "Murgatroyds (Collins Computing)"
-  year "1982"
-  manufacturer "Collins Computing"
-  rom ( name "murgatroyds.p" size 7097 crc A0130EEA md5 4B59AF5F517EBEEAEB25DB1A85883C5E sha1 6D309CCBE66964B30C9ED418EF8537EFD07BC17E )
-)
-
-game (
-  name "Murgatroyds (Collins Computing)"
-  description "Murgatroyds (Collins Computing)"
-  year "1982"
-  manufacturer "Collins Computing"
-  rom ( name "Murgatroyds.tzx" size 7315 crc D35AF98D md5 40A6BB5E88B35F7309F76B55C808A7F2 sha1 E9B44DC8DCE87E747C15C2BB24DC508F319DDC36 )
-)
-
-game (
-  name "Music Composer (Memotronic)"
-  description "Music Composer (Memotronic)"
-  manufacturer "Frank Beer and Wolfgang Labus"
-  rom ( name "musiccomposer.p" size 5578 crc B0DCDCCA md5 76133648609D8AB9B7B24A418E9AE215 sha1 70A99A384559E1D70E38B2EC5A6DFCAC3CFE6EC0 )
-)
-
-game (
-  name "Music Composer (Memotronic)"
-  description "Music Composer (Memotronic)"
-  manufacturer "Frank Beer and Wolfgang Labus"
-  rom ( name "MusicComposer.tzx" size 5822 crc D0CC5789 md5 8AB416356FB8DE668546530C4AB0A890 sha1 BBF95991604EB52B8211D709736CDCDE9AC4DC3B )
-)
-
-game (
-  name "Music Educator 1 (Timex)"
-  description "Music Educator 1 (Timex)"
-  year "1983"
-  manufacturer "Tim Rossetti"
-  rom ( name "MusicEducator1.tzx" size 14372 crc DB66A8DD md5 F1FD3CF9B70BB1E730C0C73C75BF8129 sha1 0EE598AB50535505E8382F93D6F77F158D1E43E4 )
-)
-
-game (
-  name "Music Educator 1 (Timex)"
-  description "Music Educator 1 (Timex)"
-  year "1983"
-  manufacturer "Tim Rossetti"
-  rom ( name "musiceducator1.p" size 14146 crc B7C34C96 md5 702E4B03957EF8A387A76013D1F1E932 sha1 457B9A66701A0EDC6CB5B1C91D84758B64C3A074 )
-)
-
-game (
-  name "Namtir Raiders (Artic)"
-  description "Namtir Raiders (Artic)"
-  year "1982"
-  manufacturer "J. Ritman"
-  rom ( name "NamtirRaiders.tzx" size 3984 crc E65D10F3 md5 80D72C6B620D287E922279B2A5902E65 sha1 364DD09FAC90173806CD1A643B594CB378156A55 )
-)
-
-game (
-  name "Namtir Raiders (Artic)"
-  description "Namtir Raiders (Artic)"
-  year "1982"
-  manufacturer "J. Ritman"
-  rom ( name "namtirraiders.p" size 3740 crc 8BA3150E md5 28A7022C5386D46864FEC0F0E9516A4F sha1 FB0367A015A4BEB3CF6EE00853E84E430CEECC36 )
-)
-
-game (
-  name "Night Gunner (Digital Integration)"
-  description "Night Gunner (Digital Integration)"
-  year "1982"
-  manufacturer "Digital Integration"
-  rom ( name "nightgunner.p" size 5113 crc 8FC7C658 md5 F15A54C0F92CC903B91CE8ED37E7CB88 sha1 9EC875318FA4E35087E65A9CF3B9DEF0080F3705 )
-)
-
-game (
-  name "Night Gunner (Digital Integration)"
-  description "Night Gunner (Digital Integration)"
-  year "1982"
-  manufacturer "Digital Integration"
-  rom ( name "NightGunner.tzx" size 5333 crc BA8BEA96 md5 CB630368C6F87F40C3D461F988F005FA sha1 ECD2C009311A97F40EAE7102FAF426E8572B6F96 )
-)
-
-game (
-  name "Night Gunner (Softsync)"
-  description "Night Gunner (Softsync)"
-  year "1982"
-  manufacturer "Digital Integration"
-  rom ( name "nightgunner(softsync).p" size 5113 crc 77639E65 md5 32CBAF62810EC52668BB663029E893A5 sha1 F3B4EA9743015A0CB2C612A79322663A0E36A25A )
-)
-
-game (
-  name "Night Gunner (Softsync)"
-  description "Night Gunner (Softsync)"
-  year "1982"
-  manufacturer "Digital Integration"
-  rom ( name "NightGunner(Softsync).tzx" size 5333 crc 422FB2AB md5 5FB5E7061C2C292259D4244B2B9847C1 sha1 9BD903833515016E2E6215C068B630223FC0138A )
-)
-
-game (
-  name "Nightmare Park (Macronics)"
-  description "Nightmare Park (Macronics)"
-  year "1981"
-  manufacturer "J. D. S. Cranston"
-  rom ( name "NightmarePark.tzx" size 11879 crc 53965B76 md5 42B898FEE8207B3A73316056A7BF7ECA sha1 86DBCA70AE32E736A89C161C7E260E43576DA971 )
-)
-
-game (
-  name "Nightmare Park (Macronics)"
-  description "Nightmare Park (Macronics)"
-  year "1981"
-  manufacturer "J. D. S. Cranston"
-  rom ( name "nightmarepark.p" size 11659 crc 28F39976 md5 ACE96513FEF192CD7197825120D9EB95 sha1 7B6344D8E2C62AA1DC1BEBB64107DEC51617B402 )
-)
-
-game (
-  name "Octopussy (Peaksoft)"
-  description "Octopussy (Peaksoft)"
-  manufacturer "Peaksoft"
-  rom ( name "octopussy.p" size 6090 crc 62265923 md5 4C419DD9A3B3463D331E5C8C2F3D7E6B sha1 CA8C3A27854E51ACB3ABBB02C5EBB6AE40C628C0 )
-)
-
-game (
-  name "Octopussy (Peaksoft)"
-  description "Octopussy (Peaksoft)"
-  manufacturer "Peaksoft"
-  rom ( name "Octopussy.tzx" size 6308 crc 9D408C0E md5 FA9F1E45071A0B907B6D8FDFC71F0430 sha1 745515410B88F840A33611B15C4E0A31E6B28611 )
-)
-
-game (
-  name "The Oracle's Cave (Doric Computer Systems)"
-  description "The Oracle's Cave (Doric Computer Systems)"
-  year "1981"
-  manufacturer "C. T. Dorrel"
-  rom ( name "oraclescavethe.p" size 15953 crc 6135DAAD md5 01F7597A8EECF63967921A7DC63FF23E sha1 9358857B5B1BE76EE495A089E07CD61BC44C6F48 )
-)
-
-game (
-  name "The Oracle's Cave (Doric Computer Systems)"
-  description "The Oracle's Cave (Doric Computer Systems)"
-  year "1981"
-  manufacturer "C. T. Dorrel"
-  rom ( name "OraclesCaveThe.tzx" size 16181 crc DEA5489A md5 E148DDC58CCCE3FC4F32BE9B8ABC2B63 sha1 752BB718F14E0A7E9DA87FA958CCD0E366813A34 )
-)
-
-game (
-  name "Othello (CDS Micro Systems)"
-  description "Othello (CDS Micro Systems)"
-  manufacturer "CDS Micro Systems"
-  rom ( name "othello.p" size 11655 crc 73457797 md5 EF70888041689CC60B9336201735F725 sha1 4DD7218297D9EF6CFB776DECBD2F040A297E1C3E )
-)
-
-game (
-  name "Othello (CDS Micro Systems)"
-  description "Othello (CDS Micro Systems)"
-  manufacturer "CDS Micro Systems"
-  rom ( name "Othello.tzx" size 11885 crc 09D487FE md5 CFCB326E75DFA9A59A79E05491686DD6 sha1 47C8980D14972B59FAB5098667B170169894515D )
-)
-
-game (
-  name "ZX Othello (Moi)"
-  description "ZX Othello (Moi)"
-  year "1982"
-  manufacturer "Moi"
-  rom ( name "Othello(Moi).tzx" size 12809 crc 96EEAB64 md5 2B76C39D66873CFA8959CEBDD71D5CEC sha1 78F78E57BF940D87D020C39AA4218B273F612313 )
-)
-
-game (
-  name "Paint-Maze (Mikro-Gen)"
-  description "Paint-Maze (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "PaintMaze.tzx" size 5086 crc 2EFF4B27 md5 23DD48A06FF28C78E8A3F9BF26AA557E sha1 E8519C3EB5B772F13FE374C1C57A15D7D4791887 )
-)
-
-game (
-  name "Peloponnesian War (Lothlorien)"
-  description "Peloponnesian War (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "PeloponnesianWar.tzx" size 16341 crc F56E0C9D md5 7A8AB89F6173649C5BBC0A6A9BF4D62D sha1 94EBC1A99152A5441238AD242DA19B4C9CCEE699 )
-)
-
-game (
-  name "Peloponnesian War (Lothlorien)"
-  description "Peloponnesian War (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "peloponnesianwar.p" size 16121 crc F44DEC8B md5 1BC0299B676A7656670585FC0199772C sha1 A3F5B184568AC4EA26AE03F9E737E9FD1D4EAC53 )
-)
-
-game (
-  name "Pengy (Fawkes Computing)"
-  description "Pengy (Fawkes Computing)"
-  year "1984"
-  manufacturer "Fawkes Computing"
-  rom ( name "Pengy.tzx" size 8782 crc 85894997 md5 BB2821339AF5EBE2F6EB4CCC752F6A55 sha1 27606CF98E27ECC5A6DA5DA5E36BA5AB9C4FA038 )
-)
-
-game (
-  name "Pengy (Fawkes Computing)"
-  description "Pengy (Fawkes Computing)"
-  year "1984"
-  manufacturer "Fawkes Computing"
-  rom ( name "pengy.p" size 8564 crc F7E0304A md5 CDB3809C3F646129F7DECBA0DCC0C0CE sha1 19A0D22ACA1F1580FAC805B570A7BC3EA7EC4D2C )
-)
-
-game (
-  name "Pilot (Hewson Consultants)"
-  description "Pilot (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "Pilot.tzx" size 15119 crc 775BAFED md5 BE91F4D73F8C368C0B5C55A33A836D28 sha1 8C4645159BCBEC8144E875EFEACB772D6609119D )
-)
-
-game (
-  name "Pilot (Hewson Consultants)"
-  description "Pilot (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "pilot.p" size 14899 crc 8DFFD009 md5 68DC6D6B80D3C94E16D60CB5082A341F sha1 954DD9582E636990DE568425B3602D3467C45D18 )
-)
-
-game (
-  name "Pilot (Colour inlay) (Hewson Consultants)"
-  description "Pilot (Colour inlay) (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "pilot.p" size 14899 crc 8DFFD009 md5 68DC6D6B80D3C94E16D60CB5082A341F sha1 954DD9582E636990DE568425B3602D3467C45D18 )
-)
-
-game (
-  name "Pilot (Colour inlay) (Hewson Consultants)"
-  description "Pilot (Colour inlay) (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "Pilot.tzx" size 15119 crc 775BAFED md5 BE91F4D73F8C368C0B5C55A33A836D28 sha1 8C4645159BCBEC8144E875EFEACB772D6609119D )
-)
-
-game (
-  name "Pilot (New) (Hewson Consultants)"
-  description "Pilot (New) (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "Pilot(New).tzx" size 13271 crc 0BC60AAD md5 B3B606ADD7070B8C774FF1AF2B562732 sha1 42E19385766FE586291DEE026B49B60F47A9DF0F )
-)
-
-game (
-  name "Pilot (New) (Hewson Consultants)"
-  description "Pilot (New) (Hewson Consultants)"
-  year "1982"
-  manufacturer "Hewson Consultants"
-  rom ( name "pilot(new).p" size 13051 crc D9519A6E md5 8B5DF07010240DCEAD0141109297547E sha1 8ECB69E390BD24941DB252F592F059E327BE0DB6 )
-)
-
-game (
-  name "Pimania (Automata Cartography)"
-  description "Pimania (Automata Cartography)"
-  year "1982"
-  manufacturer "Automata"
-  rom ( name "Pimania.tzx" size 16003 crc 37CFB18D md5 5047A7041130A121E5D4E2D33E7AC1EB sha1 DD537D6AB72A749D1F6071D91748282E2EA2B89F )
-)
-
-game (
-  name "Pimania (Automata Cartography)"
-  description "Pimania (Automata Cartography)"
-  year "1982"
-  manufacturer "Automata"
-  rom ( name "pimania.p" size 15773 crc 351EB08B md5 536E24E5B74EF6BE13C44EAEBEBCEEA5 sha1 39F717B621452E6C853DC0E0318C01ACB5AD45E6 )
-)
-
-game (
-  name "Pinball (Timex)"
-  description "Pinball (Timex)"
-  year "1982"
-  manufacturer "A. H. Laity"
-  rom ( name "Pinball.tzx" size 4898 crc F8452E21 md5 986CC07F307993D0F7A996CAA18AF0EB sha1 4FF5E7491088E5EBE4C67B4813BAA943AAEA5164 )
-)
-
-game (
-  name "Pinball (Timex)"
-  description "Pinball (Timex)"
-  year "1982"
-  manufacturer "A. H. Laity"
-  rom ( name "pinball.p" size 4668 crc 40B6BEF6 md5 1E2905FD9AB4F7F57E6A9D81DDFE2E7C sha1 26C5D56388AE2BDC5F9ADC53AA670E427F3F5E68 )
-)
-
-game (
-  name "Pioneer Trail (Quicksilva)"
-  description "Pioneer Trail (Quicksilva)"
-  year "1983"
-  manufacturer "M.Stubbs"
-  rom ( name "pioneertrail.p" size 15462 crc E4AD892D md5 77F604B5F45DC443B41AEFE41387F0F5 sha1 33FDC9772DE2008CD98E5A55FE0013EAEF752FE8 )
-)
-
-game (
-  name "Pioneer Trail (Quicksilva)"
-  description "Pioneer Trail (Quicksilva)"
-  year "1983"
-  manufacturer "M.Stubbs"
-  rom ( name "PioneerTrail.tzx" size 15682 crc CEB55F84 md5 3187C5EB7E83D9020E2AABF3F7ECB5EB sha1 1FF2A193FFDA69D2CA542D63334399BCF2301390 )
-)
-
-game (
-  name "Adventure A: Planet of Death (Sinclair Research)"
-  description "Adventure A: Planet of Death (Sinclair Research)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "planetofdeath.p" size 13445 crc AB715C00 md5 F0A90C314572232E860A486F47C34CFE sha1 247F37D1B70A0EEC9ABCE64EA094D55E3E59B27C )
-)
-
-game (
-  name "Adventure A: Planet of Death (Sinclair Research)"
-  description "Adventure A: Planet of Death (Sinclair Research)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "PlanetOfDeath.tzx" size 13675 crc CDEF18A4 md5 4ECB3F0A3A9A9C9A25520BF1F7D2175E sha1 346412F09B472C931874FD441660AB5435D5F3C1 )
-)
-
-game (
-  name "Adventure A: Planet of Death (Artic)"
-  description "Adventure A: Planet of Death (Artic)"
-  manufacturer "Artic"
-  rom ( name "PlanetOfDeath.tzx" size 13675 crc CDEF18A4 md5 4ECB3F0A3A9A9C9A25520BF1F7D2175E sha1 346412F09B472C931874FD441660AB5435D5F3C1 )
-)
-
-game (
-  name "Adventure A: Planet of Death (Artic)"
-  description "Adventure A: Planet of Death (Artic)"
-  manufacturer "Artic"
-  rom ( name "planetofdeath.p" size 13445 crc AB715C00 md5 F0A90C314572232E860A486F47C34CFE sha1 247F37D1B70A0EEC9ABCE64EA094D55E3E59B27C )
-)
-
-game (
-  name "Planetoids (Macronics)"
-  description "Planetoids (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "planetoids.p" size 4909 crc 8A63863A md5 EFDB0ABDAB99EDBBF7B0C31281A17A8F sha1 9BCA8CF12D888DBBE9B1D8F5A00E8F207CD0A346 )
-)
-
-game (
-  name "Planetoids (Macronics)"
-  description "Planetoids (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "Planetoids.tzx" size 5127 crc 02A6B2AD md5 8715626FA60FFA829018000D02DD3A1C sha1 270765BE9B076E4EAA0704EECE81137AD2C0AE10 )
-)
-
-game (
-  name "Portfolio Analysis (Timex)"
-  description "Portfolio Analysis (Timex)"
-  year "1982"
-  manufacturer "American Micro Products"
-  rom ( name "PortfolioAnalysis.tzx" size 15819 crc D7AC34ED md5 0FD3B75C0D622131340A3C1BF3325EDF sha1 E92DA69A510BDDB77AD5FAB8E13F70D388EE5878 )
-)
-
-game (
-  name "Portfolio Analysis (Timex)"
-  description "Portfolio Analysis (Timex)"
-  year "1982"
-  manufacturer "American Micro Products"
-  rom ( name "portfolioanalysis.p" size 15597 crc B540A618 md5 562CDB1A3E92927A8797312F03C448B6 sha1 26EBCCFF7160857F8490074A84BFD30C99ACA883 )
-)
-
-game (
-  name "Presidents (Timex)"
-  description "Presidents (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "presidents.p" size 5072 crc 61969B67 md5 6B8958911520B13BA8DCBA0695D550E6 sha1 BA972C28536586A0C567357DBDCAD2E362F45F91 )
-)
-
-game (
-  name "Presidents (Timex)"
-  description "Presidents (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "Presidents.tzx" size 5300 crc 7BB539CF md5 7C4CCC1D49EF865BFD3A4E0BABAC9F4B sha1 E8ECEE650BD89D88C7EB2FB9EC06EDA5D5647CAA )
-)
-
-game (
-  name "Print Shop (Cases Computer Simulations)"
-  description "Print Shop (Cases Computer Simulations)"
-  year "1983"
-  manufacturer "Cases Computer Simulations"
-  rom ( name "PrintShop.tzx" size 15212 crc DA63A78F md5 5DF01A04FF5CA4CF0F48939DD76A60FE sha1 6D911EA6F2E1DF74F2547FB89C99F240A0E0272B )
-)
-
-game (
-  name "Print Shop (Cases Computer Simulations)"
-  description "Print Shop (Cases Computer Simulations)"
-  year "1983"
-  manufacturer "Cases Computer Simulations"
-  rom ( name "printshop.p" size 14978 crc 5514B638 md5 CD8F4D73855EAEF7ED7E81772A29EA3B sha1 CD58BEE963702779034BFDBB17A22B8AEEB86C15 )
-)
-
-game (
-  name "Printer Programs (Nick Godwin)"
-  description "Printer Programs (Nick Godwin)"
-  year "1984"
-  manufacturer "Nick Godwin"
-  rom ( name "PrinterPrograms.tzx" size 20668 crc 11D50D78 md5 DD1CCFE9D8243D306EBB0BDA40E351A4 sha1 22A458E45D174F9053A5B96BCDF848FA2AFC0E9E )
-)
-
-game (
-  name "Privateer (Lothlorien)"
-  description "Privateer (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "Privateer.tzx" size 13217 crc 32E4F2D4 md5 7899A00015CC9B9B791C767D7C540C5E sha1 DB608044F7C01B572406ADE9481A6AEA68995488 )
-)
-
-game (
-  name "Privateer (Lothlorien)"
-  description "Privateer (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "privateer.p" size 12983 crc 8B4CE0E7 md5 81BD561DDED0399D415F1E3C7B4D2419 sha1 B27DEC9EAEB5F88581365FB6D5BD20C56E9BD6A9 )
-)
-
-game (
-  name "Progmerge (ACS Software)"
-  description "Progmerge (ACS Software)"
-  year "1982"
-  manufacturer "ACS Software"
-  rom ( name "Progmerge.tzx" size 5513 crc 13313BB9 md5 389D183A481034896E71E0C94603E729 sha1 FEF5282A0E6A8937F22398C45187BB0E98E51B27 )
-)
-
-game (
-  name "Progmerge (ACS Software)"
-  description "Progmerge (ACS Software)"
-  year "1982"
-  manufacturer "ACS Software"
-  rom ( name "progmerge.p" size 5279 crc D3FC7BF8 md5 951F8F1A0652936A3BB3F118C9BCC74E sha1 CDE61A0ECB7A1E2F2531CC1743D2CAEB746E47DE )
-)
-
-game (
-  name "Protector (Abacus)"
-  description "Protector (Abacus)"
-  year "1982"
-  manufacturer "K. Flynn"
-  rom ( name "protector.p" size 7601 crc 571DB599 md5 3C438049FFF5DCC3247C530C9D39047E sha1 FA2BDBF6919EE3BE7205F9A07DB6A2EA1041E579 )
-)
-
-game (
-  name "Protector (Abacus)"
-  description "Protector (Abacus)"
-  year "1982"
-  manufacturer "K. Flynn"
-  rom ( name "Protector.tzx" size 7835 crc 941C0480 md5 4D4C872B5934E61F8BB2064DBF7F122C sha1 750A926049ABEC9C67F6ADE68FC029A068800DC6 )
-)
-
-game (
-  name "Puckman (Hewson Consultants)"
-  description "Puckman (Hewson Consultants)"
-  year "1981"
-  manufacturer "Hewson Consultants"
-  rom ( name "puckman.p" size 10535 crc 23E9839E md5 CA251287C8C980E758D4C497028A24D0 sha1 7571EBDBBD2308FFF0653217FE599ADB8E702B26 )
-)
-
-game (
-  name "Puckman (Hewson Consultants)"
-  description "Puckman (Hewson Consultants)"
-  year "1981"
-  manufacturer "Hewson Consultants"
-  rom ( name "Puckman.tzx" size 10765 crc 2678C742 md5 46A91FB71DA2119DF0CE3AC027A7CBB3 sha1 C382093F64AC43318766C4C884854150A1775F2F )
-)
-
-game (
-  name "QS Asteroids (No characters) (Quicksilva)"
-  description "QS Asteroids (No characters) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSAsteroids(NC).tzx" size 3647 crc 92DF0BF9 md5 83A4ED182CA56C6CC560E1F017F536CE sha1 64A0E4AA51C42DDC49BA4A4A26F73FE4FEF123FB )
-)
-
-game (
-  name "QS Asteroids (No characters) (Quicksilva)"
-  description "QS Asteroids (No characters) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsasteroids(nc).p" size 3425 crc 64116F53 md5 CDBF8582FD0EB31C153708960714E98D sha1 52E3612464419DBE622C5C23FA50DCE1FAB9B4C3 )
-)
-
-game (
-  name "QS Asteroids (Big picture, no text) (Quicksilva)"
-  description "QS Asteroids (Big picture, no text) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "qsasteroids(bp2).p" size 3419 crc B88DB752 md5 D5208B3C585A16897AA9488865FAED2E sha1 F74FA3E6439F92A3491F2D6CF4C07961F40847F0 )
-)
-
-game (
-  name "QS Asteroids (Big picture, no text) (Quicksilva)"
-  description "QS Asteroids (Big picture, no text) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "QSAsteroids(BP2).tzx" size 3641 crc C5FCF3DB md5 DF2760F0A630F8019D417946916FEFEB sha1 B39C7484A5CEC019727F037A37103E44B37741EC )
-)
-
-game (
-  name "QS Defenda (Quicksilva)"
-  description "QS Defenda (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSDefenda.tzx" size 2739 crc F53682E9 md5 6B4ADFF2E0FEAF1B8722F9025FF979CA sha1 DB9F63DEB748E232C16B4C8B769B143315D83540 )
-)
-
-game (
-  name "QS Defenda (Quicksilva)"
-  description "QS Defenda (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsdefenda.p" size 2517 crc 91FC58B0 md5 CDA9AB3AD5EC7DBFFC54F03AF34E09A0 sha1 B309D7EB02194221ED8AACE44C17DA53052555E6 )
-)
-
-game (
-  name "QS Defenda (Number) (Quicksilva)"
-  description "QS Defenda (Number) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsdefenda.p" size 2517 crc 91FC58B0 md5 CDA9AB3AD5EC7DBFFC54F03AF34E09A0 sha1 B309D7EB02194221ED8AACE44C17DA53052555E6 )
-)
-
-game (
-  name "QS Defenda (Number) (Quicksilva)"
-  description "QS Defenda (Number) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSDefenda.tzx" size 2739 crc F53682E9 md5 6B4ADFF2E0FEAF1B8722F9025FF979CA sha1 DB9F63DEB748E232C16B4C8B769B143315D83540 )
-)
-
-game (
-  name "QS Defenda (Big picture) (Quicksilva)"
-  description "QS Defenda (Big picture) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "QSDefenda(BP).tzx" size 1971 crc 15B06F98 md5 CC64EBD2A4E4BEBC7033F975D33A0D4A sha1 ECCD0670138EA0F14DE3448536ADDDC1DF5CD57F )
-)
-
-game (
-  name "QS Defenda (Big picture) (Quicksilva)"
-  description "QS Defenda (Big picture) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "qsdefenda(bp).p" size 1749 crc 18409A9F md5 973E7FA1E1F0EBDFDFAC2AF2DCF15929 sha1 8E297AEC1684FA43CDD5A1F2D8540BFB0B1B74DD )
-)
-
-game (
-  name "QS Invaders (Quicksilva)"
-  description "QS Invaders (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
-)
-
-game (
-  name "QS Invaders (Quicksilva)"
-  description "QS Invaders (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
-)
-
-game (
-  name "QS Invaders (Number) (Quicksilva)"
-  description "QS Invaders (Number) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
-)
-
-game (
-  name "QS Invaders (Number) (Quicksilva)"
-  description "QS Invaders (Number) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
-)
-
-game (
-  name "QS Invaders (Number, Upside down) (Quicksilva)"
-  description "QS Invaders (Number, Upside down) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
-)
-
-game (
-  name "QS Invaders (Number, Upside down) (Quicksilva)"
-  description "QS Invaders (Number, Upside down) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
-)
-
-game (
-  name "QS Invaders (Big picture) (Quicksilva)"
-  description "QS Invaders (Big picture) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "qsinvaders(bp).p" size 7185 crc F855545E md5 72C039832C770144F6ABBD7FCC1410D8 sha1 C2AB1CD34875DCD0F23206C5CE2F745169D047C0 )
-)
-
-game (
-  name "QS Invaders (Big picture) (Quicksilva)"
-  description "QS Invaders (Big picture) (Quicksilva)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "QSInvaders(BP).tzx" size 7407 crc 05B21451 md5 AC31E8EF363DEF7FB56EBBAB76F49DB1 sha1 92B476ABE309E02A9721AB2DB8D927418060338E )
-)
-
-game (
-  name "QS Scramble (Number) (Quicksilva)"
-  description "QS Scramble (Number) (Quicksilva)"
-  year "1982"
-  manufacturer "Quicksilva"
-  rom ( name "QSScramble(Alt).tzx" size 6320 crc 30847836 md5 09A4633A93747AEB1BCA9E190AEAA14C sha1 7EE4B859C49EE81A670BD629E05AC27177DDDB7D )
-)
-
-game (
-  name "Q Save (PSS)"
-  description "Q Save (PSS)"
-  manufacturer "PSS"
-  rom ( name "qsave.p" size 1547 crc A3EDAAB2 md5 48C37E545EAA01EF260E4B4799DC5992 sha1 FBDC2B3081B1E088AB05129EF8A5376E1378652D )
-)
-
-game (
-  name "Q Save (Red) (PSS)"
-  description "Q Save (Red) (PSS)"
-  manufacturer "PSS"
-  rom ( name "QSave(Red).tzx" size 1693 crc 28BCFD44 md5 D6DB4577CE639CE63B01D3EC351A5CF6 sha1 173946BA09A7B0F085B975D25DDFE6F431541186 )
-)
-
-game (
-  name "Q Save (Red) (PSS)"
-  description "Q Save (Red) (PSS)"
-  manufacturer "PSS"
-  rom ( name "qsave(red).p" size 1467 crc 7918413A md5 597C8A759AF88CA64C2AD2462492887F sha1 46EE323C057848AB62D253662891EAE847E449D8 )
-)
-
-game (
-  name "RPN Calculator (Zeta Software)"
-  description "RPN Calculator (Zeta Software)"
-  year "1982"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "rpncalculator.p" size 8282 crc FD66EF0E md5 DF81AB32F89ACCD286BF7CAC114DB2A4 sha1 CD9F8D264AF05FEE79132004522EB5049F250650 )
-)
-
-game (
-  name "RPN Calculator (Zeta Software)"
-  description "RPN Calculator (Zeta Software)"
-  year "1982"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "RPNCalculator.tzx" size 8504 crc 1609EF0D md5 6943FDF8FB6E3D76EE3C9D119D3CD441 sha1 A6283859FFC5D6390B55803129777FE32B74D627 )
-)
-
-game (
-  name "Ram Runner (Timex)"
-  description "Ram Runner (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "ramrunner.p" size 12985 crc 1CAA4B3E md5 B18437B08FDEFF0CACA69EA2AFAE96EB sha1 998860F07B4C60A190883E5BBDFB3AE249C40F1C )
-)
-
-game (
-  name "Ram Runner (Timex)"
-  description "Ram Runner (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "RamRunner.tzx" size 13213 crc 9AD7E13F md5 EEF86DD226681E5E6CD3DB6A7EB2766E sha1 C821A765C4045B8107FF273DAC9D211BACA717CD )
-)
-
-game (
-  name "Real Estate Investment Analysis (Timex)"
-  description "Real Estate Investment Analysis (Timex)"
-  year "1982"
-  manufacturer "American Micro Products Inc."
-  rom ( name "RealEstateInvestmentAnalysis.tzx" size 16047 crc 8373ADA1 md5 98459338D5E57BE0F9E7721C4BCFD883 sha1 240481EB5E8B45EE3E7D240076819B8E2593C3F0 )
-)
-
-game (
-  name "Real Estate Investment Analysis (Timex)"
-  description "Real Estate Investment Analysis (Timex)"
-  year "1982"
-  manufacturer "American Micro Products Inc."
-  rom ( name "realestateinvestmentanalysis.p" size 15825 crc EDEF9F40 md5 5767AD8D9E1AE3F9FEDBA17514A069E5 sha1 C75505864F9FE3D9842561EC9BDE7A4D24CC9D57 )
-)
-
-game (
-  name "Red Alert (Softsync)"
-  description "Red Alert (Softsync)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "RedAlert.tzx" size 4236 crc 16D48454 md5 4C5E219F57813A8838E43BA6AE791810 sha1 61A4719DA9099699143E39713D08C13E381E9216 )
-)
-
-game (
-  name "Red Alert (Softsync)"
-  description "Red Alert (Softsync)"
-  year "1981"
-  manufacturer "Quicksilva"
-  rom ( name "redalert.p" size 4004 crc E3F0E0C6 md5 3EE4DE96FF92AA764D6A5AF1978BF769 sha1 D95C77E1B695AF04D6679CDAB70ED2AB9CAA8F2A )
-)
-
-game (
-  name "Rental Property Manager (Data-assette)"
-  description "Rental Property Manager (Data-assette)"
-  manufacturer "John Powers"
-  rom ( name "rentalpropertymanager.p" size 16109 crc 2316C873 md5 79E94AC3F50F837458EAF07ED4317951 sha1 79194CF5DFCA47D67866257DBF2E2F31D8E79272 )
-)
-
-game (
-  name "Rental Property Manager (Data-assette)"
-  description "Rental Property Manager (Data-assette)"
-  manufacturer "John Powers"
-  rom ( name "RentalPropertyManager.tzx" size 16339 crc 92F8AA70 md5 4B297D59DFA3FD14EE638B35D6F8BC99 sha1 378BB82167E1EE3A4F8EC8A69B2A3612CD2B2810 )
-)
-
-game (
-  name "Reversi also known as Othello (Sinclair Research)"
-  description "Reversi also known as Othello (Sinclair Research)"
-  year "1982"
-  manufacturer "Moi/Games of Skill Ltd"
-  rom ( name "Reversi.tzx" size 6452 crc 01930D80 md5 E33B1E6B4508F5EFF9D7F0C873B0C94D sha1 0B09A2D44F3FB3243DA9CC46FF161BFFE6D8021B )
-)
-
-game (
-  name "Reversi also known as Othello (Sinclair Research)"
-  description "Reversi also known as Othello (Sinclair Research)"
-  year "1982"
-  manufacturer "Moi/Games of Skill Ltd"
-  rom ( name "reversi.p" size 6222 crc 9317D6CF md5 496AEEF5F2CEA222A7223625F990C8F4 sha1 DF86A5E30D5E38F37A3AB4E2975515E38BDDBB82 )
-)
-
-game (
-  name "Reversi (Artic)"
-  description "Reversi (Artic)"
-  year "1982"
-  manufacturer "T. Hughes"
-  rom ( name "reversi(artic).p" size 14726 crc 613DD959 md5 5529E75702832F4C17874D81E49833A2 sha1 89E9591FF6720A374C30A1BE117E5B9720FCEA98 )
-)
-
-game (
-  name "Reversi (Artic)"
-  description "Reversi (Artic)"
-  year "1982"
-  manufacturer "T. Hughes"
-  rom ( name "Reversi(Artic).tzx" size 14952 crc D5796E37 md5 708F70B98133DE0290338C974AE50509 sha1 516F08CEEFE2997E183E6F47E774FDA4B81D7BE3 )
-)
-
-game (
-  name "Robbers of the Lost Tomb (Timeworks)"
-  description "Robbers of the Lost Tomb (Timeworks)"
-  year "1982"
-  manufacturer "Timeworks"
-  rom ( name "robbersofthelosttomb.p" size 12141 crc 79FCFB44 md5 02209F4889C543A0A43D451743708328 sha1 345FA829AD2F082291C236EC5826AED0E864D8BA )
-)
-
-game (
-  name "Robbers of the Lost Tomb (Timeworks)"
-  description "Robbers of the Lost Tomb (Timeworks)"
-  year "1982"
-  manufacturer "Timeworks"
-  rom ( name "RobbersOfTheLostTomb.tzx" size 12365 crc 700A0975 md5 7D90A419CC9FC490F597993EFFB7D068 sha1 4E78F00D3529ACCFDDE236C2EF24E43106B5D8D4 )
-)
-
-game (
-  name "Rocket Man (Software Farm)"
-  description "Rocket Man (Software Farm)"
-  year "1984"
-  manufacturer "Software Farm"
-  rom ( name "RocketMan.tzx" size 15561 crc E34ADCA9 md5 4EF97704D962703CA65309098356D20B sha1 024909DDF04E7EFB22C4E84781AEA9CE8E20A877 )
-)
-
-game (
-  name "Rocket Man (Software Farm)"
-  description "Rocket Man (Software Farm)"
-  year "1984"
-  manufacturer "Software Farm"
-  rom ( name "rocketman.p" size 15327 crc 93FDEFB0 md5 2A2606484CF8BBC5BFDFECE4B1AB657B sha1 C9BDE797AB35E89FE71FE595857B5D1D1D2740FC )
-)
-
-game (
-  name "Roman Empire (Lothlorien)"
-  description "Roman Empire (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "RomanEmpire.tzx" size 15328 crc 5EEEF590 md5 A0B4632B0BC95998B687AF11DF7C769B sha1 38225146A420B541CD425E420B5C21C794FD7486 )
-)
-
-game (
-  name "Roman Empire (Lothlorien)"
-  description "Roman Empire (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "romanempire.p" size 15108 crc 19EBF247 md5 5C3BABFF0601A703A4EE3549D7608422 sha1 3629F81C9DFF99B9D9BB84EE392F3C3EC345916F )
-)
-
-game (
-  name "Rubik Cube (Alt) (CDS Micro Systems)"
-  description "Rubik Cube (Alt) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "RubikCube(Alt).tzx" size 14601 crc 11D010A0 md5 A514D66D19792684AD2F5F8987BB9448 sha1 7996CA3BB737847719BDFC0663483D0906D74282 )
-)
-
-game (
-  name "Rubik Cube (Alt) (CDS Micro Systems)"
-  description "Rubik Cube (Alt) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "rubikcube(alt).p" size 14375 crc C163A924 md5 12BCC34945162BEB2B494198AEA60E23 sha1 8075D277091B180EE535F253DAEAF7CD39135069 )
-)
-
-game (
-  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-  description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "rubikcube.p" size 15158 crc 8AE261A2 md5 D70593B633E0E6A88A7E919F6F4C95C2 sha1 31426D332E594597879A9C42B259436445E96E4E )
-)
-
-game (
-  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-  description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-  year "1982"
-  manufacturer "CDS Micro Systems"
-  rom ( name "RubikCube.tzx" size 15384 crc 580179A6 md5 724CDC2B86991F8710876579F9A16559 sha1 9B1B7F10E2EBFC90B3653DC10EC0FFD0D5A5C552 )
-)
-
-game (
-  name "Sabotage (Sinclair Research)"
-  description "Sabotage (Sinclair Research)"
-  year "1982"
-  manufacturer "Macronics"
-  rom ( name "Sabotage.tzx" size 9070 crc 0120FE03 md5 6BECDEBC9329742A817E1D0068716DED sha1 4D123B512A757FE2E0BFD7DDEE111322D8238D9F )
-)
-
-game (
-  name "Sabotage (Sinclair Research)"
-  description "Sabotage (Sinclair Research)"
-  year "1982"
-  manufacturer "Macronics"
-  rom ( name "sabotage.p" size 8852 crc 682B39A0 md5 93A3AC8C7C759D72848470E7BF1595FC sha1 43467CEF8EF83457AD6BAC424DDD89AB885FED3C )
-)
-
-game (
-  name "Salvo (Orbyte Software)"
-  description "Salvo (Orbyte Software)"
-  manufacturer "A & M Productions"
-  rom ( name "salvo.p" size 15284 crc 202F1A9B md5 009ACFC6E76E528F40CC693753E73251 sha1 3BD88AC1E2A1DFCA98AD495346E0C65D9936A1A0 )
-)
-
-game (
-  name "Salvo (Orbyte Software)"
-  description "Salvo (Orbyte Software)"
-  manufacturer "A & M Productions"
-  rom ( name "Salvo.tzx" size 15510 crc D9303929 md5 A28B801FF835CD8DCCDDACF23ED8DB1F sha1 706DDD40FFC24AD4FFFCEF7D8F77889A6A1C1A19 )
-)
-
-game (
-  name "Samurai Warrior (Lothlorien)"
-  description "Samurai Warrior (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "samuraiwarrior.p" size 15261 crc 6804E38D md5 E268D6C175C8359BC23491AA237C0AA5 sha1 24AC5226D3E646254F00F3CCAD7ABFDE618B346C )
-)
-
-game (
-  name "Samurai Warrior (Lothlorien)"
-  description "Samurai Warrior (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "SamuraiWarrior.tzx" size 15481 crc 68F13FB0 md5 4E59F61C5A39BF5F8B372BA40A009B07 sha1 A6D7B88718F8EF85E300CB1BA696544A6CB1EFCF )
-)
-
-game (
-  name "Scramble (Mikro-Gen)"
-  description "Scramble (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "Scramble.tzx" size 4693 crc DD9359A4 md5 8F50B50F065FF824C39209C4680BF2AA sha1 84760E3B08C0E5686C9ACE4B23DFF5B6187DA367 )
-)
-
-game (
-  name "Scramble (Mikro-Gen)"
-  description "Scramble (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "scramble.p" size 4455 crc 6CA59CEB md5 1CACE2E4CEA14D6F96913F3ED7D7204F sha1 BD6FF916C9A18EA0EDA7D21B061670231643E308 )
-)
-
-game (
-  name "Scramble (Colour inlay) (Mikro-Gen)"
-  description "Scramble (Colour inlay) (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "scramble(ci).p" size 4455 crc BFC4A5E6 md5 F9BA0FFC3497E3FD978A6894FCF28547 sha1 6ADD38B04DE58597B939F24F35613B6A1B8E2EB5 )
-)
-
-game (
-  name "Scramble (Colour inlay) (Mikro-Gen)"
-  description "Scramble (Colour inlay) (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "Scramble(CI).tzx" size 4693 crc 0EF260A9 md5 DE5F9BB0623C40822463CA512F959D06 sha1 338BA99E7D814653800311CD67BE49FCA764A822 )
-)
-
-game (
-  name "Screen Kit 1 (Picturesque)"
-  description "Screen Kit 1 (Picturesque)"
-  manufacturer "Picturesque"
-  rom ( name "screenkit1.p" size 1841 crc FE229E5D md5 3DAB82C0980EECA3B0F22016ED6DCD16 sha1 84ABE2D096D68E01573FE1AEA3C3A0646C62E6F5 )
-)
-
-game (
-  name "Screen Kit 1 (Picturesque)"
-  description "Screen Kit 1 (Picturesque)"
-  manufacturer "Picturesque"
-  rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 EC8D98CEC4AC5B718D7AB4C188A99A01 sha1 78351CB1C27587935242BF9BB0F512D07B902625 )
-)
-
-game (
-  name "Sea Wolf (Stephen Hartley Computing)"
-  description "Sea Wolf (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. R. Bird"
-  rom ( name "SeaWolf.tzx" size 9732 crc D23CF454 md5 0FCEB5B1AE6ED2721D95F2343F6CDF37 sha1 F0275FE3BC08875E643BE9431615B7A7C5BA64AB )
-)
-
-game (
-  name "Sea Wolf (Stephen Hartley Computing)"
-  description "Sea Wolf (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. R. Bird"
-  rom ( name "seawolf.p" size 9502 crc 7156979A md5 394000D5A21F5320B63C1145E30F119F sha1 1C221622620508CDD921E0D84C34042FCA87D1CC )
-)
-
-game (
-  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
-  description "Sea Wolf (Newer) (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. R. Bird"
-  rom ( name "seawolf(newer).p" size 9502 crc 3D713295 md5 A437D3A2D8AE59C77CCA90BFB572ECD7 sha1 C75D950618D084F3CF1A0903A696D0A9BB8B6121 )
-)
-
-game (
-  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
-  description "Sea Wolf (Newer) (Stephen Hartley Computing)"
-  year "1983"
-  manufacturer "I. R. Bird"
-  rom ( name "SeaWolf(Newer).tzx" size 9732 crc 9E1B515B md5 C71A018235CC635882535A19A256CE7A sha1 B55B9B06C9805D2253335D4F61A6AE43BBE9FFE4 )
-)
-
-game (
-  name "Adventure C: The Ship of Doom (Sinclair Research)"
-  description "Adventure C: The Ship of Doom (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "ShipOfDoom.tzx" size 14275 crc AE8D5B3C md5 6E53EF483B27D942FF3AD6E69256C116 sha1 A1E5AB55214DA2CA312345586F684E65204D52AD )
-)
-
-game (
-  name "Adventure C: The Ship of Doom (Sinclair Research)"
-  description "Adventure C: The Ship of Doom (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "shipofdoom.p" size 14045 crc B8E32F06 md5 2515BA4AD2C1758F83D4E2F2CC81D6CA sha1 C64B4AE9FDBD955695660E6BD6A04EF2A6F91F39 )
-)
-
-game (
-  name "Adventure C: Ship of Doom (Artic)"
-  description "Adventure C: Ship of Doom (Artic)"
-  manufacturer "Artic"
-  rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284A314F md5 CA0BAB03EEFF0FC9BCC040148E20C7D2 sha1 96221BCEBA4FF6E90FDC59271DA1D7973362E8F8 )
-)
-
-game (
-  name "Adventure C: Ship of Doom (Artic)"
-  description "Adventure C: Ship of Doom (Artic)"
-  manufacturer "Artic"
-  rom ( name "shipofdoom(artic).p" size 14045 crc 3E244575 md5 47AE04D2D34190DD2F9D47FB9815F4DE sha1 689552EF631FACC558C6FC9B902F20495E870936 )
-)
-
-game (
-  name "Similes Countdown (AVC Software)"
-  description "Similes Countdown (AVC Software)"
-  year "1981"
-  manufacturer "K. Jammer and S. Brown"
-  rom ( name "SimilesCountdown.tzx" size 10151 crc FBBCDEF4 md5 E270304C53D20E65B47EF69BD0FEFDC8 sha1 7CD764FCBD90D455FB2D31CEEC7CDA10B08EC8CD )
-)
-
-game (
-  name "Similes Countdown (AVC Software)"
-  description "Similes Countdown (AVC Software)"
-  year "1981"
-  manufacturer "K. Jammer and S. Brown"
-  rom ( name "similescountdown.p" size 9899 crc F2F2B554 md5 ADCE97D888CA6665A5071A5DF2759364 sha1 4D0117466C37DF6B4FAFDC3EFF7F75F3AEA3AED1 )
-)
-
-game (
-  name "Space Intruders (Hewson Consultants)"
-  description "Space Intruders (Hewson Consultants)"
-  year "1981"
-  manufacturer "Hewson Consultants"
-  rom ( name "SpaceIntruders.tzx" size 4010 crc 88B1156F md5 F15A15BE576DC7EFDCFD8BDF87FAAADF sha1 8AAF24A56FE3CC999CE32AE795CE0BBD7983838F )
-)
-
-game (
-  name "Space Intruders (Hewson Consultants)"
-  description "Space Intruders (Hewson Consultants)"
-  year "1981"
-  manufacturer "Hewson Consultants"
-  rom ( name "spaceintruders.p" size 3764 crc 074DC33E md5 6919EDC03F14FC6772C089AF461624D6 sha1 DFED85EAFDE74AFB2C3237003D73E7FA3FE69837 )
-)
-
-game (
-  name "Space Invaders (Mikro-Gen)"
-  description "Space Invaders (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "SpaceInvaders.tzx" size 2896 crc A345E8DB md5 F835A9B2D5DCE454A2DDC4CAF8175505 sha1 4536F0D2A465A71891803B23D29BC8C54C1B874F )
-)
-
-game (
-  name "Space Invaders (Mikro-Gen)"
-  description "Space Invaders (Mikro-Gen)"
-  manufacturer "Mikro-Gen"
-  rom ( name "spaceinvaders.p" size 2664 crc E39A90BE md5 CCE844A181612AD7E32209E73CE42B9C sha1 795CC3740CAEE56E9AF16A52B557D93B968D0CDE )
-)
-
-game (
-  name "Space Invaders (dK'tronics)"
-  description "Space Invaders (dK'tronics)"
-  year "1981"
-  manufacturer "dK'tronics"
-  rom ( name "spaceinvaders(dk).p" size 6645 crc 4C0EDB0A md5 7BB4A934DDC0746167E6FAC17F71CAE4 sha1 1392C3C2BA459FBC67EDB18FD96FD617FD8AD167 )
-)
-
-game (
-  name "Space Invaders (dK'tronics)"
-  description "Space Invaders (dK'tronics)"
-  year "1981"
-  manufacturer "dK'tronics"
-  rom ( name "SpaceInvaders(dk).tzx" size 6889 crc 720BF20C md5 3D25C73AC6E5C6F48081EB86A5D0E0B3 sha1 E9D543B4F96BBDA648C1488A06D2538ED3DA3001 )
-)
-
-game (
-  name "Space Invaders 3K (Macronics)"
-  description "Space Invaders 3K (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "spaceinvaders3k.p" size 2854 crc F1273575 md5 DD982A212278DF38FA34C19B19DB4484 sha1 653DD0BA53D7005005FFF184EE8D556CB6982A23 )
-)
-
-game (
-  name "Space Invaders 3K (Macronics)"
-  description "Space Invaders 3K (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "SpaceInvaders3K.tzx" size 3074 crc 69729ABD md5 753F7387213896A0DAE8E09A4974D2A2 sha1 00BEA09A8D43CFD35CB2FB44EFF623692811D2A9 )
-)
-
-game (
-  name "Space Man Apollo (ICT)"
-  description "Space Man Apollo (ICT)"
-  year "1984"
-  manufacturer "Iain Thomson"
-  rom ( name "SpacemanApollo.tzx" size 15875 crc 0FC40716 md5 17291434CA3E09AED13B243F95498B0B sha1 68861A48E02A2D65B717012DF38600D96986DF97 )
-)
-
-game (
-  name "Space Man Apollo (ICT)"
-  description "Space Man Apollo (ICT)"
-  year "1984"
-  manufacturer "Iain Thomson"
-  rom ( name "spacemanapollo.p" size 15647 crc 1ADF5140 md5 0E91BCAC7314FB7D95DB8D86CB4920F4 sha1 FD98B6596B28BC0ECDA1F3B7AAEF526809D3A38E )
-)
-
-game (
-  name "Space Mission (Gem Software)"
-  description "Space Mission (Gem Software)"
-  year "1982"
-  manufacturer "Gem Software"
-  rom ( name "SpaceMission.tzx" size 13607 crc 0DACAB8D md5 35AC87605BE32557CE38BFBF61F3DBAA sha1 BD92C04A311A49E5846E35528D692EE5E6EB2BCF )
-)
-
-game (
-  name "Space Mission (Gem Software)"
-  description "Space Mission (Gem Software)"
-  year "1982"
-  manufacturer "Gem Software"
-  rom ( name "spacemission.p" size 13365 crc 97DF84E4 md5 BE00529EBF59E65659D1D658976FA738 sha1 1071D74D173D8F325894F0DBAC851E60A15E38B2 )
-)
-
-game (
-  name "Space Trek (Micromega)"
-  description "Space Trek (Micromega)"
-  manufacturer "Micromega"
-  rom ( name "spacetrek.p" size 15395 crc 8C8545B1 md5 EB1DB83F22E599C4A8927BDF043D2677 sha1 FF8A32EE7197F3EF632F2CF231CB0CA7CBF1DEFC )
-)
-
-game (
-  name "Space Trek (Micromega)"
-  description "Space Trek (Micromega)"
-  manufacturer "Micromega"
-  rom ( name "SpaceTrek.tzx" size 15619 crc 081B0787 md5 7A2A66E12F7983634FF1CA0B9B795DED sha1 0E20ED7812A34AD507EC1C1DC23536641C4B9993 )
-)
-
-game (
-  name "Spacetrek (JRS Software)"
-  description "Spacetrek (JRS Software)"
-  manufacturer "JRS Software"
-  rom ( name "Spacetrek(JRS).tzx" size 550 crc D62CC02F md5 17AAF306F2269D03004C5866D47AF928 sha1 1B0C8177A41AEA9AA40F5698280C86E505151349 )
-)
-
-game (
-  name "Spacetrek (JRS Software)"
-  description "Spacetrek (JRS Software)"
-  manufacturer "JRS Software"
-  rom ( name "spacetrek(jrs).p" size 332 crc C2F526DF md5 A3B4C8C194FFD9B3DF6AB21F57BCC6CC sha1 6B5C61147A38082825FC71A003937E5F07F59F02 )
-)
-
-game (
-  name "Spelling Bee (Timex)"
-  description "Spelling Bee (Timex)"
-  year "1983"
-  manufacturer "Russell Klein"
-  rom ( name "SpellingBee.tzx" size 48415 crc A5987F22 md5 75F46B5EAC8F50943EBE3C185DA8A98B sha1 D992D921483B59B85AE68BDFA6E44D1C9C5068CC )
-)
-
-game (
-  name "The Stamp Collector (Timex)"
-  description "The Stamp Collector (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "stampcollectorthe.p" size 14449 crc 2A38E112 md5 9329DEE03B6620D5000DD3FFC9643068 sha1 69DAAAB88AEC472F12910BB0C3B56C188B5C05AD )
-)
-
-game (
-  name "The Stamp Collector (Timex)"
-  description "The Stamp Collector (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "StampCollectorThe.tzx" size 14675 crc 702011B4 md5 A207294C88268520101A8B277FC1B882 sha1 E44F8118A5EF3C7FFC55A46D476CDB0F516179CE )
-)
-
-game (
-  name "Star Trek (Bug Byte)"
-  description "Star Trek (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "StarTrek.tzx" size 10250 crc C8107516 md5 DB8FBA7FBA8544B74B63C53519163BE7 sha1 3E0F7D137F9572F756BA9EDC5C6835FA9367BE81 )
-)
-
-game (
-  name "Star Trek (Bug Byte)"
-  description "Star Trek (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "startrek.p" size 10018 crc A3004740 md5 33BACEF251164137A75E7B9A7164ADA0 sha1 7A890295C0B822938DB6E8DC70BB68D669BF9051 )
-)
-
-game (
-  name "Star Trek (Macronics)"
-  description "Star Trek (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "StarTrek(Macronics).tzx" size 16091 crc 171E0B56 md5 9F7EF6572BF3D71C53B3EF64053A0715 sha1 5A25A295FC011E37B8941634AD32746B9D626D48 )
-)
-
-game (
-  name "Star Trek (Macronics)"
-  description "Star Trek (Macronics)"
-  year "1981"
-  manufacturer "Macronics"
-  rom ( name "startrek(macronics).p" size 15869 crc E33D9286 md5 DAC4C635719E0A8A0B7D55CC18F2E6A6 sha1 2F7D41853AA556EE5197A54E03E405286884343D )
-)
-
-game (
-  name "Star Trek (Typed Inlay) (Bug Byte)"
-  description "Star Trek (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "startrek(typed).p" size 10018 crc 2749661E md5 9E9F60D7E165323899D49206285D9C3A sha1 F289F9958DF4C2A7F811E36920FA4B7C74BC505C )
-)
-
-game (
-  name "Star Trek (Typed Inlay) (Bug Byte)"
-  description "Star Trek (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "StarTrek(Typed).tzx" size 10250 crc 4C595448 md5 C7D23895712792195672678584E5D250 sha1 D6286120A5ACC82D974F76E381F3382FE0C55BE8 )
-)
-
-game (
-  name "Starquest (Pixel Productions)"
-  description "Starquest (Pixel Productions)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Starquest.2.Starquest.tzx" size 16209 crc 85BFC2B5 md5 7602A6DA23E1E058B4EF39AC1B1D29CD sha1 F0D5783909CA9A5954ECD71854F4F9AAA57D6619 )
-)
-
-game (
-  name "Starquest (Pixel Productions)"
-  description "Starquest (Pixel Productions)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "starquest.p" size 15989 crc FB070BD6 md5 73407DFBDAE230F813EE47EE62747A4F sha1 6171F22250E4BFAF347B85F1E0CFECA5312DDDAE )
-)
-
-game (
-  name "Starquest (International Publishing and Software Inc.)"
-  description "Starquest (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Starquest(IPS).tzx" size 17893 crc 0375BD08 md5 7237E3D312CDECFA235A945CD88B3AEF sha1 FA7A242596852D6AA1C2FF15142EA2F1ED6D4B1F )
-)
-
-game (
-  name "The Starter (Timex)"
-  description "The Starter (Timex)"
-  year "1981"
-  manufacturer "Sinclair"
-  rom ( name "Starter.tzx" size 2613 crc 00CB3C24 md5 D4DE1B915C3A27215AE0BF6BFC60AA91 sha1 C2BE276CF0F988DF20707105F0FB5D6380D8E357 )
-)
-
-game (
-  name "States and Capitals (Timex)"
-  description "States and Capitals (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "StatesAndCapitals.tzx" size 11538 crc C70FA5A4 md5 A2FAD8976A643EA58281AE9C6276123A sha1 99551D3BB7AD39B7F55BE16973AF29DC7425E9E3 )
-)
-
-game (
-  name "States and Capitals (Timex)"
-  description "States and Capitals (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "statesandcapitals.p" size 11310 crc D0BE9818 md5 BEDB20F535283C3D59EB0990A07690AF sha1 509778144C3918CE04F64A5D723D17F7CACD9719 )
-)
-
-game (
-  name "Statistics (Timex)"
-  description "Statistics (Timex)"
-  year "1982"
-  manufacturer "R. Daniel"
-  rom ( name "Statistics.tzx" size 4852 crc 22EB02C8 md5 0EB9DB5C0720BE88D236A198C94797D4 sha1 494389E8AD0A8C8ADB4A7FA17C91464A78D555E2 )
-)
-
-game (
-  name "Statistics (Zeta Software)"
-  description "Statistics (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "statistics(zeta).p" size 13376 crc 9204F603 md5 F82DE91F3B217E98A74152E96AB3856B sha1 5DF7CA4145A22CC7F730AAC13FE8835C40669321 )
-)
-
-game (
-  name "Statistics (Zeta Software)"
-  description "Statistics (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "Statistics(Zeta).tzx" size 13600 crc C0B4F14A md5 2B944E3BF6F17648919C3591B7B9905A sha1 7F13B230064429AB366F0816B43D683085D0BF62 )
-)
-
-game (
-  name "Stock Car (Informatique Service)"
-  description "Stock Car (Informatique Service)"
-  year "1984"
-  rom ( name "StockCar.tzx" size 8450 crc FEDBBC78 md5 CD54361859D4D5AE1E4290C8C5DB8063 sha1 3604D2FF3B9DE27E45CB691131B98BE09BA3C65B )
-)
-
-game (
-  name "Stock Car (Informatique Service)"
-  description "Stock Car (Informatique Service)"
-  year "1984"
-  rom ( name "stockcar.p" size 8216 crc 41224D6B md5 C7549CD5DFC22BD438A16D6FFEB29B18 sha1 E70D50DE2F51597BC74A50BDB25A34BF6B059888 )
-)
-
-game (
-  name "Stock-Market (Video Software)"
-  description "Stock-Market (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "StockMarket.A.tzx" size 11978 crc 440CC0E5 md5 CAD4AB9C37B2DB19EE7950CDFBE71490 sha1 849C2761901E9210F101500E5603D38B90E55A8C )
-)
-
-game (
-  name "Stock-Market (Video Software)"
-  description "Stock-Market (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "stockmarket.p" size 11738 crc D6F22D69 md5 3C4E77ADF07396603240C9225499245D sha1 A71FF5FCC069C95E0E0CA480E78A724EA73FCF00 )
-)
-
-game (
-  name "Stock Market Tech. Analysis 1 (Timex)"
-  description "Stock Market Tech. Analysis 1 (Timex)"
-  year "1982"
-  manufacturer "T. H. Nooter"
-  rom ( name "StockMarketTechAnalysis1.tzx" size 16405 crc 40A9B729 md5 BB445169BD552AA1BEFF7B3221856965 sha1 0D23879DA55A4E5CBD7A8B482D010FDCB21E06F6 )
-)
-
-game (
-  name "Stock Market Tech. Analysis 1 (Timex)"
-  description "Stock Market Tech. Analysis 1 (Timex)"
-  year "1982"
-  manufacturer "T. H. Nooter"
-  rom ( name "stockmarkettechanalysis1.p" size 16177 crc 0EE43E40 md5 23D4292A790D7120376375574118136B sha1 6D8FE3F2BF6B8171AF5A30EC199F6EC5F8C31C30 )
-)
-
-game (
-  name "The Stock Option Analyzer (Timex)"
-  description "The Stock Option Analyzer (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "stockoptionanalyzerthe.p" size 5533 crc 6A11FEF8 md5 5172731B04549EA7E6FD487FCF0B2497 sha1 1FD0599C4CB2F3EC072D2F858F844EAAC0B3CA12 )
-)
-
-game (
-  name "The Stock Option Analyzer (Timex)"
-  description "The Stock Option Analyzer (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "StockOptionAnalyzerThe.tzx" size 5763 crc B829C9C3 md5 78DED4A1D1170EA521DFF3AC3F302CCA sha1 7691EE6F0AC6A103168684AC3CDE78EC128C5E68 )
-)
-
-game (
-  name "Strategy Football (Timex)"
-  description "Strategy Football (Timex)"
-  year "1983"
-  manufacturer "Gerald Bennett"
-  rom ( name "StrategyFootball.tzx" size 15469 crc 432F9356 md5 9CE1D8687FA6EC86C44CEB48F5F0C4BD sha1 4ADD01B5F9E3DDF8F19A686AD91385D4DECE1BBD )
-)
-
-game (
-  name "Strategy Football (Timex)"
-  description "Strategy Football (Timex)"
-  year "1983"
-  manufacturer "Gerald Bennett"
-  rom ( name "strategyfootball.p" size 15249 crc 903DB439 md5 23B460AC48B647E5F5D2029A62C3A27A sha1 51E03AD187AE202E999E2B391E9FE82D4A301D5A )
-)
-
-game (
-  name "Subspace Striker (International Publishing and Software Inc.)"
-  description "Subspace Striker (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "SubspaceStriker(IPS).tzx" size 17446 crc B3C93F34 md5 7D123FE1A0F6430B7A8492483E2FEEB6 sha1 4A0D2D26033BFB0B0D67248B8B2AE1FA5F423DC4 )
-)
-
-game (
-  name "Super Chess (CP Software)"
-  description "Super Chess (CP Software)"
-  year "1982"
-  manufacturer "CP Software"
-  rom ( name "superchess.p" size 16060 crc 650317B6 md5 ABFB385E22165912BEADCA3377E4A6B2 sha1 324F41E92E9C6D5EA06792238B9374EB2340919F )
-)
-
-game (
-  name "Super Chess (CP Software)"
-  description "Super Chess (CP Software)"
-  year "1982"
-  manufacturer "CP Software"
-  rom ( name "SuperChess.tzx" size 16296 crc DAD51D68 md5 50316E46482E309565E8BB584190F3ED sha1 CE79C0B548BB98118E1725C82396887E01AEA430 )
-)
-
-game (
-  name "Super Chess (Softsync)"
-  description "Super Chess (Softsync)"
-  year "1982"
-  manufacturer "CP Software"
-  rom ( name "SuperChess(Softsync).tzx" size 16296 crc BDB36226 md5 5CFB66AEFD5C74F85443D1A89D420410 sha1 5DDA6654A11C6F0AFA5DCB9D7F128667359A6954 )
-)
-
-game (
-  name "Super Chess (Softsync)"
-  description "Super Chess (Softsync)"
-  year "1982"
-  manufacturer "CP Software"
-  rom ( name "superchess(softsync).p" size 16060 crc 026568F8 md5 3834752BC2C52E38631F234A1390810B sha1 A91DF04216AF0CE22B85C6A9BFA8C523E97B7DA2 )
-)
-
-game (
-  name "Super Invaders (Bridge Software)"
-  description "Super Invaders (Bridge Software)"
-  year "1982"
-  manufacturer "Bridge Software"
-  rom ( name "SuperInvaders.tzx" size 12541 crc F662BD98 md5 B4BF9DFF58752EB60FFD48D6AF234720 sha1 3D8C7A7F290D9C792EA7263957DCDAA14CD02C93 )
-)
-
-game (
-  name "Super Invaders (Bridge Software)"
-  description "Super Invaders (Bridge Software)"
-  year "1982"
-  manufacturer "Bridge Software"
-  rom ( name "superinvaders.p" size 12317 crc 94F95161 md5 4F2F2556AB2020046B3B864E1FFDF218 sha1 5BF9CCC9A39A47095143F0506AA778A1BE11C341 )
-)
-
-game (
-  name "Super Invasion (Softsync)"
-  description "Super Invasion (Softsync)"
-  year "1981"
-  manufacturer "Beam Software"
-  rom ( name "superinvasion.p" size 896 crc 54DF2BD2 md5 C65906F94FC9CEF39C32BBDF56CD1B20 sha1 3C6A9CE5D9785C2A51802A21E666B01AF73E0C8E )
-)
-
-game (
-  name "Super Invasion (Softsync)"
-  description "Super Invasion (Softsync)"
-  year "1981"
-  manufacturer "Beam Software"
-  rom ( name "SuperInvasion.tzx" size 1124 crc CC59F451 md5 DD3904D9A8D535358BEBC9AFFCF11854 sha1 447855AB4BD695A574A93FF9FAB09D65258438A5 )
-)
-
-game (
-  name "Super Math (Timex)"
-  description "Super Math (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "SuperMath.tzx" size 8299 crc 21EB7B78 md5 1278409CD4AEF861297F630F88665C5F sha1 3F30FEEAD9537BF39DA7D83175A5A0CC3DCF0A72 )
-)
-
-game (
-  name "Super Math (Timex)"
-  description "Super Math (Timex)"
-  year "1982"
-  manufacturer "Timex"
-  rom ( name "supermath.p" size 8075 crc 1F288F07 md5 5D4125044A0954EA23754D036920A1E7 sha1 4373CF521B219EDB88A527454E97080A27344A72 )
-)
-
-game (
-  name "Super Nine (Romik Software)"
-  description "Super Nine (Romik Software)"
-  year "1982"
-  manufacturer "Romik Software"
-  rom ( name "SuperNine.tzx" size 6872 crc E8B39D87 md5 5C6A25CD318DE3F362261214003C32F1 sha1 5D3CB094E65D4BD9C412F4B6FC18AFCC768E6F41 )
-)
-
-game (
-  name "Super Programs 8 (Sinclair Research)"
-  description "Super Programs 8 (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "SuperPrograms8.tzx" size 15192 crc 2AA20758 md5 545C084C45B5188079167DA9F1ACB304 sha1 DE665EBE1949E077934ED6F0961D525F274F3D6E )
-)
-
-game (
-  name "Super Programs 8 (Sinclair Research)"
-  description "Super Programs 8 (Sinclair Research)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "superprograms8.p" size 14974 crc B876FA33 md5 6D3374DC7EDBFD66F4D48B6140C17C11 sha1 CC2AA503A948D62D0A40FB29D0C628A5E4EA3632 )
-)
-
-game (
-  name "Super Programs 8 (ICL)"
-  description "Super Programs 8 (ICL)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "superprograms8(icl).p" size 14974 crc B7E6C5F1 md5 9AE1C2A5DD3976372CF9A9D712AE20F5 sha1 8CF3626E7B7289CE5FE14F4B5D15D3DDB71BD0EF )
-)
-
-game (
-  name "Super Programs 8 (ICL)"
-  description "Super Programs 8 (ICL)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389A md5 2F2FFF60323980089B85D19FDB34F21C sha1 A40650A76C57EDC7A0431117FE9D9E5C4F47BB6B )
-)
-
-game (
-  name "Super Programs 8 (Sinclair Black) (ICL)"
-  description "Super Programs 8 (Sinclair Black) (ICL)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "superprograms8(icl).p" size 14974 crc B7E6C5F1 md5 9AE1C2A5DD3976372CF9A9D712AE20F5 sha1 8CF3626E7B7289CE5FE14F4B5D15D3DDB71BD0EF )
-)
-
-game (
-  name "Super Programs 8 (Sinclair Black) (ICL)"
-  description "Super Programs 8 (Sinclair Black) (ICL)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389A md5 2F2FFF60323980089B85D19FDB34F21C sha1 A40650A76C57EDC7A0431117FE9D9E5C4F47BB6B )
-)
-
-game (
-  name "Super Scramble (Software Farm)"
-  description "Super Scramble (Software Farm)"
-  year "1982"
-  manufacturer "Software Farm"
-  rom ( name "superscramble.p" size 9068 crc 29C5C5D5 md5 8846EF2A3955E7637F72B13D0A8405B2 sha1 AB1E6FAE6BA522C9CC9363DDB75C35A794FFDFD2 )
-)
-
-game (
-  name "Super Scramble (Software Farm)"
-  description "Super Scramble (Software Farm)"
-  year "1982"
-  manufacturer "Software Farm"
-  rom ( name "SuperScramble.tzx" size 9312 crc 5F11C06C md5 579E55D4ADF1D3EE050BFB59ABAB6167 sha1 AA22BB6FF4C10B8279F2C1E568DB7B9AE5158CA6 )
-)
-
-game (
-  name "Supermaze (Timex)"
-  description "Supermaze (Timex)"
-  year "1982"
-  manufacturer "Greg Harvey"
-  rom ( name "Supermaze.tzx" size 16394 crc 6E93CE7F md5 225EF6BA2E2B9788DBEBA444B5FC60ED sha1 F85D7522E9CD2BF3CBDC3C05493423D7AFAD482B )
-)
-
-game (
-  name "Supermaze (Timex)"
-  description "Supermaze (Timex)"
-  year "1982"
-  manufacturer "Greg Harvey"
-  rom ( name "supermaze.p" size 16170 crc C58F309B md5 2684494519118B0C23B94AB177ED694E sha1 B36C2EAFF62752137C75855E7686A90C58127906 )
-)
-
-game (
-  name "Tables Countdown (AVC Software)"
-  description "Tables Countdown (AVC Software)"
-  year "1981"
-  manufacturer "K. Jammer and C. Deeson"
-  rom ( name "TablesCountdown.tzx" size 9197 crc 59BD7DE7 md5 8FEC27B406D4041D3FB99784F7318F08 sha1 71D4F85478E2EB9016BAB2FD0FAC0107A7FCCDEA )
-)
-
-game (
-  name "Tables Countdown (AVC Software)"
-  description "Tables Countdown (AVC Software)"
-  year "1981"
-  manufacturer "K. Jammer and C. Deeson"
-  rom ( name "tablescountdown.p" size 8947 crc E3B0D8D8 md5 B71D10DCEC0D99531FB8D2FB777751A0 sha1 1713FEB2D1FBDF6D3712E10E2F0291A6BCE813C4 )
-)
-
-game (
-  name "Tai (PSS)"
-  description "Tai (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "tai.p" size 14015 crc C7869E9E md5 17E769CECA4301BEAFB8C1547E62A326 sha1 7A44314234CFFD9FFF42C90A46BE0DB954E63352 )
-)
-
-game (
-  name "Tai (PSS)"
-  description "Tai (PSS)"
-  year "1982"
-  manufacturer "PSS"
-  rom ( name "Tai.tzx" size 14237 crc 3A1351F8 md5 2D7F98ECA4BD7EFE614CA55B6EB4FDE3 sha1 FD0A3CEAC8CE8540E13C7E6AF6F547A2FEFF5D8A )
-)
-
-game (
-  name "Talkback (M. W. F. Ringrose)"
-  description "Talkback (M. W. F. Ringrose)"
-  year "1983"
-  manufacturer "M. W. F. Ringrose"
-  rom ( name "Talkback.tzx" size 12740 crc 36724D18 md5 6CAA20B159F6E66BEC947D4A901862DD sha1 6B32FF6DD4930AD62CADB59B3C4ECDB6EB4A2654 )
-)
-
-game (
-  name "Tapebook 50 1K (Control Technology)"
-  description "Tapebook 50 1K (Control Technology)"
-  manufacturer "Control Technology"
-  rom ( name "TapeBook50.tzx" size 37005 crc D882BCCD md5 05B0B6C39C1A331E9D4592944F5FCF03 sha1 0D1B30D4D024147C9489D56E0519F9F60BF75CBD )
-)
-
-game (
-  name "Tarot (Timex)"
-  description "Tarot (Timex)"
-  year "1983"
-  manufacturer "Computer Phood"
-  rom ( name "Tarot.tzx" size 29510 crc 5C63C324 md5 35525DAE43101AB654360464227DFC37 sha1 81F1AB607044FD2B44C1163A0CB317DC1727D0A4 )
-)
-
-game (
-  name "Tasword (Tasman Software)"
-  description "Tasword (Tasman Software)"
-  year "1982"
-  manufacturer "Tasman Software"
-  rom ( name "tasword.p" size 5339 crc D2CD3934 md5 DD0169E3A06413005F30670F959D56D4 sha1 9DD68379EB1079CEB6B3A106CBC9839A2DF9AD30 )
-)
-
-game (
-  name "Tasword (Tasman Software)"
-  description "Tasword (Tasman Software)"
-  year "1982"
-  manufacturer "Tasman Software"
-  rom ( name "Tasword.tzx" size 5569 crc 9B77040A md5 321945F0628D33E073AE1C306D2EAD5A sha1 100BE588AD785F012F513E8043C323348B5E44ED )
-)
-
-game (
-  name "Tempest (Mikro-Gen)"
-  description "Tempest (Mikro-Gen)"
-  manufacturer "S. P. Kelly"
-  rom ( name "Tempest.tzx" size 3521 crc 5CCA0DED md5 09BDEA36A433F0A3F5FE8B8BCC8E0AA3 sha1 A4CFD1F82D0E4D255AE3B54A54F30A6CB96CE4F9 )
-)
-
-game (
-  name "Tempest (Mikro-Gen)"
-  description "Tempest (Mikro-Gen)"
-  manufacturer "S. P. Kelly"
-  rom ( name "tempest.p" size 3291 crc F760AFBA md5 44309DC8B4E242A1E08DFAD3F4D590BA sha1 8E4C160DF4EC5905F38A922E8E1403D984C92FE4 )
-)
-
-game (
-  name "Ten 1K Games (Computer Rentals)"
-  description "Ten 1K Games (Computer Rentals)"
-  year "1983"
-  manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
-  rom ( name "Ten1KGames.tzx" size 7545 crc C724FD4A md5 60CCCFA8C4852F55D0EEDA74524C0CA0 sha1 589C68041F90A46FB8C18118C0889C6B8F91F0CA )
-)
-
-game (
-  name "Tomb of Dracula (Moviedrome Video)"
-  description "Tomb of Dracula (Moviedrome Video)"
-  manufacturer "Moviedrome Video"
-  rom ( name "TombOfDracula.tzx" size 14743 crc EF2A3F64 md5 D1E99F6B365C888E93C405E7A37A529A sha1 E883C6E1992DDD67A82E66709211D024B563AA36 )
-)
-
-game (
-  name "Tomb of Dracula (Moviedrome Video)"
-  description "Tomb of Dracula (Moviedrome Video)"
-  manufacturer "Moviedrome Video"
-  rom ( name "tombofdracula.p" size 14523 crc D7EBCD59 md5 547C42491C4EA4D99FD0386644CB3394 sha1 2228C845E69487DB3CB302D4AF27E2C03181D3B5 )
-)
-
-game (
-  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
-  description "Tomb of Dracula (Colour Inlay) (Felix Software)"
-  year "1982"
-  manufacturer "Felix Software"
-  rom ( name "TombOfDracula.tzx" size 14743 crc EF2A3F64 md5 D1E99F6B365C888E93C405E7A37A529A sha1 E883C6E1992DDD67A82E66709211D024B563AA36 )
-)
-
-game (
-  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
-  description "Tomb of Dracula (Colour Inlay) (Felix Software)"
-  year "1982"
-  manufacturer "Felix Software"
-  rom ( name "tombofdracula.p" size 14523 crc D7EBCD59 md5 547C42491C4EA4D99FD0386644CB3394 sha1 2228C845E69487DB3CB302D4AF27E2C03181D3B5 )
-)
-
-game (
-  name "Toolkit (Sinclair Research)"
-  description "Toolkit (Sinclair Research)"
-  manufacturer "Artic"
-  rom ( name "Toolkit.tzx" size 3820 crc C015038B md5 EE928ACDD0608E4095D31D8245038271 sha1 422FADBDF7CFC0DA1E6FDFD101F1D613581ED884 )
-)
-
-game (
-  name "Toolkit (Sinclair Research)"
-  description "Toolkit (Sinclair Research)"
-  manufacturer "Artic"
-  rom ( name "toolkit.p" size 3600 crc 28C28DC8 md5 75B1355E07AD2A2055D86809C1D12256 sha1 7A4132458D5D3BE2502C736B560DAE0A84E9DC91 )
-)
-
-game (
-  name "Toolkit (Artic)"
-  description "Toolkit (Artic)"
-  manufacturer "Artic"
-  rom ( name "toolkit(artic).p" size 3582 crc D331E275 md5 19C29072C4CF201F0C6D80A34C487E1A sha1 1076DA4A02F3E667D86EF0D40E644103768E71ED )
-)
-
-game (
-  name "Toolkit (Artic)"
-  description "Toolkit (Artic)"
-  manufacturer "Artic"
-  rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743B221 md5 7B527B5AFDB2C55D5A0135B6FAA68F98 sha1 049169DEB7C4C760D79DD66FDF49172D5A77D776 )
-)
-
-game (
-  name "Toolkit (Artic)"
-  description "Toolkit (Artic)"
-  rom ( name "Toolkit.tzx" size 3820 crc C015038B md5 EE928ACDD0608E4095D31D8245038271 sha1 422FADBDF7CFC0DA1E6FDFD101F1D613581ED884 )
-)
-
-game (
-  name "Toolkit (Artic)"
-  description "Toolkit (Artic)"
-  rom ( name "toolkit.p" size 3600 crc 28C28DC8 md5 75B1355E07AD2A2055D86809C1D12256 sha1 7A4132458D5D3BE2502C736B560DAE0A84E9DC91 )
-)
-
-game (
-  name "Toolkit (JRS Software)"
-  description "Toolkit (JRS Software)"
-  year "1982"
-  manufacturer "Paul Holmes"
-  rom ( name "Toolkit(JRS).tzx" size 2318 crc 5C378F0F md5 C16AB5E0F0A83C954596A61278865A60 sha1 2121E140989DC586810BEC4E1399DE1007924286 )
-)
-
-game (
-  name "Toolkit (JRS Software)"
-  description "Toolkit (JRS Software)"
-  year "1982"
-  manufacturer "Paul Holmes"
-  rom ( name "toolkit(jrs).p" size 2094 crc 9DE785FD md5 DDFABE0545708752DC9947C12B0691DD sha1 45C020C2381E691E42385D005E496A7032C72B0E )
-)
-
-game (
-  name "Trace (Texgate)"
-  description "Trace (Texgate)"
-  year "1983"
-  manufacturer "Texgate"
-  rom ( name "Trace.tzx" size 3474 crc B43432D2 md5 BA0BC19769D99D42E22475E2CA5C5D76 sha1 68EA27C33EE7B25628862EBD51BF07B716AA0D57 )
-)
-
-game (
-  name "Trace (Texgate)"
-  description "Trace (Texgate)"
-  year "1983"
-  manufacturer "Texgate"
-  rom ( name "trace.p" size 3248 crc 347A23E2 md5 588BAF432B5F22295D6E8347B8E12F9B sha1 5B5FB4641DE0CECEE592944B7991CAD5514C3F69 )
-)
-
-game (
-  name "Trader (Quicksilva)"
-  description "Trader (Quicksilva)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Trader.tzx" size 49461 crc 41C24497 md5 80943BB4B68AD15508C1028F2B59AD15 sha1 37FD173296FB68815CA87544977B354C44A54D9E )
-)
-
-game (
-  name "Trader (Flap-fronted box) (Pixel Productions)"
-  description "Trader (Flap-fronted box) (Pixel Productions)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Trader.tzx" size 49461 crc 41C24497 md5 80943BB4B68AD15508C1028F2B59AD15 sha1 37FD173296FB68815CA87544977B354C44A54D9E )
-)
-
-game (
-  name "Trader (Pixel Productions)"
-  description "Trader (Pixel Productions)"
-  year "1982"
-  manufacturer "Pixel"
-  rom ( name "Trader(Jewel).tzx" size 49639 crc 01E4EC2A md5 F0837CBFE6AC9168B3264AAC3C21857D sha1 0082993BF62F04B69581990F052786DAEEA5620C )
-)
-
-game (
-  name "Traffic (Loriciels)"
-  description "Traffic (Loriciels)"
-  year "1984"
-  manufacturer "M Bouat"
-  rom ( name "Traffic.tzx" size 7030 crc BE09C247 md5 2F644A8598A84813FDC38BBAB38D080F sha1 44626D460F9C918C4BC9E0611737B50215C73A3C )
-)
-
-game (
-  name "Traffic (Loriciels)"
-  description "Traffic (Loriciels)"
-  year "1984"
-  manufacturer "M Bouat"
-  rom ( name "traffic.p" size 6800 crc B40D7FA0 md5 66919861847FB1DAE81487DE697B1C74 sha1 0D91BD4B6F1ABAEC8882B2B360E144EF2A523137 )
-)
-
-game (
-  name "Tutor (German) (Artic)"
-  description "Tutor (German) (Artic)"
-  year "1983"
-  manufacturer "S. and J. Mitchell"
-  rom ( name "tutorgerman.p" size 13643 crc 1812F460 md5 A0C9D577D010F7D36F52F0E46FAFCA4C sha1 E0A880B515F960CF65E76EA4EACAED3326F7EA1C )
-)
-
-game (
-  name "Tutor (German) (Artic)"
-  description "Tutor (German) (Artic)"
-  year "1983"
-  manufacturer "S. and J. Mitchell"
-  rom ( name "TutorGerman.tzx" size 13869 crc 44DDECBA md5 C14B69F2223528031A15C8EC638AD941 sha1 058F24EF7BE7494A90CD9799CD68B07E78169B95 )
-)
-
-game (
-  name "Tutor (Spanish) (Artic)"
-  description "Tutor (Spanish) (Artic)"
-  year "1983"
-  manufacturer "S. and J. Mitchell"
-  rom ( name "tutorspanish.p" size 14993 crc 822E1B3E md5 38D6E26ACB7D0F937AC92DEADE6ECFB1 sha1 88A4E1152CC0A92A3539A21C11A8AC227915B529 )
-)
-
-game (
-  name "Tutor (Spanish) (Artic)"
-  description "Tutor (Spanish) (Artic)"
-  year "1983"
-  manufacturer "S. and J. Mitchell"
-  rom ( name "TutorSpanish.tzx" size 15219 crc 4D62869A md5 02068AFEC8B6F9C2875ACF822951AF83 sha1 E12AABEA86FF2542821BD04CDF6E2868F1D3F5D7 )
-)
-
-game (
-  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-  description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-  year "1982"
-  manufacturer "Informatique Service Logiciels"
-  rom ( name "TyrannosaureRex.tzx" size 11728 crc 5300E4D1 md5 5660C77DBAAAE1C8E4FE7F18380B03F6 sha1 CB0CAA82180A19407CD5E850CA88CA33E12B8EFC )
-)
-
-game (
-  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-  description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-  year "1982"
-  manufacturer "Informatique Service Logiciels"
-  rom ( name "tyrannosaurerex.p" size 11506 crc B4BA768A md5 1319F6E2E899B6611FC24443EF13CD9B sha1 7C5172140B9F208B40357C28F348DCA23F8AE1A8 )
-)
-
-game (
-  name "Tyrant of Athens (Lothlorien)"
-  description "Tyrant of Athens (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "tyrantofathens.p" size 12848 crc 00039ED3 md5 40C8CFD3EBEB9510F04115B34BE32097 sha1 347C589D6D9A22794F863D6E61BE0CE8C31EC485 )
-)
-
-game (
-  name "Tyrant of Athens (Lothlorien)"
-  description "Tyrant of Athens (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "TyrantOfAthens.tzx" size 13068 crc FC3FD4F8 md5 C3F5E5D0F379FE1529A27596A8D5B13F sha1 882B644962F09D68BC813563478D773C3A07115B )
-)
-
-game (
-  name "UDG (dK'tronics)"
-  description "UDG (dK'tronics)"
-  year "1981"
-  manufacturer "dK'tronics"
-  rom ( name "udg.p" size 7928 crc A4259B70 md5 E9FDD20A2BB40D5B1D6D356E1B34793A sha1 7C2656D8CBD5427F5E464A5108F82EC84C539706 )
-)
-
-game (
-  name "UDG (dK'tronics)"
-  description "UDG (dK'tronics)"
-  year "1981"
-  manufacturer "dK'tronics"
-  rom ( name "UDG.tzx" size 8150 crc 66A2453F md5 76F87A79206C9FC82E5127B7E94C2D6F sha1 0FEFC639D3C9A6C2ED2A5D994F94EE0691E0DCA5 )
-)
-
-game (
-  name "UFO (Protek)"
-  description "UFO (Protek)"
-  year "1983"
-  manufacturer "Protek"
-  rom ( name "ufo.p" size 5158 crc 4E3F3226 md5 318F5420747069FEB32F65E008B84A61 sha1 F4E7A1691AD0AF71B26A9D1BCC36E3155814100A )
-)
-
-game (
-  name "UFO (Protek)"
-  description "UFO (Protek)"
-  year "1983"
-  manufacturer "Protek"
-  rom ( name "UFO.tzx" size 5380 crc 6B8CBCEC md5 EAC2815189BDB98A886B8F6739B4F188 sha1 F9BD4F690CB67FA718154CB9F07D63E8103A8C4F )
-)
-
-game (
-  name "UFO + 3D Maze (Babtech)"
-  description "UFO + 3D Maze (Babtech)"
-  year "1982"
-  manufacturer "Babtech"
-  rom ( name "UFOAnd3DMaze.tzx" size 13279 crc CC63DFDF md5 90EFA80FF6A2BD4CA39AF581F1CB43A4 sha1 07A8D839B7202B3846FD8F1F84025000FB222F58 )
-)
-
-game (
-  name "VU-CALC (Sinclair Research)"
-  description "VU-CALC (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "VU-CALC.tzx" size 5781 crc 221479DF md5 CB3925E52D2AFA1C3F93CBAFEB2443FE sha1 50275CE9C48F4F3533899A00C5291BDADE4A1EFE )
-)
-
-game (
-  name "VU-CALC (Sinclair Research)"
-  description "VU-CALC (Sinclair Research)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "vu-calc.p" size 5551 crc 85195A78 md5 5B833077456F266ABBF68CA295A60EE1 sha1 19280C9645A23FFBD53818889C4899BD00D29D29 )
-)
-
-game (
-  name "VU-CALC (Timex)"
-  description "VU-CALC (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "VU-CALC(Timex).tzx" size 5779 crc 3DB82474 md5 AC03E37DC2013D571C352AD8FA3EE69D sha1 D1533151DFECF9614C55551E0D6BBAB85BCE9C3C )
-)
-
-game (
-  name "VU-CALC (Timex)"
-  description "VU-CALC (Timex)"
-  year "1982"
-  manufacturer "Psion"
-  rom ( name "vu-calc(timex).p" size 5549 crc 294A26C8 md5 5DF9F5BB28E55CD1BB0E8EAE025C38BC sha1 CE80BFEE2434761BABBFB0AA2B204B2CDB70C76C )
-)
-
-game (
-  name "Variance Analyzer (Zeta Software)"
-  description "Variance Analyzer (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "varianceanalyzer.p" size 8185 crc 73023B9A md5 72FBC8622939AC385B41DC3355B6D4C9 sha1 01535D36D01908855E4530C3077C6B774E893CE8 )
-)
-
-game (
-  name "Variance Analyzer (Zeta Software)"
-  description "Variance Analyzer (Zeta Software)"
-  manufacturer "Dr. Walter Diembeck"
-  rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90A5774A md5 5237031B0A92F415C5AC347D60FD5D3E sha1 A429C8165B8BE52791C99E5DA26A84758A4C508B )
-)
-
-game (
-  name "Vector Mathematics (W. H. Smith)"
-  description "Vector Mathematics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "VectorMathematics.tzx" size 12101 crc C33B86BA md5 4CE4BF8556A215E4D1528E0ADC8DE3C9 sha1 B82230BCC7F57F7B1F12720D82440031135BE44B )
-)
-
-game (
-  name "Vector Mathematics (W. H. Smith)"
-  description "Vector Mathematics (W. H. Smith)"
-  year "1982"
-  manufacturer "ICL"
-  rom ( name "vectormathematics.p" size 11849 crc A13C22DE md5 7F44ADCD2EAB5FA11A948BAD8677E102 sha1 8A75F82FD30681BF8D557E03BABC165C0F64567C )
-)
-
-game (
-  name "Video-Ad (Video Software)"
-  description "Video-Ad (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "VideoAd.A.tzx" size 15281 crc 42136ADC md5 BAEF4C10EF4E5D71498C31E5D2197F64 sha1 C2409CD598CE050D622EB8850E21D74D709060EB )
-)
-
-game (
-  name "Video-Ad (Video Software)"
-  description "Video-Ad (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "videoad.p" size 15049 crc ABC19F74 md5 209BEEC2010448BB63643842DF41793D sha1 BEEBC6BC78805B1BB6328D518AAB9CFF70B2A3A2 )
-)
-
-game (
-  name "Video Graffiti (AGF Hardware)"
-  description "Video Graffiti (AGF Hardware)"
-  year "1982"
-  manufacturer "AGF Hardware"
-  rom ( name "videograffiti.p" size 5033 crc 4B37557F md5 521067DB79CB6F937B5CF2E2D0662F15 sha1 45996EFA5157865159C613CA49DC1F54402E3C7B )
-)
-
-game (
-  name "Video Graffiti (AGF Hardware)"
-  description "Video Graffiti (AGF Hardware)"
-  year "1982"
-  manufacturer "AGF Hardware"
-  rom ( name "VideoGraffiti.tzx" size 5263 crc DD2ECB00 md5 7EA6FB6995EAE21A6731A7C61F7FE91C sha1 CF2E6CEE862CC503BE44BF2E6621A2E8D005C521 )
-)
-
-game (
-  name "Video-Map (Video Software)"
-  description "Video-Map (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "VideoMap.A.tzx" size 15713 crc B76622DC md5 86528F5577970284C231B5048AD5F669 sha1 86D292DEF89F2CD01BDF677F50ABDB18002507A6 )
-)
-
-game (
-  name "Video-Map (Video Software)"
-  description "Video-Map (Video Software)"
-  year "1981"
-  manufacturer "Video Software"
-  rom ( name "videomap.p" size 15479 crc F37CC7C7 md5 CA144229C898E0FBEDF4C974CED0FE56 sha1 3791B93F30FE410716EFDB3D9D345FF803973D28 )
-)
-
-game (
-  name "Video-Plan (Video Software)"
-  description "Video-Plan (Video Software)"
-  manufacturer "Video Software"
-  rom ( name "VideoPlan.A.tzx" size 15425 crc 849E21DC md5 23E1F6EED1029F7433286C3682CCFF69 sha1 FFFA47475A0634FC9859212E5A309603D922D258 )
-)
-
-game (
-  name "Video-Plan (Video Software)"
-  description "Video-Plan (Video Software)"
-  manufacturer "Video Software"
-  rom ( name "videoplan.p" size 15189 crc FD242331 md5 260E9496C1BD1CB40A6095F04E0BBEC2 sha1 2CB0A66C7AA506061FE621A53EE0BC7F143B9988 )
-)
-
-game (
-  name "Video-View (Video Software)"
-  description "Video-View (Video Software)"
-  manufacturer "Video Software"
-  rom ( name "videoview.p" size 13859 crc 53ECA8E2 md5 E02361E6A92651A25CA5F0F5CAC3C408 sha1 BDC28FC5964960F3159A8BD08DB7B3DED64ECA98 )
-)
-
-game (
-  name "Video-View (Video Software)"
-  description "Video-View (Video Software)"
-  manufacturer "Video Software"
-  rom ( name "VideoView.tzx" size 14095 crc F5FDB04B md5 FD38379FC882828484B0A1E7FAC02A4D sha1 ABADD8BD7A829C778D6FBF1D4F394025CD1B7C58 )
-)
-
-game (
-  name "Viewtext (U.S. release) (Bug Byte)"
-  description "Viewtext (U.S. release) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "Viewtext(US).tzx" size 12767 crc 83F14397 md5 7AB7FF7C1B3BAEBCFDB31632ABE00646 sha1 EB0996DDB294A42C133B0C301958BDAA3B5F4A1A )
-)
-
-game (
-  name "Viewtext (U.S. release) (Bug Byte)"
-  description "Viewtext (U.S. release) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "viewtext(us).p" size 12535 crc 4A6DE687 md5 A9EDBDB5E0F43EFC83BD3233ED8122EA sha1 9C9999F8DAEFFD8D6F9F4234548C665C0D2D18A5 )
-)
-
-game (
-  name "Volcanic Dungeon (Carnell)"
-  description "Volcanic Dungeon (Carnell)"
-  year "1982"
-  manufacturer "Carnell Software"
-  rom ( name "volcanicdungeon.p" size 16234 crc BDCC9896 md5 801E5CD018F555198867D3F989033B24 sha1 503C8CFD4994440A3662FBCE25D46B000887056A )
-)
-
-game (
-  name "Volcanic Dungeon (Carnell)"
-  description "Volcanic Dungeon (Carnell)"
-  year "1982"
-  manufacturer "Carnell Software"
-  rom ( name "VolcanicDungeon.tzx" size 16482 crc C6F44894 md5 60210E10F6D239CDDAFFE65B6A3911C8 sha1 6275899B3B7849A97CA8EA869D2BC5806522AE9A )
-)
-
-game (
-  name "Warlord (Lothlorien)"
-  description "Warlord (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "warlord.p" size 15659 crc 5B5B6FBB md5 0D8E945E8CDF72F737D2848CB35EF853 sha1 E8FE374088097ADB86B658E54A4BC05208627AE5 )
-)
-
-game (
-  name "Warlord (Lothlorien)"
-  description "Warlord (Lothlorien)"
-  year "1982"
-  manufacturer "M. C. Lothlorien"
-  rom ( name "Warlord.tzx" size 15879 crc 9BFF8537 md5 1F8271889F8E1F381C60707A0D10621B sha1 DEE7757FC095D4DE68EFCD4147777E0CBBAD8424 )
-)
-
-game (
-  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-  description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-  year "1983"
-  manufacturer "Computertutor"
-  rom ( name "whizzquiz.p" size 16032 crc B8995DC4 md5 7F62BE0EFDC60665D015473550FAFA0E sha1 436C07C66875F854B57A43B543C3002AD6C3E061 )
-)
-
-game (
-  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-  description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-  year "1983"
-  manufacturer "Computertutor"
-  rom ( name "WhizzQuiz.tzx" size 16252 crc 831E3890 md5 9CB954C3643F9BBDAC2F2FD5EE28A79B sha1 81B7FA7BC053EA09617EDD5428EA8B9BC7D8E4D2 )
-)
-
-game (
-  name "Winged Avenger (Work Force)"
-  description "Winged Avenger (Work Force)"
-  year "1982"
-  manufacturer "Work Force"
-  rom ( name "WingedAvenger.tzx" size 4004 crc 18536D36 md5 8D6E49676509AE0666CF832B8BE958B1 sha1 B3ECBF77BB7D691BD1B973EDE3774BF3A54A1494 )
-)
-
-game (
-  name "Winged Avenger (Work Force)"
-  description "Winged Avenger (Work Force)"
-  year "1982"
-  manufacturer "Work Force"
-  rom ( name "wingedavenger.p" size 3760 crc EC61FACB md5 ABB4AB208952C4F184769683545B68E8 sha1 EF6259D87F68C3882AECB6BD47EF0B99A6DBE2A9 )
-)
-
-game (
-  name "Word Processor (Alan's Recordings)"
-  description "Word Processor (Alan's Recordings)"
-  manufacturer "Alan D. Went"
-  rom ( name "WordProcessor.A.tzx" size 12384 crc C1F41D1C md5 668F2DF5BA976DDA0E79405A1C3B0353 sha1 4F2E76139EFB5A07B443C5495636BCBB42489241 )
-)
-
-game (
-  name "Word Test (Mindware)"
-  description "Word Test (Mindware)"
-  year "1982"
-  manufacturer "Christopher Jones"
-  rom ( name "wordtest.p" size 901 crc BE88DF61 md5 338AF799286FEE95CA3F1131A2C00BAC sha1 FBBE0822184C0A4594C5932358EDCFBE3DF4E7BE )
-)
-
-game (
-  name "Word Test (Mindware)"
-  description "Word Test (Mindware)"
-  year "1982"
-  manufacturer "Christopher Jones"
-  rom ( name "WordTest.1.WordTest.tzx" size 1133 crc E12825A4 md5 1D78C945FE6ED7C191F0016E26C4961B sha1 A17549CE398AA7C4955E6A691FD27DBCE089DB4A )
-)
-
-game (
-  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
-  description "World Cup Football (Test your knowledge of) (M. A. Smith)"
-  year "1982"
-  manufacturer "M. A. Smith"
-  rom ( name "worldcupfootball.p" size 10439 crc 5647EB5E md5 C08C7F4881310B8E3AD0C336CA996965 sha1 80B894C252D6185362018B1405D4868484CD0198 )
-)
-
-game (
-  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
-  description "World Cup Football (Test your knowledge of) (M. A. Smith)"
-  year "1982"
-  manufacturer "M. A. Smith"
-  rom ( name "WorldCupFootball.tzx" size 10657 crc 685D01CE md5 F603BC86BBD22E511E7628A9209C3838 sha1 D081CCD8B759A2866BFF5676A112481BB73D5F88 )
-)
-
-game (
-  name "10 Games (J. K. Greye)"
-  description "10 Games (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
-)
-
-game (
-  name "1K Games Pack (Artic)"
-  description "1K Games Pack (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
-)
-
-game (
-  name "1K Games (Sinclair Research)"
-  description "1K Games (Sinclair Research)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
-)
-
-game (
-  name "1K ZX Chess (Sinclair Research)"
-  description "1K ZX Chess (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
-)
-
-game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
-)
-
-game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
-)
-
-game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
-  description "2K Games Pack (International Publishing and Software Inc.)"
-  year "1982"
-  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
-)
-
-game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
-)
-
-game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
-)
-
-game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
-)
-
-game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
-)
-
-game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
-)
-
-game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
-)
-
-game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
-)
-
-game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
-)
-
-game (
-  name "5-2K Family Pak (Timeworks)"
-  description "5-2K Family Pak (Timeworks)"
-  manufacturer "Timeworks"
-  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
-)
-
-game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  manufacturer "GM4IHJ (J Branegan)"
-  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
-)
-
-game (
-  name "10 Games (J. K. Greye)"
-  description "10 Games (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
-)
-
-game (
-  name "1K Games Pack (Artic)"
-  description "1K Games Pack (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
-)
-
-game (
-  name "1K Games (Sinclair Research)"
-  description "1K Games (Sinclair Research)"
-  manufacturer "Artic"
-  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
-)
-
-game (
-  name "1K ZX Chess (Sinclair Research)"
-  description "1K ZX Chess (Sinclair Research)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
-)
-
-game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
-)
-
-game (
-  name "1K ZX Chess (Artic)"
-  description "1K ZX Chess (Artic)"
-  manufacturer "Artic"
-  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
-)
-
-game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
-  description "2K Games Pack (International Publishing and Software Inc.)"
-  year "1982"
-  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
-)
-
-game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
-)
-
-game (
-  name "3D Defender (J. K. Greye)"
-  description "3D Defender (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
-)
-
-game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
-)
-
-game (
-  name "3D Defender (New Generation)"
-  description "3D Defender (New Generation)"
-  year "1981"
-  manufacturer "M. E. Evans"
-  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
-)
-
-game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
-)
-
-game (
-  name "3D Monster Maze (J. K. Greye)"
-  description "3D Monster Maze (J. K. Greye)"
-  year "1981"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
-)
-
-game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
-)
-
-game (
-  name "3D Monster Maze (New Generation)"
-  description "3D Monster Maze (New Generation)"
-  year "1982"
-  manufacturer "J. K. Greye"
-  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
-)
-
-game (
-  name "5-2K Family Pak (Timeworks)"
-  description "5-2K Family Pak (Timeworks)"
-  manufacturer "Timeworks"
-  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
-)
-
-game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-  manufacturer "GM4IHJ (J Branegan)"
-  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
-)
-
-game (
-  name "ZXAS (Bug Byte)"
-  description "ZXAS (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
-)
-
-game (
-  name "ZXAS (Bug Byte)"
-  description "ZXAS (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
-)
-
-game (
-  name "ZXAS (Printed instructions) (Bug Byte)"
-  description "ZXAS (Printed instructions) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
-)
-
-game (
-  name "ZXAS (Printed instructions) (Bug Byte)"
-  description "ZXAS (Printed instructions) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
-)
-
-game (
-  name "ZXAS (Gladstone) (Gladstone Electronics)"
-  description "ZXAS (Gladstone) (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "zxas(ge).p" size 5619 crc 850BAB49 md5 7C622F096AD94F4201922E7CDEA35C67 sha1 0B758FDB9BCFC94D9B37F743F78075595563C529 )
-)
-
-game (
-  name "ZXAS (Gladstone) (Gladstone Electronics)"
-  description "ZXAS (Gladstone) (Gladstone Electronics)"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS(GE).tzx" size 5843 crc A448E4BA md5 BEEBBC4F4B2262F2E2C4AA3F45A62C69 sha1 E09ABFF8F1C771B7E1ACE6B6612EB99DFA539654 )
-)
-
-game (
-  name "ZXAS (Monochrome) (Bug Byte)"
-  description "ZXAS (Monochrome) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
-)
-
-game (
-  name "ZXAS (Monochrome) (Bug Byte)"
-  description "ZXAS (Monochrome) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
-)
-
-game (
-  name "ZXAS (Typed Inlay) (Bug Byte)"
-  description "ZXAS (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
-)
-
-game (
-  name "ZXAS (Typed Inlay) (Bug Byte)"
-  description "ZXAS (Typed Inlay) (Bug Byte)"
-  year "1981"
-  manufacturer "Bug Byte"
-  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
-)
-
-game (
-  name "ZXAS (Yellow) (Bug Byte)"
-  description "ZXAS (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
-)
-
-game (
-  name "ZXAS (Yellow) (Bug Byte)"
-  description "ZXAS (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
-)
-
-game (
-  name "ZX Action Pack (Axis)"
-  description "ZX Action Pack (Axis)"
-  year "1982"
-  manufacturer "Axis"
-  rom ( name "ZXActionPack.tzx" size 4677 crc F5F95245 md5 7E8C4E96F560CE731AE5D167009CC947 sha1 A97DBF23EE4788951617CC26E8BBD2987D3A4CD6 )
-)
-
-game (
-  name "ZX Assembler (Artic)"
-  description "ZX Assembler (Artic)"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "ZXAssembler.tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
-)
-
-game (
-  name "ZX Assembler (Artic)"
-  description "ZX Assembler (Artic)"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "zxassembler.p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
-)
-
-game (
-  name "ZX Assembler (International Publishing and Software Inc.)"
-  description "ZX Assembler (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton (Artic)"
-  rom ( name "ZXAssembler.tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
-)
-
-game (
-  name "ZX Assembler (International Publishing and Software Inc.)"
-  description "ZX Assembler (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton (Artic)"
-  rom ( name "zxassembler.p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
-)
-
-game (
-  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-  description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "zxassembler(mono).p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
-)
-
-game (
-  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-  description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "ZXAssembler(Mono).tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
-)
-
-game (
-  name "ZX Assembleur (French) (Artic)"
-  description "ZX Assembleur (French) (Artic)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "ZXAssembleur.tzx" size 9197 crc AA532026 md5 7B58C9BFE54C57CB8080441BEA91E7EC sha1 02A75242AABFBFA1D233B134DF53727D5B8F597B )
-)
-
-game (
-  name "ZX Assembleur (French) (Artic)"
-  description "ZX Assembleur (French) (Artic)"
-  year "1982"
-  manufacturer "D. P. Aknai and M. Streeton"
-  rom ( name "zxassembleur.p" size 8963 crc D0D72BDC md5 B085ECFB9D97D32FC9EEB0FE94A8629E sha1 1FE43E6C0E7DD3C33BFF97B7246FB5172D5AA892 )
-)
-
-game (
-  name "ZX Asteroids (Electric Pencil Company)"
-  description "ZX Asteroids (Electric Pencil Company)"
-  year "1982"
-  manufacturer "Robert J. Wray"
-  rom ( name "zxasteroids.p" size 6054 crc BC47CFF8 md5 57B3EC022DEC0B1796AA7C6FADCD8F35 sha1 98E75C5767925CD515A10B88F731181CAA84B337 )
-)
-
-game (
-  name "ZX Asteroids (Electric Pencil Company)"
-  description "ZX Asteroids (Electric Pencil Company)"
-  year "1982"
-  manufacturer "Robert J. Wray"
-  rom ( name "ZXAsteroids.tzx" size 6280 crc C92D5C86 md5 F3E15EEFE198558FFB618F9B005AA063 sha1 BC223F7B59F8BA07D7FAF1DA62F5A408034C568C )
-)
-
-game (
-  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-  description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "ZXBug.tzx" size 5572 crc B77B6A0D md5 C5FADBC61693ECCA4761E523D2024999 sha1 5F513D59C871AA94DD8D1C1919FEA0E8D5AAE806 )
-)
-
-game (
-  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-  description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "zxbug.p" size 5350 crc 2859B9EB md5 2766880AAC6AE3B92031AAA2737AF2EC sha1 4030B892FBB1906FE97AB601A37F9D4FFBF52A30 )
-)
-
-game (
-  name "ZX Bug (International Publishing and Software Inc.)"
-  description "ZX Bug (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "Artic (?)"
-  rom ( name "ZXBug(IPS).tzx" size 5576 crc F8959E82 md5 2D051B4F0218C4C78D897CE2A851FE6D sha1 446C92783F64EA88A3FAF3F0D5338223995D99A5 )
-)
-
-game (
-  name "ZX Bug (International Publishing and Software Inc.)"
-  description "ZX Bug (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "Artic (?)"
-  rom ( name "zxbug(ips).p" size 5350 crc AF2C11CA md5 70354BFA74200E4578F92AFC927DB38B sha1 92827B6CB5AB8C7C64127C700C20C36902676CB4 )
-)
-
-game (
-  name "ZX Chess I (Black inlay) (Artic)"
-  description "ZX Chess I (Black inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "zxchessi(black).p" size 14119 crc CCE17D9C md5 2AA8D6A1B52211893F7A7264CFF2BC1A sha1 CECA1C8F7719AFE71D991A073A88561FCDA27AE8 )
-)
-
-game (
-  name "ZX Chess I (Black inlay) (Artic)"
-  description "ZX Chess I (Black inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "ZXChessI(Black).tzx" size 14337 crc 98F8FD30 md5 F2EE420566092A3ECD4D82F532BC98DE sha1 B2EE8FB73779FC8B13B1BEC533E59D762F6F871F )
-)
-
-game (
-  name "ZX Chess II (Artic)"
-  description "ZX Chess II (Artic)"
-  manufacturer "Artic"
-  rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
-)
-
-game (
-  name "ZX Chess II (Artic)"
-  description "ZX Chess II (Artic)"
-  manufacturer "Artic"
-  rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
-)
-
-game (
-  name "ZX Chess II (Black inlay) (Artic)"
-  description "ZX Chess II (Black inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
-)
-
-game (
-  name "ZX Chess II (Black inlay) (Artic)"
-  description "ZX Chess II (Black inlay) (Artic)"
-  manufacturer "Artic"
-  rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
-)
-
-game (
-  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-  description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "ZXChessII(IPS).tzx" size 14326 crc E300FFC8 md5 489B56232D78BBEEBDB69F4CC5FCC320 sha1 D06522009C0438E7E201611C1EC10E17650DBF39 )
-)
-
-game (
-  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-  description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "International Publishing and Software Inc."
-  rom ( name "zxchessii(ips).p" size 14096 crc 95534F49 md5 288FEDCCF17C6D1EC8312C219FE1398E sha1 DF54149F4ED916F7B804A8E0B8E34F790505F7C0 )
-)
-
-game (
-  name "ZX Chess II (Improved) (Artic)"
-  description "ZX Chess II (Improved) (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "zxchessii(improved).p" size 14096 crc 16E86CE7 md5 19D6E472A1121EA8D28CF0B79EEF739D sha1 585FCE3FB637ABD4783F907F24D6945D9472B7E7 )
-)
-
-game (
-  name "ZX Chess II (Improved) (Artic)"
-  description "ZX Chess II (Improved) (Artic)"
-  year "1981"
-  manufacturer "Artic"
-  rom ( name "ZXChessII(Improved).tzx" size 14326 crc 60BBDC66 md5 00F547BD9654A6DCD024639C91152471 sha1 A4238332FE59D8E4E7048069CB6E26C0B357C16D )
-)
-
-game (
-  name "ZX-Compiler (Silversoft)"
-  description "ZX-Compiler (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "ZXCompiler.tzx" size 7163 crc 491041A6 md5 BB0497BB6EEEA52B39EB7E189F55728C sha1 09CECBEC3370CFD1FF77E316C69661132F2E932F )
-)
-
-game (
-  name "ZX-Compiler (Silversoft)"
-  description "ZX-Compiler (Silversoft)"
-  year "1982"
-  manufacturer "Silversoft"
-  rom ( name "zxcompiler.p" size 6931 crc F25627C4 md5 8603E97D1FE5548927E829FD2486F5A7 sha1 1AE703F1D6E47A4F6C3A07F0C5A11C233562782F )
-)
-
-game (
-  name "ZXDB (Bug Byte)"
-  description "ZXDB (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
-)
-
-game (
-  name "ZXDB (Bug Byte)"
-  description "ZXDB (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
-)
-
-game (
-  name "ZXDB (Typed Inlay, black) (Bug Byte)"
-  description "ZXDB (Typed Inlay, black) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
-)
-
-game (
-  name "ZXDB (Typed Inlay, black) (Bug Byte)"
-  description "ZXDB (Typed Inlay, black) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
-)
-
-game (
-  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
-  description "ZXDB (Typed Inlay, blue) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
-)
-
-game (
-  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
-  description "ZXDB (Typed Inlay, blue) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
-)
-
-game (
-  name "ZXDB (Yellow) (Bug Byte)"
-  description "ZXDB (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
-)
-
-game (
-  name "ZXDB (Yellow) (Bug Byte)"
-  description "ZXDB (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
-)
-
-game (
-  name "ZX Forth (Artic)"
-  description "ZX Forth (Artic)"
-  manufacturer "Artic Computing"
-  rom ( name "ZXForth.tzx" size 20567 crc 587D765F md5 421DDC790C350146AF56D1683D3CF2B6 sha1 63C6E3CD88655B30CEF4AFCDF4FCAB959210047F )
-)
-
-game (
-  name "ZX Forth (International Publishing and Software Inc.)"
-  description "ZX Forth (International Publishing and Software Inc.)"
-  year "1982"
-  manufacturer "Artic"
-  rom ( name "ZXForth(IPS).tzx" size 12455 crc 73E4BF92 md5 408A2AD80923D4E802A4529C8FACB917 sha1 5CD85E8A39CB6151C243B4D83DFAF88A4F23C3BC )
-)
-
-game (
-  name "ZX-MC (Picturesque)"
-  description "ZX-MC (Picturesque)"
-  manufacturer "Picturesque"
-  rom ( name "zxmc.p" size 3555 crc DE00007D md5 1FE46C4D47A32B6C7B77144987A6C753 sha1 8897D32731370314DA8BAE6C4E8AE56761E4B3AA )
-)
-
-game (
-  name "ZX-MC (Picturesque)"
-  description "ZX-MC (Picturesque)"
-  manufacturer "Picturesque"
-  rom ( name "ZXMC.tzx" size 3781 crc BAD36AEF md5 A9804BE70B200A01D551198DE5D13E70 sha1 9EDC5C21E1EDD96E1A733908D9E7D39CEC6DF85E )
-)
-
-game (
-  name "ZXM Sound Box Super Editor (Timedata)"
-  description "ZXM Sound Box Super Editor (Timedata)"
-  year "1983"
-  manufacturer "Timedata"
-  rom ( name "ZXMSuperEditor.tzx" size 2693 crc 989424D1 md5 498E30B4CFD9E0E0D65DF71E64FFF20C sha1 9AF273026FBD076097EFFEE86E09A9F07D58F1FC )
-)
-
-game (
-  name "ZXM Sound Box Super Editor (Timedata)"
-  description "ZXM Sound Box Super Editor (Timedata)"
-  year "1983"
-  manufacturer "Timedata"
-  rom ( name "zxmsupereditor.p" size 2473 crc 37830A34 md5 C4A52E25B43580685F277856CF85CE72 sha1 1D030FE2BEE1C42635299E7D0F925F5ADB4582A7 )
-)
-
-game (
-  name "ZX Pro/File (Thomas B. Woods)"
-  description "ZX Pro/File (Thomas B. Woods)"
-  year "1983"
-  manufacturer "Thomas B. Woods"
-  rom ( name "zxprofile.p" size 16071 crc 73F67B5B md5 E0021B805CBAE2655A4158128931035D sha1 9CCB69EA8EF5D613440720D63E84E67675A4614F )
-)
-
-game (
-  name "ZX Pro/File (Thomas B. Woods)"
-  description "ZX Pro/File (Thomas B. Woods)"
-  year "1983"
-  manufacturer "Thomas B. Woods"
-  rom ( name "ZXProFile.tzx" size 16291 crc 5D5146CF md5 64B39D80729E025FAD4828F378CC8032 sha1 214FAFF9ECC28E7D20E229554BFAAE88A8B23B98 )
-)
-
-game (
-  name "ZX-Sideprint (Microsphere)"
-  description "ZX-Sideprint (Microsphere)"
-  year "1982"
-  manufacturer "Microsphere"
-  rom ( name "zxsideprint.p" size 1941 crc DB6371DF md5 D263455884FA102D245F3109C9A66A2F sha1 869334C4250219AA8E6FCF6752D2EBA5F6AA7E69 )
-)
-
-game (
-  name "ZX-Sideprint (Microsphere)"
-  description "ZX-Sideprint (Microsphere)"
-  year "1982"
-  manufacturer "Microsphere"
-  rom ( name "ZXSideprint.tzx" size 2175 crc 5F320B4A md5 D990BB98194F1A992E902AAAEC9C3FBB sha1 6965F265CBFCA8F6813F698BE70ED0E709C59632 )
-)
-
-game (
-  name "ZXTK (Bug Byte)"
-  description "ZXTK (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
-)
-
-game (
-  name "ZXTK (Bug Byte)"
-  description "ZXTK (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
-)
-
-game (
-  name "ZXTK (Printed instructions) (Bug Byte)"
-  description "ZXTK (Printed instructions) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
-)
-
-game (
-  name "ZXTK (Printed instructions) (Bug Byte)"
-  description "ZXTK (Printed instructions) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
-)
-
-game (
-  name "ZXTK (Yellow) (Bug Byte)"
-  description "ZXTK (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
-)
-
-game (
-  name "ZXTK (Yellow) (Bug Byte)"
-  description "ZXTK (Yellow) (Bug Byte)"
-  year "1982"
-  manufacturer "Bug Byte"
-  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
-)
-
-game (
-  name "Zac-Man (Macronics)"
-  description "Zac-Man (Macronics)"
-  manufacturer "Macronics"
-  rom ( name "zacman.p" size 6881 crc 261A596B md5 CD301F8807F261D005A0F5E0A5F8E1B3 sha1 1C8CB9858647E86A3BE82467A6DA6A04A4A40D15 )
-)
-
-game (
-  name "Zac-Man (Macronics)"
-  description "Zac-Man (Macronics)"
-  manufacturer "Macronics"
-  rom ( name "ZacMan.tzx" size 7111 crc 76FCA436 md5 C33DEB5191E85BCAA942A92F184236C7 sha1 E4271947DFAB4C3EEB64A5927CDA4D25445A0E53 )
-)
-
-game (
-  name "Zaraks (Computer Rentals)"
-  description "Zaraks (Computer Rentals)"
-  year "1983"
-  manufacturer "Richard Taylor"
-  rom ( name "Zaraks.tzx" size 3923 crc 4466C390 md5 46D8771CF8578EDCF534505127A3735D sha1 D4D0575F849ED626A6D2B02CC3D64660980694C5 )
-)
-
-game (
-  name "Zaraks (Computer Rentals)"
-  description "Zaraks (Computer Rentals)"
-  year "1983"
-  manufacturer "Richard Taylor"
-  rom ( name "zaraks.p" size 3695 crc 733E3147 md5 F41780FBD2B777457AFBDBACF838C2FB sha1 46A79FA15ABF021D05E323B36629DCAB80E84E72 )
-)
-
-game (
-  name "Zombies/Sword of Peace (Artic)"
-  description "Zombies/Sword of Peace (Artic)"
-  manufacturer "Artic"
-  rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 CF95266460228F0BE0EC5CD944051FCA sha1 519D3115B5CEB75B61DFF442A927BE851FB0CA96 )
-)
-
-game (
-  name "Zuckman (White inlay) (DJL Software)"
-  description "Zuckman (White inlay) (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "Zuckman.tzx" size 10169 crc C80BADF3 md5 5B98D152D8A4EAD841A65716F68F7DD6 sha1 E212C3315D69861422DEE61AF487F6729568520A )
-)
-
-game (
-  name "Zuckman (White inlay) (DJL Software)"
-  description "Zuckman (White inlay) (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "zuckman.p" size 9939 crc E518A2BD md5 4D40C31B628FCA5ED079F992E8AE2D24 sha1 30720D6D3AF16AED257832988218F8EC3F002765 )
-)
-
-game (
-  name "Zuckman (Black inlay) (DJL Software)"
-  description "Zuckman (Black inlay) (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "Zuckman(Alt).tzx" size 10169 crc 886FA5B4 md5 82570CAFB6BAE5E05CF474C69C5ABF8B sha1 87F7870077134B24DFC9BAB9E406762BD7FF6D04 )
-)
-
-game (
-  name "Zuckman (Black inlay) (DJL Software)"
-  description "Zuckman (Black inlay) (DJL Software)"
-  year "1982"
-  manufacturer "DJL Software"
-  rom ( name "zuckman(alt).p" size 9939 crc A57CAAFA md5 B57A30D83B200790BCCF55EF9959AAA0 sha1 BF63E2441FCFAD7C72C8E8BDED65F9D3704D85ED )
-)
-
 game (
 	name "Ant Attack"
 	description "Ant Attack (2013) - Bob's interpretation of Sandy White's classic isometric title from 1983."
 	rom ( name "AntAttack.p" size 16167 crc 2e30a8cf md5 1fe5cfe57b540868e31fd73e7e54388b sha1 1b4fc9eb5cd3373a9986fcd395d0117c6b3c4718 )
-	manufacturer "Bob Smith"
-	year "2013"
 )
-
+game (
+	name "Arcade Action (Micromega)"
+	description "Arcade Action (Micromega)"
+	manufacturer "Micromega"
+	rom ( name "ArcadeAction.tzx" size 4651 crc 5cb215e3 md5 5a76c5d34baa6d9aaf3bdd34e5c89597 sha1 04fc1ffa34592f093f1c0eae9d54b3ff31eb3e86 )
+)
+game (
+	name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+	description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+	year 1982
+	rom ( name "aroundeuropein80hours.p" size 15223 crc 2da984a7 md5 1dd7d90a090b80ea53c1b387b852d497 sha1 5d2a941cd7edca847bfd6c10b41b9025a81d4352 )
+	rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758c6 md5 5feee6f195cee427cd9195a1c4462f58 sha1 cb59d966fe38c858df9a002f2eaaae2cb0e1ba73 )
+)
+game (
+	name "Asteroids (Silversoft)"
+	description "Asteroids (Silversoft)"
+	year 1982
+	manufacturer "Silversoft"
+	rom ( name "asteroids.p" size 3542 crc 7484ac13 md5 0a392517e1d78420e0a5b5aafefe0c39 sha1 27d633e47d4e5a6b1594b16103e6a7ea12b5d0a7 )
+	rom ( name "Asteroids.tzx" size 3776 crc 939e50e5 md5 5f4836d37cb10b4bb5c7c71bb857409a sha1 85047ab187bfcd02195f00150419cee1bfc07a5f )
+)
+game (
+	name "Asteroids (Software Farm)"
+	description "Asteroids (Software Farm)"
+	manufacturer "Software Farm"
+	rom ( name "asteroids(sf).p" size 8360 crc 0efcebd4 md5 583c3e31090f678a465c46d0cfcf2ad7 sha1 7f114cd978045301b7c63f7177d2fe2d0ee33264 )
+	rom ( name "Asteroids(SF).tzx" size 8594 crc 8b6f8743 md5 d7f2518bd65dbd7d99842f5a27aab588 sha1 d56d7e03a545b99607174faec186c42e64618189 )
+)
+game (
+	name "Autochef (Cases Computer Simulations)"
+	description "Autochef (Cases Computer Simulations)"
+	year 1982
+	rom ( name "autochef.p" size 15430 crc 575560bb md5 21c42c6c6eaf0866dc56533f89688f4f sha1 dd0ee23e39d50738d91731c427063ac8e59ad9d3 )
+	rom ( name "Autochef.tzx" size 15648 crc 3869ae07 md5 81856a30f98ccaa2fdbd6c88d8c7897f sha1 2b7416327bdb907108d287f8cd4eaa0fd291ecba )
+)
+game (
+	name "Avenger (Abacus)"
+	description "Avenger (Abacus)"
+	year 1982
+	manufacturer "K. Flynn"
+	rom ( name "avenger.p" size 7138 crc 53621a49 md5 1af4b6a7f31315a701b5dd54068c5596 sha1 0f402a98c52410358f2a3ec94280af6c7375f9ac )
+	rom ( name "Avenger.tzx" size 7368 crc b545fdae md5 b0e975a6cdff98f667536f3fd4d902bd sha1 529b2a9eb67c50db12494cc0ff7272925e9d18b4 )
+)
+game (
+	name "Backgammon (Keith Archer)"
+	description "Backgammon (Keith Archer)"
+	year 1982
+	manufacturer "Keith Archer"
+	rom ( name "backgammon(ka).p" size 11625 crc f4d9073b md5 b0a388f1b834d98852d96f998c1978cc sha1 c0c4e28934d05735b2200c41f2af8eb7b3abd1cb )
+	rom ( name "Backgammon(KA).tzx" size 11861 crc 153ed883 md5 71f46d576fe8bfa343d41949dabd2e55 sha1 81f25c1667c8eba6936eabfd080ccad3a3a34add )
+)
+game (
+	name "Backgammon (Timex)"
+	description "Backgammon (Timex)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "Backgammon(Timex).tzx" size 17108 crc 307aacd2 md5 d068903731302f4dc6c0e7810d1ed944 sha1 5a78754d849fe5284342089159af45588029c0a9 )
+)
+game (
+	name "Bank Robber (Romik Software)"
+	description "Bank Robber (Romik Software)"
+	year 1983
+	manufacturer "Roland Stokes"
+	rom ( name "bankrobber.p" size 6560 crc 2973af44 md5 8ca20ed973a7a1b830087cd30db7edba sha1 5ebdbd6b13b82933c158bd439b89bf6ce69149a7 )
+	rom ( name "BankRobber.tzx" size 6798 crc f9a7ab7d md5 36e6e97bd4ea83c494b6134e1aeee1c2 sha1 40d0fcc8faaf73b0082d4f1937ef16626d289f66 )
+)
+game (
+	name "Baron (Temptation Software)"
+	description "Baron (Temptation Software)"
+	manufacturer "Simon Mansfield"
+	rom ( name "Baron.tzx" size 16716 crc 2813c7a1 md5 c6ae4f6cf29411686bde01114a682498 sha1 fd944cedd638d3a5d6b70a8a4d50f2d41c16ea74 )
+)
+game (
+	name "Basicode 2 (BBC)"
+	description "Basicode 2 (BBC)"
+	year 1984
+	manufacturer "The Chip Shop"
+	rom ( name "Basicode2.A.tzx" size 3570 crc db6f1818 md5 ad1857f473ca1de8ed5d7b855d566c54 sha1 9204245adf3f343e82c43d6ec70117c4dc491908 )
+	rom ( name "basicode2.p" size 3338 crc 89ce64f1 md5 cab7e8adf644459ce8c1dd54897a184c sha1 07a3de146663d0e77a98a0800fb6f0545d567d77 )
+)
+game (
+	name "Bat Cage (Timex)"
+	description "Bat Cage (Timex)"
+	year 1982
+	manufacturer "Thomas J. Burke"
+	rom ( name "batcage.p" size 1222 crc a1b5d16f md5 0a716ad28c067c5938d776fabadfc176 sha1 e3dbde749ff3618ab07a6c8fc712531be6272bcf )
+	rom ( name "BatCage.tzx" size 1446 crc 650a94d8 md5 c3b8a71965f8ba025d546b7fe8f1531b sha1 8f6842f02e416e8b66c8d6172f2e852a5e14d2f8 )
+)
+game (
+	name "Battleships (JRS Software)"
+	description "Battleships (JRS Software)"
+	year 1982
+	manufacturer "JRS Software"
+	rom ( name "battleships.p" size 12732 crc a0a631a4 md5 99bdb02395ed7a85c8b13911c0344516 sha1 6897424919c684a7a18235d967c7f621f02d1cf0 )
+	rom ( name "Battleships.tzx" size 12962 crc a1057bc5 md5 8840352dd5514d5bc84e82f14f6211e2 sha1 0c36982f0243f39c028a21207a2218d40b1cb369 )
+)
+game (
+	name "Bigflap Attack (Timex)"
+	description "Bigflap Attack (Timex)"
+	manufacturer "Timex"
+	rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66c706f432ad9277573b709c913b16a0 sha1 985f2f32ae4478051b5b7d91cb17bbc474fd26f6 )
+)
+game (
+	name "Black Star (Quicksilva)"
+	description "Black Star (Quicksilva)"
+	year 1983
+	manufacturer "M. Sudworth"
+	rom ( name "blackstar.p" size 6811 crc 0407beac md5 d34202b6ac2f39323ad1212ca360e18b sha1 c17aa876dfeef10fd9d8da5bd83cc6fec9396fb9 )
+	rom ( name "BlackStar.tzx" size 7047 crc f227253f md5 c5b418b890bb6d828ec84d2fb36152ab sha1 0abe2ca4064679c23da82773fab70bf05c245844 )
+)
 game (
 	name "Boulder Logic"
 	description "Boulder Logic (2011) - Bradford Walker-Smythe needs to find the perfect engagement ring to win the heart of his true love Tania when he asks for her hand in marriage. And so, to prove his devotion, he sets off to the Cornish mines in search of the perfect diamond..."
 	rom ( name "BoulderL.p" size 16240 crc 23cc342f md5 b040c3e750ef06a93c56b53ed299b9ca sha1 3c74569ef70327ecf17db982ef92b4557c17b538 )
-	manufacturer "Bob Smith"
-	year "2011"
 )
-
+game (
+	name "Bouncing Bert (Software Farm)"
+	description "Bouncing Bert (Software Farm)"
+	year 1985
+	manufacturer "S C T"
+	rom ( name "bouncingbert.p" size 14919 crc fb88ad49 md5 e575aa04406a3f9eb1c095e8c0b6cd3a sha1 a56dddc42a1383c392d6988c9dafb4c8db37007a )
+	rom ( name "BouncingBert.tzx" size 15151 crc c30caf71 md5 ae2a31c5a4b92c6213b7547608110e86 sha1 ef3be8446d80452a155ed647a55c7d24aee58a6d )
+)
+game (
+	name "Breakout 3 (Axis)"
+	description "Breakout 3 (Axis)"
+	year 1982
+	manufacturer "Axis"
+	rom ( name "breakout3.p" size 5485 crc a836659c md5 9ae6333ad0003617da56543e57a60903 sha1 f226df48cfcabea16956faff21e88e3eeeccf66c )
+	rom ( name "Breakout3.tzx" size 5705 crc 69b9a5bf md5 595c064a5d18089bec87664dc37ab2da sha1 faf622eff6cca236e0623d7f23cf35bfef74d823 )
+)
+game (
+	name "Breakout (CDS Micro Systems)"
+	description "Breakout (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "breakout.p" size 3235 crc 82836ac3 md5 3f4b0e39130be53ae22381f8a82a3081 sha1 eb36d14650c568ed47326dc094392c70fd249b3c )
+	rom ( name "Breakout.tzx" size 3467 crc 322fafd6 md5 0323a0d24248e0de2dce75c7cd3b71a9 sha1 1cb495c3b751e64e8b1fc38c68fabf0340365f39 )
+)
+game (
+	name "Breakout (J. K. Greye)"
+	description "Breakout (J. K. Greye)"
+	year 1981
+	manufacturer "J. K. Greye"
+	rom ( name "breakout(jkg).p" size 716 crc 15cb56b4 md5 4655a4c1f58c705f303d31d2f2e64f7f sha1 2a4ddae5df3c18192c851be567daeb9ab59aa456 )
+	rom ( name "Breakout(JKG).tzx" size 948 crc e3f0284a md5 c52f2080dc8e969b4636da6f9d4f1e54 sha1 c8138f8960aedf4d848c65b676d76bf717ec9154 )
+)
+game (
+	name "Breakout (New Generation)"
+	description "Breakout (New Generation)"
+	year 1982
+	manufacturer "J. K. Greye"
+	rom ( name "breakout(ngs).p" size 716 crc d4496e38 md5 e488ef1a3efc25f2abd308f9aef901b5 sha1 bd90a91d1ef17e19802d145dac955d0d34cab5f0 )
+	rom ( name "Breakout(NGS).tzx" size 948 crc 227210c6 md5 50fe074b25394a62a8fbbb8dac9513fb sha1 86b96863cffca1038110a78b99b4df5fbcc75daa )
+)
+game (
+	name "Breakout, Space Invaders and Music (Macronics)"
+	description "Breakout, Space Invaders and Music (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "BreakoutSIAndMusic.tzx" size 2734 crc d383db01 md5 13110862adf0b4abb06573a2be710087 sha1 d5582e7a6a79bd6b8a2096ed968c91292b46483b )
+)
+game (
+	name "Brick Stop (CDS Micro Systems)"
+	description "Brick Stop (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "brickstop.p" size 3126 crc 8ee66abe md5 b70594c6cb40ac4b3b7706574153563d sha1 fd697ae6ec522406f4e6b91a5c7a5d7c9058a4ff )
+	rom ( name "BrickStop.tzx" size 3362 crc 2e173afa md5 65a723688c0fd694ad600407fc12ec17 sha1 232822deb023be4037e9864a1ccd01e8c42a32bf )
+)
+game (
+	name "Bubble Bugs (Romik Software)"
+	description "Bubble Bugs (Romik Software)"
+	year 1983
+	manufacturer "Roland Stokes"
+	rom ( name "bubblebugs.p" size 6409 crc 1e09b9ec md5 00b1a8fe3030cf7b4cd91b5eaf986516 sha1 8770497d4db9455f31dc6f422b710ba44dcab096 )
+	rom ( name "BubbleBugs.tzx" size 6647 crc 368c6f68 md5 3e4feeb96b4ff463ff81be369592c0de sha1 e52ddab32b1183910d1c74ae04999a8fb92dc158 )
+)
+game (
+	name "Bumper 7 (Axis)"
+	description "Bumper 7 (Axis)"
+	year 1981
+	manufacturer "Axis"
+	rom ( name "Bumper7.tzx" size 5179 crc 3c31d394 md5 7a42934f415ad9587a203974bbe2f6f2 sha1 2adc581baca7d49305c0ccd720f594c50618be5e )
+)
+game (
+	name "Byter (Protek)"
+	description "Byter (Protek)"
+	year 1983
+	manufacturer "Protek"
+	rom ( name "byter.p" size 5045 crc 1c53ac02 md5 8db34a0ed323545380ac2eb69190fa18 sha1 c396155336a5f43e908de08c5398b670f694b4f7 )
+	rom ( name "Byter.tzx" size 5271 crc 540854fe md5 423d68cc0edd3f4c360cc58f167f0e71 sha1 ab1f4d1f13735e7ffe4e143c1ee159a2ca1a0617 )
+)
+game (
+	name "Can of Worms (Automata Cartography)"
+	description "Can of Worms (Automata Cartography)"
+	manufacturer "Automata Cartography"
+	rom ( name "CanOfWorms.tzx" size 7150 crc b2e6fa12 md5 3a724f1a32f350922012f1ff6b6e0193 sha1 9bb651b39206913bbe74600997114fcbcd70747c )
+)
+game (
+	name "Cassette 3 (M. Orwin)"
+	description "Cassette 3 (M. Orwin)"
+	year 1982
+	manufacturer "Various"
+	rom ( name "Cassette3.tzx" size 96710 crc f612e596 md5 688fe0bd73cf475d632ebb2bc920f92c sha1 a3a02c88cd119f5acf87ef056a8b26dad0a79390 )
+)
+game (
+	name "Cassette 4 (M. Orwin)"
+	description "Cassette 4 (M. Orwin)"
+	year 1982
+	manufacturer "Various"
+	rom ( name "Cassette4.tzx" size 53160 crc 9c246427 md5 acfc26dd06d2a03808f0ff71e9be96d2 sha1 5cdb627ac5b3498225d7d4d5fb90d80751187218 )
+)
+game (
+	name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+	description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
+	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
+)
+game (
+	name "Castle Adventure (CDS Micro Systems)"
+	description "Castle Adventure (CDS Micro Systems)"
+	manufacturer "CDS Micro Systems"
+	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
+	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
+)
+game (
+	name "Catacombs (J. K. Greye)"
+	description "Catacombs (J. K. Greye)"
+	year 1981
+	manufacturer "J. K. Greye"
+	rom ( name "catacombs.p" size 12506 crc b1ed0b59 md5 5e674ce62efd5ab861bbeef9de75d711 sha1 a5d32e1d50d291c485549c4740e5cc6ba3de36ab )
+	rom ( name "Catacombs.tzx" size 12740 crc f8d6aee6 md5 6ec147973d7561ede4726bc413409cdd sha1 c872d07e278df997df9a66185852f580fd851151 )
+)
+game (
+	name "Cave Crusade (AWA Software)"
+	description "Cave Crusade (AWA Software)"
+	manufacturer "S. Hughes"
+	rom ( name "cavecrusade.p" size 6270 crc a2eb2f80 md5 b6c9c3f387d5ba97d80fe92a03e6d0c5 sha1 5f05d170d3eba9a7c4915eecd7e65bbbb958feca )
+	rom ( name "CaveCrusade.tzx" size 6510 crc 9dec44e3 md5 4e27965613610224b2c60f824983f7a7 sha1 bc4a46fdec5734a88afc005df4864feae26549e1 )
+)
+game (
+	name "Centipede (dktronics) (dK'tronics)"
+	description "Centipede (dktronics) (dK'tronics)"
+	year 1982
+	manufacturer "Jeff Minter"
+	rom ( name "centipede(dktronics).p" size 9790 crc 1e369ce6 md5 dd7d3f2e2b36ffbd2cc169624fc60421 sha1 7770684a912c0bb2116d9f73f1caafc1796a23df )
+	rom ( name "Centipede(dktronics).tzx" size 10008 crc f12c5ee1 md5 78b3d51b99fa1b99182d60b206fe2944 sha1 c90d0ca1dd3e1679c9c0e4a359d6b84978c129f7 )
+)
+game (
+	name "Centipede (Green cover) (dK'tronics)"
+	description "Centipede (Green cover) (dK'tronics)"
+	manufacturer "dK'tronics"
+	rom ( name "centipede(green).p" size 9733 crc f5f4b919 md5 90610d4fa888969f53204a5ca98f6a20 sha1 418c10220fbf3bcf83c07b2a9c717dd12dc92c53 )
+	rom ( name "Centipede(Green).tzx" size 9967 crc 0ed972cd md5 9dd33fd4999f2d1de4bf52e4590d2521 sha1 1bf47ef2651d5d09a6971ce9eb931aa41ed846cb )
+)
+game (
+	name "Centipede (Llamasoft)"
+	description "Centipede (Llamasoft)"
+	year 1982
+	manufacturer "Jeff Minter"
+	rom ( name "centipede.p" size 9706 crc f2414d13 md5 eeba50f572e820d43fb3f8d140c673e1 sha1 0f23aa3eac663bd04de225074b80701ba05fcb1b )
+	rom ( name "Centipede.tzx" size 9940 crc 163cf493 md5 74ac41b73e525977dd00e99e92a46e53 sha1 dd75bbb4ec90c8d054e1c0a41164e02a8f3121e3 )
+)
+game (
+	name "Challenge (Micromega)"
+	description "Challenge (Micromega)"
+	manufacturer "Micromega"
+	rom ( name "Challenge.tzx" size 4865 crc 8439c8b1 md5 b963b33677e4e187630608606fecba67 sha1 b3dd53df21a684570b3120a8a996fae738dfb15a )
+)
+game (
+	name "Champions! (Peaksoft)"
+	description "Champions! (Peaksoft)"
+	manufacturer "Peaksoft"
+	rom ( name "champions.p" size 14858 crc d363867f md5 806e86a4e8c5807ce53717e4ba441c98 sha1 2148c6108e52c8c33a8c1593c47a1ee89ed711b8 )
+	rom ( name "Champions.tzx" size 15086 crc 7ae0415b md5 7f738befe88938ae2f5bfaf464cc2c16 sha1 1847183ffcaf74bb7f709d09d1d5fea24c720e6a )
+)
+game (
+	name "Chess (Timex)"
+	description "Chess (Timex)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "Chess(Timex).tzx" size 10227 crc 8f6bfdc7 md5 c0678ed697e11dfa85e483db93dd053c sha1 bd2a54d8ccb6bd918deaba02b0793cf0372c8f27 )
+)
+game (
+	name "Chrs Demo (Quicksilva)"
+	description "Chrs Demo (Quicksilva)"
+	manufacturer "Quicksilva"
+	rom ( name "ChrsDemo.tzx" size 5993 crc 3e8d1da7 md5 b69ea89a89170660517bf2284c791e12 sha1 8509b1fc61dc20c1e9280526858b0e95bd6359b5 )
+)
+game (
+	name "City of Xon (Pleasantrees)"
+	description "City of Xon (Pleasantrees)"
+	year 1982
+	manufacturer "Pleasantrees"
+	rom ( name "cityofxon.p" size 15507 crc e853667c md5 82a04afaf98222545389663888140b7b sha1 2111223fd0cab96c1aca585430336e60d501017f )
+	rom ( name "CityOfXon.tzx" size 15729 crc 3b72af94 md5 18b114ee78e469ea4b85e858802a716c sha1 0d07fb55913b3495b0c26178c84d010cd5eeb03e )
+)
+game (
+	name "City Patrol (Sinclair Research)"
+	description "City Patrol (Sinclair Research)"
+	year 1982
+	manufacturer "Macronics (Don Priestley)"
+	rom ( name "citypatrol.p" size 9168 crc b9cf2e5f md5 a14424f16ed442e3c0af074f2ea01c95 sha1 333c2e1052dc734d76b19da5dddfaa9835177e12 )
+	rom ( name "CityPatrol.tzx" size 9388 crc 1ea8841e md5 71c94bc78806c1ea06d1996cbf6d64e8 sha1 99d5ae89cfe7940e67d8ede6dbd860020b1ad9df )
+)
+game (
+	name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+	description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+	year 1983
+	manufacturer "Computertutor"
+	rom ( name "whizzquiz.p" size 16032 crc b8995dc4 md5 7f62be0efdc60665d015473550fafa0e sha1 436c07c66875f854b57a43b543c3002ad6c3e061 )
+	rom ( name "WhizzQuiz.tzx" size 16252 crc 831e3890 md5 9cb954c3643f9bbdac2f2fd5ee28a79b sha1 81b7fa7bc053ea09617edd5428ea8b9bc7d8e4d2 )
+)
+game (
+	name "Club Record Controller (Sinclair Research)"
+	description "Club Record Controller (Sinclair Research)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "clubrecordcontroller.p" size 6857 crc 16b8f22f md5 481daf4708c4217ff3c5446f049e5d61 sha1 73048e28d5c2f198a97c1ba33e9a2111a1901465 )
+	rom ( name "ClubRecordController.tzx" size 7075 crc c1bdaa09 md5 03638152afe7d50f7f3050d42423fb5a sha1 246f887ed316a62311165af8ac7abee59c0cfce6 )
+)
+game (
+	name "Club Records (W. H. Smith)"
+	description "Club Records (W. H. Smith)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "clubrecords.p" size 7526 crc 770ead60 md5 43274f46a93f29e10650a6c0ea5d6ea6 sha1 06c9b03442650d03948bdd73095ba4541cf4fff4 )
+	rom ( name "ClubRecords.tzx" size 7744 crc 229bf155 md5 9061510c942e211db25159985fd39a7b sha1 d62dc88512d6dc336dad5637924e6056a19e12a7 )
+)
+game (
+	name "Collector's Pack (Sinclair Research)"
+	description "Collector's Pack (Sinclair Research)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "collectorspack.p" size 7447 crc ad2faa57 md5 dc7c428a0df6b6140dd71f0924f80316 sha1 67ff172b4ec0b7b088b17ee62df3860851748705 )
+	rom ( name "CollectorsPack.tzx" size 7665 crc 4998a5d6 md5 8fd43049ae5c0246d79c82d59cef6cd4 sha1 bb2b43893119eabf30754be20992bf32e05e6832 )
+)
+game (
+	name "Collector's Recording System (W. H. Smith)"
+	description "Collector's Recording System (W. H. Smith)"
+	manufacturer "ICL"
+	rom ( name "collectorsrecordingsystem.p" size 7447 crc fe3eb9cc md5 8af2b0e4d7a7480859b978aff6b8954d sha1 bf4b5d5c78b6a1e68784296567aa655362d6a552 )
+	rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1a89b64d md5 d0735fc71d39a879e80fe130f3ca8226 sha1 7fb6cf85c4a0e47a2ad78f5f4371deeebadcb923 )
+)
+game (
+	name "Community Chest (Artic)"
+	description "Community Chest (Artic)"
+	manufacturer "Artic"
+	rom ( name "communitychest.p" size 14048 crc 0fe4512d md5 a40b1c79c5b578238002454f2a4b92bc sha1 941725aeef9136f7b105bd1e8c21245ec671ac86 )
+	rom ( name "CommunityChest.tzx" size 14270 crc bf585c82 md5 a4b42d6021ceca0f9c09aa0e6596c110 sha1 c95af3f37795adabe7f251643efff51cb7e2579f )
+)
+game (
+	name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+	description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+	year 1981
+	manufacturer "S. C. Stephens"
+	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
+	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
+)
+game (
+	name "ComputaCalc ZX (Silicon Tricks)"
+	description "ComputaCalc ZX (Silicon Tricks)"
+	year 1981
+	manufacturer "S. C. Stephens"
+	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
+	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
+)
+game (
+	name "Constellation (Bug Byte)"
+	description "Constellation (Bug Byte)"
+	manufacturer "Bug Byte"
+	rom ( name "constellation.p" size 12385 crc 82892356 md5 b7ff958c98e6955281aed8d50ce4a8b2 sha1 b020cec9fd14f00882de28165f4f2a207e020306 )
+	rom ( name "Constellation.tzx" size 12611 crc a0146b49 md5 500508c55bfae7c20d1191cf95b37e5d sha1 fb8bbc99988812c5ef372a7358a36ceadb53ae73 )
+)
+game (
+	name "Constellation (Gladstone) (Gladstone Electronics)"
+	description "Constellation (Gladstone) (Gladstone Electronics)"
+	manufacturer "Bug Byte"
+	rom ( name "constellation(ge).p" size 15452 crc ca46cb85 md5 7eb28d1ad0f29be00794f00be04ff1e7 sha1 58f35fb046a9e20052dc7b838e1754c593fcdb53 )
+	rom ( name "Constellation(GE).tzx" size 15694 crc 89092de9 md5 e76748a332503ed9799fb76a16cf24f2 sha1 69da2b7f7a1f311a73858f4787f05c31460e7172 )
+)
+game (
+	name "Control Technology Tapes 1,2,3 (Control Technology)"
+	description "Control Technology Tapes 1,2,3 (Control Technology)"
+	manufacturer "Control Technology"
+	rom ( name "ControlTechnology123.tzx" size 48433 crc d9610ea9 md5 1c5691270a4f2ef50a859f6eefe7891f sha1 8e630dbc2725862733cd138e69a7c8ca9eeed84f )
+)
+game (
+	name "Conversational German (Timex)"
+	description "Conversational German (Timex)"
+	year 1983
+	manufacturer "D. E. Hagan"
+	rom ( name "conversationalgerman.p" size 15375 crc 2a3a859e md5 b73d18d611af33ad7c555f03f0cc597d sha1 f03403678a5b6caa88cedee89aee74ba8d4270ab )
+	rom ( name "ConversationalGerman.tzx" size 15603 crc 810bdcc4 md5 1e27801fd4db30240671c6f1ecbbe73d sha1 ddb421fe807557a6f4a2eb7ea78e15c249b15de1 )
+)
+game (
+	name "Cosmic Guerilla (Quicksilva)"
+	description "Cosmic Guerilla (Quicksilva)"
+	year 1983
+	manufacturer "C. K. Tame"
+	rom ( name "cosmicguerilla.p" size 7333 crc 8594884e md5 37c438dbf7ec1a61b574c870ab04b375 sha1 1f0226f4de15f5ee393761631a6d3aad46c75a10 )
+	rom ( name "CosmicGuerilla.tzx" size 7561 crc 001ef96d md5 de8ca35128d7ec90516dd6ee759e65a6 sha1 ef8e79312d0dc7efec6bf2a9a6ca785b0e4a94a0 )
+)
+game (
+	name "Counter Attack (Woodside Software)"
+	description "Counter Attack (Woodside Software)"
+	manufacturer "P. Hennessy"
+	rom ( name "counterattack.p" size 6975 crc 4095691a md5 846be5d9faf79197323d5c2b05b82136 sha1 45aae62dc5ed72ecba3c33b280b2c3d7310cf942 )
+	rom ( name "CounterAttack.tzx" size 7219 crc 6b8852ca md5 dfe0270c48c5af69bd0652f723f6c5b2 sha1 286cd36a713f95ffcc5e847539a59de6c55f6c42 )
+)
+game (
+	name "Critical Path Analysis (Hilderbay)"
+	description "Critical Path Analysis (Hilderbay)"
+	year 1981
+	manufacturer "Hilderbay"
+	rom ( name "criticalpathanalysis.p" size 6053 crc 10fb4d01 md5 30f5b565eebb684d446a1d9073860bd2 sha1 e6e505e111c04a395e8a946cf2c5b7bbed948ba1 )
+	rom ( name "CriticalPathAnalysis.tzx" size 6275 crc 28ee5886 md5 47b2d99a813ea1744ad5a41d15016a8d sha1 3ee5a82dec70e4bd7eb1d514cdd4538cb433f24a )
+)
+game (
+	name "Critical Path Analysis (Timex)"
+	description "Critical Path Analysis (Timex)"
+	year 1982
+	manufacturer "W. Emery"
+	rom ( name "CriticalPathAnalysis(Timex).tzx" size 6720 crc c1835895 md5 af015196bc37c30e8f529da34262ed28 sha1 469f80fbf8e3979b8534e28dabd9d7089e55425e )
+)
+game (
+	name "Croaka-Crawla (Quicksilva)"
+	description "Croaka-Crawla (Quicksilva)"
+	year 1983
+	manufacturer "Quicksilva"
+	rom ( name "croakacrawla.p" size 14666 crc 2e8a9af1 md5 96fdeaf0f549a9198b633a19510be1fe sha1 4bb58b01e86aaf1dc21999e77ec7d557f4353ffe )
+	rom ( name "CroakaCrawla.tzx" size 14896 crc 1e07d1c3 md5 51e05750eda73cbd667e52d945c742d9 sha1 3489fd97ee769b1b59e0b74ccdeb667f135dbcbd )
+)
 game (
 	name "CroZXy Road"
 	description "CroZXy Road (2015) - Bob's interpretation of Hipster Whale's iconic 'Crossy Road'"
 	rom ( name "CrozxyRoad.p" size 16058 crc 38885a68 md5 dee3fff6ce7789a7a4a4c38cffdb7a5d sha1 98ef4e7a24f87c9d253da0dc68698850dcd2752f )
-	manufacturer "Bob Smith"
-	year "2015"
 )
-
+game (
+	name "D Coder (Cosma)"
+	description "D Coder (Cosma)"
+	manufacturer "Cosma"
+	rom ( name "DCoder.A.tzx" size 7680 crc 1684ba79 md5 229d7eb3cd3c17b82a1fb4e5daec5370 sha1 39f16bb21b52c566218f38aa07b1951e38c0f8bd )
+)
+game (
+	name "Dallas (French) (Cases Computer Simulations)"
+	description "Dallas (French) (Cases Computer Simulations)"
+	year 1983
+	manufacturer "Cases Computer Simulations"
+	rom ( name "dallas(french).p" size 16151 crc 6fc5f7ec md5 c76bd00587e4017e445c023ad12fdfcb sha1 1d1cd2f2ce3cdfc7a8c18e8bdd1cd0cdc8f2797e )
+	rom ( name "Dallas(French).tzx" size 16379 crc 4a65562e md5 6ea358b625c6deecce8b906983884a27 sha1 499bee247f3bdc37eca67e95eee1624de11ec5d6 )
+)
+game (
+	name "Dictator (Bug Byte)"
+	description "Dictator (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "dictator.p" size 16074 crc 9ef1b3cf md5 8aa9775f53f519ded0ae7f7a2c5b3f60 sha1 42b98d75f715b69c1c54722a05a8d0d7b07783ec )
+	rom ( name "Dictator.tzx" size 16306 crc b01e01a7 md5 2e2e96ed20915990eb8280021ce7838e sha1 c14608ecc904b6ad8141d64bb4eed66c43b6316d )
+)
+game (
+	name "Do Not Pass Go (Work Force)"
+	description "Do Not Pass Go (Work Force)"
+	manufacturer "Work Force"
+	rom ( name "donotpassgo.p" size 13355 crc 292a5505 md5 0480349fbee60fd0939f31cc6d210c2b sha1 a05ba8ad8560a15c5ecffff289d10daa421b5cb8 )
+	rom ( name "DoNotPassGo.tzx" size 13587 crc a2dd0f0c md5 d4cdfcee0472c465483738b520960d65 sha1 45ded58ce3255e5239722c956eef084bac20ad6d )
+)
+game (
+	name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
+	description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "DodgemsAndConnect4(Brown).tzx" size 9488 crc 39d4e107 md5 b6110b1177643dfb269784ee01902964 sha1 de9f3293e482ac4f92b3278d262e45321450fe79 )
+)
 game (
 	name "Domin8tr1s"
 	description "Domin8tr1s (2010) - Arrange the dominoes as they tumble from the sky so that matching digits are adjacent, either horizontally or vertically, to each other.  Align the same number of digits as the digit itself to make those dominoes disappear."
 	rom ( name "DOMIN8TR1S.P" size 6581 crc 96911e31 md5 d3e69b3bba27f609f426a6434f3a93ac sha1 8e8ee9c4fc589f386596ef3b3e8fab9b9ee799ef )
-	manufacturer "Bob Smith"
-	year "2010"
 )
-
+game (
+	name "Dominoes (Phipps Associates)"
+	description "Dominoes (Phipps Associates)"
+	year 1983
+	manufacturer "D. G. Cross"
+	rom ( name "dominoes.p" size 15143 crc f53499e9 md5 7c250a09c6e3e1fe996ab0df7fc312ff sha1 cd00bf0a030844133f39fbbac4712ba1c8591dca )
+	rom ( name "Dominoes.tzx" size 15375 crc 4fc4e410 md5 c9ec351812095d3a1a91e4db7926a5d8 sha1 b780954c535ccd6f6a778999b7244de33bb3ad53 )
+)
+game (
+	name "Dr. Floyd (Apropos Technology)"
+	description "Dr. Floyd (Apropos Technology)"
+	manufacturer "Apropos Technology"
+	rom ( name "drfloyd.p" size 14062 crc d16282da md5 4e26541f29e46baba6beac4ad8bccc31 sha1 c5531613742a634a5b41503198ae567adc6a42ab )
+	rom ( name "DrFloyd.tzx" size 14294 crc d5b0408f md5 5e0b05b046b113239ec5efdb9e23589e sha1 6982c898304a0e319434984a019b96682d177661 )
+)
+game (
+	name "Dragon Maze (Macronics)"
+	description "Dragon Maze (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "dragonmaze.p" size 4750 crc b252b048 md5 d5520c004ecd8e8d15d36fa70fddec8e sha1 f6f90b253527935b27ce3674c49b33d914b37dfc )
+	rom ( name "DragonMaze.tzx" size 4970 crc c2a29e0d md5 3aaaadd623df3a672361715bb3b9c6f3 sha1 58e77f8d47f0a0061f0545e3d95485d9041d7025 )
+)
+game (
+	name "Dungeons of Doom (Temptation Software)"
+	description "Dungeons of Doom (Temptation Software)"
+	year 1982
+	manufacturer "Simon Mansfield"
+	rom ( name "DungeonsOfDoom.tzx" size 15074 crc d5034066 md5 747215bd1afebf2217addc18b14b1e36 sha1 b2884c73af5da39e4c32d9a11206769e006f456f )
+)
+game (
+	name "E.E. 1 - Filter Design (Timex)"
+	description "E.E. 1 - Filter Design (Timex)"
+	year 1982
+	manufacturer "American Micro Products"
+	rom ( name "ee1filterdesign.p" size 11825 crc a6a157c9 md5 5e5b10ecc426f5820f3dab25b7c6ad92 sha1 152342a49020a5740a50650d9b2bbf9c5d66c9b7 )
+	rom ( name "EE1FilterDesign.tzx" size 12047 crc 1159b6aa md5 0a3fb9fd79259c485b0df31a4d387d20 sha1 d6714fe623f9e444c22cde90f56488a58fce0d33 )
+)
+game (
+	name "Electric Cost Analyzer (Timex)"
+	description "Electric Cost Analyzer (Timex)"
+	year 1983
+	manufacturer "Tim Rossetti"
+	rom ( name "electriccostanalyzer.p" size 15557 crc bccae88d md5 adca050f5154d5e1107ca72433db06e1 sha1 dd7ae4f987b76d764d60d5a0fd95cf879310dde2 )
+	rom ( name "ElectricCostAnalyzer.tzx" size 15789 crc d6745b7a md5 ca1d14bad434d1ad36f829aaac3939a1 sha1 f5f5c2a8038df69484937ce4b853b4e83dfcf5f5 )
+)
+game (
+	name "Electronics (Spectre)"
+	description "Electronics (Spectre)"
+	manufacturer "Spectre"
+	rom ( name "electronics.p" size 15899 crc b18d5d28 md5 8d3ee1b1eb0d3df446f50731c6659279 sha1 2f56472672d41361c60591d7cf177eb18148976b )
+	rom ( name "Electronics.tzx" size 16121 crc e777753a md5 48b223d7a2e94415ad4dc381b6a33fe8 sha1 d3a41d3aa66db93144eef927a1c37fc8bb9fab90 )
+)
+game (
+	name "Encounter (Quicksilva)"
+	description "Encounter (Quicksilva)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Encounter.tzx" size 17612 crc af150f3f md5 d526d1745135dcc2bc1f357fa2cab910 sha1 ec8355c006d83dfc367a166ee6f33cb3530381ab )
+)
+game (
+	name "Escape From Manhattan (Computer Rentals)"
+	description "Escape From Manhattan (Computer Rentals)"
+	year 1983
+	manufacturer "N. Taylor"
+	rom ( name "escapefrommanhattan.p" size 16102 crc 63f8023f md5 135b8483bb5b316c8744d824acbb86c1 sha1 53799e5ea4da7a6c5ebba8537126f25ebbeb8285 )
+	rom ( name "EscapeFromManhattan.tzx" size 16320 crc 2cacbb72 md5 2b526ba624af0fdfc1733099ccec82ab sha1 975c976e36b9dbd47fcf5312fae4ad5c2521d6d7 )
+)
+game (
+	name "Escape from Shazzar (International Publishing and Software Inc.)"
+	description "Escape from Shazzar (International Publishing and Software Inc.)"
+	year 1983
+	manufacturer "A. F. Nuttall"
+	rom ( name "escapefromshazzar.p" size 16146 crc c587593d md5 b2dc9a81ac27d4bc267c8d4a0236acb5 sha1 48fa28f6b637e59f48a58e618617a98f83fe6813 )
+	rom ( name "EscapeFromShazzar.tzx" size 16376 crc 78075b95 md5 0854165d7caa9f5d43203e5f9c999fa0 sha1 992dfcece29b42c729bbca05422bf090dc7c275c )
+)
+game (
+	name "Fast Load Save (Musamy Software)"
+	description "Fast Load Save (Musamy Software)"
+	year 1982
+	manufacturer "Musamy Software"
+	rom ( name "FastLoadSave.tzx" size 11000 crc 939f03cb md5 be316fadc3492e475e6d07bdf9ae310e sha1 616dfc2662d46f415277990bebf0b09e187ed36e )
+)
+game (
+	name "Flight Simulation (Sinclair Research)"
+	description "Flight Simulation (Sinclair Research)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
+	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+)
+game (
+	name "Flug-Simulation (Sinclair Research)"
+	description "Flug-Simulation (Sinclair Research)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
+	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+)
+game (
+	name "Football (Tyrant)"
+	description "Football (Tyrant)"
+	manufacturer "Tyrant"
+	rom ( name "football.p" size 15626 crc 33233387 md5 ef4f6c235f9017f7b4c83f19ffc72818 sha1 f0ee8a1607a606d22b7c2ba518a06bd2cd387fd9 )
+	rom ( name "Football.tzx" size 15858 crc 8503533c md5 673dfecb1920d35fcd55f23aab95dbf8 sha1 d75dfc7310f08160f7ff61f2e08f2ed4fa5aabb0 )
+)
+game (
+	name "Football Manager (Addictive Games)"
+	description "Football Manager (Addictive Games)"
+	year 1982
+	manufacturer "Kevin J. Toms"
+	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
+	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+)
+game (
+	name "Football Manager (Black inlay) (Addictive Games)"
+	description "Football Manager (Black inlay) (Addictive Games)"
+	year 1981
+	manufacturer "Kevin J. Toms"
+	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
+	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+)
+game (
+	name "Football Manager (Red) (Addictive Games)"
+	description "Football Manager (Red) (Addictive Games)"
+	year 1981
+	manufacturer "Kevin J. Toms"
+	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
+	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+)
+game (
+	name "Football Pools Program (Hartland Software)"
+	description "Football Pools Program (Hartland Software)"
+	manufacturer "Hartland Software"
+	rom ( name "FootballPools.tzx" size 24422 crc 2d0ed98b md5 387bb8707269de22cfb13b4c8781d20c sha1 a2ae0611ad434600777c2ba0df4cc48d8109d9f8 )
+)
+game (
+	name "Football-League (Video Software)"
+	description "Football-League (Video Software)"
+	year 1981
+	manufacturer "Video Software"
+	rom ( name "FootballLeague.A.tzx" size 14343 crc 78694c75 md5 64ad8a73b7b3b45c35aa937b09e14817 sha1 4887f03b6e5725d1acb156a485ddc9c450607d88 )
+	rom ( name "footballleague.p" size 14097 crc 9e4623c5 md5 b430448d983a97c6de8d0fd776bef9c8 sha1 c8b1bd7a85d2981ec2b6478e0c58b36dccb42ac3 )
+)
+game (
+	name "Forth (Sinclair Research)"
+	description "Forth (Sinclair Research)"
+	year 1983
+	manufacturer "Artic"
+	rom ( name "Forth.tzx" size 14183 crc 376c5750 md5 5ad0f910d2987e3a51716dd82e6f4113 sha1 012a7e585c3f2d245e3d7ffba935ea1962be21c4 )
+)
+game (
+	name "Fortress of Zorlac (Timex)"
+	description "Fortress of Zorlac (Timex)"
+	year 1982
+	manufacturer "Paul Carlson"
+	rom ( name "fortressofzorlac.p" size 7214 crc aded8203 md5 0852a128df135af9f240356567d626b8 sha1 872b7049cab2fea166921ba30d93fccdaf63f840 )
+	rom ( name "FortressOfZorlac.tzx" size 7442 crc 30d3ba7d md5 05b14472e34f62f64d40e71f0001f900 sha1 13f8969e92932f3f6e4c6f177bbe34512780b96f )
+)
+game (
+	name "Forty Niner (Software Farm)"
+	description "Forty Niner (Software Farm)"
+	manufacturer "Software Farm"
+	rom ( name "fortyniner.p" size 13868 crc b8650da4 md5 9729d9b8a4faee1d12f4384f789c0b44 sha1 694ac6d1410eade17ecc9e06a3c39191e8dda352 )
+	rom ( name "FortyNiner.tzx" size 14106 crc 1c4eff0a md5 fba0b998270a673af60ede6b1f6da4ff sha1 e563342e858b8c38a384ebfd695c479feb01a4a5 )
+)
+game (
+	name "Frogger (DJL Software)"
+	description "Frogger (DJL Software)"
+	manufacturer "DJL Software"
+	rom ( name "frogger.p" size 13493 crc 8d24d478 md5 db791414f02377a0b2bb60e1539401f3 sha1 29d815b98770a1fbae3714642c5c70583d02ed17 )
+	rom ( name "Frogger.tzx" size 13723 crc bd7df880 md5 9a8c77a4c24e8e67f7308be91a2b95aa sha1 75499b16de8dfbabf668328109d0a36963bfd11b )
+)
+game (
+	name "Frogger (Sega) (Timex)"
+	description "Frogger (Sega) (Timex)"
+	year 1981
+	manufacturer "Cornsoft/Sega"
+	rom ( name "frogger(sega).p" size 10638 crc 3993108b md5 1e6fdfe09452ba5609c693a7683c94f7 sha1 b17facf22bb6f66fe8eef0977cbdf1b1ecde6c6c )
+	rom ( name "Frogger(Sega).tzx" size 10868 crc 95952886 md5 e8ebe732890b6dc7d39674e7bf527716 sha1 08999372caf4a07b532e7360f1573c5262b56ed7 )
+)
+game (
+	name "Froggy (DJL Software)"
+	description "Froggy (DJL Software)"
+	year 1982
+	manufacturer "DJL Software"
+	rom ( name "froggy.p" size 10394 crc 5624f4f4 md5 c0408bb2b6d716d9643fa64670d7c241 sha1 9f45088a30fdbddffccb01f55690cde7276df088 )
+	rom ( name "Froggy.tzx" size 10622 crc e84f00da md5 8a827657ccd27300bafaa4af1076045a sha1 c0d7d2db94e8fb84bb22428b0b6a5c5ccc11c52b )
+)
+game (
+	name "Frogs (Mikro-Gen)"
+	description "Frogs (Mikro-Gen)"
+	manufacturer "Mikro-Gen"
+	rom ( name "frogs.p" size 4223 crc b5335a99 md5 55d1b367c05a5f9259da78aad2b072da sha1 d3edabf6c4e7e88cb1224ace1c63b2735dbf2f0f )
+	rom ( name "Frogs.tzx" size 4453 crc efd0f05e md5 9409197480d2e19da908b0594580ee89 sha1 899d5cdf74208e30d17c5d34f5733d207222daaa )
+)
+game (
+	name "Fun Fair Adventure (Fawkes Computing)"
+	description "Fun Fair Adventure (Fawkes Computing)"
+	year 1983
+	manufacturer "Fawkes Computing"
+	rom ( name "funfairadventure.p" size 15670 crc f5238943 md5 4f267d0ad39d72853cbb7ff914a491b0 sha1 d654cca3195f48a50e1391bc5bc8db72a1d4215f )
+	rom ( name "FunFairAdventure.tzx" size 15892 crc 477b0e8f md5 8b00dde0094158be9fa735e62bc99bf9 sha1 c828c69e2a899e1b15968dafeaeb19b6045b360b )
+)
+game (
+	name "FUNdamentals of Math (Timex)"
+	description "FUNdamentals of Math (Timex)"
+	year 1983
+	manufacturer "ATM"
+	rom ( name "FUNdamentalsOfMath.tzx" size 39312 crc 75ade9a1 md5 fbe76752ce6fd550c78f7116e8472d37 sha1 0c1fd6d5034fa73e8d1d3dd525e088cd96971bd7 )
+)
+game (
+	name "Galactic Gunner (Timex)"
+	description "Galactic Gunner (Timex)"
+	year 1983
+	manufacturer "Paul W. Carlson"
+	rom ( name "galacticgunner.p" size 8786 crc fef205ce md5 35300ca762e104fc8c6efba2280feb96 sha1 cbb2fb7c55caa311826d2a2481c6dffad40b5863 )
+	rom ( name "GalacticGunner.tzx" size 9014 crc 1ee1c007 md5 9e6d42b5ba230a9e298dfe1c49744b23 sha1 93f8f8b5fde8de8305d0946f25296da88e26d720 )
+)
+game (
+	name "Galactic Patrol (Computer Rentals)"
+	description "Galactic Patrol (Computer Rentals)"
+	year 1983
+	manufacturer "Richard Brisbourne"
+	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
+	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
+)
+game (
+	name "Galactic Patrol (Omega re-release) (Omega)"
+	description "Galactic Patrol (Omega re-release) (Omega)"
+	year 1984
+	manufacturer "CRL"
+	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
+	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
+)
+game (
+	name "Galactic Trooper (Romik Software)"
+	description "Galactic Trooper (Romik Software)"
+	year 1983
+	manufacturer "Ian Morrison and David Anderson"
+	rom ( name "galactictrooper.p" size 4269 crc ae87f0a7 md5 74661343c5098f10bf44fdf40dc02f04 sha1 e6ba889b1f3d97366cc829d07e9d13fd665d40f5 )
+	rom ( name "GalacticTrooper.tzx" size 4517 crc 95146c5f md5 86cd07956e3d37c94d5cc19c7753f152 sha1 ee48ee10e53adbbbfe6d62c8b4fbadea8bc1eb16 )
+)
+game (
+	name "Galaxians (Artic)"
+	description "Galaxians (Artic)"
+	manufacturer "Artic"
+	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
+	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
+)
+game (
+	name "Galaxians (Monochrome) (Artic)"
+	description "Galaxians (Monochrome) (Artic)"
+	manufacturer "Artic"
+	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
+	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
+)
+game (
+	name "Galaxy Invaders (International Publishing and Software Inc.)"
+	description "Galaxy Invaders (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "International Publishing and Software Inc."
+	rom ( name "galaxyinvaders(ips).p" size 4002 crc 4328beba md5 fb94065d6c8b3a4aa2f12a7d015e569d sha1 1bb9b928230de4ab517bf8b248a687c94c3df639 )
+	rom ( name "GalaxyInvaders(IPS).tzx" size 4224 crc 6df4e24b md5 490e79f413dcb97060633218e014a62f sha1 23fc85b7e2ecfacd664dc991acf7e56393a345a1 )
+)
+game (
+	name "Galaxy Jailbreak (Romik Software)"
+	description "Galaxy Jailbreak (Romik Software)"
+	year 1983
+	manufacturer "Roland Stokes"
+	rom ( name "galaxyjailbreak.p" size 5413 crc ae762991 md5 6493ac3cd7c77be6027bc00c3932c68c sha1 aeb080263f016d94bf0a13ff521bbc30d7032686 )
+	rom ( name "GalaxyJailbreak.tzx" size 5661 crc 8f630ce4 md5 f1ceb2d7e0cee7cb924a0b824dbf418b sha1 351dce4ff4d8d3dcc68508b39bb910b21cecfb84 )
+)
+game (
+	name "Galaxy Warrior/Star Trek (Artic)"
+	description "Galaxy Warrior/Star Trek (Artic)"
+	manufacturer "Artic"
+	rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1bcb3a5f md5 fff5135ca3ac8c8553e9eace62d55667 sha1 abfb5609bfa713c2f4841bc45ba11eb7363b6bf7 )
+)
+game (
+	name "Games Pack (JRS Software)"
+	description "Games Pack (JRS Software)"
+	year 1982
+	manufacturer "JRS Software"
+	rom ( name "GamesPack.tzx" size 20187 crc 4c92529e md5 893ed24f30dbba822dc001b87750b873 sha1 eb8aec55c92fc530591e033c862ce3b95c40a149 )
+)
+game (
+	name "General Statistics (W. H. Smith)"
+	description "General Statistics (W. H. Smith)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "generalstatistics.p" size 14214 crc 10c6ef87 md5 a779367a54ad8ac03543a2d70c2e88e1 sha1 f65e699472236439c262640299628cb01284223e )
+	rom ( name "GeneralStatistics.tzx" size 14466 crc 8889d5e3 md5 acf9669f43af8b165cda56888e9a1348 sha1 a1f94c7ca3a27e24ebfaba575700cfccf8640356 )
+)
+game (
+	name "Geographics UK (Novus Software)"
+	description "Geographics UK (Novus Software)"
+	manufacturer "Novus"
+	rom ( name "geographicsuk.p" size 16037 crc fbc771bf md5 fea62f9b738c3f63cf9de62a37431588 sha1 fb07ebddca1f03eef2b4d06052d4abde520d4ae0 )
+	rom ( name "GeographicsUK.tzx" size 16281 crc 4af3cfc9 md5 4534b531e811c27a32effaa76a9a257e sha1 0d88e5bc5e71cc898a375156e40396b5b536d7a0 )
+)
+game (
+	name "Geometry 1 (Timex)"
+	description "Geometry 1 (Timex)"
+	year 1982
+	manufacturer "Home Computer Software"
+	rom ( name "Geometry1.tzx" size 5483 crc 80dad6c4 md5 d8c843396ea93e08a986ed3ec74a1b53 sha1 be9373f6519a369e7d2dba40a14319f4751b1b78 )
+)
+game (
+	name "Ghost Hunt (PSS)"
+	description "Ghost Hunt (PSS)"
+	year 1982
+	manufacturer "PSS"
+	rom ( name "ghosthunt.p" size 5302 crc dea898bd md5 dc3e16535dcf3395085a311decc1d8e5 sha1 da84c5b1e1e7cb26ebdbaa119a4e0f29f9e4ef4f )
+	rom ( name "GhostHunt.tzx" size 5538 crc 8e8d76f5 md5 c3b97b5345ea55bdc8c6307ee40f21b2 sha1 33ac921be892a02c115f7dfa73c54cafe178671b )
+)
+game (
+	name "Gobbleman (Colour Inlay) (Artic)"
+	description "Gobbleman (Colour Inlay) (Artic)"
+	manufacturer "Artic"
+	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
+)
+game (
+	name "Gobbleman (Monochrome Inlay) (Artic)"
+	description "Gobbleman (Monochrome Inlay) (Artic)"
+	manufacturer "Artic"
+	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
+)
+game (
+	name "Gobblers (Software Farm)"
+	description "Gobblers (Software Farm)"
+	manufacturer "Software Farm"
+	rom ( name "gobblers.p" size 7162 crc b7687e93 md5 cb4cfa5b341c3d129405a82d97bc84bf sha1 fc15194e2cd43c8ed2121bc76331313532bd49da )
+	rom ( name "Gobblers.tzx" size 7394 crc dafe76e1 md5 8de20a364ca8693eb9c755a7da120189 sha1 681bd965a868d25b3ded5c9111c6f6a622a7df1e )
+)
+game (
+	name "Gold (Hilderbay)"
+	description "Gold (Hilderbay)"
+	year 1981
+	manufacturer "Hilderbay"
+	rom ( name "Gold.tzx" size 23791 crc a280fcba md5 6824a18251adf4cae7ca49ea6f04d865 sha1 33c0acac2f430cc9884739426e287098d646bd92 )
+)
+game (
+	name "Golf (R & R Software)"
+	description "Golf (R & R Software)"
+	year 1982
+	manufacturer "R & R Software"
+	rom ( name "golf.p" size 9244 crc bdc6ff4e md5 761909f603ceaa4fb32bdfc288fbb19e sha1 0add3b45b1a4a246ddb24ce1d3eea288032f8d99 )
+	rom ( name "Golf.tzx" size 9468 crc 1b658fab md5 01ade7a91bd9f70953004cb25d9e1d88 sha1 3177bea82297a86a2c5c541cde8426fff95cc052 )
+)
+game (
+	name "Graphics Kit (Softsync)"
+	description "Graphics Kit (Softsync)"
+	year 1981
+	manufacturer "Paul Holmes"
+	rom ( name "GraphicsKit.tzx" size 6203 crc 0e978f07 md5 53ac6583ca184c362108642e40f086cd sha1 2e26b56a9895655424d29d23d2836c28b0a26226 )
+)
+game (
+	name "Great Britain Ltd (Simon W. Hessel)"
+	description "Great Britain Ltd (Simon W. Hessel)"
+	manufacturer "Simon W. Hessel"
+	rom ( name "greatbritainltd.p" size 15541 crc 23ad347c md5 e4b1812bd16ea7cfdd416e932467e4d4 sha1 8eafc58c5610b3901b85478da04d25156f00bff1 )
+	rom ( name "GreatBritainLtd.tzx" size 15767 crc 4b717923 md5 07bff59ab86d31689cf4450d21f3741d sha1 bbde7b36f9f2cb65cd0ef2f112c52ce612a19433 )
+)
+game (
+	name "Grimm's Fairy Trails (Timex)"
+	description "Grimm's Fairy Trails (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "grimmsfairytrails.p" size 9331 crc ad7e74e0 md5 bdea9f593d45946fa07521844b0dd51e sha1 ee1b726655bfd5e897da2af3888f3c8545d85b99 )
+	rom ( name "GrimmsFairyTrails.tzx" size 9563 crc 55fe8f96 md5 2ed795d94caa50cd02cf68475e01aef5 sha1 cb65770be85add8b3aa5e01cecacc3b2b2835ecb )
+)
+game (
+	name "Guitar For Beginners (Timex)"
+	description "Guitar For Beginners (Timex)"
+	year 1982
+	manufacturer "Tim Rossetti"
+	rom ( name "guitarforbeginners.p" size 11018 crc 73af3c6d md5 fb35abb3bce84cd543e1bb9d46f65c82 sha1 97adfd80a6abb57717469a3fdaf17f7a160793f2 )
+	rom ( name "GuitarForBeginners.tzx" size 11246 crc 10734bfb md5 69edfc6fcf6f8b26d2907aa32e3c5669 sha1 975deca435c26ed3e0604497454129186e139307 )
+)
+game (
+	name "Gulp 2 (Campbell Systems)"
+	description "Gulp 2 (Campbell Systems)"
+	year 1982
+	manufacturer "Campbell Systems"
+	rom ( name "gulp2.p" size 6116 crc 1bfd713d md5 c7db6f6ed8cba0f14aa92df6d55f93a7 sha1 2399dff41d799578005ad8b23cc5086e120971e0 )
+	rom ( name "Gulp2.tzx" size 6342 crc b041f1bf md5 7c1be7d5a5b5d0f65dafdd2a0f252a2d sha1 aa0fadd80146c2dab98dab49c88f52ba4852c861 )
+)
+game (
+	name "Gulp (Mindware)"
+	description "Gulp (Mindware)"
+	year 1982
+	manufacturer "Campbell Systems"
+	rom ( name "Gulp(Mindware).1.Gulp.tzx" size 1125 crc c651f1e5 md5 e342f3fcc020d8afd4bf4a496ca75f75 sha1 c91c14f5ec001c991ed3c67673fe38c8b7b9d02d )
+	rom ( name "gulp.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
+)
+game (
+	name "Gulpman (Micromega)"
+	description "Gulpman (Micromega)"
+	year 1982
+	manufacturer "Campbell Systems"
+	rom ( name "gulpman.p" size 6121 crc 74a38569 md5 3ef8b687b566f338a2c672133e638379 sha1 9551cfdf7d738e0db679f08b35b72724d2f5a7a2 )
+	rom ( name "Gulpman.tzx" size 6351 crc 7baebe9a md5 e47f73d6aadf86310e6379a22a7d6b7a sha1 d28c22863672b87a1f0f6b23f2262b0195b3e1fb )
+)
+game (
+	name "Haute Resolution (Pluto)"
+	description "Haute Resolution (Pluto)"
+	year 1984
+	manufacturer "CRL"
+	rom ( name "HauteResolution.tzx" size 6970 crc f52d460f md5 42186664d3f698c0ede72a2b0c2ab398 sha1 91cd6738fcec38d4fc9d3e3ba08614634935918a )
+)
+game (
+	name "Heating System Analyzer (Timex)"
+	description "Heating System Analyzer (Timex)"
+	year 1982
+	manufacturer "Tim Rossetti"
+	rom ( name "heatingsystemanalyzer.p" size 15494 crc 17d05fc2 md5 8b2aceadfbb20f65c305cdeaea598262 sha1 087d0e4680643e6d9e808cce10c918e58d3c72ab )
+	rom ( name "HeatingSystemAnalyzer.tzx" size 15718 crc ea836c43 md5 29fa5b64d2c89de8a19c0f678c6b2c94 sha1 9d5e5a4f1e26f6a5dba03028940310bb796da199 )
+)
+game (
+	name "High Res (Macronics)"
+	description "High Res (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "highres.p" size 10763 crc e37bad7f md5 493817d98b6d96356df1e1c3f93866e9 sha1 d817b3db8f0065843e3b3d7eb4e55b673c08de03 )
+	rom ( name "HighRes.tzx" size 10985 crc fa40dbc1 md5 f48465678582d4fd7bd8325ddede7788 sha1 9b81b10a719af4c6c61a03ed003f1198f68bda1b )
+)
+game (
+	name "Hopper (PSS)"
+	description "Hopper (PSS)"
+	year 1982
+	manufacturer "PSS"
+	rom ( name "hopper.p" size 10833 crc 965d961a md5 f76d900361978e5a354569718c918783 sha1 9e5b1e824f492a88999c023646486a9620e1c89f )
+	rom ( name "Hopper.tzx" size 11061 crc f5601550 md5 30ed7cc222c8a94447629233bb357832 sha1 4102dbfe6c3cddb82877bb9b089f764420f0a249 )
+)
+game (
+	name "Hopper (Truck) (PSS)"
+	description "Hopper (Truck) (PSS)"
+	year 1981
+	manufacturer "PSS"
+	rom ( name "hopper(truck).p" size 10833 crc 343ec159 md5 e49392779795505c5e776a86bb27de9b sha1 347965bc2ab0003c295c1005e89cde7053dd7040 )
+	rom ( name "Hopper(Truck).tzx" size 11061 crc 57034213 md5 ecc9da3396ba5f0eee543e3915a3ab8d sha1 5747373be057f05059c47d8acb42f2c9312eeb83 )
+)
+game (
+	name "House of Death (A. J. Rushton)"
+	description "House of Death (A. J. Rushton)"
+	manufacturer "A. J. Rushton"
+	rom ( name "houseofdeath.p" size 15045 crc d88c206a md5 89e832d5035229bcfe30a9d77a0242a9 sha1 962346b1f5e5d9f8c025994824736ac497be1ea2 )
+	rom ( name "HouseOfDeath.tzx" size 15289 crc e78272e3 md5 68fb7bfd61e73901337800b912db3760 sha1 80ee47dd77a43c051c600a38def525950a110119 )
+)
+game (
+	name "HRG 7.0 (Unknown)"
+	description "HRG 7.0 (Unknown)"
+	year 1983
+	manufacturer "J. M. Cohen"
+	rom ( name "HRG70.tzx" size 19444 crc 75adee54 md5 eec31c8470c05281f4e8c957e56889d3 sha1 9f062ea8b3bd11a868a773dd4fed573a51225a1e )
+)
 game (
 	name "Impact!"
 	description "Impact! (2012) - Bob's interpretation of Atari's 1979 arcade game 'Asteroids'."
 	rom ( name "Impact.p" size 16154 crc d6e106b8 md5 b6ad9cb0b2dc0153eb080a9ce87c797c sha1 11c5fe8d44763d94a3eedf597b6daf0438364e22 )
-	manufacturer "Bob Smith"
-	year "2012"
 )
-
+game (
+	name "Introduction To Chemistry (Timex)"
+	description "Introduction To Chemistry (Timex)"
+	year 1983
+	manufacturer "J. J. Hollandsworth"
+	rom ( name "IntroductionToChemistry.tzx" size 37232 crc 7b7d1b69 md5 f7c95b6d075d662664527efc3fc842d0 sha1 4a49f3c842e387dd1353dc859877b93c92aa8ace )
+)
+game (
+	name "Invaders (A. G. Software)"
+	description "Invaders (A. G. Software)"
+	manufacturer "Andrew Glaister"
+	rom ( name "invaders(ags).p" size 2117 crc 134835d7 md5 b2cb96deb94f2caf1167c6aa9eed3c35 sha1 125d09e68f9ad9490b47adee512bf46db7286c2a )
+	rom ( name "Invaders(AGS).tzx" size 2349 crc 58299c24 md5 6a329b8b6bdca462dc2564297fb425f2 sha1 37503b2c552016a3265ff387afca6ffa6380c5e8 )
+)
+game (
+	name "Invaders (Bug Byte)"
+	description "Invaders (Bug Byte)"
+	year 1982
+	manufacturer "S. Munnery"
+	rom ( name "invaders.p" size 2373 crc 3b79c6ac md5 e3cd419e7f34dbfc4efd9b4c8e0a7633 sha1 8683fd832959844fb6357fd272dcde5ece0a601d )
+	rom ( name "Invaders.tzx" size 2605 crc 93d1d5d7 md5 1d391665fb5734a2b274e2c9630d35f7 sha1 bb79a0ea9ff54e882d45a7ca94dc71762488b2cd )
+)
+game (
+	name "Invaders (Forward Software)"
+	description "Invaders (Forward Software)"
+	manufacturer "Silversoft"
+	rom ( name "invaders(forward).p" size 3465 crc 7005eda5 md5 0e940cd5d0fab16b860c1e5648ea7b8a sha1 425223961fdb8c2825796b99bbc5358e51bf9b14 )
+	rom ( name "Invaders(Forward).tzx" size 3697 crc 3ea98bb5 md5 b52fecd042da1349d326508f77d3db33 sha1 a8ae592fe3b4b939b664be00454fb591b004f478 )
+)
+game (
+	name "Invaders (Monochrome) (Bug Byte)"
+	description "Invaders (Monochrome) (Bug Byte)"
+	manufacturer "S. Munnery"
+	rom ( name "invaders(mono).p" size 2373 crc 2840348b md5 1b95516181a57da16f56109cc87cfd94 sha1 1971694d7a009402c065f5d23cec3ad847839232 )
+	rom ( name "Invaders(Mono).tzx" size 2605 crc 80e827f0 md5 186d39211398bdbb5497d1ba89df5ab9 sha1 3aeb0fa4a5c458ace0affc01f528d4b15ee047b8 )
+)
+game (
+	name "Invaders (Re-release) (Bug Byte)"
+	description "Invaders (Re-release) (Bug Byte)"
+	year 1982
+	manufacturer "S. Munnery"
+	rom ( name "invaders(alt).p" size 2373 crc 4a1b632b md5 119058dbc93bb2ac6a7e804a878f03cc sha1 6beb1369d7f96b83092cd84c0e32fe2ad786c2ac )
+	rom ( name "Invaders(Alt).tzx" size 2605 crc e2b37050 md5 8886052187ad052bd05d2cb8e6d2a713 sha1 c5a9f1683d2730eaf40a879c0f5c676b5f718e03 )
+)
+game (
+	name "Invaders (Typed Inlay) (Bug Byte)"
+	description "Invaders (Typed Inlay) (Bug Byte)"
+	year 1981
+	manufacturer "S. Munnery"
+	rom ( name "invaders(typed).p" size 2373 crc eeefd34b md5 f426df7408433e814f04cf3909a5a2f5 sha1 5ff6048270fdd16665eb1b1169f2f026c84a3b24 )
+	rom ( name "Invaders(Typed).tzx" size 2605 crc 4647c030 md5 c6dbced1c948e5322109052583789338 sha1 a3669f5ce7897e144314b0a4ea5e3e1b79cff5ef )
+)
+game (
+	name "Invasion Force (Artic)"
+	description "Invasion Force (Artic)"
+	year 1982
+	manufacturer "Simon Wadsworth"
+	rom ( name "invasionforce.p" size 7658 crc a997ef38 md5 111b625cefae5439236a45013066a7ae sha1 6a3516b9127e8345a56c076990a9ffb7bf5834e7 )
+	rom ( name "InvasionForce.tzx" size 7890 crc 84b20542 md5 c38ec3f7baba880dcb937e9419956a22 sha1 3bf53649fdf8249fdb8a601bb7ae7dbbb38b08de )
+)
+game (
+	name "Invasion Force (International Publishing and Software Inc.)"
+	description "Invasion Force (International Publishing and Software Inc.)"
+	year 1983
+	manufacturer "Simon Wadsworth"
+	rom ( name "invasionforce(ips).p" size 7658 crc eaa1c1ed md5 c38f1c2548052873d8fbff20f67a29dd sha1 39ebceafc98f2a8a7b2b4eb5cb35b4e2a4b34adf )
+	rom ( name "InvasionForce(IPS).tzx" size 7890 crc c7842b97 md5 4c05ebb64d88d13ec859403f5c7f2b1e sha1 3b59f5a004f92d081181834aa59073ba74b47909 )
+)
+game (
+	name "Inventory Control (Data-assette)"
+	description "Inventory Control (Data-assette)"
+	manufacturer "John Powers"
+	rom ( name "inventorycontrol(da).p" size 15941 crc eb911b8b md5 2e9c7b2134665a0fa235764e75cc2957 sha1 4f63db3c39ff4aabb3e0661500095f0c69dab41d )
+	rom ( name "InventoryControl(DA).tzx" size 16175 crc 21d56ec5 md5 bfadca8523ed9926c47c20b04e980289 sha1 390707e52e816a1df284b65ce1fd52e14110a504 )
+)
+game (
+	name "J.D.Arcades (Computer Rentals)"
+	description "J.D.Arcades (Computer Rentals)"
+	year 1982
+	manufacturer "John Davies"
+	rom ( name "jdarcades.p" size 8548 crc e7ea958d md5 e555ef74ec2f6346b82b363c24d97c96 sha1 7d47ec7d6670d7009cf6d059fe50c730e068d891 )
+	rom ( name "JDArcades.tzx" size 8782 crc 6fb5f451 md5 e4ab3d1820711eb5b96dcd106694aa1d sha1 08c17dc95d0a7e8a68fb9b534398d45656e25ea5 )
+)
+game (
+	name "Kasino Kraps (Timex)"
+	description "Kasino Kraps (Timex)"
+	year 1983
+	manufacturer "Gerald Bennett"
+	rom ( name "kasinokraps.p" size 12557 crc f041256f md5 dedab418c1ee0b2e03200acf878164f3 sha1 c782994290da3a40a82433718fb877a59fcd771b )
+	rom ( name "KasinoKraps.tzx" size 12777 crc 7e27ad21 md5 32a434e44b75cfeedf737a25e4d22ae0 sha1 39950e34a01e852c6df5fb06e59dfae019d54e90 )
+)
+game (
+	name "Keyboard Calculator (Timex)"
+	description "Keyboard Calculator (Timex)"
+	year 1982
+	manufacturer "J. Gishen"
+	rom ( name "KeyboardCalculator.tzx" size 6160 crc 56b36255 md5 781d98f620db9510336788eb8ff310ea sha1 064abd828a4d801e1e2029234762f6aadcba008e )
+)
+game (
+	name "Keys To Gondrun (International Publishing and Software Inc.)"
+	description "Keys To Gondrun (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "International Publishing and Software Inc."
+	rom ( name "keystogondrun.p" size 15704 crc f8340d3b md5 aaca5c9eb8ae112eb41d7a3b99e93a6b sha1 639d2eb5931fd7b874d0ca9b1374bce68971ded6 )
+	rom ( name "KeysToGondrun.tzx" size 15928 crc 97e9ac6d md5 9d45dcb3c159ffb5396641c88e7e5196 sha1 38c82913732383ae4fae62dd1be8f5a04927cdfd )
+)
+game (
+	name "Kingdom of Nam (Microgame Simulations)"
+	description "Kingdom of Nam (Microgame Simulations)"
+	year 1981
+	manufacturer "R. Erskine"
+	rom ( name "kingdomofnam.p" size 7958 crc a997242d md5 eccad4f7e6ca9806b1d2976970ee39fd sha1 718235cfddafacfdf7276438614712042488ecf5 )
+	rom ( name "KingdomOfNam.tzx" size 8202 crc ca57c0c9 md5 5d075c2ea9428e0c2d3b09597056d810 sha1 d5c07352365144b1f0c9eb4c89a3f854747b7a90 )
+)
+game (
+	name "Kongs Revenge (Stephen Hartley Computing)"
+	description "Kongs Revenge (Stephen Hartley Computing)"
+	year 1984
+	manufacturer "I. Kendrick"
+	rom ( name "kongsrevenge.p" size 14601 crc daf31c48 md5 a88f23545d67709d83d214efc9344173 sha1 6915c841a5af606e7e0a0198efec07aed4c8cb91 )
+	rom ( name "KongsRevenge.tzx" size 14843 crc cc315aca md5 c82fd9679ee58446a0c54271e2f56287 sha1 c87d1a7f00cca913b0d9bdbe8a8752e82c72fd6c )
+)
+game (
+	name "Krazy Kong (Intercomputer Inc)"
+	description "Krazy Kong (Intercomputer Inc)"
+	year 1983
+	manufacturer "C. P. Cullen"
+	rom ( name "krazykong(inter).p" size 7563 crc ad4fe8ff md5 c1aaf449bdc105ee2ccd74de7ba82ec5 sha1 554d1d5b991c9a221183dd6f6067e41c77746d7b )
+	rom ( name "KrazyKong(Inter).tzx" size 7799 crc d5a3ddd8 md5 b355c229f453610568ab040ea9cebb5e sha1 1e4edf41f7a576a8b68ecfaab4f936ba80460360 )
+)
+game (
+	name "Krazy Kong (PSS)"
+	description "Krazy Kong (PSS)"
+	year 1982
+	manufacturer "C. P. Cullen"
+	rom ( name "krazykong.p" size 8229 crc e5e30579 md5 fea1dd4edf42f770255b5d90d6da9cff sha1 0bbee2723aaa7a2758b5394d2ad269ffc561ede8 )
+	rom ( name "KrazyKong.tzx" size 8465 crc a5dd2afe md5 4df17878870a7bc5b63fa607c8eb4c36 sha1 ac74298badc343b3c81a96fca8bcab1b43faad87 )
+)
+game (
+	name "Labyrinth (Axis)"
+	description "Labyrinth (Axis)"
+	year 1981
+	manufacturer "Axis"
+	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
+	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
+)
+game (
+	name "Labyrinth (Colour Inlay) (Axis)"
+	description "Labyrinth (Colour Inlay) (Axis)"
+	year 1981
+	manufacturer "Axis"
+	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
+	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
+)
+game (
+	name "Language Usage (Timex)"
+	description "Language Usage (Timex)"
+	year 1982
+	manufacturer "Software for Excellence"
+	rom ( name "LanguageUsage.tzx" size 43685 crc f83ba0cd md5 81f643d82c2f273248421f15f4e8f91b sha1 8892aac163feb54128ee568636c905c0cb18e7e5 )
+)
+game (
+	name "Lap Record (Macronics)"
+	description "Lap Record (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "laprecord.p" size 4895 crc 13522b1e md5 4e017f1d09e8cd51b3b3656b5c1efdfa sha1 5091eaf17d8816a7766811f0d57ea54611825670 )
+	rom ( name "LapRecord.tzx" size 5115 crc 4ab33041 md5 075644fa16a629b4b732265c9129998c sha1 28d2a56bc5974bed6e848a495367140893f35eb1 )
+)
+game (
+	name "Lost Island (JRS Software)"
+	description "Lost Island (JRS Software)"
+	year 1982
+	manufacturer "JRS Software"
+	rom ( name "lostisland.p" size 15542 crc c93d1958 md5 f1783d3018e369fe915e919646ab845c sha1 56310e5ea2f0dc1e77c95717e7b5e988c9c0fff9 )
+	rom ( name "LostIsland.tzx" size 15766 crc b0682ddb md5 28ac9145502b4144b038821d63b419e4 sha1 b1bed07dd568166c87352c1700c8e3fb81a43a7b )
+)
+game (
+	name "Lunar Rescue (Mikro-Gen)"
+	description "Lunar Rescue (Mikro-Gen)"
+	manufacturer "K. J. Bezant"
+	rom ( name "lunarrescue.p" size 4657 crc 0ec491ce md5 62d3cd05d6ea6103cb47824c7316135f sha1 810fe42934480bc6967d058f91586cc558bf4bc5 )
+	rom ( name "LunarRescue.tzx" size 4885 crc b63d952a md5 9d99d03e0da02ab1601a4dbe89446bab sha1 620f51472b3313aa14bee80521e5654c05b4c5b6 )
+)
+game (
+	name "Machine Code Test Tool (F. O. Ainley)"
+	description "Machine Code Test Tool (F. O. Ainley)"
+	year 1982
+	manufacturer "F. O. Ainley"
+	rom ( name "machinecodetesttool.p" size 2823 crc 778f13a8 md5 440b350563fa9dd8ac48b7a3d01a27bd sha1 5063e60e26a804e8cb2f210349d9ccef375f3c2e )
+	rom ( name "MachineCodeTestTool.tzx" size 3047 crc e7fc10fc md5 fb5cd1e9564af7fcbda7227b19104342 sha1 9108f1176687353a4b9e0a0eff750478a863d5c2 )
+)
+game (
+	name "Manufacturing Control (Timex)"
+	description "Manufacturing Control (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "manufacturingcontrol.p" size 14780 crc 10e493b2 md5 84384096921e088b18cc9e3eedb3b143 sha1 c603b553fc42d949fed9139cb58d0bde4f3c3d3e )
+	rom ( name "ManufacturingControl.tzx" size 15008 crc fec50d8e md5 38bcf567460a33edb8ff13034834100f sha1 694cfa2652b6134621f5b6a2a189af5b8f1e853b )
+)
+game (
+	name "Marine Rescue (International Publishing and Software Inc.)"
+	description "Marine Rescue (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "International Publishing & Software Inc."
+	rom ( name "marinerescue.p" size 10829 crc d91c71e8 md5 bf106cf05b1e4d7318df3f7c1a7c125c sha1 39af94024ccbbe9262bbf98b8841cb00d258c418 )
+	rom ( name "MarineRescue.tzx" size 11057 crc 60217181 md5 ca6ce91a6aea06ac28859c418daac227 sha1 c0fe4882d84b9fc7503004128975115b5cc355f2 )
+)
+game (
+	name "Math Routines and Fit (Zeta Software)"
+	description "Math Routines and Fit (Zeta Software)"
+	manufacturer "Dr. Walter Diembeck"
+	rom ( name "mathroutinesandfit.p" size 15850 crc ef830293 md5 205efa1a71ba01038cd3bc523f1a9667 sha1 c1a6b8f1c9798fb57faea5ee52dc1bcacee68b1b )
+	rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896de80 md5 ee3e759e69b64248f0e5bd1846d63a76 sha1 aa81c6329174cb096d5690cf4d6456b0e0dbdccc )
+)
+game (
+	name "Maths Invaders (Programs in Education)"
+	description "Maths Invaders (Programs in Education)"
+	rom ( name "mathsinvaders.p" size 7786 crc 27b974ec md5 0e79e0ceebc05771120adc45bebb8fb9 sha1 348d5786fd8b153ea7ef26e7eb0af63a273a9d18 )
+	rom ( name "MathsInvaders.tzx" size 8030 crc 19057596 md5 479d85ee6074fb7e7eccedb399dbc1f2 sha1 4e6e0fc96692a767de539ec97df4b06b30c5af70 )
+)
+game (
+	name "Mazogs (Bug Byte)"
+	description "Mazogs (Bug Byte)"
+	year 1982
+	manufacturer "Don Priestley"
+	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
+	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
+)
+game (
+	name "Mazogs (Gladstone) (Gladstone Electronics)"
+	description "Mazogs (Gladstone) (Gladstone Electronics)"
+	manufacturer "Don Priestley"
+	rom ( name "mazogs(ge).p" size 12942 crc bdab60b2 md5 d8bbd02ade6ac94438547f255c04517b sha1 14ca73f2ae0d621ba17fbc5e0f0e8d9184184347 )
+	rom ( name "Mazogs(GE).tzx" size 13170 crc 5d7dd442 md5 cb162114851f80e1a4a820d4e7e4cc22 sha1 94e2da0938bd44f9c0392e2061e390e69d49d47b )
+)
+game (
+	name "Mazogs (Monochrome) (Bug Byte)"
+	description "Mazogs (Monochrome) (Bug Byte)"
+	year 1981
+	manufacturer "Don Priestley"
+	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
+	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
+)
+game (
+	name "Mazogs (Softsync)"
+	description "Mazogs (Softsync)"
+	year 1982
+	manufacturer "Don Priestley"
+	rom ( name "mazogs(softsync).p" size 12831 crc 60b3c966 md5 acd2a6c8f4340c6f2553449225123cd8 sha1 a8e8494bee216f4054cdb2f34735177108305de8 )
+	rom ( name "Mazogs(Softsync).tzx" size 13059 crc 2c73fa3b md5 c89acd6ec795ffeef1d658836bb0dde3 sha1 56e5e86334cb633863fc2386ffda515ad8c58ea9 )
+)
+game (
+	name "MCoder 11 (PSS)"
+	description "MCoder 11 (PSS)"
+	year 1983
+	manufacturer "PSS"
+	rom ( name "mcoder11.p" size 5713 crc 44b1bbe5 md5 7b5d8eaaaed4ba91ff36b3308126976f sha1 cd400d506c292dfd1946264d8d5518feceb8e0ba )
+	rom ( name "MCoder11.tzx" size 5941 crc 4c0ee232 md5 4e67fb609fa6b32e7b84c3c9713e468f sha1 e4d21864bfbba4e7584fb8d4817494eddebeba52 )
+)
+game (
+	name "MCoder (PSS)"
+	description "MCoder (PSS)"
+	year 1982
+	manufacturer "PSS"
+	rom ( name "mcoder.p" size 3558 crc 7297a09d md5 712640382c22590907acdf151c7c35f3 sha1 48e7bcfb62552fd617af3c4b903b3f52f759db3b )
+	rom ( name "MCoder.tzx" size 3786 crc 3aef6340 md5 3e6a131a6ff49dff552f0e8518686726 sha1 74d2103372c2d6e5d627c9deddba2ed948606c77 )
+)
+game (
+	name "Merchant of Venus (Crystal)"
+	description "Merchant of Venus (Crystal)"
+	year 1983
+	manufacturer "Crystal"
+	rom ( name "merchantofvenus.p" size 16161 crc 51cf1515 md5 f607c834c5f1405f7ff0f0e99af1e934 sha1 4be29a8df43bb849740910a055a8773e4d35a2fd )
+	rom ( name "MerchantOfVenus.tzx" size 16393 crc 5e4a029e md5 76409f6a8710a0231ffc4562a5217465 sha1 95f7628f548dcbfeb169fe3f12baa23e720b6f8c )
+)
+game (
+	name "Meteor Storm (dK'tronics)"
+	description "Meteor Storm (dK'tronics)"
+	year 1982
+	manufacturer "dK'tronics"
+	rom ( name "meteorstorm.p" size 5747 crc 8aed8ff8 md5 16a19477d2b25332dfd44117da71fa78 sha1 1c737a14c4bae0d2af32f28ed9dd2baa4d1dd792 )
+)
+game (
+	name "Meteor Storm (Fast Master) (dK'tronics)"
+	description "Meteor Storm (Fast Master) (dK'tronics)"
+	year 1982
+	manufacturer "dK'tronics"
+	rom ( name "meteorstorm(fastmaster).p" size 5784 crc 83ae249c md5 0bbaafb1a7802dbbbbb03eb1852330e7 sha1 736654e354223e719629101bb94fdaf8a847220c )
+	rom ( name "MeteorStorm(FastMaster).tzx" size 6024 crc 35c2540e md5 4066b1dcfb69b1f9205ed0cb6b6bf35c sha1 e02a6983c28a40ccc70a3fa3edd1dc6dbf176354 )
+)
+game (
+	name "Micro Mouse goes de-bugging (Lothlorien)"
+	description "Micro Mouse goes de-bugging (Lothlorien)"
+	year 1983
+	manufacturer "M. C. Lothlorien"
+	rom ( name "micromouse.p" size 8487 crc 17365457 md5 d0603604ed0847e629eea1ec9e701457 sha1 c4510c08365bb8e873315f98fbbbbc067ec06612 )
+	rom ( name "MicroMouse.tzx" size 8713 crc db8110b5 md5 052bc1c42964e438a69feab1759a255c sha1 012a444ac366224d63daf2bc242ca30b58a0e33a )
+)
+game (
+	name "Mind vs. Machine (2-Bit Software)"
+	description "Mind vs. Machine (2-Bit Software)"
+	year 1982
+	manufacturer "2-Bit Software"
+	rom ( name "MindvsMachine.B.tzx" size 3168 crc c7ac234d md5 bb2ef658c6ffe1da45c34e32dd7a5161 sha1 5bf1942b1696ad670427a5119bac1cbddcac30f0 )
+)
 game (
 	name "Miner Man"
 	description "Miner Man (2011) - 'Play through 60 levels of puzzles, mazes and traps. Each level will present the player with different amount of gems to collect. To collect the gems the player will have to work through the levels avoiding the traps and solving the puzzles.' (taken from the original game)"
 	rom ( name "MinerMan.p" size 15851 crc f84e2f0d md5 692985da7943b89cad06f4571b9a7b2f sha1 54db0c5305f89a629a19e5e107f34e65d2bfbd93 )
-	manufacturer "Bob Smith"
-	year "2011"
 )
-
+game (
+	name "Mixed Game Bag III (Timex)"
+	description "Mixed Game Bag III (Timex)"
+	year 1982
+	manufacturer "M. Orwin"
+	rom ( name "MixedGameBagIII.tzx" size 6939 crc 9115c144 md5 1aa50b1328afe02ce01d69fcee6ee746 sha1 9ad8a4c6321346b904995ac8e9aee31124eb5868 )
+)
+game (
+	name "Money Analyzer 1 (Timex)"
+	description "Money Analyzer 1 (Timex)"
+	year 1982
+	manufacturer "T. J. Software"
+	rom ( name "MoneyAnalyzer1.tzx" size 2508 crc 8b0ecf6c md5 38b90377d5298596fd2d123f2e1bd9c2 sha1 5a223f431b06f01ccd7e30c31d462422409a3c69 )
+)
+game (
+	name "Moniteur Desassembleur (Direco International)"
+	description "Moniteur Desassembleur (Direco International)"
+	year 1982
+	rom ( name "moniteurdesassembleur.p" size 5593 crc 357448ff md5 5635d4860a5b03b9312ea12a87383631 sha1 6b32ff9ce4f9dab7e9e43df50c9dd8264d9cf5b9 )
+	rom ( name "MoniteurDesassembleur.tzx" size 5825 crc e548a0e6 md5 4b422022a5ed280d6bd1f6f74f7b56c5 sha1 f3433d201596f069dff1053a86fc2f293b8e4612 )
+)
+game (
+	name "Monster Mine (Gem Software)"
+	description "Monster Mine (Gem Software)"
+	year 1982
+	manufacturer "Gem Software"
+	rom ( name "monstermine.p" size 10808 crc c0b1f76e md5 951905cd41aa8a43d7cece736a99099e sha1 f5063aff551446d25a9cbd3d7080e5d505d1f66a )
+	rom ( name "MonsterMine.tzx" size 11048 crc ac4bec18 md5 bba503301be95ea4fe4f9e3c45e867c1 sha1 bcbf2d46f2c8b547600f979882968d4a57c5b524 )
+)
+game (
+	name "Morse Reader (JEP Electronics)"
+	description "Morse Reader (JEP Electronics)"
+	manufacturer "JEP Electronics"
+	rom ( name "morsereader.p" size 8827 crc 059ee1f6 md5 fffbf7d1aac3e3bf21f8895a5ea53194 sha1 51ce900cec1c55f91037989da1610dd6b73cbae6 )
+	rom ( name "MorseReader.tzx" size 9055 crc 9fce1af5 md5 f01f1d0b641939493ed663d9703baa5b sha1 debe28ec7e350d9b6431dc6fca6da97513232f02 )
+)
+game (
+	name "Mothership (Sinclair Research)"
+	description "Mothership (Sinclair Research)"
+	year 1982
+	manufacturer "Alan Laity, Softsync"
+	rom ( name "mothership.p" size 9627 crc 7de56c4b md5 33404fcdbd84277061d678ebe4d6dbe3 sha1 55cd6d320281c29978170e22a8286803f0c72049 )
+	rom ( name "Mothership.tzx" size 9863 crc 526e7fa1 md5 bd8246e4a145f366bc9bf23bb45913c1 sha1 05fd66ec3eb2c22df673f2bdaa238faab8ae5fc2 )
+)
+game (
+	name "Mothership (Softsync)"
+	description "Mothership (Softsync)"
+	year 1983
+	manufacturer "Alan Laity"
+	rom ( name "mothership(softsync).p" size 9627 crc 077d1fe8 md5 4b63a2614e5907b002264efea78a41e5 sha1 697ca1d242137e2207a98c70181d02a7895da64d )
+	rom ( name "Mothership(Softsync).tzx" size 9863 crc 28f60c02 md5 b065399ad89b9c5d000a60f7ac971154 sha1 63dec851b552ac48d167ce90deec768f0677d42f )
+)
+game (
+	name "Multifile (Gladstone) (Gladstone Electronics)"
+	description "Multifile (Gladstone) (Gladstone Electronics)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "multifile(ge).p" size 5549 crc d71bf8bc md5 e4806a5d67124ada1f733f0e681cf66b sha1 bab72e5aae3ae98d0d4da03cba691b9e61e32fe6 )
+	rom ( name "Multifile(GE).tzx" size 5783 crc 18343751 md5 b05754895c071d02f191e4d7d588bf59 sha1 d72de512a1adc62cf2de299c2e1ff64ed630316b )
+)
+game (
+	name "Multifile Plus (Gladstone Electronics)"
+	description "Multifile Plus (Gladstone Electronics)"
+	manufacturer "Bug Byte"
+	rom ( name "multifileplus(ge).p" size 7677 crc 6cb1f589 md5 dea427c0ddcdb0e27bdbfa199d903c8f sha1 e036fc55971244c9e2a3b157bd9f527b349dce17 )
+	rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952ff07 md5 80ff32332cb0bda770c476a519b0365a sha1 c2866c2c9430d5aec6ea4eb01d7f04c839b1b30c )
+)
+game (
+	name "Multigraphics 2.3 (Bridge Software)"
+	description "Multigraphics 2.3 (Bridge Software)"
+	year 1981
+	manufacturer "Bridge Software"
+	rom ( name "multigraphics.p" size 14210 crc f55b43e1 md5 7000c83bd3b8b8ee761dffc603b7b90c sha1 256d229a11058bed6f608553fc1d9d081397ae89 )
+	rom ( name "Multigraphics.tzx" size 14452 crc 14dd97d3 md5 3b70eaa4b9c771feed049f6c1e0b798b sha1 7b7bead37db83539393b9bab71c15ed048608d85 )
+)
+game (
+	name "Munchees (Quicksilva)"
+	description "Munchees (Quicksilva)"
+	year 1983
+	manufacturer "A. Laird"
+	rom ( name "munchees.p" size 7545 crc b9365fa1 md5 4d0347c0d394cdf1bbcb10d5553bb34b sha1 7c59c57a62eb0aa7750175020287b913e34aaa19 )
+	rom ( name "Munchees.tzx" size 7777 crc 4da90eed md5 b724025d7778e61dd088a66d0ba7b272 sha1 c64c8336f95030b957f3e6c3aed5be3a2237dbb1 )
+)
+game (
+	name "Muncher (Silversoft)"
+	description "Muncher (Silversoft)"
+	year 1982
+	manufacturer "Silversoft"
+	rom ( name "muncher.p" size 5200 crc cadff742 md5 dba0e8079ab8f60c47b31bdff986e49e sha1 f9fcbbd7d5aac8a8c22bf7e73b87eccb18aedc00 )
+	rom ( name "Muncher.tzx" size 5430 crc 7334ad2a md5 2e1104b8d2d21f6c359477cc66366358 sha1 2d7edcfd205dfbdfe253967fa8dd25711964b00c )
+)
+game (
+	name "Murgatroyds (Collins Computing)"
+	description "Murgatroyds (Collins Computing)"
+	year 1982
+	manufacturer "Collins Computing"
+	rom ( name "murgatroyds.p" size 7097 crc a0130eea md5 4b59af5f517ebeeaeb25db1a85883c5e sha1 6d309ccbe66964b30c9ed418ef8537efd07bc17e )
+	rom ( name "Murgatroyds.tzx" size 7315 crc d35af98d md5 40a6bb5e88b35f7309f76b55c808a7f2 sha1 e9b44dc8dce87e747c15c2bb24dc508f319ddc36 )
+)
+game (
+	name "Music Composer (Memotronic)"
+	description "Music Composer (Memotronic)"
+	manufacturer "Frank Beer and Wolfgang Labus"
+	rom ( name "musiccomposer.p" size 5578 crc b0dcdcca md5 76133648609d8ab9b7b24a418e9ae215 sha1 70a99a384559e1d70e38b2ec5a6dfcac3cfe6ec0 )
+	rom ( name "MusicComposer.tzx" size 5822 crc d0cc5789 md5 8ab416356fb8de668546530c4ab0a890 sha1 bbf95991604eb52b8211d709736cdcde9ac4dc3b )
+)
+game (
+	name "Music Educator 1 (Timex)"
+	description "Music Educator 1 (Timex)"
+	year 1983
+	manufacturer "Tim Rossetti"
+	rom ( name "musiceducator1.p" size 14146 crc b7c34c96 md5 702e4b03957ef8a387a76013d1f1e932 sha1 457b9a66701a0edc6cb5b1c91d84758b64c3a074 )
+	rom ( name "MusicEducator1.tzx" size 14372 crc db66a8dd md5 f1fd3cf9b70bb1e730c0c73c75bf8129 sha1 0ee598ab50535505e8382f93d6f77f158d1e43e4 )
+)
+game (
+	name "Namtir Raiders (Artic)"
+	description "Namtir Raiders (Artic)"
+	year 1982
+	manufacturer "J. Ritman"
+	rom ( name "namtirraiders.p" size 3740 crc 8ba3150e md5 28a7022c5386d46864fec0f0e9516a4f sha1 fb0367a015a4beb3cf6ee00853e84e430ceecc36 )
+	rom ( name "NamtirRaiders.tzx" size 3984 crc e65d10f3 md5 80d72c6b620d287e922279b2a5902e65 sha1 364dd09fac90173806cd1a643b594cb378156a55 )
+)
+game (
+	name "Night Gunner (Digital Integration)"
+	description "Night Gunner (Digital Integration)"
+	year 1982
+	manufacturer "Digital Integration"
+	rom ( name "nightgunner.p" size 5113 crc 8fc7c658 md5 f15a54c0f92cc903b91ce8ed37e7cb88 sha1 9ec875318fa4e35087e65a9cf3b9def0080f3705 )
+	rom ( name "NightGunner.tzx" size 5333 crc ba8bea96 md5 cb630368c6f87f40c3d461f988f005fa sha1 ecd2c009311a97f40eae7102faf426e8572b6f96 )
+)
+game (
+	name "Night Gunner (Softsync)"
+	description "Night Gunner (Softsync)"
+	year 1982
+	manufacturer "Digital Integration"
+	rom ( name "nightgunner(softsync).p" size 5113 crc 77639e65 md5 32cbaf62810ec52668bb663029e893a5 sha1 f3b4ea9743015a0cb2c612a79322663a0e36a25a )
+	rom ( name "NightGunner(Softsync).tzx" size 5333 crc 422fb2ab md5 5fb5e7061c2c292259d4244b2b9847c1 sha1 9bd903833515016e2e6215c068b630223fc0138a )
+)
+game (
+	name "Nightmare Park (Macronics)"
+	description "Nightmare Park (Macronics)"
+	year 1981
+	manufacturer "J. D. S. Cranston"
+	rom ( name "nightmarepark.p" size 11659 crc 28f39976 md5 ace96513fef192cd7197825120d9eb95 sha1 7b6344d8e2c62aa1dc1bebb64107dec51617b402 )
+	rom ( name "NightmarePark.tzx" size 11879 crc 53965b76 md5 42b898fee8207b3a73316056a7bf7eca sha1 86dbca70ae32e736a89c161c7e260e43576da971 )
+)
 game (
 	name "Noir Shapes"
 	description "Noir Shapes (2012) - Move the various shapes into a given space to complete each level, ensuring that none of the tiles overlap at any time. It may sound simple, but with limited room in which to arrange the tiles within things soon start to get claustrophobic..."
 	rom ( name "NoirShapes.p" size 15072 crc 20861b7a md5 b560973a9161f27e2929ce9a26a71fff sha1 5642ddd94d1c6649bc2e01ca112b7d76f376c826 )
-	manufacturer "Bob Smith"
-	year "2012"
 )
-
+game (
+	name "Octopussy (Peaksoft)"
+	description "Octopussy (Peaksoft)"
+	manufacturer "Peaksoft"
+	rom ( name "octopussy.p" size 6090 crc 62265923 md5 4c419dd9a3b3463d331e5c8c2f3d7e6b sha1 ca8c3a27854e51acb3abbb02c5ebb6ae40c628c0 )
+	rom ( name "Octopussy.tzx" size 6308 crc 9d408c0e md5 fa9f1e45071a0b907b6d8fdfc71f0430 sha1 745515410b88f840a33611b15c4e0a31e6b28611 )
+)
 game (
 	name "One Little Ghost"
 	description "One Little Ghost (2012) - Bob's interpretation of Namco's 1980 arcade game 'Pac-Man'."
 	rom ( name "OneLG.p" size 15884 crc c6b562c2 md5 3ed2b203e8ad7aefa659e11fa66fdc62 sha1 7bd65421239915dad4137206c0c7572f31c6ac5a )
-	manufacturer "Bob Smith"
-	year "2012"
 )
-
+game (
+	name "Othello (CDS Micro Systems)"
+	description "Othello (CDS Micro Systems)"
+	manufacturer "CDS Micro Systems"
+	rom ( name "othello.p" size 11655 crc 73457797 md5 ef70888041689cc60b9336201735f725 sha1 4dd7218297d9ef6cfb776decbd2f040a297e1c3e )
+	rom ( name "Othello.tzx" size 11885 crc 09d487fe md5 cfcb326e75dfa9a59a79e05491686dd6 sha1 47c8980d14972b59fab5098667b170169894515d )
+)
+game (
+	name "Paint-Maze (Mikro-Gen)"
+	description "Paint-Maze (Mikro-Gen)"
+	manufacturer "Mikro-Gen"
+	rom ( name "PaintMaze.tzx" size 5086 crc 2eff4b27 md5 23dd48a06ff28c78e8a3f9bf26aa557e sha1 e8519c3eb5b772f13fe374c1c57a15d7d4791887 )
+)
 game (
 	name "Pandemic"
 	description "Pandemic (2014) - 'That is not dead which can eternal lie... in a petri dish' (with apologies to HP Lovecraft) -  The sequel 2010's VIRUS."
 	rom ( name "Pandemic.p" size 15934 crc 273220fa md5 4160c3e5a055e1258aeb500c7a60ffa7 sha1 28afa426e660186a1c1c56d74251b604e25bb2a1 )
-	manufacturer "Bob Smith"
-	year "2014"
 )
-
+game (
+	name "Peloponnesian War (Lothlorien)"
+	description "Peloponnesian War (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "peloponnesianwar.p" size 16121 crc f44dec8b md5 1bc0299b676a7656670585fc0199772c sha1 a3f5b184568ac4ea26ae03f9e737e9fd1d4eac53 )
+	rom ( name "PeloponnesianWar.tzx" size 16341 crc f56e0c9d md5 7a8ab89f6173649c5bbc0a6a9bf4d62d sha1 94ebc1a99152a5441238ad242da19b4c9ccee699 )
+)
+game (
+	name "Pengy (Fawkes Computing)"
+	description "Pengy (Fawkes Computing)"
+	year 1984
+	manufacturer "Fawkes Computing"
+	rom ( name "pengy.p" size 8564 crc f7e0304a md5 cdb3809c3f646129f7decba0dcc0c0ce sha1 19a0d22aca1f1580fac805b570a7bc3ea7ec4d2c )
+	rom ( name "Pengy.tzx" size 8782 crc 85894997 md5 bb2821339af5ebe2f6eb4ccc752f6a55 sha1 27606cf98e27ecc5a6da5da5e36ba5ab9c4fa038 )
+)
+game (
+	name "Pilot (Colour inlay) (Hewson Consultants)"
+	description "Pilot (Colour inlay) (Hewson Consultants)"
+	year 1982
+	manufacturer "Hewson Consultants"
+	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
+	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
+)
+game (
+	name "Pilot (Hewson Consultants)"
+	description "Pilot (Hewson Consultants)"
+	year 1982
+	manufacturer "Hewson Consultants"
+	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
+	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
+)
+game (
+	name "Pilot (New) (Hewson Consultants)"
+	description "Pilot (New) (Hewson Consultants)"
+	year 1982
+	manufacturer "Hewson Consultants"
+	rom ( name "pilot(new).p" size 13051 crc d9519a6e md5 8b5df07010240dcead0141109297547e sha1 8ecb69e390bd24941db252f592f059e327be0db6 )
+	rom ( name "Pilot(New).tzx" size 13271 crc 0bc60aad md5 b3b606add7070b8c774ff1af2b562732 sha1 42e19385766fe586291dee026b49b60f47a9df0f )
+)
+game (
+	name "Pimania (Automata Cartography)"
+	description "Pimania (Automata Cartography)"
+	year 1982
+	manufacturer "Automata"
+	rom ( name "pimania.p" size 15773 crc 351eb08b md5 536e24e5b74ef6be13c44eaebebceea5 sha1 39f717b621452e6c853dc0e0318c01acb5ad45e6 )
+	rom ( name "Pimania.tzx" size 16003 crc 37cfb18d md5 5047a7041130a121e5d4e2d33e7ac1eb sha1 dd537d6ab72a749d1f6071d91748282e2ea2b89f )
+)
+game (
+	name "Pinball (Timex)"
+	description "Pinball (Timex)"
+	year 1982
+	manufacturer "A. H. Laity"
+	rom ( name "pinball.p" size 4668 crc 40b6bef6 md5 1e2905fd9ab4f7f57e6a9d81ddfe2e7c sha1 26c5d56388ae2bdc5f9adc53aa670e427f3f5e68 )
+	rom ( name "Pinball.tzx" size 4898 crc f8452e21 md5 986cc07f307993d0f7a996caa18af0eb sha1 4ff5e7491088e5ebe4c67b4813baa943aaea5164 )
+)
+game (
+	name "Pioneer Trail (Quicksilva)"
+	description "Pioneer Trail (Quicksilva)"
+	year 1983
+	manufacturer "M.Stubbs"
+	rom ( name "pioneertrail.p" size 15462 crc e4ad892d md5 77f604b5f45dc443b41aefe41387f0f5 sha1 33fdc9772de2008cd98e5a55fe0013eaef752fe8 )
+	rom ( name "PioneerTrail.tzx" size 15682 crc ceb55f84 md5 3187c5eb7e83d9020e2aabf3f7ecb5eb sha1 1ff2a193ffda69d2ca542d63334399bcf2301390 )
+)
+game (
+	name "Planetoids (Macronics)"
+	description "Planetoids (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "planetoids.p" size 4909 crc 8a63863a md5 efdb0abdab99edbbf7b0c31281a17a8f sha1 9bca8cf12d888dbbe9b1d8f5a00e8f207cd0a346 )
+	rom ( name "Planetoids.tzx" size 5127 crc 02a6b2ad md5 8715626fa60ffa829018000d02dd3a1c sha1 270765be9b076e4eaa0704eece81137ad2c0ae10 )
+)
+game (
+	name "Portfolio Analysis (Timex)"
+	description "Portfolio Analysis (Timex)"
+	year 1982
+	manufacturer "American Micro Products"
+	rom ( name "portfolioanalysis.p" size 15597 crc b540a618 md5 562cdb1a3e92927a8797312f03c448b6 sha1 26ebccff7160857f8490074a84bfd30c99aca883 )
+	rom ( name "PortfolioAnalysis.tzx" size 15819 crc d7ac34ed md5 0fd3b75c0d622131340a3c1bf3325edf sha1 e92da69a510bddb77ad5fab8e13f70d388ee5878 )
+)
+game (
+	name "Presidents (Timex)"
+	description "Presidents (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "presidents.p" size 5072 crc 61969b67 md5 6b8958911520b13ba8dcba0695d550e6 sha1 ba972c28536586a0c567357dbdcad2e362f45f91 )
+	rom ( name "Presidents.tzx" size 5300 crc 7bb539cf md5 7c4ccc1d49ef865bfd3a4e0babac9f4b sha1 e8ecee650bd89d88c7eb2fb9ec06eda5d5647caa )
+)
+game (
+	name "Print Shop (Cases Computer Simulations)"
+	description "Print Shop (Cases Computer Simulations)"
+	year 1983
+	manufacturer "Cases Computer Simulations"
+	rom ( name "printshop.p" size 14978 crc 5514b638 md5 cd8f4d73855eaef7ed7e81772a29ea3b sha1 cd58bee963702779034bfdbb17a22b8aeeb86c15 )
+	rom ( name "PrintShop.tzx" size 15212 crc da63a78f md5 5df01a04ff5ca4cf0f48939dd76a60fe sha1 6d911ea6f2e1df74f2547fb89c99f240a0e0272b )
+)
+game (
+	name "Printer Programs (Nick Godwin)"
+	description "Printer Programs (Nick Godwin)"
+	year 1984
+	manufacturer "Nick Godwin"
+	rom ( name "PrinterPrograms.tzx" size 20668 crc 11d50d78 md5 dd1ccfe9d8243d306ebb0bda40e351a4 sha1 22a458e45d174f9053a5b96bcdf848fa2afc0e9e )
+)
+game (
+	name "Privateer (Lothlorien)"
+	description "Privateer (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "privateer.p" size 12983 crc 8b4ce0e7 md5 81bd561dded0399d415f1e3c7b4d2419 sha1 b27dec9eaeb5f88581365fb6d5bd20c56e9bd6a9 )
+	rom ( name "Privateer.tzx" size 13217 crc 32e4f2d4 md5 7899a00015cc9b9b791c767d7c540c5e sha1 db608044f7c01b572406ade9481a6aea68995488 )
+)
+game (
+	name "Progmerge (ACS Software)"
+	description "Progmerge (ACS Software)"
+	year 1982
+	manufacturer "ACS Software"
+	rom ( name "progmerge.p" size 5279 crc d3fc7bf8 md5 951f8f1a0652936a3bb3f118c9bcc74e sha1 cde61a0ecb7a1e2f2531cc1743d2caeb746e47de )
+	rom ( name "Progmerge.tzx" size 5513 crc 13313bb9 md5 389d183a481034896e71e0c94603e729 sha1 fef5282a0e6a8937f22398c45187bb0e98e51b27 )
+)
+game (
+	name "Protector (Abacus)"
+	description "Protector (Abacus)"
+	year 1982
+	manufacturer "K. Flynn"
+	rom ( name "protector.p" size 7601 crc 571db599 md5 3c438049fff5dcc3247c530c9d39047e sha1 fa2bdbf6919ee3be7205f9a07db6a2ea1041e579 )
+	rom ( name "Protector.tzx" size 7835 crc 941c0480 md5 4d4c872b5934e61f8bb2064dbf7f122c sha1 750a926049abec9c67f6ade68fc029a068800dc6 )
+)
+game (
+	name "Puckman (Hewson Consultants)"
+	description "Puckman (Hewson Consultants)"
+	year 1981
+	manufacturer "Hewson Consultants"
+	rom ( name "puckman.p" size 10535 crc 23e9839e md5 ca251287c8c980e758d4c497028a24d0 sha1 7571ebdbbd2308fff0653217fe599adb8e702b26 )
+	rom ( name "Puckman.tzx" size 10765 crc 2678c742 md5 46a91fb71da2119df0ce3ac027a7cbb3 sha1 c382093f64ac43318766c4c884854150a1775f2f )
+)
+game (
+	name "Q Save (PSS)"
+	description "Q Save (PSS)"
+	manufacturer "PSS"
+	rom ( name "qsave.p" size 1547 crc a3edaab2 md5 48c37e545eaa01ef260e4b4799dc5992 sha1 fbdc2b3081b1e088ab05129ef8a5376e1378652d )
+)
+game (
+	name "Q Save (Red) (PSS)"
+	description "Q Save (Red) (PSS)"
+	manufacturer "PSS"
+	rom ( name "qsave(red).p" size 1467 crc 7918413a md5 597c8a759af88ca64c2ad2462492887f sha1 46ee323c057848ab62d253662891eae847e449d8 )
+	rom ( name "QSave(Red).tzx" size 1693 crc 28bcfd44 md5 d6db4577ce639ce63b01d3ec351a5cf6 sha1 173946ba09a7b0f085b975d25ddfe6f431541186 )
+)
+game (
+	name "QS Asteroids (Big picture, no text) (Quicksilva)"
+	description "QS Asteroids (Big picture, no text) (Quicksilva)"
+	year 1981
+	manufacturer "Quicksilva"
+	rom ( name "qsasteroids(bp2).p" size 3419 crc b88db752 md5 d5208b3c585a16897aa9488865faed2e sha1 f74fa3e6439f92a3491f2d6cf4c07961f40847f0 )
+	rom ( name "QSAsteroids(BP2).tzx" size 3641 crc c5fcf3db md5 df2760f0a630f8019d417946916fefeb sha1 b39c7484a5cec019727f037a37103e44b37741ec )
+)
+game (
+	name "QS Asteroids (No characters) (Quicksilva)"
+	description "QS Asteroids (No characters) (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsasteroids(nc).p" size 3425 crc 64116f53 md5 cdbf8582fd0eb31c153708960714e98d sha1 52e3612464419dbe622c5c23fa50dce1fab9b4c3 )
+	rom ( name "QSAsteroids(NC).tzx" size 3647 crc 92df0bf9 md5 83a4ed182ca56c6cc560e1f017f536ce sha1 64a0e4aa51c42ddc49ba4a4a26f73fe4fef123fb )
+)
+game (
+	name "QS Defenda (Big picture) (Quicksilva)"
+	description "QS Defenda (Big picture) (Quicksilva)"
+	year 1981
+	manufacturer "Quicksilva"
+	rom ( name "qsdefenda(bp).p" size 1749 crc 18409a9f md5 973e7fa1e1f0ebdfdfac2af2dcf15929 sha1 8e297aec1684fa43cdd5a1f2d8540bfb0b1b74dd )
+	rom ( name "QSDefenda(BP).tzx" size 1971 crc 15b06f98 md5 cc64ebd2a4e4bebc7033f975d33a0d4a sha1 eccd0670138ea0f14de3448536adddc1df5cd57f )
+)
+game (
+	name "QS Defenda (Number) (Quicksilva)"
+	description "QS Defenda (Number) (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
+	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
+)
+game (
+	name "QS Defenda (Quicksilva)"
+	description "QS Defenda (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
+	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
+)
+game (
+	name "QS Invaders (Big picture) (Quicksilva)"
+	description "QS Invaders (Big picture) (Quicksilva)"
+	year 1981
+	manufacturer "Quicksilva"
+	rom ( name "qsinvaders(bp).p" size 7185 crc f855545e md5 72c039832c770144f6abbd7fcc1410d8 sha1 c2ab1cd34875dcd0f23206c5ce2f745169d047c0 )
+	rom ( name "QSInvaders(BP).tzx" size 7407 crc 05b21451 md5 ac31e8ef363def7fb56ebbab76f49db1 sha1 92b476abe309e02a9721ab2db8d927418060338e )
+)
+game (
+	name "QS Invaders (Number) (Quicksilva)"
+	description "QS Invaders (Number) (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
+	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+)
+game (
+	name "QS Invaders (Number, Upside down) (Quicksilva)"
+	description "QS Invaders (Number, Upside down) (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
+	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+)
+game (
+	name "QS Invaders (Quicksilva)"
+	description "QS Invaders (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
+	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+)
+game (
+	name "QS Scramble (Number) (Quicksilva)"
+	description "QS Scramble (Number) (Quicksilva)"
+	year 1982
+	manufacturer "Quicksilva"
+	rom ( name "QSScramble(Alt).tzx" size 6320 crc 30847836 md5 09a4633a93747aeb1bca9e190aeaa14c sha1 7ee4b859c49ee81a670bd629e05ac27177dddb7d )
+)
 game (
 	name "Quack!"
 	description "Quack! (2014) - Bob's interpretation of the mobile game 'Flappy Bird'. Control a duck by tapping any key to make him fly up, and so avoid the oncoming pipes."
 	rom ( name "quack.p" size 8383 crc 01e8d775 md5 66afd32ec050cd1e4dbf657fd4f2089b sha1 d7e40348cc9181d2033c63e17e8fe07589e90c64 )
-	manufacturer "Bob Smith"
-	year "2014"
 )
-
+game (
+	name "Ram Runner (Timex)"
+	description "Ram Runner (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "ramrunner.p" size 12985 crc 1caa4b3e md5 b18437b08fdeff0caca69ea2afae96eb sha1 998860f07b4c60a190883e5bbdfb3ae249c40f1c )
+	rom ( name "RamRunner.tzx" size 13213 crc 9ad7e13f md5 eef86dd226681e5e6cd3db6a7eb2766e sha1 c821a765c4045b8107ff273dac9d211baca717cd )
+)
+game (
+	name "Real Estate Investment Analysis (Timex)"
+	description "Real Estate Investment Analysis (Timex)"
+	year 1982
+	manufacturer "American Micro Products Inc."
+	rom ( name "realestateinvestmentanalysis.p" size 15825 crc edef9f40 md5 5767ad8d9e1ae3f9fedba17514a069e5 sha1 c75505864f9fe3d9842561ec9bde7a4d24cc9d57 )
+	rom ( name "RealEstateInvestmentAnalysis.tzx" size 16047 crc 8373ada1 md5 98459338d5e57be0f9e7721c4bcfd883 sha1 240481eb5e8b45ee3e7d240076819b8e2593c3f0 )
+)
 game (
 	name "Rebound"
 	description "Rebound (2014) - Bob's interpretation of a Breakout / Arkanoid game, with 32 unique levels, 16 ball directions, multiple balls, and power-ups."
 	rom ( name "Rebound.p" size 13897 crc 00721ae3 md5 81ef01732f2f2e4d7fa96fba5984665c sha1 6abc2d4de5bb40aac8f3703e5c33a9ce3a31be75 )
-	manufacturer "Bob Smith"
-	year "2014"
 )
-
+game (
+	name "Red Alert (Softsync)"
+	description "Red Alert (Softsync)"
+	year 1981
+	manufacturer "Quicksilva"
+	rom ( name "redalert.p" size 4004 crc e3f0e0c6 md5 3ee4de96ff92aa764d6a5af1978bf769 sha1 d95c77e1b695af04d6679cdab70ed2ab9caa8f2a )
+	rom ( name "RedAlert.tzx" size 4236 crc 16d48454 md5 4c5e219f57813a8838e43ba6ae791810 sha1 61a4719da9099699143e39713d08c13e381e9216 )
+)
+game (
+	name "Rental Property Manager (Data-assette)"
+	description "Rental Property Manager (Data-assette)"
+	manufacturer "John Powers"
+	rom ( name "rentalpropertymanager.p" size 16109 crc 2316c873 md5 79e94ac3f50f837458eaf07ed4317951 sha1 79194cf5dfca47d67866257dbf2e2f31d8e79272 )
+	rom ( name "RentalPropertyManager.tzx" size 16339 crc 92f8aa70 md5 4b297d59dfa3fd14ee638b35d6f8bc99 sha1 378bb82167e1ee3a4f8ec8a69b2a3612cd2b2810 )
+)
+game (
+	name "Reversi (Artic)"
+	description "Reversi (Artic)"
+	year 1982
+	manufacturer "T. Hughes"
+	rom ( name "reversi(artic).p" size 14726 crc 613dd959 md5 5529e75702832f4c17874d81e49833a2 sha1 89e9591ff6720a374c30a1be117e5b9720fcea98 )
+	rom ( name "Reversi(Artic).tzx" size 14952 crc d5796e37 md5 708f70b98133de0290338c974ae50509 sha1 516f08ceefe2997e183e6f47e774fda4b81d7be3 )
+)
+game (
+	name "Reversi also known as Othello (Sinclair Research)"
+	description "Reversi also known as Othello (Sinclair Research)"
+	year 1982
+	manufacturer "Moi/Games of Skill Ltd"
+	rom ( name "reversi.p" size 6222 crc 9317d6cf md5 496aeef5f2cea222a7223625f990c8f4 sha1 df86a5e30d5e38f37a3ab4e2975515e38bddbb82 )
+	rom ( name "Reversi.tzx" size 6452 crc 01930d80 md5 e33b1e6b4508f5eff9d7f0c873b0c94d sha1 0b09a2d44f3fb3243da9cc46ff161bffe6d8021b )
+)
+game (
+	name "Robbers of the Lost Tomb (Timeworks)"
+	description "Robbers of the Lost Tomb (Timeworks)"
+	year 1982
+	manufacturer "Timeworks"
+	rom ( name "robbersofthelosttomb.p" size 12141 crc 79fcfb44 md5 02209f4889c543a0a43d451743708328 sha1 345fa829ad2f082291c236ec5826aed0e864d8ba )
+	rom ( name "RobbersOfTheLostTomb.tzx" size 12365 crc 700a0975 md5 7d90a419cc9fc490f597993effb7d068 sha1 4e78f00d3529accfdde236c2ef24e43106b5d8d4 )
+)
+game (
+	name "Rocket Man (Software Farm)"
+	description "Rocket Man (Software Farm)"
+	year 1984
+	manufacturer "Software Farm"
+	rom ( name "rocketman.p" size 15327 crc 93fdefb0 md5 2a2606484cf8bbc5bfdfece4b1ab657b sha1 c9bde797ab35e89fe71fe595857b5d1d1d2740fc )
+	rom ( name "RocketMan.tzx" size 15561 crc e34adca9 md5 4ef97704d962703ca65309098356d20b sha1 024909ddf04e7efb22c4e84781aea9ce8e20a877 )
+)
+game (
+	name "Roman Empire (Lothlorien)"
+	description "Roman Empire (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "romanempire.p" size 15108 crc 19ebf247 md5 5c3babff0601a703a4ee3549d7608422 sha1 3629f81c9dff99b9d9bb84ee392f3c3ec345916f )
+	rom ( name "RomanEmpire.tzx" size 15328 crc 5eeef590 md5 a0b4632b0bc95998b687af11df7c769b sha1 38225146a420b541cd425e420b5c21c794fd7486 )
+)
+game (
+	name "RPN Calculator (Zeta Software)"
+	description "RPN Calculator (Zeta Software)"
+	year 1982
+	manufacturer "Dr. Walter Diembeck"
+	rom ( name "rpncalculator.p" size 8282 crc fd66ef0e md5 df81ab32f89accd286bf7cac114db2a4 sha1 cd9f8d264af05fee79132004522eb5049f250650 )
+	rom ( name "RPNCalculator.tzx" size 8504 crc 1609ef0d md5 6943fdf8fb6e3d76ee3c9d119d3cd441 sha1 a6283859ffc5d6390b55803129777fe32b74d627 )
+)
+game (
+	name "Rubik Cube (Alt) (CDS Micro Systems)"
+	description "Rubik Cube (Alt) (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "rubikcube(alt).p" size 14375 crc c163a924 md5 12bcc34945162beb2b494198aea60e23 sha1 8075d277091b180ee535f253daeaf7cd39135069 )
+	rom ( name "RubikCube(Alt).tzx" size 14601 crc 11d010a0 md5 a514d66d19792684ad2f5f8987bb9448 sha1 7996ca3bb737847719bdfc0663483d0906d74282 )
+)
+game (
+	name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+	description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+	year 1982
+	manufacturer "CDS Micro Systems"
+	rom ( name "rubikcube.p" size 15158 crc 8ae261a2 md5 d70593b633e0e6a88a7e919f6f4c95c2 sha1 31426d332e594597879a9c42b259436445e96e4e )
+	rom ( name "RubikCube.tzx" size 15384 crc 580179a6 md5 724cdc2b86991f8710876579f9a16559 sha1 9b1b7f10e2ebfc90b3653dc10ec0ffd0d5a5c552 )
+)
+game (
+	name "Sabotage (Sinclair Research)"
+	description "Sabotage (Sinclair Research)"
+	year 1982
+	manufacturer "Macronics"
+	rom ( name "sabotage.p" size 8852 crc 682b39a0 md5 93a3ac8c7c759d72848470e7bf1595fc sha1 43467cef8ef83457ad6bac424ddd89ab885fed3c )
+	rom ( name "Sabotage.tzx" size 9070 crc 0120fe03 md5 6becdebc9329742a817e1d0068716ded sha1 4d123b512a757fe2e0bfd7ddee111322d8238d9f )
+)
+game (
+	name "Salvo (Orbyte Software)"
+	description "Salvo (Orbyte Software)"
+	manufacturer "A & M Productions"
+	rom ( name "salvo.p" size 15284 crc 202f1a9b md5 009acfc6e76e528f40cc693753e73251 sha1 3bd88ac1e2a1dfca98ad495346e0c65d9936a1a0 )
+	rom ( name "Salvo.tzx" size 15510 crc d9303929 md5 a28b801ff835cd8dccddacf23ed8db1f sha1 706ddd40ffc24ad4fffcef7d8f77889a6a1c1a19 )
+)
+game (
+	name "Samurai Warrior (Lothlorien)"
+	description "Samurai Warrior (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "samuraiwarrior.p" size 15261 crc 6804e38d md5 e268d6c175c8359bc23491aa237c0aa5 sha1 24ac5226d3e646254f00f3ccad7abfde618b346c )
+	rom ( name "SamuraiWarrior.tzx" size 15481 crc 68f13fb0 md5 4e59f61c5a39bf5f8b372ba40a009b07 sha1 a6d7b88718f8ef85e300cb1ba696544a6cb1efcf )
+)
+game (
+	name "Scramble (Colour inlay) (Mikro-Gen)"
+	description "Scramble (Colour inlay) (Mikro-Gen)"
+	manufacturer "Mikro-Gen"
+	rom ( name "scramble(ci).p" size 4455 crc bfc4a5e6 md5 f9ba0ffc3497e3fd978a6894fcf28547 sha1 6add38b04de58597b939f24f35613b6a1b8e2eb5 )
+	rom ( name "Scramble(CI).tzx" size 4693 crc 0ef260a9 md5 de5f9bb0623c40822463ca512f959d06 sha1 338ba99e7d814653800311cd67be49fca764a822 )
+)
+game (
+	name "Scramble (Mikro-Gen)"
+	description "Scramble (Mikro-Gen)"
+	manufacturer "Mikro-Gen"
+	rom ( name "scramble.p" size 4455 crc 6ca59ceb md5 1cace2e4cea14d6f96913f3ed7d7204f sha1 bd6ff916c9a18ea0eda7d21b061670231643e308 )
+	rom ( name "Scramble.tzx" size 4693 crc dd9359a4 md5 8f50b50f065ff824c39209c4680bf2aa sha1 84760e3b08c0e5686c9ace4b23dff5b6187da367 )
+)
+game (
+	name "Screen Kit 1 (Picturesque)"
+	description "Screen Kit 1 (Picturesque)"
+	manufacturer "Picturesque"
+	rom ( name "screenkit1.p" size 1841 crc fe229e5d md5 3dab82c0980eeca3b0f22016ed6dcd16 sha1 84abe2d096d68e01573fe1aea3c3a0646c62e6f5 )
+	rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 ec8d98cec4ac5b718d7ab4c188a99a01 sha1 78351cb1c27587935242bf9bb0f512d07b902625 )
+)
+game (
+	name "Sea Wolf (Newer) (Stephen Hartley Computing)"
+	description "Sea Wolf (Newer) (Stephen Hartley Computing)"
+	year 1983
+	manufacturer "I. R. Bird"
+	rom ( name "seawolf(newer).p" size 9502 crc 3d713295 md5 a437d3a2d8ae59c77cca90bfb572ecd7 sha1 c75d950618d084f3cf1a0903a696d0a9bb8b6121 )
+	rom ( name "SeaWolf(Newer).tzx" size 9732 crc 9e1b515b md5 c71a018235cc635882535a19a256ce7a sha1 b55b9b06c9805d2253335d4f61a6ae43bbe9ffe4 )
+)
+game (
+	name "Sea Wolf (Stephen Hartley Computing)"
+	description "Sea Wolf (Stephen Hartley Computing)"
+	year 1983
+	manufacturer "I. R. Bird"
+	rom ( name "seawolf.p" size 9502 crc 7156979a md5 394000d5a21f5320b63c1145e30f119f sha1 1c221622620508cdd921e0d84c34042fca87d1cc )
+	rom ( name "SeaWolf.tzx" size 9732 crc d23cf454 md5 0fceb5b1ae6ed2721d95f2343f6cdf37 sha1 f0275fe3bc08875e643be9431615b7a7c5ba64ab )
+)
+game (
+	name "Similes Countdown (AVC Software)"
+	description "Similes Countdown (AVC Software)"
+	year 1981
+	manufacturer "K. Jammer and S. Brown"
+	rom ( name "similescountdown.p" size 9899 crc f2f2b554 md5 adce97d888ca6665a5071a5df2759364 sha1 4d0117466c37df6b4fafdc3eff7f75f3aea3aed1 )
+	rom ( name "SimilesCountdown.tzx" size 10151 crc fbbcdef4 md5 e270304c53d20e65b47ef69bd0fefdc8 sha1 7cd764fcbd90d455fb2d31ceec7cda10b08ec8cd )
+)
+game (
+	name "Space Intruders (Hewson Consultants)"
+	description "Space Intruders (Hewson Consultants)"
+	year 1981
+	manufacturer "Hewson Consultants"
+	rom ( name "spaceintruders.p" size 3764 crc 074dc33e md5 6919edc03f14fc6772c089af461624d6 sha1 dfed85eafde74afb2c3237003d73e7fa3fe69837 )
+	rom ( name "SpaceIntruders.tzx" size 4010 crc 88b1156f md5 f15a15be576dc7efdcfd8bdf87faaadf sha1 8aaf24a56fe3cc999ce32ae795ce0bbd7983838f )
+)
+game (
+	name "Space Invaders 3K (Macronics)"
+	description "Space Invaders 3K (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "spaceinvaders3k.p" size 2854 crc f1273575 md5 dd982a212278df38fa34c19b19db4484 sha1 653dd0ba53d7005005fff184ee8d556cb6982a23 )
+	rom ( name "SpaceInvaders3K.tzx" size 3074 crc 69729abd md5 753f7387213896a0dae8e09a4974d2a2 sha1 00bea09a8d43cfd35cb2fb44eff623692811d2a9 )
+)
+game (
+	name "Space Invaders (dK'tronics)"
+	description "Space Invaders (dK'tronics)"
+	year 1981
+	manufacturer "dK'tronics"
+	rom ( name "spaceinvaders(dk).p" size 6645 crc 4c0edb0a md5 7bb4a934ddc0746167e6fac17f71cae4 sha1 1392c3c2ba459fbc67edb18fd96fd617fd8ad167 )
+	rom ( name "SpaceInvaders(dk).tzx" size 6889 crc 720bf20c md5 3d25c73ac6e5c6f48081eb86a5d0e0b3 sha1 e9d543b4f96bbda648c1488a06d2538ed3da3001 )
+)
+game (
+	name "Space Invaders (Mikro-Gen)"
+	description "Space Invaders (Mikro-Gen)"
+	manufacturer "Mikro-Gen"
+	rom ( name "spaceinvaders.p" size 2664 crc e39a90be md5 cce844a181612ad7e32209e73ce42b9c sha1 795cc3740caee56e9af16a52b557d93b968d0cde )
+	rom ( name "SpaceInvaders.tzx" size 2896 crc a345e8db md5 f835a9b2d5dce454a2ddc4caf8175505 sha1 4536f0d2a465a71891803b23d29bc8c54c1b874f )
+)
+game (
+	name "Space Man Apollo (ICT)"
+	description "Space Man Apollo (ICT)"
+	year 1984
+	manufacturer "Iain Thomson"
+	rom ( name "spacemanapollo.p" size 15647 crc 1adf5140 md5 0e91bcac7314fb7d95db8d86cb4920f4 sha1 fd98b6596b28bc0ecda1f3b7aaef526809d3a38e )
+	rom ( name "SpacemanApollo.tzx" size 15875 crc 0fc40716 md5 17291434ca3e09aed13b243f95498b0b sha1 68861a48e02a2d65b717012df38600d96986df97 )
+)
+game (
+	name "Space Mission (Gem Software)"
+	description "Space Mission (Gem Software)"
+	year 1982
+	manufacturer "Gem Software"
+	rom ( name "spacemission.p" size 13365 crc 97df84e4 md5 be00529ebf59e65659d1d658976fa738 sha1 1071d74d173d8f325894f0dbac851e60a15e38b2 )
+	rom ( name "SpaceMission.tzx" size 13607 crc 0dacab8d md5 35ac87605be32557ce38bfbf61f3dbaa sha1 bd92c04a311a49e5846e35528d692ee5e6eb2bcf )
+)
+game (
+	name "Space Trek (Micromega)"
+	description "Space Trek (Micromega)"
+	manufacturer "Micromega"
+	rom ( name "spacetrek.p" size 15395 crc 8c8545b1 md5 eb1db83f22e599c4a8927bdf043d2677 sha1 ff8a32ee7197f3ef632f2cf231cb0ca7cbf1defc )
+	rom ( name "SpaceTrek.tzx" size 15619 crc 081b0787 md5 7a2a66e12f7983634ff1ca0b9b795ded sha1 0e20ed7812a34ad507ec1c1dc23536641c4b9993 )
+)
+game (
+	name "Spacetrek (JRS Software)"
+	description "Spacetrek (JRS Software)"
+	manufacturer "JRS Software"
+	rom ( name "spacetrek(jrs).p" size 332 crc c2f526df md5 a3b4c8c194ffd9b3df6ab21f57bcc6cc sha1 6b5c61147a38082825fc71a003937e5f07f59f02 )
+	rom ( name "Spacetrek(JRS).tzx" size 550 crc d62cc02f md5 17aaf306f2269d03004c5866d47af928 sha1 1b0c8177a41aea9aa40f5698280c86e505151349 )
+)
+game (
+	name "Spelling Bee (Timex)"
+	description "Spelling Bee (Timex)"
+	year 1983
+	manufacturer "Russell Klein"
+	rom ( name "SpellingBee.tzx" size 48415 crc a5987f22 md5 75f46b5eac8f50943ebe3c185da8a98b sha1 d992d921483b59b85ae68bdfa6e44d1c9c5068cc )
+)
+game (
+	name "Star Trek (Bug Byte)"
+	description "Star Trek (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "startrek.p" size 10018 crc a3004740 md5 33bacef251164137a75e7b9a7164ada0 sha1 7a890295c0b822938db6e8dc70bb68d669bf9051 )
+	rom ( name "StarTrek.tzx" size 10250 crc c8107516 md5 db8fba7fba8544b74b63c53519163be7 sha1 3e0f7d137f9572f756ba9edc5c6835fa9367be81 )
+)
+game (
+	name "Star Trek (Macronics)"
+	description "Star Trek (Macronics)"
+	year 1981
+	manufacturer "Macronics"
+	rom ( name "startrek(macronics).p" size 15869 crc e33d9286 md5 dac4c635719e0a8a0b7d55cc18f2e6a6 sha1 2f7d41853aa556ee5197a54e03e405286884343d )
+	rom ( name "StarTrek(Macronics).tzx" size 16091 crc 171e0b56 md5 9f7ef6572bf3d71c53b3ef64053a0715 sha1 5a25a295fc011e37b8941634ad32746b9d626d48 )
+)
+game (
+	name "Star Trek (Typed Inlay) (Bug Byte)"
+	description "Star Trek (Typed Inlay) (Bug Byte)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "startrek(typed).p" size 10018 crc 2749661e md5 9e9f60d7e165323899d49206285d9c3a sha1 f289f9958df4c2a7f811e36920fa4b7c74bc505c )
+	rom ( name "StarTrek(Typed).tzx" size 10250 crc 4c595448 md5 c7d23895712792195672678584e5d250 sha1 d6286120a5acc82d974f76e381f3382fe0c55be8 )
+)
+game (
+	name "Starquest (International Publishing and Software Inc.)"
+	description "Starquest (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Starquest(IPS).tzx" size 17893 crc 0375bd08 md5 7237e3d312cdecfa235a945cd88b3aef sha1 fa7a242596852d6aa1c2ff15142ea2f1ed6d4b1f )
+)
+game (
+	name "Starquest (Pixel Productions)"
+	description "Starquest (Pixel Productions)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Starquest.2.Starquest.tzx" size 16209 crc 85bfc2b5 md5 7602a6da23e1e058b4ef39ac1b1d29cd sha1 f0d5783909ca9a5954ecd71854f4f9aaa57d6619 )
+	rom ( name "starquest.p" size 15989 crc fb070bd6 md5 73407dfbdae230f813ee47ee62747a4f sha1 6171f22250e4bfaf347b85f1e0cfeca5312dddae )
+)
+game (
+	name "States and Capitals (Timex)"
+	description "States and Capitals (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "statesandcapitals.p" size 11310 crc d0be9818 md5 bedb20f535283c3d59eb0990a07690af sha1 509778144c3918ce04f64a5d723d17f7cacd9719 )
+	rom ( name "StatesAndCapitals.tzx" size 11538 crc c70fa5a4 md5 a2fad8976a643ea58281ae9c6276123a sha1 99551d3bb7ad39b7f55be16973af29dc7425e9e3 )
+)
+game (
+	name "Statistics (Timex)"
+	description "Statistics (Timex)"
+	year 1982
+	manufacturer "R. Daniel"
+	rom ( name "Statistics.tzx" size 4852 crc 22eb02c8 md5 0eb9db5c0720be88d236a198c94797d4 sha1 494389e8ad0a8c8adb4a7fa17c91464a78d555e2 )
+)
+game (
+	name "Statistics (Zeta Software)"
+	description "Statistics (Zeta Software)"
+	manufacturer "Dr. Walter Diembeck"
+	rom ( name "statistics(zeta).p" size 13376 crc 9204f603 md5 f82de91f3b217e98a74152e96ab3856b sha1 5df7ca4145a22cc7f730aac13fe8835c40669321 )
+	rom ( name "Statistics(Zeta).tzx" size 13600 crc c0b4f14a md5 2b944e3bf6f17648919c3591b7b9905a sha1 7f13b230064429ab366f0816b43d683085d0bf62 )
+)
+game (
+	name "Stock Car (Informatique Service)"
+	description "Stock Car (Informatique Service)"
+	year 1984
+	rom ( name "stockcar.p" size 8216 crc 41224d6b md5 c7549cd5dfc22bd438a16d6ffeb29b18 sha1 e70d50de2f51597bc74a50bdb25a34bf6b059888 )
+	rom ( name "StockCar.tzx" size 8450 crc fedbbc78 md5 cd54361859d4d5ae1e4290c8c5db8063 sha1 3604d2ff3b9de27e45cb691131b98be09ba3c65b )
+)
+game (
+	name "Stock Market Tech. Analysis 1 (Timex)"
+	description "Stock Market Tech. Analysis 1 (Timex)"
+	year 1982
+	manufacturer "T. H. Nooter"
+	rom ( name "stockmarkettechanalysis1.p" size 16177 crc 0ee43e40 md5 23d4292a790d7120376375574118136b sha1 6d8fe3f2bf6b8171af5a30ec199f6ec5f8c31c30 )
+	rom ( name "StockMarketTechAnalysis1.tzx" size 16405 crc 40a9b729 md5 bb445169bd552aa1beff7b3221856965 sha1 0d23879da55a4e5cbd7a8b482d010fdcb21e06f6 )
+)
+game (
+	name "Stock-Market (Video Software)"
+	description "Stock-Market (Video Software)"
+	year 1981
+	manufacturer "Video Software"
+	rom ( name "StockMarket.A.tzx" size 11978 crc 440cc0e5 md5 cad4ab9c37b2db19ee7950cdfbe71490 sha1 849c2761901e9210f101500e5603d38b90e55a8c )
+	rom ( name "stockmarket.p" size 11738 crc d6f22d69 md5 3c4e77adf07396603240c9225499245d sha1 a71ff5fcc069c95e0e0ca480e78a724ea73fcf00 )
+)
+game (
+	name "Strategy Football (Timex)"
+	description "Strategy Football (Timex)"
+	year 1983
+	manufacturer "Gerald Bennett"
+	rom ( name "strategyfootball.p" size 15249 crc 903db439 md5 23b460ac48b647e5f5d2029a62c3a27a sha1 51e03ad187ae202e999e2b391e9fe82d4a301d5a )
+	rom ( name "StrategyFootball.tzx" size 15469 crc 432f9356 md5 9ce1d8687fa6ec86c44ceb48f5f0c4bd sha1 4add01b5f9e3ddf8f19a686ad91385d4dece1bbd )
+)
+game (
+	name "Subspace Striker (International Publishing and Software Inc.)"
+	description "Subspace Striker (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "SubspaceStriker(IPS).tzx" size 17446 crc b3c93f34 md5 7d123fe1a0f6430b7a8492483e2feeb6 sha1 4a0d2d26033bfb0b0d67248b8b2ae1fa5f423dc4 )
+)
+game (
+	name "Super Chess (CP Software)"
+	description "Super Chess (CP Software)"
+	year 1982
+	manufacturer "CP Software"
+	rom ( name "superchess.p" size 16060 crc 650317b6 md5 abfb385e22165912beadca3377e4a6b2 sha1 324f41e92e9c6d5ea06792238b9374eb2340919f )
+	rom ( name "SuperChess.tzx" size 16296 crc dad51d68 md5 50316e46482e309565e8bb584190f3ed sha1 ce79c0b548bb98118e1725c82396887e01aea430 )
+)
+game (
+	name "Super Chess (Softsync)"
+	description "Super Chess (Softsync)"
+	year 1982
+	manufacturer "CP Software"
+	rom ( name "superchess(softsync).p" size 16060 crc 026568f8 md5 3834752bc2c52e38631f234a1390810b sha1 a91df04216af0ce22b85c6a9bfa8c523e97b7da2 )
+	rom ( name "SuperChess(Softsync).tzx" size 16296 crc bdb36226 md5 5cfb66aefd5c74f85443d1a89d420410 sha1 5dda6654a11c6f0afa5dcb9d7f128667359a6954 )
+)
+game (
+	name "Super Invaders (Bridge Software)"
+	description "Super Invaders (Bridge Software)"
+	year 1982
+	manufacturer "Bridge Software"
+	rom ( name "superinvaders.p" size 12317 crc 94f95161 md5 4f2f2556ab2020046b3b864e1ffdf218 sha1 5bf9ccc9a39a47095143f0506aa778a1be11c341 )
+	rom ( name "SuperInvaders.tzx" size 12541 crc f662bd98 md5 b4bf9dff58752eb60ffd48d6af234720 sha1 3d8c7a7f290d9c792ea7263957dcdaa14cd02c93 )
+)
+game (
+	name "Super Invasion (Softsync)"
+	description "Super Invasion (Softsync)"
+	year 1981
+	manufacturer "Beam Software"
+	rom ( name "superinvasion.p" size 896 crc 54df2bd2 md5 c65906f94fc9cef39c32bbdf56cd1b20 sha1 3c6a9ce5d9785c2a51802a21e666b01af73e0c8e )
+	rom ( name "SuperInvasion.tzx" size 1124 crc cc59f451 md5 dd3904d9a8d535358bebc9affcf11854 sha1 447855ab4bd695a574a93ff9fab09d65258438a5 )
+)
+game (
+	name "Super Math (Timex)"
+	description "Super Math (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "supermath.p" size 8075 crc 1f288f07 md5 5d4125044a0954ea23754d036920a1e7 sha1 4373cf521b219edb88a527454e97080a27344a72 )
+	rom ( name "SuperMath.tzx" size 8299 crc 21eb7b78 md5 1278409cd4aef861297f630f88665c5f sha1 3f30feead9537bf39da7d83175a5a0cc3dcf0a72 )
+)
+game (
+	name "Super Nine (Romik Software)"
+	description "Super Nine (Romik Software)"
+	year 1982
+	manufacturer "Romik Software"
+	rom ( name "SuperNine.tzx" size 6872 crc e8b39d87 md5 5c6a25cd318de3f362261214003c32f1 sha1 5d3cb094e65d4bd9c412f4b6fc18afcc768e6f41 )
+)
+game (
+	name "Super Programs 8 (ICL)"
+	description "Super Programs 8 (ICL)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
+	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
+)
+game (
+	name "Super Programs 8 (Sinclair Black) (ICL)"
+	description "Super Programs 8 (Sinclair Black) (ICL)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
+	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
+)
+game (
+	name "Super Programs 8 (Sinclair Research)"
+	description "Super Programs 8 (Sinclair Research)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "superprograms8.p" size 14974 crc b876fa33 md5 6d3374dc7edbfd66f4d48b6140c17c11 sha1 cc2aa503a948d62d0a40fb29d0c628a5e4ea3632 )
+	rom ( name "SuperPrograms8.tzx" size 15192 crc 2aa20758 md5 545c084c45b5188079167da9f1acb304 sha1 de665ebe1949e077934ed6f0961d525f274f3d6e )
+)
+game (
+	name "Super Scramble (Software Farm)"
+	description "Super Scramble (Software Farm)"
+	year 1982
+	manufacturer "Software Farm"
+	rom ( name "superscramble.p" size 9068 crc 29c5c5d5 md5 8846ef2a3955e7637f72b13d0a8405b2 sha1 ab1e6fae6ba522c9cc9363ddb75c35a794ffdfd2 )
+	rom ( name "SuperScramble.tzx" size 9312 crc 5f11c06c md5 579e55d4adf1d3ee050bfb59abab6167 sha1 aa22bb6ff4c10b8279f2c1e568db7b9ae5158ca6 )
+)
+game (
+	name "Supermaze (Timex)"
+	description "Supermaze (Timex)"
+	year 1982
+	manufacturer "Greg Harvey"
+	rom ( name "supermaze.p" size 16170 crc c58f309b md5 2684494519118b0c23b94ab177ed694e sha1 b36c2eaff62752137c75855e7686a90c58127906 )
+	rom ( name "Supermaze.tzx" size 16394 crc 6e93ce7f md5 225ef6ba2e2b9788dbeba444b5fc60ed sha1 f85d7522e9cd2bf3cbdc3c05493423d7afad482b )
+)
+game (
+	name "Tables Countdown (AVC Software)"
+	description "Tables Countdown (AVC Software)"
+	year 1981
+	manufacturer "K. Jammer and C. Deeson"
+	rom ( name "tablescountdown.p" size 8947 crc e3b0d8d8 md5 b71d10dcec0d99531fb8d2fb777751a0 sha1 1713feb2d1fbdf6d3712e10e2f0291a6bce813c4 )
+	rom ( name "TablesCountdown.tzx" size 9197 crc 59bd7de7 md5 8fec27b406d4041d3fb99784f7318f08 sha1 71d4f85478e2eb9016bab2fd0fac0107a7fccdea )
+)
+game (
+	name "Tai (PSS)"
+	description "Tai (PSS)"
+	year 1982
+	manufacturer "PSS"
+	rom ( name "tai.p" size 14015 crc c7869e9e md5 17e769ceca4301beafb8c1547e62a326 sha1 7a44314234cffd9fff42c90a46be0db954e63352 )
+	rom ( name "Tai.tzx" size 14237 crc 3a1351f8 md5 2d7f98eca4bd7efe614ca55b6eb4fde3 sha1 fd0a3ceac8ce8540e13c7e6af6f547a2feff5d8a )
+)
+game (
+	name "Talkback (M. W. F. Ringrose)"
+	description "Talkback (M. W. F. Ringrose)"
+	year 1983
+	manufacturer "M. W. F. Ringrose"
+	rom ( name "Talkback.tzx" size 12740 crc 36724d18 md5 6caa20b159f6e66bec947d4a901862dd sha1 6b32ff6dd4930ad62cadb59b3c4ecdb6eb4a2654 )
+)
+game (
+	name "Tapebook 50 1K (Control Technology)"
+	description "Tapebook 50 1K (Control Technology)"
+	manufacturer "Control Technology"
+	rom ( name "TapeBook50.tzx" size 37005 crc d882bccd md5 05b0b6c39c1a331e9d4592944f5fcf03 sha1 0d1b30d4d024147c9489d56e0519f9f60bf75cbd )
+)
+game (
+	name "Tarot (Timex)"
+	description "Tarot (Timex)"
+	year 1983
+	manufacturer "Computer Phood"
+	rom ( name "Tarot.tzx" size 29510 crc 5c63c324 md5 35525dae43101ab654360464227dfc37 sha1 81f1ab607044fd2b44c1163a0cb317dc1727d0a4 )
+)
+game (
+	name "Tasword (Tasman Software)"
+	description "Tasword (Tasman Software)"
+	year 1982
+	manufacturer "Tasman Software"
+	rom ( name "tasword.p" size 5339 crc d2cd3934 md5 dd0169e3a06413005f30670f959d56d4 sha1 9dd68379eb1079ceb6b3a106cbc9839a2df9ad30 )
+	rom ( name "Tasword.tzx" size 5569 crc 9b77040a md5 321945f0628d33e073ae1c306d2ead5a sha1 100be588ad785f012f513e8043c323348b5e44ed )
+)
+game (
+	name "Tempest (Mikro-Gen)"
+	description "Tempest (Mikro-Gen)"
+	manufacturer "S. P. Kelly"
+	rom ( name "tempest.p" size 3291 crc f760afba md5 44309dc8b4e242a1e08dfad3f4d590ba sha1 8e4c160df4ec5905f38a922e8e1403d984c92fe4 )
+	rom ( name "Tempest.tzx" size 3521 crc 5cca0ded md5 09bdea36a433f0a3f5fe8b8bcc8e0aa3 sha1 a4cfd1f82d0e4d255ae3b54a54f30a6cb96ce4f9 )
+)
+game (
+	name "Ten 1K Games (Computer Rentals)"
+	description "Ten 1K Games (Computer Rentals)"
+	year 1983
+	manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
+	rom ( name "Ten1KGames.tzx" size 7545 crc c724fd4a md5 60cccfa8c4852f55d0eeda74524c0ca0 sha1 589c68041f90a46fb8c18118c0889c6b8f91f0ca )
+)
+game (
+	name "The Budgeter (Timex)"
+	description "The Budgeter (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "budgeterthe.p" size 7421 crc 8d3b6fc8 md5 f8f70240fd3ce11eda2d349f26d760d9 sha1 c2d31635238b2d581c1d8e4c7ed0565933275b1d )
+	rom ( name "BudgeterThe.tzx" size 7653 crc 5ea30258 md5 ab5775378af88aaf6fd6b6e653f00318 sha1 936a4bdf69507c24b8a634c94065548a3757fac9 )
+)
+game (
+	name "The Carpooler (Timex)"
+	description "The Carpooler (Timex)"
+	manufacturer "Timex"
+	rom ( name "carpoolerthe.p" size 14277 crc 0d8abcac md5 068be6e28af97837ffbb6d292930b6d7 sha1 992b08b7fc5bc7d0d891459fbcebb078ba9d2649 )
+	rom ( name "CarpoolerThe.tzx" size 14507 crc d8258cef md5 9f1a67808e8506b0df3c66bf00568caf sha1 cafbb78bf77f88c0ffb29e6c2a92666899149c8e )
+)
+game (
+	name "The Challenger 1 (Timex)"
+	description "The Challenger 1 (Timex)"
+	year 1982
+	manufacturer "R. Fowkes"
+	rom ( name "Challenger1The.tzx" size 4178 crc a01b37e4 md5 ca1d005637983ed5618c1bfd4b9bb08d sha1 5b9809a27911e43d8fb882a60da3752fe202bc27 )
+)
+game (
+	name "The Checkbook Manager (Timex)"
+	description "The Checkbook Manager (Timex)"
+	year 1982
+	manufacturer "John Heaney"
+	rom ( name "checkbookmanagerthe.p" size 13483 crc b9446d9b md5 6e610dca9691a1fc82c89a5ba4a4574d sha1 5a12849ce4be86742c393306023fbf2fb081ca6a )
+	rom ( name "CheckbookManagerThe.tzx" size 13713 crc b32eaa12 md5 59cd50185f32789958737b3eac99c64b sha1 d1b150fee25332715af8115604d8063e5a71b77d )
+)
+game (
+	name "The Coupon Manager (Timex)"
+	description "The Coupon Manager (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "couponmanagerthe.p" size 15892 crc d4803e75 md5 ae154df5fad396df2c60a12ff7275328 sha1 e6f50fcc128863cd06428a20a731b0cdb1b76379 )
+)
+game (
+	name "The Cube Game (Timex)"
+	description "The Cube Game (Timex)"
+	year 1982
+	manufacturer "John Heaney"
+	rom ( name "cubegamethe.p" size 13490 crc 5b814ea8 md5 46141c523cf55f37ad18594d434c118e sha1 c30033cd7773cf740f517b3e5c8fd7b1bfe593da )
+	rom ( name "CubeGameThe.tzx" size 13714 crc c87bea16 md5 e7e0b000b8fce72a25f358b4b5f2478e sha1 dbf04e07ff5ed808df032c66191f79d0c96488a5 )
+)
+game (
+	name "The Damsel and the Beast (Bug Byte)"
+	description "The Damsel and the Beast (Bug Byte)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "damselandthebeastthe.p" size 10200 crc e572e012 md5 a4ba6fb14be2c6841565dffc496d8c18 sha1 15033d3454985a1ce45289bb33296791ab3332aa )
+	rom ( name "DamselAndTheBeastThe.tzx" size 10464 crc b34252c8 md5 d055c7009157dcf01dc9689d414dbafa sha1 574392a27b8328ec82121e1c666e2c3411f34342 )
+)
+game (
+	name "The Electronic Checkbook (Timeworks)"
+	description "The Electronic Checkbook (Timeworks)"
+	year 1982
+	manufacturer "Timeworks"
+	rom ( name "electroniccheckbookthe.p" size 16162 crc 75097784 md5 cdd6ea720f382f5dc8f2c971a53e3e2f sha1 a2ace5b2b1bf45c5dbd0ebf2cbd47934dc668787 )
+	rom ( name "ElectronicCheckbookThe.tzx" size 16382 crc bc3ed36d md5 c0f35b0fcef5474812364c0ea6cdcf2e sha1 3791720c3974c31c322b9d1e6a6281de6e6bcfcd )
+)
+game (
+	name "The Fast One (Campbell Systems)"
+	description "The Fast One (Campbell Systems)"
+	manufacturer "Campbell Systems"
+	rom ( name "FastOne(Green).tzx" size 9837 crc 3c57d2f2 md5 24bfe29d78ac664aa6b367ef983c590d sha1 c31f2892ea9145cdab6ef5f21cd126ab9d079036 )
+)
+game (
+	name "The Flight Simulator (Timex)"
+	description "The Flight Simulator (Timex)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
+	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+)
+game (
+	name "The Gambler (Timex)"
+	description "The Gambler (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "GamblerThe.tzx" size 19202 crc e05a3062 md5 ea6c404af8fc06091341e038643a85a6 sha1 61da0728b3850a4235d13b1a71e7bb0e339fac63 )
+)
+game (
+	name "The Gauntlet (Colourmatic)"
+	description "The Gauntlet (Colourmatic)"
+	year 1982
+	manufacturer "Colourmatic"
+	rom ( name "gauntletthe.p" size 14411 crc ae7d6fec md5 b0f5118cdb2d11510ae8a9f6cd735225 sha1 4b1ad35595a0ddd772a3facc1f0c57499030d69a )
+	rom ( name "GauntletThe.tzx" size 14643 crc 7de2e0a3 md5 90c561d24d267dd43e349eed180fe51d sha1 49e714e58e9725925b28f8e17d90c708961064b5 )
+)
+game (
+	name "The Gauntlet (PSS) (PSS)"
+	description "The Gauntlet (PSS) (PSS)"
+	year 1984
+	manufacturer "Colourmatic"
+	rom ( name "gauntletthe(pss).p" size 14561 crc f8f47bbf md5 c0f5783184d967260c7d8e4a0b027850 sha1 27b343c7b034563ff4c5218ae6ffa8e190b7313f )
+	rom ( name "GauntletThe(PSS).tzx" size 14793 crc 076726dd md5 f4ad5284a8d7eca0e7e7e564131b3b6b sha1 3756c65ac420104c97a01317cdf156c2f412a2df )
+)
+game (
+	name "The Home Asset Manager (Timex)"
+	description "The Home Asset Manager (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "homeassetmanagerthe.p" size 14886 crc 20b3e57e md5 9b8cb2a6f3192db3dd54c6de1ab895dc sha1 2bfd33290ac86115bbd77e00ca1617f3aab588ea )
+	rom ( name "HomeAssetManagerThe.tzx" size 15112 crc fd728104 md5 9ead11c52ed50477589a292313faa4b9 sha1 e19508787e6ede4ec4323df540dd7516b49b295d )
+)
+game (
+	name "The Home Improvement Planner (Timex)"
+	description "The Home Improvement Planner (Timex)"
+	year 1982
+	manufacturer "K. Frink"
+	rom ( name "homeimprovementplannerthe.p" size 15647 crc f3a473a6 md5 d966246149ab479d02fe07debb61fcd5 sha1 3536d7cd6538e0ce71b00cb9d8166303114d769d )
+	rom ( name "HomeImprovementPlannerThe.tzx" size 15871 crc 4e4df58c md5 15d4996825631a65404bcbebb7358e09 sha1 45e98db0f02643a37ed71b86a85042a331b9aac1 )
+)
+game (
+	name "The IRA Planner (Timex)"
+	description "The IRA Planner (Timex)"
+	year 1982
+	manufacturer "Vincent H. Chase"
+	rom ( name "IRAPlannerThe.tzx" size 16247 crc ad9f1b1c md5 73d76e80fe78e640708645b14e6dac88 sha1 74f585b9673b45307f59019f5d03e324ffedfb8c )
+)
+game (
+	name "The Knight's Quest (Phipps Associates)"
+	description "The Knight's Quest (Phipps Associates)"
+	year 1983
+	manufacturer "Mike Farley"
+	rom ( name "KnightsQuest.tzx" size 52909 crc 2bcedb3f md5 bb390c8d2bd1ced32c6e0a739daecdb3 sha1 ce182bf32766964ca43066727475eadbaa6a8d1a )
+)
+game (
+	name "The List Manager (Timex)"
+	description "The List Manager (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "ListManagerThe.tzx" size 29918 crc 9df64f46 md5 7994115109d17648490efb35403448b0 sha1 f3fed91b2947d49a6d85c26797f46366ba614769 )
+)
+game (
+	name "The Loan/Mortgage Amortizer (Timex)"
+	description "The Loan/Mortgage Amortizer (Timex)"
+	year 1982
+	manufacturer "T. J. Software"
+	rom ( name "loanmortgageamortizerthe.p" size 10332 crc 08257da4 md5 418e25313141160cd04d7ac8693b5784 sha1 731aaa3f99ed2aa3f71d86858037f37c4b7af86b )
+	rom ( name "LoanMortgageAmortizerThe.tzx" size 10564 crc 8fd28637 md5 b0bf87937e33697f07d9b3d62d436e36 sha1 60988beeefb18dd293f49a3f91c6487d6245a554 )
+)
+game (
+	name "The Oracle's Cave (Doric Computer Systems)"
+	description "The Oracle's Cave (Doric Computer Systems)"
+	year 1981
+	manufacturer "C. T. Dorrel"
+	rom ( name "oraclescavethe.p" size 15953 crc 6135daad md5 01f7597a8eecf63967921a7dc63ff23e sha1 9358857b5b1be76ee495a089e07cd61bc44c6f48 )
+	rom ( name "OraclesCaveThe.tzx" size 16181 crc dea5489a md5 e148ddc58ccce3fc4f32be9b8abc2b63 sha1 752bb718f14e0a7e9da87fa958ccd0e366813a34 )
+)
+game (
+	name "The Stamp Collector (Timex)"
+	description "The Stamp Collector (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "stampcollectorthe.p" size 14449 crc 2a38e112 md5 9329dee03b6620d5000dd3ffc9643068 sha1 69daaab88aec472f12910bb0c3b56c188b5c05ad )
+	rom ( name "StampCollectorThe.tzx" size 14675 crc 702011b4 md5 a207294c88268520101a8b277fc1b882 sha1 e44f8118a5ef3c7ffc55a46d476cdb0f516179ce )
+)
+game (
+	name "The Starter (Timex)"
+	description "The Starter (Timex)"
+	year 1981
+	manufacturer "Sinclair"
+	rom ( name "Starter.tzx" size 2613 crc 00cb3c24 md5 d4de1b915c3a27215ae0bf6bfc60aa91 sha1 c2be276cf0f988df20707105f0fb5d6380d8e357 )
+)
+game (
+	name "The Stock Option Analyzer (Timex)"
+	description "The Stock Option Analyzer (Timex)"
+	year 1982
+	manufacturer "Timex"
+	rom ( name "stockoptionanalyzerthe.p" size 5533 crc 6a11fef8 md5 5172731b04549ea7e6fd487fcf0b2497 sha1 1fd0599c4cb2f3ec072d2f858f844eaac0b3ca12 )
+	rom ( name "StockOptionAnalyzerThe.tzx" size 5763 crc b829c9c3 md5 78ded4a1d1170ea521dff3ac3f302cca sha1 7691ee6f0ac6a103168684ac3cde78ec128c5e68 )
+)
+game (
+	name "Tomb of Dracula (Colour Inlay) (Felix Software)"
+	description "Tomb of Dracula (Colour Inlay) (Felix Software)"
+	year 1982
+	manufacturer "Felix Software"
+	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
+	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
+)
+game (
+	name "Tomb of Dracula (Moviedrome Video)"
+	description "Tomb of Dracula (Moviedrome Video)"
+	manufacturer "Moviedrome Video"
+	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
+	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
+)
+game (
+	name "Toolkit (Artic)"
+	description "Toolkit (Artic)"
+	manufacturer "Artic"
+	rom ( name "toolkit(artic).p" size 3582 crc d331e275 md5 19c29072c4cf201f0c6d80a34c487e1a sha1 1076da4a02f3e667d86ef0d40e644103768e71ed )
+	rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743b221 md5 7b527b5afdb2c55d5a0135b6faa68f98 sha1 049169deb7c4c760d79dd66fdf49172d5a77d776 )
+	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
+	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
+)
+game (
+	name "Toolkit (JRS Software)"
+	description "Toolkit (JRS Software)"
+	year 1982
+	manufacturer "Paul Holmes"
+	rom ( name "toolkit(jrs).p" size 2094 crc 9de785fd md5 ddfabe0545708752dc9947c12b0691dd sha1 45c020c2381e691e42385d005e496a7032c72b0e )
+	rom ( name "Toolkit(JRS).tzx" size 2318 crc 5c378f0f md5 c16ab5e0f0a83c954596a61278865a60 sha1 2121e140989dc586810bec4e1399de1007924286 )
+)
+game (
+	name "Toolkit (Sinclair Research)"
+	description "Toolkit (Sinclair Research)"
+	manufacturer "Artic"
+	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
+	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
+)
+game (
+	name "Trace (Texgate)"
+	description "Trace (Texgate)"
+	year 1983
+	manufacturer "Texgate"
+	rom ( name "trace.p" size 3248 crc 347a23e2 md5 588baf432b5f22295d6e8347b8e12f9b sha1 5b5fb4641de0cecee592944b7991cad5514c3f69 )
+	rom ( name "Trace.tzx" size 3474 crc b43432d2 md5 ba0bc19769d99d42e22475e2ca5c5d76 sha1 68ea27c33ee7b25628862ebd51bf07b716aa0d57 )
+)
+game (
+	name "Trader (Flap-fronted box) (Pixel Productions)"
+	description "Trader (Flap-fronted box) (Pixel Productions)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
+)
+game (
+	name "Trader (Pixel Productions)"
+	description "Trader (Pixel Productions)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Trader(Jewel).tzx" size 49639 crc 01e4ec2a md5 f0837cbfe6ac9168b3264aac3c21857d sha1 0082993bf62f04b69581990f052786daeea5620c )
+)
+game (
+	name "Trader (Quicksilva)"
+	description "Trader (Quicksilva)"
+	year 1982
+	manufacturer "Pixel"
+	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
+)
+game (
+	name "Traffic (Loriciels)"
+	description "Traffic (Loriciels)"
+	year 1984
+	manufacturer "M Bouat"
+	rom ( name "traffic.p" size 6800 crc b40d7fa0 md5 66919861847fb1dae81487de697b1c74 sha1 0d91bd4b6f1abaec8882b2b360e144ef2a523137 )
+	rom ( name "Traffic.tzx" size 7030 crc be09c247 md5 2f644a8598a84813fdc38bbab38d080f sha1 44626d460f9c918c4bc9e0611737b50215c73a3c )
+)
+game (
+	name "Tutor (German) (Artic)"
+	description "Tutor (German) (Artic)"
+	year 1983
+	manufacturer "S. and J. Mitchell"
+	rom ( name "tutorgerman.p" size 13643 crc 1812f460 md5 a0c9d577d010f7d36f52f0e46fafca4c sha1 e0a880b515f960cf65e76ea4eacaed3326f7ea1c )
+	rom ( name "TutorGerman.tzx" size 13869 crc 44ddecba md5 c14b69f2223528031a15c8ec638ad941 sha1 058f24ef7be7494a90cd9799cd68b07e78169b95 )
+)
+game (
+	name "Tutor (Spanish) (Artic)"
+	description "Tutor (Spanish) (Artic)"
+	year 1983
+	manufacturer "S. and J. Mitchell"
+	rom ( name "tutorspanish.p" size 14993 crc 822e1b3e md5 38d6e26acb7d0f937ac92deade6ecfb1 sha1 88a4e1152cc0a92a3539a21c11a8ac227915b529 )
+	rom ( name "TutorSpanish.tzx" size 15219 crc 4d62869a md5 02068afec8b6f9c2875acf822951af83 sha1 e12aabea86ff2542821bd04cdf6e2868f1d3f5d7 )
+)
+game (
+	name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+	description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+	year 1982
+	manufacturer "Informatique Service Logiciels"
+	rom ( name "tyrannosaurerex.p" size 11506 crc b4ba768a md5 1319f6e2e899b6611fc24443ef13cd9b sha1 7c5172140b9f208b40357c28f348dca23f8ae1a8 )
+	rom ( name "TyrannosaureRex.tzx" size 11728 crc 5300e4d1 md5 5660c77dbaaae1c8e4fe7f18380b03f6 sha1 cb0caa82180a19407cd5e850ca88ca33e12b8efc )
+)
+game (
+	name "Tyrant of Athens (Lothlorien)"
+	description "Tyrant of Athens (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "tyrantofathens.p" size 12848 crc 00039ed3 md5 40c8cfd3ebeb9510f04115b34be32097 sha1 347c589d6d9a22794f863d6e61be0ce8c31ec485 )
+	rom ( name "TyrantOfAthens.tzx" size 13068 crc fc3fd4f8 md5 c3f5e5d0f379fe1529a27596a8d5b13f sha1 882b644962f09d68bc813563478d773c3a07115b )
+)
 game (
 	name "U-Bend"
 	description "U-Bend (2015) - Bob's interpretation of a Pipe-Mania game, with 36 unique levels."
 	rom ( name "UBend.p" size 14905 crc c537e261 md5 1d648c9042117e6cc47e9293d66aec0c sha1 17c49e4ac9179ed0d08c18c671f3db5343bad3cc )
-	manufacturer "Bob Smith"
-	year "2015"
 )
-
+game (
+	name "UDG (dK'tronics)"
+	description "UDG (dK'tronics)"
+	year 1981
+	manufacturer "dK'tronics"
+	rom ( name "udg.p" size 7928 crc a4259b70 md5 e9fdd20a2bb40d5b1d6d356e1b34793a sha1 7c2656d8cbd5427f5e464a5108f82ec84c539706 )
+	rom ( name "UDG.tzx" size 8150 crc 66a2453f md5 76f87a79206c9fc82e5127b7e94c2d6f sha1 0fefc639d3c9a6c2ed2a5d994f94ee0691e0dca5 )
+)
+game (
+	name "UFO (Protek)"
+	description "UFO (Protek)"
+	year 1983
+	manufacturer "Protek"
+	rom ( name "ufo.p" size 5158 crc 4e3f3226 md5 318f5420747069feb32f65e008b84a61 sha1 f4e7a1691ad0af71b26a9d1bcc36e3155814100a )
+	rom ( name "UFO.tzx" size 5380 crc 6b8cbcec md5 eac2815189bdb98a886b8f6739b4f188 sha1 f9bd4f690cb67fa718154cb9f07d63e8103a8c4f )
+)
+game (
+	name "UFO + 3D Maze (Babtech)"
+	description "UFO + 3D Maze (Babtech)"
+	year 1982
+	manufacturer "Babtech"
+	rom ( name "UFOAnd3DMaze.tzx" size 13279 crc cc63dfdf md5 90efa80ff6a2bd4ca39af581f1cb43a4 sha1 07a8d839b7202b3846fd8f1f84025000fb222f58 )
+)
+game (
+	name "Variance Analyzer (Zeta Software)"
+	description "Variance Analyzer (Zeta Software)"
+	manufacturer "Dr. Walter Diembeck"
+	rom ( name "varianceanalyzer.p" size 8185 crc 73023b9a md5 72fbc8622939ac385b41dc3355b6d4c9 sha1 01535d36d01908855e4530c3077c6b774e893ce8 )
+	rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90a5774a md5 5237031b0a92f415c5ac347d60fd5d3e sha1 a429c8165b8be52791c99e5da26a84758a4c508b )
+)
+game (
+	name "Vector Mathematics (W. H. Smith)"
+	description "Vector Mathematics (W. H. Smith)"
+	year 1982
+	manufacturer "ICL"
+	rom ( name "vectormathematics.p" size 11849 crc a13c22de md5 7f44adcd2eab5fa11a948bad8677e102 sha1 8a75f82fd30681bf8d557e03babc165c0f64567c )
+	rom ( name "VectorMathematics.tzx" size 12101 crc c33b86ba md5 4ce4bf8556a215e4d1528e0adc8de3c9 sha1 b82230bcc7f57f7b1f12720d82440031135be44b )
+)
+game (
+	name "Video Graffiti (AGF Hardware)"
+	description "Video Graffiti (AGF Hardware)"
+	year 1982
+	manufacturer "AGF Hardware"
+	rom ( name "videograffiti.p" size 5033 crc 4b37557f md5 521067db79cb6f937b5cf2e2d0662f15 sha1 45996efa5157865159c613ca49dc1f54402e3c7b )
+	rom ( name "VideoGraffiti.tzx" size 5263 crc dd2ecb00 md5 7ea6fb6995eae21a6731a7c61f7fe91c sha1 cf2e6cee862cc503be44bf2e6621a2e8d005c521 )
+)
+game (
+	name "Video-Ad (Video Software)"
+	description "Video-Ad (Video Software)"
+	year 1981
+	manufacturer "Video Software"
+	rom ( name "VideoAd.A.tzx" size 15281 crc 42136adc md5 baef4c10ef4e5d71498c31e5d2197f64 sha1 c2409cd598ce050d622eb8850e21d74d709060eb )
+	rom ( name "videoad.p" size 15049 crc abc19f74 md5 209beec2010448bb63643842df41793d sha1 beebc6bc78805b1bb6328d518aab9cff70b2a3a2 )
+)
+game (
+	name "Video-Map (Video Software)"
+	description "Video-Map (Video Software)"
+	year 1981
+	manufacturer "Video Software"
+	rom ( name "VideoMap.A.tzx" size 15713 crc b76622dc md5 86528f5577970284c231b5048ad5f669 sha1 86d292def89f2cd01bdf677f50abdb18002507a6 )
+	rom ( name "videomap.p" size 15479 crc f37cc7c7 md5 ca144229c898e0fbedf4c974ced0fe56 sha1 3791b93f30fe410716efdb3d9d345ff803973d28 )
+)
+game (
+	name "Video-Plan (Video Software)"
+	description "Video-Plan (Video Software)"
+	manufacturer "Video Software"
+	rom ( name "VideoPlan.A.tzx" size 15425 crc 849e21dc md5 23e1f6eed1029f7433286c3682ccff69 sha1 fffa47475a0634fc9859212e5a309603d922d258 )
+	rom ( name "videoplan.p" size 15189 crc fd242331 md5 260e9496c1bd1cb40a6095f04e0bbec2 sha1 2cb0a66c7aa506061fe621a53ee0bc7f143b9988 )
+)
+game (
+	name "Video-View (Video Software)"
+	description "Video-View (Video Software)"
+	manufacturer "Video Software"
+	rom ( name "videoview.p" size 13859 crc 53eca8e2 md5 e02361e6a92651a25ca5f0f5cac3c408 sha1 bdc28fc5964960f3159a8bd08db7b3ded64eca98 )
+	rom ( name "VideoView.tzx" size 14095 crc f5fdb04b md5 fd38379fc882828484b0a1e7fac02a4d sha1 abadd8bd7a829c778d6fbf1d4f394025cd1b7c58 )
+)
+game (
+	name "Viewtext (U.S. release) (Bug Byte)"
+	description "Viewtext (U.S. release) (Bug Byte)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "viewtext(us).p" size 12535 crc 4a6de687 md5 a9edbdb5e0f43efc83bd3233ed8122ea sha1 9c9999f8daeffd8d6f9f4234548c665c0d2d18a5 )
+	rom ( name "Viewtext(US).tzx" size 12767 crc 83f14397 md5 7ab7ff7c1b3baebcfdb31632abe00646 sha1 eb0996ddb294a42c133b0c301958bdaa3b5f4a1a )
+)
 game (
 	name "Virus"
 	description "Virus (2010) - A very playable and extremely polished top-down shoot'em up, making the most of the machine's limitations."
 	rom ( name "virus.p" size 16164 crc 9495a62e md5 2ee3b625a6481026c9d00a7da43c8fd1 sha1 0f7a62fa0d575d595857aafdefc78b33a207be91 )
-	manufacturer "Bob Smith"
-	year "2010"
 )
-
+game (
+	name "Volcanic Dungeon (Carnell)"
+	description "Volcanic Dungeon (Carnell)"
+	year 1982
+	manufacturer "Carnell Software"
+	rom ( name "volcanicdungeon.p" size 16234 crc bdcc9896 md5 801e5cd018f555198867d3f989033b24 sha1 503c8cfd4994440a3662fbce25d46b000887056a )
+	rom ( name "VolcanicDungeon.tzx" size 16482 crc c6f44894 md5 60210e10f6d239cddaffe65b6a3911c8 sha1 6275899b3b7849a97ca8ea869d2bc5806522ae9a )
+)
+game (
+	name "VU-CALC (Sinclair Research)"
+	description "VU-CALC (Sinclair Research)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "vu-calc.p" size 5551 crc 85195a78 md5 5b833077456f266abbf68ca295a60ee1 sha1 19280c9645a23ffbd53818889c4899bd00d29d29 )
+	rom ( name "VU-CALC.tzx" size 5781 crc 221479df md5 cb3925e52d2afa1c3f93cbafeb2443fe sha1 50275ce9c48f4f3533899a00c5291bdade4a1efe )
+)
+game (
+	name "VU-CALC (Timex)"
+	description "VU-CALC (Timex)"
+	year 1982
+	manufacturer "Psion"
+	rom ( name "vu-calc(timex).p" size 5549 crc 294a26c8 md5 5df9f5bb28e55cd1bb0e8eae025c38bc sha1 ce80bfee2434761babbfb0aa2b204b2cdb70c76c )
+	rom ( name "VU-CALC(Timex).tzx" size 5779 crc 3db82474 md5 ac03e37dc2013d571c352ad8fa3ee69d sha1 d1533151dfecf9614c55551e0d6bbab85bce9c3c )
+)
+game (
+	name "Warlord (Lothlorien)"
+	description "Warlord (Lothlorien)"
+	year 1982
+	manufacturer "M. C. Lothlorien"
+	rom ( name "warlord.p" size 15659 crc 5b5b6fbb md5 0d8e945e8cdf72f737d2848cb35ef853 sha1 e8fe374088097adb86b658e54a4bc05208627ae5 )
+	rom ( name "Warlord.tzx" size 15879 crc 9bff8537 md5 1f8271889f8e1f381c60707a0d10621b sha1 dee7757fc095d4de68efcd4147777e0cbbad8424 )
+)
+game (
+	name "Winged Avenger (Work Force)"
+	description "Winged Avenger (Work Force)"
+	year 1982
+	manufacturer "Work Force"
+	rom ( name "wingedavenger.p" size 3760 crc ec61facb md5 abb4ab208952c4f184769683545b68e8 sha1 ef6259d87f68c3882aecb6bd47ef0b99a6dbe2a9 )
+	rom ( name "WingedAvenger.tzx" size 4004 crc 18536d36 md5 8d6e49676509ae0666cf832b8be958b1 sha1 b3ecbf77bb7d691bd1b973ede3774bf3a54a1494 )
+)
+game (
+	name "Word Processor (Alan's Recordings)"
+	description "Word Processor (Alan's Recordings)"
+	manufacturer "Alan D. Went"
+	rom ( name "WordProcessor.A.tzx" size 12384 crc c1f41d1c md5 668f2df5ba976dda0e79405a1c3b0353 sha1 4f2e76139efb5a07b443c5495636bcbb42489241 )
+)
+game (
+	name "Word Test (Mindware)"
+	description "Word Test (Mindware)"
+	year 1982
+	manufacturer "Christopher Jones"
+	rom ( name "WordTest.1.WordTest.tzx" size 1133 crc e12825a4 md5 1d78c945fe6ed7c191f0016e26c4961b sha1 a17549ce398aa7c4955e6a691fd27dbce089db4a )
+	rom ( name "wordtest.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
+)
+game (
+	name "World Cup Football (Test your knowledge of) (M. A. Smith)"
+	description "World Cup Football (Test your knowledge of) (M. A. Smith)"
+	year 1982
+	manufacturer "M. A. Smith"
+	rom ( name "worldcupfootball.p" size 10439 crc 5647eb5e md5 c08c7f4881310b8e3ad0c336ca996965 sha1 80b894c252d6185362018b1405d4868484cd0198 )
+	rom ( name "WorldCupFootball.tzx" size 10657 crc 685d01ce md5 f603bc86bbd22e511e7628a9209c3838 sha1 d081ccd8b759a2866bff5676a112481bb73d5f88 )
+)
+game (
+	name "Zac-Man (Macronics)"
+	description "Zac-Man (Macronics)"
+	manufacturer "Macronics"
+	rom ( name "zacman.p" size 6881 crc 261a596b md5 cd301f8807f261d005a0f5e0a5f8e1b3 sha1 1c8cb9858647e86a3be82467a6da6a04a4a40d15 )
+	rom ( name "ZacMan.tzx" size 7111 crc 76fca436 md5 c33deb5191e85bcaa942a92f184236c7 sha1 e4271947dfab4c3eeb64a5927cda4d25445a0e53 )
+)
+game (
+	name "Zaraks (Computer Rentals)"
+	description "Zaraks (Computer Rentals)"
+	year 1983
+	manufacturer "Richard Taylor"
+	rom ( name "zaraks.p" size 3695 crc 733e3147 md5 f41780fbd2b777457afbdbacf838c2fb sha1 46a79fa15abf021d05e323b36629dcab80e84e72 )
+	rom ( name "Zaraks.tzx" size 3923 crc 4466c390 md5 46d8771cf8578edcf534505127a3735d sha1 d4d0575f849ed626a6d2b02cc3d64660980694c5 )
+)
+game (
+	name "Zombies/Sword of Peace (Artic)"
+	description "Zombies/Sword of Peace (Artic)"
+	manufacturer "Artic"
+	rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 cf95266460228f0be0ec5cd944051fca sha1 519d3115b5ceb75b61dff442a927be851fb0ca96 )
+)
+game (
+	name "Zuckman (Black inlay) (DJL Software)"
+	description "Zuckman (Black inlay) (DJL Software)"
+	year 1982
+	manufacturer "DJL Software"
+	rom ( name "zuckman(alt).p" size 9939 crc a57caafa md5 b57a30d83b200790bccf55ef9959aaa0 sha1 bf63e2441fcfad7c72c8e8bded65f9d3704d85ed )
+	rom ( name "Zuckman(Alt).tzx" size 10169 crc 886fa5b4 md5 82570cafb6bae5e05cf474c69c5abf8b sha1 87f7870077134b24dfc9bab9e406762bd7ff6d04 )
+)
+game (
+	name "Zuckman (White inlay) (DJL Software)"
+	description "Zuckman (White inlay) (DJL Software)"
+	year 1982
+	manufacturer "DJL Software"
+	rom ( name "zuckman.p" size 9939 crc e518a2bd md5 4d40c31b628fca5ed079f992e8ae2d24 sha1 30720d6d3af16aed257832988218f8ec3f002765 )
+	rom ( name "Zuckman.tzx" size 10169 crc c80badf3 md5 5b98d152d8a4ead841a65716f68f7dd6 sha1 e212c3315d69861422dee61af487f6729568520a )
+)
+game (
+	name "ZX Action Pack (Axis)"
+	description "ZX Action Pack (Axis)"
+	year 1982
+	manufacturer "Axis"
+	rom ( name "ZXActionPack.tzx" size 4677 crc f5f95245 md5 7e8c4e96f560ce731ae5d167009cc947 sha1 a97dbf23ee4788951617cc26e8bbd2987d3a4cd6 )
+)
+game (
+	name "ZX Assembler (Artic)"
+	description "ZX Assembler (Artic)"
+	manufacturer "D. P. Aknai and M. Streeton"
+	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
+	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+)
+game (
+	name "ZX Assembler (International Publishing and Software Inc.)"
+	description "ZX Assembler (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "D. P. Aknai and M. Streeton (Artic)"
+	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
+	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+)
+game (
+	name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+	description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "D. P. Aknai and M. Streeton"
+	rom ( name "zxassembler(mono).p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
+	rom ( name "ZXAssembler(Mono).tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+)
+game (
+	name "ZX Assembleur (French) (Artic)"
+	description "ZX Assembleur (French) (Artic)"
+	year 1982
+	manufacturer "D. P. Aknai and M. Streeton"
+	rom ( name "zxassembleur.p" size 8963 crc d0d72bdc md5 b085ecfb9d97d32fc9eeb0fe94a8629e sha1 1fe43e6c0e7dd3c33bff97b7246fb5172d5aa892 )
+	rom ( name "ZXAssembleur.tzx" size 9197 crc aa532026 md5 7b58c9bfe54c57cb8080441bea91e7ec sha1 02a75242aabfbfa1d233b134df53727d5b8f597b )
+)
+game (
+	name "ZX Asteroids (Electric Pencil Company)"
+	description "ZX Asteroids (Electric Pencil Company)"
+	year 1982
+	manufacturer "Robert J. Wray"
+	rom ( name "zxasteroids.p" size 6054 crc bc47cff8 md5 57b3ec022dec0b1796aa7c6fadcd8f35 sha1 98e75c5767925cd515a10b88f731181caa84b337 )
+	rom ( name "ZXAsteroids.tzx" size 6280 crc c92d5c86 md5 f3e15eefe198558ffb618f9b005aa063 sha1 bc223f7b59f8ba07d7faf1da62f5a408034c568c )
+)
+game (
+	name "ZX Bug (International Publishing and Software Inc.)"
+	description "ZX Bug (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "Artic (?)"
+	rom ( name "zxbug(ips).p" size 5350 crc af2c11ca md5 70354bfa74200e4578f92afc927db38b sha1 92827b6cb5ab8c7c64127c700c20c36902676cb4 )
+	rom ( name "ZXBug(IPS).tzx" size 5576 crc f8959e82 md5 2d051b4f0218c4c78d897ce2a851fe6d sha1 446c92783f64ea88a3faf3f0d5338223995d99a5 )
+)
+game (
+	name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+	description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+	year 1981
+	manufacturer "Artic"
+	rom ( name "zxbug.p" size 5350 crc 2859b9eb md5 2766880aac6ae3b92031aaa2737af2ec sha1 4030b892fbb1906fe97ab601a37f9d4ffbf52a30 )
+	rom ( name "ZXBug.tzx" size 5572 crc b77b6a0d md5 c5fadbc61693ecca4761e523d2024999 sha1 5f513d59c871aa94dd8d1c1919fea0e8d5aae806 )
+)
+game (
+	name "ZX Chess I (Black inlay) (Artic)"
+	description "ZX Chess I (Black inlay) (Artic)"
+	manufacturer "Artic"
+	rom ( name "zxchessi(black).p" size 14119 crc cce17d9c md5 2aa8d6a1b52211893f7a7264cff2bc1a sha1 ceca1c8f7719afe71d991a073a88561fcda27ae8 )
+	rom ( name "ZXChessI(Black).tzx" size 14337 crc 98f8fd30 md5 f2ee420566092a3ecd4d82f532bc98de sha1 b2ee8fb73779fc8b13b1bec533e59d762f6f871f )
+)
+game (
+	name "ZX Chess II (Artic)"
+	description "ZX Chess II (Artic)"
+	manufacturer "Artic"
+	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
+	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
+)
+game (
+	name "ZX Chess II (Black inlay) (Artic)"
+	description "ZX Chess II (Black inlay) (Artic)"
+	manufacturer "Artic"
+	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
+	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
+)
+game (
+	name "ZX Chess II (Improved) (Artic)"
+	description "ZX Chess II (Improved) (Artic)"
+	year 1981
+	manufacturer "Artic"
+	rom ( name "zxchessii(improved).p" size 14096 crc 16e86ce7 md5 19d6e472a1121ea8d28cf0b79eef739d sha1 585fce3fb637abd4783f907f24d6945d9472b7e7 )
+	rom ( name "ZXChessII(Improved).tzx" size 14326 crc 60bbdc66 md5 00f547bd9654a6dcd024639c91152471 sha1 a4238332fe59d8e4e7048069cb6e26c0b357c16d )
+)
+game (
+	name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+	description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "International Publishing and Software Inc."
+	rom ( name "zxchessii(ips).p" size 14096 crc 95534f49 md5 288fedccf17c6d1ec8312c219fe1398e sha1 df54149f4ed916f7b804a8e0b8e34f790505f7c0 )
+	rom ( name "ZXChessII(IPS).tzx" size 14326 crc e300ffc8 md5 489b56232d78bbeebdb69f4cc5fcc320 sha1 d06522009c0438e7e201611c1ec10e17650dbf39 )
+)
+game (
+	name "ZX Forth (Artic)"
+	description "ZX Forth (Artic)"
+	manufacturer "Artic Computing"
+	rom ( name "ZXForth.tzx" size 20567 crc 587d765f md5 421ddc790c350146af56d1683d3cf2b6 sha1 63c6e3cd88655b30cef4afcdf4fcab959210047f )
+)
+game (
+	name "ZX Forth (International Publishing and Software Inc.)"
+	description "ZX Forth (International Publishing and Software Inc.)"
+	year 1982
+	manufacturer "Artic"
+	rom ( name "ZXForth(IPS).tzx" size 12455 crc 73e4bf92 md5 408a2ad80923d4e802a4529c8facb917 sha1 5cd85e8a39cb6151c243b4d83dfaf88a4f23c3bc )
+)
+game (
+	name "ZX Othello (Moi)"
+	description "ZX Othello (Moi)"
+	year 1982
+	manufacturer "Moi"
+	rom ( name "Othello(Moi).tzx" size 12809 crc 96eeab64 md5 2b76c39d66873cfa8959cebdd71d5cec sha1 78f78e57bf940d87d020c39aa4218b273f612313 )
+)
+game (
+	name "ZX Pro/File (Thomas B. Woods)"
+	description "ZX Pro/File (Thomas B. Woods)"
+	year 1983
+	manufacturer "Thomas B. Woods"
+	rom ( name "zxprofile.p" size 16071 crc 73f67b5b md5 e0021b805cbae2655a4158128931035d sha1 9ccb69ea8ef5d613440720d63e84e67675a4614f )
+	rom ( name "ZXProFile.tzx" size 16291 crc 5d5146cf md5 64b39d80729e025fad4828f378cc8032 sha1 214faff9ecc28e7d20e229554bfaae88a8b23b98 )
+)
+game (
+	name "ZX-Compiler (Silversoft)"
+	description "ZX-Compiler (Silversoft)"
+	year 1982
+	manufacturer "Silversoft"
+	rom ( name "zxcompiler.p" size 6931 crc f25627c4 md5 8603e97d1fe5548927e829fd2486f5a7 sha1 1ae703f1d6e47a4f6c3a07f0c5a11c233562782f )
+	rom ( name "ZXCompiler.tzx" size 7163 crc 491041a6 md5 bb0497bb6eeea52b39eb7e189f55728c sha1 09cecbec3370cfd1ff77e316c69661132f2e932f )
+)
+game (
+	name "ZX-MC (Picturesque)"
+	description "ZX-MC (Picturesque)"
+	manufacturer "Picturesque"
+	rom ( name "zxmc.p" size 3555 crc de00007d md5 1fe46c4d47a32b6c7b77144987a6c753 sha1 8897d32731370314da8bae6c4e8ae56761e4b3aa )
+	rom ( name "ZXMC.tzx" size 3781 crc bad36aef md5 a9804be70b200a01d551198de5d13e70 sha1 9edc5c21e1edd96e1a733908d9e7d39cec6df85e )
+)
+game (
+	name "ZX-Sideprint (Microsphere)"
+	description "ZX-Sideprint (Microsphere)"
+	year 1982
+	manufacturer "Microsphere"
+	rom ( name "zxsideprint.p" size 1941 crc db6371df md5 d263455884fa102d245f3109c9a66a2f sha1 869334c4250219aa8e6fcf6752d2eba5f6aa7e69 )
+	rom ( name "ZXSideprint.tzx" size 2175 crc 5f320b4a md5 d990bb98194f1a992e902aaaec9c3fbb sha1 6965f265cbfca8f6813f698be70ed0e709c59632 )
+)
 game (
 	name "ZXagon"
 	description "ZXagon (2014) - Bob's interpretation of Terry Cavanagh's masterpiece 'Super Hexagon'."
 	rom ( name "ZXagon.p" size 15336 crc d6784677 md5 4a7f14d7f0d4918ca48c028ae151ccee sha1 59dae098079f00c3e72ec4647ccbd2ed99b979f1 )
-	manufacturer "Bob Smith"
-	year "2014"
+)
+game (
+	name "ZXAS (Bug Byte)"
+	description "ZXAS (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
+	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+)
+game (
+	name "ZXAS (Gladstone) (Gladstone Electronics)"
+	description "ZXAS (Gladstone) (Gladstone Electronics)"
+	manufacturer "Bug Byte"
+	rom ( name "zxas(ge).p" size 5619 crc 850bab49 md5 7c622f096ad94f4201922e7cdea35c67 sha1 0b758fdb9bcfc94d9b37f743f78075595563c529 )
+	rom ( name "ZXAS(GE).tzx" size 5843 crc a448e4ba md5 beebbc4f4b2262f2e2c4aa3f45a62c69 sha1 e09abff8f1c771b7e1ace6b6612eb99dfa539654 )
+)
+game (
+	name "ZXAS (Monochrome) (Bug Byte)"
+	description "ZXAS (Monochrome) (Bug Byte)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
+	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+)
+game (
+	name "ZXAS (Printed instructions) (Bug Byte)"
+	description "ZXAS (Printed instructions) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
+	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+)
+game (
+	name "ZXAS (Typed Inlay) (Bug Byte)"
+	description "ZXAS (Typed Inlay) (Bug Byte)"
+	year 1981
+	manufacturer "Bug Byte"
+	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
+	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+)
+game (
+	name "ZXAS (Yellow) (Bug Byte)"
+	description "ZXAS (Yellow) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
+	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+)
+game (
+	name "ZXDB (Bug Byte)"
+	description "ZXDB (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
+	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+)
+game (
+	name "ZXDB (Typed Inlay, black) (Bug Byte)"
+	description "ZXDB (Typed Inlay, black) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
+	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+)
+game (
+	name "ZXDB (Typed Inlay, blue) (Bug Byte)"
+	description "ZXDB (Typed Inlay, blue) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
+	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+)
+game (
+	name "ZXDB (Yellow) (Bug Byte)"
+	description "ZXDB (Yellow) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
+	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+)
+game (
+	name "ZXM Sound Box Super Editor (Timedata)"
+	description "ZXM Sound Box Super Editor (Timedata)"
+	year 1983
+	manufacturer "Timedata"
+	rom ( name "zxmsupereditor.p" size 2473 crc 37830a34 md5 c4a52e25b43580685f277856cf85ce72 sha1 1d030fe2bee1c42635299e7d0f925f5adb4582a7 )
+	rom ( name "ZXMSuperEditor.tzx" size 2693 crc 989424d1 md5 498e30b4cfd9e0e0d65df71e64fff20c sha1 9af273026fbd076097effee86e09a9f07d58f1fc )
+)
+game (
+	name "ZXTK (Bug Byte)"
+	description "ZXTK (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
+	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+)
+game (
+	name "ZXTK (Printed instructions) (Bug Byte)"
+	description "ZXTK (Printed instructions) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
+	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+)
+game (
+	name "ZXTK (Yellow) (Bug Byte)"
+	description "ZXTK (Yellow) (Bug Byte)"
+	year 1982
+	manufacturer "Bug Byte"
+	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
+	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
 )

--- a/dat/Sinclair - ZX 81.dat
+++ b/dat/Sinclair - ZX 81.dat
@@ -6,7 +6,7 @@ clrmamepro (
 )
 
 game (
-  name "10 Games (J. K. Greye)"
+  name "10 Games (J. K. Greye) [TZX]"
   description "10 Games (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -14,21 +14,21 @@ game (
 )
 
 game (
-  name "1K Games Pack (Artic)"
+  name "1K Games Pack (Artic) [TZX]"
   description "1K Games Pack (Artic)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K Games (Sinclair Research)"
+  name "1K Games (Sinclair Research) [TZX]"
   description "1K Games (Sinclair Research)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K ZX Chess (Sinclair Research)"
+  name "1K ZX Chess (Sinclair Research) [TZX]"
   description "1K ZX Chess (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -36,28 +36,28 @@ game (
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [P]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [TZX]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
 )
 
 game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
+  name "2K Games Pack (International Publishing and Software Inc.) [TZX]"
   description "2K Games Pack (International Publishing and Software Inc.)"
   year "1982"
   rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [P]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -65,7 +65,7 @@ game (
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [TZX]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -73,7 +73,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [TZX]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -81,7 +81,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [P]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -89,7 +89,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [P]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -97,7 +97,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [TZX]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -105,7 +105,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [TZX]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -113,7 +113,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [P]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -121,28 +121,28 @@ game (
 )
 
 game (
-  name "5-2K Family Pak (Timeworks)"
+  name "5-2K Family Pak (Timeworks) [TZX]"
   description "5-2K Family Pak (Timeworks)"
   manufacturer "Timeworks"
   rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
 )
 
 game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service) [TZX]"
   description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
   manufacturer "GM4IHJ (J Branegan)"
   rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
 )
 
 game (
-  name "Admiral Graf Spee (Temptation Software)"
+  name "Admiral Graf Spee (Temptation Software) [TZX]"
   description "Admiral Graf Spee (Temptation Software)"
   manufacturer "Simon Mansfield"
   rom ( name "AdmiralGrafSpee.tzx" size 17024 crc C583887E md5 3BD4FAC61BDB6FC0A1BBC04EC7270DF9 sha1 741A2B608801FC12705535FA88F2D895AF486E80 )
 )
 
 game (
-  name "Advanced Budget Manager (Softsync)"
+  name "Advanced Budget Manager (Softsync) [P]"
   description "Advanced Budget Manager (Softsync)"
   year "1982"
   manufacturer "Robert E. Davis Jr."
@@ -150,7 +150,7 @@ game (
 )
 
 game (
-  name "Advanced Budget Manager (Softsync)"
+  name "Advanced Budget Manager (Softsync) [TZX]"
   description "Advanced Budget Manager (Softsync)"
   year "1982"
   manufacturer "Robert E. Davis Jr."
@@ -158,7 +158,7 @@ game (
 )
 
 game (
-  name "Advanced Mathematics (W. H. Smith)"
+  name "Advanced Mathematics (W. H. Smith) [P]"
   description "Advanced Mathematics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -166,7 +166,7 @@ game (
 )
 
 game (
-  name "Advanced Mathematics (W. H. Smith)"
+  name "Advanced Mathematics (W. H. Smith) [TZX]"
   description "Advanced Mathematics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -174,7 +174,7 @@ game (
 )
 
 game (
-  name "Adventure (Bug Byte)"
+  name "Adventure (Bug Byte) [P]"
   description "Adventure (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -182,7 +182,7 @@ game (
 )
 
 game (
-  name "Adventure (Bug Byte)"
+  name "Adventure (Bug Byte) [TZX]"
   description "Adventure (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -190,7 +190,7 @@ game (
 )
 
 game (
-  name "Adventure C (Monochrome) (Artic)"
+  name "Adventure C (Monochrome) (Artic) [P]"
   description "Adventure C (Monochrome) (Artic)"
   year "1982"
   manufacturer "Artic"
@@ -198,7 +198,7 @@ game (
 )
 
 game (
-  name "Adventure C (Monochrome) (Artic)"
+  name "Adventure C (Monochrome) (Artic) [TZX]"
   description "Adventure C (Monochrome) (Artic)"
   year "1982"
   manufacturer "Artic"
@@ -206,7 +206,7 @@ game (
 )
 
 game (
-  name "Adventure One (Abersoft)"
+  name "Adventure One (Abersoft) [TZX]"
   description "Adventure One (Abersoft)"
   year "1982"
   manufacturer "Abersoft"
@@ -214,7 +214,7 @@ game (
 )
 
 game (
-  name "Adventure One (Abersoft)"
+  name "Adventure One (Abersoft) [P]"
   description "Adventure One (Abersoft)"
   year "1982"
   manufacturer "Abersoft"
@@ -222,7 +222,7 @@ game (
 )
 
 game (
-  name "Adventure Tape 1 (Phipps Associates)"
+  name "Adventure Tape 1 (Phipps Associates) [TZX]"
   description "Adventure Tape 1 (Phipps Associates)"
   year "1983"
   manufacturer "Phipps Associates"
@@ -230,7 +230,7 @@ game (
 )
 
 game (
-  name "Adventure Tape No. 1 (Phipps Associates)"
+  name "Adventure Tape No. 1 (Phipps Associates) [TZX]"
   description "Adventure Tape No. 1 (Phipps Associates)"
   year "1982"
   manufacturer "Phipps Associates"
@@ -238,21 +238,21 @@ game (
 )
 
 game (
-  name "Airline (Cases Computer Simulations)"
+  name "Airline (Cases Computer Simulations) [P]"
   description "Airline (Cases Computer Simulations)"
   year "1982"
   rom ( name "airline.p" size 15842 crc EE5EBB38 md5 0D2270547B0E378EDAA4F22D1058DEB4 sha1 88E1C1454CE376710F1EF8D864B20AF8D6BB2FD5 )
 )
 
 game (
-  name "Airline (Cases Computer Simulations)"
+  name "Airline (Cases Computer Simulations) [TZX]"
   description "Airline (Cases Computer Simulations)"
   year "1982"
   rom ( name "Airline.tzx" size 16072 crc 844CBAAC md5 3F4F3645C603230B8EB3742585C743C3 sha1 56B18D5296DA989927C05C0F33DC30D2A3B1BA4C )
 )
 
 game (
-  name "Algebra 1 (Timex)"
+  name "Algebra 1 (Timex) [TZX]"
   description "Algebra 1 (Timex)"
   year "1982"
   manufacturer "Home Computer Software"
@@ -260,7 +260,7 @@ game (
 )
 
 game (
-  name "Alien (PSS)"
+  name "Alien (PSS) [P]"
   description "Alien (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -268,7 +268,7 @@ game (
 )
 
 game (
-  name "Alien (PSS)"
+  name "Alien (PSS) [TZX]"
   description "Alien (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -276,21 +276,21 @@ game (
 )
 
 game (
-  name "Alien Attack (Computer Rentals)"
+  name "Alien Attack (Computer Rentals) [TZX]"
   description "Alien Attack (Computer Rentals)"
   manufacturer "Computer Rentals"
   rom ( name "AlienAttack.tzx" size 6429 crc E6CE2FA6 md5 53FF8E58BA83E04522C87E4CB0D54002 sha1 F52DF2571903D9AAE931B359EABB67E2BBD6FC41 )
 )
 
 game (
-  name "Alien Attack (Computer Rentals)"
+  name "Alien Attack (Computer Rentals) [P]"
   description "Alien Attack (Computer Rentals)"
   manufacturer "Computer Rentals"
   rom ( name "alienattack.p" size 6209 crc 946E0ED7 md5 52CDD5D46F020AF4A42C898919C866CF sha1 FB0BE0363133DCD5DAB240253FDCBF21C7F50C65 )
 )
 
 game (
-  name "Alien-Dropout (Silversoft)"
+  name "Alien-Dropout (Silversoft) [TZX]"
   description "Alien-Dropout (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -298,7 +298,7 @@ game (
 )
 
 game (
-  name "Alien-Dropout (Silversoft)"
+  name "Alien-Dropout (Silversoft) [P]"
   description "Alien-Dropout (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -306,42 +306,42 @@ game (
 )
 
 game (
-  name "Alphaprobe (Artic)"
+  name "Alphaprobe (Artic) [TZX]"
   description "Alphaprobe (Artic)"
   manufacturer "Artic"
   rom ( name "Alphaprobe.tzx" size 11252 crc 7B7603F0 md5 0C36B487EACCB85755604C91D05DD8FE sha1 A71FDAEC9225187AD0724BDAAAB65B2860E994FB )
 )
 
 game (
-  name "Alphaprobe (Artic)"
+  name "Alphaprobe (Artic) [P]"
   description "Alphaprobe (Artic)"
   manufacturer "Artic"
   rom ( name "alphaprobe.p" size 11016 crc 4B8BB297 md5 0FADAEBDE9D1D1843B74415333EADC7B sha1 CDABA21F5432945BF9AE06B111804F3C4CD385E2 )
 )
 
 game (
-  name "Arcade Action (Micromega)"
+  name "Arcade Action (Micromega) [TZX]"
   description "Arcade Action (Micromega)"
   manufacturer "Micromega"
   rom ( name "ArcadeAction.tzx" size 4651 crc 5CB215E3 md5 5A76C5D34BAA6D9AAF3BDD34E5C89597 sha1 04FC1FFA34592F093F1C0EAE9D54B3FF31EB3E86 )
 )
 
 game (
-  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  name "Around Europe in 80 Hours (International Publishing and Software Inc.) [P]"
   description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
   year "1982"
   rom ( name "aroundeuropein80hours.p" size 15223 crc 2DA984A7 md5 1DD7D90A090B80EA53C1B387B852D497 sha1 5D2A941CD7EDCA847BFD6C10B41B9025A81D4352 )
 )
 
 game (
-  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  name "Around Europe in 80 Hours (International Publishing and Software Inc.) [TZX]"
   description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
   year "1982"
   rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758C6 md5 5FEEE6F195CEE427CD9195A1C4462F58 sha1 CB59D966FE38C858DF9A002F2EAAAE2CB0E1BA73 )
 )
 
 game (
-  name "Asteroids (Silversoft)"
+  name "Asteroids (Silversoft) [TZX]"
   description "Asteroids (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -349,7 +349,7 @@ game (
 )
 
 game (
-  name "Asteroids (Silversoft)"
+  name "Asteroids (Silversoft) [P]"
   description "Asteroids (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -357,35 +357,35 @@ game (
 )
 
 game (
-  name "Asteroids (Software Farm)"
+  name "Asteroids (Software Farm) [TZX]"
   description "Asteroids (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "Asteroids(SF).tzx" size 8594 crc 8B6F8743 md5 D7F2518BD65DBD7D99842F5A27AAB588 sha1 D56D7E03A545B99607174FAEC186C42E64618189 )
 )
 
 game (
-  name "Asteroids (Software Farm)"
+  name "Asteroids (Software Farm) [P]"
   description "Asteroids (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "asteroids(sf).p" size 8360 crc 0EFCEBD4 md5 583C3E31090F678A465C46D0CFCF2AD7 sha1 7F114CD978045301B7C63F7177D2FE2D0EE33264 )
 )
 
 game (
-  name "Autochef (Cases Computer Simulations)"
+  name "Autochef (Cases Computer Simulations) [TZX]"
   description "Autochef (Cases Computer Simulations)"
   year "1982"
   rom ( name "Autochef.tzx" size 15648 crc 3869AE07 md5 81856A30F98CCAA2FDBD6C88D8C7897F sha1 2B7416327BDB907108D287F8CD4EAA0FD291ECBA )
 )
 
 game (
-  name "Autochef (Cases Computer Simulations)"
+  name "Autochef (Cases Computer Simulations) [P]"
   description "Autochef (Cases Computer Simulations)"
   year "1982"
   rom ( name "autochef.p" size 15430 crc 575560BB md5 21C42C6C6EAF0866DC56533F89688F4F sha1 DD0EE23E39D50738D91731C427063AC8E59AD9D3 )
 )
 
 game (
-  name "Avenger (Abacus)"
+  name "Avenger (Abacus) [TZX]"
   description "Avenger (Abacus)"
   year "1982"
   manufacturer "K. Flynn"
@@ -393,7 +393,7 @@ game (
 )
 
 game (
-  name "Avenger (Abacus)"
+  name "Avenger (Abacus) [P]"
   description "Avenger (Abacus)"
   year "1982"
   manufacturer "K. Flynn"
@@ -401,7 +401,7 @@ game (
 )
 
 game (
-  name "Backgammon (Keith Archer)"
+  name "Backgammon (Keith Archer) [TZX]"
   description "Backgammon (Keith Archer)"
   year "1982"
   manufacturer "Keith Archer"
@@ -409,7 +409,7 @@ game (
 )
 
 game (
-  name "Backgammon (Keith Archer)"
+  name "Backgammon (Keith Archer) [P]"
   description "Backgammon (Keith Archer)"
   year "1982"
   manufacturer "Keith Archer"
@@ -417,7 +417,7 @@ game (
 )
 
 game (
-  name "Backgammon (Timex)"
+  name "Backgammon (Timex) [TZX]"
   description "Backgammon (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -425,7 +425,7 @@ game (
 )
 
 game (
-  name "Bank Robber (Romik Software)"
+  name "Bank Robber (Romik Software) [P]"
   description "Bank Robber (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -433,7 +433,7 @@ game (
 )
 
 game (
-  name "Bank Robber (Romik Software)"
+  name "Bank Robber (Romik Software) [TZX]"
   description "Bank Robber (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -441,14 +441,14 @@ game (
 )
 
 game (
-  name "Baron (Temptation Software)"
+  name "Baron (Temptation Software) [TZX]"
   description "Baron (Temptation Software)"
   manufacturer "Simon Mansfield"
   rom ( name "Baron.tzx" size 16716 crc 2813C7A1 md5 C6AE4F6CF29411686BDE01114A682498 sha1 FD944CEDD638D3A5D6B70A8A4D50F2D41C16EA74 )
 )
 
 game (
-  name "Basicode 2 (BBC)"
+  name "Basicode 2 (BBC) [TZX]"
   description "Basicode 2 (BBC)"
   year "1984"
   manufacturer "The Chip Shop"
@@ -456,7 +456,7 @@ game (
 )
 
 game (
-  name "Basicode 2 (BBC)"
+  name "Basicode 2 (BBC) [P]"
   description "Basicode 2 (BBC)"
   year "1984"
   manufacturer "The Chip Shop"
@@ -464,7 +464,7 @@ game (
 )
 
 game (
-  name "Bat Cage (Timex)"
+  name "Bat Cage (Timex) [P]"
   description "Bat Cage (Timex)"
   year "1982"
   manufacturer "Thomas J. Burke"
@@ -472,7 +472,7 @@ game (
 )
 
 game (
-  name "Bat Cage (Timex)"
+  name "Bat Cage (Timex) [TZX]"
   description "Bat Cage (Timex)"
   year "1982"
   manufacturer "Thomas J. Burke"
@@ -480,7 +480,7 @@ game (
 )
 
 game (
-  name "Battleships (JRS Software)"
+  name "Battleships (JRS Software) [TZX]"
   description "Battleships (JRS Software)"
   year "1982"
   manufacturer "JRS Software"
@@ -488,7 +488,7 @@ game (
 )
 
 game (
-  name "Battleships (JRS Software)"
+  name "Battleships (JRS Software) [P]"
   description "Battleships (JRS Software)"
   year "1982"
   manufacturer "JRS Software"
@@ -496,14 +496,14 @@ game (
 )
 
 game (
-  name "Bigflap Attack (Timex)"
+  name "Bigflap Attack (Timex) [P]"
   description "Bigflap Attack (Timex)"
   manufacturer "Timex"
   rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66C706F432AD9277573B709C913B16A0 sha1 985F2F32AE4478051B5B7D91CB17BBC474FD26F6 )
 )
 
 game (
-  name "Black Star (Quicksilva)"
+  name "Black Star (Quicksilva) [P]"
   description "Black Star (Quicksilva)"
   year "1983"
   manufacturer "M. Sudworth"
@@ -511,7 +511,7 @@ game (
 )
 
 game (
-  name "Black Star (Quicksilva)"
+  name "Black Star (Quicksilva) [TZX]"
   description "Black Star (Quicksilva)"
   year "1983"
   manufacturer "M. Sudworth"
@@ -519,7 +519,7 @@ game (
 )
 
 game (
-  name "Bouncing Bert (Software Farm)"
+  name "Bouncing Bert (Software Farm) [P]"
   description "Bouncing Bert (Software Farm)"
   year "1985"
   manufacturer "S C T"
@@ -527,7 +527,7 @@ game (
 )
 
 game (
-  name "Bouncing Bert (Software Farm)"
+  name "Bouncing Bert (Software Farm) [TZX]"
   description "Bouncing Bert (Software Farm)"
   year "1985"
   manufacturer "S C T"
@@ -535,7 +535,7 @@ game (
 )
 
 game (
-  name "Breakout (CDS Micro Systems)"
+  name "Breakout (CDS Micro Systems) [P]"
   description "Breakout (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -543,7 +543,7 @@ game (
 )
 
 game (
-  name "Breakout (CDS Micro Systems)"
+  name "Breakout (CDS Micro Systems) [TZX]"
   description "Breakout (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -551,7 +551,7 @@ game (
 )
 
 game (
-  name "Breakout (J. K. Greye)"
+  name "Breakout (J. K. Greye) [P]"
   description "Breakout (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -559,7 +559,7 @@ game (
 )
 
 game (
-  name "Breakout (J. K. Greye)"
+  name "Breakout (J. K. Greye) [TZX]"
   description "Breakout (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -567,7 +567,7 @@ game (
 )
 
 game (
-  name "Breakout (New Generation)"
+  name "Breakout (New Generation) [P]"
   description "Breakout (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -575,7 +575,7 @@ game (
 )
 
 game (
-  name "Breakout (New Generation)"
+  name "Breakout (New Generation) [TZX]"
   description "Breakout (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -583,7 +583,7 @@ game (
 )
 
 game (
-  name "Breakout 3 (Axis)"
+  name "Breakout 3 (Axis) [TZX]"
   description "Breakout 3 (Axis)"
   year "1982"
   manufacturer "Axis"
@@ -591,7 +591,7 @@ game (
 )
 
 game (
-  name "Breakout 3 (Axis)"
+  name "Breakout 3 (Axis) [P]"
   description "Breakout 3 (Axis)"
   year "1982"
   manufacturer "Axis"
@@ -599,7 +599,7 @@ game (
 )
 
 game (
-  name "Breakout, Space Invaders and Music (Macronics)"
+  name "Breakout, Space Invaders and Music (Macronics) [TZX]"
   description "Breakout, Space Invaders and Music (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -607,7 +607,7 @@ game (
 )
 
 game (
-  name "Brick Stop (CDS Micro Systems)"
+  name "Brick Stop (CDS Micro Systems) [TZX]"
   description "Brick Stop (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -615,7 +615,7 @@ game (
 )
 
 game (
-  name "Brick Stop (CDS Micro Systems)"
+  name "Brick Stop (CDS Micro Systems) [P]"
   description "Brick Stop (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -623,7 +623,7 @@ game (
 )
 
 game (
-  name "Bubble Bugs (Romik Software)"
+  name "Bubble Bugs (Romik Software) [TZX]"
   description "Bubble Bugs (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -631,7 +631,7 @@ game (
 )
 
 game (
-  name "Bubble Bugs (Romik Software)"
+  name "Bubble Bugs (Romik Software) [P]"
   description "Bubble Bugs (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -639,7 +639,7 @@ game (
 )
 
 game (
-  name "The Budgeter (Timex)"
+  name "The Budgeter (Timex) [TZX]"
   description "The Budgeter (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -647,7 +647,7 @@ game (
 )
 
 game (
-  name "The Budgeter (Timex)"
+  name "The Budgeter (Timex) [P]"
   description "The Budgeter (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -655,7 +655,7 @@ game (
 )
 
 game (
-  name "Bumper 7 (Axis)"
+  name "Bumper 7 (Axis) [TZX]"
   description "Bumper 7 (Axis)"
   year "1981"
   manufacturer "Axis"
@@ -663,7 +663,7 @@ game (
 )
 
 game (
-  name "Byter (Protek)"
+  name "Byter (Protek) [P]"
   description "Byter (Protek)"
   year "1983"
   manufacturer "Protek"
@@ -671,7 +671,7 @@ game (
 )
 
 game (
-  name "Byter (Protek)"
+  name "Byter (Protek) [TZX]"
   description "Byter (Protek)"
   year "1983"
   manufacturer "Protek"
@@ -679,28 +679,28 @@ game (
 )
 
 game (
-  name "Can of Worms (Automata Cartography)"
+  name "Can of Worms (Automata Cartography) [TZX]"
   description "Can of Worms (Automata Cartography)"
   manufacturer "Automata Cartography"
   rom ( name "CanOfWorms.tzx" size 7150 crc B2E6FA12 md5 3A724F1A32F350922012F1FF6B6E0193 sha1 9BB651B39206913BBE74600997114FCBCD70747C )
 )
 
 game (
-  name "The Carpooler (Timex)"
+  name "The Carpooler (Timex) [TZX]"
   description "The Carpooler (Timex)"
   manufacturer "Timex"
   rom ( name "CarpoolerThe.tzx" size 14507 crc D8258CEF md5 9F1A67808E8506B0DF3C66BF00568CAF sha1 CAFBB78BF77F88C0FFB29E6C2A92666899149C8E )
 )
 
 game (
-  name "The Carpooler (Timex)"
+  name "The Carpooler (Timex) [P]"
   description "The Carpooler (Timex)"
   manufacturer "Timex"
   rom ( name "carpoolerthe.p" size 14277 crc 0D8ABCAC md5 068BE6E28AF97837FFBB6D292930B6D7 sha1 992B08B7FC5BC7D0D891459FBCEBB078BA9D2649 )
 )
 
 game (
-  name "Cassette 3 (M. Orwin)"
+  name "Cassette 3 (M. Orwin) [TZX]"
   description "Cassette 3 (M. Orwin)"
   year "1982"
   manufacturer "Various"
@@ -708,7 +708,7 @@ game (
 )
 
 game (
-  name "Cassette 4 (M. Orwin)"
+  name "Cassette 4 (M. Orwin) [TZX]"
   description "Cassette 4 (M. Orwin)"
   year "1982"
   manufacturer "Various"
@@ -716,21 +716,21 @@ game (
 )
 
 game (
-  name "Castle Adventure (CDS Micro Systems)"
+  name "Castle Adventure (CDS Micro Systems) [TZX]"
   description "Castle Adventure (CDS Micro Systems)"
   manufacturer "CDS Micro Systems"
   rom ( name "Castle.tzx" size 14716 crc BA09CC38 md5 EF3141D3308BCD5DD7831A27E8CC5899 sha1 688ABD7300F76E35F69AE025A4411F2767514B94 )
 )
 
 game (
-  name "Castle Adventure (CDS Micro Systems)"
+  name "Castle Adventure (CDS Micro Systems) [P]"
   description "Castle Adventure (CDS Micro Systems)"
   manufacturer "CDS Micro Systems"
   rom ( name "castle.p" size 14488 crc 1D01ED81 md5 239C2112AE0B67A045BFEB0397D4F3E0 sha1 00755932CA214C899B866036E666DF6325FDD59A )
 )
 
 game (
-  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  name "Castle Adventure (Brown inlay) (CDS Micro Systems) [TZX]"
   description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -738,7 +738,7 @@ game (
 )
 
 game (
-  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  name "Castle Adventure (Brown inlay) (CDS Micro Systems) [P]"
   description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -746,7 +746,7 @@ game (
 )
 
 game (
-  name "Catacombs (J. K. Greye)"
+  name "Catacombs (J. K. Greye) [TZX]"
   description "Catacombs (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -754,7 +754,7 @@ game (
 )
 
 game (
-  name "Catacombs (J. K. Greye)"
+  name "Catacombs (J. K. Greye) [P]"
   description "Catacombs (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -762,21 +762,21 @@ game (
 )
 
 game (
-  name "Cave Crusade (AWA Software)"
+  name "Cave Crusade (AWA Software) [TZX]"
   description "Cave Crusade (AWA Software)"
   manufacturer "S. Hughes"
   rom ( name "CaveCrusade.tzx" size 6510 crc 9DEC44E3 md5 4E27965613610224B2C60F824983F7A7 sha1 BC4A46FDEC5734A88AFC005DF4864FEAE26549E1 )
 )
 
 game (
-  name "Cave Crusade (AWA Software)"
+  name "Cave Crusade (AWA Software) [P]"
   description "Cave Crusade (AWA Software)"
   manufacturer "S. Hughes"
   rom ( name "cavecrusade.p" size 6270 crc A2EB2F80 md5 B6C9C3F387D5BA97D80FE92A03E6D0C5 sha1 5F05D170D3EBA9A7C4915EECD7E65BBBB958FECA )
 )
 
 game (
-  name "Centipede (Llamasoft)"
+  name "Centipede (Llamasoft) [TZX]"
   description "Centipede (Llamasoft)"
   year "1982"
   manufacturer "Jeff Minter"
@@ -784,7 +784,7 @@ game (
 )
 
 game (
-  name "Centipede (Llamasoft)"
+  name "Centipede (Llamasoft) [P]"
   description "Centipede (Llamasoft)"
   year "1982"
   manufacturer "Jeff Minter"
@@ -792,21 +792,21 @@ game (
 )
 
 game (
-  name "Centipede (Green cover) (dK'tronics)"
+  name "Centipede (Green cover) (dK'tronics) [TZX]"
   description "Centipede (Green cover) (dK'tronics)"
   manufacturer "dK'tronics"
   rom ( name "Centipede(Green).tzx" size 9967 crc 0ED972CD md5 9DD33FD4999F2D1DE4BF52E4590D2521 sha1 1BF47EF2651D5D09A6971CE9EB931AA41ED846CB )
 )
 
 game (
-  name "Centipede (Green cover) (dK'tronics)"
+  name "Centipede (Green cover) (dK'tronics) [P]"
   description "Centipede (Green cover) (dK'tronics)"
   manufacturer "dK'tronics"
   rom ( name "centipede(green).p" size 9733 crc F5F4B919 md5 90610D4FA888969F53204A5CA98F6A20 sha1 418C10220FBF3BCF83C07B2A9C717DD12DC92C53 )
 )
 
 game (
-  name "Centipede (dktronics) (dK'tronics)"
+  name "Centipede (dktronics) (dK'tronics) [P]"
   description "Centipede (dktronics) (dK'tronics)"
   year "1982"
   manufacturer "Jeff Minter"
@@ -814,7 +814,7 @@ game (
 )
 
 game (
-  name "Centipede (dktronics) (dK'tronics)"
+  name "Centipede (dktronics) (dK'tronics) [TZX]"
   description "Centipede (dktronics) (dK'tronics)"
   year "1982"
   manufacturer "Jeff Minter"
@@ -822,14 +822,14 @@ game (
 )
 
 game (
-  name "Challenge (Micromega)"
+  name "Challenge (Micromega) [TZX]"
   description "Challenge (Micromega)"
   manufacturer "Micromega"
   rom ( name "Challenge.tzx" size 4865 crc 8439C8B1 md5 B963B33677E4E187630608606FECBA67 sha1 B3DD53DF21A684570B3120A8A996FAE738DFB15A )
 )
 
 game (
-  name "The Challenger 1 (Timex)"
+  name "The Challenger 1 (Timex) [TZX]"
   description "The Challenger 1 (Timex)"
   year "1982"
   manufacturer "R. Fowkes"
@@ -837,21 +837,21 @@ game (
 )
 
 game (
-  name "Champions! (Peaksoft)"
+  name "Champions! (Peaksoft) [P]"
   description "Champions! (Peaksoft)"
   manufacturer "Peaksoft"
   rom ( name "champions.p" size 14858 crc D363867F md5 806E86A4E8C5807CE53717E4BA441C98 sha1 2148C6108E52C8C33A8C1593C47A1EE89ED711B8 )
 )
 
 game (
-  name "Champions! (Peaksoft)"
+  name "Champions! (Peaksoft) [TZX]"
   description "Champions! (Peaksoft)"
   manufacturer "Peaksoft"
   rom ( name "Champions.tzx" size 15086 crc 7AE0415B md5 7F738BEFE88938AE2F5BFAF464CC2C16 sha1 1847183FFCAF74BB7F709D09D1D5FEA24C720E6A )
 )
 
 game (
-  name "The Checkbook Manager (Timex)"
+  name "The Checkbook Manager (Timex) [P]"
   description "The Checkbook Manager (Timex)"
   year "1982"
   manufacturer "John Heaney"
@@ -859,7 +859,7 @@ game (
 )
 
 game (
-  name "The Checkbook Manager (Timex)"
+  name "The Checkbook Manager (Timex) [TZX]"
   description "The Checkbook Manager (Timex)"
   year "1982"
   manufacturer "John Heaney"
@@ -867,7 +867,7 @@ game (
 )
 
 game (
-  name "Chess (Timex)"
+  name "Chess (Timex) [TZX]"
   description "Chess (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -875,14 +875,14 @@ game (
 )
 
 game (
-  name "Chrs Demo (Quicksilva)"
+  name "Chrs Demo (Quicksilva) [TZX]"
   description "Chrs Demo (Quicksilva)"
   manufacturer "Quicksilva"
   rom ( name "ChrsDemo.tzx" size 5993 crc 3E8D1DA7 md5 B69EA89A89170660517BF2284C791E12 sha1 8509B1FC61DC20C1E9280526858B0E95BD6359B5 )
 )
 
 game (
-  name "City of Xon (Pleasantrees)"
+  name "City of Xon (Pleasantrees) [TZX]"
   description "City of Xon (Pleasantrees)"
   year "1982"
   manufacturer "Pleasantrees"
@@ -890,7 +890,7 @@ game (
 )
 
 game (
-  name "City of Xon (Pleasantrees)"
+  name "City of Xon (Pleasantrees) [P]"
   description "City of Xon (Pleasantrees)"
   year "1982"
   manufacturer "Pleasantrees"
@@ -898,7 +898,7 @@ game (
 )
 
 game (
-  name "City Patrol (Sinclair Research)"
+  name "City Patrol (Sinclair Research) [P]"
   description "City Patrol (Sinclair Research)"
   year "1982"
   manufacturer "Macronics (Don Priestley)"
@@ -906,7 +906,7 @@ game (
 )
 
 game (
-  name "City Patrol (Sinclair Research)"
+  name "City Patrol (Sinclair Research) [TZX]"
   description "City Patrol (Sinclair Research)"
   year "1982"
   manufacturer "Macronics (Don Priestley)"
@@ -914,7 +914,7 @@ game (
 )
 
 game (
-  name "Club Record Controller (Sinclair Research)"
+  name "Club Record Controller (Sinclair Research) [P]"
   description "Club Record Controller (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -922,7 +922,7 @@ game (
 )
 
 game (
-  name "Club Record Controller (Sinclair Research)"
+  name "Club Record Controller (Sinclair Research) [TZX]"
   description "Club Record Controller (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -930,7 +930,7 @@ game (
 )
 
 game (
-  name "Club Records (W. H. Smith)"
+  name "Club Records (W. H. Smith) [P]"
   description "Club Records (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -938,7 +938,7 @@ game (
 )
 
 game (
-  name "Club Records (W. H. Smith)"
+  name "Club Records (W. H. Smith) [TZX]"
   description "Club Records (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -946,7 +946,7 @@ game (
 )
 
 game (
-  name "Collector's Pack (Sinclair Research)"
+  name "Collector's Pack (Sinclair Research) [P]"
   description "Collector's Pack (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -954,7 +954,7 @@ game (
 )
 
 game (
-  name "Collector's Pack (Sinclair Research)"
+  name "Collector's Pack (Sinclair Research) [TZX]"
   description "Collector's Pack (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -962,35 +962,35 @@ game (
 )
 
 game (
-  name "Collector's Recording System (W. H. Smith)"
+  name "Collector's Recording System (W. H. Smith) [P]"
   description "Collector's Recording System (W. H. Smith)"
   manufacturer "ICL"
   rom ( name "collectorsrecordingsystem.p" size 7447 crc FE3EB9CC md5 8AF2B0E4D7A7480859B978AFF6B8954D sha1 BF4B5D5C78B6A1E68784296567AA655362D6A552 )
 )
 
 game (
-  name "Collector's Recording System (W. H. Smith)"
+  name "Collector's Recording System (W. H. Smith) [TZX]"
   description "Collector's Recording System (W. H. Smith)"
   manufacturer "ICL"
   rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1A89B64D md5 D0735FC71D39A879E80FE130F3CA8226 sha1 7FB6CF85C4A0E47A2AD78F5F4371DEEEBADCB923 )
 )
 
 game (
-  name "Community Chest (Artic)"
+  name "Community Chest (Artic) [TZX]"
   description "Community Chest (Artic)"
   manufacturer "Artic"
   rom ( name "CommunityChest.tzx" size 14270 crc BF585C82 md5 A4B42D6021CECA0F9C09AA0E6596C110 sha1 C95AF3F37795ADABE7F251643EFFF51CB7E2579F )
 )
 
 game (
-  name "Community Chest (Artic)"
+  name "Community Chest (Artic) [P]"
   description "Community Chest (Artic)"
   manufacturer "Artic"
   rom ( name "communitychest.p" size 14048 crc 0FE4512D md5 A40B1C79C5B578238002454F2A4B92BC sha1 941725AEEF9136F7B105BD1E8C21245EC671AC86 )
 )
 
 game (
-  name "ComputaCalc ZX (Silicon Tricks)"
+  name "ComputaCalc ZX (Silicon Tricks) [P]"
   description "ComputaCalc ZX (Silicon Tricks)"
   year "1981"
   manufacturer "S. C. Stephens"
@@ -998,7 +998,7 @@ game (
 )
 
 game (
-  name "ComputaCalc ZX (Silicon Tricks)"
+  name "ComputaCalc ZX (Silicon Tricks) [TZX]"
   description "ComputaCalc ZX (Silicon Tricks)"
   year "1981"
   manufacturer "S. C. Stephens"
@@ -1006,7 +1006,7 @@ game (
 )
 
 game (
-  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks) [P]"
   description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
   year "1981"
   manufacturer "S. C. Stephens"
@@ -1014,7 +1014,7 @@ game (
 )
 
 game (
-  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks) [TZX]"
   description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
   year "1981"
   manufacturer "S. C. Stephens"
@@ -1022,42 +1022,42 @@ game (
 )
 
 game (
-  name "Constellation (Bug Byte)"
+  name "Constellation (Bug Byte) [P]"
   description "Constellation (Bug Byte)"
   manufacturer "Bug Byte"
   rom ( name "constellation.p" size 12385 crc 82892356 md5 B7FF958C98E6955281AED8D50CE4A8B2 sha1 B020CEC9FD14F00882DE28165F4F2A207E020306 )
 )
 
 game (
-  name "Constellation (Bug Byte)"
+  name "Constellation (Bug Byte) [TZX]"
   description "Constellation (Bug Byte)"
   manufacturer "Bug Byte"
   rom ( name "Constellation.tzx" size 12611 crc A0146B49 md5 500508C55BFAE7C20D1191CF95B37E5D sha1 FB8BBC99988812C5EF372A7358A36CEADB53AE73 )
 )
 
 game (
-  name "Constellation (Gladstone) (Gladstone Electronics)"
+  name "Constellation (Gladstone) (Gladstone Electronics) [TZX]"
   description "Constellation (Gladstone) (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "Constellation(GE).tzx" size 15694 crc 89092DE9 md5 E76748A332503ED9799FB76A16CF24F2 sha1 69DA2B7F7A1F311A73858F4787F05C31460E7172 )
 )
 
 game (
-  name "Constellation (Gladstone) (Gladstone Electronics)"
+  name "Constellation (Gladstone) (Gladstone Electronics) [P]"
   description "Constellation (Gladstone) (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "constellation(ge).p" size 15452 crc CA46CB85 md5 7EB28D1AD0F29BE00794F00BE04FF1E7 sha1 58F35FB046A9E20052DC7B838E1754C593FCDB53 )
 )
 
 game (
-  name "Control Technology Tapes 1,2,3 (Control Technology)"
+  name "Control Technology Tapes 1,2,3 (Control Technology) [TZX]"
   description "Control Technology Tapes 1,2,3 (Control Technology)"
   manufacturer "Control Technology"
   rom ( name "ControlTechnology123.tzx" size 48433 crc D9610EA9 md5 1C5691270A4F2EF50A859F6EEFE7891F sha1 8E630DBC2725862733CD138E69A7C8CA9EEED84F )
 )
 
 game (
-  name "Conversational German (Timex)"
+  name "Conversational German (Timex) [P]"
   description "Conversational German (Timex)"
   year "1983"
   manufacturer "D. E. Hagan"
@@ -1065,7 +1065,7 @@ game (
 )
 
 game (
-  name "Conversational German (Timex)"
+  name "Conversational German (Timex) [TZX]"
   description "Conversational German (Timex)"
   year "1983"
   manufacturer "D. E. Hagan"
@@ -1073,7 +1073,7 @@ game (
 )
 
 game (
-  name "Cosmic Guerilla (Quicksilva)"
+  name "Cosmic Guerilla (Quicksilva) [TZX]"
   description "Cosmic Guerilla (Quicksilva)"
   year "1983"
   manufacturer "C. K. Tame"
@@ -1081,7 +1081,7 @@ game (
 )
 
 game (
-  name "Cosmic Guerilla (Quicksilva)"
+  name "Cosmic Guerilla (Quicksilva) [P]"
   description "Cosmic Guerilla (Quicksilva)"
   year "1983"
   manufacturer "C. K. Tame"
@@ -1089,21 +1089,21 @@ game (
 )
 
 game (
-  name "Counter Attack (Woodside Software)"
+  name "Counter Attack (Woodside Software) [TZX]"
   description "Counter Attack (Woodside Software)"
   manufacturer "P. Hennessy"
   rom ( name "CounterAttack.tzx" size 7219 crc 6B8852CA md5 DFE0270C48C5AF69BD0652F723F6C5B2 sha1 286CD36A713F95FFCC5E847539A59DE6C55F6C42 )
 )
 
 game (
-  name "Counter Attack (Woodside Software)"
+  name "Counter Attack (Woodside Software) [P]"
   description "Counter Attack (Woodside Software)"
   manufacturer "P. Hennessy"
   rom ( name "counterattack.p" size 6975 crc 4095691A md5 846BE5D9FAF79197323D5C2B05B82136 sha1 45AAE62DC5ED72ECBA3C33B280B2C3D7310CF942 )
 )
 
 game (
-  name "The Coupon Manager (Timex)"
+  name "The Coupon Manager (Timex) [P]"
   description "The Coupon Manager (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -1111,7 +1111,7 @@ game (
 )
 
 game (
-  name "Critical Path Analysis (Hilderbay)"
+  name "Critical Path Analysis (Hilderbay) [P]"
   description "Critical Path Analysis (Hilderbay)"
   year "1981"
   manufacturer "Hilderbay"
@@ -1119,7 +1119,7 @@ game (
 )
 
 game (
-  name "Critical Path Analysis (Hilderbay)"
+  name "Critical Path Analysis (Hilderbay) [TZX]"
   description "Critical Path Analysis (Hilderbay)"
   year "1981"
   manufacturer "Hilderbay"
@@ -1127,7 +1127,7 @@ game (
 )
 
 game (
-  name "Critical Path Analysis (Timex)"
+  name "Critical Path Analysis (Timex) [TZX]"
   description "Critical Path Analysis (Timex)"
   year "1982"
   manufacturer "W. Emery"
@@ -1135,7 +1135,7 @@ game (
 )
 
 game (
-  name "Croaka-Crawla (Quicksilva)"
+  name "Croaka-Crawla (Quicksilva) [P]"
   description "Croaka-Crawla (Quicksilva)"
   year "1983"
   manufacturer "Quicksilva"
@@ -1143,7 +1143,7 @@ game (
 )
 
 game (
-  name "Croaka-Crawla (Quicksilva)"
+  name "Croaka-Crawla (Quicksilva) [TZX]"
   description "Croaka-Crawla (Quicksilva)"
   year "1983"
   manufacturer "Quicksilva"
@@ -1151,7 +1151,7 @@ game (
 )
 
 game (
-  name "The Cube Game (Timex)"
+  name "The Cube Game (Timex) [TZX]"
   description "The Cube Game (Timex)"
   year "1982"
   manufacturer "John Heaney"
@@ -1159,7 +1159,7 @@ game (
 )
 
 game (
-  name "The Cube Game (Timex)"
+  name "The Cube Game (Timex) [P]"
   description "The Cube Game (Timex)"
   year "1982"
   manufacturer "John Heaney"
@@ -1167,14 +1167,14 @@ game (
 )
 
 game (
-  name "D Coder (Cosma)"
+  name "D Coder (Cosma) [TZX]"
   description "D Coder (Cosma)"
   manufacturer "Cosma"
   rom ( name "DCoder.A.tzx" size 7680 crc 1684BA79 md5 229D7EB3CD3C17B82A1FB4E5DAEC5370 sha1 39F16BB21B52C566218F38AA07B1951E38C0F8BD )
 )
 
 game (
-  name "Dallas (French) (Cases Computer Simulations)"
+  name "Dallas (French) (Cases Computer Simulations) [TZX]"
   description "Dallas (French) (Cases Computer Simulations)"
   year "1983"
   manufacturer "Cases Computer Simulations"
@@ -1182,7 +1182,7 @@ game (
 )
 
 game (
-  name "Dallas (French) (Cases Computer Simulations)"
+  name "Dallas (French) (Cases Computer Simulations) [P]"
   description "Dallas (French) (Cases Computer Simulations)"
   year "1983"
   manufacturer "Cases Computer Simulations"
@@ -1190,7 +1190,7 @@ game (
 )
 
 game (
-  name "The Damsel and the Beast (Bug Byte)"
+  name "The Damsel and the Beast (Bug Byte) [P]"
   description "The Damsel and the Beast (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -1198,7 +1198,7 @@ game (
 )
 
 game (
-  name "The Damsel and the Beast (Bug Byte)"
+  name "The Damsel and the Beast (Bug Byte) [TZX]"
   description "The Damsel and the Beast (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -1206,7 +1206,7 @@ game (
 )
 
 game (
-  name "Dictator (Bug Byte)"
+  name "Dictator (Bug Byte) [TZX]"
   description "Dictator (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -1214,7 +1214,7 @@ game (
 )
 
 game (
-  name "Dictator (Bug Byte)"
+  name "Dictator (Bug Byte) [P]"
   description "Dictator (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -1222,21 +1222,21 @@ game (
 )
 
 game (
-  name "Do Not Pass Go (Work Force)"
+  name "Do Not Pass Go (Work Force) [P]"
   description "Do Not Pass Go (Work Force)"
   manufacturer "Work Force"
   rom ( name "donotpassgo.p" size 13355 crc 292A5505 md5 0480349FBEE60FD0939F31CC6D210C2B sha1 A05BA8AD8560A15C5ECFFFF289D10DAA421B5CB8 )
 )
 
 game (
-  name "Do Not Pass Go (Work Force)"
+  name "Do Not Pass Go (Work Force) [TZX]"
   description "Do Not Pass Go (Work Force)"
   manufacturer "Work Force"
   rom ( name "DoNotPassGo.tzx" size 13587 crc A2DD0F0C md5 D4CDFCEE0472C465483738B520960D65 sha1 45DED58CE3255E5239722C956EEF084BAC20AD6D )
 )
 
 game (
-  name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
+  name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems) [TZX]"
   description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -1244,7 +1244,7 @@ game (
 )
 
 game (
-  name "Dominoes (Phipps Associates)"
+  name "Dominoes (Phipps Associates) [TZX]"
   description "Dominoes (Phipps Associates)"
   year "1983"
   manufacturer "D. G. Cross"
@@ -1252,7 +1252,7 @@ game (
 )
 
 game (
-  name "Dominoes (Phipps Associates)"
+  name "Dominoes (Phipps Associates) [P]"
   description "Dominoes (Phipps Associates)"
   year "1983"
   manufacturer "D. G. Cross"
@@ -1260,21 +1260,21 @@ game (
 )
 
 game (
-  name "Dr. Floyd (Apropos Technology)"
+  name "Dr. Floyd (Apropos Technology) [TZX]"
   description "Dr. Floyd (Apropos Technology)"
   manufacturer "Apropos Technology"
   rom ( name "DrFloyd.tzx" size 14294 crc D5B0408F md5 5E0B05B046B113239EC5EFDB9E23589E sha1 6982C898304A0E319434984A019B96682D177661 )
 )
 
 game (
-  name "Dr. Floyd (Apropos Technology)"
+  name "Dr. Floyd (Apropos Technology) [P]"
   description "Dr. Floyd (Apropos Technology)"
   manufacturer "Apropos Technology"
   rom ( name "drfloyd.p" size 14062 crc D16282DA md5 4E26541F29E46BABA6BEAC4AD8BCCC31 sha1 C5531613742A634A5B41503198AE567ADC6A42AB )
 )
 
 game (
-  name "Dragon Maze (Macronics)"
+  name "Dragon Maze (Macronics) [TZX]"
   description "Dragon Maze (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -1282,7 +1282,7 @@ game (
 )
 
 game (
-  name "Dragon Maze (Macronics)"
+  name "Dragon Maze (Macronics) [P]"
   description "Dragon Maze (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -1290,7 +1290,7 @@ game (
 )
 
 game (
-  name "Dungeons of Doom (Temptation Software)"
+  name "Dungeons of Doom (Temptation Software) [TZX]"
   description "Dungeons of Doom (Temptation Software)"
   year "1982"
   manufacturer "Simon Mansfield"
@@ -1298,7 +1298,7 @@ game (
 )
 
 game (
-  name "E.E. 1 - Filter Design (Timex)"
+  name "E.E. 1 - Filter Design (Timex) [TZX]"
   description "E.E. 1 - Filter Design (Timex)"
   year "1982"
   manufacturer "American Micro Products"
@@ -1306,7 +1306,7 @@ game (
 )
 
 game (
-  name "E.E. 1 - Filter Design (Timex)"
+  name "E.E. 1 - Filter Design (Timex) [P]"
   description "E.E. 1 - Filter Design (Timex)"
   year "1982"
   manufacturer "American Micro Products"
@@ -1314,7 +1314,7 @@ game (
 )
 
 game (
-  name "Electric Cost Analyzer (Timex)"
+  name "Electric Cost Analyzer (Timex) [P]"
   description "Electric Cost Analyzer (Timex)"
   year "1983"
   manufacturer "Tim Rossetti"
@@ -1322,7 +1322,7 @@ game (
 )
 
 game (
-  name "Electric Cost Analyzer (Timex)"
+  name "Electric Cost Analyzer (Timex) [TZX]"
   description "Electric Cost Analyzer (Timex)"
   year "1983"
   manufacturer "Tim Rossetti"
@@ -1330,7 +1330,7 @@ game (
 )
 
 game (
-  name "The Electronic Checkbook (Timeworks)"
+  name "The Electronic Checkbook (Timeworks) [P]"
   description "The Electronic Checkbook (Timeworks)"
   year "1982"
   manufacturer "Timeworks"
@@ -1338,7 +1338,7 @@ game (
 )
 
 game (
-  name "The Electronic Checkbook (Timeworks)"
+  name "The Electronic Checkbook (Timeworks) [TZX]"
   description "The Electronic Checkbook (Timeworks)"
   year "1982"
   manufacturer "Timeworks"
@@ -1346,21 +1346,21 @@ game (
 )
 
 game (
-  name "Electronics (Spectre)"
+  name "Electronics (Spectre) [P]"
   description "Electronics (Spectre)"
   manufacturer "Spectre"
   rom ( name "electronics.p" size 15899 crc B18D5D28 md5 8D3EE1B1EB0D3DF446F50731C6659279 sha1 2F56472672D41361C60591D7CF177EB18148976B )
 )
 
 game (
-  name "Electronics (Spectre)"
+  name "Electronics (Spectre) [TZX]"
   description "Electronics (Spectre)"
   manufacturer "Spectre"
   rom ( name "Electronics.tzx" size 16121 crc E777753A md5 48B223D7A2E94415AD4DC381B6A33FE8 sha1 D3A41D3AA66DB93144EEF927A1C37FC8BB9FAB90 )
 )
 
 game (
-  name "Encounter (Quicksilva)"
+  name "Encounter (Quicksilva) [TZX]"
   description "Encounter (Quicksilva)"
   year "1982"
   manufacturer "Pixel"
@@ -1368,7 +1368,7 @@ game (
 )
 
 game (
-  name "Escape From Manhattan (Computer Rentals)"
+  name "Escape From Manhattan (Computer Rentals) [TZX]"
   description "Escape From Manhattan (Computer Rentals)"
   year "1983"
   manufacturer "N. Taylor"
@@ -1376,7 +1376,7 @@ game (
 )
 
 game (
-  name "Escape From Manhattan (Computer Rentals)"
+  name "Escape From Manhattan (Computer Rentals) [P]"
   description "Escape From Manhattan (Computer Rentals)"
   year "1983"
   manufacturer "N. Taylor"
@@ -1384,7 +1384,7 @@ game (
 )
 
 game (
-  name "Escape from Shazzar (International Publishing and Software Inc.)"
+  name "Escape from Shazzar (International Publishing and Software Inc.) [TZX]"
   description "Escape from Shazzar (International Publishing and Software Inc.)"
   year "1983"
   manufacturer "A. F. Nuttall"
@@ -1392,7 +1392,7 @@ game (
 )
 
 game (
-  name "Escape from Shazzar (International Publishing and Software Inc.)"
+  name "Escape from Shazzar (International Publishing and Software Inc.) [P]"
   description "Escape from Shazzar (International Publishing and Software Inc.)"
   year "1983"
   manufacturer "A. F. Nuttall"
@@ -1400,7 +1400,7 @@ game (
 )
 
 game (
-  name "Adventure D - Espionage Island (Sinclair Research)"
+  name "Adventure D - Espionage Island (Sinclair Research) [TZX]"
   description "Adventure D: Espionage Island (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -1408,7 +1408,7 @@ game (
 )
 
 game (
-  name "Adventure D - Espionage Island (Sinclair Research)"
+  name "Adventure D - Espionage Island (Sinclair Research) [P]"
   description "Adventure D: Espionage Island (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -1416,21 +1416,21 @@ game (
 )
 
 game (
-  name "Adventure D - Espionage Island (Artic)"
+  name "Adventure D - Espionage Island (Artic) [TZX]"
   description "Adventure D: Espionage Island (Artic)"
   manufacturer "Artic"
   rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06A3887C md5 30754AA09608D83DEB1C0194C04B85CB sha1 7B36F0BCE5ECCB9FC3DC4FB553516E5E7F5ADABE )
 )
 
 game (
-  name "Adventure D - Espionage Island (Artic)"
+  name "Adventure D - Espionage Island (Artic) [P]"
   description "Adventure D: Espionage Island (Artic)"
   manufacturer "Artic"
   rom ( name "espionageisland(artic).p" size 15504 crc AC8DF706 md5 348A6B4FBEC8E375DAF1BE03D1C674DF sha1 8AD3E1AE97A34A6F6B1E2F653AEED770BA33F01E )
 )
 
 game (
-  name "FUNdamentals of Math (Timex)"
+  name "FUNdamentals of Math (Timex) [TZX]"
   description "FUNdamentals of Math (Timex)"
   year "1983"
   manufacturer "ATM"
@@ -1438,7 +1438,7 @@ game (
 )
 
 game (
-  name "Fast Load Save (Musamy Software)"
+  name "Fast Load Save (Musamy Software) [TZX]"
   description "Fast Load Save (Musamy Software)"
   year "1982"
   manufacturer "Musamy Software"
@@ -1446,14 +1446,14 @@ game (
 )
 
 game (
-  name "The Fast One (Campbell Systems)"
+  name "The Fast One (Campbell Systems) [TZX]"
   description "The Fast One (Campbell Systems)"
   manufacturer "Campbell Systems"
   rom ( name "FastOne(Green).tzx" size 9837 crc 3C57D2F2 md5 24BFE29D78AC664AA6B367EF983C590D sha1 C31F2892EA9145CDAB6EF5F21CD126AB9D079036 )
 )
 
 game (
-  name "Flight Simulation (Sinclair Research)"
+  name "Flight Simulation (Sinclair Research) [P]"
   description "Flight Simulation (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -1461,7 +1461,7 @@ game (
 )
 
 game (
-  name "Flight Simulation (Sinclair Research)"
+  name "Flight Simulation (Sinclair Research) [TZX]"
   description "Flight Simulation (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -1469,7 +1469,7 @@ game (
 )
 
 game (
-  name "The Flight Simulator (Timex)"
+  name "The Flight Simulator (Timex) [TZX]"
   description "The Flight Simulator (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -1477,7 +1477,7 @@ game (
 )
 
 game (
-  name "The Flight Simulator (Timex)"
+  name "The Flight Simulator (Timex) [P]"
   description "The Flight Simulator (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -1485,7 +1485,7 @@ game (
 )
 
 game (
-  name "Flug-Simulation (Sinclair Research)"
+  name "Flug-Simulation (Sinclair Research) [TZX]"
   description "Flug-Simulation (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -1493,7 +1493,7 @@ game (
 )
 
 game (
-  name "Flug-Simulation (Sinclair Research)"
+  name "Flug-Simulation (Sinclair Research) [P]"
   description "Flug-Simulation (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -1501,21 +1501,21 @@ game (
 )
 
 game (
-  name "Football (Tyrant)"
+  name "Football (Tyrant) [TZX]"
   description "Football (Tyrant)"
   manufacturer "Tyrant"
   rom ( name "Football.tzx" size 15858 crc 8503533C md5 673DFECB1920D35FCD55F23AAB95DBF8 sha1 D75DFC7310F08160F7FF61F2E08F2ED4FA5AABB0 )
 )
 
 game (
-  name "Football (Tyrant)"
+  name "Football (Tyrant) [P]"
   description "Football (Tyrant)"
   manufacturer "Tyrant"
   rom ( name "football.p" size 15626 crc 33233387 md5 EF4F6C235F9017F7B4C83F19FFC72818 sha1 F0EE8A1607A606D22B7C2BA518A06BD2CD387FD9 )
 )
 
 game (
-  name "Football-League (Video Software)"
+  name "Football-League (Video Software) [TZX]"
   description "Football-League (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -1523,7 +1523,7 @@ game (
 )
 
 game (
-  name "Football-League (Video Software)"
+  name "Football-League (Video Software) [P]"
   description "Football-League (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -1531,7 +1531,7 @@ game (
 )
 
 game (
-  name "Football Manager (Addictive Games)"
+  name "Football Manager (Addictive Games) [TZX]"
   description "Football Manager (Addictive Games)"
   year "1982"
   manufacturer "Kevin J. Toms"
@@ -1539,7 +1539,7 @@ game (
 )
 
 game (
-  name "Football Manager (Addictive Games)"
+  name "Football Manager (Addictive Games) [P]"
   description "Football Manager (Addictive Games)"
   year "1982"
   manufacturer "Kevin J. Toms"
@@ -1547,7 +1547,7 @@ game (
 )
 
 game (
-  name "Football Manager (Black inlay) (Addictive Games)"
+  name "Football Manager (Black inlay) (Addictive Games) [P]"
   description "Football Manager (Black inlay) (Addictive Games)"
   year "1981"
   manufacturer "Kevin J. Toms"
@@ -1555,7 +1555,7 @@ game (
 )
 
 game (
-  name "Football Manager (Black inlay) (Addictive Games)"
+  name "Football Manager (Black inlay) (Addictive Games) [TZX]"
   description "Football Manager (Black inlay) (Addictive Games)"
   year "1981"
   manufacturer "Kevin J. Toms"
@@ -1563,7 +1563,7 @@ game (
 )
 
 game (
-  name "Football Manager (Red) (Addictive Games)"
+  name "Football Manager (Red) (Addictive Games) [P]"
   description "Football Manager (Red) (Addictive Games)"
   year "1981"
   manufacturer "Kevin J. Toms"
@@ -1571,7 +1571,7 @@ game (
 )
 
 game (
-  name "Football Manager (Red) (Addictive Games)"
+  name "Football Manager (Red) (Addictive Games) [TZX]"
   description "Football Manager (Red) (Addictive Games)"
   year "1981"
   manufacturer "Kevin J. Toms"
@@ -1579,14 +1579,14 @@ game (
 )
 
 game (
-  name "Football Pools Program (Hartland Software)"
+  name "Football Pools Program (Hartland Software) [TZX]"
   description "Football Pools Program (Hartland Software)"
   manufacturer "Hartland Software"
   rom ( name "FootballPools.tzx" size 24422 crc 2D0ED98B md5 387BB8707269DE22CFB13B4C8781D20C sha1 A2AE0611AD434600777C2BA0DF4CC48D8109D9F8 )
 )
 
 game (
-  name "Forth (Sinclair Research)"
+  name "Forth (Sinclair Research) [TZX]"
   description "Forth (Sinclair Research)"
   year "1983"
   manufacturer "Artic"
@@ -1594,7 +1594,7 @@ game (
 )
 
 game (
-  name "Fortress of Zorlac (Timex)"
+  name "Fortress of Zorlac (Timex) [P]"
   description "Fortress of Zorlac (Timex)"
   year "1982"
   manufacturer "Paul Carlson"
@@ -1602,7 +1602,7 @@ game (
 )
 
 game (
-  name "Fortress of Zorlac (Timex)"
+  name "Fortress of Zorlac (Timex) [TZX]"
   description "Fortress of Zorlac (Timex)"
   year "1982"
   manufacturer "Paul Carlson"
@@ -1610,35 +1610,35 @@ game (
 )
 
 game (
-  name "Forty Niner (Software Farm)"
+  name "Forty Niner (Software Farm) [TZX]"
   description "Forty Niner (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "FortyNiner.tzx" size 14106 crc 1C4EFF0A md5 FBA0B998270A673AF60EDE6B1F6DA4FF sha1 E563342E858B8C38A384EBFD695C479FEB01A4A5 )
 )
 
 game (
-  name "Forty Niner (Software Farm)"
+  name "Forty Niner (Software Farm) [P]"
   description "Forty Niner (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "fortyniner.p" size 13868 crc B8650DA4 md5 9729D9B8A4FAEE1D12F4384F789C0B44 sha1 694AC6D1410EADE17ECC9E06A3C39191E8DDA352 )
 )
 
 game (
-  name "Frogger (DJL Software)"
+  name "Frogger (DJL Software) [P]"
   description "Frogger (DJL Software)"
   manufacturer "DJL Software"
   rom ( name "frogger.p" size 13493 crc 8D24D478 md5 DB791414F02377A0B2BB60E1539401F3 sha1 29D815B98770A1FBAE3714642C5C70583D02ED17 )
 )
 
 game (
-  name "Frogger (DJL Software)"
+  name "Frogger (DJL Software) [TZX]"
   description "Frogger (DJL Software)"
   manufacturer "DJL Software"
   rom ( name "Frogger.tzx" size 13723 crc BD7DF880 md5 9A8C77A4C24E8E67F7308BE91A2B95AA sha1 75499B16DE8DFBABF668328109D0A36963BFD11B )
 )
 
 game (
-  name "Frogger (Sega) (Timex)"
+  name "Frogger (Sega) (Timex) [P]"
   description "Frogger (Sega) (Timex)"
   year "1981"
   manufacturer "Cornsoft/Sega"
@@ -1646,7 +1646,7 @@ game (
 )
 
 game (
-  name "Frogger (Sega) (Timex)"
+  name "Frogger (Sega) (Timex) [TZX]"
   description "Frogger (Sega) (Timex)"
   year "1981"
   manufacturer "Cornsoft/Sega"
@@ -1654,7 +1654,7 @@ game (
 )
 
 game (
-  name "Froggy (DJL Software)"
+  name "Froggy (DJL Software) [P]"
   description "Froggy (DJL Software)"
   year "1982"
   manufacturer "DJL Software"
@@ -1662,7 +1662,7 @@ game (
 )
 
 game (
-  name "Froggy (DJL Software)"
+  name "Froggy (DJL Software) [TZX]"
   description "Froggy (DJL Software)"
   year "1982"
   manufacturer "DJL Software"
@@ -1670,21 +1670,21 @@ game (
 )
 
 game (
-  name "Frogs (Mikro-Gen)"
+  name "Frogs (Mikro-Gen) [P]"
   description "Frogs (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "frogs.p" size 4223 crc B5335A99 md5 55D1B367C05A5F9259DA78AAD2B072DA sha1 D3EDABF6C4E7E88CB1224ACE1C63B2735DBF2F0F )
 )
 
 game (
-  name "Frogs (Mikro-Gen)"
+  name "Frogs (Mikro-Gen) [TZX]"
   description "Frogs (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "Frogs.tzx" size 4453 crc EFD0F05E md5 9409197480D2E19DA908B0594580EE89 sha1 899D5CDF74208E30D17C5D34F5733D207222DAAA )
 )
 
 game (
-  name "Fun Fair Adventure (Fawkes Computing)"
+  name "Fun Fair Adventure (Fawkes Computing) [P]"
   description "Fun Fair Adventure (Fawkes Computing)"
   year "1983"
   manufacturer "Fawkes Computing"
@@ -1692,7 +1692,7 @@ game (
 )
 
 game (
-  name "Fun Fair Adventure (Fawkes Computing)"
+  name "Fun Fair Adventure (Fawkes Computing) [TZX]"
   description "Fun Fair Adventure (Fawkes Computing)"
   year "1983"
   manufacturer "Fawkes Computing"
@@ -1700,7 +1700,7 @@ game (
 )
 
 game (
-  name "Galactic Gunner (Timex)"
+  name "Galactic Gunner (Timex) [P]"
   description "Galactic Gunner (Timex)"
   year "1983"
   manufacturer "Paul W. Carlson"
@@ -1708,7 +1708,7 @@ game (
 )
 
 game (
-  name "Galactic Gunner (Timex)"
+  name "Galactic Gunner (Timex) [TZX]"
   description "Galactic Gunner (Timex)"
   year "1983"
   manufacturer "Paul W. Carlson"
@@ -1716,7 +1716,7 @@ game (
 )
 
 game (
-  name "Galactic Patrol (Computer Rentals)"
+  name "Galactic Patrol (Computer Rentals) [TZX]"
   description "Galactic Patrol (Computer Rentals)"
   year "1983"
   manufacturer "Richard Brisbourne"
@@ -1724,7 +1724,7 @@ game (
 )
 
 game (
-  name "Galactic Patrol (Computer Rentals)"
+  name "Galactic Patrol (Computer Rentals) [P]"
   description "Galactic Patrol (Computer Rentals)"
   year "1983"
   manufacturer "Richard Brisbourne"
@@ -1732,7 +1732,7 @@ game (
 )
 
 game (
-  name "Galactic Patrol (Omega re-release) (Omega)"
+  name "Galactic Patrol (Omega re-release) (Omega) [TZX]"
   description "Galactic Patrol (Omega re-release) (Omega)"
   year "1984"
   manufacturer "CRL"
@@ -1740,7 +1740,7 @@ game (
 )
 
 game (
-  name "Galactic Patrol (Omega re-release) (Omega)"
+  name "Galactic Patrol (Omega re-release) (Omega) [P]"
   description "Galactic Patrol (Omega re-release) (Omega)"
   year "1984"
   manufacturer "CRL"
@@ -1748,7 +1748,7 @@ game (
 )
 
 game (
-  name "Galactic Trooper (Romik Software)"
+  name "Galactic Trooper (Romik Software) [TZX]"
   description "Galactic Trooper (Romik Software)"
   year "1983"
   manufacturer "Ian Morrison and David Anderson"
@@ -1756,7 +1756,7 @@ game (
 )
 
 game (
-  name "Galactic Trooper (Romik Software)"
+  name "Galactic Trooper (Romik Software) [P]"
   description "Galactic Trooper (Romik Software)"
   year "1983"
   manufacturer "Ian Morrison and David Anderson"
@@ -1764,35 +1764,35 @@ game (
 )
 
 game (
-  name "Galaxians (Artic)"
+  name "Galaxians (Artic) [P]"
   description "Galaxians (Artic)"
   manufacturer "Artic"
   rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
 )
 
 game (
-  name "Galaxians (Artic)"
+  name "Galaxians (Artic) [TZX]"
   description "Galaxians (Artic)"
   manufacturer "Artic"
   rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
 )
 
 game (
-  name "Galaxians (Monochrome) (Artic)"
+  name "Galaxians (Monochrome) (Artic) [TZX]"
   description "Galaxians (Monochrome) (Artic)"
   manufacturer "Artic"
   rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
 )
 
 game (
-  name "Galaxians (Monochrome) (Artic)"
+  name "Galaxians (Monochrome) (Artic) [P]"
   description "Galaxians (Monochrome) (Artic)"
   manufacturer "Artic"
   rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
 )
 
 game (
-  name "Galaxy Invaders (International Publishing and Software Inc.)"
+  name "Galaxy Invaders (International Publishing and Software Inc.) [TZX]"
   description "Galaxy Invaders (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -1800,7 +1800,7 @@ game (
 )
 
 game (
-  name "Galaxy Invaders (International Publishing and Software Inc.)"
+  name "Galaxy Invaders (International Publishing and Software Inc.) [P]"
   description "Galaxy Invaders (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -1808,7 +1808,7 @@ game (
 )
 
 game (
-  name "Galaxy Jailbreak (Romik Software)"
+  name "Galaxy Jailbreak (Romik Software) [P]"
   description "Galaxy Jailbreak (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -1816,7 +1816,7 @@ game (
 )
 
 game (
-  name "Galaxy Jailbreak (Romik Software)"
+  name "Galaxy Jailbreak (Romik Software) [TZX]"
   description "Galaxy Jailbreak (Romik Software)"
   year "1983"
   manufacturer "Roland Stokes"
@@ -1824,14 +1824,14 @@ game (
 )
 
 game (
-  name "Galaxy Warrior/Star Trek (Artic)"
+  name "Galaxy Warrior_Star Trek (Artic) [TZX]"
   description "Galaxy Warrior/Star Trek (Artic)"
   manufacturer "Artic"
   rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1BCB3A5F md5 FFF5135CA3AC8C8553E9EACE62D55667 sha1 ABFB5609BFA713C2F4841BC45BA11EB7363B6BF7 )
 )
 
 game (
-  name "The Gambler (Timex)"
+  name "The Gambler (Timex) [TZX]"
   description "The Gambler (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -1839,7 +1839,7 @@ game (
 )
 
 game (
-  name "Games Pack (JRS Software)"
+  name "Games Pack (JRS Software) [TZX]"
   description "Games Pack (JRS Software)"
   year "1982"
   manufacturer "JRS Software"
@@ -1847,7 +1847,7 @@ game (
 )
 
 game (
-  name "The Gauntlet (Colourmatic)"
+  name "The Gauntlet (Colourmatic) [P]"
   description "The Gauntlet (Colourmatic)"
   year "1982"
   manufacturer "Colourmatic"
@@ -1855,7 +1855,7 @@ game (
 )
 
 game (
-  name "The Gauntlet (Colourmatic)"
+  name "The Gauntlet (Colourmatic) [TZX]"
   description "The Gauntlet (Colourmatic)"
   year "1982"
   manufacturer "Colourmatic"
@@ -1863,7 +1863,7 @@ game (
 )
 
 game (
-  name "The Gauntlet (PSS) (PSS)"
+  name "The Gauntlet (PSS) (PSS) [P]"
   description "The Gauntlet (PSS) (PSS)"
   year "1984"
   manufacturer "Colourmatic"
@@ -1871,7 +1871,7 @@ game (
 )
 
 game (
-  name "The Gauntlet (PSS) (PSS)"
+  name "The Gauntlet (PSS) (PSS) [TZX]"
   description "The Gauntlet (PSS) (PSS)"
   year "1984"
   manufacturer "Colourmatic"
@@ -1879,7 +1879,7 @@ game (
 )
 
 game (
-  name "General Statistics (W. H. Smith)"
+  name "General Statistics (W. H. Smith) [TZX]"
   description "General Statistics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -1887,7 +1887,7 @@ game (
 )
 
 game (
-  name "General Statistics (W. H. Smith)"
+  name "General Statistics (W. H. Smith) [P]"
   description "General Statistics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -1895,21 +1895,21 @@ game (
 )
 
 game (
-  name "Geographics UK (Novus Software)"
+  name "Geographics UK (Novus Software) [TZX]"
   description "Geographics UK (Novus Software)"
   manufacturer "Novus"
   rom ( name "GeographicsUK.tzx" size 16281 crc 4AF3CFC9 md5 4534B531E811C27A32EFFAA76A9A257E sha1 0D88E5BC5E71CC898A375156E40396B5B536D7A0 )
 )
 
 game (
-  name "Geographics UK (Novus Software)"
+  name "Geographics UK (Novus Software) [P]"
   description "Geographics UK (Novus Software)"
   manufacturer "Novus"
   rom ( name "geographicsuk.p" size 16037 crc FBC771BF md5 FEA62F9B738C3F63CF9DE62A37431588 sha1 FB07EBDDCA1F03EEF2B4D06052D4ABDE520D4AE0 )
 )
 
 game (
-  name "Geometry 1 (Timex)"
+  name "Geometry 1 (Timex) [TZX]"
   description "Geometry 1 (Timex)"
   year "1982"
   manufacturer "Home Computer Software"
@@ -1917,7 +1917,7 @@ game (
 )
 
 game (
-  name "Ghost Hunt (PSS)"
+  name "Ghost Hunt (PSS) [TZX]"
   description "Ghost Hunt (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -1925,7 +1925,7 @@ game (
 )
 
 game (
-  name "Ghost Hunt (PSS)"
+  name "Ghost Hunt (PSS) [P]"
   description "Ghost Hunt (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -1933,35 +1933,35 @@ game (
 )
 
 game (
-  name "Gobbleman (Monochrome Inlay) (Artic)"
+  name "Gobbleman (Monochrome Inlay) (Artic) [P]"
   description "Gobbleman (Monochrome Inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
 )
 
 game (
-  name "Gobbleman (Colour Inlay) (Artic)"
+  name "Gobbleman (Colour Inlay) (Artic) [P]"
   description "Gobbleman (Colour Inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
 )
 
 game (
-  name "Gobblers (Software Farm)"
+  name "Gobblers (Software Farm) [P]"
   description "Gobblers (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "gobblers.p" size 7162 crc B7687E93 md5 CB4CFA5B341C3D129405A82D97BC84BF sha1 FC15194E2CD43C8ED2121BC76331313532BD49DA )
 )
 
 game (
-  name "Gobblers (Software Farm)"
+  name "Gobblers (Software Farm) [TZX]"
   description "Gobblers (Software Farm)"
   manufacturer "Software Farm"
   rom ( name "Gobblers.tzx" size 7394 crc DAFE76E1 md5 8DE20A364CA8693EB9C755A7DA120189 sha1 681BD965A868D25B3DED5C9111C6F6A622A7DF1E )
 )
 
 game (
-  name "Gold (Hilderbay)"
+  name "Gold (Hilderbay) [TZX]"
   description "Gold (Hilderbay)"
   year "1981"
   manufacturer "Hilderbay"
@@ -1969,7 +1969,7 @@ game (
 )
 
 game (
-  name "Golf (R & R Software)"
+  name "Golf (R & R Software) [TZX]"
   description "Golf (R & R Software)"
   year "1982"
   manufacturer "R & R Software"
@@ -1977,7 +1977,7 @@ game (
 )
 
 game (
-  name "Golf (R & R Software)"
+  name "Golf (R & R Software) [P]"
   description "Golf (R & R Software)"
   year "1982"
   manufacturer "R & R Software"
@@ -1985,7 +1985,7 @@ game (
 )
 
 game (
-  name "Graphics Kit (Softsync)"
+  name "Graphics Kit (Softsync) [TZX]"
   description "Graphics Kit (Softsync)"
   year "1981"
   manufacturer "Paul Holmes"
@@ -1993,21 +1993,21 @@ game (
 )
 
 game (
-  name "Great Britain Ltd (Simon W. Hessel)"
+  name "Great Britain Ltd (Simon W. Hessel) [P]"
   description "Great Britain Ltd (Simon W. Hessel)"
   manufacturer "Simon W. Hessel"
   rom ( name "greatbritainltd.p" size 15541 crc 23AD347C md5 E4B1812BD16EA7CFDD416E932467E4D4 sha1 8EAFC58C5610B3901B85478DA04D25156F00BFF1 )
 )
 
 game (
-  name "Great Britain Ltd (Simon W. Hessel)"
+  name "Great Britain Ltd (Simon W. Hessel) [TZX]"
   description "Great Britain Ltd (Simon W. Hessel)"
   manufacturer "Simon W. Hessel"
   rom ( name "GreatBritainLtd.tzx" size 15767 crc 4B717923 md5 07BFF59AB86D31689CF4450D21F3741D sha1 BBDE7B36F9F2CB65CD0EF2F112C52CE612A19433 )
 )
 
 game (
-  name "Grimm's Fairy Trails (Timex)"
+  name "Grimm's Fairy Trails (Timex) [P]"
   description "Grimm's Fairy Trails (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2015,7 +2015,7 @@ game (
 )
 
 game (
-  name "Grimm's Fairy Trails (Timex)"
+  name "Grimm's Fairy Trails (Timex) [TZX]"
   description "Grimm's Fairy Trails (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2023,7 +2023,7 @@ game (
 )
 
 game (
-  name "Guitar For Beginners (Timex)"
+  name "Guitar For Beginners (Timex) [TZX]"
   description "Guitar For Beginners (Timex)"
   year "1982"
   manufacturer "Tim Rossetti"
@@ -2031,7 +2031,7 @@ game (
 )
 
 game (
-  name "Guitar For Beginners (Timex)"
+  name "Guitar For Beginners (Timex) [P]"
   description "Guitar For Beginners (Timex)"
   year "1982"
   manufacturer "Tim Rossetti"
@@ -2039,7 +2039,7 @@ game (
 )
 
 game (
-  name "Gulp (Mindware)"
+  name "Gulp (Mindware) [TZX]"
   description "Gulp (Mindware)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2047,7 +2047,7 @@ game (
 )
 
 game (
-  name "Gulp (Mindware)"
+  name "Gulp (Mindware) [P]"
   description "Gulp (Mindware)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2055,7 +2055,7 @@ game (
 )
 
 game (
-  name "Gulp 2 (Campbell Systems)"
+  name "Gulp 2 (Campbell Systems) [P]"
   description "Gulp 2 (Campbell Systems)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2063,7 +2063,7 @@ game (
 )
 
 game (
-  name "Gulp 2 (Campbell Systems)"
+  name "Gulp 2 (Campbell Systems) [TZX]"
   description "Gulp 2 (Campbell Systems)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2071,7 +2071,7 @@ game (
 )
 
 game (
-  name "Gulpman (Micromega)"
+  name "Gulpman (Micromega) [TZX]"
   description "Gulpman (Micromega)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2079,7 +2079,7 @@ game (
 )
 
 game (
-  name "Gulpman (Micromega)"
+  name "Gulpman (Micromega) [P]"
   description "Gulpman (Micromega)"
   year "1982"
   manufacturer "Campbell Systems"
@@ -2087,7 +2087,7 @@ game (
 )
 
 game (
-  name "HRG 7.0 (Unknown)"
+  name "HRG 7.0 (Unknown) [TZX]"
   description "HRG 7.0 (Unknown)"
   year "1983"
   manufacturer "J. M. Cohen"
@@ -2095,7 +2095,7 @@ game (
 )
 
 game (
-  name "Haute Resolution (Pluto)"
+  name "Haute Resolution (Pluto) [TZX]"
   description "Haute Resolution (Pluto)"
   year "1984"
   manufacturer "CRL"
@@ -2103,7 +2103,7 @@ game (
 )
 
 game (
-  name "Heating System Analyzer (Timex)"
+  name "Heating System Analyzer (Timex) [TZX]"
   description "Heating System Analyzer (Timex)"
   year "1982"
   manufacturer "Tim Rossetti"
@@ -2111,7 +2111,7 @@ game (
 )
 
 game (
-  name "Heating System Analyzer (Timex)"
+  name "Heating System Analyzer (Timex) [P]"
   description "Heating System Analyzer (Timex)"
   year "1982"
   manufacturer "Tim Rossetti"
@@ -2119,7 +2119,7 @@ game (
 )
 
 game (
-  name "High Res (Macronics)"
+  name "High Res (Macronics) [P]"
   description "High Res (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -2127,7 +2127,7 @@ game (
 )
 
 game (
-  name "High Res (Macronics)"
+  name "High Res (Macronics) [TZX]"
   description "High Res (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -2135,7 +2135,7 @@ game (
 )
 
 game (
-  name "The Home Asset Manager (Timex)"
+  name "The Home Asset Manager (Timex) [P]"
   description "The Home Asset Manager (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2143,7 +2143,7 @@ game (
 )
 
 game (
-  name "The Home Asset Manager (Timex)"
+  name "The Home Asset Manager (Timex) [TZX]"
   description "The Home Asset Manager (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2151,7 +2151,7 @@ game (
 )
 
 game (
-  name "The Home Improvement Planner (Timex)"
+  name "The Home Improvement Planner (Timex) [P]"
   description "The Home Improvement Planner (Timex)"
   year "1982"
   manufacturer "K. Frink"
@@ -2159,7 +2159,7 @@ game (
 )
 
 game (
-  name "The Home Improvement Planner (Timex)"
+  name "The Home Improvement Planner (Timex) [TZX]"
   description "The Home Improvement Planner (Timex)"
   year "1982"
   manufacturer "K. Frink"
@@ -2167,7 +2167,7 @@ game (
 )
 
 game (
-  name "Hopper (PSS)"
+  name "Hopper (PSS) [TZX]"
   description "Hopper (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -2175,7 +2175,7 @@ game (
 )
 
 game (
-  name "Hopper (PSS)"
+  name "Hopper (PSS) [P]"
   description "Hopper (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -2183,7 +2183,7 @@ game (
 )
 
 game (
-  name "Hopper (Truck) (PSS)"
+  name "Hopper (Truck) (PSS) [P]"
   description "Hopper (Truck) (PSS)"
   year "1981"
   manufacturer "PSS"
@@ -2191,7 +2191,7 @@ game (
 )
 
 game (
-  name "Hopper (Truck) (PSS)"
+  name "Hopper (Truck) (PSS) [TZX]"
   description "Hopper (Truck) (PSS)"
   year "1981"
   manufacturer "PSS"
@@ -2199,21 +2199,21 @@ game (
 )
 
 game (
-  name "House of Death (A. J. Rushton)"
+  name "House of Death (A. J. Rushton) [TZX]"
   description "House of Death (A. J. Rushton)"
   manufacturer "A. J. Rushton"
   rom ( name "HouseOfDeath.tzx" size 15289 crc E78272E3 md5 68FB7BFD61E73901337800B912DB3760 sha1 80EE47DD77A43C051C600A38DEF525950A110119 )
 )
 
 game (
-  name "House of Death (A. J. Rushton)"
+  name "House of Death (A. J. Rushton) [P]"
   description "House of Death (A. J. Rushton)"
   manufacturer "A. J. Rushton"
   rom ( name "houseofdeath.p" size 15045 crc D88C206A md5 89E832D5035229BCFE30A9D77A0242A9 sha1 962346B1F5E5D9F8C025994824736AC497BE1EA2 )
 )
 
 game (
-  name "The IRA Planner (Timex)"
+  name "The IRA Planner (Timex) [TZX]"
   description "The IRA Planner (Timex)"
   year "1982"
   manufacturer "Vincent H. Chase"
@@ -2221,7 +2221,7 @@ game (
 )
 
 game (
-  name "Adventure B - Inca Curse (Sinclair Research)"
+  name "Adventure B - Inca Curse (Sinclair Research) [P]"
   description "Adventure B: Inca Curse (Sinclair Research)"
   year "1981"
   manufacturer "Artic"
@@ -2229,7 +2229,7 @@ game (
 )
 
 game (
-  name "Adventure B - Inca Curse (Sinclair Research)"
+  name "Adventure B - Inca Curse (Sinclair Research) [TZX]"
   description "Adventure B: Inca Curse (Sinclair Research)"
   year "1981"
   manufacturer "Artic"
@@ -2237,7 +2237,7 @@ game (
 )
 
 game (
-  name "Adventure B - Inca Curse (Artic)"
+  name "Adventure B - Inca Curse (Artic) [TZX]"
   description "Adventure B: Inca Curse (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -2245,7 +2245,7 @@ game (
 )
 
 game (
-  name "Adventure B - Inca Curse (Artic)"
+  name "Adventure B - Inca Curse (Artic) [P]"
   description "Adventure B: Inca Curse (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -2253,7 +2253,7 @@ game (
 )
 
 game (
-  name "Introduction To Chemistry (Timex)"
+  name "Introduction To Chemistry (Timex) [TZX]"
   description "Introduction To Chemistry (Timex)"
   year "1983"
   manufacturer "J. J. Hollandsworth"
@@ -2261,7 +2261,7 @@ game (
 )
 
 game (
-  name "Invaders (Bug Byte)"
+  name "Invaders (Bug Byte) [TZX]"
   description "Invaders (Bug Byte)"
   year "1982"
   manufacturer "S. Munnery"
@@ -2269,7 +2269,7 @@ game (
 )
 
 game (
-  name "Invaders (Bug Byte)"
+  name "Invaders (Bug Byte) [P]"
   description "Invaders (Bug Byte)"
   year "1982"
   manufacturer "S. Munnery"
@@ -2277,21 +2277,21 @@ game (
 )
 
 game (
-  name "Invaders (A. G. Software)"
+  name "Invaders (A. G. Software) [TZX]"
   description "Invaders (A. G. Software)"
   manufacturer "Andrew Glaister"
   rom ( name "Invaders(AGS).tzx" size 2349 crc 58299C24 md5 6A329B8B6BDCA462DC2564297FB425F2 sha1 37503B2C552016A3265FF387AFCA6FFA6380C5E8 )
 )
 
 game (
-  name "Invaders (A. G. Software)"
+  name "Invaders (A. G. Software) [P]"
   description "Invaders (A. G. Software)"
   manufacturer "Andrew Glaister"
   rom ( name "invaders(ags).p" size 2117 crc 134835D7 md5 B2CB96DEB94F2CAF1167C6AA9EED3C35 sha1 125D09E68F9AD9490B47ADEE512BF46DB7286C2A )
 )
 
 game (
-  name "Invaders (Re-release) (Bug Byte)"
+  name "Invaders (Re-release) (Bug Byte) [TZX]"
   description "Invaders (Re-release) (Bug Byte)"
   year "1982"
   manufacturer "S. Munnery"
@@ -2299,7 +2299,7 @@ game (
 )
 
 game (
-  name "Invaders (Re-release) (Bug Byte)"
+  name "Invaders (Re-release) (Bug Byte) [P]"
   description "Invaders (Re-release) (Bug Byte)"
   year "1982"
   manufacturer "S. Munnery"
@@ -2307,35 +2307,35 @@ game (
 )
 
 game (
-  name "Invaders (Forward Software)"
+  name "Invaders (Forward Software) [TZX]"
   description "Invaders (Forward Software)"
   manufacturer "Silversoft"
   rom ( name "Invaders(Forward).tzx" size 3697 crc 3EA98BB5 md5 B52FECD042DA1349D326508F77D3DB33 sha1 A8AE592FE3B4B939B664BE00454FB591B004F478 )
 )
 
 game (
-  name "Invaders (Forward Software)"
+  name "Invaders (Forward Software) [P]"
   description "Invaders (Forward Software)"
   manufacturer "Silversoft"
   rom ( name "invaders(forward).p" size 3465 crc 7005EDA5 md5 0E940CD5D0FAB16B860C1E5648EA7B8A sha1 425223961FDB8C2825796B99BBC5358E51BF9B14 )
 )
 
 game (
-  name "Invaders (Monochrome) (Bug Byte)"
+  name "Invaders (Monochrome) (Bug Byte) [P]"
   description "Invaders (Monochrome) (Bug Byte)"
   manufacturer "S. Munnery"
   rom ( name "invaders(mono).p" size 2373 crc 2840348B md5 1B95516181A57DA16F56109CC87CFD94 sha1 1971694D7A009402C065F5D23CEC3AD847839232 )
 )
 
 game (
-  name "Invaders (Monochrome) (Bug Byte)"
+  name "Invaders (Monochrome) (Bug Byte) [TZX]"
   description "Invaders (Monochrome) (Bug Byte)"
   manufacturer "S. Munnery"
   rom ( name "Invaders(Mono).tzx" size 2605 crc 80E827F0 md5 186D39211398BDBB5497D1BA89DF5AB9 sha1 3AEB0FA4A5C458ACE0AFFC01F528D4B15EE047B8 )
 )
 
 game (
-  name "Invaders (Typed Inlay) (Bug Byte)"
+  name "Invaders (Typed Inlay) (Bug Byte) [TZX]"
   description "Invaders (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "S. Munnery"
@@ -2343,7 +2343,7 @@ game (
 )
 
 game (
-  name "Invaders (Typed Inlay) (Bug Byte)"
+  name "Invaders (Typed Inlay) (Bug Byte) [P]"
   description "Invaders (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "S. Munnery"
@@ -2351,7 +2351,7 @@ game (
 )
 
 game (
-  name "Invasion Force (Artic)"
+  name "Invasion Force (Artic) [TZX]"
   description "Invasion Force (Artic)"
   year "1982"
   manufacturer "Simon Wadsworth"
@@ -2359,7 +2359,7 @@ game (
 )
 
 game (
-  name "Invasion Force (Artic)"
+  name "Invasion Force (Artic) [P]"
   description "Invasion Force (Artic)"
   year "1982"
   manufacturer "Simon Wadsworth"
@@ -2367,7 +2367,7 @@ game (
 )
 
 game (
-  name "Invasion Force (International Publishing and Software Inc.)"
+  name "Invasion Force (International Publishing and Software Inc.) [TZX]"
   description "Invasion Force (International Publishing and Software Inc.)"
   year "1983"
   manufacturer "Simon Wadsworth"
@@ -2375,7 +2375,7 @@ game (
 )
 
 game (
-  name "Invasion Force (International Publishing and Software Inc.)"
+  name "Invasion Force (International Publishing and Software Inc.) [P]"
   description "Invasion Force (International Publishing and Software Inc.)"
   year "1983"
   manufacturer "Simon Wadsworth"
@@ -2383,21 +2383,21 @@ game (
 )
 
 game (
-  name "Inventory Control (Data-assette)"
+  name "Inventory Control (Data-assette) [TZX]"
   description "Inventory Control (Data-assette)"
   manufacturer "John Powers"
   rom ( name "InventoryControl(DA).tzx" size 16175 crc 21D56EC5 md5 BFADCA8523ED9926C47C20B04E980289 sha1 390707E52E816A1DF284B65CE1FD52E14110A504 )
 )
 
 game (
-  name "Inventory Control (Data-assette)"
+  name "Inventory Control (Data-assette) [P]"
   description "Inventory Control (Data-assette)"
   manufacturer "John Powers"
   rom ( name "inventorycontrol(da).p" size 15941 crc EB911B8B md5 2E9C7B2134665A0FA235764E75CC2957 sha1 4F63DB3C39FF4AABB3E0661500095F0C69DAB41D )
 )
 
 game (
-  name "J.D.Arcades (Computer Rentals)"
+  name "J.D.Arcades (Computer Rentals) [P]"
   description "J.D.Arcades (Computer Rentals)"
   year "1982"
   manufacturer "John Davies"
@@ -2405,7 +2405,7 @@ game (
 )
 
 game (
-  name "J.D.Arcades (Computer Rentals)"
+  name "J.D.Arcades (Computer Rentals) [TZX]"
   description "J.D.Arcades (Computer Rentals)"
   year "1982"
   manufacturer "John Davies"
@@ -2413,7 +2413,7 @@ game (
 )
 
 game (
-  name "Kasino Kraps (Timex)"
+  name "Kasino Kraps (Timex) [P]"
   description "Kasino Kraps (Timex)"
   year "1983"
   manufacturer "Gerald Bennett"
@@ -2421,7 +2421,7 @@ game (
 )
 
 game (
-  name "Kasino Kraps (Timex)"
+  name "Kasino Kraps (Timex) [TZX]"
   description "Kasino Kraps (Timex)"
   year "1983"
   manufacturer "Gerald Bennett"
@@ -2429,7 +2429,7 @@ game (
 )
 
 game (
-  name "Keyboard Calculator (Timex)"
+  name "Keyboard Calculator (Timex) [TZX]"
   description "Keyboard Calculator (Timex)"
   year "1982"
   manufacturer "J. Gishen"
@@ -2437,7 +2437,7 @@ game (
 )
 
 game (
-  name "Keys To Gondrun (International Publishing and Software Inc.)"
+  name "Keys To Gondrun (International Publishing and Software Inc.) [TZX]"
   description "Keys To Gondrun (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -2445,7 +2445,7 @@ game (
 )
 
 game (
-  name "Keys To Gondrun (International Publishing and Software Inc.)"
+  name "Keys To Gondrun (International Publishing and Software Inc.) [P]"
   description "Keys To Gondrun (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -2453,7 +2453,7 @@ game (
 )
 
 game (
-  name "Kingdom of Nam (Microgame Simulations)"
+  name "Kingdom of Nam (Microgame Simulations) [TZX]"
   description "Kingdom of Nam (Microgame Simulations)"
   year "1981"
   manufacturer "R. Erskine"
@@ -2461,7 +2461,7 @@ game (
 )
 
 game (
-  name "Kingdom of Nam (Microgame Simulations)"
+  name "Kingdom of Nam (Microgame Simulations) [P]"
   description "Kingdom of Nam (Microgame Simulations)"
   year "1981"
   manufacturer "R. Erskine"
@@ -2469,7 +2469,7 @@ game (
 )
 
 game (
-  name "The Knight's Quest (Phipps Associates)"
+  name "The Knight's Quest (Phipps Associates) [TZX]"
   description "The Knight's Quest (Phipps Associates)"
   year "1983"
   manufacturer "Mike Farley"
@@ -2477,7 +2477,7 @@ game (
 )
 
 game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
+  name "Kongs Revenge (Stephen Hartley Computing) [TZX]"
   description "Kongs Revenge (Stephen Hartley Computing)"
   year "1984"
   manufacturer "I. Kendrick"
@@ -2485,7 +2485,7 @@ game (
 )
 
 game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
+  name "Kongs Revenge (Stephen Hartley Computing) [P]"
   description "Kongs Revenge (Stephen Hartley Computing)"
   year "1984"
   manufacturer "I. Kendrick"
@@ -2493,7 +2493,7 @@ game (
 )
 
 game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
+  name "Kongs Revenge (Stephen Hartley Computing) [P]"
   description "Kongs Revenge (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. Kendrick"
@@ -2501,7 +2501,7 @@ game (
 )
 
 game (
-  name "Kongs Revenge (Stephen Hartley Computing)"
+  name "Kongs Revenge (Stephen Hartley Computing) [TZX]"
   description "Kongs Revenge (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. Kendrick"
@@ -2509,7 +2509,7 @@ game (
 )
 
 game (
-  name "Krazy Kong (PSS)"
+  name "Krazy Kong (PSS) [P]"
   description "Krazy Kong (PSS)"
   year "1982"
   manufacturer "C. P. Cullen"
@@ -2517,7 +2517,7 @@ game (
 )
 
 game (
-  name "Krazy Kong (PSS)"
+  name "Krazy Kong (PSS) [TZX]"
   description "Krazy Kong (PSS)"
   year "1982"
   manufacturer "C. P. Cullen"
@@ -2525,7 +2525,7 @@ game (
 )
 
 game (
-  name "Krazy Kong (Intercomputer Inc)"
+  name "Krazy Kong (Intercomputer Inc) [TZX]"
   description "Krazy Kong (Intercomputer Inc)"
   year "1983"
   manufacturer "C. P. Cullen"
@@ -2533,7 +2533,7 @@ game (
 )
 
 game (
-  name "Krazy Kong (Intercomputer Inc)"
+  name "Krazy Kong (Intercomputer Inc) [P]"
   description "Krazy Kong (Intercomputer Inc)"
   year "1983"
   manufacturer "C. P. Cullen"
@@ -2541,7 +2541,7 @@ game (
 )
 
 game (
-  name "Labyrinth (Axis)"
+  name "Labyrinth (Axis) [TZX]"
   description "Labyrinth (Axis)"
   year "1981"
   manufacturer "Axis"
@@ -2549,7 +2549,7 @@ game (
 )
 
 game (
-  name "Labyrinth (Axis)"
+  name "Labyrinth (Axis) [P]"
   description "Labyrinth (Axis)"
   year "1981"
   manufacturer "Axis"
@@ -2557,7 +2557,7 @@ game (
 )
 
 game (
-  name "Labyrinth (Colour Inlay) (Axis)"
+  name "Labyrinth (Colour Inlay) (Axis) [P]"
   description "Labyrinth (Colour Inlay) (Axis)"
   year "1981"
   manufacturer "Axis"
@@ -2565,7 +2565,7 @@ game (
 )
 
 game (
-  name "Labyrinth (Colour Inlay) (Axis)"
+  name "Labyrinth (Colour Inlay) (Axis) [TZX]"
   description "Labyrinth (Colour Inlay) (Axis)"
   year "1981"
   manufacturer "Axis"
@@ -2573,7 +2573,7 @@ game (
 )
 
 game (
-  name "Language Usage (Timex)"
+  name "Language Usage (Timex) [TZX]"
   description "Language Usage (Timex)"
   year "1982"
   manufacturer "Software for Excellence"
@@ -2581,7 +2581,7 @@ game (
 )
 
 game (
-  name "Lap Record (Macronics)"
+  name "Lap Record (Macronics) [P]"
   description "Lap Record (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -2589,7 +2589,7 @@ game (
 )
 
 game (
-  name "Lap Record (Macronics)"
+  name "Lap Record (Macronics) [TZX]"
   description "Lap Record (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -2597,7 +2597,7 @@ game (
 )
 
 game (
-  name "The List Manager (Timex)"
+  name "The List Manager (Timex) [TZX]"
   description "The List Manager (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2605,7 +2605,7 @@ game (
 )
 
 game (
-  name "The Loan/Mortgage Amortizer (Timex)"
+  name "The Loan_Mortgage Amortizer (Timex) [TZX]"
   description "The Loan/Mortgage Amortizer (Timex)"
   year "1982"
   manufacturer "T. J. Software"
@@ -2613,7 +2613,7 @@ game (
 )
 
 game (
-  name "The Loan/Mortgage Amortizer (Timex)"
+  name "The Loan_Mortgage Amortizer (Timex) [P]"
   description "The Loan/Mortgage Amortizer (Timex)"
   year "1982"
   manufacturer "T. J. Software"
@@ -2621,7 +2621,7 @@ game (
 )
 
 game (
-  name "Lost Island (JRS Software)"
+  name "Lost Island (JRS Software) [P]"
   description "Lost Island (JRS Software)"
   year "1982"
   manufacturer "JRS Software"
@@ -2629,7 +2629,7 @@ game (
 )
 
 game (
-  name "Lost Island (JRS Software)"
+  name "Lost Island (JRS Software) [TZX]"
   description "Lost Island (JRS Software)"
   year "1982"
   manufacturer "JRS Software"
@@ -2637,21 +2637,21 @@ game (
 )
 
 game (
-  name "Lunar Rescue (Mikro-Gen)"
+  name "Lunar Rescue (Mikro-Gen) [P]"
   description "Lunar Rescue (Mikro-Gen)"
   manufacturer "K. J. Bezant"
   rom ( name "lunarrescue.p" size 4657 crc 0EC491CE md5 62D3CD05D6EA6103CB47824C7316135F sha1 810FE42934480BC6967D058F91586CC558BF4BC5 )
 )
 
 game (
-  name "Lunar Rescue (Mikro-Gen)"
+  name "Lunar Rescue (Mikro-Gen) [TZX]"
   description "Lunar Rescue (Mikro-Gen)"
   manufacturer "K. J. Bezant"
   rom ( name "LunarRescue.tzx" size 4885 crc B63D952A md5 9D99D03E0DA02AB1601A4DBE89446BAB sha1 620F51472B3313AA14BEE80521E5654C05B4C5B6 )
 )
 
 game (
-  name "MCoder (PSS)"
+  name "MCoder (PSS) [P]"
   description "MCoder (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -2659,7 +2659,7 @@ game (
 )
 
 game (
-  name "MCoder (PSS)"
+  name "MCoder (PSS) [TZX]"
   description "MCoder (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -2667,7 +2667,7 @@ game (
 )
 
 game (
-  name "MCoder 11 (PSS)"
+  name "MCoder 11 (PSS) [TZX]"
   description "MCoder 11 (PSS)"
   year "1983"
   manufacturer "PSS"
@@ -2675,7 +2675,7 @@ game (
 )
 
 game (
-  name "MCoder 11 (PSS)"
+  name "MCoder 11 (PSS) [P]"
   description "MCoder 11 (PSS)"
   year "1983"
   manufacturer "PSS"
@@ -2683,7 +2683,7 @@ game (
 )
 
 game (
-  name "Machine Code Test Tool (F. O. Ainley)"
+  name "Machine Code Test Tool (F. O. Ainley) [P]"
   description "Machine Code Test Tool (F. O. Ainley)"
   year "1982"
   manufacturer "F. O. Ainley"
@@ -2691,7 +2691,7 @@ game (
 )
 
 game (
-  name "Machine Code Test Tool (F. O. Ainley)"
+  name "Machine Code Test Tool (F. O. Ainley) [TZX]"
   description "Machine Code Test Tool (F. O. Ainley)"
   year "1982"
   manufacturer "F. O. Ainley"
@@ -2699,7 +2699,7 @@ game (
 )
 
 game (
-  name "Manufacturing Control (Timex)"
+  name "Manufacturing Control (Timex) [P]"
   description "Manufacturing Control (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2707,7 +2707,7 @@ game (
 )
 
 game (
-  name "Manufacturing Control (Timex)"
+  name "Manufacturing Control (Timex) [TZX]"
   description "Manufacturing Control (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -2715,7 +2715,7 @@ game (
 )
 
 game (
-  name "Marine Rescue (International Publishing and Software Inc.)"
+  name "Marine Rescue (International Publishing and Software Inc.) [P]"
   description "Marine Rescue (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing & Software Inc."
@@ -2723,7 +2723,7 @@ game (
 )
 
 game (
-  name "Marine Rescue (International Publishing and Software Inc.)"
+  name "Marine Rescue (International Publishing and Software Inc.) [TZX]"
   description "Marine Rescue (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing & Software Inc."
@@ -2731,14 +2731,14 @@ game (
 )
 
 game (
-  name "Math Routines and Fit (Zeta Software)"
+  name "Math Routines and Fit (Zeta Software) [TZX]"
   description "Math Routines and Fit (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896DE80 md5 EE3E759E69B64248F0E5BD1846D63A76 sha1 AA81C6329174CB096D5690CF4D6456B0E0DBDCCC )
 )
 
 game (
-  name "Math Routines and Fit (Zeta Software)"
+  name "Math Routines and Fit (Zeta Software) [P]"
   description "Math Routines and Fit (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "mathroutinesandfit.p" size 15850 crc EF830293 md5 205EFA1A71BA01038CD3BC523F1A9667 sha1 C1A6B8F1C9798FB57FAEA5EE52DC1BCACEE68B1B )
@@ -2757,7 +2757,7 @@ game (
 )
 
 game (
-  name "Mazogs (Bug Byte)"
+  name "Mazogs (Bug Byte) [P]"
   description "Mazogs (Bug Byte)"
   year "1982"
   manufacturer "Don Priestley"
@@ -2765,7 +2765,7 @@ game (
 )
 
 game (
-  name "Mazogs (Bug Byte)"
+  name "Mazogs (Bug Byte) [TZX]"
   description "Mazogs (Bug Byte)"
   year "1982"
   manufacturer "Don Priestley"
@@ -2773,21 +2773,21 @@ game (
 )
 
 game (
-  name "Mazogs (Gladstone) (Gladstone Electronics)"
+  name "Mazogs (Gladstone) (Gladstone Electronics) [P]"
   description "Mazogs (Gladstone) (Gladstone Electronics)"
   manufacturer "Don Priestley"
   rom ( name "mazogs(ge).p" size 12942 crc BDAB60B2 md5 D8BBD02ADE6AC94438547F255C04517B sha1 14CA73F2AE0D621BA17FBC5E0F0E8D9184184347 )
 )
 
 game (
-  name "Mazogs (Gladstone) (Gladstone Electronics)"
+  name "Mazogs (Gladstone) (Gladstone Electronics) [TZX]"
   description "Mazogs (Gladstone) (Gladstone Electronics)"
   manufacturer "Don Priestley"
   rom ( name "Mazogs(GE).tzx" size 13170 crc 5D7DD442 md5 CB162114851F80E1A4A820D4E7E4CC22 sha1 94E2DA0938BD44F9C0392E2061E390E69D49D47B )
 )
 
 game (
-  name "Mazogs (Monochrome) (Bug Byte)"
+  name "Mazogs (Monochrome) (Bug Byte) [TZX]"
   description "Mazogs (Monochrome) (Bug Byte)"
   year "1981"
   manufacturer "Don Priestley"
@@ -2795,7 +2795,7 @@ game (
 )
 
 game (
-  name "Mazogs (Monochrome) (Bug Byte)"
+  name "Mazogs (Monochrome) (Bug Byte) [P]"
   description "Mazogs (Monochrome) (Bug Byte)"
   year "1981"
   manufacturer "Don Priestley"
@@ -2803,7 +2803,7 @@ game (
 )
 
 game (
-  name "Mazogs (Softsync)"
+  name "Mazogs (Softsync) [P]"
   description "Mazogs (Softsync)"
   year "1982"
   manufacturer "Don Priestley"
@@ -2811,7 +2811,7 @@ game (
 )
 
 game (
-  name "Mazogs (Softsync)"
+  name "Mazogs (Softsync) [TZX]"
   description "Mazogs (Softsync)"
   year "1982"
   manufacturer "Don Priestley"
@@ -2819,7 +2819,7 @@ game (
 )
 
 game (
-  name "Merchant of Venus (Crystal)"
+  name "Merchant of Venus (Crystal) [P]"
   description "Merchant of Venus (Crystal)"
   year "1983"
   manufacturer "Crystal"
@@ -2827,7 +2827,7 @@ game (
 )
 
 game (
-  name "Merchant of Venus (Crystal)"
+  name "Merchant of Venus (Crystal) [TZX]"
   description "Merchant of Venus (Crystal)"
   year "1983"
   manufacturer "Crystal"
@@ -2835,7 +2835,7 @@ game (
 )
 
 game (
-  name "Meteor Storm (dK'tronics)"
+  name "Meteor Storm (dK'tronics) [P]"
   description "Meteor Storm (dK'tronics)"
   year "1982"
   manufacturer "dK'tronics"
@@ -2843,7 +2843,7 @@ game (
 )
 
 game (
-  name "Meteor Storm (Fast Master) (dK'tronics)"
+  name "Meteor Storm (Fast Master) (dK'tronics) [P]"
   description "Meteor Storm (Fast Master) (dK'tronics)"
   year "1982"
   manufacturer "dK'tronics"
@@ -2851,7 +2851,7 @@ game (
 )
 
 game (
-  name "Meteor Storm (Fast Master) (dK'tronics)"
+  name "Meteor Storm (Fast Master) (dK'tronics) [TZX]"
   description "Meteor Storm (Fast Master) (dK'tronics)"
   year "1982"
   manufacturer "dK'tronics"
@@ -2859,7 +2859,7 @@ game (
 )
 
 game (
-  name "Micro Mouse goes de-bugging (Lothlorien)"
+  name "Micro Mouse goes de-bugging (Lothlorien) [P]"
   description "Micro Mouse goes de-bugging (Lothlorien)"
   year "1983"
   manufacturer "M. C. Lothlorien"
@@ -2867,7 +2867,7 @@ game (
 )
 
 game (
-  name "Micro Mouse goes de-bugging (Lothlorien)"
+  name "Micro Mouse goes de-bugging (Lothlorien) [TZX]"
   description "Micro Mouse goes de-bugging (Lothlorien)"
   year "1983"
   manufacturer "M. C. Lothlorien"
@@ -2875,7 +2875,7 @@ game (
 )
 
 game (
-  name "Mind vs. Machine (2-Bit Software)"
+  name "Mind vs. Machine (2-Bit Software) [TZX]"
   description "Mind vs. Machine (2-Bit Software)"
   year "1982"
   manufacturer "2-Bit Software"
@@ -2883,7 +2883,7 @@ game (
 )
 
 game (
-  name "Mixed Game Bag III (Timex)"
+  name "Mixed Game Bag III (Timex) [TZX]"
   description "Mixed Game Bag III (Timex)"
   year "1982"
   manufacturer "M. Orwin"
@@ -2891,7 +2891,7 @@ game (
 )
 
 game (
-  name "Money Analyzer 1 (Timex)"
+  name "Money Analyzer 1 (Timex) [TZX]"
   description "Money Analyzer 1 (Timex)"
   year "1982"
   manufacturer "T. J. Software"
@@ -2899,21 +2899,21 @@ game (
 )
 
 game (
-  name "Moniteur Desassembleur (Direco International)"
+  name "Moniteur Desassembleur (Direco International) [P]"
   description "Moniteur Desassembleur (Direco International)"
   year "1982"
   rom ( name "moniteurdesassembleur.p" size 5593 crc 357448FF md5 5635D4860A5B03B9312EA12A87383631 sha1 6B32FF9CE4F9DAB7E9E43DF50C9DD8264D9CF5B9 )
 )
 
 game (
-  name "Moniteur Desassembleur (Direco International)"
+  name "Moniteur Desassembleur (Direco International) [TZX]"
   description "Moniteur Desassembleur (Direco International)"
   year "1982"
   rom ( name "MoniteurDesassembleur.tzx" size 5825 crc E548A0E6 md5 4B422022A5ED280D6BD1F6F74F7B56C5 sha1 F3433D201596F069DFF1053A86FC2F293B8E4612 )
 )
 
 game (
-  name "Monster Mine (Gem Software)"
+  name "Monster Mine (Gem Software) [TZX]"
   description "Monster Mine (Gem Software)"
   year "1982"
   manufacturer "Gem Software"
@@ -2921,7 +2921,7 @@ game (
 )
 
 game (
-  name "Monster Mine (Gem Software)"
+  name "Monster Mine (Gem Software) [P]"
   description "Monster Mine (Gem Software)"
   year "1982"
   manufacturer "Gem Software"
@@ -2929,21 +2929,21 @@ game (
 )
 
 game (
-  name "Morse Reader (JEP Electronics)"
+  name "Morse Reader (JEP Electronics) [P]"
   description "Morse Reader (JEP Electronics)"
   manufacturer "JEP Electronics"
   rom ( name "morsereader.p" size 8827 crc 059EE1F6 md5 FFFBF7D1AAC3E3BF21F8895A5EA53194 sha1 51CE900CEC1C55F91037989DA1610DD6B73CBAE6 )
 )
 
 game (
-  name "Morse Reader (JEP Electronics)"
+  name "Morse Reader (JEP Electronics) [TZX]"
   description "Morse Reader (JEP Electronics)"
   manufacturer "JEP Electronics"
   rom ( name "MorseReader.tzx" size 9055 crc 9FCE1AF5 md5 F01F1D0B641939493ED663D9703BAA5B sha1 DEBE28EC7E350D9B6431DC6FCA6DA97513232F02 )
 )
 
 game (
-  name "Mothership (Sinclair Research)"
+  name "Mothership (Sinclair Research) [TZX]"
   description "Mothership (Sinclair Research)"
   year "1982"
   manufacturer "Alan Laity, Softsync"
@@ -2951,7 +2951,7 @@ game (
 )
 
 game (
-  name "Mothership (Sinclair Research)"
+  name "Mothership (Sinclair Research) [P]"
   description "Mothership (Sinclair Research)"
   year "1982"
   manufacturer "Alan Laity, Softsync"
@@ -2959,7 +2959,7 @@ game (
 )
 
 game (
-  name "Mothership (Softsync)"
+  name "Mothership (Softsync) [TZX]"
   description "Mothership (Softsync)"
   year "1983"
   manufacturer "Alan Laity"
@@ -2967,7 +2967,7 @@ game (
 )
 
 game (
-  name "Mothership (Softsync)"
+  name "Mothership (Softsync) [P]"
   description "Mothership (Softsync)"
   year "1983"
   manufacturer "Alan Laity"
@@ -2975,7 +2975,7 @@ game (
 )
 
 game (
-  name "Multifile (Gladstone) (Gladstone Electronics)"
+  name "Multifile (Gladstone) (Gladstone Electronics) [TZX]"
   description "Multifile (Gladstone) (Gladstone Electronics)"
   year "1981"
   manufacturer "Bug Byte"
@@ -2983,7 +2983,7 @@ game (
 )
 
 game (
-  name "Multifile (Gladstone) (Gladstone Electronics)"
+  name "Multifile (Gladstone) (Gladstone Electronics) [P]"
   description "Multifile (Gladstone) (Gladstone Electronics)"
   year "1981"
   manufacturer "Bug Byte"
@@ -2991,21 +2991,21 @@ game (
 )
 
 game (
-  name "Multifile Plus (Gladstone Electronics)"
+  name "Multifile Plus (Gladstone Electronics) [TZX]"
   description "Multifile Plus (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952FF07 md5 80FF32332CB0BDA770C476A519B0365A sha1 C2866C2C9430D5AEC6EA4EB01D7F04C839B1B30C )
 )
 
 game (
-  name "Multifile Plus (Gladstone Electronics)"
+  name "Multifile Plus (Gladstone Electronics) [P]"
   description "Multifile Plus (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "multifileplus(ge).p" size 7677 crc 6CB1F589 md5 DEA427C0DDCDB0E27BDBFA199D903C8F sha1 E036FC55971244C9E2A3B157BD9F527B349DCE17 )
 )
 
 game (
-  name "Multigraphics 2.3 (Bridge Software)"
+  name "Multigraphics 2.3 (Bridge Software) [TZX]"
   description "Multigraphics 2.3 (Bridge Software)"
   year "1981"
   manufacturer "Bridge Software"
@@ -3013,7 +3013,7 @@ game (
 )
 
 game (
-  name "Multigraphics 2.3 (Bridge Software)"
+  name "Multigraphics 2.3 (Bridge Software) [P]"
   description "Multigraphics 2.3 (Bridge Software)"
   year "1981"
   manufacturer "Bridge Software"
@@ -3021,7 +3021,7 @@ game (
 )
 
 game (
-  name "Munchees (Quicksilva)"
+  name "Munchees (Quicksilva) [P]"
   description "Munchees (Quicksilva)"
   year "1983"
   manufacturer "A. Laird"
@@ -3029,7 +3029,7 @@ game (
 )
 
 game (
-  name "Munchees (Quicksilva)"
+  name "Munchees (Quicksilva) [TZX]"
   description "Munchees (Quicksilva)"
   year "1983"
   manufacturer "A. Laird"
@@ -3037,7 +3037,7 @@ game (
 )
 
 game (
-  name "Muncher (Silversoft)"
+  name "Muncher (Silversoft) [P]"
   description "Muncher (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -3045,7 +3045,7 @@ game (
 )
 
 game (
-  name "Muncher (Silversoft)"
+  name "Muncher (Silversoft) [TZX]"
   description "Muncher (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -3053,7 +3053,7 @@ game (
 )
 
 game (
-  name "Murgatroyds (Collins Computing)"
+  name "Murgatroyds (Collins Computing) [P]"
   description "Murgatroyds (Collins Computing)"
   year "1982"
   manufacturer "Collins Computing"
@@ -3061,7 +3061,7 @@ game (
 )
 
 game (
-  name "Murgatroyds (Collins Computing)"
+  name "Murgatroyds (Collins Computing) [TZX]"
   description "Murgatroyds (Collins Computing)"
   year "1982"
   manufacturer "Collins Computing"
@@ -3069,21 +3069,21 @@ game (
 )
 
 game (
-  name "Music Composer (Memotronic)"
+  name "Music Composer (Memotronic) [P]"
   description "Music Composer (Memotronic)"
   manufacturer "Frank Beer and Wolfgang Labus"
   rom ( name "musiccomposer.p" size 5578 crc B0DCDCCA md5 76133648609D8AB9B7B24A418E9AE215 sha1 70A99A384559E1D70E38B2EC5A6DFCAC3CFE6EC0 )
 )
 
 game (
-  name "Music Composer (Memotronic)"
+  name "Music Composer (Memotronic) [TZX]"
   description "Music Composer (Memotronic)"
   manufacturer "Frank Beer and Wolfgang Labus"
   rom ( name "MusicComposer.tzx" size 5822 crc D0CC5789 md5 8AB416356FB8DE668546530C4AB0A890 sha1 BBF95991604EB52B8211D709736CDCDE9AC4DC3B )
 )
 
 game (
-  name "Music Educator 1 (Timex)"
+  name "Music Educator 1 (Timex) [TZX]"
   description "Music Educator 1 (Timex)"
   year "1983"
   manufacturer "Tim Rossetti"
@@ -3091,7 +3091,7 @@ game (
 )
 
 game (
-  name "Music Educator 1 (Timex)"
+  name "Music Educator 1 (Timex) [P]"
   description "Music Educator 1 (Timex)"
   year "1983"
   manufacturer "Tim Rossetti"
@@ -3099,7 +3099,7 @@ game (
 )
 
 game (
-  name "Namtir Raiders (Artic)"
+  name "Namtir Raiders (Artic) [TZX]"
   description "Namtir Raiders (Artic)"
   year "1982"
   manufacturer "J. Ritman"
@@ -3107,7 +3107,7 @@ game (
 )
 
 game (
-  name "Namtir Raiders (Artic)"
+  name "Namtir Raiders (Artic) [P]"
   description "Namtir Raiders (Artic)"
   year "1982"
   manufacturer "J. Ritman"
@@ -3115,7 +3115,7 @@ game (
 )
 
 game (
-  name "Night Gunner (Digital Integration)"
+  name "Night Gunner (Digital Integration) [P]"
   description "Night Gunner (Digital Integration)"
   year "1982"
   manufacturer "Digital Integration"
@@ -3123,7 +3123,7 @@ game (
 )
 
 game (
-  name "Night Gunner (Digital Integration)"
+  name "Night Gunner (Digital Integration) [TZX]"
   description "Night Gunner (Digital Integration)"
   year "1982"
   manufacturer "Digital Integration"
@@ -3131,7 +3131,7 @@ game (
 )
 
 game (
-  name "Night Gunner (Softsync)"
+  name "Night Gunner (Softsync) [P]"
   description "Night Gunner (Softsync)"
   year "1982"
   manufacturer "Digital Integration"
@@ -3139,7 +3139,7 @@ game (
 )
 
 game (
-  name "Night Gunner (Softsync)"
+  name "Night Gunner (Softsync) [TZX]"
   description "Night Gunner (Softsync)"
   year "1982"
   manufacturer "Digital Integration"
@@ -3147,7 +3147,7 @@ game (
 )
 
 game (
-  name "Nightmare Park (Macronics)"
+  name "Nightmare Park (Macronics) [TZX]"
   description "Nightmare Park (Macronics)"
   year "1981"
   manufacturer "J. D. S. Cranston"
@@ -3155,7 +3155,7 @@ game (
 )
 
 game (
-  name "Nightmare Park (Macronics)"
+  name "Nightmare Park (Macronics) [P]"
   description "Nightmare Park (Macronics)"
   year "1981"
   manufacturer "J. D. S. Cranston"
@@ -3163,21 +3163,21 @@ game (
 )
 
 game (
-  name "Octopussy (Peaksoft)"
+  name "Octopussy (Peaksoft) [P]"
   description "Octopussy (Peaksoft)"
   manufacturer "Peaksoft"
   rom ( name "octopussy.p" size 6090 crc 62265923 md5 4C419DD9A3B3463D331E5C8C2F3D7E6B sha1 CA8C3A27854E51ACB3ABBB02C5EBB6AE40C628C0 )
 )
 
 game (
-  name "Octopussy (Peaksoft)"
+  name "Octopussy (Peaksoft) [TZX]"
   description "Octopussy (Peaksoft)"
   manufacturer "Peaksoft"
   rom ( name "Octopussy.tzx" size 6308 crc 9D408C0E md5 FA9F1E45071A0B907B6D8FDFC71F0430 sha1 745515410B88F840A33611B15C4E0A31E6B28611 )
 )
 
 game (
-  name "The Oracle's Cave (Doric Computer Systems)"
+  name "The Oracle's Cave (Doric Computer Systems) [P]"
   description "The Oracle's Cave (Doric Computer Systems)"
   year "1981"
   manufacturer "C. T. Dorrel"
@@ -3185,7 +3185,7 @@ game (
 )
 
 game (
-  name "The Oracle's Cave (Doric Computer Systems)"
+  name "The Oracle's Cave (Doric Computer Systems) [TZX]"
   description "The Oracle's Cave (Doric Computer Systems)"
   year "1981"
   manufacturer "C. T. Dorrel"
@@ -3193,21 +3193,21 @@ game (
 )
 
 game (
-  name "Othello (CDS Micro Systems)"
+  name "Othello (CDS Micro Systems) [P]"
   description "Othello (CDS Micro Systems)"
   manufacturer "CDS Micro Systems"
   rom ( name "othello.p" size 11655 crc 73457797 md5 EF70888041689CC60B9336201735F725 sha1 4DD7218297D9EF6CFB776DECBD2F040A297E1C3E )
 )
 
 game (
-  name "Othello (CDS Micro Systems)"
+  name "Othello (CDS Micro Systems) [TZX]"
   description "Othello (CDS Micro Systems)"
   manufacturer "CDS Micro Systems"
   rom ( name "Othello.tzx" size 11885 crc 09D487FE md5 CFCB326E75DFA9A59A79E05491686DD6 sha1 47C8980D14972B59FAB5098667B170169894515D )
 )
 
 game (
-  name "ZX Othello (Moi)"
+  name "ZX Othello (Moi) [TZX]"
   description "ZX Othello (Moi)"
   year "1982"
   manufacturer "Moi"
@@ -3215,14 +3215,14 @@ game (
 )
 
 game (
-  name "Paint-Maze (Mikro-Gen)"
+  name "Paint-Maze (Mikro-Gen) [TZX]"
   description "Paint-Maze (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "PaintMaze.tzx" size 5086 crc 2EFF4B27 md5 23DD48A06FF28C78E8A3F9BF26AA557E sha1 E8519C3EB5B772F13FE374C1C57A15D7D4791887 )
 )
 
 game (
-  name "Peloponnesian War (Lothlorien)"
+  name "Peloponnesian War (Lothlorien) [TZX]"
   description "Peloponnesian War (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3230,7 +3230,7 @@ game (
 )
 
 game (
-  name "Peloponnesian War (Lothlorien)"
+  name "Peloponnesian War (Lothlorien) [P]"
   description "Peloponnesian War (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3238,7 +3238,7 @@ game (
 )
 
 game (
-  name "Pengy (Fawkes Computing)"
+  name "Pengy (Fawkes Computing) [TZX]"
   description "Pengy (Fawkes Computing)"
   year "1984"
   manufacturer "Fawkes Computing"
@@ -3246,7 +3246,7 @@ game (
 )
 
 game (
-  name "Pengy (Fawkes Computing)"
+  name "Pengy (Fawkes Computing) [P]"
   description "Pengy (Fawkes Computing)"
   year "1984"
   manufacturer "Fawkes Computing"
@@ -3254,7 +3254,7 @@ game (
 )
 
 game (
-  name "Pilot (Hewson Consultants)"
+  name "Pilot (Hewson Consultants) [TZX]"
   description "Pilot (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3262,7 +3262,7 @@ game (
 )
 
 game (
-  name "Pilot (Hewson Consultants)"
+  name "Pilot (Hewson Consultants) [P]"
   description "Pilot (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3270,7 +3270,7 @@ game (
 )
 
 game (
-  name "Pilot (Colour inlay) (Hewson Consultants)"
+  name "Pilot (Colour inlay) (Hewson Consultants) [P]"
   description "Pilot (Colour inlay) (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3278,7 +3278,7 @@ game (
 )
 
 game (
-  name "Pilot (Colour inlay) (Hewson Consultants)"
+  name "Pilot (Colour inlay) (Hewson Consultants) [TZX]"
   description "Pilot (Colour inlay) (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3286,7 +3286,7 @@ game (
 )
 
 game (
-  name "Pilot (New) (Hewson Consultants)"
+  name "Pilot (New) (Hewson Consultants) [TZX]"
   description "Pilot (New) (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3294,7 +3294,7 @@ game (
 )
 
 game (
-  name "Pilot (New) (Hewson Consultants)"
+  name "Pilot (New) (Hewson Consultants) [P]"
   description "Pilot (New) (Hewson Consultants)"
   year "1982"
   manufacturer "Hewson Consultants"
@@ -3302,7 +3302,7 @@ game (
 )
 
 game (
-  name "Pimania (Automata Cartography)"
+  name "Pimania (Automata Cartography) [TZX]"
   description "Pimania (Automata Cartography)"
   year "1982"
   manufacturer "Automata"
@@ -3310,7 +3310,7 @@ game (
 )
 
 game (
-  name "Pimania (Automata Cartography)"
+  name "Pimania (Automata Cartography) [P]"
   description "Pimania (Automata Cartography)"
   year "1982"
   manufacturer "Automata"
@@ -3318,7 +3318,7 @@ game (
 )
 
 game (
-  name "Pinball (Timex)"
+  name "Pinball (Timex) [TZX]"
   description "Pinball (Timex)"
   year "1982"
   manufacturer "A. H. Laity"
@@ -3326,7 +3326,7 @@ game (
 )
 
 game (
-  name "Pinball (Timex)"
+  name "Pinball (Timex) [P]"
   description "Pinball (Timex)"
   year "1982"
   manufacturer "A. H. Laity"
@@ -3334,7 +3334,7 @@ game (
 )
 
 game (
-  name "Pioneer Trail (Quicksilva)"
+  name "Pioneer Trail (Quicksilva) [P]"
   description "Pioneer Trail (Quicksilva)"
   year "1983"
   manufacturer "M.Stubbs"
@@ -3342,7 +3342,7 @@ game (
 )
 
 game (
-  name "Pioneer Trail (Quicksilva)"
+  name "Pioneer Trail (Quicksilva) [TZX]"
   description "Pioneer Trail (Quicksilva)"
   year "1983"
   manufacturer "M.Stubbs"
@@ -3350,7 +3350,7 @@ game (
 )
 
 game (
-  name "Adventure A - Planet of Death (Sinclair Research)"
+  name "Adventure A - Planet of Death (Sinclair Research) [P]"
   description "Adventure A: Planet of Death (Sinclair Research)"
   year "1981"
   manufacturer "Artic"
@@ -3358,7 +3358,7 @@ game (
 )
 
 game (
-  name "Adventure A - Planet of Death (Sinclair Research)"
+  name "Adventure A - Planet of Death (Sinclair Research) [TZX]"
   description "Adventure A: Planet of Death (Sinclair Research)"
   year "1981"
   manufacturer "Artic"
@@ -3366,21 +3366,21 @@ game (
 )
 
 game (
-  name "Adventure A - Planet of Death (Artic)"
+  name "Adventure A - Planet of Death (Artic) [TZX]"
   description "Adventure A: Planet of Death (Artic)"
   manufacturer "Artic"
   rom ( name "PlanetOfDeath.tzx" size 13675 crc CDEF18A4 md5 4ECB3F0A3A9A9C9A25520BF1F7D2175E sha1 346412F09B472C931874FD441660AB5435D5F3C1 )
 )
 
 game (
-  name "Adventure A - Planet of Death (Artic)"
+  name "Adventure A - Planet of Death (Artic) [P]"
   description "Adventure A: Planet of Death (Artic)"
   manufacturer "Artic"
   rom ( name "planetofdeath.p" size 13445 crc AB715C00 md5 F0A90C314572232E860A486F47C34CFE sha1 247F37D1B70A0EEC9ABCE64EA094D55E3E59B27C )
 )
 
 game (
-  name "Planetoids (Macronics)"
+  name "Planetoids (Macronics) [P]"
   description "Planetoids (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -3388,7 +3388,7 @@ game (
 )
 
 game (
-  name "Planetoids (Macronics)"
+  name "Planetoids (Macronics) [TZX]"
   description "Planetoids (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -3396,7 +3396,7 @@ game (
 )
 
 game (
-  name "Portfolio Analysis (Timex)"
+  name "Portfolio Analysis (Timex) [TZX]"
   description "Portfolio Analysis (Timex)"
   year "1982"
   manufacturer "American Micro Products"
@@ -3404,7 +3404,7 @@ game (
 )
 
 game (
-  name "Portfolio Analysis (Timex)"
+  name "Portfolio Analysis (Timex) [P]"
   description "Portfolio Analysis (Timex)"
   year "1982"
   manufacturer "American Micro Products"
@@ -3412,7 +3412,7 @@ game (
 )
 
 game (
-  name "Presidents (Timex)"
+  name "Presidents (Timex) [P]"
   description "Presidents (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -3420,7 +3420,7 @@ game (
 )
 
 game (
-  name "Presidents (Timex)"
+  name "Presidents (Timex) [TZX]"
   description "Presidents (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -3428,7 +3428,7 @@ game (
 )
 
 game (
-  name "Print Shop (Cases Computer Simulations)"
+  name "Print Shop (Cases Computer Simulations) [TZX]"
   description "Print Shop (Cases Computer Simulations)"
   year "1983"
   manufacturer "Cases Computer Simulations"
@@ -3436,7 +3436,7 @@ game (
 )
 
 game (
-  name "Print Shop (Cases Computer Simulations)"
+  name "Print Shop (Cases Computer Simulations) [P]"
   description "Print Shop (Cases Computer Simulations)"
   year "1983"
   manufacturer "Cases Computer Simulations"
@@ -3444,7 +3444,7 @@ game (
 )
 
 game (
-  name "Printer Programs (Nick Godwin)"
+  name "Printer Programs (Nick Godwin) [TZX]"
   description "Printer Programs (Nick Godwin)"
   year "1984"
   manufacturer "Nick Godwin"
@@ -3452,7 +3452,7 @@ game (
 )
 
 game (
-  name "Privateer (Lothlorien)"
+  name "Privateer (Lothlorien) [TZX]"
   description "Privateer (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3460,7 +3460,7 @@ game (
 )
 
 game (
-  name "Privateer (Lothlorien)"
+  name "Privateer (Lothlorien) [P]"
   description "Privateer (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3468,7 +3468,7 @@ game (
 )
 
 game (
-  name "Progmerge (ACS Software)"
+  name "Progmerge (ACS Software) [TZX]"
   description "Progmerge (ACS Software)"
   year "1982"
   manufacturer "ACS Software"
@@ -3476,7 +3476,7 @@ game (
 )
 
 game (
-  name "Progmerge (ACS Software)"
+  name "Progmerge (ACS Software) [P]"
   description "Progmerge (ACS Software)"
   year "1982"
   manufacturer "ACS Software"
@@ -3484,7 +3484,7 @@ game (
 )
 
 game (
-  name "Protector (Abacus)"
+  name "Protector (Abacus) [P]"
   description "Protector (Abacus)"
   year "1982"
   manufacturer "K. Flynn"
@@ -3492,7 +3492,7 @@ game (
 )
 
 game (
-  name "Protector (Abacus)"
+  name "Protector (Abacus) [TZX]"
   description "Protector (Abacus)"
   year "1982"
   manufacturer "K. Flynn"
@@ -3500,7 +3500,7 @@ game (
 )
 
 game (
-  name "Puckman (Hewson Consultants)"
+  name "Puckman (Hewson Consultants) [P]"
   description "Puckman (Hewson Consultants)"
   year "1981"
   manufacturer "Hewson Consultants"
@@ -3508,7 +3508,7 @@ game (
 )
 
 game (
-  name "Puckman (Hewson Consultants)"
+  name "Puckman (Hewson Consultants) [TZX]"
   description "Puckman (Hewson Consultants)"
   year "1981"
   manufacturer "Hewson Consultants"
@@ -3516,7 +3516,7 @@ game (
 )
 
 game (
-  name "QS Asteroids (No characters) (Quicksilva)"
+  name "QS Asteroids (No characters) (Quicksilva) [TZX]"
   description "QS Asteroids (No characters) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3524,7 +3524,7 @@ game (
 )
 
 game (
-  name "QS Asteroids (No characters) (Quicksilva)"
+  name "QS Asteroids (No characters) (Quicksilva) [P]"
   description "QS Asteroids (No characters) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3532,7 +3532,7 @@ game (
 )
 
 game (
-  name "QS Asteroids (Big picture, no text) (Quicksilva)"
+  name "QS Asteroids (Big picture, no text) (Quicksilva) [P]"
   description "QS Asteroids (Big picture, no text) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3540,7 +3540,7 @@ game (
 )
 
 game (
-  name "QS Asteroids (Big picture, no text) (Quicksilva)"
+  name "QS Asteroids (Big picture, no text) (Quicksilva) [TZX]"
   description "QS Asteroids (Big picture, no text) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3548,7 +3548,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Quicksilva)"
+  name "QS Defenda (Quicksilva) [TZX]"
   description "QS Defenda (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3556,7 +3556,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Quicksilva)"
+  name "QS Defenda (Quicksilva) [P]"
   description "QS Defenda (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3564,7 +3564,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Number) (Quicksilva)"
+  name "QS Defenda (Number) (Quicksilva) [P]"
   description "QS Defenda (Number) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3572,7 +3572,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Number) (Quicksilva)"
+  name "QS Defenda (Number) (Quicksilva) [TZX]"
   description "QS Defenda (Number) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3580,7 +3580,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Big picture) (Quicksilva)"
+  name "QS Defenda (Big picture) (Quicksilva) [TZX]"
   description "QS Defenda (Big picture) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3588,7 +3588,7 @@ game (
 )
 
 game (
-  name "QS Defenda (Big picture) (Quicksilva)"
+  name "QS Defenda (Big picture) (Quicksilva) [P]"
   description "QS Defenda (Big picture) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3596,7 +3596,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Quicksilva)"
+  name "QS Invaders (Quicksilva) [P]"
   description "QS Invaders (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3604,7 +3604,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Quicksilva)"
+  name "QS Invaders (Quicksilva) [TZX]"
   description "QS Invaders (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3612,7 +3612,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Number) (Quicksilva)"
+  name "QS Invaders (Number) (Quicksilva) [TZX]"
   description "QS Invaders (Number) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3620,7 +3620,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Number) (Quicksilva)"
+  name "QS Invaders (Number) (Quicksilva) [P]"
   description "QS Invaders (Number) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3628,7 +3628,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Number, Upside down) (Quicksilva)"
+  name "QS Invaders (Number, Upside down) (Quicksilva) [TZX]"
   description "QS Invaders (Number, Upside down) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3636,7 +3636,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Number, Upside down) (Quicksilva)"
+  name "QS Invaders (Number, Upside down) (Quicksilva) [P]"
   description "QS Invaders (Number, Upside down) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3644,7 +3644,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Big picture) (Quicksilva)"
+  name "QS Invaders (Big picture) (Quicksilva) [P]"
   description "QS Invaders (Big picture) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3652,7 +3652,7 @@ game (
 )
 
 game (
-  name "QS Invaders (Big picture) (Quicksilva)"
+  name "QS Invaders (Big picture) (Quicksilva) [TZX]"
   description "QS Invaders (Big picture) (Quicksilva)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3660,7 +3660,7 @@ game (
 )
 
 game (
-  name "QS Scramble (Number) (Quicksilva)"
+  name "QS Scramble (Number) (Quicksilva) [TZX]"
   description "QS Scramble (Number) (Quicksilva)"
   year "1982"
   manufacturer "Quicksilva"
@@ -3668,28 +3668,28 @@ game (
 )
 
 game (
-  name "Q Save (PSS)"
+  name "Q Save (PSS) [P]"
   description "Q Save (PSS)"
   manufacturer "PSS"
   rom ( name "qsave.p" size 1547 crc A3EDAAB2 md5 48C37E545EAA01EF260E4B4799DC5992 sha1 FBDC2B3081B1E088AB05129EF8A5376E1378652D )
 )
 
 game (
-  name "Q Save (Red) (PSS)"
+  name "Q Save (Red) (PSS) [TZX]"
   description "Q Save (Red) (PSS)"
   manufacturer "PSS"
   rom ( name "QSave(Red).tzx" size 1693 crc 28BCFD44 md5 D6DB4577CE639CE63B01D3EC351A5CF6 sha1 173946BA09A7B0F085B975D25DDFE6F431541186 )
 )
 
 game (
-  name "Q Save (Red) (PSS)"
+  name "Q Save (Red) (PSS) [P]"
   description "Q Save (Red) (PSS)"
   manufacturer "PSS"
   rom ( name "qsave(red).p" size 1467 crc 7918413A md5 597C8A759AF88CA64C2AD2462492887F sha1 46EE323C057848AB62D253662891EAE847E449D8 )
 )
 
 game (
-  name "RPN Calculator (Zeta Software)"
+  name "RPN Calculator (Zeta Software) [P]"
   description "RPN Calculator (Zeta Software)"
   year "1982"
   manufacturer "Dr. Walter Diembeck"
@@ -3697,7 +3697,7 @@ game (
 )
 
 game (
-  name "RPN Calculator (Zeta Software)"
+  name "RPN Calculator (Zeta Software) [TZX]"
   description "RPN Calculator (Zeta Software)"
   year "1982"
   manufacturer "Dr. Walter Diembeck"
@@ -3705,7 +3705,7 @@ game (
 )
 
 game (
-  name "Ram Runner (Timex)"
+  name "Ram Runner (Timex) [P]"
   description "Ram Runner (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -3713,7 +3713,7 @@ game (
 )
 
 game (
-  name "Ram Runner (Timex)"
+  name "Ram Runner (Timex) [TZX]"
   description "Ram Runner (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -3721,7 +3721,7 @@ game (
 )
 
 game (
-  name "Real Estate Investment Analysis (Timex)"
+  name "Real Estate Investment Analysis (Timex) [TZX]"
   description "Real Estate Investment Analysis (Timex)"
   year "1982"
   manufacturer "American Micro Products Inc."
@@ -3729,7 +3729,7 @@ game (
 )
 
 game (
-  name "Real Estate Investment Analysis (Timex)"
+  name "Real Estate Investment Analysis (Timex) [P]"
   description "Real Estate Investment Analysis (Timex)"
   year "1982"
   manufacturer "American Micro Products Inc."
@@ -3737,7 +3737,7 @@ game (
 )
 
 game (
-  name "Red Alert (Softsync)"
+  name "Red Alert (Softsync) [TZX]"
   description "Red Alert (Softsync)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3745,7 +3745,7 @@ game (
 )
 
 game (
-  name "Red Alert (Softsync)"
+  name "Red Alert (Softsync) [P]"
   description "Red Alert (Softsync)"
   year "1981"
   manufacturer "Quicksilva"
@@ -3753,21 +3753,21 @@ game (
 )
 
 game (
-  name "Rental Property Manager (Data-assette)"
+  name "Rental Property Manager (Data-assette) [P]"
   description "Rental Property Manager (Data-assette)"
   manufacturer "John Powers"
   rom ( name "rentalpropertymanager.p" size 16109 crc 2316C873 md5 79E94AC3F50F837458EAF07ED4317951 sha1 79194CF5DFCA47D67866257DBF2E2F31D8E79272 )
 )
 
 game (
-  name "Rental Property Manager (Data-assette)"
+  name "Rental Property Manager (Data-assette) [TZX]"
   description "Rental Property Manager (Data-assette)"
   manufacturer "John Powers"
   rom ( name "RentalPropertyManager.tzx" size 16339 crc 92F8AA70 md5 4B297D59DFA3FD14EE638B35D6F8BC99 sha1 378BB82167E1EE3A4F8EC8A69B2A3612CD2B2810 )
 )
 
 game (
-  name "Reversi also known as Othello (Sinclair Research)"
+  name "Reversi also known as Othello (Sinclair Research) [TZX]"
   description "Reversi also known as Othello (Sinclair Research)"
   year "1982"
   manufacturer "Moi/Games of Skill Ltd"
@@ -3775,7 +3775,7 @@ game (
 )
 
 game (
-  name "Reversi also known as Othello (Sinclair Research)"
+  name "Reversi also known as Othello (Sinclair Research) [P]"
   description "Reversi also known as Othello (Sinclair Research)"
   year "1982"
   manufacturer "Moi/Games of Skill Ltd"
@@ -3783,7 +3783,7 @@ game (
 )
 
 game (
-  name "Reversi (Artic)"
+  name "Reversi (Artic) [P]"
   description "Reversi (Artic)"
   year "1982"
   manufacturer "T. Hughes"
@@ -3791,7 +3791,7 @@ game (
 )
 
 game (
-  name "Reversi (Artic)"
+  name "Reversi (Artic) [TZX]"
   description "Reversi (Artic)"
   year "1982"
   manufacturer "T. Hughes"
@@ -3799,7 +3799,7 @@ game (
 )
 
 game (
-  name "Robbers of the Lost Tomb (Timeworks)"
+  name "Robbers of the Lost Tomb (Timeworks) [P]"
   description "Robbers of the Lost Tomb (Timeworks)"
   year "1982"
   manufacturer "Timeworks"
@@ -3807,7 +3807,7 @@ game (
 )
 
 game (
-  name "Robbers of the Lost Tomb (Timeworks)"
+  name "Robbers of the Lost Tomb (Timeworks) [TZX]"
   description "Robbers of the Lost Tomb (Timeworks)"
   year "1982"
   manufacturer "Timeworks"
@@ -3815,7 +3815,7 @@ game (
 )
 
 game (
-  name "Rocket Man (Software Farm)"
+  name "Rocket Man (Software Farm) [TZX]"
   description "Rocket Man (Software Farm)"
   year "1984"
   manufacturer "Software Farm"
@@ -3823,7 +3823,7 @@ game (
 )
 
 game (
-  name "Rocket Man (Software Farm)"
+  name "Rocket Man (Software Farm) [P]"
   description "Rocket Man (Software Farm)"
   year "1984"
   manufacturer "Software Farm"
@@ -3831,7 +3831,7 @@ game (
 )
 
 game (
-  name "Roman Empire (Lothlorien)"
+  name "Roman Empire (Lothlorien) [TZX]"
   description "Roman Empire (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3839,7 +3839,7 @@ game (
 )
 
 game (
-  name "Roman Empire (Lothlorien)"
+  name "Roman Empire (Lothlorien) [P]"
   description "Roman Empire (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3847,7 +3847,7 @@ game (
 )
 
 game (
-  name "Rubik Cube (Alt) (CDS Micro Systems)"
+  name "Rubik Cube (Alt) (CDS Micro Systems) [TZX]"
   description "Rubik Cube (Alt) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -3855,7 +3855,7 @@ game (
 )
 
 game (
-  name "Rubik Cube (Alt) (CDS Micro Systems)"
+  name "Rubik Cube (Alt) (CDS Micro Systems) [P]"
   description "Rubik Cube (Alt) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -3863,7 +3863,7 @@ game (
 )
 
 game (
-  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  name "Rubik Cube (Brown inlay) (CDS Micro Systems) [P]"
   description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -3871,7 +3871,7 @@ game (
 )
 
 game (
-  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  name "Rubik Cube (Brown inlay) (CDS Micro Systems) [TZX]"
   description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
   year "1982"
   manufacturer "CDS Micro Systems"
@@ -3879,7 +3879,7 @@ game (
 )
 
 game (
-  name "Sabotage (Sinclair Research)"
+  name "Sabotage (Sinclair Research) [TZX]"
   description "Sabotage (Sinclair Research)"
   year "1982"
   manufacturer "Macronics"
@@ -3887,7 +3887,7 @@ game (
 )
 
 game (
-  name "Sabotage (Sinclair Research)"
+  name "Sabotage (Sinclair Research) [P]"
   description "Sabotage (Sinclair Research)"
   year "1982"
   manufacturer "Macronics"
@@ -3895,21 +3895,21 @@ game (
 )
 
 game (
-  name "Salvo (Orbyte Software)"
+  name "Salvo (Orbyte Software) [P]"
   description "Salvo (Orbyte Software)"
   manufacturer "A & M Productions"
   rom ( name "salvo.p" size 15284 crc 202F1A9B md5 009ACFC6E76E528F40CC693753E73251 sha1 3BD88AC1E2A1DFCA98AD495346E0C65D9936A1A0 )
 )
 
 game (
-  name "Salvo (Orbyte Software)"
+  name "Salvo (Orbyte Software) [TZX]"
   description "Salvo (Orbyte Software)"
   manufacturer "A & M Productions"
   rom ( name "Salvo.tzx" size 15510 crc D9303929 md5 A28B801FF835CD8DCCDDACF23ED8DB1F sha1 706DDD40FFC24AD4FFFCEF7D8F77889A6A1C1A19 )
 )
 
 game (
-  name "Samurai Warrior (Lothlorien)"
+  name "Samurai Warrior (Lothlorien) [P]"
   description "Samurai Warrior (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3917,7 +3917,7 @@ game (
 )
 
 game (
-  name "Samurai Warrior (Lothlorien)"
+  name "Samurai Warrior (Lothlorien) [TZX]"
   description "Samurai Warrior (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -3925,49 +3925,49 @@ game (
 )
 
 game (
-  name "Scramble (Mikro-Gen)"
+  name "Scramble (Mikro-Gen) [TZX]"
   description "Scramble (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "Scramble.tzx" size 4693 crc DD9359A4 md5 8F50B50F065FF824C39209C4680BF2AA sha1 84760E3B08C0E5686C9ACE4B23DFF5B6187DA367 )
 )
 
 game (
-  name "Scramble (Mikro-Gen)"
+  name "Scramble (Mikro-Gen) [P]"
   description "Scramble (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "scramble.p" size 4455 crc 6CA59CEB md5 1CACE2E4CEA14D6F96913F3ED7D7204F sha1 BD6FF916C9A18EA0EDA7D21B061670231643E308 )
 )
 
 game (
-  name "Scramble (Colour inlay) (Mikro-Gen)"
+  name "Scramble (Colour inlay) (Mikro-Gen) [P]"
   description "Scramble (Colour inlay) (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "scramble(ci).p" size 4455 crc BFC4A5E6 md5 F9BA0FFC3497E3FD978A6894FCF28547 sha1 6ADD38B04DE58597B939F24F35613B6A1B8E2EB5 )
 )
 
 game (
-  name "Scramble (Colour inlay) (Mikro-Gen)"
+  name "Scramble (Colour inlay) (Mikro-Gen) [TZX]"
   description "Scramble (Colour inlay) (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "Scramble(CI).tzx" size 4693 crc 0EF260A9 md5 DE5F9BB0623C40822463CA512F959D06 sha1 338BA99E7D814653800311CD67BE49FCA764A822 )
 )
 
 game (
-  name "Screen Kit 1 (Picturesque)"
+  name "Screen Kit 1 (Picturesque) [P]"
   description "Screen Kit 1 (Picturesque)"
   manufacturer "Picturesque"
   rom ( name "screenkit1.p" size 1841 crc FE229E5D md5 3DAB82C0980EECA3B0F22016ED6DCD16 sha1 84ABE2D096D68E01573FE1AEA3C3A0646C62E6F5 )
 )
 
 game (
-  name "Screen Kit 1 (Picturesque)"
+  name "Screen Kit 1 (Picturesque) [TZX]"
   description "Screen Kit 1 (Picturesque)"
   manufacturer "Picturesque"
   rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 EC8D98CEC4AC5B718D7AB4C188A99A01 sha1 78351CB1C27587935242BF9BB0F512D07B902625 )
 )
 
 game (
-  name "Sea Wolf (Stephen Hartley Computing)"
+  name "Sea Wolf (Stephen Hartley Computing) [TZX]"
   description "Sea Wolf (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. R. Bird"
@@ -3975,7 +3975,7 @@ game (
 )
 
 game (
-  name "Sea Wolf (Stephen Hartley Computing)"
+  name "Sea Wolf (Stephen Hartley Computing) [P]"
   description "Sea Wolf (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. R. Bird"
@@ -3983,7 +3983,7 @@ game (
 )
 
 game (
-  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  name "Sea Wolf (Newer) (Stephen Hartley Computing) [P]"
   description "Sea Wolf (Newer) (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. R. Bird"
@@ -3991,7 +3991,7 @@ game (
 )
 
 game (
-  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  name "Sea Wolf (Newer) (Stephen Hartley Computing) [TZX]"
   description "Sea Wolf (Newer) (Stephen Hartley Computing)"
   year "1983"
   manufacturer "I. R. Bird"
@@ -3999,7 +3999,7 @@ game (
 )
 
 game (
-  name "Adventure C - The Ship of Doom (Sinclair Research)"
+  name "Adventure C - The Ship of Doom (Sinclair Research) [TZX]"
   description "Adventure C: The Ship of Doom (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -4007,7 +4007,7 @@ game (
 )
 
 game (
-  name "Adventure C - The Ship of Doom (Sinclair Research)"
+  name "Adventure C - The Ship of Doom (Sinclair Research) [P]"
   description "Adventure C: The Ship of Doom (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -4015,21 +4015,21 @@ game (
 )
 
 game (
-  name "Adventure C - Ship of Doom (Artic)"
+  name "Adventure C - Ship of Doom (Artic) [TZX]"
   description "Adventure C: Ship of Doom (Artic)"
   manufacturer "Artic"
   rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284A314F md5 CA0BAB03EEFF0FC9BCC040148E20C7D2 sha1 96221BCEBA4FF6E90FDC59271DA1D7973362E8F8 )
 )
 
 game (
-  name "Adventure C - Ship of Doom (Artic)"
+  name "Adventure C - Ship of Doom (Artic) [P]"
   description "Adventure C: Ship of Doom (Artic)"
   manufacturer "Artic"
   rom ( name "shipofdoom(artic).p" size 14045 crc 3E244575 md5 47AE04D2D34190DD2F9D47FB9815F4DE sha1 689552EF631FACC558C6FC9B902F20495E870936 )
 )
 
 game (
-  name "Similes Countdown (AVC Software)"
+  name "Similes Countdown (AVC Software) [TZX]"
   description "Similes Countdown (AVC Software)"
   year "1981"
   manufacturer "K. Jammer and S. Brown"
@@ -4037,7 +4037,7 @@ game (
 )
 
 game (
-  name "Similes Countdown (AVC Software)"
+  name "Similes Countdown (AVC Software) [P]"
   description "Similes Countdown (AVC Software)"
   year "1981"
   manufacturer "K. Jammer and S. Brown"
@@ -4045,7 +4045,7 @@ game (
 )
 
 game (
-  name "Space Intruders (Hewson Consultants)"
+  name "Space Intruders (Hewson Consultants) [TZX]"
   description "Space Intruders (Hewson Consultants)"
   year "1981"
   manufacturer "Hewson Consultants"
@@ -4053,7 +4053,7 @@ game (
 )
 
 game (
-  name "Space Intruders (Hewson Consultants)"
+  name "Space Intruders (Hewson Consultants) [P]"
   description "Space Intruders (Hewson Consultants)"
   year "1981"
   manufacturer "Hewson Consultants"
@@ -4061,21 +4061,21 @@ game (
 )
 
 game (
-  name "Space Invaders (Mikro-Gen)"
+  name "Space Invaders (Mikro-Gen) [TZX]"
   description "Space Invaders (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "SpaceInvaders.tzx" size 2896 crc A345E8DB md5 F835A9B2D5DCE454A2DDC4CAF8175505 sha1 4536F0D2A465A71891803B23D29BC8C54C1B874F )
 )
 
 game (
-  name "Space Invaders (Mikro-Gen)"
+  name "Space Invaders (Mikro-Gen) [P]"
   description "Space Invaders (Mikro-Gen)"
   manufacturer "Mikro-Gen"
   rom ( name "spaceinvaders.p" size 2664 crc E39A90BE md5 CCE844A181612AD7E32209E73CE42B9C sha1 795CC3740CAEE56E9AF16A52B557D93B968D0CDE )
 )
 
 game (
-  name "Space Invaders (dK'tronics)"
+  name "Space Invaders (dK'tronics) [P]"
   description "Space Invaders (dK'tronics)"
   year "1981"
   manufacturer "dK'tronics"
@@ -4083,7 +4083,7 @@ game (
 )
 
 game (
-  name "Space Invaders (dK'tronics)"
+  name "Space Invaders (dK'tronics) [TZX]"
   description "Space Invaders (dK'tronics)"
   year "1981"
   manufacturer "dK'tronics"
@@ -4091,7 +4091,7 @@ game (
 )
 
 game (
-  name "Space Invaders 3K (Macronics)"
+  name "Space Invaders 3K (Macronics) [P]"
   description "Space Invaders 3K (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -4099,7 +4099,7 @@ game (
 )
 
 game (
-  name "Space Invaders 3K (Macronics)"
+  name "Space Invaders 3K (Macronics) [TZX]"
   description "Space Invaders 3K (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -4107,7 +4107,7 @@ game (
 )
 
 game (
-  name "Space Man Apollo (ICT)"
+  name "Space Man Apollo (ICT) [TZX]"
   description "Space Man Apollo (ICT)"
   year "1984"
   manufacturer "Iain Thomson"
@@ -4115,7 +4115,7 @@ game (
 )
 
 game (
-  name "Space Man Apollo (ICT)"
+  name "Space Man Apollo (ICT) [P]"
   description "Space Man Apollo (ICT)"
   year "1984"
   manufacturer "Iain Thomson"
@@ -4123,7 +4123,7 @@ game (
 )
 
 game (
-  name "Space Mission (Gem Software)"
+  name "Space Mission (Gem Software) [TZX]"
   description "Space Mission (Gem Software)"
   year "1982"
   manufacturer "Gem Software"
@@ -4131,7 +4131,7 @@ game (
 )
 
 game (
-  name "Space Mission (Gem Software)"
+  name "Space Mission (Gem Software) [P]"
   description "Space Mission (Gem Software)"
   year "1982"
   manufacturer "Gem Software"
@@ -4139,35 +4139,35 @@ game (
 )
 
 game (
-  name "Space Trek (Micromega)"
+  name "Space Trek (Micromega) [P]"
   description "Space Trek (Micromega)"
   manufacturer "Micromega"
   rom ( name "spacetrek.p" size 15395 crc 8C8545B1 md5 EB1DB83F22E599C4A8927BDF043D2677 sha1 FF8A32EE7197F3EF632F2CF231CB0CA7CBF1DEFC )
 )
 
 game (
-  name "Space Trek (Micromega)"
+  name "Space Trek (Micromega) [TZX]"
   description "Space Trek (Micromega)"
   manufacturer "Micromega"
   rom ( name "SpaceTrek.tzx" size 15619 crc 081B0787 md5 7A2A66E12F7983634FF1CA0B9B795DED sha1 0E20ED7812A34AD507EC1C1DC23536641C4B9993 )
 )
 
 game (
-  name "Spacetrek (JRS Software)"
+  name "Spacetrek (JRS Software) [TZX]"
   description "Spacetrek (JRS Software)"
   manufacturer "JRS Software"
   rom ( name "Spacetrek(JRS).tzx" size 550 crc D62CC02F md5 17AAF306F2269D03004C5866D47AF928 sha1 1B0C8177A41AEA9AA40F5698280C86E505151349 )
 )
 
 game (
-  name "Spacetrek (JRS Software)"
+  name "Spacetrek (JRS Software) [P]"
   description "Spacetrek (JRS Software)"
   manufacturer "JRS Software"
   rom ( name "spacetrek(jrs).p" size 332 crc C2F526DF md5 A3B4C8C194FFD9B3DF6AB21F57BCC6CC sha1 6B5C61147A38082825FC71A003937E5F07F59F02 )
 )
 
 game (
-  name "Spelling Bee (Timex)"
+  name "Spelling Bee (Timex) [TZX]"
   description "Spelling Bee (Timex)"
   year "1983"
   manufacturer "Russell Klein"
@@ -4175,7 +4175,7 @@ game (
 )
 
 game (
-  name "The Stamp Collector (Timex)"
+  name "The Stamp Collector (Timex) [P]"
   description "The Stamp Collector (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4183,7 +4183,7 @@ game (
 )
 
 game (
-  name "The Stamp Collector (Timex)"
+  name "The Stamp Collector (Timex) [TZX]"
   description "The Stamp Collector (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4191,7 +4191,7 @@ game (
 )
 
 game (
-  name "Star Trek (Bug Byte)"
+  name "Star Trek (Bug Byte) [TZX]"
   description "Star Trek (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -4199,7 +4199,7 @@ game (
 )
 
 game (
-  name "Star Trek (Bug Byte)"
+  name "Star Trek (Bug Byte) [P]"
   description "Star Trek (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -4207,7 +4207,7 @@ game (
 )
 
 game (
-  name "Star Trek (Macronics)"
+  name "Star Trek (Macronics) [TZX]"
   description "Star Trek (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -4215,7 +4215,7 @@ game (
 )
 
 game (
-  name "Star Trek (Macronics)"
+  name "Star Trek (Macronics) [P]"
   description "Star Trek (Macronics)"
   year "1981"
   manufacturer "Macronics"
@@ -4223,7 +4223,7 @@ game (
 )
 
 game (
-  name "Star Trek (Typed Inlay) (Bug Byte)"
+  name "Star Trek (Typed Inlay) (Bug Byte) [P]"
   description "Star Trek (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -4231,7 +4231,7 @@ game (
 )
 
 game (
-  name "Star Trek (Typed Inlay) (Bug Byte)"
+  name "Star Trek (Typed Inlay) (Bug Byte) [TZX]"
   description "Star Trek (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -4239,7 +4239,7 @@ game (
 )
 
 game (
-  name "Starquest (Pixel Productions)"
+  name "Starquest (Pixel Productions) [TZX]"
   description "Starquest (Pixel Productions)"
   year "1982"
   manufacturer "Pixel"
@@ -4247,7 +4247,7 @@ game (
 )
 
 game (
-  name "Starquest (Pixel Productions)"
+  name "Starquest (Pixel Productions) [P]"
   description "Starquest (Pixel Productions)"
   year "1982"
   manufacturer "Pixel"
@@ -4255,7 +4255,7 @@ game (
 )
 
 game (
-  name "Starquest (International Publishing and Software Inc.)"
+  name "Starquest (International Publishing and Software Inc.) [TZX]"
   description "Starquest (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "Pixel"
@@ -4263,7 +4263,7 @@ game (
 )
 
 game (
-  name "The Starter (Timex)"
+  name "The Starter (Timex) [TZX]"
   description "The Starter (Timex)"
   year "1981"
   manufacturer "Sinclair"
@@ -4271,7 +4271,7 @@ game (
 )
 
 game (
-  name "States and Capitals (Timex)"
+  name "States and Capitals (Timex) [TZX]"
   description "States and Capitals (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4279,7 +4279,7 @@ game (
 )
 
 game (
-  name "States and Capitals (Timex)"
+  name "States and Capitals (Timex) [P]"
   description "States and Capitals (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4287,7 +4287,7 @@ game (
 )
 
 game (
-  name "Statistics (Timex)"
+  name "Statistics (Timex) [TZX]"
   description "Statistics (Timex)"
   year "1982"
   manufacturer "R. Daniel"
@@ -4295,35 +4295,35 @@ game (
 )
 
 game (
-  name "Statistics (Zeta Software)"
+  name "Statistics (Zeta Software) [P]"
   description "Statistics (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "statistics(zeta).p" size 13376 crc 9204F603 md5 F82DE91F3B217E98A74152E96AB3856B sha1 5DF7CA4145A22CC7F730AAC13FE8835C40669321 )
 )
 
 game (
-  name "Statistics (Zeta Software)"
+  name "Statistics (Zeta Software) [TZX]"
   description "Statistics (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "Statistics(Zeta).tzx" size 13600 crc C0B4F14A md5 2B944E3BF6F17648919C3591B7B9905A sha1 7F13B230064429AB366F0816B43D683085D0BF62 )
 )
 
 game (
-  name "Stock Car (Informatique Service)"
+  name "Stock Car (Informatique Service) [TZX]"
   description "Stock Car (Informatique Service)"
   year "1984"
   rom ( name "StockCar.tzx" size 8450 crc FEDBBC78 md5 CD54361859D4D5AE1E4290C8C5DB8063 sha1 3604D2FF3B9DE27E45CB691131B98BE09BA3C65B )
 )
 
 game (
-  name "Stock Car (Informatique Service)"
+  name "Stock Car (Informatique Service) [P]"
   description "Stock Car (Informatique Service)"
   year "1984"
   rom ( name "stockcar.p" size 8216 crc 41224D6B md5 C7549CD5DFC22BD438A16D6FFEB29B18 sha1 E70D50DE2F51597BC74A50BDB25A34BF6B059888 )
 )
 
 game (
-  name "Stock-Market (Video Software)"
+  name "Stock-Market (Video Software) [TZX]"
   description "Stock-Market (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -4331,7 +4331,7 @@ game (
 )
 
 game (
-  name "Stock-Market (Video Software)"
+  name "Stock-Market (Video Software) [P]"
   description "Stock-Market (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -4339,7 +4339,7 @@ game (
 )
 
 game (
-  name "Stock Market Tech. Analysis 1 (Timex)"
+  name "Stock Market Tech. Analysis 1 (Timex) [TZX]"
   description "Stock Market Tech. Analysis 1 (Timex)"
   year "1982"
   manufacturer "T. H. Nooter"
@@ -4347,7 +4347,7 @@ game (
 )
 
 game (
-  name "Stock Market Tech. Analysis 1 (Timex)"
+  name "Stock Market Tech. Analysis 1 (Timex) [P]"
   description "Stock Market Tech. Analysis 1 (Timex)"
   year "1982"
   manufacturer "T. H. Nooter"
@@ -4355,7 +4355,7 @@ game (
 )
 
 game (
-  name "The Stock Option Analyzer (Timex)"
+  name "The Stock Option Analyzer (Timex) [P]"
   description "The Stock Option Analyzer (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4363,7 +4363,7 @@ game (
 )
 
 game (
-  name "The Stock Option Analyzer (Timex)"
+  name "The Stock Option Analyzer (Timex) [TZX]"
   description "The Stock Option Analyzer (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4371,7 +4371,7 @@ game (
 )
 
 game (
-  name "Strategy Football (Timex)"
+  name "Strategy Football (Timex) [TZX]"
   description "Strategy Football (Timex)"
   year "1983"
   manufacturer "Gerald Bennett"
@@ -4379,7 +4379,7 @@ game (
 )
 
 game (
-  name "Strategy Football (Timex)"
+  name "Strategy Football (Timex) [P]"
   description "Strategy Football (Timex)"
   year "1983"
   manufacturer "Gerald Bennett"
@@ -4387,7 +4387,7 @@ game (
 )
 
 game (
-  name "Subspace Striker (International Publishing and Software Inc.)"
+  name "Subspace Striker (International Publishing and Software Inc.) [TZX]"
   description "Subspace Striker (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "Pixel"
@@ -4395,7 +4395,7 @@ game (
 )
 
 game (
-  name "Super Chess (CP Software)"
+  name "Super Chess (CP Software) [P]"
   description "Super Chess (CP Software)"
   year "1982"
   manufacturer "CP Software"
@@ -4403,7 +4403,7 @@ game (
 )
 
 game (
-  name "Super Chess (CP Software)"
+  name "Super Chess (CP Software) [TZX]"
   description "Super Chess (CP Software)"
   year "1982"
   manufacturer "CP Software"
@@ -4411,7 +4411,7 @@ game (
 )
 
 game (
-  name "Super Chess (Softsync)"
+  name "Super Chess (Softsync) [TZX]"
   description "Super Chess (Softsync)"
   year "1982"
   manufacturer "CP Software"
@@ -4419,7 +4419,7 @@ game (
 )
 
 game (
-  name "Super Chess (Softsync)"
+  name "Super Chess (Softsync) [P]"
   description "Super Chess (Softsync)"
   year "1982"
   manufacturer "CP Software"
@@ -4427,7 +4427,7 @@ game (
 )
 
 game (
-  name "Super Invaders (Bridge Software)"
+  name "Super Invaders (Bridge Software) [TZX]"
   description "Super Invaders (Bridge Software)"
   year "1982"
   manufacturer "Bridge Software"
@@ -4435,7 +4435,7 @@ game (
 )
 
 game (
-  name "Super Invaders (Bridge Software)"
+  name "Super Invaders (Bridge Software) [P]"
   description "Super Invaders (Bridge Software)"
   year "1982"
   manufacturer "Bridge Software"
@@ -4443,7 +4443,7 @@ game (
 )
 
 game (
-  name "Super Invasion (Softsync)"
+  name "Super Invasion (Softsync) [P]"
   description "Super Invasion (Softsync)"
   year "1981"
   manufacturer "Beam Software"
@@ -4451,7 +4451,7 @@ game (
 )
 
 game (
-  name "Super Invasion (Softsync)"
+  name "Super Invasion (Softsync) [TZX]"
   description "Super Invasion (Softsync)"
   year "1981"
   manufacturer "Beam Software"
@@ -4459,7 +4459,7 @@ game (
 )
 
 game (
-  name "Super Math (Timex)"
+  name "Super Math (Timex) [TZX]"
   description "Super Math (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4467,7 +4467,7 @@ game (
 )
 
 game (
-  name "Super Math (Timex)"
+  name "Super Math (Timex) [P]"
   description "Super Math (Timex)"
   year "1982"
   manufacturer "Timex"
@@ -4475,7 +4475,7 @@ game (
 )
 
 game (
-  name "Super Nine (Romik Software)"
+  name "Super Nine (Romik Software) [TZX]"
   description "Super Nine (Romik Software)"
   year "1982"
   manufacturer "Romik Software"
@@ -4483,7 +4483,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (Sinclair Research)"
+  name "Super Programs 8 (Sinclair Research) [TZX]"
   description "Super Programs 8 (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -4491,7 +4491,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (Sinclair Research)"
+  name "Super Programs 8 (Sinclair Research) [P]"
   description "Super Programs 8 (Sinclair Research)"
   year "1982"
   manufacturer "ICL"
@@ -4499,7 +4499,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (ICL)"
+  name "Super Programs 8 (ICL) [P]"
   description "Super Programs 8 (ICL)"
   year "1982"
   manufacturer "ICL"
@@ -4507,7 +4507,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (ICL)"
+  name "Super Programs 8 (ICL) [TZX]"
   description "Super Programs 8 (ICL)"
   year "1982"
   manufacturer "ICL"
@@ -4515,7 +4515,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (Sinclair Black) (ICL)"
+  name "Super Programs 8 (Sinclair Black) (ICL) [P]"
   description "Super Programs 8 (Sinclair Black) (ICL)"
   year "1982"
   manufacturer "ICL"
@@ -4523,7 +4523,7 @@ game (
 )
 
 game (
-  name "Super Programs 8 (Sinclair Black) (ICL)"
+  name "Super Programs 8 (Sinclair Black) (ICL) [TZX]"
   description "Super Programs 8 (Sinclair Black) (ICL)"
   year "1982"
   manufacturer "ICL"
@@ -4531,7 +4531,7 @@ game (
 )
 
 game (
-  name "Super Scramble (Software Farm)"
+  name "Super Scramble (Software Farm) [P]"
   description "Super Scramble (Software Farm)"
   year "1982"
   manufacturer "Software Farm"
@@ -4539,7 +4539,7 @@ game (
 )
 
 game (
-  name "Super Scramble (Software Farm)"
+  name "Super Scramble (Software Farm) [TZX]"
   description "Super Scramble (Software Farm)"
   year "1982"
   manufacturer "Software Farm"
@@ -4547,7 +4547,7 @@ game (
 )
 
 game (
-  name "Supermaze (Timex)"
+  name "Supermaze (Timex) [TZX]"
   description "Supermaze (Timex)"
   year "1982"
   manufacturer "Greg Harvey"
@@ -4555,7 +4555,7 @@ game (
 )
 
 game (
-  name "Supermaze (Timex)"
+  name "Supermaze (Timex) [P]"
   description "Supermaze (Timex)"
   year "1982"
   manufacturer "Greg Harvey"
@@ -4563,7 +4563,7 @@ game (
 )
 
 game (
-  name "Tables Countdown (AVC Software)"
+  name "Tables Countdown (AVC Software) [TZX]"
   description "Tables Countdown (AVC Software)"
   year "1981"
   manufacturer "K. Jammer and C. Deeson"
@@ -4571,7 +4571,7 @@ game (
 )
 
 game (
-  name "Tables Countdown (AVC Software)"
+  name "Tables Countdown (AVC Software) [P]"
   description "Tables Countdown (AVC Software)"
   year "1981"
   manufacturer "K. Jammer and C. Deeson"
@@ -4579,7 +4579,7 @@ game (
 )
 
 game (
-  name "Tai (PSS)"
+  name "Tai (PSS) [P]"
   description "Tai (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -4587,7 +4587,7 @@ game (
 )
 
 game (
-  name "Tai (PSS)"
+  name "Tai (PSS) [TZX]"
   description "Tai (PSS)"
   year "1982"
   manufacturer "PSS"
@@ -4595,7 +4595,7 @@ game (
 )
 
 game (
-  name "Talkback (M. W. F. Ringrose)"
+  name "Talkback (M. W. F. Ringrose) [TZX]"
   description "Talkback (M. W. F. Ringrose)"
   year "1983"
   manufacturer "M. W. F. Ringrose"
@@ -4603,14 +4603,14 @@ game (
 )
 
 game (
-  name "Tapebook 50 1K (Control Technology)"
+  name "Tapebook 50 1K (Control Technology) [TZX]"
   description "Tapebook 50 1K (Control Technology)"
   manufacturer "Control Technology"
   rom ( name "TapeBook50.tzx" size 37005 crc D882BCCD md5 05B0B6C39C1A331E9D4592944F5FCF03 sha1 0D1B30D4D024147C9489D56E0519F9F60BF75CBD )
 )
 
 game (
-  name "Tarot (Timex)"
+  name "Tarot (Timex) [TZX]"
   description "Tarot (Timex)"
   year "1983"
   manufacturer "Computer Phood"
@@ -4618,7 +4618,7 @@ game (
 )
 
 game (
-  name "Tasword (Tasman Software)"
+  name "Tasword (Tasman Software) [P]"
   description "Tasword (Tasman Software)"
   year "1982"
   manufacturer "Tasman Software"
@@ -4626,7 +4626,7 @@ game (
 )
 
 game (
-  name "Tasword (Tasman Software)"
+  name "Tasword (Tasman Software) [TZX]"
   description "Tasword (Tasman Software)"
   year "1982"
   manufacturer "Tasman Software"
@@ -4634,21 +4634,21 @@ game (
 )
 
 game (
-  name "Tempest (Mikro-Gen)"
+  name "Tempest (Mikro-Gen) [TZX]"
   description "Tempest (Mikro-Gen)"
   manufacturer "S. P. Kelly"
   rom ( name "Tempest.tzx" size 3521 crc 5CCA0DED md5 09BDEA36A433F0A3F5FE8B8BCC8E0AA3 sha1 A4CFD1F82D0E4D255AE3B54A54F30A6CB96CE4F9 )
 )
 
 game (
-  name "Tempest (Mikro-Gen)"
+  name "Tempest (Mikro-Gen) [P]"
   description "Tempest (Mikro-Gen)"
   manufacturer "S. P. Kelly"
   rom ( name "tempest.p" size 3291 crc F760AFBA md5 44309DC8B4E242A1E08DFAD3F4D590BA sha1 8E4C160DF4EC5905F38A922E8E1403D984C92FE4 )
 )
 
 game (
-  name "Ten 1K Games (Computer Rentals)"
+  name "Ten 1K Games (Computer Rentals) [TZX]"
   description "Ten 1K Games (Computer Rentals)"
   year "1983"
   manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
@@ -4656,21 +4656,21 @@ game (
 )
 
 game (
-  name "Tomb of Dracula (Moviedrome Video)"
+  name "Tomb of Dracula (Moviedrome Video) [TZX]"
   description "Tomb of Dracula (Moviedrome Video)"
   manufacturer "Moviedrome Video"
   rom ( name "TombOfDracula.tzx" size 14743 crc EF2A3F64 md5 D1E99F6B365C888E93C405E7A37A529A sha1 E883C6E1992DDD67A82E66709211D024B563AA36 )
 )
 
 game (
-  name "Tomb of Dracula (Moviedrome Video)"
+  name "Tomb of Dracula (Moviedrome Video) [P]"
   description "Tomb of Dracula (Moviedrome Video)"
   manufacturer "Moviedrome Video"
   rom ( name "tombofdracula.p" size 14523 crc D7EBCD59 md5 547C42491C4EA4D99FD0386644CB3394 sha1 2228C845E69487DB3CB302D4AF27E2C03181D3B5 )
 )
 
 game (
-  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  name "Tomb of Dracula (Colour Inlay) (Felix Software) [TZX]"
   description "Tomb of Dracula (Colour Inlay) (Felix Software)"
   year "1982"
   manufacturer "Felix Software"
@@ -4678,7 +4678,7 @@ game (
 )
 
 game (
-  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  name "Tomb of Dracula (Colour Inlay) (Felix Software) [P]"
   description "Tomb of Dracula (Colour Inlay) (Felix Software)"
   year "1982"
   manufacturer "Felix Software"
@@ -4686,28 +4686,28 @@ game (
 )
 
 game (
-  name "Toolkit (Sinclair Research)"
+  name "Toolkit (Sinclair Research) [TZX]"
   description "Toolkit (Sinclair Research)"
   manufacturer "Artic"
   rom ( name "Toolkit.tzx" size 3820 crc C015038B md5 EE928ACDD0608E4095D31D8245038271 sha1 422FADBDF7CFC0DA1E6FDFD101F1D613581ED884 )
 )
 
 game (
-  name "Toolkit (Sinclair Research)"
+  name "Toolkit (Sinclair Research) [P]"
   description "Toolkit (Sinclair Research)"
   manufacturer "Artic"
   rom ( name "toolkit.p" size 3600 crc 28C28DC8 md5 75B1355E07AD2A2055D86809C1D12256 sha1 7A4132458D5D3BE2502C736B560DAE0A84E9DC91 )
 )
 
 game (
-  name "Toolkit (Artic)"
+  name "Toolkit (Artic) [P]"
   description "Toolkit (Artic)"
   manufacturer "Artic"
   rom ( name "toolkit(artic).p" size 3582 crc D331E275 md5 19C29072C4CF201F0C6D80A34C487E1A sha1 1076DA4A02F3E667D86EF0D40E644103768E71ED )
 )
 
 game (
-  name "Toolkit (Artic)"
+  name "Toolkit (Artic) [TZX]"
   description "Toolkit (Artic)"
   manufacturer "Artic"
   rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743B221 md5 7B527B5AFDB2C55D5A0135B6FAA68F98 sha1 049169DEB7C4C760D79DD66FDF49172D5A77D776 )
@@ -4726,7 +4726,7 @@ game (
 )
 
 game (
-  name "Toolkit (JRS Software)"
+  name "Toolkit (JRS Software) [TZX]"
   description "Toolkit (JRS Software)"
   year "1982"
   manufacturer "Paul Holmes"
@@ -4734,7 +4734,7 @@ game (
 )
 
 game (
-  name "Toolkit (JRS Software)"
+  name "Toolkit (JRS Software) [P]"
   description "Toolkit (JRS Software)"
   year "1982"
   manufacturer "Paul Holmes"
@@ -4742,7 +4742,7 @@ game (
 )
 
 game (
-  name "Trace (Texgate)"
+  name "Trace (Texgate) [TZX]"
   description "Trace (Texgate)"
   year "1983"
   manufacturer "Texgate"
@@ -4750,7 +4750,7 @@ game (
 )
 
 game (
-  name "Trace (Texgate)"
+  name "Trace (Texgate) [P]"
   description "Trace (Texgate)"
   year "1983"
   manufacturer "Texgate"
@@ -4758,7 +4758,7 @@ game (
 )
 
 game (
-  name "Trader (Quicksilva)"
+  name "Trader (Quicksilva) [TZX]"
   description "Trader (Quicksilva)"
   year "1982"
   manufacturer "Pixel"
@@ -4766,7 +4766,7 @@ game (
 )
 
 game (
-  name "Trader (Flap-fronted box) (Pixel Productions)"
+  name "Trader (Flap-fronted box) (Pixel Productions) [TZX]"
   description "Trader (Flap-fronted box) (Pixel Productions)"
   year "1982"
   manufacturer "Pixel"
@@ -4774,7 +4774,7 @@ game (
 )
 
 game (
-  name "Trader (Pixel Productions)"
+  name "Trader (Pixel Productions) [TZX]"
   description "Trader (Pixel Productions)"
   year "1982"
   manufacturer "Pixel"
@@ -4782,7 +4782,7 @@ game (
 )
 
 game (
-  name "Traffic (Loriciels)"
+  name "Traffic (Loriciels) [TZX]"
   description "Traffic (Loriciels)"
   year "1984"
   manufacturer "M Bouat"
@@ -4790,7 +4790,7 @@ game (
 )
 
 game (
-  name "Traffic (Loriciels)"
+  name "Traffic (Loriciels) [P]"
   description "Traffic (Loriciels)"
   year "1984"
   manufacturer "M Bouat"
@@ -4798,7 +4798,7 @@ game (
 )
 
 game (
-  name "Tutor (German) (Artic)"
+  name "Tutor (German) (Artic) [P]"
   description "Tutor (German) (Artic)"
   year "1983"
   manufacturer "S. and J. Mitchell"
@@ -4806,7 +4806,7 @@ game (
 )
 
 game (
-  name "Tutor (German) (Artic)"
+  name "Tutor (German) (Artic) [TZX]"
   description "Tutor (German) (Artic)"
   year "1983"
   manufacturer "S. and J. Mitchell"
@@ -4814,7 +4814,7 @@ game (
 )
 
 game (
-  name "Tutor (Spanish) (Artic)"
+  name "Tutor (Spanish) (Artic) [P]"
   description "Tutor (Spanish) (Artic)"
   year "1983"
   manufacturer "S. and J. Mitchell"
@@ -4822,7 +4822,7 @@ game (
 )
 
 game (
-  name "Tutor (Spanish) (Artic)"
+  name "Tutor (Spanish) (Artic) [TZX]"
   description "Tutor (Spanish) (Artic)"
   year "1983"
   manufacturer "S. and J. Mitchell"
@@ -4830,7 +4830,7 @@ game (
 )
 
 game (
-  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service) [TZX]"
   description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
   year "1982"
   manufacturer "Informatique Service Logiciels"
@@ -4838,7 +4838,7 @@ game (
 )
 
 game (
-  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service) [P]"
   description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
   year "1982"
   manufacturer "Informatique Service Logiciels"
@@ -4846,7 +4846,7 @@ game (
 )
 
 game (
-  name "Tyrant of Athens (Lothlorien)"
+  name "Tyrant of Athens (Lothlorien) [P]"
   description "Tyrant of Athens (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -4854,7 +4854,7 @@ game (
 )
 
 game (
-  name "Tyrant of Athens (Lothlorien)"
+  name "Tyrant of Athens (Lothlorien) [TZX]"
   description "Tyrant of Athens (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -4862,7 +4862,7 @@ game (
 )
 
 game (
-  name "UDG (dK'tronics)"
+  name "UDG (dK'tronics) [P]"
   description "UDG (dK'tronics)"
   year "1981"
   manufacturer "dK'tronics"
@@ -4870,7 +4870,7 @@ game (
 )
 
 game (
-  name "UDG (dK'tronics)"
+  name "UDG (dK'tronics) [TZX]"
   description "UDG (dK'tronics)"
   year "1981"
   manufacturer "dK'tronics"
@@ -4878,7 +4878,7 @@ game (
 )
 
 game (
-  name "UFO (Protek)"
+  name "UFO (Protek) [P]"
   description "UFO (Protek)"
   year "1983"
   manufacturer "Protek"
@@ -4886,7 +4886,7 @@ game (
 )
 
 game (
-  name "UFO (Protek)"
+  name "UFO (Protek) [TZX]"
   description "UFO (Protek)"
   year "1983"
   manufacturer "Protek"
@@ -4894,7 +4894,7 @@ game (
 )
 
 game (
-  name "UFO + 3D Maze (Babtech)"
+  name "UFO + 3D Maze (Babtech) [TZX]"
   description "UFO + 3D Maze (Babtech)"
   year "1982"
   manufacturer "Babtech"
@@ -4902,7 +4902,7 @@ game (
 )
 
 game (
-  name "VU-CALC (Sinclair Research)"
+  name "VU-CALC (Sinclair Research) [TZX]"
   description "VU-CALC (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -4910,7 +4910,7 @@ game (
 )
 
 game (
-  name "VU-CALC (Sinclair Research)"
+  name "VU-CALC (Sinclair Research) [P]"
   description "VU-CALC (Sinclair Research)"
   year "1982"
   manufacturer "Psion"
@@ -4918,7 +4918,7 @@ game (
 )
 
 game (
-  name "VU-CALC (Timex)"
+  name "VU-CALC (Timex) [TZX]"
   description "VU-CALC (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -4926,7 +4926,7 @@ game (
 )
 
 game (
-  name "VU-CALC (Timex)"
+  name "VU-CALC (Timex) [P]"
   description "VU-CALC (Timex)"
   year "1982"
   manufacturer "Psion"
@@ -4934,21 +4934,21 @@ game (
 )
 
 game (
-  name "Variance Analyzer (Zeta Software)"
+  name "Variance Analyzer (Zeta Software) [P]"
   description "Variance Analyzer (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "varianceanalyzer.p" size 8185 crc 73023B9A md5 72FBC8622939AC385B41DC3355B6D4C9 sha1 01535D36D01908855E4530C3077C6B774E893CE8 )
 )
 
 game (
-  name "Variance Analyzer (Zeta Software)"
+  name "Variance Analyzer (Zeta Software) [TZX]"
   description "Variance Analyzer (Zeta Software)"
   manufacturer "Dr. Walter Diembeck"
   rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90A5774A md5 5237031B0A92F415C5AC347D60FD5D3E sha1 A429C8165B8BE52791C99E5DA26A84758A4C508B )
 )
 
 game (
-  name "Vector Mathematics (W. H. Smith)"
+  name "Vector Mathematics (W. H. Smith) [TZX]"
   description "Vector Mathematics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -4956,7 +4956,7 @@ game (
 )
 
 game (
-  name "Vector Mathematics (W. H. Smith)"
+  name "Vector Mathematics (W. H. Smith) [P]"
   description "Vector Mathematics (W. H. Smith)"
   year "1982"
   manufacturer "ICL"
@@ -4964,7 +4964,7 @@ game (
 )
 
 game (
-  name "Video-Ad (Video Software)"
+  name "Video-Ad (Video Software) [TZX]"
   description "Video-Ad (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -4972,7 +4972,7 @@ game (
 )
 
 game (
-  name "Video-Ad (Video Software)"
+  name "Video-Ad (Video Software) [P]"
   description "Video-Ad (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -4980,7 +4980,7 @@ game (
 )
 
 game (
-  name "Video Graffiti (AGF Hardware)"
+  name "Video Graffiti (AGF Hardware) [P]"
   description "Video Graffiti (AGF Hardware)"
   year "1982"
   manufacturer "AGF Hardware"
@@ -4988,7 +4988,7 @@ game (
 )
 
 game (
-  name "Video Graffiti (AGF Hardware)"
+  name "Video Graffiti (AGF Hardware) [TZX]"
   description "Video Graffiti (AGF Hardware)"
   year "1982"
   manufacturer "AGF Hardware"
@@ -4996,7 +4996,7 @@ game (
 )
 
 game (
-  name "Video-Map (Video Software)"
+  name "Video-Map (Video Software) [TZX]"
   description "Video-Map (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -5004,7 +5004,7 @@ game (
 )
 
 game (
-  name "Video-Map (Video Software)"
+  name "Video-Map (Video Software) [P]"
   description "Video-Map (Video Software)"
   year "1981"
   manufacturer "Video Software"
@@ -5012,35 +5012,35 @@ game (
 )
 
 game (
-  name "Video-Plan (Video Software)"
+  name "Video-Plan (Video Software) [TZX]"
   description "Video-Plan (Video Software)"
   manufacturer "Video Software"
   rom ( name "VideoPlan.A.tzx" size 15425 crc 849E21DC md5 23E1F6EED1029F7433286C3682CCFF69 sha1 FFFA47475A0634FC9859212E5A309603D922D258 )
 )
 
 game (
-  name "Video-Plan (Video Software)"
+  name "Video-Plan (Video Software) [P]"
   description "Video-Plan (Video Software)"
   manufacturer "Video Software"
   rom ( name "videoplan.p" size 15189 crc FD242331 md5 260E9496C1BD1CB40A6095F04E0BBEC2 sha1 2CB0A66C7AA506061FE621A53EE0BC7F143B9988 )
 )
 
 game (
-  name "Video-View (Video Software)"
+  name "Video-View (Video Software) [P]"
   description "Video-View (Video Software)"
   manufacturer "Video Software"
   rom ( name "videoview.p" size 13859 crc 53ECA8E2 md5 E02361E6A92651A25CA5F0F5CAC3C408 sha1 BDC28FC5964960F3159A8BD08DB7B3DED64ECA98 )
 )
 
 game (
-  name "Video-View (Video Software)"
+  name "Video-View (Video Software) [TZX]"
   description "Video-View (Video Software)"
   manufacturer "Video Software"
   rom ( name "VideoView.tzx" size 14095 crc F5FDB04B md5 FD38379FC882828484B0A1E7FAC02A4D sha1 ABADD8BD7A829C778D6FBF1D4F394025CD1B7C58 )
 )
 
 game (
-  name "Viewtext (U.S. release) (Bug Byte)"
+  name "Viewtext (U.S. release) (Bug Byte) [TZX]"
   description "Viewtext (U.S. release) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5048,7 +5048,7 @@ game (
 )
 
 game (
-  name "Viewtext (U.S. release) (Bug Byte)"
+  name "Viewtext (U.S. release) (Bug Byte) [P]"
   description "Viewtext (U.S. release) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5056,7 +5056,7 @@ game (
 )
 
 game (
-  name "Volcanic Dungeon (Carnell)"
+  name "Volcanic Dungeon (Carnell) [P]"
   description "Volcanic Dungeon (Carnell)"
   year "1982"
   manufacturer "Carnell Software"
@@ -5064,7 +5064,7 @@ game (
 )
 
 game (
-  name "Volcanic Dungeon (Carnell)"
+  name "Volcanic Dungeon (Carnell) [TZX]"
   description "Volcanic Dungeon (Carnell)"
   year "1982"
   manufacturer "Carnell Software"
@@ -5072,7 +5072,7 @@ game (
 )
 
 game (
-  name "Warlord (Lothlorien)"
+  name "Warlord (Lothlorien) [P]"
   description "Warlord (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -5080,7 +5080,7 @@ game (
 )
 
 game (
-  name "Warlord (Lothlorien)"
+  name "Warlord (Lothlorien) [TZX]"
   description "Warlord (Lothlorien)"
   year "1982"
   manufacturer "M. C. Lothlorien"
@@ -5088,7 +5088,7 @@ game (
 )
 
 game (
-  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor) [P]"
   description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
   year "1983"
   manufacturer "Computertutor"
@@ -5096,7 +5096,7 @@ game (
 )
 
 game (
-  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor) [TZX]"
   description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
   year "1983"
   manufacturer "Computertutor"
@@ -5104,7 +5104,7 @@ game (
 )
 
 game (
-  name "Winged Avenger (Work Force)"
+  name "Winged Avenger (Work Force) [TZX]"
   description "Winged Avenger (Work Force)"
   year "1982"
   manufacturer "Work Force"
@@ -5112,7 +5112,7 @@ game (
 )
 
 game (
-  name "Winged Avenger (Work Force)"
+  name "Winged Avenger (Work Force) [P]"
   description "Winged Avenger (Work Force)"
   year "1982"
   manufacturer "Work Force"
@@ -5120,14 +5120,14 @@ game (
 )
 
 game (
-  name "Word Processor (Alan's Recordings)"
+  name "Word Processor (Alan's Recordings) [TZX]"
   description "Word Processor (Alan's Recordings)"
   manufacturer "Alan D. Went"
   rom ( name "WordProcessor.A.tzx" size 12384 crc C1F41D1C md5 668F2DF5BA976DDA0E79405A1C3B0353 sha1 4F2E76139EFB5A07B443C5495636BCBB42489241 )
 )
 
 game (
-  name "Word Test (Mindware)"
+  name "Word Test (Mindware) [P]"
   description "Word Test (Mindware)"
   year "1982"
   manufacturer "Christopher Jones"
@@ -5135,7 +5135,7 @@ game (
 )
 
 game (
-  name "Word Test (Mindware)"
+  name "Word Test (Mindware) [TZX]"
   description "Word Test (Mindware)"
   year "1982"
   manufacturer "Christopher Jones"
@@ -5143,7 +5143,7 @@ game (
 )
 
 game (
-  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  name "World Cup Football (Test your knowledge of) (M. A. Smith) [P]"
   description "World Cup Football (Test your knowledge of) (M. A. Smith)"
   year "1982"
   manufacturer "M. A. Smith"
@@ -5151,7 +5151,7 @@ game (
 )
 
 game (
-  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  name "World Cup Football (Test your knowledge of) (M. A. Smith) [TZX]"
   description "World Cup Football (Test your knowledge of) (M. A. Smith)"
   year "1982"
   manufacturer "M. A. Smith"
@@ -5159,7 +5159,7 @@ game (
 )
 
 game (
-  name "10 Games (J. K. Greye)"
+  name "10 Games (J. K. Greye) [TZX]"
   description "10 Games (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5167,21 +5167,21 @@ game (
 )
 
 game (
-  name "1K Games Pack (Artic)"
+  name "1K Games Pack (Artic) [TZX]"
   description "1K Games Pack (Artic)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K Games (Sinclair Research)"
+  name "1K Games (Sinclair Research) [TZX]"
   description "1K Games (Sinclair Research)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K ZX Chess (Sinclair Research)"
+  name "1K ZX Chess (Sinclair Research) [TZX]"
   description "1K ZX Chess (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -5189,28 +5189,28 @@ game (
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [P]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [TZX]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
 )
 
 game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
+  name "2K Games Pack (International Publishing and Software Inc.) [TZX]"
   description "2K Games Pack (International Publishing and Software Inc.)"
   year "1982"
   rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [P]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5218,7 +5218,7 @@ game (
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [TZX]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5226,7 +5226,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [TZX]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -5234,7 +5234,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [P]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -5242,7 +5242,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [P]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5250,7 +5250,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [TZX]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5258,7 +5258,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [TZX]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -5266,7 +5266,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [P]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -5274,21 +5274,21 @@ game (
 )
 
 game (
-  name "5-2K Family Pak (Timeworks)"
+  name "5-2K Family Pak (Timeworks) [TZX]"
   description "5-2K Family Pak (Timeworks)"
   manufacturer "Timeworks"
   rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
 )
 
 game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service) [TZX]"
   description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
   manufacturer "GM4IHJ (J Branegan)"
   rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
 )
 
 game (
-  name "10 Games (J. K. Greye)"
+  name "10 Games (J. K. Greye) [TZX]"
   description "10 Games (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5296,21 +5296,21 @@ game (
 )
 
 game (
-  name "1K Games Pack (Artic)"
+  name "1K Games Pack (Artic) [TZX]"
   description "1K Games Pack (Artic)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K Games (Sinclair Research)"
+  name "1K Games (Sinclair Research) [TZX]"
   description "1K Games (Sinclair Research)"
   manufacturer "Artic"
   rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
 
 game (
-  name "1K ZX Chess (Sinclair Research)"
+  name "1K ZX Chess (Sinclair Research) [TZX]"
   description "1K ZX Chess (Sinclair Research)"
   year "1982"
   manufacturer "Artic"
@@ -5318,28 +5318,28 @@ game (
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [P]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
 )
 
 game (
-  name "1K ZX Chess (Artic)"
+  name "1K ZX Chess (Artic) [TZX]"
   description "1K ZX Chess (Artic)"
   manufacturer "Artic"
   rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
 )
 
 game (
-  name "2K Games Pack (International Publishing and Software Inc.)"
+  name "2K Games Pack (International Publishing and Software Inc.) [TZX]"
   description "2K Games Pack (International Publishing and Software Inc.)"
   year "1982"
   rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [P]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5347,7 +5347,7 @@ game (
 )
 
 game (
-  name "3D Defender (J. K. Greye)"
+  name "3D Defender (J. K. Greye) [TZX]"
   description "3D Defender (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5355,7 +5355,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [TZX]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -5363,7 +5363,7 @@ game (
 )
 
 game (
-  name "3D Defender (New Generation)"
+  name "3D Defender (New Generation) [P]"
   description "3D Defender (New Generation)"
   year "1981"
   manufacturer "M. E. Evans"
@@ -5371,7 +5371,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [P]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5379,7 +5379,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (J. K. Greye)"
+  name "3D Monster Maze (J. K. Greye) [TZX]"
   description "3D Monster Maze (J. K. Greye)"
   year "1981"
   manufacturer "J. K. Greye"
@@ -5387,7 +5387,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [TZX]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -5395,7 +5395,7 @@ game (
 )
 
 game (
-  name "3D Monster Maze (New Generation)"
+  name "3D Monster Maze (New Generation) [P]"
   description "3D Monster Maze (New Generation)"
   year "1982"
   manufacturer "J. K. Greye"
@@ -5403,21 +5403,21 @@ game (
 )
 
 game (
-  name "5-2K Family Pak (Timeworks)"
+  name "5-2K Family Pak (Timeworks) [TZX]"
   description "5-2K Family Pak (Timeworks)"
   manufacturer "Timeworks"
   rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
 )
 
 game (
-  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service) [TZX]"
   description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
   manufacturer "GM4IHJ (J Branegan)"
   rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
 )
 
 game (
-  name "ZXAS (Bug Byte)"
+  name "ZXAS (Bug Byte) [P]"
   description "ZXAS (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5425,7 +5425,7 @@ game (
 )
 
 game (
-  name "ZXAS (Bug Byte)"
+  name "ZXAS (Bug Byte) [TZX]"
   description "ZXAS (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5433,7 +5433,7 @@ game (
 )
 
 game (
-  name "ZXAS (Printed instructions) (Bug Byte)"
+  name "ZXAS (Printed instructions) (Bug Byte) [P]"
   description "ZXAS (Printed instructions) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5441,7 +5441,7 @@ game (
 )
 
 game (
-  name "ZXAS (Printed instructions) (Bug Byte)"
+  name "ZXAS (Printed instructions) (Bug Byte) [TZX]"
   description "ZXAS (Printed instructions) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5449,21 +5449,21 @@ game (
 )
 
 game (
-  name "ZXAS (Gladstone) (Gladstone Electronics)"
+  name "ZXAS (Gladstone) (Gladstone Electronics) [P]"
   description "ZXAS (Gladstone) (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "zxas(ge).p" size 5619 crc 850BAB49 md5 7C622F096AD94F4201922E7CDEA35C67 sha1 0B758FDB9BCFC94D9B37F743F78075595563C529 )
 )
 
 game (
-  name "ZXAS (Gladstone) (Gladstone Electronics)"
+  name "ZXAS (Gladstone) (Gladstone Electronics) [TZX]"
   description "ZXAS (Gladstone) (Gladstone Electronics)"
   manufacturer "Bug Byte"
   rom ( name "ZXAS(GE).tzx" size 5843 crc A448E4BA md5 BEEBBC4F4B2262F2E2C4AA3F45A62C69 sha1 E09ABFF8F1C771B7E1ACE6B6612EB99DFA539654 )
 )
 
 game (
-  name "ZXAS (Monochrome) (Bug Byte)"
+  name "ZXAS (Monochrome) (Bug Byte) [TZX]"
   description "ZXAS (Monochrome) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5471,7 +5471,7 @@ game (
 )
 
 game (
-  name "ZXAS (Monochrome) (Bug Byte)"
+  name "ZXAS (Monochrome) (Bug Byte) [P]"
   description "ZXAS (Monochrome) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5479,7 +5479,7 @@ game (
 )
 
 game (
-  name "ZXAS (Typed Inlay) (Bug Byte)"
+  name "ZXAS (Typed Inlay) (Bug Byte) [TZX]"
   description "ZXAS (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5487,7 +5487,7 @@ game (
 )
 
 game (
-  name "ZXAS (Typed Inlay) (Bug Byte)"
+  name "ZXAS (Typed Inlay) (Bug Byte) [P]"
   description "ZXAS (Typed Inlay) (Bug Byte)"
   year "1981"
   manufacturer "Bug Byte"
@@ -5495,7 +5495,7 @@ game (
 )
 
 game (
-  name "ZXAS (Yellow) (Bug Byte)"
+  name "ZXAS (Yellow) (Bug Byte) [TZX]"
   description "ZXAS (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5503,7 +5503,7 @@ game (
 )
 
 game (
-  name "ZXAS (Yellow) (Bug Byte)"
+  name "ZXAS (Yellow) (Bug Byte) [P]"
   description "ZXAS (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5511,7 +5511,7 @@ game (
 )
 
 game (
-  name "ZX Action Pack (Axis)"
+  name "ZX Action Pack (Axis) [TZX]"
   description "ZX Action Pack (Axis)"
   year "1982"
   manufacturer "Axis"
@@ -5519,21 +5519,21 @@ game (
 )
 
 game (
-  name "ZX Assembler (Artic)"
+  name "ZX Assembler (Artic) [TZX]"
   description "ZX Assembler (Artic)"
   manufacturer "D. P. Aknai and M. Streeton"
   rom ( name "ZXAssembler.tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
 )
 
 game (
-  name "ZX Assembler (Artic)"
+  name "ZX Assembler (Artic) [P]"
   description "ZX Assembler (Artic)"
   manufacturer "D. P. Aknai and M. Streeton"
   rom ( name "zxassembler.p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
 )
 
 game (
-  name "ZX Assembler (International Publishing and Software Inc.)"
+  name "ZX Assembler (International Publishing and Software Inc.) [TZX]"
   description "ZX Assembler (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton (Artic)"
@@ -5541,7 +5541,7 @@ game (
 )
 
 game (
-  name "ZX Assembler (International Publishing and Software Inc.)"
+  name "ZX Assembler (International Publishing and Software Inc.) [P]"
   description "ZX Assembler (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton (Artic)"
@@ -5549,7 +5549,7 @@ game (
 )
 
 game (
-  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.) [P]"
   description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton"
@@ -5557,7 +5557,7 @@ game (
 )
 
 game (
-  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.) [TZX]"
   description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton"
@@ -5565,7 +5565,7 @@ game (
 )
 
 game (
-  name "ZX Assembleur (French) (Artic)"
+  name "ZX Assembleur (French) (Artic) [TZX]"
   description "ZX Assembleur (French) (Artic)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton"
@@ -5573,7 +5573,7 @@ game (
 )
 
 game (
-  name "ZX Assembleur (French) (Artic)"
+  name "ZX Assembleur (French) (Artic) [P]"
   description "ZX Assembleur (French) (Artic)"
   year "1982"
   manufacturer "D. P. Aknai and M. Streeton"
@@ -5581,7 +5581,7 @@ game (
 )
 
 game (
-  name "ZX Asteroids (Electric Pencil Company)"
+  name "ZX Asteroids (Electric Pencil Company) [P]"
   description "ZX Asteroids (Electric Pencil Company)"
   year "1982"
   manufacturer "Robert J. Wray"
@@ -5589,7 +5589,7 @@ game (
 )
 
 game (
-  name "ZX Asteroids (Electric Pencil Company)"
+  name "ZX Asteroids (Electric Pencil Company) [TZX]"
   description "ZX Asteroids (Electric Pencil Company)"
   year "1982"
   manufacturer "Robert J. Wray"
@@ -5597,7 +5597,7 @@ game (
 )
 
 game (
-  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  name "ZX Bug V3.125 (Monochrome Inlay) (Artic) [TZX]"
   description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -5605,7 +5605,7 @@ game (
 )
 
 game (
-  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  name "ZX Bug V3.125 (Monochrome Inlay) (Artic) [P]"
   description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -5613,7 +5613,7 @@ game (
 )
 
 game (
-  name "ZX Bug (International Publishing and Software Inc.)"
+  name "ZX Bug (International Publishing and Software Inc.) [TZX]"
   description "ZX Bug (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "Artic (?)"
@@ -5621,7 +5621,7 @@ game (
 )
 
 game (
-  name "ZX Bug (International Publishing and Software Inc.)"
+  name "ZX Bug (International Publishing and Software Inc.) [P]"
   description "ZX Bug (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "Artic (?)"
@@ -5629,49 +5629,49 @@ game (
 )
 
 game (
-  name "ZX Chess I (Black inlay) (Artic)"
+  name "ZX Chess I (Black inlay) (Artic) [P]"
   description "ZX Chess I (Black inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "zxchessi(black).p" size 14119 crc CCE17D9C md5 2AA8D6A1B52211893F7A7264CFF2BC1A sha1 CECA1C8F7719AFE71D991A073A88561FCDA27AE8 )
 )
 
 game (
-  name "ZX Chess I (Black inlay) (Artic)"
+  name "ZX Chess I (Black inlay) (Artic) [TZX]"
   description "ZX Chess I (Black inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "ZXChessI(Black).tzx" size 14337 crc 98F8FD30 md5 F2EE420566092A3ECD4D82F532BC98DE sha1 B2EE8FB73779FC8B13B1BEC533E59D762F6F871F )
 )
 
 game (
-  name "ZX Chess II (Artic)"
+  name "ZX Chess II (Artic) [P]"
   description "ZX Chess II (Artic)"
   manufacturer "Artic"
   rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
 )
 
 game (
-  name "ZX Chess II (Artic)"
+  name "ZX Chess II (Artic) [TZX]"
   description "ZX Chess II (Artic)"
   manufacturer "Artic"
   rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
 )
 
 game (
-  name "ZX Chess II (Black inlay) (Artic)"
+  name "ZX Chess II (Black inlay) (Artic) [TZX]"
   description "ZX Chess II (Black inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
 )
 
 game (
-  name "ZX Chess II (Black inlay) (Artic)"
+  name "ZX Chess II (Black inlay) (Artic) [P]"
   description "ZX Chess II (Black inlay) (Artic)"
   manufacturer "Artic"
   rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
 )
 
 game (
-  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  name "ZX Chess II (IPS) (International Publishing and Software Inc.) [TZX]"
   description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -5679,7 +5679,7 @@ game (
 )
 
 game (
-  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  name "ZX Chess II (IPS) (International Publishing and Software Inc.) [P]"
   description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "International Publishing and Software Inc."
@@ -5687,7 +5687,7 @@ game (
 )
 
 game (
-  name "ZX Chess II (Improved) (Artic)"
+  name "ZX Chess II (Improved) (Artic) [P]"
   description "ZX Chess II (Improved) (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -5695,7 +5695,7 @@ game (
 )
 
 game (
-  name "ZX Chess II (Improved) (Artic)"
+  name "ZX Chess II (Improved) (Artic) [TZX]"
   description "ZX Chess II (Improved) (Artic)"
   year "1981"
   manufacturer "Artic"
@@ -5703,7 +5703,7 @@ game (
 )
 
 game (
-  name "ZX-Compiler (Silversoft)"
+  name "ZX-Compiler (Silversoft) [TZX]"
   description "ZX-Compiler (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -5711,7 +5711,7 @@ game (
 )
 
 game (
-  name "ZX-Compiler (Silversoft)"
+  name "ZX-Compiler (Silversoft) [P]"
   description "ZX-Compiler (Silversoft)"
   year "1982"
   manufacturer "Silversoft"
@@ -5719,7 +5719,7 @@ game (
 )
 
 game (
-  name "ZXDB (Bug Byte)"
+  name "ZXDB (Bug Byte) [TZX]"
   description "ZXDB (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5727,7 +5727,7 @@ game (
 )
 
 game (
-  name "ZXDB (Bug Byte)"
+  name "ZXDB (Bug Byte) [P]"
   description "ZXDB (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5735,7 +5735,7 @@ game (
 )
 
 game (
-  name "ZXDB (Typed Inlay, black) (Bug Byte)"
+  name "ZXDB (Typed Inlay, black) (Bug Byte) [TZX]"
   description "ZXDB (Typed Inlay, black) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5743,7 +5743,7 @@ game (
 )
 
 game (
-  name "ZXDB (Typed Inlay, black) (Bug Byte)"
+  name "ZXDB (Typed Inlay, black) (Bug Byte) [P]"
   description "ZXDB (Typed Inlay, black) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5751,7 +5751,7 @@ game (
 )
 
 game (
-  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  name "ZXDB (Typed Inlay, blue) (Bug Byte) [TZX]"
   description "ZXDB (Typed Inlay, blue) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5759,7 +5759,7 @@ game (
 )
 
 game (
-  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  name "ZXDB (Typed Inlay, blue) (Bug Byte) [P]"
   description "ZXDB (Typed Inlay, blue) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5767,7 +5767,7 @@ game (
 )
 
 game (
-  name "ZXDB (Yellow) (Bug Byte)"
+  name "ZXDB (Yellow) (Bug Byte) [TZX]"
   description "ZXDB (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5775,7 +5775,7 @@ game (
 )
 
 game (
-  name "ZXDB (Yellow) (Bug Byte)"
+  name "ZXDB (Yellow) (Bug Byte) [P]"
   description "ZXDB (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5783,14 +5783,14 @@ game (
 )
 
 game (
-  name "ZX Forth (Artic)"
+  name "ZX Forth (Artic) [TZX]"
   description "ZX Forth (Artic)"
   manufacturer "Artic Computing"
   rom ( name "ZXForth.tzx" size 20567 crc 587D765F md5 421DDC790C350146AF56D1683D3CF2B6 sha1 63C6E3CD88655B30CEF4AFCDF4FCAB959210047F )
 )
 
 game (
-  name "ZX Forth (International Publishing and Software Inc.)"
+  name "ZX Forth (International Publishing and Software Inc.) [TZX]"
   description "ZX Forth (International Publishing and Software Inc.)"
   year "1982"
   manufacturer "Artic"
@@ -5798,21 +5798,21 @@ game (
 )
 
 game (
-  name "ZX-MC (Picturesque)"
+  name "ZX-MC (Picturesque) [P]"
   description "ZX-MC (Picturesque)"
   manufacturer "Picturesque"
   rom ( name "zxmc.p" size 3555 crc DE00007D md5 1FE46C4D47A32B6C7B77144987A6C753 sha1 8897D32731370314DA8BAE6C4E8AE56761E4B3AA )
 )
 
 game (
-  name "ZX-MC (Picturesque)"
+  name "ZX-MC (Picturesque) [TZX]"
   description "ZX-MC (Picturesque)"
   manufacturer "Picturesque"
   rom ( name "ZXMC.tzx" size 3781 crc BAD36AEF md5 A9804BE70B200A01D551198DE5D13E70 sha1 9EDC5C21E1EDD96E1A733908D9E7D39CEC6DF85E )
 )
 
 game (
-  name "ZXM Sound Box Super Editor (Timedata)"
+  name "ZXM Sound Box Super Editor (Timedata) [TZX]"
   description "ZXM Sound Box Super Editor (Timedata)"
   year "1983"
   manufacturer "Timedata"
@@ -5820,7 +5820,7 @@ game (
 )
 
 game (
-  name "ZXM Sound Box Super Editor (Timedata)"
+  name "ZXM Sound Box Super Editor (Timedata) [P]"
   description "ZXM Sound Box Super Editor (Timedata)"
   year "1983"
   manufacturer "Timedata"
@@ -5828,7 +5828,7 @@ game (
 )
 
 game (
-  name "ZX Pro/File (Thomas B. Woods)"
+  name "ZX Pro_File (Thomas B. Woods) [P]"
   description "ZX Pro/File (Thomas B. Woods)"
   year "1983"
   manufacturer "Thomas B. Woods"
@@ -5836,7 +5836,7 @@ game (
 )
 
 game (
-  name "ZX Pro/File (Thomas B. Woods)"
+  name "ZX Pro_File (Thomas B. Woods) [TZX]"
   description "ZX Pro/File (Thomas B. Woods)"
   year "1983"
   manufacturer "Thomas B. Woods"
@@ -5844,7 +5844,7 @@ game (
 )
 
 game (
-  name "ZX-Sideprint (Microsphere)"
+  name "ZX-Sideprint (Microsphere) [P]"
   description "ZX-Sideprint (Microsphere)"
   year "1982"
   manufacturer "Microsphere"
@@ -5852,7 +5852,7 @@ game (
 )
 
 game (
-  name "ZX-Sideprint (Microsphere)"
+  name "ZX-Sideprint (Microsphere) [TZX]"
   description "ZX-Sideprint (Microsphere)"
   year "1982"
   manufacturer "Microsphere"
@@ -5860,7 +5860,7 @@ game (
 )
 
 game (
-  name "ZXTK (Bug Byte)"
+  name "ZXTK (Bug Byte) [TZX]"
   description "ZXTK (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5868,7 +5868,7 @@ game (
 )
 
 game (
-  name "ZXTK (Bug Byte)"
+  name "ZXTK (Bug Byte) [P]"
   description "ZXTK (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5876,7 +5876,7 @@ game (
 )
 
 game (
-  name "ZXTK (Printed instructions) (Bug Byte)"
+  name "ZXTK (Printed instructions) (Bug Byte) [TZX]"
   description "ZXTK (Printed instructions) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5884,7 +5884,7 @@ game (
 )
 
 game (
-  name "ZXTK (Printed instructions) (Bug Byte)"
+  name "ZXTK (Printed instructions) (Bug Byte) [P]"
   description "ZXTK (Printed instructions) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5892,7 +5892,7 @@ game (
 )
 
 game (
-  name "ZXTK (Yellow) (Bug Byte)"
+  name "ZXTK (Yellow) (Bug Byte) [TZX]"
   description "ZXTK (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5900,7 +5900,7 @@ game (
 )
 
 game (
-  name "ZXTK (Yellow) (Bug Byte)"
+  name "ZXTK (Yellow) (Bug Byte) [P]"
   description "ZXTK (Yellow) (Bug Byte)"
   year "1982"
   manufacturer "Bug Byte"
@@ -5908,21 +5908,21 @@ game (
 )
 
 game (
-  name "Zac-Man (Macronics)"
+  name "Zac-Man (Macronics) [P]"
   description "Zac-Man (Macronics)"
   manufacturer "Macronics"
   rom ( name "zacman.p" size 6881 crc 261A596B md5 CD301F8807F261D005A0F5E0A5F8E1B3 sha1 1C8CB9858647E86A3BE82467A6DA6A04A4A40D15 )
 )
 
 game (
-  name "Zac-Man (Macronics)"
+  name "Zac-Man (Macronics) [TZX]"
   description "Zac-Man (Macronics)"
   manufacturer "Macronics"
   rom ( name "ZacMan.tzx" size 7111 crc 76FCA436 md5 C33DEB5191E85BCAA942A92F184236C7 sha1 E4271947DFAB4C3EEB64A5927CDA4D25445A0E53 )
 )
 
 game (
-  name "Zaraks (Computer Rentals)"
+  name "Zaraks (Computer Rentals) [TZX]"
   description "Zaraks (Computer Rentals)"
   year "1983"
   manufacturer "Richard Taylor"
@@ -5930,7 +5930,7 @@ game (
 )
 
 game (
-  name "Zaraks (Computer Rentals)"
+  name "Zaraks (Computer Rentals) [P]"
   description "Zaraks (Computer Rentals)"
   year "1983"
   manufacturer "Richard Taylor"
@@ -5938,14 +5938,14 @@ game (
 )
 
 game (
-  name "Zombies/Sword of Peace (Artic)"
+  name "Zombies_Sword of Peace (Artic) [TZX]"
   description "Zombies/Sword of Peace (Artic)"
   manufacturer "Artic"
   rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 CF95266460228F0BE0EC5CD944051FCA sha1 519D3115B5CEB75B61DFF442A927BE851FB0CA96 )
 )
 
 game (
-  name "Zuckman (White inlay) (DJL Software)"
+  name "Zuckman (White inlay) (DJL Software) [TZX]"
   description "Zuckman (White inlay) (DJL Software)"
   year "1982"
   manufacturer "DJL Software"
@@ -5953,7 +5953,7 @@ game (
 )
 
 game (
-  name "Zuckman (White inlay) (DJL Software)"
+  name "Zuckman (White inlay) (DJL Software) [P]"
   description "Zuckman (White inlay) (DJL Software)"
   year "1982"
   manufacturer "DJL Software"
@@ -5961,7 +5961,7 @@ game (
 )
 
 game (
-  name "Zuckman (Black inlay) (DJL Software)"
+  name "Zuckman (Black inlay) (DJL Software) [TZX]"
   description "Zuckman (Black inlay) (DJL Software)"
   year "1982"
   manufacturer "DJL Software"
@@ -5969,7 +5969,7 @@ game (
 )
 
 game (
-  name "Zuckman (Black inlay) (DJL Software)"
+  name "Zuckman (Black inlay) (DJL Software) [P]"
   description "Zuckman (Black inlay) (DJL Software)"
   year "1982"
   manufacturer "DJL Software"

--- a/dat/Sinclair - ZX 81.dat
+++ b/dat/Sinclair - ZX 81.dat
@@ -1,3149 +1,6089 @@
 clrmamepro (
-	name "Sinclair - ZX 81"
-	description "Sinclair - ZX 81"
-	version "20160505113721"
-	author ""
-	comment "extracted from http://www.zx81stuff.org.uk, also with games from http://www.bobs-stuff.co.uk/zx81.html"
+  name "Sinclair - ZX 81"
+  description "Sinclair - ZX 81"
+  version 20160505113721
+  comment "extracted from http://www.zx81stuff.org.uk, also with games from http://www.bobs-stuff.co.uk/zx81.html"
 )
+
 game (
-	name "1K Games (Sinclair Research)"
-	description "1K Games (Sinclair Research)"
-	manufacturer "Artic"
-	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
+  name "10 Games (J. K. Greye)"
+  description "10 Games (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
 )
+
 game (
-	name "1K Games Pack (Artic)"
-	description "1K Games Pack (Artic)"
-	manufacturer "Artic"
-	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
+  name "1K Games Pack (Artic)"
+  description "1K Games Pack (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
+
 game (
-	name "1K ZX Chess (Artic)"
-	description "1K ZX Chess (Artic)"
-	manufacturer "Artic"
-	rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9c750652 md5 d6694fd23f6a9aa6ff644a0d7417332c sha1 ed848d9bd69311536da64c0414f7ae2ec9316622 )
-	rom ( name "chessqueen.p" size 941 crc 1a82385a md5 5292e4cac70342eed1b350846db0a90f sha1 dfad4c2de72aa4900367dbe92271f126ea192804 )
+  name "1K Games (Sinclair Research)"
+  description "1K Games (Sinclair Research)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
 )
+
 game (
-	name "1K ZX Chess (Sinclair Research)"
-	description "1K ZX Chess (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "1KZXChess.tzx" size 2223 crc 2fc225b9 md5 ddf8021eef88111be73fbccf8392439e sha1 055730a794e227e02d6fa780f1bb82a68c1b86bf )
+  name "1K ZX Chess (Sinclair Research)"
+  description "1K ZX Chess (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
 )
+
 game (
-	name "2K Games Pack (International Publishing and Software Inc.)"
-	description "2K Games Pack (International Publishing and Software Inc.)"
-	year 1982
-	rom ( name "2KGamesPack(IPS).tzx" size 6977 crc c1893b03 md5 25ebafa20015b01a383b70c19394e307 sha1 b33fdc40eb4631617c2687795de02904c92255c3 )
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
 )
+
 game (
-	name "3D Defender (J. K. Greye)"
-	description "3D Defender (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "3ddefender.p" size 11857 crc 4f97cbc6 md5 b344194f7456805b053f3e6786cfcdd5 sha1 bbaf7cd6f122f2508efecca8a8b2e1006b728752 )
-	rom ( name "3DDefender.tzx" size 12095 crc a9e69d1c md5 cd64e962bfcc000a9e3bd8cdb6e1c3e1 sha1 7c6b0a1fdef5c43aeed21f9d98f4e0c9837214cf )
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
 )
+
 game (
-	name "3D Defender (New Generation)"
-	description "3D Defender (New Generation)"
-	year 1981
-	manufacturer "M. E. Evans"
-	rom ( name "3ddefender(ngs).p" size 11857 crc eb8178fd md5 57e5bdeaef06c83ae246bf132618a5ff sha1 1c9205c36224875446de0dc3abf0907200b7b993 )
-	rom ( name "3DDefender(NGS).tzx" size 12095 crc 0df02e27 md5 b2fe247ea9c9e64ba9fe419c96c9fc9c sha1 6aa9a12e6256bc2657326361c636571faf2cfb83 )
+  name "2K Games Pack (International Publishing and Software Inc.)"
+  description "2K Games Pack (International Publishing and Software Inc.)"
+  year "1982"
+  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
 )
+
 game (
-	name "3D Monster Maze (J. K. Greye)"
-	description "3D Monster Maze (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "3dmonstermaze.p" size 10552 crc 8f782725 md5 4e344f938d5600d81b7b0fde756abe7e sha1 cb254b2ce2012140211b641deeaf57177757ac25 )
-	rom ( name "3DMonsterMaze.tzx" size 10798 crc 436d8b0e md5 c38f7c7e81c6e781a9d665a4e468c6ef sha1 c6c141057d870b114d8844bb7578040ad8c5b151 )
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
 )
+
 game (
-	name "3D Monster Maze (New Generation)"
-	description "3D Monster Maze (New Generation)"
-	year 1982
-	manufacturer "J. K. Greye"
-	rom ( name "3dmonstermaze(ngs).p" size 10552 crc f4ce6079 md5 9cd5af6a9a9c61b2ea272f4f35058928 sha1 15093d2b89b5c5c4c0454af917be5554454864a7 )
-	rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38dbcc52 md5 5912b1261d2ed44f40d80bd6ca813405 sha1 2b0e9cd691979154c2d75ac76f93be076aab3423 )
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
 )
+
 game (
-	name "5-2K Family Pak (Timeworks)"
-	description "5-2K Family Pak (Timeworks)"
-	manufacturer "Timeworks"
-	rom ( name "52KFamilyPak.tzx" size 7846 crc fa438ced md5 e0b79ae2de178ddab3c3ee2691c68f78 sha1 1d613e0ab6462ab52c757aa1b6b6262311eb6c8e )
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
 )
+
 game (
-	name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-	description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-	manufacturer "GM4IHJ (J Branegan)"
-	rom ( name "8Programs.tzx" size 56578 crc bb788390 md5 4cf8b801597ae314132d8de1d5dc5d9b sha1 e2185c5962d8c89bb020028a22e25470405bef0f )
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
 )
+
 game (
-	name "10 Games (J. K. Greye)"
-	description "10 Games (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "10Games.tzx" size 7636 crc 141cddd1 md5 02eb203cd57645589a158495c2f7cebb sha1 3a776f7dbf4fd169572aad5b775b4ca27c61222a )
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
 )
+
 game (
-	name "Admiral Graf Spee (Temptation Software)"
-	description "Admiral Graf Spee (Temptation Software)"
-	manufacturer "Simon Mansfield"
-	rom ( name "AdmiralGrafSpee.tzx" size 17024 crc c583887e md5 3bd4fac61bdb6fc0a1bbc04ec7270df9 sha1 741a2b608801fc12705535fa88f2d895af486e80 )
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
 )
+
 game (
-	name "Advanced Budget Manager (Softsync)"
-	description "Advanced Budget Manager (Softsync)"
-	year 1982
-	manufacturer "Robert E. Davis Jr."
-	rom ( name "advancedbudgetmanager.p" size 16065 crc 3c9470f1 md5 57f9a0131be02387c11ff873da3c4fd4 sha1 9fff89fe3b70caac516db12f50e35c44fdd2c8e9 )
-	rom ( name "AdvancedBudgetManager.tzx" size 16291 crc 72a0eeda md5 b27dc1e6bb1a68b163457dad74a83f06 sha1 617af815c0545f0832cd9502ba51a0a5db5dcd1d )
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
 )
+
 game (
-	name "Advanced Mathematics (W. H. Smith)"
-	description "Advanced Mathematics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "advancedmathematics.p" size 13415 crc 53d03118 md5 3057d11d80675cc9910181c915387cc6 sha1 944f9cfd8dbfd6038ae71c1c84343e17a3308f8b )
-	rom ( name "AdvancedMathematics.tzx" size 13671 crc e6a14eaa md5 0707dca0772a33981eb91f87dfab135d sha1 8caa2805da995945d9153828c921ad4ab96678a5 )
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
 )
+
 game (
-	name "Adventure (Bug Byte)"
-	description "Adventure (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "adventure.p" size 15783 crc dd2dc75d md5 756ee1b0642b97ec7fa586aa0e8ef519 sha1 e06106ebb14581c6f69b351261f88f24be8c7bd2 )
-	rom ( name "Adventure.tzx" size 16017 crc 35d4be2a md5 55bae9d8b6d5e7d62ef8f1646c0dcc03 sha1 c5fb1e4aa356ec4a406a2da76495d9f9b368d058 )
+  name "5-2K Family Pak (Timeworks)"
+  description "5-2K Family Pak (Timeworks)"
+  manufacturer "Timeworks"
+  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
 )
+
 game (
-	name "Adventure A - Planet of Death (Artic)"
-	description "Adventure A: Planet of Death (Artic)"
-	manufacturer "Artic"
-	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
-	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  manufacturer "GM4IHJ (J Branegan)"
+  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
 )
+
 game (
-	name "Adventure A - Planet of Death (Sinclair Research)"
-	description "Adventure A: Planet of Death (Sinclair Research)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
-	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
+  name "Admiral Graf Spee (Temptation Software)"
+  description "Admiral Graf Spee (Temptation Software)"
+  manufacturer "Simon Mansfield"
+  rom ( name "AdmiralGrafSpee.tzx" size 17024 crc C583887E md5 3BD4FAC61BDB6FC0A1BBC04EC7270DF9 sha1 741A2B608801FC12705535FA88F2D895AF486E80 )
 )
+
 game (
-	name "Adventure B - Inca Curse (Artic)"
-	description "Adventure B: Inca Curse (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "incacurse(artic).p" size 11975 crc e5a05a0a md5 e24f9ea9c889a9587479085276980fa1 sha1 b1b85676ade56e51488f2262ee60facc22989967 )
-	rom ( name "IncaCurse(Artic).tzx" size 12205 crc 76d699e6 md5 15459a76af72151af7309c00ff13abae sha1 c3840c1539239437150d7e300b0bae412ad6a987 )
+  name "Advanced Budget Manager (Softsync)"
+  description "Advanced Budget Manager (Softsync)"
+  year "1982"
+  manufacturer "Robert E. Davis Jr."
+  rom ( name "advancedbudgetmanager.p" size 16065 crc 3C9470F1 md5 57F9A0131BE02387C11FF873DA3C4FD4 sha1 9FFF89FE3B70CAAC516DB12F50E35C44FDD2C8E9 )
 )
+
 game (
-	name "Adventure B - Inca Curse (Sinclair Research)"
-	description "Adventure B: Inca Curse (Sinclair Research)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "incacurse.p" size 11975 crc e37cddd8 md5 736fd7c4c8854760206a05361299faf1 sha1 acb41012d467f473cb452f3cf1acb8608f108725 )
-	rom ( name "IncaCurse.tzx" size 12205 crc 700a1e34 md5 438603d7eaed102378af94260a15be1a sha1 8948f63c75c80dffa4e317e4d8ed400bd6b11de9 )
+  name "Advanced Budget Manager (Softsync)"
+  description "Advanced Budget Manager (Softsync)"
+  year "1982"
+  manufacturer "Robert E. Davis Jr."
+  rom ( name "AdvancedBudgetManager.tzx" size 16291 crc 72A0EEDA md5 B27DC1E6BB1A68B163457DAD74A83F06 sha1 617AF815C0545F0832CD9502BA51A0A5DB5DCD1D )
 )
+
 game (
-	name "Adventure C (Monochrome) (Artic)"
-	description "Adventure C (Monochrome) (Artic)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "adventurec.p" size 14045 crc 52f0a175 md5 c824db7237c7299477c957becdf39335 sha1 152de35905f06389f06925e5a09cb30183669ad0 )
-	rom ( name "AdventureC.tzx" size 14275 crc 449ed54f md5 d4bbb25a3eb32b2e063a3ab9b09565ab sha1 ebc2d62e91088447c40bd394aa825acbe2982210 )
+  name "Advanced Mathematics (W. H. Smith)"
+  description "Advanced Mathematics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "advancedmathematics.p" size 13415 crc 53D03118 md5 3057D11D80675CC9910181C915387CC6 sha1 944F9CFD8DBFD6038AE71C1C84343E17A3308F8B )
 )
+
 game (
-	name "Adventure C - Ship of Doom (Artic)"
-	description "Adventure C: Ship of Doom (Artic)"
-	manufacturer "Artic"
-	rom ( name "shipofdoom(artic).p" size 14045 crc 3e244575 md5 47ae04d2d34190dd2f9d47fb9815f4de sha1 689552ef631facc558c6fc9b902f20495e870936 )
-	rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284a314f md5 ca0bab03eeff0fc9bcc040148e20c7d2 sha1 96221bceba4ff6e90fdc59271da1d7973362e8f8 )
+  name "Advanced Mathematics (W. H. Smith)"
+  description "Advanced Mathematics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "AdvancedMathematics.tzx" size 13671 crc E6A14EAA md5 0707DCA0772A33981EB91F87DFAB135D sha1 8CAA2805DA995945D9153828C921AD4AB96678A5 )
 )
+
 game (
-	name "Adventure C - The Ship of Doom (Sinclair Research)"
-	description "Adventure C: The Ship of Doom (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "shipofdoom.p" size 14045 crc b8e32f06 md5 2515ba4ad2c1758f83d4e2f2cc81d6ca sha1 c64b4ae9fdbd955695660e6bd6a04ef2a6f91f39 )
-	rom ( name "ShipOfDoom.tzx" size 14275 crc ae8d5b3c md5 6e53ef483b27d942ff3ad6e69256c116 sha1 a1e5ab55214da2ca312345586f684e65204d52ad )
+  name "Adventure (Bug Byte)"
+  description "Adventure (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "adventure.p" size 15783 crc DD2DC75D md5 756EE1B0642B97EC7FA586AA0E8EF519 sha1 E06106EBB14581C6F69B351261F88F24BE8C7BD2 )
 )
+
 game (
-	name "Adventure D - Espionage Island (Artic)"
-	description "Adventure D: Espionage Island (Artic)"
-	manufacturer "Artic"
-	rom ( name "espionageisland(artic).p" size 15504 crc ac8df706 md5 348a6b4fbec8e375daf1be03d1c674df sha1 8ad3e1ae97a34a6f6b1e2f653aeed770ba33f01e )
-	rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06a3887c md5 30754aa09608d83deb1c0194c04b85cb sha1 7b36f0bce5eccb9fc3dc4fb553516e5e7f5adabe )
+  name "Adventure (Bug Byte)"
+  description "Adventure (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "Adventure.tzx" size 16017 crc 35D4BE2A md5 55BAE9D8B6D5E7D62EF8F1646C0DCC03 sha1 C5FB1E4AA356EC4A406A2DA76495D9F9B368D058 )
 )
+
 game (
-	name "Adventure D - Espionage Island (Sinclair Research)"
-	description "Adventure D: Espionage Island (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "espionageisland.p" size 15504 crc 81ddf2b0 md5 24c456b967f1b621685579289a656ceb sha1 9c2db35b667f12a155aad2f2e5725b9fcf54e290 )
-	rom ( name "EspionageIsland.tzx" size 15734 crc 2bf38dca md5 50a59a5a1ca60349959ba2283e4188f8 sha1 1afaa1c3773c78f8f92941d95de226a727cc8822 )
+  name "Adventure C (Monochrome) (Artic)"
+  description "Adventure C (Monochrome) (Artic)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "adventurec.p" size 14045 crc 52F0A175 md5 C824DB7237C7299477C957BECDF39335 sha1 152DE35905F06389F06925E5A09CB30183669AD0 )
 )
+
 game (
-	name "Adventure One (Abersoft)"
-	description "Adventure One (Abersoft)"
-	year 1982
-	manufacturer "Abersoft"
-	rom ( name "adventureone.p" size 15612 crc 67617c4d md5 a3ddf09fae32bb1bebc9890bee01e788 sha1 34f97d91871439200f127334a675d01e5a918b4c )
-	rom ( name "AdventureOne.tzx" size 15848 crc b1cbaaa7 md5 95e5c9663fdd2dae7494826beb4b3d39 sha1 bad2e766140ee0159389ac513f37c0e8372ed5c8 )
+  name "Adventure C (Monochrome) (Artic)"
+  description "Adventure C (Monochrome) (Artic)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "AdventureC.tzx" size 14275 crc 449ED54F md5 D4BBB25A3EB32B2E063A3AB9B09565AB sha1 EBC2D62E91088447C40BD394AA825ACBE2982210 )
 )
+
 game (
-	name "Adventure Tape 1 (Phipps Associates)"
-	description "Adventure Tape 1 (Phipps Associates)"
-	year 1983
-	manufacturer "Phipps Associates"
-	rom ( name "AdventureTape1.tzx" size 57316 crc f85217cb md5 ebf8c22018a8a88743ce8f926c7a5592 sha1 851fd8d8c082c534766deb7c7d724ed0e9ae9410 )
+  name "Adventure One (Abersoft)"
+  description "Adventure One (Abersoft)"
+  year "1982"
+  manufacturer "Abersoft"
+  rom ( name "AdventureOne.tzx" size 15848 crc B1CBAAA7 md5 95E5C9663FDD2DAE7494826BEB4B3D39 sha1 BAD2E766140EE0159389AC513F37C0E8372ED5C8 )
 )
+
 game (
-	name "Adventure Tape No. 1 (Phipps Associates)"
-	description "Adventure Tape No. 1 (Phipps Associates)"
-	year 1982
-	manufacturer "Phipps Associates"
-	rom ( name "AdventureTapeNo1.tzx" size 57280 crc 48254758 md5 80d738ef8e9bf92f06760da0bd986cbd sha1 bc8d49cbfa4156fcd10739b8ba17987a6708a2aa )
+  name "Adventure One (Abersoft)"
+  description "Adventure One (Abersoft)"
+  year "1982"
+  manufacturer "Abersoft"
+  rom ( name "adventureone.p" size 15612 crc 67617C4D md5 A3DDF09FAE32BB1BEBC9890BEE01E788 sha1 34F97D91871439200F127334A675D01E5A918B4C )
 )
+
 game (
-	name "Airline (Cases Computer Simulations)"
-	description "Airline (Cases Computer Simulations)"
-	year 1982
-	rom ( name "airline.p" size 15842 crc ee5ebb38 md5 0d2270547b0e378edaa4f22d1058deb4 sha1 88e1c1454ce376710f1ef8d864b20af8d6bb2fd5 )
-	rom ( name "Airline.tzx" size 16072 crc 844cbaac md5 3f4f3645c603230b8eb3742585c743c3 sha1 56b18d5296da989927c05c0f33dc30d2a3b1ba4c )
+  name "Adventure Tape 1 (Phipps Associates)"
+  description "Adventure Tape 1 (Phipps Associates)"
+  year "1983"
+  manufacturer "Phipps Associates"
+  rom ( name "AdventureTape1.tzx" size 57316 crc F85217CB md5 EBF8C22018A8A88743CE8F926C7A5592 sha1 851FD8D8C082C534766DEB7C7D724ED0E9AE9410 )
 )
+
 game (
-	name "Algebra 1 (Timex)"
-	description "Algebra 1 (Timex)"
-	year 1982
-	manufacturer "Home Computer Software"
-	rom ( name "Algebra1.tzx" size 3926 crc 11f6af7c md5 06f5ba26638ce245da0d0c622bca75f1 sha1 4cfec3ba12646b6b5cf05860401750fa149fbce9 )
+  name "Adventure Tape No. 1 (Phipps Associates)"
+  description "Adventure Tape No. 1 (Phipps Associates)"
+  year "1982"
+  manufacturer "Phipps Associates"
+  rom ( name "AdventureTapeNo1.tzx" size 57280 crc 48254758 md5 80D738EF8E9BF92F06760DA0BD986CBD sha1 BC8D49CBFA4156FCD10739B8BA17987A6708A2AA )
 )
+
 game (
-	name "Alien (PSS)"
-	description "Alien (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "alien.p" size 11735 crc b85d2a16 md5 47ab0a499a9a5558d7b76d9acc02f86f sha1 bbfd196dc9ca7694987fc079c7ba445f29435b3b )
-	rom ( name "Alien.tzx" size 11961 crc febc8fef md5 bf6d8512bdb99c04e3f0e40157fc6b6a sha1 9545ca45d3440c9a34be3411bc7395f37af82777 )
+  name "Airline (Cases Computer Simulations)"
+  description "Airline (Cases Computer Simulations)"
+  year "1982"
+  rom ( name "airline.p" size 15842 crc EE5EBB38 md5 0D2270547B0E378EDAA4F22D1058DEB4 sha1 88E1C1454CE376710F1EF8D864B20AF8D6BB2FD5 )
 )
+
 game (
-	name "Alien Attack (Computer Rentals)"
-	description "Alien Attack (Computer Rentals)"
-	manufacturer "Computer Rentals"
-	rom ( name "alienattack.p" size 6209 crc 946e0ed7 md5 52cdd5d46f020af4a42c898919c866cf sha1 fb0be0363133dcd5dab240253fdcbf21c7f50c65 )
-	rom ( name "AlienAttack.tzx" size 6429 crc e6ce2fa6 md5 53ff8e58ba83e04522c87e4cb0d54002 sha1 f52df2571903d9aae931b359eabb67e2bbd6fc41 )
+  name "Airline (Cases Computer Simulations)"
+  description "Airline (Cases Computer Simulations)"
+  year "1982"
+  rom ( name "Airline.tzx" size 16072 crc 844CBAAC md5 3F4F3645C603230B8EB3742585C743C3 sha1 56B18D5296DA989927C05C0F33DC30D2A3B1BA4C )
 )
+
 game (
-	name "Alien-Dropout (Silversoft)"
-	description "Alien-Dropout (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "aliendropout.p" size 3192 crc d6570c8d md5 f20b18d295751068432cd101cecab2c9 sha1 a18219e3e44a6cacb38afabd21153a6abf72fe82 )
-	rom ( name "AlienDropout.tzx" size 3424 crc fe0f33f4 md5 80d3c0c640aa71a3c12691b83b4c26cf sha1 c51813b542dd1432421ad7bb222a6f5cef4cd641 )
+  name "Algebra 1 (Timex)"
+  description "Algebra 1 (Timex)"
+  year "1982"
+  manufacturer "Home Computer Software"
+  rom ( name "Algebra1.tzx" size 3926 crc 11F6AF7C md5 06F5BA26638CE245DA0D0C622BCA75F1 sha1 4CFEC3BA12646B6B5CF05860401750FA149FBCE9 )
 )
+
 game (
-	name "Alphaprobe (Artic)"
-	description "Alphaprobe (Artic)"
-	manufacturer "Artic"
-	rom ( name "alphaprobe.p" size 11016 crc 4b8bb297 md5 0fadaebde9d1d1843b74415333eadc7b sha1 cdaba21f5432945bf9ae06b111804f3c4cd385e2 )
-	rom ( name "Alphaprobe.tzx" size 11252 crc 7b7603f0 md5 0c36b487eaccb85755604c91d05dd8fe sha1 a71fdaec9225187ad0724bdaaab65b2860e994fb )
+  name "Alien (PSS)"
+  description "Alien (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "alien.p" size 11735 crc B85D2A16 md5 47AB0A499A9A5558D7B76D9ACC02F86F sha1 BBFD196DC9CA7694987FC079C7BA445F29435B3B )
 )
+
+game (
+  name "Alien (PSS)"
+  description "Alien (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "Alien.tzx" size 11961 crc FEBC8FEF md5 BF6D8512BDB99C04E3F0E40157FC6B6A sha1 9545CA45D3440C9A34BE3411BC7395F37AF82777 )
+)
+
+game (
+  name "Alien Attack (Computer Rentals)"
+  description "Alien Attack (Computer Rentals)"
+  manufacturer "Computer Rentals"
+  rom ( name "AlienAttack.tzx" size 6429 crc E6CE2FA6 md5 53FF8E58BA83E04522C87E4CB0D54002 sha1 F52DF2571903D9AAE931B359EABB67E2BBD6FC41 )
+)
+
+game (
+  name "Alien Attack (Computer Rentals)"
+  description "Alien Attack (Computer Rentals)"
+  manufacturer "Computer Rentals"
+  rom ( name "alienattack.p" size 6209 crc 946E0ED7 md5 52CDD5D46F020AF4A42C898919C866CF sha1 FB0BE0363133DCD5DAB240253FDCBF21C7F50C65 )
+)
+
+game (
+  name "Alien-Dropout (Silversoft)"
+  description "Alien-Dropout (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "AlienDropout.tzx" size 3424 crc FE0F33F4 md5 80D3C0C640AA71A3C12691B83B4C26CF sha1 C51813B542DD1432421AD7BB222A6F5CEF4CD641 )
+)
+
+game (
+  name "Alien-Dropout (Silversoft)"
+  description "Alien-Dropout (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "aliendropout.p" size 3192 crc D6570C8D md5 F20B18D295751068432CD101CECAB2C9 sha1 A18219E3E44A6CACB38AFABD21153A6ABF72FE82 )
+)
+
+game (
+  name "Alphaprobe (Artic)"
+  description "Alphaprobe (Artic)"
+  manufacturer "Artic"
+  rom ( name "Alphaprobe.tzx" size 11252 crc 7B7603F0 md5 0C36B487EACCB85755604C91D05DD8FE sha1 A71FDAEC9225187AD0724BDAAAB65B2860E994FB )
+)
+
+game (
+  name "Alphaprobe (Artic)"
+  description "Alphaprobe (Artic)"
+  manufacturer "Artic"
+  rom ( name "alphaprobe.p" size 11016 crc 4B8BB297 md5 0FADAEBDE9D1D1843B74415333EADC7B sha1 CDABA21F5432945BF9AE06B111804F3C4CD385E2 )
+)
+
+game (
+  name "Arcade Action (Micromega)"
+  description "Arcade Action (Micromega)"
+  manufacturer "Micromega"
+  rom ( name "ArcadeAction.tzx" size 4651 crc 5CB215E3 md5 5A76C5D34BAA6D9AAF3BDD34E5C89597 sha1 04FC1FFA34592F093F1C0EAE9D54B3FF31EB3E86 )
+)
+
+game (
+  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  year "1982"
+  rom ( name "aroundeuropein80hours.p" size 15223 crc 2DA984A7 md5 1DD7D90A090B80EA53C1B387B852D497 sha1 5D2A941CD7EDCA847BFD6C10B41B9025A81D4352 )
+)
+
+game (
+  name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
+  year "1982"
+  rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758C6 md5 5FEEE6F195CEE427CD9195A1C4462F58 sha1 CB59D966FE38C858DF9A002F2EAAAE2CB0E1BA73 )
+)
+
+game (
+  name "Asteroids (Silversoft)"
+  description "Asteroids (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "Asteroids.tzx" size 3776 crc 939E50E5 md5 5F4836D37CB10B4BB5C7C71BB857409A sha1 85047AB187BFCD02195F00150419CEE1BFC07A5F )
+)
+
+game (
+  name "Asteroids (Silversoft)"
+  description "Asteroids (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "asteroids.p" size 3542 crc 7484AC13 md5 0A392517E1D78420E0A5B5AAFEFE0C39 sha1 27D633E47D4E5A6B1594B16103E6A7EA12B5D0A7 )
+)
+
+game (
+  name "Asteroids (Software Farm)"
+  description "Asteroids (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "Asteroids(SF).tzx" size 8594 crc 8B6F8743 md5 D7F2518BD65DBD7D99842F5A27AAB588 sha1 D56D7E03A545B99607174FAEC186C42E64618189 )
+)
+
+game (
+  name "Asteroids (Software Farm)"
+  description "Asteroids (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "asteroids(sf).p" size 8360 crc 0EFCEBD4 md5 583C3E31090F678A465C46D0CFCF2AD7 sha1 7F114CD978045301B7C63F7177D2FE2D0EE33264 )
+)
+
+game (
+  name "Autochef (Cases Computer Simulations)"
+  description "Autochef (Cases Computer Simulations)"
+  year "1982"
+  rom ( name "Autochef.tzx" size 15648 crc 3869AE07 md5 81856A30F98CCAA2FDBD6C88D8C7897F sha1 2B7416327BDB907108D287F8CD4EAA0FD291ECBA )
+)
+
+game (
+  name "Autochef (Cases Computer Simulations)"
+  description "Autochef (Cases Computer Simulations)"
+  year "1982"
+  rom ( name "autochef.p" size 15430 crc 575560BB md5 21C42C6C6EAF0866DC56533F89688F4F sha1 DD0EE23E39D50738D91731C427063AC8E59AD9D3 )
+)
+
+game (
+  name "Avenger (Abacus)"
+  description "Avenger (Abacus)"
+  year "1982"
+  manufacturer "K. Flynn"
+  rom ( name "Avenger.tzx" size 7368 crc B545FDAE md5 B0E975A6CDFF98F667536F3FD4D902BD sha1 529B2A9EB67C50DB12494CC0FF7272925E9D18B4 )
+)
+
+game (
+  name "Avenger (Abacus)"
+  description "Avenger (Abacus)"
+  year "1982"
+  manufacturer "K. Flynn"
+  rom ( name "avenger.p" size 7138 crc 53621A49 md5 1AF4B6A7F31315A701B5DD54068C5596 sha1 0F402A98C52410358F2A3EC94280AF6C7375F9AC )
+)
+
+game (
+  name "Backgammon (Keith Archer)"
+  description "Backgammon (Keith Archer)"
+  year "1982"
+  manufacturer "Keith Archer"
+  rom ( name "Backgammon(KA).tzx" size 11861 crc 153ED883 md5 71F46D576FE8BFA343D41949DABD2E55 sha1 81F25C1667C8EBA6936EABFD080CCAD3A3A34ADD )
+)
+
+game (
+  name "Backgammon (Keith Archer)"
+  description "Backgammon (Keith Archer)"
+  year "1982"
+  manufacturer "Keith Archer"
+  rom ( name "backgammon(ka).p" size 11625 crc F4D9073B md5 B0A388F1B834D98852D96F998C1978CC sha1 C0C4E28934D05735B2200C41F2AF8EB7B3ABD1CB )
+)
+
+game (
+  name "Backgammon (Timex)"
+  description "Backgammon (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "Backgammon(Timex).tzx" size 17108 crc 307AACD2 md5 D068903731302F4DC6C0E7810D1ED944 sha1 5A78754D849FE5284342089159AF45588029C0A9 )
+)
+
+game (
+  name "Bank Robber (Romik Software)"
+  description "Bank Robber (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "bankrobber.p" size 6560 crc 2973AF44 md5 8CA20ED973A7A1B830087CD30DB7EDBA sha1 5EBDBD6B13B82933C158BD439B89BF6CE69149A7 )
+)
+
+game (
+  name "Bank Robber (Romik Software)"
+  description "Bank Robber (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "BankRobber.tzx" size 6798 crc F9A7AB7D md5 36E6E97BD4EA83C494B6134E1AEEE1C2 sha1 40D0FCC8FAAF73B0082D4F1937EF16626D289F66 )
+)
+
+game (
+  name "Baron (Temptation Software)"
+  description "Baron (Temptation Software)"
+  manufacturer "Simon Mansfield"
+  rom ( name "Baron.tzx" size 16716 crc 2813C7A1 md5 C6AE4F6CF29411686BDE01114A682498 sha1 FD944CEDD638D3A5D6B70A8A4D50F2D41C16EA74 )
+)
+
+game (
+  name "Basicode 2 (BBC)"
+  description "Basicode 2 (BBC)"
+  year "1984"
+  manufacturer "The Chip Shop"
+  rom ( name "Basicode2.A.tzx" size 3570 crc DB6F1818 md5 AD1857F473CA1DE8ED5D7B855D566C54 sha1 9204245ADF3F343E82C43D6EC70117C4DC491908 )
+)
+
+game (
+  name "Basicode 2 (BBC)"
+  description "Basicode 2 (BBC)"
+  year "1984"
+  manufacturer "The Chip Shop"
+  rom ( name "basicode2.p" size 3338 crc 89CE64F1 md5 CAB7E8ADF644459CE8C1DD54897A184C sha1 07A3DE146663D0E77A98A0800FB6F0545D567D77 )
+)
+
+game (
+  name "Bat Cage (Timex)"
+  description "Bat Cage (Timex)"
+  year "1982"
+  manufacturer "Thomas J. Burke"
+  rom ( name "batcage.p" size 1222 crc A1B5D16F md5 0A716AD28C067C5938D776FABADFC176 sha1 E3DBDE749FF3618AB07A6C8FC712531BE6272BCF )
+)
+
+game (
+  name "Bat Cage (Timex)"
+  description "Bat Cage (Timex)"
+  year "1982"
+  manufacturer "Thomas J. Burke"
+  rom ( name "BatCage.tzx" size 1446 crc 650A94D8 md5 C3B8A71965F8BA025D546B7FE8F1531B sha1 8F6842F02E416E8B66C8D6172F2E852A5E14D2F8 )
+)
+
+game (
+  name "Battleships (JRS Software)"
+  description "Battleships (JRS Software)"
+  year "1982"
+  manufacturer "JRS Software"
+  rom ( name "Battleships.tzx" size 12962 crc A1057BC5 md5 8840352DD5514D5BC84E82F14F6211E2 sha1 0C36982F0243F39C028A21207A2218D40B1CB369 )
+)
+
+game (
+  name "Battleships (JRS Software)"
+  description "Battleships (JRS Software)"
+  year "1982"
+  manufacturer "JRS Software"
+  rom ( name "battleships.p" size 12732 crc A0A631A4 md5 99BDB02395ED7A85C8B13911C0344516 sha1 6897424919C684A7A18235D967C7F621F02D1CF0 )
+)
+
+game (
+  name "Bigflap Attack (Timex)"
+  description "Bigflap Attack (Timex)"
+  manufacturer "Timex"
+  rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66C706F432AD9277573B709C913B16A0 sha1 985F2F32AE4478051B5B7D91CB17BBC474FD26F6 )
+)
+
+game (
+  name "Black Star (Quicksilva)"
+  description "Black Star (Quicksilva)"
+  year "1983"
+  manufacturer "M. Sudworth"
+  rom ( name "blackstar.p" size 6811 crc 0407BEAC md5 D34202B6AC2F39323AD1212CA360E18B sha1 C17AA876DFEEF10FD9D8DA5BD83CC6FEC9396FB9 )
+)
+
+game (
+  name "Black Star (Quicksilva)"
+  description "Black Star (Quicksilva)"
+  year "1983"
+  manufacturer "M. Sudworth"
+  rom ( name "BlackStar.tzx" size 7047 crc F227253F md5 C5B418B890BB6D828EC84D2FB36152AB sha1 0ABE2CA4064679C23DA82773FAB70BF05C245844 )
+)
+
+game (
+  name "Bouncing Bert (Software Farm)"
+  description "Bouncing Bert (Software Farm)"
+  year "1985"
+  manufacturer "S C T"
+  rom ( name "bouncingbert.p" size 14919 crc FB88AD49 md5 E575AA04406A3F9EB1C095E8C0B6CD3A sha1 A56DDDC42A1383C392D6988C9DAFB4C8DB37007A )
+)
+
+game (
+  name "Bouncing Bert (Software Farm)"
+  description "Bouncing Bert (Software Farm)"
+  year "1985"
+  manufacturer "S C T"
+  rom ( name "BouncingBert.tzx" size 15151 crc C30CAF71 md5 AE2A31C5A4B92C6213B7547608110E86 sha1 EF3BE8446D80452A155ED647A55C7D24AEE58A6D )
+)
+
+game (
+  name "Breakout (CDS Micro Systems)"
+  description "Breakout (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "breakout.p" size 3235 crc 82836AC3 md5 3F4B0E39130BE53AE22381F8A82A3081 sha1 EB36D14650C568ED47326DC094392C70FD249B3C )
+)
+
+game (
+  name "Breakout (CDS Micro Systems)"
+  description "Breakout (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "Breakout.tzx" size 3467 crc 322FAFD6 md5 0323A0D24248E0DE2DCE75C7CD3B71A9 sha1 1CB495C3B751E64E8B1FC38C68FABF0340365F39 )
+)
+
+game (
+  name "Breakout (J. K. Greye)"
+  description "Breakout (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "breakout(jkg).p" size 716 crc 15CB56B4 md5 4655A4C1F58C705F303D31D2F2E64F7F sha1 2A4DDAE5DF3C18192C851BE567DAEB9AB59AA456 )
+)
+
+game (
+  name "Breakout (J. K. Greye)"
+  description "Breakout (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "Breakout(JKG).tzx" size 948 crc E3F0284A md5 C52F2080DC8E969B4636DA6F9D4F1E54 sha1 C8138F8960AEDF4D848C65B676D76BF717EC9154 )
+)
+
+game (
+  name "Breakout (New Generation)"
+  description "Breakout (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "breakout(ngs).p" size 716 crc D4496E38 md5 E488EF1A3EFC25F2ABD308F9AEF901B5 sha1 BD90A91D1EF17E19802D145DAC955D0D34CAB5F0 )
+)
+
+game (
+  name "Breakout (New Generation)"
+  description "Breakout (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "Breakout(NGS).tzx" size 948 crc 227210C6 md5 50FE074B25394A62A8FBBB8DAC9513FB sha1 86B96863CFFCA1038110A78B99B4DF5FBCC75DAA )
+)
+
+game (
+  name "Breakout 3 (Axis)"
+  description "Breakout 3 (Axis)"
+  year "1982"
+  manufacturer "Axis"
+  rom ( name "Breakout3.tzx" size 5705 crc 69B9A5BF md5 595C064A5D18089BEC87664DC37AB2DA sha1 FAF622EFF6CCA236E0623D7F23CF35BFEF74D823 )
+)
+
+game (
+  name "Breakout 3 (Axis)"
+  description "Breakout 3 (Axis)"
+  year "1982"
+  manufacturer "Axis"
+  rom ( name "breakout3.p" size 5485 crc A836659C md5 9AE6333AD0003617DA56543E57A60903 sha1 F226DF48CFCABEA16956FAFF21E88E3EEECCF66C )
+)
+
+game (
+  name "Breakout, Space Invaders and Music (Macronics)"
+  description "Breakout, Space Invaders and Music (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "BreakoutSIAndMusic.tzx" size 2734 crc D383DB01 md5 13110862ADF0B4ABB06573A2BE710087 sha1 D5582E7A6A79BD6B8A2096ED968C91292B46483B )
+)
+
+game (
+  name "Brick Stop (CDS Micro Systems)"
+  description "Brick Stop (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "BrickStop.tzx" size 3362 crc 2E173AFA md5 65A723688C0FD694AD600407FC12EC17 sha1 232822DEB023BE4037E9864A1CCD01E8C42A32BF )
+)
+
+game (
+  name "Brick Stop (CDS Micro Systems)"
+  description "Brick Stop (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "brickstop.p" size 3126 crc 8EE66ABE md5 B70594C6CB40AC4B3B7706574153563D sha1 FD697AE6EC522406F4E6B91A5C7A5D7C9058A4FF )
+)
+
+game (
+  name "Bubble Bugs (Romik Software)"
+  description "Bubble Bugs (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "BubbleBugs.tzx" size 6647 crc 368C6F68 md5 3E4FEEB96B4FF463FF81BE369592C0DE sha1 E52DDAB32B1183910D1C74AE04999A8FB92DC158 )
+)
+
+game (
+  name "Bubble Bugs (Romik Software)"
+  description "Bubble Bugs (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "bubblebugs.p" size 6409 crc 1E09B9EC md5 00B1A8FE3030CF7B4CD91B5EAF986516 sha1 8770497D4DB9455F31DC6F422B710BA44DCAB096 )
+)
+
+game (
+  name "The Budgeter (Timex)"
+  description "The Budgeter (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "BudgeterThe.tzx" size 7653 crc 5EA30258 md5 AB5775378AF88AAF6FD6B6E653F00318 sha1 936A4BDF69507C24B8A634C94065548A3757FAC9 )
+)
+
+game (
+  name "The Budgeter (Timex)"
+  description "The Budgeter (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "budgeterthe.p" size 7421 crc 8D3B6FC8 md5 F8F70240FD3CE11EDA2D349F26D760D9 sha1 C2D31635238B2D581C1D8E4C7ED0565933275B1D )
+)
+
+game (
+  name "Bumper 7 (Axis)"
+  description "Bumper 7 (Axis)"
+  year "1981"
+  manufacturer "Axis"
+  rom ( name "Bumper7.tzx" size 5179 crc 3C31D394 md5 7A42934F415AD9587A203974BBE2F6F2 sha1 2ADC581BACA7D49305C0CCD720F594C50618BE5E )
+)
+
+game (
+  name "Byter (Protek)"
+  description "Byter (Protek)"
+  year "1983"
+  manufacturer "Protek"
+  rom ( name "byter.p" size 5045 crc 1C53AC02 md5 8DB34A0ED323545380AC2EB69190FA18 sha1 C396155336A5F43E908DE08C5398B670F694B4F7 )
+)
+
+game (
+  name "Byter (Protek)"
+  description "Byter (Protek)"
+  year "1983"
+  manufacturer "Protek"
+  rom ( name "Byter.tzx" size 5271 crc 540854FE md5 423D68CC0EDD3F4C360CC58F167F0E71 sha1 AB1F4D1F13735E7FFE4E143C1EE159A2CA1A0617 )
+)
+
+game (
+  name "Can of Worms (Automata Cartography)"
+  description "Can of Worms (Automata Cartography)"
+  manufacturer "Automata Cartography"
+  rom ( name "CanOfWorms.tzx" size 7150 crc B2E6FA12 md5 3A724F1A32F350922012F1FF6B6E0193 sha1 9BB651B39206913BBE74600997114FCBCD70747C )
+)
+
+game (
+  name "The Carpooler (Timex)"
+  description "The Carpooler (Timex)"
+  manufacturer "Timex"
+  rom ( name "CarpoolerThe.tzx" size 14507 crc D8258CEF md5 9F1A67808E8506B0DF3C66BF00568CAF sha1 CAFBB78BF77F88C0FFB29E6C2A92666899149C8E )
+)
+
+game (
+  name "The Carpooler (Timex)"
+  description "The Carpooler (Timex)"
+  manufacturer "Timex"
+  rom ( name "carpoolerthe.p" size 14277 crc 0D8ABCAC md5 068BE6E28AF97837FFBB6D292930B6D7 sha1 992B08B7FC5BC7D0D891459FBCEBB078BA9D2649 )
+)
+
+game (
+  name "Cassette 3 (M. Orwin)"
+  description "Cassette 3 (M. Orwin)"
+  year "1982"
+  manufacturer "Various"
+  rom ( name "Cassette3.tzx" size 96710 crc F612E596 md5 688FE0BD73CF475D632EBB2BC920F92C sha1 A3A02C88CD119F5ACF87EF056A8B26DAD0A79390 )
+)
+
+game (
+  name "Cassette 4 (M. Orwin)"
+  description "Cassette 4 (M. Orwin)"
+  year "1982"
+  manufacturer "Various"
+  rom ( name "Cassette4.tzx" size 53160 crc 9C246427 md5 ACFC26DD06D2A03808F0FF71E9BE96D2 sha1 5CDB627AC5B3498225D7D4D5FB90D80751187218 )
+)
+
+game (
+  name "Castle Adventure (CDS Micro Systems)"
+  description "Castle Adventure (CDS Micro Systems)"
+  manufacturer "CDS Micro Systems"
+  rom ( name "Castle.tzx" size 14716 crc BA09CC38 md5 EF3141D3308BCD5DD7831A27E8CC5899 sha1 688ABD7300F76E35F69AE025A4411F2767514B94 )
+)
+
+game (
+  name "Castle Adventure (CDS Micro Systems)"
+  description "Castle Adventure (CDS Micro Systems)"
+  manufacturer "CDS Micro Systems"
+  rom ( name "castle.p" size 14488 crc 1D01ED81 md5 239C2112AE0B67A045BFEB0397D4F3E0 sha1 00755932CA214C899B866036E666DF6325FDD59A )
+)
+
+game (
+  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "Castle.tzx" size 14716 crc BA09CC38 md5 EF3141D3308BCD5DD7831A27E8CC5899 sha1 688ABD7300F76E35F69AE025A4411F2767514B94 )
+)
+
+game (
+  name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "castle.p" size 14488 crc 1D01ED81 md5 239C2112AE0B67A045BFEB0397D4F3E0 sha1 00755932CA214C899B866036E666DF6325FDD59A )
+)
+
+game (
+  name "Catacombs (J. K. Greye)"
+  description "Catacombs (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "Catacombs.tzx" size 12740 crc F8D6AEE6 md5 6EC147973D7561EDE4726BC413409CDD sha1 C872D07E278DF997DF9A66185852F580FD851151 )
+)
+
+game (
+  name "Catacombs (J. K. Greye)"
+  description "Catacombs (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "catacombs.p" size 12506 crc B1ED0B59 md5 5E674CE62EFD5AB861BBEEF9DE75D711 sha1 A5D32E1D50D291C485549C4740E5CC6BA3DE36AB )
+)
+
+game (
+  name "Cave Crusade (AWA Software)"
+  description "Cave Crusade (AWA Software)"
+  manufacturer "S. Hughes"
+  rom ( name "CaveCrusade.tzx" size 6510 crc 9DEC44E3 md5 4E27965613610224B2C60F824983F7A7 sha1 BC4A46FDEC5734A88AFC005DF4864FEAE26549E1 )
+)
+
+game (
+  name "Cave Crusade (AWA Software)"
+  description "Cave Crusade (AWA Software)"
+  manufacturer "S. Hughes"
+  rom ( name "cavecrusade.p" size 6270 crc A2EB2F80 md5 B6C9C3F387D5BA97D80FE92A03E6D0C5 sha1 5F05D170D3EBA9A7C4915EECD7E65BBBB958FECA )
+)
+
+game (
+  name "Centipede (Llamasoft)"
+  description "Centipede (Llamasoft)"
+  year "1982"
+  manufacturer "Jeff Minter"
+  rom ( name "Centipede.tzx" size 9940 crc 163CF493 md5 74AC41B73E525977DD00E99E92A46E53 sha1 DD75BBB4EC90C8D054E1C0A41164E02A8F3121E3 )
+)
+
+game (
+  name "Centipede (Llamasoft)"
+  description "Centipede (Llamasoft)"
+  year "1982"
+  manufacturer "Jeff Minter"
+  rom ( name "centipede.p" size 9706 crc F2414D13 md5 EEBA50F572E820D43FB3F8D140C673E1 sha1 0F23AA3EAC663BD04DE225074B80701BA05FCB1B )
+)
+
+game (
+  name "Centipede (Green cover) (dK'tronics)"
+  description "Centipede (Green cover) (dK'tronics)"
+  manufacturer "dK'tronics"
+  rom ( name "Centipede(Green).tzx" size 9967 crc 0ED972CD md5 9DD33FD4999F2D1DE4BF52E4590D2521 sha1 1BF47EF2651D5D09A6971CE9EB931AA41ED846CB )
+)
+
+game (
+  name "Centipede (Green cover) (dK'tronics)"
+  description "Centipede (Green cover) (dK'tronics)"
+  manufacturer "dK'tronics"
+  rom ( name "centipede(green).p" size 9733 crc F5F4B919 md5 90610D4FA888969F53204A5CA98F6A20 sha1 418C10220FBF3BCF83C07B2A9C717DD12DC92C53 )
+)
+
+game (
+  name "Centipede (dktronics) (dK'tronics)"
+  description "Centipede (dktronics) (dK'tronics)"
+  year "1982"
+  manufacturer "Jeff Minter"
+  rom ( name "centipede(dktronics).p" size 9790 crc 1E369CE6 md5 DD7D3F2E2B36FFBD2CC169624FC60421 sha1 7770684A912C0BB2116D9F73F1CAAFC1796A23DF )
+)
+
+game (
+  name "Centipede (dktronics) (dK'tronics)"
+  description "Centipede (dktronics) (dK'tronics)"
+  year "1982"
+  manufacturer "Jeff Minter"
+  rom ( name "Centipede(dktronics).tzx" size 10008 crc F12C5EE1 md5 78B3D51B99FA1B99182D60B206FE2944 sha1 C90D0CA1DD3E1679C9C0E4A359D6B84978C129F7 )
+)
+
+game (
+  name "Challenge (Micromega)"
+  description "Challenge (Micromega)"
+  manufacturer "Micromega"
+  rom ( name "Challenge.tzx" size 4865 crc 8439C8B1 md5 B963B33677E4E187630608606FECBA67 sha1 B3DD53DF21A684570B3120A8A996FAE738DFB15A )
+)
+
+game (
+  name "The Challenger 1 (Timex)"
+  description "The Challenger 1 (Timex)"
+  year "1982"
+  manufacturer "R. Fowkes"
+  rom ( name "Challenger1The.tzx" size 4178 crc A01B37E4 md5 CA1D005637983ED5618C1BFD4B9BB08D sha1 5B9809A27911E43D8FB882A60DA3752FE202BC27 )
+)
+
+game (
+  name "Champions! (Peaksoft)"
+  description "Champions! (Peaksoft)"
+  manufacturer "Peaksoft"
+  rom ( name "champions.p" size 14858 crc D363867F md5 806E86A4E8C5807CE53717E4BA441C98 sha1 2148C6108E52C8C33A8C1593C47A1EE89ED711B8 )
+)
+
+game (
+  name "Champions! (Peaksoft)"
+  description "Champions! (Peaksoft)"
+  manufacturer "Peaksoft"
+  rom ( name "Champions.tzx" size 15086 crc 7AE0415B md5 7F738BEFE88938AE2F5BFAF464CC2C16 sha1 1847183FFCAF74BB7F709D09D1D5FEA24C720E6A )
+)
+
+game (
+  name "The Checkbook Manager (Timex)"
+  description "The Checkbook Manager (Timex)"
+  year "1982"
+  manufacturer "John Heaney"
+  rom ( name "checkbookmanagerthe.p" size 13483 crc B9446D9B md5 6E610DCA9691A1FC82C89A5BA4A4574D sha1 5A12849CE4BE86742C393306023FBF2FB081CA6A )
+)
+
+game (
+  name "The Checkbook Manager (Timex)"
+  description "The Checkbook Manager (Timex)"
+  year "1982"
+  manufacturer "John Heaney"
+  rom ( name "CheckbookManagerThe.tzx" size 13713 crc B32EAA12 md5 59CD50185F32789958737B3EAC99C64B sha1 D1B150FEE25332715AF8115604D8063E5A71B77D )
+)
+
+game (
+  name "Chess (Timex)"
+  description "Chess (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "Chess(Timex).tzx" size 10227 crc 8F6BFDC7 md5 C0678ED697E11DFA85E483DB93DD053C sha1 BD2A54D8CCB6BD918DEABA02B0793CF0372C8F27 )
+)
+
+game (
+  name "Chrs Demo (Quicksilva)"
+  description "Chrs Demo (Quicksilva)"
+  manufacturer "Quicksilva"
+  rom ( name "ChrsDemo.tzx" size 5993 crc 3E8D1DA7 md5 B69EA89A89170660517BF2284C791E12 sha1 8509B1FC61DC20C1E9280526858B0E95BD6359B5 )
+)
+
+game (
+  name "City of Xon (Pleasantrees)"
+  description "City of Xon (Pleasantrees)"
+  year "1982"
+  manufacturer "Pleasantrees"
+  rom ( name "CityOfXon.tzx" size 15729 crc 3B72AF94 md5 18B114EE78E469EA4B85E858802A716C sha1 0D07FB55913B3495B0C26178C84D010CD5EEB03E )
+)
+
+game (
+  name "City of Xon (Pleasantrees)"
+  description "City of Xon (Pleasantrees)"
+  year "1982"
+  manufacturer "Pleasantrees"
+  rom ( name "cityofxon.p" size 15507 crc E853667C md5 82A04AFAF98222545389663888140B7B sha1 2111223FD0CAB96C1ACA585430336E60D501017F )
+)
+
+game (
+  name "City Patrol (Sinclair Research)"
+  description "City Patrol (Sinclair Research)"
+  year "1982"
+  manufacturer "Macronics (Don Priestley)"
+  rom ( name "citypatrol.p" size 9168 crc B9CF2E5F md5 A14424F16ED442E3C0AF074F2EA01C95 sha1 333C2E1052DC734D76B19DA5DDDFAA9835177E12 )
+)
+
+game (
+  name "City Patrol (Sinclair Research)"
+  description "City Patrol (Sinclair Research)"
+  year "1982"
+  manufacturer "Macronics (Don Priestley)"
+  rom ( name "CityPatrol.tzx" size 9388 crc 1EA8841E md5 71C94BC78806C1EA06D1996CBF6D64E8 sha1 99D5AE89CFE7940E67D8EDE6DBD860020B1AD9DF )
+)
+
+game (
+  name "Club Record Controller (Sinclair Research)"
+  description "Club Record Controller (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "clubrecordcontroller.p" size 6857 crc 16B8F22F md5 481DAF4708C4217FF3C5446F049E5D61 sha1 73048E28D5C2F198A97C1BA33E9A2111A1901465 )
+)
+
+game (
+  name "Club Record Controller (Sinclair Research)"
+  description "Club Record Controller (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "ClubRecordController.tzx" size 7075 crc C1BDAA09 md5 03638152AFE7D50F7F3050D42423FB5A sha1 246F887ED316A62311165AF8AC7ABEE59C0CFCE6 )
+)
+
+game (
+  name "Club Records (W. H. Smith)"
+  description "Club Records (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "clubrecords.p" size 7526 crc 770EAD60 md5 43274F46A93F29E10650A6C0EA5D6EA6 sha1 06C9B03442650D03948BDD73095BA4541CF4FFF4 )
+)
+
+game (
+  name "Club Records (W. H. Smith)"
+  description "Club Records (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "ClubRecords.tzx" size 7744 crc 229BF155 md5 9061510C942E211DB25159985FD39A7B sha1 D62DC88512D6DC336DAD5637924E6056A19E12A7 )
+)
+
+game (
+  name "Collector's Pack (Sinclair Research)"
+  description "Collector's Pack (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "collectorspack.p" size 7447 crc AD2FAA57 md5 DC7C428A0DF6B6140DD71F0924F80316 sha1 67FF172B4EC0B7B088B17EE62DF3860851748705 )
+)
+
+game (
+  name "Collector's Pack (Sinclair Research)"
+  description "Collector's Pack (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "CollectorsPack.tzx" size 7665 crc 4998A5D6 md5 8FD43049AE5C0246D79C82D59CEF6CD4 sha1 BB2B43893119EABF30754BE20992BF32E05E6832 )
+)
+
+game (
+  name "Collector's Recording System (W. H. Smith)"
+  description "Collector's Recording System (W. H. Smith)"
+  manufacturer "ICL"
+  rom ( name "collectorsrecordingsystem.p" size 7447 crc FE3EB9CC md5 8AF2B0E4D7A7480859B978AFF6B8954D sha1 BF4B5D5C78B6A1E68784296567AA655362D6A552 )
+)
+
+game (
+  name "Collector's Recording System (W. H. Smith)"
+  description "Collector's Recording System (W. H. Smith)"
+  manufacturer "ICL"
+  rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1A89B64D md5 D0735FC71D39A879E80FE130F3CA8226 sha1 7FB6CF85C4A0E47A2AD78F5F4371DEEEBADCB923 )
+)
+
+game (
+  name "Community Chest (Artic)"
+  description "Community Chest (Artic)"
+  manufacturer "Artic"
+  rom ( name "CommunityChest.tzx" size 14270 crc BF585C82 md5 A4B42D6021CECA0F9C09AA0E6596C110 sha1 C95AF3F37795ADABE7F251643EFFF51CB7E2579F )
+)
+
+game (
+  name "Community Chest (Artic)"
+  description "Community Chest (Artic)"
+  manufacturer "Artic"
+  rom ( name "communitychest.p" size 14048 crc 0FE4512D md5 A40B1C79C5B578238002454F2A4B92BC sha1 941725AEEF9136F7B105BD1E8C21245EC671AC86 )
+)
+
+game (
+  name "ComputaCalc ZX (Silicon Tricks)"
+  description "ComputaCalc ZX (Silicon Tricks)"
+  year "1981"
+  manufacturer "S. C. Stephens"
+  rom ( name "computacalc.p" size 8990 crc 45EAF966 md5 7D48EECD455038A643E84CFD5FEAB476 sha1 D765D5C3AA5E516E07EB9465E222A777ED540FA8 )
+)
+
+game (
+  name "ComputaCalc ZX (Silicon Tricks)"
+  description "ComputaCalc ZX (Silicon Tricks)"
+  year "1981"
+  manufacturer "S. C. Stephens"
+  rom ( name "ComputaCalc.tzx" size 9228 crc 06066AFC md5 FE153257A523703B95488A6CDB4640BC sha1 496065DBC17D2461647BB76933AD9247F03CD1DE )
+)
+
+game (
+  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  year "1981"
+  manufacturer "S. C. Stephens"
+  rom ( name "computacalc.p" size 8990 crc 45EAF966 md5 7D48EECD455038A643E84CFD5FEAB476 sha1 D765D5C3AA5E516E07EB9465E222A777ED540FA8 )
+)
+
+game (
+  name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
+  year "1981"
+  manufacturer "S. C. Stephens"
+  rom ( name "ComputaCalc.tzx" size 9228 crc 06066AFC md5 FE153257A523703B95488A6CDB4640BC sha1 496065DBC17D2461647BB76933AD9247F03CD1DE )
+)
+
+game (
+  name "Constellation (Bug Byte)"
+  description "Constellation (Bug Byte)"
+  manufacturer "Bug Byte"
+  rom ( name "constellation.p" size 12385 crc 82892356 md5 B7FF958C98E6955281AED8D50CE4A8B2 sha1 B020CEC9FD14F00882DE28165F4F2A207E020306 )
+)
+
+game (
+  name "Constellation (Bug Byte)"
+  description "Constellation (Bug Byte)"
+  manufacturer "Bug Byte"
+  rom ( name "Constellation.tzx" size 12611 crc A0146B49 md5 500508C55BFAE7C20D1191CF95B37E5D sha1 FB8BBC99988812C5EF372A7358A36CEADB53AE73 )
+)
+
+game (
+  name "Constellation (Gladstone) (Gladstone Electronics)"
+  description "Constellation (Gladstone) (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "Constellation(GE).tzx" size 15694 crc 89092DE9 md5 E76748A332503ED9799FB76A16CF24F2 sha1 69DA2B7F7A1F311A73858F4787F05C31460E7172 )
+)
+
+game (
+  name "Constellation (Gladstone) (Gladstone Electronics)"
+  description "Constellation (Gladstone) (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "constellation(ge).p" size 15452 crc CA46CB85 md5 7EB28D1AD0F29BE00794F00BE04FF1E7 sha1 58F35FB046A9E20052DC7B838E1754C593FCDB53 )
+)
+
+game (
+  name "Control Technology Tapes 1,2,3 (Control Technology)"
+  description "Control Technology Tapes 1,2,3 (Control Technology)"
+  manufacturer "Control Technology"
+  rom ( name "ControlTechnology123.tzx" size 48433 crc D9610EA9 md5 1C5691270A4F2EF50A859F6EEFE7891F sha1 8E630DBC2725862733CD138E69A7C8CA9EEED84F )
+)
+
+game (
+  name "Conversational German (Timex)"
+  description "Conversational German (Timex)"
+  year "1983"
+  manufacturer "D. E. Hagan"
+  rom ( name "conversationalgerman.p" size 15375 crc 2A3A859E md5 B73D18D611AF33AD7C555F03F0CC597D sha1 F03403678A5B6CAA88CEDEE89AEE74BA8D4270AB )
+)
+
+game (
+  name "Conversational German (Timex)"
+  description "Conversational German (Timex)"
+  year "1983"
+  manufacturer "D. E. Hagan"
+  rom ( name "ConversationalGerman.tzx" size 15603 crc 810BDCC4 md5 1E27801FD4DB30240671C6F1ECBBE73D sha1 DDB421FE807557A6F4A2EB7EA78E15C249B15DE1 )
+)
+
+game (
+  name "Cosmic Guerilla (Quicksilva)"
+  description "Cosmic Guerilla (Quicksilva)"
+  year "1983"
+  manufacturer "C. K. Tame"
+  rom ( name "CosmicGuerilla.tzx" size 7561 crc 001EF96D md5 DE8CA35128D7EC90516DD6EE759E65A6 sha1 EF8E79312D0DC7EFEC6BF2A9A6CA785B0E4A94A0 )
+)
+
+game (
+  name "Cosmic Guerilla (Quicksilva)"
+  description "Cosmic Guerilla (Quicksilva)"
+  year "1983"
+  manufacturer "C. K. Tame"
+  rom ( name "cosmicguerilla.p" size 7333 crc 8594884E md5 37C438DBF7EC1A61B574C870AB04B375 sha1 1F0226F4DE15F5EE393761631A6D3AAD46C75A10 )
+)
+
+game (
+  name "Counter Attack (Woodside Software)"
+  description "Counter Attack (Woodside Software)"
+  manufacturer "P. Hennessy"
+  rom ( name "CounterAttack.tzx" size 7219 crc 6B8852CA md5 DFE0270C48C5AF69BD0652F723F6C5B2 sha1 286CD36A713F95FFCC5E847539A59DE6C55F6C42 )
+)
+
+game (
+  name "Counter Attack (Woodside Software)"
+  description "Counter Attack (Woodside Software)"
+  manufacturer "P. Hennessy"
+  rom ( name "counterattack.p" size 6975 crc 4095691A md5 846BE5D9FAF79197323D5C2B05B82136 sha1 45AAE62DC5ED72ECBA3C33B280B2C3D7310CF942 )
+)
+
+game (
+  name "The Coupon Manager (Timex)"
+  description "The Coupon Manager (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "couponmanagerthe.p" size 15892 crc D4803E75 md5 AE154DF5FAD396DF2C60A12FF7275328 sha1 E6F50FCC128863CD06428A20A731B0CDB1B76379 )
+)
+
+game (
+  name "Critical Path Analysis (Hilderbay)"
+  description "Critical Path Analysis (Hilderbay)"
+  year "1981"
+  manufacturer "Hilderbay"
+  rom ( name "criticalpathanalysis.p" size 6053 crc 10FB4D01 md5 30F5B565EEBB684D446A1D9073860BD2 sha1 E6E505E111C04A395E8A946CF2C5B7BBED948BA1 )
+)
+
+game (
+  name "Critical Path Analysis (Hilderbay)"
+  description "Critical Path Analysis (Hilderbay)"
+  year "1981"
+  manufacturer "Hilderbay"
+  rom ( name "CriticalPathAnalysis.tzx" size 6275 crc 28EE5886 md5 47B2D99A813EA1744AD5A41D15016A8D sha1 3EE5A82DEC70E4BD7EB1D514CDD4538CB433F24A )
+)
+
+game (
+  name "Critical Path Analysis (Timex)"
+  description "Critical Path Analysis (Timex)"
+  year "1982"
+  manufacturer "W. Emery"
+  rom ( name "CriticalPathAnalysis(Timex).tzx" size 6720 crc C1835895 md5 AF015196BC37C30E8F529DA34262ED28 sha1 469F80FBF8E3979B8534E28DABD9D7089E55425E )
+)
+
+game (
+  name "Croaka-Crawla (Quicksilva)"
+  description "Croaka-Crawla (Quicksilva)"
+  year "1983"
+  manufacturer "Quicksilva"
+  rom ( name "croakacrawla.p" size 14666 crc 2E8A9AF1 md5 96FDEAF0F549A9198B633A19510BE1FE sha1 4BB58B01E86AAF1DC21999E77EC7D557F4353FFE )
+)
+
+game (
+  name "Croaka-Crawla (Quicksilva)"
+  description "Croaka-Crawla (Quicksilva)"
+  year "1983"
+  manufacturer "Quicksilva"
+  rom ( name "CroakaCrawla.tzx" size 14896 crc 1E07D1C3 md5 51E05750EDA73CBD667E52D945C742D9 sha1 3489FD97EE769B1B59E0B74CCDEB667F135DBCBD )
+)
+
+game (
+  name "The Cube Game (Timex)"
+  description "The Cube Game (Timex)"
+  year "1982"
+  manufacturer "John Heaney"
+  rom ( name "CubeGameThe.tzx" size 13714 crc C87BEA16 md5 E7E0B000B8FCE72A25F358B4B5F2478E sha1 DBF04E07FF5ED808DF032C66191F79D0C96488A5 )
+)
+
+game (
+  name "The Cube Game (Timex)"
+  description "The Cube Game (Timex)"
+  year "1982"
+  manufacturer "John Heaney"
+  rom ( name "cubegamethe.p" size 13490 crc 5B814EA8 md5 46141C523CF55F37AD18594D434C118E sha1 C30033CD7773CF740F517B3E5C8FD7B1BFE593DA )
+)
+
+game (
+  name "D Coder (Cosma)"
+  description "D Coder (Cosma)"
+  manufacturer "Cosma"
+  rom ( name "DCoder.A.tzx" size 7680 crc 1684BA79 md5 229D7EB3CD3C17B82A1FB4E5DAEC5370 sha1 39F16BB21B52C566218F38AA07B1951E38C0F8BD )
+)
+
+game (
+  name "Dallas (French) (Cases Computer Simulations)"
+  description "Dallas (French) (Cases Computer Simulations)"
+  year "1983"
+  manufacturer "Cases Computer Simulations"
+  rom ( name "Dallas(French).tzx" size 16379 crc 4A65562E md5 6EA358B625C6DEECCE8B906983884A27 sha1 499BEE247F3BDC37ECA67E95EEE1624DE11EC5D6 )
+)
+
+game (
+  name "Dallas (French) (Cases Computer Simulations)"
+  description "Dallas (French) (Cases Computer Simulations)"
+  year "1983"
+  manufacturer "Cases Computer Simulations"
+  rom ( name "dallas(french).p" size 16151 crc 6FC5F7EC md5 C76BD00587E4017E445C023AD12FDFCB sha1 1D1CD2F2CE3CDFC7A8C18E8BDD1CD0CDC8F2797E )
+)
+
+game (
+  name "The Damsel and the Beast (Bug Byte)"
+  description "The Damsel and the Beast (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "damselandthebeastthe.p" size 10200 crc E572E012 md5 A4BA6FB14BE2C6841565DFFC496D8C18 sha1 15033D3454985A1CE45289BB33296791AB3332AA )
+)
+
+game (
+  name "The Damsel and the Beast (Bug Byte)"
+  description "The Damsel and the Beast (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "DamselAndTheBeastThe.tzx" size 10464 crc B34252C8 md5 D055C7009157DCF01DC9689D414DBAFA sha1 574392A27B8328EC82121E1C666E2C3411F34342 )
+)
+
+game (
+  name "Dictator (Bug Byte)"
+  description "Dictator (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "Dictator.tzx" size 16306 crc B01E01A7 md5 2E2E96ED20915990EB8280021CE7838E sha1 C14608ECC904B6AD8141D64BB4EED66C43B6316D )
+)
+
+game (
+  name "Dictator (Bug Byte)"
+  description "Dictator (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "dictator.p" size 16074 crc 9EF1B3CF md5 8AA9775F53F519DED0AE7F7A2C5B3F60 sha1 42B98D75F715B69C1C54722A05A8D0D7B07783EC )
+)
+
+game (
+  name "Do Not Pass Go (Work Force)"
+  description "Do Not Pass Go (Work Force)"
+  manufacturer "Work Force"
+  rom ( name "donotpassgo.p" size 13355 crc 292A5505 md5 0480349FBEE60FD0939F31CC6D210C2B sha1 A05BA8AD8560A15C5ECFFFF289D10DAA421B5CB8 )
+)
+
+game (
+  name "Do Not Pass Go (Work Force)"
+  description "Do Not Pass Go (Work Force)"
+  manufacturer "Work Force"
+  rom ( name "DoNotPassGo.tzx" size 13587 crc A2DD0F0C md5 D4CDFCEE0472C465483738B520960D65 sha1 45DED58CE3255E5239722C956EEF084BAC20AD6D )
+)
+
+game (
+  name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
+  description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "DodgemsAndConnect4(Brown).tzx" size 9488 crc 39D4E107 md5 B6110B1177643DFB269784EE01902964 sha1 DE9F3293E482AC4F92B3278D262E45321450FE79 )
+)
+
+game (
+  name "Dominoes (Phipps Associates)"
+  description "Dominoes (Phipps Associates)"
+  year "1983"
+  manufacturer "D. G. Cross"
+  rom ( name "Dominoes.tzx" size 15375 crc 4FC4E410 md5 C9EC351812095D3A1A91E4DB7926A5D8 sha1 B780954C535CCD6F6A778999B7244DE33BB3AD53 )
+)
+
+game (
+  name "Dominoes (Phipps Associates)"
+  description "Dominoes (Phipps Associates)"
+  year "1983"
+  manufacturer "D. G. Cross"
+  rom ( name "dominoes.p" size 15143 crc F53499E9 md5 7C250A09C6E3E1FE996AB0DF7FC312FF sha1 CD00BF0A030844133F39FBBAC4712BA1C8591DCA )
+)
+
+game (
+  name "Dr. Floyd (Apropos Technology)"
+  description "Dr. Floyd (Apropos Technology)"
+  manufacturer "Apropos Technology"
+  rom ( name "DrFloyd.tzx" size 14294 crc D5B0408F md5 5E0B05B046B113239EC5EFDB9E23589E sha1 6982C898304A0E319434984A019B96682D177661 )
+)
+
+game (
+  name "Dr. Floyd (Apropos Technology)"
+  description "Dr. Floyd (Apropos Technology)"
+  manufacturer "Apropos Technology"
+  rom ( name "drfloyd.p" size 14062 crc D16282DA md5 4E26541F29E46BABA6BEAC4AD8BCCC31 sha1 C5531613742A634A5B41503198AE567ADC6A42AB )
+)
+
+game (
+  name "Dragon Maze (Macronics)"
+  description "Dragon Maze (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "DragonMaze.tzx" size 4970 crc C2A29E0D md5 3AAAADD623DF3A672361715BB3B9C6F3 sha1 58E77F8D47F0A0061F0545E3D95485D9041D7025 )
+)
+
+game (
+  name "Dragon Maze (Macronics)"
+  description "Dragon Maze (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "dragonmaze.p" size 4750 crc B252B048 md5 D5520C004ECD8E8D15D36FA70FDDEC8E sha1 F6F90B253527935B27CE3674C49B33D914B37DFC )
+)
+
+game (
+  name "Dungeons of Doom (Temptation Software)"
+  description "Dungeons of Doom (Temptation Software)"
+  year "1982"
+  manufacturer "Simon Mansfield"
+  rom ( name "DungeonsOfDoom.tzx" size 15074 crc D5034066 md5 747215BD1AFEBF2217ADDC18B14B1E36 sha1 B2884C73AF5DA39E4C32D9A11206769E006F456F )
+)
+
+game (
+  name "E.E. 1 - Filter Design (Timex)"
+  description "E.E. 1 - Filter Design (Timex)"
+  year "1982"
+  manufacturer "American Micro Products"
+  rom ( name "EE1FilterDesign.tzx" size 12047 crc 1159B6AA md5 0A3FB9FD79259C485B0DF31A4D387D20 sha1 D6714FE623F9E444C22CDE90F56488A58FCE0D33 )
+)
+
+game (
+  name "E.E. 1 - Filter Design (Timex)"
+  description "E.E. 1 - Filter Design (Timex)"
+  year "1982"
+  manufacturer "American Micro Products"
+  rom ( name "ee1filterdesign.p" size 11825 crc A6A157C9 md5 5E5B10ECC426F5820F3DAB25B7C6AD92 sha1 152342A49020A5740A50650D9B2BBF9C5D66C9B7 )
+)
+
+game (
+  name "Electric Cost Analyzer (Timex)"
+  description "Electric Cost Analyzer (Timex)"
+  year "1983"
+  manufacturer "Tim Rossetti"
+  rom ( name "electriccostanalyzer.p" size 15557 crc BCCAE88D md5 ADCA050F5154D5E1107CA72433DB06E1 sha1 DD7AE4F987B76D764D60D5A0FD95CF879310DDE2 )
+)
+
+game (
+  name "Electric Cost Analyzer (Timex)"
+  description "Electric Cost Analyzer (Timex)"
+  year "1983"
+  manufacturer "Tim Rossetti"
+  rom ( name "ElectricCostAnalyzer.tzx" size 15789 crc D6745B7A md5 CA1D14BAD434D1AD36F829AAAC3939A1 sha1 F5F5C2A8038DF69484937CE4B853B4E83DFCF5F5 )
+)
+
+game (
+  name "The Electronic Checkbook (Timeworks)"
+  description "The Electronic Checkbook (Timeworks)"
+  year "1982"
+  manufacturer "Timeworks"
+  rom ( name "electroniccheckbookthe.p" size 16162 crc 75097784 md5 CDD6EA720F382F5DC8F2C971A53E3E2F sha1 A2ACE5B2B1BF45C5DBD0EBF2CBD47934DC668787 )
+)
+
+game (
+  name "The Electronic Checkbook (Timeworks)"
+  description "The Electronic Checkbook (Timeworks)"
+  year "1982"
+  manufacturer "Timeworks"
+  rom ( name "ElectronicCheckbookThe.tzx" size 16382 crc BC3ED36D md5 C0F35B0FCEF5474812364C0EA6CDCF2E sha1 3791720C3974C31C322B9D1E6A6281DE6E6BCFCD )
+)
+
+game (
+  name "Electronics (Spectre)"
+  description "Electronics (Spectre)"
+  manufacturer "Spectre"
+  rom ( name "electronics.p" size 15899 crc B18D5D28 md5 8D3EE1B1EB0D3DF446F50731C6659279 sha1 2F56472672D41361C60591D7CF177EB18148976B )
+)
+
+game (
+  name "Electronics (Spectre)"
+  description "Electronics (Spectre)"
+  manufacturer "Spectre"
+  rom ( name "Electronics.tzx" size 16121 crc E777753A md5 48B223D7A2E94415AD4DC381B6A33FE8 sha1 D3A41D3AA66DB93144EEF927A1C37FC8BB9FAB90 )
+)
+
+game (
+  name "Encounter (Quicksilva)"
+  description "Encounter (Quicksilva)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Encounter.tzx" size 17612 crc AF150F3F md5 D526D1745135DCC2BC1F357FA2CAB910 sha1 EC8355C006D83DFC367A166EE6F33CB3530381AB )
+)
+
+game (
+  name "Escape From Manhattan (Computer Rentals)"
+  description "Escape From Manhattan (Computer Rentals)"
+  year "1983"
+  manufacturer "N. Taylor"
+  rom ( name "EscapeFromManhattan.tzx" size 16320 crc 2CACBB72 md5 2B526BA624AF0FDFC1733099CCEC82AB sha1 975C976E36B9DBD47FCF5312FAE4AD5C2521D6D7 )
+)
+
+game (
+  name "Escape From Manhattan (Computer Rentals)"
+  description "Escape From Manhattan (Computer Rentals)"
+  year "1983"
+  manufacturer "N. Taylor"
+  rom ( name "escapefrommanhattan.p" size 16102 crc 63F8023F md5 135B8483BB5B316C8744D824ACBB86C1 sha1 53799E5EA4DA7A6C5EBBA8537126F25EBBEB8285 )
+)
+
+game (
+  name "Escape from Shazzar (International Publishing and Software Inc.)"
+  description "Escape from Shazzar (International Publishing and Software Inc.)"
+  year "1983"
+  manufacturer "A. F. Nuttall"
+  rom ( name "EscapeFromShazzar.tzx" size 16376 crc 78075B95 md5 0854165D7CAA9F5D43203E5F9C999FA0 sha1 992DFCECE29B42C729BBCA05422BF090DC7C275C )
+)
+
+game (
+  name "Escape from Shazzar (International Publishing and Software Inc.)"
+  description "Escape from Shazzar (International Publishing and Software Inc.)"
+  year "1983"
+  manufacturer "A. F. Nuttall"
+  rom ( name "escapefromshazzar.p" size 16146 crc C587593D md5 B2DC9A81AC27D4BC267C8D4A0236ACB5 sha1 48FA28F6B637E59F48A58E618617A98F83FE6813 )
+)
+
+game (
+  name "Adventure D - Espionage Island (Sinclair Research)"
+  description "Adventure D: Espionage Island (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "EspionageIsland.tzx" size 15734 crc 2BF38DCA md5 50A59A5A1CA60349959BA2283E4188F8 sha1 1AFAA1C3773C78F8F92941D95DE226A727CC8822 )
+)
+
+game (
+  name "Adventure D - Espionage Island (Sinclair Research)"
+  description "Adventure D: Espionage Island (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "espionageisland.p" size 15504 crc 81DDF2B0 md5 24C456B967F1B621685579289A656CEB sha1 9C2DB35B667F12A155AAD2F2E5725B9FCF54E290 )
+)
+
+game (
+  name "Adventure D - Espionage Island (Artic)"
+  description "Adventure D: Espionage Island (Artic)"
+  manufacturer "Artic"
+  rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06A3887C md5 30754AA09608D83DEB1C0194C04B85CB sha1 7B36F0BCE5ECCB9FC3DC4FB553516E5E7F5ADABE )
+)
+
+game (
+  name "Adventure D - Espionage Island (Artic)"
+  description "Adventure D: Espionage Island (Artic)"
+  manufacturer "Artic"
+  rom ( name "espionageisland(artic).p" size 15504 crc AC8DF706 md5 348A6B4FBEC8E375DAF1BE03D1C674DF sha1 8AD3E1AE97A34A6F6B1E2F653AEED770BA33F01E )
+)
+
+game (
+  name "FUNdamentals of Math (Timex)"
+  description "FUNdamentals of Math (Timex)"
+  year "1983"
+  manufacturer "ATM"
+  rom ( name "FUNdamentalsOfMath.tzx" size 39312 crc 75ADE9A1 md5 FBE76752CE6FD550C78F7116E8472D37 sha1 0C1FD6D5034FA73E8D1D3DD525E088CD96971BD7 )
+)
+
+game (
+  name "Fast Load Save (Musamy Software)"
+  description "Fast Load Save (Musamy Software)"
+  year "1982"
+  manufacturer "Musamy Software"
+  rom ( name "FastLoadSave.tzx" size 11000 crc 939F03CB md5 BE316FADC3492E475E6D07BDF9AE310E sha1 616DFC2662D46F415277990BEBF0B09E187ED36E )
+)
+
+game (
+  name "The Fast One (Campbell Systems)"
+  description "The Fast One (Campbell Systems)"
+  manufacturer "Campbell Systems"
+  rom ( name "FastOne(Green).tzx" size 9837 crc 3C57D2F2 md5 24BFE29D78AC664AA6B367EF983C590D sha1 C31F2892EA9145CDAB6EF5F21CD126AB9D079036 )
+)
+
+game (
+  name "Flight Simulation (Sinclair Research)"
+  description "Flight Simulation (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
+)
+
+game (
+  name "Flight Simulation (Sinclair Research)"
+  description "Flight Simulation (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
+)
+
+game (
+  name "The Flight Simulator (Timex)"
+  description "The Flight Simulator (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
+)
+
+game (
+  name "The Flight Simulator (Timex)"
+  description "The Flight Simulator (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
+)
+
+game (
+  name "Flug-Simulation (Sinclair Research)"
+  description "Flug-Simulation (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "FlightSimulation.tzx" size 13855 crc 945DA3C1 md5 CAD45E8938878607ED1A6CA38F08C3C5 sha1 DE020D7531C0904A8A152193E7B3D5203E5C1017 )
+)
+
+game (
+  name "Flug-Simulation (Sinclair Research)"
+  description "Flug-Simulation (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "flightsimulation.p" size 13627 crc 7B1BB76A md5 7279FFB7409871741475587B3F707E70 sha1 F80F7B67FB2A629FA1492F67756EA2078E6D28D7 )
+)
+
+game (
+  name "Football (Tyrant)"
+  description "Football (Tyrant)"
+  manufacturer "Tyrant"
+  rom ( name "Football.tzx" size 15858 crc 8503533C md5 673DFECB1920D35FCD55F23AAB95DBF8 sha1 D75DFC7310F08160F7FF61F2E08F2ED4FA5AABB0 )
+)
+
+game (
+  name "Football (Tyrant)"
+  description "Football (Tyrant)"
+  manufacturer "Tyrant"
+  rom ( name "football.p" size 15626 crc 33233387 md5 EF4F6C235F9017F7B4C83F19FFC72818 sha1 F0EE8A1607A606D22B7C2BA518A06BD2CD387FD9 )
+)
+
+game (
+  name "Football-League (Video Software)"
+  description "Football-League (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "FootballLeague.A.tzx" size 14343 crc 78694C75 md5 64AD8A73B7B3B45C35AA937B09E14817 sha1 4887F03B6E5725D1ACB156A485DDC9C450607D88 )
+)
+
+game (
+  name "Football-League (Video Software)"
+  description "Football-League (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "footballleague.p" size 14097 crc 9E4623C5 md5 B430448D983A97C6DE8D0FD776BEF9C8 sha1 C8B1BD7A85D2981EC2B6478E0C58B36DCCB42AC3 )
+)
+
+game (
+  name "Football Manager (Addictive Games)"
+  description "Football Manager (Addictive Games)"
+  year "1982"
+  manufacturer "Kevin J. Toms"
+  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
+)
+
+game (
+  name "Football Manager (Addictive Games)"
+  description "Football Manager (Addictive Games)"
+  year "1982"
+  manufacturer "Kevin J. Toms"
+  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
+)
+
+game (
+  name "Football Manager (Black inlay) (Addictive Games)"
+  description "Football Manager (Black inlay) (Addictive Games)"
+  year "1981"
+  manufacturer "Kevin J. Toms"
+  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
+)
+
+game (
+  name "Football Manager (Black inlay) (Addictive Games)"
+  description "Football Manager (Black inlay) (Addictive Games)"
+  year "1981"
+  manufacturer "Kevin J. Toms"
+  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
+)
+
+game (
+  name "Football Manager (Red) (Addictive Games)"
+  description "Football Manager (Red) (Addictive Games)"
+  year "1981"
+  manufacturer "Kevin J. Toms"
+  rom ( name "footballmanager.p" size 14736 crc FFF630DE md5 192646C148629B8F4B21CD9497C7C906 sha1 5A9FB7C31E7049ED46D1FCE4F68551BB063D857D )
+)
+
+game (
+  name "Football Manager (Red) (Addictive Games)"
+  description "Football Manager (Red) (Addictive Games)"
+  year "1981"
+  manufacturer "Kevin J. Toms"
+  rom ( name "FootballManager.tzx" size 14968 crc 34E09721 md5 2C766DDB245DFA7CD4821B49875F63BD sha1 56180074FE4BBC0F6C0189B88482AFFD537B5645 )
+)
+
+game (
+  name "Football Pools Program (Hartland Software)"
+  description "Football Pools Program (Hartland Software)"
+  manufacturer "Hartland Software"
+  rom ( name "FootballPools.tzx" size 24422 crc 2D0ED98B md5 387BB8707269DE22CFB13B4C8781D20C sha1 A2AE0611AD434600777C2BA0DF4CC48D8109D9F8 )
+)
+
+game (
+  name "Forth (Sinclair Research)"
+  description "Forth (Sinclair Research)"
+  year "1983"
+  manufacturer "Artic"
+  rom ( name "Forth.tzx" size 14183 crc 376C5750 md5 5AD0F910D2987E3A51716DD82E6F4113 sha1 012A7E585C3F2D245E3D7FFBA935EA1962BE21C4 )
+)
+
+game (
+  name "Fortress of Zorlac (Timex)"
+  description "Fortress of Zorlac (Timex)"
+  year "1982"
+  manufacturer "Paul Carlson"
+  rom ( name "fortressofzorlac.p" size 7214 crc ADED8203 md5 0852A128DF135AF9F240356567D626B8 sha1 872B7049CAB2FEA166921BA30D93FCCDAF63F840 )
+)
+
+game (
+  name "Fortress of Zorlac (Timex)"
+  description "Fortress of Zorlac (Timex)"
+  year "1982"
+  manufacturer "Paul Carlson"
+  rom ( name "FortressOfZorlac.tzx" size 7442 crc 30D3BA7D md5 05B14472E34F62F64D40E71F0001F900 sha1 13F8969E92932F3F6E4C6F177BBE34512780B96F )
+)
+
+game (
+  name "Forty Niner (Software Farm)"
+  description "Forty Niner (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "FortyNiner.tzx" size 14106 crc 1C4EFF0A md5 FBA0B998270A673AF60EDE6B1F6DA4FF sha1 E563342E858B8C38A384EBFD695C479FEB01A4A5 )
+)
+
+game (
+  name "Forty Niner (Software Farm)"
+  description "Forty Niner (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "fortyniner.p" size 13868 crc B8650DA4 md5 9729D9B8A4FAEE1D12F4384F789C0B44 sha1 694AC6D1410EADE17ECC9E06A3C39191E8DDA352 )
+)
+
+game (
+  name "Frogger (DJL Software)"
+  description "Frogger (DJL Software)"
+  manufacturer "DJL Software"
+  rom ( name "frogger.p" size 13493 crc 8D24D478 md5 DB791414F02377A0B2BB60E1539401F3 sha1 29D815B98770A1FBAE3714642C5C70583D02ED17 )
+)
+
+game (
+  name "Frogger (DJL Software)"
+  description "Frogger (DJL Software)"
+  manufacturer "DJL Software"
+  rom ( name "Frogger.tzx" size 13723 crc BD7DF880 md5 9A8C77A4C24E8E67F7308BE91A2B95AA sha1 75499B16DE8DFBABF668328109D0A36963BFD11B )
+)
+
+game (
+  name "Frogger (Sega) (Timex)"
+  description "Frogger (Sega) (Timex)"
+  year "1981"
+  manufacturer "Cornsoft/Sega"
+  rom ( name "frogger(sega).p" size 10638 crc 3993108B md5 1E6FDFE09452BA5609C693A7683C94F7 sha1 B17FACF22BB6F66FE8EEF0977CBDF1B1ECDE6C6C )
+)
+
+game (
+  name "Frogger (Sega) (Timex)"
+  description "Frogger (Sega) (Timex)"
+  year "1981"
+  manufacturer "Cornsoft/Sega"
+  rom ( name "Frogger(Sega).tzx" size 10868 crc 95952886 md5 E8EBE732890B6DC7D39674E7BF527716 sha1 08999372CAF4A07B532E7360F1573C5262B56ED7 )
+)
+
+game (
+  name "Froggy (DJL Software)"
+  description "Froggy (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "froggy.p" size 10394 crc 5624F4F4 md5 C0408BB2B6D716D9643FA64670D7C241 sha1 9F45088A30FDBDDFFCCB01F55690CDE7276DF088 )
+)
+
+game (
+  name "Froggy (DJL Software)"
+  description "Froggy (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "Froggy.tzx" size 10622 crc E84F00DA md5 8A827657CCD27300BAFAA4AF1076045A sha1 C0D7D2DB94E8FB84BB22428B0B6A5C5CCC11C52B )
+)
+
+game (
+  name "Frogs (Mikro-Gen)"
+  description "Frogs (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "frogs.p" size 4223 crc B5335A99 md5 55D1B367C05A5F9259DA78AAD2B072DA sha1 D3EDABF6C4E7E88CB1224ACE1C63B2735DBF2F0F )
+)
+
+game (
+  name "Frogs (Mikro-Gen)"
+  description "Frogs (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "Frogs.tzx" size 4453 crc EFD0F05E md5 9409197480D2E19DA908B0594580EE89 sha1 899D5CDF74208E30D17C5D34F5733D207222DAAA )
+)
+
+game (
+  name "Fun Fair Adventure (Fawkes Computing)"
+  description "Fun Fair Adventure (Fawkes Computing)"
+  year "1983"
+  manufacturer "Fawkes Computing"
+  rom ( name "funfairadventure.p" size 15670 crc F5238943 md5 4F267D0AD39D72853CBB7FF914A491B0 sha1 D654CCA3195F48A50E1391BC5BC8DB72A1D4215F )
+)
+
+game (
+  name "Fun Fair Adventure (Fawkes Computing)"
+  description "Fun Fair Adventure (Fawkes Computing)"
+  year "1983"
+  manufacturer "Fawkes Computing"
+  rom ( name "FunFairAdventure.tzx" size 15892 crc 477B0E8F md5 8B00DDE0094158BE9FA735E62BC99BF9 sha1 C828C69E2A899E1B15968DAFEAEB19B6045B360B )
+)
+
+game (
+  name "Galactic Gunner (Timex)"
+  description "Galactic Gunner (Timex)"
+  year "1983"
+  manufacturer "Paul W. Carlson"
+  rom ( name "galacticgunner.p" size 8786 crc FEF205CE md5 35300CA762E104FC8C6EFBA2280FEB96 sha1 CBB2FB7C55CAA311826D2A2481C6DFFAD40B5863 )
+)
+
+game (
+  name "Galactic Gunner (Timex)"
+  description "Galactic Gunner (Timex)"
+  year "1983"
+  manufacturer "Paul W. Carlson"
+  rom ( name "GalacticGunner.tzx" size 9014 crc 1EE1C007 md5 9E6D42B5BA230A9E298DFE1C49744B23 sha1 93F8F8B5FDE8DE8305D0946F25296DA88E26D720 )
+)
+
+game (
+  name "Galactic Patrol (Computer Rentals)"
+  description "Galactic Patrol (Computer Rentals)"
+  year "1983"
+  manufacturer "Richard Brisbourne"
+  rom ( name "GalacticPatrol.tzx" size 6295 crc 25CB9C4E md5 03A02BF71F85C41298C99424A97C1FFD sha1 ED32FC48477D367E241B4A7F311F7D0C7CAA615A )
+)
+
+game (
+  name "Galactic Patrol (Computer Rentals)"
+  description "Galactic Patrol (Computer Rentals)"
+  year "1983"
+  manufacturer "Richard Brisbourne"
+  rom ( name "galacticpatrol.p" size 6063 crc 6FC3B9B1 md5 D88DCBD760136C7635C3CD44FC2F7548 sha1 E3C8AFBB3E1DFD637AA974F33A887293965F573E )
+)
+
+game (
+  name "Galactic Patrol (Omega re-release) (Omega)"
+  description "Galactic Patrol (Omega re-release) (Omega)"
+  year "1984"
+  manufacturer "CRL"
+  rom ( name "GalacticPatrol.tzx" size 6295 crc 25CB9C4E md5 03A02BF71F85C41298C99424A97C1FFD sha1 ED32FC48477D367E241B4A7F311F7D0C7CAA615A )
+)
+
+game (
+  name "Galactic Patrol (Omega re-release) (Omega)"
+  description "Galactic Patrol (Omega re-release) (Omega)"
+  year "1984"
+  manufacturer "CRL"
+  rom ( name "galacticpatrol.p" size 6063 crc 6FC3B9B1 md5 D88DCBD760136C7635C3CD44FC2F7548 sha1 E3C8AFBB3E1DFD637AA974F33A887293965F573E )
+)
+
+game (
+  name "Galactic Trooper (Romik Software)"
+  description "Galactic Trooper (Romik Software)"
+  year "1983"
+  manufacturer "Ian Morrison and David Anderson"
+  rom ( name "GalacticTrooper.tzx" size 4517 crc 95146C5F md5 86CD07956E3D37C94D5CC19C7753F152 sha1 EE48EE10E53ADBBBFE6D62C8B4FBADEA8BC1EB16 )
+)
+
+game (
+  name "Galactic Trooper (Romik Software)"
+  description "Galactic Trooper (Romik Software)"
+  year "1983"
+  manufacturer "Ian Morrison and David Anderson"
+  rom ( name "galactictrooper.p" size 4269 crc AE87F0A7 md5 74661343C5098F10BF44FDF40DC02F04 sha1 E6BA889B1F3D97366CC829D07E9D13FD665D40F5 )
+)
+
+game (
+  name "Galaxians (Artic)"
+  description "Galaxians (Artic)"
+  manufacturer "Artic"
+  rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
+)
+
+game (
+  name "Galaxians (Artic)"
+  description "Galaxians (Artic)"
+  manufacturer "Artic"
+  rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
+)
+
+game (
+  name "Galaxians (Monochrome) (Artic)"
+  description "Galaxians (Monochrome) (Artic)"
+  manufacturer "Artic"
+  rom ( name "Galaxians.tzx" size 3788 crc 1CB67CB3 md5 D81A74C24C6E4B923D3CDE71B05EE5E0 sha1 8BEC4C27D81DA870A63EE5DA3205855C27ACB802 )
+)
+
+game (
+  name "Galaxians (Monochrome) (Artic)"
+  description "Galaxians (Monochrome) (Artic)"
+  manufacturer "Artic"
+  rom ( name "galaxians.p" size 3562 crc B5FC1488 md5 EF30971AD58C33FE200BB36F95470350 sha1 190A30B1B54C09E681B8F07C196999E80105DA98 )
+)
+
+game (
+  name "Galaxy Invaders (International Publishing and Software Inc.)"
+  description "Galaxy Invaders (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "GalaxyInvaders(IPS).tzx" size 4224 crc 6DF4E24B md5 490E79F413DCB97060633218E014A62F sha1 23FC85B7E2ECFACD664DC991ACF7E56393A345A1 )
+)
+
+game (
+  name "Galaxy Invaders (International Publishing and Software Inc.)"
+  description "Galaxy Invaders (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "galaxyinvaders(ips).p" size 4002 crc 4328BEBA md5 FB94065D6C8B3A4AA2F12A7D015E569D sha1 1BB9B928230DE4AB517BF8B248A687C94C3DF639 )
+)
+
+game (
+  name "Galaxy Jailbreak (Romik Software)"
+  description "Galaxy Jailbreak (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "galaxyjailbreak.p" size 5413 crc AE762991 md5 6493AC3CD7C77BE6027BC00C3932C68C sha1 AEB080263F016D94BF0A13FF521BBC30D7032686 )
+)
+
+game (
+  name "Galaxy Jailbreak (Romik Software)"
+  description "Galaxy Jailbreak (Romik Software)"
+  year "1983"
+  manufacturer "Roland Stokes"
+  rom ( name "GalaxyJailbreak.tzx" size 5661 crc 8F630CE4 md5 F1CEB2D7E0CEE7CB924A0B824DBF418B sha1 351DCE4FF4D8D3DCC68508B39BB910B21CECFB84 )
+)
+
+game (
+  name "Galaxy Warrior/Star Trek (Artic)"
+  description "Galaxy Warrior/Star Trek (Artic)"
+  manufacturer "Artic"
+  rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1BCB3A5F md5 FFF5135CA3AC8C8553E9EACE62D55667 sha1 ABFB5609BFA713C2F4841BC45BA11EB7363B6BF7 )
+)
+
+game (
+  name "The Gambler (Timex)"
+  description "The Gambler (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "GamblerThe.tzx" size 19202 crc E05A3062 md5 EA6C404AF8FC06091341E038643A85A6 sha1 61DA0728B3850A4235D13B1A71E7BB0E339FAC63 )
+)
+
+game (
+  name "Games Pack (JRS Software)"
+  description "Games Pack (JRS Software)"
+  year "1982"
+  manufacturer "JRS Software"
+  rom ( name "GamesPack.tzx" size 20187 crc 4C92529E md5 893ED24F30DBBA822DC001B87750B873 sha1 EB8AEC55C92FC530591E033C862CE3B95C40A149 )
+)
+
+game (
+  name "The Gauntlet (Colourmatic)"
+  description "The Gauntlet (Colourmatic)"
+  year "1982"
+  manufacturer "Colourmatic"
+  rom ( name "gauntletthe.p" size 14411 crc AE7D6FEC md5 B0F5118CDB2D11510AE8A9F6CD735225 sha1 4B1AD35595A0DDD772A3FACC1F0C57499030D69A )
+)
+
+game (
+  name "The Gauntlet (Colourmatic)"
+  description "The Gauntlet (Colourmatic)"
+  year "1982"
+  manufacturer "Colourmatic"
+  rom ( name "GauntletThe.tzx" size 14643 crc 7DE2E0A3 md5 90C561D24D267DD43E349EED180FE51D sha1 49E714E58E9725925B28F8E17D90C708961064B5 )
+)
+
+game (
+  name "The Gauntlet (PSS) (PSS)"
+  description "The Gauntlet (PSS) (PSS)"
+  year "1984"
+  manufacturer "Colourmatic"
+  rom ( name "gauntletthe(pss).p" size 14561 crc F8F47BBF md5 C0F5783184D967260C7D8E4A0B027850 sha1 27B343C7B034563FF4C5218AE6FFA8E190B7313F )
+)
+
+game (
+  name "The Gauntlet (PSS) (PSS)"
+  description "The Gauntlet (PSS) (PSS)"
+  year "1984"
+  manufacturer "Colourmatic"
+  rom ( name "GauntletThe(PSS).tzx" size 14793 crc 076726DD md5 F4AD5284A8D7ECA0E7E7E564131B3B6B sha1 3756C65AC420104C97A01317CDF156C2F412A2DF )
+)
+
+game (
+  name "General Statistics (W. H. Smith)"
+  description "General Statistics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "GeneralStatistics.tzx" size 14466 crc 8889D5E3 md5 ACF9669F43AF8B165CDA56888E9A1348 sha1 A1F94C7CA3A27E24EBFABA575700CFCCF8640356 )
+)
+
+game (
+  name "General Statistics (W. H. Smith)"
+  description "General Statistics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "generalstatistics.p" size 14214 crc 10C6EF87 md5 A779367A54AD8AC03543A2D70C2E88E1 sha1 F65E699472236439C262640299628CB01284223E )
+)
+
+game (
+  name "Geographics UK (Novus Software)"
+  description "Geographics UK (Novus Software)"
+  manufacturer "Novus"
+  rom ( name "GeographicsUK.tzx" size 16281 crc 4AF3CFC9 md5 4534B531E811C27A32EFFAA76A9A257E sha1 0D88E5BC5E71CC898A375156E40396B5B536D7A0 )
+)
+
+game (
+  name "Geographics UK (Novus Software)"
+  description "Geographics UK (Novus Software)"
+  manufacturer "Novus"
+  rom ( name "geographicsuk.p" size 16037 crc FBC771BF md5 FEA62F9B738C3F63CF9DE62A37431588 sha1 FB07EBDDCA1F03EEF2B4D06052D4ABDE520D4AE0 )
+)
+
+game (
+  name "Geometry 1 (Timex)"
+  description "Geometry 1 (Timex)"
+  year "1982"
+  manufacturer "Home Computer Software"
+  rom ( name "Geometry1.tzx" size 5483 crc 80DAD6C4 md5 D8C843396EA93E08A986ED3EC74A1B53 sha1 BE9373F6519A369E7D2DBA40A14319F4751B1B78 )
+)
+
+game (
+  name "Ghost Hunt (PSS)"
+  description "Ghost Hunt (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "GhostHunt.tzx" size 5538 crc 8E8D76F5 md5 C3B97B5345EA55BDC8C6307EE40F21B2 sha1 33AC921BE892A02C115F7DFA73C54CAFE178671B )
+)
+
+game (
+  name "Ghost Hunt (PSS)"
+  description "Ghost Hunt (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "ghosthunt.p" size 5302 crc DEA898BD md5 DC3E16535DCF3395085A311DECC1D8E5 sha1 DA84C5B1E1E7CB26EBDBAA119A4E0F29F9E4EF4F )
+)
+
+game (
+  name "Gobbleman (Monochrome Inlay) (Artic)"
+  description "Gobbleman (Monochrome Inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
+)
+
+game (
+  name "Gobbleman (Colour Inlay) (Artic)"
+  description "Gobbleman (Colour Inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "gobbleman.p" size 4014 crc F834B214 md5 F55862BE05B018EA8BB62590DFE5AF5C sha1 A44E9611539D65664B6277C163436BF0AC0513D4 )
+)
+
+game (
+  name "Gobblers (Software Farm)"
+  description "Gobblers (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "gobblers.p" size 7162 crc B7687E93 md5 CB4CFA5B341C3D129405A82D97BC84BF sha1 FC15194E2CD43C8ED2121BC76331313532BD49DA )
+)
+
+game (
+  name "Gobblers (Software Farm)"
+  description "Gobblers (Software Farm)"
+  manufacturer "Software Farm"
+  rom ( name "Gobblers.tzx" size 7394 crc DAFE76E1 md5 8DE20A364CA8693EB9C755A7DA120189 sha1 681BD965A868D25B3DED5C9111C6F6A622A7DF1E )
+)
+
+game (
+  name "Gold (Hilderbay)"
+  description "Gold (Hilderbay)"
+  year "1981"
+  manufacturer "Hilderbay"
+  rom ( name "Gold.tzx" size 23791 crc A280FCBA md5 6824A18251ADF4CAE7CA49EA6F04D865 sha1 33C0ACAC2F430CC9884739426E287098D646BD92 )
+)
+
+game (
+  name "Golf (R & R Software)"
+  description "Golf (R & R Software)"
+  year "1982"
+  manufacturer "R & R Software"
+  rom ( name "Golf.tzx" size 9468 crc 1B658FAB md5 01ADE7A91BD9F70953004CB25D9E1D88 sha1 3177BEA82297A86A2C5C541CDE8426FFF95CC052 )
+)
+
+game (
+  name "Golf (R & R Software)"
+  description "Golf (R & R Software)"
+  year "1982"
+  manufacturer "R & R Software"
+  rom ( name "golf.p" size 9244 crc BDC6FF4E md5 761909F603CEAA4FB32BDFC288FBB19E sha1 0ADD3B45B1A4A246DDB24CE1D3EEA288032F8D99 )
+)
+
+game (
+  name "Graphics Kit (Softsync)"
+  description "Graphics Kit (Softsync)"
+  year "1981"
+  manufacturer "Paul Holmes"
+  rom ( name "GraphicsKit.tzx" size 6203 crc 0E978F07 md5 53AC6583CA184C362108642E40F086CD sha1 2E26B56A9895655424D29D23D2836C28B0A26226 )
+)
+
+game (
+  name "Great Britain Ltd (Simon W. Hessel)"
+  description "Great Britain Ltd (Simon W. Hessel)"
+  manufacturer "Simon W. Hessel"
+  rom ( name "greatbritainltd.p" size 15541 crc 23AD347C md5 E4B1812BD16EA7CFDD416E932467E4D4 sha1 8EAFC58C5610B3901B85478DA04D25156F00BFF1 )
+)
+
+game (
+  name "Great Britain Ltd (Simon W. Hessel)"
+  description "Great Britain Ltd (Simon W. Hessel)"
+  manufacturer "Simon W. Hessel"
+  rom ( name "GreatBritainLtd.tzx" size 15767 crc 4B717923 md5 07BFF59AB86D31689CF4450D21F3741D sha1 BBDE7B36F9F2CB65CD0EF2F112C52CE612A19433 )
+)
+
+game (
+  name "Grimm's Fairy Trails (Timex)"
+  description "Grimm's Fairy Trails (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "grimmsfairytrails.p" size 9331 crc AD7E74E0 md5 BDEA9F593D45946FA07521844B0DD51E sha1 EE1B726655BFD5E897DA2AF3888F3C8545D85B99 )
+)
+
+game (
+  name "Grimm's Fairy Trails (Timex)"
+  description "Grimm's Fairy Trails (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "GrimmsFairyTrails.tzx" size 9563 crc 55FE8F96 md5 2ED795D94CAA50CD02CF68475E01AEF5 sha1 CB65770BE85ADD8B3AA5E01CECACC3B2B2835ECB )
+)
+
+game (
+  name "Guitar For Beginners (Timex)"
+  description "Guitar For Beginners (Timex)"
+  year "1982"
+  manufacturer "Tim Rossetti"
+  rom ( name "GuitarForBeginners.tzx" size 11246 crc 10734BFB md5 69EDFC6FCF6F8B26D2907AA32E3C5669 sha1 975DECA435C26ED3E0604497454129186E139307 )
+)
+
+game (
+  name "Guitar For Beginners (Timex)"
+  description "Guitar For Beginners (Timex)"
+  year "1982"
+  manufacturer "Tim Rossetti"
+  rom ( name "guitarforbeginners.p" size 11018 crc 73AF3C6D md5 FB35ABB3BCE84CD543E1BB9D46F65C82 sha1 97ADFD80A6ABB57717469A3FDAF17F7A160793F2 )
+)
+
+game (
+  name "Gulp (Mindware)"
+  description "Gulp (Mindware)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "Gulp(Mindware).1.Gulp.tzx" size 1125 crc C651F1E5 md5 E342F3FCC020D8AFD4BF4A496CA75F75 sha1 C91C14F5EC001C991ED3C67673FE38C8B7B9D02D )
+)
+
+game (
+  name "Gulp (Mindware)"
+  description "Gulp (Mindware)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "gulp.p" size 901 crc BE88DF61 md5 338AF799286FEE95CA3F1131A2C00BAC sha1 FBBE0822184C0A4594C5932358EDCFBE3DF4E7BE )
+)
+
+game (
+  name "Gulp 2 (Campbell Systems)"
+  description "Gulp 2 (Campbell Systems)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "gulp2.p" size 6116 crc 1BFD713D md5 C7DB6F6ED8CBA0F14AA92DF6D55F93A7 sha1 2399DFF41D799578005AD8B23CC5086E120971E0 )
+)
+
+game (
+  name "Gulp 2 (Campbell Systems)"
+  description "Gulp 2 (Campbell Systems)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "Gulp2.tzx" size 6342 crc B041F1BF md5 7C1BE7D5A5B5D0F65DAFDD2A0F252A2D sha1 AA0FADD80146C2DAB98DAB49C88F52BA4852C861 )
+)
+
+game (
+  name "Gulpman (Micromega)"
+  description "Gulpman (Micromega)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "Gulpman.tzx" size 6351 crc 7BAEBE9A md5 E47F73D6AADF86310E6379A22A7D6B7A sha1 D28C22863672B87A1F0F6B23F2262B0195B3E1FB )
+)
+
+game (
+  name "Gulpman (Micromega)"
+  description "Gulpman (Micromega)"
+  year "1982"
+  manufacturer "Campbell Systems"
+  rom ( name "gulpman.p" size 6121 crc 74A38569 md5 3EF8B687B566F338A2C672133E638379 sha1 9551CFDF7D738E0DB679F08B35B72724D2F5A7A2 )
+)
+
+game (
+  name "HRG 7.0 (Unknown)"
+  description "HRG 7.0 (Unknown)"
+  year "1983"
+  manufacturer "J. M. Cohen"
+  rom ( name "HRG70.tzx" size 19444 crc 75ADEE54 md5 EEC31C8470C05281F4E8C957E56889D3 sha1 9F062EA8B3BD11A868A773DD4FED573A51225A1E )
+)
+
+game (
+  name "Haute Resolution (Pluto)"
+  description "Haute Resolution (Pluto)"
+  year "1984"
+  manufacturer "CRL"
+  rom ( name "HauteResolution.tzx" size 6970 crc F52D460F md5 42186664D3F698C0EDE72A2B0C2AB398 sha1 91CD6738FCEC38D4FC9D3E3BA08614634935918A )
+)
+
+game (
+  name "Heating System Analyzer (Timex)"
+  description "Heating System Analyzer (Timex)"
+  year "1982"
+  manufacturer "Tim Rossetti"
+  rom ( name "HeatingSystemAnalyzer.tzx" size 15718 crc EA836C43 md5 29FA5B64D2C89DE8A19C0F678C6B2C94 sha1 9D5E5A4F1E26F6A5DBA03028940310BB796DA199 )
+)
+
+game (
+  name "Heating System Analyzer (Timex)"
+  description "Heating System Analyzer (Timex)"
+  year "1982"
+  manufacturer "Tim Rossetti"
+  rom ( name "heatingsystemanalyzer.p" size 15494 crc 17D05FC2 md5 8B2ACEADFBB20F65C305CDEAEA598262 sha1 087D0E4680643E6D9E808CCE10C918E58D3C72AB )
+)
+
+game (
+  name "High Res (Macronics)"
+  description "High Res (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "highres.p" size 10763 crc E37BAD7F md5 493817D98B6D96356DF1E1C3F93866E9 sha1 D817B3DB8F0065843E3B3D7EB4E55B673C08DE03 )
+)
+
+game (
+  name "High Res (Macronics)"
+  description "High Res (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "HighRes.tzx" size 10985 crc FA40DBC1 md5 F48465678582D4FD7BD8325DDEDE7788 sha1 9B81B10A719AF4C6C61A03ED003F1198F68BDA1B )
+)
+
+game (
+  name "The Home Asset Manager (Timex)"
+  description "The Home Asset Manager (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "homeassetmanagerthe.p" size 14886 crc 20B3E57E md5 9B8CB2A6F3192DB3DD54C6DE1AB895DC sha1 2BFD33290AC86115BBD77E00CA1617F3AAB588EA )
+)
+
+game (
+  name "The Home Asset Manager (Timex)"
+  description "The Home Asset Manager (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "HomeAssetManagerThe.tzx" size 15112 crc FD728104 md5 9EAD11C52ED50477589A292313FAA4B9 sha1 E19508787E6EDE4EC4323DF540DD7516B49B295D )
+)
+
+game (
+  name "The Home Improvement Planner (Timex)"
+  description "The Home Improvement Planner (Timex)"
+  year "1982"
+  manufacturer "K. Frink"
+  rom ( name "homeimprovementplannerthe.p" size 15647 crc F3A473A6 md5 D966246149AB479D02FE07DEBB61FCD5 sha1 3536D7CD6538E0CE71B00CB9D8166303114D769D )
+)
+
+game (
+  name "The Home Improvement Planner (Timex)"
+  description "The Home Improvement Planner (Timex)"
+  year "1982"
+  manufacturer "K. Frink"
+  rom ( name "HomeImprovementPlannerThe.tzx" size 15871 crc 4E4DF58C md5 15D4996825631A65404BCBEBB7358E09 sha1 45E98DB0F02643A37ED71B86A85042A331B9AAC1 )
+)
+
+game (
+  name "Hopper (PSS)"
+  description "Hopper (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "Hopper.tzx" size 11061 crc F5601550 md5 30ED7CC222C8A94447629233BB357832 sha1 4102DBFE6C3CDDB82877BB9B089F764420F0A249 )
+)
+
+game (
+  name "Hopper (PSS)"
+  description "Hopper (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "hopper.p" size 10833 crc 965D961A md5 F76D900361978E5A354569718C918783 sha1 9E5B1E824F492A88999C023646486A9620E1C89F )
+)
+
+game (
+  name "Hopper (Truck) (PSS)"
+  description "Hopper (Truck) (PSS)"
+  year "1981"
+  manufacturer "PSS"
+  rom ( name "hopper(truck).p" size 10833 crc 343EC159 md5 E49392779795505C5E776A86BB27DE9B sha1 347965BC2AB0003C295C1005E89CDE7053DD7040 )
+)
+
+game (
+  name "Hopper (Truck) (PSS)"
+  description "Hopper (Truck) (PSS)"
+  year "1981"
+  manufacturer "PSS"
+  rom ( name "Hopper(Truck).tzx" size 11061 crc 57034213 md5 ECC9DA3396BA5F0EEE543E3915A3AB8D sha1 5747373BE057F05059C47D8ACB42F2C9312EEB83 )
+)
+
+game (
+  name "House of Death (A. J. Rushton)"
+  description "House of Death (A. J. Rushton)"
+  manufacturer "A. J. Rushton"
+  rom ( name "HouseOfDeath.tzx" size 15289 crc E78272E3 md5 68FB7BFD61E73901337800B912DB3760 sha1 80EE47DD77A43C051C600A38DEF525950A110119 )
+)
+
+game (
+  name "House of Death (A. J. Rushton)"
+  description "House of Death (A. J. Rushton)"
+  manufacturer "A. J. Rushton"
+  rom ( name "houseofdeath.p" size 15045 crc D88C206A md5 89E832D5035229BCFE30A9D77A0242A9 sha1 962346B1F5E5D9F8C025994824736AC497BE1EA2 )
+)
+
+game (
+  name "The IRA Planner (Timex)"
+  description "The IRA Planner (Timex)"
+  year "1982"
+  manufacturer "Vincent H. Chase"
+  rom ( name "IRAPlannerThe.tzx" size 16247 crc AD9F1B1C md5 73D76E80FE78E640708645B14E6DAC88 sha1 74F585B9673B45307F59019F5D03E324FFEDFB8C )
+)
+
+game (
+  name "Adventure B - Inca Curse (Sinclair Research)"
+  description "Adventure B: Inca Curse (Sinclair Research)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "incacurse.p" size 11975 crc E37CDDD8 md5 736FD7C4C8854760206A05361299FAF1 sha1 ACB41012D467F473CB452F3CF1ACB8608F108725 )
+)
+
+game (
+  name "Adventure B - Inca Curse (Sinclair Research)"
+  description "Adventure B: Inca Curse (Sinclair Research)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "IncaCurse.tzx" size 12205 crc 700A1E34 md5 438603D7EAED102378AF94260A15BE1A sha1 8948F63C75C80DFFA4E317E4D8ED400BD6B11DE9 )
+)
+
+game (
+  name "Adventure B - Inca Curse (Artic)"
+  description "Adventure B: Inca Curse (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "IncaCurse(Artic).tzx" size 12205 crc 76D699E6 md5 15459A76AF72151AF7309C00FF13ABAE sha1 C3840C1539239437150D7E300B0BAE412AD6A987 )
+)
+
+game (
+  name "Adventure B - Inca Curse (Artic)"
+  description "Adventure B: Inca Curse (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "incacurse(artic).p" size 11975 crc E5A05A0A md5 E24F9EA9C889A9587479085276980FA1 sha1 B1B85676ADE56E51488F2262EE60FACC22989967 )
+)
+
+game (
+  name "Introduction To Chemistry (Timex)"
+  description "Introduction To Chemistry (Timex)"
+  year "1983"
+  manufacturer "J. J. Hollandsworth"
+  rom ( name "IntroductionToChemistry.tzx" size 37232 crc 7B7D1B69 md5 F7C95B6D075D662664527EFC3FC842D0 sha1 4A49F3C842E387DD1353DC859877B93C92AA8ACE )
+)
+
+game (
+  name "Invaders (Bug Byte)"
+  description "Invaders (Bug Byte)"
+  year "1982"
+  manufacturer "S. Munnery"
+  rom ( name "Invaders.tzx" size 2605 crc 93D1D5D7 md5 1D391665FB5734A2B274E2C9630D35F7 sha1 BB79A0EA9FF54E882D45A7CA94DC71762488B2CD )
+)
+
+game (
+  name "Invaders (Bug Byte)"
+  description "Invaders (Bug Byte)"
+  year "1982"
+  manufacturer "S. Munnery"
+  rom ( name "invaders.p" size 2373 crc 3B79C6AC md5 E3CD419E7F34DBFC4EFD9B4C8E0A7633 sha1 8683FD832959844FB6357FD272DCDE5ECE0A601D )
+)
+
+game (
+  name "Invaders (A. G. Software)"
+  description "Invaders (A. G. Software)"
+  manufacturer "Andrew Glaister"
+  rom ( name "Invaders(AGS).tzx" size 2349 crc 58299C24 md5 6A329B8B6BDCA462DC2564297FB425F2 sha1 37503B2C552016A3265FF387AFCA6FFA6380C5E8 )
+)
+
+game (
+  name "Invaders (A. G. Software)"
+  description "Invaders (A. G. Software)"
+  manufacturer "Andrew Glaister"
+  rom ( name "invaders(ags).p" size 2117 crc 134835D7 md5 B2CB96DEB94F2CAF1167C6AA9EED3C35 sha1 125D09E68F9AD9490B47ADEE512BF46DB7286C2A )
+)
+
+game (
+  name "Invaders (Re-release) (Bug Byte)"
+  description "Invaders (Re-release) (Bug Byte)"
+  year "1982"
+  manufacturer "S. Munnery"
+  rom ( name "Invaders(Alt).tzx" size 2605 crc E2B37050 md5 8886052187AD052BD05D2CB8E6D2A713 sha1 C5A9F1683D2730EAF40A879C0F5C676B5F718E03 )
+)
+
+game (
+  name "Invaders (Re-release) (Bug Byte)"
+  description "Invaders (Re-release) (Bug Byte)"
+  year "1982"
+  manufacturer "S. Munnery"
+  rom ( name "invaders(alt).p" size 2373 crc 4A1B632B md5 119058DBC93BB2AC6A7E804A878F03CC sha1 6BEB1369D7F96B83092CD84C0E32FE2AD786C2AC )
+)
+
+game (
+  name "Invaders (Forward Software)"
+  description "Invaders (Forward Software)"
+  manufacturer "Silversoft"
+  rom ( name "Invaders(Forward).tzx" size 3697 crc 3EA98BB5 md5 B52FECD042DA1349D326508F77D3DB33 sha1 A8AE592FE3B4B939B664BE00454FB591B004F478 )
+)
+
+game (
+  name "Invaders (Forward Software)"
+  description "Invaders (Forward Software)"
+  manufacturer "Silversoft"
+  rom ( name "invaders(forward).p" size 3465 crc 7005EDA5 md5 0E940CD5D0FAB16B860C1E5648EA7B8A sha1 425223961FDB8C2825796B99BBC5358E51BF9B14 )
+)
+
+game (
+  name "Invaders (Monochrome) (Bug Byte)"
+  description "Invaders (Monochrome) (Bug Byte)"
+  manufacturer "S. Munnery"
+  rom ( name "invaders(mono).p" size 2373 crc 2840348B md5 1B95516181A57DA16F56109CC87CFD94 sha1 1971694D7A009402C065F5D23CEC3AD847839232 )
+)
+
+game (
+  name "Invaders (Monochrome) (Bug Byte)"
+  description "Invaders (Monochrome) (Bug Byte)"
+  manufacturer "S. Munnery"
+  rom ( name "Invaders(Mono).tzx" size 2605 crc 80E827F0 md5 186D39211398BDBB5497D1BA89DF5AB9 sha1 3AEB0FA4A5C458ACE0AFFC01F528D4B15EE047B8 )
+)
+
+game (
+  name "Invaders (Typed Inlay) (Bug Byte)"
+  description "Invaders (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "S. Munnery"
+  rom ( name "Invaders(Typed).tzx" size 2605 crc 4647C030 md5 C6DBCED1C948E5322109052583789338 sha1 A3669F5CE7897E144314B0A4EA5E3E1B79CFF5EF )
+)
+
+game (
+  name "Invaders (Typed Inlay) (Bug Byte)"
+  description "Invaders (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "S. Munnery"
+  rom ( name "invaders(typed).p" size 2373 crc EEEFD34B md5 F426DF7408433E814F04CF3909A5A2F5 sha1 5FF6048270FDD16665EB1B1169F2F026C84A3B24 )
+)
+
+game (
+  name "Invasion Force (Artic)"
+  description "Invasion Force (Artic)"
+  year "1982"
+  manufacturer "Simon Wadsworth"
+  rom ( name "InvasionForce.tzx" size 7890 crc 84B20542 md5 C38EC3F7BABA880DCB937E9419956A22 sha1 3BF53649FDF8249FDB8A601BB7AE7DBBB38B08DE )
+)
+
+game (
+  name "Invasion Force (Artic)"
+  description "Invasion Force (Artic)"
+  year "1982"
+  manufacturer "Simon Wadsworth"
+  rom ( name "invasionforce.p" size 7658 crc A997EF38 md5 111B625CEFAE5439236A45013066A7AE sha1 6A3516B9127E8345A56C076990A9FFB7BF5834E7 )
+)
+
+game (
+  name "Invasion Force (International Publishing and Software Inc.)"
+  description "Invasion Force (International Publishing and Software Inc.)"
+  year "1983"
+  manufacturer "Simon Wadsworth"
+  rom ( name "InvasionForce(IPS).tzx" size 7890 crc C7842B97 md5 4C05EBB64D88D13EC859403F5C7F2B1E sha1 3B59F5A004F92D081181834AA59073BA74B47909 )
+)
+
+game (
+  name "Invasion Force (International Publishing and Software Inc.)"
+  description "Invasion Force (International Publishing and Software Inc.)"
+  year "1983"
+  manufacturer "Simon Wadsworth"
+  rom ( name "invasionforce(ips).p" size 7658 crc EAA1C1ED md5 C38F1C2548052873D8FBFF20F67A29DD sha1 39EBCEAFC98F2A8A7B2B4EB5CB35B4E2A4B34ADF )
+)
+
+game (
+  name "Inventory Control (Data-assette)"
+  description "Inventory Control (Data-assette)"
+  manufacturer "John Powers"
+  rom ( name "InventoryControl(DA).tzx" size 16175 crc 21D56EC5 md5 BFADCA8523ED9926C47C20B04E980289 sha1 390707E52E816A1DF284B65CE1FD52E14110A504 )
+)
+
+game (
+  name "Inventory Control (Data-assette)"
+  description "Inventory Control (Data-assette)"
+  manufacturer "John Powers"
+  rom ( name "inventorycontrol(da).p" size 15941 crc EB911B8B md5 2E9C7B2134665A0FA235764E75CC2957 sha1 4F63DB3C39FF4AABB3E0661500095F0C69DAB41D )
+)
+
+game (
+  name "J.D.Arcades (Computer Rentals)"
+  description "J.D.Arcades (Computer Rentals)"
+  year "1982"
+  manufacturer "John Davies"
+  rom ( name "jdarcades.p" size 8548 crc E7EA958D md5 E555EF74EC2F6346B82B363C24D97C96 sha1 7D47EC7D6670D7009CF6D059FE50C730E068D891 )
+)
+
+game (
+  name "J.D.Arcades (Computer Rentals)"
+  description "J.D.Arcades (Computer Rentals)"
+  year "1982"
+  manufacturer "John Davies"
+  rom ( name "JDArcades.tzx" size 8782 crc 6FB5F451 md5 E4AB3D1820711EB5B96DCD106694AA1D sha1 08C17DC95D0A7E8A68FB9B534398D45656E25EA5 )
+)
+
+game (
+  name "Kasino Kraps (Timex)"
+  description "Kasino Kraps (Timex)"
+  year "1983"
+  manufacturer "Gerald Bennett"
+  rom ( name "kasinokraps.p" size 12557 crc F041256F md5 DEDAB418C1EE0B2E03200ACF878164F3 sha1 C782994290DA3A40A82433718FB877A59FCD771B )
+)
+
+game (
+  name "Kasino Kraps (Timex)"
+  description "Kasino Kraps (Timex)"
+  year "1983"
+  manufacturer "Gerald Bennett"
+  rom ( name "KasinoKraps.tzx" size 12777 crc 7E27AD21 md5 32A434E44B75CFEEDF737A25E4D22AE0 sha1 39950E34A01E852C6DF5FB06E59DFAE019D54E90 )
+)
+
+game (
+  name "Keyboard Calculator (Timex)"
+  description "Keyboard Calculator (Timex)"
+  year "1982"
+  manufacturer "J. Gishen"
+  rom ( name "KeyboardCalculator.tzx" size 6160 crc 56B36255 md5 781D98F620DB9510336788EB8FF310EA sha1 064ABD828A4D801E1E2029234762F6AADCBA008E )
+)
+
+game (
+  name "Keys To Gondrun (International Publishing and Software Inc.)"
+  description "Keys To Gondrun (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "KeysToGondrun.tzx" size 15928 crc 97E9AC6D md5 9D45DCB3C159FFB5396641C88E7E5196 sha1 38C82913732383AE4FAE62DD1BE8F5A04927CDFD )
+)
+
+game (
+  name "Keys To Gondrun (International Publishing and Software Inc.)"
+  description "Keys To Gondrun (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "keystogondrun.p" size 15704 crc F8340D3B md5 AACA5C9EB8AE112EB41D7A3B99E93A6B sha1 639D2EB5931FD7B874D0CA9B1374BCE68971DED6 )
+)
+
+game (
+  name "Kingdom of Nam (Microgame Simulations)"
+  description "Kingdom of Nam (Microgame Simulations)"
+  year "1981"
+  manufacturer "R. Erskine"
+  rom ( name "KingdomOfNam.tzx" size 8202 crc CA57C0C9 md5 5D075C2EA9428E0C2D3B09597056D810 sha1 D5C07352365144B1F0C9EB4C89A3F854747B7A90 )
+)
+
+game (
+  name "Kingdom of Nam (Microgame Simulations)"
+  description "Kingdom of Nam (Microgame Simulations)"
+  year "1981"
+  manufacturer "R. Erskine"
+  rom ( name "kingdomofnam.p" size 7958 crc A997242D md5 ECCAD4F7E6CA9806B1D2976970EE39FD sha1 718235CFDDAFACFDF7276438614712042488ECF5 )
+)
+
+game (
+  name "The Knight's Quest (Phipps Associates)"
+  description "The Knight's Quest (Phipps Associates)"
+  year "1983"
+  manufacturer "Mike Farley"
+  rom ( name "KnightsQuest.tzx" size 52909 crc 2BCEDB3F md5 BB390C8D2BD1CED32C6E0A739DAECDB3 sha1 CE182BF32766964CA43066727475EADBAA6A8D1A )
+)
+
+game (
+  name "Kongs Revenge (Stephen Hartley Computing)"
+  description "Kongs Revenge (Stephen Hartley Computing)"
+  year "1984"
+  manufacturer "I. Kendrick"
+  rom ( name "KongsRevenge.tzx" size 14843 crc CC315ACA md5 C82FD9679EE58446A0C54271E2F56287 sha1 C87D1A7F00CCA913B0D9BDBE8A8752E82C72FD6C )
+)
+
+game (
+  name "Kongs Revenge (Stephen Hartley Computing)"
+  description "Kongs Revenge (Stephen Hartley Computing)"
+  year "1984"
+  manufacturer "I. Kendrick"
+  rom ( name "kongsrevenge.p" size 14601 crc DAF31C48 md5 A88F23545D67709D83D214EFC9344173 sha1 6915C841A5AF606E7E0A0198EFEC07AED4C8CB91 )
+)
+
+game (
+  name "Kongs Revenge (Stephen Hartley Computing)"
+  description "Kongs Revenge (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. Kendrick"
+  rom ( name "kongsrevenge.p" size 14601 crc DAF31C48 md5 A88F23545D67709D83D214EFC9344173 sha1 6915C841A5AF606E7E0A0198EFEC07AED4C8CB91 )
+)
+
+game (
+  name "Kongs Revenge (Stephen Hartley Computing)"
+  description "Kongs Revenge (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. Kendrick"
+  rom ( name "KongsRevenge.tzx" size 14843 crc CC315ACA md5 C82FD9679EE58446A0C54271E2F56287 sha1 C87D1A7F00CCA913B0D9BDBE8A8752E82C72FD6C )
+)
+
+game (
+  name "Krazy Kong (PSS)"
+  description "Krazy Kong (PSS)"
+  year "1982"
+  manufacturer "C. P. Cullen"
+  rom ( name "krazykong.p" size 8229 crc E5E30579 md5 FEA1DD4EDF42F770255B5D90D6DA9CFF sha1 0BBEE2723AAA7A2758B5394D2AD269FFC561EDE8 )
+)
+
+game (
+  name "Krazy Kong (PSS)"
+  description "Krazy Kong (PSS)"
+  year "1982"
+  manufacturer "C. P. Cullen"
+  rom ( name "KrazyKong.tzx" size 8465 crc A5DD2AFE md5 4DF17878870A7BC5B63FA607C8EB4C36 sha1 AC74298BADC343B3C81A96FCA8BCAB1B43FAAD87 )
+)
+
+game (
+  name "Krazy Kong (Intercomputer Inc)"
+  description "Krazy Kong (Intercomputer Inc)"
+  year "1983"
+  manufacturer "C. P. Cullen"
+  rom ( name "KrazyKong(Inter).tzx" size 7799 crc D5A3DDD8 md5 B355C229F453610568AB040EA9CEBB5E sha1 1E4EDF41F7A576A8B68ECFAAB4F936BA80460360 )
+)
+
+game (
+  name "Krazy Kong (Intercomputer Inc)"
+  description "Krazy Kong (Intercomputer Inc)"
+  year "1983"
+  manufacturer "C. P. Cullen"
+  rom ( name "krazykong(inter).p" size 7563 crc AD4FE8FF md5 C1AAF449BDC105EE2CCD74DE7BA82EC5 sha1 554D1D5B991C9A221183DD6F6067E41C77746D7B )
+)
+
+game (
+  name "Labyrinth (Axis)"
+  description "Labyrinth (Axis)"
+  year "1981"
+  manufacturer "Axis"
+  rom ( name "Labyrinth.tzx" size 10956 crc 2BD7DD50 md5 25EB8D058AB8AEB9D5CE8FF64DFCC0D8 sha1 2CE0F07C10363839828A54FB00FB278F1ED5AEAC )
+)
+
+game (
+  name "Labyrinth (Axis)"
+  description "Labyrinth (Axis)"
+  year "1981"
+  manufacturer "Axis"
+  rom ( name "labyrinth.p" size 10722 crc 46400A6F md5 0A3F962C532CB046D7A71998CC29D412 sha1 8AD0DF41D206AD534AEED2BE3FE208BB00F99BB6 )
+)
+
+game (
+  name "Labyrinth (Colour Inlay) (Axis)"
+  description "Labyrinth (Colour Inlay) (Axis)"
+  year "1981"
+  manufacturer "Axis"
+  rom ( name "labyrinth.p" size 10722 crc 46400A6F md5 0A3F962C532CB046D7A71998CC29D412 sha1 8AD0DF41D206AD534AEED2BE3FE208BB00F99BB6 )
+)
+
+game (
+  name "Labyrinth (Colour Inlay) (Axis)"
+  description "Labyrinth (Colour Inlay) (Axis)"
+  year "1981"
+  manufacturer "Axis"
+  rom ( name "Labyrinth.tzx" size 10956 crc 2BD7DD50 md5 25EB8D058AB8AEB9D5CE8FF64DFCC0D8 sha1 2CE0F07C10363839828A54FB00FB278F1ED5AEAC )
+)
+
+game (
+  name "Language Usage (Timex)"
+  description "Language Usage (Timex)"
+  year "1982"
+  manufacturer "Software for Excellence"
+  rom ( name "LanguageUsage.tzx" size 43685 crc F83BA0CD md5 81F643D82C2F273248421F15F4E8F91B sha1 8892AAC163FEB54128EE568636C905C0CB18E7E5 )
+)
+
+game (
+  name "Lap Record (Macronics)"
+  description "Lap Record (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "laprecord.p" size 4895 crc 13522B1E md5 4E017F1D09E8CD51B3B3656B5C1EFDFA sha1 5091EAF17D8816A7766811F0D57EA54611825670 )
+)
+
+game (
+  name "Lap Record (Macronics)"
+  description "Lap Record (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "LapRecord.tzx" size 5115 crc 4AB33041 md5 075644FA16A629B4B732265C9129998C sha1 28D2A56BC5974BED6E848A495367140893F35EB1 )
+)
+
+game (
+  name "The List Manager (Timex)"
+  description "The List Manager (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "ListManagerThe.tzx" size 29918 crc 9DF64F46 md5 7994115109D17648490EFB35403448B0 sha1 F3FED91B2947D49A6D85C26797F46366BA614769 )
+)
+
+game (
+  name "The Loan/Mortgage Amortizer (Timex)"
+  description "The Loan/Mortgage Amortizer (Timex)"
+  year "1982"
+  manufacturer "T. J. Software"
+  rom ( name "LoanMortgageAmortizerThe.tzx" size 10564 crc 8FD28637 md5 B0BF87937E33697F07D9B3D62D436E36 sha1 60988BEEEFB18DD293F49A3F91C6487D6245A554 )
+)
+
+game (
+  name "The Loan/Mortgage Amortizer (Timex)"
+  description "The Loan/Mortgage Amortizer (Timex)"
+  year "1982"
+  manufacturer "T. J. Software"
+  rom ( name "loanmortgageamortizerthe.p" size 10332 crc 08257DA4 md5 418E25313141160CD04D7AC8693B5784 sha1 731AAA3F99ED2AA3F71D86858037F37C4B7AF86B )
+)
+
+game (
+  name "Lost Island (JRS Software)"
+  description "Lost Island (JRS Software)"
+  year "1982"
+  manufacturer "JRS Software"
+  rom ( name "lostisland.p" size 15542 crc C93D1958 md5 F1783D3018E369FE915E919646AB845C sha1 56310E5EA2F0DC1E77C95717E7B5E988C9C0FFF9 )
+)
+
+game (
+  name "Lost Island (JRS Software)"
+  description "Lost Island (JRS Software)"
+  year "1982"
+  manufacturer "JRS Software"
+  rom ( name "LostIsland.tzx" size 15766 crc B0682DDB md5 28AC9145502B4144B038821D63B419E4 sha1 B1BED07DD568166C87352C1700C8E3FB81A43A7B )
+)
+
+game (
+  name "Lunar Rescue (Mikro-Gen)"
+  description "Lunar Rescue (Mikro-Gen)"
+  manufacturer "K. J. Bezant"
+  rom ( name "lunarrescue.p" size 4657 crc 0EC491CE md5 62D3CD05D6EA6103CB47824C7316135F sha1 810FE42934480BC6967D058F91586CC558BF4BC5 )
+)
+
+game (
+  name "Lunar Rescue (Mikro-Gen)"
+  description "Lunar Rescue (Mikro-Gen)"
+  manufacturer "K. J. Bezant"
+  rom ( name "LunarRescue.tzx" size 4885 crc B63D952A md5 9D99D03E0DA02AB1601A4DBE89446BAB sha1 620F51472B3313AA14BEE80521E5654C05B4C5B6 )
+)
+
+game (
+  name "MCoder (PSS)"
+  description "MCoder (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "mcoder.p" size 3558 crc 7297A09D md5 712640382C22590907ACDF151C7C35F3 sha1 48E7BCFB62552FD617AF3C4B903B3F52F759DB3B )
+)
+
+game (
+  name "MCoder (PSS)"
+  description "MCoder (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "MCoder.tzx" size 3786 crc 3AEF6340 md5 3E6A131A6FF49DFF552F0E8518686726 sha1 74D2103372C2D6E5D627C9DEDDBA2ED948606C77 )
+)
+
+game (
+  name "MCoder 11 (PSS)"
+  description "MCoder 11 (PSS)"
+  year "1983"
+  manufacturer "PSS"
+  rom ( name "MCoder11.tzx" size 5941 crc 4C0EE232 md5 4E67FB609FA6B32E7B84C3C9713E468F sha1 E4D21864BFBBA4E7584FB8D4817494EDDEBEBA52 )
+)
+
+game (
+  name "MCoder 11 (PSS)"
+  description "MCoder 11 (PSS)"
+  year "1983"
+  manufacturer "PSS"
+  rom ( name "mcoder11.p" size 5713 crc 44B1BBE5 md5 7B5D8EAAAED4BA91FF36B3308126976F sha1 CD400D506C292DFD1946264D8D5518FECEB8E0BA )
+)
+
+game (
+  name "Machine Code Test Tool (F. O. Ainley)"
+  description "Machine Code Test Tool (F. O. Ainley)"
+  year "1982"
+  manufacturer "F. O. Ainley"
+  rom ( name "machinecodetesttool.p" size 2823 crc 778F13A8 md5 440B350563FA9DD8AC48B7A3D01A27BD sha1 5063E60E26A804E8CB2F210349D9CCEF375F3C2E )
+)
+
+game (
+  name "Machine Code Test Tool (F. O. Ainley)"
+  description "Machine Code Test Tool (F. O. Ainley)"
+  year "1982"
+  manufacturer "F. O. Ainley"
+  rom ( name "MachineCodeTestTool.tzx" size 3047 crc E7FC10FC md5 FB5CD1E9564AF7FCBDA7227B19104342 sha1 9108F1176687353A4B9E0A0EFF750478A863D5C2 )
+)
+
+game (
+  name "Manufacturing Control (Timex)"
+  description "Manufacturing Control (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "manufacturingcontrol.p" size 14780 crc 10E493B2 md5 84384096921E088B18CC9E3EEDB3B143 sha1 C603B553FC42D949FED9139CB58D0BDE4F3C3D3E )
+)
+
+game (
+  name "Manufacturing Control (Timex)"
+  description "Manufacturing Control (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "ManufacturingControl.tzx" size 15008 crc FEC50D8E md5 38BCF567460A33EDB8FF13034834100F sha1 694CFA2652B6134621F5B6A2A189AF5B8F1E853B )
+)
+
+game (
+  name "Marine Rescue (International Publishing and Software Inc.)"
+  description "Marine Rescue (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing & Software Inc."
+  rom ( name "marinerescue.p" size 10829 crc D91C71E8 md5 BF106CF05B1E4D7318DF3F7C1A7C125C sha1 39AF94024CCBBE9262BBF98B8841CB00D258C418 )
+)
+
+game (
+  name "Marine Rescue (International Publishing and Software Inc.)"
+  description "Marine Rescue (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing & Software Inc."
+  rom ( name "MarineRescue.tzx" size 11057 crc 60217181 md5 CA6CE91A6AEA06AC28859C418DAAC227 sha1 C0FE4882D84B9FC7503004128975115B5CC355F2 )
+)
+
+game (
+  name "Math Routines and Fit (Zeta Software)"
+  description "Math Routines and Fit (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896DE80 md5 EE3E759E69B64248F0E5BD1846D63A76 sha1 AA81C6329174CB096D5690CF4D6456B0E0DBDCCC )
+)
+
+game (
+  name "Math Routines and Fit (Zeta Software)"
+  description "Math Routines and Fit (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "mathroutinesandfit.p" size 15850 crc EF830293 md5 205EFA1A71BA01038CD3BC523F1A9667 sha1 C1A6B8F1C9798FB57FAEA5EE52DC1BCACEE68B1B )
+)
+
+game (
+  name "Maths Invaders (Programs in Education)"
+  description "Maths Invaders (Programs in Education)"
+  rom ( name "mathsinvaders.p" size 7786 crc 27B974EC md5 0E79E0CEEBC05771120ADC45BEBB8FB9 sha1 348D5786FD8B153EA7EF26E7EB0AF63A273A9D18 )
+)
+
+game (
+  name "Maths Invaders (Programs in Education)"
+  description "Maths Invaders (Programs in Education)"
+  rom ( name "MathsInvaders.tzx" size 8030 crc 19057596 md5 479D85EE6074FB7E7ECCEDB399DBC1F2 sha1 4E6E0FC96692A767DE539EC97DF4B06B30C5AF70 )
+)
+
+game (
+  name "Mazogs (Bug Byte)"
+  description "Mazogs (Bug Byte)"
+  year "1982"
+  manufacturer "Don Priestley"
+  rom ( name "mazogs.p" size 12831 crc 007463E5 md5 589A35248F7A9CB539F91B03427F9A3C sha1 DEE47E0C7E717B9721E63078E1CFDCE88FF9F725 )
+)
+
+game (
+  name "Mazogs (Bug Byte)"
+  description "Mazogs (Bug Byte)"
+  year "1982"
+  manufacturer "Don Priestley"
+  rom ( name "Mazogs.tzx" size 13059 crc 4CB450B8 md5 421C3CDBE09CBA807770D925BBB56DDE sha1 EDEE5D84ED22C2CFFA6B605A4CAA998A8510DA17 )
+)
+
+game (
+  name "Mazogs (Gladstone) (Gladstone Electronics)"
+  description "Mazogs (Gladstone) (Gladstone Electronics)"
+  manufacturer "Don Priestley"
+  rom ( name "mazogs(ge).p" size 12942 crc BDAB60B2 md5 D8BBD02ADE6AC94438547F255C04517B sha1 14CA73F2AE0D621BA17FBC5E0F0E8D9184184347 )
+)
+
+game (
+  name "Mazogs (Gladstone) (Gladstone Electronics)"
+  description "Mazogs (Gladstone) (Gladstone Electronics)"
+  manufacturer "Don Priestley"
+  rom ( name "Mazogs(GE).tzx" size 13170 crc 5D7DD442 md5 CB162114851F80E1A4A820D4E7E4CC22 sha1 94E2DA0938BD44F9C0392E2061E390E69D49D47B )
+)
+
+game (
+  name "Mazogs (Monochrome) (Bug Byte)"
+  description "Mazogs (Monochrome) (Bug Byte)"
+  year "1981"
+  manufacturer "Don Priestley"
+  rom ( name "Mazogs.tzx" size 13059 crc 4CB450B8 md5 421C3CDBE09CBA807770D925BBB56DDE sha1 EDEE5D84ED22C2CFFA6B605A4CAA998A8510DA17 )
+)
+
+game (
+  name "Mazogs (Monochrome) (Bug Byte)"
+  description "Mazogs (Monochrome) (Bug Byte)"
+  year "1981"
+  manufacturer "Don Priestley"
+  rom ( name "mazogs.p" size 12831 crc 007463E5 md5 589A35248F7A9CB539F91B03427F9A3C sha1 DEE47E0C7E717B9721E63078E1CFDCE88FF9F725 )
+)
+
+game (
+  name "Mazogs (Softsync)"
+  description "Mazogs (Softsync)"
+  year "1982"
+  manufacturer "Don Priestley"
+  rom ( name "mazogs(softsync).p" size 12831 crc 60B3C966 md5 ACD2A6C8F4340C6F2553449225123CD8 sha1 A8E8494BEE216F4054CDB2F34735177108305DE8 )
+)
+
+game (
+  name "Mazogs (Softsync)"
+  description "Mazogs (Softsync)"
+  year "1982"
+  manufacturer "Don Priestley"
+  rom ( name "Mazogs(Softsync).tzx" size 13059 crc 2C73FA3B md5 C89ACD6EC795FFEEF1D658836BB0DDE3 sha1 56E5E86334CB633863FC2386FFDA515AD8C58EA9 )
+)
+
+game (
+  name "Merchant of Venus (Crystal)"
+  description "Merchant of Venus (Crystal)"
+  year "1983"
+  manufacturer "Crystal"
+  rom ( name "merchantofvenus.p" size 16161 crc 51CF1515 md5 F607C834C5F1405F7FF0F0E99AF1E934 sha1 4BE29A8DF43BB849740910A055A8773E4D35A2FD )
+)
+
+game (
+  name "Merchant of Venus (Crystal)"
+  description "Merchant of Venus (Crystal)"
+  year "1983"
+  manufacturer "Crystal"
+  rom ( name "MerchantOfVenus.tzx" size 16393 crc 5E4A029E md5 76409F6A8710A0231FFC4562A5217465 sha1 95F7628F548DCBFEB169FE3F12BAA23E720B6F8C )
+)
+
+game (
+  name "Meteor Storm (dK'tronics)"
+  description "Meteor Storm (dK'tronics)"
+  year "1982"
+  manufacturer "dK'tronics"
+  rom ( name "meteorstorm.p" size 5747 crc 8AED8FF8 md5 16A19477D2B25332DFD44117DA71FA78 sha1 1C737A14C4BAE0D2AF32F28ED9DD2BAA4D1DD792 )
+)
+
+game (
+  name "Meteor Storm (Fast Master) (dK'tronics)"
+  description "Meteor Storm (Fast Master) (dK'tronics)"
+  year "1982"
+  manufacturer "dK'tronics"
+  rom ( name "meteorstorm(fastmaster).p" size 5784 crc 83AE249C md5 0BBAAFB1A7802DBBBBB03EB1852330E7 sha1 736654E354223E719629101BB94FDAF8A847220C )
+)
+
+game (
+  name "Meteor Storm (Fast Master) (dK'tronics)"
+  description "Meteor Storm (Fast Master) (dK'tronics)"
+  year "1982"
+  manufacturer "dK'tronics"
+  rom ( name "MeteorStorm(FastMaster).tzx" size 6024 crc 35C2540E md5 4066B1DCFB69B1F9205ED0CB6B6BF35C sha1 E02A6983C28A40CCC70A3FA3EDD1DC6DBF176354 )
+)
+
+game (
+  name "Micro Mouse goes de-bugging (Lothlorien)"
+  description "Micro Mouse goes de-bugging (Lothlorien)"
+  year "1983"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "micromouse.p" size 8487 crc 17365457 md5 D0603604ED0847E629EEA1EC9E701457 sha1 C4510C08365BB8E873315F98FBBBBC067EC06612 )
+)
+
+game (
+  name "Micro Mouse goes de-bugging (Lothlorien)"
+  description "Micro Mouse goes de-bugging (Lothlorien)"
+  year "1983"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "MicroMouse.tzx" size 8713 crc DB8110B5 md5 052BC1C42964E438A69FEAB1759A255C sha1 012A444AC366224D63DAF2BC242CA30B58A0E33A )
+)
+
+game (
+  name "Mind vs. Machine (2-Bit Software)"
+  description "Mind vs. Machine (2-Bit Software)"
+  year "1982"
+  manufacturer "2-Bit Software"
+  rom ( name "MindvsMachine.B.tzx" size 3168 crc C7AC234D md5 BB2EF658C6FFE1DA45C34E32DD7A5161 sha1 5BF1942B1696AD670427A5119BAC1CBDDCAC30F0 )
+)
+
+game (
+  name "Mixed Game Bag III (Timex)"
+  description "Mixed Game Bag III (Timex)"
+  year "1982"
+  manufacturer "M. Orwin"
+  rom ( name "MixedGameBagIII.tzx" size 6939 crc 9115C144 md5 1AA50B1328AFE02CE01D69FCEE6EE746 sha1 9AD8A4C6321346B904995AC8E9AEE31124EB5868 )
+)
+
+game (
+  name "Money Analyzer 1 (Timex)"
+  description "Money Analyzer 1 (Timex)"
+  year "1982"
+  manufacturer "T. J. Software"
+  rom ( name "MoneyAnalyzer1.tzx" size 2508 crc 8B0ECF6C md5 38B90377D5298596FD2D123F2E1BD9C2 sha1 5A223F431B06F01CCD7E30C31D462422409A3C69 )
+)
+
+game (
+  name "Moniteur Desassembleur (Direco International)"
+  description "Moniteur Desassembleur (Direco International)"
+  year "1982"
+  rom ( name "moniteurdesassembleur.p" size 5593 crc 357448FF md5 5635D4860A5B03B9312EA12A87383631 sha1 6B32FF9CE4F9DAB7E9E43DF50C9DD8264D9CF5B9 )
+)
+
+game (
+  name "Moniteur Desassembleur (Direco International)"
+  description "Moniteur Desassembleur (Direco International)"
+  year "1982"
+  rom ( name "MoniteurDesassembleur.tzx" size 5825 crc E548A0E6 md5 4B422022A5ED280D6BD1F6F74F7B56C5 sha1 F3433D201596F069DFF1053A86FC2F293B8E4612 )
+)
+
+game (
+  name "Monster Mine (Gem Software)"
+  description "Monster Mine (Gem Software)"
+  year "1982"
+  manufacturer "Gem Software"
+  rom ( name "MonsterMine.tzx" size 11048 crc AC4BEC18 md5 BBA503301BE95EA4FE4F9E3C45E867C1 sha1 BCBF2D46F2C8B547600F979882968D4A57C5B524 )
+)
+
+game (
+  name "Monster Mine (Gem Software)"
+  description "Monster Mine (Gem Software)"
+  year "1982"
+  manufacturer "Gem Software"
+  rom ( name "monstermine.p" size 10808 crc C0B1F76E md5 951905CD41AA8A43D7CECE736A99099E sha1 F5063AFF551446D25A9CBD3D7080E5D505D1F66A )
+)
+
+game (
+  name "Morse Reader (JEP Electronics)"
+  description "Morse Reader (JEP Electronics)"
+  manufacturer "JEP Electronics"
+  rom ( name "morsereader.p" size 8827 crc 059EE1F6 md5 FFFBF7D1AAC3E3BF21F8895A5EA53194 sha1 51CE900CEC1C55F91037989DA1610DD6B73CBAE6 )
+)
+
+game (
+  name "Morse Reader (JEP Electronics)"
+  description "Morse Reader (JEP Electronics)"
+  manufacturer "JEP Electronics"
+  rom ( name "MorseReader.tzx" size 9055 crc 9FCE1AF5 md5 F01F1D0B641939493ED663D9703BAA5B sha1 DEBE28EC7E350D9B6431DC6FCA6DA97513232F02 )
+)
+
+game (
+  name "Mothership (Sinclair Research)"
+  description "Mothership (Sinclair Research)"
+  year "1982"
+  manufacturer "Alan Laity, Softsync"
+  rom ( name "Mothership.tzx" size 9863 crc 526E7FA1 md5 BD8246E4A145F366BC9BF23BB45913C1 sha1 05FD66EC3EB2C22DF673F2BDAA238FAAB8AE5FC2 )
+)
+
+game (
+  name "Mothership (Sinclair Research)"
+  description "Mothership (Sinclair Research)"
+  year "1982"
+  manufacturer "Alan Laity, Softsync"
+  rom ( name "mothership.p" size 9627 crc 7DE56C4B md5 33404FCDBD84277061D678EBE4D6DBE3 sha1 55CD6D320281C29978170E22A8286803F0C72049 )
+)
+
+game (
+  name "Mothership (Softsync)"
+  description "Mothership (Softsync)"
+  year "1983"
+  manufacturer "Alan Laity"
+  rom ( name "Mothership(Softsync).tzx" size 9863 crc 28F60C02 md5 B065399AD89B9C5D000A60F7AC971154 sha1 63DEC851B552AC48D167CE90DEEC768F0677D42F )
+)
+
+game (
+  name "Mothership (Softsync)"
+  description "Mothership (Softsync)"
+  year "1983"
+  manufacturer "Alan Laity"
+  rom ( name "mothership(softsync).p" size 9627 crc 077D1FE8 md5 4B63A2614E5907B002264EFEA78A41E5 sha1 697CA1D242137E2207A98C70181D02A7895DA64D )
+)
+
+game (
+  name "Multifile (Gladstone) (Gladstone Electronics)"
+  description "Multifile (Gladstone) (Gladstone Electronics)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "Multifile(GE).tzx" size 5783 crc 18343751 md5 B05754895C071D02F191E4D7D588BF59 sha1 D72DE512A1ADC62CF2DE299C2E1FF64ED630316B )
+)
+
+game (
+  name "Multifile (Gladstone) (Gladstone Electronics)"
+  description "Multifile (Gladstone) (Gladstone Electronics)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "multifile(ge).p" size 5549 crc D71BF8BC md5 E4806A5D67124ADA1F733F0E681CF66B sha1 BAB72E5AAE3AE98D0D4DA03CBA691B9E61E32FE6 )
+)
+
+game (
+  name "Multifile Plus (Gladstone Electronics)"
+  description "Multifile Plus (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952FF07 md5 80FF32332CB0BDA770C476A519B0365A sha1 C2866C2C9430D5AEC6EA4EB01D7F04C839B1B30C )
+)
+
+game (
+  name "Multifile Plus (Gladstone Electronics)"
+  description "Multifile Plus (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "multifileplus(ge).p" size 7677 crc 6CB1F589 md5 DEA427C0DDCDB0E27BDBFA199D903C8F sha1 E036FC55971244C9E2A3B157BD9F527B349DCE17 )
+)
+
+game (
+  name "Multigraphics 2.3 (Bridge Software)"
+  description "Multigraphics 2.3 (Bridge Software)"
+  year "1981"
+  manufacturer "Bridge Software"
+  rom ( name "Multigraphics.tzx" size 14452 crc 14DD97D3 md5 3B70EAA4B9C771FEED049F6C1E0B798B sha1 7B7BEAD37DB83539393B9BAB71C15ED048608D85 )
+)
+
+game (
+  name "Multigraphics 2.3 (Bridge Software)"
+  description "Multigraphics 2.3 (Bridge Software)"
+  year "1981"
+  manufacturer "Bridge Software"
+  rom ( name "multigraphics.p" size 14210 crc F55B43E1 md5 7000C83BD3B8B8EE761DFFC603B7B90C sha1 256D229A11058BED6F608553FC1D9D081397AE89 )
+)
+
+game (
+  name "Munchees (Quicksilva)"
+  description "Munchees (Quicksilva)"
+  year "1983"
+  manufacturer "A. Laird"
+  rom ( name "munchees.p" size 7545 crc B9365FA1 md5 4D0347C0D394CDF1BBCB10D5553BB34B sha1 7C59C57A62EB0AA7750175020287B913E34AAA19 )
+)
+
+game (
+  name "Munchees (Quicksilva)"
+  description "Munchees (Quicksilva)"
+  year "1983"
+  manufacturer "A. Laird"
+  rom ( name "Munchees.tzx" size 7777 crc 4DA90EED md5 B724025D7778E61DD088A66D0BA7B272 sha1 C64C8336F95030B957F3E6C3AED5BE3A2237DBB1 )
+)
+
+game (
+  name "Muncher (Silversoft)"
+  description "Muncher (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "muncher.p" size 5200 crc CADFF742 md5 DBA0E8079AB8F60C47B31BDFF986E49E sha1 F9FCBBD7D5AAC8A8C22BF7E73B87ECCB18AEDC00 )
+)
+
+game (
+  name "Muncher (Silversoft)"
+  description "Muncher (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "Muncher.tzx" size 5430 crc 7334AD2A md5 2E1104B8D2D21F6C359477CC66366358 sha1 2D7EDCFD205DFBDFE253967FA8DD25711964B00C )
+)
+
+game (
+  name "Murgatroyds (Collins Computing)"
+  description "Murgatroyds (Collins Computing)"
+  year "1982"
+  manufacturer "Collins Computing"
+  rom ( name "murgatroyds.p" size 7097 crc A0130EEA md5 4B59AF5F517EBEEAEB25DB1A85883C5E sha1 6D309CCBE66964B30C9ED418EF8537EFD07BC17E )
+)
+
+game (
+  name "Murgatroyds (Collins Computing)"
+  description "Murgatroyds (Collins Computing)"
+  year "1982"
+  manufacturer "Collins Computing"
+  rom ( name "Murgatroyds.tzx" size 7315 crc D35AF98D md5 40A6BB5E88B35F7309F76B55C808A7F2 sha1 E9B44DC8DCE87E747C15C2BB24DC508F319DDC36 )
+)
+
+game (
+  name "Music Composer (Memotronic)"
+  description "Music Composer (Memotronic)"
+  manufacturer "Frank Beer and Wolfgang Labus"
+  rom ( name "musiccomposer.p" size 5578 crc B0DCDCCA md5 76133648609D8AB9B7B24A418E9AE215 sha1 70A99A384559E1D70E38B2EC5A6DFCAC3CFE6EC0 )
+)
+
+game (
+  name "Music Composer (Memotronic)"
+  description "Music Composer (Memotronic)"
+  manufacturer "Frank Beer and Wolfgang Labus"
+  rom ( name "MusicComposer.tzx" size 5822 crc D0CC5789 md5 8AB416356FB8DE668546530C4AB0A890 sha1 BBF95991604EB52B8211D709736CDCDE9AC4DC3B )
+)
+
+game (
+  name "Music Educator 1 (Timex)"
+  description "Music Educator 1 (Timex)"
+  year "1983"
+  manufacturer "Tim Rossetti"
+  rom ( name "MusicEducator1.tzx" size 14372 crc DB66A8DD md5 F1FD3CF9B70BB1E730C0C73C75BF8129 sha1 0EE598AB50535505E8382F93D6F77F158D1E43E4 )
+)
+
+game (
+  name "Music Educator 1 (Timex)"
+  description "Music Educator 1 (Timex)"
+  year "1983"
+  manufacturer "Tim Rossetti"
+  rom ( name "musiceducator1.p" size 14146 crc B7C34C96 md5 702E4B03957EF8A387A76013D1F1E932 sha1 457B9A66701A0EDC6CB5B1C91D84758B64C3A074 )
+)
+
+game (
+  name "Namtir Raiders (Artic)"
+  description "Namtir Raiders (Artic)"
+  year "1982"
+  manufacturer "J. Ritman"
+  rom ( name "NamtirRaiders.tzx" size 3984 crc E65D10F3 md5 80D72C6B620D287E922279B2A5902E65 sha1 364DD09FAC90173806CD1A643B594CB378156A55 )
+)
+
+game (
+  name "Namtir Raiders (Artic)"
+  description "Namtir Raiders (Artic)"
+  year "1982"
+  manufacturer "J. Ritman"
+  rom ( name "namtirraiders.p" size 3740 crc 8BA3150E md5 28A7022C5386D46864FEC0F0E9516A4F sha1 FB0367A015A4BEB3CF6EE00853E84E430CEECC36 )
+)
+
+game (
+  name "Night Gunner (Digital Integration)"
+  description "Night Gunner (Digital Integration)"
+  year "1982"
+  manufacturer "Digital Integration"
+  rom ( name "nightgunner.p" size 5113 crc 8FC7C658 md5 F15A54C0F92CC903B91CE8ED37E7CB88 sha1 9EC875318FA4E35087E65A9CF3B9DEF0080F3705 )
+)
+
+game (
+  name "Night Gunner (Digital Integration)"
+  description "Night Gunner (Digital Integration)"
+  year "1982"
+  manufacturer "Digital Integration"
+  rom ( name "NightGunner.tzx" size 5333 crc BA8BEA96 md5 CB630368C6F87F40C3D461F988F005FA sha1 ECD2C009311A97F40EAE7102FAF426E8572B6F96 )
+)
+
+game (
+  name "Night Gunner (Softsync)"
+  description "Night Gunner (Softsync)"
+  year "1982"
+  manufacturer "Digital Integration"
+  rom ( name "nightgunner(softsync).p" size 5113 crc 77639E65 md5 32CBAF62810EC52668BB663029E893A5 sha1 F3B4EA9743015A0CB2C612A79322663A0E36A25A )
+)
+
+game (
+  name "Night Gunner (Softsync)"
+  description "Night Gunner (Softsync)"
+  year "1982"
+  manufacturer "Digital Integration"
+  rom ( name "NightGunner(Softsync).tzx" size 5333 crc 422FB2AB md5 5FB5E7061C2C292259D4244B2B9847C1 sha1 9BD903833515016E2E6215C068B630223FC0138A )
+)
+
+game (
+  name "Nightmare Park (Macronics)"
+  description "Nightmare Park (Macronics)"
+  year "1981"
+  manufacturer "J. D. S. Cranston"
+  rom ( name "NightmarePark.tzx" size 11879 crc 53965B76 md5 42B898FEE8207B3A73316056A7BF7ECA sha1 86DBCA70AE32E736A89C161C7E260E43576DA971 )
+)
+
+game (
+  name "Nightmare Park (Macronics)"
+  description "Nightmare Park (Macronics)"
+  year "1981"
+  manufacturer "J. D. S. Cranston"
+  rom ( name "nightmarepark.p" size 11659 crc 28F39976 md5 ACE96513FEF192CD7197825120D9EB95 sha1 7B6344D8E2C62AA1DC1BEBB64107DEC51617B402 )
+)
+
+game (
+  name "Octopussy (Peaksoft)"
+  description "Octopussy (Peaksoft)"
+  manufacturer "Peaksoft"
+  rom ( name "octopussy.p" size 6090 crc 62265923 md5 4C419DD9A3B3463D331E5C8C2F3D7E6B sha1 CA8C3A27854E51ACB3ABBB02C5EBB6AE40C628C0 )
+)
+
+game (
+  name "Octopussy (Peaksoft)"
+  description "Octopussy (Peaksoft)"
+  manufacturer "Peaksoft"
+  rom ( name "Octopussy.tzx" size 6308 crc 9D408C0E md5 FA9F1E45071A0B907B6D8FDFC71F0430 sha1 745515410B88F840A33611B15C4E0A31E6B28611 )
+)
+
+game (
+  name "The Oracle's Cave (Doric Computer Systems)"
+  description "The Oracle's Cave (Doric Computer Systems)"
+  year "1981"
+  manufacturer "C. T. Dorrel"
+  rom ( name "oraclescavethe.p" size 15953 crc 6135DAAD md5 01F7597A8EECF63967921A7DC63FF23E sha1 9358857B5B1BE76EE495A089E07CD61BC44C6F48 )
+)
+
+game (
+  name "The Oracle's Cave (Doric Computer Systems)"
+  description "The Oracle's Cave (Doric Computer Systems)"
+  year "1981"
+  manufacturer "C. T. Dorrel"
+  rom ( name "OraclesCaveThe.tzx" size 16181 crc DEA5489A md5 E148DDC58CCCE3FC4F32BE9B8ABC2B63 sha1 752BB718F14E0A7E9DA87FA958CCD0E366813A34 )
+)
+
+game (
+  name "Othello (CDS Micro Systems)"
+  description "Othello (CDS Micro Systems)"
+  manufacturer "CDS Micro Systems"
+  rom ( name "othello.p" size 11655 crc 73457797 md5 EF70888041689CC60B9336201735F725 sha1 4DD7218297D9EF6CFB776DECBD2F040A297E1C3E )
+)
+
+game (
+  name "Othello (CDS Micro Systems)"
+  description "Othello (CDS Micro Systems)"
+  manufacturer "CDS Micro Systems"
+  rom ( name "Othello.tzx" size 11885 crc 09D487FE md5 CFCB326E75DFA9A59A79E05491686DD6 sha1 47C8980D14972B59FAB5098667B170169894515D )
+)
+
+game (
+  name "ZX Othello (Moi)"
+  description "ZX Othello (Moi)"
+  year "1982"
+  manufacturer "Moi"
+  rom ( name "Othello(Moi).tzx" size 12809 crc 96EEAB64 md5 2B76C39D66873CFA8959CEBDD71D5CEC sha1 78F78E57BF940D87D020C39AA4218B273F612313 )
+)
+
+game (
+  name "Paint-Maze (Mikro-Gen)"
+  description "Paint-Maze (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "PaintMaze.tzx" size 5086 crc 2EFF4B27 md5 23DD48A06FF28C78E8A3F9BF26AA557E sha1 E8519C3EB5B772F13FE374C1C57A15D7D4791887 )
+)
+
+game (
+  name "Peloponnesian War (Lothlorien)"
+  description "Peloponnesian War (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "PeloponnesianWar.tzx" size 16341 crc F56E0C9D md5 7A8AB89F6173649C5BBC0A6A9BF4D62D sha1 94EBC1A99152A5441238AD242DA19B4C9CCEE699 )
+)
+
+game (
+  name "Peloponnesian War (Lothlorien)"
+  description "Peloponnesian War (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "peloponnesianwar.p" size 16121 crc F44DEC8B md5 1BC0299B676A7656670585FC0199772C sha1 A3F5B184568AC4EA26AE03F9E737E9FD1D4EAC53 )
+)
+
+game (
+  name "Pengy (Fawkes Computing)"
+  description "Pengy (Fawkes Computing)"
+  year "1984"
+  manufacturer "Fawkes Computing"
+  rom ( name "Pengy.tzx" size 8782 crc 85894997 md5 BB2821339AF5EBE2F6EB4CCC752F6A55 sha1 27606CF98E27ECC5A6DA5DA5E36BA5AB9C4FA038 )
+)
+
+game (
+  name "Pengy (Fawkes Computing)"
+  description "Pengy (Fawkes Computing)"
+  year "1984"
+  manufacturer "Fawkes Computing"
+  rom ( name "pengy.p" size 8564 crc F7E0304A md5 CDB3809C3F646129F7DECBA0DCC0C0CE sha1 19A0D22ACA1F1580FAC805B570A7BC3EA7EC4D2C )
+)
+
+game (
+  name "Pilot (Hewson Consultants)"
+  description "Pilot (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "Pilot.tzx" size 15119 crc 775BAFED md5 BE91F4D73F8C368C0B5C55A33A836D28 sha1 8C4645159BCBEC8144E875EFEACB772D6609119D )
+)
+
+game (
+  name "Pilot (Hewson Consultants)"
+  description "Pilot (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "pilot.p" size 14899 crc 8DFFD009 md5 68DC6D6B80D3C94E16D60CB5082A341F sha1 954DD9582E636990DE568425B3602D3467C45D18 )
+)
+
+game (
+  name "Pilot (Colour inlay) (Hewson Consultants)"
+  description "Pilot (Colour inlay) (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "pilot.p" size 14899 crc 8DFFD009 md5 68DC6D6B80D3C94E16D60CB5082A341F sha1 954DD9582E636990DE568425B3602D3467C45D18 )
+)
+
+game (
+  name "Pilot (Colour inlay) (Hewson Consultants)"
+  description "Pilot (Colour inlay) (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "Pilot.tzx" size 15119 crc 775BAFED md5 BE91F4D73F8C368C0B5C55A33A836D28 sha1 8C4645159BCBEC8144E875EFEACB772D6609119D )
+)
+
+game (
+  name "Pilot (New) (Hewson Consultants)"
+  description "Pilot (New) (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "Pilot(New).tzx" size 13271 crc 0BC60AAD md5 B3B606ADD7070B8C774FF1AF2B562732 sha1 42E19385766FE586291DEE026B49B60F47A9DF0F )
+)
+
+game (
+  name "Pilot (New) (Hewson Consultants)"
+  description "Pilot (New) (Hewson Consultants)"
+  year "1982"
+  manufacturer "Hewson Consultants"
+  rom ( name "pilot(new).p" size 13051 crc D9519A6E md5 8B5DF07010240DCEAD0141109297547E sha1 8ECB69E390BD24941DB252F592F059E327BE0DB6 )
+)
+
+game (
+  name "Pimania (Automata Cartography)"
+  description "Pimania (Automata Cartography)"
+  year "1982"
+  manufacturer "Automata"
+  rom ( name "Pimania.tzx" size 16003 crc 37CFB18D md5 5047A7041130A121E5D4E2D33E7AC1EB sha1 DD537D6AB72A749D1F6071D91748282E2EA2B89F )
+)
+
+game (
+  name "Pimania (Automata Cartography)"
+  description "Pimania (Automata Cartography)"
+  year "1982"
+  manufacturer "Automata"
+  rom ( name "pimania.p" size 15773 crc 351EB08B md5 536E24E5B74EF6BE13C44EAEBEBCEEA5 sha1 39F717B621452E6C853DC0E0318C01ACB5AD45E6 )
+)
+
+game (
+  name "Pinball (Timex)"
+  description "Pinball (Timex)"
+  year "1982"
+  manufacturer "A. H. Laity"
+  rom ( name "Pinball.tzx" size 4898 crc F8452E21 md5 986CC07F307993D0F7A996CAA18AF0EB sha1 4FF5E7491088E5EBE4C67B4813BAA943AAEA5164 )
+)
+
+game (
+  name "Pinball (Timex)"
+  description "Pinball (Timex)"
+  year "1982"
+  manufacturer "A. H. Laity"
+  rom ( name "pinball.p" size 4668 crc 40B6BEF6 md5 1E2905FD9AB4F7F57E6A9D81DDFE2E7C sha1 26C5D56388AE2BDC5F9ADC53AA670E427F3F5E68 )
+)
+
+game (
+  name "Pioneer Trail (Quicksilva)"
+  description "Pioneer Trail (Quicksilva)"
+  year "1983"
+  manufacturer "M.Stubbs"
+  rom ( name "pioneertrail.p" size 15462 crc E4AD892D md5 77F604B5F45DC443B41AEFE41387F0F5 sha1 33FDC9772DE2008CD98E5A55FE0013EAEF752FE8 )
+)
+
+game (
+  name "Pioneer Trail (Quicksilva)"
+  description "Pioneer Trail (Quicksilva)"
+  year "1983"
+  manufacturer "M.Stubbs"
+  rom ( name "PioneerTrail.tzx" size 15682 crc CEB55F84 md5 3187C5EB7E83D9020E2AABF3F7ECB5EB sha1 1FF2A193FFDA69D2CA542D63334399BCF2301390 )
+)
+
+game (
+  name "Adventure A - Planet of Death (Sinclair Research)"
+  description "Adventure A: Planet of Death (Sinclair Research)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "planetofdeath.p" size 13445 crc AB715C00 md5 F0A90C314572232E860A486F47C34CFE sha1 247F37D1B70A0EEC9ABCE64EA094D55E3E59B27C )
+)
+
+game (
+  name "Adventure A - Planet of Death (Sinclair Research)"
+  description "Adventure A: Planet of Death (Sinclair Research)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "PlanetOfDeath.tzx" size 13675 crc CDEF18A4 md5 4ECB3F0A3A9A9C9A25520BF1F7D2175E sha1 346412F09B472C931874FD441660AB5435D5F3C1 )
+)
+
+game (
+  name "Adventure A - Planet of Death (Artic)"
+  description "Adventure A: Planet of Death (Artic)"
+  manufacturer "Artic"
+  rom ( name "PlanetOfDeath.tzx" size 13675 crc CDEF18A4 md5 4ECB3F0A3A9A9C9A25520BF1F7D2175E sha1 346412F09B472C931874FD441660AB5435D5F3C1 )
+)
+
+game (
+  name "Adventure A - Planet of Death (Artic)"
+  description "Adventure A: Planet of Death (Artic)"
+  manufacturer "Artic"
+  rom ( name "planetofdeath.p" size 13445 crc AB715C00 md5 F0A90C314572232E860A486F47C34CFE sha1 247F37D1B70A0EEC9ABCE64EA094D55E3E59B27C )
+)
+
+game (
+  name "Planetoids (Macronics)"
+  description "Planetoids (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "planetoids.p" size 4909 crc 8A63863A md5 EFDB0ABDAB99EDBBF7B0C31281A17A8F sha1 9BCA8CF12D888DBBE9B1D8F5A00E8F207CD0A346 )
+)
+
+game (
+  name "Planetoids (Macronics)"
+  description "Planetoids (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "Planetoids.tzx" size 5127 crc 02A6B2AD md5 8715626FA60FFA829018000D02DD3A1C sha1 270765BE9B076E4EAA0704EECE81137AD2C0AE10 )
+)
+
+game (
+  name "Portfolio Analysis (Timex)"
+  description "Portfolio Analysis (Timex)"
+  year "1982"
+  manufacturer "American Micro Products"
+  rom ( name "PortfolioAnalysis.tzx" size 15819 crc D7AC34ED md5 0FD3B75C0D622131340A3C1BF3325EDF sha1 E92DA69A510BDDB77AD5FAB8E13F70D388EE5878 )
+)
+
+game (
+  name "Portfolio Analysis (Timex)"
+  description "Portfolio Analysis (Timex)"
+  year "1982"
+  manufacturer "American Micro Products"
+  rom ( name "portfolioanalysis.p" size 15597 crc B540A618 md5 562CDB1A3E92927A8797312F03C448B6 sha1 26EBCCFF7160857F8490074A84BFD30C99ACA883 )
+)
+
+game (
+  name "Presidents (Timex)"
+  description "Presidents (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "presidents.p" size 5072 crc 61969B67 md5 6B8958911520B13BA8DCBA0695D550E6 sha1 BA972C28536586A0C567357DBDCAD2E362F45F91 )
+)
+
+game (
+  name "Presidents (Timex)"
+  description "Presidents (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "Presidents.tzx" size 5300 crc 7BB539CF md5 7C4CCC1D49EF865BFD3A4E0BABAC9F4B sha1 E8ECEE650BD89D88C7EB2FB9EC06EDA5D5647CAA )
+)
+
+game (
+  name "Print Shop (Cases Computer Simulations)"
+  description "Print Shop (Cases Computer Simulations)"
+  year "1983"
+  manufacturer "Cases Computer Simulations"
+  rom ( name "PrintShop.tzx" size 15212 crc DA63A78F md5 5DF01A04FF5CA4CF0F48939DD76A60FE sha1 6D911EA6F2E1DF74F2547FB89C99F240A0E0272B )
+)
+
+game (
+  name "Print Shop (Cases Computer Simulations)"
+  description "Print Shop (Cases Computer Simulations)"
+  year "1983"
+  manufacturer "Cases Computer Simulations"
+  rom ( name "printshop.p" size 14978 crc 5514B638 md5 CD8F4D73855EAEF7ED7E81772A29EA3B sha1 CD58BEE963702779034BFDBB17A22B8AEEB86C15 )
+)
+
+game (
+  name "Printer Programs (Nick Godwin)"
+  description "Printer Programs (Nick Godwin)"
+  year "1984"
+  manufacturer "Nick Godwin"
+  rom ( name "PrinterPrograms.tzx" size 20668 crc 11D50D78 md5 DD1CCFE9D8243D306EBB0BDA40E351A4 sha1 22A458E45D174F9053A5B96BCDF848FA2AFC0E9E )
+)
+
+game (
+  name "Privateer (Lothlorien)"
+  description "Privateer (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "Privateer.tzx" size 13217 crc 32E4F2D4 md5 7899A00015CC9B9B791C767D7C540C5E sha1 DB608044F7C01B572406ADE9481A6AEA68995488 )
+)
+
+game (
+  name "Privateer (Lothlorien)"
+  description "Privateer (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "privateer.p" size 12983 crc 8B4CE0E7 md5 81BD561DDED0399D415F1E3C7B4D2419 sha1 B27DEC9EAEB5F88581365FB6D5BD20C56E9BD6A9 )
+)
+
+game (
+  name "Progmerge (ACS Software)"
+  description "Progmerge (ACS Software)"
+  year "1982"
+  manufacturer "ACS Software"
+  rom ( name "Progmerge.tzx" size 5513 crc 13313BB9 md5 389D183A481034896E71E0C94603E729 sha1 FEF5282A0E6A8937F22398C45187BB0E98E51B27 )
+)
+
+game (
+  name "Progmerge (ACS Software)"
+  description "Progmerge (ACS Software)"
+  year "1982"
+  manufacturer "ACS Software"
+  rom ( name "progmerge.p" size 5279 crc D3FC7BF8 md5 951F8F1A0652936A3BB3F118C9BCC74E sha1 CDE61A0ECB7A1E2F2531CC1743D2CAEB746E47DE )
+)
+
+game (
+  name "Protector (Abacus)"
+  description "Protector (Abacus)"
+  year "1982"
+  manufacturer "K. Flynn"
+  rom ( name "protector.p" size 7601 crc 571DB599 md5 3C438049FFF5DCC3247C530C9D39047E sha1 FA2BDBF6919EE3BE7205F9A07DB6A2EA1041E579 )
+)
+
+game (
+  name "Protector (Abacus)"
+  description "Protector (Abacus)"
+  year "1982"
+  manufacturer "K. Flynn"
+  rom ( name "Protector.tzx" size 7835 crc 941C0480 md5 4D4C872B5934E61F8BB2064DBF7F122C sha1 750A926049ABEC9C67F6ADE68FC029A068800DC6 )
+)
+
+game (
+  name "Puckman (Hewson Consultants)"
+  description "Puckman (Hewson Consultants)"
+  year "1981"
+  manufacturer "Hewson Consultants"
+  rom ( name "puckman.p" size 10535 crc 23E9839E md5 CA251287C8C980E758D4C497028A24D0 sha1 7571EBDBBD2308FFF0653217FE599ADB8E702B26 )
+)
+
+game (
+  name "Puckman (Hewson Consultants)"
+  description "Puckman (Hewson Consultants)"
+  year "1981"
+  manufacturer "Hewson Consultants"
+  rom ( name "Puckman.tzx" size 10765 crc 2678C742 md5 46A91FB71DA2119DF0CE3AC027A7CBB3 sha1 C382093F64AC43318766C4C884854150A1775F2F )
+)
+
+game (
+  name "QS Asteroids (No characters) (Quicksilva)"
+  description "QS Asteroids (No characters) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSAsteroids(NC).tzx" size 3647 crc 92DF0BF9 md5 83A4ED182CA56C6CC560E1F017F536CE sha1 64A0E4AA51C42DDC49BA4A4A26F73FE4FEF123FB )
+)
+
+game (
+  name "QS Asteroids (No characters) (Quicksilva)"
+  description "QS Asteroids (No characters) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsasteroids(nc).p" size 3425 crc 64116F53 md5 CDBF8582FD0EB31C153708960714E98D sha1 52E3612464419DBE622C5C23FA50DCE1FAB9B4C3 )
+)
+
+game (
+  name "QS Asteroids (Big picture, no text) (Quicksilva)"
+  description "QS Asteroids (Big picture, no text) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "qsasteroids(bp2).p" size 3419 crc B88DB752 md5 D5208B3C585A16897AA9488865FAED2E sha1 F74FA3E6439F92A3491F2D6CF4C07961F40847F0 )
+)
+
+game (
+  name "QS Asteroids (Big picture, no text) (Quicksilva)"
+  description "QS Asteroids (Big picture, no text) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "QSAsteroids(BP2).tzx" size 3641 crc C5FCF3DB md5 DF2760F0A630F8019D417946916FEFEB sha1 B39C7484A5CEC019727F037A37103E44B37741EC )
+)
+
+game (
+  name "QS Defenda (Quicksilva)"
+  description "QS Defenda (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSDefenda.tzx" size 2739 crc F53682E9 md5 6B4ADFF2E0FEAF1B8722F9025FF979CA sha1 DB9F63DEB748E232C16B4C8B769B143315D83540 )
+)
+
+game (
+  name "QS Defenda (Quicksilva)"
+  description "QS Defenda (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsdefenda.p" size 2517 crc 91FC58B0 md5 CDA9AB3AD5EC7DBFFC54F03AF34E09A0 sha1 B309D7EB02194221ED8AACE44C17DA53052555E6 )
+)
+
+game (
+  name "QS Defenda (Number) (Quicksilva)"
+  description "QS Defenda (Number) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsdefenda.p" size 2517 crc 91FC58B0 md5 CDA9AB3AD5EC7DBFFC54F03AF34E09A0 sha1 B309D7EB02194221ED8AACE44C17DA53052555E6 )
+)
+
+game (
+  name "QS Defenda (Number) (Quicksilva)"
+  description "QS Defenda (Number) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSDefenda.tzx" size 2739 crc F53682E9 md5 6B4ADFF2E0FEAF1B8722F9025FF979CA sha1 DB9F63DEB748E232C16B4C8B769B143315D83540 )
+)
+
+game (
+  name "QS Defenda (Big picture) (Quicksilva)"
+  description "QS Defenda (Big picture) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "QSDefenda(BP).tzx" size 1971 crc 15B06F98 md5 CC64EBD2A4E4BEBC7033F975D33A0D4A sha1 ECCD0670138EA0F14DE3448536ADDDC1DF5CD57F )
+)
+
+game (
+  name "QS Defenda (Big picture) (Quicksilva)"
+  description "QS Defenda (Big picture) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "qsdefenda(bp).p" size 1749 crc 18409A9F md5 973E7FA1E1F0EBDFDFAC2AF2DCF15929 sha1 8E297AEC1684FA43CDD5A1F2D8540BFB0B1B74DD )
+)
+
+game (
+  name "QS Invaders (Quicksilva)"
+  description "QS Invaders (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
+)
+
+game (
+  name "QS Invaders (Quicksilva)"
+  description "QS Invaders (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
+)
+
+game (
+  name "QS Invaders (Number) (Quicksilva)"
+  description "QS Invaders (Number) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
+)
+
+game (
+  name "QS Invaders (Number) (Quicksilva)"
+  description "QS Invaders (Number) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
+)
+
+game (
+  name "QS Invaders (Number, Upside down) (Quicksilva)"
+  description "QS Invaders (Number, Upside down) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSInvaders.tzx" size 7399 crc 6E8F0E11 md5 4C23B7F672AE9F4A12C24A54A485CDA0 sha1 E9AA462B6D7EDD1D2BCF20F37CF2F486AE61EFF1 )
+)
+
+game (
+  name "QS Invaders (Number, Upside down) (Quicksilva)"
+  description "QS Invaders (Number, Upside down) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "qsinvaders.p" size 7177 crc 81C099F2 md5 E3356D6FBA598AA9FA70D4E8853F2C76 sha1 BE764A893381A2B7AD55706DD7A60B1C0EBA97F4 )
+)
+
+game (
+  name "QS Invaders (Big picture) (Quicksilva)"
+  description "QS Invaders (Big picture) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "qsinvaders(bp).p" size 7185 crc F855545E md5 72C039832C770144F6ABBD7FCC1410D8 sha1 C2AB1CD34875DCD0F23206C5CE2F745169D047C0 )
+)
+
+game (
+  name "QS Invaders (Big picture) (Quicksilva)"
+  description "QS Invaders (Big picture) (Quicksilva)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "QSInvaders(BP).tzx" size 7407 crc 05B21451 md5 AC31E8EF363DEF7FB56EBBAB76F49DB1 sha1 92B476ABE309E02A9721AB2DB8D927418060338E )
+)
+
+game (
+  name "QS Scramble (Number) (Quicksilva)"
+  description "QS Scramble (Number) (Quicksilva)"
+  year "1982"
+  manufacturer "Quicksilva"
+  rom ( name "QSScramble(Alt).tzx" size 6320 crc 30847836 md5 09A4633A93747AEB1BCA9E190AEAA14C sha1 7EE4B859C49EE81A670BD629E05AC27177DDDB7D )
+)
+
+game (
+  name "Q Save (PSS)"
+  description "Q Save (PSS)"
+  manufacturer "PSS"
+  rom ( name "qsave.p" size 1547 crc A3EDAAB2 md5 48C37E545EAA01EF260E4B4799DC5992 sha1 FBDC2B3081B1E088AB05129EF8A5376E1378652D )
+)
+
+game (
+  name "Q Save (Red) (PSS)"
+  description "Q Save (Red) (PSS)"
+  manufacturer "PSS"
+  rom ( name "QSave(Red).tzx" size 1693 crc 28BCFD44 md5 D6DB4577CE639CE63B01D3EC351A5CF6 sha1 173946BA09A7B0F085B975D25DDFE6F431541186 )
+)
+
+game (
+  name "Q Save (Red) (PSS)"
+  description "Q Save (Red) (PSS)"
+  manufacturer "PSS"
+  rom ( name "qsave(red).p" size 1467 crc 7918413A md5 597C8A759AF88CA64C2AD2462492887F sha1 46EE323C057848AB62D253662891EAE847E449D8 )
+)
+
+game (
+  name "RPN Calculator (Zeta Software)"
+  description "RPN Calculator (Zeta Software)"
+  year "1982"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "rpncalculator.p" size 8282 crc FD66EF0E md5 DF81AB32F89ACCD286BF7CAC114DB2A4 sha1 CD9F8D264AF05FEE79132004522EB5049F250650 )
+)
+
+game (
+  name "RPN Calculator (Zeta Software)"
+  description "RPN Calculator (Zeta Software)"
+  year "1982"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "RPNCalculator.tzx" size 8504 crc 1609EF0D md5 6943FDF8FB6E3D76EE3C9D119D3CD441 sha1 A6283859FFC5D6390B55803129777FE32B74D627 )
+)
+
+game (
+  name "Ram Runner (Timex)"
+  description "Ram Runner (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "ramrunner.p" size 12985 crc 1CAA4B3E md5 B18437B08FDEFF0CACA69EA2AFAE96EB sha1 998860F07B4C60A190883E5BBDFB3AE249C40F1C )
+)
+
+game (
+  name "Ram Runner (Timex)"
+  description "Ram Runner (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "RamRunner.tzx" size 13213 crc 9AD7E13F md5 EEF86DD226681E5E6CD3DB6A7EB2766E sha1 C821A765C4045B8107FF273DAC9D211BACA717CD )
+)
+
+game (
+  name "Real Estate Investment Analysis (Timex)"
+  description "Real Estate Investment Analysis (Timex)"
+  year "1982"
+  manufacturer "American Micro Products Inc."
+  rom ( name "RealEstateInvestmentAnalysis.tzx" size 16047 crc 8373ADA1 md5 98459338D5E57BE0F9E7721C4BCFD883 sha1 240481EB5E8B45EE3E7D240076819B8E2593C3F0 )
+)
+
+game (
+  name "Real Estate Investment Analysis (Timex)"
+  description "Real Estate Investment Analysis (Timex)"
+  year "1982"
+  manufacturer "American Micro Products Inc."
+  rom ( name "realestateinvestmentanalysis.p" size 15825 crc EDEF9F40 md5 5767AD8D9E1AE3F9FEDBA17514A069E5 sha1 C75505864F9FE3D9842561EC9BDE7A4D24CC9D57 )
+)
+
+game (
+  name "Red Alert (Softsync)"
+  description "Red Alert (Softsync)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "RedAlert.tzx" size 4236 crc 16D48454 md5 4C5E219F57813A8838E43BA6AE791810 sha1 61A4719DA9099699143E39713D08C13E381E9216 )
+)
+
+game (
+  name "Red Alert (Softsync)"
+  description "Red Alert (Softsync)"
+  year "1981"
+  manufacturer "Quicksilva"
+  rom ( name "redalert.p" size 4004 crc E3F0E0C6 md5 3EE4DE96FF92AA764D6A5AF1978BF769 sha1 D95C77E1B695AF04D6679CDAB70ED2AB9CAA8F2A )
+)
+
+game (
+  name "Rental Property Manager (Data-assette)"
+  description "Rental Property Manager (Data-assette)"
+  manufacturer "John Powers"
+  rom ( name "rentalpropertymanager.p" size 16109 crc 2316C873 md5 79E94AC3F50F837458EAF07ED4317951 sha1 79194CF5DFCA47D67866257DBF2E2F31D8E79272 )
+)
+
+game (
+  name "Rental Property Manager (Data-assette)"
+  description "Rental Property Manager (Data-assette)"
+  manufacturer "John Powers"
+  rom ( name "RentalPropertyManager.tzx" size 16339 crc 92F8AA70 md5 4B297D59DFA3FD14EE638B35D6F8BC99 sha1 378BB82167E1EE3A4F8EC8A69B2A3612CD2B2810 )
+)
+
+game (
+  name "Reversi also known as Othello (Sinclair Research)"
+  description "Reversi also known as Othello (Sinclair Research)"
+  year "1982"
+  manufacturer "Moi/Games of Skill Ltd"
+  rom ( name "Reversi.tzx" size 6452 crc 01930D80 md5 E33B1E6B4508F5EFF9D7F0C873B0C94D sha1 0B09A2D44F3FB3243DA9CC46FF161BFFE6D8021B )
+)
+
+game (
+  name "Reversi also known as Othello (Sinclair Research)"
+  description "Reversi also known as Othello (Sinclair Research)"
+  year "1982"
+  manufacturer "Moi/Games of Skill Ltd"
+  rom ( name "reversi.p" size 6222 crc 9317D6CF md5 496AEEF5F2CEA222A7223625F990C8F4 sha1 DF86A5E30D5E38F37A3AB4E2975515E38BDDBB82 )
+)
+
+game (
+  name "Reversi (Artic)"
+  description "Reversi (Artic)"
+  year "1982"
+  manufacturer "T. Hughes"
+  rom ( name "reversi(artic).p" size 14726 crc 613DD959 md5 5529E75702832F4C17874D81E49833A2 sha1 89E9591FF6720A374C30A1BE117E5B9720FCEA98 )
+)
+
+game (
+  name "Reversi (Artic)"
+  description "Reversi (Artic)"
+  year "1982"
+  manufacturer "T. Hughes"
+  rom ( name "Reversi(Artic).tzx" size 14952 crc D5796E37 md5 708F70B98133DE0290338C974AE50509 sha1 516F08CEEFE2997E183E6F47E774FDA4B81D7BE3 )
+)
+
+game (
+  name "Robbers of the Lost Tomb (Timeworks)"
+  description "Robbers of the Lost Tomb (Timeworks)"
+  year "1982"
+  manufacturer "Timeworks"
+  rom ( name "robbersofthelosttomb.p" size 12141 crc 79FCFB44 md5 02209F4889C543A0A43D451743708328 sha1 345FA829AD2F082291C236EC5826AED0E864D8BA )
+)
+
+game (
+  name "Robbers of the Lost Tomb (Timeworks)"
+  description "Robbers of the Lost Tomb (Timeworks)"
+  year "1982"
+  manufacturer "Timeworks"
+  rom ( name "RobbersOfTheLostTomb.tzx" size 12365 crc 700A0975 md5 7D90A419CC9FC490F597993EFFB7D068 sha1 4E78F00D3529ACCFDDE236C2EF24E43106B5D8D4 )
+)
+
+game (
+  name "Rocket Man (Software Farm)"
+  description "Rocket Man (Software Farm)"
+  year "1984"
+  manufacturer "Software Farm"
+  rom ( name "RocketMan.tzx" size 15561 crc E34ADCA9 md5 4EF97704D962703CA65309098356D20B sha1 024909DDF04E7EFB22C4E84781AEA9CE8E20A877 )
+)
+
+game (
+  name "Rocket Man (Software Farm)"
+  description "Rocket Man (Software Farm)"
+  year "1984"
+  manufacturer "Software Farm"
+  rom ( name "rocketman.p" size 15327 crc 93FDEFB0 md5 2A2606484CF8BBC5BFDFECE4B1AB657B sha1 C9BDE797AB35E89FE71FE595857B5D1D1D2740FC )
+)
+
+game (
+  name "Roman Empire (Lothlorien)"
+  description "Roman Empire (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "RomanEmpire.tzx" size 15328 crc 5EEEF590 md5 A0B4632B0BC95998B687AF11DF7C769B sha1 38225146A420B541CD425E420B5C21C794FD7486 )
+)
+
+game (
+  name "Roman Empire (Lothlorien)"
+  description "Roman Empire (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "romanempire.p" size 15108 crc 19EBF247 md5 5C3BABFF0601A703A4EE3549D7608422 sha1 3629F81C9DFF99B9D9BB84EE392F3C3EC345916F )
+)
+
+game (
+  name "Rubik Cube (Alt) (CDS Micro Systems)"
+  description "Rubik Cube (Alt) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "RubikCube(Alt).tzx" size 14601 crc 11D010A0 md5 A514D66D19792684AD2F5F8987BB9448 sha1 7996CA3BB737847719BDFC0663483D0906D74282 )
+)
+
+game (
+  name "Rubik Cube (Alt) (CDS Micro Systems)"
+  description "Rubik Cube (Alt) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "rubikcube(alt).p" size 14375 crc C163A924 md5 12BCC34945162BEB2B494198AEA60E23 sha1 8075D277091B180EE535F253DAEAF7CD39135069 )
+)
+
+game (
+  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "rubikcube.p" size 15158 crc 8AE261A2 md5 D70593B633E0E6A88A7E919F6F4C95C2 sha1 31426D332E594597879A9C42B259436445E96E4E )
+)
+
+game (
+  name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
+  year "1982"
+  manufacturer "CDS Micro Systems"
+  rom ( name "RubikCube.tzx" size 15384 crc 580179A6 md5 724CDC2B86991F8710876579F9A16559 sha1 9B1B7F10E2EBFC90B3653DC10EC0FFD0D5A5C552 )
+)
+
+game (
+  name "Sabotage (Sinclair Research)"
+  description "Sabotage (Sinclair Research)"
+  year "1982"
+  manufacturer "Macronics"
+  rom ( name "Sabotage.tzx" size 9070 crc 0120FE03 md5 6BECDEBC9329742A817E1D0068716DED sha1 4D123B512A757FE2E0BFD7DDEE111322D8238D9F )
+)
+
+game (
+  name "Sabotage (Sinclair Research)"
+  description "Sabotage (Sinclair Research)"
+  year "1982"
+  manufacturer "Macronics"
+  rom ( name "sabotage.p" size 8852 crc 682B39A0 md5 93A3AC8C7C759D72848470E7BF1595FC sha1 43467CEF8EF83457AD6BAC424DDD89AB885FED3C )
+)
+
+game (
+  name "Salvo (Orbyte Software)"
+  description "Salvo (Orbyte Software)"
+  manufacturer "A & M Productions"
+  rom ( name "salvo.p" size 15284 crc 202F1A9B md5 009ACFC6E76E528F40CC693753E73251 sha1 3BD88AC1E2A1DFCA98AD495346E0C65D9936A1A0 )
+)
+
+game (
+  name "Salvo (Orbyte Software)"
+  description "Salvo (Orbyte Software)"
+  manufacturer "A & M Productions"
+  rom ( name "Salvo.tzx" size 15510 crc D9303929 md5 A28B801FF835CD8DCCDDACF23ED8DB1F sha1 706DDD40FFC24AD4FFFCEF7D8F77889A6A1C1A19 )
+)
+
+game (
+  name "Samurai Warrior (Lothlorien)"
+  description "Samurai Warrior (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "samuraiwarrior.p" size 15261 crc 6804E38D md5 E268D6C175C8359BC23491AA237C0AA5 sha1 24AC5226D3E646254F00F3CCAD7ABFDE618B346C )
+)
+
+game (
+  name "Samurai Warrior (Lothlorien)"
+  description "Samurai Warrior (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "SamuraiWarrior.tzx" size 15481 crc 68F13FB0 md5 4E59F61C5A39BF5F8B372BA40A009B07 sha1 A6D7B88718F8EF85E300CB1BA696544A6CB1EFCF )
+)
+
+game (
+  name "Scramble (Mikro-Gen)"
+  description "Scramble (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "Scramble.tzx" size 4693 crc DD9359A4 md5 8F50B50F065FF824C39209C4680BF2AA sha1 84760E3B08C0E5686C9ACE4B23DFF5B6187DA367 )
+)
+
+game (
+  name "Scramble (Mikro-Gen)"
+  description "Scramble (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "scramble.p" size 4455 crc 6CA59CEB md5 1CACE2E4CEA14D6F96913F3ED7D7204F sha1 BD6FF916C9A18EA0EDA7D21B061670231643E308 )
+)
+
+game (
+  name "Scramble (Colour inlay) (Mikro-Gen)"
+  description "Scramble (Colour inlay) (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "scramble(ci).p" size 4455 crc BFC4A5E6 md5 F9BA0FFC3497E3FD978A6894FCF28547 sha1 6ADD38B04DE58597B939F24F35613B6A1B8E2EB5 )
+)
+
+game (
+  name "Scramble (Colour inlay) (Mikro-Gen)"
+  description "Scramble (Colour inlay) (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "Scramble(CI).tzx" size 4693 crc 0EF260A9 md5 DE5F9BB0623C40822463CA512F959D06 sha1 338BA99E7D814653800311CD67BE49FCA764A822 )
+)
+
+game (
+  name "Screen Kit 1 (Picturesque)"
+  description "Screen Kit 1 (Picturesque)"
+  manufacturer "Picturesque"
+  rom ( name "screenkit1.p" size 1841 crc FE229E5D md5 3DAB82C0980EECA3B0F22016ED6DCD16 sha1 84ABE2D096D68E01573FE1AEA3C3A0646C62E6F5 )
+)
+
+game (
+  name "Screen Kit 1 (Picturesque)"
+  description "Screen Kit 1 (Picturesque)"
+  manufacturer "Picturesque"
+  rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 EC8D98CEC4AC5B718D7AB4C188A99A01 sha1 78351CB1C27587935242BF9BB0F512D07B902625 )
+)
+
+game (
+  name "Sea Wolf (Stephen Hartley Computing)"
+  description "Sea Wolf (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. R. Bird"
+  rom ( name "SeaWolf.tzx" size 9732 crc D23CF454 md5 0FCEB5B1AE6ED2721D95F2343F6CDF37 sha1 F0275FE3BC08875E643BE9431615B7A7C5BA64AB )
+)
+
+game (
+  name "Sea Wolf (Stephen Hartley Computing)"
+  description "Sea Wolf (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. R. Bird"
+  rom ( name "seawolf.p" size 9502 crc 7156979A md5 394000D5A21F5320B63C1145E30F119F sha1 1C221622620508CDD921E0D84C34042FCA87D1CC )
+)
+
+game (
+  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  description "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. R. Bird"
+  rom ( name "seawolf(newer).p" size 9502 crc 3D713295 md5 A437D3A2D8AE59C77CCA90BFB572ECD7 sha1 C75D950618D084F3CF1A0903A696D0A9BB8B6121 )
+)
+
+game (
+  name "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  description "Sea Wolf (Newer) (Stephen Hartley Computing)"
+  year "1983"
+  manufacturer "I. R. Bird"
+  rom ( name "SeaWolf(Newer).tzx" size 9732 crc 9E1B515B md5 C71A018235CC635882535A19A256CE7A sha1 B55B9B06C9805D2253335D4F61A6AE43BBE9FFE4 )
+)
+
+game (
+  name "Adventure C - The Ship of Doom (Sinclair Research)"
+  description "Adventure C: The Ship of Doom (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "ShipOfDoom.tzx" size 14275 crc AE8D5B3C md5 6E53EF483B27D942FF3AD6E69256C116 sha1 A1E5AB55214DA2CA312345586F684E65204D52AD )
+)
+
+game (
+  name "Adventure C - The Ship of Doom (Sinclair Research)"
+  description "Adventure C: The Ship of Doom (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "shipofdoom.p" size 14045 crc B8E32F06 md5 2515BA4AD2C1758F83D4E2F2CC81D6CA sha1 C64B4AE9FDBD955695660E6BD6A04EF2A6F91F39 )
+)
+
+game (
+  name "Adventure C - Ship of Doom (Artic)"
+  description "Adventure C: Ship of Doom (Artic)"
+  manufacturer "Artic"
+  rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284A314F md5 CA0BAB03EEFF0FC9BCC040148E20C7D2 sha1 96221BCEBA4FF6E90FDC59271DA1D7973362E8F8 )
+)
+
+game (
+  name "Adventure C - Ship of Doom (Artic)"
+  description "Adventure C: Ship of Doom (Artic)"
+  manufacturer "Artic"
+  rom ( name "shipofdoom(artic).p" size 14045 crc 3E244575 md5 47AE04D2D34190DD2F9D47FB9815F4DE sha1 689552EF631FACC558C6FC9B902F20495E870936 )
+)
+
+game (
+  name "Similes Countdown (AVC Software)"
+  description "Similes Countdown (AVC Software)"
+  year "1981"
+  manufacturer "K. Jammer and S. Brown"
+  rom ( name "SimilesCountdown.tzx" size 10151 crc FBBCDEF4 md5 E270304C53D20E65B47EF69BD0FEFDC8 sha1 7CD764FCBD90D455FB2D31CEEC7CDA10B08EC8CD )
+)
+
+game (
+  name "Similes Countdown (AVC Software)"
+  description "Similes Countdown (AVC Software)"
+  year "1981"
+  manufacturer "K. Jammer and S. Brown"
+  rom ( name "similescountdown.p" size 9899 crc F2F2B554 md5 ADCE97D888CA6665A5071A5DF2759364 sha1 4D0117466C37DF6B4FAFDC3EFF7F75F3AEA3AED1 )
+)
+
+game (
+  name "Space Intruders (Hewson Consultants)"
+  description "Space Intruders (Hewson Consultants)"
+  year "1981"
+  manufacturer "Hewson Consultants"
+  rom ( name "SpaceIntruders.tzx" size 4010 crc 88B1156F md5 F15A15BE576DC7EFDCFD8BDF87FAAADF sha1 8AAF24A56FE3CC999CE32AE795CE0BBD7983838F )
+)
+
+game (
+  name "Space Intruders (Hewson Consultants)"
+  description "Space Intruders (Hewson Consultants)"
+  year "1981"
+  manufacturer "Hewson Consultants"
+  rom ( name "spaceintruders.p" size 3764 crc 074DC33E md5 6919EDC03F14FC6772C089AF461624D6 sha1 DFED85EAFDE74AFB2C3237003D73E7FA3FE69837 )
+)
+
+game (
+  name "Space Invaders (Mikro-Gen)"
+  description "Space Invaders (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "SpaceInvaders.tzx" size 2896 crc A345E8DB md5 F835A9B2D5DCE454A2DDC4CAF8175505 sha1 4536F0D2A465A71891803B23D29BC8C54C1B874F )
+)
+
+game (
+  name "Space Invaders (Mikro-Gen)"
+  description "Space Invaders (Mikro-Gen)"
+  manufacturer "Mikro-Gen"
+  rom ( name "spaceinvaders.p" size 2664 crc E39A90BE md5 CCE844A181612AD7E32209E73CE42B9C sha1 795CC3740CAEE56E9AF16A52B557D93B968D0CDE )
+)
+
+game (
+  name "Space Invaders (dK'tronics)"
+  description "Space Invaders (dK'tronics)"
+  year "1981"
+  manufacturer "dK'tronics"
+  rom ( name "spaceinvaders(dk).p" size 6645 crc 4C0EDB0A md5 7BB4A934DDC0746167E6FAC17F71CAE4 sha1 1392C3C2BA459FBC67EDB18FD96FD617FD8AD167 )
+)
+
+game (
+  name "Space Invaders (dK'tronics)"
+  description "Space Invaders (dK'tronics)"
+  year "1981"
+  manufacturer "dK'tronics"
+  rom ( name "SpaceInvaders(dk).tzx" size 6889 crc 720BF20C md5 3D25C73AC6E5C6F48081EB86A5D0E0B3 sha1 E9D543B4F96BBDA648C1488A06D2538ED3DA3001 )
+)
+
+game (
+  name "Space Invaders 3K (Macronics)"
+  description "Space Invaders 3K (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "spaceinvaders3k.p" size 2854 crc F1273575 md5 DD982A212278DF38FA34C19B19DB4484 sha1 653DD0BA53D7005005FFF184EE8D556CB6982A23 )
+)
+
+game (
+  name "Space Invaders 3K (Macronics)"
+  description "Space Invaders 3K (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "SpaceInvaders3K.tzx" size 3074 crc 69729ABD md5 753F7387213896A0DAE8E09A4974D2A2 sha1 00BEA09A8D43CFD35CB2FB44EFF623692811D2A9 )
+)
+
+game (
+  name "Space Man Apollo (ICT)"
+  description "Space Man Apollo (ICT)"
+  year "1984"
+  manufacturer "Iain Thomson"
+  rom ( name "SpacemanApollo.tzx" size 15875 crc 0FC40716 md5 17291434CA3E09AED13B243F95498B0B sha1 68861A48E02A2D65B717012DF38600D96986DF97 )
+)
+
+game (
+  name "Space Man Apollo (ICT)"
+  description "Space Man Apollo (ICT)"
+  year "1984"
+  manufacturer "Iain Thomson"
+  rom ( name "spacemanapollo.p" size 15647 crc 1ADF5140 md5 0E91BCAC7314FB7D95DB8D86CB4920F4 sha1 FD98B6596B28BC0ECDA1F3B7AAEF526809D3A38E )
+)
+
+game (
+  name "Space Mission (Gem Software)"
+  description "Space Mission (Gem Software)"
+  year "1982"
+  manufacturer "Gem Software"
+  rom ( name "SpaceMission.tzx" size 13607 crc 0DACAB8D md5 35AC87605BE32557CE38BFBF61F3DBAA sha1 BD92C04A311A49E5846E35528D692EE5E6EB2BCF )
+)
+
+game (
+  name "Space Mission (Gem Software)"
+  description "Space Mission (Gem Software)"
+  year "1982"
+  manufacturer "Gem Software"
+  rom ( name "spacemission.p" size 13365 crc 97DF84E4 md5 BE00529EBF59E65659D1D658976FA738 sha1 1071D74D173D8F325894F0DBAC851E60A15E38B2 )
+)
+
+game (
+  name "Space Trek (Micromega)"
+  description "Space Trek (Micromega)"
+  manufacturer "Micromega"
+  rom ( name "spacetrek.p" size 15395 crc 8C8545B1 md5 EB1DB83F22E599C4A8927BDF043D2677 sha1 FF8A32EE7197F3EF632F2CF231CB0CA7CBF1DEFC )
+)
+
+game (
+  name "Space Trek (Micromega)"
+  description "Space Trek (Micromega)"
+  manufacturer "Micromega"
+  rom ( name "SpaceTrek.tzx" size 15619 crc 081B0787 md5 7A2A66E12F7983634FF1CA0B9B795DED sha1 0E20ED7812A34AD507EC1C1DC23536641C4B9993 )
+)
+
+game (
+  name "Spacetrek (JRS Software)"
+  description "Spacetrek (JRS Software)"
+  manufacturer "JRS Software"
+  rom ( name "Spacetrek(JRS).tzx" size 550 crc D62CC02F md5 17AAF306F2269D03004C5866D47AF928 sha1 1B0C8177A41AEA9AA40F5698280C86E505151349 )
+)
+
+game (
+  name "Spacetrek (JRS Software)"
+  description "Spacetrek (JRS Software)"
+  manufacturer "JRS Software"
+  rom ( name "spacetrek(jrs).p" size 332 crc C2F526DF md5 A3B4C8C194FFD9B3DF6AB21F57BCC6CC sha1 6B5C61147A38082825FC71A003937E5F07F59F02 )
+)
+
+game (
+  name "Spelling Bee (Timex)"
+  description "Spelling Bee (Timex)"
+  year "1983"
+  manufacturer "Russell Klein"
+  rom ( name "SpellingBee.tzx" size 48415 crc A5987F22 md5 75F46B5EAC8F50943EBE3C185DA8A98B sha1 D992D921483B59B85AE68BDFA6E44D1C9C5068CC )
+)
+
+game (
+  name "The Stamp Collector (Timex)"
+  description "The Stamp Collector (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "stampcollectorthe.p" size 14449 crc 2A38E112 md5 9329DEE03B6620D5000DD3FFC9643068 sha1 69DAAAB88AEC472F12910BB0C3B56C188B5C05AD )
+)
+
+game (
+  name "The Stamp Collector (Timex)"
+  description "The Stamp Collector (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "StampCollectorThe.tzx" size 14675 crc 702011B4 md5 A207294C88268520101A8B277FC1B882 sha1 E44F8118A5EF3C7FFC55A46D476CDB0F516179CE )
+)
+
+game (
+  name "Star Trek (Bug Byte)"
+  description "Star Trek (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "StarTrek.tzx" size 10250 crc C8107516 md5 DB8FBA7FBA8544B74B63C53519163BE7 sha1 3E0F7D137F9572F756BA9EDC5C6835FA9367BE81 )
+)
+
+game (
+  name "Star Trek (Bug Byte)"
+  description "Star Trek (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "startrek.p" size 10018 crc A3004740 md5 33BACEF251164137A75E7B9A7164ADA0 sha1 7A890295C0B822938DB6E8DC70BB68D669BF9051 )
+)
+
+game (
+  name "Star Trek (Macronics)"
+  description "Star Trek (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "StarTrek(Macronics).tzx" size 16091 crc 171E0B56 md5 9F7EF6572BF3D71C53B3EF64053A0715 sha1 5A25A295FC011E37B8941634AD32746B9D626D48 )
+)
+
+game (
+  name "Star Trek (Macronics)"
+  description "Star Trek (Macronics)"
+  year "1981"
+  manufacturer "Macronics"
+  rom ( name "startrek(macronics).p" size 15869 crc E33D9286 md5 DAC4C635719E0A8A0B7D55CC18F2E6A6 sha1 2F7D41853AA556EE5197A54E03E405286884343D )
+)
+
+game (
+  name "Star Trek (Typed Inlay) (Bug Byte)"
+  description "Star Trek (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "startrek(typed).p" size 10018 crc 2749661E md5 9E9F60D7E165323899D49206285D9C3A sha1 F289F9958DF4C2A7F811E36920FA4B7C74BC505C )
+)
+
+game (
+  name "Star Trek (Typed Inlay) (Bug Byte)"
+  description "Star Trek (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "StarTrek(Typed).tzx" size 10250 crc 4C595448 md5 C7D23895712792195672678584E5D250 sha1 D6286120A5ACC82D974F76E381F3382FE0C55BE8 )
+)
+
+game (
+  name "Starquest (Pixel Productions)"
+  description "Starquest (Pixel Productions)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Starquest.2.Starquest.tzx" size 16209 crc 85BFC2B5 md5 7602A6DA23E1E058B4EF39AC1B1D29CD sha1 F0D5783909CA9A5954ECD71854F4F9AAA57D6619 )
+)
+
+game (
+  name "Starquest (Pixel Productions)"
+  description "Starquest (Pixel Productions)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "starquest.p" size 15989 crc FB070BD6 md5 73407DFBDAE230F813EE47EE62747A4F sha1 6171F22250E4BFAF347B85F1E0CFECA5312DDDAE )
+)
+
+game (
+  name "Starquest (International Publishing and Software Inc.)"
+  description "Starquest (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Starquest(IPS).tzx" size 17893 crc 0375BD08 md5 7237E3D312CDECFA235A945CD88B3AEF sha1 FA7A242596852D6AA1C2FF15142EA2F1ED6D4B1F )
+)
+
+game (
+  name "The Starter (Timex)"
+  description "The Starter (Timex)"
+  year "1981"
+  manufacturer "Sinclair"
+  rom ( name "Starter.tzx" size 2613 crc 00CB3C24 md5 D4DE1B915C3A27215AE0BF6BFC60AA91 sha1 C2BE276CF0F988DF20707105F0FB5D6380D8E357 )
+)
+
+game (
+  name "States and Capitals (Timex)"
+  description "States and Capitals (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "StatesAndCapitals.tzx" size 11538 crc C70FA5A4 md5 A2FAD8976A643EA58281AE9C6276123A sha1 99551D3BB7AD39B7F55BE16973AF29DC7425E9E3 )
+)
+
+game (
+  name "States and Capitals (Timex)"
+  description "States and Capitals (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "statesandcapitals.p" size 11310 crc D0BE9818 md5 BEDB20F535283C3D59EB0990A07690AF sha1 509778144C3918CE04F64A5D723D17F7CACD9719 )
+)
+
+game (
+  name "Statistics (Timex)"
+  description "Statistics (Timex)"
+  year "1982"
+  manufacturer "R. Daniel"
+  rom ( name "Statistics.tzx" size 4852 crc 22EB02C8 md5 0EB9DB5C0720BE88D236A198C94797D4 sha1 494389E8AD0A8C8ADB4A7FA17C91464A78D555E2 )
+)
+
+game (
+  name "Statistics (Zeta Software)"
+  description "Statistics (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "statistics(zeta).p" size 13376 crc 9204F603 md5 F82DE91F3B217E98A74152E96AB3856B sha1 5DF7CA4145A22CC7F730AAC13FE8835C40669321 )
+)
+
+game (
+  name "Statistics (Zeta Software)"
+  description "Statistics (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "Statistics(Zeta).tzx" size 13600 crc C0B4F14A md5 2B944E3BF6F17648919C3591B7B9905A sha1 7F13B230064429AB366F0816B43D683085D0BF62 )
+)
+
+game (
+  name "Stock Car (Informatique Service)"
+  description "Stock Car (Informatique Service)"
+  year "1984"
+  rom ( name "StockCar.tzx" size 8450 crc FEDBBC78 md5 CD54361859D4D5AE1E4290C8C5DB8063 sha1 3604D2FF3B9DE27E45CB691131B98BE09BA3C65B )
+)
+
+game (
+  name "Stock Car (Informatique Service)"
+  description "Stock Car (Informatique Service)"
+  year "1984"
+  rom ( name "stockcar.p" size 8216 crc 41224D6B md5 C7549CD5DFC22BD438A16D6FFEB29B18 sha1 E70D50DE2F51597BC74A50BDB25A34BF6B059888 )
+)
+
+game (
+  name "Stock-Market (Video Software)"
+  description "Stock-Market (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "StockMarket.A.tzx" size 11978 crc 440CC0E5 md5 CAD4AB9C37B2DB19EE7950CDFBE71490 sha1 849C2761901E9210F101500E5603D38B90E55A8C )
+)
+
+game (
+  name "Stock-Market (Video Software)"
+  description "Stock-Market (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "stockmarket.p" size 11738 crc D6F22D69 md5 3C4E77ADF07396603240C9225499245D sha1 A71FF5FCC069C95E0E0CA480E78A724EA73FCF00 )
+)
+
+game (
+  name "Stock Market Tech. Analysis 1 (Timex)"
+  description "Stock Market Tech. Analysis 1 (Timex)"
+  year "1982"
+  manufacturer "T. H. Nooter"
+  rom ( name "StockMarketTechAnalysis1.tzx" size 16405 crc 40A9B729 md5 BB445169BD552AA1BEFF7B3221856965 sha1 0D23879DA55A4E5CBD7A8B482D010FDCB21E06F6 )
+)
+
+game (
+  name "Stock Market Tech. Analysis 1 (Timex)"
+  description "Stock Market Tech. Analysis 1 (Timex)"
+  year "1982"
+  manufacturer "T. H. Nooter"
+  rom ( name "stockmarkettechanalysis1.p" size 16177 crc 0EE43E40 md5 23D4292A790D7120376375574118136B sha1 6D8FE3F2BF6B8171AF5A30EC199F6EC5F8C31C30 )
+)
+
+game (
+  name "The Stock Option Analyzer (Timex)"
+  description "The Stock Option Analyzer (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "stockoptionanalyzerthe.p" size 5533 crc 6A11FEF8 md5 5172731B04549EA7E6FD487FCF0B2497 sha1 1FD0599C4CB2F3EC072D2F858F844EAAC0B3CA12 )
+)
+
+game (
+  name "The Stock Option Analyzer (Timex)"
+  description "The Stock Option Analyzer (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "StockOptionAnalyzerThe.tzx" size 5763 crc B829C9C3 md5 78DED4A1D1170EA521DFF3AC3F302CCA sha1 7691EE6F0AC6A103168684AC3CDE78EC128C5E68 )
+)
+
+game (
+  name "Strategy Football (Timex)"
+  description "Strategy Football (Timex)"
+  year "1983"
+  manufacturer "Gerald Bennett"
+  rom ( name "StrategyFootball.tzx" size 15469 crc 432F9356 md5 9CE1D8687FA6EC86C44CEB48F5F0C4BD sha1 4ADD01B5F9E3DDF8F19A686AD91385D4DECE1BBD )
+)
+
+game (
+  name "Strategy Football (Timex)"
+  description "Strategy Football (Timex)"
+  year "1983"
+  manufacturer "Gerald Bennett"
+  rom ( name "strategyfootball.p" size 15249 crc 903DB439 md5 23B460AC48B647E5F5D2029A62C3A27A sha1 51E03AD187AE202E999E2B391E9FE82D4A301D5A )
+)
+
+game (
+  name "Subspace Striker (International Publishing and Software Inc.)"
+  description "Subspace Striker (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "SubspaceStriker(IPS).tzx" size 17446 crc B3C93F34 md5 7D123FE1A0F6430B7A8492483E2FEEB6 sha1 4A0D2D26033BFB0B0D67248B8B2AE1FA5F423DC4 )
+)
+
+game (
+  name "Super Chess (CP Software)"
+  description "Super Chess (CP Software)"
+  year "1982"
+  manufacturer "CP Software"
+  rom ( name "superchess.p" size 16060 crc 650317B6 md5 ABFB385E22165912BEADCA3377E4A6B2 sha1 324F41E92E9C6D5EA06792238B9374EB2340919F )
+)
+
+game (
+  name "Super Chess (CP Software)"
+  description "Super Chess (CP Software)"
+  year "1982"
+  manufacturer "CP Software"
+  rom ( name "SuperChess.tzx" size 16296 crc DAD51D68 md5 50316E46482E309565E8BB584190F3ED sha1 CE79C0B548BB98118E1725C82396887E01AEA430 )
+)
+
+game (
+  name "Super Chess (Softsync)"
+  description "Super Chess (Softsync)"
+  year "1982"
+  manufacturer "CP Software"
+  rom ( name "SuperChess(Softsync).tzx" size 16296 crc BDB36226 md5 5CFB66AEFD5C74F85443D1A89D420410 sha1 5DDA6654A11C6F0AFA5DCB9D7F128667359A6954 )
+)
+
+game (
+  name "Super Chess (Softsync)"
+  description "Super Chess (Softsync)"
+  year "1982"
+  manufacturer "CP Software"
+  rom ( name "superchess(softsync).p" size 16060 crc 026568F8 md5 3834752BC2C52E38631F234A1390810B sha1 A91DF04216AF0CE22B85C6A9BFA8C523E97B7DA2 )
+)
+
+game (
+  name "Super Invaders (Bridge Software)"
+  description "Super Invaders (Bridge Software)"
+  year "1982"
+  manufacturer "Bridge Software"
+  rom ( name "SuperInvaders.tzx" size 12541 crc F662BD98 md5 B4BF9DFF58752EB60FFD48D6AF234720 sha1 3D8C7A7F290D9C792EA7263957DCDAA14CD02C93 )
+)
+
+game (
+  name "Super Invaders (Bridge Software)"
+  description "Super Invaders (Bridge Software)"
+  year "1982"
+  manufacturer "Bridge Software"
+  rom ( name "superinvaders.p" size 12317 crc 94F95161 md5 4F2F2556AB2020046B3B864E1FFDF218 sha1 5BF9CCC9A39A47095143F0506AA778A1BE11C341 )
+)
+
+game (
+  name "Super Invasion (Softsync)"
+  description "Super Invasion (Softsync)"
+  year "1981"
+  manufacturer "Beam Software"
+  rom ( name "superinvasion.p" size 896 crc 54DF2BD2 md5 C65906F94FC9CEF39C32BBDF56CD1B20 sha1 3C6A9CE5D9785C2A51802A21E666B01AF73E0C8E )
+)
+
+game (
+  name "Super Invasion (Softsync)"
+  description "Super Invasion (Softsync)"
+  year "1981"
+  manufacturer "Beam Software"
+  rom ( name "SuperInvasion.tzx" size 1124 crc CC59F451 md5 DD3904D9A8D535358BEBC9AFFCF11854 sha1 447855AB4BD695A574A93FF9FAB09D65258438A5 )
+)
+
+game (
+  name "Super Math (Timex)"
+  description "Super Math (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "SuperMath.tzx" size 8299 crc 21EB7B78 md5 1278409CD4AEF861297F630F88665C5F sha1 3F30FEEAD9537BF39DA7D83175A5A0CC3DCF0A72 )
+)
+
+game (
+  name "Super Math (Timex)"
+  description "Super Math (Timex)"
+  year "1982"
+  manufacturer "Timex"
+  rom ( name "supermath.p" size 8075 crc 1F288F07 md5 5D4125044A0954EA23754D036920A1E7 sha1 4373CF521B219EDB88A527454E97080A27344A72 )
+)
+
+game (
+  name "Super Nine (Romik Software)"
+  description "Super Nine (Romik Software)"
+  year "1982"
+  manufacturer "Romik Software"
+  rom ( name "SuperNine.tzx" size 6872 crc E8B39D87 md5 5C6A25CD318DE3F362261214003C32F1 sha1 5D3CB094E65D4BD9C412F4B6FC18AFCC768E6F41 )
+)
+
+game (
+  name "Super Programs 8 (Sinclair Research)"
+  description "Super Programs 8 (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "SuperPrograms8.tzx" size 15192 crc 2AA20758 md5 545C084C45B5188079167DA9F1ACB304 sha1 DE665EBE1949E077934ED6F0961D525F274F3D6E )
+)
+
+game (
+  name "Super Programs 8 (Sinclair Research)"
+  description "Super Programs 8 (Sinclair Research)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "superprograms8.p" size 14974 crc B876FA33 md5 6D3374DC7EDBFD66F4D48B6140C17C11 sha1 CC2AA503A948D62D0A40FB29D0C628A5E4EA3632 )
+)
+
+game (
+  name "Super Programs 8 (ICL)"
+  description "Super Programs 8 (ICL)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "superprograms8(icl).p" size 14974 crc B7E6C5F1 md5 9AE1C2A5DD3976372CF9A9D712AE20F5 sha1 8CF3626E7B7289CE5FE14F4B5D15D3DDB71BD0EF )
+)
+
+game (
+  name "Super Programs 8 (ICL)"
+  description "Super Programs 8 (ICL)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389A md5 2F2FFF60323980089B85D19FDB34F21C sha1 A40650A76C57EDC7A0431117FE9D9E5C4F47BB6B )
+)
+
+game (
+  name "Super Programs 8 (Sinclair Black) (ICL)"
+  description "Super Programs 8 (Sinclair Black) (ICL)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "superprograms8(icl).p" size 14974 crc B7E6C5F1 md5 9AE1C2A5DD3976372CF9A9D712AE20F5 sha1 8CF3626E7B7289CE5FE14F4B5D15D3DDB71BD0EF )
+)
+
+game (
+  name "Super Programs 8 (Sinclair Black) (ICL)"
+  description "Super Programs 8 (Sinclair Black) (ICL)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389A md5 2F2FFF60323980089B85D19FDB34F21C sha1 A40650A76C57EDC7A0431117FE9D9E5C4F47BB6B )
+)
+
+game (
+  name "Super Scramble (Software Farm)"
+  description "Super Scramble (Software Farm)"
+  year "1982"
+  manufacturer "Software Farm"
+  rom ( name "superscramble.p" size 9068 crc 29C5C5D5 md5 8846EF2A3955E7637F72B13D0A8405B2 sha1 AB1E6FAE6BA522C9CC9363DDB75C35A794FFDFD2 )
+)
+
+game (
+  name "Super Scramble (Software Farm)"
+  description "Super Scramble (Software Farm)"
+  year "1982"
+  manufacturer "Software Farm"
+  rom ( name "SuperScramble.tzx" size 9312 crc 5F11C06C md5 579E55D4ADF1D3EE050BFB59ABAB6167 sha1 AA22BB6FF4C10B8279F2C1E568DB7B9AE5158CA6 )
+)
+
+game (
+  name "Supermaze (Timex)"
+  description "Supermaze (Timex)"
+  year "1982"
+  manufacturer "Greg Harvey"
+  rom ( name "Supermaze.tzx" size 16394 crc 6E93CE7F md5 225EF6BA2E2B9788DBEBA444B5FC60ED sha1 F85D7522E9CD2BF3CBDC3C05493423D7AFAD482B )
+)
+
+game (
+  name "Supermaze (Timex)"
+  description "Supermaze (Timex)"
+  year "1982"
+  manufacturer "Greg Harvey"
+  rom ( name "supermaze.p" size 16170 crc C58F309B md5 2684494519118B0C23B94AB177ED694E sha1 B36C2EAFF62752137C75855E7686A90C58127906 )
+)
+
+game (
+  name "Tables Countdown (AVC Software)"
+  description "Tables Countdown (AVC Software)"
+  year "1981"
+  manufacturer "K. Jammer and C. Deeson"
+  rom ( name "TablesCountdown.tzx" size 9197 crc 59BD7DE7 md5 8FEC27B406D4041D3FB99784F7318F08 sha1 71D4F85478E2EB9016BAB2FD0FAC0107A7FCCDEA )
+)
+
+game (
+  name "Tables Countdown (AVC Software)"
+  description "Tables Countdown (AVC Software)"
+  year "1981"
+  manufacturer "K. Jammer and C. Deeson"
+  rom ( name "tablescountdown.p" size 8947 crc E3B0D8D8 md5 B71D10DCEC0D99531FB8D2FB777751A0 sha1 1713FEB2D1FBDF6D3712E10E2F0291A6BCE813C4 )
+)
+
+game (
+  name "Tai (PSS)"
+  description "Tai (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "tai.p" size 14015 crc C7869E9E md5 17E769CECA4301BEAFB8C1547E62A326 sha1 7A44314234CFFD9FFF42C90A46BE0DB954E63352 )
+)
+
+game (
+  name "Tai (PSS)"
+  description "Tai (PSS)"
+  year "1982"
+  manufacturer "PSS"
+  rom ( name "Tai.tzx" size 14237 crc 3A1351F8 md5 2D7F98ECA4BD7EFE614CA55B6EB4FDE3 sha1 FD0A3CEAC8CE8540E13C7E6AF6F547A2FEFF5D8A )
+)
+
+game (
+  name "Talkback (M. W. F. Ringrose)"
+  description "Talkback (M. W. F. Ringrose)"
+  year "1983"
+  manufacturer "M. W. F. Ringrose"
+  rom ( name "Talkback.tzx" size 12740 crc 36724D18 md5 6CAA20B159F6E66BEC947D4A901862DD sha1 6B32FF6DD4930AD62CADB59B3C4ECDB6EB4A2654 )
+)
+
+game (
+  name "Tapebook 50 1K (Control Technology)"
+  description "Tapebook 50 1K (Control Technology)"
+  manufacturer "Control Technology"
+  rom ( name "TapeBook50.tzx" size 37005 crc D882BCCD md5 05B0B6C39C1A331E9D4592944F5FCF03 sha1 0D1B30D4D024147C9489D56E0519F9F60BF75CBD )
+)
+
+game (
+  name "Tarot (Timex)"
+  description "Tarot (Timex)"
+  year "1983"
+  manufacturer "Computer Phood"
+  rom ( name "Tarot.tzx" size 29510 crc 5C63C324 md5 35525DAE43101AB654360464227DFC37 sha1 81F1AB607044FD2B44C1163A0CB317DC1727D0A4 )
+)
+
+game (
+  name "Tasword (Tasman Software)"
+  description "Tasword (Tasman Software)"
+  year "1982"
+  manufacturer "Tasman Software"
+  rom ( name "tasword.p" size 5339 crc D2CD3934 md5 DD0169E3A06413005F30670F959D56D4 sha1 9DD68379EB1079CEB6B3A106CBC9839A2DF9AD30 )
+)
+
+game (
+  name "Tasword (Tasman Software)"
+  description "Tasword (Tasman Software)"
+  year "1982"
+  manufacturer "Tasman Software"
+  rom ( name "Tasword.tzx" size 5569 crc 9B77040A md5 321945F0628D33E073AE1C306D2EAD5A sha1 100BE588AD785F012F513E8043C323348B5E44ED )
+)
+
+game (
+  name "Tempest (Mikro-Gen)"
+  description "Tempest (Mikro-Gen)"
+  manufacturer "S. P. Kelly"
+  rom ( name "Tempest.tzx" size 3521 crc 5CCA0DED md5 09BDEA36A433F0A3F5FE8B8BCC8E0AA3 sha1 A4CFD1F82D0E4D255AE3B54A54F30A6CB96CE4F9 )
+)
+
+game (
+  name "Tempest (Mikro-Gen)"
+  description "Tempest (Mikro-Gen)"
+  manufacturer "S. P. Kelly"
+  rom ( name "tempest.p" size 3291 crc F760AFBA md5 44309DC8B4E242A1E08DFAD3F4D590BA sha1 8E4C160DF4EC5905F38A922E8E1403D984C92FE4 )
+)
+
+game (
+  name "Ten 1K Games (Computer Rentals)"
+  description "Ten 1K Games (Computer Rentals)"
+  year "1983"
+  manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
+  rom ( name "Ten1KGames.tzx" size 7545 crc C724FD4A md5 60CCCFA8C4852F55D0EEDA74524C0CA0 sha1 589C68041F90A46FB8C18118C0889C6B8F91F0CA )
+)
+
+game (
+  name "Tomb of Dracula (Moviedrome Video)"
+  description "Tomb of Dracula (Moviedrome Video)"
+  manufacturer "Moviedrome Video"
+  rom ( name "TombOfDracula.tzx" size 14743 crc EF2A3F64 md5 D1E99F6B365C888E93C405E7A37A529A sha1 E883C6E1992DDD67A82E66709211D024B563AA36 )
+)
+
+game (
+  name "Tomb of Dracula (Moviedrome Video)"
+  description "Tomb of Dracula (Moviedrome Video)"
+  manufacturer "Moviedrome Video"
+  rom ( name "tombofdracula.p" size 14523 crc D7EBCD59 md5 547C42491C4EA4D99FD0386644CB3394 sha1 2228C845E69487DB3CB302D4AF27E2C03181D3B5 )
+)
+
+game (
+  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  description "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  year "1982"
+  manufacturer "Felix Software"
+  rom ( name "TombOfDracula.tzx" size 14743 crc EF2A3F64 md5 D1E99F6B365C888E93C405E7A37A529A sha1 E883C6E1992DDD67A82E66709211D024B563AA36 )
+)
+
+game (
+  name "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  description "Tomb of Dracula (Colour Inlay) (Felix Software)"
+  year "1982"
+  manufacturer "Felix Software"
+  rom ( name "tombofdracula.p" size 14523 crc D7EBCD59 md5 547C42491C4EA4D99FD0386644CB3394 sha1 2228C845E69487DB3CB302D4AF27E2C03181D3B5 )
+)
+
+game (
+  name "Toolkit (Sinclair Research)"
+  description "Toolkit (Sinclair Research)"
+  manufacturer "Artic"
+  rom ( name "Toolkit.tzx" size 3820 crc C015038B md5 EE928ACDD0608E4095D31D8245038271 sha1 422FADBDF7CFC0DA1E6FDFD101F1D613581ED884 )
+)
+
+game (
+  name "Toolkit (Sinclair Research)"
+  description "Toolkit (Sinclair Research)"
+  manufacturer "Artic"
+  rom ( name "toolkit.p" size 3600 crc 28C28DC8 md5 75B1355E07AD2A2055D86809C1D12256 sha1 7A4132458D5D3BE2502C736B560DAE0A84E9DC91 )
+)
+
+game (
+  name "Toolkit (Artic)"
+  description "Toolkit (Artic)"
+  manufacturer "Artic"
+  rom ( name "toolkit(artic).p" size 3582 crc D331E275 md5 19C29072C4CF201F0C6D80A34C487E1A sha1 1076DA4A02F3E667D86EF0D40E644103768E71ED )
+)
+
+game (
+  name "Toolkit (Artic)"
+  description "Toolkit (Artic)"
+  manufacturer "Artic"
+  rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743B221 md5 7B527B5AFDB2C55D5A0135B6FAA68F98 sha1 049169DEB7C4C760D79DD66FDF49172D5A77D776 )
+)
+
+game (
+  name "Toolkit (Artic)"
+  description "Toolkit (Artic)"
+  rom ( name "Toolkit.tzx" size 3820 crc C015038B md5 EE928ACDD0608E4095D31D8245038271 sha1 422FADBDF7CFC0DA1E6FDFD101F1D613581ED884 )
+)
+
+game (
+  name "Toolkit (Artic)"
+  description "Toolkit (Artic)"
+  rom ( name "toolkit.p" size 3600 crc 28C28DC8 md5 75B1355E07AD2A2055D86809C1D12256 sha1 7A4132458D5D3BE2502C736B560DAE0A84E9DC91 )
+)
+
+game (
+  name "Toolkit (JRS Software)"
+  description "Toolkit (JRS Software)"
+  year "1982"
+  manufacturer "Paul Holmes"
+  rom ( name "Toolkit(JRS).tzx" size 2318 crc 5C378F0F md5 C16AB5E0F0A83C954596A61278865A60 sha1 2121E140989DC586810BEC4E1399DE1007924286 )
+)
+
+game (
+  name "Toolkit (JRS Software)"
+  description "Toolkit (JRS Software)"
+  year "1982"
+  manufacturer "Paul Holmes"
+  rom ( name "toolkit(jrs).p" size 2094 crc 9DE785FD md5 DDFABE0545708752DC9947C12B0691DD sha1 45C020C2381E691E42385D005E496A7032C72B0E )
+)
+
+game (
+  name "Trace (Texgate)"
+  description "Trace (Texgate)"
+  year "1983"
+  manufacturer "Texgate"
+  rom ( name "Trace.tzx" size 3474 crc B43432D2 md5 BA0BC19769D99D42E22475E2CA5C5D76 sha1 68EA27C33EE7B25628862EBD51BF07B716AA0D57 )
+)
+
+game (
+  name "Trace (Texgate)"
+  description "Trace (Texgate)"
+  year "1983"
+  manufacturer "Texgate"
+  rom ( name "trace.p" size 3248 crc 347A23E2 md5 588BAF432B5F22295D6E8347B8E12F9B sha1 5B5FB4641DE0CECEE592944B7991CAD5514C3F69 )
+)
+
+game (
+  name "Trader (Quicksilva)"
+  description "Trader (Quicksilva)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Trader.tzx" size 49461 crc 41C24497 md5 80943BB4B68AD15508C1028F2B59AD15 sha1 37FD173296FB68815CA87544977B354C44A54D9E )
+)
+
+game (
+  name "Trader (Flap-fronted box) (Pixel Productions)"
+  description "Trader (Flap-fronted box) (Pixel Productions)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Trader.tzx" size 49461 crc 41C24497 md5 80943BB4B68AD15508C1028F2B59AD15 sha1 37FD173296FB68815CA87544977B354C44A54D9E )
+)
+
+game (
+  name "Trader (Pixel Productions)"
+  description "Trader (Pixel Productions)"
+  year "1982"
+  manufacturer "Pixel"
+  rom ( name "Trader(Jewel).tzx" size 49639 crc 01E4EC2A md5 F0837CBFE6AC9168B3264AAC3C21857D sha1 0082993BF62F04B69581990F052786DAEEA5620C )
+)
+
+game (
+  name "Traffic (Loriciels)"
+  description "Traffic (Loriciels)"
+  year "1984"
+  manufacturer "M Bouat"
+  rom ( name "Traffic.tzx" size 7030 crc BE09C247 md5 2F644A8598A84813FDC38BBAB38D080F sha1 44626D460F9C918C4BC9E0611737B50215C73A3C )
+)
+
+game (
+  name "Traffic (Loriciels)"
+  description "Traffic (Loriciels)"
+  year "1984"
+  manufacturer "M Bouat"
+  rom ( name "traffic.p" size 6800 crc B40D7FA0 md5 66919861847FB1DAE81487DE697B1C74 sha1 0D91BD4B6F1ABAEC8882B2B360E144EF2A523137 )
+)
+
+game (
+  name "Tutor (German) (Artic)"
+  description "Tutor (German) (Artic)"
+  year "1983"
+  manufacturer "S. and J. Mitchell"
+  rom ( name "tutorgerman.p" size 13643 crc 1812F460 md5 A0C9D577D010F7D36F52F0E46FAFCA4C sha1 E0A880B515F960CF65E76EA4EACAED3326F7EA1C )
+)
+
+game (
+  name "Tutor (German) (Artic)"
+  description "Tutor (German) (Artic)"
+  year "1983"
+  manufacturer "S. and J. Mitchell"
+  rom ( name "TutorGerman.tzx" size 13869 crc 44DDECBA md5 C14B69F2223528031A15C8EC638AD941 sha1 058F24EF7BE7494A90CD9799CD68B07E78169B95 )
+)
+
+game (
+  name "Tutor (Spanish) (Artic)"
+  description "Tutor (Spanish) (Artic)"
+  year "1983"
+  manufacturer "S. and J. Mitchell"
+  rom ( name "tutorspanish.p" size 14993 crc 822E1B3E md5 38D6E26ACB7D0F937AC92DEADE6ECFB1 sha1 88A4E1152CC0A92A3539A21C11A8AC227915B529 )
+)
+
+game (
+  name "Tutor (Spanish) (Artic)"
+  description "Tutor (Spanish) (Artic)"
+  year "1983"
+  manufacturer "S. and J. Mitchell"
+  rom ( name "TutorSpanish.tzx" size 15219 crc 4D62869A md5 02068AFEC8B6F9C2875ACF822951AF83 sha1 E12AABEA86FF2542821BD04CDF6E2868F1D3F5D7 )
+)
+
+game (
+  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  year "1982"
+  manufacturer "Informatique Service Logiciels"
+  rom ( name "TyrannosaureRex.tzx" size 11728 crc 5300E4D1 md5 5660C77DBAAAE1C8E4FE7F18380B03F6 sha1 CB0CAA82180A19407CD5E850CA88CA33E12B8EFC )
+)
+
+game (
+  name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
+  year "1982"
+  manufacturer "Informatique Service Logiciels"
+  rom ( name "tyrannosaurerex.p" size 11506 crc B4BA768A md5 1319F6E2E899B6611FC24443EF13CD9B sha1 7C5172140B9F208B40357C28F348DCA23F8AE1A8 )
+)
+
+game (
+  name "Tyrant of Athens (Lothlorien)"
+  description "Tyrant of Athens (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "tyrantofathens.p" size 12848 crc 00039ED3 md5 40C8CFD3EBEB9510F04115B34BE32097 sha1 347C589D6D9A22794F863D6E61BE0CE8C31EC485 )
+)
+
+game (
+  name "Tyrant of Athens (Lothlorien)"
+  description "Tyrant of Athens (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "TyrantOfAthens.tzx" size 13068 crc FC3FD4F8 md5 C3F5E5D0F379FE1529A27596A8D5B13F sha1 882B644962F09D68BC813563478D773C3A07115B )
+)
+
+game (
+  name "UDG (dK'tronics)"
+  description "UDG (dK'tronics)"
+  year "1981"
+  manufacturer "dK'tronics"
+  rom ( name "udg.p" size 7928 crc A4259B70 md5 E9FDD20A2BB40D5B1D6D356E1B34793A sha1 7C2656D8CBD5427F5E464A5108F82EC84C539706 )
+)
+
+game (
+  name "UDG (dK'tronics)"
+  description "UDG (dK'tronics)"
+  year "1981"
+  manufacturer "dK'tronics"
+  rom ( name "UDG.tzx" size 8150 crc 66A2453F md5 76F87A79206C9FC82E5127B7E94C2D6F sha1 0FEFC639D3C9A6C2ED2A5D994F94EE0691E0DCA5 )
+)
+
+game (
+  name "UFO (Protek)"
+  description "UFO (Protek)"
+  year "1983"
+  manufacturer "Protek"
+  rom ( name "ufo.p" size 5158 crc 4E3F3226 md5 318F5420747069FEB32F65E008B84A61 sha1 F4E7A1691AD0AF71B26A9D1BCC36E3155814100A )
+)
+
+game (
+  name "UFO (Protek)"
+  description "UFO (Protek)"
+  year "1983"
+  manufacturer "Protek"
+  rom ( name "UFO.tzx" size 5380 crc 6B8CBCEC md5 EAC2815189BDB98A886B8F6739B4F188 sha1 F9BD4F690CB67FA718154CB9F07D63E8103A8C4F )
+)
+
+game (
+  name "UFO + 3D Maze (Babtech)"
+  description "UFO + 3D Maze (Babtech)"
+  year "1982"
+  manufacturer "Babtech"
+  rom ( name "UFOAnd3DMaze.tzx" size 13279 crc CC63DFDF md5 90EFA80FF6A2BD4CA39AF581F1CB43A4 sha1 07A8D839B7202B3846FD8F1F84025000FB222F58 )
+)
+
+game (
+  name "VU-CALC (Sinclair Research)"
+  description "VU-CALC (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "VU-CALC.tzx" size 5781 crc 221479DF md5 CB3925E52D2AFA1C3F93CBAFEB2443FE sha1 50275CE9C48F4F3533899A00C5291BDADE4A1EFE )
+)
+
+game (
+  name "VU-CALC (Sinclair Research)"
+  description "VU-CALC (Sinclair Research)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "vu-calc.p" size 5551 crc 85195A78 md5 5B833077456F266ABBF68CA295A60EE1 sha1 19280C9645A23FFBD53818889C4899BD00D29D29 )
+)
+
+game (
+  name "VU-CALC (Timex)"
+  description "VU-CALC (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "VU-CALC(Timex).tzx" size 5779 crc 3DB82474 md5 AC03E37DC2013D571C352AD8FA3EE69D sha1 D1533151DFECF9614C55551E0D6BBAB85BCE9C3C )
+)
+
+game (
+  name "VU-CALC (Timex)"
+  description "VU-CALC (Timex)"
+  year "1982"
+  manufacturer "Psion"
+  rom ( name "vu-calc(timex).p" size 5549 crc 294A26C8 md5 5DF9F5BB28E55CD1BB0E8EAE025C38BC sha1 CE80BFEE2434761BABBFB0AA2B204B2CDB70C76C )
+)
+
+game (
+  name "Variance Analyzer (Zeta Software)"
+  description "Variance Analyzer (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "varianceanalyzer.p" size 8185 crc 73023B9A md5 72FBC8622939AC385B41DC3355B6D4C9 sha1 01535D36D01908855E4530C3077C6B774E893CE8 )
+)
+
+game (
+  name "Variance Analyzer (Zeta Software)"
+  description "Variance Analyzer (Zeta Software)"
+  manufacturer "Dr. Walter Diembeck"
+  rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90A5774A md5 5237031B0A92F415C5AC347D60FD5D3E sha1 A429C8165B8BE52791C99E5DA26A84758A4C508B )
+)
+
+game (
+  name "Vector Mathematics (W. H. Smith)"
+  description "Vector Mathematics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "VectorMathematics.tzx" size 12101 crc C33B86BA md5 4CE4BF8556A215E4D1528E0ADC8DE3C9 sha1 B82230BCC7F57F7B1F12720D82440031135BE44B )
+)
+
+game (
+  name "Vector Mathematics (W. H. Smith)"
+  description "Vector Mathematics (W. H. Smith)"
+  year "1982"
+  manufacturer "ICL"
+  rom ( name "vectormathematics.p" size 11849 crc A13C22DE md5 7F44ADCD2EAB5FA11A948BAD8677E102 sha1 8A75F82FD30681BF8D557E03BABC165C0F64567C )
+)
+
+game (
+  name "Video-Ad (Video Software)"
+  description "Video-Ad (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "VideoAd.A.tzx" size 15281 crc 42136ADC md5 BAEF4C10EF4E5D71498C31E5D2197F64 sha1 C2409CD598CE050D622EB8850E21D74D709060EB )
+)
+
+game (
+  name "Video-Ad (Video Software)"
+  description "Video-Ad (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "videoad.p" size 15049 crc ABC19F74 md5 209BEEC2010448BB63643842DF41793D sha1 BEEBC6BC78805B1BB6328D518AAB9CFF70B2A3A2 )
+)
+
+game (
+  name "Video Graffiti (AGF Hardware)"
+  description "Video Graffiti (AGF Hardware)"
+  year "1982"
+  manufacturer "AGF Hardware"
+  rom ( name "videograffiti.p" size 5033 crc 4B37557F md5 521067DB79CB6F937B5CF2E2D0662F15 sha1 45996EFA5157865159C613CA49DC1F54402E3C7B )
+)
+
+game (
+  name "Video Graffiti (AGF Hardware)"
+  description "Video Graffiti (AGF Hardware)"
+  year "1982"
+  manufacturer "AGF Hardware"
+  rom ( name "VideoGraffiti.tzx" size 5263 crc DD2ECB00 md5 7EA6FB6995EAE21A6731A7C61F7FE91C sha1 CF2E6CEE862CC503BE44BF2E6621A2E8D005C521 )
+)
+
+game (
+  name "Video-Map (Video Software)"
+  description "Video-Map (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "VideoMap.A.tzx" size 15713 crc B76622DC md5 86528F5577970284C231B5048AD5F669 sha1 86D292DEF89F2CD01BDF677F50ABDB18002507A6 )
+)
+
+game (
+  name "Video-Map (Video Software)"
+  description "Video-Map (Video Software)"
+  year "1981"
+  manufacturer "Video Software"
+  rom ( name "videomap.p" size 15479 crc F37CC7C7 md5 CA144229C898E0FBEDF4C974CED0FE56 sha1 3791B93F30FE410716EFDB3D9D345FF803973D28 )
+)
+
+game (
+  name "Video-Plan (Video Software)"
+  description "Video-Plan (Video Software)"
+  manufacturer "Video Software"
+  rom ( name "VideoPlan.A.tzx" size 15425 crc 849E21DC md5 23E1F6EED1029F7433286C3682CCFF69 sha1 FFFA47475A0634FC9859212E5A309603D922D258 )
+)
+
+game (
+  name "Video-Plan (Video Software)"
+  description "Video-Plan (Video Software)"
+  manufacturer "Video Software"
+  rom ( name "videoplan.p" size 15189 crc FD242331 md5 260E9496C1BD1CB40A6095F04E0BBEC2 sha1 2CB0A66C7AA506061FE621A53EE0BC7F143B9988 )
+)
+
+game (
+  name "Video-View (Video Software)"
+  description "Video-View (Video Software)"
+  manufacturer "Video Software"
+  rom ( name "videoview.p" size 13859 crc 53ECA8E2 md5 E02361E6A92651A25CA5F0F5CAC3C408 sha1 BDC28FC5964960F3159A8BD08DB7B3DED64ECA98 )
+)
+
+game (
+  name "Video-View (Video Software)"
+  description "Video-View (Video Software)"
+  manufacturer "Video Software"
+  rom ( name "VideoView.tzx" size 14095 crc F5FDB04B md5 FD38379FC882828484B0A1E7FAC02A4D sha1 ABADD8BD7A829C778D6FBF1D4F394025CD1B7C58 )
+)
+
+game (
+  name "Viewtext (U.S. release) (Bug Byte)"
+  description "Viewtext (U.S. release) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "Viewtext(US).tzx" size 12767 crc 83F14397 md5 7AB7FF7C1B3BAEBCFDB31632ABE00646 sha1 EB0996DDB294A42C133B0C301958BDAA3B5F4A1A )
+)
+
+game (
+  name "Viewtext (U.S. release) (Bug Byte)"
+  description "Viewtext (U.S. release) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "viewtext(us).p" size 12535 crc 4A6DE687 md5 A9EDBDB5E0F43EFC83BD3233ED8122EA sha1 9C9999F8DAEFFD8D6F9F4234548C665C0D2D18A5 )
+)
+
+game (
+  name "Volcanic Dungeon (Carnell)"
+  description "Volcanic Dungeon (Carnell)"
+  year "1982"
+  manufacturer "Carnell Software"
+  rom ( name "volcanicdungeon.p" size 16234 crc BDCC9896 md5 801E5CD018F555198867D3F989033B24 sha1 503C8CFD4994440A3662FBCE25D46B000887056A )
+)
+
+game (
+  name "Volcanic Dungeon (Carnell)"
+  description "Volcanic Dungeon (Carnell)"
+  year "1982"
+  manufacturer "Carnell Software"
+  rom ( name "VolcanicDungeon.tzx" size 16482 crc C6F44894 md5 60210E10F6D239CDDAFFE65B6A3911C8 sha1 6275899B3B7849A97CA8EA869D2BC5806522AE9A )
+)
+
+game (
+  name "Warlord (Lothlorien)"
+  description "Warlord (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "warlord.p" size 15659 crc 5B5B6FBB md5 0D8E945E8CDF72F737D2848CB35EF853 sha1 E8FE374088097ADB86B658E54A4BC05208627AE5 )
+)
+
+game (
+  name "Warlord (Lothlorien)"
+  description "Warlord (Lothlorien)"
+  year "1982"
+  manufacturer "M. C. Lothlorien"
+  rom ( name "Warlord.tzx" size 15879 crc 9BFF8537 md5 1F8271889F8E1F381C60707A0D10621B sha1 DEE7757FC095D4DE68EFCD4147777E0CBBAD8424 )
+)
+
+game (
+  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  year "1983"
+  manufacturer "Computertutor"
+  rom ( name "whizzquiz.p" size 16032 crc B8995DC4 md5 7F62BE0EFDC60665D015473550FAFA0E sha1 436C07C66875F854B57A43B543C3002AD6C3E061 )
+)
+
+game (
+  name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
+  year "1983"
+  manufacturer "Computertutor"
+  rom ( name "WhizzQuiz.tzx" size 16252 crc 831E3890 md5 9CB954C3643F9BBDAC2F2FD5EE28A79B sha1 81B7FA7BC053EA09617EDD5428EA8B9BC7D8E4D2 )
+)
+
+game (
+  name "Winged Avenger (Work Force)"
+  description "Winged Avenger (Work Force)"
+  year "1982"
+  manufacturer "Work Force"
+  rom ( name "WingedAvenger.tzx" size 4004 crc 18536D36 md5 8D6E49676509AE0666CF832B8BE958B1 sha1 B3ECBF77BB7D691BD1B973EDE3774BF3A54A1494 )
+)
+
+game (
+  name "Winged Avenger (Work Force)"
+  description "Winged Avenger (Work Force)"
+  year "1982"
+  manufacturer "Work Force"
+  rom ( name "wingedavenger.p" size 3760 crc EC61FACB md5 ABB4AB208952C4F184769683545B68E8 sha1 EF6259D87F68C3882AECB6BD47EF0B99A6DBE2A9 )
+)
+
+game (
+  name "Word Processor (Alan's Recordings)"
+  description "Word Processor (Alan's Recordings)"
+  manufacturer "Alan D. Went"
+  rom ( name "WordProcessor.A.tzx" size 12384 crc C1F41D1C md5 668F2DF5BA976DDA0E79405A1C3B0353 sha1 4F2E76139EFB5A07B443C5495636BCBB42489241 )
+)
+
+game (
+  name "Word Test (Mindware)"
+  description "Word Test (Mindware)"
+  year "1982"
+  manufacturer "Christopher Jones"
+  rom ( name "wordtest.p" size 901 crc BE88DF61 md5 338AF799286FEE95CA3F1131A2C00BAC sha1 FBBE0822184C0A4594C5932358EDCFBE3DF4E7BE )
+)
+
+game (
+  name "Word Test (Mindware)"
+  description "Word Test (Mindware)"
+  year "1982"
+  manufacturer "Christopher Jones"
+  rom ( name "WordTest.1.WordTest.tzx" size 1133 crc E12825A4 md5 1D78C945FE6ED7C191F0016E26C4961B sha1 A17549CE398AA7C4955E6A691FD27DBCE089DB4A )
+)
+
+game (
+  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  description "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  year "1982"
+  manufacturer "M. A. Smith"
+  rom ( name "worldcupfootball.p" size 10439 crc 5647EB5E md5 C08C7F4881310B8E3AD0C336CA996965 sha1 80B894C252D6185362018B1405D4868484CD0198 )
+)
+
+game (
+  name "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  description "World Cup Football (Test your knowledge of) (M. A. Smith)"
+  year "1982"
+  manufacturer "M. A. Smith"
+  rom ( name "WorldCupFootball.tzx" size 10657 crc 685D01CE md5 F603BC86BBD22E511E7628A9209C3838 sha1 D081CCD8B759A2866BFF5676A112481BB73D5F88 )
+)
+
+game (
+  name "10 Games (J. K. Greye)"
+  description "10 Games (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
+)
+
+game (
+  name "1K Games Pack (Artic)"
+  description "1K Games Pack (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+)
+
+game (
+  name "1K Games (Sinclair Research)"
+  description "1K Games (Sinclair Research)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+)
+
+game (
+  name "1K ZX Chess (Sinclair Research)"
+  description "1K ZX Chess (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
+)
+
+game (
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
+)
+
+game (
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
+)
+
+game (
+  name "2K Games Pack (International Publishing and Software Inc.)"
+  description "2K Games Pack (International Publishing and Software Inc.)"
+  year "1982"
+  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
+)
+
+game (
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
+)
+
+game (
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
+)
+
+game (
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
+)
+
+game (
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
+)
+
+game (
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
+)
+
+game (
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
+)
+
+game (
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
+)
+
+game (
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
+)
+
+game (
+  name "5-2K Family Pak (Timeworks)"
+  description "5-2K Family Pak (Timeworks)"
+  manufacturer "Timeworks"
+  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
+)
+
+game (
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  manufacturer "GM4IHJ (J Branegan)"
+  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
+)
+
+game (
+  name "10 Games (J. K. Greye)"
+  description "10 Games (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "10Games.tzx" size 7636 crc 141CDDD1 md5 02EB203CD57645589A158495C2F7CEBB sha1 3A776F7DBF4FD169572AAD5B775B4CA27C61222A )
+)
+
+game (
+  name "1K Games Pack (Artic)"
+  description "1K Games Pack (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+)
+
+game (
+  name "1K Games (Sinclair Research)"
+  description "1K Games (Sinclair Research)"
+  manufacturer "Artic"
+  rom ( name "1KGames.tzx" size 8576 crc 2648F563 md5 915FEBE842110ADA339F53DB2A822812 sha1 11562494BB40CEF9BCEA606B1BD2AD375F47EF75 )
+)
+
+game (
+  name "1K ZX Chess (Sinclair Research)"
+  description "1K ZX Chess (Sinclair Research)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "1KZXChess.tzx" size 2223 crc 2FC225B9 md5 DDF8021EEF88111BE73FBCCF8392439E sha1 055730A794E227E02D6FA780F1BB82A68C1B86BF )
+)
+
+game (
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "chessqueen.p" size 941 crc 1A82385A md5 5292E4CAC70342EED1B350846DB0A90F sha1 DFAD4C2DE72AA4900367DBE92271F126EA192804 )
+)
+
+game (
+  name "1K ZX Chess (Artic)"
+  description "1K ZX Chess (Artic)"
+  manufacturer "Artic"
+  rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9C750652 md5 D6694FD23F6A9AA6FF644A0D7417332C sha1 ED848D9BD69311536DA64C0414F7AE2EC9316622 )
+)
+
+game (
+  name "2K Games Pack (International Publishing and Software Inc.)"
+  description "2K Games Pack (International Publishing and Software Inc.)"
+  year "1982"
+  rom ( name "2KGamesPack(IPS).tzx" size 6977 crc C1893B03 md5 25EBAFA20015B01A383B70C19394E307 sha1 B33FDC40EB4631617C2687795DE02904C92255C3 )
+)
+
+game (
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3ddefender.p" size 11857 crc 4F97CBC6 md5 B344194F7456805B053F3E6786CFCDD5 sha1 BBAF7CD6F122F2508EFECCA8A8B2E1006B728752 )
+)
+
+game (
+  name "3D Defender (J. K. Greye)"
+  description "3D Defender (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DDefender.tzx" size 12095 crc A9E69D1C md5 CD64E962BFCC000A9E3BD8CDB6E1C3E1 sha1 7C6B0A1FDEF5C43AEED21F9D98F4E0C9837214CF )
+)
+
+game (
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3DDefender(NGS).tzx" size 12095 crc 0DF02E27 md5 B2FE247EA9C9E64BA9FE419C96C9FC9C sha1 6AA9A12E6256BC2657326361C636571FAF2CFB83 )
+)
+
+game (
+  name "3D Defender (New Generation)"
+  description "3D Defender (New Generation)"
+  year "1981"
+  manufacturer "M. E. Evans"
+  rom ( name "3ddefender(ngs).p" size 11857 crc EB8178FD md5 57E5BDEAEF06C83AE246BF132618A5FF sha1 1C9205C36224875446DE0DC3ABF0907200B7B993 )
+)
+
+game (
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze.p" size 10552 crc 8F782725 md5 4E344F938D5600D81B7B0FDE756ABE7E sha1 CB254B2CE2012140211B641DEEAF57177757AC25 )
+)
+
+game (
+  name "3D Monster Maze (J. K. Greye)"
+  description "3D Monster Maze (J. K. Greye)"
+  year "1981"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze.tzx" size 10798 crc 436D8B0E md5 C38F7C7E81C6E781A9D665A4E468C6EF sha1 C6C141057D870B114D8844BB7578040AD8C5B151 )
+)
+
+game (
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38DBCC52 md5 5912B1261D2ED44F40D80BD6CA813405 sha1 2B0E9CD691979154C2D75AC76F93BE076AAB3423 )
+)
+
+game (
+  name "3D Monster Maze (New Generation)"
+  description "3D Monster Maze (New Generation)"
+  year "1982"
+  manufacturer "J. K. Greye"
+  rom ( name "3dmonstermaze(ngs).p" size 10552 crc F4CE6079 md5 9CD5AF6A9A9C61B2EA272F4F35058928 sha1 15093D2B89B5C5C4C0454AF917BE5554454864A7 )
+)
+
+game (
+  name "5-2K Family Pak (Timeworks)"
+  description "5-2K Family Pak (Timeworks)"
+  manufacturer "Timeworks"
+  rom ( name "52KFamilyPak.tzx" size 7846 crc FA438CED md5 E0B79AE2DE178DDAB3C3EE2691C68F78 sha1 1D613E0AB6462AB52C757AA1B6B6262311EB6C8E )
+)
+
+game (
+  name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
+  manufacturer "GM4IHJ (J Branegan)"
+  rom ( name "8Programs.tzx" size 56578 crc BB788390 md5 4CF8B801597AE314132D8DE1D5DC5D9B sha1 E2185C5962D8C89BB020028A22E25470405BEF0F )
+)
+
+game (
+  name "ZXAS (Bug Byte)"
+  description "ZXAS (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
+)
+
+game (
+  name "ZXAS (Bug Byte)"
+  description "ZXAS (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
+)
+
+game (
+  name "ZXAS (Printed instructions) (Bug Byte)"
+  description "ZXAS (Printed instructions) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
+)
+
+game (
+  name "ZXAS (Printed instructions) (Bug Byte)"
+  description "ZXAS (Printed instructions) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
+)
+
+game (
+  name "ZXAS (Gladstone) (Gladstone Electronics)"
+  description "ZXAS (Gladstone) (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "zxas(ge).p" size 5619 crc 850BAB49 md5 7C622F096AD94F4201922E7CDEA35C67 sha1 0B758FDB9BCFC94D9B37F743F78075595563C529 )
+)
+
+game (
+  name "ZXAS (Gladstone) (Gladstone Electronics)"
+  description "ZXAS (Gladstone) (Gladstone Electronics)"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS(GE).tzx" size 5843 crc A448E4BA md5 BEEBBC4F4B2262F2E2C4AA3F45A62C69 sha1 E09ABFF8F1C771B7E1ACE6B6612EB99DFA539654 )
+)
+
+game (
+  name "ZXAS (Monochrome) (Bug Byte)"
+  description "ZXAS (Monochrome) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
+)
+
+game (
+  name "ZXAS (Monochrome) (Bug Byte)"
+  description "ZXAS (Monochrome) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
+)
+
+game (
+  name "ZXAS (Typed Inlay) (Bug Byte)"
+  description "ZXAS (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
+)
+
+game (
+  name "ZXAS (Typed Inlay) (Bug Byte)"
+  description "ZXAS (Typed Inlay) (Bug Byte)"
+  year "1981"
+  manufacturer "Bug Byte"
+  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
+)
+
+game (
+  name "ZXAS (Yellow) (Bug Byte)"
+  description "ZXAS (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXAS.tzx" size 5843 crc FA15514C md5 A2AD68A98CEE37835E84121B9EE8B53D sha1 0422F7ECA685E2EE3981C86E44624B8FF0FF8ACA )
+)
+
+game (
+  name "ZXAS (Yellow) (Bug Byte)"
+  description "ZXAS (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxas.p" size 5619 crc DB561EBF md5 60A230CE6474ECACFF6DD1C1CC5760A3 sha1 6B4BD425549C0BDDE54C33527506C213C8CCAA09 )
+)
+
+game (
+  name "ZX Action Pack (Axis)"
+  description "ZX Action Pack (Axis)"
+  year "1982"
+  manufacturer "Axis"
+  rom ( name "ZXActionPack.tzx" size 4677 crc F5F95245 md5 7E8C4E96F560CE731AE5D167009CC947 sha1 A97DBF23EE4788951617CC26E8BBD2987D3A4CD6 )
+)
+
+game (
+  name "ZX Assembler (Artic)"
+  description "ZX Assembler (Artic)"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "ZXAssembler.tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
+)
+
+game (
+  name "ZX Assembler (Artic)"
+  description "ZX Assembler (Artic)"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "zxassembler.p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
+)
+
+game (
+  name "ZX Assembler (International Publishing and Software Inc.)"
+  description "ZX Assembler (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton (Artic)"
+  rom ( name "ZXAssembler.tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
+)
+
+game (
+  name "ZX Assembler (International Publishing and Software Inc.)"
+  description "ZX Assembler (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton (Artic)"
+  rom ( name "zxassembler.p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
+)
+
+game (
+  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "zxassembler(mono).p" size 7330 crc 95A485D6 md5 20F54F3A1F15FC2956937EE10582B1F2 sha1 8E2526BDB2AA5000FF2D814A009CEC5259D46DED )
+)
+
+game (
+  name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "ZXAssembler(Mono).tzx" size 7564 crc 99C7FAEC md5 7CFC5B8A15F9A4DEA3F1CE6D27E6FF31 sha1 7FE0C1C9DFBDFF0E3F1C4274E09A19EB3AC88A59 )
+)
+
+game (
+  name "ZX Assembleur (French) (Artic)"
+  description "ZX Assembleur (French) (Artic)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "ZXAssembleur.tzx" size 9197 crc AA532026 md5 7B58C9BFE54C57CB8080441BEA91E7EC sha1 02A75242AABFBFA1D233B134DF53727D5B8F597B )
+)
+
+game (
+  name "ZX Assembleur (French) (Artic)"
+  description "ZX Assembleur (French) (Artic)"
+  year "1982"
+  manufacturer "D. P. Aknai and M. Streeton"
+  rom ( name "zxassembleur.p" size 8963 crc D0D72BDC md5 B085ECFB9D97D32FC9EEB0FE94A8629E sha1 1FE43E6C0E7DD3C33BFF97B7246FB5172D5AA892 )
+)
+
+game (
+  name "ZX Asteroids (Electric Pencil Company)"
+  description "ZX Asteroids (Electric Pencil Company)"
+  year "1982"
+  manufacturer "Robert J. Wray"
+  rom ( name "zxasteroids.p" size 6054 crc BC47CFF8 md5 57B3EC022DEC0B1796AA7C6FADCD8F35 sha1 98E75C5767925CD515A10B88F731181CAA84B337 )
+)
+
+game (
+  name "ZX Asteroids (Electric Pencil Company)"
+  description "ZX Asteroids (Electric Pencil Company)"
+  year "1982"
+  manufacturer "Robert J. Wray"
+  rom ( name "ZXAsteroids.tzx" size 6280 crc C92D5C86 md5 F3E15EEFE198558FFB618F9B005AA063 sha1 BC223F7B59F8BA07D7FAF1DA62F5A408034C568C )
+)
+
+game (
+  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "ZXBug.tzx" size 5572 crc B77B6A0D md5 C5FADBC61693ECCA4761E523D2024999 sha1 5F513D59C871AA94DD8D1C1919FEA0E8D5AAE806 )
+)
+
+game (
+  name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "zxbug.p" size 5350 crc 2859B9EB md5 2766880AAC6AE3B92031AAA2737AF2EC sha1 4030B892FBB1906FE97AB601A37F9D4FFBF52A30 )
+)
+
+game (
+  name "ZX Bug (International Publishing and Software Inc.)"
+  description "ZX Bug (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "Artic (?)"
+  rom ( name "ZXBug(IPS).tzx" size 5576 crc F8959E82 md5 2D051B4F0218C4C78D897CE2A851FE6D sha1 446C92783F64EA88A3FAF3F0D5338223995D99A5 )
+)
+
+game (
+  name "ZX Bug (International Publishing and Software Inc.)"
+  description "ZX Bug (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "Artic (?)"
+  rom ( name "zxbug(ips).p" size 5350 crc AF2C11CA md5 70354BFA74200E4578F92AFC927DB38B sha1 92827B6CB5AB8C7C64127C700C20C36902676CB4 )
+)
+
+game (
+  name "ZX Chess I (Black inlay) (Artic)"
+  description "ZX Chess I (Black inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "zxchessi(black).p" size 14119 crc CCE17D9C md5 2AA8D6A1B52211893F7A7264CFF2BC1A sha1 CECA1C8F7719AFE71D991A073A88561FCDA27AE8 )
+)
+
+game (
+  name "ZX Chess I (Black inlay) (Artic)"
+  description "ZX Chess I (Black inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "ZXChessI(Black).tzx" size 14337 crc 98F8FD30 md5 F2EE420566092A3ECD4D82F532BC98DE sha1 B2EE8FB73779FC8B13B1BEC533E59D762F6F871F )
+)
+
+game (
+  name "ZX Chess II (Artic)"
+  description "ZX Chess II (Artic)"
+  manufacturer "Artic"
+  rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
+)
+
+game (
+  name "ZX Chess II (Artic)"
+  description "ZX Chess II (Artic)"
+  manufacturer "Artic"
+  rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
+)
+
+game (
+  name "ZX Chess II (Black inlay) (Artic)"
+  description "ZX Chess II (Black inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "ZXChessII.tzx" size 14422 crc 90F0224C md5 7FEBB46157A5CA656A1C70109FD727D1 sha1 1E99CB497498E471F5F0AEB85C79D292208107B2 )
+)
+
+game (
+  name "ZX Chess II (Black inlay) (Artic)"
+  description "ZX Chess II (Black inlay) (Artic)"
+  manufacturer "Artic"
+  rom ( name "zxchessii.p" size 14192 crc A9CE4067 md5 0AABBE2F2FC2992535866DD50C957203 sha1 B2DD0EACD363A184FEB09CC63A9DD26EDB620EB4 )
+)
+
+game (
+  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "ZXChessII(IPS).tzx" size 14326 crc E300FFC8 md5 489B56232D78BBEEBDB69F4CC5FCC320 sha1 D06522009C0438E7E201611C1EC10E17650DBF39 )
+)
+
+game (
+  name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "International Publishing and Software Inc."
+  rom ( name "zxchessii(ips).p" size 14096 crc 95534F49 md5 288FEDCCF17C6D1EC8312C219FE1398E sha1 DF54149F4ED916F7B804A8E0B8E34F790505F7C0 )
+)
+
+game (
+  name "ZX Chess II (Improved) (Artic)"
+  description "ZX Chess II (Improved) (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "zxchessii(improved).p" size 14096 crc 16E86CE7 md5 19D6E472A1121EA8D28CF0B79EEF739D sha1 585FCE3FB637ABD4783F907F24D6945D9472B7E7 )
+)
+
+game (
+  name "ZX Chess II (Improved) (Artic)"
+  description "ZX Chess II (Improved) (Artic)"
+  year "1981"
+  manufacturer "Artic"
+  rom ( name "ZXChessII(Improved).tzx" size 14326 crc 60BBDC66 md5 00F547BD9654A6DCD024639C91152471 sha1 A4238332FE59D8E4E7048069CB6E26C0B357C16D )
+)
+
+game (
+  name "ZX-Compiler (Silversoft)"
+  description "ZX-Compiler (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "ZXCompiler.tzx" size 7163 crc 491041A6 md5 BB0497BB6EEEA52B39EB7E189F55728C sha1 09CECBEC3370CFD1FF77E316C69661132F2E932F )
+)
+
+game (
+  name "ZX-Compiler (Silversoft)"
+  description "ZX-Compiler (Silversoft)"
+  year "1982"
+  manufacturer "Silversoft"
+  rom ( name "zxcompiler.p" size 6931 crc F25627C4 md5 8603E97D1FE5548927E829FD2486F5A7 sha1 1AE703F1D6E47A4F6C3A07F0C5A11C233562782F )
+)
+
+game (
+  name "ZXDB (Bug Byte)"
+  description "ZXDB (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
+)
+
+game (
+  name "ZXDB (Bug Byte)"
+  description "ZXDB (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
+)
+
+game (
+  name "ZXDB (Typed Inlay, black) (Bug Byte)"
+  description "ZXDB (Typed Inlay, black) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
+)
+
+game (
+  name "ZXDB (Typed Inlay, black) (Bug Byte)"
+  description "ZXDB (Typed Inlay, black) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
+)
+
+game (
+  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  description "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
+)
+
+game (
+  name "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  description "ZXDB (Typed Inlay, blue) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
+)
+
+game (
+  name "ZXDB (Yellow) (Bug Byte)"
+  description "ZXDB (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXDB.tzx" size 6081 crc F4BD2DC5 md5 95F75928EED2BD7ACB2DEE0AC8840D00 sha1 33604F3874337C4A579B9D1C6FB0D56887D2A128 )
+)
+
+game (
+  name "ZXDB (Yellow) (Bug Byte)"
+  description "ZXDB (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxdb.p" size 5857 crc F2454173 md5 B4F8B1AE06E3E801269ABAB746BD4131 sha1 7C5A6E0FE6D2F12D14CC9CE43A2FD712F629341D )
+)
+
+game (
+  name "ZX Forth (Artic)"
+  description "ZX Forth (Artic)"
+  manufacturer "Artic Computing"
+  rom ( name "ZXForth.tzx" size 20567 crc 587D765F md5 421DDC790C350146AF56D1683D3CF2B6 sha1 63C6E3CD88655B30CEF4AFCDF4FCAB959210047F )
+)
+
+game (
+  name "ZX Forth (International Publishing and Software Inc.)"
+  description "ZX Forth (International Publishing and Software Inc.)"
+  year "1982"
+  manufacturer "Artic"
+  rom ( name "ZXForth(IPS).tzx" size 12455 crc 73E4BF92 md5 408A2AD80923D4E802A4529C8FACB917 sha1 5CD85E8A39CB6151C243B4D83DFAF88A4F23C3BC )
+)
+
+game (
+  name "ZX-MC (Picturesque)"
+  description "ZX-MC (Picturesque)"
+  manufacturer "Picturesque"
+  rom ( name "zxmc.p" size 3555 crc DE00007D md5 1FE46C4D47A32B6C7B77144987A6C753 sha1 8897D32731370314DA8BAE6C4E8AE56761E4B3AA )
+)
+
+game (
+  name "ZX-MC (Picturesque)"
+  description "ZX-MC (Picturesque)"
+  manufacturer "Picturesque"
+  rom ( name "ZXMC.tzx" size 3781 crc BAD36AEF md5 A9804BE70B200A01D551198DE5D13E70 sha1 9EDC5C21E1EDD96E1A733908D9E7D39CEC6DF85E )
+)
+
+game (
+  name "ZXM Sound Box Super Editor (Timedata)"
+  description "ZXM Sound Box Super Editor (Timedata)"
+  year "1983"
+  manufacturer "Timedata"
+  rom ( name "ZXMSuperEditor.tzx" size 2693 crc 989424D1 md5 498E30B4CFD9E0E0D65DF71E64FFF20C sha1 9AF273026FBD076097EFFEE86E09A9F07D58F1FC )
+)
+
+game (
+  name "ZXM Sound Box Super Editor (Timedata)"
+  description "ZXM Sound Box Super Editor (Timedata)"
+  year "1983"
+  manufacturer "Timedata"
+  rom ( name "zxmsupereditor.p" size 2473 crc 37830A34 md5 C4A52E25B43580685F277856CF85CE72 sha1 1D030FE2BEE1C42635299E7D0F925F5ADB4582A7 )
+)
+
+game (
+  name "ZX Pro/File (Thomas B. Woods)"
+  description "ZX Pro/File (Thomas B. Woods)"
+  year "1983"
+  manufacturer "Thomas B. Woods"
+  rom ( name "zxprofile.p" size 16071 crc 73F67B5B md5 E0021B805CBAE2655A4158128931035D sha1 9CCB69EA8EF5D613440720D63E84E67675A4614F )
+)
+
+game (
+  name "ZX Pro/File (Thomas B. Woods)"
+  description "ZX Pro/File (Thomas B. Woods)"
+  year "1983"
+  manufacturer "Thomas B. Woods"
+  rom ( name "ZXProFile.tzx" size 16291 crc 5D5146CF md5 64B39D80729E025FAD4828F378CC8032 sha1 214FAFF9ECC28E7D20E229554BFAAE88A8B23B98 )
+)
+
+game (
+  name "ZX-Sideprint (Microsphere)"
+  description "ZX-Sideprint (Microsphere)"
+  year "1982"
+  manufacturer "Microsphere"
+  rom ( name "zxsideprint.p" size 1941 crc DB6371DF md5 D263455884FA102D245F3109C9A66A2F sha1 869334C4250219AA8E6FCF6752D2EBA5F6AA7E69 )
+)
+
+game (
+  name "ZX-Sideprint (Microsphere)"
+  description "ZX-Sideprint (Microsphere)"
+  year "1982"
+  manufacturer "Microsphere"
+  rom ( name "ZXSideprint.tzx" size 2175 crc 5F320B4A md5 D990BB98194F1A992E902AAAEC9C3FBB sha1 6965F265CBFCA8F6813F698BE70ED0E709C59632 )
+)
+
+game (
+  name "ZXTK (Bug Byte)"
+  description "ZXTK (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
+)
+
+game (
+  name "ZXTK (Bug Byte)"
+  description "ZXTK (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
+)
+
+game (
+  name "ZXTK (Printed instructions) (Bug Byte)"
+  description "ZXTK (Printed instructions) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
+)
+
+game (
+  name "ZXTK (Printed instructions) (Bug Byte)"
+  description "ZXTK (Printed instructions) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
+)
+
+game (
+  name "ZXTK (Yellow) (Bug Byte)"
+  description "ZXTK (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "ZXTK.tzx" size 2837 crc 4F4182C4 md5 5DFCB789500923DE2E3E818B735FF185 sha1 FD398501A5E72EF51C0FD817085E77300807FB57 )
+)
+
+game (
+  name "ZXTK (Yellow) (Bug Byte)"
+  description "ZXTK (Yellow) (Bug Byte)"
+  year "1982"
+  manufacturer "Bug Byte"
+  rom ( name "zxtk.p" size 2613 crc 89A5914B md5 C0793CB9BFD99AD68878ACCD3CC14B37 sha1 3EC38ECCF7BF79F299A8AD93DCFCBF976CF91CB9 )
+)
+
+game (
+  name "Zac-Man (Macronics)"
+  description "Zac-Man (Macronics)"
+  manufacturer "Macronics"
+  rom ( name "zacman.p" size 6881 crc 261A596B md5 CD301F8807F261D005A0F5E0A5F8E1B3 sha1 1C8CB9858647E86A3BE82467A6DA6A04A4A40D15 )
+)
+
+game (
+  name "Zac-Man (Macronics)"
+  description "Zac-Man (Macronics)"
+  manufacturer "Macronics"
+  rom ( name "ZacMan.tzx" size 7111 crc 76FCA436 md5 C33DEB5191E85BCAA942A92F184236C7 sha1 E4271947DFAB4C3EEB64A5927CDA4D25445A0E53 )
+)
+
+game (
+  name "Zaraks (Computer Rentals)"
+  description "Zaraks (Computer Rentals)"
+  year "1983"
+  manufacturer "Richard Taylor"
+  rom ( name "Zaraks.tzx" size 3923 crc 4466C390 md5 46D8771CF8578EDCF534505127A3735D sha1 D4D0575F849ED626A6D2B02CC3D64660980694C5 )
+)
+
+game (
+  name "Zaraks (Computer Rentals)"
+  description "Zaraks (Computer Rentals)"
+  year "1983"
+  manufacturer "Richard Taylor"
+  rom ( name "zaraks.p" size 3695 crc 733E3147 md5 F41780FBD2B777457AFBDBACF838C2FB sha1 46A79FA15ABF021D05E323B36629DCAB80E84E72 )
+)
+
+game (
+  name "Zombies/Sword of Peace (Artic)"
+  description "Zombies/Sword of Peace (Artic)"
+  manufacturer "Artic"
+  rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 CF95266460228F0BE0EC5CD944051FCA sha1 519D3115B5CEB75B61DFF442A927BE851FB0CA96 )
+)
+
+game (
+  name "Zuckman (White inlay) (DJL Software)"
+  description "Zuckman (White inlay) (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "Zuckman.tzx" size 10169 crc C80BADF3 md5 5B98D152D8A4EAD841A65716F68F7DD6 sha1 E212C3315D69861422DEE61AF487F6729568520A )
+)
+
+game (
+  name "Zuckman (White inlay) (DJL Software)"
+  description "Zuckman (White inlay) (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "zuckman.p" size 9939 crc E518A2BD md5 4D40C31B628FCA5ED079F992E8AE2D24 sha1 30720D6D3AF16AED257832988218F8EC3F002765 )
+)
+
+game (
+  name "Zuckman (Black inlay) (DJL Software)"
+  description "Zuckman (Black inlay) (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "Zuckman(Alt).tzx" size 10169 crc 886FA5B4 md5 82570CAFB6BAE5E05CF474C69C5ABF8B sha1 87F7870077134B24DFC9BAB9E406762BD7FF6D04 )
+)
+
+game (
+  name "Zuckman (Black inlay) (DJL Software)"
+  description "Zuckman (Black inlay) (DJL Software)"
+  year "1982"
+  manufacturer "DJL Software"
+  rom ( name "zuckman(alt).p" size 9939 crc A57CAAFA md5 B57A30D83B200790BCCF55EF9959AAA0 sha1 BF63E2441FCFAD7C72C8E8BDED65F9D3704D85ED )
+)
+
 game (
 	name "Ant Attack"
 	description "Ant Attack (2013) - Bob's interpretation of Sandy White's classic isometric title from 1983."
 	rom ( name "AntAttack.p" size 16167 crc 2e30a8cf md5 1fe5cfe57b540868e31fd73e7e54388b sha1 1b4fc9eb5cd3373a9986fcd395d0117c6b3c4718 )
+	manufacturer "Bob Smith"
+	year "2013"
 )
-game (
-	name "Arcade Action (Micromega)"
-	description "Arcade Action (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "ArcadeAction.tzx" size 4651 crc 5cb215e3 md5 5a76c5d34baa6d9aaf3bdd34e5c89597 sha1 04fc1ffa34592f093f1c0eae9d54b3ff31eb3e86 )
-)
-game (
-	name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-	description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-	year 1982
-	rom ( name "aroundeuropein80hours.p" size 15223 crc 2da984a7 md5 1dd7d90a090b80ea53c1b387b852d497 sha1 5d2a941cd7edca847bfd6c10b41b9025a81d4352 )
-	rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758c6 md5 5feee6f195cee427cd9195a1c4462f58 sha1 cb59d966fe38c858df9a002f2eaaae2cb0e1ba73 )
-)
-game (
-	name "Asteroids (Silversoft)"
-	description "Asteroids (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "asteroids.p" size 3542 crc 7484ac13 md5 0a392517e1d78420e0a5b5aafefe0c39 sha1 27d633e47d4e5a6b1594b16103e6a7ea12b5d0a7 )
-	rom ( name "Asteroids.tzx" size 3776 crc 939e50e5 md5 5f4836d37cb10b4bb5c7c71bb857409a sha1 85047ab187bfcd02195f00150419cee1bfc07a5f )
-)
-game (
-	name "Asteroids (Software Farm)"
-	description "Asteroids (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "asteroids(sf).p" size 8360 crc 0efcebd4 md5 583c3e31090f678a465c46d0cfcf2ad7 sha1 7f114cd978045301b7c63f7177d2fe2d0ee33264 )
-	rom ( name "Asteroids(SF).tzx" size 8594 crc 8b6f8743 md5 d7f2518bd65dbd7d99842f5a27aab588 sha1 d56d7e03a545b99607174faec186c42e64618189 )
-)
-game (
-	name "Autochef (Cases Computer Simulations)"
-	description "Autochef (Cases Computer Simulations)"
-	year 1982
-	rom ( name "autochef.p" size 15430 crc 575560bb md5 21c42c6c6eaf0866dc56533f89688f4f sha1 dd0ee23e39d50738d91731c427063ac8e59ad9d3 )
-	rom ( name "Autochef.tzx" size 15648 crc 3869ae07 md5 81856a30f98ccaa2fdbd6c88d8c7897f sha1 2b7416327bdb907108d287f8cd4eaa0fd291ecba )
-)
-game (
-	name "Avenger (Abacus)"
-	description "Avenger (Abacus)"
-	year 1982
-	manufacturer "K. Flynn"
-	rom ( name "avenger.p" size 7138 crc 53621a49 md5 1af4b6a7f31315a701b5dd54068c5596 sha1 0f402a98c52410358f2a3ec94280af6c7375f9ac )
-	rom ( name "Avenger.tzx" size 7368 crc b545fdae md5 b0e975a6cdff98f667536f3fd4d902bd sha1 529b2a9eb67c50db12494cc0ff7272925e9d18b4 )
-)
-game (
-	name "Backgammon (Keith Archer)"
-	description "Backgammon (Keith Archer)"
-	year 1982
-	manufacturer "Keith Archer"
-	rom ( name "backgammon(ka).p" size 11625 crc f4d9073b md5 b0a388f1b834d98852d96f998c1978cc sha1 c0c4e28934d05735b2200c41f2af8eb7b3abd1cb )
-	rom ( name "Backgammon(KA).tzx" size 11861 crc 153ed883 md5 71f46d576fe8bfa343d41949dabd2e55 sha1 81f25c1667c8eba6936eabfd080ccad3a3a34add )
-)
-game (
-	name "Backgammon (Timex)"
-	description "Backgammon (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "Backgammon(Timex).tzx" size 17108 crc 307aacd2 md5 d068903731302f4dc6c0e7810d1ed944 sha1 5a78754d849fe5284342089159af45588029c0a9 )
-)
-game (
-	name "Bank Robber (Romik Software)"
-	description "Bank Robber (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "bankrobber.p" size 6560 crc 2973af44 md5 8ca20ed973a7a1b830087cd30db7edba sha1 5ebdbd6b13b82933c158bd439b89bf6ce69149a7 )
-	rom ( name "BankRobber.tzx" size 6798 crc f9a7ab7d md5 36e6e97bd4ea83c494b6134e1aeee1c2 sha1 40d0fcc8faaf73b0082d4f1937ef16626d289f66 )
-)
-game (
-	name "Baron (Temptation Software)"
-	description "Baron (Temptation Software)"
-	manufacturer "Simon Mansfield"
-	rom ( name "Baron.tzx" size 16716 crc 2813c7a1 md5 c6ae4f6cf29411686bde01114a682498 sha1 fd944cedd638d3a5d6b70a8a4d50f2d41c16ea74 )
-)
-game (
-	name "Basicode 2 (BBC)"
-	description "Basicode 2 (BBC)"
-	year 1984
-	manufacturer "The Chip Shop"
-	rom ( name "Basicode2.A.tzx" size 3570 crc db6f1818 md5 ad1857f473ca1de8ed5d7b855d566c54 sha1 9204245adf3f343e82c43d6ec70117c4dc491908 )
-	rom ( name "basicode2.p" size 3338 crc 89ce64f1 md5 cab7e8adf644459ce8c1dd54897a184c sha1 07a3de146663d0e77a98a0800fb6f0545d567d77 )
-)
-game (
-	name "Bat Cage (Timex)"
-	description "Bat Cage (Timex)"
-	year 1982
-	manufacturer "Thomas J. Burke"
-	rom ( name "batcage.p" size 1222 crc a1b5d16f md5 0a716ad28c067c5938d776fabadfc176 sha1 e3dbde749ff3618ab07a6c8fc712531be6272bcf )
-	rom ( name "BatCage.tzx" size 1446 crc 650a94d8 md5 c3b8a71965f8ba025d546b7fe8f1531b sha1 8f6842f02e416e8b66c8d6172f2e852a5e14d2f8 )
-)
-game (
-	name "Battleships (JRS Software)"
-	description "Battleships (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "battleships.p" size 12732 crc a0a631a4 md5 99bdb02395ed7a85c8b13911c0344516 sha1 6897424919c684a7a18235d967c7f621f02d1cf0 )
-	rom ( name "Battleships.tzx" size 12962 crc a1057bc5 md5 8840352dd5514d5bc84e82f14f6211e2 sha1 0c36982f0243f39c028a21207a2218d40b1cb369 )
-)
-game (
-	name "Bigflap Attack (Timex)"
-	description "Bigflap Attack (Timex)"
-	manufacturer "Timex"
-	rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66c706f432ad9277573b709c913b16a0 sha1 985f2f32ae4478051b5b7d91cb17bbc474fd26f6 )
-)
-game (
-	name "Black Star (Quicksilva)"
-	description "Black Star (Quicksilva)"
-	year 1983
-	manufacturer "M. Sudworth"
-	rom ( name "blackstar.p" size 6811 crc 0407beac md5 d34202b6ac2f39323ad1212ca360e18b sha1 c17aa876dfeef10fd9d8da5bd83cc6fec9396fb9 )
-	rom ( name "BlackStar.tzx" size 7047 crc f227253f md5 c5b418b890bb6d828ec84d2fb36152ab sha1 0abe2ca4064679c23da82773fab70bf05c245844 )
-)
+
 game (
 	name "Boulder Logic"
 	description "Boulder Logic (2011) - Bradford Walker-Smythe needs to find the perfect engagement ring to win the heart of his true love Tania when he asks for her hand in marriage. And so, to prove his devotion, he sets off to the Cornish mines in search of the perfect diamond..."
 	rom ( name "BoulderL.p" size 16240 crc 23cc342f md5 b040c3e750ef06a93c56b53ed299b9ca sha1 3c74569ef70327ecf17db982ef92b4557c17b538 )
+	manufacturer "Bob Smith"
+	year "2011"
 )
-game (
-	name "Bouncing Bert (Software Farm)"
-	description "Bouncing Bert (Software Farm)"
-	year 1985
-	manufacturer "S C T"
-	rom ( name "bouncingbert.p" size 14919 crc fb88ad49 md5 e575aa04406a3f9eb1c095e8c0b6cd3a sha1 a56dddc42a1383c392d6988c9dafb4c8db37007a )
-	rom ( name "BouncingBert.tzx" size 15151 crc c30caf71 md5 ae2a31c5a4b92c6213b7547608110e86 sha1 ef3be8446d80452a155ed647a55c7d24aee58a6d )
-)
-game (
-	name "Breakout 3 (Axis)"
-	description "Breakout 3 (Axis)"
-	year 1982
-	manufacturer "Axis"
-	rom ( name "breakout3.p" size 5485 crc a836659c md5 9ae6333ad0003617da56543e57a60903 sha1 f226df48cfcabea16956faff21e88e3eeeccf66c )
-	rom ( name "Breakout3.tzx" size 5705 crc 69b9a5bf md5 595c064a5d18089bec87664dc37ab2da sha1 faf622eff6cca236e0623d7f23cf35bfef74d823 )
-)
-game (
-	name "Breakout (CDS Micro Systems)"
-	description "Breakout (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "breakout.p" size 3235 crc 82836ac3 md5 3f4b0e39130be53ae22381f8a82a3081 sha1 eb36d14650c568ed47326dc094392c70fd249b3c )
-	rom ( name "Breakout.tzx" size 3467 crc 322fafd6 md5 0323a0d24248e0de2dce75c7cd3b71a9 sha1 1cb495c3b751e64e8b1fc38c68fabf0340365f39 )
-)
-game (
-	name "Breakout (J. K. Greye)"
-	description "Breakout (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "breakout(jkg).p" size 716 crc 15cb56b4 md5 4655a4c1f58c705f303d31d2f2e64f7f sha1 2a4ddae5df3c18192c851be567daeb9ab59aa456 )
-	rom ( name "Breakout(JKG).tzx" size 948 crc e3f0284a md5 c52f2080dc8e969b4636da6f9d4f1e54 sha1 c8138f8960aedf4d848c65b676d76bf717ec9154 )
-)
-game (
-	name "Breakout (New Generation)"
-	description "Breakout (New Generation)"
-	year 1982
-	manufacturer "J. K. Greye"
-	rom ( name "breakout(ngs).p" size 716 crc d4496e38 md5 e488ef1a3efc25f2abd308f9aef901b5 sha1 bd90a91d1ef17e19802d145dac955d0d34cab5f0 )
-	rom ( name "Breakout(NGS).tzx" size 948 crc 227210c6 md5 50fe074b25394a62a8fbbb8dac9513fb sha1 86b96863cffca1038110a78b99b4df5fbcc75daa )
-)
-game (
-	name "Breakout, Space Invaders and Music (Macronics)"
-	description "Breakout, Space Invaders and Music (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "BreakoutSIAndMusic.tzx" size 2734 crc d383db01 md5 13110862adf0b4abb06573a2be710087 sha1 d5582e7a6a79bd6b8a2096ed968c91292b46483b )
-)
-game (
-	name "Brick Stop (CDS Micro Systems)"
-	description "Brick Stop (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "brickstop.p" size 3126 crc 8ee66abe md5 b70594c6cb40ac4b3b7706574153563d sha1 fd697ae6ec522406f4e6b91a5c7a5d7c9058a4ff )
-	rom ( name "BrickStop.tzx" size 3362 crc 2e173afa md5 65a723688c0fd694ad600407fc12ec17 sha1 232822deb023be4037e9864a1ccd01e8c42a32bf )
-)
-game (
-	name "Bubble Bugs (Romik Software)"
-	description "Bubble Bugs (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "bubblebugs.p" size 6409 crc 1e09b9ec md5 00b1a8fe3030cf7b4cd91b5eaf986516 sha1 8770497d4db9455f31dc6f422b710ba44dcab096 )
-	rom ( name "BubbleBugs.tzx" size 6647 crc 368c6f68 md5 3e4feeb96b4ff463ff81be369592c0de sha1 e52ddab32b1183910d1c74ae04999a8fb92dc158 )
-)
-game (
-	name "Bumper 7 (Axis)"
-	description "Bumper 7 (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "Bumper7.tzx" size 5179 crc 3c31d394 md5 7a42934f415ad9587a203974bbe2f6f2 sha1 2adc581baca7d49305c0ccd720f594c50618be5e )
-)
-game (
-	name "Byter (Protek)"
-	description "Byter (Protek)"
-	year 1983
-	manufacturer "Protek"
-	rom ( name "byter.p" size 5045 crc 1c53ac02 md5 8db34a0ed323545380ac2eb69190fa18 sha1 c396155336a5f43e908de08c5398b670f694b4f7 )
-	rom ( name "Byter.tzx" size 5271 crc 540854fe md5 423d68cc0edd3f4c360cc58f167f0e71 sha1 ab1f4d1f13735e7ffe4e143c1ee159a2ca1a0617 )
-)
-game (
-	name "Can of Worms (Automata Cartography)"
-	description "Can of Worms (Automata Cartography)"
-	manufacturer "Automata Cartography"
-	rom ( name "CanOfWorms.tzx" size 7150 crc b2e6fa12 md5 3a724f1a32f350922012f1ff6b6e0193 sha1 9bb651b39206913bbe74600997114fcbcd70747c )
-)
-game (
-	name "Cassette 3 (M. Orwin)"
-	description "Cassette 3 (M. Orwin)"
-	year 1982
-	manufacturer "Various"
-	rom ( name "Cassette3.tzx" size 96710 crc f612e596 md5 688fe0bd73cf475d632ebb2bc920f92c sha1 a3a02c88cd119f5acf87ef056a8b26dad0a79390 )
-)
-game (
-	name "Cassette 4 (M. Orwin)"
-	description "Cassette 4 (M. Orwin)"
-	year 1982
-	manufacturer "Various"
-	rom ( name "Cassette4.tzx" size 53160 crc 9c246427 md5 acfc26dd06d2a03808f0ff71e9be96d2 sha1 5cdb627ac5b3498225d7d4d5fb90d80751187218 )
-)
-game (
-	name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-	description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
-	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
-)
-game (
-	name "Castle Adventure (CDS Micro Systems)"
-	description "Castle Adventure (CDS Micro Systems)"
-	manufacturer "CDS Micro Systems"
-	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
-	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
-)
-game (
-	name "Catacombs (J. K. Greye)"
-	description "Catacombs (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "catacombs.p" size 12506 crc b1ed0b59 md5 5e674ce62efd5ab861bbeef9de75d711 sha1 a5d32e1d50d291c485549c4740e5cc6ba3de36ab )
-	rom ( name "Catacombs.tzx" size 12740 crc f8d6aee6 md5 6ec147973d7561ede4726bc413409cdd sha1 c872d07e278df997df9a66185852f580fd851151 )
-)
-game (
-	name "Cave Crusade (AWA Software)"
-	description "Cave Crusade (AWA Software)"
-	manufacturer "S. Hughes"
-	rom ( name "cavecrusade.p" size 6270 crc a2eb2f80 md5 b6c9c3f387d5ba97d80fe92a03e6d0c5 sha1 5f05d170d3eba9a7c4915eecd7e65bbbb958feca )
-	rom ( name "CaveCrusade.tzx" size 6510 crc 9dec44e3 md5 4e27965613610224b2c60f824983f7a7 sha1 bc4a46fdec5734a88afc005df4864feae26549e1 )
-)
-game (
-	name "Centipede (dktronics) (dK'tronics)"
-	description "Centipede (dktronics) (dK'tronics)"
-	year 1982
-	manufacturer "Jeff Minter"
-	rom ( name "centipede(dktronics).p" size 9790 crc 1e369ce6 md5 dd7d3f2e2b36ffbd2cc169624fc60421 sha1 7770684a912c0bb2116d9f73f1caafc1796a23df )
-	rom ( name "Centipede(dktronics).tzx" size 10008 crc f12c5ee1 md5 78b3d51b99fa1b99182d60b206fe2944 sha1 c90d0ca1dd3e1679c9c0e4a359d6b84978c129f7 )
-)
-game (
-	name "Centipede (Green cover) (dK'tronics)"
-	description "Centipede (Green cover) (dK'tronics)"
-	manufacturer "dK'tronics"
-	rom ( name "centipede(green).p" size 9733 crc f5f4b919 md5 90610d4fa888969f53204a5ca98f6a20 sha1 418c10220fbf3bcf83c07b2a9c717dd12dc92c53 )
-	rom ( name "Centipede(Green).tzx" size 9967 crc 0ed972cd md5 9dd33fd4999f2d1de4bf52e4590d2521 sha1 1bf47ef2651d5d09a6971ce9eb931aa41ed846cb )
-)
-game (
-	name "Centipede (Llamasoft)"
-	description "Centipede (Llamasoft)"
-	year 1982
-	manufacturer "Jeff Minter"
-	rom ( name "centipede.p" size 9706 crc f2414d13 md5 eeba50f572e820d43fb3f8d140c673e1 sha1 0f23aa3eac663bd04de225074b80701ba05fcb1b )
-	rom ( name "Centipede.tzx" size 9940 crc 163cf493 md5 74ac41b73e525977dd00e99e92a46e53 sha1 dd75bbb4ec90c8d054e1c0a41164e02a8f3121e3 )
-)
-game (
-	name "Challenge (Micromega)"
-	description "Challenge (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "Challenge.tzx" size 4865 crc 8439c8b1 md5 b963b33677e4e187630608606fecba67 sha1 b3dd53df21a684570b3120a8a996fae738dfb15a )
-)
-game (
-	name "Champions! (Peaksoft)"
-	description "Champions! (Peaksoft)"
-	manufacturer "Peaksoft"
-	rom ( name "champions.p" size 14858 crc d363867f md5 806e86a4e8c5807ce53717e4ba441c98 sha1 2148c6108e52c8c33a8c1593c47a1ee89ed711b8 )
-	rom ( name "Champions.tzx" size 15086 crc 7ae0415b md5 7f738befe88938ae2f5bfaf464cc2c16 sha1 1847183ffcaf74bb7f709d09d1d5fea24c720e6a )
-)
-game (
-	name "Chess (Timex)"
-	description "Chess (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "Chess(Timex).tzx" size 10227 crc 8f6bfdc7 md5 c0678ed697e11dfa85e483db93dd053c sha1 bd2a54d8ccb6bd918deaba02b0793cf0372c8f27 )
-)
-game (
-	name "Chrs Demo (Quicksilva)"
-	description "Chrs Demo (Quicksilva)"
-	manufacturer "Quicksilva"
-	rom ( name "ChrsDemo.tzx" size 5993 crc 3e8d1da7 md5 b69ea89a89170660517bf2284c791e12 sha1 8509b1fc61dc20c1e9280526858b0e95bd6359b5 )
-)
-game (
-	name "City of Xon (Pleasantrees)"
-	description "City of Xon (Pleasantrees)"
-	year 1982
-	manufacturer "Pleasantrees"
-	rom ( name "cityofxon.p" size 15507 crc e853667c md5 82a04afaf98222545389663888140b7b sha1 2111223fd0cab96c1aca585430336e60d501017f )
-	rom ( name "CityOfXon.tzx" size 15729 crc 3b72af94 md5 18b114ee78e469ea4b85e858802a716c sha1 0d07fb55913b3495b0c26178c84d010cd5eeb03e )
-)
-game (
-	name "City Patrol (Sinclair Research)"
-	description "City Patrol (Sinclair Research)"
-	year 1982
-	manufacturer "Macronics (Don Priestley)"
-	rom ( name "citypatrol.p" size 9168 crc b9cf2e5f md5 a14424f16ed442e3c0af074f2ea01c95 sha1 333c2e1052dc734d76b19da5dddfaa9835177e12 )
-	rom ( name "CityPatrol.tzx" size 9388 crc 1ea8841e md5 71c94bc78806c1ea06d1996cbf6d64e8 sha1 99d5ae89cfe7940e67d8ede6dbd860020b1ad9df )
-)
-game (
-	name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-	description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-	year 1983
-	manufacturer "Computertutor"
-	rom ( name "whizzquiz.p" size 16032 crc b8995dc4 md5 7f62be0efdc60665d015473550fafa0e sha1 436c07c66875f854b57a43b543c3002ad6c3e061 )
-	rom ( name "WhizzQuiz.tzx" size 16252 crc 831e3890 md5 9cb954c3643f9bbdac2f2fd5ee28a79b sha1 81b7fa7bc053ea09617edd5428ea8b9bc7d8e4d2 )
-)
-game (
-	name "Club Record Controller (Sinclair Research)"
-	description "Club Record Controller (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "clubrecordcontroller.p" size 6857 crc 16b8f22f md5 481daf4708c4217ff3c5446f049e5d61 sha1 73048e28d5c2f198a97c1ba33e9a2111a1901465 )
-	rom ( name "ClubRecordController.tzx" size 7075 crc c1bdaa09 md5 03638152afe7d50f7f3050d42423fb5a sha1 246f887ed316a62311165af8ac7abee59c0cfce6 )
-)
-game (
-	name "Club Records (W. H. Smith)"
-	description "Club Records (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "clubrecords.p" size 7526 crc 770ead60 md5 43274f46a93f29e10650a6c0ea5d6ea6 sha1 06c9b03442650d03948bdd73095ba4541cf4fff4 )
-	rom ( name "ClubRecords.tzx" size 7744 crc 229bf155 md5 9061510c942e211db25159985fd39a7b sha1 d62dc88512d6dc336dad5637924e6056a19e12a7 )
-)
-game (
-	name "Collector's Pack (Sinclair Research)"
-	description "Collector's Pack (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "collectorspack.p" size 7447 crc ad2faa57 md5 dc7c428a0df6b6140dd71f0924f80316 sha1 67ff172b4ec0b7b088b17ee62df3860851748705 )
-	rom ( name "CollectorsPack.tzx" size 7665 crc 4998a5d6 md5 8fd43049ae5c0246d79c82d59cef6cd4 sha1 bb2b43893119eabf30754be20992bf32e05e6832 )
-)
-game (
-	name "Collector's Recording System (W. H. Smith)"
-	description "Collector's Recording System (W. H. Smith)"
-	manufacturer "ICL"
-	rom ( name "collectorsrecordingsystem.p" size 7447 crc fe3eb9cc md5 8af2b0e4d7a7480859b978aff6b8954d sha1 bf4b5d5c78b6a1e68784296567aa655362d6a552 )
-	rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1a89b64d md5 d0735fc71d39a879e80fe130f3ca8226 sha1 7fb6cf85c4a0e47a2ad78f5f4371deeebadcb923 )
-)
-game (
-	name "Community Chest (Artic)"
-	description "Community Chest (Artic)"
-	manufacturer "Artic"
-	rom ( name "communitychest.p" size 14048 crc 0fe4512d md5 a40b1c79c5b578238002454f2a4b92bc sha1 941725aeef9136f7b105bd1e8c21245ec671ac86 )
-	rom ( name "CommunityChest.tzx" size 14270 crc bf585c82 md5 a4b42d6021ceca0f9c09aa0e6596c110 sha1 c95af3f37795adabe7f251643efff51cb7e2579f )
-)
-game (
-	name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-	description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-	year 1981
-	manufacturer "S. C. Stephens"
-	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
-	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
-)
-game (
-	name "ComputaCalc ZX (Silicon Tricks)"
-	description "ComputaCalc ZX (Silicon Tricks)"
-	year 1981
-	manufacturer "S. C. Stephens"
-	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
-	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
-)
-game (
-	name "Constellation (Bug Byte)"
-	description "Constellation (Bug Byte)"
-	manufacturer "Bug Byte"
-	rom ( name "constellation.p" size 12385 crc 82892356 md5 b7ff958c98e6955281aed8d50ce4a8b2 sha1 b020cec9fd14f00882de28165f4f2a207e020306 )
-	rom ( name "Constellation.tzx" size 12611 crc a0146b49 md5 500508c55bfae7c20d1191cf95b37e5d sha1 fb8bbc99988812c5ef372a7358a36ceadb53ae73 )
-)
-game (
-	name "Constellation (Gladstone) (Gladstone Electronics)"
-	description "Constellation (Gladstone) (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "constellation(ge).p" size 15452 crc ca46cb85 md5 7eb28d1ad0f29be00794f00be04ff1e7 sha1 58f35fb046a9e20052dc7b838e1754c593fcdb53 )
-	rom ( name "Constellation(GE).tzx" size 15694 crc 89092de9 md5 e76748a332503ed9799fb76a16cf24f2 sha1 69da2b7f7a1f311a73858f4787f05c31460e7172 )
-)
-game (
-	name "Control Technology Tapes 1,2,3 (Control Technology)"
-	description "Control Technology Tapes 1,2,3 (Control Technology)"
-	manufacturer "Control Technology"
-	rom ( name "ControlTechnology123.tzx" size 48433 crc d9610ea9 md5 1c5691270a4f2ef50a859f6eefe7891f sha1 8e630dbc2725862733cd138e69a7c8ca9eeed84f )
-)
-game (
-	name "Conversational German (Timex)"
-	description "Conversational German (Timex)"
-	year 1983
-	manufacturer "D. E. Hagan"
-	rom ( name "conversationalgerman.p" size 15375 crc 2a3a859e md5 b73d18d611af33ad7c555f03f0cc597d sha1 f03403678a5b6caa88cedee89aee74ba8d4270ab )
-	rom ( name "ConversationalGerman.tzx" size 15603 crc 810bdcc4 md5 1e27801fd4db30240671c6f1ecbbe73d sha1 ddb421fe807557a6f4a2eb7ea78e15c249b15de1 )
-)
-game (
-	name "Cosmic Guerilla (Quicksilva)"
-	description "Cosmic Guerilla (Quicksilva)"
-	year 1983
-	manufacturer "C. K. Tame"
-	rom ( name "cosmicguerilla.p" size 7333 crc 8594884e md5 37c438dbf7ec1a61b574c870ab04b375 sha1 1f0226f4de15f5ee393761631a6d3aad46c75a10 )
-	rom ( name "CosmicGuerilla.tzx" size 7561 crc 001ef96d md5 de8ca35128d7ec90516dd6ee759e65a6 sha1 ef8e79312d0dc7efec6bf2a9a6ca785b0e4a94a0 )
-)
-game (
-	name "Counter Attack (Woodside Software)"
-	description "Counter Attack (Woodside Software)"
-	manufacturer "P. Hennessy"
-	rom ( name "counterattack.p" size 6975 crc 4095691a md5 846be5d9faf79197323d5c2b05b82136 sha1 45aae62dc5ed72ecba3c33b280b2c3d7310cf942 )
-	rom ( name "CounterAttack.tzx" size 7219 crc 6b8852ca md5 dfe0270c48c5af69bd0652f723f6c5b2 sha1 286cd36a713f95ffcc5e847539a59de6c55f6c42 )
-)
-game (
-	name "Critical Path Analysis (Hilderbay)"
-	description "Critical Path Analysis (Hilderbay)"
-	year 1981
-	manufacturer "Hilderbay"
-	rom ( name "criticalpathanalysis.p" size 6053 crc 10fb4d01 md5 30f5b565eebb684d446a1d9073860bd2 sha1 e6e505e111c04a395e8a946cf2c5b7bbed948ba1 )
-	rom ( name "CriticalPathAnalysis.tzx" size 6275 crc 28ee5886 md5 47b2d99a813ea1744ad5a41d15016a8d sha1 3ee5a82dec70e4bd7eb1d514cdd4538cb433f24a )
-)
-game (
-	name "Critical Path Analysis (Timex)"
-	description "Critical Path Analysis (Timex)"
-	year 1982
-	manufacturer "W. Emery"
-	rom ( name "CriticalPathAnalysis(Timex).tzx" size 6720 crc c1835895 md5 af015196bc37c30e8f529da34262ed28 sha1 469f80fbf8e3979b8534e28dabd9d7089e55425e )
-)
-game (
-	name "Croaka-Crawla (Quicksilva)"
-	description "Croaka-Crawla (Quicksilva)"
-	year 1983
-	manufacturer "Quicksilva"
-	rom ( name "croakacrawla.p" size 14666 crc 2e8a9af1 md5 96fdeaf0f549a9198b633a19510be1fe sha1 4bb58b01e86aaf1dc21999e77ec7d557f4353ffe )
-	rom ( name "CroakaCrawla.tzx" size 14896 crc 1e07d1c3 md5 51e05750eda73cbd667e52d945c742d9 sha1 3489fd97ee769b1b59e0b74ccdeb667f135dbcbd )
-)
+
 game (
 	name "CroZXy Road"
 	description "CroZXy Road (2015) - Bob's interpretation of Hipster Whale's iconic 'Crossy Road'"
 	rom ( name "CrozxyRoad.p" size 16058 crc 38885a68 md5 dee3fff6ce7789a7a4a4c38cffdb7a5d sha1 98ef4e7a24f87c9d253da0dc68698850dcd2752f )
+	manufacturer "Bob Smith"
+	year "2015"
 )
-game (
-	name "D Coder (Cosma)"
-	description "D Coder (Cosma)"
-	manufacturer "Cosma"
-	rom ( name "DCoder.A.tzx" size 7680 crc 1684ba79 md5 229d7eb3cd3c17b82a1fb4e5daec5370 sha1 39f16bb21b52c566218f38aa07b1951e38c0f8bd )
-)
-game (
-	name "Dallas (French) (Cases Computer Simulations)"
-	description "Dallas (French) (Cases Computer Simulations)"
-	year 1983
-	manufacturer "Cases Computer Simulations"
-	rom ( name "dallas(french).p" size 16151 crc 6fc5f7ec md5 c76bd00587e4017e445c023ad12fdfcb sha1 1d1cd2f2ce3cdfc7a8c18e8bdd1cd0cdc8f2797e )
-	rom ( name "Dallas(French).tzx" size 16379 crc 4a65562e md5 6ea358b625c6deecce8b906983884a27 sha1 499bee247f3bdc37eca67e95eee1624de11ec5d6 )
-)
-game (
-	name "Dictator (Bug Byte)"
-	description "Dictator (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "dictator.p" size 16074 crc 9ef1b3cf md5 8aa9775f53f519ded0ae7f7a2c5b3f60 sha1 42b98d75f715b69c1c54722a05a8d0d7b07783ec )
-	rom ( name "Dictator.tzx" size 16306 crc b01e01a7 md5 2e2e96ed20915990eb8280021ce7838e sha1 c14608ecc904b6ad8141d64bb4eed66c43b6316d )
-)
-game (
-	name "Do Not Pass Go (Work Force)"
-	description "Do Not Pass Go (Work Force)"
-	manufacturer "Work Force"
-	rom ( name "donotpassgo.p" size 13355 crc 292a5505 md5 0480349fbee60fd0939f31cc6d210c2b sha1 a05ba8ad8560a15c5ecffff289d10daa421b5cb8 )
-	rom ( name "DoNotPassGo.tzx" size 13587 crc a2dd0f0c md5 d4cdfcee0472c465483738b520960d65 sha1 45ded58ce3255e5239722c956eef084bac20ad6d )
-)
-game (
-	name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-	description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "DodgemsAndConnect4(Brown).tzx" size 9488 crc 39d4e107 md5 b6110b1177643dfb269784ee01902964 sha1 de9f3293e482ac4f92b3278d262e45321450fe79 )
-)
+
 game (
 	name "Domin8tr1s"
 	description "Domin8tr1s (2010) - Arrange the dominoes as they tumble from the sky so that matching digits are adjacent, either horizontally or vertically, to each other.  Align the same number of digits as the digit itself to make those dominoes disappear."
 	rom ( name "DOMIN8TR1S.P" size 6581 crc 96911e31 md5 d3e69b3bba27f609f426a6434f3a93ac sha1 8e8ee9c4fc589f386596ef3b3e8fab9b9ee799ef )
+	manufacturer "Bob Smith"
+	year "2010"
 )
-game (
-	name "Dominoes (Phipps Associates)"
-	description "Dominoes (Phipps Associates)"
-	year 1983
-	manufacturer "D. G. Cross"
-	rom ( name "dominoes.p" size 15143 crc f53499e9 md5 7c250a09c6e3e1fe996ab0df7fc312ff sha1 cd00bf0a030844133f39fbbac4712ba1c8591dca )
-	rom ( name "Dominoes.tzx" size 15375 crc 4fc4e410 md5 c9ec351812095d3a1a91e4db7926a5d8 sha1 b780954c535ccd6f6a778999b7244de33bb3ad53 )
-)
-game (
-	name "Dr. Floyd (Apropos Technology)"
-	description "Dr. Floyd (Apropos Technology)"
-	manufacturer "Apropos Technology"
-	rom ( name "drfloyd.p" size 14062 crc d16282da md5 4e26541f29e46baba6beac4ad8bccc31 sha1 c5531613742a634a5b41503198ae567adc6a42ab )
-	rom ( name "DrFloyd.tzx" size 14294 crc d5b0408f md5 5e0b05b046b113239ec5efdb9e23589e sha1 6982c898304a0e319434984a019b96682d177661 )
-)
-game (
-	name "Dragon Maze (Macronics)"
-	description "Dragon Maze (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "dragonmaze.p" size 4750 crc b252b048 md5 d5520c004ecd8e8d15d36fa70fddec8e sha1 f6f90b253527935b27ce3674c49b33d914b37dfc )
-	rom ( name "DragonMaze.tzx" size 4970 crc c2a29e0d md5 3aaaadd623df3a672361715bb3b9c6f3 sha1 58e77f8d47f0a0061f0545e3d95485d9041d7025 )
-)
-game (
-	name "Dungeons of Doom (Temptation Software)"
-	description "Dungeons of Doom (Temptation Software)"
-	year 1982
-	manufacturer "Simon Mansfield"
-	rom ( name "DungeonsOfDoom.tzx" size 15074 crc d5034066 md5 747215bd1afebf2217addc18b14b1e36 sha1 b2884c73af5da39e4c32d9a11206769e006f456f )
-)
-game (
-	name "E.E. 1 - Filter Design (Timex)"
-	description "E.E. 1 - Filter Design (Timex)"
-	year 1982
-	manufacturer "American Micro Products"
-	rom ( name "ee1filterdesign.p" size 11825 crc a6a157c9 md5 5e5b10ecc426f5820f3dab25b7c6ad92 sha1 152342a49020a5740a50650d9b2bbf9c5d66c9b7 )
-	rom ( name "EE1FilterDesign.tzx" size 12047 crc 1159b6aa md5 0a3fb9fd79259c485b0df31a4d387d20 sha1 d6714fe623f9e444c22cde90f56488a58fce0d33 )
-)
-game (
-	name "Electric Cost Analyzer (Timex)"
-	description "Electric Cost Analyzer (Timex)"
-	year 1983
-	manufacturer "Tim Rossetti"
-	rom ( name "electriccostanalyzer.p" size 15557 crc bccae88d md5 adca050f5154d5e1107ca72433db06e1 sha1 dd7ae4f987b76d764d60d5a0fd95cf879310dde2 )
-	rom ( name "ElectricCostAnalyzer.tzx" size 15789 crc d6745b7a md5 ca1d14bad434d1ad36f829aaac3939a1 sha1 f5f5c2a8038df69484937ce4b853b4e83dfcf5f5 )
-)
-game (
-	name "Electronics (Spectre)"
-	description "Electronics (Spectre)"
-	manufacturer "Spectre"
-	rom ( name "electronics.p" size 15899 crc b18d5d28 md5 8d3ee1b1eb0d3df446f50731c6659279 sha1 2f56472672d41361c60591d7cf177eb18148976b )
-	rom ( name "Electronics.tzx" size 16121 crc e777753a md5 48b223d7a2e94415ad4dc381b6a33fe8 sha1 d3a41d3aa66db93144eef927a1c37fc8bb9fab90 )
-)
-game (
-	name "Encounter (Quicksilva)"
-	description "Encounter (Quicksilva)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Encounter.tzx" size 17612 crc af150f3f md5 d526d1745135dcc2bc1f357fa2cab910 sha1 ec8355c006d83dfc367a166ee6f33cb3530381ab )
-)
-game (
-	name "Escape From Manhattan (Computer Rentals)"
-	description "Escape From Manhattan (Computer Rentals)"
-	year 1983
-	manufacturer "N. Taylor"
-	rom ( name "escapefrommanhattan.p" size 16102 crc 63f8023f md5 135b8483bb5b316c8744d824acbb86c1 sha1 53799e5ea4da7a6c5ebba8537126f25ebbeb8285 )
-	rom ( name "EscapeFromManhattan.tzx" size 16320 crc 2cacbb72 md5 2b526ba624af0fdfc1733099ccec82ab sha1 975c976e36b9dbd47fcf5312fae4ad5c2521d6d7 )
-)
-game (
-	name "Escape from Shazzar (International Publishing and Software Inc.)"
-	description "Escape from Shazzar (International Publishing and Software Inc.)"
-	year 1983
-	manufacturer "A. F. Nuttall"
-	rom ( name "escapefromshazzar.p" size 16146 crc c587593d md5 b2dc9a81ac27d4bc267c8d4a0236acb5 sha1 48fa28f6b637e59f48a58e618617a98f83fe6813 )
-	rom ( name "EscapeFromShazzar.tzx" size 16376 crc 78075b95 md5 0854165d7caa9f5d43203e5f9c999fa0 sha1 992dfcece29b42c729bbca05422bf090dc7c275c )
-)
-game (
-	name "Fast Load Save (Musamy Software)"
-	description "Fast Load Save (Musamy Software)"
-	year 1982
-	manufacturer "Musamy Software"
-	rom ( name "FastLoadSave.tzx" size 11000 crc 939f03cb md5 be316fadc3492e475e6d07bdf9ae310e sha1 616dfc2662d46f415277990bebf0b09e187ed36e )
-)
-game (
-	name "Flight Simulation (Sinclair Research)"
-	description "Flight Simulation (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
-)
-game (
-	name "Flug-Simulation (Sinclair Research)"
-	description "Flug-Simulation (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
-)
-game (
-	name "Football (Tyrant)"
-	description "Football (Tyrant)"
-	manufacturer "Tyrant"
-	rom ( name "football.p" size 15626 crc 33233387 md5 ef4f6c235f9017f7b4c83f19ffc72818 sha1 f0ee8a1607a606d22b7c2ba518a06bd2cd387fd9 )
-	rom ( name "Football.tzx" size 15858 crc 8503533c md5 673dfecb1920d35fcd55f23aab95dbf8 sha1 d75dfc7310f08160f7ff61f2e08f2ed4fa5aabb0 )
-)
-game (
-	name "Football Manager (Addictive Games)"
-	description "Football Manager (Addictive Games)"
-	year 1982
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
-)
-game (
-	name "Football Manager (Black inlay) (Addictive Games)"
-	description "Football Manager (Black inlay) (Addictive Games)"
-	year 1981
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
-)
-game (
-	name "Football Manager (Red) (Addictive Games)"
-	description "Football Manager (Red) (Addictive Games)"
-	year 1981
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
-)
-game (
-	name "Football Pools Program (Hartland Software)"
-	description "Football Pools Program (Hartland Software)"
-	manufacturer "Hartland Software"
-	rom ( name "FootballPools.tzx" size 24422 crc 2d0ed98b md5 387bb8707269de22cfb13b4c8781d20c sha1 a2ae0611ad434600777c2ba0df4cc48d8109d9f8 )
-)
-game (
-	name "Football-League (Video Software)"
-	description "Football-League (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "FootballLeague.A.tzx" size 14343 crc 78694c75 md5 64ad8a73b7b3b45c35aa937b09e14817 sha1 4887f03b6e5725d1acb156a485ddc9c450607d88 )
-	rom ( name "footballleague.p" size 14097 crc 9e4623c5 md5 b430448d983a97c6de8d0fd776bef9c8 sha1 c8b1bd7a85d2981ec2b6478e0c58b36dccb42ac3 )
-)
-game (
-	name "Forth (Sinclair Research)"
-	description "Forth (Sinclair Research)"
-	year 1983
-	manufacturer "Artic"
-	rom ( name "Forth.tzx" size 14183 crc 376c5750 md5 5ad0f910d2987e3a51716dd82e6f4113 sha1 012a7e585c3f2d245e3d7ffba935ea1962be21c4 )
-)
-game (
-	name "Fortress of Zorlac (Timex)"
-	description "Fortress of Zorlac (Timex)"
-	year 1982
-	manufacturer "Paul Carlson"
-	rom ( name "fortressofzorlac.p" size 7214 crc aded8203 md5 0852a128df135af9f240356567d626b8 sha1 872b7049cab2fea166921ba30d93fccdaf63f840 )
-	rom ( name "FortressOfZorlac.tzx" size 7442 crc 30d3ba7d md5 05b14472e34f62f64d40e71f0001f900 sha1 13f8969e92932f3f6e4c6f177bbe34512780b96f )
-)
-game (
-	name "Forty Niner (Software Farm)"
-	description "Forty Niner (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "fortyniner.p" size 13868 crc b8650da4 md5 9729d9b8a4faee1d12f4384f789c0b44 sha1 694ac6d1410eade17ecc9e06a3c39191e8dda352 )
-	rom ( name "FortyNiner.tzx" size 14106 crc 1c4eff0a md5 fba0b998270a673af60ede6b1f6da4ff sha1 e563342e858b8c38a384ebfd695c479feb01a4a5 )
-)
-game (
-	name "Frogger (DJL Software)"
-	description "Frogger (DJL Software)"
-	manufacturer "DJL Software"
-	rom ( name "frogger.p" size 13493 crc 8d24d478 md5 db791414f02377a0b2bb60e1539401f3 sha1 29d815b98770a1fbae3714642c5c70583d02ed17 )
-	rom ( name "Frogger.tzx" size 13723 crc bd7df880 md5 9a8c77a4c24e8e67f7308be91a2b95aa sha1 75499b16de8dfbabf668328109d0a36963bfd11b )
-)
-game (
-	name "Frogger (Sega) (Timex)"
-	description "Frogger (Sega) (Timex)"
-	year 1981
-	manufacturer "Cornsoft/Sega"
-	rom ( name "frogger(sega).p" size 10638 crc 3993108b md5 1e6fdfe09452ba5609c693a7683c94f7 sha1 b17facf22bb6f66fe8eef0977cbdf1b1ecde6c6c )
-	rom ( name "Frogger(Sega).tzx" size 10868 crc 95952886 md5 e8ebe732890b6dc7d39674e7bf527716 sha1 08999372caf4a07b532e7360f1573c5262b56ed7 )
-)
-game (
-	name "Froggy (DJL Software)"
-	description "Froggy (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "froggy.p" size 10394 crc 5624f4f4 md5 c0408bb2b6d716d9643fa64670d7c241 sha1 9f45088a30fdbddffccb01f55690cde7276df088 )
-	rom ( name "Froggy.tzx" size 10622 crc e84f00da md5 8a827657ccd27300bafaa4af1076045a sha1 c0d7d2db94e8fb84bb22428b0b6a5c5ccc11c52b )
-)
-game (
-	name "Frogs (Mikro-Gen)"
-	description "Frogs (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "frogs.p" size 4223 crc b5335a99 md5 55d1b367c05a5f9259da78aad2b072da sha1 d3edabf6c4e7e88cb1224ace1c63b2735dbf2f0f )
-	rom ( name "Frogs.tzx" size 4453 crc efd0f05e md5 9409197480d2e19da908b0594580ee89 sha1 899d5cdf74208e30d17c5d34f5733d207222daaa )
-)
-game (
-	name "Fun Fair Adventure (Fawkes Computing)"
-	description "Fun Fair Adventure (Fawkes Computing)"
-	year 1983
-	manufacturer "Fawkes Computing"
-	rom ( name "funfairadventure.p" size 15670 crc f5238943 md5 4f267d0ad39d72853cbb7ff914a491b0 sha1 d654cca3195f48a50e1391bc5bc8db72a1d4215f )
-	rom ( name "FunFairAdventure.tzx" size 15892 crc 477b0e8f md5 8b00dde0094158be9fa735e62bc99bf9 sha1 c828c69e2a899e1b15968dafeaeb19b6045b360b )
-)
-game (
-	name "FUNdamentals of Math (Timex)"
-	description "FUNdamentals of Math (Timex)"
-	year 1983
-	manufacturer "ATM"
-	rom ( name "FUNdamentalsOfMath.tzx" size 39312 crc 75ade9a1 md5 fbe76752ce6fd550c78f7116e8472d37 sha1 0c1fd6d5034fa73e8d1d3dd525e088cd96971bd7 )
-)
-game (
-	name "Galactic Gunner (Timex)"
-	description "Galactic Gunner (Timex)"
-	year 1983
-	manufacturer "Paul W. Carlson"
-	rom ( name "galacticgunner.p" size 8786 crc fef205ce md5 35300ca762e104fc8c6efba2280feb96 sha1 cbb2fb7c55caa311826d2a2481c6dffad40b5863 )
-	rom ( name "GalacticGunner.tzx" size 9014 crc 1ee1c007 md5 9e6d42b5ba230a9e298dfe1c49744b23 sha1 93f8f8b5fde8de8305d0946f25296da88e26d720 )
-)
-game (
-	name "Galactic Patrol (Computer Rentals)"
-	description "Galactic Patrol (Computer Rentals)"
-	year 1983
-	manufacturer "Richard Brisbourne"
-	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
-	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
-)
-game (
-	name "Galactic Patrol (Omega re-release) (Omega)"
-	description "Galactic Patrol (Omega re-release) (Omega)"
-	year 1984
-	manufacturer "CRL"
-	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
-	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
-)
-game (
-	name "Galactic Trooper (Romik Software)"
-	description "Galactic Trooper (Romik Software)"
-	year 1983
-	manufacturer "Ian Morrison and David Anderson"
-	rom ( name "galactictrooper.p" size 4269 crc ae87f0a7 md5 74661343c5098f10bf44fdf40dc02f04 sha1 e6ba889b1f3d97366cc829d07e9d13fd665d40f5 )
-	rom ( name "GalacticTrooper.tzx" size 4517 crc 95146c5f md5 86cd07956e3d37c94d5cc19c7753f152 sha1 ee48ee10e53adbbbfe6d62c8b4fbadea8bc1eb16 )
-)
-game (
-	name "Galaxians (Artic)"
-	description "Galaxians (Artic)"
-	manufacturer "Artic"
-	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
-	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
-)
-game (
-	name "Galaxians (Monochrome) (Artic)"
-	description "Galaxians (Monochrome) (Artic)"
-	manufacturer "Artic"
-	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
-	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
-)
-game (
-	name "Galaxy Invaders (International Publishing and Software Inc.)"
-	description "Galaxy Invaders (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "galaxyinvaders(ips).p" size 4002 crc 4328beba md5 fb94065d6c8b3a4aa2f12a7d015e569d sha1 1bb9b928230de4ab517bf8b248a687c94c3df639 )
-	rom ( name "GalaxyInvaders(IPS).tzx" size 4224 crc 6df4e24b md5 490e79f413dcb97060633218e014a62f sha1 23fc85b7e2ecfacd664dc991acf7e56393a345a1 )
-)
-game (
-	name "Galaxy Jailbreak (Romik Software)"
-	description "Galaxy Jailbreak (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "galaxyjailbreak.p" size 5413 crc ae762991 md5 6493ac3cd7c77be6027bc00c3932c68c sha1 aeb080263f016d94bf0a13ff521bbc30d7032686 )
-	rom ( name "GalaxyJailbreak.tzx" size 5661 crc 8f630ce4 md5 f1ceb2d7e0cee7cb924a0b824dbf418b sha1 351dce4ff4d8d3dcc68508b39bb910b21cecfb84 )
-)
-game (
-	name "Galaxy Warrior/Star Trek (Artic)"
-	description "Galaxy Warrior/Star Trek (Artic)"
-	manufacturer "Artic"
-	rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1bcb3a5f md5 fff5135ca3ac8c8553e9eace62d55667 sha1 abfb5609bfa713c2f4841bc45ba11eb7363b6bf7 )
-)
-game (
-	name "Games Pack (JRS Software)"
-	description "Games Pack (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "GamesPack.tzx" size 20187 crc 4c92529e md5 893ed24f30dbba822dc001b87750b873 sha1 eb8aec55c92fc530591e033c862ce3b95c40a149 )
-)
-game (
-	name "General Statistics (W. H. Smith)"
-	description "General Statistics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "generalstatistics.p" size 14214 crc 10c6ef87 md5 a779367a54ad8ac03543a2d70c2e88e1 sha1 f65e699472236439c262640299628cb01284223e )
-	rom ( name "GeneralStatistics.tzx" size 14466 crc 8889d5e3 md5 acf9669f43af8b165cda56888e9a1348 sha1 a1f94c7ca3a27e24ebfaba575700cfccf8640356 )
-)
-game (
-	name "Geographics UK (Novus Software)"
-	description "Geographics UK (Novus Software)"
-	manufacturer "Novus"
-	rom ( name "geographicsuk.p" size 16037 crc fbc771bf md5 fea62f9b738c3f63cf9de62a37431588 sha1 fb07ebddca1f03eef2b4d06052d4abde520d4ae0 )
-	rom ( name "GeographicsUK.tzx" size 16281 crc 4af3cfc9 md5 4534b531e811c27a32effaa76a9a257e sha1 0d88e5bc5e71cc898a375156e40396b5b536d7a0 )
-)
-game (
-	name "Geometry 1 (Timex)"
-	description "Geometry 1 (Timex)"
-	year 1982
-	manufacturer "Home Computer Software"
-	rom ( name "Geometry1.tzx" size 5483 crc 80dad6c4 md5 d8c843396ea93e08a986ed3ec74a1b53 sha1 be9373f6519a369e7d2dba40a14319f4751b1b78 )
-)
-game (
-	name "Ghost Hunt (PSS)"
-	description "Ghost Hunt (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "ghosthunt.p" size 5302 crc dea898bd md5 dc3e16535dcf3395085a311decc1d8e5 sha1 da84c5b1e1e7cb26ebdbaa119a4e0f29f9e4ef4f )
-	rom ( name "GhostHunt.tzx" size 5538 crc 8e8d76f5 md5 c3b97b5345ea55bdc8c6307ee40f21b2 sha1 33ac921be892a02c115f7dfa73c54cafe178671b )
-)
-game (
-	name "Gobbleman (Colour Inlay) (Artic)"
-	description "Gobbleman (Colour Inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
-)
-game (
-	name "Gobbleman (Monochrome Inlay) (Artic)"
-	description "Gobbleman (Monochrome Inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
-)
-game (
-	name "Gobblers (Software Farm)"
-	description "Gobblers (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "gobblers.p" size 7162 crc b7687e93 md5 cb4cfa5b341c3d129405a82d97bc84bf sha1 fc15194e2cd43c8ed2121bc76331313532bd49da )
-	rom ( name "Gobblers.tzx" size 7394 crc dafe76e1 md5 8de20a364ca8693eb9c755a7da120189 sha1 681bd965a868d25b3ded5c9111c6f6a622a7df1e )
-)
-game (
-	name "Gold (Hilderbay)"
-	description "Gold (Hilderbay)"
-	year 1981
-	manufacturer "Hilderbay"
-	rom ( name "Gold.tzx" size 23791 crc a280fcba md5 6824a18251adf4cae7ca49ea6f04d865 sha1 33c0acac2f430cc9884739426e287098d646bd92 )
-)
-game (
-	name "Golf (R & R Software)"
-	description "Golf (R & R Software)"
-	year 1982
-	manufacturer "R & R Software"
-	rom ( name "golf.p" size 9244 crc bdc6ff4e md5 761909f603ceaa4fb32bdfc288fbb19e sha1 0add3b45b1a4a246ddb24ce1d3eea288032f8d99 )
-	rom ( name "Golf.tzx" size 9468 crc 1b658fab md5 01ade7a91bd9f70953004cb25d9e1d88 sha1 3177bea82297a86a2c5c541cde8426fff95cc052 )
-)
-game (
-	name "Graphics Kit (Softsync)"
-	description "Graphics Kit (Softsync)"
-	year 1981
-	manufacturer "Paul Holmes"
-	rom ( name "GraphicsKit.tzx" size 6203 crc 0e978f07 md5 53ac6583ca184c362108642e40f086cd sha1 2e26b56a9895655424d29d23d2836c28b0a26226 )
-)
-game (
-	name "Great Britain Ltd (Simon W. Hessel)"
-	description "Great Britain Ltd (Simon W. Hessel)"
-	manufacturer "Simon W. Hessel"
-	rom ( name "greatbritainltd.p" size 15541 crc 23ad347c md5 e4b1812bd16ea7cfdd416e932467e4d4 sha1 8eafc58c5610b3901b85478da04d25156f00bff1 )
-	rom ( name "GreatBritainLtd.tzx" size 15767 crc 4b717923 md5 07bff59ab86d31689cf4450d21f3741d sha1 bbde7b36f9f2cb65cd0ef2f112c52ce612a19433 )
-)
-game (
-	name "Grimm's Fairy Trails (Timex)"
-	description "Grimm's Fairy Trails (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "grimmsfairytrails.p" size 9331 crc ad7e74e0 md5 bdea9f593d45946fa07521844b0dd51e sha1 ee1b726655bfd5e897da2af3888f3c8545d85b99 )
-	rom ( name "GrimmsFairyTrails.tzx" size 9563 crc 55fe8f96 md5 2ed795d94caa50cd02cf68475e01aef5 sha1 cb65770be85add8b3aa5e01cecacc3b2b2835ecb )
-)
-game (
-	name "Guitar For Beginners (Timex)"
-	description "Guitar For Beginners (Timex)"
-	year 1982
-	manufacturer "Tim Rossetti"
-	rom ( name "guitarforbeginners.p" size 11018 crc 73af3c6d md5 fb35abb3bce84cd543e1bb9d46f65c82 sha1 97adfd80a6abb57717469a3fdaf17f7a160793f2 )
-	rom ( name "GuitarForBeginners.tzx" size 11246 crc 10734bfb md5 69edfc6fcf6f8b26d2907aa32e3c5669 sha1 975deca435c26ed3e0604497454129186e139307 )
-)
-game (
-	name "Gulp 2 (Campbell Systems)"
-	description "Gulp 2 (Campbell Systems)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "gulp2.p" size 6116 crc 1bfd713d md5 c7db6f6ed8cba0f14aa92df6d55f93a7 sha1 2399dff41d799578005ad8b23cc5086e120971e0 )
-	rom ( name "Gulp2.tzx" size 6342 crc b041f1bf md5 7c1be7d5a5b5d0f65dafdd2a0f252a2d sha1 aa0fadd80146c2dab98dab49c88f52ba4852c861 )
-)
-game (
-	name "Gulp (Mindware)"
-	description "Gulp (Mindware)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "Gulp(Mindware).1.Gulp.tzx" size 1125 crc c651f1e5 md5 e342f3fcc020d8afd4bf4a496ca75f75 sha1 c91c14f5ec001c991ed3c67673fe38c8b7b9d02d )
-	rom ( name "gulp.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
-)
-game (
-	name "Gulpman (Micromega)"
-	description "Gulpman (Micromega)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "gulpman.p" size 6121 crc 74a38569 md5 3ef8b687b566f338a2c672133e638379 sha1 9551cfdf7d738e0db679f08b35b72724d2f5a7a2 )
-	rom ( name "Gulpman.tzx" size 6351 crc 7baebe9a md5 e47f73d6aadf86310e6379a22a7d6b7a sha1 d28c22863672b87a1f0f6b23f2262b0195b3e1fb )
-)
-game (
-	name "Haute Resolution (Pluto)"
-	description "Haute Resolution (Pluto)"
-	year 1984
-	manufacturer "CRL"
-	rom ( name "HauteResolution.tzx" size 6970 crc f52d460f md5 42186664d3f698c0ede72a2b0c2ab398 sha1 91cd6738fcec38d4fc9d3e3ba08614634935918a )
-)
-game (
-	name "Heating System Analyzer (Timex)"
-	description "Heating System Analyzer (Timex)"
-	year 1982
-	manufacturer "Tim Rossetti"
-	rom ( name "heatingsystemanalyzer.p" size 15494 crc 17d05fc2 md5 8b2aceadfbb20f65c305cdeaea598262 sha1 087d0e4680643e6d9e808cce10c918e58d3c72ab )
-	rom ( name "HeatingSystemAnalyzer.tzx" size 15718 crc ea836c43 md5 29fa5b64d2c89de8a19c0f678c6b2c94 sha1 9d5e5a4f1e26f6a5dba03028940310bb796da199 )
-)
-game (
-	name "High Res (Macronics)"
-	description "High Res (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "highres.p" size 10763 crc e37bad7f md5 493817d98b6d96356df1e1c3f93866e9 sha1 d817b3db8f0065843e3b3d7eb4e55b673c08de03 )
-	rom ( name "HighRes.tzx" size 10985 crc fa40dbc1 md5 f48465678582d4fd7bd8325ddede7788 sha1 9b81b10a719af4c6c61a03ed003f1198f68bda1b )
-)
-game (
-	name "Hopper (PSS)"
-	description "Hopper (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "hopper.p" size 10833 crc 965d961a md5 f76d900361978e5a354569718c918783 sha1 9e5b1e824f492a88999c023646486a9620e1c89f )
-	rom ( name "Hopper.tzx" size 11061 crc f5601550 md5 30ed7cc222c8a94447629233bb357832 sha1 4102dbfe6c3cddb82877bb9b089f764420f0a249 )
-)
-game (
-	name "Hopper (Truck) (PSS)"
-	description "Hopper (Truck) (PSS)"
-	year 1981
-	manufacturer "PSS"
-	rom ( name "hopper(truck).p" size 10833 crc 343ec159 md5 e49392779795505c5e776a86bb27de9b sha1 347965bc2ab0003c295c1005e89cde7053dd7040 )
-	rom ( name "Hopper(Truck).tzx" size 11061 crc 57034213 md5 ecc9da3396ba5f0eee543e3915a3ab8d sha1 5747373be057f05059c47d8acb42f2c9312eeb83 )
-)
-game (
-	name "House of Death (A. J. Rushton)"
-	description "House of Death (A. J. Rushton)"
-	manufacturer "A. J. Rushton"
-	rom ( name "houseofdeath.p" size 15045 crc d88c206a md5 89e832d5035229bcfe30a9d77a0242a9 sha1 962346b1f5e5d9f8c025994824736ac497be1ea2 )
-	rom ( name "HouseOfDeath.tzx" size 15289 crc e78272e3 md5 68fb7bfd61e73901337800b912db3760 sha1 80ee47dd77a43c051c600a38def525950a110119 )
-)
-game (
-	name "HRG 7.0 (Unknown)"
-	description "HRG 7.0 (Unknown)"
-	year 1983
-	manufacturer "J. M. Cohen"
-	rom ( name "HRG70.tzx" size 19444 crc 75adee54 md5 eec31c8470c05281f4e8c957e56889d3 sha1 9f062ea8b3bd11a868a773dd4fed573a51225a1e )
-)
+
 game (
 	name "Impact!"
 	description "Impact! (2012) - Bob's interpretation of Atari's 1979 arcade game 'Asteroids'."
 	rom ( name "Impact.p" size 16154 crc d6e106b8 md5 b6ad9cb0b2dc0153eb080a9ce87c797c sha1 11c5fe8d44763d94a3eedf597b6daf0438364e22 )
+	manufacturer "Bob Smith"
+	year "2012"
 )
-game (
-	name "Introduction To Chemistry (Timex)"
-	description "Introduction To Chemistry (Timex)"
-	year 1983
-	manufacturer "J. J. Hollandsworth"
-	rom ( name "IntroductionToChemistry.tzx" size 37232 crc 7b7d1b69 md5 f7c95b6d075d662664527efc3fc842d0 sha1 4a49f3c842e387dd1353dc859877b93c92aa8ace )
-)
-game (
-	name "Invaders (A. G. Software)"
-	description "Invaders (A. G. Software)"
-	manufacturer "Andrew Glaister"
-	rom ( name "invaders(ags).p" size 2117 crc 134835d7 md5 b2cb96deb94f2caf1167c6aa9eed3c35 sha1 125d09e68f9ad9490b47adee512bf46db7286c2a )
-	rom ( name "Invaders(AGS).tzx" size 2349 crc 58299c24 md5 6a329b8b6bdca462dc2564297fb425f2 sha1 37503b2c552016a3265ff387afca6ffa6380c5e8 )
-)
-game (
-	name "Invaders (Bug Byte)"
-	description "Invaders (Bug Byte)"
-	year 1982
-	manufacturer "S. Munnery"
-	rom ( name "invaders.p" size 2373 crc 3b79c6ac md5 e3cd419e7f34dbfc4efd9b4c8e0a7633 sha1 8683fd832959844fb6357fd272dcde5ece0a601d )
-	rom ( name "Invaders.tzx" size 2605 crc 93d1d5d7 md5 1d391665fb5734a2b274e2c9630d35f7 sha1 bb79a0ea9ff54e882d45a7ca94dc71762488b2cd )
-)
-game (
-	name "Invaders (Forward Software)"
-	description "Invaders (Forward Software)"
-	manufacturer "Silversoft"
-	rom ( name "invaders(forward).p" size 3465 crc 7005eda5 md5 0e940cd5d0fab16b860c1e5648ea7b8a sha1 425223961fdb8c2825796b99bbc5358e51bf9b14 )
-	rom ( name "Invaders(Forward).tzx" size 3697 crc 3ea98bb5 md5 b52fecd042da1349d326508f77d3db33 sha1 a8ae592fe3b4b939b664be00454fb591b004f478 )
-)
-game (
-	name "Invaders (Monochrome) (Bug Byte)"
-	description "Invaders (Monochrome) (Bug Byte)"
-	manufacturer "S. Munnery"
-	rom ( name "invaders(mono).p" size 2373 crc 2840348b md5 1b95516181a57da16f56109cc87cfd94 sha1 1971694d7a009402c065f5d23cec3ad847839232 )
-	rom ( name "Invaders(Mono).tzx" size 2605 crc 80e827f0 md5 186d39211398bdbb5497d1ba89df5ab9 sha1 3aeb0fa4a5c458ace0affc01f528d4b15ee047b8 )
-)
-game (
-	name "Invaders (Re-release) (Bug Byte)"
-	description "Invaders (Re-release) (Bug Byte)"
-	year 1982
-	manufacturer "S. Munnery"
-	rom ( name "invaders(alt).p" size 2373 crc 4a1b632b md5 119058dbc93bb2ac6a7e804a878f03cc sha1 6beb1369d7f96b83092cd84c0e32fe2ad786c2ac )
-	rom ( name "Invaders(Alt).tzx" size 2605 crc e2b37050 md5 8886052187ad052bd05d2cb8e6d2a713 sha1 c5a9f1683d2730eaf40a879c0f5c676b5f718e03 )
-)
-game (
-	name "Invaders (Typed Inlay) (Bug Byte)"
-	description "Invaders (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "S. Munnery"
-	rom ( name "invaders(typed).p" size 2373 crc eeefd34b md5 f426df7408433e814f04cf3909a5a2f5 sha1 5ff6048270fdd16665eb1b1169f2f026c84a3b24 )
-	rom ( name "Invaders(Typed).tzx" size 2605 crc 4647c030 md5 c6dbced1c948e5322109052583789338 sha1 a3669f5ce7897e144314b0a4ea5e3e1b79cff5ef )
-)
-game (
-	name "Invasion Force (Artic)"
-	description "Invasion Force (Artic)"
-	year 1982
-	manufacturer "Simon Wadsworth"
-	rom ( name "invasionforce.p" size 7658 crc a997ef38 md5 111b625cefae5439236a45013066a7ae sha1 6a3516b9127e8345a56c076990a9ffb7bf5834e7 )
-	rom ( name "InvasionForce.tzx" size 7890 crc 84b20542 md5 c38ec3f7baba880dcb937e9419956a22 sha1 3bf53649fdf8249fdb8a601bb7ae7dbbb38b08de )
-)
-game (
-	name "Invasion Force (International Publishing and Software Inc.)"
-	description "Invasion Force (International Publishing and Software Inc.)"
-	year 1983
-	manufacturer "Simon Wadsworth"
-	rom ( name "invasionforce(ips).p" size 7658 crc eaa1c1ed md5 c38f1c2548052873d8fbff20f67a29dd sha1 39ebceafc98f2a8a7b2b4eb5cb35b4e2a4b34adf )
-	rom ( name "InvasionForce(IPS).tzx" size 7890 crc c7842b97 md5 4c05ebb64d88d13ec859403f5c7f2b1e sha1 3b59f5a004f92d081181834aa59073ba74b47909 )
-)
-game (
-	name "Inventory Control (Data-assette)"
-	description "Inventory Control (Data-assette)"
-	manufacturer "John Powers"
-	rom ( name "inventorycontrol(da).p" size 15941 crc eb911b8b md5 2e9c7b2134665a0fa235764e75cc2957 sha1 4f63db3c39ff4aabb3e0661500095f0c69dab41d )
-	rom ( name "InventoryControl(DA).tzx" size 16175 crc 21d56ec5 md5 bfadca8523ed9926c47c20b04e980289 sha1 390707e52e816a1df284b65ce1fd52e14110a504 )
-)
-game (
-	name "J.D.Arcades (Computer Rentals)"
-	description "J.D.Arcades (Computer Rentals)"
-	year 1982
-	manufacturer "John Davies"
-	rom ( name "jdarcades.p" size 8548 crc e7ea958d md5 e555ef74ec2f6346b82b363c24d97c96 sha1 7d47ec7d6670d7009cf6d059fe50c730e068d891 )
-	rom ( name "JDArcades.tzx" size 8782 crc 6fb5f451 md5 e4ab3d1820711eb5b96dcd106694aa1d sha1 08c17dc95d0a7e8a68fb9b534398d45656e25ea5 )
-)
-game (
-	name "Kasino Kraps (Timex)"
-	description "Kasino Kraps (Timex)"
-	year 1983
-	manufacturer "Gerald Bennett"
-	rom ( name "kasinokraps.p" size 12557 crc f041256f md5 dedab418c1ee0b2e03200acf878164f3 sha1 c782994290da3a40a82433718fb877a59fcd771b )
-	rom ( name "KasinoKraps.tzx" size 12777 crc 7e27ad21 md5 32a434e44b75cfeedf737a25e4d22ae0 sha1 39950e34a01e852c6df5fb06e59dfae019d54e90 )
-)
-game (
-	name "Keyboard Calculator (Timex)"
-	description "Keyboard Calculator (Timex)"
-	year 1982
-	manufacturer "J. Gishen"
-	rom ( name "KeyboardCalculator.tzx" size 6160 crc 56b36255 md5 781d98f620db9510336788eb8ff310ea sha1 064abd828a4d801e1e2029234762f6aadcba008e )
-)
-game (
-	name "Keys To Gondrun (International Publishing and Software Inc.)"
-	description "Keys To Gondrun (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "keystogondrun.p" size 15704 crc f8340d3b md5 aaca5c9eb8ae112eb41d7a3b99e93a6b sha1 639d2eb5931fd7b874d0ca9b1374bce68971ded6 )
-	rom ( name "KeysToGondrun.tzx" size 15928 crc 97e9ac6d md5 9d45dcb3c159ffb5396641c88e7e5196 sha1 38c82913732383ae4fae62dd1be8f5a04927cdfd )
-)
-game (
-	name "Kingdom of Nam (Microgame Simulations)"
-	description "Kingdom of Nam (Microgame Simulations)"
-	year 1981
-	manufacturer "R. Erskine"
-	rom ( name "kingdomofnam.p" size 7958 crc a997242d md5 eccad4f7e6ca9806b1d2976970ee39fd sha1 718235cfddafacfdf7276438614712042488ecf5 )
-	rom ( name "KingdomOfNam.tzx" size 8202 crc ca57c0c9 md5 5d075c2ea9428e0c2d3b09597056d810 sha1 d5c07352365144b1f0c9eb4c89a3f854747b7a90 )
-)
-game (
-	name "Kongs Revenge (Stephen Hartley Computing)"
-	description "Kongs Revenge (Stephen Hartley Computing)"
-	year 1984
-	manufacturer "I. Kendrick"
-	rom ( name "kongsrevenge.p" size 14601 crc daf31c48 md5 a88f23545d67709d83d214efc9344173 sha1 6915c841a5af606e7e0a0198efec07aed4c8cb91 )
-	rom ( name "KongsRevenge.tzx" size 14843 crc cc315aca md5 c82fd9679ee58446a0c54271e2f56287 sha1 c87d1a7f00cca913b0d9bdbe8a8752e82c72fd6c )
-)
-game (
-	name "Krazy Kong (Intercomputer Inc)"
-	description "Krazy Kong (Intercomputer Inc)"
-	year 1983
-	manufacturer "C. P. Cullen"
-	rom ( name "krazykong(inter).p" size 7563 crc ad4fe8ff md5 c1aaf449bdc105ee2ccd74de7ba82ec5 sha1 554d1d5b991c9a221183dd6f6067e41c77746d7b )
-	rom ( name "KrazyKong(Inter).tzx" size 7799 crc d5a3ddd8 md5 b355c229f453610568ab040ea9cebb5e sha1 1e4edf41f7a576a8b68ecfaab4f936ba80460360 )
-)
-game (
-	name "Krazy Kong (PSS)"
-	description "Krazy Kong (PSS)"
-	year 1982
-	manufacturer "C. P. Cullen"
-	rom ( name "krazykong.p" size 8229 crc e5e30579 md5 fea1dd4edf42f770255b5d90d6da9cff sha1 0bbee2723aaa7a2758b5394d2ad269ffc561ede8 )
-	rom ( name "KrazyKong.tzx" size 8465 crc a5dd2afe md5 4df17878870a7bc5b63fa607c8eb4c36 sha1 ac74298badc343b3c81a96fca8bcab1b43faad87 )
-)
-game (
-	name "Labyrinth (Axis)"
-	description "Labyrinth (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
-	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
-)
-game (
-	name "Labyrinth (Colour Inlay) (Axis)"
-	description "Labyrinth (Colour Inlay) (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
-	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
-)
-game (
-	name "Language Usage (Timex)"
-	description "Language Usage (Timex)"
-	year 1982
-	manufacturer "Software for Excellence"
-	rom ( name "LanguageUsage.tzx" size 43685 crc f83ba0cd md5 81f643d82c2f273248421f15f4e8f91b sha1 8892aac163feb54128ee568636c905c0cb18e7e5 )
-)
-game (
-	name "Lap Record (Macronics)"
-	description "Lap Record (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "laprecord.p" size 4895 crc 13522b1e md5 4e017f1d09e8cd51b3b3656b5c1efdfa sha1 5091eaf17d8816a7766811f0d57ea54611825670 )
-	rom ( name "LapRecord.tzx" size 5115 crc 4ab33041 md5 075644fa16a629b4b732265c9129998c sha1 28d2a56bc5974bed6e848a495367140893f35eb1 )
-)
-game (
-	name "Lost Island (JRS Software)"
-	description "Lost Island (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "lostisland.p" size 15542 crc c93d1958 md5 f1783d3018e369fe915e919646ab845c sha1 56310e5ea2f0dc1e77c95717e7b5e988c9c0fff9 )
-	rom ( name "LostIsland.tzx" size 15766 crc b0682ddb md5 28ac9145502b4144b038821d63b419e4 sha1 b1bed07dd568166c87352c1700c8e3fb81a43a7b )
-)
-game (
-	name "Lunar Rescue (Mikro-Gen)"
-	description "Lunar Rescue (Mikro-Gen)"
-	manufacturer "K. J. Bezant"
-	rom ( name "lunarrescue.p" size 4657 crc 0ec491ce md5 62d3cd05d6ea6103cb47824c7316135f sha1 810fe42934480bc6967d058f91586cc558bf4bc5 )
-	rom ( name "LunarRescue.tzx" size 4885 crc b63d952a md5 9d99d03e0da02ab1601a4dbe89446bab sha1 620f51472b3313aa14bee80521e5654c05b4c5b6 )
-)
-game (
-	name "Machine Code Test Tool (F. O. Ainley)"
-	description "Machine Code Test Tool (F. O. Ainley)"
-	year 1982
-	manufacturer "F. O. Ainley"
-	rom ( name "machinecodetesttool.p" size 2823 crc 778f13a8 md5 440b350563fa9dd8ac48b7a3d01a27bd sha1 5063e60e26a804e8cb2f210349d9ccef375f3c2e )
-	rom ( name "MachineCodeTestTool.tzx" size 3047 crc e7fc10fc md5 fb5cd1e9564af7fcbda7227b19104342 sha1 9108f1176687353a4b9e0a0eff750478a863d5c2 )
-)
-game (
-	name "Manufacturing Control (Timex)"
-	description "Manufacturing Control (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "manufacturingcontrol.p" size 14780 crc 10e493b2 md5 84384096921e088b18cc9e3eedb3b143 sha1 c603b553fc42d949fed9139cb58d0bde4f3c3d3e )
-	rom ( name "ManufacturingControl.tzx" size 15008 crc fec50d8e md5 38bcf567460a33edb8ff13034834100f sha1 694cfa2652b6134621f5b6a2a189af5b8f1e853b )
-)
-game (
-	name "Marine Rescue (International Publishing and Software Inc.)"
-	description "Marine Rescue (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing & Software Inc."
-	rom ( name "marinerescue.p" size 10829 crc d91c71e8 md5 bf106cf05b1e4d7318df3f7c1a7c125c sha1 39af94024ccbbe9262bbf98b8841cb00d258c418 )
-	rom ( name "MarineRescue.tzx" size 11057 crc 60217181 md5 ca6ce91a6aea06ac28859c418daac227 sha1 c0fe4882d84b9fc7503004128975115b5cc355f2 )
-)
-game (
-	name "Math Routines and Fit (Zeta Software)"
-	description "Math Routines and Fit (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "mathroutinesandfit.p" size 15850 crc ef830293 md5 205efa1a71ba01038cd3bc523f1a9667 sha1 c1a6b8f1c9798fb57faea5ee52dc1bcacee68b1b )
-	rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896de80 md5 ee3e759e69b64248f0e5bd1846d63a76 sha1 aa81c6329174cb096d5690cf4d6456b0e0dbdccc )
-)
-game (
-	name "Maths Invaders (Programs in Education)"
-	description "Maths Invaders (Programs in Education)"
-	rom ( name "mathsinvaders.p" size 7786 crc 27b974ec md5 0e79e0ceebc05771120adc45bebb8fb9 sha1 348d5786fd8b153ea7ef26e7eb0af63a273a9d18 )
-	rom ( name "MathsInvaders.tzx" size 8030 crc 19057596 md5 479d85ee6074fb7e7eccedb399dbc1f2 sha1 4e6e0fc96692a767de539ec97df4b06b30c5af70 )
-)
-game (
-	name "Mazogs (Bug Byte)"
-	description "Mazogs (Bug Byte)"
-	year 1982
-	manufacturer "Don Priestley"
-	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
-	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
-)
-game (
-	name "Mazogs (Gladstone) (Gladstone Electronics)"
-	description "Mazogs (Gladstone) (Gladstone Electronics)"
-	manufacturer "Don Priestley"
-	rom ( name "mazogs(ge).p" size 12942 crc bdab60b2 md5 d8bbd02ade6ac94438547f255c04517b sha1 14ca73f2ae0d621ba17fbc5e0f0e8d9184184347 )
-	rom ( name "Mazogs(GE).tzx" size 13170 crc 5d7dd442 md5 cb162114851f80e1a4a820d4e7e4cc22 sha1 94e2da0938bd44f9c0392e2061e390e69d49d47b )
-)
-game (
-	name "Mazogs (Monochrome) (Bug Byte)"
-	description "Mazogs (Monochrome) (Bug Byte)"
-	year 1981
-	manufacturer "Don Priestley"
-	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
-	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
-)
-game (
-	name "Mazogs (Softsync)"
-	description "Mazogs (Softsync)"
-	year 1982
-	manufacturer "Don Priestley"
-	rom ( name "mazogs(softsync).p" size 12831 crc 60b3c966 md5 acd2a6c8f4340c6f2553449225123cd8 sha1 a8e8494bee216f4054cdb2f34735177108305de8 )
-	rom ( name "Mazogs(Softsync).tzx" size 13059 crc 2c73fa3b md5 c89acd6ec795ffeef1d658836bb0dde3 sha1 56e5e86334cb633863fc2386ffda515ad8c58ea9 )
-)
-game (
-	name "MCoder 11 (PSS)"
-	description "MCoder 11 (PSS)"
-	year 1983
-	manufacturer "PSS"
-	rom ( name "mcoder11.p" size 5713 crc 44b1bbe5 md5 7b5d8eaaaed4ba91ff36b3308126976f sha1 cd400d506c292dfd1946264d8d5518feceb8e0ba )
-	rom ( name "MCoder11.tzx" size 5941 crc 4c0ee232 md5 4e67fb609fa6b32e7b84c3c9713e468f sha1 e4d21864bfbba4e7584fb8d4817494eddebeba52 )
-)
-game (
-	name "MCoder (PSS)"
-	description "MCoder (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "mcoder.p" size 3558 crc 7297a09d md5 712640382c22590907acdf151c7c35f3 sha1 48e7bcfb62552fd617af3c4b903b3f52f759db3b )
-	rom ( name "MCoder.tzx" size 3786 crc 3aef6340 md5 3e6a131a6ff49dff552f0e8518686726 sha1 74d2103372c2d6e5d627c9deddba2ed948606c77 )
-)
-game (
-	name "Merchant of Venus (Crystal)"
-	description "Merchant of Venus (Crystal)"
-	year 1983
-	manufacturer "Crystal"
-	rom ( name "merchantofvenus.p" size 16161 crc 51cf1515 md5 f607c834c5f1405f7ff0f0e99af1e934 sha1 4be29a8df43bb849740910a055a8773e4d35a2fd )
-	rom ( name "MerchantOfVenus.tzx" size 16393 crc 5e4a029e md5 76409f6a8710a0231ffc4562a5217465 sha1 95f7628f548dcbfeb169fe3f12baa23e720b6f8c )
-)
-game (
-	name "Meteor Storm (dK'tronics)"
-	description "Meteor Storm (dK'tronics)"
-	year 1982
-	manufacturer "dK'tronics"
-	rom ( name "meteorstorm.p" size 5747 crc 8aed8ff8 md5 16a19477d2b25332dfd44117da71fa78 sha1 1c737a14c4bae0d2af32f28ed9dd2baa4d1dd792 )
-)
-game (
-	name "Meteor Storm (Fast Master) (dK'tronics)"
-	description "Meteor Storm (Fast Master) (dK'tronics)"
-	year 1982
-	manufacturer "dK'tronics"
-	rom ( name "meteorstorm(fastmaster).p" size 5784 crc 83ae249c md5 0bbaafb1a7802dbbbbb03eb1852330e7 sha1 736654e354223e719629101bb94fdaf8a847220c )
-	rom ( name "MeteorStorm(FastMaster).tzx" size 6024 crc 35c2540e md5 4066b1dcfb69b1f9205ed0cb6b6bf35c sha1 e02a6983c28a40ccc70a3fa3edd1dc6dbf176354 )
-)
-game (
-	name "Micro Mouse goes de-bugging (Lothlorien)"
-	description "Micro Mouse goes de-bugging (Lothlorien)"
-	year 1983
-	manufacturer "M. C. Lothlorien"
-	rom ( name "micromouse.p" size 8487 crc 17365457 md5 d0603604ed0847e629eea1ec9e701457 sha1 c4510c08365bb8e873315f98fbbbbc067ec06612 )
-	rom ( name "MicroMouse.tzx" size 8713 crc db8110b5 md5 052bc1c42964e438a69feab1759a255c sha1 012a444ac366224d63daf2bc242ca30b58a0e33a )
-)
-game (
-	name "Mind vs. Machine (2-Bit Software)"
-	description "Mind vs. Machine (2-Bit Software)"
-	year 1982
-	manufacturer "2-Bit Software"
-	rom ( name "MindvsMachine.B.tzx" size 3168 crc c7ac234d md5 bb2ef658c6ffe1da45c34e32dd7a5161 sha1 5bf1942b1696ad670427a5119bac1cbddcac30f0 )
-)
+
 game (
 	name "Miner Man"
 	description "Miner Man (2011) - 'Play through 60 levels of puzzles, mazes and traps. Each level will present the player with different amount of gems to collect. To collect the gems the player will have to work through the levels avoiding the traps and solving the puzzles.' (taken from the original game)"
 	rom ( name "MinerMan.p" size 15851 crc f84e2f0d md5 692985da7943b89cad06f4571b9a7b2f sha1 54db0c5305f89a629a19e5e107f34e65d2bfbd93 )
+	manufacturer "Bob Smith"
+	year "2011"
 )
-game (
-	name "Mixed Game Bag III (Timex)"
-	description "Mixed Game Bag III (Timex)"
-	year 1982
-	manufacturer "M. Orwin"
-	rom ( name "MixedGameBagIII.tzx" size 6939 crc 9115c144 md5 1aa50b1328afe02ce01d69fcee6ee746 sha1 9ad8a4c6321346b904995ac8e9aee31124eb5868 )
-)
-game (
-	name "Money Analyzer 1 (Timex)"
-	description "Money Analyzer 1 (Timex)"
-	year 1982
-	manufacturer "T. J. Software"
-	rom ( name "MoneyAnalyzer1.tzx" size 2508 crc 8b0ecf6c md5 38b90377d5298596fd2d123f2e1bd9c2 sha1 5a223f431b06f01ccd7e30c31d462422409a3c69 )
-)
-game (
-	name "Moniteur Desassembleur (Direco International)"
-	description "Moniteur Desassembleur (Direco International)"
-	year 1982
-	rom ( name "moniteurdesassembleur.p" size 5593 crc 357448ff md5 5635d4860a5b03b9312ea12a87383631 sha1 6b32ff9ce4f9dab7e9e43df50c9dd8264d9cf5b9 )
-	rom ( name "MoniteurDesassembleur.tzx" size 5825 crc e548a0e6 md5 4b422022a5ed280d6bd1f6f74f7b56c5 sha1 f3433d201596f069dff1053a86fc2f293b8e4612 )
-)
-game (
-	name "Monster Mine (Gem Software)"
-	description "Monster Mine (Gem Software)"
-	year 1982
-	manufacturer "Gem Software"
-	rom ( name "monstermine.p" size 10808 crc c0b1f76e md5 951905cd41aa8a43d7cece736a99099e sha1 f5063aff551446d25a9cbd3d7080e5d505d1f66a )
-	rom ( name "MonsterMine.tzx" size 11048 crc ac4bec18 md5 bba503301be95ea4fe4f9e3c45e867c1 sha1 bcbf2d46f2c8b547600f979882968d4a57c5b524 )
-)
-game (
-	name "Morse Reader (JEP Electronics)"
-	description "Morse Reader (JEP Electronics)"
-	manufacturer "JEP Electronics"
-	rom ( name "morsereader.p" size 8827 crc 059ee1f6 md5 fffbf7d1aac3e3bf21f8895a5ea53194 sha1 51ce900cec1c55f91037989da1610dd6b73cbae6 )
-	rom ( name "MorseReader.tzx" size 9055 crc 9fce1af5 md5 f01f1d0b641939493ed663d9703baa5b sha1 debe28ec7e350d9b6431dc6fca6da97513232f02 )
-)
-game (
-	name "Mothership (Sinclair Research)"
-	description "Mothership (Sinclair Research)"
-	year 1982
-	manufacturer "Alan Laity, Softsync"
-	rom ( name "mothership.p" size 9627 crc 7de56c4b md5 33404fcdbd84277061d678ebe4d6dbe3 sha1 55cd6d320281c29978170e22a8286803f0c72049 )
-	rom ( name "Mothership.tzx" size 9863 crc 526e7fa1 md5 bd8246e4a145f366bc9bf23bb45913c1 sha1 05fd66ec3eb2c22df673f2bdaa238faab8ae5fc2 )
-)
-game (
-	name "Mothership (Softsync)"
-	description "Mothership (Softsync)"
-	year 1983
-	manufacturer "Alan Laity"
-	rom ( name "mothership(softsync).p" size 9627 crc 077d1fe8 md5 4b63a2614e5907b002264efea78a41e5 sha1 697ca1d242137e2207a98c70181d02a7895da64d )
-	rom ( name "Mothership(Softsync).tzx" size 9863 crc 28f60c02 md5 b065399ad89b9c5d000a60f7ac971154 sha1 63dec851b552ac48d167ce90deec768f0677d42f )
-)
-game (
-	name "Multifile (Gladstone) (Gladstone Electronics)"
-	description "Multifile (Gladstone) (Gladstone Electronics)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "multifile(ge).p" size 5549 crc d71bf8bc md5 e4806a5d67124ada1f733f0e681cf66b sha1 bab72e5aae3ae98d0d4da03cba691b9e61e32fe6 )
-	rom ( name "Multifile(GE).tzx" size 5783 crc 18343751 md5 b05754895c071d02f191e4d7d588bf59 sha1 d72de512a1adc62cf2de299c2e1ff64ed630316b )
-)
-game (
-	name "Multifile Plus (Gladstone Electronics)"
-	description "Multifile Plus (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "multifileplus(ge).p" size 7677 crc 6cb1f589 md5 dea427c0ddcdb0e27bdbfa199d903c8f sha1 e036fc55971244c9e2a3b157bd9f527b349dce17 )
-	rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952ff07 md5 80ff32332cb0bda770c476a519b0365a sha1 c2866c2c9430d5aec6ea4eb01d7f04c839b1b30c )
-)
-game (
-	name "Multigraphics 2.3 (Bridge Software)"
-	description "Multigraphics 2.3 (Bridge Software)"
-	year 1981
-	manufacturer "Bridge Software"
-	rom ( name "multigraphics.p" size 14210 crc f55b43e1 md5 7000c83bd3b8b8ee761dffc603b7b90c sha1 256d229a11058bed6f608553fc1d9d081397ae89 )
-	rom ( name "Multigraphics.tzx" size 14452 crc 14dd97d3 md5 3b70eaa4b9c771feed049f6c1e0b798b sha1 7b7bead37db83539393b9bab71c15ed048608d85 )
-)
-game (
-	name "Munchees (Quicksilva)"
-	description "Munchees (Quicksilva)"
-	year 1983
-	manufacturer "A. Laird"
-	rom ( name "munchees.p" size 7545 crc b9365fa1 md5 4d0347c0d394cdf1bbcb10d5553bb34b sha1 7c59c57a62eb0aa7750175020287b913e34aaa19 )
-	rom ( name "Munchees.tzx" size 7777 crc 4da90eed md5 b724025d7778e61dd088a66d0ba7b272 sha1 c64c8336f95030b957f3e6c3aed5be3a2237dbb1 )
-)
-game (
-	name "Muncher (Silversoft)"
-	description "Muncher (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "muncher.p" size 5200 crc cadff742 md5 dba0e8079ab8f60c47b31bdff986e49e sha1 f9fcbbd7d5aac8a8c22bf7e73b87eccb18aedc00 )
-	rom ( name "Muncher.tzx" size 5430 crc 7334ad2a md5 2e1104b8d2d21f6c359477cc66366358 sha1 2d7edcfd205dfbdfe253967fa8dd25711964b00c )
-)
-game (
-	name "Murgatroyds (Collins Computing)"
-	description "Murgatroyds (Collins Computing)"
-	year 1982
-	manufacturer "Collins Computing"
-	rom ( name "murgatroyds.p" size 7097 crc a0130eea md5 4b59af5f517ebeeaeb25db1a85883c5e sha1 6d309ccbe66964b30c9ed418ef8537efd07bc17e )
-	rom ( name "Murgatroyds.tzx" size 7315 crc d35af98d md5 40a6bb5e88b35f7309f76b55c808a7f2 sha1 e9b44dc8dce87e747c15c2bb24dc508f319ddc36 )
-)
-game (
-	name "Music Composer (Memotronic)"
-	description "Music Composer (Memotronic)"
-	manufacturer "Frank Beer and Wolfgang Labus"
-	rom ( name "musiccomposer.p" size 5578 crc b0dcdcca md5 76133648609d8ab9b7b24a418e9ae215 sha1 70a99a384559e1d70e38b2ec5a6dfcac3cfe6ec0 )
-	rom ( name "MusicComposer.tzx" size 5822 crc d0cc5789 md5 8ab416356fb8de668546530c4ab0a890 sha1 bbf95991604eb52b8211d709736cdcde9ac4dc3b )
-)
-game (
-	name "Music Educator 1 (Timex)"
-	description "Music Educator 1 (Timex)"
-	year 1983
-	manufacturer "Tim Rossetti"
-	rom ( name "musiceducator1.p" size 14146 crc b7c34c96 md5 702e4b03957ef8a387a76013d1f1e932 sha1 457b9a66701a0edc6cb5b1c91d84758b64c3a074 )
-	rom ( name "MusicEducator1.tzx" size 14372 crc db66a8dd md5 f1fd3cf9b70bb1e730c0c73c75bf8129 sha1 0ee598ab50535505e8382f93d6f77f158d1e43e4 )
-)
-game (
-	name "Namtir Raiders (Artic)"
-	description "Namtir Raiders (Artic)"
-	year 1982
-	manufacturer "J. Ritman"
-	rom ( name "namtirraiders.p" size 3740 crc 8ba3150e md5 28a7022c5386d46864fec0f0e9516a4f sha1 fb0367a015a4beb3cf6ee00853e84e430ceecc36 )
-	rom ( name "NamtirRaiders.tzx" size 3984 crc e65d10f3 md5 80d72c6b620d287e922279b2a5902e65 sha1 364dd09fac90173806cd1a643b594cb378156a55 )
-)
-game (
-	name "Night Gunner (Digital Integration)"
-	description "Night Gunner (Digital Integration)"
-	year 1982
-	manufacturer "Digital Integration"
-	rom ( name "nightgunner.p" size 5113 crc 8fc7c658 md5 f15a54c0f92cc903b91ce8ed37e7cb88 sha1 9ec875318fa4e35087e65a9cf3b9def0080f3705 )
-	rom ( name "NightGunner.tzx" size 5333 crc ba8bea96 md5 cb630368c6f87f40c3d461f988f005fa sha1 ecd2c009311a97f40eae7102faf426e8572b6f96 )
-)
-game (
-	name "Night Gunner (Softsync)"
-	description "Night Gunner (Softsync)"
-	year 1982
-	manufacturer "Digital Integration"
-	rom ( name "nightgunner(softsync).p" size 5113 crc 77639e65 md5 32cbaf62810ec52668bb663029e893a5 sha1 f3b4ea9743015a0cb2c612a79322663a0e36a25a )
-	rom ( name "NightGunner(Softsync).tzx" size 5333 crc 422fb2ab md5 5fb5e7061c2c292259d4244b2b9847c1 sha1 9bd903833515016e2e6215c068b630223fc0138a )
-)
-game (
-	name "Nightmare Park (Macronics)"
-	description "Nightmare Park (Macronics)"
-	year 1981
-	manufacturer "J. D. S. Cranston"
-	rom ( name "nightmarepark.p" size 11659 crc 28f39976 md5 ace96513fef192cd7197825120d9eb95 sha1 7b6344d8e2c62aa1dc1bebb64107dec51617b402 )
-	rom ( name "NightmarePark.tzx" size 11879 crc 53965b76 md5 42b898fee8207b3a73316056a7bf7eca sha1 86dbca70ae32e736a89c161c7e260e43576da971 )
-)
+
 game (
 	name "Noir Shapes"
 	description "Noir Shapes (2012) - Move the various shapes into a given space to complete each level, ensuring that none of the tiles overlap at any time. It may sound simple, but with limited room in which to arrange the tiles within things soon start to get claustrophobic..."
 	rom ( name "NoirShapes.p" size 15072 crc 20861b7a md5 b560973a9161f27e2929ce9a26a71fff sha1 5642ddd94d1c6649bc2e01ca112b7d76f376c826 )
+	manufacturer "Bob Smith"
+	year "2012"
 )
-game (
-	name "Octopussy (Peaksoft)"
-	description "Octopussy (Peaksoft)"
-	manufacturer "Peaksoft"
-	rom ( name "octopussy.p" size 6090 crc 62265923 md5 4c419dd9a3b3463d331e5c8c2f3d7e6b sha1 ca8c3a27854e51acb3abbb02c5ebb6ae40c628c0 )
-	rom ( name "Octopussy.tzx" size 6308 crc 9d408c0e md5 fa9f1e45071a0b907b6d8fdfc71f0430 sha1 745515410b88f840a33611b15c4e0a31e6b28611 )
-)
+
 game (
 	name "One Little Ghost"
 	description "One Little Ghost (2012) - Bob's interpretation of Namco's 1980 arcade game 'Pac-Man'."
 	rom ( name "OneLG.p" size 15884 crc c6b562c2 md5 3ed2b203e8ad7aefa659e11fa66fdc62 sha1 7bd65421239915dad4137206c0c7572f31c6ac5a )
+	manufacturer "Bob Smith"
+	year "2012"
 )
-game (
-	name "Othello (CDS Micro Systems)"
-	description "Othello (CDS Micro Systems)"
-	manufacturer "CDS Micro Systems"
-	rom ( name "othello.p" size 11655 crc 73457797 md5 ef70888041689cc60b9336201735f725 sha1 4dd7218297d9ef6cfb776decbd2f040a297e1c3e )
-	rom ( name "Othello.tzx" size 11885 crc 09d487fe md5 cfcb326e75dfa9a59a79e05491686dd6 sha1 47c8980d14972b59fab5098667b170169894515d )
-)
-game (
-	name "Paint-Maze (Mikro-Gen)"
-	description "Paint-Maze (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "PaintMaze.tzx" size 5086 crc 2eff4b27 md5 23dd48a06ff28c78e8a3f9bf26aa557e sha1 e8519c3eb5b772f13fe374c1c57a15d7d4791887 )
-)
+
 game (
 	name "Pandemic"
 	description "Pandemic (2014) - 'That is not dead which can eternal lie... in a petri dish' (with apologies to HP Lovecraft) -  The sequel 2010's VIRUS."
 	rom ( name "Pandemic.p" size 15934 crc 273220fa md5 4160c3e5a055e1258aeb500c7a60ffa7 sha1 28afa426e660186a1c1c56d74251b604e25bb2a1 )
+	manufacturer "Bob Smith"
+	year "2014"
 )
-game (
-	name "Peloponnesian War (Lothlorien)"
-	description "Peloponnesian War (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "peloponnesianwar.p" size 16121 crc f44dec8b md5 1bc0299b676a7656670585fc0199772c sha1 a3f5b184568ac4ea26ae03f9e737e9fd1d4eac53 )
-	rom ( name "PeloponnesianWar.tzx" size 16341 crc f56e0c9d md5 7a8ab89f6173649c5bbc0a6a9bf4d62d sha1 94ebc1a99152a5441238ad242da19b4c9ccee699 )
-)
-game (
-	name "Pengy (Fawkes Computing)"
-	description "Pengy (Fawkes Computing)"
-	year 1984
-	manufacturer "Fawkes Computing"
-	rom ( name "pengy.p" size 8564 crc f7e0304a md5 cdb3809c3f646129f7decba0dcc0c0ce sha1 19a0d22aca1f1580fac805b570a7bc3ea7ec4d2c )
-	rom ( name "Pengy.tzx" size 8782 crc 85894997 md5 bb2821339af5ebe2f6eb4ccc752f6a55 sha1 27606cf98e27ecc5a6da5da5e36ba5ab9c4fa038 )
-)
-game (
-	name "Pilot (Colour inlay) (Hewson Consultants)"
-	description "Pilot (Colour inlay) (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
-	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
-)
-game (
-	name "Pilot (Hewson Consultants)"
-	description "Pilot (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
-	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
-)
-game (
-	name "Pilot (New) (Hewson Consultants)"
-	description "Pilot (New) (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot(new).p" size 13051 crc d9519a6e md5 8b5df07010240dcead0141109297547e sha1 8ecb69e390bd24941db252f592f059e327be0db6 )
-	rom ( name "Pilot(New).tzx" size 13271 crc 0bc60aad md5 b3b606add7070b8c774ff1af2b562732 sha1 42e19385766fe586291dee026b49b60f47a9df0f )
-)
-game (
-	name "Pimania (Automata Cartography)"
-	description "Pimania (Automata Cartography)"
-	year 1982
-	manufacturer "Automata"
-	rom ( name "pimania.p" size 15773 crc 351eb08b md5 536e24e5b74ef6be13c44eaebebceea5 sha1 39f717b621452e6c853dc0e0318c01acb5ad45e6 )
-	rom ( name "Pimania.tzx" size 16003 crc 37cfb18d md5 5047a7041130a121e5d4e2d33e7ac1eb sha1 dd537d6ab72a749d1f6071d91748282e2ea2b89f )
-)
-game (
-	name "Pinball (Timex)"
-	description "Pinball (Timex)"
-	year 1982
-	manufacturer "A. H. Laity"
-	rom ( name "pinball.p" size 4668 crc 40b6bef6 md5 1e2905fd9ab4f7f57e6a9d81ddfe2e7c sha1 26c5d56388ae2bdc5f9adc53aa670e427f3f5e68 )
-	rom ( name "Pinball.tzx" size 4898 crc f8452e21 md5 986cc07f307993d0f7a996caa18af0eb sha1 4ff5e7491088e5ebe4c67b4813baa943aaea5164 )
-)
-game (
-	name "Pioneer Trail (Quicksilva)"
-	description "Pioneer Trail (Quicksilva)"
-	year 1983
-	manufacturer "M.Stubbs"
-	rom ( name "pioneertrail.p" size 15462 crc e4ad892d md5 77f604b5f45dc443b41aefe41387f0f5 sha1 33fdc9772de2008cd98e5a55fe0013eaef752fe8 )
-	rom ( name "PioneerTrail.tzx" size 15682 crc ceb55f84 md5 3187c5eb7e83d9020e2aabf3f7ecb5eb sha1 1ff2a193ffda69d2ca542d63334399bcf2301390 )
-)
-game (
-	name "Planetoids (Macronics)"
-	description "Planetoids (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "planetoids.p" size 4909 crc 8a63863a md5 efdb0abdab99edbbf7b0c31281a17a8f sha1 9bca8cf12d888dbbe9b1d8f5a00e8f207cd0a346 )
-	rom ( name "Planetoids.tzx" size 5127 crc 02a6b2ad md5 8715626fa60ffa829018000d02dd3a1c sha1 270765be9b076e4eaa0704eece81137ad2c0ae10 )
-)
-game (
-	name "Portfolio Analysis (Timex)"
-	description "Portfolio Analysis (Timex)"
-	year 1982
-	manufacturer "American Micro Products"
-	rom ( name "portfolioanalysis.p" size 15597 crc b540a618 md5 562cdb1a3e92927a8797312f03c448b6 sha1 26ebccff7160857f8490074a84bfd30c99aca883 )
-	rom ( name "PortfolioAnalysis.tzx" size 15819 crc d7ac34ed md5 0fd3b75c0d622131340a3c1bf3325edf sha1 e92da69a510bddb77ad5fab8e13f70d388ee5878 )
-)
-game (
-	name "Presidents (Timex)"
-	description "Presidents (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "presidents.p" size 5072 crc 61969b67 md5 6b8958911520b13ba8dcba0695d550e6 sha1 ba972c28536586a0c567357dbdcad2e362f45f91 )
-	rom ( name "Presidents.tzx" size 5300 crc 7bb539cf md5 7c4ccc1d49ef865bfd3a4e0babac9f4b sha1 e8ecee650bd89d88c7eb2fb9ec06eda5d5647caa )
-)
-game (
-	name "Print Shop (Cases Computer Simulations)"
-	description "Print Shop (Cases Computer Simulations)"
-	year 1983
-	manufacturer "Cases Computer Simulations"
-	rom ( name "printshop.p" size 14978 crc 5514b638 md5 cd8f4d73855eaef7ed7e81772a29ea3b sha1 cd58bee963702779034bfdbb17a22b8aeeb86c15 )
-	rom ( name "PrintShop.tzx" size 15212 crc da63a78f md5 5df01a04ff5ca4cf0f48939dd76a60fe sha1 6d911ea6f2e1df74f2547fb89c99f240a0e0272b )
-)
-game (
-	name "Printer Programs (Nick Godwin)"
-	description "Printer Programs (Nick Godwin)"
-	year 1984
-	manufacturer "Nick Godwin"
-	rom ( name "PrinterPrograms.tzx" size 20668 crc 11d50d78 md5 dd1ccfe9d8243d306ebb0bda40e351a4 sha1 22a458e45d174f9053a5b96bcdf848fa2afc0e9e )
-)
-game (
-	name "Privateer (Lothlorien)"
-	description "Privateer (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "privateer.p" size 12983 crc 8b4ce0e7 md5 81bd561dded0399d415f1e3c7b4d2419 sha1 b27dec9eaeb5f88581365fb6d5bd20c56e9bd6a9 )
-	rom ( name "Privateer.tzx" size 13217 crc 32e4f2d4 md5 7899a00015cc9b9b791c767d7c540c5e sha1 db608044f7c01b572406ade9481a6aea68995488 )
-)
-game (
-	name "Progmerge (ACS Software)"
-	description "Progmerge (ACS Software)"
-	year 1982
-	manufacturer "ACS Software"
-	rom ( name "progmerge.p" size 5279 crc d3fc7bf8 md5 951f8f1a0652936a3bb3f118c9bcc74e sha1 cde61a0ecb7a1e2f2531cc1743d2caeb746e47de )
-	rom ( name "Progmerge.tzx" size 5513 crc 13313bb9 md5 389d183a481034896e71e0c94603e729 sha1 fef5282a0e6a8937f22398c45187bb0e98e51b27 )
-)
-game (
-	name "Protector (Abacus)"
-	description "Protector (Abacus)"
-	year 1982
-	manufacturer "K. Flynn"
-	rom ( name "protector.p" size 7601 crc 571db599 md5 3c438049fff5dcc3247c530c9d39047e sha1 fa2bdbf6919ee3be7205f9a07db6a2ea1041e579 )
-	rom ( name "Protector.tzx" size 7835 crc 941c0480 md5 4d4c872b5934e61f8bb2064dbf7f122c sha1 750a926049abec9c67f6ade68fc029a068800dc6 )
-)
-game (
-	name "Puckman (Hewson Consultants)"
-	description "Puckman (Hewson Consultants)"
-	year 1981
-	manufacturer "Hewson Consultants"
-	rom ( name "puckman.p" size 10535 crc 23e9839e md5 ca251287c8c980e758d4c497028a24d0 sha1 7571ebdbbd2308fff0653217fe599adb8e702b26 )
-	rom ( name "Puckman.tzx" size 10765 crc 2678c742 md5 46a91fb71da2119df0ce3ac027a7cbb3 sha1 c382093f64ac43318766c4c884854150a1775f2f )
-)
-game (
-	name "Q Save (PSS)"
-	description "Q Save (PSS)"
-	manufacturer "PSS"
-	rom ( name "qsave.p" size 1547 crc a3edaab2 md5 48c37e545eaa01ef260e4b4799dc5992 sha1 fbdc2b3081b1e088ab05129ef8a5376e1378652d )
-)
-game (
-	name "Q Save (Red) (PSS)"
-	description "Q Save (Red) (PSS)"
-	manufacturer "PSS"
-	rom ( name "qsave(red).p" size 1467 crc 7918413a md5 597c8a759af88ca64c2ad2462492887f sha1 46ee323c057848ab62d253662891eae847e449d8 )
-	rom ( name "QSave(Red).tzx" size 1693 crc 28bcfd44 md5 d6db4577ce639ce63b01d3ec351a5cf6 sha1 173946ba09a7b0f085b975d25ddfe6f431541186 )
-)
-game (
-	name "QS Asteroids (Big picture, no text) (Quicksilva)"
-	description "QS Asteroids (Big picture, no text) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsasteroids(bp2).p" size 3419 crc b88db752 md5 d5208b3c585a16897aa9488865faed2e sha1 f74fa3e6439f92a3491f2d6cf4c07961f40847f0 )
-	rom ( name "QSAsteroids(BP2).tzx" size 3641 crc c5fcf3db md5 df2760f0a630f8019d417946916fefeb sha1 b39c7484a5cec019727f037a37103e44b37741ec )
-)
-game (
-	name "QS Asteroids (No characters) (Quicksilva)"
-	description "QS Asteroids (No characters) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsasteroids(nc).p" size 3425 crc 64116f53 md5 cdbf8582fd0eb31c153708960714e98d sha1 52e3612464419dbe622c5c23fa50dce1fab9b4c3 )
-	rom ( name "QSAsteroids(NC).tzx" size 3647 crc 92df0bf9 md5 83a4ed182ca56c6cc560e1f017f536ce sha1 64a0e4aa51c42ddc49ba4a4a26f73fe4fef123fb )
-)
-game (
-	name "QS Defenda (Big picture) (Quicksilva)"
-	description "QS Defenda (Big picture) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda(bp).p" size 1749 crc 18409a9f md5 973e7fa1e1f0ebdfdfac2af2dcf15929 sha1 8e297aec1684fa43cdd5a1f2d8540bfb0b1b74dd )
-	rom ( name "QSDefenda(BP).tzx" size 1971 crc 15b06f98 md5 cc64ebd2a4e4bebc7033f975d33a0d4a sha1 eccd0670138ea0f14de3448536adddc1df5cd57f )
-)
-game (
-	name "QS Defenda (Number) (Quicksilva)"
-	description "QS Defenda (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
-	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
-)
-game (
-	name "QS Defenda (Quicksilva)"
-	description "QS Defenda (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
-	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
-)
-game (
-	name "QS Invaders (Big picture) (Quicksilva)"
-	description "QS Invaders (Big picture) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders(bp).p" size 7185 crc f855545e md5 72c039832c770144f6abbd7fcc1410d8 sha1 c2ab1cd34875dcd0f23206c5ce2f745169d047c0 )
-	rom ( name "QSInvaders(BP).tzx" size 7407 crc 05b21451 md5 ac31e8ef363def7fb56ebbab76f49db1 sha1 92b476abe309e02a9721ab2db8d927418060338e )
-)
-game (
-	name "QS Invaders (Number) (Quicksilva)"
-	description "QS Invaders (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
-)
-game (
-	name "QS Invaders (Number, Upside down) (Quicksilva)"
-	description "QS Invaders (Number, Upside down) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
-)
-game (
-	name "QS Invaders (Quicksilva)"
-	description "QS Invaders (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
-)
-game (
-	name "QS Scramble (Number) (Quicksilva)"
-	description "QS Scramble (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "QSScramble(Alt).tzx" size 6320 crc 30847836 md5 09a4633a93747aeb1bca9e190aeaa14c sha1 7ee4b859c49ee81a670bd629e05ac27177dddb7d )
-)
+
 game (
 	name "Quack!"
 	description "Quack! (2014) - Bob's interpretation of the mobile game 'Flappy Bird'. Control a duck by tapping any key to make him fly up, and so avoid the oncoming pipes."
 	rom ( name "quack.p" size 8383 crc 01e8d775 md5 66afd32ec050cd1e4dbf657fd4f2089b sha1 d7e40348cc9181d2033c63e17e8fe07589e90c64 )
+	manufacturer "Bob Smith"
+	year "2014"
 )
-game (
-	name "Ram Runner (Timex)"
-	description "Ram Runner (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "ramrunner.p" size 12985 crc 1caa4b3e md5 b18437b08fdeff0caca69ea2afae96eb sha1 998860f07b4c60a190883e5bbdfb3ae249c40f1c )
-	rom ( name "RamRunner.tzx" size 13213 crc 9ad7e13f md5 eef86dd226681e5e6cd3db6a7eb2766e sha1 c821a765c4045b8107ff273dac9d211baca717cd )
-)
-game (
-	name "Real Estate Investment Analysis (Timex)"
-	description "Real Estate Investment Analysis (Timex)"
-	year 1982
-	manufacturer "American Micro Products Inc."
-	rom ( name "realestateinvestmentanalysis.p" size 15825 crc edef9f40 md5 5767ad8d9e1ae3f9fedba17514a069e5 sha1 c75505864f9fe3d9842561ec9bde7a4d24cc9d57 )
-	rom ( name "RealEstateInvestmentAnalysis.tzx" size 16047 crc 8373ada1 md5 98459338d5e57be0f9e7721c4bcfd883 sha1 240481eb5e8b45ee3e7d240076819b8e2593c3f0 )
-)
+
 game (
 	name "Rebound"
 	description "Rebound (2014) - Bob's interpretation of a Breakout / Arkanoid game, with 32 unique levels, 16 ball directions, multiple balls, and power-ups."
 	rom ( name "Rebound.p" size 13897 crc 00721ae3 md5 81ef01732f2f2e4d7fa96fba5984665c sha1 6abc2d4de5bb40aac8f3703e5c33a9ce3a31be75 )
+	manufacturer "Bob Smith"
+	year "2014"
 )
-game (
-	name "Red Alert (Softsync)"
-	description "Red Alert (Softsync)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "redalert.p" size 4004 crc e3f0e0c6 md5 3ee4de96ff92aa764d6a5af1978bf769 sha1 d95c77e1b695af04d6679cdab70ed2ab9caa8f2a )
-	rom ( name "RedAlert.tzx" size 4236 crc 16d48454 md5 4c5e219f57813a8838e43ba6ae791810 sha1 61a4719da9099699143e39713d08c13e381e9216 )
-)
-game (
-	name "Rental Property Manager (Data-assette)"
-	description "Rental Property Manager (Data-assette)"
-	manufacturer "John Powers"
-	rom ( name "rentalpropertymanager.p" size 16109 crc 2316c873 md5 79e94ac3f50f837458eaf07ed4317951 sha1 79194cf5dfca47d67866257dbf2e2f31d8e79272 )
-	rom ( name "RentalPropertyManager.tzx" size 16339 crc 92f8aa70 md5 4b297d59dfa3fd14ee638b35d6f8bc99 sha1 378bb82167e1ee3a4f8ec8a69b2a3612cd2b2810 )
-)
-game (
-	name "Reversi (Artic)"
-	description "Reversi (Artic)"
-	year 1982
-	manufacturer "T. Hughes"
-	rom ( name "reversi(artic).p" size 14726 crc 613dd959 md5 5529e75702832f4c17874d81e49833a2 sha1 89e9591ff6720a374c30a1be117e5b9720fcea98 )
-	rom ( name "Reversi(Artic).tzx" size 14952 crc d5796e37 md5 708f70b98133de0290338c974ae50509 sha1 516f08ceefe2997e183e6f47e774fda4b81d7be3 )
-)
-game (
-	name "Reversi also known as Othello (Sinclair Research)"
-	description "Reversi also known as Othello (Sinclair Research)"
-	year 1982
-	manufacturer "Moi/Games of Skill Ltd"
-	rom ( name "reversi.p" size 6222 crc 9317d6cf md5 496aeef5f2cea222a7223625f990c8f4 sha1 df86a5e30d5e38f37a3ab4e2975515e38bddbb82 )
-	rom ( name "Reversi.tzx" size 6452 crc 01930d80 md5 e33b1e6b4508f5eff9d7f0c873b0c94d sha1 0b09a2d44f3fb3243da9cc46ff161bffe6d8021b )
-)
-game (
-	name "Robbers of the Lost Tomb (Timeworks)"
-	description "Robbers of the Lost Tomb (Timeworks)"
-	year 1982
-	manufacturer "Timeworks"
-	rom ( name "robbersofthelosttomb.p" size 12141 crc 79fcfb44 md5 02209f4889c543a0a43d451743708328 sha1 345fa829ad2f082291c236ec5826aed0e864d8ba )
-	rom ( name "RobbersOfTheLostTomb.tzx" size 12365 crc 700a0975 md5 7d90a419cc9fc490f597993effb7d068 sha1 4e78f00d3529accfdde236c2ef24e43106b5d8d4 )
-)
-game (
-	name "Rocket Man (Software Farm)"
-	description "Rocket Man (Software Farm)"
-	year 1984
-	manufacturer "Software Farm"
-	rom ( name "rocketman.p" size 15327 crc 93fdefb0 md5 2a2606484cf8bbc5bfdfece4b1ab657b sha1 c9bde797ab35e89fe71fe595857b5d1d1d2740fc )
-	rom ( name "RocketMan.tzx" size 15561 crc e34adca9 md5 4ef97704d962703ca65309098356d20b sha1 024909ddf04e7efb22c4e84781aea9ce8e20a877 )
-)
-game (
-	name "Roman Empire (Lothlorien)"
-	description "Roman Empire (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "romanempire.p" size 15108 crc 19ebf247 md5 5c3babff0601a703a4ee3549d7608422 sha1 3629f81c9dff99b9d9bb84ee392f3c3ec345916f )
-	rom ( name "RomanEmpire.tzx" size 15328 crc 5eeef590 md5 a0b4632b0bc95998b687af11df7c769b sha1 38225146a420b541cd425e420b5c21c794fd7486 )
-)
-game (
-	name "RPN Calculator (Zeta Software)"
-	description "RPN Calculator (Zeta Software)"
-	year 1982
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "rpncalculator.p" size 8282 crc fd66ef0e md5 df81ab32f89accd286bf7cac114db2a4 sha1 cd9f8d264af05fee79132004522eb5049f250650 )
-	rom ( name "RPNCalculator.tzx" size 8504 crc 1609ef0d md5 6943fdf8fb6e3d76ee3c9d119d3cd441 sha1 a6283859ffc5d6390b55803129777fe32b74d627 )
-)
-game (
-	name "Rubik Cube (Alt) (CDS Micro Systems)"
-	description "Rubik Cube (Alt) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "rubikcube(alt).p" size 14375 crc c163a924 md5 12bcc34945162beb2b494198aea60e23 sha1 8075d277091b180ee535f253daeaf7cd39135069 )
-	rom ( name "RubikCube(Alt).tzx" size 14601 crc 11d010a0 md5 a514d66d19792684ad2f5f8987bb9448 sha1 7996ca3bb737847719bdfc0663483d0906d74282 )
-)
-game (
-	name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-	description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "rubikcube.p" size 15158 crc 8ae261a2 md5 d70593b633e0e6a88a7e919f6f4c95c2 sha1 31426d332e594597879a9c42b259436445e96e4e )
-	rom ( name "RubikCube.tzx" size 15384 crc 580179a6 md5 724cdc2b86991f8710876579f9a16559 sha1 9b1b7f10e2ebfc90b3653dc10ec0ffd0d5a5c552 )
-)
-game (
-	name "Sabotage (Sinclair Research)"
-	description "Sabotage (Sinclair Research)"
-	year 1982
-	manufacturer "Macronics"
-	rom ( name "sabotage.p" size 8852 crc 682b39a0 md5 93a3ac8c7c759d72848470e7bf1595fc sha1 43467cef8ef83457ad6bac424ddd89ab885fed3c )
-	rom ( name "Sabotage.tzx" size 9070 crc 0120fe03 md5 6becdebc9329742a817e1d0068716ded sha1 4d123b512a757fe2e0bfd7ddee111322d8238d9f )
-)
-game (
-	name "Salvo (Orbyte Software)"
-	description "Salvo (Orbyte Software)"
-	manufacturer "A & M Productions"
-	rom ( name "salvo.p" size 15284 crc 202f1a9b md5 009acfc6e76e528f40cc693753e73251 sha1 3bd88ac1e2a1dfca98ad495346e0c65d9936a1a0 )
-	rom ( name "Salvo.tzx" size 15510 crc d9303929 md5 a28b801ff835cd8dccddacf23ed8db1f sha1 706ddd40ffc24ad4fffcef7d8f77889a6a1c1a19 )
-)
-game (
-	name "Samurai Warrior (Lothlorien)"
-	description "Samurai Warrior (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "samuraiwarrior.p" size 15261 crc 6804e38d md5 e268d6c175c8359bc23491aa237c0aa5 sha1 24ac5226d3e646254f00f3ccad7abfde618b346c )
-	rom ( name "SamuraiWarrior.tzx" size 15481 crc 68f13fb0 md5 4e59f61c5a39bf5f8b372ba40a009b07 sha1 a6d7b88718f8ef85e300cb1ba696544a6cb1efcf )
-)
-game (
-	name "Scramble (Colour inlay) (Mikro-Gen)"
-	description "Scramble (Colour inlay) (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "scramble(ci).p" size 4455 crc bfc4a5e6 md5 f9ba0ffc3497e3fd978a6894fcf28547 sha1 6add38b04de58597b939f24f35613b6a1b8e2eb5 )
-	rom ( name "Scramble(CI).tzx" size 4693 crc 0ef260a9 md5 de5f9bb0623c40822463ca512f959d06 sha1 338ba99e7d814653800311cd67be49fca764a822 )
-)
-game (
-	name "Scramble (Mikro-Gen)"
-	description "Scramble (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "scramble.p" size 4455 crc 6ca59ceb md5 1cace2e4cea14d6f96913f3ed7d7204f sha1 bd6ff916c9a18ea0eda7d21b061670231643e308 )
-	rom ( name "Scramble.tzx" size 4693 crc dd9359a4 md5 8f50b50f065ff824c39209c4680bf2aa sha1 84760e3b08c0e5686c9ace4b23dff5b6187da367 )
-)
-game (
-	name "Screen Kit 1 (Picturesque)"
-	description "Screen Kit 1 (Picturesque)"
-	manufacturer "Picturesque"
-	rom ( name "screenkit1.p" size 1841 crc fe229e5d md5 3dab82c0980eeca3b0f22016ed6dcd16 sha1 84abe2d096d68e01573fe1aea3c3a0646c62e6f5 )
-	rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 ec8d98cec4ac5b718d7ab4c188a99a01 sha1 78351cb1c27587935242bf9bb0f512d07b902625 )
-)
-game (
-	name "Sea Wolf (Newer) (Stephen Hartley Computing)"
-	description "Sea Wolf (Newer) (Stephen Hartley Computing)"
-	year 1983
-	manufacturer "I. R. Bird"
-	rom ( name "seawolf(newer).p" size 9502 crc 3d713295 md5 a437d3a2d8ae59c77cca90bfb572ecd7 sha1 c75d950618d084f3cf1a0903a696d0a9bb8b6121 )
-	rom ( name "SeaWolf(Newer).tzx" size 9732 crc 9e1b515b md5 c71a018235cc635882535a19a256ce7a sha1 b55b9b06c9805d2253335d4f61a6ae43bbe9ffe4 )
-)
-game (
-	name "Sea Wolf (Stephen Hartley Computing)"
-	description "Sea Wolf (Stephen Hartley Computing)"
-	year 1983
-	manufacturer "I. R. Bird"
-	rom ( name "seawolf.p" size 9502 crc 7156979a md5 394000d5a21f5320b63c1145e30f119f sha1 1c221622620508cdd921e0d84c34042fca87d1cc )
-	rom ( name "SeaWolf.tzx" size 9732 crc d23cf454 md5 0fceb5b1ae6ed2721d95f2343f6cdf37 sha1 f0275fe3bc08875e643be9431615b7a7c5ba64ab )
-)
-game (
-	name "Similes Countdown (AVC Software)"
-	description "Similes Countdown (AVC Software)"
-	year 1981
-	manufacturer "K. Jammer and S. Brown"
-	rom ( name "similescountdown.p" size 9899 crc f2f2b554 md5 adce97d888ca6665a5071a5df2759364 sha1 4d0117466c37df6b4fafdc3eff7f75f3aea3aed1 )
-	rom ( name "SimilesCountdown.tzx" size 10151 crc fbbcdef4 md5 e270304c53d20e65b47ef69bd0fefdc8 sha1 7cd764fcbd90d455fb2d31ceec7cda10b08ec8cd )
-)
-game (
-	name "Space Intruders (Hewson Consultants)"
-	description "Space Intruders (Hewson Consultants)"
-	year 1981
-	manufacturer "Hewson Consultants"
-	rom ( name "spaceintruders.p" size 3764 crc 074dc33e md5 6919edc03f14fc6772c089af461624d6 sha1 dfed85eafde74afb2c3237003d73e7fa3fe69837 )
-	rom ( name "SpaceIntruders.tzx" size 4010 crc 88b1156f md5 f15a15be576dc7efdcfd8bdf87faaadf sha1 8aaf24a56fe3cc999ce32ae795ce0bbd7983838f )
-)
-game (
-	name "Space Invaders 3K (Macronics)"
-	description "Space Invaders 3K (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "spaceinvaders3k.p" size 2854 crc f1273575 md5 dd982a212278df38fa34c19b19db4484 sha1 653dd0ba53d7005005fff184ee8d556cb6982a23 )
-	rom ( name "SpaceInvaders3K.tzx" size 3074 crc 69729abd md5 753f7387213896a0dae8e09a4974d2a2 sha1 00bea09a8d43cfd35cb2fb44eff623692811d2a9 )
-)
-game (
-	name "Space Invaders (dK'tronics)"
-	description "Space Invaders (dK'tronics)"
-	year 1981
-	manufacturer "dK'tronics"
-	rom ( name "spaceinvaders(dk).p" size 6645 crc 4c0edb0a md5 7bb4a934ddc0746167e6fac17f71cae4 sha1 1392c3c2ba459fbc67edb18fd96fd617fd8ad167 )
-	rom ( name "SpaceInvaders(dk).tzx" size 6889 crc 720bf20c md5 3d25c73ac6e5c6f48081eb86a5d0e0b3 sha1 e9d543b4f96bbda648c1488a06d2538ed3da3001 )
-)
-game (
-	name "Space Invaders (Mikro-Gen)"
-	description "Space Invaders (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "spaceinvaders.p" size 2664 crc e39a90be md5 cce844a181612ad7e32209e73ce42b9c sha1 795cc3740caee56e9af16a52b557d93b968d0cde )
-	rom ( name "SpaceInvaders.tzx" size 2896 crc a345e8db md5 f835a9b2d5dce454a2ddc4caf8175505 sha1 4536f0d2a465a71891803b23d29bc8c54c1b874f )
-)
-game (
-	name "Space Man Apollo (ICT)"
-	description "Space Man Apollo (ICT)"
-	year 1984
-	manufacturer "Iain Thomson"
-	rom ( name "spacemanapollo.p" size 15647 crc 1adf5140 md5 0e91bcac7314fb7d95db8d86cb4920f4 sha1 fd98b6596b28bc0ecda1f3b7aaef526809d3a38e )
-	rom ( name "SpacemanApollo.tzx" size 15875 crc 0fc40716 md5 17291434ca3e09aed13b243f95498b0b sha1 68861a48e02a2d65b717012df38600d96986df97 )
-)
-game (
-	name "Space Mission (Gem Software)"
-	description "Space Mission (Gem Software)"
-	year 1982
-	manufacturer "Gem Software"
-	rom ( name "spacemission.p" size 13365 crc 97df84e4 md5 be00529ebf59e65659d1d658976fa738 sha1 1071d74d173d8f325894f0dbac851e60a15e38b2 )
-	rom ( name "SpaceMission.tzx" size 13607 crc 0dacab8d md5 35ac87605be32557ce38bfbf61f3dbaa sha1 bd92c04a311a49e5846e35528d692ee5e6eb2bcf )
-)
-game (
-	name "Space Trek (Micromega)"
-	description "Space Trek (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "spacetrek.p" size 15395 crc 8c8545b1 md5 eb1db83f22e599c4a8927bdf043d2677 sha1 ff8a32ee7197f3ef632f2cf231cb0ca7cbf1defc )
-	rom ( name "SpaceTrek.tzx" size 15619 crc 081b0787 md5 7a2a66e12f7983634ff1ca0b9b795ded sha1 0e20ed7812a34ad507ec1c1dc23536641c4b9993 )
-)
-game (
-	name "Spacetrek (JRS Software)"
-	description "Spacetrek (JRS Software)"
-	manufacturer "JRS Software"
-	rom ( name "spacetrek(jrs).p" size 332 crc c2f526df md5 a3b4c8c194ffd9b3df6ab21f57bcc6cc sha1 6b5c61147a38082825fc71a003937e5f07f59f02 )
-	rom ( name "Spacetrek(JRS).tzx" size 550 crc d62cc02f md5 17aaf306f2269d03004c5866d47af928 sha1 1b0c8177a41aea9aa40f5698280c86e505151349 )
-)
-game (
-	name "Spelling Bee (Timex)"
-	description "Spelling Bee (Timex)"
-	year 1983
-	manufacturer "Russell Klein"
-	rom ( name "SpellingBee.tzx" size 48415 crc a5987f22 md5 75f46b5eac8f50943ebe3c185da8a98b sha1 d992d921483b59b85ae68bdfa6e44d1c9c5068cc )
-)
-game (
-	name "Star Trek (Bug Byte)"
-	description "Star Trek (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "startrek.p" size 10018 crc a3004740 md5 33bacef251164137a75e7b9a7164ada0 sha1 7a890295c0b822938db6e8dc70bb68d669bf9051 )
-	rom ( name "StarTrek.tzx" size 10250 crc c8107516 md5 db8fba7fba8544b74b63c53519163be7 sha1 3e0f7d137f9572f756ba9edc5c6835fa9367be81 )
-)
-game (
-	name "Star Trek (Macronics)"
-	description "Star Trek (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "startrek(macronics).p" size 15869 crc e33d9286 md5 dac4c635719e0a8a0b7d55cc18f2e6a6 sha1 2f7d41853aa556ee5197a54e03e405286884343d )
-	rom ( name "StarTrek(Macronics).tzx" size 16091 crc 171e0b56 md5 9f7ef6572bf3d71c53b3ef64053a0715 sha1 5a25a295fc011e37b8941634ad32746b9d626d48 )
-)
-game (
-	name "Star Trek (Typed Inlay) (Bug Byte)"
-	description "Star Trek (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "startrek(typed).p" size 10018 crc 2749661e md5 9e9f60d7e165323899d49206285d9c3a sha1 f289f9958df4c2a7f811e36920fa4b7c74bc505c )
-	rom ( name "StarTrek(Typed).tzx" size 10250 crc 4c595448 md5 c7d23895712792195672678584e5d250 sha1 d6286120a5acc82d974f76e381f3382fe0c55be8 )
-)
-game (
-	name "Starquest (International Publishing and Software Inc.)"
-	description "Starquest (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Starquest(IPS).tzx" size 17893 crc 0375bd08 md5 7237e3d312cdecfa235a945cd88b3aef sha1 fa7a242596852d6aa1c2ff15142ea2f1ed6d4b1f )
-)
-game (
-	name "Starquest (Pixel Productions)"
-	description "Starquest (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Starquest.2.Starquest.tzx" size 16209 crc 85bfc2b5 md5 7602a6da23e1e058b4ef39ac1b1d29cd sha1 f0d5783909ca9a5954ecd71854f4f9aaa57d6619 )
-	rom ( name "starquest.p" size 15989 crc fb070bd6 md5 73407dfbdae230f813ee47ee62747a4f sha1 6171f22250e4bfaf347b85f1e0cfeca5312dddae )
-)
-game (
-	name "States and Capitals (Timex)"
-	description "States and Capitals (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "statesandcapitals.p" size 11310 crc d0be9818 md5 bedb20f535283c3d59eb0990a07690af sha1 509778144c3918ce04f64a5d723d17f7cacd9719 )
-	rom ( name "StatesAndCapitals.tzx" size 11538 crc c70fa5a4 md5 a2fad8976a643ea58281ae9c6276123a sha1 99551d3bb7ad39b7f55be16973af29dc7425e9e3 )
-)
-game (
-	name "Statistics (Timex)"
-	description "Statistics (Timex)"
-	year 1982
-	manufacturer "R. Daniel"
-	rom ( name "Statistics.tzx" size 4852 crc 22eb02c8 md5 0eb9db5c0720be88d236a198c94797d4 sha1 494389e8ad0a8c8adb4a7fa17c91464a78d555e2 )
-)
-game (
-	name "Statistics (Zeta Software)"
-	description "Statistics (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "statistics(zeta).p" size 13376 crc 9204f603 md5 f82de91f3b217e98a74152e96ab3856b sha1 5df7ca4145a22cc7f730aac13fe8835c40669321 )
-	rom ( name "Statistics(Zeta).tzx" size 13600 crc c0b4f14a md5 2b944e3bf6f17648919c3591b7b9905a sha1 7f13b230064429ab366f0816b43d683085d0bf62 )
-)
-game (
-	name "Stock Car (Informatique Service)"
-	description "Stock Car (Informatique Service)"
-	year 1984
-	rom ( name "stockcar.p" size 8216 crc 41224d6b md5 c7549cd5dfc22bd438a16d6ffeb29b18 sha1 e70d50de2f51597bc74a50bdb25a34bf6b059888 )
-	rom ( name "StockCar.tzx" size 8450 crc fedbbc78 md5 cd54361859d4d5ae1e4290c8c5db8063 sha1 3604d2ff3b9de27e45cb691131b98be09ba3c65b )
-)
-game (
-	name "Stock Market Tech. Analysis 1 (Timex)"
-	description "Stock Market Tech. Analysis 1 (Timex)"
-	year 1982
-	manufacturer "T. H. Nooter"
-	rom ( name "stockmarkettechanalysis1.p" size 16177 crc 0ee43e40 md5 23d4292a790d7120376375574118136b sha1 6d8fe3f2bf6b8171af5a30ec199f6ec5f8c31c30 )
-	rom ( name "StockMarketTechAnalysis1.tzx" size 16405 crc 40a9b729 md5 bb445169bd552aa1beff7b3221856965 sha1 0d23879da55a4e5cbd7a8b482d010fdcb21e06f6 )
-)
-game (
-	name "Stock-Market (Video Software)"
-	description "Stock-Market (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "StockMarket.A.tzx" size 11978 crc 440cc0e5 md5 cad4ab9c37b2db19ee7950cdfbe71490 sha1 849c2761901e9210f101500e5603d38b90e55a8c )
-	rom ( name "stockmarket.p" size 11738 crc d6f22d69 md5 3c4e77adf07396603240c9225499245d sha1 a71ff5fcc069c95e0e0ca480e78a724ea73fcf00 )
-)
-game (
-	name "Strategy Football (Timex)"
-	description "Strategy Football (Timex)"
-	year 1983
-	manufacturer "Gerald Bennett"
-	rom ( name "strategyfootball.p" size 15249 crc 903db439 md5 23b460ac48b647e5f5d2029a62c3a27a sha1 51e03ad187ae202e999e2b391e9fe82d4a301d5a )
-	rom ( name "StrategyFootball.tzx" size 15469 crc 432f9356 md5 9ce1d8687fa6ec86c44ceb48f5f0c4bd sha1 4add01b5f9e3ddf8f19a686ad91385d4dece1bbd )
-)
-game (
-	name "Subspace Striker (International Publishing and Software Inc.)"
-	description "Subspace Striker (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "SubspaceStriker(IPS).tzx" size 17446 crc b3c93f34 md5 7d123fe1a0f6430b7a8492483e2feeb6 sha1 4a0d2d26033bfb0b0d67248b8b2ae1fa5f423dc4 )
-)
-game (
-	name "Super Chess (CP Software)"
-	description "Super Chess (CP Software)"
-	year 1982
-	manufacturer "CP Software"
-	rom ( name "superchess.p" size 16060 crc 650317b6 md5 abfb385e22165912beadca3377e4a6b2 sha1 324f41e92e9c6d5ea06792238b9374eb2340919f )
-	rom ( name "SuperChess.tzx" size 16296 crc dad51d68 md5 50316e46482e309565e8bb584190f3ed sha1 ce79c0b548bb98118e1725c82396887e01aea430 )
-)
-game (
-	name "Super Chess (Softsync)"
-	description "Super Chess (Softsync)"
-	year 1982
-	manufacturer "CP Software"
-	rom ( name "superchess(softsync).p" size 16060 crc 026568f8 md5 3834752bc2c52e38631f234a1390810b sha1 a91df04216af0ce22b85c6a9bfa8c523e97b7da2 )
-	rom ( name "SuperChess(Softsync).tzx" size 16296 crc bdb36226 md5 5cfb66aefd5c74f85443d1a89d420410 sha1 5dda6654a11c6f0afa5dcb9d7f128667359a6954 )
-)
-game (
-	name "Super Invaders (Bridge Software)"
-	description "Super Invaders (Bridge Software)"
-	year 1982
-	manufacturer "Bridge Software"
-	rom ( name "superinvaders.p" size 12317 crc 94f95161 md5 4f2f2556ab2020046b3b864e1ffdf218 sha1 5bf9ccc9a39a47095143f0506aa778a1be11c341 )
-	rom ( name "SuperInvaders.tzx" size 12541 crc f662bd98 md5 b4bf9dff58752eb60ffd48d6af234720 sha1 3d8c7a7f290d9c792ea7263957dcdaa14cd02c93 )
-)
-game (
-	name "Super Invasion (Softsync)"
-	description "Super Invasion (Softsync)"
-	year 1981
-	manufacturer "Beam Software"
-	rom ( name "superinvasion.p" size 896 crc 54df2bd2 md5 c65906f94fc9cef39c32bbdf56cd1b20 sha1 3c6a9ce5d9785c2a51802a21e666b01af73e0c8e )
-	rom ( name "SuperInvasion.tzx" size 1124 crc cc59f451 md5 dd3904d9a8d535358bebc9affcf11854 sha1 447855ab4bd695a574a93ff9fab09d65258438a5 )
-)
-game (
-	name "Super Math (Timex)"
-	description "Super Math (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "supermath.p" size 8075 crc 1f288f07 md5 5d4125044a0954ea23754d036920a1e7 sha1 4373cf521b219edb88a527454e97080a27344a72 )
-	rom ( name "SuperMath.tzx" size 8299 crc 21eb7b78 md5 1278409cd4aef861297f630f88665c5f sha1 3f30feead9537bf39da7d83175a5a0cc3dcf0a72 )
-)
-game (
-	name "Super Nine (Romik Software)"
-	description "Super Nine (Romik Software)"
-	year 1982
-	manufacturer "Romik Software"
-	rom ( name "SuperNine.tzx" size 6872 crc e8b39d87 md5 5c6a25cd318de3f362261214003c32f1 sha1 5d3cb094e65d4bd9c412f4b6fc18afcc768e6f41 )
-)
-game (
-	name "Super Programs 8 (ICL)"
-	description "Super Programs 8 (ICL)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
-	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
-)
-game (
-	name "Super Programs 8 (Sinclair Black) (ICL)"
-	description "Super Programs 8 (Sinclair Black) (ICL)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
-	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
-)
-game (
-	name "Super Programs 8 (Sinclair Research)"
-	description "Super Programs 8 (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8.p" size 14974 crc b876fa33 md5 6d3374dc7edbfd66f4d48b6140c17c11 sha1 cc2aa503a948d62d0a40fb29d0c628a5e4ea3632 )
-	rom ( name "SuperPrograms8.tzx" size 15192 crc 2aa20758 md5 545c084c45b5188079167da9f1acb304 sha1 de665ebe1949e077934ed6f0961d525f274f3d6e )
-)
-game (
-	name "Super Scramble (Software Farm)"
-	description "Super Scramble (Software Farm)"
-	year 1982
-	manufacturer "Software Farm"
-	rom ( name "superscramble.p" size 9068 crc 29c5c5d5 md5 8846ef2a3955e7637f72b13d0a8405b2 sha1 ab1e6fae6ba522c9cc9363ddb75c35a794ffdfd2 )
-	rom ( name "SuperScramble.tzx" size 9312 crc 5f11c06c md5 579e55d4adf1d3ee050bfb59abab6167 sha1 aa22bb6ff4c10b8279f2c1e568db7b9ae5158ca6 )
-)
-game (
-	name "Supermaze (Timex)"
-	description "Supermaze (Timex)"
-	year 1982
-	manufacturer "Greg Harvey"
-	rom ( name "supermaze.p" size 16170 crc c58f309b md5 2684494519118b0c23b94ab177ed694e sha1 b36c2eaff62752137c75855e7686a90c58127906 )
-	rom ( name "Supermaze.tzx" size 16394 crc 6e93ce7f md5 225ef6ba2e2b9788dbeba444b5fc60ed sha1 f85d7522e9cd2bf3cbdc3c05493423d7afad482b )
-)
-game (
-	name "Tables Countdown (AVC Software)"
-	description "Tables Countdown (AVC Software)"
-	year 1981
-	manufacturer "K. Jammer and C. Deeson"
-	rom ( name "tablescountdown.p" size 8947 crc e3b0d8d8 md5 b71d10dcec0d99531fb8d2fb777751a0 sha1 1713feb2d1fbdf6d3712e10e2f0291a6bce813c4 )
-	rom ( name "TablesCountdown.tzx" size 9197 crc 59bd7de7 md5 8fec27b406d4041d3fb99784f7318f08 sha1 71d4f85478e2eb9016bab2fd0fac0107a7fccdea )
-)
-game (
-	name "Tai (PSS)"
-	description "Tai (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "tai.p" size 14015 crc c7869e9e md5 17e769ceca4301beafb8c1547e62a326 sha1 7a44314234cffd9fff42c90a46be0db954e63352 )
-	rom ( name "Tai.tzx" size 14237 crc 3a1351f8 md5 2d7f98eca4bd7efe614ca55b6eb4fde3 sha1 fd0a3ceac8ce8540e13c7e6af6f547a2feff5d8a )
-)
-game (
-	name "Talkback (M. W. F. Ringrose)"
-	description "Talkback (M. W. F. Ringrose)"
-	year 1983
-	manufacturer "M. W. F. Ringrose"
-	rom ( name "Talkback.tzx" size 12740 crc 36724d18 md5 6caa20b159f6e66bec947d4a901862dd sha1 6b32ff6dd4930ad62cadb59b3c4ecdb6eb4a2654 )
-)
-game (
-	name "Tapebook 50 1K (Control Technology)"
-	description "Tapebook 50 1K (Control Technology)"
-	manufacturer "Control Technology"
-	rom ( name "TapeBook50.tzx" size 37005 crc d882bccd md5 05b0b6c39c1a331e9d4592944f5fcf03 sha1 0d1b30d4d024147c9489d56e0519f9f60bf75cbd )
-)
-game (
-	name "Tarot (Timex)"
-	description "Tarot (Timex)"
-	year 1983
-	manufacturer "Computer Phood"
-	rom ( name "Tarot.tzx" size 29510 crc 5c63c324 md5 35525dae43101ab654360464227dfc37 sha1 81f1ab607044fd2b44c1163a0cb317dc1727d0a4 )
-)
-game (
-	name "Tasword (Tasman Software)"
-	description "Tasword (Tasman Software)"
-	year 1982
-	manufacturer "Tasman Software"
-	rom ( name "tasword.p" size 5339 crc d2cd3934 md5 dd0169e3a06413005f30670f959d56d4 sha1 9dd68379eb1079ceb6b3a106cbc9839a2df9ad30 )
-	rom ( name "Tasword.tzx" size 5569 crc 9b77040a md5 321945f0628d33e073ae1c306d2ead5a sha1 100be588ad785f012f513e8043c323348b5e44ed )
-)
-game (
-	name "Tempest (Mikro-Gen)"
-	description "Tempest (Mikro-Gen)"
-	manufacturer "S. P. Kelly"
-	rom ( name "tempest.p" size 3291 crc f760afba md5 44309dc8b4e242a1e08dfad3f4d590ba sha1 8e4c160df4ec5905f38a922e8e1403d984c92fe4 )
-	rom ( name "Tempest.tzx" size 3521 crc 5cca0ded md5 09bdea36a433f0a3f5fe8b8bcc8e0aa3 sha1 a4cfd1f82d0e4d255ae3b54a54f30a6cb96ce4f9 )
-)
-game (
-	name "Ten 1K Games (Computer Rentals)"
-	description "Ten 1K Games (Computer Rentals)"
-	year 1983
-	manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
-	rom ( name "Ten1KGames.tzx" size 7545 crc c724fd4a md5 60cccfa8c4852f55d0eeda74524c0ca0 sha1 589c68041f90a46fb8c18118c0889c6b8f91f0ca )
-)
-game (
-	name "The Budgeter (Timex)"
-	description "The Budgeter (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "budgeterthe.p" size 7421 crc 8d3b6fc8 md5 f8f70240fd3ce11eda2d349f26d760d9 sha1 c2d31635238b2d581c1d8e4c7ed0565933275b1d )
-	rom ( name "BudgeterThe.tzx" size 7653 crc 5ea30258 md5 ab5775378af88aaf6fd6b6e653f00318 sha1 936a4bdf69507c24b8a634c94065548a3757fac9 )
-)
-game (
-	name "The Carpooler (Timex)"
-	description "The Carpooler (Timex)"
-	manufacturer "Timex"
-	rom ( name "carpoolerthe.p" size 14277 crc 0d8abcac md5 068be6e28af97837ffbb6d292930b6d7 sha1 992b08b7fc5bc7d0d891459fbcebb078ba9d2649 )
-	rom ( name "CarpoolerThe.tzx" size 14507 crc d8258cef md5 9f1a67808e8506b0df3c66bf00568caf sha1 cafbb78bf77f88c0ffb29e6c2a92666899149c8e )
-)
-game (
-	name "The Challenger 1 (Timex)"
-	description "The Challenger 1 (Timex)"
-	year 1982
-	manufacturer "R. Fowkes"
-	rom ( name "Challenger1The.tzx" size 4178 crc a01b37e4 md5 ca1d005637983ed5618c1bfd4b9bb08d sha1 5b9809a27911e43d8fb882a60da3752fe202bc27 )
-)
-game (
-	name "The Checkbook Manager (Timex)"
-	description "The Checkbook Manager (Timex)"
-	year 1982
-	manufacturer "John Heaney"
-	rom ( name "checkbookmanagerthe.p" size 13483 crc b9446d9b md5 6e610dca9691a1fc82c89a5ba4a4574d sha1 5a12849ce4be86742c393306023fbf2fb081ca6a )
-	rom ( name "CheckbookManagerThe.tzx" size 13713 crc b32eaa12 md5 59cd50185f32789958737b3eac99c64b sha1 d1b150fee25332715af8115604d8063e5a71b77d )
-)
-game (
-	name "The Coupon Manager (Timex)"
-	description "The Coupon Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "couponmanagerthe.p" size 15892 crc d4803e75 md5 ae154df5fad396df2c60a12ff7275328 sha1 e6f50fcc128863cd06428a20a731b0cdb1b76379 )
-)
-game (
-	name "The Cube Game (Timex)"
-	description "The Cube Game (Timex)"
-	year 1982
-	manufacturer "John Heaney"
-	rom ( name "cubegamethe.p" size 13490 crc 5b814ea8 md5 46141c523cf55f37ad18594d434c118e sha1 c30033cd7773cf740f517b3e5c8fd7b1bfe593da )
-	rom ( name "CubeGameThe.tzx" size 13714 crc c87bea16 md5 e7e0b000b8fce72a25f358b4b5f2478e sha1 dbf04e07ff5ed808df032c66191f79d0c96488a5 )
-)
-game (
-	name "The Damsel and the Beast (Bug Byte)"
-	description "The Damsel and the Beast (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "damselandthebeastthe.p" size 10200 crc e572e012 md5 a4ba6fb14be2c6841565dffc496d8c18 sha1 15033d3454985a1ce45289bb33296791ab3332aa )
-	rom ( name "DamselAndTheBeastThe.tzx" size 10464 crc b34252c8 md5 d055c7009157dcf01dc9689d414dbafa sha1 574392a27b8328ec82121e1c666e2c3411f34342 )
-)
-game (
-	name "The Electronic Checkbook (Timeworks)"
-	description "The Electronic Checkbook (Timeworks)"
-	year 1982
-	manufacturer "Timeworks"
-	rom ( name "electroniccheckbookthe.p" size 16162 crc 75097784 md5 cdd6ea720f382f5dc8f2c971a53e3e2f sha1 a2ace5b2b1bf45c5dbd0ebf2cbd47934dc668787 )
-	rom ( name "ElectronicCheckbookThe.tzx" size 16382 crc bc3ed36d md5 c0f35b0fcef5474812364c0ea6cdcf2e sha1 3791720c3974c31c322b9d1e6a6281de6e6bcfcd )
-)
-game (
-	name "The Fast One (Campbell Systems)"
-	description "The Fast One (Campbell Systems)"
-	manufacturer "Campbell Systems"
-	rom ( name "FastOne(Green).tzx" size 9837 crc 3c57d2f2 md5 24bfe29d78ac664aa6b367ef983c590d sha1 c31f2892ea9145cdab6ef5f21cd126ab9d079036 )
-)
-game (
-	name "The Flight Simulator (Timex)"
-	description "The Flight Simulator (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
-)
-game (
-	name "The Gambler (Timex)"
-	description "The Gambler (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "GamblerThe.tzx" size 19202 crc e05a3062 md5 ea6c404af8fc06091341e038643a85a6 sha1 61da0728b3850a4235d13b1a71e7bb0e339fac63 )
-)
-game (
-	name "The Gauntlet (Colourmatic)"
-	description "The Gauntlet (Colourmatic)"
-	year 1982
-	manufacturer "Colourmatic"
-	rom ( name "gauntletthe.p" size 14411 crc ae7d6fec md5 b0f5118cdb2d11510ae8a9f6cd735225 sha1 4b1ad35595a0ddd772a3facc1f0c57499030d69a )
-	rom ( name "GauntletThe.tzx" size 14643 crc 7de2e0a3 md5 90c561d24d267dd43e349eed180fe51d sha1 49e714e58e9725925b28f8e17d90c708961064b5 )
-)
-game (
-	name "The Gauntlet (PSS) (PSS)"
-	description "The Gauntlet (PSS) (PSS)"
-	year 1984
-	manufacturer "Colourmatic"
-	rom ( name "gauntletthe(pss).p" size 14561 crc f8f47bbf md5 c0f5783184d967260c7d8e4a0b027850 sha1 27b343c7b034563ff4c5218ae6ffa8e190b7313f )
-	rom ( name "GauntletThe(PSS).tzx" size 14793 crc 076726dd md5 f4ad5284a8d7eca0e7e7e564131b3b6b sha1 3756c65ac420104c97a01317cdf156c2f412a2df )
-)
-game (
-	name "The Home Asset Manager (Timex)"
-	description "The Home Asset Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "homeassetmanagerthe.p" size 14886 crc 20b3e57e md5 9b8cb2a6f3192db3dd54c6de1ab895dc sha1 2bfd33290ac86115bbd77e00ca1617f3aab588ea )
-	rom ( name "HomeAssetManagerThe.tzx" size 15112 crc fd728104 md5 9ead11c52ed50477589a292313faa4b9 sha1 e19508787e6ede4ec4323df540dd7516b49b295d )
-)
-game (
-	name "The Home Improvement Planner (Timex)"
-	description "The Home Improvement Planner (Timex)"
-	year 1982
-	manufacturer "K. Frink"
-	rom ( name "homeimprovementplannerthe.p" size 15647 crc f3a473a6 md5 d966246149ab479d02fe07debb61fcd5 sha1 3536d7cd6538e0ce71b00cb9d8166303114d769d )
-	rom ( name "HomeImprovementPlannerThe.tzx" size 15871 crc 4e4df58c md5 15d4996825631a65404bcbebb7358e09 sha1 45e98db0f02643a37ed71b86a85042a331b9aac1 )
-)
-game (
-	name "The IRA Planner (Timex)"
-	description "The IRA Planner (Timex)"
-	year 1982
-	manufacturer "Vincent H. Chase"
-	rom ( name "IRAPlannerThe.tzx" size 16247 crc ad9f1b1c md5 73d76e80fe78e640708645b14e6dac88 sha1 74f585b9673b45307f59019f5d03e324ffedfb8c )
-)
-game (
-	name "The Knight's Quest (Phipps Associates)"
-	description "The Knight's Quest (Phipps Associates)"
-	year 1983
-	manufacturer "Mike Farley"
-	rom ( name "KnightsQuest.tzx" size 52909 crc 2bcedb3f md5 bb390c8d2bd1ced32c6e0a739daecdb3 sha1 ce182bf32766964ca43066727475eadbaa6a8d1a )
-)
-game (
-	name "The List Manager (Timex)"
-	description "The List Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "ListManagerThe.tzx" size 29918 crc 9df64f46 md5 7994115109d17648490efb35403448b0 sha1 f3fed91b2947d49a6d85c26797f46366ba614769 )
-)
-game (
-	name "The Loan/Mortgage Amortizer (Timex)"
-	description "The Loan/Mortgage Amortizer (Timex)"
-	year 1982
-	manufacturer "T. J. Software"
-	rom ( name "loanmortgageamortizerthe.p" size 10332 crc 08257da4 md5 418e25313141160cd04d7ac8693b5784 sha1 731aaa3f99ed2aa3f71d86858037f37c4b7af86b )
-	rom ( name "LoanMortgageAmortizerThe.tzx" size 10564 crc 8fd28637 md5 b0bf87937e33697f07d9b3d62d436e36 sha1 60988beeefb18dd293f49a3f91c6487d6245a554 )
-)
-game (
-	name "The Oracle's Cave (Doric Computer Systems)"
-	description "The Oracle's Cave (Doric Computer Systems)"
-	year 1981
-	manufacturer "C. T. Dorrel"
-	rom ( name "oraclescavethe.p" size 15953 crc 6135daad md5 01f7597a8eecf63967921a7dc63ff23e sha1 9358857b5b1be76ee495a089e07cd61bc44c6f48 )
-	rom ( name "OraclesCaveThe.tzx" size 16181 crc dea5489a md5 e148ddc58ccce3fc4f32be9b8abc2b63 sha1 752bb718f14e0a7e9da87fa958ccd0e366813a34 )
-)
-game (
-	name "The Stamp Collector (Timex)"
-	description "The Stamp Collector (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "stampcollectorthe.p" size 14449 crc 2a38e112 md5 9329dee03b6620d5000dd3ffc9643068 sha1 69daaab88aec472f12910bb0c3b56c188b5c05ad )
-	rom ( name "StampCollectorThe.tzx" size 14675 crc 702011b4 md5 a207294c88268520101a8b277fc1b882 sha1 e44f8118a5ef3c7ffc55a46d476cdb0f516179ce )
-)
-game (
-	name "The Starter (Timex)"
-	description "The Starter (Timex)"
-	year 1981
-	manufacturer "Sinclair"
-	rom ( name "Starter.tzx" size 2613 crc 00cb3c24 md5 d4de1b915c3a27215ae0bf6bfc60aa91 sha1 c2be276cf0f988df20707105f0fb5d6380d8e357 )
-)
-game (
-	name "The Stock Option Analyzer (Timex)"
-	description "The Stock Option Analyzer (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "stockoptionanalyzerthe.p" size 5533 crc 6a11fef8 md5 5172731b04549ea7e6fd487fcf0b2497 sha1 1fd0599c4cb2f3ec072d2f858f844eaac0b3ca12 )
-	rom ( name "StockOptionAnalyzerThe.tzx" size 5763 crc b829c9c3 md5 78ded4a1d1170ea521dff3ac3f302cca sha1 7691ee6f0ac6a103168684ac3cde78ec128c5e68 )
-)
-game (
-	name "Tomb of Dracula (Colour Inlay) (Felix Software)"
-	description "Tomb of Dracula (Colour Inlay) (Felix Software)"
-	year 1982
-	manufacturer "Felix Software"
-	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
-	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
-)
-game (
-	name "Tomb of Dracula (Moviedrome Video)"
-	description "Tomb of Dracula (Moviedrome Video)"
-	manufacturer "Moviedrome Video"
-	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
-	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
-)
-game (
-	name "Toolkit (Artic)"
-	description "Toolkit (Artic)"
-	manufacturer "Artic"
-	rom ( name "toolkit(artic).p" size 3582 crc d331e275 md5 19c29072c4cf201f0c6d80a34c487e1a sha1 1076da4a02f3e667d86ef0d40e644103768e71ed )
-	rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743b221 md5 7b527b5afdb2c55d5a0135b6faa68f98 sha1 049169deb7c4c760d79dd66fdf49172d5a77d776 )
-	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
-	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
-)
-game (
-	name "Toolkit (JRS Software)"
-	description "Toolkit (JRS Software)"
-	year 1982
-	manufacturer "Paul Holmes"
-	rom ( name "toolkit(jrs).p" size 2094 crc 9de785fd md5 ddfabe0545708752dc9947c12b0691dd sha1 45c020c2381e691e42385d005e496a7032c72b0e )
-	rom ( name "Toolkit(JRS).tzx" size 2318 crc 5c378f0f md5 c16ab5e0f0a83c954596a61278865a60 sha1 2121e140989dc586810bec4e1399de1007924286 )
-)
-game (
-	name "Toolkit (Sinclair Research)"
-	description "Toolkit (Sinclair Research)"
-	manufacturer "Artic"
-	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
-	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
-)
-game (
-	name "Trace (Texgate)"
-	description "Trace (Texgate)"
-	year 1983
-	manufacturer "Texgate"
-	rom ( name "trace.p" size 3248 crc 347a23e2 md5 588baf432b5f22295d6e8347b8e12f9b sha1 5b5fb4641de0cecee592944b7991cad5514c3f69 )
-	rom ( name "Trace.tzx" size 3474 crc b43432d2 md5 ba0bc19769d99d42e22475e2ca5c5d76 sha1 68ea27c33ee7b25628862ebd51bf07b716aa0d57 )
-)
-game (
-	name "Trader (Flap-fronted box) (Pixel Productions)"
-	description "Trader (Flap-fronted box) (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
-)
-game (
-	name "Trader (Pixel Productions)"
-	description "Trader (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader(Jewel).tzx" size 49639 crc 01e4ec2a md5 f0837cbfe6ac9168b3264aac3c21857d sha1 0082993bf62f04b69581990f052786daeea5620c )
-)
-game (
-	name "Trader (Quicksilva)"
-	description "Trader (Quicksilva)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
-)
-game (
-	name "Traffic (Loriciels)"
-	description "Traffic (Loriciels)"
-	year 1984
-	manufacturer "M Bouat"
-	rom ( name "traffic.p" size 6800 crc b40d7fa0 md5 66919861847fb1dae81487de697b1c74 sha1 0d91bd4b6f1abaec8882b2b360e144ef2a523137 )
-	rom ( name "Traffic.tzx" size 7030 crc be09c247 md5 2f644a8598a84813fdc38bbab38d080f sha1 44626d460f9c918c4bc9e0611737b50215c73a3c )
-)
-game (
-	name "Tutor (German) (Artic)"
-	description "Tutor (German) (Artic)"
-	year 1983
-	manufacturer "S. and J. Mitchell"
-	rom ( name "tutorgerman.p" size 13643 crc 1812f460 md5 a0c9d577d010f7d36f52f0e46fafca4c sha1 e0a880b515f960cf65e76ea4eacaed3326f7ea1c )
-	rom ( name "TutorGerman.tzx" size 13869 crc 44ddecba md5 c14b69f2223528031a15c8ec638ad941 sha1 058f24ef7be7494a90cd9799cd68b07e78169b95 )
-)
-game (
-	name "Tutor (Spanish) (Artic)"
-	description "Tutor (Spanish) (Artic)"
-	year 1983
-	manufacturer "S. and J. Mitchell"
-	rom ( name "tutorspanish.p" size 14993 crc 822e1b3e md5 38d6e26acb7d0f937ac92deade6ecfb1 sha1 88a4e1152cc0a92a3539a21c11a8ac227915b529 )
-	rom ( name "TutorSpanish.tzx" size 15219 crc 4d62869a md5 02068afec8b6f9c2875acf822951af83 sha1 e12aabea86ff2542821bd04cdf6e2868f1d3f5d7 )
-)
-game (
-	name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-	description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-	year 1982
-	manufacturer "Informatique Service Logiciels"
-	rom ( name "tyrannosaurerex.p" size 11506 crc b4ba768a md5 1319f6e2e899b6611fc24443ef13cd9b sha1 7c5172140b9f208b40357c28f348dca23f8ae1a8 )
-	rom ( name "TyrannosaureRex.tzx" size 11728 crc 5300e4d1 md5 5660c77dbaaae1c8e4fe7f18380b03f6 sha1 cb0caa82180a19407cd5e850ca88ca33e12b8efc )
-)
-game (
-	name "Tyrant of Athens (Lothlorien)"
-	description "Tyrant of Athens (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "tyrantofathens.p" size 12848 crc 00039ed3 md5 40c8cfd3ebeb9510f04115b34be32097 sha1 347c589d6d9a22794f863d6e61be0ce8c31ec485 )
-	rom ( name "TyrantOfAthens.tzx" size 13068 crc fc3fd4f8 md5 c3f5e5d0f379fe1529a27596a8d5b13f sha1 882b644962f09d68bc813563478d773c3a07115b )
-)
+
 game (
 	name "U-Bend"
 	description "U-Bend (2015) - Bob's interpretation of a Pipe-Mania game, with 36 unique levels."
 	rom ( name "UBend.p" size 14905 crc c537e261 md5 1d648c9042117e6cc47e9293d66aec0c sha1 17c49e4ac9179ed0d08c18c671f3db5343bad3cc )
+	manufacturer "Bob Smith"
+	year "2015"
 )
-game (
-	name "UDG (dK'tronics)"
-	description "UDG (dK'tronics)"
-	year 1981
-	manufacturer "dK'tronics"
-	rom ( name "udg.p" size 7928 crc a4259b70 md5 e9fdd20a2bb40d5b1d6d356e1b34793a sha1 7c2656d8cbd5427f5e464a5108f82ec84c539706 )
-	rom ( name "UDG.tzx" size 8150 crc 66a2453f md5 76f87a79206c9fc82e5127b7e94c2d6f sha1 0fefc639d3c9a6c2ed2a5d994f94ee0691e0dca5 )
-)
-game (
-	name "UFO (Protek)"
-	description "UFO (Protek)"
-	year 1983
-	manufacturer "Protek"
-	rom ( name "ufo.p" size 5158 crc 4e3f3226 md5 318f5420747069feb32f65e008b84a61 sha1 f4e7a1691ad0af71b26a9d1bcc36e3155814100a )
-	rom ( name "UFO.tzx" size 5380 crc 6b8cbcec md5 eac2815189bdb98a886b8f6739b4f188 sha1 f9bd4f690cb67fa718154cb9f07d63e8103a8c4f )
-)
-game (
-	name "UFO + 3D Maze (Babtech)"
-	description "UFO + 3D Maze (Babtech)"
-	year 1982
-	manufacturer "Babtech"
-	rom ( name "UFOAnd3DMaze.tzx" size 13279 crc cc63dfdf md5 90efa80ff6a2bd4ca39af581f1cb43a4 sha1 07a8d839b7202b3846fd8f1f84025000fb222f58 )
-)
-game (
-	name "Variance Analyzer (Zeta Software)"
-	description "Variance Analyzer (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "varianceanalyzer.p" size 8185 crc 73023b9a md5 72fbc8622939ac385b41dc3355b6d4c9 sha1 01535d36d01908855e4530c3077c6b774e893ce8 )
-	rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90a5774a md5 5237031b0a92f415c5ac347d60fd5d3e sha1 a429c8165b8be52791c99e5da26a84758a4c508b )
-)
-game (
-	name "Vector Mathematics (W. H. Smith)"
-	description "Vector Mathematics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "vectormathematics.p" size 11849 crc a13c22de md5 7f44adcd2eab5fa11a948bad8677e102 sha1 8a75f82fd30681bf8d557e03babc165c0f64567c )
-	rom ( name "VectorMathematics.tzx" size 12101 crc c33b86ba md5 4ce4bf8556a215e4d1528e0adc8de3c9 sha1 b82230bcc7f57f7b1f12720d82440031135be44b )
-)
-game (
-	name "Video Graffiti (AGF Hardware)"
-	description "Video Graffiti (AGF Hardware)"
-	year 1982
-	manufacturer "AGF Hardware"
-	rom ( name "videograffiti.p" size 5033 crc 4b37557f md5 521067db79cb6f937b5cf2e2d0662f15 sha1 45996efa5157865159c613ca49dc1f54402e3c7b )
-	rom ( name "VideoGraffiti.tzx" size 5263 crc dd2ecb00 md5 7ea6fb6995eae21a6731a7c61f7fe91c sha1 cf2e6cee862cc503be44bf2e6621a2e8d005c521 )
-)
-game (
-	name "Video-Ad (Video Software)"
-	description "Video-Ad (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "VideoAd.A.tzx" size 15281 crc 42136adc md5 baef4c10ef4e5d71498c31e5d2197f64 sha1 c2409cd598ce050d622eb8850e21d74d709060eb )
-	rom ( name "videoad.p" size 15049 crc abc19f74 md5 209beec2010448bb63643842df41793d sha1 beebc6bc78805b1bb6328d518aab9cff70b2a3a2 )
-)
-game (
-	name "Video-Map (Video Software)"
-	description "Video-Map (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "VideoMap.A.tzx" size 15713 crc b76622dc md5 86528f5577970284c231b5048ad5f669 sha1 86d292def89f2cd01bdf677f50abdb18002507a6 )
-	rom ( name "videomap.p" size 15479 crc f37cc7c7 md5 ca144229c898e0fbedf4c974ced0fe56 sha1 3791b93f30fe410716efdb3d9d345ff803973d28 )
-)
-game (
-	name "Video-Plan (Video Software)"
-	description "Video-Plan (Video Software)"
-	manufacturer "Video Software"
-	rom ( name "VideoPlan.A.tzx" size 15425 crc 849e21dc md5 23e1f6eed1029f7433286c3682ccff69 sha1 fffa47475a0634fc9859212e5a309603d922d258 )
-	rom ( name "videoplan.p" size 15189 crc fd242331 md5 260e9496c1bd1cb40a6095f04e0bbec2 sha1 2cb0a66c7aa506061fe621a53ee0bc7f143b9988 )
-)
-game (
-	name "Video-View (Video Software)"
-	description "Video-View (Video Software)"
-	manufacturer "Video Software"
-	rom ( name "videoview.p" size 13859 crc 53eca8e2 md5 e02361e6a92651a25ca5f0f5cac3c408 sha1 bdc28fc5964960f3159a8bd08db7b3ded64eca98 )
-	rom ( name "VideoView.tzx" size 14095 crc f5fdb04b md5 fd38379fc882828484b0a1e7fac02a4d sha1 abadd8bd7a829c778d6fbf1d4f394025cd1b7c58 )
-)
-game (
-	name "Viewtext (U.S. release) (Bug Byte)"
-	description "Viewtext (U.S. release) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "viewtext(us).p" size 12535 crc 4a6de687 md5 a9edbdb5e0f43efc83bd3233ed8122ea sha1 9c9999f8daeffd8d6f9f4234548c665c0d2d18a5 )
-	rom ( name "Viewtext(US).tzx" size 12767 crc 83f14397 md5 7ab7ff7c1b3baebcfdb31632abe00646 sha1 eb0996ddb294a42c133b0c301958bdaa3b5f4a1a )
-)
+
 game (
 	name "Virus"
 	description "Virus (2010) - A very playable and extremely polished top-down shoot'em up, making the most of the machine's limitations."
 	rom ( name "virus.p" size 16164 crc 9495a62e md5 2ee3b625a6481026c9d00a7da43c8fd1 sha1 0f7a62fa0d575d595857aafdefc78b33a207be91 )
+	manufacturer "Bob Smith"
+	year "2010"
 )
-game (
-	name "Volcanic Dungeon (Carnell)"
-	description "Volcanic Dungeon (Carnell)"
-	year 1982
-	manufacturer "Carnell Software"
-	rom ( name "volcanicdungeon.p" size 16234 crc bdcc9896 md5 801e5cd018f555198867d3f989033b24 sha1 503c8cfd4994440a3662fbce25d46b000887056a )
-	rom ( name "VolcanicDungeon.tzx" size 16482 crc c6f44894 md5 60210e10f6d239cddaffe65b6a3911c8 sha1 6275899b3b7849a97ca8ea869d2bc5806522ae9a )
-)
-game (
-	name "VU-CALC (Sinclair Research)"
-	description "VU-CALC (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "vu-calc.p" size 5551 crc 85195a78 md5 5b833077456f266abbf68ca295a60ee1 sha1 19280c9645a23ffbd53818889c4899bd00d29d29 )
-	rom ( name "VU-CALC.tzx" size 5781 crc 221479df md5 cb3925e52d2afa1c3f93cbafeb2443fe sha1 50275ce9c48f4f3533899a00c5291bdade4a1efe )
-)
-game (
-	name "VU-CALC (Timex)"
-	description "VU-CALC (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "vu-calc(timex).p" size 5549 crc 294a26c8 md5 5df9f5bb28e55cd1bb0e8eae025c38bc sha1 ce80bfee2434761babbfb0aa2b204b2cdb70c76c )
-	rom ( name "VU-CALC(Timex).tzx" size 5779 crc 3db82474 md5 ac03e37dc2013d571c352ad8fa3ee69d sha1 d1533151dfecf9614c55551e0d6bbab85bce9c3c )
-)
-game (
-	name "Warlord (Lothlorien)"
-	description "Warlord (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "warlord.p" size 15659 crc 5b5b6fbb md5 0d8e945e8cdf72f737d2848cb35ef853 sha1 e8fe374088097adb86b658e54a4bc05208627ae5 )
-	rom ( name "Warlord.tzx" size 15879 crc 9bff8537 md5 1f8271889f8e1f381c60707a0d10621b sha1 dee7757fc095d4de68efcd4147777e0cbbad8424 )
-)
-game (
-	name "Winged Avenger (Work Force)"
-	description "Winged Avenger (Work Force)"
-	year 1982
-	manufacturer "Work Force"
-	rom ( name "wingedavenger.p" size 3760 crc ec61facb md5 abb4ab208952c4f184769683545b68e8 sha1 ef6259d87f68c3882aecb6bd47ef0b99a6dbe2a9 )
-	rom ( name "WingedAvenger.tzx" size 4004 crc 18536d36 md5 8d6e49676509ae0666cf832b8be958b1 sha1 b3ecbf77bb7d691bd1b973ede3774bf3a54a1494 )
-)
-game (
-	name "Word Processor (Alan's Recordings)"
-	description "Word Processor (Alan's Recordings)"
-	manufacturer "Alan D. Went"
-	rom ( name "WordProcessor.A.tzx" size 12384 crc c1f41d1c md5 668f2df5ba976dda0e79405a1c3b0353 sha1 4f2e76139efb5a07b443c5495636bcbb42489241 )
-)
-game (
-	name "Word Test (Mindware)"
-	description "Word Test (Mindware)"
-	year 1982
-	manufacturer "Christopher Jones"
-	rom ( name "WordTest.1.WordTest.tzx" size 1133 crc e12825a4 md5 1d78c945fe6ed7c191f0016e26c4961b sha1 a17549ce398aa7c4955e6a691fd27dbce089db4a )
-	rom ( name "wordtest.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
-)
-game (
-	name "World Cup Football (Test your knowledge of) (M. A. Smith)"
-	description "World Cup Football (Test your knowledge of) (M. A. Smith)"
-	year 1982
-	manufacturer "M. A. Smith"
-	rom ( name "worldcupfootball.p" size 10439 crc 5647eb5e md5 c08c7f4881310b8e3ad0c336ca996965 sha1 80b894c252d6185362018b1405d4868484cd0198 )
-	rom ( name "WorldCupFootball.tzx" size 10657 crc 685d01ce md5 f603bc86bbd22e511e7628a9209c3838 sha1 d081ccd8b759a2866bff5676a112481bb73d5f88 )
-)
-game (
-	name "Zac-Man (Macronics)"
-	description "Zac-Man (Macronics)"
-	manufacturer "Macronics"
-	rom ( name "zacman.p" size 6881 crc 261a596b md5 cd301f8807f261d005a0f5e0a5f8e1b3 sha1 1c8cb9858647e86a3be82467a6da6a04a4a40d15 )
-	rom ( name "ZacMan.tzx" size 7111 crc 76fca436 md5 c33deb5191e85bcaa942a92f184236c7 sha1 e4271947dfab4c3eeb64a5927cda4d25445a0e53 )
-)
-game (
-	name "Zaraks (Computer Rentals)"
-	description "Zaraks (Computer Rentals)"
-	year 1983
-	manufacturer "Richard Taylor"
-	rom ( name "zaraks.p" size 3695 crc 733e3147 md5 f41780fbd2b777457afbdbacf838c2fb sha1 46a79fa15abf021d05e323b36629dcab80e84e72 )
-	rom ( name "Zaraks.tzx" size 3923 crc 4466c390 md5 46d8771cf8578edcf534505127a3735d sha1 d4d0575f849ed626a6d2b02cc3d64660980694c5 )
-)
-game (
-	name "Zombies/Sword of Peace (Artic)"
-	description "Zombies/Sword of Peace (Artic)"
-	manufacturer "Artic"
-	rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 cf95266460228f0be0ec5cd944051fca sha1 519d3115b5ceb75b61dff442a927be851fb0ca96 )
-)
-game (
-	name "Zuckman (Black inlay) (DJL Software)"
-	description "Zuckman (Black inlay) (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "zuckman(alt).p" size 9939 crc a57caafa md5 b57a30d83b200790bccf55ef9959aaa0 sha1 bf63e2441fcfad7c72c8e8bded65f9d3704d85ed )
-	rom ( name "Zuckman(Alt).tzx" size 10169 crc 886fa5b4 md5 82570cafb6bae5e05cf474c69c5abf8b sha1 87f7870077134b24dfc9bab9e406762bd7ff6d04 )
-)
-game (
-	name "Zuckman (White inlay) (DJL Software)"
-	description "Zuckman (White inlay) (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "zuckman.p" size 9939 crc e518a2bd md5 4d40c31b628fca5ed079f992e8ae2d24 sha1 30720d6d3af16aed257832988218f8ec3f002765 )
-	rom ( name "Zuckman.tzx" size 10169 crc c80badf3 md5 5b98d152d8a4ead841a65716f68f7dd6 sha1 e212c3315d69861422dee61af487f6729568520a )
-)
-game (
-	name "ZX Action Pack (Axis)"
-	description "ZX Action Pack (Axis)"
-	year 1982
-	manufacturer "Axis"
-	rom ( name "ZXActionPack.tzx" size 4677 crc f5f95245 md5 7e8c4e96f560ce731ae5d167009cc947 sha1 a97dbf23ee4788951617cc26e8bbd2987d3a4cd6 )
-)
-game (
-	name "ZX Assembler (Artic)"
-	description "ZX Assembler (Artic)"
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
-)
-game (
-	name "ZX Assembler (International Publishing and Software Inc.)"
-	description "ZX Assembler (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton (Artic)"
-	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
-)
-game (
-	name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-	description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembler(mono).p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler(Mono).tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
-)
-game (
-	name "ZX Assembleur (French) (Artic)"
-	description "ZX Assembleur (French) (Artic)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembleur.p" size 8963 crc d0d72bdc md5 b085ecfb9d97d32fc9eeb0fe94a8629e sha1 1fe43e6c0e7dd3c33bff97b7246fb5172d5aa892 )
-	rom ( name "ZXAssembleur.tzx" size 9197 crc aa532026 md5 7b58c9bfe54c57cb8080441bea91e7ec sha1 02a75242aabfbfa1d233b134df53727d5b8f597b )
-)
-game (
-	name "ZX Asteroids (Electric Pencil Company)"
-	description "ZX Asteroids (Electric Pencil Company)"
-	year 1982
-	manufacturer "Robert J. Wray"
-	rom ( name "zxasteroids.p" size 6054 crc bc47cff8 md5 57b3ec022dec0b1796aa7c6fadcd8f35 sha1 98e75c5767925cd515a10b88f731181caa84b337 )
-	rom ( name "ZXAsteroids.tzx" size 6280 crc c92d5c86 md5 f3e15eefe198558ffb618f9b005aa063 sha1 bc223f7b59f8ba07d7faf1da62f5a408034c568c )
-)
-game (
-	name "ZX Bug (International Publishing and Software Inc.)"
-	description "ZX Bug (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Artic (?)"
-	rom ( name "zxbug(ips).p" size 5350 crc af2c11ca md5 70354bfa74200e4578f92afc927db38b sha1 92827b6cb5ab8c7c64127c700c20c36902676cb4 )
-	rom ( name "ZXBug(IPS).tzx" size 5576 crc f8959e82 md5 2d051b4f0218c4c78d897ce2a851fe6d sha1 446c92783f64ea88a3faf3f0d5338223995d99a5 )
-)
-game (
-	name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-	description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "zxbug.p" size 5350 crc 2859b9eb md5 2766880aac6ae3b92031aaa2737af2ec sha1 4030b892fbb1906fe97ab601a37f9d4ffbf52a30 )
-	rom ( name "ZXBug.tzx" size 5572 crc b77b6a0d md5 c5fadbc61693ecca4761e523d2024999 sha1 5f513d59c871aa94dd8d1c1919fea0e8d5aae806 )
-)
-game (
-	name "ZX Chess I (Black inlay) (Artic)"
-	description "ZX Chess I (Black inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessi(black).p" size 14119 crc cce17d9c md5 2aa8d6a1b52211893f7a7264cff2bc1a sha1 ceca1c8f7719afe71d991a073a88561fcda27ae8 )
-	rom ( name "ZXChessI(Black).tzx" size 14337 crc 98f8fd30 md5 f2ee420566092a3ecd4d82f532bc98de sha1 b2ee8fb73779fc8b13b1bec533e59d762f6f871f )
-)
-game (
-	name "ZX Chess II (Artic)"
-	description "ZX Chess II (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
-	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
-)
-game (
-	name "ZX Chess II (Black inlay) (Artic)"
-	description "ZX Chess II (Black inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
-	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
-)
-game (
-	name "ZX Chess II (Improved) (Artic)"
-	description "ZX Chess II (Improved) (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "zxchessii(improved).p" size 14096 crc 16e86ce7 md5 19d6e472a1121ea8d28cf0b79eef739d sha1 585fce3fb637abd4783f907f24d6945d9472b7e7 )
-	rom ( name "ZXChessII(Improved).tzx" size 14326 crc 60bbdc66 md5 00f547bd9654a6dcd024639c91152471 sha1 a4238332fe59d8e4e7048069cb6e26c0b357c16d )
-)
-game (
-	name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-	description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "zxchessii(ips).p" size 14096 crc 95534f49 md5 288fedccf17c6d1ec8312c219fe1398e sha1 df54149f4ed916f7b804a8e0b8e34f790505f7c0 )
-	rom ( name "ZXChessII(IPS).tzx" size 14326 crc e300ffc8 md5 489b56232d78bbeebdb69f4cc5fcc320 sha1 d06522009c0438e7e201611c1ec10e17650dbf39 )
-)
-game (
-	name "ZX Forth (Artic)"
-	description "ZX Forth (Artic)"
-	manufacturer "Artic Computing"
-	rom ( name "ZXForth.tzx" size 20567 crc 587d765f md5 421ddc790c350146af56d1683d3cf2b6 sha1 63c6e3cd88655b30cef4afcdf4fcab959210047f )
-)
-game (
-	name "ZX Forth (International Publishing and Software Inc.)"
-	description "ZX Forth (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "ZXForth(IPS).tzx" size 12455 crc 73e4bf92 md5 408a2ad80923d4e802a4529c8facb917 sha1 5cd85e8a39cb6151c243b4d83dfaf88a4f23c3bc )
-)
-game (
-	name "ZX Othello (Moi)"
-	description "ZX Othello (Moi)"
-	year 1982
-	manufacturer "Moi"
-	rom ( name "Othello(Moi).tzx" size 12809 crc 96eeab64 md5 2b76c39d66873cfa8959cebdd71d5cec sha1 78f78e57bf940d87d020c39aa4218b273f612313 )
-)
-game (
-	name "ZX Pro/File (Thomas B. Woods)"
-	description "ZX Pro/File (Thomas B. Woods)"
-	year 1983
-	manufacturer "Thomas B. Woods"
-	rom ( name "zxprofile.p" size 16071 crc 73f67b5b md5 e0021b805cbae2655a4158128931035d sha1 9ccb69ea8ef5d613440720d63e84e67675a4614f )
-	rom ( name "ZXProFile.tzx" size 16291 crc 5d5146cf md5 64b39d80729e025fad4828f378cc8032 sha1 214faff9ecc28e7d20e229554bfaae88a8b23b98 )
-)
-game (
-	name "ZX-Compiler (Silversoft)"
-	description "ZX-Compiler (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "zxcompiler.p" size 6931 crc f25627c4 md5 8603e97d1fe5548927e829fd2486f5a7 sha1 1ae703f1d6e47a4f6c3a07f0c5a11c233562782f )
-	rom ( name "ZXCompiler.tzx" size 7163 crc 491041a6 md5 bb0497bb6eeea52b39eb7e189f55728c sha1 09cecbec3370cfd1ff77e316c69661132f2e932f )
-)
-game (
-	name "ZX-MC (Picturesque)"
-	description "ZX-MC (Picturesque)"
-	manufacturer "Picturesque"
-	rom ( name "zxmc.p" size 3555 crc de00007d md5 1fe46c4d47a32b6c7b77144987a6c753 sha1 8897d32731370314da8bae6c4e8ae56761e4b3aa )
-	rom ( name "ZXMC.tzx" size 3781 crc bad36aef md5 a9804be70b200a01d551198de5d13e70 sha1 9edc5c21e1edd96e1a733908d9e7d39cec6df85e )
-)
-game (
-	name "ZX-Sideprint (Microsphere)"
-	description "ZX-Sideprint (Microsphere)"
-	year 1982
-	manufacturer "Microsphere"
-	rom ( name "zxsideprint.p" size 1941 crc db6371df md5 d263455884fa102d245f3109c9a66a2f sha1 869334c4250219aa8e6fcf6752d2eba5f6aa7e69 )
-	rom ( name "ZXSideprint.tzx" size 2175 crc 5f320b4a md5 d990bb98194f1a992e902aaaec9c3fbb sha1 6965f265cbfca8f6813f698be70ed0e709c59632 )
-)
+
 game (
 	name "ZXagon"
 	description "ZXagon (2014) - Bob's interpretation of Terry Cavanagh's masterpiece 'Super Hexagon'."
 	rom ( name "ZXagon.p" size 15336 crc d6784677 md5 4a7f14d7f0d4918ca48c028ae151ccee sha1 59dae098079f00c3e72ec4647ccbd2ed99b979f1 )
-)
-game (
-	name "ZXAS (Bug Byte)"
-	description "ZXAS (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
-)
-game (
-	name "ZXAS (Gladstone) (Gladstone Electronics)"
-	description "ZXAS (Gladstone) (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "zxas(ge).p" size 5619 crc 850bab49 md5 7c622f096ad94f4201922e7cdea35c67 sha1 0b758fdb9bcfc94d9b37f743f78075595563c529 )
-	rom ( name "ZXAS(GE).tzx" size 5843 crc a448e4ba md5 beebbc4f4b2262f2e2c4aa3f45a62c69 sha1 e09abff8f1c771b7e1ace6b6612eb99dfa539654 )
-)
-game (
-	name "ZXAS (Monochrome) (Bug Byte)"
-	description "ZXAS (Monochrome) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
-)
-game (
-	name "ZXAS (Printed instructions) (Bug Byte)"
-	description "ZXAS (Printed instructions) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
-)
-game (
-	name "ZXAS (Typed Inlay) (Bug Byte)"
-	description "ZXAS (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
-)
-game (
-	name "ZXAS (Yellow) (Bug Byte)"
-	description "ZXAS (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
-)
-game (
-	name "ZXDB (Bug Byte)"
-	description "ZXDB (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
-)
-game (
-	name "ZXDB (Typed Inlay, black) (Bug Byte)"
-	description "ZXDB (Typed Inlay, black) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
-)
-game (
-	name "ZXDB (Typed Inlay, blue) (Bug Byte)"
-	description "ZXDB (Typed Inlay, blue) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
-)
-game (
-	name "ZXDB (Yellow) (Bug Byte)"
-	description "ZXDB (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
-)
-game (
-	name "ZXM Sound Box Super Editor (Timedata)"
-	description "ZXM Sound Box Super Editor (Timedata)"
-	year 1983
-	manufacturer "Timedata"
-	rom ( name "zxmsupereditor.p" size 2473 crc 37830a34 md5 c4a52e25b43580685f277856cf85ce72 sha1 1d030fe2bee1c42635299e7d0f925f5adb4582a7 )
-	rom ( name "ZXMSuperEditor.tzx" size 2693 crc 989424d1 md5 498e30b4cfd9e0e0d65df71e64fff20c sha1 9af273026fbd076097effee86e09a9f07d58f1fc )
-)
-game (
-	name "ZXTK (Bug Byte)"
-	description "ZXTK (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
-)
-game (
-	name "ZXTK (Printed instructions) (Bug Byte)"
-	description "ZXTK (Printed instructions) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
-)
-game (
-	name "ZXTK (Yellow) (Bug Byte)"
-	description "ZXTK (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+	manufacturer "Bob Smith"
+	year "2014"
 )


### PR DESCRIPTION
This makes the DAT one that is recognized by most of the prevailing programs out there for management.
Notable changes:
- ~Removed duplicate set names by combining ones with the same name~
- Removed instances of `:` and `/` from set names (reserved path characters that can't be used)
- ~Automatic alphabetization of the DAT~
- Fixed duplicate set names by appending file type