### PR TITLE
Clean up hacks (resolves #1040)

### DIFF
--- a/metadat/hacks/Nintendo - Game Boy Advance.dat
+++ b/metadat/hacks/Nintendo - Game Boy Advance.dat
@@ -3,18 +3,6 @@ clrmamepro (
     description "Hacks of Game Boy Advance games"
 )
 game (
-    name "Celeste Classic"
-    description "Celeste Classic by Matt Thorson and Noel Berry. GameBoy Advance port by JeffRuLz."
-    version "1.0"
-    developer "Matt Makes Games"
-    genre "Platformer"
-    releaseyear "2018"
-    releasemonth "1"
-    releaseday "28"
-    rom ( name "Celeste Classic (v1.0).gba" size 5416932 crc f79b0d53 md5 d5b7c99707098401f12f6e4dfac87c9f sha1 756f02396a150698e695ad4afd24445e2af70576 )
-    homepage "https://github.com/JeffRuLz/Celeste-Classic-GBA"
-)
-game (
     name "Magical Vacation (Japan) [T-En by magicalpatcher]"
     description "English translation by magicalpatcher version (1.0)"
     rom ( name "Magical Vacation (Japan).gba" size 9043968 crc 98fbbd9a md5 7bc82e72f6b9f734766f6cd9faf43e66 sha1 f928f9ca70ce76c19abbe50077f2c0d06efe6cfe )

--- a/metadat/hacks/Nintendo - Game Boy Advance.dat
+++ b/metadat/hacks/Nintendo - Game Boy Advance.dat
@@ -16,7 +16,7 @@ game (
 )
 game (
     name "Metroid - SR387 [Hack by OneOf99]"
-    description "Metroid - Zero Mission hack by OneOf99 (1.0)"
+    description "Metroid - Zero Mission hack by OneOf99 version (1.0)"
     rom ( name "Metroid - Zero Mission (USA).gba" size 16777216 crc fde1aa44 md5 ede03aaa4245932a88be3e5e411d5426 sha1 e32c8d9fdb24119f85d4c2ae3245d46cc9efb938 )
     patch "http://www.romhacking.net/hacks/4113/"
 )
@@ -27,27 +27,27 @@ game (
     patch "http://www.romhacking.net/translations/2035/"
 )
 game (
-    name "Pokemon - Liquid Crystal"
-    description "Pokemon Liquid Crystal B3.3.00512"
-    rom ( name "liquid-crystal-b3.3.00512.gba" size 16777216 crc 6A761D9F md5 e2cf937901114df0928ea29443525986 sha1 7acf9d4c14b570a375402cb4dd2619f910a8a45b )
+    name "Pokemon - Liquid Crystal Version [Hack by linkandzelda]"
+    description "Pokemon - Liquid Crystal Version by linkandzelda version (B3.3.00512)"
+    rom ( name "Pokemon - FireRed Version (USA, Europe).gba" size 16777216 crc 6A761D9F md5 e2cf937901114df0928ea29443525986 sha1 7acf9d4c14b570a375402cb4dd2619f910a8a45b )
     patch "https://www.pokemoncoders.com/pokemon-liquid-crystal-download/"
 )
 game (
-    name "Pokemon - Glazed"
-    description "Pokemon Glazed Beta 7"
-    rom ( name "Pokemon - Glazed B7.gba" size 33554432 crc 1288C0DD md5 6279166857cea1b52eb93543c6668ff1 sha1 df35172a17b62ebaf622790c6cd1e143b6647b33 )
+    name "Pokemon Glazed [Hack by Redriders180]"
+    description "Pokemon Glazed by Redriders180 version (8.6.3)"
+    rom ( name "Pokemon - Emerald Version (USA, Europe).gba" size 33554432 crc b56d1a8a md5 8060cbf18b8eff44be00daa1ffff0a90 sha1 9cd39ac0e9f43a4226af4acf4083c5f23ec0b40b )
     patch "https://www.pokemoncoders.com/pokemon-glazed/"
 )
 game (
-    name "Pokemon - Rijon Adventures"
-    description "Pokemon Rijon Adventures 2009 R1"
-    rom ( name "rijonadventures-b2009-r1.gba" size 33554432 crc 935ECB8B md5 7a866795d43ae1d0200c2c625b4c46ce sha1 ef8730be6f0626f63600722a45bf0a792135223f )
+    name "Pokemon rijonAdventures [Hack by Hiroshi Sotomura]"
+    description "Pokemon rijonAdventures by Hiroshi Sotomura version (2009 Beta Rev 1)"
+    rom ( name "Pokemon - FireRed Version (USA, Europe).gba" size 33554432 crc 935ECB8B md5 7a866795d43ae1d0200c2c625b4c46ce sha1 ef8730be6f0626f63600722a45bf0a792135223f )
     patch "https://www.gbahacks.com/2014/07/pokemon-rijonadventures.html"
 )
 game (
-    name "Pokemon - AshGray Version (USA)"
-    description "Pokemon - AshGray Version (USA) (Beta 4.5.3)"
-    rom ( name "Pokemon - AshGray Version (USA).gba" size 16777216 crc 10ef71a7 md5 92262059190c05a5615be6b98612fb14 sha1 1ee1557db1e4c2e0e94c6306efcc40506bc40cc9 )
+    name "Pokemon - AshGray Version [Hack by metapod23]"
+    description "Pokemon - AshGray Version by metapod23 version (Beta 4.5.3)"
+    rom ( name "Pokemon - FireRed Version (USA, Europe).gba" size 16777216 crc 10ef71a7 md5 92262059190c05a5615be6b98612fb14 sha1 1ee1557db1e4c2e0e94c6306efcc40506bc40cc9 )
     patch "https://www.pokecommunity.com/showthread.php?t=180722"
 )
 game (
@@ -113,25 +113,25 @@ game (
 game (
     name "Castlevania Aria of Sorrow Gebel Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Gebel Hack by caminopreacher version (1.0)"
-    rom ( name "Castlevania - Aria of Sorrow (USA).gba.gba" size 8388608 crc 317f5c4f md5 8df41935661e22ddc70e216bd6249216 sha1 48fbd3c3a0b0477160f82c19149841b6de271c75 )
+    rom ( name "Castlevania - Aria of Sorrow (USA).gba" size 8388608 crc 317f5c4f md5 8df41935661e22ddc70e216bd6249216 sha1 48fbd3c3a0b0477160f82c19149841b6de271c75 )
     patch "http://www.romhacking.net/hacks/4136/"
 )
 game (
     name "Castlevania Aria of Sorrow Zangetsu Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Zangetsu Hack by caminopreacher version (1.0)"
-    rom ( name "Castlevania - Aria of Sorrow (USA).gba.gba" size 8388608 crc 027d4b31 md5 fd0fa411a7c7722c752116beca243f27 sha1 7112dd9c55fd2d33cd5274dfdb71202e162cc1e2 )
+    rom ( name "Castlevania - Aria of Sorrow (USA).gba" size 8388608 crc 027d4b31 md5 fd0fa411a7c7722c752116beca243f27 sha1 7112dd9c55fd2d33cd5274dfdb71202e162cc1e2 )
     patch "http://www.romhacking.net/hacks/4130/"
 )
 game (
     name "Castlevania Aria of Sorrow Alfred Hack [Hack by caminopreacher]"
     description "Castlevania Aria of Sorrow Alfred Hack by caminopreacher version (1.0)"
-    rom ( name "Castlevania - Aria of Sorrow (USA).gba.gba" size 8388608 crc 9f88961f md5 7c5c06345e69eec96b13668e969177f8 sha1 4191b6d131e5307ccbd210df5fb39d7824e59355 )
+    rom ( name "Castlevania - Aria of Sorrow (USA).gba" size 8388608 crc 9f88961f md5 7c5c06345e69eec96b13668e969177f8 sha1 4191b6d131e5307ccbd210df5fb39d7824e59355 )
     patch "http://www.romhacking.net/hacks/4131/"
 )
 game (
     name "Castlevania Akatsuki no Rhapsody - ikusatatsu's castle [Hack by ikusatatsu_ushiromiya]"
-    description "Castlevania Aria of Sorrow Hack by ikusatatsu_ushiromiya version (1.04)"
-    rom ( name "Castlevania - Aria of Sorrow (USA).gba" size 8388608 crc 9dc7320c md5 854eb032c4d6f98d49fe817c78113173 sha1 0b0f551d3ad5b08f608ef264fb72ebffe43a2bbc )
+    description "Castlevania Akatsuki no Rhapsody - ikusatatsu's castle by ikusatatsu_ushiromiya version (1.21)"
+    rom ( name "Castlevania - Aria of Sorrow (USA).gba" size 8388608 crc 0e62b112 md5 90a92c962f81f634368d4dda17b7b4e8 sha1 3e58abda0e87962e251fa2987aa550b8123eac15 )
     patch "https://www.romhacking.net/hacks/3696/"
 )
 game (
@@ -148,55 +148,55 @@ game (
 )
 game (
     name "Shin chan - Aventuras en Cineland (Spain) [T-En by LeonarthCG]"
-    description "English translation by LeonarthCG (1.0)"
+    description "English translation by LeonarthCG version (1.0)"
     rom ( name "Shin chan - Aventuras en Cineland (Spain).gba" size 17359992 crc 4c5ffba8 md5 34d50b2e3fa34a53632f631b0605170a sha1 ecf588ec3a435eafc28fcb86c59ad39d3b5d59fa8 )
     patch "https://www.romhacking.net/translations/4567/"
 )
 game (
     name "Breath of Fire - Sound Restoration (Europe) [Hack by Bregalad]"
-    description "Sound Restoration hack by Bregalad (1.0)"
-    rom ( name "Breath of Fire (Europe).gba" size 4194304 crc 31db82cf md5 b2731bf52975b5163129666690160a2a sha1 5ec64e7c4649043aab25bd5cf8eee627f1abdb58 )
+    description "Breath of Fire - Sound Restoration by Bregalad version (1.1)"
+    rom ( name "Breath of Fire (Europe).gba" size 4194304 crc ecb2e2ae md5 23ed4bcab840f7c501cb1343102722b9 sha1 63bfcacfc9af99c17ca1123221d8859ea898653c )
     patch "https://www.romhacking.net/hacks/3764/"
 )
 game (
     name "Breath of Fire II - Sound Restoration (Europe) [Hack by Bregalad]"
-    description "Sound Restoration hack by Bregalad (1.2)"
+    description "Breath of Fire II - Sound Restoration by Bregalad version (1.2)"
     rom ( name "Breath of Fire II (Europe).gba" size 4292756 crc 3d868bbf md5 d80b43e555efd0b3a1a9d34bd96f6e3e sha1 26cbba9cb34c380344092ef07a710594fa0b51d4 )
     patch "https://www.romhacking.net/hacks/3765/"
 )
 game (
     name "Fire Emblem - Requiem [Hack by Sacred Blaze]"
-    description "Fire Emblem hack by Sacred Blaze (1.4.1)"
+    description "Fire Emblem - Requiem by Sacred Blaze version (1.4.1)"
     rom ( name "Fire Emblem (USA, Australia).gba" size 18774848 crc 2144df1c md5 659e6b097a54f92666d405664271402e sha1 26cbba9cb34c380344092ef07a710594fa0b51d4 )
     patch "https://forums.serenesforest.net/index.php?/topic/54594-fire-emblem-requiem-v14-is-up/"
 )
 game (
-    name "The Last Promise [Hack by Blazer]"
-    description "Fire Emblem hack by Blazer (2.1)"
+    name "Last Promise, The [Hack by Blazer]"
+    description "The Last Promise by Blazer version (2.1)"
     rom ( name "Fire Emblem (USA, Australia).gba" size 32505856 crc d1c6e5d5 md5 485740f0f0036d32bdf7369334be13e0 sha1 1c09cbe7f5d23a37ad2404efb4f2b536943f8cd5 )
     patch "http://www.feshrine.net/thelastpromise/"
 )
 game (
     name "Void's Blitzarre Adventure [Hack by Fire Emblem Universe]"
-    description "Fire Emblem - The Sacred Stones hack by Fire Emblem Universe (1.16)"
+    description "Void's Blitzarre Adventure by Fire Emblem Universe version (1.16)"
     rom ( name "Fire Emblem - The Sacred Stones (USA, Australia).gba" size 18641452 crc 9d22107c md5 4a991060c2c3284e76b02b2ea08b3c1c sha1 8ae8ff3045f5815a9ed973121767b6b2f1462b86 )
     patch "https://feuniverse.us/t/feu-chapter-creation-blitz-voids-blitzarre-adventure/2629"
 )
 game (
     name "Final Fantasy IV - Sound Restoration hack [Hack by Bregalad]"
-    description "Final Fantasy IV Advance hack by Bregalad (1.3)"
+    description "Final Fantasy IV - Sound Restoration hack by Bregalad version (1.3)"
     rom ( name "Final Fantasy IV Advance (Europe) (En,Fr,De,Es,It).gba" size 8388608 crc b963708b md5 13602c6fd1e69fb3fffe3967df78cab0 sha1 d8bc46983bf410d903f8478ea16418cd373d8057 )
     patch "https://www.romhacking.net/hacks/969/"
 )
 game (
     name "Final Fantasy V - Sound restoration and no framerate drop (orchestral intro) [Hack by Bregalad]"
-    description "Final Fantasy V hack by Bregalad (3.0a)"
+    description "Final Fantasy V - Sound restoration and no framerate drop (orchestral intro) by Bregalad version (3.0a)"
     rom ( name "Final Fantasy V Advance (Europe) (En,Fr,De,Es,It).gba" size 16777216 crc d7dfc429 md5 aa75364f817e4af7bdf43e3b866f4890 sha1 6d45a898fe31054c2f8d4a9c83be3c078f64cbb8 )
     patch "https://www.romhacking.net/hacks/563/"
 )
 game (
     name "Final Fantasy VI - Sound Restoration hack and few framerate drop (true opera) [Hack by Bregalad]"
-    description "Final Fantasy VI hack by Bregalad (2.1)"
+    description "Final Fantasy VI - Sound Restoration hack and few framerate drop (true opera) by Bregalad version (2.1)"
     rom ( name "Final Fantasy VI Advance (Europe) (En,Fr,De,Es,It).gba" size 16777216 crc 762f894d md5 65c1ce9257960895ab5f81d4e9699fe7 sha1 919ebecefe7be6c3469ba379df05b7fddca16059 )
     patch "https://www.romhacking.net/hacks/657/"
 )

--- a/metadat/hacks/Nintendo - Game Boy Color.dat
+++ b/metadat/hacks/Nintendo - Game Boy Color.dat
@@ -9,33 +9,21 @@ game (
     patch "http://www.romhacking.net/translations/3468/"
 )
 game (
-    name "Pokemon - Prism"
-    description "Pokemon - Prism Version 0.94 Build 0229"
-    rom ( name "prism-v0.94-b0229.gbc" size 2097152 crc 3D8CE356 md5 e72a3532f47fe0c7cf3160cf6f80713d sha1 50db018476be671b9b1cc2e34dcca968b87171bb )
+    name "Pokemon Prism [Hack by Koolboyman]"
+    description "Pokemon Prism by Koolboyman version (0.94 Build 0235)"
+    rom ( name "Pokemon - Crystal Version (USA, Europe).gbc" size 2097152 crc 3D8CE356 md5 5de4f04f745c1ab89f08f74f63760991 sha1 64d337de7238e44a8fb9d3f754531185d3be3e87 )
     patch "https://www.gbahacks.com/2016/12/prism.html"
 )
 game (
-    name "Pokemon - Prism"
-    description "Pokemon - Prism Version 0.94 Build 0235"
-    rom ( name "prism-v0.94-b0235.gbc" size 2097152 crc 3D8CE356 md5 5de4f04f745c1ab89f08f74f63760991 sha1 64d337de7238e44a8fb9d3f754531185d3be3e87 )
+    name "Pokemon Prism (Debug) [Hack by Koolboyman]"
+    description "Pokemon Prism hack by Koolboyman version (0.94 Build 0235) (Debug)"
+    rom ( name "Pokemon - Crystal Version (USA, Europe).gbc" size 2097152 crc 5473B933 md5 361c6d470661ac7155297471136ec8d8 sha1 ae9e952b6b4b33a7c40c3828364adf8cfcd43137 )
     patch "https://www.gbahacks.com/2016/12/prism.html"
 )
 game (
-    name "Pokemon - Prism Debug version"
-    description "Pokemon - Prism Version 0.94 Build 0229 Debug Version"
-    rom ( name "prism-v0.94-b0229-debug.gbc" size 2097152 crc 072FADDB md5 e3a0c3346ae52a403b3bdba96f6491fd sha1 98edd422ca364116a4c865b78a9cad4eb080ba87 )
-    patch "https://www.gbahacks.com/2016/12/prism.html"
-)
-game (
-    name "Pokemon - Prism Debug version"
-    description "Pokemon - Prism Version 0.94 Build 0235 Debug Version"
-    rom ( name "prism-v0.94-b0235-debug.gbc" size 2097152 crc 5473B933 md5 361c6d470661ac7155297471136ec8d8 sha1 ae9e952b6b4b33a7c40c3828364adf8cfcd43137 )
-    patch "https://www.gbahacks.com/2016/12/prism.html"
-)
-game (
-    name "Pokemon - Crystal Clear"
-    description "Better version of pokemon crystal"
-    rom ( name "Crystal_Clear.gbc" size 2097152 crc 720F5ABF md5 6294e690aeb566874b77937016d23e81 sha1 49e31236ec0d2a1d79aec47c074707180ecbeda8 )
+    name "Pokemon - Crystal Clear [Hack by ShockSlayer]"
+    description "Pokemon - Crystal Clear hack by ShockSlayer version (1.1)"
+    rom ( name "Pokemon - Crystal Version (USA, Europe).gbc" size 2097152 crc 720F5ABF md5 6294e690aeb566874b77937016d23e81 sha1 49e31236ec0d2a1d79aec47c074707180ecbeda8 )
     patch "https://web.archive.org/web/20180225173408/http://shockslayer.com:80/crystal/"
 )
 game (
@@ -63,8 +51,8 @@ game (
     patch "http://www.romhacking.net/translations/2151/"
 )
 game (
-    name "Lufia: The Legend Returns Text Cleanup [Hack by vivify93]"
-    description "Lufia: The Legend Returns Text Cleanup by vivify93 version (2.1)"
+    name "Lufia - The Legend Returns Text Cleanup [Hack by vivify93]"
+    description "Lufia - The Legend Returns Text Cleanup by vivify93 version (2.1)"
     rom ( name "Lufia - The Legend Returns (USA).gbc" size 2097152 crc 08920415 md5 e43bdbf799b9b2548a68f15916a49dce sha1 536b889d53ce091d774b4aa7f3bbd5016d3972e4 )
     patch "http://www.romhacking.net/hacks/813/"
 )
@@ -99,8 +87,8 @@ game (
     patch "http://www.romhacking.net/hacks/3580/"
 )
 game (
-    name "Wendy: Every Witch Way - Force GBA Enhanced Mode [Hack by celebi23]"
-    description "Wendy: Every Witch Way - Force GBA Enhanced Mode by celebi23 version (1.0)"
+    name "Wendy - Every Witch Way - Force GBA Enhanced Mode [Hack by celebi23]"
+    description "Wendy - Every Witch Way - Force GBA Enhanced Mode by celebi23 version (1.0)"
     rom ( name "Wendy - Every Witch Way (USA, Europe).gbc" size 1048576 crc 2c0c9cb3 md5 067b1ff18d9ee9f939d79a55f47d850e sha1 e5d2a32613d179a93482fca11138171c17340672 )
     patch "http://www.romhacking.net/hacks/4039/"
 )

--- a/metadat/hacks/Nintendo - Game Boy.dat
+++ b/metadat/hacks/Nintendo - Game Boy.dat
@@ -87,8 +87,8 @@ game (
     patch "http://www.romhacking.net/translations/3154/"
 )
 game (
-    name "Pokemon - Brown"
-    description "Pokemon Brown version"
-    rom ( name "Pokemon - Brown.gb" size 2097152 crc 2097152 md5 854390c4a18d0a1744fb437037b4a531 sha1 d794d1c98a37287865a6784e1428a1591e88d45f )
+    name "Pokemon Brown 2014 [Hack by Koolboyman]"
+    description "Pokemon Brown 2014 by Koolboyman version (5.4)"
+    rom ( name "Pokemon - Red Version (USA, Europe) (SGB Enhanced).gb" size 2097152 crc 926ee644 md5 854390c4a18d0a1744fb437037b4a531 sha1 d794d1c98a37287865a6784e1428a1591e88d45f )
     patch "https://www.romhacking.net/hacks/134/"
 )

--- a/metadat/hacks/Nintendo - Nintendo 64.dat
+++ b/metadat/hacks/Nintendo - Nintendo 64.dat
@@ -3,14 +3,15 @@ clrmamepro (
     description "Hacks of Nintendo 64 games"
 )
 game (
-    name "SM64 Last Impact (USA)"
-    description "'Super Mario 64' hack by kaze version 1.1"
-    rom ( name "SM64 Last Impact V1.1.z64" size 67108864 crc 4ce7fa2a md5 836667a37dce62414064b62f5dafe9f6 sha1 78e3e86f679330a40a0480372f65c362179042ff )
+    name "Super Mario 64 - Last Impact [Hack by Kaze Emanuar]"
+    description "Super Mario 64 - Last Impact by Kaze Emanuar version (1.2)"
+    rom ( name "Super Mario 64 (USA).z64" size 67108864 crc 0c693ced md5 70059d4d7ba7ac0f0741b44aec8b44dc sha1 1200de3f186e4e272d87b9889e7b15e1b5a8b797 )
+    patch "https://youtu.be/GTIcZlPpjsE"
 )
 game (
-    name "Super Mario 64 (USA)
-    description "Super Mario 64 (O2 Optimised)"
-    rom ( name "Super Mario 64 (USA) O2 Optimised" size 8388608 crc fb6fb9fe md5 6d6b7c02ece14b4feb390f1f298c0465 sha1 e2fc14dc38cd73aea89d64a0beac383d7583114b )
+    name "Super Mario 64 Reduced Lag (USA) [Hack by Nintendo 64 Wizard]"
+    description "Super Mario 64 with -O2 optimizations by Nintendo 64 Wizard version (1.0)"
+    rom ( name "Super Mario 64 (USA).z64" size 8388608 crc fb6fb9fe md5 6d6b7c02ece14b4feb390f1f298c0465 sha1 e2fc14dc38cd73aea89d64a0beac383d7583114b )
     patch "https://www.romhacking.net/hacks/4905/"
 )
 game (

--- a/metadat/hacks/Nintendo - Nintendo DS.dat
+++ b/metadat/hacks/Nintendo - Nintendo DS.dat
@@ -57,8 +57,8 @@ game (
     patch "http://www.romhacking.net/hacks/2235/"
 )
 game (
-    name "Castlevania: Dawn of Dignity (New Portraits Hack) [Hack by ShadowOne333 + 2 hacks]"
-    description "Castlevania: Dawn of Dignity (New Portraits Hack) by ShadowOne333 version (1.1) + Castlevania: Dawn of Sorrow Fixed Luck by LagoLunatic version (1.0) + Castlevania: Dawn of Sorrow No Required Touch Screen by LagoLunatic version (1.1)"
+    name "Castlevania - Dawn of Dignity (New Portraits Hack) [Hack by ShadowOne333 + 2 hacks]"
+    description "Castlevania - Dawn of Dignity (New Portraits Hack) by ShadowOne333 version (1.1) + Castlevania - Dawn of Sorrow Fixed Luck by LagoLunatic version (1.0) + Castlevania - Dawn of Sorrow No Required Touch Screen by LagoLunatic version (1.1)"
     rom ( name "Castlevania - Dawn of Sorrow (USA).nds" size 67108864 crc f6c7192b md5 4161086eedebafdbacc1678bb7349577 sha1 2f23dc3c148556f4ba2ad845fd172bb223693535 )
     patch "http://www.romhacking.net/hacks/3356/"
     patch "http://www.romhacking.net/hacks/3407/"

--- a/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
@@ -28,12 +28,6 @@ game (
     rom ( name "Sonic_NES_Improvement_plus_Music_plus_Graphics.nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
 )
 game (
-    name "Super Tilt Bro"
-    version "1.0.0-beta6"
-    description "Super Tilt Bro is a demake of the Super Smash Bros. series compatible with the good old Nintendo Entertainment System from the 1980s."
-    rom ( name "Super Tilt Bro (E).nes" size 1619304 crc 4c6e66ed md5 c0b0a89a7d1263f8627fb43778077387 sha1 a6dec1ad862704c2dee7d0e11bb6d984501638f5 )
-)
-game (
     name "Mario Adventure"
     description "'Super Mario Bros. 3' hack by DahrkDaiz"
     rom ( name "Mario_Adventure.nes" size 426000 crc 26a8de2c md5 ceb3261eaf10e464842bce5072b6abf0 sha1 069be38823c366777268c49da6e19b84c5667622 )
@@ -44,21 +38,4 @@ game (
     description "'Mother' hack by DragonDePlatino, Dr. Floppy, Tomato, vince94, and Jonesy47 version 1.11"
     rom ( name "Mother_25th_Anniversary_Edition.nes" size 524304 crc 6e24f190 md5 88cfab9094665bff0849079999dcf681 sha1 00ae39f447bc787edf01f3515977bea689cd5c54 )
     patch "http://www.romhacking.net/hacks/2211/"
-)
-
-game (
-	name "Teletime (Homebrew)"
-	description "NES cartridge album / Creative Commons - CC BY-NC-ND 3.0 license"
-	year "2010"
-	developer "Animal Style and NO CARRIER"
-	rom ( name "Teletime (Homebrew).nes" size 40976 crc 921ba26c md5 b412194b21aa4bbad4d039fda075effd sha1 faed721d2e3e4b3077a246b469920acec019ca25 )
-)
-
-game (
-	name "Micro Mages"
-	description "Micro Mages is a new platform game for the NES, play solo or with up to 4 players simultaneously. Fight to get the best score or cooperate to overcome challenging levels."
-	year "2018"
-	developer "Morphcat Games"
-	homepage "http://morphcat.de/micromages/"
-	rom ( name "Micro Mages.nes" size 40976 crc b0b6b5e4 md5 1062df5838a11e0e17ed590bdc1095c6 sha1 1411f9009cfa944c23b318620da72e395070c650 )
 )

--- a/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Nintendo Entertainment System.dat
@@ -3,39 +3,45 @@ clrmamepro (
     description "Romhacks of NES/Famicom games"
 )
 game (
-    name "BattleCity (Japan) 4 Players Hack"
-    description "4 players hack by Ti version 1.3"
-    rom ( name "Battle_City_-_4_Players_Hack_(v1.3).nes" size 40976 crc 974a5902 md5 b9fd5c27bf82200b3a6827cf3bc1bc2b sha1 5a2a37462fce65d83fdcae20c5e49aaa34025645 )
+    name "Battle City - 4 Players Hack [Hack by Ti]"
+    description "Battle City - 4 Players Hack by Ti version (1.3)"
+    rom ( name "BattleCity (Japan).nes" size 40976 crc 974a5902 md5 b9fd5c27bf82200b3a6827cf3bc1bc2b sha1 5a2a37462fce65d83fdcae20c5e49aaa34025645 )
+    patch "https://www.romhacking.net/hacks/2142/"
 )
 game (
-    name "Battletoads & Double Dragon - On Ragnarok (USA)"
-    description "'Battletoads' hack by Corpse Grinder version 1.2"
-    rom ( name "Battletoads_Double_Dragon_-_On_Ragnarok.nes" size 524304 crc aa42045e md5 fe1e4900fa16b0b0ba4f21ec9f632cad sha1 db810ed0b5ab7585ff82c8de2e9dad8e25a007db )
+    name "Battletoads & Double Dragon - On Ragnarok [Hack by Corpse Grinder]"
+    description "Battletoads & Double Dragon - On Ragnarok by Corpse Grinder version (1.2)"
+    rom ( name "Battletoads-Double Dragon (USA).nes" size 524304 crc aa42045e md5 fe1e4900fa16b0b0ba4f21ec9f632cad sha1 db810ed0b5ab7585ff82c8de2e9dad8e25a007db )
 )
 game (
-    name "DuckTales 2 (USA) Two Players Hack"
-    description "2 players hack by Ti version 1.2"
-    rom ( name "Duck_Tales_2_Two_Players_Hack_(v1.2).nes" size 262160 crc 910ab4c7 md5 21f9353652fb32c8cf4abe5023bbb2ff sha1 8f182a0f324b8294957766b88e57c7eab73f789d )
+    name "DuckTales 2 - Two Players Hack [Hack by Ti]"
+    description "DuckTales 2 - Two Players Hack by Ti version (1.2)"
+    rom ( name "DuckTales 2 (USA).nes" size 262160 crc 910ab4c7 md5 21f9353652fb32c8cf4abe5023bbb2ff sha1 8f182a0f324b8294957766b88e57c7eab73f789d )
+    patch "https://www.romhacking.net/hacks/2141/"
 )
 game (
-    name "Metroid - Rogue Dawn (USA)"
-    description "'Metroid' hack by snarfblam, Optomon and Grimlock version 1.10"
-    rom ( name "Metroid_Rogue_Dawn_V1.10.nes" size 786448 crc a24fd9e7 md5 6fc5e68df69d5c91366427113a8ef414 sha1 6c458f25521a985ea0b87db280eadf1297e798de )
+    name "Metroid - Rogue Dawn [Hack by Grimlock, Optomon, and snarfblam]"
+    description "Metroid - Rogue Dawn by Grimlock, Optomon, and snarfblam version (1.21)"
+    rom ( name "Metroid (USA).nes" size 786448 crc bdcf38b2 md5 f8aeb04e76a1ccbcf8c1387b58aac8d5 sha1 e2abd7a4647eab55d1b5a9b0b71a0a79f6317da2 )
+    patch "https://www.romhacking.net/hacks/3280/"
 )
 game (
-    name "Sonic The Hedgehog (USA) Improvement"
-    description "'Somari The Adventurer' hack by the jabu, Ti and Sics"
-    rom ( name "Sonic_NES_Improvement_plus_Music_plus_Graphics.nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
+    name "Sonic The Hedgehog (NES) Improvement [Hack by the jabu + 2 hacks]"
+    description "Sonic The Hedgehog (NES) Improvement by the jabu + Music by Ti + Graphics by Sics version (1.0)"
+    rom ( name "Somari (Unl) [p1].nes" size 786448 crc a38eceeb md5 0e2214993648014f95544b310ee6a11d sha1 b8a13b58d52d13fe1e616bb1c4fff6f827dc5890 )
+    patch "https://www.romhacking.net/hacks/3208/"
+    patch "https://www.romhacking.net/hacks/3223/"
+    patch "https://www.romhacking.net/hacks/3224/"
 )
 game (
-    name "Mario Adventure"
-    description "'Super Mario Bros. 3' hack by DahrkDaiz"
-    rom ( name "Mario_Adventure.nes" size 426000 crc 26a8de2c md5 ceb3261eaf10e464842bce5072b6abf0 sha1 069be38823c366777268c49da6e19b84c5667622 )
+    name "Mario Adventure [Hack by DahrkDaiz]"
+    description "Mario Adventure by DahrkDaiz version (1.0)"
+    rom ( name "Super Mario Bros. 3 (USA) (Rev A).nes" size 426000 crc 26a8de2c md5 ceb3261eaf10e464842bce5072b6abf0 sha1 069be38823c366777268c49da6e19b84c5667622 )
     patch "http://www.romhacking.net/hacks/70/"
 )
 game (
-    name "Mother: 25th Anniversary Edition"
-    description "'Mother' hack by DragonDePlatino, Dr. Floppy, Tomato, vince94, and Jonesy47 version 1.11"
-    rom ( name "Mother_25th_Anniversary_Edition.nes" size 524304 crc 6e24f190 md5 88cfab9094665bff0849079999dcf681 sha1 00ae39f447bc787edf01f3515977bea689cd5c54 )
+    name "Mother - 25th Anniversary Edition [Hack by DragonDePlatino]"
+    description "Mother - 25th Anniversary Edition by DragonDePlatino version (1.11)"
+    rom ( name "Earth Bound (USA) (Proto).nes" size 524304 crc 6e24f190 md5 88cfab9094665bff0849079999dcf681 sha1 00ae39f447bc787edf01f3515977bea689cd5c54 )
     patch "http://www.romhacking.net/hacks/2211/"
 )

--- a/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
@@ -3,213 +3,211 @@ clrmamepro (
     description "Romhacks of Super Nintendo / Super Famicom games"
 )
 game (
-    name "Ancient Chozo (1.1.0)"
-    description "'Super Metroid' Hack by Albert V."
+    name "Ancient Chozo [Hack by Albert V.]"
+    description "Ancient Chozo by Albert V. version (1.1.5)"
     homepage "http://metroidconstruction.com/hack.php?id=365"
-    rom ( name "Ancient_Chozo_1.1.0.smc" size 3244032 crc 0f3890f5 md5 a817bc339d87dbb68fb03dae8decbcd9 sha1 fa7328f225cf1ffa6d1f34487fb66e63c03ad944 )
+    rom ( name "Super Metroid (Japan, USA) (En,Ja).sfc" size 3571712 crc b6e07bad md5 20c9fb4b9e56d74f2ab40fe650afbd9d sha1 85844e0e9743e779e6dd7703697d5e3fd9e88932 )
 )
 game (
-    name "Banzai Mario World (USA)"
-    description "'Super Mario World' hack by GbreezeSunset"
+    name "Banzai Mario World [Hack by GbreezeSunset]"
+    description "Banzai Mario World by GbreezeSunset"
     homepage "https://www.smwcentral.net/?p=section&a=details&id=11477"
-    rom ( name "Banzai Mario World.sfc" size 2097152 crc 922d3660 md5 1daa2333725eec3e0f0ec077c2395755 sha1 ddc5df0b72a3a7b8e4904649087991ad3ab694d8 )
+    rom ( name "Super Mario World (USA).sfc" size 2097152 crc 922d3660 md5 1daa2333725eec3e0f0ec077c2395755 sha1 ddc5df0b72a3a7b8e4904649087991ad3ab694d8 )
 )
 game (
-    name "Chrono Trigger - Crimson Echoes (USA)"
-    description "'Chrono Trigger' hack by Kajam Laboratories"
-    rom ( name "ChronoTrigger - Crimson Echoes.smc" size 6291968 crc 2ebceb79 md5 24955542c1ea9c5bbd21a07479e64047 sha1 a43632026948df3d288f0bb03f6c83ee8e76bdd5 )
+    name "Chrono Trigger - Crimson Echoes [Hack by Kajar Laboratories]"
+    description "Chrono Trigger - Crimson Echoes by Kajar Laboratories"
+    rom ( name "Chrono Trigger (USA).smc" size 6291968 crc 2ebceb79 md5 24955542c1ea9c5bbd21a07479e64047 sha1 a43632026948df3d288f0bb03f6c83ee8e76bdd5 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01]"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01]"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01].sfc" size 4194304 crc 496a732d md5 d20b087e43b21782bbf7104f34fa710d sha1 6ffa84a357b0eef904e9ee14c89b44fe1681dad0 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 496a732d md5 d20b087e43b21782bbf7104f34fa710d sha1 6ffa84a357b0eef904e9ee14c89b44fe1681dad0 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Config 1).sfc" size 4194304 crc 017c1b14 md5 59301dc161a9ac99f9b5812e54fecfaa sha1 41fca01e18ae6d22b22895078ecb1031f32e1f4e )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 017c1b14 md5 59301dc161a9ac99f9b5812e54fecfaa sha1 41fca01e18ae6d22b22895078ecb1031f32e1f4e )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Config 2).sfc" size 4194304 crc d45668f6 md5 5e4ff42da754ef2f21ce69d342629d68 sha1 1e3b409bda7e9d7a53474da7bfa97cdfd8e1f8fb )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc d45668f6 md5 5e4ff42da754ef2f21ce69d342629d68 sha1 1e3b409bda7e9d7a53474da7bfa97cdfd8e1f8fb )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu A).sfc" size 4194304 crc 0146e2c2 md5 bbeb63146c138681fbaf8c095f4283f6 sha1 941c4ade4ece4129e40702c68548299dafef0c19 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 0146e2c2 md5 bbeb63146c138681fbaf8c095f4283f6 sha1 941c4ade4ece4129e40702c68548299dafef0c19 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu B)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Music Player Main Menu B)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Music Player Main Menu B) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Music Player Main Menu B)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Music Player Main Menu B).sfc" size 4194304 crc fa72d7c7 md5 1149ff4cc5ffb73400f87146e25969f7 sha1 a7ea8603dd680ada19ff83c0f6aa708f0d99d17e )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc fa72d7c7 md5 1149ff4cc5ffb73400f87146e25969f7 sha1 a7ea8603dd680ada19ff83c0f6aa708f0d99d17e )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes).sfc" size 4194304 crc 72f6c8b9 md5 4595980aaff9a8fdf4352b090de6c978 sha1 192dfac806c5eb0555230f7e300357f6084ec42b )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 72f6c8b9 md5 4595980aaff9a8fdf4352b090de6c978 sha1 192dfac806c5eb0555230f7e300357f6084ec42b )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes) (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 1).sfc" size 4194304 crc 3ae0a080 md5 ce219609adbbd4f01aca3c09a6c9120f sha1 2def721c63912a7e587084a775a20d37bf3a2b9b )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 3ae0a080 md5 ce219609adbbd4f01aca3c09a6c9120f sha1 2def721c63912a7e587084a775a20d37bf3a2b9b )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes) (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Config 2).sfc" size 4194304 crc efcad362 md5 d9f839b85fd59daae1f4459cddafafaf sha1 411b6f4f1d7d735e7555f61fb89c1637dabb4a79 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc efcad362 md5 d9f839b85fd59daae1f4459cddafafaf sha1 411b6f4f1d7d735e7555f61fb89c1637dabb4a79 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes) (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes) (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes) (Music Player Main Menu A).sfc" size 4194304 crc 891acc1c md5 44e284c085959d397d3c7d2be2465445 sha1 937a153f469545cd3d99db379c1f9cc0cb614fb2 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 891acc1c md5 44e284c085959d397d3c7d2be2465445 sha1 937a153f469545cd3d99db379c1f9cc0cb614fb2 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Add-Ons) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Add-Ons)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons).sfc" size 4194304 crc f5f4a492 md5 b5282e5c781eed3cfb25ed89a24f18bf sha1 9a9deb3fb033dec62e696849d97d37f6c5183fbd )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc f5f4a492 md5 b5282e5c781eed3cfb25ed89a24f18bf sha1 9a9deb3fb033dec62e696849d97d37f6c5183fbd )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Add-Ons) (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Add-Ons) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 1).sfc" size 4194304 crc bde2ccab md5 0b0f7a6cb545b7ed39e059be47164e8d sha1 d454f7357871d89c151560b77b1b2e61eeb8685b )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc bde2ccab md5 0b0f7a6cb545b7ed39e059be47164e8d sha1 d454f7357871d89c151560b77b1b2e61eeb8685b )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Add-Ons) (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Add-Ons) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Config 2).sfc" size 4194304 crc 68c8bf49 md5 3b27b255a91602706b9ec59a060e77b5 sha1 70c3ce1627d0f1a22fd9c70e31c9fb5ae60a7e83 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 68c8bf49 md5 3b27b255a91602706b9ec59a060e77b5 sha1 70c3ce1627d0f1a22fd9c70e31c9fb5ae60a7e83 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Add-Ons) (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Add-Ons) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Add-Ons) (Music Player Main Menu A).sfc" size 4194304 crc 0e18a037 md5 58b0e8a7c4cf1b4334aa851c95fe68ed sha1 d5abbaa0718326971193651b0d5551eb0947baac )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 0e18a037 md5 58b0e8a7c4cf1b4334aa851c95fe68ed sha1 d5abbaa0718326971193651b0d5551eb0947baac )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera).sfc" size 4194304 crc 9a555238 md5 470b038a57a2527771e1130e1d78d663 sha1 87563f8cec80f9983d0d61e815125619dd4833cf )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 9a555238 md5 470b038a57a2527771e1130e1d78d663 sha1 87563f8cec80f9983d0d61e815125619dd4833cf )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera) (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 1).sfc" size 4194304 crc d2433a01 md5 fd2f5ffebbf06f043e2ecf001e5ba724 sha1 582089cc4aef1d2ac30ff95452d7337ef79bafb2 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc d2433a01 md5 fd2f5ffebbf06f043e2ecf001e5ba724 sha1 582089cc4aef1d2ac30ff95452d7337ef79bafb2 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera) (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Config 2).sfc" size 4194304 crc 076949e3 md5 078e24dc0e88da06c54febd7b00f0d77 sha1 29cedb11c8ca643c8e532bc33eb639973fbc5b44 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 076949e3 md5 078e24dc0e88da06c54febd7b00f0d77 sha1 29cedb11c8ca643c8e532bc33eb639973fbc5b44 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera) (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera) (Music Player Main Menu A).sfc" size 4194304 crc 61b9569d md5 2aa2be40e461065fe8c6ef817fb24be8 sha1 c8dea3c804bdae50bdb538ab15b1db0bf99acaa7 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 61b9569d md5 2aa2be40e461065fe8c6ef817fb24be8 sha1 c8dea3c804bdae50bdb538ab15b1db0bf99acaa7 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera, Add-Ons) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera, Add-Ons)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons).sfc" size 4194304 crc 747c2038 md5 cecc23d950153dd9c8af8d446cc32f21 sha1 1cd19ef28d58912bd7679583c8915f401a16d0de )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 747c2038 md5 cecc23d950153dd9c8af8d446cc32f21 sha1 1cd19ef28d58912bd7679583c8915f401a16d0de )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 1).sfc" size 4194304 crc 3c6a4801 md5 0f02218bef725649cb025c777bf82ebb sha1 42b269a86de5c19fa60fdece81825466f9fd1f92 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 3c6a4801 md5 0f02218bef725649cb025c777bf82ebb sha1 42b269a86de5c19fa60fdece81825466f9fd1f92 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Config 2).sfc" size 4194304 crc e9403be3 md5 bd8464371c86e0ec5a2c887041920af8 sha1 00dc8d2947acc5e0f2b02103dfc71078bf9fd881 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc e9403be3 md5 bd8464371c86e0ec5a2c887041920af8 sha1 00dc8d2947acc5e0f2b02103dfc71078bf9fd881 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Bug Fixes, Updated Opera, Add-Ons) (Music Player Main Menu A).sfc" size 4194304 crc 8f90249d md5 b042767cabb3e75827c78346d31d6952 sha1 d6a5455b59cf0dc4dff8f7bc4602e599cc0c6680 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 8f90249d md5 b042767cabb3e75827c78346d31d6952 sha1 d6a5455b59cf0dc4dff8f7bc4602e599cc0c6680 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Updated Opera)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Updated Opera) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Updated Opera)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera).sfc" size 4194304 crc ea50cd89 md5 b589d6d0d78c07f422efbdce96a84a44 sha1 3d5b3e64b31036b5b30ce1a2e1db364c99a114c0 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc ea50cd89 md5 b589d6d0d78c07f422efbdce96a84a44 sha1 3d5b3e64b31036b5b30ce1a2e1db364c99a114c0 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 1)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Config 1)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Updated Opera) (Music Player Config 1) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Updated Opera) (Music Player Config 1)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 1).sfc" size 4194304 crc a246a5b0 md5 b914e85efaa6ba88c824bf53f54212a0 sha1 c484d67324bb0493525ed9da239de7ea5b1b9aa0 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc a246a5b0 md5 b914e85efaa6ba88c824bf53f54212a0 sha1 c484d67324bb0493525ed9da239de7ea5b1b9aa0 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 2)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Config 2)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Updated Opera) (Music Player Config 2) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Updated Opera) (Music Player Config 2)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Config 2).sfc" size 4194304 crc 776cd652 md5 316902d08bb213e8a408f7eaaca44d8b sha1 e03758566ceaec22ecdad36742e9c2d2b114c11e )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 776cd652 md5 316902d08bb213e8a408f7eaaca44d8b sha1 e03758566ceaec22ecdad36742e9c2d2b114c11e )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu A)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Main Menu A)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Updated Opera) (Music Player Main Menu A) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Updated Opera) (Music Player Main Menu A)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu A).sfc" size 4194304 crc a27c5c66 md5 ec8a6b57af4ebdde472d044c82bbf462 sha1 d4dca9df543346a55f5069ae5a22a807a12f9f76 )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc a27c5c66 md5 ec8a6b57af4ebdde472d044c82bbf462 sha1 d4dca9df543346a55f5069ae5a22a807a12f9f76 )
 )
 game (
-    name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu B)"
-    description "Final Fantasy VI [Ted Woolsey Uncensored Edition v2.01] (Updated Opera) (Music Player Main Menu B)"
+    name "Final Fantasy VI - Ted Woolsey Uncensored Edition (Updated Opera) (Music Player Main Menu B) [Hack by Rodimus Primal]"
+    description "Final Fantasy VI TWUE by Rodimus Primal version (2.01) (Updated Opera) (Music Player Main Menu B)"
     homepage "https://www.romhacking.net/hacks/1386/"
-    rom ( name "Final Fantasy VI [TWUE v2.01] (Updated Opera) (Music Player Main Menu B).sfc" size 4194304 crc 59486963 md5 003b119e354c70022d4e8ce67e5ddba3 sha1 750bf9dec0e428c1a164691a67c22147752955ab )
+    rom ( name "Final Fantasy III (USA).sfc" size 4194304 crc 59486963 md5 003b119e354c70022d4e8ce67e5ddba3 sha1 750bf9dec0e428c1a164691a67c22147752955ab )
 )
 game (
-    name "Hyper Metroid (1.0)"
-    description "'Super Metroid' Hack by RealRed"
+    name "Hyper Metroid [Hack by RealRed]"
+    description "Hyper Metroid by RealRed version (1.0)"
     homepage "http://metroidconstruction.com/hack.php?id=294"
-    rom ( name "Hyper Metroid.sfc" size 4194304 crc d4d38230 md5 6b3c722165b3c566eda465386b585b51 sha1 727f8763983753e014e706520bb958bb4752e8b7 )
+    rom ( name "Super Metroid (Japan, USA) (En,Ja).sfc" size 4194304 crc d4d38230 md5 6b3c722165b3c566eda465386b585b51 sha1 727f8763983753e014e706520bb958bb4752e8b7 )
 )
 game (
-    name "Mario & Luigi - Kola Kingdom Quest (USA)"
-    description "'Super Mario World' hack by GammaV"
-    rom ( name "KKQFinalFixed.sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )
+    name "Mario & Luigi - Kola Kingdom Quest [Hack by Gamma V]"
+    description "Mario & Luigi - Kola Kingdom Quest by Gamma V version (1.0)"
+    rom ( name "Super Mario World (USA).sfc" size 4194304 crc 5d593cdc md5 bdaca14679139c592ab0d0ae20b1e40c sha1 15b1f4ebffd931c4f839104ddc93f7bc65f31d3a )
+    patch "https://www.romhacking.net/hacks/2364/"
 )
 game (
-    name "NBA Jam 2K17 (USA)"
-    description "'NBA Jam - Tournament Edition' hack by Ethan Miller"
-    rom ( name "NBA Jam 2k17.SMC" size 3145728 crc 5bd9eb28 md5 4675c4f100784f83ada83b74bb24a50a sha1 932d4fe315f06001de82ab2dc82d755363bb343a )
+    name "NBA Jam 2K17 [Hack by EMiller518]"
+    description "NBA Jam 2K17 by EMiller518 version (1.0)"
+    rom ( name "NBA Jam - Tournament Edition (USA).smc" size 3145728 crc 5bd9eb28 md5 4675c4f100784f83ada83b74bb24a50a sha1 932d4fe315f06001de82ab2dc82d755363bb343a )
+    patch "https://www.romhacking.net/hacks/3283/"
 )
 game (
-    name "Oh No! More Zombies Ate My Neighbors! (USA)"
-    description "'Zombies Ate My Neighbors' hack by Stanley_Decker and sloat version 1.0"
-    rom ( name "Oh No! More Zombies Ate My Neighbors!.sfc" size 4194304 crc d218147c md5 7f44a65cf20b213502314fc118b5a6f4 sha1 917b2c381e0ed77b8c3f196171d7285fce21a090 )
+    name "Oh No! More Zombies Ate My Neighbors! [Hack by Stanley_Decker and sloat]"
+    description "Oh No! More Zombies Ate My Neighbors! by Stanley_Decker and sloat version (1.0)"
+    rom ( name "Zombies Ate My Neighbors (USA).sfc" size 4194304 crc d218147c md5 7f44a65cf20b213502314fc118b5a6f4 sha1 917b2c381e0ed77b8c3f196171d7285fce21a090 )
+    patch "https://www.romhacking.net/hacks/623/"
 )
 game (
-    name "Project Base (0.7.3)"
-    description "'Super Metroid' Hack by begrimed"
+    name "Project Base [Hack by begrimed]"
+    description "Project Base by begrimed version (0.7.3)"
     homepage "http://metroidconstruction.com/hack.php?id=307"
-    rom ( name "project_base_0.7.3.sfc" size 3211264 crc f225d664 md5 7bcd52c50cfacc8bf6d162a952e9bcbc sha1 8144b131714b87dc314618bcee810921de79dfde )
+    rom ( name "Super Metroid (Japan, USA) (En,Ja).sfc" size 3211264 crc f225d664 md5 7bcd52c50cfacc8bf6d162a952e9bcbc sha1 8144b131714b87dc314618bcee810921de79dfde )
 )
 game (
-    name  "Super Boss Gaiden (J)"
-    description "Super Boss Gaiden (J)"
-    rom ( name "Super Boss Gaiden (J).sfc" size 524288 crc 188f152b md5 73abcd4808657a6d546652cfac4683b5 sha1 65b22d721b148c7863d315cd7bb78a851342d009 )
-)
-game (
-    name  "Super Famicon Wars (Japan) (E)"
-    description "Super Famicon Wars (Japan) (E)"
+    name "Super Famicom Wars [T-En by Optiroc]"
+    description "English translation by Optiroc version (1.1)"
     homepage "https://www.romhacking.net/translations/3354/"
-    rom ( name "Super Famicon Wars (Japan) (E).sfc" size 2097152 crc 45cbdf8d md5 96501e0e8d2f7435ac6ac5727571f8bb sha1 e8309511f7bb903059de7e166c2d08cd971792e5 )
+    rom ( name "Super Famicom Wars (Japan) (NP).sfc" size 2097152 crc 45cbdf8d md5 96501e0e8d2f7435ac6ac5727571f8bb sha1 e8309511f7bb903059de7e166c2d08cd971792e5 )
 )

--- a/metadat/hacks/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/hacks/SNK - Neo Geo Pocket Color.dat
@@ -3,9 +3,9 @@ clrmamepro (
     description "Romhacks of Neo Geo Pocket games"
 )
 game (
-    name "Nigeronpa (Japan) [T-En by Loïc]"
+    name "Nige-ron-pa (Japan) [T-En by Loic]"
     description "English translation by Loïc version (0.9)"
-    rom ( name "Nigeronpa (Japan).ngc" size 2097152 crc 6672d6e6 md5 866e717e2c684e073e6d034f5a56f7b7 sha1 85bf5be2cce3b5559fbb68799ac6c15539b87621 )
+    rom ( name "Nige-ron-pa (Japan).ngc" size 2097152 crc 6672d6e6 md5 866e717e2c684e073e6d034f5a56f7b7 sha1 85bf5be2cce3b5559fbb68799ac6c15539b87621 )
     patch "http://www.romhacking.net/translations/3804/"
 )
 game (

--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -284,12 +284,6 @@ game (
     patch "http://www.romhacking.net/hacks/1056/"
 )
 game (
-    name "Sonic 3D Blast: Director's Cut [Hack by GameHut]"
-    description "Sonic 3D Blast: Director's Cut by GameHut version (1.0)"
-    rom ( name "Sonic 3D Blast ~ Sonic 3D Flickies' Island (USA, Europe).md" size 4191682 crc 9767e840 md5 742dd5c98d143ff6716800dee6a25dc5 sha1 4072d34e119e199131b839d338f1fc38e472203a )
-    patch "http://www.romhacking.net/hacks/3810/"
-)
-game (
     name "Sonic the Hedgehog Classic Heroes [Hack by flamewing]"
     description "Sonic the Hedgehog Classic Heroes by flamewing version (0.10.008a)"
     rom ( name "Sonic Classic Heroes.md" size 4194304 crc c27093da md5 4634c397a507053b0e04fc3ce6c49d9a sha1 a39b4a7c2d69f7d0bc8b40de7757e3be13acea0b )

--- a/metadat/hacks/Sega - Mega Drive - Genesis.dat
+++ b/metadat/hacks/Sega - Mega Drive - Genesis.dat
@@ -27,14 +27,14 @@ game (
     patch "http://www.romhacking.net/translations/3544/"
 )
 game (
-    name "The Chaos Engine Amiga colors & music speed fix [Hack by fusaru]"
+    name "Chaos Engine, The Amiga colors & music speed fix [Hack by fusaru]"
     description "The Chaos Engine Amiga colors & music speed fix by fusaru version (1.01)"
     rom ( name "Chaos Engine, The (Europe).md" size 1572864 crc 65887f32 md5 43fdebcd2edc168f5fb9439eed68820b sha1 7d70a839f9ca5b49f937b54377c16c58fe2fea41 )
     patch "http://www.romhacking.net/hacks/2754/"
 )
 game (
-    name "Contra: Hard Corps Enhancement Hack [Hack by M.I.J.E.T.]"
-    description "Contra: Hard Corps Enhancement Hack by M.I.J.E.T. version (Super Cham)"
+    name "Contra - Hard Corps Enhancement Hack [Hack by M.I.J.E.T.]"
+    description "Contra - Hard Corps Enhancement Hack by M.I.J.E.T. version (Super Cham)"
     rom ( name "Contra - Hard Corps (USA, Korea).md" size 2097152 crc 41b49317 md5 f055fce2a6ab82a96a65290465e0c97e sha1 475a1c99713df4f7f8e66d4f75664559a3dac851 )
     patch "http://www.romhacking.net/hacks/450/"
 )
@@ -225,8 +225,8 @@ game (
     patch "http://www.romhacking.net/translations/3549/"
 )
 game (
-    name "Phantasy Star Generation: 4 - A Relocalization [Hack by GhaleonUnlimited]"
-    description "Phantasy Star Generation: 4 - A Relocalization by GhaleonUnlimited version (4.0)"
+    name "Phantasy Star Generation - 4 - A Relocalization [Hack by GhaleonUnlimited]"
+    description "Phantasy Star Generation - 4 - A Relocalization by GhaleonUnlimited version (4.0)"
     rom ( name "Phantasy Star IV (USA).md" size 3209748 crc 78fbb881 md5 2f563c79016787a25cfd1e5f9d5e49ff sha1 a61aea0d09beaecf202c1d6e429919ed886dfb02 )
     patch "http://www.romhacking.net/hacks/4171/"
 )
@@ -249,14 +249,14 @@ game (
     patch "http://www.romhacking.net/translations/2309/"
 )
 game (
-    name "Rock n' Roll Racing (USA) Hack"
-    description "Hack by Ti version 15"
-    rom ( name "Rock_n'_Roll_Racing_Hack_v15.bin" size 2097152 crc 205f4afc md5 bd4bae13a6fed5d2801face18572fab2 sha1 bedfa111535fbeea0b75999b799317415bc4bab3 )
+    name "Rock n' Roll Racing Hack [Hack by Ti]"
+    description "Rock n' Roll Racing Hack by Ti version (15)"
+    rom ( name "Rock n' Roll Racing (USA).md" size 2097152 crc 205f4afc md5 bd4bae13a6fed5d2801face18572fab2 sha1 bedfa111535fbeea0b75999b799317415bc4bab3 )
 )
 game (
     name "Sally Acorn in Sonic the Hedgehog [Hack by E-122-Psi]"
     description "Sally Acorn in Sonic the Hedgehog by E-122-Psi version (2.2)"
-    rom ( name "Sally Acorn In Sonic The Hedgehog.md" size 1048576 crc 96f971f6 md5 80d3491eca8580494a87186ca9f40abd sha1 1bb88d7f4dfcea94d3f47e79b9c1fddf364b2d59 )
+    rom ( name "Sonic The Hedgehog (USA, Europe).md" size 1048576 crc 96f971f6 md5 80d3491eca8580494a87186ca9f40abd sha1 1bb88d7f4dfcea94d3f47e79b9c1fddf364b2d59 )
     patch "http://www.romhacking.net/hacks/1020/"
 )
 game (
@@ -286,7 +286,7 @@ game (
 game (
     name "Sonic the Hedgehog Classic Heroes [Hack by flamewing]"
     description "Sonic the Hedgehog Classic Heroes by flamewing version (0.10.008a)"
-    rom ( name "Sonic Classic Heroes.md" size 4194304 crc c27093da md5 4634c397a507053b0e04fc3ce6c49d9a sha1 a39b4a7c2d69f7d0bc8b40de7757e3be13acea0b )
+    rom ( name "Sonic The Hedgehog 2 (World).md" size 4194304 crc c27093da md5 4634c397a507053b0e04fc3ce6c49d9a sha1 a39b4a7c2d69f7d0bc8b40de7757e3be13acea0b )
     patch "http://www.romhacking.net/hacks/1038/"
 )
 game (
@@ -298,7 +298,7 @@ game (
 game (
     name "Street Fighter 2 Champion Edition Arcade Hack [Hack by Lord Hiryu]"
     description "Street Fighter 2 Champion Edition Arcade Hack by Lord Hiryu version (2.0)"
-    rom ( name "Street Fighter 2 Champion Edition Arcade Hack.md" size 3145728 crc 518a850e md5 262131e441fadd75d31e3bcf0dd9cccd sha1 4f8167ce31d90ccc95315e32ddb36b7b108bc9ca )
+    rom ( name "Street Fighter II' - Special Champion Edition (USA).md" size 3145728 crc 518a850e md5 262131e441fadd75d31e3bcf0dd9cccd sha1 4f8167ce31d90ccc95315e32ddb36b7b108bc9ca )
     patch "http://www.romhacking.net/hacks/3212/"
 )
 game (
@@ -332,13 +332,13 @@ game (
     patch "http://www.romhacking.net/translations/914/"
 )
 game (
-    name "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors [Hack by fusaru]"
-    description "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors by fusaru version (2.00)"
+    name "Twin Cobra Arcade tiles + sprites + colors [Hack by fusaru]"
+    description "Twin Cobra/Kyuukyoku Tiger Arcade tiles/sprites/colors by fusaru version (2.00) (USA)"
     rom ( name "Twin Cobra (USA).md" size 704120 crc 88ea1e4e md5 d1c82b81594f80a1868a141275e16bba sha1 1bae39be93427bddfd7fff1db2a47954abb9d8a1 )
     patch "http://www.romhacking.net/hacks/2920/"
 )
 game (
-    name "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors [Hack by fusaru]"
+    name "Daisenpuu ~ Twin Hawk arcade style tiles, sprites, and colors [Hack by fusaru]"
     description "Twin Hawk / Daisenpuu arcade style tiles/sprites/colors by fusaru version (1.0)"
     rom ( name "Daisenpuu ~ Twin Hawk (Japan, Europe).md" size 524288 crc abd8ce33 md5 1100938e017a56ee30c8e368ba06dc18 sha1 51e3b19d3652d5bcb45165ab6838c77455a39a28 )
     patch "http://www.romhacking.net/hacks/3310/"
@@ -358,7 +358,7 @@ game (
 game (
     name "Ultimate Mortal Kombat Trilogy [Hack by KABAL_MK]"
     description "Ultimate Mortal Kombat Trilogy by KABAL_MK version (23 (5125))"
-    rom ( name "Ultimate Mortal Kombat Trilogy.md" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
+    rom ( name "Ultimate Mortal Kombat 3 (USA).md" size 10485760 crc d083dbba md5 073bef4bea44531dd1a217e801ab04b7 sha1 140063d3a2cda353851c512571b6f706d0a96dfe )
     patch "http://www.romhacking.net/hacks/1059/"
 )
 game (

--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -29,8 +29,8 @@ game (
     patch "http://www.romhacking.net/translations/1622/"
 )
 game (
-    name "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) [Hack by paul_met]"
-    description "The Legend of Oasis / The Story of Thor 2  (4 in 1 hack) by paul_met version (1.1)"
+    name "Legend of Oasis, The + The Story of Thor 2 (4 in 1 hack) [Hack by paul_met]"
+    description "The Legend of Oasis / The Story of Thor 2 (4 in 1 hack) by paul_met version (1.1)"
     rom ( name "Story of Thor 2, The (Europe) (Track 1).bin" size 81995424 crc 651c0da5 md5 aededa1efee1099ff758978f194b9078 sha1 b9514624acf837a3f5a98a39b3f86112f9226eb3 )
     patch "http://www.romhacking.net/hacks/3403/"
 )
@@ -42,7 +42,7 @@ game (
 )
 game (
     name "Sakura Taisen (Japan) (Disc 1) [T-En by NoahSteam]"
-    description "Sakura Taisen (Disc 1) English translation by NoahSteam version (1.0)"
+    description "English translation by NoahSteam version (1.0)"
     rom ( name "Sakura Taisen (Japan) (Disc 1) (Track 1) [T-En by NoahSteam].bin" size 554715136 crc 22cdf414 md5 97825db1b348375b65256c1f0319b86e sha1 dd460872850ab66edef08d371b6d424f966b3689 )
     patch "https://www.romhacking.net/translations/5318/"
     comment "No reputable source"
@@ -50,7 +50,7 @@ game (
 )
 game (
     name "Sakura Taisen (Japan) (Disc 2) [T-En by NoahSteam]"
-    description "Sakura Taisen (Disc 2) English translation by NoahSteam version (1.0)"
+    description "English translation by NoahSteam version (1.0)"
     rom ( name "Sakura Taisen (Japan) (Disc 2) (Track 1) [T-En by NoahSteam].bin" size 539021312 crc 6ba39d09 md5 fef61d20a807a99a237467d31bc6d49b sha1 e8b35142a5140a192e0c51162be80b2b1d1a4a28 )
     patch "https://www.romhacking.net/translations/5318/"
     comment "No reputable source"

--- a/metadat/hacks/Sony - PlayStation.dat
+++ b/metadat/hacks/Sony - PlayStation.dat
@@ -117,8 +117,8 @@ game (
     patch "http://www.romhacking.net/translations/1711/"
 )
 game (
-    name "Castlevania: Symphony of the Night - Quality hack [Hack by paul_met]"
-    description "Castlevania: Symphony of the Night - Quality hack by paul_met version (1.2)"
+    name "Castlevania - Symphony of the Night - Quality hack [Hack by paul_met]"
+    description "Castlevania - Symphony of the Night - Quality hack by paul_met version (1.2)"
     rom ( name "Castlevania - Symphony of the Night (USA) (Track 1).bin" size 538655040 crc 0431c247 md5 6674f4a75ea11fd9422669f247ec27fd sha1 1fa7cd542e15f9ce281e83320eedd24daace79e8 )
     patch "http://www.romhacking.net/hacks/3606/"
 )

--- a/metadat/homebrew/Nintendo - Game Boy Advance.dat
+++ b/metadat/homebrew/Nintendo - Game Boy Advance.dat
@@ -1,0 +1,18 @@
+clrmamepro (
+    name "Nintendo - Game Boy Advance"
+    description "Homebrew for Nintendo - Game Boy Advance"
+    version "2020.4.27"
+    homepage "https://github.com/libretro/libretro-database/tree/master/metadat"
+)
+game (
+    name "Celeste Classic"
+    description "Celeste Classic by Matt Thorson and Noel Berry. GameBoy Advance port by JeffRuLz."
+    version "1.0"
+    developer "Matt Makes Games"
+    genre "Platformer"
+    releaseyear "2018"
+    releasemonth "1"
+    releaseday "28"
+    rom ( name "Celeste Classic (v1.0).gba" size 5416932 crc f79b0d53 md5 d5b7c99707098401f12f6e4dfac87c9f sha1 756f02396a150698e695ad4afd24445e2af70576 )
+    homepage "https://github.com/JeffRuLz/Celeste-Classic-GBA"
+)

--- a/metadat/homebrew/Nintendo - GameCube.dat
+++ b/metadat/homebrew/Nintendo - GameCube.dat
@@ -1,6 +1,6 @@
 clrmamepro (
     name "Nintendo - GameCube"
-    description "Hacks and homebrew for Nintendo - GameCube"
+    description "Homebrew for Nintendo - GameCube"
 )
 
 game (

--- a/metadat/homebrew/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/homebrew/Nintendo - Nintendo Entertainment System.dat
@@ -15,3 +15,29 @@ game (
     version "1.0.2"
     rom ( name "What Remains.nes" size 40976 crc 2f2d03e5 md5 7be8c009c4bf1749b54afc49ea8ee31c sha1 0536b31eb0d88ccf7cef660ca6aff22aca2dccaa )
 )
+
+game (
+    name "Super Tilt Bro"
+    version "1.0.0-beta6"
+    description "Super Tilt Bro is a demake of the Super Smash Bros. series compatible with the good old Nintendo Entertainment System from the 1980s."
+    rom ( name "Super Tilt Bro (E).nes" size 1619304 crc 4c6e66ed md5 c0b0a89a7d1263f8627fb43778077387 sha1 a6dec1ad862704c2dee7d0e11bb6d984501638f5 )
+)
+
+
+game (
+	name "Teletime (Homebrew)"
+	description "NES cartridge album / Creative Commons - CC BY-NC-ND 3.0 license"
+	year "2010"
+	developer "Animal Style and NO CARRIER"
+	rom ( name "Teletime (Homebrew).nes" size 40976 crc 921ba26c md5 b412194b21aa4bbad4d039fda075effd sha1 faed721d2e3e4b3077a246b469920acec019ca25 )
+)
+
+game (
+	name "Micro Mages"
+	description "Micro Mages is a new platform game for the NES, play solo or with up to 4 players simultaneously. Fight to get the best score or cooperate to overcome challenging levels."
+	year "2018"
+	developer "Morphcat Games"
+	homepage "http://morphcat.de/micromages/"
+	rom ( name "Micro Mages.nes" size 40976 crc b0b6b5e4 md5 1062df5838a11e0e17ed590bdc1095c6 sha1 1411f9009cfa944c23b318620da72e395070c650 )
+)
+

--- a/metadat/homebrew/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/homebrew/Nintendo - Nintendo Entertainment System.dat
@@ -1,7 +1,7 @@
 clrmamepro (
     name "Nintendo - Nintendo Entertainment System"
     description "Homebrew for Nintendo - Nintendo Entertainment System"
-    version "2020.2.4"
+    version "2020.4.27"
     homepage "https://github.com/libretro/libretro-database/tree/master/metadat"
 )
 

--- a/metadat/homebrew/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/homebrew/Nintendo - Super Nintendo Entertainment System.dat
@@ -1,0 +1,12 @@
+clrmamepro (
+    name "Nintendo - Super Nintendo Entertainment System"
+    description "Homebrew for Nintendo - Super Nintendo Entertainment System"
+    version "2020.4.27"
+    homepage "https://github.com/libretro/libretro-database/tree/master/metadat"
+)
+
+game (
+    name "Super Boss Gaiden (J)"
+    description "Super Boss Gaiden (J)"
+    rom ( name "Super Boss Gaiden (J).sfc" size 524288 crc 188f152b md5 73abcd4808657a6d546652cfac4683b5 sha1 65b22d721b148c7863d315cd7bb78a851342d009 )
+)


### PR DESCRIPTION
I’ve applied some more consistent naming to the ROM hacks.

I’d also like to ask what should be done for translations. Some of them translate the title, but all the entries here use the original title. Should this be changed?