### PR TITLE
vitaquake2: Add Quake II Database

### DIFF
--- a/dat/Quake II.dat
+++ b/dat/Quake II.dat
@@ -1,0 +1,34 @@
+clrmamepro (
+	name "Quake II"
+	description "Quake II"
+	version 2019.10.10
+	author "libretro"
+)
+
+game (
+	name "Quake II"
+	description "Quake II"
+  homepage "https://en.wikipedia.org/wiki/Quake_II"
+  developer "id Software"
+  genre "FPS"
+  users 1
+	releaseyear "1997"
+	releasemonth "12"
+	releaseday "9"
+	version "1.34"
+	rom ( name pak0.pak size 183997730 crc 6888136e md5 1ec55a724dc3109fd50dde71ab581d70 sha1 1dd586a3230d1ac5bfd34e57cc796000d4c252c2 )
+)
+
+game (
+	name "Quake II Demo"
+	description "Quake II Demo"
+  homepage "https://en.wikipedia.org/wiki/Quake_II"
+  developer "id Software"
+  genre "FPS"
+  users 1
+	releaseyear "1997"
+	releasemonth "12"
+	releaseday "9"
+	version "1.34"
+	rom ( name pak0.pak size 49951322 crc cdd535b6 md5 27d77240466ec4f3253256832b54db8a sha1 b86e8878a8e8706595ceebe88b3e6b4c1ba5bcab )
+)


### PR DESCRIPTION
This adds a Quake II database so that Quake II can be scanned and loaded through the menu.

@Rinnegatamante Mind reviewing these pak0.pak files? Unsure if they're the right files, but they seem to be loading correctly to me.