### PR TITLE
Update - MSX BIOS

### DIFF
--- a/dat/System.dat
+++ b/dat/System.dat
@@ -2,7 +2,7 @@ clrmamepro (
 	name "System"
 	description "System"
 	comment "System, firmware, or BIOS files used by libretro."
-	version "2020-09-14"
+	version "2020-10-12"
 	author "libretro"
 	homepage "http://github.com/libretro/libretro-database"
 	url "http://github.com/libretro/libretro-database"
@@ -73,8 +73,12 @@ game (
 	rom ( name grom.bin size 2048 crc 683a4158 md5 0cd5946c6473e42e8e4c2137785e427f sha1 f9608bb4ad1cfe3640d02844c7ad8e0bcd974917 )
 
 	comment "Microsoft - MSX"
+	rom ( name CARTS.SHA size 33152 crc d42f4444 md5 74b0f217fa0e2b8bb5a2f8e2ecc69da3 sha1 bf5fb954db868e523febccc68549ed9187961076 )
+	rom ( name CYRILLIC.FNT size 2048 crc 73af9bc3 md5 85b38e4128bbc300e675f55b278683a8 sha1 000ac11b702a4c42e40f135df12fa5f2f13e20a1 )
 	rom ( name DISK.ROM size 16384 crc 721f61df md5 80dcd1ad1a4cf65d64b7ba10504e8190 sha1 032cb1c1c75b9a191fa1230978971698d9d2a17f )
 	rom ( name FMPAC.ROM size 65536 crc 0e84505d md5 6f69cc8b5ed761b03afd78000dfb0e19 sha1 9d789166e3caf28e4742fe933d962e99618c633d )
+	rom ( name FMPAC16..ROM size 16384 crc 5d6c4d27 md5 af8537262df8df267072f359399a7635 sha1 2dc4517ebd5a061f9b5aa6b449cc4d4a2073540c )
+	rom ( name ITALIC.FNT size 2048 crc c90ec498 md5 c83e50e9f33b8dd893c414691822740d sha1 401dd6692dc80628e5f68b7c79be0b0ebbc4d3ee )
 	rom ( name KANJI.ROM size 131072 crc c9651b32 md5 febe8782b466d7c3b16de6d104826b34 sha1 84a645becec0a25d3ab7a909cde1b242699a8662 )
 	rom ( name MSX.ROM size 32768 crc 94ee12f3 md5 aa95aea2563cd5ec0a0919b44cc17d47 sha1 409e82adac40f6bdd18eb6c84e8b2fbdc7fb5498 )
 	rom ( name MSX2.ROM size 32768 crc 6cdaf3a5 md5 ec3a01c91f24fbddcbcab0ad301bc9ef sha1 6103b39f1e38d1aa2d84b1c3219c44f1abb5436e )
@@ -83,6 +87,7 @@ game (
 	rom ( name MSX2PEXT.ROM size 16384 crc b8ba44d3 md5 7c8243c71d8f143b2531f01afa6a05dc sha1 fe0254cbfc11405b79e7c86c7769bd6322b04995 )
 	rom ( name MSXDOS2.ROM size 65536 crc 1c430991 md5 6418d091cd6907bbcf940324339e43bb sha1 c36c9e0f96738a340381e23b4f97245388801a46 )
 	rom ( name PAINTER.ROM size 65536 crc 1bda68a3 md5 403cdea1cbd2bb24fae506941f8f655e sha1 7fd2a28c4fdaeb140f3c8c8fb90271b1472c97b9 )
+	rom ( name RS232.ROM size 16640 crc ab6874f8 md5 279efd1eae0d358eecd4edc7d9adedf3 sha1 7aec0134ad6a5177f4056fcb6047083e8e00529b )
 
 	comment "NEC - PC Engine - TurboGrafx 16 - SuperGrafx"
 	rom ( name gecard.pce size 32768 crc 51a12d90 md5 6d2cb14fc3e1f65ceb135633d1694122 sha1 014881a959e045e00f4db8f52955200865d40280 )


### PR DESCRIPTION
Updated the MSX BIOS hashes:
The "CARTS.SHA" can be found in the fMSX 5.8 (the latest version at current time):  https://fms.komkon.org/fMSX/#Downloads