### PR TITLE
Added Doom64 and Doom64 Ex 2.5

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -183,7 +183,6 @@ game (
 	name "Doom 64 (2020)"
 	description "DOOM 64 (2020)"
 	rom ( name DOOM64.WAD size 15103284 crc cb10a53d md5 e16e17f59afe7b3297f53ebe7e9de815 sha1 ae363db8cd5645e1753d9bacc82cc0724e8e7f21 )
-	rom ( name DOOMSND.DLS size 3230114 crc 1eee229c md5 6a362600e661f425fa5e4d53fa5094a3 sha1 62267b6344468cd759be12365c2324618f783083 )
 )
 
 game (

--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -1,7 +1,7 @@
 clrmamepro (
 	name "Doom"
 	description "Doom"
-	version 2019.09.22
+	version 2020.03.22
 	author "Obiwantje, LodanZark, libretro"
 )
 
@@ -171,6 +171,20 @@ game (
 	name "Doom (v1.9) (Demo)"
 	description "Doom (v1.9) (Demo)"
 	rom ( name DOOM1.WAD size 4196020 crc 162b696a md5 f0cefca49926d00903cf57551d901abe sha1 5b2e249b9c5133ec987b3ea77596381dc0d6bc1d )
+)
+
+game (
+	name "Doom 64 Ex (v2.5)"
+	description "DOOM 64 EX (v2.5)"
+	rom ( name DOOM64.WAD size 8671616 crc 3b3e307d md5 e1f1c2bba2c1be41e22aa2e4d37d169e sha1 7656ddaa6d6ac405954d8b29946361a7114a1837 )
+	rom ( name DOOMSND.SF2 size 5429302 crc 03190b8e md5 51dfe2bd6d7f41c764a79893053cdffe sha1 e2fe47c504461cc88a683a798f2c9a20c43ce93a )
+)
+
+game (
+	name "Doom 64 (2020)"
+	description "DOOM 64 (2020)"
+	rom ( name DOOM64.WAD size 15103284 crc cb10a53d md5 e16e17f59afe7b3297f53ebe7e9de815 sha1 ae363db8cd5645e1753d9bacc82cc0724e8e7f21 )
+	rom ( name DOOMSND.DLS size 3230114 crc 1eee229c md5 6a362600e661f425fa5e4d53fa5094a3 sha1 62267b6344468cd759be12365c2324618f783083 )
 )
 
 game (

--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -177,7 +177,6 @@ game (
 	name "Doom 64 Ex (v2.5)"
 	description "DOOM 64 EX (v2.5)"
 	rom ( name DOOM64.WAD size 8671616 crc 3b3e307d md5 e1f1c2bba2c1be41e22aa2e4d37d169e sha1 7656ddaa6d6ac405954d8b29946361a7114a1837 )
-	rom ( name DOOMSND.SF2 size 5429302 crc 03190b8e md5 51dfe2bd6d7f41c764a79893053cdffe sha1 e2fe47c504461cc88a683a798f2c9a20c43ce93a )
 )
 
 game (


### PR DESCRIPTION
Doom64 can be found in the steam store https://store.steampowered.com/app/1148590/DOOM_64/ probably has same hashs as other platforms too.

Doom 64 EX 2.5 WAD can be generated by the tool with same name that can be found here: https://doom64ex.wordpress.com/downloads/
For that purpose it's required a valid N64 rom, in this case was used the no-intro "Doom 64 (USA) (Rev 1)" and "Doom 64 (USA)", which for some reason has  generated a wad with same hashs, but the European and Japanese version will a different hashs.