### PR TITLE
Simplify "Sonic Advance (World) (Code Breaker).cht"

### DIFF
--- a/cht/Nintendo - Game Boy Advance/Sonic Advance (World) (Code Breaker).cht
+++ b/cht/Nintendo - Game Boy Advance/Sonic Advance (World) (Code Breaker).cht
@@ -1,58 +1,58 @@
 cheats = 14 
 
 cheat0_desc = "Enable Code (Must Be On)"
-cheat0_code = "972DEB4E+BE0E+F4D9B2E3+CD66+F7A776EC+D19D"
+cheat0_code = "0000FFE5+000A+1000122A+0007"
 cheat0_enable = false 
 
 cheat1_desc = "Get Best Time For The End Of A Zone"
-cheat1_code = "33806F88+5D98"
+cheat1_code = "83005034+0001"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Rings"
-cheat2_code = "16635639+2A38"
+cheat2_code = "83004FEC+03E7"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "EEC7F625+C1B1"
+cheat3_code = "33005024+000A"
 cheat3_enable = false 
 
 cheat4_desc = "Quick Score Gain"
-cheat4_code = "B4FF1075+3F53"
+cheat4_code = "83005030+FFFF"
 cheat4_enable = false 
 
 cheat5_desc = "Max Score"
-cheat5_code = "36EB1071+F777+CD57B087+8001"
+cheat5_code = "83005030+967F+83005032+0098"
 cheat5_enable = false 
 
 cheat6_desc = "Max Rings (Special Stage)"
-cheat6_code = "31F25CB1+2F90"
+cheat6_code = "33005078+00FF"
 cheat6_enable = false 
 
 cheat7_desc = "Have All Chaos Emeralds"
-cheat7_code = "936658B7+EA90"
+cheat7_code = "3300517C+007F"
 cheat7_enable = false 
 
 cheat8_desc = "Normal Shield Effects"
-cheat8_code = "B3CE5EC9+F5DF"
+cheat8_code = "33005A46+0001"
 cheat8_enable = false 
 
 cheat9_desc = "Lightning Shield Effects"
-cheat9_code = "EFCF87C5+F94E"
+cheat9_code = "33005A56+0008"
 cheat9_enable = false 
 
 cheat10_desc = "Play As Sonic"
-cheat10_code = "6990DE8C+7998"
+cheat10_code = "33005084+0000"
 cheat10_enable = false 
 
 cheat11_desc = "Play As Tails"
-cheat11_code = "31905E88+7D98"
+cheat11_code = "33005084+0001"
 cheat11_enable = false 
 
 cheat12_desc = "Play As Knuckles"
-cheat12_code = "69D2DEAD+6990"
+cheat12_code = "33005084+0002"
 cheat12_enable = false 
 
 cheat13_desc = "Play As Amy"
-cheat13_code = "31D25EA9+6D90"
+cheat13_code = "33005084+0003"
 cheat13_enable = false 
 


### PR DESCRIPTION
Replaced codes for Sonic Advance (World) with their decrypted equivalents.

This makes the .cht file a little smaller than if the encryption line were added to each code group.