### PR TITLE
Add support for Quake Episode 5: Dimension of the Past

### DIFF
--- a/dat/Quake.dat
+++ b/dat/Quake.dat
@@ -26,3 +26,9 @@ game (
 	description "Quake Mission Pack 2: Dissolution of Eternity"
 	rom ( name "PAK0.PAK" size 37875279 crc 38b70ce8 md5 c38a4e04219c317cd1b02f386bdfe11f sha1 78df8ce771d1bef5eb9da3d51c7628b11b4ae2c8 )
 )
+
+game (
+	name "Quake Episode 5: Dimension of the Past"
+	description "Quake Episode 5: Dimension of the Past"
+	rom ( name "PAK0.PAK" size 18556973 crc 8a68d267 md5 607a5d9f0fc778cad37889a093dc593e sha1 f519ae4935cf18a1f6fecb07b34f5cfbcdacc7fd )
+)


### PR DESCRIPTION
Episode 5: Dimension of the Past is a semi-official expansion released in 2016 for the 20th anniversary of the Quake series:

https://quake.fandom.com/wiki/Episode_5:_Dimension_of_the_Past

https://twitter.com/machinegames/status/746363189768650752

Quake 1 (TyrQuake) core has support for it:

https://docs.libretro.com/library/tyrquake/

But the title was not in libretro-database. This pull request adds Episode 5 to the Quake database.