### PR TITLE
Add "Enigma" code to Mega Man X5 cheats.

### DIFF
--- a/cht/Sony - PlayStation/Mega Man X5 (USA, Europe) (GameShark).cht
+++ b/cht/Sony - PlayStation/Mega Man X5 (USA, Europe) (GameShark).cht
@@ -1,4 +1,4 @@
-cheats = 69 
+cheats = 70
 
 cheat0_desc = "Normal Joker"
 cheat0_code = "D00C931C+????"
@@ -275,4 +275,8 @@ cheat67_enable = false
 cheat68_desc = "Kill Bosses In 1 Hit"
 cheat68_code = "D10920EC+0000+800920EC+0000"
 cheat68_enable = false 
+
+cheat69_desc = "Enigma Cannon Always Succeeds"
+cheat69_code = "80093F70+0000"
+cheat69_enable = false
 


### PR DESCRIPTION
The enigma cannon failing is one of the most annoying things about the game, and I must share this cheat.