### PR TITLE
Update Nintendo - Super Nintendo Entertainment System.dat

### DIFF
--- a/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/hacks/Nintendo - Super Nintendo Entertainment System.dat
@@ -179,7 +179,7 @@ game (
     name "Hyper Metroid [Hack by RealRed]"
     description "Hyper Metroid by RealRed version (1.0)"
     homepage "http://metroidconstruction.com/hack.php?id=294"
-    rom ( name "Super Metroid (Japan, USA) (En,Ja).sfc" size 4194304 crc d4d38230 md5 6b3c722165b3c566eda465386b585b51 sha1 727f8763983753e014e706520bb958bb4752e8b7 )
+    rom ( name "Super Metroid (Japan, USA) (En,Ja).sfc" size 4194304 crc d4d38230 md5 51c91e0372d47207a325e8eca40e0587 sha1 d8a37ef21a73d6be0f8907090a33d96531358cc0 )
 )
 game (
     name "Mario & Luigi - Kola Kingdom Quest [Hack by Gamma V]"


### PR DESCRIPTION
The CRC32 is right, but the MD5 and SHA1 hashes for Hyper Metroid by RealRed version (1.0) are wrong.