### PR TITLE
Use `make install` on the Gitlab CI to set up

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,11 +7,7 @@ stages:
   variables:
     MEDIA_PATH: .media
   script:
-    - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}
-    - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/cursors
-    - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/rdb
-    - cp -R ./cursors/*.dbc ${MEDIA_PATH}/${CI_PROJECT_NAME}/cursors
-    - cp -R ./rdb/*.rdb ${MEDIA_PATH}/${CI_PROJECT_NAME}/rdb
+    - make INSTALLDIR=${MEDIA_PATH}/${CI_PROJECT_NAME} install
   artifacts:
     paths:
     - ${MEDIA_PATH}


### PR DESCRIPTION
Use the [Makefile](https://github.com/libretro/libretro-database/blob/master/Makefile) to set up libretro-database. Before the chts dir was missing. Using `make install` will include it.