### PR TITLE
Update Alien 3 (USA, Europe) (Action Replay).cht

### DIFF
--- a/cht/Sega - Mega Drive - Genesis/Alien 3 (USA, Europe) (Action Replay).cht
+++ b/cht/Sega - Mega Drive - Genesis/Alien 3 (USA, Europe) (Action Replay).cht
@@ -1,7 +1,7 @@
 cheats = 9 
 
 cheat0_desc = "Infinite Pulse Rifle Ammo"
-cheat0_code = "FF0844:99"
+cheat0_code = "FF0844:63"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
@@ -9,15 +9,15 @@ cheat1_code = "FF0866:60"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Fuel"
-cheat2_code = "FF0846:99"
+cheat2_code = "FF0846:63"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Grenades"
-cheat3_code = "FF0848:99"
+cheat3_code = "FF0848:63"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Hand Grenades"
-cheat4_code = "FF084A:99"
+cheat4_code = "FF084A:63"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Energy"


### PR DESCRIPTION
Change 99 to 63 hex. 99 results in 0 and weapon, granage ,flame is not usable. 63 shows visually the same as 99 but works and can shoot