### PR TITLE
Rename BIOS.dat to System.dat

### DIFF
--- a/dat/System.dat
+++ b/dat/System.dat
@@ -1,7 +1,7 @@
 clrmamepro (
-	name "BIOS"
-	description "BIOS"
-	comment "BIOS files required by libretro, merged into one folder."
+	name "System"
+	description "System"
+	comment "System, firmware, or BIOS files used by libretro."
 	version "2019-07-21"
 	author "libretro"
 	homepage "http://github.com/libretro/libretro-database"


### PR DESCRIPTION
This represents libretro's system directory, not a bios or firmware directory.

Fixes #979