### PR TITLE
Add a `make build` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/libretro-super

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# libretro-database
+#
+# This file provides some install and building commands for libretro-database.
+#
+# make install
+#     Installs the needed files to the given DESTDIR and INSTALLDIR.
+#
+# make build
+#     Builds the RDB files using libretro-super.
+
 PREFIX := /usr
 INSTALLDIR := $(PREFIX)/share/libretro/database
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ libretro-super:
 	git clone https://github.com/libretro/libretro-super.git
 
 libretro-super/retroarch: libretro-super
-	cd libretro-super && ./libretro-fetch.sh retroarch
+	cd libretro-super && SHALLOW_CLONE=1 ./libretro-fetch.sh retroarch
 
 build: libretro-super/retroarch
 	rm -rf libretro-super/retroarch/media/libretrodb/dat

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,18 @@ install:
 
 test-install: all
 	DESTDIR=/tmp/build $(MAKE) install
+
+libretro-super:
+	git clone https://github.com/libretro/libretro-super.git
+
+libretro-super/retroarch: libretro-super
+	cd libretro-super && ./libretro-fetch.sh retroarch
+
+build: libretro-super/retroarch
+	rm -rf libretro-super/retroarch/media/libretrodb/dat
+	rm -rf libretro-super/retroarch/media/libretrodb/metadat
+	rm -rf libretro-super/retroarch/media/libretrodb/rdb
+	cp -rf dat metadat rdb libretro-super/retroarch/media/libretrodb
+	cd libretro-super && ./libretro-build-database.sh
+	rm -rf rdb
+	cp -rf libretro-super/retroarch/media/libretrodb/rdb .


### PR DESCRIPTION
To rebuild the `.rdb` files you can now just run `make build` from the project root.