### PR TITLE
Update - Arcade BIOS (fbneo, flycast)

### DIFF
--- a/dat/System.dat
+++ b/dat/System.dat
@@ -2,7 +2,7 @@ clrmamepro (
 	name "System"
 	description "System"
 	comment "System, firmware, or BIOS files used by libretro."
-	version "2020-10-13"
+	version "2020-11-02"
 	author "libretro"
 	homepage "http://github.com/libretro/libretro-database"
 	url "http://github.com/libretro/libretro-database"
@@ -27,8 +27,23 @@ game (
 	rom ( name panafz1j.bin size 1048576 crc d9493adc md5 a496cfdded3da562759be3561317b605 sha1 ec7ec62d60ec0459a14ed56ebc66761ef3c80efc )
 	rom ( name sanyotry.bin size 1048576 crc d5cbc509 md5 35fa1a1ebaaeea286dc5cd15487c13ea sha1 b01c53da256dde43ffec4ad3fc3adfa8d635e943 )
 
-	comment "Arcade (various)"
-	rom ( name neo-geo.rom size 131072 crc 9036d879 md5 2968f59f44bf328639aa79391aeeeab4 sha1 4f5ed7105b7128794654ce82b51723e16e389543 )
+	comment "Arcade"
+	rom ( name airlbios.zip size 715730 crc f83ec60f md5 7a11bfe0cc72886d032e386db68f890c sha1 f2a730530f4989ca0e8860aa4e455b6a5fe69e1d )
+	rom ( name awbios.zip size 42296 crc 67a14ad5 md5 85254fbe320ca82a768ec2c26bb08def sha1 7940c7bf29eee85a5b2fdec78750b19aa22895dc )
+	rom ( name bubsys.zip size 7950 crc 8fc2fd2e md5 f81298afd68a1a24a49a1a2d9f087964 sha1 1c0ffcd308b0c8c6dbb74ad8b811a0767200d366 )
+	rom ( name cchip.zip size 2700 crc 23debecb md5 df6f8a3d83c028a5cb9f2f2be60773f3 sha1 364f2302a145a0fd6de767d7f8484badde1d1a6e )
+	rom ( name decocass.zip size 16107 crc 5de524e5 md5 b7e1189b341bf6a8e270017c096d21b0 sha1 30b97b2670b79d0de41cba190324c504846c6fa1 )
+	rom ( name f355bios.zip size 1394278 crc 17516536 md5 547f3d12aed389058ca06148f1cca0ed sha1 b6ff66dcb5547bd91760d239ddf428a655631c53 )
+	rom ( name f355dlx.zip size 2328436 crc 23ac17be md5 1028615bcac4c31634a3364ce5c04044 sha1 48d1712d1b1cdfeeeb43c6287c17b0b6309cfaab )
+	rom ( name hod2bios.zip size 1479106 crc 0ddc6daf md5 f4011d3116500354edf7302a90402711 sha1 782c303cbdfab1027b04db74a63e27bdad5e0c53 )
+	rom ( name isgsm.zip size 10207 crc 26856bf9 md5 4a56d56e2219c5e2b006b66a4263c01c sha1 f590ccf688b4c05fa1da5c5dd92c224545170c3b )
+	rom ( name midssio.zip size 163 crc 7620bd32 md5 5904b0de768d1d506e766aa7e18994c1 sha1 54275c9833e497f71f76ab239030cc386c863991 )
+	rom ( name naomi.zip size 9321533 crc 6ee50181 md5 526eda1e2a7920c92c88178789d71d84 sha1 c96711c01c0158f161791d6fbe75d88329e8ac0a )
+	rom ( name neogeo.zip size 1859335 crc 81315163 md5 00dad01abdbf8ea9e79ad2fe11bdb182 sha1 deb62b0074b8cae4f162c257662136733cfc76ad )
+	rom ( name nmk004.zip size 3556 crc a6099353 md5 bfacf1a68792d5348f93cf724d2f1dda sha1 489256f5e2001070d2ad94c90d255282c71ed274 )
+	rom ( name pgm.zip size 2094636 crc bf3dd2ef md5 87cc944eef4c671aa2629a8ba48a08e0 sha1 c0c001ec80fa860857000f4cfc9844a28498a355 )
+	rom ( name skns.zip size 924762 crc 5692af22 md5 3f956c4e7008804cb47cbde49bd5b908 sha1 4257bd14b541fafbd555cb98ba079a3416a45934 )
+	rom ( name ym2608.zip size 7609 crc 5b4c29c4 md5 79ae0d2bb1901b7e606b6dc339b79a97 sha1 06fc753d015b43ca1787f4cfd9331b1674202e64 )
 
 	comment "Atari - 400-800"
 	rom ( name ATARIBAS.ROM size 8192 crc 7d684184 md5 0bac0c6a50104045d902df4503a4c30b sha1 3693c9cb9bf3b41bae1150f7a8264992468fc8c0 )


### PR DESCRIPTION
Added BIOS needed to boot arcade games for flycast and fbneo core, also can be used for mame too.
Files are torrentzipped to keep hashes consistent.