### PR TITLE
Add unity versions of doom wads

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -1,7 +1,7 @@
 clrmamepro (
 	name "Doom"
 	description "Doom"
-	version 2020.03.22
+	version 2020.04.12
 	author "Obiwantje, LodanZark, libretro"
 )
 
@@ -186,6 +186,12 @@ game (
 )
 
 game (
+	name "Doom II - Hell on Earth (Bethesda.net)"
+	description "Doom II - Hell on Earth (Bethesda.net)"
+	rom ( name DOOM2.WAD size 14603212 crc 62fd057f md5 97573aaf26957099ed45e61d81a0a1a3 sha1 f1b6ba94352d53f646b67c01d2da88c5c40e3179 )
+)
+
+game (
 	name "Doom II - Hell on Earth (BFG Edition)"
 	description "Doom II - Hell on Earth (BFG Edition)"
 	rom ( name DOOM2.WAD size 14691821 crc 927a778a md5 c3bea40570c23e511a7ed3ebcd9865f7 sha1 a59548125f59f6aa1a41c22f615557d3dd2e85a9 )
@@ -207,6 +213,12 @@ game (
 	name "Doom II - Hell on Earth (Tapwave Zodiac)"
 	description "Doom II - Hell on Earth (Tapwave Zodiac)"
 	rom ( name DOOM2.WAD size 14639397 crc 541a97c2 md5 9640fc4b2c8447bbd28f2080725d5c51 sha1 2cda310805397ae44059bbcaed3cd602f4864a82 )
+)
+
+game (
+	name "Doom II - Hell on Earth (Unity) (v1.1)"
+	description "Doom II - Hell on Earth (Unity) (v1.1)"
+	rom ( name DOOM2.WAD size 14685607 crc 22c291c8 md5 7895d10c281305c45a7e5f01b3f7b1d8 sha1 b723882122e90b61a1d92a11dcfcf9cbf95a407e )
 )
 
 game (
@@ -270,6 +282,12 @@ game (
 )
 
 game (
+	name "Doom II - No Rest for the Living (Unity)"
+	description "Doom II - No Rest for the Living (Unity)"
+	rom ( name NERVE.WAD size 3821966 crc ab68447f md5 4214c47651b63ee2257b1c2490a518c9 sha1 321e951f6cc6e9d51bc16eac53e0d001f0f3f338 )
+)
+
+game (
 	name "Final Doom - Evilution"
 	description "Final Doom - Evilution"
 	rom ( name TNT.WAD size 18195736 crc 903dcc27 md5 4e158d9953c79ccf97bd0663244cc6b6 sha1 9fbc66aedef7fe3bae0986cdb9323d2b8db4c9d3 )
@@ -289,6 +307,12 @@ game (
 )
 
 game (
+	name "Final Doom - Evilution (Unity)"
+	description "Final Doom - Evilution (Unity)"
+	rom ( name TNT.WAD size 18434452 crc 7a0117a3 md5 a6685de59ddf2c07f45deeec95296d98 sha1 503271390606ebded04a2cfaa1a4e249c0313a9d )
+)
+
+game (
 	name "Final Doom - The Plutonia Experiment"
 	description "Final Doom - The Plutonia Experiment"
 	rom ( name PLUTONIA.WAD size 17420824 crc 48d1453c md5 75c8cf89566741fa9d22447604053bd7 sha1 90361e2a538d2388506657252ae41aceeb1ba360 )
@@ -304,6 +328,12 @@ game (
 	name "Final Doom - The Plutonia Experiment (id Anthology)"
 	description "Final Doom - The Plutonia Experiment (id Anthology)"
 	rom ( name PLUTONIA.WAD size 18240172 crc 15cd1448 md5 3493be7e1e2588bc9c8b31eab2587a04 sha1 f131cbe1946d7fddb3caec4aa258c83399c21e60 )
+)
+
+game (
+	name "Final Doom - The Plutonia Experiment (Unity)"
+	description "Final Doom - The Plutonia Experiment (Unity)"
+	rom ( name PLUTONIA.WAD size 17421754 crc 7530bd6e md5 0b381ff7bae93bde6496f9547463619d sha1 54e27b5791fbc5677bf7e83c1de3a92ea3ef935b )
 )
 
 game (
@@ -556,6 +586,72 @@ game (
 )
 
 game (
+	name "SIGIL (Compatible Edition) (Unity)" 
+	description "SIGIL (Compatible Edition) (Unity)"
+	rom ( name "SIGIL.wad" size 4646543 crc 983c19a3 md5 94cd9ea558989c1eb681d5f02a2fe47e sha1 7ed2c2293daf8a6f3f39e7ed24d1446b9b28e473 )
+)
+
+game (
+	name "SIGIL (v1.0)" 
+	description "SIGIL (v1.0)"
+	rom ( name "SIGIL.wad" size 4473686 crc e74b2233 md5 f53ffc4fb89e966839bb8d20c632819a sha1 5e5241f49f0dbb7a6f6df3d46b494c1e163a2c53 )
+)
+
+game (
+	name "SIGIL (v1.1)"
+	description "SIGIL (v1.1)"
+	rom ( name "SIGIL.wad" size 4525740 crc 5a80c2cd md5 1fe9daa0e837c7452eb2f91aac2cc983 sha1 1d95e599a1587d1130bf24356a73b817ac2c1b57 )
+)
+
+game (
+	name "SIGIL (v1.2)"
+	description "SIGIL (v1.2)"
+	rom ( name "SIGIL_v1_2.wad" size 4639917 crc 8292a285 md5 427ca995600970abcd2efcc684a64c88 sha1 ca88fa5749e494af5a757866c14008c305428ab6 )
+)
+
+game (
+	name "SIGIL (v1.21)"
+	description "SIGIL (v1.21)"
+	rom ( name "SIGIL_v1_21.wad" size 4640210 crc f9216574 md5 743d6323cb2b9be24c258ff0fc350883 sha1 e2efdf379e1383c4e15c03de89063361897cd459 )
+)
+
+game (
+	name "SIGIL (v1.0) (Compatible Edition)"
+	description "SIGIL (v1.0) (Compatible Edition)"
+	rom ( name "SIGIL_COMPAT.wad" size 4468256 crc abaef919 md5 a775262ca0e423468196803b71a57a43 sha1 c7b52480221678f96daf8b8c34d08e05a4591704 )
+)
+
+game (
+	name "SIGIL (v1.1) (Compatible Edition)" 
+	description "SIGIL (v1.1) (Compatible Edition)"
+	rom ( name "SIGIL_COMPAT.wad" size 4483345 crc 4fa56fdb md5 c04912beab6aa82c114a19c976ec8c0d sha1 60641c2519ba95565c714de09b1cf1358c4905fd )
+)
+
+game (
+	name "SIGIL (v1.2) (Compatible Edition)" 
+	description "SIGIL (v1.2) (Compatible Edition)"
+	rom ( name "SIGIL_COMPAT_v1_2.wad" size 4633831 crc c2e2f76b md5 9285e9cc2dbd87d238baab37d700c644 sha1 90e02ee6fd023f6d62a64d71c05c4f00a841e7bd )
+)
+
+game (
+	name "SIGIL (v1.21) (Compatible Edition)" 
+	description "SIGIL (v1.21) (Compatible Edition)"
+	rom ( name "SIGIL_COMPAT_v1_21.wad" size 4634157 crc b7679050 md5 573f3f178c76709f512089ed15484391 sha1 b5e68950820b3a0385375dbace81376e73568207 )
+)
+
+game (
+	name "SIGIL Buckethead Music" 
+	description "SIGIL Buckethead Music"
+	rom ( name "SIGIL_SHREDS.wad" size 162146269 crc cf88488f md5 b424dcf46ae55a496c34ac37cce32646 sha1 efdc3b2255a50b1b058ac609044cbd5e36029bc4 )
+)
+
+game (
+	name "SIGIL Buckethead Music (Compatible Edition)" 
+	description "SIGIL Buckethead Music (Compatible Edition)"
+	rom ( name "SIGIL_SHREDS_COMPAT.wad" size 162146269 crc 8524df67 md5 343faa815928c58faa08939a4502d5d2 sha1 42a5034d76a4effb4a26194dbb90d6ee859e8374 )
+)
+
+game (
 	name "Strife"
 	description "Strife"
 	rom ( name VOICES.WAD size 27319149 crc cd12ebcf md5 082234d6a3f7086424856478b5aa9e95 sha1 ec6883100d807b894a98f426d024d22c77b63e7f )
@@ -624,9 +720,15 @@ game (
 )
 
 game (
-	name "Ultimate Doom, The (BFG Edition, Classic Complete) (PlayStation 3)"
-	description "Ultimate Doom, The (BFG Edition, Classic Complete) (PlayStation 3)"
+	name "Ultimate Doom, The (Bethesda.net, BFG Edition, Classic Complete) (PlayStation 3)"
+	description "Ultimate Doom, The (Bethesda.net, BFG Edition, Classic Complete) (PlayStation 3)"
 	rom ( name DOOM.WAD size 12474561 crc 3f646587 md5 e4f120eab6fb410a5b6e11c947832357 sha1 117015379c529573510be08cf59810aa10bb934e )
+)
+
+game (
+	name "Ultimate Doom, The (Unity) (v1.1)"
+	description "Ultimate Doom, The (Unity) (v1.1)"
+	rom ( name DOOM.WAD size 12468955 crc 346a4bfd md5 21b200688d0fa7c1b6f63703d2bdd455 sha1 08ab2507e1d525c4c06b6df4f6d5862568a6b009 )
 )
 
 game (
@@ -639,64 +741,4 @@ game (
 	name "Ultimate Doom, The (Xbox)"
 	description "Ultimate Doom, The (Xbox)"
 	rom ( name DOOM.WAD size 12538385 crc ff1ba733 md5 0c8758f102ccafe26a3040bee8ba5021 sha1 1d1d4f69fe14fa255228d8243470678b1b4efdc5 )
-)
-
-game (
-	name "SIGIL (v1.0)" 
-	description "SIGIL (v1.0)"
-	rom ( name "SIGIL.wad" size 4473686 crc e74b2233 md5 f53ffc4fb89e966839bb8d20c632819a sha1 5e5241f49f0dbb7a6f6df3d46b494c1e163a2c53 )
-)
-
-game (
-	name "SIGIL (v1.1)"
-	description "SIGIL (v1.1)"
-	rom ( name "SIGIL.wad" size 4525740 crc 5a80c2cd md5 1fe9daa0e837c7452eb2f91aac2cc983 sha1 1d95e599a1587d1130bf24356a73b817ac2c1b57 )
-)
-
-game (
-	name "SIGIL (v1.2)"
-	description "SIGIL (v1.2)"
-	rom ( name "SIGIL_v1_2.wad" size 4639917 crc 8292a285 md5 427ca995600970abcd2efcc684a64c88 sha1 ca88fa5749e494af5a757866c14008c305428ab6 )
-)
-
-game (
-	name "SIGIL (v1.21)"
-	description "SIGIL (v1.21)"
-	rom ( name "SIGIL_v1_21.wad" size 4640210 crc f9216574 md5 743d6323cb2b9be24c258ff0fc350883 sha1 e2efdf379e1383c4e15c03de89063361897cd459 )
-)
-
-game (
-	name "SIGIL (v1.0) (Compatible Edition)"
-	description "SIGIL (v1.0) (Compatible Edition)"
-	rom ( name "SIGIL_COMPAT.wad" size 4468256 crc abaef919 md5 a775262ca0e423468196803b71a57a43 sha1 c7b52480221678f96daf8b8c34d08e05a4591704 )
-)
-
-game (
-	name "SIGIL (v1.1) (Compatible Edition)" 
-	description "SIGIL (v1.1) (Compatible Edition)"
-	rom ( name "SIGIL_COMPAT.wad" size 4483345 crc 4fa56fdb md5 c04912beab6aa82c114a19c976ec8c0d sha1 60641c2519ba95565c714de09b1cf1358c4905fd )
-)
-
-game (
-	name "SIGIL (v1.2) (Compatible Edition)" 
-	description "SIGIL (v1.2) (Compatible Edition)"
-	rom ( name "SIGIL_COMPAT_v1_2.wad" size 4633831 crc c2e2f76b md5 9285e9cc2dbd87d238baab37d700c644 sha1 90e02ee6fd023f6d62a64d71c05c4f00a841e7bd )
-)
-
-game (
-	name "SIGIL (v1.21) (Compatible Edition)" 
-	description "SIGIL (v1.21) (Compatible Edition)"
-	rom ( name "SIGIL_COMPAT_v1_21.wad" size 4634157 crc b7679050 md5 573f3f178c76709f512089ed15484391 sha1 b5e68950820b3a0385375dbace81376e73568207 )
-)
-
-game (
-	name "SIGIL Buckethead Music" 
-	description "SIGIL Buckethead Music"
-	rom ( name "SIGIL_SHREDS.wad" size 162146269 crc cf88488f md5 b424dcf46ae55a496c34ac37cce32646 sha1 efdc3b2255a50b1b058ac609044cbd5e36029bc4 )
-)
-
-game (
-	name "SIGIL Buckethead Music (Compatible Edition)" 
-	description "SIGIL Buckethead Music (Compatible Edition)"
-	rom ( name "SIGIL_SHREDS_COMPAT.wad" size 162146269 crc 8524df67 md5 343faa815928c58faa08939a4502d5d2 sha1 42a5034d76a4effb4a26194dbb90d6ee859e8374 )
 )


### PR DESCRIPTION
Added the following:

Doom II - Hell on Earth (Unity) (v1.1)
Doom II - No Rest for the Living (Unity)
Final Doom - Evilution (Unity)
Final Doom - The Plutonia Experiment (Unity)
SIGIL (Compatible Edition) (Unity)
Ultimate Doom, The (Unity) (v1.1)

Doom II - Hell on Earth (Bethesda.net) <-- This is the DOS version included with Doom re release on Bethesda.net.  This version also comes with Doom Eternal.

I also renamed this:
Ultimate Doom, The (BFG Edition, Classic Complete) (PlayStation 3)
To this:
Ultimate Doom, The (Bethesda.net, BFG Edition, Classic Complete) (PlayStation 3)

The aforementioned version is also the DOS version included with Doom II re release on Bethesda.net.  This version also comes with Doom Eternal.