### PR TITLE
Add size field to HACX (crc: b9a93237)

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -321,7 +321,7 @@ game (
 game (
 	name "HACX"
 	description "HACX"
-	rom ( name HACX.WAD crc b9a93237 md5 1511a7032ebc834a3884cf390d7f186e sha1 dc6df745e342eaea325677a40184e10cbc6629d7 )
+	rom ( name HACX.WAD size 21951805 crc b9a93237 md5 1511a7032ebc834a3884cf390d7f186e sha1 dc6df745e342eaea325677a40184e10cbc6629d7 )
 )
 
 game (


### PR DESCRIPTION
Added size field to crc b9a93237 so rom managers are less likely to freak out about this file.