### PR TITLE
Updated NES 2.0 header dat to current

### DIFF
--- a/metadat/headered/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/headered/Nintendo - Nintendo Entertainment System.dat
@@ -2,11 +2,11 @@ clrmamepro (
 	name "Nintendo - Nintendo Entertainment System"
 	description "Nintendo - Nintendo Entertainment System [NES 2.0 Headered]"
 	category "Standard DatFile"
-	version 20200727-154945
-	date 2020-07-29
+	version 20200917-053714
+	date 2020-09-30
 	author KickMeElmo
 	url https://forums.nesdev.com/viewtopic.php?f=3&t=19940
-	comment "Headers are from the 2020-07-26 database release."
+	comment "Headers are from the 2020-09-27 database release."
 )
 
 game (
@@ -106,9 +106,9 @@ game (
 )
 
 game (
-	name "3D Block (Asia) (Ja) (Hwang Shinwei) (Unl)"
-	description "3D Block (Asia) (Ja) (Hwang Shinwei) (Unl)"
-	rom ( name "3D Block (Asia) (Ja) (Hwang Shinwei) (Unl).nes" size 32784 crc b3c40a69 md5 63941d5b99122b38751fd95c6c6a1fea sha1 b786ec636fe1fcb5905f07468b3a133c07a99a7b )
+	name "3D Block (Asia) (En) (Hwang Shinwei) (Unl)"
+	description "3D Block (Asia) (En) (Hwang Shinwei) (Unl)"
+	rom ( name "3D Block (Asia) (En) (Hwang Shinwei) (Unl).nes" size 33808 crc ecf7db42 md5 59188d0c9a1848d200be515d1addc4c2 sha1 fbdc756b792621676f072d32634ee64f1d8878be )
 )
 
 game (
@@ -850,9 +850,9 @@ game (
 )
 
 game (
-	name "Arkanoid (Japan)"
-	description "Arkanoid (Japan)"
-	rom ( name "Arkanoid (Japan).nes" size 49168 crc b52a3b7b md5 938bdfa998998d36acf2e2dd8fa737d7 sha1 d8c083039d7aa8b3525276bce0ee238ce4a3cf05 )
+	name "Arkanoid (Japan) (En)"
+	description "Arkanoid (Japan) (En)"
+	rom ( name "Arkanoid (Japan) (En).nes" size 49168 crc b52a3b7b md5 938bdfa998998d36acf2e2dd8fa737d7 sha1 d8c083039d7aa8b3525276bce0ee238ce4a3cf05 )
 )
 
 game (
@@ -862,15 +862,15 @@ game (
 )
 
 game (
-	name "Arkanoid II (Japan)"
-	description "Arkanoid II (Japan)"
-	rom ( name "Arkanoid II (Japan).nes" size 196624 crc 5bbb7c20 md5 505158927d6a4a03ec103ee08cfdebcf sha1 e352ddd87d911fea5f637c907aab744e11bb7142 )
+	name "Arkanoid II (Japan) (En)"
+	description "Arkanoid II (Japan) (En)"
+	rom ( name "Arkanoid II (Japan) (En).nes" size 196624 crc 5bbb7c20 md5 505158927d6a4a03ec103ee08cfdebcf sha1 e352ddd87d911fea5f637c907aab744e11bb7142 )
 )
 
 game (
-	name "Arkanoid II (Japan) (Beta)"
-	description "Arkanoid II (Japan) (Beta)"
-	rom ( name "Arkanoid II (Japan) (Beta).nes" size 196624 crc a82282ea md5 701044c35c19649311904ea9df146a6f sha1 b37794983e9376426e6eaa4536fac1a7efe24294 )
+	name "Arkanoid II (Japan) (En) (Beta)"
+	description "Arkanoid II (Japan) (En) (Beta)"
+	rom ( name "Arkanoid II (Japan) (En) (Beta).nes" size 196624 crc a82282ea md5 701044c35c19649311904ea9df146a6f sha1 b37794983e9376426e6eaa4536fac1a7efe24294 )
 )
 
 game (
@@ -889,6 +889,12 @@ game (
 	name "Artelius (Japan)"
 	description "Artelius (Japan)"
 	rom ( name "Artelius (Japan).nes" size 163856 crc 8470a23d md5 08551b017cffbc58d0213276a5d53ca2 sha1 d19c10e83b7eaf670259ae3064c7b889182f8bbd )
+)
+
+game (
+	name "Asder - 20 in 1 (USA) (Unl)"
+	description "Asder - 20 in 1 (USA) (Unl)"
+	rom ( name "Asder - 20 in 1 (USA) (Unl).nes" size 786448 crc c10724bd md5 418cdb73044fe80190337fce008e0c80 sha1 eca225f29b3a76f36b58a506e7ff4041aff9755f )
 )
 
 game (
@@ -1020,7 +1026,7 @@ game (
 game (
 	name "AV Hanafuda Club (Japan) (Unl)"
 	description "AV Hanafuda Club (Japan) (Unl)"
-	rom ( name "AV Hanafuda Club (Japan) (Unl).nes" size 98320 crc 4e97d920 md5 070f4c7e2bfda4c60e6fd40504f800ef sha1 09030d4ef7a1fb604dd535ef70310dc1f4b49a94 )
+	rom ( name "AV Hanafuda Club (Japan) (Unl).nes" size 98320 crc 169156a6 md5 73146982f30b05e707aee80978588ec3 sha1 a0b5c9b49275cb1fa32e6ae0e5720f9f6f1a9bf8 )
 )
 
 game (
@@ -1042,6 +1048,12 @@ game (
 )
 
 game (
+	name "AV Mahjong Club (Japan) (Alt) (Unl)"
+	description "AV Mahjong Club (Japan) (Alt) (Unl)"
+	rom ( name "AV Mahjong Club (Japan) (Alt) (Unl).nes" size 131088 crc 3c6bfb0d md5 8e775b20cf1787e145a4b95790473da9 sha1 8d80ce95cdecb9c3fd4f67c85185fa981356aec0 )
+)
+
+game (
 	name "AV Mahjong Club (Japan) (Unl)"
 	description "AV Mahjong Club (Japan) (Unl)"
 	rom ( name "AV Mahjong Club (Japan) (Unl).nes" size 131088 crc 714ddec0 md5 9ca2823ce2748301248ebea3606a67c8 sha1 9f784f0a8e505394cb1885e6f943f8d47a37e934 )
@@ -1050,7 +1062,7 @@ game (
 game (
 	name "AV Mei Shao Nv Zhan Shi (Asia) (Unl)"
 	description "AV Mei Shao Nv Zhan Shi (Asia) (Unl)"
-	rom ( name "AV Mei Shao Nv Zhan Shi (Asia) (Unl).nes" size 655376 crc 74009482 md5 1a49c6d8fb280e51f2a9cbdcadc7fb40 sha1 6a1a436bbaa61bf44d8387a9976ffa75552ff9c5 )
+	rom ( name "AV Mei Shao Nv Zhan Shi (Asia) (Unl).nes" size 655376 crc f5715c9c md5 4542a63377ac2be80082fd26bd8d9083 sha1 95ad69549bc3806f10d3df1991907f540c0dfcb4 )
 )
 
 game (
@@ -1062,19 +1074,19 @@ game (
 game (
 	name "AV Pachi-Slot (Japan) (Unl)"
 	description "AV Pachi-Slot (Japan) (Unl)"
-	rom ( name "AV Pachi-Slot (Japan) (Unl).nes" size 98320 crc 06b590b6 md5 d9b5ab02367ffa2a257ebce429557723 sha1 9c0ef5b8093b6fa210242c95c935cac2fc54cef4 )
+	rom ( name "AV Pachi-Slot (Japan) (Unl).nes" size 98320 crc 5eb31f30 md5 4ad2217023514ff809dbf6181e85afdd sha1 765b1a554661d6cf895344bb0c0b2c920b9f188f )
 )
 
 game (
 	name "AV Poker (Japan) (Unl)"
 	description "AV Poker (Japan) (Unl)"
-	rom ( name "AV Poker (Japan) (Unl).nes" size 98320 crc 83eafce5 md5 f058544292b26db848355778e6755309 sha1 20b9ed012de0e4ca934a80a9061df686eec54883 )
+	rom ( name "AV Poker (Japan) (Unl).nes" size 98320 crc ff94f406 md5 b797296fad700c6cc903a8c291e39d4a sha1 23784b11805110df0fd3e84fe7d65b7f2119f8dc )
 )
 
 game (
 	name "AV Soccer (Japan) (Unl)"
 	description "AV Soccer (Japan) (Unl)"
-	rom ( name "AV Soccer (Japan) (Unl).nes" size 98320 crc 46d53b5d md5 a83b7ea63c22676465a3df60f3c87bd5 sha1 e111cbac912ebddd1fc1aae8aedc6904b8f5b5c1 )
+	rom ( name "AV Soccer (Japan) (Unl).nes" size 98320 crc 1ed3b4db md5 8d97afcddae5c080e8d7fde192f68dfb sha1 4e02e45d548168cab576caad8a7423021922dcfb )
 )
 
 game (
@@ -1276,9 +1288,9 @@ game (
 )
 
 game (
-	name "Bao Xiao San Guo (Asia) (Unl)"
-	description "Bao Xiao San Guo (Asia) (Unl)"
-	rom ( name "Bao Xiao San Guo (Asia) (Unl).nes" size 1048592 crc 1566295d md5 2a743d128e2b65c2500569ff3e36e8ae sha1 849f840a73712512610d5b9c567ba408fa4be134 )
+	name "Bao Xiao San Guo (Asia) (Unl) [b]"
+	description "Bao Xiao San Guo (Asia) (Unl) [b]"
+	rom ( name "Bao Xiao San Guo (Asia) (Unl) [b].nes" size 1048592 crc 1566295d md5 2a743d128e2b65c2500569ff3e36e8ae sha1 849f840a73712512610d5b9c567ba408fa4be134 )
 )
 
 game (
@@ -2080,6 +2092,12 @@ game (
 )
 
 game (
+	name "Booky Man (Brazil) (CCE) (Unl)"
+	description "Booky Man (Brazil) (CCE) (Unl)"
+	rom ( name "Booky Man (Brazil) (CCE) (Unl).nes" size 24592 crc d8f11b78 md5 58e879f53d4211abcfa737e2d85eec12 sha1 2f91d7e68beff7251dc28f391b20e1ff8efd590f )
+)
+
+game (
 	name "Booky Man (Spain) (Gluk Video) (Unl)"
 	description "Booky Man (Spain) (Gluk Video) (Unl)"
 	rom ( name "Booky Man (Spain) (Gluk Video) (Unl).nes" size 24592 crc 3f209637 md5 a47bb22af8b03da8ae5c9e02f9950171 sha1 ecf30c05dc0ca32e779453c0cf876deac19260d5 )
@@ -2740,12 +2758,6 @@ game (
 )
 
 game (
-	name "Chik Bik Ji Jin - Saam Gwok Ji (Asia) (Ja) (Unl)"
-	description "Chik Bik Ji Jin - Saam Gwok Ji (Asia) (Ja) (Unl)"
-	rom ( name "Chik Bik Ji Jin - Saam Gwok Ji (Asia) (Ja) (Unl).nes" size 393232 crc 9b5c67ad md5 db5635abeb9b61e97d5e13816fcfeee3 sha1 699758d9eb4b261fb2ce0287492e31673d330c47 )
-)
-
-game (
 	name "Chiki Chiki Machine Mou Race (Japan)"
 	description "Chiki Chiki Machine Mou Race (Japan)"
 	rom ( name "Chiki Chiki Machine Mou Race (Japan).nes" size 262160 crc 9b169c20 md5 c0c6a4cd71a351bd76ea882ddb659592 sha1 6ded8d1176391b145868dde80359b396eb853378 )
@@ -2929,12 +2941,6 @@ game (
 	name "Chuugoku Senseijutsu (Japan)"
 	description "Chuugoku Senseijutsu (Japan)"
 	rom ( name "Chuugoku Senseijutsu (Japan).nes" size 131088 crc 5282b9ad md5 2378cecd004c7491a07066ae777cf80d sha1 f9300f12a57f328532834d625d595810fb01c9e4 )
-)
-
-game (
-	name "Chuugoku Taitei (Asia) (Ja) (Unl)"
-	description "Chuugoku Taitei (Asia) (Ja) (Unl)"
-	rom ( name "Chuugoku Taitei (Asia) (Ja) (Unl).nes" size 393232 crc 9b9d2dd2 md5 7f058105bfc7d6b5a563b23d1f9075fa sha1 c383b2ae85363d2157d843d4454f90854c05e05e )
 )
 
 game (
@@ -3406,9 +3412,9 @@ game (
 )
 
 game (
-	name "Dao Shuai (Asia) (Ja) (Unl)"
-	description "Dao Shuai (Asia) (Ja) (Unl)"
-	rom ( name "Dao Shuai (Asia) (Ja) (Unl).nes" size 65552 crc c4baccc3 md5 14866432d82abbc4462997bca8bf5fef sha1 e4debafb878d1826f38ee2575a5d4b8adcc760a6 )
+	name "Dao Shuai (Asia) (Unl)"
+	description "Dao Shuai (Asia) (Unl)"
+	rom ( name "Dao Shuai (Asia) (Unl).nes" size 65552 crc c4baccc3 md5 14866432d82abbc4462997bca8bf5fef sha1 e4debafb878d1826f38ee2575a5d4b8adcc760a6 )
 )
 
 game (
@@ -3700,6 +3706,12 @@ game (
 )
 
 game (
+	name "Destroyer (Asia) (En) (Mega Soft) (Unl)"
+	description "Destroyer (Asia) (En) (Mega Soft) (Unl)"
+	rom ( name "Destroyer (Asia) (En) (Mega Soft) (Unl).nes" size 65552 crc d9362123 md5 cca4f87a891a5e838304169f530381b6 sha1 064fabd6f01b47d91d50846e89d27d08cc13f972 )
+)
+
+game (
 	name "Destructor, El (Spain) (Gluk Video) (Unl)"
 	description "Destructor, El (Spain) (Gluk Video) (Unl)"
 	rom ( name "Destructor, El (Spain) (Gluk Video) (Unl).nes" size 65552 crc 9dbbc7a6 md5 3f6186cdbb280be892d4c05061fcd988 sha1 267a2acaccf450ef7e2e79dba3f56a79147aad69 )
@@ -3892,9 +3904,9 @@ game (
 )
 
 game (
-	name "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl)"
-	description "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl)"
-	rom ( name "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl).nes" size 65552 crc ea6094b3 md5 b89363f312a9e793001f583f2bf700d3 sha1 59c855b2380bc2ff3d60f1ee9818644342fb37ba )
+	name "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl) [b]"
+	description "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl) [b]"
+	rom ( name "Dong Dong Nao II - Guo Zhong Ying Wen (Yi) (Asia) (Ja) (Unl) [b].nes" size 65552 crc ea6094b3 md5 b89363f312a9e793001f583f2bf700d3 sha1 59c855b2380bc2ff3d60f1ee9818644342fb37ba )
 )
 
 game (
@@ -3922,9 +3934,9 @@ game (
 )
 
 game (
-	name "Donkey Kong - Original Edition (USA) (3DS Virtual Console)"
-	description "Donkey Kong - Original Edition (USA) (3DS Virtual Console)"
-	rom ( name "Donkey Kong - Original Edition (USA) (3DS Virtual Console).nes" size 65552 crc 88a78bd9 md5 00894f05b4fa407dccac4822c4c9cbbc sha1 a71d1ca35920c9630daf4b946bcf02f93ea592cc )
+	name "Donkey Kong - Original Edition (USA) (Virtual Console)"
+	description "Donkey Kong - Original Edition (USA) (Virtual Console)"
+	rom ( name "Donkey Kong - Original Edition (USA) (Virtual Console).nes" size 65552 crc 88a78bd9 md5 00894f05b4fa407dccac4822c4c9cbbc sha1 a71d1ca35920c9630daf4b946bcf02f93ea592cc )
 )
 
 game (
@@ -4498,12 +4510,6 @@ game (
 )
 
 game (
-	name "Duck (Asia) (En) (Rev 1) (Unl)"
-	description "Duck (Asia) (En) (Rev 1) (Unl)"
-	rom ( name "Duck (Asia) (En) (Rev 1) (Unl).nes" size 40976 crc 775a757e md5 1099e01539f70ceeff90bf47208dd922 sha1 dc25a0c5891eab2f254715972fba7162076b480a )
-)
-
-game (
 	name "Duck (Asia) (En) (Unl)"
 	description "Duck (Asia) (En) (Unl)"
 	rom ( name "Duck (Asia) (En) (Unl).nes" size 40976 crc 2cc9dcab md5 97a591662d9de01a01853c7868c4dade sha1 0e100c953a6e09e95ffcf4364fc7673d749e79a7 )
@@ -4630,9 +4636,9 @@ game (
 )
 
 game (
-	name "Dynamite Bowl (Japan) (Rev A)"
-	description "Dynamite Bowl (Japan) (Rev A)"
-	rom ( name "Dynamite Bowl (Japan) (Rev A).nes" size 65552 crc 69aee567 md5 f5ce0475316fcecca92442bfbfa3aa79 sha1 ccb628a366e68a61fd26112c762554a8263f69b3 )
+	name "Dynamite Bowl (Japan) (Rev 1)"
+	description "Dynamite Bowl (Japan) (Rev 1)"
+	rom ( name "Dynamite Bowl (Japan) (Rev 1).nes" size 65552 crc 69aee567 md5 f5ce0475316fcecca92442bfbfa3aa79 sha1 ccb628a366e68a61fd26112c762554a8263f69b3 )
 )
 
 game (
@@ -5026,6 +5032,12 @@ game (
 )
 
 game (
+	name "Family BASIC (Japan)"
+	description "Family BASIC (Japan)"
+	rom ( name "Family BASIC (Japan).nes" size 40976 crc 30b1840a md5 0c3fc3d2971ba12a86633ddea7bfbc76 sha1 7e923cc0c8316e14011f5d2e031816f48814159b )
+)
+
+game (
 	name "Family BASIC (Japan) (Rev 1)"
 	description "Family BASIC (Japan) (Rev 1)"
 	rom ( name "Family BASIC (Japan) (Rev 1).nes" size 40976 crc 300a6746 md5 7d66309f4de33d4c9db34a61eac5f67e sha1 b78716c63ddbaa785ee2d45c16e58d23d3da5300 )
@@ -5038,15 +5050,9 @@ game (
 )
 
 game (
-	name "Family BASIC (Japan) (v1.0)"
-	description "Family BASIC (Japan) (v1.0)"
-	rom ( name "Family BASIC (Japan) (v1.0).nes" size 40976 crc 30b1840a md5 0c3fc3d2971ba12a86633ddea7bfbc76 sha1 7e923cc0c8316e14011f5d2e031816f48814159b )
-)
-
-game (
-	name "Family BASIC (Japan) (v3.0)"
-	description "Family BASIC (Japan) (v3.0)"
-	rom ( name "Family BASIC (Japan) (v3.0).nes" size 40976 crc 6ba08175 md5 0cc06af39cb084885c34233b1b93b975 sha1 04a2ad94ff02aab2135557c70900071eff41be82 )
+	name "Family BASIC V3 (Japan)"
+	description "Family BASIC V3 (Japan)"
+	rom ( name "Family BASIC V3 (Japan).nes" size 40976 crc 6ba08175 md5 0cc06af39cb084885c34233b1b93b975 sha1 04a2ad94ff02aab2135557c70900071eff41be82 )
 )
 
 game (
@@ -6022,21 +6028,21 @@ game (
 )
 
 game (
-	name "Garfield no Isshukan (Japan)"
-	description "Garfield no Isshukan (Japan)"
-	rom ( name "Garfield no Isshukan (Japan).nes" size 163856 crc 9d9a3f5e md5 58ae3379c06a85e47f1f8e347b086a19 sha1 8ec3c42e0b788eb7f3e1b1d0e6b3495a6a92a05d )
+	name "Garfield no Isshukan (Japan) (En)"
+	description "Garfield no Isshukan (Japan) (En)"
+	rom ( name "Garfield no Isshukan (Japan) (En).nes" size 163856 crc 9d9a3f5e md5 58ae3379c06a85e47f1f8e347b086a19 sha1 8ec3c42e0b788eb7f3e1b1d0e6b3495a6a92a05d )
 )
 
 game (
-	name "Garfield no Isshukan (Japan) (Beta 1)"
-	description "Garfield no Isshukan (Japan) (Beta 1)"
-	rom ( name "Garfield no Isshukan (Japan) (Beta 1).nes" size 163856 crc d87510ff md5 cdc610fb776fc9b8df2b4b275185ffdb sha1 6e463d03c84d71e1e6859936e03ad1fa7f33a02a )
+	name "Garfield no Isshukan (Japan) (En) (Beta 1)"
+	description "Garfield no Isshukan (Japan) (En) (Beta 1)"
+	rom ( name "Garfield no Isshukan (Japan) (En) (Beta 1).nes" size 163856 crc d87510ff md5 cdc610fb776fc9b8df2b4b275185ffdb sha1 6e463d03c84d71e1e6859936e03ad1fa7f33a02a )
 )
 
 game (
-	name "Garfield no Isshukan (Japan) (Beta 2)"
-	description "Garfield no Isshukan (Japan) (Beta 2)"
-	rom ( name "Garfield no Isshukan (Japan) (Beta 2).nes" size 163856 crc d212a727 md5 9d6cc3e42177f98318f66b01c1efa144 sha1 411307f987aca77d70dae5a6aa386e32eadfb92a )
+	name "Garfield no Isshukan (Japan) (En) (Beta 2)"
+	description "Garfield no Isshukan (Japan) (En) (Beta 2)"
+	rom ( name "Garfield no Isshukan (Japan) (En) (Beta 2).nes" size 163856 crc d212a727 md5 9d6cc3e42177f98318f66b01c1efa144 sha1 411307f987aca77d70dae5a6aa386e32eadfb92a )
 )
 
 game (
@@ -6726,7 +6732,7 @@ game (
 game (
 	name "Hanafuda Yuukyou Den - Nagarebana Oryuu (Japan) (Unl)"
 	description "Hanafuda Yuukyou Den - Nagarebana Oryuu (Japan) (Unl)"
-	rom ( name "Hanafuda Yuukyou Den - Nagarebana Oryuu (Japan) (Unl).nes" size 65552 crc 16139882 md5 fb369c0f5cbac51098c25c48ce5085f1 sha1 f8d784bfdfa470d9a9a47bba4275d6cad2199dc3 )
+	rom ( name "Hanafuda Yuukyou Den - Nagarebana Oryuu (Japan) (Unl).nes" size 98320 crc bba0a39a md5 5b0bd90d58ea52d508b9e9246357ee0b sha1 0bb14c4ee14e2cf63d3327bc476376746be24081 )
 )
 
 game (
@@ -7356,7 +7362,7 @@ game (
 game (
 	name "Idemitsu - Space College - Kikenbutsu no Yasashii Butsuri to Kagaku (Japan)"
 	description "Idemitsu - Space College - Kikenbutsu no Yasashii Butsuri to Kagaku (Japan)"
-	rom ( name "Idemitsu - Space College - Kikenbutsu no Yasashii Butsuri to Kagaku (Japan).nes" size 917520 crc deb090aa md5 0d967da483f0f7f720e14eef46a04538 sha1 6722a18f0529c61224f667defadca7273bc5be3f )
+	rom ( name "Idemitsu - Space College - Kikenbutsu no Yasashii Butsuri to Kagaku (Japan).nes" size 786448 crc 5c081bd0 md5 6c31f0ba9e421bbfdd089782a020db89 sha1 e80fe8cc51ef69d7a7431d4fcd1e4b0c203246a4 )
 )
 
 game (
@@ -7368,7 +7374,7 @@ game (
 game (
 	name "Idol Shisen Mahjong (Japan) (Unl)"
 	description "Idol Shisen Mahjong (Japan) (Unl)"
-	rom ( name "Idol Shisen Mahjong (Japan) (Unl).nes" size 98320 crc 850e995d md5 53ade0f37e2611893c032b3b97c1ea3a sha1 1acc5910810d7eb7ee2a649bf77cd961b8330d8b )
+	rom ( name "Idol Shisen Mahjong (Japan) (Unl).nes" size 98320 crc dd0816db md5 ed87f0babe9288feb7d55972e727b447 sha1 cdf5b77a630edfc84e06626242c9e8fce1b7e493 )
 )
 
 game (
@@ -7510,9 +7516,9 @@ game (
 )
 
 game (
-	name "Incantation (Asia) (Ja) (Unl)"
-	description "Incantation (Asia) (Ja) (Unl)"
-	rom ( name "Incantation (Asia) (Ja) (Unl).nes" size 65552 crc acf4c9cf md5 2b4e831a6a26e700b7c14052e9c889af sha1 76375195b7a133cb55b40b882419f191134b4e42 )
+	name "Incantation (Asia) (Unl) [b]"
+	description "Incantation (Asia) (Unl) [b]"
+	rom ( name "Incantation (Asia) (Unl) [b].nes" size 65552 crc acf4c9cf md5 2b4e831a6a26e700b7c14052e9c889af sha1 76375195b7a133cb55b40b882419f191134b4e42 )
 )
 
 game (
@@ -7984,9 +7990,9 @@ game (
 )
 
 game (
-	name "Jurassic Park (Europe)"
-	description "Jurassic Park (Europe)"
-	rom ( name "Jurassic Park (Europe).nes" size 262160 crc bc088578 md5 e57bb2d67c8963156c9af5d662cc4293 sha1 126c06263ef9ef08c086dba0813b44dd4418a248 )
+	name "Jurassic Park (Europe) (En,Fr,De,Es)"
+	description "Jurassic Park (Europe) (En,Fr,De,Es)"
+	rom ( name "Jurassic Park (Europe) (En,Fr,De,Es).nes" size 262160 crc bc088578 md5 e57bb2d67c8963156c9af5d662cc4293 sha1 126c06263ef9ef08c086dba0813b44dd4418a248 )
 )
 
 game (
@@ -9013,12 +9019,6 @@ game (
 	name "Lion King, The (Europe)"
 	description "Lion King, The (Europe)"
 	rom ( name "Lion King, The (Europe).nes" size 262160 crc a51e7199 md5 bba9201f1091f35b4fb0b6b4ec574bef sha1 19bc003ddc1edae9fda036468cab21ac0012bc5d )
-)
-
-game (
-	name "Lipple Island (Japan)"
-	description "Lipple Island (Japan)"
-	rom ( name "Lipple Island (Japan).nes" size 131088 crc f416286d md5 dd7268d00e002096a4eb8675865999ee sha1 1b4a5e3983bb40bb91bf7ff1284e3e8c318a7e87 )
 )
 
 game (
@@ -11232,19 +11232,19 @@ game (
 game (
 	name "NHK Gakuen - Space School - Sansu 5 Nen (Jou) (Japan)"
 	description "NHK Gakuen - Space School - Sansu 5 Nen (Jou) (Japan)"
-	rom ( name "NHK Gakuen - Space School - Sansu 5 Nen (Jou) (Japan).nes" size 917520 crc ad5bb8e0 md5 f63e92c5f59e5bd9003c289900c8b843 sha1 800a70b6eb534113fd5d293db3ac6441b42d255b )
+	rom ( name "NHK Gakuen - Space School - Sansu 5 Nen (Jou) (Japan).nes" size 786448 crc 883ef237 md5 a853f0ca8995af0db0a40660cfda7a50 sha1 5bd4019d518a1a05849e91fef6ea356f8279b154 )
 )
 
 game (
 	name "NHK Gakuen - Space School - Sansu 6 Nen (Ge) (Japan)"
 	description "NHK Gakuen - Space School - Sansu 6 Nen (Ge) (Japan)"
-	rom ( name "NHK Gakuen - Space School - Sansu 6 Nen (Ge) (Japan).nes" size 917520 crc 372427cc md5 194e916525f55977b1b7d6920e3d9197 sha1 2b1370d5285d6e1eb5202ebbf87f725ff3df75a9 )
+	rom ( name "NHK Gakuen - Space School - Sansu 6 Nen (Ge) (Japan).nes" size 786448 crc 063e957b md5 7443ee43d75331c859c54c88860ae879 sha1 d413ad1c9ffe06e0f30db7dae8b558adecc89213 )
 )
 
 game (
 	name "NHK Gakuen - Space School - Sansu 6 Nen (Jou) (Japan)"
 	description "NHK Gakuen - Space School - Sansu 6 Nen (Jou) (Japan)"
-	rom ( name "NHK Gakuen - Space School - Sansu 6 Nen (Jou) (Japan).nes" size 917520 crc 5d05a448 md5 a378dd325daa302bab9f59a8bcf93a08 sha1 5dae78a7ea7f8c8770914fbbb7c8e8870de56764 )
+	rom ( name "NHK Gakuen - Space School - Sansu 6 Nen (Jou) (Japan).nes" size 786448 crc 2024bd58 md5 32a47880b88d2c85e70ace2bf6ba6317 sha1 7867b165f10b92f07a4cfec8066dd589a39ce219 )
 )
 
 game (
@@ -11548,9 +11548,9 @@ game (
 )
 
 game (
-	name "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev A)"
-	description "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev A)"
-	rom ( name "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev A).nes" size 786448 crc 7746d00b md5 a8615666779168b6d5fb57d6287f5550 sha1 7d8ca8290e6ce38e8d5a5a793fc1735d9b9fc615 )
+	name "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev 1)"
+	description "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev 1)"
+	rom ( name "Nobunaga no Yabou - Bushou Fuuun Roku (Japan) (Rev 1).nes" size 786448 crc 7746d00b md5 a8615666779168b6d5fb57d6287f5550 sha1 7d8ca8290e6ce38e8d5a5a793fc1735d9b9fc615 )
 )
 
 game (
@@ -11896,9 +11896,9 @@ game (
 )
 
 game (
-	name "Pachio-kun 3 (Japan) (Rev A)"
-	description "Pachio-kun 3 (Japan) (Rev A)"
-	rom ( name "Pachio-kun 3 (Japan) (Rev A).nes" size 393232 crc 4424755a md5 e4f96912e6ed12f0d15ad4c7ade21384 sha1 82508cbaafd85abcbe08cb39f47e54687f509013 )
+	name "Pachio-kun 3 (Japan) (Rev 1)"
+	description "Pachio-kun 3 (Japan) (Rev 1)"
+	rom ( name "Pachio-kun 3 (Japan) (Rev 1).nes" size 393232 crc 4424755a md5 e4f96912e6ed12f0d15ad4c7ade21384 sha1 82508cbaafd85abcbe08cb39f47e54687f509013 )
 )
 
 game (
@@ -12184,15 +12184,9 @@ game (
 )
 
 game (
-	name "Pipe V (Asia) (Ja) (Unl)"
-	description "Pipe V (Asia) (Ja) (Unl)"
-	rom ( name "Pipe V (Asia) (Ja) (Unl).nes" size 81936 crc 5537cbe2 md5 88f13aeaf435f43357a7fc3d9e7c1a11 sha1 7d2ab3a30d1d9a3dd8164c6dc5116b3958aa8888 )
-)
-
-game (
-	name "Pipemania (Australia) (HES) (Unl)"
-	description "Pipemania (Australia) (HES) (Unl)"
-	rom ( name "Pipemania (Australia) (HES) (Unl).nes" size 49168 crc bd546cda md5 2916c4f741cc670bfac9e1f2e1ff2ad6 sha1 eab8b0ba77d7f8010fb0f9b4e1f37c7fdefde0fe )
+	name "Pipe V ~ Pipemania (Asia, Australia) (Unl)"
+	description "Pipe V ~ Pipemania (Asia, Australia) (Unl)"
+	rom ( name "Pipe V ~ Pipemania (Asia, Australia) (Unl).nes" size 49168 crc bd546cda md5 2916c4f741cc670bfac9e1f2e1ff2ad6 sha1 eab8b0ba77d7f8010fb0f9b4e1f37c7fdefde0fe )
 )
 
 game (
@@ -12262,21 +12256,9 @@ game (
 )
 
 game (
-	name "Poker III (Asia) (Ja) (Alt 1) (Unl)"
-	description "Poker III (Asia) (Ja) (Alt 1) (Unl)"
-	rom ( name "Poker III (Asia) (Ja) (Alt 1) (Unl).nes" size 131088 crc 2dbd9939 md5 05bc9fdb3d3fcd804b13a5316b1cf544 sha1 ce5cb194100ffb41f72da84713dc65a9f87a44b3 )
-)
-
-game (
-	name "Poker III (Asia) (Ja) (Alt 2) (Unl)"
-	description "Poker III (Asia) (Ja) (Alt 2) (Unl)"
-	rom ( name "Poker III (Asia) (Ja) (Alt 2) (Unl).nes" size 131088 crc 38755b3f md5 2e6e86b89dedd0a4d009cf409b8c35c4 sha1 74d4bd78d8eb6ac3f447ebdb43eef3bda55e2dd4 )
-)
-
-game (
 	name "Poker III (Asia) (Ja) (Unl)"
 	description "Poker III (Asia) (Ja) (Unl)"
-	rom ( name "Poker III (Asia) (Ja) (Unl).nes" size 131088 crc c111192e md5 baf0601bf95fbe2662e59a819e862f6a sha1 e91afe66b372d61add5e01861328d1458ba4cc0c )
+	rom ( name "Poker III (Asia) (Ja) (Unl).nes" size 131088 crc 38755b3f md5 2e6e86b89dedd0a4d009cf409b8c35c4 sha1 74d4bd78d8eb6ac3f447ebdb43eef3bda55e2dd4 )
 )
 
 game (
@@ -13066,6 +13048,12 @@ game (
 )
 
 game (
+	name "Ripple Island (Japan)"
+	description "Ripple Island (Japan)"
+	rom ( name "Ripple Island (Japan).nes" size 131088 crc f416286d md5 dd7268d00e002096a4eb8675865999ee sha1 1b4a5e3983bb40bb91bf7ff1284e3e8c318a7e87 )
+)
+
+game (
 	name "River City Ransom (USA)"
 	description "River City Ransom (USA)"
 	rom ( name "River City Ransom (USA).nes" size 262160 crc 527a65d6 md5 6ab1dde329ce81cb2ee24ff1f549bd7a sha1 50ddef044cbcdd681198697093858b82ef26bc8f )
@@ -13318,9 +13306,9 @@ game (
 )
 
 game (
-	name "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev A)"
-	description "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev A)"
-	rom ( name "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev A).nes" size 524304 crc 82e6b4a1 md5 2030a47d0a30ec0ccccbb24e0aa2a5ad sha1 e2013f52d8d1a68ddbe63bf39a39bfb31b110f27 )
+	name "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev 1)"
+	description "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev 1)"
+	rom ( name "Rockman 4 - Aratanaru Yabou!! (Japan) (Rev 1).nes" size 524304 crc 82e6b4a1 md5 2030a47d0a30ec0ccccbb24e0aa2a5ad sha1 e2013f52d8d1a68ddbe63bf39a39bfb31b110f27 )
 )
 
 game (
@@ -13651,6 +13639,12 @@ game (
 	name "Sanguo Chunqiu - Sichuan Sheng (Asia) (Unl)"
 	description "Sanguo Chunqiu - Sichuan Sheng (Asia) (Unl)"
 	rom ( name "Sanguo Chunqiu - Sichuan Sheng (Asia) (Unl).nes" size 262160 crc 306e1fc9 md5 10dceebdcaa857ff788a572d4a531043 sha1 8790bcd0b7cb4e778eb17e93e2da528bb9b18fc5 )
+)
+
+game (
+	name "Sanguozhi - Chibi zhi Zhan (Asia) (Unl)"
+	description "Sanguozhi - Chibi zhi Zhan (Asia) (Unl)"
+	rom ( name "Sanguozhi - Chibi zhi Zhan (Asia) (Unl).nes" size 393232 crc 9b5c67ad md5 db5635abeb9b61e97d5e13816fcfeee3 sha1 699758d9eb4b261fb2ce0287492e31673d330c47 )
 )
 
 game (
@@ -14008,12 +14002,6 @@ game (
 )
 
 game (
-	name "Shaffle Fight (Japan)"
-	description "Shaffle Fight (Japan)"
-	rom ( name "Shaffle Fight (Japan).nes" size 262160 crc b5799771 md5 d508799719262a54a039aa1431f036da sha1 b7217fd5d570afec12d3e46855537444c98935b1 )
-)
-
-game (
 	name "Shang Gu Shen Jian (Asia) (Unl)"
 	description "Shang Gu Shen Jian (Asia) (Unl)"
 	rom ( name "Shang Gu Shen Jian (Asia) (Unl).nes" size 1048592 crc 36a5c8b2 md5 bc28f885639626c8698c8da20c3572d3 sha1 3569f35e7b3531087e57767da8b7661d23b1680b )
@@ -14191,6 +14179,12 @@ game (
 	name "Shuang Ying (Asia) (Ja) (Unl)"
 	description "Shuang Ying (Asia) (Ja) (Unl)"
 	rom ( name "Shuang Ying (Asia) (Ja) (Unl).nes" size 65552 crc 715963e9 md5 36f0c2862cb6798b9abe835ba8e505b6 sha1 6c6c0a6a5c91c5fb4eb6ed19ce9f9bf9e24829a8 )
+)
+
+game (
+	name "Shuffle Fight (Japan)"
+	description "Shuffle Fight (Japan)"
+	rom ( name "Shuffle Fight (Japan).nes" size 262160 crc b5799771 md5 d508799719262a54a039aa1431f036da sha1 b7217fd5d570afec12d3e46855537444c98935b1 )
 )
 
 game (
@@ -14425,6 +14419,12 @@ game (
 	name "Sky Shark (USA)"
 	description "Sky Shark (USA)"
 	rom ( name "Sky Shark (USA).nes" size 196624 crc 2fcd317d md5 57de95ec806465def894b6684a40d8fe sha1 28beae2e27019dd6ea2de2f1b02e9e49f216481a )
+)
+
+game (
+	name "Sky Shark (USA) (Rev 1)"
+	description "Sky Shark (USA) (Rev 1)"
+	rom ( name "Sky Shark (USA) (Rev 1).nes" size 262160 crc b66e897c md5 f089d6095b92969b738f71200ee7680b sha1 21a47445f02155064ad7f1d5ced3fee74bcb09e0 )
 )
 
 game (
@@ -15604,9 +15604,9 @@ game (
 )
 
 game (
-	name "Super Sprint (Japan)"
-	description "Super Sprint (Japan)"
-	rom ( name "Super Sprint (Japan).nes" size 131088 crc 05310638 md5 3b52e6f86be29a3b9116b3dc018e591a sha1 e24b17114dcf725436eb307a6349b460b11d36b2 )
+	name "Super Sprint (Japan) (En)"
+	description "Super Sprint (Japan) (En)"
+	rom ( name "Super Sprint (Japan) (En).nes" size 131088 crc 05310638 md5 3b52e6f86be29a3b9116b3dc018e591a sha1 e24b17114dcf725436eb307a6349b460b11d36b2 )
 )
 
 game (
@@ -15751,12 +15751,6 @@ game (
 	name "Swords and Serpents (USA)"
 	description "Swords and Serpents (USA)"
 	rom ( name "Swords and Serpents (USA).nes" size 131088 crc 787f666d md5 74f825ddd8f85535f267916598c0d1e9 sha1 a740b2ccd11e25ee4ca69fc3063b129bc075f0ad )
-)
-
-game (
-	name "Taan Hak Fung Wan - King Tank (Asia) (Unl)"
-	description "Taan Hak Fung Wan - King Tank (Asia) (Unl)"
-	rom ( name "Taan Hak Fung Wan - King Tank (Asia) (Unl).nes" size 65552 crc 23ed2d06 md5 3d240c076a673383b35d5742ca370fe2 sha1 e7e35fca561dbea44b006617feab2d68dd1b0c75 )
 )
 
 game (
@@ -15949,6 +15943,12 @@ game (
 	name "Tank (Asia) (En) (Caltron) (Unl)"
 	description "Tank (Asia) (En) (Caltron) (Unl)"
 	rom ( name "Tank (Asia) (En) (Caltron) (Unl).nes" size 40976 crc 5a170584 md5 46048764f355e0b12a3a55483ae89cf5 sha1 d476aeca38bf43bce325233a617177ace321250f )
+)
+
+game (
+	name "Tank Fengyun - King Tank (Asia) (Unl)"
+	description "Tank Fengyun - King Tank (Asia) (Unl)"
+	rom ( name "Tank Fengyun - King Tank (Asia) (Unl).nes" size 65552 crc 23ed2d06 md5 3d240c076a673383b35d5742ca370fe2 sha1 e7e35fca561dbea44b006617feab2d68dd1b0c75 )
 )
 
 game (
@@ -16246,9 +16246,9 @@ game (
 )
 
 game (
-	name "Tenchi o Kurau (Japan) (Rev A)"
-	description "Tenchi o Kurau (Japan) (Rev A)"
-	rom ( name "Tenchi o Kurau (Japan) (Rev A).nes" size 262160 crc 2ce2e0e3 md5 9a555abc2a68c1e3bdcbf2493d5e4341 sha1 a2da4abdd24344a23901eff294cacd054bc791fe )
+	name "Tenchi o Kurau (Japan) (Rev 1)"
+	description "Tenchi o Kurau (Japan) (Rev 1)"
+	rom ( name "Tenchi o Kurau (Japan) (Rev 1).nes" size 262160 crc 2ce2e0e3 md5 9a555abc2a68c1e3bdcbf2493d5e4341 sha1 a2da4abdd24344a23901eff294cacd054bc791fe )
 )
 
 game (
@@ -16258,9 +16258,9 @@ game (
 )
 
 game (
-	name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev A)"
-	description "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev A)"
-	rom ( name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev A).nes" size 524304 crc a109b36a md5 4f3ffea5867c5fade8f94636346c48e0 sha1 ffdcd0d879bd963c5c26eb04bc78a4996f026329 )
+	name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev 1)"
+	description "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev 1)"
+	rom ( name "Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev 1).nes" size 524304 crc a109b36a md5 4f3ffea5867c5fade8f94636346c48e0 sha1 ffdcd0d879bd963c5c26eb04bc78a4996f026329 )
 )
 
 game (
@@ -16882,9 +16882,9 @@ game (
 )
 
 game (
-	name "Track & Field II (USA) (Rev A)"
-	description "Track & Field II (USA) (Rev A)"
-	rom ( name "Track & Field II (USA) (Rev A).nes" size 262160 crc ea54134c md5 64d32ba5d859f905edf7ed19eea9bef5 sha1 6aedae6f403869266ef0031257ef6894f389444a )
+	name "Track & Field II (USA) (Rev 1)"
+	description "Track & Field II (USA) (Rev 1)"
+	rom ( name "Track & Field II (USA) (Rev 1).nes" size 262160 crc ea54134c md5 64d32ba5d859f905edf7ed19eea9bef5 sha1 6aedae6f403869266ef0031257ef6894f389444a )
 )
 
 game (
@@ -17028,13 +17028,13 @@ game (
 game (
 	name "U-Force Power Games (USA) (Proto 1)"
 	description "U-Force Power Games (USA) (Proto 1)"
-	rom ( name "U-Force Power Games (USA) (Proto 1).nes" size 65552 crc d8a1d742 md5 094f0d486c9a98b822de69069cfe22f3 sha1 c21e60fc0073ae063c4ba74e4205ca943d3608c4 )
+	rom ( name "U-Force Power Games (USA) (Proto 1).nes" size 65552 crc 20934e75 md5 dbde8cc447e7e730d6741f49168981bd sha1 fc21753034c7504507c60d08e3dc2e5a5eb8a287 )
 )
 
 game (
 	name "U-Force Power Games (USA) (Proto 2) [b]"
 	description "U-Force Power Games (USA) (Proto 2) [b]"
-	rom ( name "U-Force Power Games (USA) (Proto 2) [b].nes" size 65552 crc b56e91c8 md5 04eb3e6013c24d79aabeaa7752407e9c sha1 8bc5fd74b81042726dbf327799852f89278c1515 )
+	rom ( name "U-Force Power Games (USA) (Proto 2) [b].nes" size 65552 crc 4d5c08ff md5 e3a2114d060411769c2d95ddcf58dcf8 sha1 32f25390a2d68ac982fced245ce83568b60dc693 )
 )
 
 game (
@@ -17308,15 +17308,15 @@ game (
 )
 
 game (
-	name "Venice Beach Volleyball (Asia) (Ja) (Idea-Tek) (Unl)"
-	description "Venice Beach Volleyball (Asia) (Ja) (Idea-Tek) (Unl)"
-	rom ( name "Venice Beach Volleyball (Asia) (Ja) (Idea-Tek) (Unl).nes" size 65552 crc 4016358f md5 6fbfc375237dee2a4c989f52512d9e05 sha1 8857fc455f7d1a9b9f58c94c91138016d379cbd3 )
+	name "Venice Beach Volleyball (Asia) (En) (Idea-Tek) (Unl)"
+	description "Venice Beach Volleyball (Asia) (En) (Idea-Tek) (Unl)"
+	rom ( name "Venice Beach Volleyball (Asia) (En) (Idea-Tek) (Unl).nes" size 65552 crc 4016358f md5 6fbfc375237dee2a4c989f52512d9e05 sha1 8857fc455f7d1a9b9f58c94c91138016d379cbd3 )
 )
 
 game (
-	name "Venice Beach Volleyball (Asia) (Ja) (Super Mega) (Unl)"
-	description "Venice Beach Volleyball (Asia) (Ja) (Super Mega) (Unl)"
-	rom ( name "Venice Beach Volleyball (Asia) (Ja) (Super Mega) (Unl).nes" size 65552 crc 3e3e4eca md5 e0553da29515a2ef622ea3e52d2a12c1 sha1 a8f851301ed3f102a87e579ad246a3907b401574 )
+	name "Venice Beach Volleyball (Asia) (En) (Super Mega) (Unl) [b]"
+	description "Venice Beach Volleyball (Asia) (En) (Super Mega) (Unl) [b]"
+	rom ( name "Venice Beach Volleyball (Asia) (En) (Super Mega) (Unl) [b].nes" size 65552 crc 3e3e4eca md5 e0553da29515a2ef622ea3e52d2a12c1 sha1 a8f851301ed3f102a87e579ad246a3907b401574 )
 )
 
 game (
@@ -17566,9 +17566,9 @@ game (
 )
 
 game (
-	name "Wei Lai Xiao Zi (Asia) (Ja) (Unl)"
-	description "Wei Lai Xiao Zi (Asia) (Ja) (Unl)"
-	rom ( name "Wei Lai Xiao Zi (Asia) (Ja) (Unl).nes" size 65552 crc ab914373 md5 67cfaec8c559193fe63271c42d1ac9e5 sha1 e6c75a8db2215c0f8cfd960d9d3ef4cd1850a9f9 )
+	name "Wei Lai Xiao Zi - Joy Van Kid (Asia) (En) (Unl)"
+	description "Wei Lai Xiao Zi - Joy Van Kid (Asia) (En) (Unl)"
+	rom ( name "Wei Lai Xiao Zi - Joy Van Kid (Asia) (En) (Unl).nes" size 65552 crc ab914373 md5 67cfaec8c559193fe63271c42d1ac9e5 sha1 e6c75a8db2215c0f8cfd960d9d3ef4cd1850a9f9 )
 )
 
 game (
@@ -18058,9 +18058,9 @@ game (
 )
 
 game (
-	name "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl)"
-	description "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl)"
-	rom ( name "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl).nes" size 262160 crc 4156e153 md5 f3774c8123b0a609e2796ed84c9a1afe sha1 464e776e4a6146cf9ac726850e3f9931b4df308b )
+	name "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl) (Pirate)"
+	description "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl) (Pirate)"
+	rom ( name "Ying Xiong Yuan Yi Jing Chuan Qi (Asia) (Unl) (Pirate).nes" size 262160 crc 4156e153 md5 f3774c8123b0a609e2796ed84c9a1afe sha1 464e776e4a6146cf9ac726850e3f9931b4df308b )
 )
 
 game (
@@ -18262,9 +18262,9 @@ game (
 )
 
 game (
-	name "Zhan Guo Si Chuan Sheng (Asia) (Nei-Hu) (Unl)"
-	description "Zhan Guo Si Chuan Sheng (Asia) (Nei-Hu) (Unl)"
-	rom ( name "Zhan Guo Si Chuan Sheng (Asia) (Nei-Hu) (Unl).nes" size 65552 crc 2eb951a6 md5 caa4bd4434a79cb90be669717be9eff1 sha1 287a110d32fa830dbf4e96afd094eb7c1ba40be6 )
+	name "Zhan Guo Si Chuan Sheng (Asia) (Idea-Tek) (Unl)"
+	description "Zhan Guo Si Chuan Sheng (Asia) (Idea-Tek) (Unl)"
+	rom ( name "Zhan Guo Si Chuan Sheng (Asia) (Idea-Tek) (Unl).nes" size 65552 crc 2eb951a6 md5 caa4bd4434a79cb90be669717be9eff1 sha1 287a110d32fa830dbf4e96afd094eb7c1ba40be6 )
 )
 
 game (
@@ -18289,6 +18289,12 @@ game (
 	name "Zhong Guo Xiang Qi - Chinese Chese (Asia) (Ja) (Unl)"
 	description "Zhong Guo Xiang Qi - Chinese Chese (Asia) (Ja) (Unl)"
 	rom ( name "Zhong Guo Xiang Qi - Chinese Chese (Asia) (Ja) (Unl).nes" size 40976 crc 900a3432 md5 be81ea76498a84ca90dee94a5a11d0e8 sha1 cca2950c9578203a1a109fe93751cd3bfa8cabf9 )
+)
+
+game (
+	name "Zhongguo Daheng (Asia) (Unl)"
+	description "Zhongguo Daheng (Asia) (Unl)"
+	rom ( name "Zhongguo Daheng (Asia) (Unl).nes" size 393232 crc 9b9d2dd2 md5 7f058105bfc7d6b5a563b23d1f9075fa sha1 c383b2ae85363d2157d843d4454f90854c05e05e )
 )
 
 game (


### PR DESCRIPTION
* Verified with latest No-Intro dat
* Headers fixed with current NES 2.0 database entries
* Kid Dracula .sav file manually removed

Same as last time (#1079). I intend to continue to submit these updates as the header database has new releases. None of the database content is from me, it's simply brought up to date with changes to no-intro's dat.